### PR TITLE
Fix typespec of code:load_binary/3

### DIFF
--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -81,6 +81,7 @@
                         | 'nofile'
                         | 'not_purged'
                         | 'on_load'
+                        | 'on_load_failure'
                         | 'sticky_directory'.
 -type load_ret() :: {'error', What :: load_error_rsn()}
                   | {'module', Module :: module()}.

--- a/lib/kernel/test/code_SUITE.erl
+++ b/lib/kernel/test/code_SUITE.erl
@@ -35,7 +35,7 @@
 	 purge_stacktrace/1, mult_lib_roots/1, bad_erl_libs/1,
 	 code_archive/1, code_archive2/1, on_load/1, on_load_binary/1,
 	 on_load_embedded/1, on_load_errors/1, big_boot_embedded/1,
-	 native_early_modules/1, get_mode/1]).
+	 native_early_modules/1, get_mode/1, on_load_failure/1]).
 
 -export([init_per_testcase/2, end_per_testcase/2,
 	 init_per_suite/1, end_per_suite/1]).
@@ -61,7 +61,7 @@ all() ->
      where_is_file_cached, purge_stacktrace, mult_lib_roots,
      bad_erl_libs, code_archive, code_archive2, on_load,
      on_load_binary, on_load_embedded, on_load_errors,
-     big_boot_embedded, native_early_modules, get_mode].
+     big_boot_embedded, native_early_modules, get_mode, on_load_failure].
 
 groups() ->
     [].
@@ -1563,6 +1563,18 @@ create_big_script(Config,Local) ->
 is_source_dir() ->
     filename:basename(code:lib_dir(kernel)) =:= "kernel" andalso
 	filename:basename(code:lib_dir(stdlib)) =:= "stdlib".
+
+on_load_failure(Config) when is_list(Config) ->
+    SourceFile = filename:join([
+	?config(data_dir, Config),
+	"on_load_failure",
+	"code_on_load_failure.erl"
+    ]),
+    {ok, code_on_load_failure, Binary} = compile:file(SourceFile, [binary]),
+    {error, on_load_failure} = code:load_binary(
+	code_on_load_failure,
+	SourceFile,
+	Binary).
 
 on_load_errors(Config) when is_list(Config) ->
     Master = on_load_error_test_case_process,

--- a/lib/kernel/test/code_SUITE_data/on_load_failure/code_on_load_failure.erl
+++ b/lib/kernel/test/code_SUITE_data/on_load_failure/code_on_load_failure.erl
@@ -1,0 +1,6 @@
+-module(code_on_load_failure).
+
+-on_load(nif_load/0).
+
+nif_load() ->
+    exit(load_failure).


### PR DESCRIPTION
```code:load_binary/3``` return ```{error, on_load_failure}``` when a module can't load