### PR TITLE
Use the gen_sctp:option/0 type in the diameter_sctp module

### DIFF
--- a/lib/diameter/src/transport/diameter_sctp.erl
+++ b/lib/diameter/src/transport/diameter_sctp.erl
@@ -70,14 +70,14 @@
 
 -type connect_option() :: {raddr, inet:ip_address()}
                         | {rport, inet:port_number()}
-                        | gen_sctp:open_option().
+                        | gen_sctp:option().
 
 -type match() :: inet:ip_address()
                | string()
                | [match()].
 
 -type listen_option() :: {accept, match()}
-                       | gen_sctp:open_option().
+                       | gen_sctp:option().
 
 -type uint() :: non_neg_integer().
 


### PR DESCRIPTION
The `diameter_sctp` module uses the `gen_sctp:open_option/0` type, but its
correct name is `gen_sctp:option/0`.
