### PR TITLE
Add name_in_archive option to erl_tar:add/3

### DIFF
--- a/lib/stdlib/doc/src/erl_tar.xml
+++ b/lib/stdlib/doc/src/erl_tar.xml
@@ -84,7 +84,8 @@
         <v>TarDescriptor = term()</v>
         <v>Filename = filename()</v>
         <v>Options = [Option]</v>
-        <v>Option = dereference|verbose</v>
+        <v>Option = dereference|verbose|{name_in_archive,NameInArchive}</v>
+        <v>NameInArchive = filename()</v>
         <v>RetValue = ok|{error,{Filename,Reason}}</v>
         <v>Reason = term()</v>
       </type>
@@ -103,6 +104,12 @@
           <tag><c>verbose</c></tag>
           <item>
             <p>Print an informational message about the file being added.</p>
+          </item>
+          <tag><c>{name_in_archive,NameInArchive}</c></tag>
+          <item>
+            <p><c>NameInArchive</c> is the name under which the file will
+          be stored in the tar file. That is the name that the file will
+          get when it will be extracted from the tar file.</p>
           </item>
         </taglist>
       </desc>

--- a/lib/stdlib/src/erl_tar.erl
+++ b/lib/stdlib/src/erl_tar.erl
@@ -77,7 +77,8 @@ close(_) ->
 %% Adds a file to a tape archive.
 
 add(File, Name, Options) ->
-    add(File, Name, Name, Options).
+    NameInArchive = proplists:get_value( name_in_archive, Options, Name ),
+    add(File, Name, NameInArchive, Options).
 
 add({write, File}, Name, NameInArchive, Options) ->
     Opts = #add_opts{read_info=fun(F) -> file:read_link_info(F) end},

--- a/lib/stdlib/test/tar_SUITE.erl
+++ b/lib/stdlib/test/tar_SUITE.erl
@@ -651,6 +651,7 @@ open_add_close(Config) when is_list(Config) ->
     ?line TarOne = filename:join(Dir, "archive1.tar"),
     ?line {ok,AD} = erl_tar:open(TarOne, [write]),
     ?line ok = erl_tar:add(AD, FileOne, []),
+    ?line ok = erl_tar:add(AD, FileOne, [{name_in_archive, "first_file_again"}]),
     ?line ok = erl_tar:add(AD, FileTwo, "second file", []),
     ?line ok = erl_tar:add(AD, FileThree, [verbose]),
     ?line ok = erl_tar:add(AD, ADir, [verbose]),
@@ -660,7 +661,7 @@ open_add_close(Config) when is_list(Config) ->
     ?line ok = erl_tar:t(TarOne),
     ?line ok = erl_tar:tt(TarOne),
 
-    ?line {ok,[FileOne,"second file",FileThree,ADir,SomeContent]} = erl_tar:table(TarOne),
+    ?line {ok,[FileOne, "first_file_again","second file",FileThree,ADir,SomeContent]} = erl_tar:table(TarOne),
 
     ?line delete_files(["oac_file","oac_small","oac_big",Dir,AnotherDir,ADir]),
 


### PR DESCRIPTION
There are 2 erl_tar:add(). One has an option as an extra argument.
It is better to allow this option to be part of the normal options.
The extra function is kept for backwards compatibility.
