### PR TITLE
Change a list comprehension to a foreach/2 call

### DIFF
--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -882,7 +882,7 @@ valfun_4(_, _) ->
 verify_put_map(Fail, Src, Dst, Live, List, Vst0) ->
     verify_live(Live, Vst0),
     verify_y_init(Vst0),
-    [assert_term(Term, Vst0) || Term <- List],
+    foreach(fun (Term) -> assert_term(Term, Vst0) end, List),
     assert_term(Src, Vst0),
     Vst1 = heap_alloc(0, Vst0),
     Vst2 = branch_state(Fail, Vst1),
@@ -909,7 +909,7 @@ validate_bs_skip_utf(Fail, Ctx, Live, Vst0) ->
     branch_state(Fail, Vst).
 
 %%
-%% Special state handling for setelement/3 and the set_tuple_element/3 instruction.
+%% Special state handling for setelement/3 and set_tuple_element/3 instructions.
 %% A possibility for garbage collection must not occur between setelement/3 and
 %% set_tuple_element/3.
 %%


### PR DESCRIPTION
Partly to avoid unmatched return warnings from dialyzer and in order
to preserve the style of other similar-looking code in that file.

While at it, fix the wording in one comment.
