### PR TITLE
HiPE code alloc fixes

### DIFF
--- a/erts/emulator/hipe/hipe_amd64.c
+++ b/erts/emulator/hipe/hipe_amd64.c
@@ -224,8 +224,6 @@ void *hipe_alloc_code(Uint nrbytes, Eterm callees, Eterm *trampolines, Process *
     return alloc_code(nrbytes);
 }
 
-/* called from hipe_bif0.c:hipe_bifs_make_native_stub_2()
-   and hipe_bif0.c:hipe_make_stub() */
 void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
 {
     /*

--- a/erts/emulator/hipe/hipe_amd64.c
+++ b/erts/emulator/hipe/hipe_amd64.c
@@ -125,7 +125,7 @@ static void atexit_alloc_code_stats(void)
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
-static void morecore(unsigned int alloc_bytes)
+static int morecore(unsigned int alloc_bytes)
 {
     unsigned int map_bytes;
     char *map_hint, *map_start;
@@ -174,10 +174,9 @@ static void morecore(unsigned int alloc_bytes)
 	abort();
     }
 #endif
-    if (map_start == MAP_FAILED) {
-	perror("mmap");
-	abort();
-    }
+    if (map_start == MAP_FAILED)
+	return -1;
+
     ALLOC_CODE_STATS(total_mapped += map_bytes);
 
     /* Merge adjacent mappings, so the trailing portion of the previous
@@ -197,6 +196,8 @@ static void morecore(unsigned int alloc_bytes)
     }
 
     ALLOC_CODE_STATS(atexit_alloc_code_stats());
+
+    return 0;
 }
 
 static void *alloc_code(unsigned int alloc_bytes)
@@ -206,8 +207,8 @@ static void *alloc_code(unsigned int alloc_bytes)
     /* Align function entries. */
     alloc_bytes = (alloc_bytes + 3) & ~3;
 
-    if (code_bytes < alloc_bytes)
-	morecore(alloc_bytes);
+    if (code_bytes < alloc_bytes && morecore(alloc_bytes) != 0)
+	return NULL;
     ALLOC_CODE_STATS(++nr_allocs);
     ALLOC_CODE_STATS(total_alloc += alloc_bytes);
     res = code_next;
@@ -250,6 +251,8 @@ void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
       ((P_BEAM_IP + 4) >= 128 ? 3 : 0) +
       (P_ARITY >= 128 ? 3 : 0);
     codep = code = alloc_code(codeSize);
+    if (!code)
+	return NULL;
 
     /* movl $beamAddress, P_BEAM_IP(%ebp); 3 or 6 bytes, plus 4 */
     codep[0] = 0xc7;

--- a/erts/emulator/hipe/hipe_arch.h
+++ b/erts/emulator/hipe/hipe_arch.h
@@ -29,6 +29,7 @@ extern void hipe_patch_load_fe(Uint *address, Uint value);
 extern int hipe_patch_insn(void *address, Uint value, Eterm type);
 extern int hipe_patch_call(void *callAddress, void *destAddress, void *trampoline);
 
+extern void *hipe_alloc_code(Uint nrbytes, Eterm callees, Eterm *trampolines, Process *p);
 extern void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity);
 
 #if defined(__sparc__)

--- a/erts/emulator/hipe/hipe_arm.c
+++ b/erts/emulator/hipe/hipe_arm.c
@@ -260,8 +260,6 @@ int hipe_patch_insn(void *address, Uint32 value, Eterm type)
     return 0;
 }
 
