### PR TITLE
Support binary standard input in ets:i/1

### DIFF
--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -1613,12 +1613,17 @@ choice(Height, Width, P, Mode, Tab, Key, Turn, Opos) ->
     end.
 
 get_line(P, Default) ->
-    case io:get_line(P) of
+    case line_string(io:get_line(P)) of
 	"\n" ->
 	    Default;
 	L ->
 	    L
     end.
+
+%% If the standard input is set to binary mode
+%% convert it to a list so we can properly match.
+line_string(Binary) when is_binary(Binary) -> unicode:characters_to_list(Binary);
+line_string(Other) -> Other.
 
 nonl(S) -> string:strip(S, right, $\n).
 


### PR DESCRIPTION
The standard_input may be set to binary mode via `io:getopts/2`
and in such cases `ets:i/0` and `ets:i/1` get stuck as
they are unable to match new lines in binaries.

This is similar to previous changes seen in commits 2db2f977598dab05dc125acdc478c375cb66ddb8 and 4525bc59822acf0dfffa1edc64125c180d29e59e.