### PR TITLE
enable SNMP to create missing database directories

### DIFF
--- a/lib/snmp/doc/src/snmp_app.xml
+++ b/lib/snmp/doc/src/snmp_app.xml
@@ -763,12 +763,15 @@
       </item>
 
       <marker id="db_init_error"></marker>
-      <tag><c>db_init_error() = terminate | create</c></tag>
+      <tag><c>db_init_error() = terminate | create | create_db_and_dir</c></tag>
       <item>
         <p>Defines what to do if the agent or manager is unable to open an
           existing database file. <c>terminate</c> means that the
           agent/manager will terminate and <c>create</c> means that the 
-          agent/manager will remove the faulty file(s) and create new ones.</p>
+          agent/manager will remove the faulty file(s) and create new ones,
+          and <c>create_db_and_dir</c> means that the agent/manager will
+          create the database file along with any missing parent directories
+          for the database file.</p>
         <p>Default is <c>terminate</c>.</p>
       </item>
 

--- a/lib/snmp/doc/src/snmp_config.xml
+++ b/lib/snmp/doc/src/snmp_config.xml
@@ -792,12 +792,15 @@ in so far as it will be converted to the new format if found.
       </item>
 
       <marker id="db_init_error"></marker>
-      <tag><c>db_init_error() = terminate | create</c></tag>
+      <tag><c>db_init_error() = terminate | create | create_db_and_dir</c></tag>
       <item>
         <p>Defines what to do if the agent is unable to open an
           existing database file. <c>terminate</c> means that the
-          agent/manager will terminate and <c>create</c> means that the 
-          agent/manager will remove the faulty file(s) and create new ones.</p>
+          agent/manager will terminate, <c>create</c> means that the 
+          agent/manager will remove the faulty file(s) and create new ones,
+          and <c>create_db_and_dir</c> means that the agent/manager will
+          create the database file along with any missing parent directories
+          for the database file.</p>
         <p>Default is <c>terminate</c>.</p>
       </item>
 

--- a/lib/snmp/src/agent/snmpa_local_db.erl
+++ b/lib/snmp/src/agent/snmpa_local_db.erl
@@ -191,6 +191,12 @@ dets_open(DbDir, DbInitError, Opts) ->
 		    end
 	    end;
 	_ ->
+	    case DbInitError of
+		create_db_and_dir ->
+		    ok = filelib:ensure_dir(Filename);
+		_ ->
+		    ok
+	    end,
 	    case do_dets_open(Name, Filename, Opts) of
 		{ok, Dets} ->
 		    ?vdebug("dets open done",[]),

--- a/lib/snmp/src/agent/snmpa_supervisor.erl
+++ b/lib/snmp/src/agent/snmpa_supervisor.erl
@@ -356,7 +356,7 @@ init([AgentType, Opts]) ->
     SymStoreSpec = 
 	worker_spec(snmpa_symbolic_store, SymStoreArgs, Restart, 2000),
 
-    LdbArgs = [Prio, DbDir, LdbOpts],
+    LdbArgs = [Prio, DbDir, DbInitError, LdbOpts],
     LocalDbSpec = 
 	worker_spec(snmpa_local_db, LdbArgs, Restart, 5000),
 


### PR DESCRIPTION
Add {db_init_error, create_db_and_dir} option to SNMP manager and
agent. This allows them to create any missing parent directories for
db_dir, rather than treating any missing directories as a fatal error.

The default for db_init_error, which is terminate, is unchanged.

Add create_db_and_dir to the documentation.

Add new tests to verify that using create_db_and_dir results in missing
parent directories being created.
