### PR TITLE
erts: two FP exception fixes

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2916,6 +2916,10 @@ else
 #include <signal.h>
 #include <stdlib.h>
 
+#if defined(__clang__) || defined(__llvm__)
+#error "Clang/LLVM generates broken code for FP exceptions"
+#endif
+
 volatile int erl_fp_exception;
 
 /*

--- a/erts/emulator/sys/unix/sys_float.c
+++ b/erts/emulator/sys/unix/sys_float.c
@@ -85,7 +85,7 @@ static void set_current_fp_exception(unsigned long pc)
 
 void erts_fp_check_init_error(volatile unsigned long *fpexnp)
 {
-    char buf[64];
+    char buf[128];
     snprintf(buf, sizeof buf, "ERTS_FP_CHECK_INIT at %p: detected unhandled FPE at %p\r\n",
 	     __builtin_return_address(0), (void*)*fpexnp);
     if (write(2, buf, strlen(buf)) <= 0)


### PR DESCRIPTION
- Change erts/configure.in to force-disable FP exceptions if
  the VM is compiled by clang/llvm.  clang/llvm generates FP
  code which does not work with FP exceptions (whether unmasked
  as used in the Erlang VM, or masked followed by tests of
  which are signalled).  This is a known long-standing problem.
- Increase buffer size in erts_fp_check_init_error().
  The current size is too small for 64-bit machines, causing
  messages to be truncated and making debugging more difficult.