### PR TITLE
OTP 18.2 HiPE fix for FreeBSD 10.2-STABLE

### DIFF
--- a/erts/emulator/hipe/hipe_x86_signal.c
+++ b/erts/emulator/hipe/hipe_x86_signal.c
@@ -234,7 +234,29 @@ static void do_init(void)
 #define INIT()	do { if (!init_done()) do_init(); } while (0)
 #endif /* __sun__ */
 
-#if !(defined(__GLIBC__) || defined(__DARWIN__) || defined(__NetBSD__) || defined(__sun__))
+#if defined(__FreeBSD__)
+/*
+ * This is a copy of Darwin code for FreeBSD.
+ * CAVEAT: detailed semantics are not verified yet.
+ */
+#include <dlfcn.h>
+static int (*__next_sigaction)(int, const struct sigaction*, struct sigaction*);
+#define init_done()	(__next_sigaction != 0)
+extern int _sigaction(int, const struct sigaction*, struct sigaction*);
+#define __SIGACTION _sigaction
+static void do_init(void)
+{
+    __next_sigaction = dlsym(RTLD_NEXT, "sigaction");
+    if (__next_sigaction != 0)
+	return;
+    perror("dlsym_freebsd");
+    abort();
+}
+#define _NSIG NSIG
+#define INIT()	do { if (!init_done()) do_init(); } while (0)
+#endif /* __FreeBSD__ */
+
+#if !(defined(__GLIBC__) || defined(__DARWIN__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__sun__))
 /*
  * Unknown libc -- assume musl.  Note: musl deliberately does not provide a musl-specific
  * feature test macro, so we cannot check for it.
@@ -259,7 +281,7 @@ static void do_init(void)
 #define _NSIG NSIG
 #endif
 #define INIT()	do { if (!init_done()) do_init(); } while (0)
-#endif	/* !(__GLIBC__ || __DARWIN__ || __NetBSD__ || __sun__) */
+#endif	/* !(__GLIBC__ || __DARWIN__ || __NetBSD__ || __FreeBSD__ || __sun__) */
 
 #if !defined(__NetBSD__)
 /*
@@ -299,7 +321,7 @@ int __SIGACTION(int signum, const struct sigaction *act, struct sigaction *oldac
 /*
  * This catches the application's own sigaction() calls.
  */
-#if !defined(__DARWIN__) && !defined(__NetBSD__)
+#if !defined(__DARWIN__) && !defined(__NetBSD__) && !defined(__FreeBSD__)
 int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
 {
     return my_sigaction(signum, act, oldact);

--- a/erts/emulator/sys/common/erl_mmap.h
+++ b/erts/emulator/sys/common/erl_mmap.h
@@ -109,7 +109,17 @@ Eterm erts_mmap_debug_info(struct process*);
 #  if HAVE_MREMAP
 #    define ERTS_HAVE_OS_MREMAP 1
 #  endif
-#  if defined(MAP_FIXED) && defined(MAP_NORESERVE)
+/*
+ * MAP_NORESERVE is undefined in FreeBSD 10.x and later.
+ * This is to enable 64bit HiPE experimentally on FreeBSD.
+ * Note that on FreeBSD MAP_NORESERVE was "never implemented"
+ * even before 11.x (and the flag does not exist in /usr/src/sys/vm/mmap.c
+ * of 10.2-STABLE r291856 either), and HiPE was working on OTP 18.1.5,
+ * so mandating MAP_NORESERVE on FreeBSD might not be needed.
+ * See the following message on how MAP_NORESERVE was treated on FreeBSD:
+ * http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20150202/122958.html
+ */
+#  if defined(MAP_FIXED) && (defined(MAP_NORESERVE) || defined(__FreeBSD__))
 #    define ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION 1
 #  endif
 #endif

--- a/jj1bdx-build-command.sh
+++ b/jj1bdx-build-command.sh
@@ -1,0 +1,5 @@
+gmake clean
+export ERL_TOP=`pwd`
+export CC=clang CXX=clang CFLAGS="-O -g -fstack-protector" LDFLAGS="-fstack-protector" MAKEFLAGS="-j4"
+./configure --enable-native-libs --with-ssl=/usr/local --without-javac --enable-hipe --enable-kernel-poll --without-odbc --without-wx-config --enable-threads --disable-sctp --enable-smp-support --enable-fp-exceptions --disable-silent-rules
+gmake

--- a/jj1bdx-build-command.sh
+++ b/jj1bdx-build-command.sh
@@ -1,5 +1,0 @@
-gmake clean
-export ERL_TOP=`pwd`
-export CC=clang CXX=clang CFLAGS="-O -g -fstack-protector" LDFLAGS="-fstack-protector" MAKEFLAGS="-j4"
-./configure --enable-native-libs --with-ssl=/usr/local --without-javac --enable-hipe --enable-kernel-poll --without-odbc --without-wx-config --enable-threads --disable-sctp --enable-smp-support --enable-fp-exceptions --disable-silent-rules
-gmake


### PR DESCRIPTION
This pull request includes an experimental fix of running HiPE on FreeBSD.
Two fixes are included:

* Disregarding MAP_NORESERVE for FreeBSD since it hasn't been implemented in 10.x and will be removed from 11.x. Mandating this might not be needed because in the past versions HiPE did work on amd64. More detailed testing needed.
* Add FreeBSD sigaction code for HiPE. This is based on the Darwin (OS X) code and more detailed testing needed. FreeBSD libc is not musl, so this code is needed. See https://github.com/erlang/otp/pull/893 for the code in OTP 18.2.