### PR TITLE
gen_statem M:callback_mode/0 (OTP-13752)

### DIFF
--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -60,7 +60,8 @@
 	]).
 
 %%% Behaviour callbacks
--export([handle_event/4, terminate/3, format_status/2, code_change/4]).
+-export([callback_mode/0, handle_event/4, terminate/3,
+	 format_status/2, code_change/4]).
 
 %%% Exports not intended to be used :). They are used for spawning and tests
 -export([init_connection_handler/3,	   % proc_lib:spawn needs this
@@ -374,14 +375,12 @@ init_connection_handler(Role, Socket, Opts) ->
 	S ->
 	    gen_statem:enter_loop(?MODULE,
 				  [], %%[{debug,[trace,log,statistics,debug]} || Role==server],
-				  handle_event_function,
 				  {hello,Role},
 				  S)
     catch
 	_:Error ->
 	    gen_statem:enter_loop(?MODULE,
 				  [],
-				  handle_event_function,
 				  {init_error,Error},
 				  S0)
     end.
@@ -503,6 +502,9 @@ init_ssh_record(Role, Socket, Opts) ->
 %% . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 %%% ######## Error in the initialisation ####
+
+callback_mode() ->
+    handle_event_function.
 
 handle_event(_, _Event, {init_error,Error}, _) ->
     case Error of
@@ -1401,12 +1403,12 @@ fmt_stat_rec(FieldNames, Rec, Exclude) ->
 		  state_name(),
 		  #data{},
 		  term()
-		 ) -> {gen_statem:callback_mode(), state_name(), #data{}}.
+		 ) -> {ok, state_name(), #data{}}.
 
 %% . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 code_change(_OldVsn, StateName, State, _Extra) ->
-    {handle_event_function, StateName, State}.
+    {ok, StateName, State}.
 
 
 %%====================================================================

--- a/lib/ssl/src/dtls_connection.erl
+++ b/lib/ssl/src/dtls_connection.erl
@@ -65,9 +65,7 @@
 	 hello/3, certify/3, cipher/3, abbreviated/3, %% Handshake states 
 	 connection/3]). 
 %% gen_statem callbacks
--export([terminate/3, code_change/4, format_status/2]).
-
--define(GEN_STATEM_CB_MODE, state_functions).
+-export([callback_mode/0, terminate/3, code_change/4, format_status/2]).
 
 %%====================================================================
 %% Internal application API
@@ -161,11 +159,14 @@ init([Role, Host, Port, Socket, Options,  User, CbInfo]) ->
     State0 =  initial_state(Role, Host, Port, Socket, Options, User, CbInfo),
     try
 	State = ssl_connection:ssl_config(State0#state.ssl_options, Role, State0),
-	gen_statem:enter_loop(?MODULE, [], ?GEN_STATEM_CB_MODE, init, State)
+	gen_statem:enter_loop(?MODULE, [], init, State)
     catch
 	throw:Error ->
-	    gen_statem:enter_loop(?MODULE, [], ?GEN_STATEM_CB_MODE, error, {Error,State0})
+	    gen_statem:enter_loop(?MODULE, [], error, {Error,State0})
     end.
+
+callback_mode() ->
+    state_functions.
 
 %%--------------------------------------------------------------------
 %% State functionsconnection/2
@@ -376,7 +377,7 @@ terminate(Reason, StateName, State) ->
 %% Description: Convert process state when code is changed
 %%--------------------------------------------------------------------
 code_change(_OldVsn, StateName, State, _Extra) ->
-    {?GEN_STATEM_CB_MODE, StateName, State}.
+    {ok, StateName, State}.
 
 format_status(Type, Data) ->
     ssl_connection:format_status(Type, Data).

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -68,10 +68,8 @@
 	 hello/3, certify/3, cipher/3, abbreviated/3, %% Handshake states 
 	 connection/3]). 
 %% gen_statem callbacks
--export([terminate/3, code_change/4, format_status/2]).
+-export([callback_mode/0, terminate/3, code_change/4, format_status/2]).
  
--define(GEN_STATEM_CB_MODE, state_functions).
-
 %%====================================================================
 %% Internal application API
 %%====================================================================	     
