### PR TITLE
Test nocache option of mod_cgi and mod_esi

### DIFF
--- a/lib/inets/test/Makefile
+++ b/lib/inets/test/Makefile
@@ -215,7 +215,7 @@ INETS_FILES = inets.config $(INETS_SPECS)
 # 	inets_tftp_suite
 
 INETS_DATADIRS = inets_SUITE_data inets_sup_SUITE_data 
-HTTPD_DATADIRS = httpd_test_data httpd_SUITE_data
+HTTPD_DATADIRS = httpd_test_data httpd_SUITE_data httpd_basic_SUITE_data
 HTTPC_DATADIRS = httpc_SUITE_data httpc_proxy_SUITE_data
 FTP_DATADIRS   = ftp_SUITE_data  
 

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -1919,7 +1919,7 @@ ticket_5865(Config) ->
 					       " HTTP/1.1\r\nHost:"
 					       ++Host++"\r\n\r\n", 
 					       [{statuscode, 200},
-						{no_last_modified,
+						{no_header,
 						 "last-modified"}]),
 	    ok;
 	{error, Reason} ->

--- a/lib/inets/test/httpd_basic_SUITE.erl
+++ b/lib/inets/test/httpd_basic_SUITE.erl
@@ -19,6 +19,7 @@
 %%
 -module(httpd_basic_SUITE).
 
+-include_lib("kernel/include/file.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include("inets_test_lib.hrl").
 
@@ -34,6 +35,7 @@ all() ->
     [
      uri_too_long_414, 
      header_too_long_413, 
+     script_nocache,
      escaped_url_in_error_body,
      slowdose
     ].
@@ -62,6 +64,7 @@ init_per_suite(Config) ->
 	"~n   Config: ~p", [Config]),
     ok = inets:start(),
     PrivDir = ?config(priv_dir, Config),
+    DataDir = ?config(data_dir, Config), 
 
     Dummy = 
 "<HTML>
@@ -74,6 +77,18 @@ DUMMY
 </HTML>",
 
     DummyFile = filename:join([PrivDir,"dummy.html"]),
+    CgiDir =  filename:join(PrivDir, "cgi-bin"),
+    ok = file:make_dir(CgiDir),
+    Cgi = case test_server:os_type() of
+	      {win32, _} ->
+		  "printenv.bat";
+	      _ ->
+		  "printenv.sh"
+	  end,
+    inets_test_lib:copy_file(Cgi, DataDir, CgiDir),
+    AbsCgi = filename:join([CgiDir, Cgi]),
+    {ok, FileInfo} = file:read_file_info(AbsCgi),
+    ok = file:write_file_info(AbsCgi, FileInfo#file_info{mode = 8#00755}),
     {ok, Fd}  = file:open(DummyFile, [write]),
     ok        = file:write(Fd, Dummy),
     ok        = file:close(Fd), 
@@ -84,7 +99,7 @@ DUMMY
 		 {document_root, PrivDir}, 
 		 {bind_address,  "localhost"}],
 
-    [{httpd_conf, HttpdConf} |  Config].
+    [{httpd_conf, HttpdConf}, {cgi_dir, CgiDir}, {cgi_script, Cgi} |  Config].
 
 %%--------------------------------------------------------------------
 %% Function: end_per_suite(Config) -> _
@@ -178,6 +193,52 @@ header_too_long_413(Config) when is_list(Config) ->
  				        {version, "HTTP/1.1"}]),
     inets:stop(httpd, Pid).
    
