### PR TITLE
Fix handling of 'on_load' attribute

### DIFF
--- a/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
+++ b/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
@@ -168,7 +168,7 @@ analysis_start(Parent, Analysis) ->
       throw:{error, _ErrorMsg} = Error -> exit(Error)
     end,
   NewPlt0 = dialyzer_plt:insert_types(Plt, dialyzer_codeserver:get_records(NewCServer)),
-  ExpTypes =  dialyzer_codeserver:get_exported_types(NewCServer),
+  ExpTypes = dialyzer_codeserver:get_exported_types(NewCServer),
   NewPlt1 = dialyzer_plt:insert_exported_types(NewPlt0, ExpTypes),
   State0 = State#analysis_state{plt = NewPlt1},
   dump_callgraph(Callgraph, State0, Analysis),
@@ -423,11 +423,8 @@ abs_get_nowarn(Abs, M) ->
     false ->
       [{M, F, A} || {function, _, F, A, _} <- Abs]; % all functions
     true ->
-      OnLoad =
-	lists:flatten([{M, F, A} || {attribute, _, on_load, {F, A}} <- Abs]),
-      OnLoad ++ [{M, F, A} ||
-		  {nowarn_unused_function, FAs} <- Opts,
-		  {F, A} <- lists:flatten([FAs])]
+      [{M, F, A} || {nowarn_unused_function, FAs} <- Opts,
+		    {F, A} <- lists:flatten([FAs])]
   end.
 
 get_exported_types_from_core(Core) ->

--- a/lib/dialyzer/test/small_SUITE_data/src/on_load.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/on_load.erl
@@ -1,4 +1,6 @@
 %%% This is to ensure that "on_load" functions are never reported as unused.
+%%% In addition, all functions called by a function in an on_load attribute
+%%% should be considered as called by an entry point of the module.
 
 -module(on_load).
 
@@ -8,4 +10,7 @@
 
 foo() -> ok.
 
-bar() -> ok.
+bar() -> gazonk(17).
+
+gazonk(N) when N < 42 -> gazonk(N+1);
+gazonk(42) -> ok.


### PR DESCRIPTION
The handling of functions appearing in an 'on_load' attribute was wrong.
Instead of considering the functions specified in these attributes as
escaping from the module and performing a full analysis starting from
them, the code just bypassed this analysis and only suppressed unused
warning messages for these functions. This worked for most of the cases
but resulted in functions (directly or indirectly) called by 'on_load'
functions being reported as not called by the module.

Such a case existed in the code of the 'crypto' application.

To solve these issues the initialization code for functions escaping
from the module was changed and the test for the on_load functionality
was appropriately extended.
