### PR TITLE
Updated documentation recommending against using crypto:rand_bytes

### DIFF
--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -601,8 +601,11 @@
       </type>
       <desc>
         <p>Generates N bytes randomly uniform 0..255, and returns the
-          result in a binary. Uses the <c>crypto</c> library pseudo-random
-          number generator.</p>
+        result in a binary. Uses the <c>crypto</c> library pseudo-random
+        number generator.</p>
+        <p>This function is not recommended for cryptographic purposes.
+        Please use <seealso marker="#strong_rand_bytes/1">
+        strong_rand_bytes/1</seealso> instead.</p>
       </desc>
     </func>
 

--- a/lib/ssh/doc/src/using_ssh.xml
+++ b/lib/ssh/doc/src/using_ssh.xml
@@ -252,7 +252,7 @@
     <code type="erlang">
 %% First three parameters depending on which crypto type we select:
 Key = &lt;&lt;"This is a 256 bit key. abcdefghi">>,
-Ivec0 = crypto:rand_bytes(16),
+Ivec0 = crypto:strong_rand_bytes(16),
 DataSize = 1024,  % DataSize rem 16 = 0 for aes_cbc
 
 %% Initialization of the CryptoState, in this case it is the Ivector.

--- a/lib/stdlib/doc/src/rand.xml
+++ b/lib/stdlib/doc/src/rand.xml
@@ -104,7 +104,7 @@
     strong. If a strong cryptographic random number generator is
     needed, use one of functions in the
     <seealso marker="crypto:crypto">crypto</seealso>
-    module, for example <c>crypto:rand_bytes/1</c>.</p></note>
+    module, for example <c>crypto:strong_rand_bytes/1</c>.</p></note>
   </description>
   <datatypes>
     <datatype>

--- a/lib/stdlib/doc/src/random.xml
+++ b/lib/stdlib/doc/src/random.xml
@@ -48,7 +48,7 @@
       tuple of three integers.</p>
     <p>It should be noted that this random number generator is not cryptographically 
       strong. If a strong cryptographic random number generator is needed for
-      example <c>crypto:rand_bytes/1</c> could be used instead.</p>
+      example <c>crypto:strong_rand_bytes/1</c> could be used instead.</p>
       <note><p>The new and improved <seealso
       marker="stdlib:rand">rand</seealso> module should be used
       instead of this module.</p></note>


### PR DESCRIPTION
## Changes

This pull request makes changes to the documentation to advise users against using crypto:rand_bytes for cryptographic purposes, and recommending crypto:strong_rand_bytes instead.

## Reason for changes

crypto:rand_bytes uses a deprecated function as a PRNG.

According to https://www.openssl.org/docs/manmaster/crypto/RAND_bytes.html, the Openssl function RAND_pseudo_bytes() has been deprecated, and Openssl advise users to use it for non-cryptographic purposes only. crypto:rand_bytes uses RAND_pseudo_bytes(), and so crypto:rand_bytes should probably either use a different PRNG or it should not be used for cryptographic purposes.
