### PR TITLE
Fix code_server crash when adding some code paths ERL-194

### DIFF
--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -933,14 +933,20 @@ del_ebin(Dir) ->
     filename:join(del_ebin_1(filename:split(Dir))).
 
 del_ebin_1([Parent,App,"ebin"]) ->
-    Ext = archive_extension(),
-    case filename:basename(Parent, Ext) of
-	Parent ->
-	    %% Plain directory.
+    case filename:basename(Parent) of
+	[] ->
+	    %% Parent is the root directory
 	    [Parent,App];
-	Archive ->
-	    %% Archive.
-	    [Archive]
+	_ ->
+	    Ext = archive_extension(),
+	    case filename:basename(Parent, Ext) of
+		Parent ->
+		    %% Plain directory.
+		    [Parent,App];
+		Archive ->
+		    %% Archive.
+		    [Archive]
+	    end
     end;
 del_ebin_1([H|T]) ->
     [H|del_ebin_1(T)];


### PR DESCRIPTION
Fix the problem when adding code paths hanging from root like "/myproject/ebin".
Fix [ERL-194](https://bugs.erlang.org/browse/ERL-194)