### PR TITLE
emulator: Sweep HiPE stack for literals on purge

### DIFF
--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -37,6 +37,10 @@
 #include "erl_bits.h"
 #include "erl_thr_progress.h"
 
+#ifdef HIPE
+#  include "hipe_stack.h"
+#endif
+
 static void set_default_trace_pattern(Eterm module);
 static Eterm check_process_code(Process* rp, Module* modp, Uint flags, int *redsp, int fcalls);
 static void delete_code(Module* modp);
@@ -916,6 +920,10 @@ check_process_code(Process* rp, Module* modp, Uint flags, int *redsp, int fcalls
 	}
 	if (any_heap_ref_ptrs(rp->stop, rp->hend, literals, lit_bsize))
 	    goto try_literal_gc;
+#ifdef HIPE
+	if (nstack_any_heap_ref_ptrs(rp, literals, lit_bsize))
+	    goto try_literal_gc;
+#endif
 	if (any_heap_refs(rp->heap, rp->htop, literals, lit_bsize))
 	    goto try_literal_gc;
 	if (any_heap_refs(rp->old_heap, rp->old_htop, literals, lit_bsize))

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -882,6 +882,58 @@ erts_garbage_collect_hibernate(Process* p)
 }
 
 
+/*
+ * HiPE native code stack scanning procedures:
+ * - fullsweep_nstack()
+ * - gensweep_nstack()
+ * - offset_nstack()
+ * - sweep_literals_nstack()
+ */
+#if defined(HIPE)
+
+#define GENSWEEP_NSTACK(p,old_htop,n_htop)				\
+	do {								\
+		Eterm *tmp_old_htop = old_htop;				\
+		Eterm *tmp_n_htop = n_htop;				\
+		gensweep_nstack((p), &tmp_old_htop, &tmp_n_htop);	\
+		old_htop = tmp_old_htop;				\
+		n_htop = tmp_n_htop;					\
+	} while(0)
+
+/*
+ * offset_nstack() can ignore the descriptor-based traversal the other
+ * nstack procedures use and simply call offset_heap_ptr() instead.
+ * This relies on two facts:
+ * 1. The only live non-Erlang terms on an nstack are return addresses,
+ *    and they will be skipped thanks to the low/high range check.
+ * 2. Dead values, even if mistaken for pointers into the low/high area,
+ *    can be offset safely since they won't be dereferenced.
+ *
+ * XXX: WARNING: If HiPE starts storing other non-Erlang values on the
+ * nstack, such as floats, then this will have to be changed.
+ */
+static ERTS_INLINE void offset_nstack(Process* p, Sint offs,
+				      char* area, Uint area_size)
+{
+    if (p->hipe.nstack) {
+	ASSERT(p->hipe.nsp && p->hipe.nstend);
+	offset_heap_ptr(hipe_nstack_start(p), hipe_nstack_used(p),
+			offs, area, area_size);
+    }
+    else {
+	ASSERT(!p->hipe.nsp && !p->hipe.nstend);
+    }
+}
+
+#else /* !HIPE */
+
+#define fullsweep_nstack(p,n_htop)		        	(n_htop)
+#define GENSWEEP_NSTACK(p,old_htop,n_htop)	        	do{}while(0)
+#define offset_nstack(p,offs,area,area_size)	        	do{}while(0)
+#define sweep_literals_nstack(p,old_htop,area,area_size)	(old_htop)
+
+#endif /* HIPE */
+
 void
 erts_garbage_collect_literals(Process* p, Eterm* literals,
 			      Uint byte_lit_size,
@@ -944,7 +996,7 @@ erts_garbage_collect_literals(Process* p, Eterm* literals,
     area_size = byte_lit_size;
     n = setup_rootset(p, p->arg_reg, p->arity, &rootset);
     roots = rootset.roots;
-    old_htop = p->old_htop;
+    old_htop = sweep_literals_nstack(p, p->old_htop, area, area_size);
     while (n--) {
         Eterm* g_ptr = roots->v;
         Uint g_sz = roots->sz;
@@ -1210,56 +1262,6 @@ minor_collection(Process* p, ErlHeapFragment *live_hf_end,
      */
     return -1;
 }
-
-/*
- * HiPE native code stack scanning procedures:
- * - fullsweep_nstack()
- * - gensweep_nstack()
- * - offset_nstack()
- */
-#if defined(HIPE)
-
-#define GENSWEEP_NSTACK(p,old_htop,n_htop)				\
-	do {								\
-		Eterm *tmp_old_htop = old_htop;				\
-		Eterm *tmp_n_htop = n_htop;				\
-		gensweep_nstack((p), &tmp_old_htop, &tmp_n_htop);	\
-		old_htop = tmp_old_htop;				\
-		n_htop = tmp_n_htop;					\
-	} while(0)
-
-/*
- * offset_nstack() can ignore the descriptor-based traversal the other
- * nstack procedures use and simply call offset_heap_ptr() instead.
- * This relies on two facts:
- * 1. The only live non-Erlang terms on an nstack are return addresses,
- *    and they will be skipped thanks to the low/high range check.
- * 2. Dead values, even if mistaken for pointers into the low/high area,
- *    can be offset safely since they won't be dereferenced.
- *
- * XXX: WARNING: If HiPE starts storing other non-Erlang values on the
- * nstack, such as floats, then this will have to be changed.
- */
-static ERTS_INLINE void offset_nstack(Process* p, Sint offs,
-				      char* area, Uint area_size)
-{
-    if (p->hipe.nstack) {
-	ASSERT(p->hipe.nsp && p->hipe.nstend);
-	offset_heap_ptr(hipe_nstack_start(p), hipe_nstack_used(p),
-			offs, area, area_size);
-    }
-    else {
-	ASSERT(!p->hipe.nsp && !p->hipe.nstend);
-    }
-}
-
-#else /* !HIPE */
-
-#define fullsweep_nstack(p,n_htop)		(n_htop)
-#define GENSWEEP_NSTACK(p,old_htop,n_htop)	do{}while(0)
-#define offset_nstack(p,offs,area,area_size)	do{}while(0)
-
-#endif /* HIPE */
 
 static void
 do_minor(Process *p, ErlHeapFragment *live_hf_end,

--- a/erts/emulator/hipe/hipe_gc.c
+++ b/erts/emulator/hipe/hipe_gc.c
@@ -237,3 +237,122 @@ void gensweep_nstack(Process *p, Eterm **ptr_old_htop, Eterm **ptr_n_htop)
     }
     abort();
 }
+
+Eterm *sweep_literals_nstack(Process *p, Eterm *old_htop, char *area,
+			     Uint area_size)
+{
+    /* known nstack walk state */
+    Eterm *nsp;
+    Eterm *nsp_end;
+    const struct sdesc *sdesc;
+    /* arch-specific nstack walk state */
+    struct nstack_walk_state walk_state;
+
+    ASSERT(!p->hipe.gc_is_unsafe);
+
+    if (!p->hipe.nstack) {
+	ASSERT(!p->hipe.nsp && !p->hipe.nstend);
+	return old_htop;
+    }
+    if (!nstack_walk_init_check(p))
+	return old_htop;
+
+    ASSERT(p->hipe.nsp && p->hipe.nstend);
+    nsp = nstack_walk_nsp_begin(p);
+    nsp_end = nstack_walk_nsp_end(p);
+    sdesc = nstack_walk_init_sdesc_ignore_trap(p, &walk_state);
+
+    while (!nstack_walk_nsp_reached_end(nsp, nsp_end)) {
+	unsigned long ra;
+	unsigned sdesc_size = nstack_walk_frame_size(sdesc);
+	unsigned i = 0;
+	unsigned mask = sdesc->livebits[0];
+	for (;;) {
+	    if (mask & 1) {
+		Eterm *nsp_i = nstack_walk_frame_index(nsp, i);
+		Eterm gval = *nsp_i;
+		if (is_boxed(gval)) {
+		    Eterm *ptr = boxed_val(gval);
+		    Eterm val = *ptr;
+		    if (IS_MOVED_BOXED(val)) {
+			ASSERT(is_boxed(val));
+			*nsp_i = val;
+		    } else if (ErtsInArea(ptr, area, area_size)) {
+			MOVE_BOXED(ptr, val, old_htop, nsp_i);
+		    }
+		} else if (is_list(gval)) {
+		    Eterm *ptr = list_val(gval);
+		    Eterm val = *ptr;
+		    if (IS_MOVED_CONS(val)) {
+			*nsp_i = ptr[1];
+		    } else if (ErtsInArea(ptr, area, area_size)) {
+			MOVE_CONS(ptr, val, old_htop, nsp_i);
+		    }
+		}
+	    }
+	    if (++i >= sdesc_size)
+		break;
+	    if (i & 31)
+		mask >>= 1;
+	    else
+		mask = sdesc->livebits[i >> 5];
+	}
+	ra = nstack_walk_frame_ra(nsp, sdesc);
+	if (ra == (unsigned long)nbif_stack_trap_ra)
+	    ra = (unsigned long)p->hipe.ngra;
+	sdesc = hipe_find_sdesc(ra);
+	nsp = nstack_walk_next_frame(nsp, sdesc_size);
+    }
+    return old_htop;
+}
+
+int
+nstack_any_heap_ref_ptrs(Process *rp, char* mod_start, Uint mod_size)
+{
+    Eterm *nsp;
+    Eterm *nsp_end;
+    const struct sdesc *sdesc;
+    /* arch-specific nstack walk state */
+    struct nstack_walk_state walk_state;
+
+    ASSERT(!rp->hipe.gc_is_unsafe);
+
+    if (!rp->hipe.nstack || !nstack_walk_init_check(rp)) return 0;
+    ASSERT(rp->hipe.nsp && rp->hipe.nstend);
+    nsp = nstack_walk_nsp_begin(rp);
+    nsp_end = nstack_walk_nsp_end(rp);
+    sdesc = nstack_walk_init_sdesc_ignore_trap(rp, &walk_state);
+
+    while (!nstack_walk_nsp_reached_end(nsp, nsp_end)) {
+	unsigned long ra;
+	unsigned sdesc_size = nstack_walk_frame_size(sdesc);
+	unsigned i = 0;
+	unsigned mask = sdesc->livebits[0];
+	for (;;) {
+	    if (mask & 1) {
+		Eterm *nsp_i = nstack_walk_frame_index(nsp, i);
+		Eterm val = *nsp_i;
+		switch (primary_tag(val)) {
+		case TAG_PRIMARY_BOXED:
+		case TAG_PRIMARY_LIST:
+		    if (ErtsInArea(val, mod_start, mod_size)) {
+			return 1;
+		    }
+		    break;
+		}
+	    }
+	    if (++i >= sdesc_size)
+		break;
+	    if (i & 31)
+		mask >>= 1;
+	    else
+		mask = sdesc->livebits[i >> 5];
+	}
+	ra = nstack_walk_frame_ra(nsp, sdesc);
+	if (ra == (unsigned long)nbif_stack_trap_ra)
+	    ra = (unsigned long)rp->hipe.ngra;
+	sdesc = hipe_find_sdesc(ra);
+	nsp = nstack_walk_next_frame(nsp, sdesc_size);
+    }
+    return 0;
+}

--- a/erts/emulator/hipe/hipe_risc_gc.h
+++ b/erts/emulator/hipe/hipe_risc_gc.h
@@ -51,6 +51,19 @@ nstack_walk_init_sdesc(const Process *p, struct nstack_walk_state *state)
     return sdesc;
 }
 
+static inline const struct sdesc*
+nstack_walk_init_sdesc_ignore_trap(const Process *p,
+				   struct nstack_walk_state *state)
+{
+    unsigned long ra = (unsigned long)p->hipe.nra;
+    const struct sdesc *sdesc;
+    if (ra == (unsigned long)&nbif_stack_trap_ra)
+	ra = (unsigned long)p->hipe.ngra;
+    sdesc = hipe_find_sdesc(ra);
+    state->sdesc0 = sdesc;
+    return sdesc;
+}
+
 static inline void nstack_walk_update_trap(Process *p, const struct sdesc *sdesc0)
 {
     Eterm *nsp = p->hipe.nsp;

--- a/erts/emulator/hipe/hipe_stack.h
+++ b/erts/emulator/hipe/hipe_stack.h
@@ -131,5 +131,8 @@ static __inline__ void hipe_check_nstack(Process *p, unsigned nwords)
  */
 extern Eterm *fullsweep_nstack(Process *p, Eterm *n_htop);
 extern void gensweep_nstack(Process *p, Eterm **ptr_old_htop, Eterm **ptr_n_htop);
+extern Eterm *sweep_literals_nstack(Process *p, Eterm *n_htop, char *area,
+				    Uint area_size);
+extern int nstack_any_heap_ref_ptrs(Process *, char* mod_start, Uint mod_size);
 
 #endif /* HIPE_STACK_H */

--- a/erts/emulator/hipe/hipe_x86_gc.h
+++ b/erts/emulator/hipe/hipe_x86_gc.h
@@ -81,6 +81,23 @@ nstack_walk_init_sdesc(const Process *p, struct nstack_walk_state *state)
 #endif
 }
 
+static inline const struct sdesc*
+nstack_walk_init_sdesc_ignore_trap(const Process *p,
+				   struct nstack_walk_state *state)
+{
+#ifdef SKIP_YOUNGEST_FRAME
+    unsigned long ra = p->hipe.nsp[0];
+    const struct sdesc *sdesc;
+    if (ra == (unsigned long)nbif_stack_trap_ra)
+	ra = (unsigned long)p->hipe.ngra;
+    sdesc = hipe_find_sdesc(ra);
+    state->sdesc0 = sdesc;
+    return sdesc;
+#else
+    return nstack_walk_init_sdesc(p, state);
+#endif
+}
+
 static inline void nstack_walk_update_trap(Process *p, const struct sdesc *sdesc0)
 {
 #ifdef SKIP_YOUNGEST_FRAME

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -70,6 +70,7 @@ MODULES= \
 	guard_SUITE \
 	hash_SUITE \
 	hibernate_SUITE \
+	hipe_SUITE \
 	list_bif_SUITE \
 	lttng_SUITE \
 	map_SUITE \

--- a/erts/emulator/test/hipe_SUITE.erl
+++ b/erts/emulator/test/hipe_SUITE.erl
@@ -1,0 +1,64 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2016. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(hipe_SUITE).
+-export([all/0, t_copy_literals/1]).
+
+all() ->
+    case erlang:system_info(hipe_architecture) of
+	undefined -> {skip, "HiPE is disabled"};
+	_ -> [t_copy_literals]
+    end.
+
+t_copy_literals(doc) ->
+    "Check that BEAM literals referenced from HiPE stack are copied by"
+    " check_process_code";
+t_copy_literals(Config) when is_list(Config) ->
+    %% Compile the the ref_cell and literals modules.
+    Data = proplists:get_value(data_dir, Config),
+    Priv = proplists:get_value(priv_dir, Config),
+    RefFile = filename:join(Data, "ref_cell"),
+    {ok,ref_cell} = c:c(RefFile, [{outdir,Priv},native]),
+    true = code:is_module_native(ref_cell),
+    LitFile = filename:join(Data, "literals"),
+    {ok,literals} = c:c(LitFile, [{outdir,Priv}]),
+
+    %% store references to literals on HiPE stacks
+    PA = ref_cell:start_link(),
+    ref_cell:call(PA, {put_res_of, fun literals:a/0}),
+    PB = ref_cell:start_link_deep(),
+    ref_cell:call(PB, {put_res_of, fun literals:b/0}),
+
+    %% purge the literals
+    _ = (catch erlang:purge_module(literals)),
+    true = erlang:delete_module(literals),
+    true = erlang:purge_module(literals),
+
+    %% check that the ex-literals are ok
+    [a,b,c] = ref_cell:call(PA, get),
+    {a,b,c} = ref_cell:call(PB, get),
+
+    %% cleanup
+    ref_cell:call(PA, done),
+    ref_cell:call(PB, done),
+    _ = (catch erlang:purge_module(ref_cell)),
+    true = erlang:delete_module(ref_cell),
+    true = erlang:purge_module(ref_cell),
+    ok.

--- a/erts/emulator/test/hipe_SUITE_data/literals.erl
+++ b/erts/emulator/test/hipe_SUITE_data/literals.erl
@@ -1,0 +1,26 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2016. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(literals).
+
+-export([a/0, b/0]).
+
+a() -> [a,b,c].
+b() -> {a,b,c}.

--- a/erts/emulator/test/hipe_SUITE_data/ref_cell.erl
+++ b/erts/emulator/test/hipe_SUITE_data/ref_cell.erl
@@ -1,0 +1,64 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2016. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(ref_cell).
+
+-export([start_link/0, start_link_deep/0, call/2]).
+
+-compile(native).
+
+-define(DEPTH, 100).
+-define(ALLOCS, 500).
+
+start_link() ->
+    spawn_link(fun() -> loop(undefined) end).
+
+start_link_deep() ->
+    spawn_link(fun() -> go_deep(?DEPTH) end).
+
+%% Create a stack large enough to get a graylimit trap placed next time there's
+%% a minor gc.
+go_deep(0) ->
+    alloc_some(?ALLOCS),
+    loop(undefined),
+    0;
+go_deep(Depth) ->
+    go_deep(Depth-1)+1.
+
+%% Do some allocation to trigger a minor gc
+alloc_some(Amount) ->
+    Check = (Amount * (Amount + 1)) div 2,
+    Check = lists:sum(lists:seq(1, Amount)).
+
+call(Pid, Call) ->
+    Pid ! {Call, self()},
+    receive {Pid, Res} -> Res end.
+
+loop(Thing) ->
+    receive
+	{done, Pid} -> Pid ! {self(), done};
+	{{put_res_of, Fun}, Pid} ->
+	    NewThing = Fun(),
+	    Pid ! {self(), put},
+	    loop(NewThing);
+	{get, Pid} ->
+	    Pid ! {self(), Thing},
+	    loop(Thing)
+    end.


### PR DESCRIPTION
Because `check_process_code` neglected checking the HiPE stack for
references to the literal area, such references would survive the purge
and subsequent deletion of a module and its literal area. These dangling
references would then cause incorrect behaviour or even hard crashes of
the VM.

By simply adding a scan of the HiPE stack to `check_process_code` and
`erts_garbage_collect_literals`, this problem is fixed.

In order to support full stack walks without deleting the graylimit
trap, a new stack walking interface function,
`nstack_walk_init_sdesc_ignore_trap()` was introduced.

A new test suite for the emulator, `hipe_SUITE`, was introduced to hold the
test for this issue, as it does not really belong in the HiPE application.