### PR TITLE
os_mon: cpu_sup should use native sysctl/libkvm calls on BSD

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -4705,9 +4705,18 @@ AC_CHECK_LIB(kstat, kstat_open, [
 	CPU_SUP_LIBS="$CPU_SUP_LIBS -lkstat"
 	])
 
+AC_CHECK_LIB(kvm, kvm_open, [
+	os_mon_programs="$os_mon_programs cpu_sup"
+	CPU_SUP_LIBS="$CPU_SUP_LIBS -lkvm"
+	])
+
 case $host_os in
 	solaris2*)
 		os_mon_programs="$os_mon_programs ferrule mod_syslog" ;;
+	darwin*)
+		os_mon_programs="$os_mon_programs cpu_sup" ;;
+	openbsd*)
+		os_mon_programs="$os_mon_programs cpu_sup" ;;
 	linux*)
 		os_mon_programs="$os_mon_programs cpu_sup" ;;
 esac

--- a/lib/os_mon/c_src/cpu_sup.c
+++ b/lib/os_mon/c_src/cpu_sup.c
@@ -138,7 +138,7 @@ static void util_measure(unsigned int **result_vec, int *result_sz);
 #if defined(__sun__)
 static unsigned int misc_measure(char* name);
 #endif
-static void send(unsigned int data);
+static void sendi(unsigned int data);
 static void sendv(unsigned int data[], int ints);
 static void error(char* err_msg);
 
@@ -192,12 +192,12 @@ int main(int argc, char** argv) {
       error("Erlang has closed");
     
     switch(cmd) {
-    case PING:		send(4711);					break;
+    case PING:		sendi(4711);					break;
 #if defined(__sun__)
-    case NPROCS:	send(misc_measure("nproc"));			break;
-    case AVG1:		send(misc_measure("avenrun_1min"));		break;
-    case AVG5:		send(misc_measure("avenrun_5min"));		break;
-    case AVG15:		send(misc_measure("avenrun_15min"));		break;
+    case NPROCS:	sendi(misc_measure("nproc"));			break;
+    case AVG1:		sendi(misc_measure("avenrun_1min"));		break;
+    case AVG5:		sendi(misc_measure("avenrun_5min"));		break;
+    case AVG15:		sendi(misc_measure("avenrun_15min"));		break;
 #elif defined(__OpenBSD__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__) || defined(__DragonFly__)
     case NPROCS:	bsd_count_procs();				break;
     case AVG1:		bsd_loadavg(0);					break;
@@ -225,7 +225,7 @@ static void bsd_loadavg(int idx) {
 	error(strerror(errno));
 	return;
     }
-    send((unsigned int)(avgs[idx] * 256));
+    sendi((unsigned int)(avgs[idx] * 256));
 }
 
 #endif
@@ -243,7 +243,7 @@ static void bsd_count_procs(void) {
 	return;
     }
 
-    send((unsigned int)nproc);
+    sendi((unsigned int)nproc);
 }
 
 #elif defined(__FreeBSD__) || defined(__DragonFly__)
@@ -269,7 +269,7 @@ static void bsd_count_procs(void) {
     }
 
     (void)kvm_close(kd);
-    send((unsigned int)cnt);
+    sendi((unsigned int)cnt);
 }
 
 #elif (defined(__APPLE__) && defined(__MACH__))
@@ -285,7 +285,7 @@ static void bsd_count_procs(void) {
 	return;
     }
 
-    send((unsigned int)(len / sizeof(struct kinfo_proc)));
+    sendi((unsigned int)(len / sizeof(struct kinfo_proc)));
 }
 
 #endif
