### PR TITLE
Properly parse URI fragments

### DIFF
--- a/lib/inets/doc/src/http_uri.xml
+++ b/lib/inets/doc/src/http_uri.xml
@@ -63,6 +63,7 @@ host()      = string()
 port()      = pos_integer()
 path()      = string() - Representing a file path or directory path 
 query()     = string()
+fragment()  = string()
     ]]></code>
 
     <marker id="scheme_defaults"></marker>
@@ -92,13 +93,16 @@ query()     = string()
         <v>URI = uri() </v> 
         <v>Options = [Option] </v> 
         <v>Option = {ipv6_host_with_brackets, boolean()} | 
-                    {scheme_defaults, scheme_defaults()}]</v> 
-	<v>Result = {Scheme, UserInfo, Host, Port, Path, Query}</v>
+                    {scheme_defaults, scheme_defaults()} |
+                    {fragment, boolean()}]</v>
+        <v>Result = {Scheme, UserInfo, Host, Port, Path, Query} |
+                    {Scheme, UserInfo, Host, Port, Path, Query, Fragment}</v>
 	<v>UserInfo = user_info()</v>
 	<v>Host = host()</v>
 	<v>Port = pos_integer()</v>
 	<v>Path = path()</v>
 	<v>Query = query()</v>
+        <v>Fragment = fragment()</v>
 	<v>Reason = term() </v>
       </type>
       <desc>
@@ -110,6 +114,9 @@ query()     = string()
         <p>Note that when parsing an URI with an unknown scheme (that is, 
 	a scheme not found in the scheme defaults) a port number must be 
 	provided or else the parsing will fail. </p>
+
+        <p>If the fragment option is true, the URI fragment will be returned as
+          part of the parsing result, otherwise it is completely ignored.</p>
 
         <marker id="encode"></marker>
       </desc>

--- a/lib/inets/test/uri_SUITE.erl
+++ b/lib/inets/test/uri_SUITE.erl
@@ -46,6 +46,7 @@ all() ->
      userinfo,
      scheme,
      queries,
+     fragments,
      escaped,
      hexed_query
     ].
@@ -104,6 +105,42 @@ scheme(Config) when is_list(Config) ->
 queries(Config) when is_list(Config) ->
     {ok, {http,[],"localhost",8888,"/foobar.html","?foo=bar&foobar=42"}} =
 	http_uri:parse("http://localhost:8888/foobar.html?foo=bar&foobar=42").
+
+fragments(Config) when is_list(Config) ->
+    {ok, {http,[],"localhost",80,"/",""}} =
+        http_uri:parse("http://localhost#fragment"),
+    {ok, {http,[],"localhost",80,"/path",""}} =
+        http_uri:parse("http://localhost/path#fragment"),
+    {ok, {http,[],"localhost",80,"/","?query"}} =
+        http_uri:parse("http://localhost?query#fragment"),
+    {ok, {http,[],"localhost",80,"/path","?query"}} =
+        http_uri:parse("http://localhost/path?query#fragment"),
+    {ok, {http,[],"localhost",80,"/","","#fragment"}} =
+        http_uri:parse("http://localhost#fragment", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/path","","#fragment"}} =
+        http_uri:parse("http://localhost/path#fragment", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/","?query","#fragment"}} =
+        http_uri:parse("http://localhost?query#fragment", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/path","?query","#fragment"}} =
+        http_uri:parse("http://localhost/path?query#fragment",
+                       [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/","",""}} =
+        http_uri:parse("http://localhost", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/path","",""}} =
+        http_uri:parse("http://localhost/path", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/","?query",""}} =
+        http_uri:parse("http://localhost?query", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/path","?query",""}} =
+        http_uri:parse("http://localhost/path?query", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/","","#"}} =
+        http_uri:parse("http://localhost#", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/path","","#"}} =
+        http_uri:parse("http://localhost/path#", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/","?query","#"}} =
+        http_uri:parse("http://localhost?query#", [{fragment,true}]),
+    {ok, {http,[],"localhost",80,"/path","?query","#"}} =
+        http_uri:parse("http://localhost/path?query#", [{fragment,true}]),
+    ok.
 
 escaped(Config) when is_list(Config) ->
        {ok, {http,[],"www.somedomain.com",80,"/%2Eabc",[]}} =


### PR DESCRIPTION
This fixes a bug in httpc where redirection URIs could lead to bad requests if they contained fragments.