### PR TITLE
Add ssl:getstat/1 and ssl:getstat/2

### DIFF
--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -73,7 +73,7 @@
 
 -export_type([address_family/0, hostent/0, hostname/0, ip4_address/0,
               ip6_address/0, ip_address/0, posix/0, socket/0,
-              port_number/0]).
+              port_number/0, stat_option/0]).
 
 %% imports
 -import(lists, [append/1, duplicate/2, filter/2, foldl/3]).

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -849,6 +849,23 @@ fun(srp, Username :: string(), UserState :: term()) ->
     </func>
 
     <func>
+      <name>getstat(Socket) ->
+        {ok, OptionValues} | {error, inet:posix()}</name>
+      <name>getstat(Socket, OptionNames) ->
+        {ok, OptionValues} | {error, inet:posix()}</name>
+      <fsummary>Get one or more statistic options for a socket</fsummary>
+      <type>
+    <v>Socket = sslsocket()</v>
+    <v>OptionNames = [atom()]</v>
+        <v>OptionValues = [{inet:stat_option(), integer()}]</v>
+      </type>
+      <desc>
+        <p>Gets one or more statistic options for the underlying TCP socket.</p>
+        <p>See inet:getstat/2 for statistic options description.</p>
+      </desc>
+    </func>
+
+    <func>
       <name>listen(Port, Options) ->
 	{ok, ListenSocket} | {error, Reason}</name>
       <fsummary>Creates an SSL listen socket.</fsummary>

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -34,7 +34,8 @@
 	 listen/2, transport_accept/1, transport_accept/2,
 	 ssl_accept/1, ssl_accept/2, ssl_accept/3,
 	 controlling_process/2, peername/1, peercert/1, sockname/1,
