### PR TITLE
Fix some errors in the inets documentation

### DIFF
--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -300,11 +300,11 @@ filename()       = string()
 	    process or to a file. When streaming to the calling process 
 	    using the option <c>self</c> the following stream messages
 	    will be sent to that process: <c>{http, {RequestId,
-	    stream_start, Headers}, {http, {RequestId, stream,
-	    BinBodyPart}, {http, {RequestId, stream_end, Headers}</c>. When
+	    stream_start, Headers}}, {http, {RequestId, stream,
+	    BinBodyPart}}, {http, {RequestId, stream_end, Headers}}</c>. When
 	    streaming to to the calling processes using the option
 	    <c>{self, once}</c> the first message will have an additional
-	    element e.i. <c>{http, {RequestId, stream_start, Headers, Pid}</c>,
+	    element e.i. <c>{http, {RequestId, stream_start, Headers, Pid}}</c>,
 	    this is the process id that should be used as an argument to
 	    <c>http:stream_next/1</c> to trigger the next message to be sent to
 	    the calling process. </p>

--- a/lib/inets/doc/src/httpd.xml
+++ b/lib/inets/doc/src/httpd.xml
@@ -406,7 +406,7 @@ bytes
 	begins with url-path is mapped to local files that begins with
 	directory-filename, for example:
 	
-	<code>{alias, {"/image", "/ftp/pub/image"}</code>
+	<code>{alias, {"/image", "/ftp/pub/image"}}</code>
 	
 	and an access to http://your.server.org/image/foo.gif would refer to
 	the file /ftp/pub/image/foo.gif. </p>
@@ -421,7 +421,7 @@ bytes
         by re:replace/3 to produce a path in the local filesystem.
         For example:
 	
-	<code>{re_write, {"^/[~]([^/]+)(.*)$", "/home/\\1/public\\2"}</code>
+	<code>{re_write, {"^/[~]([^/]+)(.*)$", "/home/\\1/public\\2"}}</code>
 	
 	and an access to http://your.server.org/~bob/foo.gif would refer to
 	the file /home/bob/public/foo.gif.
@@ -468,7 +468,7 @@ bytes
 	scripts. URLs with a path beginning with url-path are mapped to
 	scripts beginning with directory-filename, for example:
 	
-	<code>{script_alias, {"/cgi-bin/", "/web/cgi-bin/"}</code>
+	<code>{script_alias, {"/cgi-bin/", "/web/cgi-bin/"}}</code>
 	
 	and an access to http://your.server.org/cgi-bin/foo would cause
 	the server to run the script /web/cgi-bin/foo. </p>
@@ -483,7 +483,7 @@ bytes
 	scripts. URLs with a path beginning with url-path are mapped to
 	scripts beginning with directory-filename, for example:
 	
-	<code>{script_re_write, {"^/cgi-bin/(\\d+)/", "/web/\\1/cgi-bin/"}</code>
+	<code>{script_re_write, {"^/cgi-bin/(\\d+)/", "/web/\\1/cgi-bin/"}}</code>
 	
 	and an access to http://your.server.org/cgi-bin/17/foo would cause
 	the server to run the script /web/17/cgi-bin/foo. </p>
@@ -517,7 +517,7 @@ bytes
 	the standard CGI PATH_INFO and PATH_TRANSLATED environment
 	variables.
 
-	<code>{action, {"text/plain", "/cgi-bin/log_and_deliver_text"}</code>
+	<code>{action, {"text/plain", "/cgi-bin/log_and_deliver_text"}}</code>
 	</p>
       </item>
 
@@ -532,7 +532,7 @@ bytes
 	the standard CGI PATH_INFO and PATH_TRANSLATED environment
 	variables.
 	
-	<code>{script, {"PUT", "/cgi-bin/put"}</code>
+	<code>{script, {"PUT", "/cgi-bin/put"}}</code>
 	</p>
 	
       </item>
@@ -549,7 +549,7 @@ bytes
 	scheme scripts. A matching URL is mapped into a specific module
 	and function. For example:
 	
-	<code>{erl_script_alias, {"/cgi-bin/example", [httpd_example]}
+	<code>{erl_script_alias, {"/cgi-bin/example", [httpd_example]}}
 	</code>
 	
 	and a request to
@@ -706,7 +706,7 @@ bytes
 	
 	For example:
 	
-	<code>{allow_from, ["123.34.56.11", "150.100.23"] </code>
+	<code>{allow_from, ["123.34.56.11", "150.100.23"]}</code>
           
 	The host 123.34.56.11 and all machines on the 150.100.23
 	subnet are allowed access. </p>
@@ -719,7 +719,7 @@ bytes
 	which should be denied access to a given directory.
 	For example:
 	
-	<code>{deny_from, ["123.34.56.11", "150.100.23"] </code>
+	<code>{deny_from, ["123.34.56.11", "150.100.23"]}</code>
           
 	The host 123.34.56.11 and all machines on the 150.100.23
 	subnet are not allowed access. </p>
@@ -835,7 +835,7 @@ bytes
     <p><em>Security properties - requires mod_security </em></p>
  
     <marker id="prop_sec_dir"></marker>
-    <p><em>{security_directory, {path(), [{property(), term()}]}</em></p>
+    <p><em>{security_directory, {path(), [{property(), term()}]}}</em></p>
        
     <marker id="props_sdir"></marker>
     <p>Here follows the valid properties for security directories</p>
@@ -1067,7 +1067,7 @@ bytes
       <fsummary>Called for each request to the Web server.</fsummary>
       <type>
         <v>OldData = list()</v>
-        <v>NewData = [{response,{StatusCode,Body}}] | [{response,{response,Head,Body}}] |  [{response,{already_sent,Statuscode,Size}] </v>
+        <v>NewData = [{response,{StatusCode,Body}}] | [{response,{response,Head,Body}}] |  [{response,{already_sent,Statuscode,Size}}] </v>
         <v>StausCode = integer()</v>
         <v>Body = io_list() | nobody | {Fun, Arg}</v>
         <v>Head = [HeaderOption]</v>

--- a/lib/inets/doc/src/httpd_util.xml
+++ b/lib/inets/doc/src/httpd_util.xml
@@ -337,10 +337,10 @@
 
     <func>
       <name>rfc1123_date() -> RFC1123Date</name>
-      <name>rfc1123_date({{YYYY,MM,DD},{Hour,Min,Sec}}}) -> RFC1123Date</name>
+      <name>rfc1123_date({{YYYY,MM,DD},{Hour,Min,Sec}}) -> RFC1123Date</name>
       <fsummary>Return the current date in RFC 1123 format.</fsummary>
       <type>
-        <v>YYYY = MM = DD = Hour = Min =Sec = integer()</v>
+        <v>YYYY = MM = DD = Hour = Min = Sec = integer()</v>
         <v>RFC1123Date = string()</v>
       </type>
       <desc>

--- a/lib/inets/doc/src/mod_alias.xml
+++ b/lib/inets/doc/src/mod_alias.xml
@@ -118,7 +118,7 @@
     </func>
 
     <func>
-      <name>real_script_name(ConfigDB,RequestURI,ScriptAliases) -> Ret</name>
+      <name>real_script_name(ConfigDB, RequestURI, ScriptAliases) -> Ret</name>
       <fsummary>Expand a request uri using ScriptAlias config directives.</fsummary>
       <type>
         <v>ConfigDB = config_db()</v>
@@ -129,7 +129,7 @@
       </type>
       <desc>
         <marker id="real_script_name"></marker>
-        <p><c>real_name/3</c> traverses <c>ScriptAliases</c>,
+        <p><c>real_script_name/3</c> traverses <c>ScriptAliases</c>,
 	typically extracted from <c>ConfigDB</c>, and matches each
 	<c>FakeName</c> with <c>RequestURI</c>. If a match is found
 	<c>FakeName</c> is replaced with <c>RealName</c> in the

--- a/lib/inets/doc/src/notes_history.xml
+++ b/lib/inets/doc/src/notes_history.xml
@@ -834,7 +834,7 @@
     <list type="bulleted">
       <item>
 	<p>[ftp, client] - A new option {progress, {CBmodule,
-	  CBFunction, InitProgressTerm} has been added to allow
+	  CBFunction, InitProgressTerm}} has been added to allow
 	  users to create things such as progress bars in there
 	  GUI's. The option affects ftp:send/[3,4] and
 	  ftp:recv/[3,4].</p>


### PR DESCRIPTION
Initially just wanted to report the "real_name" -> "real_script_name" error, but found some more.
