### PR TITLE
Fix location of true binary under Mac OSX

### DIFF
--- a/lib/erl_interface/test/ei_decode_encode_SUITE.erl
+++ b/lib/erl_interface/test/ei_decode_encode_SUITE.erl
@@ -68,6 +68,8 @@ test_ei_decode_encode(Config) when is_list(Config) ->
     Port  = case os:type() of
 		{win32,_} ->
 		    open_port({spawn,"sort"},[]);
+		{unix, darwin} ->
+		    open_port({spawn,"/usr/bin/true"},[]);
 		_ ->
 		    open_port({spawn,"/bin/true"},[])
 	    end,


### PR DESCRIPTION
Trivial fix for location of the true binary under OSX. The fault doesn't cause the test to fail but does result in the following terminal output:

sh: /bin/true: No such file or directory
sh: line 0: exec: /bin/true: cannot execute: No such file or directory
