### PR TITLE
Fix infinite loop in merl_transform

### DIFF
--- a/lib/syntax_tools/src/merl_tests.erl
+++ b/lib/syntax_tools/src/merl_tests.erl
@@ -48,6 +48,21 @@ parse_error_test_() ->
                    f(merl:quote("{")))
     ].
 
+transform_parse_error_test_() ->
+    [?_assertEqual("merl:quote(\"{\")",
+                   f(merl_transform:parse_transform(
+                       [?Q("merl:quote(\"{\")")], []))),
+     ?_assertEqual("merl:quote(2, \"{\")",
+                   f(merl_transform:parse_transform(
+                       [?Q("merl:quote(2, \"{\")")], []))),
+     ?_assertEqual("merl:qquote(\"{\", [{var, V}])",
+                   f(merl_transform:parse_transform(
+                       [?Q("merl:qquote(\"{\", [{var, V}])")], []))),
+     ?_assertEqual("merl:qquote(2, \"{\", [{var, V}])",
+                   f(merl_transform:parse_transform(
+                       [?Q("merl:qquote(2, \"{\", [{var, V}])")], [])))
+    ].
+
 term_test_() ->
     [?_assertEqual(tuple, erl_syntax:type(merl:term({}))),
      ?_assertEqual("{foo, 42}", f(merl:term({foo, 42})))

--- a/lib/syntax_tools/src/merl_transform.erl
+++ b/lib/syntax_tools/src/merl_transform.erl
@@ -104,10 +104,15 @@ expand_qquote([Text, Env], T, Line) ->
     case erl_syntax:is_literal(Text) of
         true ->
             As = [Line, erl_syntax:concrete(Text)],
-            %% expand further if possible
-            expand(merl:qquote(Line, "merl:subst(_@tree, _@env)",
-                               [{tree, eval_call(Line, quote, As, T)},
-                                {env, Env}]));
+            case eval_call(Line, quote, As, failed) of
+                failed ->
+                    T;
+                T1 ->
+                    %% expand further if possible
+                    expand(merl:qquote(Line, "merl:subst(_@tree, _@env)",
+                                       [{tree, T1},
+                                        {env, Env}]))
+            end;
         false ->
             T
     end;

--- a/lib/syntax_tools/test/merl_SUITE.erl
+++ b/lib/syntax_tools/test/merl_SUITE.erl
@@ -29,12 +29,14 @@
 	 init_per_group/2,end_per_group/2]).
 
 %% Test cases
--export([merl_smoke_test/1]).
+-export([merl_smoke_test/1,
+         transform_parse_error_test/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
-    [merl_smoke_test].
+    [merl_smoke_test,
+     transform_parse_error_test].
 
 groups() -> 
     [].
@@ -82,6 +84,21 @@ merl_smoke_test(Config) when is_list(Config) ->
                            ?Q("{foo, _@Bar, '@Baz'}") -> ?Q("{_@Bar, _@Baz}")
                        end
                    end)),
+    ok.
+
+transform_parse_error_test(_Config) ->
+    ?assertEqual("merl:quote(\"{\")",
+                 f(merl_transform:parse_transform(
+                     [?Q("merl:quote(\"{\")")], []))),
+    ?assertEqual("merl:quote(2, \"{\")",
+                 f(merl_transform:parse_transform(
+                     [?Q("merl:quote(2, \"{\")")], []))),
+    ?assertEqual("merl:qquote(\"{\", [{var, V}])",
+                 f(merl_transform:parse_transform(
+                     [?Q("merl:qquote(\"{\", [{var, V}])")], []))),
+    ?assertEqual("merl:qquote(2, \"{\", [{var, V}])",
+                 f(merl_transform:parse_transform(
+                     [?Q("merl:qquote(2, \"{\", [{var, V}])")], []))),
     ok.
 
 %% utilities


### PR DESCRIPTION
This can happen when a syntactically incorrect text is passed to a
merl:qquote/2,/3 call.

The parse transform optimizes calls to some functions in merl by
converting strings into templates at compile time. If this evaluation
fails (in eval_call/4 - for example because of a sytanx error in the
parsed text) the original function call should be kept unchanged.
However in case of qquote/3 the call is converted into a combination of
quote/2 and subst/2, but upon failure the original qquote/3 call is
substituted into the wrong place. E.g.:

this expression
  `merl:qquote(Pos, Text, Env)`

is first converted to
  `merl:subst(merl:quote(Pos, Text), Env)`

then if evaluating the quote call fails into
  `merl:subst(merl:qquote(Pos, Text, Env), Env)`

and the expansion is run again on the internal qquote/3 argument
resulting in an infinite loop.

This is now fixed so in case of failure the original qquote/3 call is kept.

I was not sure where to put the tests so I added the same cases to both the ct suite and the eunit module.