### PR TITLE
add gb_trees:iterator_from

### DIFF
--- a/lib/stdlib/doc/src/gb_trees.xml
+++ b/lib/stdlib/doc/src/gb_trees.xml
@@ -188,7 +188,7 @@
       <desc>
         <p>Returns an iterator that can be used for traversing the
             entries of <c><anno>Tree</anno></c>; see <c>next/1</c>. The main
-            difference with regular iterator that it finds firts key greater
+            difference with regular iterator that it finds first key greater
             of equal <c><anno>Key</anno></c> and then traverse
             remaining tree.</p>
       </desc>

--- a/lib/stdlib/doc/src/gb_trees.xml
+++ b/lib/stdlib/doc/src/gb_trees.xml
@@ -42,7 +42,7 @@
     <title>Data structure</title>
     <p>Data structure:</p>
     <code type="none">
-      
+
 - {Size, Tree}, where `Tree' is composed of nodes of the form:
   - {Key, Value, Smaller, Bigger}, and the "empty tree" node:
   - nil.</code>
@@ -183,6 +183,17 @@
       </desc>
     </func>
     <func>
+      <name name="iterator_from" arity="2"/>
+      <fsummary>Return an iterator for a tree starting from specified key</fsummary>
+      <desc>
+        <p>Returns an iterator that can be used for traversing the
+            entries of <c><anno>Tree</anno></c>; see <c>next/1</c>. The main
+            difference with regular iterator that it finds firts key greater
+            of equal <c><anno>Key</anno></c> and then traverse
+            remaining tree.</p>
+      </desc>
+    </func>
+    <func>
       <name name="keys" arity="1"/>
       <fsummary>Return a list of the keys in a tree</fsummary>
       <desc>
@@ -292,7 +303,7 @@
 
   <section>
     <title>SEE ALSO</title>
-    <p><seealso marker="gb_sets">gb_sets(3)</seealso>, 
+    <p><seealso marker="gb_sets">gb_sets(3)</seealso>,
       <seealso marker="dict">dict(3)</seealso></p>
   </section>
 </erlref>

--- a/lib/stdlib/src/gb_trees.erl
+++ b/lib/stdlib/src/gb_trees.erl
@@ -102,6 +102,12 @@
 %%   approach is that it does not require the complete list of all
 %%   elements to be built in memory at one time.
 %%
+%% - iterator_from(K, T): returns an iterator starting from K. that can
+%%   be used for traversing the entries of tree T; see `next'. The main
+%%   difference with regular iterator that it finds starting position
+%%   in O(logN) and then traverse remaining tree. Helpful if you need
+%%   to fetch ranges from tree.
+%%
 %% - next(S): returns {X, V, S1} where X is the smallest key referred to
 %%   by the iterator S, and S1 is the new iterator to be used for
 %%   traversing the remaining entries, or the atom `none' if no entries
@@ -117,7 +123,7 @@
 	 update/3, enter/3, delete/2, delete_any/2, balance/1,
 	 is_defined/2, keys/1, values/1, to_list/1, from_orddict/1,
 	 smallest/1, largest/1, take_smallest/1, take_largest/1,
-	 iterator/1, next/1, map/2]).
+	 iterator/1, iterator_from/2, next/1, map/2]).
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -529,6 +535,32 @@ iterator({_, _, L, _} = T, As) ->
 iterator(nil, As) ->
     As.
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% regular version will iterate through all the key even if we need only last 10
+%% this version allows to specify start key from which iteration begins
+%% Need duplicate all the functions for backard compatibility
+%% because we can't guarantee key that will be smaller than other possible keys
+-spec iterator_from(Key, Tree) -> Iter when
+      Tree :: tree(Key, Value),
+      Iter :: iter(Key, Value).
+
+iterator_from(S, {_, T}) ->
+    iterator_1_from(S, T).
+
+iterator_1_from(S, T) ->
+    iterator_from(S, T, []).
+
+iterator_from(S, {K, _, _, T}, As) when K < S ->
+    iterator_from(S, T, As);
+iterator_from(_, {_, _, nil, _} = T, As) ->
+    [T | As];
+iterator_from(S, {_, _, L, _} = T, As) ->
+    iterator_from(S, L, [T | As]);
+iterator_from(_, nil, As) ->
+    As.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 -spec next(Iter1) -> 'none' | {Key, Value, Iter2} when
       Iter1 :: iter(Key, Value),
       Iter2 :: iter(Key, Value).

--- a/lib/stdlib/test/dict_SUITE.erl
+++ b/lib/stdlib/test/dict_SUITE.erl
@@ -1,19 +1,19 @@
 %%
 %% %CopyrightBegin%
-%% 
+%%
 %% Copyright Ericsson AB 2008-2013. All Rights Reserved.
-%% 
+%%
 %% The contents of this file are subject to the Erlang Public License,
 %% Version 1.1, (the "License"); you may not use this file except in
 %% compliance with the License. You should have received a copy of the
 %% Erlang Public License along with this software. If not, it can be
 %% retrieved online at http://www.erlang.org/.
-%% 
+%%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
 %% the License for the specific language governing rights and limitations
 %% under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 
@@ -22,21 +22,21 @@
 
 -module(dict_SUITE).
 
--export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
-	 init_per_group/2,end_per_group/2,
-	 init_per_testcase/2,end_per_testcase/2,
-	 create/1,store/1]).
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
+         init_per_group/2,end_per_group/2,
+         init_per_testcase/2,end_per_testcase/2,
+         create/1,store/1,iterate/1]).
 
 -include_lib("test_server/include/test_server.hrl").
 
--import(lists, [foldl/3,reverse/1]).
+-import(lists, [foldl/3]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
-all() -> 
-    [create, store].
+all() ->
+    [create, store, iterate].
 
-groups() -> 
+groups() ->
     [].
 
 init_per_suite(Config) ->
@@ -50,7 +50,6 @@ init_per_group(_GroupName, Config) ->
 
 end_per_group(_GroupName, Config) ->
     Config.
-
 
 init_per_testcase(_Case, Config) ->
     Dog = ?t:timetrap(?t:minutes(5)),
@@ -80,16 +79,29 @@ store_1(List, M) ->
     %% Make sure that we get the same result by inserting
     %% elements one at the time.
     D1 = foldl(fun({K,V}, Dict) -> M(enter, {K,V,Dict}) end,
-	       M(empty, []), List),
+               M(empty, []), List),
     true = M(equal, {D0,D1}),
     case List of
-	[] ->
-	    true = M(is_empty, D0),
-	    true = M(is_empty, D1);
-	[_|_] ->
-	    false = M(is_empty, D0),
-	    false = M(is_empty, D1)
+        [] ->
+            true = M(is_empty, D0),
+            true = M(is_empty, D1);
+        [_|_] ->
+            false = M(is_empty, D0),
+            false = M(is_empty, D1)
     end,
+    D0.
+
+iterate(Config) when is_list(Config) ->
+    test_all([{0,132},{253,258},{510,514}], fun iterate_1/2).
+
+iterate_1(List, M) ->
+    D0 = M(from_list, List),
+    L0 = M(to_list, D0),
+    L0 = M(iterate, D0),
+    Start = random:uniform(100),
+    Filter = fun({K, _}) -> K >= Start end,
+    L1 = lists:filter(Filter, L0),
+    L1 = M(iterate_from, {Start, D0}),
     D0.
 
 %%%
@@ -99,11 +111,11 @@ store_1(List, M) ->
 dict_mods() ->
     Orddict = dict_test_lib:new(orddict, fun(X, Y) -> X == Y end),
     Dict = dict_test_lib:new(dict, fun(X, Y) ->
-					   lists:sort(dict:to_list(X)) == 
-					       lists:sort(dict:to_list(Y)) end),
+                    lists:sort(dict:to_list(X)) ==
+                    lists:sort(dict:to_list(Y)) end),
     Gb = dict_test_lib:new(gb_trees, fun(X, Y) ->
-					     gb_trees:to_list(X) == 
-						 gb_trees:to_list(Y) end),
+                    gb_trees:to_list(X) ==
+                    gb_trees:to_list(Y) end),
     [Orddict,Dict,Gb].
 
 test_all(Tester) ->
@@ -113,16 +125,16 @@ test_all(Tester) ->
 spawn_tester(M, Tester) ->
     Parent = self(),
     spawn_link(fun() ->
-		       random:seed(1, 2, 42),
-		       S = Tester(M),
-		       Res = {M(size, S),lists:sort(M(to_list, S))},
-		       Parent ! {result,self(),Res}
-	       end).
+                random:seed(1, 2, 42),
+                S = Tester(M),
+                Res = {M(size, S),lists:sort(M(to_list, S))},
+                Parent ! {result,self(),Res}
+        end).
 
 collect_all([Pid|Pids], Acc) ->
     receive
-	{result,Pid,Result} ->
-	    collect_all(Pids, [Result|Acc])
+        {result,Pid,Result} ->
+            collect_all(Pids, [Result|Acc])
     end;
 collect_all([], Acc) ->
     all_same(Acc).
@@ -156,7 +168,7 @@ rnd_list_1(N, Acc) ->
 
 atomic_rnd_term() ->
     case random:uniform(3) of
-	 1 -> list_to_atom(integer_to_list($\s+random:uniform(94))++"rnd");
-	 2 -> random:uniform();
-	 3 -> random:uniform(50)-37
+        1 -> list_to_atom(integer_to_list($\s+random:uniform(94))++"rnd");
+        2 -> random:uniform();
+        3 -> random:uniform(50)-37
     end.

--- a/lib/stdlib/test/dict_test_lib.erl
+++ b/lib/stdlib/test/dict_test_lib.erl
@@ -1,19 +1,19 @@
 %%
 %% %CopyrightBegin%
-%% 
+%%
 %% Copyright Ericsson AB 2008-2013. All Rights Reserved.
-%% 
+%%
 %% The contents of this file are subject to the Erlang Public License,
 %% Version 1.1, (the "License"); you may not use this file except in
 %% compliance with the License. You should have received a copy of the
 %% Erlang Public License along with this software. If not, it can be
 %% retrieved online at http://www.erlang.org/.
-%% 
+%%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
 %% the License for the specific language governing rights and limitations
 %% under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 
@@ -29,7 +29,10 @@ new(Mod, Eq) ->
 	(module, []) -> Mod;
 	(size, D) -> Mod:size(D);
 	(is_empty, D) -> Mod:is_empty(D);
+    (iterate_from, {S, D}) -> iterate_from(Mod, S, D);
+    (iterate, D) -> iterate(Mod, D);
 	(to_list, D) -> to_list(Mod, D)
+    % (to_list_ordered, D) -> to_list_ordered(Mod, D)
     end.
 
 empty(Mod) ->
@@ -40,6 +43,13 @@ empty(Mod) ->
 
 to_list(Mod, D) ->
     Mod:to_list(D).
+
+% to_list_ordered(Mod, D) ->
+    % L = Mod:to_list(D),
+    % case Mod of
+        % dict -> lists:sort(L);
+        % _ -> L
+    % end.
 
 from_list(Mod, L) ->
     case erlang:function_exported(Mod, from_orddict, 1) of
@@ -54,6 +64,36 @@ from_list(Mod, L) ->
 	    Orddict = orddict:from_list(L),
 	    Mod:from_orddict(Orddict)
     end.
+
+iterate(Mod, Dict) ->
+    case erlang:function_exported(Mod, iterator, 1) of
+        true ->
+            lists:reverse(iterate_tree(Mod, Dict));
+        false ->
+            Mod:to_list(Dict)
+    end.
+
+iterate_from(Mod, Start, Dict) ->
+    case erlang:function_exported(Mod, iterator_from, 2) of
+        true ->
+            lists:reverse(iterate_tree(Mod, Start, Dict));
+        false ->
+            Filter = fun({K, _}) -> K >= Start end,
+            lists:filter(Filter, Mod:to_list(Dict))
+    end.
+
+iterate_tree(Mod, Tree) ->
+    I = Mod:iterator(Tree),
+    iterate_tree_1(Mod, Mod:next(I), []).
+
+iterate_tree(Mod, Start, Tree) ->
+    I = Mod:iterator_from(Start, Tree),
+    iterate_tree_1(Mod, Mod:next(I), []).
+
+iterate_tree_1(_, none, R) ->
+    R;
+iterate_tree_1(Mod, {K, V, I}, R) ->
+    iterate_tree_1(Mod, Mod:next(I), [{K, V} | R]).
 
 %% Store new value into dictionary or update previous value in dictionary.
 enter(Mod, Key, Val, Dict) ->


### PR DESCRIPTION
gb_trees iterator version useful for traversing from specified Key (all keys greater than specified) without the need to skip previous keys
I coludn't locate any tests for gb_trees, if you direct me I write some tests.