### PR TITLE
Eliminate dialyzer warnings for unmatched_returns

### DIFF
--- a/lib/eldap/src/eldap.erl
+++ b/lib/eldap/src/eldap.erl
@@ -242,7 +242,7 @@ modify_dn(Handle, Entry, NewRDN, DelOldRDN, NewSup)
 
 %%% Sanity checks !
 
-bool_p(Bool) when Bool==true;Bool==false -> Bool.
+bool_p(Bool) when is_boolean(Bool) -> Bool.
 
 optional([])    -> asn1_NOVALUE;
 optional(Value) -> Value.
@@ -1022,10 +1022,13 @@ log(_, _, _, _) ->
 %%% Misc. routines
 %%% --------------------------------------------------------------------
 
-send(To,Msg) -> To ! {self(),Msg}.
+send(To,Msg) ->
+    To ! {self(), Msg},
+    ok.
+
 recv(From)   ->
     receive
-	{From,Msg} -> Msg;
+	{From, Msg} -> Msg;
 	{'EXIT', From, Reason} ->
 	    {error, {internal_error, Reason}}
     end.


### PR DESCRIPTION
While at it, do a minor cleanup using is_boolean/1