### PR TITLE
Fix alignment of q command in Erlang shell user switch command help

### DIFF
--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -418,7 +418,7 @@ list_commands(Iport, Oport) ->
 		  true -> 
 		      [];
 		  false ->
-		      [{put_chars,unicode,"  q        - quit erlang\n"}]
+		      [{put_chars, unicode,"  q                 - quit erlang\n"}]
 	      end,
     io_requests([{put_chars, unicode,"  c [nn]            - connect to job\n"},
 		 {put_chars, unicode,"  i [nn]            - interrupt job\n"},


### PR DESCRIPTION
This PR fixes the bad alignment of the `q` command.

```
Eshell V5.10.2  (abort with ^G)
1> 
User switch command
 --> h
  c [nn]            - connect to job
  i [nn]            - interrupt job
  k [nn]            - kill job
  j                 - list all jobs
  s [shell]         - start local shell
  r [node [shell]]  - start remote shell
  q        - quit erlang
  ? | h             - this message
 --> q
```
