### PR TITLE
Fix index for #person.address in create_table/2

### DIFF
--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -863,7 +863,7 @@ mnesia:create_table(person,
      {attributes, record_info(fields,person)}]).
         </code>
         <p>The specification of <c>index</c> and <c>attributes</c> may be
-          hard coded as <c>{index, [2]}</c> and 
+          hard coded as <c>{index, [4]}</c> and
           <c>{attributes, [name, age, address, salary, children]}</c> 
           respectively.
           </p>


### PR DESCRIPTION
{index, [2]} refers to #person.name rather than #person.address, which
caused a little confusion in #erlang today.

{index, [4]} is the correct "hard coded" field for #person.address.