### PR TITLE
Properly detect reused boolean values in beam_bool

### DIFF
--- a/lib/compiler/src/beam_bool.erl
+++ b/lib/compiler/src/beam_bool.erl
@@ -438,9 +438,10 @@ bopt_bool_args(As, Forest) ->
     mapfoldl(fun bopt_bool_arg/2, Forest, As).
 
 bopt_bool_arg({T,_}=R, Forest) when T =:= x; T =:= y; T =:= tmp ->
-    Val = case gb_trees:get(R, Forest) of
-	      any -> {test,is_eq_exact,fail,[R,{atom,true}]};
-	      Val0 -> Val0
+    Val = case gb_trees:lookup(R, Forest) of
+	      {value,any} -> {test,is_eq_exact,fail,[R,{atom,true}]};
+	      {value,Val0} -> Val0;
+              none -> throw(mixed)
 	  end,
     {Val,gb_trees:delete(R, Forest)};
 bopt_bool_arg(Term, Forest) ->

--- a/lib/compiler/test/andor_SUITE.erl
+++ b/lib/compiler/test/andor_SUITE.erl
@@ -171,6 +171,8 @@ t_and_or(Config) when is_list(Config) ->
     false = ?GUARD(erlang:'not'(erlang:'and'(bar, True))),
     false = ?GUARD(erlang:'not'(erlang:'not'(erlang:'and'(bar, True)))),
 
+    true = (fun (X = true) when X or true or X -> true end)(True),
+
    ok.
 
 t_andalso(Config) when is_list(Config) ->


### PR DESCRIPTION
The following code could crash the compiler:

``` erlang
f(X = true) when X or true or X -> ok.
```

@UlfNorell
