### PR TITLE
Remove vestiges of watchdog support in heart

### DIFF
--- a/erts/etc/common/heart.c
+++ b/erts/etc/common/heart.c
@@ -48,13 +48,10 @@
  *
  *  HEART_BEATING
  *
- *  This program expects a heart beat messages. If it does not receive a 
- *  heart beat message from Erlang within heart_beat_timeout seconds, it 
- *  reboots the system. The variable heart_beat_timeout is exported (so
- *  that it can be set from the shell in VxWorks, as is the variable
- *  heart_beat_report_delay). When using Solaris, the system is rebooted
- *  by executing the command stored in the environment variable
- *  HEART_COMMAND.
+ *  This program expects a heart beat message. If it does not receive a
+ *  heart beat message from Erlang within heart_beat_timeout seconds, it
+ *  reboots the system. The system is rebooted by executing the command
+ *  stored in the environment variable HEART_COMMAND.
  *
  *  BLOCKING DESCRIPTORS
  *
@@ -149,26 +146,16 @@ struct msg {
 /*  Maybe interesting to change */
 
 /* Times in seconds */
-#define  HEART_BEAT_BOOT_DELAY       60  /* 1 minute */
 #define  SELECT_TIMEOUT               5  /* Every 5 seconds we reset the
 					    watchdog timer */
 
 /* heart_beat_timeout is the maximum gap in seconds between two
-   consecutive heart beat messages from Erlang, and HEART_BEAT_BOOT_DELAY
-   is the the extra delay that wd_keeper allows for, to give heart a
-   chance to reboot in the "normal" way before the hardware watchdog
-   enters the scene. heart_beat_report_delay is the time allowed for reporting
-   before rebooting under VxWorks. */
+   consecutive heart beat messages from Erlang. */
 
 int heart_beat_timeout = 60;
-int heart_beat_report_delay = 30;
-int heart_beat_boot_delay = HEART_BEAT_BOOT_DELAY;
 /* All current platforms have a process identifier that
    fits in an unsigned long and where 0 is an impossible or invalid value */
 unsigned long heart_beat_kill_pid = 0;
-
-#define VW_WD_TIMEOUT (heart_beat_timeout+heart_beat_report_delay+heart_beat_boot_delay)
-#define SOL_WD_TIMEOUT (heart_beat_timeout+heart_beat_boot_delay)
 
 /* reasons for reboot */
 #define  R_TIMEOUT          (1)
@@ -297,7 +284,6 @@ free_env_val(char *value)
 static void get_arguments(int argc, char** argv) {
     int i = 1;
     int h;
-    int w;
     unsigned long p;
 
     while (i < argc) {
@@ -310,15 +296,6 @@ static void get_arguments(int argc, char** argv) {
 			if ((h > 10) && (h <= 65535)) {
 			    heart_beat_timeout = h;
 			    fprintf(stderr,"heart_beat_timeout = %d\n",h);
-			    i++;
-			}
-		break;
-	    case 'w':
-		if (strcmp(argv[i], "-wt") == 0)
-		    if (sscanf(argv[i+1],"%i",&w) ==1)
-			if ((w > 10) && (w <= 65535)) {
-			    heart_beat_boot_delay = w;
-			    fprintf(stderr,"heart_beat_boot_delay = %d\n",w);
 			    i++;
 			}
 		break;
@@ -347,7 +324,7 @@ static void get_arguments(int argc, char** argv) {
 	}
 	i++;
     }
-    debugf("arguments -ht %d -wt %d -pid %lu\n",h,w,p);
+    debugf("arguments -ht %d -pid %lu\n",h,p);
 }
 
 int main(int argc, char **argv) {
@@ -674,11 +651,6 @@ void win_system(char *command)
  */
 static void 
 do_terminate(int erlin_fd, int reason) {
-  /*
-    When we get here, we have HEART_BEAT_BOOT_DELAY secs to finish
-    (plus heart_beat_report_delay if under VxWorks), so we don't need
-    to call wd_reset().
-    */
   int ret = 0, tmo=0;
   char *tmo_env;
 

--- a/lib/kernel/doc/src/heart.xml
+++ b/lib/kernel/doc/src/heart.xml
@@ -37,10 +37,7 @@
       the <c>heart</c> port program is to check that the Erlang runtime system
       it is supervising is still running. If the port program has not
       received any heartbeats within <c>HEART_BEAT_TIMEOUT</c> seconds
-      (defaults to 60 seconds), the system can be rebooted. Also, if
-      the system is equipped with a hardware watchdog timer and is
-      running Solaris, the watchdog can be used to supervise the entire
-      system.</p>
+      (defaults to 60 seconds), the system can be rebooted.</p>
     <p>An Erlang runtime system to be monitored by a heart program
       is to be started with command-line flag <c>-heart</c> (see
       also <seealso marker="erts:erl"><c>erl(1)</c></seealso>).
@@ -51,17 +48,13 @@
       or a terminated Erlang runtime system, environment variable
       <c>HEART_COMMAND</c> must be set before the system is started.
       If this variable is not set, a warning text is printed but
-      the system does not reboot. However, if the hardware watchdog is
-      used, it still triggers a reboot <c>HEART_BEAT_BOOT_DELAY</c>
-      seconds later (defaults to 60 seconds).</p>
+      the system does not reboot.</p>
     <p>To reboot on Windows, <c>HEART_COMMAND</c> can be
       set to <c>heart -shutdown</c> (included in the Erlang delivery)
       or to any other suitable program that can activate a reboot.</p>
-    <p>The hardware watchdog is not started under Solaris if
-      environment variable <c>HW_WD_DISABLE</c> is set.</p>
-    <p>The environment variables <c>HEART_BEAT_TIMEOUT</c> and
-      <c>HEART_BEAT_BOOT_DELAY</c> can be used to configure the heart
-      time-outs; they can be set in the operating system shell before Erlang
+    <p>The environment variable <c>HEART_BEAT_TIMEOUT</c>
+      can be used to configure the heart
+      time-outs; it can be set in the operating system shell before Erlang
       is started or be specified at the command line:</p>
     <pre>
 % <input>erl -heart -env HEART_BEAT_TIMEOUT 30 ...</input></pre>

--- a/lib/kernel/src/heart.erl
+++ b/lib/kernel/src/heart.erl
@@ -198,16 +198,11 @@ start_portprogram() ->
     end.
 
 get_heart_timeouts() ->
-    HeartOpts = case os:getenv("HEART_BEAT_TIMEOUT") of
-		    false -> "";
-		    H when is_list(H) -> 
-			"-ht " ++ H
-		end,
-    HeartOpts ++ case os:getenv("HEART_BEAT_BOOT_DELAY") of
-		     false -> "";
-		     W when is_list(W) ->
-			 " -wt " ++ W
-		 end.
+    case os:getenv("HEART_BEAT_TIMEOUT") of
+	false -> "";
+	H when is_list(H) ->
+	    "-ht " ++ H
+    end.
 
 check_start_heart() ->
     case init:get_argument(heart) of

--- a/lib/sasl/test/release_handler_SUITE_data/start
+++ b/lib/sasl/test/release_handler_SUITE_data/start
@@ -21,8 +21,7 @@ then
 fi
 
 HEART_COMMAND=$ROOTDIR/bin/start
-HW_WD_DISABLE=true
-export HW_WD_DISABLE HEART_COMMAND
+export HEART_COMMAND
 
 START_ERL_DATA=${1:-$RELDIR/start_erl.data}
 

--- a/lib/sasl/test/release_handler_SUITE_data/start_client
+++ b/lib/sasl/test/release_handler_SUITE_data/start_client
@@ -24,8 +24,7 @@ RELDIR=$CLIENTDIR/releases
 # Note that this scripts is modified an copied to $CLIENTDIR/bin/start
 # in release_handler_SUITE:copy_client - therefore HEART_COMMAND is as follows:
 HEART_COMMAND=$CLIENTDIR/bin/start
-HW_WD_DISABLE=true
-export HW_WD_DISABLE HEART_COMMAND
+export HEART_COMMAND
 
 START_ERL_DATA=${1:-$RELDIR/start_erl.data}
 


### PR DESCRIPTION
Hardware watchdog support was removed from heart in R13A, but there were
still some vestiges in the code and the documentation.

- Remove mentions of the HW_WD_DISABLE variable, as it's no longer used.
- Remove the HEART_BEAT_BOOT_DELAY variable, as it was only used for the
  hardware watchdog.