### PR TITLE
decode now non hexa url with % inside

### DIFF
--- a/lib/inets/src/http_lib/http_uri.erl
+++ b/lib/inets/src/http_lib/http_uri.erl
@@ -112,7 +112,15 @@ encode(URI) ->
 decode(String) ->
     do_decode(String).
 
-do_decode([$%,Hex1,Hex2|Rest]) ->
+do_decode([$%,Hex1,Hex2|Rest])
+  when
+      ( (Hex1>=$0) andalso (Hex1=<$9)
+	orelse (Hex1>=$A) andalso (Hex1=<$F)
+	orelse (Hex1>=$a) andalso (Hex1=<$f) )
+      andalso ( (Hex2>=$0) andalso (Hex2=<$9)
+		orelse (Hex2>=$A) andalso (Hex2=<$F)
+		orelse (Hex2>=$a) andalso (Hex2=<$f) )
+      ->
     [hex2dec(Hex1)*16+hex2dec(Hex2)|do_decode(Rest)];
 do_decode([First|Rest]) ->
     [First|do_decode(Rest)];


### PR DESCRIPTION
```erlang
1> [{T, http_uri:decode(T)} || T <-["20% sure", "20%% sure", "20%25%20sure", "20%25%25%20sure"]].
[{"20% sure","20% sure"},
 {"20%% sure","20%% sure"},
 {"20%25%20sure","20% sure"},
 {"20%25%25%20sure","20%% sure"}]
```
without this patch :
```erlang
** exception error: no function clause matching http_uri:hex2dec(32) (http_uri.erl, line 237)
     in function  http_uri:do_decode/1 (http_uri.erl, line 116)
     in call from http_uri:do_decode/1 (http_uri.erl, line 118)
```