### PR TITLE
Fix memsup:get_os_wordsize() on 64-bit FreeBSD

### DIFF
--- a/lib/os_mon/src/memsup.erl
+++ b/lib/os_mon/src/memsup.erl
@@ -699,6 +699,7 @@ get_os_wordsize_with_uname() ->
     case String of
 	"x86_64"  -> 64;
 	"sparc64" -> 64;
+	"amd64"   -> 64;
 	_         -> 32
     end.
 


### PR DESCRIPTION
The output of `uname -m` on 64-bit FreeBSD is 'amd64' (not 'x86_64').
memsup:get_os_wordsize() always returns 32
