### PR TITLE
Fix compilation on SUN/SPARC by including <stdlib.h>

### DIFF
--- a/lib/os_mon/c_src/ferrule.c
+++ b/lib/os_mon/c_src/ferrule.c
@@ -18,6 +18,7 @@
  * %CopyrightEnd%
  */
 #include 	<stdio.h>
+#include 	<stdlib.h>
 #include 	<string.h>
 #include 	<stropts.h>
 #include 	<poll.h>

--- a/lib/os_mon/c_src/mod_syslog.c
+++ b/lib/os_mon/c_src/mod_syslog.c
@@ -18,6 +18,7 @@
  * %CopyrightEnd%
  */
 #include 	<stdio.h>
+#include 	<stdlib.h>
 #include 	<string.h>
 #include 	<unistd.h>
 #include 	<sys/types.h>


### PR DESCRIPTION
The combination of the use of the exit() function without including
stdlib.h,  together with the option -Werror=implicit-function-declaration
causes the compilation (and the 'make') to fail on SUN/SPARC with gcc 4.9.3.