### PR TITLE
Specify the spec of lists:append/2

### DIFF
--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -107,8 +107,8 @@ reverse(_, _) ->
 
 -spec append(List1, List2) -> List3 when
       List1 :: [T],
-      List2 :: [T],
-      List3 :: [T],
+      List2 :: any(),
+      List3 :: maybe_improper_list(),
       T :: term().
 
 append(L1, L2) -> L1 ++ L2.


### PR DESCRIPTION
Adding to the expected behaviour of '++' on proper lists we have
- 4 = [] ++ 4
- and [1|4] = [1] ++ 4

The spec should mention this behaviour on improper lists.
