### PR TITLE
Add ECC curve selection order config in TLS server

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -170,6 +170,14 @@
       <tag><c>SNIfun::fun()</c></tag>
       <item><p><c>= fun(ServerName :: string()) -> [ssl_option()]</c></p></item>
 
+      <tag><c>named_curve() =</c></tag>
+      <item><p><c>sect571r1 | sect571k1 | secp521r1 | brainpoolP512r1
+       | sect409k1 | sect409r1 | brainpoolP384r1 | secp384r1
+       | sect283k1 | sect283r1 | brainpoolP256r1 | secp256k1 | secp256r1
+       | sect239k1 | sect233k1 | sect233r1 | secp224k1 | secp224r1
+       | sect193r1 | sect193r2 | secp192k1 | secp192r1 | sect163k1
+       | sect163r1 | sect163r2 | secp160k1 | secp160r1 | secp160r2</c></p></item>
+
     </taglist>
   </section>
 
@@ -216,6 +224,11 @@
       this option; they are supported/enabled by the peer also.
       Anonymous cipher suites are supported for testing purposes
       only and are not be used when security matters.</p></item>
+
+      <tag><c>{eccs, [named_curve()]}</c></tag>
+      <item><p> Allows to specify the order of preference for named curves
+      and to restrict their usage when using a cipher suite supporting them.
+      </p></item>
 
       <tag><c>{secure_renegotiate, boolean()}</c></tag>
       <item><p>Specifies if to reject renegotiation attempt that does
@@ -751,6 +764,11 @@ fun(srp, Username :: string(), UserState :: term()) ->
       (the default), use the client's preference.
       </item>
       
+      <tag><c>{honor_ecc_order, boolean()}</c></tag>
+      <item>If true, use the server's preference for ECC curve selection. If false
+      (the default), use the client's preference.
+      </item>
+
       <tag><c>{signature_algs, [{hash(), ecdsa | rsa | dsa}]}</c></tag>
       <item><p> The algorithms specified by
       this option will be the ones accepted by the server in a signature algorithm
@@ -801,6 +819,17 @@ fun(srp, Username :: string(), UserState :: term()) ->
 	<c>cipher_suites(all)</c> are not used unless explicitly configured
 	by the user.</p>
     </desc>
+    </func>
+
+    <func>
+      <name>eccs() -></name>
+      <name>eccs(protocol()) -> [named_curve()]</name>
+      <fsummary>Returns a list of supported ECCs.</fsummary>
+
+      <desc><p>Returns a list of supported ECCs. <c>eccs()</c>
+      is equivalent to calling <c>eccs(Protocol)</c> with all
+      supported protocols and then deduplicating the output.</p>
+      </desc>
     </func>
 
     <func>
@@ -898,7 +927,7 @@ fun(srp, Username :: string(), UserState :: term()) ->
       <fsummary>Returns all the connection information.
       </fsummary>
       <type>
-        <v>Item = protocol | cipher_suite | sni_hostname | atom()</v>
+        <v>Item = protocol | cipher_suite | sni_hostname | ecc | atom()</v>
 	<d>Meaningful atoms, not specified above, are the ssl option names.</d>
 	<v>Result = [{Item::atom(), Value::term()}]</v>
         <v>Reason = term()</v>

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -140,6 +140,8 @@
 	  crl_check                  :: boolean() | peer | best_effort, 
 	  crl_cache,
 	  signature_algs,
+	  eccs,
+	  honor_ecc_order            :: boolean(),
 	  v2_hello_compatible        :: boolean()
 	  }).
 

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -160,13 +160,15 @@ handle_client_hello(Version, #client_hello{session_id = SugesstedId,
 					   extensions = #hello_extensions{elliptic_curves = Curves,
 									  signature_algs = ClientHashSigns} = HelloExt},
 		    #ssl_options{versions = Versions,
