### PR TITLE
Add lists:find/2,3

### DIFF
--- a/lib/stdlib/doc/src/lists.xml
+++ b/lib/stdlib/doc/src/lists.xml
@@ -177,6 +177,28 @@ filtermap(Fun, List1) ->
       </desc>
     </func>
     <func>
+      <name name="find" arity="2" />
+      <fsummary>Find the first element which satisfies a predicate</fsummary>
+      <desc>
+        <p>Returns <c>{value, <anno>Elem</anno>}</c> for the first
+        element <c><anno>Elem</anno></c> of <c><anno>List</anno></c>
+        for which <c><anno>Pred</anno>(<anno>Elem</anno>)</c>
+        returns <c>true</c>, or <c>false</c>.
+        </p>
+      </desc>
+    </func>
+    <func>
+      <name name="find" arity="3" />
+      <fsummary>Find the first element which satisfies a predicate</fsummary>
+      <desc>
+        <p>Returns <c>{value, <anno>Elem</anno>}</c> for the first
+        element <c><anno>Elem</anno></c> of <c><anno>List</anno></c>
+        for which <c><anno>Pred</anno>(<anno>Elem</anno>)</c> returns
+        <c>true</c>, or <c><anno>Default</anno></c>.
+        </p>
+      </desc>
+    </func>
+    <func>
       <name name="flatlength" arity="1"/>
       <fsummary>Length of flattened deep list</fsummary>
       <desc>

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -35,7 +35,7 @@
 
 -export([merge/3, rmerge/3, sort/2, umerge/3, rumerge/3, usort/2]).
 
--export([all/2,any/2,map/2,flatmap/2,foldl/3,foldr/3,filter/2,
+-export([all/2,any/2,map/2,find/2,find/3,flatmap/2,foldl/3,foldr/3,filter/2,
 	 partition/2,zf/2,filtermap/2,
 	 mapfoldl/3,mapfoldr/3,foreach/2,takewhile/2,dropwhile/2,splitwith/2,
 	 split/2]).
@@ -1269,6 +1269,31 @@ foldr(F, Accu, []) when is_function(F, 2) -> Accu.
 
 filter(Pred, List) when is_function(Pred, 1) ->
     [ E || E <- List, Pred(E) ].
+
+%% Equivalent to find(Pred, List, false).
+
+-spec find(Pred, List) -> {value, Elem} | false when
+      Pred :: fun((Elem :: T) -> boolean()),
+      List :: [T],
+      Elem :: T,
+      T :: term().
+
+find(Pred, List) when is_function(Pred, 1) ->
+    find(Pred, List, false).
+
+-spec find(Pred, List, Default) -> {value, Elem} | Default when
+      Pred :: fun((Elem :: T) -> boolean()),
+      List :: [T],
+      Elem :: T,
+      T :: term(),
+      Default :: term().
+
+find(Pred, [], Default) when is_function(Pred, 1) -> Default;
+find(Pred, [H|T], Default) ->
+    case Pred(H) of
+        true ->  {value, H};
+        false -> find(Pred, T, Default)
+    end.
 
 %% Equivalent to {filter(F, L), filter(NotF, L)}, if NotF = 'fun(X) ->
 %% not F(X) end'.

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -60,6 +60,7 @@
 	 ufunsort_error/1,
 	 zip_unzip/1, zip_unzip3/1, zipwith/1, zipwith3/1,
 	 filter_partition/1, 
+         find/1,
 	 otp_5939/1, otp_6023/1, otp_6606/1, otp_7230/1,
 	 suffix/1, subtract/1]).
 
@@ -85,7 +86,7 @@ all() ->
      {group, usort}, {group, keysort}, {group, ukeysort},
      {group, funsort}, {group, ufunsort}, {group, sublist},
      {group, flatten}, {group, seq}, zip_unzip, zip_unzip3,
-     zipwith, zipwith3, filter_partition, {group, tickets},
+     zipwith, zipwith3, filter_partition, find, {group, tickets},
      suffix, subtract].
 
 groups() -> 
@@ -2480,6 +2481,24 @@ filpart(F, All, Exp) ->
     Other = lists:filter(fun(E) -> not F(E) end, All),
     {Exp,Other} = lists:partition(F, All).
 
+%% Test lists:find/2,3
+find(Config) when is_list(Config) ->
+    F = fun(I) -> I rem 2 =:= 0 end,
+    F2 = fun(A,B) -> A > B end,
+
+    ?line {value, 2} = lists:find(F, [1,2,3,4]),
+    ?line false = lists:find(F, [1,3,5,7]),
+    ?line false = lists:find(F, []),
+    ?line {value, 2} = lists:find(F, [1,2,3,4], notfound),
+    ?line notfound = lists:find(F, [1,3,5,7], notfound),
+    ?line notfound = lists:find(F, [], notfound),
+
+    %% Error cases.
+    ?line {'EXIT',{function_clause,_}} = (catch lists:find(badfun, [])),
+    ?line {'EXIT',{function_clause,_}} = (catch lists:find(badfun, [], notfound)),
+    ?line {'EXIT',{function_clause,_}} = (catch lists:find(F2, [])),
+    ?line {'EXIT',{function_clause,_}} = (catch lists:find(F2, [], notfound)),
+    ok.
 
 otp_5939(doc) ->   ["OTP-5939. Guard tests added."];
 otp_5939(suite) -> [];


### PR DESCRIPTION
`lists:find/2,3` returns the first element of the passed list for which the predicate fun returns `true`, wrapped in a tuple `{value, Elem}`. If no elements result in the predicate being true, `false` (/2) or the given default value (/3) is returned.
## Why this new feature?

A common task is to select the first element from a list that matches a condition, but there is no existing lists function or language feature that avoids traversing the entire list, while still returning a "safe" value. `lists:find/2,3` codifies the pattern of a tail-recursive search for the matching item without resorting to exceptions (used to abort `foreach/2` or `foldl/3`) and always returns either the first matching item, or an otherwise safe value.
## Risks / uncertain artifacts

It is unclear the desired order of arguments for the 3-arity version. I have made the default value the final argument which is consistent with `application:get_env/3` and `proplists:get_value/3`, but most functions in lists place the `List` argument last.
## How did you solve it?

Following the patterns of other functions in the lists module, `lists:find/3` tests the predicate function against the head of the list, returning the head if the predicate passes, or recursing over the tail if it does not.
