### PR TITLE
Print on_load error in a more useful style

### DIFF
--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -1414,7 +1414,7 @@ finish_on_load_report(Mod, Term) ->
     %% from the code_server process.
     spawn(fun() ->
 		  F = "The on_load function for module "
-		      "~s returned ~P\n",
+		      "~s returned:~n~P\n",
 
 		  %% Express the call as an apply to simplify
 		  %% the ext_mod_dep/1 test case.


### PR DESCRIPTION
When printing the error term from on_load, insert a newline because the
term is never short and will produce hard to read/copy output that is
just hanging off to the right.