### PR TITLE
Add missing default value for regexps in reltool

### DIFF
--- a/lib/reltool/src/reltool_utils.erl
+++ b/lib/reltool/src/reltool_utils.erl
@@ -589,6 +589,8 @@ throw_error(Format, Args) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+decode_regexps(Key, Regexps, undefined) ->
+    decode_regexps(Key, Regexps, []);
 decode_regexps(Key, {add, Regexps}, Old) when is_list(Regexps) ->
     do_decode_regexps(Key, Regexps, Old);
 decode_regexps(_Key, {del, Regexps}, Old)  when is_list(Regexps) ->

--- a/lib/reltool/test/reltool_server_SUITE.erl
+++ b/lib/reltool/test/reltool_server_SUITE.erl
@@ -144,7 +144,8 @@ all() ->
      mod_incl_cond_derived,
      use_selected_vsn,
      use_selected_vsn_relative_path,
-     non_standard_vsn_id].
+     non_standard_vsn_id,
+     undefined_regexp].
 
 groups() -> 
     [].
@@ -2506,6 +2507,12 @@ non_standard_vsn_id(Config) ->
 	  reltool_server:get_app(Pid2,b)),
    ok.
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+undefined_regexp(_Config) ->
+    ?msym({ok,_},
+          reltool:get_config([{sys,[{app,asn1,[{excl_app_filters,
+                                                {add, ["^priv"]}}]}]}])),
+    ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Library functions


### PR DESCRIPTION
It caused a function clause in lists:sort/1:

  reltool_server_SUITE.erl(2512): <ERROR>
  Not matching actual result was:
   {error,
       {function_clause,
           [{lists,sort,
                [[{regexp,"^priv",
                      {re_pattern,0,1,
                          <<69,82,67,80,64,0,0,0,16,8,0,0,0,0,0,0,0,0,0,0,0,
                            0,0,0,48,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
                            0,0,0,93,0,12,25,27,112,27,114,27,105,27,118,84,
                            0,12,0>>}}|
                  undefined]],
                [{file,"lists.erl"},{line,465}]},
            {reltool_server,decode,2,[{file,"reltool_server.erl"},{line,1499}]},
            {reltool_server,decode,2,[{file,"reltool_server.erl"},{line,1363}]},
            {reltool_server,read_config,2,
                [{file,"reltool_server.erl"},{line,1335}]},
            {reltool_server,parse_options,4,
                [{file,"reltool_server.erl"},{line,224}]},
            {reltool_server,do_init,1,[{file,"reltool_server.erl"},{line,154}]},
            {reltool_server,init,1,[{file,"reltool_server.erl"},{line,133}]},
            {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}}
  Expected { ok , _ }
