### PR TITLE
Fix if-clauses that make code to be unreachable

### DIFF
--- a/erts/etc/win32/Install.c
+++ b/erts/etc/win32/Install.c
@@ -80,7 +80,7 @@ int wmain(int argc, wchar_t **argv)
 	}
     }
     if (root == NULL) {
-	if (module = NULL) {
+	if (module == NULL) {
 	    fprintf(stderr, "Cannot GetModuleHandle()\n");
 	    exit(1);
 	}

--- a/erts/etc/win32/erl.c
+++ b/erts/etc/win32/erl.c
@@ -264,7 +264,7 @@ static void get_parameters(void)
     int len;
 
 
-    if (module = NULL) {
+    if (module == NULL) {
         error("Cannot GetModuleHandle()");
     }
 


### PR DESCRIPTION
Fix two cases where use of assigment operator instead of comparison
operator causes if-clauses to be always false and code to be unreachable.
