### PR TITLE
Fix hipe bug when matching a writable binary

### DIFF
--- a/erts/emulator/hipe/hipe_bif0.c
+++ b/erts/emulator/hipe/hipe_bif0.c
@@ -1028,6 +1028,14 @@ void hipe_emulate_fpe(Process* p)
 }
 #endif
 
+void hipe_emasculate_binary(Eterm bin)
+{
+    ProcBin* pb = (ProcBin *) boxed_val(bin);
+    if (pb->thing_word == HEADER_PROC_BIN && pb->flags != 0) {
+	erts_emasculate_writable_binary(pb);
+    }
+}
+
 #if 0 /* XXX: unused */
 /*
  * At least parts of this should be inlined in native code.

--- a/erts/emulator/hipe/hipe_bif0.c
+++ b/erts/emulator/hipe/hipe_bif0.c
@@ -1031,9 +1031,9 @@ void hipe_emulate_fpe(Process* p)
 void hipe_emasculate_binary(Eterm bin)
 {
     ProcBin* pb = (ProcBin *) boxed_val(bin);
-    if (pb->thing_word == HEADER_PROC_BIN && pb->flags != 0) {
-	erts_emasculate_writable_binary(pb);
-    }
+    ASSERT(pb->thing_word == HEADER_PROC_BIN);
+    ASSERT(pb->flags != 0);
+    erts_emasculate_writable_binary(pb);
 }
 
 #if 0 /* XXX: unused */

--- a/erts/emulator/hipe/hipe_bif0.tab
+++ b/erts/emulator/hipe/hipe_bif0.tab
@@ -142,4 +142,5 @@ atom bs_get_utf16
 atom bs_validate_unicode
 atom bs_validate_unicode_retract
 atom emulate_fpe
+atom emasculate_binary
 

--- a/erts/emulator/hipe/hipe_bif_list.m4
+++ b/erts/emulator/hipe/hipe_bif_list.m4
@@ -250,6 +250,8 @@ gc_bif_interface_0(nbif_check_get_msg, hipe_check_get_msg)
 nocons_nofail_primop_interface_0(nbif_emulate_fpe, hipe_emulate_fpe)
 #endif
 
+noproc_primop_interface_1(nbif_emasculate_binary, hipe_emasculate_binary)
+
 /*
  * SMP-specific stuff
  */

--- a/erts/emulator/hipe/hipe_native_bif.h
+++ b/erts/emulator/hipe/hipe_native_bif.h
@@ -98,6 +98,9 @@ AEXTERN(void,nbif_emulate_fpe,(Process*));
 void hipe_emulate_fpe(Process*);
 #endif
 
+AEXTERN(void,nbif_emasculate_binary,(Eterm));
+void hipe_emasculate_binary(Eterm);
+
 /*
  * Stuff that is different in SMP and non-SMP.
  */

--- a/erts/emulator/hipe/hipe_primops.h
+++ b/erts/emulator/hipe/hipe_primops.h
@@ -80,6 +80,7 @@ PRIMOP_LIST(am_fclearerror_error, &nbif_fclearerror_error)
 #ifdef NO_FPE_SIGNALS
 PRIMOP_LIST(am_emulate_fpe, &nbif_emulate_fpe)
 #endif
+PRIMOP_LIST(am_emasculate_binary, &nbif_emasculate_binary)
 PRIMOP_LIST(am_debug_native_called, &nbif_hipe_bifs_debug_native_called)
 
 #if defined(__sparc__)

--- a/lib/hipe/rtl/hipe_rtl_binary_match.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_match.erl
@@ -704,6 +704,7 @@ get_base(Orig,Base) ->
    hipe_rtl:mk_alu(Base, Orig, 'add', hipe_rtl:mk_imm(?HEAP_BIN_DATA-2)),
    hipe_rtl:mk_goto(hipe_rtl:label_name(EndLbl)),
    REFCLbl,
+   hipe_rtl:mk_call([], emasculate_binary, [Orig], [], [], 'not_remote'),
    hipe_rtl:mk_load(Base, Orig, hipe_rtl:mk_imm(?PROC_BIN_BYTES-2)),
    EndLbl].
 

--- a/lib/hipe/rtl/hipe_rtl_binary_match.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_match.erl
@@ -697,14 +697,22 @@ get_binary_bytes(Binary, BinSize, Base, Offset, Orig,
 %%%%%%%%%%%%%%%%%%%%%%%%% UTILS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 get_base(Orig,Base) ->
-  [HeapLbl,REFCLbl,EndLbl] = create_lbls(3),
+  [HeapLbl,REFCLbl,WritableLbl,NotWritableLbl,EndLbl] = create_lbls(5),
+  Flags = hipe_rtl:mk_new_reg_gcsafe(),
+
   [hipe_tagscheme:test_heap_binary(Orig, hipe_rtl:label_name(HeapLbl),
 				   hipe_rtl:label_name(REFCLbl)),
    HeapLbl,
    hipe_rtl:mk_alu(Base, Orig, 'add', hipe_rtl:mk_imm(?HEAP_BIN_DATA-2)),
    hipe_rtl:mk_goto(hipe_rtl:label_name(EndLbl)),
    REFCLbl,
+   get_field_from_term({proc_bin, flags}, Orig, Flags),
+   hipe_rtl:mk_branch(Flags, 'ne', hipe_rtl:mk_imm(0),
+		      hipe_rtl:label_name(WritableLbl),
+		      hipe_rtl:label_name(NotWritableLbl)),
+   WritableLbl,
    hipe_rtl:mk_call([], emasculate_binary, [Orig], [], [], 'not_remote'),
+   NotWritableLbl,
    hipe_rtl:mk_load(Base, Orig, hipe_rtl:mk_imm(?PROC_BIN_BYTES-2)),
    EndLbl].
 


### PR DESCRIPTION
This is a fix for a hipe problem reported by Johannes Weißl and Sebastian Egner:

http://erlang.org/pipermail/erlang-bugs/2015-April/004884.html

Seen symptom: Hipe compiled code with `<<C/utf8, ...>> = Bin` does sometimes
not match even though Bin contains a valid utf8 character. There might be
other possible binary matching symptoms, as the problem is not utf8
specific.

Problem: A writable binary was not "emasculated" when the matching started
(as it should) by the hipe compiled code.

Fix: Add a new primop emasculate_binary(Bin) that is called when
a matchstate is created.

ToDo: There are probably room for optimization. For example only call
emasculate_binary if ProcBin.flags is set.