### PR TITLE
Let Java compiler output all warnings

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/Makefile
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/Makefile
@@ -66,7 +66,7 @@ ifneq ($(V),0)
 JARFLAGS=-cfv
 endif
 
-JAVA_OPTIONS = 
+JAVA_OPTIONS = -Xlint 
 
 ifeq ($(TESTROOT),)
 RELEASE_PATH="$(ERL_TOP)/release/$(TARGET)"
@@ -113,4 +113,3 @@ release_docs_spec:
 
 
 # ----------------------------------------------------
-


### PR DESCRIPTION
Warnings can reveal problems in the code. This will enable all of them and there are currently many. Another PR will be submitted to fix the warnings.
