### PR TITLE
Clean up some awkward wording around the +spp flag.

### DIFF
--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -1126,18 +1126,18 @@
           <tag><marker id="+spp"><c>+spp Bool</c></marker></tag>
           <item>
 	    <p>Set default scheduler hint for port parallelism. If set to
-	    <c>true</c>, the VM will schedule port tasks when it by this can
-	    improve the parallelism in the system. If set to <c>false</c>,
-	    the VM will try to perform port tasks immediately and by this
-	    improve latency at the expense of parallelism. If this
-	    flag has not been passed, the default scheduler hint for port
-	    parallelism is currently <c>false</c>. The default used can be
-	    inspected in runtime by calling
-	    <seealso marker="erlang#system_info_port_parallelism">erlang:system_info(port_parallelism)</seealso>.
+	    <c>true</c>, the VM will schedule port tasks when doing so will
+	    improve parallelism in the system. If set to <c>false</c>, the VM
+	    will try to perform port tasks immediately, improving latency at the
+	    expense of parallelism. If this flag has not been passed, the
+	    default scheduler hint for port parallelism is currently
+	    <c>false</c>. The default used can be inspected in runtime by
+	    calling <seealso
+	    marker="erlang#system_info_port_parallelism">erlang:system_info(port_parallelism)</seealso>.
 	    The default can be overriden on port creation by passing the
 	    <seealso marker="erlang#open_port_parallelism">parallelism</seealso>
-	    option to
-	    <seealso marker="erlang#open_port/2">open_port/2</seealso></p>.
+	    option to <seealso
+	    marker="erlang#open_port/2">open_port/2</seealso></p>.
 	  </item>
 	  <tag><marker id="sched_thread_stack_size"><c><![CDATA[+sss size]]></c></marker></tag>
 	  <item>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2886,11 +2886,11 @@ os_prompt% </pre>
           <tag><marker id="open_port_parallelism"><c>{parallelism, Boolean}</c></marker></tag>
           <item>
             <p>Set scheduler hint for port parallelism. If set to <c>true</c>,
-	    the VM will schedule port tasks when it by this can improve the
+	    the VM will schedule port tasks when doing so will improve
 	    parallelism in the system. If set to <c>false</c>, the VM will
-	    try to perform port tasks immediately and by this improving the
-	    latency at the expense of parallelism. The default can be set on
-	    system startup by passing the
+	    try to perform port tasks immediately, improving latency at the
+            expense of parallelism. The default can be set on system startup
+            by passing the
 	    <seealso marker="erl#+spp">+spp</seealso> command line argument
 	    to <seealso marker="erl">erl(1)</seealso>.
 	    </p>


### PR DESCRIPTION
This issue was pointed out by lpgauth in #erlounge. While the intention is
clear, the original wording was a bit dodgy. I'm no grammarian--though I am a
native speaker--so it's quite possible the new wording I've introduced is not
impeachable. Should be idiomatic, though.

Signed-off-by: Brian L. Troutwine brian.troutwine@adroll.com