@@ -169,10 +167,13 @@ init([Role, Host, Port, Socket, Options,  User, CbInfo]) ->
     State0 = initial_state(Role, Host, Port, Socket, Options, User, CbInfo),
     try 
 	State = ssl_connection:ssl_config(State0#state.ssl_options, Role, State0),
-	gen_statem:enter_loop(?MODULE, [], ?GEN_STATEM_CB_MODE, init, State)
+	gen_statem:enter_loop(?MODULE, [], init, State)
     catch throw:Error ->
-	gen_statem:enter_loop(?MODULE, [], ?GEN_STATEM_CB_MODE, error, {Error, State0}) 
+	gen_statem:enter_loop(?MODULE, [], error, {Error, State0}) 
     end.
+
+callback_mode() ->
+    state_functions.
 
 %%--------------------------------------------------------------------
 %% State functions
@@ -457,9 +458,9 @@ format_status(Type, Data) ->
 %%--------------------------------------------------------------------
 code_change(_OldVsn, StateName, State0, {Direction, From, To}) ->
     State = convert_state(State0, Direction, From, To),
-    {?GEN_STATEM_CB_MODE, StateName, State};
+    {ok, StateName, State};
 code_change(_OldVsn, StateName, State, _) ->
-    {?GEN_STATEM_CB_MODE, StateName, State}.
+    {ok, StateName, State}.
 
 %%--------------------------------------------------------------------
 %%% Internal functions

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -97,6 +97,9 @@ gen_statem module            Callback module
 gen_statem:start
 gen_statem:start_link -----> Module:init/1
 
+Server start or code change
+                      -----> Module:callback_mode/0
+
 gen_statem:stop       -----> Module:terminate/3
 
 gen_statem:call
@@ -127,7 +130,8 @@ erlang:'!'            -----> Module:StateName/3
       in a <c>gen_statem</c> is the callback function that is called
       for all events in this state. It is selected depending on which
       <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-      that the implementation specifies when the server starts.
+      that the callback module defines with the callback function
+      <seealso marker="#Module:callback_mode/0"><c>Module:callback_mode/0</c></seealso>.
     </p>
     <p>
       When the
@@ -138,9 +142,9 @@ erlang:'!'            -----> Module:StateName/3
       This gathers all code for a specific state
       in one function as the <c>gen_statem</c> engine
       branches depending on state name.
-      Notice that in this mode the mandatory callback function
+      Notice the fact that there is a mandatory callback function
       <seealso marker="#Module:terminate/3"><c>Module:terminate/3</c></seealso>
-      makes the state name <c>terminate</c> unusable.
+      makes the state name <c>terminate</c> unusable in this mode.
     </p>
     <p>
       When the
@@ -249,11 +253,10 @@ erlang:'!'            -----> Module:StateName/3
 -behaviour(gen_statem).
 
 -export([start/0,push/0,get_count/0,stop/0]).
--export([terminate/3,code_change/4,init/1]).
+-export([terminate/3,code_change/4,init/1,callback_mode/0]).
 -export([on/3,off/3]).
 
 name() -> pushbutton_statem. % The registered server name
-callback_mode() -> state_functions.
 
 %% API.  This example uses a registered name name()
 %% and does not link to the caller.
@@ -270,15 +273,14 @@ stop() ->
 terminate(_Reason, _State, _Data) ->
     void.
 code_change(_Vsn, State, Data, _Extra) ->
-    {callback_mode(),State,Data}.
+    {ok,State,Data}.
 init([]) ->
-    %% Set the callback mode and initial state + data.
-    %% Data is used only as a counter.
+    %% Set the initial state + data.  Data is used only as a counter.
     State = off, Data = 0,
-    {callback_mode(),State,Data}.
+    {ok,State,Data}.
+callback_mode() -> state_functions.
 
-
-%%% State functions
+%%% State function(s)
 
 off({call,From}, push, Data) ->
     %% Go to 'on', increment count and reply
@@ -326,18 +328,13 @@ ok
       To compare styles, here follows the same example using
       <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
       <c>state_functions</c>, or rather the code to replace
-      from function <c>init/1</c> of the <c>pushbutton.erl</c>
+      after function <c>init/1</c> of the <c>pushbutton.erl</c>
       example file above:
     </p>
     <code type="erl">
-init([]) ->
-    %% Set the callback mode and initial state + data.
-    %% Data is used only as a counter.
-    State = off, Data = 0,
-    {handle_event_function,State,Data}.
+callback_mode() -> handle_event_function.
 
-
-%%% Event handling
+%%% State function(s)
 
 handle_event({call,From}, push, off, Data) ->
     %% Go to 'on', increment count and reply
@@ -426,8 +423,8 @@ handle_event(_, _, State, Data) ->
       <desc>
 	<p>
 	  Debug option that can be used when starting
-	  a <c>gen_statem</c> server through, for example,
-	  <seealso marker="#enter_loop/5"><c>enter_loop/5</c></seealso>.
+	  a <c>gen_statem</c> server through,
+	  <seealso marker="#enter_loop/4"><c>enter_loop/4-6</c></seealso>.
 	</p>
 	<p>
 	  For every entry in <c><anno>Dbgs</anno></c>,
@@ -525,12 +522,9 @@ handle_event(_, _, State, Data) ->
       <desc>
 	<p>
 	  The <em>callback mode</em> is selected when starting the
-	  <c>gen_statem</c> using the return value from
-	  <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>
-	  or when calling
-	  <seealso marker="#enter_loop/5"><c>enter_loop/5,6,7</c></seealso>,
-	  and with the return value from
-	  <seealso marker="#Module:code_change/4"><c>Module:code_change/4</c></seealso>.
+	  <c>gen_statem</c> and after code change
+	  using the return value from
+	  <seealso marker="#Module:callback_mode/0"><c>Module:callback_mode/0</c></seealso>.
 	</p>
 	<taglist>
 	  <tag><c>state_functions</c></tag>
@@ -691,7 +685,7 @@ handle_event(_, _, State, Data) ->
 	  <seealso marker="#state_function">state function</seealso>, from
 	  <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>
 	  or by giving them to
-	  <seealso marker="#enter_loop/6"><c>enter_loop/6,7</c></seealso>.
+	  <seealso marker="#enter_loop/5"><c>enter_loop/5,6</c></seealso>.
 	</p>
 	<p>
 	  Actions are executed in the containing list order.
@@ -958,35 +952,36 @@ handle_event(_, _, State, Data) ->
     </func>
 
     <func>
-      <name name="enter_loop" arity="5"/>
+      <name name="enter_loop" arity="4"/>
       <fsummary>Enter the <c>gen_statem</c> receive loop.</fsummary>
       <desc>
 	<p>
 	  The same as
-	  <seealso marker="#enter_loop/7"><c>enter_loop/7</c></seealso>
-	  except that no
+	  <seealso marker="#enter_loop/6"><c>enter_loop/6</c></seealso>
+	  with <c>Actions = []</c> except that no
 	  <seealso marker="#type-server_name"><c>server_name()</c></seealso>
-	  must have been registered.
+	  must have been registered.  This creates an anonymous server.
 	</p>
       </desc>
     </func>
 
     <func>
-      <name name="enter_loop" arity="6"/>
+      <name name="enter_loop" arity="5"/>
       <fsummary>Enter the <c>gen_statem</c> receive loop.</fsummary>
       <desc>
 	<p>
 	  If <c><anno>Server_or_Actions</anno></c> is a <c>list()</c>,
 	  the same as
-	  <seealso marker="#enter_loop/7"><c>enter_loop/7</c></seealso>
+	  <seealso marker="#enter_loop/6"><c>enter_loop/6</c></seealso>
 	  except that no
 	  <seealso marker="#type-server_name"><c>server_name()</c></seealso>
 	  must have been registered and
 	  <c>Actions = <anno>Server_or_Actions</anno></c>.
+	  This creates an anonymous server.
 	</p>
 	<p>
 	  Otherwise the same as
-	  <seealso marker="#enter_loop/7"><c>enter_loop/7</c></seealso>
+	  <seealso marker="#enter_loop/6"><c>enter_loop/6</c></seealso>
 	  with
 	  <c>Server = <anno>Server_or_Actions</anno></c> and
 	  <c>Actions = []</c>.
@@ -995,7 +990,7 @@ handle_event(_, _, State, Data) ->
     </func>
 
     <func>
-      <name name="enter_loop" arity="7"/>
+      <name name="enter_loop" arity="6"/>
       <fsummary>Enter the <c>gen_statem</c> receive loop.</fsummary>
       <desc>
 	<p>
@@ -1015,21 +1010,31 @@ handle_event(_, _, State, Data) ->
 	  the <c>gen_statem</c> behavior provides.
 	</p>
 	<p>
-	  <c><anno>Module</anno></c>, <c><anno>Opts</anno></c>, and
-	  <c><anno>Server</anno></c> have the same meanings
-	  as when calling
+	  <c><anno>Module</anno></c>, <c><anno>Opts</anno></c>
+	  have the same meaning as when calling
 	  <seealso marker="#start_link/3"><c>start[_link]/3,4</c></seealso>.
+	</p>
+	<p>
+	  If <c><anno>Server</anno></c> is <c>self()</c> an anonymous
+	  server is created just as when using 
+	  <seealso marker="#start_link/3"><c>start[_link]/3</c></seealso>.
+	  If <c><anno>Server</anno></c> is a
+	  <seealso marker="#type-server_name"><c>server_name()</c></seealso>
+	  a named server is created just as when using
+	  <seealso marker="#start_link/4"><c>start[_link]/4</c></seealso>.
 	  However, the
 	  <seealso marker="#type-server_name"><c>server_name()</c></seealso>
 	  name must have been registered accordingly
-	  <em>before</em> this function is called.</p>
+	  <em>before</em> this function is called.
+	</p>
         <p>
-	  <c><anno>CallbackMode</anno></c>, <c><anno>State</anno></c>,
-	  <c><anno>Data</anno></c>, and <c><anno>Actions</anno></c>
+	  <c><anno>State</anno></c>, <c><anno>Data</anno></c>,
+	  and <c><anno>Actions</anno></c>
 	  have the same meanings as in the return value of
 	  <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>.
-	  Also, the callback module <c><anno>Module</anno></c>
-	  does not need to export an <c>init/1</c> function.
+	  Also, the callback module does not need to export a
+	  <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>
+	  function.
 	</p>
         <p>
 	  The function fails if the calling process was not started by a
@@ -1253,6 +1258,54 @@ handle_event(_, _, State, Data) ->
 
   <funcs>
     <func>
+      <name>Module:callback_mode() -> CallbackMode</name>
+      <fsummary>Update the internal state during upgrade/downgrade.</fsummary>
+      <type>
+	<v>
+	  CallbackMode =
+	  <seealso marker="#type-callback_mode">callback_mode()</seealso>
+	</v>
+      </type>
+      <desc>
+        <p>
+	  This function is called by a <c>gen_statem</c>
+	  when it needs to find out the
+	  <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
+	  of the callback module.  The value is cached by <c>gen_statem</c>
+	  for efficiency reasons, so this function is only called
+	  once after server start and after code change,
+	  but before the first
+	  <seealso marker="#state_function">state function</seealso>
+	  is called.  More occasions may be added in future versions
+	  of <c>gen_statem</c>.
+	</p>
+	<p>
+	  Server start happens either when
+	  <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>
+	  returns or when
+	  <seealso marker="#enter_loop/4"><c>enter_loop/4-6</c></seealso>
+	  is called.  Code change happens when
+	  <seealso marker="#Module:code_change/4"><c>Module:code_change/4</c></seealso>
+	  returns.
+	</p>
+	<p>
+	  This function can use
+	  <seealso marker="erts:erlang#throw/1"><c>erlang:throw/1</c></seealso>
+	  to return <c>CallbackMode</c>, just for symmetry reasons.
+	  There should be no actual reason to use this.
+	</p>
+	<note>
+	  <p>
+	    If this function's body does not consist of solely one of two
+	    possible
+	    <seealso marker="#type-callback_mode">atoms</seealso>
+	    the callback module is doing something strange.
+	  </p>
+	</note>
+      </desc>
+    </func>
+
+    <func>
       <name>Module:code_change(OldVsn, OldState, OldData, Extra) ->
         Result
       </name>
@@ -1262,11 +1315,7 @@ handle_event(_, _, State, Data) ->
         <v>&nbsp;&nbsp;Vsn = term()</v>
         <v>OldState = NewState = term()</v>
         <v>Extra = term()</v>
-	<v>Result = {CallbackMode,NewState,NewData} | Reason</v>
-	<v>
-	  CallbackMode =
-	  <seealso marker="#type-callback_mode">callback_mode()</seealso>
-	</v>
+	<v>Result = {ok,NewState,NewData} | Reason</v>
 	<v>
 	  OldState = NewState =
 	  <seealso marker="#type-state">state()</seealso>
@@ -1295,21 +1344,6 @@ handle_event(_, _, State, Data) ->
 	  <c>Module</c>. If no such attribute is defined, the version
 	  is the checksum of the Beam file.
 	</p>
-	<note>
-	  <p>
-	    If you would dare to change
-	    <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-	    during release upgrade/downgrade, the upgrade is no problem,
-	    as the new code surely knows what <em>callback mode</em>
-	    it needs. However, for a downgrade this function must
-	    know from argument <c>Extra</c> that comes from the
-	    <seealso marker="sasl:appup"><c>sasl:appup</c></seealso>
-	    file what <em>callback mode</em> the old code did use.
-	    It can also be possible to figure this out
-	    from argument <c>{down,Vsn}</c>, as <c>Vsn</c>
-	    in effect defines the old callback module version.
-	  </p>
-	</note>
         <p>
 	  <c>OldState</c> and <c>OldData</c> is the internal state
 	  of the <c>gen_statem</c>.
@@ -1321,16 +1355,16 @@ handle_event(_, _, State, Data) ->
 	<p>
 	  If successful, the function must return the updated
 	  internal state in an
-	  <c>{CallbackMode,NewState,NewData}</c> tuple.
+	  <c>{ok,NewState,NewData}</c> tuple.
 	</p>
 	<p>
 	  If the function returns a failure <c>Reason</c>, the ongoing
 	  upgrade fails and rolls back to the old release.
-	  Note that <c>Reason</c> can not be a 3-tuple since that
-	  will be regarded as a
-	  <c>{CallbackMode,NewState,NewData}</c> tuple,
+	  Note that <c>Reason</c> can not be an <c>{ok,_,_}</c> tuple
+	  since that will be regarded as a
+	  <c>{ok,NewState,NewData}</c> tuple,
 	  and that a tuple matching <c>{ok,_}</c>
-	  is an invalid failure <c>Reason</c>.
+	  is an also invalid failure <c>Reason</c>.
 	  It is recommended to use an atom as <c>Reason</c> since
 	  it will be wrapped in an <c>{error,Reason}</c> tuple.
 	</p>
@@ -1344,16 +1378,14 @@ handle_event(_, _, State, Data) ->
 
     <func>
       <name>Module:init(Args) -> Result</name>
-      <fsummary>Initialize process and internal state.</fsummary>
+      <fsummary>
+	Optional function for initializing process and internal state.
+      </fsummary>
       <type>
         <v>Args = term()</v>
-        <v>Result = {CallbackMode,State,Data}</v>
-	<v>&nbsp;| {CallbackMode,State,Data,Actions}</v>
+        <v>Result = {ok,State,Data}</v>
+	<v>&nbsp;| {ok,State,Data,Actions}</v>
         <v>&nbsp;| {stop,Reason} | ignore</v>
-	<v>
-	  CallbackMode =
-	  <seealso marker="#type-callback_mode">callback_mode()</seealso>
-	</v>
 	<v>State = <seealso marker="#type-state">state()</seealso></v>
 	<v>
 	  Data = <seealso marker="#type-data">data()</seealso>
@@ -1372,7 +1404,7 @@ handle_event(_, _, State, Data) ->
 	  <seealso marker="#start_link/3"><c>start_link/3,4</c></seealso>
 	  or
 	  <seealso marker="#start/3"><c>start/3,4</c></seealso>,
-	  this function is called by the new process to initialize
+	  this optional function is called by the new process to initialize
 	  the implementation state and server data.
 	</p>
 	<p>
@@ -1381,11 +1413,8 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>
 	  If the initialization is successful, the function is to
-	  return <c>{CallbackMode,State,Data}</c> or
-	  <c>{CallbackMode,State,Data,Actions}</c>.
-	  <c>CallbackMode</c> selects the
-	  <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
-	  of the <c>gen_statem</c>.
+	  return <c>{ok,State,Data}</c> or
+	  <c>{ok,State,Data,Actions}</c>.
 	  <c>State</c> is the initial
 	  <seealso marker="#type-state"><c>state()</c></seealso>
 	  and <c>Data</c> the initial server
@@ -1408,6 +1437,16 @@ handle_event(_, _, State, Data) ->
 	  <seealso marker="erts:erlang#throw/1"><c>erlang:throw/1</c></seealso>
 	  to return <c>Result</c>.
 	</p>
+        <note>
+	  <p>
+	    This callback is optional, so a callback module does not need
+	    to export it, but most do.  If this function is not exported,
+	    the <c>gen_statem</c> should be started through
+	    <seealso marker="proc_lib"><c>proc_lib</c></seealso>
+	    and
+	    <seealso marker="#enter_loop/4"><c>enter_loop/4-6</c></seealso>.
+	  </p>
+        </note>
       </desc>
     </func>
 

--- a/lib/stdlib/test/gen_statem_SUITE.erl
+++ b/lib/stdlib/test/gen_statem_SUITE.erl
@@ -37,33 +37,32 @@ all() ->
      {group, stop_handle_event},
      {group, abnormal},
      {group, abnormal_handle_event},
-     shutdown, stop_and_reply, event_order,
+     shutdown, stop_and_reply, event_order, code_change,
      {group, sys},
      hibernate, enter_loop].
 
 groups() ->
