### PR TITLE
Fix sys:get_state/2 and sys:replace_state/3 when sys suspended

### DIFF
--- a/lib/stdlib/doc/src/sys.xml
+++ b/lib/stdlib/doc/src/sys.xml
@@ -246,6 +246,7 @@
           <c>{Module, Id, HandlerState}</c>, where <c>Module</c> is the event handler's module name,
           <c>Id</c> is the handler's ID (which is the value <c>false</c> if it was registered without
           an ID), and <c>HandlerState</c> is the handler's state.</p>
+        <p><c>Mod:system_get_state/1</c> will be called in the target process to get the <c>State</c>.</p>
         <p>To obtain more information about a process, including its state, see
           <seealso marker="#get_status-1">get_status/1</seealso> and
           <seealso marker="#get_status-2">get_status/2</seealso>.</p>
@@ -289,6 +290,8 @@
           function means that only the state of the particular event handler it was working on when it
           failed or crashed is unchanged; it can still succeed in changing the states of other event
           handlers registered in the same <c>gen_event</c> process.</p>
+      <p><c>Mod:system_replace_state/2</c> will be called in the target process to replace the
+        <c>State</c> using <c>StateFun</c>.</p>
       </desc>
     </func>
     <func>
@@ -375,8 +378,9 @@
           process continues the execution, or
           <c><anno>Module</anno>:system_terminate(Reason, <anno>Parent</anno>, <anno>Debug</anno>, <anno>Misc</anno>)</c> if
           the process should terminate. The <c><anno>Module</anno></c> must export
-          <c>system_continue/3</c>, <c>system_terminate/4</c>, and
-          <c>system_code_change/4</c> (see below).
+          <c>system_continue/3</c>, <c>system_terminate/4</c>,
+          <c>system_code_change/4</c>, <c>system_get_state/1</c> and
+          <c>system_replace_state/2</c> (see below).
           </p>
         <p>The <c><anno>Misc</anno></c> argument can be used to save internal data
           in a process, for example its state. It is sent to
@@ -442,6 +446,36 @@
           structure. <c>OldVsn</c> is the <em>vsn</em> attribute of the
           old version of the <c>Module</c>. If no such attribute was
           defined, the atom <c>undefined</c> is sent.</p>
+      </desc>
+    </func>
+    <func>
+      <name>Mod:system_get_state(Misc) -> {ok, State, NMisc}</name>
+      <fsummary>Called when the process should return its current state</fsummary>
+      <type>
+        <v>Misc = term()</v>
+        <v>State = term()</v>
+        <v>NMisc = term()</v>
+    </type>
+      <desc>
+        <p>This function is called from <c>sys:handle_system_msg/6</c> when the process
+          should return a term that reflects its current state. <c>State</c> is the
+          value returned by <c>sys:get_state/2</c>.</p>
+      </desc>
+    </func>
+    <func>
+      <name>Mod:system_replace_state(StateFun, Misc) -> {ok, NState, NMisc}</name>
+      <fsummary>Called when the process should replace is state</fsummary>
+      <type>
+        <v>StateFun = fun((State :: term()) -> NState)</v>
+        <v>Misc = term()</v>
+        <v>NState = term()</v>
+        <v>NMisc = term()</v>
+    </type>
+      <desc>
+        <p>This function is called from <c>sys:handle_system_msg/6</c> when the process
+         should replace its current state. If the <c>StateFun</c> throws an exception
+         it should be caught and the current state returned. <c>NState</c> is the value
+         returned by <c>sys:replace_state/3</c>.</p>
       </desc>
     </func>
   </funcs>

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -118,6 +118,8 @@
 	 system_continue/3,
 	 system_terminate/4,
 	 system_code_change/4,
+	 system_get_state/1,
+	 system_replace_state/2,
 	 format_status/2]).
 
 -import(error_logger, [format/2]).
@@ -422,17 +424,6 @@ wake_hib(Parent, Name, StateName, StateData, Mod, Debug) ->
 
 decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, Debug, Hib) ->
     case Msg of
-	{system, From, get_state} ->
-	    Misc = [Name, StateName, StateData, Mod, Time],
-	    sys:handle_system_msg(get_state, From, Parent, ?MODULE, Debug,
-				  {{StateName, StateData}, Misc}, Hib);
-	{system, From, {replace_state, StateFun}} ->
-	    State = {StateName, StateData},
-	    NState = {NStateName, NStateData} = try StateFun(State)
-						catch _:_ -> State end,
-	    NMisc = [Name, NStateName, NStateData, Mod, Time],
-	    sys:handle_system_msg(replace_state, From, Parent, ?MODULE, Debug,
-				  {NState, NMisc}, Hib);
         {system, From, Req} ->
 	    sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug,
 				  [Name, StateName, StateData, Mod, Time], Hib);
