### PR TITLE
Fix evaluation of andalso and orelse in the debugger

### DIFF
--- a/lib/debugger/src/dbg_ieval.erl
+++ b/lib/debugger/src/dbg_ieval.erl
@@ -694,23 +694,25 @@ expr({'if',Line,Cs}, Bs, Ieval) ->
     if_clauses(Cs, Bs, Ieval#ieval{line=Line});
 
 %% Andalso/orelse
-expr({'andalso',Line,E1,E2}, Bs, Ieval) ->
-    case expr(E1, Bs, Ieval#ieval{line=Line, top=false}) of
-	{value,false,_}=Res ->
-	    Res;
-	{value,true,_} -> 
-	    expr(E2, Bs, Ieval#ieval{line=Line, top=false});
-	{value,Val,Bs} ->
-	    exception(error, {badarg,Val}, Bs, Ieval)
+expr({'andalso',Line,E1,E2}, Bs0, Ieval) ->
+    case expr(E1, Bs0, Ieval#ieval{line=Line, top=false}) of
+        {value,false,_}=Res ->
+           Res;
+        {value,true,Bs} ->
+            {value,Val,_} = expr(E2, Bs, Ieval#ieval{line=Line, top=false}),
+            {value,Val,Bs};
+        {value,Val,Bs} ->
+            exception(error, {badarg,Val}, Bs, Ieval)
     end;
-expr({'orelse',Line,E1,E2}, Bs, Ieval) ->
-    case expr(E1, Bs, Ieval#ieval{line=Line, top=false}) of
-	{value,true,_}=Res ->
-	    Res;
-	{value,false,_} ->
-	    expr(E2, Bs, Ieval#ieval{line=Line, top=false});
-	{value,Val,_} ->
-	    exception(error, {badarg,Val}, Bs, Ieval)
+expr({'orelse',Line,E1,E2}, Bs0, Ieval) ->
+    case expr(E1, Bs0, Ieval#ieval{line=Line, top=false}) of
+        {value,true,_}=Res ->
+           Res;
+        {value,false,Bs} ->
+            {value,Val,_} = expr(E2, Bs, Ieval#ieval{line=Line, top=false}),
+            {value,Val,Bs};
+        {value,Val,Bs} ->
+            exception(error, {badarg,Val}, Bs, Ieval)
     end;
 
 %% Matching expression

--- a/lib/debugger/test/int_eval_SUITE_data/my_int_eval_module.erl
+++ b/lib/debugger/test/int_eval_SUITE_data/my_int_eval_module.erl
@@ -236,4 +236,8 @@ otp_8310() ->
         (catch {a, [X || X <- a]}),
     {'EXIT',{{bad_generator,b},_}} =
         (catch {a, << <<X>>  || << X >> <= b >>}),
+    true = begin (X1 = true) andalso X1, X1 end,
+    false = begin (X2 = false) andalso X2, X2 end,
+    true = begin (X3 = true) orelse X3, X3 end,
+    false = begin (X4 = false) orelse X4, X4 end,
     ok.


### PR DESCRIPTION
Their exporting rules were not respected.
