### PR TITLE
Error on nan inf

### DIFF
--- a/lib/erl_interface/configure.in
+++ b/lib/erl_interface/configure.in
@@ -138,6 +138,7 @@ esac
 # Checks for libraries.
 AC_CHECK_LIB([nsl], [gethostbyname])
 AC_CHECK_LIB([socket], [getpeername])
+AC_CHECK_LIB([m], [isfinite])
 
 # Checks for header files.
 AC_HEADER_STDC

--- a/lib/erl_interface/configure.in
+++ b/lib/erl_interface/configure.in
@@ -138,7 +138,18 @@ esac
 # Checks for libraries.
 AC_CHECK_LIB([nsl], [gethostbyname])
 AC_CHECK_LIB([socket], [getpeername])
-AC_CHECK_LIB([m], [isfinite])
+
+AC_MSG_CHECKING([for isfinite])
+AC_TRY_LINK([#include <math.h>],
+            [isfinite(0);], have_isfinite=yes, have_isfinite=no),
+
+if test $have_isfinite = yes; then
+    AC_DEFINE(HAVE_ISFINITE,[1],
+              [Define to 1 if you have the `isfinite' function.])
+    AC_MSG_RESULT(yes)
+else
+    AC_MSG_RESULT(no)
+fi
 
 # Checks for header files.
 AC_HEADER_STDC

--- a/lib/erl_interface/src/encode/encode_double.c
+++ b/lib/erl_interface/src/encode/encode_double.c
@@ -18,7 +18,9 @@
  */
 #include <stdio.h>
 #include <string.h>
+#if HAVE_ISFINITE == 1
 #include <math.h>
+#endif
 #include "eidef.h"
 #include "eiext.h"
 #include "putget.h"
@@ -31,9 +33,11 @@ int ei_encode_double(char *buf, int *index, double p)
   /* Erlang does not handle Inf and NaN, so we return an error rather
    * than letting the Erlang VM complain about a bad external
    * term. */
+#if HAVE_ISFINITE == 1
   if(!isfinite(p)) {
       return -1;
   }
+#endif
 
   if (!buf)
     s += 9;

--- a/lib/erl_interface/src/encode/encode_double.c
+++ b/lib/erl_interface/src/encode/encode_double.c
@@ -18,7 +18,7 @@
  */
 #include <stdio.h>
 #include <string.h>
-#if HAVE_ISFINITE == 1
+#if defined(HAVE_ISFINITE)
 #include <math.h>
 #endif
 #include "eidef.h"
@@ -33,7 +33,7 @@ int ei_encode_double(char *buf, int *index, double p)
   /* Erlang does not handle Inf and NaN, so we return an error rather
    * than letting the Erlang VM complain about a bad external
    * term. */
-#if HAVE_ISFINITE == 1
+#if defined(HAVE_ISFINITE)
   if(!isfinite(p)) {
       return -1;
   }

--- a/lib/erl_interface/src/encode/encode_double.c
+++ b/lib/erl_interface/src/encode/encode_double.c
@@ -31,10 +31,8 @@ int ei_encode_double(char *buf, int *index, double p)
   /* Erlang does not handle Inf and NaN, so we return an error rather
    * than letting the Erlang VM complain about a bad external
    * term. */
-  switch(fpclassify(p)) {
-      case FP_NAN:
-      case FP_INFINITE:
-          return -1;
+  if(!isfinite(p)) {
+      return -1;
   }
 
   if (!buf)

--- a/lib/erl_interface/src/encode/encode_double.c
+++ b/lib/erl_interface/src/encode/encode_double.c
@@ -18,6 +18,7 @@
  */
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include "eidef.h"
 #include "eiext.h"
 #include "putget.h"
@@ -26,6 +27,15 @@ int ei_encode_double(char *buf, int *index, double p)
 {
   char *s = buf + *index;
   char *s0 = s;
+
+  /* Erlang does not handle Inf and NaN, so we return an error rather
+   * than letting the Erlang VM complain about a bad external
+   * term. */
+  switch(fpclassify(p)) {
+      case FP_NAN:
+      case FP_INFINITE:
+          return -1;
+  }
 
   if (!buf)
     s += 9;

--- a/lib/erl_interface/src/legacy/erl_eterm.c
+++ b/lib/erl_interface/src/legacy/erl_eterm.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <math.h>
 
 #include "ei_locking.h"
 #include "ei_resolve.h"
@@ -124,6 +125,15 @@ ETERM *erl_mk_ulonglong (unsigned long long i)
 ETERM *erl_mk_float (double d)
 {
     ETERM *ep;
+
+    /* Erlang does not handle Inf and NaN, so we return an error
+     * rather than letting the Erlang VM complain about a bad external
+     * term. */
+    switch(fpclassify(d)) {
+        case FP_NAN:
+        case FP_INFINITE:
+            return NULL;
+    }
 
     ep = erl_alloc_eterm(ERL_FLOAT);
     ERL_COUNT(ep) = 1;

--- a/lib/erl_interface/test/ei_encode_SUITE.erl
+++ b/lib/erl_interface/test/ei_encode_SUITE.erl
@@ -174,7 +174,7 @@ test_ei_encode_ulonglong(Config) when is_list(Config) ->
 
 
 %% ######################################################################## %%
-%% A "character" for us is an 8 bit integer, alwasy positive, i.e.
+%% A "character" for us is an 8 bit integer, always positive, i.e.
 %% it is unsigned.
 %% FIXME maybe the API should change to use "unsigned char" to be clear?!
 


### PR DESCRIPTION
The C code used to connect a C node to Erlang should explicitly disallow floats that Erlang does not accept.

It's better to fail early and in a clear way than have Erlang spit out something that the C programmer may very well not understand.

http://erlang.org/pipermail/erlang-questions/2014-December/082003.html