### PR TITLE
ssl: fix max sequence number so it does not overflow

### DIFF
--- a/lib/ssl/src/ssl_record.hrl
+++ b/lib/ssl/src/ssl_record.hrl
@@ -70,7 +70,7 @@
 
 -define(INITIAL_BYTES, 5).
 
--define(MAX_SEQENCE_NUMBER, 18446744073709552000). %% math:pow(2, 64) - 1 = 1.8446744073709552e19
+-define(MAX_SEQENCE_NUMBER, 18446744073709551615). %% (1 bsl 64) - 1 = 18446744073709551615
 %% Sequence numbers can not wrap so when max is about to be reached we should renegotiate.
 %% We will renegotiate a little before so that there will be sequence numbers left
 %% for the rehandshake and a little data. Currently we decided to renegotiate a little more


### PR DESCRIPTION
The old value of 18446744073709552000 was calculated using math:pow
which returns float therefore isn't precise. And it would overflow:

erlang:integer_to_list(18446744073709552000, 16) = "10000000000000180"

This patch changes MAX_SEQENCE_NUMBER to value calculated with bitwise
shift:
(1 bsl 64) - 1 = 18446744073709551615
