### PR TITLE
Add AES-CBF8 cypher to crypto module

### DIFF
--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -128,7 +128,7 @@
 
      <p><code>stream_cipher() = rc4 | aes_ctr </code></p>
 
-     <p><code>block_cipher() =  aes_cbc128 | aes_cfb128 | aes_ige256 | blowfish_cbc |
+     <p><code>block_cipher() =  aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_ige256 | blowfish_cbc |
      blowfish_cfb64 | des_cbc | des_cfb | des3_cbc | des3_cbf
      | des_ede3 | rc2_cbc </code></p>
 
@@ -152,7 +152,7 @@
      Note that both md4 and md5 are recommended only for compatibility with existing applications.
      </p>
      <p><code> cipher_algorithms() = des_cbc | des_cfb |  des3_cbc | des3_cbf | des_ede3 |
-     blowfish_cbc | blowfish_cfb64 | aes_cbc128 | aes_cfb128| aes_cbc256 | aes_ige256 | rc2_cbc | aes_ctr| rc4  </code> </p>
+     blowfish_cbc | blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128| aes_cbc256 | aes_ige256 | rc2_cbc | aes_ctr| rc4  </code> </p>
      <p><code> public_key_algorithms() =   rsa |dss | ecdsa | dh | ecdh | ec_gf2m</code>
      Note that ec_gf2m is not strictly a public key algorithm, but a restriction on what curves are supported
      with ecdsa and ecdh.

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -210,7 +210,7 @@ supports()->
 
     [{hashs, Hashs},
      {ciphers, [des_cbc, des_cfb, des3_cbc, des_ede3, blowfish_cbc,
-		blowfish_cfb64, blowfish_ofb64, blowfish_ecb, aes_cbc128, aes_cfb128,
+		blowfish_cfb64, blowfish_ofb64, blowfish_ecb, aes_cbc128, aes_cfb8, aes_cfb128,
 		aes_cbc256, rc2_cbc, aes_ctr, rc4] ++ Ciphers},
      {public_keys, [rsa, dss, dh, srp] ++ PubKeys}
     ].
@@ -281,7 +281,7 @@ hmac_final_n(_Context, _HashLen) -> ? nif_stub.
 %% Ecrypt/decrypt %%%
 
 -spec block_encrypt(des_cbc | des_cfb | des3_cbc | des3_cbf | des_ede3 | blowfish_cbc |
-		    blowfish_cfb64 | aes_cbc128 | aes_cfb128 | aes_cbc256 | rc2_cbc,
+		    blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_cbc256 | rc2_cbc,
 		    Key::iodata(), Ivec::binary(), Data::iodata()) -> binary().
 
 block_encrypt(des_cbc, Key, Ivec, Data) ->
@@ -306,6 +306,8 @@ block_encrypt(aes_cbc256, Key, Ivec, Data) ->
     aes_cbc_256_encrypt(Key, Ivec, Data);
 block_encrypt(aes_ige256, Key, Ivec, Data) ->
     aes_ige_256_encrypt(Key, Ivec, Data);
+block_encrypt(aes_cfb8, Key, Ivec, Data) ->
+    aes_cfb_8_encrypt(Key, Ivec, Data);
 block_encrypt(aes_cfb128, Key, Ivec, Data) ->
     aes_cfb_128_encrypt(Key, Ivec, Data);
 block_encrypt(rc2_cbc, Key, Ivec, Data) ->
@@ -313,7 +315,7 @@ block_encrypt(rc2_cbc, Key, Ivec, Data) ->
 
 -spec block_decrypt(des_cbc | des_cfb | des3_cbc | des3_cbf | des_ede3 | blowfish_cbc |
 	      blowfish_cfb64 | blowfish_ofb64  | aes_cbc128 | aes_cbc256 | aes_ige256 |
-          aes_cfb128 | rc2_cbc,
+          aes_cfb8 | aes_cfb128 | rc2_cbc,
 	      Key::iodata(), Ivec::binary(), Data::iodata()) -> binary().
 
 block_decrypt(des_cbc, Key, Ivec, Data) ->
@@ -338,6 +340,8 @@ block_decrypt(aes_cbc256, Key, Ivec, Data) ->
     aes_cbc_256_decrypt(Key, Ivec, Data);
 block_decrypt(aes_ige256, Key, Ivec, Data) ->
     aes_ige_256_decrypt(Key, Ivec, Data);
