### PR TITLE
Erts hipe x86 signal cleanups

### DIFF
--- a/erts/emulator/hipe/hipe_x86_signal.c
+++ b/erts/emulator/hipe/hipe_x86_signal.c
@@ -251,7 +251,7 @@ static void hipe_sigaltstack(void *ss_sp)
     stack_t ss;
 
     ss.ss_sp = ss_sp;
-    ss.ss_flags = SS_ONSTACK;
+    ss.ss_flags = 0;
     ss.ss_size = SIGSTKSZ;
     if (sigaltstack(&ss, NULL) < 0) {
 	perror("sigaltstack");

--- a/erts/emulator/hipe/hipe_x86_signal.c
+++ b/erts/emulator/hipe/hipe_x86_signal.c
@@ -192,6 +192,15 @@ static void do_init(void)
 #define INIT()	do { if (!init_done()) do_init(); } while (0)
 #endif /* __FreeBSD__ */
 
+#if defined(__NetBSD__)
+/*
+ * Note: This is only stub code to allow the build to succeed.
+ * Whether this actually provides the needed overrides for safe
+ * signal delivery or not is unknown.
+ */
+#define INIT()	do { } while (0)
+#endif /* __NetBSD__ */
+
 #if !(defined(__GLIBC__) || defined(__DARWIN__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__sun__))
 /*
  * Unknown libc -- assume musl.  Note: musl deliberately does not provide a musl-specific
@@ -243,6 +252,7 @@ static int my_sigaction(int signum, const struct sigaction *act, struct sigactio
     return __next_sigaction(signum, act, oldact);
 }
 #endif
+
 /*
  * This overrides the C library's core sigaction() procedure, catching
  * all its internal calls.
@@ -313,9 +323,7 @@ void hipe_signal_init(void)
     struct sigaction sa;
     int i;
 
-#ifndef __NetBSD__
     INIT();
-#endif
 
     hipe_sigaltstack_init();
 

--- a/erts/emulator/hipe/hipe_x86_signal.c
+++ b/erts/emulator/hipe/hipe_x86_signal.c
@@ -84,7 +84,7 @@
 static int (*__next_sigaction)(int, const struct sigaction*, struct sigaction*);
 #define init_done()	(__next_sigaction != 0)
 extern int __sigaction(int, const struct sigaction*, struct sigaction*);
-#define __SIGACTION __sigaction
+#define LIBC_SIGACTION __sigaction
 static void do_init(void)
 {
     __next_sigaction = dlsym(RTLD_NEXT, "__sigaction");
@@ -121,7 +121,7 @@ static void do_init(void)
 static int (*__next_sigaction)(int, const struct sigaction*, struct sigaction*);
 #define init_done()	(__next_sigaction != 0)
 extern int _sigaction(int, const struct sigaction*, struct sigaction*);
-#define __SIGACTION _sigaction
+#define LIBC_SIGACTION _sigaction
 static void do_init(void)
 {
     __next_sigaction = dlsym(RTLD_NEXT, "sigaction");
@@ -157,7 +157,7 @@ static void do_init(void)
 #include <dlfcn.h>
 static int (*__next_sigaction)(int, const struct sigaction*, struct sigaction*);
 #define init_done()	(__next_sigaction != 0)
-#define __SIGACTION _sigaction
+#define LIBC_SIGACTION _sigaction
 static void do_init(void)
 {
     __next_sigaction = dlsym(RTLD_NEXT, "_sigaction");
@@ -179,7 +179,7 @@ static void do_init(void)
 static int (*__next_sigaction)(int, const struct sigaction*, struct sigaction*);
 #define init_done()	(__next_sigaction != 0)
 extern int _sigaction(int, const struct sigaction*, struct sigaction*);
-#define __SIGACTION _sigaction
+#define LIBC_SIGACTION _sigaction
 static void do_init(void)
 {
     __next_sigaction = dlsym(RTLD_NEXT, "sigaction");
@@ -213,7 +213,7 @@ static void do_init(void)
 #include <dlfcn.h>
 static int (*__next_sigaction)(int, const struct sigaction*, struct sigaction*);
 #define init_done()	(__next_sigaction != 0)
-#define __SIGACTION __libc_sigaction
+#define LIBC_SIGACTION __libc_sigaction
 static void do_init(void)
 {
     __next_sigaction = dlsym(RTLD_NEXT, "__libc_sigaction");
@@ -257,8 +257,8 @@ static int my_sigaction(int signum, const struct sigaction *act, struct sigactio
  * This overrides the C library's core sigaction() procedure, catching
  * all its internal calls.
  */
-#ifdef __SIGACTION
-int __SIGACTION(int signum, const struct sigaction *act, struct sigaction *oldact)
+#if defined(LIBC_SIGACTION)
+int LIBC_SIGACTION(int signum, const struct sigaction *act, struct sigaction *oldact)
 {
     return my_sigaction(signum, act, oldact);
 }

--- a/erts/emulator/hipe/hipe_x86_signal.c
+++ b/erts/emulator/hipe/hipe_x86_signal.c
@@ -81,7 +81,6 @@
 #define __USE_GNU		/* to un-hide RTLD_NEXT */
 #endif
 #define NEXT_SIGACTION "__sigaction"
-extern int __sigaction(int, const struct sigaction*, struct sigaction*);
 #define LIBC_SIGACTION __sigaction
 #endif	/* glibc >= 2.3 */
 
@@ -107,7 +106,6 @@ extern int __sigaction(int, const struct sigaction*, struct sigaction*);
  * of and don't modify.
  */
 #define NEXT_SIGACTION "sigaction"
-extern int _sigaction(int, const struct sigaction*, struct sigaction*);
 #define LIBC_SIGACTION _sigaction
 #define _NSIG NSIG
 #endif /* __DARWIN__ */
@@ -143,7 +141,6 @@ extern int _sigaction(int, const struct sigaction*, struct sigaction*);
  * CAVEAT: detailed semantics are not verified yet.
  */
 #define NEXT_SIGACTION "sigaction"
-extern int _sigaction(int, const struct sigaction*, struct sigaction*);
 #define LIBC_SIGACTION _sigaction
 #define _NSIG NSIG
 #endif /* __FreeBSD__ */
@@ -218,11 +215,12 @@ static int my_sigaction(int signum, const struct sigaction *act, struct sigactio
 }
 #endif
 
+#if defined(LIBC_SIGACTION)
 /*
  * This overrides the C library's core sigaction() procedure, catching
  * all its internal calls.
  */
-#if defined(LIBC_SIGACTION)
+extern int LIBC_SIGACTION(int, const struct sigaction*, struct sigaction*);
 int LIBC_SIGACTION(int signum, const struct sigaction *act, struct sigaction *oldact)
 {
     return my_sigaction(signum, act, oldact);

--- a/erts/emulator/hipe/hipe_x86_signal.c
+++ b/erts/emulator/hipe/hipe_x86_signal.c
@@ -82,6 +82,7 @@
 #endif
 #define NEXT_SIGACTION "__sigaction"
 #define LIBC_SIGACTION __sigaction
+#define OVERRIDE_SIGACTION
 #endif	/* glibc >= 2.3 */
 
 /* Is there no standard identifier for Darwin/MacOSX ? */
@@ -107,6 +108,7 @@
  */
 #define NEXT_SIGACTION "sigaction"
 #define LIBC_SIGACTION _sigaction
+#undef OVERRIDE_SIGACTION
 #define _NSIG NSIG
 #endif /* __DARWIN__ */
 
@@ -132,6 +134,7 @@
  */
 #define NEXT_SIGACTION "_sigaction"
 #define LIBC_SIGACTION _sigaction
+#define OVERRIDE_SIGACTION
 #define _NSIG NSIG
 #endif /* __sun__ */
 
@@ -142,6 +145,7 @@
  */
 #define NEXT_SIGACTION "sigaction"
 #define LIBC_SIGACTION _sigaction
+#undef OVERRIDE_SIGACTION
 #define _NSIG NSIG
 #endif /* __FreeBSD__ */
 
@@ -152,6 +156,7 @@
  * signal delivery or not is unknown.
  */
 #undef NEXT_SIGACTION
+#undef OVERRIDE_SIGACTION
 #endif /* __NetBSD__ */
 
 #if !(defined(__GLIBC__) || defined(__DARWIN__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__sun__))
@@ -165,6 +170,7 @@
  */
 #define NEXT_SIGACTION "__libc_sigaction"
 #define LIBC_SIGACTION __libc_sigaction
+#define OVERRIDE_SIGACTION
 #ifndef _NSIG
 #define _NSIG NSIG
 #endif
@@ -227,10 +233,10 @@ int LIBC_SIGACTION(int signum, const struct sigaction *act, struct sigaction *ol
 }
 #endif
 
+#if defined(OVERRIDE_SIGACTION)
 /*
  * This catches the application's own sigaction() calls.
  */
-#if !defined(__DARWIN__) && !defined(__NetBSD__) && !defined(__FreeBSD__)
 int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
 {
     return my_sigaction(signum, act, oldact);


### PR DESCRIPTION
Various cleanups in hipe_x86_signal.c:

- remove code for glibc < 2.3 and Linux kernels < 2.4
- rename locally defined symbols to avoid names prefixed by "_" (which are reserved in C)
- refactor to reduce code duplication
- introduce feature macros to replace long system-specific ifndefs
  (the one for musl libc needs to remain until we have a configure test for it)

I manually compared the generated assembly code on Linux/x86_64/glibc before and after this series, and found no unexpected changes.

This is currently a series of commits, each tackling a specific change, to keep things reviewable.  I'd be happy to squash these together, or have OTP squash them, before they go upstream.