### PR TITLE
Fix DTrace/SystemTap-related formatting

### DIFF
--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -1301,7 +1301,7 @@ void process_main(void)
                                       (Eterm)fptr[1], (Uint)fptr[2],
                                       NULL, fun_buf);
                 } else {
-                    erts_snprintf(fun_buf, sizeof(fun_buf),
+                    erts_snprintf(fun_buf, DTRACE_CHARBUF_SIZEOF(fun_buf),
                                   "<unknown/%p>", next);
                 }
             }

--- a/erts/emulator/beam/copy.c
+++ b/erts/emulator/beam/copy.c
@@ -48,7 +48,7 @@ copy_object(Eterm obj, Process* to)
     if (DTRACE_ENABLED(copy_object)) {
         DTRACE_CHARBUF(proc_name, 64);
 
-        erts_snprintf(proc_name, sizeof(proc_name), "%T", to->common.id);
+        erts_snprintf(proc_name, DTRACE_CHARBUF_SIZEOF(proc_name), "%T", to->common.id);
         DTRACE2(copy_object, proc_name, size);
     }
 #endif

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -851,9 +851,9 @@ erts_dsig_send_msg(ErtsDSigData *dsdp, Eterm remote, Eterm message)
 #ifdef USE_VM_PROBES
     *node_name = *sender_name = *receiver_name = '\0';
     if (DTRACE_ENABLED(message_send) || DTRACE_ENABLED(message_send_remote)) {
-        erts_snprintf(node_name, sizeof(node_name), "%T", dsdp->dep->sysname);
-        erts_snprintf(sender_name, sizeof(sender_name), "%T", sender->common.id);
-        erts_snprintf(receiver_name, sizeof(receiver_name), "%T", remote);
+        erts_snprintf(node_name, DTRACE_CHARBUF_SIZEOF(node_name), "%T", dsdp->dep->sysname);
+        erts_snprintf(sender_name, DTRACE_CHARBUF_SIZEOF(sender_name), "%T", sender->common.id);
+        erts_snprintf(receiver_name, DTRACE_CHARBUF_SIZEOF(receiver_name), "%T", remote);
         msize = size_object(message);
         if (token != NIL && token != am_have_dt_utag) {
             tok_label = signed_val(SEQ_TRACE_T_LABEL(token));
@@ -908,9 +908,9 @@ erts_dsig_send_reg_msg(ErtsDSigData *dsdp, Eterm remote_name, Eterm message)
 #ifdef USE_VM_PROBES
     *node_name = *sender_name = *receiver_name = '\0';
     if (DTRACE_ENABLED(message_send) || DTRACE_ENABLED(message_send_remote)) {
-        erts_snprintf(node_name, sizeof(node_name), "%T", dsdp->dep->sysname);
-        erts_snprintf(sender_name, sizeof(sender_name), "%T", sender->common.id);
-        erts_snprintf(receiver_name, sizeof(receiver_name),
+        erts_snprintf(node_name, DTRACE_CHARBUF_SIZEOF(node_name), "%T", dsdp->dep->sysname);
+        erts_snprintf(sender_name, DTRACE_CHARBUF_SIZEOF(sender_name), "%T", sender->common.id);
+        erts_snprintf(receiver_name, DTRACE_CHARBUF_SIZEOF(receiver_name),
                       "{%T,%s}", remote_name, node_name);
         msize = size_object(message);
         if (token != NIL && token != am_have_dt_utag) {
@@ -971,11 +971,11 @@ erts_dsig_send_exit_tt(ErtsDSigData *dsdp, Eterm local, Eterm remote,
 #ifdef USE_VM_PROBES
     *node_name = *sender_name = *remote_name = '\0';
     if (DTRACE_ENABLED(process_exit_signal_remote)) {
-        erts_snprintf(node_name, sizeof(node_name), "%T", dsdp->dep->sysname);
-        erts_snprintf(sender_name, sizeof(sender_name), "%T", sender->common.id);
-        erts_snprintf(remote_name, sizeof(remote_name),
+        erts_snprintf(node_name, DTRACE_CHARBUF_SIZEOF(node_name), "%T", dsdp->dep->sysname);
+        erts_snprintf(sender_name, DTRACE_CHARBUF_SIZEOF(sender_name), "%T", sender->common.id);
+        erts_snprintf(remote_name, DTRACE_CHARBUF_SIZEOF(remote_name),
                       "{%T,%s}", remote, node_name);
-        erts_snprintf(reason_str, sizeof(reason), "%T", reason);
+        erts_snprintf(reason_str, DTRACE_CHARBUF_SIZEOF(reason_str), "%T", reason);
         if (token != NIL && token != am_have_dt_utag) {
             tok_label = signed_val(SEQ_TRACE_T_LABEL(token));
             tok_lastcnt = signed_val(SEQ_TRACE_T_LASTCNT(token));
@@ -1797,8 +1797,8 @@ dsig_send(ErtsDSigData *dsdp, Eterm ctl, Eterm msg, int force_busy)
                     DTRACE_CHARBUF(port_str, 64);
                     DTRACE_CHARBUF(remote_str, 64);
 
-                    erts_snprintf(port_str, sizeof(port_str), "%T", cid);
-                    erts_snprintf(remote_str, sizeof(remote_str),
+                    erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", cid);
+                    erts_snprintf(remote_str, DTRACE_CHARBUF_SIZEOF(remote_str),
                                   "%T", dep->sysname);
                     DTRACE3(dist_port_not_busy, erts_this_node_sysname,
                             port_str, remote_str);
@@ -1855,9 +1855,9 @@ dsig_send(ErtsDSigData *dsdp, Eterm ctl, Eterm msg, int force_busy)
             DTRACE_CHARBUF(remote_str, 64);
             DTRACE_CHARBUF(pid_str, 16);
 
-            erts_snprintf(port_str, sizeof(port_str), "%T", cid);
-            erts_snprintf(remote_str, sizeof(remote_str), "%T", dep->sysname);
-            erts_snprintf(pid_str, sizeof(pid_str), "%T", c_p->common.id);
+            erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", cid);
+            erts_snprintf(remote_str, DTRACE_CHARBUF_SIZEOF(remote_str), "%T", dep->sysname);
+            erts_snprintf(pid_str, DTRACE_CHARBUF_SIZEOF(pid_str), "%T", c_p->common.id);
             DTRACE4(dist_port_busy, erts_this_node_sysname,
                     port_str, remote_str, pid_str);
         }
@@ -1890,8 +1890,8 @@ dist_port_command(Port *prt, ErtsDistOutputBuf *obuf)
         DTRACE_CHARBUF(port_str, 64);
         DTRACE_CHARBUF(remote_str, 64);
 
-        erts_snprintf(port_str, sizeof(port_str), "%T", prt->common.id);
-        erts_snprintf(remote_str, sizeof(remote_str),
+        erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", prt->common.id);
+        erts_snprintf(remote_str, DTRACE_CHARBUF_SIZEOF(remote_str),
                       "%T", prt->dist_entry->sysname);
         DTRACE4(dist_output, erts_this_node_sysname, port_str,
                 remote_str, size);
@@ -1944,8 +1944,8 @@ dist_port_commandv(Port *prt, ErtsDistOutputBuf *obuf)
         DTRACE_CHARBUF(port_str, 64);
         DTRACE_CHARBUF(remote_str, 64);
 
-        erts_snprintf(port_str, sizeof(port_str), "%T", prt->common.id);
-        erts_snprintf(remote_str, sizeof(remote_str),
+        erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", prt->common.id);
+        erts_snprintf(remote_str, DTRACE_CHARBUF_SIZEOF(remote_str),
                       "%T", prt->dist_entry->sysname);
         DTRACE4(dist_outputv, erts_this_node_sysname, port_str,
                 remote_str, size);
@@ -2280,8 +2280,8 @@ erts_dist_port_not_busy(Port *prt)
         DTRACE_CHARBUF(port_str, 64);
         DTRACE_CHARBUF(remote_str, 64);
 
-        erts_snprintf(port_str, sizeof(port_str), "%T", prt->common.id);
-        erts_snprintf(remote_str, sizeof(remote_str),
+        erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", prt->common.id);
+        erts_snprintf(remote_str, DTRACE_CHARBUF_SIZEOF(remote_str),
                       "%T", prt->dist_entry->sysname);
         DTRACE3(dist_port_not_busy, erts_this_node_sysname,
                 port_str, remote_str);
@@ -3246,10 +3246,10 @@ send_nodes_mon_msgs(Process *c_p, Eterm what, Eterm node, Eterm type, Eterm reas
         DTRACE_CHARBUF(type_str, 12);
         DTRACE_CHARBUF(reason_str, 64);
 
-        erts_snprintf(what_str, sizeof(what_str), "%T", what);
-        erts_snprintf(node_str, sizeof(node_str), "%T", node);
-        erts_snprintf(type_str, sizeof(type_str), "%T", type);
-        erts_snprintf(reason_str, sizeof(reason_str), "%T", reason);
+        erts_snprintf(what_str, DTRACE_CHARBUF_SIZEOF(what_str), "%T", what);
+        erts_snprintf(node_str, DTRACE_CHARBUF_SIZEOF(node_str), "%T", node);
+        erts_snprintf(type_str, DTRACE_CHARBUF_SIZEOF(type_str), "%T", type);
+        erts_snprintf(reason_str, DTRACE_CHARBUF_SIZEOF(reason_str), "%T", reason);
         DTRACE5(dist_monitor, erts_this_node_sysname,
                 what_str, node_str, type_str, reason_str);
     }

--- a/erts/emulator/beam/dtrace-wrapper.h
+++ b/erts/emulator/beam/dtrace-wrapper.h
@@ -42,7 +42,7 @@
 #define DTRACE_CHARBUF(name, size) \
     char name##_BUFFER[size], *name = name##_BUFFER
 
-#define DTRACE_CHARBUF_NAME(name) name##_BUFFER
+#define DTRACE_CHARBUF_SIZEOF(name) sizeof(name##_BUFFER)
 
 #if defined(USE_DYNAMIC_TRACE) && defined(USE_VM_PROBES) 
 

--- a/erts/emulator/beam/erl_async.c
+++ b/erts/emulator/beam/erl_async.c
@@ -292,7 +292,7 @@ static ERTS_INLINE void async_add(ErtsAsync *a, ErtsAsyncQ* q)
     if (DTRACE_ENABLED(aio_pool_add)) {
         DTRACE_CHARBUF(port_str, 16);
 
-        erts_snprintf(port_str, sizeof(port_str), "%T", a->port);
+        erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", a->port);
         /* DTRACE TODO: Get the queue length from erts_thr_q_enqueue() ? */
         len = -1;
         DTRACE2(aio_pool_add, port_str, len);
@@ -327,7 +327,7 @@ static ERTS_INLINE ErtsAsync *async_get(ErtsThrQ_t *q,
             if (DTRACE_ENABLED(aio_pool_get)) {
                 DTRACE_CHARBUF(port_str, 16);
 
-                erts_snprintf(port_str, sizeof(port_str), "%T", a->port);
+                erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", a->port);
                 /* DTRACE TODO: Get the length from erts_thr_q_dequeue() ? */
                 len = -1;
                 DTRACE2(aio_pool_get, port_str, len);

--- a/erts/emulator/beam/erl_bif_port.c
+++ b/erts/emulator/beam/erl_bif_port.c
@@ -882,7 +882,7 @@ open_port(Process* p, Eterm name, Eterm settings, int *err_typep, int *err_nump)
         DTRACE_CHARBUF(port_str, DTRACE_TERM_BUF_SIZE);
 
         dtrace_proc_str(p, process_str);
-        erts_snprintf(port_str, sizeof(port_str), "%T", port->common.id);
+        erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", port->common.id);
         DTRACE3(port_open, process_str, name_buf, port_str);
     }
 #endif

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -896,8 +896,8 @@ erts_send_message(Process* sender,
  #ifdef USE_VM_PROBES
     *sender_name = *receiver_name = '\0';
    if (DTRACE_ENABLED(message_send)) {
-        erts_snprintf(sender_name, sizeof(DTRACE_CHARBUF_NAME(sender_name)), "%T", sender->common.id);
-        erts_snprintf(receiver_name, sizeof(DTRACE_CHARBUF_NAME(receiver_name)), "%T", receiver->common.id);
+        erts_snprintf(sender_name, DTRACE_CHARBUF_SIZEOF(sender_name), "%T", sender->common.id);
+        erts_snprintf(receiver_name, DTRACE_CHARBUF_SIZEOF(receiver_name), "%T", receiver->common.id);
     }
 #endif
     if (SEQ_TRACE_TOKEN(sender) != NIL && !(flags & ERTS_SND_FLG_NO_SEQ_TRACE)) {

--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -2035,9 +2035,9 @@ begin_port_cleanup(Port *pp, ErtsPortTask **execqp, int *processing_busy_q_p)
 	    DTRACE_CHARBUF(pid_str, 16);
 	    ErtsProcList* plp2 = plp;
 
-	    erts_snprintf(port_str, sizeof(port_str), "%T", pp->common.id);
+	    erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", pp->common.id);
 	    while (plp2 != NULL) {
-		erts_snprintf(pid_str, sizeof(pid_str), "%T", plp2->pid);
+		erts_snprintf(pid_str, DTRACE_CHARBUF_SIZEOF(pid_str), "%T", plp2->pid);
 		DTRACE2(process_port_unblocked, pid_str, port_str);
 	    }
 	}

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -11313,7 +11313,7 @@ send_exit_signal(Process *c_p,		/* current process if and only
 
         dtrace_pid_str(from, sender_str);
         dtrace_proc_str(rp, receiver_str);
-        erts_snprintf(reason_buf, sizeof(reason_buf) - 1, "%T", reason);
+        erts_snprintf(reason_buf, DTRACE_CHARBUF_SIZEOF(reason_buf) - 1, "%T", reason);
         DTRACE3(process_exit_signal, sender_str, receiver_str, reason_buf);
     }
 #endif

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -2473,7 +2473,7 @@ set_port_connected(int bang_op,
 	    DTRACE_CHARBUF(newprocess_str, DTRACE_TERM_BUF_SIZE);
 
 	    dtrace_pid_str(connect, process_str);
-	    erts_snprintf(port_str, sizeof(port_str), "%T", prt->common.id);
+	    erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", prt->common.id);
 	    dtrace_proc_str(rp, newprocess_str);
 	    DTRACE4(port_connect, process_str, port_str, prt->name, newprocess_str);
 	}
@@ -3591,9 +3591,9 @@ erts_deliver_port_exit(Port *p, Eterm from, Eterm reason, int send_closed)
        DTRACE_CHARBUF(port_str, DTRACE_TERM_BUF_SIZE);
        DTRACE_CHARBUF(rreason_str, 64);
 
-       erts_snprintf(from_str, sizeof(from_str), "%T", from);
+       erts_snprintf(from_str, DTRACE_CHARBUF_SIZEOF(from_str), "%T", from);
        dtrace_port_str(p, port_str);
-       erts_snprintf(rreason_str, sizeof(rreason_str), "%T", rreason);
+       erts_snprintf(rreason_str, DTRACE_CHARBUF_SIZEOF(rreason_str), "%T", rreason);
        DTRACE4(port_exit, from_str, port_str, p->name, rreason_str);
    }
 #endif
@@ -4660,7 +4660,7 @@ set_busy_port(ErlDrvPort dprt, int on)
 
 #ifdef USE_VM_PROBES
         if (DTRACE_ENABLED(port_busy)) {
-            erts_snprintf(port_str, sizeof(port_str),
+            erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str),
                           "%T", prt->common.id);
             DTRACE1(port_busy, port_str);
         }
@@ -4673,7 +4673,7 @@ set_busy_port(ErlDrvPort dprt, int on)
 
 #ifdef USE_VM_PROBES
         if (DTRACE_ENABLED(port_not_busy)) {
-            erts_snprintf(port_str, sizeof(port_str),
+            erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str),
                           "%T", prt->common.id);
             DTRACE1(port_not_busy, port_str);
         }
@@ -4725,9 +4725,9 @@ erts_port_resume_procs(Port *prt)
 	    DTRACE_CHARBUF(pid_str, 16);
 	    ErtsProcList* plp2 = plp;
 
-	    erts_snprintf(port_str, sizeof(port_str), "%T", prt->common.id);
+	    erts_snprintf(port_str, DTRACE_CHARBUF_SIZEOF(port_str), "%T", prt->common.id);
 	    while (plp2 != NULL) {
-		erts_snprintf(pid_str, sizeof(pid_str), "%T", plp2->pid);
+		erts_snprintf(pid_str, DTRACE_CHARBUF_SIZEOF(pid_str), "%T", plp2->pid);
 		DTRACE2(process_port_unblocked, pid_str, port_str);
 	    }
 	}

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -527,7 +527,7 @@ ERTS_CIO_EXPORT(driver_select)(ErlDrvPort ix,
 	    /* fast track to stop_select callback */
 	    stop_select_fn = prt->drv_ptr->stop_select;
 #ifdef USE_VM_PROBES
-	    strncpy(name, prt->drv_ptr->name, sizeof(name)-1);
+	    strncpy(name, prt->drv_ptr->name, DTRACE_CHARBUF_SIZEOF(name)-1);
 	    name[sizeof(name)-1] = '\0';
 #endif
 	    ret = 0;


### PR DESCRIPTION
Thanks to Michał Ptaszek for bringing this embarrassing formatting error to
my attention.  Many DTrace/SystemTap trace strings are incorrectly
truncated at 4/8 bytes, depending on the CPU word size.  This patch expands
the work from commit d032e097 by zheng siyao.

Michał's report to the erlang-bugs list can be found at:
http://erlang.org/pipermail/erlang-bugs/2014-March/004250.html

cc: @paulgray @vinoski
