### PR TITLE
handle ct_slave nodename in the same way as net_kernel

### DIFF
--- a/lib/common_test/src/ct_slave.erl
+++ b/lib/common_test/src/ct_slave.erl
@@ -309,7 +309,12 @@ is_started(ENode) ->
 
 % make a Erlang node name from name and hostname
 enodename(Host, Node) ->
-    list_to_atom(atom_to_list(Node)++"@"++atom_to_list(Host)).
+    case lists:member($@, atom_to_list(Node)) of
+        true ->
+            Node;
+        false ->
+            list_to_atom(atom_to_list(Node)++"@"++atom_to_list(Host))
+    end.
 
 % performs actual start of the "slave" node
 do_start(Host, Node, Options) ->


### PR DESCRIPTION
This change makes how `ct_slave` handles a nodename passed by the user the same as those passed to `net_kernel` or `-sname`/`-name`. Meaning if the host is part of the nodename it is used as the host instead of appending the resolved host from the system.

Before:

``` erlang
(a@127.0.0.1)1> ct_slave:start('b@127.0.0.1').
{error,boot_timeout,'b@127.0.0.1@fanon'}
```

After:

``` erlang
(a@127.0.0.1)1> ct_slave:start('b@127.0.0.1').
{ok,'b@127.0.0.1'}
```
