### PR TITLE
Stop xmerl printing to stdout

### DIFF
--- a/lib/xmerl/src/xmerl.erl
+++ b/lib/xmerl/src/xmerl.erl
@@ -40,6 +40,7 @@
 	 callbacks/1]).
 
 -include("xmerl.hrl").
+-include("xmerl_internal.hrl").
 
 
 %% @spec export(Content, Callback) -> ExportedFormat
@@ -273,7 +274,7 @@ tagdef(Tag,Pos,Parents,Args,CBs) ->
 
 callbacks(Module) ->
     Result = check_inheritance(Module, []),
-%%%     io:format("callbacks = ~p~n", [lists:reverse(Result)]),
+%%%     ?dbg("callbacks = ~p~n", [lists:reverse(Result)]),
     lists:reverse(Result).
 
 callbacks([M|Mods], Visited) ->
@@ -288,7 +289,7 @@ callbacks([], Visited) ->
     Visited.
 
 check_inheritance(M, Visited) ->
-%%%     io:format("calling ~p:'#xml-inheritance#'()~n", [M]),
+%%%     ?dbg("calling ~p:'#xml-inheritance#'()~n", [M]),
     case M:'#xml-inheritance#'() of
 	[] ->
 	    [M|Visited];
@@ -313,7 +314,7 @@ apply_cb([M|Ms], F, Df, Args, A, Ms0) ->
         true -> apply(M, F, Args);
         false -> apply_cb(Ms, F, Df, Args, A, Ms0)
     end;
-apply_cb([], Df, Df, Args, A, _Ms0) ->
+apply_cb([], Df, Df, Args, _A, _Ms0) ->
     exit({unknown_tag, {Df, Args}});
 apply_cb([], F, Df, Args, A, Ms0) ->
     apply_cb(Ms0, Df, Df, [F|Args], A+1).

--- a/lib/xmerl/src/xmerl_eventp.erl
+++ b/lib/xmerl/src/xmerl_eventp.erl
@@ -80,17 +80,17 @@ stream_sax(Fname, CallBack, UserState,Options) ->
     HookF=
 	fun(ParsedEntity, S) ->
 		{CBs,Arg}=xmerl_scan:user_state(S),
-%		io:format("stream_sax Arg=~p~n",[Arg]),
+%		?dbg("stream_sax Arg=~p~n",[Arg]),
 		case ParsedEntity of
 		    #xmlComment{} -> % Toss away comments...
 			{[],S};
 		    _ ->  % Use callback module for the rest
-%		io:format("stream_sax ParsedEntity=~p~n",[ParsedEntity]),
+%		?dbg("stream_sax ParsedEntity=~p~n",[ParsedEntity]),
 			case xmerl:export_element(ParsedEntity,CBs,Arg) of
 			    {error,Reason} ->
 				throw({error,Reason});
 			    Resp ->
-%		io:format("stream_sax Resp=~p~n",[Resp]),
+%		?dbg("stream_sax Resp=~p~n",[Resp]),
 				{Resp,xmerl_scan:user_state({CBs,Resp},S)}
 			end
 		end

--- a/lib/xmerl/src/xmerl_otpsgml.erl
+++ b/lib/xmerl/src/xmerl_otpsgml.erl
@@ -34,6 +34,7 @@
 		    export_text/1]).
 
 -include("xmerl.hrl").
+-include("xmerl_internal.hrl").
 
 
 '#xml-inheritance#'() -> [xmerl_sgml].
@@ -58,7 +59,7 @@
 %% the scope of a markup is not extended by mistake.)
 
 '#element#'(Tag, Data, Attrs, _Parents, _E) ->
-%    io:format("parents:\n~p\n",[_Parents]),
+%    ?dbg("parents:\n~p\n",[_Parents]),
     case convert_tag(Tag,Attrs) of
 	{false,NewTag,NewAttrs} ->
 	    markup(NewTag, NewAttrs, Data);
