### PR TITLE
mnesia: don't delete log file on emfile error

### DIFF
--- a/lib/mnesia/src/mnesia_log.erl
+++ b/lib/mnesia/src/mnesia_log.erl
@@ -349,6 +349,8 @@ open_log(Name, Header, Fname, Exists, Repair, Mode) ->
 	    mnesia_lib:important("Data may be missing, log ~p repaired: Lost ~p bytes~n",
 				 [Fname, BadBytes]),
 	    Log;
+	{error, Reason = {file_error, _Fname, emfile}} ->
+	    fatal("Cannot open log file ~p: ~p~n", [Fname, Reason]);
 	{error, Reason} when Repair == true ->
 	    file:delete(Fname),
 	    mnesia_lib:important("Data may be missing, Corrupt logfile deleted: ~p, ~p ~n",


### PR DESCRIPTION
If the VM runs into the process' file descriptor limit when mnesia
tries to open (not create) a disk_log file, the open fails with an
emfile error.  Mnesia misinterprets this as a corrupt file, deletes
it, tries to create a new empty disk_log file, which also fails.
The end result is a corrupt database on disk.

Check for emfile errors and error out immediately without deleting
the file in those cases.