### PR TITLE
add missing description for +SDio option

### DIFF
--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -848,6 +848,19 @@
           </p>
       </item>
       <tag><marker id="+SDio"><c><![CDATA[+SDio IOSchedulers]]></c></marker></tag>
+      <item>
+          <p>Sets the number of dirty I/O scheduler threads to create when threading
+            support has been enabled. The valid range is 0-1024. By default, the number
+            of dirty I/O scheduler threads created is 10, same as the default number of
+            threads in the <seealso marker="#async_thread_pool_size">async thread pool
+            </seealso>.
+          </p>
+          <p>This option is ignored if the emulator doesn't have threading support
+            enabled. Currently, <em>this option is experimental</em> and is supported only
+            if the emulator was configured and built with support for dirty schedulers
+            enabled (it's disabled by default).
+          </p>
+      </item>
       <tag><c><![CDATA[+sFlag Value]]></c></tag>
       <item>
         <p>Scheduling specific flags.</p>


### PR DESCRIPTION
Add explanatory text for the +SDio option, which is used to set the number
of dirty I/O schedulers.
