### PR TITLE
Propagate exceptions fully when using proc_lib

### DIFF
--- a/lib/stdlib/doc/src/proc_lib.xml
+++ b/lib/stdlib/doc/src/proc_lib.xml
@@ -66,6 +66,12 @@
       <seealso marker="sasl:error_logging">SASL Error Logging</seealso>
       in the SASL User's Guide.</p>
 
+    <p>Unlike in "plain Erlang", <c>proc_lib</c> processes will not generate
+      <em>error reports</em>, which are written to the terminal by the
+      emulator and do not require SASL to be started. All exceptions are
+      converted to <em>exits</em> which are ignored by the default
+      <c>error_logger</c> handler.</p>
+
     <p>The crash report contains the previously stored information, such
       as ancestors and initial function, the termination reason, and
       information about other processes that terminate as a result

--- a/lib/stdlib/test/gen_statem_SUITE.erl
+++ b/lib/stdlib/test/gen_statem_SUITE.erl
@@ -505,10 +505,10 @@ abnormal2(Config) ->
     {ok,Pid} = gen_statem:start_link(?MODULE, start_arg(Config, []), []),
 
     %% bad return value in the gen_statem loop
-    {{bad_return_from_state_function,badreturn},_} =
+    {{{bad_return_from_state_function,badreturn},_},_} =
 	?EXPECT_FAILURE(gen_statem:call(Pid, badreturn), Reason),
     receive
-	{'EXIT',Pid,{bad_return_from_state_function,badreturn}} -> ok
+	{'EXIT',Pid,{{bad_return_from_state_function,badreturn},_}} -> ok
     after 5000 ->
 	    ct:fail(gen_statem_did_not_die)
     end,
@@ -887,7 +887,7 @@ error_format_status(Config) ->
 	gen_statem:start(
 	  ?MODULE, start_arg(Config, {data,Data}), []),
     %% bad return value in the gen_statem loop
-    {{bad_return_from_state_function,badreturn},_} =
+    {{{bad_return_from_state_function,badreturn},_},_} =
 	?EXPECT_FAILURE(gen_statem:call(Pid, badreturn), Reason),
     receive
 	{error,_,


### PR DESCRIPTION
This is a small and heavy change. I can do any documentation changes after the PR is approved.
## The patch

This makes proc_lib behaves like a normal process as far
as exceptions are concerned.

Before this commit, the following difference could be
observed:

```
6> spawn_link(fun() -> ssl:send(a,b) end).
<0.43.0>
7> flush().
Shell got {'EXIT',<0.43.0>,
           {function_clause,
            [{ssl,send,[a,b],[{file,"..."},{line,275}]}]}}
ok

8> proc_lib:spawn_link(fun() -> ssl:send(a,b) end).
<0.46.0>
9> flush().
Shell got {'EXIT',<0.46.0>,function_clause}
```

After this commit, we get the following instead:

```
3> flush().
Shell got {'EXIT',<0.61.0>,
           {function_clause,
            [{ssl,send,[a,b],[{file,"..."},{line,275}]},
             {proc_lib,init_p,3,[{file,"..."},{line,232}]}]}}
```

The stacktrace will show minor differences of course
but the form is now the same as without proc_lib.
## Rationale
- We now have a single form regardless of how the process
  was started
- We can use the stacktrace to programmatically alter behavior
  (for example an HTTP server identifying problems in input
  decoding to send back a generic 400, or a 500 otherwise)
- We can access the stacktrace to print it somewhere (for
  example an HTTP server could send it back to the client
  when a debug mode is enabled)
## Breaking changes
- The 'EXIT' message reason format changes due to the addition of the stacktrace
