### PR TITLE
ssl: Add TLS-ALPN support

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -89,6 +89,8 @@
       |{dh, der_encoded()} | {dhfile, path()} | {ciphers, ciphers()} |
       {user_lookup_fun, {fun(), term()}}, {psk_identity, string()}, {srp_identity, {string(), string()}} |
       {ssl_imp, ssl_imp()} | {reuse_sessions, boolean()} | {reuse_session, fun()}
+      {alpn_advertised_protocols, [binary()]} |
+      {alpn_preferred_protocols, [binary()]} |
       {next_protocols_advertised, [binary()]} |
       {client_preferred_next_protocols, {client | server, [binary()]} | {client | server, [binary()], binary()}} |
       {log_alert, boolean()} | {server_name_indication, hostname() | disable}
@@ -388,7 +390,20 @@ fun(srp, Username :: string(), UserState :: term()) ->
       certificates are used during server authentication and when building the
       client certificate chain.
      </item>
-  
+
+      <tag>{alpn_advertised_protocols, [binary()]}</tag>
+      <item>
+      <p>The list of protocols supported by the client to be sent to the
+      server to be used for an Application-Layer Protocol Negotiation (ALPN).
+      If the server supports ALPN then it will choose a protocol from this
+      list; otherwise it will fail the connection with a "no_application_protocol"
+      alert. A server that does not support ALPN will ignore this value.</p>
+
+      <p>The list of protocols must not contain an empty binary.</p>
+
+      <p>The negotiated protocol can be retrieved using the <c>negotiated_protocol/1</c> function.</p>
+      </item>
+
       <tag>{client_preferred_next_protocols, {Precedence :: server | client, ClientPrefs :: [binary()]}}</tag>
       <tag>{client_preferred_next_protocols, {Precedence :: server | client, ClientPrefs :: [binary()], Default :: binary()}}</tag>
 	   <item>
@@ -508,12 +523,25 @@ fun(srp, Username :: string(), UserState :: term()) ->
       and CipherSuite is of type ciphersuite().
     </item>
 
+      <tag>{alpn_preferred_protocols, [binary()]}</tag>
+      <item>
+      <p>Indicates the server will try to perform Application-Layer
+      Protocol Negotiation (ALPN).</p>
+
+      <p>The list of protocols is in order of preference. The protocol
+      negotiated will be the first in the list that matches one of the
+      protocols advertised by the client. If no protocol matches, the
+      server will fail the connection with a "no_application_protocol" alert.</p>
+
+      <p>The negotiated protocol can be retrieved using the <c>negotiated_protocol/1</c> function.</p>
+      </item>
+
       <tag>{next_protocols_advertised, Protocols :: [binary()]}</tag>
       <item>The list of protocols to send to the client if the client indicates
       it supports the Next Protocol extension. The client may select a protocol
       that is not on this list. The list of protocols must not contain an empty
       binary. If the server negotiates a Next Protocol it can be accessed
-      using <c>negotiated_next_protocol/1</c> method.
+      using <c>negotiated_protocol/1</c> function.
       </item>
 
       <tag>{psk_identity, string()}</tag>
@@ -981,15 +1009,15 @@ fun(srp, Username :: string(), UserState :: term()) ->
       </desc>
     </func>
     <func>
-      <name>negotiated_next_protocol(Socket) -> {ok, Protocol} | {error, next_protocol_not_negotiated}</name>
-      <fsummary>Returns the Next Protocol negotiated.</fsummary>
+      <name>negotiated_protocol(Socket) -> {ok, Protocol} | {error, protocol_not_negotiated}</name>
+      <fsummary>Returns the protocol negotiated through ALPN or NPN extensions.</fsummary>
       <type>
         <v>Socket = sslsocket()</v>
         <v>Protocol = binary()</v>
       </type>
       <desc>
         <p>
-          Returns the Next Protocol negotiated.
+          Returns the protocol negotiated through ALPN or NPN extensions.
         </p>
       </desc>
     </func>

--- a/lib/ssl/src/dtls_connection.erl
+++ b/lib/ssl/src/dtls_connection.erl
@@ -227,9 +227,9 @@ hello(Hello,
     case dtls_handshake:hello(Hello, SslOptions, ConnectionStates0, Renegotiation) of
 	#alert{} = Alert ->
 	    handle_own_alert(Alert, ReqVersion, hello, State);
-	{Version, NewId, ConnectionStates, NextProtocol} ->
+	{Version, NewId, ConnectionStates, ProtoExt, Protocol} ->
 	    ssl_connection:handle_session(Hello, 
-					  Version, NewId, ConnectionStates, NextProtocol, State)
+					  Version, NewId, ConnectionStates, ProtoExt, Protocol, State)
     end;
 
 hello(Msg, State) ->

--- a/lib/ssl/src/dtls_handshake.erl
+++ b/lib/ssl/src/dtls_handshake.erl
@@ -181,8 +181,8 @@ handle_server_hello_extensions(Version, SessionId, Random, CipherSuite,
 						      SslOpt, ConnectionStates0, Renegotiation) of
 	#alert{} = Alert ->
 	    Alert;
-	{ConnectionStates, Protocol} ->
-	    {Version, SessionId, ConnectionStates, Protocol}
+	{ConnectionStates, ProtoExt, Protocol} ->
+	    {Version, SessionId, ConnectionStates, ProtoExt, Protocol}
     end.
 
 dtls_fragment(Mss, MsgType, Len, MsgSeq, Bin, Offset, Acc)

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -38,9 +38,11 @@
 %% SSL/TLS protocol handling
 -export([cipher_suites/0, cipher_suites/1, suite_definition/1,
 	 connection_info/1, versions/0, session_info/1, format_error/1,
-	 renegotiate/1, prf/5, negotiated_next_protocol/1]).
+	 renegotiate/1, prf/5, negotiated_protocol/1, negotiated_next_protocol/1]).
 %% Misc
 -export([random_bytes/1]).
+
+-deprecated({negotiated_next_protocol, 1, next_major_release}).
 
 -include("ssl_api.hrl").
 -include("ssl_internal.hrl").
@@ -330,13 +332,27 @@ suite_definition(S) ->
     {KeyExchange, Cipher, Hash}.
 
 %%--------------------------------------------------------------------