-/* called from hipe_bif0.c:hipe_bifs_make_native_stub_2()
-   and hipe_bif0.c:hipe_make_stub() */
 void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
 {
     unsigned int *code;

--- a/erts/emulator/hipe/hipe_arm.c
+++ b/erts/emulator/hipe/hipe_arm.c
@@ -281,6 +281,8 @@ void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
      */
 
     code = alloc_stub(4, &tramp_callemu);
+    if (!code)
+	return NULL;
     callemu_offset = ((int)&nbif_callemu - ((int)&code[2] + 8)) >> 2;
     if (!(callemu_offset >= -0x00800000 && callemu_offset <= 0x007FFFFF)) {
 	callemu_offset = ((int)tramp_callemu - ((int)&code[2] + 8)) >> 2;

--- a/erts/emulator/hipe/hipe_arm.h
+++ b/erts/emulator/hipe/hipe_arm.h
@@ -40,8 +40,4 @@ static __inline__ int hipe_word32_address_ok(void *address)
 
 extern void hipe_arm_inc_stack(void);
 
-/* for hipe_bifs_enter_code_2 */
-extern void *hipe_alloc_code(Uint nrbytes, Eterm callees, Eterm *trampolines, Process *p);
-#define HIPE_ALLOC_CODE(n,c,t,p) hipe_alloc_code((n),(c),(t),(p))
-
 #endif /* HIPE_ARM_H */

--- a/erts/emulator/hipe/hipe_bif0.c
+++ b/erts/emulator/hipe/hipe_bif0.c
@@ -433,8 +433,16 @@ BIF_RETTYPE hipe_bifs_enter_code_2(BIF_ALIST_2)
     ASSERT(bitsize == 0);
     trampolines = NIL;
     address = hipe_alloc_code(nrbytes, BIF_ARG_2, &trampolines, BIF_P);
-    if (!address)
-	erl_exit(1, "hipe_bifs_enter_code_2: code allocation failed\r\n");
+    if (!address) {
+	Uint nrcallees;
+
+	if (is_tuple(BIF_ARG_2))
+	    nrcallees = arityval(tuple_val(BIF_ARG_2)[0]);
+	else
+	    nrcallees = 0;
+	erl_exit(1, "%s: failed to allocate %lu bytes and %lu trampolines\r\n",
+		 __func__, (unsigned long)nrbytes, (unsigned long)nrcallees);
+    }
     memcpy(address, bytes, nrbytes);
     hipe_flush_icache_range(address, nrbytes);
     hp = HAlloc(BIF_P, 3);

--- a/erts/emulator/hipe/hipe_bif0.c
+++ b/erts/emulator/hipe/hipe_bif0.c
@@ -432,15 +432,9 @@ BIF_RETTYPE hipe_bifs_enter_code_2(BIF_ALIST_2)
     ASSERT(bitoffs == 0);
     ASSERT(bitsize == 0);
     trampolines = NIL;
-#ifdef HIPE_ALLOC_CODE
-    address = HIPE_ALLOC_CODE(nrbytes, BIF_ARG_2, &trampolines, BIF_P);
+    address = hipe_alloc_code(nrbytes, BIF_ARG_2, &trampolines, BIF_P);
     if (!address)
 	BIF_ERROR(BIF_P, BADARG);
-#else
-    if (is_not_nil(BIF_ARG_2))
-	BIF_ERROR(BIF_P, BADARG);
-    address = erts_alloc(ERTS_ALC_T_HIPE, nrbytes);
-#endif
     memcpy(address, bytes, nrbytes);
     hipe_flush_icache_range(address, nrbytes);
     hp = HAlloc(BIF_P, 3);

--- a/erts/emulator/hipe/hipe_bif0.c
+++ b/erts/emulator/hipe/hipe_bif0.c
@@ -647,19 +647,6 @@ static void *hipe_get_emu_address(Eterm m, Eterm f, unsigned int arity, int is_r
     return address;
 }
 
-#if 0 /* XXX: unused */
-BIF_RETTYPE hipe_bifs_get_emu_address_1(BIF_ALIST_1)
-{
-    struct mfa mfa;
-    void *address;
-
-    if (!term_to_mfa(BIF_ARG_1, &mfa))
-	BIF_ERROR(BIF_P, BADARG);
-    address = hipe_get_emu_address(mfa.mod, mfa.fun, mfa.ari);
-    BIF_RET(address_to_term(address, BIF_P));
-}
-#endif
-
 BIF_RETTYPE hipe_bifs_set_native_address_3(BIF_ALIST_3)
 {
     Eterm *pc;
@@ -1156,22 +1143,6 @@ BIF_RETTYPE hipe_bifs_set_native_address_in_fe_2(BIF_ALIST_2)
 	erts_erase_fun_entry(fe);
     BIF_RET(am_true);
 }
-
-#if 0 /* XXX: unused */
-BIF_RETTYPE hipe_bifs_make_native_stub_2(BIF_ALIST_2)
-{
-    void *beamAddress;
-    Uint beamArity;
-    void *stubAddress;
-
-    if ((beamAddress = term_to_address(BIF_ARG_1)) == 0 ||
-	is_not_small(BIF_ARG_2) ||
-	(beamArity = unsigned_val(BIF_ARG_2)) >= 256)
-	BIF_ERROR(BIF_P, BADARG);
-    stubAddress = hipe_make_native_stub(beamAddress, beamArity);
-    BIF_RET(address_to_term(stubAddress, BIF_P));
-}
-#endif
 
 /*
  * MFA info hash table:

--- a/erts/emulator/hipe/hipe_bif0.tab
+++ b/erts/emulator/hipe/hipe_bif0.tab
@@ -49,7 +49,6 @@ bif hipe_bifs:constants_size/0
 bif hipe_bifs:merge_term/1
 
 bif hipe_bifs:fun_to_address/1
-#bif hipe_bifs:get_emu_address/1
 bif hipe_bifs:set_native_address/3
 #bif hipe_bifs:address_to_fun/1
 
@@ -72,7 +71,6 @@ bif hipe_bifs:term_to_word/1
 bif hipe_bifs:get_fe/2
 bif hipe_bifs:set_native_address_in_fe/2
 
-#bif hipe_bifs:make_native_stub/2
 bif hipe_bifs:find_na_or_make_stub/2
 
 bif hipe_bifs:check_crc/1

--- a/erts/emulator/hipe/hipe_ppc.c
+++ b/erts/emulator/hipe/hipe_ppc.c
@@ -355,8 +355,6 @@ int hipe_patch_insn(void *address, Uint32 value, Eterm type)
     return 0;
 }
 
-/* called from hipe_bif0.c:hipe_bifs_make_native_stub_2()
-   and hipe_bif0.c:hipe_make_stub() */
 void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
 {
     unsigned int *code;

--- a/erts/emulator/hipe/hipe_ppc.c
+++ b/erts/emulator/hipe/hipe_ppc.c
@@ -293,6 +293,8 @@ void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
 	abort();
 
     code = alloc_stub(7);
+    if (!code)
+	return NULL;
 
     /* addis r12,0,beamAddress@highest */
     code[0] = 0x3d800000 | (((unsigned long)beamAddress >> 48) & 0xffff);
@@ -381,6 +383,8 @@ void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
 	abort();
 
     code = alloc_stub(4);
+    if (!code)
+	return NULL;
 
     /* addi r12,0,beamAddress@l */
     code[0] = 0x39800000 | ((unsigned long)beamAddress & 0xFFFF);

--- a/erts/emulator/hipe/hipe_ppc.h
+++ b/erts/emulator/hipe/hipe_ppc.h
@@ -64,10 +64,6 @@ AEXTERN(void,hipe_ppc_inc_stack,(void));
 extern void hipe_ppc_inc_stack(void); /* we don't have the AEXTERN() fallback :-( */
 #endif
 
-/* for hipe_bifs_enter_code_2 */
-extern void *hipe_alloc_code(Uint nrbytes, Eterm callees, Eterm *trampolines, Process *p);
-#define HIPE_ALLOC_CODE(n,c,t,p) hipe_alloc_code((n),(c),(t),(p))
-
 #if !defined(__powerpc64__)
 extern const unsigned int fconv_constant[];
 #endif

--- a/erts/emulator/hipe/hipe_sparc.c
+++ b/erts/emulator/hipe/hipe_sparc.c
@@ -204,8 +204,6 @@ void *hipe_alloc_code(Uint nrbytes, Eterm callees, Eterm *trampolines, Process *
     return alloc_code(nrbytes);
 }
 
-/* called from hipe_bif0.c:hipe_bifs_make_native_stub_2()
-   and hipe_bif0.c:hipe_make_stub() */
 void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
 {
     unsigned int *code;

--- a/erts/emulator/hipe/hipe_sparc.c
+++ b/erts/emulator/hipe/hipe_sparc.c
@@ -130,7 +130,7 @@ static void atexit_alloc_code_stats(void)
 #define ALLOC_CODE_STATS(X)	do{}while(0)
 #endif
 
-static void morecore(unsigned int alloc_bytes)
+static int morecore(unsigned int alloc_bytes)
 {
     unsigned int map_bytes;
     char *map_hint, *map_start;
@@ -158,10 +158,9 @@ static void morecore(unsigned int alloc_bytes)
 #endif
 		     ,
 		     -1, 0);
-    if (map_start == MAP_FAILED) {
-	perror("mmap");
-	abort();
-    }
+    if (map_start == MAP_FAILED)
+	return -1;
+
     ALLOC_CODE_STATS(total_mapped += map_bytes);
 
     /* Merge adjacent mappings, so the trailing portion of the previous
@@ -177,6 +176,8 @@ static void morecore(unsigned int alloc_bytes)
     }
 
     ALLOC_CODE_STATS(atexit_alloc_code_stats());
+
+    return 0;
 }
 
 static void *alloc_code(unsigned int alloc_bytes)
@@ -186,8 +187,8 @@ static void *alloc_code(unsigned int alloc_bytes)
     /* Align function entries. */
     alloc_bytes = (alloc_bytes + 3) & ~3;
 
-    if (code_bytes < alloc_bytes)
-	morecore(alloc_bytes);
+    if (code_bytes < alloc_bytes && morecore(alloc_bytes) != 0)
+	return NULL;
     ALLOC_CODE_STATS(++nr_allocs);
     ALLOC_CODE_STATS(total_alloc += alloc_bytes);
     res = code_next;
@@ -211,6 +212,8 @@ void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
     int i;
 
     code = alloc_code(5*sizeof(int));
+    if (!code)
+	return NULL;
 
     /* sethi %hi(Address), %i4 */
     code[0] = 0x39000000 | (((unsigned int)beamAddress >> 10) & 0x3FFFFF);

--- a/erts/emulator/hipe/hipe_sparc.h
+++ b/erts/emulator/hipe/hipe_sparc.h
@@ -47,8 +47,4 @@ static __inline__ int hipe_word32_address_ok(void *address)
 
 extern void hipe_sparc_inc_stack(void);
 
-/* for hipe_bifs_enter_code_2 */
-extern void *hipe_alloc_code(Uint nrbytes, Eterm callees, Eterm *trampolines, Process *p);
-#define HIPE_ALLOC_CODE(n,c,t,p) hipe_alloc_code((n),(c),(t),(p))
-
 #endif /* HIPE_SPARC_H */

--- a/erts/emulator/hipe/hipe_x86.c
+++ b/erts/emulator/hipe/hipe_x86.c
@@ -182,8 +182,6 @@ void *hipe_alloc_code(Uint nrbytes, Eterm callees, Eterm *trampolines, Process *
     return alloc_code(nrbytes);
 }
 
-/* called from hipe_bif0.c:hipe_bifs_make_native_stub_2()
-   and hipe_bif0.c:hipe_make_stub() */
 void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
 {
     /*

--- a/erts/emulator/hipe/hipe_x86.c
+++ b/erts/emulator/hipe/hipe_x86.c
@@ -108,7 +108,7 @@ static void atexit_alloc_code_stats(void)
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
-static void morecore(unsigned int alloc_bytes)
+static int morecore(unsigned int alloc_bytes)
 {
     unsigned int map_bytes;
     char *map_hint, *map_start;
@@ -136,10 +136,9 @@ static void morecore(unsigned int alloc_bytes)
 #endif
 		     ,
 		     -1, 0);
-    if (map_start == MAP_FAILED) {
-	perror("mmap");
-	abort();
-    }
+    if (map_start == MAP_FAILED)
+	return -1;
+
     ALLOC_CODE_STATS(total_mapped += map_bytes);
 
     /* Merge adjacent mappings, so the trailing portion of the previous
@@ -155,6 +154,8 @@ static void morecore(unsigned int alloc_bytes)
     }
 
     ALLOC_CODE_STATS(atexit_alloc_code_stats());
+
+    return 0;
 }
 
 static void *alloc_code(unsigned int alloc_bytes)
@@ -164,8 +165,8 @@ static void *alloc_code(unsigned int alloc_bytes)
     /* Align function entries. */
     alloc_bytes = (alloc_bytes + 3) & ~3;
 
-    if (code_bytes < alloc_bytes)
-	morecore(alloc_bytes);
+    if (code_bytes < alloc_bytes && morecore(alloc_bytes) != 0)
+	return NULL;
     ALLOC_CODE_STATS(++nr_allocs);
     ALLOC_CODE_STATS(total_alloc += alloc_bytes);
     res = code_next;
@@ -207,6 +208,8 @@ void *hipe_make_native_stub(void *beamAddress, unsigned int beamArity)
 	(P_BEAM_IP >= 128 ? 3 : 0) +
 	(P_ARITY >= 128 ? 3 : 0);
     codep = code = alloc_code(codeSize);
+    if (!code)
+	return NULL;
 
     /* movl $beamAddress, P_BEAM_IP(%ebp); 3 or 6 bytes, plus 4 */
     codep[0] = 0xc7;

--- a/erts/emulator/hipe/hipe_x86.h
+++ b/erts/emulator/hipe/hipe_x86.h
@@ -53,8 +53,4 @@ extern void nbif_inc_stack_0(void);
 extern void nbif_handle_fp_exception(void);
 #endif
 
-/* for hipe_bifs_enter_code_2 */
-extern void *hipe_alloc_code(Uint nrbytes, Eterm callees, Eterm *trampolines, Process *p);
-#define HIPE_ALLOC_CODE(n,c,t,p) hipe_alloc_code((n),(c),(t),(p))
-
 #endif /* HIPE_X86_H */

--- a/lib/hipe/cerl/erl_bif_types.erl
+++ b/lib/hipe/cerl/erl_bif_types.erl
@@ -1070,9 +1070,6 @@ type(hipe_bifs, find_na_or_make_stub, 2, Xs, Opaques) ->
 type(hipe_bifs, fun_to_address, 1, Xs, Opaques) ->
   strict(hipe_bifs, fun_to_address, 1, Xs,
 	 fun (_) -> t_integer() end, Opaques);
-%% type(hipe_bifs, get_emu_address, 1, Xs, Opaques) ->
-%%    strict(hipe_bifs, get_emu_address, 1, Xs,
-%%	   fun (_) -> t_integer() end, Opaques); % address
 type(hipe_bifs, get_fe, 2, Xs, Opaques) ->
   strict(hipe_bifs, get_fe, 2, Xs, fun (_) -> t_integer() end, Opaques);
 type(hipe_bifs, get_rts_param, 1, Xs, Opaques) ->
@@ -1081,9 +1078,6 @@ type(hipe_bifs, get_rts_param, 1, Xs, Opaques) ->
 type(hipe_bifs, invalidate_funinfo_native_addresses, 1, Xs, Opaques) ->
   strict(hipe_bifs, invalidate_funinfo_native_addresses, 1, Xs,
 	 fun (_) -> t_nil() end, Opaques);
-%% type(hipe_bifs, make_native_stub, 2, Xs, Opaques) ->
-%%    strict(hipe_bifs, make_native_stub, 2, Xs,
-%%	   fun (_) -> t_integer() end, Opaques); % address
 type(hipe_bifs, mark_referred_from, 1, Xs, Opaques) ->
   strict(hipe_bifs, mark_referred_from, 1, Xs,
 	 fun (_) -> t_nil() end, Opaques);
@@ -2462,16 +2456,12 @@ arg_types(hipe_bifs, find_na_or_make_stub, 2) ->
   [t_mfa(), t_boolean()];
 arg_types(hipe_bifs, fun_to_address, 1) ->
   [t_mfa()];
-%% arg_types(hipe_bifs, get_emu_address, 1) ->
-%%   [t_mfa()];
 arg_types(hipe_bifs, get_fe, 2) ->
   [t_atom(), t_tuple([t_integer(), t_integer(), t_integer()])];
 arg_types(hipe_bifs, get_rts_param, 1) ->
   [t_fixnum()];
 arg_types(hipe_bifs, invalidate_funinfo_native_addresses, 1) ->
   [t_list(t_mfa())];
-%% arg_types(hipe_bifs, make_native_stub, 2) ->
-%%   [t_integer(), t_arity()];
 arg_types(hipe_bifs, mark_referred_from, 1) ->
   [t_mfa()];
 arg_types(hipe_bifs, merge_term, 1) ->


### PR DESCRIPTION
This branch contains cleanups and fixes related to memory allocation for code in the HiPE runtime.

- it changes generic code to raise Erlang-level exceptions on allocation failures
- it changes platform-specific code to signal allocation failures rather than crashing the VM (with abort() or  SEGV from NULL pointer dereferences)
- it removes obsolete and disabled BIFs related to code management
- it eliminates a useless internal platform-specific macro

Tested with the HiPE testsuite on x86_64 (-m64 and -m32), armv7, sparc64 -m32, and ppc64 -m32.