### PR TITLE
Use proc_lib to fetch the supervisor callback module

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -262,10 +262,8 @@ cast(Supervisor, Req) ->
       Pid :: pid(),
       Module :: atom().
 get_callback_module(Pid) ->
-    {status, _Pid, {module, _Mod},
-     [_PDict, _SysState, _Parent, _Dbg, Misc]} = sys:get_status(Pid),
-    [_Header, _Data, {data, [{"State", State}]}] = Misc,
-    State#state.module.
+    {supervisor, Module, _Args} = proc_lib:initial_call(Pid),
+    Module.
 
 %%% ---------------------------------------------------
 %%% 

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -66,7 +66,7 @@
 
 %% Misc tests
 -export([child_unlink/1, tree/1, count_children/1,
-	 count_restarting_children/1,
+	 count_restarting_children/1, get_callback_module/1,
 	 do_not_save_start_parameters_for_temporary_children/1,
 	 do_not_save_child_specs_for_temporary_children/1,
 	 simple_one_for_one_scale_many_temporary_children/1,
@@ -91,7 +91,7 @@ all() ->
      {group, normal_termination},
      {group, shutdown_termination},
      {group, abnormal_termination}, child_unlink, tree,
-     count_children, count_restarting_children,
+     count_children, count_restarting_children, get_callback_module,
      do_not_save_start_parameters_for_temporary_children,
      do_not_save_child_specs_for_temporary_children,
      simple_one_for_one_scale_many_temporary_children, temporary_bystander,
@@ -1505,6 +1505,14 @@ count_restarting_children(Config) when is_list(Config) ->
     [1,1,0,1] = get_child_counts(SupPid),
     ok = supervisor:terminate_child(SupPid, Ch3_2),
     [1,0,0,0] = get_child_counts(SupPid).
+
+%%-------------------------------------------------------------------------
+%% Test get_callback_module
+get_callback_module(Config) when is_list(Config) ->
+    Child = {child, {supervisor_1, start_child, []}, temporary, 1000,
+	     worker, []},
+    {ok, SupPid} = start_link({ok, {{simple_one_for_one, 2, 3600}, [Child]}}),
+    supervisor_SUITE = supervisor:get_callback_module(SupPid).
 
 %%-------------------------------------------------------------------------
 %% Temporary children shall not be restarted so they should not save


### PR DESCRIPTION
The previous implementation of supervisor:get_callback_module/1
used sys:get_status/1 to get the supervisor inner state and
retrieve the callback module. Such implementation forbids any
other supervisor implementation that has an internal state
different than the #state{} record in supervisor.erl.

This patch uses proc_lib:initial_call/1 to retrieve the
callback module from the returned {supervisor, Module, Args}
format.

Although using proc_lib still relies on supervisor specific
behaviour, such behaviour can be reproduced by properly setting
$initial_call in any process and is less fragile than relying
on the supervisor internal state, making it simpler to build
alternative supervisor implementations.

This is an alternative to #1000. /cc @sirihansen 