### PR TITLE
specs for start_link of supervisor are correct now.

### DIFF
--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -37,7 +37,9 @@
 %%-----------------------------------------------------------------
 
 -type linkage()    :: 'link' | 'nolink'.
--type emgr_name()  :: {'local', atom()} | {'global', term()} | {via, atom(), term()}.
+-type emgr_name()  :: {'local', atom()}
+                    | {'global', term()} 
+                    | {'via', Modulename :: atom(), Key :: term()}.
 
 -type start_ret()  :: {'ok', pid()} | 'ignore' | {'error', term()}.
 

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -45,7 +45,9 @@
 -type restart()  :: 'permanent' | 'transient' | 'temporary'.
 -type shutdown() :: 'brutal_kill' | timeout().
 -type worker()   :: 'worker' | 'supervisor'.
--type sup_name() :: {'local', Name :: atom()} | {'global', Name :: atom()}.
+-type sup_name() :: {'local', Name :: atom()} 
+                  | {'global', Name :: atom()}
+                  | {via, Modulename :: atom(), Key :: term()}.
 -type sup_ref()  :: (Name :: atom())
                   | {Name :: atom(), Node :: node()}
                   | {'global', Name :: atom()}


### PR DESCRIPTION
The spec for start_link arguments of supervisor for externe registry was not right.
