### PR TITLE
[tools/cover] Remove bottleneck in reset/0

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -2360,22 +2360,13 @@ do_reset_collection_table(Module) ->
     ets:match_delete(?COLLECTION_TABLE, {#bump{module=Module},'_'}).
 
 %% do_reset(Module) -> ok
-%% The reset is done on a per-clause basis to avoid building
-%% long lists in the case of very large modules
 do_reset(Module) ->
-    [{Module,Clauses}] = ets:lookup(?COVER_CLAUSE_TABLE, Module),
-    do_reset2(Clauses).
-
-do_reset2([{M,F,A,C,_L}|Clauses]) ->
-    Pattern = {#bump{module=M, function=F, arity=A, clause=C}, '_'},
+    Pattern = {#bump{module=Module, _ = '_'}, '_'},
     Bumps = ets:match_object(?COVER_TABLE, Pattern),
     lists:foreach(fun({Bump,_N}) ->
 			  ets:insert(?COVER_TABLE, {Bump,0})
 		  end,
-		  Bumps),
-    do_reset2(Clauses);
-do_reset2([]) ->
-    ok.    
+		  Bumps).
 
 do_clear(Module) ->
     ets:match_delete(?COVER_CLAUSE_TABLE, {Module,'_'}),


### PR DESCRIPTION
do_reset/1 tried to avoid building long lists by resetting one
clause at a time. However, if the modules are large,
ets:match_object will take enough time to make reset/0 relly
slow. Thus, it is better to reset one module at a time.

We observed that our test suite was spending significant time (~10s) resetting cover - The issue was that to avoid building "long lists" reset was done on a per-clause basis, where each reset contained a call to ets:match_object.

It should be a safe optimization to assume that the list of clauses/lines fits in memory. (If that is not the case reset/0 will hardly be the main problem!)

While covering ~30 medium sized modules (~50 clauses per module) this patch reduced the time for reset/0 from 340ms to 8ms. And for the full test suite 6600ms was reduced to 30ms.