### PR TITLE
Truly test debugger in erl_eval_SUITE copy

### DIFF
--- a/lib/debugger/src/dbg_ieval.erl
+++ b/lib/debugger/src/dbg_ieval.erl
@@ -1032,7 +1032,7 @@ eval_generate([V|Rest], P, Bs0, CompFun, Ieval) ->
     case catch match1(P, V, erl_eval:new_bindings(), Bs0) of
 	{match,Bsn} ->
 	    Bs2 = add_bindings(Bsn, Bs0),
-            CompFun(Bs2) ++ eval_generate(Rest, P, Bs2, CompFun, Ieval);
+            CompFun(Bs2) ++ eval_generate(Rest, P, Bs0, CompFun, Ieval);
 	nomatch -> 
 	    eval_generate(Rest, P, Bs0, CompFun, Ieval)
 	end;

--- a/lib/debugger/test/erl_eval_SUITE.erl
+++ b/lib/debugger/test/erl_eval_SUITE.erl
@@ -63,6 +63,7 @@ config(priv_dir,_) ->
 % Default timetrap timeout (set in init_per_testcase).
 -define(default_timeout, ?t:minutes(1)).
 init_per_testcase(_Case, Config) ->
+    test_lib:interpret(?MODULE),
     ?line Dog = ?t:timetrap(?default_timeout),
     [{watchdog, Dog} | Config].
 end_per_testcase(_Case, Config) ->


### PR DESCRIPTION
The module was not interpreted.

This surfaced two bugs, related to shadowed variables in binary patterns in comprehension generators, and guard filters not properly detected. The guard detection code from dbg_iload is deleted in favor of erl_lint:is_guard_test/1.
