### PR TITLE
Fix dialyzer warning in ssh (missing timestamp function)

### DIFF
--- a/lib/ssh/src/ssh_info.erl
+++ b/lib/ssh/src/ssh_info.erl
@@ -179,14 +179,7 @@ line(Len, Char) ->
 	    
 
 datetime() ->
-    %% Adapt to new OTP 18 erlang time API and be back-compatible
-    TimeStamp = try
-                    erlang:timestamp()
-                catch
-                    error:undef ->
-                        erlang:now()
-                end,
-    {{YYYY,MM,DD}, {H,M,S}} = calendar:now_to_universal_time(TimeStamp),
+    {{YYYY,MM,DD}, {H,M,S}} = calendar:now_to_universal_time(now()),
     lists:flatten(io_lib:format('~4w-~2..0w-~2..0w ~2..0w:~2..0w:~2..0w UTC',[YYYY,MM,DD, H,M,S])).
 
 


### PR DESCRIPTION
Since af972aa, the following warning appears when building the dialyzer PLT:

    dialyzer --build_plt --apps erts kernel stdlib mnesia compiler asn1 syntax_tools hipe crypto public_key ssh
      Compiling some key modules to native code... done in 0m18.65s
      Creating PLT /home/weisslj/.dialyzer_plt ...
    ssh_info.erl:184: Call to missing or unexported function erlang:timestamp/0
     done in 2m14.41s
    done (warnings were emitted)