### PR TITLE
Float to list 2

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -1069,6 +1069,28 @@ b</pre>
       </desc>
     </func>
     <func>
+      <name>float_to_list(Float, Options) -> string()</name>
+      <fsummary>Text representation of a float formatted using given options</fsummary>
+      <type>
+        <v>Float = float()</v>
+        <v>Options = [Option]</v>
+        <v>Option = {precision, Precision::integer()} | compact</v>
+      </type>
+      <desc>
+        <p>Returns a string which corresponds to the text
+          representation of <c>Float</c> using fixed decimal point formatting.
+          When <c>precision</c> option is specified
+          the returned value will contain at most <c>Precision</c> number of
+          digits past the decimal point.  When <c>compact</c> option is provided
+          the trailing zeros at the end of the list are truncated.</p>
+        <pre>
+> <input>float_to_list(7.12, [{precision, 4}]).</input>
+"7.1200"
+> <input>float_to_list(7.12, [{precision, 4}, compact]).</input>
+"7.12"</pre>
+      </desc>
+    </func>
+    <func>
       <name>erlang:fun_info(Fun) -> [{Item, Info}]</name>
       <fsummary>Information about a fun</fsummary>
       <type>

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -139,6 +139,7 @@ atom close
 atom closed
 atom code
 atom command
+atom compact
 atom compat_rel
 atom compile
 atom compressed
@@ -411,6 +412,7 @@ atom pid
 atom port
 atom ports
 atom port_count
+atom precision
 atom print
 atom priority
 atom private

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -91,6 +91,8 @@ ubif erlang:float/1
 ubif 'erl.lang.number':to_float/1	ebif_to_float_1 float_1
 bif erlang:float_to_list/1
 bif 'erl.lang.float':to_string/1	ebif_float_to_string_1 float_to_list_1
+bif erlang:float_to_list/2
+bif 'erl.lang.float':to_string/2	ebif_float_to_string_2 float_to_list_2
 bif erlang:fun_info/2
 bif 'erl.lang.function':info/2		ebif_fun_info_2
 bif erlang:garbage_collect/0

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -656,6 +656,7 @@ void fini_getenv_state(GETENV_STATE *);
 void init_sys_float(void);
 int sys_chars_to_double(char*, double*);
 int sys_double_to_chars(double, char*);
+int sys_double_to_chars_fast(double, char*, int, int, int);
 void sys_get_pid(char *);
 
 /* erts_sys_putenv() returns, 0 on success and a value != 0 on failure. */

--- a/erts/emulator/sys/unix/sys_float.c
+++ b/erts/emulator/sys/unix/sys_float.c
@@ -764,6 +764,134 @@ sys_double_to_chars(double fp, char *buf)
     return s-buf; /* i.e strlen(buf) */
 }
 
