### PR TITLE
erts/common: check for OOM on Windows

### DIFF
--- a/erts/etc/common/ct_run.c
+++ b/erts/etc/common/ct_run.c
@@ -81,13 +81,14 @@ static int eargc;		/* Number of arguments in eargv. */
  */
 
 static void error(char* format, ...);
-static char* emalloc(size_t size);
+static void* emalloc(size_t size);
 static char* strsave(char* string);
 static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
 static char* possibly_quote(char* arg);
+static void* erealloc(void *p, size_t size);
 #endif
 
 /*
@@ -141,10 +142,10 @@ int main(int argc, char** argv)
     int i;
     int len;
     /* Convert argv to utf8 */
-    argv = malloc((argc+1) * sizeof(char*));
+    argv = emalloc((argc+1) * sizeof(char*));
     for (i=0; i<argc; i++) {
 	len = WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, NULL, 0, NULL, NULL);
-	argv[i] = malloc(len*sizeof(char));
+	argv[i] = emalloc(len*sizeof(char));
 	WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, argv[i], len, NULL, NULL);
     }
     argv[argc] = NULL;
@@ -334,7 +335,7 @@ wchar_t *make_commandline(char **argv)
 	buff = (wchar_t *) emalloc(siz*sizeof(wchar_t));
     } else if (siz < num) {
 	siz = num;
-	buff = (wchar_t *) realloc(buff,siz*sizeof(wchar_t));
+	buff = (wchar_t *) erealloc(buff,siz*sizeof(wchar_t));
     }
     p = buff;
     num=0;
@@ -437,14 +438,25 @@ error(char* format, ...)
     exit(1);
 }
 
-static char*
+static void*
 emalloc(size_t size)
 {
-  char *p = malloc(size);
+  void *p = malloc(size);
   if (p == NULL)
     error("Insufficient memory");
   return p;
 }
+
+#ifdef __WIN32__
+static void *
+erealloc(void *p, size_t size)
+{
+    void *res = realloc(p, size);
+    if (res == NULL)
+    error("Insufficient memory");
+    return res;
+}
+#endif
 
 static char*
 strsave(char* string)

--- a/erts/etc/common/dialyzer.c
+++ b/erts/etc/common/dialyzer.c
@@ -63,13 +63,14 @@ static int eargc;		/* Number of arguments in eargv. */
  */
 
 static void error(char* format, ...);
-static char* emalloc(size_t size);
+static void* emalloc(size_t size);
 static char* strsave(char* string);
 static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
 static char* possibly_quote(char* arg);
+static void* erealloc(void *p, size_t size);
 #endif
 
 /*
@@ -164,10 +165,10 @@ int main(int argc, char** argv)
 #ifdef __WIN32__
     int len;
     /* Convert argv to utf8 */
-    argv = malloc((argc+1) * sizeof(char*));
+    argv = emalloc((argc+1) * sizeof(char*));
     for (i=0; i<argc; i++) {
 	len = WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, NULL, 0, NULL, NULL);
-	argv[i] = malloc(len*sizeof(char));
+	argv[i] = emalloc(len*sizeof(char));
 	WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, argv[i], len, NULL, NULL);
     }
     argv[argc] = NULL;
@@ -310,7 +311,7 @@ wchar_t *make_commandline(char **argv)
 	buff = (wchar_t *) emalloc(siz*sizeof(wchar_t));
     } else if (siz < num) {
 	siz = num;
-	buff = (wchar_t *) realloc(buff,siz*sizeof(wchar_t));
+	buff = (wchar_t *) erealloc(buff,siz*sizeof(wchar_t));
     }
     p = buff;
     num=0;
@@ -413,14 +414,25 @@ error(char* format, ...)
     exit(1);
 }
 
-static char*
+static void*
 emalloc(size_t size)
 {
-  char *p = malloc(size);
+  void *p = malloc(size);
   if (p == NULL)
     error("Insufficient memory");
   return p;
 }
+
+#ifdef __WIN32__
+static void *
+erealloc(void *p, size_t size)
+{
+    void *res = realloc(p, size);
+    if (res == NULL)
+    error("Insufficient memory");
+    return res;
+}
+#endif
 
 static char*
 strsave(char* string)

--- a/erts/etc/common/erlc.c
+++ b/erts/etc/common/erlc.c
@@ -71,13 +71,14 @@ static int pause_after_execution = 0;
 
 static char* process_opt(int* pArgc, char*** pArgv, int offset);
 static void error(char* format, ...);
-static char* emalloc(size_t size);
+static void* emalloc(size_t size);
 static char* strsave(char* string);
 static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
 static char* possibly_quote(char* arg);
+static void* erealloc(void *p, size_t size);
 #endif
 
 /*
@@ -171,10 +172,10 @@ int main(int argc, char** argv)
     int i;
     int len;
     /* Convert argv to utf8 */
-    argv = malloc((argc+1) * sizeof(char*));
+    argv = emalloc((argc+1) * sizeof(char*));
     for (i=0; i<argc; i++) {
 	len = WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, NULL, 0, NULL, NULL);
-	argv[i] = malloc(len*sizeof(char));
+	argv[i] = emalloc(len*sizeof(char));
 	WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, argv[i], len, NULL, NULL);
     }
     argv[argc] = NULL;
@@ -370,7 +371,7 @@ wchar_t *make_commandline(char **argv)
 	buff = (wchar_t *) emalloc(siz*sizeof(wchar_t));
     } else if (siz < num) {
 	siz = num;
-	buff = (wchar_t *) realloc(buff,siz*sizeof(wchar_t));
+	buff = (wchar_t *) erealloc(buff,siz*sizeof(wchar_t));
     }
     p = buff;
     num=0;
