### PR TITLE
added missed ifdef HAVE_DLOPEN flag

### DIFF
--- a/erts/emulator/sys/unix/erl_unix_sys_ddll.c
+++ b/erts/emulator/sys/unix/erl_unix_sys_ddll.c
@@ -123,6 +123,7 @@ int erts_sys_ddll_open2(const char *full_name, void **handle, ErtsSysDdllError* 
 
 int erts_sys_ddll_open_noext(char *dlname, void **handle, ErtsSysDdllError* err)
 {
+#if defined(HAVE_DLOPEN)   
     int ret = ERL_DE_NO_ERROR;
     char *str;
     dlerror();
@@ -148,6 +149,9 @@ int erts_sys_ddll_open_noext(char *dlname, void **handle, ErtsSysDdllError* err)
 	ret = ERL_DE_DYNAMIC_ERROR_OFFSET - find_errcode(str, err);
     }
     return ret;
+#else
+    return ERL_DE_ERROR_NO_DDLL_FUNCTIONALITY;
+#endif
 }
 
 /* 


### PR DESCRIPTION
The compilation of OTP for embedded systems (e.g. Android, Raspberry PI) with -static flags is failed;

obj/arm-unknown-linux-androideabi/opt/plain/erl_unix_sys_ddll.o:erl_unix_sys_ddll.c:function erts_sys_ddll_open_noext: error: undefined reference to 'dlerror'
obj/arm-unknown-linux-androideabi/opt/plain/erl_unix_sys_ddll.o:erl_unix_sys_ddll.c:function erts_sys_ddll_open_noext: error: undefined reference to 'dlopen'
obj/arm-unknown-linux-androideabi/opt/plain/erl_unix_sys_ddll.o:erl_unix_sys_ddll.c:function erts_sys_ddll_open_noext: error: undefined reference to 'dlerror'

The function erts_sys_ddll_open_noext(...) is missing #if defined(HAVE_DLOPEN) ... #else ... #endif constrain  
