### PR TITLE
TLS distribution: check node names against certificate

### DIFF
--- a/bootstrap/lib/kernel/include/dist_util.hrl
+++ b/bootstrap/lib/kernel/include/dist_util.hrl
@@ -63,6 +63,7 @@
 	  f_getll,               %% Get low level port or pid.
 	  f_address,         %% The address of the "socket", 
 	                     %% generated from Socket,Node
+	  f_name_allowed,    %% Check whether node name is allowed.
 	  %% These three are used in the tick loop,
 	  %% so they are not fun's to avoid holding old code.
 	  mf_tick,           %% Takes the socket as parameters and

--- a/lib/kernel/include/dist_util.hrl
+++ b/lib/kernel/include/dist_util.hrl
@@ -63,6 +63,7 @@
 	  f_getll,               %% Get low level port or pid.
 	  f_address,         %% The address of the "socket", 
 	                     %% generated from Socket,Node
+	  f_name_allowed,    %% Check whether node name is allowed.
 	  %% These three are used in the tick loop,
 	  %% so they are not fun's to avoid holding old code.
 	  mf_tick,           %% Takes the socket as parameters and

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1008,6 +1008,9 @@ fun(srp, Username :: string(), UserState :: term()) ->
         <p>The peer certificate is returned as a DER-encoded binary.
 	  The certificate can be decoded with
 	  <c>public_key:pkix_decode_cert/2</c>.</p>
+
+	<p>If the peer didn't present a certificate, this function
+	  returns <c>{error, no_peercert}</c>.</p>
       </desc>
     </func>
 

--- a/lib/ssl/doc/src/ssl_distribution.xml
+++ b/lib/ssl/doc/src/ssl_distribution.xml
@@ -214,6 +214,14 @@ Eshell V5.0  (abort with ^G)
     <p>The server can also take the options <c>dhfile</c> and
     <c>fail_if_no_peer_cert</c> (also prefixed).</p>
 
+    <p>Additionally, <c>check_nodename_fun</c> can be specified for
+    either client or server.  It takes a value of the form <c>{Module,
+    Function}</c>.  The given function is called with two arguments:
+    the node name of the other node as an atom, and the certificate
+    presented by the other node as a binary.  It should return
+    <c>ok</c> if the node name matches the certificate, or <c>{error,
+    term()}</c> if not.</p>
+
     <p><c>client_</c>-prefixed options are used when the distribution 
     initiates a connection to another node. <c>server_</c>-prefixed 
     options are used when accepting a connection from a remote node.</p>

--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -94,10 +94,10 @@ do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 			   [Node,Version]),
 		    dist_util:reset_timer(Timer),
 		    case ssl_tls_dist_proxy:connect(Driver, Ip, TcpPort) of
-			{ok, Socket, _PeerCert} ->
+			{ok, Socket, PeerCert} ->
 			    HSData = connect_hs_data(Kernel, Node, MyNode, Socket, 
 						     Timer, Version, Ip, TcpPort, Address,
-						     Type),
+						     Type, PeerCert),
 			    dist_util:handshake_we_started(HSData);
 			Other ->
 			    %% Other Node may have closed since 
@@ -125,11 +125,11 @@ close(Socket) ->
 do_accept(Driver, Kernel, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
     process_flag(priority, max),
     receive
-	{AcceptPid, controller, _PeerCert} ->
+	{AcceptPid, controller, PeerCert} ->
 	    Timer = dist_util:start_timer(SetupTime),
 	    case check_ip(Driver, Socket) of
 		true ->
-		    HSData = accept_hs_data(Kernel, MyNode, Socket, Timer, Allowed),
+		    HSData = accept_hs_data(Kernel, MyNode, Socket, Timer, Allowed, PeerCert),
 		    dist_util:handshake_other_started(HSData);
 		{false,IP} ->
 		    error_logger:error_msg("** Connection attempt from "
@@ -220,7 +220,8 @@ split_node([H|T], Chr, Ack) ->
 split_node([], _, Ack) -> 
     [lists:reverse(Ack)].
 
-connect_hs_data(Kernel, Node, MyNode, Socket, Timer, Version, Ip, TcpPort, Address, Type) ->
+connect_hs_data(Kernel, Node, MyNode, Socket, Timer, Version, Ip, TcpPort, Address, Type,
+		PeerCert) ->
     common_hs_data(Kernel, MyNode, Socket, Timer, 
 		   #hs_data{other_node = Node,
 			    other_version = Version,
@@ -231,13 +232,15 @@ connect_hs_data(Kernel, Node, MyNode, Socket, Timer, Version, Ip, TcpPort, Addre
 						     protocol = proxy,
 						     family = inet}
 				end,
+			    f_name_allowed = check_nodename_fun(client, PeerCert),
 			    request_type = Type
 			   }).
 
-accept_hs_data(Kernel, MyNode, Socket, Timer, Allowed) ->
+accept_hs_data(Kernel, MyNode, Socket, Timer, Allowed, PeerCert) ->
     common_hs_data(Kernel, MyNode, Socket, Timer, #hs_data{
 					     allowed = Allowed,
-					     f_address = fun get_remote_id/2
+					     f_address = fun get_remote_id/2,
+					     f_name_allowed = check_nodename_fun(server, PeerCert)
 					    }).
 
 common_hs_data(Kernel, MyNode, Socket, Timer, HsData) ->
