### PR TITLE
Add infometion about function()

### DIFF
--- a/system/doc/reference_manual/typespec.xml
+++ b/system/doc/reference_manual/typespec.xml
@@ -217,6 +217,9 @@
       <cell><c>iolist()</c></cell><cell><c>maybe_improper_list(byte() | binary() | iolist(), binary() | [])</c></cell>
     </row>
     <row>
+      <cell><c>function()</c></cell><cell><c>fun()</c></cell>
+    </row>
+    <row>
       <cell><c>module()</c></cell><cell><c>atom()</c></cell>
     </row>
     <row> 


### PR DESCRIPTION
`function()` may not be recommended. But we would see warnings when we define own `function()` type. So I think it should be written in document.
