### PR TITLE
Fix "-smp disable" for emulator with dirty schedulers

### DIFF
--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -90,7 +90,7 @@ static char erts_system_version[] = ("Erlang/OTP " ERLANG_OTP_RELEASE
 				     " [smp:%beu:%beu]"
 #endif
 #ifdef USE_THREADS
-#ifdef ERTS_DIRTY_SCHEDULERS
+#if defined(ERTS_DIRTY_SCHEDULERS) && defined(ERTS_SMP)
 				     " [ds:%beu:%beu:%beu]"
 #endif
 				     " [async-threads:%d]"


### PR DESCRIPTION
Running "erl -smp disable" on an emulator built with dirty scheduler
support caused problems such as segmentation violations and emulator status
line outputs containing garbage. For example:

```
$ erl -smp disable
Segmentation fault (core dumped)
```

and:

```
$ erl -smp disable
Erlang/OTP 17 [DEVELOPMENT] [erts-6.2] [source] [64-bit] [ds:10:4297895689:4299948152] [async-threads:280]
```

This problem also caused the emulator smoke_test_SUITE to hit these same
problems if run in an emulator started with the "-smp disable" option.

Fix this segmentation violation by ensuring that dirty scheduler
information is printed in the status line only when the emulator is
compiled with ERTS_SMP enabled.

With this fix in place, the smoke_test_SUITE now passes when the "-smp
disable" option is used, and the emulator status line prints correctly for
both "-smp enable" and "-smp disable":

```
$ erl -smp enable
Erlang/OTP 17 [DEVELOPMENT] [erts-6.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [kernel-poll:false]
```

and:

```
$ erl -smp disable
Erlang/OTP 17 [DEVELOPMENT] [erts-6.2] [source] [64-bit] [async-threads:10] [kernel-poll:false]
```
