### PR TITLE
Set xml namespace to http://www.w3.org/XML/1998/namespace.

### DIFF
--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -2324,8 +2324,13 @@ expanded_name(_Name, {Prefix, Local}, #xmlNamespace{nodes = Ns}, S) ->
 	    {URI, list_to_atom(Local)};
 	false ->
 	    %% A namespace constraint of XML Names is that the prefix
-	    %% must be declared
-	    ?fatal({namespace_prefix_not_declared, Prefix}, S)
+      %% must be declared, except 'xml', which is always defined
+      %% as http://www.w3.org/XML/1998/namespace
+      case Prefix of 
+        "xml" -> {'http://www.w3.org/XML/1998/namespace',
+                  list_to_atom(Local)};
+        _ -> ?fatal({namespace_prefix_not_declared, Prefix}, S)
+      end
     end.
 
 


### PR DESCRIPTION
Statically set the xml namespace to http://www.w3.org/XML/1998/namespace, as
stated in 'Namespaces in XML 1.1 (Second Edition)' [1]:
"The prefix xml is by definition bound to the namespace name http://www.w3.org/XML/1998/namespace.
It MAY, but need not, be declared, and MUST NOT be undeclared or bound to any other namespace name.
Other prefixes MUST NOT be bound to this namespace name, and it MUST NOT be declared as the
default namespace. "

[1] http://www.w3.org/TR/xml-names11/