### PR TITLE
Add `system_info(atom_limit)` 

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -7185,13 +7185,14 @@ ok
               <c>erlang:system_info({allocator,
               <anno>Alloc</anno>})</c></seealso>.</p>
           </item>
+          
         </taglist>
       </desc>
     </func>
 
     <func>
-      <name name="system_info" arity="1" clause_i="10"/>
       <name name="system_info" arity="1" clause_i="11"/>
+      <name name="system_info" arity="1" clause_i="12"/>
       <fsummary>Information about the CPU topology of the system.</fsummary>
       <type name="cpu_topology"/>
       <type name="level_entry"/>
@@ -7291,12 +7292,12 @@ ok
     </func>
 
     <func>
-      <name name="system_info" arity="1" clause_i="27"/>
       <name name="system_info" arity="1" clause_i="28"/>
-      <name name="system_info" arity="1" clause_i="36"/>
+      <name name="system_info" arity="1" clause_i="29"/>
       <name name="system_info" arity="1" clause_i="37"/>
       <name name="system_info" arity="1" clause_i="38"/>
       <name name="system_info" arity="1" clause_i="39"/>
+      <name name="system_info" arity="1" clause_i="40"/>
       <fsummary>Information about the default process heap settings.</fsummary>
       <type name="message_queue_data"/>
       <type name="max_heap_size"/>
@@ -7373,7 +7374,7 @@ ok
       <name name="system_info" arity="1" clause_i="7"/>
       <name name="system_info" arity="1" clause_i="8"/>
       <name name="system_info" arity="1" clause_i="9"/>
-      <name name="system_info" arity="1" clause_i="12"/>
+      <name name="system_info" arity="1" clause_i="10"/>
       <name name="system_info" arity="1" clause_i="13"/>
       <name name="system_info" arity="1" clause_i="14"/>
       <name name="system_info" arity="1" clause_i="15"/>
@@ -7388,14 +7389,14 @@ ok
       <name name="system_info" arity="1" clause_i="24"/>
       <name name="system_info" arity="1" clause_i="25"/>
       <name name="system_info" arity="1" clause_i="26"/>
-      <name name="system_info" arity="1" clause_i="29"/>
+      <name name="system_info" arity="1" clause_i="27"/>
       <name name="system_info" arity="1" clause_i="30"/>
       <name name="system_info" arity="1" clause_i="31"/>
       <name name="system_info" arity="1" clause_i="32"/>
       <name name="system_info" arity="1" clause_i="33"/>
       <name name="system_info" arity="1" clause_i="34"/>
       <name name="system_info" arity="1" clause_i="35"/>
-      <name name="system_info" arity="1" clause_i="40"/>
+      <name name="system_info" arity="1" clause_i="36"/>
       <name name="system_info" arity="1" clause_i="41"/>
       <name name="system_info" arity="1" clause_i="42"/>
       <name name="system_info" arity="1" clause_i="43"/>
@@ -7425,6 +7426,7 @@ ok
       <name name="system_info" arity="1" clause_i="67"/>
       <name name="system_info" arity="1" clause_i="68"/>
       <name name="system_info" arity="1" clause_i="69"/>
+      <name name="system_info" arity="1" clause_i="70"/>
       <fsummary>Information about the system.</fsummary>
       <desc>
         <p>Returns various information about the current system
@@ -7435,6 +7437,16 @@ ok
           <item>
             <p>See <seealso marker="#system_info_allocator_tags">
               above</seealso>.</p>
+          </item>
+          <tag><c>atom_limit</c></tag>
+          <item>
+            <marker id="system_info_atom_limit"></marker>
+            <p>Returns the maximum number of atoms allowed.
+              This limit can be increased at startup by passing
+              command-line flag
+              <seealso marker="erts:erl#+t"><c>+t</c></seealso> to
+              <c>erl(1)</c>. 
+            </p>
           </item>
           <tag><c>build_type</c></tag>
           <item>

--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -483,3 +483,9 @@ dump_atoms(int to, void *to_arg)
 	}
     }
 }
+
+Uint
+erts_get_atom_limit(void)
+{
+    return erts_atom_table.limit;
+}

--- a/erts/emulator/beam/atom.h
+++ b/erts/emulator/beam/atom.h
@@ -138,6 +138,7 @@ int atom_static_put(byte*, int);
 void init_atom_table(void);
 void atom_info(int, void *);
 void dump_atoms(int, void *);
+Uint erts_get_atom_limit(void);
 int erts_atom_get(const char* name, int len, Eterm* ap, ErtsAtomEncoding enc);
 void erts_atom_get_text_space_sizes(Uint *reserved, Uint *used);
 #endif

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2859,6 +2859,9 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
     else if (ERTS_IS_ATOM_STR("ets_limit",BIF_ARG_1)) {
         BIF_RET(make_small(erts_db_get_max_tabs()));
     }
