### PR TITLE
Add AgentAddr field to the snmp_v1_trap_info() data type

### DIFF
--- a/lib/snmp/doc/src/snmpm_user.xml
+++ b/lib/snmp/doc/src/snmpm_user.xml
@@ -82,6 +82,7 @@ snmp_gen_info() = {ErrorStatus :: atom(),
                    ErrorIndex  :: pos_integer(), 
                    Varbinds    :: [snmp:varbind()]}
 snmp_v1_trap_info() :: {Enteprise :: snmp:oid(), 
+                        AgentAddr :: ip_address(),
                         Generic   :: integer(), 
                         Spec      :: integer(), 
                         Timestamp :: integer(), 

--- a/lib/snmp/src/manager/snmpm_server.erl
+++ b/lib/snmp/src/manager/snmpm_server.erl
@@ -2230,21 +2230,22 @@ ensure_present([{Key, _Val} = Elem|Ensure], Config) ->
     
 %% Retrieve user info for this agent.
 %% If this is an unknown agent, then use the default user
-handle_snmp_trap(
-  #trappdu{enterprise    = Enteprise, 
-	   generic_trap  = Generic, 
-	   specific_trap = Spec,
-	   time_stamp    = Timestamp, 
-	   varbinds      = Varbinds} = Trap, Domain, Addr, State) ->
+handle_snmp_trap(#trappdu{enterprise = Enteprise,
+                agent_addr    = AgentAddr,
+                generic_trap  = Generic,
+                specific_trap = Spec,
+                time_stamp    = Timestamp,
+                varbinds      = Varbinds} = Trap,
+            Addr, Port, State) ->
 
-    ?vtrace("handle_snmp_trap [trappdu] -> entry with~n"
-	    "   Domain:  ~p~n"
-	    "   Addr:    ~p~n"
-	    "   Trap:    ~p", [Domain, Addr, Trap]),
+    ?vtrace("handle_snmp_trap [trappdu] -> entry with"
+	    "~n   Addr: ~p"
+	    "~n   Port: ~p"
+	    "~n   Trap: ~p", [Addr, Port, Trap]),
 
-    Varbinds2 = fix_vbs_BITS(Varbinds), 
-    SnmpTrapInfo = {Enteprise, Generic, Spec, Timestamp, Varbinds2},
-    do_handle_snmp_trap(SnmpTrapInfo, Domain, Addr, State);
+    Varbinds2 = fix_vbs_BITS(Varbinds),
+    SnmpTrapInfo = {Enteprise, AgentAddr, Generic, Spec, Timestamp, Varbinds2},
+    do_handle_snmp_trap(SnmpTrapInfo, Addr, Port, State);
 
 handle_snmp_trap(#pdu{error_status = EStatus, 
 		      error_index  = EIndex, 

--- a/lib/snmp/src/manager/snmpm_user.erl
+++ b/lib/snmp/src/manager/snmpm_user.erl
@@ -20,18 +20,19 @@
 -module(snmpm_user).
 
 -export_type([
-	      snmp_gen_info/0, 
-	      snmp_v1_trap_info/0 
+	      snmp_gen_info/0,
+	      snmp_v1_trap_info/0
 	     ]).
 
--type snmp_gen_info() :: {ErrorStatus :: atom(), 
-			  ErrorIndex :: pos_integer(), 
+-type snmp_gen_info() :: {ErrorStatus :: atom(),
+			  ErrorIndex :: pos_integer(),
 			  Varbinds :: [snmp:varbind()]}.
--type snmp_v1_trap_info() :: {Enteprise :: snmp:oid(), 
-			      Generic   :: integer(), 
-			      Spec      :: integer(), 
-			      Timestamp :: integer(), 
-			      Varbinds  :: [snmp:varbind()]}.
+-type snmp_v1_trap_info() :: {Enteprise :: snmp:oid(),
+                    AgentAddr :: ip_address(),
+                    Generic   :: integer(),
+                    Spec      :: integer(),
+                    Timestamp :: integer(),
+                    Varbinds  :: [snmp:varbind()]}.
 -type ip_address()  :: inet:ip_address().
 -type port_number() :: inet:port_number().
 


### PR DESCRIPTION
 It's impossible to know the real agent address in cases when SNMP traps arrive through proxy

This patch makes it possible to get the real address from where trap has come to snmp_user callback.
