### PR TITLE
erts: fix binary_to_integer boundary case

### DIFF
--- a/erts/emulator/beam/big.c
+++ b/erts/emulator/beam/big.c
@@ -2618,6 +2618,9 @@ Eterm erts_chars_to_integer(Process *BIF_P, char *bytes,
 	size--;
     }
 
+    if (size == 0)
+	goto bytebuf_to_integer_1_error;
+
     if (size < SMALL_DIGITS && base <= 10) {
 	/* *
 	 * Take shortcut if we know that all chars are '0' < b < '9' and

--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -429,7 +429,7 @@ t_string_to_integer(Config) when is_list(Config) ->
 				       list_to_binary(Value))),
 			  {'EXIT', {badarg, _}} = 
 			      (catch erlang:list_to_integer(Value))
-		  end,["1.0"," 1"," -1",""]),
+		  end,["1.0"," 1"," -1","","+"]),
     
     % Custom base error cases
     lists:foreach(fun({Value,Base}) ->


### PR DESCRIPTION
erlang:binary_to_integer/1 and /2 fail to detect invalid
input consisting of a single + or - sign but nothing else.
For an input like <<"+">> they return 0, while list_to_integer/1
correctly signals a badarg for "+".

Fixed by checking if the input is empty after the initial +/-
sign processing.

Added a test case which fails without this fix but passes with it.

Thanks to "niku" for reporting the issue.