### PR TITLE
Attempt to save memory by dialyzing fewer applications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,10 @@ script:
   
 after_success:
   - $ERL_TOP/bin/dialyzer --build_plt --apps asn1 compiler crypto dialyzer edoc erts et hipe inets kernel mnesia observer public_key runtime_tools snmp ssh ssl stdlib syntax_tools wx xmerl --statistics
-  - $ERL_TOP/bin/dialyzer -n -Wunmatched_returns --apps asn1 compiler crypto dialyzer erts hipe parsetools public_key runtime_tools sasl stdlib tools --statistics
+  - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps compiler erts kernel stdlib --statistics
+  - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps asn1 crypto dialyzer --statistics
+  - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps hipe parsetools public_key --statistics
+  - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps runtime_tools sasl tools --statistics
   - ./otp_build tests && make release_docs
 
 after_script:

--- a/lib/stdlib/src/rand.erl
+++ b/lib/stdlib/src/rand.erl
@@ -155,7 +155,7 @@ uniform_s(N, State0 = {#{uniform:=Uniform}, _})
 %% after a large number of call defined for each algorithm.
 %% The large number is algorithm dependent.
 
--spec jump(state()) -> NewS :: state().
+-spec jump(state()) -> {NewS :: state()}.
 jump(State = {#{jump:=Jump}, _}) ->
     Jump(State).
 
@@ -164,7 +164,7 @@ jump(State = {#{jump:=Jump}, _}) ->
 %% and write back the new value to the internal state,
 %% then returns the new value.
 
--spec jump() -> NewS :: state().
+-spec jump() -> {NewS :: state()}.
 
 jump() ->
     seed_put(jump(seed_get())).
@@ -323,14 +323,16 @@ exsplus_uniform(Max, {Alg, R}) ->
 -define(JUMPCONST2, 16#345d2a0f85f788c).
 -define(JUMPELEMLEN, 58).
 
--dialyzer({no_improper_lists, exsplus_jump/1}).
--spec exsplus_jump(state()) -> state().
+-spec exsplus_jump(exsplus_state()) -> exsplus_state().
+
 exsplus_jump({Alg, S}) ->
     {S1, AS1} = exsplus_jump(S, [0|0], ?JUMPCONST1, ?JUMPELEMLEN),
     {_,  AS2} = exsplus_jump(S1, AS1,  ?JUMPCONST2, ?JUMPELEMLEN),
     {Alg, AS2}.
 
--dialyzer({no_improper_lists, exsplus_jump/4}).
+-spec exsplus_jump(state(), state(), pos_integer(), pos_integer()) ->
+           {state(), state()}.
+
 exsplus_jump(S, AS, _, 0) ->
     {S, AS};
 exsplus_jump(S, [AS0|AS1], J, N) ->
@@ -438,6 +440,10 @@ exs1024_jump({Alg, {L, RL}}) ->
          ?JUMPCONSTTAIL, ?JUMPCONSTHEAD, ?JUMPELEMLEN, ?JUMPTOTALLEN),
     {ASL, ASR} = lists:split(?RINGLEN - P, AS),
     {Alg, {ASL, lists:reverse(ASR)}}.
+
+-spec exs1024_jump(state(), list(non_neg_integer()),
+           list(non_neg_integer()), non_neg_integer(),
+           non_neg_integer(), non_neg_integer()) -> list(non_neg_integer()).
 
 exs1024_jump(_, AS, _, _, _, 0) ->
     AS;


### PR DESCRIPTION
Travis has crashed several times because of the memory limit
of 2Gb has been exceeded. Try to fix that by analyzing fewer
applications.

Same as #1248, except based on master. Also see #1244.