-				 signature_algs = SupportedHashSigns} = SslOpts,
+				 signature_algs = SupportedHashSigns,
+				 eccs = SupportedECCs,
+				 honor_ecc_order = ECCOrder} = SslOpts,
 		    {Port, Session0, Cache, CacheCb, ConnectionStates0, Cert, _}, Renegotiation) ->
     case tls_record:is_acceptable_version(Version, Versions) of
 	true ->
 	    AvailableHashSigns = ssl_handshake:available_signature_algs(
 				   ClientHashSigns, SupportedHashSigns, Cert, Version),
-	    ECCCurve = ssl_handshake:select_curve(Curves, ssl_handshake:supported_ecc(Version)),
+	    ECCCurve = ssl_handshake:select_curve(Curves, SupportedECCs, ECCOrder),
 	    {Type, #session{cipher_suite = CipherSuite} = Session1}
 		= ssl_handshake:select_session(SugesstedId, CipherSuites, AvailableHashSigns, Compressions,
 					       Port, Session0#session{ecc = ECCCurve}, Version,

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -31,8 +31,17 @@
 
 -export([master_secret/4, finished/5, certificate_verify/3, mac_hash/7,
 	 setup_keys/8, suites/1, prf/5,
-	 ecc_curves/1, oid_to_enum/1, enum_to_oid/1, 
+	 ecc_curves/1, ecc_curves/2, oid_to_enum/1, enum_to_oid/1, 
 	 default_signature_algs/1, signature_algs/2]).
+
+-type named_curve() :: sect571r1 | sect571k1 | secp521r1 | brainpoolP512r1 |
+                       sect409k1 | sect409r1 | brainpoolP384r1 | secp384r1 |
+                       sect283k1 | sect283r1 | brainpoolP256r1 | secp256k1 | secp256r1 |
+                       sect239k1 | sect233k1 | sect233r1 | secp224k1 | secp224r1 |
+                       sect193r1 | sect193r2 | secp192k1 | secp192r1 | sect163k1 |
+                       sect163r1 | sect163r2 | secp160k1 | secp160r1 | secp160r2.
+-type curves() :: [named_curve()].
+-export_type([curves/0, named_curve/0]).
 
 %%====================================================================
 %% Internal application API
@@ -399,13 +408,20 @@ is_pair(Hash, rsa, Hashs) ->
     lists:member(Hash, AtLeastMd5).
 
 %% list ECC curves in prefered order
-ecc_curves(_Minor) ->
-    TLSCurves = [sect571r1,sect571k1,secp521r1,brainpoolP512r1,
-		 sect409k1,sect409r1,brainpoolP384r1,secp384r1,
-		 sect283k1,sect283r1,brainpoolP256r1,secp256k1,secp256r1,
-		 sect239k1,sect233k1,sect233r1,secp224k1,secp224r1,
-		 sect193r1,sect193r2,secp192k1,secp192r1,sect163k1,
-		 sect163r1,sect163r2,secp160k1,secp160r1,secp160r2],
+-spec ecc_curves(1..3 | all) -> [named_curve()].
+ecc_curves(all) ->
+    [sect571r1,sect571k1,secp521r1,brainpoolP512r1,
+     sect409k1,sect409r1,brainpoolP384r1,secp384r1,
+     sect283k1,sect283r1,brainpoolP256r1,secp256k1,secp256r1,
+     sect239k1,sect233k1,sect233r1,secp224k1,secp224r1,
+     sect193r1,sect193r2,secp192k1,secp192r1,sect163k1,
+     sect163r1,sect163r2,secp160k1,secp160r1,secp160r2];
+ecc_curves(Minor) ->
+    TLSCurves = ecc_curves(all),
+    ecc_curves(Minor, TLSCurves).
+
+-spec ecc_curves(1..3, [named_curve()]) -> [named_curve()].
+ecc_curves(_Minor, TLSCurves) ->
     CryptoCurves = crypto:ec_curves(),
     lists:foldr(fun(Curve, Curves) ->
 			case proplists:get_bool(Curve, CryptoCurves) of
@@ -413,6 +429,7 @@ ecc_curves(_Minor) ->
 			    false -> Curves
 			end
 		end, [], TLSCurves).
+
 
 %% ECC curves from draft-ietf-tls-ecc-12.txt (Oct. 17, 2005)
 oid_to_enum(?sect163k1) -> 1;

--- a/lib/ssl/test/ssl_ECC_SUITE.erl
+++ b/lib/ssl/test/ssl_ECC_SUITE.erl
@@ -46,7 +46,7 @@ groups() ->
      {'tlsv1', [], all_versions_groups()},
      {'erlang_server', [], key_cert_combinations()},
      {'erlang_client', [], key_cert_combinations()},
-     {'erlang', [], key_cert_combinations() ++ misc()}
+     {'erlang', [], key_cert_combinations() ++ misc() ++ ecc_negotiation()}
     ].
 
 all_versions_groups ()->
@@ -67,6 +67,23 @@ key_cert_combinations() ->
 
 misc()->
     [client_ecdsa_server_ecdsa_with_raw_key].
+
+ecc_negotiation() ->
+    [ecc_default_order,
+     ecc_default_order_custom_curves,
+     ecc_client_order,
+     ecc_client_order_custom_curves,
+     ecc_unknown_curve,
+     client_ecdh_server_ecdh_ecc_server_custom,
+     client_rsa_server_ecdh_ecc_server_custom,
+     client_ecdh_server_rsa_ecc_server_custom,
+     client_rsa_server_rsa_ecc_server_custom,
+     client_ecdsa_server_ecdsa_ecc_server_custom,
+     client_ecdsa_server_rsa_ecc_server_custom,
+     client_rsa_server_ecdsa_ecc_server_custom,
+     client_ecdsa_server_ecdsa_ecc_client_custom,
+     client_rsa_server_ecdsa_ecc_client_custom
+    ].
 
 %%--------------------------------------------------------------------
 init_per_suite(Config0) ->
@@ -218,6 +235,132 @@ client_ecdsa_server_ecdsa_with_raw_key(Config)  when is_list(Config) ->
     check_result(Server, SType, Client, CType),
     close(Server, Client).
 
+ecc_default_order(Config) ->
+    COpts =  proplists:get_value(client_ecdsa_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [],
+    case supported_eccs([{eccs, [sect571r1]}]) of
+        true -> ecc_test(sect571r1, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+ecc_default_order_custom_curves(Config) ->
+    COpts =  proplists:get_value(client_ecdsa_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [{eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(sect571r1, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+ecc_client_order(Config) ->
+    COpts =  proplists:get_value(client_ecdsa_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [{honor_ecc_order, false}],
+    case supported_eccs([{eccs, [sect571r1]}]) of
+        true -> ecc_test(sect571r1, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+ecc_client_order_custom_curves(Config) ->
+    COpts =  proplists:get_value(client_ecdsa_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [{honor_ecc_order, false}, {eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(sect571r1, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+ecc_unknown_curve(Config) ->
+    COpts =  proplists:get_value(client_ecdsa_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [{eccs, ['123_fake_curve']}],
+    ecc_test_error(COpts, SOpts, [], ECCOpts, Config).
+
+%% We can only expect to see a named curve on a conn with
+%% a server supporting ecdsa. Otherwise the curve is selected
+%% but not used and communicated to the client?
+client_ecdh_server_ecdh_ecc_server_custom(Config) ->
+    COpts =  proplists:get_value(client_ecdh_rsa_opts, Config),
+    SOpts = proplists:get_value(server_ecdh_rsa_opts, Config),
+    ECCOpts = [{honor_ecc_order, true}, {eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(undefined, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+client_ecdh_server_rsa_ecc_server_custom(Config) ->
+    COpts =  proplists:get_value(client_ecdh_rsa_opts, Config),
+    SOpts = proplists:get_value(server_opts, Config),
+    ECCOpts = [{honor_ecc_order, true}, {eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(undefined, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+client_rsa_server_ecdh_ecc_server_custom(Config) ->
+    COpts =  proplists:get_value(client_opts, Config),
+    SOpts = proplists:get_value(server_ecdh_rsa_opts, Config),
+    ECCOpts = [{honor_ecc_order, true}, {eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(undefined, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+client_rsa_server_rsa_ecc_server_custom(Config) ->
+    COpts =  proplists:get_value(client_opts, Config),
+    SOpts = proplists:get_value(server_opts, Config),
+    ECCOpts = [{honor_ecc_order, true}, {eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(undefined, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+client_ecdsa_server_ecdsa_ecc_server_custom(Config) ->
+    COpts =  proplists:get_value(client_ecdsa_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [{honor_ecc_order, true}, {eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(secp256r1, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+client_ecdsa_server_rsa_ecc_server_custom(Config) ->
+    COpts =  proplists:get_value(client_ecdsa_opts, Config),
+    SOpts = proplists:get_value(server_opts, Config),
+    ECCOpts = [{honor_ecc_order, true}, {eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(undefined, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+client_rsa_server_ecdsa_ecc_server_custom(Config) ->
+    COpts =  proplists:get_value(client_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [{honor_ecc_order, true}, {eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(secp256r1, COpts, SOpts, [], ECCOpts, Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+client_ecdsa_server_ecdsa_ecc_client_custom(Config) ->
+    COpts =  proplists:get_value(client_ecdsa_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [{eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(secp256r1, COpts, SOpts, ECCOpts, [], Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
+client_rsa_server_ecdsa_ecc_client_custom(Config) ->
+    COpts =  proplists:get_value(client_opts, Config),
+    SOpts = proplists:get_value(server_ecdsa_opts, Config),
+    ECCOpts = [{eccs, [secp256r1, sect571r1]}],
+    case supported_eccs(ECCOpts) of
+        true -> ecc_test(secp256r1, COpts, SOpts, ECCOpts, [], Config);
+        false -> {skip, "unsupported named curves"}
+    end.
+
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------
 %%--------------------------------------------------------------------
@@ -244,6 +387,30 @@ basic_test(ClientCert, ClientKey, ClientCA, ServerCert, ServerKey, ServerCA, Con
     check_result(Server, SType, Client, CType),
     close(Server, Client).    
 
+ecc_test(Expect, COpts, SOpts, CECCOpts, SECCOpts, Config) ->
+    CCA = proplists:get_value(cacertfile, COpts),
+    CCert = proplists:get_value(certfile, COpts),
+    CKey = proplists:get_value(keyfile, COpts),
+    SCA = proplists:get_value(cacertfile, SOpts),
+    SCert = proplists:get_value(certfile, SOpts),
+    SKey = proplists:get_value(keyfile, SOpts),
+    {Server, Port} = start_server_ecc(erlang, CCA, SCA, SCert, SKey, Expect, SECCOpts, Config),
+    Client = start_client_ecc(erlang, Port, SCA, CCA, CCert, CKey, Expect, CECCOpts, Config),
+    ssl_test_lib:check_result(Server, ok, Client, ok),
+    close(Server, Client).
+
+ecc_test_error(COpts, SOpts, CECCOpts, SECCOpts, Config) ->
+    CCA = proplists:get_value(cacertfile, COpts),
+    CCert = proplists:get_value(certfile, COpts),
+    CKey = proplists:get_value(keyfile, COpts),
+    SCA = proplists:get_value(cacertfile, SOpts),
+    SCert = proplists:get_value(certfile, SOpts),
+    SKey = proplists:get_value(keyfile, SOpts),
+    {Server, Port} = start_server_ecc_error(erlang, CCA, SCA, SCert, SKey, SECCOpts, Config),
+    Client = start_client_ecc_error(erlang, Port, SCA, CCA, CCert, CKey, CECCOpts, Config),
+    Error = {error, {tls_alert, "insufficient security"}},
+    ssl_test_lib:check_result(Server, Error, Client, Error).
+
 start_client(openssl, Port, PeerCA, OwnCa, Cert, Key, _Config) ->
     CA = new_openssl_ca("openssl_client_ca", PeerCA, OwnCa),
     Version = tls_record:protocol_version(tls_record:highest_protocol_version([])),
@@ -266,6 +433,31 @@ start_client(erlang, Port, PeerCA, OwnCa, Cert, Key, Config) ->
 			       {options, [{verify, verify_peer}, 
 					  {cacertfile, CA},
 					  {certfile, Cert}, {keyfile, Key}]}]).
+
+start_client_ecc(erlang, Port, PeerCA, OwnCa, Cert, Key, Expect, ECCOpts, Config) ->
+    CA = new_ca("erlang_client_ca", PeerCA, OwnCa),
+    {ClientNode, _, Hostname} = ssl_test_lib:run_where(Config),
+    ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+                               {host, Hostname},
+                               {from, self()},
+                               {mfa, {?MODULE, check_ecc, [client, Expect]}},
+                               {options,
+                                ECCOpts ++
+                                [{verify, verify_peer},
+                                 {cacertfile, CA},
+                                 {certfile, Cert}, {keyfile, Key}]}]).
+
+start_client_ecc_error(erlang, Port, PeerCA, OwnCa, Cert, Key, ECCOpts, Config) ->
+    CA = new_ca("erlang_client_ca", PeerCA, OwnCa),
+    {ClientNode, _, Hostname} = ssl_test_lib:run_where(Config),
+    ssl_test_lib:start_client_error([{node, ClientNode}, {port, Port},
+                                     {host, Hostname},
+                                     {from, self()},
+                                     {options,
+                                      ECCOpts ++
+                                      [{verify, verify_peer},
+                                       {cacertfile, CA},
+                                       {certfile, Cert}, {keyfile, Key}]}]).
 
 start_server(openssl, PeerCA, OwnCa, Cert, Key, _Config) ->
     CA = new_openssl_ca("openssl_server_ca", PeerCA, OwnCa),
@@ -290,6 +482,7 @@ start_server(erlang, PeerCA, OwnCa, Cert, Key, Config) ->
 				[{verify, verify_peer}, {cacertfile, CA},
 				 {certfile, Cert}, {keyfile, Key}]}]),
     {Server, ssl_test_lib:inet_port(Server)}.
+
 start_server_with_raw_key(erlang, PeerCA, OwnCa, Cert, Key, Config) ->
      CA = new_ca("erlang_server_ca", PeerCA, OwnCa),
     {_, ServerNode, _} = ssl_test_lib:run_where(Config),
@@ -301,6 +494,29 @@ start_server_with_raw_key(erlang, PeerCA, OwnCa, Cert, Key, Config) ->
 			       {options,
 				[{verify, verify_peer}, {cacertfile, CA},
 				 {certfile, Cert}, {key, Key}]}]),
+    {Server, ssl_test_lib:inet_port(Server)}.
+
+start_server_ecc(erlang, PeerCA, OwnCa, Cert, Key, Expect, ECCOpts, Config) ->
+    CA = new_ca("erlang_server_ca", PeerCA, OwnCa),
+    {_, ServerNode, _} = ssl_test_lib:run_where(Config),
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                                        {from, self()},
+                                        {mfa, {?MODULE, check_ecc, [server, Expect]}},
+                                        {options,
+                                         ECCOpts ++
+                                         [{verify, verify_peer}, {cacertfile, CA},
+                                          {certfile, Cert}, {keyfile, Key}]}]),
+    {Server, ssl_test_lib:inet_port(Server)}.
+
+start_server_ecc_error(erlang, PeerCA, OwnCa, Cert, Key, ECCOpts, Config) ->
+    CA = new_ca("erlang_server_ca", PeerCA, OwnCa),
+    {_, ServerNode, _} = ssl_test_lib:run_where(Config),
+    Server = ssl_test_lib:start_server_error([{node, ServerNode}, {port, 0},
+                                              {from, self()},
+                                              {options,
+                                               ECCOpts ++
+                                               [{verify, verify_peer}, {cacertfile, CA},
+                                                {certfile, Cert}, {keyfile, Key}]}]),
     {Server, ssl_test_lib:inet_port(Server)}.
 
 check_result(Server, erlang, Client, erlang) ->
@@ -362,3 +578,17 @@ new_openssl_ca(FileName, CA, OwnCa) ->
 	    file:write_file(FileName,  Pem)
     end,  
     FileName.
+
+supported_eccs(Opts) ->
+    ToCheck = proplists:get_value(eccs, Opts, []),
+    Supported = ssl:eccs(),
+    lists:all(fun(Curve) -> lists:member(Curve, Supported) end, ToCheck).
+
+check_ecc(SSL, Role, Expect) ->
+    {ok, Data} = ssl:connection_information(SSL),
+    case lists:keyfind(ecc, 1, Data) of
+        {ecc, {named_curve, Expect}} -> ok;
+        false when Expect =:= undefined -> ok;
+        Other -> {error, Role, Expect, Other}
+    end.
+


### PR DESCRIPTION
As per RFC 4492 Sec 5.1, the preferred order of selection of named
curves is based on client preferences.

Currently, the SSL application only picks entries according to the
absolute order of entries as tracked in a hardcoded list in code.

This patch changes things so that the client-specified order is
preferred. It also allows a mode where the server can be configured to
override the client's preferred order with its own, although the chosen
ECC must still be within both lists.

Currently, this PR still lacks tests. As seen in https://github.com/erlang/otp/pull/1179, there are no good
tests for this feature as of today, so we'll have to figure that one out.

For now, I've run the existing tests with the default config to confirm
nothing broke, and ran additional manual tests by inspecting SSL packets
by hand to see that curve selection does indeed take place:
---

Default config (equivalent to client preference):

Server:

```
1> BaseConfig = [{cacertfile, "/home/ferd/code/self/otp/lib/ssl/cacerts.pem"}, {certfile, "/home/ferd/code/self/otp/lib/ssl/cert.pem"}, {keyfile, "/home/ferd/code/self/otp/lib/ssl/key.pem"}, {reuseaddr, true}, {active,false}], 
2> f(F), F= fun() -> {ok,L} = ssl:listen(9234, BaseConfig), 
2> {ok,S} = ssl:transport_accept(L), ok = ssl:ssl_accept(S),
2> {ok,Data}=ssl:recv(S, 0), ssl:send(S, Data), ssl:close(L) end.
#Fun<erl_eval.20.52032458>
3> F().
```

Client:

```
→ openssl s_client -connect localhost:9234 -msg | grep -A3 'ServerKeyExchange'
depth=2 CN = erlangCA, OU = Erlang OTP, O = Ericsson AB, L = Stockholm, C = SE, emailAddress = peter@erix.ericsson.se
verify error:num=19:self signed certificate in certificate chain
verify return:0
<<< TLS 1.2 Handshake [length 019d], ServerKeyExchange
    0c 00 01 99 03 00 0e 91 04 02 9a b3 66 39 5f b9
    f6 30 e5 92 50 6e 7a 52 8e 0c f1 29 aa 11 3f f0
    c0 c2 31 15 0f ed d2 05 5a bd bb 80 c5 d9 03 94
```

`0c`: this is a ServerKeyExchange message (described in section 5.4 of RFC 4492)
`00 01 99`: of length 0x000199 bytes (409 bytes)
`03`: the curve type is "named_curve"
`00 0e`: the curve is `sect571r1` (curve identifiers are in section 5.1.1, identifier 0x000E is 14 in decimal)
---

Client preference config:

Server:

```
4> f(F), F= fun() -> {ok,L} = ssl:listen(9234, [{ecc_order, client_order}] ++ BaseConfig), 
4> {ok,S} = ssl:transport_accept(L), ok = ssl:ssl_accept(S),
4> {ok,Data}=ssl:recv(S, 0), ssl:send(S, Data), ssl:close(L) end.
#Fun<erl_eval.20.52032458>
5> F().
```

Client:

```
→ openssl s_client -connect localhost:9234 -msg | grep -A3 'ServerKeyExchange'
depth=2 CN = erlangCA, OU = Erlang OTP, O = Ericsson AB, L = Stockholm, C = SE, emailAddress = peter@erix.ericsson.se
verify error:num=19:self signed certificate in certificate chain
verify return:0
<<< TLS 1.2 Handshake [length 019d], ServerKeyExchange
    0c 00 01 99 03 00 0e 91 04 02 9a b3 66 39 5f b9
    f6 30 e5 92 50 6e 7a 52 8e 0c f1 29 aa 11 3f f0
    c0 c2 31 15 0f ed d2 05 5a bd bb 80 c5 d9 03 94
```

(same as before) 

`0c`: this is a ServerKeyExchange message (described in section 5.4 of RFC 4492)
`00 01 99`: of length 0x000199 bytes (409 bytes)
`03`: the curve type is "named_curve"
`00 0e`: the curve is `sect571r1` (curve identifiers are in section 5.1.1, identifier 0x000E is 14 in decimal)
---

Server with config that has nothing in common with the client:

Server:

```
6> f(F), F= fun() -> {ok,L} = ssl:listen(9234, [{ecc_order, [bacon]}] ++ BaseConfig), 
6> {ok,S} = ssl:transport_accept(L), ok = ssl:ssl_accept(S),
6> {ok,Data}=ssl:recv(S, 0), ssl:send(S, Data), ssl:close(L) end.
#Fun<erl_eval.20.52032458>
7> F().
```

Client:

```
→ openssl s_client -connect localhost:9234 -msg | grep -A3 'ServerKeyExchange'
140188496156320:error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure:s23_clnt.c:770:
```

fails as expected
---

Server config picking another order, but common one:

Server:

```
8> f(F), F= fun() -> {ok,L} = ssl:listen(9234, [{ecc_order, [secp256r1]}] ++ BaseConfig), 
8> {ok,S} = ssl:transport_accept(L), ok = ssl:ssl_accept(S),
8> {ok,Data}=ssl:recv(S, 0), ssl:send(S, Data), ssl:close(L) end.
#Fun<erl_eval.20.52032458>
9> F().
```

Client:

```
→  openssl s_client -connect localhost:9234 -msg | grep -A3 'ServerKeyExchange'
depth=2 CN = erlangCA, OU = Erlang OTP, O = Ericsson AB, L = Stockholm, C = SE, emailAddress = peter@erix.ericsson.se
verify error:num=19:self signed certificate in certificate chain
verify return:0
<<< TLS 1.2 Handshake [length 014d], ServerKeyExchange
    0c 00 01 49 03 00 17 41 04 d9 51 be 9c 0e b6 8b
    fe ff db 2e 65 d6 83 33 1e 4d 12 c4 fe cf 54 9b
    28 d4 a3 c5 0f 68 a8 35 fa f6 78 71 d1 cd 38 5a
```

(same as before) 

`0c`: this is a ServerKeyExchange message (described in section 5.4 of RFC 4492)
`00 01 49`: of length 0x000149 bytes (329 bytes)
`03`: the curve type is "named_curve"
`00 17`: the curve is `secp256r1` (curve identifiers are in section 5.1.1, identifier 0x0017 is 23 in decimal)
---

Not exactly sure how to bring these tests within Erlang/OTP test suites.
