### PR TITLE
Section reference number incorrect

### DIFF
--- a/system/doc/reference_manual/typespec.xml
+++ b/system/doc/reference_manual/typespec.xml
@@ -103,7 +103,7 @@
         | Map
         | Tuple
         | Union
-        | UserDefined           %% described in Section 6.3
+        | UserDefined           %% described in Section 7.3
 
   Atom :: atom()
         | Erlang_Atom           %% 'foo', 'bar', ...


### PR DESCRIPTION
I just fount that the section reference is pointing to the wrong section on http://www.erlang.org/doc/reference_manual/typespec.html, under 7.2 where it say:

```
    | UserDefined           %% described in Section 6.3
```

Should say '7.3.'

Don't know about the wording because if the whole section change, the reference will be wrong again. 
