### PR TITLE
Inside type specs, line-initial commas align with open curly braces

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -2970,8 +2970,9 @@ Return nil if inside string, t if in a comment."
              (current-column)))
 	  ;; Type and Spec indentation
 	  ((eq (car stack-top) '::)
-	   (if (looking-at "}")
-	       ;; Closing record definition with types
+	   (if (looking-at "[},)]")
+	       ;; Closing function spec, record definition with types,
+               ;; or a comma at the start of the line
 	       ;; pop stack and recurse
 	       (erlang-calculate-stack-indent indent-point
 					      (cons (erlang-pop stack) (cdr state)))

--- a/lib/tools/emacs/test.erl.indented
+++ b/lib/tools/emacs/test.erl.indented
@@ -70,6 +70,9 @@ foo() ->
 	      234,
 	  d}).
 
+-record(record5, { a = 1 :: integer()
+                 , b = foobar :: atom()
+                 }).
 
 -define(MACRO_1, macro).
 -define(MACRO_2(_), macro).
@@ -144,6 +147,12 @@ foo() ->
 -type t25() :: #rec3{f123 :: [t24() | 
 			      1|2|3|4|a|b|c|d| 
 			      nonempty_maybe_improper_list(integer, any())]}. 
+-type t26() :: #rec4{ a :: integer()
+                    , b :: any()
+                    }.
+-type t27() :: { integer()
+               , atom()
+               }.
 -type t99() ::
 	{t2(),t4(),t5(),t6(),t7(),t8(),t10(),t14(),
 	 t15(),t20(),t21(), t22(),t25()}. 
@@ -178,6 +187,10 @@ foo() ->
 			     Return :: pid()
 				     | {'error', {'no_process', term()}
 					| {'no_such_group', term()}}.
+
+-spec add( X :: integer()
+         , Y :: integer()
+         ) -> integer().
 
 -opaque attributes_data() :: 
 	  [{'column', column()} | {'line', info_line()} |

--- a/lib/tools/emacs/test.erl.orig
+++ b/lib/tools/emacs/test.erl.orig
@@ -70,6 +70,9 @@ foo() ->
      234,
  d}).
 
+-record(record5, { a = 1 :: integer()
+, b = foobar :: atom()
+}).
 
 -define(MACRO_1, macro).
 -define(MACRO_2(_), macro).
@@ -144,6 +147,12 @@ nonempty_maybe_improper_list('integer', any())|
 -type t25() :: #rec3{f123 :: [t24() | 
 1|2|3|4|a|b|c|d| 
 nonempty_maybe_improper_list(integer, any())]}. 
+-type t26() :: #rec4{ a :: integer()
+, b :: any()
+}.
+-type t27() :: { integer()
+, atom()
+}.
 -type t99() ::
 {t2(),t4(),t5(),t6(),t7(),t8(),t10(),t14(),
 t15(),t20(),t21(), t22(),t25()}. 
@@ -178,6 +187,10 @@ t15(),t20(),t21(), t22(),t25()}.
        Return :: pid()
  | {'error', {'no_process', term()}
    | {'no_such_group', term()}}.
+
+-spec add( X :: integer()
+, Y :: integer()
+) -> integer().
 
 -opaque attributes_data() :: 
 [{'column', column()} | {'line', info_line()} |


### PR DESCRIPTION
For example:

```erlang
  { a :: integer()
  , b :: integer()
  }
```

This does not affect coding styles that don't put commas at the beginning of lines. Follows up on 104c602.