### PR TITLE
Implement cond expressions

### DIFF
--- a/erts/doc/src/absform.xml
+++ b/erts/doc/src/absform.xml
@@ -246,6 +246,10 @@
        where each <c><![CDATA[Ic_i]]></c> is an if clause then
        Rep(E) =
       <c><![CDATA[{'if',LINE,[Rep(Ic_1), ..., Rep(Ic_k)]}]]></c>.</item>
+      <item>If E is <c><![CDATA[cond Cc_1 ; ... ; Cc_k  end]]></c>,
+       where each <c><![CDATA[Cc_i]]></c> is a cond clause then
+       Rep(E) =
+      <c><![CDATA[{'cond',LINE,[Rep(Cc_1), ..., Rep(Cc_k)]}]]></c>.</item>
       <item>If E is <c><![CDATA[case E_0 of Cc_1 ; ... ; Cc_k end]]></c>,
        where <c><![CDATA[E_0]]></c> is an expression and each <c><![CDATA[Cc_i]]></c> is a
        case clause then
@@ -361,7 +365,7 @@
 
   <section>
     <title>Clauses</title>
-    <p>There are function clauses, if clauses, case clauses 
+    <p>There are function clauses, if clauses, cond clauses, case clauses
       and catch clauses.</p>
     <p>A clause <c><![CDATA[C]]></c> is one of the following alternatives:</p>
     <list type="bulleted">
@@ -375,6 +379,10 @@
       <item>If C is an if clause <c><![CDATA[Gs -> B]]></c> 
        where <c><![CDATA[Gs]]></c> is a guard sequence and <c><![CDATA[B]]></c> is a body, then 
        Rep(C) = <c><![CDATA[{clause,LINE,[],Rep(Gs),Rep(B)}]]></c>.</item>
