### PR TITLE
Support setting eccs option for TLS distribution

### DIFF
--- a/lib/ssl/doc/src/ssl_distribution.xml
+++ b/lib/ssl/doc/src/ssl_distribution.xml
@@ -205,6 +205,7 @@ Eshell V5.0  (abort with ^G)
       <item><c>depth</c></item>
       <item><c>hibernate_after</c></item>
       <item><c>ciphers</c> (use old string format)</item>
+      <item><c>eccs</c> (use comma-separated curve names)</item>
     </list>
 
     <p>Note that <c>verify_fun</c> needs to be written in a different

--- a/lib/ssl/src/ssl_tls_dist_proxy.erl
+++ b/lib/ssl/src/ssl_tls_dist_proxy.erl
@@ -434,6 +434,12 @@ ssl_options(server, ["server_ciphers", Value|T]) ->
     [{ciphers, Value} | ssl_options(server,T)];
 ssl_options(client, ["client_ciphers", Value|T]) ->
     [{ciphers, Value} | ssl_options(client,T)];
+ssl_options(server, ["server_eccs", Value|T]) ->
+    Eccs = lists:map(fun list_to_atom/1, string:tokens(Value, ",")),
+    [{eccs, Eccs} | ssl_options(server,T)];
+ssl_options(client, ["client_eccs", Value|T]) ->
+    Eccs = lists:map(fun list_to_atom/1, string:tokens(Value, ",")),
+    [{eccs, Eccs} | ssl_options(client,T)];
 ssl_options(server, ["server_dhfile", Value|T]) ->
     [{dhfile, Value} | ssl_options(server,T)];
 ssl_options(server, ["server_fail_if_no_peer_cert", Value|T]) ->


### PR DESCRIPTION
Add server_eccs and client_eccs to the list of options accepted by the
-ssl_dist_opt command line argument, so that it's possible to limit the
choice of elliptic curves for TLS distribution connections.
