### PR TITLE
fix incorrect number of seconds in the 24h_in_sec macro

### DIFF
--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -78,6 +78,9 @@
 -define(ALL_DATAGRAM_SUPPORTED_VERSIONS, ['dtlsv1.2', dtlsv1]).
 -define(MIN_DATAGRAM_SUPPORTED_VERSIONS, ['dtlsv1.2', dtlsv1]).
 
+-define('24H_in_msec', 86400000).
+-define('24H_in_sec', 86400).
+
 -record(ssl_options, {
 	  protocol    :: tls | dtls,
 	  versions    :: [ssl_record:ssl_version()], %% ssl_record:atom_version() in API

--- a/lib/ssl/src/ssl_manager.erl
+++ b/lib/ssl/src/ssl_manager.erl
@@ -57,8 +57,6 @@
 	  clear_pem_cache 
 	 }).
 
--define('24H_in_msec', 86400000).
--define('24H_in_sec', 86400).
 -define(GEN_UNIQUE_ID_MAX_TRIES, 10).
 -define(SESSION_VALIDATION_INTERVAL, 60000).
 -define(CLEAR_PEM_CACHE, 120000).

--- a/lib/ssl/src/ssl_session.erl
+++ b/lib/ssl/src/ssl_session.erl
@@ -31,8 +31,6 @@
 %% Internal application API
 -export([is_new/2, client_id/4, server_id/6, valid_session/2]).
 
--define('24H_in_sec', 8640).
-
 -type seconds()   :: integer(). 
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
The previous commit, merged here: https://github.com/erlang/otp/pull/386  fixed the macro only in one place. I moved the macro to the header file, which is included in both files. As far as I understand, with this bug, the server_id function was filtering out valid sessions, and as a result new sessions were created.  

By the way, I wonder if 24h is a sane default. I encountered an issue similar to this one:  https://github.com/ninenines/gun/issues/68. When I changed the session_lifetime option to 10 minutes, the memory stopped "leaking". I was making https requests to a service deployed on heroku. Unfortunately, I don't have the configuration details, but my guess is the server side has a much smaller session_lifetime.

As a result, when session resumption fails the session is not removed from the cache(https://github.com/erlang/otp/commit/2b31edf742b3d9236dfc35b947b3b0c356010236). I suspect that it was performing better under R16 because of the 2.4h lifetime.Correct me if I'm wrong, as I might have missed something, this is my first time digging in the otp/ssl library.  

