### PR TITLE
inets: Terminate really gracefully when an invalid chunked length header is encountered

### DIFF
--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -106,6 +106,7 @@ only_simulated() ->
      bad_response,
      internal_server_error,
      invalid_http,
+     invalid_chunk_size,
      headers_dummy,
      headers_with_obs_fold,
      empty_response_header,
@@ -765,6 +766,22 @@ invalid_http(Config) when is_list(Config) ->
     ct:print("Parse error: ~p ~n", [Reason]).
 
 %%-------------------------------------------------------------------------
+
+invalid_chunk_size(doc) ->
+    ["Test parse error of HTTP chunk size"];
+invalid_chunk_size(suite) ->
+    [];
+invalid_chunk_size(Config) when is_list(Config) ->
+
+    URL = url(group_name(Config), "/invalid_chunk_size.html", Config),
+
+    {error, {chunk_size, _} = Reason} =
+	httpc:request(get, {URL, []}, [], []),
+
+    ct:print("Parse error: ~p ~n", [Reason]).
+
+%%-------------------------------------------------------------------------
+
 emulate_lower_versions(doc) ->
     [{doc, "Perform request as 0.9 and 1.0 clients."}];
 emulate_lower_versions(Config) when is_list(Config) ->
@@ -1875,6 +1892,10 @@ handle_uri(_,"/once.html",_,_,Socket,_) ->
 handle_uri(_,"/invalid_http.html",_,_,_,_) ->
     "HTTP/1.1 301\r\nDate:Sun, 09 Dec 2007 13:04:18 GMT\r\n" ++
 	"Transfer-Encoding:chunked\r\n\r\n";
+
+handle_uri(_,"/invalid_chunk_size.html",_,_,_,_) ->
+    "HTTP/1.1 200 ok\r\n" ++
+	"Transfer-Encoding:chunked\r\n\r\nåäö\r\n";
 
 handle_uri(_,"/missing_reason_phrase.html",_,_,_,_) ->
     "HTTP/1.1 200\r\n" ++


### PR DESCRIPTION
Without this fix, httpc:request/1 crashes the httpc_handler when an invalid chunked length header is encountered:

    =ERROR REPORT==== 14-Nov-2015::17:19:30 ===
    ** Generic server <0.651.0> terminating
    ** Last message in was {tcp,#Port<0.5714>,
                                <<"HTTP/1.1 200 ok\r\nTransfer-Encoding:chunked\r\n\r\nåäö\r\n">>}
    ** When Server state == {state,
    [...]
    ** Reason for termination ==
    ** {bad_return_value,{error,{chunk_size,"åäö"}}}

This is a fixup for commit 77acb47.