### PR TITLE
crypto: Support 192-bit keys for AES CBC

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -2511,7 +2511,7 @@ static ERL_NIF_TERM aes_cbc_crypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
     CHECK_OSE_CRYPTO();
 
     if (!enif_inspect_iolist_as_binary(env, argv[0], &key_bin)
-	|| (key_bin.size != 16 && key_bin.size != 32)
+	|| (key_bin.size != 16 && key_bin.size != 24 && key_bin.size != 32)
 	|| !enif_inspect_binary(env, argv[1], &ivec_bin)
 	|| ivec_bin.size != 16
 	|| !enif_inspect_iolist_as_binary(env, argv[2], &data_bin)
@@ -2529,6 +2529,8 @@ static ERL_NIF_TERM aes_cbc_crypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
 
     if (key_bin.size == 16)
 	cipher = EVP_aes_128_cbc();
+    else if (key_bin.size == 24)
+	cipher = EVP_aes_192_cbc();
     else if (key_bin.size == 32)
 	cipher = EVP_aes_256_cbc();
 

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -135,8 +135,8 @@
 
      <p><code>stream_cipher() = rc4 | aes_ctr </code></p>
 
-     <p><code>block_cipher() =  aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_ige256 | blowfish_cbc |
-     blowfish_cfb64 | des_cbc | des_cfb | des3_cbc | des3_cbf
+     <p><code>block_cipher() =  aes_cbc | aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_cbc192 |
+     aes_ige256 | blowfish_cbc | blowfish_cfb64 | des_cbc | des_cfb | des3_cbc | des3_cbf
      | des_ede3 | rc2_cbc </code></p>
 
      <p><code>aead_cipher() =  aes_gcm | chacha20_poly1305 </code></p>
@@ -161,7 +161,8 @@
      Note that both md4 and md5 are recommended only for compatibility with existing applications.
      </p>
      <p><code> cipher_algorithms() = des_cbc | des_cfb |  des3_cbc | des3_cbf | des_ede3 |
-     blowfish_cbc | blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128| aes_cbc256 | aes_ige256 | aes_gcm | chacha20_poly1305 | rc2_cbc | aes_ctr| rc4  </code> </p>
+     blowfish_cbc | blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128| aes_cbc256 |
+     aes_ige256 | aes_gcm | chacha20_poly1305 | rc2_cbc | aes_ctr | rc4 | aes_cbc192 | aes_cbc  </code> </p>
      <p><code> public_key_algorithms() =   rsa |dss | ecdsa | dh | ecdh | ec_gf2m</code>
      Note that ec_gf2m is not strictly a public key algorithm, but a restriction on what curves are supported
      with ecdsa and ecdh.

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -135,9 +135,8 @@
 
      <p><code>stream_cipher() = rc4 | aes_ctr </code></p>
 
-     <p><code>block_cipher() =  aes_cbc | aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_cbc192 |
-     aes_ige256 | blowfish_cbc | blowfish_cfb64 | des_cbc | des_cfb | des3_cbc | des3_cbf
-     | des_ede3 | rc2_cbc </code></p>
+     <p><code>block_cipher() =  aes_cbc | aes_cfb8 | aes_cfb128 | aes_ige256 | blowfish_cbc |
+     blowfish_cfb64 | des_cbc | des_cfb | des3_cbc | des3_cbf | des_ede3 | rc2_cbc </code></p>
 
      <p><code>aead_cipher() =  aes_gcm | chacha20_poly1305 </code></p>
 
@@ -160,9 +159,9 @@
      <p><code> hash_algorithms() =  md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512 </code> md4 is also supported for hash_init/1 and hash/2.
      Note that both md4 and md5 are recommended only for compatibility with existing applications.
      </p>
-     <p><code> cipher_algorithms() = des_cbc | des_cfb |  des3_cbc | des3_cbf | des_ede3 |
-     blowfish_cbc | blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128| aes_cbc256 |
-     aes_ige256 | aes_gcm | chacha20_poly1305 | rc2_cbc | aes_ctr | rc4 | aes_cbc192 | aes_cbc  </code> </p>
+     <p><code> cipher_algorithms() = aes_cbc | aes_cfb8 | aes_cfb128 | aes_ctr | aes_gcm |
+     aes_ige256 | blowfish_cbc | blowfish_cfb64 | chacha20_poly1305 | des_cbc | des_cfb |
+     des3_cbc | des3_cbf | des_ede3 | rc2_cbc | rc4 </code> </p>
      <p><code> public_key_algorithms() =   rsa |dss | ecdsa | dh | ecdh | ec_gf2m</code>
      Note that ec_gf2m is not strictly a public key algorithm, but a restriction on what curves are supported
      with ecdsa and ecdh.

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -123,15 +123,12 @@
 -deprecated({blowfish_ofb64_encrypt, 3, next_major_release}).
 -export([aes_cfb_128_encrypt/3, aes_cfb_128_decrypt/3]).
 -export([aes_cbc_128_encrypt/3, aes_cbc_128_decrypt/3]).
--export([aes_cbc_192_encrypt/3, aes_cbc_192_decrypt/3]).
 -export([aes_cbc_256_encrypt/3, aes_cbc_256_decrypt/3]).
 -export([aes_cbc_ivec/1]).
 -deprecated({aes_cfb_128_encrypt, 3, next_major_release}).
 -deprecated({aes_cfb_128_decrypt, 3, next_major_release}).
 -deprecated({aes_cbc_128_encrypt, 3, next_major_release}).
 -deprecated({aes_cbc_128_decrypt, 3, next_major_release}).
--deprecated({aes_cbc_192_encrypt, 3, next_major_release}).
--deprecated({aes_cbc_192_decrypt, 3, next_major_release}).
 -deprecated({aes_cbc_256_encrypt, 3, next_major_release}).
 -deprecated({aes_cbc_256_decrypt, 3, next_major_release}).
 -deprecated({aes_cbc_ivec, 1, next_major_release}).
@@ -214,8 +211,8 @@ supports()->
 
     [{hashs, Hashs},
      {ciphers, [des_cbc, des_cfb, des3_cbc, des_ede3, blowfish_cbc,
-		blowfish_cfb64, blowfish_ofb64, blowfish_ecb, aes_cbc128, aes_cfb8, aes_cfb128,
-		aes_cbc256, rc2_cbc, aes_ctr, rc4, aes_ecb, aes_cbc192, aes_cbc] ++ Ciphers},
+		blowfish_cfb64, blowfish_ofb64, blowfish_ecb, aes_cfb8, aes_cfb128,
+		rc2_cbc, aes_ctr, rc4, aes_ecb, aes_cbc] ++ Ciphers},
      {public_keys, [rsa, dss, dh, srp] ++ PubKeys}
     ].
 
