### PR TITLE
erlang-mode: do not configure require-final-newline

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -1514,8 +1514,6 @@ Other commands:
   (setq paragraph-separate paragraph-start)
   (make-local-variable 'paragraph-ignore-fill-prefix)
   (setq paragraph-ignore-fill-prefix t)
-  (make-local-variable 'require-final-newline)
-  (setq require-final-newline t)
   (make-local-variable 'defun-prompt-regexp)
   (setq defun-prompt-regexp erlang-defun-prompt-regexp)
   (make-local-variable 'comment-start)


### PR DESCRIPTION
Erlang source files do not require a final newline. Thus,
require-final-newline is a personal setting and should not be configured
in the major mode. Setting it here will also negatively impact helpers
like ethan-wspace.