### PR TITLE
erts: Add garbage_collection_info to process_info/2

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -4621,6 +4621,17 @@ os_prompt% </pre>
 	       The content of <c><anno>GCInfo</anno></c> can be changed without
 	       prior notice.</p>
           </item>
+          <tag><c>{garbage_collection_info, <anno>GCInfo</anno>}</c></tag>
+          <item>
+            <p><c><anno>GCInfo</anno></c> is a list containing miscellaneous
+	       detailed information about garbage collection for this process.
+	       The content of <c><anno>GCInfo</anno></c> can be changed without
+	       prior notice.
+               See <seealso marker="#gc_start">gc_start</seealso> in
+               <seealso marker="#trace/3">erlang:trace/3</seealso> for details about
+               what each item means.
+            </p>
+          </item>
           <tag><c>{group_leader, <anno>GroupLeader</anno>}</c></tag>
           <item>
             <p><c><anno>GroupLeader</anno></c> is group leader for the I/O of

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -256,6 +256,7 @@ atom functions
 atom function_clause
 atom garbage_collecting
 atom garbage_collection
+atom garbage_collection_info
 atom gc_end
 atom gc_start
 atom Ge='>='

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -589,7 +589,8 @@ static Eterm pi_args[] = {
     am_min_bin_vheap_size,
     am_current_location,
     am_current_stacktrace,
-    am_off_heap_message_queue
+    am_off_heap_message_queue,
+    am_garbage_collection_info
 };
 
 #define ERTS_PI_ARGS ((int) (sizeof(pi_args)/sizeof(Eterm)))
@@ -638,6 +639,7 @@ pi_arg2ix(Eterm arg)
     case am_current_location:			return 29;
     case am_current_stacktrace:			return 30;
     case am_off_heap_message_queue:		return 31;
+    case am_garbage_collection_info:		return 32;
     default:					return -1;
     }
 }
@@ -1393,6 +1395,32 @@ process_info_aux(Process *BIF_P,
 	t = TUPLE2(hp, am_min_bin_vheap_size, make_small(MIN_VHEAP_SIZE(rp))); hp += 3;
 	res = CONS(hp, t, res); hp += 2;
 	break;
+    }
+
+    case am_garbage_collection_info: {
+        Uint sz = 0, actual_sz = 0;
+
+        if (rp == BIF_P) {
+            sz += ERTS_PROCESS_GC_INFO_MAX_SIZE;
+        } else {
+            erts_process_gc_info(rp, &sz, NULL);
+            sz += 3;
+        }
+
+        hp = HAlloc(BIF_P, sz);
+        res = erts_process_gc_info(rp, &actual_sz, &hp);
+
+        /* We may have some extra space, fill with 0 tuples */
+        if (actual_sz <= sz - 3) {
+            for (; actual_sz < sz - 3; hp++, actual_sz++)
+                hp[0] = make_arityval(0);
+        } else {
+            for (; actual_sz < sz; hp++, actual_sz++)
+                hp[0] = make_arityval(0);
+            hp = HAlloc(BIF_P, 3);
+        }
+
+        break;
     }
 
     case am_group_leader: {

--- a/erts/emulator/beam/erl_gc.h
+++ b/erts/emulator/beam/erl_gc.h
@@ -132,6 +132,11 @@ typedef struct {
   Uint64 garbage_cols;
 } ErtsGCInfo;
 
+#define ERTS_PROCESS_GC_INFO_MAX_TERMS (11)  /* number of elements in process_gc_info*/
+#define ERTS_PROCESS_GC_INFO_MAX_SIZE                                   \
+    (ERTS_PROCESS_GC_INFO_MAX_TERMS * (2/*cons*/ + 3/*2-tuple*/ + BIG_UINT_HEAP_SIZE))
+Eterm erts_process_gc_info(struct process*, Uint *, Eterm **);
+
 void erts_gc_info(ErtsGCInfo *gcip);
 void erts_init_gc(void);
 int erts_garbage_collect_nobump(struct process*, int, Eterm*, int);

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -2144,11 +2144,6 @@ void save_calls(Process *p, Export *e)
 void
 trace_gc(Process *p, Eterm what)
 {
-    ERTS_DECL_AM(bin_vheap_size);
-    ERTS_DECL_AM(bin_vheap_block_size);
-    ERTS_DECL_AM(bin_old_vheap_size);
-    ERTS_DECL_AM(bin_old_vheap_block_size);
-
     ErlHeapFragment *bp = NULL;
     ErlOffHeap *off_heap;
     ERTS_TRACER_REF_TYPE tracer_ref = ERTS_NULL_TRACER_REF;	/* Initialized
@@ -2159,43 +2154,13 @@ trace_gc(Process *p, Eterm what)
     Eterm msg = NIL;
     Uint size;
 
-    Eterm tags[] = {
-	am_old_heap_block_size,
-	am_heap_block_size,
-	am_mbuf_size,
-	am_recent_size,
-	am_stack_size,
-	am_old_heap_size,
-	am_heap_size,
-	AM_bin_vheap_size,
-	AM_bin_vheap_block_size,
-	AM_bin_old_vheap_size,
-	AM_bin_old_vheap_block_size
-    };
-
-    UWord values[] = {
-	OLD_HEAP(p) ? OLD_HEND(p) - OLD_HEAP(p) : 0,
-	HEAP_SIZE(p),
-	MBUF_SIZE(p),
-	HIGH_WATER(p) - HEAP_START(p),
-	STACK_START(p) - p->stop,
-	OLD_HEAP(p) ? OLD_HTOP(p) - OLD_HEAP(p) : 0,
-	HEAP_TOP(p) - HEAP_START(p),
-	MSO(p).overhead,
-	BIN_VHEAP_SZ(p),
-	BIN_OLD_VHEAP(p),
-	BIN_OLD_VHEAP_SZ(p)
-    };
 #define LOCAL_HEAP_SIZE						\
-    (sizeof(values)/sizeof(*values)) *				\
-	(2/*cons*/ + 3/*2-tuple*/ + BIG_UINT_HEAP_SIZE) +	\
+    (ERTS_PROCESS_GC_INFO_MAX_SIZE) +                           \
 	5/*4-tuple */ + TS_HEAP_WORDS
     DeclareTmpHeap(local_heap,LOCAL_HEAP_SIZE,p);
 #ifdef DEBUG
     Eterm* limit;
 #endif
-
-    ERTS_CT_ASSERT(sizeof(values)/sizeof(*values) == sizeof(tags)/sizeof(Eterm));
 
     UseTmpHeap(LOCAL_HEAP_SIZE,p);
 
@@ -2203,11 +2168,8 @@ trace_gc(Process *p, Eterm what)
 	hp = local_heap;
 #ifdef DEBUG
 	size = 0;
-	(void) erts_bld_atom_uword_2tup_list(NULL,
-					    &size,
-					    sizeof(values)/sizeof(*values),
-					    tags,
-					    values);
+        (void) erts_process_gc_info(p, &size, NULL);
+
 	size += 5/*4-tuple*/ + TS_SIZE(p);
 #endif
     } else {
@@ -2218,11 +2180,8 @@ trace_gc(Process *p, Eterm what)
 			    ERTS_TRACE_FLAGS(p));
 
 	size = 0;
