### PR TITLE
Allow all auto imports to be suppressed at once

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -402,6 +402,11 @@ module.beam: module.erl \
 	  <code>-compile({no_auto_import,[error/1]}).</code>
 	  </item>
 
+          <tag><c>no_auto_import</c></tag>
+          <item>
+            <p>Do not auto import any functions from the module <c>erlang</c>.</p>
+          </item>
+
           <tag><c>no_line_info</c></tag>
 
           <item>

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -100,7 +100,7 @@ value_option(Flag, Default, On, OnVal, Off, OffVal, Opts) ->
                compile=[],                      %Compile flags
                records=dict:new()	:: dict(),	%Record definitions
                locals=gb_sets:empty()	:: gb_set(),	%All defined functions (prescanned)
-	       no_auto=gb_sets:empty()	:: gb_set(),	%Functions explicitly not autoimported
+	       no_auto=gb_sets:empty()	:: gb_set() | 'all',	%Functions explicitly not autoimported
                defined=gb_sets:empty()	:: gb_set(),	%Defined fuctions
 	       on_load=[] :: [fa()],		%On-load function
 	       on_load_line=0 :: line(),	%Line for on_load
@@ -3544,15 +3544,22 @@ is_imported_from_erlang(ImportSet,{Func,Arity}) ->
         {ok,erlang} -> true;
         _ -> false
     end.
-%% Build set of functions where auto-import is explicitly supressed
+%% Build set of functions where auto-import is explicitly suppressed
 auto_import_suppressed(CompileFlags) ->
-    L0 = [ X || {no_auto_import,X} <- CompileFlags ],
-    L1 = [ {Y,Z} || {Y,Z} <- lists:flatten(L0), is_atom(Y), is_integer(Z) ],
-    gb_sets:from_list(L1).
-%% Predicate to find out if autoimport is explicitly supressed for a function
+    case lists:member(no_auto_import, CompileFlags) of
+        true ->
+            all;
+        false ->
+            L0 = [ X || {no_auto_import,X} <- CompileFlags ],
+            L1 = [ {Y,Z} || {Y,Z} <- lists:flatten(L0), is_atom(Y), is_integer(Z) ],
+            gb_sets:from_list(L1)
+    end.
+%% Predicate to find out if autoimport is explicitly suppressed for a function
+is_autoimport_suppressed(all,{_Func,_Arity}) ->
+    true;
 is_autoimport_suppressed(NoAutoSet,{Func,Arity}) ->
     gb_sets:is_element({Func,Arity},NoAutoSet).
-%% Predicate to find out if a function specific bif-clash supression (old deprecated) is present
+%% Predicate to find out if a function specific bif-clash suppression (old deprecated) is present
 bif_clash_specifically_disabled(St,{F,A}) ->
     Nowarn = nowarn_function(nowarn_bif_clash, St#lint.compile),
     lists:member({F,A},Nowarn).

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -2742,7 +2742,24 @@ bif_clash(Config) when is_list(Config) ->
 		    {6,erl_lint,{illegal_guard_local_call,{is_tuple,1}}},
 		    {7,erl_lint,{illegal_guard_local_call,{is_list,1}}},
 		    {8,erl_lint,{illegal_guard_local_call,{is_record,3}}},
-		    {9,erl_lint,{illegal_guard_local_call,{is_record,3}}}],[]}}
+		    {9,erl_lint,{illegal_guard_local_call,{is_record,3}}}],[]}},
+	  %% We can also suppress all auto imports at once
+	  {clash22,
+          <<"-export([size/1, binary_part/2]).
+             -compile(no_auto_import).
+             size([]) ->
+               0;
+             size({N,_}) ->
+               N;
+             size([_|T]) ->
+               1+size(T).
+             binary_part({B,_},{X,Y}) ->
+               binary_part(B,{X,Y});
+             binary_part(B,{X,Y}) ->
+               binary:part(B,X,Y).
+            ">>,
+	   [],
+	   []}
 	 ],
 
     ?line [] = run(Config, Ts),


### PR DESCRIPTION
This patch introduces the no_auto_import attribute:

```
-compile(no_auto_import).
```

Useful for code generation tools that always use the
qualified function names and want to avoid the auto
imported functions clashing with local ones.

Implementation wise, we chose to have a special flag
'all' to avoid doing many set lookups when checking for
suppression.
