### PR TITLE
Fix cover bug on last expressions with empty clauses

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -1696,6 +1696,8 @@ fix_expr(T, Line, Bump) when is_tuple(T) ->
 fix_expr(E, _Line, _Bump) ->
     E.
 
+fix_clauses([], _Line, _Bump) ->
+    [];
 fix_clauses(Cs, Line, Bump) ->
     case bumps_line(lists:last(Cs), Line) of
         true ->

--- a/lib/tools/test/cover_SUITE_data/b.erl
+++ b/lib/tools/test/cover_SUITE_data/b.erl
@@ -1,5 +1,5 @@
 -module(b).
--export([start/0, loop/0]).
+-export([start/0, loop/0, wait/0]).
 
 start() ->
     spawn(?MODULE, loop, []).
@@ -12,3 +12,9 @@ loop() ->
 	stop ->
 	    done
     end.
+
+%% This checks for a bug in expressions which have no
+%% "main" clauses (only after and friends) followed by
+%% a return value in the same line.
+wait() ->
+    receive after 1000 -> done end, ok.


### PR DESCRIPTION
[OTP-8188](https://github.com/erlang/otp/blob/8304aeb0114e61e8f694a58cf9e91a00856c3fe5/lib/tools/src/cover.erl#L1621) introduced a fix for handling last expressions in
expressions like case, try and friends. However the fix did
not account that some of those expressions like receive may
have no clauses (only an after clause), leading to a function
clause error when cover compiling code with such expressions.

Thanks to @jtmoulia for reporting the bug and to @fishcakez for
isolating it and proposing a fix.
