### PR TITLE
Put compile options from code into parse_transfrom/2 options variable.

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -900,7 +900,7 @@ transform_module(#compile{options=Opt,code=Code0}=St0) ->
 	    %% Remove parse_transform attributes from the abstract code to
 	    %% prevent parse transforms to be run more than once.
 	    Code = clean_parse_transforms(Code0),
-	    St = St0#compile{code=Code},
+	    St = St0#compile{options=Opt ++ compile_options(Code),code=Code},
 	    foldl_transform(St, Ts)
     end.
 


### PR DESCRIPTION
Put compile options from code (i.e. -compile(myoption1)) into the options variable used as second argument in parse_transform/2. This makes it possible to access all compile options (i.e. the ones specified in the command-line and the ones specified in code) in a consistent way.

``` erlang
-module(dummy_module).

-compile({parse_transform, dummy_transform}).
-compile(dummy_transform_option1).
```

``` erlang
-module(dummy_transform).

-export([parse_transform/2]).

parse_transform(Forms, Opts) ->
    true = lists:member(dummy_transform_option1, Opts),
    Forms.
```

This contribution has been discussed in http://erlang.org/pipermail/erlang-patches/2014-May/004668.html
