### PR TITLE
Fix expansion of records in maps

### DIFF
--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -135,9 +135,10 @@ pattern({tuple,Line,Ps}, St0) ->
 pattern({map,Line,Ps}, St0) ->
     {TPs,St1} = pattern_list(Ps, St0),
     {{map,Line,TPs},St1};
-pattern({map_field_exact,Line,Key,V0}, St0) ->
-    {V,St1} = pattern(V0, St0),
-    {{map_field_exact,Line,Key,V},St1};
+pattern({map_field_exact,Line,Key0,V0}, St0) ->
+    {Key,St1} = pattern(Key0, St0),
+    {V,St2} = pattern(V0, St1),
+    {{map_field_exact,Line,Key,V},St2};
 %%pattern({struct,Line,Tag,Ps}, St0) ->
 %%    {TPs,TPsvs,St1} = pattern_list(Ps, St0),
 %%    {{struct,Line,Tag,TPs},TPsvs,St1};
@@ -310,9 +311,10 @@ expr({tuple,Line,Es0}, St0) ->
 expr({map,Line,Es0}, St0) ->
     {Es1,St1} = expr_list(Es0, St0),
     {{map,Line,Es1},St1};
-expr({map,Line,Var,Es0}, St0) ->
-    {Es1,St1} = expr_list(Es0, St0),
-    {{map,Line,Var,Es1},St1};
+expr({map,Line,Arg0,Es0}, St0) ->
+    {Arg1,St1} = expr(Arg0, St0),
+    {Es1,St2} = expr_list(Es0, St1),
+    {{map,Line,Arg1,Es1},St2};
 expr({map_field_assoc,Line,K0,V0}, St0) ->
     {K,St1} = expr(K0, St0),
     {V,St2} = expr(V0, St1),

--- a/lib/stdlib/test/erl_expand_records_SUITE.erl
+++ b/lib/stdlib/test/erl_expand_records_SUITE.erl
@@ -38,7 +38,7 @@
 -export([attributes/1, expr/1, guard/1,
          init/1, pattern/1, strict/1, update/1,
 	 otp_5915/1, otp_7931/1, otp_5990/1,
-	 otp_7078/1, otp_7101/1]).
+	 otp_7078/1, otp_7101/1, maps/1]).
 
 % Default timetrap timeout (set in init_per_testcase).
 -define(default_timeout, ?t:minutes(1)).
@@ -56,7 +56,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
     [attributes, expr, guard, init,
-     pattern, strict, update, {group, tickets}].
+     pattern, strict, update, maps, {group, tickets}].
 
 groups() -> 
     [{tickets, [],
@@ -402,7 +402,22 @@ update(Config) when is_list(Config) ->
       ],
     ?line run(Config, Ts),
     ok.
-    
+
+maps(Config) when is_list(Config) ->
+    Ts = [<<"-record(rr, {a,b,c}).
+             t() ->
+                 R0 = id(#rr{a=1,b=2,c=3}),
+                 R1 = id(#rr{a=4,b=5,c=6}),
+                 [{R0,R1}] =
+                     maps:to_list(#{#rr{a=1,b=2,c=3} => #rr{a=4,b=5,c=6}}),
+                 #{#rr{a=1,b=2,c=3} := #rr{a=1,b=2,c=3}} =
+                     #{#rr{a=1,b=2,c=3} => R1}#{#rr{a=1,b=2,c=3} := R0},
+                 ok.
+
+             id(X) -> X.
+            ">>],
+    run(Config, Ts, [strict_record_tests]),
+    ok.
 
 otp_5915(doc) ->
     "Strict record tests in guards.";


### PR DESCRIPTION
Records were not properly expanded in keys in patterns and in arguments in map updates.
