### PR TITLE
Do not export variables from comprehension cases in v3_core

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -1765,13 +1765,16 @@ uexpr(#iletrec{anno=A,defs=Fs0,body=B0}, Ks, St0) ->
     {B1,St2} = uexprs(B0, Ks, St1),
     Used = used_in_any(map(fun ({_,F}) -> F end, Fs1) ++ B1),
     {#iletrec{anno=A#a{us=Used,ns=[]},defs=Fs1,body=B1},St2};
-uexpr(#icase{anno=A,args=As0,clauses=Cs0,fc=Fc0}, Ks, St0) ->
+uexpr(#icase{anno=#a{anno=Anno}=A,args=As0,clauses=Cs0,fc=Fc0}, Ks, St0) ->
     %% As0 will never generate new variables.
     {As1,St1} = uexpr_list(As0, Ks, St0),
     {Cs1,St2} = uclauses(Cs0, Ks, St1),
     {Fc1,St3} = uclause(Fc0, Ks, St2),
     Used = union(used_in_any(As1), used_in_any(Cs1)),
-    New = new_in_all(Cs1),
+    New = case lists:member(list_comprehension, Anno) of
+              true -> [];
+              false -> new_in_all(Cs1)
+          end,
     {#icase{anno=A#a{us=Used,ns=New},args=As1,clauses=Cs1,fc=Fc1},St3};
 uexpr(#ifun{anno=A0,id=Id,vars=As,clauses=Cs0,fc=Fc0,name=Name}, Ks0, St0) ->
     Avs = lit_list_vars(As),

--- a/lib/compiler/test/lc_SUITE.erl
+++ b/lib/compiler/test/lc_SUITE.erl
@@ -23,7 +23,7 @@
 	 init_per_group/2,end_per_group/2,
 	 init_per_testcase/2,end_per_testcase/2,
 	 basic/1,deeply_nested/1,no_generator/1,
-	 empty_generator/1]).
+	 empty_generator/1,no_export/1]).
 
 -include_lib("test_server/include/test_server.hrl").
 
@@ -31,7 +31,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
     test_lib:recompile(?MODULE),
-    [basic, deeply_nested, no_generator, empty_generator].
+    [basic, deeply_nested, no_generator, empty_generator, no_export].
 
 groups() -> 
     [].
@@ -175,6 +175,10 @@ no_gen_one_more(A, B) -> A + 1 =:= B.
 
 empty_generator(Config) when is_list(Config) ->
     ?line [] = [X || {X} <- [], (false or (X/0 > 3))],
+    ok.
+
+no_export(Config) when is_list(Config) ->
+    [] = [ _X = a || false ] ++ [ _X = a || false ],
     ok.
 
 id(I) -> I.


### PR DESCRIPTION
Code like the following snippet could make the compiler crash:

``` erlang
f() -> [X = a || false] ++ [X = a || false].
```

@UlfNorell