-	 close/1, close/2, shutdown/2, recv/2, recv/3, send/2, getopts/2, setopts/2
+	 close/1, close/2, shutdown/2, recv/2, recv/3, send/2,
+	 getopts/2, setopts/2, getstat/1, getstat/2
 	]).
 %% SSL/TLS protocol handling
 -export([cipher_suites/0, cipher_suites/1, suite_definition/1,
@@ -472,6 +473,32 @@ setopts(#sslsocket{pid = {_, #config{transport_info = {Transport,_,_,_}}}} = Lis
     end;
 setopts(#sslsocket{}, Options) ->
     {error, {options,{not_a_proplist, Options}}}.
+
+%%---------------------------------------------------------------
+-spec getstat(Socket) ->
+	{ok, OptionValues} | {error, inet:posix()} when
+      Socket :: #sslsocket{},
+      OptionValues :: [{inet:stat_option(), integer()}].
+%%
+%% Description: Get all statistic options for a socket.
+%%--------------------------------------------------------------------
+getstat(Socket) ->
+	getstat(Socket, inet:stats()).
+
+%%---------------------------------------------------------------
+-spec getstat(Socket, Options) ->
+	{ok, OptionValues} | {error, inet:posix()} when
+      Socket :: #sslsocket{},
+      Options :: [inet:stat_option()],
+      OptionValues :: [{inet:stat_option(), integer()}].
+%%
+%% Description: Get one or more statistic options for a socket.
+%%--------------------------------------------------------------------
+getstat(#sslsocket{pid = {Listen,  #config{transport_info = {Transport, _, _, _}}}}, Options) when is_port(Listen), is_list(Options) ->
+    ssl_socket:getstat(Transport, Listen, Options);
+
+getstat(#sslsocket{pid = Pid, fd = {Transport, Socket, _, _}}, Options) when is_pid(Pid), is_list(Options) ->
+    ssl_socket:getstat(Transport, Socket, Options).
 
 %%---------------------------------------------------------------
 -spec shutdown(#sslsocket{}, read | write | read_write) ->  ok | {error, reason()}.

--- a/lib/ssl/src/ssl_socket.erl
+++ b/lib/ssl/src/ssl_socket.erl
@@ -24,7 +24,7 @@
 -include("ssl_internal.hrl").
 -include("ssl_api.hrl").
 
--export([socket/5, setopts/3, getopts/3, peername/2, sockname/2, port/2]).
+-export([socket/5, setopts/3, getopts/3, getstat/3, peername/2, sockname/2, port/2]).
 -export([emulated_options/0, internal_inet_values/0, default_inet_values/0,
 	 init/1, start_link/3, terminate/2, inherit_tracker/3, get_emulated_opts/1, 
 	 set_emulated_opts/2, get_all_opts/1, handle_call/3, handle_cast/2,
@@ -73,6 +73,11 @@ getopts(gen_tcp, Socket, Options) ->
     inet:getopts(Socket, Options);
 getopts(Transport, Socket, Options) ->
     Transport:getopts(Socket, Options).
+
+getstat(gen_tcp, Socket, Options) ->
+	inet:getstat(Socket, Options);
+getstat(Transport, Socket, Options) ->
+	Transport:getstat(Socket, Options).
 
 peername(gen_tcp, Socket) ->
     inet:peername(Socket);

--- a/lib/ssl/test/ssl_basic_SUITE.erl
+++ b/lib/ssl/test/ssl_basic_SUITE.erl
@@ -127,6 +127,7 @@ api_tests() ->
      sockname,
      versions,
      controlling_process,
+     getstat,
      upgrade,
      upgrade_with_timeout,
      downgrade,
@@ -525,6 +526,70 @@ controlling_process(Config) when is_list(Config) ->
 
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
+
+%%--------------------------------------------------------------------
+getstat() ->
+    [{doc,"Test API function getstat/2"}].
+
+getstat(Config) when is_list(Config) ->
+    ClientOpts = ?config(client_opts, Config),
+    ServerOpts = ?config(server_opts, Config),
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Server1 =
+        ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                                   {from, self()},
+                                   {mfa, {ssl_test_lib, send_recv_result, []}},
+                                   {options,  [{active, false} | ServerOpts]}]),
+    Port1 = ssl_test_lib:inet_port(Server1),
+    Server2 =
+        ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                                   {from, self()},
+                                   {mfa, {ssl_test_lib, send_recv_result, []}},
+                                   {options,  [{active, false} | ServerOpts]}]),
+    Port2 = ssl_test_lib:inet_port(Server2),
+    {ok, ActiveC} = rpc:call(ClientNode, ssl, connect,
+                          [Hostname,Port1,[{active, false}|ClientOpts]]),
+    {ok, PassiveC} = rpc:call(ClientNode, ssl, connect,
+                          [Hostname,Port2,[{active, false}|ClientOpts]]),
+
+    ct:log("Testcase ~p, Client ~p  Servers ~p, ~p ~n",
+                       [self(), self(), Server1, Server2]),
+
+    %% We only check that the values are non-zero initially
+    %% (due to the handshake), and that sending more changes the values.
+
+    %% Passive socket.
+
+    {ok, InitialStats} = ssl:getstat(PassiveC),
+    [true] = lists:usort([0 =/= proplists:get_value(Name, InitialStats)
+        || Name <- [recv_cnt, recv_oct, recv_avg, recv_max, send_cnt, send_oct, send_avg, send_max]]),
+
+    ok = ssl:send(PassiveC, "Hello world"),
+    {ok, SStats} = ssl:getstat(PassiveC, [send_cnt, send_oct, send_avg]),
+    [true] = lists:usort([proplists:get_value(Name, SStats) =/= proplists:get_value(Name, InitialStats)
+        || Name <- [send_cnt, send_oct, send_avg]]),
+
+    %% Active socket.
+
+    {ok, InitialAStats} = ssl:getstat(ActiveC),
+    [true] = lists:usort([0 =/= proplists:get_value(Name, InitialStats)
+        || Name <- [recv_cnt, recv_oct, recv_avg, recv_max, send_cnt, send_oct, send_avg, send_max]]),
+
+    ssl:setopts(ActiveC, [{active, once}]),
+    _ = receive
+        {ssl, ActiveC, Data} ->
+            "Hello world" = Data
+    after
+        ?SLEEP ->
+            exit(timeout)
+    end,
+
+    ok = ssl:send(ActiveC, "Hello world"),
+    {ok, ASStats} = ssl:getstat(ActiveC, [send_cnt, send_oct, send_avg]),
+    [true] = lists:usort([proplists:get_value(Name, ASStats) =/= proplists:get_value(Name, InitialAStats)
+        || Name <- [send_cnt, send_oct, send_avg]]),
+
+    ok.
 
 %%--------------------------------------------------------------------
 controller_dies() ->


### PR DESCRIPTION
These functions call getstat on the underlying TCP socket.
The only way to do this before now was to use a hack, either
by looking inside the #sslsocket{} record directly, or by
not using the SSL listen/accept functions and upgrading
from a TCP socket that is kept around for the purpose of
calling getstat later on.

A separate commit also exports the type inet:stat_option/0
to be able to use it in the ssl module's specs.