### PR TITLE
Make ODBC configure handle OS X El Capitan

### DIFF
--- a/lib/odbc/configure.in
+++ b/lib/odbc/configure.in
@@ -147,7 +147,7 @@ AC_SUBST(THR_LIBS)
 odbc_lib_link_success=no
 AC_SUBST(TARGET_FLAGS)
     case $host_os in
-        darwin1[[0-4]].*|darwin[[0-9]].*)
+        darwin1[[0-5]].*|darwin[[0-9]].*)
                 TARGET_FLAGS="-DUNIX"
 	        if test ! -d "$with_odbc" || test "$with_odbc" = "yes"; then
 		    ODBC_LIB= -L"/usr/lib"


### PR DESCRIPTION
Change ODBC configure.in script to recognize OS X El Capitan (Darwin v15.x)