### PR TITLE
ssl: TLSv1.2: proper default sign algo for RSA

### DIFF
--- a/lib/ssl/src/dtls_connection.erl
+++ b/lib/ssl/src/dtls_connection.erl
@@ -202,13 +202,13 @@ hello(Hello = #client_hello{client_version = ClientVersion,
 		     session_cache = Cache,
 		     session_cache_cb = CacheCb,
 		     ssl_options = SslOpts}) ->
-    HashSign = ssl_handshake:select_hashsign(HashSigns, Cert),
     case dtls_handshake:hello(Hello, SslOpts, {Port, Session0, Cache, CacheCb,
 					      ConnectionStates0, Cert}, Renegotiation) of
         {Version, {Type, Session},
 	 ConnectionStates,
 	 #hello_extensions{ec_point_formats = EcPointFormats,
 			   elliptic_curves = EllipticCurves} = ServerHelloExt} ->
+            HashSign = ssl_handshake:select_hashsign(HashSigns, Cert, Version),
             ssl_connection:hello({common_client_hello, Type, ServerHelloExt, HashSign},
 				 State#state{connection_states  = ConnectionStates,
 					     negotiated_version = Version,

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -441,8 +441,9 @@ certify(#server_key_exchange{} = Msg,
     Connection:handle_unexpected_message(Msg, certify_server_keyexchange, State);
 
 certify(#certificate_request{hashsign_algorithms = HashSigns},
-	#state{session = #session{own_certificate = Cert}} = State0, Connection) ->
-    HashSign = ssl_handshake:select_hashsign(HashSigns, Cert),
+	#state{session = #session{own_certificate = Cert},
+        negotiated_version = Version} = State0, Connection) ->
+    HashSign = ssl_handshake:select_hashsign(HashSigns, Cert, Version),
     {Record, State} = Connection:next_record(State0#state{client_certificate_requested = true}),
     Connection:next_state(certify, certify, Record,
 			  State#state{cert_hashsign_algorithm = HashSign});

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -208,11 +208,11 @@ hello(Hello = #client_hello{client_version = ClientVersion,
 		     session_cache = Cache,
 		     session_cache_cb = CacheCb,
 		     ssl_options = SslOpts}) ->
-    HashSign = ssl_handshake:select_hashsign(HashSigns, Cert),
     case tls_handshake:hello(Hello, SslOpts, {Port, Session0, Cache, CacheCb,
 					      ConnectionStates0, Cert}, Renegotiation) of
         {Version, {Type, Session},
 	 ConnectionStates, ServerHelloExt} ->
+            HashSign = ssl_handshake:select_hashsign(HashSigns, Cert, Version),
             ssl_connection:hello({common_client_hello, Type, ServerHelloExt, HashSign},
 				 State#state{connection_states  = ConnectionStates,
 					     negotiated_version = Version,

--- a/lib/ssl/test/ssl_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_handshake_SUITE.erl
@@ -101,5 +101,7 @@ encode_single_hello_sni_extension_correctly(_Config) ->
 select_proper_tls_1_2_rsa_default_hashsign(_Config) ->
     % RFC 5246 section 7.4.1.4.1 tells to use {sha1,rsa} as default signature_algorithm for RSA key exchanges
     {sha, rsa} = ssl_handshake:select_cert_hashsign(undefined, ?rsaEncryption, {3,3}),
-    {md5sha, rsa} = ssl_handshake:select_cert_hashsign(undefined, ?rsaEncryption, {undefined,undefined}).
+    % Older versions use MD5/SHA1 combination
+    {md5sha, rsa} = ssl_handshake:select_cert_hashsign(undefined, ?rsaEncryption, {3,2}),
+    {md5sha, rsa} = ssl_handshake:select_cert_hashsign(undefined, ?rsaEncryption, {3,0}).
 


### PR DESCRIPTION
Select {sha, rsa} signature algorithm when TLSv1.2 client
does not send signature_algorithms extension and negotiates
RSA key exchange.
See RFC 5246 section 7.4.1.4.1 for details.

Also this change fixes badarg when server tried to use
md5sha combination as public_key:sign algo.
