### PR TITLE
inets: Fix streaming with single chunk body

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -1116,8 +1116,16 @@ handle_http_body(Body, #state{headers       = Headers,
 			   {new_body,        NewBody}]),
 		    NewHeaders = http_chunk:handle_headers(Headers, 
 							   ChunkedHeaders),
-		    handle_response(State#state{headers = NewHeaders, 
-						body    = NewBody})
+                    case Body of
+                        <<>> ->
+                           handle_response(State#state{headers = NewHeaders,
+                                                body    = NewBody});
+                        _ ->
+                           {NewBody2, NewRequest} =
+                                stream(NewBody, Request, Code),
+                           handle_response(State#state{headers = NewHeaders,
+                                       body    = NewBody2})
+                    end
 	    end;
         Encoding when is_list(Encoding) ->
 	    ?hcrt("handle_http_body - encoding", [{encoding, Encoding}]),

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -93,6 +93,7 @@ only_simulated() ->
      cookie_profile,
      trace,
      stream_once,
+     stream_single_chunk,
      no_content_204,
      tolerate_missing_CR,
      userinfo,
@@ -379,6 +380,13 @@ stream_once(Config) when is_list(Config) ->
 
     Request2  = {url(group_name(Config), "/once_chunked.html", Config), []},
     stream_test(Request2, {stream, {self, once}}).
+%%-------------------------------------------------------------------------
+stream_single_chunk() ->
+    [{doc, "Test the option stream for asynchrony requests"}].
+stream_single_chunk(Config) when is_list(Config) ->
+    Request  = {url(group_name(Config), "/single_chunk.html", Config), []},
+    stream_test(Request, {stream, self}).
+
 
 %%-------------------------------------------------------------------------
 redirect_multiple_choises() ->
@@ -1020,7 +1028,7 @@ stream_test(Request, To) ->
 		ct:fail(Msg)
 	end,
 
-    Body == binary_to_list(StreamedBody).
+    Body = binary_to_list(StreamedBody).
 
 url(http, End, Config) ->
     Port = ?config(port, Config),
@@ -1634,6 +1642,14 @@ handle_uri(_,"/once_chunked.html",_,_,Socket,_) ->
     send(Socket,
 	 http_chunk:encode("obar</BODY></HTML>")),
     http_chunk:encode_last();
+
+handle_uri(_,"/single_chunk.html",_,_,Socket,_) ->
+    Chunk =  "HTTP/1.1 200 ok\r\n" ++
+        "Transfer-Encoding:Chunked\r\n\r\n" ++
+        http_chunk:encode("<HTML><BODY>fo") ++
+        http_chunk:encode("obar</BODY></HTML>") ++
+        http_chunk:encode_last(),
+    send(Socket, Chunk);
 
 handle_uri(_,"/once.html",_,_,Socket,_) ->
     Head =  "HTTP/1.1 200 ok\r\n" ++


### PR DESCRIPTION
Receiving HTTP response with chunked transfer encoding in a single
TCP message should produce stream messages for response body when
streaming mode is used for httpc.
