### PR TITLE
Remove extraneous dev debug code left in the close function. We do not n...

### DIFF
--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -95,11 +95,6 @@ do_setup(Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
     end.
 
 close(Socket) ->
-    try
-	erlang:error(foo)
-    catch _:_ ->
-	    io:format("close called ~p ~p~n",[Socket, erlang:get_stacktrace()])
-    end,
     gen_tcp:close(Socket),
     ok.
 


### PR DESCRIPTION
We do not need a traceback on every close in inet_tls_dist and this breaks using nodetool in control scripts on SSL clustered nodes
