### PR TITLE
Don't try to add the log_mf_h handler in sasl unless configured to do so

### DIFF
--- a/lib/sasl/src/sasl.erl
+++ b/lib/sasl/src/sasl.erl
@@ -82,8 +82,8 @@ get_mf() ->
     MaxB = get_mf_maxb(),
     MaxF = get_mf_maxf(),
     case {Dir, MaxB, MaxF} of
-	{undefined,undefined,undefined} = R ->
-	    R;
+	{undefined,undefined,undefined} ->
+	    undefined;
 	{undefined,_,_} ->
 	    exit({missing_config, {sasl, error_logger_mf_dir}});
 	{_,undefined,_} ->


### PR DESCRIPTION
The functions add_error_logger_mf/1 and delete_error_logger_mf/1 in sasl.erl
are designed to do nothing if the handler configuration as returned by
get_error_logger_mf/0 is 'undefined'. However, that function returns a
triple {undefined,undefined,undefined} when the error_logger_mf_*
configurations have not been set. This makes SASL always try to add the
log_mf_h handler on startup, passing 'undefined' for each of the Dir, MaxB
and MaxF parameters. The gen_event callback function log_mf_h:init/1 will
then crash with a function_clause error, causing the handler to be silently
removed again. This patch fixes the problem by making get_error_logger_mf/0
return the single atom 'undefined' as it is expected to do.
