### PR TITLE
HiPE fconv and fmove fixes

### DIFF
--- a/lib/hipe/ppc/hipe_rtl_to_ppc.erl
+++ b/lib/hipe/ppc/hipe_rtl_to_ppc.erl
@@ -102,10 +102,18 @@ conv_insn(I, Map, Data) ->
   end.
 
 conv_fconv(I, Map, Data) ->
-  %% Dst := (double)Src, where Dst is FP reg and Src is int reg
+  %% Dst := (double)Src, where Dst is FP reg and Src is GP reg or imm
   {Dst, Map0} = conv_fpreg(hipe_rtl:fconv_dst(I), Map),
-  {Src, Map1} = conv_src(hipe_rtl:fconv_src(I), Map0), % exclude imm src
-  I2 = mk_fconv(Dst, Src),
+  {Src, Map1} = conv_src(hipe_rtl:fconv_src(I), Map0),
+  I2 =
+    case hipe_ppc:is_temp(Src) of
+      true ->
+	mk_fconv(Dst, Src);
+      false ->
+	Tmp = new_untagged_temp(),
+	mk_li(Tmp, Src,
+	      mk_fconv(Dst, Tmp))
+    end,
   {I2, Map1, Data}.
 
 mk_fconv(Dst, Src) ->

--- a/lib/hipe/rtl/hipe_rtl.erl
+++ b/lib/hipe/rtl/hipe_rtl.erl
@@ -413,11 +413,11 @@ rtl_info_update(Rtl, Info) -> Rtl#rtl{info=Info}.
 %% move
 %%
 
-mk_move(Dst, Src) -> #move{dst=Dst, src=Src}.
+mk_move(Dst, Src) -> false = is_fpreg(Dst), false = is_fpreg(Src), #move{dst=Dst, src=Src}.
 move_dst(#move{dst=Dst}) -> Dst.
-move_dst_update(M, NewDst) -> M#move{dst=NewDst}.
+move_dst_update(M, NewDst) -> false = is_fpreg(NewDst), M#move{dst=NewDst}.
 move_src(#move{src=Src}) -> Src.
-move_src_update(M, NewSrc) -> M#move{src=NewSrc}.
+move_src_update(M, NewSrc) -> false = is_fpreg(NewSrc), M#move{src=NewSrc}.
 %% is_move(#move{}) -> true;
 %% is_move(_) -> false.
 
@@ -469,7 +469,11 @@ phi_remove_pred(Phi, Pred) ->
   case NewArgList of
     [Arg] -> %% the phi should be turned into a move instruction
       {_Label,Var} = Arg,
-      mk_move(phi_dst(Phi), Var);
+      Dst = phi_dst(Phi),
+      case {is_fpreg(Dst), is_fpreg(Var)} of
+	{true, true} -> mk_fmove(Dst, Var);
+	{false, false} -> mk_move(Dst, Var)
+      end;
   %%    io:format("~nPhi (~w) turned into move (~w) when removing pred ~w~n",[Phi,Move,Pred]),
     [_|_] ->
       Phi#phi{arglist=NewArgList}
@@ -836,11 +840,11 @@ fp_unop_op(#fp_unop{op=Op}) -> Op.
 %% fmove
 %%
 
-mk_fmove(X, Y) -> #fmove{dst=X, src=Y}.
+mk_fmove(X, Y) -> true = is_fpreg(X), true = is_fpreg(Y), #fmove{dst=X, src=Y}.
 fmove_dst(#fmove{dst=Dst}) -> Dst.
-fmove_dst_update(M, NewDst) -> M#fmove{dst=NewDst}.
+fmove_dst_update(M, NewDst) -> true = is_fpreg(NewDst), M#fmove{dst=NewDst}.
 fmove_src(#fmove{src=Src}) -> Src.
-fmove_src_update(M, NewSrc) -> M#fmove{src=NewSrc}.
+fmove_src_update(M, NewSrc) -> true = is_fpreg(NewSrc), M#fmove{src=NewSrc}.
 
 %%
 %% fconv

--- a/lib/hipe/sparc/hipe_rtl_to_sparc.erl
+++ b/lib/hipe/sparc/hipe_rtl_to_sparc.erl
@@ -85,17 +85,17 @@ conv_insn(I, Map, Data) ->
   end.
 
 conv_fconv(I, Map, Data) ->
-  %% Dst := (double)Src, where Dst is FP reg and Src is int reg
-  {Src, Map1} = conv_src(hipe_rtl:fconv_src(I), Map), % exclude imm src
+  %% Dst := (double)Src, where Dst is FP reg and Src is GP reg or imm
+  {Src, Map1} = conv_src(hipe_rtl:fconv_src(I), Map),
   {Dst, Map2} = conv_fpreg(hipe_rtl:fconv_dst(I), Map1),
   I2 = mk_fconv(Src, Dst),
   {I2, Map2, Data}.
 
 mk_fconv(Src, Dst) ->
   CSP = hipe_sparc:mk_temp(14, 'untagged'), % o6
-  Disp = hipe_sparc:mk_simm13(100),
-  [hipe_sparc:mk_store('stw', Src, CSP, Disp),
-   hipe_sparc:mk_pseudo_fload(CSP, Disp, Dst, true),
+  Offset = 100,
+  mk_store('stw', Src, CSP, Offset) ++
+  [hipe_sparc:mk_pseudo_fload(CSP, hipe_sparc:mk_simm13(Offset), Dst, true),
    hipe_sparc:mk_fp_unary('fitod', Dst, Dst)].
 
 conv_fmove(I, Map, Data) ->


### PR DESCRIPTION
The following test case crashes the HiPE compiler on all targets except ARM:

==snip==
-module(trivial_13).
-export([test/0]).
test() -> return_it(42).
return_it(X) -> R = (2 * X) / 2, round(R).
==snip==

This actually triggers two independent bugs:

RTL produces an #fconv{} instruction with an immediate operand, but the backends unconditionally access the operand as a temporary. This results in broken representation in the backends and eventually they crash. In this case, the bug is in the backends.

The backends must check for immediate operands in #fconv{} and translate them accordingly for their respective targets.

With the above fixed the backends still crash, generally with complaints about inconsistent and/or incomplete register allocation. This happens because hipe_rtl:phi_remove_pred/2 produces a #move{} instruction with floating-point temporaries as operands, even though such moves MUST be #fmove{} instructions.

This is fixed by updating phi_remove_pred/2 to check for and handle floating-point moves. I also added type checks to the #move{} and #fmove{} constructor and setter functions to ensure that similar mishaps cannot happen again.

Tested with the HiPE test suite on x86_64, sparc64 (32-bit), and powerpc64 (32-bit): fixes the test case with no new failures. The ARM backend is still "soft-float" and not affected by these problems.

[Same changes as previous pull req, but with commit messages amended to
follow otp's commit message guidelines.]