### PR TITLE
Add 3 tests: constants and purging modules

### DIFF
--- a/lib/kernel/test/code_SUITE_data/module_with_constants.erl
+++ b/lib/kernel/test/code_SUITE_data/module_with_constants.erl
@@ -1,0 +1,19 @@
+-module(module_with_constants).
+-export([get_a_constant/0,
+         get_a_term_with_unshared_constants/1,
+         get_a_term_with_shared_constants/1]).
+
+get_a_constant() ->
+    [{magic, ?VERSION, constant}, 1, 2, 7, 17, 42].
+
+get_a_term_with_unshared_constants(0) ->
+    get_a_constant();
+get_a_term_with_unshared_constants(N) ->
+    X = get_a_term_with_unshared_constants(N-1),
+    [N | X].
+
+get_a_term_with_shared_constants(0) ->
+    get_a_constant();
+get_a_term_with_shared_constants(N) ->
+    X = get_a_term_with_shared_constants(N-1),
+    [N, X | X].


### PR DESCRIPTION
These tests check if the use of constants creates dangling pointers
after a module is purged.  They are intended to verify that the
sharing-preserving implementation (when the flag is enabled) handles
constants properly.  They should also pass without problems if the
flag is disabled.

    ts:run(kernel, code_SUITE, mod_const_direct, [batch]).
    ts:run(kernel, code_SUITE, mod_const_send, [batch]).
    ts:run(kernel, code_SUITE, mod_const_spawn, [batch]).