### PR TITLE
iso_week_to_date/3 

### DIFF
--- a/lib/stdlib/src/calendar.erl
+++ b/lib/stdlib/src/calendar.erl
@@ -30,6 +30,7 @@
 	 is_leap_year/1,
 	 iso_week_number/0,
 	 iso_week_number/1,
+   iso_week_to_date/3,
 	 last_day_of_the_month/2,
 	 local_time/0, 
 	 local_time_to_universal_time/1, 
@@ -190,6 +191,28 @@ is_leap_year1(Year) when Year rem 400 =:= 0 ->
     true;
 is_leap_year1(_) -> false.
 
+%%
+%% Calculates the date for an iso week number, year and day of the week.
+%%
+-spec(iso_week_to_date(year(), weeknum(), daynum()) -> date()).
+iso_week_to_date(Year, WeekNo, WeekDay) ->
+    DayNum = day_of_the_week({Year, 1, 4}),
+    DayOfYear = (WeekNo * 7) + WeekDay - (DayNum + 3),
+    ExtraDay = case is_leap_year(Year) of
+      true ->
+		       1;
+		  false ->
+		       0
+	  end,
+    {Month, Day} = year_day_to_date2(ExtraDay, DayOfYear),
+    case {Day > 31, Day < 0} of
+      {true, _} ->
+        {Year + 1, 1, Day - 31};
+      {_, true} ->
+        {Year - 1, 12, 31 + Day};
+      _ ->
+        {Year, Month, Day}
+    end.
 
 %%
 %% Calculates the iso week number for the current date.
@@ -198,7 +221,6 @@ is_leap_year1(_) -> false.
 iso_week_number() ->
     {Date, _} = local_time(),
     iso_week_number(Date).
-
 
 %%
 %% Calculates the iso week number for the given date.

--- a/lib/stdlib/test/calendar_SUITE.erl
+++ b/lib/stdlib/test/calendar_SUITE.erl
@@ -29,7 +29,8 @@
 	 leap_years/1,
 	 last_day_of_the_month/1,
 	 local_time_to_universal_time_dst/1,
-	 iso_week_number/1]).
+	 iso_week_number/1,
+         iso_week_to_date/1]).
 
 -define(START_YEAR, 1947).			
 -define(END_YEAR, 2012).
@@ -39,7 +40,8 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 all() -> 
     [gregorian_days, gregorian_seconds, day_of_the_week,
      day_of_the_week_calibrate, leap_years,
-     last_day_of_the_month, local_time_to_universal_time_dst, iso_week_number].
+     last_day_of_the_month, local_time_to_universal_time_dst, iso_week_number,
+     iso_week_to_date].
 
 groups() -> 
     [].
@@ -180,6 +182,16 @@ iso_week_number(suite) ->
 iso_week_number(Config) when is_list(Config) ->
 	?line check_iso_week_number().
 
+iso_week_to_date(doc) ->
+	"Test the inverse of iso week number calculation for all three possibilities."
+	" When the date falls on the last week of the previous year,"
+	" when the date falls on a week within the given year and finally,"
+	" when the date falls on the first week of the next year.";
+iso_week_to_date(suite) ->
+	[];
+iso_week_to_date(Config) when is_list(Config) ->
+	?line check_iso_week_to_date().
+
 %%
 %% LOCAL FUNCTIONS
 %%
@@ -274,6 +286,10 @@ check_iso_week_number() ->
     ?line {2004, 53} = calendar:iso_week_number({2005, 1, 1}),
     ?line {2007, 1} = calendar:iso_week_number({2007, 1, 1}),
     ?line {2009, 1} = calendar:iso_week_number({2008, 12, 29}).
-    
 
-
+%% check_iso_week_to_date
+%%
+check_iso_week_to_date() ->
+    ?line {2005, 1, 1} = calendar:iso_week_to_date(2004, 53, 6),
+    ?line {2007, 1, 1} = calendar:iso_week_to_date(2007, 1, 1),
+    ?line {2008, 12, 29} = calendar:iso_week_to_date(2009, 1, 1).


### PR DESCRIPTION
Add iso_week_to_date

Following http://en.wikipedia.org/wiki/ISO_week_date as reference add iso_week_to_date/3 which takes ISO Week, year and day of the week and finding the date associated with it. This is the inverse of iso_week_number/1. This function returns date representing the iso week given to it