### PR TITLE
Remove extra @param in javadoc

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpSelf.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpSelf.java
@@ -153,9 +153,6 @@ public class OtpSelf extends OtpLocalNode {
      *            the port number you wish to use for incoming connections.
      *            Specifying 0 lets the system choose an available port.
      *
-     * @param transportFactory
-     *            the transport factory to use when creating connections.
-     *
      * @exception IOException
      *                in case of server transport failure
      */


### PR DESCRIPTION
This gives an error when building the docs.