### PR TITLE
Don't refresh observer table view if there was no change

### DIFF
--- a/lib/observer/src/observer_tv_wx.erl
+++ b/lib/observer/src/observer_tv_wx.erl
@@ -176,10 +176,16 @@ handle_call(Event, From, _State) ->
 handle_cast(Event, _State) ->
     error({unhandled_cast, Event}).
 
-handle_info(refresh_interval, State = #state{node=Node, grid=Grid, opt=Opt}) ->
-    Tables = get_tables(Node, Opt),
-    Tabs = update_grid(Grid, Opt, Tables),
-    {noreply, State#state{tabs=Tabs}};
+handle_info(refresh_interval, State = #state{node=Node, grid=Grid, opt=Opt,
+                                             tabs=OldTabs}) ->
+    case get_tables(Node, Opt) of
+        OldTabs ->
+            %% no change
+            {noreply, State};
+        Tables ->
+            Tabs = update_grid(Grid, Opt, Tables),
+            {noreply, State#state{tabs=Tabs}}
+    end;
 
 handle_info({active, Node}, State = #state{parent=Parent, grid=Grid, opt=Opt,
 					   timer=Timer0}) ->


### PR DESCRIPTION
Avoid refreshing the list of tables every refresh interval
(by default 10 secs) if the content did not change.
Because of the refresh the list was scrolled to the begining
and current selection was lost which could be quite anoying.