### PR TITLE
Include file and line in bin_partition warning

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -3096,7 +3096,7 @@ bsm_ensure_no_partition_after([#c_clause{pats=Ps}|Cs], Pos) ->
 	#c_var{} ->
 	    bsm_ensure_no_partition_after(Cs, Pos);
 	P ->
-	    bsm_problem(P, bin_partition)
+	    bsm_problem(bsm_real_pattern(P), bin_partition)
     end;
 bsm_ensure_no_partition_after([], _) -> ok.
 


### PR DESCRIPTION
Take the code below:

    -module(sample).
    -compile(export_all).

    cast(<<Hour:2/bytes, $:, Min:2/bytes, Rest/binary>>) ->
      {Hour, Min, Rest};
    cast(#{time := _} = T) ->
      {ok, T};
    cast(#{hour := Hour, min := Min} = T) ->
      {Hour, Min, T}.

It will emit the following warning:

    no_file: Warning: INFO: matching non-variables after
    a previous clause matching a variable will prevent delayed
    sub binary optimization

This commit fixes the code above to emit proper file and
line information by retrieving the pattern refered by the
error message from the c_alias node.