### PR TITLE
Md5 fixes r18

### DIFF
--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -39,11 +39,8 @@ static void set_default_trace_pattern(Eterm module);
 static Eterm check_process_code(Process* rp, Module* modp, int allow_gc, int *redsp);
 static void delete_code(Module* modp);
 static void decrement_refc(BeamInstr* code);
-static int is_native(BeamInstr* code);
 static int any_heap_ref_ptrs(Eterm* start, Eterm* end, char* mod_start, Uint mod_size);
 static int any_heap_refs(Eterm* start, Eterm* end, char* mod_start, Uint mod_size);
-
-
 
 BIF_RETTYPE code_is_module_native_1(BIF_ALIST_1)
 {
@@ -59,8 +56,8 @@ BIF_RETTYPE code_is_module_native_1(BIF_ALIST_1)
 	return am_undefined;
     }
     erts_rlock_old_code(code_ix);
-    res = ((modp->curr.code && is_native(modp->curr.code)) ||
-	    (modp->old.code != 0 && is_native(modp->old.code))) ?
+    res = (erts_is_module_native(modp->curr.code) ||
+           erts_is_module_native(modp->old.code)) ?
 		am_true : am_false;
     erts_runlock_old_code(code_ix);
     return res;
@@ -1106,25 +1103,3 @@ beam_make_current_old(Process *c_p, ErtsProcLocks c_p_locks, Eterm module)
     }
     return NIL;
 }
-
-static int
-is_native(BeamInstr* code)
-{
-    Uint i, num_functions = code[MI_NUM_FUNCTIONS];
-
-    /* Check NativeAdress of first real function in module
-     */
-    for (i=0; i<num_functions; i++) {
-	BeamInstr* func_info = (BeamInstr *) code[MI_FUNCTIONS+i];
-	Eterm name = (Eterm) func_info[3];
-
-	if (is_atom(name)) {
-	    return func_info[1] != 0;    
-	}
-	else ASSERT(is_nil(name)); /* ignore BIF stubs */
-    }
-    /* Not a single non-BIF function? */
-    return 0;
-}
-
-

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -5497,7 +5497,11 @@ md5_of_module(Process* p, /* Process whose heap to use. */
 	return THE_NON_VALUE;
     }
     code = modp->curr.code;
-    res = new_binary(p, (byte *) code[MI_MD5_PTR], MD5_SIZE);
+    if (code[MI_MD5_PTR] != 0) {
+      res = new_binary(p, (byte *) code[MI_MD5_PTR], MD5_SIZE);
+    } else {
+      res = am_undefined;
+    }
     return res;
 }
 

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -6027,6 +6027,7 @@ erts_make_stub_module(Process* p, Eterm Mod, Eterm Beam, Eterm Info)
     LoaderState* stp;
     BeamInstr Funcs;
     BeamInstr Patchlist;
+    Eterm MD5Bin;
     Eterm* tp;
     BeamInstr* code = NULL;
     BeamInstr* ptrs;
@@ -6055,12 +6056,15 @@ erts_make_stub_module(Process* p, Eterm Mod, Eterm Beam, Eterm Info)
 	goto error;
     }
     tp = tuple_val(Info);
