### PR TITLE
Fix typo

### DIFF
--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -169,7 +169,7 @@ BEAM_FORMAT_NUMBER=0
 26: wait_timeout/2
 
 #
-# Arithmethic opcodes.
+# Arithmetic opcodes.
 #
 27: -m_plus/4
 28: -m_minus/4

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -45,7 +45,7 @@ BEAM_FORMAT_NUMBER=0
 ##      Save the next instruction as the return address in the CP register.
 4: call/2
 
-## @spec call_last Arity Label Dellocate
+## @spec call_last Arity Label Deallocate
 ## @doc Deallocate and do a tail recursive call to the function at Label.
 ##      Do not update the CP register.
 ##      Before the call deallocate Deallocate words of stack.

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -316,7 +316,7 @@ BEAM_FORMAT_NUMBER=0
 66: get_tuple_element/3
 
 ## @spec set_tuple_element NewElement Tuple Position
-## @doc  Update the element at postition Position of the tuple Tuple
+## @doc  Update the element at position Position of the tuple Tuple
 ##       with the new element NewElement.
 67: set_tuple_element/3
 

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -137,7 +137,7 @@ BEAM_FORMAT_NUMBER=0
 # Sending & receiving.
 #
 ## @spec send
-## @doc  Send argument in x(0) as a message to the destination process in x(0).
+## @doc  Send argument in x(1) as a message to the destination process in x(0).
 ##       The message in x(1) ends up as the result of the send in x(0).
 20: send/0
 

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -164,7 +164,7 @@ BEAM_FORMAT_NUMBER=0
 25: wait/1
 
 ## @spec wait_timeout Lable Time
-## @doc  Sets up a timeout of Time milllisecons and saves the address of the
+## @doc  Sets up a timeout of Time milliseconds and saves the address of the
 ##       following instruction as the entry point if the timeout triggers.
 26: wait_timeout/2
 


### PR DESCRIPTION
`milliseconds` instead of
`milllisecons`