### PR TITLE
crypto: Implement crypt/sign/verify with EVP_PKEY to allow for additional modes

### DIFF
--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -157,6 +157,16 @@
 
      <p><code>digest_type() =  md5 | sha | sha224 | sha256 | sha384 | sha512</code></p>
 
+     <p><code>rsa_digest_type() = md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512</code></p>
+
+     <p><code>dss_digest_type() = sha | sha224 | sha256 | sha384 | sha512</code></p>
+
+     <p><code>ecdsa_digest_type() = sha | sha224 | sha256 | sha384 | sha512</code></p>
+
+     <p><code>sign_options() = [{rsa_pad, rsa_sign_padding()} | {rsa_pss_saltlen, integer()}]</code></p>
+
+     <p><code>rsa_sign_padding() = rsa_pkcs1_padding | rsa_pkcs1_pss_padding</code></p>
+
      <p><code> hash_algorithms() =  md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512 </code> md4 is also supported for hash_init/1 and hash/2.
      Note that both md4 and md5 are recommended only for compatibility with existing applications.
      </p>
@@ -636,6 +646,7 @@
 
     <func>
       <name>sign(Algorithm, DigestType, Msg, Key) -> binary()</name>
+      <name>sign(Algorithm, DigestType, Msg, Key, Options) -> binary()</name>
       <fsummary> Create digital signature.</fsummary>
       <type>
 	<v>Algorithm = rsa | dss | ecdsa </v>
@@ -643,8 +654,9 @@
 	<d>The msg is either the binary "cleartext" data to be
 	signed or it is the hashed value of "cleartext" i.e. the
 	digest (plaintext).</d>
-	<v>DigestType = digest_type()</v>
+	<v>DigestType = rsa_digest_type() | dss_digest_type() | ecdsa_digest_type()</v>
 	<v>Key = rsa_private() | dss_private() | [ecdh_private(),ecdh_params()]</v>
+	<v>Options = sign_options()</v>
       </type>
       <desc>
 	<p>Creates a digital signature.</p>
@@ -787,15 +799,17 @@
 
   <func>
       <name>verify(Algorithm, DigestType, Msg, Signature, Key) -> boolean()</name>
+      <name>verify(Algorithm, DigestType, Msg, Signature, Key, Options) -> boolean()</name>
       <fsummary>Verifies a digital signature.</fsummary>
       <type>
 	<v> Algorithm = rsa | dss | ecdsa </v>
 	<v>Msg = binary() | {digest,binary()}</v>
 	<d>The msg is either the binary "cleartext" data
         or it is the hashed value of "cleartext" i.e. the digest (plaintext).</d>
-	<v>DigestType = digest_type()</v>
+	<v>DigestType = rsa_digest_type() | dss_digest_type() | ecdsa_digest_type()</v>
 	<v>Signature = binary()</v>
 	<v>Key = rsa_public() | dss_public() | [ecdh_public(),ecdh_params()]</v>
+	<v>Options = sign_options()</v>
       </type>
       <desc>
 	<p>Verifies a digital signature</p>

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -4,7 +4,8 @@
 <erlref>
   <header>
     <copyright>
-      <year>1999</year><year>2014</year>
+      <year>1999</year>
+      <year>2015</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -157,15 +158,19 @@
 
      <p><code>digest_type() =  md5 | sha | sha224 | sha256 | sha384 | sha512</code></p>
 
-     <p><code>rsa_digest_type() = md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512</code></p>
+     <p><code>rsa_digest_type() = md5 | none | ripemd160 | sha | sha224 | sha256 | sha384 | sha512</code></p>
 
      <p><code>dss_digest_type() = sha | sha224 | sha256 | sha384 | sha512</code></p>
 
      <p><code>ecdsa_digest_type() = sha | sha224 | sha256 | sha384 | sha512</code></p>
 
-     <p><code>sign_options() = [{rsa_pad, rsa_sign_padding()} | {rsa_pss_saltlen, integer()}]</code></p>
+     <p><code>rsa_crypt_padding() = rsa_no_padding | rsa_pkcs1_padding | rsa_pkcs1_oaep_padding | rsa_sslv23_padding | rsa_x931_padding</code></p>
 
-     <p><code>rsa_sign_padding() = rsa_pkcs1_padding | rsa_pkcs1_pss_padding</code></p>
+     <p><code>rsa_crypt_option() = {rsa_mgf1_md, rsa_digest_type()} | {rsa_oaep_label, binary()} | {rsa_oaep_md, rsa_digest_type()} | {rsa_padding, rsa_crypt_padding()}</code></p>
+
+     <p><code>rsa_sign_padding() = rsa_no_padding | rsa_pkcs1_padding | rsa_pkcs1_pss_padding | rsa_x931_padding</code></p>
+
+     <p><code>rsa_sign_option() = {rsa_mgf1_md, rsa_digest_type()} | {rsa_padding, rsa_sign_padding()} | {rsa_pss_saltlen, integer()}</code></p>
 
      <p><code> hash_algorithms() =  md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512 </code> md4 is also supported for hash_init/1 and hash/2.
      Note that both md4 and md5 are recommended only for compatibility with existing applications.
@@ -516,13 +521,13 @@
     </func>
 
     <func>
-      <name>private_decrypt(Type, CipherText, PrivateKey, Padding) -> PlainText</name>
+      <name>private_decrypt(Type, CipherText, PrivateKey, Options) -> PlainText</name>
       <fsummary>Decrypts CipherText using the private Key.</fsummary>
       <type>
 	<v>Type = rsa</v>
 	<v>CipherText = binary()</v>
 	<v>PrivateKey = rsa_private()</v>
-	<v>Padding = rsa_pkcs1_padding | rsa_pkcs1_oaep_padding | rsa_no_padding</v>
+	<v>Options = [rsa_crypt_option()]</v>
         <v>PlainText = binary()</v>
       </type>
       <desc>
@@ -531,42 +536,47 @@
 	  using the <c>PrivateKey</c>, and returns the
 	  plaintext (message digest). This is a low level signature  verification operation
 	used for instance by older versions of the SSL protocol.
-	  See also <seealso marker="public_key:public_key#decrypt_private-2">public_key:decrypt_private/[2,3]</seealso>
 	</p>
+	<p>May throw exception <c>notsup</c> in case the chosen <c>Options</c>
+        are not supported by the underlying OpenSSL implementation.</p>
+        See also <seealso marker="public_key:public_key#decrypt_private-2">public_key:decrypt_private/[2,3]</seealso>
       </desc>
     </func>
     
     <func>
-      <name>private_encrypt(Type, PlainText, PrivateKey, Padding) -> CipherText</name>
+      <name>private_encrypt(Type, PlainText, PrivateKey, Options) -> CipherText</name>
       <fsummary>Encrypts PlainText using the private Key.</fsummary>
       <type>
 	<v>Type = rsa</v>
 	<v>PlainText = binary()</v>
 	<d> The size of the <c>PlainText</c> must be less
-	than <c>byte_size(N)-11</c> if <c>rsa_pkcs1_padding</c> is
-	used, and <c>byte_size(N)</c> if <c>rsa_no_padding</c> is
-	used, where N is public modulus of the RSA key.</d>
+	than <c>byte_size(N)-11</c> if <c>rsa_pkcs1_padding</c> or
+	<c>rsa_sslv23_padding</c> is used, <c>byte_size(N)-2</c> if
+	<c>rsa_x931_padding</c> is used, and <c>byte_size(N)</c>
+	if <c>rsa_no_padding</c> is used, where N is public modulus
+	of the RSA key.</d>
 	<v>PrivateKey = rsa_private()</v>
-	<v>Padding = rsa_pkcs1_padding | rsa_no_padding</v>
+	<v>Options = [rsa_crypt_option()]</v>
         <v>CipherText = binary()</v>
       </type>
       <desc>
 	<p>Encrypts the <c>PlainText</c> using the <c>PrivateKey</c>
 	and returns the ciphertext. This is a low level signature operation
