### PR TITLE
Allow non-local peers to interact with epmd

### DIFF
--- a/erts/epmd/src/epmd.c
+++ b/erts/epmd/src/epmd.c
@@ -161,6 +161,7 @@ int main(int argc, char** argv)
 #endif
 
     g->addresses      = get_addresses();
+    g->allow_non_local= 0;
     g->port           = get_port_no();
     g->debug          = 0;
 
@@ -218,7 +219,10 @@ int main(int argc, char** argv)
 	      usage(g);
 	    g->addresses = argv[1];
 	    argv += 2; argc -= 2;
-	} else if (strcmp(argv[0], "-port") == 0) {
+	} else if (strcmp(argv[0], "-allow_non_local") == 0) {
+      g->allow_non_local = 1;
+      argv++; argc--;
+  } else if (strcmp(argv[0], "-port") == 0) {
 	    if ((argc == 1) ||
 		((g->port = atoi(argv[1])) == 0))
 	      usage(g);
@@ -412,6 +416,8 @@ static void usage(EpmdVars *g)
     fprintf(stderr, "    -address List\n");
     fprintf(stderr, "        Let epmd listen only on the comma-separated list of IP\n");
     fprintf(stderr, "        addresses (and on the loopback interface).\n");
+    fprintf(stderr, "    -allow_non_local\n");
+    fprintf(stderr, "        Allow non-local peers to interact as if they were local.\n");
     fprintf(stderr, "    -port No\n");
     fprintf(stderr, "        Let epmd listen to another port than default %d\n",
 	    EPMD_PORT_NO);

--- a/erts/epmd/src/epmd_int.h
+++ b/erts/epmd/src/epmd_int.h
@@ -307,6 +307,7 @@ typedef struct {
   int debug;
   int silent; 
   int is_daemon;
+  int allow_non_local;
   int brutal_kill;
   unsigned packet_timeout;
   unsigned delay_accept;

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -988,6 +988,12 @@ static int conn_open(EpmdVars *g,int fd)
       dbg_tty_printf(g,2,(s->local_peer) ? "Local peer connected" :
 		     "Non-local peer connected");
 
+      /* Pretend the connected peer is local */
+      if (g->allow_non_local && ! s->local_peer) {
+        dbg_tty_printf(g,2, "Allowing non-local peer interaction");
+        s->local_peer = EPMD_TRUE;
+      }
+
       s->want = 0;		/* Currently unknown */
       s->got  = 0;
       s->mod_time = current_time(g); /* Note activity */


### PR DESCRIPTION
I am running distributed Erlang applications in the cloud using Docker [1]. To make this work for Erlang, EPMD must allow non-local peers to interact. The peers are non-local because they run in their own containers. An overview of this use-case is described here:

https://github.com/thijsterlouw/docker-research/blob/master/pictures/erlang-docker.png

This patch adds an option "-allow_non_local" to explicitly allow non-local peers. This terminology was previously used in epmd, so I stuck with it. Note that I did not update the `start_epmd` function for VXWORKS, since I counted 10 arguments already and didn't really see the need to allocate more.

[1] www.docker.io
