### PR TITLE
Export useful types from zlib module

### DIFF
--- a/erts/preloaded/src/zlib.erl
+++ b/erts/preloaded/src/zlib.erl
@@ -30,7 +30,7 @@
 	 compress/1,uncompress/1,zip/1,unzip/1,
 	 gzip/1,gunzip/1]).
 
--export_type([zstream/0]).
+-export_type([zstream/0, zlevel/0, zwindowbits/0, zmemlevel/0, zstrategy/0]).
 
 %% flush argument encoding
 -define(Z_NO_FLUSH,      0).


### PR DESCRIPTION
Didn't add zmethod() because it can't be configured and so it is not very useful to have outside this module. However the four I add can very well be arguments to functions or configuration options and so it is interesting to have those types exported.