### PR TITLE
Preserve key order in mnesia:table_info

### DIFF
--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -1882,9 +1882,10 @@ any_table_info(Tab, Item) when is_atom(Tab) ->
 		[] ->
 		    abort({no_exists, Tab, Item});
 		Props ->
-		    lists:map(fun({setorbag, Type}) -> {type, Type};
-				 (Prop) -> Prop end,
-			      Props)
+                    Rename = fun ({setorbag, Type}) -> {type, Type};
+                                 (Prop) -> Prop
+                             end,
+                    lists:sort(lists:map(Rename, Props))
 	    end;
 	name ->
 	    Tab;


### PR DESCRIPTION
The result from mnesia_schema:get_table_properties(Tab) is sorted, but this map operation breaks the ordering, so it should be sorted again.