### PR TITLE
Fix minor grammatical errors in epmd docs

### DIFF
--- a/erts/doc/src/epmd.xml
+++ b/erts/doc/src/epmd.xml
@@ -58,12 +58,12 @@
       of the IP address and a port number. The name of the node is
       an atom on the form of <c><![CDATA[Name@Node]]></c>.
       The job of the <c><![CDATA[epmd]]></c> daemon is to keep track of which
-      node name listens on which address. Hence, <c><![CDATA[epmd]]></c> map
+      node name listens on which address. Hence, <c><![CDATA[epmd]]></c> maps
       symbolic node names to machine addresses.</p>
 
       <p>The TCP/IP <c>epmd</c> daemon actually only keeps track of
-      the <c>Name</c> (first) part of an Erlang node name, the <c>Host</c>
-      part (whatever is after the <c><![CDATA[@]]></c> is implicit in the
+      the <c>Name</c> (first) part of an Erlang node name. The <c>Host</c>
+      part (whatever is after the <c><![CDATA[@]]></c>) is implicit in the
       node name where the <c>epmd</c> daemon was actually contacted,
       as is the IP address where the Erlang node can be
       reached. Consistent and correct TCP naming services are
@@ -77,12 +77,12 @@
         <p>The daemon is started automatically by the <c>erl</c>
         command if the node is to be distributed and there is no
         running instance present. If automatically launched,
-        environment variables has to be used to alter the behavior of
+        environment variables have to be used to alter the behavior of
         the daemon. See the <seealso
         marker="#environment_variables">Environment
         variables</seealso> section below.</p>
 
-        <p>If the -daemon argument is not given, the
+        <p>If the -daemon argument is not given, 
         <c><![CDATA[epmd]]></c> runs as a normal program with the
 	controlling terminal of the shell in which it is
 	started. Normally, it should run as a daemon.</p>
@@ -122,7 +122,7 @@
       comma-separated list of IP addresses and on the loopback address
       (which is implicitly added to the list if it has not been
       specified). This can also be set using the
-      <c><![CDATA[ERL_EPMD_ADDRESS]]></c> environment variable, see the
+      <c><![CDATA[ERL_EPMD_ADDRESS]]></c> environment variable. See the
       section <seealso marker="#environment_variables">Environment
       variables</seealso> below.</p>
     </item>
@@ -130,7 +130,7 @@
     <item>
       <p>Let this instance of epmd listen to another TCP port than
       default 4369. This can also be set using the
-      <c><![CDATA[ERL_EPMD_PORT]]></c> environment variable, see the
+      <c><![CDATA[ERL_EPMD_PORT]]></c> environment variable. See the
       section <seealso marker="#environment_variables">Environment
       variables</seealso> below</p>
     </item>
@@ -153,7 +153,7 @@
             <p>With relaxed command checking, the <c>epmd</c> daemon can be killed from the localhost with i.e. <c>epmd -kill</c> even if there are active nodes registered. Normally only daemons with an empty node database can be killed with the <c>epmd -kill</c> command.</p>
 	  </item>
 	  <item>
-	    <p>The <c>epmd -stop</c> command (and the corresponding messages to epmd, as can be given using <c>erl_interface/ei</c>) is normally always ignored, as it opens up for strange situation when two nodes of the same name can be alive at the same time. A node unregisters itself by just closing the connection to epmd, why the <c>stop</c> command was only intended for use in debugging situations.</p>
+	    <p>The <c>epmd -stop</c> command (and the corresponding messages to epmd, as can be given using <c>erl_interface/ei</c>) is normally always ignored, as it opens up the possibility of a strange situation where two nodes of the same name can be alive at the same time. A node unregisters itself by just closing the connection to epmd, which is why the <c>stop</c> command was only intended for use in debugging situations.</p>
 	    <p>With relaxed command checking enabled, you can forcibly unregister live nodes.</p>
 	  </item>
         </list>
@@ -166,7 +166,7 @@
   <section>
     <marker id="debug_flags"></marker>
     <title>DbgExtra options</title>
-    <p>These options are purely for debugging and testing epmd clients, they should not be used in normal operation.</p>
+    <p>These options are purely for debugging and testing epmd clients. They should not be used in normal operation.</p>
 
     <taglist>
     <tag><c><![CDATA[-packet_timeout Seconds]]></c></tag>
@@ -177,9 +177,9 @@
     </item>
     <tag><c><![CDATA[-delay_accept Seconds]]></c></tag>
     <item>
-    <p>To simulate a busy server you can insert a delay between epmd
-    gets notified about that a new connection is requested and
-    when the connections gets accepted.</p>
+    <p>To simulate a busy server you can insert a delay between when epmd
+    gets notified that a new connection is requested and
+    when the connection gets accepted.</p>
     </item>
     <tag><c><![CDATA[-delay_write Seconds]]></c></tag>
     <item>
@@ -191,15 +191,15 @@
   <section>
     <marker id="interactive_flags"></marker>
     <title>Interactive options</title>
-    <p>These options make <c>epmd</c> run as an interactive command displaying the results of sending queries ta an already running instance of <c>epmd</c>. The epmd contacted is always on the local node, but the <c>-port</c> option can be used to select between instances if several are running using different port on the host.</p>
+    <p>These options make <c>epmd</c> run as an interactive command, displaying the results of sending queries to an already running instance of <c>epmd</c>. The epmd contacted is always on the local node, but the <c>-port</c> option can be used to select between instances if several are running using different ports on the host.</p>
     <taglist>
     <tag><c><![CDATA[-port No]]></c></tag>
     <item>
       <p>Contacts the <c>epmd</c> listening on the given TCP port number
       (default 4369). This can also be set using the
-      <c><![CDATA[ERL_EPMD_PORT]]></c> environment variable, see the
+      <c><![CDATA[ERL_EPMD_PORT]]></c> environment variable. See the
       section <seealso marker="#environment_variables">Environment
-      variables</seealso> below</p>
+      variables</seealso> below.</p>
     </item>
     <tag><c><![CDATA[-names]]></c></tag>
     <item>
@@ -210,7 +210,7 @@
       <p>Kill the currently running <c>epmd</c>.</p>
 
       <p>Killing the running <c>epmd</c> is only allowed if <c>epmd
-        -names</c> show an empty database or
+        -names</c> shows an empty database or
         <c>-relaxed_command_check</c> was given when the running
         instance of <c>epmd</c> was started. Note that
         <c>-relaxed_command_check</c> is given when starting the
@@ -228,7 +228,7 @@
        <p>This command can only be used when contacting <c>epmd</c>
        instances started with the <c>-relaxed_command_check</c>
        flag. Note that relaxed command checking has to be enabled for
-       the <c>epmd</c> daemon contacted, When running epmd
+       the <c>epmd</c> daemon contacted. When running epmd
        interactively,
         <c>-relaxed_command_check</c> has no effect.</p>
     </item>
@@ -259,7 +259,7 @@
       <item>
         <p>If set prior to start, the <c>epmd</c> daemon will behave
         as if the <c>-relaxed_command_check</c> option was given at
-        start-up. If consequently setting this option before starting
+        start-up. Consequently, if this option is set before starting
         the Erlang virtual machine, the automatically started
         <c>epmd</c> will accept the <c>-kill</c> and <c>-stop</c>
         commands without restrictions.</p>
@@ -287,8 +287,8 @@
   remote hosts. However, only the query commands are answered (and
   acted upon) if the query comes from a remote host. It is always an
   error to try to register a nodename if the client is not a process
-  located on the same host as the <c>epmd</c> instance is running on,
-  why such requests are considered hostile and the connection is
+  located on the same host as the <c>epmd</c> instance is running on-
+  such requests are considered hostile and the connection is
   immediately closed.</p>
 
   <p>The queries accepted from remote nodes are:</p>
@@ -306,4 +306,5 @@
   </section>
 
 </comref>
+
 


### PR DESCRIPTION
Small grammar changes.
