### PR TITLE
crypto: Support 192-bit keys and multiple blocks for AES ECB

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -2042,13 +2042,14 @@ static ERL_NIF_TERM aes_ecb_crypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
     ErlNifBinary key_bin, data_bin;
     AES_KEY aes_key;
     int i;
+    int j;
     unsigned char* ret_ptr;
     ERL_NIF_TERM ret;    
 
     CHECK_OSE_CRYPTO();
 
     if (!enif_inspect_iolist_as_binary(env, argv[0], &key_bin)
-    || (key_bin.size != 16 && key_bin.size != 32)
+    || (key_bin.size != 16 && key_bin.size != 24 && key_bin.size != 32)
     || !enif_inspect_iolist_as_binary(env, argv[1], &data_bin)
     || data_bin.size % 16 != 0) {
     return enif_make_badarg(env);
@@ -2064,7 +2065,9 @@ static ERL_NIF_TERM aes_ecb_crypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
     }
 
     ret_ptr = enif_make_new_binary(env, data_bin.size, &ret);
-    AES_ecb_encrypt(data_bin.data, ret_ptr, &aes_key, i);
+    for (j = 0; j <= data_bin.size; j += 16) {
+	AES_ecb_encrypt(data_bin.data+j, ret_ptr+j, &aes_key, i);
+    }
     CONSUME_REDS(env,data_bin);
     return ret;
 }

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -1301,7 +1301,31 @@ aes_ecb() ->
       <<"0000000000000000">>},
      {aes_ecb,
       <<"FEDCBA9876543210">>, 
-      <<"FFFFFFFFFFFFFFFF">>}
+      <<"FFFFFFFFFFFFFFFF">>},
+     %% AES ECB test vectors from http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf
+     %% F.1.1 ECB-AES128.Encrypt, F.1.2 ECB-AES128.Decrypt
+     {aes_ecb,
+      hexstr2bin("2b7e151628aed2a6abf7158809cf4f3c"),
+      hexstr2bin("6bc1bee22e409f96e93d7e117393172a"
+		 "ae2d8a571e03ac9c9eb76fac45af8e51"
+		 "30c81c46a35ce411e5fbc1191a0a52ef"
+		 "f69f2445df4f9b17ad2b417be66c3710")},
+     %% F.1.3 ECB-AES192.Encrypt, F.1.4 ECB-AES192.Decrypt
+     {aes_ecb,
+      hexstr2bin("8e73b0f7da0e6452c810f32b809079e5"
+		 "62f8ead2522c6b7b"),
+      hexstr2bin("6bc1bee22e409f96e93d7e117393172a"
+		 "ae2d8a571e03ac9c9eb76fac45af8e51"
+		 "30c81c46a35ce411e5fbc1191a0a52ef"
+		 "f69f2445df4f9b17ad2b417be66c3710")},
+     %% F.1.5 ECB-AES256.Encrypt, F.1.6 ECB-AES256.Decrypt
+     {aes_ecb,
+      hexstr2bin("603deb1015ca71be2b73aef0857d7781"
+		 "1f352c073b6108d72d9810a30914dff4"),
+      hexstr2bin("6bc1bee22e409f96e93d7e117393172a"
+		 "ae2d8a571e03ac9c9eb76fac45af8e51"
+		 "30c81c46a35ce411e5fbc1191a0a52ef"
+		 "f69f2445df4f9b17ad2b417be66c3710")}
     ].
 
 aes_ige256() ->


### PR DESCRIPTION
This pull request adds support for 192-bit keys for AES ECB and allows for more than one block to be encrypted/decrypted.  This brings the AES ECB multiple block behavior closer to the behavior defined in [NIST.800-38A](http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf) (see section 5.2).  In other words, it will actually encrypt and decrypt all of the plaintext instead of the first 128 bits alone.

