### PR TITLE
epmd: pedantic spelling fix in comments

### DIFF
--- a/erts/epmd/src/epmd.c
+++ b/erts/epmd/src/epmd.c
@@ -345,7 +345,7 @@ static void run_daemon(EpmdVars *g)
        inform it of that the log is closed. */
     closelog();
 
-    /* These chouldn't be needed but for safety... */
+    /* These shouldn't be needed but for safety... */
 
     open("/dev/null", O_RDONLY); /* Order is important! */
     open("/dev/null", O_WRONLY);
@@ -386,7 +386,7 @@ static void run_daemon(EpmdVars *g)
     close(1);
     close(2);
 
-    /* These chouldn't be needed but for safety... */
+    /* These shouldn't be needed but for safety... */
 
     open("nul", O_RDONLY);
     open("nul", O_WRONLY);


### PR DESCRIPTION
Correct spelling errors in the run_daemon() comments which describe
the redirection of stdin, stdout, and stderr to /dev/null for safety
reasons.

(Exceptionally pedantic but this was literally the first piece of code I decided to examine in the `otp` repository and it popped out at me. Present since at least the initial extended Erlang OTP history commit, b48c3645)
