### PR TITLE
Default compiler flags

### DIFF
--- a/erts/preloaded/src/Makefile
+++ b/erts/preloaded/src/Makefile
@@ -73,7 +73,7 @@ KERNEL_SRC=$(ERL_TOP)/lib/kernel/src
 KERNEL_INCLUDE=$(ERL_TOP)/lib/kernel/include
 STDLIB_INCLUDE=$(ERL_TOP)/lib/stdlib/include
 
-ERL_COMPILE_FLAGS += +warn_obsolete_guard +debug_info -I$(KERNEL_SRC) -I$(KERNEL_INCLUDE)
+ERL_COMPILE_FLAGS += +debug_info -I$(KERNEL_SRC) -I$(KERNEL_INCLUDE)
 
 debug opt: $(TARGET_FILES) 
 

--- a/lib/asn1/test/Makefile
+++ b/lib/asn1/test/Makefile
@@ -134,7 +134,7 @@ RELSYSDIR = $(RELEASE_PATH)/asn1_test
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += +warnings_as_errors
+ERL_COMPILE_FLAGS += +warnings_as_errors +nowarn_export_all
 EBIN = .
 
 # ----------------------------------------------------

--- a/lib/common_test/src/unix_telnet.erl
+++ b/lib/common_test/src/unix_telnet.erl
@@ -53,8 +53,6 @@
 %%% @see ct_telnet
 -module(unix_telnet).
 
--compile(export_all).
-
 %% Callbacks for ct_telnet.erl
 -export([connect/7,get_prompt_regexp/0]).
 -import(ct_telnet,[start_gen_log/1,log/4,end_gen_log/0]).

--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -498,9 +498,11 @@ module.beam: module.erl \
 	    </warning>
           </item>
 
-	  <tag><c>warn_export_all</c></tag>
+	  <tag><c>nowarn_export_all</c></tag>
           <item>
-	      <p>Emits a warning if option <c>export_all</c> is also given.</p>
+	      <p>Turns off warnings for uses of the <c>export_all</c>
+	      option. Default is to emit a warning if option
+	      <c>export_all</c> is also given.</p>
           </item>
 
 	  <tag><c>warn_export_vars</c></tag>

--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -574,7 +574,7 @@ module.beam: module.erl \
 	    such as <c>pid/1</c> and <c>list/1</c>. See the
 	    <seealso marker="doc/reference_manual:expressions#guards">Erlang Reference Manual</seealso>
 	      for a complete list of type testing BIFs and their old
-	      equivalents. Default is to emit no warnings for calls to 
+	      equivalents. Default is to emit warnings for calls to
 	      old type testing BIFs.</p>
           </item>
 

--- a/lib/crypto/src/Makefile
+++ b/lib/crypto/src/Makefile
@@ -56,7 +56,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += +warn_obsolete_guard -DCRYPTO_VSN=\"$(VSN)\" -Werror
+ERL_COMPILE_FLAGS += -DCRYPTO_VSN=\"$(VSN)\" -Werror
 
 # ----------------------------------------------------
 # Targets

--- a/lib/debugger/src/Makefile
+++ b/lib/debugger/src/Makefile
@@ -85,7 +85,7 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += +warn_obsolete_guard -Werror
+ERL_COMPILE_FLAGS += -Werror
 
 
 # ----------------------------------------------------

--- a/lib/diameter/test/diameter_capx_SUITE.erl
+++ b/lib/diameter/test/diameter_capx_SUITE.erl
@@ -384,7 +384,7 @@ load_dict(N) ->
     A3 = erl_anno:new(3),
     A4 = erl_anno:new(4),
     Forms = [{attribute, A1, module, Mod},
-             {attribute, A2, compile, [export_all]},
+             {attribute, A2, export, [{id,0}]},
              {function, A3, id, 0,
               [{clause, A4, [], [], [{integer, A4, N}]}]}],
     {ok, Mod, Bin, []} = compile:forms(Forms, [return]),

--- a/lib/eunit/src/Makefile
+++ b/lib/eunit/src/Makefile
@@ -24,7 +24,7 @@ RELSYSDIR = $(RELEASE_PATH)/lib/eunit-$(VSN)
 EBIN = ../ebin
 INCLUDE=../include
 
-ERL_COMPILE_FLAGS += -pa $(EBIN) -pa ../../stdlib/ebin -I$(INCLUDE) +warn_unused_vars +nowarn_shadow_vars +warn_unused_import +warn_obsolete_guard
+ERL_COMPILE_FLAGS += -pa $(EBIN) -pa ../../stdlib/ebin -I$(INCLUDE) +nowarn_shadow_vars +warn_unused_import
 
 PARSE_TRANSFORM = eunit_autoexport.erl
 

--- a/lib/observer/src/cdv_wx.erl
+++ b/lib/observer/src/cdv_wx.erl
@@ -17,7 +17,7 @@
 %%
 %% %CopyrightEnd%
 -module(cdv_wx).
--compile(export_all).
+
 -behaviour(wx_object).
 
 -export([start/1]).

