### PR TITLE
remove deprecated driver_async_cancel function

### DIFF
--- a/erts/doc/src/erl_driver.xml
+++ b/erts/doc/src/erl_driver.xml
@@ -745,7 +745,7 @@ typedef struct ErlIOVec {
           created and decrement it once when the port associated with
           the lock terminates. The emulator will also increment the
           reference count when an async job is enqueued and decrement
-          it after an async job has been invoked, or canceled. Besides
+          it after an async job has been invoked. Besides
           this, it is the responsibility of the driver to ensure that
           the reference count does not reach zero before the last use
           of the lock by the driver has been made. The reference count
@@ -1995,14 +1995,12 @@ ERL_DRV_EXT2TERM     char *buf, ErlDrvUInt len
           <c>async_invoke</c> and <c>async_free</c>. It's typically a
           pointer to a structure that contains a pipe or event that
           can be used to signal that the async operation completed.
-          The data should be freed in <c>async_free</c>, because it's
-          called if <c>driver_async_cancel</c> is called.</p>
+          The data should be freed in <c>async_free</c>.</p>
         <p>When the async operation is done, <seealso marker="driver_entry#ready_async">ready_async</seealso> driver
           entry function is called. If <c>ready_async</c> is null in
           the driver entry, the <c>async_free</c> function is called
           instead.</p>
-        <p>The return value is a handle to the asynchronous task, which
-          can be used as argument to <c>driver_async_cancel</c>.</p>
+        <p>The return value is a handle to the asynchronous task.</p>
         <note>
           <p>As of erts version 5.5.4.3 the default stack size for
             threads in the async-thread pool is 16 kilowords,
@@ -2037,26 +2035,6 @@ ERL_DRV_EXT2TERM     char *buf, ErlDrvUInt len
 	can achieve the same distribution based on port id's as before
 	OTP-R16.</p>
 	</note>
-      </desc>
-    </func>
-    <func>
-      <name><ret>int</ret><nametext>driver_async_cancel(long id)</nametext></name>
-      <fsummary>Cancel an asynchronous call</fsummary>
-      <desc>
-        <marker id="driver_async_cancel"></marker>
-        <p>This function used to cancel a scheduled asynchronous operation,
-	  if it was still in the queue. It returned 1 if it succeeded, and
-	  0 if it failed.</p>
-	<p>Since it could not guarantee success, it was more or less useless.
-	   The user had to implement synchronization of cancellation anyway.
-	   It also unnecessarily complicated the implementation. Therefore,
-	   as of OTP-R15B <c>driver_async_cancel()</c> is deprecated, and
-	   scheduled for removal in OTP-R17. It will currently always fail,
-	   and return 0.</p>
-	<warning><p><c>driver_async_cancel()</c> is deprecated and will
-	            be removed in the OTP-R17 release.</p>
-	</warning>
-
       </desc>
     </func>
     <func>

--- a/erts/emulator/beam/erl_async.c
+++ b/erts/emulator/beam/erl_async.c
@@ -602,7 +602,7 @@ unsigned int driver_async_port_key(ErlDrvPort port)
 ** return values:
 **  0  completed 
 **  -1 error
-**  N  handle value (used with async_cancel)
+**  N  handle value
 **  arguments:
 **      ix             driver index 
 **      key            pointer to secedule queue (NULL means round robin)
@@ -687,23 +687,3 @@ long driver_async(ErlDrvPort ix, unsigned int* key,
 
     return id;
 }
-
-int driver_async_cancel(unsigned int id)
-{
-    /*
-     * Not supported anymore. Always fail (which is backward
-     * compatible).
-     *
-     * This functionality could be implemented again. However,
-     * it is (and always has been) completely useless since
-     * it doesn't give you any guarantees whatsoever. The user
-     * needs to (and always have had to) synchronize in his/her
-     * own code in order to get any guarantees.
-     */
-    return 0;
-}
-
-
-
-
-

--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -132,8 +132,8 @@ typedef struct {
 #define DO_WRITE ERL_DRV_WRITE
 
 #define ERL_DRV_EXTENDED_MARKER		(0xfeeeeeed)
-#define ERL_DRV_EXTENDED_MAJOR_VERSION	2
-#define ERL_DRV_EXTENDED_MINOR_VERSION	2
+#define ERL_DRV_EXTENDED_MAJOR_VERSION	3
+#define ERL_DRV_EXTENDED_MINOR_VERSION	0
 
 /*
  * The emulator will refuse to load a driver with different major
@@ -656,12 +656,6 @@ EXTERN long driver_async(ErlDrvPort ix,
 			 void (*async_invoke)(void*), 
 			 void* async_data,
 			 void (*async_free)(void*));
-
-/*
- * driver_async_cancel() is deprecated. It is scheduled for removal
- * in OTP-R16. For more information see the erl_driver(3) documentation.
- */
-EXTERN int driver_async_cancel(unsigned int key) ERL_DRV_DEPRECATED_FUNC;
 
 /* Locks the driver in the machine "forever", there is
    no unlock function. Note that this is almost never useful, as an open

--- a/erts/emulator/sys/win32/erl_win_dyn_driver.h
+++ b/erts/emulator/sys/win32/erl_win_dyn_driver.h
@@ -82,7 +82,6 @@ WDD_TYPEDEF(int, erl_drv_send_term, (ErlDrvTermData, ErlDrvTermData, ErlDrvTermD
 WDD_TYPEDEF(int, driver_send_term, (ErlDrvPort, ErlDrvTermData, ErlDrvTermData*, int));
 WDD_TYPEDEF(unsigned int, driver_async_port_key, (ErlDrvPort));
 WDD_TYPEDEF(long, driver_async, (ErlDrvPort,unsigned int*,void (*)(void*),void*,void (*)(void*)));
-WDD_TYPEDEF(int, driver_async_cancel, (unsigned int));
 WDD_TYPEDEF(int, driver_lock_driver, (ErlDrvPort));
 WDD_TYPEDEF(void *, driver_dl_open, (char *));
 WDD_TYPEDEF(void *, driver_dl_sym, (void *, char *));
@@ -200,7 +199,6 @@ typedef struct {
     WDD_FTYPE(driver_send_term) *driver_send_term;
     WDD_FTYPE(driver_async_port_key) *driver_async_port_key;
     WDD_FTYPE(driver_async) *driver_async;
-    WDD_FTYPE(driver_async_cancel) *driver_async_cancel;
     WDD_FTYPE(driver_lock_driver) *driver_lock_driver;
     WDD_FTYPE(driver_dl_open) *driver_dl_open;
     WDD_FTYPE(driver_dl_sym) *driver_dl_sym;
@@ -312,7 +310,6 @@ extern TWinDynDriverCallbacks WinDynDriverCallbacks;
 #define driver_send_term (WinDynDriverCallbacks.driver_send_term)
 #define driver_async_port_key (WinDynDriverCallbacks.driver_async_port_key)
 #define driver_async (WinDynDriverCallbacks.driver_async)
-#define driver_async_cancel (WinDynDriverCallbacks.driver_async_cancel)
 #define driver_lock_driver (WinDynDriverCallbacks.driver_lock_driver)
 #define driver_dl_open (WinDynDriverCallbacks.driver_dl_open)
 #define driver_dl_sym (WinDynDriverCallbacks.driver_dl_sym)
@@ -448,7 +445,6 @@ do {				                        \
 ((W).driver_send_term) = driver_send_term;		\
 ((W).driver_async_port_key) = driver_async_port_key;	\
 ((W).driver_async) = driver_async;			\
-((W).driver_async_cancel) = driver_async_cancel;	\
 ((W).driver_lock_driver) = driver_lock_driver;	       	\
 ((W).driver_dl_open) =  driver_dl_open;			\
 ((W).driver_dl_sym) =  driver_dl_sym;			\

--- a/erts/emulator/test/driver_SUITE_data/ioq_exit_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/ioq_exit_drv.c
@@ -277,10 +277,6 @@ static void stop(ErlDrvData drv_data)
 	case IOQ_EXIT_TIMEOUT_ASYNC:
 	    driver_cancel_timer(ddp->port);
 	    break;
-	case IOQ_EXIT_READY_ASYNC:
-	    if (ddp->outstanding_async_task)
-		driver_async_cancel(ddp->async_task);
-	    break;
 	default:
 	    break;
 	}

--- a/erts/emulator/test/driver_SUITE_data/otp_9302_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/otp_9302_drv.c
@@ -227,6 +227,4 @@ static void output(ErlDrvData drv_data,
     ad[4]->term_data.msg = driver_mk_atom("end_of_jobs");
     for (i = 0; i < sizeof(id)/sizeof(id[0]); i++)
 	id[i] = driver_async(data->port, &key, async_invoke, ad[i], driver_free);
-    if (id[2] > 0)
-	driver_async_cancel(id[2]);
 }

--- a/erts/emulator/test/driver_SUITE_data/sys_info_base_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/sys_info_base_drv.c
@@ -19,14 +19,14 @@
 /*
  * Author: Rickard Green
  *
- * Description: Driver that fakes driver version 2.0 and tests
+ * Description: Driver that fakes driver version 3.0 and tests
  *              driver_system_info().
  *
  */
 
 #include "sys_info_drv_impl.h"
 
-#define SYS_INFO_DRV_MAJOR_VSN		2
+#define SYS_INFO_DRV_MAJOR_VSN		3
 #define SYS_INFO_DRV_MINOR_VSN		0
 #define SYS_INFO_DRV_NAME_STR		"sys_info_base_drv"
 #define SYS_INFO_DRV_NAME		sys_info_base_drv

--- a/erts/emulator/test/driver_SUITE_data/sys_info_prev_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/sys_info_prev_drv.c
@@ -19,14 +19,14 @@
 /*
  * Author: Rickard Green
  *
- * Description: Driver that fakes driver version 2.0 and tests
+ * Description: Driver that fakes driver version 3.0 and tests
  *              driver_system_info().
  *
  */
 
 #include "sys_info_drv_impl.h"
 
-#define SYS_INFO_DRV_MAJOR_VSN		2
+#define SYS_INFO_DRV_MAJOR_VSN		3
 #define SYS_INFO_DRV_MINOR_VSN		0
 #define SYS_INFO_DRV_NAME_STR		"sys_info_prev_drv"
 #define SYS_INFO_DRV_NAME		sys_info_prev_drv


### PR DESCRIPTION
Some time ago the driver_async_cancel function was deprecated and slated
for removal in R17. This commit removes the function along with its
associated tests and documentation, sets the
ERL_DRV_EXTENDED_MAJOR_VERSION to 3 and ERL_DRV_EXTENDED_MINOR_VERSION to
0, and modifies the sys_info_base_drv and sys_info_prev_drv tests in the
driver test suite to check version 3.0 instead of 2.0.
