### PR TITLE
Add details on the FOP formatter

### DIFF
--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -210,6 +210,16 @@ the `$PATH`.
 
     $ export PATH=$ERL_TOP/bin:$PATH     # Assuming bash/sh
 
+For the FOP print formatter, two steps must be taken:
+
+* Adding the location of your installation of `fop` in `$FOP_HOME`.
+
+```
+$ export FOP_HOME=/path/to/fop/dir # Assuming bash/sh
+```
+
+* Adding the `fop` script (in `$FOP_HOME`) to your `$PATH`, either by adding `$FOP_HOME` to `$PATH`, or by copying the `fop` script to a directory already in your `$PATH`.
+
 Build the documentation.
 
     $ make docs


### PR DESCRIPTION
I found that I needed to take the two steps I added to INSTALL.md for
this PR, or else fop execution when doing a "make docs" would fail with
either a Java ClassNotFoundException or command "fop" not found:

* Adding the FOP install directory to $FOP_HOME
* Adding the fop script to $PATH