### PR TITLE
fixes problem with ODBC on OS X 10.9 Mavericks

### DIFF
--- a/lib/odbc/configure.in
+++ b/lib/odbc/configure.in
@@ -130,7 +130,7 @@ AC_SUBST(THR_LIBS)
 odbc_lib_link_success=no
 AC_SUBST(TARGET_FLAGS)
     case $host_os in
-        darwin*)
+        darwin1[[0-2]].*|darwin[[0-9]].*)
                 TARGET_FLAGS="-DUNIX"
 	        if test ! -d "$with_odbc" || test "$with_odbc" = "yes"; then
 		    ODBC_LIB= -L"/usr/lib"


### PR DESCRIPTION
Since Apple has removed iODBC from the default OS X 10.9 Mavericks installation I tried to compile Erlang R16B02 with unixODBC.
Even with installed unixODBC and specified --with-odbc=[path to my unixODBC] option Erlang R16B02 still uses iODBC (because Apple has left some iODBC binaries):

1> odbc:start().
ok
2> odbc:connect("",[]).
{error,"[iODBC][Driver Manager]No data source or driver specified, dialog prohibited SQLSTATE IS: IM007 Connection to database failed."}