-	(void) erts_bld_atom_uword_2tup_list(NULL,
-					    &size,
-					    sizeof(values)/sizeof(*values),
-					    tags,
-					    values);
+        (void) erts_process_gc_info(p, &size, NULL);
+
 	size += 5/*4-tuple*/ + TS_SIZE(p);
 
 	hp = ERTS_ALLOC_SYSMSG_HEAP(size, &bp, &off_heap, tracer_ref);
@@ -2233,11 +2192,7 @@ trace_gc(Process *p, Eterm what)
     ASSERT(size <= LOCAL_HEAP_SIZE);
 #endif
 
-    msg = erts_bld_atom_uword_2tup_list(&hp,
-				       NULL,
-				       sizeof(values)/sizeof(*values),
-				       tags,
-				       values);
+    msg = erts_process_gc_info(p, NULL, &hp);
 
     msg = TUPLE4(hp, am_trace, p->common.id, what, msg);
     hp += 5;

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2074,6 +2074,7 @@ process_flag(_Flag, _Value) ->
       dictionary |
       error_handler |
       garbage_collection |
+      garbage_collection_info |
       group_leader |
       heap_size |
       initial_call |
@@ -2114,6 +2115,7 @@ process_flag(_Flag, _Value) ->
       {dictionary, Dictionary :: [{Key :: term(), Value :: term()}]} |
       {error_handler, Module :: module()} |
       {garbage_collection, GCInfo :: [{atom(),non_neg_integer()}]} |
+      {garbage_collection_info, GCInfo :: [{atom(),non_neg_integer()}]} |
       {group_leader, GroupLeader :: pid()} |
       {heap_size, Size :: non_neg_integer()} |
       {initial_call, mfa()} |


### PR DESCRIPTION
This info request returns greater details about the current gc state. For some reason this information was previously only available as trace messages.

Suggestions on a better name than garbage_collection_info would be greatly appreciated.