### PR TITLE
Fix ability to use gen_tcp/gen_udp with externally open AF_LOCAL fds

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2238,7 +2238,7 @@ fi
 dnl Need by run_erl.
 AC_CHECK_FUNCS([openpty])
 
-AC_CHECK_HEADERS(net/if_dl.h ifaddrs.h netpacket/packet.h)
+AC_CHECK_HEADERS(net/if_dl.h ifaddrs.h netpacket/packet.h sys/un.h)
 AC_CHECK_FUNCS([getifaddrs])
 
 dnl Checks for variables in6addr_any and in6addr_loopback,

--- a/lib/kernel/doc/src/gen_tcp.xml
+++ b/lib/kernel/doc/src/gen_tcp.xml
@@ -132,6 +132,13 @@ do_recv(Sock, Bs) ->
             <p>Set up the socket for IPv6.</p>
           </item>
 
+		  <tag><c>local</c></tag>
+		  <item>
+            <p>Set up the socket for local address family. This option is only
+               valid together with <c>{fd, integer()}</c> when the file descriptor
+               is of local address family (e.g. a Unix Domain Socket)</p>
+          </item>
+
           <tag><c>{port, Port}</c></tag>
           <item>
             <p>Specify which local port number to use.</p>

--- a/lib/kernel/doc/src/gen_udp.xml
+++ b/lib/kernel/doc/src/gen_udp.xml
@@ -101,6 +101,13 @@
             <p>Set up the socket for IPv4.</p>
           </item>
 
+		  <tag><c>local</c></tag>
+		  <item>
+            <p>Set up the socket for local address family. This option is only
+               valid together with <c>{fd, integer()}</c> when the file descriptor
+               is of local address family (e.g. a Unix Domain Socket)</p>
+          </item>
+
 		  <tag><c>{udp_module, module()}</c></tag>
 		  <item> <p>
 				  Override which callback module is used. Defaults to

--- a/lib/kernel/src/inet_int.hrl
+++ b/lib/kernel/src/inet_int.hrl
@@ -29,6 +29,7 @@
 -define(INET_AF_INET6,        2).
 -define(INET_AF_ANY,          3). % Fake for ANY in any address family
 -define(INET_AF_LOOPBACK,     4). % Fake for LOOPBACK in any address family
+-define(INET_AF_LOCAL,        5). % For Unix Domain address family
 
 %% type codes to open and gettype - INET_REQ_GETTYPE
 -define(INET_TYPE_STREAM,     1).
@@ -378,7 +379,8 @@
 	{ 
 	  ifaddr = any,     %% bind to interface address
 	  port   = 0,       %% bind to port (default is dynamic port)
-	  fd      = -1,     %% fd >= 0 => already bound
+	  fd     = -1,      %% fd >= 0 => already bound
+	  family = inet,    %% address family
 	  opts   = []       %% [{active,true}] added in inet:connect_options
 	 }).
 
@@ -388,6 +390,7 @@
 	  port   = 0,                %% bind to port (default is dynamic port)
 	  backlog = ?LISTEN_BACKLOG, %% backlog
 	  fd      = -1,              %% %% fd >= 0 => already bound
+	  family = inet,             %% address family
 	  opts   = []                %% [{active,true}] added in 
 	                             %% inet:listen_options
 	 }).
@@ -397,6 +400,7 @@
 	  ifaddr = any,
 	  port   = 0,
 	  fd     = -1,
+	  family = inet,
 	  opts   = [{active,true}]
 	 }).
 

--- a/lib/kernel/src/inet_tcp.erl
+++ b/lib/kernel/src/inet_tcp.erl
@@ -108,9 +108,10 @@ do_connect({A,B,C,D}, Port, Opts, Time) when ?ip(A,B,C,D), ?port(Port) ->
 	{ok, #connect_opts{fd=Fd,
 			   ifaddr=BAddr={Ab,Bb,Cb,Db},
 			   port=BPort,
+			   family=Family,
 			   opts=SockOpts}}
 	when ?ip(Ab,Bb,Cb,Db), ?port(BPort) ->
-	    case inet:open(Fd,BAddr,BPort,SockOpts,tcp,inet,stream,?MODULE) of
+	    case inet:open(Fd,BAddr,BPort,SockOpts,tcp,Family,stream,?MODULE) of
 		{ok, S} ->
 		    case prim_inet:connect(S, {A,B,C,D}, Port, Time) of
 			ok    -> {ok,S};
@@ -130,9 +131,10 @@ listen(Port, Opts) ->
 	{ok, #listen_opts{fd=Fd,
 			  ifaddr=BAddr={A,B,C,D},
 			  port=BPort,
+			  family=Family,
 			  opts=SockOpts}=R}
 	when ?ip(A,B,C,D), ?port(BPort) ->
-	    case inet:open(Fd,BAddr,BPort,SockOpts,tcp,inet,stream,?MODULE) of
+	    case inet:open(Fd,BAddr,BPort,SockOpts,tcp,Family,stream,?MODULE) of
 		{ok, S} ->
 		    case prim_inet:listen(S, R#listen_opts.backlog) of
 			ok -> {ok, S};
@@ -165,4 +167,7 @@ accept(L,Timeout) ->
 %% Create a port/socket from a file descriptor 
 %%
 fdopen(Fd, Opts) ->
-    inet:fdopen(Fd, Opts, tcp, inet, stream, ?MODULE).
+    fdopen(Fd, inet:getfamily(Opts), Opts).
+
+fdopen(Fd, Family, Opts) ->
+    inet:fdopen(Fd, Opts, tcp, Family, stream, ?MODULE).

--- a/lib/kernel/src/inet_udp.erl
+++ b/lib/kernel/src/inet_udp.erl
@@ -52,8 +52,9 @@ open(Port, Opts) ->
 	{ok, #udp_opts{fd=Fd,
 		       ifaddr=BAddr={A,B,C,D},
 		       port=BPort,
+		       family=Family,
 		       opts=SockOpts}} when ?ip(A,B,C,D), ?port(BPort) ->
-	    inet:open(Fd,BAddr,BPort,SockOpts,udp,inet,dgram,?MODULE);
+	    inet:open(Fd,BAddr,BPort,SockOpts,udp,Family,dgram,?MODULE);
 	{ok, _} -> exit(badarg)
     end.
 
@@ -92,9 +93,12 @@ controlling_process(Socket, NewOwner) ->
 %% Create a port/socket from a file descriptor 
 %%
 fdopen(Fd, Opts) ->
+    fdopen(Fd, inet:getfamily(Opts), Opts).
+
+fdopen(Fd, Family, Opts) ->
     inet:fdopen(Fd, 
 		optuniquify([{recbuf, ?RECBUF} | Opts]), 
-		udp, inet, dgram, ?MODULE).
+		udp, Family, dgram, ?MODULE).
 
 
 %% Remove all duplicate options from an option list.


### PR DESCRIPTION
When a AF_LOCAL file descriptor is created externally (e.g. Unix
Domain Socket) and passed to `gen_tcp:listen(0, [{fd, FD}])`, the
implementation incorrectly assigned the address family to be equal
to `inet`, which in the inet_drv driver translated to AF_INET instead
of AF_LOCAL (or AF_UNIX), and an `einval` error code was returned.
This patch fixes this problem such that the file descriptors of the
`local` address family are supported in the inet:fdopen/5,
gen_tcp:connect/3, gen_tcp:listen/2, gen_udp:open/2 calls.

See https://github.com/saleyn/euds for examples of using this feature.