### PR TITLE
Clarify the use of SIGUSR1 for forcing crash dumps

### DIFF
--- a/erts/doc/src/crash_dump.xml
+++ b/erts/doc/src/crash_dump.xml
@@ -115,8 +115,9 @@
          sockets/pipes can be used simultaneously by Erlang (due to
          limitations in the Unix <c><![CDATA[select]]></c> call).  The number of
          open regular files is not affected by this.</item>
-        <item>"Received SIGUSR1" - The SIGUSR1 signal was sent to the
-         Erlang machine (Unix only).</item>
+        <item>"Received SIGUSR1" - Sending the SIGUSR1 signal to a
+         Erlang machine (Unix only) forces a crash dump. This slogan reflects
+         that the Erlang machine crash-dumped due to receiving that signal.</item>
         <item>"Kernel pid terminated (<em>Who</em>)
          (<em>Exit-reason</em>)" - The kernel supervisor has detected
          a failure, usually that the <c><![CDATA[application_controller]]></c>

--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -525,7 +525,8 @@
 	core dump and no crash dump if an internal error is detected.</p>
 
 	<p>Calling <c>erlang:halt/1</c> with a string argument will still
-	produce a crash dump.</p>
+	produce a crash dump. On Unix systems, sending an emulator process
+	a SIGUSR1 signal will also force a crash dump.</p>
       </item>
       <tag><marker id="+e"><c><![CDATA[+e Number]]></c></marker></tag>
       <item>


### PR DESCRIPTION
The crash_dump document mentions indirectly that delivering a SIGUSR1 to a
running emulator process can force it to crash dump. Clarify that text to
make it clear SIGUSR1 can be used for that purpose, and also add a similar
note about using SIGUSR1 to the erl documentation.
