### PR TITLE
Eunit description support for Unicode

### DIFF
--- a/lib/eunit/src/eunit_data.erl
+++ b/lib/eunit/src/eunit_data.erl
@@ -391,7 +391,7 @@ parse({with, X, As}=T) when is_list(As) ->
 parse({S, T1} = T) when is_list(S) ->
     case eunit_lib:is_string(S) of
 	true ->
-	    group(#group{tests = T1, desc = list_to_binary(S)});
+	    group(#group{tests = T1, desc = unicode:characters_to_binary(S)});
 	false ->
 	    bad_test(T)
     end;


### PR DESCRIPTION
If list_to_binary "description" of eunit is unicode raise the exception.

I have to use the unicode:characters_to_binary/1 instead of list_to_binary/1.

sample code

``` erlang
spam_test_() ->
    [
        %% Spam in Japanese
        {"スパム",
            ?_assert(...)}
    ]    
```
