### PR TITLE
epmd: Fix -names option on Windows

### DIFF
--- a/erts/epmd/src/epmd_cli.c
+++ b/erts/epmd/src/epmd_cli.c
@@ -118,7 +118,7 @@ void epmd_call(EpmdVars *g,int what)
     if (!g->silent) {
 	rval = erts_snprintf(buf, OUTBUF_SIZE,
 			     "epmd: up and running on port %d with data:\n", j);
-	write(1, buf, rval);
+	fwrite(buf, 1, rval, stdout);
     }
     while(1) {
 	if ((rval = read(fd,buf,OUTBUF_SIZE)) <= 0)  {
@@ -126,7 +126,7 @@ void epmd_call(EpmdVars *g,int what)
 	    epmd_cleanup_exit(g,0);
 	}
 	if (!g->silent)
-	    write(1, buf, rval); /* Potentially UTF-8 encoded */
+	    fwrite(buf, 1, rval, stdout); /* Potentially UTF-8 encoded */
     }
 }
 


### PR DESCRIPTION
Since 3aa60cc `epmd -names` does not produce any output on Windows
anymore. This patch uses fwrite() instead of write() which adds the
necessary carriage returns to the output so that it is suitable for the
Windows cmd.exe.

A test case is added (fails on Windows without the patch).
