### PR TITLE
Export type gen_udp:socket/0.

### DIFF
--- a/lib/kernel/src/gen_udp.erl
+++ b/lib/kernel/src/gen_udp.erl
@@ -78,7 +78,7 @@
 	ipv6_v6only.
 -type socket() :: port().
 
--export_type([option/0, option_name/0]).
+-export_type([option/0, option_name/0, socket/0]).
 
 -spec open(Port) -> {ok, Socket} | {error, Reason} when
       Port :: inet:port_number(),


### PR DESCRIPTION
It's documented but not exported, that got me confused.