### PR TITLE
HiPE: Better crash message for internal errors and fix icode_call_elim crash

### DIFF
--- a/lib/hipe/icode/hipe_icode_call_elim.erl
+++ b/lib/hipe/icode/hipe_icode_call_elim.erl
@@ -46,7 +46,8 @@ cfg(IcodeSSA) ->
 -spec elim_insn(icode_instr()) -> icode_instr().
 elim_insn(Insn=#icode_call{'fun'={_,_,_}=MFA, args=Args, type=remote,
 			   dstlist=[Dst=#icode_variable{
-				      annotation={type_anno, RetType, _}}]}) ->
+					   annotation={type_anno, RetType, _}}],
+			   continuation=[], fail_label=[]}) ->
   Opaques = 'universe',
   case erl_types:t_is_singleton(RetType, Opaques) of
     true ->

--- a/lib/hipe/main/hipe.hrl.src
+++ b/lib/hipe/main/hipe.hrl.src
@@ -1,4 +1,4 @@
-%% -*- erlang-indent-level: 2 -*-
+%% -*- mode: erlang; erlang-indent-level: 2 -*-
 %%
 %% %CopyrightBegin%
 %% 
@@ -70,10 +70,14 @@
 	code_server:info_msg(?MSGTAG ++ Msg, Args)).
 -define(untagged_msg(Msg, Args),
 	code_server:info_msg(Msg, Args)).
+-define(untagged_error_msg(Msg, Args),
+	code_server:error_msg(Msg, Args)).
 -else.
 -define(msg(Msg, Args),
 	io:format(?MSGTAG ++ Msg, Args)).
 -define(untagged_msg(Msg, Args),
+	io:format(Msg, Args)).
+-define(untagged_error_msg(Msg, Args),
 	io:format(Msg, Args)).
 -endif.
 
@@ -81,9 +85,9 @@
 %% Define error and warning messages.
 %%
 -define(error_msg(Msg, Args),
-	code_server:error_msg(?MSGTAG ++
+	?untagged_error_msg(?MSGTAG ++
 			      "Error: [~s:~w]: " ++ Msg,
-			      [?MODULE,?LINE|Args])).
+			    [?MODULE,?LINE|Args])).
 -define(WARNING_MSG(Msg, Args),
 	?msg("Warning: [~s:~w]: " ++ Msg, [?MODULE,?LINE|Args])).
 

--- a/lib/hipe/test/maps_SUITE_data/maps_redundant_branch_is_key.erl
+++ b/lib/hipe/test/maps_SUITE_data/maps_redundant_branch_is_key.erl
@@ -1,0 +1,14 @@
+-module(maps_redundant_branch_is_key).
+-export([test/0]).
+
+test() ->
+    ok = thingy(#{a => 1}),
+    ok = thingy(#{a => 2}),
+    ok.
+
+thingy(Map) ->
+    try
+	#{a := _} = Map,
+	ok
+    catch _ -> error
+    end.


### PR DESCRIPTION
It will now print the MFA/module being compiled, and pretty-print the backtrace with
`lib:format_stacktrace/4`.

Additionally, the `error_msg/2` macro in `hipe.hrl` will now respect the
`HIPE_LOGGING` define, since messages produced by this macro just before
runtime shutdown were sometimes lost (since `code_server:error_msg/2` is
asynchronous).