### PR TITLE
Add Ctrl+D support to ssh and user_drv

### DIFF
--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -572,6 +572,8 @@ io_command({delete_chars,N}) ->
     {command,[?OP_DELC|put_int16(N, [])]};
 io_command(beep) ->
     {command,[?OP_BEEP]};
+io_command({halt, Status}) ->
+    erlang:halt(Status);
 io_command(Else) ->
     throw(Else).
 

--- a/lib/ssh/src/ssh_cli.erl
+++ b/lib/ssh/src/ssh_cli.erl
@@ -300,6 +300,10 @@ io_request({put_chars_sync, Class, Cs, Reply}, Buf, Tty, Group) ->
     Group ! {reply, Reply},
     io_request({put_chars, Class, Cs}, Buf, Tty, Group);
 
+%% New in 19
+io_request({halt, Status}, _Buf, _Tty, _Group) ->
+    erlang:halt(Status);
+
 io_request(_R, Buf, _Tty, _Group) ->
     {[], Buf}.
 

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -186,7 +186,7 @@ prefix_arg(N) -> N.
 key_map(A, _) when is_atom(A) -> A;		% so we can push keywords
 key_map($\^A, none) -> beginning_of_line;
 key_map($\^B, none) -> backward_char;
-key_map($\^D, none) -> forward_delete_char;
+key_map($\^D, none) -> forward_delete_char_with_halt_on_empty;
 key_map($\^E, none) -> end_of_line;
 key_map($\^F, none) -> forward_char;
 key_map($\^H, none) -> backward_delete_char;
@@ -361,6 +361,11 @@ do_op(auto_blink, Bef, Aft, Rs) ->
 	N -> {blink,N+1,{Bef,Aft},
 	      [{move_rel,-(N+1)}|Rs]}
     end;
+
+do_op(forward_delete_char_with_halt_on_empty, [], [], Rs) ->
+    {{[], []}, [{halt, 0}, {put_chars, unicode, [$\n]}|Rs]};
+do_op(forward_delete_char_with_halt_on_empty, Bef, [_|Aft], Rs) ->
+    {{Bef,Aft},[{delete_chars,1}|Rs]};
 do_op(forward_delete_char, Bef, [_|Aft], Rs) ->
     {{Bef,Aft},[{delete_chars,1}|Rs]};
 do_op(backward_delete_char, [_|Bef], Aft, Rs) ->


### PR DESCRIPTION
It works similar to the shell in Unix systems and
in many languages where Ctrl+D will shut the system
down if the current line is empty (i.e. no text before
nor after the current cursor position).

If there is text after, it will be deleted as previously.
If there is text before, a beep sound will be emitted.

In case of remote nodes, it won't shut down the remote node.