### PR TITLE
Clarify permission bits in file.xml

### DIFF
--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -1477,8 +1477,8 @@ f.txt:  {person, "kalle", 25}.
               <tag><c>16#400</c></tag>
               <item><p>set group id on execution</p></item>
             </taglist>
-            <p>On Unix platforms, the following bits
-              can also be set:</p>
+            <p>On Unix platforms, other bits than those listed above
+		may be set.</p>
           </item>
           <tag><c>links = integer() >= 0</c></tag>
           <item>
@@ -2042,8 +2042,8 @@ f.txt:  {person, "kalle", 25}.
               <tag><c>16#400</c></tag>
               <item><p>Set group id on execution</p></item>
             </taglist>
-            <p>On Unix platforms, the following bits
-              can also be set.</p>
+            <p>On Unix platforms, other bits than those listed above
+		may be set.</p>
           </item>
           <tag><c>uid = integer() >= 0</c></tag>
           <item>


### PR DESCRIPTION
In commit 3d70cee4034e, this text was changed to suggest that a list of Unix-specific permission bits would follow, but no such list was added. Let's revert back to the previous wording, so people won't look for a list that isn't there.

NB: I'm not sure that this statement is actually true. If the list of permission bits is in fact complete, this piece of text should just be removed.
