### PR TITLE
remove extraneous text from system_info() doc

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6024,8 +6024,7 @@ ok
 	    <seealso marker="#system_info_schedulers">erlang:system_info(schedulers)</seealso>,
 	    and
 	    <seealso marker="#system_flag_schedulers_online">erlang:system_flag(schedulers_online, SchedulersOnline)</seealso>.
-	    </p>      <name name="system_info" arity="1" clause_i="49"/>
-
+	    </p>
           </item>
           <tag><c>smp_support</c></tag>
           <item>


### PR DESCRIPTION
The documentation for erlang;system_info(schedulers_online) in erlang.xml
had some extra text pertaining to the system_info(threads) clause at the
end of its description. Looks like it was an accidental cut-and-paste
error from a long time ago. Fixed.
