### PR TITLE
os:getuid/0 and os:geteuid/0 BIFs on Unix

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1978,6 +1978,16 @@ dnl       fdatasync requires linking against -lrt on SunOS <= 5.10.
 dnl       OpenSolaris 2009.06 is SunOS 5.11 and does not require -lrt.
 AC_SEARCH_LIBS(fdatasync, [rt])
 
+dnl getuid syscall
+case $host in
+   win32) ;;
+   *ose)  ;;
+   *)
+      AC_SEARCH_LIBS(getuid, unistd ,
+		     AC_DEFINE([HAVE_GETUID], [1],
+			       [Define to 1 if you have the 'getuid' function.]))
+      ;;
+esac
 
 dnl sendfile syscall
 case $host_os in

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1978,17 +1978,17 @@ dnl       fdatasync requires linking against -lrt on SunOS <= 5.10.
 dnl       OpenSolaris 2009.06 is SunOS 5.11 and does not require -lrt.
 AC_SEARCH_LIBS(fdatasync, [rt])
 
-dnl getuid syscall
+dnl getuid / geteuid syscalls
 case $host in
    win32) ;;
    *ose)  ;;
    *)
-      AC_SEARCH_LIBS(getuid, unistd ,
-		     AC_DEFINE([HAVE_GETUID], [1],
-			       [Define to 1 if you have the 'getuid' function.]))
-      AC_SEARCH_LIBS(geteuid, unistd ,
-		     AC_DEFINE([HAVE_GETEUID], [1],
-			       [Define to 1 if you have the 'geteuid' function.]))
+      AC_CHECK_FUNC(getuid,
+		    AC_DEFINE([HAVE_GETUID], [1],
+			      [Define to 1 if you have the `getuid' function.]))
+      AC_CHECK_FUNC(geteuid,
+		    AC_DEFINE([HAVE_GETEUID], [1],
+			      [Define to 1 if you have the `geteuid' function.]))
       ;;
 esac
 

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1986,6 +1986,9 @@ case $host in
       AC_SEARCH_LIBS(getuid, unistd ,
 		     AC_DEFINE([HAVE_GETUID], [1],
 			       [Define to 1 if you have the 'getuid' function.]))
+      AC_SEARCH_LIBS(geteuid, unistd ,
+		     AC_DEFINE([HAVE_GETEUID], [1],
+			       [Define to 1 if you have the 'geteuid' function.]))
       ;;
 esac
 

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -643,3 +643,6 @@ bif erts_debug:map_info/1
 #
 
 bif erlang:hash/2
+
+# new: getuid
+bif os:getuid/0

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -644,5 +644,6 @@ bif erts_debug:map_info/1
 
 bif erlang:hash/2
 
-# new: getuid
+# new: getuid / geteuid
 bif os:getuid/0
+bif os:geteuid/0

--- a/erts/emulator/beam/erl_bif_os.c
+++ b/erts/emulator/beam/erl_bif_os.c
@@ -65,6 +65,21 @@ BIF_RETTYPE os_getpid_0(BIF_ALIST_0)
      BIF_RET(buf_to_intlist(&hp, pid_string, n, NIL));
 }
 
+BIF_RETTYPE os_getuid_0(BIF_ALIST_0)
+{
+#ifdef HAVE_GETUID
+     char pid_string[21]; /* also enough for a 64 bit number */
+     int n;
+     Eterm* hp;
+     sys_get_uid(pid_string, sizeof(pid_string)); /* In sys.c */
+     n = sys_strlen(pid_string);
+     hp = HAlloc(BIF_P, n*2);
+     BIF_RET(buf_to_intlist(&hp, pid_string, n, NIL));
+#else
+     BIF_ERROR(BIF_P, EXC_NOTSUP);
+#endif
+}
+
 BIF_RETTYPE os_getenv_0(BIF_ALIST_0)
 {
     GETENV_STATE state;

--- a/erts/emulator/beam/erl_bif_os.c
+++ b/erts/emulator/beam/erl_bif_os.c
@@ -80,6 +80,21 @@ BIF_RETTYPE os_getuid_0(BIF_ALIST_0)
 #endif
 }
 
+BIF_RETTYPE os_geteuid_0(BIF_ALIST_0)
+{
+#ifdef HAVE_GETEUID
+     char pid_string[21]; /* alas, also enough for a 64 bit number */
+     int n;
+     Eterm* hp;
+     sys_get_euid(pid_string, sizeof(pid_string)); /* In sys.c */
+     n = sys_strlen(pid_string);
+     hp = HAlloc(BIF_P, n*2);
+     BIF_RET(buf_to_intlist(&hp, pid_string, n, NIL));
+#else
+     BIF_ERROR(BIF_P, EXC_NOTSUP);
+#endif
+}
+
 BIF_RETTYPE os_getenv_0(BIF_ALIST_0)
 {
     GETENV_STATE state;

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -848,6 +848,10 @@ int sys_double_to_chars_ext(double, char*, size_t, size_t);
 int sys_double_to_chars_fast(double, char*, int, int, int);
 void sys_get_pid(char *, size_t);
 
+#ifdef HAVE_GETUID
+void sys_get_uid(char *, size_t);
+#endif
+
 /* erts_sys_putenv() returns, 0 on success and a value != 0 on failure. */
 int erts_sys_putenv(char *key, char *value);
 /* Simple variant used from drivers, raw eightbit interface */

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -852,6 +852,10 @@ void sys_get_pid(char *, size_t);
 void sys_get_uid(char *, size_t);
 #endif
 
+#ifdef HAVE_GETEUID
+void sys_get_euid(char *, size_t);
+#endif
+
 /* erts_sys_putenv() returns, 0 on success and a value != 0 on failure. */
 int erts_sys_putenv(char *key, char *value);
 /* Simple variant used from drivers, raw eightbit interface */

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -37,6 +37,11 @@
 #include <sys/utsname.h>
 #include <sys/select.h>
 
+#ifdef HAVE_GETUID
+#include <unistd.h>
+#include <sys/types.h>
+#endif
+
 #ifdef ISC32
 #include <sys/bsdtypes.h>
 #endif
@@ -2649,6 +2654,13 @@ void sys_get_pid(char *buffer, size_t buffer_size){
     /* Assume the pid is scalar and can rest in an unsigned long... */
     erts_snprintf(buffer, buffer_size, "%lu",(unsigned long) p);
 }
+
+#ifdef HAVE_GETUID
+void sys_get_uid(char *buffer, size_t buffer_size) {
+    uid_t uid = getuid();
+    erts_snprintf(buffer, buffer_size, "%lu", (unsigned long) uid);
+}
+#endif
 
 int
 erts_sys_putenv_raw(char *key, char *value) {

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -37,7 +37,7 @@
 #include <sys/utsname.h>
 #include <sys/select.h>
 
-#ifdef HAVE_GETUID
+#if defined(HAVE_GETUID) || defined(HAVE_GETEUID)
 #include <unistd.h>
 #include <sys/types.h>
 #endif
@@ -2658,6 +2658,13 @@ void sys_get_pid(char *buffer, size_t buffer_size){
 #ifdef HAVE_GETUID
 void sys_get_uid(char *buffer, size_t buffer_size) {
     uid_t uid = getuid();
+    erts_snprintf(buffer, buffer_size, "%lu", (unsigned long) uid);
+}
+#endif
+
+#ifdef HAVE_GETEUID
+void sys_get_euid(char *buffer, size_t buffer_size) {
+    uid_t uid = geteuid();
     erts_snprintf(buffer, buffer_size, "%lu", (unsigned long) uid);
 }
 #endif

--- a/lib/kernel/doc/src/os.xml
+++ b/lib/kernel/doc/src/os.xml
@@ -128,6 +128,15 @@ DirOut = os:cmd("dir"), % on Win32 platform</code>
       </desc>
     </func>
     <func>
+      <name name="getuid" arity="0"/>
+      <fsummary>Return the user identifier of the emulator process</fsummary>
+      <desc>
+        <p>Returns the user identifier, on Unix-like systems, under which the emulator
+          process is running. <c><anno>Value</anno></c> is returned as a string containing
+          the numerical identifier returned by the <c>getuid()</c> system call.</p>
+      </desc>
+    </func>
+    <func>
       <name name="putenv" arity="2"/>
       <fsummary>Set a new value for an environment variable</fsummary>
       <desc>

--- a/lib/kernel/doc/src/os.xml
+++ b/lib/kernel/doc/src/os.xml
@@ -137,6 +137,15 @@ DirOut = os:cmd("dir"), % on Win32 platform</code>
       </desc>
     </func>
     <func>
+      <name name="geteuid" arity="0"/>
+      <fsummary>Return the effective user identifier of the emulator process</fsummary>
+      <desc>
+        <p>Returns the effective user identifier, on Unix-like systems, under which the emulator
+          process is running. <c><anno>Value</anno></c> is returned as a string containing
+          the numerical identifier returned by the <c>geteuid()</c> system call.</p>
+      </desc>
+    </func>
+    <func>
       <name name="putenv" arity="2"/>
       <fsummary>Set a new value for an environment variable</fsummary>
       <desc>

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -27,7 +27,8 @@
 
 %%% BIFs
 
--export([getenv/0, getenv/1, getenv/2, getpid/0, putenv/2, system_time/0, system_time/1,
+-export([getenv/0, getenv/1, getenv/2, getpid/0, getuid/0,
+	 putenv/2, system_time/0, system_time/1,
 	 timestamp/0, unsetenv/1]).
 
 -spec getenv() -> [string()].
@@ -58,6 +59,12 @@ getenv(VarName, DefaultValue) ->
       Value :: string().
 
 getpid() ->
+    erlang:nif_error(undef).
+
+-spec getuid() -> Value when
+      Value :: string().
+
+getuid() ->
     erlang:nif_error(undef).
 
 -spec putenv(VarName, Value) -> true when

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -27,7 +27,7 @@
 
 %%% BIFs
 
--export([getenv/0, getenv/1, getenv/2, getpid/0, getuid/0,
+-export([getenv/0, getenv/1, getenv/2, getpid/0, getuid/0, geteuid/0,
 	 putenv/2, system_time/0, system_time/1,
 	 timestamp/0, unsetenv/1]).
 
@@ -65,6 +65,12 @@ getpid() ->
       Value :: string().
 
 getuid() ->
+    erlang:nif_error(undef).
+
+-spec geteuid() -> Value when
+      Value :: string().
+
+geteuid() ->
     erlang:nif_error(undef).
 
 -spec putenv(VarName, Value) -> true when


### PR DESCRIPTION
As recently discussed on the erlang-questions mailing list; simple enough and quite useful. These calls never fail (according to documentation.)

I thought about supporting win32 as well, but in between not having a Windows machine handy and not being quite sure about what could be considered an user ID on it (UUID? Username?) I figured it would be better to leave it for someone else.