### PR TITLE
More options for TLS distribution connections

### DIFF
--- a/lib/ssl/doc/src/ssl_distribution.xml
+++ b/lib/ssl/doc/src/ssl_distribution.xml
@@ -196,6 +196,7 @@ Eshell V5.0  (abort with ^G)
       <item><c>password</c></item>
       <item><c>cacertfile</c></item>
       <item><c>verify</c></item>
+      <item><c>verify_fun</c> (write as <c>{Module, Function, InitialUserState}</c>)</item>
       <item><c>reuse_sessions</c></item>
       <item><c>secure_renegotiate</c></item>
       <item><c>depth</c></item>
@@ -203,16 +204,16 @@ Eshell V5.0  (abort with ^G)
       <item><c>ciphers</c> (use old string format)</item>
     </list>
 
+    <p>Note that <c>verify_fun</c> needs to be written in a different
+    form than the corresponding SSL option, since funs are not
+    accepted on the command line.</p>
+
     <p>The server can also take the options <c>dhfile</c> and
     <c>fail_if_no_peer_cert</c> (also prefixed).</p>
 
     <p><c>client_</c>-prefixed options are used when the distribution 
     initiates a connection to another node. <c>server_</c>-prefixed 
     options are used when accepting a connection from a remote node.</p>
-
-    <p>More complex options, such as <c>verify_fun</c>, are currently not 
-    available, but a mechanism to handle such options may be added in
-    a future release.</p>
 
     <p>Raw socket options, such as <c>packet</c> and <c>size</c> must not 
     be specified on the command line.</p>

--- a/lib/ssl/doc/src/ssl_distribution.xml
+++ b/lib/ssl/doc/src/ssl_distribution.xml
@@ -197,6 +197,8 @@ Eshell V5.0  (abort with ^G)
       <item><c>cacertfile</c></item>
       <item><c>verify</c></item>
       <item><c>verify_fun</c> (write as <c>{Module, Function, InitialUserState}</c>)</item>
+      <item><c>crl_check</c></item>
+      <item><c>crl_cache</c> (write as Erlang term)</item>
       <item><c>reuse_sessions</c></item>
       <item><c>secure_renegotiate</c></item>
       <item><c>depth</c></item>

--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -396,6 +396,10 @@ ssl_options(server, ["server_verify", Value|T]) ->
     [{verify, atomize(Value)} | ssl_options(server,T)];
 ssl_options(client, ["client_verify", Value|T]) ->
     [{verify, atomize(Value)} | ssl_options(client,T)];
+ssl_options(server, ["server_verify_fun", Value|T]) ->
+    [{verify_fun, verify_fun(Value)} | ssl_options(server,T)];
+ssl_options(client, ["client_verify_fun", Value|T]) ->
+    [{verify_fun, verify_fun(Value)} | ssl_options(client,T)];
 ssl_options(server, ["server_reuse_sessions", Value|T]) ->
     [{reuse_sessions, atomize(Value)} | ssl_options(server,T)];
 ssl_options(client, ["client_reuse_sessions", Value|T]) ->
@@ -427,6 +431,20 @@ atomize(List) when is_list(List) ->
     list_to_atom(List);
 atomize(Atom) when is_atom(Atom) ->
     Atom.
+
+termify(String) when is_list(String) ->
+    {ok, Tokens, _} = erl_scan:string(String ++ "."),
+    {ok, Term} = erl_parse:parse_term(Tokens),
+    Term.
+
+verify_fun(Value) ->
+    case termify(Value) of
+	{Mod, Func, State} when is_atom(Mod), is_atom(Func) ->
+	    Fun = fun Mod:Func/3,
+	    {Fun, State};
+	_ ->
+	    error(malformed_ssl_dist_opt, [Value])
+    end.
 
 flush_old_controller(Pid, Socket) ->
     receive

--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -420,8 +420,8 @@ ssl_options(server, ["server_dhfile", Value|T]) ->
     [{dhfile, Value} | ssl_options(server,T)];
 ssl_options(server, ["server_fail_if_no_peer_cert", Value|T]) ->
     [{fail_if_no_peer_cert, atomize(Value)} | ssl_options(server,T)];
-ssl_options(_,_) ->
-    exit(malformed_ssl_dist_opt).
+ssl_options(Type, Opts) ->
+    error(malformed_ssl_dist_opt, [Type, Opts]).
 
 atomize(List) when is_list(List) ->
     list_to_atom(List);

--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -400,6 +400,14 @@ ssl_options(server, ["server_verify_fun", Value|T]) ->
     [{verify_fun, verify_fun(Value)} | ssl_options(server,T)];
 ssl_options(client, ["client_verify_fun", Value|T]) ->
     [{verify_fun, verify_fun(Value)} | ssl_options(client,T)];
