### PR TITLE
inets: scheme validation fun for http_uri

### DIFF
--- a/lib/inets/doc/src/http_uri.xml
+++ b/lib/inets/doc/src/http_uri.xml
@@ -117,7 +117,8 @@
         <v>Options = [Option]</v> 
         <v>Option = {ipv6_host_with_brackets, boolean()} | 
                     {scheme_defaults, scheme_defaults()} |
-                    {fragment, boolean()}]</v>
+                    {fragment, boolean()} |
+                    {schema_validation_fun, fun()}]</v>
         <v>Result = {Scheme, UserInfo, Host, Port, Path, Query} |
                     {Scheme, UserInfo, Host, Port, Path, Query, Fragment}</v>
 	<v>UserInfo = user_info()</v>
@@ -140,6 +141,16 @@
 
         <p>If the fragment option is <c>true</c>, the URI fragment is returned as
           part of the parsing result, otherwise it is ignored.</p>
+
+        <p>Scheme validation fun is to be defined as follows:
+
+	    <code>
+fun(SchemeStr :: string()) ->
+	valid |	{error, Reason :: term()}.
+	    </code>
+
+        It is called before scheme string gets converted into scheme atom and
+        thus possible atom leak could be prevented</p>
 
         <marker id="encode"></marker>
       </desc>

--- a/lib/inets/test/uri_SUITE.erl
+++ b/lib/inets/test/uri_SUITE.erl
@@ -49,7 +49,8 @@ all() ->
      queries,
      fragments,
      escaped,
-     hexed_query
+     hexed_query,
+     scheme_validation
     ].
 
 %%--------------------------------------------------------------------
@@ -174,6 +175,26 @@ hexed_query(Config) when is_list(Config) ->
     verify_uri(URI1, Verify1),
     verify_uri(URI2, Verify2),
     verify_uri(URI3, Verify3).
+
+scheme_validation(Config) when is_list(Config) ->
+    {ok, {http,[],"localhost",80,"/",""}} =
+	http_uri:parse("http://localhost#fragment"),
+
+    ValidationFun =
+	fun("http") -> valid;
+	   (_) -> {error, bad_scheme}
+	end,
+
+    {ok, {http,[],"localhost",80,"/",""}} =
+	http_uri:parse("http://localhost#fragment",
+		       [{scheme_validation_fun, ValidationFun}]),
+    {error, bad_scheme} =
+	http_uri:parse("https://localhost#fragment",
+		       [{scheme_validation_fun, ValidationFun}]),
+    %% non-fun scheme_validation_fun works as no option passed
+    {ok, {https,[],"localhost",443,"/",""}} =
+	http_uri:parse("https://localhost#fragment",
+		       [{scheme_validation_fun, none}]).
 
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
http_uri:parse_scheme function should allow checking
scheme of URIs otherwise it could be easily abused to
reach limit number of atoms in the VM