+      <item>If C is a cond clause <c><![CDATA[E -> B]]></c>
+       where <c><![CDATA[E]]></c> is an expression and <c><![CDATA[B]]></c> is a
+       body, then
+       Rep(C) = <c><![CDATA[{clause,LINE,[],[[Rep(E)]],Rep(B)}]]></c>.</item>
       <item>If C is a case clause <c><![CDATA[P -> B]]></c> 
        where <c><![CDATA[P]]></c> is a pattern and <c><![CDATA[B]]></c> is a body, then 
        Rep(C) = <c><![CDATA[{clause,LINE,[Rep(P)],[],Rep(B)}]]></c>.</item>

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -1389,6 +1389,14 @@ is_not_tuple(#c_cons{}) -> true;
 is_not_tuple(#c_map{}) -> true;
 is_not_tuple(_) -> false.
 
+%% is_not_boolean(Core) -> true | false.
+%%  Returns true if Core is definitely not a boolean.
+
+is_not_boolean(#c_literal{val=Val}) when not is_boolean(Val) -> true;
+is_not_boolean(#c_tuple{}) -> true;
+is_not_boolean(#c_cons{}) -> true;
+is_not_boolean(_) -> false.
+
 %% eval_setelement(Call, Pos, Tuple, NewVal) -> Core.
 %%  Evaluates setelement/3 if position Pos is an integer
 %%  the shape of the tuple Tuple is known.
@@ -1672,7 +1680,8 @@ warn_no_clause_match(CaseOrig, CaseOpt) ->
     OrigCs = cerl:case_clauses(CaseOrig),
     OptCs = cerl:case_clauses(CaseOpt),
     case any(fun(C) -> not is_compiler_generated(C) end, OrigCs) andalso
-	all(fun is_compiler_generated/1, OptCs) of
+         all(fun is_compiler_generated/1, OptCs) andalso
+         not is_cond_case(CaseOrig) of
 	true ->
 	    %% The original list of clauses did contain at least one
 	    %% user-specified clause, but none of them will match.
@@ -1768,6 +1777,12 @@ will_match_1({true,_}) -> yes.
 opt_bool_case(#c_case{arg=Arg}=Case0) ->
     case is_bool_expr(Arg) of
 	false ->
+	    case is_cond_case(Case0) andalso is_not_boolean(Arg) of
+		false ->
+		    ok;
+		true ->
+		    add_warning(Case0, no_cond_match)
+	    end,
 	    Case0;
 	true ->
 	    try opt_bool_clauses(Case0) of
@@ -3110,6 +3125,10 @@ is_compiler_generated(Core) ->
     Anno = core_lib:get_anno(Core),
     member(compiler_generated, Anno).
 
+is_cond_case(Core) ->
+    Anno = core_lib:get_anno(Core),
+    member(cond_case, Anno).
+
 get_warnings() ->
     ordsets:from_list((erase({?MODULE,warnings}))).
 
@@ -3118,6 +3137,7 @@ get_warnings() ->
 	       | 'bin_partition' | 'bin_var_used' | 'bin_var_used_in_guard'
 	       | 'embedded_binary_size' | 'nomatch_clause_type'
 	       | 'nomatch_guard' | 'nomatch_shadow' | 'no_clause_match'
+	       | 'no_cond_match'
 	       | 'orig_bin_var_used_in_guard' | 'result_ignored'
 	       | 'useless_building'
 	       | {'eval_failure', term()}
@@ -3149,6 +3169,8 @@ format_error(nomatch_guard) ->
     "the guard for this clause evaluates to 'false'";
 format_error(no_clause_match) ->
     "no clause will ever match";
+format_error(no_cond_match) ->
+    "this clause will crash";
 format_error(nomatch_clause_type) ->
     "this clause cannot match because of different types/sizes";
 format_error({no_effect,{erlang,F,A}}) ->

--- a/lib/compiler/src/sys_pre_expand.erl
+++ b/lib/compiler/src/sys_pre_expand.erl
@@ -352,6 +352,9 @@ expr({block,Line,Es0}, St0) ->
 expr({'if',Line,Cs0}, St0) ->
     {Cs,St1} = icr_clauses(Cs0, St0),
     {{'if',Line,Cs},St1};
+expr({'cond',Line,Cs0}, St0) ->
+    {Cs,St1} = icr_clauses(Cs0, St0),
+    {{'cond',Line,Cs},St1};
 expr({'case',Line,E0,Cs0}, St0) ->
     {E,St1} = expr(E0, St0),
     {Cs,St2} = icr_clauses(Cs0, St1),

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -566,6 +566,8 @@ expr({'if',L,Cs0}, St0) ->
     Lanno = lineno_anno(L, St1),
     Fc = fail_clause([], Lanno, #c_literal{val=if_clause}),
     {#icase{anno=#a{anno=Lanno},args=[],clauses=Cs1,fc=Fc},[],St1};
+expr({'cond',L,Cs}, St) ->
+    cond_tq(L, Cs, St);
 expr({'case',L,E0,Cs0}, St0) ->
     {E1,Eps,St1} = novars(E0, St0),
     {Cs1,St2} = clauses(Cs0, St1),
@@ -954,6 +956,34 @@ bitstr({bin_element,_,E0,Size0,[Type,{unit,Unit}|Flags]}, St0) ->
 	       type=#c_literal{val=Type},
 	       flags=#c_literal{val=Flags}},
      Eps ++ Eps2,St2}.
+
+%% cond_tq(Line, [Clause], State) -> {Case,[PreExp],State}.
+
+cond_tq(L, [{clause,CL,[],[[E]],B}|Cs], St0) ->
+    LA = lineno_anno(CL, St0),
+    {Cc,Cps,St1} = cond_tq(L, Cs, St0),
+    {Fpat,St2} = new_var(St1),
+    Fc = fail_clause([Fpat], LA,
+                     c_tuple([#c_literal{val=badbool},Fpat])),
+    {Ec,Eps,St3} = novars(E, St2),
+    {Bc,St4} = exprs(B, St3),
+    {#icase{anno=#a{anno=[cond_case|LA]},
+            args=[Ec],
+            clauses=[#iclause{anno=#a{anno=LA},
+                              pats=[#c_literal{anno=LA,val=true}],
+                              guard=[],
+                              body=Bc},
+                     #iclause{anno=#a{anno=LA},
+                              pats=[#c_literal{anno=LA,val=false}],
+                              guard=[],
+                              body=Cps ++ [Cc]}],
+            fc=Fc},
+     Eps,St4};
+cond_tq(L, [], St) ->
+    Anno = lineno_anno(L, St),
+    {#iprimop{anno=#a{anno=Anno},name=#c_literal{val=match_fail},
+              args=[#c_literal{val=cond_clause}]},
+     [],St}.
 
 %% fun_tq(Id, [Clauses], Line, State, NameInfo) -> {Fun,[PreExp],State}.
 

--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -39,7 +39,7 @@
 	 guard/1,bad_arith/1,bool_cases/1,bad_apply/1,
          files/1,effect/1,bin_opt_info/1,bin_construction/1,
 	 comprehensions/1,maps/1,redundant_boolean_clauses/1,
-	 latin1_fallback/1]).
+         latin1_fallback/1,'cond'/1]).
 
 % Default timetrap timeout (set in init_per_testcase).
 -define(default_timeout, ?t:minutes(2)).
@@ -64,7 +64,7 @@ groups() ->
       [pattern,pattern2,pattern3,pattern4,guard,
        bad_arith,bool_cases,bad_apply,files,effect,
        bin_opt_info,bin_construction,comprehensions,maps,
-       redundant_boolean_clauses,latin1_fallback]}].
+       redundant_boolean_clauses,latin1_fallback,'cond']}].
 
 init_per_suite(Config) ->
     Config.
@@ -676,6 +676,24 @@ latin1_fallback(Conf) when is_list(Conf) ->
 	    {warnings,[{2,compile,reparsing_invalid_unicode}]}}],
     [] = run(Conf, Ts3),
 
