### PR TITLE
fix arity of crypto:hash_update/2 in deprecation warnings

### DIFF
--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -83,11 +83,11 @@ obsolete_1(crypto, sha_init, 0) ->
     {deprecated, {crypto, hash_init, 1}};
 
 obsolete_1(crypto, md4_update, 2) ->
-    {deprecated, {crypto, hash_update, 3}};
+    {deprecated, {crypto, hash_update, 2}};
 obsolete_1(crypto, md5_update, 2) ->
-    {deprecated, {crypto, hash_update, 3}};
+    {deprecated, {crypto, hash_update, 2}};
 obsolete_1(crypto, sha_update, 2) ->
-    {deprecated, {crypto, hash_update, 3}};
+    {deprecated, {crypto, hash_update, 2}};
 
 obsolete_1(crypto, md4_final, 1) ->
     {deprecated, {crypto, hash_final, 2}};


### PR DESCRIPTION
When compiling code using deprecated crypto functions that should be
replaced with crypto:hash_update/2, the deprecation warnings were saying
"use crypto:hash_update/3", with the wrong arity of 3, instead of "use
crypto:hash_update/2".

The problem was reported in this email message to erlang-bugs:

http://erlang.org/pipermail/erlang-bugs/2014-March/004281.html