@@ -465,6 +456,19 @@ system_code_change([Name, StateName, StateData, Mod, Time],
 	{ok, NewStateName, NewStateData} ->
 	    {ok, [Name, NewStateName, NewStateData, Mod, Time]};
 	Else -> Else
+    end.
+
+system_get_state([_Name, StateName, StateData, _Mod, _Time] = GenState) ->
+    {ok, {StateName, StateData}, GenState}.
+
+system_replace_state(StateFun,
+		     [Name, StateName, StateData, Mod, Time] = GenState) ->
+    try StateFun({StateName, StateData}) of
+	{NStateName, NStateData} = Result ->
+	    {ok, Result, [Name, NStateName, NStateData, Mod, Time]}
+    catch
+	_:_ ->
+	    {ok, {StateName, StateData}, GenState}
     end.
 
 %%-----------------------------------------------------------------

--- a/lib/stdlib/test/gen_event_SUITE.erl
+++ b/lib/stdlib/test/gen_event_SUITE.erl
@@ -974,6 +974,10 @@ get_state(Config) when is_list(Config) ->
     [{dummy1_h,false,State1},{dummy1_h,id,State2}] = lists:sort(Result1),
     Result2 = sys:get_state(Pid, 5000),
     [{dummy1_h,false,State1},{dummy1_h,id,State2}] = lists:sort(Result2),
+    ok = sys:suspend(Pid),
+    Result3 = sys:get_state(Pid),
+    [{dummy1_h,false,State1},{dummy1_h,id,State2}] = lists:sort(Result3),
+    ok = sys:resume(Pid),
     ok = gen_event:stop(Pid),
     ok.
 
@@ -998,4 +1002,11 @@ replace_state(Config) when is_list(Config) ->
     Replace3 = fun(_) -> exit(fail) end,
     [{dummy1_h,false,NState2}] = sys:replace_state(Pid, Replace3),
     [{dummy1_h,false,NState2}] = sys:get_state(Pid),
+    %% verify state replaced if process sys suspended
+    NState3 = "replaced again and again",
+    Replace4 = fun({dummy1_h,false,_}=S) -> setelement(3,S,NState3) end,
+    ok = sys:suspend(Pid),
+    [{dummy1_h,false,NState3}] = sys:replace_state(Pid, Replace4),
+    ok = sys:resume(Pid),
+    [{dummy1_h,false,NState3}] = sys:get_state(Pid),
     ok.

--- a/lib/stdlib/test/gen_fsm_SUITE.erl
+++ b/lib/stdlib/test/gen_fsm_SUITE.erl
@@ -426,6 +426,14 @@ get_state(Config) when is_list(Config) ->
     {idle, State} = sys:get_state(gfsm),
     {idle, State} = sys:get_state(gfsm, 5000),
     stop_it(Pid2),
+
+    %% check that get_state works when pid is sys suspended
+    {ok, Pid3} = gen_fsm:start(gen_fsm_SUITE, {state_data, State}, []),
+    {idle, State} = sys:get_state(Pid3),
+    ok = sys:suspend(Pid3),
+    {idle, State} = sys:get_state(Pid3, 5000),
+    ok = sys:resume(Pid3),
+    stop_it(Pid3),
     ok.
 
 replace_state(Config) when is_list(Config) ->
@@ -444,6 +452,14 @@ replace_state(Config) when is_list(Config) ->
     Replace3 = fun(_) -> error(fail) end,
     {state0, NState2} = sys:replace_state(Pid, Replace3),
     {state0, NState2} = sys:get_state(Pid),
+    %% verify state replaced if process sys suspended
+    ok = sys:suspend(Pid),
+    Suffix2 = " and again",
+    NState3 = NState2 ++ Suffix2,
+    Replace3 = fun({StateName, _}) -> {StateName, NState3} end,
+    {state0, NState3} = sys:replace_state(Pid, Replace3),
+    ok = sys:resume(Pid),
+    NState3 = sys:get_state(Pid, 5000),
     stop_it(Pid),
     ok.
 

--- a/lib/stdlib/test/gen_server_SUITE.erl
+++ b/lib/stdlib/test/gen_server_SUITE.erl
@@ -1049,6 +1049,9 @@ get_state(Config) when is_list(Config) ->
     {ok, Pid} = gen_server:start_link(?MODULE, {state,State}, []),
     State = sys:get_state(Pid),
     State = sys:get_state(Pid, 5000),
+    ok = sys:suspend(Pid),
+    State = sys:get_state(Pid),
+    ok = sys:resume(Pid),
     ok.
 
 %% Verify that sys:replace_state correctly replaces gen_server state
@@ -1077,6 +1080,14 @@ replace_state(Config) when is_list(Config) ->
     Replace3 = fun(_) -> throw(fail) end,
     NState2 = sys:replace_state(Pid, Replace3),
     NState2 = sys:get_state(Pid, 5000),
+    %% verify state replaced if process sys suspended
+    ok = sys:suspend(Pid),
+    Suffix2 = " and again",
+    NState3 = NState2 ++ Suffix2,
+    Replace3 = fun(S) -> S ++ Suffix2 end,
+    NState3 = sys:replace_state(Pid, Replace3),
+    ok = sys:resume(Pid),
+    NState3 = sys:get_state(Pid, 5000),
     ok.
 
 %% Test that the time for a huge message queue is not

--- a/system/doc/design_principles/spec_proc.xml
+++ b/system/doc/design_principles/spec_proc.xml
@@ -180,6 +180,18 @@ system_continue(Parent, Deb, Chs) ->
 system_terminate(Reason, Parent, Deb, Chs) ->
     exit(Reason).
 
+system_get_state(Chs) ->
+    {ok, Chs, Chs}.
+
+system_replace_state(StateFun, Chs) ->
+    try StateFun(Chs) of
+        Chs2 ->
+            {ok, Chs2, Chs2}
+    catch
+        _:_ ->
+            {ok, Chs, Chs}
+    end.
+
 write_debug(Dev, Event, Name) ->
     io:format(Dev, "~p event = ~p~n", [Name, Event]).</pre>
       <p>Example on how the simple debugging functions in <c>sys</c> can
@@ -353,12 +365,19 @@ sys:handle_system_msg(Request, From, Parent, Module, Deb, State)</code>
         message and then call:</p>
       <code type="none">
 Module:system_continue(Parent, Deb, State)</code>
-      <p>if process execution should continue, or:</p>
+      <p>if process execution should continue, or if the process should
+        terminate:</p>
       <code type="none">
 Module:system_terminate(Reason, Parent, Deb, State)</code>
       <p>if the process should terminate. Note that a process in a
         supervision tree is expected to terminate with the same reason as
         its parent.</p>
+      <p>If the process should return its state sysHandle_system_msg will call:</p>
+      <code type="none">
+Module:system_get_state(State)</code>
+      <p>Or if the process should replace its state using the fun <c>StateFun</c>:</p>
+      <code type="none">
+Module:system_replace_state(StateFun, State)</code>
       <list type="bulleted">
         <item><c>Request</c> and <c>From</c> should be passed as-is from
          the system message to the call to <c>handle_system_msg</c>.</item>
@@ -366,7 +385,8 @@ Module:system_terminate(Reason, Parent, Deb, State)</code>
         <item><c>Module</c> is the name of the module.</item>
         <item><c>Deb</c> is the debug structure.</item>
         <item><c>State</c> is a term describing the internal state and
-         is passed to <c>system_continue</c>/<c>system_terminate</c>.</item>
+         is passed to <c>system_continue</c>/<c>system_terminate</c>/
+         <c>system_get_state</c>/<c>system_replace_state</c>.</item>
       </list>
       <p>In the example:</p>
       <code type="none">
@@ -383,7 +403,19 @@ system_continue(Parent, Deb, Chs) ->
     loop(Chs, Parent, Deb).
 
 system_terminate(Reason, Parent, Deb, Chs) ->
-    exit(Reason).</code>
+    exit(Reason).
+
+system_get_state(Chs) ->
+    {ok, Chs, Chs}.
+
+system_replace_state(StateFun, Chs) ->
+    try StateFun(Chs) of
+        Chs2 ->
+            {ok, Chs2, Chs2}
+    catch
+        _:_ ->
+            {ok, Chs, Chs}
+    end.</code>
       <p>If the special process is set to trap exits, note that if
         the parent process terminates, the expected behavior is to
         terminate with the same reason:</p>


### PR DESCRIPTION
Currently it is not possible to use `sys:get_state/2` and `sys:replace_state/3` after calling `sys:suspend/2`. This patch adds two new system callbacks `system_get_state/1` and `system_replace_state/2` that will only be used when the current method of intercepting the system message is not present or the process is suspended by sys. The generic otp behaviours are updated to use the callbacks.
