### PR TITLE
Fix parsing list of one test directory in ct:run_test/1

### DIFF
--- a/lib/common_test/src/ct_run.erl
+++ b/lib/common_test/src/ct_run.erl
@@ -1620,11 +1620,15 @@ groups_and_cases(Gs, Cs) ->
 tests(TestDir, Suites, []) when is_list(TestDir), is_integer(hd(TestDir)) ->
     [{?testdir(TestDir,Suites),ensure_atom(Suites),all}];
 tests(TestDir, Suite, Cases) when is_list(TestDir), is_integer(hd(TestDir)) ->
+    [{?testdir(TestDir,Suite),ensure_atom(Suite),Cases}];
+tests([TestDir], Suite, Cases) when is_list(TestDir), is_integer(hd(TestDir)) ->
     [{?testdir(TestDir,Suite),ensure_atom(Suite),Cases}].
 tests([{Dir,Suite}],Cases) ->
     [{?testdir(Dir,Suite),ensure_atom(Suite),Cases}];
 tests(TestDir, Suite) when is_list(TestDir), is_integer(hd(TestDir)) ->
-    tests(TestDir, ensure_atom(Suite), all).
+    tests(TestDir, ensure_atom(Suite), all);
+tests([TestDir], Suite) when is_list(TestDir), is_integer(hd(TestDir)) ->
+     tests(TestDir, ensure_atom(Suite), all).
 tests(DirSuites) when is_list(DirSuites), is_tuple(hd(DirSuites)) ->
     [{?testdir(Dir,Suite),ensure_atom(Suite),all} || {Dir,Suite} <- DirSuites];
 tests(TestDir) when is_list(TestDir), is_integer(hd(TestDir)) ->


### PR DESCRIPTION
Fix support for the following cases for `ct:run_test/1` options:
* `[{dir, [Dir]}, {suite, _}, ...]`
* `[{dir, [Dir]}, {suite, Suite}, {group, _}, ...]`
* `[{dir, [Dir]}, {suite, Suite}, {case, _}, ...]`

Previously these options would result in a function_clause error as `{dir, [Dir]}` was not handled when combined with a suite.

Example error:
```
{function_clause,
                         [{ct_run,tests,[["test"],test_SUITE,[testcase]],[{file,"ct_run.erl"},{line,1618}]},
                          {ct_run,run_dir,2,[{file,"ct_run.erl"},{line,1315}]},
                          {ct_run,run_test1,1,[{file,"ct_run.erl"},{line,913}]}]}
```