### PR TITLE
fix gc_start\end bug

### DIFF
--- a/lib/tools/src/fprof.erl
+++ b/lib/tools/src/fprof.erl
@@ -1636,6 +1636,11 @@ trace_handler({trace_ts, Pid, gc_major_start, _Func, TS} = Trace, Table, _, Dump
     dump_stack(Dump, get(Pid), Trace),
     trace_gc_start(Table, Pid, TS),
     TS;
+    
+trace_handler({trace_ts, Pid, gc_start, _Func, TS} = Trace, Table, _, Dump) ->
+    dump_stack(Dump, get(Pid), Trace),
+    trace_gc_start(Table, Pid, TS),
+    TS;
 
 %%
 %% gc_end
@@ -1648,6 +1653,12 @@ trace_handler({trace_ts, Pid, gc_major_end, _Func, TS} = Trace, Table, _, Dump) 
     dump_stack(Dump, get(Pid), Trace),
     trace_gc_end(Table, Pid, TS),
     TS;
+    
+trace_handler({trace_ts, Pid, gc_end, _Func, TS} = Trace, Table, _, Dump) ->
+    dump_stack(Dump, get(Pid), Trace),
+    trace_gc_end(Table, Pid, TS),
+    TS;
+    
 %%
 %% link
 trace_handler({trace_ts, Pid, link, _OtherPid, TS} = Trace,


### PR DESCRIPTION
Avoid errors with gc_start and gc_end while fprof:profile/1
Ex:

    fprof:profile({file, "/home/tihon/full.trace"}).
    Reading trace data...
    ..................................................
    .................................................,
    ..................................................
    .........
    End of erroneous trace!
    {error,{incorrect_trace_data,fprof,1708,
                                 [{trace_ts,<7595.8871.1>,gc_start,
                                            [{old_heap_block_size,1598},
                                             {heap_block_size,233},
                                             {mbuf_size,26},
                                             {recent_size,25},
                                             {stack_size,19},
                                             {old_heap_size,1169},
                                             {heap_size,214},
                                             {bin_vheap_size,78},
                                             {bin_vheap_block_size,46422},
                                             {bin_old_vheap_size,178},
                                             {bin_old_vheap_block_size,46422}],
                                            {1469,730152,117381}}]}}

And other:

    fprof:profile({file, "/home/tihon/full.trace"}).
    Reading trace data...
    ..................................................
    .................................................,
    ..................................................
    .........
    End of erroneous trace!
    {error,{incorrect_trace_data,fprof,1713,
                                 [{trace_ts,<7391.8898.1>,gc_end,
                                            [{old_heap_block_size,1598},
                                             {heap_block_size,376},
                                             {mbuf_size,0},
                                             {recent_size,60},
                                             {stack_size,19},
                                             {old_heap_size,1169},
                                             {heap_size,60},
                                             {bin_vheap_size,0},
                                             {bin_vheap_block_size,46422},
                                             {bin_old_vheap_size,178},
                                             {bin_old_vheap_block_size,46422}],
                                            {1469,730152,117477}}]}}