### PR TITLE
ssl: Add BEAST mitigation selection option

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -417,10 +417,24 @@ fun(srp, Username :: string(), UserState :: term()) ->
       If set to <c>false</c>, it disables the block cipher padding check
       to be able to interoperate with legacy software.</p></item>
 
-    </taglist>
-
         <warning><p>Using <c>{padding_check, boolean()}</c> makes TLS
 	vulnerable to the Poodle attack.</p></warning>
+
+      <tag><c>{beast_mitigation, one_n_minus_one | zero_n | disabled}</c></tag>
+      <item><p>Affects SSL-3.0 and TLS-1.0 connections only. Used to change the BEAST
+       mitigation strategy to interoperate with legacy software.
+       Defaults to <c>one_n_minus_one</c></p>.
+
+      <p><c>one_n_minus_one</c> - Perform 1/n-1 BEAST mitigation.</p>
+
+      <p><c>zero_n</c> - Perform 0/n BEAST mitigation.</p>
+
+      <p><c>disabled</c> - Disable BEAST mitigation.</p></item>
+
+        <warning><p>Using <c>{beast_mitigation, disabled}</c> makes SSL or TLS
+        vulnerable to the BEAST attack.</p></warning>
+    </taglist>
+
   </section>
   
   <section>

--- a/lib/ssl/src/dtls_connection.erl
+++ b/lib/ssl/src/dtls_connection.erl
@@ -416,7 +416,8 @@ encode_change_cipher(#change_cipher_spec{}, Version, ConnectionStates) ->
 
 initial_state(Role, Host, Port, Socket, {SSLOptions, SocketOptions}, User,
 	      {CbModule, DataTag, CloseTag, ErrorTag}) ->
-    ConnectionStates = ssl_record:init_connection_states(Role),
+    #ssl_options{beast_mitigation = BeastMitigation} = SSLOptions,
+    ConnectionStates = ssl_record:init_connection_states(Role, BeastMitigation),
     
     SessionCacheCb = case application:get_env(ssl, session_cb) of
 			 {ok, Cb} when is_atom(Cb) ->

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -725,6 +725,7 @@ handle_options(Opts0, Role) ->
 						       server, Role),
 		    protocol = proplists:get_value(protocol, Opts, tls),
 		    padding_check =  proplists:get_value(padding_check, Opts, true),
