### PR TITLE
Extract line annotation from filter qualifiers in a type-friendly way

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -1148,6 +1148,7 @@ get_qual_line({'case',Line,_,_}) -> Line;
 get_qual_line({'if',Line,_}) -> Line;
 get_qual_line({block,Line,_}) -> Line;
 get_qual_line({match,Line,_}) -> Line;
+get_qual_line({atom,Line,_}) -> Line;
 get_qual_line({var,Line,_}) -> Line.
 
 %%


### PR DESCRIPTION
A recently submitted patch (78ce891).used function `get_anno/1` to extract
the line annotation from filter qualifiers in comprehensions, but this did not
respect the spec of this function and resulted in a dialyzer warning.
To make the code more type-friendly, an appropriate `get_qual_line/1`
function was introduced.  The new function also ensures that the
qualifiers are of the appropriate form.

While at it, also simplified an Edoc comment.
