### PR TITLE
Stop supervisor adding temporary children on code change

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -655,8 +655,15 @@ update_childspec1([Child|OldC], Children, KeepOld) ->
 	    update_childspec1(OldC, Children, [Child|KeepOld])
     end;
 update_childspec1([], Children, KeepOld) ->
+    %% Temporary children are never restarted so any new are ignored.
+    NChildren = lists:foldl(fun(#child{pid=undefined,
+				       restart_type=temporary}, Acc) ->
+				    Acc;
+			       (Ch, Acc) ->
+				    [Ch|Acc]
+			    end, [], Children),
     %% Return them in (kept) reverse start order.
-    lists:reverse(Children ++ KeepOld).
+    lists:reverse(KeepOld, NChildren).
 
 update_chsp(OldCh, Children) ->
     case lists:map(fun(Ch) when OldCh#child.name =:= Ch#child.name ->


### PR DESCRIPTION
If a `temporary` child has stopped (and so been removed from a supervisor's childspecs) a code upgrade would re-add it to the childspecs. If the supervisor was `one_for_all` or `rest_for_one` the `temporary` child would be restarted if another child triggered a restart. The `temporary` child would also appear in the `supervisor:which_children/1` results with an `undefined` pid, which is unexpected given the behaviour of `temporary` children.

This patch prevents new `temporary` children being added to a supervisor's childspecs in a code upgrade, copying the behaviour added in 4f9b938112a80f1c1e210b1a6af40a42f833cfa2.
