### PR TITLE
Parsetools fix unicode leex

### DIFF
--- a/lib/parsetools/src/leex.erl
+++ b/lib/parsetools/src/leex.erl
@@ -491,7 +491,7 @@ parse_rules_end(_, NextLine, REAs, As, St) ->
 
 collect_rule(Ifile, Chars, L0) ->
     %% Erlang strings are 1 based, but re 0 :-(
-    {match,[{St0,Len}|_]} = re:run(Chars, "[^ \t\r\n]+"),
+    {match,[{St0,Len}|_]} = re:run(Chars, "[^ \t\r\n]+", [unicode]),
     St = St0 + 1,
     %%io:fwrite("RE = ~p~n", [substr(Chars, St, Len)]),
     case collect_action(Ifile, substr(Chars, St+Len), L0, []) of
@@ -548,7 +548,7 @@ var_used(Name, Toks) ->
 %% here as it uses info in replace string (&).
 
 parse_rule_regexp(RE0, [{M,Exp}|Ms], St) ->
-    Split= re:split(RE0, "\\{" ++ M ++ "\\}", [{return,list}]),
+    Split= re:split(RE0, "\\{" ++ M ++ "\\}", [{return,list},unicode]),
     RE1 = string:join(Split, Exp),
     parse_rule_regexp(RE1, Ms, St);
 parse_rule_regexp(RE, [], St) ->


### PR DESCRIPTION
```
%% -*- coding: utf-8 -*-
Definitions.
RTLarrow    = (←)
Rules.
{RTLarrow}  : {token,{'<-',TokenLine}}.
Erlang code.
```

This code would either not work as intended (which is build a lexer capable of recognizing a unicode arrow)
or crash at compile time.

An error was thrown when compiling this code (put inside lexer.xrl):

```
unexpected error compiling src/lexer.xrl
{'EXIT',{badarg,[{re,run,
                     [[83,121,109,98,111,108,32,32,32,32,32,32,61,32,40,91,36,
                       163,8364,93,124,91,60,62,61,93,41,10],
                      "^[ \t]*([A-Z_][A-Za-z0-9_]*)[ \t]*=[ \t]*([^ \t\r\n]*)[ \t\r\n]*$",
                      [{capture,all_but_first,list}]],
                     []},
                 {leex,parse_defs,4,[{file,"leex.erl"},{line,439}]},
                 {leex,parse_file,1,[{file,"leex.erl"},{line,407}]},
                 {leex,file,2,[{file,"leex.erl"},{line,112}]},
                 {rebar_erlc_compiler,compile_xrl_yrl,5,
                                      [{file,"src/rebar_erlc_compiler.erl"},
                                       {line,429}]},
                 {rebar_base_compiler,compile,3,
                                      [{file,"src/rebar_base_compiler.erl"},
                                       {line,121}]},
                 {rebar_base_compiler,compile_worker,3,
                                      [{file,"src/rebar_base_compiler.erl"},
                                       {line,194}]}]}}
```

This commit fixes said error and enables Erlang's Leex to build lexers for Unicode languages.
