### PR TITLE
Update zlib:zwindowbits/0 type to accept 8 and -8

### DIFF
--- a/erts/doc/src/zlib.xml
+++ b/erts/doc/src/zlib.xml
@@ -99,7 +99,7 @@ list_to_binary([Compressed|Last])</pre>
     <datatype>
       <name name="zwindowbits"/>
       <desc>
-        <p>Normally in the range <c>-15..-9 | 9..15</c>.</p>
+        <p>Normally in the range <c>-15..-8 | 8..15</c>.</p>
       </desc>
     </datatype>
   </datatypes>
@@ -149,7 +149,7 @@ list_to_binary([Compressed|Last])</pre>
           currently the only supported method is <c>deflated</c>.</p>
         <p>The <c><anno>WindowBits</anno></c> parameter is the base two logarithm
           of the window size (the size of the history buffer).  It
-          should be in the range 9 through 15. Larger values
+          should be in the range 8 through 15. Larger values
           of this parameter result in better compression at the
           expense of memory usage. The default value is 15 if
           <c>deflateInit/2</c>. A negative <c><anno>WindowBits</anno></c>
@@ -288,7 +288,7 @@ list_to_binary([B1,B2])</pre>
         <p>Initialize decompression session on zlib stream.</p>
         <p>The <c><anno>WindowBits</anno></c> parameter is the base two logarithm
           of the maximum window size (the size of the history buffer).
-          It should be in the range 9 through 15.
+          It should be in the range 8 through 15.
           The default value is 15 if <c>inflateInit/1</c> is used.
           If a compressed stream with a larger window size is
           given as input, inflate() will throw the <c>data_error</c>

--- a/erts/preloaded/src/zlib.erl
+++ b/erts/preloaded/src/zlib.erl
@@ -124,7 +124,7 @@
 -type zlevel()      :: 'none' | 'default' | 'best_compression' | 'best_speed' 
                      | 0..9.
 -type zmethod()     :: 'deflated'.
--type zwindowbits() :: -15..-9 | 9..47.
+-type zwindowbits() :: -15..-8 | 8..47.
 -type zmemlevel()   :: 1..9.
 -type zstrategy()   :: 'default' | 'filtered' | 'huffman_only' | 'rle'.
 
@@ -496,8 +496,8 @@ arg_method(_) -> erlang:error(badarg).
 
 -spec arg_bitsz(zwindowbits()) -> zwindowbits().
 arg_bitsz(Bits) when is_integer(Bits) andalso
-		     ((8 < Bits andalso Bits < 48) orelse
-		      (-15 =< Bits andalso Bits < -8)) ->
+		     ((8 =< Bits andalso Bits < 48) orelse
+		      (-15 =< Bits andalso Bits =< -8)) ->
     Bits;
 arg_bitsz(_) -> erlang:error(badarg).
 

--- a/lib/kernel/test/zlib_SUITE.erl
+++ b/lib/kernel/test/zlib_SUITE.erl
@@ -146,8 +146,6 @@ api_deflateInit(Config) when is_list(Config) ->
     ?m(?BARG, zlib:deflateInit(Z1,default,deflated,-20,8,default)),
     ?m(?BARG, zlib:deflateInit(Z1,default,deflated,-7,8,default)),
     ?m(?BARG, zlib:deflateInit(Z1,default,deflated,7,8,default)),
-    ?m(?BARG, zlib:deflateInit(Z1,default,deflated,-8,8,default)),
-    ?m(?BARG, zlib:deflateInit(Z1,default,deflated,8,8,default)),
     
     ?m(?BARG, zlib:deflateInit(Z1,default,deflated,-15,0,default)),
     ?m(?BARG, zlib:deflateInit(Z1,default,deflated,-15,10,default)),    
@@ -169,7 +167,7 @@ api_deflateInit(Config) when is_list(Config) ->
 			  ?m(ok, zlib:deflateInit(Z12,default,deflated,-Wbits,8,default)),
 			  ?m(ok,zlib:close(Z11)),
 			  ?m(ok,zlib:close(Z12))
-		  end, lists:seq(9, 15)),
+		  end, lists:seq(8, 15)),
     
     lists:foreach(fun(MemLevel) ->
 			  ?line Z = zlib:open(),
@@ -277,7 +275,7 @@ api_inflateInit(Config) when is_list(Config) ->
 			  ?m(ok, zlib:inflateInit(Z12,-Wbits)),
 			  ?m(ok,zlib:close(Z11)),
 			  ?m(ok,zlib:close(Z12))
-		  end, lists:seq(9,15)),
+		  end, lists:seq(8,15)),
     ?m(?BARG, zlib:inflateInit(gurka, -15)),
     ?m(?BARG, zlib:inflateInit(Z1, 7)),
     ?m(?BARG, zlib:inflateInit(Z1, -7)),


### PR DESCRIPTION
Commit 7e8f5a776cbfa376e03369d058a90c8dd9f217fc (importing R11B-3)
updated zlib, which had changed what values it accepts for window
bits from 9-15 to 8-15.

From deflate.c:

``` c
-        windowBits < 9 || windowBits > 15 || level < 0 || level > 9 ||
-   strategy < 0 || strategy > Z_HUFFMAN_ONLY) {
+        windowBits < 8 || windowBits > 15 || level < 0 || level > 9 ||
+        strategy < 0 || strategy > Z_FIXED) {
         return Z_STREAM_ERROR;
     }
+    if (windowBits == 8) windowBits = 9;  /* until 256-byte window bug fixed */
```

In inflate.c 8 was already an accepted value.

This commit updates OTP to also accept the values 8 and -8.

----------------------------------

This PR makes the zlib interface closer to the original.

The 8 value as you can see is set to 9 by zlib. They have a bug affecting only deflate from what I can tell, and until they fix it zlib will use slightly more memory than it could with 8. I don't think Erlang's bindings should depend on a bug that will be fixed down the line.

I have tested that using 8 works as intended when communicating with the Python 2.7 deflate implementation. I have also modified tests to ensure everything works as intended.

I am hoping this can make it into OTP 18. I am available should any more change be needed.
