### PR TITLE
Add 'remove_empty_parts' option to binary:split/3

### DIFF
--- a/lib/stdlib/doc/src/binary.xml
+++ b/lib/stdlib/doc/src/binary.xml
@@ -578,6 +578,10 @@ store(Binary, GBSet) ->
 
       <item><p>Removes trailing empty parts of the result (as does trim in <c>re:split/3</c>)</p></item>
 
+      <tag>trim_all</tag>
+
+      <item><p>Removes all empty parts of the result.</p></item>
+
       <tag>global</tag>
 
       <item><p>Repeats the split until the <c><anno>Subject</anno></c> is

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -506,12 +506,35 @@ do_interesting(Module) ->
     ?line [<<1,2,3>>,<<6>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
 					   [<<4,5>>,<<7>>,<<8>>],
 					   [global,trim]),
+    ?line [<<1,2,3>>,<<6>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
+					   [<<4,5>>,<<7>>,<<8>>],
+					   [global,trim_all]),
     ?line [<<1,2,3,4,5,6,7,8>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
 					       [<<4,5>>,<<7>>,<<8>>],
 					       [global,trim,{scope,{0,4}}]),
     ?line [<<1,2,3>>,<<6,7,8>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
 					       [<<4,5>>,<<7>>,<<8>>],
 					       [global,trim,{scope,{0,5}}]),
