### PR TITLE
added asn1 to applications needed for start_ssl

### DIFF
--- a/lib/ssl/doc/src/ssl_distribution.xml
+++ b/lib/ssl/doc/src/ssl_distribution.xml
@@ -98,6 +98,7 @@
       {stdlib,"1.18"},
       {crypto, "2.0.3"},
       {public_key, "0.12"},
+      {asn1, "4.0"},
       {ssl, "5.0"}
       ]}.
    </code>


### PR DESCRIPTION
I found [this link regarding the ssl distribution setup](http://erlang.org/pipermail/erlang-bugs/2014-March/004261.html) while attempting to follow the documentation.  Seeing that the doc hadn't been updated I thought I'd try to do that.  :-)