### PR TITLE
Add manual tick support

### DIFF
--- a/lib/erl_interface/doc/src/ei_connect.xml
+++ b/lib/erl_interface/doc/src/ei_connect.xml
@@ -75,6 +75,28 @@
       the return values and the semantics from the functions without 
       the <c><![CDATA[_tmo]]></c> suffix.</p>
   </section>
+
+  <section>
+    <title>With Tick functions</title>
+    <p>Most receive functions appear in a version with the suffix
+      <c><![CDATA[_wt]]></c> appended to the function name. These functions
+      do not automatically respond to <em>tick</em> requests from connected nodes.
+      When a <em>tick</em> is received, these functions will still return <c><![CDATA[ERL_TICK]]></c>
+      but the reply (a <em>tock</em>) will not be sent. The reply must be sent explicitly using the
+      <c><![CDATA[ei_send_tock]]></c> function. Failure to do so will cause the remote node to disconnect.</p>
+    <p>The semantics is this; when dealing with multi-threaded code that writes to the connection, it
+      is neccessary to protect the socket with a mutex. However, because the non <c><![CDATA[_wt]]></c>
+      functions automatically respond to the <em>tick</em>, there is no way to protect the socket during
+      the write and data corruption can occur. It is not possible to wrap the <c><![CDATA[ei_receive_]]></c>
+      calls in a mutex as this is a blocking call and would prevent the other threads from writing to the socket.
+      It can be done with the <c><![CDATA[_tmo]]></c> versions of the function, however setting the timeout becomes
+      arbitrary and there is the possibility that the function will timeout before a message has been completely received.</p>
+    <p>The <c><![CDATA[_wt]]></c> versions allow for the <c><![CDATA[ei_receive_]]></c> functions to block indefinitely. When
+      a <em>tick</em> is received, the <c><![CDATA[ei_send_tock]]></c> function can be called from within a mutex to ensure all
+      writes to the socket are properly protected.</p>
+    <p>In short, the <c><![CDATA[_wt]]></c> functions are useful when multilple threads might write to the socket. In single threaded
+       applications or where writes are always done from the same thread that calls <c><![CDATA[ei_receive_]]></c>, the non <c><![CDATA[_wt]]></c> functions can safely be used.</p> 
+      </section> 
   <funcs>
     <func>
       <name><ret>int</ret><nametext>ei_connect_init(ei_cnode* ec, const char* this_node_name, const char *cookie, short creation)</nametext></name>
@@ -223,10 +245,26 @@ fd = ei_xconnect(&ec, &addr, ALIVE);
       </desc>
     </func>
     <func>
+      <name><ret>int</ret><nametext>ei_receive_wt(int fd, unsigned char* bufp, int bufsize)</nametext></name>
+      <fsummary>Receive a message with tick handling set to manual</fsummary>
+      <desc>
+        <p>ei_receive with tick handling set to manual,
+          see the description at the beginning of this document.</p>
+      </desc>
+    </func>
+    <func>
       <name><ret>int</ret><nametext>ei_receive_tmo(int fd, unsigned char* bufp, int bufsize, unsigned timeout_ms)</nametext></name>
       <fsummary>Receive a message with optional timeout</fsummary>
       <desc>
         <p>ei_receive with an optional timeout argument,
+          see the description at the beginning of this document.</p>
+      </desc>
+    </func>
+    <func>
+      <name><ret>int</ret><nametext>ei_receive_tmo_wt(int fd, unsigned char* bufp, int bufsize, unsigned timeout_ms)</nametext></name>
+      <fsummary>Receive a message with optional timeout and tick handling set to manual</fsummary>
+      <desc>
+        <p>ei_receive with optional timeout and tick handling set to manual,
           see the description at the beginning of this document.</p>
       </desc>
     </func>
