### PR TITLE
Handle lines in console helpers when standard_input is set to binary

### DIFF
--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -330,12 +330,17 @@ choice(F) ->
     end.
 
 get_line(P, Default) ->
-    case io:get_line(P) of
+    case line_string(io:get_line(P)) of
 	"\n" ->
 	    Default;
 	L ->
 	    L
     end.
+
+%% If the standard input is set to binary mode
+%% convert it to a list so we can properly match.
+line_string(Binary) when is_binary(Binary) -> unicode:characters_to_list(Binary);
+line_string(Other) -> Other.
 
 mfa_string(Fun) when is_function(Fun) ->
     {module,M} = erlang:fun_info(Fun, module),


### PR DESCRIPTION
There are no existing tests for the current functionality (only a couple console helpers are tested), so I haven't added a new one. I have guaranteed this works locally though.
