### PR TITLE
Adjust shutdown strategies for distribution over TLS

### DIFF
--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -29,7 +29,7 @@
 
 childspecs() ->
     {ok, [{ssl_dist_sup,{ssl_dist_sup, start_link, []},
-	   permanent, 2000, worker, [ssl_dist_sup]}]}.
+	   permanent, infinity, supervisor, [ssl_dist_sup]}]}.
 
 select(Node) ->
     case split_node(atom_to_list(Node), $@, []) of

--- a/lib/ssl/src/ssl_dist_sup.erl
+++ b/lib/ssl/src/ssl_dist_sup.erl
@@ -69,7 +69,7 @@ connection_manager_child_spec() ->
     Name = ssl_connection_dist,  
     StartFunc = {tls_connection_sup, start_link_dist, []},
     Restart = permanent, 
-    Shutdown = 4000,
+    Shutdown = infinity,
     Modules = [tls_connection_sup],
     Type = supervisor,
     {Name, StartFunc, Restart, Shutdown, Type, Modules}.


### PR DESCRIPTION
Change `ssl_dist_sup` to be considered as a supervisor with infinite shutdown time.

Change the `ssl_connection_dist` instance of `tls_connection_sup` to have infinite shutdown time.

This avoids spurious error messages when shutting down a node that uses distribution over TLS.