### PR TITLE
Update INSTALL.md

### DIFF
--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -184,7 +184,7 @@ in your web browser and make sure that there are zero failed test cases.
 You are now ready to install the Erlang/OTP release!
 The following command will install the release on your system.
 
-    $ make install
+    # make install
 
 
 ### Running ###


### PR DESCRIPTION
make install fails with 

```
test -d "/usr/local/bin" || /usr/bin/install -c -d "/usr/local/bin"
/usr/bin/install -c -d "/usr/local/lib/erlang"
/usr/bin/install: cannot change permissions of ‘/usr/local/lib/erlang’: No such file or directory
make: *** [install.dirs] Error 1
```

unless you run it as root. Changed HOWTO/INSTALL.md to reflect this.
