### PR TITLE
kernel: inet_res case insensitivity

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -678,8 +678,8 @@ res_hostent_by_domain(Domain, Type, Rec) ->
 
 res_hostent_by_domain(Domain, Aliases, Type, RRs) ->
     LcRRs = [lower_rr(RR) || RR <- RRs],
-    LcDomain = string:to_lower(Domain),
-    LcAliases = [string:to_lower(Alias) || Alias <- Aliases],
+    LcDomain = tolower(Domain),
+    LcAliases = [tolower(Alias) || Alias <- Aliases],
     case res_hostent_by_lower_domain(LcDomain, LcAliases, Type, LcRRs) of
 	{ok, #hostent{} = HostEnt} ->
 	    {ok, HostEnt#hostent{h_name = Domain, h_aliases = Aliases}};
@@ -688,7 +688,7 @@ res_hostent_by_domain(Domain, Aliases, Type, RRs) ->
     end.
 
 lower_rr(#dns_rr{domain = Domain} = RR) ->
-    RR#dns_rr{domain = string:to_lower(Domain)}.
+    RR#dns_rr{domain = tolower(Domain)}.
 
 res_hostent_by_lower_domain(Domain, Aliases, Type, RRs) ->
     case res_lookup_type(Domain, Type, RRs) of
@@ -697,7 +697,7 @@ res_hostent_by_lower_domain(Domain, Aliases, Type, RRs) ->
 		[] ->  
 		    {error, nxdomain};
 		[CName | _] ->
-		    LCName = string:to_lower(CName),
+		    LCName = tolower(CName),
 		    case lists:member(LCName, [Domain | Aliases]) of
 			true -> 
 			    {error, nxdomain};

--- a/lib/kernel/test/inet_res_SUITE.erl
+++ b/lib/kernel/test/inet_res_SUITE.erl
@@ -273,7 +273,6 @@ proxy({server_case_scramble, N}, Outbound, NS, P, Inbound) when is_integer(N), N
 	    ScrambledQueries = [scramble_query_domain(Q) || Q <- Queries],
 	    ScrambledMsg = inet_dns:make_msg(Msg, qdlist, ScrambledQueries),
 	    ScrambledReq = inet_dns:encode(ScrambledMsg),
-	    ct:pal("Proxying packet: ~9999p", [inet_dns:decode(ScrambledReq)]),
 	    ok = gen_udp:send(Outbound, NS, P, ScrambledReq),
 	    {SrcIP, SrcPort}
     end,


### PR DESCRIPTION
Some caching DNS servers respond with records containing domain
names in case different from requested. This caused native resolver functions
such as `inet_res:gethostbyname/{1,2,3}` to return `{error, nxdomain}`
even when resolve actually succeeded.

How it looks in shell: https://www.evernote.com/shard/s21/sh/15a0e808-f28d-4166-92fc-9f0eac302fba/babc3f362ae16e067440b27cd137a45b

This PR fixes the problem and adds tests for it.