@@ -285,8 +282,7 @@ hmac_final_n(_Context, _HashLen) -> ? nif_stub.
 %% Ecrypt/decrypt %%%
 
 -spec block_encrypt(des_cbc | des_cfb | des3_cbc | des3_cbf | des_ede3 | blowfish_cbc |
-		    blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_cbc256 | rc2_cbc |
-		    aes_cbc192 | aes_cbc,
+		    blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_cbc256 | rc2_cbc | aes_cbc,
 		    Key::iodata(), Ivec::binary(), Data::iodata()) -> binary();
 		   (aes_gcm | chacha20_poly1305, Key::iodata(), Ivec::binary(), {AAD::binary(), Data::iodata()}) -> {binary(), binary()}.
 
@@ -310,8 +306,6 @@ block_encrypt(aes_cbc, Key, Ivec, Data) ->
     aes_cbc_crypt(Key, Ivec, Data, true);
 block_encrypt(aes_cbc128, Key, Ivec, Data) ->
     aes_cbc_128_encrypt(Key, Ivec, Data);
-block_encrypt(aes_cbc192, Key, Ivec, Data) ->
-    aes_cbc_192_encrypt(Key, Ivec, Data);
 block_encrypt(aes_cbc256, Key, Ivec, Data) ->
     aes_cbc_256_encrypt(Key, Ivec, Data);
 block_encrypt(aes_ige256, Key, Ivec, Data) ->
