### PR TITLE
RFC Fix compilation with `--enable-vm-probes`

### DIFF
--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -5300,6 +5300,7 @@ void erts_dirty_process_main(ErtsSchedulerData *esdp)
     reg = esdp->x_reg_array;
     {
 	Eterm* argp;
+	BeamInstr *next;
 	int i;
 
 	argp = c_p->arg_reg;
@@ -5316,7 +5317,8 @@ void erts_dirty_process_main(ErtsSchedulerData *esdp)
 
 	I = c_p->i;
 
-	ASSERT(BeamOp(op_call_nif) == (BeamInstr *) *I);
+	next = (BeamInstr *) *I;
+	ASSERT(BeamOp(op_call_nif) == next);
 
 	if (ERTS_PROC_GET_SAVED_CALLS_BUF(c_p)
 	    && (ERTS_TRACE_FLAGS(c_p) & F_SENSITIVE) == 0) {


### PR DESCRIPTION
Please refer to commit messages for details.

First error is fixed:
```
    beam/beam_emu.c:5344:51: error: use of undeclared identifier 'next'
                                      "<unknown/%p>", next);
                                                      ^
```

Second error is not fixed yet:
```
    beam/beam_emu.c:5414:3: error: indirect goto in function with no address-of-label expressions
                    Goto(*I);
                    ^
    beam/beam_emu.c:58:21: note: expanded from macro 'Goto'
                        ^
```

... hence I did not manage to compile hence I did not manage to test.

Not sure when/if I will be able to propose fix for second error hence opening pull request with proposed fix for only first error.

Marking pull request as RFC because of the very reduced testing and the incomplete understanding of the beam_emu.c code.