### PR TITLE
Fixed rpc:call/5 for local calls with a finite Timeout

### DIFF
--- a/lib/kernel/src/rpc.erl
+++ b/lib/kernel/src/rpc.erl
@@ -286,7 +286,7 @@ call(N,M,F,A) ->
       Reason :: term(),
       Timeout :: timeout().
 
-call(N,M,F,A,_Timeout) when node() =:= N ->  %% Optimize local call
+call(N,M,F,A,infinity) when node() =:= N ->  %% Optimize local call
     local_call(M,F,A);
 call(N,M,F,A,infinity) ->
     do_call(N, {call,M,F,A,group_leader()}, infinity);


### PR DESCRIPTION
rpc:call/5 currently ignores the Timeout parameter if the node happens to be the local node. This fixes that.
