### PR TITLE
Fix race condition in mnesia_locker after nodedown for sticky_locks

### DIFF
--- a/lib/mnesia/src/mnesia_locker.erl
+++ b/lib/mnesia/src/mnesia_locker.erl
@@ -109,6 +109,20 @@ l_request(Node, X, Store) ->
     {?MODULE, Node} ! {self(), X},
     l_req_rec(Node, Store).
 
+l_req_rec_mon(Node, Store, MRef) ->
+    ?ets_insert(Store, {nodes, Node}),
+    receive
+	{?MODULE, Node, Reply} ->
+	    erlang:demonitor(MRef, [flush]),
+	    Reply;
+	{mnesia_down, Node} ->
+	    erlang:demonitor(MRef, [flush]),
+	    {not_granted, {node_not_running, Node}};
+	{'DOWN', MRef, _, _, _} ->
+	    %% Node not running
+	    {not_granted, {node_not_running, Node}}
+    end.
+
 l_req_rec(Node, Store) ->
     ?ets_insert(Store, {nodes, Node}),
     receive
@@ -1083,8 +1097,11 @@ rlock_get_reply(_Node, _Store, _Oid, {not_granted, Reason}) ->
 
 rlock_get_reply(_Node, Store, Oid, {switch, N2, Req}) ->
     ?ets_insert(Store, {nodes, N2}),
+    %% We are not sure, that N2 is alive, so monitor it to prevent
+    %% waiting indefinitely
+    MRef = monitor(process, {?MODULE, N2}),
     {?MODULE, N2} ! Req,
-    rlock_get_reply(N2, Store, Oid, l_req_rec(N2, Store)).
+    rlock_get_reply(N2, Store, Oid, l_req_rec_mon(N2, Store, MRef)).
 
 rlock_table(Tid, Store, Tab) ->
     rlock(Tid, Store, {Tab, ?ALL}).


### PR DESCRIPTION
Situation:
- node A and B have copies of table T
- node A ows sticky of table T
- node A goes down (e.g. crash)
- node B tries to perform transactional operation on table T
  (e.g. mnesia:select)

In this situation there is possibilty that first (and maybe other)
transaction on node B will hang indefinitely.
This is caused by race condition, when transaction process send lock
request operation to node A and waits for reply. When node A is down
it will never send reply, so process on node B will be stucked
forever.
Reason is that message sent to mnesia_locker gen_server from
mnesia_locker:mnesia_down can be received after mnesia_locker gen_server
already replies to transaction processes with {switch, N, Req} and
node N is down.
Monitoring remote process when sending request to other node should
be safe soltuion.
