### PR TITLE
fix -Wno_behaviours doc error in dialyzer man page

### DIFF
--- a/lib/dialyzer/doc/src/dialyzer.xml
+++ b/lib/dialyzer/doc/src/dialyzer.xml
@@ -231,7 +231,7 @@
        match.</item>
       <tag><c><![CDATA[-Wno_opaque]]></c></tag>
       <item>Suppress warnings for violations of opaqueness of data types.</item>
-      <tag><c><![CDATA[-Wno_behaviours]]></c>***</tag>
+      <tag><c><![CDATA[-Wno_behaviours]]></c></tag>
       <item>Suppress warnings about behaviour callbacks which drift from the
        published recommended interfaces.</item>
       <tag><c><![CDATA[-Wunmatched_returns]]></c>***</tag>


### PR DESCRIPTION
The description of the -Wno_behaviours in the dialyzer man page incorrectly
includes a "***" footnote marker, indicating that it's an option that turns
on a warning rather than turning it off. Since the option actually turns
off a warning, remove the marker. This fix makes the documentation match
that obtained from dialyzer --help.
