### PR TITLE
Remove mnemosyne rules support from syntax_tools

### DIFF
--- a/lib/edoc/src/edoc_extract.erl
+++ b/lib/edoc/src/edoc_extract.erl
@@ -353,8 +353,6 @@ preprocess_forms_2(F, Fs) ->
 	    [F | preprocess_forms_1(Fs)];
 	{function, _} ->
 	    [F | preprocess_forms_1(Fs)];
-	{rule, _} ->
-	    [F | preprocess_forms_1(Fs)];
 	{attribute, {module, _}} ->
 	    [F | preprocess_forms_1(Fs)];
   	text ->
@@ -387,15 +385,6 @@ collect([F | Fs], Cs, Ss, Ts, As, Header, Mod) ->
 	    L = erl_syntax:get_pos(F),
 	    Export = ordsets:is_element(Name, Mod#module.exports),
 	    Args = parameters(erl_syntax:function_clauses(F)),
-	    collect(Fs, [], [], [],
-                    [#entry{name = Name, args = Args, line = L,
-                            export = Export,
-                            data = {comment_text(Cs),Ss,Ts}} | As],
-		    Header, Mod);
-	{rule, Name} ->
-	    L = erl_syntax:get_pos(F),
-	    Export = ordsets:is_element(Name, Mod#module.exports),
-	    Args = parameters(erl_syntax:rule_clauses(F)),
 	    collect(Fs, [], [], [],
                     [#entry{name = Name, args = Args, line = L,
                             export = Export,

--- a/lib/syntax_tools/src/erl_prettypr.erl
+++ b/lib/syntax_tools/src/erl_prettypr.erl
@@ -851,14 +851,10 @@ lay_2(Node, Ctxt) ->
 		   floating(text(".")),
 		   lay(erl_syntax:record_access_field(Node),
 		       set_prec(Ctxt, PrecR))),
-	    D3 = case erl_syntax:record_access_type(Node) of
-		     none ->
-			 D2;
-		     T ->
-			 beside(beside(floating(text("#")),
-				       lay(T, reset_prec(Ctxt))),
-				D2)
-		 end,
+	    T = erl_syntax:record_access_type(Node),
+	    D3 = beside(beside(floating(text("#")),
+                               lay(T, reset_prec(Ctxt))),
+                        D2),
 	    maybe_parentheses(beside(D1, D3), Prec, Ctxt);
 
 	record_expr ->

--- a/lib/syntax_tools/src/erl_prettypr.erl
+++ b/lib/syntax_tools/src/erl_prettypr.erl
@@ -50,8 +50,7 @@
               | fun((erl_syntax:syntaxTree(), _, _) -> prettypr:document()).
 -type clause_t() :: 'case_expr' | 'cond_expr' | 'fun_expr'
                   | 'if_expr' | 'receive_expr' | 'try_expr'
-                  | {'function', prettypr:document()}
-                  | {'rule', prettypr:document()}.
+                  | {'function', prettypr:document()}.
 
 -record(ctxt, {prec = 0           :: integer(),
 	       sub_indent = 2     :: non_neg_integer(),
@@ -587,8 +586,6 @@ lay_2(Node, Ctxt) ->
 		    make_case_clause(D1, D2, D3, Ctxt);
 		try_expr ->
 		    make_case_clause(D1, D2, D3, Ctxt);
-		{rule, N} ->
-		    make_rule_clause(N, D1, D2, D3, Ctxt);
 		undefined ->
 		    %% If a clause is formatted out of context, we
 		    %% use a "fun-expression" clause style.
@@ -922,15 +919,6 @@ lay_2(Node, Ctxt) ->
             D2 = lay(erl_syntax:map_field_exact_value(Node), Ctxt1),
             par([D1, floating(text(":=")), D2], Ctxt1#ctxt.break_indent);
 
-	rule ->
-	    %% Comments on the name will be repeated; cf.
-	    %% `function'.
-	    Ctxt1 = reset_prec(Ctxt),
-	    D1 = lay(erl_syntax:rule_name(Node), Ctxt1),
-	    D2 = lay_clauses(erl_syntax:rule_clauses(Node),
-			     {rule, D1}, Ctxt1),
-	    beside(D2, floating(text(".")));
-
 	size_qualifier ->
 	    Ctxt1 = set_prec(Ctxt, max_prec()),
 	    D1 = lay(erl_syntax:size_qualifier_body(Node), Ctxt1),
@@ -1069,10 +1057,6 @@ make_fun_clause_head(N, P, Ctxt) ->
 	    beside(N, D)
     end.
 
-make_rule_clause(N, P, G, B, Ctxt) ->
-    D = make_fun_clause_head(N, P, Ctxt),
-    append_rule_body(B, append_guard(G, D, Ctxt), Ctxt).
-
 make_case_clause(P, G, B, Ctxt) ->
     append_clause_body(B, append_guard(G, P, Ctxt), Ctxt).
 
@@ -1087,9 +1071,6 @@ make_if_clause(_P, G, B, Ctxt) ->
 
 append_clause_body(B, D, Ctxt) ->
     append_clause_body(B, D, floating(text(" ->")), Ctxt).
-
-append_rule_body(B, D, Ctxt) ->
-    append_clause_body(B, D, floating(text(" :-")), Ctxt).
 
 append_clause_body(B, D, S, Ctxt) ->
     sep([beside(D, S), nest(Ctxt#ctxt.break_indent, B)]).

--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -1669,7 +1669,7 @@ analyze_record_attribute_tuple(Node) ->
 %%   <dt>`record_expr':</dt>
 %%     <dd>`{atom(), [{atom(), Value}]}'</dd>
 %%   <dt>`record_access':</dt>
-%%     <dd>`{atom(), atom()} | atom()'</dd>
+%%     <dd>`{atom(), atom()}'</dd>
 %%   <dt>`record_index_expr':</dt>
 %%     <dd>`{atom(), atom()}'</dd>
 %% </dl>
@@ -1679,9 +1679,7 @@ analyze_record_attribute_tuple(Node) ->
 %% listed in the order they appear. (See
 %% `analyze_record_field/1' for details on the field
 %% descriptors). For a `record_access' node,
-%% `Info' represents the record name and the field name (or
-%% if the record name is not included, only the field name; this is
-%% allowed only in Mnemosyne-query syntax). For a
+%% `Info' represents the record name and the field name. For a
 %% `record_index_expr' node, `Info' represents the
 %% record name and the name field name.
 %%
@@ -1713,18 +1711,14 @@ analyze_record_expr(Node) ->
 	    F = erl_syntax:record_access_field(Node),
 	    case erl_syntax:type(F) of
 		atom ->
-		    case erl_syntax:record_access_type(Node) of
-			none ->
-			    {record_access, erl_syntax:atom_value(F)};
-			A ->
-			    case erl_syntax:type(A) of
-				atom ->
-				    {record_access,
-				     {erl_syntax:atom_value(A),
-				      erl_syntax:atom_value(F)}};
-				_ ->
-				    throw(syntax_error)
-			    end
+		    A = erl_syntax:record_access_type(Node),
+                    case erl_syntax:type(A) of
+                        atom ->
+                            {record_access,
+                             {erl_syntax:atom_value(A),
+                              erl_syntax:atom_value(F)}};
+                        _ ->
+                            throw(syntax_error)
 		    end;
 		_ ->
 		    throw(syntax_error)

--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -35,8 +35,7 @@
          analyze_function_name/1, analyze_implicit_fun/1,
          analyze_import_attribute/1, analyze_module_attribute/1,
          analyze_record_attribute/1, analyze_record_expr/1,
-         analyze_record_field/1, analyze_rule/1,
-         analyze_wild_attribute/1, annotate_bindings/1,
+         analyze_record_field/1, analyze_wild_attribute/1, annotate_bindings/1,
          annotate_bindings/2, fold/3, fold_subtrees/3, foldl_listlist/3,
          function_name_expansions/1, is_fail_expr/1, limit/2, limit/3,
          map/2, map_subtrees/2, mapfold/3, mapfold_subtrees/3,
@@ -527,8 +526,6 @@ vann(Tree, Env) ->
             vann_try_expr(Tree, Env);
         function ->
             vann_function(Tree, Env);
-        rule ->
-            vann_rule(Tree, Env);
         fun_expr ->
             vann_fun_expr(Tree, Env);
         list_comp ->
@@ -566,15 +563,6 @@ vann_function(Tree, Env) ->
     N = erl_syntax:function_name(Tree),
     {N1, _, _} = vann(N, Env),
     Tree1 = rewrite(Tree, erl_syntax:function(N1, Cs1)),
-    Bound = [],
-    {ann_bindings(Tree1, Env, Bound, Free), Bound, Free}.
-
-vann_rule(Tree, Env) ->
-    Cs = erl_syntax:rule_clauses(Tree),
-    {Cs1, {_, Free}} = vann_clauses(Cs, Env),
-    N = erl_syntax:rule_name(Tree),
-    {N1, _, _} = vann(N, Env),
-    Tree1 = rewrite(Tree, erl_syntax:rule(N1, Cs1)),
     Bound = [],
     {ann_bindings(Tree1, Env, Bound, Free), Bound, Free}.
 
@@ -946,7 +934,7 @@ is_fail_expr(E) ->
 %%
 %%          Forms = syntaxTree() | [syntaxTree()]
 %%          Key = attributes | errors | exports | functions | imports
-%%                | module | records | rules | warnings
+%%                | module | records | warnings
 %%
 %% @doc Analyzes a sequence of "program forms". The given
 %% `Forms' may be a single syntax tree of type
@@ -1047,16 +1035,6 @@ is_fail_expr(E) ->
 %% 	 that each record name occurs at most once in the list. The
 %% 	 order of listing is not defined.</dd>
 %%
-%%     <dt>`{rules, Rules}'</dt>
-%%       <dd><ul>
-%% 	    <li>`Rules = [{atom(), integer()}]'</li>
-%%       </ul>
-%% 	 `Rules' is a list of the names of the rules that are
-%% 	 defined in `Forms' (cf.
-%% 	 `analyze_rule/1'). We do not guarantee that each
-%% 	 name occurs at most once in the list. The order of listing is
-%% 	 not defined.</dd>
-%%
 %%     <dt>`{warnings, Warnings}'</dt>
 %%       <dd><ul>
 %% 	    <li>`Warnings = [term()]'</li>
@@ -1074,12 +1052,11 @@ is_fail_expr(E) ->
 %% @see analyze_import_attribute/1
 %% @see analyze_record_attribute/1
 %% @see analyze_function/1
-%% @see analyze_rule/1
 %% @see erl_syntax:error_marker_info/1
 %% @see erl_syntax:warning_marker_info/1
 
 -type key() :: 'attributes' | 'errors' | 'exports' | 'functions' | 'imports'
-             | 'module' | 'records' | 'rules' | 'warnings'.
+             | 'module' | 'records' | 'warnings'.
 -type info_pair() :: {key(), term()}.
 
 -spec analyze_forms(erl_syntax:forms()) -> [info_pair()].
@@ -1099,8 +1076,6 @@ collect_form(Node, Info) ->
             Info;
         {function, Name} ->
             finfo_add_function(Name, Info);
-        {rule, Name} ->
-            finfo_add_rule(Name, Info);
         {error_marker, Data} ->
             finfo_add_error(Data, Info);
         {warning_marker, Data} ->
@@ -1136,8 +1111,7 @@ collect_attribute(_, {N, V}, Info) ->
 		records        = []   :: [{atom(), [{atom(), field_default()}]}],
 		errors         = []   :: [term()],
 		warnings       = []   :: [term()],
-		functions      = []   :: [{atom(), arity()}],
-		rules          = []   :: [{atom(), arity()}]}).
+		functions      = []   :: [{atom(), arity()}]}).
 
 -type field_default() :: 'none' | erl_syntax:syntaxTree().
 
@@ -1183,9 +1157,6 @@ finfo_add_warning(R, Info) ->
 finfo_add_function(F, Info) ->
     Info#forms{functions = [F | Info#forms.functions]}.
 
-finfo_add_rule(F, Info) ->
-    Info#forms{rules = [F | Info#forms.rules]}.
-
 finfo_to_list(Info) ->
     [{Key, Value}
      || {Key, {value, Value}} <-
@@ -1197,8 +1168,7 @@ finfo_to_list(Info) ->
              {records, list_value(Info#forms.records)},
              {errors, list_value(Info#forms.errors)},
              {warnings, list_value(Info#forms.warnings)},
-             {functions, list_value(Info#forms.functions)},
-             {rules, list_value(Info#forms.rules)}
+             {functions, list_value(Info#forms.functions)}
             ]].
 
 list_value([]) ->
@@ -1229,10 +1199,6 @@ list_value(List) ->
 %%
 %% 	    <dd>where `Info = analyze_function(Node)'.</dd>
 %%
-%%   <dt>`{rule, Info}'</dt>
-%%
-%% 	    <dd>where `Info = analyze_rule(Node)'.</dd>
-%%
 %%   <dt>`{warning_marker, Info}'</dt>
 %%
 %% 	    <dd>where `Info =
@@ -1245,7 +1211,6 @@ list_value(List) ->
 %%
 %% @see analyze_attribute/1
 %% @see analyze_function/1
-%% @see analyze_rule/1
 %% @see erl_syntax:is_form/1
 %% @see erl_syntax:error_marker_info/1
 %% @see erl_syntax:warning_marker_info/1
@@ -1258,8 +1223,6 @@ analyze_form(Node) ->
             {attribute, analyze_attribute(Node)};
         function ->
             {function, analyze_function(Node)};
-        rule ->
-            {rule, analyze_rule(Node)};
         error_marker ->
             {error_marker, erl_syntax:error_marker_info(Node)};
         warning_marker ->
@@ -1829,8 +1792,6 @@ analyze_file_attribute(Node) ->
 %% The evaluation throws `syntax_error' if
 %% `Node' does not represent a well-formed function
 %% definition.
-%%
-%% @see analyze_rule/1
 
 -spec analyze_function(erl_syntax:syntaxTree()) -> {atom(), arity()}.
 
@@ -1842,37 +1803,6 @@ analyze_function(Node) ->
                 atom ->
                     {erl_syntax:atom_value(N),
                      erl_syntax:function_arity(Node)};
-                _ ->
-                    throw(syntax_error)
-            end;
-        _ ->
-            throw(syntax_error)
-    end.
-
-
-%% =====================================================================
-%% @spec analyze_rule(Node::syntaxTree()) -> {atom(), integer()}
-%%
-%% @doc Returns the name and arity of a Mnemosyne rule. The result is a
-%% pair `{Name, A}' if `Node' represents a rule
-%% "`Name(<em>P_1</em>, ..., <em>P_A</em>) :- ...'".
-%%
-%% The evaluation throws `syntax_error' if
-%% `Node' does not represent a well-formed Mnemosyne
-%% rule.
-%%
-%% @see analyze_function/1
-
--spec analyze_rule(erl_syntax:syntaxTree()) -> {atom(), arity()}.
-
-analyze_rule(Node) ->
-    case erl_syntax:type(Node) of
-        rule ->
-            N = erl_syntax:rule_name(Node),
-            case erl_syntax:type(N) of
-                atom ->
-                    {erl_syntax:atom_value(N),
-                     erl_syntax:rule_arity(Node)};
                 _ ->
                     throw(syntax_error)
             end;

--- a/lib/syntax_tools/src/igor.erl
+++ b/lib/syntax_tools/src/igor.erl
@@ -1713,8 +1713,6 @@ transform(Tree, Env, St) ->
   	    transform_function(Tree, Env, St);
  	implicit_fun ->
  	    transform_implicit_fun(Tree, Env, St);
-  	rule ->
-  	    transform_rule(Tree, Env, St);
   	record_expr ->
   	    transform_record(Tree, Env, St);
   	record_index_expr ->
@@ -1777,27 +1775,6 @@ renaming_note(Name) ->
 
 rename_atom(Node, Atom) ->
     rewrite(Node, erl_syntax:atom(Atom)).
-
-%% Renaming Mnemosyne rules (just like function definitions)
-
-transform_rule(T, Env, St) ->
-    {T1, St1} = default_transform(T, Env, St),
-    F = erl_syntax_lib:analyze_rule(T1),
-    {V, Text} = case (Env#code.map)(F) of
-		    F ->
-			%% Not renamed
-			{none, []};
-		    {Atom, _Arity} ->
-			%% Renamed
-			Cs = erl_syntax:rule_clauses(T1),
-			N = rename_atom(
-			      erl_syntax:rule_name(T1),
-			      Atom),
-			T2 = rewrite(T1,
-				     erl_syntax:rule(N, Cs)),
-			{{value, T2}, renaming_note(Atom)}
-		end,
-    {maybe_modified(V, T1, 2, Text, Env), St1}.
 
 %% Renaming "implicit fun" expressions (done quietly).
 


### PR DESCRIPTION
Mnemosyne rule syntax is no longer supported in Erlang. This removes the corresponding support in syntax tools.