### PR TITLE
Don't kill old erlang if HEART_NO_KILL is set

### DIFF
--- a/erts/etc/common/heart.c
+++ b/erts/etc/common/heart.c
@@ -119,6 +119,8 @@
 #define HEART_COMMAND_ENV          "HEART_COMMAND"
 #define ERL_CRASH_DUMP_SECONDS_ENV "ERL_CRASH_DUMP_SECONDS"
 #define HEART_KILL_SIGNAL          "HEART_KILL_SIGNAL"
+#define HEART_NO_KILL              "HEART_NO_KILL"
+
 
 #define MSG_HDR_SIZE         (2)
 #define MSG_HDR_PLUS_OP_SIZE (3)
@@ -524,6 +526,10 @@ static void
 kill_old_erlang(void){
     HANDLE erlh;
     DWORD exit_code;
+
+    if (is_env_set(HEART_NO_KILL))
+      return;
+
     if(heart_beat_kill_pid != 0){
 	if((erlh = OpenProcess(PROCESS_TERMINATE | 
 			       SYNCHRONIZE | 
@@ -556,6 +562,9 @@ kill_old_erlang(void){
     int i, res;
     int sig = SIGKILL;
     char *sigenv = NULL;
+
+    if (is_env_set(HEART_NO_KILL))
+      return;
 
     sigenv = get_env(HEART_KILL_SIGNAL);
     if (sigenv && strcmp(sigenv, "SIGABRT") == 0) {

--- a/lib/kernel/doc/src/heart.xml
+++ b/lib/kernel/doc/src/heart.xml
@@ -89,6 +89,16 @@
     <pre>
 % <input>erl -heart -env HEART_KILL_SIGNAL SIGABRT ...</input></pre>
 
+  <p> If heart should <b>not</b> kill the Erlang runtime system, this can be indicated
+      using the environment variable <c><![CDATA[HEART_NO_KILL]]></c>. 
+      This can be useful if the command executed by heart takes care of this,
+      for example as part of a specific cleanup sequence. 
+      If unset, the default behaviour will be to kill as described above.
+  </p>
+
+    <pre>
+% <input>erl -heart -env HEART_NO_KILL 1 ...</input></pre>
+
   <p>
 	  Furthermore, <c><![CDATA[ERL_CRASH_DUMP_SECONDS]]></c> has the following behaviour on
 	  <c>heart</c>:

--- a/lib/kernel/test/heart_SUITE.erl
+++ b/lib/kernel/test/heart_SUITE.erl
@@ -29,11 +29,11 @@
 	 set_cmd/1, clear_cmd/1, get_cmd/1,
 	 callback_api/1,
          options_api/1,
-	 dont_drop/1, kill_pid/1]).
+	 dont_drop/1, kill_pid/1, heart_no_kill/1]).
 
 -export([init_per_testcase/2, end_per_testcase/2]).
 
--export([start_heart_stress/1, mangle/1, suicide_by_heart/0]).
+-export([start_heart_stress/1, mangle/1, suicide_by_heart/0, non_suicide_by_heart/0]).
 
 -define(DEFAULT_TIMEOUT_SECS, 120).
 
@@ -507,6 +507,30 @@ do_kill_pid(_Config) ->
 	    false
     end.
 
+
+heart_no_kill(suite) ->
+    [];
+heart_no_kill(doc) ->
+    ["Tests that heart doesn't kill the old erlang node when ",
+     "HEART_NO_KILL is set."];
+heart_no_kill(Config) when is_list(Config) ->
+    ok = do_no_kill(Config).
+
+do_no_kill(_Config) ->
+    Name = heart_test,
+    {ok,Node} = start_node_run(Name,[],non_suicide_by_heart,[]),
+    io:format("Node is ~p~n", [Node]),
+    ok = wait_for_node(Node,15),
+    io:format("wait_for_node is ~p~n", [ok]),
+    erlang:monitor_node(Node, true),
+    receive {nodedown,Node} -> false
+    after 30000 ->
+	    io:format("Node didn't die..\n"),
+	    rpc:call(Node,init,stop,[]),
+	    io:format("done init:stop..\n"),
+	    ok
+    end.
+
 wait_for_node(_,0) ->
     false;
 wait_for_node(Node,N) ->
@@ -623,6 +647,18 @@ suicide_by_heart() ->
     receive
 	{makaronipudding} ->
 	    sallad
+    end.
+
+non_suicide_by_heart() ->
+    P = open_port({spawn,"heart -ht 11 -pid "++os:getpid()},[exit_status, {env, {"HEART_NO_KILL", "1"}}, {packet,2}]),
+    receive X -> X end,
+    %% Just hang and wait for heart to timeout
+    receive
+	{P,{exit_status,_}} ->
+	    ok
+    after
+	20000 ->
+	    exit(timeout)
     end.
 
 


### PR DESCRIPTION
Use the environment variable HEART_NO_KILL to control if heart kills the old erlang process.

This can be useful if the command executed by heart takes care of this, for example as part of a specific cleanup sequence.