### PR TITLE
Fix wrong instrumentation of binary comprehensions

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -1995,7 +1995,7 @@ munge_expr({lc,Line,Expr,Qs}, Vars) ->
     {{lc,Line,MungedExpr,MungedQs}, Vars3};
 munge_expr({bc,Line,Expr,Qs}, Vars) ->
     {bin,BLine,[{bin_element,EL,Val,Sz,TSL}|Es]} = Expr,
-    Expr2 = {bin,BLine,[{bin_element,EL,?BLOCK1(Val),Sz,TSL}|Es]},
+    Expr2 = {bin,BLine,[{bin_element,EL,Val,Sz,TSL}|Es]},
     {MungedExpr,Vars2} = munge_expr(Expr2, Vars),
     {MungedQs, Vars3} = munge_qualifiers(Qs, Vars2),
     {{bc,Line,MungedExpr,MungedQs}, Vars3};


### PR DESCRIPTION
When cover instruments binary comprehensions it's generating a
{block, ...} abstract code term inside a {bc, ...} term that is causing
the evaluation to fail at runtime. Removing the block statement
eliminates the error.

Repro steps:
   * create m.erl with content:
```
-module(m).
-compile([export_all]).

pad(A, L) ->
    P = << <<"#">> || _ <- lists:seq(1, L) >>,
    <<A/binary, P/binary>>.

test() ->
    pad(<<"hi">>, 2).
```
   * compile it with debug information:
`erlc +debug_info m.erl
`
   * run from the erlang shell:
```
 m:test(). % runs fine
 {ok, _} = cover:start().
 {ok, m} = cover:compile_beam("m.beam").
 m:test().

** exception error: bad argument
     in function  m:'-pad/2-lbc$^0/2-0-'/2 (m.erl, line 5)
     in call from m:pad/2 (m.erl, line 5)
```

examining the abstract code after cover instrumentation we see the following in the bc statement:
```
{bc,5,
    {bin,5,
      [{bin_element,5,
           {block,0,[{string,5,"#"}]},
           default,default}]},
    [{block,0,[{atom,5,true}]},
```

the {block,0,[{string,5,"#"}]} is the one causing the test to fail, not sure why though as this seems a valid statement, at least according to the Erlang Abstract Form document (http://www.erlang.org/doc/apps/erts/absform.html)