### PR TITLE
reltool: Add release as new incl_cond setting

### DIFF
--- a/lib/reltool/doc/src/reltool.xml
+++ b/lib/reltool/doc/src/reltool.xml
@@ -155,7 +155,9 @@
         escripts that do not have any explicit <c>incl_cond</c>
         setting will be included. <c>exclude</c> implies that all
         applications and escripts that do not have any explicit
-        <c>incl_cond</c> setting will be excluded.</p>
+        <c>incl_cond</c> setting will be excluded. <c>release</c>
+        is similar to <c>exclude</c>. It does only include
+        applications that are listed in a release (rel).</p>
       </item>
 
       <tag><c>boot_rel</c></tag>
@@ -499,7 +501,7 @@ sys()               = {root_dir, root_dir()}
                     | {escript, escript_file(), [escript()]}
                     | {app, app_name(), [app()]}
                     | {mod_cond, mod_cond()} 
-                    | {incl_cond, incl_cond()}
+                    | {incl_cond, app_cond()}
                     | {boot_rel, boot_rel()}
                     | {rel, rel_name(), rel_vsn(), [rel_app()]}
                     | {relocatable, relocatable()}
@@ -516,7 +518,7 @@ app()               = {vsn, app_vsn()}
                     | {lib_dir, lib_dir()}
                     | {mod, mod_name(), [mod()]}
                     | {mod_cond, mod_cond()}
-                    | {incl_cond, incl_cond()}
+                    | {incl_cond, app_cond()}
                     | {debug_info, debug_info()}
                     | {app_file, app_file()}
 		    | {excl_lib, excl_lib()}
@@ -552,6 +554,7 @@ incl_app()          = app_name()
 incl_app_filters()  = regexps()
 incl_archive_filters() = regexps()
 incl_cond()         = include | exclude | derived
+app_cond()          = incl_cond() | release
 incl_sys_filters()  = regexps()
 lib_dir()           = dir()
 mod_cond()          = all | app | ebin | derived | none

--- a/lib/reltool/src/reltool.hrl
+++ b/lib/reltool/src/reltool.hrl
@@ -27,6 +27,7 @@
 %% derived  - Include only those modules that others are dependent on
 -type mod_cond()         :: all | app | ebin | derived | none.
 -type incl_cond()        :: include | exclude | derived.
+-type app_cond()         :: incl_cond() | release.
 -type debug_info()       :: keep | strip.
 -type app_file()         :: keep | strip | all.
 -type re_regexp()        :: string(). % re:regexp()
@@ -66,7 +67,7 @@
 			  | {lib_dir, lib_dir()}
                           | {mod, mod_name(), [mod()]}
                           | {mod_cond, mod_cond()}
-                          | {incl_cond, incl_cond()}
+                          | {incl_cond, app_cond()}
                           | {app_file, app_file()}
                           | {debug_info, debug_info()}
                           | {incl_app_filters, incl_app_filters()}
@@ -75,7 +76,7 @@
                           | {excl_archive_filters, excl_archive_filters()}.
 -type escript()          :: {incl_cond, incl_cond()}.
 -type sys()              :: {mod_cond, mod_cond()}
-                          | {incl_cond, incl_cond()}
+                          | {incl_cond, app_cond()}
                           | {debug_info, debug_info()}
                           | {app_file, app_file()}
                           | {profile, profile()}
@@ -184,7 +185,7 @@
 
           %% Static source cond
           mod_cond  :: '_' | mod_cond()  | undefined,
-          incl_cond :: '_' | incl_cond() | undefined,
+          incl_cond :: '_' | app_cond() | undefined,
 
           %% Static target cond
           debug_info            :: '_' | debug_info() | undefined,
@@ -227,7 +228,7 @@
           lib_dirs  :: [dir()],
           escripts  :: [file()],
           mod_cond  :: mod_cond(),
