### PR TITLE
Prevent zip:zip_open/1,2 from leaking ports

### DIFF
--- a/lib/stdlib/doc/src/zip.xml
+++ b/lib/stdlib/doc/src/zip.xml
@@ -430,6 +430,8 @@
           means that subsequently reading files from the archive will be
           faster than unzipping files one at a time with <c>unzip</c>.</p>
         <p>The archive must be closed with <c>zip_close/1</c>.</p>
+        <p>The <c><anno>ZipHandle</anno></c> will be closed if the
+          process which originally opened the archive dies.</p>
       </desc>
     </func>
     <func>

--- a/lib/stdlib/src/zip.erl
+++ b/lib/stdlib/src/zip.erl
@@ -1114,15 +1114,19 @@ local_file_header_from_info_method_name(#file_info{mtime = MTime},
 		       file_name_length = length(Name),
 		       extra_field_length = 0}.
 
+server_init(Parent) ->
+    %% we want to know if our parent dies
+    process_flag(trap_exit, true),
+    server_loop(Parent, not_open).
 
 %% small, simple, stupid zip-archive server
-server_loop(OpenZip) ->
+server_loop(Parent, OpenZip) ->
     receive
 	{From, {open, Archive, Options}} ->
 	    case openzip_open(Archive, Options) of
 		{ok, NewOpenZip} ->
 		    From ! {self(), {ok, self()}},
-		    server_loop(NewOpenZip);
+		    server_loop(Parent, NewOpenZip);
 		Error ->
 		    From ! {self(), Error}
 	    end;
@@ -1130,19 +1134,22 @@ server_loop(OpenZip) ->
 	    From ! {self(), openzip_close(OpenZip)};
 	{From, get} ->
 	    From ! {self(), openzip_get(OpenZip)},
-	    server_loop(OpenZip);
+	    server_loop(Parent, OpenZip);
 	{From, {get, FileName}} ->
 	    From ! {self(), openzip_get(FileName, OpenZip)},
-	    server_loop(OpenZip);
+	    server_loop(Parent, OpenZip);
 	{From, list_dir} ->
 	    From ! {self(), openzip_list_dir(OpenZip)},
-	    server_loop(OpenZip);
+	    server_loop(Parent, OpenZip);
 	{From, {list_dir, Opts}} ->
 	    From ! {self(), openzip_list_dir(OpenZip, Opts)},
-	    server_loop(OpenZip);
+	    server_loop(Parent, OpenZip);
 	{From, get_state} ->
 	    From ! {self(), OpenZip},
-	    server_loop(OpenZip);
+	    server_loop(Parent, OpenZip);
+        {'EXIT', Parent, Reason} ->
+            openzip_close(OpenZip),
+            exit({parent_died, Reason});
 	_ ->
 	    {error, bad_msg}
     end.
@@ -1162,8 +1169,9 @@ zip_open(Archive) -> zip_open(Archive, []).
       Reason :: term()).
 
 zip_open(Archive, Options) ->
-    Pid = spawn(fun() -> server_loop(not_open) end),
-    request(self(), Pid, {open, Archive, Options}).
+    Self = self(),
+    Pid = spawn_link(fun() -> server_init(Self) end),
+    request(Self, Pid, {open, Archive, Options}).
 
 -spec(zip_get(ZipHandle) -> {ok, [Result]} | {error, Reason} when
       ZipHandle :: pid(),

--- a/lib/stdlib/src/zip.erl
+++ b/lib/stdlib/src/zip.erl
@@ -214,7 +214,9 @@
 -type zip_comment() :: #zip_comment{}.
 -type zip_file() :: #zip_file{}.
 
--export_type([create_option/0, filename/0]).
+-opaque handle() :: pid().
+
+-export_type([create_option/0, filename/0, handle/0]).
 
 %% Open a zip archive with options
 %%
@@ -500,7 +502,7 @@ do_list_dir(F, Options) ->
 
 -spec(t(Archive) -> ok when
       Archive :: file:name() | binary() | ZipHandle,
-      ZipHandle :: pid()).
+      ZipHandle :: handle()).
 
 t(F) when is_pid(F) -> zip_t(F);
 t(F) when is_record(F, openzip) -> openzip_t(F);
@@ -524,7 +526,7 @@ do_t(F, RawPrint) ->
 
 -spec(tt(Archive) -> ok when
       Archive :: file:name() | binary() | ZipHandle,
-      ZipHandle :: pid()).
+      ZipHandle :: handle()).
 
 tt(F) when is_pid(F) -> zip_tt(F);
 tt(F) when is_record(F, openzip) -> openzip_tt(F);
@@ -1156,14 +1158,14 @@ server_loop(Parent, OpenZip) ->
 
 -spec(zip_open(Archive) -> {ok, ZipHandle} | {error, Reason} when
       Archive :: file:name() | binary(),
-      ZipHandle :: pid(),
+      ZipHandle :: handle(),
       Reason :: term()).
 
 zip_open(Archive) -> zip_open(Archive, []).
 
 -spec(zip_open(Archive, Options) -> {ok, ZipHandle} | {error, Reason} when
       Archive :: file:name() | binary(),
-      ZipHandle :: pid(),
+      ZipHandle :: handle(),
       Options :: [Option],
       Option :: cooked | memory | {cwd, CWD :: file:filename()},
       Reason :: term()).
@@ -1174,7 +1176,7 @@ zip_open(Archive, Options) ->
     request(Self, Pid, {open, Archive, Options}).
 
 -spec(zip_get(ZipHandle) -> {ok, [Result]} | {error, Reason} when
-      ZipHandle :: pid(),
+      ZipHandle :: handle(),
       Result :: file:name() | {file:name(), binary()},
       Reason :: term()).
 
@@ -1182,14 +1184,14 @@ zip_get(Pid) when is_pid(Pid) ->
     request(self(), Pid, get).
 
 -spec(zip_close(ZipHandle) -> ok | {error, einval} when
-      ZipHandle :: pid()).
+      ZipHandle :: handle()).
 
 zip_close(Pid) when is_pid(Pid) ->
     request(self(), Pid, close).
 
 -spec(zip_get(FileName, ZipHandle) -> {ok, Result} | {error, Reason} when
       FileName :: file:name(),
-      ZipHandle :: pid(),
+      ZipHandle :: handle(),
       Result :: file:name() | {file:name(), binary()},
       Reason :: term()).
 
@@ -1198,7 +1200,7 @@ zip_get(FileName, Pid) when is_pid(Pid) ->
 
 -spec(zip_list_dir(ZipHandle) -> {ok, Result} | {error, Reason} when
       Result :: [zip_comment() | zip_file()],
-      ZipHandle :: pid(),
+      ZipHandle :: handle(),
       Reason :: term()).
 
 zip_list_dir(Pid) when is_pid(Pid) ->


### PR DESCRIPTION
The case was discovered where a parent process would exit before closing
the zip file. The result was that a port would be left open
indefinitely, as the small zip server would not detect this condition.

By comparison, the file module will close the associated port when the
parent exits for any reason. This change would make the zip module more
consistent with the semantics of similar modules.

This change is breaking for any callers expecting to pass the handle to
another process for processing (assuming it exits).

With this in mind, it may need a bit more thought with regards to:

1. Is this the best way to cope with a parent process exiting?
2. Should an equivalent of `gen_tcp:controlling_process/2` to deal with
    migrating an open zip to another process?
3. If backwards compatibility is necessary, then would it be worth
    introducing new functions without the "zip_" prefix?