### PR TITLE
Create a new "file" token attribute in erl_scan

### DIFF
--- a/lib/stdlib/doc/src/erl_scan.xml
+++ b/lib/stdlib/doc/src/erl_scan.xml
@@ -284,6 +284,9 @@
             column()</seealso>}</c></tag>
           <item><p>The column where the token begins.</p>
           </item>
+          <tag><c>{file, string()}</c></tag>
+          <item><p>The file in which the token is.</p>
+          </item>
           <tag><c>{length, integer() > 0}</c></tag>
           <item><p>The length of the token's text.</p>
           </item>
@@ -351,6 +354,9 @@
             column()</seealso>}</c></tag>
           <item><p>The column where the token begins.</p>
           </item>
+          <tag><c>{file, string()}</c></tag>
+          <item><p>The file in which the token is.</p>
+          </item>
           <tag><c>{length, integer() > 0}</c></tag>
           <item><p>The length of the token's text.</p>
           </item>
@@ -373,11 +379,14 @@
       <name name="set_attribute" arity="3"/>
       <fsummary>Set a token attribute value</fsummary>
       <desc>
-        <p>Sets the value of the <c>line</c> attribute of the token
-          attributes <c><anno>Attributes</anno></c>.</p>
+        <p>Sets the value of the <c>line</c> or <c>file</c> attribute of the
+          token attributes <c><anno>Attributes</anno></c>.</p>
         <p>The <c><anno>SetAttributeFun</anno></c> is called with the value of
-          the <c>line</c> attribute, and is to return the new value of
-          the <c>line</c> attribute.</p>
+          the <c>line</c> or <c>file</c> attribute, and is to return its new
+          value.</p>
+        <p>When setting the value of the <c>file</c> attribute,
+          <c><anno>SetAttributeFun</anno></c> may be given or return
+          <c>undefined</c> as an absence of value.</p>
       </desc>
     </func>
     <func>

--- a/lib/stdlib/src/erl_scan.erl
+++ b/lib/stdlib/src/erl_scan.erl
@@ -88,7 +88,8 @@
 -type symbol() :: atom() | float() | integer() | string().
 -type info_line() :: integer() | term().
 -type attributes_data()
-       :: [{'column', column()} | {'line', info_line()} | {'text', string()}]
+       :: [{'column', column()} | {'line', info_line()} | {'text', string()}
+              | {'file', string()}]
         |  {line(), column()}.
 %% The fact that {line(),column()} is a possible attributes() type
 %% is hidden.
@@ -198,12 +199,13 @@ continuation_location({erl_scan_continuation,_,Col,_,Line,_,_,_}) ->
     {Line,Col}.
 
 -type attribute_item() :: 'column' | 'length' | 'line'
-                        | 'location' | 'text'.
+                        | 'location' | 'text' | 'file'.
 -type info_location() :: location() | term().
 -type attribute_info() :: {'column', column()}| {'length', pos_integer()}
                         | {'line', info_line()}
                         | {'location', info_location()}
-                        | {'text', string()}.
+                        | {'text', string()}
+                        | {'file', string()}.
 -type token_item() :: 'category' | 'symbol' | attribute_item().
 -type token_info() :: {'category', category()} | {'symbol', symbol()}
                     | attribute_info().
@@ -212,7 +214,7 @@ continuation_location({erl_scan_continuation,_,Col,_,Line,_,_,_}) ->
       Token :: token(),
       TokenInfo :: [TokenInfoTuple :: token_info()].
 token_info(Token) ->
-    Items = [category,column,length,line,symbol,text], % undefined order
+    Items = [category,column,length,line,symbol,text,file], % undefined order
     token_info(Token, Items).
 
 -spec token_info(Token, TokenItem) -> TokenInfoTuple | 'undefined' when
@@ -249,7 +251,7 @@ token_info({_Category,Attrs,_Symbol}, Item) ->
       Attributes :: attributes(),
       AttributesInfo :: [AttributeInfoTuple :: attribute_info()].
 attributes_info(Attributes) ->
-    Items = [column,length,line,text], % undefined order
+    Items = [column,length,line,text,file], % undefined order
     attributes_info(Attributes, Items).
 
 -spec attributes_info
@@ -314,13 +316,19 @@ attributes_info(Line, text) when ?ALINE(Line) ->
     undefined;
 attributes_info(Attrs, text=Item) ->
     attr_info(Attrs, Item);
+attributes_info({Line,Column}, file) when ?ALINE(Line), ?COLUMN(Column) ->
+    undefined;
+attributes_info(Line, file) when ?ALINE(Line) ->
+    undefined;
+attributes_info(Attrs, file=Item) ->
+    attr_info(Attrs, Item);
 attributes_info(T1, T2) ->
     erlang:error(badarg, [T1,T2]).
 
 -spec set_attribute(AttributeItem, Attributes, SetAttributeFun) -> Attributes when