+    ok.
+
+'cond'(Config) when is_list(Config) ->
+    Ts = [{cond_1,
+           <<"
+             t(X) ->
+                 cond true -> ok end.
+           ">>,
+           [],
+           {warnings,[]}},
+          {cond_2,
+           <<"
+             t(X) ->
+                 cond false -> ok end.
+           ">>,
+           [],
+           {warnings,[]}}],
+    run(Config, Ts),
     ok.
 
 %%%

--- a/lib/debugger/src/dbg_ieval.erl
+++ b/lib/debugger/src/dbg_ieval.erl
@@ -730,6 +730,10 @@ expr({'case',Line,E,Cs}, Bs0, Ieval) ->
 expr({'if',Line,Cs}, Bs, Ieval) ->
     if_clauses(Cs, Bs, Ieval#ieval{line=Line});
 
+%% Cond statement
+expr({'cond',Line,Cs}, Bs, Ieval) ->
+    cond_clauses(Cs, Bs, Ieval#ieval{line=Line});
+
 %% Andalso/orelse
 expr({'andalso',Line,E1,E2}, Bs0, Ieval) ->
     case expr(E1, Bs0, Ieval#ieval{line=Line, top=false}) of
@@ -1363,6 +1367,19 @@ if_clauses([{clause,_,[],G,B}|Cs], Bs, Ieval) ->
     end;
 if_clauses([], Bs, Ieval) ->
     exception(error, if_clause, Bs, Ieval).
+
+%% cond_clauses(Clauses, Bindings, Ieval)
+cond_clauses([{clause,_,[],[[E]],B}|Cs], Bs0, Ieval) ->
+    case expr(E, Bs0, Ieval) of
+        {value,true,Bs} ->
+            seq(B, Bs, Ieval);
+        {value,false,_} ->
+            cond_clauses(Cs, Bs0, Ieval);
+        {value,Other,Bs} ->
+            exception(error, {badbool,Other}, Bs, Ieval)
+    end;
+cond_clauses([], Bs, Ieval) ->
+    exception(error, cond_clause, Bs, Ieval).
 
 %% case_clauses(Value, Clauses, Bindings, Error, Ieval)
 %%   Error = try_clause | case_clause

--- a/lib/debugger/src/dbg_iload.erl
+++ b/lib/debugger/src/dbg_iload.erl
@@ -372,6 +372,9 @@ expr({block,Line,Es0}, Lc) ->
 expr({'if',Line,Cs0}, Lc) ->
     Cs1 = icr_clauses(Cs0, Lc),
     {'if',Line,Cs1};
+expr({'cond',Line,Cs0}, Lc) ->
+    Cs1 = cond_clauses(Cs0, Lc),
+    {'cond',Line,Cs1};
 expr({'case',Line,E0,Cs0}, Lc) ->
     E1 = expr(E0, false),
     Cs1 = icr_clauses(Cs0, Lc),
@@ -533,6 +536,10 @@ icr_clauses([C0|Cs], Lc) ->
     C1 = clause(C0, Lc),
     [C1|icr_clauses(Cs, Lc)];
 icr_clauses([], _) -> [].
+
+cond_clauses([{clause,L,[],[[G]],B}|Cs], Lc) ->
+    [{clause,L,[],[[expr(G, true)]],exprs(B, Lc)}|cond_clauses(Cs, Lc)];
+cond_clauses([], _) -> [].
 
 fun_clauses([{clause,L,H,G,B}|Cs]) ->
     [{clause,L,head(H),guard(G),exprs(B, true)}|fun_clauses(Cs)];

--- a/lib/debugger/test/erl_eval_SUITE.erl
+++ b/lib/debugger/test/erl_eval_SUITE.erl
@@ -40,7 +40,8 @@
          funs/1,
 	 try_catch/1,
 	 eval_expr_5/1,
-         eep37/1]).
+         eep37/1,
+         'cond'/1]).
 
 %%
 %% Define to run outside of test server
@@ -80,7 +81,7 @@ all() ->
      pattern_expr, match_bin, guard_3, guard_4, lc,
      simple_cases, unary_plus, apply_atom, otp_5269,
      otp_6539, otp_6543, otp_6787, otp_6977, otp_7550,
