### PR TITLE
Fix inconsistency in free_memory value on Linux platforms

### DIFF
--- a/lib/os_mon/c_src/memsup.c
+++ b/lib/os_mon/c_src/memsup.c
@@ -442,7 +442,9 @@ get_basic_mem(unsigned long *tot, unsigned long *used, unsigned long *pagesize){
     }
     *tot      = me.total;
     *pagesize = me.pagesize;
-    *used     = me.total - me.free;
+    *used     = me.total - me.free
+      + (me.flag & F_MEM_BUFFERS ? me.buffered : 0)
+      + (me.flag & F_MEM_CACHED  ? me.cached   : 0);
 #elif defined(BSD4_4)
     struct vmtotal vt;
     long pgsz;

--- a/lib/os_mon/doc/src/memsup.xml
+++ b/lib/os_mon/doc/src/memsup.xml
@@ -209,8 +209,8 @@
         <p>Returns the empty list [] if <c>memsup</c> is not available,
           or if the memory check times out.</p>
 	<note><p>
-	On linux the memory available to the emulator is <c>cached_memory</c> and <c>buffered_memory</c> in addition to 
-	<c>free_memory</c>.</p>
+	  On linux the memory available to the emulator in <c>free_memory</c>
+	  includes <c>cached_memory</c> and <c>buffered_memory</c>.</p>
 	</note>
       </desc>
     </func>


### PR DESCRIPTION
Since this didn't get any comment on erlang_bugs, I'm submitting it as a pull request.

The documentation for memsup:get_system_memory_data() states the
free_memory element contains the "amount of free memory available to
the Erlang emulator for allocation". However later a note states that
this is not true for Linux.

This patch corrects the inconsistency by adding the memory allocated by
kernel buffers and caches back to the kernel "free" value. It also
modifies the note to the effect that these value are included in
free_memory.

With this patch, a user application that monitors and/or reports free
memory can rely on the meaning of free_memory to be consistent across
deployed platforms.
