### PR TITLE
erl_interface: add vprintf style functions

### DIFF
--- a/lib/erl_interface/doc/src/ei.xml
+++ b/lib/erl_interface/doc/src/ei.xml
@@ -695,11 +695,13 @@ ei_x_encode_empty_list(&amp;x);
     </func>
     <func>
       <name><ret>int</ret><nametext>ei_x_format(ei_x_buff* x, const char* fmt, ...)</nametext></name>
-      <name><ret>int</ret><nametext>ei_x_format_wo_ver(ei_x_buff* x, const char *fmt, ... )</nametext></name>
+      <name><ret>int</ret><nametext>ei_x_format_wo_ver(ei_x_buff* x, const char *fmt, ...)</nametext></name>
+      <name><ret>int</ret><nametext>ei_x_vformat(ei_x_buff* x, const char* fmt, va_list ap)</nametext></name>
+      <name><ret>int</ret><nametext>ei_x_vformat_wo_ver(ei_x_buff* x, const char *fmt, va_list ap)</nametext></name>
       <fsummary>Format a term from a format string and parameters.</fsummary>
       <desc>
         <p>Format a term, given as a string, to a buffer. This
-          functions works like a sprintf for erlang terms. The
+          functions works like a sprintf and svprintf for erlang terms. The
           <c><![CDATA[fmt]]></c> contains a format string, with arguments like
           <c><![CDATA[~d]]></c>, to insert terms from variables. The following
           formats are supported (with the C types given):</p>

--- a/lib/erl_interface/include/ei.h
+++ b/lib/erl_interface/include/ei.h
@@ -525,11 +525,13 @@ int ei_print_term(FILE *fp, const char* buf, int* index);
 int ei_s_print_term(char** s, const char* buf, int* index);
 
 /*
- * format to build binary format terms a bit like printf
+ * format to build binary format terms a bit like printf & vprintf
  */
 
 int ei_x_format(ei_x_buff* x, const char* fmt, ...);
 int ei_x_format_wo_ver(ei_x_buff* x, const char *fmt, ...);
+int ei_x_vformat(ei_x_buff* x, const char* fmt, va_list args);
+int ei_x_vformat_wo_ver(ei_x_buff* x, const char *fmt, va_list args);
 
 int ei_x_new(ei_x_buff* x);
 int ei_x_new_with_version(ei_x_buff* x);

--- a/lib/erl_interface/src/misc/ei_format.c
+++ b/lib/erl_interface/src/misc/ei_format.c
@@ -442,23 +442,15 @@ static int read_args(const char* fmt, va_list ap, union arg **argp)
     return 0;
 }
        
-int ei_x_format(ei_x_buff* x, const char* fmt, ... )
+int ei_x_vformat_wo_ver(ei_x_buff* x, const char* fmt, va_list ap)
 {
-    va_list ap;
+    int res;
     union arg* args;
     union arg* saved_args; 
-    int res;
 
-    res = ei_x_encode_version(x);
-    if (res < 0) return res;
-
-    va_start(ap, fmt);
     res = read_args(fmt,ap,&args);
     saved_args = args;
-    va_end(ap);
-    if (res < 0) {
-	return -1;
-    }
+    if (res < 0) return -1;
 
     res = eiformat(&fmt, &args, x);
     ei_free(saved_args);
@@ -466,22 +458,35 @@ int ei_x_format(ei_x_buff* x, const char* fmt, ... )
     return res;
 }
 
-int ei_x_format_wo_ver(ei_x_buff* x, const char* fmt, ... )
+int ei_x_vformat(ei_x_buff* x, const char* fmt, va_list ap)
+{
+    int res;
+
+    res = ei_x_encode_version(x);
+    if (res < 0) return res;
+    return ei_x_vformat_wo_ver(x,fmt,ap);
+}
+
+int ei_x_format(ei_x_buff* x, const char* fmt, ... )
 {
     va_list ap;
-    union arg* args; 
-    union arg* saved_args; 
     int res;
 
     va_start(ap, fmt);
-    res = read_args(fmt,ap,&args);
-    saved_args = args;
+    res = ei_x_vformat(x,fmt,ap);
     va_end(ap);
-    if (res < 0) {
-	return -1;
-    }
-    res = eiformat(&fmt, &args, x);
-    ei_free(saved_args);
+
+    return res;
+}
+
+int ei_x_format_wo_ver(ei_x_buff* x, const char* fmt, ... )
+{
+    va_list ap;
+    int res;
+
+    va_start(ap, fmt);
+    res = ei_x_vformat_wo_ver(x,fmt,ap);
+    va_end(ap);
 
     return res;
 }


### PR DESCRIPTION
As stated at: http://c-faq.com/varargs/handoff.html it is not possible to write
a function which takes a variable number of arguments and passes them to some other function (which takes a variable number of arguments). You should provide a version of that other function which accepts a va_list pointer.

So this provides:
- ei_x_format => ei_x_vformat
- ei_x_format_wo_ver => ei_x_vformat_wo_ver
  and refactors function implementation in order to avoid code duplication.