-     otp_8133, funs, try_catch, eval_expr_5, eep37].
+     otp_8133, funs, try_catch, eval_expr_5, eep37, 'cond'].
 
 groups() -> 
     [].
@@ -1344,6 +1345,33 @@ eep37(Config) when is_list(Config) ->
           end,
           "(fun Fact(N) when N > 0 -> N * Fact(N - 1); Fact(0) -> 1 end)(6).",
           720),
+    ok.
+
+'cond'(Config) when is_list(Config) ->
+    check(fun () -> cond true -> ok end end,
+          "cond true -> ok end.",
+          ok),
+    check(fun () -> catch cond throw(not_ok) -> ok end end,
+          "catch cond throw(not_ok) -> ok end.",
+          not_ok),
+    check(fun () ->
+                  {'EXIT',{{badbool,hello},_}} = (catch cond hello -> ok end),
+                  done
+          end,
+          "begin "
+          "    {'EXIT',{{badbool,hello},_}} = (catch cond hello -> ok end), "
+          "    done "
+          "end.",
+          done),
+    check(fun () ->
+                  {'EXIT',{cond_clause,_}} = (catch cond false -> ok end),
+                  done
+          end,
+          "begin "
+          "    {'EXIT',{cond_clause,_}} = (catch cond false -> ok end), "
+          "    done "
+          "end.",
+          done),
     ok.
 
 %% Check the string in different contexts: as is; in fun; from compiled code.

--- a/lib/stdlib/examples/erl_id_trans.erl
+++ b/lib/stdlib/examples/erl_id_trans.erl
@@ -419,6 +419,9 @@ expr({block,Line,Es0}) ->
 expr({'if',Line,Cs0}) ->
     Cs1 = icr_clauses(Cs0),
     {'if',Line,Cs1};
+expr({'cond',Line,Cs0}) ->
+    Cs1 = icr_clauses(fun ([[E]]) -> expr(E) end, Cs0),
+    {'cond',Line,Cs1};
 expr({'case',Line,E0,Cs0}) ->
     E1 = expr(E0),
     Cs1 = icr_clauses(Cs0),
@@ -519,10 +522,13 @@ record_updates([]) -> [].
 
 %% -type icr_clauses([Clause]) -> [Clause].
 
-icr_clauses([C0|Cs]) ->
-    C1 = clause(C0),
-    [C1|icr_clauses(Cs)];
-icr_clauses([]) -> [].
+icr_clauses(Cs) ->
+    icr_clauses(fun guard/1, Cs).
+
+icr_clauses(GuardF, [C0|Cs]) ->
+    C1 = clause(GuardF, C0),
+    [C1|icr_clauses(GuardF, Cs)];
+icr_clauses(_, []) -> [].
 
 %% -type lc_bc_quals([Qualifier]) -> [Qualifier].
 %%  Allow filters to be both guard tests and general expressions.

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -351,6 +351,9 @@ expr({block,Line,Es0}, St0) ->
 expr({'if',Line,Cs0}, St0) ->
     {Cs,St1} = clauses(Cs0, St0),
     {{'if',Line,Cs},St1};
+expr({'cond',Line,Cs0}, St0) ->
+    {Cs,St1} = clauses(Cs0, St0),
+    {{'cond',Line,Cs},St1};
 expr({'case',Line,E0,Cs0}, St0) ->
     {E,St1} = expr(E0, St0),
     {Cs,St2} = clauses(Cs0, St1),

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -36,6 +36,7 @@ tuple
 record_expr record_tuple record_field record_fields
 map_expr map_tuple map_field map_field_assoc map_field_exact map_fields map_key
 if_expr if_clause if_clauses case_expr cr_clause cr_clauses receive_expr
+cond_expr cond_clauses cond_clause
 fun_expr fun_clause fun_clauses atom_or_var integer_or_var
 try_expr try_catch try_clause try_clauses
 function_call argument_list
@@ -56,6 +57,7 @@ char integer float atom string var
 
 '(' ')' ',' '->' ':-' '{' '}' '[' ']' '|' '||' '<-' ';' ':' '#' '.'
 'after' 'begin' 'case' 'try' 'catch' 'end' 'fun' 'if' 'of' 'receive' 'when'
+'cond'
 'andalso' 'orelse'
 'bnot' 'not'
 '*' '/' 'div' 'rem' 'band' 'and'
@@ -277,6 +279,7 @@ expr_max -> tuple : '$1'.
 expr_max -> '(' expr ')' : '$2'.
 expr_max -> 'begin' exprs 'end' : {block,?line('$1'),'$2'}.
 expr_max -> if_expr : '$1'.
