### PR TITLE
Fix a bug related to constraints generated for erlang:'*'/2

### DIFF
--- a/lib/dialyzer/src/dialyzer_typesig.erl
+++ b/lib/dialyzer/src/dialyzer_typesig.erl
@@ -1579,11 +1579,11 @@ get_bif_constr({M, F, A} = _BIF, Dst, Args, _State) ->
 eval_inv_arith('+', _Pos, Dst, Arg) ->
   bif_return(erlang, '-', 2, [Dst, Arg]);
 eval_inv_arith('*', _Pos, Dst, Arg) ->
-  case t_number_vals(Arg) of
-    [0] -> t_integer();
-    _ ->
+  Zero = t_from_term(0),
+  case t_is_none(t_inf(Arg, Zero)) of
+    false -> t_integer();
+    true ->
       TmpRet = bif_return(erlang, 'div', 2, [Dst, Arg]),
-      Zero = t_from_term(0),
       %% If 0 is not part of the result, it cannot be part of the argument.
       case t_is_subtype(Zero, Dst) of
 	false -> t_subtract(TmpRet, Zero);

--- a/lib/dialyzer/test/small_SUITE_data/src/inv_mult.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/inv_mult.erl
@@ -1,0 +1,15 @@
+%% Dialyzer was too constraining when checking the relation between the
+%% arguments and result of a multiplication. We should not constrain an argument
+%% if the other operand *may* be zero.
+%%
+%% Bug found by Kostis Sagonas, fixed by Stavros Aronis
+
+-module(inv_mult).
+-compile(export_all).
+
+main(L) ->
+    N = -1 * length(L),
+    fact(N).
+
+fact(0) -> 1;
+fact(N) -> N * fact(N-1).


### PR DESCRIPTION
For Rst = A1 * A2, typesig for erlang:'*'/2 was constraining the
arguments A1 and A2 in the 'reverse' direction by requiring that A2 is a
subtype of Rst div A1, unless A1 is a hard zero. This is not correct: if
for example both Rst and A1 are non_negative, such a constraint will
first force A1 to be non-zero for the division to go through and then
require A2 to be non_negative as non_negative div positive =
non_negative, always (see commited test).

In the fixed version, we are not constraining an argument if the other
operand *may* be zero.