### PR TITLE
Fix cover crash

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -90,7 +90,7 @@
 	 stop/0, stop/1]).
 -export([remote_start/1,get_main_node/0]).
 %-export([bump/5]).
--export([transform/5]). % for test purposes
+-export([transform/4]). % for test purposes
 
 -record(main_state, {compiled=[],           % [{Module,File}]
 		     imported=[],           % [{Module,File,ImportFile}]
@@ -1435,6 +1435,10 @@ get_source_info(Module, Beam) ->
 	_ ->
 		[]
     end.
+
+transform(Vsn, Code, Module, Beam) ->
+    MainFile = find_main_filename(Code),
+    transform(Vsn, Code, MainFile, Module, Beam).
 
 transform(Vsn, Code, MainFile, Module, Beam) when Vsn=:=abstract_v1; Vsn=:=abstract_v2 ->
     Vars0 = #vars{module=Module, vsn=Vsn},

--- a/lib/tools/test/cover_SUITE_data/cc.erl
+++ b/lib/tools/test/cover_SUITE_data/cc.erl
@@ -51,7 +51,7 @@ cvr(Module, P) ->
 		    undefined, undefined, undefined, undefined, undefined,
 		    undefined,
 		    false},
-	    {ok, TForms, _Vars2} = cover:transform(Forms, [], Vars),
+	    {ok, TForms, _Vars2} = cover:transform(Vsn, Forms, [], Vars),
 	    File = atom_to_list(Module)++".cvr",
 	    apply(?MODULE, P, [File, TForms]);
 	Error ->


### PR DESCRIPTION
Cover crashes when it encounters a beam file without a declared main file.

e.g. generated dtl templates

before the patch:

    1> rp(cover:compile_beam_directory("/Users/lpgauth/Git/project/_build/test/lib/project/ebin")).

    =ERROR REPORT==== 5-Nov-2015::16:05:17 ===
    Error in process <0.44.0> with exit value:
    {function_clause,[{cover,find_main_filename,
                             [[]],
                             [{file,"cover.erl"},{line,1461}]},
                      {cover,transform,4,[{file,"cover.erl"},{line,1454}]},
                      {cover,do_compile_beam,3,[{file,"cover.erl"},{line,1385}]},
                      {cover,main_process_loop,1,
                             [{file,"cover.erl"},{line,626}]}]}
    ** exception exit: {function_clause,[{cover,find_main_filename,
                                                [[]],
                                                [{file,"cover.erl"},{line,1461}]},
                                         {cover,transform,4,[{file,"cover.erl"},{line,1454}]},
                                         {cover,do_compile_beam,3,[{file,"cover.erl"},{line,1385}]},
                                         {cover,main_process_loop,1,
                                                [{file,"cover.erl"},{line,626}]}]}
         in function  cover:call/1 (cover.erl, line 541)
         in call from cover:compile_beams/2 (cover.erl, line 348)

after the patch is applied:

    2> rp(cover:compile_beam_directory("/Users/lpgauth/Git/project/_build/test/lib/project/ebin")).
    [{error,{no_main_file,"/Users/lpgauth/Git/project/_build/test/lib/project/ebin/template_dtl.beam"}},
     {ok,test}]
    ok