### PR TITLE
ssh: Fix dialyzer type specs and documentation

### DIFF
--- a/lib/ssh/doc/src/ssh.xml
+++ b/lib/ssh/doc/src/ssh.xml
@@ -365,8 +365,11 @@
     </func>
 
     <func>
-      <name>stop() -> ok </name>
+      <name>stop() -> ok | {error, Reason}</name>
       <fsummary>Stops the SSH application.</fsummary>
+      <type>
+        <v>Reason = term()</v>
+      </type>
       <desc>
         <p>Stops the SSH application. See also
           <seealso marker="kernel:application">application(3)</seealso></p>

--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -32,8 +32,8 @@
 	 shell/1, shell/2, shell/3]).
 
 %%--------------------------------------------------------------------
--spec start() -> ok.
--spec start(permanent | transient | temporary) -> ok.
+-spec start() -> ok | {error, term()}.
+-spec start(permanent | transient | temporary) -> ok | {error, term()}.
 %%
 %% Description: Starts the ssh application. Default type
 %% is temporary. see application(3)
@@ -51,7 +51,7 @@ start(Type) ->
     application:start(ssh, Type).
 
 %%--------------------------------------------------------------------
--spec stop() -> ok.
+-spec stop() -> ok | {error, term()}.
 %%
 %% Description: Stops the ssh application.
 %%--------------------------------------------------------------------

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -157,7 +157,7 @@ init([Role, Socket, SshOpts]) ->
 
 %%--------------------------------------------------------------------
 -spec open_channel(pid(), string(), iodata(), integer(), integer(),
-		   timeout()) -> {open, channel_id()} | {open_error, term(), string(), string()}.
+		   timeout()) -> {open, channel_id()} | {error, term()}.
 %%--------------------------------------------------------------------
 open_channel(ConnectionHandler, ChannelType, ChannelSpecificData,
 					InitialWindowSize,


### PR DESCRIPTION
Similar to d9ebfb8. The wrong specs were leading to dialyzer warnings
like this in our application since R16B03:

```
The pattern 'ok' can never match the type {'error',_}.
The pattern {'error', {'already_started', 'ssh'}} can never match the type 'ok'.
The pattern {'error', _} can never match the type {'open_error',_,string(),string()}.
```
