### PR TITLE
Clarify docs for driver_async() return value

### DIFF
--- a/erts/doc/src/erl_driver.xml
+++ b/erts/doc/src/erl_driver.xml
@@ -2033,7 +2033,8 @@ ERL_DRV_MAP          int sz
           entry function is called. If <c>ready_async</c> is null in
           the driver entry, the <c>async_free</c> function is called
           instead.</p>
-        <p>The return value is a handle to the asynchronous task.</p>
+        <p>The return value is -1 if the <c>driver_async</c> call
+          fails.</p>
         <note>
           <p>As of erts version 5.5.4.3 the default stack size for
             threads in the async-thread pool is 16 kilowords,


### PR DESCRIPTION
The documentation for driver_async() still referred to the return value of
the function as a "handle", which is no longer meaningful since
driver_async_cancel() was deprecated and removed. Modify the documentation
to simply indicate that the driver_async() return value will be -1 if it
fails.
