### PR TITLE
Properly let floating-point instructions through in the BEAM compiler

### DIFF
--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -144,6 +144,9 @@ collect({set_tuple_element,S,D,I}) -> {set,[],[S,D],{set_tuple_element,I}};
 collect({get_list,S,D1,D2})  -> {set,[D1,D2],[S],get_list};
 collect(remove_message)      -> {set,[],[],remove_message};
 collect({'catch',R,L})       -> {set,[R],[],{'catch',L}};
+collect(fclearerror)         -> {set,[],[],fclearerror};
+collect({fcheckerror,{f,0}}) -> {set,[],[],fcheckerror};
+collect({fmove,S,D})         -> {set,[D],[S],fmove};
 collect(_)                   -> error.
 
 %% embed_lines([Instruction]) -> [Instruction]

--- a/lib/compiler/src/beam_type.erl
+++ b/lib/compiler/src/beam_type.erl
@@ -142,6 +142,12 @@ simplify_float(Is0, Ts0) ->
 	throw:not_possible -> not_possible
     end.
 
+simplify_float_1([{set,[],[],fclearerror}|Is], Ts, Rs, Acc) ->
+    simplify_float_1(Is, Ts, Rs, clearerror(Acc));
+simplify_float_1([{set,[],[],fcheckerror}|Is], Ts, Rs, Acc) ->
+    simplify_float_1(Is, Ts, Rs, checkerror(Acc));
+simplify_float_1([{set,[{fr,_}],_,_}=I|Is], Ts, Rs, Acc) ->
+    simplify_float_1(Is, Ts, Rs, [I|Acc]);
 simplify_float_1([{set,[D0],[A0],{alloc,_,{gc_bif,'-',{f,0}}}}=I|Is]=Is0,
 		 Ts0, Rs0, Acc0) ->
     case tdb_find(A0, Ts0) of


### PR DESCRIPTION
The compiler shouldn't crash when fed an already-optimised BEAM assembly file.
