### PR TITLE
FIX reverting optional_callbacks in erl_syntax

### DIFF
--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -3182,13 +3182,13 @@ revert_attribute_1(module, [M, List], Pos, Node) ->
 	    {attribute, Pos, module, {A, Vs}};
 	error -> Node
     end;
-revert_attribute_1(export, [List], Pos, Node) ->
+revert_attribute_1(N, [List], Pos, Node) when N =:= export; N =:= optional_callbacks ->
     case is_list_skeleton(List) of
 	true ->
 	    case is_proper_list(List) of
 		true ->
 		    Fs = fold_function_names(list_elements(List)),
-		    {attribute, Pos, export, Fs};
+		    {attribute, Pos, N, Fs};
 		false ->
 		    Node
 	    end;

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -25,14 +25,14 @@
 	 init_per_group/2,end_per_group/2]).
 
 %% Test cases
--export([app_test/1,appup_test/1,smoke_test/1,revert/1,revert_map/1,
+-export([app_test/1,appup_test/1,smoke_test/1,revert/1,revert_map/1,revert_optional_callbacks/1,
 	t_abstract_type/1,t_erl_parse_type/1,t_epp_dodger/1,
 	t_comment_scan/1,t_igor/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
-all() -> 
-    [app_test,appup_test,smoke_test,revert,revert_map,
+all() ->
+    [app_test,appup_test,smoke_test,revert,revert_map,revert_optional_callbacks,
     t_abstract_type,t_erl_parse_type,t_epp_dodger,
     t_comment_scan,t_igor].
 
@@ -123,7 +123,20 @@ revert_map(Config) when is_list(Config) ->
 			     {map_field_assoc,{atom,17,name},{var,18,'Value'}}}]),
     ?t:timetrap_cancel(Dog).
 
-
+%% Testing bug fix for reverting optional_callbacks
+revert_optional_callbacks(Config) when is_list(Config) ->
+    Dog = ?t:timetrap(?t:minutes(1)),
+    [{attribute,3,optional_callbacks,[{b,0}]}] =
+        erl_syntax:revert_forms([{tree,attribute,
+                                  {attr,3,[],none},
+                                  {attribute,
+                                   {atom,3,optional_callbacks},
+                                   [{cons,3,
+                                     {tree,arity_qualifier,
+                                      {attr,3,[],none},
+                                      {arity_qualifier,{atom,0,b},{integer,0,0}}},
+                                     {nil,3}}]}}]),
+    ?t:timetrap_cancel(Dog).
 
 %% api tests
 


### PR DESCRIPTION
Now, we can not get the correct result, when we use parse_transform to the module that use optional_callbacks.

e.g.
Use two modules.
- [cth_readable_transform](https://github.com/ferd/cth_readable/blob/master/src/cth_readable_transform.erl)
- [spam_behaviour](https://gist.github.com/soranoba/f204516cad4b97d80ee5)

```erlang
1> compile:file("spam_behaviour.erl", []).
{ok,spam_behaviour}
2> spam_behaviour:module_info().
[{module,spam_behaviour},
 {exports,[{behaviour_info,1},
           {module_info,0},
           {module_info,1}]},
 {attributes,[{vsn,[35725444967346471917509995781393807706]},
              {optional_callbacks,[{b,0}]},
              {callback,[{{a,0},
                          [{type,[5],
                                 'fun',
                                 [{type,[5],product,[]},{atom,[5],ok}]}]}]},
              {callback,[{{b,0},
                          [{type,[6],
                                 'fun',
                                 [{type,[6],product,[]},{atom,[6],ok}]}]}]}]},
 {compile,[{options,[]},
           {version,"6.0.2"},
           {time,{2016,2,17,16,2,33}},
           {source,"/home/skyplace/Documents/cth_readable/spam_behaviour.erl"}]},
 {native,false},
 {md5,<<26,224,120,109,179,171,34,105,102,224,155,14,46,
        128,249,90>>}]
```

```erlang
1> compile:file("spam_behaviour.erl", [{parse_transform, cth_readable_transform}]).
{ok,spam_behaviour}
2> spam_behaviour:module_info().
[{module,spam_behaviour},
 {exports,[{behaviour_info,1},
           {module_info,0},
           {module_info,1}]},
 {attributes,[{vsn,[80889456943641145268189515282482762837]},
              {optional_callbacks,[{{atom,0,b},{integer,0,0}}]}, %% what happened !?
              {callback,[{{a,0},
                          [{type,[5],
                                 'fun',
                                 [{type,[5],product,[]},{atom,[5],ok}]}]}]},
              {callback,[{{b,0},
                          [{type,[6],
                                 'fun',
                                 [{type,[6],product,[]},{atom,[6],ok}]}]}]}]},
 {compile,[{options,[{parse_transform,cth_readable_transform}]},
           {version,"6.0.2"},
           {time,{2016,2,17,16,4,45}},
           {source,"/home/skyplace/Documents/cth_readable/spam_behaviour.erl"}]},
 {native,false},
 {md5,<<60,218,190,35,163,106,215,32,242,82,31,162,66,52,
        148,85>>}]
```

I fix this.