### PR TITLE
fix a little typo in public_key documentation

### DIFF
--- a/lib/public_key/doc/src/using_public_key.xml
+++ b/lib/public_key/doc/src/using_public_key.xml
@@ -350,7 +350,7 @@ ok</code>
 
     <p> or </p>
 
-    <code>1> PemBin = public_key:pem_entry_encode('SubjectPublicKeyInfo', RSAPubKey).
+    <code>1> PemEntry = public_key:pem_entry_encode('SubjectPublicKeyInfo', RSAPubKey).
 {'SubjectPublicKeyInfo', &lt;&lt;48,92...&gt;&gt;, not_encrypted}
 
 2> PemBin = public_key:pem_encode([PemEntry]).


### PR DESCRIPTION
In the example of `public_key:pem_entry_encode/2`, the result
should match to `PemEntry` rather than to `PemBin` since `PemEntry`
is expected as an input argument of `public_key:pem_encode/1` called
just on the next line of the example.
