### PR TITLE
fix unused parameter warning in enif_make_pid

### DIFF
--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -543,7 +543,7 @@ static ERL_NIF_INLINE ERL_NIF_TERM enif_make_list9(ErlNifEnv* env,
 
 #ifndef enif_make_pid
 
-#  define enif_make_pid(ENV, PID) ((const ERL_NIF_TERM)((PID)->pid))
+#  define enif_make_pid(ENV, PID) ((void)(ENV),(const ERL_NIF_TERM)((PID)->pid))
 
 #if SIZEOF_LONG == 8
 #  define enif_get_int64 enif_get_long


### PR DESCRIPTION
When compiling a nif module with `-Wall` and `enif_make_pid` is contained in a function like this...

```
inline ERL_NIF_TERM foo(ErlNifEnv *env, const ErlNifPid *pid)
{
    return enif_make_pid(env, pid);
}
```
... the compile will produce this warning:
```
In file included from nifpptest.cpp:11:0:
../nifpp.h:394:13: warning: unused parameter ‘env’ [-Wunused-parameter]
```

This happens because `enif_make_pid` is implemented as a macro that does not use the `env` parameter.  This pull request adjusts the `enif_make_pid` macro to refer to the `env` param to make the warning go away.

This problem was observed while [cleaning up warnings on nifpp](https://github.com/goertzenator/nifpp/pull/5).



