### PR TITLE
Extends NIF api

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -524,6 +524,18 @@ typedef struct {
           <p>Note that <c>ErlNifBinary</c> is a semi-opaque type and you are
           only allowed to read fields <c>size</c> and <c>data</c>.</p>
       </item>
+
+      <tag><marker id="ErlNifBinaryToTerm"/>ErlNifBinaryToTerm</tag>
+      <item>
+        <p>An enumeration of the options that can be given to
+        <seealso marker="#enif_binary_to_term">enif_binary_to_term</seealso>.
+	For default behavior, use the value <c>0</c>.</p>
+        <taglist>
+	  <tag><c>ERL_NIF_BIN2TERM_SAFE</c></tag>
+	  <item><p>Use this option when receiving data from untrusted sources.</p></item>
+	</taglist>
+      </item>
+
       <tag><marker id="ErlNifPid"/>ErlNifPid</tag>
        <item>
           <p><c>ErlNifPid</c> is a process identifier (pid). In contrast to
@@ -655,16 +667,23 @@ typedef enum {
       have been allocated with <seealso marker="#enif_alloc_env">enif_alloc_env</seealso>.
       </p></desc>
     </func>
-    <func><name><ret>int</ret><nametext>enif_binary_to_term(ErlNifEnv *env, ErlNifBinary *bin, ERL_NIF_TERM *term)</nametext></name>
-    <fsummary>Convert a term from the external format</fsummary>
+    <func><name><ret>size_t</ret><nametext>enif_binary_to_term(ErlNifEnv *env, const unsigned char* data, size_t size, ERL_NIF_TERM *term, ErlNifBinaryToTerm opts)</nametext></name>
+    <fsummary>Create a term from the external format</fsummary>
     <desc>
-      <p>Returns a term that is the result of decoding <c>bin</c>
-      according to the Erlang external term format.</p>
-      <p>See also:</p>
-      <list>
-        <item><seealso marker="erlang#binary_to_term-1"><c>erlang:binary_to_term/1</c></seealso></item>
-        <item><seealso marker="#enif_term_to_binary"><c>enif_term_to_binary</c></seealso></item>
-      </list>
+      <p>Create a term that is the result of decoding the binary data
+      at <c>data</c>, which must be encoded according to the Erlang external term format.
+      No more than <c>size</c> bytes are read from <c>data</c>. Argument <c>opts</c>
+      correspond to the second argument to <seealso marker="erlang#binary_to_term-2">
+      <c>erlang:binary_to_term/2</c></seealso>, and must be either <c>0</c> or
+      <c>ERL_NIF_BIN2TERM_SAFE</c>.</p>
+      <p>On success, store the resulting term at <c>*term</c> and return
+      the actual number of bytes read. Return zero if decoding fails or if <c>opts</c>
+      is invalid.</p>
+      <p>See also:
+        <seealso marker="#ErlNifBinaryToTerm"><c>ErlNifBinaryToTerm</c></seealso>,
+        <seealso marker="erlang#binary_to_term-2"><c>erlang:binary_to_term/2</c></seealso> and
+        <seealso marker="#enif_term_to_binary"><c>enif_term_to_binary</c></seealso>.
+      </p>
     </desc>
     </func>
     <func><name><ret>int</ret><nametext>enif_compare(ERL_NIF_TERM lhs, ERL_NIF_TERM rhs)</nametext></name>

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -655,6 +655,18 @@ typedef enum {
       have been allocated with <seealso marker="#enif_alloc_env">enif_alloc_env</seealso>.
       </p></desc>
     </func>
+    <func><name><ret>int</ret><nametext>enif_binary_to_term(ErlNifEnv *env, ErlNifBinary *bin, ERL_NIF_TERM *term)</nametext></name>
+    <fsummary>Convert a term from the external format</fsummary>
+    <desc>
+      <p>Returns a term that is the result of decoding <c>bin</c>
+      according to the Erlang external term format.</p>
+      <p>See also:</p>
+      <list>
+        <item><seealso marker="erlang#binary_to_term-1"><c>erlang:binary_to_term/1</c></seealso></item>
+        <item><seealso marker="#enif_term_to_binary"><c>enif_term_to_binary</c></seealso></item>
+      </list>
+    </desc>
+    </func>
     <func><name><ret>int</ret><nametext>enif_compare(ERL_NIF_TERM lhs, ERL_NIF_TERM rhs)</nametext></name>
       <fsummary>Compare two terms</fsummary>
       <desc><p>Return an integer less than, equal to, or greater than
@@ -1598,6 +1610,18 @@ enif_map_iterator_destroy(env, &amp;iter);
       <fsummary>Get information about the Erlang runtime system</fsummary>
       <desc><p>Same as <seealso marker="erl_driver#driver_system_info">driver_system_info</seealso>.
             </p></desc>
+    </func>
+    <func><name><ret>int</ret><nametext>enif_term_to_binary(ErlNifEnv *env, ERL_NIF_TERM term, ErlNifBinary *bin)</nametext></name>
+    <fsummary>Convert a term to the external format</fsummary>
+    <desc>
+      <p>Returns a binary data object that is the result of encoding <c>term</c>
+      according to the Erlang external term format.</p>
+      <p>See also:</p>
+      <list>
+        <item><seealso marker="erlang#term_to_binary-1"><c>erlang:term_to_binary/1</c></seealso></item>
+        <item><seealso marker="#enif_binary_to_term"><c>enif_binary_to_term</c></seealso></item>
+      </list>
+    </desc>
     </func>
     <func><name><ret>int</ret><nametext>enif_thread_create(char *name,ErlNifTid *tid,void * (*func)(void *),void *args,ErlNifThreadOpts *opts)</nametext></name>
     <fsummary></fsummary>

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -1464,6 +1464,38 @@ enif_map_iterator_destroy(env, &amp;iter);
        and <seealso marker="#upgrade">upgrade</seealso>.</p>
       </desc>
     </func>
+    <func><name><ret>int</ret><nametext>enif_port_command(ErlNifEnv* env, const ErlNifPort* to_port, ErlNifEnv *msg_env, ERL_NIF_TERM msg)</nametext></name>
+      <fsummary>Send a port_command to to_port</fsummary>
+      <desc>
+        <p>This function works the same as <seealso marker="erlang#port_command-2">erlang:port_command/2</seealso>
+        except that it is always completely asynchronous. This call may return false
+        if it detects that the port is already dead, otherwise it will return true.
+        </p>
+        <taglist>
+          <tag><c>env</c></tag>
+          <item>The environment of the calling process. May not be NULL.</item>
+          <tag><c>*to_port</c></tag>
+          <item>The port id of the receiving port. The port id should refer to a
+          port on the local node.</item>
+          <tag><c>msg_env</c></tag>
+          <item>The environment of the message term. Can be a process
+          independent environment allocated with
+          <seealso marker="#enif_alloc_env">enif_alloc_env</seealso> or NULL.</item>
+          <tag><c>msg</c></tag>
+          <item>The message term to send. The same limitations apply as on the
+          payload to <seealso marker="erlang#port_command-2">erlang:port_command/2</seealso>.</item>
+        </taglist>
+        <p>Using a <c>msg_env</c> of NULL is an optimization which groups together
+        calls to <c>enif_alloc_env</c>, <c>enif_make_copy</c>, <c>enif_port_command</c>
+        and <c>enif_free_env</c> into one call. This optimization is only usefull
+        when a majority of the terms are to be copied from <c>env</c> to the <c>msg_env</c>.</p>
+        <p>The call may return false if it detects that the command failed for some reason. Otherwise true is returned.</p>
+        <p>See also:</p>
+        <list>
+          <item><seealso marker="#enif_get_local_port"><c>enif_get_local_port</c></seealso></item>
+        </list>
+      </desc>
+    </func>
     <func><name><ret>void *</ret><nametext>enif_priv_data(ErlNifEnv* env)</nametext></name>
       <fsummary>Get the private data of a NIF library</fsummary>
       <desc><p>Return the pointer to the private data that was set by <c>load</c>,

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -532,6 +532,14 @@ typedef struct {
           <seealso marker="#ErlNifEnv">environment</seealso>. <c>ErlNifPid</c>
           is an opaque type.</p>
         </item>
+      <tag><marker id="ErlNifPort"/>ErlNifPort</tag>
+       <item>
+          <p><c>ErlNifPort</c> is a port identifier. In contrast to
+          port id terms (instances of <c>ERL_NIF_TERM</c>), <c>ErlNifPort</c>'s are self
+          contained and not bound to any
+          <seealso marker="#ErlNifEnv">environment</seealso>. <c>ErlNifPort</c>
+          is an opaque type.</p>
+        </item>
 
       <tag><marker id="ErlNifResourceType"/>ErlNifResourceType</tag>
        <item>
@@ -801,6 +809,12 @@ typedef enum {
     pid variable <c>*pid</c> from it and return true. Otherwise return false.
     No check if the process is alive is done.</p></desc>
     </func>
+    <func><name><ret>int</ret><nametext>enif_get_local_port(ErlNifEnv* env, ERL_NIF_TERM term, ErlNifPort* port_id)</nametext></name>
+    <fsummary>Read an local port term</fsummary>
+    <desc><p>If <c>term</c> is the port of a node local port, initialize the
+    port variable <c>*port_id</c> from it and return true. Otherwise return false.
+    No check if the port is alive is done.</p></desc>
+    </func>
     <func><name><ret>int</ret><nametext>enif_get_list_cell(ErlNifEnv* env, ERL_NIF_TERM list, ERL_NIF_TERM* head, ERL_NIF_TERM* tail)</nametext></name>
       <fsummary>Get head and tail from a list</fsummary>
       <desc><p>Set <c>*head</c> and <c>*tail</c> from
@@ -968,6 +982,17 @@ typedef enum {
     <func><name><ret>int</ret><nametext>enif_is_port(ErlNifEnv* env, ERL_NIF_TERM term)</nametext></name>
       <fsummary>Determine if a term is a port</fsummary>
       <desc><p>Return true if <c>term</c> is a port.</p></desc>
+    </func>
+    <func><name><ret>int</ret><nametext>enif_is_port_alive(ErlNifEnv* env, ErlNifPort *port_id)</nametext></name>
+      <fsummary>Determine if a local port is alive or not.</fsummary>
+      <desc><p>Return true if <c>port_id</c> is currently alive.</p>
+      <p>This function can only be used in a from a NIF-calling thread.</p></desc>
+    </func>
+    <func><name><ret>int</ret><nametext>enif_is_process_alive(ErlNifEnv* env, ErlNifPid *pid)</nametext></name>
+      <fsummary>Determine if a local process is alive or not.</fsummary>
+      <desc><p>Return true if <c>pid</c> is currently alive.</p>
+      <p>This function is only thread-safe when the emulator with SMP support is used.
+      It can only be used in a non-SMP emulator from a NIF-calling thread.</p></desc>
     </func>
     <func><name><ret>int</ret><nametext>enif_is_ref(ErlNifEnv* env, ERL_NIF_TERM term)</nametext></name>
       <fsummary>Determine if a term is a reference</fsummary>

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -591,6 +591,21 @@ typedef enum {
 	</taglist>
       </item>
 
+      <tag><marker id="ErlNifUniqueInteger"/>ErlNifUniqueInteger</tag>
+      <item>
+        <p>An enumeration of the properties that can be requested from
+        <seealso marker="#enif_unique_integer">
+        enif_unique_integer</seealso>.</p>
+        <taglist>
+	  <tag><c>ERL_NIF_UNIQUE_POSITIVE</c></tag>
+	  <item><p>A positive integer</p></item>
+	  <tag><c>ERL_NIF_UNIQUE_MONOTONIC</c></tag>
+	  <item><p>A
+	  <seealso marker="time_correction#Strictly_Monotonically_Increasing">strictly
+	  monotonically increasing</seealso> integer corresponding to creation time</p></item>
+	</taglist>
+      </item>
+
     </taglist>
   </section>
 
@@ -689,7 +704,49 @@ typedef enum {
     a number of repeated NIF-calls without the need to create threads.
     See also the <seealso marker="#WARNING">warning</seealso> text at the beginning of this document.</p>
     </desc>
+
     </func>
+
+    <func>
+      <name><ret>ErlNifTime</ret><nametext>enif_convert_time_unit(ErlNifTime val, ErlNifTimeUnit from, ErlNifTimeUnit to)</nametext></name>
+      <fsummary>Convert time unit of a time value</fsummary>
+      <desc>
+	<marker id="enif_convert_time_unit"></marker>
+	<p>Arguments:</p>
+	<taglist>
+	  <tag><c>val</c></tag>
+	  <item>Value to convert time unit for.</item>
+	  <tag><c>from</c></tag>
+	  <item>Time unit of <c>val</c>.</item>
+	  <tag><c>to</c></tag>
+	  <item>Time unit of returned value.</item>
+	</taglist>
+	<p>Converts the <c>val</c> value of time unit <c>from</c> to
+	the corresponding value of time unit <c>to</c>. The result is
+	rounded using the floor function.</p>
+	<p>Returns <c>ERL_NIF_TIME_ERROR</c> if called with an invalid
+	time unit argument.</p>
+	<p>See also:</p>
+	<list>
+	  <item><seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso></item>
+	  <item><seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso></item>
+	</list>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>ERL_NIF_TERM</ret><nametext>enif_cpu_time(ErlNifEnv *)</nametext></name>
+      <fsummary></fsummary>
+      <desc>
+        <p>Returns the CPU time in the same format as <seealso marker="erlang#timestamp-0">erlang:timestamp()</seealso>.
+        The CPU time is the time the current logical cpu has spent executing since
+        some arbitrary point in the past.
+        If the OS does not support fetching of this value <c>enif_cpu_time</c>
+        invokes <seealso marker="#enif_make_badarg">enif_make_badarg</seealso>.
+        </p>
+      </desc>
+    </func>
+
     <func><name><ret>int</ret><nametext>enif_equal_tids(ErlNifTid tid1, ErlNifTid tid2)</nametext></name>
     <fsummary></fsummary>
     <desc><p>Same as <seealso marker="erl_driver#erl_drv_equal_tids">erl_drv_equal_tids</seealso>.
@@ -1195,6 +1252,24 @@ typedef enum {
       <fsummary>Create an unsigned integer term</fsummary>
       <desc><p>Create an integer term from an unsigned 64-bit integer.</p></desc>
     </func>
+    <func>
+      <name><ret>ERL_NIF_TERM</ret><nametext>enif_make_unique_integer(ErlNifEnv *env, ErlNifUniqueInteger properties)</nametext></name>
+      <fsummary></fsummary>
+      <desc>
+        <p>Returns a unique integer with the same properties as given by <seealso marker="erlang#unique_integer-1">erlang:unique_integer/1</seealso>.</p>
+        <p><c>env</c> is the environment to create the integer in.</p>
+        <p>
+          <c>ERL_NIF_UNIQUE_POSITIVE</c> and <c>ERL_NIF_UNIQUE_MONOTONIC</c> can
+          be passed as the second argument to change the properties of the
+          integer returned. It is possible to combine them by or:ing the
+          two values together.
+        </p>
+        <p>See also:</p>
+	<list>
+	  <item><seealso marker="#ErlNifUniqueInteger"><c>ErlNifUniqueInteger</c></seealso></item>
+	</list>
+      </desc>
+    </func>
     <func><name><ret>ERL_NIF_TERM</ret><nametext>enif_make_ulong(ErlNifEnv* env, unsigned long i)</nametext></name>
       <fsummary>Create an integer term from an unsigned long int</fsummary>
       <desc><p>Create an integer term from an <c>unsigned long int</c>.</p></desc>
@@ -1265,6 +1340,34 @@ enif_map_iterator_destroy(env, &amp;iter);
       or false if the iterator is positioned at the head (before the first
       entry).</p></desc>
     </func>
+
+    <func>
+      <name><ret>ErlNifTime</ret><nametext>enif_monotonic_time(ErlNifTimeUnit time_unit)</nametext></name>
+      <fsummary>Get Erlang Monotonic Time</fsummary>
+      <desc>
+	<marker id="enif_monotonic_time"></marker>
+	<p>Arguments:</p>
+	<taglist>
+	  <tag><c>time_unit</c></tag>
+	  <item>Time unit of returned value.</item>
+	</taglist>
+	<p>
+	  Returns
+	  <seealso marker="time_correction#Erlang_Monotonic_Time">Erlang
+	  monotonic time</seealso>. Note that it is not uncommon with
+	  negative values.
+	</p>
+	<p>Returns <c>ERL_NIF_TIME_ERROR</c> if called with an invalid
+	time unit argument, or if called from a thread that is not a
+	scheduler thread.</p>
+	<p>See also:</p>
+	<list>
+	  <item><seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso></item>
+	  <item><seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso></item>
+	</list>
+      </desc>
+    </func>
+
     <func><name><ret>ErlNifMutex *</ret><nametext>enif_mutex_create(char *name)</nametext></name>
     <fsummary></fsummary>
     <desc><p>Same as <seealso marker="erl_driver#erl_drv_mutex_create">erl_drv_mutex_create</seealso>.
@@ -1289,6 +1392,11 @@ enif_map_iterator_destroy(env, &amp;iter);
     <fsummary></fsummary>
     <desc><p>Same as <seealso marker="erl_driver#erl_drv_mutex_unlock">erl_drv_mutex_unlock</seealso>.
           </p></desc>
+    </func>
+    <func><name><ret>ERL_NIF_TERM</ret><nametext>enif_now_time(ErlNifEnv *env)</nametext></name>
+    <fsummary></fsummary>
+    <desc><p>Retuns an <seealso marker="erlang#now-0">erlang:now()</seealso> timestamp.
+    The enif_now_time function is <em>deprecated</em>.</p></desc>
     </func>
     <func><name><ret>ErlNifResourceType *</ret><nametext>enif_open_resource_type(ErlNifEnv* env,
                              const char* module_str, const char* name,
@@ -1496,54 +1604,6 @@ enif_map_iterator_destroy(env, &amp;iter);
     <desc><p>Same as <seealso marker="erl_driver#erl_drv_thread_self">erl_drv_thread_self</seealso>.
           </p></desc>
     </func>
-    <func><name><ret>int</ret><nametext>enif_tsd_key_create(char *name, ErlNifTSDKey *key)</nametext></name>
-    <fsummary></fsummary>
-    <desc><p>Same as <seealso marker="erl_driver#erl_drv_tsd_key_create">erl_drv_tsd_key_create</seealso>.
-          </p></desc>
-    </func>
-    <func><name><ret>void</ret><nametext>enif_tsd_key_destroy(ErlNifTSDKey key)</nametext></name>
-    <fsummary></fsummary>
-    <desc><p>Same as <seealso marker="erl_driver#erl_drv_tsd_key_destroy">erl_drv_tsd_key_destroy</seealso>.
-          </p></desc>
-    </func>
-    <func><name><ret>void *</ret><nametext>enif_tsd_get(ErlNifTSDKey key)</nametext></name>
-    <fsummary></fsummary>
-    <desc><p>Same as <seealso marker="erl_driver#erl_drv_tsd_get">erl_drv_tsd_get</seealso>.
-          </p></desc>
-    </func>
-    <func><name><ret>void</ret><nametext>enif_tsd_set(ErlNifTSDKey key, void *data)</nametext></name>
-    <fsummary></fsummary>
-    <desc><p>Same as <seealso marker="erl_driver#erl_drv_tsd_set">erl_drv_tsd_set</seealso>.
-          </p></desc>
-    </func>
-
-
-    <func>
-      <name><ret>ErlNifTime</ret><nametext>enif_monotonic_time(ErlNifTimeUnit time_unit)</nametext></name>
-      <fsummary>Get Erlang Monotonic Time</fsummary>
-      <desc>
-	<marker id="enif_monotonic_time"></marker>
-	<p>Arguments:</p>
-	<taglist>
-	  <tag><c>time_unit</c></tag>
-	  <item>Time unit of returned value.</item>
-	</taglist>
-	<p>
-	  Returns
-	  <seealso marker="time_correction#Erlang_Monotonic_Time">Erlang
-	  monotonic time</seealso>. Note that it is not uncommon with
-	  negative values.
-	</p>
-	<p>Returns <c>ERL_NIF_TIME_ERROR</c> if called with an invalid
-	time unit argument, or if called from a thread that is not a
-	scheduler thread.</p>
-	<p>See also:</p>
-	<list>
-	  <item><seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso></item>
-	  <item><seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso></item>
-	</list>
-      </desc>
-    </func>
 
     <func>
       <name><ret>ErlNifTime</ret><nametext>enif_time_offset(ErlNifTimeUnit time_unit)</nametext></name>
@@ -1571,33 +1631,26 @@ enif_map_iterator_destroy(env, &amp;iter);
       </desc>
     </func>
 
-    <func>
-      <name><ret>ErlNifTime</ret><nametext>enif_convert_time_unit(ErlNifTime val, ErlNifTimeUnit from, ErlNifTimeUnit to)</nametext></name>
-      <fsummary>Convert time unit of a time value</fsummary>
-      <desc>
-	<marker id="enif_convert_time_unit"></marker>
-	<p>Arguments:</p>
-	<taglist>
-	  <tag><c>val</c></tag>
-	  <item>Value to convert time unit for.</item>
-	  <tag><c>from</c></tag>
-	  <item>Time unit of <c>val</c>.</item>
-	  <tag><c>to</c></tag>
-	  <item>Time unit of returned value.</item>
-	</taglist>
-	<p>Converts the <c>val</c> value of time unit <c>from</c> to
-	the corresponding value of time unit <c>to</c>. The result is
-	rounded using the floor function.</p>
-	<p>Returns <c>ERL_NIF_TIME_ERROR</c> if called with an invalid
-	time unit argument.</p>
-	<p>See also:</p>
-	<list>
-	  <item><seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso></item>
-	  <item><seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso></item>
-	</list>
-      </desc>
+    <func><name><ret>int</ret><nametext>enif_tsd_key_create(char *name, ErlNifTSDKey *key)</nametext></name>
+    <fsummary></fsummary>
+    <desc><p>Same as <seealso marker="erl_driver#erl_drv_tsd_key_create">erl_drv_tsd_key_create</seealso>.
+          </p></desc>
     </func>
-
+    <func><name><ret>void</ret><nametext>enif_tsd_key_destroy(ErlNifTSDKey key)</nametext></name>
+    <fsummary></fsummary>
+    <desc><p>Same as <seealso marker="erl_driver#erl_drv_tsd_key_destroy">erl_drv_tsd_key_destroy</seealso>.
+          </p></desc>
+    </func>
+    <func><name><ret>void *</ret><nametext>enif_tsd_get(ErlNifTSDKey key)</nametext></name>
+    <fsummary></fsummary>
+    <desc><p>Same as <seealso marker="erl_driver#erl_drv_tsd_get">erl_drv_tsd_get</seealso>.
+          </p></desc>
+    </func>
+    <func><name><ret>void</ret><nametext>enif_tsd_set(ErlNifTSDKey key, void *data)</nametext></name>
+    <fsummary></fsummary>
+    <desc><p>Same as <seealso marker="erl_driver#erl_drv_tsd_set">erl_drv_tsd_set</seealso>.
+          </p></desc>
+    </func>
   </funcs>
   <section>
     <title>SEE ALSO</title>

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -614,13 +614,13 @@ typedef enum {
       <tag><marker id="ErlNifUniqueInteger"/>ErlNifUniqueInteger</tag>
       <item>
         <p>An enumeration of the properties that can be requested from
-        <seealso marker="#enif_unique_integer">
-        enif_unique_integer</seealso>.</p>
+        <seealso marker="#enif_make_unique_integer">enif_unique_integer</seealso>.
+	For default properties, use the value <c>0</c>.</p>
         <taglist>
 	  <tag><c>ERL_NIF_UNIQUE_POSITIVE</c></tag>
-	  <item><p>A positive integer</p></item>
+	  <item><p>Return only positive integers</p></item>
 	  <tag><c>ERL_NIF_UNIQUE_MONOTONIC</c></tag>
-	  <item><p>A
+	  <item><p>Return only
 	  <seealso marker="time_correction#Strictly_Monotonically_Increasing">strictly
 	  monotonically increasing</seealso> integer corresponding to creation time</p></item>
 	</taglist>
@@ -765,11 +765,10 @@ typedef enum {
 	rounded using the floor function.</p>
 	<p>Returns <c>ERL_NIF_TIME_ERROR</c> if called with an invalid
 	time unit argument.</p>
-	<p>See also:</p>
-	<list>
-	  <item><seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso></item>
-	  <item><seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso></item>
-	</list>
+	<p>See also:
+	  <seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso> and
+	  <seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso>.
+	</p>
       </desc>
     </func>
 
@@ -842,7 +841,7 @@ typedef enum {
     </func>
     <func><name><ret>int</ret><nametext>enif_get_local_port(ErlNifEnv* env, ERL_NIF_TERM term, ErlNifPort* port_id)</nametext></name>
     <fsummary>Read an local port term</fsummary>
-    <desc><p>If <c>term</c> is the port of a node local port, initialize the
+    <desc><p>If <c>term</c> identifies a node local port, initialize the
     port variable <c>*port_id</c> from it and return true. Otherwise return false.
     No check if the port is alive is done.</p></desc>
     </func>
@@ -1074,7 +1073,7 @@ typedef enum {
       <seealso marker="#enif_is_exception">enif_is_exception</seealso>, but
       not to any other NIF API function.</p>
       <p>See also: <seealso marker="#enif_has_pending_exception">enif_has_pending_exception</seealso>
-      and <seealso marker="#enif_raise_exception">enif_raise_exception</seealso>
+      and <seealso marker="#enif_raise_exception">enif_raise_exception</seealso>.
       </p>
       <note><p>In earlier versions (older than erts-7.0, OTP 18) the return value
       from <c>enif_make_badarg</c> had to be returned from the NIF. This
@@ -1320,10 +1319,9 @@ typedef enum {
           integer returned. It is possible to combine them by or:ing the
           two values together.
         </p>
-        <p>See also:</p>
-	<list>
-	  <item><seealso marker="#ErlNifUniqueInteger"><c>ErlNifUniqueInteger</c></seealso></item>
-	</list>
+        <p>See also:
+	<seealso marker="#ErlNifUniqueInteger"><c>ErlNifUniqueInteger</c></seealso>.
+	</p>
       </desc>
     </func>
     <func><name><ret>ERL_NIF_TERM</ret><nametext>enif_make_ulong(ErlNifEnv* env, unsigned long i)</nametext></name>
@@ -1408,7 +1406,7 @@ enif_map_iterator_destroy(env, &amp;iter);
 	  <item>Time unit of returned value.</item>
 	</taglist>
 	<p>
-	  Returns
+	  Returns the current
 	  <seealso marker="time_correction#Erlang_Monotonic_Time">Erlang
 	  monotonic time</seealso>. Note that it is not uncommon with
 	  negative values.
@@ -1416,11 +1414,10 @@ enif_map_iterator_destroy(env, &amp;iter);
 	<p>Returns <c>ERL_NIF_TIME_ERROR</c> if called with an invalid
 	time unit argument, or if called from a thread that is not a
 	scheduler thread.</p>
-	<p>See also:</p>
-	<list>
-	  <item><seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso></item>
-	  <item><seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso></item>
-	</list>
+	<p>See also:
+	  <seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso> and
+	  <seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso>.
+	</p>
       </desc>
     </func>
 
@@ -1509,10 +1506,7 @@ enif_map_iterator_destroy(env, &amp;iter);
         and <c>enif_free_env</c> into one call. This optimization is only usefull
         when a majority of the terms are to be copied from <c>env</c> to the <c>msg_env</c>.</p>
         <p>The call may return false if it detects that the command failed for some reason. Otherwise true is returned.</p>
-        <p>See also:</p>
-        <list>
-          <item><seealso marker="#enif_get_local_port"><c>enif_get_local_port</c></seealso></item>
-        </list>
+        <p>See also: <seealso marker="#enif_get_local_port"><c>enif_get_local_port</c></seealso>.</p>
       </desc>
     </func>
     <func><name><ret>void *</ret><nametext>enif_priv_data(ErlNifEnv* env)</nametext></name>
@@ -1649,6 +1643,8 @@ enif_map_iterator_destroy(env, &amp;iter);
       of cleared for reuse with <seealso marker="#enif_clear_env">enif_clear_env</seealso>.</p>
       <p>This function is only thread-safe when the emulator with SMP support is used.
       It can only be used in a non-SMP emulator from a NIF-calling thread.</p>
+      <note><p>Passing <c>msg_env</c> as <c>NULL</c> is only supported since
+      erts-8.0 (OTP 19).</p></note>
       </desc>
     </func>
     <func><name><ret>unsigned</ret><nametext>enif_sizeof_resource(void* obj)</nametext></name>
@@ -1665,13 +1661,13 @@ enif_map_iterator_destroy(env, &amp;iter);
     <func><name><ret>int</ret><nametext>enif_term_to_binary(ErlNifEnv *env, ERL_NIF_TERM term, ErlNifBinary *bin)</nametext></name>
     <fsummary>Convert a term to the external format</fsummary>
     <desc>
-      <p>Returns a binary data object that is the result of encoding <c>term</c>
-      according to the Erlang external term format.</p>
-      <p>See also:</p>
-      <list>
-        <item><seealso marker="erlang#term_to_binary-1"><c>erlang:term_to_binary/1</c></seealso></item>
-        <item><seealso marker="#enif_binary_to_term"><c>enif_binary_to_term</c></seealso></item>
-      </list>
+      <p>Allocates a new binary with <seealso marker="#enif_alloc_binary">enif_alloc_binary</seealso>
+      and stores the result of encoding <c>term</c> according to the Erlang external term format.</p>
+      <p>Returns true on success or false if allocation failed.</p>
+      <p>See also:
+        <seealso marker="erlang#term_to_binary-1"><c>erlang:term_to_binary/1</c></seealso> and
+        <seealso marker="#enif_binary_to_term"><c>enif_binary_to_term</c></seealso>.
+      </p>
     </desc>
     </func>
     <func><name><ret>int</ret><nametext>enif_thread_create(char *name,ErlNifTid *tid,void * (*func)(void *),void *args,ErlNifThreadOpts *opts)</nametext></name>
@@ -1723,11 +1719,10 @@ enif_map_iterator_destroy(env, &amp;iter);
 	<p>Returns <c>ERL_NIF_TIME_ERROR</c> if called with an invalid
 	time unit argument, or if called from a thread that is not a
 	scheduler thread.</p>
-	<p>See also:</p>
-	<list>
-	  <item><seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso></item>
-	  <item><seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso></item>
-	</list>
+	<p>See also:
+	    <seealso marker="#ErlNifTime"><c>ErlNifTime</c></seealso> and
+	    <seealso marker="#ErlNifTimeUnit"><c>ErlNifTimeUnit</c></seealso>.
+	</p>
       </desc>
     </func>
 

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -1548,7 +1548,7 @@ read_literal_table(LoaderState* stp)
             erts_factory_heap_frag_init(&factory,
 					new_literal_fragment(heap_size));
 	    factory.alloc_type = ERTS_ALC_T_PREPARED_CODE;
-            val = erts_decode_ext(&factory, &p);
+            val = erts_decode_ext(&factory, &p, 0);
 
             if (is_non_value(val)) {
                 LoadError1(stp, "literal %d: bad external format", i);
@@ -1559,7 +1559,7 @@ read_literal_table(LoaderState* stp)
         }
         else {
             erts_factory_dummy_init(&factory);
-            val = erts_decode_ext(&factory, &p);
+            val = erts_decode_ext(&factory, &p, 0);
             if (is_non_value(val)) {
                 LoadError1(stp, "literal %d: bad external format", i);
             }
@@ -5719,7 +5719,7 @@ attributes_for_module(Process* p, /* Process whose heap to use. */
     if (ext != NULL) {
 	ErtsHeapFactory factory;
 	erts_factory_proc_prealloc_init(&factory, p, code_hdr->attr_size_on_heap);
-	result = erts_decode_ext(&factory, &ext);
+	result = erts_decode_ext(&factory, &ext, 0);
 	if (is_value(result)) {
 	    erts_factory_close(&factory);
 	}
@@ -5742,7 +5742,7 @@ compilation_info_for_module(Process* p, /* Process whose heap to use. */
     if (ext != NULL) {
 	ErtsHeapFactory factory;
 	erts_factory_proc_prealloc_init(&factory, p, code_hdr->compile_size_on_heap);
-	result = erts_decode_ext(&factory, &ext);
+	result = erts_decode_ext(&factory, &ext, 0);
 	if (is_value(result)) {
 	    erts_factory_close(&factory);
 	}

--- a/erts/emulator/beam/erl_bif_unique.c
+++ b/erts/emulator/beam/erl_bif_unique.c
@@ -266,17 +266,19 @@ static ERTS_INLINE Eterm unique_integer_bif(Process *c_p, int positive)
 }
 
 Uint
-erts_raw_unique_integer_heap_size(Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES])
+erts_raw_unique_integer_heap_size(Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES],
+                                  int positive)
 {
     Uint sz;
-    bld_unique_integer_term(NULL, &sz, val[0], val[1], 0);
+    bld_unique_integer_term(NULL, &sz, val[0], val[1], positive);
     return sz;
 }
 
 Eterm
-erts_raw_make_unique_integer(Eterm **hpp, Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES])
+erts_raw_make_unique_integer(Eterm **hpp, Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES],
+    int positive)
 {
-    return bld_unique_integer_term(hpp, NULL, val[0], val[1], 0);
+    return bld_unique_integer_term(hpp, NULL, val[0], val[1], positive);
 }
 
 void
@@ -426,16 +428,16 @@ erts_raw_get_unique_monotonic_integer(void)
 }
 
 Uint
-erts_raw_unique_monotonic_integer_heap_size(Sint64 raw)
+erts_raw_unique_monotonic_integer_heap_size(Sint64 raw, int positive)
 {
-    return get_unique_monotonic_integer_heap_size(raw, 0);
+    return get_unique_monotonic_integer_heap_size(raw, positive);
 }
 
 Eterm
-erts_raw_make_unique_monotonic_integer_value(Eterm **hpp, Sint64 raw)
+erts_raw_make_unique_monotonic_integer_value(Eterm **hpp, Sint64 raw, int positive)
 {
-    Uint hsz = get_unique_monotonic_integer_heap_size(raw, 0);
-    Eterm res = make_unique_monotonic_integer_value(*hpp, hsz, raw, 0);
+    Uint hsz = get_unique_monotonic_integer_heap_size(raw, positive);
+    Eterm res = make_unique_monotonic_integer_value(*hpp, hsz, raw, positive);
     *hpp += hsz;
     return res;
 }

--- a/erts/emulator/beam/erl_bif_unique.h
+++ b/erts/emulator/beam/erl_bif_unique.h
@@ -41,8 +41,9 @@ void erts_make_ref_in_array(Uint32 ref[ERTS_MAX_REF_NUMBERS]);
  * not necessarily correspond to the end result.
  */
 Sint64 erts_raw_get_unique_monotonic_integer(void);
-Uint erts_raw_unique_monotonic_integer_heap_size(Sint64 raw);
-Eterm erts_raw_make_unique_monotonic_integer_value(Eterm **hpp, Sint64 raw);
+Uint erts_raw_unique_monotonic_integer_heap_size(Sint64 raw, int positive);
+Eterm erts_raw_make_unique_monotonic_integer_value(Eterm **hpp, Sint64 raw,
+                                                   int positive);
 
 Sint64 erts_get_min_unique_monotonic_integer(void);
 
@@ -53,8 +54,11 @@ Eterm erts_debug_get_unique_monotonic_integer_state(Process *c_p);
 #define ERTS_UNIQUE_INT_RAW_VALUES 2
 #define ERTS_MAX_UNIQUE_INT_HEAP_SIZE ERTS_UINT64_ARRAY_TO_BIG_MAX_HEAP_SZ(2)
 
-Uint erts_raw_unique_integer_heap_size(Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES]);
-Eterm erts_raw_make_unique_integer(Eterm **hpp, Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES]);
+Uint erts_raw_unique_integer_heap_size(Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES],
+                                       int positive);
+Eterm erts_raw_make_unique_integer(Eterm **hpp,
+                                   Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES],
+                                   int postive);
 void erts_raw_get_unique_integer(Uint64 val[ERTS_UNIQUE_INT_RAW_VALUES]);
 Sint64 erts_get_min_unique_integer(void);
 

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -705,19 +705,8 @@ size_t enif_binary_to_term(ErlNifEnv *dst_env,
         return 0;
 
     if (size > 0) {
-
-        if (is_internal_pid(dst_env->proc->common.id)) {
-            flush_env(dst_env);
-            erts_factory_proc_prealloc_init(&factory, dst_env->proc, size);
-            cache_env(dst_env);
-        } else {
-
-            /* this is guaranteed to create a heap fragment */
-            if (!alloc_heap(dst_env, size))
-                return 0;
-
-            erts_factory_heap_frag_init(&factory, dst_env->heap_frag);
-        }
+        flush_env(dst_env);
+        erts_factory_proc_prealloc_init(&factory, dst_env->proc, size);
     } else {
         erts_factory_dummy_init(&factory);
     }
@@ -728,6 +717,8 @@ size_t enif_binary_to_term(ErlNifEnv *dst_env,
         return 0;
     }
     erts_factory_close(&factory);
+    cache_env(dst_env);
+
     ASSERT(bp > data);
     return bp - data;
 }

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -375,6 +375,29 @@ int enif_send(ErlNifEnv* env, const ErlNifPid* to_pid,
     return 1;
 }
 
+int
+enif_port_command(ErlNifEnv *env, const ErlNifPort* to_port,
+                  ErlNifEnv *msg_env, ERL_NIF_TERM msg)
+{
+
+    ErtsSchedulerData *esdp = erts_get_scheduler_data();
+    int scheduler = esdp ? esdp->no : 0;
+    Port *prt;
+
+    if (scheduler == 0 || !env)
+        return 0;
+
+    prt = erts_port_lookup(to_port->port_id,
+                           (erts_port_synchronous_ops
+                            ? ERTS_PORT_SFLGS_INVALID_DRIVER_LOOKUP
+                            : ERTS_PORT_SFLGS_INVALID_LOOKUP));
+
+    if (!prt)
+        return 0;
+
+    return erts_port_output_async(prt, env->proc->common.id, msg);
+}
+
 ERL_NIF_TERM enif_make_copy(ErlNifEnv* dst_env, ERL_NIF_TERM src_term)
 {
     Uint sz;

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -209,6 +209,7 @@ static void flush_env(ErlNifEnv* env)
 */
 static void cache_env(ErlNifEnv* env)
 {
+    env->heap_frag = MBUF(env->proc);
     if (env->heap_frag == NULL) {
 	ASSERT(env->hp_end == HEAP_LIMIT(env->proc));
 	ASSERT(env->hp <= HEAP_TOP(env->proc));
@@ -216,10 +217,6 @@ static void cache_env(ErlNifEnv* env)
 	env->hp = HEAP_TOP(env->proc);
     }
     else {
-	ASSERT(env->hp_end != HEAP_LIMIT(env->proc));
-	ASSERT(env->hp_end - env->hp <= env->heap_frag->alloc_size);       
-	env->heap_frag = MBUF(env->proc);
-	ASSERT(env->heap_frag != NULL);
 	env->hp = env->heap_frag->mem + env->heap_frag->used_size;
 	env->hp_end = env->heap_frag->mem + env->heap_frag->alloc_size;
     }

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -150,7 +150,12 @@ typedef enum
 typedef struct
 {
     ERL_NIF_TERM pid;  /* internal, may change */
-}ErlNifPid;
+} ErlNifPid;
+
+typedef struct
+{
+    ERL_NIF_TERM port_id;  /* internal, may change */
+}ErlNifPort;
 
 typedef ErlDrvSysInfo ErlNifSysInfo;
 

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -207,6 +207,10 @@ typedef enum {
     ERL_NIF_UNIQUE_MONOTONIC = (1 << 1)
 } ErlNifUniqueInteger;
 
+typedef enum {
+    ERL_NIF_BIN2TERM_SAFE = 0x20000000
+} ErlNifBinaryToTerm;
+
 #if (defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_))
 #  define ERL_NIF_API_FUNC_DECL(RET_TYPE, NAME, ARGS) RET_TYPE (*NAME) ARGS
 typedef struct {

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -197,6 +197,11 @@ typedef enum {
     ERL_NIF_MAP_ITERATOR_TAIL = ERL_NIF_MAP_ITERATOR_LAST
 } ErlNifMapIteratorEntry;
 
+typedef enum {
+    ERL_NIF_UNIQUE_POSITIVE = (1 << 0),
+    ERL_NIF_UNIQUE_MONOTONIC = (1 << 1)
+} ErlNifUniqueInteger;
+
 #if (defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_))
 #  define ERL_NIF_API_FUNC_DECL(RET_TYPE, NAME, ARGS) RET_TYPE (*NAME) ARGS
 typedef struct {

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -171,6 +171,7 @@ ERL_NIF_API_FUNC_DECL(int, enif_is_port_alive, (ErlNifEnv *env, ErlNifPort *port
 ERL_NIF_API_FUNC_DECL(int, enif_get_local_port, (ErlNifEnv* env, ERL_NIF_TERM, ErlNifPort* port_id));
 ERL_NIF_API_FUNC_DECL(int, enif_term_to_binary, (ErlNifEnv *env, ERL_NIF_TERM term, ErlNifBinary *bin));
 ERL_NIF_API_FUNC_DECL(int, enif_binary_to_term, (ErlNifEnv *env, ErlNifBinary *bin, ERL_NIF_TERM *term));
+ERL_NIF_API_FUNC_DECL(int, enif_port_command, (ErlNifEnv *env, const ErlNifPort* to_port, ErlNifEnv *msg_env, ERL_NIF_TERM msg));
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
@@ -334,6 +335,7 @@ ERL_NIF_API_FUNC_DECL(int,enif_is_on_dirty_scheduler,(ErlNifEnv*));
 #  define enif_get_local_port ERL_NIF_API_FUNC_MACRO(enif_get_local_port)
 #  define enif_term_to_binary ERL_NIF_API_FUNC_MACRO(enif_term_to_binary)
 #  define enif_binary_to_term ERL_NIF_API_FUNC_MACRO(enif_binary_to_term)
+#  define enif_port_command ERL_NIF_API_FUNC_MACRO(enif_port_command)
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment)

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -170,7 +170,7 @@ ERL_NIF_API_FUNC_DECL(int, enif_is_process_alive, (ErlNifEnv *env, ErlNifPid *pi
 ERL_NIF_API_FUNC_DECL(int, enif_is_port_alive, (ErlNifEnv *env, ErlNifPort *port_id));
 ERL_NIF_API_FUNC_DECL(int, enif_get_local_port, (ErlNifEnv* env, ERL_NIF_TERM, ErlNifPort* port_id));
 ERL_NIF_API_FUNC_DECL(int, enif_term_to_binary, (ErlNifEnv *env, ERL_NIF_TERM term, ErlNifBinary *bin));
-ERL_NIF_API_FUNC_DECL(int, enif_binary_to_term, (ErlNifEnv *env, ErlNifBinary *bin, ERL_NIF_TERM *term));
+ERL_NIF_API_FUNC_DECL(size_t, enif_binary_to_term, (ErlNifEnv *env, const unsigned char* data, size_t sz, ERL_NIF_TERM *term, unsigned int opts));
 ERL_NIF_API_FUNC_DECL(int, enif_port_command, (ErlNifEnv *env, const ErlNifPort* to_port, ErlNifEnv *msg_env, ERL_NIF_TERM msg));
 
 /*

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -169,6 +169,8 @@ ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM, enif_make_unique_integer, (ErlNifEnv *env, E
 ERL_NIF_API_FUNC_DECL(int, enif_is_process_alive, (ErlNifEnv *env, ErlNifPid *pid));
 ERL_NIF_API_FUNC_DECL(int, enif_is_port_alive, (ErlNifEnv *env, ErlNifPort *port_id));
 ERL_NIF_API_FUNC_DECL(int, enif_get_local_port, (ErlNifEnv* env, ERL_NIF_TERM, ErlNifPort* port_id));
+ERL_NIF_API_FUNC_DECL(int, enif_term_to_binary, (ErlNifEnv *env, ERL_NIF_TERM term, ErlNifBinary *bin));
+ERL_NIF_API_FUNC_DECL(int, enif_binary_to_term, (ErlNifEnv *env, ErlNifBinary *bin, ERL_NIF_TERM *term));
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
@@ -330,6 +332,8 @@ ERL_NIF_API_FUNC_DECL(int,enif_is_on_dirty_scheduler,(ErlNifEnv*));
 #  define enif_is_process_alive ERL_NIF_API_FUNC_MACRO(enif_is_process_alive)
 #  define enif_is_port_alive ERL_NIF_API_FUNC_MACRO(enif_is_port_alive)
 #  define enif_get_local_port ERL_NIF_API_FUNC_MACRO(enif_get_local_port)
+#  define enif_term_to_binary ERL_NIF_API_FUNC_MACRO(enif_term_to_binary)
+#  define enif_binary_to_term ERL_NIF_API_FUNC_MACRO(enif_binary_to_term)
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment)

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -163,6 +163,9 @@ ERL_NIF_API_FUNC_DECL(int,enif_getenv,(const char* key, char* value, size_t* val
 ERL_NIF_API_FUNC_DECL(ErlNifTime, enif_monotonic_time, (ErlNifTimeUnit));
 ERL_NIF_API_FUNC_DECL(ErlNifTime, enif_time_offset, (ErlNifTimeUnit));
 ERL_NIF_API_FUNC_DECL(ErlNifTime, enif_convert_time_unit, (ErlNifTime, ErlNifTimeUnit, ErlNifTimeUnit));
+ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM, enif_now_time, (ErlNifEnv *env));
+ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM, enif_cpu_time, (ErlNifEnv *env));
+ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM, enif_make_unique_integer, (ErlNifEnv *env, ErlNifUniqueInteger properties));
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
@@ -318,6 +321,9 @@ ERL_NIF_API_FUNC_DECL(int,enif_is_on_dirty_scheduler,(ErlNifEnv*));
 #  define enif_monotonic_time ERL_NIF_API_FUNC_MACRO(enif_monotonic_time)
 #  define enif_time_offset ERL_NIF_API_FUNC_MACRO(enif_time_offset)
 #  define enif_convert_time_unit ERL_NIF_API_FUNC_MACRO(enif_convert_time_unit)
+#  define enif_now_time ERL_NIF_API_FUNC_MACRO(enif_now_time)
+#  define enif_cpu_time ERL_NIF_API_FUNC_MACRO(enif_cpu_time)
+#  define enif_make_unique_integer ERL_NIF_API_FUNC_MACRO(enif_make_unique_integer)
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment)

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -166,6 +166,9 @@ ERL_NIF_API_FUNC_DECL(ErlNifTime, enif_convert_time_unit, (ErlNifTime, ErlNifTim
 ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM, enif_now_time, (ErlNifEnv *env));
 ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM, enif_cpu_time, (ErlNifEnv *env));
 ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM, enif_make_unique_integer, (ErlNifEnv *env, ErlNifUniqueInteger properties));
+ERL_NIF_API_FUNC_DECL(int, enif_is_process_alive, (ErlNifEnv *env, ErlNifPid *pid));
+ERL_NIF_API_FUNC_DECL(int, enif_is_port_alive, (ErlNifEnv *env, ErlNifPort *port_id));
+ERL_NIF_API_FUNC_DECL(int, enif_get_local_port, (ErlNifEnv* env, ERL_NIF_TERM, ErlNifPort* port_id));
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
@@ -324,6 +327,9 @@ ERL_NIF_API_FUNC_DECL(int,enif_is_on_dirty_scheduler,(ErlNifEnv*));
 #  define enif_now_time ERL_NIF_API_FUNC_MACRO(enif_now_time)
 #  define enif_cpu_time ERL_NIF_API_FUNC_MACRO(enif_cpu_time)
 #  define enif_make_unique_integer ERL_NIF_API_FUNC_MACRO(enif_make_unique_integer)
+#  define enif_is_process_alive ERL_NIF_API_FUNC_MACRO(enif_is_process_alive)
+#  define enif_is_port_alive ERL_NIF_API_FUNC_MACRO(enif_is_port_alive)
+#  define enif_get_local_port ERL_NIF_API_FUNC_MACRO(enif_get_local_port)
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment)

--- a/erts/emulator/beam/erl_port.h
+++ b/erts/emulator/beam/erl_port.h
@@ -949,6 +949,8 @@ ErtsPortOpResult erts_port_control(Process *, Port *, unsigned int, Eterm, Eterm
 ErtsPortOpResult erts_port_call(Process *, Port *, unsigned int, Eterm, Eterm *);
 ErtsPortOpResult erts_port_info(Process *, Port *, Eterm, Eterm *);
 
+int erts_port_output_async(Port *, Eterm, Eterm);
+
 /*
  * Signals from ports to ports. Used by sys drivers.
  */

--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -180,10 +180,9 @@ p2p_sig_data_to_task(ErtsProc2PortSigData *sigdp)
     return ptp;
 }
 
-ErtsProc2PortSigData *
-erts_port_task_alloc_p2p_sig_data(void)
+static ERTS_INLINE ErtsProc2PortSigData *
+p2p_sig_data_init(ErtsPortTask *ptp)
 {
-    ErtsPortTask *ptp = port_task_alloc();
 
     ptp->type = ERTS_PORT_TASK_PROC_SIG;
     ptp->u.alive.flags = ERTS_PT_FLG_SIG_DEP;
@@ -192,6 +191,31 @@ erts_port_task_alloc_p2p_sig_data(void)
     ASSERT(ptp == p2p_sig_data_to_task(&ptp->u.alive.td.psig.data));
 
     return &ptp->u.alive.td.psig.data;
+}
+
+ErtsProc2PortSigData *
+erts_port_task_alloc_p2p_sig_data(void)
+{
+    ErtsPortTask *ptp = port_task_alloc();
+
+    return p2p_sig_data_init(ptp);
+}
+
+ErtsProc2PortSigData *
+erts_port_task_alloc_p2p_sig_data_extra(size_t extra, void **extra_ptr)
+{
+    ErtsPortTask *ptp = erts_alloc(ERTS_ALC_T_PORT_TASK,
+                                   sizeof(ErtsPortTask) + extra);
+
+    *extra_ptr = ptp+1;
+
+    return p2p_sig_data_init(ptp);
+}
+
+void
+erts_port_task_free_p2p_sig_data(ErtsProc2PortSigData *sigdp)
+{
+    schedule_port_task_free(p2p_sig_data_to_task(sigdp));
 }
 
 static ERTS_INLINE Eterm

--- a/erts/emulator/beam/erl_port_task.h
+++ b/erts/emulator/beam/erl_port_task.h
@@ -269,6 +269,8 @@ int erts_port_task_schedule(Eterm,
 void erts_port_task_free_port(Port *);
 int erts_port_is_scheduled(Port *);
 ErtsProc2PortSigData *erts_port_task_alloc_p2p_sig_data(void);
+ErtsProc2PortSigData *erts_port_task_alloc_p2p_sig_data_extra(size_t extra, void **extra_ptr);
+void erts_port_task_free_p2p_sig_data(ErtsProc2PortSigData *sigdp);
 
 #ifdef ERTS_SMP
 void erts_enqueue_port(ErtsRunQueue *rq, Port *pp);

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -176,7 +176,7 @@ take_timestamp(ErtsTraceTimeStamp *tsp, int ts_type)
 	    hsz += 3; /* 2-tuple */
 	    raw_unique = erts_raw_get_unique_monotonic_integer();
 	    tsp->u.monotonic.raw_unique = raw_unique;
-	    hsz += erts_raw_unique_monotonic_integer_heap_size(raw_unique);
+	    hsz += erts_raw_unique_monotonic_integer_heap_size(raw_unique, 0);
 	}
 	return hsz;
     }
@@ -216,8 +216,7 @@ write_timestamp(ErtsTraceTimeStamp *tsp, Eterm **hpp)
 	    return emtime;
 
 	raw = tsp->u.monotonic.raw_unique;
-	unique = erts_raw_make_unique_monotonic_integer_value(hpp,
-							      raw);
+	unique = erts_raw_make_unique_monotonic_integer_value(hpp, raw, 0);
 	res = TUPLE2(*hpp, emtime, unique);
 	*hpp += 3;
 	return res;

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -985,9 +985,6 @@ Eterm erts_decode_ext(ErtsHeapFactory* factory, byte **ext, Uint32 flags)
     }
     ep = dec_term(edep, factory, ep, &obj, NULL);
     if (!ep) {
-#ifdef DEBUG
-	bin_write(ERTS_PRINT_STDERR,NULL,*ext,500);
-#endif
 	return THE_NON_VALUE;
     }
     *ext = ep;

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -967,15 +967,23 @@ erts_decode_dist_ext(ErtsHeapFactory* factory,
     return THE_NON_VALUE;
 }
 
-Eterm erts_decode_ext(ErtsHeapFactory* factory, byte **ext)
+Eterm erts_decode_ext(ErtsHeapFactory* factory, byte **ext, Uint32 flags)
 {
+    ErtsDistExternal ede, *edep;
     Eterm obj;
     byte *ep = *ext;
     if (*ep++ != VERSION_MAGIC) {
         erts_factory_undo(factory);
 	return THE_NON_VALUE;
     }
-    ep = dec_term(NULL, factory, ep, &obj, NULL);
+    if (flags) {
+        ASSERT(flags == ERTS_DIST_EXT_BTT_SAFE);
+        ede.flags = flags; /* a dummy struct just for the flags */
+        edep = &ede;
+    } else {
+        edep = NULL;
+    }
+    ep = dec_term(edep, factory, ep, &obj, NULL);
     if (!ep) {
 #ifdef DEBUG
 	bin_write(ERTS_PRINT_STDERR,NULL,*ext,500);

--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -191,7 +191,7 @@ Eterm erts_decode_dist_ext(ErtsHeapFactory* factory, ErtsDistExternal *);
 
 Sint erts_decode_ext_size(byte*, Uint);
 Sint erts_decode_ext_size_ets(byte*, Uint);
-Eterm erts_decode_ext(ErtsHeapFactory*, byte**);
+Eterm erts_decode_ext(ErtsHeapFactory*, byte**, Uint32 flags);
 Eterm erts_decode_ext_ets(ErtsHeapFactory*, byte*);
 
 Eterm erts_term_to_binary(Process* p, Eterm Term, int level, Uint flags);

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -1749,7 +1749,6 @@ cleanup_scheduled_outputv(ErlIOVec *ev, ErlDrvBinary *cbinp)
 	    driver_free_binary(ev->binv[i]);
     if (cbinp)
 	driver_free_binary(cbinp);
-    erts_free(ERTS_ALC_T_DRV_CMD_DATA, ev);
 }
 
 static int
@@ -1887,6 +1886,188 @@ port_sig_output(Port *prt, erts_aint32_t state, int op, ErtsProc2PortSigData *si
     return ERTS_PORT_REDS_CMD_OUTPUT;
 }
 
+
+/*
+ * This erts_port_output will always create a port task.
+ * The call is treated as a port_command call, i.e. no
+ * badsig i generated if the input in invalid. However
+ * an error_logger message is generated.
+ */
+int
+erts_port_output_async(Port *prt, Eterm from, Eterm list)
+{
+
+    ErtsPortOpResult res;
+    ErtsProc2PortSigData *sigdp;
+    erts_driver_t *drv = prt->drv_ptr;
+    size_t size;
+    int task_flags;
+    ErtsProc2PortSigCallback port_sig_callback;
+    ErlDrvBinary *cbin = NULL;
+    ErlIOVec *evp = NULL;
+    char *buf = NULL;
+    ErtsPortTaskHandle *ns_pthp;
+
+    if (drv->outputv) {
+        ErlIOVec ev;
+	SysIOVec* ivp;
+	ErlDrvBinary**  bvp;
+        int vsize;
+	Uint csize;
+	Uint pvsize;
+	Uint pcsize;
+        size_t iov_offset, binv_offset, alloc_size;
+        Uint blimit = 0;
+        char *ptr;
+        int i;
+
+        Eterm* bptr = NULL;
+        Uint offset;
+
+        if (is_binary(list)) {
+            /* We optimize for when we get a procbin without offset */
+            Eterm real_bin;
+            int bitoffs;
+            int bitsize;
+            ERTS_GET_REAL_BIN(list, real_bin, offset, bitoffs, bitsize);
+            bptr = binary_val(real_bin);
+            if (*bptr == HEADER_PROC_BIN && bitoffs == 0) {
+                size = binary_size(list);
+                vsize = 1;
+            } else
+                bptr = NULL;
+        }
+
+        if (!bptr) {
+            if (io_list_vec_len(list, &vsize, &csize, &pvsize, &pcsize, &size))
+                goto bad_value;
+
+            /* To pack or not to pack (small binaries) ...? */
+            if (vsize >= SMALL_WRITE_VEC) {
+                /* Do pack */
+                vsize = pvsize + 1;
+                csize = pcsize;
+                blimit = ERL_SMALL_IO_BIN_LIMIT;
+            }
+            cbin = driver_alloc_binary(csize);
+            if (!cbin)
+                erts_alloc_enomem(ERTS_ALC_T_DRV_BINARY, ERTS_SIZEOF_Binary(csize));
+        }
+
+
+        iov_offset = ERTS_ALC_DATA_ALIGN_SIZE(sizeof(ErlIOVec));
+	binv_offset = iov_offset;
+        binv_offset += ERTS_ALC_DATA_ALIGN_SIZE((vsize+1)*sizeof(SysIOVec));
+        alloc_size = binv_offset;
+	alloc_size += (vsize+1)*sizeof(ErlDrvBinary *);
+
+        sigdp = erts_port_task_alloc_p2p_sig_data_extra(alloc_size, (void**)&ptr);
+
+        evp = (ErlIOVec *) ptr;
+        ivp = evp->iov = (SysIOVec *) (ptr + iov_offset);
+        bvp = evp->binv = (ErlDrvBinary **) (ptr + binv_offset);
+
+        ivp[0].iov_base = NULL;
+	ivp[0].iov_len = 0;
+	bvp[0] = NULL;
+
+        if (bptr) {
+            ProcBin* pb = (ProcBin *) bptr;
+
+            ivp[1].iov_base = pb->bytes+offset;
+            ivp[1].iov_len = size;
+            bvp[1] = Binary2ErlDrvBinary(pb->val);
+
+            evp->vsize = 1;
+        } else {
+
+            evp->vsize = io_list_to_vec(list, ivp+1, bvp+1, cbin, blimit);
+            if (evp->vsize < 0) {
+                if (evp != &ev)
+                    erts_free(ERTS_ALC_T_DRV_CMD_DATA, evp);
+                driver_free_binary(cbin);
+                goto bad_value;
+            }
+        }
+#if 0
+	/* This assertion may say something useful, but it can
+        be falsified during the emulator test suites. */
+	ASSERT(evp->vsize == vsize);
+#endif
+	evp->vsize++;
+	evp->size = size;  /* total size */
+
+        /* Need to increase refc on all binaries */
+        for (i = 1; i < evp->vsize; i++)
+            if (bvp[i])
+                driver_binary_inc_refc(bvp[i]);
+
+	sigdp->flags = ERTS_P2P_SIG_TYPE_OUTPUTV;
+	sigdp->u.outputv.from = from;
+	sigdp->u.outputv.evp = evp;
+	sigdp->u.outputv.cbinp = cbin;
+	port_sig_callback = port_sig_outputv;
+    } else {
+        ErlDrvSizeT ERTS_DECLARE_DUMMY(r);
+
+	/*
+	 * Apperently there exist code that write 1 byte to
+	 * much in buffer. Where it resides I don't know, but
+	 * we can live with one byte extra allocated...
+	 */
+
+        if (erts_iolist_size(list, &size))
+            goto bad_value;
+
+        buf = erts_alloc(ERTS_ALC_T_DRV_CMD_DATA, size + 1);
+
+        r = erts_iolist_to_buf(list, buf, size);
+        ASSERT(ERTS_IOLIST_TO_BUF_SUCCEEDED(r));
+
+	sigdp = erts_port_task_alloc_p2p_sig_data();
+	sigdp->flags = ERTS_P2P_SIG_TYPE_OUTPUT;
+	sigdp->u.output.from = from;
+	sigdp->u.output.bufp = buf;
+	sigdp->u.output.size = size;
+	port_sig_callback = port_sig_output;
+    }
+    sigdp->flags = 0;
+    ns_pthp = NULL;
+    task_flags = 0;
+
+    res = erts_schedule_proc2port_signal(NULL,
+					 prt,
+					 ERTS_INVALID_PID,
+					 NULL,
+					 sigdp,
+					 task_flags,
+					 ns_pthp,
+					 port_sig_callback);
+
+    if (res != ERTS_PORT_OP_SCHEDULED) {
+	if (drv->outputv)
+	    cleanup_scheduled_outputv(evp, cbin);
+	else
+	    cleanup_scheduled_output(buf);
+	return 1;
+    }
+    return 1;
+
+bad_value:
+
+    /*
+     * We call badsig directly here as this function is called with
+     * the main lock of the calling process still held.
+     * At the moment this operation is always not a bang_op, so
+     * only an error_logger message should be generated, no badsig.
+    */
+
+    badsig_received(0, prt, erts_atomic32_read_nob(&prt->state), 1);
+
+    return 0;
+
+}
+
 ErtsPortOpResult
 erts_port_output(Process *c_p,
 		 int flags,
@@ -1896,7 +2077,7 @@ erts_port_output(Process *c_p,
 		 Eterm *refp)
 {
     ErtsPortOpResult res;
-    ErtsProc2PortSigData *sigdp;
+    ErtsProc2PortSigData *sigdp = NULL;
     erts_driver_t *drv = prt->drv_ptr;
     size_t size;
     int try_call;
@@ -1978,10 +2159,13 @@ erts_port_output(Process *c_p,
 	    evp = &ev;
 	}
 	else {
-	    char *ptr = erts_alloc((try_call
-				    ? ERTS_ALC_T_TMP
-				    : ERTS_ALC_T_DRV_CMD_DATA), alloc_size);
-
+            char *ptr;
+            if (try_call) {
+                ptr = erts_alloc(ERTS_ALC_T_TMP, alloc_size);
+            } else {
+                sigdp = erts_port_task_alloc_p2p_sig_data_extra(
+                    alloc_size, (void**)&ptr);
+            }
 	    evp = (ErlIOVec *) ptr;
 	    ivp = evp->iov = (SysIOVec *) (ptr + iov_offset);
 	    bvp = evp->binv = (ErlDrvBinary **) (ptr + binv_offset);
@@ -2010,9 +2194,12 @@ erts_port_output(Process *c_p,
 	bvp[0] = NULL;
 	evp->vsize = io_list_to_vec(list, ivp+1, bvp+1, cbin, blimit);
 	if (evp->vsize < 0) {
-	    if (evp != &ev)
-		erts_free(try_call ? ERTS_ALC_T_TMP : ERTS_ALC_T_DRV_CMD_DATA,
-			  evp);
+            if (evp != &ev) {
+                if (try_call)
+                    erts_free(ERTS_ALC_T_TMP, evp);
+                else
+                    erts_port_task_free_p2p_sig_data(sigdp);
+            }
 	    driver_free_binary(cbin);
 	    goto bad_value;
 	}
@@ -2064,8 +2251,10 @@ erts_port_output(Process *c_p,
 		/* Fall through... */
 	    case ERTS_TRY_IMM_DRV_CALL_INVALID_PORT:
 		driver_free_binary(cbin);
-		if (evp != &ev)
+		if (evp != &ev) {
+                    ASSERT(!sigdp);
 		    erts_free(ERTS_ALC_T_TMP, evp);
+                }
 		if (try_call_res != ERTS_TRY_IMM_DRV_CALL_OK)
 		    return ERTS_PORT_OP_DROPPED;
 		if (c_p)
@@ -2076,8 +2265,10 @@ erts_port_output(Process *c_p,
 		if (async_nosuspend
 		    && (sched_flags & (busy_flgs|ERTS_PTS_FLG_EXIT))) {
 		    driver_free_binary(cbin);
-		    if (evp != &ev)
+                    if (evp != &ev) {
+                        ASSERT(!sigdp);
 			erts_free(ERTS_ALC_T_TMP, evp);
+                    }
 		    return ((sched_flags & ERTS_PTS_FLG_EXIT)
 			    ? ERTS_PORT_OP_DROPPED
 			    : ERTS_PORT_OP_BUSY);
@@ -2092,9 +2283,16 @@ erts_port_output(Process *c_p,
 		if (bvp[i])
 		    driver_binary_inc_refc(bvp[i]);
 
-	    new_evp = erts_alloc(ERTS_ALC_T_DRV_CMD_DATA, alloc_size);
+            /* The port task and iovec is allocated in the
+               same structure as an optimization. This
+               is especially important in erts_port_output_async
+               of when !try_call */
+            ASSERT(sigdp == NULL);
+            sigdp = erts_port_task_alloc_p2p_sig_data_extra(
+                alloc_size, (void**)&new_evp);
 
 	    if (evp != &ev) {
+                /* Copy from TMP alloc to port task */
 		sys_memcpy((void *) new_evp, (void *) evp, alloc_size);
 		new_evp->iov = (SysIOVec *) (((char *) new_evp)
 					     + iov_offset);
@@ -2142,7 +2340,6 @@ erts_port_output(Process *c_p,
 	    evp = new_evp;
 	}
 
-	sigdp = erts_port_task_alloc_p2p_sig_data();
 	sigdp->flags = ERTS_P2P_SIG_TYPE_OUTPUTV;
 	sigdp->u.outputv.from = from;
 	sigdp->u.outputv.evp = evp;

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -4570,7 +4570,7 @@ port_sig_call(Port *prt,
 
                 (void) erts_factory_message_create(&factory, rp, &rp_locks, hsz);
 		endp = (byte *) resp_bufp;
-		msg = erts_decode_ext(&factory, &endp);
+		msg = erts_decode_ext(&factory, &endp, 0);
 		if (is_value(msg)) {
                     hp = erts_produce_heap(&factory,
                                            3,
@@ -4689,7 +4689,7 @@ erts_port_call(Process* c_p,
 	    hsz += 3;
             erts_factory_proc_prealloc_init(&factory, c_p, hsz);
 	    endp = (byte *) resp_bufp;
-	    term = erts_decode_ext(&factory, &endp);
+	    term = erts_decode_ext(&factory, &endp, 0);
 	    if (term == THE_NON_VALUE)
 		return ERTS_PORT_OP_BADARG;
             hp = erts_produce_heap(&factory,3,0);

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -44,7 +44,8 @@
 	 nif_nan_and_inf/1, nif_atom_too_long/1,
 	 nif_monotonic_time/1, nif_time_offset/1, nif_convert_time_unit/1,
          nif_now_time/1, nif_cpu_time/1, nif_unique_integer/1,
-         nif_is_process_alive/1, nif_is_port_alive/1
+         nif_is_process_alive/1, nif_is_port_alive/1,
+         nif_term_to_binary/1, nif_binary_to_term/1
 	]).
 
 -export([many_args_100/100]).
@@ -77,7 +78,8 @@ all() ->
      nif_exception, nif_nan_and_inf, nif_atom_too_long,
      nif_monotonic_time, nif_time_offset, nif_convert_time_unit,
      nif_now_time, nif_cpu_time, nif_unique_integer,
-     nif_is_process_alive, nif_is_port_alive
+     nif_is_process_alive, nif_is_port_alive,
+     nif_term_to_binary, nif_binary_to_term
     ].
 
 init_per_testcase(_Case, Config) ->
@@ -1958,6 +1960,23 @@ nif_is_port_alive(Config) ->
     port_close(Port),
     false = is_port_alive_nif(Port).
 
+nif_term_to_binary(Config) ->
+    ensure_lib_loaded(Config),
+    T = {#{ok => nok}, <<0:8096>>, lists:seq(1,100)},
+    Bin = term_to_binary(T),
+    ct:log("~p",[Bin]),
+    Bin = term_to_binary_nif(T, undefined),
+    true = term_to_binary_nif(T, self()),
+    receive Bin -> ok end.
+
+nif_binary_to_term(Config) ->
+    ensure_lib_loaded(Config),
+    T = {#{ok => nok}, <<0:8096>>, lists:seq(1,100)},
+    Bin = term_to_binary(T),
+    T = binary_to_term_nif(Bin, undefined),
+    true = binary_to_term_nif(Bin, self()),
+    receive T -> ok end.
+
 %% The NIFs:
 lib_version() -> undefined.
 call_history() -> ?nif_stub.
@@ -2018,6 +2037,8 @@ call_nif_atom_too_long(_) -> ?nif_stub.
 unique_integer_nif(_) -> ?nif_stub.
 is_process_alive_nif(_) -> ?nif_stub.
 is_port_alive_nif(_) -> ?nif_stub.
+term_to_binary_nif(_, _) -> ?nif_stub.
+binary_to_term_nif(_, _) -> ?nif_stub.
 
 %% maps
 is_map_nif(_) -> ?nif_stub.

--- a/erts/emulator/test/nif_SUITE_data/Makefile.src
+++ b/erts/emulator/test/nif_SUITE_data/Makefile.src
@@ -4,8 +4,7 @@ NIF_LIBS = nif_SUITE.1@dll@ \
            nif_mod.2@dll@ \
            nif_mod.3@dll@
 
-all: $(NIF_LIBS) basic@dll@ rwlock@dll@ tsd@dll@
-
+all: $(NIF_LIBS) basic@dll@ rwlock@dll@ tsd@dll@ echo_drv@dll@
 
 @SHLIB_RULES@
 

--- a/erts/emulator/test/nif_SUITE_data/echo_drv.c
+++ b/erts/emulator/test/nif_SUITE_data/echo_drv.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include "erl_driver.h"
+
+static ErlDrvPort erlang_port;
+static ErlDrvData echo_start(ErlDrvPort, char *);
+static void from_erlang(ErlDrvData, char*, ErlDrvSizeT);
+static ErlDrvSSizeT echo_call(ErlDrvData drv_data, unsigned int command,
+			      char *buf, ErlDrvSizeT len,
+			      char **rbuf, ErlDrvSizeT rlen, unsigned *ret_flags);
+static ErlDrvEntry echo_driver_entry = { 
+    NULL,			/* Init */
+    echo_start,
+    NULL,			/* Stop */
+    from_erlang,
+    NULL,			/* Ready input */
+    NULL,			/* Ready output */
+    "echo_drv",
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    echo_call,
+    NULL,
+    ERL_DRV_EXTENDED_MARKER,
+    ERL_DRV_EXTENDED_MAJOR_VERSION,
+    ERL_DRV_EXTENDED_MINOR_VERSION,
+    0,
+    NULL,
+    NULL,
+    NULL
+};
+
+DRIVER_INIT(echo_drv)
+{
+    return &echo_driver_entry;
+}
+
+static ErlDrvData
+echo_start(ErlDrvPort port, char *buf)
+{
+    return (ErlDrvData) port;
+}
+
+static void
+from_erlang(ErlDrvData data, char *buf, ErlDrvSizeT count)
+{
+    driver_output((ErlDrvPort) data, buf, count);
+}
+
+static ErlDrvSSizeT
+echo_call(ErlDrvData drv_data, unsigned int command,
+	  char *buf, ErlDrvSizeT len, char **rbuf, ErlDrvSizeT rlen,
+	  unsigned *ret_flags)
+{
+    *rbuf = buf;
+    *ret_flags |= DRIVER_CALL_KEEP_BUFFER;
+    return len;
+}
+

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -30,6 +30,7 @@ static int static_cntA; /* zero by default */
 static int static_cntB = NIF_SUITE_LIB_VER * 100;
 
 static ERL_NIF_TERM atom_false;
+static ERL_NIF_TERM atom_true;
 static ERL_NIF_TERM atom_self;
 static ERL_NIF_TERM atom_ok;
 static ERL_NIF_TERM atom_join;
@@ -138,6 +139,7 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 						    msgenv_dtor,
 						    ERL_NIF_RT_CREATE, NULL);
     atom_false = enif_make_atom(env,"false");
+    atom_true = enif_make_atom(env,"true");
     atom_self = enif_make_atom(env,"self");
     atom_ok = enif_make_atom(env,"ok");
     atom_join = enif_make_atom(env,"join");
@@ -2008,6 +2010,26 @@ static ERL_NIF_TERM unique_integer(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
     return enif_make_unique_integer(env, properties);
 }
 
+static ERL_NIF_TERM is_process_alive(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ErlNifPid pid;
+    if (!enif_get_local_pid(env, argv[0], &pid))
+        return enif_make_badarg(env);
+    if (enif_is_process_alive(env, &pid))
+        return atom_true;
+    return atom_false;
+}
+
+static ERL_NIF_TERM is_port_alive(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ErlNifPort port;
+    if (!enif_get_local_port(env, argv[0], &port))
+        return enif_make_badarg(env);
+    if (enif_is_port_alive(env, &port))
+        return atom_true;
+    return atom_false;
+}
+
 static ErlNifFunc nif_funcs[] =
 {
     {"lib_version", 0, lib_version},
@@ -2083,7 +2105,9 @@ static ErlNifFunc nif_funcs[] =
     {"convert_time_unit", 3, convert_time_unit},
     {"now_time", 0, now_time},
     {"cpu_time", 0, cpu_time},
-    {"unique_integer_nif", 1, unique_integer}
+    {"unique_integer_nif", 1, unique_integer},
+    {"is_process_alive_nif", 1, is_process_alive},
+    {"is_port_alive_nif", 1, is_port_alive}
 };
 
 ERL_NIF_INIT(nif_SUITE,nif_funcs,load,reload,upgrade,unload)

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -2057,25 +2057,31 @@ static ERL_NIF_TERM term_to_binary(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
 static ERL_NIF_TERM binary_to_term(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ErlNifBinary bin;
-    ERL_NIF_TERM term;
+    ERL_NIF_TERM term, ret_term;
     ErlNifPid pid;
     ErlNifEnv *msg_env = env;
+    unsigned int opts;
+    ErlNifUInt64 ret;
 
     if (enif_get_local_pid(env, argv[1], &pid))
         msg_env = enif_alloc_env();
 
-    if (!enif_inspect_binary(env, argv[0], &bin))
+    if (!enif_inspect_binary(env, argv[0], &bin)
+	|| !enif_get_uint(env, argv[2], &opts))
         return enif_make_badarg(env);
 
-    if (!enif_binary_to_term(env, &bin, &term))
-        return enif_make_badarg(env);
+    ret = enif_binary_to_term(msg_env, bin.data, bin.size, &term,
+			      (ErlNifBinaryToTerm)opts);
+    if (!ret)
+	return atom_false;
 
+    ret_term = enif_make_uint64(env, ret);
     if (msg_env != env) {
         enif_send(env, &pid, msg_env, term);
         enif_free_env(msg_env);
-        return atom_true;
+        return ret_term;
     } else {
-        return term;
+        return enif_make_tuple2(env, ret_term, term);
     }
 }
 
@@ -2170,7 +2176,7 @@ static ErlNifFunc nif_funcs[] =
     {"is_process_alive_nif", 1, is_process_alive},
     {"is_port_alive_nif", 1, is_port_alive},
     {"term_to_binary_nif", 2, term_to_binary},
-    {"binary_to_term_nif", 2, binary_to_term},
+    {"binary_to_term_nif", 3, binary_to_term},
     {"port_command_nif", 2, port_command}
 };
 

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -2079,6 +2079,18 @@ static ERL_NIF_TERM binary_to_term(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
     }
 }
 
+static ERL_NIF_TERM port_command(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ErlNifPort port;
+
+    if (!enif_get_local_port(env, argv[0], &port))
+        return enif_make_badarg(env);
+
+    if (!enif_port_command(env, &port, NULL, argv[1]))
+        return enif_make_badarg(env);
+    return atom_true;
+}
+
 static ErlNifFunc nif_funcs[] =
 {
     {"lib_version", 0, lib_version},
@@ -2158,7 +2170,8 @@ static ErlNifFunc nif_funcs[] =
     {"is_process_alive_nif", 1, is_process_alive},
     {"is_port_alive_nif", 1, is_port_alive},
     {"term_to_binary_nif", 2, term_to_binary},
-    {"binary_to_term_nif", 2, binary_to_term}
+    {"binary_to_term_nif", 2, binary_to_term},
+    {"port_command_nif", 2, port_command}
 };
 
 ERL_NIF_INIT(nif_SUITE,nif_funcs,load,reload,upgrade,unload)

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -1978,6 +1978,36 @@ static ERL_NIF_TERM convert_time_unit(ErlNifEnv* env, int argc, const ERL_NIF_TE
     return enif_make_int64(env, enif_convert_time_unit(val, from, to));
 }
 
+static ERL_NIF_TERM now_time(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    return enif_now_time(env);
+}
+
+static ERL_NIF_TERM cpu_time(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    return enif_cpu_time(env);
+}
+
+static ERL_NIF_TERM unique_integer(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ERL_NIF_TERM atom_pos = enif_make_atom(env,"positive"),
+        atom_mon = enif_make_atom(env,"monotonic");
+    ERL_NIF_TERM opts = argv[0], opt;
+    ErlNifUniqueInteger properties = 0;
+
+    while (!enif_is_empty_list(env, opts)) {
+	if (!enif_get_list_cell(env, opts, &opt, &opts))
+            return enif_make_badarg(env);
+
+        if (enif_compare(opt, atom_pos) == 0)
+            properties |= ERL_NIF_UNIQUE_POSITIVE;
+        if (enif_compare(opt, atom_mon) == 0)
+            properties |= ERL_NIF_UNIQUE_MONOTONIC;
+    }
+
+    return enif_make_unique_integer(env, properties);
+}
+
 static ErlNifFunc nif_funcs[] =
 {
     {"lib_version", 0, lib_version},
@@ -2050,8 +2080,10 @@ static ErlNifFunc nif_funcs[] =
     {"sorted_list_from_maps_nif", 1, sorted_list_from_maps_nif},
     {"monotonic_time", 1, monotonic_time},
     {"time_offset", 1, time_offset},
-    {"convert_time_unit", 3, convert_time_unit}
+    {"convert_time_unit", 3, convert_time_unit},
+    {"now_time", 0, now_time},
+    {"cpu_time", 0, cpu_time},
+    {"unique_integer_nif", 1, unique_integer}
 };
 
 ERL_NIF_INIT(nif_SUITE,nif_funcs,load,reload,upgrade,unload)
-


### PR DESCRIPTION
This PR adds a couple of new NIF function that are needed in order to create the new tracer modules to be added in 19.0.

The functions added are:
* enif_now_time
* enif_cpu_time
* enif_make_unique_integer
* enif_is_process_alive
* enif_is_port_alive
* enif_term_to_binary
* enif_binary_to_term
* enif_port_command