### PR TITLE
[warnings] Cleaned -Wconditional-uninitialized warnings by clang

### DIFF
--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -240,7 +240,7 @@ erts_atom_put(const byte *name, int len, ErtsAtomEncoding enc, int trunc)
     byte utf8_copy[MAX_ATOM_SZ_FROM_LATIN1];
     const byte *text = name;
     int tlen = len;
-    Sint no_latin1_chars;
+    Sint no_latin1_chars = 0;
     Atom a;
     int aix;
 

--- a/erts/emulator/beam/beam_bp.c
+++ b/erts/emulator/beam/beam_bp.c
@@ -861,7 +861,7 @@ do_call_trace(Process* c_p, BeamInstr* I, Eterm* reg,
     Eterm* cpp;
     int return_to_trace = 0;
     BeamInstr w;
-    BeamInstr *cp_save;
+    BeamInstr *cp_save = NULL;
     Uint32 flags;
     Uint need = 0;
     Eterm* E = c_p->stop;

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -177,7 +177,7 @@ BIF_RETTYPE link_1(BIF_ALIST_1)
 	erts_smp_proc_unlock(BIF_P, ERTS_PROC_LOCK_LINK);
 
 	if (send_link_signal) {
-	    Eterm ref;
+            Eterm ref = NIL;
 	    Eterm *refp = erts_port_synchronous_ops ? &ref : NULL;
 
 	    switch (erts_port_link(BIF_P, prt, BIF_P->common.id, refp)) {
@@ -982,7 +982,7 @@ BIF_RETTYPE unlink_1(BIF_ALIST_1)
 	    prt = erts_port_lookup(BIF_ARG_1, ERTS_PORT_SFLGS_DEAD);
 	    if (prt) {
 		ErtsPortOpResult res;
-		Eterm ref;
+                Eterm ref = NIL;
 		Eterm *refp = erts_port_synchronous_ops ? &ref : NULL;
 #ifdef DEBUG
 		ref = NIL;
@@ -1366,7 +1366,7 @@ BIF_RETTYPE exit_2(BIF_ALIST_2)
       */
 
      if (is_internal_port(BIF_ARG_1)) {
-	 Eterm ref, *refp;
+         Eterm ref = NIL, *refp;
 	 Uint32 invalid_flags;
 	 Port *prt;
 

--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -2758,7 +2758,7 @@ erts_allocator_options(void *proc)
 #if HAVE_ERTS_MSEG
     int use_mseg = 0;
 #endif
-    Uint sz, *szp, *hp, **hpp;
+    Uint sz, *szp, *hp = NULL, **hpp;
     Eterm res, features, settings;
     Eterm atoms[ERTS_ALC_A_MAX-ERTS_ALC_A_MIN+7];
     Uint terms[ERTS_ALC_A_MAX-ERTS_ALC_A_MIN+7];
@@ -2961,7 +2961,7 @@ reply_alloc_info(void *vair)
     int global_instances = air->req_sched == sched_id;
     ErtsProcLocks rp_locks;
     Process *rp = air->proc;
-    Eterm ref_copy = NIL, ai_list, msg;
+    Eterm ref_copy = NIL, ai_list, msg = NIL;
     Eterm *hp = NULL, *hp_end = NULL, *hp_start = NULL;
     Eterm **hpp;
     Uint sz, *szp;

--- a/erts/emulator/beam/erl_bif_port.c
+++ b/erts/emulator/beam/erl_bif_port.c
@@ -616,7 +616,7 @@ BIF_RETTYPE port_get_data_1(BIF_ALIST_1)
 static Port *
 open_port(Process* p, Eterm name, Eterm settings, int *err_typep, int *err_nump)
 {
-    int i;
+    int i = 0;
     Eterm option;
     Uint arity;
     Eterm* tp;

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -448,8 +448,8 @@ Eterm
 erts_bs_get_float_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
 {
     Eterm* hp;
-    float f32;
-    double f64;
+    float  f32 = 0.0f;
+    double f64 = 0.0;
     byte* fptr;
     FloatDef f;
 

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -851,7 +851,7 @@ BIF_RETTYPE ets_update_counter_3(BIF_ALIST_3)
     int cret = DB_ERROR_BADITEM;
     Eterm upop_list;
     int list_size;
-    Eterm ret;  /* int or [int] */
+    Eterm ret = NIL;  /* int or [int] */
     Eterm* ret_list_currp = NULL;
     Eterm* ret_list_prevp = NULL;
     Eterm iter;

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -400,7 +400,7 @@ erts_garbage_collect(Process* p, int need, Eterm* objv, int nobj)
 {
     Uint reclaimed_now = 0;
     int done = 0;
-    Uint ms1, s1, us1;
+    Uint ms1 = 0, s1 = 0, us1 = 0;
     ErtsSchedulerData *esdp;
 #ifdef USE_VM_PROBES
     DTRACE_CHARBUF(pidbuf, DTRACE_TERM_BUF_SIZE);
@@ -677,7 +677,7 @@ erts_garbage_collect_literals(Process* p, Eterm* literals,
     Uint area_size;
     Eterm* old_htop;
     Uint n;
-    struct erl_off_heap_header** prev;
+    struct erl_off_heap_header** prev = NULL;
 
     if (p->flags & F_DISABLE_GC)
 	return;

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -9739,7 +9739,7 @@ execute_sys_tasks(Process *c_p, erts_aint32_t *statep, int in_reds)
     do {
 	ErtsProcSysTask *st;
 	int st_prio;
-	Eterm st_res;
+        Eterm st_res = NIL;
 
 	if (state & (ERTS_PSFLG_EXITING|ERTS_PSFLG_PENDING_EXIT)) {
 #ifdef ERTS_SMP

--- a/erts/emulator/beam/erl_unicode.c
+++ b/erts/emulator/beam/erl_unicode.c
@@ -1158,12 +1158,11 @@ static ERTS_INLINE int
 analyze_utf8(byte *source, Uint size, byte **err_pos, Uint *num_chars, int *left,
 	     Sint *num_latin1_chars, Uint max_chars)
 {
-    Uint latin1_count;
-    int is_latin1;
+    Uint latin1_count = 0;
+    int is_latin1 = 0;
     *err_pos = source;
     if (num_latin1_chars) {
 	is_latin1 = 1;
-	latin1_count = 0;
     }
     *num_chars = 0;
     while (size) {

--- a/erts/emulator/pcre/pcre_compile.c
+++ b/erts/emulator/pcre/pcre_compile.c
@@ -2920,7 +2920,7 @@ static int
 get_othercase_range(pcre_uint32 *cptr, pcre_uint32 d, pcre_uint32 *ocptr,
   pcre_uint32 *odptr)
 {
-pcre_uint32 c, othercase, next;
+pcre_uint32 c, othercase = 0, next;
 unsigned int co;
 
 /* Find the first character that has an other case. If it has multiple other

--- a/erts/emulator/pcre/pcre_exec.c
+++ b/erts/emulator/pcre/pcre_exec.c
@@ -564,14 +564,14 @@ match(REGISTER PCRE_PUCHAR eptr, REGISTER const pcre_uchar *ecode,
 so they can be ordinary variables in all cases. Mark some of them with
 "register" because they are used a lot in loops. */
 
-register int  rrc;         /* Returns from recursive calls */
-register int  i;           /* Used for loops not involving calls to RMATCH() */
-register pcre_uint32 c;    /* Character values not kept over RMATCH() calls */
+register int  rrc = 0;     /* Returns from recursive calls */
+register int  i = 0;       /* Used for loops not involving calls to RMATCH() */
+register pcre_uint32 c = 0;/* Character values not kept over RMATCH() calls */
 register BOOL utf;         /* Local copy of UTF flag for speed */
 
-BOOL minimize, possessive; /* Quantifier options */
-BOOL caseless;
-int condcode;
+BOOL minimize = FALSE, possessive = FALSE; /* Quantifier options */
+BOOL caseless = FALSE;
+int condcode = 0;
 
 /* When recursion is not being used, all "local" variables that have to be
 preserved over calls to RMATCH() are part of a "frame". We set up the top-level

--- a/erts/emulator/sys/common/erl_mmap.c
+++ b/erts/emulator/sys/common/erl_mmap.c
@@ -1788,7 +1788,7 @@ remap_move(Uint32 flags, void *ptr, UWord old_size, UWord *sizep)
 void *
 erts_mremap(Uint32 flags, void *ptr, UWord old_size, UWord *sizep)
 {
-    void *new_ptr;
+    void *new_ptr = NULL;
     Uint32 superaligned;
     UWord asize;
 

--- a/erts/etc/common/heart.c
+++ b/erts/etc/common/heart.c
@@ -292,9 +292,9 @@ free_env_val(char *value)
  */
 static void get_arguments(int argc, char** argv) {
     int i = 1;
-    int h;
-    int w;
-    unsigned long p;
+    int h = 0;
+    int w = 0;
+    unsigned long p = 0;
 
     while (i < argc) {
 	switch (argv[i][0]) {


### PR DESCRIPTION
This branch is a part of initiative to fix compile warnings on maximum warning level

This commit fixes some conditionally uninitialized variables (which are not initialized in all branches of 
execution). To reviewer: See if NIL is appropriate init value everywhere.