-    [{start, [],
-      [start1, start2, start3, start4, start5, start6, start7,
-       start8, start9, start10, start11, start12, next_events]},
-     {start_handle_event, [],
-      [start1, start2, start3, start4, start5, start6, start7,
-       start8, start9, start10, start11, start12, next_events]},
-     {stop, [],
-      [stop1, stop2, stop3, stop4, stop5, stop6, stop7, stop8, stop9, stop10]},
-     {stop_handle_event, [],
-      [stop1, stop2, stop3, stop4, stop5, stop6, stop7, stop8, stop9, stop10]},
-     {abnormal, [], [abnormal1, abnormal2]},
-     {abnormal_handle_event, [], [abnormal1, abnormal2]},
-     {sys, [],
-      [sys1, code_change,
-       call_format_status,
-       error_format_status, terminate_crash_format,
-       get_state, replace_state]},
-     {sys_handle_event, [],
-      [sys1,
-       call_format_status,
-       error_format_status, terminate_crash_format,
-       get_state, replace_state]}].
+    [{start, [], tcs(start)},
+     {start_handle_event, [], tcs(start)},
+     {stop, [], tcs(stop)},
+     {stop_handle_event, [], tcs(stop)},
+     {abnormal, [], tcs(abnormal)},
+     {abnormal_handle_event, [], tcs(abnormal)},
+     {sys, [], tcs(sys)},
+     {sys_handle_event, [], tcs(sys)}].
+
+tcs(start) ->
+    [start1, start2, start3, start4, start5, start6, start7,
+     start8, start9, start10, start11, start12, next_events];
+tcs(stop) ->
+    [stop1, stop2, stop3, stop4, stop5, stop6, stop7, stop8, stop9, stop10];
+tcs(abnormal) ->
+    [abnormal1, abnormal2];
+tcs(sys) ->
+    [sys1, call_format_status,
+     error_format_status, terminate_crash_format,
+     get_state, replace_state].
+
 
 init_per_suite(Config) ->
     Config.
