### PR TITLE
Use file read buffering in dbg:trace_client

### DIFF
--- a/lib/runtime_tools/src/dbg.erl
+++ b/lib/runtime_tools/src/dbg.erl
@@ -1269,7 +1269,7 @@ gen_reader(follow_file, Filename) ->
 
 %% Opens a file and returns a reader (lazy list).
 gen_reader_file(ReadFun, Filename) ->
-    case file:open(Filename, [read, raw, binary]) of
+    case file:open(Filename, [read, raw, binary, read_ahead]) of
 	{ok, File} ->
 	    mk_reader(ReadFun, File);
 	Error ->
@@ -1294,7 +1294,7 @@ mk_reader(ReadFun, Source) ->
 mk_reader_wrap([]) ->
     [];
 mk_reader_wrap([Hd | _] = WrapFiles) ->
-    case file:open(wrap_name(Hd), [read, raw, binary]) of
+    case file:open(wrap_name(Hd), [read, raw, binary, read_ahead]) of
 	{ok, File} ->
 	    mk_reader_wrap(WrapFiles, File);
 	Error ->


### PR DESCRIPTION
Trace files are typically large but contain small terms so we can expect
a performance gain from read buffering. dbg:trace_client with a dummy
handler ran more then 3x faster on a sample 200MB trace file.
fprof:profile can also gain a bit.