+expr_max -> cond_expr : '$1'.
 expr_max -> case_expr : '$1'.
 expr_max -> receive_expr : '$1'.
 expr_max -> fun_expr : '$1'.
@@ -400,6 +403,15 @@ if_clauses -> if_clause ';' if_clauses : ['$1' | '$3'].
 
 if_clause -> guard clause_body :
 	{clause,?line(hd(hd('$1'))),[],'$1','$2'}.
+
+
+cond_expr -> 'cond' cond_clauses 'end' : {'cond',?line('$1'),'$2'}.
+
+cond_clauses -> cond_clause : ['$1'].
+cond_clauses -> cond_clause ';' cond_clauses : ['$1' | '$3'].
+
+cond_clause -> expr clause_body :
+	{clause,?line('$1'),[],[['$1']],'$2'}.
 
 
 case_expr -> 'case' expr 'of' cr_clauses 'end' :

--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -873,6 +873,7 @@ translate_language_element(Atom) ->
 		{bc,"binary comprehension"},
 		{block, "begin/end block"},
 		{'if', "if"},
+                {'cond', "cond"},
 		{'case', "case"},
 		{'receive', "receive"},
 		{'try', "try"},

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -393,6 +393,8 @@ expand_expr({block,L,Es}, C) ->
     {block,L,expand_exprs(Es, C)};
 expand_expr({'if',L,Cs}, C) ->
     {'if',L,expand_cs(Cs, C)};
+expand_expr({'cond',L,Cs}, C) ->
+    {'cond',L,expand_cs(Cs, C)};
 expand_expr({'case',L,E,Cs}, C) ->
     {'case',L,expand_expr(E, C),expand_cs(Cs, C)};
 expand_expr({'try',L,Es,Scs,Ccs,As}, C) ->

--- a/lib/stdlib/test/erl_eval_SUITE.erl
+++ b/lib/stdlib/test/erl_eval_SUITE.erl
@@ -43,7 +43,8 @@
 	 eval_expr_5/1,
 	 zero_width/1,
          eep37/1,
-         eep43/1]).
+         eep43/1,
+         'cond'/1]).
 
 %%
 %% Define to run outside of test server
@@ -83,7 +84,7 @@ all() ->
      simple_cases, unary_plus, apply_atom, otp_5269,
      otp_6539, otp_6543, otp_6787, otp_6977, otp_7550,
      otp_8133, otp_10622, funs, try_catch, eval_expr_5, zero_width,
-     eep37, eep43].
+     eep37, eep43, 'cond'].
 
 groups() -> 
     [].
@@ -1460,6 +1461,33 @@ eep43(Config) when is_list(Config) ->
           [#{hello => 0, price => 0}]),
     error_check("[camembert]#{}.", {badarg,[camembert]}),
     error_check("#{} = 1.", {badmatch,1}),
+    ok.
+
+'cond'(Config) when is_list(Config) ->
+    check(fun () -> cond true -> ok end end,
+          "cond true -> ok end.",
+          ok),
+    check(fun () -> catch cond throw(not_ok) -> ok end end,
+          "catch cond throw(not_ok) -> ok end.",
+          not_ok),
+    check(fun () ->
+                  {'EXIT',{{badbool,hello},_}} = (catch cond hello -> ok end),
+                  done
+          end,
+          "begin "
+          "    {'EXIT',{{badbool,hello},_}} = (catch cond hello -> ok end), "
+          "    done "
+          "end.",
+          done),
+    check(fun () ->
+                  {'EXIT',{cond_clause,_}} = (catch cond false -> ok end),
+                  done
+          end,
+          "begin "
+          "    {'EXIT',{cond_clause,_}} = (catch cond false -> ok end), "
+          "    done "
+          "end.",
+          done),
     ok.
 
 %% Check the string in different contexts: as is; in fun; from compiled code.

--- a/lib/stdlib/test/erl_expand_records_SUITE.erl
+++ b/lib/stdlib/test/erl_expand_records_SUITE.erl
@@ -38,7 +38,7 @@
 -export([attributes/1, expr/1, guard/1,
          init/1, pattern/1, strict/1, update/1,
 	 otp_5915/1, otp_7931/1, otp_5990/1,
-	 otp_7078/1, otp_7101/1, maps/1]).
+	 otp_7078/1, otp_7101/1, maps/1, 'cond'/1]).
 
 % Default timetrap timeout (set in init_per_testcase).
 -define(default_timeout, ?t:minutes(1)).
@@ -416,6 +416,19 @@ maps(Config) when is_list(Config) ->
 
              id(X) -> X.
             ">>],
