### PR TITLE
Track variable substitutions in Core clause patterns

### DIFF
--- a/lib/compiler/test/bin_alias.core
+++ b/lib/compiler/test/bin_alias.core
@@ -1,0 +1,39 @@
+module 'bin_alias' ['t'/1]
+    attributes []
+'t'/1 =
+    %% Line 4
+    fun (_cor0) ->
+    case _cor0 of
+      <Bin1> when 'true' ->
+          %% Line 5
+          case Bin1 of
+        %% Line 6
+        <#{}#> when 'true' ->
+            'ok'
+        %% Line 7
+        <Bin2> when 'true' ->
+            %% Line 8
+            case Bin1 of
+              %% Line 9
+              <#{#<0>(8,1,'integer',['unsigned'|['big']])}#> when 'true' ->
+              'ok'
+              %% Line 10
+              <_cor4> when 'true' ->
+              Bin2
+              ( <_cor1> when 'true' ->
+                primop 'match_fail'
+                ({'case_clause',_cor1})
+            -| ['compiler_generated'] )
+            end
+        ( <_cor2> when 'true' ->
+              primop 'match_fail'
+              ({'case_clause',_cor2})
+          -| ['compiler_generated'] )
+          end
+      ( <_cor3> when 'true' ->
+        ( primop 'match_fail'
+              ({'function_clause',_cor3})
+          -| [{'function_name',{'t',1}}] )
+        -| ['compiler_generated'] )
+    end
+end

--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -22,7 +22,7 @@
 	 init_per_group/2,end_per_group/2,
 	 t_element/1,setelement/1,t_length/1,append/1,t_apply/1,bifs/1,
 	 eq/1,nested_call_in_case/1,guard_try_catch/1,coverage/1,
-	 unused_multiple_values_error/1,unused_multiple_values/1]).
+	 unused_multiple_values_error/1,unused_multiple_values/1,bin_alias/1]).
 
 -export([foo/0,foo/1,foo/2,foo/3]).
 
@@ -38,7 +38,7 @@ groups() ->
     [{p,test_lib:parallel(),
       [t_element,setelement,t_length,append,t_apply,bifs,
        eq,nested_call_in_case,guard_try_catch,coverage,
-       unused_multiple_values_error,unused_multiple_values]}].
+       unused_multiple_values_error,unused_multiple_values,bin_alias]}].
 
 
 init_per_suite(Config) ->
@@ -329,3 +329,11 @@ do_something(I) ->
     put(unused_multiple_values,
 	[I|get(unused_multiple_values)]),
     I.
+
+bin_alias(Config) when is_list(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    Dir = filename:dirname(code:which(?MODULE)),
+    Core = filename:join(Dir, "bin_alias"),
+    Opts = [clint,return,from_core,{outdir,PrivDir}|test_lib:opt_opts(?MODULE)],
+    {ok,bin_alias} = c:c(Core, Opts),
+    ok.


### PR DESCRIPTION
This allows the compiler to properly track aliases and avoids some crash related
to match context reusing as in the following code:

t(Bin1) ->
    case Bin1 of
        <<>> -> ok;
        Bin2 ->
            case Bin1 of
                <<0>> -> ok;
                _ -> Bin2
            end
    end.
