### PR TITLE
Make shell ctrl-u save killed text correctly

### DIFF
--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -296,6 +296,7 @@ ctrl_keys(doc) -> ["Tests various control keys"];
 ctrl_keys(_Conf) when is_list(_Conf) ->
     Cu=[$\^u],
     Cw=[$\^w],
+    Cy=[$\^y],
     Home=[27,$O,$H],
     End=[27,$O,$F],
     rtnode([{putline,""},
@@ -308,6 +309,8 @@ ctrl_keys(_Conf) when is_list(_Conf) ->
 	    {putline,"world\"."++Home++"\"hello "},	% test <HOME>
 	    {getline,"\"hello world\""},
 	    {putline,"world"++Home++"\"hello "++End++"\"."},	% test <END>
+	    {getline,"\"hello world\""},
+	    {putline,"\"hello world\""++Cu++Cy++"."},
 	    {getline,"\"hello world\""}]
 	    ++wordLeft()++wordRight(),[]).
 

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -390,7 +390,7 @@ do_op(end_of_line, Bef, [C|Aft], Rs) ->
 do_op(end_of_line, Bef, [], Rs) ->
     {{Bef,[]},Rs};
 do_op(ctlu, Bef, Aft, Rs) ->
-    put(kill_buffer, Bef),
+    put(kill_buffer, reverse(Bef)),
     {{[], Aft}, [{delete_chars, -length(Bef)} | Rs]};
 do_op(beep, Bef, Aft, Rs) ->
     {{Bef,Aft},[beep|Rs]};


### PR DESCRIPTION
Fix edlin to correctly save text killed with ctrl-u. Prior to this fix,
entering text into the Erlang shell and then killing it with ctrl-u
followed by yanking it back with ctrl-y would result in the yanked text
being the reverse of the original killed text.

Add a test for the fix to shell_SUITE.

(This is the same fix as in PR#416, but that PR was never completed.)
