### PR TITLE
Fix function reference (no first/2 in ets)

### DIFF
--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -610,7 +610,7 @@ ets:is_compiled_ms(Broken).</code>
         <p>Returns the last key <c><anno>Key</anno></c> according to Erlang term
           order in the table <c>Tab</c> of the <c>ordered_set</c> type.
           If the table is of any other type, the function is synonymous
-          to <c>first/2</c>. If the table is empty,
+          to <c>first/1</c>. If the table is empty,
           <c>'$end_of_table'</c> is returned.</p>
         <p>Use <c>prev/2</c> to find preceding keys in the table.</p>
       </desc>


### PR DESCRIPTION
Minor typo in online docs. Tested in release 18:

58> TabId2 = ets:new(newtable, [named_table]).
60> ets:first(newtable).
'$end_of_table'
61> ets:first(newtable,2).
** exception error: undefined function ets:first/2
