### PR TITLE
ct_slave  bugfix&feature

### DIFF
--- a/lib/common_test/src/ct_slave.erl
+++ b/lib/common_test/src/ct_slave.erl
@@ -37,7 +37,7 @@
 
 -record(options, {username, password, boot_timeout, init_timeout,
 		  startup_timeout, startup_functions, monitor_master,
-		  kill_if_fail, erl_flags, env}).
+		  kill_if_fail, erl_flags, env, ssh_port, ssh_opts}).
 
 %%%-----------------------------------------------------------------
 %%% @spec start(Node) -> Result
@@ -254,11 +254,13 @@ fetch_options(Options) ->
     KillIfFail = get_option_value(kill_if_fail, Options, true),
     ErlFlags = get_option_value(erl_flags, Options, []),
     EnvVars = get_option_value(env, Options, []),
+    SSHPort = get_option_value(ssh_port, Options, []),
+    SSHOpts = get_option_value(ssh_opts, Options, []),
     #options{username=UserName, password=Password,
 	     boot_timeout=BootTimeout, init_timeout=InitTimeout,
 	     startup_timeout=StartupTimeout, startup_functions=StartupFunctions,
 	     monitor_master=Monitor, kill_if_fail=KillIfFail,
-	     erl_flags=ErlFlags, env=EnvVars}.
+	     erl_flags=ErlFlags, env=EnvVars, ssh_port=SSHPort, ssh_opts=SSHOpts}.
 
 % send a message when slave node is started
 % @hidden
@@ -419,7 +421,13 @@ spawn_remote_node(Host, Node, Options) ->
     #options{username=Username,
 	     password=Password,
 	     erl_flags=ErlFlags,
-	     env=Env} = Options,
+	     env=Env,
+       ssh_port=MaybeSSHPort,
+       ssh_opts=SSHOpts} = Options,
+    SSHPort = case MaybeSSHPort of
+                [] -> 22; % Use default SSH port
+                A  -> A
+              end,
     SSHOptions = case {Username, Password} of
 	{[], []}->
 	    [];
@@ -427,9 +435,9 @@ spawn_remote_node(Host, Node, Options) ->
 	    [{user, Username}];
 	{_, _}->
 	    [{user, Username}, {password, Password}]
-    end ++ [{silently_accept_hosts, true}],
+    end ++ [{silently_accept_hosts, true}] ++ SSHOpts,
     check_for_ssh_running(),
-    {ok, SSHConnRef} = ssh:connect(atom_to_list(Host), 22, SSHOptions),
+    {ok, SSHConnRef} = ssh:connect(atom_to_list(Host), SSHPort, SSHOptions),
     {ok, SSHChannelId} = ssh_connection:session_channel(SSHConnRef, infinity),
     ssh_setenv(SSHConnRef, SSHChannelId, Env),
     ssh_connection:exec(SSHConnRef, SSHChannelId, get_cmd(Node, ErlFlags), infinity).


### PR DESCRIPTION
Patch-1:  bugfix to start asn1 and public_key when starting ssh application.

Patch-2: support for ct_slave to pass ssh_port and ssh-options to ssh:connect.
