### PR TITLE
Spec for atan2 should be atan2(Y, X), not atan2(X, Y)

### DIFF
--- a/lib/stdlib/src/math.erl
+++ b/lib/stdlib/src/math.erl
@@ -51,9 +51,9 @@ asinh(_) ->
 atan(_) ->
     erlang:nif_error(undef).
 
--spec atan2(X, Y) -> float() when
-      X :: number(),
-      Y :: number().
+-spec atan2(Y, X) -> float() when
+      Y :: number(),
+      X :: number().
 atan2(_, _) ->
     erlang:nif_error(undef).
 


### PR DESCRIPTION
math:atan2 receives Y and X as arguments, but the spec here ( http://www.erlang.org/doc/man/math.html ) says atan2(X, Y). I guess that comes from the file changed in this commit.