-	used for instance by older versions of the SSL protocol. See
-	also <seealso
-	marker="public_key:public_key#encrypt_private-2">public_key:encrypt_private/[2,3]</seealso>
+	used for instance by older versions of the SSL protocol.
 	</p>
+	<p>May throw exception <c>notsup</c> in case the chosen <c>Options</c>
+        are not supported by the underlying OpenSSL implementation.</p>
+        See also <seealso marker="public_key:public_key#encrypt_private-2">public_key:encrypt_private/[2,3]</seealso>
       </desc>
     </func>
     <func>
-      <name>public_decrypt(Type, CipherText, PublicKey, Padding) -> PlainText</name>
+      <name>public_decrypt(Type, CipherText, PublicKey, Options) -> PlainText</name>
       <fsummary>Decrypts CipherText using the public Key.</fsummary>
       <type>
 	<v>Type = rsa</v>
 	<v>CipherText = binary()</v>
 	<v>PublicKey =  rsa_public() </v>
-	<v>Padding = rsa_pkcs1_padding | rsa_no_padding</v>
+	<v>Options = [rsa_crypt_option()]</v>
         <v>PlainText = binary()</v>
       </type>
       <desc>
@@ -575,31 +585,37 @@
 	  using the <c>PrivateKey</c>, and returns the
 	  plaintext (message digest). This is a low level signature verification operation
 	  used for instance by older versions of the SSL protocol.
-	  See also <seealso marker="public_key:public_key#decrypt_public-2">public_key:decrypt_public/[2,3]</seealso>
 	</p>
+	<p>May throw exception <c>notsup</c> in case the chosen <c>Options</c>
+        are not supported by the underlying OpenSSL implementation.</p>
+        See also <seealso marker="public_key:public_key#decrypt_public-2">public_key:decrypt_public/[2,3]</seealso>
       </desc>
     </func>
 
     <func>
-      <name>public_encrypt(Type, PlainText, PublicKey, Padding) -> CipherText</name>
+      <name>public_encrypt(Type, PlainText, PublicKey, Options) -> CipherText</name>
       <fsummary>Encrypts PlainText using the public Key.</fsummary>
       <type>
 	<v>Type = rsa</v>
 	<v>PlainText = binary()</v>
 	<d> The size of the <c>PlainText</c> must be less
-	than <c>byte_size(N)-11</c> if <c>rsa_pkcs1_padding</c> is
-	used, and <c>byte_size(N)</c> if <c>rsa_no_padding</c> is
-	used, where N is public modulus of the RSA key.</d>
+	than <c>byte_size(N)-11</c> if <c>rsa_pkcs1_padding</c> or
+	<c>rsa_sslv23_padding</c> is used, <c>byte_size(N)-2-byte_size(H)*2</c>
+	if <c>rsa_pkcs1_oaep_padding</c> is used, and <c>byte_size(N)</c>
+	if <c>rsa_no_padding</c> is used, where N is public modulus
+	of the RSA key and H is the hash function specified
+	by <c>rsa_oaep_md</c> (defaults to <c>sha</c>).</d>
 	<v>PublicKey = rsa_public()</v>
-	<v>Padding = rsa_pkcs1_padding | rsa_pkcs1_oaep_padding | rsa_no_padding</v>
+	<v>Options = [rsa_crypt_option()]</v>
         <v>CipherText = binary()</v>
       </type>
       <desc>
 	<p>Encrypts the <c>PlainText</c> (message digest) using the <c>PublicKey</c>
 	and returns the <c>CipherText</c>. This is a low level signature operation
-	used for instance by older versions of the SSL protocol. See also <seealso
-	marker="public_key:public_key#encrypt_public-2">public_key:encrypt_public/[2,3]</seealso>
-	</p>
+	used for instance by older versions of the SSL protocol.</p>
+	<p>May throw exception <c>notsup</c> in case the chosen <c>Options</c>
+        are not supported by the underlying OpenSSL implementation.</p>
+	See also <seealso marker="public_key:public_key#encrypt_public-2">public_key:encrypt_public/[2,3]</seealso>
       </desc>
     </func>
 
@@ -656,13 +672,13 @@
 	digest (plaintext).</d>
 	<v>DigestType = rsa_digest_type() | dss_digest_type() | ecdsa_digest_type()</v>
 	<v>Key = rsa_private() | dss_private() | [ecdh_private(),ecdh_params()]</v>
-	<v>Options = sign_options()</v>
+	<v>Options = [rsa_sign_option()]</v>
       </type>
       <desc>
 	<p>Creates a digital signature.</p>
-	<p>Algorithm <c>dss</c> can only be used together with digest type
-	<c>sha</c>.</p>
-	See also <seealso marker="public_key:public_key#sign-3">public_key:sign/3</seealso>
+	<p>May throw exception <c>notsup</c> in case the chosen <c>DigestType</c>
+        or <c>Options</c> are not supported by the underlying OpenSSL implementation.</p>
+	See also <seealso marker="public_key:public_key#sign-3">public_key:sign/[2,3]</seealso>
       </desc>
     </func>
 
@@ -809,14 +825,13 @@
 	<v>DigestType = rsa_digest_type() | dss_digest_type() | ecdsa_digest_type()</v>
 	<v>Signature = binary()</v>
 	<v>Key = rsa_public() | dss_public() | [ecdh_public(),ecdh_params()]</v>
-	<v>Options = sign_options()</v>
+	<v>Options = [rsa_sign_option()]</v>
       </type>
       <desc>
 	<p>Verifies a digital signature</p>
-	<p>Algorithm <c>dss</c> can only be used together with digest type
-	<c>sha</c>.</p>
-
-	See also <seealso marker="public_key:public_key#verify-4">public_key:verify/4</seealso>
+	<p>May throw exception <c>notsup</c> in case the chosen <c>DigestType</c>
+        or <c>Options</c> are not supported by the underlying OpenSSL implementation.</p>
+	See also <seealso marker="public_key:public_key#verify-4">public_key:verify/[4,5]</seealso>
       </desc>
     </func>
 

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -229,9 +229,10 @@ sign_verify(Config) when is_list(Config) ->
 public_encrypt() ->
      [{doc, "Test public_encrypt/decrypt and private_encrypt/decrypt functions. "}].
 public_encrypt(Config) when is_list(Config) ->
-    Params = proplists:get_value(pub_priv_encrypt, Config),
-    lists:foreach(fun do_public_encrypt/1, Params),
-    lists:foreach(fun do_private_encrypt/1, Params).
+    PrivPubParams = proplists:get_value(priv_pub_encrypt, Config),
+    PubPrivParams = proplists:get_value(pub_priv_encrypt, Config),
+    lists:foreach(fun do_public_encrypt/1, PubPrivParams),
+    lists:foreach(fun do_private_encrypt/1, PrivPubParams).
 
 %%--------------------------------------------------------------------
 generate_compute() ->
@@ -450,7 +451,15 @@ do_sign_verify({Type, Hash, Public, Private, Msg}) ->
 	    negative_verify(Type, Hash, Msg, <<10,20>>, Public);
 	false ->
 	    ct:fail({{crypto, verify, [Type, Hash, Msg, Signature, Public]}})
-    end. 
+    end;
+do_sign_verify({Type, Hash, Public, Private, Msg, Options}) ->
+    Signature = crypto:sign(Type, Hash, Msg, Private, Options),
+    case crypto:verify(Type, Hash, Msg, Signature, Public, Options) of
+	true ->
+	    negative_verify(Type, Hash, Msg, <<10,20>>, Public, Options);
+	false ->
+	    ct:fail({{crypto, verify, [Type, Hash, Msg, Signature, Public, Options]}})
+    end.
 
 negative_verify(Type, Hash, Msg, Signature, Public) ->
     case crypto:verify(Type, Hash, Msg, Signature, Public) of
@@ -460,26 +469,58 @@ negative_verify(Type, Hash, Msg, Signature, Public) ->
 	    ok
     end.
 
