### PR TITLE
Correct usage of sizeof() for pointer types.

### DIFF
--- a/erts/emulator/beam/erl_node_tables.c
+++ b/erts/emulator/beam/erl_node_tables.c
@@ -705,7 +705,7 @@ erts_set_this_node(Eterm sysname, Uint creation)
     erts_this_node->sysname = sysname;
     erts_this_node->creation = creation;
     erts_this_node_sysname = erts_this_node_sysname_BUFFER;
-    erts_snprintf(erts_this_node_sysname, sizeof(erts_this_node_sysname),
+    erts_snprintf(erts_this_node_sysname, sizeof(erts_this_node_sysname_BUFFER),
                   "%T", sysname);
     (void) hash_put(&erts_node_table, (void *) erts_this_node);
 
@@ -794,7 +794,7 @@ void erts_init_node_tables(void)
     erts_this_node->creation			= 0;
     erts_this_node->dist_entry			= erts_this_dist_entry;
     erts_this_node_sysname = erts_this_node_sysname_BUFFER;
-    erts_snprintf(erts_this_node_sysname, sizeof(erts_this_node_sysname),
+    erts_snprintf(erts_this_node_sysname, sizeof(erts_this_node_sysname_BUFFER),
                   "%T", erts_this_node->sysname);
 
     (void) hash_put(&erts_node_table, (void *) erts_this_node);

--- a/erts/etc/ose/run_erl.c
+++ b/erts/etc/ose/run_erl.c
@@ -615,7 +615,7 @@ int run_erl(int argc,char **argv) {
        returns */
     PROCESS main_pid;
     hunt_in_block("run_erl","main",&main_pid);
-    sig = alloc(sizeof(sig),ERTS_SIGNAL_RUN_ERL_DAEMON);
+    sig = alloc(sizeof(*sig),ERTS_SIGNAL_RUN_ERL_DAEMON);
     send(&sig,main_pid);
     sig = receive(sigsel);
     pid = sender(&sig);


### PR DESCRIPTION
I'd really like a pair of eyes on this one, since my C is still rusty, but I think I've verified everything to be correct. Essentially this is a semantic search over the source code base for these kinds of errors, and I found three errors, where I manually corrected 2 of them, but I don't know the context fully, so I may have made a mistake.

One fix is in the OSE code, the other two pertains to buffer sizes in `erts_snprintf()` calls in the erl_node_tables.c code.