### PR TITLE
Fix erroneous splitting of emulator path

### DIFF
--- a/erts/etc/common/ct_run.c
+++ b/erts/etc/common/ct_run.c
@@ -83,7 +83,6 @@ static int eargc;		/* Number of arguments in eargv. */
 static void error(char* format, ...);
 static char* emalloc(size_t size);
 static char* strsave(char* string);
-static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
@@ -152,6 +151,8 @@ int main(int argc, char** argv)
     argv0 = argv;
 
     emulator = get_default_emulator(argv[0]);
+    if (strlen(emulator) >= MAXPATHLEN)
+	error("Emulator path length is too large");
 
     /*
      * Allocate the argv vector to be used for arguments to Erlang.
@@ -163,7 +164,7 @@ int main(int argc, char** argv)
     eargv_base = (char **) emalloc(eargv_size*sizeof(char*));
     eargv = eargv_base;
     eargc = 0;
-    push_words(emulator);
+    PUSH(strsave(emulator));
     eargc_base = eargc;
     eargv = eargv + eargv_size/2;
     eargc = 0;
@@ -294,26 +295,6 @@ int main(int argc, char** argv)
     return run_erlang(eargv[0], eargv);
 }
 
-static void
-push_words(char* src)
-{
-    char sbuf[MAXPATHLEN];
-    char* dst;
-
-    dst = sbuf;
-    while ((*dst++ = *src++) != '\0') {
-	if (isspace((int)*src)) {
-	    *dst = '\0';
-	    PUSH(strsave(sbuf));
-	    dst = sbuf;
-	    do {
-		src++;
-	    } while (isspace((int)*src));
-	}
-    }
-    if (sbuf[0])
-	PUSH(strsave(sbuf));
-}
 #ifdef __WIN32__
 wchar_t *make_commandline(char **argv)
 {

--- a/erts/etc/common/dialyzer.c
+++ b/erts/etc/common/dialyzer.c
@@ -65,7 +65,6 @@ static int eargc;		/* Number of arguments in eargv. */
 static void error(char* format, ...);
 static char* emalloc(size_t size);
 static char* strsave(char* string);
-static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
@@ -189,7 +188,7 @@ int main(int argc, char** argv)
     eargv_base = (char **) emalloc(eargv_size*sizeof(char*));
     eargv = eargv_base;
     eargc = 0;
-    push_words(emulator);
+    PUSH(strsave(emulator));
     eargc_base = eargc;
     eargv = eargv + eargv_size/2;
     eargc = 0;
@@ -267,27 +266,6 @@ int main(int argc, char** argv)
 
     PUSH(NULL);
     return run_erlang(eargv[0], eargv);
-}
-
-static void
-push_words(char* src)
-{
-    char sbuf[MAXPATHLEN];
-    char* dst;
-
-    dst = sbuf;
-    while ((*dst++ = *src++) != '\0') {
-	if (isspace((int)*src)) {
-	    *dst = '\0';
-	    PUSH(strsave(sbuf));
-	    dst = sbuf;
-	    do {
-		src++;
-	    } while (isspace((int)*src));
-	}
-    }
-    if (sbuf[0])
-	PUSH(strsave(sbuf));
 }
 
 #ifdef __WIN32__

--- a/erts/etc/common/erlc.c
+++ b/erts/etc/common/erlc.c
@@ -200,7 +200,7 @@ int main(int argc, char** argv)
     eargv_base = (char **) emalloc(eargv_size*sizeof(char*));
     eargv = eargv_base;
     eargc = 0;
-    push_words(emulator);
+    PUSH(strsave(emulator));
     eargc_base = eargc;
     eargv = eargv + eargv_size/2;
     eargc = 0;
@@ -330,26 +330,6 @@ process_opt(int* pArgc, char*** pArgv, int offset)
     return argv[1];
 }
 
-static void
-push_words(char* src)
-{
-    char sbuf[MAXPATHLEN];
-    char* dst;
-
-    dst = sbuf;
-    while ((*dst++ = *src++) != '\0') {
-	if (isspace((int)*src)) {
-	    *dst = '\0';
-	    PUSH(strsave(sbuf));
-	    dst = sbuf;
-	    do {
-		src++;
-	    } while (isspace((int)*src));
-	}
-    }
-    if (sbuf[0])
-	PUSH(strsave(sbuf));
-}
 #ifdef __WIN32__
 wchar_t *make_commandline(char **argv)
 {

--- a/erts/etc/common/escript.c
+++ b/erts/etc/common/escript.c
@@ -74,7 +74,6 @@ static void error(char* format, ...);
 static char* emalloc(size_t size);
 static void efree(void *p);
 static char* strsave(char* string);
-static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
@@ -432,7 +431,7 @@ main(int argc, char** argv)
 	emulator = get_default_emulator(argv[0]);
     }
 
