### PR TITLE
Fix DTrace build on Illumos

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3804,10 +3804,16 @@ if test "$enable_dtrace_test" = "yes" ; then
                 if ! dtrace -h $DTRACE_CPP -Iemulator/beam -o ./foo-dtrace.h -s emulator/beam/erlang_dtrace.d; then
                         AC_MSG_ERROR([Could not precompile erlang_dtrace.d: dtrace -h failed])
                 fi
-                rm -f foo-dtrace.h
+
+                $RM -f dtest.{o,c}
+                cat > dtest.c <<_DTEST
+                        #include "foo-dtrace.h"
+                        int main(void) { ERLANG_DIST_PORT_BUSY_ENABLED(); return 0; }
+_DTEST
+                $CC $CFLAGS -c -o dtest.o dtest.c
 
                 $RM -f $DTRACE_2STEP_TEST
-                if dtrace -G $DTRACE_CPP $DTRACE_BITS_FLAG -Iemulator/beam -o $DTRACE_2STEP_TEST -s emulator/beam/erlang_dtrace.d 2> /dev/null && \
+                if dtrace -G $DTRACE_CPP $DTRACE_BITS_FLAG -Iemulator/beam -o $DTRACE_2STEP_TEST -s emulator/beam/erlang_dtrace.d dtest.o && \
                    test -f $DTRACE_2STEP_TEST ; then
                         rm $DTRACE_2STEP_TEST
                         DTRACE_ENABLED_2STEP=yes
@@ -3815,6 +3821,8 @@ if test "$enable_dtrace_test" = "yes" ; then
                 else
                         AC_MSG_NOTICE([dtrace precompilation for 1-stage DTrace successful])
                 fi
+                $RM -f dtest.{o,c} foo-dtrace.h
+
                 DTRACE_ENABLED=yes
                 case $OPSYS in
                     linux)

--- a/lib/runtime_tools/c_src/Makefile.in
+++ b/lib/runtime_tools/c_src/Makefile.in
@@ -21,11 +21,6 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 include $(ERL_TOP)/make/$(TARGET)/otp_ded.mk
 
 # ----------------------------------------------------
-# Items from top-level configure
-# ----------------------------------------------------
-DTRACE_ENABLED=@DTRACE_ENABLED@
-DTRACE_ENABLED_2STEP=@DTRACE_ENABLED_2STEP@
-# ----------------------------------------------------
 # Application version
 # ----------------------------------------------------
 include ../vsn.mk
@@ -108,28 +103,7 @@ _create_dirs := $(shell mkdir -p $(OBJDIR) $(LIBDIR))
 
 debug opt valgrind: $(SOLIBS) $(OBJDIR) $(LIBDIR) $(NIF_LIB)
 
-ifdef DTRACE_ENABLED
-DTRACE_USER_HEADER=$(OBJDIR)/dtrace_user.h
-$(OBJDIR)/dtrace_user.h: ./dtrace_user.d
-	$(dtrace_verbose)dtrace -h -C $(INCLUDES) \
-	  -s ./dtrace_user.d \
-	  -o ./dtrace_user.tmp
-	$(V_at)sed -e '/^#define[ 	]*ERLANG_[A-Z0-9_]*(.*)/y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/' ./dtrace_user.tmp > $@
-	$(V_at)rm ./dtrace_user.tmp
-else
-DTRACE_USER_HEADER=
-endif
-
-DTRACE_OBJS =
-ifdef DTRACE_ENABLED_2STEP
-DTRACE_OBJS += $(OBJDIR)/dtrace_user.o
-$(OBJDIR)/dtrace_user.o: $(before_DTrace_OBJS) $(OBJDIR)/dtrace_user.h
-	$(dtrace_verbose)dtrace -G -C \
-	  -s ./dtrace_user.d \
-	  -o $@ $(before_DTrace_OBJS)
-endif
-
-DYNTRACE_OBJS = $(before_DTrace_OBJS) $(DTRACE_OBJS)
+DYNTRACE_OBJS = $(before_DTrace_OBJS)
 
 $(OBJDIR):
 	-@mkdir -p $(OBJDIR)
@@ -137,7 +111,7 @@ $(OBJDIR):
 $(LIBDIR):
 	-@mkdir -p $(LIBDIR)
 
-$(OBJDIR)/dyntrace$(TYPEMARKER).o: dyntrace.c $(DTRACE_USER_HEADER)
+$(OBJDIR)/dyntrace$(TYPEMARKER).o: dyntrace.c
 	$(V_at)$(INSTALL_DIR) $(OBJDIR)
 	$(V_CC) -c -o $@ $(ALL_CFLAGS) $<
 

--- a/lib/runtime_tools/c_src/dyntrace.c
+++ b/lib/runtime_tools/c_src/dyntrace.c
@@ -30,9 +30,6 @@
 #if defined(USE_DYNAMIC_TRACE) && (defined(USE_DTRACE) || defined(USE_SYSTEMTAP))
 #define HAVE_USE_DTRACE 1
 #endif
-#ifdef  HAVE_USE_DTRACE
-#include "dtrace_user.h"
-#endif
 
 void dtrace_nifenv_str(ErlNifEnv *env, char *process_buf);
 void get_string_maybe(ErlNifEnv *env, const ERL_NIF_TERM term, char **ptr, char *buf, int bufsiz);


### PR DESCRIPTION
DTrace was recently patched in Illumos to fail to create an object
file if no probes are found.
- https://www.illumos.org/issues/4248
- https://github.com/illumos/illumos-gate/commit/54a20ab41aadcb81c53e72fc65886e964e9add59

This patch fixes two issues:
- Modify the configure script to pass an object file to `dtrace -G`
  that actually invokes a probe.
- Remove creation of `dtrace_user.o` from the dyntrace Makefile. In a
  previous commit [1](https://github.com/erlang/otp/commit/75552bd3bb4e7f3cf4dab81a5c81cf73b1d3fb99) Scott Fritchie relocated all the user probes
  into the VM proper due to difficulties with DTrace probes in shared
  libraries. The `dtrace_user.d` file is now empty and generates a
  header file with nothing in it. There is no longer any reason to
  generate `dtrace_user.o` because all the probes are in the VM. Thus
  all the steps for building `dtrace_user.o` have been removed.
