### PR TITLE
In ssl_tls_dist_proxy, use nodelay for all sockets

### DIFF
--- a/lib/ssl/test/ssl_dist_SUITE.erl
+++ b/lib/ssl/test/ssl_dist_SUITE.erl
@@ -43,7 +43,7 @@ suite() ->
     [{ct_hooks,[ts_install_cth]}].
 
 all() ->
-    [basic, payload, plain_options, plain_verify_options].
+    [basic, payload, plain_options, plain_verify_options, nodelay_option].
 
 groups() ->
     [].
@@ -255,6 +255,17 @@ plain_verify_options(Config) when is_list(Config) ->
     stop_ssl_node(NH1),
     stop_ssl_node(NH2),
     success(Config).
+%%--------------------------------------------------------------------
+nodelay_option() ->
+    [{doc,"Test specifying dist_nodelay option"}].
+nodelay_option(Config) ->
+    try
+	%% The default is 'true', so try setting it to 'false'.
+	application:set_env(kernel, dist_nodelay, false),
+	basic(Config)
+    after
+	application:unset_env(kernel, dist_nodelay)
+    end.
 
 %%--------------------------------------------------------------------
 %%% Internal functions -----------------------------------------------


### PR DESCRIPTION
On Linux, not using this option leads to occasional latency of 40 ms,
the default delay for Nagle's algorithm.  Let's ensure packets flow
without delays by disabling that.

To reproduce this, first create a certificate and a private key:

```
openssl req \
    -new \
    -newkey rsa:4096 \
    -days 365 \
    -nodes \
    -x509 \
    -subj "/CN=foo" \
    -keyout erldist.key \
    -out erldist.cert
```

Set ERL_FLAGS to enable distribution over TLS:

```
export ERL_FLAGS="-pa $ERL_TOP/lib/ssl/ebin/ -proto_dist inet_tls \
      -ssl_dist_opt server_certfile erldist.cert server_keyfile erldist.key"
```

Start two nodes:

```
erl -sname foo@localhost
erl -sname bar@localhost
```

Make a sequence of RPC calls from one node to the other:

```
Node = foo@localhost.
[element(1, timer:tc(rpc, call, [Node, erlang, self, []]))
 || _ <- lists:seq(1,5)].
```

(Try this in both directions, as the settings for the "client" and the
"server" can be different.)

Without this change, most of the calls will take around 40 milliseconds:

```
[156164,40342,39854,39993,39958]
```

With this change, the latency drops to less than a millisecond:

```
[47541,275,247,244,245]
```

(The first call takes longer, to set up the connection and do the TLS
handshake.)