### PR TITLE
Fix file:position (not raw mode)

### DIFF
--- a/lib/kernel/src/file_io_server.erl
+++ b/lib/kernel/src/file_io_server.erl
@@ -256,7 +256,12 @@ file_request(close,
     {stop,normal,?PRIM_FILE:close(Handle),State#state{buf= <<>>}};
 file_request({position,At}, 
 	     #state{handle=Handle,buf=Buf}=State) ->
-    std_reply(position(Handle, At, Buf), State);
+    case position(Handle, At, Buf) of
+    {error, _Reason}=Reply ->
+        {error,Reply,State};
+    Reply ->
+        {reply,Reply,State#state{buf= <<>>}}
+    end;
 file_request(truncate, 
 	     #state{handle=Handle}=State) ->
     case ?PRIM_FILE:truncate(Handle) of

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -47,7 +47,7 @@
 -export([cur_dir_0/1, cur_dir_1/1, make_del_dir/1,
 	 list_dir/1,list_dir_error/1,
 	 untranslatable_names/1, untranslatable_names_error/1,
-	 pos1/1, pos2/1]).
+	 pos1/1, pos2/1, pos3/1]).
 -export([close/1, consult1/1, path_consult/1, delete/1]).
 -export([ eval1/1, path_eval/1, script1/1, path_script/1,
 	 open1/1,
@@ -1219,6 +1219,20 @@ pos2(Config) when is_list(Config) ->
     ?line test_server:timetrap_cancel(Dog),
     ok.
 
+pos3(suite) -> [];
+pos3(doc) -> ["When it does not use raw mode, file:postiion had a bug."];
+pos3(Config) when is_list(Config) ->
+    ?line Dog = test_server:timetrap(test_server:seconds(5)),
+    ?line RootDir = ?config(data_dir, Config),
+    ?line Name = filename:join(RootDir, "realmen.html.gz"),
+
+    ?line {ok, Fd} = ?FILE_MODULE:open(Name, [read, binary]),
+    ?line {ok, _}  = ?FILE_MODULE:read(Fd, 5),
+    ?line {error, einval} = ?FILE_MODULE:position(Fd, {bof, -1}),
+    %% Here ok had returned =(
+    ?line {error, einval} = ?FILE_MODULE:position(Fd, {cur, -10}),
+    ?line test_server:timetrap_cancel(Dog),
+    ok.
 
 file_info_basic_file(suite) -> [];
 file_info_basic_file(doc) -> [];


### PR DESCRIPTION
When it called the "file:position", it subtract the size that was read into the buffer, and returns the value.
However, it has been discarded buffer and correct position is lost, if "file:postion" returns error.

So...

e.g.
```erlang
%% data ... <<"abcdefghijklmnopqrstuvwxyz">> (size: 26Bytes)
1> {ok, Fd} = file:open("data", [read, binary]).
{ok, <0.38.0>}
2> file:read(Fd, 5).
{ok, <<"abcde">>}
3> file:position(Fd, {bof, -1}).
{error, einval}
4> file:position(Fd, cur).
{ok, 27} %% skip !!
5> file:read(Fd, 1).
eof
```

I fix this.