### PR TITLE
Implement lists:join/2

### DIFF
--- a/lib/stdlib/doc/src/lists.xml
+++ b/lib/stdlib/doc/src/lists.xml
@@ -262,6 +262,21 @@ flatmap(Fun, List1) ->
       </desc>
     </func>
     <func>
+      <name name="join" arity="2"/>
+      <fsummary>Insert an element between elements in a list</fsummary>
+      <desc>
+        <p>Inserts <c><anno>Sep</anno></c> between each element in <c><anno>List1</anno></c>. Has no
+          effect on the empty list and on a singleton list. For example:</p>
+        <pre>
+> <input>lists:join(x, [a,b,c]).</input>
+[a,x,b,x,c]
+> <input>lists:join(x, [a]).</input>
+[a]
+> <input>lists:join(x, []).</input>
+[]</pre>
+      </desc>
+    </func>
+    <func>
       <name name="foreach" arity="2"/>
       <fsummary>Apply a function to each element of a list</fsummary>
       <desc>

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -39,7 +39,8 @@
 -export([all/2,any/2,map/2,flatmap/2,foldl/3,foldr/3,filter/2,
 	 partition/2,zf/2,filtermap/2,
 	 mapfoldl/3,mapfoldr/3,foreach/2,takewhile/2,dropwhile/2,splitwith/2,
-	 split/2]).
+	 split/2,
+	 join/2]).
 
 %%% BIFs
 -export([keyfind/3, keymember/3, keysearch/3, member/2, reverse/2]).
@@ -1438,6 +1439,18 @@ split(N, [H|T], R) ->
     split(N-1, T, [H|R]);
 split(_, [], _) ->
     badarg.
+
+-spec join(Sep, List1) -> List2 when
+      Sep :: T,
+      List1 :: [T],
+      List2 :: [T],
+      T :: term().
+
+join(_Sep, []) -> [];
+join(Sep, [H|T]) -> [H|join_prepend(Sep, T)].
+
+join_prepend(_Sep, []) -> [];
+join_prepend(Sep, [H|T]) -> [Sep,H|join_prepend(Sep,T)].
 
 %%% =================================================================
 %%% Here follows the implementation of the sort functions.

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -55,6 +55,7 @@
 	 ufunsort_error/1,
 	 zip_unzip/1, zip_unzip3/1, zipwith/1, zipwith3/1,
 	 filter_partition/1, 
+	 join/1,
 	 otp_5939/1, otp_6023/1, otp_6606/1, otp_7230/1,
 	 suffix/1, subtract/1, droplast/1, hof/1]).
 
@@ -119,7 +120,7 @@ groups() ->
      {tickets, [parallel], [otp_5939, otp_6023, otp_6606, otp_7230]},
      {zip, [parallel], [zip_unzip, zip_unzip3, zipwith, zipwith3]},
      {misc, [parallel], [reverse, member, dropwhile, takewhile,
-			 filter_partition, suffix, subtract,
+			 filter_partition, suffix, subtract, join,
 			 hof]}
     ].
 
@@ -2411,6 +2412,19 @@ zipwith3(Config) when is_list(Config) ->
     {'EXIT',{function_clause,_}} = (catch lists:zipwith3(Zip, [], [b], [])),
     {'EXIT',{function_clause,_}} = (catch lists:zipwith3(Zip, [a], [], [])),
 
+    ok.
+
+%% Test lists:join/2
+join(Config) when is_list(Config) ->
+    A = [a,b,c],
+    Sep = x,
+    [a,x,b,x,c] = lists:join(Sep, A),
+
+    B = [b],
+    [b] = lists:join(Sep, B),
+
+    C = [],
+    [] = lists:join(Sep, C),
     ok.
 
 %% Test lists:filter/2, lists:partition/2.


### PR DESCRIPTION
Add a call which works much like string:join/2 but for arbitrary lists. Provide
the function itself, lifted from Haskells Data.List standard library, provide
documentation and provide tests for the function.

## Notes for the PR:

* The addition is fairly simple, and I think it should find its way into Erlang/OTP since there are so many people who write this exact function. I've known to be getting it wrong in the past in certain projects of mine.
* The name `join` is what I ended up with, giving the discussion on erlang-questions@. The reason, I believe, Haskell uses the name `intersperse` has to do with the fact that in Haskell, people tend to avoid adding the module part. So the name must be quite unique, which join isn't. For Erlang, on the other hand, we have the ability to prefix with the module, so a name reuse is logical.
* Why not `string:join/2` ? Because this is really a lists-module functionality which can be used in many places apart from string-like objects.
* The order of the arguments is chosen to be consistent with other `lists:F/N` calls as they are all taking the list they are operating on as the last parameter. It is also consistent with the Haskell implementation of the same call.
* I ran the stdlib tests, and they all pass.
* I did not check the documentation a whole lot, but I wrote it based on another function from the lists module. Hopefully I did not make a mistake here.
