### PR TITLE
Fix inadvertent deletion of callback info in Dialyzer

### DIFF
--- a/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
+++ b/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
@@ -93,23 +93,14 @@ loop(#server_state{parent = Parent} = State,
       send_log(Parent, LogMsg),
       loop(State, Analysis, ExtCalls);
     {AnalPid, warnings, Warnings} ->
-      case Warnings of
-	[] -> ok;
-	SendWarnings ->
-	  send_warnings(Parent, SendWarnings)
-      end,
+      send_warnings(Parent, Warnings),
       loop(State, Analysis, ExtCalls);
     {AnalPid, cserver, CServer, Plt} ->
       send_codeserver_plt(Parent, CServer, Plt),
       loop(State, Analysis, ExtCalls);
     {AnalPid, done, Plt, DocPlt} ->
-      case ExtCalls =:= none of
-	true ->
-	  send_analysis_done(Parent, Plt, DocPlt);
-	false ->
-	  send_ext_calls(Parent, ExtCalls),
-	  send_analysis_done(Parent, Plt, DocPlt)
-      end;
+      send_ext_calls(Parent, ExtCalls),
+      send_analysis_done(Parent, Plt, DocPlt);
     {AnalPid, ext_calls, NewExtCalls} ->
       loop(State, Analysis, NewExtCalls);
     {AnalPid, ext_types, ExtTypes} ->
@@ -569,6 +560,8 @@ send_analysis_done(Parent, Plt, DocPlt) ->
   Parent ! {self(), done, Plt, DocPlt},
   ok.
 
+send_ext_calls(_Parent, none) ->
+  ok;
 send_ext_calls(Parent, ExtCalls) ->
   Parent ! {self(), ext_calls, ExtCalls},
   ok.

--- a/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
+++ b/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
@@ -115,9 +115,6 @@ loop(#server_state{parent = Parent} = State,
     {AnalPid, ext_types, ExtTypes} ->
       send_ext_types(Parent, ExtTypes),
       loop(State, Analysis, ExtCalls);
-    {AnalPid, unknown_behaviours, UnknownBehaviour} ->
-      send_unknown_behaviours(Parent, UnknownBehaviour),
-      loop(State, Analysis, ExtCalls);
     {AnalPid, mod_deps, ModDeps} ->
       send_mod_deps(Parent, ModDeps),
       loop(State, Analysis, ExtCalls);
@@ -578,10 +575,6 @@ send_ext_calls(Parent, ExtCalls) ->
 
 send_ext_types(Parent, ExtTypes) ->
   Parent ! {self(), ext_types, ExtTypes},
-  ok.
-
-send_unknown_behaviours(Parent, UnknownBehaviours) ->
-  Parent ! {self(), unknown_behaviours, UnknownBehaviours},
   ok.
 
 send_codeserver_plt(Parent, CServer, Plt ) ->

--- a/lib/dialyzer/src/dialyzer_plt.erl
+++ b/lib/dialyzer/src/dialyzer_plt.erl
@@ -137,7 +137,7 @@ delete_list(#plt{info = Info, types = Types,
   #plt{info = table_delete_list(Info, List),
        types = Types,
        contracts = table_delete_list(Contracts, List),
-       callbacks = table_delete_list(Callbacks, List),
+       callbacks = Callbacks,
        exported_types = ExpTypes}.
 
 -spec insert_contract_list(plt(), dialyzer_contracts:plt_contracts()) -> plt().


### PR DESCRIPTION
If a behaviour module contains an non-exported function with the same name as
one of the behaviour's callbacks, the callback info was inadvertently deleted
from the PLT as the dialyzer_plt:delete_list/2 function was cleaning up the
callback table. This bug was reported by Brujo Benavides.

Fixes ERL-72 bug report.
