### PR TITLE
inet: fix typo in inet:getstat/2 doc

### DIFF
--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -361,7 +361,7 @@ fe80::204:acff:fe17:bf38
 	  </item>
 	  <tag><c>send_dvi</c></tag>
 	  <item>
-            <p>Average packet size deviation in bytes received sent from the socket.</p>
+            <p>Average packet size deviation in bytes sent from the socket.</p>
 	  </item>
 	  <tag><c>send_max</c></tag>
 	  <item>


### PR DESCRIPTION
There was a copy-paste typo in send_dvi option description
