### PR TITLE
Fix typo in ssh_basic_SUITE

### DIFF
--- a/lib/ssh/test/ssh_basic_SUITE.erl
+++ b/lib/ssh/test/ssh_basic_SUITE.erl
@@ -187,7 +187,7 @@ app_test(Config) when is_list(Config) ->
 misc_ssh_options(doc) ->
     ["Test that we can set some misc options not tested elsewhere, "
      "some options not yet present are not decided if we should support or "
-     "if they need thier own test case."];
+     "if they need their own test case."];
 misc_ssh_options(suite) ->
     [];
 misc_ssh_options(Config) when is_list(Config) ->  


### PR DESCRIPTION
Sorry, can't help it while I read code to fix misc typos.
