### PR TITLE
matherr() must not fake an FP exception

### DIFF
--- a/erts/emulator/sys/ose/sys_float.c
+++ b/erts/emulator/sys/ose/sys_float.c
@@ -836,10 +836,5 @@ sys_chars_to_double(char* buf, double* fp)
 int
 matherr(struct exception *exc)
 {
-#if !defined(NO_FPE_SIGNALS)
-    volatile unsigned long *fpexnp = erts_get_current_fp_exception();
-    if (fpexnp != NULL)
-	*fpexnp = (unsigned long)__builtin_return_address(0);
-#endif
     return 1;
 }

--- a/erts/emulator/sys/unix/sys_float.c
+++ b/erts/emulator/sys/unix/sys_float.c
@@ -838,11 +838,6 @@ sys_chars_to_double(char* buf, double* fp)
 int
 matherr(struct exception *exc)
 {
-#if !defined(NO_FPE_SIGNALS)
-    volatile unsigned long *fpexnp = erts_get_current_fp_exception();
-    if (fpexnp != NULL)
-	*fpexnp = (unsigned long)__builtin_return_address(0);
-#endif
     return 1;
 }
 

--- a/erts/emulator/sys/win32/sys_float.c
+++ b/erts/emulator/sys/win32/sys_float.c
@@ -139,8 +139,7 @@ sys_double_to_chars_ext(double fp, char *buffer, size_t buffer_size, size_t deci
 int
 matherr(struct _exception *exc)
 {
-    erl_fp_exception = 1;
-    DEBUGF(("FP exception (matherr) (0x%x) (%d)\n", exc->type, erl_fp_exception));
+    DEBUGF(("FP exception (matherr) (0x%x)\n", exc->type));
     return 1;
 }
 


### PR DESCRIPTION
When FP exceptions are used, matherr() forces a fake FP exception,
which is interpreted as an error by the checking code after a math
routine call.  This is wrong for several reasons:

- it's not necessary for error checking: when FP exceptions aren't
  used, matherr() is a stub and no information is derived from it
  being called

- it's not necessary for FPU maintenance: the FPU only needs to be
  reprogrammed after an actual FP exception

- it causes false negatives: matherr() may be called even though
  Erlang doesn't consider the case to be an error (exp() and pow()
  underflows on Solaris for instance); with FP exceptions enabled
  they are incorrectly considered errors

The fix is to remove all FP exception related code from matherr().