### PR TITLE
Fix shell crash when in switch command mode

### DIFF
--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -132,6 +132,10 @@ server1(Iport, Oport, Shell) ->
 		flatten(io_lib:format("~ts\n",
 				      [erlang:system_info(system_version)]))},
 	       Iport, Oport),
+
+    %% Init edlin used by switch command
+    edlin:init(),
+
     %% Enter the server loop.
     server_loop(Iport, Oport, Curr, User, Gr).
 


### PR DESCRIPTION
The user_drv process can crash if ctrl-y is pressed when in switch command mode (ctrl-g).
This is due to switch mode using edlin to parse the input.
And edlin uses the process dictionary to store the kill_buffer.
However the kill_buffer is undefined if not initialized by edlin:init/0
which makes the user_drv process crash since edlin is calling list:reverse/2 with undefined.

Fix calles edlin:init/0 once before server_loop is entered.