### PR TITLE
Allow to refresh resolver settings on startup

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -514,7 +514,8 @@ res_update(Tag, TagTm, TagInfo, TagSetTm, SetFun) ->
 	undefined -> ok;
 	TM ->
 	    case times() of
-		Now when Now >= TM + ?RES_FILE_UPDATE_TM ->
+		Now when Now >= TM + ?RES_FILE_UPDATE_TM;
+		(TM =:= 0 andalso Now < ?RES_FILE_UPDATE_TM) ->
 		    case db_get(Tag) of
 			undefined ->
 			    SetFun("");


### PR DESCRIPTION
After the VM time changes `inet_db:times/0` instead of returning number of
seconds since 1970, returns number of seconds since the VM start. As a
result, if `inet_res:lookup/3` is called right after the system start, the
condition for re-reading /etc/resolv.conf will not be met (time
difference between last access: 0, and the value returned from
`inet_db:times/0` -> [0-5) is lower than 5 seconds) and no nameservers
will be used.

This patch allows /etc/resolv.conf to be read immediately after the
system is started.

dbg output for repro: https://gist.github.com/paulgray/fe64b8baf8230803863f