### PR TITLE
Support binary standard_input in ssh_io

### DIFF
--- a/lib/ssh/src/ssh_io.erl
+++ b/lib/ssh/src/ssh_io.erl
@@ -81,6 +81,8 @@ format(Fmt, Args) ->
 
 trim(Line) when is_list(Line) ->
     lists:reverse(trim1(lists:reverse(trim1(Line))));
+trim(Line) when is_binary(Line) ->
+    trim(unicode:characters_to_list(Line));
 trim(Other) -> Other.
 
 trim1([$\s|Cs]) -> trim(Cs);


### PR DESCRIPTION
This patch updates the `ssh_io` module to also be able to handle
the cases where the standard_io device is set to binary, which causes
binaries to be returned when reading from the device.
