### PR TITLE
Keep dirty schedulers from waking other schedulers

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -4885,9 +4885,11 @@ wakeup_other_check(ErtsRunQueue *rq, Uint32 flags)
 				 + ERTS_WAKEUP_OTHER_FIXED_INC);
 	    if (rq->wakeup_other > wakeup_other.limit) {
 #ifdef ERTS_DIRTY_SCHEDULERS
-		if (ERTS_RUNQ_IX_IS_DIRTY(rq->ix) && rq->waiting)
-		    wake_dirty_schedulers(rq, 1);
-		else
+		if (ERTS_RUNQ_IX_IS_DIRTY(rq->ix)) {
+		    if (rq->waiting) {
+			wake_dirty_schedulers(rq, 1);
+		    }
+		} else
 #endif
 		{
 		    int empty_rqs =


### PR DESCRIPTION
Prevent dirty schedulers from checking regular run queues and trying
to wake up regular schedulers.