### PR TITLE
Implementation of Little Endian encoding for ports.

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -360,6 +360,7 @@ atom multiline
 atom name
 atom named_table
 atom namelist
+atom native
 atom native_addresses
 atom Neq='=/='
 atom Neqeq='/='
@@ -435,6 +436,7 @@ atom output
 atom overlapped_io
 atom owner
 atom packet
+atom packet_endian
 atom packet_size
 atom parallelism
 atom Plus='+'

--- a/erts/emulator/beam/packet_parser.c
+++ b/erts/emulator/beam/packet_parser.c
@@ -288,6 +288,42 @@ int packet_get_length(enum PacketParseType htype,
         plen = get_int32(ptr);
         goto remain;
 
+    case TCP_PB_LE2:
+        /* TCP_PB_LE2:    [L0,L1 | Data] */
+        hlen = 2;
+        if (n < hlen) goto more;
+        plen = get_int16le(ptr);
+        goto remain;
+
+    case TCP_PB_LE4:
+        /* TCP_PB_LE4:    [L0,L1,L2,L3 | Data] */
+        hlen = 4;
+        if (n < hlen) goto more;
+        plen = get_int32le(ptr);
+        goto remain;
+
+    case TCP_PB_NE2: {
+                         /* TCP_PB_NE2:  [L0,L1 | Data] */
+                         /* L0, L1 - in native endian for this machine */
+                         hlen = 2;
+                         if (n < hlen) goto more;
+                         uint16_t tmp_len;
+                         memcpy(&tmp_len,ptr,2);
+                         plen=tmp_len;
+                         goto remain;
+                     }
+
+    case TCP_PB_NE4: {
+                         /* TCP_PB_NE4:  [L0,L1,L2,L3 | Data] */
+                         /* L0, L1, L2, L3 - in native endian for this machine */
+                         hlen = 4;
+                         if (n < hlen) goto more;
+                         uint32_t tmp_len;
+                         memcpy(&tmp_len,ptr,4);
+                         plen=tmp_len;
+                         goto remain;
+                     }
+
     case TCP_PB_RM:
         /* TCP_PB_RM:    [L3,L2,L1,L0 | Data] 
         ** where MSB (bit) is used to signal end of record

--- a/erts/emulator/beam/packet_parser.h
+++ b/erts/emulator/beam/packet_parser.h
@@ -43,7 +43,17 @@ enum PacketParseType {
     TCP_PB_HTTPH    = 11,
     TCP_PB_SSL_TLS  = 12,
     TCP_PB_HTTP_BIN = 13,
-    TCP_PB_HTTPH_BIN = 14
+    TCP_PB_HTTPH_BIN = 14,
+    TCP_PB_LE2      = 15,
+    TCP_PB_NE2      = 16,
+    TCP_PB_LE4      = 17,
+    TCP_PB_NE4      = 18
+};
+
+enum PacketHeaderEndian {
+    TCP_PH_ENDIAN_BIG=0,
+    TCP_PH_ENDIAN_LITTLE=1,
+    TCP_PH_ENDIAN_NATIVE=2
 };
 
 typedef struct http_atom {
@@ -146,14 +156,21 @@ ERTS_GLB_INLINE
 void packet_get_body(enum PacketParseType htype, const char** bufp, int* lenp)
 {
     switch (htype) {
-    case TCP_PB_1:  *bufp += 1; *lenp -= 1; break;
-    case TCP_PB_2:  *bufp += 2; *lenp -= 2; break;
-    case TCP_PB_4:  *bufp += 4; *lenp -= 4; break;
-    case TCP_PB_FCGI:
-	*lenp -= ((struct fcgi_head*)*bufp)->paddingLength;
-        break;
-    default:
-        ;/* Return other packets "as is" */
+        case TCP_PB_1:
+            *bufp += 1; *lenp -= 1; break;
+        case TCP_PB_2:
+        case TCP_PB_LE2:
+        case TCP_PB_NE2:
+            *bufp += 2; *lenp -= 2; break;
+        case TCP_PB_4:
+        case TCP_PB_LE4:
+        case TCP_PB_NE4:
+            *bufp += 4; *lenp -= 4; break;
+        case TCP_PB_FCGI:
+            *lenp -= ((struct fcgi_head*)*bufp)->paddingLength;
+            break;
+        default:
+            break;/* Return other packets "as is" */
     }
 }
 

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -627,6 +627,7 @@ typedef struct _SysDriverOpts {
     Uint ifd;			/* Input file descriptor (fd driver). */
     Uint ofd;			/* Outputfile descriptor (fd driver). */
     int packet_bytes;		/* Number of bytes in packet header. */
+    int packet_endian;          /* Endian of packet header. 0 - big, 1 - little, 2 - native */
     int read_write;		/* Read and write bits. */
     int use_stdio;		/* Use standard I/O: TRUE or FALSE. */
     int redir_stderr;           /* Redirect stderr to stdout: TRUE/FALSE. */
@@ -983,10 +984,21 @@ extern int erts_use_kernel_poll;
                       (((unsigned char*) (s))[2] << 8)  | \
                       (((unsigned char*) (s))[3]))
 
