### PR TITLE
Fix FreeBSD sendfile

### DIFF
--- a/erts/emulator/drivers/common/efile_drv.c
+++ b/erts/emulator/drivers/common/efile_drv.c
@@ -1938,6 +1938,8 @@ static void invoke_sendfile(void *data)
 	d->result_ok = 1;
 	if (d->c.sendfile.nbytes != 0)
 	  d->c.sendfile.nbytes -= nbytes;
+      } else if (nbytes == 0 && d->c.sendfile.nbytes == 0) {
+	d->result_ok = 1;
       } else
 	d->result_ok = 0;
     } else {


### PR DESCRIPTION
check (nbytes == 0 && d->c.sendfile.nbytes == 0) when efile_sendfile returns 0 and
has EAGAIN set.

FreeBSD sendfile(2) man page:

     When using a socket marked for non-blocking I/O, sendfile() may send
     fewer bytes than requested.  In this case, the number of bytes
     successfully written is returned in *sbytes (if specified), and the error
     EAGAIN is returned.

The number of bytes successfully written can be 0. If this happens and
in a request handling either file:sendfile/2 or file:sendfile/5 with Bytes=0,
the sendfile loop will stop prematurely and file:sendfile will return
{ok, BytesSent} where BytesSent < DataAfterOffset, effectively breaking sendfile
support on FreeBSD.