### PR TITLE
Add forgotten argument to example in erl_nif doc

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -1177,7 +1177,7 @@ typedef enum {
       <code type="none">
 ERL_NIF_TERM key, value;
 ErlNifMapIterator iter;
-enif_map_iterator_create(env, my_map, ERL_NIF_MAP_ITERATOR_FIRST);
+enif_map_iterator_create(env, my_map, &amp;iter, ERL_NIF_MAP_ITERATOR_FIRST);
 
 while (enif_map_iterator_get_pair(env, &amp;iter, &amp;key, &amp;value)) {
     do_something(key,value);


### PR DESCRIPTION
In the documentation for erl_nif, in the map iterator example,
the iterator argument was forgotten in the call to function
enif_map_iterator_create. This is now fixed.