### PR TITLE
Add Visual Studio macros to erl_driver.h and ei.h

### DIFF
--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -198,7 +198,7 @@ typedef long long ErlDrvSInt64;
 #error No 64-bit integer type
 #endif
 
-#if defined(__WIN32__)
+#if defined(__WIN32__) || defined(_WIN32)
 typedef ErlDrvUInt ErlDrvSizeT;
 typedef ErlDrvSInt ErlDrvSSizeT;
 #else

--- a/lib/erl_interface/include/ei.h
+++ b/lib/erl_interface/include/ei.h
@@ -39,7 +39,7 @@
 #include <stdio.h>		/* Need type FILE */
 #include <errno.h>		/* Need EHOSTUNREACH, ENOMEM, ... */
 
-#if !defined(__WIN32__) && !defined(VXWORKS) || (defined(VXWORKS) && defined(HAVE_SENS))
+#if !(defined(__WIN32__) || defined(_WIN32)) && !defined(VXWORKS) || (defined(VXWORKS) && defined(HAVE_SENS))
 # include <netdb.h>
 #endif
 


### PR DESCRIPTION
Visual Studio (at least 2013 version) uses `_WIN32` macro instead of `__WIN32__`, so it wasn't possible to compile drivers and ports with `cl.exe`.
