### PR TITLE
dbg:fun2ms: allow empty list as head

### DIFF
--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -451,6 +451,8 @@ check_type(_,[{record,_,_,_}],ets) ->
     ok;
 check_type(_,[{cons,_,_,_}],dbg) ->
     ok;
+check_type(_,[{nil,_}],dbg) ->
+    ok;
 check_type(Line0,[{match,_,{var,_,_},X}],Any) ->
     check_type(Line0,[X],Any);
 check_type(Line0,[{match,_,X,{var,_,_}}],Any) ->

--- a/lib/stdlib/test/ms_transform_SUITE.erl
+++ b/lib/stdlib/test/ms_transform_SUITE.erl
@@ -296,6 +296,8 @@ basic_dbg(Config) when is_list(Config) ->
 	compile_and_run(<<"dbg:fun2ms(fun([A,B]) -> bindings() end)">>),
     [{['$1','$2'],[],['$_']}] =
 	compile_and_run(<<"dbg:fun2ms(fun([A,B]) -> object() end)">>),
+    [{[],[],[{return_trace}]}] =
+	compile_and_run(<<"dbg:fun2ms(fun([]) -> return_trace() end)">>),
     ok.
 
 %% Test calling of ets/dbg:fun2ms from the shell.


### PR DESCRIPTION
Running 'dbg:fun2ms(fun([]) -> return_trace() end' resulted in an error
"dbg:fun2ms requires fun with single variable or list parameter"

But the empty list is actually a list and it is a valid value as a
match-spec head (matching on arity-0 functions).

Although its practical use is questionable this commit eliminates a
small limitation of ms_transform which is not present in the match-spec
grammar.