### PR TITLE
Avoid erts_cmp jump in atom and int comparisons

### DIFF
--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -176,7 +176,7 @@ atom_alloc(Atom* tmpl)
 
     /*
      * Precompute ordinal value of first 3 bytes + 7 bits.
-     * This is used by utils.c:cmp_atoms().
+     * This is used by utils.c:erts_cmp_atoms().
      * We cannot use the full 32 bits of the first 4 bytes,
      * since we use the sign of the difference between two
      * ordinal values to represent their relative order.

--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -665,8 +665,8 @@ void** beam_ops;
 #define EqualImmed(X, Y, Action) if (X != Y) { Action; }
 #define NotEqualImmed(X, Y, Action) if (X == Y) { Action; }
 #define EqualExact(X, Y, Action) if (!EQ(X,Y)) { Action; }
-#define IsLessThan(X, Y, Action) if (CMP_GE(X, Y)) { Action; }
-#define IsGreaterEqual(X, Y, Action) if (CMP_LT(X, Y)) { Action; }
+#define IsLessThan(X, Y, Action) CMP_SPEC(X,Y,>=,Action)
+#define IsGreaterEqual(X, Y, Action) CMP_SPEC(X,Y,<,Action)
 
 #define IsFloat(Src, Fail) if (is_not_float(Src)) { Fail; }
 

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -479,14 +479,19 @@ i_is_lt_spec f r r
 i_is_lt_spec f c c
 %hot
 
-is_ge Lbl S1=xc S2=xc => i_is_ge_spec Lbl S1 S2
+is_ge Lbl S1=rxc S2=rxc => i_is_ge_spec Lbl S1 S2
 
 %macro: i_is_ge_spec IsGreaterEqual -fail_action
 
 i_is_ge_spec f x x
+i_is_ge_spec f x r
 i_is_ge_spec f x c
+i_is_ge_spec f r x
+i_is_ge_spec f r c
 i_is_ge_spec f c x
+i_is_ge_spec f c r
 %cold
+i_is_ge_spec f r r
 i_is_ge_spec f c c
 %hot
 


### PR DESCRIPTION
Given the two possible definitions for the same
function:

    check(X) when X >= 0, X <= 20 -> true.

and:

    check(0) -> true;
    check(1) -> true;
    ...
    check(20) -> true.

@nox has originally noticed that perfoming lt and ge
guard tests (the first) were drastically slower than
matching on values (the second).

Further investigation revealed that most of the cost
was in jumping to the erts_cmp function. This patch
brings the operations already inlined in erts_cmp
into the emulator, removing the jump cost.

Notice floats were not inlined, as they are not
constants and handled by erts_cmp_compound anyway.

This patch also specializes other "ge" operations,
bringing it on pair with the current "lt" ops codes.

After applying these changes, invoking the first
check/1 function defined above 30000 times with
different values from 0 to 20 has fallen from 560us
to 370us (measured as average of 3 runs).