+ssl_options(server, ["server_crl_check", Value|T]) ->
+    [{crl_check, atomize(Value)} | ssl_options(server,T)];
+ssl_options(client, ["client_crl_check", Value|T]) ->
+    [{crl_check, atomize(Value)} | ssl_options(client,T)];
+ssl_options(server, ["server_crl_cache", Value|T]) ->
+    [{crl_cache, termify(Value)} | ssl_options(server,T)];
+ssl_options(client, ["client_crl_cache", Value|T]) ->
+    [{crl_cache, termify(Value)} | ssl_options(client,T)];
 ssl_options(server, ["server_reuse_sessions", Value|T]) ->
     [{reuse_sessions, atomize(Value)} | ssl_options(server,T)];
 ssl_options(client, ["client_reuse_sessions", Value|T]) ->

--- a/lib/ssl/test/ssl_dist_SUITE.erl
+++ b/lib/ssl/test/ssl_dist_SUITE.erl
@@ -581,7 +581,7 @@ crl_cache_check_pass(Config) when is_list(Config) ->
     NodeDir = filename:join([PrivDir, "Certs"]),
     DistOpts = "-ssl_dist_opt "
         "client_crl_check true "
-        "client_crl_cache {ssl_dist_SUITE,{internal,\\\"" ++ NodeDir ++ "\\\"}}",
+        "client_crl_cache {ssl_dist_SUITE,{\\\"" ++ NodeDir ++ "\\\",[]}}",
     NewConfig =
         [{many_verify_opts, true}, {additional_dist_opts, DistOpts}] ++ Config,
 
@@ -607,7 +607,7 @@ crl_cache_check_fail(Config) when is_list(Config) ->
     NodeDir = filename:join([PrivDir, "Certs"]),
     DistOpts = "-ssl_dist_opt "
         "client_crl_check true "
-        "client_crl_cache {ssl_dist_SUITE,{internal,\\\"" ++ NodeDir ++ "\\\"}}",
+        "client_crl_cache {ssl_dist_SUITE,{\\\"" ++ NodeDir ++ "\\\",[]}}",
     NewConfig =
         [{many_verify_opts, true},
          %% The server uses a revoked certificate.
@@ -631,7 +631,7 @@ crl_cache_check_fail(Config) when is_list(Config) ->
 lookup(_DistributionPoint, _DbHandle) ->
     not_available.
 
-select({rdnSequence, NameParts}, {_, NodeDir}) ->
+select({rdnSequence, NameParts}, {NodeDir, _}) ->
     %% Extract the CN from the issuer name...
     [CN] = [CN ||
                [#'AttributeTypeAndValue'{

--- a/lib/ssl/test/ssl_dist_SUITE.erl
+++ b/lib/ssl/test/ssl_dist_SUITE.erl
@@ -806,11 +806,13 @@ mk_node_cmdline(ListenPort, Name, Args) ->
 	++ NameSw ++ " " ++ Name ++ " "
 	++ "-pa " ++ Pa ++ " "
 	++ "-run application start crypto -run application start public_key "
+	++ "-eval 'net_kernel:verbose(1)' "
 	++ "-run " ++ atom_to_list(?MODULE) ++ " cnct2tstsrvr "
 	++ host_name() ++ " "
 	++ integer_to_list(ListenPort) ++ " "
 	++ Args ++ " "
 	++ "-env ERL_CRASH_DUMP " ++ Pwd ++ "/erl_crash_dump." ++ Name ++ " "
+	++ "-kernel error_logger '{file,\"" ++ Pwd ++ "/error_log." ++ Name ++ "\"}' "
 	++ "-setcookie " ++ atom_to_list(erlang:get_cookie()).
 
 %%

--- a/lib/ssl/test/ssl_dist_SUITE.erl
+++ b/lib/ssl/test/ssl_dist_SUITE.erl
@@ -812,7 +812,7 @@ mk_node_cmdline(ListenPort, Name, Args) ->
 	++ integer_to_list(ListenPort) ++ " "
 	++ Args ++ " "
 	++ "-env ERL_CRASH_DUMP " ++ Pwd ++ "/erl_crash_dump." ++ Name ++ " "
-	++ "-kernel error_logger '{file,\"" ++ Pwd ++ "/error_log." ++ Name ++ "\"}' "
+	++ "-kernel error_logger \"{file,\\\"" ++ Pwd ++ "/error_log." ++ Name ++ "\\\"}\" "
 	++ "-setcookie " ++ atom_to_list(erlang:get_cookie()).
 
 %%


### PR DESCRIPTION
Allow specifying `verify_fun`, `crl_check` and `crl_cache` options for TLS distribution connections.

For `verify_fun`, I made it parse arguments of the form `module:function`, since that's presumably the most common kind of value, and I didn't want the command line syntax to be too complicated. For `crl_cache` on the other hand, I made it parse full Erlang terms, since you're likely to need that in order to specify options for the CRL cache module.