### PR TITLE
Add check_plt option to dialyzer erlang api

### DIFF
--- a/lib/dialyzer/doc/src/dialyzer.xml
+++ b/lib/dialyzer/doc/src/dialyzer.xml
@@ -290,6 +290,7 @@ Option   :: {files,          [Filename :: string()]}
           | {include_dirs,   [DirName :: string()]}
           | {output_file,    FileName :: string()}
           | {output_plt,     FileName :: string()}
+          | {check_plt,      boolean()},
           | {analysis_type,  'succ_typings' |
                              'plt_add' |
                              'plt_build' |

--- a/lib/dialyzer/src/dialyzer.erl
+++ b/lib/dialyzer/src/dialyzer.erl
@@ -162,14 +162,7 @@ run(Opts) ->
     {error, Msg} ->
       throw({dialyzer_error, Msg});
     OptsRecord ->
-      case OptsRecord#options.check_plt of
-        true ->
-          case cl_check_init(OptsRecord) of
-            {ok, ?RET_NOTHING_SUSPICIOUS} -> ok;
-            {error, ErrorMsg1} -> throw({dialyzer_error, ErrorMsg1})
-          end;
-        false -> ok
-      end,
+      ok = check_init(OptsRecord),
       case dialyzer_cl:start(OptsRecord) of
         {?RET_DISCREPANCIES, Warnings} -> Warnings;
         {?RET_NOTHING_SUSPICIOUS, _}  -> []
@@ -178,6 +171,16 @@ run(Opts) ->
     throw:{dialyzer_error, ErrorMsg} ->
       erlang:error({dialyzer_error, lists:flatten(ErrorMsg)})
   end.
+
+check_init(#options{analysis_type = plt_check}) ->
+    ok;
+check_init(#options{check_plt = true} = OptsRecord) ->
+    case cl_check_init(OptsRecord) of
+	{ok, _} -> ok;
+	{error, Msg} -> throw({dialyzer_error, Msg})
+    end;
+check_init(#options{check_plt = false}) ->
+    ok.
 
 internal_gui(OptsRecord) ->
   F = fun() ->
@@ -199,17 +202,13 @@ gui(Opts) ->
       throw({dialyzer_error, Msg});
     OptsRecord ->
       ok = check_gui_options(OptsRecord),
-      case cl_check_init(OptsRecord) of
-	{ok, ?RET_NOTHING_SUSPICIOUS} ->
-	  F = fun() ->
-		  dialyzer_gui_wx:start(OptsRecord)
-	      end,
-	  case doit(F) of
-	    {ok, _} -> ok;
-	    {error, Msg} -> throw({dialyzer_error, Msg})
-	  end;
-	{error, ErrorMsg1} ->
-	  throw({dialyzer_error, ErrorMsg1})
+      ok = check_init(OptsRecord),
+      F = fun() ->
+          dialyzer_gui_wx:start(OptsRecord)
+      end,
+      case doit(F) of
+	  {ok, _} -> ok;
+	  {error, Msg} -> throw({dialyzer_error, Msg})
       end
   catch
     throw:{dialyzer_error, ErrorMsg} ->

--- a/lib/dialyzer/test/dialyzer_SUITE.erl
+++ b/lib/dialyzer/test/dialyzer_SUITE.erl
@@ -30,12 +30,13 @@
 -export([init_per_testcase/2, end_per_testcase/2]).
 
 %% Test cases must be exported.
--export([app_test/1, appup_test/1, beam_tests/1]).
+-export([app_test/1, appup_test/1, beam_tests/1,
+	 run_plt_check/1, run_succ_typings/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
-    [app_test, appup_test, beam_tests].
+    [app_test, appup_test, beam_tests, run_plt_check, run_succ_typings].
 
 groups() ->
     [].
@@ -93,7 +94,75 @@ beam_tests(Config) when is_list(Config) ->
              ">>,
     Opts = [no_auto_import],
     {ok, BeamFile} = compile(Config, Prog, no_auto_import, Opts),
-    [] = run_dialyzer([BeamFile]),
+    [] = run_dialyzer(plt_build, [BeamFile], []),
+    ok.
+
+run_plt_check(Config) when is_list(Config) ->
+    Mod1 = <<"
+	      -module(run_plt_check1).
+	     ">>,
+
+    Mod2A = <<"
+	       -module(run_plt_check2).
+	      ">>,
+
+    {ok, BeamFile1} = compile(Config, Mod1, run_plt_check1, []),
+    {ok, BeamFile2} = compile(Config, Mod2A, run_plt_check2, []),
+    [] = run_dialyzer(plt_build, [BeamFile1, BeamFile2], []),
+
+    Mod2B = <<"
+	       -module(run_plt_check2).
+
+	       -export([call/1]).
+
+	       call(X) -> run_plt_check1:call(X).
+	     ">>,
+
+    {ok, BeamFile2} = compile(Config, Mod2B, run_plt_check2, []),
+
+    % callgraph warning as run_plt_check2:call/1 makes a call to unexported
+    % function run_plt_check1:call/1.
+    [_] = run_dialyzer(plt_check, [], []),
+
+    ok.
+
+run_succ_typings(Config) when is_list(Config) ->
+    Mod1A = <<"
+	       -module(run_succ_typings1).
+
+	       -export([call/0]).
+
+	       call() -> a.
+	      ">>,
+
+    {ok, BeamFile1} = compile(Config, Mod1A, run_succ_typings1, []),
+    [] = run_dialyzer(plt_build, [BeamFile1], []),
+
+    Mod1B = <<"
+	       -module(run_succ_typings1).
+
+	       -export([call/0]).
+
+	       call() -> b.
+	     ">>,
+
+    Mod2 = <<"
+	      -module(run_succ_typings2).
+
+	      -export([call/0]).
+
+	      -spec call() -> b.
+	      call() -> run_succ_typings1:call().
+	     ">>,
+
+    {ok, BeamFile1} = compile(Config, Mod1B, run_succ_typings1, []),
+    {ok, BeamFile2} = compile(Config, Mod2, run_succ_typings2, []),
+    % contract types warning as run_succ_typings2:call/0 makes a call to
+    % run_succ_typings1:call/0, which returns a (not b) in the PLT.
+    [_] = run_dialyzer(succ_typings, [BeamFile2], [{check_plt, false}]),
+    % warning not returned as run_succ_typings1 is updated in the PLT.
+    [] = run_dialyzer(succ_typings, [BeamFile2], [{check_plt, true}]),
+
     ok.
 
 compile(Config, Prog, Module, CompileOpts) ->
@@ -105,8 +174,9 @@ compile(Config, Prog, Module, CompileOpts) ->
     {ok, Module} = compile:file(Filename, Opts),
     {ok, filename:join([PrivDir, lists:concat([Module, ".beam"])])}.
 
-run_dialyzer(Files) ->
-    dialyzer:run([{analysis_type, plt_build},
-                  {files, Files},
-                  {from, byte_code},
-                  {check_plt, false}]).
+run_dialyzer(Analysis, Files, Opts) ->
+    dialyzer:run([{analysis_type, Analysis},
+		  {files, Files},
+		  {from, byte_code},
+		  {warnings, [no_unknown]} |
+		  Opts]).


### PR DESCRIPTION
* Document (previously undocumented) option check_plt
* Nolonger check a PLT twice when the analysis type is plt_check
* Nolonger raise a case_clause error when checking a plt finds warnings