### PR TITLE
64-bit bug with odbcserver.

### DIFF
--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -1222,7 +1222,7 @@ static db_result_msg encode_out_params(db_state *state,
 					   (column.type.strlen_or_indptr_array[j]));
 			break;
                 case SQL_C_SLONG:
-                    ei_x_encode_long(&dynamic_buffer(state), ((long*)values)[j]);
+                    ei_x_encode_long(&dynamic_buffer(state), ((SQLINTEGER*)values)[j]);
                     break;
                 case SQL_C_DOUBLE:
                     ei_x_encode_double(&dynamic_buffer(state),


### PR DESCRIPTION
Values returned from DB should be casted to SQLINTEGER, rather than long. When casted to long type.