@@ -633,11 +632,13 @@ sys1(Config) ->
     sys:resume(Pid),
     stop_it(Pid).
 
-code_change(Config) ->
-    Mode = handle_event_function,
-    {ok,Pid} = gen_statem:start(?MODULE, start_arg(Config, []), []),
+code_change(_Config) ->
+    {ok,Pid} =
+	gen_statem:start(
+	  ?MODULE, {callback_mode,state_functions,[]}, []),
     {idle,data} = sys:get_state(Pid),
     sys:suspend(Pid),
+    Mode = handle_event_function,
     sys:change_code(Pid, ?MODULE, old_vsn, Mode),
     sys:resume(Pid),
     {idle,{old_vsn,data,Mode}} = sys:get_state(Pid),
@@ -1029,11 +1030,7 @@ enter_loop(_Config) ->
     end,
 
     %% Process not started using proc_lib
-    CallbackMode = state_functions,
-    Pid4 =
-	spawn_link(
-	  gen_statem, enter_loop,
-	  [?MODULE,[],CallbackMode,state0,[]]),
+    Pid4 = spawn_link(gen_statem, enter_loop, [?MODULE,[],state0,[]]),
     receive
 	{'EXIT',Pid4,process_was_not_started_by_proc_lib} ->
 	    ok
