### PR TITLE
Use full list of bindings when matching on map keys

### DIFF
--- a/lib/stdlib/src/erl_eval.erl
+++ b/lib/stdlib/src/erl_eval.erl
@@ -1184,7 +1184,7 @@ match_tuple([], _, _, Bs, _BBs) ->
 
 match_map([{map_field_exact, _, K, V}|Fs], Map, Bs0, BBs) ->
     Vm = try
-	{value, Ke, _} = expr(K, Bs0),
+	{value, Ke, _} = expr(K, BBs),
 	maps:get(Ke,Map)
     catch error:_ ->
 	throw(nomatch)

--- a/lib/stdlib/test/erl_eval_SUITE.erl
+++ b/lib/stdlib/test/erl_eval_SUITE.erl
@@ -1483,6 +1483,16 @@ eep43(Config) when is_list(Config) ->
 	  "    #{ K1 := 1, K2 := 2, K3 := 3, {2,2} := 4} = Map "
 	  "end.",
 	  #{ 1 => 1, <<42:301>> => 2, {3,<<42:301>>} => 3, {2,2} => 4}),
+    check(fun () ->
+		X = key,
+		(fun(#{X := value}) -> true end)(#{X => value})
+	  end,
+	  "begin "
+	  "    X = key, "
+	  "    (fun(#{X := value}) -> true end)(#{X => value}) "
+	  "end.",
+	  true),
+
     error_check("[camembert]#{}.", {badmap,[camembert]}),
     error_check("[camembert]#{nonexisting:=v}.", {badmap,[camembert]}),
     error_check("#{} = 1.", {badmatch,1}),


### PR DESCRIPTION
Prior to this patch, the following code would not eval:

    X = key,
    (fun(#{X := value}) -> true end)(#{X => value})

That's because the key evaluation was using the new
list of bindings introduced on every anonymous fun.
Since keys only match on values defined prior to the
pattern and do not introduce any new binding, we must
use the full and original list of binding.

The example above works fine in compiled code but
fails when code is evaluated.