### PR TITLE
Fix incorrect reporting of memory on OS X via memsup.

### DIFF
--- a/lib/os_mon/src/memsup.erl
+++ b/lib/os_mon/src/memsup.erl
@@ -721,20 +721,19 @@ reply(Pending, MemUsage, SysMemUsage) ->
 %% get_memory_usage(OS) -> {Alloc, Total}
 
 %% Darwin:
-%% Uses vm_stat command. This appears to lie about the page size in
-%% Mac OS X 10.2.2 - the pages given are based on 4000 bytes, but
-%% the vm_stat command tells us that it is 4096...
+%% Uses vm_stat command.
 get_memory_usage({unix,darwin}) ->
     Str1 = os:cmd("/usr/bin/vm_stat"),
-    
-    {[Free],     Str2} = fread_value("Pages free:~d.", Str1),
-    {[Active],   Str3} = fread_value("Pages active:~d.", Str2),
-    {[Inactive], Str4} = fread_value("Pages inactive:~d.", Str3),
-    {[_],        Str5} = fread_value("Pages speculative:~d.", Str4),
+    PageSize = 4096,
+
+    {[Free],        Str2} = fread_value("Pages free:~d.", Str1),
+    {[Active],      Str3} = fread_value("Pages active:~d.", Str2),
+    {[Inactive],    Str4} = fread_value("Pages inactive:~d.", Str3),
+    {[Speculative], Str5} = fread_value("Pages speculative:~d.", Str4),
     {[Wired],       _} = fread_value("Pages wired down:~d.", Str5),
 
-    NMemUsed  = (Wired + Active + Inactive) * 4000,
-    NMemTotal = NMemUsed + Free * 4000,
+    NMemUsed  = (Wired + Active + Inactive) * PageSize,
+    NMemTotal = NMemUsed + (Free + Speculative) * PageSize,
     {NMemUsed,NMemTotal};
 
 %% FreeBSD: Look in /usr/include/sys/vmmeter.h for the format of struct


### PR DESCRIPTION
Application memsup should be calculating free memory using the
speculative pages, in the same manner that the Activity Monitor and top
programs on OS X do.  In addition, correct page size to 4096, based on
verification of available memory between top, vm_stat and Activity
Monitor.

References:

http://superuser.com/questions/197059/mac-os-x-sysctl-get-total-and-free-memory-size
http://erlang.org/pipermail/erlang-questions/2009-March/042201.html
http://apple.stackexchange.com/questions/81581/why-does-free-active-inactive-speculative-wired-not-equal-total-ram
http://superuser.com/questions/197059/mac-os-x-sysctl-get-total-and-free-memory-size#comment200035_197086