+#define get_int32le(s) ((((unsigned char*) (s))[3] << 24) | \
+                      (((unsigned char*) (s))[2] << 16) | \
+                      (((unsigned char*) (s))[1] << 8)  | \
+                      (((unsigned char*) (s))[0]))
+
 #define put_int32(i, s) do {((char*)(s))[0] = (char)((i) >> 24) & 0xff;   \
                             ((char*)(s))[1] = (char)((i) >> 16) & 0xff;   \
                             ((char*)(s))[2] = (char)((i) >> 8)  & 0xff;   \
                             ((char*)(s))[3] = (char)(i)         & 0xff;} \
+                        while (0)
+
+#define put_int32le(i, s) do {((char*)(s))[3] = (char)((i) >> 24) & 0xff;   \
+                            ((char*)(s))[2] = (char)((i) >> 16) & 0xff;   \
+                            ((char*)(s))[1] = (char)((i) >> 8)  & 0xff;   \
+                            ((char*)(s))[0] = (char)(i)         & 0xff;} \
                         while (0)
 
 #define get_int24(s) ((((unsigned char*) (s))[0] << 16) | \
@@ -1001,9 +1013,15 @@ extern int erts_use_kernel_poll;
 #define get_int16(s) ((((unsigned char*)  (s))[0] << 8) | \
                       (((unsigned char*)  (s))[1]))
 
+#define get_int16le(s) ((((unsigned char*)  (s))[1] << 8) | \
+                      (((unsigned char*)  (s))[0]))
 
 #define put_int16(i, s) do {((char*)(s))[0] = (char)((i) >> 8) & 0xff;  \
                             ((char*)(s))[1] = (char)(i)        & 0xff;} \
+                        while (0)
+
+#define put_int16le(i, s) do {((char*)(s))[1] = (char)((i) >> 8) & 0xff;  \
+                            ((char*)(s))[0] = (char)(i)        & 0xff;} \
                         while (0)
 
 #define get_int8(s) ((((unsigned char*)  (s))[0] ))

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -10570,7 +10570,8 @@ static int tcp_sendv(tcp_descriptor* desc, ErlIOVec* ev)
              put_int16le(len, buf);
          }
          else if(desc->inet.pkt_endian==2) {
-             memcpy(buf, &len, 2);
+	     uint16_t tmp=len;
+             memcpy(buf, &tmp, 2);
          }
          else {
              put_int16(len, buf);
@@ -10582,7 +10583,8 @@ static int tcp_sendv(tcp_descriptor* desc, ErlIOVec* ev)
              put_int32le(len, buf);
          }
          else if(desc->inet.pkt_endian==2) {
-             memcpy(buf, &len, 4);
+	     uint32_t tmp=len;
+             memcpy(buf, &tmp, 4);
          }
          else {
              put_int32(len, buf);

--- a/erts/preloaded/src/prim_inet.erl
+++ b/erts/preloaded/src/prim_inet.erl
@@ -1160,6 +1160,7 @@ enc_opt(packet_size)     -> ?INET_LOPT_PACKET_SIZE;
 enc_opt(read_packets)    -> ?INET_LOPT_READ_PACKETS;
 enc_opt(netns)           -> ?INET_LOPT_NETNS;
 enc_opt(raw)             -> ?INET_OPT_RAW;
+enc_opt(packet_endian)   -> ?INET_LOPT_PACKET_ENDIAN;
 % Names of SCTP opts:
 enc_opt(sctp_rtoinfo)	 	   -> ?SCTP_OPT_RTOINFO;
 enc_opt(sctp_associnfo)	 	   -> ?SCTP_OPT_ASSOCINFO;
@@ -1280,6 +1281,10 @@ type_opt_1(active) ->
 	   {true, ?INET_ACTIVE}, 
 	   {once, ?INET_ONCE},
            {multi, ?INET_MULTI}]};
