### PR TITLE
HiPE: fix ARM/Thumb interworking

### DIFF
--- a/erts/emulator/hipe/hipe_arm_bifs.m4
+++ b/erts/emulator/hipe/hipe_arm_bifs.m4
@@ -25,6 +25,7 @@ include(`hipe/hipe_arm_asm.m4')
 
 	.text
 	.p2align 2
+	.arm
 
 `#if defined(ERTS_ENABLE_LOCK_CHECK) && defined(ERTS_SMP)
 #  define CALL_BIF(F)	ldr r14, =F; str r14, [r0, #P_BIF_CALLEE]; bl hipe_debug_bif_wrapper
@@ -391,7 +392,14 @@ $1:
 	mov	r0, P
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(0)
+#else
 	QUICK_CALL_RET($2,0)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -407,7 +415,14 @@ $1:
 	NBIF_ARG(r1,1,0)
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(1)
+#else
 	QUICK_CALL_RET($2,1)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -424,7 +439,14 @@ $1:
 	NBIF_ARG(r2,2,1)
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(2)
+#else
 	QUICK_CALL_RET($2,2)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -442,7 +464,14 @@ $1:
 	NBIF_ARG(r3,3,2)
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(3)
+#else
 	QUICK_CALL_RET($2,3)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -466,7 +495,14 @@ $1:
 	NBIF_ARG(r3,5,2)
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(5)
+#else
 	QUICK_CALL_RET($2,5)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -488,9 +524,16 @@ define(noproc_primop_interface_0,
 #`define' HAVE_$1
 	.global	$1
 $1:
-	/* XXX: this case is always trivial; how to suppress the branch? */
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(0)
+#else
+	/* XXX: this case is always trivial; how to suppress the branch? */
 	QUICK_CALL_RET($2,0)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -505,7 +548,14 @@ $1:
 	NBIF_ARG(r0,1,0)
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(1)
+#else
 	QUICK_CALL_RET($2,1)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -521,7 +571,14 @@ $1:
 	NBIF_ARG(r1,2,1)
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(2)
+#else
 	QUICK_CALL_RET($2,2)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -538,7 +595,14 @@ $1:
 	NBIF_ARG(r2,3,2)
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(3)
+#else
 	QUICK_CALL_RET($2,3)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')
@@ -558,7 +622,14 @@ $1:
 	str	r4, [sp, #0]
 
 	/* Perform a quick save;call;restore;ret sequence. */
+#ifdef __thumb__
+	SAVE_CONTEXT_QUICK
+	bl	$2
+	RESTORE_CONTEXT_QUICK
+	NBIF_RET(5)
+#else
 	QUICK_CALL_RET($2,5)
+#endif
 	.size	$1, .-$1
 	.type	$1, %function
 #endif')

--- a/erts/emulator/hipe/hipe_arm_glue.S
+++ b/erts/emulator/hipe/hipe_arm_glue.S
@@ -25,6 +25,7 @@
 
 	.text
 	.p2align 2
+	.arm
 
 /*
  * Enter Erlang from C.
@@ -70,6 +71,7 @@
  * Emulated code recursively calls native code.
  */
 	.global	hipe_arm_call_to_native
+	.type	hipe_arm_call_to_native, %function
 hipe_arm_call_to_native:
 	ENTER_FROM_C
 	/* get argument registers */
@@ -85,6 +87,7 @@ hipe_arm_call_to_native:
  * This is where native code returns to emulated code.
  */
 	.global	nbif_return
+	.type	nbif_return, %function
 nbif_return:
 	str	r0, [P, #P_ARG0]			/* save retval */
 	mov	r0, #HIPE_MODE_SWITCH_RES_RETURN
@@ -95,6 +98,7 @@ nbif_return:
  * Emulated code returns to its native code caller.
  */
 	.global	hipe_arm_return_to_native
+	.type	hipe_arm_return_to_native, %function
 hipe_arm_return_to_native:
 	ENTER_FROM_C
 	/* get return value */
@@ -111,6 +115,7 @@ hipe_arm_return_to_native:
  * Emulated code tailcalls native code.
  */
 	.global	hipe_arm_tailcall_to_native
+	.type	hipe_arm_tailcall_to_native, %function
 hipe_arm_tailcall_to_native:
 	ENTER_FROM_C
 	/* get argument registers */
@@ -125,6 +130,7 @@ hipe_arm_tailcall_to_native:
  * Emulated code throws an exception to its native code caller.
  */
 	.global	hipe_arm_throw_to_native
+	.type	hipe_arm_throw_to_native, %function
 hipe_arm_throw_to_native:
 	ENTER_FROM_C
 	/* invoke the handler */
@@ -142,6 +148,7 @@ hipe_arm_throw_to_native:
  * XXX: Different stubs for different number of register parameters?
  */
 	.global	nbif_callemu
+	.type	nbif_callemu, %function
 nbif_callemu:
 	str	r8, [P, #P_BEAM_IP]
 	str	r0, [P, #P_ARITY]
@@ -153,6 +160,7 @@ nbif_callemu:
  * nbif_apply
  */
 	.global	nbif_apply
+	.type	nbif_apply, %function
 nbif_apply:
 	STORE_ARG_REGS
 	mov	r0, #HIPE_MODE_SWITCH_RES_APPLY
@@ -169,6 +177,7 @@ nbif_apply:
  */
 #if NR_ARG_REGS >= 6
 	.global	nbif_ccallemu6
+	.type	nbif_ccallemu6, %function
 nbif_ccallemu6:
 	str	ARG5, [P, #P_ARG5]
 #if NR_ARG_REGS > 6
@@ -181,6 +190,7 @@ nbif_ccallemu6:
 
 #if NR_ARG_REGS >= 5
 	.global	nbif_ccallemu5
+	.type	nbif_ccallemu5, %function
 nbif_ccallemu5:
 	str	ARG4, [P, #P_ARG4]
 #if NR_ARG_REGS > 5
@@ -193,6 +203,7 @@ nbif_ccallemu5:
 
 #if NR_ARG_REGS >= 4
 	.global	nbif_ccallemu4
+	.type	nbif_ccallemu4, %function
 nbif_ccallemu4:
 	str	ARG3, [P, #P_ARG3]
 #if NR_ARG_REGS > 4
@@ -205,6 +216,7 @@ nbif_ccallemu4:
 
 #if NR_ARG_REGS >= 3
 	.global	nbif_ccallemu3
+	.type	nbif_ccallemu3, %function
 nbif_ccallemu3:
 	str	ARG2, [P, #P_ARG2]
 #if NR_ARG_REGS > 3
@@ -217,6 +229,7 @@ nbif_ccallemu3:
 
 #if NR_ARG_REGS >= 2
 	.global	nbif_ccallemu2
+	.type	nbif_ccallemu2, %function
 nbif_ccallemu2:
 	str	ARG1, [P, #P_ARG1]
 #if NR_ARG_REGS > 2
@@ -229,6 +242,7 @@ nbif_ccallemu2:
 
 #if NR_ARG_REGS >= 1
 	.global	nbif_ccallemu1
+	.type	nbif_ccallemu1, %function
 nbif_ccallemu1:
 	str	ARG0, [P, #P_ARG0]
 #if NR_ARG_REGS > 1
@@ -240,6 +254,7 @@ nbif_ccallemu1:
 #endif
 
 	.global	nbif_ccallemu0
+	.type	nbif_ccallemu0, %function
 nbif_ccallemu0:
 	/* We use r1 not ARG0 here because ARG0 is not
 	   defined when NR_ARG_REGS == 0. */
@@ -254,6 +269,7 @@ nbif_ccallemu0:
  * This is where native code suspends.
  */
 	.global	nbif_suspend_0
+	.type	nbif_suspend_0, %function
 nbif_suspend_0:
 	mov	r0, #HIPE_MODE_SWITCH_RES_SUSPEND
 	b	.suspend_exit
@@ -262,6 +278,7 @@ nbif_suspend_0:
  * Suspend from a receive (waiting for a message)
  */
 	.global	nbif_suspend_msg
+	.type	nbif_suspend_msg, %function
 nbif_suspend_msg:
 	mov	r0, #HIPE_MODE_SWITCH_RES_WAIT
 	b	.suspend_exit
@@ -272,6 +289,7 @@ nbif_suspend_msg:
  *	else { return 0; }
  */
 	.global	nbif_suspend_msg_timeout
+	.type	nbif_suspend_msg_timeout, %function
 nbif_suspend_msg_timeout:
 	ldr	r1, [P, #P_FLAGS]
 	mov	r0, #HIPE_MODE_SWITCH_RES_WAIT_TIMEOUT
@@ -286,23 +304,31 @@ nbif_suspend_msg_timeout:
  * This is the default exception handler for native code.
  */
 	.global	nbif_fail
+	.type	nbif_fail, %function
 nbif_fail:
 	mov	r0, #HIPE_MODE_SWITCH_RES_THROW
 	b	.flush_exit	/* no need to save RA */
 
 	.global	nbif_0_gc_after_bif
-	.global	nbif_1_gc_after_bif
-	.global	nbif_2_gc_after_bif
-	.global	nbif_3_gc_after_bif
+	.type	nbif_0_gc_after_bif, %function
 nbif_0_gc_after_bif:
 	mov	r1, #0
 	b	.gc_after_bif
+
+	.global	nbif_1_gc_after_bif
+	.type	nbif_1_gc_after_bif, %function
 nbif_1_gc_after_bif:
 	mov	r1, #1
 	b	.gc_after_bif
+
+	.global	nbif_2_gc_after_bif
+	.type	nbif_2_gc_after_bif, %function
 nbif_2_gc_after_bif:
 	mov	r1, #2
 	b	.gc_after_bif
+
+	.global	nbif_3_gc_after_bif
+	.type	nbif_3_gc_after_bif, %function
 nbif_3_gc_after_bif:
 	mov	r1, #3
 	/*FALLTHROUGH*/
@@ -330,18 +356,25 @@ nbif_3_gc_after_bif:
  * TEMP_LR contains a copy of LR
  */
 	.global	nbif_0_simple_exception
+	.type	nbif_0_simple_exception, %function
 nbif_0_simple_exception:
 	mov	r1, #0
 	b	.nbif_simple_exception
+
 	.global	nbif_1_simple_exception
+	.type	nbif_1_simple_exception, %function
 nbif_1_simple_exception:
 	mov	r1, #1
 	b	.nbif_simple_exception
+
 	.global	nbif_2_simple_exception
+	.type	nbif_2_simple_exception, %function
 nbif_2_simple_exception:
 	mov	r1, #2
 	b	.nbif_simple_exception
+
 	.global	nbif_3_simple_exception
+	.type	nbif_3_simple_exception, %function
 nbif_3_simple_exception:
 	mov	r1, #3
 	/*FALLTHROUGH*/
@@ -385,6 +418,7 @@ nbif_3_simple_exception:
  * the gray/white stack boundary
  */
 	.global	nbif_stack_trap_ra
+	.type	nbif_stack_trap_ra, %function
 nbif_stack_trap_ra:		/* a return address, not a function */
 	# This only handles a single return value.
 	# If we have more, we need to save them in the PCB.
@@ -401,6 +435,7 @@ nbif_stack_trap_ra:		/* a return address, not a function */
  * Caller saved its LR in TEMP_LR (== TEMP1) before calling us.
  */
 	.global	hipe_arm_inc_stack
+	.type	hipe_arm_inc_stack, %function
 hipe_arm_inc_stack:
 	STORE_ARG_REGS
 	mov	TEMP_ARG0, lr


### PR DESCRIPTION
HiPE on ARM is currently severely broken if the rest of the VM is
compiled to run in Thumb mode -- calling native code quickly ends
up executing code in the wrong mode and crashing the VM.  This is
a problem on e.g. Ubuntu which configures its system GCC to generate
Thumb by default.  It can also be triggered by overriding CC or
CFLAGS when compiling the VM.

There were three issues that caused the breakage:

1. Assembly-coded functions in hipe_arm_glue.S weren't explicitly
   tagged as functions, preventing the linker from generating the
   correct mode-switching call instructions for calls from C to
   these functions.

   Fixed by tagging those symbols as functions.

2. A few BIF wrappers were so simple that they performed tailcalls
   to the C BIFs.  This fails to switch mode when C is in Thumb.

   Fixed by performing ordinary recursive calls when C is in Thumb.

3. The assembly-coded source files weren't explicitly tagged as ARM.

Tested with the HiPE testsuite on ARMv7, with the VM built as ARM
and as Thumb.  Also manually inspected the object code for the beam
executable and checked that call sites from C to HiPE's ARM runtime
code and vice versa used the correct mode-switching instructions.