### PR TITLE
Report errors from TLS tunnel request to correct process

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -1749,14 +1749,16 @@ tls_tunnel(Address, Request, #state{session = #session{socket = Socket,
 
 tls_tunnel_request(#request{headers = Headers, 
 			     settings = Options,
+			     id = RequestId,
+			     from = From,
 			     address =  {Host, Port}= Adress,
 			     ipv6_host_with_brackets = IPV6}) ->
     
     URI = Host ++":" ++ integer_to_list(Port),
     
     #request{
-       id = make_ref(),
-       from = self(),
+       id = RequestId,
+       from = From,
        scheme = http, %% Use tcp-first and then upgrade!
        address = Adress,
        path = URI,


### PR DESCRIPTION
Previously errors from TLS tunnel requests were sent to the same httpc_handler process which exits after sending the error to itself and the error is lost. This caused the process initiating the request to hang forever since the request timeout is not started until the first non-tunneled request is sent.

It is safe to set `from` to the calling process since messages will only be sent when errors occur.

I cannot create tests for this since I am unable to setup the proxy software (on macOS) needed to run the tests.