### PR TITLE
sendfile: Fix sending of files larger than the OS send buffer on FreeBSD

### DIFF
--- a/erts/emulator/drivers/unix/unix_efile.c
+++ b/erts/emulator/drivers/unix/unix_efile.c
@@ -39,6 +39,11 @@
 #ifdef HAVE_SYS_UIO_H
 #include <sys/types.h>
 #include <sys/uio.h>
+#if defined(HAVE_SENDFILE) && (defined(__FreeBSD__) || defined(__DragonFly__))
+/* Need to define __BSD_VISIBLE in order to expose prototype of sendfile */
+#define __BSD_VISIBLE 1
+#include <sys/socket.h>
+#endif
 #endif
 #if defined(HAVE_SENDFILE) && (defined(__linux__) || (defined(__sun) && defined(__SVR4)))
 #include <sys/sendfile.h>


### PR DESCRIPTION
This patch has been tested to work correctly on FreeBSD 10.1-RELEASE-p10.