+int
+sys_double_to_chars_fast(double f, char *outbuf, int maxlen, int precision, int compact)
+{
+    enum {
+          FRAC_SIZE = 52
+        , EXP_SIZE  = 11
+        , EXP_MASK  = (1ll << EXP_SIZE) - 1
+        , FRAC_MASK = (1ll << FRAC_SIZE) - 1
+        , FRAC_MASK2 = (1ll << (FRAC_SIZE + 1)) - 1
+        , MAX_FLOAT  = 1ll << (FRAC_SIZE+1)
+    };
+
+    long long mantissa, int_part, int_part2, frac_part;
+    short exp;
+    int sign, i, n, m, max;
+    double absf;
+    union { long long L; double F; } x;
+    char c, *p = outbuf;
+    int digit, roundup;
+
+    x.F = f;
+
+    exp      = (x.L >> FRAC_SIZE) & EXP_MASK;
+    mantissa = x.L & FRAC_MASK;
+    sign     = x.L >= 0 ? 1 : -1;
+    if (exp == EXP_MASK) {
+        if (mantissa == 0) {
+            if (sign == -1)
+                *p++ = '-';
+            *p++ = 'i';
+            *p++ = 'n';
+            *p++ = 'f';
+        } else {
+            *p++ = 'n';
+            *p++ = 'a';
+            *p++ = 'n';
+        }
+        *p = '\0';
+        return p - outbuf;
+    }
+
+    exp     -= EXP_MASK >> 1;
+    mantissa |= (1ll << FRAC_SIZE);
+    frac_part = 0;
+    int_part  = 0;
+    absf      = f * sign;
+
+    /* Don't bother with optimizing too large numbers and precision */
+    if (absf > MAX_FLOAT || precision > maxlen-17) {
+       int len = snprintf(outbuf, maxlen, "%.*f", precision, f);
+       return len;
+    }
+
+    if (exp >= FRAC_SIZE)
+        int_part  = mantissa << (exp - FRAC_SIZE);
+    else if (exp >= 0) {
+        int_part  = mantissa >> (FRAC_SIZE - exp);
+        frac_part = (mantissa << (exp + 1)) & FRAC_MASK2;
+    }
+    else /* if (exp < 0) */
+        frac_part = (mantissa & FRAC_MASK2) >> -(exp + 1);
+
+    if (int_part == 0) {
+        if (sign == -1)
+            *p++ = '-';
+        *p++ = '0';
+    } else {
+        int ret;
+        while (int_part != 0) {
+            int_part2 = int_part / 10;
+            *p++ = (char)(int_part - ((int_part2 << 3) + (int_part2 << 1)) + '0');
+            int_part = int_part2;
+        }
+        if (sign == -1)
+            *p++ = '-';
+        /* Reverse string */
+        ret = p - outbuf;
+        for (i = 0, n = ret/2; i < n; i++) {
+            c = outbuf[i];
+            outbuf[i] = outbuf[ret - i - 1];
+            outbuf[ret - i - 1] = c;
+        }
+    }
+    if (precision != 0)
+        *p++ = '.';
+
+    max = maxlen - (p - outbuf);
+    if (max > precision)
+        max = precision;
+    for (m = 0; m < max; m++) {
+        /* frac_part *= 10; */
+        frac_part = (frac_part << 3) + (frac_part << 1);
+
+        *p++ = (char)((frac_part >> (FRAC_SIZE + 1)) + '0');
+        frac_part &= FRAC_MASK2;
+    }
+    /* Delete ending zeroes */
+    if (compact)
+        for (--p; *p == '0' && *(p-1) == '0'; --p);
+
+    roundup = 0;
+    /* Rounding - look at the next digit */
+    frac_part = (frac_part << 3) + (frac_part << 1);
+    digit = (frac_part >> (FRAC_SIZE + 1));
+    if (digit > 5)
+        roundup = 1;
+    else if (digit == 5) {
+        frac_part &= FRAC_MASK2;
+        if (frac_part != 0) roundup = 1;
+    }
+    if (roundup) {
+        char d;
+        int pos = p - outbuf - 1;
+        do {
+            d = outbuf[pos];
+            if (d == '-') break;
+            if (d == '.') { pos--; continue; }
+            d++; outbuf[pos] = d;
+            if (d != ':') break;
+            outbuf[pos] = '0';
+            pos--;
+        } while (pos);
+    }
+
+    *p = '\0';
+    return p - outbuf;
+}
+
 /* Float conversion */
 
 int

