### PR TITLE
Snmp agent vacmViewTreeFamily with non 'null' mask bugfix

### DIFF
--- a/lib/snmp/src/agent/snmp_view_based_acm_mib.erl
+++ b/lib/snmp/src/agent/snmp_view_based_acm_mib.erl
@@ -33,6 +33,8 @@
 
 %% Internal exports
 -export([check_vacm/1]).
+%%
+-export([emask2imask/1]).
 
 
 -include("snmp_types.hrl").

--- a/lib/snmp/src/agent/snmpa_acm.erl
+++ b/lib/snmp/src/agent/snmpa_acm.erl
@@ -279,7 +279,7 @@ validate_mib_view(Oid, MibView) ->
     end.
 
 get_largest_family([{SubTree, Mask, Type} | T], Oid, Res) ->
-    case check_mask(Oid, SubTree, Mask) of
+    case check_mask(Oid, SubTree, snmp_view_based_acm_mib:emask2imask(Mask)) of
 	true -> get_largest_family(T, Oid, add_res(length(SubTree), SubTree,
 						   Type, Res));
 	false -> get_largest_family(T, Oid, Res)
@@ -344,7 +344,7 @@ validate_all_mib_view([], _MibView) ->
 %% intelligent.
 %%-----------------------------------------------------------------
 is_definitely_not_in_mib_view(Oid, [{SubTree, Mask,?view_included}|T]) ->
-    case check_maybe_mask(Oid, SubTree, Mask) of
+    case check_maybe_mask(Oid, SubTree, snmp_view_based_acm_mib:emask2imask(Mask)) of
 	true -> false;
 	false -> is_definitely_not_in_mib_view(Oid, T)
     end;

--- a/lib/snmp/src/agent/snmpa_mib_data_tttn.erl
+++ b/lib/snmp/src/agent/snmpa_mib_data_tttn.erl
@@ -816,7 +816,7 @@ next_node(D, {tree, Tree, {table_entry, _MibName}},
 	"~n   RevOidSoFar: ~p"
 	"~n   MibView:     ~p", [size(Tree), Oid, RevOidSoFar, MibView]),
     OidSoFar = lists:reverse(RevOidSoFar),
-    case snmpa_acm:is_definitely_not_in_mib_view(OidSoFar, MibView) of
+    case snmpa_acm:is_definitely_not_in_mib_view(OidSoFar ++ Oid, MibView) of
 	true -> 
 	    ?vdebug("next_node(tree,table_entry) -> not in mib view",[]),
 	    false;

--- a/lib/snmp/src/misc/snmp_conf.erl
+++ b/lib/snmp/src/misc/snmp_conf.erl
@@ -1004,6 +1004,8 @@ check_imask(IMask) when is_list(IMask) ->
     do_check_imask(IMask), 
     {ok, IMask}.
 
+do_check_imask([]) ->
+    ok;
 do_check_imask([0|IMask]) ->
     do_check_imask(IMask);
 do_check_imask([1|IMask]) ->


### PR DESCRIPTION
It fixes
http://erlang.org/pipermail/erlang-bugs/2015-April/004891.html
And includes
http://erlang.org/pipermail/erlang-patches/2015-April/004766.html