### PR TITLE
Ensure that file:write_file/3 can use `writev` if given `raw` mode

### DIFF
--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -397,25 +397,36 @@ write_file(Name, Bin) ->
       Modes :: [mode()],
       Reason :: posix() | badarg | terminated | system_limit.
 
-write_file(Name, Bin, ModeList) when is_list(ModeList) ->
-    case make_binary(Bin) of
-	B when is_binary(B) ->
-	    case open(Name, [binary, write | 
-			     lists:delete(binary, 
-					  lists:delete(write, ModeList))]) of
-		{ok, Handle} ->
-		    case write(Handle, B) of
-			ok ->
-			    close(Handle);
-			E1 ->
-			    _ = close(Handle),
-			    E1
-		    end;
-		E2 ->
-		    E2
-	    end;
-	E3 ->
-	    E3
+write_file(Name, IOData, ModeList) when is_list(ModeList) ->
+    case lists:member(raw, ModeList) of
+        true ->
+          %% For backwards compatibility of error messages
+            try iolist_size(IOData) of
+                _Size -> do_write_file(Name, IOData, ModeList)
+            catch
+                error:Error -> {error, Error}
+            end;
+        false ->
+            case make_binary(IOData) of
+                Bin when is_binary(Bin) ->
+                    do_write_file(Name, Bin, ModeList);
+                Error ->
+                    Error
+            end
+    end.
+
+do_write_file(Name, IOData, ModeList) ->
+    case open(Name, [binary, write | ModeList]) of
+        {ok, Handle} ->
+            case write(Handle, IOData) of
+                ok ->
+                    close(Handle);
+                E1 ->
+                    _ = close(Handle),
+                    E1
+            end;
+        E2 ->
+            E2
     end.
 
 %% Obsolete, undocumented, local node only, don't use!.


### PR DESCRIPTION
Previously, this function would turn any input into a single binary
before writing. This meant it could not take advantage of the `writev`
system call if it was given a list of binaries and told to write with
`raw` mode.

To see this, start an erlang shell on the parent commit, and also
start [this dtrace script](https://github.com/evanmiller/tracewrite) like this:

    sudo dtrace -s tracewrite.d -p $(pgrep beam)

In the erlang shell, run the following:

```erlang
file:write_file("/tmp/tmp.txt", [<<97,98>>, <<98,97>>], [raw]).
```

In the dtrace output, you will see that the system call used is `write`.

Now repeat with this commit, and you will see that `writev` is used.

This is a very small change, but looks bigger because of whitespace
differences. See https://github.com/erlang/otp/pull/1149/files?w=1 to
ignore them.