### PR TITLE
Properly detect nonboolean protected expressions in beam_bool

### DIFF
--- a/lib/compiler/src/beam_bool.erl
+++ b/lib/compiler/src/beam_bool.erl
@@ -391,10 +391,14 @@ bopt_tree([{set,_,_,{bif,'xor',_}}|_], _, _) ->
     throw('xor');
 bopt_tree([{protected,[Dst],Code,_}|Is], Forest0, Pre) ->
     ProtForest0 = gb_trees:from_orddict([P || {_,any}=P <- gb_trees:to_list(Forest0)]),
-    {ProtPre,[{_,ProtTree}]} = bopt_tree(Code, ProtForest0, []),
-    Prot = {prot,ProtPre,ProtTree},
-    Forest = gb_trees:enter(Dst, Prot, Forest0),
-    bopt_tree(Is, Forest, Pre);    
+    case bopt_tree(Code, ProtForest0, []) of
+        {ProtPre,[{_,ProtTree}]} ->
+            Prot = {prot,ProtPre,ProtTree},
+            Forest = gb_trees:enter(Dst, Prot, Forest0),
+            bopt_tree(Is, Forest, Pre);
+        _Res ->
+            throw(not_boolean_expr)
+    end;
 bopt_tree([{set,[Dst],[Src],move}=Move|Is], Forest, Pre) ->
     case {Src,Dst} of
 	{{tmp,_},_} -> throw(move);

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -33,7 +33,7 @@
 	 tricky/1,rel_ops/1,literal_type_tests/1,
 	 basic_andalso_orelse/1,traverse_dcd/1,
 	 check_qlc_hrl/1,andalso_semi/1,t_tuple_size/1,binary_part/1,
-	 bad_constants/1]).
+	 bad_constants/1,bad_guards/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -50,7 +50,7 @@ groups() ->
        t_is_boolean,is_function_2,tricky,rel_ops,
        literal_type_tests,basic_andalso_orelse,traverse_dcd,
        check_qlc_hrl,andalso_semi,t_tuple_size,binary_part,
-       bad_constants]}].
+       bad_constants,bad_guards]}].
 
 init_per_suite(Config) ->
     Config.
@@ -1548,6 +1548,10 @@ bad_constants(Config) when is_list(Config) ->
     ?line ?FAILING(<<1>>),
     ?line ?FAILING(42),
     ?line ?FAILING(3.14),
+    ok.
+
+bad_guards(Config) when is_list(Config) ->
+    if erlang:float(self()); true -> ok end,
     ok.
 
 %% Call this function to turn off constant propagation.


### PR DESCRIPTION
Silly code such as the following could make the compiler crash:

``` erlang
f() when erlang:float(self()); true -> ok.
```

@UlfNorell
