### PR TITLE
SSL close function hang permanently

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -99,6 +99,7 @@
 	#'DHParameter'{prime = ?DEFAULT_DIFFIE_HELLMAN_PRIME,
 		       base = ?DEFAULT_DIFFIE_HELLMAN_GENERATOR}).
 -define(WAIT_TO_ALLOW_RENEGOTIATION, 12000).
+-define(CLOSE_TIMEOUT, 5000).
 
 -type state_name()           :: hello | abbreviated | certify | cipher | connection.
 -type gen_fsm_state_return() :: {next_state, state_name(), #state{}} |
@@ -2347,7 +2348,7 @@ workaround_transport_delivery_problems(Socket, Transport, _) ->
     %% get a correct error message.
     inet:setopts(Socket, [{active, false}]),
     Transport:shutdown(Socket, write),
-    Transport:recv(Socket, 0).
+    Transport:recv(Socket, 0, ?CLOSE_TIMEOUT).
 
 linux_workaround_transport_delivery_problems(#alert{level = ?FATAL}, Socket) ->
     case os:type() of


### PR DESCRIPTION
In case of TCP half close or something, ssl_connection process is hanging on function "workaround_transport_delivery_problems" in order to waiting packet from client.
It causes process leak to my server.

I added timeout to recv function. But I do not insure timeout of 5 seconds is sufficient.
(Maybe It would better move to SSL Options).

Please consider it. thank you.
