### PR TITLE
Fix program paths used in build process

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -62,9 +62,6 @@ if test x"${ERL_TOP}/erts" != x"$srcdir"; then
 fi
 erl_top=${ERL_TOP}
 
-# Remove old configuration information
-/bin/rm -f "$ERL_TOP/erts/CONF_INFO"
-
 # echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # echo X
 # echo "X srcdir  = $srcdir"
@@ -796,6 +793,27 @@ esac
 	
 AC_SUBST(LIBCARBON)
 
+
+_search_path=/bin:/usr/bin:/usr/local/bin:$PATH
+
+AC_PATH_PROG(RM, rm, false, $_search_path)
+if test "$ac_cv_path_RM" = false; then
+  AC_MSG_ERROR([No 'rm' command found])
+fi
+
+AC_PATH_PROG(MKDIR, mkdir, false, $_search_path)
+if test "$ac_cv_path_MKDIR" = false; then
+  AC_MSG_ERROR([No 'mkdir' command found])
+fi
+
+_search_path=
+
+
+# Remove old configuration information.
+# Next line should be placed after AC_PATH_PROG(RM, ...), but before
+# first output to CONN_INFO. So this is just the right place.
+$RM -f "$ERL_TOP/erts/CONF_INFO"
+
 dnl Check if we should/can build a halfword emulator
 
 AC_MSG_CHECKING(if we are building a halfword emulator (32bit heap on 64bit machine))
@@ -845,27 +863,13 @@ if test "$ac_cv_prog_AR" = false; then
   AC_MSG_ERROR([No 'ar' command found in PATH])
 fi
 
-_search_path=/bin:/usr/bin:/usr/local/bin:$PATH
-
-AC_PATH_PROG(RM, rm, false, $_search_path)
-if test "$ac_cv_path_RM" = false; then
-  AC_MSG_ERROR([No 'rm' command found])
-fi
-
-AC_PATH_PROG(MKDIR, mkdir, false, $_search_path)
-if test "$ac_cv_path_MKDIR" = false; then
-  AC_MSG_ERROR([No 'mkdir' command found])
-fi
-
-_search_path=
-
 #
 # Get programs needed for building the documentation 
 #
 
 ## Delete previous failed configure results
 if test -f doc/CONF_INFO; then
-   rm doc/CONF_INFO
+   $RM doc/CONF_INFO
 fi
 
 AC_CHECK_PROGS(XSLTPROC, xsltproc)
@@ -3967,7 +3971,7 @@ if test "$enable_dtrace_test" = "yes" ; then
 		    [$RM -f $DTRACE_2STEP_TEST
 		     dtrace -G $DTRACE_CPP $DTRACE_BITS_FLAG -Iemulator/beam -o $DTRACE_2STEP_TEST -s emulator/beam/erlang_dtrace.d conftest.$OBJEXT 2>&AS_MESSAGE_LOG_FD
                      if test -f $DTRACE_2STEP_TEST; then
-			rm $DTRACE_2STEP_TEST
+			$RM $DTRACE_2STEP_TEST
                         DTRACE_ENABLED_2STEP=yes
 		     fi],
                     [])
@@ -4143,7 +4147,7 @@ ssl_done=yes # Default only one run
 
 # Remove all SKIP files from previous runs
 for a in ssl crypto ssh; do
-  /bin/rm -f $ERL_TOP/lib/$a/SKIP
+  $RM -f $ERL_TOP/lib/$a/SKIP
 done
 
 SSL_DYNAMIC_ONLY=$enable_dynamic_ssl
@@ -4740,7 +4744,7 @@ need_java="jinterface ic/java_src"
 
 # Remove all SKIP files from previous runs
 for a in $need_java ; do
-  /bin/rm -f $ERL_TOP/lib/$a/SKIP
+  $RM -f $ERL_TOP/lib/$a/SKIP
 done
 
 if test "X$with_javac" = "Xno"; then
@@ -4791,7 +4795,7 @@ dnl this deliberately does not believe that 'gcc' is a C++ compiler
 AC_CHECK_TOOLS(CXX, [$CCC c++ g++ CC cxx cc++ cl], false)
 
 # Remove SKIP file from previous run
-/bin/rm -f $ERL_TOP/lib/orber/SKIP
+$RM -f $ERL_TOP/lib/orber/SKIP
 
 if test "$CXX" = false; then
   echo "No C++ compiler found" > $ERL_TOP/lib/orber/SKIP

--- a/lib/odbc/configure.in
+++ b/lib/odbc/configure.in
@@ -73,6 +73,16 @@ AC_CHECK_TOOL(LD, ld, '$(CC)')
 
 AC_SUBST(LD)
 
+_search_path=/bin:/usr/bin:/usr/local/bin:$PATH
+
+AC_PATH_PROG(RM, rm, false, $_search_path)
+if test "$ac_cv_path_RM" = false; then
+  AC_MSG_ERROR([No 'rm' command found])
+fi
+
+_search_path=
+
+
 # Sockets
 #--------------------------------------------------------------------
 #	Check for the existence of the -lsocket and -lnsl libraries.
@@ -128,7 +138,7 @@ dnl Checks for library functions.
 AC_CHECK_FUNCS([memset socket])
 	
 # ODBC 
-/bin/rm -f "$ERL_TOP/lib/odbc/SKIP"
+$RM -f "$ERL_TOP/lib/odbc/SKIP"
 
 LM_CHECK_THR_LIB
 AC_SUBST(THR_DEFS)

--- a/otp_build
+++ b/otp_build
@@ -139,7 +139,7 @@ check_erltop ()
 	if [ "X$ERL_TOP" = "X" ]; then
 		if [ -f ./otp_build -a -f ./erts/autoconf/config.guess ]; then
 		    ERLTOP_FORCED=true
-		    ERL_TOP=`/bin/pwd`
+		    ERL_TOP=`pwd`
 		    export ERL_TOP
 		else
 		    echo "The environment variable ERL_TOP must be set." >&2
@@ -679,7 +679,7 @@ echo_env_erltop ()
     if [ X"$ERL_TOP" = X"" -o "$ERLTOP_FORCED" = "true" ]; then
 	if [ -f ./otp_build ]; then
 	    # Seems to be current directory...
-	    echo_setenv ERL_TOP `/bin/pwd` ';'
+	    echo_setenv ERL_TOP `pwd` ';'
 	else
 	    echo "You need to either set ERL_TOP first or stand in the same" \ 
 		"directory as this script resides in." >&2


### PR DESCRIPTION
Not every OS has '/bin/rm' or '/bin/pwd' at exactly that location (e.g. NixOS).

In some places in configure scripts result of AC_PATH_PROG was already
correctly used, this patch makes this usage more consistent. But some configure parts had to be moved around.

As for `/bin/pwd` in `otp_build`, shell built-in one is already used in
mingw parts - so it should cause no harm to use it everywhere.
Difference is only in symlinks resolution - non-builtin `pwd` always
returns absolute path, and builtin-one could take into account what
sequence of user actions lead to current value of $PWD (so it could preserver some symlinks).

