### PR TITLE
Fix locations of shadowing warnings in ms_transform

### DIFF
--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -725,10 +725,10 @@ transform_head([V],OuterBound) ->
     th(NewV,NewBind,OuterBound).
 
 
-toplevel_head_match({match,Line,{var,_,VName},Expr},B,OB) ->
+toplevel_head_match({match,_,{var,Line,VName},Expr},B,OB) ->
     warn_var_clash(Line,VName,OB),
     {Expr,new_bind({VName,'$_'},B)};
-toplevel_head_match({match,Line,Expr,{var,_,VName}},B,OB) ->
+toplevel_head_match({match,_,Expr,{var,Line,VName}},B,OB) ->
     warn_var_clash(Line,VName,OB),
     {Expr,new_bind({VName,'$_'},B)};
 toplevel_head_match(Other,B,_OB) ->

--- a/lib/stdlib/test/ms_transform_SUITE.erl
+++ b/lib/stdlib/test/ms_transform_SUITE.erl
@@ -91,21 +91,23 @@ warnings(Config) when is_list(Config) ->
 	    "            end)">>,
     ?line [{_,[{_,ms_transform,{?WARN_NUMBER_SHADOW,'A'}}]}] =
 	compile_ww(Prog),
-    Prog2 = <<"C=5, "
-	    "ets:fun2ms(fun({A,B} = C) "
-	    "            when is_integer(A) and (A+5 > B) -> "
-	    "              {A andalso B,C} "
-	    "            end)">>,
-    ?line [{_,[{_,ms_transform,{?WARN_NUMBER_SHADOW,'C'}}]}] =
+    Prog2 = <<"C = 5,
+               ets:fun2ms(fun ({A,B} =
+                                       C) when is_integer(A) and (A+5 > B) ->
+                                  {A andalso B,C}
+                          end)">>,
+    [{_,[{3,ms_transform,{?WARN_NUMBER_SHADOW,'C'}}]}] =
 	compile_ww(Prog2),
     Rec3 = <<"-record(a,{a,b,c,d=foppa}).">>,
-    Prog3 = <<"A=3,C=5, "
-	    "ets:fun2ms(fun(#a{a = A, b = B} = C) "
-	    "            when is_integer(A) and (A+5 > B) -> "
-	    "              {A andalso B,C} "
-	    "            end)">>,
-    ?line [{_,[{_,ms_transform,{?WARN_NUMBER_SHADOW,'A'}},
-	       {_,ms_transform,{?WARN_NUMBER_SHADOW,'C'}}]}] =
+    Prog3 = <<"A = 3,
+               C = 5,
+               ets:fun2ms(fun (C
+                                 = #a{a = A, b = B})
+                              when is_integer(A) and (A+5 > B) ->
+                                  {A andalso B,C}
+                          end)">>,
+    [{_,[{3,ms_transform,{?WARN_NUMBER_SHADOW,'C'}},
+         {4,ms_transform,{?WARN_NUMBER_SHADOW,'A'}}]}] =
 	compile_ww(Rec3,Prog3),
     Rec4 = <<"-record(a,{a,b,c,d=foppa}).">>,
     Prog4 = <<"A=3,C=5, "
@@ -867,6 +869,7 @@ compile_ww(Records,Expr) ->
     "-include_lib(\"stdlib/include/ms_transform.hrl\").\n",
     "-export([tmp/0]).\n",
     Records/binary,"\n",
+    "-file(?FILE, 0). ",
     "tmp() ->\n",
     Expr/binary,".\n">>,
     FN=temp_name(),


### PR DESCRIPTION
A shadowed variable in an ms_transform match expression emits a warning located at the match expression instead of the variable.