@@ -108,7 +109,7 @@ convert_aref([#xmlAttribute{name = href, value = V}|_Rest]) ->
 	    seealso
     end;
 convert_aref([#xmlAttribute{name = K}|Rest]) ->
-    io:format("Warning: ignoring attribute \'~p\' for tag \'a\'\n",[K]),
+    error_logger:warning_msg("ignoring attribute \'~p\' for tag \'a\'\n",[K]),
     convert_aref(Rest).
 convert_aref_attrs(url,Attrs) ->
     Attrs;
@@ -130,7 +131,7 @@ html_content([_H|T]) ->
 % convert_seealso_attrs([#xmlAttribute{name = href, value = V} = A|Rest]) ->
 %     [A#xmlAttribute{name=marker,value=normalize_web_ref(V)}|convert_seealso_attrs(Rest)];
 % convert_seealso_attrs([#xmlAttribute{name = K}|Rest]) ->
-%     io:format("Warning: ignoring attribute \'~p\' for tag \'a\'\n",[K]),
+%     error_logger:warning_msg("ignoring attribute \'~p\' for tag \'a\'\n",[K]),
 %     convert_seealso_attrs(Rest);
 % convert_seealso_attrs([]) ->
 %     [].

--- a/lib/xmerl/src/xmerl_sax_old_dom.erl
+++ b/lib/xmerl/src/xmerl_sax_old_dom.erl
@@ -28,6 +28,7 @@
 %% Include files
 %%----------------------------------------------------------------------
 -include("xmerl_sax_old_dom.hrl").
+-include("xmerl_internal.hrl").
 
 %%----------------------------------------------------------------------
 %% External exports
@@ -126,7 +127,7 @@ build_dom(endDocument,
 						 content=lists:reverse(C)
 						}]};
 	_ ->
-	    io:format("~p\n", [D]),
+	    %%?dbg("~p\n", [D]),
 	    ?error("we're not at end the document when endDocument event is encountered.")
     end;
 

--- a/lib/xmerl/src/xmerl_sax_simple_dom.erl
+++ b/lib/xmerl/src/xmerl_sax_simple_dom.erl
@@ -28,6 +28,7 @@
 %% Include files
 %%----------------------------------------------------------------------
 -include("xmerl_sax_old_dom.hrl").
+-include("xmerl_internal.hrl").
 
 %%----------------------------------------------------------------------
 %% External exports
@@ -127,7 +128,7 @@ build_dom(endDocument,
 	    State#xmerl_sax_simple_dom_state{dom=[Decl, {Tag, Attributes, 
 						   lists:reverse(Content)}]};
 	_ ->
-	    io:format("~p\n", [D]),
+	    ?dbg("~p\n", [D]),
 	    ?error("we're not at end the document when endDocument event is encountered.")
     end;
 

--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -147,7 +147,8 @@
 	    S#xmerl_scanner.quiet ->
 		ok;
 	    true ->
-		ok=io:format("~p- fatal: ~p~n", [?LINE, Reason])
+		error_logger:error_msg("~p- fatal: ~p~n", [?LINE, Reason]),
+		ok
 	end,
 	fatal(Reason, S)).
 
@@ -255,7 +256,7 @@ file(F, Options) ->
     end.
 
 int_file(F, Options,_ExtCharset) ->
-     %%io:format("int_file F=~p~n",[F]),
+     %%?dbg("int_file F=~p~n",[F]),
     case file:read_file(F) of
 	{ok, Bin} ->
 	    int_string(binary_to_list(Bin), Options, filename:dirname(F),F);
@@ -264,7 +265,7 @@ int_file(F, Options,_ExtCharset) ->
     end.
 
 int_file_decl(F, Options,_ExtCharset) ->
-%     io:format("int_file_decl F=~p~n",[F]),
+%     ?dbg("int_file_decl F=~p~n",[F]),
     case file:read_file(F) of
 	{ok, Bin} ->
 	    int_string_decl(binary_to_list(Bin), Options, filename:dirname(F),F);
@@ -294,7 +295,7 @@ int_string(Str, Options,FileName) ->
 int_string(Str, Options, XMLBase, FileName) ->
     S0=initial_state0(Options,XMLBase),
     S = S0#xmerl_scanner{filename=FileName},
-    %%io:format("int_string1, calling xmerl_lib:detect_charset~n",[]),
+    %%?dbg("int_string1, calling xmerl_lib:detect_charset~n",[]),
 
     %% In case of no encoding attribute in document utf-8 is default, but
     %% another character set may be detected with help of Byte Order Marker or
@@ -559,20 +560,20 @@ scan_document(Str0, S=#xmerl_scanner{event_fun = Event,
 		Str0
 	end,
 %%     M1 = erlang:memory(),
-%%     io:format("Memory status before prolog: ~p~n",[M1]),
+%%     ?dbg("Memory status before prolog: ~p~n",[M1]),
     {Prolog, Pos, T1, S2} = scan_prolog(Str, S1, _StartPos = 1),
 %%     M2 = erlang:memory(),
-%%     io:format("Memory status after prolog: ~p~n",[M2]),
-    %%io:format("scan_document 2, prolog parsed~n",[]),
+%%     ?dbg("Memory status after prolog: ~p~n",[M2]),
+    %%?dbg("scan_document 2, prolog parsed~n",[]),
     T2 = scan_mandatory("<", T1, 1, S2, expected_element_start_tag),
 %%     M3 = erlang:memory(),
-%%     io:format("Memory status before element: ~p~n",[M3]),
+%%     ?dbg("Memory status before element: ~p~n",[M3]),
     {Res, T3, S3} = scan_element(T2,S2,Pos),
 %%     M4 = erlang:memory(),
-%%     io:format("Memory status after element: ~p~n",[M4]),
+%%     ?dbg("Memory status after element: ~p~n",[M4]),
     {Misc, _Pos1, Tail, S4}=scan_misc(T3, S3, Pos + 1),
 %%     M5 = erlang:memory(),
-%%     io:format("Memory status after misc: ~p~n",[M5]),
+%%     ?dbg("Memory status after misc: ~p~n",[M5]),
 
     S5 = #xmerl_scanner{} = Event(#xmerl_event{event = ended,
 					       line = S4#xmerl_scanner.line,
@@ -604,7 +605,7 @@ scan_document(Str0, S=#xmerl_scanner{event_fun = Event,
 		 case schemaLocations(Res, S5) of
 		     {ok, Schemas} ->
 			 cleanup(S5),
-			 %%io:format("Schemas: ~p~nRes: ~p~ninhertih_options(S): ~p~n",
+			 %%?dbg("Schemas: ~p~nRes: ~p~ninhertih_options(S): ~p~n",
 			 %%          [Schemas,Res,inherit_options(S5)]),
 			 XSDRes = xmerl_xsd:process_validate(Schemas, Res,
 							     inherit_options(S5)),
@@ -1373,7 +1374,7 @@ fetch_not_parse(ExtSpec,S=#xmerl_scanner{fetch_fun=Fetch}) ->
     end.
 
 get_file(F,S) ->
-%     io:format("get_file F=~p~n",[F]),
+%     ?dbg("get_file F=~p~n",[F]),
     case file:read_file(F) of
 	{ok,Bin} ->
 	    binary_to_list(Bin);
@@ -4088,7 +4089,7 @@ schemaLocations(#xmlElement{attributes=Atts,xmlbase=_Base}) ->
     end.
 
 inherit_options(S) ->
-    %%io:format("xsdbase: ~p~n",[S#xmerl_scanner.xmlbase]),
+    %%?dbg("xsdbase: ~p~n",[S#xmerl_scanner.xmlbase]),
     [{xsdbase,S#xmerl_scanner.xmlbase}].
 
 handle_schema_result({XSDRes=#xmlElement{},_},S5) ->
@@ -4227,7 +4228,7 @@ string_to_char_set(_,Str) ->
 %%     NewTot =
 %%     case {lists:keysearch(total,1,Mem),OldTot*1.1} of
 %% 	{{_,{_,Tot}},Tot110} when Tot > Tot110 ->
-%% 	    io:format("From ~p to ~p, total memory: ~p (~p)~n",[OldLine,Line,Tot,OldTot]),
+%% 	    ?dbg("From ~p to ~p, total memory: ~p (~p)~n",[OldLine,Line,Tot,OldTot]),
 %% 	    Tot;
 %% 	{{_,{_,Tot}},_} ->
 %% 	    Tot

--- a/lib/xmerl/src/xmerl_ucs.erl
+++ b/lib/xmerl/src/xmerl_ucs.erl
@@ -227,7 +227,7 @@ from_ucs4be(<<Ch:32/big-signed-integer, Rest/binary>>,Acc,Tail) ->
 from_ucs4be(<<>>,Acc,Tail) ->
     lists:reverse(Acc,Tail);
 from_ucs4be(Bin,Acc,Tail) ->
-    io:format("ucs Error: Bin=~p~n     Acc=~p~n     Tail=~p~n",[Bin,Acc,Tail]),
+    ucs_error(Bin,Acc,Tail),
     {error,not_ucs4be}.
 
 char_to_ucs4le(Ch) ->
@@ -247,7 +247,7 @@ from_ucs4le(<<Ch:32/little-signed-integer, Rest/binary>>,Acc,Tail) ->
 from_ucs4le(<<>>,Acc,Tail) ->
     lists:reverse(Acc,Tail);
 from_ucs4le(Bin,Acc,Tail) ->
-    io:format("ucs Error: Bin=~p~n     Acc=~p~n     Tail=~p~n",[Bin,Acc,Tail]),
+    ucs_error(Bin,Acc,Tail),
     {error,not_ucs4le}.
 
 
@@ -269,7 +269,7 @@ from_ucs2be(<<Ch:16/big-signed-integer, Rest/binary>>,Acc,Tail) ->
 from_ucs2be(<<>>,Acc,Tail) ->
     lists:reverse(Acc,Tail);
 from_ucs2be(Bin,Acc,Tail) ->
-    io:format("ucs Error: Bin=~p~n     Acc=~p~n     Tail=~p~n",[Bin,Acc,Tail]),
+    ucs_error(Bin,Acc,Tail),
     {error,not_ucs2be}.
 
 char_to_ucs2le(Ch) ->
@@ -287,7 +287,7 @@ from_ucs2le(<<Ch:16/little-signed-integer, Rest/binary>>,Acc,Tail) ->
 from_ucs2le(<<>>,Acc,Tail) ->
     lists:reverse(Acc,Tail);
 from_ucs2le(Bin,Acc,Tail) ->
-    io:format("ucs Error: Bin=~p~n     Acc=~p~n     Tail=~p~n",[Bin,Acc,Tail]),
+    ucs_error(Bin,Acc,Tail),
     {error,not_ucs2le}.
 
 
@@ -331,7 +331,7 @@ from_utf16be(<<Hi:16/big-unsigned-integer, Lo:16/big-unsigned-integer,
 from_utf16be(<<>>,Acc,Tail) ->
     lists:reverse(Acc,Tail);
 from_utf16be(Bin,Acc,Tail) ->
-    io:format("ucs Error: Bin=~p~n     Acc=~p~n     Tail=~p~n",[Bin,Acc,Tail]),
+    ucs_error(Bin,Acc,Tail),
     {error,not_utf16be}.
 
 char_to_utf16le(Ch) when is_integer(Ch), Ch >= 0 ->
@@ -363,7 +363,7 @@ from_utf16le(<<Hi:16/little-unsigned-integer, Lo:16/little-unsigned-integer,
 from_utf16le(<<>>,Acc,Tail) ->
     lists:reverse(Acc,Tail);
 from_utf16le(Bin,Acc,Tail) ->
-    io:format("ucs Error: Bin=~p~n     Acc=~p~n     Tail=~p~n",[Bin,Acc,Tail]),
+    ucs_error(Bin,Acc,Tail),
     {error,not_utf16le}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -571,3 +571,6 @@ test_charset(Fun,Input) ->
 	    false
     end.
 
+ucs_error(Bin,Acc,Tail) ->
+    error_logger:error_msg("~w: Bin=~p~n     Acc=~p~n     Tail=~p~n",
+                           [?MODULE,Bin,Acc,Tail]).

--- a/lib/xmerl/src/xmerl_validate.erl
+++ b/lib/xmerl/src/xmerl_validate.erl
@@ -23,7 +23,7 @@
 
 
 -include("xmerl.hrl").		% record def, macros
-
+-include("xmerl_internal.hrl").
 
 
 %% +type validate(xmerl_scanner(),xmlElement())->
@@ -300,7 +300,7 @@ test_attribute_value('NMTOKEN',#xmlAttribute{name=Name,value=V}=Attr,
 		    true->
 			ok;
 		    false->
-			%%io:format("Warning*** nmtoken,value_incorrect:  ~p~n",[V]),
+			%%?dbg("nmtoken,value_incorrect:  ~p~n",[V]),
 			exit({error,{invalid_value_nmtoken,Name,V}})
 		end
 	end,
@@ -381,7 +381,7 @@ test_attribute_value({Type,L},#xmlAttribute{value=Value}=Attr,Default,_S)
 	    exit({error,{duplicate_tokens_not_allowed,{list,L}}})
     end;
 test_attribute_value(_Rule,Attr,_,_) ->
-%    io:format("Attr Value*****~nRule~p~nValue~p~n",[Rule,Attr]),
+%    ?dbg("Attr Value*****~nRule~p~nValue~p~n",[Rule,Attr]),
     Attr.
 
 
@@ -423,11 +423,11 @@ parse({'+',SubRule}, XMLS, Rules, WSaction, S) ->
 parse({choice,CHOICE}, XMLS, Rules, WSaction, S)->
 %    case XMLS of
 %	[] ->
-%	    io:format("~p~n",[{choice,CHOICE,[]}]);
+%	    ?dbg("~p~n",[{choice,CHOICE,[]}]);
 %	[#xmlElement{name=Name,pos=Pos}|_] ->
-%	    io:format("~p~n",[{choice,CHOICE,{Name,Pos}}]);
+%	    ?dbg("~p~n",[{choice,CHOICE,{Name,Pos}}]);
 %	[#xmlText{value=V}|_] ->
-%	    io:format("~p~n",[{choice,CHOICE,{text,V}}])
+%	    ?dbg("~p~n",[{choice,CHOICE,{text,V}}])
 %    end,
     choice(CHOICE, XMLS, Rules, WSaction, S);
 parse(empty, [], _Rules, _WSaction, _S) ->
@@ -550,10 +550,10 @@ star(Rule,XMLS,Rules,WSaction,Tree,S) ->
     {WS,XMLS1} = whitespace_action(XMLS,WSaction),
     case parse(Rule,XMLS1,Rules,WSaction,S) of
 	{error, _E, {{next,N},{act,A}}}->
-	    %%io:format("Error~p~n",[_E]),
+	    %%?dbg("Error~p~n",[_E]),
 	    {WS++Tree++A,N};
 	{error, _E}->
-	    %%io:format("Error~p~n",[_E]),
+	    %%?dbg("Error~p~n",[_E]),
 %	    {WS++[Tree],[]};
 	    case  whitespace_action(XMLS,ws_action(WSaction,remove)) of
 		{[],_} ->

--- a/lib/xmerl/src/xmerl_xml.erl
+++ b/lib/xmerl/src/xmerl_xml.erl
@@ -31,6 +31,7 @@
 -import(xmerl_lib, [markup/3, empty_tag/2, export_text/1]).
 
 -include("xmerl.hrl").
+-include("xmerl_internal.hrl").
 
 
 '#xml-inheritance#'() -> [].
@@ -39,7 +40,7 @@
 %% The '#text#' function is called for every text segment.
 
 '#text#'(Text) ->
-%io:format("Text=~p~n",[Text]),
+%?dbg("Text=~p~n",[Text]),
     export_text(Text).
 
 
@@ -55,8 +56,8 @@
 %% The '#element#' function is the default handler for XML elements.
 
 '#element#'(Tag, [], Attrs, _Parents, _E) ->
-%io:format("Empty Tag=~p~n",[Tag]),
+%?dbg("Empty Tag=~p~n",[Tag]),
     empty_tag(Tag, Attrs);
 '#element#'(Tag, Data, Attrs, _Parents, _E) ->
-%io:format("Tag=~p~n",[Tag]),
+%?dbg("Tag=~p~n",[Tag]),
     markup(Tag, Attrs, Data).

--- a/lib/xmerl/src/xmerl_xpath.erl
+++ b/lib/xmerl/src/xmerl_xpath.erl
@@ -128,18 +128,18 @@ string(Str, Node, Parents, Doc, Options) ->
 	    [{H, P}|_] when is_atom(H), is_integer(P) ->
 		full_parents(Parents, Doc)
 	end,
-%io:format("string FullParents=~p~n",[FullParents]),
+%?dbg("string FullParents=~p~n",[FullParents]),
     ContextNode=#xmlNode{type = node_type(Node),
 			 node = Node,
 			 parents = FullParents},
-%io:format("string ContextNode=~p~n",[ContextNode]),
+%?dbg("string ContextNode=~p~n",[ContextNode]),
     WholeDoc = whole_document(Doc),
-%io:format("string WholeDoc=~p~n",[WholeDoc]),
+%?dbg("string WholeDoc=~p~n",[WholeDoc]),
     Context=(new_context(Options))#xmlContext{context_node = ContextNode,
 					      whole_document = WholeDoc},
-%io:format("string Context=~p~n",[Context]),
+%?dbg("string Context=~p~n",[Context]),
     #state{context = NewContext} = match(Str, #state{context = Context}),
-%io:format("string NewContext=~p~n",[NewContext]),
+%?dbg("string NewContext=~p~n",[NewContext]),
     case NewContext#xmlContext.nodeset of
 	ScalObj = #xmlObj{type=Scalar} 
 	when Scalar == boolean;	Scalar == number; Scalar == string ->
@@ -274,7 +274,7 @@ eval_pred(Predicate, S = #state{context = C =
     NewNodeSet = 
 	lists:filter(
 	  fun(Node) ->
-		  %io:format("current node: ~p~n", [write_node(Node)]),
+		  %?dbg("current node: ~p~n", [write_node(Node)]),
 		  ThisContext = C#xmlContext{context_node = Node},
 		  xmerl_xpath_pred:eval(Predicate, ThisContext)
 	  end, NodeSet),
@@ -461,7 +461,7 @@ match_descendant_or_self(Tok, N, Acc, Context) ->
 
 
 match_child(Tok, N, Acc, Context) ->
-    %io:format("match_child(~p)~n", [write_node(N)]),
+    %?dbg("match_child(~p)~n", [write_node(N)]),
     #xmlNode{parents = Ps, node = Node, type = Type} = N,
     case Type of
 	El when El == element; El == root_node ->
@@ -738,7 +738,7 @@ node_test({prefix_test, Prefix}, #xmlNode{node = N}, Context) ->
     end;
 node_test({name, {Tag, _Prefix, _Local}}, 
 	  #xmlNode{node = #xmlElement{name = Tag}}=_N, _Context) -> 
-    %io:format("node_test({tag, ~p}, ~p) -> true.~n", [Tag, write_node(_N)]),
+    %?dbg("node_test({tag, ~p}, ~p) -> true.~n", [Tag, write_node(_N)]),
     true;
 node_test({name, {Tag, Prefix, Local}}, 
 	  #xmlNode{node = #xmlElement{name = Name,
@@ -816,7 +816,7 @@ node_test({processing_instruction, Name1},
 	  #xmlNode{node = #xmlPI{name = Name2}}, _Context) ->
     Name1 == atom_to_list(Name2);
 node_test(_Other, _N, _Context) ->
-    %io:format("node_test(~p, ~p) -> false.~n", [_Other, write_node(_N)]),
+    %?dbg("node_test(~p, ~p) -> false.~n", [_Other, write_node(_N)]),
     false.
 
 

--- a/lib/xmerl/src/xmerl_xpath_pred.erl
+++ b/lib/xmerl/src/xmerl_xpath_pred.erl
@@ -58,6 +58,7 @@
 -export([core_function/1]).	 
 
 -include("xmerl.hrl").
+-include("xmerl_internal.hrl").
 -include("xmerl_xpath.hrl").
 
 %% -record(obj, {type,
@@ -88,7 +89,7 @@ eval(Expr, C = #xmlContext{context_node = #xmlNode{pos = Pos}}) ->
 	      _ ->
 		  mk_boolean(C, Obj)
 	  end,
-%    io:format("eval(~p, ~p) -> ~p~n", [Expr, Pos, Res]),
+%    ?dbg("eval(~p, ~p) -> ~p~n", [Expr, Pos, Res]),
     Res.
 
 

--- a/lib/xmerl/src/xmerl_xsd.erl
+++ b/lib/xmerl/src/xmerl_xsd.erl
@@ -381,7 +381,7 @@ initiate_state2(S,[{target_namespace,_NS}|T]) ->
 %%    initiate_state2(S#xsd_state{targetNamespace=if_list_to_atom(NS)},T);
     initiate_state2(S,T); %% used in validation phase
 initiate_state2(S,[H|T]) ->
-    error_msg("Invalid option: ~p~n",[H]),
+    error_msg("~w: invalid option: ~p~n",[?MODULE, H]),
     initiate_state2(S,T).
 
 validation_options(S,[{target_namespace,NS}|T]) ->
@@ -5391,7 +5391,7 @@ search_attribute(_,{Name,_,_},SchemaAtts) ->
     end.
 
 error_msg(Format,Args) ->
-    io:format(Format,Args).
+    error_logger:error_msg(Format,Args).
 
 
 add_once(El,L) ->
@@ -5425,7 +5425,7 @@ add_key_once(Key,N,El,L) ->
 %%     "/"++filename:join(L).
 
 %% mk_xml_path(Parents,Type,Pos) ->
-%% %%    io:format("mk_xml_path: Parents = ~p~n",[Parents]),
+%% %%    ?dbg("mk_xml_path: Parents = ~p~n",[Parents]),
 %%     {filename:join([[io_lib:format("/~w(~w)",[X,Y])||{X,Y}<-Parents],Type]),Pos}.
 
 %% @spec format_error(Errors) -> Result

--- a/lib/xmerl/src/xmerl_xsd_type.erl
+++ b/lib/xmerl/src/xmerl_xsd_type.erl
@@ -29,6 +29,7 @@
 -export([compare_durations/2,compare_dateTime/2]).
 
 -include("xmerl.hrl").
+-include("xmerl_internal.hrl").
 -include("xmerl_xsd.hrl").
 
 
@@ -687,7 +688,8 @@ facet_fun(Type,{fractionDigits,V}) ->
     fractionDigits_fun(Type,list_to_integer(V));
 facet_fun(Type,F) ->
     fun(_X_) ->
-	    io:format("Warning: not valid facet on ~p ~p~n",[Type,F])
+	    error_logger:warning_msg("~w: not valid facet on ~p ~p~n",
+                                     [?MODULE,Type,F])
     end.
 
 
@@ -1075,7 +1077,7 @@ compare_floats(F1,F2) when F1=="-INF";F2=="INF" ->
 compare_floats(Str1,Str2) ->
     F1={S1,_B1,_D1,_E1} = str_to_float(Str1),
     F2={S2,_B2,_D2,_E2} = str_to_float(Str2),
-%    io:format("F1: ~p~nF2: ~p~n",[F1,F2]),
+%    ?dbg("F1: ~p~nF2: ~p~n",[F1,F2]),
     if
 	S1=='-',S2=='+' -> lt;
 	S1=='+',S2=='-' -> gt;


### PR DESCRIPTION
Replace sloppy calls to io:format() in xmerl to use error_logger or debug
macros instead, as appropriate.