### PR TITLE
Fix simple_one_for_one supervisor crashing in terminate/2 without shutting down all its children

### DIFF
--- a/lib/stdlib/doc/src/supervisor.xml
+++ b/lib/stdlib/doc/src/supervisor.xml
@@ -337,9 +337,15 @@ child_spec() = {Id,StartFunc,Restart,Shutdown,Type,Modules}
           added to the supervisor and the function returns the same
           value.</p>
         <p>If the child process start function returns <c>ignore</c>,
-          the child specification is added to the supervisor, the pid
-          is set to <c>undefined</c> and the function returns
-          <c>{ok,undefined}</c>.</p>
+          the child specification is added to the supervisor (unless the
+          supervisor is a <c>simple_one_for_one</c> supervisor, see below),
+          the pid is set to <c>undefined</c> and the function returns
+          <c>{ok,undefined}</c>.
+        </p>
+        <p>In the case of a <c>simple_one_for_one</c> supervisor, when a child
+          process start function returns <c>ignore</c> the functions returns
+          <c>{ok,undefined}</c> and no child is added to the supervisor.
+        </p>
         <p>If the child process start function returns an error tuple or
           an erroneous value, or if it fails, the child specification is
           discarded and the function returns <c>{error,Error}</c> where

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -353,7 +353,7 @@ handle_call({start_child, EArgs}, _From, State) when ?is_simple(State) ->
     #child{mfargs = {M, F, A}} = Child,
     Args = A ++ EArgs,
     case do_start_child_i(M, F, Args) of
-	{ok, undefined} when Child#child.restart_type =:= temporary ->
+	{ok, undefined} ->
 	    {reply, {ok, undefined}, State};
 	{ok, Pid} ->
 	    NState = save_dynamic_child(Child#child.restart_type, Pid, Args, State),


### PR DESCRIPTION
If a child of a simple_one_for_one returns ignore from its start function no longer store the child for any restart type. It is not possible to restart or delete the child because the supervisor is a simple_one_for_one.

Previously a simple_one_for_one would crash, potentially without shutting down all of its children, when it tried to shutdown a child with undefined pid.

Previous only one undefined pid child was stored in a simple_one_for_one supervisor no matter how many times the child start function returned ignore.

An example:

```erlang
-module(simple_sup).

-behaviour(supervisor).

-export([test/0]).
-export([start_link/1]).
-export([init/1]).

test() ->
    process_flag(trap_exit, true),
    {ok, Pid} = start_link(parent),
    {ok, undefined} = supervisor:start_child(Pid, []),
    exit(Pid, shutdown),
    receive
        {'EXIT', Pid, shutdown} ->
            ok;
        {'EXIT', Pid, Reason} ->
            exit(Reason)
    end.

start_link(Arg) ->
    supervisor:start_link(?MODULE, Arg).

init(parent) ->
    ChildSpec = {?MODULE, {?MODULE, start_link, [child]},
                 permanent, 5000, worker, [?MODULE]},
    {ok, {{simple_one_for_one, 1, 5}, [ChildSpec]}};
init(child) ->
    ignore.
```

```
1> simple_sup:test().

=ERROR REPORT==== 4-Mar-2015::23:21:55 ===
** Generic server <0.76.0> terminating 
** Last message in was {'EXIT',<0.74.0>,shutdown}
** When Server state == {state,
                            {<0.76.0>,simple_sup},
                            simple_one_for_one,
                            [{child,undefined,simple_sup,
                                 {simple_sup,start_link,[child]},
                                 permanent,5000,worker,
                                 [simple_sup]}],
                            {dict,1,16,16,8,80,48,
                                {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],
                                 []},
                                {{[],[],[],[],
                                  [[undefined,child]],
                                  [],[],[],[],[],[],[],[],[],[],[]}}},
                            1,5,[],simple_sup,parent}
** Reason for termination == 
** {function_clause,
       [{supervisor,'-monitor_dynamic_children/2-fun-1-',
            [undefined,
             [child],
             {{set,0,16,16,8,80,48,
                  {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                  {{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}},
              {dict,0,16,16,8,80,48,
                  {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                  {{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}}}],
            [{file,"supervisor.erl"},{line,1002}]},
        {dict,fold_bucket,3,[{file,"dict.erl"},{line,434}]},
        {dict,fold_seg,4,[{file,"dict.erl"},{line,430}]},
        {dict,fold_segs,4,[{file,"dict.erl"},{line,426}]},
        {supervisor,terminate_dynamic_children,3,
            [{file,"supervisor.erl"},{line,969}]},
        {gen_server,try_terminate,3,[{file,"gen_server.erl"},{line,621}]},
        {gen_server,terminate,7,[{file,"gen_server.erl"},{line,787}]},
        {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,237}]}]}
```