### PR TITLE
Include explicit attrs when default_attrs=true

### DIFF
--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -2225,16 +2225,18 @@ processed_whole_element(S=#xmerl_scanner{hook_fun = _Hook,
     AllAttrs =
 	case S#xmerl_scanner.default_attrs of
 	    true ->
-		[ #xmlAttribute{name = AttName,
-				parents = [{Name, Pos} | Parents],
-				language = Lang,
-				nsinfo = NSI,
-				namespace = Namespace,
-				value = AttValue,
-				normalized = true} ||
-		  {AttName, AttValue} <- get_default_attrs(S, Name),
-		  AttValue =/= no_value,
-		  not lists:keymember(AttName, #xmlAttribute.name, Attrs) ];
+            DefaultAttrs =
+                [ #xmlAttribute{name = AttName,
+                                parents = [{Name, Pos} | Parents],
+                                language = Lang,
+                                nsinfo = NSI,
+                                namespace = Namespace,
+                                value = AttValue,
+                                normalized = true} ||
+                  {AttName, AttValue} <- get_default_attrs(S, Name),
+                  AttValue =/= no_value,
+                  not lists:keymember(AttName, #xmlAttribute.name, Attrs) ],
+            lists:append(Attrs, DefaultAttrs);
 	    false ->
 		Attrs
 	end,

--- a/lib/xmerl/test/xmerl_SUITE.erl
+++ b/lib/xmerl/test/xmerl_SUITE.erl
@@ -54,7 +54,8 @@ groups() ->
        cpd_expl_provided_DTD]},
      {misc, [],
       [latin1_alias, syntax_bug1, syntax_bug2, syntax_bug3,
-       pe_ref1, copyright, testXSEIF, export_simple1, export]},
+       pe_ref1, copyright, testXSEIF, export_simple1, export,
+       default_attrs_bug]},
      {eventp_tests, [], [sax_parse_and_export]},
      {ticket_tests, [],
       [ticket_5998, ticket_7211, ticket_7214, ticket_7430,
@@ -222,6 +223,21 @@ syntax_bug3(Config) ->
                 Reason;
             Err -> Err
         end.
+
+default_attrs_bug(Config) ->
+    file:set_cwd(datadir(Config)),
+    Doc = "<!DOCTYPE doc [<!ATTLIST doc b CDATA \"default\">]>\n"
+          "<doc a=\"explicit\"/>",
+    {#xmlElement{attributes = [#xmlAttribute{name = a, value = "explicit"},
+                               #xmlAttribute{name = b, value = "default"}]},
+     []
+    } = xmerl_scan:string(Doc, [{default_attrs, true}]),
+    Doc2 = "<!DOCTYPE doc [<!ATTLIST doc b CDATA \"default\">]>\n"
+           "<doc b=\"also explicit\" a=\"explicit\"/>",
+    {#xmlElement{attributes = [#xmlAttribute{name = b, value = "also explicit"},
+                               #xmlAttribute{name = a, value = "explicit"}]},
+     []
+    } = xmerl_scan:string(Doc2, [{default_attrs, true}]).
 
 pe_ref1(Config) ->
     file:set_cwd(datadir(Config)),


### PR DESCRIPTION
With the `default_attrs` option set to `true`, xmerl_scan was replacing the attributes for each element with the default attributes, discarding any attributes which were explicitly set.

The new behaviour appends the default attributes, keeping the explicit attributes intact.

The new test I've added for this change tests two documents to ensure both attributes exist in each case:

```xml
<!DOCTYPE doc [<!ATTLIST doc b CDATA "default">]>
<doc a="explicit"/>
```

```xml
<!DOCTYPE doc [<!ATTLIST doc b CDATA "default">]>
<doc b="also explicit" a="explicit"/>
```

Prior to this change, the `a` attribute was not included in the parsed structure.