@@ -276,12 +314,39 @@ typedef struct {
       </desc>
     </func>
     <func>
-      <name><ret>int</ret><nametext>ei_receive_msg_tmo(int fd, erlang_msg* msg, ei_x_buff* x, unsigned imeout_ms)</nametext></name>
+      <name><ret>int</ret><nametext>ei_receive_msg_tmo(int fd, erlang_msg* msg, ei_x_buff* x, unsigned timeout_ms)</nametext></name>
       <name><ret>int</ret><nametext>ei_xreceive_msg_tmo(int fd, erlang_msg* msg, ei_x_buff* x, unsigned timeout_ms)</nametext></name>
       <fsummary>Receive a message with optional timeout</fsummary>
       <desc>
         <p>ei_receive_msg and ei_xreceive_msg with an optional timeout argument,
           see the description at the beginning of this document.</p>
+      </desc>
+    </func>
+    <func>
+      <name><ret>int</ret><nametext>ei_receive_msg_tmo_wt(int fd, erlang_msg* msg, ei_x_buff* x, unsigned timeout_ms)</nametext></name>
+      <name><ret>int</ret><nametext>ei_xreceive_msg_tmo_wt(int fd, erlang_msg* msg, ei_x_buff* x, unsigned timeout_ms)</nametext></name>
+      <fsummary>Receive a message with optional timeout and tick handling set to manual</fsummary>
+      <desc>
+        <p>ei_receive_msg and ei_xreceive_msg with an optional timeout argument and tick handling set to manual,
+          see the description at the beginning of this document.</p>
+      </desc>
+    </func>
+      <func>
+      <name><ret>void</ret><nametext>ei_send_tock(int fd)</nametext></name>
+      <fsummary>Sends a tock (a reply to the tick heartbeat message)</fsummary>
+      <desc>
+        <p><c><![CDATA[ei_send_tock]]></c> sends a tock (a reply to the tick heartbeat message).
+          This is <em>only</em> necessary when using the <c><![CDATA[_wt]]></c> versions of the <c><![CDATA[ei_receive]]></c> functions.
+          For more information see the description at the beginning of this document.</p>
+      </desc>
+    </func>
+    <func>
+      <name><ret>void</ret><nametext>ei_send_tock(int fd, unsigned timeout_ms)</nametext></name>
+      <fsummary>Sends a tock (a reply to the tick heartbeat message) with optional timeout</fsummary>
+      <desc>
+        <p><c><![CDATA[ei_send_tock]]></c> sends a tock (a reply to the tick heartbeat message) with an optional timeout.
+          This is <em>only</em> necessary when using the <c><![CDATA[_wt]]></c> versions of the <c><![CDATA[ei_receive]]></c> functions.
+          For more information see the description at the beginning of this document.</p>
       </desc>
     </func>
     <func>

--- a/lib/erl_interface/include/ei.h
+++ b/lib/erl_interface/include/ei.h
@@ -99,6 +99,9 @@
 #define ERL_DEMONITOR_P    20
 #define ERL_MONITOR_P_EXIT 21
 
+/* For enabling / disabling auto tick */
+#define ERL_TICK_AUTO      0
+#define ERL_TICK_MANUAL    1
 
 /* -------------------------------------------------------------------- */
 /*           Defines used for ei_get_type_internal() output             */
@@ -329,6 +332,17 @@ int ei_receive_msg(int fd, erlang_msg* msg, ei_x_buff* x);
 int ei_receive_msg_tmo(int fd, erlang_msg* msg, ei_x_buff* x, unsigned ms);
 int ei_xreceive_msg(int fd, erlang_msg* msg, ei_x_buff* x);
 int ei_xreceive_msg_tmo(int fd, erlang_msg* msg, ei_x_buff* x, unsigned ms);
+
+int ei_receive_wt(int fd, unsigned char *bufp, int bufsize);
+int ei_receive_tmo_wt(int fd, unsigned char *bufp, int bufsize, unsigned ms);
+int ei_receive_msg_wt(int fd, erlang_msg* msg, ei_x_buff* x);
+int ei_receive_msg_tmo_wt(int fd, erlang_msg* msg, ei_x_buff* x, unsigned ms);
+int ei_xreceive_msg_wt(int fd, erlang_msg *msg, ei_x_buff *x);
+int ei_xreceive_msg_tmo_wt(int fd, erlang_msg *msg, ei_x_buff *x, unsigned ms);
+
+
+void ei_send_tock_tmo(int fd, int ms);
+void ei_send_tock(int fd);
 
 int ei_send(int fd, erlang_pid* to, char* buf, int len);
 int ei_send_tmo(int fd, erlang_pid* to, char* buf, int len, unsigned ms);

--- a/lib/erl_interface/src/Makefile.in
+++ b/lib/erl_interface/src/Makefile.in
@@ -406,7 +406,8 @@ MISCSRC = \
 	misc/eimd5.c \
 	misc/get_type.c \
 	misc/show_msg.c \
-	misc/ei_compat.c
+	misc/ei_compat.c\
+	misc/ei_send_tock.c
 
 REGISTRYSRC = \
 	registry/hash_dohash.c \

--- a/lib/erl_interface/src/connect/ei_connect_int.h
+++ b/lib/erl_interface/src/connect/ei_connect_int.h
@@ -112,7 +112,14 @@ const char* ei_getfdcookie(int fd);
 short       ei_thiscreation(const ei_cnode* ec);
 const char *ei_thiscookie(const ei_cnode* ec);
 
+int ei_do_receive_msg_wt(int fd, int staticbuffer_p, 
+		      erlang_msg* msg, ei_x_buff* x, unsigned ms, int auto_tick);
+
 int ei_do_receive_msg(int fd, int staticbuffer_p, 
 		      erlang_msg* msg, ei_x_buff* x, unsigned ms);
+
+int ei_receive_tmo_wt_actual(int fd, unsigned char *bufp, int bufsize, unsigned ms, int auto_tick);
+
+int ei_receive_wt_actual(int fd, unsigned char *bufp, int bufsize, int auto_tick);
 
 #endif /* _EI_CONNECT_H */

--- a/lib/erl_interface/src/connect/eirecv.h
+++ b/lib/erl_interface/src/connect/eirecv.h
@@ -20,7 +20,9 @@
 #define _EIRECV_H
 
 /* Internal interface */
+int ei_recv_internal_wt(int fd, char **mbufp, int *bufsz, erlang_msg *msg,
+		     int *msglenp, int staticbufp, unsigned ms, int auto_tick);
+
 int ei_recv_internal(int fd, char **mbufp, int *bufsz, erlang_msg *msg,
 		     int *msglenp, int staticbufp, unsigned ms);
-
 #endif /* _EIRECV_H */

--- a/lib/erl_interface/src/depend.mk
+++ b/lib/erl_interface/src/depend.mk
@@ -1,176 +1,190 @@
 # Generated dependency rules
-$(ST_OBJDIR)/ei_connect.o: connect/ei_connect.c $(TARGET)/config.h \
-  misc/eidef.h ../include/ei.h misc/eiext.h misc/ei_portio.h \
-  misc/ei_internal.h connect/ei_connect_int.h misc/ei_locking.h \
-  connect/eisend.h connect/eirecv.h misc/eimd5.h misc/putget.h \
-  connect/ei_resolve.h epmd/ei_epmd.h
-$(ST_OBJDIR)/ei_resolve.o: connect/ei_resolve.c $(TARGET)/config.h \
-  misc/eidef.h ../include/ei.h connect/ei_resolve.h misc/ei_locking.h
+$(ST_OBJDIR)/ei_connect.o: connect/ei_connect.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_portio.h misc/ei_internal.h connect/ei_connect_int.h \
+ misc/ei_locking.h connect/eisend.h connect/eirecv.h misc/eimd5.h \
+ misc/putget.h connect/ei_resolve.h epmd/ei_epmd.h
+$(ST_OBJDIR)/ei_resolve.o: connect/ei_resolve.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h connect/ei_resolve.h \
+ misc/ei_locking.h
 $(ST_OBJDIR)/eirecv.o: connect/eirecv.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eirecv.h misc/ei_portio.h \
-  misc/ei_internal.h misc/putget.h misc/ei_trace.h misc/show_msg.h
+ ../include/ei.h misc/eiext.h connect/eirecv.h misc/ei_portio.h \
+ misc/ei_internal.h misc/putget.h misc/ei_trace.h misc/show_msg.h
 $(ST_OBJDIR)/send.o: connect/send.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
-  connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
-  misc/show_msg.h
+ ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
+ connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
+ misc/ei_portio.h misc/show_msg.h
 $(ST_OBJDIR)/send_exit.o: connect/send_exit.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/ei_connect_int.h misc/ei_trace.h \
-  misc/ei_internal.h misc/putget.h misc/show_msg.h
-$(ST_OBJDIR)/send_reg.o: connect/send_reg.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
-  connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
-  misc/show_msg.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/ei_connect_int.h misc/ei_trace.h \
+ misc/ei_internal.h misc/putget.h misc/ei_portio.h misc/show_msg.h
+$(ST_OBJDIR)/send_reg.o: connect/send_reg.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h misc/putget.h connect/ei_connect_int.h \
+ misc/ei_internal.h misc/ei_trace.h misc/ei_portio.h misc/show_msg.h
 $(ST_OBJDIR)/decode_atom.o: decode/decode_atom.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_big.o: decode/decode_big.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
-$(ST_OBJDIR)/decode_bignum.o: decode/decode_bignum.c $(TARGET)/config.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(ST_OBJDIR)/decode_bignum.o: decode/decode_bignum.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h
 $(ST_OBJDIR)/decode_binary.o: decode/decode_binary.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_boolean.o: decode/decode_boolean.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_char.o: decode/decode_char.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_double.o: decode/decode_double.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_fun.o: decode/decode_fun.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_malloc.h decode/decode_skip.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_malloc.h decode/decode_skip.h misc/putget.h
 $(ST_OBJDIR)/decode_intlist.o: decode/decode_intlist.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_list_header.o: decode/decode_list_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_long.o: decode/decode_long.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_pid.o: decode/decode_pid.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_port.o: decode/decode_port.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_ref.o: decode/decode_ref.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_skip.o: decode/decode_skip.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  decode/decode_skip.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ decode/decode_skip.h
 $(ST_OBJDIR)/decode_string.o: decode/decode_string.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_trace.o: decode/decode_trace.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/putget.h
 $(ST_OBJDIR)/decode_tuple_header.o: decode/decode_tuple_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_ulong.o: decode/decode_ulong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_version.o: decode/decode_version.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_longlong.o: decode/decode_longlong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/decode_ulonglong.o: decode/decode_ulonglong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_atom.o: encode/encode_atom.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
-$(ST_OBJDIR)/encode_bignum.o: encode/encode_bignum.c $(TARGET)/config.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(ST_OBJDIR)/encode_big.o: encode/encode_big.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
+$(ST_OBJDIR)/encode_bignum.o: encode/encode_bignum.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h
 $(ST_OBJDIR)/encode_binary.o: encode/encode_binary.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_boolean.o: encode/encode_boolean.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_char.o: encode/encode_char.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_double.o: encode/encode_double.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_fun.o: encode/encode_fun.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_list_header.o: encode/encode_list_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_long.o: encode/encode_long.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_pid.o: encode/encode_pid.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_port.o: encode/encode_port.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_ref.o: encode/encode_ref.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_string.o: encode/encode_string.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_trace.o: encode/encode_trace.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/putget.h
 $(ST_OBJDIR)/encode_tuple_header.o: encode/encode_tuple_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_ulong.o: encode/encode_ulong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_version.o: encode/encode_version.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(ST_OBJDIR)/encode_longlong.o: encode/encode_longlong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
 $(ST_OBJDIR)/encode_ulonglong.o: encode/encode_ulonglong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h
-$(ST_OBJDIR)/epmd_port.o: epmd/epmd_port.c misc/ei_internal.h epmd/ei_epmd.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
+$(ST_OBJDIR)/epmd_port.o: epmd/epmd_port.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ epmd/ei_epmd.h misc/ei_portio.h misc/putget.h
 $(ST_OBJDIR)/epmd_publish.o: epmd/epmd_publish.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
-  misc/putget.h ../include/erl_interface.h epmd/ei_epmd.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ misc/putget.h epmd/ei_epmd.h misc/ei_portio.h
 $(ST_OBJDIR)/epmd_unpublish.o: epmd/epmd_unpublish.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
-  misc/putget.h ../include/erl_interface.h epmd/ei_epmd.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ misc/putget.h epmd/ei_epmd.h misc/ei_portio.h
 $(ST_OBJDIR)/ei_decode_term.o: misc/ei_decode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_decode_term.h misc/putget.h
-$(ST_OBJDIR)/ei_format.o: misc/ei_format.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/ei_malloc.h misc/ei_format.h
-$(ST_OBJDIR)/ei_locking.o: misc/ei_locking.c $(TARGET)/config.h \
-  misc/ei_malloc.h misc/ei_locking.h
-$(ST_OBJDIR)/ei_malloc.o: misc/ei_malloc.c misc/ei_malloc.h
-$(ST_OBJDIR)/ei_portio.o: misc/ei_portio.c misc/ei_portio.h misc/ei_internal.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_decode_term.h misc/putget.h
+$(ST_OBJDIR)/ei_format.o: misc/ei_format.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h \
+ misc/ei_format.h
+$(ST_OBJDIR)/ei_locking.o: misc/ei_locking.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h \
+ misc/ei_locking.h
+$(ST_OBJDIR)/ei_malloc.o: misc/ei_malloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h
+$(ST_OBJDIR)/ei_portio.o: misc/ei_portio.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_portio.h \
+ misc/ei_internal.h
 $(ST_OBJDIR)/ei_printterm.o: misc/ei_printterm.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_printterm.h misc/ei_malloc.h
-$(ST_OBJDIR)/ei_pthreads.o: misc/ei_pthreads.c $(TARGET)/config.h \
-  ../include/ei.h misc/ei_locking.h
-$(ST_OBJDIR)/ei_trace.o: misc/ei_trace.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/ei_trace.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_printterm.h misc/ei_malloc.h
+$(ST_OBJDIR)/ei_pthreads.o: misc/ei_pthreads.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h
+$(ST_OBJDIR)/ei_trace.o: misc/ei_trace.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_trace.h
 $(ST_OBJDIR)/ei_x_encode.o: misc/ei_x_encode.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_x_encode.h \
-  misc/ei_malloc.h
-$(ST_OBJDIR)/eimd5.o: misc/eimd5.c misc/eimd5.h
-$(ST_OBJDIR)/get_type.o: misc/get_type.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h misc/putget.h
-$(ST_OBJDIR)/show_msg.o: misc/show_msg.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h misc/putget.h misc/ei_printterm.h \
-  misc/ei_internal.h misc/show_msg.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_x_encode.h \
+ misc/ei_malloc.h
+$(ST_OBJDIR)/eimd5.o: misc/eimd5.c misc/eidef.h $(TARGET)/config.h \
+ ../include/ei.h misc/eimd5.h
+$(ST_OBJDIR)/get_type.o: misc/get_type.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(ST_OBJDIR)/show_msg.o: misc/show_msg.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_printterm.h misc/ei_internal.h misc/show_msg.h
 $(ST_OBJDIR)/ei_compat.o: misc/ei_compat.c ../include/ei.h misc/ei_internal.h
 $(ST_OBJDIR)/hash_dohash.o: registry/hash_dohash.c registry/hash.h ../include/ei.h
 $(ST_OBJDIR)/hash_foreach.o: registry/hash_foreach.c registry/hash.h ../include/ei.h
@@ -183,277 +197,306 @@ $(ST_OBJDIR)/hash_remove.o: registry/hash_remove.c registry/hash.h ../include/ei
 $(ST_OBJDIR)/hash_resize.o: registry/hash_resize.c registry/hash.h ../include/ei.h
 $(ST_OBJDIR)/hash_rlookup.o: registry/hash_rlookup.c registry/hash.h ../include/ei.h
 $(ST_OBJDIR)/reg_close.o: registry/reg_close.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_delete.o: registry/reg_delete.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_dirty.o: registry/reg_dirty.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_dump.o: registry/reg_dump.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
-  connect/ei_connect_int.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
+ connect/ei_connect_int.h
 $(ST_OBJDIR)/reg_free.o: registry/reg_free.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_get.o: registry/reg_get.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_getf.o: registry/reg_getf.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_geti.o: registry/reg_geti.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_getp.o: registry/reg_getp.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_gets.o: registry/reg_gets.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_make.o: registry/reg_make.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_open.o: registry/reg_open.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_purge.o: registry/reg_purge.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_resize.o: registry/reg_resize.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_restore.o: registry/reg_restore.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
-  connect/ei_connect_int.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
+ connect/ei_connect_int.h
 $(ST_OBJDIR)/reg_set.o: registry/reg_set.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_setf.o: registry/reg_setf.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_seti.o: registry/reg_seti.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_setp.o: registry/reg_setp.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_sets.o: registry/reg_sets.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_stat.o: registry/reg_stat.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/reg_tabstat.o: registry/reg_tabstat.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(ST_OBJDIR)/decode_term.o: legacy/decode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h ../include/erl_interface.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h ../include/erl_interface.h ../include/ei.h
 $(ST_OBJDIR)/encode_term.o: legacy/encode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h ../include/erl_interface.h \
-  legacy/erl_marshal.h legacy/erl_eterm.h legacy/portability.h
-$(ST_OBJDIR)/erl_connect.o: legacy/erl_connect.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_config.h \
-  legacy/erl_connect.h legacy/erl_eterm.h legacy/portability.h \
-  legacy/erl_malloc.h misc/putget.h connect/ei_connect_int.h \
-  misc/ei_locking.h epmd/ei_epmd.h misc/ei_internal.h
-$(ST_OBJDIR)/erl_error.o: legacy/erl_error.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_error.h
-$(ST_OBJDIR)/erl_eterm.o: legacy/erl_eterm.c misc/ei_locking.h \
-  $(TARGET)/config.h connect/ei_resolve.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_eterm.h \
-  legacy/portability.h legacy/erl_malloc.h legacy/erl_marshal.h \
-  legacy/erl_error.h legacy/erl_internal.h misc/ei_internal.h
-$(ST_OBJDIR)/erl_fix_alloc.o: legacy/erl_fix_alloc.c $(TARGET)/config.h \
-  misc/ei_locking.h ../include/erl_interface.h ../include/ei.h \
-  legacy/erl_error.h legacy/erl_malloc.h legacy/erl_fix_alloc.h \
-  legacy/erl_eterm.h legacy/portability.h
-$(ST_OBJDIR)/erl_format.o: legacy/erl_format.c ../include/erl_interface.h \
-  ../include/ei.h legacy/erl_eterm.h legacy/portability.h \
-  legacy/erl_malloc.h legacy/erl_error.h legacy/erl_internal.h
-$(ST_OBJDIR)/erl_malloc.o: legacy/erl_malloc.c ../include/erl_interface.h \
-  ../include/ei.h legacy/erl_fix_alloc.h legacy/erl_malloc.h \
-  legacy/erl_internal.h legacy/erl_eterm.h legacy/portability.h \
-  misc/ei_malloc.h
-$(ST_OBJDIR)/erl_marshal.o: legacy/erl_marshal.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_marshal.h \
-  legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
-  legacy/erl_error.h legacy/erl_internal.h misc/eiext.h misc/putget.h
-$(ST_OBJDIR)/erl_timeout.o: legacy/erl_timeout.c $(TARGET)/config.h \
-  legacy/erl_timeout.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h ../include/erl_interface.h \
+ ../include/ei.h legacy/erl_marshal.h legacy/erl_eterm.h \
+ legacy/portability.h
+$(ST_OBJDIR)/erl_connect.o: legacy/erl_connect.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ misc/putget.h connect/ei_connect_int.h misc/ei_locking.h epmd/ei_epmd.h \
+ misc/ei_internal.h
+$(ST_OBJDIR)/erl_error.o: legacy/erl_error.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_error.h
+$(ST_OBJDIR)/erl_eterm.o: legacy/erl_eterm.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h \
+ connect/ei_resolve.h ../include/erl_interface.h ../include/ei.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ legacy/erl_marshal.h legacy/erl_error.h legacy/erl_internal.h \
+ misc/ei_internal.h misc/putget.h
+$(ST_OBJDIR)/erl_fix_alloc.o: legacy/erl_fix_alloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_error.h \
+ legacy/erl_malloc.h legacy/erl_fix_alloc.h legacy/erl_eterm.h \
+ legacy/portability.h
+$(ST_OBJDIR)/erl_format.o: legacy/erl_format.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_eterm.h \
+ legacy/portability.h legacy/erl_malloc.h legacy/erl_error.h \
+ legacy/erl_internal.h
+$(ST_OBJDIR)/erl_malloc.o: legacy/erl_malloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_fix_alloc.h \
+ legacy/erl_malloc.h legacy/erl_internal.h legacy/erl_eterm.h \
+ legacy/portability.h misc/ei_malloc.h
+$(ST_OBJDIR)/erl_marshal.o: legacy/erl_marshal.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_marshal.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ legacy/erl_error.h legacy/erl_internal.h misc/eiext.h misc/putget.h
+$(ST_OBJDIR)/erl_resolve.o: legacy/erl_resolve.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h connect/ei_resolve.h \
+ connect/ei_connect_int.h epmd/ei_epmd.h
+$(ST_OBJDIR)/erl_timeout.o: legacy/erl_timeout.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_timeout.h
 $(ST_OBJDIR)/global_names.o: legacy/global_names.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 $(ST_OBJDIR)/global_register.o: legacy/global_register.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h ../include/erl_interface.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h ../include/erl_interface.h \
+ ../include/ei.h
 $(ST_OBJDIR)/global_unregister.o: legacy/global_unregister.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 $(ST_OBJDIR)/global_whereis.o: legacy/global_whereis.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 
-$(MT_OBJDIR)/ei_connect.o: connect/ei_connect.c $(TARGET)/config.h \
-  misc/eidef.h ../include/ei.h misc/eiext.h misc/ei_portio.h \
-  misc/ei_internal.h connect/ei_connect_int.h misc/ei_locking.h \
-  connect/eisend.h connect/eirecv.h misc/eimd5.h misc/putget.h \
-  connect/ei_resolve.h epmd/ei_epmd.h
-$(MT_OBJDIR)/ei_resolve.o: connect/ei_resolve.c $(TARGET)/config.h \
-  misc/eidef.h ../include/ei.h connect/ei_resolve.h misc/ei_locking.h
+$(MT_OBJDIR)/ei_connect.o: connect/ei_connect.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_portio.h misc/ei_internal.h connect/ei_connect_int.h \
+ misc/ei_locking.h connect/eisend.h connect/eirecv.h misc/eimd5.h \
+ misc/putget.h connect/ei_resolve.h epmd/ei_epmd.h
+$(MT_OBJDIR)/ei_resolve.o: connect/ei_resolve.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h connect/ei_resolve.h \
+ misc/ei_locking.h
 $(MT_OBJDIR)/eirecv.o: connect/eirecv.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eirecv.h misc/ei_portio.h \
-  misc/ei_internal.h misc/putget.h misc/ei_trace.h misc/show_msg.h
+ ../include/ei.h misc/eiext.h connect/eirecv.h misc/ei_portio.h \
+ misc/ei_internal.h misc/putget.h misc/ei_trace.h misc/show_msg.h
 $(MT_OBJDIR)/send.o: connect/send.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
-  connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
-  misc/show_msg.h
+ ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
+ connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
+ misc/ei_portio.h misc/show_msg.h
 $(MT_OBJDIR)/send_exit.o: connect/send_exit.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/ei_connect_int.h misc/ei_trace.h \
-  misc/ei_internal.h misc/putget.h misc/show_msg.h
-$(MT_OBJDIR)/send_reg.o: connect/send_reg.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
-  connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
-  misc/show_msg.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/ei_connect_int.h misc/ei_trace.h \
+ misc/ei_internal.h misc/putget.h misc/ei_portio.h misc/show_msg.h
+$(MT_OBJDIR)/send_reg.o: connect/send_reg.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h misc/putget.h connect/ei_connect_int.h \
+ misc/ei_internal.h misc/ei_trace.h misc/ei_portio.h misc/show_msg.h
 $(MT_OBJDIR)/decode_atom.o: decode/decode_atom.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_big.o: decode/decode_big.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
-$(MT_OBJDIR)/decode_bignum.o: decode/decode_bignum.c $(TARGET)/config.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MT_OBJDIR)/decode_bignum.o: decode/decode_bignum.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h
 $(MT_OBJDIR)/decode_binary.o: decode/decode_binary.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_boolean.o: decode/decode_boolean.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_char.o: decode/decode_char.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_double.o: decode/decode_double.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_fun.o: decode/decode_fun.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_malloc.h decode/decode_skip.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_malloc.h decode/decode_skip.h misc/putget.h
 $(MT_OBJDIR)/decode_intlist.o: decode/decode_intlist.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_list_header.o: decode/decode_list_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_long.o: decode/decode_long.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_pid.o: decode/decode_pid.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_port.o: decode/decode_port.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_ref.o: decode/decode_ref.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_skip.o: decode/decode_skip.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  decode/decode_skip.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ decode/decode_skip.h
 $(MT_OBJDIR)/decode_string.o: decode/decode_string.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_trace.o: decode/decode_trace.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/putget.h
 $(MT_OBJDIR)/decode_tuple_header.o: decode/decode_tuple_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_ulong.o: decode/decode_ulong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_version.o: decode/decode_version.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_longlong.o: decode/decode_longlong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/decode_ulonglong.o: decode/decode_ulonglong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_atom.o: encode/encode_atom.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
