### PR TITLE
Apply show_econnreset socket option to send errors

### DIFF
--- a/erts/preloaded/src/prim_inet.erl
+++ b/erts/preloaded/src/prim_inet.erl
@@ -1140,6 +1140,7 @@ enc_opt(delay_send)      -> ?INET_LOPT_TCP_DELAY_SEND;
 enc_opt(packet_size)     -> ?INET_LOPT_PACKET_SIZE;
 enc_opt(read_packets)    -> ?INET_LOPT_READ_PACKETS;
 enc_opt(netns)           -> ?INET_LOPT_NETNS;
+enc_opt(show_econnreset) -> ?INET_LOPT_TCP_SHOW_ECONNRESET;
 enc_opt(raw)             -> ?INET_OPT_RAW;
 % Names of SCTP opts:
 enc_opt(sctp_rtoinfo)	 	   -> ?SCTP_OPT_RTOINFO;
@@ -1197,6 +1198,7 @@ dec_opt(?INET_LOPT_TCP_DELAY_SEND)   -> delay_send;
 dec_opt(?INET_LOPT_PACKET_SIZE)      -> packet_size;
 dec_opt(?INET_LOPT_READ_PACKETS)     -> read_packets;
 dec_opt(?INET_LOPT_NETNS)           -> netns;
+dec_opt(?INET_LOPT_TCP_SHOW_ECONNRESET) -> show_econnreset;
 dec_opt(?INET_OPT_RAW)              -> raw;
 dec_opt(I) when is_integer(I)     -> undefined.
 
@@ -1296,6 +1298,7 @@ type_opt_1(delay_send)      -> bool;
 type_opt_1(packet_size)     -> uint;
 type_opt_1(read_packets)    -> uint;
 type_opt_1(netns)           -> binary;
+type_opt_1(show_econnreset) -> bool;
 %% 
 %% SCTP options (to be set). If the type is a record type, the corresponding
 %% record signature is returned, otherwise, an "elementary" type tag 

--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -1056,7 +1056,10 @@ setcap cap_sys_admin,cap_sys_ptrace,cap_dac_read_search+epi beam.smp
               active mode, the controlling process will receive a
               <c>{tcp_error, Socket, econnreset}</c> message
               before the usual <c>{tcp_closed, Socket}</c>, as is
-              the case for any other socket error.</p>
+              the case for any other socket error. Calls to
+              <seealso marker="gen_tcp#send/2">gen_tcp:send/2</seealso>
+              will also return <c>{error, econnreset}</c> when it
+              is detected that a TCP peer has sent an RST.</p>
             <p>A connected socket returned from
               <seealso marker="gen_tcp#accept/1">gen_tcp:accept/1</seealso>
               will inherit the <c>show_econnreset</c> setting from the

--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -1037,6 +1037,33 @@ setcap cap_sys_admin,cap_sys_ptrace,cap_dac_read_search+epi beam.smp
 			<marker id="option-sndbuf"></marker>
           </item>
 
+          <tag><c>{show_econnreset, Boolean}</c>(TCP/IP sockets)</tag>
+          <item>
+            <p>When this option is set to <c>false</c>, as it is by
+              default, an RST that is received from the TCP peer is treated
+              as a normal close (as though a FIN was sent). A caller
+              to <seealso marker="gen_tcp#recv/2">gen_tcp:recv/2</seealso>
+              will get <c>{error, closed}</c>. In active
+              mode the controlling process will receive a
+              <c>{tcp_close, Socket}</c> message, indicating that the
+              peer has closed the connection.</p>
+            <p>Setting this option to <c>true</c> will allow you to
+              distinguish between a connection that was closed normally,
+              and one which was aborted (intentionally or unintentionally)
+              by the TCP peer. A call to
+              <seealso marker="gen_tcp#recv/2">gen_tcp:recv/2</seealso>
+              will return <c>{error, econnreset}</c>. In
+              active mode, the controlling process will receive a
+              <c>{tcp_error, Socket, econnreset}</c> message
+              before the usual <c>{tcp_closed, Socket}</c>, as is
+              the case for any other socket error.</p>
+            <p>A connected socket returned from
+              <seealso marker="gen_tcp#accept/1">gen_tcp:accept/1</seealso>
+              will inherit the <c>show_econnreset</c> setting from the
+              listening socket.</p>
+			<marker id="option-show_econnreset"></marker>
+          </item>
+
           <tag><c>{sndbuf, Size}</c></tag>
           <item>
             <p>The minimum size of the send buffer to use for the socket.

