### PR TITLE
Changed setBackgroundColour to setBackgroundStyle

### DIFF
--- a/lib/observer/src/observer_lib.erl
+++ b/lib/observer/src/observer_lib.erl
@@ -122,7 +122,7 @@ display_yes_no_dialog(Str) ->
 %% display_info(Parent, [{Title, [{Label, Info}]}]) -> {Panel, Sizer, InfoFieldsToUpdate}
 display_info(Frame, Info) ->
     Panel = wxPanel:new(Frame),
-    wxWindow:setBackgroundColour(Panel, {255,255,255}),
+    wxWindow:setBackgroundStyle(Panel, ?wxBG_STYLE_SYSTEM),
     Sizer = wxBoxSizer:new(?wxVERTICAL),
     wxSizer:addSpacer(Sizer, 5),
     Add = fun(BoxInfo) ->
@@ -380,16 +380,16 @@ add_box(Panel, OuterBox, Cursor, Title, Proportion, {Format, List}) ->
     ScrollSizer  = wxBoxSizer:new(?wxVERTICAL),
     wxScrolledWindow:setSizer(Scroll, ScrollSizer),
     BC = wxWindow:getBackgroundColour(Panel),
-    wxWindow:setBackgroundColour(Scroll,BC),
+    wxWindow:setBackgroundStyle(Scroll, ?wxBG_STYLE_SYSTEM),
     add_entries(Format, List, Scroll, ScrollSizer, BC, Cursor),
     wxSizer:add(Box,Scroll,[{proportion,1},{flag,?wxEXPAND}]),
     wxSizer:add(OuterBox,Box,[{proportion,Proportion},{flag,?wxEXPAND}]),
     {Scroll,ScrollSizer,length(List)}.
 
-add_entries(click, List, Scroll, ScrollSizer, BC, Cursor) ->
+add_entries(click, List, Scroll, ScrollSizer, _BC, Cursor) ->
     Add = fun(Link) ->
 		  TC = link_entry(Scroll, Link, Cursor),
-		  wxWindow:setBackgroundColour(TC,BC),
+                  wxWindow:setBackgroundStyle(TC, ?wxBG_STYLE_SYSTEM),
 		  wxSizer:add(ScrollSizer,TC,[{flag,?wxEXPAND}])
 	  end,
     [Add(Link) || Link <- List];

--- a/lib/observer/src/observer_lib.erl
+++ b/lib/observer/src/observer_lib.erl
@@ -214,9 +214,8 @@ update_info2([], []) -> ok.
 update_scroll_boxes({_, _, 0}, {_, []}) -> ok;
 update_scroll_boxes({Win, Sizer, _}, {Type, List}) ->
     [wxSizerItem:deleteWindows(Child) ||  Child <- wxSizer:getChildren(Sizer)],
-    BC = wxWindow:getBackgroundColour(Win),
     Cursor = wxCursor:new(?wxCURSOR_HAND),
-    add_entries(Type, List, Win, Sizer, BC, Cursor),
+    add_entries(Type, List, Win, Sizer, Cursor),
     wxCursor:destroy(Cursor),
     wxSizer:recalcSizes(Sizer),
     wxWindow:refresh(Win),
@@ -379,21 +378,20 @@ add_box(Panel, OuterBox, Cursor, Title, Proportion, {Format, List}) ->
     wxScrolledWindow:setScrollbars(Scroll,1,1,0,0),
     ScrollSizer  = wxBoxSizer:new(?wxVERTICAL),
     wxScrolledWindow:setSizer(Scroll, ScrollSizer),
-    BC = wxWindow:getBackgroundColour(Panel),
     wxWindow:setBackgroundStyle(Scroll, ?wxBG_STYLE_SYSTEM),
-    add_entries(Format, List, Scroll, ScrollSizer, BC, Cursor),
+    add_entries(Format, List, Scroll, ScrollSizer, Cursor),
     wxSizer:add(Box,Scroll,[{proportion,1},{flag,?wxEXPAND}]),
     wxSizer:add(OuterBox,Box,[{proportion,Proportion},{flag,?wxEXPAND}]),
     {Scroll,ScrollSizer,length(List)}.
 
-add_entries(click, List, Scroll, ScrollSizer, _BC, Cursor) ->
+add_entries(click, List, Scroll, ScrollSizer, Cursor) ->
     Add = fun(Link) ->
 		  TC = link_entry(Scroll, Link, Cursor),
                   wxWindow:setBackgroundStyle(TC, ?wxBG_STYLE_SYSTEM),
 		  wxSizer:add(ScrollSizer,TC,[{flag,?wxEXPAND}])
 	  end,
     [Add(Link) || Link <- List];
-add_entries(plain, List, Scroll, ScrollSizer, _, _) ->
+add_entries(plain, List, Scroll, ScrollSizer, _) ->
     Add = fun(String) ->
 		  TC = wxTextCtrl:new(Scroll, ?wxID_ANY,
 				      [{style,?SINGLE_LINE_STYLE},

--- a/lib/observer/src/observer_perf_wx.erl
+++ b/lib/observer/src/observer_perf_wx.erl
@@ -94,7 +94,7 @@ setup_graph_drawing(Panels) ->
     IsWindows = element(1, os:type()) =:= win32,
     IgnoreCB = {callback, fun(_,_) -> ok end},
     Do = fun(Panel) ->
-		 wxWindow:setBackgroundColour(Panel, ?wxWHITE),
+		 wxWindow:setBackgroundStyle(Panel, ?wxBG_STYLE_SYSTEM),
 		 wxPanel:connect(Panel, paint, [callback]),
 		 IsWindows andalso
 		     wxPanel:connect(Panel, erase_background, [IgnoreCB])


### PR DESCRIPTION
Changed setBackgroundColour to setBackgroundStyle to enable attempts to use themes for this window.
if the system supports them, since usually the themes represent the appearance chosen by the user to be used for all applications on the system. 

ref:http://docs.wxwidgets.org/2.8.12/wx_wxwindow.html#wxwindowsetbackgroundcolour

For example if a user is using a dark themes 
Before:  using **setBackgroundColour**
![alt text][before]

After:  using **setBackgroundStyle**
![alt text][after]

[before]:http://i.imgur.com/bnwgt2A.png
[after]:http://i.imgur.com/QqGfdlt.png