### PR TITLE
Fix ssh_sftp:start_channel timeout

### DIFF
--- a/lib/ssh/src/ssh_sftp.erl
+++ b/lib/ssh/src/ssh_sftp.erl
@@ -112,7 +112,7 @@ start_channel(Host, Opts) ->
 start_channel(Host, Port, Opts) ->
     {SshOpts, SftpOpts} = handle_options(Opts, [], []),
     Timeout = proplists:get_value(timeout, SftpOpts, infinity),
-    case ssh_xfer:connect(Host, Port, SshOpts) of
+    case ssh_xfer:connect(Host, Port, SshOpts, Timeout) of
 	{ok, ChannelId, Cm} ->
 	    case ssh_channel:start(Cm, ChannelId, ?MODULE, [Cm, 
 							    ChannelId, SftpOpts]) of

--- a/lib/ssh/src/ssh_xfer.erl
+++ b/lib/ssh/src/ssh_xfer.erl
@@ -23,7 +23,7 @@
 
 -module(ssh_xfer).
 
--export([attach/2, connect/3]).
+-export([attach/2, connect/3, connect/4]).
 -export([open/6, opendir/3, readdir/3, close/3, read/5, write/5,
 	 rename/5, remove/3, mkdir/4, rmdir/3, realpath/3, extended/4,
 	 stat/4, fstat/4, lstat/4, setstat/4,
@@ -55,6 +55,13 @@ attach(CM, Opts) ->
 connect(Host, Port, Opts) ->
     case ssh:connect(Host, Port, Opts) of
 	{ok, CM} -> open_xfer(CM, Opts);
+	Error -> Error
+    end.
+
+connect(Host, Port, Opts, Timeout) ->
+    case ssh:connect(Host, Port, Opts, Timeout) of
+	{ok, CM} -> open_xfer(CM, [{timeout, Timeout}|Opts]);
+	{error, Timeout} -> {error, timeout};
 	Error -> Error
     end.
 


### PR DESCRIPTION
The {timeout, Timeout} option passed to ssh_sftp:start_channel is not
applied to the early phases of the SSH protocol. For example, if the
remote server fails to respond after the "hello" then the call will hang
for as long as the server keeps the TCP connection alive.

This patch passes the Timeout through to ssh:connect. In case the
timeout occurs during these phases, {error, timeout} is returned.
