### PR TITLE
jinterface: updated pom.xml.src (ERL-67)

### DIFF
--- a/lib/jinterface/java_src/pom.xml.src
+++ b/lib/jinterface/java_src/pom.xml.src
@@ -7,14 +7,14 @@
 	<version>%VSN%</version>
 	<name>jinterface</name>
 	<description>
-  Jinterface Java package contains java classes, which help you integrate programs written in Java with Erlang.
+		Jinterface Java package contains java classes, which help you integrate programs written in Java with Erlang.
   Erlang is a programming language designed at the Ericsson Computer Science Laboratory.
-  </description>
+	</description>
 	<url>http://erlang.org/</url>
 	<licenses>
 		<license>
-			<name>ERLANG PUBLIC LICENSE 1.1</name>
-			<url>http://www.erlang.org/EPLICENSE</url>
+			<name>Apache License 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -37,14 +37,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.10</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -56,6 +58,32 @@
 								<source>java_src</source>
 							</sources>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.3</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>
@@ -85,7 +113,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.0-alpha-4</version>
+						<version>1.6</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>


### PR DESCRIPTION
http://bugs.erlang.org/browse/ERL-67

These are a few changes to the (otherwise unused) pom.xml for jinterface, so that it actually works for building the library with Maven.