### PR TITLE
Use crypto:strong_rand_bytes to generate keys

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -641,13 +641,7 @@ compute_key(ecdh, Others, My, Curve) ->
 
 
 random_bytes(N) ->
-    try strong_rand_bytes(N) of
-	RandBytes ->
-	    RandBytes
-    catch
-	error:low_entropy ->
-	    rand_bytes(N)
-    end.
+    strong_rand_bytes(N).
 
 %%--------------------------------------------------------------------
 %%% On load

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -593,13 +593,7 @@ format_error(Error) ->
 %% fallbacks on pseudo random function
 %%--------------------------------------------------------------------
 random_bytes(N) ->
-    try crypto:strong_rand_bytes(N) of
-	RandBytes ->
-	    RandBytes
-    catch
-	error:low_entropy ->
-	    crypto:rand_bytes(N)
-    end.
+    crypto:strong_rand_bytes(N).
 
 %%%--------------------------------------------------------------
 %%% Internal functions

--- a/lib/ssl/src/ssl_manager.erl
+++ b/lib/ssl/src/ssl_manager.erl
@@ -529,7 +529,7 @@ last_delay_timer({_,_}, TRef, {_, LastClient}) ->
 new_id(_, 0, _, _) ->
     <<>>;
 new_id(Port, Tries, Cache, CacheCb) ->
-    Id = crypto:rand_bytes(?NUM_OF_SESSION_ID_BYTES),
+    Id = crypto:strong_rand_bytes(?NUM_OF_SESSION_ID_BYTES),
     case CacheCb:lookup(Cache, {Port, Id}) of
 	undefined ->
 	    Now =  calendar:datetime_to_gregorian_seconds({date(), time()}),

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -450,7 +450,7 @@ empty_security_params(ConnectionEnd = ?SERVER) ->
 random() ->
     Secs_since_1970 = calendar:datetime_to_gregorian_seconds(
 			calendar:universal_time()) - 62167219200,
-    Random_28_bytes = crypto:rand_bytes(28),
+    Random_28_bytes = crypto:strong_rand_bytes(28),
     <<?UINT32(Secs_since_1970), Random_28_bytes/binary>>.
 
 dtls_next_epoch(#connection_state{epoch = undefined}) -> %% SSL/TLS


### PR DESCRIPTION
## Changes

Replaced crypto:rand_bytes with crypto:strong_rand_bytes, and changed a function which falls back to crypto:rand_bytes to simple raise an error (using crypto:strong_rand_bytes).

### Reasons for changes

As noted in #883, crypto:rand_bytes uses a PRNG that has been deprecated by Openssl, and Openssl recommend against using it to generate keys.