### PR TITLE
Fix ssl_connection:select_curve/1

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -1845,7 +1845,7 @@ cipher_role(server, Data, Session,  #state{connection_states = ConnectionStates0
     {Record, State} = prepare_connection(State1, Connection),
     Connection:next_event(connection, Record, State).
 
-select_curve(#state{client_ecc = {[Curve|_], _}}) ->
+select_curve(#state{client_ecc = {#elliptic_curves{elliptic_curve_list = [Curve|_]}, _}}) ->
     {namedCurve, Curve};
 select_curve(_) ->
     {namedCurve, ?secp256r1}.

--- a/lib/ssl/src/ssl_connection.hrl
+++ b/lib/ssl/src/ssl_connection.hrl
@@ -81,7 +81,7 @@
           expecting_next_protocol_negotiation = false ::boolean(),
 	  expecting_finished =                  false ::boolean(),
           negotiated_protocol = undefined             :: undefined | binary(),
-	  client_ecc,          % {Curves, PointFmt}
+	  client_ecc           :: {#elliptic_curves{}, #ec_point_formats{}},
 	  tracker              :: pid() | 'undefined', %% Tracker process for listen socket
 	  sni_hostname = undefined,
 	  downgrade,


### PR DESCRIPTION
The function ssl_connection:select_curve/1 used to assume that the
available curves were a list inside the client_ecc state field, but they
are in fact stored inside an elliptic_curves record.  This would lead to
the TLS server ignoring client curve preferences and always selecting
the curve 'secp256r1'.

Also add a type spec for the client_ecc record field.