@@ -334,7 +328,7 @@ block_encrypt(rc2_cbc, Key, Ivec, Data) ->
     rc2_cbc_encrypt(Key, Ivec, Data).
 
 -spec block_decrypt(des_cbc | des_cfb | des3_cbc | des3_cbf | des_ede3 | blowfish_cbc |
-		    blowfish_cfb64 | blowfish_ofb64 | aes_cbc | aes_cbc128 | aes_cbc192 | aes_cbc256 |
+		    blowfish_cfb64 | blowfish_ofb64 | aes_cbc | aes_cbc128 | aes_cbc256 |
 		    aes_ige256 | aes_cfb8 | aes_cfb128 | rc2_cbc,
 		    Key::iodata(), Ivec::binary(), Data::iodata()) -> binary();
 		   (aes_gcm | chacha20_poly1305, Key::iodata(), Ivec::binary(),
@@ -359,8 +353,6 @@ block_decrypt(aes_cbc, Key, Ivec, Data) ->
     aes_cbc_crypt(Key, Ivec, Data, false);
 block_decrypt(aes_cbc128, Key, Ivec, Data) ->
     aes_cbc_128_decrypt(Key, Ivec, Data);
-block_decrypt(aes_cbc192, Key, Ivec, Data) ->
-    aes_cbc_192_decrypt(Key, Ivec, Data);
 block_decrypt(aes_cbc256, Key, Ivec, Data) ->
     aes_cbc_256_decrypt(Key, Ivec, Data);
 block_decrypt(aes_ige256, Key, Ivec, Data) ->
@@ -1304,10 +1296,6 @@ des_cfb_ivec(IVec, Data) ->
 				 binary().
 -spec aes_cbc_128_decrypt(iodata(), binary(), iodata()) ->
 				 binary().
--spec aes_cbc_192_encrypt(iodata(), binary(), iodata()) ->
-				 binary().
--spec aes_cbc_192_decrypt(iodata(), binary(), iodata()) ->
-				 binary().
 -spec aes_cbc_256_encrypt(iodata(), binary(), iodata()) ->
 				 binary().
 -spec aes_cbc_256_decrypt(iodata(), binary(), iodata()) ->
@@ -1317,12 +1305,6 @@ aes_cbc_128_encrypt(Key, IVec, Data) ->
     aes_cbc_crypt(Key, IVec, Data, true).
 
 aes_cbc_128_decrypt(Key, IVec, Data) ->
-    aes_cbc_crypt(Key, IVec, Data, false).
-
-aes_cbc_192_encrypt(Key, IVec, Data) ->
-    aes_cbc_crypt(Key, IVec, Data, true).
-
-aes_cbc_192_decrypt(Key, IVec, Data) ->
     aes_cbc_crypt(Key, IVec, Data, false).
 
 aes_cbc_256_encrypt(Key, IVec, Data) ->
@@ -1861,7 +1843,6 @@ mod_exp_nif(_Base,_Exp,_Mod,_bin_hdr) -> ?nif_stub.
 		    rc2_cbc_encrypt, rc2_cbc_decrypt,
 		    rc2_40_cbc_encrypt, rc2_40_cbc_decrypt,
 		    aes_cbc_128_encrypt, aes_cbc_128_decrypt,
-		    aes_cbc_192_encrypt, aes_cbc_192_decrypt,
 		    aes_cbc_256_encrypt, aes_cbc_256_decrypt,
 		    blowfish_cbc_encrypt, blowfish_cbc_decrypt,
 		    blowfish_cfb64_encrypt, blowfish_cfb64_decrypt,

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -123,12 +123,15 @@
 -deprecated({blowfish_ofb64_encrypt, 3, next_major_release}).
 -export([aes_cfb_128_encrypt/3, aes_cfb_128_decrypt/3]).
 -export([aes_cbc_128_encrypt/3, aes_cbc_128_decrypt/3]).
+-export([aes_cbc_192_encrypt/3, aes_cbc_192_decrypt/3]).
 -export([aes_cbc_256_encrypt/3, aes_cbc_256_decrypt/3]).
 -export([aes_cbc_ivec/1]).
 -deprecated({aes_cfb_128_encrypt, 3, next_major_release}).
 -deprecated({aes_cfb_128_decrypt, 3, next_major_release}).
 -deprecated({aes_cbc_128_encrypt, 3, next_major_release}).
 -deprecated({aes_cbc_128_decrypt, 3, next_major_release}).
+-deprecated({aes_cbc_192_encrypt, 3, next_major_release}).
+-deprecated({aes_cbc_192_decrypt, 3, next_major_release}).
 -deprecated({aes_cbc_256_encrypt, 3, next_major_release}).
 -deprecated({aes_cbc_256_decrypt, 3, next_major_release}).
 -deprecated({aes_cbc_ivec, 1, next_major_release}).
@@ -212,7 +215,7 @@ supports()->
     [{hashs, Hashs},
      {ciphers, [des_cbc, des_cfb, des3_cbc, des_ede3, blowfish_cbc,
 		blowfish_cfb64, blowfish_ofb64, blowfish_ecb, aes_cbc128, aes_cfb8, aes_cfb128,
-		aes_cbc256, rc2_cbc, aes_ctr, rc4, aes_ecb] ++ Ciphers},
+		aes_cbc256, rc2_cbc, aes_ctr, rc4, aes_ecb, aes_cbc192, aes_cbc] ++ Ciphers},
      {public_keys, [rsa, dss, dh, srp] ++ PubKeys}
     ].
 
