### PR TITLE
Don't add newline after arrow on -callback lines

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -4236,7 +4236,7 @@ This function is designed to be a member of a criteria list."
 This function is designed to be a member of a criteria list."
   (save-excursion
     (beginning-of-line)
-    (when (save-match-data (looking-at "-\\(spec\\|type\\)"))
+    (when (save-match-data (looking-at "-\\(spec\\|type\\|callback\\)"))
       'stop)))
 
 


### PR DESCRIPTION
In the Emacs Erlang mode, typing "->" will usually automatically add a
newline, which is usually what you want when writing a function, but
not when writing a type spec.  Therefore, there is a check for not
adding the newline when the current line starts with -spec or -type.

This change adds -callback to that check, since it is usually written
the same way as type specs.