@@ -478,14 +479,25 @@ error(char* format, ...)
     exit(1);
 }
 
-static char*
+static void*
 emalloc(size_t size)
 {
-  char *p = malloc(size);
+  void *p = malloc(size);
   if (p == NULL)
     error("Insufficient memory");
   return p;
 }
+
+#ifdef __WIN32__
+static void *
+erealloc(void *p, size_t size)
+{
+    void *res = realloc(p, size);
+    if (res == NULL)
+    error("Insufficient memory");
+    return res;
+}
+#endif
 
 static char*
 strsave(char* string)

--- a/erts/etc/common/escript.c
+++ b/erts/etc/common/escript.c
@@ -71,7 +71,7 @@ static int eargc;		/* Number of arguments in eargv. */
  */
 
 static void error(char* format, ...);
-static char* emalloc(size_t size);
+static void* emalloc(size_t size);
 static void efree(void *p);
 static char* strsave(char* string);
 static void push_words(char* src);
@@ -79,6 +79,7 @@ static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
 static char* possibly_quote(char* arg);
+static void* erealloc(void *p, size_t size);
 #endif
 
 /*
@@ -418,10 +419,10 @@ main(int argc, char** argv)
     int i;
     int len;
     /* Convert argv to utf8 */
-    argv = malloc((argc+1) * sizeof(char*));
+    argv = emalloc((argc+1) * sizeof(char*));
     for (i=0; i<argc; i++) {
 	len = WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, NULL, 0, NULL, NULL);
-	argv[i] = malloc(len*sizeof(char));
+	argv[i] = emalloc(len*sizeof(char));
 	WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, argv[i], len, NULL, NULL);
     }
     argv[argc] = NULL;
@@ -594,7 +595,7 @@ wchar_t *make_commandline(char **argv)
 	buff = (wchar_t *) emalloc(siz*sizeof(wchar_t));
     } else if (siz < num) {
 	siz = num;
-	buff = (wchar_t *) realloc(buff,siz*sizeof(wchar_t));
+	buff = (wchar_t *) erealloc(buff,siz*sizeof(wchar_t));
     }
     p = buff;
     num=0;
@@ -694,14 +695,25 @@ error(char* format, ...)
     exit(1);
 }
 
-static char*
+static void*
 emalloc(size_t size)
 {
-  char *p = malloc(size);
+  void *p = malloc(size);
   if (p == NULL)
     error("Insufficient memory");
   return p;
 }
+
+#ifdef __WIN32__
+static void *
+erealloc(void *p, size_t size)
+{
+    void *res = realloc(p, size);
+    if (res == NULL)
+    error("Insufficient memory");
+    return res;
+}
+#endif
 
 static void
 efree(void *p) 

--- a/erts/etc/common/inet_gethost.c
+++ b/erts/etc/common/inet_gethost.c
@@ -2646,7 +2646,7 @@ static void *my_realloc(void *old, size_t size)
 
 BOOL create_mesq(MesQ **q) 
 {
-    MesQ *tmp = malloc(sizeof(MesQ));
+    MesQ *tmp = ALLOC(sizeof(MesQ));
     tmp->data_present = CreateEvent(NULL, TRUE, FALSE,NULL);
     if (tmp->data_present == NULL) {
 	free(tmp);

--- a/erts/etc/common/typer.c
+++ b/erts/etc/common/typer.c
@@ -63,13 +63,14 @@ static int eargc;		/* Number of arguments in eargv. */
  */
 
 static void error(char* format, ...);
-static char* emalloc(size_t size);
+static void* emalloc(size_t size);
 static char* strsave(char* string);
 static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
 static char* possibly_quote(char* arg);
+static void* erealloc(void *p, size_t size);
 #endif
 
 /*
@@ -118,10 +119,10 @@ main(int argc, char** argv)
     int i;
     int len;
     /* Convert argv to utf8 */
-    argv = malloc((argc+1) * sizeof(char*));
+    argv = emalloc((argc+1) * sizeof(char*));
     for (i=0; i<argc; i++) {
 	len = WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, NULL, 0, NULL, NULL);
-	argv[i] = malloc(len*sizeof(char));
+	argv[i] = emalloc(len*sizeof(char));
 	WideCharToMultiByte(CP_UTF8, 0, wcargv[i], -1, argv[i], len, NULL, NULL);
     }
     argv[argc] = NULL;
@@ -232,7 +233,7 @@ wchar_t *make_commandline(char **argv)
 	buff = (wchar_t *) emalloc(siz*sizeof(wchar_t));
     } else if (siz < num) {
 	siz = num;
-	buff = (wchar_t *) realloc(buff,siz*sizeof(wchar_t));
+	buff = (wchar_t *) erealloc(buff,siz*sizeof(wchar_t));
     }
     p = buff;
     num=0;
@@ -332,14 +333,25 @@ error(char* format, ...)
     exit(1);
 }
 
-static char*
+static void*
 emalloc(size_t size)
 {
-  char *p = malloc(size);
+  void *p = malloc(size);
   if (p == NULL)
     error("Insufficient memory");
   return p;
 }
+
+#ifdef __WIN32__
+static void *
+erealloc(void *p, size_t size)
+{
+    void *res = realloc(p, size);
+    if (res == NULL)
+    error("Insufficient memory");
+    return res;
+}
+#endif
 
 static char*
 strsave(char* string)


### PR DESCRIPTION
Fix the command line tools to abort on allocation failures when run
on Windows. Modify the malloc() wrapper to consistently return void*
across all the tools.