### PR TITLE
Replace ref() with reference() in inets files

### DIFF
--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -68,7 +68,7 @@
       this module:</p>
     <p><c>boolean() = true | false</c></p>
     <p><c>string()</c> = list of ASCII characters</p>
-    <p><c>request_id() = ref()</c></p>
+    <p><c>request_id() = reference()</c></p>
     <p><c>profile() = atom()</c></p>
     <p><c>path() = string()</c> representing a file path or directory path</p>
     <p><c>ip_address()</c> = See the

--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -45,28 +45,30 @@
 
 -record(timers, 
         {
-          request_timers = [], % [ref()]
-          queue_timer          % ref()
+          request_timers = [] :: [reference()],
+          queue_timer         :: reference() | 'undefined'
          }).
+
+-type session_failed() :: {'connect_failed',term()} | {'send_failed',term()}.
 
 -record(state, 
         {
-          request,                   % #request{}
-          session,                   % #session{}
+          request                   :: request() | 'undefined',
+          session                   :: session() | session_failed() | 'undefined',
           status_line,               % {Version, StatusCode, ReasonPharse}
-          headers,                   % #http_response_h{}
-          body,                      % binary()
+          headers                   :: http_response_h() | 'undefined',
+          body                      :: binary() | 'undefined',
           mfa,                       % {Module, Function, Args}
-          pipeline = queue:new(),    % queue:queue()
-          keep_alive = queue:new(),  % queue:queue()
+          pipeline = queue:new()    :: queue:queue(),
+          keep_alive = queue:new()  :: queue:queue(),
           status,   % undefined | new | pipeline | keep_alive | close | {ssl_tunnel, Request}
           canceled = [],             % [RequestId]
-          max_header_size = nolimit, % nolimit | integer() 
-          max_body_size = nolimit,   % nolimit | integer()
-          options,                   % #options{}
-          timers = #timers{},        % #timers{}
-          profile_name,              % atom() - id of httpc_manager process.
-          once = inactive            % inactive | once
+          max_header_size = nolimit :: nolimit | integer(),
+          max_body_size = nolimit   :: nolimit | integer(),
+          options                   :: options(),
+          timers = #timers{}        :: #timers{},
+          profile_name              :: atom(), % id of httpc_manager process.
+          once = inactive           :: 'inactive' | 'once'
          }).
 
 
@@ -113,7 +115,7 @@ send(Request, Pid) ->
 
 %%--------------------------------------------------------------------
 %% Function: cancel(RequestId, Pid) -> ok
-%%      RequestId = ref()
+%%      RequestId = reference()
 %%      Pid = pid() -  the pid of the http-request handler process.
 %%
 %% Description: Cancels a request. Intended to be called by the httpc
@@ -789,47 +791,6 @@ deliver_answer(Request) ->
 %% Purpose: Convert process state when code is changed
 %%--------------------------------------------------------------------
 
