### PR TITLE
Don't let inline_list_funcs degrade optimizations

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -734,7 +734,7 @@ call(#c_call{args=As}=Call, #c_literal{val=M}=M0, #c_literal{val=N}=N0, Sub) ->
   	false ->
 	    case sys_core_fold_lists:call(Call, M, N, As) of
 		none ->
-		    call_1(Call, M, N, As, Sub);
+		    call_1(Call, M0, N0, As, Sub);
 		Core ->
 		    expr(Core, Sub)
 	    end


### PR DESCRIPTION
83199af0263 refactored sys_core_fold to break out the code for the
inline_lists_funcs option to its own module. Unfortunately, it also
accidentally turned off compile-time evaluation of calls to BIFs with
wholly or partial constant arguments.

For example, the code for the following funtion gets much worse
when inline_list_funcs is used:

b() ->
    R0 = #r{},
    R1 = setelement(1+2, R0, "deux"),
    R2 = setelement(1+3, R1, "trois"),
    R3 = setelement(1+5, R2, "cinq"),
    R4 = setelement(1+2, R3, "DEUX"),
    R4.

ERL-285