### PR TITLE
Added line numbers to coverage report

### DIFF
--- a/lib/tools/doc/src/cover.xml
+++ b/lib/tools/doc/src/cover.xml
@@ -293,7 +293,7 @@
         <v>Module = atom()</v>
         <v>OutFile = string()</v>
         <v>Options = [Option]</v>
-        <v>Option = html</v>
+        <v>Option = html|line_numbers</v>
         <v>Error = {not_cover_compiled,Module} | {file,File,Reason} | no_source_code_found | not_main_node</v>
         <v>&nbsp;File = string()</v>
         <v>&nbsp;Reason = term()</v>
@@ -305,6 +305,8 @@
         <p>The output file <c>OutFile</c> defaults to
           <c>Module.COVER.out</c>, or <c>Module.COVER.html</c> if the
           option <c>html</c> was used.</p>
+        <p>The output file contains line numbers if thw option 
+          <c>line_numbers</c> was used.</p>
         <p>If <c>Module</c> is not Cover compiled, the function returns
           <c>{error,{not_cover_compiled,Module}}</c>.</p>
         <p>If the source file and/or the output file cannot be opened using
@@ -338,7 +340,7 @@
         <v>Module = atom()</v>
         <v>OutFile = string()</v>
         <v>Options = [Option]</v>
-        <v>Option = html</v>
+        <v>Option = html|line_numbers</v>
         <v>Error = {not_cover_compiled,Module} | {file,File,Reason} | no_source_code_found | not_main_node</v>
         <v>&nbsp;File = string()</v>
         <v>&nbsp;Reason = term()</v>

--- a/lib/tools/doc/src/cover_chapter.xml
+++ b/lib/tools/doc/src/cover_chapter.xml
@@ -317,58 +317,58 @@ File generated from channel.erl by COVER 2001-05-21 at 11:16:38
 
 ****************************************************************************
 
-        |  -module(channel).
-        |  -behaviour(gen_server).
-        |  
-        |  -export([start_link/0,stop/0]).
-        |  -export([alloc/0,free/1]). % client interface
-        |  -export([init/1,handle_call/3,terminate/2]). % callback functions
-        |  
-        |  start_link() ->
-     1..|      gen_server:start_link({local,channel},channel,[],[]).
-        |  
-        |  stop() ->
-     1..|      gen_server:call(channel,stop).
-        |  
-        |  %%%-Client interface functions------------------------------------
-        |  
-        |  alloc() ->
-     1..|      gen_server:call(channel,alloc).
-        |  
-        |  free(Channel) ->
-     1..|      gen_server:call(channel,{free,Channel}).
-        |  
-        |  %%%-gen_server callback functions---------------------------------
-        |  
-        |  init(_Arg) ->
-     1..|      {ok,channels()}.
-        |  
-        |  handle_call(stop,Client,Channels) ->
-     1..|      {stop,normal,ok,Channels};
-        |  
-        |  handle_call(alloc,Client,Channels) ->
-     1..|      {Ch,Channels2} = alloc(Channels),
-     1..|      {reply,{ok,Ch},Channels2};
-        |  
-        |  handle_call({free,Channel},Client,Channels) ->
-     1..|      Channels2 = free(Channel,Channels),
-     1..|      {reply,ok,Channels2}.
-        |  
-        |  terminate(_Reason,Channels) ->
-     1..|      ok.
-        |  
-        |  %%%-Internal functions--------------------------------------------
-        |  
-        |  channels() ->
-     1..|      [ch1,ch2,ch3].
-        |  
-        |  alloc([Channel|Channels]) ->
-     1..|      {Channel,Channels};
-        |  alloc([]) ->
-     0..|      false.
-        |  
-        |  free(Channel,Channels) ->
-     1..|      [Channel|Channels].</pre>
+    1:        |  -module(channel).
+    2:        |  -behaviour(gen_server).
+    3:        |  
+    4:        |  -export([start_link/0,stop/0]).
+    5:        |  -export([alloc/0,free/1]). % client interface
+    6:        |  -export([init/1,handle_call/3,terminate/2]). % callback functions
+    7:        |  
+    8:        |  start_link() ->
+    9:     1..|      gen_server:start_link({local,channel},channel,[],[]).
+   10:        |  
+   11:        |  stop() ->
+   12:     1..|      gen_server:call(channel,stop).
+   13:        |  
+   14:        |  %%%-Client interface functions------------------------------------
+   15:        |  
+   16:        |  alloc() ->
+   17:     1..|      gen_server:call(channel,alloc).
+   18:        |  
+   19:        |  free(Channel) ->
+   20:     1..|      gen_server:call(channel,{free,Channel}).
+   21:        |  
+   22:        |  %%%-gen_server callback functions---------------------------------
+   23:        |  
+   24:        |  init(_Arg) ->
+   25:     1..|      {ok,channels()}.
+   26:        |  
+   27:        |  handle_call(stop,Client,Channels) ->
+   28:     1..|      {stop,normal,ok,Channels};
+   29:        |  
+   30:        |  handle_call(alloc,Client,Channels) ->
+   31:     1..|      {Ch,Channels2} = alloc(Channels),
+   32:     1..|      {reply,{ok,Ch},Channels2};
+   33:        |  
+   34:        |  handle_call({free,Channel},Client,Channels) ->
+   35:     1..|      Channels2 = free(Channel,Channels),
+   36:     1..|      {reply,ok,Channels2}.
+   37:        |  
+   38:        |  terminate(_Reason,Channels) ->
+   39:     1..|      ok.
+   40:        |  
+   41:        |  %%%-Internal functions--------------------------------------------
+   42:        |  
+   43:        |  channels() ->
+   44:     1..|      [ch1,ch2,ch3].
+   45:        |  
+   46:        |  alloc([Channel|Channels]) ->
+   47:     1..|      {Channel,Channels};
+   48:        |  alloc([]) ->
+   49:     0..|      false.
+   50:        |  
+   51:        |  free(Channel,Channels) ->
+   52:     1..|      [Channel|Channels].</pre>
     </section>
 
     <section>

