### PR TITLE
Yecc better error message

### DIFF
--- a/lib/parsetools/include/yeccpre.hrl
+++ b/lib/parsetools/include/yeccpre.hrl
@@ -167,7 +167,7 @@ yecctoken2string({char,_,C}) -> io_lib:write_char(C);
 yecctoken2string({var,_,V}) -> io_lib:format("~s", [V]);
 yecctoken2string({string,_,S}) -> io_lib:write_unicode_string(S);
 yecctoken2string({reserved_symbol, _, A}) -> io_lib:write(A);
-yecctoken2string({_Cat, _, Val}) -> io_lib:write(Val);
+yecctoken2string({_Cat, _, Val}) -> io_lib:format("~p",[Val]);
 yecctoken2string({dot, _}) -> "'.'";
 yecctoken2string({'$end', _}) ->
     [];


### PR DESCRIPTION
There was an error in yecc - if you make your own token for example
{identifier,123,"fileHandle"} and there was a syntax error
format_error would make a horrible error message 
like  this:

error in line:123 of:? syntax error before: [102,105,108,101,72,97,110,100,108,101]

I changed the io_lib:write - to io_lib:format - and now we get

error in line: 123 of ? syntax error before: "fileHandle"

Cheers

/Joe

Which is much better 
