### PR TITLE
beam_block: Avoid unsafe inclusion of get_map_elements in blocks

### DIFF
--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -64,7 +64,6 @@ norm({set,[],[S,D],{set_tuple_element,I}}) -> {set_tuple_element,S,D,I};
 norm({set,[D1,D2],[S],get_list})          -> {get_list,S,D1,D2};
 norm({set,[D],[S|Puts],{alloc,R,{put_map,Op,F}}}) ->
     {put_map,F,Op,S,D,R,{list,Puts}};
-%% get_map_elements is always handled in beam_split (moved out of block)
 norm({set,[],[],remove_message})   -> remove_message;
 norm({set,[],[],fclearerror}) -> fclearerror;
 norm({set,[],[],fcheckerror}) -> {fcheckerror,{f,0}}.

--- a/lib/compiler/src/beam_split.erl
+++ b/lib/compiler/src/beam_split.erl
@@ -56,9 +56,6 @@ split_block([{set,[D],[S|Puts],{alloc,R,{put_map,Op,{f,Lbl}=Fail}}}|Is],
 	    Bl, Acc) when Lbl =/= 0 ->
     split_block(Is, [], [{put_map,Fail,Op,S,D,R,{list,Puts}}|
 			 make_block(Bl, Acc)]);
-split_block([{set,Ds,[S|Ss],{get_map_elements,Fail}}|Is], Bl, Acc) ->
-    Gets = beam_utils:join_even(Ss,Ds),
-    split_block(Is, [], [{get_map_elements,Fail,S,{list,Gets}}|make_block(Bl, Acc)]);
 split_block([{set,[R],[],{try_catch,Op,L}}|Is], Bl, Acc) ->
     split_block(Is, [], [{Op,R,L}|make_block(Bl, Acc)]);
 split_block([{set,[],[],{line,_}=Line}|Is], Bl, Acc) ->


### PR DESCRIPTION
c2035ebb8b restricted the get_map_elements instruction so that it
could only occur at the beginning of a block. It turns out to
also be unsafe.

Therefore, never put get_map_elements instruction in blocks.

ERL-266