### PR TITLE
Grouped AVP packing bug-fix

### DIFF
--- a/lib/diameter/src/base/diameter_codec.erl
+++ b/lib/diameter/src/base/diameter_codec.erl
@@ -663,6 +663,8 @@ pack_avp([#diameter_avp{} = A | Avps]) ->
     pack_avp(A#diameter_avp{data = Avps});
 pack_avp(#diameter_avp{data = [#diameter_avp{} | _] = Avps} = A) ->
     pack_avp(A#diameter_avp{data = encode_avps(Avps)});
+pack_avp(#diameter_avp{data = [[#diameter_avp{} | _] | _] = Avps} = A) ->
+        pack_avp(A#diameter_avp{data = encode_avps(Avps)});
 
 %% ... data as a type/value tuple ...
 pack_avp(#diameter_avp{data = {Type, Value}} = A)


### PR DESCRIPTION
When working in relay/proxy mode and the Diameter request contains grouped AVP which contains another grouped AVP the Diameter application fails to encode the message (previously decoded request) before sending it to the relayed peer.

```
(<0.178.0>) call diameter_traffic:incr_error(send,{badarg,[{erlang,iolist_to_binary,1,[]},
         {diameter_codec,pack_avp,1,
                         [{file,"base/diameter_codec.erl"},{line,711}]},
         {lists,map,2,[{file,"lists.erl"},{line,1237}]},
         {lists,map,2,[{file,"lists.erl"},{line,1237}]},
         {diameter_codec,encode_avps,1,
                         [{file,"base/diameter_codec.erl"},{line,280}]},
         {diameter_codec,e,2,[{file,"base/diameter_codec.erl"},{line,139}]},
         {diameter_codec,encode,2,
                         [{file,"base/diameter_codec.erl"},{line,117}]},
         {diameter_traffic,encode,3,
                           [{file,"base/diameter_traffic.erl"},{line,1690}]}],
        {diameter_header,1,940,272,4,210792137,554498001,true,true,false,
                         false}},<0.156.0>,diameter_gen_3gpp_ro)
```