### PR TITLE
Add option for using TLS distribution over IPv6

### DIFF
--- a/lib/ssl/doc/src/ssl_distribution.xml
+++ b/lib/ssl/doc/src/ssl_distribution.xml
@@ -271,4 +271,27 @@ Eshell V5.0  (abort with ^G)
     <p>The <c>init:get_arguments()</c> call verifies that the correct
       arguments are supplied to the emulator.</p>
   </section>
+
+  <section>
+    <title>Using SSL distribution over IPv6</title>
+    <p>It is possible to use SSL distribution over IPv6 instead of
+    IPv4. To do this, pass the option <c>-proto_dist inet6_tls</c>
+    instead of <c>-proto_dist inet_tls</c> when starting Erlang,
+    either on the command line or in the <c>ERL_FLAGS</c> environment
+    variable.</p>
+
+    <p>An example command line with this option would look like this:</p>
+    <code type="none">
+$ erl -boot /home/me/ssl/start_ssl -proto_dist inet6_tls
+  -ssl_dist_opt server_certfile "/home/me/ssl/erlserver.pem"
+  -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true
+  -sname ssl_test
+Erlang (BEAM) emulator version 5.0 [source]
+
+Eshell V5.0  (abort with ^G)
+(ssl_test@myhost)1>     </code>
+
+    <p>A node started in this way will only be able to communicate with
+    other nodes using SSL distribution over IPv6.</p>
+  </section>
 </chapter>

--- a/lib/ssl/src/Makefile
+++ b/lib/ssl/src/Makefile
@@ -51,6 +51,7 @@ MODULES= \
 	ssl_dist_sup\
 	ssl_sup \
 	inet_tls_dist \
+	inet6_tls_dist \
 	ssl_certificate\
 	ssl_pkix_db\
 	ssl_cipher \

--- a/lib/ssl/src/inet6_tls_dist.erl
+++ b/lib/ssl/src/inet6_tls_dist.erl
@@ -1,0 +1,46 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2015. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+-module(inet6_tls_dist).
+
+-export([childspecs/0, listen/1, accept/1, accept_connection/5,
+	 setup/5, close/1, select/1]).
+
+childspecs() ->
+    inet_tls_dist:childspecs().
+
+select(Node) ->
+    inet_tls_dist:gen_select(inet6_tcp, Node).
+
+listen(Name) ->
+    inet_tls_dist:gen_listen(inet6_tcp, Name).
+
+accept(Listen) ->
+    inet_tls_dist:gen_accept(inet6_tcp, Listen).
+
+accept_connection(AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
+    inet_tls_dist:gen_accept_connection(inet6_tcp, AcceptPid, Socket, MyNode, Allowed, SetupTime).
+
+setup(Node, Type, MyNode, LongOrShortNames,SetupTime) ->
+    inet_tls_dist:gen_setup(inet6_tcp, Node, Type, MyNode, LongOrShortNames,SetupTime).
+
+close(Socket) ->
+    inet_tls_dist:close(Socket).

--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -24,6 +24,10 @@
 -export([childspecs/0, listen/1, accept/1, accept_connection/5,
 	 setup/5, close/1, select/1, is_node_name/1]).
 
+%% Generalized dist API
+-export([gen_listen/2, gen_accept/2, gen_accept_connection/6,
+	 gen_setup/6, gen_select/2]).
+
 -include_lib("kernel/include/net_address.hrl").
 -include_lib("kernel/include/dist.hrl").
 -include_lib("kernel/include/dist_util.hrl").
@@ -33,9 +37,15 @@ childspecs() ->
 	   permanent, infinity, supervisor, [ssl_dist_sup]}]}.
 
 select(Node) ->
+    gen_select(inet_tcp, Node).
+
+gen_select(Driver, Node) ->
     case split_node(atom_to_list(Node), $@, []) of
-	[_,_Host] -> 
-	    true;
+	[_, Host] ->
+	    case inet:getaddr(Host, Driver:family()) of
+		{ok, _} -> true;
+		_ -> false
+	    end;
 	_ -> 
 	    false
     end.
@@ -46,23 +56,35 @@ is_node_name(_) ->
     false.
 
 listen(Name) ->
-    ssl_tls_dist_proxy:listen(Name).
+    gen_listen(inet_tcp, Name).
+
+gen_listen(Driver, Name) ->
+    ssl_tls_dist_proxy:listen(Driver, Name).
 
 accept(Listen) ->
