### PR TITLE
Fix a crash when closing an ssh client connection

### DIFF
--- a/lib/ssh/src/ssh_connection_manager.erl
+++ b/lib/ssh/src/ssh_connection_manager.erl
@@ -570,9 +570,12 @@ terminate(Reason, #state{connection_state =
 			 end, Requests)),
     Address =  proplists:get_value(address, Opts),
     Port = proplists:get_value(port, Opts),
-    SystemSup = ssh_system_sup:system_supervisor(Address, Port),
-    ssh_system_sup:stop_subsystem(SystemSup, SubSysSup),
-    ok.
+    case ssh_system_sup:system_supervisor(Address, Port) of
+        undefined -> ok;
+        SystemSup ->
+            ssh_system_sup:stop_subsystem(SystemSup, SubSysSup),
+            ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Func: code_change(OldVsn, State, Extra) -> {ok, NewState}


### PR DESCRIPTION
I have found an issue in ssh_connection_manager:terminate that causes crashes when you are using the ssh library for client operations. It appears that the problem is related to an attempt to shut down a supervisor that never gets started when using the ssh library solely for client operations. The error output is attached and the code below can be used to reproduce the issue.

```
=ERROR REPORT==== 15-Nov-2010::19:42:16 ===
** Generic server <0.47.0> terminating 
** Last message in was stop
** When Server state == {state,client,<0.2.0>,undefined,<0.50.0>,
                        {connection,[],16400,[],[],0,undefined,undefined,
                            undefined,undefined,undefined,undefined},
                        0,
                        [{address,"127.0.0.1"},
                         {port,22},
                         {role,client},
                         {channel_pid,<0.2.0>},
                         {socket_opts,[inet6]},
                         {ssh_opts,
                             [{host,"127.0.0.1"},
                              {password,"password"},
                              {user,"user"},
                              {user_interaction,false},
                              {silently_accept_hosts,true}]}],
                        undefined,true}
** Reason for termination == 
** {noproc,{gen_server,call,[undefined,which_children,infinity]}}

=ERROR REPORT==== 15-Nov-2010::19:42:16 ===
** Generic server <0.46.0> terminating 
** Last message in was {'EXIT',<0.47.0>,
                       {noproc,
                           {gen_server,call,
                               [undefined,which_children,infinity]}}}
** When Server state == {state,client,<0.47.0>,<0.50.0>,undefined}
** Reason for termination == 
** {noproc,{gen_server,call,[undefined,which_children,infinity]}}



-module(test_ssh).
-compile(export_all).

run() ->
    crypto:start(),
    ssh:start(),
    {ok, Ssh} = ssh:connect("127.0.0.1", 22, [{silently_accept_hosts, true},
                                          {user_interaction, false},
                                          {user, "user"},
                                          {password, "password"}]),
    ssh:close(Ssh).
```
