### PR TITLE
Add a version of application:info that takes a timeout

### DIFF
--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -28,7 +28,7 @@
 -export([set_env/3, set_env/4, unset_env/2, unset_env/3]).
 -export([get_env/1, get_env/2, get_env/3, get_all_env/0, get_all_env/1]).
 -export([get_key/1, get_key/2, get_all_key/0, get_all_key/1]).
--export([get_application/0, get_application/1, info/0]).
+-export([get_application/0, get_application/1, info/0, info/1]).
 -export([start_type/0]).
 
 -export_type([start_type/0]).
@@ -278,6 +278,12 @@ loaded_applications() ->
 
 info() -> 
     application_controller:info().
+
+-spec info(Timeout) -> term() when
+      Timeout :: timeout().
+
+info(Timeout) ->
+    application_controller:info(Timeout).
 
 -spec set_env(Application, Par, Val) -> 'ok' when
       Application :: atom(),

--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -26,7 +26,7 @@
 	 control_application/1,
 	 change_application_data/2, prep_config_change/0, config_change/1,
 	 which_applications/0, which_applications/1,
-	 loaded_applications/0, info/0,
+	 loaded_applications/0, info/0, info/1,
 	 get_pid_env/2, get_env/2, get_pid_all_env/1, get_all_env/1,
 	 get_pid_key/2, get_key/2, get_pid_all_key/1, get_all_key/1,
 	 get_master/1, get_application/1, get_application_module/1,
@@ -277,7 +277,9 @@ loaded_applications() ->
 
 %% Returns some debug info
 info() ->
-    gen_server:call(?AC, info).    
+    gen_server:call(?AC, info).
+info(Timeout) ->
+    gen_server:call(?AC, info, Timeout).
 
 control_application(AppName) ->
     gen_server:call(?AC, {control_application, AppName}, infinity).


### PR DESCRIPTION
The `application:info/0` has a 5 second timeout, which is not convenient, because the `application_controller` process is blocked while an application is stopping, and that can definitely take more than 5 seconds.

This commit adds `application:info/1` that takes a timeout, similar to how `application:which_applications/1` and `application:which_applications/0` relate to each other.