### PR TITLE
Tests passed : little improvements

### DIFF
--- a/lib/eunit/src/eunit_tty.erl
+++ b/lib/eunit/src/eunit_tty.erl
@@ -67,6 +67,8 @@ terminate({ok, Data}, St) ->
 		    end,
 		    if Pass =:= 1 ->
 			    fwrite("  Test passed.\n");
+		       Pass =:= 2 ->
+			    fwrite("  2 tests passed.\n");
 		       true ->
 			    fwrite("  All ~w tests passed.\n", [Pass])
 		    end


### PR DESCRIPTION
When having 1 test message reads, **Test passed.**
when having 5 tests, **All 5 tests passed.**
but when having only 2 tests, **All 2 tests passed.** sounds a bit odd.

Improved to say: **2 tests passed.** when dealing with only two tests.