### PR TITLE
Allow use of complete interface of cerl_pmatch module

### DIFF
--- a/lib/hipe/cerl/cerl_pmatch.erl
+++ b/lib/hipe/cerl/cerl_pmatch.erl
@@ -31,7 +31,7 @@
 
 -module(cerl_pmatch).
 
--define(NO_UNUSED, true).
+%%-define(NO_UNUSED, true).
 
 -export([clauses/2]).
 -ifndef(NO_UNUSED).
@@ -59,6 +59,8 @@
 %% @see transform/2
 
 -ifndef(NO_UNUSED).
+-spec core_transform(cerl:c_module(), [_]) -> cerl:c_module().
+
 core_transform(M, Opts) ->
     cerl:to_records(transform(cerl:from_records(M), Opts)).
 -endif.	% NO_UNUSED
@@ -76,6 +78,8 @@ core_transform(M, Opts) ->
 %% @see core_transform/2
 
 -ifndef(NO_UNUSED).
+-spec transform(cerl:cerl(), [_]) -> cerl:cerl().
+
 transform(M, _Opts) ->
   expr(M, env__empty()).
 -endif.	% NO_UNUSED
@@ -109,7 +113,7 @@ transform(M, _Opts) ->
 %% @see expr/2
 %% @see transform/2
 
--spec clauses([cerl:cerl()], rec_env:environment()) -> 
+-spec clauses([cerl:cerl(),...], rec_env:environment()) ->
           {cerl:cerl(), [cerl:cerl()]}.
 
 clauses(Cs, Env) ->
@@ -406,6 +410,8 @@ make_let(Vs, A, B) ->
 %% @see rec_env
 
 -ifndef(NO_UNUSED).
+-spec expr(cerl:cerl(), rec_env:environment()) -> cerl:cerl().
+
 expr(E, Env) ->
     case cerl:type(E) of
  	literal ->


### PR DESCRIPTION
The cerl_pmatch module performs pattern matching compilation at the
level of Core Erlang.  Functions that were not needed by the HiPE
compiler were ifdef-ed out.  However, these functions may come handy
to other users; in particular a new testing tool currently under
development needs access to these functions.

While at it, added specs for these exported functions and also
strengthened the spec of another one.