### PR TITLE
Fix supervisor reporting error

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1079,7 +1079,7 @@ wait_dynamic_children(#child{restart_type=RType} = Child, Pids, Sz,
 
         {timeout, TRef, kill} ->
             ?SETS:fold(fun(P, _) -> exit(P, kill) end, ok, Pids),
-            wait_dynamic_children(Child, Pids, Sz-1, undefined, EStack)
+            wait_dynamic_children(Child, Pids, Sz, undefined, EStack)
     end.
 
 %%-----------------------------------------------------------------


### PR DESCRIPTION
The commit message reads:

    When a simple_one_for_one supervisor is shutting down, if one or more
    of its children fail to terminate within the 'shutdown' timeout, then
    the following reporting error will occur:
    
     * If there is only one child that fails to exit on time, then no
       supervisor report will be generated.
    
     * If more than one child fails to exit on time, then the reporting
       of 'nb_children' in the supervisor report will be 1 less than it
       should be.

There is no test case to accompany this bug as the fix is trivial and
the problem doesn't lend itself to automated testing. I have posted some
example code here:

    git clone https://gist.github.com/0de4e083dd3e4cbbee8f.git

You call it with the number of failed children you want, for example:

    example:run(5).             % reports nb_children as 4

    example:run(1).             % shows no supervisor report at all

Thanks.
