### PR TITLE
Fix documention for timeout type in gen_fsm Module:init

### DIFF
--- a/lib/stdlib/doc/src/gen_fsm.xml
+++ b/lib/stdlib/doc/src/gen_fsm.xml
@@ -503,7 +503,7 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <v>&nbsp;&nbsp;| {stop,Reason,NewStateData}</v>
         <v>&nbsp;NextStateName = atom()</v>
         <v>&nbsp;NewStateData = term()</v>
-        <v>&nbsp;Timeout = int()>0 | infinity</v>
+        <v>&nbsp;Timeout = int()>=0 | infinity</v>
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>


### PR DESCRIPTION
Timeout should be a non-negative integer, as documented by the timeout() type. The docs incorrectly state that it should be a positive integer.