@@ -282,7 +285,8 @@ hmac_final_n(_Context, _HashLen) -> ? nif_stub.
 %% Ecrypt/decrypt %%%
 
 -spec block_encrypt(des_cbc | des_cfb | des3_cbc | des3_cbf | des_ede3 | blowfish_cbc |
-		    blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_cbc256 | rc2_cbc,
+		    blowfish_cfb64 | aes_cbc128 | aes_cfb8 | aes_cfb128 | aes_cbc256 | rc2_cbc |
+		    aes_cbc192 | aes_cbc,
 		    Key::iodata(), Ivec::binary(), Data::iodata()) -> binary();
 		   (aes_gcm | chacha20_poly1305, Key::iodata(), Ivec::binary(), {AAD::binary(), Data::iodata()}) -> {binary(), binary()}.
 
@@ -302,8 +306,12 @@ block_encrypt(blowfish_cfb64, Key, Ivec, Data) ->
     blowfish_cfb64_encrypt(Key, Ivec, Data);
 block_encrypt(blowfish_ofb64, Key, Ivec, Data) ->
     blowfish_ofb64_encrypt(Key, Ivec, Data);
+block_encrypt(aes_cbc, Key, Ivec, Data) ->
+    aes_cbc_crypt(Key, Ivec, Data, true);
 block_encrypt(aes_cbc128, Key, Ivec, Data) ->
     aes_cbc_128_encrypt(Key, Ivec, Data);
+block_encrypt(aes_cbc192, Key, Ivec, Data) ->
+    aes_cbc_192_encrypt(Key, Ivec, Data);
 block_encrypt(aes_cbc256, Key, Ivec, Data) ->
     aes_cbc_256_encrypt(Key, Ivec, Data);
 block_encrypt(aes_ige256, Key, Ivec, Data) ->
@@ -326,8 +334,8 @@ block_encrypt(rc2_cbc, Key, Ivec, Data) ->
     rc2_cbc_encrypt(Key, Ivec, Data).
 
 -spec block_decrypt(des_cbc | des_cfb | des3_cbc | des3_cbf | des_ede3 | blowfish_cbc |
-		    blowfish_cfb64 | blowfish_ofb64  | aes_cbc128 | aes_cbc256 | aes_ige256 |
-		    aes_cfb8 | aes_cfb128 | rc2_cbc,
+		    blowfish_cfb64 | blowfish_ofb64 | aes_cbc | aes_cbc128 | aes_cbc192 | aes_cbc256 |
+		    aes_ige256 | aes_cfb8 | aes_cfb128 | rc2_cbc,
 		    Key::iodata(), Ivec::binary(), Data::iodata()) -> binary();
 		   (aes_gcm | chacha20_poly1305, Key::iodata(), Ivec::binary(),
 		    {AAD::binary(), Data::iodata(), Tag::binary()}) -> binary() | error.
@@ -347,8 +355,12 @@ block_decrypt(blowfish_cfb64, Key, Ivec, Data) ->
     blowfish_cfb64_decrypt(Key, Ivec, Data);
 block_decrypt(blowfish_ofb64, Key, Ivec, Data) ->
     blowfish_ofb64_decrypt(Key, Ivec, Data);
+block_decrypt(aes_cbc, Key, Ivec, Data) ->
+    aes_cbc_crypt(Key, Ivec, Data, false);
 block_decrypt(aes_cbc128, Key, Ivec, Data) ->
     aes_cbc_128_decrypt(Key, Ivec, Data);
+block_decrypt(aes_cbc192, Key, Ivec, Data) ->
+    aes_cbc_192_decrypt(Key, Ivec, Data);
 block_decrypt(aes_cbc256, Key, Ivec, Data) ->
     aes_cbc_256_decrypt(Key, Ivec, Data);
 block_decrypt(aes_ige256, Key, Ivec, Data) ->