-do_public_encrypt({Type, Public, Private, Msg, Padding}) ->
-    PublicEcn = (catch crypto:public_encrypt(Type, Msg, Public, Padding)),
-    case crypto:private_decrypt(Type, PublicEcn, Private, Padding) of
-	Msg ->
-	    ok;
-	Other ->
-	    ct:fail({{crypto, private_decrypt, [Type, PublicEcn, Private, Padding]}, {expected, Msg}, {got, Other}})
-    end. 
-
-do_private_encrypt({_Type, _Public, _Private, _Msg, rsa_pkcs1_oaep_padding}) ->
-    ok; %% Not supported by openssl
-do_private_encrypt({Type, Public, Private, Msg, Padding}) ->
-    PrivEcn = (catch crypto:private_encrypt(Type, Msg, Private, Padding)),
-    case crypto:public_decrypt(rsa, PrivEcn, Public, Padding) of
-	Msg ->
-	    ok;
-	Other ->
-	    ct:fail({{crypto, public_decrypt, [Type, PrivEcn, Public, Padding]}, {expected, Msg}, {got, Other}})
+negative_verify(Type, Hash, Msg, Signature, Public, Options) ->
+    case crypto:verify(Type, Hash, Msg, Signature, Public, Options) of
+	true ->
+	    ct:fail({{crypto, verify, [Type, Hash, Msg, Signature, Public, Options]}, should_fail});
+	false ->
+	    ok
     end.
-     
+
+do_public_encrypt({Type, Public, Private, Msg, Options}) ->
+    case catch crypto:public_encrypt(Type, Msg, Public, Options) of
+	PublicEcn when is_binary(PublicEcn) ->
+	    case proplists:get_value(rsa_padding, Options) of
+		rsa_sslv23_padding ->
+		    ok;
+		_ ->
+		    case catch crypto:private_decrypt(Type, PublicEcn, Private, Options) of
+			Msg ->
+			    ok;
+			{'EXIT', {notsup, _}} ->
+			    ok;
+			Other ->
+			    ct:fail({{crypto, private_decrypt, [Type, PublicEcn, Private, Options]}, {expected, Msg}, {got, Other}})
+		    end
+	    end;
+	{'EXIT', {notsup, _}} ->
+	    ok;
+	Other ->
+	    ct:fail({{crypto, public_encrypt, [Type, Msg, Public, Options]}, {expected, binary}, {got, Other}})
+    end.
+
+do_private_encrypt({Type, Public, Private, Msg, Options}) ->
+    case catch crypto:private_encrypt(Type, Msg, Private, Options) of
+	PrivEcn when is_binary(PrivEcn) ->
+	    case proplists:get_value(rsa_padding, Options) of
+		rsa_sslv23_padding ->
+		    ok;
+		_ ->
+		    case catch crypto:public_decrypt(Type, PrivEcn, Public, Options) of
+			Msg ->
+			    ok;
+			{'EXIT', {notsup, _}} ->
+			    ok;
+			Other ->
+			    ct:fail({{crypto, public_decrypt, [Type, Type, PrivEcn, Public, Options]}, {expected, Msg}, {got, Other}})
+		    end
+	    end;
+	{'EXIT', {notsup, _}} ->
+	    ok;
+	Other ->
+	    ct:fail({{crypto, private_encrypt, [Type, Msg, Private, Options]}, {expected, binary}, {got, Other}})
+    end.
+
 do_generate_compute({srp = Type, UserPrivate, UserGenParams, UserComParams,
 		     HostPublic, HostPrivate, HostGenParams, HostComParam, SessionKey}) ->
     {UserPublic, UserPrivate} = crypto:generate_key(Type, UserGenParams, UserPrivate),
@@ -716,11 +757,19 @@ group_config(rsa = Type, Config) ->
     PrivateS = rsa_private_stronger(),
     SignVerify = sign_verify_tests(Type, Msg, Public, Private, PublicS, PrivateS),
     MsgPubEnc = <<"7896345786348 Asldi">>,
-    PubPrivEnc = [{rsa, Public, Private, MsgPubEnc, rsa_pkcs1_padding},
-		  rsa_oaep(),
+    PrivPubEnc = [{rsa, Public, Private, MsgPubEnc, [{rsa_padding, rsa_pkcs1_padding}]},
+		  {rsa, Public, Private, MsgPubEnc, [{rsa_padding, rsa_sslv23_padding}]},
+		  {rsa, Public, Private, MsgPubEnc, [{rsa_padding, rsa_x931_padding}]},
 		  no_padding()
 		 ],
-    [{sign_verify, SignVerify}, {pub_priv_encrypt, PubPrivEnc} | Config];
+    PubPrivEnc = [{rsa, Public, Private, MsgPubEnc, [{rsa_padding, rsa_pkcs1_padding}]},
+		  rsa_oaep(),
+		  rsa_oaep_label(),
+		  rsa_oaep256(),
+		  no_padding()
+		 ],
+    [{sign_verify, SignVerify}, {priv_pub_encrypt, PrivPubEnc},
+     {pub_priv_encrypt, PubPrivEnc} | Config];
 group_config(dss = Type, Config) ->
     Msg = dss_plain(),
     Public = dss_params() ++ [dss_public()], 
@@ -807,18 +856,38 @@ group_config(_, Config) ->
     Config.
 
 sign_verify_tests(Type, Msg, Public, Private, PublicS, PrivateS) ->
-    sign_verify_tests(Type, [md5, sha, sha224, sha256], Msg, Public, Private) ++
-	sign_verify_tests(Type, [sha384, sha512], Msg, PublicS, PrivateS).
+    gen_sign_verify_tests(Type, [md5, ripemd160, sha, sha224, sha256], Msg, Public, Private,
+			  [undefined,
+			   [{rsa_padding, rsa_pkcs1_pss_padding}],
+			   [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, 0}],
+			   [{rsa_padding, rsa_x931_padding}]
+			  ]) ++
+	gen_sign_verify_tests(Type, [sha384, sha512], Msg, PublicS, PrivateS,
+			      [undefined,
+			       [{rsa_padding, rsa_pkcs1_pss_padding}],
+			       [{rsa_padding, rsa_pkcs1_pss_padding}, {rsa_pss_saltlen, 0}],
+			       [{rsa_padding, rsa_x931_padding}]
+			      ]).
 
-sign_verify_tests(Type, Hashs, Msg, Public, Private) ->
-    lists:foldl(fun(Hash, Acc) -> 
-			case is_supported(Hash) of
-			    true ->
-				[{Type, Hash,  Public, Private, Msg}|Acc];
-			    false ->
-			      Acc
-			end
-		end, [], Hashs).
+gen_sign_verify_tests(Type, Hashs, Msg, Public, Private, Opts) ->
+    lists:foldr(fun(Hash, Acc0) ->
+	case is_supported(Hash) of
+	    true ->
+		lists:foldr(fun
+		    (undefined, Acc1) ->
+			[{Type, Hash, Public, Private, Msg} | Acc1];
+		    ([{rsa_padding, rsa_x931_padding} | _], Acc1)
+			    when Hash =:= md5
+			    orelse Hash =:= ripemd160
+			    orelse Hash =:= sha224 ->
+			Acc1;
+		    (Opt, Acc1) ->
+			[{Type, Hash, Public, Private, Msg, Opt} | Acc1]
+		end, Acc0, Opts);
+	    false ->
+		Acc0
+	end
+    end, [], Hashs).
 
 rfc_1321_msgs() ->
     [<<"">>, 
@@ -2152,7 +2221,32 @@ rsa_oaep() ->
 			 hexstr2bin("4f456c502493bdc0ed2ab756a3a6ed4d67352a697d4216e93212b127a63d5411ce6fa98d5dbefd73263e3728142743818166ed7dd63687dd2a8ca1d2f4fbd8e1")],
     %%Msg = hexstr2bin("6628194e12073db03ba94cda9ef9532397d50dba79b987004afefe34"),
     Msg =  hexstr2bin("750c4047f547e8e41411856523298ac9bae245efaf1397fbe56f9dd5"),
