### PR TITLE
Avoid crash for SSL connections with nonexistent keyfile

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -1781,7 +1781,7 @@ handle_trusted_certs_db(#state{ssl_options = #ssl_options{cacertfile = <<>>, cac
     ok;
 handle_trusted_certs_db(#state{cert_db_ref = Ref,
 			       cert_db = CertDb,
-			       ssl_options = #ssl_options{cacertfile = <<>>}}) ->
+			       ssl_options = #ssl_options{cacertfile = <<>>}}) when CertDb =/= undefined ->
     %% Certs provided as DER directly can not be shared
     %% with other connections and it is safe to delete them when the connection ends.
     ssl_pkix_db:remove_trusted_certs(Ref, CertDb);


### PR DESCRIPTION
Starting an SSL connection with a nonexistent keyfile will obviously
return an error:

    > ssl:connect("www.google.com", 443, [{keyfile, "nonexistent"}]).
    {error,{options,{keyfile,"nonexistent",{error,enoent}}}}

But it also generates an error report with the following backtrace:

    ** Reason for termination =
    ** {badarg,[{ets,select_delete,
                     [undefined,[{{{undefined,'_','_'},'_'},[],[true]}]],
                     []},
                {ets,match_delete,2,[{file,"ets.erl"},{line,700}]},
                {ssl_pkix_db,remove_certs,2,[{file,"ssl_pkix_db.erl"},{line,243}]},
                {ssl_connection,terminate,3,
                                [{file,"ssl_connection.erl"},{line,941}]},
                {tls_connection,terminate,3,
                                [{file,"tls_connection.erl"},{line,335}]},
                {gen_fsm,terminate,7,[{file,"gen_fsm.erl"},{line,610}]},
                {gen_fsm,handle_msg,7,[{file,"gen_fsm.erl"},{line,532}]},
                {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}

This happens because the ssl_connection process receives its cert_db
while handling the {start, Timeout} message, but if the handshake
fails, the cert_db will never be inserted into the state data, and the
terminate function will use 'undefined' as an ETS table name.

Avoid this by checking for 'undefined' in the handle_trusted_certs_db
function.