### PR TITLE
Handle dot as electric command

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -3970,7 +3970,6 @@ non-whitespace characters following the point on the current line."
     (erlang-indent-line)
     (end-of-line)
     (newline)
-    (newline)
     (condition-case nil
   (erlang-indent-line)
       (error (if (bolp) (delete-backward-char 1))))))


### PR DESCRIPTION
goal:

improve erlang-mode by handling dot sign as electric command, by automatic ending function, indenting current line and moving to next line.
