### PR TITLE
Inherit options in gen_tcp:accept/1 in inet_drv directly

### DIFF
--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -8981,6 +8981,7 @@ static tcp_descriptor* tcp_inet_copy(tcp_descriptor* desc,SOCKET s,
     }
 
     /* Some flags must be inherited at this point */
+    copy_desc->inet.active   = desc->inet.active;
     copy_desc->inet.mode     = desc->inet.mode;
     copy_desc->inet.exitf    = desc->inet.exitf;
     copy_desc->inet.deliver  = desc->inet.deliver;
@@ -8994,6 +8995,7 @@ static tcp_descriptor* tcp_inet_copy(tcp_descriptor* desc,SOCKET s,
     copy_desc->low           = desc->low;
     copy_desc->send_timeout  = desc->send_timeout;
     copy_desc->send_timeout_close = desc->send_timeout_close;
+    copy_desc->tcp_add_flags = desc->tcp_add_flags & TCP_ADDF_DELAY_SEND;
     
     /* The new port will be linked and connected to the original caller */
     port = driver_create_port(port, owner, "tcp_inet", (ErlDrvData) copy_desc);

--- a/erts/preloaded/src/prim_inet.erl
+++ b/erts/preloaded/src/prim_inet.erl
@@ -307,24 +307,10 @@ accept0(L, Time) when is_port(L), is_integer(Time) ->
     case async_accept(L, Time) of
 	{ok, Ref} ->
 	    receive 
-		{inet_async, L, Ref, {ok,S}} ->
-		    accept_opts(L, S);
-		{inet_async, L, Ref, Error} ->
-		    Error
+                {inet_async, L, Ref, Result} ->
+                    Result
 	    end;
 	Error -> Error
-    end.
-
-%% setup options from listen socket on the connected socket
-accept_opts(L, S) ->
-    case getopts(L, [active, nodelay, keepalive, delay_send, priority, tos]) of
-	{ok, Opts} ->
-	    case setopts(S, Opts) of
-		ok -> {ok, S};
-		Error -> close(S), Error
-	    end;
-	Error ->
-	    close(S), Error
     end.
 
 async_accept(L, Time) ->


### PR DESCRIPTION
I can't test whether 'priority' and 'tos' are properly inherited here as OS X doesn't support these options.

Cc @reedr.