### PR TITLE
Add os:isatty/1 as a bif

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -347,6 +347,7 @@ bif os:getenv/0
 bif os:getenv/1
 bif os:getpid/0
 bif os:timestamp/0
+bif os:isatty/1
 
 #
 # Bifs in the erl_ddll module (the module actually does not exist)

--- a/erts/emulator/beam/erl_bif_os.c
+++ b/erts/emulator/beam/erl_bif_os.c
@@ -202,3 +202,28 @@ BIF_RETTYPE os_unsetenv_1(BIF_ALIST_1)
     }
     BIF_RET(am_true);
 }
+
+BIF_RETTYPE os_isatty_1(BIF_ALIST_1)
+{
+    Uint u;
+
+    if (is_atom(BIF_ARG_1)) {
+	if (ERTS_IS_ATOM_STR("stdin", BIF_ARG_1)) {
+            u = 0;
+	} else if (ERTS_IS_ATOM_STR("stdout", BIF_ARG_1)) {
+            u = 1;
+        } else if (ERTS_IS_ATOM_STR("stderr", BIF_ARG_1)) {
+            u = 2;
+        } else {
+            BIF_ERROR(BIF_P, BADARG);
+        }
+    } else if (!term_to_Uint(BIF_ARG_1, &u) || ((u >> 16) >> 16) != 0) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    if (isatty(u)) {
+        BIF_RET(am_true);
+    } else {
+        BIF_RET(am_false);
+    }
+}

--- a/lib/kernel/doc/src/os.xml
+++ b/lib/kernel/doc/src/os.xml
@@ -114,6 +114,14 @@ DirOut = os:cmd("dir"), % on Win32 platform</code>
       </desc>
     </func>
     <func>
+        <name name="isatty" arity="1"/>
+        <fsummary>Check if the file descriptor is a tty</fsummary>
+        <desc>
+          <p>Returns <c>true</c> if <c><anno>FileDescriptor</anno></c> is a tty
+            or <c>false</c> otherwise.</p>
+        </desc>
+    </func>
+    <func>
       <name name="putenv" arity="2"/>
       <fsummary>Set a new value for an environment variable</fsummary>
       <desc>

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -27,6 +27,13 @@
 %%% BIFs
 
 -export([getenv/0, getenv/1, getpid/0, putenv/2, timestamp/0, unsetenv/1]).
+-export([isatty/1]).
+
+-spec isatty(FileDescriptor) -> boolean() when
+      FileDescriptor :: non_neg_integer() | stdin | stdout | stderr.
+
+isatty(_) ->
+    erlang:nif_error(undef).
 
 -spec getenv() -> [string()].
 

--- a/lib/kernel/test/os_SUITE.erl
+++ b/lib/kernel/test/os_SUITE.erl
@@ -21,7 +21,8 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2]).
 -export([space_in_cwd/1, quoting/1, cmd_unicode/1, space_in_name/1, bad_command/1,
-	 find_executable/1, unix_comment_in_command/1, deep_list_command/1, evil/1]).
+	 find_executable/1, unix_comment_in_command/1, deep_list_command/1,
+         evil/1, isatty_args/1]).
 
 -include_lib("test_server/include/test_server.hrl").
 
@@ -29,7 +30,8 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
     [space_in_cwd, quoting, cmd_unicode, space_in_name, bad_command,
-     find_executable, unix_comment_in_command, deep_list_command, evil].
+     find_executable, unix_comment_in_command, deep_list_command, evil,
+     isatty_args].
 
 groups() ->
     [].
@@ -163,6 +165,23 @@ bad_command(Config) when is_list(Config) ->
     ?line os:cmd("xxxxx"),
 
     ok.
+
+isatty_args(suite) -> [];
+isatty_args(doc) ->
+    "Check that arguments are properly handled.";
+isatty_args(_Config) ->
+    os:isatty(stdin),
+    os:isatty(stdout),
+    os:isatty(stderr),
+    os:isatty(0),
+    os:isatty(1),
+    os:isatty(5),
+    V = try
+            os:isatty(-1)
+        catch _:badarg ->
+            badarg
+        end,
+    V = badarg.
 
 find_executable(suite) -> [];
 find_executable(doc) -> [];


### PR DESCRIPTION
The posix libc function, isatty(), is a useful function that will tell
you if a file descriptor is attached to a terminal. If, for instance, you
want to write a program that uses ansi color codes, it is not enough to
just check $TERM because the output could be redirected to a file. In
that case you would end up with the escape codes in the file making it
harder to read and parse. By calling os:isatty/1 with stdout as its
parameter the program can ensure that it never writes escape codes to
log files.

This PR adds os:isatty/1 as well as docs and a test of its argument
handling. os:isatty/1 accepts the atoms stdin, stdout and stderr as well
as any 32 bit non_negative_integer() representing a file descriptor. It
simply returns false in case the integer is not an FD, and throws in the
case of a bad argument. The test does not check the return value in the
valid case, because that would depend upon how tests are run.

This code should work on all platforms including Windows, as isatty is a
posix function. Note however that it is deprecated on Windows according
to MSDN in favor of the C++ standard _isatty().
