### PR TITLE
ssl: option to override TLS record layer version

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -538,6 +538,13 @@ fun(srp, Username :: string(), UserState :: term()) ->
 	 be supported by the server for the prevention to work.
 	</p></warning>
       </item>
+      <tag>record_layer_version</tag>
+      <item>
+        <p>This option can be used for backwards compatibility with older
+        servers as it is specified in section 1 of Appendix E in RFC 5246.</p>
+        <p>It provides a way to specify record layer version number different
+        from the highest protocol version which is used by default.</p>
+      </item>
       
     </taglist>
    </section>

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -81,6 +81,7 @@
 -record(ssl_options, {
 	  protocol    :: tls | dtls,
 	  versions    :: [ssl_record:ssl_version()], %% ssl_record:atom_version() in API
+	  record_layer_version :: undefined | 'tlsv1.2' | 'tlsv1.1' | tlsv1 | sslv3,
 	  verify      :: verify_none | verify_peer,
 	  verify_fun,  %%:: fun(CertVerifyErrors::term()) -> boolean(),
 	  partial_chain       :: fun(),

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -167,7 +167,7 @@ hello(start, #state{host = Host, port = Port, role = client,
     Hello = tls_handshake:client_hello(Host, Port, ConnectionStates0, SslOpts,
 				       Cache, CacheCb, Renegotiation, Cert),
     
-    Version = Hello#client_hello.client_version,
+    Version = Hello#client_hello.record_layer_version,
     Handshake0 = ssl_handshake:init_handshake_history(),
     {BinMsg, ConnectionStates, Handshake} =
         encode_handshake(Hello, Version, ConnectionStates0, Handshake0),

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -49,11 +49,13 @@
 %%--------------------------------------------------------------------
 client_hello(Host, Port, ConnectionStates,
 	     #ssl_options{versions = Versions,
+			  record_layer_version = OptsRecordVersion,
 			  ciphers = UserSuites,
 			  fallback = Fallback
 			 } = SslOpts,
 	     Cache, CacheCb, Renegotiation, OwnCert) ->
     Version = tls_record:highest_protocol_version(Versions),
+    RecordLayerVersion = record_layer_version(Version, OptsRecordVersion),
     Pending = ssl_record:pending_connection_state(ConnectionStates, read),
     SecParams = Pending#connection_state.security_parameters,
     AvailableCipherSuites = ssl_handshake:available_suites(UserSuites, Version), 
@@ -70,6 +72,7 @@ client_hello(Host, Port, ConnectionStates,
     Id = ssl_session:client_id({Host, Port, SslOpts}, Cache, CacheCb, OwnCert),    
     #client_hello{session_id = Id,
 		  client_version = Version,
+		  record_layer_version = RecordLayerVersion,
 		  cipher_suites = CipherSuites,
 		  compression_methods = ssl_record:compressions(),
 		  random = SecParams#security_parameters.client_random,
@@ -269,3 +272,7 @@ handle_server_hello_extensions(Version, SessionId, Random, CipherSuite,
 	    {Version, SessionId, ConnectionStates, ProtoExt, Protocol}
     end.
 
+record_layer_version(HighestVersion, undefined) ->
+    HighestVersion;
+record_layer_version(_, OptsVersion) ->
+    OptsVersion.

--- a/lib/ssl/src/tls_handshake.hrl
+++ b/lib/ssl/src/tls_handshake.hrl
@@ -30,6 +30,7 @@
 
 -record(client_hello, {
 	  client_version,
+	  record_layer_version,
 	  random,             
 	  session_id,          % opaque SessionID<0..32>
 	  cipher_suites,       % cipher_suites<2..2^16-1>


### PR DESCRIPTION
`ssl` application should allow override record layer version used when sending client hello message as
a way to be more backwards compatible with older servers.
Corresponding RFC section is https://tools.ietf.org/html/rfc5246#appendix-E and e.g. https://github.com/openssl/openssl/blob/master/ssl/s3_clnt.c#L799 shows comments from OpenSSL comments on that matter.
As an example https://ssl0.ovh.net/fr/ opens with no problem with Chrome or Firefox and curl or python `requests` (with OpenSSL) have no troubles accessing it. And `httpc` fails to retrieve that page because of `{tls_alert,"protocol version"}` (because the server does not like TLS 1.2 used by default)