### PR TITLE
erl_bif_lists.c:append() fixes

### DIFF
--- a/erts/emulator/beam/erl_bif_lists.c
+++ b/erts/emulator/beam/erl_bif_lists.c
@@ -46,7 +46,7 @@ static BIF_RETTYPE append(Process* p, Eterm A, Eterm B)
 
     if (is_nil(A)) {
 	BIF_RET(B);
-    } else if (is_nil(B)) {
+    } else if (is_nil(B) && is_list(A)) {
 	BIF_RET(A);
     }
     i = erts_list_length(A);

--- a/erts/emulator/beam/erl_bif_lists.c
+++ b/erts/emulator/beam/erl_bif_lists.c
@@ -44,13 +44,14 @@ static BIF_RETTYPE append(Process* p, Eterm A, Eterm B)
     Eterm* hp;
     int i;
 
-    if ((i = erts_list_length(A)) < 0) {
-	BIF_ERROR(p, BADARG);
-    }
-    if (i == 0) {
+    if (is_nil(A)) {
 	BIF_RET(B);
     } else if (is_nil(B)) {
 	BIF_RET(A);
+    }
+    i = erts_list_length(A);
+    if (i < 0) {
+	BIF_ERROR(p, BADARG);
     }
 
     need = 2*i;


### PR DESCRIPTION
The BIF implementing lists:append(A, B) aka A ++ B has two issues:

- It checks that A is a proper list even if B is the empty list.
  In this case A should be returned as-it, but the implementation may
  spend inordinate amount of time checking that A is a proper list.
  This check is also not interruptible.

- The type checking treatment of A and B is inconsistent.  If A is
  the empty list B is returned as-is with no type checking at all,
  but if B is empty A is required to be a proper list.

Both issues are fixed by moving the length(A) computation below the
short-circuiting logic for A == [] and B == [].

I browsed the documentation, but could find no statement that appending
an improper list and a proper one MUST generate a badarg exception.