### PR TITLE
Add mnesia:repair_continuation for continuing a select in a new activity

### DIFF
--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -1409,8 +1409,14 @@ select_cont(Tid,_,State=#mnesia_select{tid=Tid,written=[]}) ->
     select_state(dirty_sel_cont(State),State);
 select_cont(Tid,_Ts,State=#mnesia_select{tid=Tid})  ->
     trans_select(dirty_sel_cont(State), State);
-select_cont(_Tid2,_,#mnesia_select{tid=_Tid1}) ->  % Missmatching tids
+select_cont(Tid2,_,#mnesia_select{tid=_Tid1})
+  when element(1,Tid2) == tid ->  % Mismatching tids
     abort(wrong_transaction);
+select_cont(Tid,Ts,State=#mnesia_select{}) ->
+    % Repair mismatching tids in non-transactional contexts
+    RepairedState = State#mnesia_select{tid = Tid, written = [],
+                                        spec = undefined, type = undefined},
+    select_cont(Tid,Ts,RepairedState);
 select_cont(_,_,Cont) ->
     abort({badarg, Cont}).
 


### PR DESCRIPTION
I think the problem this PR fixes is best explained via the use case behind it. I have a web app implementing paginated search results using `mnesia:select/4`:

```erlang
{Rows1, C1} = mnesia:activity(async_dirty, fun mnesia:select/4, [Tab, MatchSpec, NObjects, read]),
draw_table(Rows1),

%% and when the user clicks next:
{Rows2, C2} = mnesia:activity(async_dirty, fun mnesia:select/1, [C1]),
draw_table(Rows2),

%% and so on
```

Unfortunately this doesn't work when the `mnesia:select/1` call is done from a different process (which is typical for web apps). It crashes with `{aborted,wrong_transaction}`, because the activity id for `async_dirty` contains the pid, so it will only match in the same process.

I understand this check is important for transactional contexts: reusing a continuation in a different transaction would break the transactional guarantees. However, for dirty (or `ets`) contexts it simply doesn't make sense.

One option would be to remove the check on the activity context in non-transactional uses. But that seems to be a bit too much magic to me, and also opens up a lot of questions about edge cases like continuing a select that was started in a transactional context in a non-transactional activity.

I decided on adding an explicit call, `mnesia:repair_continuation/1` (named after `ets:repair_continuation/1`), for importing a continuation into the current activity. It works across both transactional and non-transactional contexts. Maybe the first use case would not make much sense in practice, but if you actually need it, well, feel free to do it at your own risk! And since the new feature is introduced in a new function, it will not break existing code either.

So this PR makes possible to do things like this, regardless which process uses `C2`:

```erlang
{Rows1, C1} = mnesia:activity(async_dirty, fun mnesia:select/4, [Tab, MatchSpec, NObjects, read]),
draw_table(Rows1),

%% and when the user clicks next:
{Rows2, C2} = mnesia:activity(async_dirty, fun () -> mnesia:select(mnesia:repair_continuation(C1)) end),
draw_table(Rows2),

%% and so on
```

I tried to describe `mnesia:repair_continuation/1` in the docs as well as I could, but suggestions for improvements are welcome.