### PR TITLE
Protect zip:extract/1,2 from directory traversal

### DIFF
--- a/lib/stdlib/doc/src/zip.xml
+++ b/lib/stdlib/doc/src/zip.xml
@@ -11,7 +11,7 @@
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.
       You may obtain a copy of the License at
- 
+
           http://www.apache.org/licenses/LICENSE-2.0
 
       Unless required by applicable law or agreed to in writing, software
@@ -137,10 +137,10 @@
       </desc>
     </datatype>
     <datatype>
-      <name name="handle"/>                                                                          
+      <name name="handle"/>
       <desc>
-        <p>As returned by <seealso marker="#zip_open/2">zip_open/2</seealso>.</p>                     
-      </desc>                                                        
+        <p>As returned by <seealso marker="#zip_open/2">zip_open/2</seealso>.</p>
+      </desc>
     </datatype>
   </datatypes>
   <funcs>
@@ -270,6 +270,9 @@
         <p>If the <c><anno>Archive</anno></c> argument is given as a binary,
           the contents of the binary is assumed to be a zip archive,
           otherwise it should be a filename.</p>
+        <p>Note that <c>".."</c> path components will be removed from all
+          filenames to protect from directory traversal attacks. For example
+          <c>"../foo/../bar"</c> will be changed to <c>"foo/bar"</c>.</p>
         <p>The following options are available:</p>
         <taglist>
           <tag><c>{file_list, <anno>FileList</anno>}</c></tag>
@@ -475,4 +478,3 @@
     </func>
   </funcs>
 </erlref>
-

--- a/lib/stdlib/src/zip.erl
+++ b/lib/stdlib/src/zip.erl
@@ -825,21 +825,19 @@ add_cwd(CWD, F) -> filename:join(CWD, F).
 %% remove ".." components from the path to protect from directory traversal
 protect_from_traversal("") -> "";
 protect_from_traversal(F) ->
-	SafeName = filename:join(lists:filter(fun(E) -> E =/= ".." end, filename:split(F))),
+	SafeName = filename:join([E || E <- filename:split(F), E =/= ".."]),
 	%% filename:split/1 removes trailing separators so we append them here if needed
 	maybe_append_slash(F, SafeName, os:type()).
 
 maybe_append_slash(F, SafeName, {win32, _}) ->
-	IsDirectory = [lists:last(F)] == "\\",
-	if
-		IsDirectory -> SafeName ++ "\\";
-		true -> SafeName
+	case lists:suffix("\\", F) of
+		true -> SafeName ++ "\\";
+		false -> SafeName
 	end;
 maybe_append_slash(F, SafeName, _) ->
-	IsDirectory = [lists:last(F)] == "/",
-	if
-		IsDirectory -> SafeName ++ "/";
-		true -> SafeName
+	case lists:suffix("/", F) of
+		true -> SafeName ++ "/";
+		false -> SafeName
 	end.
 
 %% already compressed data should be stored as is in archive,


### PR DESCRIPTION
`zip:unzip/1,2` and `zip:extract/1,2` are currently vulnerable to [directory traversal attacks](https://en.wikipedia.org/wiki/Directory_traversal_attack).

For example: `/home/net/zips/archive.zip` – containing `../evil.txt` – will extract `evil.txt` to `/home/net` instead of `/home/net/zips` if not properly guarded against.

```erlang
/                        ┌────────────────┐
└─home/              ┌──▷│    Contents    │
  └─net/             │   ├────────────────┤
    └─zips/          │   │../evil.txt     │
      └─archive.zip──┘   └────────────────┘
┌─────────────────────────────────────────┐
│ % cd ~/zips                             │
│ % erl                                   │
│ 1> zip:unzip("archive.zip").            │
│ {ok,["../evil.txt"]}                    │
└─────────────────────────────────────────┘
/
└─home/
  └─net/
    ├─evil.txt ◀──
    └─zips/
      └─archive.zip
```

[ptoomey3/evilarc](https://github.com/ptoomey3/evilarc) let's you create archives for testing directory traversal.

This commit protects against directory traversal by removing ".." components from filenames when extracting zips. Path components that simply _include_ ".."s are left intact (e.g. `foo..bar/`).

- Added function protect_from_traversal/1 to remove ".." components
from filenames.
- get_z_file/8 now passes filenames through protect_from_traversal.
- filename:split/1 removes trailing separators so maybe_append_slash/2
was added to fix this (trailing separators signify a directory instead
of a file).
- Documented the change in the zip doc file.