### PR TITLE
Use inet_dist options when setting up TLS Dist proxy

### DIFF
--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -103,7 +103,7 @@ init([]) ->
 handle_call({listen, Name}, _From, State) ->
     case gen_tcp:listen(0, [{active, false}, {packet,?PPRE}]) of
        {ok, Socket} ->
-           {ok, World} = do_listen([{active, false}, binary, {packet,?PPRE}]),
+           {ok, World} = do_listen([{active, false}, binary, {packet,?PPRE}, {reuseaddr, true}]),
            {ok, TcpAddress} = get_tcp_address(Socket),
            {ok, WorldTcpAddress} = get_tcp_address(World),
            {_,Port} = WorldTcpAddress#net_address.address,


### PR DESCRIPTION
When using SSL for a cluster, the inet_dist_listen_min/max options are ignored and the socket is bound  to whatever port the kernel gives it. This patch makes the 'World' socket in the tls dist proxy use the same options as the listener in lib/kernel/src/inet_tcp_dist.erl