### PR TITLE
Use the `perl` on the `$PATH`

### DIFF
--- a/make/make_emakefile
+++ b/make/make_emakefile
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # -*- cperl -*-
 
 use strict;


### PR DESCRIPTION
Seems `make_emakefile` is [hard-coding]( https://github.com/erlang/otp/blob/53e7743216647d810d529e397bd3ea7278c6047c/make/make_emakefile#L1 ) the `perl` used. This is causing me some grief as I don't have `perl` in `/usr/bin/`, but do have it somewhere else. Everything else in the build seems to be picking `perl` up fine except for this script. Note that other uses of `perl` in `otp` do the [same thing]( https://github.com/erlang/otp/search?utf8=%E2%9C%93&q=%22%23%21%2Fusr%2Fbin%2Fenv+perl%22&type=Code ).