### PR TITLE
Improve format_warning/1 spec

### DIFF
--- a/lib/dialyzer/src/dialyzer.erl
+++ b/lib/dialyzer/src/dialyzer.erl
@@ -282,7 +282,7 @@ cl_check_log(none) ->
 cl_check_log(Output) ->
   io:format("  Check output file `~s' for details\n", [Output]).
 
--spec format_warning(raw_warning()) -> string().
+-spec format_warning(raw_warning() | dial_warning()) -> string().
 
 format_warning(W) ->
   format_warning(W, basename).


### PR DESCRIPTION
Let it handle `dial_warning()` input as well, to match what `format_warning/2` expects.