### PR TITLE
Fix segfault in crypto by increasing algo_cipher array

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -749,7 +749,7 @@ static ERL_NIF_TERM algo_hash[8];   /* increase when extending the list */
 static int algo_pubkey_cnt;
 static ERL_NIF_TERM algo_pubkey[7]; /* increase when extending the list */
 static int algo_cipher_cnt;
-static ERL_NIF_TERM algo_cipher[20]; /* increase when extending the list */
+static ERL_NIF_TERM algo_cipher[21]; /* increase when extending the list */
 
 static void init_algorithms_types(ErlNifEnv* env)
 {


### PR DESCRIPTION
The size of `algo_cipher` has to be increased, to allow holding all possible ciphers.
backtrace: https://gist.github.com/zbrdge/3283483599df146672fc061942391c42

https://github.com/voidlinux/void-packages/issues/4548