+
+%%-------------------------------------------------------------------------
+%%-------------------------------------------------------------------------
+
+script_nocache(doc) ->
+    ["Test nocache option for mod_cgi and mod_esi"];
+script_nocache(suite) ->
+    [];
+script_nocache(Config) when is_list(Config) ->
+    Normal = {no_header, "cache-control"},
+    NoCache = {header, "cache-control", "no-cache"},
+    verify_script_nocache(Config, false, false, Normal, Normal),
+    verify_script_nocache(Config, true, false, NoCache, Normal),
+    verify_script_nocache(Config, false, true, Normal, NoCache),
+    verify_script_nocache(Config, true, true, NoCache, NoCache),
+    ok.
+
+verify_script_nocache(Config, CgiNoCache, EsiNoCache, CgiOption, EsiOption) ->
+    HttpdConf = ?config(httpd_conf, Config),
+    CgiScript = ?config(cgi_script, Config),
+    CgiDir = ?config(cgi_dir, Config),
+    {ok, Pid} = inets:start(httpd, [{port, 0},
+				    {script_alias,
+				     {"/cgi-bin/", CgiDir ++ "/"}},
+				    {script_nocache, CgiNoCache},
+				    {erl_script_alias,
+				     {"/cgi-bin/erl", [httpd_example,io]}},
+				    {erl_script_nocache, EsiNoCache}
+				    | HttpdConf]),
+    Info = httpd:info(Pid),
+    Port = proplists:get_value(port, Info),
+    Address = proplists:get_value(bind_address, Info),
+    ok = httpd_test_lib:verify_request(ip_comm, Address, Port, node(),
+				       "GET /cgi-bin/" ++ CgiScript ++
+					   " HTTP/1.0\r\n\r\n",
+				       [{statuscode, 200},
+					CgiOption,
+					{version, "HTTP/1.0"}]),
+    ok = httpd_test_lib:verify_request(ip_comm, Address, Port, node(),
+				       "GET /cgi-bin/erl/httpd_example:get "
+				       "HTTP/1.0\r\n\r\n",
+				       [{statuscode, 200},
+					EsiOption,
+					{version, "HTTP/1.0"}]),
+    inets:stop(httpd, Pid).
+
 
 %%-------------------------------------------------------------------------
 %%-------------------------------------------------------------------------

--- a/lib/inets/test/httpd_basic_SUITE_data/printenv.bat
+++ b/lib/inets/test/httpd_basic_SUITE_data/printenv.bat
@@ -1,0 +1,1 @@
+../httpd_SUITE_data/server_root/cgi-bin/printenv.bat

--- a/lib/inets/test/httpd_basic_SUITE_data/printenv.sh
+++ b/lib/inets/test/httpd_basic_SUITE_data/printenv.sh
@@ -1,0 +1,1 @@
+../httpd_SUITE_data/server_root/cgi-bin/printenv.sh

--- a/lib/inets/test/httpd_mod.erl
+++ b/lib/inets/test/httpd_mod.erl
@@ -842,6 +842,14 @@ cgi(Type, Port, Host, Node) ->
 				       {version, "HTTP/1.0"}]),
 
 %%     tsp("cgi -> done"),
+
+    %% Check "ScriptNoCache" directive (default: false)
+    ok = httpd_test_lib:verify_request(Type, Host, Port, Node,
+				       "GET /cgi-bin/" ++ Script ++
+				       " HTTP/1.0\r\n\r\n",
+				       [{statuscode, 200},
+					{no_header, "cache-control"},
+					{version, "HTTP/1.0"}]),
     ok.
 
 
@@ -898,6 +906,13 @@ esi(Type, Port, Host, Node) ->
 					"GET /cgi-bin/erl/httpd_example/yahoo"
 					" HTTP/1.0\r\n\r\n",
 					[{statuscode, 302},
+					{version, "HTTP/1.0"}]),
+    %% Check "ErlScriptNoCache" directive (default: false)
+    ok = httpd_test_lib:verify_request(Type, Host, Port, Node,
+				       "GET /cgi-bin/erl/httpd_example:get"
+				       " HTTP/1.0\r\n\r\n",
+				       [{statuscode, 200},
+					{no_header, "cache-control"},
 					{version, "HTTP/1.0"}]),
     ok.
 

--- a/lib/inets/test/httpd_test_lib.erl
+++ b/lib/inets/test/httpd_test_lib.erl
@@ -361,7 +361,7 @@ do_validate(Header, [{header, HeaderField, Value}|Rest],N,P) ->
 	    tsf({wrong_header_field_value, LowerHeaderField, Header})
     end,
     do_validate(Header, Rest, N, P);
-do_validate(Header,[{no_last_modified, HeaderField}|Rest],N,P) ->
+do_validate(Header,[{no_header, HeaderField}|Rest],N,P) ->
     case lists:keysearch(HeaderField,1,Header) of
 	{value,_} ->
 	    tsf({wrong_header_field_value, HeaderField, Header});


### PR DESCRIPTION
Tests that the nocache options work and can be used independently from
each other. This was broken before c8ef69c.

http://erlang.org/pipermail/erlang-patches/2013-August/004226.html
