### PR TITLE
debugger: logical error in int:i2/3

### DIFF
--- a/lib/debugger/src/int.erl
+++ b/lib/debugger/src/int.erl
@@ -105,11 +105,11 @@ ni(AbsMods, _Options) -> i2(AbsMods, distributed, ok).
 i2([AbsMod|AbsMods], Dist, Acc)
   when is_atom(AbsMod); is_list(AbsMod); is_tuple(AbsMod) -> 
     Res = int_mod(AbsMod, Dist),
-    case Acc of
+    case Res of
 	error ->
-	    i2(AbsMods, Dist, Acc);
+	    i2(AbsMods, Dist, Res);
 	_ ->
-	    i2(AbsMods, Dist, Res)
+	    i2(AbsMods, Dist, Acc)
     end;
 i2([], _Dist, Acc) ->
     Acc;

--- a/lib/debugger/test/int_SUITE.erl
+++ b/lib/debugger/test/int_SUITE.erl
@@ -27,7 +27,7 @@
 -export([init_per_testcase/2, end_per_testcase/2]).
 
 %% Test cases
--export([interpret/1, guards/1, interpretable/1]).
+-export([interpret/1, interpret1/1, guards/1, interpretable/1]).
 -export([ append_1/1, append_2/1, member/1, reverse/1]).
 
 %% Default timetrap timeout (set in init_per_testcase)
@@ -63,7 +63,7 @@ end_per_testcase(_Case, Config) ->
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
-    [interpret, guards, {group, list_suite}, interpretable].
+    [interpret, interpret1, guards, {group, list_suite}, interpretable].
 
 groups() -> 
     [{list_suite, [], [{group, append}, reverse, member]},
@@ -106,6 +106,19 @@ interpret(Config) when is_list(Config) ->
     ?line [ordsets1] = int:interpreted(),
     ?line ok = int:n("ordsets1"),
     ?line [] = int:interpreted(),
+
+    ok.
+
+interpret1(suite) ->
+    [];
+interpret1(doc) ->
+    ["Interpreting multiple modules"];
+interpret1(Config) when is_list(Config) ->
+    ?line int:n(int:interpreted()),
+
+    %% Interpret some existing and non-existing modules
+    ?line DataDir = ?config(data_dir, Config),
+    ?line error = int:i([filename:join([DataDir,lists1]), non_existent_module, filename:join([DataDir,ordsets1])]),
 
     ok.
 


### PR DESCRIPTION
When called with a list of modules and there is an error with any of
them, the final result should be 'error'. The wrong value was folded
through Acc.
