### PR TITLE
Fix compilation on Solaris

### DIFF
--- a/lib/os_mon/c_src/ferrule.c
+++ b/lib/os_mon/c_src/ferrule.c
@@ -50,7 +50,7 @@
 #define		FDS_STDIN	0
 #define		FDS_PIPE	1
 
-main(int argc, char *argv[])
+int	main(int argc, char *argv[])
 /*	usage: ferrule ownpath */
 {
     int		i, pipe_fd;

--- a/lib/os_mon/c_src/mod_syslog.c
+++ b/lib/os_mon/c_src/mod_syslog.c
@@ -47,7 +47,7 @@
 #define		TRUE		1
 #define		WAIT		1
 
-main(int argc, char *argv[])
+int	main(int argc, char *argv[])
 /*	usage: mod_syslog mode ownpath syslogconf */
 {
     int	syslogd_pid, n_lines_copied=0;
@@ -128,6 +128,7 @@ main(int argc, char *argv[])
        make_exit(PIPE_NOT_FOUND);
        else */
     make_exit(OK);
+    return 0;
 }
 
 void	make_exit(int exit_code)


### PR DESCRIPTION
Trying to compile R16B01 on SmartOS resulted in following errors:

```
gcc -c -o ../priv/obj/i386-pc-solaris2.11/ferrule.o -Werror=return-type  -g -O2 -I/root/otp_src_R16B01/erts/i386-pc-solaris2.11  -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fno-tree-copyrename  -DHAVE_CONFIG_H  ferrule.c
ferrule.c:53:1: error: return type defaults to 'int' [-Werror=return-type]
...
gcc -c -o ../priv/obj/i386-pc-solaris2.11/mod_syslog.o -Werror=return-type  -g -O2 -I/root/otp_src_R16B01/erts/i386-pc-solaris2.11  -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fno-tree-copyrename  -DHAVE_CONFIG_H  mod_syslog.c
mod_syslog.c:50:1: error: return type defaults to 'int' [-Werror=return-type]
mod_syslog.c: In function 'make_exit':
mod_syslog.c:136:5: warning: incompatible implicit declaration of built-in function 'exit' [enabled by default]
mod_syslog.c: In function 'main':
mod_syslog.c:131:1: error: control reaches end of non-void function [-Werror=return-type]
```

Adding return values and types to `main` functions in `mod_syslog.c` and
`ferrule.c` fixed the build.