@@ -1286,11 +1298,15 @@ des_cfb_ivec(IVec, Data) ->
 
 
 %%
-%% AES - with 128 or 256 bit key in cipher block chaining mode (CBC)
+%% AES - with 128, 192, or 256 bit key in cipher block chaining mode (CBC)
 %%
 -spec aes_cbc_128_encrypt(iodata(), binary(), iodata()) ->
 				 binary().
 -spec aes_cbc_128_decrypt(iodata(), binary(), iodata()) ->
+				 binary().
+-spec aes_cbc_192_encrypt(iodata(), binary(), iodata()) ->
+				 binary().
+-spec aes_cbc_192_decrypt(iodata(), binary(), iodata()) ->
 				 binary().
 -spec aes_cbc_256_encrypt(iodata(), binary(), iodata()) ->
 				 binary().
@@ -1301,6 +1317,12 @@ aes_cbc_128_encrypt(Key, IVec, Data) ->
     aes_cbc_crypt(Key, IVec, Data, true).
 
 aes_cbc_128_decrypt(Key, IVec, Data) ->
+    aes_cbc_crypt(Key, IVec, Data, false).
+
+aes_cbc_192_encrypt(Key, IVec, Data) ->
+    aes_cbc_crypt(Key, IVec, Data, true).
+
+aes_cbc_192_decrypt(Key, IVec, Data) ->
     aes_cbc_crypt(Key, IVec, Data, false).
 
 aes_cbc_256_encrypt(Key, IVec, Data) ->
@@ -1839,6 +1861,7 @@ mod_exp_nif(_Base,_Exp,_Mod,_bin_hdr) -> ?nif_stub.
 		    rc2_cbc_encrypt, rc2_cbc_decrypt,
 		    rc2_40_cbc_encrypt, rc2_40_cbc_decrypt,
 		    aes_cbc_128_encrypt, aes_cbc_128_decrypt,
+		    aes_cbc_192_encrypt, aes_cbc_192_decrypt,
 		    aes_cbc_256_encrypt, aes_cbc_256_decrypt,
 		    blowfish_cbc_encrypt, blowfish_cbc_decrypt,
 		    blowfish_cfb64_encrypt, blowfish_cfb64_decrypt,

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -66,7 +66,6 @@ all() ->
      {group, aes_ctr},
      {group, aes_gcm},
      {group, chacha20_poly1305},
-     {group, aes_cbc192},
      {group, aes_cbc},
      mod_pow,
      exor,
@@ -110,7 +109,6 @@ groups() ->
      {aes_ctr, [], [stream]},
      {aes_gcm, [], [aead]},
      {chacha20_poly1305, [], [aead]},
-     {aes_cbc192, [], [block]},
      {aes_cbc, [], [block]}
     ].
 
@@ -828,9 +826,6 @@ group_config(aes_gcm, Config) ->
 group_config(chacha20_poly1305, Config) ->
     AEAD = chacha20_poly1305(),
     [{aead, AEAD} | Config];
-group_config(aes_cbc192, Config) ->
-    Block = aes_cbc192(),
-    [{block, Block} | Config];
 group_config(aes_cbc, Config) ->
     Block = aes_cbc(),
     [{block, Block} | Config];
@@ -1259,25 +1254,6 @@ aes_cbc128() ->
       hexstr2bin("73BED6B8E3C1743B7116E69E22229516"),
       hexstr2bin("f69f2445df4f9b17ad2b417be66c3710")}
     ].
