### PR TITLE
Fix program paths used in build process

### DIFF
--- a/lib/public_key/priv/generate
+++ b/lib/public_key/priv/generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Generate ssh moduli files for the sizes in $moduli
 

--- a/make/make_emakefile
+++ b/make/make_emakefile
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # -*- cperl -*-
 
 use strict;


### PR DESCRIPTION
Followup to https://github.com/erlang/otp/pull/1023

- make/make_emakefile is fixed because otherwise `./otp_build tests`
  fails early.
- And grep showed that there is only one other file that also should be
  fixed - lib/public_key/priv/generate