### PR TITLE
Fix bug in FreeBSD topology detection code

### DIFF
--- a/erts/lib_src/common/erl_misc_utils.c
+++ b/erts/lib_src/common/erl_misc_utils.c
@@ -1515,7 +1515,7 @@ const char* parse_topology_spec_group(erts_cpu_info_t *cpuinfo, const char* xml,
 		if (is_thread_group) {
 		    thread++;
 		} else {
-		    *core_p = (*core_p)++;
+		    *core_p = (*core_p) + 1;
 		}
 		index_procs++;
 	    }
@@ -1535,9 +1535,9 @@ const char* parse_topology_spec_group(erts_cpu_info_t *cpuinfo, const char* xml,
 
     if (parentCacheLevel == 0) {
 	*core_p = 0;
-	*processor_p = (*processor_p)++;
+	*processor_p = (*processor_p) + 1;
     } else {
-	*core_p = (*core_p)++;
+	*core_p = (*core_p) + 1;
     }
 
     if (error)


### PR DESCRIPTION
Code incorrectly relied on undefined C behavior. Clang and gcc 4.9 do not behave
as code expected. This affected cores and processors detection on FreeBSD.
