### PR TITLE
Typo fix ambigous -> ambiguous

### DIFF
--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -530,7 +530,7 @@ valfun_2(I, #vst{current=#st{ct=[[Fail]|_]}}=Vst) when is_integer(Fail) ->
     %% Update branched state
     valfun_3(I, branch_state(Fail, Vst));
 valfun_2(_, _) ->
-    error(ambigous_catch_try_state).
+    error(ambiguous_catch_try_state).
 
 %% Handle the remaining floating point instructions here.
 %% Floating point.


### PR DESCRIPTION
Small typo fix, ran across this debugging an `Elixir` library. 