--- a/lib/os_mon/src/Makefile
+++ b/lib/os_mon/src/Makefile
@@ -60,7 +60,7 @@ TARGET_FILES= $(MODULES:%=$(EBIN)/%.$(EMULATOR)) $(APP_TARGET) $(APPUP_TARGET)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += +warn_obsolete_guard -I$(INCLUDE) -Werror
+ERL_COMPILE_FLAGS += -I$(INCLUDE) -Werror
 
 # ----------------------------------------------------
 # Targets

--- a/lib/otp_mibs/src/Makefile
+++ b/lib/otp_mibs/src/Makefile
@@ -64,7 +64,7 @@ TARGETS = $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -I$(INCLUDE) +warn_obsolete_guard
+ERL_COMPILE_FLAGS += -I$(INCLUDE)
 
 # ----------------------------------------------------
 # Targets

--- a/lib/parsetools/src/Makefile
+++ b/lib/parsetools/src/Makefile
@@ -59,7 +59,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += +warn_obsolete_guard -I$(ERL_TOP)/lib/stdlib/include \
+ERL_COMPILE_FLAGS += -I$(ERL_TOP)/lib/stdlib/include \
   -Werror
 
 # ----------------------------------------------------

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -526,7 +526,7 @@ start(File, Opts) ->
 		      true, Opts)},
 	 {export_all,
 	  bool_option(warn_export_all, nowarn_export_all,
-		      false, Opts)},
+		      true, Opts)},
 	 {export_vars,
 	  bool_option(warn_export_vars, nowarn_export_vars,
 		      false, Opts)},

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -306,7 +306,7 @@ otp_5362(Config) when is_list(Config) ->
     File_Back_hrl = filename:join(Dir, "back_5362.hrl"),
     Back = <<"-module(back_5362).
 
