### PR TITLE
let Java compiler output all warnings

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/Makefile
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/Makefile
@@ -66,7 +66,7 @@ ifneq ($(V),0)
 JARFLAGS=-cfv
 endif
 
-JAVA_OPTIONS = 
+JAVA_OPTIONS = -Xlint 
 
 ifeq ($(TESTROOT),)
 RELEASE_PATH="$(ERL_TOP)/release/$(TARGET)"
@@ -113,4 +113,3 @@ release_docs_spec:
 
 
 # ----------------------------------------------------
-


### PR DESCRIPTION
This will make javac output a whole lot of warnings for the current code base. Another PR will be available soon that takes care of those.
