### PR TITLE
Fix markup in dbg.xml

### DIFF
--- a/lib/runtime_tools/doc/src/dbg.xml
+++ b/lib/runtime_tools/doc/src/dbg.xml
@@ -167,7 +167,8 @@ Error: fun containing local erlang function calls ('is_atomm' called in guard)\
           <item>If the <c>Item</c> is a <c>pid()</c>, the corresponding
            process is traced.  The process may be a remote process
            (on another Erlang node). The node must be in the list of
-           traced nodes (<seealso marker="#n">see</seealso><c>n/1</c> and <c>tracer/0/2/3</c>).</item>
+           traced nodes (see <seealso marker="#n"><c>n/1</c></seealso> and
+           <c>tracer/0/2/3</c>).</item>
           <item>If the <c>Item</c> is the atom <c>all</c>, all processes in the
            system as well as all processes created hereafter are
            to be traced. This also affects all nodes added with the
@@ -648,7 +649,7 @@ Error: fun containing local erlang function calls ('is_atomm' called in guard)\
         <p>If <c>Nodename</c> is the local node, the error reason
           <c>cant_add_local_node</c> is returned.
           </p>
-        <p>If a trace port (<seealso marker="#trace_port">see</seealso><c>trace_port/2</c>) is
+        <p>If a trace port (see <seealso marker="#trace_port"><c>trace_port/2</c></seealso>) is
           running on the local node, remote nodes can not be traced with
           a tracer process. The error reason
           <c>cant_trace_remote_pid_to_local_port</c> is returned. A


### PR DESCRIPTION
Put the name of the functions linked to inside the seealso tag, not the word "see".