+    run(Config, Ts, [strict_record_tests]),
+    ok.
+
+'cond'(Config) when is_list(Config) ->
+    Ts = [<<"-record(rr, {a=0,b,c}).
+             t() ->
+                 R0 = id(#rr{a=1,b=2,c=3}),
+                 cond is_record(R0, rr) -> R0#rr.a;
+                      R0#rr.a =:= #rr{}#rr.a -> R0#rr.b
+                 end,
+                 ok.
+
+             id(X) -> X.">>],
     run(Config, Ts, [strict_record_tests]),
     ok.
 

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -63,7 +63,8 @@
 	  too_many_arguments/1,
 	  basic_errors/1,bin_syntax_errors/1,
           predef/1,
-          maps/1,maps_type/1
+          maps/1,maps_type/1,
+          'cond'/1
         ]).
 
 % Default timetrap timeout (set in init_per_testcase).
@@ -92,7 +93,7 @@ all() ->
      bif_clash, behaviour_basic, behaviour_multiple,
      otp_7550, otp_8051, format_warn, {group, on_load},
      too_many_arguments, basic_errors, bin_syntax_errors, predef,
-     maps, maps_type].
+     maps, maps_type, 'cond'].
 
 groups() -> 
     [{unused_vars_warn, [],
@@ -3471,6 +3472,14 @@ maps_type(Config) when is_list(Config) ->
 	 ">>,
 	 [],
 	 {warnings,[{3,erl_lint,{new_var_arity_type,map}}]}}],
+    [] = run(Config, Ts),
+    ok.
+
+'cond'(Config) when is_list(Config) ->
+    Ts = [{cond_1,
+           <<"t(A) -> cond A =:= true -> ok; A =:= false -> error end.">>,
+           [],
+           []}],
     [] = run(Config, Ts),
     ok.
 

--- a/lib/stdlib/test/ms_transform_SUITE.erl
+++ b/lib/stdlib/test/ms_transform_SUITE.erl
@@ -41,6 +41,7 @@
 -export([warnings/1]).
 -export([no_warnings/1]).
 -export([eep37/1]).
+-export(['cond'/1]).
 -export([init_per_testcase/2, end_per_testcase/2]).
 
 init_per_testcase(_Func, Config) ->
@@ -58,7 +59,7 @@ all() ->
      record_index, multipass, bitsyntax, record_defaults,
      andalso_orelse, float_1_function, action_function,
      warnings, no_warnings, top_match, old_guards, autoimported,
-     semicolon, eep37].
+     semicolon, eep37, 'cond'].
 
 groups() -> 
     [].
@@ -814,6 +815,11 @@ eep37(Config) when is_list(Config) ->
                           "            ets:fun2ms(fun (X) -> X end)\n"
                           "    end,\n"
                           "F()">>).
+
+'cond'(Config) when is_list(Config) ->
+    setup(Config),
+    [{'$1',[],['$1']}] =
+        compile_and_run(<<"cond true -> ets:fun2ms(fun (X) -> X end) end">>).
 
 
 

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -744,6 +744,7 @@ resulting regexp is surrounded by \\_< and \\_>."
       "byte_size"
       "check_old_code"
       "check_process_code"
+      "cond"
       "date"
       "delete_module"
       "demonitor"
@@ -2583,7 +2584,7 @@ Value is list (stack token-start token-type in-what)."
 	       (if (and stack (memq (car (car stack)) '(icr begin try)))
 		   (erlang-pop stack))))
 	    )  
