### PR TITLE
Additions to support the erlide debugger

### DIFF
--- a/lib/debugger/src/dbg_icmd.erl
+++ b/lib/debugger/src/dbg_icmd.erl
@@ -25,6 +25,7 @@
 -export([step/1, next/1, continue/1, finish/1, skip/1, timeout/1,
 	 stop/1]).
 -export([eval/2]).
+-export([set_variable_value/4]).
 -export([set/3, get/3]).
 -export([handle_msg/4]).
 
@@ -184,6 +185,16 @@ timeout(Meta) ->  Meta ! {user, timeout}.
 
 stop(Meta) ->     Meta ! {user, {cmd, stop}}.
 
+set_variable_value(Meta, Variable, Value, SP) ->
+    eval(Meta, {no_module, Variable++"="++Value, SP}),
+    receive
+        {Meta, EvalRsp} ->
+            EvalRsp
+    after 5000 ->
+            {error, timeout}
+    end.
+
+
 eval(Meta, {Mod, Cmd}) ->
     eval(Meta, {Mod, Cmd, nostack});
 eval(Meta, {Mod, Cmd, SP}) ->
@@ -339,6 +350,10 @@ handle_user_msg({set,trace,Bool}, _Status, _Bs, _Ieval) ->
     tell_attached({trace, Bool});
 handle_user_msg({set,stack_trace,Flag}, _Status, _Bs, _Ieval) ->
     set_stack_trace(Flag);
+handle_user_msg({get, all_stack_frames, From, _}, _Status, Bs, _Ieval) ->
+    reply(From, all_stack_frames, {all_frames(), Bs});
+handle_user_msg({get, all_modules_on_stack, From, _}, _Status, _Bs, _Ieval) ->
+    reply(From, all_modules_on_stack, all_modules_on_stack());
 handle_user_msg({get,bindings,From,SP}, _Status, Bs, _Ieval) ->
     reply(From, bindings, bindings(Bs, SP));
 handle_user_msg({get,stack_frame,From,{Dir,SP}}, _Status, _Bs,_Ieval) ->
@@ -347,6 +362,12 @@ handle_user_msg({get,messages,From,_}, _Status, _Bs, _Ieval) ->
     reply(From, messages, messages());
 handle_user_msg({get,backtrace,From,N}, _Status, _Bs, Ieval) ->
     reply(From, backtrace, dbg_istk:backtrace(N, Ieval)).
+
+all_modules_on_stack() ->
+    dbg_istk:all_modules_on_stack().
+
+all_frames() ->
+    dbg_ieval:all_frames().
 
 set_stack_trace(true) ->
     set_stack_trace(all);


### PR DESCRIPTION
There are mostly new functions and messages that don't affect the
regular debugger. The only exception is in dbg_ieval, where the exit_at
message has more detailed information (the pid of the process, a
stacktrace and the current bindings).

The new API is about
- getting the current stacktrace
- setting the value of a variable
- storing stacktrace and bindings for exited processes, it is useful for post-mortem analysis

If these changes are accepted, erlide can stop using a copy of the debugger code with patches. Even the regular debugger might like to use these.