+		    beast_mitigation = handle_option(beast_mitigation, Opts, one_n_minus_one),
 		    fallback = handle_option(fallback, Opts,
 					     proplists:get_value(fallback, Opts,    
 								 default_option_role(client, 
@@ -746,7 +747,7 @@ handle_options(Opts0, Role) ->
 		  alpn_preferred_protocols, next_protocols_advertised,
 		  client_preferred_next_protocols, log_alert,
 		  server_name_indication, honor_cipher_order, padding_check, crl_check, crl_cache,
-		  fallback, signature_algs],
+		  fallback, signature_algs, beast_mitigation],
 
     SockOpts = lists:foldl(fun(Key, PropList) ->
 				   proplists:delete(Key, PropList)
@@ -986,6 +987,10 @@ validate_option(crl_check, Value) when (Value == best_effort) or (Value == peer)
     Value;
 validate_option(crl_cache, {Cb, {_Handle, Options}} = Value) when is_atom(Cb) and is_list(Options) ->
     Value;
+validate_option(beast_mitigation, Value) when Value == one_n_minus_one orelse
+                                              Value == zero_n orelse
+                                              Value == disabled ->
+  Value;
 validate_option(Opt, Value) ->
     throw({error, {options, {Opt, Value}}}).
 

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -133,6 +133,9 @@
 	  %% the client?
 	  honor_cipher_order = false :: boolean(),
 	  padding_check = true       :: boolean(),
+	  %%Should we use 1/n-1 or 0/n splitting to mitigate BEAST, or disable
+	  %%mitigation entirely?
+	  beast_mitigation = one_n_minus_one :: one_n_minus_one | zero_n | disabled,
 	  fallback = false           :: boolean(),
 	  crl_check                  :: boolean() | peer | best_effort, 
 	  crl_cache,

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -30,7 +30,7 @@
 -include("ssl_alert.hrl").
 
 %% Connection state handling
--export([init_connection_states/1,
+-export([init_connection_states/2,
 	 current_connection_state/2, pending_connection_state/2,
 	 activate_pending_connection_state/2,
 	 set_security_params/3,
@@ -62,15 +62,16 @@
 %%====================================================================
 
 %%--------------------------------------------------------------------
--spec init_connection_states(client | server) -> #connection_states{}.
+-spec init_connection_states(client | server, one_n_minus_one | zero_n | disabled ) ->
+				      #connection_states{}.
 %%
 %% Description: Creates a connection_states record with appropriate
 %% values for the initial SSL connection setup.
 %%--------------------------------------------------------------------
-init_connection_states(Role) ->
+init_connection_states(Role, BeastMitigation) ->
     ConnectionEnd = record_protocol_role(Role),
-    Current = initial_connection_state(ConnectionEnd),
-    Pending = empty_connection_state(ConnectionEnd),
+    Current = initial_connection_state(ConnectionEnd, BeastMitigation),
+    Pending = empty_connection_state(ConnectionEnd, BeastMitigation),
     #connection_states{current_read = Current,
 		       pending_read = Pending,
 		       current_write = Current,
@@ -119,9 +120,10 @@ activate_pending_connection_state(States =
                                   read) ->
     NewCurrent = Pending#connection_state{epoch = dtls_next_epoch(Current),
 					  sequence_number = 0},
+    BeastMitigation = Pending#connection_state.beast_mitigation,
     SecParams = Pending#connection_state.security_parameters,
     ConnectionEnd = SecParams#security_parameters.connection_end,
-    EmptyPending = empty_connection_state(ConnectionEnd),
+    EmptyPending = empty_connection_state(ConnectionEnd, BeastMitigation),
     SecureRenegotation = NewCurrent#connection_state.secure_renegotiation,
     NewPending = EmptyPending#connection_state{secure_renegotiation = SecureRenegotation},
     States#connection_states{current_read = NewCurrent,
@@ -134,9 +136,10 @@ activate_pending_connection_state(States =
                                   write) ->
     NewCurrent = Pending#connection_state{epoch = dtls_next_epoch(Current),
 					  sequence_number = 0},
+    BeastMitigation = Pending#connection_state.beast_mitigation,
     SecParams = Pending#connection_state.security_parameters,
     ConnectionEnd = SecParams#security_parameters.connection_end,
-    EmptyPending = empty_connection_state(ConnectionEnd),
+    EmptyPending = empty_connection_state(ConnectionEnd, BeastMitigation),
     SecureRenegotation = NewCurrent#connection_state.secure_renegotiation,
     NewPending = EmptyPending#connection_state{secure_renegotiation = SecureRenegotation},
     States#connection_states{current_write = NewCurrent,
@@ -314,12 +317,13 @@ set_pending_cipher_state(#connection_states{pending_read = Read,
 encode_handshake(Frag, Version, 
 		 #connection_states{current_write = 
 					#connection_state{
+					   beast_mitigation = BeastMitigation,
 					   security_parameters =
 					       #security_parameters{bulk_cipher_algorithm = BCA}}} = 
 		     ConnectionStates) ->
     case iolist_size(Frag) of
 	N  when N > ?MAX_PLAIN_TEXT_LENGTH ->
-	    Data = split_bin(iolist_to_binary(Frag), ?MAX_PLAIN_TEXT_LENGTH, Version, BCA),
+	    Data = split_bin(iolist_to_binary(Frag), ?MAX_PLAIN_TEXT_LENGTH, Version, BCA, BeastMitigation),
 	    encode_iolist(?HANDSHAKE, Data, Version, ConnectionStates);
 	_  ->
 	    encode_plain_text(?HANDSHAKE, Version, Frag, ConnectionStates)
@@ -352,10 +356,11 @@ encode_change_cipher_spec(Version, ConnectionStates) ->
 %%--------------------------------------------------------------------
 encode_data(Frag, Version,
 	    #connection_states{current_write = #connection_state{
+				 beast_mitigation = BeastMitigation,
 				 security_parameters =
 				     #security_parameters{bulk_cipher_algorithm = BCA}}} =
 		ConnectionStates) ->
-    Data = split_bin(Frag, ?MAX_PLAIN_TEXT_LENGTH, Version, BCA),
+    Data = split_bin(Frag, ?MAX_PLAIN_TEXT_LENGTH, Version, BCA, BeastMitigation),
     encode_iolist(?APPLICATION_DATA, Data, Version, ConnectionStates).
 
 uncompress(?NULL, Data, CS) ->
@@ -447,9 +452,10 @@ decipher_aead(Version, CipherFragment,
 %%--------------------------------------------------------------------
 %%% Internal functions
 %%--------------------------------------------------------------------
-empty_connection_state(ConnectionEnd) ->
+empty_connection_state(ConnectionEnd, BeastMitigation) ->
     SecParams = empty_security_params(ConnectionEnd),
-    #connection_state{security_parameters = SecParams}.
+    #connection_state{security_parameters = SecParams,
+                      beast_mitigation = BeastMitigation}.
 
 empty_security_params(ConnectionEnd = ?CLIENT) ->
     #security_parameters{connection_end = ConnectionEnd,
@@ -478,10 +484,11 @@ record_protocol_role(client) ->
 record_protocol_role(server) ->
     ?SERVER.
 
-initial_connection_state(ConnectionEnd) ->
+initial_connection_state(ConnectionEnd, BeastMitigation) ->
     #connection_state{security_parameters =
 			  initial_security_params(ConnectionEnd),
-                      sequence_number = 0
+                      sequence_number = 0,
+                      beast_mitigation = BeastMitigation
                      }.
 
 initial_security_params(ConnectionEnd) ->
@@ -506,11 +513,17 @@ encode_iolist(Type, Data, Version, ConnectionStates0) ->
 
 %% 1/n-1 splitting countermeasure Rizzo/Duong-Beast, RC4 chiphers are
 %% not vulnerable to this attack.
-split_bin(<<FirstByte:8, Rest/binary>>, ChunkSize, Version, BCA) when
+split_bin(<<FirstByte:8, Rest/binary>>, ChunkSize, Version, BCA, one_n_minus_one) when
       BCA =/= ?RC4 andalso ({3, 1} == Version orelse
 			    {3, 0} == Version) ->
     do_split_bin(Rest, ChunkSize, [[FirstByte]]);
-split_bin(Bin, ChunkSize, _, _) ->
+%% 0/n splitting countermeasure for clients that are incompatible with 1/n-1
+%% splitting.
+split_bin(Bin, ChunkSize, Version, BCA, zero_n) when
+      BCA =/= ?RC4 andalso ({3, 1} == Version orelse
+			    {3, 0} == Version) ->
+    do_split_bin(Bin, ChunkSize, [[<<>>]]);
+split_bin(Bin, ChunkSize, _, _, _) ->
     do_split_bin(Bin, ChunkSize, []).
 
 do_split_bin(<<>>, _, Acc) ->

--- a/lib/ssl/src/ssl_record.hrl
+++ b/lib/ssl/src/ssl_record.hrl
@@ -40,7 +40,9 @@
 	  %% RFC 5746
 	  secure_renegotiation,
 	  client_verify_data,
-	  server_verify_data
+	  server_verify_data,
+	  %% How to do BEAST mitigation?
+	  beast_mitigation
 	 }).
 
 -record(connection_states, {

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -496,7 +496,8 @@ decode_alerts(Bin) ->
 
 initial_state(Role, Host, Port, Socket, {SSLOptions, SocketOptions, Tracker}, User,
 	      {CbModule, DataTag, CloseTag, ErrorTag}) ->
-    ConnectionStates = ssl_record:init_connection_states(Role),
+    #ssl_options{beast_mitigation = BeastMitigation} = SSLOptions,
+    ConnectionStates = ssl_record:init_connection_states(Role, BeastMitigation),
     
     SessionCacheCb = case application:get_env(ssl, session_cb) of
 			 {ok, Cb} when is_atom(Cb) ->


### PR DESCRIPTION
This PR adds a new ssloption that allows one to select the content splitting method (1/n-1 or 0/n) used by SSLv3 and TLSv1.0 connections or disable content splitting entirely.

Documentation updates and tests are included in the patch.