### PR TITLE
Fix tags completion in erlang.el for GNU Emacs 23+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # emacs
 *~
+lib/tools/emacs/*.elc
 # vim
 .*.sw[a-z]
 


### PR DESCRIPTION
The tag completion code was changed in GNU Emacs 23.1 in a way that
broke erlang.el tag completion.  This commit fix that for Emacs 23.1 and
later.

Add progress report while building completion table.

Add completion of module_info/0 for all modules.

Add lib/tools/emacs/*.elc to .gitignore.