### PR TITLE
Turn off parallel make for start scripts Makefile

### DIFF
--- a/erts/start_scripts/Makefile
+++ b/erts/start_scripts/Makefile
@@ -17,6 +17,9 @@
 #
 # %CopyrightEnd%
 #
+
+.NOTPARALLEL:
+
 include $(ERL_TOP)/make/target.mk
 include $(ERL_TOP)/make/$(TARGET)/otp.mk
 


### PR DESCRIPTION
At least on macOS (OS X), /usr/bin/install does not seem to be
thread-safe when creating directories. That is, if several
invocations of /usr/bin/install attempts to create the same
directory, one or more of the invocations may fail with an
error, causing the build to fail.

Avoid the problem by turning off parallel make for the
Makefile in erts/start_scripts.

Reported-by: https://bugs.erlang.org/browse/ERL-250