### PR TITLE
Add show econnreset socket option

### DIFF
--- a/erts/preloaded/src/prim_inet.erl
+++ b/erts/preloaded/src/prim_inet.erl
@@ -1140,6 +1140,7 @@ enc_opt(delay_send)      -> ?INET_LOPT_TCP_DELAY_SEND;
 enc_opt(packet_size)     -> ?INET_LOPT_PACKET_SIZE;
 enc_opt(read_packets)    -> ?INET_LOPT_READ_PACKETS;
 enc_opt(netns)           -> ?INET_LOPT_NETNS;
+enc_opt(show_econnreset) -> ?INET_LOPT_TCP_SHOW_ECONNRESET;
 enc_opt(raw)             -> ?INET_OPT_RAW;
 % Names of SCTP opts:
 enc_opt(sctp_rtoinfo)	 	   -> ?SCTP_OPT_RTOINFO;
@@ -1197,6 +1198,7 @@ dec_opt(?INET_LOPT_TCP_DELAY_SEND)   -> delay_send;
 dec_opt(?INET_LOPT_PACKET_SIZE)      -> packet_size;
 dec_opt(?INET_LOPT_READ_PACKETS)     -> read_packets;
 dec_opt(?INET_LOPT_NETNS)           -> netns;
+dec_opt(?INET_LOPT_TCP_SHOW_ECONNRESET) -> show_econnreset;
 dec_opt(?INET_OPT_RAW)              -> raw;
 dec_opt(I) when is_integer(I)     -> undefined.
 
@@ -1296,6 +1298,7 @@ type_opt_1(delay_send)      -> bool;
 type_opt_1(packet_size)     -> uint;
 type_opt_1(read_packets)    -> uint;
 type_opt_1(netns)           -> binary;
+type_opt_1(show_econnreset) -> bool;
 %% 
 %% SCTP options (to be set). If the type is a record type, the corresponding
 %% record signature is returned, otherwise, an "elementary" type tag 

--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -1056,7 +1056,10 @@ setcap cap_sys_admin,cap_sys_ptrace,cap_dac_read_search+epi beam.smp
               active mode, the controlling process will receive a
               <c>{tcp_error, Socket, econnreset}</c> message
               before the usual <c>{tcp_closed, Socket}</c>, as is
-              the case for any other socket error.</p>
+              the case for any other socket error. Calls to
+              <seealso marker="gen_tcp#send/2">gen_tcp:send/2</seealso>
+              will also return <c>{error, econnreset}</c> when it
+              is detected that a TCP peer has sent an RST.</p>
             <p>A connected socket returned from
               <seealso marker="gen_tcp#accept/1">gen_tcp:accept/1</seealso>
               will inherit the <c>show_econnreset</c> setting from the

--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -1037,6 +1037,33 @@ setcap cap_sys_admin,cap_sys_ptrace,cap_dac_read_search+epi beam.smp
 			<marker id="option-sndbuf"></marker>
           </item>
 
+          <tag><c>{show_econnreset, Boolean}</c>(TCP/IP sockets)</tag>
+          <item>
+            <p>When this option is set to <c>false</c>, as it is by
+              default, an RST that is received from the TCP peer is treated
+              as a normal close (as though a FIN was sent). A caller
+              to <seealso marker="gen_tcp#recv/2">gen_tcp:recv/2</seealso>
+              will get <c>{error, closed}</c>. In active
+              mode the controlling process will receive a
+              <c>{tcp_close, Socket}</c> message, indicating that the
+              peer has closed the connection.</p>
+            <p>Setting this option to <c>true</c> will allow you to
+              distinguish between a connection that was closed normally,
+              and one which was aborted (intentionally or unintentionally)
+              by the TCP peer. A call to
+              <seealso marker="gen_tcp#recv/2">gen_tcp:recv/2</seealso>
+              will return <c>{error, econnreset}</c>. In
+              active mode, the controlling process will receive a
+              <c>{tcp_error, Socket, econnreset}</c> message
+              before the usual <c>{tcp_closed, Socket}</c>, as is
+              the case for any other socket error.</p>
+            <p>A connected socket returned from
+              <seealso marker="gen_tcp#accept/1">gen_tcp:accept/1</seealso>
+              will inherit the <c>show_econnreset</c> setting from the
+              listening socket.</p>
+			<marker id="option-show_econnreset"></marker>
+          </item>
+
           <tag><c>{sndbuf, Size}</c></tag>
           <item>
             <p>The minimum size of the send buffer to use for the socket.

