### PR TITLE
Add {line_delimiter, Char} option to file:open/2

### DIFF
--- a/erts/preloaded/src/prim_file.erl
+++ b/erts/preloaded/src/prim_file.erl
@@ -138,6 +138,7 @@
 %% Options
 -define(FILE_OPT_DELAYED_WRITE, 0).
 -define(FILE_OPT_READ_AHEAD,    1).
+-define(FILE_OPT_DELIMITER,     2).
 
 %% IPREAD variants
 -define(IPREAD_S32BU_P32BU, 0).
@@ -1239,6 +1240,10 @@ open_mode([{read_ahead, Size}|Rest], Mode, Portopts, Setopts)
 	true ->
 	    einval
     end;
+open_mode([{line_delimiter, Char}|Rest], Mode, Portopts, Setopts)
+  when is_integer(Char), 0 =< Char, Char =< 255 ->
+    open_mode(Rest, Mode, Portopts,
+          [<<?FILE_SETOPT, ?FILE_OPT_DELIMITER, Char>> | Setopts]);
 open_mode([], Mode, Portopts, Setopts) ->
     {Mode, reverse(Portopts), reverse(Setopts)};
 open_mode(_, _Mode, _Portopts, _Setopts) ->

--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -767,6 +767,12 @@
               less than, or even greater than <c>Size</c> bytes, no
               performance gain can be expected.</p>
           </item>
+          <tag><c>{line_delimiter, Delimiter}</c></tag>
+          <item>
+            <p>When file is opened in the <c>raw</c> mode, <c>Delimiter</c> tells
+              <c>read_line/1</c> to use the <c>Delimiter</c> character for line
+              delimitation.  Default value for <c>Delimiter</c> is <c>$\n</c></p>
+          </item>
           <tag><c>read_ahead</c></tag>
           <item>
             <p>The same as <c>{read_ahead, Size}</c> with a reasonable

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -84,7 +84,7 @@
 
 -export([large_file/1, large_write/1]).
 
--export([read_line_1/1, read_line_2/1, read_line_3/1,read_line_4/1]).
+-export([read_line_1/1, read_line_2/1, read_line_3/1,read_line_4/1,read_line_5/1]).
 
 -export([advise/1]).
 
@@ -4239,6 +4239,35 @@ read_line_4(Config) when is_list(Config) ->
 	    end || {_,File,_,Y} <- All , Y =:= fail],
     ?line read_line_remove_files(All),
     ok.
+read_line_5(suite) ->
+    [];
+read_line_5(doc) ->
+    ["read_line with custom line delimiter"];
+read_line_5(Config) when is_list(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    File    = filename:join(PrivDir, "read_line_test_delim.txt"),
+    file:delete(File),
+    ok      = file:write_file(File, <<"abc",0,"efg",0,"kkk">>),
+    {ok,F1} = file:open(File, [binary,raw,{line_delimiter, 0}]),
+    {ok,<<"abc",0>>} = file:read_line(F1),
+    {ok,<<"efg",0>>} = file:read_line(F1),
+    {ok,<<"kkk">>}   = file:read_line(F1),
+    eof              = file:read_line(F1),
+    ok      = file:close(F1),
+    ok      = file:write_file(File, <<"abcXefgXkkk">>),
+    {ok,F2} = file:open(File, [binary,raw,{line_delimiter, $X}]),
+    {ok,<<"abcX">>}  = file:read_line(F2),
+    {ok,<<"efgX">>}  = file:read_line(F2),
+    {ok,<<"kkk">>}   = file:read_line(F2),
+    eof              = file:read_line(F2),
+    ok      = file:close(F2),
+    ok      = file:write_file(File, <<"abc\nefg\nkkk">>),
+    {ok,F3} = file:open(File, [binary,raw]),
+    {ok,<<"abc\n">>} = file:read_line(F3),
+    {ok,<<"efg\n">>} = file:read_line(F3),
+    {ok,<<"kkk">>}   = file:read_line(F3),
+    eof              = file:read_line(F3),
+    ok      = file:close(F3).
 
 rl_lines() ->
     [ <<"hej">>,<<"hopp">>,<<"i">>,<<"lingon\rskogen">>].


### PR DESCRIPTION
The new option `{line_delimiter, Delimiter}` affects how file:read_line/1
delimits lines.  When file is opened in the `raw` mode, `Delimiter` tells
`file:read_line/1` to use the `Delimiter` character for line
delimitation.  Default value for `Delimiter` is `$\n`.