### PR TITLE
Properly lint map expressions in erl_lint

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2288,8 +2288,8 @@ map_fields([{Tag,_,K,V}|Fs], Vt, St, F) when Tag =:= map_field_assoc;
     {Pvt,St2} = F([K,V], Vt, St),
     {Vts,St3} = map_fields(Fs, Vt, St2, F),
     {vtupdate(Pvt, Vts),St3};
-map_fields([], Vt, St, _) ->
-  {Vt,St}.
+map_fields([], _, St, _) ->
+  {[],St}.
 
 %% warn_invalid_record(Line, Record, State0) -> State
 %% Adds warning if the record is invalid.

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -3708,7 +3708,13 @@ maps(Config) ->
 	   ">>,
 	   [],
 	   {errors,[{4,erl_lint,illegal_map_construction},
-		    {6,erl_lint,illegal_map_key}],[]}}],
+                    {6,erl_lint,illegal_map_key}],[]}},
+          {unused_vars_with_empty_maps,
+           <<"t(Foo, Bar, Baz) -> {#{},#{}}.">>,
+           [warn_unused_variables],
+           {warnings,[{1,erl_lint,{unused_var,'Bar'}},
+                      {1,erl_lint,{unused_var,'Baz'}},
+                      {1,erl_lint,{unused_var,'Foo'}}]}}],
     [] = run(Config, Ts),
     ok.
 


### PR DESCRIPTION
The returned variable table when linting a map expression shouldn't include variables that didn't appear in the expression.

@alco