### PR TITLE
make clean should not remove SKIP files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -992,9 +992,12 @@ $(IBIN_DIR):
 
 clean: check_recreate_primary_bootstrap
 	rm -f *~ *.bak config.log config.status prebuilt.files ibin/*
-	find . -type f -name SKIP -print | xargs $(RM)
 	cd erts && ERL_TOP=$(ERL_TOP) $(MAKE) clean
 	cd lib  && ERL_TOP=$(ERL_TOP) $(MAKE) clean BUILD_ALL=true
+
+distclean: clean
+	find . -type f -name SKIP              -print | xargs $(RM)
+	find . -type f -name SKIP-APPLICATIONS -print | xargs $(RM)
 
 #
 # Just wipe out emulator, not libraries


### PR DESCRIPTION
Add new make target 'distclean' that removes files created by configure.

SKIP files are created by configure for instance if configured  --without-javac.  They should only be removed if one has to reconfigure, otherwise   'make clean; make' breaks.
