### PR TITLE
implement IPv6 multicast support

### DIFF
--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -864,6 +864,10 @@ static int my_strncasecmp(const char *s1, const char *s2, size_t n)
 #define INET_LOPT_MSGQ_HIWTRMRK     36  /* set local msgq high watermark */
 #define INET_LOPT_MSGQ_LOWTRMRK     37  /* set local msgq low watermark */
 #define INET_LOPT_NETNS             38  /* Network namespace pathname */
+#define UDP_OPT_IPV6_JOIN_GROUP     39  /* join an IPv6 multicast group */
+#define UDP_OPT_IPV6_LEAVE_GROUP    40  /* leave an IPv6 multicast group */
+#define UDP_OPT_IPV6_MULTICAST_IF   41  /* set IPv6 multicast interface */
+
 /* SCTP options: a separate range, from 100: */
 #define SCTP_OPT_RTOINFO		100
 #define SCTP_OPT_ASSOCINFO		101
@@ -6045,6 +6049,7 @@ static int inet_set_opts(inet_descriptor* desc, char* ptr, int len)
     struct linger li_val;
 #ifdef HAVE_MULTICAST_SUPPORT
     struct ip_mreq mreq_val;
+    struct ipv6_mreq v6_mreq_val;
 #endif
     int ival;
     char* arg_ptr;
@@ -6314,49 +6319,140 @@ static int inet_set_opts(inet_descriptor* desc, char* ptr, int len)
 	    break;
 
 #ifdef HAVE_MULTICAST_SUPPORT
-
 	case UDP_OPT_MULTICAST_TTL:
-	    proto = IPPROTO_IP;
-	    type = IP_MULTICAST_TTL;
-	    DEBUGF(("inet_set_opts(%ld): s=%d, IP_MULTICAST_TTL=%d\r\n",
-		    (long)desc->port,desc->s,ival));
-	    break;
-
 	case UDP_OPT_MULTICAST_LOOP:
-	    proto = IPPROTO_IP;
-	    type = IP_MULTICAST_LOOP;
-	    DEBUGF(("inet_set_opts(%ld): s=%d, IP_MULTICAST_LOOP=%d\r\n",
-		    (long)desc->port,desc->s,ival));
-	    break;
-
 	case UDP_OPT_MULTICAST_IF:
-	    proto = IPPROTO_IP;
-	    type = IP_MULTICAST_IF;
-	    DEBUGF(("inet_set_opts(%ld): s=%d, IP_MULTICAST_IF=%x\r\n",
-		    (long)desc->port, desc->s, ival));
-	    ival = sock_htonl(ival);
-	    break;
-
 	case UDP_OPT_ADD_MEMBERSHIP:
-	    proto = IPPROTO_IP;
-	    type = IP_ADD_MEMBERSHIP;
-	    DEBUGF(("inet_set_opts(%ld): s=%d, IP_ADD_MEMBERSHIP=%d\r\n",
-		    (long)desc->port, desc->s,ival));
-	    goto L_set_mreq;
-	    
 	case UDP_OPT_DROP_MEMBERSHIP:
