### PR TITLE
Don't use non-POSIX compliant fdatasync on OS X

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1970,7 +1970,15 @@ AC_C_BIGENDIAN
 AC_C_DOUBLE_MIDDLE_ENDIAN
 
 dnl fdatasync syscall (Unix only)
-AC_CHECK_FUNCS([fdatasync])
+case $host_os in
+    darwin*)
+	ac_cv_func_fdatasync=no # Mac OS X wrongly reports it has fdatasync()
+	;;
+
+    *)
+	AC_CHECK_FUNCS([fdatasync])
+	;;
+esac
 
 dnl Find which C libraries are required to use fdatasync
 dnl TODO: Remove check once SunOS >= 5.11 is required by erts.


### PR DESCRIPTION
On OS X fdatasync is an undocumented private system call, not the POSIX function of the same name. Observing with dtrace suggests it even takes 3 parameters. Casual googling shows a lot of similar observations/complaints.
Since AC_CHECK_FUNCS([fdatasync]) succeeds, check explicitly for OS X in erts/configure