### PR TITLE
Export type zlib:zstream/0

### DIFF
--- a/erts/preloaded/src/zlib.erl
+++ b/erts/preloaded/src/zlib.erl
@@ -30,6 +30,8 @@
 	 compress/1,uncompress/1,zip/1,unzip/1,
 	 gzip/1,gunzip/1]).
 
+-export_type([zstream/0]).
+
 %% flush argument encoding
 -define(Z_NO_FLUSH,      0).
 -define(Z_SYNC_FLUSH,    2).


### PR DESCRIPTION
Terms of this type are returned and sometimes sit in states.
Exporting it allows us to properly track the types there.