--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -58,6 +58,7 @@
         {reuseaddr,       boolean()} |
         {send_timeout,    non_neg_integer() | infinity} |
         {send_timeout_close, boolean()} |
+        {show_econnreset, boolean()} |
         {sndbuf,          non_neg_integer()} |
         {tos,             non_neg_integer()} |
 	{ipv6_v6only,     boolean()}.
@@ -89,6 +90,7 @@
         reuseaddr |
         send_timeout |
         send_timeout_close |
+        show_econnreset |
         sndbuf |
         tos |
 	ipv6_v6only.

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -654,7 +654,7 @@ options() ->
      multicast_if, multicast_ttl, multicast_loop,
      exit_on_close, high_watermark, low_watermark,
      high_msgq_watermark, low_msgq_watermark,
-     send_timeout, send_timeout_close
+     send_timeout, send_timeout_close, show_econnreset
     ].
 
 %% Return a list of statistics options
@@ -672,7 +672,8 @@ connect_options() ->
     [tos, priority, reuseaddr, keepalive, linger, sndbuf, recbuf, nodelay,
      header, active, packet, packet_size, buffer, mode, deliver,
      exit_on_close, high_watermark, low_watermark, high_msgq_watermark,
-     low_msgq_watermark, send_timeout, send_timeout_close, delay_send, raw].
+     low_msgq_watermark, send_timeout, send_timeout_close, delay_send, raw,
+     show_econnreset].
     
 connect_options(Opts, Family) ->
     BaseOpts = 
@@ -740,7 +741,7 @@ listen_options() ->
      header, active, packet, buffer, mode, deliver, backlog, ipv6_v6only,
      exit_on_close, high_watermark, low_watermark, high_msgq_watermark,
      low_msgq_watermark, send_timeout, send_timeout_close, delay_send,
-     packet_size, raw].
+     packet_size, raw, show_econnreset].
 
 listen_options(Opts, Family) ->
     BaseOpts = 

--- a/lib/kernel/src/inet_int.hrl
+++ b/lib/kernel/src/inet_int.hrl
@@ -147,6 +147,7 @@
 -define(INET_LOPT_MSGQ_HIWTRMRK,  36).
 -define(INET_LOPT_MSGQ_LOWTRMRK,  37).
 -define(INET_LOPT_NETNS,          38).
+-define(INET_LOPT_TCP_SHOW_ECONNRESET, 39).
 % Specific SCTP options: separate range:
 -define(SCTP_OPT_RTOINFO,	 	100).
 -define(SCTP_OPT_ASSOCINFO,	 	101).

--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -32,7 +32,10 @@
 	 otp_3924/1, otp_3924_sender/4, closed_socket/1,
 	 shutdown_active/1, shutdown_passive/1, shutdown_pending/1,
 	 show_econnreset_active/1, show_econnreset_active_once/1,
-	 show_econnreset_passive/1,
+	 show_econnreset_passive/1, econnreset_after_sync_send/1,
+	 econnreset_after_async_send_active/1,
+	 econnreset_after_async_send_active_once/1,
+	 econnreset_after_async_send_passive/1,
 	 default_options/1, http_bad_packet/1, 
 	 busy_send/1, busy_disconnect_passive/1, busy_disconnect_active/1,
 	 fill_sendq/1, partial_recv_and_close/1, 
@@ -95,7 +98,10 @@ all() ->
      accept_closed_by_other_process, otp_3924, closed_socket,
      shutdown_active, shutdown_passive, shutdown_pending,
      show_econnreset_active, show_econnreset_active_once,
-     show_econnreset_passive,
+     show_econnreset_passive, econnreset_after_sync_send,
+     econnreset_after_async_send_active,
+     econnreset_after_async_send_active_once,
+     econnreset_after_async_send_passive,
      default_options, http_bad_packet, busy_send,
      busy_disconnect_passive, busy_disconnect_active,
      fill_sendq, partial_recv_and_close,
