### PR TITLE
Don't wrap continuations from mnesia_ext backends

### DIFF
--- a/lib/mnesia/src/mnesia_lib.erl
+++ b/lib/mnesia/src/mnesia_lib.erl
@@ -1192,25 +1192,15 @@ db_select(Storage, Tab, Pat) ->
     end.
 
 db_select_init({ext, Alias, Mod}, Tab, Pat, Limit) ->
-    case Mod:select(Alias, Tab, Pat, Limit) of
-	{Matches, Continuation} when is_list(Matches) ->
-	    {Matches, {Alias, Continuation}};
-	R ->
-	    R
-    end;
+    Mod:select(Alias, Tab, Pat, Limit);
 db_select_init(disc_only_copies, Tab, Pat, Limit) ->
     dets:select(Tab, Pat, Limit);
 db_select_init(_, Tab, Pat, Limit) ->
     ets:select(Tab, Pat, Limit).
 
-db_select_cont({ext, Alias, Mod}, Cont0, Ms) ->
+db_select_cont({ext, _Alias, Mod}, Cont0, Ms) ->
     Cont = Mod:repair_continuation(Cont0, Ms),
-    case Mod:select(Cont) of
-	{Matches, Continuation} when is_list(Matches) ->
-	    {Matches, {Alias, Continuation}};
-	R ->
-	    R
-    end;
+    Mod:select(Cont);
 db_select_cont(disc_only_copies, Cont0, Ms) ->
     Cont = dets:repair_continuation(Cont0, Ms),
     dets:select(Cont);

--- a/lib/mnesia/test/ext_test.erl
+++ b/lib/mnesia/test/ext_test.erl
@@ -233,5 +233,5 @@ select_1({Acc, C}) ->
 select(ext_ets, Tab, Ms, Limit) when is_integer(Limit); Limit =:= infinity ->
     ets:select(mnesia_lib:val({?MODULE,Tab}), Ms, Limit).
 
-repair_continuation({Alias, Cont}, Ms) ->
-    {Alias, ets:repair_continuation(Cont, Ms)}.
+repair_continuation(Cont, Ms) ->
+    ets:repair_continuation(Cont, Ms).


### PR DESCRIPTION
Continuations returned from mnesia_ext backends were originally wrapped with
the backend module, but that was a remnant of the earliest implementation,
and is not actually needed, since Mnesia already knows what the table
storage type is when it applies the continuation. When mnesia_ext was ported
to OTP 19, the wrapper got changed to use the table type alias instead of
the module, which triggered an error in the mnesia_eleveldb backend. This
patch removes the wrapping completely.