### PR TITLE
Speed up linting by not traversing filenames in erl_anno

### DIFF
--- a/lib/stdlib/src/erl_anno.erl
+++ b/lib/stdlib/src/erl_anno.erl
@@ -147,7 +147,7 @@ is_anno2(_, _) ->
     false.
 
 is_filename(T) ->
-    is_string(T) orelse is_binary(T).
+    is_list(T) orelse is_binary(T).
 
 is_string(T) ->
     try lists:all(fun(C) when is_integer(C), C >= 0 -> true end, T)


### PR DESCRIPTION
Compilation on Erlang 18.0-rc2 is about 10% slower than in Erlang 17.
After some debugging, we have noticed that linting is on average 30%
to 50% slower being the main responsible for the performance reduction.

Later profiling revealed is_filename/1 to be the biggest culprit. The change
in this commit brings compilation times to about the same times as Erlang 17.

Note this commit doesn't change the compiler behaviour compared to Erlang
17 because we didn't sanity check the value given to the file annotation in the
past. I would say checking the filename is not worth it if it means compilation
becomes 10% slower on average. After all, there are many places in the
compiler where it will fail if we give it a malformed tree, I wouldn't then special
case file annotation.