### PR TITLE
Handle EAGAIN in fd_driver async functions

### DIFF
--- a/lib/kernel/test/standard_error_SUITE.erl
+++ b/lib/kernel/test/standard_error_SUITE.erl
@@ -21,13 +21,13 @@
 -module(standard_error_SUITE).
 
 -export([all/0,suite/0]).
--export([badarg/1,getopts/1]).
+-export([badarg/1,getopts/1,output/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
-    [badarg,getopts].
+    [badarg,getopts,output].
 
 badarg(Config) when is_list(Config) ->
     {'EXIT',{badarg,_}} = (catch io:put_chars(standard_error, [oops])),
@@ -37,3 +37,30 @@ badarg(Config) when is_list(Config) ->
 getopts(Config) when is_list(Config) ->
     [{encoding,latin1}] = io:getopts(standard_error),
     ok.
+
+%% Test that writing a lot of output to standard_error does not cause the
+%% processes handling it to terminate like this:
+%%
+%%    =ERROR REPORT==== 9-Aug-2015::23:19:23 ===
+%%    ** Generic server standard_error_sup terminating
+%%    ** Last message in was {'EXIT',<0.28.0>,eagain}
+%%    ** When Server state == {state,standard_error,undefined,<0.28.0>,
+%%                                   {local,standard_error_sup}}
+%%    ** Reason for termination ==
+%%    ** eagain
+%%
+%% This problem, observed with Erlang 18.0.2, was fixed in fd_driver by
+%% properly handling EAGAIN if it arises on file descriptor writes.
+%%
+output(Config) when is_list(Config) ->
+    Ref = monitor(process, standard_error_sup),
+    Chars = [ [["1234567890" || _ <- lists:seq(1,10)], $\s,
+               integer_to_list(L), $\r, $\n] || L <- lists:seq(1, 100) ],
+    ok = io:put_chars(standard_error, Chars),
+    receive
+        {'DOWN', Ref, process, _, _} ->
+            error(standard_error_noproc)
+    after
+        500 ->
+            ok
+    end.


### PR DESCRIPTION
Several users on erlang-questions have reported problems with recent
releases where output to standard_error causes standard_error_sup to
die from receiving an unexpected eagain error. In the fd_driver,
change the fd_async() function to handle EINTR, and change
fd_ready_async() to handle EAGAIN. Add a new test to
standard_error_SUITE to generate output to standard_error and ensure
that standard_error_sup does not die. Thanks to Kota Uenishi for
contributing the test case.