### PR TITLE
Make the scanned form of the io_lib format strings available for processing

### DIFF
--- a/lib/stdlib/doc/src/io.xml
+++ b/lib/stdlib/doc/src/io.xml
@@ -505,7 +505,8 @@ ok
             <p>Writes the data with standard syntax in the same way as
               <c>~w</c>, but breaks terms whose printed representation
               is longer than one line into many lines and indents each
-              line sensibly. It also tries to detect lists of
+              line sensibly. Left justification is not supported.
+              It also tries to detect lists of
               printable characters and to output these as strings. The
               Unicode translation modifier is used for determining
               what characters are printable. For example:</p>

--- a/lib/stdlib/doc/src/io_lib.xml
+++ b/lib/stdlib/doc/src/io_lib.xml
@@ -59,6 +59,9 @@
     <datatype>
       <name name="latin1_string"/>
     </datatype>
+    <datatype>
+      <name name="format_spec"/>
+    </datatype>
   </datatypes>
   <funcs>
     <func>
@@ -257,6 +260,41 @@
       <desc>
         <p>Returns the list of characters needed to print a character
           constant in the ISO-latin-1 character set.</p>
+      </desc>
+    </func>
+    <func>
+      <name name="scan_format" arity="2"/>
+      <fsummary>Parse all control sequences in the format string.</fsummary>
+      <desc>
+        <p>Returns a list corresponding to the given format string, where
+           control sequences have been replaced with corresponding tuples.
+           This list can be passed to
+           <seealso marker="#build_text/1">io_lib:build_text/1</seealso>
+           to have the same effect as <c>io_lib:format(Format, Args)</c>, or to
+           <seealso marker="#unscan_format/1">io_lib:unscan_format/1</seealso>
+           in order to get the corresponding pair of <c>Format</c> and
+           <c>Args</c>.</p>
+        <p>A typical use of this function is to replace unbounded-size
+        control sequences like <c>~w</c> and <c>~p</c> with the
+        depth-limited variants <c>~W</c> and <c>~P</c> before formatting to
+        text, e.g. in a logger.</p>
+      </desc>
+    </func>
+    <func>
+      <name name="unscan_format" arity="1"/>
+      <fsummary>Revert a pre-parsed format list to a plain character list
+                and a list of arguments.</fsummary>
+      <desc>
+        <p>See <seealso marker="#scan_format/2">io_lib:scan_format/2</seealso>
+        for details.</p>
+      </desc>
+    </func>
+    <func>
+      <name name="build_text" arity="1"/>
+      <fsummary>Build the output text for a pre-parsed format list.</fsummary>
+      <desc>
+        <p>See <seealso marker="#scan_format/2">io_lib:scan_format/2</seealso>
+        for details.</p>
       </desc>
     </func>
     <func>

--- a/lib/stdlib/src/io_lib.erl
+++ b/lib/stdlib/src/io_lib.erl
@@ -60,6 +60,7 @@
 -module(io_lib).
 
 -export([fwrite/2,fread/2,fread/3,format/2]).
+-export([scan_format/2,unscan_format/1,build_text/1]).
 -export([print/1,print/4,indentation/2]).
 
 -export([write/1,write/2,write/3,nl/0,format_prompt/1,format_prompt/2]).
@@ -108,6 +109,15 @@
 
 -type fread_item() :: string() | atom() | integer() | float().
 
+-type format_spec() :: {ControlChar :: char(),
+                        Args :: [any()],
+                        Width :: none | integer(),
+                        Adjust :: left | right,
+                        Precision :: none | integer(),
+                        PadChar :: char(),
+                        Encoding :: unicode | latin1,
+                        Strings :: boolean()}.
+
 %%----------------------------------------------------------------------
 
 %% Interface calls to sub-modules.
@@ -155,6 +165,31 @@ format(Format, Args) ->
 	Other ->
 	    Other
     end.
+
+-spec scan_format(Format, Data) -> FormatList when
+      Format :: io:format(),
+      Data :: [term()],
+      FormatList :: [char()|format_spec()].
+
+scan_format(Format, Args) ->
+    try io_lib_format:scan(Format, Args)
+    catch
+        _:_ -> erlang:error(badarg, [Format, Args])
+    end.
+
+-spec unscan_format(FormatList) -> {Format, Data} when
+      FormatList :: [char()|format_spec()],
+      Format :: io:format(),
+      Data :: [term()].
+
+unscan_format(FormatList) ->
+    io_lib_format:unscan(FormatList).
+
+-spec build_text(FormatList) -> string() when
+      FormatList :: [char()|format_spec()].
+
+build_text(FormatList) ->
+    io_lib_format:build(FormatList).
 
 -spec print(Term) -> chars() when
       Term :: term().


### PR DESCRIPTION
This adds three new functions to io_lib - scan_format/2, unscan_format/1,
and build_text/1 - which expose the parsed form of the format control
sequences to make it possible to easily modify or filter the input to
io_lib:format/2. This can e.g. be used in order to replace unbounded-size
control sequences like ~w or ~p with corresponding depth-limited ~W and ~P
before doing the actual formatting.