### PR TITLE
ssl: When we receive a clear_pem_cache message, don't check its size, just clear it.

### DIFF
--- a/lib/ssl/src/ssl_manager.erl
+++ b/lib/ssl/src/ssl_manager.erl
@@ -59,7 +59,6 @@
 -define(CLEAR_PEM_CACHE, 120000).
 -define(CLEAN_SESSION_DB, 60000).
 -define(CLEAN_CERT_DB, 500).
--define(NOT_TO_BIG, 10).
 
 %%====================================================================
 %% API
@@ -328,13 +327,8 @@ handle_info({delayed_clean_session, Key}, #state{session_cache = Cache,
     CacheCb:delete(Cache, Key),
     {noreply, State};
 
-handle_info(clear_pem_cache, #state{certificate_db = [_,_,PemChace]} = State) ->
-    case ssl_pkix_db:db_size(PemChace) of
-	N  when N < ?NOT_TO_BIG ->
-	    ok;
-	_ ->
-	    ssl_pkix_db:clear(PemChace)
-    end,
+handle_info(clear_pem_cache, #state{certificate_db = [_,_,PemCache]} = State) ->
+    ssl_pkix_db:clear(PemCache),
     erlang:send_after(?CLEAR_PEM_CACHE, self(), clear_pem_cache),
     {noreply, State};
 


### PR DESCRIPTION
Checking the db_size when receiving a clear_pem_message causes a regression where the PEM cache would not be cleared if it was too small. This would in turn cause updated PEM files to not be utilized by the rest of the ssl application.

This appears to have been originally added into ssl_certificate_db.erl in 68a055e261d70d3053694efddc1e5a26bf3553f1 and then moved to ssl_manager.erl in 8e80b89c7aafc70fbcb538c9c6b464912cb11d83 . Thus, this regression should affect R15B02 up to the current maint branch. I have manually verified that it's reproducible in R16B03-1 and OTP 17.3 .

Reproduction (with some tracing):

``` erlang
%% Start with an expired certificate (this also occurs with valid certificates that become expired).

$ erl
Erlang/OTP 17 [erts-6.2] [source] [64-bit] [smp:8:8] [async-threads:10] [kernel-poll:false]

Eshell V6.2  (abort with ^G)
1> dbg:start().
{ok,<0.35.0>}
2> dbg:tracer().
{ok,<0.35.0>}
3> dbg:p(all,call).
{ok,[{matched,nonode@nohost,26}]}
4> dbg:tpl(ssl_manager,handle_info,2,[]).
{ok,[{matched,nonode@nohost,1}]}
5> ssl:start().
ok

%% Attempt to make a connection

6> Opts = [
6>     {active, false},
6>     {mode, binary},
6>     {certfile, "/path/to/cert.pem"},
6>     {keyfile, "/path/to/key.pem"}
6> ].
[{active,false},
 {mode,binary},
 {certfile,"/path/to/cert.pem"},
 {keyfile,"/path/to/key.pem"}]

7> (<0.48.0>) call ssl_manager:handle_info(clear_pem_cache,{state,28691,ssl_session_cache,86400,
       [16400,20497,24594],
       #Ref<0.0.0.60>,
       {undefined,undefined}})

7> ssl:connect("destination.example.com",443,Opts).

=ERROR REPORT==== 11-Dec-2014::14:25:49 ===
SSL: cipher: ssl_alert.erl:92:Fatal error: certificate expired
{error,{tls_alert,"certificate expired"}}

%% At this point we replace the expired certificate with a new one in the filesystem.

8> (<0.48.0>) call ssl_manager:handle_info(clear_pem_cache,{state,28691,ssl_session_cache,86400,
       [16400,20497,24594],
       #Ref<0.0.0.60>,
       {undefined,undefined}})

8> ssl:connect("destination.example.com",443,Opts).

=ERROR REPORT==== 11-Dec-2014::14:27:18 ===
SSL: cipher: ssl_alert.erl:92:Fatal error: certificate expired
{error,{tls_alert,"certificate expired"}}

%% The timer sent a message to clear the PEM cache, and that's what we should've done, but we didn't.

%% Next, verify that it is indeed an issue with the PEM cache.

9> ssl_manager:clear_pem_cache().
ok
10> ssl:connect("destination.example.com",443,Opts).
{ok,{sslsocket,{gen_tcp,#Port<0.1198>,tls_connection,
                        undefined},
               <0.62.0>}}
```
