### PR TITLE
BER decoding: Don't allow primitives with indefinite lengths

### DIFF
--- a/lib/asn1/c_src/asn1_erl_nif.c
+++ b/lib/asn1/c_src/asn1_erl_nif.c
@@ -949,7 +949,7 @@ static int ber_decode_value(ErlNifEnv* env, ERL_NIF_TERM *value, unsigned char *
     } else if (in_buf[*ib_index] == ASN1_INDEFINITE_LENGTH) {
 	(*ib_index)++;
 	curr_head = enif_make_list(env, 0);
-	if (*ib_index+1 >= in_buf_len) {
+	if (*ib_index+1 >= in_buf_len || form == ASN1_PRIMITIVE) {
 	    return ASN1_INDEF_LEN_ERROR;
 	}
 	while (!(in_buf[*ib_index] == 0 && in_buf[*ib_index + 1] == 0)) {

--- a/lib/asn1/test/asn1_SUITE_data/Constructed.asn
+++ b/lib/asn1/test/asn1_SUITE_data/Constructed.asn
@@ -1,6 +1,3 @@
-
-
-
 Constructed DEFINITIONS ::=
 BEGIN
 
@@ -20,4 +17,7 @@ C ::= CHOICE {
 S3 ::= SEQUENCE {i INTEGER}
 
 S3ext ::= SEQUENCE {i INTEGER, ...}
+
+OS ::= OCTET STRING
+
 END

--- a/lib/asn1/test/ber_decode_error.erl
+++ b/lib/asn1/test/ber_decode_error.erl
@@ -61,6 +61,10 @@ run([]) ->
 	(catch 'Constructed':decode('S', sub(<<40,16#80,1,1,255,0,0>>, 6))),
     {error,{asn1,{invalid_length,_}}} =
 	(catch 'Constructed':decode('S', sub(<<40,16#80,1,1,255,0,0>>, 5))),
+
+    %% A primitive must not be encoded with an indefinite length.
+    {error,{asn1,{invalid_length,_}}} =
+	(catch 'Constructed':decode('OS', <<4,128,4,3,97,98,99,0,0>>)),
     ok.
 
 sub(Bin, Bytes) ->


### PR DESCRIPTION
According to the BER encoding rules, only constructed values may
have indefinite lengths. A primitive value must be encoded with
a definite length.

Reported-by: Simon Cornish
