### PR TITLE
Display labels in observer's update refresh interval slider

### DIFF
--- a/lib/wx/include/wx.hrl
+++ b/lib/wx/include/wx.hrl
@@ -2515,7 +2515,9 @@
 -define(wxSL_RIGHT, 256).
 -define(wxSL_TOP, 128).
 -define(wxSL_LEFT, 64).
--define(wxSL_LABELS, 24576).
+-define(wxSL_MIN_MAX_LABELS, 8192).
+-define(wxSL_VALUE_LABEL, 16384).
+-define(wxSL_LABELS, ?wxSL_MIN_MAX_LABELS bor ?wxSL_VALUE_LABEL). % 24576
 -define(wxSL_AUTOTICKS, ?wxSL_TICKS).
 -define(wxSL_TICKS, 16).
 -define(wxSL_VERTICAL, ?wxVERTICAL).


### PR DESCRIPTION
Wx's `wx_SL_LABELS` macro seems to be wrongly set to 32. According to `wxWidget`'s official `slider.h` [file](http://docs.wxwidgets.org/3.0/slider_8h.html#ab11c6aa70bee53b6af0f4d8b4d9a6f7d), `wx_SL_LABELS` should be set to  24576 instead.

Missing `wxSL_MIN_MAX_LABELS` and `wx_VALUE_LABEL` macros are also introduced in this patch.

I noticed this error because the observer application was not displaying the labels of the slider widget. This error should be affecting other wx-based applications making use of the slider widget.

This is how observer's update refresh interval look like before this patch:
![slider-before](https://cloud.githubusercontent.com/assets/603610/2942563/af054392-d9b6-11e3-9476-6aa4a5d0bda6.png)

This is the result after applying the patch:
![slider-after](https://cloud.githubusercontent.com/assets/603610/2942451/9681c392-d9b4-11e3-8541-b53af3c1e4b5.png)
