### PR TITLE
gen_statem Auto Callback Mode (OTP-13752)

### DIFF
--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -374,14 +374,12 @@ init_connection_handler(Role, Socket, Opts) ->
 	S ->
 	    gen_statem:enter_loop(?MODULE,
 				  [], %%[{debug,[trace,log,statistics,debug]} || Role==server],
-				  handle_event_function,
 				  {hello,Role},
 				  S)
     catch
 	_:Error ->
 	    gen_statem:enter_loop(?MODULE,
 				  [],
-				  handle_event_function,
 				  {init_error,Error},
 				  S0)
     end.
@@ -1401,12 +1399,12 @@ fmt_stat_rec(FieldNames, Rec, Exclude) ->
 		  state_name(),
 		  #data{},
 		  term()
-		 ) -> {gen_statem:callback_mode(), state_name(), #data{}}.
+		 ) -> {ok, state_name(), #data{}}.
 
 %% . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 code_change(_OldVsn, StateName, State, _Extra) ->
-    {handle_event_function, StateName, State}.
+    {ok, StateName, State}.
 
 
 %%====================================================================

--- a/lib/ssl/src/dtls_connection.erl
+++ b/lib/ssl/src/dtls_connection.erl
@@ -67,8 +67,6 @@
 %% gen_statem callbacks
 -export([terminate/3, code_change/4, format_status/2]).
 
--define(GEN_STATEM_CB_MODE, state_functions).
-
 %%====================================================================
 %% Internal application API
 %%====================================================================	     
@@ -161,10 +159,10 @@ init([Role, Host, Port, Socket, Options,  User, CbInfo]) ->
     State0 =  initial_state(Role, Host, Port, Socket, Options, User, CbInfo),
     try
 	State = ssl_connection:ssl_config(State0#state.ssl_options, Role, State0),
-	gen_statem:enter_loop(?MODULE, [], ?GEN_STATEM_CB_MODE, init, State)
+	gen_statem:enter_loop(?MODULE, [], init, State)
     catch
 	throw:Error ->
-	    gen_statem:enter_loop(?MODULE, [], ?GEN_STATEM_CB_MODE, error, {Error,State0})
+	    gen_statem:enter_loop(?MODULE, [], error, {Error,State0})
     end.
 
 %%--------------------------------------------------------------------
@@ -376,7 +374,7 @@ terminate(Reason, StateName, State) ->
 %% Description: Convert process state when code is changed
 %%--------------------------------------------------------------------
 code_change(_OldVsn, StateName, State, _Extra) ->
-    {?GEN_STATEM_CB_MODE, StateName, State}.
+    {ok, StateName, State}.
 
 format_status(Type, Data) ->
     ssl_connection:format_status(Type, Data).

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -70,8 +70,6 @@
 %% gen_statem callbacks
 -export([terminate/3, code_change/4, format_status/2]).
  
--define(GEN_STATEM_CB_MODE, state_functions).
-
 %%====================================================================
 %% Internal application API
 %%====================================================================	     
@@ -169,9 +167,9 @@ init([Role, Host, Port, Socket, Options,  User, CbInfo]) ->
     State0 = initial_state(Role, Host, Port, Socket, Options, User, CbInfo),
     try 
 	State = ssl_connection:ssl_config(State0#state.ssl_options, Role, State0),
-	gen_statem:enter_loop(?MODULE, [], ?GEN_STATEM_CB_MODE, init, State)
+	gen_statem:enter_loop(?MODULE, [], init, State)
     catch throw:Error ->
-	gen_statem:enter_loop(?MODULE, [], ?GEN_STATEM_CB_MODE, error, {Error, State0}) 
+	gen_statem:enter_loop(?MODULE, [], error, {Error, State0}) 
     end.
 
 %%--------------------------------------------------------------------
@@ -457,9 +455,9 @@ format_status(Type, Data) ->
 %%--------------------------------------------------------------------
 code_change(_OldVsn, StateName, State0, {Direction, From, To}) ->
     State = convert_state(State0, Direction, From, To),
-    {?GEN_STATEM_CB_MODE, StateName, State};
+    {ok, StateName, State};
 code_change(_OldVsn, StateName, State, _) ->
-    {?GEN_STATEM_CB_MODE, StateName, State}.
+    {ok, StateName, State}.
 
 %%--------------------------------------------------------------------
 %%% Internal functions

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -32,24 +32,27 @@
   <modulesummary>Generic state machine behavior.</modulesummary>
   <description>
     <p>
-      This behavior module provides a state machine. Two
-      <seealso marker="#type-callback_mode"><em>callback modes</em></seealso>
-      are supported:
+      This behavior module provides a state machine.
+      Two callback flavours are supported:
     </p>
-    <list type="bulleted">
+    <taglist>
+      <tag>State Name Functions</tag>
       <item>
-        <p>One for finite-state machines
+        <p>
+	  For finite-state machines
           (<seealso marker="gen_fsm"><c>gen_fsm</c></seealso> like),
           which requires the state to be an atom and uses that state as
           the name of the current callback function
         </p>
       </item>
+      <tag>One State Function</tag>
       <item>
-        <p>One without restriction on the state data type
-          that uses one callback function for all states
+        <p>
+	  Without restriction on the state data type.
+          One callback function is used for all states.
         </p>
       </item>
-    </list>
+    </taglist>
     <note>
       <p>
         This is a new behavior in Erlang/OTP 19.0.
@@ -122,34 +125,41 @@ erlang:'!'            -----> Module:StateName/3
     </p>
     <marker id="state_function"/>
     <p>
-      The "<em>state function</em>" for a specific
+      The <em>state function</em> for a specific
       <seealso marker="#type-state">state</seealso>
       in a <c>gen_statem</c> is the callback function that is called
-      for all events in this state. It is selected depending on which
-      <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-      that the implementation specifies when the server starts.
+      for all events in this state. It is selected depending on if
+      <seealso marker="#Module:handle_event/4">
+	<c>Module:handle_event/4</c>
+      </seealso>
+      is exported.  This is checked once before the first state function
+      is called after server start and once after a
+      <seealso marker="#Module:code_change/4"><c>code change</c></seealso>.
     </p>
     <p>
-      When the
-      <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-      is <c>state_functions</c>, the state must be an atom and
+      When
+      <seealso marker="#Module:handle_event/4">
+	<c>Module:handle_event/4</c>
+      </seealso>
+      <em>is not</em> exported, the state must be an atom and
       is used as the state function name; see
       <seealso marker="#Module:StateName/3"><c>Module:StateName/3</c></seealso>.
       This gathers all code for a specific state
       in one function as the <c>gen_statem</c> engine
       branches depending on state name.
-      Notice that in this mode the mandatory callback function
+      Notice that in this case the mandatory callback function
       <seealso marker="#Module:terminate/3"><c>Module:terminate/3</c></seealso>
-      makes the state name <c>terminate</c> unusable.
+      renders the state name <c>terminate</c> unusable.
     </p>
     <p>
-      When the
-      <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-      is <c>handle_event_function</c>, the state can be any term
-      and the state function name is
-      <seealso marker="#Module:handle_event/4"><c>Module:handle_event/4</c></seealso>.
+      When
+      <seealso marker="#Module:handle_event/4">
+	<c>Module:handle_event/4</c>
+      </seealso>
+      <em>is</em> exported it is used as the one state function
+      and the state can be any term.
       This makes it easy to branch depending on state or event as you desire.
-      Be careful about which events you handle in which
+      Be careful though, about which events you handle in which
       states so that you do not accidentally postpone an event
       forever creating an infinite busy loop.
     </p>
@@ -235,9 +245,8 @@ erlang:'!'            -----> Module:StateName/3
     <title>Example</title>
     <p>
       The following example shows a simple pushbutton model
-      for a toggling pushbutton implemented with
-      <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-      <c>state_functions</c>.
+      for a toggling pushbutton
+      implemented with <em>state name functions</em>.
       You can push the button and it replies if it went on or off,
       and you can ask for a count of how many times it has been
       pushed to switch on.
@@ -253,7 +262,6 @@ erlang:'!'            -----> Module:StateName/3
 -export([on/3,off/3]).
 
 name() -> pushbutton_statem. % The registered server name
-callback_mode() -> state_functions.
 
 %% API.  This example uses a registered name name()
 %% and does not link to the caller.
@@ -270,12 +278,12 @@ stop() ->
 terminate(_Reason, _State, _Data) ->
     void.
 code_change(_Vsn, State, Data, _Extra) ->
-    {callback_mode(),State,Data}.
+    {ok,State,Data}.
 init([]) ->
-    %% Set the callback mode and initial state + data.
+    %% Set initial state + data.
     %% Data is used only as a counter.
     State = off, Data = 0,
-    {callback_mode(),State,Data}.
+    {ok,State,Data}.
 
 
 %%% State functions
@@ -324,19 +332,14 @@ ok
     </pre>
     <p>
       To compare styles, here follows the same example using
-      <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-      <c>state_functions</c>, or rather the code to replace
-      from function <c>init/1</c> of the <c>pushbutton.erl</c>
-      example file above:
+      <em>one state function</em>, or rather the code to
+      replace the state function exports and definitions with
+      in the <c>pushbutton.erl</c> example file above:
     </p>
     <code type="erl">
-init([]) ->
-    %% Set the callback mode and initial state + data.
-    %% Data is used only as a counter.
-    State = off, Data = 0,
-    {handle_event_function,State,Data}.
-
-
+-export([handle_event/4]).
+    </code>
+    <code type="erl">
 %%% Event handling
 
 handle_event({call,From}, push, off, Data) ->
@@ -480,10 +483,11 @@ handle_event(_, _, State, Data) ->
       <name name="state_name"/>
       <desc>
 	<p>
-	  If the
-	  <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-	  is <c>state_functions</c>,
-	  the state must be of this type.
+	  If the callback function
+	  <seealso marker="#Module:handle_event/4">
+	    <c>Module:handle_event/4</c>
+	  </seealso>
+	  is exported the state must be of this type.
 	</p>
       </desc>
     </datatype>
@@ -518,40 +522,6 @@ handle_event(_, _, State, Data) ->
 	  implementation can generate events of types
 	  <c>timeout</c> and <c>internal</c> to itself.
 	</p>
-      </desc>
-    </datatype>
-    <datatype>
-      <name name="callback_mode"/>
-      <desc>
-	<p>
-	  The <em>callback mode</em> is selected when starting the
-	  <c>gen_statem</c> using the return value from
-	  <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>
-	  or when calling
-	  <seealso marker="#enter_loop/5"><c>enter_loop/5,6,7</c></seealso>,
-	  and with the return value from
-	  <seealso marker="#Module:code_change/4"><c>Module:code_change/4</c></seealso>.
-	</p>
-	<taglist>
-	  <tag><c>state_functions</c></tag>
-	  <item>
-	    <p>
-	      The state must be of type
-	      <seealso marker="#type-state_name"><c>state_name()</c></seealso>
-	      and one callback function per state, that is,
-	      <seealso marker="#Module:StateName/3"><c>Module:StateName/3</c></seealso>,
-	      is used.
-	    </p>
-	  </item>
-	  <tag><c>handle_event_function</c></tag>
-	  <item>
-	    <p>
-	      The state can be any term and the callback function
-	      <seealso marker="#Module:handle_event/4"><c>Module:handle_event/4</c></seealso>
-	      is used for all states.
-	    </p>
-	  </item>
-	</taglist>
       </desc>
     </datatype>
     <datatype>
@@ -958,7 +928,7 @@ handle_event(_, _, State, Data) ->
     </func>
 
     <func>
-      <name name="enter_loop" arity="5"/>
+      <name name="enter_loop" arity="4"/>
       <fsummary>Enter the <c>gen_statem</c> receive loop.</fsummary>
       <desc>
 	<p>
@@ -972,7 +942,7 @@ handle_event(_, _, State, Data) ->
     </func>
 
     <func>
-      <name name="enter_loop" arity="6"/>
+      <name name="enter_loop" arity="5"/>
       <fsummary>Enter the <c>gen_statem</c> receive loop.</fsummary>
       <desc>
 	<p>
@@ -986,7 +956,7 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>
 	  Otherwise the same as
-	  <seealso marker="#enter_loop/7"><c>enter_loop/7</c></seealso>
+	  <seealso marker="#enter_loop/6"><c>enter_loop/7</c></seealso>
 	  with
 	  <c>Server = <anno>Server_or_Actions</anno></c> and
 	  <c>Actions = []</c>.
@@ -995,7 +965,7 @@ handle_event(_, _, State, Data) ->
     </func>
 
     <func>
-      <name name="enter_loop" arity="7"/>
+      <name name="enter_loop" arity="6"/>
       <fsummary>Enter the <c>gen_statem</c> receive loop.</fsummary>
       <desc>
 	<p>
@@ -1024,7 +994,7 @@ handle_event(_, _, State, Data) ->
 	  name must have been registered accordingly
 	  <em>before</em> this function is called.</p>
         <p>
-	  <c><anno>CallbackMode</anno></c>, <c><anno>State</anno></c>,
+	  <c><anno>State</anno></c>,
 	  <c><anno>Data</anno></c>, and <c><anno>Actions</anno></c>
 	  have the same meanings as in the return value of
 	  <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>.
@@ -1262,11 +1232,7 @@ handle_event(_, _, State, Data) ->
         <v>&nbsp;&nbsp;Vsn = term()</v>
         <v>OldState = NewState = term()</v>
         <v>Extra = term()</v>
-	<v>Result = {CallbackMode,NewState,NewData} | Reason</v>
-	<v>
-	  CallbackMode =
-	  <seealso marker="#type-callback_mode">callback_mode()</seealso>
-	</v>
+	<v>Result = {ok,NewState,NewData} | Reason</v>
 	<v>
 	  OldState = NewState =
 	  <seealso marker="#type-state">state()</seealso>
@@ -1295,21 +1261,6 @@ handle_event(_, _, State, Data) ->
 	  <c>Module</c>. If no such attribute is defined, the version
 	  is the checksum of the Beam file.
 	</p>
-	<note>
-	  <p>
-	    If you would dare to change
-	    <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-	    during release upgrade/downgrade, the upgrade is no problem,
-	    as the new code surely knows what <em>callback mode</em>
-	    it needs. However, for a downgrade this function must
-	    know from argument <c>Extra</c> that comes from the
-	    <seealso marker="sasl:appup"><c>sasl:appup</c></seealso>
-	    file what <em>callback mode</em> the old code did use.
-	    It can also be possible to figure this out
-	    from argument <c>{down,Vsn}</c>, as <c>Vsn</c>
-	    in effect defines the old callback module version.
-	  </p>
-	</note>
         <p>
 	  <c>OldState</c> and <c>OldData</c> is the internal state
 	  of the <c>gen_statem</c>.
@@ -1320,17 +1271,16 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>
 	  If successful, the function must return the updated
-	  internal state in an
-	  <c>{CallbackMode,NewState,NewData}</c> tuple.
+	  internal state in an <c>{ok,NewState,NewData}</c> tuple.
 	</p>
 	<p>
 	  If the function returns a failure <c>Reason</c>, the ongoing
 	  upgrade fails and rolls back to the old release.
-	  Note that <c>Reason</c> can not be a 3-tuple since that
-	  will be regarded as a
-	  <c>{CallbackMode,NewState,NewData}</c> tuple,
+	  Note that <c>Reason</c> can not be an <c>{ok,_,_}</c> tuple
+	  since that will be regarded as an
+	  <c>{ok,NewState,NewData}</c> tuple,
 	  and that a tuple matching <c>{ok,_}</c>
-	  is an invalid failure <c>Reason</c>.
+	  is also an invalid failure <c>Reason</c>.
 	  It is recommended to use an atom as <c>Reason</c> since
 	  it will be wrapped in an <c>{error,Reason}</c> tuple.
 	</p>
@@ -1347,13 +1297,9 @@ handle_event(_, _, State, Data) ->
       <fsummary>Initialize process and internal state.</fsummary>
       <type>
         <v>Args = term()</v>
-        <v>Result = {CallbackMode,State,Data}</v>
-	<v>&nbsp;| {CallbackMode,State,Data,Actions}</v>
+        <v>Result = {ok,State,Data}</v>
+	<v>&nbsp;| {ok,State,Data,Actions}</v>
         <v>&nbsp;| {stop,Reason} | ignore</v>
-	<v>
-	  CallbackMode =
-	  <seealso marker="#type-callback_mode">callback_mode()</seealso>
-	</v>
 	<v>State = <seealso marker="#type-state">state()</seealso></v>
 	<v>
 	  Data = <seealso marker="#type-data">data()</seealso>
@@ -1381,11 +1327,8 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>
 	  If the initialization is successful, the function is to
-	  return <c>{CallbackMode,State,Data}</c> or
-	  <c>{CallbackMode,State,Data,Actions}</c>.
-	  <c>CallbackMode</c> selects the
-	  <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-	  of the <c>gen_statem</c>.
+	  return <c>{ok,State,Data}</c> or
+	  <c>{ok,State,Data,Actions}</c>.
 	  <c>State</c> is the initial
 	  <seealso marker="#type-state"><c>state()</c></seealso>
 	  and <c>Data</c> the initial server
@@ -1546,11 +1489,15 @@ handle_event(_, _, State, Data) ->
 	  Whenever a <c>gen_statem</c> receives an event from
 	  <seealso marker="#call/2"><c>call/2</c></seealso>,
 	  <seealso marker="#cast/2"><c>cast/2</c></seealso>, or
-	  as a normal process message, one of these functions is called. If
-	  <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-	  is <c>state_functions</c>, <c>Module:StateName/3</c> is called,
-	  and if it is <c>handle_event_function</c>,
-	  <c>Module:handle_event/4</c> is called.
+	  as a normal process message, one of these functions is called.
+	  If <c>Module:handle_event/4</c> is exported it is called
+	  with the current <c>State</c> as an argument.
+	  Otherwise <c>Module:StateName/3</c> is called where
+	  <c>StateName = State</c> but must be an atom.
+	  If no function is exported for a particular <c>StateName</c>,
+	  for example if <c>State</c> is not an atom,
+	  the <c>gen_statem</c> terminates with an error
+	  pinpointing the undefined state function.
 	</p>
 	<p>
 	  If <c>EventType</c> is

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -47,6 +47,7 @@ MODULES= \
 	gen_fsm_SUITE \
 	gen_server_SUITE \
 	gen_statem_SUITE \
+	gen_statem_SUITE_handle_event \
 	id_transform_SUITE \
 	io_SUITE \
 	io_proto_SUITE \

--- a/lib/stdlib/test/gen_statem_SUITE_handle_event.erl
+++ b/lib/stdlib/test/gen_statem_SUITE_handle_event.erl
@@ -1,0 +1,34 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2016. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(gen_statem_SUITE_handle_event).
+-compile(export_all).
+-behaviour(gen_statem).
+-define(CB, gen_statem_SUITE).
+
+init(Args) ->
+    ?CB:init(Args).
+handle_event(EventType, EventContent, State, Data) ->
+    ?CB:handle_event_function(EventType, EventContent, State, Data).
+terminate(Reason, State, Data) ->
+    ?CB:terminate(Reason, State, Data).
+code_change(OldVsn, OldState, OldData, Extra) ->
+    ?CB:code_change(OldVsn, OldState, OldData, Extra).
+format_status(StatusOption, Status) ->
+    ?CB:format_status(StatusOption, Status).

--- a/lib/tools/doc/src/erlang_mode.xml
+++ b/lib/tools/doc/src/erlang_mode.xml
@@ -252,7 +252,14 @@
        behavior</item>
       <item>gen_event - skeleton for the OTP gen_event behavior</item>
       <item>gen_fsm - skeleton for the OTP gen_fsm behavior</item>
-      <item>gen_statem - skeleton for the OTP gen_statem behavior</item>
+      <item>
+	gen_statem (StateName/3) - skeleton for the OTP gen_statem behavior
+	using state name functions
+      </item>
+      <item>
+	gen_statem (handle_event/4) - skeleton for the OTP gen_statem behavior
+	using one state function
+      </item>
       <item>Library module - skeleton for a module that does not
        implement a process.</item>
       <item>Corba callback - skeleton for a Corba callback module.</item>

--- a/lib/tools/emacs/erlang-skels.el
+++ b/lib/tools/emacs/erlang-skels.el
@@ -56,8 +56,10 @@
      erlang-skel-gen-event erlang-skel-header)
     ("gen_fsm" "gen-fsm"
      erlang-skel-gen-fsm erlang-skel-header)
-    ("gen_statem" "gen-statem"
-     erlang-skel-gen-statem erlang-skel-header)
+    ("gen_statem (StateName/3)" "gen-statem-StateName"
+     erlang-skel-gen-statem-StateName erlang-skel-header)
+    ("gen_statem (handle_event/4)" "gen-statem-handle-event"
+     erlang-skel-gen-statem-handle-event erlang-skel-header)
     ("wx_object" "wx-object"
      erlang-skel-wx-object erlang-skel-header)
     ("Library module" "gen-lib"
@@ -860,7 +862,7 @@ Please see the function `tempo-define-template'.")
   "*The template of a gen_fsm.
 Please see the function `tempo-define-template'.")
 
-(defvar erlang-skel-gen-statem
+(defvar erlang-skel-gen-statem-StateName
   '((erlang-skel-include erlang-skel-large-header)
     "-behaviour(gen_statem)." n n
 
@@ -870,7 +872,6 @@ Please see the function `tempo-define-template'.")
     "%% gen_statem callbacks" n
     "-export([init/1, terminate/3, code_change/4])." n
     "-export([state_name/3])." n
-    "-export([handle_event/4])." n
     n
     "-define(SERVER, ?MODULE)." n
     n
@@ -904,25 +905,24 @@ Please see the function `tempo-define-template'.")
     "%% process to initialize." n
     (erlang-skel-separator-end 2)
     "-spec init(Args :: term()) ->" n>
-    "{gen_statem:callback_mode()," n>
-    "State :: term(), Data :: term()} |" n>
-    "{gen_statem:callback_mode()," n>
-    "State :: term(), Data :: term()," n>
+    "{ok, State :: term(), Data :: term()} |" n>
+    "{ok, State :: term(), Data :: term()," n>
     "[gen_statem:action()] | gen_statem:action()} |" n>
     "ignore |" n>
     "{stop, Reason :: term()}." n
     "init([]) ->" n>
-    "{state_functions, state_name, #data{}}." n
+    "{ok, state_name, #data{}}." n
     n
     (erlang-skel-separator-start 2)
     "%% @private" n
     "%% @doc" n
-    "%% If the gen_statem runs with CallbackMode =:= state_functions" n
-    "%% there should be one instance of this function for each possible" n
-    "%% state name. Whenever a gen_statem receives an event," n
-    "%% the instance of this function with the same name" n
-    "%% as the current state name StateName is called to" n
-    "%% handle the event." n
+    "%% There should be one function like this for each state name." n
+    "%% Whenever a gen_statem receives an event, the function " n
+    "%% with the name of the current state (StateName) " n
+    "%% is called to handle the event." n
+    "%%" n
+    "%% NOTE: If there is an exported function handle_event/4, it is called" n
+    "%%       instead of StateName/3 functions like this!" n
     (erlang-skel-separator-end 2)
     "-spec state_name(" n>
     "gen_statem:event_type(), Msg :: term()," n>
@@ -934,8 +934,93 @@ Please see the function `tempo-define-template'.")
     (erlang-skel-separator-start 2)
     "%% @private" n
     "%% @doc" n
-    "%% If the gen_statem runs with CallbackMode =:= handle_event_function" n
-    "%% this function is called for every event a gen_statem receives." n
+    "%% This function is called by a gen_statem when it is about to" n
+    "%% terminate. It should be the opposite of Module:init/1 and do any" n
+    "%% necessary cleaning up. When it returns, the gen_statem terminates with" n
+    "%% Reason. The return value is ignored." n
+    (erlang-skel-separator-end 2)
+    "-spec terminate(Reason :: term(), State :: term(), Data :: term()) ->" n>
+    "any()." n
+    "terminate(_Reason, _State, _Data) ->" n>
+    "void." n
+    n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
+    "%% Convert process state when code is changed" n
+    (erlang-skel-separator-end 2)
+    "-spec code_change(" n>
+    "OldVsn :: term() | {down,term()}," n>
+    "State :: term(), Data :: term(), Extra :: term()) ->" n>
+    "{ok, NewState :: term(), NewData :: term()} |" n>
+    "(Reason :: term())." n
+    "code_change(_OldVsn, State, Data, _Extra) ->" n>
+    "{ok, State, Data}." n
+    n
+    (erlang-skel-double-separator-start 3)
+    "%%% Internal functions" n
+    (erlang-skel-double-separator-end 3)
+    )
+  "*The template of a gen_statem (StateName/3).
+Please see the function `tempo-define-template'.")
+
+(defvar erlang-skel-gen-statem-handle-event
+  '((erlang-skel-include erlang-skel-large-header)
+    "-behaviour(gen_statem)." n n
+
+    "%% API" n
+    "-export([start_link/0])." n
+    n
+    "%% gen_statem callbacks" n
+    "-export([init/1, terminate/3, handle_event/4, code_change/4])." n
+    n
+    "-define(SERVER, ?MODULE)." n
+    n
+    "-record(data, {})." n
+    n
+    (erlang-skel-double-separator-start 3)
+    "%%% API" n
+    (erlang-skel-double-separator-end 3) n
+    (erlang-skel-separator-start 2)
+    "%% @doc" n
+    "%% Creates a gen_statem process which calls Module:init/1 to" n
+    "%% initialize. To ensure a synchronized start-up procedure, this" n
+    "%% function does not return until Module:init/1 has returned." n
+    "%%" n
+    (erlang-skel-separator-end 2)
+    "-spec start_link() ->" n>
+    "{ok, Pid :: pid()} |" n>
+    "ignore |" n>
+    "{error, Error :: term()}." n
+    "start_link() ->" n>
+    "gen_statem:start_link({local, ?SERVER}, ?MODULE, [], [])." n
+    n
+    (erlang-skel-double-separator-start 3)
+    "%%% gen_statem callbacks" n
+    (erlang-skel-double-separator-end 3) n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
+    "%% Whenever a gen_statem is started using gen_statem:start/[3,4] or" n
+    "%% gen_statem:start_link/[3,4], this function is called by the new" n
+    "%% process to initialize." n
+    (erlang-skel-separator-end 2)
+    "-spec init(Args :: term()) ->" n>
+    "{ok, State :: term(), Data :: term()} |" n>
+    "{ok, State :: term(), Data :: term()," n>
+    "[gen_statem:action()] | gen_statem:action()} |" n>
+    "ignore |" n>
+    "{stop, Reason :: term()}." n
+    "init([]) ->" n>
+    "{ok, state_name, #data{}}." n
+    n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
+    "%% This function is called for every event a gen_statem receives." n
+    "%%" n
+    "%% NOTE: If there is no exported function handle_event/4," n
+    "%%       StateName/3 functions are called instead!" n
     (erlang-skel-separator-end 2)
     "-spec handle_event(" n>
     "gen_statem:event_type(), Msg :: term()," n>
@@ -965,17 +1050,16 @@ Please see the function `tempo-define-template'.")
     "-spec code_change(" n>
     "OldVsn :: term() | {down,term()}," n>
     "State :: term(), Data :: term(), Extra :: term()) ->" n>
-    "{gen_statem:callback_mode()," n>
-    "NewState :: term(), NewData :: term()} |" n>
+    "{ok, NewState :: term(), NewData :: term()} |" n>
     "(Reason :: term())." n
     "code_change(_OldVsn, State, Data, _Extra) ->" n>
-    "{state_functions, State, Data}." n
+    "{ok, State, Data}." n
     n
     (erlang-skel-double-separator-start 3)
     "%%% Internal functions" n
     (erlang-skel-double-separator-end 3)
     )
-  "*The template of a gen_statem.
+  "*The template of a gen_statem (handle_event/4).
 Please see the function `tempo-define-template'.")
 
 (defvar erlang-skel-wx-object

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -33,8 +33,8 @@
   <p>
     This section is to be read with the
     <seealso marker="stdlib:gen_statem"><c>gen_statem(3)</c></seealso>
-    manual page in <c>STDLIB</c>, where all interface functions and callback
-    functions are described in detail.
+    manual page in <c>STDLIB</c>, where all interface functions
+    and callback functions are described in detail.
   </p>
   <note>
     <p>
@@ -52,7 +52,7 @@
   <section>
     <title>Event-Driven State Machines</title>
     <p>
-      Established Automata theory does not deal much with
+      Established Automata Theory does not deal much with
       how a state transition is triggered,
       but assumes that the output is a function
       of the input (and the state) and that they are
@@ -94,39 +94,53 @@ State(S) x Event(E) -> Actions(A), State(S')</pre>
 <!-- =================================================================== -->
 
   <section>
-    <marker id="callback_modes" />
-    <title>Callback Modes</title>
+    <marker id="callback_flavours" />
+    <title>Callback Flavours</title>
     <p>
-      The <c>gen_statem</c> behavior supports two callback modes:
+      The <c>gen_statem</c> behavior supports two callback flavours:
     </p>
-    <list type="bulleted">
+    <taglist>
+      <tag>State Name Functions</tag>
       <item>
         <p>
-          In mode
-	  <seealso marker="stdlib:gen_statem#type-callback_mode"><c>state_functions</c></seealso>,
-          the state transition rules are written as some Erlang
-          functions, which conform to the following convention:
+          The state transition rules are written as Erlang functions,
+	  conforming to the following convention:
         </p>
         <pre>
 StateName(EventType, EventContent, Data) ->
     .. code for actions here ...
     {next_state, NewStateName, NewData}.</pre>
+        <p>
+	  This flavour is used if no
+	  <seealso marker="stdlib:gen_statem#Module:handle_event/4">
+	    <c>Module:handle_event/4</c>
+	  </seealso>
+	  function is exported.
+	</p>
       </item>
+      <tag>One State Function</tag>
       <item>
         <p>
-          In mode
-	  <seealso marker="stdlib:gen_statem#type-callback_mode"><c>handle_event_function</c></seealso>,
-          only one Erlang function provides all state transition rules:
+          Exactly one Erlang function provides all state transition rules:
         </p>
         <pre>
 handle_event(EventType, EventContent, State, Data) ->
     .. code for actions here ...
     {next_state, NewState, NewData}</pre>
+        <p>
+	  This flavour is used if
+	  <seealso marker="stdlib:gen_statem#Module:handle_event/4">
+	    <c>Module:handle_event/4</c>
+	  </seealso>
+	  is an exported function.
+	</p>
       </item>
-    </list>
+    </taglist>
     <p>
-      Both these modes allow other return tuples; see
-      <seealso marker="stdlib:gen_statem#Module:StateName/3"><c>Module:StateName/3</c></seealso>
+      Both these callback flavours allow other return tuples; see
+      <seealso marker="stdlib:gen_statem#Module:StateName/3">
+	<c>Module:StateName/3</c>
+      </seealso>
       in the <c>gen_statem</c> manual page.
       These other return tuples can, for example, stop the machine,
       execute state transition actions on the machine engine itself,
@@ -134,10 +148,10 @@ handle_event(EventType, EventContent, State, Data) ->
     </p>
 
     <section>
-      <title>Choosing the Callback Mode</title>
+      <title>Choosing the Callback Flavour</title>
       <p>
 	The two
-	<seealso marker="#callback_modes">callback modes</seealso>
+	<seealso marker="#callback_flavours">callback flavours</seealso>
 	give different possibilities
 	and restrictions, but one goal remains:
 	you want to handle all possible combinations of
@@ -151,7 +165,7 @@ handle_event(EventType, EventContent, State, Data) ->
 	You can also use a mix of these strategies.
       </p>
       <p>
-	With <c>state_functions</c>, you are restricted to use
+	With <em>state name functions</em>, you are restricted to use
 	atom-only states, and the <c>gen_statem</c> engine
 	branches depending on state name for you.
 	This encourages the callback module to gather
@@ -160,25 +174,27 @@ handle_event(EventType, EventContent, State, Data) ->
 	hence to focus on one state at the time.
       </p>
       <p>
-	This mode fits well when you have a regular state diagram,
+	This callback flavour fits well when you have a regular state diagram,
 	like the ones in this chapter, which describes all events and actions
 	belonging to a state visually around that state,
 	and each state has its unique name.
       </p>
       <p>
-	With <c>handle_event_function</c>, you are free to mix strategies,
+	With <em>one state function</em>, you are free to mix strategies,
 	as all events and states are handled in the same callback function.
       </p>
       <p>
-	This mode works equally well when you want to focus on
+	This callback flavour works equally well when you want to focus on
 	one event at the time or on
 	one state at the time, but function
-	<seealso marker="stdlib:gen_statem#Module:handle_event/4"><c>Module:handle_event/4</c></seealso>
+	<seealso marker="stdlib:gen_statem#Module:handle_event/4">
+	  <c>Module:handle_event/4</c>
+	</seealso>
 	quickly grows too large to handle without branching to
 	helper functions.
       </p>
       <p>
-	The mode enables the use of non-atom states, for example,
+	This flavour enables the use of non-atom states, for example,
 	complex states or even hierarchical states.
 	If, for example, a state diagram is largely alike
 	for the client side and the server side of a protocol,
@@ -197,8 +213,9 @@ handle_event(EventType, EventContent, State, Data) ->
   <section>
     <title>Example</title>
     <p>
-      This example starts off as equivalent to the example in section
-      <seealso marker="fsm"><c>gen_fsm</c> Behavior</seealso>.
+      This example starts off as equivalent to the example
+      in the section for the
+      <seealso marker="fsm"><c>gen_fsm</c></seealso> Behaviour.
       In later sections, additions and tweaks are made
       using features in <c>gen_statem</c> that <c>gen_fsm</c> does not have.
       The end of this chapter provides the example again
@@ -226,7 +243,6 @@ handle_event(EventType, EventContent, State, Data) ->
 -module(code_lock).
 -behaviour(gen_statem).
 -define(NAME, code_lock).
--define(CALLBACK_MODE, state_functions).
 
 -export([start_link/1]).
 -export([button/1]).
@@ -242,7 +258,7 @@ button(Digit) ->
 init(Code) ->
     do_lock(),
     Data = #{code => Code, remaining => Code},
-    {?CALLBACK_MODE,locked,Data}.
+    {ok,locked,Data}.
 
 locked(
   cast, {button,Digit},
@@ -273,7 +289,7 @@ terminate(_Reason, State, _Data) ->
     State =/= locked andalso do_lock(),
     ok.
 code_change(_Vsn, State, Data, _Extra) ->
-    {?CALLBACK_MODE,State,Data}.
+    {ok,State,Data}.
     ]]></code>
     <p>The code is explained in the next sections.</p>
   </section>
@@ -343,13 +359,7 @@ start_link(Code) ->
     <p>
       If name registration succeeds, the new <c>gen_statem</c> process
       calls callback function <c>code_lock:init(Code)</c>.
-      This function is expected to return <c>{CallbackMode,State,Data}</c>,
-      where
-      <seealso marker="#callback_modes"><c>CallbackMode</c></seealso>
-      selects callback module state function mode, in this case
-      <seealso marker="stdlib:gen_statem#type-callback_mode"><c>state_functions</c></seealso>
-      through macro <c>?CALLBACK_MODE</c>. That is, each state
-      has got its own handler function.
+      This function is expected to return <c>{ok,State,Data}</c>.
       <c>State</c> is the initial state of the <c>gen_statem</c>,
       in this case <c>locked</c>; assuming that the door is locked to begin
       with. <c>Data</c> is the internal server data of the <c>gen_statem</c>.
@@ -363,7 +373,7 @@ start_link(Code) ->
 init(Code) ->
     do_lock(),
     Data = #{code => Code, remaining => Code},
-    {?CALLBACK_MODE,locked,Data}.
+    {ok,locked,Data}.
     ]]></code>
     <p>Function
       <seealso marker="stdlib:gen_statem#start_link/3"><c>gen_statem:start_link</c></seealso>
@@ -524,17 +534,16 @@ handle_event({call,From}, code_length, #{code := Code} = Data) ->
   <section>
     <title>One Event Handler</title>
     <p>
-      If mode <c>handle_event_function</c> is used,
+      If callback flavour <em>one state function</em> is used,
       all events are handled in
-      <seealso marker="stdlib:gen_statem#Module:handle_event/4"><c>Module:handle_event/4</c></seealso>
+      <seealso marker="stdlib:gen_statem#Module:handle_event/4">
+	<c>Module:handle_event/4</c>
+      </seealso>
       and we can (but do not have to) use an event-centered approach
       where we first branch depending on event
       and then depending on state:
     </p>
     <code type="erl"><![CDATA[
-...
--define(CALLBACK_MODE, handle_event_function).
-
 ...
 -export([handle_event/4]).
 
@@ -651,7 +660,9 @@ stop() ->
       These are ordered by returning a list of
       <seealso marker="stdlib:gen_statem#type-action">actions</seealso>
       in the
-      <seealso marker="stdlib:gen_statem#type-state_function_result">return tuple</seealso>
+      <seealso marker="stdlib:gen_statem#type-state_function_result">
+	return tuple
+      </seealso>
       from the
       <seealso marker="stdlib:gen_statem#Module:StateName/3">callback function</seealso>.
       These state transition actions affect the <c>gen_statem</c>
@@ -962,14 +973,10 @@ do_unlock() ->
     </p>
     <code type="erl"><![CDATA[
 ...
--define(CALLBACK_MODE, state_functions).
-
-...
-
 init(Code) ->
     process_flag(trap_exit, true),
     Data = #{code => Code},
-    enter(?CALLBACK_MODE, locked, Data).
+    enter(ok, locked, Data).
 
 ...
 
@@ -1019,15 +1026,14 @@ enter(Tag, State, Data) ->
     </p>
 
     <section>
-      <title>Callback Mode: state_functions</title>
+      <title>State Name Functions</title>
       <p>
-	Using state functions:
+	Using state name functions:
       </p>
       <code type="erl"><![CDATA[
 -module(code_lock).
 -behaviour(gen_statem).
 -define(NAME, code_lock_2).
--define(CALLBACK_MODE, state_functions).
 
 -export([start_link/1,stop/0]).
 -export([button/1,code_length/0]).
@@ -1047,7 +1053,7 @@ code_length() ->
 init(Code) ->
     process_flag(trap_exit, true),
     Data = #{code => Code},
-    enter(?CALLBACK_MODE, locked, Data).
+    enter(ok, locked, Data).
 
 locked(internal, enter, #{code := Code} = Data) ->
     do_lock(),
@@ -1091,12 +1097,12 @@ terminate(_Reason, State, _Data) ->
     State =/= locked andalso do_lock(),
     ok.
 code_change(_Vsn, State, Data, _Extra) ->
-    {?CALLBACK_MODE,State,Data}.
+    {ok,State,Data}.
       ]]></code>
     </section>
 
     <section>
-      <title>Callback Mode: handle_event_function</title>
+      <title>One State Function</title>
       <p>
         This section describes what to change in the example
         to use one <c>handle_event/4</c> function.
@@ -1105,9 +1111,6 @@ code_change(_Vsn, State, Data, _Extra) ->
         entry actions, so this example first branches depending on state:
       </p>
       <code type="erl"><![CDATA[
-...
--define(CALLBACK_MODE, handle_event_function).
-
 ...
 -export([handle_event/4]).
 
@@ -1217,11 +1220,12 @@ format_status(Opt, [_PDict,State,Data]) ->
   <section>
     <title>Complex State</title>
     <p>
-      The callback mode
-      <seealso marker="stdlib:gen_statem#type-callback_mode"><c>handle_event_function</c></seealso>
-      enables using a non-atom state as described in section
-      <seealso marker="#callback_modes">Callback Modes</seealso>,
-      for example, a complex state term like a tuple.
+      The callback flavour 
+      <seealso marker="#callback_flavours">
+	<em>one state function</em>
+      </seealso>
+      allows using any term as the state,
+      for example a complex state term like a tuple.
     </p>
     <p>
       One reason to use this is when you have
@@ -1273,7 +1277,6 @@ format_status(Opt, [_PDict,State,Data]) ->
 -module(code_lock).
 -behaviour(gen_statem).
 -define(NAME, code_lock_3).
--define(CALLBACK_MODE, handle_event_function).
 
 -export([start_link/2,stop/0]).
 -export([button/1,code_length/0,set_lock_button/1]).
@@ -1296,7 +1299,7 @@ set_lock_button(LockButton) ->
 init({Code,LockButton}) ->
     process_flag(trap_exit, true),
     Data = #{code => Code, remaining => undefined, timer => undefined},
-    enter(?CALLBACK_MODE, {locked,LockButton}, Data, []).
+    enter(ok, {locked,LockButton}, Data, []).
 
 handle_event(
   {call,From}, {set_lock_button,NewLockButton},
@@ -1366,7 +1369,7 @@ terminate(_Reason, State, _Data) ->
     State =/= locked andalso do_lock(),
     ok.
 code_change(_Vsn, State, Data, _Extra) ->
-    {?CALLBACK_MODE,State,Data}.
+    {ok,State,Data}.
 format_status(Opt, [_PDict,State,Data]) ->
     StateData =
 	{State,


### PR DESCRIPTION
After the dust settled in the discussion about the new `gen_statem` behaviour (#960) I had time to contemplate and think I will make use of the disclaimer about the new behaviour being somewhat experimental...


#### Selecting Callback Mode

During the discussion I think it was suggested that `gen_statem` could automatically select callback mode depending on which callbacks that were exported, and it was dismissed for some then good reason.  I think one reason was that the `handle_event` and `StateName` callbacks during that time in the discussion had the same arity, and that another reason was efficiency.

As I see it now it is very possible to select callback mode automatically, so that is what this pull request implements: if `Module:handle_event/4` is exported it is called, and if not `Module:StateName/3` is called.  Efficiency is achieved by only testing `erlang:function_exported(Module, handle_event, 4)` once after `Module:init/1` and `Module:code_change/4`, caching the result.


#### Code Downgrade

This solves the annoying problem of code downgrade (which is why I started to think about this solution in the first place).  The new code from which you can make a code change back to an earlier version now does not have to know the callback mode of the old code, since it is defined by the old code.


#### Backwards Incompatibility

It would be possible to make this change backwards compatible by allowing e.g `Module:init/1` to return `{ callback_mode() | ok, ... }` and to only do an automatic callback mode selection only if `ok` is the first element of the returned tuple, but I think there is no benefit in the added complexity.

I think it is better to use the possibility to make a backwards incompatible change for the better (cleaner code and documentation) of an experimental behaviour.

Also see the changes to the SSH and SSL applications in the diff; they are small and simple.  Rewriting for this change is not hard, and more compatible to the older `gen_fsm` and `gen_server` behaviours.


#### Callback Flavour

In the documentation I have stopped talking  about Callback Mode and make a lesser point of it by instead talking briefly about two Callback Flavours: State Name Functions versus One State Function.  Then the important point is whether `Module:handle_event/4` is exported or not.
