### PR TITLE
Add a -discontiguous directive as in EEP 38

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -418,7 +418,7 @@ passes(Type, Opts) ->
     {Ext,Passes0} = passes_1(Opts),
     Passes1 = case Type of
 		  file -> Passes0;
-		  forms -> tl(Passes0)
+		  forms -> [?pass(join_discontiguous_clauses) | tl(Passes0)]
 	      end,
     Passes = select_passes(Passes1, Opts),
 
@@ -722,6 +722,13 @@ binary_passes() ->
 remove_file(St) ->
     _ = file:delete(St#compile.ofile),
     {ok,St}.
+
+join_discontiguous_clauses(St) ->
+    Forms1 = St#compile.code,
+    Forms2 = if is_list(Forms1) -> epp:join_discontiguous_clauses(Forms1);
+		true -> Forms1 % eg core
+	     end,
+    {ok,St#compile{code=Forms2}}.
 
 -record(asm_module, {module,
 		     exports,

--- a/system/doc/reference_manual/functions.xml
+++ b/system/doc/reference_manual/functions.xml
@@ -69,6 +69,11 @@ fact(N) when N>0 ->  % first clause head
 
 fact(0) ->           % second clause head
     1.               % second clause body</pre>
+    <p>Normally, all function clauses are kept together, but on
+      occasion, it may be useful to separate individual clauses or
+      groups of clauses. The <c>-discontiguous([Name/Arity]).</c>
+      directive allows this to be done for a function with the
+      specified name and arity.</p>
   </section>
 
   <section>

--- a/system/doc/reference_manual/modules.xml
+++ b/system/doc/reference_manual/modules.xml
@@ -129,6 +129,13 @@ fact(0) ->           %  |
 	    <seealso marker="code_loading#on_load">
             Running a Function When a Module is Loaded</seealso>.</p>
         </item>
+        <tag><c>-discontiguous(Functions).</c></tag>
+        <item>
+          <p>Declare that the specified functions may be presented as
+            more than one group of clauses, possibly separated by other
+            directives and function clause groups.</p>
+          <p><c>Functions</c> is a list similar as for <c>export</c>.</p>
+        </item>
       </taglist>
     </section>
 


### PR DESCRIPTION
This commit adds the directive
```erlang
  -discontiguous([FunctionName/Arity, ...]).
```
"so that specified functions may be presented as more than one group of
clauses, possibly separated by other directives and function clause
groups." (quote from the [EEP 38](https://github.com/erlang/eep/blob/master/eeps/eep-0038.md))

Thus, it is possible to write code for instance like this (note how the clauses for
format_error are separated):
```erlang
    -module(something).
    -compile([...]).
    -discontiguous([format_error/1]).

    some_function(...) -> ...
    format_error({bad_something,X}) -> ...

    some_other_function(...) -> ...
    format_error({invalid_other_thing,Y}) -> ...
```
There are more uses, see to the [EEP](https://github.com/erlang/eep/blob/master/eeps/eep-0038.md) for a more thorough discussion.

Performance impact:
For a large sample file, with no -discontiguous directive, a slowdown of 0.3 percent was measured. The file was 672 kB in size, with 1298 functions, and 79 defined records, The measurement was timing the evaluation of `compile:file("sample.erl", [binary])).` (The `binary` option was to exclude file system operations (writes) from the measurements as far as possible, I assume that for read operations, the file system cache took the hits. It was measured on a 3.3GHz core i7 Haswell.)

I've based the PR on maint, but I can easily rebase to master if you would want me to.