### PR TITLE
Fix comment that differs from code

### DIFF
--- a/erts/emulator/beam/erl_db_tree.c
+++ b/erts/emulator/beam/erl_db_tree.c
@@ -485,7 +485,7 @@ static int db_first_tree(Process *p, DbTable *tbl, Eterm *ret)
 	*ret = am_EOT;
 	return DB_ERROR_NONE;
     }
-    /* Walk down to the tree to the left */
+    /* Walk down the tree to the left */
     if ((stack = get_static_stack(tb)) != NULL) {
 	stack->pos = stack->slot = 0;
     }
@@ -531,7 +531,7 @@ static int db_last_tree(Process *p, DbTable *tbl, Eterm *ret)
 	*ret = am_EOT;
 	return DB_ERROR_NONE;
     }
-    /* Walk down to the tree to the left */
+    /* Walk down the tree to the right */
     if ((stack = get_static_stack(tb)) != NULL) {
 	stack->pos = stack->slot = 0;
     }    


### PR DESCRIPTION
The comment in the code state that the tree is traversed to the left,
when in fact it is traversed to the right.
