### PR TITLE
ERL-151: Make erl_tidy work on input file with tilda (~) character.

### DIFF
--- a/lib/syntax_tools/src/erl_tidy.erl
+++ b/lib/syntax_tools/src/erl_tidy.erl
@@ -414,7 +414,7 @@ write_module(Tree, Name, Opts) ->
 
 print_module(Tree, Opts) ->
 	Printer = proplists:get_value(printer, Opts),
-	io:put_chars([Printer(Tree, Opts)]).
+	io:put_chars(Printer(Tree, Opts)).
 
 output(FD, Printer, Tree, Opts) ->
     io:put_chars(FD, Printer(Tree, Opts)),

--- a/lib/syntax_tools/src/erl_tidy.erl
+++ b/lib/syntax_tools/src/erl_tidy.erl
@@ -414,7 +414,7 @@ write_module(Tree, Name, Opts) ->
 
 print_module(Tree, Opts) ->
 	Printer = proplists:get_value(printer, Opts),
-	io:format(Printer(Tree, Opts)).
+	io:format("~p", [Printer(Tree, Opts)]).
 
 output(FD, Printer, Tree, Opts) ->
     io:put_chars(FD, Printer(Tree, Opts)),

--- a/lib/syntax_tools/src/erl_tidy.erl
+++ b/lib/syntax_tools/src/erl_tidy.erl
@@ -414,7 +414,7 @@ write_module(Tree, Name, Opts) ->
 
 print_module(Tree, Opts) ->
 	Printer = proplists:get_value(printer, Opts),
-	io:format("~p", [Printer(Tree, Opts)]).
+	io:put_chars([Printer(Tree, Opts)]).
 
 output(FD, Printer, Tree, Opts) ->
     io:put_chars(FD, Printer(Tree, Opts)),

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -226,7 +226,7 @@ t_igor(Config) when is_list(Config) ->
 
 t_erl_tidy(Config) when is_list(Config) ->
     DataDir   = ?config(data_dir, Config),
-    File  = filename:join(DataDir,"erl_tidy_tilda.erl"),
+    File  = filename:join(DataDir,"erl_tidy_tilde.erl"),
     ok = erl_tidy:file(File, [{stdout, true}]),
     ok.
 

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -27,14 +27,14 @@
 %% Test cases
 -export([app_test/1,appup_test/1,smoke_test/1,revert/1,revert_map/1,
 	t_abstract_type/1,t_erl_parse_type/1,t_epp_dodger/1,
-	t_comment_scan/1,t_igor/1]).
+	t_comment_scan/1,t_igor/1,t_erl_tidy/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
     [app_test,appup_test,smoke_test,revert,revert_map,
     t_abstract_type,t_erl_parse_type,t_epp_dodger,
-    t_comment_scan,t_igor].
+    t_comment_scan,t_igor,t_erl_tidy].
 
 groups() -> 
     [].
@@ -222,6 +222,12 @@ t_igor(Config) when is_list(Config) ->
     FileM2  = filename:join(DataDir,"m2.erl"),
     ["m.erl",_]=R = igor:merge(m,[FileM1,FileM2],[{outdir,PrivDir}]),
     io:format("igor:merge/3 = ~p~n", [R]),
+    ok.
+
+t_erl_tidy(Config) when is_list(Config) ->
+    DataDir   = ?config(data_dir, Config),
+    File  = filename:join(DataDir,"erl_tidy_tilda.erl"),
+    ok = erl_tidy:file(File, [{stdout, true}]),
     ok.
 
 test_comment_scan([],_) -> ok;

--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/erl_tidy_tilda.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/erl_tidy_tilda.erl
@@ -1,9 +1,0 @@
-%%
-%% File:    erl_tidy_tilda.erl
-%% Author:  Mark Bucciarelli
-%% Created: 2016-06-05
-%%
-
--module(erl_tidy_tilda).
-
-?assertEqual("~", 1).

--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/erl_tidy_tilda.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/erl_tidy_tilda.erl
@@ -1,0 +1,9 @@
+%%
+%% File:    erl_tidy_tilda.erl
+%% Author:  Mark Bucciarelli
+%% Created: 2016-06-05
+%%
+
+-module(erl_tidy_tilda).
+
+?assertEqual("~", 1).

--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/erl_tidy_tilde.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/erl_tidy_tilde.erl
@@ -1,0 +1,13 @@
+%%
+%% File:    erl_tidy_tilde.erl
+%% Author:  Mark Bucciarelli
+%% Created: 2016-06-05
+%%
+
+-module(erl_tidy_tilde).
+
+-export([start/0]).
+
+start() ->
+    io:put_chars("tilde characters ('~')in source were "
+                 "breaking erl_tidy\n").


### PR DESCRIPTION
See http://bugs.erlang.org/browse/ERL-151 for a test case.
