### PR TITLE
hipe: Fix compilation with 'no_remove_comments'

### DIFF
--- a/lib/hipe/icode/hipe_icode.erl
+++ b/lib/hipe/icode/hipe_icode.erl
@@ -1464,6 +1464,7 @@ successors(I) ->
       case fail_label(I) of [] -> []; L when is_integer(L) -> [L] end;
     #icode_enter{} -> [];
     #icode_return{} -> [];
+    #icode_comment{} -> [];
     %% the following are included here for handling linear code
     #icode_move{} -> [];
     #icode_begin_handler{} -> []


### PR DESCRIPTION
To reproduce the error:
$ echo '-module(hello).' > hello.erl
$ erl
1> c(hello, [native,{hipe,[no_remove_comments]}]).
[...]
<HiPE (v 3.10.2.1)> Error: [hipe:834]: ERROR: {{case_clause,
                                                {icode_comment,call_ext_only}},
                                               [{hipe_icode,successors,1,
                                                 [{file,"hipe_icode.erl"},
                                                  {line,1444}]},
[...]