+
+    ?line [<<>>,<<>>,<<3>>,<<6,7,8>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
+					   [<<1>>,<<2>>,<<4,5>>],
+					   [global,trim]),
+    ?line [<<3>>,<<6,7,8>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
+					   [<<1>>,<<2>>,<<4,5>>],
+					   [global,trim_all]),
+
+    ?line [<<1,2,3>>,<<>>,<<7,8>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
+					   [<<4,5>>,<<6>>],
+					   [global,trim]),
+    ?line [<<1,2,3>>,<<7,8>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
+					   [<<4,5>>,<<6>>],
+					   [global,trim_all]),
+    ?line [<<>>,<<>>,<<3>>,<<>>,<<6>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
+					   [<<1>>,<<2>>,<<4>>,<<5>>,<<7>>,<<8>>],
+					   [global,trim]),
+    ?line [<<3>>,<<6>>] = Module:split(<<1,2,3,4,5,6,7,8>>,
+					   [<<1>>,<<2>>,<<4>>,<<5>>,<<7>>,<<8>>],
+					   [global,trim_all]),
     ?line badarg = ?MASK_ERROR(
 		      Module:replace(<<1,2,3,4,5,6,7,8>>,
 				     [<<4,5>>,<<7>>,<<8>>],<<99>>,
@@ -1247,6 +1270,8 @@ do_random_split_comp(N,NeedleRange,HaystackRange) ->
     true = do_split_comp(Needle,Haystack,[]),
     true = do_split_comp(Needle,Haystack,[global]),
     true = do_split_comp(Needle,Haystack,[global,trim]),
+    true = do_split_comp(Needle,Haystack,[global,trim_all]),
+    true = do_split_comp(Needle,Haystack,[global,trim,trim_all]),
     do_random_split_comp(N-1,NeedleRange,HaystackRange).
 do_random_split_comp2(0,_,_) ->
     ok;
@@ -1257,6 +1282,9 @@ do_random_split_comp2(N,NeedleRange,HaystackRange) ->
 		  _ <- lists:duplicate(NumNeedles,a)],
     true = do_split_comp(Needles,Haystack,[]),
     true = do_split_comp(Needles,Haystack,[global]),
+    true = do_split_comp(Needles,Haystack,[global,trim]),
+    true = do_split_comp(Needles,Haystack,[global,trim_all]),
+    true = do_split_comp(Needles,Haystack,[global,trim,trim_all]),
     do_random_split_comp2(N-1,NeedleRange,HaystackRange).
 
 do_split_comp(N,H,Opts) ->

--- a/lib/stdlib/test/binref.erl
+++ b/lib/stdlib/test/binref.erl
@@ -155,7 +155,8 @@ split(Haystack,Needles0,Options) ->
 		      true ->
 			  exit(badtype)
 		  end,
-	{Part,Global,Trim} = get_opts_split(Options,{nomatch,false,false}),
+	{Part,Global,Trim,TrimAll} =
+        get_opts_split(Options,{nomatch,false,false,false}),
 	{Start,End,NewStack} =
 	    case Part of
 		nomatch ->
@@ -180,20 +181,24 @@ split(Haystack,Needles0,Options) ->
 				[X]
 			end
 		end,
-	do_split(Haystack,MList,0,Trim)
+	do_split(Haystack,MList,0,Trim,TrimAll)
     catch
 	_:_ ->
 	    erlang:error(badarg)
     end.
 
-do_split(H,[],N,true) when N >= byte_size(H) ->
+do_split(H,[],N,true,_) when N >= byte_size(H) ->
     [];
-do_split(H,[],N,_) ->
+do_split(H,[],N,_,true) when N >= byte_size(H) ->
+    [];
+do_split(H,[],N,_,_) ->
     [part(H,{N,byte_size(H)-N})];
-do_split(H,[{A,B}|T],N,Trim) ->
+do_split(H,[{A,B}|T],N,Trim,TrimAll) ->
     case part(H,{N,A-N}) of
+	<<>> when TrimAll == true ->
+	    do_split(H,T,A+B,Trim,TrimAll);
 	<<>> ->
-	    Rest =  do_split(H,T,A+B,Trim),
+	    Rest =  do_split(H,T,A+B,Trim,TrimAll),
 	    case {Trim, Rest} of
 		{true,[]} ->
 		    [];
@@ -201,7 +206,7 @@ do_split(H,[{A,B}|T],N,Trim) ->
 		    [<<>> | Rest]
 	    end;
 	Oth ->
-	    [Oth | do_split(H,T,A+B,Trim)]
+	    [Oth | do_split(H,T,A+B,Trim,TrimAll)]
     end.
 
 
@@ -565,14 +570,16 @@ get_opts_match([{scope,{A,B}} | T],_Part) ->
 get_opts_match(_,_) ->
     throw(badopt).
 
-get_opts_split([],{Part,Global,Trim}) ->
-    {Part,Global,Trim};
-get_opts_split([{scope,{A,B}} | T],{_Part,Global,Trim}) ->
-    get_opts_split(T,{{A,B},Global,Trim});
-get_opts_split([global | T],{Part,_Global,Trim}) ->
-    get_opts_split(T,{Part,true,Trim});
-get_opts_split([trim | T],{Part,Global,_Trim}) ->
-    get_opts_split(T,{Part,Global,true});
+get_opts_split([],{Part,Global,Trim,TrimAll}) ->
+    {Part,Global,Trim,TrimAll};
+get_opts_split([{scope,{A,B}} | T],{_Part,Global,Trim,TrimAll}) ->
+    get_opts_split(T,{{A,B},Global,Trim,TrimAll});
+get_opts_split([global | T],{Part,_Global,Trim,TrimAll}) ->
+    get_opts_split(T,{Part,true,Trim,TrimAll});
+get_opts_split([trim | T],{Part,Global,_Trim,TrimAll}) ->
+    get_opts_split(T,{Part,Global,true,TrimAll});
+get_opts_split([trim_all | T],{Part,Global,Trim,_TrimAll}) ->
+    get_opts_split(T,{Part,Global,Trim,true});
 get_opts_split(_,_) ->
     throw(badopt).
 


### PR DESCRIPTION
As its name suggest, this option can be used to remove _ALL_ empty parts of the result of a call to binary:split/3.

```erlang
1> binary:split(<<"  1  2  3  ">>, <<$\s>>, [global]).
[<<>>,<<>>,<<"1">>,<<>>,<<"2">>,<<>>,<<"3">>,<<>>,<<>>]
2> binary:split(<<"  1  2  3  ">>, <<$\s>>, [global,trim]).
[<<>>,<<>>,<<"1">>,<<>>,<<"2">>,<<>>,<<"3">>]
3> binary:split(<<"  1  2  3  ">>, <<$\s>>, [global,remove_empty_parts]).
[<<"1">>,<<"2">>,<<"3">>]
```

This could be done with a simple list comprehension on the result, but I think it is a need common enough to justify this patch.