### PR TITLE
ei_connect_xinit shall mask creation to two lowest bits.

### DIFF
--- a/lib/erl_interface/src/connect/ei_connect.c
+++ b/lib/erl_interface/src/connect/ei_connect.c
@@ -423,7 +423,7 @@ int ei_connect_xinit(ei_cnode* ec, const char *thishostname,
     }
 #endif /* _REENTRANT */
 
-    ec->creation = creation;
+    ec->creation = creation & 0x3; /* 2 bits */
     
     if (cookie) {
 	if (strlen(cookie) >= sizeof(ec->ei_connect_cookie)) { 
@@ -462,7 +462,7 @@ int ei_connect_xinit(ei_cnode* ec, const char *thishostname,
     strcpy(ec->self.node,thisnodename);
     ec->self.num = 0;
     ec->self.serial = 0;
-    ec->self.creation = creation;
+    ec->self.creation = creation & 0x3; /* 2 bits */
 
     if ((dbglevel = getenv("EI_TRACELEVEL")) != NULL ||
 	(dbglevel = getenv("ERL_DEBUG_DIST")) != NULL)


### PR DESCRIPTION
Closes issue discussed here:
http://erlang.org/pipermail/erlang-questions/2016-October/090592.html