### PR TITLE
Use isfinite() instead of finite() when available

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2109,6 +2109,17 @@ AC_CHECK_FUNCS([ieee_handler fpsetmask finite isnan isinf res_gethostbyname dlop
 		flockfile fstat strlcpy strlcat setsid posix2time time2posix \
 		setlocale nl_langinfo poll mlockall])
 
+AC_MSG_CHECKING([for isfinite])
+AC_TRY_COMPILE([#include <math.h>],
+               [isfinite(0);], have_isfinite=yes, have_isfinite=no),
+
+if test $have_isfinite = yes; then
+    AC_DEFINE(HAVE_ISFINITE,[1],
+              [Define to 1 if you have the `isfinite' function.])
+    AC_MSG_RESULT(yes)
+else
+    AC_MSG_RESULT(no)
+fi
 
 case X$erl_xcomp_posix_memalign in
      Xno) ;;
@@ -4817,7 +4828,7 @@ AH_BOTTOM([
 #define HAVE_GETHRVTIME
 #endif
 
-#ifndef HAVE_FINITE
+#if !defined(HAVE_ISFINITE) && !defined(HAVE_FINITE)
 # if defined(HAVE_ISINF) && defined(HAVE_ISNAN)
 #  define USE_ISINF_ISNAN
 # endif

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -501,7 +501,7 @@ extern volatile int erts_writing_erl_crash_dump;
 #  define NO_ERF
 #  define NO_ERFC
 /* This definition doesn't take NaN into account, but matherr() gets those */
-#  define finite(x) (fabs(x) != HUGE_VAL)
+#  define isfinite(x) (fabs(x) != HUGE_VAL)
 #  define USE_MATHERR
 #  define HAVE_FINITE
 #endif

--- a/erts/emulator/hipe/hipe_bif0.c
+++ b/erts/emulator/hipe/hipe_bif0.c
@@ -1022,7 +1022,7 @@ BIF_RETTYPE hipe_conv_big_to_float(BIF_ALIST_1)
 */
 void hipe_emulate_fpe(Process* p)
 {
-    if (!finite(p->hipe.float_result)) {
+    if (!isfinite(p->hipe.float_result)) {
 	p->fp_exception = 1;
     }
 }

--- a/erts/emulator/sys/unix/erl_unix_sys.h
+++ b/erts/emulator/sys/unix/erl_unix_sys.h
@@ -230,8 +230,13 @@ extern void sys_stop_cat(void);
  */
 
 #ifdef USE_ISINF_ISNAN		/* simulate finite() */
-#  define finite(f) (!isinf(f) && !isnan(f))
-#  define HAVE_FINITE
+#  define isfinite(f) (!isinf(f) && !isnan(f))
+#  define HAVE_ISFINITE
+#elif defined(isfinite) && !defined(HAVE_ISFINITE)
+#  define HAVE_ISFINITE
+#elif !defined(HAVE_ISFINITE) && defined(HAVE_FINITE)
+#  define isfinite finite
+#  define HAVE_ISFINITE
 #endif
 
 #ifdef NO_FPE_SIGNALS
@@ -241,7 +246,7 @@ extern void sys_stop_cat(void);
 #define erts_thread_init_fp_exception() do{}while(0)
 #endif
 #  define __ERTS_FP_CHECK_INIT(fpexnp) do {} while (0)
-#  define __ERTS_FP_ERROR(fpexnp, f, Action) if (!finite(f)) { Action; } else {}
+#  define __ERTS_FP_ERROR(fpexnp, f, Action) if (!isfinite(f)) { Action; } else {}
 #  define __ERTS_FP_ERROR_THOROUGH(fpexnp, f, Action) __ERTS_FP_ERROR(fpexnp, f, Action)
 #  define __ERTS_SAVE_FP_EXCEPTION(fpexnp)
 #  define __ERTS_RESTORE_FP_EXCEPTION(fpexnp)
@@ -305,7 +310,7 @@ static __inline__ void __ERTS_FP_CHECK_INIT(volatile unsigned long *fp_exception
       code to always throw floating-point exceptions on errors. */
 static __inline__ int erts_check_fpe_thorough(volatile unsigned long *fp_exception, double f)
 {
-    return erts_check_fpe(fp_exception, f) || !finite(f);
+    return erts_check_fpe(fp_exception, f) || !isfinite(f);
 }
 #  define __ERTS_FP_ERROR_THOROUGH(fpexnp, f, Action) \
   do { if (erts_check_fpe_thorough((fpexnp),(f))) { Action; } } while (0)

--- a/erts/emulator/test/float_SUITE_data/fp_drv.c
+++ b/erts/emulator/test/float_SUITE_data/fp_drv.c
@@ -29,8 +29,8 @@
 #if defined (__GNUC__)
 int _finite(double x);
 #endif
-#ifndef finite
-#define finite _finite
+#ifndef isfinite
+#define isfinite _finite
 #endif
 #endif
 #include "erl_driver.h"
@@ -79,21 +79,21 @@ do_test(void *unused)
     x = 3.23e133;
     y = 3.57e257;
     z = x*y;
-    if (finite(z))
+    if (isfinite(z))
 	return "is finite (1)";
 
     x = 5.0;
     y = 0.0;
     z = x/y;
-    if (finite(z))
+    if (isfinite(z))
 	return "is finite (2)";
 
     z = log(-1.0);
-    if (finite(z))
+    if (isfinite(z))
 	return "is finite (3)";
 
     z = log(0.0);
-    if (finite(z))
+    if (isfinite(z))
 	return "is finite (4)";
 
     return "ok";

--- a/lib/erl_interface/src/decode/decode_big.c
+++ b/lib/erl_interface/src/decode/decode_big.c
@@ -151,13 +151,18 @@ int ei_big_comp(erlang_big *x, erlang_big *y)
 #endif
 
 #ifdef USE_ISINF_ISNAN		/* simulate finite() */
-#  define finite(f) (!isinf(f) && !isnan(f))
-#  define HAVE_FINITE
+#  define isfinite(f) (!isinf(f) && !isnan(f))
+#  define HAVE_ISFINITE
+#elif defined(isfinite) && !defined(HAVE_ISFINITE)
+#  define HAVE_ISFINITE
+#elif !defined(HAVE_ISFINITE) && defined(HAVE_FINITE)
+#  define isfinite finite
+#  define HAVE_ISFINITE
 #endif
 
 #ifdef NO_FPE_SIGNALS
 #  define ERTS_FP_CHECK_INIT() do {} while (0)
-#  define ERTS_FP_ERROR(f, Action) if (!finite(f)) { Action; } else {}
+#  define ERTS_FP_ERROR(f, Action) if (!isfinite(f)) { Action; } else {}
 #  define ERTS_SAVE_FP_EXCEPTION()
 #  define ERTS_RESTORE_FP_EXCEPTION()
 #else

--- a/lib/test_server/src/configure.in
+++ b/lib/test_server/src/configure.in
@@ -360,6 +360,22 @@ AC_HAVE_LIBRARY(resolv)
 AC_CHECK_LIB(resolv, res_gethostbyname,[DEFS="$DEFS -DHAVE_RES_GETHOSTBYNAME=1"])
 
 #--------------------------------------------------------------------
+# Check for isfinite
+#--------------------------------------------------------------------
+
+AC_MSG_CHECKING([for isfinite])
+AC_TRY_COMPILE([#include <math.h>],
+               [isfinite(0);], have_isfinite=yes, have_isfinite=no),
+
+if test $have_isfinite = yes; then
+    DEFS="$DEFS -DHAVE_ISFINITE=1"
+    AC_MSG_RESULT(yes)
+else
+    DEFS="$DEFS -DHAVE_FINITE=1"
+    AC_MSG_RESULT(no)
+fi
+
+#--------------------------------------------------------------------
 # Emulator compatible flags (for drivers)
 #--------------------------------------------------------------------
 


### PR DESCRIPTION
**Note: Anthony Ramine did most of this work in Nov 2013. With his permission, I cherry-picked his commit, made sure it worked, and am now submitting it.**

OS X Mavericks builds result in a number of warnings about `finite()` being
deprecated, like these:

```
beam/erl_arith.c:451:7: warning: 'finite' is deprecated: first deprecated in OS X 10.9 [-Wdeprecated-declarations]
                    ERTS_FP_ERROR(p, f1.fd, goto badarith);
                    ^
sys/unix/erl_unix_sys.h:319:33: note: expanded from macro 'ERTS_FP_ERROR'
                                        ^
sys/unix/erl_unix_sys.h:244:51: note: expanded from macro '__ERTS_FP_ERROR'
                                                  ^
/usr/include/math.h:718:12: note: 'finite' has been explicitly marked deprecated here
extern int finite(double) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_0, __MAC_10_9, __IPHONE_NA, __IPHONE_NA);
```

Add checks to use `isfinite()` instead of `finite()` where available. Verified
on OS X Mavericks 10.9.5 and Ubuntu 12.04.
