### PR TITLE
Clean up temporary dtrace file during config

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3970,6 +3970,7 @@ if test "$enable_dtrace_test" = "yes" ; then
                         DTRACE_ENABLED_2STEP=yes
 		     fi],
                     [])
+		$RM -f foo-dtrace.h
 		AS_IF([test "x$DTRACE_ENABLED_2STEP" = "xyes"],
 		      [AC_MSG_RESULT([yes])],
                       [AC_MSG_RESULT([no])])


### PR DESCRIPTION
When configuring erts to support dynamic trace via dtrace, be sure to clean
up the temporary file "erts/foo-dtrace.h" used to help check for dtrace
support. Otherwise, it shows up as an untracked file in git.
