### PR TITLE
OpenSSL without rc4

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -50,7 +50,9 @@
 #include <openssl/ripemd.h>
 #include <openssl/bn.h>
 #include <openssl/objects.h>
+#ifndef OPENSSL_NO_RC4
 #include <openssl/rc4.h>
+#endif /* OPENSSL_NO_RC4 */
 #include <openssl/rc2.h>
 #include <openssl/blowfish.h>
 #include <openssl/rand.h>
@@ -828,7 +830,9 @@ static void init_algorithms_types(ErlNifEnv* env)
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"blowfish_ofb64");
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"blowfish_ecb");
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"rc2_cbc");
+#ifndef OPENSSL_NO_RC4
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"rc4");
+#endif
 #if defined(HAVE_GCM)
     algo_cipher[algo_cipher_cnt++] = enif_make_atom(env,"aes_gcm");
 #endif
@@ -2327,6 +2331,7 @@ static ERL_NIF_TERM do_exor(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
 static ERL_NIF_TERM rc4_encrypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {/* (Key, Data) */
+#ifndef OPENSSL_NO_RC4
     ErlNifBinary key, data;
     RC4_KEY rc4_key;
     ERL_NIF_TERM ret;
@@ -2340,10 +2345,14 @@ static ERL_NIF_TERM rc4_encrypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
 	enif_make_new_binary(env, data.size, &ret));
     CONSUME_REDS(env,data);
     return ret;
-}   
+#else
+    return enif_raise_exception(env, atom_notsup);
+#endif
+}
 
 static ERL_NIF_TERM rc4_set_key(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {/* (Key) */
+#ifndef OPENSSL_NO_RC4
     ErlNifBinary key;
     ERL_NIF_TERM ret;
 
@@ -2353,11 +2362,14 @@ static ERL_NIF_TERM rc4_set_key(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
     RC4_set_key((RC4_KEY*)enif_make_new_binary(env, sizeof(RC4_KEY), &ret),
 		key.size, key.data);        
     return ret;
+#else
+    return enif_raise_exception(env, atom_notsup);
+#endif
 }
 
 static ERL_NIF_TERM rc4_encrypt_with_state(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {/* (State, Data) */
-
+#ifndef OPENSSL_NO_RC4
     ErlNifBinary state, data;
     RC4_KEY* rc4_key;
     ERL_NIF_TERM new_state, new_data;
@@ -2373,7 +2385,10 @@ static ERL_NIF_TERM rc4_encrypt_with_state(ErlNifEnv* env, int argc, const ERL_N
 	enif_make_new_binary(env, data.size, &new_data));
     CONSUME_REDS(env,data);
     return enif_make_tuple2(env,new_state,new_data);
-}   
+#else
+    return enif_raise_exception(env, atom_notsup);
+#endif
+}
 
 static int get_rsa_private_key(ErlNifEnv* env, ERL_NIF_TERM key, RSA *rsa)
 {

--- a/lib/crypto/test/old_crypto_SUITE.erl
+++ b/lib/crypto/test/old_crypto_SUITE.erl
@@ -2117,6 +2117,9 @@ rc4_test(doc) ->
 rc4_test(suite) ->
     [];
 rc4_test(Config) when is_list(Config) ->
+    if_supported(rc4, fun rc4_test_do/0).
+
+rc4_test_do() ->
     CT1 = <<"Yo baby yo">>,
     R1 = <<118,122,68,110,157,166,141,212,139,39>>,
     K = "apaapa",
@@ -2132,6 +2135,9 @@ rc4_stream_test(doc) ->
 rc4_stream_test(suite) ->
     [];
 rc4_stream_test(Config) when is_list(Config) ->
+    if_supported(rc4, fun rc4_stream_test_do/0).
+
+rc4_stream_test_do() ->
     CT1 = <<"Yo ">>,
     CT2 = <<"baby yo">>,
     K = "apaapa",

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1458,6 +1458,9 @@ is_acceptable_cipher(Cipher, Algos)
 is_acceptable_cipher(Cipher, Algos)
   when Cipher == chacha20_poly1305 ->
     proplists:get_bool(Cipher, Algos);
+is_acceptable_cipher(Cipher, Algos)
+  when Cipher == rc4_128 ->
+    proplists:get_bool(rc4, Algos);
 is_acceptable_cipher(_, _) ->
     true.
 


### PR DESCRIPTION
mostly the same as #1163 but for RC4 support.

SSL/TLS is affected as well. The SSL test suites might need some additional changes as they assume that RC4 is always a valid stream cipher.