### PR TITLE
Do not consider "." part of names in edlin

### DIFF
--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -465,7 +465,6 @@ word_char(C) when C >= $a, C =< $z -> true;
 word_char(C) when C >= $ß, C =< $ÿ, C =/= $÷ -> true;
 word_char(C) when C >= $0, C =< $9 -> true;
 word_char(C) when C =:= $_ -> true;
-word_char(C) when C =:= $. -> true;    % accept dot-separated names
 word_char(_) -> false.
 
 %% over_white(Chars, InitialStack, InitialCount) ->


### PR DESCRIPTION
Today, if you press Ctrl+W inside erl, it will erase word chars including dots.

This may have made sense in the past when Erlang had packages, but today
considering the most common case for dots inside erl is to work with records,
considering the dot part of the word is rather a mistake.

For example, imagine the following code, where [] is the cursor:

    1> S#elixir_scope.name[]

When I press Ctrl+W it erases all up to #:

    1> S#[]

This patch changes it to the dot is no longer considered part of the name:

    1> S#elixir_scope.[]

Which is rather expected behaviour for most use cases of dot in Erlang.