### PR TITLE
Pass 'raw' options through ssl:listen/1

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -1169,6 +1169,8 @@ assert_proplist([]) ->
 assert_proplist([{Key,_} | Rest]) when is_atom(Key) ->
     assert_proplist(Rest);
 %% Handle exceptions 
+assert_proplist([{raw,_,_,_} | Rest]) ->
+    assert_proplist(Rest);
 assert_proplist([inet | Rest]) ->
     assert_proplist(Rest);
 assert_proplist([inet6 | Rest]) ->


### PR DESCRIPTION
In Erlang R16B03-1, I've been passing raw options to `ssl:listen` as
follows, and it's been working fine:

    % The constants are defined elsewhere.
    LOpts = [{raw, ?IPPROTO_TCP, ?TCP_MAXSEG, <<MSS:32/native>>} | ...],
    {ok, LSocket} = ssl:listen(0, LOpts)

In Erlang 17.3, this fails with
`{option_not_a_key_value_tuple,{raw,6,2,<<64,2,0,0>>}}`

I originally reported this in
http://erlang.org/pipermail/erlang-questions/2014-October/081226.html

I need to pass *this particular* raw option to `ssl:listen`, because it needs to be applied when the socket is first opened -- between `inet:open` and `prim_inet:listen` -- it cannot be applied later by `setopts`. This means that it needs to be done by `inet_tcp:listen/2` -- well, actually by `inet:open/8`, but...

Otherwise it's racey -- a client could connect between `prim_inet:listen` and the `setopts` call. The MSS option is advertised in the `SYN,ACK` packet, and can't be changed later.