-    {rsa, Public, Private, Msg, rsa_pkcs1_oaep_padding}.
+    {rsa, Public, Private, Msg, [{rsa_padding, rsa_pkcs1_oaep_padding}]}.
+
+rsa_oaep_label() ->
+    Public = [hexstr2bin("010001"),
+	      hexstr2bin("a8b3b284af8eb50b387034a860f146c4919f318763cd6c5598c8ae4811a1e0abc4c7e0b082d693a5e7fced675cf4668512772c0cbc64a742c6c630f533c8cc72f62ae833c40bf25842e984bb78bdbf97c0107d55bdb662f5c4e0fab9845cb5148ef7392dd3aaff93ae1e6b667bb3d4247616d4f5ba10d4cfd226de88d39f16fb")],
+    Private = Public ++ [hexstr2bin("53339cfdb79fc8466a655c7316aca85c55fd8f6dd898fdaf119517ef4f52e8fd8e258df93fee180fa0e4ab29693cd83b152a553d4ac4d1812b8b9fa5af0e7f55fe7304df41570926f3311f15c4d65a732c483116ee3d3d2d0af3549ad9bf7cbfb78ad884f84d5beb04724dc7369b31def37d0cf539e9cfcdd3de653729ead5d1"),
+			 hexstr2bin("d32737e7267ffe1341b2d5c0d150a81b586fb3132bed2f8d5262864a9cb9f30af38be448598d413a172efb802c21acf1c11c520c2f26a471dcad212eac7ca39d"),
+			 hexstr2bin("cc8853d1d54da630fac004f471f281c7b8982d8224a490edbeb33d3e3d5cc93c4765703d1dd791642f1f116a0dd852be2419b2af72bfe9a030e860b0288b5d77"),
+			 hexstr2bin("0e12bf1718e9cef5599ba1c3882fe8046a90874eefce8f2ccc20e4f2741fb0a33a3848aec9c9305fbecbd2d76819967d4671acc6431e4037968db37878e695c1"),
+			 hexstr2bin("95297b0f95a2fa67d00707d609dfd4fc05c89dafc2ef6d6ea55bec771ea333734d9251e79082ecda866efef13c459e1a631386b7e354c899f5f112ca85d71583"),
+			 hexstr2bin("4f456c502493bdc0ed2ab756a3a6ed4d67352a697d4216e93212b127a63d5411ce6fa98d5dbefd73263e3728142743818166ed7dd63687dd2a8ca1d2f4fbd8e1")],
+    Msg = hexstr2bin("750c4047f547e8e41411856523298ac9bae245efaf1397fbe56f9dd5"),
+    Lbl = hexstr2bin("1332a67ca7088f75c9b8fb5e3d072882"),
+    {rsa, Public, Private, Msg, [{rsa_padding, rsa_pkcs1_oaep_padding}, {rsa_oaep_label, Lbl}]}.
+
+rsa_oaep256() ->
+    Public = [hexstr2bin("010001"),
+	      hexstr2bin("a8b3b284af8eb50b387034a860f146c4919f318763cd6c5598c8ae4811a1e0abc4c7e0b082d693a5e7fced675cf4668512772c0cbc64a742c6c630f533c8cc72f62ae833c40bf25842e984bb78bdbf97c0107d55bdb662f5c4e0fab9845cb5148ef7392dd3aaff93ae1e6b667bb3d4247616d4f5ba10d4cfd226de88d39f16fb")],
+    Private = Public ++ [hexstr2bin("53339cfdb79fc8466a655c7316aca85c55fd8f6dd898fdaf119517ef4f52e8fd8e258df93fee180fa0e4ab29693cd83b152a553d4ac4d1812b8b9fa5af0e7f55fe7304df41570926f3311f15c4d65a732c483116ee3d3d2d0af3549ad9bf7cbfb78ad884f84d5beb04724dc7369b31def37d0cf539e9cfcdd3de653729ead5d1"),
+			 hexstr2bin("d32737e7267ffe1341b2d5c0d150a81b586fb3132bed2f8d5262864a9cb9f30af38be448598d413a172efb802c21acf1c11c520c2f26a471dcad212eac7ca39d"),
+			 hexstr2bin("cc8853d1d54da630fac004f471f281c7b8982d8224a490edbeb33d3e3d5cc93c4765703d1dd791642f1f116a0dd852be2419b2af72bfe9a030e860b0288b5d77"),
+			 hexstr2bin("0e12bf1718e9cef5599ba1c3882fe8046a90874eefce8f2ccc20e4f2741fb0a33a3848aec9c9305fbecbd2d76819967d4671acc6431e4037968db37878e695c1"),
+			 hexstr2bin("95297b0f95a2fa67d00707d609dfd4fc05c89dafc2ef6d6ea55bec771ea333734d9251e79082ecda866efef13c459e1a631386b7e354c899f5f112ca85d71583"),
+			 hexstr2bin("4f456c502493bdc0ed2ab756a3a6ed4d67352a697d4216e93212b127a63d5411ce6fa98d5dbefd73263e3728142743818166ed7dd63687dd2a8ca1d2f4fbd8e1")],
+    Msg = hexstr2bin("750c4047f547e8e41411856523298ac9bae245efaf1397fbe56f9dd5"),
+    {rsa, Public, Private, Msg, [{rsa_padding, rsa_pkcs1_oaep_padding}, {rsa_oaep_md, sha256}]}.
 
 ecc() ->
 %%               http://point-at-infinity.org/ecc/nisttv
@@ -2180,7 +2274,7 @@ no_padding() ->
     Private = rsa_private(),
     MsgLen = erlang:byte_size(int_to_bin(Mod)),
     Msg = list_to_binary(lists:duplicate(MsgLen, $X)),
-    {rsa, Public, Private, Msg, rsa_no_padding}.
+    {rsa, Public, Private, Msg, [{rsa_padding, rsa_no_padding}]}.
 
 int_to_bin(X) when X < 0 -> int_to_bin_neg(X, []);
 int_to_bin(X) -> int_to_bin_pos(X, []).

--- a/lib/public_key/doc/src/public_key.xml
+++ b/lib/public_key/doc/src/public_key.xml
@@ -156,18 +156,27 @@
 	<p><c>| 'rsa_no_padding'</c></p>
       </item>
 
+      <tag><c>public_sign_options() =</c></tag>
+      <item><p><c>[{rsa_pad, rsa_sign_padding()} | {rsa_pss_saltlen, integer()}]</c></p></item>
+
+      <tag><c>rsa_sign_padding() =</c></tag>
+      <item>
+	<p><c>'rsa_pkcs1_padding'</c></p>
+	<p><c>| 'rsa_pkcs1_pss_padding'</c></p>
+      </item>
+
       <tag><c>digest_type() = </c></tag>
       <item><p>Union of <c>rsa_digest_type()</c>, <c>dss_digest_type()</c>, 
       and <c>ecdsa_digest_type()</c>.</p></item>
 
       <tag><c>rsa_digest_type() = </c></tag>
-      <item><p><c>'md5' | 'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'</c></p></item>
+      <item><p><c>'md5' | 'ripemd160' | 'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'</c></p></item>
 
       <tag><c>dss_digest_type() = </c></tag>
-      <item><p><c>'sha'</c></p></item>
+      <item><p><c>'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'</c></p></item>
 
       <tag><c>ecdsa_digest_type() = </c></tag>
-      <item><p><c>'sha'| 'sha224' | 'sha256' | 'sha384' | 'sha512'</c></p></item>
+      <item><p><c>'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'</c></p></item>
       
       <tag><c>crl_reason() = </c></tag>
       <item>
