### PR TITLE
Run dialyzer as part of the travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ script:
   - ./otp_build all -a
   
 after_success:
+  - $ERL_TOP/bin/dialyzer --build_plt --apps asn1 compiler crypto dialyzer edoc erts et hipe inets kernel mnesia observer public_key runtime_tools snmp ssh ssl stdlib syntax_tools wx xmerl --statistics
+  - $ERL_TOP/bin/dialyzer -n -Wunmatched_returns --apps asn1 compiler crypto dialyzer erts hipe parsetools public_key runtime_tools sasl stdlib tools --statistics
   - ./otp_build tests && make release_docs
 
 after_script:
   - cd $ERL_TOP/release/tests/test_server && $ERL_TOP/bin/erl -s ts install -s ts smoke_test batch -s init stop
-  
-


### PR DESCRIPTION
(A duplicate of #1244 rebased on `master` to test that it can
properly detect dialyzer problems.)

Build a dialyzer PLT and use it to analyze all OTP applications
that can currently be analyzed without warnings even when the
option -Wunmatched_returns is turned on. Note that the dialyzer
run does _not_ enable the option which allows for improper lists.

Applications to run dialyzer on are mentioned alphabetically.
As more applications are fixed to run cleanly even with unmatched
returns, they can be added to this list.  However, there will come
a point when the warning pass of Dialyzer will run out of memory
on Travis and the process will be killed.  This should be fixed in
dialyzer.