### PR TITLE
Fix filename:split/1 when given <<>>.

### DIFF
--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -644,7 +644,7 @@ split(Name0) ->
 unix_splitb(Name) ->
     L = binary:split(Name,[<<"/">>],[global]),
     LL = case L of
-	     [<<>>|Rest] ->
+	     [<<>>|Rest] when Rest =/= [] ->
 		 [<<"/">>|Rest];
 	     _ ->
 		 L

--- a/lib/stdlib/test/filename_SUITE.erl
+++ b/lib/stdlib/test/filename_SUITE.erl
@@ -687,6 +687,7 @@ split_bin(Config) when is_list(Config) ->
     [<<"/">>,<<"usr">>,<<"local">>,<<"bin">>] = filename:split(<<"/usr/local/bin">>),
     [<<"foo">>,<<"bar">>]= filename:split(<<"foo/bar">>),
     [<<"foo">>, <<"bar">>, <<"hello">>]= filename:split(<<"foo////bar//hello">>),
+    [] = filename:split(<<>>),
     case os:type() of
        {win32,_} ->
 	    [<<"a:/">>,<<"msdev">>,<<"include">>] =


### PR DESCRIPTION
 Now, given `<<>>` to `filename:split/1`, `<<"/">>` is returned. I think it is strange that come back `<<"/">>`, when there is no path. So I was modified to return an empty list `[]`.
 This also is the same as the behavior when given an empty string.

- previous behavior
```erl
> filename:split(<<>>).
[<<"/">>]
```

- post behavior
```erl
> filename:split(<<>>).
[]
```
