### PR TITLE
digraph: export label type

### DIFF
--- a/lib/stdlib/src/digraph.erl
+++ b/lib/stdlib/src/digraph.erl
@@ -36,7 +36,7 @@
 
 -export([get_short_path/3, get_short_cycle/2]).
 
--export_type([graph/0, d_type/0, vertex/0, edge/0]).
+-export_type([graph/0, d_type/0, vertex/0, edge/0, label/0]).
 
 -record(digraph, {vtab = notable :: ets:tab(),
 		  etab = notable :: ets:tab(),


### PR DESCRIPTION
Together with vertex and edge, label is a core type of digraph module
according to documentation and therefore should be exported as well.