### PR TITLE
Fix weird strncmp length in erl_interface example

### DIFF
--- a/system/doc/tutorial/ei.c
+++ b/system/doc/tutorial/ei.c
@@ -21,7 +21,7 @@ int main() {
     
     if (strncmp(ERL_ATOM_PTR(fnp), "foo", 3) == 0) {
       res = foo(ERL_INT_VALUE(argp));
-    } else if (strncmp(ERL_ATOM_PTR(fnp), "bar", 17) == 0) {
+    } else if (strncmp(ERL_ATOM_PTR(fnp), "bar", 3) == 0) {
       res = bar(ERL_INT_VALUE(argp));
     }
 


### PR DESCRIPTION
Not sure why it was 17 there, especially considering the explanations above have the same lines with 3 instead. So I put 3 in the end snippet too.