### PR TITLE
Properly silence an unmatched return warning

### DIFF
--- a/lib/parsetools/src/yecc.erl
+++ b/lib/parsetools/src/yecc.erl
@@ -421,10 +421,10 @@ infile(Parent, Infilex, Options) ->
              {error, Reason} ->
                  add_error(St0#yecc.infile, none, {file_error, Reason}, St0)
          end,
-    case {St#yecc.errors, werror(St)} of
-        {[], false} -> ok;
-        _ -> _ = file:delete(St#yecc.outfile)
-    end,
+    _ = case {St#yecc.errors, werror(St)} of
+	    {[], false} -> ok;
+	    _ -> file:delete(St#yecc.outfile)
+	end,
     Parent ! {self(), yecc_ret(St)}.
 
 werror(St) ->


### PR DESCRIPTION
An underscore, presumably used to signify that a file:delete/1 call
was to be issued independently of whether the call would work ok or
not, was placed at a point that made dialyzer -Wunmatched_returns
on this file complain that the result of the case expression was
an unmatched union of an 'ok' and and {'error',term()} type value.
Place the underscore in its proper place instead.
