### PR TITLE
inets: fix suppport of HTTP headers with obs-fold

### DIFF
--- a/lib/inets/src/http_lib/http_response.erl
+++ b/lib/inets/src/http_lib/http_response.erl
@@ -31,16 +31,11 @@
 %%   Value - string()	
 %%                                   
 %% Description: Creates a http_response_h-record used internally to
-%%              handle http-headers.
+%%              handle http-headers, assumes reversed list of headers
+%%              to unfold multiline headers with obs-folds
 %%-------------------------------------------------------------------------
-headers([], Headers) ->
-    Headers;
-
-headers([Header | Tail], Headers) ->  
-    {Key, [$: | Value]} =
-	lists:splitwith(fun($:) -> false; (_) -> true end, Header), 
-    headers(Tail, headers(http_util:to_lower(string:strip(Key)), 
-			  string:strip(Value), Headers)).
+headers(RevLines, Headers) ->
+    fill_headers(RevLines, [], Headers).
 
 %%-------------------------------------------------------------------------
 %% headers(#http_response_h{}) -> HeaderList
@@ -68,6 +63,23 @@ header_list(Headers) ->
 %%%========================================================================
 %%% Internal functions
 %%%========================================================================
+fill_headers([], _, Headers) ->
+    Headers;
+fill_headers([[Ch|HeaderFold]|Tail], Folded, Headers)
+  when Ch == $\t; Ch == $\s ->
+    fill_headers(Tail, [HeaderFold|Folded], Headers);
+fill_headers([Header | Tail], Folded, Headers) ->
+    Unfolded = unfold([Header|Folded]),
+    {Key, [$: | Value]} =
+	lists:splitwith(fun($:) -> false; (_) -> true end, Unfolded),
+    fill_headers(Tail, [], headers(http_util:to_lower(string:strip(Key)),
+				   string:strip(Value), Headers)).
+
+unfold([L]) ->
+    L;
+unfold(Folded) ->
+    string:join(Folded, " ").
+
 headers("cache-control", Value, Headers) ->
     Headers#http_response_h{'cache-control'= Value};
 headers("connection", Value, Headers) ->

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -105,6 +105,7 @@ only_simulated() ->
      internal_server_error,
      invalid_http,
      headers_dummy,
+     headers_with_obs_fold,
      empty_response_header,
      remote_socket_close,
      remote_socket_close_async,
@@ -890,6 +891,13 @@ headers_dummy(Config) when is_list(Config) ->
 		      ], "text/plain", FooBar},
 		     [], []).
 
+
+%%-------------------------------------------------------------------------
+
+headers_with_obs_fold(Config) when is_list(Config) ->
+    Request = {url(group_name(Config), "/obs_folded_headers.html", Config), []},
+    {ok, {{_,200,_}, Headers, [_|_]}} = httpc:request(get, Request, [], []),
+    "a b c" = proplists:get_value("folded", Headers).
 
 %%-------------------------------------------------------------------------
 
@@ -1712,6 +1720,14 @@ handle_uri(_,"/dummy_headers.html",_,_,Socket,_) ->
     send(Socket, http_chunk:encode("<HTML><BODY>fo")),
     send(Socket, http_chunk:encode("obar</BODY></HTML>")),
     http_chunk:encode_last();
+
+handle_uri(_,"/obs_folded_headers.html",_,_,_,_) ->
+    "HTTP/1.1 200 ok\r\n"
+    "Content-Length:5\r\n"
+    "Folded: a\r\n"
+    " b\r\n"
+    "\tc\r\n\r\n"
+    "Hello";
 
 handle_uri(_,"/capital_transfer_encoding.html",_,_,Socket,_) ->
     Head =  "HTTP/1.1 200 ok\r\n" ++


### PR DESCRIPTION
httpc should not fail when response contains (now deprecated)
multiline HTTP headers constructed with obs-folds. And as
RFC7230 specifies user agent should replace obs-folds with
spaces.