-
-aes_cbc192() ->
-    [{aes_cbc192,
-      hexstr2bin("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"),
-      hexstr2bin("000102030405060708090a0b0c0d0e0f"),
-      hexstr2bin("6bc1bee22e409f96e93d7e117393172a")},
-     {aes_cbc192,
-      hexstr2bin("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"),
-      hexstr2bin("4f021db243bc633d7178183a9fa071e8"),
-      hexstr2bin("ae2d8a571e03ac9c9eb76fac45af8e51")},
-     {aes_cbc192,
-      hexstr2bin("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"),
-      hexstr2bin("b4d9ada9ad7dedf4e5e738763f69145a"),
-      hexstr2bin("30c81c46a35ce411e5fbc1191a0a52ef")},
-     {aes_cbc192,
-      hexstr2bin("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"),
-      hexstr2bin("571b242012fb7ae07fa9baac3df102e0"),
-      hexstr2bin("f69f2445df4f9b17ad2b417be66c3710")}
-     ].
 
 aes_cbc256() -> 
     [{aes_cbc256,

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -66,6 +66,8 @@ all() ->
      {group, aes_ctr},
      {group, aes_gcm},
      {group, chacha20_poly1305},
+     {group, aes_cbc192},
+     {group, aes_cbc},
      mod_pow,
      exor,
      rand_uniform
@@ -107,7 +109,9 @@ groups() ->
      {rc4, [], [stream]}, 
      {aes_ctr, [], [stream]},
      {aes_gcm, [], [aead]},
-     {chacha20_poly1305, [], [aead]}
+     {chacha20_poly1305, [], [aead]},
+     {aes_cbc192, [], [block]},
+     {aes_cbc, [], [block]}
     ].
 
 %%-------------------------------------------------------------------
@@ -363,6 +367,21 @@ block_cipher({Type, Key,  IV, PlainText}) ->
 	    ok;
 	Other ->
 	    ct:fail({{crypto, block_decrypt, [Type, Key, IV, CipherText]}, {expected, Plain}, {got, Other}})
+    end;
+
+block_cipher({Type, Key, IV, PlainText, CipherText}) ->
+    Plain = iolist_to_binary(PlainText),
+    case crypto:block_encrypt(Type, Key, IV, Plain) of
+	CipherText ->
+	    ok;
+	Other0 ->
+	    ct:fail({{crypto, block_encrypt, [Type, Key, IV, Plain]}, {expected, CipherText}, {got, Other0}})
+    end,
+    case crypto:block_decrypt(Type, Key, IV, CipherText) of
+	Plain ->
+	    ok;
+	Other1 ->
+	    ct:fail({{crypto, block_decrypt, [Type, Key, IV, CipherText]}, {expected, Plain}, {got, Other1}})
     end.
 
 block_cipher_increment({Type, Key, IV, PlainTexts}) when Type == des_cbc;
@@ -370,7 +389,11 @@ block_cipher_increment({Type, Key, IV, PlainTexts}) when Type == des_cbc;
 							 Type == aes_cbc; 
 							 Type == des_cbf
 							 ->
-     block_cipher_increment(Type, Key, IV, IV, PlainTexts, iolist_to_binary(PlainTexts), []);
+    block_cipher_increment(Type, Key, IV, IV, PlainTexts, iolist_to_binary(PlainTexts), []);
+block_cipher_increment({Type, Key, IV, PlainTexts, _CipherText}) when Type == aes_cbc ->
+    Plain = iolist_to_binary(PlainTexts),
+    Blocks = [iolistify(Block) || << Block:128/bitstring >> <= Plain],
+    block_cipher_increment(Type, Key, IV, IV, Blocks, Plain, []);
 block_cipher_increment({_Type, _, _, _}) ->
     ok;
 block_cipher_increment({_,_,_}) ->
@@ -552,7 +575,9 @@ do_block_iolistify({des_ede3 = Type, Key, IV, PlainText}) ->
 do_block_iolistify({Type, Key, PlainText}) ->
     {Type, iolistify(Key), iolistify(PlainText)};
 do_block_iolistify({Type, Key, IV, PlainText}) ->
-    {Type, iolistify(Key), IV, iolistify(PlainText)}.
+    {Type, iolistify(Key), IV, iolistify(PlainText)};
+do_block_iolistify({Type, Key, IV, PlainText, CipherText}) ->
+    {Type, iolistify(Key), IV, iolistify(PlainText), CipherText}.
 
 iolistify(<<"Test With Truncation">>)->
     %% Do not iolistify as it spoils this special case
@@ -803,6 +828,12 @@ group_config(aes_gcm, Config) ->
 group_config(chacha20_poly1305, Config) ->
     AEAD = chacha20_poly1305(),
     [{aead, AEAD} | Config];
+group_config(aes_cbc192, Config) ->
+    Block = aes_cbc192(),
+    [{block, Block} | Config];
+group_config(aes_cbc, Config) ->
+    Block = aes_cbc(),
+    [{block, Block} | Config];
 group_config(_, Config) ->
     Config.
 
@@ -1166,6 +1197,50 @@ rc2_cbc() ->
       <<72,91,135,182,25,42,35,210>>,
      <<36,245,206,158,168,230,58,69,148,137,32,192,250,41,237,181,181,251, 192,2,175,135,177,171,57,30,111,117,159,149,15,28,88,158,28,81,28,115, 85,219,241,82,117,222,91,85,73,117,164,25,182,52,191,64,123,57,26,19, 211,27,253,31,194,219,231,104,247,240,172,130,119,21,225,154,101,247, 32,216,42,216,133,169,78,22,97,27,227,26,196,224,172,168,17,9,148,55, 203,91,252,40,61,226,236,221,215,160,78,63,13,181,68,57,196,241,185, 207, 116,129,152,237,60,139,247,153,27,146,161,246,222,98,185,222,152, 187,135, 236,86,34,7,110,91,230,173,34,160,242,202,222,121,127,181,140, 101,203,195, 190,88,250,86,147,127,87,72,126,171,16,71,47,110,248,88, 14,29,143,161,152, 129,236,148,22,152,186,208,119,70,8,174,193,203,100, 193,203,200,117,102,242, 134,142,96,125,135,200,217,190,76,117,50,70, 209,186,101,241,200,91,40,193,54, 90,195,38,47,59,197,38,234,86,223,16, 51,253,204,129,20,171,66,21,241,26,135,216, 196,114,110,91,15,53,40, 164,201,136,113,95,247,51,181,208,241,68,168,98,151,36, 155,72,24,57, 42,191,14,125,204,10,167,214,233,138,115,125,234,121,134,227,26,247, 77,200,117,110,117,111,168,156,206,67,159,149,189,173,150,193,91,199, 216,153,22, 189,137,185,89,160,13,131,132,58,109,28,110,246,252,251,14, 232,91,38,52,29,101,188,69,123,50,0,130,178,93,73,239,118,7,77,35,59, 253,10,159,45,86,142,37,78,232,48>>
      }].
