### PR TITLE
Updated erlang-flymake to recognize the "deps" folder as an include directory

### DIFF
--- a/lib/tools/emacs/erlang-flymake.el
+++ b/lib/tools/emacs/erlang-flymake.el
@@ -60,7 +60,8 @@ check on newline and when there are no changes)."
   (list (concat (erlang-flymake-get-app-dir) "ebin")))
 
 (defun erlang-flymake-get-include-dirs ()
-  (list (concat (erlang-flymake-get-app-dir) "include")))
+  (list (concat (erlang-flymake-get-app-dir) "include")
+        (concat (erlang-flymake-get-app-dir) "deps")))
 
 (defun erlang-flymake-get-app-dir ()
   (let ((src-path (file-name-directory (buffer-file-name))))


### PR DESCRIPTION
Updated erlang-flymake to recognize the "deps" folder as an include directory. This makes erlang-flymake compatible with the rebar dependency management tool's default folder structure, which puts included dependencies in "deps".
