### PR TITLE
sasl: Fix 'function_clause' in systools_make:format_error

### DIFF
--- a/lib/sasl/src/systools_make.erl
+++ b/lib/sasl/src/systools_make.erl
@@ -2218,7 +2218,7 @@ format_error({undefined_applications,Apps}) ->
     io_lib:format("Undefined applications: ~p~n",[Apps]);
 format_error({duplicate_modules,Dups}) ->
     io_lib:format("Duplicated modules: ~n~ts",
-		  [map(fun({{Mod,_,App1,_,_},{Mod,_,App2,_,_}}) ->
+		  [map(fun({{Mod,App1,_},{Mod,App2,_}}) ->
 			       io_lib:format("\t~w specified in ~w and ~w~n",
 					     [Mod,App1,App2])
 		       end, Dups)]);

--- a/lib/sasl/test/systools_SUITE.erl
+++ b/lib/sasl/test/systools_SUITE.erl
@@ -47,6 +47,7 @@
 	 abnormal_script/1, src_tests_script/1, crazy_script/1,
 	 included_script/1, included_override_script/1,
 	 included_fail_script/1, included_bug_script/1, exref_script/1,
+	 duplicate_modules_script/1,
 	 otp_3065_circular_dependenies/1, included_and_used_sort_script/1]).
 -export([tar_options/1, normal_tar/1, no_mod_vsn_tar/1, system_files_tar/1,
 	 system_files_tar/2, invalid_system_files_tar/1,
@@ -84,6 +85,7 @@ groups() ->
        src_tests_script, crazy_script,
        included_script, included_override_script,
        included_fail_script, included_bug_script, exref_script,
+       duplicate_modules_script,
        otp_3065_circular_dependenies, included_and_used_sort_script]},
      {tar, [],
       [tar_options, normal_tar, no_mod_vsn_tar, system_files_tar,
@@ -821,6 +823,33 @@ no_hipe({ok, Value}) ->
 	_Arch ->
 	    {ok, Value}
     end.
+
+%% duplicate_modules_script: Check that make_script rejects two
+%% applications providing the same module.
+duplicate_modules_script(Config) when is_list(Config) ->
+    {ok, OldDir} = file:get_cwd(),
+
+    {LatestDir, LatestName} = create_script(duplicate_modules,Config),
+
+    DataDir = filename:absname(?copydir),
+
+    ok = file:set_cwd(LatestDir),
+    LibDir = fname([DataDir, d_duplicate_modules, lib]),
+    P = [fname([LibDir, 'app1-1.0', ebin]),
+	 fname([LibDir, 'app2-1.0', ebin])],
+
+    %% Check wrong app vsn
+    error = systools:make_script(LatestName, [{path, P}]),
+    {error,
+      systools_make,
+      {duplicate_modules, [
+          {{myapp,app1,_}, {myapp,app2,_}}
+        ]
+      }
+    } = systools:make_script(LatestName, [silent, {path, P}]),
+
+    ok = file:set_cwd(OldDir),
+    ok.
 
 %% tar_options: Check illegal tar options.
 tar_options(Config) when is_list(Config) ->
@@ -2186,7 +2215,10 @@ create_script(current_all_future_sasl,Config) ->
     do_create_script(current_all_future_sasl,Config,current,Apps);
 create_script({unicode,RelVsn},Config) ->
     Apps = core_apps(current) ++ [{ua,"1.0"}],
-    do_create_script(unicode,RelVsn,Config,current,Apps).
+    do_create_script(unicode,RelVsn,Config,current,Apps);
+create_script(duplicate_modules,Config) ->
+    Apps = core_apps(current) ++ [{app1,"1.0"},{app2,"1.0"}],
+    do_create_script(duplicate_modules,Config,current,Apps).
 
 
 do_create_script(Id,Config,ErtsVsn,AppVsns) ->

--- a/lib/sasl/test/systools_SUITE_data/d_duplicate_modules/lib/app1-1.0/ebin/app1.app
+++ b/lib/sasl/test/systools_SUITE_data/d_duplicate_modules/lib/app1-1.0/ebin/app1.app
@@ -1,0 +1,7 @@
+{application, app1,
+   [{description, "Application 1"},
+    {vsn, "1.0"},
+    {modules, [myapp]},
+    {registered, []},
+    {applications, []},
+    {env, []}]}.

--- a/lib/sasl/test/systools_SUITE_data/d_duplicate_modules/lib/app1-1.0/src/myapp.erl
+++ b/lib/sasl/test/systools_SUITE_data/d_duplicate_modules/lib/app1-1.0/src/myapp.erl
@@ -1,0 +1,2 @@
+-module(myapp).
+-vsn("1.0").

--- a/lib/sasl/test/systools_SUITE_data/d_duplicate_modules/lib/app2-1.0/ebin/app2.app
+++ b/lib/sasl/test/systools_SUITE_data/d_duplicate_modules/lib/app2-1.0/ebin/app2.app
@@ -1,0 +1,7 @@
+{application, app2,
+   [{description, "Application 2"},
+    {vsn, "1.0"},
+    {modules, [myapp]},
+    {registered, []},
+    {applications, []},
+    {env, []}]}.

--- a/lib/sasl/test/systools_SUITE_data/d_duplicate_modules/lib/app2-1.0/src/myapp.erl
+++ b/lib/sasl/test/systools_SUITE_data/d_duplicate_modules/lib/app2-1.0/src/myapp.erl
@@ -1,0 +1,2 @@
+-module(myapp).
+-vsn("1.0").


### PR DESCRIPTION
({duplicate_modules,_})

The format of the Dups argument is:
  [
    {{Mod,App1,_}, {Mod,App2,_}},
    ...
  ]

But the function expected:
  [
    {{Mod,_,App1,_,_}, {Mod,_,App2,_,_}},
    ...
  ]

A workaround was to pass the 'silent' option to systools:make_script/2.
format_error/1 was not called in this case.
