### PR TITLE
Do not crash on unknown hash and signature algorithms

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1209,8 +1209,7 @@ hash_algorithm(?SHA) -> sha;
 hash_algorithm(?SHA224) -> sha224;
 hash_algorithm(?SHA256) -> sha256;
 hash_algorithm(?SHA384) -> sha384;
-hash_algorithm(?SHA512) -> sha512;
-hash_algorithm(_) -> null.
+hash_algorithm(?SHA512) -> sha512.
 
 sign_algorithm(anon)  -> ?ANON;
 sign_algorithm(rsa)   -> ?RSA;
@@ -1219,8 +1218,7 @@ sign_algorithm(ecdsa) -> ?ECDSA;
 sign_algorithm(?ANON) -> anon;
 sign_algorithm(?RSA) -> rsa;
 sign_algorithm(?DSA) -> dsa;
-sign_algorithm(?ECDSA) -> ecdsa;
-sign_algorithm(_) -> anon.
+sign_algorithm(?ECDSA) -> ecdsa.
 
 hash_size(null) ->
     0;

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1209,7 +1209,10 @@ hash_algorithm(?SHA) -> sha;
 hash_algorithm(?SHA224) -> sha224;
 hash_algorithm(?SHA256) -> sha256;
 hash_algorithm(?SHA384) -> sha384;
-hash_algorithm(?SHA512) -> sha512.
+hash_algorithm(?SHA512) -> sha512;
+hash_algorithm(Other)
+  when is_integer(Other) andalso ((Other >= 224) and (Other =< 255)) ->
+    Other.
 
 sign_algorithm(anon)  -> ?ANON;
 sign_algorithm(rsa)   -> ?RSA;
@@ -1218,7 +1221,10 @@ sign_algorithm(ecdsa) -> ?ECDSA;
 sign_algorithm(?ANON) -> anon;
 sign_algorithm(?RSA) -> rsa;
 sign_algorithm(?DSA) -> dsa;
-sign_algorithm(?ECDSA) -> ecdsa.
+sign_algorithm(?ECDSA) -> ecdsa;
+sign_algorithm(Other)
+  when is_integer(Other) andalso ((Other >= 224) and (Other =< 255)) ->
+    Other.
 
 hash_size(null) ->
     0;

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1209,7 +1209,8 @@ hash_algorithm(?SHA) -> sha;
 hash_algorithm(?SHA224) -> sha224;
 hash_algorithm(?SHA256) -> sha256;
 hash_algorithm(?SHA384) -> sha384;
-hash_algorithm(?SHA512) -> sha512.
+hash_algorithm(?SHA512) -> sha512;
+hash_algorithm(_) -> null.
 
 sign_algorithm(anon)  -> ?ANON;
 sign_algorithm(rsa)   -> ?RSA;
@@ -1218,7 +1219,8 @@ sign_algorithm(ecdsa) -> ?ECDSA;
 sign_algorithm(?ANON) -> anon;
 sign_algorithm(?RSA) -> rsa;
 sign_algorithm(?DSA) -> dsa;
-sign_algorithm(?ECDSA) -> ecdsa.
+sign_algorithm(?ECDSA) -> ecdsa;
+sign_algorithm(_) -> anon.
 
 hash_size(null) ->
     0;


### PR DESCRIPTION
**Do not merge as is.**

Hi @IngelaAndin,

Here is a workaround for a crash on SSL when trying to connect on a server for which Erlang does not yet know hash / signature algorithm.

The crash is:
```
** {function_clause,[{ssl_cipher,hash_algorithm,"ï",[{file,"ssl_cipher.erl"},{line,1174}]},{ssl_handshake,'-decode_handshake/3-blc$^0/1-0-',1,[{file,"ssl_handshake.erl"},{line,898}]},{ssl_handshake,'-decode_handshake/3-blc$^0/1-0-',1,[{file,"ssl_handshake.erl"},{line,899}]},{ssl_handshake,decode_handshake,3,[{file,"ssl_handshake.erl"},{line,898}]},{tls_handshake,get_tls_handshake_aux,3,[{file,"tls_handshake.erl"},{line,153}]},{tls_connection,next_state,4,[{file,"tls_connection.erl"},{line,454}]},{tls_connection,next_state,4,[{file,"tls_connection.erl"},{line,458}]},{gen_fsm,handle_msg,7,[{file,"gen_fsm.erl"},{line,505}]}]}
```

You can reproduce it by using any random .pem with the following command (against Apple Server, be careful):
```
ssl:start().
ssl:connect("gateway.sandbox.push.apple.com", 2195, [{certfile, "test_cert.pem"}, {active, true}, binary], 5000).
```

Our fix is certainly not the final one, as you probably have a better idea on how to integrate it to your test in Erlang code base. Instead of reporting unknown hash or signature as anon/none, it is better to report them as unknown and have them ignore at a later stage in the negotiation process.

Anyway, we thought this patch and test case could help you understand the issue.