### PR TITLE
Update io:prompt() type

### DIFF
--- a/lib/stdlib/src/io.erl
+++ b/lib/stdlib/src/io.erl
@@ -40,7 +40,7 @@
 %%-------------------------------------------------------------------------
 
 -type device() :: atom() | pid().
--type prompt() :: atom() | string().
+-type prompt() :: atom() | unicode:chardata().
 
 %% ErrorDescription is whatever the I/O-server sends.
 -type server_no_data() :: {'error', ErrorDescription :: term()} | 'eof'.


### PR DESCRIPTION
Functions that expect an io:prompt() also accept binaries and
iolists as arguments. Therefore its type has been updated to
reflect the same types accepted by other io functions.
