### PR TITLE
Remove hipe_ceach module from lib/hipe/main/hipe.app.src

### DIFF
--- a/lib/hipe/main/hipe.app.src
+++ b/lib/hipe/main/hipe.app.src
@@ -74,7 +74,6 @@
 	     hipe_arm_specific,
 	     hipe_bb,
 	     hipe_beam_to_icode,
-	     hipe_ceach,
 	     hipe_coalescing_regalloc,
 	     hipe_consttab,
 	     hipe_data_pp,


### PR DESCRIPTION
The absence of hipe_ceach.beam caused my reltool-generated releases to crash upon startup.  Removing hipe_ceach from the module list in hipe.app.src fixes the issue.  I assume it should have been removed when hipe_ceach.erl was removed from the source tree?
