### PR TITLE
fix indentation error from scan-sexp in erlang.el

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -3038,7 +3038,7 @@ This assumes that the preceding expression is either simple
 \(i.e. an atom) or parenthesized."
   (save-excursion
     (or arg (setq arg 1))
-    (forward-sexp (- arg))
+    (ignore-errors (forward-sexp (- arg)))
     (let ((col (current-column)))
       (skip-chars-backward " \t")
       ;; Special hack to handle: (note line break)

--- a/lib/tools/emacs/test.erl.indented
+++ b/lib/tools/emacs/test.erl.indented
@@ -731,3 +731,8 @@ commas_first() ->
 	     ] }
 	  ]
     }.
+
+
+%% this used to result in a scan-sexp error
+[{
+ }].

--- a/lib/tools/emacs/test.erl.orig
+++ b/lib/tools/emacs/test.erl.orig
@@ -731,3 +731,8 @@ commas_first() ->
             ] }
 ]
 }.
+
+
+%% this used to result in a scan-sexp error
+[{
+}].


### PR DESCRIPTION
Fix an indentation error being returned by scan-sexp, and add a new
indentation test case for the error.
