### PR TITLE
inets: Allow whitespace after HTTP chunk size again

### DIFF
--- a/lib/inets/src/http_lib/http_chunk.erl
+++ b/lib/inets/src/http_lib/http_chunk.erl
@@ -147,7 +147,7 @@ decode_size(Data = <<?CR, ?LF, ChunkRest/binary>>, HexList, AccHeaderSize,
 	    {MaxBodySize, Body, 
 	     AccLength,
 	     MaxHeaderSize}) ->
-    try http_util:hexlist_to_integer(lists:reverse(HexList)) of
+    try http_util:hexlist_to_integer(lists:reverse(string:strip(HexList, left))) of
 	0 -> % Last chunk, there was no data
 	    ignore_extensions(Data, remaing_size(MaxHeaderSize, AccHeaderSize), MaxHeaderSize,
 			      {?MODULE, decode_trailer, 


### PR DESCRIPTION
Before 77acb47 http:request/1 could parse server responses with whitespace after the HTTP chunk size (some embedded legacy devices still do this).

This patch restores this functionality.