### PR TITLE
Fix cross compilation for Android

### DIFF
--- a/erts/etc/common/run_erl_common.c
+++ b/erts/etc/common/run_erl_common.c
@@ -32,6 +32,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifdef __ANDROID__
+#  include <termios.h>
+#endif
+
 #ifdef HAVE_SYSLOG_H
 #  include <syslog.h>
 #endif


### PR DESCRIPTION
Hello,

Trying to build Erlang OTP following the instructions in HOWTO/INSTALL-ANDROID.md has been broken for quite some time.

Here is a 3-line patch to fix the compilation error, based on the maint branch.

Thank you,
Jérôme

P.S. I agree that this contribution can be licensed under Apache 2.0 License as well


Fix cross compilation for Android

Signed-off-by: Jérôme de Bretagne <jerome.debretagne@gmail.com>