### PR TITLE
eunit: Add ?debugValAll macro

### DIFF
--- a/lib/eunit/doc/overview.edoc
+++ b/lib/eunit/doc/overview.edoc
@@ -693,6 +693,8 @@ it like `debugMsg'. The result is always `ok'.</dd>
 shown truncated.) The result is always the value of `Expr', so this
 macro can be wrapped around any expression to display its value when
 the code is compiled with debugging enabled.</dd>
+<dt>`debugValAll(Expr)'</dt>
+<dd>This is almost same as `debugVal(Expr)`, but doesn't truncate terms to print.</dd>
 <dt>`debugTime(Text,Expr)'</dt>
 <dd>Prints `Text' and the wall clock time for evaluation of `Expr'. The
 result is always the value of `Expr', so this macro can be wrapped

--- a/lib/eunit/include/eunit.hrl
+++ b/lib/eunit/include/eunit.hrl
@@ -212,6 +212,7 @@
 -define(debugHere, ok).
 -define(debugFmt(S, As), ok).
 -define(debugVal(E), (E)).
+-define(debugValAll(E), (E)).
 -define(debugTime(S, E), (E)).
 -else.
 -define(debugMsg(S),
@@ -226,6 +227,13 @@
 	begin
 	((fun (__V) ->
 		  ?debugFmt(<<"~ts = ~tP">>, [(??E), __V, 15]),
+		  __V
+	  end)(E))
+	end).
+-define(debugValAll(E),
+	begin
+	((fun (__V) ->
+		  ?debugFmt(<<"~ts = ~tp">>, [(??E), __V]),
 		  __V
 	  end)(E))
 	end).


### PR DESCRIPTION
Add a macro which works much like ?debugVal, but doesn't truncate terms to
print.

