### PR TITLE
Remove references to mod_include and webtool from examples and tests

### DIFF
--- a/lib/inets/examples/server_root/conf/8080.conf
+++ b/lib/inets/examples/server_root/conf/8080.conf
@@ -1,7 +1,7 @@
 Port 8080
 #ServerName your.server.net
 SocketType ip_comm
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8080

--- a/lib/inets/examples/server_root/conf/8888.conf
+++ b/lib/inets/examples/server_root/conf/8888.conf
@@ -1,7 +1,7 @@
 Port 8888
 #ServerName your.server.net
 SocketType ip_comm
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8888

--- a/lib/inets/examples/server_root/conf/httpd.conf
+++ b/lib/inets/examples/server_root/conf/httpd.conf
@@ -64,7 +64,7 @@ SocketType ip_comm
 # WARNING! Do not tamper with this directive unless you are familiar with
 # EWSAPI.
 
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_responsecontrol mod_trace mod_range mod_head mod_include mod_dir mod_get mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_responsecontrol mod_trace mod_range mod_head mod_dir mod_get mod_log mod_disk_log
 
 # ServerAdmin: Your address, where problems with the server should be
 # e-mailed.

--- a/lib/inets/examples/server_root/conf/ssl.conf
+++ b/lib/inets/examples/server_root/conf/ssl.conf
@@ -1,7 +1,7 @@
 Port 8088
 #ServerName your.server.net
 SocketType ssl
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8088

--- a/lib/inets/test/httpd_1_1.erl
+++ b/lib/inets/test/httpd_1_1.erl
@@ -233,14 +233,6 @@ trace(Type, Port, Host, Node)->
 					  "Max-Forwards:2\r\n\r\n",
 					  [{statuscode, 200}]).
 head(Type, Port, Host, Node)->
-    %% mod_include 
-    ok = httpd_test_lib:verify_request(Type, Host, Port, Node,
-				       "HEAD /fsize.shtml HTTP/1.0\r\n\r\n", 
-				       [{statuscode, 200},
-				       {version, "HTTP/1.0"}]),
-    ok = httpd_test_lib:verify_request(Type, Host, Port, Node,
-			"HEAD /fsize.shtml HTTP/1.1\r\nhost:" ++ 
-			Host  ++ "\r\n\r\n", [{statuscode, 200}]),
     %% mod_esi
     ok = httpd_test_lib:verify_request(Type, Host, Port, Node,
 			"HEAD /cgi-bin/erl/httpd_example/newformat"

--- a/lib/inets/test/httpd_test_data/server_root/conf/8080.conf
+++ b/lib/inets/test/httpd_test_data/server_root/conf/8080.conf
@@ -1,7 +1,7 @@
 Port 8080
 #ServerName your.server.net
 SocketType ip_comm
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8080

--- a/lib/inets/test/httpd_test_data/server_root/conf/8888.conf
+++ b/lib/inets/test/httpd_test_data/server_root/conf/8888.conf
@@ -1,7 +1,7 @@
 Port 8888
 #ServerName your.server.net
 SocketType ip_comm
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8888

--- a/lib/inets/test/httpd_test_data/server_root/conf/httpd.conf
+++ b/lib/inets/test/httpd_test_data/server_root/conf/httpd.conf
@@ -64,7 +64,7 @@ SocketType ip_comm
 # WARNING! Do not tamper with this directive unless you are familiar with
 # EWSAPI.
 
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_responsecontrol mod_trace mod_range mod_head mod_include mod_dir mod_get mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_responsecontrol mod_trace mod_range mod_head mod_dir mod_get mod_log mod_disk_log
 
 # ServerAdmin: Your address, where problems with the server should be
 # e-mailed.

--- a/lib/inets/test/httpd_test_data/server_root/conf/ssl.conf
+++ b/lib/inets/test/httpd_test_data/server_root/conf/ssl.conf
@@ -1,7 +1,7 @@
 Port 8088
 #ServerName your.server.net
 SocketType ssl
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8088

--- a/lib/inets/test/old_httpd_SUITE_data/server_root/conf/8080.conf
+++ b/lib/inets/test/old_httpd_SUITE_data/server_root/conf/8080.conf
@@ -1,7 +1,7 @@
 Port 8080
 #ServerName your.server.net
 SocketType ip_comm
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8080

--- a/lib/inets/test/old_httpd_SUITE_data/server_root/conf/8888.conf
+++ b/lib/inets/test/old_httpd_SUITE_data/server_root/conf/8888.conf
@@ -1,7 +1,7 @@
 Port 8888
 #ServerName your.server.net
 SocketType ip_comm
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8888

--- a/lib/inets/test/old_httpd_SUITE_data/server_root/conf/httpd.conf
+++ b/lib/inets/test/old_httpd_SUITE_data/server_root/conf/httpd.conf
@@ -64,7 +64,7 @@ SocketType ip_comm
 # WARNING! Do not tamper with this directive unless you are familiar with
 # EWSAPI.
 
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_responsecontrol mod_trace mod_range mod_head mod_include mod_dir mod_get mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_responsecontrol mod_trace mod_range mod_head mod_dir mod_get mod_log mod_disk_log
 
 # ServerAdmin: Your address, where problems with the server should be
 # e-mailed.

--- a/lib/inets/test/old_httpd_SUITE_data/server_root/conf/ssl.conf
+++ b/lib/inets/test/old_httpd_SUITE_data/server_root/conf/ssl.conf
@@ -1,7 +1,7 @@
 Port 8088
 #ServerName your.server.net
 SocketType ssl
-Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_include mod_dir mod_get mod_head mod_log mod_disk_log
+Modules mod_alias mod_auth mod_esi mod_actions mod_cgi mod_dir mod_get mod_head mod_log mod_disk_log
 ServerAdmin jocke@erix.ericsson.se
 ServerRoot /var/tmp/server_root
 ErrorLog logs/error_log_8088


### PR DESCRIPTION
As suggested in #985, this PR purges mention of mod_include and also of webtool. There's two places that I didn't change (besides, of course, the documents talking about webtool in older versions):

* There's a `ct_webtool` which appears to be a copy of webtool and mod_include but stuffed inside common test. Is that sticking around?
* Orber's documentation includes OrberWeb which says it requires webtool. I'm not familiar with orber so I left it alone for now.