### PR TITLE
Customize SASL error_logger file opening modes

### DIFF
--- a/lib/sasl/doc/src/sasl_app.xml
+++ b/lib/sasl/doc/src/sasl_app.xml
@@ -92,6 +92,13 @@
           <item>Installs <c>sasl_report_file_h</c> in the error logger.
            This makes all reports go to the file <c>FileName</c>.
           <c>FileName</c> is a string.</item>
+          <tag><c>{file,FileName,Modes}</c></tag>
+          <item>Same as <c>{file,FileName}</c> except that the <c>Modes</c>
+           allows to specify the modes used for opening the <c>FileName</c>
+           given to the <seealso marker="kernel:file#open/2">file:open/2</seealso>
+           call. When not specified, the <c>Modes</c> defaults to <c>[write]</c>.
+           Use <c>[append]</c> for having the <c>FileName</c> open in append mode.
+          <c>FileName</c> is a string.</item>
           <tag><c>false</c></tag>
           <item>
             <p>No SASL error logger handler is installed.</p>

--- a/lib/sasl/src/sasl.erl
+++ b/lib/sasl/src/sasl.erl
@@ -55,7 +55,9 @@ get_sasl_error_logger() ->
     case application:get_env(sasl, sasl_error_logger) of
 	{ok, false} -> undefined;
 	{ok, tty} -> tty;
-	{ok, {file, File}} when is_list(File) -> {file, File};
+	{ok, {file, File}} when is_list(File) -> {file, File, [write]};
+	{ok, {file, File, Modes}} when is_list(File), is_list(Modes) ->
+        {file, File, Modes};
 	{ok, Bad} -> exit({bad_config, {sasl, {sasl_error_logger, Bad}}});
 	_ -> undefined
     end.
@@ -125,9 +127,9 @@ delete_sasl_error_logger(Type) ->
     error_logger:delete_report_handler(mod(Type)).
 
 mod(tty) -> sasl_report_tty_h;
-mod({file, _File}) -> sasl_report_file_h.
+mod({file, _File, _Modes}) -> sasl_report_file_h.
 
-args({file, File}, Type) -> {File, type(Type)};
+args({file, File, Modes}, Type) -> {File, Modes, type(Type)};
 args(_, Type) -> type(Type).
 
 type(error) -> error;

--- a/lib/sasl/src/sasl_report_file_h.erl
+++ b/lib/sasl/src/sasl_report_file_h.erl
@@ -28,9 +28,9 @@
 	 handle_event/2, handle_call/2, handle_info/2,
 	 terminate/2]).
 
-init({File, Type}) ->
+init({File, Modes, Type}) when is_list(Modes) ->
     process_flag(trap_exit, true),
-    case file:open(File, [write]) of
+    case file:open(File, Modes) of
 	{ok,Fd} ->
 	    {ok, {Fd, File, Type}};
 	What ->


### PR DESCRIPTION
Include the ability to open a SASL error log file in append mode
at startup vs currently implemented "rewrite-always" mode.

Note: this is a replacement of pull request https://github.com/erlang/otp/pull/628, which is rebased on master.