@@ -286,4 +289,48 @@ get_remote_id(Socket, _Node) ->
 	    Address;
 	{error, _Reason} ->
 	    ?shutdown(no_node)
+    end.
+
+check_nodename_fun(_ClientOrServer, no_peercert) ->
+    %% The peer didn't present a certificate.  We wouldn't have gotten
+    %% this far if the option fail_if_no_peer_cert were specified, so
+    %% treat this as an expected situation.
+    undefined;
+check_nodename_fun(ClientOrServer, PeerCert) ->
+    case check_nodename_option(ClientOrServer) of
+	undefined ->
+	    undefined;
+	CheckNodenameFun ->
+	    fun(Node) ->
+		    CheckNodenameFun(Node, PeerCert)
+	    end
+    end.
+
+check_nodename_option(Type) when Type =:= client; Type =:= server ->
+    case init:get_argument(ssl_dist_opt) of
+	{ok, Args} ->
+	    ok;
+	_ ->
+	    Args = []
+    end,
+    check_nodename_option(Type, lists:append(Args)).
+
+check_nodename_option(server, ["server_check_nodename_fun", Value | _]) ->
+    convert_check_nodename_option(Value);
+check_nodename_option(client, ["client_check_nodename_fun", Value | _]) ->
+    convert_check_nodename_option(Value);
+check_nodename_option(Type, [_Option, _Value | T]) ->
+    check_nodename_option(Type, T);
+check_nodename_option(_, []) ->
+    %% By default, don't check nodenames.
+    undefined.
+
+convert_check_nodename_option(String) ->
+    {ok, Tokens, _} = erl_scan:string(String ++ "."),
+    {ok, Term} = erl_parse:parse_term(Tokens),
+    case Term of
+	{Mod, Func} when is_atom(Mod), is_atom(Func) ->
+	    fun Mod:Func/2;
+	_ ->
+	    error(malformed_ssl_dist_opt, [String])
     end.

--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -94,7 +94,7 @@ do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 			   [Node,Version]),
 		    dist_util:reset_timer(Timer),
 		    case ssl_tls_dist_proxy:connect(Driver, Ip, TcpPort) of
-			{ok, Socket} ->
+			{ok, Socket, _PeerCert} ->
 			    HSData = connect_hs_data(Kernel, Node, MyNode, Socket, 
 						     Timer, Version, Ip, TcpPort, Address,
 						     Type),
@@ -125,7 +125,7 @@ close(Socket) ->
 do_accept(Driver, Kernel, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
     process_flag(priority, max),
     receive
-	{AcceptPid, controller} ->
+	{AcceptPid, controller, _PeerCert} ->
 	    Timer = dist_util:start_timer(SetupTime),
 	    case check_ip(Driver, Socket) of
 		true ->

--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -430,6 +430,11 @@ ssl_options(server, ["server_dhfile", Value|T]) ->
     [{dhfile, Value} | ssl_options(server,T)];
 ssl_options(server, ["server_fail_if_no_peer_cert", Value|T]) ->
     [{fail_if_no_peer_cert, atomize(Value)} | ssl_options(server,T)];
+%% "*_check_nodename_fun" is used in inet_tls_dist
+ssl_options(server, ["server_check_nodename_fun", _Value|T]) ->
+    ssl_options(server,T);
+ssl_options(client, ["client_check_nodename_fun", _Value|T]) ->
+    ssl_options(client,T);
 ssl_options(Type, Opts) ->
     error(malformed_ssl_dist_opt, [Type, Opts]).
 


### PR DESCRIPTION
It's me again!

This change adds a hook to the TLS distribution options for checking the node name of the remote node against its certificate.

Why a hook? Because I'm not sure there is a single answer to how you want to compare node names to certificates. In particular:
- Do you compare the entire node name, or just the hostname part?
- Do you compare against the Common Name in the certificate? (RFC 6125 suggests that Common Names be used only for backwards compatibility.)
- For Subject Alternative Names, do you check against DNS names? IP addresses? Some custom name type?
- If the certificate contains Subject Alternative Names, but none of them match, do you try matching against the Common Name? (RFC 6125 suggests not doing that.)

With a hook, every application can decide on an appropriate policy.

In the first two commits, I attempt to simplify `ssl_tls_dist_proxy`. It used to use two different mechanisms for incoming and outgoing connections: for incoming connections, it listened on an "ERTS socket", waiting for an internal connection from the process that listens on the "world socket"; for outgoing connections, it would open an ad-hoc listening socket. I kept the latter, since that's the one where it was simpler to pass along the peer's certificate.

For passing the check function along, I couldn't find any other way than adding a new field to the `hs_data` record, which means that distribution protocol modules compiled against earlier versions need to be recompiled. It would be possible to check the names of outbound connections without this, since we know the name of the node we're trying to connect to by the time we do the TLS handshake, but for incoming connections we only get the name at the time of the distribution handshake. Therefore, the name check must be initiated in `dist_util` for incoming connections, and we might as well use the same mechanism in both directions.
