### PR TITLE
SSH subsystem typo

### DIFF
--- a/lib/ssh/src/ssh_connection.erl
+++ b/lib/ssh/src/ssh_connection.erl
@@ -662,7 +662,7 @@ handle_msg(#ssh_msg_channel_request{recipient_channel = ChannelId,
     ReplyMsg =  {subsystem, ChannelId, WantReply, binary_to_list(SsName)},
     
     try
-	{ok, Pid} = start_subsytem(SsName, Connection, Channel0, ReplyMsg),
+	{ok, Pid} = start_subsystem(SsName, Connection, Channel0, ReplyMsg),
 	erlang:monitor(process, Pid),
 	Channel = Channel0#channel{user = Pid},
 	ssh_channel:cache_update(Cache, Channel),
@@ -1017,7 +1017,7 @@ start_cli(#connection{options = Options,
 		      sub_system_supervisor = SubSysSup}, ChannelId) ->
     start_channel(CbModule, ChannelId, Args, SubSysSup, Exec, Options).
 
-start_subsytem(BinName, #connection{options = Options,
+start_subsystem(BinName, #connection{options = Options,
 				    sub_system_supervisor = SubSysSup},
 	       #channel{local_id = ChannelId}, _ReplyMsg) ->
     Name = binary_to_list(BinName),

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1088,7 +1088,7 @@ handle_info(UnexpectedMessage, StateName, #state{opts = Opts,
 terminate(normal, _, #state{transport_cb = Transport,
 			    connection_state = Connection,
 			    socket = Socket}) ->
-    terminate_subsytem(Connection),
+    terminate_subsystem(Connection),
     (catch Transport:close(Socket)),
     ok;
 
@@ -1117,7 +1117,7 @@ terminate({shutdown, _}, StateName, State) ->
 
 terminate(Reason, StateName, #state{ssh_params = Ssh0, starter = _Pid,
 				   connection_state = Connection} = State) ->
-    terminate_subsytem(Connection),
+    terminate_subsystem(Connection),
     log_error(Reason),
     DisconnectMsg = 
 	#ssh_msg_disconnect{code = ?SSH_DISCONNECT_BY_APPLICATION,
@@ -1128,10 +1128,10 @@ terminate(Reason, StateName, #state{ssh_params = Ssh0, starter = _Pid,
     terminate(normal, StateName, State#state{ssh_params = Ssh}).
 
 
-terminate_subsytem(#connection{system_supervisor = SysSup,
+terminate_subsystem(#connection{system_supervisor = SysSup,
 			       sub_system_supervisor = SubSysSup}) when is_pid(SubSysSup) ->
     ssh_system_sup:stop_subsystem(SysSup, SubSysSup);
-terminate_subsytem(_) ->
+terminate_subsystem(_) ->
     ok.
 
 format_status(normal, [_, State]) ->


### PR DESCRIPTION
This fixes a typo for two SSH subsystem functions, `start_subsystem` and `terminate_subsystem`. They both used `subsytem`, but were internally consistent. I found this while doing some reading to try to understand the SSH daemon, but have basically no Erlang knowledge, so I don't have much intuition on how this might break user code -- I leave that up to wiser heads :)