+
+%% AES CBC test vectors from http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf
+aes_cbc() ->
+    [
+     %% F.2.1 CBC-AES128.Encrypt, F.2.2 CBC-AES128.Decrypt
+     {aes_cbc,
+      hexstr2bin("2b7e151628aed2a6abf7158809cf4f3c"),                    %% Key
+      hexstr2bin("000102030405060708090a0b0c0d0e0f"),                    %% IV
+      hexstr2bin("6bc1bee22e409f96e93d7e117393172a"                      %% PlainText
+		 "ae2d8a571e03ac9c9eb76fac45af8e51"
+		 "30c81c46a35ce411e5fbc1191a0a52ef"
+		 "f69f2445df4f9b17ad2b417be66c3710"),
+      hexstr2bin("7649abac8119b246cee98e9b12e9197d"                      %% CipherText
+		 "5086cb9b507219ee95db113a917678b2"
+		 "73bed6b8e3c1743b7116e69e22229516"
+		 "3ff1caa1681fac09120eca307586e1a7")},
+     %% F.2.3 CBC-AES192.Encrypt, F.2.4 CBC-AES192.Decrypt
+     {aes_cbc,
+      hexstr2bin("8e73b0f7da0e6452c810f32b809079e5"                      %% Key
+		 "62f8ead2522c6b7b"),
+      hexstr2bin("000102030405060708090a0b0c0d0e0f"),                    %% IV
+      hexstr2bin("6bc1bee22e409f96e93d7e117393172a"                      %% PlainText
+		 "ae2d8a571e03ac9c9eb76fac45af8e51"
+		 "30c81c46a35ce411e5fbc1191a0a52ef"
+		 "f69f2445df4f9b17ad2b417be66c3710"),
+      hexstr2bin("4f021db243bc633d7178183a9fa071e8"                      %% CipherText
+		 "b4d9ada9ad7dedf4e5e738763f69145a"
+		 "571b242012fb7ae07fa9baac3df102e0"
+		 "08b0e27988598881d920a9e64f5615cd")},
+     %% F.2.5 CBC-AES256.Encrypt, F.2.6 CBC-AES256.Decrypt
+     {aes_cbc,
+      hexstr2bin("603deb1015ca71be2b73aef0857d7781"                      %% Key
+		 "1f352c073b6108d72d9810a30914dff4"),
+      hexstr2bin("000102030405060708090a0b0c0d0e0f"),                    %% IV
+      hexstr2bin("6bc1bee22e409f96e93d7e117393172a"                      %% PlainText
+		 "ae2d8a571e03ac9c9eb76fac45af8e51"
+		 "30c81c46a35ce411e5fbc1191a0a52ef"
+		 "f69f2445df4f9b17ad2b417be66c3710"),
+      hexstr2bin("f58c4c04d6e5f1ba779eabfb5f7bfbd6"                      %% CipherText
+		 "9cfc4e967edb808d679f777bc6702c7d"
+		 "39f23369a9d9bacfa530e26304231461"
+		 "b2eb05e2c39be9fcda6c19078c6a9d1b")}
+    ].
+
 aes_cbc128() ->
     [{aes_cbc128,
       hexstr2bin("2b7e151628aed2a6abf7158809cf4f3c"), 
@@ -1184,6 +1259,25 @@ aes_cbc128() ->
       hexstr2bin("73BED6B8E3C1743B7116E69E22229516"),
       hexstr2bin("f69f2445df4f9b17ad2b417be66c3710")}
     ].
