### PR TITLE
Fix erroneous use of __uint32_t

### DIFF
--- a/erts/emulator/sys/common/erl_poll.h
+++ b/erts/emulator/sys/common/erl_poll.h
@@ -140,7 +140,7 @@ struct erts_sys_fd_type {
 #endif
 
 #define ERTS_POLL_EV_E2N(EV) \
-  ((__uint32_t) (EV))
+  ((uint32_t) (EV))
 #define ERTS_POLL_EV_N2E(EV) \
   ((ErtsPollEvents) (EV))
 


### PR DESCRIPTION
The presence of this symbol is libc-specific. In particular, it is absent from [musl][1]. The correct solution is to use uint32_t.

[1]: http://www.musl-libc.org/