### PR TITLE
Add display(Term) shell command

### DIFF
--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -22,7 +22,7 @@
 
 %% Avoid warning for local function error/2 clashing with autoimported BIF.
 -compile({no_auto_import,[error/2]}).
--export([help/0,lc/1,c/1,c/2,nc/1,nc/2, nl/1,l/1,i/0,i/1,ni/0,
+-export([help/0,p/1,lc/1,c/1,c/2,nc/1,nc/2, nl/1,l/1,i/0,i/1,ni/0,
          y/1, y/2,
 	 lc_batch/0, lc_batch/1,
 	 i/3,pid/3,m/0,m/1,
@@ -60,6 +60,7 @@ help() ->
 		   "memory(T)  -- memory allocation information of type <T>\n"
 		   "nc(File)   -- compile and load code in <File> on all nodes\n"
 		   "nl(Module) -- load module on all nodes\n"
+		   "p(T)       -- print the fully-expanded term T\n"
 		   "pid(X,Y,Z) -- convert X,Y,Z to a Pid\n"
 		   "pwd()      -- print working directory\n"
 		   "q()        -- quit - shorthand for init:stop()\n"
@@ -67,6 +68,13 @@ help() ->
 		   "nregs()    -- information about all registered processes\n"
 		   "xm(M)      -- cross reference check a module\n"
 		   "y(File)    -- generate a Yecc parser\n">>).
+
+%% p(Term)
+%%  Print a term.
+
+p(Term) ->
+	_ = erlang:display(Term),
+	ok.
 
 %% c(FileName)
 %%  Compile a file/module.

--- a/lib/stdlib/src/shell_default.erl
+++ b/lib/stdlib/src/shell_default.erl
@@ -22,7 +22,7 @@
 
 -module(shell_default).
 
--export([help/0,lc/1,c/1,c/2,nc/1,nl/1,l/1,i/0,pid/3,i/3,m/0,m/1,
+-export([help/0,p/1,lc/1,c/1,c/2,nc/1,nl/1,l/1,i/0,pid/3,i/3,m/0,m/1,
          memory/0,memory/1,
 	 erlangrc/1,bi/1, regs/0, flush/0,pwd/0,ls/0,ls/1,cd/1, 
          y/1, y/2,
@@ -88,6 +88,7 @@ nc(X)     	-> c:nc(X).
 ni()            -> c:ni().
 nl(Mod) 	-> c:nl(Mod).
 nregs()         -> c:nregs().
+p(T)            -> c:p(T).
 pid(X,Y,Z) 	-> c:pid(X,Y,Z).
 pwd()           -> c:pwd().
 q()		-> c:q().


### PR DESCRIPTION
This is a proposal to add a display(Term) shell command. I do not know if that's the best way to add it, or even the best name, but I believe it is a useful addition and will make all required changes you need to get this in.

Commit message follows

-----------------------

The erlang:display/1 function is very useful in various
steps of development and debugging, as it allows printing
terms fully-expanded, something the shell will not do by
default.

An alias would not only be shorter to use, but it would
also allow users to know of its existence, and make them
stop using io:format("~p~n", [Term]), which can be much
worse for a production node due to the heavy formatting
to squeeze the output into 80 columns.