### PR TITLE
Fix confusing documentation about error handlers in SASL

### DIFF
--- a/lib/sasl/doc/src/error_logging.xml
+++ b/lib/sasl/doc/src/error_logging.xml
@@ -173,8 +173,9 @@
   <section>
     <title>Report Browser</title>
     <p>The report browser is used to browse and format error reports
-      written by the error logger handler <c>error_logger_mf_h</c>.</p>
-    <p>The <c>error_logger_mf_h</c> handler writes all reports to a
+      written by the error logger handler <c>log_mf_h</c> defined in
+      <c>stdlib</c>.</p>
+    <p>The <c>log_mf_h</c> handler writes all reports to a
       report logging directory. This directory is specified when
       configuring the SASL application.</p>
     <p>If the report browser is

--- a/lib/sasl/doc/src/sasl_app.xml
+++ b/lib/sasl/doc/src/sasl_app.xml
@@ -51,7 +51,7 @@
 
   <section>
     <title>Error Logger Event Handlers</title>
-    <p>The following error logger event handlers are defined in
+    <p>The following error logger event handlers are used by
       the SASL application.</p>
     <taglist>
       <tag><c>sasl_report_tty_h</c></tag>
@@ -62,11 +62,10 @@
       <item>
         <p>Formats and writes <em>supervisor reports</em>, <em>crash report</em> and <em>progress report</em> to a single file.</p>
       </item>
-      <tag><c>error_logger_mf_h</c></tag>
+      <tag><c>log_mf_h</c></tag>
       <item>
         <p>This error logger writes <em>all</em> events sent to
-          the error logger to disk. It installs the <c>log_mf_h</c>
-          event handler in the <c>error_logger</c> process.</p>
+          the error logger to disk.</p>
         <p>To activate this event handler, the following three sasl
           configuration parameters must be set:
           <c>error_logger_mf_dir</c>, <c>error_logger_mf_maxbytes</c>
@@ -109,18 +108,18 @@
       <item>
         <p>Specifies in which directory the files are stored. If this
           parameter is undefined or <c>false</c>,
-          the <c>error_logger_mf_h</c> is not installed.</p>
+          the <c>log_mf_h</c> handler is not installed.</p>
       </item>
       <tag><c><![CDATA[error_logger_mf_maxbytes = integer() <optional>]]></c></tag>
       <item>
         <p>Specifies how large each individual file can be. If this
-          parameter is undefined, the <c>error_logger_mf_h</c> is not
+          parameter is undefined, the <c>log_mf_h</c> handler is not
           installed.</p>
       </item>
       <tag><c><![CDATA[error_logger_mf_maxfiles = 0<integer()<256 <optional>]]></c></tag>
       <item>
         <p>Specifies how many files are used. If this parameter is
-          undefined, the <c>error_logger_mf_h</c> is not installed.</p>
+          undefined, the <c>log_mf_h</c> handler is not installed.</p>
       </item>
       <tag><c><![CDATA[overload_max_intensity = float() > 0 <optional>]]></c></tag>
       <item>


### PR DESCRIPTION
The SASL documentation confusingly talks about a handler 'error_logger_mf_h'
which doesn't actually exist. The handler is named 'log_mf_h', and it and
all other error handlers used by SASL are part of stdlib, not SASL itself.
This patch makes the documentation clearer.
