### PR TITLE
erl-shell expands zero-arity functions completely: adds the closing parenthesis.

### DIFF
--- a/lib/stdlib/src/edlin_expand.erl
+++ b/lib/stdlib/src/edlin_expand.erl
@@ -89,7 +89,13 @@ match(Prefix, Alts, Extra) ->
  		    {yes, Remain, []}
  	    end;
  	{complete, Str} ->
- 	    {yes, nthtail(Len, Str) ++ Extra, []};
+            {_, Arity} = lists:keyfind(Str, 1, Matches),
+            case {Arity, Extra} of
+                {0, "("} ->
+                    {yes, nthtail(Len, Str) ++ "()", []};
+                _ ->
+                    {yes, nthtail(Len, Str) ++ Extra, []}
+            end;
  	no ->
  	    {no, [], []}
     end.

--- a/lib/stdlib/test/edlin_expand_SUITE.erl
+++ b/lib/stdlib/test/edlin_expand_SUITE.erl
@@ -76,11 +76,14 @@ normal(Config) when is_list(Config) ->
 	   [{"a_fun_name",1},
 	    {"a_less_fun_name",1},
 	    {"b_comes_after_a",1},
+            {"expand0arity_entirely",0},
 	    {"module_info",0},
 	    {"module_info",1}]} = edlin_expand:expand(lists:reverse("expand_test:")),
     ?line {yes,[],[{"a_fun_name",1},
 		   {"a_less_fun_name",1}]} = edlin_expand:expand(
 					       lists:reverse("expand_test:a_")),
+    ?line {yes,"arity_entirely()",[]} = edlin_expand:expand(
+                                         lists:reverse("expand_test:expand0")),
     ok.
 
 quoted_fun(doc) ->
@@ -93,7 +96,7 @@ quoted_fun(Config) when is_list(Config) ->
     %% should be no colon after test this time
     ?line {yes, "test", []} = edlin_expand:expand(lists:reverse("expand_")),
     ?line {no, [], []} = edlin_expand:expand(lists:reverse("expandXX_")),
-    ?line {no,[],[{"'#weird-fun-name'",0},
+    ?line {no,[],[{"'#weird-fun-name'",1},
 		  {"'Quoted_fun_name'",0},
 		  {"'Quoted_fun_too'",0},
 		  {"a_fun_name",1},
@@ -108,7 +111,7 @@ quoted_fun(Config) when is_list(Config) ->
 		   {"a_less_fun_name",1}]} = edlin_expand:expand(
 					       lists:reverse("expand_test1:a_")),
     ?line {yes,[],
-	   [{"'#weird-fun-name'",0},
+	   [{"'#weird-fun-name'",1},
 	    {"'Quoted_fun_name'",0},
 	    {"'Quoted_fun_too'",0}]} = edlin_expand:expand(
 					 lists:reverse("expand_test1:'")),
@@ -172,6 +175,6 @@ quoted_both(Config) when is_list(Config) ->
 	   [{"'Quoted_fun_name'",0},
 	    {"'Quoted_fun_too'",0}]} = edlin_expand:expand(
 					 lists:reverse("'ExpandTestCaps1':'Quoted_fun_")),
-    ?line {yes,"weird-fun-name'(",[]} = edlin_expand:expand(
-					  lists:reverse("'ExpandTestCaps1':'#")),
+    ?line {yes,"weird-fun-name'()",[]} = edlin_expand:expand(
+                                           lists:reverse("'ExpandTestCaps1':'#")),
     ok.

--- a/lib/stdlib/test/expand_test.erl
+++ b/lib/stdlib/test/expand_test.erl
@@ -20,7 +20,8 @@
 
 -export([a_fun_name/1,
 	 a_less_fun_name/1,
-	 b_comes_after_a/1]).
+	 b_comes_after_a/1,
+         expand0arity_entirely/0]).
 
 a_fun_name(X) ->
     X.
@@ -30,3 +31,6 @@ a_less_fun_name(X) ->
 
 b_comes_after_a(X) ->
     X.
+
+expand0arity_entirely () ->
+    ok.

--- a/lib/stdlib/test/expand_test1.erl
+++ b/lib/stdlib/test/expand_test1.erl
@@ -23,7 +23,7 @@
 	 b_comes_after_a/1,
 	 'Quoted_fun_name'/0,
 	 'Quoted_fun_too'/0,
-	 '#weird-fun-name'/0]).
+	 '#weird-fun-name'/1]).
 
 a_fun_name(X) ->
     X.
@@ -40,5 +40,5 @@ b_comes_after_a(X) ->
 'Quoted_fun_too'() ->
     too.
 
-'#weird-fun-name'() ->
+'#weird-fun-name'(_) ->
     weird.


### PR DESCRIPTION
Say you have a module **m** with 3 exported functions:

```
my_func/0
my_func/1
ok_fun/0
```

Then the shell can now tab-completion (-->) this:

```
m:ok_ --> m:ok_fun()
```

Still, old (correct) behaviour is preserved:

```
m:my --> m:my_func(             %% instead of expanding to “m:my_func()”
```

These are the actual changes: https://github.com/fenollp/otp/blob/88753d3c3c0875d8ad6c04fe422559a2f328edda/lib/stdlib/src/edlin_expand.erl#L91-L98
Related tests is mostly this one: https://github.com/fenollp/otp/blob/cdee8ad3b69fb32a550b8711f04b5c5c9818d696/lib/stdlib/test/edlin_expand_SUITE.erl#L85-L86
