### PR TITLE
Fix I/O-protocol error handling in eunit

### DIFF
--- a/lib/eunit/src/eunit_proc.erl
+++ b/lib/eunit/src/eunit_proc.erl
@@ -643,11 +643,11 @@ io_request({get_until, _Prompt, _M, _F, _As}, Buf) ->
 io_request({setopts, _Opts}, Buf) ->
     {ok, Buf};
 io_request(getopts, Buf) ->
-    {error, {error, enotsup}, Buf};
+    {{error, enotsup}, Buf};
 io_request({get_geometry,columns}, Buf) ->
-    {error, {error, enotsup}, Buf};
+    {{error, enotsup}, Buf};
 io_request({get_geometry,rows}, Buf) ->
-    {error, {error, enotsup}, Buf};
+    {{error, enotsup}, Buf};
 io_request({requests, Reqs}, Buf) ->
     io_requests(Reqs, {ok, Buf});
 io_request(_, Buf) ->
@@ -657,3 +657,10 @@ io_requests([R | Rs], {ok, Buf}) ->
     io_requests(Rs, io_request(R, Buf));
 io_requests(_, Result) ->
     Result.
+
+-ifdef(TEST).
+io_error_test_() ->
+    [?_assertMatch({error, enotsup}, io:getopts()),
+     ?_assertMatch({error, enotsup}, io:columns()),
+     ?_assertMatch({error, enotsup}, io:rows())].
+-endif.


### PR DESCRIPTION
Some io_requests, getopts, {get_geometry, rows} and {get_geometry, columns}
in eunit raises unexpected error.

For example,

``` erlang
-module(my_test).
-include_lib("eunit/include/eunit.hrl").

my_test() ->
  io:getopts().
```

``` erlang
1> c(my_test).
{ok,my_test}
2> eunit:test(my_test).
my_test: my_test (module 'my_test')...*skipped*
undefined
*unexpected termination of test process*
::{{badmatch,{error,{error,enotsup},[]}},
   [{eunit_proc,io_request,4,[{file,"eunit_proc.erl"},{line,614}]},
    {eunit_proc,group_leader_loop,3,[{file,"eunit_proc.erl"},{line,584}]}]}

=======================================================
  Failed: 0.  Skipped: 0.  Passed: 0.
One or more tests were cancelled.
error

=ERROR REPORT==== 21-Sep-2013::19:49:27 ===
Error in process <0.49.0> with exit value: {{badmatch,{error,{error,enotsup},[]}},[{eunit_proc,io_request,4,[{file,"eunit_proc.erl"},{line,614}]},{eunit_proc,group_leader_loop,3,[{file,"eunit_proc.erl"},{line,584}]}]}
```
