### PR TITLE
Check for already started beam_lib crypto server

### DIFF
--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -931,7 +931,10 @@ call_crypto_server(Req) ->
     end.
 
 call_crypto_server_1(Req) ->
-    {ok, _} = gen_server:start({local,?CRYPTO_KEY_SERVER}, ?MODULE, [], []),
+    case gen_server:start({local,?CRYPTO_KEY_SERVER}, ?MODULE, [], []) of
+	{ok, _} -> ok;
+	{already_started, _} -> ok
+    end,
     erlang:yield(),
     call_crypto_server(Req).
 


### PR DESCRIPTION
When starting the beam_lib crypto server don't crash
when it is already running, some other process might
have already called it.

Found in the wild when using rebar to build a project using the -j option which spawns multiple processes for compiling (issue rebar/rebar#569)