### PR TITLE
Change snmp_pdus.erl for Counter64 to 2^64-1(MAX)

### DIFF
--- a/lib/snmp/src/misc/snmp_pdus.erl
+++ b/lib/snmp/src/misc/snmp_pdus.erl
@@ -336,7 +336,7 @@ dec_value([70 | Bytes]) ->
     {Value, Rest} = dec_integer_notag(Bytes),
     Value2 = 
     	if
-    	    (Value >= 0) andalso (Value < 16#8000000000000000) ->
+    	    (Value >= 0) andalso (Value < 18446744073709551615) ->
     		Value;
     	    (Value < 0) ->
     		16#ffffffffffffffff + Value + 1;


### PR DESCRIPTION
From SNMPV2(RFC 1573), Counter64's range is 0-18446744073709551615.
From OTP-8563, Counter64's range is (-9223372036854775808)-(9223372036854775807) in erlang snmpm. If Counter64 is encoded and decoded by erlang snmpm, everything is ok. 
If Counter64 is collected by real network device and decoded by erlang snmpm, "{error,{bad_counter64,18446744073709551615}}}" will be reported by erlang snmpm.

So I think "(Value >= 0) andalso (Value < 16#8000000000000000) ->" should be modified to "(Value >= 0) andalso (Value < 18446744073709551615) ->" in snmp_pdus.erl.