### PR TITLE
Use more correct delimiters for erl_nif.h include

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -80,7 +80,7 @@
 
     <code type="none">
 /* niftest.c */
-#include "erl_nif.h"
+#include &lt;erl_nif.h&gt;
 
 static ERL_NIF_TERM hello(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {

--- a/erts/doc/src/erl_tracer.xml
+++ b/erts/doc/src/erl_tracer.xml
@@ -684,7 +684,7 @@ trace(_, _, _, _, _) ->
     <p><c>erl_msg_tracer.c</c>:</p>
 
     <pre>
-#include "erl_nif.h"
+#include &lt;erl_nif.h&gt;
 
 /* NIF interface declarations */
 static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info);

--- a/erts/emulator/test/alloc_SUITE_data/testcase_driver.h
+++ b/erts/emulator/test/alloc_SUITE_data/testcase_driver.h
@@ -20,7 +20,7 @@
 #ifndef TESTCASE_DRIVER_H__
 #define TESTCASE_DRIVER_H__
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 #include <stdlib.h>
 
 typedef struct {

--- a/erts/emulator/test/dirty_nif_SUITE_data/dirty_nif_SUITE.c
+++ b/erts/emulator/test/dirty_nif_SUITE_data/dirty_nif_SUITE.c
@@ -17,7 +17,7 @@
  *
  * %CopyrightEnd%
  */
-#include "erl_nif.h"
+#include <erl_nif.h>
 #include <assert.h>
 #ifdef __WIN32__
 #include <windows.h>

--- a/erts/emulator/test/mtx_SUITE_data/mtx_SUITE.c
+++ b/erts/emulator/test/mtx_SUITE_data/mtx_SUITE.c
@@ -24,7 +24,7 @@
  * Author: Rickard Green
  */
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 #ifdef __WIN32__
 #  ifndef WIN32_LEAN_AND_MEAN

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -17,7 +17,7 @@
  *
  * %CopyrightEnd%
  */
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.c
@@ -17,7 +17,7 @@
  *
  * %CopyrightEnd%
  */
-#include "erl_nif.h"
+#include <erl_nif.h>
 #include <string.h>
 #include <stdio.h>
 

--- a/erts/emulator/test/nif_SUITE_data/testcase_driver.h
+++ b/erts/emulator/test/nif_SUITE_data/testcase_driver.h
@@ -20,7 +20,7 @@
 #ifndef TESTCASE_DRIVER_H__
 #define TESTCASE_DRIVER_H__
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/erts/emulator/test/nif_SUITE_data/tester.c
+++ b/erts/emulator/test/nif_SUITE_data/tester.c
@@ -1,4 +1,4 @@
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 #include <stdio.h>
 #include <stdarg.h>

--- a/erts/emulator/test/trace_call_time_SUITE_data/trace_nif.c
+++ b/erts/emulator/test/trace_call_time_SUITE_data/trace_nif.c
@@ -1,4 +1,4 @@
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 
 static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)

--- a/erts/emulator/test/trace_nif_SUITE_data/trace_nif.c
+++ b/erts/emulator/test/trace_nif_SUITE_data/trace_nif.c
@@ -1,4 +1,4 @@
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 
 static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)

--- a/erts/emulator/test/tracer_SUITE_data/tracer_test.c
+++ b/erts/emulator/test/tracer_SUITE_data/tracer_test.c
@@ -18,7 +18,7 @@
  * %CopyrightEnd%
  */
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/erts/example/matrix_nif.c
+++ b/erts/example/matrix_nif.c
@@ -22,7 +22,7 @@
  *          for matrix calculations.
  */
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 #include <stddef.h>
 #include <assert.h>

--- a/lib/asn1/c_src/asn1_erl_nif.c
+++ b/lib/asn1/c_src/asn1_erl_nif.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 /* #define ASN1_DEBUG 1 */
 

--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -31,7 +31,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 #define OPENSSL_THREAD_DEFINES
 #include <openssl/opensslconf.h>

--- a/lib/crypto/c_src/crypto_callback.c
+++ b/lib/crypto/c_src/crypto_callback.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <openssl/opensslconf.h>
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 #include "crypto_callback.h"
 
 #ifdef DEBUG

--- a/lib/kernel/test/gen_tcp_api_SUITE_data/gen_tcp_api_SUITE.c
+++ b/lib/kernel/test/gen_tcp_api_SUITE_data/gen_tcp_api_SUITE.c
@@ -17,7 +17,7 @@
  *
  * %CopyrightEnd%
  */
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/lib/runtime_tools/c_src/dyntrace.c
+++ b/lib/runtime_tools/c_src/dyntrace.c
@@ -24,7 +24,7 @@
 
 
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 #include "config.h"
 #include "sys.h"
 #include "dtrace-wrapper.h"

--- a/lib/runtime_tools/test/dbg_SUITE_data/dbg_SUITE.c
+++ b/lib/runtime_tools/test/dbg_SUITE_data/dbg_SUITE.c
@@ -18,7 +18,7 @@
  * %CopyrightEnd%
  */
 
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/system/doc/tutorial/complex6_nif.c
+++ b/system/doc/tutorial/complex6_nif.c
@@ -1,4 +1,4 @@
-#include "erl_nif.h"
+#include <erl_nif.h>
 
 extern int foo(int x);
 extern int bar(int y);


### PR DESCRIPTION
Anywhere but the beam sources we shouldn't `#include "erl_nif.h"`, because
what `"erl_nif.h"` does is: (1) fail to find it outside of `-I` dirs, (2)
then treat it as if it was written like `<erl_nif.h>`. Using `<erl_nif.h>`
skips (1).

More information can be found in 6.10.2 of the C standard.

Because the examples use `"erl_nif.h"`, NIF projects in the Erlang
ecosystem copy this verbatim and make the same mistake.