### PR TITLE
Fix typo in description of EPMD_DUMP_REQ response

### DIFF
--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -364,14 +364,14 @@ If Result > 0, the packet only consists of [119, Result].
 	  NodeInfo is, as expressed in Erlang:
 	</p>
 	<code>
-	io:format("active name     ~ts at port ~p, fd = ~p ~n",
+	io:format("active name     ~ts at port ~p, fd = ~p~n",
 	          [NodeName, Port, Fd]).
 	</code>
 	<p>
 	  or
 	</p>
 	<code>
-	io:format("old/unused name ~ts at port ~p, fd = ~p~n",
+	io:format("old/unused name ~ts at port ~p, fd = ~p ~n",
 	          [NodeName, Port, Fd]).
 	</code>
 


### PR DESCRIPTION
According to the source code, there is a space before the newline for unused
nodes and no space before the newline for active ones, see:

https://github.com/erlang/otp/blob/master/erts/epmd/src/epmd_srv.c#L847
https://github.com/erlang/otp/blob/master/erts/epmd/src/epmd_srv.c#L870

In current documentation, it is exactly opposite.
This commit fixes the documentation to match with source code.