### PR TITLE
Move Route-Record AVP to the end of the AVPs list

### DIFF
--- a/lib/diameter/src/base/diameter_traffic.erl
+++ b/lib/diameter/src/base/diameter_traffic.erl
@@ -592,7 +592,7 @@ resend(false,
     Route = #diameter_avp{data = {Dict0, 'Route-Record', OH}},
     Seq = diameter_session:sequence(Mask),
     Hdr = Hdr0#diameter_header{hop_by_hop_id = Seq},
-    Msg = [Hdr, Route | Avps],
+    Msg = [Hdr|Avps++[Route]],
     resend(send_request(SvcName, App, Msg, Opts), Caps, Dict0, Pkt).
 %% The incoming request is relayed with the addition of a
 %% Route-Record. Note the requirement on the return from call/4 below,


### PR DESCRIPTION
When using Diameter application's proxy mode the Route-Record AVP is currently added on the top of AVPs list. This may cause producing invalid Diameter message that will be rejected by the destination peer, when the diameter message include fixed position AVPs, because they must be placed on the top of the Diameter message in the certain order.

```
 <STR> ::= < Diameter Header: 275, REQ, PXY >
                < Session-Id >
                { Origin-Host }
                { Origin-Realm }
                { Destination-Realm }
                { Auth-Application-Id }
                { Termination-Cause }
                [ User-Name ]
                [ Destination-Host ]
              * [ Class ]
                [ Origin-State-Id ]
              * [ Proxy-Info ]
              * [ Route-Record ]
              * [ AVP ]
```

For example: for the above message the `Route-Record` AVP will be placed before `Session-Id` AVP which is wrong.
It would be better to place `Route-Record` at the end of the Diameter message.