### PR TITLE
Use compile source info in debugger

### DIFF
--- a/lib/debugger/src/int.erl
+++ b/lib/debugger/src/int.erl
@@ -547,7 +547,7 @@ load({Mod, Src, Beam, BeamBin, Exp, Abst}, Dist) ->
 check_module(Mod) ->
     case code:which(Mod) of
 	Beam when is_list(Beam) ->
-	    case find_src(Beam) of
+	    case find_src(Mod, Beam) of
 		Src when is_list(Src) ->
 		    check_application(Src),
 		    case check_beam(Beam) of
@@ -608,7 +608,7 @@ check_application2("gs-"++_) -> throw({error,{app,gs}});
 check_application2("debugger-"++_) -> throw({error,{app,debugger}});
 check_application2(_) -> ok.
 
-find_src(Beam) ->
+find_src(Mod, Beam) ->
     Src0 = filename:rootname(Beam) ++ ".erl",
     case is_file(Src0) of
 	true -> Src0;
@@ -618,8 +618,20 @@ find_src(Beam) ->
 				 filename:basename(Src0)]),
 	    case is_file(Src) of
 		true -> Src;
-		false -> error
+		false -> find_src_from_module(Mod)
 	    end
+    end.
+
+find_src_from_module(Mod) ->
+    Compile = Mod:module_info(compile),
+    case lists:keyfind(source, 1, Compile) of
+	{source, Src} ->
+	    case is_file(Src) of
+		true -> Src;
+		false -> error
+	    end;
+	false ->
+	    error
     end.
 
 find_beam(Mod, Src) ->

--- a/lib/debugger/test/int_SUITE.erl
+++ b/lib/debugger/test/int_SUITE.erl
@@ -245,14 +245,13 @@ interpretable(Config) when is_list(Config) ->
     ?line true = int:interpretable(filename:join([DataDir,lists1])),
     ?line true = code:del_path(DataDir),
 
-    %% {error, no_src}
-    ?line PrivDir = filename:join(?config(priv_dir, Config), ""),
-    ?line {ok, _} = file:copy(filename:join([DataDir,"lists1.beam"]),
+    %% true (from source)
+    PrivDir = filename:join(?config(priv_dir, Config), ""),
+    {ok, _} = file:copy(filename:join([DataDir,"lists1.beam"]),
 			      filename:join([PrivDir,"lists1.beam"])),
-    ?line true = code:add_patha(PrivDir),
-
-    ?line {error, no_src} = int:interpretable(lists1),
-    ?line ok = file:delete(filename:join([PrivDir,"lists1.beam"])),
+    true = code:add_patha(PrivDir),
+    true = int:interpretable(lists1),
+    ok = file:delete(filename:join([PrivDir,"lists1.beam"])),
 
     %% {error, no_beam}
     Src = filename:join([PrivDir,"lists1.erl"]),
@@ -266,6 +265,11 @@ interpretable(Config) when is_list(Config) ->
     ?line {error, no_debug_info} = int:interpretable(lists1),
     ?line ok = file:delete(Src),
     ?line true = code:del_path(PrivDir),
+
+    %% {error, no_src}
+    {ok, lists2, Binary} = compile:forms([{attribute,1,module,lists2}], []),
+    code:load_binary(lists2, "unknown", Binary),
+    {error, no_src} = int:interpretable(lists2),
 
     %% {error, badarg}
     ?line {error, badarg} = int:interpretable(pride),


### PR DESCRIPTION
Prior to this commit, the debugger relied on a simple heuristic
that traverses directory from the beam file to find a source file.
The heuristic was maintained with this patch but, if it fails,
it fallbacks to the source value in the module compile info.

In order to illustrate how it works, one of the tests that
could not find its source now passes successfully (showing the
source lookup is more robust).