### PR TITLE
Minor fixes to emacs erlang-mode

### DIFF
--- a/lib/tools/emacs/test.erl.indented
+++ b/lib/tools/emacs/test.erl.indented
@@ -32,6 +32,14 @@
 -module(test).
 -compile(export_all).
 
+%% Used to cause an "Unbalanced parentheses" error.
+foo(M) ->
+    M#{a :=<<"a">>
+      ,b:=1}.
+foo() ->
+    #{a =><<"a">>
+     ,b=>1}.
+
 %% Module attributes should be highlighted
 
 -export([t/1]).

--- a/lib/tools/emacs/test.erl.orig
+++ b/lib/tools/emacs/test.erl.orig
@@ -32,6 +32,14 @@
 -module(test).
 -compile(export_all).
 
+%% Used to cause an "Unbalanced parentheses" error.
+foo(M) ->
+M#{a :=<<"a">>
+,b:=1}.
+foo() ->
+#{a =><<"a">>
+,b=>1}.
+
 %% Module attributes should be highlighted
 
 -export([t/1]).


### PR DESCRIPTION
Fix "Unbalanced parentheses" error when indenting particular map
constructs. Add new test cases for this fix.

To prevent infinite looping when the programmer mistakenly enters
incorrect syntax, detect cases where erlang-partial-parse fails to
advance when called within a loop, and raise an "Illegal syntax"
error.