### PR TITLE
Add .cmd to the list of supported port executables on Windows

### DIFF
--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -1787,7 +1787,7 @@ static int application_type (const wchar_t *originalName, /* Name of the applica
     char buf[2];
     DWORD read;
     IMAGE_DOS_HEADER header;
-    static wchar_t extensions[][5] = {L"", L".com", L".exe", L".bat"};
+    static wchar_t extensions[][5] = {L"", L".cmd", L".com", L".exe", L".bat"};
     int is_quoted;
     int len;
     wchar_t xfullpath[MAX_PATH];


### PR DESCRIPTION
In os:extensions/0 we list ".cmd" for Windows. This made
os:find_executable/1 return executables with ".cmd" extension
on Windows but the port was ultimately unable to execute it,
failing with eacces error.

Disclaimer: Unfortunately I have no means for testing this on
Windows and therefore I haven't done so. If for some reason
ports are unable to execute ".cmd" files, then maybe we should
remove ".cmd" from the list of supported extensions on os:extensions/0.