+type_opt_1(packet_endian) ->
+    {enum,[{big, ?TCP_PH_ENDIAN_BIG},
+	   {little, ?TCP_PH_ENDIAN_LITTLE},
+           {native, ?TCP_PH_ENDIAN_NATIVE}]};
 type_opt_1(packet) -> 
     {enum,[{0, ?TCP_PB_RAW},
 	   {1, ?TCP_PB_1},

--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -48,6 +48,8 @@
         {packet,
          0 | 1 | 2 | 4 | raw | sunrm |  asn1 |
          cdr | fcgi | line | tpkt | http | httph | http_bin | httph_bin } |
+        {packet_endian,
+         big | little | native } |
         {packet_size,     non_neg_integer()} |
         {priority,        non_neg_integer()} |
         {raw,

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -670,7 +670,7 @@ stats() ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 connect_options() ->
     [tos, priority, reuseaddr, keepalive, linger, sndbuf, recbuf, nodelay,
-     header, active, packet, packet_size, buffer, mode, deliver,
+     header, active, packet, packet_endian, packet_size, buffer, mode, deliver,
      exit_on_close, high_watermark, low_watermark, high_msgq_watermark,
      low_msgq_watermark, send_timeout, send_timeout_close, delay_send, raw].
     
@@ -737,7 +737,7 @@ con_add(Name, Val, #connect_opts{} = R, Opts, AllOpts) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 listen_options() ->
     [tos, priority, reuseaddr, keepalive, linger, sndbuf, recbuf, nodelay,
-     header, active, packet, buffer, mode, deliver, backlog, ipv6_v6only,
+     header, active, packet, packet_endian, buffer, mode, deliver, backlog, ipv6_v6only,
      exit_on_close, high_watermark, low_watermark, high_msgq_watermark,
      low_msgq_watermark, send_timeout, send_timeout_close, delay_send,
      packet_size, raw].

--- a/lib/kernel/src/inet_int.hrl
+++ b/lib/kernel/src/inet_int.hrl
@@ -147,6 +147,7 @@
 -define(INET_LOPT_MSGQ_HIWTRMRK,  36).
 -define(INET_LOPT_MSGQ_LOWTRMRK,  37).
 -define(INET_LOPT_NETNS,          38).
+-define(INET_LOPT_PACKET_ENDIAN,  39).
 % Specific SCTP options: separate range:
 -define(SCTP_OPT_RTOINFO,	 	100).
 -define(SCTP_OPT_ASSOCINFO,	 	101).
@@ -192,6 +193,9 @@
 -define(TCP_PB_HTTP_BIN,13).
 -define(TCP_PB_HTTPH_BIN,14).
 
+-define(TCP_PH_ENDIAN_BIG,0).
+-define(TCP_PH_ENDIAN_LITTLE,1).
+-define(TCP_PH_ENDIAN_NATIVE,2).
 
 %% getstat, INET_REQ_GETSTAT
 -define(INET_STAT_RECV_CNT,  1).


### PR DESCRIPTION
My implementation of little endian packet header for decode_packet/3 and ports.
To select little-endian header specify negative length: {packet, -2} or {packet: -4}
Update preloaded module prim_inet needed!

Sorry I didn't tried to build on win32.


