### PR TITLE
In ssl_tls_dist_proxy, pass along EPMD registration errors

### DIFF
--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -66,9 +66,13 @@ handle_call({listen, Name}, _From, State) ->
 	    {ok, TcpAddress} = get_tcp_address(Socket),
 	    {ok, WorldTcpAddress} = get_tcp_address(World),
 	    {_,Port} = WorldTcpAddress#net_address.address,
-	    {ok, Creation} = erl_epmd:register_node(Name, Port),
-	    {reply, {ok, {Socket, TcpAddress, Creation}},
-	     State#state{listen={Socket, World}}};
+	    case erl_epmd:register_node(Name, Port) of
+		{ok, Creation} ->
+		    {reply, {ok, {Socket, TcpAddress, Creation}},
+		     State#state{listen={Socket, World}}};
+		{error, _} = Error ->
+		    {reply, Error, State}
+	    end;
 	Error ->
 	    {reply, Error, State}
     end;


### PR DESCRIPTION
The `duplicate_name` error returned from `erl_epmd:register_node` elicits a
particularly precise error message from `net_kernel`, so let's pass it
along to our caller.

Not doing this for the other things that could go wrong here, since for
those having the line number will likely aid debugging.