### PR TITLE
jinterface: fix bug in equality for OtpErlangFun

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpErlangFun.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpErlangFun.java
@@ -94,7 +94,7 @@ public class OtpErlangFun extends OtpErlangObject implements Serializable {
 		return false;
 	    }
 	} else {
-	    if (!md5.equals(f.md5)) {
+	    if (!Arrays.equals(md5, f.md5)) {
 		return false;
 	    }
 	}
@@ -104,7 +104,7 @@ public class OtpErlangFun extends OtpErlangObject implements Serializable {
 	if (freeVars == null) {
 	    return f.freeVars == null;
 	}
-	return freeVars.equals(f.freeVars);
+	return Arrays.equals(freeVars, f.freeVars);
     }
     
     @Override

--- a/lib/jinterface/test/jinterface_SUITE.erl
+++ b/lib/jinterface/test/jinterface_SUITE.erl
@@ -38,7 +38,8 @@
 	 java_exit_with_reason_any_term/1,
 	 status_handler_localStatus/1, status_handler_remoteStatus/1,
 	 status_handler_connAttempt/1,
-	 maps/1
+	 maps/1,
+	 fun_equals/1
      ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -106,7 +107,8 @@ fundamental() ->
      register_and_whereis, % RegisterAndWhereis.java
      get_names,            % GetNames.java
      boolean_atom,         % BooleanAtom.java
-     maps                  % Maps.java
+     maps,                 % Maps.java
+     fun_equals            % FunEquals.java
     ].
 
 ping() ->
@@ -688,6 +690,18 @@ maps(Config) when is_list(Config) ->
     ok = jitu:java(?config(java, Config),
            ?config(data_dir, Config),
            "Maps",
+           []).
+
+%%%-----------------------------------------------------------------
+fun_equals(doc) ->
+    ["FunEquals.java: "
+     "Test OtpErlangFun.equals()"];
+fun_equals(suite) ->
+    [];
+fun_equals(Config) when is_list(Config) ->
+    ok = jitu:java(?config(java, Config),
+           ?config(data_dir, Config),
+           "FunEquals",
            []).
 
 %%%-----------------------------------------------------------------

--- a/lib/jinterface/test/jinterface_SUITE_data/FunEquals.java
+++ b/lib/jinterface/test/jinterface_SUITE_data/FunEquals.java
@@ -1,0 +1,71 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2004-2010. All Rights Reserved.
+ *
+ * The contents of this file are subject to the Erlang Public License,
+ * Version 1.1, (the "License"); you may not use this file except in
+ * compliance with the License. You should have received a copy of the
+ * Erlang Public License along with this software. If not, it can be
+ * retrieved online at http://www.erlang.org/.
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+ * the License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+import java.util.Arrays;
+
+import com.ericsson.otp.erlang.*;
+
+public class FunEquals {
+
+    /*
+      Implements test case jinterface_SUITE:fun_equals/1
+
+      Test the function OtpErlangFun.equals()
+    */
+
+    public static void main(String argv[]) {
+
+        OtpErlangPid pid = new OtpErlangPid("here", 4, 5, 0);
+        String module = "mod";
+        int arity = 2;
+        byte[] md5 = new byte[]{3,5,7};
+        int index = 2;
+        long old_index = 1;
+        long uniq= 2;
+        OtpErlangObject[] freeVars = new OtpErlangObject[]{
+                new OtpErlangAtom("hej"), new OtpErlangLong(9)
+            };
+
+        OtpErlangFun f1 = new OtpErlangFun(pid, module, arity, md5,
+                index, old_index, uniq, freeVars);
+        OtpErlangFun f2 = new OtpErlangFun(pid, module, arity, copyArray(md5),
+                index, old_index, uniq, copyArray(freeVars));
+
+        if(!f1.equals(f2))
+            fail(1);
+
+    }
+
+    private static void fail(int reason) {
+        System.exit(reason);
+    }
+
+    private static byte[] copyArray(byte[] source) {
+        byte[] result = new byte[source.length];
+        System.arraycopy(source, 0, result, 0, source.length);
+        return result;
+    }
+
+    private static OtpErlangObject[] copyArray(OtpErlangObject[] source) {
+        OtpErlangObject[] result = new OtpErlangObject[source.length];
+        System.arraycopy(source, 0, result, 0, source.length);
+        return result;
+    }
+
+}

--- a/lib/jinterface/test/jinterface_SUITE_data/Makefile.src
+++ b/lib/jinterface/test/jinterface_SUITE_data/Makefile.src
@@ -47,7 +47,8 @@ JAVA_FILES = \
 	MboxSendReceive.java \
 	MboxLinkUnlink.java \
 	NodeStatusHandler.java \
-	Maps.java
+	Maps.java \
+	FunEquals.java
 
 CLASS_FILES = $(JAVA_FILES:.java=.class)
 


### PR DESCRIPTION
Arrays (here: md5 and freeVars) must not be compared with equals, which
is broken (compares identity).
