### PR TITLE
Simplify ssl:cipher_suites/1

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -405,19 +405,17 @@ negotiated_next_protocol(Socket) ->
 %% Description: Returns all supported cipher suites.
 %%--------------------------------------------------------------------
 cipher_suites(erlang) ->
-    Version = tls_record:highest_protocol_version([]),
-    ssl_cipher:filter_suites([ssl_cipher:erl_suite_definition(S)
-                              || S <- ssl_cipher:suites(Version)]);
+    [ssl_cipher:erl_suite_definition(S) || S <- filtered(suites)];
 cipher_suites(openssl) ->
-    Version = tls_record:highest_protocol_version([]),
-    [ssl_cipher:openssl_suite_name(S)
-     || S <- ssl_cipher:filter_suites(ssl_cipher:suites(Version))];
+    [ssl_cipher:openssl_suite_name(S) || S <- filtered(suites)];
 cipher_suites(all) ->
-    Version = tls_record:highest_protocol_version([]),
-    ssl_cipher:filter_suites([ssl_cipher:erl_suite_definition(S)
-			      || S <-ssl_cipher:all_suites(Version)]).
+    [ssl_cipher:erl_suite_definition(S) || S <- filtered(all_suites)].
 cipher_suites() ->
     cipher_suites(erlang).
+
+filtered(Function) ->
+    Version = tls_record:highest_protocol_version([]),
+    ssl_cipher:filter_suites(ssl_cipher:Function(Version)).
 
 %%--------------------------------------------------------------------
 -spec getopts(#sslsocket{}, [gen_tcp:option_name()]) ->


### PR DESCRIPTION
This PR factors most of the current redundant code into a helper
filtered/1 function, and makes it clearer by inspection that the
`erlang` and `openssl` options actually return the same list of ciphers
with different representations.

As an added benefit, this code no longer relies on the
ssl_cipher:filter_suites/1 function which matches a list of tuples, and
instead only uses the internal binary suite representation.