### PR TITLE
erts/hipe: unbreak arity 4 BIFs

### DIFF
--- a/erts/emulator/hipe/hipe_amd64_bifs.m4
+++ b/erts/emulator/hipe/hipe_amd64_bifs.m4
@@ -159,37 +159,36 @@ define(standard_bif_interface_4,
 `
 #ifndef HAVE_$1
 #`define' HAVE_$1
-    TEXT
-    .align  4
-    GLOBAL(ASYM($1))
+	TEXT
+	.align  4
+	GLOBAL(ASYM($1))
 ASYM($1):
-    /* set up the parameters */
-    movq    P, %rdi
-    NBIF_ARG(%rsi,4,0)
-    NBIF_ARG(%rdx,4,1)
-    NBIF_ARG(%rcx,4,2)
-    NBIF_ARG(%r8,4,3)
+	/* set up the parameters */
+	movq	P, %rdi
+	NBIF_ARG(%rsi,4,0)
+	NBIF_ARG(%rdx,4,1)
+	NBIF_ARG(%rcx,4,2)
+	NBIF_ARG(%r8,4,3)
 
-    /* make the call on the C stack */
-    SWITCH_ERLANG_TO_C
-    pushq   %r8
-    pushq   %rcx
-    pushq   %rdx
-    pushq   %rsi
-    movq    %rsp, %rsi  /* Eterm* BIF__ARGS */
-    sub $(8), %rsp  /* stack frame 16-byte alignment */
-    CALL_BIF($2)
-    add $(4*8 + 8), %rsp
-    TEST_GOT_MBUF
-    SWITCH_C_TO_ERLANG
+	/* make the call on the C stack */
+	SWITCH_ERLANG_TO_C
+	pushq	%r8
+	pushq	%rcx
+	pushq	%rdx
+	pushq	%rsi
+	movq	%rsp, %rsi	/* Eterm* BIF__ARGS */
+	CALL_BIF($2)
+	add	$(4*8), %rsp
+	TEST_GOT_MBUF
+	SWITCH_C_TO_ERLANG
 
-    /* throw exception if failure, otherwise return */
-    TEST_GOT_EXN
-    jz  nbif_4_simple_exception
-    NBIF_RET(4)
-    HANDLE_GOT_MBUF(4)
-    SET_SIZE(ASYM($1))
-    TYPE_FUNCTION(ASYM($1))
+	/* throw exception if failure, otherwise return */
+	TEST_GOT_EXN
+	jz	nbif_4_simple_exception
+	NBIF_RET(4)
+	HANDLE_GOT_MBUF(4)
+	SET_SIZE(ASYM($1))
+	TYPE_FUNCTION(ASYM($1))
 #endif')
 
 define(standard_bif_interface_0,

--- a/erts/emulator/hipe/hipe_arm_asm.m4
+++ b/erts/emulator/hipe/hipe_arm_asm.m4
@@ -163,6 +163,10 @@ define(NBIF_ARG,`ifelse(eval($3 >= NR_ARG_REGS),0,`NBIF_REG_ARG($1,$3)',`NBIF_ST
 `/* #define NBIF_ARG_3_0	'NBIF_ARG(r1,3,0)` */'
 `/* #define NBIF_ARG_3_1	'NBIF_ARG(r2,3,1)` */'
 `/* #define NBIF_ARG_3_2	'NBIF_ARG(r3,3,2)` */'
+`/* #define NBIF_ARG_4_0	'NBIF_ARG(r1,4,0)` */'
+`/* #define NBIF_ARG_4_1	'NBIF_ARG(r2,4,1)` */'
+`/* #define NBIF_ARG_4_2	'NBIF_ARG(r3,4,2)` */'
+`/* #define NBIF_ARG_4_3	'NBIF_ARG(r4,4,3)` */'
 `/* #define NBIF_ARG_5_0	'NBIF_ARG(r1,5,0)` */'
 `/* #define NBIF_ARG_5_1	'NBIF_ARG(r2,5,1)` */'
 `/* #define NBIF_ARG_5_2	'NBIF_ARG(r3,5,2)` */'
@@ -186,6 +190,7 @@ define(NBIF_RET,`NBIF_RET_N(eval(RET_POP($1)))')dnl
 `/* #define NBIF_RET_1	'NBIF_RET(1)` */'
 `/* #define NBIF_RET_2	'NBIF_RET(2)` */'
 `/* #define NBIF_RET_3	'NBIF_RET(3)` */'
+`/* #define NBIF_RET_4	'NBIF_RET(4)` */'
 `/* #define NBIF_RET_5	'NBIF_RET(5)` */'
 
 dnl

--- a/erts/emulator/hipe/hipe_arm_bifs.m4
+++ b/erts/emulator/hipe/hipe_arm_bifs.m4
@@ -42,9 +42,10 @@ define(TEST_GOT_MBUF,`ldr r1, [P, #P_MBUF]	/* `TEST_GOT_MBUF' */
  * standard_bif_interface_1(nbif_name, cbif_name)
  * standard_bif_interface_2(nbif_name, cbif_name)
  * standard_bif_interface_3(nbif_name, cbif_name)
+ * standard_bif_interface_4(nbif_name, cbif_name)
  * standard_bif_interface_0(nbif_name, cbif_name)
  *
- * Generate native interface for a BIF with 1-3 parameters and
+ * Generate native interface for a BIF with 0-4 parameters and
  * standard failure mode.
  */
 define(standard_bif_interface_1,
@@ -129,6 +130,39 @@ $1:
 	RESTORE_CONTEXT_BIF
 	beq	nbif_3_simple_exception
 	NBIF_RET(3)
+	.ltorg
+	.size	$1, .-$1
+	.type	$1, %function
+#endif')
+
+define(standard_bif_interface_4,
+`
+#ifndef HAVE_$1
+#`define' HAVE_$1
+	.global	$1
+$1:
+	/* Set up C argument registers. */
+	mov	r0, P
+	NBIF_ARG(r1,4,0)
+	NBIF_ARG(r2,4,1)
+	NBIF_ARG(r3,4,2)
+	NBIF_ARG(r4,4,3)
+
+	/* Save caller-save registers and call the C function. */
+	SAVE_CONTEXT_BIF
+	str	r1, [r0, #P_ARG0]	/* Store BIF__ARGS in def_arg_reg[] */
+	str	r2, [r0, #P_ARG1]
+	str	r3, [r0, #P_ARG2]
+	str	r4, [r0, #P_ARG3]
+	add	r1, r0, #P_ARG0
+	CALL_BIF($2)
+	TEST_GOT_MBUF(4)
+
+	/* Restore registers. Check for exception. */
+	cmp	r0, #THE_NON_VALUE
+	RESTORE_CONTEXT_BIF
+	beq	nbif_4_simple_exception
+	NBIF_RET(4)
 	.ltorg
 	.size	$1, .-$1
 	.type	$1, %function

--- a/erts/emulator/hipe/hipe_arm_glue.S
+++ b/erts/emulator/hipe/hipe_arm_glue.S
@@ -330,6 +330,12 @@ nbif_2_gc_after_bif:
 	.type	nbif_3_gc_after_bif, %function
 nbif_3_gc_after_bif:
 	mov	r1, #3
+	b	.gc_after_bif
+
+	.global	nbif_4_gc_after_bif
+	.type	nbif_4_gc_after_bif, %function
+nbif_4_gc_after_bif:
+	mov	r1, #4
 	/*FALLTHROUGH*/
 .gc_after_bif:
 	str	r1, [P, #P_NARITY]
@@ -376,6 +382,12 @@ nbif_2_simple_exception:
 	.type	nbif_3_simple_exception, %function
 nbif_3_simple_exception:
 	mov	r1, #3
+	b	.nbif_simple_exception
+
+	.global	nbif_4_simple_exception
+	.type	nbif_4_simple_exception, %function
+nbif_4_simple_exception:
+	mov	r1, #4
 	/*FALLTHROUGH*/
 .nbif_simple_exception:
 	ldr	r0, [P, #P_FREASON]

--- a/erts/emulator/hipe/hipe_ppc_glue.S
+++ b/erts/emulator/hipe/hipe_ppc_glue.S
@@ -510,22 +510,26 @@ CSYM(nbif_4_gc_after_bif):
 CSYM(nbif_0_simple_exception):
 	li	r4, 0
 	b	.nbif_simple_exception
+
 	OPD(nbif_1_simple_exception)
 	GLOBAL(CSYM(nbif_1_simple_exception))
 CSYM(nbif_1_simple_exception):
 	li	r4, 1
 	b	.nbif_simple_exception
+
 	OPD(nbif_2_simple_exception)
 	GLOBAL(CSYM(nbif_2_simple_exception))
 CSYM(nbif_2_simple_exception):
 	li	r4, 2
 	b	.nbif_simple_exception
+
 	OPD(nbif_3_simple_exception)
 	GLOBAL(CSYM(nbif_3_simple_exception))
 CSYM(nbif_3_simple_exception):
 	li	r4, 3
 	b	.nbif_simple_exception
-	OPD(nbif_3_simple_exception)
+
+	OPD(nbif_4_simple_exception)
 	GLOBAL(CSYM(nbif_4_simple_exception))
 CSYM(nbif_4_simple_exception):
 	li	r4, 4

--- a/erts/emulator/hipe/hipe_sparc_bifs.m4
+++ b/erts/emulator/hipe/hipe_sparc_bifs.m4
@@ -54,7 +54,7 @@ define(HANDLE_GOT_MBUF,`
  * standard_bif_interface_1(nbif_name, cbif_name)
  * standard_bif_interface_2(nbif_name, cbif_name)
  * standard_bif_interface_3(nbif_name, cbif_name)
- * standard_bif_interface_3(nbif_name, cbif_name)
+ * standard_bif_interface_4(nbif_name, cbif_name)
  * standard_bif_interface_0(nbif_name, cbif_name)
  *
  * Generate native interface for a BIF with 0-4 parameters and

--- a/erts/emulator/hipe/hipe_x86_bifs.m4
+++ b/erts/emulator/hipe/hipe_x86_bifs.m4
@@ -51,7 +51,7 @@ define(HANDLE_GOT_MBUF,`
  * standard_bif_interface_4(nbif_name, cbif_name)
  * standard_bif_interface_0(nbif_name, cbif_name)
  *
- * Generate native interface for a BIF with 0-3 parameters and
+ * Generate native interface for a BIF with 0-4 parameters and
  * standard failure mode.
  */
 define(standard_bif_interface_1,


### PR DESCRIPTION
This fixes arity 4 BIF support in HiPE, following its introduction
on master (OTP 18) via the nox/ets-update_counter-4 merge.

- define standard_bif_interface_4, nbif_4_gc_after_bif, and
  nbif_4_simple_exception on ARM: unbreaks the build on ARM
- remove bogus stack re-alignment from standard_bif_interface_4
  on AMD64: for 4-arg BIFs the stack is already aligned, and the
  code would misalign the C stack which violates the ABI and may
  cause alignment faults in vectorized code
- the nbif_4_simple_exception OPD name on PPC64 was incorrectly
  using the nbif_3_simple_exception OPD name: this would have
  caused a multiple definition error in the assembler or linker

In addition there are a few cleanups:

- fix standard_bif_interface_N comment on x86
- fix standard_bif_interface_4 comment on SPARC
- separate nbif_N_simple_exception blocks by empty lines on PPC,
  like on ARM, to clearly show which things belong together
- fix standard_bif_interface_N comment on ARM
- fix standard_bif_interface_4 on AMD64 to match the indentation
  and spacing conventions of the rest of that file