### PR TITLE
Document badarg error for ets:lookup/2

### DIFF
--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -638,6 +638,8 @@ ets:is_compiled_ms(Broken).</code>
           key. If the table is of type <c>bag</c> or
           <c>duplicate_bag</c>, the function returns a list of
           arbitrary length.</p>
+        <p>If no table with the identifier <c><anno>Tab</anno></c> exists, the function
+          will exit with reason <c>badarg</c>.</p>
         <p>Note that the time order of object insertions is preserved;
           the first object inserted with the given key will be first
           in the resulting list, and so on.</p>


### PR DESCRIPTION
`ets:lookup/2` will exit with badarg in case the specified table was never created:
```erlang
1> ets:lookup(foo, bar).
** exception error: bad argument
     in function  ets:lookup/2
        called as ets:lookup(foo,bar)
2> 
```
Let's document this fact.