### PR TITLE
Add support for IPv6 connections

### DIFF
--- a/lib/eldap/doc/src/eldap.xml
+++ b/lib/eldap/doc/src/eldap.xml
@@ -69,12 +69,13 @@ filter()    See present/1, substrings/2,
       <fsummary>Open a connection to an LDAP server.</fsummary>
       <type>
 	<v>Handle = handle()</v>
-	<v>Option = {port, integer()} | {log, function()} | {timeout, integer()} | {ssl, boolean()} | {sslopts, list()}</v>
+	<v>Option = {port, integer()} | {log, function()} | {timeout, integer()} | {ssl, boolean()} | {sslopts, list()} | {tcpopts, list()}</v>
       </type>
       <desc>
         <p>Setup a connection to an LDAP server, the <c>HOST</c>'s are tried in order.</p>
 	<p>The log function takes three arguments, <c>fun(Level, FormatString, [FormatArg]) end</c>.</p>
 	<p>Timeout set the maximum time in milliseconds that each server request may take.</p>
+        <p>Currently, the only TCP socket option accepted is <c>inet6</c>. Default is <c>inet</c>.</p>
       </desc>
     </func>
     <func>

--- a/lib/eldap/src/eldap.erl
+++ b/lib/eldap/src/eldap.erl
@@ -45,9 +45,10 @@
 		log,                 % User provided log function
 		timeout = infinity,  % Request timeout
 		anon_auth = false,   % Allow anonymous authentication
-		ldaps = false,      % LDAP/LDAPS
+		ldaps = false,       % LDAP/LDAPS
 		using_tls = false,   % true if LDAPS or START_TLS executed
-		tls_opts = [] % ssl:ssloption()
+		tls_opts = [],       % ssl:ssloption()
+		tcp_opts = []        % inet6 support
 	       }).
 
 %%% For debug purposes
@@ -372,6 +373,8 @@ parse_args([{sslopts, Opts}|T], Cpid, Data) when is_list(Opts) ->
     parse_args(T, Cpid, Data#eldap{ldaps = true, using_tls=true, tls_opts = Opts ++ Data#eldap.tls_opts});
 parse_args([{sslopts, _}|T], Cpid, Data) ->
     parse_args(T, Cpid, Data);
+parse_args([{tcpopts, Opts}|T], Cpid, Data) when is_list(Opts) ->
+    parse_args(T, Cpid, Data#eldap{tcp_opts = inet6_opt(Opts) ++ Data#eldap.tcp_opts});
 parse_args([{log, F}|T], Cpid, Data) when is_function(F) ->
     parse_args(T, Cpid, Data#eldap{log = F});
 parse_args([{log, _}|T], Cpid, Data) ->
@@ -381,6 +384,14 @@ parse_args([H|_], Cpid, _) ->
     exit(wrong_option);
 parse_args([], _, Data) ->
     Data.
+
+inet6_opt(Opts) ->
+    case proplists:get_value(inet6, Opts) of
+	true ->
+	    [inet6];
+	_ ->
+	    []
+    end.
 
 %%% Try to connect to the hosts in the listed order,
 %%% and stop with the first one to which a successful
@@ -401,9 +412,11 @@ try_connect([],_) ->
     {error,"connect failed"}.
 
 do_connect(Host, Data, Opts) when Data#eldap.ldaps == false ->
-    gen_tcp:connect(Host, Data#eldap.port, Opts, Data#eldap.timeout);
+    gen_tcp:connect(Host, Data#eldap.port, Opts ++ Data#eldap.tcp_opts,
+		    Data#eldap.timeout);
 do_connect(Host, Data, Opts) when Data#eldap.ldaps == true ->
-    ssl:connect(Host, Data#eldap.port, Opts++Data#eldap.tls_opts).
+    ssl:connect(Host, Data#eldap.port,
+		Opts ++ Data#eldap.tls_opts ++ Data#eldap.tcp_opts).
 
 loop(Cpid, Data) ->
     receive


### PR DESCRIPTION
Currently, eldap assumes that only IPv4 will be used. This change
enables callers to use IPv6 by including the [inet6] option in the
eldap:open/2 options list. This adds inet6 to the gen_tcp or ssl
connect.  For backward compatibility, [inet] is the default if inet6 is
omitted.

(This replaces pull request #110).
