### PR TITLE
Bug fix: erts_atom_get will crash when input string's len too long

### DIFF
--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -382,7 +382,6 @@ erts_atom_get(const char *name, int len, Eterm* ap, ErtsAtomEncoding enc)
     int i;
     int res;
 
-    if (len >= MAX_ATOM_SZ_FROM_LATIN1) { return 0; }
     a.len = (Sint16) len;
     a.name = (byte *)name;
     if (enc == ERTS_ATOM_ENC_LATIN1) {

--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -382,6 +382,7 @@ erts_atom_get(const char *name, int len, Eterm* ap, ErtsAtomEncoding enc)
     int i;
     int res;
 
+    if (len >= MAX_ATOM_SZ_FROM_LATIN1) { return 0; }
     a.len = (Sint16) len;
     a.name = (byte *)name;
     if (enc == ERTS_ATOM_ENC_LATIN1) {

--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -382,6 +382,7 @@ erts_atom_get(const char *name, int len, Eterm* ap, ErtsAtomEncoding enc)
     int i;
     int res;
 
+    if (len > MAX_ATOM_CHARACTERS) { return 0; }
     a.len = (Sint16) len;
     a.name = (byte *)name;
     if (enc == ERTS_ATOM_ENC_LATIN1) {


### PR DESCRIPTION
When I use nif function: enif_make_existing_atom_len(env, str, len, &atom, ERL_NIF_LATIN1), if the input string include some chinese character and the string too long, erlang will crash.

The problem is because erts_atom_get function don't check the input string length. This patch fix the bug.

Following is a test string which will cause the problem:"1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890传统经典"