### PR TITLE
Fix type spec for cpu_sup:util/1

### DIFF
--- a/lib/os_mon/src/cpu_sup.erl
+++ b/lib/os_mon/src/cpu_sup.erl
@@ -68,7 +68,7 @@
 
 -type util_cpus() :: 'all' | integer() | [integer()].
 -type util_state() :: 'user' | 'nice_user' | 'kernel' | 'wait' | 'idle'.
--type util_value() :: {util_state(), float()} | float().
+-type util_value() :: [{util_state(), float()}] | float().
 -type util_desc() :: {util_cpus(), util_value(), util_value(), []}.
 
 %%----------------------------------------------------------------------


### PR DESCRIPTION
The documentation correctly states that the Busy and NonBusy components
in the return value of cpu_sup:util/1 are not tuples but list of tuples:
"If the detailed option is given, this is a *list* of {State, Share}
tuples"