### PR TITLE
TLS Dist: Handle ssl_error and close ssl socket

### DIFF
--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -227,7 +227,10 @@ loop_conn_setup(World, Erts) ->
 	{tcp_closed, Erts} ->
 	    ssl:close(World);
 	{ssl_closed,  World} ->
-	    gen_tcp:close(Erts)
+	    gen_tcp:close(Erts);
+	{ssl_error, World, _} ->
+
+	    ssl:close(World)
     end.
 
 loop_conn(World, Erts) ->
@@ -241,7 +244,9 @@ loop_conn(World, Erts) ->
 	{tcp_closed, Erts} ->
 	    ssl:close(World);
 	{ssl_closed,  World} ->
-	    gen_tcp:close(Erts)
+	    gen_tcp:close(Erts);
+	{ssl_error, World, _} ->
+	    ssl:close(World)
     end.
 
 get_ssl_options(Type) ->


### PR DESCRIPTION
Splitting pull request #679 into separate requests as requested.


In some instances, restarting a node causes a fatal SSL error on
the other nodes which isn't handled leaving the socket open. Eventually
the nodes will net tick timeout but the node being restarted never
comes back to life

By handling the fatal error and closing the socket, the restarting
node can restart successfully even when the ssl error occurs