### PR TITLE
Add option to override private key in ssh connect

### DIFF
--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -329,6 +329,10 @@ handle_option([{dsa_pass_phrase, _} = Opt | Rest], SocketOptions, SshOptions) ->
     handle_option(Rest, SocketOptions, [handle_ssh_option(Opt) | SshOptions]);
 handle_option([{rsa_pass_phrase, _} = Opt | Rest], SocketOptions, SshOptions) ->
     handle_option(Rest, SocketOptions, [handle_ssh_option(Opt) | SshOptions]);
+handle_option([{dsa_priv_key, _} = Opt | Rest], SocketOptions, SshOptions) ->
+    handle_option(Rest, SocketOptions, [handle_ssh_option(Opt) | SshOptions]);
+handle_option([{rsa_priv_key, _} = Opt | Rest], SocketOptions, SshOptions) ->
+    handle_option(Rest, SocketOptions, [handle_ssh_option(Opt) | SshOptions]);
 handle_option([{password, _} = Opt | Rest], SocketOptions, SshOptions) ->
     handle_option(Rest, SocketOptions, [handle_ssh_option(Opt) | SshOptions]);
 handle_option([{user_passwords, _} = Opt | Rest], SocketOptions, SshOptions) ->
@@ -457,6 +461,10 @@ handle_ssh_option({user, Value} = Opt) when is_list(Value) ->
 handle_ssh_option({dsa_pass_phrase, Value} = Opt) when is_list(Value) ->
     Opt;
 handle_ssh_option({rsa_pass_phrase, Value} = Opt) when is_list(Value) ->
+    Opt;
+handle_ssh_option({dsa_priv_key, Value} = Opt) when is_binary(Value) ->
+    Opt;
+handle_ssh_option({rsa_priv_key, Value} = Opt) when is_binary(Value) ->
     Opt;
 handle_ssh_option({password, Value} = Opt) when is_list(Value) ->
     Opt;

--- a/lib/ssh/test/ssh_test_lib.erl
+++ b/lib/ssh/test/ssh_test_lib.erl
@@ -320,6 +320,12 @@ ct:pal("DataDir ~p:~n ~p~n~nSystDir ~p:~n ~p~n~nUserDir ~p:~n ~p",[DataDir, file
     setup_ecdsa_known_host(Size, System, UserDir),
     setup_ecdsa_auth_keys(Size, UserDir, UserDir).
 
+get_rsa_priv_key(DataDir) ->
+    file:read_file(filename:join(DataDir, "id_rsa")).
+
+get_dsa_priv_key(DataDir) ->
+    file:read_file(filename:join(DataDir, "id_dsa")).
+
 clean_dsa(UserDir) ->
     del_dirs(filename:join(UserDir, "system")),
     file:delete(filename:join(UserDir,"id_dsa")),


### PR DESCRIPTION
ssh:connect/3,4 gets the user's private key from either the default
directory (~/.ssh) of the user or from the directory specified in the
'user_dir' ssh option. This change introduces new ssh:connect/3,4
options that lets the user specify the private key at the API level
instead of reading it from the file system. This is particularly
useful when the keys are stored in a database.

TODO
 * Support for ECDSA keys (all variants)
 * Documentation update