### PR TITLE
Enable customization of generated boot scripts

### DIFF
--- a/erts/etc/unix/dyn_erl.c
+++ b/erts/etc/unix/dyn_erl.c
@@ -291,6 +291,10 @@ find_erts_vsn(char *erl_top)
         }
         if (strncmp("erts-", dirp->d_name, 5) == 0) {
 	    copy_latest_vsn(latest_vsn, dirp->d_name);
+        } else if (strncmp("erts", dirp->d_name, 4) == 0) {
+            /* No erts vsn */
+            strcpy(latest_vsn, dirp->d_name);
+            break;
         }
     }
 

--- a/erts/etc/win32/erl.c
+++ b/erts/etc/win32/erl.c
@@ -157,7 +157,7 @@ static char *find_erlexec_dir2(char *install_dir)
     p = wildcard+length-1;
     if (*p != '/' && *p != '\\')
 	*++p = '\\';
-    strcpy(++p, "erts-*");
+    strcpy(++p, "erts*");
 
     /* Find first dir */
     dir_handle = FindFirstFile(wildcard, &find_data);
@@ -168,7 +168,8 @@ static char *find_erlexec_dir2(char *install_dir)
     strcpy(latest_vsn, find_data.cFileName);
 
     /* Find the rest */
-    while(FindNextFile(dir_handle, &find_data)) {
+    while((strncmp("erts", latest_vsn, 4) /= 0) &&
+          FindNextFile(dir_handle, &find_data)) {
 	copy_latest_vsn(latest_vsn, find_data.cFileName);
     }
     

--- a/lib/reltool/doc/src/reltool.xml
+++ b/lib/reltool/doc/src/reltool.xml
@@ -165,6 +165,23 @@
         booting up.</p>
       </item>
 
+      <tag><c>boot_phase_fun</c></tag>
+      <item>
+        <p>This is a user defined function which can be used for
+        customization of boot scripts. A boot script consists of the
+        following phases: <c>preloaded</c>,
+        <c>kernel_load_completed</c>, <c>modules_loaded</c>,
+        <c>init_kernel_started</c>, <c>applications_loaded</c> and
+        <c>applications_started</c>. The <c>boot_phase_fun</c> has the
+        following signature: <c>fun((rel_name(), rel_vsn(),
+        boot_phase_name(), [boot_script_cmd()]) ->
+        [boot_script_cmd()])</c>. It will be invoked once for each
+        phase with the release name, release version, boot phase name
+        and a list of boot script commands as arguments. The function
+        is intended to return a new list of boot script commands.
+        </p>
+      </item>
+
       <tag><c>rel</c></tag>
       <item>
         <p>Release specific configuration. Each release maps to a
@@ -510,6 +527,7 @@ sys()               = {root_dir, root_dir()}
                     | {mod_cond, mod_cond()} 
                     | {incl_cond, incl_cond()}
                     | {boot_rel, boot_rel()}
+                    | {boot_phase_fun, boot_phase_fun()}
                     | {rel, rel_name(), rel_vsn(), [rel_app()]}
                     | {relocatable, relocatable()}
                     | {app_file, app_file()}
@@ -549,6 +567,9 @@ app_type()          = permanent | transient | temporary | load | none
 app_vsn()           = string()
 archive_opt         = zip_create_opt()
 boot_rel()          = rel_name()
+boot_phase_fun()    = fun((rel_name(), rel_vsn(), boot_phase_name(), [boot_script_cmd()]) -> [term()])
+boot_phase_name()   = atom()
+boot_script_cmd()   = term()
 app_file()          = keep | strip | all
 app_dir_vsn()       = keep | strip
 debug_info()        = keep | strip

--- a/lib/reltool/doc/src/reltool.xml
+++ b/lib/reltool/doc/src/reltool.xml
@@ -223,6 +223,15 @@
         and <c>strip</c>.</p>
       </item>
 
+      <tag><c>app_dir_vsn</c></tag>
+      <item>
+        <p>This parameter controls whether application directories (and
+        archives) should have the version as a part of the name or
+        not. <c>keep</c>, which is the default, means that the version
+        should be kept (e.g. <c>mnesia-4.0</c>). <c>strip</c> means
+        that the version should be stripped (e.g. <c>mnesia</c>).</p>
+      </item>
+
       <tag><c>debug_info</c></tag>
       <item>
         <p>The <c>debug_info</c> parameter controls whether the debug
@@ -504,6 +513,7 @@ sys()               = {root_dir, root_dir()}
                     | {rel, rel_name(), rel_vsn(), [rel_app()]}
                     | {relocatable, relocatable()}
                     | {app_file, app_file()}
+                    | {app_dir_vsn, app_dir_vsn()}
                     | {debug_info, debug_info()}
                     | {incl_sys_filters, incl_sys_filters()}
                     | {excl_sys_filters, excl_sys_filters()}
@@ -519,6 +529,7 @@ app()               = {vsn, app_vsn()}
                     | {incl_cond, incl_cond()}
                     | {debug_info, debug_info()}
                     | {app_file, app_file()}
+                    | {app_dir_vsn, app_dir_vsn()}
 		    | {excl_lib, excl_lib()}
                     | {incl_sys_filters, incl_sys_filters()}
                     | {excl_sys_filters, excl_sys_filters()}
@@ -539,6 +550,7 @@ app_vsn()           = string()
 archive_opt         = zip_create_opt()
 boot_rel()          = rel_name()
 app_file()          = keep | strip | all
+app_dir_vsn()       = keep | strip
 debug_info()        = keep | strip
 dir()               = string()
 escript()           = {incl_cond, incl_cond()}

--- a/lib/reltool/src/reltool.hrl
+++ b/lib/reltool/src/reltool.hrl
@@ -29,6 +29,7 @@
 -type incl_cond()        :: include | exclude | derived.
 -type debug_info()       :: keep | strip.
 -type app_file()         :: keep | strip | all.
+-type app_dir_vsn()      :: keep | strip.
 -type re_regexp()        :: string(). % re:regexp()
 -type regexps()          :: [re_regexp()] |
 			    {add, [re_regexp()]} |
@@ -68,6 +69,7 @@
                           | {mod_cond, mod_cond()}
                           | {incl_cond, incl_cond()}
                           | {app_file, app_file()}
+                          | {app_dir_vsn, app_dir_vsn()}
                           | {debug_info, debug_info()}
                           | {incl_app_filters, incl_app_filters()}
                           | {excl_app_filters, excl_app_filters()}
@@ -78,6 +80,7 @@
                           | {incl_cond, incl_cond()}
                           | {debug_info, debug_info()}
                           | {app_file, app_file()}
+                          | {app_dir_vsn, app_dir_vsn()}
                           | {profile, profile()}
 			  | {excl_lib, excl_lib()}
                           | {incl_sys_filters, incl_sys_filters()}
@@ -189,6 +192,7 @@
           %% Static target cond
           debug_info            :: '_' | debug_info() | undefined,
           app_file              :: '_' | app_file() | undefined,
+          app_dir_vsn           :: '_' | app_dir_vsn() | undefined,
           app_type              :: '_' | app_type() | undefined,
           incl_app_filters      :: '_' | [#regexp{}],
           excl_app_filters      :: '_' | [#regexp{}],
@@ -247,6 +251,7 @@
           rel_app_type         :: app_type(),
           embedded_app_type    :: app_type() | undefined,
           app_file             :: app_file(),
+          app_dir_vsn          :: app_dir_vsn(),
           debug_info           :: debug_info()
 	}).
 
@@ -271,6 +276,7 @@
 -define(DEFAULT_REL_APP_TYPE,      permanent).
 -define(DEFAULT_EMBEDDED_APP_TYPE, undefined).
 -define(DEFAULT_APP_FILE,          keep).
+-define(DEFAULT_APP_DIR_VSN,       keep).
 -define(DEFAULT_DEBUG_INFO,        keep).
 
 -define(DEFAULT_INCL_ARCHIVE_FILTERS, [".*"]).

--- a/lib/reltool/src/reltool.hrl
+++ b/lib/reltool/src/reltool.hrl
@@ -57,6 +57,9 @@
 -type rel_name()         :: string().
 -type rel_vsn()          :: string().
 -type boot_rel()         :: rel_name().
+-type boot_phase_fun()   :: fun((rel_name(), rel_vsn(), boot_phase_name(), [boot_script_cmd()]) -> [boot_script_cmd()]).
+-type boot_phase_name()  :: atom().
+-type boot_script_cmd()  :: term().
 -type rel_app()          :: app_name()
                           | {app_name(), app_type()}
                           | {app_name(), [incl_app()]}
@@ -220,9 +223,9 @@
 
 -record(rel,
         {
-          name     :: rel_name(),
-          vsn      :: rel_vsn(),
-          rel_apps :: [#rel_app{}]
+          name           :: rel_name(),
+          vsn            :: rel_vsn(),
+          rel_apps       :: [#rel_app{}]
 	}).
 
 -record(sys,
@@ -236,6 +239,7 @@
 
           %% Target cond
           boot_rel 	       :: boot_rel(),
+          boot_phase_fun       :: boot_phase_fun() | undefined,
           rels     	       :: [#rel{}],
           emu_name 	       :: emu_name(),
           profile  	       :: profile(),

--- a/lib/reltool/src/reltool_server.erl
+++ b/lib/reltool/src/reltool_server.erl
@@ -195,6 +195,7 @@ default_sys() ->
 	 rel_app_type      = ?DEFAULT_REL_APP_TYPE,
 	 embedded_app_type = ?DEFAULT_EMBEDDED_APP_TYPE,
 	 app_file          = ?DEFAULT_APP_FILE,
+         app_dir_vsn       = ?DEFAULT_APP_DIR_VSN,
 	 incl_archive_filters = dec_re(incl_archive_filters,
 				       ?DEFAULT_INCL_ARCHIVE_FILTERS,
 				       []),
@@ -446,6 +447,7 @@ app_set_config_only([],#app{name                 = Name,
 			    use_selected_vsn     = undefined,
 			    debug_info           = undefined,
 			    app_file             = undefined,
+			    app_dir_vsn          = undefined,
 			    app_type             = undefined,
 			    incl_app_filters     = undefined,
 			    excl_app_filters     = undefined,
@@ -460,6 +462,7 @@ app_set_config_only(Mods,#app{name                 = Name,
 			      use_selected_vsn     = UseSelectedVsn,
 			      debug_info           = DebugInfo,
 			      app_file             = AppFile,
+			      app_dir_vsn          = AppDirVsn,
 			      app_type             = AppType,
 			      incl_app_filters     = InclAppFilters,
 			      excl_app_filters     = ExclAppFilters,
@@ -477,6 +480,7 @@ app_set_config_only(Mods,#app{name                 = Name,
 				  use_selected_vsn     = UseSelectedVsn,
 				  debug_info           = DebugInfo,
 				  app_file             = AppFile,
+                                  app_dir_vsn          = AppDirVsn,
 				  app_type             = AppType,
 				  incl_app_filters     = InclAppFilters,
 				  excl_app_filters     = ExclAppFilters,
@@ -1440,7 +1444,8 @@ decode(#sys{} = Sys, [{Key, Val} | KeyVals]) ->
 			    dec_re(Key, Val, Sys#sys.excl_archive_filters)};
             archive_opts when is_list(Val) ->
                 Sys#sys{archive_opts = Val};
-            relocatable when Val =:= true; Val =:= false ->
+            relocatable when Val =:= true;
+                             Val =:= false ->
                 Sys#sys{relocatable = Val};
             rel_app_type when Val =:= permanent;
 			      Val =:= transient;
@@ -1455,9 +1460,15 @@ decode(#sys{} = Sys, [{Key, Val} | KeyVals]) ->
 				   Val =:= none;
 				   Val =:= undefined ->
                 Sys#sys{embedded_app_type = Val};
-            app_file when Val =:= keep; Val =:= strip; Val =:= all ->
+            app_file when Val =:= keep;
+                          Val =:= strip;
+                          Val =:= all ->
                 Sys#sys{app_file = Val};
-            debug_info when Val =:= keep; Val =:= strip ->
+            app_dir_vsn when Val =:= keep;
+                             Val =:= strip ->
+                Sys#sys{app_dir_vsn = Val};
+            debug_info when Val =:= keep;
+                            Val =:= strip ->
                 Sys#sys{debug_info = Val};
             _ ->
 		reltool_utils:throw_error("Illegal option: ~p", [{Key, Val}])
@@ -1484,6 +1495,9 @@ decode(#app{} = App, [{Key, Val} | KeyVals]) ->
 			  Val =:= strip;
 			  Val =:= all ->
                 App#app{app_file = Val};
+            app_dir_vsn when Val =:= keep;
+                             Val =:= strip ->
+                App#app{app_dir_vsn = Val};
             app_type when Val =:= permanent;
 			  Val =:= transient;
 			  Val =:= temporary;

--- a/lib/reltool/src/reltool_server.erl
+++ b/lib/reltool/src/reltool_server.erl
@@ -1398,6 +1398,8 @@ decode(#sys{} = Sys, [{Key, Val} | KeyVals]) ->
                 Sys#sys{incl_cond = Val};
             boot_rel when is_list(Val) ->
                 Sys#sys{boot_rel = Val};
+            boot_phase_fun when is_function(Val, 4) ->
+                Sys#sys{boot_phase_fun = Val};
             emu_name when is_list(Val) ->
                 Sys#sys{emu_name = Val};
 	    profile when Val =:= development;
@@ -1573,7 +1575,7 @@ decode(#rel{rel_apps = RelApps} = Rel, [RelApp | KeyVals]) ->
         end,
     case ValidTypesAssigned of
 	true ->
-            decode(Rel#rel{rel_apps = RelApps ++ [RA]}, KeyVals);
+            decode(Rel#rel{rel_apps = [RA | RelApps]}, KeyVals);
         false ->
 	    reltool_utils:throw_error("Illegal option: ~p", [RelApp])
     end;

--- a/lib/reltool/src/reltool_target.erl
+++ b/lib/reltool/src/reltool_target.erl
@@ -424,7 +424,7 @@ gen_script(Rel, Sys, PathFlag, Variables) ->
     end.
 
 do_gen_script(#rel{name = RelName, vsn = RelVsn},
-              #sys{apps = Apps},
+              #sys{apps = Apps} = Sys,
 	      MergedApps,
               PathFlag,
               Variables) ->
@@ -444,19 +444,18 @@ do_gen_script(#rel{name = RelName, vsn = RelVsn},
          %% Register preloaded modules
          {preLoaded, lists:sort(Preloaded)},
          {progress, preloaded},
-
          %% Load mandatory modules
-         {path, create_mandatory_path(MergedApps, PathFlag, Variables)},
+         {path, create_mandatory_path(Sys, MergedApps, PathFlag, Variables)},
          {primLoad, lists:sort(Mandatory)},
          {kernel_load_completed},
          {progress, kernel_load_completed},
 
          %% Load remaining modules
-         [load_app_mods(A, Early, PathFlag, Variables) || A <- MergedApps],
+         [load_app_mods(Sys, A, Early, PathFlag, Variables) || A <- MergedApps],
          {progress, modules_loaded},
 
          %% Start kernel processes
-         {path, create_path(MergedApps, PathFlag, Variables)},
+         {path, create_path(Sys, MergedApps, PathFlag, Variables)},
          kernel_processes(gen_app(KernelApp)),
          {progress, init_kernel_started},
 
@@ -482,8 +481,8 @@ do_gen_script(#rel{name = RelName, vsn = RelVsn},
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-load_app_mods(#app{mods = Mods0} = App, Mand, PathFlag, Variables) ->
-    Path = cr_path(App, PathFlag, Variables),
+load_app_mods(Sys, #app{mods = Mods0} = App, Mand, PathFlag, Variables) ->
+    Path = cr_path(Sys, App, PathFlag, Variables),
     Mods = [M || #mod{name = M, is_included=true} <- Mods0,
 		 not lists:member(M, Mand)],
     [{path, [filename:join([Path])]},
@@ -671,26 +670,30 @@ del_apps([], Apps) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% Create the complete path.
-create_path(Apps, PathFlag, Variables) ->
-    make_set([cr_path(App, PathFlag, Variables) || App <- Apps]).
+create_path(Sys, Apps, PathFlag, Variables) ->
+    make_set([cr_path(Sys, App, PathFlag, Variables) || App <- Apps]).
 
 %% Create the path to a specific application.
 %% (The otp_build flag is only used for OTP internal system make)
-cr_path(#app{label = Label}, true, []) ->
-    filename:join(["$ROOT", "lib", Label, "ebin"]);
-cr_path(#app{name = Name, vsn = Vsn, label = Label, active_dir = Dir},
+cr_path(Sys, #app{label = Label} = App, true, []) ->
+    Label2 = strip_app_name(Sys, App, Label),
+    filename:join(["$ROOT", "lib", Label2, "ebin"]);
+cr_path(Sys,
+        #app{name = Name, vsn = Vsn, label = Label, active_dir = Dir} = App,
 	true,
 	Variables) ->
-    Tail = [Label, "ebin"],
+    Label2 = strip_app_name(Sys, App, Label),
+    Tail = [Label2, "ebin"],
     case variable_dir(Dir, atom_to_list(Name), Vsn, Variables) of
         {ok, VarDir} ->
             filename:join([VarDir] ++ Tail);
         _ ->
             filename:join(["$ROOT", "lib"] ++ Tail)
     end;
-cr_path(#app{name = Name}, otp_build, _) ->
-    filename:join(["$ROOT", "lib", atom_to_list(Name), "ebin"]);
-cr_path(#app{active_dir = Dir}, _, _) ->
+cr_path(Sys, #app{name = Name} = App, otp_build, _) ->
+    Name2 = strip_app_name(Sys, App, Name),
+    filename:join(["$ROOT", "lib", Name2, "ebin"]);
+cr_path(_Sys, #app{active_dir = Dir}, _, _) ->
     filename:join([Dir, "ebin"]).
 
 variable_dir(Dir, Name, Vsn, [{Var,Path} | Variables]) ->
@@ -726,12 +729,12 @@ strip_name_ebin(Dir, Name, Vsn) ->
     end.
 
 %% Create the path to the kernel and stdlib applications.
-create_mandatory_path(Apps, PathFlag, Variables) ->
+create_mandatory_path(Sys, Apps, PathFlag, Variables) ->
     Mandatory = [kernel, stdlib],
     make_set(lists:map(fun(#app{name = Name} = App) ->
                                case lists:member(Name, Mandatory) of
                                    true ->
-                                       cr_path(App, PathFlag, Variables);
+                                       cr_path(Sys, App, PathFlag, Variables);
                                    false ->
                                        ""
                                end
@@ -821,7 +824,6 @@ do_gen_spec(#sys{root_dir = RootDir,
 		 excl_lib = ExclLib,
                  incl_sys_filters = InclRegexps,
                  excl_sys_filters = ExclRegexps,
-                 relocatable = Relocatable,
                  apps = Apps} = Sys) ->
     RelFiles = spec_rel_files(Sys),
     {SysFiles, InclRegexps2, ExclRegexps2, Mandatory} =
@@ -830,7 +832,7 @@ do_gen_spec(#sys{root_dir = RootDir,
 		{[],InclRegexps,ExclRegexps,["lib"]};
 	    _ ->
 		{create_dir, _, SF} = spec_dir(RootDir),
-		{ER2, SF2} = strip_sys_files(Relocatable, SF, Apps, ExclRegexps),
+                {ER2, SF2} = strip_sys_files(Sys, SF, Apps, ExclRegexps),
 		{IR2, BinFiles} =
 		    spec_bin_files(Sys, SF, SF2, RelFiles, InclRegexps),
 		SF3 = [{create_dir, "bin", BinFiles}] ++ SF2,
@@ -847,9 +849,9 @@ do_gen_spec(#sys{root_dir = RootDir,
     check_sys(Mandatory, SysFiles4),
     SysFiles4.
 
-strip_sys_files(Relocatable, SysFiles, Apps, ExclRegexps) ->
+strip_sys_files(#sys{relocatable=Reloc} = Sys, SysFiles, Apps, ExclRegexps) ->
     ExclRegexps2 =
-	case Relocatable of
+	case Reloc of
 	    true ->
 		ExtraExcl = ["^erts.*/bin/.*src\$"],
 		reltool_utils:decode_regexps(excl_sys_filters,
@@ -858,68 +860,107 @@ strip_sys_files(Relocatable, SysFiles, Apps, ExclRegexps) ->
 	    false ->
 		ExclRegexps
 	end,
-    {value, Erts} = lists:keysearch(erts, #app.name, Apps),
+    {value, ErtsApp} = lists:keysearch(erts, #app.name, Apps),
     FilterErts =
         fun(Spec) ->
-		File = element(2, Spec),
-		case File of
-		    "erts" ->
-			reltool_utils:throw_error("This system is not installed. "
-						  "The directory ~ts is missing.",
-				    [Erts#app.label]);
-		    _ when File =:= Erts#app.label ->
-			replace_dyn_erl(Relocatable, Spec);
-                    "erts-" ++ _ ->
-			false;
-                    _ ->
-                        true
+		Dir = element(2, Spec),
+                if
+                    Dir =:= "erts"; Dir =:= ErtsApp#app.label ->
+                        Spec2 = strip_app_dir(Sys, ErtsApp, Spec, []),
+                        replace_dyn_erl(Reloc, Spec2);
+                    true ->
+                        not lists:prefix("erts", Dir)
                 end
         end,
     SysFiles2 = lists:zf(FilterErts, SysFiles),
-    SysFiles3 = lists:foldl(fun(F, Acc) -> lists:keydelete(F, 2, Acc) end,
+    SysFiles3 = lists:foldl(fun(F, Acc) ->
+                                    case lists:keymember(F, 2, Acc) of
+                                        true  ->
+                                            lists:keydelete(F, 2, Acc);
+                                        false ->
+                                            reltool_utils:throw_error(
+                                              "This system is not installed. "
+                                              "The directory ~ts is missing.",
+                                              [F])
+                                    end
+                            end,
 			    SysFiles2,
 			    ["releases", "lib", "bin"]),
     {ExclRegexps2, SysFiles3}.
 
-replace_dyn_erl(false, _ErtsSpec) ->
-    true;
-replace_dyn_erl(true, {create_dir, ErtsDir, ErtsFiles}) ->
-    [{create_dir, _, BinFiles}] =
-	safe_lookup_spec("bin", ErtsFiles),
-    case lookup_spec("dyn_erl", BinFiles) of
-        [] ->
-            case lookup_spec("erl.ini", BinFiles) of
-                [] ->
-                    true;
-                [{copy_file, ErlIni}] ->
-                    %% Remove Windows .ini file
-                    BinFiles2 = lists:keydelete(ErlIni, 2, BinFiles),
-                    ErtsFiles2 =
-			lists:keyreplace("bin",
-					 2,
-					 ErtsFiles,
-					 {create_dir, "bin", BinFiles2}),
-                    {true, {create_dir, ErtsDir, ErtsFiles2}}
-            end;
-        [{copy_file, DynErlExe}] ->
-            %% Replace erl with dyn_erl
-            ErlExe = "erl" ++ filename:extension(DynErlExe),
-            BinFiles2 = lists:keydelete(DynErlExe, 2, BinFiles),
-            DynErlExe2 = filename:join([ErtsDir, "bin", DynErlExe]),
-            BinFiles3 = lists:keyreplace(ErlExe,
-					 2,
-					 BinFiles2,
-					 {copy_file, ErlExe, DynErlExe2}),
-            ErtsFiles2 = lists:keyreplace("bin",
-					  2,
-					  ErtsFiles,
-					  {create_dir, "bin", BinFiles3}),
-            {true, {create_dir, ErtsDir, ErtsFiles2}}
+strip_app_name(Sys, App, NameVsn) when is_atom(NameVsn) ->
+    strip_app_name(Sys, App, atom_to_list(NameVsn));
+strip_app_name(Sys, App, NameVsn) when is_list(NameVsn) ->
+    case resolve_app_dir_vsn(App, Sys) of
+        keep ->
+            NameVsn;
+        strip ->
+            {Name, _Vsn} = reltool_utils:split_app_name(NameVsn),
+            atom_to_list(Name)
     end.
 
+strip_app_dir(Sys, App, CreateDir, Prefix) ->
+    Dir = element(2, CreateDir),
+    Dir2 = strip_app_name(Sys, App, Dir),
+    case CreateDir of
+        {create_dir, Dir, Files} when Dir =:= Dir2 ->
+            {create_dir, Dir, Files};
+        {create_dir, Dir, Files} when Dir =/= Dir2 ->
+            {create_dir, Dir2, filename:join(Prefix ++ [Dir]), Files};
+        {create_dir, _Dir, SourceDir, Files} ->
+            {create_dir, Dir2, SourceDir, Files}
+    end.
+
+resolve_app_dir_vsn(#app{app_dir_vsn=AppDirVsn}, #sys{app_dir_vsn=SysAppDirVsn}) ->
+    case AppDirVsn of
+        undefined -> SysAppDirVsn;
+        _         -> AppDirVsn
+    end.
+
+replace_dyn_erl(false, CreateDir) ->
+    {true, CreateDir};
+replace_dyn_erl(true, CreateDir) ->
+    FilePos = tuple_size(CreateDir),
+    ErtsFiles = element(FilePos, CreateDir),
+    DirPos = FilePos-1,
+    SourceErtsDir = element(DirPos, CreateDir),
+    [{create_dir, _, BinFiles}] = safe_lookup_spec("bin", ErtsFiles),
+    ErtsFiles2 =
+        case lookup_spec("dyn_erl", BinFiles) of
+            [] ->
+                case lookup_spec("erl.ini", BinFiles) of
+                    [] ->
+                        ErtsFiles;
+                    [{copy_file, ErlIni}] ->
+                        %% Remove Windows .ini file
+                        BinFiles2 = lists:keydelete(ErlIni, 2, BinFiles),
+                        lists:keyreplace("bin",
+                                         2,
+                                         ErtsFiles,
+                                         {create_dir, "bin", BinFiles2})
+                end;
+            [{copy_file, DynErlExe}] ->
+                %% Replace erl with dyn_erl
+                ErlExe = "erl" ++ filename:extension(DynErlExe),
+                BinFiles2 = lists:keydelete(DynErlExe, 2, BinFiles),
+                DynErlExe2 = filename:join([SourceErtsDir, "bin", DynErlExe]),
+                BinFiles3 = lists:keyreplace(ErlExe,
+                                             2,
+                                             BinFiles2,
+                                             {copy_file, ErlExe, DynErlExe2}),
+                lists:keyreplace("bin",
+                                 2,
+                                 ErtsFiles,
+                                 {create_dir, "bin", BinFiles3})
+        end,
+    {true, setelement(FilePos, CreateDir, ErtsFiles2)}.
+
 spec_bin_files(Sys, AllSysFiles, StrippedSysFiles, RelFiles, InclRegexps) ->
-    [{create_dir, ErtsLabel, ErtsFiles}] =
-	safe_lookup_spec("erts", StrippedSysFiles),
+    [ErtsCreateDir] = safe_lookup_spec("erts", StrippedSysFiles),
+    FilePos = tuple_size(ErtsCreateDir),
+    DirPos = FilePos-1,
+    ErtsLabel = element(DirPos, ErtsCreateDir),
+    ErtsFiles = element(FilePos, ErtsCreateDir),
     [{create_dir, _, BinFiles}] = safe_lookup_spec("bin", ErtsFiles),
     ErtsBin = filename:join([ErtsLabel, "bin"]),
     Escripts = spec_escripts(Sys, ErtsBin, BinFiles),
@@ -1094,15 +1135,15 @@ spec_app(#app{name              = Name,
     %% Regular top directory and/or archive
     spec_archive(App, Sys, AppFiles3).
 
-spec_archive(#app{label               = Label,
-                  active_dir          = SourceDir,
+spec_archive(#app{label                = Label,
+                  active_dir           = SourceDir,
                   incl_archive_filters = AppInclArchiveDirs,
                   excl_archive_filters = AppExclArchiveDirs,
-                  archive_opts        = AppArchiveOpts},
-             #sys{root_dir            = RootDir,
+                  archive_opts         = AppArchiveOpts} = App,
+             #sys{root_dir             = RootDir,
                   incl_archive_filters = SysInclArchiveDirs,
                   excl_archive_filters = SysExclArchiveDirs,
-                  archive_opts        = SysArchiveOpts},
+                  archive_opts         = SysArchiveOpts} = Sys,
              Files) ->
     InclArchiveDirs =
 	reltool_utils:default_val(AppInclArchiveDirs, SysInclArchiveDirs),
@@ -1114,23 +1155,25 @@ spec_archive(#app{label               = Label,
     case lists:filter(Match, Files) of
         [] ->
             %% Nothing to archive
-            [spec_create_dir(RootDir, SourceDir, Label, Files)];
+            [spec_app_create_dir(Sys, App, RootDir, SourceDir, Label, Files)];
         ArchiveFiles ->
             OptDir =
                 case Files -- ArchiveFiles of
                     [] ->
                         [];
                     ExternalFiles ->
-                        [spec_create_dir(RootDir,
-					 SourceDir,
-					 Label,
-					 ExternalFiles)]
+                        [spec_app_create_dir(Sys, App, RootDir, SourceDir,
+                                             Label, ExternalFiles)]
                 end,
             ArchiveOpts =
 		reltool_utils:default_val(AppArchiveOpts, SysArchiveOpts),
             ArchiveDir =
-		spec_create_dir(RootDir, SourceDir, Label, ArchiveFiles),
-            [{archive, Label ++ ".ez", ArchiveOpts, [ArchiveDir]} | OptDir]
+		spec_app_create_dir(Sys, App, RootDir, SourceDir,
+                                    Label, ArchiveFiles),
+%%            io:format("ArchiveDir: ~p\n", [ArchiveDir]),
+
+            NameOrLabel = element(2, ArchiveDir),
+            [{archive, NameOrLabel ++ ".ez", ArchiveOpts, [ArchiveDir]} | OptDir]
     end.
 
 spec_dir(Dir) ->
@@ -1204,12 +1247,14 @@ spec_opt_copy_file(DirName, BaseName) ->
         false -> []
     end.
 
-spec_create_dir(RootDir, SourceDir, BaseDir, Files) ->
+spec_app_create_dir(Sys, App, RootDir, SourceDir, Label, Files) ->
     LibDir = filename:join([RootDir, "lib"]),
-    case abs_to_rel_path(LibDir, SourceDir) of
-        {relative, Dir} ->  {create_dir, Dir, Files};
-        {absolute, Dir} ->  {create_dir, BaseDir, Dir, Files}
-    end.
+    CreateDir =
+        case abs_to_rel_path(LibDir, SourceDir) of
+            {relative, Dir} -> {create_dir, Dir, Files};
+            {absolute, Dir} -> {create_dir, Label, Dir, Files}
+        end,
+    strip_app_dir(Sys, App, CreateDir, ["lib"]).
 
 abs_to_rel_path(RootDir, SourcePath) ->
     R = filename:split(RootDir),
@@ -1265,7 +1310,7 @@ do_eval_spec({create_dir, Dir, OldDir, Files},
     SourceDir2 = filename:join([OrigSourceDir, OldDir]),
     TargetDir2 = filename:join([TargetDir, Dir]),
     reltool_utils:create_dir(TargetDir2),
-    do_eval_spec(Files, SourceDir2, SourceDir2, TargetDir2);
+    do_eval_spec(Files, OrigSourceDir, SourceDir2, TargetDir2);
 do_eval_spec({archive, Archive, Options, Files},
 	     OrigSourceDir,
 	     SourceDir,

--- a/lib/reltool/src/reltool_utils.erl
+++ b/lib/reltool/src/reltool_utils.erl
@@ -576,10 +576,11 @@ copy_file(From, To) ->
 		    write_file_info(To, FileInfo),
 		    ok;
 		{error, Reason} ->
+                    io:format("Stack: ~p\n", [erlang:get_stacktrace()]),
 		    Text = file:format_error(Reason),
-		    throw_error("copy file ~ts -> ~ts: ~ts\n", [From, To, Text])
+                    throw_error("copy file ~ts -> ~ts: ~ts\n", [From, To, Text])
 	    end;
-	error ->
+        error ->
 	    Text = file:format_error(enoent),
 	    throw_error("copy file ~ts -> ~ts: ~ts\n", [From, To, Text])
     end.

--- a/lib/reltool/test/reltool_server_SUITE.erl
+++ b/lib/reltool/test/reltool_server_SUITE.erl
@@ -108,6 +108,7 @@ all() ->
      create_script,
      create_script_sort,
      create_target,
+     app_dir_vsn,
      create_target_unicode,
      create_embedded,
      create_standalone,
@@ -797,7 +798,25 @@ create_target(_Config) ->
     Erl = filename:join([TargetDir, "bin", "erl"]),
     {ok, Node} = ?msym({ok, _}, start_node(?NODE_NAME, Erl)),
     ?msym(ok, stop_node(Node)),
+    ok.
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Generate target system without application versions
+
+app_dir_vsn(_Config) ->
+    %% Configure the server
+    Config = {sys, [{app_dir_vsn,strip}]},
+
+    %% Generate target file
+    TargetDir = filename:join([?WORK_DIR, "app_dir_vsn"]),
+    ?m(ok, reltool_utils:recursive_delete(TargetDir)),
+    ?m(ok, file:make_dir(TargetDir)),
+    ?log("SPEC: ~p\n", [reltool:get_target_spec([{config, Config}])]),
+    ok = ?m(ok, reltool:create_target([{config, Config}], TargetDir)),
+
+    Erl = filename:join([TargetDir, "bin", "erl"]),
+    {ok, Node} = ?msym({ok, _}, start_node(?NODE_NAME, Erl)),
+    ?msym(ok, stop_node(Node)),
     ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Functions specified with the new parameter {boot_phase_fun, fun/4} can be used to control the contents of boot files.

This pull request is based on an earlier (not yet approved) pull request in order to simplify merging.