### PR TITLE
Get timer count for some monitoring systems.

### DIFF
--- a/erts/emulator/beam/erl_hl_timer.c
+++ b/erts/emulator/beam/erl_hl_timer.c
@@ -2891,6 +2891,26 @@ erts_print_bif_timer_info(int to, void *to_arg)
     }
 }
 
+static void
+btm_acc(ErtsHLTimer *tmr, void *vcount)
+{
+    Uint *count = (Uint *) vcount;
+    (*count)++;
+}
+
+Uint erts_timer_count(void)
+{
+    Uint count = 0;
+    int six;
+
+    for (six = 0; six < erts_no_schedulers; six++) {
+        ErtsHLTimerService *srv =
+                    erts_aligned_scheduler_data[six].esd.timer_service;
+        btm_rbt_foreach(srv->btm_tree, btm_acc, (void *) &count);
+    }
+    return count;
+}
+
 typedef struct {
     void (*func)(Eterm,
 		 Eterm,

--- a/erts/emulator/beam/erl_hl_timer.h
+++ b/erts/emulator/beam/erl_hl_timer.h
@@ -72,6 +72,7 @@ erts_handle_canceled_timers(void *vesdp,
 #endif
 
 Uint erts_bif_timer_memory_size(void);
+Uint erts_timer_count(void);
 void erts_print_bif_timer_info(int to, void *to_arg);
 
 void erts_debug_bif_timer_foreach(void (*func)(Eterm,


### PR DESCRIPTION
Add a function for getting timer count easily. So some monitoring system can get the timer count trend.