### PR TITLE
ssl: Fix invalid call of ssl_cipher:anonymous_suites/1 (fixup ae68f7e)

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -358,7 +358,7 @@ cipher_suites(openssl) ->
 cipher_suites(all) ->
     Version = tls_record:highest_protocol_version([]),
     Supported = ssl_cipher:all_suites(Version)
-	++ ssl_cipher:anonymous_suites(Version)
+	++ ssl_cipher:anonymous_suites()
 	++ ssl_cipher:psk_suites(Version)
 	++ ssl_cipher:srp_suites(),
     ssl_cipher:filter_suites([suite_definition(S) || S <- Supported]).


### PR DESCRIPTION
Detected by Dialyzer:
  ssl.erl:361: Call to missing or unexported function ssl_cipher:anonymous_suites/1
