### PR TITLE
Don't report error for shutdown exit tuple

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1087,6 +1087,10 @@ wait_dynamic_children(#child{restart_type=RType} = Child, Pids, Sz,
             wait_dynamic_children(Child, ?SETS:del_element(Pid, Pids), Sz-1,
                                   TRef, EStack);
 
+        {'DOWN', _MRef, process, Pid, {shutdown, _}} ->
+            wait_dynamic_children(Child, ?SETS:del_element(Pid, Pids), Sz-1,
+                                  TRef, EStack);
+
         {'DOWN', _MRef, process, Pid, normal} when RType =/= permanent ->
             wait_dynamic_children(Child, ?SETS:del_element(Pid, Pids), Sz-1,
                                   TRef, EStack);


### PR DESCRIPTION
When a simple_one_for_one supervisor is shutting down, and a child
exits with an exit reason of the form {shutdown, Term}, handle it as
if the exit reason were 'shutdown', without printing an error report.
This makes the behaviour of wait_dynamic_children match that of
do_restart.

This fixes [ERL-163](https://bugs.erlang.org/browse/ERL-163).

