### PR TITLE
Added highlight the result of testing.

### DIFF
--- a/lib/eunit/src/eunit.erl
+++ b/lib/eunit/src/eunit.erl
@@ -130,6 +130,10 @@ test(Tests) ->
 %% <dt>`verbose'</dt>
 %% <dd>Displays more details about the running tests.</dd>
 %% </dl>
+%% <dl>
+%% <dt>`colored'</dt>
+%% <dd>Highlight the results of testing at console output.</dd>
+%% </dl>
 %%
 %% Options in the environment variable EUNIT are also included last in
 %% the option list, i.e., have lower precedence than those in `Options'.


### PR DESCRIPTION
Hello,

Since Erlang R16 support coloring for console, I've added support of coloring for unit tests' results.

To turn on colors I've added options colored. For example:
eunit:test([test_module], [colored]).

Without this options eunit doesn't colored anything.

