### PR TITLE
Make a separate application module for Mnesia

### DIFF
--- a/lib/mnesia/doc/src/Mnesia_chap3.xmlsrc
+++ b/lib/mnesia/doc/src/Mnesia_chap3.xmlsrc
@@ -348,7 +348,7 @@ skeppet %<input>erl -sname b -mnesia dir '"/ldisc/scratch/Mnesia.company"'</inpu
       <p>If the startup procedure fails, the function
         <seealso marker="mnesia#start/0">mnesia:start()</seealso>
         returns the cryptic tuple
-        <c>{error,{shutdown, {mnesia_sup,start,[normal,[]]}}}</c>.
+        <c>{error,{shutdown, {mnesia_sup,start_link,[normal,[]]}}}</c>.
         To get more information about the start failure, use
         command-line arguments <c>-boot start_sasl</c> as argument to
         the <c>erl</c> script.</p>

--- a/lib/mnesia/src/Makefile
+++ b/lib/mnesia/src/Makefile
@@ -43,6 +43,7 @@ RELSYSDIR = $(RELEASE_PATH)/lib/mnesia-$(VSN)
 # ----------------------------------------------------
 MODULES= \
 	mnesia \
+	mnesia_app \
 	mnesia_backend_type \
 	mnesia_backup \
 	mnesia_bup \

--- a/lib/mnesia/src/mnesia.app.src
+++ b/lib/mnesia/src/mnesia.app.src
@@ -3,6 +3,7 @@
   {vsn, "%VSN%"},
   {modules, [
 	     mnesia, 
+	     mnesia_app,
 	     mnesia_backend_type,
 	     mnesia_backup, 
 	     mnesia_bup, 
@@ -49,7 +50,5 @@
 		mnesia_tm
 	       ]},
   {applications, [kernel, stdlib]},
-  {mod, {mnesia_sup, []}},
+  {mod, {mnesia_app, []}},
   {runtime_dependencies, ["stdlib-2.0","kernel-3.0","erts-7.0"]}]}.
-
-

--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -273,6 +273,7 @@ kill() ->
 ms() ->
     [
      mnesia,
+     mnesia_app,
      mnesia_backup,
      mnesia_bup,
      mnesia_checkpoint,

--- a/lib/mnesia/src/mnesia_app.erl
+++ b/lib/mnesia/src/mnesia_app.erl
@@ -1,0 +1,41 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1996-2016. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+-module(mnesia_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% application callback functions
+
+start(normal, Args) ->
+    case mnesia_sup:start_link(Args) of
+	{ok, Pid} ->
+	    {ok, Pid, {normal, Args}};
+	Error ->
+	    Error
+    end;
+start(_, _) ->
+    {error, badarg}.
+
+stop(_StartArgs) ->
+    ok.

--- a/lib/mnesia/src/mnesia_sup.erl
+++ b/lib/mnesia/src/mnesia_sup.erl
@@ -23,39 +23,21 @@
 
 -module(mnesia_sup).
 
--behaviour(application).
 -behaviour(supervisor).
 
--export([start/0, start/2, init/1, stop/1, start_event/0, kill/0]).
+-export([start_link/1, init/1, start_event/0, kill/0]).
+
+start_link(Args) ->
+    supervisor:start_link({local,?MODULE}, ?MODULE, [Args]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% application and suprvisor callback functions
+%% supervisor callback functions
 
-start(normal, Args) ->
-    SupName = {local,?MODULE},
-    case supervisor:start_link(SupName, ?MODULE, [Args]) of
-	{ok, Pid} ->
-	    {ok, Pid, {normal, Args}};
-	Error -> 
-	    Error
-    end;
-start(_, _) ->
-    {error, badarg}.
-
-start() ->
-    SupName = {local,?MODULE},
-    supervisor:start_link(SupName, ?MODULE, []).
-
-stop(_StartArgs) ->
-    ok.
-
-init([]) -> % Supervisor
-    init();
-init([[]]) -> % Application
+init([[]]) ->
     init();
 init(BadArg) ->
     {error, {badarg, BadArg}}.
-    
+
 init() ->
     Flags = {one_for_all, 0, 3600}, % Should be rest_for_one policy
 
@@ -124,4 +106,3 @@ ensure_dead(Name) ->
 	    timer:sleep(10),
 	    ensure_dead(Name)
     end.
-


### PR DESCRIPTION
To separate concerns and reduce confusion, avoid implementing two
behaviours in a single module. Make a single start_link() helper in
mnesia_sup and remove the unused mnesia_sup:start() utility function.
