### PR TITLE
Remove a few superfluous vt operations in erl_lint

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2266,11 +2266,10 @@ expr({remote,Line,_M,_F}, _Vt, St) ->
 %%      {UsedVarTable,State}
 
 expr_list(Es, Vt, St) ->
-    {Vt1,St1} = foldl(fun (E, {Esvt,St0}) ->
-                              {Evt,St1} = expr(E, Vt, St0),
-                              {vtmerge_pat(Evt, Esvt),St1}
-                      end, {[],St}, Es),
-    {vtmerge(vtnew(Vt1, Vt), vtold(Vt1, Vt)),St1}.
+    foldl(fun (E, {Esvt,St0}) ->
+                  {Evt,St1} = expr(E, Vt, St0),
+                  {vtmerge_pat(Evt, Esvt),St1}
+          end, {[],St}, Es).
 
 record_expr(Line, Rec, Vt, St0) ->
     St1 = warn_invalid_record(Line, Rec, St0),


### PR DESCRIPTION
Given any Vt1 and Vt2 values, vtmerge(vtnew(Vt1, Vt2), vtold(Vt1, Vt2)) is always equal to Vt1.