### PR TITLE
Take compiler options from beam in cover:compile_beam

### DIFF
--- a/lib/tools/test/cover_SUITE.erl
+++ b/lib/tools/test/cover_SUITE.erl
@@ -28,7 +28,7 @@
 	 export_import/1,
 	 otp_5031/1, eif/1, otp_5305/1, otp_5418/1, otp_6115/1, otp_7095/1,
          otp_8188/1, otp_8270/1, otp_8273/1, otp_8340/1,
-	 otp_10979_hanging_node/1]).
+	 otp_10979_hanging_node/1, compile_beam_opts/1]).
 
 -include_lib("test_server/include/test_server.hrl").
 
@@ -53,7 +53,7 @@ all() ->
 	     dont_reconnect_after_stop, stop_node_after_disconnect,
 	     export_import, otp_5031, eif, otp_5305, otp_5418,
 	     otp_6115, otp_7095, otp_8188, otp_8270, otp_8273,
-	     otp_8340, otp_10979_hanging_node];
+	     otp_8340, otp_10979_hanging_node, compile_beam_opts];
 	_pid ->
 	    {skip,
 	     "It looks like the test server is running "
@@ -1398,6 +1398,51 @@ otp_10979_hanging_node(_Config) ->
 	    [io:format("New: ~p, ~p~n",[P,process_info(P)]) || P<-New],
 	    ct:fail(hanging_process)
     end,
+
+    ok.
+
+compile_beam_opts(doc) ->
+    ["Take compiler options from beam in cover:compile_beam"];
+compile_beam_opts(suite) -> [];
+compile_beam_opts(Config) when is_list(Config) ->
+    ?line ok = file:set_cwd(?config(priv_dir, Config)),
+    ?line IncDir = filename:join(?config(data_dir, Config),
+                                 "included_functions"),
+    File = "t.erl",
+    Test = <<"-module(t).
+             -export([exported/0]).
+             -include(\"cover_inc.hrl\").
+             -ifdef(BOOL).
+             macro() ->
+                 ?MACRO.
+             -endif.
+             exported() ->
+                 ok.
+             nonexported() ->
+                 ok.
+             ">>,
+    ?line ok = file:write_file(File, Test),
+    %% use all compiler options allowed by cover:filter_options
+    %% i and d don't make sense when compiling from beam though
+    ?line {ok, t} =
+        compile:file(File, [{i, IncDir},
+                            {d, 'BOOL'},
+                            {d, 'MACRO', macro_defined},
+                            export_all,
+                            debug_info,
+                            return_errors]),
+    Exports =
+        [{func1,0},
+         {macro, 0},
+         {exported,0},
+         {nonexported,0},
+         {module_info,0},
+         {module_info,1}],
+    ?line Exports = t:module_info(exports),
+    ?line {ok, t} = cover:compile_beam("t"),
+    ?line Exports = t:module_info(exports),
+    ?line cover:stop(),
+    ?line ok = file:delete(File),
 
     ok.
 


### PR DESCRIPTION
Similarly to cover compiling from source
(in this case some user specified compiler options are allowed)
when cover compiling from existing beam
take a filtered list of compiler options from the beamfile.
This way e.g. export_all can be preserved. See use case in eb02beb1c3
