### PR TITLE
Fix httpd_conf:validate_properties/1 for ipfamily

### DIFF
--- a/lib/inets/src/http_server/httpd_conf.erl
+++ b/lib/inets/src/http_server/httpd_conf.erl
@@ -395,7 +395,8 @@ validate_properties(Properties) ->
 %% That is, if property A depends on property B.
 %% The only sunch preperty at this time is bind_address that depends 
 %% on ipfamily.
-validate_properties2(Properties) ->
+validate_properties2(Properties0) ->
+    Properties = fix_ipfamily(Properties0),
     case proplists:get_value(bind_address, Properties) of
 	undefined ->
 	    case proplists:get_value(sock_type, Properties, ip_comm) of
@@ -420,6 +421,15 @@ validate_properties2(Properties) ->
 			      Address0, IpFamily, Reason}}, 
 		    throw(Error)
 	    end
+    end.
+
+fix_ipfamily(Properties) ->
+    case proplists:get_value(ipfamily, Properties) of
+	undefined ->
+	    Properties;
+	IpFamily ->
+	    NewProps = proplists:delete(ipfamily, Properties),
+	    [{ipfamily, validate_ipfamily(IpFamily)} | NewProps]
     end.
 
 add_inet_defaults(Properties) ->


### PR DESCRIPTION
`inets:start/2` fails when using the legacy option `inet6fb4` with a configuration proplist. It is not translated to `inet` [as documented](http://erlang.org/doc/man/httpd.html).


    {ipfamily, inet | inet6}
        Default is inet, legacy option inet6fb4 no longer makes sense
        and will be translated to inet.

This breaks existing code that relies on the documented behavior.

This commit fixes the issue by translating `inet6fb4` everywhere it is encountered in `httpd_conf:validate_properties/1`. This fixes JIRA issue ERL-200.