### PR TITLE
inets: parse correctly 'Set-Cookie' header with empty value

### DIFF
--- a/lib/inets/src/http_client/httpc_cookie.erl
+++ b/lib/inets/src/http_client/httpc_cookie.erl
@@ -362,6 +362,8 @@ parse_set_cookie(CookieHeader, {DefaultPath, DefaultDomain}) ->
     Name            = string:substr(CookieHeader, 1, Pos - 1),
     {Value, Attrs}  = 
 	case string:substr(CookieHeader, Pos + 1) of
+	    [] ->
+		{"", ""};
 	    [$;|ValueAndAttrs] ->
 		{"", string:tokens(ValueAndAttrs, ";")};
 	    ValueAndAttrs ->

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -1731,6 +1731,7 @@ handle_uri(_,"/empty_set_cookie.html",_,_,_,_) ->
 handle_uri(_,"/invalid_set_cookie.html",_,_,_,_) ->
     "HTTP/1.1 200 ok\r\n" ++
 	"set-cookie: =\r\n" ++
+	"set-cookie: name=\r\n" ++
 	"set-cookie: name-or-value\r\n" ++
 	"Content-Length:32\r\n\r\n"++
 	"<HTML><BODY>foobar</BODY></HTML>";


### PR DESCRIPTION
httpc_cookie should parse correctly cookies with empty values
and with no attributes set in those 'Set-Cookie' headers.