### PR TITLE
Add cache_return_random option to inet_config

### DIFF
--- a/erts/doc/src/inet_cfg.xml
+++ b/erts/doc/src/inet_cfg.xml
@@ -259,6 +259,15 @@
           Default is 1 h.</p>
         <p></p>
       </item>
+      <tag><em><c><![CDATA[{cache_return_random, Bool}.]]></c></em></tag>
+      <item>
+        <p></p>
+        <p><c><![CDATA[Bool = boolean()]]></c></p>
+        <p></p>
+        <p>Tells the cache to return the resource records 
+          in random order. Default is false.</p>
+        <p></p>
+      </item>
       <tag><em><c><![CDATA[{timeout, Time}.]]></c></em></tag>
       <item>
         <p></p>


### PR DESCRIPTION
Currently the resource records returned by inet_db are ordered in a deterministic way. This makes it impossible to load-balance over multiple records. This patch adds the option cache_return_random to inet_config, which makes the ordering of resource records random. 