### PR TITLE
Added the display of global names

### DIFF
--- a/lib/kernel/src/global.erl
+++ b/lib/kernel/src/global.erl
@@ -35,7 +35,7 @@
 	 set_lock/1, set_lock/2, set_lock/3,
 	 del_lock/1, del_lock/2,
 	 trans/2, trans/3, trans/4,
-	 random_exit_name/3, random_notify_name/3, notify_all_name/3]).
+	 random_exit_name/3, random_notify_name/3, notify_all_name/3, pid2name/1]).
 
 %% Internal exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
@@ -2231,3 +2231,24 @@ allow_tuple_fun({M, F}) when is_atom(M), is_atom(F) ->
     fun M:F/3;
 allow_tuple_fun(Fun) when is_function(Fun, 3) ->
     Fun.
+
+%%-----------------------------------------------------------------
+%% Method = function(Pid) -> atom | undefined
+%% Method is called for search name of process  registered globally
+%%-----------------------------------------------------------------
+-spec pid2name(Pid) -> atom() | undefined when
+      Pid :: pid().
+pid2name(Pid) when is_pid(Pid) ->
+    case ets:lookup(global_pid_names, Pid) of
+        [{Pid, Name}] -> 
+            if 
+              node(Pid) == node() ->
+                case is_process_alive(Pid) of
+                    true -> Name;
+                    false -> undefined
+                end;
+              true ->
+                  Name
+            end;
+        [] -> undefined
+    end.

--- a/lib/kernel/test/global_SUITE.erl
+++ b/lib/kernel/test/global_SUITE.erl
@@ -4309,6 +4309,16 @@ trace_message(M) ->
             ok
     end.
 
+pid2name_test() ->
+    Pid = spawn(fun() -> pid2name_proc() end),
+    yes = global:register_name(test_global_name, Pid),
+    test_global_name = global:pid2name(Pid),
+    global:unregister_name(test_global_name),
+    Pid ! die.
+
+pid2name_proc() ->
+    receive die -> ok end.
+
 %%-----------------------------------------------------------------
 %% The error_logger handler used for OTP-6931.
 %%-----------------------------------------------------------------

--- a/lib/observer/src/observer_procinfo.erl
+++ b/lib/observer/src/observer_procinfo.erl
@@ -52,7 +52,15 @@ init([Pid, ParentFrame, Parent]) ->
     try
 	Table = ets:new(observer_expand,[set,public]),
 	Title=case observer_wx:try_rpc(node(Pid), erlang, process_info, [Pid, registered_name]) of
-		  [] -> io_lib:format("~p",[Pid]);
+		  [] -> 
+		  	case global:pid2name(Pid) of
+				undefined -> 
+					io_lib:format("~p",[Pid]);
+				Name -> 
+					NewName = "*g*" ++ atom_to_list(Name),
+					io_lib:format("~p (~p)",[NewName, Pid])	
+		    end;
+		  	
 		  {registered_name, Registered} -> io_lib:format("~p (~p)",[Registered, Pid]);
 		  undefined -> throw(process_undefined)
 	      end,

--- a/lib/runtime_tools/src/appmon_info.erl
+++ b/lib/runtime_tools/src/appmon_info.erl
@@ -708,8 +708,12 @@ format(P) when is_pid(P), node(P) /= node() ->
 format(P) when is_pid(P) ->
     case process_info(P, registered_name) of
 	{registered_name, Name} -> atom_to_list(Name);
-	_ -> pid_to_list(P)
-    end;
+	_ ->
+	    case global:pid2name(P) of
+			undefined -> pid_to_list(P);
+			Name -> "*g*" ++ atom_to_list(Name)
+	    end
+	end;
 format(P) when is_port(P) ->
     "port " ++ integer_to_list(element(2, erlang:port_info(P, id)));
 format(X) ->


### PR DESCRIPTION
Add function for find process name registered in global namespace and modify observer module for use this function.
Idea and code from erlang mail list http://erlang.org/pipermail/erlang-questions/2012-December/070958.html.