### PR TITLE
Speed up supervisor:count_children/1 for simple_one_for_one

### DIFF
--- a/lib/stdlib/doc/src/supervisor.xml
+++ b/lib/stdlib/doc/src/supervisor.xml
@@ -543,7 +543,11 @@
           </item>
           <item>
             <p><c>active</c> - the count of all actively running child processes
-              managed by this supervisor.</p>
+              managed by this supervisor. In the case of <c>simple_one_for_one</c>
+              supervisors of <c>temporary</c> children, no check is carried out to
+              ensure that each child process is still alive, though the result provided
+              here is likely to be very accurate unless the supervisor is heavily
+              overloaded.</p>
           </item>
           <item>
             <p><c>supervisors</c> - the count of all children marked as

--- a/lib/stdlib/doc/src/supervisor.xml
+++ b/lib/stdlib/doc/src/supervisor.xml
@@ -544,10 +544,9 @@
           <item>
             <p><c>active</c> - the count of all actively running child processes
               managed by this supervisor. In the case of <c>simple_one_for_one</c>
-              supervisors of <c>temporary</c> children, no check is carried out to
-              ensure that each child process is still alive, though the result provided
-              here is likely to be very accurate unless the supervisor is heavily
-              overloaded.</p>
+              supervisors, no check is carried out to ensure that each child process
+              is still alive, though the result provided here is likely to be very
+              accurate unless the supervisor is heavily overloaded.</p>
           </item>
           <item>
             <p><c>supervisors</c> - the count of all children marked as

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -504,19 +504,12 @@ handle_call(which_children, _From, State) ->
 handle_call(count_children, _From, #state{children = [#child{restart_type = temporary,
 							     child_type = CT}]} = State)
   when ?is_simple(State) ->
-    {Active, Count} =
-	?SETS:fold(fun(Pid, {Alive, Tot}) ->
-			   case is_pid(Pid) andalso is_process_alive(Pid) of
-			       true ->{Alive+1, Tot +1};
-			       false ->
-				   {Alive, Tot + 1}
-			   end
-		   end, {0, 0}, dynamics_db(temporary, State#state.dynamics)),
+    Sz = ?SETS:size(dynamics_db(temporary, State#state.dynamics)),
     Reply = case CT of
-		supervisor -> [{specs, 1}, {active, Active},
-			       {supervisors, Count}, {workers, 0}];
-		worker -> [{specs, 1}, {active, Active},
-			   {supervisors, 0}, {workers, Count}]
+		supervisor -> [{specs, 1}, {active, Sz},
+			       {supervisors, Sz}, {workers, 0}];
+		worker -> [{specs, 1}, {active, Sz},
+			   {supervisors, 0}, {workers, Sz}]
 	    end,
     {reply, Reply, State};
 

--- a/lib/stdlib/test/supervisor_deadlock.erl
+++ b/lib/stdlib/test/supervisor_deadlock.erl
@@ -41,5 +41,11 @@ code_change(_OldVsn, State, _Extra) ->
 start_child() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [child], []).
 
+start_child_noreg() ->
+    gen_server:start_link(?MODULE, [child], []).
+
 restart_child() ->
     gen_server:cast(supervisor_deadlock, restart).
+
+restart_child(Pid) ->
+    gen_server:cast(Pid, restart).


### PR DESCRIPTION
There are two commits in this branch:

    01ceed3 Speed up supervisor:count_children/1; RT=temporary
    0b89543 Speed up supervisor:count_children/1; RT=non-temporary

Each patch reduces the time for a count_children/1 call for a 
simple_one_for_one supervisor. The reduction for a supervisor with
100,000 workers is from about 25-30ms down to around 0.005ms. This is achieved
by avoiding looping through the child pids and verifying that each one is alive.

The first patch is simple. Instead of looping through all the child pids in
the set and checking each one is alive, we just return the value of sets:size/1.

The second patch is more involved because the dict containing the child pids
might also have {restarting,pid()} entries to track attempts to restart the
child. Even if we were to omit the is_process_alive() call, it would still
take about 8.5ms to loop through 100,000 children (down from 30ms when we
do verify that they are alive). To avoid this looping altogether I am using
a separate variable to keep track of the number of pending restarts. At the
moment this variable is kept as a new entry in the supervisor's state{} but I
haven't written any code to handle code upgrades. An alternative would be to
stash the count in the process directory. Any thoughts?

Justification for these changes:

 1. Caller gets reply much faster.

 2. Supervisor does not block for an extended period while it makes its 
    count, potentially causing a cascade of problems.

 3. As long as the supervisor is not overloaded, the accuracy should be 
    better. The reasoning for this is as follows. If we are looping through
    the child processes and checking that each process is alive, then for
    any process that dies when we are counting, there is a 50% chance that
    it has already been counted and marked as alive. Therefore, the longer
    the count takes, the more inaccurate the result becomes.

The only time that you might get a more accurate result from looping though
the pids and checking that each is alive is when the supervisor is overloaded,
or blocking for a long time. If the caller's count_children request is in
the supervisors message queue for a long time, then it's possible that a
number of EXIT messages are appended after it. When the supervisor services
our request, these recent deaths are not counted in the results.