-    ssl_tls_dist_proxy:accept(Listen).
+    gen_accept(inet_tcp, Listen).
+
+gen_accept(Driver, Listen) ->
+    ssl_tls_dist_proxy:accept(Driver, Listen).
 
 accept_connection(AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
+    gen_accept_connection(inet_tcp, AcceptPid, Socket, MyNode, Allowed, SetupTime).
+
+gen_accept_connection(Driver, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
     Kernel = self(),
-    spawn_link(fun() -> do_accept(Kernel, AcceptPid, Socket, 
+    spawn_link(fun() -> do_accept(Driver, Kernel, AcceptPid, Socket,
 				  MyNode, Allowed, SetupTime) end).
 
 setup(Node, Type, MyNode, LongOrShortNames,SetupTime) ->
+    gen_setup(inet_tcp, Node, Type, MyNode, LongOrShortNames,SetupTime).
+
+gen_setup(Driver, Node, Type, MyNode, LongOrShortNames,SetupTime) ->
     Kernel = self(),
-    spawn_opt(fun() -> do_setup(Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) end, [link, {priority, max}]).
+    spawn_opt(fun() -> do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) end, [link, {priority, max}]).
 		   
-do_setup(Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
-    [Name, Address] = splitnode(Node, LongOrShortNames),
-    case inet:getaddr(Address, inet) of
+do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
+    [Name, Address] = splitnode(Driver, Node, LongOrShortNames),
+    case inet:getaddr(Address, Driver:family()) of
 	{ok, Ip} ->
 	    Timer = dist_util:start_timer(SetupTime),
 	    case erl_epmd:port_please(Name, Ip) of
@@ -70,7 +92,7 @@ do_setup(Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 		    ?trace("port_please(~p) -> version ~p~n", 
 			   [Node,Version]),
 		    dist_util:reset_timer(Timer),
-		    case ssl_tls_dist_proxy:connect(Ip, TcpPort) of
+		    case ssl_tls_dist_proxy:connect(Driver, Ip, TcpPort) of
 			{ok, Socket} ->
 			    HSData = connect_hs_data(Kernel, Node, MyNode, Socket, 
 						     Timer, Version, Ip, TcpPort, Address,
@@ -99,12 +121,12 @@ close(Socket) ->
     gen_tcp:close(Socket),
     ok.
 
-do_accept(Kernel, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
+do_accept(Driver, Kernel, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
     process_flag(priority, max),
     receive
 	{AcceptPid, controller} ->
 	    Timer = dist_util:start_timer(SetupTime),
-	    case check_ip(Socket) of
+	    case check_ip(Driver, Socket) of
 		true ->
 		    HSData = accept_hs_data(Kernel, MyNode, Socket, Timer, Allowed),
 		    dist_util:handshake_other_started(HSData);
@@ -118,12 +140,12 @@ do_accept(Kernel, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
 %% Do only accept new connection attempts from nodes at our
 %% own LAN, if the check_ip environment parameter is true.
 %% ------------------------------------------------------------
-check_ip(Socket) ->
+check_ip(Driver, Socket) ->
     case application:get_env(check_ip) of
 	{ok, true} ->
 	    case get_ifs(Socket) of
 		{ok, IFs, IP} ->
-		    check_ip(IFs, IP);
+		    check_ip(Driver, IFs, IP);
 		_ ->
 		    ?shutdown(no_node)
 	    end;
@@ -142,37 +164,21 @@ get_ifs(Socket) ->
 	    Error
     end.
 
-check_ip([{OwnIP, _, Netmask}|IFs], PeerIP) ->
-    case {mask(Netmask, PeerIP), mask(Netmask, OwnIP)} of
+check_ip(Driver, [{OwnIP, _, Netmask}|IFs], PeerIP) ->
+    case {Driver:mask(Netmask, PeerIP), Driver:mask(Netmask, OwnIP)} of
 	{M, M} -> true;
 	_      -> check_ip(IFs, PeerIP)
     end;
-check_ip([], PeerIP) ->
+check_ip(_Driver, [], PeerIP) ->
     {false, PeerIP}.
-
-mask({M1,M2,M3,M4}, {IP1,IP2,IP3,IP4}) ->
-    {M1 band IP1,
-     M2 band IP2,
-     M3 band IP3,
-     M4 band IP4};
-
-mask({M1,M2,M3,M4, M5, M6, M7, M8}, {IP1,IP2,IP3,IP4, IP5, IP6, IP7, IP8}) ->
-    {M1 band IP1,
-     M2 band IP2,
-     M3 band IP3,
-     M4 band IP4,
-     M5 band IP5,
-     M6 band IP6,
-     M7 band IP7,
-     M8 band IP8}.
 
 
 %% If Node is illegal terminate the connection setup!!
-splitnode(Node, LongOrShortNames) ->
+splitnode(Driver, Node, LongOrShortNames) ->
     case split_node(atom_to_list(Node), $@, []) of
 	[Name|Tail] when Tail =/= [] ->
 	    Host = lists:append(Tail),
-	    check_node(Name, Node, Host, LongOrShortNames);
+	    check_node(Driver, Name, Node, Host, LongOrShortNames);
 	[_] ->
 	    error_logger:error_msg("** Nodename ~p illegal, no '@' character **~n",
 		      [Node]),
@@ -182,15 +188,20 @@ splitnode(Node, LongOrShortNames) ->
 	    ?shutdown(Node)
     end.
 
-check_node(Name, Node, Host, LongOrShortNames) ->
+check_node(Driver, Name, Node, Host, LongOrShortNames) ->
     case split_node(Host, $., []) of
 	[_] when LongOrShortNames == longnames ->
-	    error_logger:error_msg("** System running to use "
-		      "fully qualified "
-		      "hostnames **~n"
-		      "** Hostname ~s is illegal **~n",
-		      [Host]),
-	    ?shutdown(Node);
+	    case Driver:parse_address(Host) of
+		{ok, _} ->
+		    [Name, Host];
+		_ ->
+		    error_logger:error_msg("** System running to use "
+					   "fully qualified "
+					   "hostnames **~n"
+					   "** Hostname ~s is illegal **~n",
+					   [Host]),
+		    ?shutdown(Node)
+	    end;
 	[_, _ | _] when LongOrShortNames == shortnames ->
 	    error_logger:error_msg("** System NOT running to use fully qualified "
 			      "hostnames **~n"

--- a/lib/ssl/src/ssl.app.src
+++ b/lib/ssl/src/ssl.app.src
@@ -31,6 +31,7 @@
 	       ssl_listen_tracker_sup,	
 	       %% Erlang Distribution over SSL/TLS
 	       inet_tls_dist,
+	       inet6_tls_dist,
 	       ssl_tls_dist_proxy,
 	       ssl_dist_sup,
 	       %% SSL/TLS session handling


### PR DESCRIPTION
Add the `-ssl_dist_ipv6` option for using IPv6 sockets for TLS distribution. Not sure if this is the best option name; I'm open to other proposals.

This patch depends on the patch in #871, though they are logically unrelated. I could separate this one out if desired.