### PR TITLE
[PATCH]: remove variable processes_busy

### DIFF
--- a/erts/emulator/beam/benchmark.c
+++ b/erts/emulator/beam/benchmark.c
@@ -26,7 +26,6 @@
 #include "benchmark.h"
 
 #ifdef BM_COUNTERS
-unsigned long long processes_busy;
 unsigned long long processes_spawned;
 unsigned long long messages_sent;
 unsigned long long messages_copied;
@@ -184,7 +183,6 @@ void init_benchmarking()
 #endif /* BM_TIMERS */
 
 #ifdef BM_COUNTERS
-    processes_busy     = 0;
     processes_spawned  = 0;
     messages_sent      = 0;
     messages_copied    = 0;

--- a/erts/emulator/beam/benchmark.h
+++ b/erts/emulator/beam/benchmark.h
@@ -92,7 +92,6 @@
  * BM_COUNT(var) in the code where you want to increase it.
  *
  */
-extern unsigned long long processes_busy;
 extern unsigned long long processes_spawned;
 extern unsigned long long messages_sent;
 extern unsigned long long messages_copied;

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -224,10 +224,6 @@ static ErtsAlignedSchedulerSleepInfo *aligned_sched_sleep_info;
 
 #endif
 
-#ifndef BM_COUNTERS
-static int processes_busy;
-#endif
-
 Process**  process_tab;
 static Uint last_reductions;
 static Uint last_exact_reductions;
@@ -435,9 +431,6 @@ erts_init_process(int ncpu)
     p_serial_shift = erts_fit_in_bits(erts_max_processes - 1);
     p_serial_mask = ((~(~((Uint) 0) << proc_bits)) >> p_serial_shift);
     erts_process_tab_index_mask = ~(~((Uint) 0) << p_serial_shift);
-#ifndef BM_COUNTERS
-    processes_busy = 0;
-#endif
     last_reductions = 0;
     last_exact_reductions = 0;
     erts_default_process_flags = 0;
@@ -6100,7 +6093,6 @@ erl_create_process(Process* parent, /* Parent of process (default group leader).
 	goto error;
     }
 
-    processes_busy++;
     BM_COUNT(processes_spawned);
 
 #ifndef HYBRID
@@ -7623,7 +7615,6 @@ continue_exit_process(Process *p
     pbt = ERTS_PROC_SET_CALL_TIME(p, ERTS_PROC_LOCKS_ALL, NULL);
 
     erts_smp_proc_unlock(p, ERTS_PROC_LOCKS_ALL);
-    processes_busy--;
 
     if (dep) {
 	erts_do_net_exits(dep, reason);


### PR DESCRIPTION
variable processes_busy is not used in current code, it don't have
any meaning still stay on there, so remove it.
