### PR TITLE
Ensure asserts are enabled in eunit.hrl

### DIFF
--- a/lib/eunit/include/eunit.hrl
+++ b/lib/eunit/include/eunit.hrl
@@ -51,7 +51,9 @@
 %% note that the main switch used within this file is NOTEST; however,
 %% both TEST and EUNIT may be used to check whether testing is enabled
 -ifndef(NOTEST).
--undef(NOASSERT).    % testing requires that assertions are enabled
+-ifndef(ASSERT).
+-define(ASSERT, true).  % testing requires that assertions are enabled
+-endif.
 -ifndef(TEST).
 -define(TEST, true).
 -endif.


### PR DESCRIPTION
When asserts were moved out to a separate header file, the automatic
enabling of asserts when testing stopped working.