### PR TITLE
doc: Fix code format in tutorial/c_port

### DIFF
--- a/system/doc/tutorial/c_port.xmlsrc
+++ b/system/doc/tutorial/c_port.xmlsrc
@@ -98,11 +98,11 @@ loop(Port) ->
     {call, Caller, Msg} ->
       Port ! {self(), {command, encode(Msg)}},
       receive
-    {Port, {data, Data}} ->
+        {Port, {data, Data}} ->
           Caller ! {complex, decode(Data)}
       end,
       loop(Port)
- end.</pre>
+  end.</pre>
     <p>Assuming that both the arguments and the results from the C
       functions are less than 256, a simple encoding/decoding scheme
       is employed. In this scheme, <c>foo</c> is represented by byte


### PR DESCRIPTION
The original code is at http://erlang.org/doc/tutorial/c_port.html