### PR TITLE
Support SSH key callback module options

### DIFF
--- a/lib/ssh/doc/src/ssh.xml
+++ b/lib/ssh/doc/src/ssh.xml
@@ -85,6 +85,15 @@
       <item><p><c>atom()</c> - Name of the Erlang module
       implementing the subsystem using the <c>ssh_channel</c> behavior, see
       <seealso marker="ssh_channel">ssh_channel(3)</seealso></p></item>
+      <tag><c>key_cb() =</c></tag>
+      <item>
+        <p><c>atom() | {atom(), list()}</c></p>
+        <p><c>atom()</c> - Name of the erlang module implementing the behaviours
+        <seealso marker="ssh_client_key_api">ssh_client_key_api</seealso> or
+        <seealso marker="ssh_client_key_api">ssh_client_key_api</seealso> as the
+        case maybe.</p>
+        <p><c>list()</c> - List of options that can be passed to the callback module.</p>
+      </item>
       <tag><c>channel_init_args() =</c></tag>
       <item><p><c>list()</c></p></item>
 
@@ -272,11 +281,13 @@ kex is implicit but public_key is set explicitly.</p>
 	    password, if the password authentication method is
 	    attempted.</p>
           </item>
-	  <tag><c><![CDATA[{key_cb, atom()}]]></c></tag>
+	  <tag><c><![CDATA[{key_cb, key_cb()}]]></c></tag>
 	  <item>
-	    <p>Module implementing the behaviour
-	    <seealso marker="ssh_client_key_api">ssh_client_key_api</seealso>.
-	    Can be used to customize the handling of public keys.
+	    <p>Module implementing the behaviour <seealso
+	    marker="ssh_client_key_api">ssh_client_key_api</seealso>. Can be used to
+	    customize the handling of public keys. If callback options are provided
+	    along with the module name, they are made available to the callback
+	    module via the options passed to it under the key 'key_cb_private'.
 	    </p>
 	  </item>
 	  <tag><c><![CDATA[{quiet_mode, atom() = boolean()}]]></c></tag>
@@ -607,11 +618,13 @@ kex is implicit but public_key is set explicitly.</p>
 	    </p>
 	  </item>
 
-	  <tag><c><![CDATA[{key_cb, atom()}]]></c></tag>
+	  <tag><c><![CDATA[{key_cb, key_cb()}]]></c></tag>
 	  <item>
-	    <p>Module implementing the behaviour
-	    <seealso marker="ssh_server_key_api">ssh_server_key_api</seealso>.
-	    Can be used to customize the handling of public keys.
+	    <p>Module implementing the behaviour <seealso
+	    marker="ssh_server_key_api">ssh_server_key_api</seealso>. Can be used to
+	    customize the handling of public keys. If callback options are provided
+	    along with the module name, they are made available to the callback
+	    module via the options passed to it under the key 'key_cb_private'.
 	    </p>
 	  </item>
 	  

--- a/lib/ssh/test/Makefile
+++ b/lib/ssh/test/Makefile
@@ -47,6 +47,8 @@ MODULES= \
 	ssh_to_openssh_SUITE \
 	ssh_upgrade_SUITE \
 	ssh_test_lib \
+	ssh_key_cb \
+	ssh_key_cb_options \
 	ssh_trpt_test_lib \
 	ssh_echo_server \
 	ssh_peername_sockname_server \

--- a/lib/ssh/test/ssh_key_cb.erl
+++ b/lib/ssh/test/ssh_key_cb.erl
@@ -1,0 +1,45 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2015. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+%%----------------------------------------------------------------------
+
+%% Note: This module is used by ssh_basic_SUITE
+
+-module(ssh_key_cb).
+-behaviour(ssh_client_key_api).
+-compile(export_all).
+
+add_host_key(_, _, _) ->
+    ok.
+
+is_host_key(_, _, _, _) ->
+    true.
+
+user_key('ssh-dss', Opts) ->
+    UserDir = proplists:get_value(user_dir, Opts),
+    KeyFile = filename:join(filename:dirname(UserDir), "id_dsa"),
+    {ok, KeyBin} = file:read_file(KeyFile),
+    [Entry] = public_key:pem_decode(KeyBin),
+    Key = public_key:pem_entry_decode(Entry),
+    {ok, Key};
+
+user_key(_Alg, _Opt) ->
+    {error, "Not Supported"}.

--- a/lib/ssh/test/ssh_key_cb_options.erl
+++ b/lib/ssh/test/ssh_key_cb_options.erl
@@ -1,0 +1,44 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2015. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+%%----------------------------------------------------------------------
+
+%% Note: This module is used by ssh_basic_SUITE
+
+-module(ssh_key_cb_options).
+-behaviour(ssh_client_key_api).
+-compile(export_all).
+
+add_host_key(_, _, _) ->
+    ok.
+
+is_host_key(_, _, _, _) ->
+    true.
+
+user_key('ssh-dss', Opts) ->
+    KeyCbOpts = proplists:get_value(key_cb_private, Opts),
+    KeyBin = proplists:get_value(priv_key, KeyCbOpts),
+    [Entry] = public_key:pem_decode(KeyBin),
+    Key = public_key:pem_entry_decode(Entry),
+    {ok, Key};
+
+user_key(_Alg, _Opt) ->
+    {error, "Not Supported"}.


### PR DESCRIPTION
This patch allows extra callback options to be passed to the module
implementing the SSH callback module behaviour.

A module implementing the SSH key callback API is used to customize
the handling of public key. This patch allows extra callback options
to be passed to the module implementing the SSH callback module
behaviour.

The key_cb option has been changed:

  {key_cb, atom()} -> {key_cb, key_cb()}

  Where:
	key_cb() :: atom() | {atom(), list()}

The callback options, if specified, is made available to the callback
module via the options passed to it under the key 'key_cb_private'.

More details and some backgorund is available here[1].

[1]: http://erlang.org/pipermail/erlang-patches/2015-November/004800.html