### PR TITLE
httpc: send header names in titlecase

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -515,7 +515,7 @@ handle_request(Method, Url,
 	       HTTPOptions0, Options0, Profile) ->
 
     Started     = http_util:timestamp(), 
-    NewHeaders0 = [{http_util:to_lower(Key), Val} || {Key, Val} <- Headers0],
+    NewHeaders0 = [{http_util:to_titlecase(Key), Val} || {Key, Val} <- Headers0],
 
     try
 	begin

--- a/lib/inets/src/http_lib/http_util.erl
+++ b/lib/inets/src/http_lib/http_util.erl
@@ -20,7 +20,7 @@
 -module(http_util).
 
 -export([
-	 to_upper/1, to_lower/1, 
+	 to_upper/1, to_lower/1, to_titlecase/1,
 	 convert_netscapecookie_date/1,
 	 hexlist_to_integer/1, integer_to_hexlist/1, 
 	 convert_month/1, 
@@ -38,6 +38,12 @@ to_upper(Str) ->
 
 to_lower(Str) ->
     string:to_lower(Str).
+
+to_titlecase(Str) ->
+    F = fun([H|Rest]) ->
+                [string:to_upper(H) | string:to_lower(Rest)]
+        end,
+    string:join(lists:map(F, string:tokens(Str, "-")), "-").
 
 %% Example: Mon, 09-Dec-2002 13:46:00 GMT
 convert_netscapecookie_date([_D,_A,_Y, $,, $ ,

--- a/lib/inets/test/http_format_SUITE.erl
+++ b/lib/inets/test/http_format_SUITE.erl
@@ -34,7 +34,7 @@
 	  chunk_decode_empty_chunk_otp_6511/1,
 	  chunk_decode_trailer/1,
 	  http_response/1, http_request/1, validate_request_line/1,
-	  esi_parse_headers/1, cgi_parse_headers/1,
+	  esi_parse_headers/1, cgi_parse_headers/1, to_titlecase/1,
 	  is_absolut_uri/1, convert_netscapecookie_date/1,
 	  check_content_length_encoding/1]).
 
@@ -46,7 +46,7 @@ all() ->
      convert_netscapecookie_date, check_content_length_encoding].
 
 groups() -> 
-    [{script, [], [esi_parse_headers, cgi_parse_headers]},
+    [{script, [], [esi_parse_headers, cgi_parse_headers, to_titlecase]},
      {chunk, [],
       [chunk_decode, chunk_encode, chunk_extensions_otp_6005,
        chunk_decode_otp_6264,
@@ -563,7 +563,19 @@ cgi_parse_headers(Config) when is_list(Config) ->
 	 {"age","4711"}], {200,"ok"}}  = httpd_cgi:handle_headers(Headers3),
 
     ok.
-    
+
+%%--------------------------------------------------------------------
+to_titlecase(doc) ->
+    ["Test http_util:to_titlecase/1 function."];
+to_titlecase(suite) ->
+    [];
+to_titlecase(_Config) ->
+    "Header-Name" = http_util:to_titlecase("HEADER-NAME"),
+    "Header-Name" = http_util:to_titlecase("header-name"),
+    "Header-Name" = http_util:to_titlecase("Header-name"),
+    "Header-Name" = http_util:to_titlecase("hEaDer-NAme"),
+    ok.
+
 %%-------------------------------------------------------------------------
 is_absolut_uri(doc) ->
     ["Test http_request:is_absolut_uri/1."];


### PR DESCRIPTION
Although, header names are case-insensitive, but most commonly used
form of header names is titlecase among HTTP clients.
This pull-request would provide this behaviour, in which httpc would change
header names to titlecase before sending the request.
