### PR TITLE
Add types for new HiPE BIFs

### DIFF
--- a/lib/hipe/cerl/erl_bif_types.erl
+++ b/lib/hipe/cerl/erl_bif_types.erl
@@ -1073,14 +1073,14 @@ type(hipe_bifs, fun_to_address, 1, Xs, Opaques) ->
 %% type(hipe_bifs, get_emu_address, 1, Xs, Opaques) ->
 %%    strict(hipe_bifs, get_emu_address, 1, Xs,
 %%	   fun (_) -> t_integer() end, Opaques); % address
+type(hipe_bifs, get_fe, 2, Xs, Opaques) ->
+  strict(hipe_bifs, get_fe, 2, Xs, fun (_) -> t_integer() end, Opaques);
 type(hipe_bifs, get_rts_param, 1, Xs, Opaques) ->
   strict(hipe_bifs, get_rts_param, 1, Xs,
 	 fun (_) -> t_sup(t_integer(), t_nil()) end, Opaques);
 type(hipe_bifs, invalidate_funinfo_native_addresses, 1, Xs, Opaques) ->
   strict(hipe_bifs, invalidate_funinfo_native_addresses, 1, Xs,
 	 fun (_) -> t_nil() end, Opaques);
-type(hipe_bifs, make_fe, 3, Xs, Opaques) ->
-  strict(hipe_bifs, make_fe, 3, Xs, fun (_) -> t_integer() end, Opaques);
 %% type(hipe_bifs, make_native_stub, 2, Xs, Opaques) ->
 %%    strict(hipe_bifs, make_native_stub, 2, Xs,
 %%	   fun (_) -> t_integer() end, Opaques); % address
@@ -1116,6 +1116,9 @@ type(hipe_bifs, set_funinfo_native_address, 3, Xs, Opaques) ->
 type(hipe_bifs, set_native_address, 3, Xs, Opaques) ->
   strict(hipe_bifs, set_native_address, 3, Xs,
 	 fun (_) -> t_nil() end, Opaques);
+type(hipe_bifs, set_native_address_in_fe, 2, Xs, Opaques) ->
+  strict(hipe_bifs, set_native_address_in_fe, 2, Xs,
+	 fun (_) -> t_atom('true') end, Opaques);
 type(hipe_bifs, system_crc, 1, Xs, Opaques) ->
   strict(hipe_bifs, system_crc, 1, Xs, fun (_) -> t_crc32() end, Opaques);
 type(hipe_bifs, term_to_word, 1, Xs, Opaques) ->
@@ -2451,12 +2454,12 @@ arg_types(hipe_bifs, fun_to_address, 1) ->
   [t_mfa()];
 %% arg_types(hipe_bifs, get_emu_address, 1) ->
 %%   [t_mfa()];
+arg_types(hipe_bifs, get_fe, 2) ->
+  [t_atom(), t_tuple([t_integer(), t_integer(), t_integer()])];
 arg_types(hipe_bifs, get_rts_param, 1) ->
   [t_fixnum()];
 arg_types(hipe_bifs, invalidate_funinfo_native_addresses, 1) ->
   [t_list(t_mfa())];
-arg_types(hipe_bifs, make_fe, 3) ->
-  [t_integer(), t_atom(), t_tuple([t_integer(), t_integer(), t_integer()])];
 %% arg_types(hipe_bifs, make_native_stub, 2) ->
 %%   [t_integer(), t_arity()];
 arg_types(hipe_bifs, mark_referred_from, 1) ->
@@ -2485,6 +2488,8 @@ arg_types(hipe_bifs, set_funinfo_native_address, 3) ->
   arg_types(hipe_bifs, set_native_address, 3);
 arg_types(hipe_bifs, set_native_address, 3) ->
   [t_mfa(), t_integer(), t_boolean()];
+arg_types(hipe_bifs, set_native_address_in_fe, 2) ->
+  [t_integer(), t_integer()];
 arg_types(hipe_bifs, system_crc, 1) ->
   [t_crc32()];
 arg_types(hipe_bifs, term_to_word, 1) ->


### PR DESCRIPTION
Commit https://github.com/erlang/otp/commit/81c7db0e247a6ee1b7a5c2764aa9575d7f6fb88a
broke apart hipe_bif:make_fe/3 into two BIFs but forgot to properly update
the type information about HiPE BIFs in hipe_bif_types.erl.  This commit fixes
this by taking out the types of hipe_bifs:make_fe/3 and adding types for the
new BIFs hipe_bifs:get_fe/2 and hipe_bifs:hipe_bifs_set_native_address_in_fe/2.
