### PR TITLE
Don't 'opaque-decorate' a success typing using an incompatible spec

### DIFF
--- a/lib/dialyzer/test/small_SUITE_data/results/invalid_spec_2
+++ b/lib/dialyzer/test/small_SUITE_data/results/invalid_spec_2
@@ -1,0 +1,2 @@
+
+scala_user.erl:5: Invalid type specification for function scala_user:is_list/2. The success typing is (maybe_improper_list() | tuple(),_) -> boolean()

--- a/lib/dialyzer/test/small_SUITE_data/src/invalid_spec_2/scala_data.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/invalid_spec_2/scala_data.erl
@@ -1,0 +1,5 @@
+-module(scala_data).
+
+-export_type([data/0]).
+
+-opaque data() :: {'data', term()}.

--- a/lib/dialyzer/test/small_SUITE_data/src/invalid_spec_2/scala_user.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/invalid_spec_2/scala_user.erl
@@ -1,0 +1,8 @@
+-module(scala_user).
+
+-export([is_list/2]).
+
+-spec is_list(atom(), scala_data:data()) -> boolean().
+
+is_list( List,Data) when   is_list(List) -> true;
+is_list(Tuple,Data) when is_tuple(Tuple) -> false.

--- a/lib/hipe/cerl/erl_types.erl
+++ b/lib/hipe/cerl/erl_types.erl
@@ -618,7 +618,7 @@ t_decorate_with_opaque(T1, T2, Opaques) ->
       end
   end.
 
-decorate(?none=Type, _, _Opaques) -> Type;
+decorate(Type, ?none, _Opaques) -> Type;
 decorate(?function(Domain, Range), ?function(D, R), Opaques) ->
   ?function(decorate(Domain, D, Opaques), decorate(Range, R, Opaques));
 decorate(?list(Types, Tail, Size), ?list(Ts, Tl, _Sz), Opaques) ->
@@ -684,6 +684,7 @@ union_decorate(U1, U2, Opaques) ->
   List = [A,B,F,I,L,N,T,M,Map],
   DecList = [Dec ||
               E <- List,
+              not t_is_none(E),
               not t_is_none(Dec = decorate(E, Opaque, Opaques))],
   t_sup([Union|DecList]).
 


### PR DESCRIPTION
Without this patch Dialyzer crashes when analyzing the supplemented test case.
