### PR TITLE
Fix efile_openfile() to handle stat() failure

### DIFF
--- a/erts/emulator/drivers/unix/unix_efile.c
+++ b/erts/emulator/drivers/unix/unix_efile.c
@@ -360,7 +360,12 @@ efile_openfile(Efile_error* errInfo,	/* Where to return error codes. */
     int fd;
     int mode;			/* Open mode. */
 
-    if (stat(name, &statbuf) >= 0 && !ISREG(statbuf)) {
+    if (stat(name, &statbuf) < 0) {
+	/* statbuf is undefined: if the caller depends on it,
+	   i.e. invoke_read_file(), fail the call immediately */
+	if (pSize && flags == EFILE_MODE_READ)
+	    return check_error(-1, errInfo);
+    } else if (!ISREG(statbuf)) {
 	/*
 	 * For UNIX only, here is some ugly code to allow
 	 * /dev/null to be opened as a file.


### PR DESCRIPTION
If the initial stat() fails then efile_openfile() will still proceed
to open() the file.  If that succeeds and the caller passed a non-NULL
pSize, then it will copy bogus data from the statbuf into *pSize.  This
has been observed to cause file:read_file/1 to return truncated file
data with no error indication.

The use case involved a large file system mounted via NFS, with some
directories containing large number of files, and NFS mount options
that allow the NFS client to return EIO if the NFS server does not
respond quickly enough.  Depending on the caching state of the client
and server machines, a few stat() calls (fewer than 1 per 10 million)
would take long enough to trigger EIO errors, but subsequent open()
calls would succeed, and read_file/1 would return truncated data.  This
sequence of events has been observed via "strace" on beam.smp.

Signed-off-by: Mikael Pettersson mikpelinux@gmail.com
