### PR TITLE
Properly order Kernel code for maps with mixed pairs

### DIFF
--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -519,7 +519,7 @@ map_split_pairs(A, Var, Ces, Sub, St0) ->
 	    Kes1 = [#k_map_pair{key=K,val=V}||{_,{assoc,K,V}} <- Assoc],
 	    {Mvar,Em,St2} = force_atomic(#k_map{anno=A,op=assoc,var=Var,es=Kes1},St1),
 	    Kes2 = [#k_map_pair{key=K,val=V}||{_,{exact,K,V}} <- Exact],
-	    {#k_map{anno=A,op=exact,var=Mvar,es=Kes2},Em ++ Esp,St2}
+	    {#k_map{anno=A,op=exact,var=Mvar,es=Kes2},Esp ++ Em,St2}
 
     end.
 

--- a/lib/compiler/test/map_SUITE.erl
+++ b/lib/compiler/test/map_SUITE.erl
@@ -189,7 +189,9 @@ loop_match_and_update_literals_x_q(#{q:=Q0,x:=X0} = Map, [{X,Q}|Vs]) ->
 
 t_update_map_expressions(Config) when is_list(Config) ->
     M = maps:new(),
-    #{ a := 1 } = M#{a => 1},
+    X = id(fondue),
+    M1 = #{ a := 1 } = M#{a => 1},
+    #{ b := {X} } = M1#{ a := 1, b => {X} },
 
     #{ b := 2 } = (maps:new())#{ b => 2 },
 


### PR DESCRIPTION
The Kernel instructions were not properly ordered when compiling maps with complex values mixed in assoc and exact pairs.

@UlfNorell
