### PR TITLE
Define orbvsn macro

### DIFF
--- a/lib/orber/src/Makefile
+++ b/lib/orber/src/Makefile
@@ -197,8 +197,7 @@ ERL_IDL_FLAGS += -pa $(ERL_TOP)/lib/orber/ebin
 ERL_COMPILE_FLAGS += $(ERL_IDL_FLAGS) \
 	-I$(ERL_TOP)/lib/orber/include \
 	+'{parse_transform,sys_pre_attributes}' \
-	+'{attribute,insert,app_vsn,"orber_$(ORBER_VSN)"}' \
-	-D'ORBVSN="$(ORBER_VSN)"'
+	+'{attribute,insert,app_vsn,"orber_$(ORBER_VSN)"}'
 
 ASN_FLAGS = -bber +der +compact_bit_string +nowarn_unused_record
 

--- a/lib/orber/src/orber_env.erl
+++ b/lib/orber/src/orber_env.erl
@@ -33,6 +33,7 @@
 
 -include_lib("orber/include/corba.hrl").
 -include_lib("orber/src/orber_iiop.hrl").
+-define(ORBVSN, case os:getenv("ORBER_VSN") of false -> ""; Vsn -> Vsn end).
 
 %%-----------------------------------------------------------------
 %% External exports


### PR DESCRIPTION
`lib/orber/src/orber_env.erl` needed a macro (ORBVSN) defined in the orber Makefile.
The macro is only used by orber_env.

Definition of ORBVSN is moved to the only module that uses it. It is now easier for external tools to build such a module (such as erldocs.com).
