### PR TITLE
Delete superfluous comma from `filtermap' example in documentation

### DIFF
--- a/lib/stdlib/doc/src/lists.xml
+++ b/lib/stdlib/doc/src/lists.xml
@@ -176,7 +176,7 @@ filtermap(Fun, List1) ->
                            false -> Acc;
                            true -> [Elem|Acc];
                            {true,Value} -> [Value|Acc]
-                       end,
+                       end
                 end, [], List1).</code>
         <p>Example:</p>
         <pre>


### PR DESCRIPTION
The code explaining the behaviour of `filtermap/2` had a syntax error and wouldn't compile:
```erlang
fun(...) ->
   case
     ...
   end, %% !
end
```