### PR TITLE
improve lists:nth/2 function, deal with exceed condition

### DIFF
--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -166,8 +166,14 @@ reverse([A, B | L]) ->
       T :: term().
 
 nth(1, [H|_]) -> H;
+nth(N, []) when N > 0 ->
+	error_exceed;
 nth(N, [_|T]) when N > 1 ->
-    nth(N - 1, T).
+	case T of
+		[] -> error_exceed;
+		_  ->
+    		nth(N - 1, T)
+    end.
 
 -spec nthtail(N, List) -> Tail when
       N :: non_neg_integer(),


### PR DESCRIPTION
lists:nth(N, L). when N>L.length, there will be an exception, not that friendly like:

```
lists:nth(1,[]).
** exception error: no function clause matching lists:nth(1,[]) (lists.erl, line 168)
```

I improve the nth/2 function to deal with exceed condition, which I think, can make it more friend to handle.
e.g.

```
mylist:nth(1, []).
error_exceed
```

thanks
