### PR TITLE
Ensure PCRE empty branch checker doesn't overflow

### DIFF
--- a/erts/emulator/pcre/pcre_compile.c
+++ b/erts/emulator/pcre/pcre_compile.c
@@ -2363,6 +2363,8 @@ could_be_empty_branch(const pcre_uchar *code, const pcre_uchar *endcode,
   BOOL utf, compile_data *cd)
 {
 register pcre_uchar c;
+pcre_uchar tempcode = *code;
+
 for (code = first_significant_code(code + PRIV(OP_lengths)[*code], TRUE);
      code < endcode;
      code = first_significant_code(code + PRIV(OP_lengths)[c], TRUE))
@@ -2370,6 +2372,12 @@ for (code = first_significant_code(code + PRIV(OP_lengths)[*code], TRUE);
   const pcre_uchar *ccode;
 
   c = *code;
+
+  /* We check to see if this is a faulty recursion that could loop for ever,
+     and diagnose that case. */
+  if (tempcode == OP_ALT && c == OP_RECURSE) {
+      return TRUE;
+  }
 
   /* Skip over forward assertions; the other assertions are skipped by
   first_significant_code() with a TRUE final argument. */


### PR DESCRIPTION
**Case**

`re:compile("/((?(R1)ZV+|(?1)b))+").`

**Behaviour**

Segmentation Fault, crashes interpreter.

**Notes**

I was writing a symbolic execution workload with [CUTER](https://github.com/aggelgian/cuter) and found this issue, the issue is a generic recursive overflow and doesn't appear  #exploitable.

This patch returns empty when we've struck a branch that checks a mutually recursive pattern. We check to see if this is a left-recursion between `OP_ALT` and `OP_RECURSIVE` that could loop forever and return `TRUE` if that is the case.

This is a quick patch for my own personal workload, I'd like to hear some input from someone better versed in EPCRE to see if there is a more fundamental issue at work here.