### PR TITLE
Fix compile error on ARM and GCC < 4.1.0

### DIFF
--- a/erts/include/internal/gcc/ethread.h
+++ b/erts/include/internal/gcc/ethread.h
@@ -25,6 +25,9 @@
 #ifndef ETHREAD_GCC_H__
 #define ETHREAD_GCC_H__
 
+#if defined(ETHR_HAVE___SYNC_VAL_COMPARE_AND_SWAP32) \
+     || defined(ETHR_HAVE___SYNC_VAL_COMPARE_AND_SWAP64)
+
 #ifndef ETHR_MEMBAR
 #  include "ethr_membar.h"
 #endif
@@ -43,6 +46,8 @@
      && !(ETHR_SIZEOF_PTR == 4 && defined(ETHR_HAVE_NATIVE_ATOMIC64)) \
      && !(ETHR_SIZEOF_PTR == 8 && defined(ETHR_HAVE_NATIVE_ATOMIC128)))
 #  include "ethr_dw_atomic.h"
+#endif
+
 #endif
 
 #endif


### PR DESCRIPTION
Since b29ecbd (OTP-10418, R15B03) Erlang does not compile anymore with
old versions of GCC that do not have atomic ops builtins on platforms
where there is no native ethread implementation (e.g. ARM):

In file included from ../include/internal/gcc/ethread.h:29,
                 from ../include/internal/ethread.h:354,
                 from beam/erl_threads.h:264,
                 from beam/erl_smp.h:27,
                 from beam/sys.h:413,
                 from hipe/hipe_mkliterals.c:29:
../include/internal/gcc/ethr_membar.h:49:4: error: #error "No __sync_val_compare_and_swap"

This patch adds a header guard in "gcc/ethread.h", as is present in
"libatomic_ops/ethread.h".
