### PR TITLE
Fix an erroneous spec

### DIFF
--- a/lib/dialyzer/src/dialyzer_dep.erl
+++ b/lib/dialyzer/src/dialyzer_dep.erl
@@ -58,7 +58,8 @@
 %%           separatedly.
 %%
 
--spec analyze(cerl:c_module()) -> {dict(), ordset('external' | label()), dict()}.
+-spec analyze(cerl:c_module()) ->
+	{dict(), ordset('external' | label()), dict(), dict()}.
 
 analyze(Tree) ->
   %% io:format("Handling ~w\n", [cerl:atom_val(cerl:module_name(Tree))]),


### PR DESCRIPTION
The branch that patched this file to handle the new "named funs"
added an extra argument to the main function of the module but
forgot to update its spec.
