### PR TITLE
run_erl: Redirect standard streams to /dev/null

### DIFF
--- a/erts/etc/unix/run_erl.c
+++ b/erts/etc/unix/run_erl.c
@@ -1142,6 +1142,14 @@ static void daemon_init(void)
 	sf_close(i);
     }
 
+    /* Necessary on some platforms */
+
+    open("/dev/null", O_RDONLY); /* Order is important! */
+    open("/dev/null", O_WRONLY);
+    open("/dev/null", O_WRONLY);
+
+    errno = 0;  /* if set by open */
+
     OPEN_SYSLOG();
     run_daemon = 1;
 }


### PR DESCRIPTION
Like in epmd and erlexec. Otherwise "run_erl" fails on some platforms
when called with the "-daemon" option, printing this error:

  "Cannot dup"
