### PR TITLE
* Fix looking "ERL_EPMD_PORT" os environment for epmd client

### DIFF
--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -185,7 +185,12 @@ get_epmd_port() ->
 	{ok, [[PortStr|_]|_]} when is_list(PortStr) ->
 	    list_to_integer(PortStr);
 	error ->
-	    ?erlang_daemon_port
+	    case os:getenv("ERL_EPMD_PORT", not_found) of
+		not_found ->
+		    ?erlang_daemon_port;
+		PortStr ->
+		    list_to_integer(PortStr)
+	    end
     end.
 	    
 %%


### PR DESCRIPTION
ERL_EPMD_PORT
> This environment variable can contain the port number epmd will use. The default port will work fine in most cases. A different port can be specified to allow several instances of epmd, representing independent clusters of nodes, to co-exist on the same host. All nodes in a cluster must use the same epmd port number.