### PR TITLE
Disable -fPIE for HiPE on x86_64

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2771,6 +2771,23 @@ if test "$cross_compiling" != "yes" && test X${enable_hipe} != Xno; then
   fi
 fi
 
+dnl Check to disable -fPIE and friends for HiPE on amd64
+if test X${enable_hipe} = Xyes && test X$ARCH = Xamd64; then
+   AC_TRY_COMPILE(, [#if defined(__pie__) || defined(__PIE__)
+		     #error -fPIE is enabled by default
+		     #endif],
+		    [AC_MSG_NOTICE([No -fPIE enabled by default])],
+		    [AC_MSG_WARN([Security feature -fPIE will be disabled for HiPE])
+		     STATIC_CFLAGS="-fno-PIE $STATIC_CFLAGS"
+		     saved_LDFLAGS=$LDFLAGS
+		     LDFLAGS="-no-pie $LDFLAGS"
+		     AC_TRY_LINK(,, [],
+			[AC_MSG_WARN([Linked does not accept option -no-pie])
+			 LDFLAGS=$saved_LDFLAGS])])
+
+fi
+
+
 if test X${enable_fp_exceptions} = Xauto ; then
    case $host_os in
    	*linux*)

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -49,6 +49,7 @@ CREATE_DIRS=
 LDFLAGS=@LDFLAGS@
 ARFLAGS=rc
 OMIT_OMIT_FP=no
+TYPE_LIBS=
 
 DIRTY_SCHEDULER_SUPPORT=@DIRTY_SCHEDULER_SUPPORT@
 NEW_PURGE_STRATEGY=@NEW_PURGE_STRATEGY@
@@ -90,7 +91,7 @@ PURIFY =
 TYPEMARKER = .gcov
 TYPE_FLAGS = $(DEBUG_CFLAGS) -DERTS_GCOV -DNO_JUMP_TABLE -fprofile-arcs -ftest-coverage -O0 -DERTS_CAN_INLINE=0 -DERTS_INLINE=
 ifneq ($(findstring solaris,$(TARGET)),solaris)
-LIBS += -lgcov
+TYPE_LIBS = -lgcov
 endif
 ENABLE_ALLOC_TYPE_VARS += debug
 else
@@ -145,6 +146,8 @@ endif
 endif
 endif
 endif
+
+LIBS += $(TYPE_LIBS)
 
 comma:=,
 space:=
@@ -931,7 +934,7 @@ $(OBJDIR)/%.o: hipe/%.c
 	$(V_CC) $(subst O2,O3, $(CFLAGS)) $(INCLUDES) -c $< -o $@
 
 $(BINDIR)/hipe_mkliterals$(TF_MARKER):	$(OBJDIR)/hipe_mkliterals.o
-	$(ld_verbose)$(CC) $(CFLAGS) $(INCLUDES) -o $@ $<
+	$(ld_verbose)$(CC) $(LDFLAGS) -o $@ $< $(TYPE_LIBS)
 
 $(OBJDIR)/hipe_mkliterals.o:	$(HIPE_ASM) $(TTF_DIR)/erl_alloc_types.h $(DTRACE_HEADERS) \
 	$(TTF_DIR)/OPCODES-GENERATED $(TARGET)/TABLES-GENERATED


### PR DESCRIPTION
This is an attempt to fix https://bugs.erlang.org/browse/ERL-294
by letting configure disable position independent executable (PIE) if
* PIE is enabled by default
* and hipe is enabled
* and architecture is x86_64 (amd64)
 
I encourage stake holders to test this before we merge into maint for OTP-19.2.

