### PR TITLE
Some suggested corrections for the wx documentation.

### DIFF
--- a/lib/wx/doc/overview.edoc
+++ b/lib/wx/doc/overview.edoc
@@ -39,7 +39,7 @@ wxWidgets is represented as a module in erlang. This gives
 the <em>wx</em> application a huge interface, spread over several
 modules, and it all starts with the <em>wx</em>
 module. The <em>wx</em> module contains functions to create and
-destroy the gui, i.e. <code>wx:new/0</code>,<code>wx:destroy/0</code>, and
+destroy the gui, i.e. <code>wx:new/0</code>, <code>wx:destroy/0</code>, and
 some other useful functions. 
 
 Objects or object references in <em>wx</em> should be seen as erlang


### PR DESCRIPTION
Here are some suggested corrections for the wx documentation.

There are also some more things which I would suggest, but aren't in this patch:
1) _fun_ is sometimes emphasised, sometimes not... _I_ think it should always be emphasised.
2) API, GUI and Erlang is written in lower case. _I_ think API and GUI should use upper case, and Erlang should start with a capital E.