-$(MT_OBJDIR)/encode_bignum.o: encode/encode_bignum.c $(TARGET)/config.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MT_OBJDIR)/encode_big.o: encode/encode_big.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
+$(MT_OBJDIR)/encode_bignum.o: encode/encode_bignum.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h
 $(MT_OBJDIR)/encode_binary.o: encode/encode_binary.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_boolean.o: encode/encode_boolean.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_char.o: encode/encode_char.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_double.o: encode/encode_double.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_fun.o: encode/encode_fun.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_list_header.o: encode/encode_list_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_long.o: encode/encode_long.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_pid.o: encode/encode_pid.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_port.o: encode/encode_port.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_ref.o: encode/encode_ref.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_string.o: encode/encode_string.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_trace.o: encode/encode_trace.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/putget.h
 $(MT_OBJDIR)/encode_tuple_header.o: encode/encode_tuple_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_ulong.o: encode/encode_ulong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_version.o: encode/encode_version.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MT_OBJDIR)/encode_longlong.o: encode/encode_longlong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
 $(MT_OBJDIR)/encode_ulonglong.o: encode/encode_ulonglong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h
-$(MT_OBJDIR)/epmd_port.o: epmd/epmd_port.c misc/ei_internal.h epmd/ei_epmd.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
+$(MT_OBJDIR)/epmd_port.o: epmd/epmd_port.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ epmd/ei_epmd.h misc/ei_portio.h misc/putget.h
 $(MT_OBJDIR)/epmd_publish.o: epmd/epmd_publish.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
