### PR TITLE
inets: Add DELETE Body to http client

### DIFF
--- a/lib/inets/src/http_client/httpc_request.erl
+++ b/lib/inets/src/http_client/httpc_request.erl
@@ -186,16 +186,18 @@ is_client_closing(Headers) ->
 %%%========================================================================
 %%% Internal functions
 %%%========================================================================
-post_data(Method, Headers, {ContentType, Body}, HeadersAsIs) 
-  when (Method =:= post) orelse (Method =:= put)
-       orelse (Method =:= patch) ->
+post_data(Method, Headers, {ContentType, Body}, HeadersAsIs)
+    when (Method =:= post)
+    orelse (Method =:= put)
+    orelse (Method =:= patch) ->
+
     NewBody = case Headers#http_request_h.expect of
-		  "100-continue" ->
-		      "";
-		  _ ->
-		      Body
-	      end,
-    
+          "100-continue" ->
+              "";
+          _ ->
+              Body
+          end,
+
     NewHeaders = case HeadersAsIs of
         [] ->
             Headers#http_request_h{
@@ -213,7 +215,7 @@ post_data(Method, Headers, {ContentType, Body}, HeadersAsIs)
         _ ->
             HeadersAsIs
     end,
-    
+
     {NewHeaders, NewBody};
 
 post_data(_, Headers, _, []) ->

--- a/lib/inets/src/http_client/httpc_request.erl
+++ b/lib/inets/src/http_client/httpc_request.erl
@@ -189,7 +189,8 @@ is_client_closing(Headers) ->
 post_data(Method, Headers, {ContentType, Body}, HeadersAsIs)
     when (Method =:= post)
     orelse (Method =:= put)
-    orelse (Method =:= patch) ->
+    orelse (Method =:= patch)
+    orelse (Method =:= delete) ->
 
     NewBody = case Headers#http_request_h.expect of
           "100-continue" ->

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -67,6 +67,7 @@ real_requests()->
      head,
      get,
      post,
+     delete,
      post_stream,
      patch,
      async,
@@ -256,6 +257,29 @@ post(Config) when is_list(Config) ->
     {ok, {{_,504,_}, [_ | _], []}} =
 	httpc:request(post, {URL, [{"expect","100-continue"}],
 			     "text/plain", "foobar"}, [], []).
+%%--------------------------------------------------------------------
+delete() ->
+    [{"Test http delete request against local server. We do in this case "
+     "only care about the client side of the the delete. The server "
+     "script will not actually use the delete data."}].
+delete(Config) when is_list(Config) ->
+    CGI = case test_server:os_type() of
+          {win32, _} ->
+          "/cgi-bin/cgi_echo.exe";
+          _ ->
+          "/cgi-bin/cgi_echo"
+      end,
+
+    URL  = url(group_name(Config), CGI, Config),
+    Body = lists:duplicate(100, "1"),
+
+    {ok, {{_,200,_}, [_ | _], [_ | _]}} =
+    httpc:request(delete, {URL, [{"expect","100-continue"}],
+                 "text/plain", Body}, [], []),
+
+    {ok, {{_,504,_}, [_ | _], []}} =
+    httpc:request(delete, {URL, [{"expect","100-continue"}],
+                 "text/plain", "foobar"}, [], []).
 
 %%--------------------------------------------------------------------
 patch() ->


### PR DESCRIPTION
This patch allows sending a request body on ```DELETE``` requests

Given the following request :

```erlang
httpc:request(delete, {"http://httpbin.org/delete", [], "application/json", "[1,2,3]"}, [], []).
```


Expected result :

```erlang
{ok, {
    {"HTTP/1.1",200,"OK"},
    [{"content-type","application/json"}],
     "{\"data\":\"[1,2,3]\"}"
}}
```


Actual result :

```erlang
{ok, {
    {"HTTP/1.1",200,"OK"},
    [{"content-type","application/json"}],
     "{\"data\":\"\"}"
}}
```