### PR TITLE
ssl: Do not crash on proprietary hash_sign algorithms

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1209,7 +1209,8 @@ hash_algorithm(?SHA) -> sha;
 hash_algorithm(?SHA224) -> sha224;
 hash_algorithm(?SHA256) -> sha256;
 hash_algorithm(?SHA384) -> sha384;
-hash_algorithm(?SHA512) -> sha512.
+hash_algorithm(?SHA512) -> sha512;
+hash_algorithm(Other)  when is_integer(Other) andalso ((Other >= 224) and (Other =< 255)) -> Other.
 
 sign_algorithm(anon)  -> ?ANON;
 sign_algorithm(rsa)   -> ?RSA;
@@ -1218,7 +1219,8 @@ sign_algorithm(ecdsa) -> ?ECDSA;
 sign_algorithm(?ANON) -> anon;
 sign_algorithm(?RSA) -> rsa;
 sign_algorithm(?DSA) -> dsa;
-sign_algorithm(?ECDSA) -> ecdsa.
+sign_algorithm(?ECDSA) -> ecdsa;
+sign_algorithm(Other) when is_integer(Other) andalso ((Other >= 224) and (Other =< 255)) -> Other.
 
 hash_size(null) ->
     0;


### PR DESCRIPTION
TLS hash_sign algorithms may have proprietary values see
http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml

We should add callbacks to let applications handle them.
But for now we do not want to crash if they are present and
let other algorithms be negotiated.