### PR TITLE
TLS distribution: shut down accept process cleanly

### DIFF
--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -194,6 +194,11 @@ accept_loop(Proxy, erts = Type, Listen, Extra) ->
 		{_Kernel, unsupported_protocol} ->
 		    exit(unsupported_protocol)
 	    end;
+	{error, closed} ->
+	    %% The listening socket is closed: the proxy process is
+	    %% shutting down.  Exit normally, to avoid generating a
+	    %% spurious error report.
+	    exit(normal);
 	Error ->
 	    exit(Error)
     end,


### PR DESCRIPTION
In `ssl_tls_dist_proxy:accept_loop/3`, handle `{error, closed}` by
exiting normally.  This prevents a spurious error report at node
shutdown:

    {error_logger,{{2016,2,9},{11,18,58}},supervisor_report,[{supervisor,{local,ssl_dist_sup}},{errorContext,child_terminated},{reason,{error,closed}},{offender,[{pid,<0.25.0>},{id,ssl_tls_dist_proxy},{mfargs,{ssl_tls_dist_proxy,start_link,[]}},{restart_type,permanent},{shutdown,4000},{child_type,worker}]}]}
