### PR TITLE
jinterface: OtpInputStream: support external funs in read_any

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpInputStream.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpInputStream.java
@@ -1243,6 +1243,9 @@ public class OtpInputStream extends ByteArrayInputStream {
         case OtpExternal.funTag:
             return new OtpErlangFun(this);
 
+	case OtpExternal.externalFunTag:
+	    return new OtpErlangExternalFun(this);
+
         default:
             throw new OtpErlangDecodeException("Uknown data type: " + tag);
         }


### PR DESCRIPTION
Calling ```OtpInputStream.read_any()```  on a stream containing an external function term resulted in 
```
com.ericsson.otp.erlang.OtpErlangDecodeException: Uknown data type: 113
    at com.ericsson.otp.erlang.OtpInputStream.read_any(OtpInputStream.java:1247)
```