### PR TITLE
Properly sort map pairs in v3_codegen

### DIFF
--- a/lib/compiler/src/v3_codegen.erl
+++ b/lib/compiler/src/v3_codegen.erl
@@ -1551,7 +1551,11 @@ map_pair_strip_and_termsort(Es) ->
     %%    [{map_pair,K,V}]
     %% where K is for example {integer, 1} and we want to sort on 1.
     Ls = [{K,V}||{_,K,V}<-Es],
-    lists:sort(fun({{_,A},_},{{_,B},_}) -> erts_internal:cmp_term(A,B) < 0 end, Ls).
+    lists:sort(fun ({{_,A},_}, {{_,B},_}) -> erts_internal:cmp_term(A,B) =< 0;
+                   ({nil,_},   {{_,B},_}) -> [] =< B;
+                   ({{_,A},_}, {nil,_})   -> A =< [];
+                   ({nil,_},   {nil,_})   -> true
+               end, Ls).
 
 %%%
 %%% Code generation for constructing binaries.

--- a/lib/compiler/test/map_SUITE.erl
+++ b/lib/compiler/test/map_SUITE.erl
@@ -105,6 +105,9 @@ t_build_and_match_literals(Config) when is_list(Config) ->
     M = #{ map_1:=#{ map_2:=#{value_3 := third}, value_2:= second}, value_1:=first} =
 	 id(#{ map_1=>#{ map_2=>#{value_3 => third}, value_2=> second}, value_1=>first}),
 
+    %% nil key
+    #{[]:=ok,1:=2} = id(#{[]=>ok,1=>2}),
+
     %% error case
     {'EXIT',{{badmatch,_},_}} = (catch (#{x:=3,x:=2} = id(#{x=>3}))),
     {'EXIT',{{badmatch,_},_}} = (catch (#{x:=2} = id(#{x=>3}))),


### PR DESCRIPTION
Literal nil values aren't tagged tuple but the bare atom nil.

The function lists:sort/2 expects the passed function to return true if the first element is less than or equal to the second, not strictly less than. The original base clause is changed accordingly.

@UlfNorell
