### PR TITLE
Travis: Generate dialyzer warnings for more applications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ after_success:
   - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps asn1 crypto dialyzer --statistics
   - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps hipe parsetools public_key --statistics
   - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps runtime_tools sasl tools --statistics
+  - $ERL_TOP/bin/dialyzer -n --apps common_test debugger edoc --statistics
+  - $ERL_TOP/bin/dialyzer -n --apps inets mnesia observer --statistics
+  - $ERL_TOP/bin/dialyzer -n --apps ssh ssl syntax_tools --statistics
+  - $ERL_TOP/bin/dialyzer -n --apps tools wx xmerl --statistics
   - ./otp_build tests && make release_docs
 
 after_script:


### PR DESCRIPTION
We were somewhat conservative in how many applications we tried
to analyze. Now that the current set of applications seems to work
fine, be brave and try some more applications. Note the other
applications are not free from "unmatched return" warnings.