### PR TITLE
Fix deprecated warnings

### DIFF
--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -35,7 +35,7 @@
 obsolete(Module, Name, Arity) ->
     case obsolete_1(Module, Name, Arity) of
 	{deprecated=Tag,{_,_,_}=Replacement} ->
-	    {Tag,Replacement,"in a future release"};
+	    {Tag,Replacement,"a future release"};
 	{_,String}=Ret when is_list(String) ->
 	    Ret;
 	{_,_,_}=Ret ->

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -2003,7 +2003,7 @@ otp_5362(Config) when is_list(Config) ->
            {error,
             [{5,erl_lint,{call_to_redefined_old_bif,{spawn,1}}}],
 	    [{4,erl_lint,{deprecated,{erlang,hash,2},{erlang,phash2,2},
-			  "in a future release"}}]}},
+			  "a future release"}}]}},
 
           {otp_5362_5,
            <<"-compile(nowarn_deprecated_function).
@@ -2063,7 +2063,7 @@ otp_5362(Config) when is_list(Config) ->
              {nowarn_bif_clash,{spawn,1}}]}, % has no effect
            {warnings,
             [{5,erl_lint,{deprecated,{erlang,hash,2},{erlang,phash2,2},
-			  "in a future release"}}]}},
+			  "a future release"}}]}},
 
           {otp_5362_9,
            <<"-include_lib(\"stdlib/include/qlc.hrl\").
@@ -2093,7 +2093,7 @@ otp_5362(Config) when is_list(Config) ->
 	   [],
 	   {warnings,
             [{1,erl_lint,{deprecated,{erlang,hash,2},
-			  {erlang,phash2,2},"in a future release"}}]}},
+			  {erlang,phash2,2},"a future release"}}]}},
 
 	  {call_removed_function,
 	   <<"t(X) -> regexp:match(X).">>,


### PR DESCRIPTION
In current deprecated warnings such as `crypto:rand_bytes/1 is deprecated and will be
removed in in a future release; use crypto:strong_rand_bytes/1`, the word "in" is duplicated.