### PR TITLE
Fix io:columns/0 timeout when invoked from application callback

### DIFF
--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -172,17 +172,17 @@ server_loop(Iport, Oport, Curr, User, Gr) ->
 	{Iport,eof} ->
 	    Curr ! {self(),eof},
 	    server_loop(Iport, Oport, Curr, User, Gr);
+	{Pid,tty_geometry} when Pid =:= User; Pid =:= Curr ->
+	    Pid ! {self(),tty_geometry,get_tty_geometry(Iport)},
+	    server_loop(Iport, Oport, Curr, User, Gr);
+	{Pid,get_unicode_state} when Pid =:= User; Pid =:= Curr ->
+	    Pid ! {self(),get_unicode_state,get_unicode_state(Iport)},
+	    server_loop(Iport, Oport, Curr, User, Gr);
+	{Pid,set_unicode_state, Bool} when Pid =:= User; Pid =:= Curr ->
+	    Pid ! {self(),set_unicode_state,set_unicode_state(Iport,Bool)},
+	    server_loop(Iport, Oport, Curr, User, Gr);
 	{User,Req} ->	% never block from user!
 	    io_request(Req, Iport, Oport),
-	    server_loop(Iport, Oport, Curr, User, Gr);
-	{Curr,tty_geometry} ->
-	    Curr ! {self(),tty_geometry,get_tty_geometry(Iport)},
-	    server_loop(Iport, Oport, Curr, User, Gr);
-	{Curr,get_unicode_state} ->
-	    Curr ! {self(),get_unicode_state,get_unicode_state(Iport)},
-	    server_loop(Iport, Oport, Curr, User, Gr);
-	{Curr,set_unicode_state, Bool} ->
-	    Curr ! {self(),set_unicode_state,set_unicode_state(Iport,Bool)},
 	    server_loop(Iport, Oport, Curr, User, Gr);
 	{Curr,Req} ->
 	    io_request(Req, Iport, Oport),


### PR DESCRIPTION
This patch fixes an issue where io:columns/0 times out when
invoked from any application callback (or any supervisor/supervised module
since the group leader is inherited).

To reproduce the issue, one must simply call io:columns() from any
application callback. You will notice the process will block for 2 seconds
which then times out and returns {:error, :enotsup}.

Note this bug only happens inside the erlang shell (using -noshell or
escripts do not trigger the bug).

To fix the bug, it is important to understand how io requests flow from
application callback processes. Here are the steps followed:
1. Since io:columns/1 is timing out, the first step is to find out who is the
   group leader for the application callback process. Using process_info/1, we
   can see the parent process is the application_master and it does handle
   io_requests by delegating to the group_leader:
   
   https://github.com/erlang/otp/blob/aca0b6182b039333b4c963938878d9eecc85e5a1/lib/kernel/src/application_master.erl#L172-L174
2. By inspecting the application_master process, we can find the group_leader
   the message is sent above is the registered process named user. The process is
   running the group module which does handle io:columns/1 requests:
   
   https://github.com/erlang/otp/blob/aca0b6182b039333b4c963938878d9eecc85e5a1/lib/kernel/src/group.erl#L263-L276
3. Those requests are delegated to the underlying driver defined here:
   
   https://github.com/erlang/otp/blob/aca0b6182b039333b4c963938878d9eecc85e5a1/lib/kernel/src/group.erl#L37
4. The driver is the user_drv process. The user_drv process does handle
   tty_geometry requests, except that a clause above ends up ignoring the
   tty_geometry requests from the user process:
   
   https://github.com/erlang/otp/blob/aca0b6182b039333b4c963938878d9eecc85e5a1/lib/kernel/src/user_drv.erl#L175-L180

This patch moves the user clause below the specific driver messages.
