### PR TITLE
Add erlang:system_info(tolerant_timeofday)

### DIFF
--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -495,7 +495,7 @@
           <c><![CDATA[werl]]></c>, not <c><![CDATA[erl]]></c> (<c><![CDATA[oldshell]]></c>). Note also that
           <c><![CDATA[Ctrl-Break]]></c> is used instead of <c><![CDATA[Ctrl-C]]></c> on Windows.</p>
       </item>
-      <tag><c><![CDATA[+c]]></c></tag>
+      <tag><marker id="+c"><c><![CDATA[+c]]></c></marker></tag>
       <item>
         <p>Disable compensation for sudden changes of system time.</p>
         <p>Normally, <c><![CDATA[erlang:now/0]]></c> will not immediately reflect
@@ -510,6 +510,9 @@
           reflect the current system time. Note that timers are based
           on <c><![CDATA[erlang:now/0]]></c>. If the system time jumps, timers
           then time out at the wrong time.</p>
+        <p><em>NOTE</em>: You can check whether the adjustment is enabled or
+          disabled by calling
+	  <seealso marker="erlang#system_info_tolerant_timeofday">erlang:system_info(tolerant_timeofday)</seealso>.</p>
       </item>
       <tag><c><![CDATA[+d]]></c></tag>
       <item>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6293,6 +6293,13 @@ ok
               (<seealso marker="erts:erl_driver#driver_async">driver_async()</seealso>)
               as an integer.</p>
           </item>
+          <tag><marker id="system_info_tolerant_timeofday"><c>tolerant_timeofday</c></marker></tag>
+          <item>
+            <p>Returns whether compensation for sudden changes of system
+              time is <c>enabled</c> or <c>disabled</c>.</p>
+            <p>See also <seealso marker="erts:erl#+c">+c</seealso>
+              command line flag.</p>
+          </item>
           <tag><c>trace_control_word</c></tag>
           <item>
             <p>Returns the value of the node's trace control word.

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2691,6 +2691,11 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
     else if (ERTS_IS_ATOM_STR("ets_limit",BIF_ARG_1)) {
         BIF_RET(make_small(erts_db_get_max_tabs()));
     }
+    else if (ERTS_IS_ATOM_STR("tolerant_timeofday",BIF_ARG_1)) {
+	BIF_RET(erts_disable_tolerant_timeofday
+		? am_disabled
+		: am_enabled);
+    }
 
     BIF_ERROR(BIF_P, BADARG);
 }

--- a/erts/emulator/test/system_info_SUITE.erl
+++ b/erts/emulator/test/system_info_SUITE.erl
@@ -155,6 +155,7 @@ misc_smoke_tests(Config) when is_list(Config) ->
     ?line true = is_binary(erlang:system_info(loaded)),
     ?line true = is_binary(erlang:system_info(dist)),
     ?line ok = try erlang:system_info({cpu_topology,erts_get_cpu_topology_error_case}), fail catch error:badarg -> ok end,
+    true = lists:member(erlang:system_info(tolerant_timeofday), [enabled, disabled]),
     ?line ok.
     
 

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2287,6 +2287,7 @@ tuple_to_list(_Tuple) ->
          (system_architecture) -> string();
          (threads) -> boolean();
          (thread_pool_size) -> non_neg_integer();
+         (tolerant_timeofday) -> enabled | disabled;
          (trace_control_word) -> non_neg_integer();
          (update_cpu_info) -> changed | unchanged;
          (version) -> string();


### PR DESCRIPTION
Add erlang:system_info(tolerant_timeofday), an API to check whether
compensation for sudden changes of system time is enabled or not.

This feature is previously discussed in the erlang-questions ML:
http://erlang.org/pipermail/erlang-questions/2014-March/078389.html
