### PR TITLE
erts/configure.in: handle more 'linux' spellings

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -649,7 +649,7 @@ fi
 case $chk_opsys_ in
     win32)			OPSYS=win32;;
     solaris2.*|SunOS5.*)	OPSYS=sol2;;
-    linux|Linux)		OPSYS=linux;;
+    linux*|Linux)		OPSYS=linux;;
     darwin|Darwin)		OPSYS=darwin;;
     freebsd|FreeBSD)		OPSYS=freebsd;;
     *)				OPSYS=noopsys


### PR DESCRIPTION
The configuration code which canonicalizes the operating system
name into OPSYS requires Linux to be spelled 'linux' or 'Linux'.

This is a problem in some build environments, e.g. RPM, which
supply --build and --host using the longer 'linux-gnu' spelling.
The effect is that OPSYS becomes 'noopsys' and some checks in
erts/configure.in do not work as expected, e.g. the auto-enabling
of HiPE may not happen.

Fixed by matching on 'linux*' not just 'linux'.

On ARM there are even longer variants such as 'linux-gnueabi' and
'linux-gnueabihf': these are also correctly mapped to 'linux' now.