### PR TITLE
Use atom value as hash value in process dictionary

### DIFF
--- a/erts/emulator/beam/erl_process_dict.c
+++ b/erts/emulator/beam/erl_process_dict.c
@@ -56,7 +56,7 @@
 #define MAKE_HASH(Term)                                \
     ((is_small(Term)) ? unsigned_val(Term) :           \
      ((is_atom(Term)) ?                                \
-      (atom_tab(atom_val(Term))->slot.bucket.hvalue) : \
+      atom_val(Term) :								   \
       make_internal_hash(Term)))
 
 #define PD_SZ2BYTES(Sz) (sizeof(ProcDict) + ((Sz) - 1)*sizeof(Eterm))


### PR DESCRIPTION
In the origin implementation, the hash value of atom term is retrieved
from the atom table.  Reading the atom table is expensive since it is in
memory and leads to more cache missing.

The size of a process dictionary is usually small.  The atom value (the
 index) is unique and can be hash value for it.  Using the atom value
 directly should be more efficient.