-  misc/putget.h ../include/erl_interface.h epmd/ei_epmd.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ misc/putget.h epmd/ei_epmd.h misc/ei_portio.h
 $(MT_OBJDIR)/epmd_unpublish.o: epmd/epmd_unpublish.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
-  misc/putget.h ../include/erl_interface.h epmd/ei_epmd.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ misc/putget.h epmd/ei_epmd.h misc/ei_portio.h
 $(MT_OBJDIR)/ei_decode_term.o: misc/ei_decode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_decode_term.h misc/putget.h
-$(MT_OBJDIR)/ei_format.o: misc/ei_format.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/ei_malloc.h misc/ei_format.h
-$(MT_OBJDIR)/ei_locking.o: misc/ei_locking.c $(TARGET)/config.h \
-  misc/ei_malloc.h misc/ei_locking.h
-$(MT_OBJDIR)/ei_malloc.o: misc/ei_malloc.c misc/ei_malloc.h
-$(MT_OBJDIR)/ei_portio.o: misc/ei_portio.c misc/ei_portio.h misc/ei_internal.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_decode_term.h misc/putget.h
+$(MT_OBJDIR)/ei_format.o: misc/ei_format.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h \
+ misc/ei_format.h
+$(MT_OBJDIR)/ei_locking.o: misc/ei_locking.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h \
+ misc/ei_locking.h
+$(MT_OBJDIR)/ei_malloc.o: misc/ei_malloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h
+$(MT_OBJDIR)/ei_portio.o: misc/ei_portio.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_portio.h \
+ misc/ei_internal.h
 $(MT_OBJDIR)/ei_printterm.o: misc/ei_printterm.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_printterm.h misc/ei_malloc.h
-$(MT_OBJDIR)/ei_pthreads.o: misc/ei_pthreads.c $(TARGET)/config.h \
-  ../include/ei.h misc/ei_locking.h
-$(MT_OBJDIR)/ei_trace.o: misc/ei_trace.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/ei_trace.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_printterm.h misc/ei_malloc.h
+$(MT_OBJDIR)/ei_pthreads.o: misc/ei_pthreads.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h
+$(MT_OBJDIR)/ei_trace.o: misc/ei_trace.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_trace.h
 $(MT_OBJDIR)/ei_x_encode.o: misc/ei_x_encode.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_x_encode.h \
-  misc/ei_malloc.h
-$(MT_OBJDIR)/eimd5.o: misc/eimd5.c misc/eimd5.h
-$(MT_OBJDIR)/get_type.o: misc/get_type.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h misc/putget.h
-$(MT_OBJDIR)/show_msg.o: misc/show_msg.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h misc/putget.h misc/ei_printterm.h \
-  misc/ei_internal.h misc/show_msg.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_x_encode.h \
+ misc/ei_malloc.h
+$(MT_OBJDIR)/eimd5.o: misc/eimd5.c misc/eidef.h $(TARGET)/config.h \
+ ../include/ei.h misc/eimd5.h
+$(MT_OBJDIR)/get_type.o: misc/get_type.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MT_OBJDIR)/show_msg.o: misc/show_msg.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_printterm.h misc/ei_internal.h misc/show_msg.h
 $(MT_OBJDIR)/ei_compat.o: misc/ei_compat.c ../include/ei.h misc/ei_internal.h
 $(MT_OBJDIR)/hash_dohash.o: registry/hash_dohash.c registry/hash.h ../include/ei.h
 $(MT_OBJDIR)/hash_foreach.o: registry/hash_foreach.c registry/hash.h ../include/ei.h
@@ -466,277 +509,306 @@ $(MT_OBJDIR)/hash_remove.o: registry/hash_remove.c registry/hash.h ../include/ei
 $(MT_OBJDIR)/hash_resize.o: registry/hash_resize.c registry/hash.h ../include/ei.h
 $(MT_OBJDIR)/hash_rlookup.o: registry/hash_rlookup.c registry/hash.h ../include/ei.h
 $(MT_OBJDIR)/reg_close.o: registry/reg_close.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_delete.o: registry/reg_delete.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_dirty.o: registry/reg_dirty.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_dump.o: registry/reg_dump.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
-  connect/ei_connect_int.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
+ connect/ei_connect_int.h
 $(MT_OBJDIR)/reg_free.o: registry/reg_free.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_get.o: registry/reg_get.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_getf.o: registry/reg_getf.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_geti.o: registry/reg_geti.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_getp.o: registry/reg_getp.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_gets.o: registry/reg_gets.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_make.o: registry/reg_make.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_open.o: registry/reg_open.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_purge.o: registry/reg_purge.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_resize.o: registry/reg_resize.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_restore.o: registry/reg_restore.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
-  connect/ei_connect_int.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
+ connect/ei_connect_int.h
 $(MT_OBJDIR)/reg_set.o: registry/reg_set.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_setf.o: registry/reg_setf.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_seti.o: registry/reg_seti.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_setp.o: registry/reg_setp.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_sets.o: registry/reg_sets.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_stat.o: registry/reg_stat.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/reg_tabstat.o: registry/reg_tabstat.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MT_OBJDIR)/decode_term.o: legacy/decode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h ../include/erl_interface.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h ../include/erl_interface.h ../include/ei.h
 $(MT_OBJDIR)/encode_term.o: legacy/encode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h ../include/erl_interface.h \
