### PR TITLE
Fix the EXIT message sent when a process dies

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -12397,13 +12397,14 @@ erts_continue_exit_process(Process *p)
     if (lnk) {
 	DeclareTmpHeap(tmp_heap,4,p);
 	Eterm exit_tuple;
+	Eterm rsn = reason == am_kill ? am_killed : reason;
 	Uint exit_tuple_sz;
 	Eterm* hp;
 
 	UseTmpHeap(4,p);
 	hp = &tmp_heap[0];
 
-	exit_tuple = TUPLE3(hp, am_EXIT, p->common.id, reason);
+	exit_tuple = TUPLE3(hp, am_EXIT, p->common.id, rsn);
 
 	exit_tuple_sz = size_object(exit_tuple);
 


### PR DESCRIPTION
A few days ago Robert Virding reported (see http://erlang.org/pipermail/erlang-bugs/2015-October/005092.html) a strange behaviour which can be briefly summarised in the following example:

```
1> erlang:process_flag(trap_exit, true).
false
2> erlang:spawn_link(fun() -> exit(kill) end).
<0.36.0>
3> flush().
Shell got {'EXIT',<0.36.0>,kill}
ok
4> erlang:spawn_link(fun() -> exit(self(), kill) end).
<0.39.0>
5> flush().                                           
Shell got {'EXIT',<0.39.0>,killed}
ok
```

Although in both instances the spawn process EXITs with reason 'kill', two different exit messages are delivered to the shell (one with reason 'kill' the other with reason 'killed').
This creates the illusion that different exit signals are generated depending how a process was killed.
The truth is quite different.

To send the exit signal exit/2 invokes [erts_]send_exit_signal() (from "erl_process.c") which in turn invokes erts_deliver_exit_message() which will actually build and send the exit message. However, before invoking erts_deliver_exit_message(), send_exit_signal() will change the reason into 'killed' if it is equal to the atom 'kill'.

When a process dies, no matter how, the same send_exit_signal() is invoked from doit_exit_link() for each linked peer process. However, to avoid building the same exit message again and again for each peer process, it is build once in doit_exit_link() and passed to send_exit_signal() in the exit_tuple argument. When send_exit_signal() is invoked with a valid Erlang term in exit_tuple, it will invoke send_exit_message() instead of erts_deliver_exit_message() which will use the exit_tuple as is as the exit message.

The bug is in doit_exit_link(), for when it builds the exit_tuple it doesn't make an exception for the case when reason is 'kill'. This patch makes the exception.
