### PR TITLE
fix eacces spelling

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2840,7 +2840,7 @@ os_prompt% </pre>
 	      raised. The error reason may differ between operating
 	      systems. Typically the error <c>enoent</c> is raised
 	      when one tries to run a program that is not found and
-	      <c>eaccess</c> is raised when the given file is not
+	      <c>eacces</c> is raised when the given file is not
 	      executable.</p>
           </item>
           <tag><c>{fd, <anno>In</anno>, <anno>Out</anno>}</c></tag>

--- a/lib/inets/doc/src/httpd_conf.xml
+++ b/lib/inets/doc/src/httpd_conf.xml
@@ -97,7 +97,7 @@
         <v>FilePath = string()</v>
         <v>Result = {ok,Directory} | {error,Reason}</v>
         <v>Directory = string()</v>
-        <v>Reason = string() | enoent | eaccess | enotdir | FileInfo</v>
+        <v>Reason = string() | enoent | eacces | enotdir | FileInfo</v>
         <v>FileInfo = File info record</v>
       </type>
       <desc>
@@ -105,7 +105,7 @@
         <p><c>is_directory/1</c> checks if <c>FilePath</c> is a
 	directory in which case it is returned. Please read
 	<c>file(3)</c> for a description of <c>enoent</c>,
-	<c>eaccess</c> and <c>enotdir</c>. The definition of 
+	<c>eacces</c> and <c>enotdir</c>. The definition of 
 	the file info record can be found by including <c>file.hrl</c> 
 	from the kernel application, see file(3).</p>
 
@@ -120,14 +120,14 @@
         <v>FilePath = string()</v>
         <v>Result = {ok,File} | {error,Reason}</v>
         <v>File = string()</v>
-        <v>Reason = string() | enoent | eaccess | enotdir | FileInfo</v>
+        <v>Reason = string() | enoent | eacces | enotdir | FileInfo</v>
         <v>FileInfo = File info record</v>
       </type>
       <desc>
         <marker id="is_file"></marker>
         <p><c>is_file/1</c> checks if <c>FilePath</c> is a regular
 	file in which case it is returned. Read <c>file(3)</c> for a
-	description of <c>enoent</c>, <c>eaccess</c> and
+	description of <c>enoent</c>, <c>eacces</c> and
 	<c>enotdir</c>. The definition of the file info record can be 
 	found by including <c>file.hrl</c> from the kernel application, 
 	see file(3).</p>

--- a/lib/inets/src/http_server/httpd_conf.erl
+++ b/lib/inets/src/http_server/httpd_conf.erl
@@ -44,7 +44,7 @@
 %%	FilePath = string()
 %%      Result = {ok,Directory} | {error,Reason}
 %%      Directory = string()
-%%      Reason = string() | enoent | eaccess | enotdir | FileInfo
+%%      Reason = string() | enoent | eacces | enotdir | FileInfo
 %%      FileInfo = File info record
 %%
 %% Description: Checks if FilePath is a directory in which case it is
@@ -71,7 +71,7 @@ is_directory(_Type,_Access,FileInfo,_Directory) ->
 %%	FilePath = string()
 %%      Result = {ok,File} | {error,Reason}
 %%      File = string()
-%%      Reason = string() | enoent | eaccess | enotdir | FileInfo
+%%      Reason = string() | enoent | eacces | enotdir | FileInfo
 %%      FileInfo = File info record
 %%
 %% Description: Checks if FilePath is a regular file in which case it

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -424,7 +424,7 @@ make_del_dir(Config) when is_list(Config) ->
     ?line ok = ?FILE_MODULE:del_dir(NewDir),
     ?line {error, enoent} = ?FILE_MODULE:del_dir(NewDir),
     % Make sure we are not in a directory directly under test_server
-    % as that would result in eacess errors when trying to delere '..',
+    % as that would result in eacces errors when trying to delete '..',
     % because there are processes having that directory as current.
     ?line ok = ?FILE_MODULE:make_dir(NewDir),
     ?line {ok,CurrentDir} = file:get_cwd(),

--- a/lib/kernel/test/prim_file_SUITE.erl
+++ b/lib/kernel/test/prim_file_SUITE.erl
@@ -262,7 +262,7 @@ make_del_dir(Config, Handle, Suffix) ->
     ?line {error, enoent} = ?PRIM_FILE_call(del_dir, Handle, [NewDir]),
 
     % Make sure we are not in a directory directly under test_server
-    % as that would result in eacess errors when trying to delere '..',
+    % as that would result in eacces errors when trying to delete '..',
     % because there are processes having that directory as current.
     ?line ok = ?PRIM_FILE_call(make_dir, Handle, [NewDir]),
     ?line {ok, CurrentDir} = ?PRIM_FILE_call(get_cwd, Handle, []),


### PR DESCRIPTION
The return from the file module for EACCES errors is the atom 'eacces'.  Unfortunately it's easy to misspell.  This patch fixes the places in otp where it's spelled as 'eaccess' or as 'eacess'.  Luckily the places are all in comments or in documentation, not in actual code.  The lines with the 'eacess' spelling error also misspelled 'delete' so I fixed that too.

ets:tab2file/3 synthesizes 'eaccess' which seems wrong, but changing that might break code which expects this particular atom so I'm not changing it.
