### PR TITLE
Fix malformed crypto appup template.

### DIFF
--- a/lib/crypto/src/crypto.appup.src
+++ b/lib/crypto/src/crypto.appup.src
@@ -19,10 +19,12 @@
 %%
 {"%VSN%",
  [
+  {<<"3\\..*">>, [{restart_application, crypto}]},
   {<<"2\\..*">>, [{restart_application, crypto}]},
   {<<"1\\..*">>, [{restart_application, crypto}]}
  ],
  [
+  {<<"3\\..*">>, [{restart_application, crypto}]},
   {<<"2\\..*">>, [{restart_application, crypto}]},
   {<<"1\\..*">>, [{restart_application, crypto}]}
  ]}.


### PR DESCRIPTION
This patch adds the missing comma separators in the `crypto.appup.src` template. Consulting the current file issues an error prohibiting proper release upgrade generation.
