### PR TITLE
odbc: Eliminate dialyzer unmatched_return warnings

### DIFF
--- a/lib/odbc/src/odbc.erl
+++ b/lib/odbc/src/odbc.erl
@@ -833,7 +833,7 @@ connect(ConnectionReferense, ConnectionStr, Options) ->
 odbc_send(Socket, Msg) -> %% Note currently all allowed messages are lists
     NewMsg = Msg ++ [?STR_TERMINATOR],
     ok = gen_tcp:send(Socket, NewMsg),
-    inet:setopts(Socket, [{active, once}]).
+    ok = inet:setopts(Socket, [{active, once}]).
 
 %%--------------------------------------------------------------------------
 connection_config(Key, Options) ->


### PR DESCRIPTION
The code was calling inet:setopts/2 but did not check that the call
did not result in an error.  Fix this by matching with 'ok'.