### PR TITLE
Added systemd notify support to EPMD

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1699,6 +1699,7 @@ AC_CHECK_HEADERS(systemd/sd-daemon.h,
 if test x"$have_sd_listen_fds" = x"yes" && \
    test x"$have_sd_notify" = x"yes" && \
    test x"$have_systemd_sd_daemon_h" = x"yes"; then
+  AC_DEFINE([HAVE_SYSTEMD_DAEMON],[1],[Define if you have systemd daemon])
   SYSTEMD_DAEMON_LIBS=$LIBS
 elif test x"$enable_systemd" = x"yes"; then
   AC_MSG_FAILURE([--enable-systemd was given, but test for systemd failed])

--- a/erts/epmd/src/epmd.c
+++ b/erts/epmd/src/epmd.c
@@ -175,9 +175,9 @@ int main(int argc, char** argv)
     g->nodes.reg = g->nodes.unreg = g->nodes.unreg_tail = NULL;
     g->nodes.unreg_count = 0;
     g->active_conn    = 0;
-#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#ifdef HAVE_SYSTEMD_DAEMON
     g->is_systemd     = 0;
-#endif /* HAVE_SYSTEMD_SD_DAEMON */
+#endif /* HAVE_SYSTEMD_DAEMON */
 
     for (i = 0; i < MAX_LISTEN_SOCKETS; i++)
 	g->listenfd[i] = -1;
@@ -251,11 +251,11 @@ int main(int argc, char** argv)
 	    else
 		usage(g);
 	    epmd_cleanup_exit(g,0);
-#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#ifdef HAVE_SYSTEMD_DAEMON
 	} else if (strcmp(argv[0], "-systemd") == 0) {
             g->is_systemd = 1;
             argv++; argc--;
-#endif /* HAVE_SYSTEMD_SD_DAEMON */
+#endif /* HAVE_SYSTEMD_DAEMON */
 	} else
 	    usage(g);
     }
@@ -461,11 +461,11 @@ static void usage(EpmdVars *g)
     fprintf(stderr, "        Forcibly unregisters a name with epmd\n");
     fprintf(stderr, "        (only allowed if -relaxed_command_check was given when \n");
     fprintf(stderr, "        epmd was started).\n");
-#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#ifdef HAVE_SYSTEMD_DAEMON
     fprintf(stderr, "    -systemd\n");
     fprintf(stderr, "        Wait for socket from systemd. The option makes sense\n");
     fprintf(stderr, "        when started from .socket unit.\n");
-#endif /* HAVE_SYSTEMD_SD_DAEMON */
+#endif /* HAVE_SYSTEMD_DAEMON */
     epmd_cleanup_exit(g,1);
 }
 
@@ -594,10 +594,10 @@ void epmd_cleanup_exit(EpmdVars *g, int exitval)
 	  free(g->argv[i]);
       free(g->argv);
   }
-#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#ifdef HAVE_SYSTEMD_DAEMON
   sd_notifyf(0, "STATUS=Exited.\n"
                 "ERRNO=%i", exitval);
-#endif /* HAVE_SYSTEMD_SD_DAEMON_H */
+#endif /* HAVE_SYSTEMD_DAEMON */
   exit(exitval);
 }
 

--- a/erts/epmd/src/epmd_int.h
+++ b/erts/epmd/src/epmd_int.h
@@ -125,9 +125,9 @@
 #  include "sys/select.h"
 #endif
 
-#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#ifdef HAVE_SYSTEMD_DAEMON
 #  include <systemd/sd-daemon.h>
-#endif
+#endif /* HAVE_SYSTEMD_DAEMON */
 
 /* ************************************************************************ */
 /* Replace some functions by others by making the function name a macro */
@@ -340,9 +340,9 @@ typedef struct {
   int listenfd[MAX_LISTEN_SOCKETS];
   char *addresses;
   char **argv;
-#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#ifdef HAVE_SYSTEMD_DAEMON
   int is_systemd;
-#endif
+#endif /* HAVE_SYSTEMD_DAEMON */
 } EpmdVars;
 
 void dbg_printf(EpmdVars*,int,const char*,...);

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -213,7 +213,7 @@ void run(EpmdVars *g)
   node_init(g);
   g->conn = conn_init(g);
 
-#ifdef HAVE_SYSTEMD_SD_DAEMON
+#ifdef HAVE_SYSTEMD_DAEMON
   if (g->is_systemd)
     {
       int n;
@@ -244,7 +244,7 @@ void run(EpmdVars *g)
     }
   else
     {
-#endif /* HAVE_SYSTEMD_SD_DAEMON */
+#endif /* HAVE_SYSTEMD_DAEMON */
 
   dbg_printf(g,2,"try to initiate listening port %d", g->port);
 
@@ -310,9 +310,9 @@ void run(EpmdVars *g)
       SET_ADDR(iserv_addr[0],EPMD_ADDR_ANY,sport);
       num_sockets = 1;
     }
-#ifdef HAVE_SYSTEMD_SD_DAEMON
+#ifdef HAVE_SYSTEMD_DAEMON
     }
-#endif /* HAVE_SYSTEMD_SD_DAEMON */
+#endif /* HAVE_SYSTEMD_DAEMON */
 
 #if !defined(__WIN32__) && !defined(__OSE__)
   /* We ignore the SIGPIPE signal that is raised when we call write
@@ -330,13 +330,13 @@ void run(EpmdVars *g)
   FD_ZERO(&g->orig_read_mask);
   g->select_fd_top = 0;
 
-#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#ifdef HAVE_SYSTEMD_DAEMON
   if (g->is_systemd)
       for (i = 0; i < num_sockets; i++)
           select_fd_set(g, listensock[i]);
   else
     {
-#endif /* HAVE_SYSTEMD_SD_DAEMON */
+#endif /* HAVE_SYSTEMD_DAEMON */
   for (i = 0; i < num_sockets; i++)
     {
       if ((listensock[i] = socket(FAMILY,SOCK_STREAM,0)) < 0)
@@ -399,12 +399,12 @@ void run(EpmdVars *g)
       }
       select_fd_set(g, listensock[i]);
     }
-#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#ifdef HAVE_SYSTEMD_DAEMON
     }
     sd_notifyf(0, "READY=1\n"
                   "STATUS=Processing port mapping requests...\n"
                   "MAINPID=%lu", (unsigned long) getpid());
-#endif /* HAVE_SYSTEMD_SD_DAEMON_H */
+#endif /* HAVE_SYSTEMD_DAEMON */
 
   dbg_tty_printf(g,2,"entering the main select() loop");
 


### PR DESCRIPTION
We already have support for socket activation in EPMD. And this is just another missing piece of systemd support - now a systemd notification subsystem. See this link for further details:
- http://www.freedesktop.org/software/systemd/man/sd_notify.html

Since it's guarded with ifdefs I believe it's harmless for other platforms.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
