### PR TITLE
crypto.c: openssl 1.0.1e, EC_GROUP_new_curve_GF2m

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -77,7 +77,8 @@
 #if OPENSSL_VERSION_NUMBER >= 0x009080ffL \
 	&& !defined(OPENSSL_NO_EC) \
 	&& !defined(OPENSSL_NO_ECDH) \
-	&& !defined(OPENSSL_NO_ECDSA)
+	&& !defined(OPENSSL_NO_ECDSA) \
+	&& !defined(OPENSSL_NO_EC2M)
 # define HAVE_EC
 #endif
 


### PR DESCRIPTION
In openssl 1.0.1e EC_GROUP_new_curve_GF2m function is wrapped by #ifndef OPENSSL_NO_EC2M.

We have to check whether OPENSSL_NO_EC2M is set, and if it is, then we do not have EC_GROUP_new_curve_GF2m function and do not HAVE_EC.
