### PR TITLE
Fix gc-related problem with dirty NIFs

### DIFF
--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1646,6 +1646,7 @@ init_nif_sched_data(ErlNifEnv* env, NativeFunPtr direct_fp, NativeFunPtr indirec
     ep->m = env->mod_nif;
     ep->fp = indirect_fp;
     proc->freason = TRAP;
+    proc->arity = argc;
     return THE_NON_VALUE;
 }
 

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -1564,6 +1564,8 @@ dirty_nif(Config) when is_list(Config) ->
 	    Val2 = "Erlang",
 	    Val3 = list_to_binary([Val2, 0]),
 	    {Val1, Val2, Val3} = call_dirty_nif(Val1, Val2, Val3),
+	    LargeArray = lists:duplicate(1000, ok),
+	    LargeArray = call_dirty_nif_zero_args(),
 	    ok
     catch
 	error:badarg ->
@@ -1740,6 +1742,7 @@ call_nif_schedule(_,_) -> ?nif_stub.
 call_dirty_nif(_,_,_) -> ?nif_stub.
 send_from_dirty_nif(_) -> ?nif_stub.
 call_dirty_nif_exception() -> ?nif_stub.
+call_dirty_nif_zero_args() -> ?nif_stub.
 
 %% maps
 is_map_nif(_) -> ?nif_stub.

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -1623,6 +1623,18 @@ static ERL_NIF_TERM call_dirty_nif_exception(ErlNifEnv* env, int argc, const ERL
 				 call_dirty_nif_exception, argc-1, argv);
     }
 }
+
+static ERL_NIF_TERM call_dirty_nif_zero_args(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    int i;
+    ERL_NIF_TERM result[1000];
+    ERL_NIF_TERM ok = enif_make_atom(env, "ok");
+    assert(argc == 0);
+    for (i = 0; i < sizeof(result)/sizeof(*result); i++) {
+	result[i] = ok;
+    }
+    return enif_make_list_from_array(env, result, i);
+}
 #endif
 
 static ERL_NIF_TERM is_map_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -1807,6 +1819,7 @@ static ErlNifFunc nif_funcs[] =
     {"call_dirty_nif", 3, call_dirty_nif},
     {"send_from_dirty_nif", 1, send_from_dirty_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"call_dirty_nif_exception", 0, call_dirty_nif_exception, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"call_dirty_nif_zero_args", 0, call_dirty_nif_zero_args, ERL_NIF_DIRTY_JOB_CPU_BOUND},
 #endif
     {"is_map_nif", 1, is_map_nif},
     {"get_map_size_nif", 1, get_map_size_nif},


### PR DESCRIPTION
Ensure that the return value from a dirty NIF call is made part of the GC
rootset. Add a new regression test to nif_SUITE.

Thanks to Daniel Goertzen for reporting the error and providing a test
case, and to Sverker Eriksson for making test case reproducible and finding
the fix.