+
+aes_cbc192() ->
+    [{aes_cbc192,
+      hexstr2bin("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"),
+      hexstr2bin("000102030405060708090a0b0c0d0e0f"),
+      hexstr2bin("6bc1bee22e409f96e93d7e117393172a")},
+     {aes_cbc192,
+      hexstr2bin("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"),
+      hexstr2bin("4f021db243bc633d7178183a9fa071e8"),
+      hexstr2bin("ae2d8a571e03ac9c9eb76fac45af8e51")},
+     {aes_cbc192,
+      hexstr2bin("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"),
+      hexstr2bin("b4d9ada9ad7dedf4e5e738763f69145a"),
+      hexstr2bin("30c81c46a35ce411e5fbc1191a0a52ef")},
+     {aes_cbc192,
+      hexstr2bin("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"),
+      hexstr2bin("571b242012fb7ae07fa9baac3df102e0"),
+      hexstr2bin("f69f2445df4f9b17ad2b417be66c3710")}
+     ].
 
 aes_cbc256() -> 
     [{aes_cbc256,


### PR DESCRIPTION
This pull request adds support for 192-bit keys for the AES CBC cipher and is similar to pull request #829.  I decided to keep the pull requests separate because of the additional concerns specific to each cipher implementation.

*Note:* This is part of a series of pull requests where I'm hoping to add support for algorithms that were discovered to be absent from OTP while writing the [erlang-jose](https://github.com/potatosalad/erlang-jose/blob/master/ALGORITHMS.md) project.

The changes in this pull request can be summarized as:

1. Allow key sizes of 192 bits and call `EVP_aes_192_cbc()` in [`crypto.c`](https://github.com/potatosalad/otp/commit/e70ef43b45282f0cf68e6245d6f851090d010ece#diff-7b5b13b9e0fa4a516b282276c41e5120L2514).
2. Add the `aes_cbc192` block cipher which follows the pattern of `aes_cbc128` and `aes_cbc256`, but mark it as deprecated.
3. Add the `aes_cbc` block cipher which follows the pattern of `aes_ctr`, `aes_ecb`, and `aes_gcm`.

For those unaware of the current behavior of the `aes_cbc128` and `aes_cbc256` block ciphers: both ciphers allow either key size and call the same NIF in an identical way.  For example:

```erlang
%% AES CBC 128-bit key mode      128-bit Key  128-bit IV   128-bit PlainText Block
crypto:block_encrypt(aes_cbc128, << 0:128 >>, << 0:128 >>, << 0:128 >>).

<<102,233,75,212,239,138,44,59,136,76,250,89,202,52,43,46>>

%% AES CBC 256-bit key mode      256-bit Key  128-bit IV   128-bit PlainText Block
crypto:block_encrypt(aes_cbc256, << 0:256 >>, << 0:128 >>, << 0:128 >>).

<<220,149,192,120,162,64,137,137,173,72,162,20,146,132,32,135>>

%% The 'aes_cbc128' and 'aes_cbc256' don't matter, however.  Only the key bit-size does:
%% AES CBC 256-bit key mode      128-bit Key  128-bit IV   128-bit PlainText Block
crypto:block_encrypt(aes_cbc256, << 0:128 >>, << 0:128 >>, << 0:128 >>).

<<102,233,75,212,239,138,44,59,136,76,250,89,202,52,43,46>>
```

So, the two questions I have are:

1. Does it make sense to just simplify `aes_cbc128` and `aes_cbc256` to be just `aes_cbc`?  This is how `aes_ecb`, `aes_ctr`, and `aes_gcm` behave.
2. If `aes_cbc` is the direction that makes the most sense here, should we even add `aes_cbc192` only to have it immediately considered deprecated?