--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -58,6 +58,7 @@
         {reuseaddr,       boolean()} |
         {send_timeout,    non_neg_integer() | infinity} |
         {send_timeout_close, boolean()} |
+        {show_econnreset, boolean()} |
         {sndbuf,          non_neg_integer()} |
         {tos,             non_neg_integer()} |
 	{ipv6_v6only,     boolean()}.
@@ -89,6 +90,7 @@
         reuseaddr |
         send_timeout |
         send_timeout_close |
+        show_econnreset |
         sndbuf |
         tos |
 	ipv6_v6only.

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -654,7 +654,7 @@ options() ->
      multicast_if, multicast_ttl, multicast_loop,
      exit_on_close, high_watermark, low_watermark,
      high_msgq_watermark, low_msgq_watermark,
-     send_timeout, send_timeout_close
+     send_timeout, send_timeout_close, show_econnreset
     ].
 
 %% Return a list of statistics options
@@ -672,7 +672,8 @@ connect_options() ->
     [tos, priority, reuseaddr, keepalive, linger, sndbuf, recbuf, nodelay,
      header, active, packet, packet_size, buffer, mode, deliver,
      exit_on_close, high_watermark, low_watermark, high_msgq_watermark,
-     low_msgq_watermark, send_timeout, send_timeout_close, delay_send, raw].
+     low_msgq_watermark, send_timeout, send_timeout_close, delay_send, raw,
+     show_econnreset].
     
 connect_options(Opts, Family) ->
     BaseOpts = 
@@ -740,7 +741,7 @@ listen_options() ->
      header, active, packet, buffer, mode, deliver, backlog, ipv6_v6only,
      exit_on_close, high_watermark, low_watermark, high_msgq_watermark,
      low_msgq_watermark, send_timeout, send_timeout_close, delay_send,
-     packet_size, raw].
+     packet_size, raw, show_econnreset].
 
 listen_options(Opts, Family) ->
     BaseOpts = 

--- a/lib/kernel/src/inet_int.hrl
+++ b/lib/kernel/src/inet_int.hrl
@@ -147,6 +147,7 @@
 -define(INET_LOPT_MSGQ_HIWTRMRK,  36).
 -define(INET_LOPT_MSGQ_LOWTRMRK,  37).
 -define(INET_LOPT_NETNS,          38).
+-define(INET_LOPT_TCP_SHOW_ECONNRESET, 39).
 % Specific SCTP options: separate range:
 -define(SCTP_OPT_RTOINFO,	 	100).
 -define(SCTP_OPT_ASSOCINFO,	 	101).

--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -31,6 +31,8 @@
 	 init_per_testcase/2, end_per_testcase/2,
 	 otp_3924/1, otp_3924_sender/4, closed_socket/1,
 	 shutdown_active/1, shutdown_passive/1, shutdown_pending/1,
+	 show_econnreset_active/1, show_econnreset_active_once/1,
+	 show_econnreset_passive/1,
 	 default_options/1, http_bad_packet/1, 
 	 busy_send/1, busy_disconnect_passive/1, busy_disconnect_active/1,
 	 fill_sendq/1, partial_recv_and_close/1, 
@@ -92,6 +94,8 @@ all() ->
      iter_max_socks, passive_sockets, active_n,
      accept_closed_by_other_process, otp_3924, closed_socket,
      shutdown_active, shutdown_passive, shutdown_pending,
+     show_econnreset_active, show_econnreset_active_once,
+     show_econnreset_passive,
      default_options, http_bad_packet, busy_send,
      busy_disconnect_passive, busy_disconnect_active,
      fill_sendq, partial_recv_and_close,
