### PR TITLE
Fix HiPE debug lock checking on OS X 64bit

### DIFF
--- a/erts/emulator/hipe/hipe_amd64_bifs.m4
+++ b/erts/emulator/hipe/hipe_amd64_bifs.m4
@@ -39,7 +39,10 @@ define(HANDLE_GOT_MBUF,`
 	jmp 2b')
 
 `#if defined(ERTS_ENABLE_LOCK_CHECK) && defined(ERTS_SMP)
-#  define CALL_BIF(F)	movq $CSYM(F), P_BIF_CALLEE(P); call CSYM(hipe_debug_bif_wrapper) 
+#  define CALL_BIF(F) \
+		movq CSYM(F)@GOTPCREL(%rip), %r11; \
+		movq %r11, P_BIF_CALLEE(P); \
+		call CSYM(hipe_debug_bif_wrapper)
 #else
 #  define CALL_BIF(F)	call	CSYM(F)
 #endif'


### PR DESCRIPTION
Position-independent code is mandatory on OS X. We use r11 as an intermediate register to fill
BIF_P->hipe.bif_callee. This fixes the following error when doing `make debug FLAVOR=smp`:

```
clang -cc1as: fatal error: error in backend: 32-bit absolute addressing is not supported in 64-bit mode
```
