### PR TITLE
Fix bug in filelib:wildcard/2 when 'Cwd' is ending with a dot

### DIFF
--- a/lib/stdlib/src/filelib.erl
+++ b/lib/stdlib/src/filelib.erl
@@ -371,7 +371,7 @@ compile_wildcard(Pattern, Cwd0) ->
     [Root|Rest] = filename:split(Pattern),
     case filename:pathtype(Root) of
 	relative ->
-	    Cwd = filename:join([Cwd0]),
+	    Cwd = prepare_base(Cwd0),
 	    compile_wildcard_2([Root|Rest], {cwd,Cwd});
 	_ ->
 	    compile_wildcard_2(Rest, {root,0,Root})

--- a/lib/stdlib/test/filelib_SUITE.erl
+++ b/lib/stdlib/test/filelib_SUITE.erl
@@ -86,6 +86,7 @@ wildcard_two(Config) when is_list(Config) ->
     ?line ok = file:make_dir(Dir),
     ?line do_wildcard_1(Dir, fun(Wc) -> io:format("~p~n",[{Wc,Dir, X = filelib:wildcard(Wc, Dir)}]),X  end),
     ?line do_wildcard_1(Dir, fun(Wc) -> filelib:wildcard(Wc, Dir++"/") end),
+    ?line do_wildcard_1(Dir, fun(Wc) -> filelib:wildcard(Wc, Dir++"/.") end),
     case os:type() of
 	{win32,_} ->
 	    ok;


### PR DESCRIPTION
In such case, filelib:wildcard/2 returned truncated results:

``` erlang
  1> file:set_cwd("/usr/lib/erlang/lib").
  ok
  2> filelib:wildcard("stdlib-*/ebin/*.app", filename:absname(".")).
  ["dlib-2.1/ebin/stdlib.app"]
```
