### PR TITLE
Correct mispelling in Dialyzer's acronym definition

### DIFF
--- a/lib/dialyzer/README
+++ b/lib/dialyzer/README
@@ -6,7 +6,7 @@
 ## Copyright: Held by the authors; all rights reserved (2004 - 2010).
 ##----------------------------------------------------------------------------
 
-The DIALYZER, a DIscrepany AnaLYZer for ERlang programs.
+The DIALYZER, a DIscrepancy AnaLYZer for ERlang programs.
 
 
 -----------------------------------------------

--- a/lib/dialyzer/doc/about.txt
+++ b/lib/dialyzer/doc/about.txt
@@ -1,5 +1,5 @@
 		    This is DIALYZER version 2.1.0
-	DIALYZER is a DIscrepany AnaLYZer for ERlang programs.
+	DIALYZER is a DIscrepancy AnaLYZer for ERlang programs.
 
 	Copyright (C) Tobias Lindahl <tobiasl@it.uu.se>
 		      Kostis Sagonas <kostis@it.uu.se>

--- a/lib/dialyzer/doc/manual.txt
+++ b/lib/dialyzer/doc/manual.txt
@@ -4,7 +4,7 @@
 ##	      Kostis Sagonas <kostis@it.uu.se>
 ##----------------------------------------------------------------------------
 
-The DIALYZER, a DIscrepany AnaLYZer for ERlang programs.
+The DIALYZER, a DIscrepancy AnaLYZer for ERlang programs.
 
 
 -----------------------------------------------

--- a/lib/dialyzer/info
+++ b/lib/dialyzer/info
@@ -1,2 +1,2 @@
 group: tools
-short: The DIALYZER, a DIscrepany AnaLYZer for ERlang programs.
+short: The DIALYZER, a DIscrepancy AnaLYZer for ERlang programs.

--- a/lib/dialyzer/src/dialyzer_gui_wx.erl
+++ b/lib/dialyzer/src/dialyzer_gui_wx.erl
@@ -423,7 +423,7 @@ gui_loop(#gui_state{backend_pid = BackendPid, doc_plt = DocPlt,
     #wx{id=?menuID_HELP_ABOUT, obj=Frame, 
 	event=#wxCommand{type=command_menu_selected}} ->
       Message = "	       This is DIALYZER version "  ++ ?VSN ++  " \n"++
-	"DIALYZER is a DIscrepany AnaLYZer for ERlang programs.\n\n"++
+	"DIALYZER is a DIscrepancy AnaLYZer for ERlang programs.\n\n"++
 	"     Copyright (C) Tobias Lindahl <tobiasl@it.uu.se>\n"++
 	"                   Kostis Sagonas <kostis@it.uu.se>\n\n",
       output_sms(State, "About Dialyzer", Message, info),


### PR DESCRIPTION
"DIscrepany" is replaced with "DIscrepancy" in every occurrence.