### PR TITLE
Add os:unsetenv/1

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -572,6 +572,7 @@ bif erlang:float_to_binary/2
 bif erlang:binary_to_float/1
 
 bif io:printable_range/0
+bif os:unsetenv/1
 
 #
 # Obsolete

--- a/erts/emulator/beam/erl_bif_os.c
+++ b/erts/emulator/beam/erl_bif_os.c
@@ -180,3 +180,25 @@ BIF_RETTYPE os_putenv_2(BIF_ALIST_2)
     BIF_RET(am_true);
 }
 
+BIF_RETTYPE os_unsetenv_1(BIF_ALIST_1)
+{
+    char *key_buf;
+    char buf[STATIC_BUF_SIZE];
+
+    key_buf = erts_convert_filename_to_native(BIF_ARG_1,buf,STATIC_BUF_SIZE,
+					      ERTS_ALC_T_TMP,0,0,NULL);
+    if (!key_buf) {
+	BIF_ERROR(BIF_P, BADARG);
+    }
+
+    if (erts_sys_unsetenv(key_buf)) {
+	if (key_buf != buf) {
+	    erts_free(ERTS_ALC_T_TMP, key_buf);
+	}
+	BIF_ERROR(BIF_P, BADARG);
+    }
+    if (key_buf != buf) {
+	erts_free(ERTS_ALC_T_TMP, key_buf);
+    }
+    BIF_RET(am_true);
+}

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -750,6 +750,8 @@ int erts_sys_getenv(char *key, char *value, size_t *size);
 int erts_sys_getenv_raw(char *key, char *value, size_t *size);
 /* erts_sys_getenv__() is only allowed to be used in early init phase */
 int erts_sys_getenv__(char *key, char *value, size_t *size);
+/* erst_sys_unsetenv() returns 0 on success and a value != 0 on failure. */
+int erts_sys_unsetenv(char *key);
 
 /* Easier to use, but not as efficient, environment functions */
 char *erts_read_env(char *key);

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -2489,6 +2489,16 @@ erts_sys_getenv(char *key, char *value, size_t *size)
     return res;
 }
 
+int
+erts_sys_unsetenv(char *key)
+{
+    int res;
+    erts_smp_rwmtx_rwlock(&environ_rwmtx);
+    res = unsetenv(key);
+    erts_smp_rwmtx_rwunlock(&environ_rwmtx);
+    return res;
+}
+
 void
 sys_init_io(void)
 {

--- a/erts/emulator/sys/win32/sys_env.c
+++ b/erts/emulator/sys/win32/sys_env.c
@@ -141,6 +141,24 @@ void fini_getenv_state(GETENV_STATE *state)
     erts_smp_rwmtx_runlock(&environ_rwmtx);
 }
 
+int erts_sys_unsetenv(char *key)
+{
+    int res = 0;
+    WCHAR *wkey = (WCHAR *) key;
+
+    SetLastError(0);
+    erts_smp_rwmtx_rlock(&environ_rwmtx);
+    GetEnvironmentVariableW(wkey,
+                            NULL,
+                            0);
+    if (GetLastError() != ERROR_ENVVAR_NOT_FOUND) {
+        res = (SetEnvironmentVariableW(wkey,
+                                       NULL) ? 0 : 1);
+    }
+    erts_smp_rwmtx_runlock(&environ_rwmtx);
+    return res;
+}
+
 char*
 win_build_environment(char* new_env)
 {

--- a/erts/emulator/test/bif_SUITE.erl
+++ b/erts/emulator/test/bif_SUITE.erl
@@ -388,8 +388,12 @@ os_env(Config) when is_list(Config) ->
 	      false -> ?line ok;
 	      BadVal -> ?line ?t:fail(BadVal)
 	  end,
-    %% os:putenv and os:getenv currently uses a temp buf of size 1024
-    %% for storing key+value
+    ?line true = os:putenv(EnvVar1, "mors"),
+    ?line true = os:unsetenv(EnvVar1),
+    ?line false = os:getenv(EnvVar1),
+    ?line true = os:unsetenv(EnvVar1), % unset unset variable
+    %% os:putenv, os:getenv and os:unsetenv currently use a temp
+    %% buffer of size 1024 for storing key+value
     ?line os_env_long(1010, 1030, "hej hopp").
     
 os_env_long(Min, Max, _Value) when Min > Max ->
@@ -398,7 +402,7 @@ os_env_long(Min, Max, Value) ->
     ?line EnvVar = lists:duplicate(Min, $X),
     ?line true = os:putenv(EnvVar, Value),
     ?line Value = os:getenv(EnvVar),
-    ?line true = os:putenv(EnvVar, ""),
+    ?line true = os:unsetenv(EnvVar),
     ?line os_env_long(Min+1, Max, Value).
 
 otp_7526(doc) ->    

--- a/lib/kernel/doc/src/os.xml
+++ b/lib/kernel/doc/src/os.xml
@@ -177,6 +177,17 @@ format_utc_timestamp() ->
       </desc>
     </func>
     <func>
+      <name name="unsetenv" arity="1"/>
+      <fsummary>Delete an environment variable</fsummary>
+      <desc>
+	<p>Deletes the environment variable <c><anno>VarName</anno></c>.</p>
+	<p>If Unicode filename encoding is in effect (see the <seealso
+	marker="erts:erl#file_name_encoding">erl manual
+	page</seealso>), the string (<c><anno>VarName</anno></c>) may
+	contain characters with codepoints > 255.</p>
+      </desc>
+    </func>
+    <func>
       <name name="version" arity="0"/>
       <fsummary>Return the Operating System version</fsummary>
       <desc>

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -26,7 +26,7 @@
 
 %%% BIFs
 
--export([getenv/0, getenv/1, getpid/0, putenv/2, timestamp/0]).
+-export([getenv/0, getenv/1, getpid/0, putenv/2, timestamp/0, unsetenv/1]).
 
 -spec getenv() -> [string()].
 
@@ -56,6 +56,12 @@ putenv(_, _) ->
       Timestamp :: erlang:timestamp().
 
 timestamp() ->
+    erlang:nif_error(undef).
+
+-spec unsetenv(VarName) -> true when
+      VarName :: string().
+
+unsetenv(_) ->
     erlang:nif_error(undef).
 
 %%% End of BIFs


### PR DESCRIPTION
This patch adds os:unsetenv/1 which deletes an environment variable.
### Why this new feature?

With os:unsetenv/1, it is possible to delete environment variables.
This makes it easier to test code which uses os:getenv/1 to check if
an environment variable exists or not. The new function differs from
os:putenv(Value, "") as the former deletes the variable while the
latter keeps the variable with an empty value.

Example:

  1> os:putenv("foo", "").
  true
  2> os:getenv("foo").
  []
  3> os:unsetenv("foo").
  true
  4> os:getenv("foo").
  false
### Risks / uncertain artifacts

None. New function without any changes in old functionality.
### How did you solve it?

New BIF which calls the libc function unsetenv(3) on UNIX and
SetEnvironmentVariableW(key, NULL) on Windows. The unicode support is
the same as for os:getenv and os:putenv.
