### PR TITLE
Return the same value for `disc_load_table` as `net_load_table`

### DIFF
--- a/lib/mnesia/src/mnesia_loader.erl
+++ b/lib/mnesia/src/mnesia_loader.erl
@@ -58,7 +58,7 @@ disc_load_table(Tab, Reason) ->
 do_get_disc_copy2(Tab, _Reason, Storage, _Type) when Storage == unknown ->
     verbose("Local table copy of ~p has recently been deleted, ignored.~n",
 	    [Tab]),
-    {loaded, ok};  %% ?
+    {not_loaded, storage_unknown};
 do_get_disc_copy2(Tab, Reason, Storage, Type) when Storage == disc_copies ->
     %% NOW we create the actual table
     Repair = mnesia_monitor:get_env(auto_repair),


### PR DESCRIPTION
Return the same value for `disc_load_table` as `net_load_table` if a table copy can not be found.

This breaks backward compatibility as `mnesia_controller:disc_load_table/3` now will stop Mnesia if the table was removed meanwhile instead of just ignoring this action.