-	    proto = IPPROTO_IP;
-	    type = IP_DROP_MEMBERSHIP;
-	    DEBUGF(("inet_set_opts(%ld): s=%d, IP_DROP_MEMBERSHIP=%x\r\n",
-		    (long)desc->port, desc->s, ival));
-	L_set_mreq:
-	    mreq_val.imr_multiaddr.s_addr = sock_htonl(ival);
-	    ival = get_int32(ptr);
-	    mreq_val.imr_interface.s_addr = sock_htonl(ival);
-	    ptr += 4;
-	    len -= 4;
-	    arg_ptr = (char*)&mreq_val;
-	    arg_sz = sizeof(mreq_val);
+	case UDP_OPT_IPV6_MULTICAST_IF:
+	case UDP_OPT_IPV6_JOIN_GROUP:
+	case UDP_OPT_IPV6_LEAVE_GROUP:
+	    switch (desc->sfamily) {
+	    case AF_INET:
+		switch(opt) {
+		case UDP_OPT_MULTICAST_TTL:
+		    proto = IPPROTO_IP;
+		    type = IP_MULTICAST_TTL;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IP_MULTICAST_TTL=%d\r\n",
+			    (long)desc->port,desc->s,ival));
+		    break;
+
+		case UDP_OPT_MULTICAST_LOOP:
+		    proto = IPPROTO_IP;
+		    type = IP_MULTICAST_LOOP;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IP_MULTICAST_LOOP=%d\r\n",
+			    (long)desc->port,desc->s,ival));
+		    break;
+
+		case UDP_OPT_MULTICAST_IF:
+		    proto = IPPROTO_IP;
+		    type = IP_MULTICAST_IF;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IP_MULTICAST_IF=%x\r\n",
+			    (long)desc->port, desc->s, ival));
+		    ival = sock_htonl(ival);
+		    break;
+
+		case UDP_OPT_ADD_MEMBERSHIP:
+		    proto = IPPROTO_IP;
+		    type = IP_ADD_MEMBERSHIP;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IP_ADD_MEMBERSHIP=%d\r\n",
+			    (long)desc->port, desc->s,ival));
+		    goto L_set_mreq;
+
+		case UDP_OPT_DROP_MEMBERSHIP:
+		    proto = IPPROTO_IP;
+		    type = IP_DROP_MEMBERSHIP;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IP_DROP_MEMBERSHIP=%x\r\n",
+			    (long)desc->port, desc->s, ival));
+		L_set_mreq:
+		    mreq_val.imr_multiaddr.s_addr = sock_htonl(ival);
+		    ival = get_int32(ptr);
+		    mreq_val.imr_interface.s_addr = sock_htonl(ival);
+		    ptr += 4;
+		    len -= 4;
+		    arg_ptr = (char*)&mreq_val;
+		    arg_sz = sizeof(mreq_val);
+		    break;
+
+		default:
+		    return -1;
+
+		}
+		break;
+
+#if defined(HAVE_IN6) && defined(AF_INET6)
+
+#define FILL_IFINDEX(_ifindex)						\
+    do {								\
+	struct ifreq ifr;						\
+									\
+	if (ival < 0) return -1;					\
+	if (len < ival) return -1;					\
+	memset(&ifr, 0, sizeof(ifr));					\
+	if (ival > sizeof(ifr.ifr_name) - 1) return -1;			\
+	strncpy(ifr.ifr_name, ptr, ival);				\
+	if (ioctl(desc->s, SIOCGIFINDEX, &ifr) == -1) return -1;	\
+	ptr += ival;							\
+	len -= ival;							\
+									\
+	(_ifindex) = ifr.ifr_ifindex;					\
+    } while (0)
+
+	    case AF_INET6:
+		switch(opt) {
+		case UDP_OPT_MULTICAST_TTL:
+		    proto = IPPROTO_IPV6;
+		    type = IPV6_MULTICAST_HOPS;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IPV6_MULTICAST_HOPS=%d\r\n",
+			    (long)desc->port,desc->s,ival));
+		    break;
+
+		case UDP_OPT_MULTICAST_LOOP:
+		    proto = IPPROTO_IPV6;
+		    type = IPV6_MULTICAST_LOOP;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IPV6_MULTICAST_LOOP=%d\r\n",
+			    (long)desc->port,desc->s,ival));
+		    break;
+
+		case UDP_OPT_IPV6_MULTICAST_IF:
+		    proto = IPPROTO_IPV6;
+		    type = IPV6_MULTICAST_IF;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IPV6_MULTICAST_IF=%x\r\n",
+			    (long)desc->port, desc->s, ival));
+		    FILL_IFINDEX(ival);
+		    break;
+
+		case UDP_OPT_IPV6_JOIN_GROUP:
+		    proto = IPPROTO_IPV6;
+		    type = IPV6_JOIN_GROUP;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IPV6_JOIN_GROUP=%x\r\n",
+			    (long)desc->port, desc->s,ival));
+		    goto L_set_v6_mreq;
+
+		case UDP_OPT_IPV6_LEAVE_GROUP:
+		    proto = IPPROTO_IPV6;
+		    type = IPV6_LEAVE_GROUP;
+		    DEBUGF(("inet_set_opts(%ld): s=%d, IPV6_LEAVE_GROUP=%x\r\n",
+			    (long)desc->port, desc->s, ival));
+		L_set_v6_mreq:
+		    FILL_IFINDEX(v6_mreq_val.ipv6mr_interface);
+		    if (len < sizeof(struct in6_addr)) return -1;
+		    v6_mreq_val.ipv6mr_multiaddr = *(struct in6_addr *)ptr;
+		    ptr += sizeof(struct in6_addr);
+		    len -= sizeof(struct in6_addr);
+		    arg_ptr = (char*)&v6_mreq_val;
+		    arg_sz = sizeof(v6_mreq_val);
+		    break;
+#endif
+
+		default:
+		    return -1;
+		}
+		break;
+
+	    default:
+		return -1;
+	    }
 	    break;
 
 #endif /* HAVE_MULTICAST_SUPPORT */

