### PR TITLE
Fix handling of broken symlinks in filelib

### DIFF
--- a/erts/doc/src/erl_prim_loader.xml
+++ b/erts/doc/src/erl_prim_loader.xml
@@ -148,6 +148,22 @@
       </desc>
     </func>
     <func>
+      <name name="read_link_info" arity="1"/>
+      <fsummary>Get information about a link or file</fsummary>
+      <desc>
+        <p>This function works like
+          <seealso marker="#read_file_info/1">read_file_info/1</seealso>
+          except that if <c><anno>Filename</anno></c> is a symbolic link,
+          information about the link will be returned in the <c>file_info</c>
+          record and the <c>type</c> field of the record will be set to
+          <c>symlink</c>.</p>
+        <p>If <c><anno>Filename</anno></c> is not a symbolic link, this function
+          returns exactly the same result as <c>read_file_info/1</c>.
+          On platforms that do not support symbolic links, this function
+          is always equivalent to <c>read_file_info/1</c>.</p>
+      </desc>
+    </func>
+    <func>
       <name name="set_path" arity="1"/>
       <fsummary>Set the path of the loader</fsummary>
       <desc>

--- a/lib/kernel/src/erl_boot_server.erl
+++ b/lib/kernel/src/erl_boot_server.erl
@@ -341,9 +341,13 @@ handle_command(S, PS, Msg) ->
 	    send_file_result(S, list_dir, Res),
 	    PS2;
 	{read_file_info,File} ->
-	    {Res, PS2} = erl_prim_loader:prim_read_file_info(PS, File),
+	    {Res, PS2} = erl_prim_loader:prim_read_file_info(PS, File, true),
 	    send_file_result(S, read_file_info, Res),
 	    PS2;
+        {read_link_info,File} ->
+            {Res, PS2} = erl_prim_loader:prim_read_file_info(PS, File, false),
+            send_file_result(S, read_link_info, Res),
+            PS2;
 	get_cwd ->
 	    {Res, PS2} = erl_prim_loader:prim_get_cwd(PS, []),
 	    send_file_result(S, get_cwd, Res),

--- a/lib/stdlib/src/filelib.erl
+++ b/lib/stdlib/src/filelib.erl
@@ -265,7 +265,7 @@ do_wildcard(Pattern, Cwd, Mod) ->
     lists:sort(Files).
 
 do_wildcard_1({exists,File}, Mod) ->
-    case eval_read_file_info(File, Mod) of
+    case eval_read_link_info(File, Mod) of
 	{ok,_} -> [File];
 	_ -> []
     end;
@@ -488,7 +488,7 @@ badpattern(Reason) ->
     error({badpattern,Reason}).
 
 eval_read_file_info(File, file) ->
-    file:read_link_info(File);
+    file:read_file_info(File);
 eval_read_file_info(File, erl_prim_loader) ->
     case erl_prim_loader:read_file_info(File) of
 	error -> {error, erl_prim_loader};
@@ -496,6 +496,16 @@ eval_read_file_info(File, erl_prim_loader) ->
     end;
 eval_read_file_info(File, Mod) ->
     Mod:read_file_info(File).
+
+eval_read_link_info(File, file) ->
+    file:read_link_info(File);
+eval_read_link_info(File, erl_prim_loader) ->
+    case erl_prim_loader:read_link_info(File) of
+        error -> {error, erl_prim_loader};
+        Res-> Res
+    end;
+eval_read_link_info(File, Mod) ->
+    Mod:read_link_info(File).
 
 eval_list_dir(Dir, file) ->
     file:list_dir(Dir);


### PR DESCRIPTION
This fixes a bug introduced in f11aabdc9fec593c31e6c4f3fa25c1707e9c35df where filelib:eval_read_file_info/2 was made to use file:read_link_info/1 to never follow symlinks. This fixed wildcard/1 but broke every other function using eval_read_file_info/2.

@lpgauth
@stolen