--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -2179,18 +2179,26 @@ do_analyse_to_file(Module, OutFile, ErlFile, HTML) ->
 	    {error, {file, ErlFile, Reason}}
     end.
 
+format_line_number(L, HTML)->
+    if
+        HTML ->
+            io_lib:format("<a href=\"#L~B\" name=\"L~B\">~5B</a>:",[L,L,L]);
+        true ->
+            io_lib:format("~5B:",[L])
+    end.
+
 print_lines(Module, InFd, OutFd, L, HTML) ->
     case io:get_line(InFd, '') of
 	eof ->
 	    ignore;
  	"%"++_=Line ->				%Comment line - not executed.
-        io:put_chars(OutFd, io_lib:format("~5B:",[L])),
+        io:put_chars(OutFd, format_line_number(L,HTML)),
  	    io:put_chars(OutFd, [tab(),escape_lt_and_gt(Line, HTML)]),
 	    print_lines(Module, InFd, OutFd, L+1, HTML);
 	RawLine ->
 	    Line = escape_lt_and_gt(RawLine,HTML),
 	    Pattern = {#bump{module=Module,line=L},'$1'},
-	    io:put_chars(OutFd, io_lib:format("~5B:",[L])),
+	    io:put_chars(OutFd, format_line_number(L,HTML)),
 	    case ets:match(?COLLECTION_TABLE, Pattern) of
 		[] ->
 		    io:put_chars(OutFd, [tab(),Line]);

--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -2184,11 +2184,13 @@ print_lines(Module, InFd, OutFd, L, HTML) ->
 	eof ->
 	    ignore;
  	"%"++_=Line ->				%Comment line - not executed.
+        io:put_chars(OutFd, io_lib:format("~5B:",[L])),
  	    io:put_chars(OutFd, [tab(),escape_lt_and_gt(Line, HTML)]),
 	    print_lines(Module, InFd, OutFd, L+1, HTML);
 	RawLine ->
 	    Line = escape_lt_and_gt(RawLine,HTML),
 	    Pattern = {#bump{module=Module,line=L},'$1'},
+	    io:put_chars(OutFd, io_lib:format("~5B:",[L])),
 	    case ets:match(?COLLECTION_TABLE, Pattern) of
 		[] ->
 		    io:put_chars(OutFd, [tab(),Line]);


### PR DESCRIPTION
Hi, folks.

I've tried to use module cover for code coverage. It's really hard to know line number from code coverage report.

Format was:
```erlang
        |  %%======================================================================
        |  %% API
        |  %%======================================================================
        |  start_link() ->
     0..|  	gen_server:start_link({global,?MODULE}, ?MODULE, [], []).
```

New format:
```erlang
   10:      |  %%======================================================================
   11:      |  %% API
   12:      |  %%======================================================================
   13:      |  start_link() ->
   14:   0..|  	gen_server:start_link({global,?MODULE}, ?MODULE, [], []).
```

This fix simply adds line number to coverage report. Add line number to simple report and to HTML-report. 