-      AttributeItem :: 'line',
+      AttributeItem :: 'line' | 'file',
       Attributes :: attributes(),
-      SetAttributeFun :: fun((info_line()) -> info_line()).
+      SetAttributeFun :: fun((term()) -> term()).
 set_attribute(Tag, Attributes, Fun) when ?SETATTRFUN(Fun) ->
     set_attr(Tag, Attributes, Fun).
 
@@ -400,7 +408,10 @@ attr_info(Attrs, Item) ->
             erlang:error(badarg, [Attrs, Item])
     end.
 
--spec set_attr('line', attributes(), fun((line()) -> line())) -> attributes().
+-spec set_attr('line', attributes(), fun((line()) -> line())) -> attributes();
+              ('file', attributes(),
+               fun(('undefined' | string()) -> 'undefined' | string()))
+                  -> attributes().
 
 set_attr(line, Line, Fun) when ?ALINE(Line) ->
     Ln = Fun(Line),
@@ -425,6 +436,39 @@ set_attr(line=Tag, Attrs, Fun) when is_list(Attrs) ->
             Ln;
         As ->
             As
+    end;
+set_attr(file, Line, Fun) when ?ALINE(Line) ->
+    case Fun(undefined) of
+        undefined ->
+            Line;
+        File ->
+            [{file,File},{line,Line}]
+    end;
+set_attr(file, {Line,Column}=Loc, Fun) when ?ALINE(Line), ?COLUMN(Column) ->
+    case Fun(undefined) of
+        undefined ->
+            Loc;
+        File ->
+            [{file,File},{line,Line},{column,Column}]
+    end;
+set_attr(file=Tag, Attrs, Fun) when is_list(Attrs) ->
+    case lists:keyfind(Tag, 1, Attrs) of
+        {file, OldFile} ->
+            case Fun(OldFile) of
+                undefined ->
+                    lists:keydelete(Tag, 1, Attrs);
+                OldFile ->
+                    Attrs;
+                File ->
+                    lists:keyreplace(Tag, 1, Attrs, {Tag,File})
+            end;
+        false ->
+            case Fun(undefined) of
+                undefined ->
+                    Attrs;
+                File ->
+                    [{file,File}|Attrs]
+            end
     end;
 set_attr(T1, T2, T3) ->
     erlang:error(badarg, [T1,T2,T3]).

--- a/lib/stdlib/test/erl_scan_SUITE.erl
+++ b/lib/stdlib/test/erl_scan_SUITE.erl
@@ -743,6 +743,37 @@ set_attribute() ->
     %% OTP-9412
     ?line 8 = erl_scan:set_attribute(line, [{line,{nos,'X',8}}],
                                      fun({nos,_V,VL}) -> VL end),
+
+    % file
+    ?line 8 = erl_scan:set_attribute(file, 8,
+                                     fun (undefined) -> undefined end),
+    ?line {8,1} = erl_scan:set_attribute(file, {8,1},
+                                         fun (undefined) -> undefined end),
+    ?line [{line,8},{text,""}] =
+        erl_scan:set_attribute(file, [{line,8},{text,""}],
+                               fun (undefined) -> undefined end),
+    ?line [{line,8},{column,1},{text,""}] =
+        erl_scan:set_attribute(file, [{line,8},{column,1},{text,""}],
+                               fun (undefined) -> undefined end),
+    ?line [{file,"file.erl"},{line,8}] =
+        erl_scan:set_attribute(file, 8,
+                               fun (undefined) -> "file.erl" end),
+    ?line [{file,"file.erl"},{line,8},{column,1}] =
+        erl_scan:set_attribute(file, {8,1},
+                               fun (undefined) -> "file.erl" end),
+    ?line [{line,8}] =
+        erl_scan:set_attribute(file, [{file,"file.erl"},{line,8}],
+                               fun ("file.erl") -> undefined end),
+    ?line [{line,8},{column,1}] =
+        erl_scan:set_attribute(file, [{file,"file.erl"},{line,8},{column,1}],
+                               fun ("file.erl") -> undefined end),
+    ?line [{file,"file2.erl"},{line,8}] =
+        erl_scan:set_attribute(file, [{file,"file.erl"},{line,8}],
+                               fun ("file.erl") -> "file2.erl" end),
+    ?line [{file,"file2.erl"},{line,8},{column,1}] =
+        erl_scan:set_attribute(file, [{file,"file.erl"},{line,8},{column,1}],
+                               fun ("file.erl") -> "file2.erl" end),
+
     ok.
 
 column_errors() ->


### PR DESCRIPTION
Used to properly zip file and line information in erl_lint without breaking the attributes() type.

This is the first step needed for my Clang-like compile diagnostics. As the current behaviour is a little nonsensical with regard to erl_scan:attributes(), it would be cool if it could be merged without the rest in a timely fashion.