### PR TITLE
Improve module_info, adding md5 and module and removing obsolete imports

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -278,7 +278,6 @@ atom http httph https http_response http_request http_header http_eoh http_error
 atom id
 atom if_clause
 atom ignore
-atom imports
 atom in
 atom in_exiting
 atom inactive
@@ -333,6 +332,7 @@ atom max
 atom maximum
 atom max_tables max_processes
 atom mbuf_size
+atom md5
 atom memory
 atom memory_internal
 atom memory_types

--- a/erts/emulator/beam/beam_load.h
+++ b/erts/emulator/beam/beam_load.h
@@ -91,7 +91,6 @@ extern Uint erts_total_code_size;
 #define MI_LITERALS_END		8
 #define MI_LITERALS_OFF_HEAP	9
 
-
 /*
  * Pointer to the on_load function (or NULL if none).
  */
@@ -103,6 +102,11 @@ extern Uint erts_total_code_size;
 #define MI_LINE_TABLE 11
 
 /*
+ * Pointer to the module MD5 sum (16 bytes)
+ */
+#define MI_MD5_PTR 12
+
+/*
  * Start of function pointer table.  This table contains pointers to
  * all functions in the module plus an additional pointer just beyond
  * the end of the last function.
@@ -111,7 +115,7 @@ extern Uint erts_total_code_size;
  * this table.
  */
 
-#define MI_FUNCTIONS         12
+#define MI_FUNCTIONS         13
 
 /*
  * Layout of the line table.

--- a/erts/emulator/test/module_info_SUITE.erl
+++ b/erts/emulator/test/module_info_SUITE.erl
@@ -24,7 +24,7 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
 	 init_per_group/2,end_per_group/2,
 	 init_per_testcase/2,end_per_testcase/2,
-	 exports/1,functions/1,native/1]).
+	 exports/1,functions/1,native/1,info/1]).
 
 %%-compile(native).
 
@@ -52,8 +52,8 @@ end_per_group(_GroupName, Config) ->
     Config.
 
 
-modules() -> 
-    [exports, functions, native].
+modules() ->
+    [exports, functions, native, info].
 
 init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
     Dog = ?t:timetrap(?t:minutes(3)),
@@ -121,6 +121,22 @@ native_proj({Name,Arity,Addr}) ->
 
 native_filter(Set) ->
     sofs:no_elements(Set) =/= 1.
+
+%% Test that the module info of this module is correct. Use
+%% erlang:get_module_info(?MODULE) to avoid compiler optimization tricks.
+info(Config) when is_list(Config) ->
+    Info = erlang:get_module_info(?MODULE),
+    All = all_exported(),
+    {ok,{?MODULE,MD5}} = beam_lib:md5(code:which(?MODULE)),
+    {module, ?MODULE} = lists:keyfind(module, 1, Info),
+    {md5, MD5} = lists:keyfind(md5, 1, Info),
+    {exports, Exports} = lists:keyfind(exports, 1, Info),
+    All = lists:sort(Exports),
+    {attributes, Attrs} = lists:keyfind(attributes, 1, Info),
+    {vsn,_} = lists:keyfind(vsn, 1, Attrs),
+    {compile, Compile} = lists:keyfind(compile, 1, Info),
+    {options,_} = lists:keyfind(options, 1, Compile),
+    ok.
 
 %% Helper functions (local).
 

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -1664,7 +1664,7 @@ element(_N, _Tuple) ->
 %% Not documented
 -spec erlang:get_module_info(Module, Item) -> ModuleInfo when
       Module :: atom(),
-      Item :: module | imports | exports | functions | attributes | compile | native_addresses,
+      Item :: module | md5 | exports | functions | attributes | compile | native_addresses,
       ModuleInfo :: atom() | [] | [{atom(), arity()}] | [{atom(), term()}] | [{atom(), arity(), integer()}].
 get_module_info(_Module, _Item) ->
     erlang:nif_error(undefined).

--- a/system/doc/reference_manual/modules.xml
+++ b/system/doc/reference_manual/modules.xml
@@ -229,13 +229,9 @@ behaviour_info(callbacks) -> Callbacks.</pre>
       <p>The <c>module_info/0</c> function in each module returns
       a list of <c>{Key,Value}</c> tuples with information about
       the module. Currently, the list contain tuples with the following
-      <c>Key</c>s: <c>attributes</c>, <c>compile</c>, 
-      <c>exports</c>, and <c>imports</c>. The order and number of tuples
+      <c>Key</c>s: <c>module</c>, <c>attributes</c>, <c>compile</c>,
+      <c>exports</c>, and <c>md5</c>. The order and number of tuples
       may change without prior notice.</p>
-
-      <warning><p>The <c>{imports,Value}</c> tuple may be removed in a future
-      release because <c>Value</c> is always an empty list.
-      Do not write code that depends on it being present.</p></warning>
     </section>
 
     <section>
@@ -246,6 +242,11 @@ behaviour_info(callbacks) -> Callbacks.</pre>
       <p>The following values are allowed for <c>Key</c>:</p>
 
       <taglist>
+        <tag><c>module</c></tag>
+	  <item>
+	  <p>Return an atom representing the module name.</p>
+	  </item>
+
         <tag><c>attributes</c></tag>
 	  <item>
 	  <p>Return a list of <c>{AttributeName,ValueList}</c> tuples,
@@ -267,10 +268,9 @@ behaviour_info(callbacks) -> Callbacks.</pre>
 	  <seealso marker="stdlib:beam_lib#strip/1">beam_lib(3)</seealso>.</p>
 	  </item>
 
-        <tag><c>imports</c></tag>
+        <tag><c>md5</c></tag>
 	  <item>
-	  <p>Always return an empty list. The <c>imports</c> key may not
-	  be supported in future release.</p>
+	  <p>Return a binary representing the MD5 checksum of the module.</p>
 	  </item>
 
         <tag><c>exports</c></tag>


### PR DESCRIPTION
The module_info/1/2 functions have been updated to contain entries for the
MD5 sum of the loaded module, and the module name (for completeness). The
obsolete 'imports' entry (previously always an empty list) has been dropped.
