### PR TITLE
remove comma on line 108

### DIFF
--- a/lib/odbc/configure.in
+++ b/lib/odbc/configure.in
@@ -105,7 +105,7 @@ AC_CHECK_FUNC(gethostbyname, , AC_CHECK_LIB(nsl, main, [LIBS="$LIBS -lnsl"]))
 dnl Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([fcntl.h netdb.h stdlib.h string.h sys/socket.h winsock2.h])
-AC_CHECK_HEADERS([sql.h, sqlext.h], [odbc_required_headers=yes], [odbc_required_headers=no])
+AC_CHECK_HEADERS([sql.h sqlext.h], [odbc_required_headers=yes], [odbc_required_headers=no])
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST


### PR DESCRIPTION
the original content is `AC_CHECK_HEADERS([sql.h, sqlext.h], [odbc_required_headers=yes], [odbc_required_headers=no])` on line 108 of file lib/odbc/configure.in, this will cause a compile error when test if the `sql.h` can be included in the method `ac_fn_c_try_compile` in the `lib/odbc/configure` script generated based on `lib/odbc/configure.in`.

Please check the `lib/odbc/config.log` file after running `configure` script in the ERL_ROOT dir.
