### PR TITLE
jinterface: OtpInputStream exceptions show useless value

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpInputStream.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpInputStream.java
@@ -21,6 +21,7 @@ package com.ericsson.otp.erlang;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Arrays;
 
 /**
  * Provides a stream for decoding Erlang terms from external format.
@@ -819,7 +820,7 @@ public class OtpInputStream extends ByteArrayInputStream {
 	    if (unsigned) {
 		if (c < 0) {
 		    throw new OtpErlangDecodeException("Value not unsigned: "
-			    + b);
+			    + Arrays.toString(b));
 		}
 		while (b[i] == 0) {
 		    i++; // Skip leading zero sign bytes
@@ -844,7 +845,7 @@ public class OtpInputStream extends ByteArrayInputStream {
 	    if (b.length - i > 8) {
 		// More than 64 bits of value
 		throw new OtpErlangDecodeException(
-			"Value does not fit in long: " + b);
+			"Value does not fit in long: " + Arrays.toString(b));
 	    }
 	    // Convert the necessary bytes
 	    for (v = c < 0 ? -1 : 0; i < b.length; i++) {


### PR DESCRIPTION
Arrays have no meaningful toString method, but one must use
Arrays.toString instead. The meaningless value would look for example
like "[C@16f0472", instead of "[2,4]".
