### PR TITLE
Remove duplicate docs for the priority inet option

### DIFF
--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -987,11 +987,6 @@ setcap cap_sys_admin,cap_sys_ptrace,cap_dac_read_search+epi beam.smp</code>
             <p>Sets the line delimiting character for line-oriented protocols
               (<c>line</c>). Defaults to <c>$\n</c>.</p>
           </item>
-          <tag><c>{priority, Priority}</c></tag>
-          <item>
-            <p>Sets the protocol-defined priority for all packets to be sent
-              on this socket.</p>
-          </item>
           <tag><c>{raw, Protocol, OptionNum, ValueBin}</c></tag>
           <item>
             <p>See below.</p>


### PR DESCRIPTION
Documentation for the `priority` option is found twice in the inet docs. This commit removes the least interesting of the two.

Other location: https://github.com/essen/otp/blob/d1301e814920bde89dec4acfab58d0f2600e2b78/lib/kernel/doc/src/inet.xml#L1074