### PR TITLE
Fix decoding of numbers that are encoded as an odd number of bytes.

### DIFF
--- a/lib/erl_interface/src/decode/decode_big.c
+++ b/lib/erl_interface/src/decode/decode_big.c
@@ -55,6 +55,9 @@ int ei_decode_big(const char *buf, int *index, erlang_big *b) {
 		dt[i] |= ((unsigned short) s[(i*2)+1]) << 8;
 	    }
 	}
+	if (digit_bytes & 1)
+	  // mask out the high byte if the input is an odd number of digits
+	  dt[i-1] &= 0xff;
     } else {
 	s++; /* skip sign byte */
     }


### PR DESCRIPTION
When a number is encoded as ERL_SMALL_BIG_EXT and the external
representation is an odd number of bytes it may be incorrectly decoded
by ei_decode_big.

An example of such an encoded number is:

Eshell V5.10.2  (abort with ^G)
1> term_to_binary(4297024617).
<<131,110,5,0,105,100,31,0,1>>

I tried to make a test for this using the published APIs (ie. not ei_decode_big directly) but since the bug depends on the values in the unused part of the dt arrary I did not succeed. We came across this bug in a production system where a linked-in driver was using erl_compare_ext and the results were not consistently correct.
