### PR TITLE
erl_child_setup.c: fix Android breakage

### DIFF
--- a/erts/emulator/sys/unix/erl_child_setup.c
+++ b/erts/emulator/sys/unix/erl_child_setup.c
@@ -55,7 +55,7 @@ void sys_sigrelease(int sig)
 #endif /* !SIG_SIGSET */
 
 #if defined(__ANDROID__)
-int __system_properties_fd(void);
+static int system_properties_fd(void);
 #endif /* __ANDROID__ */
 
 #if defined(__ANDROID__)
@@ -104,9 +104,12 @@ main(int argc, char *argv[])
 #if defined(HAVE_CLOSEFROM)
     closefrom(from);
 #elif defined(__ANDROID__)
-    for (i = from; i <= to; i++) {
-	if (i!=__system_properties_fd)
-	    (void) close(i);
+    if (from <= to) {
+	int spfd = system_properties_fd();
+	for (i = from; i <= to; i++) {
+	    if (i != spfd)
+		(void) close(i);
+	}
     }
 #else
     for (i = from; i <= to; i++)
@@ -143,9 +146,9 @@ main(int argc, char *argv[])
 }
 
 #if defined(__ANDROID__)
-int __system_properties_fd(void)
+static int system_properties_fd(void)
 {
-    int s, fd;
+    int fd;
     char *env;
 
     env = getenv("ANDROID_PROPERTY_WORKSPACE");
@@ -156,4 +159,3 @@ int __system_properties_fd(void)
     return fd;
 }
 #endif /* __ANDROID__ */
-


### PR DESCRIPTION
The Android support in erl_child_setup.c is broken:

1. The close fd loop compares an fd (integer i) with the address of the function
   __system_properties_fd rather than the value of calling that function.
2. This function is locally defined, but its name starts with two underscores
   which is reserved for the implementation.
3. This function is not used outside of this file, so should be static.
4. This function performs a fair amount of work (calls getenv and atoi), which
   would be repeated for each and every fd in the [from,to] range.
5. This function contains an unsed local variable 's'.

Fixed by dropping the __ prefix, making the function static, dropping the unused
local variable, and rewriting the close fd loop to call the function at most once.