### PR TITLE
Stream body with no content length

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -1226,6 +1226,7 @@ handle_response(#state{request      = Request,
 	    handle_queue(State#state{request = undefined}, Data);
 	{ok, Msg, Data} ->
 	    ?hcrd("handle response - ok", []),
+	    stream_remaining_body(Body, Request, StatusLine),
 	    end_stream(StatusLine, Request),
 	    NewState = maybe_send_answer(Request, Msg, State),
 	    handle_queue(NewState, Data); 
@@ -1634,6 +1635,10 @@ start_stream(_StatusLine, _Headers, Request) ->
     ?hcrt("start stream - no op", []),
     {ok, Request}.
 
+stream_remaining_body(<<>>, _, _) ->
+    ok;
+stream_remaining_body(Body, Request, {_, Code, _}) ->
+    stream(Body, Request, Code).
 
 %% Note the end stream message is handled by httpc_response and will
 %% be sent by answer_request

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -94,6 +94,7 @@ only_simulated() ->
      trace,
      stream_once,
      stream_single_chunk,
+     stream_no_length,
      no_content_204,
      tolerate_missing_CR,
      userinfo,
@@ -386,6 +387,15 @@ stream_single_chunk() ->
 stream_single_chunk(Config) when is_list(Config) ->
     Request  = {url(group_name(Config), "/single_chunk.html", Config), []},
     stream_test(Request, {stream, self}).
+%%-------------------------------------------------------------------------
+stream_no_length() ->
+    [{doc, "Test the option stream for asynchrony requests with HTTP 1.0 "
+      "body end on closed connection" }].
+stream_no_length(Config) when is_list(Config) ->
+    Request1 = {url(group_name(Config), "/http_1_0_no_length_single.html", Config), []},
+    stream_test(Request1, {stream, self}),
+    Request2 = {url(group_name(Config), "/http_1_0_no_length_multiple.html", Config), []},
+    stream_test(Request2, {stream, self}).
 
 
 %%-------------------------------------------------------------------------
@@ -1650,6 +1660,22 @@ handle_uri(_,"/single_chunk.html",_,_,Socket,_) ->
         http_chunk:encode("obar</BODY></HTML>") ++
         http_chunk:encode_last(),
     send(Socket, Chunk);
+
+handle_uri(_,"/http_1_0_no_length_single.html",_,_,Socket,_) ->
+    Body = "HTTP/1.0 200 ok\r\n"
+        "Content-type:text/plain\r\n\r\n"
+        "single packet",
+    send(Socket, Body),
+    close(Socket);
+
+handle_uri(_,"/http_1_0_no_length_multiple.html",_,_,Socket,_) ->
+    Head = "HTTP/1.0 200 ok\r\n"
+        "Content-type:text/plain\r\n\r\n"
+        "multiple packets, ",
+    send(Socket, Head),
+    %% long body to make sure it will be sent in multiple tcp packets
+    send(Socket, string:copies("other multiple packets ", 200)),
+    close(Socket);
 
 handle_uri(_,"/once.html",_,_,Socket,_) ->
     Head =  "HTTP/1.1 200 ok\r\n" ++


### PR DESCRIPTION
Receiving HTTP response with no Content-length header and
with body ending on closed connection should give the complete
response body contents up to the last byte received.
