### PR TITLE
Prettify default error_logger output somewhat

### DIFF
--- a/lib/kernel/src/error_logger.erl
+++ b/lib/kernel/src/error_logger.erl
@@ -434,5 +434,82 @@ add_node(X, Pid) ->
 
 %% Can't do io_lib:format
 
-display2(Tag,F,A) ->
-    erlang:display({error_logger,Tag,F,A}).
+display2({{_Y,_Mo,_D},{_H,_Mi,_S}} = Date, F, A) ->
+    display_date(Date),
+    display3(string_p(F), F, A).
+
+display_date({{Y,Mo,D},{H,Mi,S}}) ->
+    erlang:display_string(
+      integer_to_list(Y) ++ "-" ++
+	  two_digits(Mo) ++ "-" ++
+	  two_digits(D)  ++ " " ++
+	  two_digits(H)  ++ ":" ++
+	  two_digits(Mi) ++ ":" ++
+	  two_digits(S)  ++ " ").
+
+two_digits(N) when 0 =< N, N =< 9 ->
+    [$0, $0 + N];
+two_digits(N) ->
+    integer_to_list(N).
+
+display3(true, F, A) ->
+    %% Format string with arguments
+    erlang:display_string(F ++ "\n"),
+    [begin
+	 erlang:display_string("\t"),
+	 erlang:display(Arg)
+     end || Arg <- A],
+    ok;
+display3(false, Atom, A) when is_atom(Atom) ->
+    %% The widest atom seems to be 'supervisor_report' at 17.
+    ColumnWidth = 20,
+    AtomString = atom_to_list(Atom),
+    AtomLength = length(AtomString),
+    Padding = lists:duplicate(ColumnWidth - AtomLength, $\s),
+    erlang:display_string(AtomString ++ Padding),
+    display4(A);
+display3(_, F, A) ->
+    erlang:display({F, A}).
+
+display4([A, []]) ->
+    %% Not sure why crash reports look like this.
+    display4(A);
+display4(A = [_|_]) ->
+    case lists:all(fun({Key,_Value}) -> is_atom(Key); (_) -> false end, A) of
+	true ->
+	    erlang:display_string("\n"),
+	    lists:foreach(
+	      fun({Key, Value}) ->
+		      erlang:display_string(
+			"    " ++
+			    atom_to_list(Key) ++
+			    ": "),
+		      erlang:display(Value)
+	      end, A);
+	false ->
+	    erlang:display(A)
+    end;
+display4(A) ->
+    erlang:display(A).
+
+string_p([]) ->
+    false;
+string_p(Term) ->
+    string_p1(Term).
+
+string_p1([H|T]) when is_integer(H), H >= $\s, H < 255 ->
+    string_p1(T);
+string_p1([$\n|T]) -> string_p1(T);
+string_p1([$\r|T]) -> string_p1(T);
+string_p1([$\t|T]) -> string_p1(T);
+string_p1([$\v|T]) -> string_p1(T);
+string_p1([$\b|T]) -> string_p1(T);
+string_p1([$\f|T]) -> string_p1(T);
+string_p1([$\e|T]) -> string_p1(T);
+string_p1([H|T]) when is_list(H) ->
+    case string_p1(H) of
+	true -> string_p1(T);
+	_    -> false
+    end;
+string_p1([]) -> true;
+string_p1(_) ->  false.


### PR DESCRIPTION
The default error logger, the one in use before a more sophisticated
error logger can be installed, has rather terse output, in part because
it cannot rely on io:format.  This patch attempts to improve the error
logger within that constraint:

- Print timestamps as YYYY-MM-DD HH:MM:SS
- For error reports with format strings, just print the format string
  and the format arguments on separate lines
- For error reports with tuple lists, print each pair on a separate line

For example, when starting a node with a duplicate node name, the output looks like this without this change:

```
{error_logger,{{2015,10,23},{15,0,58}},"Protocol: ~tp: the name foo@poki-sona-sin seems to be in use by another Erlang node",["inet_tcp"]}
{error_logger,{{2015,10,23},{15,0,58}},crash_report,[[{initial_call,{net_kernel,init,['Argument__1']}},{pid,<0.20.0>},{registered_name,[]},{error_info,{exit,{error,badarg},[{gen_server,init_it,6,[{file,"gen_server.erl"},{line,322}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,237}]}]}},{ancestors,[net_sup,kernel_sup,<0.10.0>]},{messages,[]},{links,[#Port<0.52>,<0.17.0>]},{dictionary,[{longnames,false}]},{trap_exit,true},{status,running},{heap_size,376},{stack_size,27},{reductions,740}],[]]}
{error_logger,{{2015,10,23},{15,0,58}},supervisor_report,[{supervisor,{local,net_sup}},{errorContext,start_error},{reason,{'EXIT',nodistribution}},{offender,[{pid,undefined},{name,net_kernel},{mfargs,{net_kernel,start_link,[[foo,shortnames]]}},{restart_type,permanent},{shutdown,2000},{child_type,worker}]}]}
{error_logger,{{2015,10,23},{15,0,58}},supervisor_report,[{supervisor,{local,kernel_sup}},{errorContext,start_error},{reason,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}},{offender,[{pid,undefined},{name,net_sup},{mfargs,{erl_distribution,start_link,[]}},{restart_type,permanent},{shutdown,infinity},{child_type,supervisor}]}]}
{error_logger,{{2015,10,23},{15,0,58}},crash_report,[[{initial_call,{application_master,init,['Argument__1','Argument__2','Argument__3','Argument__4']}},{pid,<0.9.0>},{registered_name,[]},{error_info,{exit,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}},[{application_master,init,4,[{file,"application_master.erl"},{line,133}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,237}]}]}},{ancestors,[<0.8.0>]},{messages,[{'EXIT',<0.10.0>,normal}]},{links,[<0.8.0>,<0.7.0>]},{dictionary,[]},{trap_exit,true},{status,running},{heap_size,376},{stack_size,27},{reductions,117}],[]]}
{error_logger,{{2015,10,23},{15,0,58}},std_info,[{application,kernel},{exited,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}}},{type,permanent}]}
{"Kernel pid terminated",application_controller,"{application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}}}"}

Crash dump was written to: erl_crash.dump
Kernel pid terminated (application_controller) ({application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{k
```

And with this change:

```
2015-10-23 15:00:48 Protocol: ~tp: the name foo@poki-sona-sin seems to be in use by another Erlang node
	"inet_tcp"
2015-10-23 15:00:48 crash_report        
    initial_call: {net_kernel,init,['Argument__1']}
    pid: <0.20.0>
    registered_name: []
    error_info: {exit,{error,badarg},[{gen_server,init_it,6,[{file,"gen_server.erl"},{line,322}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,237}]}]}
    ancestors: [net_sup,kernel_sup,<0.10.0>]
    messages: []
    links: [#Port<0.52>,<0.17.0>]
    dictionary: [{longnames,false}]
    trap_exit: true
    status: running
    heap_size: 376
    stack_size: 27
    reductions: 740
2015-10-23 15:00:48 supervisor_report   
    supervisor: {local,net_sup}
    errorContext: start_error
    reason: {'EXIT',nodistribution}
    offender: [{pid,undefined},{name,net_kernel},{mfargs,{net_kernel,start_link,[[foo,shortnames]]}},{restart_type,permanent},{shutdown,2000},{child_type,worker}]
2015-10-23 15:00:48 supervisor_report   
    supervisor: {local,kernel_sup}
    errorContext: start_error
    reason: {shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}
    offender: [{pid,undefined},{name,net_sup},{mfargs,{erl_distribution,start_link,[]}},{restart_type,permanent},{shutdown,infinity},{child_type,supervisor}]
2015-10-23 15:00:48 crash_report        
    initial_call: {application_master,init,['Argument__1','Argument__2','Argument__3','Argument__4']}
    pid: <0.9.0>
    registered_name: []
    error_info: {exit,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}},[{application_master,init,4,[{file,"application_master.erl"},{line,133}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,237}]}]}
    ancestors: [<0.8.0>]
    messages: [{'EXIT',<0.10.0>,normal}]
    links: [<0.8.0>,<0.7.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 376
    stack_size: 27
    reductions: 117
2015-10-23 15:00:48 std_info            
    application: kernel
    exited: {{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}}
    type: permanent
{"Kernel pid terminated",application_controller,"{application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}}}"}

Crash dump was written to: erl_crash.dump
Kernel pid terminated (application_controller) ({application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{k
```