### PR TITLE
Show number of free words on heap in process_info()

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -276,6 +276,7 @@ atom grun
 atom group_leader
 atom have_dt_utag
 atom heap_block_size
+atom heap_free
 atom heap_size
 atom heap_sizes
 atom heap_type

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -596,6 +596,7 @@ static Eterm pi_args[] = {
     am_min_bin_vheap_size,
     am_current_location,
     am_current_stacktrace,
+    am_heap_free
 };
 
 #define ERTS_PI_ARGS ((int) (sizeof(pi_args)/sizeof(Eterm)))
@@ -643,6 +644,7 @@ pi_arg2ix(Eterm arg)
     case am_min_bin_vheap_size:			return 28;
     case am_current_location:			return 29;
     case am_current_stacktrace:			return 30;
+    case am_heap_free:                          return 31;
     default:					return -1;
     }
 }
@@ -662,6 +664,7 @@ static Eterm pi_1_keys[] = {
     am_group_leader,
     am_total_heap_size,
     am_heap_size,
+    am_heap_free,
     am_stack_size,
     am_reductions,
     am_garbage_collection,
@@ -1387,6 +1390,15 @@ process_info_aux(Process *BIF_P,
 	hp = HAlloc(BIF_P, 3);
 	res = erts_proc_get_error_handler(BIF_P);
 	break;
+
+    case am_heap_free: {
+        Uint hsz = 3;
+        Uint free_heap = HEAP_END(rp) - HEAP_TOP(rp);
+        (void) erts_bld_uint(NULL, &hsz, free_heap);
+        hp = HAlloc(BIF_P, hsz);
+        res = erts_bld_uint(&hp, NULL, free_heap);
+        break;
+    }
 
     case am_heap_size: {
 	Uint hsz = 3;


### PR DESCRIPTION
I am investigating garbage generation in an application, and added a line to process_info() to follow the heap impact from different functions.

This commit adds a line named `heap_free` with a diff between `HEAP_END` and `HEAP_TOP`, next to `heap_size` in the process_info() output.

`> process_info(Pid).`
`...`
`{heap_size,233},`
`{heap_free,207},`
 `{stack_size,1}`
`...`