### PR TITLE
Error reasons for more distribution errors

### DIFF
--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -156,7 +156,7 @@ is_allowed(#hs_data{other_node = Node,
 	    send_status(HSData, not_allowed),
 	    error_msg("** Connection attempt from "
 		      "disallowed node ~w ** ~n", [Node]),
-	    ?shutdown(Node);
+	    ?shutdown2(Node, {is_allowed, not_allowed});
 	_ -> true
     end.
 
@@ -607,10 +607,10 @@ recv_challenge_reply(#hs_data{socket = Socket,
 		_ ->
 		    error_msg("** Connection attempt from "
 			      "disallowed node ~w ** ~n", [NodeB]),
-		    ?shutdown(NodeB)
+		    ?shutdown2(NodeB, {recv_challenge_reply_failed, bad_cookie})
 	    end;
-	_ ->
-	    ?shutdown(no_node)
+	Other ->
+	    ?shutdown2(no_node, {recv_challenge_reply_failed, Other})
     end.
 
 recv_challenge_ack(#hs_data{socket = Socket, f_recv = FRecv, 


### PR DESCRIPTION
Add descriptive shutdown reasons when an incoming distribution
connection is rejected because it is not on the "allowed" list or
because it has an incorrect cookie.  These error reasons can be seen
after calling `net_kernel:verbose(1)`.

Distinguishing these failures is valuable, because the log message
printed is otherwise identical.

This is in addition to the error reasons introduced in #980.