### PR TITLE
erl_bif_types: Fix Dialyzer crash with opaque maps:merge/2 args (ERL-249)

### DIFF
--- a/lib/dialyzer/test/map_SUITE_data/src/opaque_bif.erl
+++ b/lib/dialyzer/test/map_SUITE_data/src/opaque_bif.erl
@@ -1,0 +1,13 @@
+-module(opaque_bif).
+-export([o1/1]).
+-export_type([opaque_any_map/0]).
+-opaque opaque_any_map() :: map().
+
+%% ERL-249: A bug with opaque arguments to maps:merge/2
+%% Reported by Felipe Ripoll on 6/9/2016
+-spec o1(opaque_any_map()) -> opaque_any_map().
+o1(Map) ->
+    maps:merge(o1_c(), Map).
+
+-spec o1_c() -> opaque_any_map().
+o1_c() -> #{}.

--- a/lib/hipe/cerl/erl_bif_types.erl
+++ b/lib/hipe/cerl/erl_bif_types.erl
@@ -124,7 +124,7 @@
 		    t_map_entries/2,
 		    t_map_put/3,
 		    t_map_update/3,
-		    map_pairwise_merge/3
+		    t_map_pairwise_merge/4
 		   ]).
 
 -ifdef(DO_ERL_BIF_TYPES_TEST).
@@ -1689,10 +1689,10 @@ type(maps, merge, 2, Xs, Opaques) ->
 	     BDefK = t_map_def_key(MapB, Opaques),
 	     ADefV = t_map_def_val(MapA, Opaques),
 	     BDefV = t_map_def_val(MapB, Opaques),
-	     t_map(map_pairwise_merge(
+	     t_map(t_map_pairwise_merge(
 		     fun(K, _,     _,  mandatory, V) -> {K, mandatory, V};
 			(K, MNess, VA, optional, VB) -> {K, MNess, t_sup(VA,VB)}
-		     end, MapA, MapB),
+		     end, MapA, MapB, Opaques),
 		   t_sup(ADefK, BDefK), t_sup(ADefV, BDefV))
 	 end, Opaques);
 type(maps, put, 3, Xs, Opaques) ->


### PR DESCRIPTION
`erl_bif_types:type/5` was calling `erl_types:map_pairwise_merge/3` directly
with its (potentially opaque) arguments, causing Dialyzer crashes.

Bug (ERL-249) reported and minimised test case provided by Felipe
Ripoll.