### PR TITLE
[RFC][DO NOT MERGE] lcnt-enabled VM may SEGV because lcnt requires time to have been initialized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
   - export MAKEFLAGS=-j6
 
 script:
-  - case $JOB-$TRAVIS_OS_NAME in DEFAULT-*) ./otp_build all -a;; MAX_CFG-linux) ( export CC=${CUSTOM_CC:?} && export CXX=${CUSTOM_CXX:?} && export LDFLAGS=$CUSTOM_LDFLAGS && ./otp_build setup -a ${CFG_PARAMS:?} && ./otp_build release -a; );; MAX_CFG-osx) ./otp_build setup -a ${CFG_PARAMS:?} && ./otp_build release -a;; esac
+  - case $JOB-$TRAVIS_OS_NAME in DEFAULT-*) ./otp_build all -a;; MAX_CFG-linux) ( export CC=${CUSTOM_CC:?} && export CXX=${CUSTOM_CXX:?} && export LDFLAGS=$CUSTOM_LDFLAGS && ./otp_build autoconf && ./otp_build configure ${CFG_PARAMS:?} && { ls -l erts/config.status && cat erts/config.status && ls -l erts/config.status; } && ./otp_build boot -a && ./otp_build release -a; );; MAX_CFG-osx) ./otp_build autoconf && ./otp_build configure ${CFG_PARAMS:?} && { ls -l erts/config.status && cat erts/config.status && ls -l erts/config.status; } && ./otp_build boot -a && ./otp_build release -a;; esac
 
 after_success:
   - ./otp_build tests && make release_docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,40 @@
 language: c
 
-sudo: false
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      env: JOB=DEFAULT
+    - os: linux
+      sudo: false
+      env: JOB=MAX_CFG CUSTOM_CC="gcc-4.8" CUSTOM_CXX="g++-4.8" CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --disable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --without-dynamic-trace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
+    - os: linux
+      sudo: false
+      env: JOB=MAX_CFG CUSTOM_CC="gcc-6" CUSTOM_CXX="g++-6" CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --disable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --without-dynamic-trace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
+    - os: linux
+      sudo: false
+      env: JOB=MAX_CFG CUSTOM_CC="clang-3.8" CUSTOM_CXX="clang++-3.8" CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --disable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --without-dynamic-trace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
+    - os: osx
+      osx_image: xcode7.1
+      env: JOB=DEFAULT
+    - os: osx
+      osx_image: xcode7.1
+      env: JOB=MAX_CFG CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --enable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --with-dynamic-trace=dtrace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
+    - os: osx
+      osx_image: xcode7.3
+      env: JOB=MAX_CFG CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --enable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --with-dynamic-trace=dtrace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
+    - os: osx
+      osx_image: xcode8
+      env: JOB=DEFAULT
+    - os: osx
+      osx_image: xcode8
+      env: JOB=MAX_CFG CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --enable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --with-dynamic-trace=dtrace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.8
     packages:
       - autoconf
       - libncurses-dev
@@ -16,6 +47,11 @@ addons:
       - default-jdk
       - g++
       - xsltproc
+      - gcc-4.8
+      - g++-4.8
+      - gcc-6
+      - g++-6
+      - clang-3.8
 
 before_script:
   - set -e
@@ -25,12 +61,10 @@ before_script:
   - export MAKEFLAGS=-j6
 
 script:
-  - ./otp_build all -a
-  
+  - case $JOB-$TRAVIS_OS_NAME in DEFAULT-*) ./otp_build all -a;; MAX_CFG-linux) ( export CC=${CUSTOM_CC:?} && export CXX=${CUSTOM_CXX:?} && ./otp_build setup -a ${CFG_PARAMS:?} && ./otp_build release -a; );; MAX_CFG-osx) ./otp_build setup -a ${CFG_PARAMS:?} && ./otp_build release -a;; esac
+
 after_success:
   - ./otp_build tests && make release_docs
 
 after_script:
   - cd $ERL_TOP/release/tests/test_server && $ERL_TOP/bin/erl -s ts install -s ts smoke_test batch -s init stop
-  
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-language: erlang
-
-otp_release:
-  - 18.0
+language: c
 
 sudo: false
 
@@ -26,7 +23,6 @@ before_script:
   - export PATH=$ERL_TOP/bin:$PATH
   - export ERL_LIBS=''
   - export MAKEFLAGS=-j6
-  - kerl_deactivate
 
 script:
   - ./otp_build all -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       env: JOB=MAX_CFG CUSTOM_CC="gcc-4.8" CUSTOM_CXX="g++-4.8" CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --disable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --without-dynamic-trace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
     - os: linux
       sudo: false
