### PR TITLE
Introduce new option 'raw' in file_info functions

### DIFF
--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -1291,6 +1291,8 @@
 			or before unix time epoch which is 1970-01-01 00:00 UTC. 
 			Default is <c>{time, local}</c>.
 		</p> 
+        <p>If the <c>raw</c> option is set, the file server will not be called
+          and only informations about local files will be returned.</p>
 		<note>
           <p>
 			  Since file times is stored in posix time on most OS it is
@@ -1517,6 +1519,8 @@
           the link will be returned in the <c>file_info</c> record and
           the <c>type</c> field of the record will be set to
           <c>symlink</c>.</p>
+      <p>If the <c>raw</c> option is set, the file server will not be called
+        and only informations about local files will be returned.</p>
         <p>If <c><anno>Name</anno></c> is not a symbolic link, this function returns
           exactly the same result as <c>read_file_info/1</c>.
           On platforms that do not support symbolic links, this function
@@ -1855,6 +1859,8 @@
 			interpret it as universal time and <c>posix</c> must be seconds since
 			or before unix time epoch which is 1970-01-01 00:00 UTC.
 			Default is <c>{time, local}</c>.
+        <p>If the <c>raw</c> option is set, the file server will not be called
+          and only informations about local files will be returned.</p>
 		</p>
         <p>The following fields are used from the record, if they are
           given.</p>


### PR DESCRIPTION
This option allows the caller not to go through the file server for information about files guaranteed to be local.
