### PR TITLE
Fix SSH custom REPL exit status

### DIFF
--- a/lib/ssh/src/ssh_cli.erl
+++ b/lib/ssh/src/ssh_cli.erl
@@ -208,8 +208,15 @@ handle_msg({Group, Req}, #state{group = Group, buf = Buf, pty = Pty,
     write_chars(ConnectionHandler, ChannelId, Chars),
     {ok, State#state{buf = NewBuf}};
 
-handle_msg({'EXIT', Group, _Reason}, #state{group = Group,
-					     channel = ChannelId} = State) ->
+handle_msg({'EXIT', Group, Reason}, #state{group = Group,
+					    cm = ConnectionHandler,
+					    channel = ChannelId} = State) ->
+    Status = case Reason of
+                 normal -> 0;
+                 _      -> -1
+             end,
+    ssh_connection:exit_status(ConnectionHandler, ChannelId, Status),
+    ssh_connection:send_eof(ConnectionHandler, ChannelId),
     {stop, ChannelId, State};
 
 handle_msg(_, State) ->


### PR DESCRIPTION
When user defined SSH shell REPL process exits with reason normal SSH channel callback module should report successful exit status to the SSH client.
This provides simple way for SSH clients to check for successful completion of executed commands.