-  legacy/erl_marshal.h legacy/erl_eterm.h legacy/portability.h
-$(MT_OBJDIR)/erl_connect.o: legacy/erl_connect.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_config.h \
-  legacy/erl_connect.h legacy/erl_eterm.h legacy/portability.h \
-  legacy/erl_malloc.h misc/putget.h connect/ei_connect_int.h \
-  misc/ei_locking.h epmd/ei_epmd.h misc/ei_internal.h
-$(MT_OBJDIR)/erl_error.o: legacy/erl_error.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_error.h
-$(MT_OBJDIR)/erl_eterm.o: legacy/erl_eterm.c misc/ei_locking.h \
-  $(TARGET)/config.h connect/ei_resolve.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_eterm.h \
-  legacy/portability.h legacy/erl_malloc.h legacy/erl_marshal.h \
-  legacy/erl_error.h legacy/erl_internal.h misc/ei_internal.h
-$(MT_OBJDIR)/erl_fix_alloc.o: legacy/erl_fix_alloc.c $(TARGET)/config.h \
-  misc/ei_locking.h ../include/erl_interface.h ../include/ei.h \
-  legacy/erl_error.h legacy/erl_malloc.h legacy/erl_fix_alloc.h \
-  legacy/erl_eterm.h legacy/portability.h
-$(MT_OBJDIR)/erl_format.o: legacy/erl_format.c ../include/erl_interface.h \
-  ../include/ei.h legacy/erl_eterm.h legacy/portability.h \
-  legacy/erl_malloc.h legacy/erl_error.h legacy/erl_internal.h
-$(MT_OBJDIR)/erl_malloc.o: legacy/erl_malloc.c ../include/erl_interface.h \
-  ../include/ei.h legacy/erl_fix_alloc.h legacy/erl_malloc.h \
-  legacy/erl_internal.h legacy/erl_eterm.h legacy/portability.h \
-  misc/ei_malloc.h
-$(MT_OBJDIR)/erl_marshal.o: legacy/erl_marshal.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_marshal.h \
-  legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
-  legacy/erl_error.h legacy/erl_internal.h misc/eiext.h misc/putget.h
-$(MT_OBJDIR)/erl_timeout.o: legacy/erl_timeout.c $(TARGET)/config.h \
-  legacy/erl_timeout.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h ../include/erl_interface.h \
+ ../include/ei.h legacy/erl_marshal.h legacy/erl_eterm.h \
+ legacy/portability.h
+$(MT_OBJDIR)/erl_connect.o: legacy/erl_connect.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ misc/putget.h connect/ei_connect_int.h misc/ei_locking.h epmd/ei_epmd.h \
+ misc/ei_internal.h
+$(MT_OBJDIR)/erl_error.o: legacy/erl_error.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_error.h
+$(MT_OBJDIR)/erl_eterm.o: legacy/erl_eterm.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h \
+ connect/ei_resolve.h ../include/erl_interface.h ../include/ei.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ legacy/erl_marshal.h legacy/erl_error.h legacy/erl_internal.h \
+ misc/ei_internal.h misc/putget.h
+$(MT_OBJDIR)/erl_fix_alloc.o: legacy/erl_fix_alloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_error.h \
+ legacy/erl_malloc.h legacy/erl_fix_alloc.h legacy/erl_eterm.h \
+ legacy/portability.h
+$(MT_OBJDIR)/erl_format.o: legacy/erl_format.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_eterm.h \
+ legacy/portability.h legacy/erl_malloc.h legacy/erl_error.h \
+ legacy/erl_internal.h
+$(MT_OBJDIR)/erl_malloc.o: legacy/erl_malloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_fix_alloc.h \
+ legacy/erl_malloc.h legacy/erl_internal.h legacy/erl_eterm.h \
+ legacy/portability.h misc/ei_malloc.h
+$(MT_OBJDIR)/erl_marshal.o: legacy/erl_marshal.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_marshal.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ legacy/erl_error.h legacy/erl_internal.h misc/eiext.h misc/putget.h
+$(MT_OBJDIR)/erl_resolve.o: legacy/erl_resolve.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h connect/ei_resolve.h \
+ connect/ei_connect_int.h epmd/ei_epmd.h
+$(MT_OBJDIR)/erl_timeout.o: legacy/erl_timeout.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_timeout.h
 $(MT_OBJDIR)/global_names.o: legacy/global_names.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 $(MT_OBJDIR)/global_register.o: legacy/global_register.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h ../include/erl_interface.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h ../include/erl_interface.h \
+ ../include/ei.h
 $(MT_OBJDIR)/global_unregister.o: legacy/global_unregister.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 $(MT_OBJDIR)/global_whereis.o: legacy/global_whereis.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 
-$(MD_OBJDIR)/ei_connect.o: connect/ei_connect.c $(TARGET)/config.h \
-  misc/eidef.h ../include/ei.h misc/eiext.h misc/ei_portio.h \
-  misc/ei_internal.h connect/ei_connect_int.h misc/ei_locking.h \
-  connect/eisend.h connect/eirecv.h misc/eimd5.h misc/putget.h \
-  connect/ei_resolve.h epmd/ei_epmd.h
-$(MD_OBJDIR)/ei_resolve.o: connect/ei_resolve.c $(TARGET)/config.h \
-  misc/eidef.h ../include/ei.h connect/ei_resolve.h misc/ei_locking.h
+$(MD_OBJDIR)/ei_connect.o: connect/ei_connect.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_portio.h misc/ei_internal.h connect/ei_connect_int.h \
+ misc/ei_locking.h connect/eisend.h connect/eirecv.h misc/eimd5.h \
+ misc/putget.h connect/ei_resolve.h epmd/ei_epmd.h
+$(MD_OBJDIR)/ei_resolve.o: connect/ei_resolve.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h connect/ei_resolve.h \
+ misc/ei_locking.h
 $(MD_OBJDIR)/eirecv.o: connect/eirecv.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eirecv.h misc/ei_portio.h \
-  misc/ei_internal.h misc/putget.h misc/ei_trace.h misc/show_msg.h
+ ../include/ei.h misc/eiext.h connect/eirecv.h misc/ei_portio.h \
+ misc/ei_internal.h misc/putget.h misc/ei_trace.h misc/show_msg.h
 $(MD_OBJDIR)/send.o: connect/send.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
-  connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
-  misc/show_msg.h
+ ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
+ connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
+ misc/ei_portio.h misc/show_msg.h
 $(MD_OBJDIR)/send_exit.o: connect/send_exit.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/ei_connect_int.h misc/ei_trace.h \
-  misc/ei_internal.h misc/putget.h misc/show_msg.h
-$(MD_OBJDIR)/send_reg.o: connect/send_reg.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
-  connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
-  misc/show_msg.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/ei_connect_int.h misc/ei_trace.h \
+ misc/ei_internal.h misc/putget.h misc/ei_portio.h misc/show_msg.h
+$(MD_OBJDIR)/send_reg.o: connect/send_reg.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h misc/putget.h connect/ei_connect_int.h \
+ misc/ei_internal.h misc/ei_trace.h misc/ei_portio.h misc/show_msg.h
 $(MD_OBJDIR)/decode_atom.o: decode/decode_atom.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_big.o: decode/decode_big.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
-$(MD_OBJDIR)/decode_bignum.o: decode/decode_bignum.c $(TARGET)/config.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MD_OBJDIR)/decode_bignum.o: decode/decode_bignum.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h
 $(MD_OBJDIR)/decode_binary.o: decode/decode_binary.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_boolean.o: decode/decode_boolean.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_char.o: decode/decode_char.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_double.o: decode/decode_double.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_fun.o: decode/decode_fun.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_malloc.h decode/decode_skip.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_malloc.h decode/decode_skip.h misc/putget.h
 $(MD_OBJDIR)/decode_intlist.o: decode/decode_intlist.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_list_header.o: decode/decode_list_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_long.o: decode/decode_long.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_pid.o: decode/decode_pid.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_port.o: decode/decode_port.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_ref.o: decode/decode_ref.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_skip.o: decode/decode_skip.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  decode/decode_skip.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ decode/decode_skip.h
 $(MD_OBJDIR)/decode_string.o: decode/decode_string.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_trace.o: decode/decode_trace.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/putget.h
 $(MD_OBJDIR)/decode_tuple_header.o: decode/decode_tuple_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_ulong.o: decode/decode_ulong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_version.o: decode/decode_version.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_longlong.o: decode/decode_longlong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/decode_ulonglong.o: decode/decode_ulonglong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_atom.o: encode/encode_atom.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
-$(MD_OBJDIR)/encode_bignum.o: encode/encode_bignum.c $(TARGET)/config.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MD_OBJDIR)/encode_big.o: encode/encode_big.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
+$(MD_OBJDIR)/encode_bignum.o: encode/encode_bignum.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h
 $(MD_OBJDIR)/encode_binary.o: encode/encode_binary.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_boolean.o: encode/encode_boolean.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_char.o: encode/encode_char.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_double.o: encode/encode_double.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_fun.o: encode/encode_fun.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_list_header.o: encode/encode_list_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_long.o: encode/encode_long.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_pid.o: encode/encode_pid.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_port.o: encode/encode_port.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_ref.o: encode/encode_ref.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_string.o: encode/encode_string.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_trace.o: encode/encode_trace.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/putget.h
 $(MD_OBJDIR)/encode_tuple_header.o: encode/encode_tuple_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_ulong.o: encode/encode_ulong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_version.o: encode/encode_version.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MD_OBJDIR)/encode_longlong.o: encode/encode_longlong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
 $(MD_OBJDIR)/encode_ulonglong.o: encode/encode_ulonglong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h
-$(MD_OBJDIR)/epmd_port.o: epmd/epmd_port.c misc/ei_internal.h epmd/ei_epmd.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
+$(MD_OBJDIR)/epmd_port.o: epmd/epmd_port.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ epmd/ei_epmd.h misc/ei_portio.h misc/putget.h
 $(MD_OBJDIR)/epmd_publish.o: epmd/epmd_publish.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
-  misc/putget.h ../include/erl_interface.h epmd/ei_epmd.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ misc/putget.h epmd/ei_epmd.h misc/ei_portio.h
 $(MD_OBJDIR)/epmd_unpublish.o: epmd/epmd_unpublish.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
-  misc/putget.h ../include/erl_interface.h epmd/ei_epmd.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ misc/putget.h epmd/ei_epmd.h misc/ei_portio.h
 $(MD_OBJDIR)/ei_decode_term.o: misc/ei_decode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_decode_term.h misc/putget.h
-$(MD_OBJDIR)/ei_format.o: misc/ei_format.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/ei_malloc.h misc/ei_format.h
-$(MD_OBJDIR)/ei_locking.o: misc/ei_locking.c $(TARGET)/config.h \
-  misc/ei_malloc.h misc/ei_locking.h
-$(MD_OBJDIR)/ei_malloc.o: misc/ei_malloc.c misc/ei_malloc.h
-$(MD_OBJDIR)/ei_portio.o: misc/ei_portio.c misc/ei_portio.h misc/ei_internal.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_decode_term.h misc/putget.h
+$(MD_OBJDIR)/ei_format.o: misc/ei_format.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h \
+ misc/ei_format.h
+$(MD_OBJDIR)/ei_locking.o: misc/ei_locking.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h \
+ misc/ei_locking.h
+$(MD_OBJDIR)/ei_malloc.o: misc/ei_malloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h
+$(MD_OBJDIR)/ei_portio.o: misc/ei_portio.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_portio.h \
+ misc/ei_internal.h
 $(MD_OBJDIR)/ei_printterm.o: misc/ei_printterm.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_printterm.h misc/ei_malloc.h
