### PR TITLE
Expose NIF version

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6144,6 +6144,11 @@ ok
               <seealso marker="#system_info_multi_scheduling">erlang:system_info(multi_scheduling)</seealso>, and
               <seealso marker="#system_info_schedulers">erlang:system_info(schedulers)</seealso>.</p>
           </item>
+          <tag><c>nif_version</c></tag>
+          <item>
+            <p>Returns a string containing the erlang NIF version
+              used by the runtime system. It will be on the form "&lt;major ver&gt;.&lt;minor ver&gt;".</p>
+          </item>
           <tag><marker id="system_info_otp_release"><c>otp_release</c></marker></tag>
           <item>
             <p>Returns a string containing the OTP release number of the

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -27,6 +27,7 @@
 #include "erl_process.h"
 #include "error.h"
 #include "erl_driver.h"
+#include "erl_nif.h"
 #include "bif.h"
 #include "big.h"
 #include "erl_version.h"
@@ -2457,6 +2458,13 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 	int n = erts_snprintf(buf, 42, "%d.%d",
 			      ERL_DRV_EXTENDED_MAJOR_VERSION,
 			      ERL_DRV_EXTENDED_MINOR_VERSION);
+	hp = HAlloc(BIF_P, 2*n);
+	BIF_RET(buf_to_intlist(&hp, buf, n, NIL));
+    } else if (ERTS_IS_ATOM_STR("nif_version", BIF_ARG_1)) {
+	char buf[42];
+	int n = erts_snprintf(buf, 42, "%d.%d",
+			      ERL_NIF_MAJOR_VERSION,
+			      ERL_NIF_MINOR_VERSION);
 	hp = HAlloc(BIF_P, 2*n);
 	BIF_RET(buf_to_intlist(&hp, buf, n, NIL));
     } else if (ERTS_IS_ATOM_STR("smp_support", BIF_ARG_1)) {

--- a/erts/emulator/test/driver_SUITE.erl
+++ b/erts/emulator/test/driver_SUITE.erl
@@ -1204,8 +1204,8 @@ check_si_res(["sched_thrs", Value]) ->
     ?line Value = integer_to_list(erlang:system_info(schedulers));
 
 %% Data added in 3rd version of driver_system_info() (driver version 1.5)
-check_si_res(["emu_nif_vsn", _Value]) ->
-    true;
+check_si_res(["emu_nif_vsn", Value]) ->
+    ?line Value = erlang:system_info(nif_version);
 
 %% Data added in 4th version of driver_system_info() (driver version 3.1)
 check_si_res(["dirty_sched", _Value]) ->

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2252,6 +2252,7 @@ tuple_to_list(_Tuple) ->
          (modified_timing_level) -> integer() | undefined;
          (multi_scheduling) -> disabled | blocked | enabled;
          (multi_scheduling_blockers) -> [PID :: pid()];
+         (nif_version) -> string();
          (otp_release) -> string();
          (port_count) -> non_neg_integer();
          (port_limit) -> pos_integer();

--- a/lib/runtime_tools/src/system_information.erl
+++ b/lib/runtime_tools/src/system_information.erl
@@ -371,6 +371,7 @@ erlang_system_info() ->
 	    logical_processors_online,
 	    logical_processors_available,
 	    driver_version,
+	    nif_version,
 	    emu_args,
 	    ethread_info,
 	    beam_jump_table,

--- a/lib/runtime_tools/test/system_information_SUITE_data/information_test_report.dat
+++ b/lib/runtime_tools/test/system_information_SUITE_data/information_test_report.dat
@@ -9720,6 +9720,7 @@
                  {logical_processors_online,4},
                  {logical_processors_available,4},
                  {driver_version,"2.1"},
+                 {nif_version,"1.1"},
                  {taints,[]}]},
                {erts_compile_info,
                 [{ldflags,[]},


### PR DESCRIPTION
This patch allows checking for NIF API version in a way similar to
driver version. E.g. by calling erlang:system_info(nif_version).

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