+block_decrypt(aes_cfb8, Key, Ivec, Data) ->
+    aes_cfb_8_decrypt(Key, Ivec, Data);
 block_decrypt(aes_cfb128, Key, Ivec, Data) ->
     aes_cfb_128_decrypt(Key, Ivec, Data);
 block_decrypt(rc2_cbc, Key, Ivec, Data) ->
@@ -1159,7 +1163,21 @@ blowfish_ofb64_encrypt(_Key, _IVec, _Data) -> ?nif_stub.
 
 
 %%
-%% AES in cipher feedback mode (CFB)
+%% AES in cipher feedback mode (CFB) - 8 bit shift
+%%
+-spec aes_cfb_8_encrypt(iodata(), binary(), iodata()) -> binary().
+-spec aes_cfb_8_decrypt(iodata(), binary(), iodata()) -> binary().
+
+aes_cfb_8_encrypt(Key, IVec, Data) ->
+    aes_cfb_8_crypt(Key, IVec, Data, true).
+
+aes_cfb_8_decrypt(Key, IVec, Data) ->
+    aes_cfb_8_crypt(Key, IVec, Data, false).
+
+aes_cfb_8_crypt(_Key, _IVec, _Data, _IsEncrypt) -> ?nif_stub.     
+
+%%
+%% AES in cipher feedback mode (CFB) - 128 bit shift
 %%
 -spec aes_cfb_128_encrypt(iodata(), binary(), iodata()) -> binary().
 -spec aes_cfb_128_decrypt(iodata(), binary(), iodata()) -> binary().

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -55,6 +55,7 @@ all() ->
      {group, blowfish_cfb64},
      {group, blowfish_ofb64},
      {group, aes_cbc128},
+     {group, aes_cfb8},
      {group, aes_cfb128},
      {group, aes_cbc256},
      {group, aes_ige256},
@@ -90,6 +91,7 @@ groups() ->
      {des3_cbf,[], [block]},
      {rc2_cbc,[], [block]},
      {aes_cbc128,[], [block]},
+     {aes_cfb8,[], [block]},
      {aes_cfb128,[], [block]},
      {aes_cbc256,[], [block]},
      {aes_ige256,[], [block]},
@@ -723,6 +725,9 @@ group_config(aes_cbc256, Config) ->
 group_config(aes_ige256, Config) ->
     Block = aes_ige256(),
     [{block, Block} | Config];
+group_config(aes_cfb8, Config) ->
+    Block = aes_cfb8(),
+    [{block, Block} | Config];
 group_config(aes_cfb128, Config) ->
     Block = aes_cfb128(),
     [{block, Block} | Config];
@@ -1161,6 +1166,25 @@ aes_ige256() ->
       {aes_ige256,
        hexstr2bin("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
        hexstr2bin("15D5A583D2D668E518E683D9BDF1B6D0E0C3B1E5D5C1D51E964822E1ADE88DFA"),
+       hexstr2bin("f69f2445df4f9b17ad2b417be66c3710")}
+     ].
+
+aes_cfb8() -> 
+    [{aes_cfb8,
+      hexstr2bin("2b7e151628aed2a6abf7158809cf4f3c"), 
+      hexstr2bin("000102030405060708090a0b0c0d0e0f"),
+      hexstr2bin("6bc1bee22e409f96e93d7e117393172a")},
+      {aes_cfb8,
+       hexstr2bin("2b7e151628aed2a6abf7158809cf4f3c"), 
+       hexstr2bin("3B3FD92EB72DAD20333449F8E83CFB4A"),
+       hexstr2bin("ae2d8a571e03ac9c9eb76fac45af8e51")},
+      {aes_cfb8,
+       hexstr2bin("2b7e151628aed2a6abf7158809cf4f3c"), 
+       hexstr2bin("C8A64537A0B3A93FCDE3CDAD9F1CE58B"),
+       hexstr2bin("30c81c46a35ce411e5fbc1191a0a52ef")},
+      {aes_cfb8,
+       hexstr2bin("2b7e151628aed2a6abf7158809cf4f3c"), 
+       hexstr2bin("26751F67A3CBB140B1808CF187A4F4DF"),
        hexstr2bin("f69f2445df4f9b17ad2b417be66c3710")}
      ].
 


### PR DESCRIPTION
This adds the aes_cfb8 cypher type (and associated tests and
documentation) to the crypto module.
