### PR TITLE
Properly lint shortcircuiting operators

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -1851,6 +1851,10 @@ gexpr({op,Line,Op,A}, Vt, St0) ->
         true -> {Avt,St1};
         false -> {Avt,add_error(Line, illegal_guard_expr, St1)}
     end;
+gexpr({op,_,'andalso',L,R}, Vt, St) ->
+    gexpr_list([L,R], Vt, St);
+gexpr({op,_,'orelse',L,R}, Vt, St) ->
+    gexpr_list([L,R], Vt, St);
 gexpr({op,Line,Op,L,R}, Vt, St0) ->
     {Avt,St1} = gexpr_list([L,R], Vt, St0),
     case is_gexpr_op(Op, 2) of
@@ -1937,12 +1941,14 @@ is_gexpr({call,L,{tuple,Lt,[{atom,Lm,erlang},{atom,Lf,F}]},As}, RDs) ->
     is_gexpr({call,L,{remote,Lt,{atom,Lm,erlang},{atom,Lf,F}},As}, RDs);
 is_gexpr({op,_L,Op,A}, RDs) ->
     is_gexpr_op(Op, 1) andalso is_gexpr(A, RDs);
+is_gexpr({op,_L,'andalso',A1,A2}, RDs) ->
+    is_gexpr_list([A1,A2], RDs);
+is_gexpr({op,_L,'orelse',A1,A2}, RDs) ->
+    is_gexpr_list([A1,A2], RDs);
 is_gexpr({op,_L,Op,A1,A2}, RDs) ->
     is_gexpr_op(Op, 2) andalso is_gexpr_list([A1,A2], RDs);
 is_gexpr(_Other, _RDs) -> false.
 
-is_gexpr_op('andalso', 2) -> true;
-is_gexpr_op('orelse', 2) -> true;
 is_gexpr_op(Op, A) ->
     try erl_internal:op_type(Op, A) of
         arith -> true;

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -1493,7 +1493,15 @@ guard(Config) when is_list(Config) ->
 	    [],
 	    {errors,[{1,erl_lint,illegal_guard_expr},
 		     {2,erl_lint,illegal_guard_expr},
-		     {3,erl_lint,illegal_guard_expr}],[]}}
+		     {3,erl_lint,illegal_guard_expr}],[]}},
+           {guard9,
+            <<"t(X, Y) when erlang:'andalso'(X, Y) -> ok;
+               t(X, Y) when erlang:'orelse'(X, Y) -> ok.
+            ">>,
+            [],
+            {errors,[{1,erl_lint,illegal_guard_expr},
+                     {2,erl_lint,illegal_guard_expr}],
+             []}}
 	  ],
     ?line [] = run(Config, Ts1),
     ok.


### PR DESCRIPTION
Shortcircuiting operators are not real functions and can't be used as such with erlang:'andalso'(...) and erlang:'orelse'(...).

@UlfNorell
