### PR TITLE
Eunit 2.2.10

### DIFF
--- a/lib/eunit/src/eunit_server.erl
+++ b/lib/eunit/src/eunit_server.erl
@@ -200,7 +200,7 @@ server_command(From, stop, St) ->
     server(St#state{stopped = true});
 server_command(From, {watch, Target, _Opts}, St) ->
     %% the code watcher is only started on demand
-    %% FIXME: this is disabled for now in the OTP distribution
+    %% TODO: this is disabled for now
     %%code_monitor:monitor(self()),
     %% TODO: propagate options to testing stage
     St1 = add_watch(Target, St),

--- a/lib/eunit/src/eunit_surefire.erl
+++ b/lib/eunit/src/eunit_surefire.erl
@@ -203,9 +203,9 @@ handle_cancel(test, Data, St) ->
 		     testcases=[TestCase|TestSuite#testsuite.testcases] },
     St#state{testsuites=store_suite(NewTestSuite, TestSuites)}.
 
-format_name({Module, Function, Arity}, Line) ->
-    lists:flatten([atom_to_list(Module), ":", atom_to_list(Function), "/",
-		   integer_to_list(Arity), "_", integer_to_list(Line)]).
+format_name({Module, Function, _Arity}, Line) ->
+    lists:flatten([atom_to_list(Module), ":", integer_to_list(Line), " ",
+                   atom_to_list(Function)]).
 format_desc(undefined) ->
     "";
 format_desc(Desc) when is_binary(Desc) ->
@@ -334,12 +334,11 @@ write_testcase(
         FileDescriptor) ->
     DescriptionAttr = case Description of
 			  [] -> [];
-			  _ -> [<<" description=\"">>, escape_attr(Description), <<"\"">>]
+			  _ -> [<<" (">>, escape_attr(Description), <<")">>]
 		      end,
     StartTag = [
         ?INDENT, <<"<testcase time=\"">>, format_time(Time),
-        <<"\" name=\"">>, escape_attr(Name), <<"\"">>,
-        DescriptionAttr],
+        <<"\" name=\"">>, escape_attr(Name), DescriptionAttr, <<"\"">>],
     ContentAndEndTag = case {Result, Output} of
         {ok, <<>>} -> [<<"/>">>, ?NEWLINE];
         _ -> [<<">">>, ?NEWLINE, format_testcase_result(Result), format_testcase_output(Output), ?INDENT, <<"</testcase>">>, ?NEWLINE]

--- a/lib/eunit/vsn.mk
+++ b/lib/eunit/vsn.mk
@@ -1,1 +1,1 @@
-EUNIT_VSN = 2.2.9
+EUNIT_VSN = 2.2.10


### PR DESCRIPTION
Previously forgotten contribution by Andreas Amsenius:

    Improve surefire xml <testcase> element

    Remove the 'description' attribute. It is not generated by Apache
    Ant or Maven Surefire and probably ignored by all other Surefire
    tools. Confirmed for Jenkins.
    
    Add testcase description (if there is one) to the 'name' attribute.
    
    Change format of 'name' attribute to look more like the output from
    running eunit with verbose. Line number and arity was quite obscure
    and arity is not useful as it is always 0.