-    if (strlen(emulator) >= PMAX)
+    if (strlen(emulator) >= MAXPATHLEN)
         error("Value of environment variable ESCRIPT_EMULATOR is too large");
 
     /*
@@ -445,7 +444,7 @@ main(int argc, char** argv)
     eargv_base = (char **) emalloc(eargv_size*sizeof(char*));
     eargv = eargv_base;
     eargc = 0;
-    push_words(emulator);
+    PUSH(strsave(emulator));
     eargc_base = eargc;
     eargv = eargv + eargv_size/2;
     eargc = 0;
@@ -554,26 +553,6 @@ main(int argc, char** argv)
     return run_erlang(eargv[0], eargv);
 }
 
-static void
-push_words(char* src)
-{
-    char sbuf[PMAX];
-    char* dst;
-
-    dst = sbuf;
-    while ((*dst++ = *src++) != '\0') {
-	if (isspace((int)*src)) {
-	    *dst = '\0';
-	    PUSH(strsave(sbuf));
-	    dst = sbuf;
-	    do {
-		src++;
-	    } while (isspace((int)*src));
-	}
-    }
-    if (sbuf[0])
-	PUSH(strsave(sbuf));
-}
 #ifdef __WIN32__
 wchar_t *make_commandline(char **argv)
 {

--- a/erts/etc/common/typer.c
+++ b/erts/etc/common/typer.c
@@ -65,7 +65,6 @@ static int eargc;		/* Number of arguments in eargv. */
 static void error(char* format, ...);
 static char* emalloc(size_t size);
 static char* strsave(char* string);
-static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
@@ -129,6 +128,9 @@ main(int argc, char** argv)
 
     emulator = get_default_emulator(argv[0]);
 
+    if (strlen(emulator) >= MAXPATHLEN)
+	error("Emulator path length is too large");
+
     /*
      * Allocate the argv vector to be used for arguments to Erlang.
      * Arrange for starting to pushing information in the middle of
@@ -139,7 +141,7 @@ main(int argc, char** argv)
     eargv_base = (char **) emalloc(eargv_size*sizeof(char*));
     eargv = eargv_base;
     eargc = 0;
-    push_words(emulator);
+    PUSH(strsave(emulator));
     eargc_base = eargc;
     eargv = eargv + eargv_size/2;
     eargc = 0;
@@ -192,26 +194,6 @@ main(int argc, char** argv)
     return run_erlang(eargv[0], eargv);
 }
 
-static void
-push_words(char* src)
-{
-    char sbuf[MAXPATHLEN];
-    char* dst;
-
-    dst = sbuf;
-    while ((*dst++ = *src++) != '\0') {
-	if (isspace((int)*src)) {
-	    *dst = '\0';
-	    PUSH(strsave(sbuf));
-	    dst = sbuf;
-	    do {
-		src++;
-	    } while (isspace((int)*src));
-	}
-    }
-    if (sbuf[0])
-	PUSH(strsave(sbuf));
-}
 #ifdef __WIN32__
 wchar_t *make_commandline(char **argv)
 {


### PR DESCRIPTION
`ct_run.c`, `erlc.c`, `escript.c` and `typer.c` do not preserve space characters in the emulator path. Thus, if a path containing space is passed via environment variables, such as `ESCRIPT_EMULATOR`, or if `get_default_emulator(progname)` returns a path with space, the execution of the programs fail. This patch fixes all occurrences found with `grep push_words -R $ERL_TOP`.

**Reproducing the error**
The following example breaks the old implementation in `escript`:

    cd /tmp
    mkdir escript_bug
    cd escript_bug/
    mkdir path\ with\ space
    cp /usr/bin/erl path\ with\ space/
    cd path\ with\ space/
    touch test.escript
    cd ..
    ESCRIPT_EMULATOR='/tmp/escript_bug/path with space/erl' escript "path with space/test.escript"
    escript: Error 2 executing '/tmp/escript_bug/path'.

**Expected**
The example with the changes applied:

    ESCRIPT_EMULATOR='/tmp/escript_bug/path with space/erl' escript "path with space/test.escript"
    escript: Premature end of file reached
