### PR TITLE
Ignore tcp errors during close request to eldap.

### DIFF
--- a/lib/eldap/src/eldap.erl
+++ b/lib/eldap/src/eldap.erl
@@ -564,7 +564,12 @@ loop(Cpid, Data) ->
             ?MODULE:loop(Cpid, NewData);
 
 	{_From, close} ->
-	    {no_reply,_NewData} = do_unbind(Data),
+        % Ignore tcp error if connection is already closed.
+        try do_unbind(Data) of
+            {no_reply,_NewData} -> ok
+        catch
+            throw:{gen_tcp_error, _TcpErr} -> ok
+        end,
 	    unlink(Cpid),
 	    exit(closed);
 


### PR DESCRIPTION
If underlying tcp connection is closed and LDAP operation returned tcp error, client applications tend to close ldap handle with `eldap:close`.
This will cause do_unbind to throw `gen_tcp_error`, which is not handled and will be sent to linked process as `{nocatch, {gen_tcp_error, ...}}`.
`gen_tcp_error` should be ignored during close, because socket will be closing anyway.

Discovered in RabbitMQ ldap authorisation backend
https://github.com/rabbitmq/rabbitmq-auth-backend-ldap/issues/30