### PR TITLE
Introduce os:getenv/2

### DIFF
--- a/lib/kernel/doc/src/os.xml
+++ b/lib/kernel/doc/src/os.xml
@@ -100,6 +100,19 @@ DirOut = os:cmd("dir"), % on Win32 platform</code>
       </desc>
     </func>
     <func>
+      <name name="getenv" arity="2"/>
+      <fsummary>Get the value of an environment variable</fsummary>
+      <desc>
+        <p>Returns the <c><anno>Value</anno></c> of the environment variable
+          <c><anno>VarName</anno></c>, or <c>DefaultValue</c> if the environment variable
+          is undefined.</p>
+	<p>If Unicode file name encoding is in effect (see the <seealso
+	marker="erts:erl#file_name_encoding">erl manual
+	page</seealso>), the strings (both <c><anno>VarName</anno></c> and
+	<c><anno>Value</anno></c>) may contain characters with codepoints > 255.</p>
+      </desc>
+    </func>
+    <func>
       <name name="getpid" arity="0"/>
       <fsummary>Return the process identifier of the emulator process</fsummary>
       <desc>

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -26,7 +26,7 @@
 
 %%% BIFs
 
--export([getenv/0, getenv/1, getpid/0, putenv/2, timestamp/0, unsetenv/1]).
+-export([getenv/0, getenv/1, getenv/2, getpid/0, putenv/2, timestamp/0, unsetenv/1]).
 
 -spec getenv() -> [string()].
 
@@ -38,6 +38,19 @@ getenv() -> erlang:nif_error(undef).
 
 getenv(_) ->
     erlang:nif_error(undef).
+
+-spec getenv(VarName, DefaultValue) -> Value when
+      VarName :: string(),
+      DefaultValue :: string(),
+      Value :: string().
+
+getenv(VarName, DefaultValue) ->
+    case os:getenv(VarName) of
+        false ->
+           DefaultValue;
+        Value ->
+            Value
+    end.
 
 -spec getpid() -> Value when
       Value :: string().


### PR DESCRIPTION
I see a lot of projects are using os:getenv/1 in a following way:

Var = case os:getenv("EnvName") of false -> "DefaultVal" ; EnvVal -> EnvVal end.

For example:
- https://github.com/basho/bitcask/blob/f7cc709ca51c15df5f2418e961336163787c0ac4/src/bitcask_io.erl#L91
- https://github.com/basho/bitcask/blob/f7cc709ca51c15df5f2418e961336163787c0ac4/test/bitcask_pulse.erl#L407
- https://github.com/basho/bitcask/blob/f7cc709ca51c15df5f2418e961336163787c0ac4/test/bitcask_pulse.erl#L411
- https://github.com/processone/ejabberd/blob/7138cc56333ffd16eb4c0483b4b2421d12cb6977/src/ejabberd_config.erl#L90
- https://github.com/erlang/otp/blob/983a39ab079c9f825d31cfe349588a76824d8ef2/lib/inets/test/erl_make_certs.erl#L219
- https://github.com/erlang/otp/blob/983a39ab079c9f825d31cfe349588a76824d8ef2/lib/jinterface/test/jitu.erl#L120
- https://github.com/erlang/otp/blob/983a39ab079c9f825d31cfe349588a76824d8ef2/lib/ssh/src/ssh_connection.erl#L1304
- https://github.com/lemenkov/erlpmd/blob/cd6ef9ad793b4b8fe1ee61ba1baf2d7a8b08e872/src/erlpmd_ctl.erl#L30
- https://github.com/lemenkov/erlpmd/blob/cd6ef9ad793b4b8fe1ee61ba1baf2d7a8b08e872/src/erlpmd_ctl.erl#L35
- https://github.com/erlyvideo/flussonic-old/blob/e52617d21b7de9524ab64df6f8aa518ecd9527f3/apps/flussonic/src/flussonic.erl#L168
- https://github.com/jcomellas/getopt/blob/626698975e63866156159661d100785d65eab6f9/src/getopt.erl#L887

...and many more. So let's introduce a new function for that!