-$(MD_OBJDIR)/ei_pthreads.o: misc/ei_pthreads.c $(TARGET)/config.h \
-  ../include/ei.h misc/ei_locking.h
-$(MD_OBJDIR)/ei_trace.o: misc/ei_trace.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/ei_trace.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_printterm.h misc/ei_malloc.h
+$(MD_OBJDIR)/ei_pthreads.o: misc/ei_pthreads.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h
+$(MD_OBJDIR)/ei_trace.o: misc/ei_trace.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_trace.h
 $(MD_OBJDIR)/ei_x_encode.o: misc/ei_x_encode.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_x_encode.h \
-  misc/ei_malloc.h
-$(MD_OBJDIR)/eimd5.o: misc/eimd5.c misc/eimd5.h
-$(MD_OBJDIR)/get_type.o: misc/get_type.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h misc/putget.h
-$(MD_OBJDIR)/show_msg.o: misc/show_msg.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h misc/putget.h misc/ei_printterm.h \
-  misc/ei_internal.h misc/show_msg.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_x_encode.h \
+ misc/ei_malloc.h
+$(MD_OBJDIR)/eimd5.o: misc/eimd5.c misc/eidef.h $(TARGET)/config.h \
+ ../include/ei.h misc/eimd5.h
+$(MD_OBJDIR)/get_type.o: misc/get_type.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MD_OBJDIR)/show_msg.o: misc/show_msg.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_printterm.h misc/ei_internal.h misc/show_msg.h
 $(MD_OBJDIR)/ei_compat.o: misc/ei_compat.c ../include/ei.h misc/ei_internal.h
 $(MD_OBJDIR)/hash_dohash.o: registry/hash_dohash.c registry/hash.h ../include/ei.h
 $(MD_OBJDIR)/hash_foreach.o: registry/hash_foreach.c registry/hash.h ../include/ei.h
@@ -749,277 +821,306 @@ $(MD_OBJDIR)/hash_remove.o: registry/hash_remove.c registry/hash.h ../include/ei
 $(MD_OBJDIR)/hash_resize.o: registry/hash_resize.c registry/hash.h ../include/ei.h
 $(MD_OBJDIR)/hash_rlookup.o: registry/hash_rlookup.c registry/hash.h ../include/ei.h
 $(MD_OBJDIR)/reg_close.o: registry/reg_close.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_delete.o: registry/reg_delete.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_dirty.o: registry/reg_dirty.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_dump.o: registry/reg_dump.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
-  connect/ei_connect_int.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
+ connect/ei_connect_int.h
 $(MD_OBJDIR)/reg_free.o: registry/reg_free.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_get.o: registry/reg_get.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_getf.o: registry/reg_getf.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_geti.o: registry/reg_geti.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_getp.o: registry/reg_getp.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_gets.o: registry/reg_gets.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_make.o: registry/reg_make.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_open.o: registry/reg_open.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_purge.o: registry/reg_purge.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_resize.o: registry/reg_resize.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_restore.o: registry/reg_restore.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
-  connect/ei_connect_int.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
+ connect/ei_connect_int.h
 $(MD_OBJDIR)/reg_set.o: registry/reg_set.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_setf.o: registry/reg_setf.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_seti.o: registry/reg_seti.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_setp.o: registry/reg_setp.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_sets.o: registry/reg_sets.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_stat.o: registry/reg_stat.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/reg_tabstat.o: registry/reg_tabstat.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MD_OBJDIR)/decode_term.o: legacy/decode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h ../include/erl_interface.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h ../include/erl_interface.h ../include/ei.h
 $(MD_OBJDIR)/encode_term.o: legacy/encode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h ../include/erl_interface.h \
-  legacy/erl_marshal.h legacy/erl_eterm.h legacy/portability.h
-$(MD_OBJDIR)/erl_connect.o: legacy/erl_connect.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_config.h \
-  legacy/erl_connect.h legacy/erl_eterm.h legacy/portability.h \
-  legacy/erl_malloc.h misc/putget.h connect/ei_connect_int.h \
-  misc/ei_locking.h epmd/ei_epmd.h misc/ei_internal.h
-$(MD_OBJDIR)/erl_error.o: legacy/erl_error.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_error.h
-$(MD_OBJDIR)/erl_eterm.o: legacy/erl_eterm.c misc/ei_locking.h \
-  $(TARGET)/config.h connect/ei_resolve.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_eterm.h \
-  legacy/portability.h legacy/erl_malloc.h legacy/erl_marshal.h \
-  legacy/erl_error.h legacy/erl_internal.h misc/ei_internal.h
-$(MD_OBJDIR)/erl_fix_alloc.o: legacy/erl_fix_alloc.c $(TARGET)/config.h \
-  misc/ei_locking.h ../include/erl_interface.h ../include/ei.h \
-  legacy/erl_error.h legacy/erl_malloc.h legacy/erl_fix_alloc.h \
-  legacy/erl_eterm.h legacy/portability.h
-$(MD_OBJDIR)/erl_format.o: legacy/erl_format.c ../include/erl_interface.h \
-  ../include/ei.h legacy/erl_eterm.h legacy/portability.h \
-  legacy/erl_malloc.h legacy/erl_error.h legacy/erl_internal.h
-$(MD_OBJDIR)/erl_malloc.o: legacy/erl_malloc.c ../include/erl_interface.h \
-  ../include/ei.h legacy/erl_fix_alloc.h legacy/erl_malloc.h \
-  legacy/erl_internal.h legacy/erl_eterm.h legacy/portability.h \
-  misc/ei_malloc.h
-$(MD_OBJDIR)/erl_marshal.o: legacy/erl_marshal.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_marshal.h \
-  legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
-  legacy/erl_error.h legacy/erl_internal.h misc/eiext.h misc/putget.h
-$(MD_OBJDIR)/erl_timeout.o: legacy/erl_timeout.c $(TARGET)/config.h \
-  legacy/erl_timeout.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h ../include/erl_interface.h \
+ ../include/ei.h legacy/erl_marshal.h legacy/erl_eterm.h \
+ legacy/portability.h
+$(MD_OBJDIR)/erl_connect.o: legacy/erl_connect.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ misc/putget.h connect/ei_connect_int.h misc/ei_locking.h epmd/ei_epmd.h \
+ misc/ei_internal.h
+$(MD_OBJDIR)/erl_error.o: legacy/erl_error.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_error.h
+$(MD_OBJDIR)/erl_eterm.o: legacy/erl_eterm.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h \
+ connect/ei_resolve.h ../include/erl_interface.h ../include/ei.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ legacy/erl_marshal.h legacy/erl_error.h legacy/erl_internal.h \
+ misc/ei_internal.h misc/putget.h
+$(MD_OBJDIR)/erl_fix_alloc.o: legacy/erl_fix_alloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_error.h \
+ legacy/erl_malloc.h legacy/erl_fix_alloc.h legacy/erl_eterm.h \
+ legacy/portability.h
+$(MD_OBJDIR)/erl_format.o: legacy/erl_format.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_eterm.h \
+ legacy/portability.h legacy/erl_malloc.h legacy/erl_error.h \
+ legacy/erl_internal.h
+$(MD_OBJDIR)/erl_malloc.o: legacy/erl_malloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_fix_alloc.h \
+ legacy/erl_malloc.h legacy/erl_internal.h legacy/erl_eterm.h \
+ legacy/portability.h misc/ei_malloc.h
+$(MD_OBJDIR)/erl_marshal.o: legacy/erl_marshal.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_marshal.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ legacy/erl_error.h legacy/erl_internal.h misc/eiext.h misc/putget.h
+$(MD_OBJDIR)/erl_resolve.o: legacy/erl_resolve.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h connect/ei_resolve.h \
+ connect/ei_connect_int.h epmd/ei_epmd.h
+$(MD_OBJDIR)/erl_timeout.o: legacy/erl_timeout.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_timeout.h
 $(MD_OBJDIR)/global_names.o: legacy/global_names.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 $(MD_OBJDIR)/global_register.o: legacy/global_register.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h ../include/erl_interface.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h ../include/erl_interface.h \
+ ../include/ei.h
 $(MD_OBJDIR)/global_unregister.o: legacy/global_unregister.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 $(MD_OBJDIR)/global_whereis.o: legacy/global_whereis.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 
-$(MDD_OBJDIR)/ei_connect.o: connect/ei_connect.c $(TARGET)/config.h \
-  misc/eidef.h ../include/ei.h misc/eiext.h misc/ei_portio.h \
-  misc/ei_internal.h connect/ei_connect_int.h misc/ei_locking.h \
-  connect/eisend.h connect/eirecv.h misc/eimd5.h misc/putget.h \
-  connect/ei_resolve.h epmd/ei_epmd.h
-$(MDD_OBJDIR)/ei_resolve.o: connect/ei_resolve.c $(TARGET)/config.h \
-  misc/eidef.h ../include/ei.h connect/ei_resolve.h misc/ei_locking.h
+$(MDD_OBJDIR)/ei_connect.o: connect/ei_connect.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_portio.h misc/ei_internal.h connect/ei_connect_int.h \
+ misc/ei_locking.h connect/eisend.h connect/eirecv.h misc/eimd5.h \
+ misc/putget.h connect/ei_resolve.h epmd/ei_epmd.h
+$(MDD_OBJDIR)/ei_resolve.o: connect/ei_resolve.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h connect/ei_resolve.h \
+ misc/ei_locking.h
 $(MDD_OBJDIR)/eirecv.o: connect/eirecv.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eirecv.h misc/ei_portio.h \
-  misc/ei_internal.h misc/putget.h misc/ei_trace.h misc/show_msg.h
+ ../include/ei.h misc/eiext.h connect/eirecv.h misc/ei_portio.h \
+ misc/ei_internal.h misc/putget.h misc/ei_trace.h misc/show_msg.h
 $(MDD_OBJDIR)/send.o: connect/send.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
