### PR TITLE
ETS: Allow for conditional insertions

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -346,6 +346,7 @@ bif ets:next/2
 bif ets:prev/2
 bif ets:insert/2
 bif ets:insert_new/2
+bif ets:compare_insert/3
 bif ets:rename/2
 bif ets:safe_fixtable/2
 bif ets:slot/2

--- a/erts/emulator/beam/erl_db_hash.h
+++ b/erts/emulator/beam/erl_db_hash.h
@@ -84,6 +84,8 @@ int db_create_hash(Process *p,
 
 int db_put_hash(DbTable *tbl, Eterm obj, int key_clash_fail);
 
+int db_compare_put_hash(DbTable *tbl, Eterm obj, Eterm expected_obj);
+
 int db_get_hash(Process *p, DbTable *tbl, Eterm key, Eterm *ret);
 
 int db_erase_hash(DbTable *tbl, Eterm key, Eterm *ret);

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -115,7 +115,10 @@ typedef struct db_table_method
 		   Eterm* ret);
     int (*db_put)(DbTable* tb, /* [in out] */ 
 		  Eterm obj,
-		  int key_clash_fail); /* DB_ERROR_BADKEY if key exists */ 
+		  int key_clash_fail); /* DB_ERROR_BADKEY if key exists */
+    int (*db_compare_put)(DbTable* tb, /* [in out] */
+            Eterm obj,
+            Eterm expected_obj);
     int (*db_get)(Process* p, 
 		  DbTable* tb, /* [in out] */ 
 		  Eterm key, 

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -180,6 +180,23 @@
       </desc>
     </func>
     <func>
+      <name name="compare_insert" arity="3"/>
+      <fsummary>Update an object if it already exists and hasn't changed</fsummary>>
+      <desc>
+        <p>This functions works similarly to <c>insert/2</c> but for a single
+          object at a time, and subject to the restriction of the existing object
+          matching <c><anno>Expected</anno></c>.
+        </p>
+        <p>The function returns <c>true</c> if the update succeeds, <c>false</c>
+          if either an object with the same key as <c><anno>Object</anno></c> wasn't
+          found or the existing object doesn't match <c><anno>Expected</anno></c>
+        </p>
+        <p>The function will fail with reason <c>badarg</c> if the table
+          is not of type <c>set</c> or <c>ordered_set</c>
+        </p>
+      </desc>
+    </func>
+    <func>
       <name name="delete" arity="1"/>
       <fsummary>Delete an entire ETS table.</fsummary>
       <desc>

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -63,7 +63,7 @@
 
 %%% BIFs
 
--export([all/0, delete/1, delete/2, delete_all_objects/1,
+-export([all/0, compare_insert/3, delete/1, delete/2, delete_all_objects/1,
          delete_object/2, first/1, give_away/3, info/1, info/2,
          insert/2, insert_new/2, is_compiled_ms/1, last/1, lookup/2,
          lookup_element/3, match/1, match/2, match/3, match_object/1,
@@ -79,6 +79,14 @@
       Tab :: tab().
 
 all() ->
+    erlang:nif_error(undef).
+
+-spec compare_insert(Tab, Object, Expected) -> boolean() when
+      Tab :: tab(),
+      Object :: tuple(),
+      Expected :: tuple().
+
+compare_insert(_, _, _) ->
     erlang:nif_error(undef).
 
 -spec delete(Tab) -> true when


### PR DESCRIPTION
This change introduces a new BIF, *ets:compare_insert/3*, for sets and ordered sets, which conditions object insertion based on what's in the table matching what we expect (in other words, a sort of compare-exchange for optimistic, atomic updates.)

As for the erl_db_util.h / DbTableMethod interface: I'm not sure whether having '_db_compare_put_' is better than simply extending the signature and functionality of '_db_put_', but that's fairly easy to change.