### PR TITLE
Take out unused code that results in a gcc warning

### DIFF
--- a/erts/emulator/hipe/hipe_native_bif.c
+++ b/erts/emulator/hipe/hipe_native_bif.c
@@ -93,9 +93,6 @@ BIF_RETTYPE hipe_set_timeout(BIF_ALIST_1)
 {
     Process* p = BIF_P;
     Eterm timeout_value = BIF_ARG_1;
-#if !defined(ARCH_64)
-    Uint time_val;
-#endif
     /* XXX: This should be converted to follow BEAM conventions,
      * but that requires some compiler changes.
      *


### PR DESCRIPTION
These ifdef-ed lines were once upon a time needed, but the recent
changes in the time mechanism of OTP render them unused and result
in a warning on architectures which are not 64-bit.