+-spec negotiated_protocol(#sslsocket{}) -> {ok, binary()} | {error, reason()}.
+%%
+%% Description: Returns the protocol that has been negotiated. If no
+%% protocol has been negotiated will return {error, protocol_not_negotiated}
+%%--------------------------------------------------------------------
+negotiated_protocol(#sslsocket{pid = Pid}) ->
+    ssl_connection:negotiated_protocol(Pid).
+
+%%--------------------------------------------------------------------
 -spec negotiated_next_protocol(#sslsocket{}) -> {ok, binary()} | {error, reason()}.
 %%
 %% Description: Returns the next protocol that has been negotiated. If no
 %% protocol has been negotiated will return {error, next_protocol_not_negotiated}
 %%--------------------------------------------------------------------
-negotiated_next_protocol(#sslsocket{pid = Pid}) ->
-    ssl_connection:negotiated_next_protocol(Pid).
+negotiated_next_protocol(Socket) ->
+    case negotiated_protocol(Socket) of
+        {error, protocol_not_negotiated} ->
+            {error, next_protocol_not_negotiated};
+        Res ->
+            Res
+    end.
 
 %%--------------------------------------------------------------------
 -spec cipher_suites(erlang | openssl | all) -> [ssl_cipher:erl_cipher_suite()] |
@@ -644,6 +660,10 @@ handle_options(Opts0) ->
 		    renegotiate_at = handle_option(renegotiate_at, Opts, ?DEFAULT_RENEGOTIATE_AT),
 		    hibernate_after = handle_option(hibernate_after, Opts, undefined),
 		    erl_dist = handle_option(erl_dist, Opts, false),
+		    alpn_advertised_protocols =
+			handle_option(alpn_advertised_protocols, Opts, undefined),
+		    alpn_preferred_protocols =
+			handle_option(alpn_preferred_protocols, Opts, undefined),
 		    next_protocols_advertised =
 			handle_option(next_protocols_advertised, Opts, undefined),
 		    next_protocol_selector =
@@ -665,7 +685,8 @@ handle_options(Opts0) ->
 		  user_lookup_fun, psk_identity, srp_identity, ciphers,
 		  reuse_session, reuse_sessions, ssl_imp,
 		  cb_info, renegotiate_at, secure_renegotiate, hibernate_after,
-		  erl_dist, next_protocols_advertised,
+		  erl_dist, alpn_advertised_protocols,
+		  alpn_preferred_protocols, next_protocols_advertised,
 		  client_preferred_next_protocols, log_alert,
 		  server_name_indication, honor_cipher_order, padding_check,
 		  fallback],
@@ -801,6 +822,20 @@ validate_option(hibernate_after, Value) when is_integer(Value), Value >= 0 ->
     Value;
 validate_option(erl_dist,Value) when is_boolean(Value) ->
     Value;
+validate_option(Opt, Value)
+  when Opt =:= alpn_advertised_protocols orelse Opt =:= alpn_preferred_protocols,
+       is_list(Value) ->
+    case tls_record:highest_protocol_version([]) of
+	{3,0} ->
+	    throw({error, {options, {not_supported_in_sslv3, {Opt, Value}}}});
+	_ ->
+	    validate_binary_list(Opt, Value),
+	    Value
+    end;
+validate_option(Opt, Value)
+  when Opt =:= alpn_advertised_protocols orelse Opt =:= alpn_preferred_protocols,
+       Value =:= undefined ->
+    undefined;
 validate_option(client_preferred_next_protocols = Opt, {Precedence, PreferredProtocols} = Value)
   when is_list(PreferredProtocols) ->
     case tls_record:highest_protocol_version([]) of
@@ -1123,6 +1158,10 @@ new_ssl_options([{secure_renegotiate, Value} | Rest], #ssl_options{} = Opts, Rec
     new_ssl_options(Rest, Opts#ssl_options{secure_renegotiate = validate_option(secure_renegotiate, Value)}, RecordCB); 
 new_ssl_options([{hibernate_after, Value} | Rest], #ssl_options{} = Opts, RecordCB) -> 
     new_ssl_options(Rest, Opts#ssl_options{hibernate_after = validate_option(hibernate_after, Value)}, RecordCB);
+new_ssl_options([{alpn_advertised_protocols, Value} | Rest], #ssl_options{} = Opts, RecordCB) ->
+	new_ssl_options(Rest, Opts#ssl_options{alpn_advertised_protocols = validate_option(alpn_advertised_protocols, Value)}, RecordCB);
+new_ssl_options([{alpn_preferred_protocols, Value} | Rest], #ssl_options{} = Opts, RecordCB) ->
+	new_ssl_options(Rest, Opts#ssl_options{alpn_preferred_protocols = validate_option(alpn_preferred_protocols, Value)}, RecordCB);
 new_ssl_options([{next_protocols_advertised, Value} | Rest], #ssl_options{} = Opts, RecordCB) -> 
     new_ssl_options(Rest, Opts#ssl_options{next_protocols_advertised = validate_option(next_protocols_advertised, Value)}, RecordCB);
 new_ssl_options([{client_preferred_next_protocols, Value} | Rest], #ssl_options{} = Opts, RecordCB) -> 

--- a/lib/ssl/src/ssl_alert.erl
+++ b/lib/ssl/src/ssl_alert.erl
@@ -163,5 +163,7 @@ description_txt(?UNKNOWN_PSK_IDENTITY) ->
     "unknown psk identity";
 description_txt(?INAPPROPRIATE_FALLBACK) ->
     "inappropriate fallback";
+description_txt(?NO_APPLICATION_PROTOCOL) ->
+    "no application protocol";
 description_txt(Enum) ->
     lists:flatten(io_lib:format("unsupported/unknown alert: ~p", [Enum])).

--- a/lib/ssl/src/ssl_alert.hrl
+++ b/lib/ssl/src/ssl_alert.hrl
@@ -69,6 +69,8 @@
 %%         bad_certificate_hash_value(114),      
 %% RFC 4366
 %%       unknown_psk_identity(115),
+%% RFC 7301
+%%       no_application_protocol(120),
 %%           (255)
 %%       } AlertDescription;
 
@@ -103,6 +105,7 @@
 -define(BAD_CERTIFICATE_STATUS_RESPONSE, 113).
 -define(BAD_CERTIFICATE_HASH_VALUE, 114).
 -define(UNKNOWN_PSK_IDENTITY, 115).
+-define(NO_APPLICATION_PROTOCOL, 120).
 
 -define(ALERT_REC(Level,Desc), #alert{level=Level,description=Desc,where={?FILE, ?LINE}}).
 

--- a/lib/ssl/src/ssl_api.hrl
+++ b/lib/ssl/src/ssl_api.hrl
@@ -49,6 +49,8 @@
                          {srp_identity, {string(), string()}} |
                          {ciphers, ciphers()} | {ssl_imp, ssl_imp()} | {reuse_sessions, boolean()} |
                          {reuse_session, fun()} | {hibernate_after, integer()|undefined} |
+                         {alpn_advertised_protocols, [binary()]} |
+                         {alpn_preferred_protocols, [binary()]} |
                          {next_protocols_advertised, list(binary())} |
                          {client_preferred_next_protocols, binary(), client | server, list(binary())}.
 

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -42,10 +42,10 @@
 %% User Events 
 -export([send/2, recv/3, close/1, shutdown/2,
 	 new_user/2, get_opts/2, set_opts/2, info/1, session_info/1, 
-	 peer_certificate/1, renegotiation/1, negotiated_next_protocol/1, prf/5	
+	 peer_certificate/1, renegotiation/1, negotiated_protocol/1, prf/5
 	]).
 
--export([handle_session/6]).
+-export([handle_session/7]).
 
 %% SSL FSM state functions 
 -export([hello/3, abbreviated/3, certify/3, cipher/3, connection/3]).
@@ -191,12 +191,12 @@ new_user(ConnectionPid, User) ->
     sync_send_all_state_event(ConnectionPid, {new_user, User}).
 
 %%--------------------------------------------------------------------
--spec negotiated_next_protocol(pid()) -> {ok, binary()} | {error, reason()}.
+-spec negotiated_protocol(pid()) -> {ok, binary()} | {error, reason()}.
 %%
 %% Description:  Returns the negotiated protocol
 %%--------------------------------------------------------------------
-negotiated_next_protocol(ConnectionPid) ->
-    sync_send_all_state_event(ConnectionPid, negotiated_next_protocol).
+negotiated_protocol(ConnectionPid) ->
+    sync_send_all_state_event(ConnectionPid, negotiated_protocol).
 
 %%--------------------------------------------------------------------
 -spec get_opts(pid(), list()) -> {ok, list()} | {error, reason()}.    
@@ -258,27 +258,26 @@ prf(ConnectionPid, Secret, Label, Seed, WantedLength) ->
 
 handle_session(#server_hello{cipher_suite = CipherSuite,
 			     compression_method = Compression}, 
-	       Version, NewId, ConnectionStates, NextProtocol, 
+	       Version, NewId, ConnectionStates, ProtoExt, Protocol0,
 	       #state{session = #session{session_id = OldId},
-		      negotiated_version = ReqVersion} = State0) ->
+		      negotiated_version = ReqVersion,
+			  negotiated_protocol = CurrentProtocol} = State0) ->
     {KeyAlgorithm, _, _, _} =
 	ssl_cipher:suite_definition(CipherSuite),
     
     PremasterSecret = make_premaster_secret(ReqVersion, KeyAlgorithm),
-    
-    NewNextProtocol = case NextProtocol of
-			  undefined ->
-			      State0#state.next_protocol;
-			  _ ->
-			      NextProtocol
-		      end,
-    
+
+	{ExpectNPN, Protocol} = case Protocol0 of
+		undefined -> {false, CurrentProtocol};
+		_ -> {ProtoExt =:= npn, Protocol0}
+	end,
+
     State = State0#state{key_algorithm = KeyAlgorithm,
 				 negotiated_version = Version,
 			 connection_states = ConnectionStates,
 			 premaster_secret = PremasterSecret,
-			 expecting_next_protocol_negotiation = NextProtocol =/= undefined,
-			 next_protocol = NewNextProtocol},
+			 expecting_next_protocol_negotiation = ExpectNPN,
+			 negotiated_protocol = Protocol},
     
     case ssl_session:is_new(OldId, NewId) of
 	true ->
@@ -371,7 +370,7 @@ abbreviated(#finished{verify_data = Data} = Finished,
 abbreviated(#next_protocol{selected_protocol = SelectedProtocol},
 	    #state{role = server, expecting_next_protocol_negotiation = true} = State0,
 	    Connection) ->
-    {Record, State} = Connection:next_record(State0#state{next_protocol = SelectedProtocol}),
+    {Record, State} = Connection:next_record(State0#state{negotiated_protocol = SelectedProtocol}),
     Connection:next_state(abbreviated, abbreviated, Record, State#state{expecting_next_protocol_negotiation = false});
 
 abbreviated(timeout, State, _) ->
@@ -589,7 +588,7 @@ cipher(#certificate_verify{signature = Signature, hashsign_algorithm = CertHashS
 
 %% client must send a next protocol message if we are expecting it
 cipher(#finished{}, #state{role = server, expecting_next_protocol_negotiation = true,
-			   next_protocol = undefined, negotiated_version = Version} = State0,
+			   negotiated_protocol = undefined, negotiated_version = Version} = State0,
        Connection) ->
     Connection:handle_own_alert(?ALERT_REC(?FATAL,?UNEXPECTED_MESSAGE), Version, cipher, State0);
 
@@ -619,7 +618,7 @@ cipher(#finished{verify_data = Data} = Finished,
 cipher(#next_protocol{selected_protocol = SelectedProtocol},
        #state{role = server, expecting_next_protocol_negotiation = true,
 	      expecting_finished = true} = State0, Connection) ->
-    {Record, State} = Connection:next_record(State0#state{next_protocol = SelectedProtocol}),
+    {Record, State} = Connection:next_record(State0#state{negotiated_protocol = SelectedProtocol}),
     Connection:next_state(cipher, cipher, Record, State#state{expecting_next_protocol_negotiation = false});
 
 cipher(timeout, State, _) ->
@@ -755,10 +754,10 @@ handle_sync_event({get_opts, OptTags}, _From, StateName,
 			 socket_options = SockOpts} = State) ->
     OptsReply = get_socket_opts(Transport, Socket, OptTags, SockOpts, []),
     {reply, OptsReply, StateName, State, get_timeout(State)};
-handle_sync_event(negotiated_next_protocol, _From, StateName, #state{next_protocol = undefined} = State) ->
-    {reply, {error, next_protocol_not_negotiated}, StateName, State, get_timeout(State)};
-handle_sync_event(negotiated_next_protocol, _From, StateName, #state{next_protocol = NextProtocol} = State) ->
-    {reply, {ok, NextProtocol}, StateName, State, get_timeout(State)};
+handle_sync_event(negotiated_protocol, _From, StateName, #state{negotiated_protocol = undefined} = State) ->
+    {reply, {error, protocol_not_negotiated}, StateName, State, get_timeout(State)};
+handle_sync_event(negotiated_protocol, _From, StateName, #state{negotiated_protocol = SelectedProtocol} = State) ->
+    {reply, {ok, SelectedProtocol}, StateName, State, get_timeout(State)};
 handle_sync_event({set_opts, Opts0}, _From, StateName0, 
 		  #state{socket_options = Opts1, 
 			 protocol_cb = Connection,
@@ -1479,11 +1478,11 @@ finalize_handshake(State0, StateName, Connection) ->
 
 next_protocol(#state{role = server} = State, _) ->
     State;
-next_protocol(#state{next_protocol = undefined} = State, _) ->
+next_protocol(#state{negotiated_protocol = undefined} = State, _) ->
     State;
 next_protocol(#state{expecting_next_protocol_negotiation = false} = State, _) ->
     State;
-next_protocol(#state{next_protocol = NextProtocol} = State0, Connection) ->
+next_protocol(#state{negotiated_protocol = NextProtocol} = State0, Connection) ->
     NextProtocolMessage = ssl_handshake:next_protocol(NextProtocol),
     Connection:send_handshake(NextProtocolMessage, State0).
 

--- a/lib/ssl/src/ssl_connection.hrl
+++ b/lib/ssl/src/ssl_connection.hrl
@@ -78,7 +78,7 @@
 	  allow_renegotiate = true                    ::boolean(),
           expecting_next_protocol_negotiation = false ::boolean(),
 	  expecting_finished =                  false ::boolean(),
-          next_protocol = undefined                   :: undefined | binary(),
+          negotiated_protocol = undefined             :: undefined | binary(),
 	  client_ecc,          % {Curves, PointFmt}
 	  tracker              :: pid() %% Tracker process for listen socket
 	 }).

--- a/lib/ssl/src/ssl_handshake.hrl
+++ b/lib/ssl/src/ssl_handshake.hrl
@@ -95,6 +95,7 @@
 -record(hello_extensions, {
 	  renegotiation_info,
 	  hash_signs,          % supported combinations of hashes/signature algos
+          alpn,
 	  next_protocol_negotiation = undefined, % [binary()]
 	  srp,
 	  ec_point_formats,
@@ -299,6 +300,14 @@
 -record(hash_sign_algos, {
 	  hash_sign_algos
 	 }).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Application-Layer Protocol Negotiation  RFC 7301
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-define(ALPN_EXT, 16).
+
+-record(alpn, {extension_data}).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Next Protocol Negotiation

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -114,6 +114,8 @@
 	  hibernate_after      :: boolean(),
 	  %% This option should only be set to true by inet_tls_dist
 	  erl_dist = false     :: boolean(),
+          alpn_advertised_protocols = undefined :: [binary()],
+          alpn_preferred_protocols = undefined :: [binary()],
 	  next_protocols_advertised = undefined, %% [binary()],
 	  next_protocol_selector = undefined,  %% fun([binary()]) -> binary())
 	  log_alert             :: boolean(),

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -246,8 +246,10 @@ handle_client_hello_extensions(Version, Type, Random, CipherSuites,
     try ssl_handshake:handle_client_hello_extensions(tls_record, Random, CipherSuites,
 						     HelloExt, Version, SslOpts,
 						     Session0, ConnectionStates0, Renegotiation) of
-	{Session, ConnectionStates, ServerHelloExt} ->
-	    {Version, {Type, Session}, ConnectionStates, ServerHelloExt}
+	#alert{} = Alert ->
+	    Alert;
+	{Session, ConnectionStates, Protocol, ServerHelloExt} ->
+	    {Version, {Type, Session}, ConnectionStates, Protocol, ServerHelloExt}
     catch throw:Alert ->
 	    Alert
     end.
@@ -260,7 +262,7 @@ handle_server_hello_extensions(Version, SessionId, Random, CipherSuite,
 						      SslOpt, ConnectionStates0, Renegotiation) of
 	#alert{} = Alert ->
 	    Alert;
-	{ConnectionStates, Protocol} ->
-	    {Version, SessionId, ConnectionStates, Protocol}
+	{ConnectionStates, ProtoExt, Protocol} ->
+	    {Version, SessionId, ConnectionStates, ProtoExt, Protocol}
     end.
 

--- a/lib/ssl/test/Makefile
+++ b/lib/ssl/test/Makefile
@@ -36,6 +36,7 @@ VSN=$(GS_VSN)
 
 MODULES = \
 	ssl_test_lib \
+	ssl_alpn_handshake_SUITE \
 	ssl_basic_SUITE \
 	ssl_bench_SUITE \
 	ssl_cipher_SUITE \

--- a/lib/ssl/test/ssl_alpn_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_alpn_handshake_SUITE.erl
@@ -1,0 +1,414 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2008-2015. All Rights Reserved.
+%%
+%% The contents of this file are subject to the Erlang Public License,
+%% Version 1.1, (the "License"); you may not use this file except in
+%% compliance with the License. You should have received a copy of the
+%% Erlang Public License along with this software. If not, it can be
+%% retrieved online at http://www.erlang.org/.
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+-module(ssl_alpn_handshake_SUITE).
+
+%% Note: This directive should only be used in test suites.
+-compile(export_all).
+-include_lib("common_test/include/ct.hrl").
+
+-define(SLEEP, 500).
+
+%%--------------------------------------------------------------------
+%% Common Test interface functions -----------------------------------
+%%--------------------------------------------------------------------
+
+suite() -> [{ct_hooks,[ts_install_cth]}].
+
+all() ->
+    [{group, 'tlsv1.2'},
+     {group, 'tlsv1.1'},
+     {group, 'tlsv1'},
+     {group, 'sslv3'}].
+
+groups() ->
+    [
+     {'tlsv1.2', [], alpn_tests()},
+     {'tlsv1.1', [], alpn_tests()},
+     {'tlsv1', [], alpn_tests()},
+     {'sslv3', [], alpn_not_supported()}
+    ].
+
+alpn_tests() ->
+    [empty_protocols_are_not_allowed,
+     protocols_must_be_a_binary_list,
+     empty_client,
+     empty_server,
+     empty_client_empty_server,
+     no_matching_protocol,
+     client_alpn_and_server_alpn,
+     client_alpn_and_server_no_support,
+     client_no_support_and_server_alpn,
+     client_alpn_npn_and_server_alpn,
+     client_alpn_npn_and_server_alpn_npn,
+     client_alpn_and_server_alpn_npn,
+     client_renegotiate,
+     session_reused
+    ].
+
+alpn_not_supported() ->
+    [alpn_not_supported_client,
+     alpn_not_supported_server
+    ].
+
+init_per_suite(Config) ->
+    catch crypto:stop(),
+    try crypto:start() of
+	ok ->
+	    ssl:start(),
+	    Result =
+		(catch make_certs:all(?config(data_dir, Config),
+				      ?config(priv_dir, Config))),
+	    ct:log("Make certs  ~p~n", [Result]),
+	    ssl_test_lib:cert_options(Config)
+    catch _:_ ->
+	    {skip, "Crypto did not start"}
+    end.
+
+end_per_suite(_Config) ->
+    ssl:stop(),
+    application:unload(ssl),
+    application:stop(crypto).
+
+
+init_per_group(GroupName, Config) ->
+    case ssl_test_lib:is_tls_version(GroupName) of
+	true ->
+	    case ssl_test_lib:sufficient_crypto_support(GroupName) of
+		true ->
+		    ssl_test_lib:init_tls_version(GroupName),
+		    Config;
+		false ->
+		    {skip, "Missing crypto support"}
+	    end;
+	_ ->
+	    ssl:start(),
+	    Config
+    end.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Test Cases --------------------------------------------------------
+%%--------------------------------------------------------------------
+
+empty_protocols_are_not_allowed(Config) when is_list(Config) ->
+    {error, {options, {alpn_preferred_protocols, {invalid_protocol, <<>>}}}}
+	= (catch ssl:listen(9443,
+			    [{alpn_preferred_protocols, [<<"foo/1">>, <<"">>]}])),
+    {error, {options, {alpn_advertised_protocols, {invalid_protocol, <<>>}}}}
+	= (catch ssl:connect({127,0,0,1}, 9443,
+			     [{alpn_advertised_protocols, [<<"foo/1">>, <<"">>]}])).
+
+%--------------------------------------------------------------------------------
+
+protocols_must_be_a_binary_list(Config) when is_list(Config) ->
+    Option1 = {alpn_preferred_protocols, hello},
+    {error, {options, Option1}} = (catch ssl:listen(9443, [Option1])),
+    Option2 = {alpn_preferred_protocols, [<<"foo/1">>, hello]},
+    {error, {options, {alpn_preferred_protocols, {invalid_protocol, hello}}}}
+        = (catch ssl:listen(9443, [Option2])),
+    Option3 = {alpn_advertised_protocols, hello},
+    {error, {options, Option3}} = (catch ssl:connect({127,0,0,1}, 9443, [Option3])),
+    Option4 = {alpn_advertised_protocols, [<<"foo/1">>, hello]},
+    {error, {options, {alpn_advertised_protocols, {invalid_protocol, hello}}}}
+        = (catch ssl:connect({127,0,0,1}, 9443, [Option4])).
+
+%--------------------------------------------------------------------------------
+
+empty_client(Config) when is_list(Config) ->
+    run_failing_handshake(Config,
+        [{alpn_advertised_protocols, []}],
+        [{alpn_preferred_protocols, [<<"spdy/2">>, <<"spdy/3">>, <<"http/2">>]}],
+        {connect_failed,{tls_alert,"no application protocol"}}).
+
+%--------------------------------------------------------------------------------
+
+empty_server(Config) when is_list(Config) ->
+    run_failing_handshake(Config,
+        [{alpn_advertised_protocols, [<<"http/1.0">>, <<"http/1.1">>]}],
+        [{alpn_preferred_protocols, []}],
+        {connect_failed,{tls_alert,"no application protocol"}}).
+
+%--------------------------------------------------------------------------------
+
+empty_client_empty_server(Config) when is_list(Config) ->
+    run_failing_handshake(Config,
+        [{alpn_advertised_protocols, []}],
+        [{alpn_preferred_protocols, []}],
+        {connect_failed,{tls_alert,"no application protocol"}}).
+
+%--------------------------------------------------------------------------------
+
+no_matching_protocol(Config) when is_list(Config) ->
+    run_failing_handshake(Config,
+        [{alpn_advertised_protocols, [<<"http/1.0">>, <<"http/1.1">>]}],
+        [{alpn_preferred_protocols, [<<"spdy/2">>, <<"spdy/3">>, <<"http/2">>]}],
+        {connect_failed,{tls_alert,"no application protocol"}}).
+
+%--------------------------------------------------------------------------------
+
+client_alpn_and_server_alpn(Config) when is_list(Config) ->
+    run_handshake(Config,
+		    [{alpn_advertised_protocols, [<<"http/1.0">>, <<"http/1.1">>]}],
+		    [{alpn_preferred_protocols, [<<"spdy/2">>, <<"http/1.1">>, <<"http/1.0">>]}],
+		    {ok, <<"http/1.1">>}).
+
+%--------------------------------------------------------------------------------
+
+client_alpn_and_server_no_support(Config) when is_list(Config) ->
+    run_handshake(Config,
+		    [{alpn_advertised_protocols, [<<"http/1.0">>, <<"http/1.1">>]}],
+		    [],
+		    {error, protocol_not_negotiated}).
+
+%--------------------------------------------------------------------------------
+
+client_no_support_and_server_alpn(Config) when is_list(Config) ->
+    run_handshake(Config,
+		    [],
+		    [{alpn_preferred_protocols, [<<"spdy/2">>, <<"http/1.1">>, <<"http/1.0">>]}],
+		    {error, protocol_not_negotiated}).
+
+%--------------------------------------------------------------------------------
+
+client_alpn_npn_and_server_alpn(Config) when is_list(Config) ->
+    run_handshake(Config,
+		    [{alpn_advertised_protocols, [<<"http/1.0">>, <<"http/1.1">>]},
+		        {client_preferred_next_protocols, {client, [<<"spdy/2">>], <<"spdy/3">>}}],
+		    [{alpn_preferred_protocols, [<<"spdy/2">>, <<"http/1.1">>, <<"http/1.0">>]}],
+		    {ok, <<"http/1.1">>}).
+
+%--------------------------------------------------------------------------------
+
+client_alpn_npn_and_server_alpn_npn(Config) when is_list(Config) ->
+    run_handshake(Config,
+		    [{alpn_advertised_protocols, [<<"http/1.0">>, <<"http/1.1">>]},
+		        {client_preferred_next_protocols, {client, [<<"spdy/2">>], <<"spdy/3">>}}],
+		    [{alpn_preferred_protocols, [<<"spdy/2">>, <<"http/1.1">>, <<"http/1.0">>]},
+		        {next_protocols_advertised, [<<"spdy/2">>, <<"http/1.0">>]}],
+		    {ok, <<"http/1.1">>}).
+
+%--------------------------------------------------------------------------------
+
+client_alpn_and_server_alpn_npn(Config) when is_list(Config) ->
+    run_handshake(Config,
+		    [{alpn_advertised_protocols, [<<"http/1.0">>, <<"http/1.1">>]}],
+		    [{alpn_preferred_protocols, [<<"spdy/2">>, <<"http/1.1">>, <<"http/1.0">>]},
+		        {next_protocols_advertised, [<<"spdy/2">>, <<"http/1.0">>]}],
+		    {ok, <<"http/1.1">>}).
+
+%--------------------------------------------------------------------------------
+
+client_renegotiate(Config) when is_list(Config) ->
+    Data = "hello world",
+    
+    ClientOpts0 = ?config(client_opts, Config),
+    ClientOpts = [{alpn_advertised_protocols, [<<"http/1.0">>]}] ++ ClientOpts0,
+    ServerOpts0 = ?config(server_opts, Config),
+    ServerOpts = [{alpn_preferred_protocols, [<<"spdy/2">>, <<"http/1.1">>, <<"http/1.0">>]}] ++  ServerOpts0,
+    ExpectedProtocol = {ok, <<"http/1.0">>},
+
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                    {from, self()},
+                    {mfa, {?MODULE, ssl_receive_and_assert_alpn, [ExpectedProtocol, Data]}},
+                    {options, ServerOpts}]),
+
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+               {host, Hostname},
+               {from, self()},
+               {mfa, {?MODULE, assert_alpn_and_renegotiate_and_send_data, [ExpectedProtocol, Data]}},
+               {options, ClientOpts}]),
+
+    ssl_test_lib:check_result(Server, ok, Client, ok).
+
+%--------------------------------------------------------------------------------
+
+session_reused(Config) when  is_list(Config)->
+    ClientOpts0 = ?config(client_opts, Config),
+    ClientOpts = [{alpn_advertised_protocols, [<<"http/1.0">>]}] ++ ClientOpts0,
+    ServerOpts0 = ?config(server_opts, Config),
+    ServerOpts = [{alpn_preferred_protocols, [<<"spdy/2">>, <<"http/1.1">>, <<"http/1.0">>]}] ++  ServerOpts0,
+
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                    {from, self()},
+                    {mfa, {ssl_test_lib, session_info_result, []}},
+					{options, ServerOpts}]),
+
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+               {host, Hostname},
+               {from, self()},
+               {mfa, {ssl_test_lib, no_result_msg, []}},
+               {options, ClientOpts}]),
+
+    SessionInfo = 
+	receive
+	    {Server, Info} ->
+		Info
+	end,
+        
+    Server ! {listen, {mfa, {ssl_test_lib, no_result, []}}},
+    
+    %% Make sure session is registered
+    ct:sleep(?SLEEP),
+
+    Client1 =
+	ssl_test_lib:start_client([{node, ClientNode},
+				   {port, Port}, {host, Hostname},
+				   {mfa, {ssl_test_lib, session_info_result, []}},
+				   {from, self()},  {options, ClientOpts}]),
+
+      receive
+	{Client1, SessionInfo} ->
+	    ok;
+	{Client1, Other} ->
+	    ct:fail(Other)
+      end,
+    
+    ssl_test_lib:close(Server), 
+    ssl_test_lib:close(Client),
+    ssl_test_lib:close(Client1).
+
+%--------------------------------------------------------------------------------
+
+alpn_not_supported_client(Config) when is_list(Config) ->
+    ClientOpts0 = ?config(client_opts, Config),
+    PrefProtocols = {client_preferred_next_protocols,
+		     {client, [<<"http/1.0">>], <<"http/1.1">>}},
+    ClientOpts = [PrefProtocols] ++ ClientOpts0,
+    {ClientNode, _ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Client = ssl_test_lib:start_client_error([{node, ClientNode}, 
+			    {port, 8888}, {host, Hostname},
+			    {from, self()},  {options, ClientOpts}]),
+    
+    ssl_test_lib:check_result(Client, {error, 
+				       {options, 
+					{not_supported_in_sslv3, PrefProtocols}}}).
+
+%--------------------------------------------------------------------------------
+
+alpn_not_supported_server(Config) when is_list(Config)->
+    ServerOpts0 = ?config(server_opts, Config),
+    AdvProtocols = {next_protocols_advertised, [<<"spdy/2">>, <<"http/1.1">>, <<"http/1.0">>]},
+    ServerOpts = [AdvProtocols] ++  ServerOpts0,
+  
+    {error, {options, {not_supported_in_sslv3, AdvProtocols}}} = ssl:listen(0, ServerOpts).
+
+%%--------------------------------------------------------------------
+%% Internal functions ------------------------------------------------
+%%--------------------------------------------------------------------
+
+run_failing_handshake(Config, ClientExtraOpts, ServerExtraOpts, ExpectedResult) ->
+    ClientOpts = ClientExtraOpts ++ ?config(client_opts, Config),
+    ServerOpts = ServerExtraOpts ++ ?config(server_opts, Config),
+
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                    {from, self()},
+                    {mfa, {?MODULE, placeholder, []}},
+                    {options, ServerOpts}]),
+
+    Port = ssl_test_lib:inet_port(Server),
+    ExpectedResult
+        = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+               {host, Hostname},
+               {from, self()},
+               {mfa, {?MODULE, placeholder, []}},
+               {options, ClientOpts}]).
+
+run_handshake(Config, ClientExtraOpts, ServerExtraOpts, ExpectedProtocol) ->
+    Data = "hello world",
+
+    ClientOpts0 = ?config(client_opts, Config),
+    ClientOpts = ClientExtraOpts ++ ClientOpts0,
+    ServerOpts0 = ?config(server_opts, Config),
+    ServerOpts = ServerExtraOpts ++  ServerOpts0,
+
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                    {from, self()},
+                    {mfa, {?MODULE, ssl_receive_and_assert_alpn, [ExpectedProtocol, Data]}},
+                    {options, ServerOpts}]),
+
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+               {host, Hostname},
+               {from, self()},
+               {mfa, {?MODULE, ssl_send_and_assert_alpn, [ExpectedProtocol, Data]}},
+               {options, ClientOpts}]),
+
+    ssl_test_lib:check_result(Server, ok, Client, ok).
+
+assert_alpn(Socket, Protocol) ->
+    ct:log("Negotiated Protocol ~p, Expecting: ~p ~n",
+		       [ssl:negotiated_protocol(Socket), Protocol]),
+    Protocol = ssl:negotiated_protocol(Socket).
+
+assert_alpn_and_renegotiate_and_send_data(Socket, Protocol, Data) ->
+    assert_alpn(Socket, Protocol),
+    ct:log("Renegotiating ~n", []),
+    ok = ssl:renegotiate(Socket),
+    ssl:send(Socket, Data),
+    assert_alpn(Socket, Protocol),
+    ok.
+
+ssl_send_and_assert_alpn(Socket, Protocol, Data) ->
+    assert_alpn(Socket, Protocol),
+    ssl_send(Socket, Data).
+
+ssl_receive_and_assert_alpn(Socket, Protocol, Data) ->
+    assert_alpn(Socket, Protocol),
+    ssl_receive(Socket, Data).
+
+ssl_send(Socket, Data) ->
+    ct:log("Connection info: ~p~n",
+               [ssl:connection_info(Socket)]),
+    ssl:send(Socket, Data).
+
+ssl_receive(Socket, Data) ->
+    ssl_receive(Socket, Data, []).
+
+ssl_receive(Socket, Data, Buffer) ->
+    ct:log("Connection info: ~p~n",
+               [ssl:connection_info(Socket)]),
+    receive
+    {ssl, Socket, MoreData} ->
+        ct:log("Received ~p~n",[MoreData]),
+        NewBuffer = Buffer ++ MoreData,
+        case NewBuffer of
+            Data ->
+                ssl:send(Socket, "Got it"),
+                ok;
+            _ ->
+                ssl_receive(Socket, Data, NewBuffer)
+        end;
+    Other ->
+        ct:fail({unexpected_message, Other})
+    after 4000 ->
+        ct:fail({did_not_get, Data})
+    end.
+
+connection_info_result(Socket) ->
+    ssl:connection_info(Socket).

--- a/lib/ssl/test/ssl_npn_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_npn_handshake_SUITE.erl
@@ -172,7 +172,7 @@ no_client_negotiate_but_server_supports_npn(Config) when is_list(Config) ->
     run_npn_handshake(Config,
 			   [],
 			   [{next_protocols_advertised, [<<"spdy/1">>, <<"http/1.1">>, <<"http/1.0">>]}],
-			   {error, next_protocol_not_negotiated}).
+			   {error, protocol_not_negotiated}).
 %--------------------------------------------------------------------------------
 
 
@@ -180,7 +180,7 @@ client_negotiate_server_does_not_support(Config) when is_list(Config) ->
     run_npn_handshake(Config,
 			   [{client_preferred_next_protocols, {client, [<<"spdy/2">>], <<"http/1.1">>}}],
 			   [],
-			   {error, next_protocol_not_negotiated}).
+			   {error, protocol_not_negotiated}).
 
 %--------------------------------------------------------------------------------
 renegotiate_from_client_after_npn_handshake(Config) when is_list(Config) ->
@@ -311,8 +311,8 @@ run_npn_handshake(Config, ClientExtraOpts, ServerExtraOpts, ExpectedProtocol) ->
 
 assert_npn(Socket, Protocol) ->
     ct:log("Negotiated Protocol ~p, Expecting: ~p ~n",
-		       [ssl:negotiated_next_protocol(Socket), Protocol]),
-    Protocol = ssl:negotiated_next_protocol(Socket).
+		       [ssl:negotiated_protocol(Socket), Protocol]),
+    Protocol = ssl:negotiated_protocol(Socket).
 
 assert_npn_and_renegotiate_and_send_data(Socket, Protocol, Data) ->
     assert_npn(Socket, Protocol),

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -1088,6 +1088,8 @@ cipher_restriction(Config0) ->
 
 check_sane_openssl_version(Version) ->
     case {Version, os:cmd("openssl version")} of
+	{_, "OpenSSL 1.0.2" ++ _} ->
+	    true;
 	{_, "OpenSSL 1.0.1" ++ _} ->
 	    true;
 	{'tlsv1.2', "OpenSSL 1.0" ++ _} ->

--- a/lib/ssl/test/ssl_to_openssl_SUITE.erl
+++ b/lib/ssl/test/ssl_to_openssl_SUITE.erl
@@ -50,9 +50,9 @@ all() ->
 
 groups() ->
     [{basic, [], basic_tests()},
-     {'tlsv1.2', [], all_versions_tests() ++ npn_tests()},
-     {'tlsv1.1', [], all_versions_tests() ++ npn_tests()},
-     {'tlsv1', [], all_versions_tests()++ npn_tests()},
+     {'tlsv1.2', [], all_versions_tests() ++ alpn_tests() ++ npn_tests()},
+     {'tlsv1.1', [], all_versions_tests() ++ alpn_tests() ++ npn_tests()},
+     {'tlsv1', [], all_versions_tests()++ alpn_tests() ++ npn_tests()},
      {'sslv3', [], all_versions_tests()}].
 
 basic_tests() ->
@@ -78,6 +78,18 @@ all_versions_tests() ->
      erlang_client_bad_openssl_server,
      expired_session,
      ssl2_erlang_server_openssl_client].
+
+alpn_tests() ->
+    [erlang_client_alpn_openssl_server_alpn,
+     erlang_server_alpn_openssl_client_alpn,
+     erlang_client_alpn_openssl_server,
+     erlang_client_openssl_server_alpn,
+     erlang_server_alpn_openssl_client,
+     erlang_server_openssl_client_alpn,
+     erlang_client_alpn_openssl_server_alpn_renegotiate,
+     erlang_server_alpn_openssl_client_alpn_renegotiate,
+     erlang_client_alpn_npn_openssl_server_alpn_npn,
+     erlang_server_alpn_npn_openssl_client_alpn_npn].
 
 npn_tests() ->
     [erlang_client_openssl_server_npn,
@@ -161,6 +173,36 @@ special_init(ssl2_erlang_server_openssl_client, Config) ->
     check_sane_openssl_sslv2(Config);
 
 special_init(TestCase, Config)
+    when TestCase == erlang_client_alpn_openssl_server_alpn;
+         TestCase == erlang_server_alpn_openssl_client_alpn;
+         TestCase == erlang_client_alpn_openssl_server;
+         TestCase == erlang_client_openssl_server_alpn;
+         TestCase == erlang_server_alpn_openssl_client;
+         TestCase == erlang_server_openssl_client_alpn ->
+    check_openssl_alpn_support(Config);
+
+special_init(TestCase, Config)
+    when TestCase == erlang_client_alpn_openssl_server_alpn_renegotiate;
+         TestCase == erlang_server_alpn_openssl_client_alpn_renegotiate ->
+    {ok, Version} = application:get_env(ssl, protocol_version),
+    case check_sane_openssl_renegotaite(Config, Version) of
+	{skip, _} = Skip ->
+	    Skip;
+	_ ->
+	    check_openssl_alpn_support(Config)
+    end;
+
+special_init(TestCase, Config)
+    when TestCase == erlang_client_alpn_npn_openssl_server_alpn_npn;
+         TestCase == erlang_server_alpn_npn_openssl_client_alpn_npn ->
+    case check_openssl_alpn_support(Config) of
+        {skip, _} = Skip ->
+            Skip;
+        _ ->
+            check_openssl_npn_support(Config)
+    end;
+
+special_init(TestCase, Config)
     when TestCase == erlang_client_openssl_server_npn;
          TestCase == erlang_server_openssl_client_npn;        
          TestCase == erlang_server_openssl_client_npn_only_server;
@@ -179,6 +221,7 @@ special_init(TestCase, Config)
 	_ -> 
 	    check_openssl_npn_support(Config)
     end;
+
 special_init(_, Config) ->
     Config.
 
@@ -924,6 +967,128 @@ ssl2_erlang_server_openssl_client(Config) when is_list(Config) ->
     process_flag(trap_exit, false).
 
 %%--------------------------------------------------------------------
+
+erlang_client_alpn_openssl_server_alpn(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_client_and_openssl_server_for_alpn_negotiation(Config, Data, fun(Client, OpensslPort) ->
+        true = port_command(OpensslPort, Data),
+
+        ssl_test_lib:check_result(Client, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------
+
+erlang_server_alpn_openssl_client_alpn(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_server_and_openssl_client_for_alpn_negotiation(Config, Data, fun(Client, OpensslPort) ->
+        true = port_command(OpensslPort, Data),
+
+        ssl_test_lib:check_result(Client, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------------
+
+erlang_client_alpn_openssl_server(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_client_and_openssl_server_with_opts(Config,
+						     [{alpn_advertised_protocols, [<<"spdy/2">>]}],
+                                                     "",
+						     Data, fun(Server, OpensslPort) ->
+        true = port_command(OpensslPort, Data),
+        ssl_test_lib:check_result(Server, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------------
+
+erlang_client_openssl_server_alpn(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_client_and_openssl_server_with_opts(Config,
+						     [],
+                                                     "-alpn spdy/2",
+						     Data, fun(Server, OpensslPort) ->
+        true = port_command(OpensslPort, Data),
+        ssl_test_lib:check_result(Server, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------------
+
+erlang_server_alpn_openssl_client(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_server_and_openssl_client_with_opts(Config,
+						     [{alpn_advertised_protocols, [<<"spdy/2">>]}],
+                                                     "",
+						     Data, fun(Server, OpensslPort) ->
+        true = port_command(OpensslPort, Data),
+        ssl_test_lib:check_result(Server, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------------
+
+erlang_server_openssl_client_alpn(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_server_and_openssl_client_with_opts(Config,
+						     [],
+                                                     "-alpn spdy/2",
+						     Data, fun(Server, OpensslPort) ->
+        true = port_command(OpensslPort, Data),
+        ssl_test_lib:check_result(Server, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------
+
+erlang_client_alpn_openssl_server_alpn_renegotiate(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_client_and_openssl_server_for_alpn_negotiation(Config, Data, fun(Client, OpensslPort) ->
+        true = port_command(OpensslPort, ?OPENSSL_RENEGOTIATE),
+        ct:sleep(?SLEEP),
+        true = port_command(OpensslPort, Data),
+
+        ssl_test_lib:check_result(Client, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------
+
+erlang_server_alpn_openssl_client_alpn_renegotiate(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_server_and_openssl_client_for_alpn_negotiation(Config, Data, fun(Client, OpensslPort) ->
+        true = port_command(OpensslPort, ?OPENSSL_RENEGOTIATE),
+        ct:sleep(?SLEEP),
+        true = port_command(OpensslPort, Data),
+
+        ssl_test_lib:check_result(Client, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------
+
+erlang_client_alpn_npn_openssl_server_alpn_npn(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_client_and_openssl_server_for_alpn_npn_negotiation(Config, Data, fun(Client, OpensslPort) ->
+        true = port_command(OpensslPort, Data),
+
+        ssl_test_lib:check_result(Client, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------
+
+erlang_server_alpn_npn_openssl_client_alpn_npn(Config) when is_list(Config) ->
+    Data = "From openssl to erlang",
+    start_erlang_server_and_openssl_client_for_alpn_npn_negotiation(Config, Data, fun(Client, OpensslPort) ->
+        true = port_command(OpensslPort, Data),
+
+        ssl_test_lib:check_result(Client, ok)
+    end),
+    ok.
+
+%%--------------------------------------------------------------------
 erlang_client_openssl_server_npn() ->
     [{doc,"Test erlang client with openssl server doing npn negotiation"}].
 
@@ -1139,6 +1304,142 @@ start_erlang_client_and_openssl_server_with_opts(Config, ErlangClientOpts, Opens
     ssl_test_lib:close(Client),
     process_flag(trap_exit, false).
 
+start_erlang_client_and_openssl_server_for_alpn_negotiation(Config, Data, Callback) ->
+    process_flag(trap_exit, true),
+    ServerOpts = ?config(server_opts, Config),
+    ClientOpts0 = ?config(client_opts, Config),
+    ClientOpts = [{alpn_advertised_protocols, [<<"spdy/2">>]} | ClientOpts0],
+
+    {ClientNode, _, Hostname} = ssl_test_lib:run_where(Config),
+
+    Data = "From openssl to erlang",
+
+    Port = ssl_test_lib:inet_port(node()),
+    CertFile = proplists:get_value(certfile, ServerOpts),
+    KeyFile = proplists:get_value(keyfile, ServerOpts),
+    Version = tls_record:protocol_version(tls_record:highest_protocol_version([])),
+
+    Cmd = "openssl s_server -msg -alpn http/1.1,spdy/2  -accept " ++ integer_to_list(Port)  ++  ssl_test_lib:version_flag(Version) ++
+    " -cert " ++ CertFile  ++ " -key " ++ KeyFile,
+
+    ct:log("openssl cmd: ~p~n", [Cmd]),
+
+    OpensslPort =  open_port({spawn, Cmd}, [stderr_to_stdout]),
+
+    ssl_test_lib:wait_for_openssl_server(),
+
+    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+                    {host, Hostname},
+                    {from, self()},
+                    {mfa, {?MODULE,
+                           erlang_ssl_receive_and_assert_negotiated_protocol, [<<"spdy/2">>, Data]}},
+                    {options, ClientOpts}]),
+
+    Callback(Client, OpensslPort),
+
+    %% Clean close down!   Server needs to be closed first !!
+    ssl_test_lib:close_port(OpensslPort),
+
+    ssl_test_lib:close(Client),
+    process_flag(trap_exit, false).
+
+start_erlang_server_and_openssl_client_for_alpn_negotiation(Config, Data, Callback) ->
+    process_flag(trap_exit, true),
+    ServerOpts0 = ?config(server_opts, Config),
+    ServerOpts = [{alpn_preferred_protocols, [<<"spdy/2">>]} | ServerOpts0],
+
+    {_, ServerNode, _} = ssl_test_lib:run_where(Config),
+
+
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                    {from, self()},
+                    {mfa, {?MODULE, erlang_ssl_receive_and_assert_negotiated_protocol, [<<"spdy/2">>, Data]}},
+                    {options, ServerOpts}]),
+    Port = ssl_test_lib:inet_port(Server),
+    Version = tls_record:protocol_version(tls_record:highest_protocol_version([])),
+    Cmd = "openssl s_client -alpn http/1.0,spdy/2 -msg -port " ++ integer_to_list(Port)  ++ ssl_test_lib:version_flag(Version) ++
+    " -host localhost",
+
+    ct:log("openssl cmd: ~p~n", [Cmd]),
+
+    OpenSslPort =  open_port({spawn, Cmd}, [stderr_to_stdout]),
+
+    Callback(Server, OpenSslPort),
+
+    ssl_test_lib:close(Server),
+
+    ssl_test_lib:close_port(OpenSslPort),
+    process_flag(trap_exit, false).
+
+start_erlang_client_and_openssl_server_for_alpn_npn_negotiation(Config, Data, Callback) ->
+    process_flag(trap_exit, true),
+    ServerOpts = ?config(server_opts, Config),
+    ClientOpts0 = ?config(client_opts, Config),
+    ClientOpts = [{alpn_advertised_protocols, [<<"spdy/2">>]},
+        {client_preferred_next_protocols, {client, [<<"spdy/3">>, <<"http/1.1">>]}} | ClientOpts0],
+
+    {ClientNode, _, Hostname} = ssl_test_lib:run_where(Config),
+
+    Data = "From openssl to erlang",
+
+    Port = ssl_test_lib:inet_port(node()),
+    CertFile = proplists:get_value(certfile, ServerOpts),
+    KeyFile = proplists:get_value(keyfile, ServerOpts),
+    Version = tls_record:protocol_version(tls_record:highest_protocol_version([])),
+
+    Cmd = "openssl s_server -msg -alpn http/1.1,spdy/2 -nextprotoneg spdy/3 -accept " ++ integer_to_list(Port)  ++  ssl_test_lib:version_flag(Version) ++
+    " -cert " ++ CertFile  ++ " -key " ++ KeyFile,
+
+    ct:log("openssl cmd: ~p~n", [Cmd]),
+
+    OpensslPort =  open_port({spawn, Cmd}, [stderr_to_stdout]),
+
+    ssl_test_lib:wait_for_openssl_server(),
+
+    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+                    {host, Hostname},
+                    {from, self()},
+                    {mfa, {?MODULE,
+                           erlang_ssl_receive_and_assert_negotiated_protocol, [<<"spdy/2">>, Data]}},
+                    {options, ClientOpts}]),
+
+    Callback(Client, OpensslPort),
+
+    %% Clean close down!   Server needs to be closed first !!
+    ssl_test_lib:close_port(OpensslPort),
+
+    ssl_test_lib:close(Client),
+    process_flag(trap_exit, false).
+
+start_erlang_server_and_openssl_client_for_alpn_npn_negotiation(Config, Data, Callback) ->
+    process_flag(trap_exit, true),
+    ServerOpts0 = ?config(server_opts, Config),
+    ServerOpts = [{alpn_preferred_protocols, [<<"spdy/2">>]},
+        {next_protocols_advertised, [<<"spdy/3">>, <<"http/1.1">>]} | ServerOpts0],
+
+    {_, ServerNode, _} = ssl_test_lib:run_where(Config),
+
+
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                    {from, self()},
+                    {mfa, {?MODULE, erlang_ssl_receive_and_assert_negotiated_protocol, [<<"spdy/2">>, Data]}},
+                    {options, ServerOpts}]),
+    Port = ssl_test_lib:inet_port(Server),
+    Version = tls_record:protocol_version(tls_record:highest_protocol_version([])),
+    Cmd = "openssl s_client -alpn http/1.1,spdy/2 -nextprotoneg spdy/3 -msg -port " ++ integer_to_list(Port)  ++ ssl_test_lib:version_flag(Version) ++
+    " -host localhost",
+
+    ct:log("openssl cmd: ~p~n", [Cmd]),
+
+    OpenSslPort =  open_port({spawn, Cmd}, [stderr_to_stdout]),
+
+    Callback(Server, OpenSslPort),
+
+    ssl_test_lib:close(Server),
+
+    ssl_test_lib:close_port(OpenSslPort),
+    process_flag(trap_exit, false).
+
 start_erlang_client_and_openssl_server_for_npn_negotiation(Config, Data, Callback) ->
     process_flag(trap_exit, true),
     ServerOpts = ?config(server_opts, Config),
@@ -1167,7 +1468,7 @@ start_erlang_client_and_openssl_server_for_npn_negotiation(Config, Data, Callbac
                     {host, Hostname},
                     {from, self()},
                     {mfa, {?MODULE,
-                           erlang_ssl_receive_and_assert_npn, [<<"spdy/2">>, Data]}},
+                           erlang_ssl_receive_and_assert_negotiated_protocol, [<<"spdy/2">>, Data]}},
                     {options, ClientOpts}]),
 
     Callback(Client, OpensslPort),
@@ -1188,7 +1489,7 @@ start_erlang_server_and_openssl_client_for_npn_negotiation(Config, Data, Callbac
 
     Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
                     {from, self()},
-                    {mfa, {?MODULE, erlang_ssl_receive_and_assert_npn, [<<"spdy/2">>, Data]}},
+                    {mfa, {?MODULE, erlang_ssl_receive_and_assert_negotiated_protocol, [<<"spdy/2">>, Data]}},
                     {options, ServerOpts}]),
     Port = ssl_test_lib:inet_port(Server),
     Version = tls_record:protocol_version(tls_record:highest_protocol_version([])),
@@ -1236,10 +1537,10 @@ start_erlang_server_and_openssl_client_with_opts(Config, ErlangServerOpts, OpenS
     process_flag(trap_exit, false).
 
 
-erlang_ssl_receive_and_assert_npn(Socket, Protocol, Data) ->
-    {ok, Protocol} = ssl:negotiated_next_protocol(Socket),
+erlang_ssl_receive_and_assert_negotiated_protocol(Socket, Protocol, Data) ->
+    {ok, Protocol} = ssl:negotiated_protocol(Socket),
     erlang_ssl_receive(Socket, Data),
-    {ok, Protocol} = ssl:negotiated_next_protocol(Socket),
+    {ok, Protocol} = ssl:negotiated_protocol(Socket),
     ok.
 
 erlang_ssl_receive(Socket, Data) ->
@@ -1293,6 +1594,15 @@ check_openssl_npn_support(Config) ->
     case string:str(HelpText, "nextprotoneg") of
         0 ->
             {skip, "Openssl not compiled with nextprotoneg support"};
+        _ ->
+            Config
+    end.
+
+check_openssl_alpn_support(Config) ->
+    HelpText = os:cmd("openssl s_client --help"),
+    case string:str(HelpText, "alpn") of
+        0 ->
+            {skip, "Openssl not compiled with alpn support"};
         _ ->
             Config
     end.

--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -590,6 +590,8 @@ obsolete_1(core_lib, is_literal_list, 1) ->
      " instead"};
 obsolete_1(core_lib, literal_value, 1) ->
     {deprecated,{core_lib,concrete,1}};
+obsolete_1(ssl, negotiated_next_protocol, 1) ->
+    {deprecated,{ssl,negotiated_protocol}};
 
 obsolete_1(_, _, _) ->
     no.


### PR DESCRIPTION
This commit adds support for RFC7301, application-layer protocol
negotiation. ALPN is the standard based approach to the NPN
extension, and is required for HTTP/2.

ALPN lives side by side with NPN and provides an equivalent
feature but in this case it is the server that decides what
protocol to use, not the client.

When both ALPN and NPN are sent by a client, and the server is
configured with both ALPN and NPN options, ALPN will always
take precedence. This behavior can also be found in the OpenSSL
implementation of ALPN.

ALPN and NPN share the ssl:negotiated_protocol/1 function for
retrieving the negotiated protocol. The previously existing
function ssl:negotiated_next_protocol/1 still exists, but has
been deprecated and removed from the documentation.

The tests against OpenSSL require OpenSSL version 1.0.2+.

-----------------------------------

The changes in this PR were first discussed with @IngelaAndin by email, including the deprecation of the ssl:negotiated_next_protocol/1 function.

We are hoping this can make it into OTP 18.