### PR TITLE
Don't make assumptions about build tools paths

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -129,6 +129,13 @@ AC_PROG_CC
 AC_PROG_CXX
 AC_CHECK_TOOL(LD, [ld])
 
+_search_path=/bin:/usr/bin:/usr/local/bin:$PATH
+
+AC_PATH_PROG(ENV, [env], false, $_search_path)
+if test "$ac_cv_path_ENV" = false; then
+  AC_MSG_ERROR([No 'env' command found])
+fi
+
 #
 # We need GNU make, complain if we can't find it
 #

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -4821,8 +4821,7 @@ dnl Output the result.
 dnl ----------------------------------------------------------------------
 
 dnl  Note that the output files are relative to $srcdir
-
-AC_OUTPUT(
+AC_CONFIG_FILES([
   emulator/$host/Makefile:emulator/Makefile.in
   epmd/src/$host/Makefile:epmd/src/Makefile.in
   etc/common/$host/Makefile:etc/common/Makefile.in
@@ -4832,15 +4831,22 @@ AC_OUTPUT(
   Makefile:Makefile.in
   ../make/$host/otp.mk:../make/otp.mk.in
   ../make/$host/otp_ded.mk:../make/otp_ded.mk.in
+])
+
+AC_CONFIG_FILES([../make/make_emakefile:../make/make_emakefile.in],
+                [chmod +x ../make/make_emakefile])
+
 dnl
 dnl The ones below should be moved to their respective lib
 dnl
+dnl  ../lib/ssl/c_src/$host/Makefile:../lib/ssl/c_src/Makefile.in
+AC_CONFIG_FILES([
   ../lib/ic/c_src/$host/Makefile:../lib/ic/c_src/Makefile.in
   ../lib/os_mon/c_src/$host/Makefile:../lib/os_mon/c_src/Makefile.in
-dnl  ../lib/ssl/c_src/$host/Makefile:../lib/ssl/c_src/Makefile.in
   ../lib/crypto/c_src/$host/Makefile:../lib/crypto/c_src/Makefile.in
   ../lib/orber/c_src/$host/Makefile:../lib/orber/c_src/Makefile.in
   ../lib/runtime_tools/c_src/$host/Makefile:../lib/runtime_tools/c_src/Makefile.in
   ../lib/tools/c_src/$host/Makefile:../lib/tools/c_src/Makefile.in
-  )
+  ])
 
+AC_OUTPUT

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -738,6 +738,11 @@ if test "$ac_cv_path_MKDIR" = false; then
   AC_MSG_ERROR([No 'mkdir' command found])
 fi
 
+AC_PATH_PROG(CP, cp, false, $_search_path)
+if test "$ac_cv_path_CP" = false; then
+  AC_MSG_ERROR([No 'cp' command found])
+fi
+
 _search_path=
 
 

--- a/lib/debugger/doc/src/Makefile
+++ b/lib/debugger/doc/src/Makefile
@@ -114,7 +114,7 @@ release_docs_spec: docs
 	$(INSTALL_DIR) "$(RELSYSDIR)/doc/pdf"
 	$(INSTALL_DATA) $(TOP_PDF_FILE) "$(RELSYSDIR)/doc/pdf"
 	$(INSTALL_DIR) "$(RELSYSDIR)/doc/html"
-	(/bin/cp -rf  $(HTMLDIR) "$(RELSYSDIR)/doc")
+	($(CP) -rf  $(HTMLDIR) "$(RELSYSDIR)/doc")
 	$(INSTALL_DATA) $(INFO_FILE) "$(RELSYSDIR)"
 	$(INSTALL_DIR) "$(RELEASE_PATH)/man/man3"
 	$(INSTALL_DATA) $(MAN3DIR)/* "$(RELEASE_PATH)/man/man3"

--- a/lib/diameter/src/Makefile
+++ b/lib/diameter/src/Makefile
@@ -123,7 +123,7 @@ ERL_COMPILE_FLAGS += \
 # erl/hrl from dictionary file.
 gen/diameter_gen_%.erl gen/diameter_gen_%.hrl: dict/%.dia
 	$(dia_verbose) \
-	../bin/diameterc -o gen -i $(EBIN) $<
+	escript ../bin/diameterc -o gen -i $(EBIN) $<
 
 opt: $(TARGET_FILES)
 

--- a/lib/gs/doc/src/Makefile
+++ b/lib/gs/doc/src/Makefile
@@ -148,7 +148,7 @@ release_docs_spec: docs
 	$(INSTALL_DIR)  "$(RELSYSDIR)/doc/pdf"
 	$(INSTALL_DATA) $(TOP_PDF_FILE)  "$(RELSYSDIR)/doc/pdf"
 	$(INSTALL_DIR) "$(RELSYSDIR)/doc/html"
-	(/bin/cp -rf  $(HTMLDIR) "$(RELSYSDIR)/doc")
+	($(CP) -rf  $(HTMLDIR) "$(RELSYSDIR)/doc")
 	$(INSTALL_DATA) $(INFO_FILE) "$(RELSYSDIR)"
 	$(INSTALL_DIR) "$(RELEASE_PATH)/man/man3"
 	$(INSTALL_DATA) $(MAN3DIR)/* "$(RELEASE_PATH)/man/man3"

--- a/lib/ic/doc/src/Makefile
+++ b/lib/ic/doc/src/Makefile
@@ -225,7 +225,7 @@ release_docs_spec: docs
 	$(INSTALL_DATA) $(TOP_PDF_FILE) "$(RELSYSDIR)/doc/pdf"
 	$(INSTALL_DATA) $(INFO_FILE) "$(RELSYSDIR)"
 	$(INSTALL_DIR) "$(RELSYSDIR)/doc/html"
-	(/bin/cp -rf  $(HTMLDIR) "$(RELSYSDIR)/doc")
+	($(CP) -rf  $(HTMLDIR) "$(RELSYSDIR)/doc")
 	$(INSTALL_DIR) "$(RELEASE_PATH)/man/man3"
 	$(INSTALL_DATA) $(MAN3_FILES) "$(RELEASE_PATH)/man/man3"
 

--- a/lib/jinterface/doc/src/Makefile
+++ b/lib/jinterface/doc/src/Makefile
@@ -166,7 +166,7 @@ release_docs_spec: docs
 	$(INSTALL_DIR) "$(RELSYSDIR)/doc/html"
 	$(INSTALL_DIR) "$(RELSYSDIR)/doc/html/java/$(JAVA_PKG_PATH)"
 	$(INSTALL_DATA) $(INFO_FILE) "$(RELSYSDIR)"
-	(/bin/cp -rf  ../html "$(RELSYSDIR)/doc")
+	($(CP) -rf  ../html "$(RELSYSDIR)/doc")
 
 #	$(INSTALL_DATA) $(GIF_FILES) $(EXTRA_FILES) $(HTML_FILES) \
 #		"$(RELSYSDIR)/doc/html"

--- a/make/emd2exml.in
+++ b/make/emd2exml.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env escript
+#!@ENV@ escript
 %% -*- erlang -*-
 %%! -smp disable
 

--- a/make/make_emakefile.in
+++ b/make/make_emakefile.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 # -*- cperl -*-
 
 use strict;

--- a/make/otp.mk.in
+++ b/make/otp.mk.in
@@ -260,6 +260,7 @@ DEFAULT_GIF_FILES = $(HTMLDIR)/min_head.gif
 XSLTPROC = @XSLTPROC@
 FOP = @FOP@
 XMLLINT = @XMLLINT@
+CP = @CP@
 
 DOCGEN=$(ERL_TOP)/lib/erl_docgen
 FOP_CONFIG = $(DOCGEN)/priv/fop.xconf


### PR DESCRIPTION
One more followup to https://github.com/erlang/otp/pull/1056 and
https://github.com/erlang/otp/pull/1023

This time it's about `/usr/bin/env` and `/bin/cp`:
- `/usr/bin/env` in `diameterc` was used to find the bootstrapped
  `escript` executable. Changed it to exlpicit call to `escript` in
  Makefile.
- `/usr/bin/env` and `/bin/cp` were referenced in documentation
  build/install process. Now full paths to this tools are injected using
  autoconf magic.