### PR TITLE
Fix application:loaded_applications/0 failure

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -266,13 +266,9 @@ which_applications(Timeout) ->
     gen_server:call(?AC, which_applications, Timeout).
 
 loaded_applications() ->
-    ets:filter(ac_tab,
-	       fun([{{loaded, AppName}, #appl{descr = Descr, vsn = Vsn}}]) ->
-		       {true, {AppName, Descr, Vsn}};
-		  (_) ->
-		       false
-	       end,
-	       []).
+    Head = {{loaded, '$1'}, #appl{descr='$2', vsn='$3', _='_'}},
+    Body = [{{'$1', '$2', '$3'}}],
+    ets:select(ac_tab, [{Head, [], Body}]).
 
 %% Returns some debug info
 info() ->

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -667,7 +667,12 @@ tab2list(T) ->
 -spec filter(tab(), function(), [term()]) -> [term()].
 
 filter(Tn, F, A) when is_atom(Tn) ; is_integer(Tn) ->
-    do_filter(Tn, ets:first(Tn), F, A, []).
+    ets:safe_fixtable(Tn, true),
+    try
+	do_filter(Tn, ets:first(Tn), F, A, [])
+    after
+	ets:safe_fixtable(Tn, false)
+    end.
 
 do_filter(_Tab, '$end_of_table', _, _, Ack) -> 
     Ack;


### PR DESCRIPTION
Use of undocumented `ets:filter/3`, which does not use `ets:safe_fixtable/2`, can lead to `application:loaded_applications/0` raising if another process causes `application_controller` to write to the `ac_tab` table. `ets:filter/3` is not documented but I did not remove it as a search of github suggests it has at least couple of users. 

* `ets:filter/3` is replaced by `ets:select/2` in `application_controller`.
* `ets:filter/3` is fixed to use `ets:safe_fixtable/2`.