### PR TITLE
Respect -proto_dist switch while connecting to/registering at EPMD

### DIFF
--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -103,6 +103,10 @@ names(EpmdAddr) ->
 
 register_node(Name, PortNo) ->
     register_node(Name, PortNo, inet).
+register_node(Name, PortNo, inet_tcp) ->
+    register_node(Name, PortNo, inet);
+register_node(Name, PortNo, inet6_tcp) ->
+    register_node(Name, PortNo, inet6);
 register_node(Name, PortNo, Family) ->
     gen_server:call(erl_epmd, {register, Name, PortNo, Family}, infinity).
 

--- a/lib/kernel/src/inet_tcp_dist.erl
+++ b/lib/kernel/src/inet_tcp_dist.erl
@@ -74,7 +74,7 @@ gen_listen(Driver, Name) ->
 	    TcpAddress = get_tcp_address(Driver, Socket),
 	    {_,Port} = TcpAddress#net_address.address,
 	    ErlEpmd = net_kernel:epmd_module(),
-	    case ErlEpmd:register_node(Name, Port) of
+	    case ErlEpmd:register_node(Name, Port, Driver) of
 		{ok, Creation} ->
 		    {ok, {Socket, TcpAddress, Creation}};
 		Error ->

--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -117,7 +117,7 @@ handle_call({listen, Driver, Name}, _From, State) ->
 	    {ok, WorldTcpAddress} = get_tcp_address(World),
 	    {_,Port} = WorldTcpAddress#net_address.address,
 	    ErlEpmd = net_kernel:epmd_module(),
-	    case ErlEpmd:register_node(Name, Port) of
+	    case ErlEpmd:register_node(Name, Port, Driver) of
 		{ok, Creation} ->
 		    {reply, {ok, {Socket, TcpAddress, Creation}},
 		     State#state{listen={Socket, World}}};


### PR DESCRIPTION
it seems that despite of setting up address family value (inet6_tcp, inet_tcp), inet_tcp_dist always uses basic erl_epmd:register_node/2 which uses 'inet' family. Let's fix that.

With this patch inet_tcp_dist  will try using inet6 loopback address if a user adds "-proto_dist inet6_tcp" command line switch. This allows Erlang distribution to work if IPv4 loopback was disabled in EPMD.

See also PR #1075.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>