### PR TITLE
Move misplaced period in ssl documentation

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -423,7 +423,7 @@ fun(srp, Username :: string(), UserState :: term()) ->
       <tag><c>{beast_mitigation, one_n_minus_one | zero_n | disabled}</c></tag>
       <item><p>Affects SSL-3.0 and TLS-1.0 connections only. Used to change the BEAST
        mitigation strategy to interoperate with legacy software.
-       Defaults to <c>one_n_minus_one</c></p>.
+       Defaults to <c>one_n_minus_one</c>.</p>
 
       <p><c>one_n_minus_one</c> - Perform 1/n-1 BEAST mitigation.</p>
 


### PR DESCRIPTION
PR #1041 added a formatting error to the ssl application documentation. This commit fixes it.