### PR TITLE
Compiler: new function env_compiler_options/0

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -40,6 +40,19 @@
 
   <funcs>
     <func>
+      <name>env_compiler_options()</name>
+      <fsummary>
+	Compiler options defined via the environment variable
+	<c>ERL_COMPILER_OPTIONS</c>
+      </fsummary>
+      <desc>
+	<p>Return compiler options given via the environment variable
+	  <c>ERL_COMPILER_OPTIONS</c>. If the value is a list, it is
+	  returned as is. If it is not a list, it is put into a list.
+	</p>
+      </desc>
+    </func>
+    <func>
       <name>file(File)</name>
       <fsummary>Compiles a file.</fsummary>
       <desc>
@@ -768,6 +781,10 @@ module.beam: module.erl \
       if you do not want the environment variable to be consulted,
       for example, if you are calling the compiler recursively from
       inside a parse transform.</p>
+
+      <p>The list can be retrieved with
+      <seealso marker="#env_compiler_options/0">env_compiler_options/0</seealso>
+      .</p>
   </section>
 
   <section>

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -26,6 +26,7 @@
 -export([forms/1,forms/2,noenv_forms/2]).
 -export([output_generated/1,noenv_output_generated/1]).
 -export([options/0]).
+-export([env_compiler_options/0]).
 
 %% Erlc interface.
 -export([compile/3,compile_beam/3,compile_asm/3,compile_core/3]).
@@ -129,6 +130,14 @@ noenv_output_generated(Opts) ->
     any(fun ({save_binary,_T,_F}) -> true;
 	    (_Other) -> false
 	end, Passes).
+
+%%
+%% Retrieve ERL_COMPILER_OPTIONS as a list of terms
+%%
+
+-spec env_compiler_options() -> [term()].
+
+env_compiler_options() -> env_default_opts().
 
 %%
 %%  Local functions

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -34,7 +34,7 @@
 	 cover/1, env/1, core/1,
 	 core_roundtrip/1, asm/1,
 	 sys_pre_attributes/1, dialyzer/1,
-	 warnings/1, pre_load_check/1
+	 warnings/1, pre_load_check/1, env_compiler_options/1
 	]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
@@ -50,7 +50,8 @@ all() ->
      other_output, encrypted_abstr,
      strict_record,
      cover, env, core, core_roundtrip, asm,
-     sys_pre_attributes, dialyzer, warnings, pre_load_check].
+     sys_pre_attributes, dialyzer, warnings, pre_load_check,
+     env_compiler_options].
 
 groups() -> 
     [].
@@ -1091,6 +1092,23 @@ compiler_modules() ->
     Ms = filelib:wildcard(Wc),
     FN = filename,
     [list_to_atom(FN:rootname(FN:basename(M), ".beam")) || M <- Ms].
+
+%% Test that ERL_COMPILER_OPTIONS are correctly retrieved
+%% by env_compiler_options/0
+
+env_compiler_options(_Config) ->
+    Cases = [
+        {"bin_opt_info", [bin_opt_info]},
+        {"'S'", ['S']},
+        {"{source, \"test.erl\"}", [{source, "test.erl"}]},
+        {"[{d,macro_one,1},{d,macro_two}]", [{d, macro_one, 1}, {d, macro_two}]},
+        {"[warn_export_all, warn_export_vars]", [warn_export_all, warn_export_vars]}
+    ],
+    F = fun({Env, Expected}) ->
+        true = os:putenv("ERL_COMPILER_OPTIONS", Env),
+        Expected = compile:env_compiler_options()
+    end,
+    lists:foreach(F, Cases).
 
 %%%
 %%% Utilities.


### PR DESCRIPTION
retrieve the value of the environment variable `ERL_COMPILER_OPTIONS`
in the same manner as used by `file/2`, `forms/2` and `output_generated/2`

for rebar3 we do a check that the compile options as generated by rebar3 match
the options used to compile existing beam files and (potentially) skip them if true. adding
this function allows us to ensure that rebar3's processing of `ERL_COMPILER_OPTIONS`
matches the processing done by `file/2`

see erlang/rebar3#1184