### PR TITLE
Correct the name of a compiler option and fix the corresponding warnings

### DIFF
--- a/lib/dialyzer/src/Makefile
+++ b/lib/dialyzer/src/Makefile
@@ -88,7 +88,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 ifeq ($(NATIVE_LIBS_ENABLED),yes)
 ERL_COMPILE_FLAGS += +native
 endif
-ERL_COMPILE_FLAGS += +warn_exported_vars +warn_unused_import +warn_untyped_record +warn_missing_spec +warnings_as_errors
+ERL_COMPILE_FLAGS += +warn_export_vars +warn_unused_import +warn_untyped_record +warn_missing_spec +warnings_as_errors
 
 # ----------------------------------------------------
 # Targets

--- a/lib/dialyzer/src/dialyzer_gui_wx.erl
+++ b/lib/dialyzer/src/dialyzer_gui_wx.erl
@@ -699,8 +699,7 @@ handle_add_files(#gui_state{chosen_box = ChosenBox, file_box = FileBox,
   end.
 
 handle_add_dir(#gui_state{chosen_box = ChosenBox, dir_entry = DirBox,
-			  files_to_analyze = FileList,
-			  mode = Mode} = State) ->
+			  files_to_analyze = FileList, mode = Mode} = State) ->
   case wxDirPickerCtrl:getPath(DirBox) of
     "" ->
       State;
@@ -714,8 +713,8 @@ handle_add_dir(#gui_state{chosen_box = ChosenBox, dir_entry = DirBox,
       State#gui_state{files_to_analyze = add_files(filter_mods(NewDir1,Ext), FileList, ChosenBox, Ext)}
   end.
 	    
-handle_add_rec(#gui_state{chosen_box = ChosenBox, dir_entry = DirBox, files_to_analyze = FileList,
-			     mode = Mode} = State) ->
+handle_add_rec(#gui_state{chosen_box = ChosenBox, dir_entry = DirBox,
+			  files_to_analyze = FileList, mode = Mode} = State) ->
   case wxDirPickerCtrl:getPath(DirBox) of
     "" ->
       State;
@@ -723,11 +722,11 @@ handle_add_rec(#gui_state{chosen_box = ChosenBox, dir_entry = DirBox, files_to_a
       NewDir = ordsets:new(),
       NewDir1 = ordsets:add_element(Dir,NewDir),
       TargetDirs = ordsets:union(NewDir1, all_subdirs(NewDir1)),
-      case wxRadioBox:getSelection(Mode) of
-	0 -> Ext = ".beam";
-	1-> Ext = ".erl"
-      end,
-      State#gui_state{files_to_analyze = add_files(filter_mods(TargetDirs,Ext), FileList, ChosenBox, Ext)}
+      Ext = case wxRadioBox:getSelection(Mode) of
+	      0 -> ".beam";
+	      1 -> ".erl"
+	    end,
+      State#gui_state{files_to_analyze = add_files(filter_mods(TargetDirs, Ext), FileList, ChosenBox, Ext)}
   end.
 
 handle_file_delete(#gui_state{chosen_box = ChosenBox,
@@ -886,13 +885,10 @@ config_gui_start(State) ->
   wxRadioBox:disable(State#gui_state.mode).
 
 save_file(#gui_state{frame = Frame, warnings_box = WBox, log = Log} = State, Type) ->
-  case Type of
-    warnings ->
-      Message = "Save Warnings",
-      Box = WBox;
-    log -> Message = "Save Log",
-	   Box = Log
-  end,
+  {Message, Box} = case Type of
+		     warnings -> {"Save Warnings", WBox};
+		     log -> {"Save Log", Log}
+		   end,
   case wxTextCtrl:getValue(Box) of
     "" -> error_sms(State,"There is nothing to save...\n");
     _ ->
@@ -936,8 +932,7 @@ include_dialog(#gui_state{gui = Wx, frame = Frame, options = Options}) ->
   wxButton:connect(DeleteAllButton, command_button_clicked),
   wxButton:connect(Ok, command_button_clicked),
   wxButton:connect(Cancel, command_button_clicked),
-  Dirs = [io_lib:format("~s", [X]) 
-	  || X <- Options#options.include_dirs],
+  Dirs = [io_lib:format("~s", [X]) || X <- Options#options.include_dirs],
   wxListBox:set(Box, Dirs),
   Layout = wxBoxSizer:new(?wxVERTICAL),
   Buttons = wxBoxSizer:new(?wxHORIZONTAL),

--- a/lib/dialyzer/src/dialyzer_races.erl
+++ b/lib/dialyzer/src/dialyzer_races.erl
@@ -990,8 +990,7 @@ fixup_race_forward_helper(CurrFun, CurrFunLabel, Fun, FunLabel,
            NewRaceVarMap, Args, NewFunArgs, NewFunTypes, NestingLevel};
         {CurrFun, Fun} ->
           NewCallsToAnalyze = lists:delete(Head, CallsToAnalyze),
-          NewRaceVarMap =
-            race_var_map(Args, NewFunArgs, RaceVarMap, bind),
+          NewRaceVarMap = race_var_map(Args, NewFunArgs, RaceVarMap, bind),
           RetC =
             case Fun of
               InitFun ->
@@ -1018,8 +1017,7 @@ fixup_race_forward_helper(CurrFun, CurrFunLabel, Fun, FunLabel,
                            label = FunLabel, var_map = NewRaceVarMap,
                            def_vars = Args, call_vars = NewFunArgs,
                            arg_types = NewFunTypes}|
-                 lists:reverse(StateRaceList)] ++
-                  RetC;
+                 lists:reverse(StateRaceList)] ++ RetC;
               _ ->
                 [#curr_fun{status = in, mfa = Fun,
                            label = FunLabel, var_map = NewRaceVarMap,
@@ -1054,13 +1052,9 @@ fixup_race_backward(CurrFun, Calls, CallsToAnalyze, Parents, Height) ->
             false -> [CurrFun|Parents]
           end;
         [Head|Tail] ->
-          MorePaths =
-            case Head of
-              {Parent, CurrFun} -> true;
-              {Parent, _TupleB} -> false
-            end,
-          case MorePaths of
-            true ->
+	  {Parent, TupleB} = Head,
+	  case TupleB =:= CurrFun of
+            true ->  % more paths are needed
               NewCallsToAnalyze = lists:delete(Head, CallsToAnalyze),
               NewParents =
                 fixup_race_backward(Parent, NewCallsToAnalyze,

--- a/lib/typer/src/Makefile
+++ b/lib/typer/src/Makefile
@@ -63,7 +63,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += +warn_exported_vars +warn_untyped_record +warn_missing_spec
+ERL_COMPILE_FLAGS += +warn_export_vars +warn_untyped_record +warn_missing_spec
 
 # ----------------------------------------------------
 # Targets


### PR DESCRIPTION
The option `warn_export_vars` was erroneously written as `warn_exported_vars`
in Makefiles of dialyzer and typer. As a result, `erlc` was silent about such
warnings (why on earth doesn't it complain on unrecognized options??) which
were corrected as part of this change.