@@ -1074,6 +1078,109 @@ shutdown_pending(Config) when is_list(Config) ->
 	     gen_tcp:send(S, integer_to_list(byte_size(Bs))),
 	     gen_tcp:close(S)
      end.
+
+%%
+%% Test 'show_econnreset' option
+%%
+
+show_econnreset_active(Config) when is_list(Config) ->
+    %% First confirm everything works with option turned off.
+    {ok, L} = gen_tcp:listen(0, []),
+    {ok, Port} = inet:port(L),
+    {ok, Client} = gen_tcp:connect(localhost, Port, [{active, false}]),
+    {ok, S} = gen_tcp:accept(L),
+    ok = gen_tcp:close(L),
+    ok = inet:setopts(Client, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(Client),
+    receive
+       {tcp_closed, S} ->
+	   ok;
+       Other ->
+	   ?t:fail({unexpected1, Other})
+    after 1000 ->
+	?t:fail({timeout, {server, no_tcp_closed}})
+    end,
+
+    %% Now test with option switched on.
+    %% Note: We are also testing that the show_econnreset option is
+    %% inherited from the listening socket by the accepting socket.
+    {ok, L1} = gen_tcp:listen(0, [{show_econnreset, true}]),
+    {ok, Port1} = inet:port(L1),
+    {ok, Client1} = gen_tcp:connect(localhost, Port1, [{active, false}]),
+    {ok, S1} = gen_tcp:accept(L1),
+    ok = gen_tcp:close(L1),
+    ok = inet:setopts(Client1, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(Client1),
+    receive
+	{tcp_error, S1, econnreset} ->
+	    receive
+		{tcp_closed, S1} ->
+		    ok;
+		Other1 ->
+		    ?t:fail({unexpected2, Other1})
+	    after 1 ->
+		?t:fail({timeout, {server, no_tcp_closed}})
+	    end;
+	Other2 ->
+	    ?t:fail({unexpected3, Other2})
+    after 1000 ->
+	?t:fail({timeout, {server, no_tcp_error}})
+    end.
+
+show_econnreset_active_once(Config) when is_list(Config) ->
+    %% Now test using {active, once}
+    {ok, L} = gen_tcp:listen(0,
+			   [{active, false},
+			    {show_econnreset, true}]),
+    {ok, Port} = inet:port(L),
+    {ok, Client} = gen_tcp:connect(localhost, Port, [{active, false}]),
+    {ok, S} = gen_tcp:accept(L),
+    ok = gen_tcp:close(L),
+    ok = inet:setopts(Client, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(Client),
+    ok = ?t:sleep(20),
+    ok = receive Msg -> {unexpected_msg, Msg} after 0 -> ok end,
+    ok = inet:setopts(S, [{active, once}]),
+    receive
+	{tcp_error, S, econnreset} ->
+	    receive
+		{tcp_closed, S} ->
+		    ok;
+		Other1 ->
+		    ?t:fail({unexpected1, Other1})
+	    after 1 ->
+		?t:fail({timeout, {server, no_tcp_closed}})
+	    end;
+	Other2 ->
+	    ?t:fail({unexpected2, Other2})
+    after 1000 ->
+	?t:fail({timeout, {server, no_tcp_error}})
+    end.
+
+show_econnreset_passive(Config) when is_list(Config) ->
+    %% First confirm everything works with option turned off.
+    {ok, L} = gen_tcp:listen(0, [{active, false}]),
+    {ok, Port} = inet:port(L),
+    {ok, Client} = gen_tcp:connect(localhost, Port, [{active, false}]),
+    {ok, S} = gen_tcp:accept(L),
+    ok = gen_tcp:close(L),
+    ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(S),
+    ok = ?t:sleep(1),
+    {error, closed} = gen_tcp:recv(Client, 0),
+
+    %% Now test with option switched on.
+    {ok, L1} = gen_tcp:listen(0, [{active, false}]),
+    {ok, Port1} = inet:port(L1),
+    {ok, Client1} = gen_tcp:connect(localhost, Port1,
+				 [{active, false},
+				  {show_econnreset, true}]),
+    {ok, S1} = gen_tcp:accept(L1),
+    ok = gen_tcp:close(L1),
+    ok = inet:setopts(S1, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(S1),
+    ok = ?t:sleep(1),
+    {error, econnreset} = gen_tcp:recv(Client1, 0).
 
 
 %% Thanks to Luke Gorrie. Tests for a very specific problem with 

--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -32,7 +32,10 @@
 	 otp_3924/1, otp_3924_sender/4, closed_socket/1,
 	 shutdown_active/1, shutdown_passive/1, shutdown_pending/1,
 	 show_econnreset_active/1, show_econnreset_active_once/1,
-	 show_econnreset_passive/1,
+	 show_econnreset_passive/1, econnreset_after_sync_send/1,
+	 econnreset_after_async_send_active/1,
+	 econnreset_after_async_send_active_once/1,
+	 econnreset_after_async_send_passive/1,
 	 default_options/1, http_bad_packet/1, 
 	 busy_send/1, busy_disconnect_passive/1, busy_disconnect_active/1,
 	 fill_sendq/1, partial_recv_and_close/1, 
@@ -95,7 +98,10 @@ all() ->
      accept_closed_by_other_process, otp_3924, closed_socket,
      shutdown_active, shutdown_passive, shutdown_pending,
      show_econnreset_active, show_econnreset_active_once,
-     show_econnreset_passive,
+     show_econnreset_passive, econnreset_after_sync_send,
+     econnreset_after_async_send_active,
+     econnreset_after_async_send_active_once,
+     econnreset_after_async_send_passive,
      default_options, http_bad_packet, busy_send,
      busy_disconnect_passive, busy_disconnect_active,
      fill_sendq, partial_recv_and_close,
@@ -1182,6 +1188,175 @@ show_econnreset_passive(Config) when is_list(Config) ->
     ok = ?t:sleep(1),
     {error, econnreset} = gen_tcp:recv(Client1, 0).
 
+econnreset_after_sync_send(Config) when is_list(Config) ->
+    %% First confirm everything works with option turned off.
+    {ok, L} = gen_tcp:listen(0, [{active, false}]),
+    {ok, Port} = inet:port(L),
+    {ok, Client} = gen_tcp:connect(localhost, Port, [{active, false}]),
+    {ok, S} = gen_tcp:accept(L),
+    ok = gen_tcp:close(L),
+    ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(S),
+    ok = ?t:sleep(20),
+    {error, closed} = gen_tcp:send(Client, "Whatever"),
+
+    %% Now test with option switched on.
+    {ok, L1} = gen_tcp:listen(0, [{active, false}]),
+    {ok, Port1} = inet:port(L1),
+    {ok, Client1} = gen_tcp:connect(localhost, Port1,
+          			  [{active, false},
+          			   {show_econnreset, true}]),
+    {ok, S1} = gen_tcp:accept(L1),
+    ok = gen_tcp:close(L1),
+    ok = inet:setopts(S1, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(S1),
+    ok = ?t:sleep(20),
+    {error, econnreset} = gen_tcp:send(Client1, "Whatever").
+
+econnreset_after_async_send_active(Config) when is_list(Config) ->
+    {OS, _} = os:type(),
+    Payload = lists:duplicate(1024 * 1024, $.),
+
+    %% First confirm everything works with option turned off.
+    {ok, L} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    {ok, Port} = inet:port(L),
+    {ok, Client} = gen_tcp:connect(localhost, Port, [{sndbuf, 4096}]),
+    {ok, S} = gen_tcp:accept(L),
+    ok = gen_tcp:close(L),
+    ok = gen_tcp:send(Client, Payload),
+    case erlang:port_info(Client, queue_size) of
+	{queue_size, N} when N > 0 -> ok;
+	{queue_size, 0} when OS =:= win32 -> ok;
+	{queue_size, 0} = T -> ?t:fail(T)
+    end,
+    ok = gen_tcp:send(S, "Whatever"),
+    ok = ?t:sleep(20),
+    ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(S),
+    ok = ?t:sleep(20),
+    receive
+	{tcp, Client, "Whatever"} ->
+	    receive
+		{tcp_closed, Client} ->
+		    ok;
+		Other1 ->
+		    ?t:fail({unexpected1, Other1})
+	    end;
+	Other2 ->
+	    ?t:fail({unexpected2, Other2})
+    end,
+
+    %% Now test with option switched on.
+    {ok, L1} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    {ok, Port1} = inet:port(L1),
+    {ok, Client1} = gen_tcp:connect(localhost, Port1,
+				  [{sndbuf, 4096},
+				   {show_econnreset, true}]),
+    {ok, S1} = gen_tcp:accept(L1),
+    ok = gen_tcp:close(L1),
+    ok = gen_tcp:send(Client1, Payload),
+    case erlang:port_info(Client1, queue_size) of
+	{queue_size, N1} when N1 > 0 -> ok;
+	{queue_size, 0} when OS =:= win32 -> ok;
+	{queue_size, 0} = T1 -> ?t:fail(T1)
+    end,
+    ok = gen_tcp:send(S1, "Whatever"),
+    ok = ?t:sleep(20),
+    ok = inet:setopts(S1, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(S1),
+    ok = ?t:sleep(20),
+    receive
+	{tcp, Client1, "Whatever"} ->
+	    receive
+		{tcp_error, Client1, econnreset} ->
+		    receive
+			{tcp_closed, Client1} ->
+			    ok;
+			Other3 ->
+			    ?t:fail({unexpected3, Other3})
+		    end;
+		Other4 ->
+		    ?t:fail({unexpected4, Other4})
+	    end;
+	Other5 ->
+	    ?t:fail({unexpected5, Other5})
+    end.
+
+econnreset_after_async_send_active_once(Config) when is_list(Config) ->
+    {OS, _} = os:type(),
+    {ok, L} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    {ok, Port} = inet:port(L),
+    {ok, Client} = gen_tcp:connect(localhost, Port,
+				   [{active, false},
+				    {sndbuf, 4096},
+				    {show_econnreset, true}]),
+    {ok,S} = gen_tcp:accept(L),
+    ok = gen_tcp:close(L),
+    Payload = lists:duplicate(1024 * 1024, $.),
+    ok = gen_tcp:send(Client, Payload),
+    case erlang:port_info(Client, queue_size) of
+	{queue_size, N} when N > 0 -> ok;
+	{queue_size, 0} when OS =:= win32 -> ok;
+	{queue_size, 0} = T -> ?t:fail(T)
+    end,
+    ok = gen_tcp:send(S, "Whatever"),
+    ok = ?t:sleep(20),
+    ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(S),
+    ok = ?t:sleep(20),
+    ok = receive Msg -> {unexpected_msg, Msg} after 0 -> ok end,
+    ok = inet:setopts(Client, [{active, once}]),
+    receive
+	{tcp_error, Client, econnreset} ->
+	    receive
+		{tcp_closed, Client} ->
+		    ok;
+		Other ->
+		    ?t:fail({unexpected1, Other})
+	    end;
+	Other ->
+	    ?t:fail({unexpected2, Other})
+    end.
+
+econnreset_after_async_send_passive(Config) when is_list(Config) ->
+    {OS, _} = os:type(),
+    Payload = lists:duplicate(1024 * 1024, $.),
+
+    %% First confirm everything works with option turned off.
+    {ok, L} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    {ok, Port} = inet:port(L),
+    {ok, Client} = gen_tcp:connect(localhost, Port,
+					 [{active, false},
+					  {sndbuf, 4096}]),
+    {ok, S} = gen_tcp:accept(L),
+    ok = gen_tcp:close(L),
+    ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ok = gen_tcp:send(S, "Whatever"),
+    ok = gen_tcp:send(Client, Payload),
+    case erlang:port_info(Client, queue_size) of
+	{queue_size, N} when N > 0 -> ok;
+	{queue_size, 0} when OS =:= win32 -> ok;
+	{queue_size, 0} = T -> ?t:fail(T)
+    end,
+    ok = gen_tcp:close(S),
+    ok = ?t:sleep(20),
+    {error, closed} = gen_tcp:recv(Client, 0),
+
+    %% Now test with option switched on.
+    {ok, L1} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    {ok, Port1} = inet:port(L1),
+    {ok, Client1} = gen_tcp:connect(localhost, Port1,
+				   [{active, false},
+				    {sndbuf, 4096},
+				    {show_econnreset, true}]),
+    {ok, S1} = gen_tcp:accept(L1),
+    ok = gen_tcp:close(L1),
+    ok = inet:setopts(S1, [{linger, {true, 0}}]),
+    ok = gen_tcp:send(S1, "Whatever"),
+    ok = gen_tcp:send(Client1, Payload),
+    ok = gen_tcp:close(S1),
+    ok = ?t:sleep(20),
+    {error, econnreset} = gen_tcp:recv(Client1, 0).
 
 %% Thanks to Luke Gorrie. Tests for a very specific problem with 
 %% corrupt data. The testcase will be killed by the timetrap timeout


### PR DESCRIPTION
This is based on the fix_gen_tcp_shutdown branch pushed yesterday.

EEP Light for adding 'show_econnreset' TCP socket option
========================================================

Why do we need this new feature?
--------------------------------

In the current TCP implementation, Erlang/OTP treats ECONNRESET errors
on incoming receives as though they are a normal close. In other
words, incoming RSTs are treated as though they are FINs.

When writing many types of TCP servers and clients (all in my opinion)
it's important to be able to distinguish between connections that were
closed because a FIN arrived and those that were closed due to an RST.
An RST might be sent to us for a variety of reasons, such as:

  * A TCP peer intentionally aborts a connection, for whatever
    reason, by setting the option SO_LINGER to {TRUE, 0} on the
    socket.

  * A TCP peer calls close() without fully reading what's in the
    kernel receive buffer. On Linux, at least, the kernel sends
    an RST when this happens.

Unless you are using an application protocol which will confirm
that you have received a complete payload, you should treat an RST
as an indication that the payload you received was incomplete. Not
all application protocols are so helpful.

As a concrete example of when one might need to distinguish RSTs
from FINs, let's assume that we are writing a HTTP Proxy/Cache
server. The HTTP spec says that a client that receives a response
without a Content-Length header is supposed to treat this as a valid
response and read from the stream until the server closes the
connection [2]. Though the spec says nothing about RSTs in this
context, I certainly wouldn't intentionally cache any document
received in such a way when the connection was terminated with an
RST. Any yet with the way Erlang/OTP currently is, I don't have the
option of detecting RSTs.

There has already been at least one other person on the
erlang-questions mailing list who has requested the ability to
receive ECONNRESET errors (see [3]).


How did you solve it?
---------------------

By adding a socket option {show_econnreset, true|false} that
enables the display of received ECONNRESET errors. By default,
this option is set to false for each socket.


Risks or uncertain artifacts?
-----------------------------

If you look at the changes that this patch makes to inet_drv.c
you will notice that it translates an ECONNABORTED error received
on Windows into an ECONNRESET. Windows definitely returns
ECONNABORTED on some occasions to signify than an RST has
arrived - some of the test code will fail without this change.
However, it's possible that Windows returns ECONNABORTED on
a connected socket for other reasons also (I don't actually know),
and it might be the preference of the Erlang/OTP team to leave
this error to be returned as {error, econnaborted} and let the
user to handle it as they see fit. Note that you are currently
masking all close errors that return on Windows in this part of
the code to normal {error, closed}, so the translation this patch
makes isn't as disruptive as it might sound.

This patch only solves part of the problem. It stops ECONNRESET
errors that are received from a recv() syscall from being
treated as a normal connection termination. It does not solve
the problem where a send() syscall is made and an error is
returned there indicating that an RST has been received. This
second problem is more difficult to solve and will be handled
in a separate patch.


References:
-----------
[1] https://tools.ietf.org/html/rfc7230#section-6.6
[2] https://tools.ietf.org/html/rfc7230#section-3.3.3
[3] http://erlang.org/pipermail/erlang-questions/2015-February/083239.html
