### PR TITLE
Avoid serialization on code_server in xmerl:export()

### DIFF
--- a/lib/xmerl/src/xmerl.erl
+++ b/lib/xmerl/src/xmerl.erl
@@ -303,18 +303,17 @@ apply_tag_cb(Ms, F, Args) ->
     apply_cb(Ms, F, '#element#', Args).
 
 apply_cb(Ms, F, Df, Args) ->
-    apply_cb(Ms, F, Df, Args, Ms).
+    apply_cb(Ms, F, Df, Args, length(Args)).
 
-apply_cb([M|Ms], F, Df, Args, Ms0) ->
-    case catch apply(M, F, Args) of
-	{'EXIT', {undef,[{M,F,_,_}|_]}} ->
-	    apply_cb(Ms, F, Df, Args, Ms0);
-	{'EXIT', Reason} ->
-	    exit(Reason);
-	Res ->
-	    Res
+apply_cb(Ms, F, Df, Args, A) ->
+    apply_cb(Ms, F, Df, Args, A, Ms).
+
+apply_cb([M|Ms], F, Df, Args, A, Ms0) ->
+    case erlang:function_exported(M, F, A) of
+        true -> apply(M, F, Args);
+        false -> apply_cb(Ms, F, Df, Args, A, Ms0)
     end;
-apply_cb([], Df, Df, Args, _Ms0) ->
+apply_cb([], Df, Df, Args, A, _Ms0) ->
     exit({unknown_tag, {Df, Args}});
-apply_cb([], F, Df, Args, Ms0) ->
-    apply_cb(Ms0, Df, Df, [F|Args]).
+apply_cb([], F, Df, Args, A, Ms0) ->
+    apply_cb(Ms0, Df, Df, [F|Args], A+1).


### PR DESCRIPTION
The inheritance mechanism in xmerl used to use 'catch apply(M,F,Args)' to
try different modules M until one was found that had a function F/A.
However, when M:F/A does not exist, apply/3 will trap to
error_handler:undefined_function/3, which will call code:ensure_loaded(M),
making a synchronous request to the code server process. If many processes
tried to use xmerl:export() concurrently, they would get serialized waiting
for the code server process. This patch uses erlang:function_exported/3
instead to check if M:F/A exists. If M exists, it should already have been
loaded at that point due to the inheritance checking in the
xmerl:callbacks/1 function.
