### PR TITLE
Added a condition to ignore empty Set-Cookie header and tests for it

### DIFF
--- a/lib/inets/src/http_client/httpc_cookie.erl
+++ b/lib/inets/src/http_client/httpc_cookie.erl
@@ -335,7 +335,8 @@ add_domain(Str, #http_cookie{domain = Domain}) ->
     Str ++ "; $Domain=" ++  Domain.
 
 parse_set_cookies(CookieHeaders, DefaultPathDomain) ->
-    SetCookieHeaders = [Value || {"set-cookie", Value} <- CookieHeaders], 
+    %% empty Set-Cookie header is invalid according to RFC but some sites violate it
+    SetCookieHeaders = [Value || {"set-cookie", Value} <- CookieHeaders, Value /= ""],
     Cookies = [parse_set_cookie(SetCookieHeader, DefaultPathDomain) || 
 		  SetCookieHeader <- SetCookieHeaders],
     %% print_cookies("Parsed Cookies", Cookies),

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -91,6 +91,7 @@ only_simulated() ->
     [
      cookie,
      cookie_profile,
+     empty_set_cookie,
      trace,
      stream_once,
      no_content_204,
@@ -528,6 +529,19 @@ cookie_profile(Config) when is_list(Config) ->
 
     ets:delete(cookie),
     inets:stop(httpc, cookie_test).
+
+%%-------------------------------------------------------------------------
+empty_set_cookie() ->
+    [{doc, "Test empty Set-Cookie header."}].
+empty_set_cookie(Config) when is_list(Config) ->
+    ok = httpc:set_options([{cookies, enabled}]),
+
+    Request0 = {url(group_name(Config), "/empty_set_cookie.html", Config), []},
+
+    {ok, {{_,200,_}, [_ | _], [_|_]}}
+	= httpc:request(get, Request0, [], []),
+
+    ok = httpc:set_options([{cookies, disabled}]).
 
 %%-------------------------------------------------------------------------
 headers_as_is(doc) ->
@@ -1613,6 +1627,12 @@ handle_uri(_,"/cookie.html",_,_,_,_) ->
     "HTTP/1.1 200 ok\r\n" ++
 	"set-cookie:" ++ "test_cookie=true; path=/;" ++
 	"max-age=60000\r\n" ++
+	"Content-Length:32\r\n\r\n"++
+	"<HTML><BODY>foobar</BODY></HTML>";
+
+handle_uri(_,"/empty_set_cookie.html",_,_,_,_) ->
+    "HTTP/1.1 200 ok\r\n" ++
+	"set-cookie: \r\n" ++
 	"Content-Length:32\r\n\r\n"++
 	"<HTML><BODY>foobar</BODY></HTML>";
 


### PR DESCRIPTION
Original bug request - http://erlang.org/pipermail/erlang-bugs/2013-August/003730.html
www.climber.com is an example of such behaviour
