### PR TITLE
Enable tag completion in emacs erlang shell

### DIFF
--- a/lib/tools/emacs/erlang-test.el
+++ b/lib/tools/emacs/erlang-test.el
@@ -132,6 +132,40 @@ concatenated to form an erlang file to test on.")
     (should (looking-back "erlang_test:"))))
 
 
+(ert-deftest erlang-test-compile-options ()
+  (erlang-test-format-opt t
+                          "t")
+  (erlang-test-format-opt nil
+                          "nil")
+  (erlang-test-format-opt (cons 1 2)
+                          "{1, 2}")
+  (erlang-test-format-opt (list 1)
+                          "[1]")
+  (erlang-test-format-opt (list 1 2)
+                          "[1, 2]")
+  (erlang-test-format-opt (list 1 2 3)
+                          "[1, 2, 3]")
+  (erlang-test-format-opt 'symbol
+                          "symbol")
+  (erlang-test-format-opt "string"
+                          "\"string\"")
+  (erlang-test-format-opt []
+                          "{}")
+  (erlang-test-format-opt [1]
+                          "{1}")
+  (erlang-test-format-opt [1 2]
+                          "{1, 2}")
+  (erlang-test-format-opt [1 2 (3 [4 5 6] 7)]
+                          "{1, 2, [3, {4, 5, 6}, 7]}"))
+
+(defun erlang-test-format-opt (elisp &optional expected-erlang)
+  (let ((erlang (inferior-erlang-format-opt elisp)))
+    (message "%s -> %s" elisp erlang)
+    (when expected-erlang
+      (should (equal erlang expected-erlang)))
+    erlang))
+
+
 (provide 'erlang-test)
 
 ;;; erlang-test.el ends here

--- a/lib/tools/emacs/erlang-test.el
+++ b/lib/tools/emacs/erlang-test.el
@@ -54,9 +54,20 @@ concatenated to form an erlang file to test on.")
   (let* ((dir (make-temp-file "erlang-test" t))
          (erlang-file (expand-file-name "erlang_test.erl" dir))
          (tags-file (expand-file-name "TAGS" dir))
-         tags-file-name tags-table-list erlang-buffer)
+         (old-tags-file-name (default-value 'tags-file-name))
+         (old-tags-table-list (default-value 'tags-table-list))
+         tags-file-name
+         tags-table-list
+         tags-table-set-list
+         erlang-buffer
+         erlang-mode-hook
+         prog-mode-hook
+         erlang-shell-mode-hook
+         tags-add-tables)
     (unwind-protect
         (progn
+          (setq-default tags-file-name nil)
+          (setq-default tags-table-list nil)
           (erlang-test-create-erlang-file erlang-file)
           (erlang-test-compile-tags erlang-file tags-file)
           (setq erlang-buffer (find-file-noselect erlang-file))
@@ -74,7 +85,9 @@ concatenated to form an erlang file to test on.")
         (when (buffer-live-p tags-buffer)
           (kill-buffer tags-buffer)))
       (when (file-exists-p dir)
-        (delete-directory dir t)))))
+        (delete-directory dir t))
+      (setq-default tags-file-name old-tags-file-name)
+      (setq-default tags-table-list old-tags-table-list))))
 
 (defun erlang-test-create-erlang-file (erlang-file)
   (with-temp-file erlang-file
@@ -121,7 +134,7 @@ concatenated to form an erlang file to test on.")
   (with-temp-buffer
     (erlang-mode)
     (setq-local tags-file-name tags-file)
-    (insert "erlang_test:fun")
+    (insert "\nerlang_test:fun")
     (erlang-complete-tag)
     (should (looking-back "erlang_test:function"))
     (insert "\nfun")

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -4777,11 +4777,7 @@ for a tag on the form `module:tag'."
   (if (fboundp 'advice-add)
       ;; Emacs 24.4+
       (advice-add 'etags-tags-completion-table :around
-                  (lambda (oldfun)
-                    (if erlang-replace-etags-tags-completion-table
-                        (erlang-etags-tags-completion-table)
-                      (funcall oldfun)))
-                  (list :name 'erlang-replace-tags-table))
+                  #'erlang-etags-tags-completion-table-advice)
     ;; Emacs 23.1-24.3
     (defadvice etags-tags-completion-table (around
                                             erlang-replace-tags-table
@@ -4789,6 +4785,11 @@ for a tag on the form `module:tag'."
       (if erlang-replace-etags-tags-completion-table
           (setq ad-return-value (erlang-etags-tags-completion-table))
         ad-do-it))))
+
+(defun erlang-etags-tags-completion-table-advice (oldfun)
+  (if erlang-replace-etags-tags-completion-table
+      (erlang-etags-tags-completion-table)
+    (funcall oldfun)))
 
 (defun erlang-complete-tag ()
   "Perform tags completion on the text around point.


### PR DESCRIPTION
Completion in erlang shell buffer only works in Emacs 25.

Minor cleanup of completion stuff.

Add test-case for completion at point.

Avoid inf-loop in erlang-end-of-clause when buffer starts with
whitespace.