### PR TITLE
Document the ordering used in ordsets and orddicts

### DIFF
--- a/lib/stdlib/doc/src/orddict.xml
+++ b/lib/stdlib/doc/src/orddict.xml
@@ -38,7 +38,7 @@
     <p>This module provides a <c>Key</c>-<c>Value</c> dictionary.
       An <c>orddict</c> is a representation of a dictionary, where a
       list of pairs is used to store the keys and values. The list is
-      ordered after the keys.</p>
+      ordered after the keys in the <em>Erlang term order</em>.</p>
 
     <p>This module provides the same interface as the
       <seealso marker="dict"><c>dict(3)</c></seealso> module

--- a/lib/stdlib/doc/src/ordsets.xml
+++ b/lib/stdlib/doc/src/ordsets.xml
@@ -39,7 +39,8 @@
     <p>Sets are collections of elements with no duplicate elements.
       An <c>ordset</c> is a representation of a set, where an ordered
       list is used to store the elements of the set. An ordered list
-      is more efficient than an unordered list.</p>
+      is more efficient than an unordered list. Elements are ordered
+      according to the <em>Erlang term order</em>.</p>
 
     <p>This module provides the same interface as the
       <seealso marker="sets"><c>sets(3)</c></seealso> module


### PR DESCRIPTION
Right now the exact order of elements is not specified, yet many
programs rely on the ordering being the obvious one - erlang term order.
It is only beneficial to make this an explicit part of the
documentation.