### PR TITLE
Clean up CA cert cache for non-file certs

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -1757,12 +1757,12 @@ handle_unrecv_data(StateName, #state{socket = Socket, transport_cb = Transport,
 	    Connection:handle_close_alert(Data, StateName, State)
     end.
 
-handle_trusted_certs_db(#state{ssl_options = #ssl_options{cacertfile = <<>>}}) ->
+handle_trusted_certs_db(#state{ssl_options = #ssl_options{cacertfile = <<>>, cacerts = []}}) ->
     %% No trusted certs specified
     ok;
 handle_trusted_certs_db(#state{cert_db_ref = Ref,
 			       cert_db = CertDb,
-			       ssl_options = #ssl_options{cacertfile = undefined}}) ->
+			       ssl_options = #ssl_options{cacertfile = <<>>}}) ->
     %% Certs provided as DER directly can not be shared
     %% with other connections and it is safe to delete them when the connection ends.
     ssl_pkix_db:remove_trusted_certs(Ref, CertDb);


### PR DESCRIPTION
When CA certificates are provided as binary blobs, rather than by
filename (ie, #ssl_options.cacerts is set, but #ssl_options.cacertfile
is not) the cleanup never occurs due to an incorrect pattern match in
tls_connection:handle_trusted_certs_db/1. This causes the table to grow
unchecked because each connection adds a new entry.

This change fixes the cleanup and adds a unit test.
