### PR TITLE
Use read_concurrency for application environment

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -490,7 +490,8 @@ init(Init, Kernel) ->
 	    %% called during start-up of any app.
 	    case check_conf_data(ConfData) of
 		ok ->
-		    _ = ets:new(ac_tab, [set, public, named_table]),
+		    _ = ets:new(ac_tab, [set, public, named_table,
+                                         {read_concurrency,true}]),
 		    S = #state{conf_data = ConfData},
 		    {ok, KAppl} = make_appl(Kernel),
 		    case catch load(S, KAppl) of


### PR DESCRIPTION
It just struck me to check if this ETS table was configured for concurrent accesses, and sure enough, it wasn't. I think that read_concurrency (but not write_concurrency) should be a good match for the typical access pattern in an Erlang/OTP system.