### PR TITLE
Extract annotations from filter qualifiers in a type-friendly way

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -1173,7 +1173,7 @@ preprocess_quals(Line, [Q|Qs0], St0, Acc) ->
             {Gen,St} = generator(Line, Q, Gs, St0),
             preprocess_quals(Line, Qs, St, [Gen|Acc]);
         false ->
-            LAnno = #a{anno=lineno_anno(get_anno(Q), St0)},
+            LAnno = #a{anno=lineno_anno(get_qual_anno(Q), St0)},
             case is_guard_test(Q) of
                 true ->
                     %% When a filter is a guard test, its argument in the
@@ -1197,6 +1197,11 @@ preprocess_quals(_, [], St, Acc) ->
 is_generator({generate,_,_,_}) -> true;
 is_generator({b_generate,_,_,_}) -> true;
 is_generator(_) -> false.
+
+%% Retrieve the annotation from an Erlang AST form.
+%% (Use get_anno/1 to retrieve the annotation from Core Erlang forms).
+
+get_qual_anno(Abstract) -> element(2, Abstract).
 
 %%
 %% Generators are abstracted as sextuplets:


### PR DESCRIPTION
Suggested replacement for https://github.com/erlang/otp/pull/300

Commit 78ce8917d started to use get_anno/1 to extract the line
annotation from filter qualifiers in comprehensions, but this does not
respect the spec of this function and resuls in a dialyzer warning.
To make the code more type-friendly, introduce a get_qual_anno/1
function.

Kostis Sagonas suggested that the function should be implemented
similar to this to also ensure that the qualifiers are of the
appropriate form:

get_qual_anno({call,Line,_,_}) -> Line;
get_qual_anno({op,Line,_,_,_}) -> Line;
.
.
.
get_qual_anno({var,Line,_}) -> Line.

The problem is that it is difficult to know exacly which forms
that may occur and the function will need to be updated if new
abstract forms are added. Thus this implementation would complicate
maintanance without any real payoff.

Reported-by: Kostis Sagonas
