### PR TITLE
add armv7hl architecture

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -620,6 +620,7 @@ case $chk_arch_ in
     armv5tel)	ARCH=arm;;
     armv5tejl)	ARCH=arm;;
     armv7l)	ARCH=arm;;
+    armv7hl)    ARCH=arm;;
     tile)	ARCH=tile;;
     *)	 	ARCH=noarch;;
 esac


### PR DESCRIPTION
armv7hl is currently detected as noarch instead of arm.