--- a/lib/kernel/doc/src/gen_udp.xml
+++ b/lib/kernel/doc/src/gen_udp.xml
@@ -136,12 +136,27 @@
 
 		  <tag><c>{add_membership, {MultiAddress, InterfaceAddress}}</c></tag>
           <item>
-			  <p>Join a multicast group. </p>
+			  <p>Join a IPv4 multicast group. </p>
           </item>
 
 		  <tag><c>{drop_membership, {MultiAddress, InterfaceAddress}}</c></tag>
           <item>
-			  <p>Leave multicast group.</p>
+			  <p>Leave IPv4 multicast group.</p>
+          </item>
+
+          <tag><c>{ipv6_multicast_if, IfName}</c></tag>
+          <item>
+	      <p>Set the local device for a IPv6 multicast socket.</p>
+          </item>
+
+	  <tag><c>{ipv6_join_group, {IfName, MultiAddress}}</c></tag>
+          <item>
+	      <p>Join a IPv6 multicast group. </p>
+          </item>
+
+	  <tag><c>{ipv6_leave_group, {IfName, MultiAddress}}</c></tag>
+          <item>
+	      <p>Leave IPv6 multicast group.</p>
           </item>
 
           <tag><c>Opt</c></tag>

--- a/lib/kernel/src/gen_udp.erl
+++ b/lib/kernel/src/gen_udp.erl
@@ -27,17 +27,17 @@
 
 -type option() ::
         {active,          true | false | once | -32768..32767} |
-        {add_membership,  {inet:ip_address(), inet:ip_address()}} |
+        {add_membership,  {inet:ip4_address(), inet:ip4_address()}} |
         {broadcast,       boolean()} |
         {buffer,          non_neg_integer()} |
         {deliver,         port | term} |
         {dontroute,       boolean()} |
-        {drop_membership, {inet:ip_address(), inet:ip_address()}} |
+        {drop_membership, {inet:ip4_address(), inet:ip4_address()}} |
         {header,          non_neg_integer()} |
         {high_msgq_watermark, pos_integer()} |
         {low_msgq_watermark, pos_integer()} |
         {mode,            list | binary} | list | binary |
-        {multicast_if,    inet:ip_address()} |
+        {multicast_if,    inet:ip4_address()} |
         {multicast_loop,  boolean()} |
         {multicast_ttl,   non_neg_integer()} |
         {priority,        non_neg_integer()} |
@@ -50,6 +50,9 @@
         {reuseaddr,       boolean()} |
         {sndbuf,          non_neg_integer()} |
         {tos,             non_neg_integer()} |
+        {ipv6_multicast_if, binary()} |
+        {ipv6_join_group,  {binary(), inet:ip6_address()}} |
+        {ipv6_leave_group, {binary(), inet:ip6_address()}} |
 	{ipv6_v6only,     boolean()}.
 -type option_name() ::
         active |

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -808,8 +808,8 @@ udp_options() ->
     [tos, priority, reuseaddr, sndbuf, recbuf, header, active, buffer, mode, 
      deliver, ipv6_v6only,
      broadcast, dontroute, multicast_if, multicast_ttl, multicast_loop,
-     add_membership, drop_membership, read_packets,raw,
-     high_msgq_watermark, low_msgq_watermark].
+     add_membership, drop_membership, ipv6_multicast_if, ipv6_join_group, ipv6_leave_group,
+     read_packets, raw, high_msgq_watermark, low_msgq_watermark].
 
 
 udp_options(Opts, Family) ->

--- a/lib/kernel/src/inet_int.hrl
+++ b/lib/kernel/src/inet_int.hrl
@@ -147,6 +147,9 @@
 -define(INET_LOPT_MSGQ_HIWTRMRK,  36).
 -define(INET_LOPT_MSGQ_LOWTRMRK,  37).
 -define(INET_LOPT_NETNS,          38).
+-define(UDP_OPT_IPV6_JOIN_GROUP,  39).
+-define(UDP_OPT_IPV6_LEAVE_GROUP,  40).
+-define(UDP_OPT_IPV6_MULTICAST_IF, 41).
 % Specific SCTP options: separate range:
 -define(SCTP_OPT_RTOINFO,	 	100).
 -define(SCTP_OPT_ASSOCINFO,	 	101).


### PR DESCRIPTION
Implement support for ipv6_join_group, ipv6_leave_group, ipv6_multicast_if,
multicast_ttl and multicast_loop UDP socket options for IPV6 sockets.

IPv6 multicast group membership socket options are suffcient different
from IPv4 to require an new socket option.