### PR TITLE
Correctly process anon_auth option for eldap:open()

### DIFF
--- a/lib/eldap/src/eldap.erl
+++ b/lib/eldap/src/eldap.erl
@@ -395,7 +395,7 @@ parse_args([{port, Port}|T], Cpid, Data) when is_integer(Port) ->
 parse_args([{timeout, Timeout}|T], Cpid, Data) when is_integer(Timeout),Timeout>0 ->
     parse_args(T, Cpid, Data#eldap{timeout = Timeout});
 parse_args([{anon_auth, true}|T], Cpid, Data) ->
-    parse_args(T, Cpid, Data#eldap{anon_auth = false});
+    parse_args(T, Cpid, Data#eldap{anon_auth = true});
 parse_args([{anon_auth, _}|T], Cpid, Data) ->
     parse_args(T, Cpid, Data);
 parse_args([{ssl, true}|T], Cpid, Data) ->


### PR DESCRIPTION
Previously, it was impossible to set anon_auth to true. Making it
difficult to anonymously bind:

    1> {ok, Conn} = eldap:open(["localhost"], [{anon_auth, true}]).
    {ok,<0.34.0>}
    2> eldap:simple_bind(Conn, "", "").
    {error,anonymous_auth}

With this change:

    1> {ok, Conn} = eldap:open(["localhost"], [{anon_auth, true}]).
    {ok,<0.34.0>}
    2> eldap:simple_bind(Conn, "", "").
    ok

NB: Users could previously work around this by calling simple_bind as
follows:

    eldap:simple_bind(Conn, anon, anon)