### PR TITLE
Replace suggested debugValAll/1 macro with debugVal/2

### DIFF
--- a/lib/eunit/doc/overview.edoc
+++ b/lib/eunit/doc/overview.edoc
@@ -690,11 +690,12 @@ it like `debugMsg'. The result is always `ok'.</dd>
 <dt>`debugVal(Expr)'</dt>
 <dd>Prints both the source code for `Expr' and its current value. E.g.,
 `?debugVal(f(X))' might be displayed as "`f(X) = 42'". (Large terms are
-shown truncated.) The result is always the value of `Expr', so this
-macro can be wrapped around any expression to display its value when
-the code is compiled with debugging enabled.</dd>
-<dt>`debugValAll(Expr)'</dt>
-<dd>This is almost same as `debugVal(Expr)`, but doesn't truncate terms to print.</dd>
+truncated to the depth given by the macro `EUNIT_DEBUG_VAL_DEPTH', which
+defaults to 15 but can be overridden by the user.) The result is always the
+value of `Expr', so this macro can be wrapped around any expression to
+display its value when the code is compiled with debugging enabled.</dd>
+<dt>`debugVal(Expr, Depth)'</dt>
+<dd>Like `debugVal(Expr)', but prints terms truncated to the given depth.</dd>
 <dt>`debugTime(Text,Expr)'</dt>
 <dd>Prints `Text' and the wall clock time for evaluation of `Expr'. The
 result is always the value of `Expr', so this macro can be wrapped

--- a/lib/eunit/include/eunit.hrl
+++ b/lib/eunit/include/eunit.hrl
@@ -223,20 +223,18 @@
 	end).
 -define(debugHere, (?debugMsg("<-"))).
 -define(debugFmt(S, As), (?debugMsg(io_lib:format((S), (As))))).
--define(debugVal(E),
+-define(debugVal(E, D),
 	begin
 	((fun (__V) ->
-		  ?debugFmt(<<"~ts = ~tP">>, [(??E), __V, 15]),
+		  ?debugFmt(<<"~ts = ~tP">>,
+                            [(??E), __V, D]),
 		  __V
 	  end)(E))
 	end).
--define(debugValAll(E),
-	begin
-	((fun (__V) ->
-		  ?debugFmt(<<"~ts = ~tp">>, [(??E), __V]),
-		  __V
-	  end)(E))
-	end).
+-ifndef(EUNIT_DEBUG_VAL_DEPTH).
+-define(EUNIT_DEBUG_VAL_DEPTH, 15).
+-endif.
+-define(debugVal(E), ?debugVal(E, ?EUNIT_DEBUG_VAL_DEPTH)).
 -define(debugTime(S, E),
 	begin
 	((fun () ->


### PR DESCRIPTION
Also make the default depth for debugVal/1 possible to override
by defining the macro EUNIT_DEBUG_VAL_DEPTH.