### PR TITLE
Improve standard_error

### DIFF
--- a/lib/kernel/test/Makefile
+++ b/lib/kernel/test/Makefile
@@ -77,7 +77,8 @@ MODULES= \
 	ignore_cores \
 	zlib_SUITE \
 	loose_node \
-	sendfile_SUITE
+	sendfile_SUITE \
+	standard_error_SUITE
 
 APP_FILES = \
 	appinc.app \

--- a/lib/kernel/test/standard_error_SUITE.erl
+++ b/lib/kernel/test/standard_error_SUITE.erl
@@ -1,0 +1,38 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2014. All Rights Reserved.
+%%
+%% The contents of this file are subject to the Erlang Public License,
+%% Version 1.1, (the "License"); you may not use this file except in
+%% compliance with the License. You should have received a copy of the
+%% Erlang Public License along with this software. If not, it can be
+%% retrieved online at http://www.erlang.org/.
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(standard_error_SUITE).
+
+-export([all/0,suite/0]).
+-export([badarg/1,getopts/1]).
+
+suite() ->
+    [{ct_hooks,[ts_install_cth]}].
+
+all() -> 
+    [badarg,getopts].
+
+badarg(Config) when is_list(Config) ->
+    {'EXIT',{badarg,_}} = (catch io:put_chars(standard_error, [oops])),
+    true = erlang:is_process_alive(whereis(standard_error)),
+    ok.
+
+getopts(Config) when is_list(Config) ->
+    [{encoding,latin1}] = io:getopts(standard_error),
+    ok.


### PR DESCRIPTION
The process handling standard_error didn't handle the getopts request correctly, nor its options were consistent with standard_io and was subject to crashes on bad protocol input (e.g. `io:put_chars(standard_error, [oops])`).

No tests yet because I would like to discuss it first.

Cc @alco