@@ -736,6 +745,7 @@ fun(#'DistributionPoint'{}, #'CertificateList'{},
 
   <func>
     <name>sign(Msg, DigestType, Key) -> binary()</name>
+    <name>sign(Msg, DigestType, Key, Options) -> binary()</name>
     <fsummary>Creates a digital signature.</fsummary>
     <type>
        <v>Msg = binary() | {digest,binary()}</v>
@@ -744,6 +754,7 @@ fun(#'DistributionPoint'{}, #'CertificateList'{},
        digest.</d>
        <v>DigestType = rsa_digest_type() | dss_digest_type() | ecdsa_digest_type()</v>
        <v>Key = rsa_private_key() | dsa_private_key() | ec_private_key()</v>
+       <v>Options = public_sign_options()</v>
   </type>
   <desc>
     <p>Creates a digital signature.</p> 
@@ -801,6 +812,7 @@ fun(#'DistributionPoint'{}, #'CertificateList'{},
 
   <func>
     <name>verify(Msg, DigestType, Signature, Key) -> boolean()</name>
+    <name>verify(Msg, DigestType, Signature, Key, Options) -> boolean()</name>
     <fsummary>Verifies a digital signature.</fsummary>
     <type>
       <v>Msg = binary() | {digest,binary()}</v>
@@ -809,6 +821,7 @@ fun(#'DistributionPoint'{}, #'CertificateList'{},
       <v>DigestType = rsa_digest_type() | dss_digest_type() | ecdsa_digest_type()</v>
       <v>Signature = binary()</v>
       <v>Key = rsa_public_key() | dsa_public_key() | ec_public_key()</v>
+      <v>Options = public_sign_options()</v>
   </type>
   <desc>
     <p>Veryfies a digital signature.</p>

--- a/lib/public_key/doc/src/public_key.xml
+++ b/lib/public_key/doc/src/public_key.xml
@@ -147,22 +147,41 @@
       <item><p><c>#'ECPrivateKey'{}</c></p></item>
 
       <tag><c>public_crypt_options() =</c></tag>
-      <item><p><c>[{rsa_pad, rsa_padding()}]</c></p></item>
+      <item><p><c>[rsa_crypt_option()]</c></p></item>
 
-      <tag><c>rsa_padding() =</c></tag>
+      <tag><c>rsa_crypt_option() =</c></tag>
       <item>
-	<p><c>'rsa_pkcs1_padding'</c></p>
+	<p><c>{'rsa_mgf1_md', rsa_digest_type()}</c></p>
+	<p><c>| {'rsa_oaep_label', binary()}</c></p>
+	<p><c>| {'rsa_oaep_md', rsa_digest_type()}</c></p>
+	<p><c>| {'rsa_padding', rsa_crypt_padding()}</c></p>
+      </item>
+
+      <tag><c>rsa_crypt_padding() =</c></tag>
+      <item>
+	<p><c>'rsa_no_padding'</c></p>
+	<p><c>| 'rsa_pkcs1_padding'</c></p>
 	<p><c>| 'rsa_pkcs1_oaep_padding'</c></p>
-	<p><c>| 'rsa_no_padding'</c></p>
+	<p><c>| 'rsa_sslv23_padding'</c></p>
+	<p><c>| 'rsa_x931_padding'</c></p>
       </item>
 
       <tag><c>public_sign_options() =</c></tag>
-      <item><p><c>[{rsa_pad, rsa_sign_padding()} | {rsa_pss_saltlen, integer()}]</c></p></item>
+      <item><p><c>[rsa_sign_option()]</c></p></item>
+
+      <tag><c>rsa_sign_option() =</c></tag>
+      <item>
+	<p><c>{'rsa_mgf1_md', rsa_digest_type()}</c></p>
+	<p><c>| {'rsa_padding', rsa_sign_padding()}</c></p>
+	<p><c>| {'rsa_pss_saltlen', integer()}</c></p>
+      </item>
 
       <tag><c>rsa_sign_padding() =</c></tag>
       <item>
-	<p><c>'rsa_pkcs1_padding'</c></p>
+	<p><c>'rsa_no_padding'</c></p>
+	<p><c>| 'rsa_pkcs1_padding'</c></p>
 	<p><c>| 'rsa_pkcs1_pss_padding'</c></p>
+	<p><c>| 'rsa_x931_padding'</c></p>
       </item>
 
       <tag><c>digest_type() = </c></tag>
@@ -170,7 +189,7 @@
       and <c>ecdsa_digest_type()</c>.</p></item>
 
       <tag><c>rsa_digest_type() = </c></tag>
-      <item><p><c>'md5' | 'ripemd160' | 'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'</c></p></item>
+      <item><p><c>'md5' | 'none' | 'ripemd160' | 'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'</c></p></item>
 
       <tag><c>dss_digest_type() = </c></tag>
       <item><p><c>'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'</c></p></item>
@@ -310,10 +329,12 @@
 
     <func>
     <name>encrypt_private(PlainText, Key) -> binary()</name>
+    <name>encrypt_private(PlainText, Key, Options) -> binary()</name>
     <fsummary>Public-key encryption using the private key.</fsummary>
     <type>
       <v>PlainText = binary()</v>
       <v>Key = rsa_private_key()</v> 
+      <v>Options = public_crypt_options()</v>
   </type> 
   <desc> 
     <p>Public-key encryption using the private key.
@@ -324,10 +345,12 @@
 
   <func>
     <name>encrypt_public(PlainText, Key) -> binary()</name>
+    <name>encrypt_public(PlainText, Key, Options) -> binary()</name>
     <fsummary>Public-key encryption using the public key.</fsummary>
     <type>
       <v>PlainText = binary()</v>
       <v>Key = rsa_public_key()</v> 
+      <v>Options = public_crypt_options()</v>
   </type> 
   <desc> 
     <p>Public-key encryption using the public key. See also <seealso

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -35,7 +35,7 @@
 	 decrypt_private/2, decrypt_private/3, 
 	 encrypt_public/2, encrypt_public/3, 
 	 decrypt_public/2, decrypt_public/3,
-	 sign/3, verify/4,
+	 sign/3, sign/4, verify/4, verify/5,
 	 generate_key/1,
 	 compute_key/2, compute_key/3,
 	 pkix_sign/2, pkix_verify/2,	 
@@ -83,10 +83,12 @@
 				auth_keys.
 -type rsa_padding()          :: 'rsa_pkcs1_padding' | 'rsa_pkcs1_oaep_padding' 
 			      | 'rsa_no_padding'.
+-type rsa_sign_padding()     :: 'rsa_pkcs1_padding' | 'rsa_pkcs1_pss_padding'.
 -type public_crypt_options() :: [{rsa_pad, rsa_padding()}].
--type rsa_digest_type()      :: 'md5' | 'sha'| 'sha224' | 'sha256' | 'sha384' | 'sha512'.
--type dss_digest_type()      :: 'none' | 'sha'. %% None is for backwards compatibility
--type ecdsa_digest_type()       :: 'sha'| 'sha224' | 'sha256' | 'sha384' | 'sha512'.
+-type rsa_digest_type()      :: 'md5' | 'ripemd160' | 'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'.
+-type dss_digest_type()      :: 'none' | 'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'. %% None is for backwards compatibility
+-type ecdsa_digest_type()    :: 'sha' | 'sha224' | 'sha256' | 'sha384' | 'sha512'.
+-type public_sign_options()  :: [{rsa_pad, rsa_sign_padding()} | {rsa_pss_saltlen, integer()}].
 -type crl_reason()           ::  unspecified | keyCompromise | cACompromise | affiliationChanged | superseded
 			       | cessationOfOperation | certificateHold | privilegeWithdrawn |  aACompromise.
 -type oid()                  :: tuple().
@@ -433,35 +435,53 @@ pkix_sign_types(?'ecdsa-with-SHA512') ->
     {sha512, ecdsa}.
 
 %%--------------------------------------------------------------------
--spec sign(binary() | {digest, binary()},  rsa_digest_type() | dss_digest_type() | ecdsa_digest_type(),
+-spec sign(binary() | {digest, binary()}, rsa_digest_type() | dss_digest_type() | ecdsa_digest_type(),
 	   rsa_private_key() |
 	   dsa_private_key() | ec_private_key()) -> Signature :: binary().
+-spec sign(binary() | {digest, binary()}, rsa_digest_type() | dss_digest_type() | ecdsa_digest_type(),
+	   rsa_private_key() |
+	   dsa_private_key() | ec_private_key(), public_sign_options()) -> Signature :: binary().
 %% Description: Create digital signature.
 %%--------------------------------------------------------------------
-sign(DigestOrPlainText, DigestType, Key = #'RSAPrivateKey'{}) ->
-    crypto:sign(rsa, DigestType, DigestOrPlainText, format_rsa_private_key(Key));
-
-sign(DigestOrPlainText, sha, #'DSAPrivateKey'{p = P, q = Q, g = G, x = X}) ->
-    crypto:sign(dss, sha, DigestOrPlainText, [P, Q, G, X]);
-
-sign(DigestOrPlainText, DigestType, #'ECPrivateKey'{privateKey = PrivKey,
-						    parameters = Param}) ->
-    ECCurve = ec_curve_spec(Param),
-    crypto:sign(ecdsa, DigestType, DigestOrPlainText, [PrivKey, ECCurve]);
+sign(DigestOrPlainText, DigestType, Key) ->
+    sign(DigestOrPlainText, DigestType, Key, []).
 
 %% Backwards compatible
-sign(Digest, none, #'DSAPrivateKey'{} = Key) ->
-    sign({digest,Digest}, sha, Key).
+sign(Digest, none, Key = #'DSAPrivateKey'{}, Options) when is_binary(Digest) ->
+    sign({digest, Digest}, sha, Key, Options);
+sign(DigestOrPlainText, DigestType, Key, Options) ->
+    case format_sign_key(Key) of
+	badarg ->
+	    erlang:error(badarg, [DigestOrPlainText, DigestType, Key, Options]);
+	{Algorithm, CryptoKey} ->
+	    crypto:sign(Algorithm, DigestType, DigestOrPlainText, CryptoKey, Options)
+    end.
 
 %%--------------------------------------------------------------------
 -spec verify(binary() | {digest, binary()}, rsa_digest_type() | dss_digest_type() | ecdsa_digest_type(),
 	     Signature :: binary(), rsa_public_key()
 	     | dsa_public_key() | ec_public_key()) -> boolean().
+-spec verify(binary() | {digest, binary()}, rsa_digest_type() | dss_digest_type() | ecdsa_digest_type(),
+	     Signature :: binary(), rsa_public_key()
+	     | dsa_public_key() | ec_public_key(), public_sign_options()) -> boolean().
 %% Description: Verifies a digital signature.
 %%--------------------------------------------------------------------
-verify(DigestOrPlainText, DigestType, Signature, Key) when is_binary(Signature) ->
-    do_verify(DigestOrPlainText, DigestType, Signature, Key);
-verify(_,_,_,_) -> 
+verify(DigestOrPlainText, DigestType, Signature, Key) ->
+    verify(DigestOrPlainText, DigestType, Signature, Key, []).
+
+%% Backwards compatible
+verify(Digest, none, Signature, Key = {_, #'Dss-Parms'{}}, Options) when is_binary(Digest) ->
+    verify({digest, Digest}, sha, Signature, Key, Options);
+verify(Digest, none, Signature, Key = #'DSAPrivateKey'{}, Options) when is_binary(Digest) ->
+    verify({digest, Digest}, sha, Signature, Key, Options);
+verify(DigestOrPlainText, DigestType, Signature, Key, Options) when is_binary(Signature) ->
+    case format_verify_key(Key) of
+	badarg ->
+	    erlang:error(badarg, [DigestOrPlainText, DigestType, Signature, Key, Options]);
+	{Algorithm, CryptoKey} ->
+	    crypto:verify(Algorithm, DigestType, DigestOrPlainText, Signature, CryptoKey, Options)
+    end;
+verify(_,_,_,_,_) -> 
     %% If Signature is a bitstring and not a binary we know already at this
     %% point that the signature is invalid.
     false.
@@ -744,22 +764,33 @@ ssh_encode(Entries, Type) when is_list(Entries),
 %%--------------------------------------------------------------------
 %%% Internal functions
 %%--------------------------------------------------------------------
-do_verify(DigestOrPlainText, DigestType, Signature,
-       #'RSAPublicKey'{modulus = Mod, publicExponent = Exp}) ->
-    crypto:verify(rsa, DigestType, DigestOrPlainText, Signature,
-		  [Exp, Mod]);
 
-do_verify(DigestOrPlaintext, DigestType, Signature, {#'ECPoint'{point = Point}, Param}) ->
-    ECCurve = ec_curve_spec(Param),
-    crypto:verify(ecdsa, DigestType, DigestOrPlaintext, Signature, [Point, ECCurve]);
+format_sign_key(Key = #'RSAPrivateKey'{}) ->
+    {rsa, format_rsa_private_key(Key)};
+format_sign_key(#'DSAPrivateKey'{p = P, q = Q, g = G, x = X}) ->
+    {dss, [P, Q, G, X]};
+format_sign_key(#'ECPrivateKey'{privateKey = PrivKey, parameters = Param}) ->
+    {ecdsa, [PrivKey, ec_curve_spec(Param)]};
+format_sign_key(_) ->
+    badarg.
 
-%% Backwards compatibility
-do_verify(Digest, none, Signature, {_,  #'Dss-Parms'{}} = Key ) ->
-    verify({digest,Digest}, sha, Signature, Key);
-
-do_verify(DigestOrPlainText, sha = DigestType, Signature, {Key,  #'Dss-Parms'{p = P, q = Q, g = G}})
-  when is_integer(Key), is_binary(Signature) ->
-    crypto:verify(dss, DigestType, DigestOrPlainText, Signature, [P, Q, G, Key]).
+format_verify_key(#'RSAPublicKey'{modulus = Mod, publicExponent = Exp}) ->
+    {rsa, [Exp, Mod]};
+format_verify_key({#'ECPoint'{point = Point}, Param}) ->
+    {ecdsa, [Point, ec_curve_spec(Param)]};
+format_verify_key({Key,  #'Dss-Parms'{p = P, q = Q, g = G}}) ->
+    {dss, [P, Q, G, Key]};
+%% Convert private keys to public keys
+format_verify_key(#'RSAPrivateKey'{modulus = Mod, publicExponent = Exp}) ->
+    format_verify_key(#'RSAPublicKey'{modulus = Mod, publicExponent = Exp});
+format_verify_key(#'ECPrivateKey'{parameters = Param, publicKey = {_, Point}}) ->
+    format_verify_key({#'ECPoint'{point = Point}, Param});
+format_verify_key(#'ECPrivateKey'{parameters = Param, publicKey = Point}) ->
+    format_verify_key({#'ECPoint'{point = Point}, Param});
+format_verify_key(#'DSAPrivateKey'{y=Y, p=P, q=Q, g=G}) ->
+    format_verify_key({Y, #'Dss-Parms'{p=P, q=Q, g=G}});
+format_verify_key(_) ->
+    badarg.
 
 do_pem_entry_encode(Asn1Type, Entity, CipherInfo, Password) ->
     Der = der_encode(Asn1Type, Entity),

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -506,7 +506,11 @@ rsa_sign_verify(Config) when is_list(Config) ->
     false = public_key:verify(Msg, sha, <<1:8, RSASign/binary>>, PublicRSA), 
 
     RSASign1 = public_key:sign(Msg, md5, PrivateRSA),
-    true = public_key:verify(Msg, md5, RSASign1, PublicRSA).
+    true = public_key:verify(Msg, md5, RSASign1, PublicRSA),
+
+    RSASign2 = public_key:sign(Msg, sha, PrivateRSA, [{rsa_padding, rsa_pkcs1_pss_padding}]),
+    false = public_key:verify(Msg, sha, RSASign2, PublicRSA),
+    true = public_key:verify(Msg, sha, RSASign2, PublicRSA, [{rsa_padding, rsa_pkcs1_pss_padding}]).
     
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
#### Overview

This pull request had two main goals:

1. Add support for the RSAES-OAEP-256 encryption padding from [RFC 3447](https://tools.ietf.org/html/rfc3447).
2. Add support for the RSASSA-PSS signature padding from [RFC 3447](https://tools.ietf.org/html/rfc3447).

This was accomplished by unifying the underlying NIF functions for `crypto:sign/[4,5]`, `crypto:verify/[5,6]`, `crypto:private_decrypt/4`, `crypto:private_encrypt/4`, `crypto:public_decrypt/4`, and `crypto:public_encrypt/4` using the [EVP library](https://www.openssl.org/docs/manmaster/crypto/evp.html) from OpenSSL (high-level cyrptographic functions) and by adding the ability to specify options for the above functions.

This removed/replaced the following NIF functions:

* `dss_sign_nif`, `ecdsa_sign_nif`, and `rsa_sign_nif` in favor of `pkey_sign_nif`
* `dss_verify_nif`, `ecdsa_verify_nif`, and `rsa_verify_nif` in favor of `pkey_verify_nif`
* `rsa_private_crypt` and `rsa_public_crypt` in favor of `pkey_crypt_nif`

These algorithms were originally implemented in pure Erlang at [`jose_jwa_pkcs1.erl`](https://github.com/potatosalad/erlang-jose/blob/master/src/jose_jwa_pkcs1.erl) prior to this implementation using OpenSSL that I'm hoping to have accepted into OTP.

*Note:* This is part of a series of pull requests where I'm hoping to add support for algorithms that were discovered to be absent from OTP while writing the [erlang-jose](https://github.com/potatosalad/erlang-jose/blob/master/ALGORITHMS.md) project.

#### Features

##### Sign/Verify

* `crypto:sign(Algorithm, DigestType, Message, PrivateKey, Options) -> binary()`
  * If a specific `DigestType` or option isn't support by the underlying OpenSSL implementation, a `notsup` error may be raised (similar to previous behavior).
  * `DigestType`
    * When `Algorithm` is `rsa`, `DigestType` support for `ripemd160` and `none` has been added. `none` may be used to skip setting the message digest type with [EVP_PKEY_CTX_set_signature_md](https://www.openssl.org/docs/manmaster/crypto/EVP_PKEY_CTX_set_signature_md.html).
    * When `Algorithm` is `dss`, `DigestType` support for `sha224`, `sha256`, `sha384`, and `sha512` has been added as mentioned in [NIST SP 800-57 Part 1](http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57_part1_rev3_general.pdf).
  * `Options`
    * `{rsa_mgf1_md, md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512}`
      * Changes the [MGF1](https://tools.ietf.org/html/rfc3447#appendix-B.2.1) for use with `rsa_pkcs1_pss_padding`. Defaults to `DigestType`.
    * `{rsa_padding, rsa_sign_padding()}`
      * `rsa_no_padding` - custom or application defined padding
      * `rsa_pkcs1_padding` - [RSASSA-PKCS1-v1_5](https://tools.ietf.org/html/rfc3447#section-8.2) padding (the default if no `rsa_padding` specified)
      * `rsa_pkcs1_pss_padding` - [RSASSA-PSS](https://tools.ietf.org/html/rfc3447#section-8.1) padding
      * `rsa_x931_padding` - [ANSI X9.31](http://www.cryptsoft.com/pkcs11doc/v230/group__SEC__11__1__13__ANSI__X9__31__RSA.html) padding
    * `{rsa_pss_saltlen, integer()}` - sets the salt length for `rsa_pkcs1_pss_padding` mode. Negative values have [special meanings](https://github.com/openssl/openssl/blob/OpenSSL_1_0_2d/crypto/rsa/rsa_pss.c#L204-L209). Defaults to `-2`.
      * `-2` - salt length is maximized
      * `-1` - salt length is hash length
* `crypto:verify(Algorithm, DigestType, Message, Signature, PublicKey, Options) -> boolean()`
  * Same behavior for `Algorithm`, `DigestType`, and `Options` as specified for `crypto:sign/5`.

*Note:* `public_key:sign/4` and `public_key:verify/5` were also added to support passing of `Options`.

##### Public/Private Crypt

* `crypto:private_encrypt(Algorithm, PlainText, PrivateKey, Options) -> binary()`
  * If a specific option isn't supported by the underlying OpenSSL implementation, a `notsup` error may be raised (similar to behavior for sign/verify).
  * `Options`
    * `{rsa_padding, rsa_sign_padding()}`
      * `rsa_no_padding` - custom or application defined padding
      * `rsa_pkcs1_padding` - [RSAES-PKCS1-v1_5](https://tools.ietf.org/html/rfc3447#section-7.2) padding (the default if no `rsa_padding` specified)
      * `rsa_sslv23_padding` - [RSAES-PKCS1-v1_5](https://tools.ietf.org/html/rfc3447#section-7.2) with [SSL-specific modification](https://tools.ietf.org/html/rfc3218)
      * `rsa_x931_padding` - [ANSI X9.31](http://www.cryptsoft.com/pkcs11doc/v230/group__SEC__11__1__13__ANSI__X9__31__RSA.html) padding
* `crypto:public_decrypt(Algorithm, CipherText, PublicKey, Options) -> binary()`
  * Same behavior for `Options` as specified for `crypto:private_encrypt/4`.
* `crypto:public_encrypt(Algorithm, PlainText, PublicKey, Options) -> binary()`
  * If a specific option isn't supported by the underlying OpenSSL implementation (for example, `rsa_oaep_label` is only supported by OpenSSL >= 1.0.2), a `notsup` error may be raised (similar to behavior for sign/verify).
  * `Options`
    * `{rsa_mgf1_md, md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512}`
      * Changes the [MGF1](https://tools.ietf.org/html/rfc3447#appendix-B.2.1) for use with `rsa_pkcs1_oaep_padding`. Defaults to `rsa_oaep_md`.
    * `{rsa_oaep_label, binary()}` - sets the label for `rsa_pkcs1_oaep_padding` mode.
    * `{rsa_oaep_md, md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512}`
      * Changes the [hash function](https://tools.ietf.org/html/rfc3447#section-7.1.1) for use with `rsa_pkcs1_oaep_padding`. Defaults to `sha`.
    * `{rsa_padding, rsa_sign_padding()}`
      * `rsa_no_padding` - custom or application defined padding
      * `rsa_pkcs1_oaep_padding` - [RSAES-OAEP](https://tools.ietf.org/html/rfc3447#section-7.1) padding
      * `rsa_pkcs1_padding` - [RSAES-PKCS1-v1_5](https://tools.ietf.org/html/rfc3447#section-7.2) padding (the default if no `rsa_padding` specified)
* `crypto:private_decrypt(Algorithm, CipherText, PrivateKey, Options) -> binary()`
  * Same behavior for `Options` as specified for `crypto:public_encrypt/4`.

*Note:* `public_key:decrypt_private/3`, `public_key:decrypt_public/3`, `public_key:encrypt_private/3`, and `public_key:encrypt_public/3` were also updated to support passing of `Options`.

#### Examples

The following RSA examples use the 2048-bit RSA key specified below:

* `rsa-private.pem`

```
-----BEGIN RSA PRIVATE KEY-----
MIIEowIBAAKCAQEApIkgn9Py4oFxRIT3nXos8+dXMi7jB5QY+/j2bAvePYSZOhBr
+EtAvnIjWbH+nQk86AZKhDuS79cBodySsJsmstQHa4AOX3vqZjIyPcWFlWRCRZbM
U9WYg5Y5af90HJmUD5g+KCk0TzjZ06hLEKdMnjlf9IATIe7EZOnSMqQvReX8iyx4
ymPPepYLaGXOQOnltNgjXpOt5yY0by4l7mnlDuIIc4A8MJ1do6s6GSYEXwrpyZB2
DZ0aNNDWloCaVCMnRI/mjALu0K142eNELhjm5PCUiEXSLHRm4j9cgJ4PNyFIGGXy
faoVG0CMyelpnXYagdgJlJ+Pr3zIwY4zeNjEsQIDAQABAoIBAE+wLoHaSE+Vu8Mg
10CJFM6IY/3lIYXhH3yiJs9LrDaFSyUJIRHfeJsEcsSVZaiu+bWynlKO++p3as33
I4CvlD2WXYWePtfWDz+x3g125ezl4wcLMykDUVuh3WrOE3FqnIA1Dx2qXzBja3SM
lNabAIu9ZBDqGtobZzks2eY3CMJEC4X7DhPac3BIPRwid5naUuqq6zSHLtaT9D/f
tiqkLxVUcKEb22hezBHYEduDiXmdySbgFle/W2ofhvAtj+XFGrG1nI2Vl2Y04Yk5
tzk4dWcBRBOZOm+JeH8H6jB7pBn2RoYlzLgvuxb+vR43kDJhzJnaP3wLz3jo07lw
dIaRUgECgYEA0V6FxRrF3ONgQhQq+lvb0J/cfPr1JMiexGtaTYrIlEob/g3N7L24
d8nJiNUcDiNmiHcmuzTbpRGz1JM+kVIzJ2cFltGMKwUcZ6t1czNNSnWaIt5VFjbM
DAfgaTHpG/yIdial9hg8PAaK9JWgTienqgY8PRgIehdnqbqdlpPk0RECgYEAyS5b
Of9xXlQskp6FwZuxn7VB7ourFx5UP6Yb+xVKDSlNlgTYQNlMHR4GJmCBk/0T4F5x
yQr9GVekl787Ojw/262QxxW4rKZDMuz2CQabATLiDaW8Y+mwhEWxNuhLmMOM51y/
14F361W3hW/LNHaGNPbCL9D3fARt1YrORW0cuaECgYAQaGfzWnXHKcqRYyM7G5fO
cbjF0qUDjPVkT0V0bjvp4yTudAZ/Vx7txFKW9pyMPxn599yBL1NHTGvbbO6qVNbN
b7VwbFufw3bGaRl7PboA69Z4hRQF+aVkC/n6RH8QQmovWDgJYTzXN2wMXu2BMnph
SLvPzeJcLxlgo89VzaFRAQKBgQCVpw0njJRZlgX+HzvidJ3h7uSXvX/M17vWCQvB
b+nA9puHYB05yCrtcfsjKyDY5CaX/clowurZoi+GzjMRs+XQ1UDgR5EzpQ5R4KF4
v1gowSAVBNep/xlWm70i2hP6FGVJad4vQljhT8cP1MR1R0G4PmLfTPP8ZhMKCZI9
ZNg8YQKBgAKZyUZhXHFXmtSxAk71SBpYglA+eiI/Ay83A7TpNQKxxvCtTRDvNgy7
iTXRYzE/zgYLzUXekK+2O1N3zk71K9tneHfrp0OGrPjKtG+lwQEkxjt2zZxvAVOG
lSw59rDFicbm+C3htLH4HVqONNoDAPE6O6P/MXCluQ1cjsIiINb1
-----END RSA PRIVATE KEY-----
```

* `rsa-public.pem`

```
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApIkgn9Py4oFxRIT3nXos
8+dXMi7jB5QY+/j2bAvePYSZOhBr+EtAvnIjWbH+nQk86AZKhDuS79cBodySsJsm
stQHa4AOX3vqZjIyPcWFlWRCRZbMU9WYg5Y5af90HJmUD5g+KCk0TzjZ06hLEKdM
njlf9IATIe7EZOnSMqQvReX8iyx4ymPPepYLaGXOQOnltNgjXpOt5yY0by4l7mnl
DuIIc4A8MJ1do6s6GSYEXwrpyZB2DZ0aNNDWloCaVCMnRI/mjALu0K142eNELhjm
5PCUiEXSLHRm4j9cgJ4PNyFIGGXyfaoVG0CMyelpnXYagdgJlJ+Pr3zIwY4zeNjE
sQIDAQAB
-----END PUBLIC KEY-----
```

* Common variable setup, including the reading of the PEM files:

```erlang
GetKey = fun(File) ->
    public_key:pem_entry_decode(hd(public_key:pem_decode(element(2, file:read_file(File)))))
end,
RSAPrivate = GetKey("rsa-private.pem"),
RSAPublic = GetKey("rsa-public.pem"),

PlainText = <<"my secret">>,
Message   = <<"my message">>.
```

##### RSAES-OAEP-256

*Note:* Requires OpenSSL >= 1.0.2

```erlang
CipherText = public_key:encrypt_public(PlainText, RSAPublic, [
    {rsa_padding, rsa_pkcs1_oaep_padding},
    {rsa_oaep_md, sha256}
]).

<<17,89,58,73,137,157,53,100,165,13,175,128,9,115,137,155,
  115,185,118,225,147,135,214,30,144,10,185,254,146,166,
  254,133,198,146,129,253,244,205,183,200,60,11,248,48,68,
  37,5,162,210,135,196,89,191,57,75,230,106,18,76,32,239,
  196,240,26,58,249,23,41,117,52,161,178,121,170,83,8,94,
  38,23,125,166,168,233,47,159,50,43,130,119,112,67,119,
  158,223,116,120,165,238,183,124,174,153,228,222,215,202,
  144,190,140,148,13,174,129,206,252,164,85,162,219,131,
  72,55,206,87,132,50,218,24,88,235,51,82,185,219,149,87,
  203,135,188,14,114,134,94,126,13,100,102,156,112,204,
  214,220,245,86,148,200,225,196,87,253,78,95,198,14,149,
  140,197,169,47,54,153,92,240,188,122,30,159,166,48,28,
  86,208,29,98,133,163,90,104,128,120,69,139,113,117,75,
  74,58,28,127,118,221,5,218,104,5,81,240,44,186,216,24,
  110,6,224,235,187,78,24,176,16,193,53,93,165,201,8,38,
  81,207,187,8,110,220,146,89,7,207,157,61,157,105,203,
  191,84,228,52,245,187,189,112,52,71,154,107,90,118>>

PlainText = public_key:decrypt_private(CipherText, RSAPrivate, [
    {rsa_padding, rsa_pkcs1_oaep_padding},
    {rsa_oaep_md, sha256}
]).

<<"my secret">>
```

##### RSASSA-PSS

```erlang
Signature = public_key:sign(Message, sha256, RSAPrivate, [
    {rsa_padding, rsa_pkcs1_pss_padding}
]).

<<62,185,164,160,155,251,183,48,229,46,100,151,91,59,45,
  17,182,75,174,12,79,247,177,150,223,101,105,90,51,177,
  179,230,5,99,254,172,159,33,225,35,208,231,5,38,132,176,
  22,164,219,240,173,245,136,192,245,209,64,161,57,216,
  255,184,157,88,238,69,106,54,226,89,229,42,170,53,92,
  198,187,204,248,196,136,253,223,216,165,67,75,65,164,
  146,250,128,247,209,201,229,4,140,135,34,30,85,233,74,
  119,59,41,77,174,11,48,82,40,12,185,196,21,225,250,51,
  137,19,29,48,107,231,244,106,149,227,117,48,126,2,150,
  150,245,49,98,26,210,234,196,181,129,195,6,171,26,36,
  162,71,70,173,54,68,167,77,75,161,207,52,73,153,90,248,
  239,214,130,64,67,202,173,173,218,158,131,6,108,238,22,
  42,201,146,104,149,138,221,159,52,58,194,118,124,159,
  238,36,254,153,158,196,153,21,13,230,21,245,174,29,144,
  78,6,189,228,126,64,2,68,148,108,115,78,225,111,161,160,
  192,5,140,179,137,19,103,130,169,191,73,111,136,239,35,
  169,183,47,187,7,15,246,158,163,172,83,123,108,92,141>>

public_key:verify(Message, sha256, Signature, RSAPublic, [
    {rsa_padding, rsa_pkcs1_pss_padding}
]).

true
```