### PR TITLE
ssl: fix elliptic curve selection in server mode

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -1597,7 +1597,7 @@ default_hashsign(_Version, KeyExchange)
 select_curve(#state{client_ecc = {[Curve|_], _}}) ->
     {namedCurve, Curve};
 select_curve(_) ->
-    {namedCurve, ?secp256k1}.
+    {namedCurve, ?secp256r1}.
 
 is_anonymous(Algo) when Algo == dh_anon;
 			Algo == ecdh_anon;

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1287,7 +1287,7 @@ select_curve(#elliptic_curves{elliptic_curve_list = ClientCurves},
 select_curve(undefined, _) ->
     %% Client did not send ECC extension use default curve if 
     %% ECC cipher is negotiated
-    {namedCurve, ?secp256k1};
+    {namedCurve, ?secp256r1};
 select_curve(_, []) ->
     no_curve;
 select_curve(Curves, [Curve| Rest]) ->

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -199,7 +199,9 @@ hello(start, #state{host = Host, port = Port, role = client,
     next_state(hello, hello, Record, State);
 
 hello(Hello = #client_hello{client_version = ClientVersion,
-			    extensions = #hello_extensions{hash_signs = HashSigns}},
+			    extensions = #hello_extensions{hash_signs = HashSigns,
+							   ec_point_formats = EcPointFormats,
+							   elliptic_curves = EllipticCurves}},
       State = #state{connection_states = ConnectionStates0,
 		     port = Port, session = #session{own_certificate = Cert} = Session0,
 		     renegotiation = {Renegotiation, _},
@@ -210,9 +212,7 @@ hello(Hello = #client_hello{client_version = ClientVersion,
     case tls_handshake:hello(Hello, SslOpts, {Port, Session0, Cache, CacheCb,
 					      ConnectionStates0, Cert}, Renegotiation) of
         {Version, {Type, Session},
-	 ConnectionStates,
-	 #hello_extensions{ec_point_formats = EcPointFormats,
-			   elliptic_curves = EllipticCurves} = ServerHelloExt} ->
+	 ConnectionStates, ServerHelloExt} ->
             ssl_connection:hello({common_client_hello, Type, ServerHelloExt, HashSign},
 				 State#state{connection_states  = ConnectionStates,
 					     negotiated_version = Version,


### PR DESCRIPTION
The server code erroneously took the list of curves supported by the
client from it's own hello extension, effectively break selection
all together.

Also the default fallback secp256k1 curve is not supported by
all clients. secp256r1 is recommended as part of the NIST Suite B
cryptographic suites. The changes are much better that all clients
support it, so use that as fallback.
