### PR TITLE
Allow forced autoredirect to match the convenience available in other languages.

### DIFF
--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -97,9 +97,21 @@ result(Response = {{_,100,_}, _, _}, Request) ->
 %% In redirect loop
 result(Response = {{_, Code, _}, _, _}, Request =
        #request{redircount = Redirects,
+		settings = #http_options{autoredirect = force}}) 
+  when ((Code div 100) =:= 3) andalso (Redirects > ?HTTP_MAX_REDIRECTS) ->
+    transparent(Response, Request);
+result(Response = {{_, Code, _}, _, _}, Request =
+       #request{redircount = Redirects,
 		settings = #http_options{autoredirect = true}}) 
   when ((Code div 100) =:= 3) andalso (Redirects > ?HTTP_MAX_REDIRECTS) ->
     transparent(Response, Request);
+
+%% force redirect no matter which 30X code we receive
+result(Response = _, 
+       Request = #request{settings = 
+              #http_options{autoredirect = 
+                    force}}) ->
+    redirect(Response, Request);
 
 %% multiple choices 
 result(Response = {{_, 300, _}, _, _}, 

--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -106,7 +106,13 @@ result(Response = {{_, Code, _}, _, _}, Request =
   when ((Code div 100) =:= 3) andalso (Redirects > ?HTTP_MAX_REDIRECTS) ->
     transparent(Response, Request);
 
-%% force redirect no matter which 30X code we receive
+%% force redirect no matter which 30X code we receive 
+%% but for POST, we change methods upon receiving 303
+result(Response = {{_, 303, _}, _, _},
+       Request = #request{settings =
+			  #http_options{autoredirect = force},
+			  method = post}) ->
+    redirect(Response, Request#request{method = get});
 result(Response = _, 
        Request = #request{settings = 
               #http_options{autoredirect = 


### PR DESCRIPTION
I understand the need for autoredirect to match the HTTP specification but sometimes users know they want to force redirect and it's a pain to keep reinventing the wheel by looking out for specific HTTP codes. This patch implements something that is already available in other languages. By setting autoredirect = force, we allow the user some convenience by always redirecting.