### PR TITLE
Fix incorrect values returned by integer_to_binary/2

### DIFF
--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -350,11 +350,33 @@ t_integer_to_string(Config) when is_list(Config) ->
 			      (catch erlang:integer_to_list(Value))
 		  end,[atom,1.2,0.0,[$1,[$2]]]),
 
+    %% Base-2 integers
+    test_its("0", 0, 2),
+    test_its("1", 1, 2),
+    test_its("110110", 54, 2),
+    test_its("-1000000", -64, 2),
+    %% Base-16 integers
+    test_its("0", 0, 16),
+    test_its("A", 10, 16),
+    test_its("D4BE", 54462, 16),
+    test_its("-D4BE", -54462, 16),
+
+    lists:foreach(fun(Value) ->
+			  {'EXIT', {badarg, _}} =
+			      (catch erlang:integer_to_binary(Value, 8)),
+			  {'EXIT', {badarg, _}} =
+			      (catch erlang:integer_to_list(Value, 8))
+		  end,[atom,1.2,0.0,[$1,[$2]]]),
+
     ok.
 
 test_its(List,Int) ->
     Int = list_to_integer(List),
     Int = binary_to_integer(list_to_binary(List)).
+
+test_its(List,Int,Base) ->
+    Int = list_to_integer(List, Base),
+    Int = binary_to_integer(list_to_binary(List), Base).
 
 %% Tests binary_to_integer/1.
 

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2891,22 +2891,23 @@ integer_to_binary(I, Base)
   when erlang:is_integer(I), erlang:is_integer(Base),
        Base >= 2, Base =< 1+$Z-$A+10 ->
     if I < 0 ->
-	    <<"$-",(integer_to_binary(-I, Base, []))/binary>>;
+	    <<$-,(integer_to_binary(-I, Base, <<>>))/binary>>;
        true ->
 	    integer_to_binary(I, Base, <<>>)
     end;
 integer_to_binary(I, Base) ->
     erlang:error(badarg, [I, Base]).
 
-integer_to_binary(0, _Base, R0) ->
-    R0;
 integer_to_binary(I0, Base, R0) ->
     D = I0 rem Base,
     I1 = I0 div Base,
-    if D >= 10 ->
-	    integer_to_binary(I1,Base,<<(D-10+$A),R0/binary>>);
-       true ->
-	    integer_to_binary(I1,Base,<<(D+$0),R0/binary>>)
+    R1 = if
+             D >= 10 -> <<(D-10+$A),R0/binary>>;
+             true -> <<(D+$0),R0/binary>>
+         end,
+    if
+        I1 =:= 0 -> R1;
+        true -> integer_to_binary(I1, Base, R1)
     end.
 
 %% erlang:flush_monitor_message/2 is for internal use only!


### PR DESCRIPTION
When `integer_to_binary/2` receives 0 or a negative number as an argument
with a base that is different from 10, it will return incorrect values
(`<<>>` in the case of 0) or it will crash (with negative numbers). This
commit fixes these problems and adds tests to cover these cases.
