### PR TITLE
Implement ets:update_counter/4

### DIFF
--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -3562,7 +3562,7 @@ get_map_elements_fail:
 	    vbf = (BifFunction) Arg(0);
 	    PROCESS_MAIN_CHK_LOCKS(c_p);
 	    bif_nif_arity = I[-1];
-	    ASSERT(bif_nif_arity <= 3);
+            ASSERT(bif_nif_arity <= 4);
 	    ERTS_SMP_UNREQ_PROC_MAIN_LOCK(c_p);
 	    reg[0] = r(0);
 	    {

--- a/erts/emulator/beam/bif.h
+++ b/erts/emulator/beam/bif.h
@@ -30,10 +30,12 @@ extern Export* erts_format_cpu_topology_trap;
 #define BIF_ALIST_1 Process* A__p, Eterm* BIF__ARGS
 #define BIF_ALIST_2 Process* A__p, Eterm* BIF__ARGS
 #define BIF_ALIST_3 Process* A__p, Eterm* BIF__ARGS
+#define BIF_ALIST_4 Process* A__p, Eterm* BIF__ARGS
 
 #define BIF_ARG_1  (BIF__ARGS[0])
 #define BIF_ARG_2  (BIF__ARGS[1])
 #define BIF_ARG_3  (BIF__ARGS[2])
+#define BIF_ARG_4  (BIF__ARGS[3])
 
 #define ERTS_IS_PROC_OUT_OF_REDS(p)		\
     ((p)->fcalls > 0				\

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -596,6 +596,8 @@ bif maps:values/1
 
 bif erts_internal:cmp_term/2
 
+bif ets:update_counter/4
+
 #
 # Obsolete
 #

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -780,7 +780,7 @@ BIF_RETTYPE ets_update_element_3(BIF_ALIST_3)
 	list = BIF_ARG_3;
     }
 
-    if (!tb->common.meth->db_lookup_dbterm(tb, BIF_ARG_2, &handle)) {
+    if (!tb->common.meth->db_lookup_dbterm(BIF_P, tb, BIF_ARG_2, THE_NON_VALUE, &handle)) {
 	cret = DB_ERROR_BADKEY;
 	goto bail_out;
     }
@@ -819,7 +819,7 @@ BIF_RETTYPE ets_update_element_3(BIF_ALIST_3)
     }
 
 finalize:
-    tb->common.meth->db_finalize_dbterm(&handle);
+    tb->common.meth->db_finalize_dbterm(cret, &handle);
 
 bail_out:
     UnUseTmpHeap(2,BIF_P);
@@ -838,14 +838,8 @@ bail_out:
     }
 }
 
