### PR TITLE
Properly handle fields too short in io_lib_format

### DIFF
--- a/lib/stdlib/src/io_lib_format.erl
+++ b/lib/stdlib/src/io_lib_format.erl
@@ -255,7 +255,7 @@ term(T, none, _Adj, none, _Pad) -> T;
 term(T, none, Adj, P, Pad) -> term(T, P, Adj, P, Pad);
 term(T, F, Adj, P0, Pad) ->
     L = lists:flatlength(T),
-    P = case P0 of none -> erlang:min(L, F); _ -> P0 end,
+    P = erlang:min(L, case P0 of none -> F; _ -> min(P0, F) end),
     if
 	L > P ->
 	    adjust(chars($*, P), chars(Pad, F-P), Adj);

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -30,7 +30,7 @@
 	 io_fread_newlines/1, otp_8989/1, io_lib_fread_literal/1,
 	 printable_range/1,
 	 io_lib_print_binary_depth_one/1, otp_10302/1, otp_10755/1,
-	 otp_10836/1]).
+         otp_10836/1, io_lib_width_too_small/1]).
 
 -export([pretty/2]).
 
@@ -69,7 +69,8 @@ all() ->
      io_lib_collect_line_3_wb, cr_whitespace_in_string,
      io_fread_newlines, otp_8989, io_lib_fread_literal,
      printable_range,
-     io_lib_print_binary_depth_one, otp_10302, otp_10755, otp_10836].
+     io_lib_print_binary_depth_one, otp_10302, otp_10755, otp_10836,
+     io_lib_width_too_small].
 
 groups() -> 
     [].
@@ -2213,3 +2214,8 @@ compile_file(File, Text, Config) ->
     try compile:file(Fname, [return])
     after ok %file:delete(Fname)
     end.
+
+io_lib_width_too_small(Config) ->
+    "**" = lists:flatten(io_lib:format("~2.3w", [3.14])),
+    "**" = lists:flatten(io_lib:format("~2.5w", [3.14])),
+    ok.


### PR DESCRIPTION
Values for which the precision or field width were too small in io_lib_format could trigger an infinite loop or crash in term/5.

@richcarl
