### PR TITLE
Fix a race condition when calling port_info

### DIFF
--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -4484,7 +4484,7 @@ make_port_info_term(Eterm **hpp_start,
 	int len;
 	int start;
 	static Eterm item[] = ERTS_PORT_INFO_1_ITEMS;
-	static Eterm value[sizeof(item)/sizeof(item[0])];
+        Eterm value[sizeof(item)/sizeof(item[0])];
 
 	start = 0;
 	len = sizeof(item)/sizeof(item[0]);


### PR DESCRIPTION
This variable hold the values returned by erlang:port_info/1 and shouldn't be static.

@Licenser