### PR TITLE
Encode empty named bitstrings in asn1 library

### DIFF
--- a/lib/asn1/src/asn1rtt_ber.erl
+++ b/lib/asn1/src/asn1rtt_ber.erl
@@ -746,6 +746,8 @@ encode_named_bit_string(C, [H|_]=Bits, NamedBitList, TagIn) when is_atom(H) ->
     do_encode_named_bit_string(C, Bits, NamedBitList, TagIn);
 encode_named_bit_string(C, [{bit,_}|_]=Bits, NamedBitList, TagIn) ->
     do_encode_named_bit_string(C, Bits, NamedBitList, TagIn);
+encode_named_bit_string(C, [], _NamedBitList, TagIn) ->
+    encode_unnamed_bit_string(C, <<>>, TagIn);
 encode_named_bit_string(C, Bits, _NamedBitList, TagIn) when is_bitstring(Bits) ->
     encode_unnamed_bit_string(C, Bits, TagIn).
 

--- a/lib/asn1/test/testPrimStrings.erl
+++ b/lib/asn1/test/testPrimStrings.erl
@@ -123,6 +123,7 @@ bit_string(Rules, Opts) ->
     %% Bs2 ::= BIT STRING {su(0), mo(1), tu(2), we(3), th(4), fr(5), sa(6) } (SIZE (7))
     %%==========================================================
     
+    roundtrip('Bs2', []),
     roundtrip('Bs2', [mo,tu,fr]),
     bs_roundtrip('Bs2', <<2#0110010:7>>, [mo,tu,fr]),
     bs_roundtrip('Bs2', <<2#0110011:7>>, [mo,tu,fr,sa]),
@@ -131,6 +132,7 @@ bit_string(Rules, Opts) ->
     %% Bs3 ::= BIT STRING {su(0), mo(1), tu(2), we(3), th(4), fr(5), sa(6) } (SIZE (1..7))
     %%==========================================================
     
+    roundtrip('Bs3', []),
     roundtrip('Bs3', [mo,tu,fr]),
     bs_roundtrip('Bs3', <<2#0110010:7>>, [mo,tu,fr]),
     bs_roundtrip('Bs3', <<2#0110010:7>>, [mo,tu,fr]),


### PR DESCRIPTION
Currently code generated by asn1 library correctly decodes BER encoded
empty named bit string values to '[]', but fails to encode them, provided patch
adds function clause to asn1rtt_ber:encode_named_bit_string/4 to fix that.