-    if (tp[0] != make_arityval(2)) {
+    if (tp[0] != make_arityval(3)) {
       goto error;
     }
     Funcs = tp[1];
-    Patchlist = tp[2];        
-   
+    Patchlist = tp[2];
+    MD5Bin = tp[3];
+    if (is_not_binary(MD5Bin) || (binary_size(MD5Bin) != MD5_SIZE)) {
+	goto error;
+    }
     if ((n = erts_list_length(Funcs)) < 0) {
 	goto error;
     }
@@ -6110,6 +6114,7 @@ erts_make_stub_module(Process* p, Eterm Mod, Eterm Beam, Eterm Info)
     code_size = ((WORDS_PER_FUNCTION+1)*n + MI_FUNCTIONS + 2) * sizeof(BeamInstr);
     code_size += stp->chunks[ATTR_CHUNK].size;
     code_size += stp->chunks[COMPILE_CHUNK].size;
+    code_size += MD5_SIZE;
     code = erts_alloc_fnf(ERTS_ALC_T_CODE, code_size);
     if (!code) {
 	goto error;
@@ -6215,6 +6220,15 @@ erts_make_stub_module(Process* p, Eterm Mod, Eterm Beam, Eterm Info)
 			  code+MI_COMPILE_SIZE_ON_HEAP);
     if (info == NULL) {
 	goto error;
+    }
+    {
+      byte *tmp = NULL;
+      byte *md5 = NULL;
+      if ((md5 = erts_get_aligned_binary_bytes(MD5Bin, &tmp)) != NULL) {
+        sys_memcpy(info, md5, MD5_SIZE);
+        code[MI_MD5_PTR] = (BeamInstr) info;
+      }
+      erts_free_aligned_binary_bytes(tmp);
     }
 
     /*

--- a/erts/emulator/beam/beam_load.h
+++ b/erts/emulator/beam/beam_load.h
@@ -23,9 +23,9 @@
 #include "beam_opcodes.h"
 #include "erl_process.h"
 
+int erts_is_module_native(BeamInstr* code);
 Eterm beam_make_current_old(Process *c_p, ErtsProcLocks c_p_locks,
 			    Eterm module);
-
 
 typedef struct gen_op_entry {
    char* name;

--- a/erts/emulator/test/code_SUITE.erl
+++ b/erts/emulator/test/code_SUITE.erl
@@ -389,61 +389,63 @@ module_md5_ok(Code) ->
 
 make_stub(Config) when is_list(Config) ->
     catch erlang:purge_module(my_code_test),
+    MD5 = erlang:md5(<<>>),
 
     ?line Data = ?config(data_dir, Config),
     ?line File = filename:join(Data, "my_code_test"),
     ?line {ok,my_code_test,Code} = compile:file(File, [binary]),
 
-    ?line my_code_test = code:make_stub_module(my_code_test, Code, {[],[]}),
+    ?line my_code_test = code:make_stub_module(my_code_test, Code, {[],[],MD5}),
     ?line true = erlang:delete_module(my_code_test),
     ?line true = erlang:purge_module(my_code_test),
 
     ?line my_code_test = code:make_stub_module(my_code_test, 
  					       make_unaligned_sub_binary(Code),
- 					       {[],[]}),
+ 					       {[],[],MD5}),
     ?line true = erlang:delete_module(my_code_test),
     ?line true = erlang:purge_module(my_code_test),
 
     ?line my_code_test = code:make_stub_module(my_code_test, zlib:gzip(Code),
- 					       {[],[]}),
+ 					       {[],[],MD5}),
     ?line true = erlang:delete_module(my_code_test),
     ?line true = erlang:purge_module(my_code_test),
 
     %% Should fail.
     ?line {'EXIT',{badarg,_}} =
-	(catch code:make_stub_module(my_code_test, <<"bad">>, {[],[]})),
+	(catch code:make_stub_module(my_code_test, <<"bad">>, {[],[],MD5})),
     ?line {'EXIT',{badarg,_}} =
 	(catch code:make_stub_module(my_code_test,
 				     bit_sized_binary(Code),
-				     {[],[]})),
+				     {[],[],MD5})),
     ?line {'EXIT',{badarg,_}} =
 	(catch code:make_stub_module(my_code_test_with_wrong_name,
-				     Code, {[],[]})),
+				     Code, {[],[],MD5})),
     ok.
 
 make_stub_many_funs(Config) when is_list(Config) ->
     catch erlang:purge_module(many_funs),
+    MD5 = erlang:md5(<<>>),
 
     ?line Data = ?config(data_dir, Config),
     ?line File = filename:join(Data, "many_funs"),
     ?line {ok,many_funs,Code} = compile:file(File, [binary]),
 
-    ?line many_funs = code:make_stub_module(many_funs, Code, {[],[]}),
+    ?line many_funs = code:make_stub_module(many_funs, Code, {[],[],MD5}),
     ?line true = erlang:delete_module(many_funs),
     ?line true = erlang:purge_module(many_funs),
     ?line many_funs = code:make_stub_module(many_funs, 
  					       make_unaligned_sub_binary(Code),
- 					       {[],[]}),
+ 					       {[],[],MD5}),
     ?line true = erlang:delete_module(many_funs),
     ?line true = erlang:purge_module(many_funs),
 
     %% Should fail.
     ?line {'EXIT',{badarg,_}} =
-	(catch code:make_stub_module(many_funs, <<"bad">>, {[],[]})),
+	(catch code:make_stub_module(many_funs, <<"bad">>, {[],[],MD5})),
     ?line {'EXIT',{badarg,_}} =
 	(catch code:make_stub_module(many_funs,
 				     bit_sized_binary(Code),
-				     {[],[]})),
+				     {[],[],MD5})),
     ok.
 
 constant_pools(Config) when is_list(Config) ->

--- a/erts/emulator/test/module_info_SUITE.erl
+++ b/erts/emulator/test/module_info_SUITE.erl
@@ -94,12 +94,15 @@ functions(Config) when is_list(Config) ->
     ok.
 
 %% Test that the list of exported functions from this module is correct.
+%% Verify that module_info(native) works.
 native(Config) when is_list(Config) ->
     ?line All = all_functions(),
     ?line case ?MODULE:module_info(native_addresses) of
 	      [] ->
+                  ?line false = ?MODULE:module_info(native),
 		  {comment,"no native functions"};
 	      L ->
+                  ?line true = ?MODULE:module_info(native),
 		  %% Verify that all functions have unique addresses.
 		  ?line S0 = sofs:set(L, [{name,arity,addr}]),
 		  ?line S1 = sofs:projection({external,fun ?MODULE:native_proj/1}, S0),

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -1931,7 +1931,7 @@ element(_N, _Tuple) ->
 %% Not documented
 -spec erlang:get_module_info(Module, Item) -> ModuleInfo when
       Module :: atom(),
-      Item :: module | imports | exports | functions | attributes | compile | native_addresses | md5,
+      Item :: module | exports | functions | attributes | compile | native_addresses | md5,
       ModuleInfo :: atom() | [] | [{atom(), arity()}] | [{atom(), term()}] | [{atom(), arity(), integer()}].
 get_module_info(_Module, _Item) ->
     erlang:nif_error(undefined).

--- a/lib/test_server/src/test_server.erl
+++ b/lib/test_server/src/test_server.erl
@@ -2469,11 +2469,7 @@ appup_test(App) ->
 %% Checks wether the module is natively compiled or not.
 
 is_native(Mod) ->
-    case catch Mod:module_info(native_addresses) of
-	[_|_] -> true;
-	_Other -> false
-    end.
-
+    (catch Mod:module_info(native)) =:= true.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% comment(String) -> ok

--- a/system/doc/reference_manual/modules.xml
+++ b/system/doc/reference_manual/modules.xml
@@ -246,7 +246,8 @@ behaviour_info(callbacks) -> Callbacks.</pre>
       a list of <c>{Key,Value}</c> tuples with information about
       the module. Currently, the list contain tuples with the following
       <c>Key</c>s: <c>module</c>, <c>attributes</c>, <c>compile</c>,
-      <c>exports</c> and <c>md5</c>. The order and number of tuples
+      <c>exports</c>, <c>md5</c> and <c>native</c>.
+      The order and number of tuples
       may change without prior notice.</p>
     </section>
 
@@ -301,6 +302,13 @@ behaviour_info(callbacks) -> Callbacks.</pre>
 	  <item>
 	  <p>Returns a list of <c>{Name,Arity}</c> tuples with
 	  all functions in the module.</p>
+	  </item>
+
+        <tag><c>native</c></tag>
+	  <item>
+	  <p>Return <c>true</c> if the module has native compiled code.
+          Return <c>false</c> otherwise. In a system compiled without HiPE
+          support, the result is always <c>false</c></p>
 	  </item>
       </taglist>
     </section>

--- a/system/doc/reference_manual/modules.xml
+++ b/system/doc/reference_manual/modules.xml
@@ -289,7 +289,9 @@ behaviour_info(callbacks) -> Callbacks.</pre>
 
         <tag><c>md5</c></tag>
 	  <item>
-	  <p>Returns a binary representing the MD5 checksum of the module.</p>
+	  <p>Returns a binary representing the MD5 checksum of the module.
+          If the module has native code loaded, this will be the MD5 of the
+          native code, not the BEAM bytecode.</p>
 	  </item>
 
         <tag><c>exports</c></tag>


### PR DESCRIPTION
Improve module_info in presence of native code

- Set module md5 based on native code, if used
- Add module info entry 'native' -> true | false
- Handle empty md5 field gracefully (do not return random bytes)
- Remove obsolete 'imports' key from module_info spec