-          incl_cond :: incl_cond(),
+          incl_cond :: app_cond(),
           apps      :: [#app{}] | undefined,
 
           %% Target cond

--- a/lib/reltool/src/reltool_server.erl
+++ b/lib/reltool/src/reltool_server.erl
@@ -621,11 +621,7 @@ app_init_is_included(#state{app_tab = AppTab, mod_tab = ModTab, sys=Sys},
 		     #app{name = AppName, mods = Mods} = A,
 		     RelApps,
 		     Status) ->
-    AppCond =
-        case A#app.incl_cond of
-            undefined -> Sys#sys.incl_cond;
-            _         -> A#app.incl_cond
-        end,
+    AppCond = resolve_app_cond(A, Sys#sys.incl_cond),
     ModCond =
         case A#app.mod_cond of
             undefined -> Sys#sys.mod_cond;
@@ -645,7 +641,11 @@ app_init_is_included(#state{app_tab = AppTab, mod_tab = ModTab, sys=Sys},
             {derived, []} ->
 		{undefined, undefined, undefined, Status};
             {derived, [_ | _]} -> % App is included in at least one rel
-		{true, undefined, true, Status}
+		{true, undefined, true, Status};
+            {release, []} ->
+		{undefined, false, false, Status};
+            {release, [_ | _]} -> % App is included in at least one rel
+		{true, true, true, Status}
         end,
     {Mods2,Status3} = lists:mapfoldl(fun(Mod,Acc) ->
 					     mod_init_is_included(ModTab,
@@ -663,6 +663,12 @@ app_init_is_included(#state{app_tab = AppTab, mod_tab = ModTab, sys=Sys},
 	       rels = Rels},
     ets:insert(AppTab, A2),
     Status3.
+
+resolve_app_cond(#app{incl_cond=InclCond}, SysInclCond) ->
+    case InclCond of
+        undefined -> SysInclCond;
+        _         -> InclCond
+    end.
 
 mod_init_is_included(ModTab, M, ModCond, AppCond, Default, Status) ->
     %% print(M#mod.name, hipe, "incl_cond -> ~w\n", [AppCond]),
@@ -690,6 +696,17 @@ mod_init_is_included(ModTab, M, ModCond, AppCond, Default, Status) ->
             exclude ->
                 false;
             derived ->
+                case M#mod.incl_cond of
+                    include ->
+                        true;
+                    exclude ->
+                        false;
+		    derived ->
+			undefined;
+                    undefined ->
+                        Default
+                end;
+            release ->
                 case M#mod.incl_cond of
                     include ->
                         true;
@@ -858,6 +875,11 @@ app_recap_dependencies(S) ->
 
 app_recap_dependencies(S, #app{mods = Mods, is_included = IsIncl} = A) ->
     {Mods2, IsIncl2} = mod_recap_dependencies(S, A, Mods, [], IsIncl),
+    IsIncl3 =
+        case resolve_app_cond(A, (S#state.sys)#sys.incl_cond) of
+            release -> IsIncl;
+            _       -> IsIncl2
+        end,
     AppStatus =
         case lists:keymember(missing, #mod.status, Mods2) of
             true  -> missing;
@@ -880,7 +902,7 @@ app_recap_dependencies(S, #app{mods = Mods, is_included = IsIncl} = A) ->
                used_by_mods = UsedByMods2,
                uses_apps = UsesApps2,
                used_by_apps = UsedByApps2,
-               is_included = IsIncl2},
+               is_included = IsIncl3},
     ets:insert(S#state.app_tab,A2),
     ok.
 
@@ -1390,7 +1412,8 @@ decode(#sys{} = Sys, [{Key, Val} | KeyVals]) ->
                 Sys#sys{mod_cond = Val};
             incl_cond when Val =:= include;
 			   Val =:= exclude;
-                           Val =:= derived ->
+                           Val =:= derived;
+                           Val =:= release ->
                 Sys#sys{incl_cond = Val};
             boot_rel when is_list(Val) ->
                 Sys#sys{boot_rel = Val};
@@ -1474,7 +1497,8 @@ decode(#app{} = App, [{Key, Val} | KeyVals]) ->
                 App#app{mod_cond = Val};
             incl_cond when Val =:= include;
 			   Val =:= exclude;
-			   Val =:= derived ->
+			   Val =:= derived;
+                           Val =:= release ->
                 App#app{incl_cond = Val};
 
             debug_info when Val =:= keep;
@@ -1615,8 +1639,7 @@ refresh(#state{sys=Sys} = S) ->
     %% to the user configuration.
     %% Then find all modules and their dependencies and set user
     %% configuration per module if it exists.
-    {RefreshedApps, Status3} = refresh_apps(Sys#sys.apps, AllApps, [],
-					    true, Status2),
+    {RefreshedApps, Status3} = refresh_apps(Sys, AllApps, [], true, Status2),
 
     %% Make sure erts exists in app list and has a version (or warn)
     {PatchedApps, Status4} = patch_erts_version(RootDir, RefreshedApps, Status3),
@@ -1955,14 +1978,14 @@ default_app(Name) ->
 
 
 
-refresh_apps(ConfigApps, [New | NewApps], Acc, Force, Status) ->
+refresh_apps(Sys, [New | NewApps], Acc, Force, Status) ->
     {New2, Status3} =
-	case lists:keymember(New#app.name,#app.name,ConfigApps) of
+	case lists:keymember(New#app.name, #app.name, Sys#sys.apps) of
 	    true ->
 		%% There is user defined config for this application, make
 		%% sure that the application exists and that correct
 		%% version is used. Set active directory.
-		{Info, ActiveDir, Status2} = ensure_app_info(New, Status),
+		{Info, ActiveDir, Status2} = ensure_app_info(Sys, New, Status),
 		OptLabel =
 		    case Info#app_info.vsn =:= New#app.vsn of
 			true -> New#app.label;
@@ -1982,25 +2005,34 @@ refresh_apps(ConfigApps, [New | NewApps], Acc, Force, Status) ->
 		%% from merge_app_dirs.
 		refresh_app(New, Force, Status)
 	end,
-    refresh_apps(ConfigApps, NewApps, [New2 | Acc], Force, Status3);
-refresh_apps(_ConfigApps, [], Acc, _Force, Status) ->
+    refresh_apps(Sys, NewApps, [New2 | Acc], Force, Status3);
+refresh_apps(_Sys, [], Acc, _Force, Status) ->
     {lists:reverse(Acc), Status}.
 
-ensure_app_info(#app{is_escript = IsEscript, active_dir = Dir, info = Info},
+ensure_app_info(_Sys,
+                #app{is_escript = IsEscript, active_dir = Dir, info = Info},
 		Status)
   when IsEscript=/=false ->
     %% Escript or application which is inlined in an escript
     {Info, Dir, Status};
-ensure_app_info(#app{name = Name, sorted_dirs = []} = App, Status) ->
+ensure_app_info(Sys,
+                #app{name = Name,
+		     active_dir = ActiveDir,
+		     sorted_dirs = [],
+                     status = AppStatus} = App,
+                Status) ->
     Reason = "~w: Missing application directory.",
-    case App of
-        #app{incl_cond = exclude, status = missing, active_dir = Dir} ->
+    AppCond = resolve_app_cond(App, Sys#sys.incl_cond),
+    Exclude = (AppCond =:= exclude) orelse (AppCond =:= release),
+    if
+        AppStatus =:= missing, Exclude ->
             Status2 = reltool_utils:add_warning(Reason, [Name], Status),
-            {missing_app_info(""), Dir, Status2};
-        _ ->
+            {missing_app_info(""), ActiveDir, Status2};
+        true ->
             reltool_utils:throw_error(Reason, [Name])
     end;
-ensure_app_info(#app{name = Name,
+ensure_app_info(_Sys,
+                #app{name = Name,
 		     vsn = Vsn,
 		     use_selected_vsn = UseSelectedVsn,
 		     active_dir = ActiveDir,
@@ -2056,7 +2088,7 @@ ensure_app_info(#app{name = Name,
 	true ->
             {FirstInfo, FirstDir, Status3}
     end;
-ensure_app_info(#app{active_dir = Dir, info = Info}, Status) ->
+ensure_app_info(_Sys, #app{active_dir = Dir, info = Info}, Status) ->
     {Info, Dir, Status}.
 
 find_vsn(Vsn, [#app_info{vsn = Vsn} = Info | _], [Dir | _]) ->

--- a/lib/reltool/src/reltool_utils.erl
+++ b/lib/reltool/src/reltool_utils.erl
@@ -245,20 +245,22 @@ mod_cond_to_index(ModCond) ->
     end.
 
 incl_conds() ->
-    ["include", "exclude", "derived"].
+    ["include", "derived", "release", "exclude"].
 
 list_to_incl_cond(List) ->
     case List of
 	"include" -> include;
  	"exclude" -> exclude;
-	"derived" -> derived
+	"derived" -> derived;
+	"release" -> release
     end.
 
 incl_cond_to_index(ModCond) ->
     case ModCond of
-	include -> 0;
-	exclude -> 1;	
-	derived -> 2
+        include -> 0;
+        derived -> 1;
+        release -> 2;
+        exclude -> 3
     end.
 
 elem_to_index(Elem, List) ->

--- a/lib/reltool/test/reltool_server_SUITE.erl
+++ b/lib/reltool/test/reltool_server_SUITE.erl
@@ -60,7 +60,7 @@ end_per_testcase(Func,Config) ->
 	    ok;
 	_Fail ->
 	    SaveDir = "save."++atom_to_list(Func),
-	    ok = file:make_dir(SaveDir),
+	    file:make_dir(SaveDir),
 	    save_test_result(Files,SaveDir)
     end,
     rm_files(Files),
@@ -142,6 +142,7 @@ all() ->
      save_config,
      dependencies,
      mod_incl_cond_derived,
+     incl_cond_release,
      use_selected_vsn,
      use_selected_vsn_relative_path,
      non_standard_vsn_id].
@@ -2345,7 +2346,23 @@ mod_incl_cond_derived(Config) ->
     %% 3. check that y2 is included since it has incl_cond=derived and
     %% is used by x3.
     ?msym({ok,#mod{is_included=true}}, reltool_server:get_mod(Pid,y2)),
+    ok.
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+incl_cond_release(_Config) ->
+    Sys = {sys,[{incl_cond, release},
+                {rel,"start_clean","1.0",[crypto,inets]},
+		{app,kernel,[{incl_cond,release}]},
+		{app,mnesia,[{incl_cond,include}]}
+               ]},
+    {ok, Pid} = ?msym({ok, _}, reltool:start_server([{config, Sys}])),
+    ?msym({ok,[#app{name=crypto},
+               #app{name=inets},
+               #app{name=kernel},
+               #app{name=mnesia},
+	       #app{name=stdlib}]},
+          reltool_server:get_apps(Pid,whitelist)),
+    ?msym({ok,[]},reltool_server:get_apps(Pid,derived)),
     ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
With 'incl_cond' set to 'release', only applications explicitly listed
in a release (rel) are included. This means that in many cases it
suffices to only list the applications in a release (rel). Now only
applications with customized settings need to be doubly specified
(both in rel and app).