@@ -1107,21 +1104,18 @@ enter_loop(Reg1, Reg2) ->
 	anon -> ignore
     end,
     proc_lib:init_ack({ok, self()}),
-    CallbackMode = state_functions,
     case Reg2 of
 	local ->
 	    gen_statem:enter_loop(
-	      ?MODULE, [], CallbackMode, state0, [], {local,armitage});
+	      ?MODULE, [], state0, [], {local,armitage});
 	global ->
 	    gen_statem:enter_loop(
-	      ?MODULE, [], CallbackMode, state0, [], {global,armitage});
+	      ?MODULE, [], state0, [], {global,armitage});
 	via ->
 	    gen_statem:enter_loop(
-	      ?MODULE, [], CallbackMode, state0, [],
-	      {via, dummy_via, armitage});
+	      ?MODULE, [], state0, [], {via, dummy_via, armitage});
 	anon ->
-	    gen_statem:enter_loop(
-	      ?MODULE, [], CallbackMode, state0, [])
+	    gen_statem:enter_loop(?MODULE, [], state0, [])
     end.
 
 
@@ -1266,33 +1260,39 @@ init(stop_shutdown) ->
     {stop,shutdown};
 init(sleep) ->
     ?t:sleep(1000),
-    {state_functions,idle,data};
+    {ok,idle,data};
 init(hiber) ->
-    {state_functions,hiber_idle,[]};
+    {ok,hiber_idle,[]};
 init(hiber_now) ->
-    {state_functions,hiber_idle,[],[hibernate]};
+    {ok,hiber_idle,[],[hibernate]};
 init({data, Data}) ->
-    {state_functions,idle,Data};
+    {ok,idle,Data};
 init({callback_mode,CallbackMode,Arg}) ->