-      env: JOB=MAX_CFG CUSTOM_CC="gcc-6" CUSTOM_CXX="g++-6" CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --disable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --without-dynamic-trace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
+      env: JOB=MAX_CFG CUSTOM_CC="gcc-6" CUSTOM_CXX="g++-6" CUSTOM_LDFLAGS="-fuse-ld=gold" CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --disable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --without-dynamic-trace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
     - os: linux
       sudo: false
       env: JOB=MAX_CFG CUSTOM_CC="clang-3.8" CUSTOM_CXX="clang++-3.8" CFG_PARAMS="--enable-threads --enable-dirty-schedulers --enable-new-purge-strategy --enable-smp-support --enable-lock-checking --enable-lock-counter --enable-kernel-poll --enable-sctp --disable-hipe --enable-fp-exceptions --disable-vm-probes --disable-saved-compile-time --enable-sharing-preserving --enable-m64-build --enable-sanitizers=address --disable-silent-rules --without-dynamic-trace --with-microstate-accounting=extra --with-ets-write-concurrency-locks=256 --with-clock-resolution=high --with-javac --with-ssl --without-odbc"
@@ -61,7 +61,7 @@ before_script:
   - export MAKEFLAGS=-j6
 
 script:
-  - case $JOB-$TRAVIS_OS_NAME in DEFAULT-*) ./otp_build all -a;; MAX_CFG-linux) ( export CC=${CUSTOM_CC:?} && export CXX=${CUSTOM_CXX:?} && ./otp_build setup -a ${CFG_PARAMS:?} && ./otp_build release -a; );; MAX_CFG-osx) ./otp_build setup -a ${CFG_PARAMS:?} && ./otp_build release -a;; esac
+  - case $JOB-$TRAVIS_OS_NAME in DEFAULT-*) ./otp_build all -a;; MAX_CFG-linux) ( export CC=${CUSTOM_CC:?} && export CXX=${CUSTOM_CXX:?} && export LDFLAGS=$CUSTOM_LDFLAGS && ./otp_build setup -a ${CFG_PARAMS:?} && ./otp_build release -a; );; MAX_CFG-osx) ./otp_build setup -a ${CFG_PARAMS:?} && ./otp_build release -a;; esac
 
 after_success:
   - ./otp_build tests && make release_docs


### PR DESCRIPTION
[This PR sets Travis CI on OSX in order to ease showing and reproducing an issue. I expect this PR not to be merged - at least not in this form. If you would like to get some portions of this PR merged please let me know and I will happy to open an amended new PR.]

**Is it ok to call `erts_init_sys_time_sup` before `erts_lcnt_init`** - i.e. partially reverting the change in https://github.com/erlang/otp/commit/e52829ceb614b36c31a650dea455a463fc490698#diff-17c71c5b10abe84f2b086c62917f1e33R534?

## Background

Some time ago `erts_init_sys_time_sup` [was moved](https://github.com/erlang/otp/commit/e52829ceb614b36c31a650dea455a463fc490698#diff-17c71c5b10abe84f2b086c62917f1e33R534) after `erts_lcnt_init` - not sure why - and is still this way in [recent master](https://github.com/erlang/otp/blob/7228e3ea97f8e2a19be97740053892e67cc20baf/erts/emulator/sys/unix/sys.c#L418-L423). I now found at least one set of configuration options on OSX where the opposite order would be required. The symptom is SEGV - more details below.

The naive change for moving forward (not sure would fix anything) would be reverting the call order - i.e. call `erts_init_sys_time_sup` before `erts_lcnt_init` - but as that call order has recently been changed (in a commit described as "erts_sys_hrtime() for lcnt") I preferred to stop here and request comments.

## Details of the SEGV on OSX

OTP master 7228e3e.

```
...
erlc -W  +debug_info -Werror +warn_export_vars +warn_missing_spec +warn_untyped_record -o../ebin hipe_gensym.erl
clock_get_time(ASAN:SIGSEGV
=================================================================
==14897==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7fff8e674f92 bp 0x7fff55fe5740 sp 0x7fff55fe5740 T0)
clock_get_time(ASAN:SIGSEGV
=================================================================
==14898==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7fff8e674f92 bp 0x7fff4fe16740 sp 0x7fff4fe16740 T0)
    #0 0x7fff8e674f91 in strlen (/usr/lib/system/libsystem_c.dylib+0xf91)
    #0 0x7fff8e674f91 in strlen (/usr/lib/system/libsystem_c.dylib+0xf91)
    #1 0x110615d99 in wrap_strlen (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/7.0.0/lib/darwin/libclang_rt.asan_osx_dynamic.dylib+0x3cd99)
    #1 0x10a445d99 in wrap_strlen (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/7.0.0/lib/darwin/libclang_rt.asan_osx_dynamic.dylib+0x3cd99)
    #2 0x10a0e58df in erts_printf_format erl_printf_format.c:775
    #3 0x109cb52d6 in erts_exit_vv erl_init.c:2384
    #4 0x109cb0114 in erts_exit erl_init.c:2409
    #5 0x109fa5d5f in erts_sys_hrtime sys_time.c:742
    #6 0x109e4f598 in lcnt_time erl_lock_count.c:112
    #7 0x109e4ea51 in erts_lcnt_clear_counters erl_lock_count.c:678
    #8 0x109f8d4e8 in erts_sys_pre_init sys.c:418
    #9 0x109cadef3 in early_init erl_init.c:792
    #10 0x109cb028c in erl_start erl_init.c:1260
    #11 0x109c19168 in main erl_main.c:30
    #12 0x7fff8ce285c8 in start (/usr/lib/system/libdyld.dylib+0x35c8)
    #13 0x1d  (<unknown module>)
...
```