### PR TITLE
Annotate used types in erl_lint

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2845,10 +2845,9 @@ check_record_types([{type, _, field_type, [{atom, AL, FName}, Type]}|Left],
 check_record_types([], _Name, _DefFields, SeenVars, St, _SeenFields) ->
     {SeenVars, St}.
 
-used_type(TypePair, L, St) ->
-    Usage = St#lint.usage,
+used_type(TypePair, L, #lint{usage = Usage, file = File} = St) ->
     OldUsed = Usage#usage.used_types,
-    UsedTypes = dict:store(TypePair, L, OldUsed),
+    UsedTypes = dict:store(TypePair, erl_anno:set_file(File, L), OldUsed),
     St#lint{usage=Usage#usage{used_types=UsedTypes}}.
 
 is_default_type({Name, NumberOfTypeVariables}) ->


### PR DESCRIPTION
This is a follow up to commit b5ee5c6.

Similar to function calls, we also need to annotate used types
on call site since this information is used later on when showing
undefined type errors.

Notice we don't need to annotate the type export because
it is an attribute and those are always properly annotated.