### PR TITLE
handle send_to_non_existing_process trace event in fprof

### DIFF
--- a/lib/tools/src/fprof.erl
+++ b/lib/tools/src/fprof.erl
@@ -1702,6 +1702,12 @@ trace_handler({trace_ts, Pid, send, _OtherPid, _Msg, TS} = Trace,
     dump_stack(Dump, get(Pid), Trace),
     TS;
 %%
+%% send_to_non_existing_process
+trace_handler({trace_ts, Pid, send_to_non_existing_process, _OtherPid, _Msg, TS} = Trace,
+	      _Table, _, Dump) ->
+    dump_stack(Dump, get(Pid), Trace),
+    TS;
+%%
 %% 'receive'
 trace_handler({trace_ts, Pid, 'receive', _Msg, TS} = Trace,
 	      _Table, _, Dump) ->


### PR DESCRIPTION
fprof did not handle this trace event. Sending to a non existing
process should not be much different from sending to an existing
process, so duplicate that logic.
