### PR TITLE
Export gen_tcp:socket() type

### DIFF
--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -114,7 +114,8 @@
         option().
 -type socket() :: port().
 
--export_type([option/0, option_name/0, connect_option/0, listen_option/0]).
+-export_type([option/0, option_name/0, connect_option/0, listen_option/0,
+              socket/0]).
 
 %%
 %% Connect a socket


### PR DESCRIPTION
When handling a gen_tcp socket, it's handy to be able to give it its proper type
and have dialyzer be able to validate it, rather than falling back on using
port(). The gen_udp equivalent is already exported.