### PR TITLE
[ct_cover] Fix paths of incl_dirs in cover spec

### DIFF
--- a/lib/common_test/src/ct_cover.erl
+++ b/lib/common_test/src/ct_cover.erl
@@ -174,7 +174,7 @@ get_spec_test(File) ->
 				     [] -> [#cover{app=none, level=details}];
 				     _ -> Res
 				 end,
-			    case get_cover_opts(Apps, Terms, []) of
+			    case get_cover_opts(Apps, Terms, Dir, []) of
 				E = {error,_} -> 
 				    E;
 				[CoverSpec] ->
@@ -205,124 +205,125 @@ collect_apps([], Apps) ->
 %% get_cover_opts(Terms) -> AppCoverInfo
 %% AppCoverInfo: [#cover{app=App,...}]
 
-get_cover_opts([App | Apps], Terms, CoverInfo) ->
-    case get_app_info(App, Terms) of
+get_cover_opts([App | Apps], Terms, Dir, CoverInfo) ->
+    case get_app_info(App, Terms, Dir) of
 	E = {error,_} -> E;
 	AppInfo ->
 	    AppInfo1 = files2mods(AppInfo),
-	    get_cover_opts(Apps, Terms, [AppInfo1|CoverInfo])
+	    get_cover_opts(Apps, Terms, Dir, [AppInfo1|CoverInfo])
     end;
-get_cover_opts([], _, CoverInfo) ->
+get_cover_opts([], _, _, CoverInfo) ->
     lists:reverse(CoverInfo).
 
-%% get_app_info(App, Terms) -> App1
+%% get_app_info(App, Terms, Dir) -> App1
 
-get_app_info(App=#cover{app=none}, [{incl_dirs,Dirs}|Terms]) ->
-    get_app_info(App, [{incl_dirs,none,Dirs}|Terms]);
-get_app_info(App=#cover{app=Name}, [{incl_dirs,Name,Dirs}|Terms]) ->
-    case get_files(Dirs, ".beam", false, []) of
+get_app_info(App=#cover{app=none}, [{incl_dirs,Dirs}|Terms], Dir) ->
+    get_app_info(App, [{incl_dirs,none,Dirs}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{incl_dirs,Name,Dirs}|Terms], Dir) ->
+    case get_files(Dirs, Dir, ".beam", false, []) of
 	E = {error,_} -> E;
 	Mods1 ->
 	    Mods = App#cover.incl_mods,
-	    get_app_info(App#cover{incl_mods=Mods++Mods1},Terms)
+	    get_app_info(App#cover{incl_mods=Mods++Mods1},Terms,Dir)
     end;
 
-get_app_info(App=#cover{app=none}, [{incl_dirs_r,Dirs}|Terms]) ->
-    get_app_info(App, [{incl_dirs_r,none,Dirs}|Terms]);
-get_app_info(App=#cover{app=Name}, [{incl_dirs_r,Name,Dirs}|Terms]) ->
-    case get_files(Dirs, ".beam", true, []) of
+get_app_info(App=#cover{app=none}, [{incl_dirs_r,Dirs}|Terms], Dir) ->
+    get_app_info(App, [{incl_dirs_r,none,Dirs}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{incl_dirs_r,Name,Dirs}|Terms], Dir) ->
+    case get_files(Dirs, Dir, ".beam", true, []) of
 	E = {error,_} -> E;
 	Mods1 ->
 	    Mods = App#cover.incl_mods,
-	    get_app_info(App#cover{incl_mods=Mods++Mods1},Terms)
+	    get_app_info(App#cover{incl_mods=Mods++Mods1},Terms,Dir)
     end;
 
-get_app_info(App=#cover{app=none}, [{incl_mods,Mods1}|Terms]) ->
-    get_app_info(App, [{incl_mods,none,Mods1}|Terms]);
-get_app_info(App=#cover{app=Name}, [{incl_mods,Name,Mods1}|Terms]) ->
+get_app_info(App=#cover{app=none}, [{incl_mods,Mods1}|Terms], Dir) ->
+    get_app_info(App, [{incl_mods,none,Mods1}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{incl_mods,Name,Mods1}|Terms], Dir) ->
     Mods = App#cover.incl_mods,
-    get_app_info(App#cover{incl_mods=Mods++Mods1},Terms);
+    get_app_info(App#cover{incl_mods=Mods++Mods1},Terms,Dir);
 
-get_app_info(App=#cover{app=none}, [{excl_dirs,Dirs}|Terms]) ->
-    get_app_info(App, [{excl_dirs,none,Dirs}|Terms]);
-get_app_info(App=#cover{app=Name}, [{excl_dirs,Name,Dirs}|Terms]) ->
-    case get_files(Dirs, ".beam", false, []) of
+get_app_info(App=#cover{app=none}, [{excl_dirs,Dirs}|Terms], Dir) ->
+    get_app_info(App, [{excl_dirs,none,Dirs}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{excl_dirs,Name,Dirs}|Terms], Dir) ->
+    case get_files(Dirs, Dir, ".beam", false, []) of
 	E = {error,_} -> E;
 	Mods1 ->
 	    Mods = App#cover.excl_mods,
-	    get_app_info(App#cover{excl_mods=Mods++Mods1},Terms)
+	    get_app_info(App#cover{excl_mods=Mods++Mods1},Terms,Dir)
     end;
 
-get_app_info(App=#cover{app=none}, [{excl_dirs_r,Dirs}|Terms]) ->
-    get_app_info(App, [{excl_dirs_r,none,Dirs}|Terms]);
-get_app_info(App=#cover{app=Name}, [{excl_dirs_r,Name,Dirs}|Terms]) ->
-    case get_files(Dirs, ".beam", true, []) of
+get_app_info(App=#cover{app=none}, [{excl_dirs_r,Dirs}|Terms],Dir) ->
+    get_app_info(App, [{excl_dirs_r,none,Dirs}|Terms],Dir);
+get_app_info(App=#cover{app=Name}, [{excl_dirs_r,Name,Dirs}|Terms],Dir) ->
+    case get_files(Dirs, Dir, ".beam", true, []) of
 	E = {error,_} -> E;
 	Mods1 ->
 	    Mods = App#cover.excl_mods,
-	    get_app_info(App#cover{excl_mods=Mods++Mods1},Terms)
+	    get_app_info(App#cover{excl_mods=Mods++Mods1},Terms,Dir)
     end;
 
-get_app_info(App=#cover{app=none}, [{excl_mods,Mods1}|Terms]) ->
-    get_app_info(App, [{excl_mods,none,Mods1}|Terms]);
-get_app_info(App=#cover{app=Name}, [{excl_mods,Name,Mods1}|Terms]) ->
+get_app_info(App=#cover{app=none}, [{excl_mods,Mods1}|Terms], Dir) ->
+    get_app_info(App, [{excl_mods,none,Mods1}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{excl_mods,Name,Mods1}|Terms], Dir) ->
     Mods = App#cover.excl_mods,
-    get_app_info(App#cover{excl_mods=Mods++Mods1},Terms);
+    get_app_info(App#cover{excl_mods=Mods++Mods1},Terms,Dir);
 
-get_app_info(App=#cover{app=none}, [{cross,Cross}|Terms]) ->
-    get_app_info(App, [{cross,none,Cross}|Terms]);
-get_app_info(App=#cover{app=Name}, [{cross,Name,Cross1}|Terms]) ->
+get_app_info(App=#cover{app=none}, [{cross,Cross}|Terms], Dir) ->
+    get_app_info(App, [{cross,none,Cross}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{cross,Name,Cross1}|Terms], Dir) ->
     Cross = App#cover.cross,
-    get_app_info(App#cover{cross=Cross++Cross1},Terms);
+    get_app_info(App#cover{cross=Cross++Cross1},Terms,Dir);
 
-get_app_info(App=#cover{app=none}, [{src_dirs,Dirs}|Terms]) ->
-    get_app_info(App, [{src_dirs,none,Dirs}|Terms]);
-get_app_info(App=#cover{app=Name}, [{src_dirs,Name,Dirs}|Terms]) ->
-    case get_files(Dirs, ".erl", false, []) of
+get_app_info(App=#cover{app=none}, [{src_dirs,Dirs}|Terms], Dir) ->
+    get_app_info(App, [{src_dirs,none,Dirs}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{src_dirs,Name,Dirs}|Terms], Dir) ->
+    case get_files(Dirs, Dir, ".erl", false, []) of
 	E = {error,_} -> E;
 	Src1 ->
 	    Src = App#cover.src,
-	    get_app_info(App#cover{src=Src++Src1},Terms)
+	    get_app_info(App#cover{src=Src++Src1},Terms,Dir)
     end;
 
-get_app_info(App=#cover{app=none}, [{src_dirs_r,Dirs}|Terms]) ->
-    get_app_info(App, [{src_dirs_r,none,Dirs}|Terms]);
-get_app_info(App=#cover{app=Name}, [{src_dirs_r,Name,Dirs}|Terms]) ->
-    case get_files(Dirs, ".erl", true, []) of
+get_app_info(App=#cover{app=none}, [{src_dirs_r,Dirs}|Terms], Dir) ->
+    get_app_info(App, [{src_dirs_r,none,Dirs}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{src_dirs_r,Name,Dirs}|Terms], Dir) ->
+    case get_files(Dirs, Dir, ".erl", true, []) of
 	E = {error,_} -> E;
 	Src1 ->
 	    Src = App#cover.src,
-	    get_app_info(App#cover{src=Src++Src1},Terms)
+	    get_app_info(App#cover{src=Src++Src1},Terms,Dir)
     end;
 
-get_app_info(App=#cover{app=none}, [{src_files,Src1}|Terms]) ->
-    get_app_info(App, [{src_files,none,Src1}|Terms]);
-get_app_info(App=#cover{app=Name}, [{src_files,Name,Src1}|Terms]) ->
+get_app_info(App=#cover{app=none}, [{src_files,Src1}|Terms], Dir) ->
+    get_app_info(App, [{src_files,none,Src1}|Terms], Dir);
+get_app_info(App=#cover{app=Name}, [{src_files,Name,Src1}|Terms], Dir) ->
     Src = App#cover.src,
-    get_app_info(App#cover{src=Src++Src1},Terms);
+    get_app_info(App#cover{src=Src++Src1},Terms,Dir);
 
-get_app_info(App, [_|Terms]) ->
-    get_app_info(App, Terms);
+get_app_info(App, [_|Terms], Dir) ->
+    get_app_info(App, Terms, Dir);
 
-get_app_info(App, []) ->
+get_app_info(App, [], _) ->
     App.
 
 %% get_files(...)
     
-get_files([Dir|Dirs], Ext, Recurse, Files) ->
-    case file:list_dir(Dir) of
+get_files([Dir|Dirs], RootDir, Ext, Recurse, Files) ->
+    DirAbs = filename:absname(Dir, RootDir),
+    case file:list_dir(DirAbs) of
 	{ok,Entries} ->
-	    {SubDirs,Matches} = analyse_files(Entries, Dir, Ext, [], []),
+	    {SubDirs,Matches} = analyse_files(Entries, DirAbs, Ext, [], []),
 	    if Recurse == false ->
-		    get_files(Dirs, Ext, Recurse, Files++Matches);
+		    get_files(Dirs, RootDir, Ext, Recurse, Files++Matches);
 	       true ->
-		    Files1 = get_files(SubDirs, Ext, Recurse, Files++Matches),
-		    get_files(Dirs, Ext, Recurse, Files1)
+		    Files1 = get_files(SubDirs, RootDir, Ext, Recurse, Files++Matches),
+		    get_files(Dirs, RootDir, Ext, Recurse, Files1)
 	    end;
 	{error,Reason} ->
-	    {error,{Reason,Dir}}
+	    {error,{Reason,DirAbs}}
     end;
-get_files([], _Ext, _R, Files) ->	      
+get_files([], _RootDir, _Ext, _R, Files) ->
     Files.
 	    
 %% analyse_files(...)

--- a/lib/common_test/test/ct_cover_SUITE.erl
+++ b/lib/common_test/test/ct_cover_SUITE.erl
@@ -78,7 +78,10 @@ all() ->
      otp_9956,
      cross,
      export_import,
-     relative_incl_dirs
+     relative_incl_dirs,
+     absolute_incl_dirs,
+     relative_excl_dirs,
+     absolute_excl_dirs
     ].
 
 %%--------------------------------------------------------------------
@@ -226,6 +229,35 @@ relative_incl_dirs(Config) ->
     check_calls(Events, 1),
     ok.
 
+absolute_incl_dirs(Config) ->
+    false = check_cover(Config),
+    CoverSpec = [{incl_dirs, [?config(data_dir, Config)]}],
+    CoverFile = create_cover_file(abs_incl_dirs, CoverSpec, Config),
+    Opts = [{cover, CoverFile}],
+    {ok, Events} = run_test(abs_incl_dirs, default, Opts, Config),
+    check_calls(Events, 1),
+    ok.
+
+relative_excl_dirs(Config) ->
+    false = check_cover(Config),
+    RelDir = rel_path(?config(priv_dir, Config), ?config(data_dir, Config)),
+    CoverSpec = default_cover_file_content() ++ [{excl_dirs, [RelDir]}],
+    CoverFile = create_cover_file(rel_excl_dirs, CoverSpec, Config),
+    Opts = [{cover, CoverFile}],
+    {ok, Events} = run_test(rel_excl_dirs, default_no_cover, Opts, Config),
+    check_no_cover_compiled(Events),
+    ok.
+
+absolute_excl_dirs(Config) ->
+    false = check_cover(Config),
+    AbsDir = ?config(data_dir, Config),
+    CoverSpec = default_cover_file_content() ++ [{excl_dirs, [AbsDir]}],
+    CoverFile = create_cover_file(abs_excl_dirs, CoverSpec, Config),
+    Opts = [{cover, CoverFile}],
+    {ok, Events} = run_test(abs_excl_dirs, default_no_cover, Opts, Config),
+    check_no_cover_compiled(Events),
+    ok.
+
 %%%-----------------------------------------------------------------
 %%% HELP FUNCTIONS
 %%%-----------------------------------------------------------------
@@ -299,22 +331,35 @@ get_log_dirs(Events) ->
 	{ct_test_support_eh,
 	 {event,start_logging,_Node,LogDir}} <- Events].
 
+%% Check if a module was compiled without cover
+check_no_cover_compiled(Events) ->
+    check_no_cover_compiled(Events, ?mod).
+check_no_cover_compiled(Events, Mod) ->
+    [ {error, {not_cover_compiled, Mod}} = analyse_log(CoverLog, Mod)
+      || CoverLog <- cover_logs(Events) ].
+
 %% Check that each coverlog includes N calls to ?mod:foo/0
 check_calls(Events,N) ->
     check_calls(Events,{?mod,foo,0},N).
 check_calls(Events,MFA,N) ->
-    CoverLogs = [filename:join(D,"all.coverdata") || D <- get_log_dirs(Events)],
-    do_check_logs(CoverLogs,MFA,N).
+    do_check_logs(cover_logs(Events),MFA,N).
 
 do_check_logs([CoverLog|CoverLogs],{Mod,_,_} = MFA,N) ->
-    {ok,_} = cover:start(),
-    ok = cover:import(CoverLog),
-    {ok,Calls} = cover:analyse(Mod,calls,function),
-    ok = cover:stop(),
+    {ok, Calls} = analyse_log(CoverLog, Mod),
     {MFA,N} = lists:keyfind(MFA,1,Calls),
     do_check_logs(CoverLogs,MFA,N);
 do_check_logs([],_,_) ->
     ok.
+
+cover_logs(Events) ->
+    [filename:join(D,"all.coverdata") || D <- get_log_dirs(Events)].
+
+analyse_log(CoverLog, Mod) ->
+    {ok, _} = cover:start(),
+    ok = cover:import(CoverLog),
+    Result = cover:analyse(Mod, calls, function),
+    ok = cover:stop(),
+    Result.
 
 fullname(Name) ->
     {ok,Host} = inet:gethostname(),

--- a/lib/common_test/test/ct_cover_SUITE.erl
+++ b/lib/common_test/test/ct_cover_SUITE.erl
@@ -77,7 +77,8 @@ all() ->
      ct_cover_add_remove_nodes,
      otp_9956,
      cross,
-     export_import
+     export_import,
+     relative_incl_dirs
     ].
 
 %%--------------------------------------------------------------------
@@ -215,6 +216,16 @@ export_import(Config) ->
     check_calls(Events2,2),
     ok.
 
+relative_incl_dirs(Config) ->
+    false = check_cover(Config),
+    RelDir = rel_path(?config(priv_dir, Config), ?config(data_dir, Config)),
+    CoverSpec = [{incl_dirs, [RelDir]}],
+    CoverFile = create_cover_file(rel_incl_dirs, CoverSpec, Config),
+    Opts = [{cover, CoverFile}],
+    {ok, Events} = run_test(rel_incl_dirs, default, Opts, Config),
+    check_calls(Events, 1),
+    ok.
+
 %%%-----------------------------------------------------------------
 %%% HELP FUNCTIONS
 %%%-----------------------------------------------------------------
@@ -333,3 +344,12 @@ start_slave(Name,Args) ->
 		    {boot_timeout,10}, % extending some timers for slow test hosts
 		    {init_timeout,10},
 		    {startup_timeout,10}]).
+
+rel_path(From, To) ->
+    Segments = do_rel_path(filename:split(From), filename:split(To)),
+    filename:join(Segments).
+
+do_rel_path([Seg|RestA], [Seg|RestB]) ->
+    do_rel_path(RestA, RestB);
+do_rel_path(PathA, PathB) ->
+    lists:duplicate(length(PathA), "..") ++ PathB.

--- a/lib/common_test/test/ct_cover_SUITE_data/cover_SUITE.erl
+++ b/lib/common_test/test/ct_cover_SUITE_data/cover_SUITE.erl
@@ -71,6 +71,10 @@ default(_Config) ->
     cover_test_mod:foo(),
     ok.
 
+default_no_cover(_Config) ->
+    cover_test_mod:foo(),
+    ok.
+
 slave(_Config) ->
     cover_compiled = code:which(cover_test_mod),
     cover_test_mod:foo(),


### PR DESCRIPTION
It seems like the commit 5a3c4668908254ee930c8db2e5cf9741945f9b2b also
broke the incl_dirs option and friends when given as relative paths.
When a cover spec contains a relative path it is looked-up in the
directory with the test results, not in the .cover file directory.