### PR TITLE
travis-ci: basic continuous integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: erlang
+
+otp_release:
+  - 18.0
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - autoconf
+      - libncurses-dev
+      - build-essential
+      - libssl-dev
+      - libwxgtk2.8-dev
+      - libgl1-mesa-dev
+      - libglu1-mesa-dev
+      - libpng3
+      - default-jdk
+      - g++
+
+before_script:
+  - set -e
+  - export ERL_TOP=$PWD
+  - export PATH=$ERL_TOP/bin:$PATH
+  - export ERL_LIBS=''
+  - kerl_deactivate
+
+script:
+  - ./otp_build all -a
+
+after_success:
+  - ./otp_build tests


### PR DESCRIPTION
Build takes around 20 minutes to finish (this means 30 more minutes can be spent checking things).

This will build then run the test suite (on a Docker image of Ubuntu).

Right now tests a ran but their output is not checked for correctness.
I need some insight into how I could fix that.

Anyway, I think this is a step towards opening OTP development to the community.
And activating @erlang's Travis CI account is free!