### PR TITLE
prevent errors from erlang.el

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -73,6 +73,8 @@
 ;;     M-x set-variable RET debug-on-error RET t RET
 ;;; Code:
 
+(eval-when-compile (require 'cl))
+
 ;; Variables:
 
 (defconst erlang-version "2.7"
@@ -3926,7 +3928,7 @@ non-whitespace characters following the point on the current line."
   (self-insert-command arg)
 
   ;; Was this the second char in bit-syntax open (`<<')?
-  (unless (< (point) 2)
+  (unless (<= (point) 2)
     (save-excursion
       (backward-char 2)
       (when (and (eq (char-after (point)) ?<)
@@ -3947,7 +3949,7 @@ non-whitespace characters following the point on the current line."
 
 (defun erlang-after-bitsyntax-close ()
   "Return t if point is immediately after a bit-syntax close parenthesis (`>>')."
-  (and (>= (point) 2)
+  (and (>= (point) 3)
        (save-excursion
 	 (backward-char 2)
 	 (and (eq (char-after (point)) ?>)


### PR DESCRIPTION
In erlang.el, add a line to evaluate the cl package at compile time so that
the use of the block macro (such as on line 3750), which is an alias for
cl-block, is evaluated correctly when erlang.el is compiled. Also modify
comparisons against (point) in functions erlang-electric-lt and
erlang-after-bitsyntax-close so that typing the characters '<' and '>'
(without the quotes) at the beginning of a buffer does not cause errors.

Thanks to user leo2007 in the #erlang channel on IRC for reporting these
problems and providing fixes.
