### PR TITLE
Include the cause when raising a new IOException

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java
@@ -959,7 +959,9 @@ public abstract class AbstractConnection extends Thread {
 	} catch (final Exception e) {
 	    final String nn = peer.node();
 	    close();
-	    throw new IOException("Error accepting connection from " + nn);
+	    IOException ioe = new IOException("Error accepting connection from " + nn);
+	    ioe.initCause(e);
+	    throw ioe;
 	}
 	if (traceLevel >= handshakeThreshold) {
 	    System.out.println("<- MD5 ACCEPTED " + peer.host());
@@ -990,7 +992,9 @@ public abstract class AbstractConnection extends Thread {
 	    throw ae;
 	} catch (final Exception e) {
 	    close();
-	    throw new IOException("Cannot connect to peer node");
+	    IOException ioe = new IOException("Cannot connect to peer node");
+	    ioe.initCause(e);
+	    throw ioe;
 	}
     }
 


### PR DESCRIPTION
I get a "Cannot connect to peer node" exception occasionally, but I haven't been able to figure out the root cause.  Searching the list, others have had similar problems.  This patch should make the reason for the exception clearer.
