### PR TITLE
crypto: Enable AES-GCM tag length to change

### DIFF
--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -203,6 +203,7 @@
     <func>
       <name>block_encrypt(Type, Key, Ivec, PlainText) -> CipherText</name>
       <name>block_encrypt(AeadType, Key, Ivec, {AAD, PlainText}) -> {CipherText, CipherTag}</name>
+      <name>block_encrypt(aes_gcm, Key, Ivec, {AAD, PlainText, TagLength}) -> {CipherText, CipherTag}</name>
       <fsummary>Encrypt <c>PlainText</c> according to <c>Type</c> block cipher</fsummary>
       <type>
 	<v>Type = block_cipher() </v>
@@ -210,6 +211,7 @@
 	<v>Key = block_key() </v>
         <v>PlainText = iodata() </v>
         <v>AAD = IVec = CipherText = CipherTag = binary()</v>
+        <v>TagLength = 1..16</v>
       </type>
       <desc>
         <p>Encrypt <c>PlainText</c> according to <c>Type</c> block cipher.

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -302,6 +302,8 @@ block_encrypt(aes_ige256, Key, Ivec, Data) ->
     aes_ige_crypt_nif(Key, Ivec, Data, true);
 block_encrypt(aes_gcm, Key, Ivec, {AAD, Data}) ->
     aes_gcm_encrypt(Key, Ivec, AAD, Data);
+block_encrypt(aes_gcm, Key, Ivec, {AAD, Data, TagLength}) ->
+    aes_gcm_encrypt(Key, Ivec, AAD, Data, TagLength);
 block_encrypt(chacha20_poly1305, Key, Ivec, {AAD, Data}) ->
     chacha20_poly1305_encrypt(Key, Ivec, AAD, Data).
 
@@ -917,7 +919,10 @@ aes_cfb_128_decrypt(Key, IVec, Data) ->
 %%
 %% AES - in Galois/Counter Mode (GCM)
 %%
-aes_gcm_encrypt(_Key, _Ivec, _AAD, _In) -> ?nif_stub.
+%% The default tag length is EVP_GCM_TLS_TAG_LEN(16),
+aes_gcm_encrypt(Key, Ivec, AAD, In) ->
+    aes_gcm_encrypt(Key, Ivec, AAD, In, 16).
+aes_gcm_encrypt(_Key, _Ivec, _AAD, _In, _TagLength) -> ?nif_stub.
 aes_gcm_decrypt(_Key, _Ivec, _AAD, _In, _Tag) -> ?nif_stub.
 
 %%


### PR DESCRIPTION
This commit enables AES-GCM encryption/decryption to change the tag
length between 1 to 16 bytes.

[old spec](http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf), which crypto module refers to, says that the tag length can be any value between 0 and 128, whereas [new spec](http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-revised-spec.pdf) says between 64 and 128.

For now, this implementation allows values between 1 and 16 bytes(it means between 8 and 128), based on the openssl's implementation(https://github.com/openssl/openssl/blob/master/crypto/evp/e_aes.c#L1350-L1355).

Use case: [quic](https://docs.google.com/document/d/1g5nIXAIkN_Y-7XJW5K45IblHd_L2f5LTaDUDwvZ5L6g/edit) uses 12-byte tag.