### PR TITLE
Allow making the system with --enable-native-libs

### DIFF
--- a/lib/stdlib/src/io_lib_pretty.erl
+++ b/lib/stdlib/src/io_lib_pretty.erl
@@ -25,6 +25,8 @@
 
 -export([print/1,print/2,print/3,print/4,print/5,print/6]).
 
+-compile(no_native).
+
 %%%
 %%% Exported functions
 %%%

--- a/lib/stdlib/src/maps.erl
+++ b/lib/stdlib/src/maps.erl
@@ -43,6 +43,8 @@
 	values/1
     ]).
 
+-compile(no_native).
+
 %% Shadowed by erl_bif_types: maps:get/3
 -spec get(Key,Map) -> Value when
     Key :: term(),


### PR DESCRIPTION
The HiPE compiler crashes when trying to compile these files because
it does not currently support maps. So, add a -compile(no_native)
attribute to these files to allow the system to be made even when
configured with --enable-native-libs.

This is a temporary fix and will be removed when the HiPE compiler
gets proper support for maps.

PLEASE INCLUDE ASAP.  Before announcing r17c-0