-  connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
-  misc/show_msg.h
+ ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
+ connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
+ misc/ei_portio.h misc/show_msg.h
 $(MDD_OBJDIR)/send_exit.o: connect/send_exit.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/ei_connect_int.h misc/ei_trace.h \
-  misc/ei_internal.h misc/putget.h misc/show_msg.h
-$(MDD_OBJDIR)/send_reg.o: connect/send_reg.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h connect/eisend.h misc/putget.h \
-  connect/ei_connect_int.h misc/ei_internal.h misc/ei_trace.h \
-  misc/show_msg.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/ei_connect_int.h misc/ei_trace.h \
+ misc/ei_internal.h misc/putget.h misc/ei_portio.h misc/show_msg.h
+$(MDD_OBJDIR)/send_reg.o: connect/send_reg.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h misc/putget.h connect/ei_connect_int.h \
+ misc/ei_internal.h misc/ei_trace.h misc/ei_portio.h misc/show_msg.h
 $(MDD_OBJDIR)/decode_atom.o: decode/decode_atom.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_big.o: decode/decode_big.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
-$(MDD_OBJDIR)/decode_bignum.o: decode/decode_bignum.c $(TARGET)/config.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MDD_OBJDIR)/decode_bignum.o: decode/decode_bignum.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h
 $(MDD_OBJDIR)/decode_binary.o: decode/decode_binary.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_boolean.o: decode/decode_boolean.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_char.o: decode/decode_char.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_double.o: decode/decode_double.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_fun.o: decode/decode_fun.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_malloc.h decode/decode_skip.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_malloc.h decode/decode_skip.h misc/putget.h
 $(MDD_OBJDIR)/decode_intlist.o: decode/decode_intlist.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_list_header.o: decode/decode_list_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_long.o: decode/decode_long.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_pid.o: decode/decode_pid.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_port.o: decode/decode_port.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_ref.o: decode/decode_ref.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_skip.o: decode/decode_skip.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  decode/decode_skip.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ decode/decode_skip.h
 $(MDD_OBJDIR)/decode_string.o: decode/decode_string.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_trace.o: decode/decode_trace.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/putget.h
 $(MDD_OBJDIR)/decode_tuple_header.o: decode/decode_tuple_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_ulong.o: decode/decode_ulong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_version.o: decode/decode_version.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_longlong.o: decode/decode_longlong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/decode_ulonglong.o: decode/decode_ulonglong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_atom.o: encode/encode_atom.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
-$(MDD_OBJDIR)/encode_bignum.o: encode/encode_bignum.c $(TARGET)/config.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MDD_OBJDIR)/encode_big.o: encode/encode_big.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
+$(MDD_OBJDIR)/encode_bignum.o: encode/encode_bignum.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h
 $(MDD_OBJDIR)/encode_binary.o: encode/encode_binary.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_boolean.o: encode/encode_boolean.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_char.o: encode/encode_char.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_double.o: encode/encode_double.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_fun.o: encode/encode_fun.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_list_header.o: encode/encode_list_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_long.o: encode/encode_long.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_pid.o: encode/encode_pid.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_port.o: encode/encode_port.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_ref.o: encode/encode_ref.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_string.o: encode/encode_string.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_trace.o: encode/encode_trace.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/putget.h
 $(MDD_OBJDIR)/encode_tuple_header.o: encode/encode_tuple_header.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_ulong.o: encode/encode_ulong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_version.o: encode/encode_version.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
 $(MDD_OBJDIR)/encode_longlong.o: encode/encode_longlong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
 $(MDD_OBJDIR)/encode_ulonglong.o: encode/encode_ulonglong.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h
-$(MDD_OBJDIR)/epmd_port.o: epmd/epmd_port.c misc/ei_internal.h epmd/ei_epmd.h \
-  misc/putget.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h
+$(MDD_OBJDIR)/epmd_port.o: epmd/epmd_port.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ epmd/ei_epmd.h misc/ei_portio.h misc/putget.h
 $(MDD_OBJDIR)/epmd_publish.o: epmd/epmd_publish.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
-  misc/putget.h ../include/erl_interface.h epmd/ei_epmd.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ misc/putget.h epmd/ei_epmd.h misc/ei_portio.h
 $(MDD_OBJDIR)/epmd_unpublish.o: epmd/epmd_unpublish.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
-  misc/putget.h ../include/erl_interface.h epmd/ei_epmd.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_internal.h \
+ misc/putget.h epmd/ei_epmd.h misc/ei_portio.h
 $(MDD_OBJDIR)/ei_decode_term.o: misc/ei_decode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_decode_term.h misc/putget.h
-$(MDD_OBJDIR)/ei_format.o: misc/ei_format.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/ei_malloc.h misc/ei_format.h
-$(MDD_OBJDIR)/ei_locking.o: misc/ei_locking.c $(TARGET)/config.h \
-  misc/ei_malloc.h misc/ei_locking.h
-$(MDD_OBJDIR)/ei_malloc.o: misc/ei_malloc.c misc/ei_malloc.h
-$(MDD_OBJDIR)/ei_portio.o: misc/ei_portio.c misc/ei_portio.h misc/ei_internal.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_decode_term.h misc/putget.h
+$(MDD_OBJDIR)/ei_format.o: misc/ei_format.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h \
+ misc/ei_format.h
+$(MDD_OBJDIR)/ei_locking.o: misc/ei_locking.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h \
+ misc/ei_locking.h
+$(MDD_OBJDIR)/ei_malloc.o: misc/ei_malloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_malloc.h
+$(MDD_OBJDIR)/ei_portio.o: misc/ei_portio.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_portio.h \
+ misc/ei_internal.h
 $(MDD_OBJDIR)/ei_printterm.o: misc/ei_printterm.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/ei_printterm.h misc/ei_malloc.h
-$(MDD_OBJDIR)/ei_pthreads.o: misc/ei_pthreads.c $(TARGET)/config.h \
-  ../include/ei.h misc/ei_locking.h
-$(MDD_OBJDIR)/ei_trace.o: misc/ei_trace.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/ei_trace.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/ei_printterm.h misc/ei_malloc.h
+$(MDD_OBJDIR)/ei_pthreads.o: misc/ei_pthreads.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h
+$(MDD_OBJDIR)/ei_trace.o: misc/ei_trace.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_trace.h
 $(MDD_OBJDIR)/ei_x_encode.o: misc/ei_x_encode.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/ei_x_encode.h \
-  misc/ei_malloc.h
-$(MDD_OBJDIR)/eimd5.o: misc/eimd5.c misc/eimd5.h
-$(MDD_OBJDIR)/get_type.o: misc/get_type.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h misc/putget.h
-$(MDD_OBJDIR)/show_msg.o: misc/show_msg.c misc/eidef.h $(TARGET)/config.h \
-  ../include/ei.h misc/eiext.h misc/putget.h misc/ei_printterm.h \
-  misc/ei_internal.h misc/show_msg.h
+ $(TARGET)/config.h ../include/ei.h misc/ei_x_encode.h \
+ misc/ei_malloc.h
+$(MDD_OBJDIR)/eimd5.o: misc/eimd5.c misc/eidef.h $(TARGET)/config.h \
+ ../include/ei.h misc/eimd5.h
+$(MDD_OBJDIR)/get_type.o: misc/get_type.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h
+$(MDD_OBJDIR)/show_msg.o: misc/show_msg.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_printterm.h misc/ei_internal.h misc/show_msg.h
 $(MDD_OBJDIR)/ei_compat.o: misc/ei_compat.c ../include/ei.h misc/ei_internal.h
 $(MDD_OBJDIR)/hash_dohash.o: registry/hash_dohash.c registry/hash.h ../include/ei.h
 $(MDD_OBJDIR)/hash_foreach.o: registry/hash_foreach.c registry/hash.h ../include/ei.h
@@ -1032,102 +1133,117 @@ $(MDD_OBJDIR)/hash_remove.o: registry/hash_remove.c registry/hash.h ../include/e
 $(MDD_OBJDIR)/hash_resize.o: registry/hash_resize.c registry/hash.h ../include/ei.h
 $(MDD_OBJDIR)/hash_rlookup.o: registry/hash_rlookup.c registry/hash.h ../include/ei.h
 $(MDD_OBJDIR)/reg_close.o: registry/reg_close.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_delete.o: registry/reg_delete.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_dirty.o: registry/reg_dirty.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_dump.o: registry/reg_dump.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
-  connect/ei_connect_int.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
+ connect/ei_connect_int.h
 $(MDD_OBJDIR)/reg_free.o: registry/reg_free.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_get.o: registry/reg_get.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_getf.o: registry/reg_getf.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_geti.o: registry/reg_geti.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_getp.o: registry/reg_getp.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_gets.o: registry/reg_gets.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_make.o: registry/reg_make.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_open.o: registry/reg_open.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_purge.o: registry/reg_purge.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_resize.o: registry/reg_resize.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_restore.o: registry/reg_restore.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
-  connect/ei_connect_int.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ registry/reg.h registry/hash.h connect/eisend.h connect/eirecv.h \
+ connect/ei_connect_int.h
 $(MDD_OBJDIR)/reg_set.o: registry/reg_set.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_setf.o: registry/reg_setf.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_seti.o: registry/reg_seti.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_setp.o: registry/reg_setp.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_sets.o: registry/reg_sets.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_stat.o: registry/reg_stat.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/reg_tabstat.o: registry/reg_tabstat.c registry/reg.h ../include/ei.h \