-              -compile(export_all).
+              -export([foo/1]).
 
               -file(?FILE, 1).
               -include(\"back_5362.hrl\").
@@ -334,7 +334,7 @@ otp_5362(Config) when is_list(Config) ->
 
                 -file(?FILE, 100).
 
-                -compile(export_all).
+                -export([foo/1,bar/1]).
 
                 -file(\"other.file\", ?LINE). % like an included file...
                 foo(A) -> % line 105
@@ -362,7 +362,7 @@ otp_5362(Config) when is_list(Config) ->
 
     Blank = <<"-module(blank_5362).
 
-               -compile(export_all).
+               -export([q/1,a/1,b/1,c/1]).
 
                -
                file(?FILE, 18). q(Q) -> foo. % line 18
@@ -1258,7 +1258,7 @@ do_otp_8911(Config) ->
 
     File = "i.erl",
     Cont = <<"-module(i).
-              -compile(export_all).
+              -export([t/0]).
               -file(\"fil1\", 100).
               -include(\"i1.erl\").
               t() ->
@@ -1391,7 +1391,7 @@ otp_11728(Config) when is_list(Config) ->
     HrlFile = filename:join(Dir, "otp_11728.hrl"),
     ok = file:write_file(HrlFile, H),
     C = <<"-module(otp_11728).
-           -compile(export_all).
+           -export([function_name/0]).
 
            -include(\"otp_11728.hrl\").
 
@@ -1599,12 +1599,12 @@ check_test(Config, Test) ->
     end.
 
 compile_test(Config, Test0) ->
-    Test = [<<"-module(epp_test). -compile(export_all). ">>, Test0],
+    Test = [<<"-module(epp_test). ">>, Test0],
     Filename = "epp_test.erl",
     PrivDir = proplists:get_value(priv_dir, Config),
     File = filename:join(PrivDir, Filename),
     ok = file:write_file(File, Test),
-    Opts = [export_all,return,nowarn_unused_record,{outdir,PrivDir}],
+    Opts = [export_all,nowarn_export_all,return,nowarn_unused_record,{outdir,PrivDir}],
     case compile_file(File, Opts) of
         {ok, Ws} -> warnings(File, Ws);
         Else -> Else
@@ -1653,7 +1653,7 @@ unopaque_forms(Forms) ->
     [erl_parse:anno_to_term(Form) || Form <- Forms].
 
 run_test(Config, Test0) ->
-    Test = [<<"-module(epp_test). -compile(export_all). ">>, Test0],
+    Test = [<<"-module(epp_test). -export([t/0]). ">>, Test0],
     Filename = "epp_test.erl",
     PrivDir = proplists:get_value(priv_dir, Config),
     File = filename:join(PrivDir, Filename),

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -1863,7 +1863,7 @@ otp_5276(Config) when is_list(Config) ->
 %% OTP-5917. Check the 'deprecated' attributed.
 otp_5917(Config) when is_list(Config) ->
     Ts = [{otp_5917_1,
-          <<"-compile(export_all).
+          <<"-export([t/0]).
 
              -deprecated({t,0}).
 
@@ -1878,7 +1878,7 @@ otp_5917(Config) when is_list(Config) ->
 %% OTP-6585. Check the deprecated guards list/1, pid/1, ....
 otp_6585(Config) when is_list(Config) ->
     Ts = [{otp_6585_1,
-          <<"-compile(export_all).
+          <<"-export([t/0]).
 
              -record(r, {}).
 
@@ -2627,7 +2627,7 @@ otp_11772(Config) when is_list(Config) ->
     Ts = <<"
             -module(newly).
 
-            -compile(export_all).
+            -export([t/0]).
 
             %% Built-in:
             -type node() :: node().
@@ -2652,7 +2652,7 @@ otp_11771(Config) when is_list(Config) ->
     Ts = <<"
             -module(newly).
 
-            -compile(export_all).
+            -export([t/0]).
 
             %% No longer allowed in 17.0:
             -type arity() :: atom().
@@ -2679,7 +2679,7 @@ otp_11872(Config) when is_list(Config) ->
     Ts = <<"
             -module(map).
 
-            -compile(export_all).
+            -export([t/0]).
 
             -export_type([map/0, product/0]).
 
@@ -3005,7 +3005,7 @@ behaviour_basic(Config) when is_list(Config) ->
 
           {behaviour4,
            <<"-behavior(application).  %% Test callbacks with export_all
-              -compile(export_all).
+              -compile([export_all, nowarn_export_all]).
               stop(_) -> ok.
              ">>,
            [],

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -2702,9 +2702,9 @@ export_all(Config) when is_list(Config) ->
 
             id(I) -> I.
            ">>,
-    [] = run_test2(Config, Ts, []),
+    [] = run_test2(Config, Ts, [nowarn_export_all]),
     {warnings,[{2,erl_lint,export_all}]} =
-	run_test2(Config, Ts, [warn_export_all]),
+	run_test2(Config, Ts, []),
     ok.
 
 %% Test warnings for functions that clash with BIFs.

--- a/lib/stdlib/test/qlc_SUITE.erl
+++ b/lib/stdlib/test/qlc_SUITE.erl
@@ -7936,7 +7936,6 @@ compile(Config, Tests, Fun) ->
 compile_file(Config, Test0, Opts0) ->
     {File, Mod} = compile_file_mod(Config),
     Test = list_to_binary(["-module(", atom_to_list(Mod), "). "
-                           "-compile(export_all). "
                            "-import(qlc_SUITE, [i/1,i/2,format_info/2]). "
                            "-import(qlc_SUITE, [etsc/2, etsc/3]). "
                            "-import(qlc_SUITE, [create_ets/2]). "
@@ -7946,7 +7945,7 @@ compile_file(Config, Test0, Opts0) ->
                            "-import(qlc_SUITE, [lookup_keys/1]). "
                            "-include_lib(\"stdlib/include/qlc.hrl\"). ",
                            Test0]),
-    Opts = [export_all,return,nowarn_unused_record,{outdir,?privdir}|Opts0],
+    Opts = [export_all,nowarn_export_all,return,nowarn_unused_record,{outdir,?privdir}|Opts0],
     ok = file:write_file(File, Test),
     case compile:file(File, Opts) of
         {ok, _M, Ws} -> warnings(File, Ws);

--- a/lib/stdlib/test/shell_SUITE.erl
+++ b/lib/stdlib/test/shell_SUITE.erl
@@ -1794,7 +1794,7 @@ Test1_shell =
 Test2 =
 <<"-module(recs).
           -record(person, {name, age, phone = [], dict = []}).
--compile(export_all).
+-export([t/0]).
 
 t() -> ok.
 
@@ -1961,7 +1961,7 @@ ok.
 progex_funs(Config) when is_list(Config) ->
     Test1 = 
 	<<"-module(funs).
-          -compile(export_all).
+          -export([t/0]).
 
 double([H|T]) -> [2*H|double(T)];
 double([])    -> [].
@@ -3031,7 +3031,7 @@ run_file(Config, Module, Test) ->
     ok.
 
 compile_file(Config, File, Test, Opts0) ->
-    Opts = [export_all,return,{outdir,proplists:get_value(priv_dir, Config)}|Opts0],
+    Opts = [export_all,nowarn_export_all,return,{outdir,proplists:get_value(priv_dir, Config)}|Opts0],
     ok = file:write_file(File, Test),
     case compile:file(File, Opts) of
               {ok, _M, _Ws} -> ok;

--- a/lib/tools/emacs/erlang-flymake.el
+++ b/lib/tools/emacs/erlang-flymake.el
@@ -37,8 +37,7 @@
   "Return a list of include directories to add to the compiler options.")
 
 (defvar erlang-flymake-extra-opts
-  (list "+warn_obsolete_guard"
-        "+warn_unused_import"
+  (list "+warn_unused_import"
         "+warn_shadow_vars"
         "+warn_export_vars"
         "+strong_validation"


### PR DESCRIPTION
I think it's time to start warning for the use of export_all by default. This should never be left in the code by mistake, as it often ends up being. If you use it in production, you should know about it and suppress warnings explicitly.

Also, fix up some leftovers from when warn_obsolete_guard got enabled by default, in particular the documentation.