--- a/erts/emulator/sys/win32/sys_float.c
+++ b/erts/emulator/sys/win32/sys_float.c
@@ -118,7 +118,7 @@ int
 sys_double_to_chars(double fp, char *buf)
 {
     char *s = buf;
-    
+
     (void) sprintf(buf, "%.20e", fp);
     /* Search upto decimal point */
     if (*s == '+' || *s == '-') s++;
@@ -127,6 +127,134 @@ sys_double_to_chars(double fp, char *buf)
     /* Scan to end of string */
     while (*s) s++;
     return s-buf; /* i.e strlen(buf) */
+}
+
+int
+sys_double_to_chars_fast(double f, char *outbuf, int maxlen, int precision, int compact)
+{
+    enum {
+          FRAC_SIZE = 52
+        , EXP_SIZE  = 11
+        , EXP_MASK  = (1ll << EXP_SIZE) - 1
+        , FRAC_MASK = (1ll << FRAC_SIZE) - 1
+        , FRAC_MASK2 = (1ll << (FRAC_SIZE + 1)) - 1
+        , MAX_FLOAT  = 1ll << (FRAC_SIZE+1)
+    };
+
+    long long mantissa, int_part, int_part2, frac_part;
+    short exp;
+    int sign, i, n, m, max;
+    double absf;
+    union { long long L; double F; } x;
+    char c, *p = outbuf;
+    int digit, roundup;
+
+    x.F = f;
+
+    exp      = (x.L >> FRAC_SIZE) & EXP_MASK;
+    mantissa = x.L & FRAC_MASK;
+    sign     = x.L >= 0 ? 1 : -1;
+    if (exp == EXP_MASK) {
+        if (mantissa == 0) {
+            if (sign == -1)
+                *p++ = '-';
+            *p++ = 'i';
+            *p++ = 'n';
+            *p++ = 'f';
+        } else {
+            *p++ = 'n';
+            *p++ = 'a';
+            *p++ = 'n';
+        }
+        *p = '\0';
+        return p - outbuf;
+    }
+
+    exp     -= EXP_MASK >> 1;
+    mantissa |= (1ll << FRAC_SIZE);
+    frac_part = 0;
+    int_part  = 0;
+    absf      = f * sign;
+
+    /* Don't bother with optimizing too large numbers and precision */
+    if (absf > MAX_FLOAT || precision > maxlen-17) {
+       int len = snprintf(outbuf, maxlen, "%.*f", precision, f);
+       return len;
+    }
+
+    if (exp >= FRAC_SIZE)
+        int_part  = mantissa << (exp - FRAC_SIZE);
+    else if (exp >= 0) {
+        int_part  = mantissa >> (FRAC_SIZE - exp);
+        frac_part = (mantissa << (exp + 1)) & FRAC_MASK2;
+    }
+    else /* if (exp < 0) */
+        frac_part = (mantissa & FRAC_MASK2) >> -(exp + 1);
+
+    if (int_part == 0) {
+        if (sign == -1)
+            *p++ = '-';
+        *p++ = '0';
+    } else {
+        int ret;
+        while (int_part != 0) {
+            int_part2 = int_part / 10;
+            *p++ = (char)(int_part - ((int_part2 << 3) + (int_part2 << 1)) + '0');
+            int_part = int_part2;
+        }
+        if (sign == -1)
+            *p++ = '-';
+        /* Reverse string */
+        ret = p - outbuf;
+        for (i = 0, n = ret/2; i < n; i++) {
+            c = outbuf[i];
+            outbuf[i] = outbuf[ret - i - 1];
+            outbuf[ret - i - 1] = c;
+        }
+    }
+    if (precision != 0)
+        *p++ = '.';
+
+    max = maxlen - (p - outbuf);
+    if (max > precision)
+        max = precision;
+    for (m = 0; m < max; m++) {
+        /* frac_part *= 10; */
+        frac_part = (frac_part << 3) + (frac_part << 1);
+
+        *p++ = (char)((frac_part >> (FRAC_SIZE + 1)) + '0');
+        frac_part &= FRAC_MASK2;
+    }
+    /* Delete ending zeroes */
+    if (compact)
+        for (--p; *p == '0' && *(p-1) == '0'; --p);
+
+    roundup = 0;
+    /* Rounding - look at the next digit */
+    frac_part = (frac_part << 3) + (frac_part << 1);
+    digit = (frac_part >> (FRAC_SIZE + 1));
+    if (digit > 5)
+        roundup = 1;
+    else if (digit == 5) {
+        frac_part &= FRAC_MASK2;
+        if (frac_part != 0) roundup = 1;
+    }
+    if (roundup) {
+        char d;
+        int pos = p - outbuf - 1;
+        do {
+            d = outbuf[pos];
+            if (d == '-') break;
+            if (d == '.') { pos--; continue; }
+            d++; outbuf[pos] = d;
+            if (d != ':') break;
+            outbuf[pos] = '0';
+            pos--;
+        } while (pos);
+    }
+
+    *p = '\0';
+    return p - outbuf;
 }
 
 int

--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -25,6 +25,7 @@
 %% 	abs/1
 %%	float/1
 %%	float_to_list/1
+%%  float_to_list/2
 %%	integer_to_list/1
 %%	list_to_float/1
 %%	list_to_integer/1
@@ -93,7 +94,7 @@ t_float(Config) when is_list(Config) ->
     ok.
 
 
