### PR TITLE
Don't wait for twice the delay_write timeout

### DIFF
--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -700,9 +700,6 @@ static void do_request(g, fd, s, buf, bsize)
 	    put_int16(node->creation, wbuf+2);
 	}
   
-	if (g->delay_write)		/* Test of busy server */
-	  sleep(g->delay_write);
-
 	if (reply(g, fd, wbuf, 4) != 4)
 	  {
 	    dbg_tty_printf(g,1,"** failed to send ALIVE2_RESP for \"%s\"",


### PR DESCRIPTION
This happens only during processing ALIVE2 request. reply() already
performs the same delay as in the deleted code.