*Note:* This is part of a series of pull requests where I'm hoping to add support for algorithms that were discovered to be absent from OTP while writing the [erlang-jose](https://github.com/potatosalad/erlang-jose/blob/master/ALGORITHMS.md) project.

An example of the changes in output are provided below:

#### 192-bit keys

This is pretty simple, they just weren't supported due to a key size restriction in [`lib/crypto/c_src/crypto.c`](https://github.com/potatosalad/otp/commit/207bbfccb270fe0b416a258d6eb182c0bc00d9c7#diff-7b5b13b9e0fa4a516b282276c41e5120L2051) to only 128 and 256 bit keys.

```erlang
%% OTP 18
crypto:block_encrypt(aes_ecb, << 0:192 >>, << 0:128 >>).

** exception error: bad argument
     in function  crypto:aes_ecb_crypt/3
        called as crypto:aes_ecb_crypt(<<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0>>,
                                       <<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0>>,
                                       true)

%% This PR
CT = crypto:block_encrypt(aes_ecb, << 0:192 >>, << 0:128 >>),
<< 0:128 >> = crypto:block_decrypt(aes_ecb, << 0:192 >>, CT).

<<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0>>
```

#### Multiple Blocks

Hopefully others agree with my changes, there may even be a security concern here:

```erlang
%% OTP 18
K = << 0:128 >>,  %% 128-bit key, but also works with 256-bit keys
PT = << 0:256 >>, %% Two 128-bit blocks of zeroes
CT = crypto:block_encrypt(aes_ecb, K, PT).

<<102,233,75,212,239,138,44,59,136,76,250,89,202,52,43,46,
  203,76,0,0,0,0,0,0,63,0,0,0,0,0,0,0>>

%%% Everything seems okay at this point, but there are two issues:
%%% 
%%% (1) Running encrypt again produces different output:
CT = crypto:block_encrypt(aes_ecb, K, PT).

** exception error: no match of right hand side value <<102,233,75,212,239,138,44,59,136,76,250,89,202,52,43,46,
                                                        193,130,3,4,1,0,0,0,0,0,0,0,0,...>>

%%%% The first 128 bits returned are the same, but the second 128 bit block is
%%%% just whatever memory enif_make_new_binary returned. Possible security issue?
%%% 
%%% (2) Running decrypt does not return original plain text:
PT = crypto:block_decrypt(aes_ecb, K, CT).

** exception error: no match of right hand side value <<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,15,3,0,0,0,0,0,0,186,
                                                        103,193,4,1,...>>

%%%% Decrypt suffers from the same issue as encrypt, the second 128 bit block is
%%%% just whatever memory enif_make_new_binary returned.
```

My changes just has crypto encrypt or decrypt each individual 128 bit block:

```erlang
%% This PR
K = << 0:128 >>,  %% 128-bit key, but also works with 192 and 256-bit keys
PT = << 0:256 >>, %% Two 128-bit blocks of zeroes
CT = crypto:block_encrypt(aes_ecb, K, PT).

<<102,233,75,212,239,138,44,59,136,76,250,89,202,52,43,46,
  102,233,75,212,239,138,44,59,136,76,250,89,202,52,43,46>>

%%% Notice that the each 128 bit block has been encrypted (since we're dealing
%%% with a 2 block zero binary, each block should be identical in ECB mode).
%%% 
%%% Decryption works as expected:
PT = crypto:block_decrypt(aes_ecb, K, CT).

<<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
  0,0,0,0>>
```

#### Tests

I added [3 of the test vectors](https://github.com/erlang/otp/pull/829/files#diff-55ee5570a80b8d50ea7577b2d185d2bfR1305) from the [NIST.800-38A](http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf) document. If anyone thinks we need additional tests here, we could potentially use some of the test vectors provided by the "Multi-block Message Text (MMT)" section of the [Cryptographic Algorithm Validation Program (CAVP)](http://csrc.nist.gov/groups/STM/cavp/).