### PR TITLE
Fix compilation when OpenSSL doesn't support RC2

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -51,7 +51,9 @@
 #include <openssl/bn.h>
 #include <openssl/objects.h>
 #include <openssl/rc4.h>
-#include <openssl/rc2.h>
+#ifndef OPENSSL_NO_RC2
+    #include <openssl/rc2.h>
+#endif
 #include <openssl/blowfish.h>
 #include <openssl/rand.h>
 #include <openssl/evp.h>
@@ -468,7 +470,13 @@ struct cipher_type_t {
 
 struct cipher_type_t cipher_types[] =
 {
-    {{"rc2_cbc"}, {&EVP_rc2_cbc}},
+    {{"rc2_cbc"},
+#ifndef OPENSSL_NO_RC2
+     {&EVP_rc2_cbc}
+#else
+     {NULL}
+#endif
+    },
     {{"des_cbc"}, {COND_NO_DES_PTR(&EVP_des_cbc)}},
     {{"des_cfb"}, {COND_NO_DES_PTR(&EVP_des_cfb8)}},
     {{"des_ecb"}, {COND_NO_DES_PTR(&EVP_des_ecb)}},
@@ -827,7 +835,9 @@ static void init_algorithms_types(ErlNifEnv* env)
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"blowfish_cfb64");
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"blowfish_ofb64");
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"blowfish_ecb");
+#ifndef OPENSSL_NO_RC2
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"rc2_cbc");
+#endif
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"rc4");
 #if defined(HAVE_GCM)
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"aes_gcm");

--- a/lib/crypto/test/old_crypto_SUITE.erl
+++ b/lib/crypto/test/old_crypto_SUITE.erl
@@ -1080,7 +1080,9 @@ rc2_cbc(doc) ->
     "Encrypt and decrypt according to RC2 CBC and check the result. "
     "Example stripped out from public_key application test";
 rc2_cbc(Config) when is_list(Config) ->
-   
+    if_supported(rc2_cbc, fun rc2_cbc_do/0).
+
+rc2_cbc_do() ->
     Key = <<146,210,160,124,215,227,153,239,227,17,222,140,3,93,27,191>>,
     IV = <<72,91,135,182,25,42,35,210>>,
 

--- a/lib/public_key/test/pbe_SUITE.erl
+++ b/lib/public_key/test/pbe_SUITE.erl
@@ -219,7 +219,12 @@ pbes2() ->
 pbes2(Config) when is_list(Config) ->
     decode_encode_key_file("pbes2_des_cbc_enc_key.pem", "password", "DES-CBC", Config),
     decode_encode_key_file("pbes2_des_ede3_cbc_enc_key.pem", "password", "DES-EDE3-CBC", Config),   
-    decode_encode_key_file("pbes2_rc2_cbc_enc_key.pem", "password", "RC2-CBC", Config).
+    case lists:member(rc2_cbc, proplists:get_value(ciphers, crypto:supports())) of
+	true ->
+	    decode_encode_key_file("pbes2_rc2_cbc_enc_key.pem", "password", "RC2-CBC", Config);
+	false ->
+	    ok
+    end.
 
 check_key_info(#'PrivateKeyInfo'{privateKeyAlgorithm =
 				     #'PrivateKeyInfo_privateKeyAlgorithm'{algorithm = ?rsaEncryption},


### PR DESCRIPTION
When OpenSSL has been configured with the "no-rc2" option, the header
file rc2.h doesn't exist, and neither does the function EVP_rc2_cbc.
Let's handle those by checking whether OPENSSL_NO_RC2 is defined.

Also update pbe_SUITE, which uses RC2-CBC in one of the tests.

`crypto_SUITE` still works, since it checks whether the algorithm it's going to test is supported, but `old_crypto_SUITE` fails if OpenSSL doesn't support RC2. Should I update that test suite as well?