### PR TITLE
ssl: Fix incorrect number of seconds in 24 hours

### DIFF
--- a/lib/ssl/src/ssl_manager.erl
+++ b/lib/ssl/src/ssl_manager.erl
@@ -52,8 +52,8 @@
 	  last_delay_timer  = {undefined, undefined}%% Keep for testing purposes
 	 }).
 
--define('24H_in_msec', 8640000).
--define('24H_in_sec', 8640).
+-define('24H_in_msec', 86400000).
+-define('24H_in_sec', 86400).
 -define(GEN_UNIQUE_ID_MAX_TRIES, 10).
 -define(SESSION_VALIDATION_INTERVAL, 60000).
 -define(CLEAR_PEM_CACHE, 120000).


### PR DESCRIPTION
24 hours in seconds should be equal to 86400 and 86400000 in milliseconds
