### PR TITLE
Fix cover output file

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -2437,7 +2437,7 @@ do_analyse_to_file1(Module, OutFile, ErlFile, HTML) ->
                                 "\n\n"]),
 
 		    Pattern = {#bump{module=Module,line='$1',_='_'},'$2'},
-		    MS = [{Pattern,[],[{{'$1','$2'}}]}],
+		    MS = [{Pattern,[{is_integer,'$1'},{'>','$1',0}],[{{'$1','$2'}}]}],
 		    CovLines = lists:keysort(1,ets:select(?COLLECTION_TABLE, MS)),
 		    print_lines(Module, CovLines, InFd, OutFd, 1, HTML),
 		    


### PR DESCRIPTION
This is introduced by ab435488a.

If a module includes lines which are less than 1, for example a module
which includes `eunit.hrl`, its cover output file misses the coverage lines.