### PR TITLE
Fix file:set_cwd/1 type spec

### DIFF
--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -197,7 +197,7 @@ get_cwd(Drive) ->
     check_and_call(get_cwd, [file_name(Drive)]).
 
 -spec set_cwd(Dir) -> ok | {error, Reason} when
-      Dir :: name(),
+      Dir :: name_all(),
       Reason :: posix() | badarg | no_translation.
 
 set_cwd(Dirname) -> 


### PR DESCRIPTION
file:set_cwd/1 accepts paths of type file:name_all(), not just
file:name().
