### PR TITLE
Emit only variables as Core map update arguments

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -500,10 +500,17 @@ expr({map,L,Es0}, St0) ->
     A = lineno_anno(L, St1),
     {#c_map{anno=A,es=Es1},Eps,St1};
 expr({map,L,M0,Es0}, St0) ->
-    {M1,Mps,St1} = safe(M0, St0),
-    {Es1,Eps,St2} = map_pair_list(Es0, St1),
-    A = lineno_anno(L, St2),
-    {#c_map{anno=A,var=M1,es=Es1},Mps++Eps,St2};
+    {M1,Mps0,St1} = safe(M0, St0),
+    {M2,Mps1,St3} = case M1 of
+                        #c_var{} ->
+                            {M1,Mps0,St1};
+                        _ ->
+                            {V,St2} = new_var(St1),
+                            {V,Mps0++[#iset{var=V,arg=M1}],St2}
+                    end,
+    {Es1,Eps,St4} = map_pair_list(Es0, St3),
+    A = lineno_anno(L, St4),
+    {#c_map{anno=A,var=M2,es=Es1},Mps1++Eps,St4};
 expr({bin,L,Es0}, St0) ->
     try expr_bin(Es0, lineno_anno(L, St0), St0) of
 	{_,_,_}=Res -> Res

--- a/lib/compiler/test/map_SUITE.erl
+++ b/lib/compiler/test/map_SUITE.erl
@@ -43,7 +43,8 @@
 
 	%% errors in 17.0-rc1
 	t_update_values/1,
-        t_expand_map_update/1
+        t_expand_map_update/1,
+        t_bad_update/1
     ]).
 
 suite() -> [].
@@ -70,7 +71,8 @@ all() -> [
 
 	%% errors in 17.0-rc1
 	t_update_values,
-        t_expand_map_update
+        t_expand_map_update,
+        t_bad_update
     ].
 
 groups() -> [].
@@ -278,6 +280,11 @@ t_update_values(Config) when is_list(Config) ->
 t_expand_map_update(Config) when is_list(Config) ->
     M = #{<<"hello">> => <<"world">>}#{<<"hello">> := <<"les gens">>},
     #{<<"hello">> := <<"les gens">>} = M,
+    ok.
+
+t_bad_update(Config) when is_list(Config) ->
+    X = id(reblochon),
+    {'EXIT',{badarg,_}} = (catch [raclette,X]#{fromage=>exquis}),
     ok.
 
 check_val(#{val1:=V1, val2:=V2},V1,V2) -> ok.


### PR DESCRIPTION
Core Erlang does not support passing anything else than a variable to a map update expression.

@UlfNorell
