### PR TITLE
add erl option to set schedulers by percentages

### DIFF
--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -748,19 +748,47 @@
       </item>
       <tag><marker id="+S"><c><![CDATA[+S Schedulers:SchedulerOnline]]></c></marker></tag>
       <item>
-        <p>Sets the amount of scheduler threads to create and scheduler
-	  threads to set online when SMP support has been enabled.
-	  Valid range for both values are 1-1024. If the
-          Erlang runtime system is able to determine the amount
-          of logical processors configured and logical processors available,
-	  <c>Schedulers</c> will default to logical processors configured,
-	  and <c>SchedulersOnline</c> will default to logical processors
-	  available; otherwise, the default values will be 1. <c>Schedulers</c>
-	  may be omitted if <c>:SchedulerOnline</c> is not and vice versa. The
-	  amount of schedulers online can be changed at run time via
+        <p>Sets the number of scheduler threads to create and scheduler
+	  threads to set online when SMP support has been enabled. The maximum for
+	  both values is 1024. If the Erlang runtime system is able to determine the
+	  amount of logical processors configured and logical processors available,
+	  <c>Schedulers</c> will default to logical processors configured, and
+	  <c>SchedulersOnline</c> will default to logical processors available;
+	  otherwise, the default values will be 1. <c>Schedulers</c> may be omitted
+	  if <c>:SchedulerOnline</c> is not and vice versa. The number of schedulers
+	  online can be changed at run time via
 	  <seealso marker="erlang#system_flag_schedulers_online">erlang:system_flag(schedulers_online, SchedulersOnline)</seealso>.
 	</p>
-        <p>This flag will be ignored if the emulator doesn't have
+	<p>If <c>Schedulers</c> or <c>SchedulersOnline</c> is specified as a
+	  negative number, the value is subtracted from the default number of
+	  logical processors configured or logical processors available, respectively.
+	</p>
+	<p>Specifying the value 0 for <c>Schedulers</c> or <c>SchedulersOnline</c>
+	  resets the number of scheduler threads or scheduler threads online respectively
+	  to its default value.
+	</p>
+        <p>This option is ignored if the emulator doesn't have
+          SMP support enabled (see the <seealso marker="#smp">-smp</seealso>
+          flag).</p>
+      </item>
+      <tag><marker id="+SP"><c><![CDATA[+SP SchedulersPercentage:SchedulersOnlinePercentage]]></c></marker></tag>
+      <item>
+        <p>Similar to <seealso marker="#+S">+S</seealso> but uses percentages to set the
+	  number of scheduler threads to create, based on logical processors configured,
+	  and scheduler threads to set online, based on logical processors available, when
+	  SMP support has been enabled. Specified values must be greater than 0. For example,
+	  <c>+SP 50:25</c> sets the number of scheduler threads to 50% of the logical processors
+	  configured and the number of scheduler threads online to 25% of the logical processors available.
+	  <c>SchedulersPercentage</c> may be omitted if <c>:SchedulersOnlinePercentage</c> is
+	  not and vice versa. The number of schedulers online can be changed at run time via
+	  <seealso marker="erlang#system_flag_schedulers_online">erlang:system_flag(schedulers_online, SchedulersOnline)</seealso>.
+	</p>
+	<p>This option interacts with <seealso marker="#+S">+S</seealso> settings.
+	  For example, on a system with 8 logical cores configured and 8 logical cores
+	  available, the combination of the options <c>+S 4:4 +SP 50:25</c> (in either order)
+	  results in 2 scheduler threads (50% of 4) and 1 scheduler thread online (25% of 4).
+	</p>
+        <p>This option is ignored if the emulator doesn't have
           SMP support enabled (see the <seealso marker="#smp">-smp</seealso>
           flag).</p>
       </item>

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -803,13 +803,25 @@ int main(int argc, char **argv)
 		  case 'n':
 		  case 'P':
 		  case 'Q':
-		  case 'S':
 		  case 't':
 		  case 'T':
 		  case 'R':
 		  case 'W':
 		  case 'K':
 		      if (argv[i][2] != '\0')
+			  goto the_default;
+		      if (i+1 >= argc)
+			  usage(argv[i]);
+		      argv[i][0] = '-';
+		      add_Eargs(argv[i]);
+		      add_Eargs(argv[i+1]);
+		      i++;
+		      break;
+		  case 'S':
+		      if (argv[i][2] == 'P') {
+			  if (argv[i][3] != '\0')
+			      goto the_default;
+		      } else if (argv[i][2] != '\0')
 			  goto the_default;
 		      if (i+1 >= argc)
 			  usage(argv[i]);
@@ -1119,7 +1131,9 @@ usage_aux(void)
 	  "[+l] [+M<SUBSWITCH> <ARGUMENT>] [+P MAX_PROCS] [+Q MAX_PORTS] "
 	  "[+R COMPAT_REL] "
 	  "[+r] [+rg READER_GROUPS_LIMIT] [+s SCHEDULER_OPTION] "
-	  "[+S NO_SCHEDULERS:NO_SCHEDULERS_ONLINE] [+T LEVEL] [+V] [+v] "
+	  "[+S NO_SCHEDULERS:NO_SCHEDULERS_ONLINE] "
+	  "[+SP PERCENTAGE_SCHEDULERS:PERCENTAGE_SCHEDULERS_ONLINE] "
+	  "[+T LEVEL] [+V] [+v] "
 	  "[+W<i|w>] [+z MISC_OPTION] [args ...]\n");
   exit(1);
 }


### PR DESCRIPTION
For applications where measurements show enhanced performance from the use
of a non-default number of emulator scheduler threads, having to accurately
set the right number of scheduler threads across multiple hosts each with
different numbers of logical processors is difficult because the erl +S
option requires absolute numbers of scheduler threads and scheduler threads
online to be specified.

To address this issue, add a +SP option to erl, similar to the existing +S
option but allowing the number of scheduler threads and scheduler threads
online to be set as percentages of logical processors configured and
logical processors available, respectively. For example, "+SP 50:25" sets
the number of scheduler threads to 50% of the logical processors
configured, and the number of scheduler threads online to 25% of the
logical processors available. For ease of scripting, the +SP option also
takes into account any settings from +S options preceding it on the command
line.

Add documentation for the +SP option.

Add tests for the +SP option to scheduler_SUITE.