@@ -523,7 +523,7 @@ static void util_measure(unsigned int **result_vec, int *result_sz) {
  *	 Generic functions 	*
  * ---------------------------- */
 
-static void send(unsigned int data) { sendv(&data, 1); }
+static void sendi(unsigned int data) { sendv(&data, 1); }
 
 static void sendv(unsigned int data[], int ints) {
     static unsigned char *buf = NULL;

--- a/lib/os_mon/src/cpu_sup.erl
+++ b/lib/os_mon/src/cpu_sup.erl
@@ -217,8 +217,6 @@ code_change(_OldVsn, State, _Extra) ->
 %% internal functions 
 %%----------------------------------------------------------------------
 
-get_uint32_measurement(Request, #internal{port = P, os_type = {unix, sunos}}) ->
-    port_server_call(P, Request);
 get_uint32_measurement(Request, #internal{os_type = {unix, linux}}) ->
     {ok,F} = file:open("/proc/loadavg",[read,raw]),
     {ok,D} = file:read(F,24),
@@ -231,67 +229,13 @@ get_uint32_measurement(Request, #internal{os_type = {unix, linux}}) ->
 	?ping -> 4711;
 	?nprocs -> PTotal
     end;
-get_uint32_measurement(Request, #internal{os_type = {unix, freebsd}}) ->
-    D = os:cmd("/sbin/sysctl -n vm.loadavg") -- "\n",
-    {ok,[Load1,Load5,Load15],_} = io_lib:fread("{ ~f ~f ~f }", D),
-    %% We could count the lines from the ps command as well
-    case Request of
-	?avg1  -> sunify(Load1);
-	?avg5  -> sunify(Load5);
-	?avg15 -> sunify(Load15);
-	?ping -> 4711;
-	?nprocs ->
-	    Ps = os:cmd("/bin/ps -ax | /usr/bin/wc -l"),
-	    {ok, [N], _} = io_lib:fread("~d", Ps),
-	    N-1
-    end;
-get_uint32_measurement(Request, #internal{os_type = {unix, dragonfly}}) ->
-    D = os:cmd("/sbin/sysctl -n vm.loadavg") -- "\n",
-    {ok,[Load1,Load5,Load15],_} = io_lib:fread("{ ~f ~f ~f }", D),
-    %% We could count the lines from the ps command as well
-    case Request of
-	?avg1  -> sunify(Load1);
-	?avg5  -> sunify(Load5);
-	?avg15 -> sunify(Load15);
-	?ping -> 4711;
-	?nprocs ->
-	    Ps = os:cmd("/bin/ps -ax | /usr/bin/wc -l"),
-	    {ok, [N], _} = io_lib:fread("~d", Ps),
-	    N-1
-    end;
-get_uint32_measurement(Request, #internal{os_type = {unix, openbsd}}) ->
-    D = os:cmd("/sbin/sysctl -n vm.loadavg") -- "\n",
-    {ok, [L1, L5, L15], _} = io_lib:fread("~f ~f ~f", D),
-    case Request of
-	?avg1  -> sunify(L1);
-	?avg5  -> sunify(L5);
-	?avg15 -> sunify(L15);
-	?ping -> 4711;
-	?nprocs ->
-	    Ps = os:cmd("/bin/ps -ax | /usr/bin/wc -l"),
-	    {ok, [N], _} = io_lib:fread("~d", Ps),
-	    N-1
-    end;
-get_uint32_measurement(Request, #internal{os_type = {unix, darwin}}) ->
-    %% Get the load average using uptime, overriding Locale setting.
-    D = os:cmd("LANG=C LC_ALL=C uptime") -- "\n",
-    %% Here is a sample uptime string from Mac OS 10.3.8 (C Locale):
-    %%    "11:17  up 12 days, 20:39, 2 users, load averages: 1.07 0.95 0.66"
-    %% The safest way to extract the load averages seems to be grab everything
-    %% after the last colon and then do an fread on that.
-    Avg = lists:reverse(hd(string:tokens(lists:reverse(D), ":"))),
-    {ok,[L1,L5,L15],_} = io_lib:fread("~f ~f ~f", Avg),
-
-    case Request of
-	?avg1  -> sunify(L1);
-	?avg5  -> sunify(L5);
-	?avg15 -> sunify(L15);
-	?ping -> 4711;
-	?nprocs ->
-	    Ps = os:cmd("/bin/ps -ax | /usr/bin/wc -l"),
-	    {ok, [N], _} = io_lib:fread("~d", Ps),
-	    N-1
-    end;
+get_uint32_measurement(Request, #internal{port = P, os_type = {unix, Sys}}) when
+								Sys == sunos;
+								Sys == dragonfly;
+								Sys == openbsd;
+								Sys == freebsd;
+								Sys == darwin ->
+    port_server_call(P, Request);
 get_uint32_measurement(Request, #internal{os_type = {unix, Sys}}) when Sys == irix64;
 								 Sys == irix ->
     %% Get the load average using uptime.
@@ -541,14 +485,16 @@ measurement_server_init() ->
     process_flag(trap_exit, true),
     OS = os:type(),
     Server = case OS of
-	{unix, Flavor} when Flavor==sunos;
-			    Flavor==linux ->
-	    {ok, Pid} = port_server_start_link(),
-	    Pid;
-	{unix, Flavor} when Flavor==darwin;
+	{unix, Flavor} when
+			    Flavor==sunos;
+			    Flavor==linux;
+			    Flavor==darwin;
 			    Flavor==freebsd;
 			    Flavor==dragonfly;
-			    Flavor==openbsd;
+			    Flavor==openbsd ->
+	    {ok, Pid} = port_server_start_link(),
+	    Pid;
+	{unix, Flavor} when
 			    Flavor==irix64;
 			    Flavor==irix ->
 	    not_used;


### PR DESCRIPTION
Currently the cpu_sup module in os_mon forks out with os:cmd on most BSD platforms, to run "uptime" or "ps" to get things like the load average and number of running processes. There is also a C port driver to get this information directly from the system on Solaris and Linux.

This patch extends the C port driver to support FreeBSD, OpenBSD, Darwin (Mac OSX) and DragonFlyBSD, and replaces the os:cmd calls. This is much faster and lighter on the system, and relies on less fragile interfaces (eg, using getloadavg(3) which has been unchanged since 4.3BSD, as opposed to relying on the exact text output format of the "uptime" command).

The motivation for this is mostly Riak, which calls the load average functions about once a second (to decide when load is low enough to run cleanup tasks etc). Riak processes get quite large in RSS terms, and the overhead of forking them and then cleaning up the child all the time can be quite expensive on these platforms. This is particularly the case on OpenBSD, where the big kernel lock still exists -- the cleanup of these processes can lock up the entire system for milliseconds at a time.

I've compiled and tested this patch on all 4 platforms, at their latest release versions.