### PR TITLE
Add ETHR_FORCE_INLINE define to hide compiler specific directives.

### DIFF
--- a/erts/include/internal/ethread.h
+++ b/erts/include/internal/ethread.h
@@ -54,13 +54,16 @@
 #undef ETHR_INLINE
 #if defined(__GNUC__)
 #  define ETHR_INLINE __inline__
+#  define ETHR_FORCE_INLINE __inline__ __attribute__((__always_inline__))
 #elif defined(__WIN32__)
 #  define ETHR_INLINE __forceinline
+#  define ETHR_FORCE_INLINE __forceinline
 #endif
 #if defined(ETHR_DEBUG) || !defined(ETHR_INLINE) || ETHR_XCHK \
     || (defined(__GNUC__) && defined(ERTS_MIXED_CYGWIN_VC))
 #  undef ETHR_INLINE
 #  define ETHR_INLINE 
+#  define ETHR_FORCE_INLINE
 #  undef ETHR_TRY_INLINE_FUNCS
 #endif
 

--- a/erts/include/internal/win/ethr_membar.h
+++ b/erts/include/internal/win/ethr_membar.h
@@ -63,13 +63,13 @@ do {							\
 #pragma intrinsic(_mm_sfence)
 #pragma intrinsic(_mm_lfence)
 
-static __forceinline void
+static ETHR_FORCE_INLINE void
 ethr_cfence__(void)
 {
     _ReadWriteBarrier();
 }
 
-static __forceinline void
+static ETHR_FORCE_INLINE void
 ethr_mfence__(void)
 {
 #if ETHR_SIZEOF_PTR == 4
@@ -80,7 +80,7 @@ ethr_mfence__(void)
 	_mm_mfence();
 }
 
-static __forceinline void
+static ETHR_FORCE_INLINE void
 ethr_sfence__(void)
 {
 #if ETHR_SIZEOF_PTR == 4
@@ -91,7 +91,7 @@ ethr_sfence__(void)
 	_mm_sfence();
 }
 
-static __forceinline void
+static ETHR_FORCE_INLINE void
 ethr_lfence__(void)
 {
 #if ETHR_SIZEOF_PTR == 4

--- a/erts/lib_src/common/erl_misc_utils.c
+++ b/erts/lib_src/common/erl_misc_utils.c
@@ -25,6 +25,7 @@
 #  include <windows.h>
 #endif
 
+#include "ethread.h"
 #include "erl_misc_utils.h"
 
 #if defined(__WIN32__)
@@ -191,7 +192,7 @@ struct erts_cpu_info_t_ {
 
 #if defined(__WIN32__)
 
-static __forceinline int
+static ETHR_FORCE_INLINE int
 get_proc_affinity(erts_cpu_info_t *cpuinfo, cpu_set_t *cpuset)
 {
     DWORD_PTR pamask;
@@ -206,7 +207,7 @@ get_proc_affinity(erts_cpu_info_t *cpuinfo, cpu_set_t *cpuset)
     }
 }
 
-static __forceinline int
+static ETHR_FORCE_INLINE int
 set_thr_affinity(cpu_set_t *set)
 {
     if (*set == (cpu_set_t) 0)
@@ -1157,7 +1158,7 @@ read_topology(erts_cpu_info_t *cpuinfo)
 #define ERTS_MU_RELATION_CACHE                2 /* RelationCache */
 #define ERTS_MU_RELATION_PROCESSOR_PACKAGE    3 /* RelationProcessorPackage */
 
-static __forceinline int
+static ETHR_FORCE_INLINE int
 rel_cmp_val(int r)
 {
     switch (r) {

--- a/erts/lib_src/common/ethr_mutex.c
+++ b/erts/lib_src/common/ethr_mutex.c
@@ -1433,7 +1433,7 @@ void LeaveCriticalSection(CRITICAL_SECTION *cs)
 #define ETHR_CND_WAIT__ ((ethr_sint32_t) 0x11dead11)
 #define ETHR_CND_WAKEUP__ ((ethr_sint32_t) 0x11beef11)
 
-static __forceinline void
+static ETHR_FORCE_INLINE void
 cond_wakeup(ethr_ts_event *tse)
 {
     ETHR_ASSERT(ethr_atomic32_read(&tse->uaflgs) == ETHR_CND_WAIT__);
@@ -1574,7 +1574,7 @@ ethr_cond_wait(ethr_cond *cnd, ethr_mutex *mtx)
     return 0;
 }
 
-static __forceinline void
+static ETHR_FORCE_INLINE void
 posix_compliant_mtx_enqueue(ethr_mutex *mtx,
 			    ethr_ts_event *tse_start,
 			    ethr_ts_event *tse_end)
@@ -1614,7 +1614,7 @@ posix_compliant_mtx_enqueue(ethr_mutex *mtx,
     }
 }
 
-static __forceinline void
+static ETHR_FORCE_INLINE void
 enqueue_cond_wakeups(ethr_ts_event *queue, int posix_compliant)
 {
     if (queue) {


### PR DESCRIPTION
Some win32 specific code does not compile with gcc (mingw-w64) since '__forceinline' is not supported by gcc. This can be avoided by defining a new macro ETHR_FORCE_INLINE similar to ETHR_INLINE.
