### PR TITLE
Cleanup and simplify some HiPE loader code

### DIFF
--- a/erts/emulator/hipe/hipe_bif0.c
+++ b/erts/emulator/hipe/hipe_bif0.c
@@ -1582,7 +1582,7 @@ BIF_RETTYPE hipe_bifs_add_ref_2(BIF_ALIST_2)
 		  ref, callee.mod, callee.fun, callee.ari, ref->address);
     DBG_TRACE_MFA(callee.mod, callee.fun, callee.ari, "add_ref at %p FROM %T:%T/%u (from %p)",
 		  ref, caller.mod, caller.fun, caller.ari, ref->address);
-    BIF_RET(NIL);
+    BIF_RET(am_ok);
 
  badarg:
     BIF_ERROR(BIF_P, BADARG);

--- a/lib/hipe/cerl/erl_bif_types.erl
+++ b/lib/hipe/cerl/erl_bif_types.erl
@@ -1003,7 +1003,7 @@ type(erlang, tuple_to_list, 1, Xs, Opaques) ->
 	 end, Opaques);
 %%-- hipe_bifs ----------------------------------------------------------------
 type(hipe_bifs, add_ref, 2, Xs, Opaques) ->
-  strict(hipe_bifs, add_ref, 2, Xs, fun (_) -> t_nil() end, Opaques);
+  strict(hipe_bifs, add_ref, 2, Xs, fun (_) -> t_atom('ok') end, Opaques);
 type(hipe_bifs, alloc_data, 3, Xs, Opaques) ->
   strict(hipe_bifs, alloc_data, 3, Xs,
 	 fun (_) -> t_integer() end, Opaques); % address

--- a/lib/kernel/src/hipe_unified_loader.erl
+++ b/lib/kernel/src/hipe_unified_loader.erl
@@ -772,27 +772,26 @@ find_const(ConstNo, []) ->
 
 add_ref(CalleeMFA, Address, FunDefs, RefType, Trampoline, RemoteOrLocal) ->
   CallerMFA = address_to_mfa_lth(Address, FunDefs),
-  _  = case RemoteOrLocal of
+  case RemoteOrLocal of
     local ->
       %% just a sanity assertion
-      {M,_,_} = CalleeMFA,
-      {M,_,_} = CallerMFA;
+      {_M,_,_} = CalleeMFA,
+      ok;
     remote ->
       hipe_bifs:add_ref(CalleeMFA, {CallerMFA,Address,RefType,Trampoline,
 				    get(hipe_loader_state)})
-  end,
-  ok.
+  end.
 
-% For FunDefs sorted from low to high addresses
+%% For FunDefs sorted from low to high addresses
 address_to_mfa_lth(Address, FunDefs) ->
-    case address_to_mfa_lth(Address, FunDefs, false) of
-	false ->
-	    ?error_msg("Local adddress not found ~w\n",[Address]),
-	    exit({?MODULE, local_address_not_found});
-	MFA ->
-	    MFA
-    end.
-    
+  case address_to_mfa_lth(Address, FunDefs, false) of
+    false ->
+      ?error_msg("Local adddress not found ~w\n",[Address]),
+      exit({?MODULE, local_address_not_found});
+    MFA ->
+      MFA
+  end.
+
 address_to_mfa_lth(Address, [#fundef{address=Adr, mfa=MFA}|Rest], Prev) ->
   if Address < Adr -> 
 	  Prev;
@@ -802,7 +801,7 @@ address_to_mfa_lth(Address, [#fundef{address=Adr, mfa=MFA}|Rest], Prev) ->
 address_to_mfa_lth(_Address, [], Prev) -> 
     Prev.
 
-% For FunDefs sorted from high to low addresses
+%% For FunDefs sorted from high to low addresses
 %% address_to_mfa_htl(Address, [#fundef{address=Adr, mfa=MFA}|_Rest]) when Address >= Adr -> MFA;
 %% address_to_mfa_htl(Address, [_ | Rest]) -> address_to_mfa_htl(Address, Rest);
 %% address_to_mfa_htl(Address, []) -> 
@@ -867,8 +866,6 @@ assert_local_patch(Address) when is_integer(Address) ->
 
 %% ____________________________________________________________________
 %% 
-
-%% Beam: nil() | binary()  (used as a flag)
 
 enter_code(CodeSize, CodeBinary, CalleeMFAs, LoaderState) ->
   true = byte_size(CodeBinary) =:= CodeSize,

--- a/lib/kernel/src/hipe_unified_loader.erl
+++ b/lib/kernel/src/hipe_unified_loader.erl
@@ -774,8 +774,9 @@ add_ref(CalleeMFA, Address, FunDefs, RefType, Trampoline, RemoteOrLocal) ->
   CallerMFA = address_to_mfa_lth(Address, FunDefs),
   case RemoteOrLocal of
     local ->
-      %% just a sanity assertion
-      {_M,_,_} = CalleeMFA,
+      %% assert that the callee and caller are from the same module
+      {M,_,_} = CalleeMFA,
+      {M,_,_} = CallerMFA,
       ok;
     remote ->
       hipe_bifs:add_ref(CalleeMFA, {CallerMFA,Address,RefType,Trampoline,


### PR DESCRIPTION
by changing the return value of  `hipe_bifs:add_ref/2`.