+    else if (ERTS_IS_ATOM_STR("atom_limit",BIF_ARG_1)) {
+        BIF_RET(make_small(erts_get_atom_limit()));
+    }
     else if (ERTS_IS_ATOM_STR("tolerant_timeofday",BIF_ARG_1)) {
 	if (erts_has_time_correction()
 	    && erts_time_offset_state() == ERTS_TIME_OFFSET_FINAL) {

--- a/erts/emulator/test/system_info_SUITE.erl
+++ b/erts/emulator/test/system_info_SUITE.erl
@@ -36,7 +36,7 @@
 -export([all/0, suite/0]).
 
 -export([process_count/1, system_version/1, misc_smoke_tests/1,
-         heap_size/1, wordsize/1, memory/1, ets_limit/1]).
+         heap_size/1, wordsize/1, memory/1, ets_limit/1, atom_limit/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -44,7 +44,7 @@ suite() ->
 
 all() -> 
     [process_count, system_version, misc_smoke_tests,
-     heap_size, wordsize, memory, ets_limit].
+     heap_size, wordsize, memory, ets_limit, atom_limit].
 
 %%%
 %%% The test cases -------------------------------------------------------------
@@ -472,6 +472,17 @@ mapn(_Fun, 0) ->
 mapn(Fun, N) ->
     [Fun(N) | mapn(Fun, N-1)].
 
+
+get_node_name(Config) ->
+    list_to_atom(atom_to_list(?MODULE)
+		 ++ "-"
+		 ++ atom_to_list(proplists:get_value(testcase, Config))
+		 ++ "-"
+		 ++ integer_to_list(erlang:system_time(second))
+		 ++ "-"
+		 ++ integer_to_list(erlang:unique_integer([positive]))).
+
+
 %% Verify system_info(ets_limit) reflects max ETS table settings.
 ets_limit(Config0) when is_list(Config0) ->
     Config = [{testcase,ets_limit}|Config0],
@@ -486,7 +497,7 @@ get_ets_limit(Config, EtsMax) ->
                0 -> [];
                _ -> [{"ERL_MAX_ETS_TABLES", integer_to_list(EtsMax)}]
            end,
-    {ok, Node} = start_node(Config, Envs),
+    {ok, Node} = start_node_ets(Config, Envs),
     Me = self(),
     Ref = make_ref(),
     spawn_link(Node,
@@ -502,16 +513,40 @@ get_ets_limit(Config, EtsMax) ->
     stop_node(Node),
     Res.
 
-start_node(Config, Envs) when is_list(Config) ->
+start_node_ets(Config, Envs) when is_list(Config) ->
     Pa = filename:dirname(code:which(?MODULE)),
-    Name = list_to_atom(atom_to_list(?MODULE)
-                        ++ "-"
-                        ++ atom_to_list(proplists:get_value(testcase, Config))
-                        ++ "-"
-                        ++ integer_to_list(erlang:system_time(second))
-                        ++ "-"
-                        ++ integer_to_list(erlang:unique_integer([positive]))),
-    test_server:start_node(Name, peer, [{args, "-pa "++Pa}, {env, Envs}]).
+    test_server:start_node(get_node_name(Config), peer,
+			   [{args, "-pa "++Pa}, {env, Envs}]).
+
+start_node_atm(Config, AtomsMax) when is_list(Config) ->
+    Pa = filename:dirname(code:which(?MODULE)),
+    test_server:start_node(get_node_name(Config), peer,
+			   [{args, "-pa "++ Pa ++ AtomsMax}]).
 
 stop_node(Node) ->
     test_server:stop_node(Node).
+
+
+%% Verify system_info(atom_limit) reflects max atoms settings
+%% (using " +t").
+atom_limit(Config0) when is_list(Config0) ->
+    Config = [{testcase,atom_limit}|Config0],
+    2186042 = get_atom_limit(Config, " +t 2186042 "),
+    ok.
+
+get_atom_limit(Config, AtomsMax) ->
+    {ok, Node} = start_node_atm(Config, AtomsMax),
+    Me = self(),
+    Ref = make_ref(),
+    spawn_link(Node,
+        fun() ->
+            Res = erlang:system_info(atom_limit),
+            unlink(Me),
+            Me ! {Ref, Res}
+        end),
+    receive
+        {Ref, Res} ->
+            Res
+    end,
+    stop_node(Node),
+    Res.

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2508,6 +2508,7 @@ tuple_to_list(_Tuple) ->
       Alloc :: atom();
          ({allocator_sizes, Alloc}) -> [_] when %% More or less anything
       Alloc :: atom();
+         (atom_limit) -> pos_integer();
          (build_type) -> opt | debug | purify | quantify | purecov |
                          gcov | valgrind | gprof | lcnt | frmptr;
          (c_compiler_used) -> {atom(), term()};


### PR DESCRIPTION
Add `system_info(atoms_limit)` to provide a way to retrieve the
maximum number of atoms allowed. Add tests and documentation for it too.

```
➜ ✗ bin/erl +t 1123456
Erlang/OTP 19 [erts-8.1] [source-e895301] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.1  (abort with ^G)
1> erlang:system_info(atoms_limit).
1123456
2>
```
Added:
 - [atoms_list](https://github.com/Gsantomaggio/otp/blob/system_info_atoms/erts/preloaded/src/erlang.erl#L2511) on `erlang.erl` 
 - [test](https://github.com/Gsantomaggio/otp/blob/system_info_atoms/erts/emulator/test/system_info_SUITE.erl#L532)
 
test result:
 ```
 1> ts:run(emulator, system_info_SUITE, atoms_limit, [batch]).
...
Common Test starting (cwd is /Users/gabriele/github/Personal/otp_atom_limit/release/tests/emulator_test)
Common Test: Running make in test directories...

CWD set to: "/Users/gabriele/github/Personal/otp_atom_limit/release/tests/test_server/ct_run.test_server@mac.2016-10-10_14.27.50"

TEST INFO: 1 test(s), 1 case(s) in 1 suite(s)

Testing tests.emulator_test.system_info_SUITE.atoms_limit: Starting test, 1 test cases
Testing tests.emulator_test.system_info_SUITE.atoms_limit: TEST COMPLETE, 1 ok, 0 failed of 1 test cases

Updating /Users/gabriele/github/Personal/otp_atom_limit/release/tests/test_server/index.html ... done
Updating /Users/gabriele/github/Personal/otp_atom_limit/release/tests/test_server/all_runs.html ... done
ok
2>
```

Also refactored [start_node](https://github.com/Gsantomaggio/otp/blob/system_info_atoms/erts/emulator/test/system_info_SUITE.erl#L516) to avoid code duplication
