### PR TITLE
Add support for the separate tinfo library from ncurses

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1338,7 +1338,7 @@ TERMCAP_LIB=
 if test "x$with_termcap" != "xno" &&
    test "X$host" != "Xwin32"; then
     # try these libs
-    termcap_libs="ncurses curses termcap termlib"
+    termcap_libs="tinfo ncurses curses termcap termlib"
 
     for termcap_lib in $termcap_libs; do
 	AC_CHECK_LIB($termcap_lib, tgetent, TERMCAP_LIB="-l$termcap_lib")


### PR DESCRIPTION
Recent versions of ncurses can be built with terminfo symbols moved into the separate tinfo library. This patch prevents erts configure from dying by adding the tinfo library to list of termcap lib candidates.
