### PR TITLE
Check all pattern arguments passed to binary:matches/2

### DIFF
--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -927,6 +927,9 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
 	    if (binary_bitsize(b) != 0) {
 		goto badarg;
 	    }
+	    if (binary_size(b) == 0) {
+		goto badarg;
+	    }
 	    ++words;
 	    characters += binary_size(b);
 	}


### PR DESCRIPTION
Including an empty binary as one of multiple patterns passed to
binary:matches/2 would crash BEAM with: "Cannot reallocate
1342177280 bytes of memory (of type "tmp")". This ensures each pattern
is valid before trying to match.