-  registry/hash.h
+ registry/hash.h
 $(MDD_OBJDIR)/decode_term.o: legacy/decode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h ../include/erl_interface.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h ../include/erl_interface.h ../include/ei.h
 $(MDD_OBJDIR)/encode_term.o: legacy/encode_term.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  misc/putget.h misc/ei_x_encode.h ../include/erl_interface.h \
-  legacy/erl_marshal.h legacy/erl_eterm.h legacy/portability.h
-$(MDD_OBJDIR)/erl_connect.o: legacy/erl_connect.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_config.h \
-  legacy/erl_connect.h legacy/erl_eterm.h legacy/portability.h \
-  legacy/erl_malloc.h misc/putget.h connect/ei_connect_int.h \
-  misc/ei_locking.h epmd/ei_epmd.h misc/ei_internal.h
-$(MDD_OBJDIR)/erl_error.o: legacy/erl_error.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_error.h
-$(MDD_OBJDIR)/erl_eterm.o: legacy/erl_eterm.c misc/ei_locking.h \
-  $(TARGET)/config.h connect/ei_resolve.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_eterm.h \
-  legacy/portability.h legacy/erl_malloc.h legacy/erl_marshal.h \
-  legacy/erl_error.h legacy/erl_internal.h misc/ei_internal.h
-$(MDD_OBJDIR)/erl_fix_alloc.o: legacy/erl_fix_alloc.c $(TARGET)/config.h \
-  misc/ei_locking.h ../include/erl_interface.h ../include/ei.h \
-  legacy/erl_error.h legacy/erl_malloc.h legacy/erl_fix_alloc.h \
-  legacy/erl_eterm.h legacy/portability.h
-$(MDD_OBJDIR)/erl_format.o: legacy/erl_format.c ../include/erl_interface.h \
-  ../include/ei.h legacy/erl_eterm.h legacy/portability.h \
-  legacy/erl_malloc.h legacy/erl_error.h legacy/erl_internal.h
-$(MDD_OBJDIR)/erl_malloc.o: legacy/erl_malloc.c ../include/erl_interface.h \
-  ../include/ei.h legacy/erl_fix_alloc.h legacy/erl_malloc.h \
-  legacy/erl_internal.h legacy/erl_eterm.h legacy/portability.h \
-  misc/ei_malloc.h
-$(MDD_OBJDIR)/erl_marshal.o: legacy/erl_marshal.c $(TARGET)/config.h \
-  ../include/erl_interface.h ../include/ei.h legacy/erl_marshal.h \
-  legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
-  legacy/erl_error.h legacy/erl_internal.h misc/eiext.h misc/putget.h
-$(MDD_OBJDIR)/erl_timeout.o: legacy/erl_timeout.c $(TARGET)/config.h \
-  legacy/erl_timeout.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ misc/putget.h misc/ei_x_encode.h ../include/erl_interface.h \
+ ../include/ei.h legacy/erl_marshal.h legacy/erl_eterm.h \
+ legacy/portability.h
+$(MDD_OBJDIR)/erl_connect.o: legacy/erl_connect.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ misc/putget.h connect/ei_connect_int.h misc/ei_locking.h epmd/ei_epmd.h \
+ misc/ei_internal.h
+$(MDD_OBJDIR)/erl_error.o: legacy/erl_error.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_error.h
+$(MDD_OBJDIR)/erl_eterm.o: legacy/erl_eterm.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h \
+ connect/ei_resolve.h ../include/erl_interface.h ../include/ei.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ legacy/erl_marshal.h legacy/erl_error.h legacy/erl_internal.h \
+ misc/ei_internal.h misc/putget.h
+$(MDD_OBJDIR)/erl_fix_alloc.o: legacy/erl_fix_alloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h misc/ei_locking.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_error.h \
+ legacy/erl_malloc.h legacy/erl_fix_alloc.h legacy/erl_eterm.h \
+ legacy/portability.h
+$(MDD_OBJDIR)/erl_format.o: legacy/erl_format.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_eterm.h \
+ legacy/portability.h legacy/erl_malloc.h legacy/erl_error.h \
+ legacy/erl_internal.h
+$(MDD_OBJDIR)/erl_malloc.o: legacy/erl_malloc.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_fix_alloc.h \
+ legacy/erl_malloc.h legacy/erl_internal.h legacy/erl_eterm.h \
+ legacy/portability.h misc/ei_malloc.h
+$(MDD_OBJDIR)/erl_marshal.o: legacy/erl_marshal.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_marshal.h \
+ legacy/erl_eterm.h legacy/portability.h legacy/erl_malloc.h \
+ legacy/erl_error.h legacy/erl_internal.h misc/eiext.h misc/putget.h
+$(MDD_OBJDIR)/erl_resolve.o: legacy/erl_resolve.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h connect/ei_resolve.h \
+ connect/ei_connect_int.h epmd/ei_epmd.h
+$(MDD_OBJDIR)/erl_timeout.o: legacy/erl_timeout.c misc/eidef.h \
+ $(TARGET)/config.h ../include/ei.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_timeout.h
 $(MDD_OBJDIR)/global_names.o: legacy/global_names.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 $(MDD_OBJDIR)/global_register.o: legacy/global_register.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h ../include/erl_interface.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h ../include/erl_interface.h \
+ ../include/ei.h
 $(MDD_OBJDIR)/global_unregister.o: legacy/global_unregister.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 $(MDD_OBJDIR)/global_whereis.o: legacy/global_whereis.c misc/eidef.h \
-  $(TARGET)/config.h ../include/ei.h misc/eiext.h \
-  connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
-  ../include/erl_interface.h legacy/erl_connect.h
+ $(TARGET)/config.h ../include/ei.h misc/eiext.h \
+ connect/eisend.h connect/eirecv.h connect/ei_connect_int.h \
+ ../include/erl_interface.h ../include/ei.h legacy/erl_connect.h
 

--- a/lib/erl_interface/src/misc/ei_send_tock.c
+++ b/lib/erl_interface/src/misc/ei_send_tock.c
@@ -1,0 +1,36 @@
+/*
+ * %CopyrightBegin%
+ * 
+ * Copyright Ericsson AB 2004-2009. All Rights Reserved.
+ * 
+ * The contents of this file are subject to the Erlang Public License,
+ * Version 1.1, (the "License"); you may not use this file except in
+ * compliance with the License. You should have received a copy of the
+ * Erlang Public License along with this software. If not, it can be
+ * retrieved online at http://www.erlang.org/.
+ * 
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+ * the License for the specific language governing rights and limitations
+ * under the License.
+ * 
+ * %CopyrightEnd%
+ *
+
+ */
+#include "ei.h"
+#include "ei_internal.h"
+#include "ei_portio.h"
+
+void
+ei_send_tock_tmo(int fd, int ms)
+{
+    char tock[] = {0,0,0,0};
+    ei_write_fill_t(fd, tock, sizeof(tock), ms);
+}
+
+void
+ei_send_tock(int fd)
+{
+    ei_send_tock_tmo(fd, 0);
+}

--- a/lib/erl_interface/src/prog/ei_fake_prog.c
+++ b/lib/erl_interface/src/prog/ei_fake_prog.c
@@ -110,6 +110,12 @@ int main(void)
   ei_receive_msg(intx, &emsg, &eix);
   ei_xreceive_msg(intx, &emsg, &eix);
 
+  ei_receive_wt(intx, ucharp, intx);
+  ei_receive_msg_wt(intx, &emsg, &eix);
+  ei_xreceive_msg_wt(intx, &emsg, &eix);
+
+  ei_send_tock(intx);
+
   ei_send(intx, &epid, charp, intx);
   ei_reg_send(&xec, intx, charp, charp, intx);
 


### PR DESCRIPTION
The EI interface library provides functions that read messages from a network socket and block until a full message is received. There are companion functions (_tmo) that allow for a timeout to be provided. Both sets of functions automatically handle _TICK_ requests from the connected Erlang node. However in multi-threaded applications, this may not be desirable.

For example, you may have a C application that in the main thread, blocks on the Erlang socket and waits for messages and has a number of threads "doing work". When these threads need to send data to the Erlang node, they write directly to the socket. This can cause problems when more than one thread tries to write at any given time. The usual solution for this is to use a mutex to protect the socket.

This works well, until you receive a heartbeat (TICK) message from the Erlang node. The ei_receive calls internally respond to the heartbeat and as they write to the socket directly, without mutex protection, data corruption is highly likely.

As the calls block, it is not possible to wrap a mutex around the receive call on the off chance that the message received might be a heart beat request. It is possible to wrap an ei_receive call that has a timeout with a mutex, but this is highly undesirable. First, it will still prevent the application from writing even though there is no need to wait. Second, it's quite possible for the timeout to trigger during a message being read and having the read fail causing the cluster connection to fail.

A simple solution to this problem is to provide a set of receive functions that do not answer heartbeat requests. When these functions are used, the application must specifically reply to those requests itself. This means that the receive function will never send data (in keeping with its name) and as such, does not need to be protected by a mutex. Replying to the heartbeat with mutex protection is straight forward:

```
const int got = ei_xreceive_msg_wt(fd, &emsg, &xbuff); // Wait indefinitely
if (got == ERL_TICK) {
    // Send TOCK - with mutex protection
    pthread_mutex_lock(&mutexSocket);
    ei_send_tock(fd);
    pthread_mutex_unlock(&mutexSocket);
}
```

This update has been tested with a production application and has been running for several days without issue. Without this patch (where I was using the timeout approach), the C application could not remain connected for more than a few seconds. 

The previous API has been maintained and it should be completely backwards compatible. I have tried it without any issues.

This is my first PR for the OTP project so thanks in advance for your patience. I am more than happy to make changes or updates based on guidance - just let me know what needs doing.

Lastly thanks for all your hard work :)
