### PR TITLE
Check libsctp for sctp funcs in configure.in

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1676,7 +1676,8 @@ if test "x$enable_sctp" != "xno" ; then
 fi
 
 if test x"$ac_cv_header_netinet_sctp_h" = x"yes"; then
-    AC_CHECK_FUNCS([sctp_bindx sctp_peeloff sctp_getladdrs sctp_freeladdrs sctp_getpaddrs sctp_freepaddrs])
+    AC_CHECK_LIB(sctp, sctp_bindx)
+    AC_CHECK_FUNCS([sctp_peeloff sctp_getladdrs sctp_freeladdrs sctp_getpaddrs sctp_freepaddrs])
     AC_CHECK_DECLS([SCTP_UNORDERED, SCTP_ADDR_OVER, SCTP_ABORT,
                     SCTP_EOF, SCTP_SENDALL, SCTP_ADDR_CONFIRMED,
 		    SCTP_DELAYED_ACK_TIME,


### PR DESCRIPTION
Call AC_CHECK_LIB before calling AC_CHECK_FUNCS to check for functions in libsctp.
Otherwise AC_CHECK_FUNCS will not link with libsctp to see if function exists.