### PR TITLE
Make odbcserver legal C99

### DIFF
--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -1746,9 +1746,9 @@ static Boolean decode_params(db_state *state, byte *buffer, int *index, param_ar
 		return FALSE;
 	}
 	if (strncmp((char*)atomarray,"true",4) == 0)
-	    param->values.bool[j] = TRUE;
+	    param->values.boolean[j] = TRUE;
 	else if (strncmp((char*)atomarray,"false",5) == 0)
-	    param->values.bool[j] = FALSE;
+	    param->values.boolean[j] = FALSE;
 	else
 	    return -1;
 	break;
@@ -2336,7 +2336,7 @@ static void init_param_column(param_array *params, byte *buffer, int *index,
 	params->type.c = SQL_C_BIT;
 	params->type.len = sizeof(byte);
 	params->type.col_size = params->type.len;
-	params->values.bool =
+	params->values.boolean =
 		(byte *)safe_malloc(num_param_values * params->type.len);
 	break;
     }
@@ -2580,7 +2580,7 @@ static void * retrive_param_values(param_array *Param)
     case SQL_C_DOUBLE: 
 	return (void *)Param->values.floating;
     case SQL_C_BIT:
-	return (void *)Param->values.bool;
+	return (void *)Param->values.boolean;
     default:
 	DO_EXIT(EXIT_FAILURE); /* Should not happen */
     }

--- a/lib/odbc/c_src/odbcserver.h
+++ b/lib/odbc/c_src/odbcserver.h
@@ -157,7 +157,7 @@ typedef struct {
 	byte *string;
 	SQLINTEGER *integer;
 	double *floating;
-	byte *bool;
+	byte *boolean;
     }values;
 } param_array;
 


### PR DESCRIPTION
Fix C99 keyword used as struct member variable name

This PR was mistakenly created against the 'master' branch, so PR #704 has been created with the same changes on the 'main' branch. This PR can be summarily closed without comment, but I haven't done so in case anyone's looking at it.

The changes in both PRs are identical.