### PR TITLE
Add string:starts_with/2 API to stdlib

### DIFF
--- a/lib/stdlib/src/string.erl
+++ b/lib/stdlib/src/string.erl
@@ -24,7 +24,7 @@
 -export([copies/2,words/1,words/2,strip/1,strip/2,strip/3,
 	 sub_word/2,sub_word/3,left/2,left/3,right/2,right/3,
 	 sub_string/2,sub_string/3,centre/2,centre/3, join/2]).
--export([to_upper/1, to_lower/1]).
+-export([to_upper/1, to_lower/1, starts_with/2]).
 
 -import(lists,[reverse/1,member/2]).
 
@@ -540,3 +540,10 @@ join([], Sep) when is_list(Sep) ->
     [];
 join([H|T], Sep) ->
     H ++ lists:append([Sep ++ X || X <- T]).
+
+-spec starts_with(String, StartString) -> Result when
+	  String :: string(),
+	  StartString :: string(),
+	  Result :: boolean().
+starts_with(String, StartString) ->
+	lists:prefix(StartString, String).

--- a/lib/stdlib/test/string_SUITE.erl
+++ b/lib/stdlib/test/string_SUITE.erl
@@ -32,7 +32,7 @@
 -export([len/1,equal/1,concat/1,chr_rchr/1,str_rstr/1]).
 -export([span_cspan/1,substr/1,tokens/1,chars/1]).
 -export([copies/1,words/1,strip/1,sub_word/1,left_right/1]).
--export([sub_string/1,centre/1, join/1]).
+-export([sub_string/1,centre/1, join/1, starts_with/1]).
 -export([to_integer/1,to_float/1]).
 -export([to_upper_to_lower/1]).
 
@@ -40,13 +40,13 @@ suite() ->
     [{ct_hooks,[ts_install_cth]},
      {timetrap,{minutes,1}}].
 
-all() -> 
+all() ->
     [len, equal, concat, chr_rchr, str_rstr, span_cspan,
      substr, tokens, chars, copies, words, strip, sub_word,
      left_right, sub_string, centre, join, to_integer,
-     to_float, to_upper_to_lower].
+     to_float, to_upper_to_lower, starts_with].
 
-groups() -> 
+groups() ->
     [].
 
 init_per_suite(Config) ->
@@ -463,3 +463,17 @@ join(Config) when is_list(Config) ->
     %% invalid arg type
     {'EXIT',_} = (catch string:join([apa], "")),
     ok.
+
+starts_with(suite) ->
+    [];
+starts_with(doc) ->
+    [];
+starts_with(Config) when is_list(Config) ->
+	?line true = string:starts_with("", ""),
+	?line true = string:starts_with("hello joe", ""),
+	?line true = string:starts_with("hello mike", "hello"),
+	?line false = string:starts_with("", "hello robert"),
+	?line false = string:starts_with("hello", "hello joe"),
+	?line false = string:starts_with("hello mike", "hello robert"),
+	?line {'EXIT',_} = (catch string:starts_with(otp, 123)),
+	ok.


### PR DESCRIPTION
I was hoping that I could write a pattern match to do this but that wasn't possible with arbitrary strings.  The next best thing would have been to use the stdlib function but there wasn't any, hence this pull request! This is a useful function to have and languages like [Python](https://docs.python.org/2/library/stdtypes.html#str.startswith) and [Java](http://docs.oracle.com/javase/7/docs/api/java/lang/String.html#startsWith(java.lang.String)) provides this in their respective stdlib's.


I haven't added the documentation yet. If this looks good and is an acceptable addition to the stdlib, I'll amend this commit and add documentation. 