### PR TITLE
Make Mnesia DCD dump behaviour available via configuration and API

### DIFF
--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -3017,6 +3017,12 @@ raise(Name, Amount) ->
           totally unpredictable.</p>
       </item>
       <item>
+        <p><c>-mnesia dump_disc_copies_at_startup true | false</c>.
+          If set to false, this disables the dumping of <c>disc_copies</c>
+          tables during startup while tables are being loaded. The default
+          is true.</p>
+      </item>
+      <item>
         <p><c>-mnesia dump_log_load_regulation true | false</c>.
           Controls if the log dumps should be performed as fast as
           possible or if the dumper should do its own load

--- a/lib/mnesia/src/mnesia_dumper.erl
+++ b/lib/mnesia/src/mnesia_dumper.erl
@@ -39,7 +39,8 @@
 	 raw_named_dump_table/2,
 	 start_regulator/0,
 	 opt_dump_log/1,
-	 update/3
+	 update/3,
+	 snapshot_dcd/1
 	]).
 
  %% Internal stuff
@@ -99,6 +100,19 @@ opt_dump_log(InitBy) ->
 		  Pid
 	  end,
     perform_dump(InitBy, Reg).
+
+snapshot_dcd(Tables) ->
+    lists:foreach(
+      fun(Tab) ->
+	      case mnesia_lib:storage_type_at_node(node(), Tab) of
+		  disc_copies ->
+		      mnesia_log:ets2dcd(Tab);
+		  _ ->
+		      %% Storage type was checked before queueing the op, though
+		      skip
+	      end
+      end, Tables),
+    dumped.
 
 %% Scan for decisions
 perform_dump(InitBy, Regulator) when InitBy == scan_decisions ->

--- a/lib/mnesia/src/mnesia_loader.erl
+++ b/lib/mnesia/src/mnesia_loader.erl
@@ -69,9 +69,10 @@ do_get_disc_copy2(Tab, Reason, Storage, Type) when Storage == disc_copies ->
 	    ignore;
 	_ ->
 	    mnesia_monitor:mktab(Tab, Args),
-	    Count = mnesia_log:dcd2ets(Tab, Repair),
-	    case ets:info(Tab, size) of
-		X when X < Count * 4 ->
+	    _Count = mnesia_log:dcd2ets(Tab, Repair),
+	    case mnesia_monitor:get_env(dump_disc_copies_at_startup)
+		andalso mnesia_dumper:needs_dump_ets(Tab) of
+		true ->
 		    ok = mnesia_log:ets2dcd(Tab);
 		_ ->
 		    ignore

--- a/lib/mnesia/src/mnesia_monitor.erl
+++ b/lib/mnesia/src/mnesia_monitor.erl
@@ -664,6 +664,7 @@ env() ->
      backup_module,
      debug,
      dir,
+     dump_disc_copies_at_startup,
      dump_log_load_regulation,
      dump_log_time_threshold,
      dump_log_update_in_place,
@@ -692,6 +693,8 @@ default_env(debug) ->
 default_env(dir) ->
     Name = lists:concat(["Mnesia.", node()]),
     filename:absname(Name);
+default_env(dump_disc_copies_at_startup) ->
+    true;
 default_env(dump_log_load_regulation) ->
     false;
 default_env(dump_log_time_threshold) ->
@@ -741,6 +744,7 @@ do_check_type(debug, trace) -> trace;
 do_check_type(debug, true) -> debug;
 do_check_type(debug, verbose) -> verbose;
 do_check_type(dir, V) -> filename:absname(V);
+do_check_type(dump_disc_copies_at_startup, B) -> bool(B);
 do_check_type(dump_log_load_regulation, B) -> bool(B);
 do_check_type(dump_log_time_threshold, I) when is_integer(I), I > 0 -> I;
 do_check_type(dump_log_update_in_place, B) -> bool(B);


### PR DESCRIPTION
Setting the new Mnesia parameter 'dump_disc_copies_at_startup' to
'false' will completely disable the DCD dumping while tables are being
loaded. If it is set to 'true' (the default), the same test will now
be performed as for normal dumps, i.e., using the 'dc_dump_limit'
parameter. Previously, the test performed at load time was different
from the one used at runtime, and caused a lot of unnecessary dumping
which slowed down the startup.

If a DCD dump is desired on-demand, use the function
mnesia_controller:snapshot_dcd(Tables). Tables must be a list of
tables that have a local disc_copy, otherwise an error will be
returned. Once the operation actually executes, any table that doesn't
have a local disc_copy is ignored.

Specifically, the dump_log worker record has been changed to allow an
arity-0 fun instead of the default log dump. This fun will be executed
as if it were a normal log dump, and must return 'dumped'. This could
also be used to e.g. insert a backup operation between log dumps.