### PR TITLE
inets: Add PATCH method to client and server

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -101,7 +101,8 @@ request(Url, Profile) ->
 %%           {ok, {StatusLine, Headers, Body}} | {ok, {Status, Body}} |
 %%           {ok, RequestId} | {error,Reason} | {ok, {saved_as, FilePath}
 %%
-%%	Method - atom() = head | get | put | post | trace | options| delete 
+%%	Method - atom() = head | get | put | patch | post | trace |
+%%	                  options | delete 
 %%	Request - {Url, Headers} | {Url, Headers, ContentType, Body} 
 %%	Url - string() 
 %%	HTTPOptions - [HttpOption]
@@ -176,8 +177,8 @@ request(Method,
 request(Method, 
 	{Url, Headers, ContentType, Body}, 
 	HTTPOptions, Options, Profile) 
-  when ((Method =:= post) orelse (Method =:= put) orelse (Method =:= delete)) andalso 
-       (is_atom(Profile) orelse is_pid(Profile)) ->
+  when ((Method =:= post) orelse (Method =:= patch) orelse (Method =:= put) orelse
+	(Method =:= delete)) andalso (is_atom(Profile) orelse is_pid(Profile)) ->
     ?hcrt("request", [{method,       Method}, 
 		      {url,          Url},
 		      {headers,      Headers}, 

--- a/lib/inets/src/http_client/httpc_request.erl
+++ b/lib/inets/src/http_client/httpc_request.erl
@@ -187,7 +187,8 @@ is_client_closing(Headers) ->
 %%% Internal functions
 %%%========================================================================
 post_data(Method, Headers, {ContentType, Body}, HeadersAsIs) 
-  when (Method =:= post) orelse (Method =:= put) ->
+  when (Method =:= post) orelse (Method =:= put)
+       orelse (Method =:= patch) ->
     NewBody = case Headers#http_request_h.expect of
 		  "100-continue" ->
 		      "";

--- a/lib/inets/src/http_server/httpd_request.erl
+++ b/lib/inets/src/http_server/httpd_request.erl
@@ -86,7 +86,8 @@ body_data(Headers, Body) ->
 %%-------------------------------------------------------------------------
 %% validate(Method, Uri, Version) -> ok | {error, {bad_request, Reason} |
 %%			     {error, {not_supported, {Method, Uri, Version}}
-%%      Method = "HEAD" | "GET" | "POST" | "TRACE" | "PUT" | "DELETE"
+%%      Method = "HEAD" | "GET" | "POST" | "PATCH" | "TRACE" | "PUT"
+%%               | "DELETE"
 %%      Uri = uri()
 %%      Version = "HTTP/N.M"      
 %% Description: Checks that HTTP-request-line is valid.
@@ -104,6 +105,8 @@ validate("PUT", Uri, "HTTP/1." ++ _N) ->
 validate("DELETE", Uri, "HTTP/1." ++ _N) ->
     validate_uri(Uri);
 validate("POST", Uri, "HTTP/1." ++ _N) ->
+    validate_uri(Uri);
+validate("PATCH", Uri, "HTTP/1." ++ _N) ->
     validate_uri(Uri);
 validate("TRACE", Uri, "HTTP/1." ++ N) when hd(N) >= $1 ->
     validate_uri(Uri);

--- a/lib/inets/src/http_server/mod_cgi.erl
+++ b/lib/inets/src/http_server/mod_cgi.erl
@@ -337,6 +337,8 @@ script_elements(#mod{method = "GET"}, {PathInfo, QueryString}) ->
     [{query_string, QueryString}, {path_info, PathInfo}];
 script_elements(#mod{method = "POST", entity_body = Body}, _) ->
     [{entity_body, Body}];
+script_elements(#mod{method = "PATCH", entity_body = Body}, _) ->
+    [{entity_body, Body}];
 script_elements(#mod{method = "PUT", entity_body = Body}, _) ->
     [{entity_body, Body}];
 script_elements(_, _) ->

--- a/lib/inets/src/http_server/mod_esi.erl
+++ b/lib/inets/src/http_server/mod_esi.erl
@@ -281,6 +281,15 @@ erl(#mod{request_uri  = ReqUri,
 		       ?NICE("Erl mechanism doesn't support method DELETE")}}|
 	      Data]};
 
+erl(#mod{request_uri  = ReqUri, 
+	 method       = "PATCH",
+         http_version = Version, 
+	 data         = Data}, _ESIBody, _Modules) ->
+    ?hdrt("erl", [{method, patch}]),
+    {proceed, [{status,{501,{"PATCH", ReqUri, Version},
+			?NICE("Erl mechanism doesn't support method PATCH")}}|
+	       Data]};
+
 erl(#mod{method      = "POST", 
 	 entity_body = Body} = ModData, ESIBody, Modules) ->
     ?hdrt("erl", [{method, post}]),

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -68,6 +68,7 @@ real_requests()->
      get,
      post,
      post_stream,
+     patch,
      async,
      pipeline,
      persistent_connection,
@@ -255,6 +256,28 @@ post(Config) when is_list(Config) ->
     {ok, {{_,504,_}, [_ | _], []}} =
 	httpc:request(post, {URL, [{"expect","100-continue"}],
 			     "text/plain", "foobar"}, [], []).
+
+%%--------------------------------------------------------------------
+patch() ->
+    [{"Test http patch request against local server. We do in this case "
+     "only care about the client side of the the patch. The server "
+     "script will not actually use the patch data."}].
+patch(Config) when is_list(Config) ->
+    CGI = case test_server:os_type() of
+	      {win32, _} ->
+		  "/cgi-bin/cgi_echo.exe";
+	      _ ->
+		  "/cgi-bin/cgi_echo"
+	  end,
+
+     URL = url(group_name(Config), CGI, Config),
+
+    %% Cgi-script expects the body length to be 100
+    Body = lists:duplicate(100, "1"),
+
+    {ok, {{_,200,_}, [_ | _], [_ | _]}} =
+	httpc:request(patch, {URL, [{"expect","100-continue"}],
+			     "text/plain", Body}, [], []).
 
 %%--------------------------------------------------------------------
 post_stream() ->


### PR DESCRIPTION
It is technically a new feature, but it really just loosens the restriction of acceptable methods to allow "PATCH", in compliance with the RFC5789.

I have adapted the test that existed for POST and manually tested the client agains an existing web service. It worked quite straightforwardly so I believe it is correct, but anyone that has a global understanding of the inets package should review it.