### PR TITLE
Include documentation of cerl and cerl_trees

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -11,6 +11,11 @@
 /common_test/doc/src/ct_telnet.xml
 /common_test/doc/src/unix_telnet.xml
 
+# compiler
+
+/compiler/doc/src/cerl.xml
+/compiler/doc/src/cerl_trees.xml
+
 # edoc
 
 /edoc/doc/src/chapter.xml

--- a/lib/compiler/doc/src/Makefile
+++ b/lib/compiler/doc/src/Makefile
@@ -32,10 +32,20 @@ APPLICATION=compiler
 RELSYSDIR = $(RELEASE_PATH)/lib/$(APPLICATION)-$(VSN)
 
 # ----------------------------------------------------
+# Man page source directory (with .erl files)
+# ----------------------------------------------------
+SRC_DIR = $(ERL_TOP)/lib/compiler/src
+
+# ----------------------------------------------------
 # Target Specs
 # ----------------------------------------------------
 XML_APPLICATION_FILES = ref_man.xml
-XML_REF3_FILES = compile.xml
+GEN_XML_REF3_FILES = \
+	cerl.xml \
+	cerl_trees.xml
+XML_REF3_FILES = \
+	$(GEN_XML_REF3_FILES) \
+	compile.xml
 
 XML_PART_FILES = part_notes.xml part_notes_history.xml
 XML_CHAPTER_FILES = notes.xml notes_history.xml
@@ -82,6 +92,9 @@ pdf: $(TOP_PDF_FILE)
 html: gifs $(HTML_REF_MAN_FILE)
 
 man: $(MAN3_FILES)
+
+$(GEN_XML_REF3_FILES):
+	escript $(DOCGEN)/priv/bin/xml_from_edoc.escript $(SRC_DIR)/$(@:%.xml=%.erl)
 
 gifs: $(GIF_FILES:%=$(HTMLDIR)/%)
 

--- a/lib/compiler/doc/src/ref_man.xml
+++ b/lib/compiler/doc/src/ref_man.xml
@@ -33,6 +33,8 @@
       code to byte-code. The highly compact byte-code is executed by
       the Erlang emulator.</p>
   </description>
+  <xi:include href="cerl.xml"/>
+  <xi:include href="cerl_trees.xml"/>
   <xi:include href="compile.xml"/>
 </application>
 


### PR DESCRIPTION
More people are using Core Erlang now, these two utility modules should be documented.