### PR TITLE
Fix request line path for proxied httpc requests

### DIFF
--- a/lib/inets/src/http_client/httpc_request.erl
+++ b/lib/inets/src/http_client/httpc_request.erl
@@ -83,14 +83,15 @@ send(SendAddr, Socket, SocketType,
     TmpHdrs = handle_user_info(UserInfo, Headers),
 
     {TmpHdrs2, Body} = post_data(Method, TmpHdrs, Content, HeadersAsIs),
+
+    Uri = Path ++ Query,
     
-    {NewHeaders, Uri} = 
+    NewHeaders =
 	case Address of
 	    SendAddr ->
-		{TmpHdrs2, Path ++ Query};
+		TmpHdrs2;
 	    _Proxy ->
-		TmpHdrs3 = handle_proxy(HttpOptions, TmpHdrs2), 
-		{TmpHdrs3, AbsUri}
+		handle_proxy(HttpOptions, TmpHdrs2)
 	end,
     
     FinalHeaders = 


### PR DESCRIPTION
This fixes an issue we've been seeing on the Hex client when using proxies with httpc. https://github.com/hexpm/hex/issues/227

It doesn't fail for every request or against every host or proxy software but some requests return with a 404 response. The issue boils down to `httpc` using the absolute URI in the request line instead of the relative path. It sends `GET https://repo.hex.pm/tarballs/cowboy-1.0.4.tar` when it should be sending `GET tarballs/cowboy-1.0.4.tar`.

As you can see in the patch; before the change `AbsUri` was assigned to `Uri` instead of `Path ++ Query` when proxying is used, my patch disables this behaviour.

This fixes the issue we are having with Hex but I was not able to run `httpc_proxy_SUITE.erl` on OS X due to it's dependency on Apache and some specific Apache modules. I am also not sure why it only broke on some requests so feedback on this patch would be appreciated.