-code_change(_, 
-            #state{session      = OldSession, 
-                   profile_name = ProfileName} = State, 
-            upgrade_from_pre_5_8_1) ->
-    case OldSession of
-        {session, 
-         Id, ClientClose, Scheme, Socket, SocketType, QueueLen, Type} ->
-            NewSession = #session{id           = Id, 
-                                  client_close = ClientClose, 
-                                  scheme       = Scheme, 
-                                  socket       = Socket, 
-                                  socket_type  = SocketType,
-                                  queue_length = QueueLen, 
-                                  type         = Type}, 
-            insert_session(NewSession, ProfileName), 
-            {ok, State#state{session = NewSession}};
-        _ -> 
-            {ok, State}
-    end;
-
-code_change(_, 
-            #state{session      = OldSession, 
-                   profile_name = ProfileName} = State, 
-            downgrade_to_pre_5_8_1) ->
-    case OldSession of
-        #session{id           = Id, 
-                 client_close = ClientClose, 
-                 scheme       = Scheme, 
-                 socket       = Socket, 
-                 socket_type  = SocketType,
-                 queue_length = QueueLen, 
-                 type         = Type} ->
-            NewSession = {session, 
-                          Id, ClientClose, Scheme, Socket, SocketType, 
-                          QueueLen, Type},
-            insert_session(NewSession, ProfileName), 
-            {ok, State#state{session = NewSession}};
-        _ -> 
-            {ok, State}
-    end;
-
 code_change(_, State, _) ->
     {ok, State}.
 
@@ -934,8 +895,7 @@ connect_and_send_first_request(Address, Request, #state{options = Options} = Sta
                     TmpState = State#state{request = Request,
                                            session = Session,
                                            mfa = init_mfa(Request, State),
-                                           status_line =
-                                           init_status_line(Request),
+                                           status_line = init_status_line(Request),
                                            headers = undefined,
                                            body = undefined,
                                            status = new},
@@ -947,8 +907,7 @@ connect_and_send_first_request(Address, Request, #state{options = Options} = Sta
                     self() ! {init_error, error_sending,
                               httpc_response:error(Request, Reason)},
                     {ok, State#state{request = Request,
-                                     session =
-                                         #session{socket = Socket}}}
+                                     session = #session{socket = Socket}}}
             end;
         {error, Reason} ->
             self() ! {init_error, error_connecting,
@@ -1796,7 +1755,7 @@ tls_tunnel_request(#request{headers = Headers,
     URI = Host ++":" ++ integer_to_list(Port),
     
     #request{
-       id =  make_ref(),
+       id = make_ref(),
        from = self(),
        scheme = http, %% Use tcp-first and then upgrade!
        address = Adress,
@@ -1922,8 +1881,8 @@ update_session(ProfileName, #session{id = SessionId} = Session, Pos, Value) ->
 %% ---------------------------------------------------------------------
 
 call(Msg, Pid) ->
-    Timeout = infinity,
-    call(Msg, Pid, Timeout).
+    call(Msg, Pid, infinity).
+
 call(Msg, Pid, Timeout) ->
     gen_server:call(Pid, Msg, Timeout).
 

--- a/lib/inets/src/http_client/httpc_internal.hrl
+++ b/lib/inets/src/http_client/httpc_internal.hrl
@@ -43,32 +43,32 @@
 %%% HTTP Client per request settings
 -record(http_options,
 	{
-	  %% string() - "HTTP/1.1" | "HTTP/1.0" | "HTTP/0.9"
-	  version, 
+	  %% "HTTP/1.1" | "HTTP/1.0" | "HTTP/0.9"
+	  version :: 'undefined' | string(),
 
-	  %% integer() | infinity - ms before a request times out
-	  timeout = ?HTTP_REQUEST_TIMEOUT,  
+	  %% ms before a request times out
+	  timeout = ?HTTP_REQUEST_TIMEOUT :: timeout(),
 
-	  %% bool() - true if auto redirect on 30x response
-	  autoredirect = true, 
+	  %% true if auto redirect on 30x response
+	  autoredirect = true :: boolean(),
 
 	  %% ssl socket options
-	  ssl = [], 
+	  ssl = [],
 
 	  %% {User, Password} = {string(), string()} 
 	  proxy_auth, 
 
-	  %% bool() - true if not strictly std compliant
-	  relaxed = false, 
+	  %% true if not strictly std compliant
+	  relaxed = false :: boolean(),
 
 	  %% integer() - ms before a connect times out
-	  connect_timeout = ?HTTP_REQUEST_CTIMEOUT,
+	  connect_timeout = ?HTTP_REQUEST_CTIMEOUT :: timeout(),
 
-	  %% bool() - Use %-encoding rfc 2396
-	  url_encode
-
+	  %% Use %-encoding rfc 2396
+	  url_encode :: 'undefined' | boolean()
 	 }
        ).
+-type http_options() :: #http_options{}.
 
 %%% HTTP Client per profile setting. 
 -record(options, 
@@ -82,18 +82,19 @@
 	 keep_alive_timeout    = ?HTTP_KEEP_ALIVE_TIMEOUT, % Used when pipeline_timeout = 0
 	 max_sessions          = ?HTTP_MAX_TCP_SESSIONS,
 	 cookies               = disabled, % enabled | disabled | verify
-	 verbose               = false,
+	 verbose               = false,   % boolean(),
 	 ipfamily              = inet,    % inet | inet6 | inet6fb4
 	 ip                    = default, % specify local interface
 	 port                  = default, % specify local port
 	 socket_opts           = []       % other socket options
 	}
        ).
+-type options() :: #options{}.
 
 %%% All data associated to a specific HTTP request
 -record(request,
 	{
-	  id,            % ref() - Request Id
+	  id            :: 'undefined' | reference(), % Request Id
 	  from,          % pid() - Caller
 	  redircount = 0,% Number of redirects made for this request
 	  scheme,        % http | https 
@@ -103,7 +104,7 @@
 	  method,        % atom() - HTTP request Method
 	  headers,       % #http_request_h{}
 	  content,       % {ContentType, Body} - Current HTTP request
-	  settings,      % #http_options{} - User defined settings
+	  settings      :: http_options(), % User defined settings
 	  abs_uri,       % string() ex: "http://www.erlang.org"
 	  userinfo,      % string() - optinal "<userinfo>@<host>:<port>"
 	  stream,	 % boolean() - stream async reply?
@@ -112,20 +113,19 @@
 			 % for testing purposes.
 	  started,       % integer() > 0 - When we started processing the 
 			 % request
-	  timer,         % undefined | ref()
+	  timer         :: undefined | reference(),
 	  socket_opts,   % undefined | [socket_option()]
 	  ipv6_host_with_brackets % boolean()
 	}
-       ).               
-
+       ).
+-type request() :: #request{}.
 
 -record(session,
 	{
 	  %% {{Host, Port}, HandlerPid}
 	  id, 
 
-	  %% true | false
-	  client_close, 
+	  client_close :: 'undefined' | boolean(),
 
 	  %% http (HTTP/TCP) | https (HTTP/SSL/TCP)
 	  scheme, 
@@ -140,14 +140,13 @@
 	  queue_length = 1, 
 
 	  %% pipeline | keep_alive (wait for response before sending new request) 
-	  type, 
+	  type :: 'undefined' | 'pipeline' | 'keep_alive',
 
-	  %% true | false
 	  %% This will be true, when a response has been received for 
 	  %% the first request. See type above.
-	  available = false
+	  available = false :: boolean()
 	 }).
-
+-type session() :: #session{}.
 
 -record(http_cookie,
 	{
@@ -162,7 +161,7 @@
 	  secure = false,
 	  version = "0" 
 	 }).
-
+-type http_cookie() :: #http_cookie{}.
 
 %% -record(parsed_uri, 
 %% 	{

--- a/lib/inets/src/http_client/httpc_manager.erl
+++ b/lib/inets/src/http_client/httpc_manager.erl
@@ -137,7 +137,7 @@ redirect_request(Request, ProfileName) ->
 
 %%--------------------------------------------------------------------
 %% Function: cancel_request(RequestId, ProfileName) -> ok
-%%	RequestId - ref()
+%%	RequestId - reference()
 %%      ProfileName = atom()
 %%
 %% Description: Cancels the request with <RequestId>.
@@ -148,7 +148,7 @@ cancel_request(RequestId, ProfileName) ->
 
 %%--------------------------------------------------------------------
 %% Function: request_done(RequestId, ProfileName) -> ok
-%%	RequestId - ref()
+%%	RequestId - reference()
 %%      ProfileName = atom()
 %%
 %% Description: Inform tha manager that a request has been completed.

--- a/lib/inets/src/http_lib/http_internal.hrl
+++ b/lib/inets/src/http_lib/http_internal.hrl
@@ -71,7 +71,7 @@
  	  'last-modified',
 	  other=[]        % list() - Key/Value list with other headers
 	 }).
-
+-type http_response_h() :: #http_response_h{}.
 
 %%% Request headers
 -record(http_request_h,{
@@ -118,5 +118,6 @@
  	  'last-modified',
 	  other=[]        % list() - Key/Value list with other headers
 	 }).
+-type http_request_h() :: #http_request_h{}.
 
 -endif. % -ifdef(http_internal_hrl).

--- a/lib/inets/src/http_server/httpd_request_handler.erl
+++ b/lib/inets/src/http_server/httpd_request_handler.erl
@@ -37,18 +37,19 @@
 -include("httpd_internal.hrl").
 
 -define(HANDSHAKE_TIMEOUT, 5000).
+
 -record(state, {mod,     %% #mod{}
 		manager, %% pid()
 		status,  %% accept | busy | blocked
 		mfa,     %% {Module, Function, Args} 
 		max_keep_alive_request = infinity, %% integer() | infinity
-		response_sent = false, %% true | false 
-		timeout,  %% infinity | integer() > 0
-		timer,     %% ref() - Request timer
-		headers,  %% #http_request_h{}
+		response_sent = false :: boolean(),
+		timeout,   %% infinity | integer() > 0
+		timer      :: 'undefined' | reference(), % Request timer
+		headers,   %% #http_request_h{}
 		body,      %% binary()
 		data,      %% The total data received in bits, checked after 10s
-		byte_limit  %% Bit limit per second before kick out
+		byte_limit %% Bit limit per second before kick out
 	       }).
 
 %%====================================================================


### PR DESCRIPTION
This supersedes PR #1185 (submitted by @KrzysiekJ) that changed
all occurrences of ref() with reference() in inets files.

However, there is little point in having these types only in comments.
So, these types are now exposed as type declarations for the record
fields they appear.  While at it, uncommented more commented out type
declarations and declared types for records defined in the affected
modules and header files.

Some type-unfriendly and obsolete code related to supporting code
ungrades with a really old OTP release was also removed.