-/* 
-** update_counter(Tab, Key, Incr) 
-** update_counter(Tab, Key, {Upop}) 
-** update_counter(Tab, Key, [{Upop}]) 
-** Upop = {Pos,Incr} | {Pos,Incr,Threshold,WarpTo}
-** Returns new value(s) (integer or [integer])
-*/
-BIF_RETTYPE ets_update_counter_3(BIF_ALIST_3)
+static BIF_RETTYPE
+do_update_counter(Process *p, Eterm arg1, Eterm arg2, Eterm arg3, Eterm arg4)
 {
     DbTable* tb;
     int cret = DB_ERROR_BADITEM;
@@ -855,7 +849,7 @@ BIF_RETTYPE ets_update_counter_3(BIF_ALIST_3)
     Eterm* ret_list_currp = NULL;
     Eterm* ret_list_prevp = NULL;
     Eterm iter;
-    DeclareTmpHeap(cell,5,BIF_P);
+    DeclareTmpHeap(cell, 5, p);
     Eterm *tuple = cell+2;
     DbUpdateHandle handle;
     Uint halloc_size = 0; /* overestimated heap usage */
@@ -863,28 +857,29 @@ BIF_RETTYPE ets_update_counter_3(BIF_ALIST_3)
     Eterm* hstart;
     Eterm* hend;
 
-    if ((tb = db_get_table(BIF_P, BIF_ARG_1, DB_WRITE, LCK_WRITE_REC)) == NULL) {
-	BIF_ERROR(BIF_P, BADARG);
+    if ((tb = db_get_table(p, arg1, DB_WRITE, LCK_WRITE_REC)) == NULL) {
+        BIF_ERROR(p, BADARG);
     }
 
-    UseTmpHeap(5,BIF_P);
+    UseTmpHeap(5, p);
 
     if (!(tb->common.status & (DB_SET | DB_ORDERED_SET))) {
 	goto bail_out;
     }
-    if (is_integer(BIF_ARG_3)) {  /* Incr */
-	upop_list = CONS(cell, TUPLE2(tuple, make_small(tb->common.keypos+1),
-				      BIF_ARG_3), NIL);
+    if (is_integer(arg3)) { /* Incr */
+        upop_list = CONS(cell,
+                         TUPLE2(tuple, make_small(tb->common.keypos+1), arg3),
+                         NIL);
     }
-    else if (is_tuple(BIF_ARG_3)) { /* {Upop} */
-	upop_list = CONS(cell, BIF_ARG_3, NIL);
+    else if (is_tuple(arg3)) { /* {Upop} */
+        upop_list = CONS(cell, arg3, NIL);
     }
     else { /* [{Upop}] (probably) */
-	upop_list = BIF_ARG_3;
+        upop_list = arg3;
 	ret_list_prevp = &ret;
     }
 
-    if (!tb->common.meth->db_lookup_dbterm(tb, BIF_ARG_2, &handle)) {
+    if (!tb->common.meth->db_lookup_dbterm(p, tb, arg2, arg4, &handle)) {
 	goto bail_out; /* key not found */
     }
 
@@ -957,13 +952,13 @@ BIF_RETTYPE ets_update_counter_3(BIF_ALIST_3)
     if (ret_list_prevp) { /* Prepare to return a list */
 	ret = NIL;
 	halloc_size += list_size;
-	hstart = HAlloc(BIF_P, halloc_size);
+	hstart = HAlloc(p, halloc_size);
 	ret_list_currp = hstart;
 	htop = hstart + list_size;
 	hend = hstart + halloc_size;
     }
     else {
-	hstart = htop = HAlloc(BIF_P, halloc_size);
+	hstart = htop = HAlloc(p, halloc_size);
     }
     hend = hstart + halloc_size;
 
@@ -1010,25 +1005,53 @@ BIF_RETTYPE ets_update_counter_3(BIF_ALIST_3)
 	   (is_list(ret) && (list_val(ret)+list_size)==ret_list_currp));
     ASSERT(htop <= hend);
 
-    HRelease(BIF_P,hend,htop);
+    HRelease(p, hend, htop);
 
 finalize:
-    tb->common.meth->db_finalize_dbterm(&handle);
+    tb->common.meth->db_finalize_dbterm(cret, &handle);
 
 bail_out:
-    UnUseTmpHeap(5,BIF_P);
+    UnUseTmpHeap(5, p);
     db_unlock(tb, LCK_WRITE_REC);
 
     switch (cret) {
     case DB_ERROR_NONE:
 	BIF_RET(ret);
     case DB_ERROR_SYSRES:
-	BIF_ERROR(BIF_P, SYSTEM_LIMIT);
+        BIF_ERROR(p, SYSTEM_LIMIT);
     default:
-	BIF_ERROR(BIF_P, BADARG);
+        BIF_ERROR(p, BADARG);
 	break;
     }
 }
+
+/*
+** update_counter(Tab, Key, Incr)
+** update_counter(Tab, Key, Upop)
+** update_counter(Tab, Key, [{Upop}])
+** Upop = {Pos,Incr} | {Pos,Incr,Threshold,WarpTo}
+** Returns new value(s) (integer or [integer])
+*/
+BIF_RETTYPE ets_update_counter_3(BIF_ALIST_3)
+{
+    return do_update_counter(BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3, THE_NON_VALUE);
+}
+
+/*
+** update_counter(Tab, Key, Incr, Default)
+** update_counter(Tab, Key, Upop, Default)
+** update_counter(Tab, Key, [{Upop}], Default)
+** Upop = {Pos,Incr} | {Pos,Incr,Threshold,WarpTo}
+** Returns new value(s) (integer or [integer])
+*/
+BIF_RETTYPE ets_update_counter_4(BIF_ALIST_4)
+{
+    if (is_not_tuple(BIF_ARG_4)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+    return do_update_counter(BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3, BIF_ARG_4);
+}
+
 
 /* 
 ** The put BIF 

--- a/erts/emulator/beam/erl_db_tree.c
+++ b/erts/emulator/beam/erl_db_tree.c
@@ -398,8 +398,11 @@ static int db_delete_all_objects_tree(Process* p, DbTable* tbl);
 #ifdef HARDDEBUG
 static void db_check_table_tree(DbTable *tbl);
 #endif
-static int db_lookup_dbterm_tree(DbTable *, Eterm key, DbUpdateHandle*);
-static void db_finalize_dbterm_tree(DbUpdateHandle*);
+static int
+db_lookup_dbterm_tree(Process *, DbTable *, Eterm key, Eterm obj,
+                      DbUpdateHandle*);
+static void
+db_finalize_dbterm_tree(int cret, DbUpdateHandle *);
 
 /*
 ** Static variables
@@ -2522,16 +2525,43 @@ static TreeDbTerm **find_node2(DbTableTree *tb, Eterm key)
     return this;
 }
 
-static int db_lookup_dbterm_tree(DbTable *tbl, Eterm key, DbUpdateHandle* handle)
+static int
+db_lookup_dbterm_tree(Process *p, DbTable *tbl, Eterm key, Eterm obj,
+                      DbUpdateHandle* handle)
 {
     DbTableTree *tb = &tbl->tree;
     TreeDbTerm **pp = find_node2(tb, key);
+    int flags = 0;
 
-    if (pp == NULL) return 0;
+    if (pp == NULL) {
+        if (obj == THE_NON_VALUE) {
+            return 0;
+        } else {
+            Eterm *objp = tuple_val(obj);
+            int arity = arityval(*objp);
+            Eterm *htop, *hend;
+
+            ASSERT(arity >= tb->common.keypos);
+            htop = HAlloc(p, arity + 1);
+            hend = htop + arity + 1;
+            sys_memcpy(htop, objp, sizeof(Eterm) * (arity + 1));
+            htop[tb->common.keypos] = key;
+            obj = make_tuple(htop);
+
+            if (db_put_tree(tbl, obj, 1) != DB_ERROR_NONE) {
+                return 0;
+            }
+
+            pp = find_node2(tb, key);
+            ASSERT(pp != NULL);
+            HRelease(p, hend, htop);
+            flags |= DB_NEW_OBJECT;
+        }
+    }
 
     handle->tb = tbl;
     handle->dbterm = &(*pp)->dbterm;
-    handle->mustResize = 0;
+    handle->flags = flags;
     handle->bp = (void**) pp;
     handle->new_size = (*pp)->dbterm.size;
 #if HALFWORD_HEAP
@@ -2540,15 +2570,21 @@ static int db_lookup_dbterm_tree(DbTable *tbl, Eterm key, DbUpdateHandle* handle
     return 1;
 }
 
-static void db_finalize_dbterm_tree(DbUpdateHandle* handle)
+static void
+db_finalize_dbterm_tree(int cret, DbUpdateHandle *handle)
 {
-    if (handle->mustResize) {
-	TreeDbTerm* oldp = (TreeDbTerm*) *handle->bp;
+    DbTable *tbl = handle->tb;
+    DbTableTree *tb = &tbl->tree;
+    TreeDbTerm *bp = (TreeDbTerm *) *handle->bp;
 
+    if (handle->flags & DB_NEW_OBJECT && cret != DB_ERROR_NONE) {
+        Eterm ret;
+        db_erase_tree(tbl, GETKEY(tb, bp->dbterm.tpl), &ret);
+    } else if (handle->flags & DB_MUST_RESIZE) {
 	db_finalize_resize(handle, offsetof(TreeDbTerm,dbterm));
-	reset_static_stack(&handle->tb->tree);
+        reset_static_stack(tb);
 
-	free_term(&handle->tb->tree, oldp);
+        free_term(tb, bp);
     }
 #ifdef DEBUG
     handle->dbterm = 0;

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -2601,10 +2601,10 @@ Wterm db_do_read_element(DbUpdateHandle* handle, Sint position)
     }
 
     ASSERT(((DbTableCommon*)handle->tb)->compress);
-    ASSERT(!handle->mustResize);
+    ASSERT(!(handle->flags & DB_MUST_RESIZE));
     handle->dbterm = db_alloc_tmp_uncompressed(&handle->tb->common,
 					       handle->dbterm);
-    handle->mustResize = 1;
+    handle->flags |= DB_MUST_RESIZE;
     return handle->dbterm->tpl[position];
 }
 
@@ -2637,11 +2637,11 @@ void db_do_update_element(DbUpdateHandle* handle,
     #endif
 	return;
     }
-    if (!handle->mustResize) {
+    if (!(handle->flags & DB_MUST_RESIZE)) {
 	if (handle->tb->common.compress) {
 	    handle->dbterm = db_alloc_tmp_uncompressed(&handle->tb->common,
 						       handle->dbterm);
-	    handle->mustResize = 1;
+	    handle->flags |= DB_MUST_RESIZE;
 	    oldval = handle->dbterm->tpl[position];
         #if HALFWORD_HEAP
 	    old_base = NULL;
@@ -2701,7 +2701,7 @@ both_size_set:
 
     /* write new value in old dbterm, finalize will make a flat copy */
     handle->dbterm->tpl[position] = newval;
-    handle->mustResize = 1;
+    handle->flags |= DB_MUST_RESIZE;
 
 #if HALFWORD_HEAP
     if (old_base && newval_sz > 0) {

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -76,6 +76,9 @@ typedef struct db_term {
 union db_table;
 typedef union db_table DbTable;
 
+#define DB_MUST_RESIZE 1
+#define DB_NEW_OBJECT 2
+
 /* Info about a database entry while it's being updated
  * (by update_counter or update_element)
  */
@@ -84,7 +87,7 @@ typedef struct {
     DbTerm* dbterm;
     void** bp;         /* {Hash|Tree}DbTerm** */
     Uint new_size;
-    int mustResize;
+    int flags;
     void* lck;
 #if HALFWORD_HEAP
     unsigned char* abs_vec;  /* [i] true if dbterm->tpl[i] is absolute Eterm */
@@ -182,15 +185,14 @@ typedef struct db_table_method
 			       void *arg);
     void (*db_check_table)(DbTable* tb);
 
-    /* Lookup a dbterm for updating. Return false if not found.
-    */
-    int (*db_lookup_dbterm)(DbTable*, Eterm key, 
-			    DbUpdateHandle* handle); /* [out] */
+    /* Lookup a dbterm for updating. Return false if not found. */
+    int (*db_lookup_dbterm)(Process *, DbTable *, Eterm key, Eterm obj,
+                            DbUpdateHandle* handle);
 
-    /* Must be called for each db_lookup_dbterm that returned true,
-    ** even if dbterm was not updated.
-    */
-    void (*db_finalize_dbterm)(DbUpdateHandle* handle);
+    /* Must be called for each db_lookup_dbterm that returned true, even if
+    ** dbterm was not updated. If the handle was of a new object and cret is
+    ** not DB_ERROR_NONE, the object is removed from the table. */
+    void (*db_finalize_dbterm)(int cret, DbUpdateHandle* handle);
 
 } DbTableMethod;
 

--- a/erts/emulator/hipe/hipe_amd64_abi.txt
+++ b/erts/emulator/hipe/hipe_amd64_abi.txt
@@ -45,7 +45,7 @@ The first return value from a function is placed in %rax, the second
 (if any) is placed in %rdx.
 
 Notes:
-- Currently, NR_ARG_REGS==0.
+- Currently, NR_ARG_REGS == 4.
 - C BIFs expect P in C parameter register 1: %rdi. By making Erlang
   parameter registers 1-5 coincide with C parameter registers 2-6,
   our BIF wrappers can simply move P to %rdi without having to shift

--- a/erts/emulator/hipe/hipe_amd64_asm.m4
+++ b/erts/emulator/hipe/hipe_amd64_asm.m4
@@ -237,6 +237,10 @@ define(NBIF_ARG,`ifelse(eval($3 >= NR_ARG_REGS),0,`NBIF_REG_ARG($1,$3)',`NBIF_ST
 `/* #define NBIF_ARG_3_0	'NBIF_ARG(%rsi,3,0)` */'
 `/* #define NBIF_ARG_3_1	'NBIF_ARG(%rdx,3,1)` */'
 `/* #define NBIF_ARG_3_2	'NBIF_ARG(%rcx,3,2)` */'
+`/* #define NBIF_ARG_4_0	'NBIF_ARG(%rsi,4,0)` */'
+`/* #define NBIF_ARG_4_1	'NBIF_ARG(%rdx,4,1)` */'
+`/* #define NBIF_ARG_4_2	'NBIF_ARG(%rcx,4,2)` */'
+`/* #define NBIF_ARG_4_3	'NBIF_ARG(%r8,4,3)` */'
 `/* #define NBIF_ARG_5_0	'NBIF_ARG(%rsi,5,0)` */'
 `/* #define NBIF_ARG_5_1	'NBIF_ARG(%rdx,5,1)` */'
 `/* #define NBIF_ARG_5_2	'NBIF_ARG(%rcx,5,2)` */'
@@ -261,6 +265,7 @@ define(NBIF_RET,`NBIF_RET_N(eval(RET_POP($1)))')dnl
 `/* #define NBIF_RET_1	'NBIF_RET(1)` */'
 `/* #define NBIF_RET_2	'NBIF_RET(2)` */'
 `/* #define NBIF_RET_3	'NBIF_RET(3)` */'
+`/* #define NBIF_RET_4	'NBIF_RET(4)` */'
 `/* #define NBIF_RET_5	'NBIF_RET(5)` */'
 
 `#endif /* HIPE_AMD64_ASM_H */'

--- a/erts/emulator/hipe/hipe_amd64_bifs.m4
+++ b/erts/emulator/hipe/hipe_amd64_bifs.m4
@@ -48,9 +48,10 @@ define(HANDLE_GOT_MBUF,`
  * standard_bif_interface_1(nbif_name, cbif_name)
  * standard_bif_interface_2(nbif_name, cbif_name)
  * standard_bif_interface_3(nbif_name, cbif_name)
+ * standard_bif_interface_4(nbif_name, cbif_name)
  * standard_bif_interface_0(nbif_name, cbif_name)
  *
- * Generate native interface for a BIF with 0-3 parameters and
+ * Generate native interface for a BIF with 0-4 parameters and
  * standard failure mode.
  */
 define(standard_bif_interface_1,
@@ -149,6 +150,43 @@ ASYM($1):
 	HANDLE_GOT_MBUF(3)
 	SET_SIZE(ASYM($1))
 	TYPE_FUNCTION(ASYM($1))
+#endif')
+
+define(standard_bif_interface_4,
+`
+#ifndef HAVE_$1
+#`define' HAVE_$1
+    TEXT
+    .align  4
+    GLOBAL(ASYM($1))
+ASYM($1):
+    /* set up the parameters */
+    movq    P, %rdi
+    NBIF_ARG(%rsi,4,0)
+    NBIF_ARG(%rdx,4,1)
+    NBIF_ARG(%rcx,4,2)
+    NBIF_ARG(%r8,4,3)
+
+    /* make the call on the C stack */
+    SWITCH_ERLANG_TO_C
+    pushq   %r8
+    pushq   %rcx
+    pushq   %rdx
+    pushq   %rsi
+    movq    %rsp, %rsi  /* Eterm* BIF__ARGS */
+    sub $(8), %rsp  /* stack frame 16-byte alignment */
+    CALL_BIF($2)
+    add $(4*8 + 8), %rsp
+    TEST_GOT_MBUF
+    SWITCH_C_TO_ERLANG
+
+    /* throw exception if failure, otherwise return */
+    TEST_GOT_EXN
+    jz  nbif_4_simple_exception
+    NBIF_RET(4)
+    HANDLE_GOT_MBUF(4)
+    SET_SIZE(ASYM($1))
+    TYPE_FUNCTION(ASYM($1))
 #endif')
 
 define(standard_bif_interface_0,

--- a/erts/emulator/hipe/hipe_amd64_glue.S
+++ b/erts/emulator/hipe/hipe_amd64_glue.S
@@ -322,6 +322,7 @@ ASYM(nbif_fail):
 	GLOBAL(nbif_1_gc_after_bif)
 	GLOBAL(nbif_2_gc_after_bif)
 	GLOBAL(nbif_3_gc_after_bif)
+	GLOBAL(nbif_4_gc_after_bif)
 	.align	4
 nbif_0_gc_after_bif:
 	xorl	%edx, %edx
@@ -337,6 +338,10 @@ nbif_2_gc_after_bif:
 	.align	4
 nbif_3_gc_after_bif:
 	movl	$3, %edx
+	jmp	.gc_after_bif
+	.align	4
+nbif_4_gc_after_bif:
+	movl	$4, %edx
 	/*FALLTHROUGH*/
 	.align	4
 .gc_after_bif:
@@ -360,6 +365,7 @@ nbif_3_gc_after_bif:
 	GLOBAL(nbif_1_simple_exception)
 	GLOBAL(nbif_2_simple_exception)
 	GLOBAL(nbif_3_simple_exception)
+	GLOBAL(nbif_4_simple_exception)
 	.align	4
 nbif_0_simple_exception:
 	xorl	%eax, %eax
@@ -375,6 +381,10 @@ nbif_2_simple_exception:
 	.align	4
 nbif_3_simple_exception:
 	movl	$3, %eax
+	jmp	.nbif_simple_exception
+	.align	4
+nbif_4_simple_exception:
+	movl	$4, %eax
 	/*FALLTHROUGH*/
 	.align	4
 .nbif_simple_exception:

--- a/erts/emulator/hipe/hipe_ppc_asm.m4
+++ b/erts/emulator/hipe/hipe_ppc_asm.m4
@@ -273,6 +273,10 @@ define(NBIF_ARG,`ifelse(eval($3 >= NR_ARG_REGS),0,`NBIF_REG_ARG($1,$3)',`NBIF_ST
 `/* #define NBIF_ARG_3_0	'NBIF_ARG(r3,3,0)` */'
 `/* #define NBIF_ARG_3_1	'NBIF_ARG(r3,3,1)` */'
 `/* #define NBIF_ARG_3_2	'NBIF_ARG(r3,3,2)` */'
+`/* #define NBIF_ARG_4_0	'NBIF_ARG(r3,4,0)` */'
+`/* #define NBIF_ARG_4_1	'NBIF_ARG(r3,4,1)` */'
+`/* #define NBIF_ARG_4_2	'NBIF_ARG(r3,4,2)` */'
+`/* #define NBIF_ARG_4_3	'NBIF_ARG(r3,4,3)` */'
 `/* #define NBIF_ARG_5_0	'NBIF_ARG(r3,5,0)` */'
 `/* #define NBIF_ARG_5_1	'NBIF_ARG(r3,5,1)` */'
 `/* #define NBIF_ARG_5_2	'NBIF_ARG(r3,5,2)` */'
@@ -294,6 +298,7 @@ define(NBIF_RET,`NBIF_RET_N(eval(RET_POP($1)))')dnl
 `/* #define NBIF_RET_1	'NBIF_RET(1)` */'
 `/* #define NBIF_RET_2	'NBIF_RET(2)` */'
 `/* #define NBIF_RET_3	'NBIF_RET(3)` */'
+`/* #define NBIF_RET_4	'NBIF_RET(4)` */'
 `/* #define NBIF_RET_5	'NBIF_RET(5)` */'
 
 dnl

--- a/erts/emulator/hipe/hipe_ppc_bifs.m4
+++ b/erts/emulator/hipe/hipe_ppc_bifs.m4
@@ -45,9 +45,10 @@ define(HANDLE_GOT_MBUF,`
  * standard_bif_interface_1(nbif_name, cbif_name)
  * standard_bif_interface_2(nbif_name, cbif_name)
  * standard_bif_interface_3(nbif_name, cbif_name)
+ * standard_bif_interface_4(nbif_name, cbif_name)
  * standard_bif_interface_0(nbif_name, cbif_name)
  *
- * Generate native interface for a BIF with 0-3 parameters and
+ * Generate native interface for a BIF with 0-4 parameters and
  * standard failure mode.
  */
 define(standard_bif_interface_1,
@@ -139,6 +140,41 @@ ASYM($1):
 1:	/* workaround for bc:s small offset operand */
 	b	CSYM(nbif_3_simple_exception)
 	HANDLE_GOT_MBUF(3)
+	SET_SIZE(ASYM($1))
+	TYPE_FUNCTION(ASYM($1))
+#endif')
+
+define(standard_bif_interface_4,
+`
+#ifndef HAVE_$1
+#`define' HAVE_$1
+	GLOBAL(ASYM($1))
+ASYM($1):
+	/* Set up C argument registers. */
+	mr	r3, P
+	NBIF_ARG(r4,4,0)
+	NBIF_ARG(r5,4,1)
+	NBIF_ARG(r6,4,2)
+	NBIF_ARG(r7,4,3)
+
+	/* Save caller-save registers and call the C function. */
+	SAVE_CONTEXT_BIF
+	STORE	r4, P_ARG0(r3)		/* Store BIF__ARGS in def_arg_reg[] */
+	STORE	r5, P_ARG1(r3)
+	STORE	r6, P_ARG2(r3)
+	STORE	r7, P_ARG3(r3)
+	addi	r4, r3, P_ARG0
+	CALL_BIF($2)
+	TEST_GOT_MBUF
+
+	/* Restore registers. Check for exception. */
+	CMPI	r3, THE_NON_VALUE
+	RESTORE_CONTEXT_BIF
+	beq-	1f
+	NBIF_RET(4)
+1:	/* workaround for bc:s small offset operand */
+	b	CSYM(nbif_4_simple_exception)
+	HANDLE_GOT_MBUF(4)
 	SET_SIZE(ASYM($1))
 	TYPE_FUNCTION(ASYM($1))
 #endif')

--- a/erts/emulator/hipe/hipe_ppc_glue.S
+++ b/erts/emulator/hipe/hipe_ppc_glue.S
@@ -463,10 +463,12 @@ ASYM(nbif_fail):
 	OPD(nbif_1_gc_after_bif)
 	OPD(nbif_2_gc_after_bif)
 	OPD(nbif_3_gc_after_bif)
+	OPD(nbif_4_gc_after_bif)
 	GLOBAL(CSYM(nbif_0_gc_after_bif))
 	GLOBAL(CSYM(nbif_1_gc_after_bif))
 	GLOBAL(CSYM(nbif_2_gc_after_bif))
 	GLOBAL(CSYM(nbif_3_gc_after_bif))
+	GLOBAL(CSYM(nbif_4_gc_after_bif))
 CSYM(nbif_0_gc_after_bif):
 	li	r4, 0
 	b	.gc_after_bif
@@ -478,6 +480,9 @@ CSYM(nbif_2_gc_after_bif):
 	b	.gc_after_bif
 CSYM(nbif_3_gc_after_bif):
 	li	r4, 3
+	b	.gc_after_bif
+CSYM(nbif_4_gc_after_bif):
+	li	r4, 4
 	/*FALLTHROUGH*/
 .gc_after_bif:
 	stw	r4, P_NARITY(P)		/* Note: narity is a 32-bit field */
@@ -520,6 +525,11 @@ CSYM(nbif_2_simple_exception):
 	GLOBAL(CSYM(nbif_3_simple_exception))
 CSYM(nbif_3_simple_exception):
 	li	r4, 3
+	b	.nbif_simple_exception
+	OPD(nbif_3_simple_exception)
+	GLOBAL(CSYM(nbif_4_simple_exception))
+CSYM(nbif_4_simple_exception):
+	li	r4, 4
 	/*FALLTHROUGH*/
 .nbif_simple_exception:
 	LOAD	r3, P_FREASON(P)

--- a/erts/emulator/hipe/hipe_sparc_asm.m4
+++ b/erts/emulator/hipe/hipe_sparc_asm.m4
@@ -171,6 +171,10 @@ define(NBIF_ARG,`ifelse(eval($3 >= NR_ARG_REGS),0,`NBIF_REG_ARG($1,$3)',`NBIF_ST
 `/* #define NBIF_ARG_3_0	'NBIF_ARG(r1,3,0)` */'
 `/* #define NBIF_ARG_3_1	'NBIF_ARG(r2,3,1)` */'
 `/* #define NBIF_ARG_3_2	'NBIF_ARG(r3,3,2)` */'
+`/* #define NBIF_ARG_4_0	'NBIF_ARG(r1,4,0)` */'
+`/* #define NBIF_ARG_4_1	'NBIF_ARG(r2,4,1)` */'
+`/* #define NBIF_ARG_4_2	'NBIF_ARG(r3,4,2)` */'
+`/* #define NBIF_ARG_4_3	'NBIF_ARG(r3,4,3)` */'
 `/* #define NBIF_ARG_5_0	'NBIF_ARG(r1,5,0)` */'
 `/* #define NBIF_ARG_5_1	'NBIF_ARG(r2,5,1)` */'
 `/* #define NBIF_ARG_5_2	'NBIF_ARG(r3,5,2)` */'
@@ -195,6 +199,7 @@ define(NBIF_RET,`NBIF_RET_N(eval(RET_POP($1)))')dnl
 `/* #define NBIF_RET_1	'NBIF_RET(1)` */'
 `/* #define NBIF_RET_2	'NBIF_RET(2)` */'
 `/* #define NBIF_RET_3	'NBIF_RET(3)` */'
+`/* #define NBIF_RET_4	'NBIF_RET(4)` */'
 `/* #define NBIF_RET_5	'NBIF_RET(5)` */'
 
 dnl

--- a/erts/emulator/hipe/hipe_sparc_bifs.m4
+++ b/erts/emulator/hipe/hipe_sparc_bifs.m4
@@ -53,9 +53,10 @@ define(HANDLE_GOT_MBUF,`
  * standard_bif_interface_1(nbif_name, cbif_name)
  * standard_bif_interface_2(nbif_name, cbif_name)
  * standard_bif_interface_3(nbif_name, cbif_name)
+ * standard_bif_interface_3(nbif_name, cbif_name)
  * standard_bif_interface_0(nbif_name, cbif_name)
  *
- * Generate native interface for a BIF with 0-3 parameters and
+ * Generate native interface for a BIF with 0-4 parameters and
  * standard failure mode.
  */
 define(standard_bif_interface_1,
@@ -141,6 +142,39 @@ $1:
 	RESTORE_CONTEXT_BIF
 	NBIF_RET(3)
 	HANDLE_GOT_MBUF(3)
+	.size	$1, .-$1
+	.type	$1, #function
+#endif')
+
+define(standard_bif_interface_4,
+`
+#ifndef HAVE_$1
+#`define' HAVE_$1
+	.global $1
+$1:
+	/* Set up C argument registers. */
+	mov	P, %o0
+	NBIF_ARG(%o1,4,0)
+	NBIF_ARG(%o2,4,1)
+	NBIF_ARG(%o3,4,2)
+	NBIF_ARG(%o4,4,3)
+
+	/* Save caller-save registers and call the C function. */
+	SAVE_CONTEXT_BIF
+	st 	%o1, [%o0+P_ARG0]	! Store BIF__ARGS in def_arg_reg
+	st 	%o2, [%o0+P_ARG1]
+	st 	%o3, [%o0+P_ARG2]
+	st 	%o4, [%o0+P_ARG3]
+	add	%o0, P_ARG0, %o1
+	CALL_BIF($2)
+	nop
+	TEST_GOT_MBUF
+
+	/* Restore registers. Check for exception. */
+	TEST_GOT_EXN(4)
+	RESTORE_CONTEXT_BIF
+	NBIF_RET(4)
+	HANDLE_GOT_MBUF(4)
 	.size	$1, .-$1
 	.type	$1, #function
 #endif')

--- a/erts/emulator/hipe/hipe_sparc_glue.S
+++ b/erts/emulator/hipe/hipe_sparc_glue.S
@@ -327,7 +327,10 @@ nbif_2_gc_after_bif:
 	ba	.gc_after_bif
 	mov	2, %o1		/* delay slot */
 nbif_3_gc_after_bif:
-	mov	3, %o1
+	ba	.gc_after_bif
+	mov	3, %o1		/* delay slot */
+nbif_4_gc_after_bif:
+	mov	4, %o1
 	/*FALLTHROUGH*/
 .gc_after_bif:
 	st	%o1, [P+P_NARITY]
@@ -365,7 +368,11 @@ nbif_2_simple_exception:
 	mov	2, %o1		/* delay slot */
 	.global	nbif_3_simple_exception
 nbif_3_simple_exception:
-	mov	3, %o1
+	ba	.nbif_simple_exception
+	mov	3, %o1		/* delay slot */
+	.global	nbif_4_simple_exception
+nbif_4_simple_exception:
+	mov	4, %o1
 	/*FALLTHROUGH*/
 .nbif_simple_exception:
 	ld	[P+P_FREASON], %o0

--- a/erts/emulator/hipe/hipe_x86_asm.m4
+++ b/erts/emulator/hipe/hipe_x86_asm.m4
@@ -204,6 +204,7 @@ define(NBIF_COPY_NSP,`ifelse(eval($1 > NR_ARG_REGS),0,,`movl	%esp, TEMP_NSP')')d
 `/* #define NBIF_COPY_NSP_1	'NBIF_COPY_NSP(1)` */'
 `/* #define NBIF_COPY_NSP_2	'NBIF_COPY_NSP(2)` */'
 `/* #define NBIF_COPY_NSP_3	'NBIF_COPY_NSP(3)` */'
+`/* #define NBIF_COPY_NSP_4	'NBIF_COPY_NSP(4)` */'
 `/* #define NBIF_COPY_NSP_5	'NBIF_COPY_NSP(5)` */'
 
 dnl
@@ -227,6 +228,10 @@ define(NBIF_ARG_OPND,`ifelse(eval($2 >= NR_ARG_REGS),0,`ARG'$2,BASE_OFFSET(eval(
 `/* #define NBIF_ARG_OPND_3_0	'NBIF_ARG_OPND(3,0)` */'
 `/* #define NBIF_ARG_OPND_3_1	'NBIF_ARG_OPND(3,1)` */'
 `/* #define NBIF_ARG_OPND_3_2	'NBIF_ARG_OPND(3,2)` */'
+`/* #define NBIF_ARG_OPND_4_0	'NBIF_ARG_OPND(4,0)` */'
+`/* #define NBIF_ARG_OPND_4_1	'NBIF_ARG_OPND(4,1)` */'
+`/* #define NBIF_ARG_OPND_4_2	'NBIF_ARG_OPND(4,2)` */'
+`/* #define NBIF_ARG_OPND_4_3	'NBIF_ARG_OPND(4,3)` */'
 `/* #define NBIF_ARG_OPND_5_0	'NBIF_ARG_OPND(5,0)` */'
 `/* #define NBIF_ARG_OPND_5_1	'NBIF_ARG_OPND(5,1)` */'
 `/* #define NBIF_ARG_OPND_5_2	'NBIF_ARG_OPND(5,2)` */'
@@ -266,6 +271,7 @@ define(NBIF_RET,`NBIF_RET_N(eval(RET_POP($1)))')dnl
 `/* #define NBIF_RET_1	'NBIF_RET(1)` */'
 `/* #define NBIF_RET_2	'NBIF_RET(2)` */'
 `/* #define NBIF_RET_3	'NBIF_RET(3)` */'
+`/* #define NBIF_RET_4	'NBIF_RET(4)` */'
 `/* #define NBIF_RET_5	'NBIF_RET(5)` */'
 
 dnl

--- a/erts/emulator/hipe/hipe_x86_bifs.m4
+++ b/erts/emulator/hipe/hipe_x86_bifs.m4
@@ -47,6 +47,7 @@ define(HANDLE_GOT_MBUF,`
  * standard_bif_interface_1(nbif_name, cbif_name)
  * standard_bif_interface_2(nbif_name, cbif_name)
  * standard_bif_interface_3(nbif_name, cbif_name)
+ * standard_bif_interface_4(nbif_name, cbif_name)
  * standard_bif_interface_0(nbif_name, cbif_name)
  *
  * Generate native interface for a BIF with 0-3 parameters and
@@ -153,6 +154,43 @@ ASYM($1):
 	jz	nbif_3_simple_exception
 	NBIF_RET(3)
 	HANDLE_GOT_MBUF(3)
+	SET_SIZE(ASYM($1))
+	TYPE_FUNCTION(ASYM($1))
+#endif')
+
+define(standard_bif_interface_4,
+`
+#ifndef HAVE_$1
+#`define' HAVE_$1
+	TEXT
+	.align	4
+	GLOBAL(ASYM($1))
+ASYM($1):
+	/* copy native stack pointer */
+	NBIF_COPY_NSP(4)
+
+	/* switch to C stack */
+	SWITCH_ERLANG_TO_C
+
+	/* make the call on the C stack */
+	NBIF_ARG_REG(0,P)
+	NBIF_ARG(2,4,0)
+	NBIF_ARG(3,4,1)
+	NBIF_ARG(4,4,2)
+	NBIF_ARG(5,4,3)
+	lea 8(%esp), %eax
+	NBIF_ARG_REG(1,%eax)	/* BIF__ARGS */
+	CALL_BIF($2)
+	TEST_GOT_MBUF
+
+	/* switch to native stack */
+	SWITCH_C_TO_ERLANG
+
+	/* throw exception if failure, otherwise return */
+	TEST_GOT_EXN
+	jz	nbif_4_simple_exception
+	NBIF_RET(4)
+	HANDLE_GOT_MBUF(4)
 	SET_SIZE(ASYM($1))
 	TYPE_FUNCTION(ASYM($1))
 #endif')

--- a/erts/emulator/hipe/hipe_x86_glue.S
+++ b/erts/emulator/hipe/hipe_x86_glue.S
@@ -300,6 +300,7 @@ ASYM(nbif_fail):
 	GLOBAL(nbif_1_gc_after_bif)
 	GLOBAL(nbif_2_gc_after_bif)
 	GLOBAL(nbif_3_gc_after_bif)
+	GLOBAL(nbif_4_gc_after_bif)
 	.align	4
 nbif_0_gc_after_bif:
 	xorl	%edx, %edx
@@ -315,6 +316,10 @@ nbif_2_gc_after_bif:
 	.align	4
 nbif_3_gc_after_bif:
 	movl	$3, %edx
+	jmp	.gc_after_bif
+	.align	4
+nbif_4_gc_after_bif:
+	movl	$4, %edx
 	/*FALLTHROUGH*/
 	.align	4
 .gc_after_bif:
@@ -338,6 +343,7 @@ nbif_3_gc_after_bif:
 	GLOBAL(nbif_1_simple_exception)
 	GLOBAL(nbif_2_simple_exception)
 	GLOBAL(nbif_3_simple_exception)
+	GLOBAL(nbif_4_simple_exception)
 	.align	4
 nbif_0_simple_exception:
 	xorl	%eax, %eax
@@ -353,6 +359,10 @@ nbif_2_simple_exception:
 	.align	4
 nbif_3_simple_exception:
 	movl	$3, %eax
+	jmp	.nbif_simple_exception
+	.align	4
+nbif_4_simple_exception:
+	movl	$4, %eax
 	/*FALLTHROUGH*/
 	.align	4
 .nbif_simple_exception:

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -1597,14 +1597,18 @@ true</pre>
     </func>
     <func> 
       <name name="update_counter" arity="3" clause_i="1"/>
+      <name name="update_counter" arity="4" clause_i="1"/>
       <name name="update_counter" arity="3" clause_i="2"/>
+      <name name="update_counter" arity="4" clause_i="2"/>
       <name name="update_counter" arity="3" clause_i="3"/>
+      <name name="update_counter" arity="4" clause_i="3"/>
       <type variable="Tab"/>
       <type variable="Key"/>
       <type variable="UpdateOp" name_i="1"/>
       <type variable="Pos" name_i="1"/>
       <type variable="Threshold" name_i="1"/>
       <type variable="SetValue" name_i="1"/>
+      <type variable="Default"/>
       <fsummary>Update a counter object in an ETS table.</fsummary>
       <desc>
         <p>This function provides an efficient way to update one or more 
@@ -1646,12 +1650,22 @@ true</pre>
           <seealso marker="#lookup/2">lookup/2</seealso> and 
           <seealso marker="#new/2">new/2</seealso>
           for details on the difference).</p>
+        <p>If a default object <c><anno>Default</anno></c> is given, it is used
+          as the object to be updated if the key is missing from the table. The
+          value in place of the key is ignored and replaced by the proper key
+          value. The return value is as if the default object had not been used,
+          that is a single updated element or a list of them.</p>
         <p>The function will fail with reason <c>badarg</c> if:</p>
         <list type="bulleted">
           <item>the table is not of type <c>set</c> or
           <c>ordered_set</c>,</item>
-          <item>no object with the right key exists,</item>
+          <item>no object with the right key exists and no default object were
+            supplied,</item>
           <item>the object has the wrong arity,</item>
+          <item>the default object arity is smaller than
+            <c><![CDATA[<keypos>]]></c></item>
+          <item>any field from the default object being updated is not an
+            integer</item>
           <item>the element to update is not an integer,</item>
           <item>the element to update is also the key, or,</item>
           <item>any of <c><anno>Pos</anno></c>, <c><anno>Incr</anno></c>, <c><anno>Threshold</anno></c> or

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -71,7 +71,7 @@
          rename/2, safe_fixtable/2, select/1, select/2, select/3,
          select_count/2, select_delete/2, select_reverse/1,
          select_reverse/2, select_reverse/3, setopts/2, slot/2,
-         update_counter/3, update_element/3]).
+         update_counter/3, update_counter/4, update_element/3]).
 
 -spec all() -> [Tab] when
       Tab :: tab().
@@ -425,6 +425,38 @@ slot(_, _) ->
       Result :: integer().
 
 update_counter(_, _, _) ->
+    erlang:nif_error(undef).
+
+-spec update_counter(Tab, Key, UpdateOp, Default) -> Result when
+                        Tab :: tab(),
+                        Key :: term(),
+                        UpdateOp :: {Pos, Incr}
+                                  | {Pos, Incr, Threshold, SetValue},
+                        Pos :: integer(),
+                        Incr :: integer(),
+                        Threshold :: integer(),
+                        SetValue :: integer(),
+                        Result :: integer(),
+                        Default :: tuple();
+                    (Tab, Key, [UpdateOp], Default) -> [Result] when
+                        Tab :: tab(),
+                        Key :: term(),
+                        UpdateOp :: {Pos, Incr}
+                                  | {Pos, Incr, Threshold, SetValue},
+                        Pos :: integer(),
+                        Incr :: integer(),
+                        Threshold :: integer(),
+                        SetValue :: integer(),
+                        Result :: integer(),
+                        Default :: tuple();
+                    (Tab, Key, Incr, Default) -> Result when
+                        Tab :: tab(),
+                        Key :: term(),
+                        Incr :: integer(),
+                        Result :: integer(),
+                        Default :: tuple().
+
+update_counter(_, _, _, _) ->
     erlang:nif_error(undef).
 
 -spec update_element(Tab, Key, ElementSpec :: {Pos, Value}) -> boolean() when

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -47,6 +47,7 @@
 -export([ordered/1, ordered_match/1, interface_equality/1,
 	 fixtable_next/1, fixtable_insert/1, rename/1, rename_unnamed/1, evil_rename/1,
 	 update_element/1, update_counter/1, evil_update_counter/1, partly_bound/1, match_heavy/1]).
+-export([update_counter_with_default/1]).
 -export([member/1]).
 -export([memory/1]).
 -export([select_fail/1]).
@@ -98,7 +99,7 @@
 	 misc1_do/1, safe_fixtable_do/1, info_do/1, dups_do/1, heavy_lookup_do/1,
 	 heavy_lookup_element_do/1, member_do/1, otp_5340_do/1, otp_7665_do/1, meta_wb_do/1,
 	 do_heavy_concurrent/1, tab2file2_do/2, exit_large_table_owner_do/2,
-         types_do/1, sleeper/0, memory_do/1,
+         types_do/1, sleeper/0, memory_do/1, update_counter_with_default_do/1,
 	 ms_tracee_dummy/1, ms_tracee_dummy/2, ms_tracee_dummy/3, ms_tracee_dummy/4
 	]).
 
@@ -135,7 +136,8 @@ all() ->
      {group, heavy}, ordered, ordered_match,
      interface_equality, fixtable_next, fixtable_insert,
      rename, rename_unnamed, evil_rename, update_element,
-     update_counter, evil_update_counter, partly_bound,
+     update_counter, evil_update_counter,
+     update_counter_with_default, partly_bound,
      match_heavy, {group, fold}, member, t_delete_object,
      t_init_table, t_whitebox, t_delete_all_objects,
      t_insert_list, t_test_ms, t_select_delete, t_ets_dets,
@@ -1759,6 +1761,14 @@ update_counter_do(Opts) ->
     OrdSet = ets_new(ordered_set,[ordered_set | Opts]),
     update_counter_for(Set),
     update_counter_for(OrdSet),
+    ets:delete_all_objects(Set),
+    ets:delete_all_objects(OrdSet),
+    ets:safe_fixtable(Set, true),
+    ets:safe_fixtable(OrdSet, true),
+    update_counter_for(Set),
+    update_counter_for(OrdSet),
+    ets:safe_fixtable(Set, false),
+    ets:safe_fixtable(OrdSet, false),
     ets:delete(Set),
     ets:delete(OrdSet),
     update_counter_neg(Opts).
@@ -1778,10 +1788,14 @@ update_counter_for(T) ->
 		      ?line {NewObj, Ret} = uc_mimic(Obj,Arg3),
 		      ArgHash = erlang:phash2({T,a,Arg3}),
 		      %%io:format("update_counter(~p, ~p, ~p) expecting ~p\n",[T,a,Arg3,Ret]),
+                      [DefaultObj] = ets:lookup(T, a),
 		      ?line Ret = ets:update_counter(T,a,Arg3),
+                      Ret = ets:update_counter(T, b, Arg3, DefaultObj),   % Use other key
 		      ?line ArgHash = erlang:phash2({T,a,Arg3}),
 		      %%io:format("NewObj=~p~n ",[NewObj]),
 		      ?line [NewObj] = ets:lookup(T,a),
+                      true = ets:lookup(T, b) =:= [setelement(1, NewObj, b)],
+                      ets:delete(T, b),
 		      Myself(NewObj,Times-1,Arg3,Myself)
 	      end,		  
 
@@ -2005,6 +2019,44 @@ evil_counter_1(0, T) ->
 evil_counter_1(Iter, T) ->
     ets:update_counter(T, dracula, 1),
     evil_counter_1(Iter-1, T).
+
+update_counter_with_default(Config) when is_list(Config) ->
+	repeat_for_opts(update_counter_with_default_do).
+
+update_counter_with_default_do(Opts) ->
+    T1 = ets_new(a, [set | Opts]),
+    %% Insert default object.
+    3 = ets:update_counter(T1, foo, 2, {beaufort,1}),
+    %% Increment.
+    5 = ets:update_counter(T1, foo, 2, {cabecou,1}),
+    %% Increment with list.
+    [9] = ets:update_counter(T1, foo, [{2,4}], {camembert,1}),
+    %% Same with non-immediate key.
+    3 = ets:update_counter(T1, {foo,bar}, 2, {{chaource,chevrotin},1}),
+    5 = ets:update_counter(T1, {foo,bar}, 2, {{cantal,comté},1}),
+    [9] = ets:update_counter(T1, {foo,bar}, [{2,4}], {{emmental,de,savoie},1}),
+    %% Same with ordered set.
+    T2 = ets_new(b, [ordered_set | Opts]),
+    3 = ets:update_counter(T2, foo, 2, {maroilles,1}),
+    5 = ets:update_counter(T2, foo, 2, {mimolette,1}),
+    [9] = ets:update_counter(T2, foo, [{2,4}], {morbier,1}),
+    3 = ets:update_counter(T2, {foo,bar}, 2, {{laguiole},1}),
+    5 = ets:update_counter(T2, {foo,bar}, 2, {{saint,nectaire},1}),
+    [9] = ets:update_counter(T2, {foo,bar}, [{2,4}], {{rocamadour},1}),
+    %% Arithmetically-equal keys.
+    3 = ets:update_counter(T2, 1.0, 2, {1,1}),
+    5 = ets:update_counter(T2, 1, 2, {1,1}),
+    7 = ets:update_counter(T2, 1, 2, {1.0,1}),
+    %% Same with reversed type difference.
+    3 = ets:update_counter(T2, 2, 2, {2.0,1}),
+    5 = ets:update_counter(T2, 2.0, 2, {2.0,1}),
+    7 = ets:update_counter(T2, 2.0, 2, {2,1}),
+    %% bar is not an integer.
+    {'EXIT',{badarg,_}} = (catch ets:update_counter(T1, qux, 3, {saint,félicien})),
+    %% No third element in default value.
+    {'EXIT',{badarg,_}} = (catch ets:update_counter(T1, qux, [{3,1}], {roquefort,1})),
+
+    ok.
 
 fixtable_next(doc) ->
     ["Check that a first-next sequence always works on a fixed table"];


### PR DESCRIPTION
A story of forbidden love between ets:update_counter/3 and dict:update/4. This new function is an extension of the former and introduces a default value as in the latter. If the key isn't found in the table, the default object is inserted and no elements are incremented.

That new BIF fails for the same reasons as ets:update_counter/3 and if:
 * the default object isn't a tuple;
 * one of the default object's elements mentioned in the operation list isn't an integer.

I have access to neither SPARC nor PPC, so I couldn't test that part of my HiPE changes.