### PR TITLE
HiPE backend miscompilation bugs

### DIFF
--- a/lib/hipe/arm/hipe_arm_registers.erl
+++ b/lib/hipe/arm/hipe_arm_registers.erl
@@ -67,6 +67,8 @@
 -define(R15, 15).
 -define(LAST_PRECOLOURED, 15). % must handle both GPR and FPR ranges
 
+-define(LR, ?R14).
+
 -define(ARG0, ?R1).
 -define(ARG1, ?R2).
 -define(ARG2, ?R3).
@@ -114,7 +116,7 @@ stack_pointer() -> ?STACK_POINTER.
 
 proc_pointer() -> ?PROC_POINTER.
 
-lr() -> ?R14.
+lr() -> ?LR.
 
 pc() -> ?R15.
 
@@ -198,7 +200,9 @@ call_clobbered() ->		% does the RA strip the type or not?
   ].
 
 tailcall_clobbered() ->		% tailcall crapola needs one temp
-  [{?TEMP1,tagged},{?TEMP1,untagged}].
+  [{?TEMP1,tagged},{?TEMP1,untagged}
+  ,{?LR,tagged},{?LR,untagged}
+  ].
 
 live_at_return() ->
   [%%{?LR,untagged},

--- a/lib/hipe/arm/hipe_rtl_to_arm.erl
+++ b/lib/hipe/arm/hipe_rtl_to_arm.erl
@@ -148,10 +148,11 @@ mk_shift_ir(S, Dst, Src1, ShiftOp, Src2) ->
   mk_li(Tmp, Src1,
 	mk_shift_rr(S, Dst, Tmp, ShiftOp, Src2)).
 
-mk_shift_ri(S, Dst, Src1, ShiftOp, Src2) when is_integer(Src2) ->
-  if Src2 >= 0, Src2 < 32 -> ok;
-     true -> io:format("~w: excessive immediate shift ~w\n", [?MODULE,Src2])
-  end,
+mk_shift_ri(S, Dst, Src1, ShiftOp, 0)
+  when ShiftOp =:= lsl; ShiftOp =:= lsr; ShiftOp =:= asr ->
+  [hipe_arm:mk_move(S, Dst, Src1)];
+mk_shift_ri(S, Dst, Src1, ShiftOp, Src2)
+  when is_integer(Src2), Src2 > 0, Src2 < 32 ->
   Am1 = {Src1,ShiftOp,Src2},
   [hipe_arm:mk_move(S, Dst, Am1)].
 

--- a/lib/hipe/ppc/hipe_ppc_assemble.erl
+++ b/lib/hipe/ppc/hipe_ppc_assemble.erl
@@ -175,7 +175,8 @@ do_slwi_opnds(Dst, Src1, {uimm,N}) when is_integer(N), 0 =< N, N < 32 ->
   {Dst, Src1, {sh,N}, {mb,0}, {me,31-N}}.
 
 do_srwi_opnds(Dst, Src1, {uimm,N}) when is_integer(N), 0 =< N, N < 32 ->
-  {Dst, Src1, {sh,32-N}, {mb,N}, {me,31}}.
+  %% SH should be 0 (not 32) when N is 0
+  {Dst, Src1, {sh,(32-N) band 31}, {mb,N}, {me,31}}.
 
 do_srawi_src2({uimm,N}) when  is_integer(N), 0 =< N, N < 32 -> {sh,N}.
 
@@ -184,7 +185,8 @@ do_sldi_opnds(Dst, Src1, {uimm,N}) when is_integer(N), 0 =< N, N < 64 ->
   {Dst, Src1, {sh6,N}, {me6,63-N}}.
 
 do_srdi_opnds(Dst, Src1, {uimm,N}) when is_integer(N), 0 =< N, N < 64 ->
-  {Dst, Src1, {sh6,64-N}, {mb6,N}}.
+  %% SH should be 0 (not 64) when N is 0
+  {Dst, Src1, {sh6,(64-N) band 63}, {mb6,N}}.
 
 do_sradi_src2({uimm,N}) when is_integer(N), 0 =< N, N < 64 -> {sh6,N}.
 

--- a/lib/hipe/ppc/hipe_ppc_assemble.erl
+++ b/lib/hipe/ppc/hipe_ppc_assemble.erl
@@ -248,6 +248,7 @@ do_load(I) ->
     case LdOp of
       'ld' -> do_disp_ds(Disp);
       'ldu' -> do_disp_ds(Disp);
+      'lwa' -> do_disp_ds(Disp);
       _ -> do_disp(Disp)
     end,
   NewBase = do_reg(Base),

--- a/lib/hipe/sparc/hipe_sparc_registers.erl
+++ b/lib/hipe/sparc/hipe_sparc_registers.erl
@@ -86,6 +86,8 @@
 -define(I7, 31).
 -define(LAST_PRECOLOURED,31).	% must handle both GRP and FPR ranges
 
+-define(RA, ?O7).
+
 -define(ARG0, ?O1).
 -define(ARG1, ?O2).
 -define(ARG2, ?O3).
@@ -174,7 +176,7 @@ stack_pointer() -> ?STACK_POINTER.
 
 proc_pointer() -> ?PROC_POINTER.
 
-return_address() -> ?O7.
+return_address() -> ?RA.
 
 g0() -> ?G0.
 
@@ -283,7 +285,9 @@ call_clobbered() ->		% does the RA strip the type or not?
   ].
 
 tailcall_clobbered() ->		% tailcall crapola needs one temp
-  [{?TEMP1,tagged},{?TEMP1,untagged}].
+  [{?TEMP1,tagged},{?TEMP1,untagged}
+  ,{?RA,tagged},{?RA,untagged}
+  ].
 
 live_at_return() ->
   [{?HEAP_POINTER,untagged},

--- a/lib/hipe/x86/hipe_x86_postpass.erl
+++ b/lib/hipe/x86/hipe_x86_postpass.erl
@@ -95,7 +95,8 @@ peep([I=#move{src=#x86_temp{reg=Src}, dst=#x86_temp{reg=Dst}},
 
 %% ElimBinALMDouble
 %% ----------------
-peep([Move=#move{src=Src, dst=Dst}, Alu=#alu{src=Src, dst=Dst}|Insns], Res, Lst) ->
+peep([Move=#move{src=Src, dst=Dst}, Alu=#alu{src=Src, dst=Dst}|Insns], Res, Lst)
+  when not is_record(Dst, x86_mem) ->
   peep([Alu#alu{src=Dst}|Insns], [Move|Res], [elimBinALMDouble|Lst]);
 
 


### PR DESCRIPTION
These are fixes to various backend bugs exposed by a branch of mine where I fix the `o0` and `o1` flags. However, as I expect the OTP team would like that PR to be on the master branch, I have extracted these fixes, which are the ones that fix miscompilation-type bugs, to be submitted to maint instead, as at least some of these bugs should still be reproducible with default compiler flags.

As such, I have no test cases included in this PR. Instead, tests that expose these bugs will be included in the optimisation level PR to master. I hope that it will suffice.