### PR TITLE
Fix HiPE LLVM backend in R19

### DIFF
--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -925,7 +925,6 @@ struct process {
     Eterm* stop;		/* Stack top */
     Eterm* heap;		/* Heap start */
     Eterm* hend;		/* Heap end */
-    Eterm* abandoned_heap;
     Uint heap_sz;		/* Size of heap in words */
     Uint min_heap_size;         /* Minimum size of heap (in words). */
     Uint min_vheap_size;        /* Minimum size of virtual heap (in words). */
@@ -939,6 +938,16 @@ struct process {
        to enable smaller & faster addressing modes on the x86. */
     struct hipe_process_state hipe;
 #endif
+
+    /*
+     * Moved to after "struct hipe_process_state hipe", as a temporary fix for
+     * LLVM hard-coding offsetof(struct process, hipe.nstack) (sic!)
+     * (see void X86FrameLowering::adjustForHiPEPrologue(...) in
+     * lib/Target/X86/X86FrameLowering.cpp).
+     *
+     * Used to be below "Eterm* hend".
+     */
+    Eterm* abandoned_heap;
 
     /*
      * Saved x registers.


### PR DESCRIPTION
It was recently observed that the LLVM backend for HiPE was broken,
generating code that crashes the VM.

It turns out that this was caused by LLVM hard-coding an offset into the
Erlang PCB, which became incorrect as of commit 3ac08f9b, that
introduced a new member into the PCB before the HiPE-specific state,
changing its offsets.

For now, until a proper fix is implemented, we move this new member to
after the HiPE-specific state, allowing the LLVM backend to work once
more.

This is the most reasonable first step towards fixing this
problem, as older LLVM versions tend to stick around because of
API breaks in major releases. Thus, a fix to LLVM only would take some
time to propagate to all affected users.