@@ -1182,6 +1188,175 @@ show_econnreset_passive(Config) when is_list(Config) ->
     ?line ok = ?t:sleep(1),
     ?line {error, econnreset} = gen_tcp:recv(Client1, 0).
 
+econnreset_after_sync_send(Config) when is_list(Config) ->
+    %% First confirm everything works with option turned off.
+    ?line {ok, L} = gen_tcp:listen(0, [{active, false}]),
+    ?line {ok, Port} = inet:port(L),
+    ?line {ok, Client} = gen_tcp:connect(localhost, Port, [{active, false}]),
+    ?line {ok, S} = gen_tcp:accept(L),
+    ?line ok = gen_tcp:close(L),
+    ?line ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(S),
+    ?line ok = ?t:sleep(20),
+    ?line {error, closed} = gen_tcp:send(Client, "Whatever"),
+
+    %% Now test with option switched on.
+    ?line {ok, L1} = gen_tcp:listen(0, [{active, false}]),
+    ?line {ok, Port1} = inet:port(L1),
+    ?line {ok, Client1} = gen_tcp:connect(localhost, Port1,
+					  [{active, false},
+					   {show_econnreset, true}]),
+    ?line {ok, S1} = gen_tcp:accept(L1),
+    ?line ok = gen_tcp:close(L1),
+    ?line ok = inet:setopts(S1, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(S1),
+    ?line ok = ?t:sleep(20),
+    ?line {error, econnreset} = gen_tcp:send(Client1, "Whatever").
+
+econnreset_after_async_send_active(Config) when is_list(Config) ->
+    ?line {OS, _} = os:type(),
+    ?line Payload = lists:duplicate(1024 * 1024, $.),
+
+    %% First confirm everything works with option turned off.
+    ?line {ok, L} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    ?line {ok, Port} = inet:port(L),
+    ?line {ok, Client} = gen_tcp:connect(localhost, Port, [{sndbuf, 4096}]),
+    ?line {ok, S} = gen_tcp:accept(L),
+    ?line ok = gen_tcp:close(L),
+    ?line ok = gen_tcp:send(Client, Payload),
+    ?line case erlang:port_info(Client, queue_size) of
+	      {queue_size, N} when N > 0 -> ok;
+	      {queue_size, 0} when OS =:= win32 -> ok;
+	      {queue_size, 0} = T -> ?t:fail(T)
+	  end,
+    ?line ok = gen_tcp:send(S, "Whatever"),
+    ?line ok = ?t:sleep(20),
+    ?line ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(S),
+    ?line ok = ?t:sleep(20),
+    ?line receive
+	      {tcp, Client, "Whatever"} ->
+		  ?line receive
+			    {tcp_closed, Client} ->
+				ok;
+			    Other1 ->
+				?t:fail({unexpected1, Other1})
+			end;
+	      Other2 ->
+		  ?t:fail({unexpected2, Other2})
+	  end,
+
+    %% Now test with option switched on.
+    ?line {ok, L1} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    ?line {ok, Port1} = inet:port(L1),
+    ?line {ok, Client1} = gen_tcp:connect(localhost, Port1,
+					  [{sndbuf, 4096},
+					   {show_econnreset, true}]),
+    ?line {ok, S1} = gen_tcp:accept(L1),
+    ?line ok = gen_tcp:close(L1),
+    ?line ok = gen_tcp:send(Client1, Payload),
+    ?line case erlang:port_info(Client1, queue_size) of
+	      {queue_size, N1} when N1 > 0 -> ok;
+	      {queue_size, 0} when OS =:= win32 -> ok;
+	      {queue_size, 0} = T1 -> ?t:fail(T1)
+	  end,
+    ?line ok = gen_tcp:send(S1, "Whatever"),
+    ?line ok = ?t:sleep(20),
+    ?line ok = inet:setopts(S1, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(S1),
+    ?line ok = ?t:sleep(20),
+    ?line receive
+	      {tcp, Client1, "Whatever"} ->
+		  ?line receive
+			    {tcp_error, Client1, econnreset} ->
+				?line receive
+					  {tcp_closed, Client1} ->
+					      ok;
+					  Other3 ->
+					      ?t:fail({unexpected3, Other3})
+				      end;
+			    Other4 ->
+				?t:fail({unexpected4, Other4})
+			end;
+	      Other5 ->
+		  ?t:fail({unexpected5, Other5})
+	  end.
+
+econnreset_after_async_send_active_once(Config) when is_list(Config) ->
+    ?line {OS, _} = os:type(),
+    ?line {ok, L} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    ?line {ok, Port} = inet:port(L),
+    ?line {ok, Client} = gen_tcp:connect(localhost, Port,
+					 [{active, false},
+					  {sndbuf, 4096},
+					  {show_econnreset, true}]),
+    ?line {ok,S} = gen_tcp:accept(L),
+    ?line ok = gen_tcp:close(L),
+    ?line Payload = lists:duplicate(1024 * 1024, $.),
+    ?line ok = gen_tcp:send(Client, Payload),
+    ?line case erlang:port_info(Client, queue_size) of
+	      {queue_size, N} when N > 0 -> ok;
+	      {queue_size, 0} when OS =:= win32 -> ok;
+	      {queue_size, 0} = T -> ?t:fail(T)
+	  end,
+    ?line ok = gen_tcp:send(S, "Whatever"),
+    ?line ok = ?t:sleep(20),
+    ?line ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(S),
+    ?line ok = ?t:sleep(20),
+    ?line ok = receive Msg -> {unexpected_msg, Msg} after 0 -> ok end,
+    ?line ok = inet:setopts(Client, [{active, once}]),
+    ?line receive
+	      {tcp_error, Client, econnreset} ->
+		  ?line receive
+			    {tcp_closed, Client} ->
+				ok;
+			    Other ->
+				?t:fail({unexpected1, Other})
+			end;
+	      Other ->
+		  ?t:fail({unexpected2, Other})
+	  end.
+
+econnreset_after_async_send_passive(Config) when is_list(Config) ->
+    ?line {OS, _} = os:type(),
+    ?line Payload = lists:duplicate(1024 * 1024, $.),
+
+    %% First confirm everything works with option turned off.
+    ?line {ok, L} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    ?line {ok, Port} = inet:port(L),
+    ?line {ok, Client} = gen_tcp:connect(localhost, Port,
+					 [{active, false},
+					  {sndbuf, 4096}]),
+    ?line {ok, S} = gen_tcp:accept(L),
+    ?line ok = gen_tcp:close(L),
+    ?line ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:send(S, "Whatever"),
+    ?line ok = gen_tcp:send(Client, Payload),
+    ?line case erlang:port_info(Client, queue_size) of
+	      {queue_size, N} when N > 0 -> ok;
+	      {queue_size, 0} when OS =:= win32 -> ok;
+	      {queue_size, 0} = T -> ?t:fail(T)
+	  end,
+    ?line ok = gen_tcp:close(S),
+    ?line ok = ?t:sleep(20),
+    ?line {error, closed} = gen_tcp:recv(Client, 0),
+
+    %% Now test with option switched on.
+    ?line {ok, L1} = gen_tcp:listen(0, [{active, false}, {recbuf, 4096}]),
+    ?line {ok, Port1} = inet:port(L1),
+    ?line {ok, Client1} = gen_tcp:connect(localhost, Port1,
+					 [{active, false},
+					  {sndbuf, 4096},
+					  {show_econnreset, true}]),
+    ?line {ok, S1} = gen_tcp:accept(L1),
+    ?line ok = gen_tcp:close(L1),
+    ?line ok = inet:setopts(S1, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:send(S1, "Whatever"),
+    ?line ok = gen_tcp:send(Client1, Payload),
+    ?line ok = gen_tcp:close(S1),
+    ?line ok = ?t:sleep(20),
+    ?line {error, econnreset} = gen_tcp:recv(Client1, 0).
 
 %% Thanks to Luke Gorrie. Tests for a very specific problem with 
 %% corrupt data. The testcase will be killed by the timetrap timeout

--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -31,6 +31,8 @@
 	 init_per_testcase/2, end_per_testcase/2,
 	 otp_3924/1, otp_3924_sender/4, closed_socket/1,
 	 shutdown_active/1, shutdown_passive/1, shutdown_pending/1,
+	 show_econnreset_active/1, show_econnreset_active_once/1,
+	 show_econnreset_passive/1,
 	 default_options/1, http_bad_packet/1, 
 	 busy_send/1, busy_disconnect_passive/1, busy_disconnect_active/1,
 	 fill_sendq/1, partial_recv_and_close/1, 
@@ -92,6 +94,8 @@ all() ->
      iter_max_socks, passive_sockets, active_n,
      accept_closed_by_other_process, otp_3924, closed_socket,
      shutdown_active, shutdown_passive, shutdown_pending,
+     show_econnreset_active, show_econnreset_active_once,
+     show_econnreset_passive,
      default_options, http_bad_packet, busy_send,
      busy_disconnect_passive, busy_disconnect_active,
      fill_sendq, partial_recv_and_close,
@@ -1074,6 +1078,109 @@ shutdown_pending(Config) when is_list(Config) ->
 	     gen_tcp:send(S, integer_to_list(byte_size(Bs))),
 	     gen_tcp:close(S)
      end.
+
+%%
+%% Test 'show_econnreset' option
+%%
+
+show_econnreset_active(Config) when is_list(Config) ->
+    %% First confirm everything works with option turned off.
+    ?line {ok, L} = gen_tcp:listen(0, []),
+    ?line {ok, Port} = inet:port(L),
+    ?line {ok, Client} = gen_tcp:connect(localhost, Port, [{active, false}]),
+    ?line {ok, S} = gen_tcp:accept(L),
+    ?line ok = gen_tcp:close(L),
+    ?line ok = inet:setopts(Client, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(Client),
+    ?line receive
+	     {tcp_closed, S} ->
+		 ok;
+	     Other ->
+		 ?t:fail({unexpected1, Other})
+	  after 1000 ->
+	      ?t:fail({timeout, {server, no_tcp_closed}})
+	  end,
+
+    %% Now test with option switched on.
+    %% Note: We are also testing that the show_econnreset option is
+    %% inherited from the listening socket by the accepting socket.
+    ?line {ok, L1} = gen_tcp:listen(0, [{show_econnreset, true}]),
+    ?line {ok, Port1} = inet:port(L1),
+    ?line {ok, Client1} = gen_tcp:connect(localhost, Port1, [{active, false}]),
+    ?line {ok, S1} = gen_tcp:accept(L1),
+    ?line ok = gen_tcp:close(L1),
+    ?line ok = inet:setopts(Client1, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(Client1),
+    ?line receive
+	      {tcp_error, S1, econnreset} ->
+		  ?line receive
+			    {tcp_closed, S1} ->
+				ok;
+			    Other1 ->
+				?t:fail({unexpected2, Other1})
+			after 1 ->
+			    ?t:fail({timeout, {server, no_tcp_closed}})
+			end;
+	      Other2 ->
+		  ?t:fail({unexpected3, Other2})
+	  after 1000 ->
+	      ?t:fail({timeout, {server, no_tcp_error}})
+	  end.
+
+show_econnreset_active_once(Config) when is_list(Config) ->
+    %% Now test using {active, once}
+    ?line {ok, L} = gen_tcp:listen(0,
+				   [{active, false},
+				    {show_econnreset, true}]),
+    ?line {ok, Port} = inet:port(L),
+    ?line {ok, Client} = gen_tcp:connect(localhost, Port, [{active, false}]),
+    ?line {ok, S} = gen_tcp:accept(L),
+    ?line ok = gen_tcp:close(L),
+    ?line ok = inet:setopts(Client, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(Client),
+    ?line ok = ?t:sleep(20),
+    ?line ok = receive Msg -> {unexpected_msg, Msg} after 0 -> ok end,
+    ?line ok = inet:setopts(S, [{active, once}]),
+    ?line receive
+	      {tcp_error, S, econnreset} ->
+		  ?line receive
+			    {tcp_closed, S} ->
+				ok;
+			    Other1 ->
+				?t:fail({unexpected1, Other1})
+			after 1 ->
+			    ?t:fail({timeout, {server, no_tcp_closed}})
+			end;
+	      Other2 ->
+		  ?t:fail({unexpected2, Other2})
+	  after 1000 ->
+	      ?t:fail({timeout, {server, no_tcp_error}})
+	  end.
+
+show_econnreset_passive(Config) when is_list(Config) ->
+    %% First confirm everything works with option turned off.
+    ?line {ok, L} = gen_tcp:listen(0, [{active, false}]),
+    ?line {ok, Port} = inet:port(L),
+    ?line {ok, Client} = gen_tcp:connect(localhost, Port, [{active, false}]),
+    ?line {ok, S} = gen_tcp:accept(L),
+    ?line ok = gen_tcp:close(L),
+    ?line ok = inet:setopts(S, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(S),
+    ?line ok = ?t:sleep(1),
+    ?line {error, closed} = gen_tcp:recv(Client, 0),
+
+    %% Now test with option switched on.
+    ?line {ok, L1} = gen_tcp:listen(0, [{active, false}]),
+    ?line {ok, Port1} = inet:port(L1),
+    ?line {ok, Client1} = gen_tcp:connect(localhost, Port1,
+					 [{active, false},
+					  {show_econnreset, true}]),
+    ?line {ok, S1} = gen_tcp:accept(L1),
+    ?line ok = gen_tcp:close(L1),
+    ?line ok = inet:setopts(S1, [{linger, {true, 0}}]),
+    ?line ok = gen_tcp:close(S1),
+    ?line ok = ?t:sleep(1),
+    ?line {error, econnreset} = gen_tcp:recv(Client1, 0).
 
 
 %% Thanks to Luke Gorrie. Tests for a very specific problem with 


### PR DESCRIPTION
This is based on the add_show_econnreset_socket_option branch pushed earlier.

EEP Light for applying 'show_econnreset' option to send errors also
===================================================================

Why do we need this new feature?
--------------------------------

When someone sets the 'show_econnreset' option on their socket, they
obviously want to be informed when an RST arrives. However, due to
the way send calls are handled asynchronously by inet_drv.c when
the driver queue is not empty, a user can get an {error, closed}
returned from gen_tcp:recv/2 even when an RST has arrived. I
described the problem on the erlang-questions mailing list as 
follows [1]:

If you have a large payload buffered in the socket driver in Erlang 
(i.e. a payload that is too large for the kernel socket send buffer) 
and you receive an RST, then your next call to gen_tcp:recv/2 will
return {error, closed} rather than {error, econnreset}. See below for
example code which shows this. The reason this happens is as follows:

 1. When there is outbound data buffered in the socket driver queue, 
    gen_tcp:send/2 becomes an asynchronous call. Which is to say, the 
    new data is added to the driver queue and the call returns 'ok'. 
    Then the actual send syscall takes place at a later time, according
    to epoll, select or whatever.

 2. Then, when you are in passive mode and an error is detected on the
    send syscall there is no caller to return it to, so it is marked as
    a "delayed close error". This has two consequences: 

      (a) it is masked to a generic {error, closed}; and
      (b) it is returned on the next call to gen_tcp:recv/2 or
          gen_tcp:send/2.

So, the send error is ultimately returned on a gen_tcp:recv/2 call, and
all send errors are masked as {error, closed}.


How did you solve it?
---------------------

There are two options for fixing this problem:

 1. Add a new 'show_send_errors' socket option that unmasks all send
    errors.

 2. Just unmask ECONNRESET errors (or related errors) and show these
    when the 'show_econnreset' option is set.

I chose the second option in this patch. In some ways this is good and
and in other ways it's not so good. The main disadvantage is that when
an RST has been received and you then make a send() syscall (or similar)
you usually get an EPIPE error (or ECONNABORTED on Windows) rather than
ECONNRESET. My patch therefore ends up translating these errors into
ECONNRESET errors. However, the advantage of doing this is that it
simplifies things for the user: they just need to worry about getting
{error, econnreset} returned from gen_tcp:recv/2 when an RST arrives;
and it also removes the need for the user to be aware of the specific
errors returned on each platform, which vary between Windows, Linux
and the other UNIXs.


Risks or uncertain artifacts?
-----------------------------

As mentioned above, an alternative solution would be to add a
'show_send_errors' socket option which unmasks all send errors.
It would require an additional int to be allocated in the
tcp_descriptor to hold the delayed error. It would also require
the user to handle send errors like {error, epipe} returned
from gen_tcp:recv/2 which wouldn't usually generate such errors.
The send errors received when an RST has arrived are different
on different platforms, and the user would need to be aware of
this and handle the right errors properly for each platform
they wish to support. Please advise if your preference would
be for this feature rather than what I have submitted.


References:
-----------
[1] http://erlang.org/pipermail/erlang-questions/2015-May/084433.html
