### PR TITLE
Correct module in eldap timeout docs

### DIFF
--- a/lib/eldap/doc/src/eldap.xml
+++ b/lib/eldap/doc/src/eldap.xml
@@ -121,7 +121,7 @@ filter()    See present/1, substrings/2,
 	  <item>Any error responded from ssl:connect/3</item>
 	</taglist>
 	<p>The <c>Timeout</c> parameter is for the actual tls upgrade (phase 2) while the timeout in
-	<seealso marker="#open/2">erl_tar:open/2</seealso> is used for the initial negotiation about
+	<seealso marker="#open/2">eldap:open/2</seealso> is used for the initial negotiation about
 	upgrade (phase 1).
 	</p>
       </desc>
@@ -258,7 +258,7 @@ filter()    See present/1, substrings/2,
   search(Handle, [{base, "dc=example, dc=com"}, {filter, Filter}, {attributes, ["cn"]}]),
 	</pre>
 	<p>The <c>timeout</c> option in the <c>SearchOptions</c> is for the ldap server, while
-	the timeout in <seealso marker="#open/2">erl_tar:open/2</seealso> is used for each
+	the timeout in <seealso marker="#open/2">eldap:open/2</seealso> is used for each
 	individual request in the search operation.
 	</p>
       </desc>


### PR DESCRIPTION
Prior to this commit, the `eldap` documentation for the timeouts of
`search/2` and `start_tls/3` referenced `erl_tar:open/2` instead of
`eldap:open/2`. The relative link was correct, only the link label
mistakenly pointed to `erl_tar`. This error was introduced in
e9a97c3cfd7615e3efd0cbf1632a78b868fda49c. This commit corrects that
mistake.