-    case init(Arg) of
-	{_,State,Data,Ops} ->
-	    {CallbackMode,State,Data,Ops};
-	{_,State,Data} ->
-	    {CallbackMode,State,Data};
-	Other ->
-	    Other
-    end;
+    ets:new(?MODULE, [named_table,private]),
+    ets:insert(?MODULE, {callback_mode,CallbackMode}),
+    init(Arg);
 init({map_statem,#{init := Init}=Machine}) ->
+    ets:new(?MODULE, [named_table,private]),
+    ets:insert(?MODULE, {callback_mode,handle_event_function}),
     case Init() of
 	{ok,State,Data,Ops} ->
-	    {handle_event_function,State,[Data|Machine],Ops};
+	    {ok,State,[Data|Machine],Ops};
 	{ok,State,Data} ->
-	    {handle_event_function,State,[Data|Machine]};
+	    {ok,State,[Data|Machine]};
 	Other ->
 	    Other
     end;
 init([]) ->
-    {state_functions,idle,data}.
+    {ok,idle,data}.
+
+callback_mode() ->
+    try ets:lookup(?MODULE, callback_mode) of
+	[{callback_mode,CallbackMode}] ->
+	    CallbackMode
+    catch
+	error:badarg ->
+	    state_functions
+    end.
 
 terminate(_, _State, crash_terminate) ->
     exit({crash,terminate});
@@ -1568,7 +1568,12 @@ wrap_result(Result) ->
 
 
 code_change(OldVsn, State, Data, CallbackMode) ->
-    {CallbackMode,State,{OldVsn,Data,CallbackMode}}.
+    io:format(
+      "code_change(~p, ~p, ~p, ~p)~n", [OldVsn,State,Data,CallbackMode]),
+    ets:insert(?MODULE, {callback_mode,CallbackMode}),
+    io:format(
+      "code_change(~p, ~p, ~p, ~p)~n", [OldVsn,State,Data,CallbackMode]),
+    {ok,State,{OldVsn,Data,CallbackMode}}.
 
 format_status(terminate, [_Pdict,State,Data]) ->
     {formatted,State,Data};

--- a/lib/tools/doc/src/erlang_mode.xml
+++ b/lib/tools/doc/src/erlang_mode.xml
@@ -252,7 +252,14 @@
        behavior</item>
       <item>gen_event - skeleton for the OTP gen_event behavior</item>
       <item>gen_fsm - skeleton for the OTP gen_fsm behavior</item>
-      <item>gen_statem - skeleton for the OTP gen_statem behavior</item>
+      <item>
+	gen_statem (StateName/3) - skeleton for the OTP gen_statem behavior
+	using state name functions
+      </item>
+      <item>
+	gen_statem (handle_event/4) - skeleton for the OTP gen_statem behavior
+	using one state function
+      </item>
       <item>Library module - skeleton for a module that does not
        implement a process.</item>
       <item>Corba callback - skeleton for a Corba callback module.</item>

--- a/lib/tools/emacs/erlang-skels.el
+++ b/lib/tools/emacs/erlang-skels.el
@@ -56,8 +56,10 @@
      erlang-skel-gen-event erlang-skel-header)
     ("gen_fsm" "gen-fsm"
      erlang-skel-gen-fsm erlang-skel-header)
-    ("gen_statem" "gen-statem"
-     erlang-skel-gen-statem erlang-skel-header)
+    ("gen_statem (StateName/3)" "gen-statem-StateName"
+     erlang-skel-gen-statem-StateName erlang-skel-header)
+    ("gen_statem (handle_event/4)" "gen-statem-handle-event"
+     erlang-skel-gen-statem-handle-event erlang-skel-header)
     ("wx_object" "wx-object"
      erlang-skel-wx-object erlang-skel-header)
     ("Library module" "gen-lib"
@@ -860,7 +862,7 @@ Please see the function `tempo-define-template'.")
   "*The template of a gen_fsm.
 Please see the function `tempo-define-template'.")
 
-(defvar erlang-skel-gen-statem
+(defvar erlang-skel-gen-statem-StateName
   '((erlang-skel-include erlang-skel-large-header)
     "-behaviour(gen_statem)." n n
 
@@ -868,8 +870,117 @@ Please see the function `tempo-define-template'.")
     "-export([start_link/0])." n
     n
     "%% gen_statem callbacks" n
-    "-export([init/1, terminate/3, code_change/4])." n
+    "-export([callback_mode/0, init/1, terminate/3, code_change/4])." n
     "-export([state_name/3])." n
+    n
+    "-define(SERVER, ?MODULE)." n
+    n
+    "-record(data, {})." n
+    n
+    (erlang-skel-double-separator-start 3)
+    "%%% API" n
+    (erlang-skel-double-separator-end 3) n
+    (erlang-skel-separator-start 2)
+    "%% @doc" n
+    "%% Creates a gen_statem process which calls Module:init/1 to" n
+    "%% initialize. To ensure a synchronized start-up procedure, this" n
+    "%% function does not return until Module:init/1 has returned." n
+    "%%" n
+    (erlang-skel-separator-end 2)
+    "-spec start_link() ->" n>
+    "{ok, Pid :: pid()} |" n>
+    "ignore |" n>
+    "{error, Error :: term()}." n
+    "start_link() ->" n>
+    "gen_statem:start_link({local, ?SERVER}, ?MODULE, [], [])." n
+    n
+    (erlang-skel-double-separator-start 3)
+    "%%% gen_statem callbacks" n
+    (erlang-skel-double-separator-end 3) n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
+    "%% Define the callback_mode() for this callback module." n
+    (erlang-skel-separator-end 2)
+    "-spec callback_mode() -> gen_statem:callback_mode()." n
+    "callback_mode() -> state_functions." n
+    n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
+    "%% Whenever a gen_statem is started using gen_statem:start/[3,4] or" n
+    "%% gen_statem:start_link/[3,4], this function is called by the new" n
+    "%% process to initialize." n
+    (erlang-skel-separator-end 2)
+    "-spec init(Args :: term()) ->" n>
+    "{ok, State :: term(), Data :: term()} |" n>
+    "{ok, State :: term(), Data :: term()," n>
+    "[gen_statem:action()] | gen_statem:action()} |" n>
+    "ignore |" n>
+    "{stop, Reason :: term()}." n
+    "init([]) ->" n>
+    "{ok, state_name, #data{}}." n
+    n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
+    "%% There should be one function like this for each state name." n
+    "%% Whenever a gen_statem receives an event, the function " n
+    "%% with the name of the current state (StateName) " n
+    "%% is called to handle the event." n
+    "%%" n
+    "%% NOTE: If there is an exported function handle_event/4, it is called" n
+    "%%       instead of StateName/3 functions like this!" n
+    (erlang-skel-separator-end 2)
+    "-spec state_name(" n>
+    "gen_statem:event_type(), Msg :: term()," n>
+    "Data :: term()) ->" n>
+    "gen_statem:state_function_result()." n
+    "state_name({call,Caller}, _Msg, Data) ->" n>
+    "{next_state, state_name, Data, [{reply,Caller,ok}]}." n
+    n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
+    "%% This function is called by a gen_statem when it is about to" n
+    "%% terminate. It should be the opposite of Module:init/1 and do any" n
+    "%% necessary cleaning up. When it returns, the gen_statem terminates with" n
+    "%% Reason. The return value is ignored." n
+    (erlang-skel-separator-end 2)
+    "-spec terminate(Reason :: term(), State :: term(), Data :: term()) ->" n>
+    "any()." n
+    "terminate(_Reason, _State, _Data) ->" n>
+    "void." n
+    n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
+    "%% Convert process state when code is changed" n
+    (erlang-skel-separator-end 2)
+    "-spec code_change(" n>
+    "OldVsn :: term() | {down,term()}," n>
+    "State :: term(), Data :: term(), Extra :: term()) ->" n>
+    "{ok, NewState :: term(), NewData :: term()} |" n>
+    "(Reason :: term())." n
+    "code_change(_OldVsn, State, Data, _Extra) ->" n>
+    "{ok, State, Data}." n
+    n
+    (erlang-skel-double-separator-start 3)
+    "%%% Internal functions" n
+    (erlang-skel-double-separator-end 3)
+    )
+  "*The template of a gen_statem (StateName/3).
+Please see the function `tempo-define-template'.")
+
+(defvar erlang-skel-gen-statem-handle-event
+  '((erlang-skel-include erlang-skel-large-header)
+    "-behaviour(gen_statem)." n n
+
+    "%% API" n
+    "-export([start_link/0])." n
+    n
+    "%% gen_statem callbacks" n
+    "-export([callback_mode/0, init/1, terminate/3, code_change/4])." n
     "-export([handle_event/4])." n
     n
     "-define(SERVER, ?MODULE)." n
@@ -899,43 +1010,34 @@ Please see the function `tempo-define-template'.")
     (erlang-skel-separator-start 2)
     "%% @private" n
     "%% @doc" n
+    "%% Define the callback_mode() for this callback module." n
+    (erlang-skel-separator-end 2)
+    "-spec callback_mode() -> gen_statem:callback_mode()." n
+    "callback_mode() -> handle_event_function." n
+    n
+    (erlang-skel-separator-start 2)
+    "%% @private" n
+    "%% @doc" n
     "%% Whenever a gen_statem is started using gen_statem:start/[3,4] or" n
     "%% gen_statem:start_link/[3,4], this function is called by the new" n
     "%% process to initialize." n
     (erlang-skel-separator-end 2)
     "-spec init(Args :: term()) ->" n>
-    "{gen_statem:callback_mode()," n>
-    "State :: term(), Data :: term()} |" n>
-    "{gen_statem:callback_mode()," n>
-    "State :: term(), Data :: term()," n>
+    "{ok, State :: term(), Data :: term()} |" n>
+    "{ok, State :: term(), Data :: term()," n>
     "[gen_statem:action()] | gen_statem:action()} |" n>
     "ignore |" n>
     "{stop, Reason :: term()}." n
     "init([]) ->" n>
-    "{state_functions, state_name, #data{}}." n
+    "{ok, state_name, #data{}}." n
     n
     (erlang-skel-separator-start 2)
     "%% @private" n
     "%% @doc" n
-    "%% If the gen_statem runs with CallbackMode =:= state_functions" n
-    "%% there should be one instance of this function for each possible" n
-    "%% state name. Whenever a gen_statem receives an event," n
-    "%% the instance of this function with the same name" n
-    "%% as the current state name StateName is called to" n
-    "%% handle the event." n
-    (erlang-skel-separator-end 2)
-    "-spec state_name(" n>
-    "gen_statem:event_type(), Msg :: term()," n>
-    "Data :: term()) ->" n>
-    "gen_statem:state_function_result()." n
-    "state_name({call,Caller}, _Msg, Data) ->" n>
-    "{next_state, state_name, Data, [{reply,Caller,ok}]}." n
-    n
-    (erlang-skel-separator-start 2)
-    "%% @private" n
-    "%% @doc" n
-    "%% If the gen_statem runs with CallbackMode =:= handle_event_function" n
-    "%% this function is called for every event a gen_statem receives." n
+    "%% This function is called for every event a gen_statem receives." n
+    "%%" n
+    "%% NOTE: If there is no exported function handle_event/4," n
+    "%%       StateName/3 functions are called instead!" n
     (erlang-skel-separator-end 2)
     "-spec handle_event(" n>
     "gen_statem:event_type(), Msg :: term()," n>
@@ -965,17 +1067,16 @@ Please see the function `tempo-define-template'.")
     "-spec code_change(" n>
     "OldVsn :: term() | {down,term()}," n>
     "State :: term(), Data :: term(), Extra :: term()) ->" n>
-    "{gen_statem:callback_mode()," n>
-    "NewState :: term(), NewData :: term()} |" n>
+    "{ok, NewState :: term(), NewData :: term()} |" n>
     "(Reason :: term())." n
     "code_change(_OldVsn, State, Data, _Extra) ->" n>
-    "{state_functions, State, Data}." n
+    "{ok, State, Data}." n
     n
     (erlang-skel-double-separator-start 3)
     "%%% Internal functions" n
     (erlang-skel-double-separator-end 3)
     )
-  "*The template of a gen_statem.
+  "*The template of a gen_statem (handle_event/4).
 Please see the function `tempo-define-template'.")
 
 (defvar erlang-skel-wx-object

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -52,7 +52,7 @@
   <section>
     <title>Event-Driven State Machines</title>
     <p>
-      Established Automata theory does not deal much with
+      Established Automata Theory does not deal much with
       how a state transition is triggered,
       but assumes that the output is a function
       of the input (and the state) and that they are
@@ -226,11 +226,10 @@ handle_event(EventType, EventContent, State, Data) ->
 -module(code_lock).
 -behaviour(gen_statem).
 -define(NAME, code_lock).
--define(CALLBACK_MODE, state_functions).
 
 -export([start_link/1]).
 -export([button/1]).
--export([init/1,terminate/3,code_change/4]).
+-export([init/1,callback_mode/0,terminate/3,code_change/4]).
 -export([locked/3,open/3]).
 
 start_link(Code) ->
@@ -242,7 +241,10 @@ button(Digit) ->
 init(Code) ->
     do_lock(),
     Data = #{code => Code, remaining => Code},
-    {?CALLBACK_MODE,locked,Data}.
+    {ok,locked,Data}.
+
+callback_mode() ->
+    state_functions.
 
 locked(
   cast, {button,Digit},
@@ -273,7 +275,7 @@ terminate(_Reason, State, _Data) ->
     State =/= locked andalso do_lock(),
     ok.
 code_change(_Vsn, State, Data, _Extra) ->
-    {?CALLBACK_MODE,State,Data}.
+    {ok,State,Data}.
     ]]></code>
     <p>The code is explained in the next sections.</p>
   </section>
@@ -343,14 +345,8 @@ start_link(Code) ->
     <p>
       If name registration succeeds, the new <c>gen_statem</c> process
       calls callback function <c>code_lock:init(Code)</c>.
-      This function is expected to return <c>{CallbackMode,State,Data}</c>,
-      where
-      <seealso marker="#callback_modes"><c>CallbackMode</c></seealso>
-      selects callback module state function mode, in this case
-      <seealso marker="stdlib:gen_statem#type-callback_mode"><c>state_functions</c></seealso>
-      through macro <c>?CALLBACK_MODE</c>. That is, each state
-      has got its own handler function.
-      <c>State</c> is the initial state of the <c>gen_statem</c>,
+      This function is expected to return <c>{ok,State,Data}</c>,
+      where <c>State</c> is the initial state of the <c>gen_statem</c>,
       in this case <c>locked</c>; assuming that the door is locked to begin
       with. <c>Data</c> is the internal server data of the <c>gen_statem</c>.
       Here the server data is a <seealso marker="stdlib:maps">map</seealso>
@@ -359,11 +355,12 @@ start_link(Code) ->
       that stores the remaining correct button sequence
       (the same as the <c>code</c> to begin with).
     </p>
+
     <code type="erl"><![CDATA[
 init(Code) ->
     do_lock(),
     Data = #{code => Code, remaining => Code},
-    {?CALLBACK_MODE,locked,Data}.
+    {ok,locked,Data}.
     ]]></code>
     <p>Function
       <seealso marker="stdlib:gen_statem#start_link/3"><c>gen_statem:start_link</c></seealso>
@@ -380,6 +377,21 @@ init(Code) ->
       can be used to start a standalone <c>gen_statem</c>, that is,
       a <c>gen_statem</c> that is not part of a supervision tree.
     </p>
+
+    <code type="erl"><![CDATA[
+callback_mode() ->
+    state_functions.
+    ]]></code>
+    <p>
+      Function
+      <seealso marker="stdlib:gen_statem#Module:callback_mode/0"><c>Module:callback_mode/0</c></seealso>
+      selects the
+      <seealso marker="#callback_modes"><c>CallbackMode</c></seealso>
+      for the callback module, in this case
+      <seealso marker="stdlib:gen_statem#type-callback_mode"><c>state_functions</c></seealso>.
+      That is, each state has got its own handler function.
+    </p>
+
   </section>
 
 <!-- =================================================================== -->
@@ -533,12 +545,11 @@ handle_event({call,From}, code_length, #{code := Code} = Data) ->
     </p>
     <code type="erl"><![CDATA[
 ...
--define(CALLBACK_MODE, handle_event_function).
-
-...
 -export([handle_event/4]).
 
 ...
+callback_mode() ->
+    handle_event_function.
 
 handle_event(cast, {button,Digit}, State, #{code := Code} = Data) ->
     case State of
@@ -962,16 +973,13 @@ do_unlock() ->
     </p>
     <code type="erl"><![CDATA[
 ...
--define(CALLBACK_MODE, state_functions).
-
-...
-
 init(Code) ->
     process_flag(trap_exit, true),
     Data = #{code => Code},
-    enter(?CALLBACK_MODE, locked, Data).
+    enter(ok, locked, Data).
 
-...
+callback_mode() ->
+    state_functions.
 
 locked(internal, enter, _Data) ->
     do_lock(),
@@ -1027,11 +1035,10 @@ enter(Tag, State, Data) ->
 -module(code_lock).
 -behaviour(gen_statem).
 -define(NAME, code_lock_2).
--define(CALLBACK_MODE, state_functions).
 
 -export([start_link/1,stop/0]).
 -export([button/1,code_length/0]).
--export([init/1,terminate/3,code_change/4]).
+-export([init/1,callback_mode/0,terminate/3,code_change/4]).
 -export([locked/3,open/3]).
 
 start_link(Code) ->
@@ -1047,7 +1054,10 @@ code_length() ->
 init(Code) ->
     process_flag(trap_exit, true),
     Data = #{code => Code},
-    enter(?CALLBACK_MODE, locked, Data).
+    enter(ok, locked, Data).
+
+callback_mode() ->
+    state_functions.
 
 locked(internal, enter, #{code := Code} = Data) ->
     do_lock(),
@@ -1091,7 +1101,7 @@ terminate(_Reason, State, _Data) ->
     State =/= locked andalso do_lock(),
     ok.
 code_change(_Vsn, State, Data, _Extra) ->
-    {?CALLBACK_MODE,State,Data}.
+    {ok,State,Data}.
       ]]></code>
     </section>
 
@@ -1106,12 +1116,11 @@ code_change(_Vsn, State, Data, _Extra) ->
       </p>
       <code type="erl"><![CDATA[
 ...
--define(CALLBACK_MODE, handle_event_function).
-
-...
 -export([handle_event/4]).
 
 ...
+callback_mode() ->
+    handle_event_function.
 
 %% State: locked
 handle_event(internal, enter, locked, #{code := Code} = Data) ->
@@ -1273,11 +1282,10 @@ format_status(Opt, [_PDict,State,Data]) ->
 -module(code_lock).
 -behaviour(gen_statem).
 -define(NAME, code_lock_3).
--define(CALLBACK_MODE, handle_event_function).
 
 -export([start_link/2,stop/0]).
 -export([button/1,code_length/0,set_lock_button/1]).
--export([init/1,terminate/3,code_change/4,format_status/2]).
+-export([init/1,callback_mode/0,terminate/3,code_change/4,format_status/2]).
 -export([handle_event/4]).
 
 start_link(Code, LockButton) ->
@@ -1296,7 +1304,10 @@ set_lock_button(LockButton) ->
 init({Code,LockButton}) ->
     process_flag(trap_exit, true),
     Data = #{code => Code, remaining => undefined, timer => undefined},
-    enter(?CALLBACK_MODE, {locked,LockButton}, Data, []).
+    enter(ok, {locked,LockButton}, Data, []).
+
+callback_mode() ->
+    handle_event_function.
 
 handle_event(
   {call,From}, {set_lock_button,NewLockButton},
@@ -1366,7 +1377,7 @@ terminate(_Reason, State, _Data) ->
     State =/= locked andalso do_lock(),
     ok.
 code_change(_Vsn, State, Data, _Extra) ->
-    {?CALLBACK_MODE,State,Data}.
+    {ok,State,Data}.
 format_status(Opt, [_PDict,State,Data]) ->
     StateData =
 	{State,


### PR DESCRIPTION
This is an alternative pull request instead of #1133 after feedback from @antipax.

This pull request also concerns the new `gen_statem` behaviour from #960 but uses `Module:callback_mode/0` to select Callback Mode instead of covertly checking if `Module:handle_event/4` is exported making the selection more explicit and the difference from #960 smaller than for #1133.
