### PR TITLE
Allow only X :: Y constraints after when in specs

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -108,8 +108,6 @@ type_sig -> fun_type 'when' type_guards   : {type, ?anno('$1'), bounded_fun,
 type_guards -> type_guard                 : ['$1'].
 type_guards -> type_guard ',' type_guards : ['$1'|'$3'].
 
-type_guard -> atom '(' top_types ')'      : {type, ?anno('$1'), constraint,
-                                             ['$1', '$3']}.
 type_guard -> var '::' top_type           : build_def('$1', '$3').
 
 top_types -> top_type                     : ['$1'].
@@ -1041,13 +1039,13 @@ build_typed_attribute({atom,Aa,Attr},_) ->
     end.
 
 build_type_spec({Kind,Aa}, {SpecFun, TypeSpecs})
-  when (Kind =:= spec) or (Kind =:= callback) ->
+  when Kind =:= spec ; Kind =:= callback ->
     NewSpecFun =
 	case SpecFun of
 	    {atom, _, Fun} ->
 		{Fun, find_arity_from_specs(TypeSpecs)};
-	    {{atom,_, Mod}, {atom,_, Fun}} ->
-		{Mod,Fun,find_arity_from_specs(TypeSpecs)}
+	    {{atom, _, Mod}, {atom, _, Fun}} ->
+		{Mod, Fun, find_arity_from_specs(TypeSpecs)}
         end,
     {attribute,Aa,Kind,{NewSpecFun, TypeSpecs}}.
 


### PR DESCRIPTION
The parser, most likely due to once upon a time supporting
is_subtype(_, _) constraints after 'when' in specs, allowed
'when's to be followed by all sorts of atom(...) constructs
and not only by type constraints of the X :: Y form.  Since
is_subtype/2 constraints are no longer allowed, the relevant
clause that parses them can now be taken out.

This change means that specs with a 'when' syntax which is
syntactically erroneous will now result in syntax errors,
instead of being passed to erl_lint or other parts of the
system and be found erroneous there.
