### PR TITLE
Update erlang.xml

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6286,7 +6286,7 @@ ok
           <tag><c>smp_support</c></tag>
           <item>
             <p>Returns <c>true</c> if the emulator has been compiled
-              with smp support; otherwise, <c>false</c>.</p>
+              with smp support and is run on a server with multiple physical or logical processors; otherwise, <c>false</c>.</p>
           </item>
           <tag><c>system_version</c></tag>
           <item>


### PR DESCRIPTION
smp_support is false on a box with just one processor even if the erlang itself has been compiled with smp support