### PR TITLE
Remove untested, undocumented option 'generic_debug' from gen_server

### DIFF
--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -791,21 +791,9 @@ opt(_, []) ->
 
 debug_options(Name, Opts) ->
     case opt(debug, Opts) of
-	{ok, Options} -> dbg_options(Name, Options);
-	_ -> dbg_options(Name, [])
+	{ok, Options} -> dbg_opts(Name, Options);
+	_ -> []
     end.
-
-dbg_options(Name, []) ->
-    Opts = 
-	case init:get_argument(generic_debug) of
-	    error ->
-		[];
-	    _ ->
-		[log, statistics]
-	end,
-    dbg_opts(Name, Opts);
-dbg_options(Name, Opts) ->
-    dbg_opts(Name, Opts).
 
 dbg_opts(Name, Opts) ->
     case catch sys:debug_options(Opts) of

--- a/lib/wx/src/wx_object.erl
+++ b/lib/wx/src/wx_object.erl
@@ -563,21 +563,9 @@ opt(_, []) ->
 %% @hidden
 debug_options(Name, Opts) ->
     case opt(debug, Opts) of
-	{ok, Options} -> dbg_options(Name, Options);
-	_ -> dbg_options(Name, [])
+	{ok, Options} -> dbg_opts(Name, Options);
+	_ -> []
     end.
-%% @hidden
-dbg_options(Name, []) ->
-    Opts = 
-	case init:get_argument(generic_debug) of
-	    error ->
-		[];
-	    _ ->
-		[log, statistics]
-	end,
-    dbg_opts(Name, Opts);
-dbg_options(Name, Opts) ->
-    dbg_opts(Name, Opts).
 %% @hidden
 dbg_opts(Name, Opts) ->
     case catch sys:debug_options(Opts) of


### PR DESCRIPTION
This undocumented option makes an init:get_argument/1 call every time a gen_server is started.

@fishcakez
