### PR TITLE
Disregard MAP_NORESERVE for FreeBSD

### DIFF
--- a/erts/emulator/sys/common/erl_mmap.c
+++ b/erts/emulator/sys/common/erl_mmap.c
@@ -1334,9 +1334,17 @@ os_mremap(void *ptr, UWord old_size, UWord new_size, int try_superalign)
 #define ERTS_MMAP_RESERVE_PROT_EXEC	(ERTS_MMAP_PROT_EXEC)
 #define ERTS_MMAP_RESERVE_FLAGS		(ERTS_MMAP_FLAGS|MAP_FIXED)
 #define ERTS_MMAP_UNRESERVE_PROT	(PROT_NONE)
+#if defined(__FreeBSD__)
+#define ERTS_MMAP_UNRESERVE_FLAGS	(ERTS_MMAP_FLAGS|MAP_FIXED)
+#else
 #define ERTS_MMAP_UNRESERVE_FLAGS	(ERTS_MMAP_FLAGS|MAP_NORESERVE|MAP_FIXED)
+#endif /* __FreeBSD__ */
 #define ERTS_MMAP_VIRTUAL_PROT		(PROT_NONE)
+#if defined(__FreeBSD__)
+#define ERTS_MMAP_VIRTUAL_FLAGS		(ERTS_MMAP_FLAGS)
+#else
 #define ERTS_MMAP_VIRTUAL_FLAGS		(ERTS_MMAP_FLAGS|MAP_NORESERVE)
+#endif /* __FreeBSD__ */
 
 static int
 os_reserve_physical(char *ptr, UWord size, int exec)

--- a/erts/emulator/sys/common/erl_mmap.h
+++ b/erts/emulator/sys/common/erl_mmap.h
@@ -38,7 +38,17 @@
 #  if HAVE_MREMAP
 #    define ERTS_HAVE_OS_MREMAP 1
 #  endif
-#  if defined(MAP_FIXED) && defined(MAP_NORESERVE)
+/*
+ * MAP_NORESERVE is undefined in FreeBSD 10.x and later.
+ * This is to enable 64bit HiPE experimentally on FreeBSD.
+ * Note that on FreeBSD MAP_NORESERVE was "never implemented"
+ * even before 11.x (and the flag does not exist in /usr/src/sys/vm/mmap.c
+ * of 10.3-STABLE r301478 either), and HiPE was working on OTP 18.3.3,
+ * so mandating MAP_NORESERVE on FreeBSD might not be needed.
+ * See the following message on how MAP_NORESERVE was treated on FreeBSD:
+ * <http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20150202/122958.html>
+ */
+#  if defined(MAP_FIXED) && (defined(MAP_NORESERVE) || defined(__FreeBSD__))
 #    define ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION 1
 #  endif
 #endif


### PR DESCRIPTION
A fix for running 19.0-rc2 on FreeBSD with HiPE enabled.

* erl_mmap.h: disregard MAP_NORESERVE for FreeBSD

    MAP_NORESERVE is undefined in FreeBSD 10.x and later.
    This is to enable 64bit HiPE experimentally on FreeBSD.
    Note that on FreeBSD MAP_NORESERVE was "never implemented"
    even before 11.x (and the flag does not exist in /usr/src/sys/vm/mmap.c
    of 10.3-STABLE r301478 either), and HiPE was working on OTP 18.3.3,
    so mandating MAP_NORESERVE on FreeBSD might not be needed.
    See the following message on how MAP_NORESERVE was treated on FreeBSD:
    <http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20150202/122958.html>

* erl_mmap.c: disable MAP_NORESERVE for FreeBSD

* See also <https://github.com/erlang/otp/pull/925/commits/b02ce940c8738785ad018c9f758ca0d05d256bbb>