### PR TITLE
tftp: support transfer of files > 65535 blocks

### DIFF
--- a/lib/inets/src/tftp/tftp_engine.erl
+++ b/lib/inets/src/tftp/tftp_engine.erl
@@ -656,22 +656,11 @@ common_read(Config, Callback, Req, _LocalAccess, ExpectedBlockNo, ActualBlockNo,
 
 do_common_read(Config, Callback, Req, LocalAccess, BlockNo, Data, Prepared)
   when is_binary(Data), is_record(Prepared, prepared) ->
-    NextBlockNo = BlockNo + 1,
-    case NextBlockNo =< 65535 of
-        true ->
-            Reply = #tftp_msg_data{block_no = NextBlockNo, data = Data},
-            {Config2, Callback2, TransferRes} =
-                transfer(Config, Callback, Req, Reply, LocalAccess, NextBlockNo, Prepared),
-            ?MODULE:common_loop(Config2, Callback2, Req, TransferRes, LocalAccess, NextBlockNo);
-        false ->
-            Code = badblk,
-            Text = "Too big transfer ID = " ++ 
-                integer_to_list(NextBlockNo) ++ " > 65535", 
-            {undefined, Error} =
-                callback({abort, {Code, Text}}, Config, Callback, Req),
-            send_msg(Config, Req, Error),
-            terminate(Config, Req, ?ERROR(read, Code, Text, Req#tftp_msg_req.filename))
-    end.
+    NextBlockNo = (BlockNo + 1) rem 65536,
+    Reply = #tftp_msg_data{block_no = NextBlockNo, data = Data},
+    {Config2, Callback2, TransferRes} =
+        transfer(Config, Callback, Req, Reply, LocalAccess, NextBlockNo, Prepared),
+    ?MODULE:common_loop(Config2, Callback2, Req, TransferRes, LocalAccess, NextBlockNo).
 
 -spec common_write(#config{}, #callback{}, _, 'write', integer(), integer(), _, #prepared{}) -> no_return().
 
@@ -715,21 +704,10 @@ common_write(Config, Callback, Req, _, ExpectedBlockNo, ActualBlockNo, Data, Pre
 common_ack(Config, Callback, Req, LocalAccess, BlockNo, Prepared) 
   when is_record(Prepared, prepared) ->
     Reply = #tftp_msg_ack{block_no = BlockNo},
-    NextBlockNo = BlockNo + 1,
+    NextBlockNo = (BlockNo + 1) rem 65536,
     {Config2, Callback2, TransferRes} = 
         transfer(Config, Callback, Req, Reply, LocalAccess, NextBlockNo, Prepared),
-    case NextBlockNo =< 65535 of
-        true ->   
-            ?MODULE:common_loop(Config2, Callback2, Req, TransferRes, LocalAccess, NextBlockNo);
-        false ->
-            Code = badblk,
-            Text = "Too big transfer ID = " ++ 
-                integer_to_list(NextBlockNo) ++ " > 65535", 
-            {undefined, Error} =
-                callback({abort, {Code, Text}}, Config, Callback2, Req),
-            send_msg(Config, Req, Error),
-            terminate(Config, Req, ?ERROR(read, Code, Text, Req#tftp_msg_req.filename))
-    end.
+    ?MODULE:common_loop(Config2, Callback2, Req, TransferRes, LocalAccess, NextBlockNo).
 
 pre_terminate(Config, Req, Result) ->
     if


### PR DESCRIPTION
The block count is an unsigned 2 byte integer. The common behaviour of
tftp clients and servers is to overflow the block count and wrap the
counter to 0 in order to support files larger than 32M. Modify the tftp
implementation to do the same rollover.

Interoperability was tested by transferring a 1.4G file using the HPA
tftp client.