-      (cond ((looking-at "\\(if\\|case\\|receive\\)[^_a-zA-Z0-9]")
+      (cond ((looking-at "\\(if\\|case\\|cond\\|receive\\)[^_a-zA-Z0-9]")
 	     ;; Must push a new icr (if/case/receive) layer.
 	     (erlang-push (list 'icr token (current-column)) stack))
 	    ((looking-at "\\(try\\|after\\)[^_a-zA-Z0-9]")
@@ -3125,7 +3126,7 @@ This assumes that the preceding expression is either simple
 
 (defun erlang-at-keyword ()
   "Are we looking at an Erlang keyword which will increase indentation?"
-  (looking-at (concat "\\(when\\|if\\|fun\\|case\\|begin\\|"
+  (looking-at (concat "\\(when\\|if\\|fun\\|case\\|cond\\|begin\\|"
 		      "of\\|receive\\|after\\|catch\\|try\\)\\b")))
 
 (defun erlang-at-operator ()

--- a/lib/tools/emacs/test.erl.indented
+++ b/lib/tools/emacs/test.erl.indented
@@ -427,6 +427,22 @@ indent_icr(Z) -> 				% icr = if case receive
 	ok
     end,
 
+    %% test cond keyword
+    cond
+	A ->
+	    ok;
+	B ->
+	    true;
+	C ->
+	    false
+    end,
+    cond is_binary(A) ->
+	    A;
+	 is_binary(B) ->
+	    B;
+	 true ->
+	    {A,B}
+    end,
 
     %% receive
     receive 

--- a/lib/tools/emacs/test.erl.orig
+++ b/lib/tools/emacs/test.erl.orig
@@ -427,6 +427,22 @@ indent_icr(Z) -> 				% icr = if case receive
  ok
  end,
 
+%% test cond keyword
+	 cond
+A ->
+ok;
+B ->
+	    true;
+C ->
+false
+end,
+cond is_binary(A) ->
+A;
+      is_binary(B) ->
+B;
+true ->
+	    {A,B}
+end,
 
  %% receive
   receive 

--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -1671,6 +1671,9 @@ fix_last_expr([MungedExpr|MungedExprs], Line, Vars) ->
 fix_expr({'if',L,Clauses}, Line, Bump) -> 
     FixedClauses = fix_clauses(Clauses, Line, Bump),
     {'if',L,FixedClauses};
+fix_expr({'cond',L,Clauses}, Line, Bump) -> 
+    FixedClauses = fix_clauses(Clauses, Line, Bump),
+    {'cond',L,FixedClauses};
 fix_expr({'case',L,Expr,Clauses}, Line, Bump) ->
     FixedExpr = fix_expr(Expr, Line, Bump),
     FixedClauses = fix_clauses(Clauses, Line, Bump),
@@ -1823,6 +1826,9 @@ munge_expr({block,Line,Body}, Vars) ->
 munge_expr({'if',Line,Clauses}, Vars) -> 
     {MungedClauses,Vars2} = munge_clauses(Clauses, Vars),
     {{'if',Line,MungedClauses}, Vars2};
+munge_expr({'cond',Line,Clauses}, Vars) ->
+    {MungedClauses,Vars2} = munge_clauses(Clauses, Vars),
+    {{'cond',Line,MungedClauses}, Vars2};
 munge_expr({'case',Line,Expr,Clauses}, Vars) ->
     {MungedExpr,Vars2} = munge_expr(Expr, Vars),
     {MungedClauses,Vars3} = munge_clauses(Clauses, Vars2),

--- a/lib/tools/test/cover_SUITE.erl
+++ b/lib/tools/test/cover_SUITE.erl
@@ -29,7 +29,7 @@
 	 export_import/1,
 	 otp_5031/1, eif/1, otp_5305/1, otp_5418/1, otp_6115/1, otp_7095/1,
          otp_8188/1, otp_8270/1, otp_8273/1, otp_8340/1,
-	 otp_10979_hanging_node/1, compile_beam_opts/1, eep37/1]).
+         otp_10979_hanging_node/1, compile_beam_opts/1, eep37/1, 'cond'/1]).
 
 -export([do_coverage/1]).
 
@@ -50,7 +50,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
     NoStartStop = [eif,otp_5305,otp_5418,otp_7095,otp_8273,
-		   otp_8340,otp_8188,compile_beam_opts,eep37],
+                   otp_8340,otp_8188,compile_beam_opts,eep37,'cond'],
     StartStop = [start, compile, analyse, misc, stop,
 		 distribution, reconnect, die_and_reconnect,
 		 dont_reconnect_after_stop, stop_node_after_disconnect,
@@ -1440,6 +1440,18 @@ eep37(Config) when is_list(Config) ->
                        "    F(6)\n" % 1
                        "end\n">>,
                     Config),
+    ok.
+
+'cond'(Config) when is_list(Config) ->
+    [{{t,1},1},{{t,2},1},{{t,3},0},{{t,5},1}] =
+        analyse_expr(<<"begin\n" % 1
+                       "    cond lists:member(foo, [bar]) ->\n" % 1
+                       "             foo_in_list;\n" % 0
+                       "         true ->\n"
+                       "             foo_not_in_list\n" % 1
+                       "    end\n"
+                       "end\n">>,
+                     Config),
     ok.
 
 otp_10979_hanging_node(_Config) ->

--- a/lib/tools/test/xref_SUITE.erl
+++ b/lib/tools/test/xref_SUITE.erl
@@ -1047,7 +1047,7 @@ read_expected(Version) ->
     POS1 = 28, POS2 = POS1+10, POS3 = POS2+6, POS4 = POS3+6, POS5 = POS4+10,
     POS6 = POS5+5, POS7 = POS6+6, POS8 = POS7+6, POS9 = POS8+8,
     POS10 = POS9+10, POS11 = POS10+7, POS12 = POS11+8, POS13 = POS12+10,
-    POS14 = POS13+18, POS15 = POS14+23,
+    POS14 = POS13+18, POS15 = POS14+23, POS16 = POS15+12,
 
     FF = {read,funfuns,0},
     U = [{POS1+5,{FF,{dist,'$F_EXPR',0}}},
@@ -1197,7 +1197,11 @@ read_expected(Version) ->
                  ++ O1;
 	     _ ->
                  [{16,{FF,{read,'$F_EXPR',178}}},
-                  {17,{FF,{modul,'$F_EXPR',179}}}]
+                  {17,{FF,{modul,'$F_EXPR',179}}},
+                  {POS16+1,{{read,bi,0},{m,f,0}}},
+                  {POS16+2,{{read,bi,0},{io,format,1}}},
+                  {POS16+4,{{read,bi,0},{io,format,1}}},
+                  {POS16+6,{{read,bi,0},{io,format,1}}}]
                  ++
                  O1
 	 end,
@@ -1226,7 +1230,9 @@ read_expected(Version) ->
                    {POS15+1,  {{read,bi,0},{erlang,'>',2}}},
                    {POS15+2,  {{read,bi,0},{erlang,'-',2}}},
                    {POS15+2,  {{read,bi,0},{erlang,'*',2}}},
-                   {POS15+8,  {{read,bi,0},{erlang,'/',2}}}]
+                   {POS15+8,  {{read,bi,0},{erlang,'/',2}}},
+                   {POS16+3,  {{read,bi,0},{erlang,'+',2}}},
+                   {POS16+3,  {{read,bi,0},{erlang,'=:=',2}}}]
           end
         ++ [{POS14+19, {{read,bi,0},{erlang,'+',2}}},
             {POS14+21, {{read,bi,0},{erlang,'+',2}}},

--- a/lib/tools/test/xref_SUITE_data/read/read.erl
+++ b/lib/tools/test/xref_SUITE_data/read/read.erl
@@ -168,7 +168,16 @@ bi() ->
     G = fun _(foo) -> bar;
             _(X) -> X / 3
         end,
-    G(foo).
+    G(foo);
+bi() ->
+    %% Cond. POS16=POS15+12
+    cond m:f() ->
+             io:format("foo!");
+         1 + 2 =:= 3 ->
+             io:format("maths still hold.");
+         true ->
+             io:format("not foo!")
+    end.
 
 local() ->
     true.

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -350,6 +350,38 @@ is_greater_than(X, Y) ->
   </section>
 
   <section>
+    <marker id="cond"></marker>
+    <title>Cond</title>
+    <pre>
+cond Expr1 ->
+         Body1;
+     ...;
+     ExprN ->
+         BodyN
+end</pre>
+    <p>The branches of an <c>cond</c>-expression are scanned sequentially
+      until an expression <c>Expr</c> which evaluates to true is found. Then the
+      corresponding <c>Body</c> is evaluated.</p>
+    <p>The return value of <c>Body</c> is the return value of
+      the <c>cond</c> expression.</p>
+    <p>If no expression is true, a <c>cond_clause</c> run-time error will occur.
+      If necessary, the expression <c>true</c> can be used in the last branch,
+      as that expression is always true.</p>
+    <p>Arbitrary expressions are allowed, if one of them evaluates to a
+      non-boolean value, a <c>badbool</c> run-time error will occur.</p>
+    <p>Example:</p>
+    <pre>
+manage_engine() ->
+    cond voltage_nominal() ->
+             continue_operations();
+         in_emergency() ->
+             set_speed_slow();
+         true ->
+             shut_device_down()
+    end.</pre>
+  </section>
+
+  <section>
     <marker id="case"></marker>
     <title>Case</title>
     <pre>


### PR DESCRIPTION
This makes the 'cond' keyword useful and introduces an expression similar to if expressions, without guard semantics.

```erlang
cond E1 -> B1;
     ...;
     Ek -> Bk
end.
```

This code is more or less equivalent to k nested cases, with the difference that bindings from tests Ei do not spill in the subsequent Ei+1 and Bi+1 trees.

```erlang
case E1 of
    true ->
        B1;
    false ->
        case ... of
            true ->
                ...;
            false ->
                case Ek of
                    true ->
                        Bk;
                    false ->
                        error(cond_clause);
                    Other ->
                        error({badbool,Other})
                end;
            Other ->
                error({badbool,Other})
        end;
    Other ->
        error({badbool,Other})
end.
```

The current implementation may be lacking with regard to warnings, please follow up on any shortcoming.