### PR TITLE
Move expansion of strings in binaries to v3_core

### DIFF
--- a/lib/compiler/src/sys_pre_expand.erl
+++ b/lib/compiler/src/sys_pre_expand.erl
@@ -520,9 +520,8 @@ new_fun_name(#expand{func=F,arity=A,fcount=I}=St, FName) ->
 
 %% pattern_bin([Element], State) -> {[Element],[Variable],[UsedVar],State}.
 
-pattern_bin(Es0, St) ->
-    Es1 = bin_expand_strings(Es0),
-    foldr(fun (E, Acc) -> pattern_element(E, Acc) end, {[],St}, Es1).
+pattern_bin(Es, St) ->
+    foldr(fun (E, Acc) -> pattern_element(E, Acc) end, {[],St}, Es).
 
 pattern_element({bin_element,Line,Expr0,Size0,Type0}, {Es,St0}) ->
     {Expr1,St1} = pattern(Expr0, St0),
@@ -558,9 +557,8 @@ coerce_to_float(E, _) -> E.
     
 %% expr_bin([Element], State) -> {[Element],State}.
 
-expr_bin(Es0, St) ->
-    Es1 = bin_expand_strings(Es0),
-    foldr(fun (E, Acc) -> bin_element(E, Acc) end, {[],St}, Es1).
+expr_bin(Es, St) ->
+    foldr(fun (E, Acc) -> bin_element(E, Acc) end, {[],St}, Es).
 
 bin_element({bin_element,Line,Expr,Size,Type}, {Es,St0}) ->
     {Expr1,St1} = expr(Expr, St0),
@@ -569,14 +567,6 @@ bin_element({bin_element,Line,Expr,Size,Type}, {Es,St0}) ->
                           end,
     {Size2,Type1} = make_bit_type(Line, Size1, Type),
     {[{bin_element,Line,Expr1,Size2,Type1}|Es],St2}.
-
-bin_expand_strings(Es) ->
-    foldr(fun ({bin_element,Line,{string,_,S},Sz,Ts}, Es1) ->
-                  foldr(fun (C, Es2) ->
-                                [{bin_element,Line,{char,Line,C},Sz,Ts}|Es2]
-                        end, Es1, S);
-              (E, Es1) -> [E|Es1]
-          end, [], Es).
 
 %% new_var_name(State) -> {VarName,State}.
 

--- a/lib/compiler/test/bs_bincomp_SUITE.erl
+++ b/lib/compiler/test/bs_bincomp_SUITE.erl
@@ -56,6 +56,7 @@ end_per_group(_GroupName, Config) ->
 byte_aligned(Config) when is_list(Config) ->
     cs_init(),
     <<"abcdefg">> = cs(<< <<(X+32)>> || <<X>> <= <<"ABCDEFG">> >>),
+    <<"AxyzBxyzCxyz">> = cs(<< <<X, "xyz">> || <<X>> <= <<"ABC">> >>),
     <<1:32/little,2:32/little,3:32/little,4:32/little>> =
 	cs(<< <<X:32/little>> || <<X:32>> <= <<1:32,2:32,3:32,4:32>> >>),
     cs(<<1:32/little,2:32/little,3:32/little,4:32/little>> =

--- a/lib/compiler/test/bs_utf_SUITE.erl
+++ b/lib/compiler/test/bs_utf_SUITE.erl
@@ -235,6 +235,7 @@ utf32_to_unicode(<<>>) -> [].
 literals(Config) when is_list(Config) ->
     abc_utf8 = match_literal(<<"abc"/utf8>>),
     abc_utf8 = match_literal(<<$a,$b,$c>>),
+    abc_utf8 = match_literal(<<$a/utf8,$b/utf8,$c/utf8>>),
 
     abc_utf16be = match_literal(<<"abc"/utf16>>),
     abc_utf16be = match_literal(<<$a:16,$b:16,$c:16>>),

--- a/lib/debugger/test/bs_bincomp_SUITE.erl
+++ b/lib/debugger/test/bs_bincomp_SUITE.erl
@@ -66,6 +66,7 @@ end_per_group(_GroupName, Config) ->
 
 byte_aligned(Config) when is_list(Config) ->
     <<"abcdefg">> = << <<(X+32)>> || <<X>> <= <<"ABCDEFG">> >>,
+    <<"AxyzBxyzCxyz">> = << <<X, "xyz">> || <<X>> <= <<"ABC">> >>,
     <<1:32/little,2:32/little,3:32/little,4:32/little>> =
 	<< <<X:32/little>> || <<X:32>> <= <<1:32,2:32,3:32,4:32>> >>,
     <<1:32/little,2:32/little,3:32/little,4:32/little>> =


### PR DESCRIPTION
This speeds up the compilation of binary literals
with string values in them. For example, compiling
a file with a ~340kB binary would yield the following
times by the compiler:

    Compiling "foo"
     parse_module       :   0.130 s    5327.6 kB
     transform_module   :   0.000 s    5327.6 kB
     lint_module        :   0.011 s    5327.8 kB
     expand_module      :   0.508 s   71881.2 kB
     v3_core            :   0.463 s      11.5 kB

Notice the increase in memory and processing time
in expand_module and v3_core. This happened because
expand_module would expand the string in binaries
into chars. For example, the binary <<"foo">>, which
is represented as

    {bin, 1, [
      {bin_element, 1, {string, 1, "foo"}, default, default}
    ]}

would be converted to

    {bin, 1, [
      {bin_element, 1, {char, 1, $f}, default, default},
      {bin_element, 1, {char, 1, $o}, default, default},
      {bin_element, 1, {char, 1, $o}, default, default}
    ]}

However, v3_core would then traverse all of those
characters and convert it into an actual binary, as it
is a literal value.

This patch addresses this issue by moving the expansion
of string into chars to v3_core and only if a literal
value cannot not be built. This reduces the compilation
time of the file mentioned above to the values below:

    Compiling "bar"
     parse_module       :   0.134 s    5327.6 kB
     transform_module   :   0.000 s    5327.6 kB
     lint_module        :   0.005 s    5327.8 kB
     expand_module      :   0.000 s    5328.7 kB
     v3_core            :   0.013 s      11.2 kB