### PR TITLE
Make ODBC configure handle OS X Mavericks and Yosemite

### DIFF
--- a/lib/odbc/configure.in
+++ b/lib/odbc/configure.in
@@ -136,7 +136,7 @@ AC_SUBST(THR_LIBS)
 odbc_lib_link_success=no
 AC_SUBST(TARGET_FLAGS)
     case $host_os in
-        darwin1[[0-2]].*|darwin[[0-9]].*)
+        darwin1[[0-4]].*|darwin[[0-9]].*)
                 TARGET_FLAGS="-DUNIX"
 	        if test ! -d "$with_odbc" || test "$with_odbc" = "yes"; then
 		    ODBC_LIB= -L"/usr/lib"


### PR DESCRIPTION
OS X Mavericks is based on Darwin version 13.x, and Yosemite on
14.x. Change the ODBC configure.in script to recognize these versions.
