### PR TITLE
Do not mark all calls to erlang:is_function/2 as safe

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -2356,6 +2356,15 @@ is_safe_bool_expr_1(#c_call{module=#c_literal{val=erlang},
     %% been rewritten to is_record(Expr, LiteralTag, TupleSize).
     false;
 is_safe_bool_expr_1(#c_call{module=#c_literal{val=erlang},
+                            name=#c_literal{val=is_function},
+                            args=[A,#c_literal{val=Arity}]},
+                    Sub, _BoolVars) when is_integer(Arity), Arity >= 0 ->
+    is_safe_simple(A, Sub);
+is_safe_bool_expr_1(#c_call{module=#c_literal{val=erlang},
+                            name=#c_literal{val=is_function}},
+                    _Sub, _BoolVars) ->
+    false;
+is_safe_bool_expr_1(#c_call{module=#c_literal{val=erlang},
 			    name=#c_literal{val=Name},args=Args},
 		    Sub, BoolVars) ->
     NumArgs = length(Args),

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -1023,6 +1023,10 @@ is_function_2(Config) when is_list(Config) ->
     true = is_function(id(fun() -> ok end), 0),
     false = is_function(id(fun ?MODULE:all/1), 0),
     false = is_function(id(fun() -> ok end), 1),
+    {'EXIT',{badarg,_}} =
+        (catch is_function(id(fun() -> ok end), -1) orelse error),
+    {'EXIT',{badarg,_}} =
+        (catch is_function(id(fun() -> ok end), '') orelse error),
 
     F = fun(_) -> ok end,
     if


### PR DESCRIPTION
Calls to erlang:is_function/2 where the second is not a literal nonnegative integer can crash at runtime and thus can't be marked as safe.
