### PR TITLE
Add the link to Fun expressions manual page

### DIFF
--- a/system/doc/programming_examples/funs.xmlsrc
+++ b/system/doc/programming_examples/funs.xmlsrc
@@ -115,7 +115,9 @@ foreach(fun(Pid) -> Pid ! M end, L)</code>
 
   <section>
     <title>The Syntax of Funs</title>
-    <p>Funs are written with the syntax:</p>
+    <p>Funs are written with the syntax (see <seealso
+      marker="doc/reference_manual:expressions#funs">Fun Expressions
+      </seealso> for the full description):</p>
     <code type="none">
 F = fun (Arg1, Arg2, ... ArgN) ->
         ...


### PR DESCRIPTION
The current document does not show full description of fun syntax.

I got help from @nox to see if the syntax with optional function name is legitimate, so hopefully this PR will help to make the document less confusing.