### PR TITLE
Add option to bypass SSL PEM cache

### DIFF
--- a/lib/ssl/src/ssl_crl.erl
+++ b/lib/ssl/src/ssl_crl.erl
@@ -47,7 +47,7 @@ trusted_cert_and_path(CRL, issuer_not_found, {Db, DbRef} = DbHandle) ->
 	    {ok, unknown_crl_ca, []}
     end.
 
-find_issuer(CRL, {Db,_}) ->
+find_issuer(CRL, {Db,DbRef}) ->
     Issuer = public_key:pkix_normalize_name(public_key:pkix_crl_issuer(CRL)),
     IsIssuerFun =
 	fun({_Key, {_Der,ErlCertCandidate}}, Acc) ->
@@ -55,14 +55,26 @@ find_issuer(CRL, {Db,_}) ->
 	   (_, Acc) ->
 		Acc
 	end,
-    
-    try ssl_pkix_db:foldl(IsIssuerFun, issuer_not_found, Db) of
-	issuer_not_found ->
-	    {error, issuer_not_found}
-    catch 
-	{ok, _} = Result ->
-	    Result
+    if is_reference(DbRef) -> % actual DB exists
+	try ssl_pkix_db:foldl(IsIssuerFun, issuer_not_found, Db) of
+	    issuer_not_found ->
+		{error, issuer_not_found}
+	catch
+	    {ok, _} = Result ->
+		Result
+	end;
+       is_tuple(DbRef), element(1,DbRef) =:= extracted -> % cache bypass byproduct
+	{extracted, CertsData} = DbRef,
+	Certs = [Entry || {decoded, Entry} <- CertsData],
+	try lists:foldl(IsIssuerFun, issuer_not_found, Certs) of
+	    issuer_not_found ->
+		{error, issuer_not_found}
+	catch
+	    {ok, _} = Result ->
+		Result
+	end
     end.
+
 
 verify_crl_issuer(CRL, ErlCertCandidate, Issuer, NotIssuer) ->
     TBSCert =  ErlCertCandidate#'OTPCertificate'.tbsCertificate,

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1219,13 +1219,18 @@ certificate_authorities(CertDbHandle, CertDbRef) ->
 	  end,
     list_to_binary([Enc(Cert) || {_, Cert} <- Authorities]).
 
-certificate_authorities_from_db(CertDbHandle, CertDbRef) ->
+certificate_authorities_from_db(CertDbHandle, CertDbRef) when is_reference(CertDbRef) ->
     ConnectionCerts = fun({{Ref, _, _}, Cert}, Acc) when Ref  == CertDbRef ->
 			      [Cert | Acc];
 			 (_, Acc) ->
 			      Acc
 		      end,
-    ssl_pkix_db:foldl(ConnectionCerts, [], CertDbHandle).
+    ssl_pkix_db:foldl(ConnectionCerts, [], CertDbHandle);
+certificate_authorities_from_db(_CertDbHandle, {extracted, CertDbData}) ->
+    %% Cache disabled, Ref contains data
+    lists:foldl(fun({decoded, {_Key,Cert}}, Acc) -> [Cert | Acc] end,
+		[], CertDbData).
+
 
 %%-------------Extension handling --------------------------------
 


### PR DESCRIPTION
The current SSL implementation has a PEM cache running through the ssl
manager process, whose primary role is caching CA chains from files on
disk. This is intended as a way to save on disk operation when the
requested certificates are often the same, and those cache values are
both time-bound and reference-counted. The code path also includes
caching the Erlang-formatted certificate as decoded by the public_key
application

The same code path is used for DER-encoded certificates, which are
passed in memory and do not require file access. These certificates are
cached, but not reference-counted and also not shared across
connections.

For heavy usage of DER-encoded certificates, the PEM cache becomes a
central bottleneck for a server, forcing the decoding of every one of
them individually through a single critical process. It is also not
clear if the cache remains useful for disk certificates in all cases.

This commit adds a configuration variable for the ssl application
(`bypass_pem_cache = true | false`) which allows to open files and decode
certificates in the calling connection process rather than the manager.
When this action takes place, the operations to cache and return data
are replaced to strictly return data.

To provide a transparent behaviour, the `CacheDbRef` used to keep track
of the certificates in the cache is replaced by the certificates itself,
and all further lookup functions or folds can be done locally.

This has proven under benchmark to more than triple the performance of
the SSL application under load (once the session cache had also been
disabled) in a full stack system of ours.

----

Do note that I have run the SSL app's tests and they mostly passed successfully
both with and without the option being set.
Exceptions include the current tests dealing with cache clearing counts, since
these cannot apply without change, and one with CRLs in the noncached version
that I'm still chasing after as I'm not quite sure how they're related, but they
apparently are.

I have however not taken the time to write new tests since I'm not quite sure
what form the OTP team wants them to take -- specifically, re-running the
suite a second time to validate all possible paths for CA cert resolution with
a single configuration switch enabled sounds like trouble, but that's what I
have done here on a solo run.

Not sure what form the OTP team would like for long term tests here.

I am also currently working on a minimal benchmark run to show the benefits
of this approach. I'm trying to see how the suites run for that one as I've
seen they are skipped by default.