### PR TITLE
Export the edge/0 type from the digraph module

### DIFF
--- a/lib/stdlib/src/digraph.erl
+++ b/lib/stdlib/src/digraph.erl
@@ -36,7 +36,7 @@
 
 -export([get_short_path/3, get_short_cycle/2]).
 
--export_type([digraph/0, d_type/0, vertex/0]).
+-export_type([digraph/0, d_type/0, vertex/0, edge/0]).
 
 -record(digraph, {vtab = notable :: ets:tab(),
 		  etab = notable :: ets:tab(),


### PR DESCRIPTION
Since `vertex/0` is exported, it makes sense to export this one too.
