### PR TITLE
inets: Forward connection errors with https proxy

### DIFF
--- a/lib/inets/test/httpc_proxy_SUITE.erl
+++ b/lib/inets/test/httpc_proxy_SUITE.erl
@@ -58,7 +58,7 @@ groups() ->
       [http_emulate_lower_versions
        |local_proxy_cases()]},
      {local_proxy_https,[],
-      local_proxy_cases()}].
+      local_proxy_cases() ++ local_proxy_https_cases()}].
 
 %% internal functions
 
@@ -76,6 +76,9 @@ local_proxy_cases() ->
      http_doesnotexist,
      http_stream,
      http_not_modified_otp_6821].
+
+local_proxy_https_cases() ->
+    [https_connect_error].
 
 %%--------------------------------------------------------------------
 
@@ -430,6 +433,21 @@ header_value(Name, [{HeaderName,HeaderValue}|Headers]) ->
 	_ ->
 	    header_value(Name, Headers)
     end.
+
+%%--------------------------------------------------------------------
+https_connect_error(doc) ->
+    ["Error from CONNECT tunnel should be returned"];
+https_connect_error(Config) when is_list(Config) ->
+    {HttpServer,HttpPort} = ?config(http, Config),
+    Method = get,
+    %% using HTTPS scheme with HTTP port to trigger connection error
+    URL = "https://" ++ HttpServer ++ ":" ++
+        integer_to_list(HttpPort) ++ "/index.html",
+    Opts = [],
+    HttpOpts = [],
+    Request = {URL,[]},
+    {error,{failed_connect,[_,{tls,_,_}]}} =
+	httpc:request(Method, Request, HttpOpts, Opts).
 
 %%--------------------------------------------------------------------
 %% Internal Functions ------------------------------------------------

--- a/lib/inets/test/httpc_proxy_SUITE_data/server_proxy.sh
+++ b/lib/inets/test/httpc_proxy_SUITE_data/server_proxy.sh
@@ -169,6 +169,8 @@ MaxRequestsPerChild 0
 ViaProxyName "tinyproxy"
 
 ConnectPort $APACHE_HTTPS_PORT
+# to test connect error
+ConnectPort $APACHE_HTTP_PORT
 EOF
 	(tinyproxy -d -c tinyproxy.conf 1>/dev/null 2>&1 </dev/null &)&
 	wait_for_pidfile tinyproxy.pid


### PR DESCRIPTION
httpc should return meaningful error reason disregarding whether
it is being used with http proxy or not