### PR TITLE
Fix emulator upgrades (broken since R15B)

### DIFF
--- a/lib/sasl/src/release_handler.erl
+++ b/lib/sasl/src/release_handler.erl
@@ -1108,7 +1108,7 @@ new_emulator_make_hybrid_boot(CurrentVsn,ToVsn,TmpVsn,BaseLibs,RelDir,Opts,Maste
     Args = [ToVsn,Opts],
     {ok,FromBoot} = read_file(FromBootFile,Masters),
     {ok,ToBoot} = read_file(ToBootFile,Masters),
-    {{_,_,KernelPath},{_,_,SaslPath},{_,_,StdlibPath}} = BaseLibs,
+    {{_,_,KernelPath},{_,_,StdlibPath},{_,_,SaslPath}} = BaseLibs,
     Paths = {filename:join(KernelPath,"ebin"),
 	     filename:join(StdlibPath,"ebin"),
 	     filename:join(SaslPath,"ebin")},


### PR DESCRIPTION
I discovered that emulator upgrades are currently not working. Trying to boot the generated intermediate release fails, due to an error in the generated `.boot` script.

After tracking down this subtle but severe bug to commit 295f980c31ce65e1f2ba0a3256e3b9055b136dc4, I realized that this form of upgrading is broken since `R15B`. This should probably be mentioned somewhere in the docs, because upgrading will fail at a step you don't have a shell connected to the node (to see the failure you'll need to read the `.erlang.log.*` file if available). To be able to upgrade from one of the broken releases to another will require a patch of the running `release_handler` module **before** installing the upgrade.

This patch fixes the intermediate `.boot` file generation. As always the patch also removes trailing whitespace and replaces tabs with spaces in the touched file. For the curious ones the (tiny) fix is on line `1111`.
