### PR TITLE
Document limitations on the halt status string

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -1786,6 +1786,8 @@ os_prompt% </pre>
 	  <tag>string()</tag>
 	  <item>An Erlang crash dump is produced with <c><anno>Status</anno></c>
 	  as slogan. Then the runtime system exits with status code <c>1</c>.
+          The <c><anno>Status</anno></c> may only contain latin1 characters and
+          its length must be less than 200 characters.
 	  </item>
 	  <tag><c>abort</c></tag>
 	  <item>


### PR DESCRIPTION
The C implementation of the `halt` BIF has some restrictions on the length and character set allowed in the halt status string which were not documented.

* Message length: [bif.c line 3934](https://github.com/erlang/otp/blob/53bfaec70f9f6daaae079a1c5cd852f4df214b57/erts/emulator/beam/bif.c#L3934)
* Latin1 character set: [utils.c line 3965](https://github.com/erlang/otp/blob/1523be48ab4071b158412f4b06fe9c8d6ba3e73c/erts/emulator/beam/utils.c#L3965)