### PR TITLE
erl_types: Fix map type parsing bug (ERL-177)

### DIFF
--- a/lib/dialyzer/test/user_SUITE_data/src/map_mand_remote_val/a.erl
+++ b/lib/dialyzer/test/user_SUITE_data/src/map_mand_remote_val/a.erl
@@ -1,0 +1,9 @@
+-module(a).
+-type t() :: #{type := b:t()}.
+-export([to_map/1, to_map/2]).
+
+-spec to_map(t()) -> map().
+to_map(Resource) -> to_map(Resource, #{}).
+
+-spec to_map(t(), map()) -> map().
+to_map(_, Map) when is_map(Map) -> #{}.

--- a/lib/dialyzer/test/user_SUITE_data/src/map_mand_remote_val/b.erl
+++ b/lib/dialyzer/test/user_SUITE_data/src/map_mand_remote_val/b.erl
@@ -1,0 +1,3 @@
+-module(b).
+-type t() :: binary().
+-export_type([t/0]).


### PR DESCRIPTION
`t_map/3` previously required callers to perform normalisation of 
`X:=none()` pairs, but as `t_from_form/5` would sometimes fail to do so,
this requirement is relaxed.

This caused a dialyzer crash when using remote types as values of
mandatory pairs with singleton keys.

Bug (ERL-177) reported and shrunk by Luke Imhoff.