### PR TITLE
fixed small typo (missing right parenthesis) in gen_fsm example

### DIFF
--- a/system/doc/design_principles/fsm.xml
+++ b/system/doc/design_principles/fsm.xml
@@ -75,7 +75,7 @@ StateName(Event, StateData) ->
 -export([init/1, locked/2, open/2]).
 
 start_link(Code) ->
-    gen_fsm:start_link({local, code_lock}, code_lock, lists:reverse(Code, []).
+    gen_fsm:start_link({local, code_lock}, code_lock, lists:reverse(Code), []).
 
 button(Digit) ->
     gen_fsm:send_event(code_lock, {button, Digit}).


### PR DESCRIPTION
I discovered in the otp-system-documentation that the gen_fsm code example has a mini-error, a missing right parenthesis. Actually in the text explaining the code example, the right parenthesis does not miss.
