### PR TITLE
Fix tls_connection shutdown cleanup

### DIFF
--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -299,6 +299,7 @@ init([Role, Host, Port, Socket, {SSLOpts0, _} = Options,  User, CbInfo]) ->
     State0 = initial_state(Role, Host, Port, Socket, Options, User, CbInfo),
     Handshake = tls_handshake:init_handshake_history(),
     TimeStamp = calendar:datetime_to_gregorian_seconds({date(), time()}),
+    process_flag(trap_exit, true),
     try ssl_init(SSLOpts0, Role) of
 	{ok, Ref, CertDbHandle, FileRefHandle, CacheHandle, OwnCert, Key, DHParams} ->
 	    Session = State0#state.session,
@@ -2974,12 +2975,12 @@ get_timeout(#state{ssl_options=#ssl_options{hibernate_after = undefined}}) ->
 get_timeout(#state{ssl_options=#ssl_options{hibernate_after = HibernateAfter}}) ->
     HibernateAfter.
 
-handle_trusted_certs_db(#state{ssl_options = #ssl_options{cacertfile = <<>>}}) ->
+handle_trusted_certs_db(#state{ssl_options = #ssl_options{cacertfile = <<>>, cacerts = []}}) ->
     %% No trusted certs specified
     ok;
 handle_trusted_certs_db(#state{cert_db_ref = Ref,
 			       cert_db = CertDb,
-			       ssl_options = #ssl_options{cacertfile = undefined}}) ->
+			       ssl_options = #ssl_options{cacertfile = <<>>}}) ->
     %% Certs provided as DER directly can not be shared
     %% with other connections and it is safe to delete them when the connection ends.
     ssl_pkix_db:remove_trusted_certs(Ref, CertDb);


### PR DESCRIPTION
The SSL library maintains an internal table of CA certificates
(ssl_otp_cacertificate_db). This is supposed to be cleaned up when the
last connection using a certificate closes, however there's two problems
in R16B02 (and in the current master branch on github):
- When CA certificates are provided as binary blobs, rather than by
  filename (ie, #ssl_options.cacerts is set, but #ssl_options.cacertfile
  is undefined) the cleanup never occurs due to an incorrect pattern
  match in tls_connection:handle_trusted_certs_db/1. This causes the
  table to grow unchecked because each connection adds a new entry.
- When the process exits abnormally, tls_connection:terminate/1 is never
  called because the trap_exit process flag is not set and so similarly
  the table (and everything else cleaned in terminate/1, for that
  matter) is not cleaned up. This doesn't affect "normal" termination
  caused by the connection closing because terminate/1 is called
  explicitly from handle_sync_event/4, rather that relying on gen_fsm's
  automatic calling.