-%% Tests float_to_list/1.
+%% Tests float_to_list/1, float_to_list/2.
 
 t_float_to_list(Config) when is_list(Config) ->
     ?line test_ftl("0.0e+0", 0.0),
@@ -101,6 +102,14 @@ t_float_to_list(Config) when is_list(Config) ->
     ?line test_ftl("2.5e+0", 2.5),
     ?line test_ftl("2.5e-1", 0.25),
     ?line test_ftl("-3.5e+17", -350.0e15),
+    ?line "1.0000"  = float_to_list(1.0,   []),
+    ?line "1.0"     = float_to_list(1.0,   [compact]),
+    ?line "-1.0000" = float_to_list(-1.0,  []),
+    ?line "1.12"    = float_to_list(1.123, [{precision, 2}]),
+    ?line "1.123"   = float_to_list(1.123, [{precision, 3}]),
+    ?line "1.1230"  = float_to_list(1.123, [{precision, 4}]),
+    ?line "1.12300" = float_to_list(1.123, [{precision, 5}]),
+    ?line "1.123"   = float_to_list(1.123, [{precision, 5}, compact]),
     ok.
     
 test_ftl(Expect, Float) ->

--- a/lib/stdlib/src/erl_internal.erl
+++ b/lib/stdlib/src/erl_internal.erl
@@ -259,6 +259,7 @@ bif(exit, 1) -> true;
 bif(exit, 2) -> true;
 bif(float, 1) -> true;
 bif(float_to_list, 1) -> true;
+bif(float_to_list, 2) -> true;
 bif(garbage_collect, 0) -> true;
 bif(garbage_collect, 1) -> true;
 bif(get, 0) -> true;


### PR DESCRIPTION
This patch implements a float_to_list/2 BIF that solves a problem of float_to_list/1 not allowing to specify
the number of digits after the decimal point when formatting floats.  Additionally this new BIF is optimized to run 5-10x faster than float_to_list/1 for floats under 2^52.

```
float_to_list(Float, Options) -> string()

Float = float()
Options = [Option]
Option = {precision, Precision::integer()} | compact
```

Text representation of a float formatted using given options

Returns a string which corresponds to the text
representation of Float using fixed decimal point formatting.
When precision option is specified
the returned value will contain at most Precision number of
digits past the decimal point.  When compact option is provided
the trailing zeros at the end of the list are truncated.

The simple test module included below illustrates the performance difference.

```
  1> test:test().
  float_to_list(123.400000)                   = {1.14305,
                                                 "1.23400000000000005684e+02"}
  float_to_list(123.400000, [])               = {0.124313,"123.4000"}
  float_to_list(123.400000, [{precision, 4}]) = {0.130213,"123.4000"}
  float_to_list(123.400000, 4)                = {0.125899,"123.4000"}
  ok
```

Test module:

```
-module(test).
-export([test/0, test/1]).

test() ->
    test(123.4).
test(N) ->
    Self = self(),
    spawn(fun() -> tc(Self, 1000000, fun() -> float_to_list(N) end) end),
    receive
    Msg0 -> io:format("float_to_list(~f)                   = ~p\n", [N, Msg0])
    end,
    spawn(fun() -> tc(Self, 1000000, fun() -> float_to_list(N, []) end) end),
    receive
    Msg1 -> io:format("float_to_list(~f, [])               = ~p\n", [N, Msg1])
    end,
    spawn(fun() -> tc(Self, 1000000, fun() -> float_to_list(N, [{precision, 4}]) end) end),
    receive
    Msg2 -> io:format("float_to_list(~f, [{precision, 4}]) = ~p\n", [N, Msg2])
    end,
    spawn(fun() -> tc(Self, 1000000, fun() -> float_to_list(N, 4) end) end),
    receive
    Msg3 -> io:format("float_to_list(~f, 4)                = ~p\n", [N, Msg3])
    end.


tc(Pid, N, F) when N > 0 ->
    loop(Pid, N, N, F, erlang:now()).

loop(Pid, 1, N, F, Time1) ->
    Res = F(),
    Int = timer:now_diff(erlang:now(), Time1),
    Pid ! {Int / N, Res};
loop(Pid, N, X, F, Time1) ->
    F(),
    loop(Pid, N-1, X, F, Time1).
```
