### PR TITLE
Do not consider map constructors as data in cerl:is_data/1

### DIFF
--- a/lib/compiler/src/cerl.erl
+++ b/lib/compiler/src/cerl.erl
@@ -3855,7 +3855,7 @@ from_records(Node) ->
 
 -spec is_data(cerl()) -> boolean().
 
-is_data(#c_literal{}) ->
+is_data(#c_literal{val=V}) when not is_map(V) ->
     true;
 is_data(#c_cons{}) ->
     true;

--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -23,7 +23,7 @@
 	 t_element/1,setelement/1,t_length/1,append/1,t_apply/1,bifs/1,
 	 eq/1,nested_call_in_case/1,guard_try_catch/1,coverage/1,
 	 unused_multiple_values_error/1,unused_multiple_values/1,
-	 multiple_aliases/1,redundant_boolean_clauses/1]).
+	 multiple_aliases/1,redundant_boolean_clauses/1,map_matching_clauses/1]).
 
 -export([foo/0,foo/1,foo/2,foo/3]).
 
@@ -40,7 +40,7 @@ groups() ->
       [t_element,setelement,t_length,append,t_apply,bifs,
        eq,nested_call_in_case,guard_try_catch,coverage,
        unused_multiple_values_error,unused_multiple_values,
-       multiple_aliases,redundant_boolean_clauses]}].
+       multiple_aliases,redundant_boolean_clauses,map_matching_clauses]}].
 
 
 init_per_suite(Config) ->
@@ -373,5 +373,11 @@ redundant_boolean_clauses(Config) when is_list(Config) ->
             true -> yes
         end.
 
+map_matching_clauses(Config) when is_list(Config) ->
+  0 = case #{} of
+          #{} -> 0;
+          a -> 1
+      end,
+  ok.
 
 id(I) -> I.


### PR DESCRIPTION
The optimisation passes and cerl_clauses can't handle yet map expressions as data constructors.

@UlfNorell
