### PR TITLE
enif_select() for asynchronous IO notifications

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -699,11 +699,29 @@ typedef struct {
           Each resource type has a unique name and a destructor function that
           is called when objects of its type are released.</p>
       </item>
+      <tag><marker id="ErlNifResourceTypeInit"/><c>ErlNifResourceTypeInit</c></tag>
+      <item>
+        <code type="none">
+typedef struct {
+    ErlNifResourceDtor* dtor;
+    ErlNifResourceStop* stop;
+} ErlNifResourceTypeInit;</code>
+        <p>Initialization structure read by <seealso marker="#enif_open_resource_type_x">
+	enif_open_resource_type_x</seealso>.</p>
+      </item>
       <tag><marker id="ErlNifResourceDtor"/><c>ErlNifResourceDtor</c></tag>
       <item>
         <code type="none">
 typedef void ErlNifResourceDtor(ErlNifEnv* env, void* obj);</code>
         <p>The function prototype of a resource destructor function.</p>
+      </item>
+      <tag><marker id="ErlNifResourceStop"/><c>ErlNifResourceStop</c></tag>
+      <item>
+        <code type="none">
+typedef void ErlNifResourceStop(ErlNifEnv* env, void* obj);</code>
+        <p>The function prototype of a resource stop function,
+	  called on the behalf of <seealso marker="#enif_select">
+	  enif_select</seealso>.</p>
       </item>
       <tag><marker id="ErlNifCharEncoding"/><c>ErlNifCharEncoding</c></tag>
       <item>
@@ -2239,6 +2257,24 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
     </func>
 
     <func>
+      <name><ret>ErlNifResourceType *</ret>
+        <nametext>enif_open_resource_type_x(ErlNifEnv* env, const char* name,
+	ErlNifResourceTypeInit* init,
+        ErlNifResourceFlags flags, ErlNifResourceFlags* tried)</nametext>
+      </name>
+      <fsummary>Create or takeover a resource type.</fsummary>
+      <desc>
+	<p>Same as <seealso marker="#enif_open_resource_type"><c>enif_open_resource_type</c></seealso>
+	  except is also accept a <c>stop</c> callback for resource types that are
+	  used together with <seealso marker="#enif_select"><c>enif_select</c></seealso>.</p>
+	<p>Argument <c>init</c> is a pointer to an
+	  <seealso marker="#ErlNifResourceTypeInit"><c>ErlNifResourceTypeInit</c></seealso>
+	  structure that contains the function pointers for the destructor and the stop callback
+	  of the resource type.</p>
+      </desc>
+    </func>
+
+    <func>
      <name><ret>int</ret><nametext>enif_port_command(ErlNifEnv* env, const
        ErlNifPort* to_port, ErlNifEnv *msg_env, ERL_NIF_TERM msg)</nametext>
      </name>
@@ -2345,7 +2381,7 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
         <nametext>enif_release_resource(void* obj)</nametext></name>
       <fsummary>Release a resource object.</fsummary>
       <desc>
-        <p>Removes a reference to resource object <c>obj</c>obtained from
+        <p>Removes a reference to resource object <c>obj</c> obtained from
           <seealso marker="#enif_alloc_resource">
           <c>enif_alloc_resource</c></seealso>.
           The resource object is destructed when the last reference is removed.
@@ -2484,6 +2520,52 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
           block waiting for the scheduled NIF to execute and return. This means
           that the calling NIF cannot expect to receive the scheduled NIF
           return value and use it for further operations.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>int</ret>
+        <nametext>enif_select(ErlNifEnv* env, ErlNifEvent event,
+	                      enum ErlNifSelectFlags mode, void* obj, Eterm ref)</nametext>
+      </name>
+      <fsummary>Manage subscription on IO event.</fsummary>
+      <desc>
+        <p>This function can be used to receive asynchronous notifications
+	  when OS-specific event objects become ready for either read or write operations.</p>
+	<p>Argument <c>event</c> identifies the event object. On Unix
+	  systems, the functions <c>select</c>/<c>poll</c> are used. The event
+	  object must be a socket, pipe or other file descriptor object that
+	  <c>select</c>/<c>poll</c> can use.</p>
+	<p>Argument <c>mode</c> describes the type of events to wait for. It can be
+	  <c>ERL_NIF_SELECT_READ</c>, <c>ERL_NIF_SELECT_WRITE</c> or a bitwise
+	  OR combination to wait for both. It can also be <c>ERL_NIF_SELECT_STOP</c>
+	  which is described further below. When a read or write event is triggerred,
+	  a notification message like this is sent to the Erlang process that called
+	  <c>enif_select</c>:</p>
+	<code type="none"><c>{select, Obj, Ref, ready_input | ready_output}</c></code>
+	<p><c>ready_input</c> or <c>ready_output</c> indicates if the event object
+	  is ready for reading or writing.</p>
+	<p>Argument <c>obj</c> is a resource object obtained from
+          <seealso marker="#enif_alloc_resource"><c>enif_alloc_resource</c></seealso>.
+	  The purpose of the resource objects is as a container of the event object
+	  to manage its state and lifetime. A handle to the resource is received
+	  in the notification message as <c>Obj</c>.</p>
+	<p>Argument <c>ref</c> must be either a reference obtained from
+	  <seealso marker="erlang#make_ref-0"><c>erlang:make_ref/0</c></seealso>
+	  or the atom <c>undefined</c>. It will be passed as <c>Ref</c> in the notifications.
+	  If a selective <c>receive</c> statement is used to wait for the notification
+	  then a reference created just before the <c>receive</c> will exploit a runtime
+	  optimization that bypasses all earlier received messages in the queue.</p>
+	<p>The notifications are one-shot only. To receive further notifications of the same
+	  type (read or write), repeated calls to <c>enif_select</c> must be made.</p>
+	<p>Use <c>ERL_NIF_SELECT_STOP</c> as <c>mode</c> in order to safely
+	  close an event object that has been passed to <c>enif_select</c>. The
+	  <seealso marker="#ErlNifResourceStop"><c>stop</c></seealso> callback
+	  of the resource <c>obj</c> will be called when it is safe to close
+	  the event object. This safe way of closing event objects must be used
+	  even if all notifications have been received and no further calls to
+	  <c>enif_select</c> have been made.</p>
+	<p>Returns 0 on success, or -1 if invalid arguments.</p>
       </desc>
     </func>
 

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -718,10 +718,12 @@ typedef void ErlNifResourceDtor(ErlNifEnv* env, void* obj);</code>
       <tag><marker id="ErlNifResourceStop"/><c>ErlNifResourceStop</c></tag>
       <item>
         <code type="none">
-typedef void ErlNifResourceStop(ErlNifEnv* env, void* obj);</code>
+typedef void ErlNifResourceStop(ErlNifEnv* env, void* obj, ErlNifEvent event, int is_direct_call);</code>
         <p>The function prototype of a resource stop function,
 	  called on the behalf of <seealso marker="#enif_select">
-	  enif_select</seealso>.</p>
+	  enif_select</seealso>. <c>obj</c> is the resource, <c>event</c> is OS event,
+	  <c>is_direct_call</c> is true if the call is made directly from <c>enif_select</c>
+	  or false if it is a scheduled call (potentially from another thread).</p>
       </item>
       <tag><marker id="ErlNifCharEncoding"/><c>ErlNifCharEncoding</c></tag>
       <item>

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -2526,7 +2526,7 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
     </func>
 
     <func>
-      <name><ret>int</ret>
+      <name><ret>enum ErlNifSelectReturn</ret>
         <nametext>enif_select(ErlNifEnv* env, ErlNifEvent event,
 	                      enum ErlNifSelectFlags mode, void* obj, Eterm ref)</nametext>
       </name>
@@ -2567,7 +2567,38 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
 	  the event object. This safe way of closing event objects must be used
 	  even if all notifications have been received and no further calls to
 	  <c>enif_select</c> have been made.</p>
-	<p>Returns 0 on success, or -1 if invalid arguments.</p>
+	<p>Returns an integer where different bits indicate the outcome of the call:</p>
+        <taglist>
+          <tag><c>ERL_NIF_SELECT_ERROR</c></tag>
+          <item>The master error bit. It will always be set if the call failed for
+	    any reason.</item>
+          <tag><c>ERL_NIF_SELECT_STOP_CALLED</c></tag>
+          <item>The stop callback was called directly by <c>enif_select</c>.</item>
+          <tag><c>ERL_NIF_SELECT_STOP_SCHEDULED</c></tag>
+          <item>The stop callback was scheduled to run on some other thread
+	    or later by this thread.</item>
+          <tag><c>ERL_NIF_SELECT_INVALID_EVENT</c></tag>
+          <item>Argument <c>event</c> is not a valid OS event object.</item>
+          <tag><c>ERL_NIF_SELECT_FAILED</c></tag>
+          <item>The system call failed to add the event object to the poll set.</item>
+        </taglist>
+	<p>The return value from a successful call with <c>mode</c> as <c>ERL_NIF_SELECT_STOP</c>,
+	will contain either bit <c>ERL_NIF_SELECT_STOP_CALLED</c> or
+	<c>ERL_NIF_SELECT_STOP_SCHEDULED</c>.</p>
+        <note>
+          <p>Always use bitwise AND to test the return value. New significant bits
+	  may be added in future releases to give more detailed information for both
+	  failed and successful calls. Do NOT use equallity tests like <c>==</c>, as
+	  that may cause your application to stop working.</p>
+	  <p>Example:</p>
+	  <code type="none">
+retval = enif_select(env, fd, ERL_NIF_SELECT_READ, resource, ref);
+if (retval &amp; ERL_NIF_SELECT_ERROR) {
+    /* handle error */
+}
+/* Success! */
+</code>
+        </note>
       </desc>
     </func>
 

--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -663,6 +663,8 @@ erts_alloc_init(int *argc, char **argv, ErtsAllocInitOpts *eaiop)
 	= sizeof(ErtsDrvEventDataState);
     fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_DRV_SEL_D_STATE)]
 	= sizeof(ErtsDrvSelectDataState);
+    fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_NIF_SEL_D_STATE)]
+        = sizeof(ErtsNifSelectDataState);
     fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_MSG_REF)]
 	= sizeof(ErtsMessageRef);
 #ifdef ERTS_SMP

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -396,6 +396,7 @@ type	DRV_TAB		LONG_LIVED	SYSTEM		drv_tab
 type	DRV_EV_STATE	LONG_LIVED	SYSTEM		driver_event_state
 type	DRV_EV_D_STATE	FIXED_SIZE	SYSTEM		driver_event_data_state
 type	DRV_SEL_D_STATE	FIXED_SIZE	SYSTEM		driver_select_data_state
+type	NIF_SEL_D_STATE	FIXED_SIZE	SYSTEM		enif_select_data_state
 type	FD_LIST		SHORT_LIVED	SYSTEM		fd_list
 type	ACTIVE_FD_ARR	SHORT_LIVED	SYSTEM		active_fd_array
 type	POLLSET		LONG_LIVED	SYSTEM		pollset

--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -76,11 +76,10 @@ typedef struct {
 #  endif
 #endif
 
-/* Values for mode arg to driver_select() */
-#define ERL_DRV_READ  (1 << 0)
-#define ERL_DRV_WRITE (1 << 1)
-#define ERL_DRV_USE   (1 << 2)
-#define ERL_DRV_USE_NO_CALLBACK (ERL_DRV_USE | (1 << 3))
+#define ERL_DRV_READ  ((int)ERL_NIF_SELECT_READ)
+#define ERL_DRV_WRITE ((int)ERL_NIF_SELECT_WRITE)
+#define ERL_DRV_USE   ((int)ERL_NIF_SELECT_STOP)
+#define ERL_DRV_USE_NO_CALLBACK (ERL_DRV_USE | (ERL_DRV_USE  << 1))
 
 /* Old deprecated */
 #define DO_READ  ERL_DRV_READ

--- a/erts/emulator/beam/erl_drv_nif.h
+++ b/erts/emulator/beam/erl_drv_nif.h
@@ -56,6 +56,14 @@ enum ErlNifSelectFlags {
     ERL_NIF_SELECT_STOP      = (1 << 2)
 };
 
+enum ErlNifSelectReturn {
+    ERL_NIF_SELECT_ERROR          = (1 << 0),
+    ERL_NIF_SELECT_STOP_CALLED    = (1 << 1),
+    ERL_NIF_SELECT_STOP_SCHEDULED = (1 << 2),
+    ERL_NIF_SELECT_INVALID_EVENT  = (1 << 3),
+    ERL_NIF_SELECT_FAILED         = (1 << 4)
+};
+
 #ifdef SIZEOF_CHAR
 #  define SIZEOF_CHAR_SAVED__ SIZEOF_CHAR
 #  undef SIZEOF_CHAR

--- a/erts/emulator/beam/erl_drv_nif.h
+++ b/erts/emulator/beam/erl_drv_nif.h
@@ -49,6 +49,13 @@ typedef enum {
     ERL_DIRTY_JOB_IO_BOUND  = 2
 } ErlDirtyJobFlags;
 
+/* Values for enif_select AND mode arg for driver_select() */
+enum ErlNifSelectFlags {
+    ERL_NIF_SELECT_READ      = (1 << 0),
+    ERL_NIF_SELECT_WRITE     = (1 << 1),
+    ERL_NIF_SELECT_STOP      = (1 << 2)
+};
+
 #ifdef SIZEOF_CHAR
 #  define SIZEOF_CHAR_SAVED__ SIZEOF_CHAR
 #  undef SIZEOF_CHAR

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -2124,12 +2124,13 @@ static void nif_resource_dtor(Binary* bin)
     }
 }
 
-void erts_resource_stop(ErlNifResource* resource)
+void erts_resource_stop(ErlNifResource* resource, ErlNifEvent e,
+                        int is_direct_call)
 {
     struct enif_msg_environment_t msg_env;
     ASSERT(resource->type->stop);
     pre_nif_noproc(&msg_env, resource->type->owner, NULL);
-    resource->type->stop(&msg_env.env, resource->data);
+    resource->type->stop(&msg_env.env, resource->data, e, is_direct_call);
     post_nif_noproc(&msg_env);
 }
 

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -146,7 +146,6 @@ typedef struct {
 typedef struct enif_resource_type_t ErlNifResourceType;
 typedef void ErlNifResourceDtor(ErlNifEnv*, void*);
 typedef void ErlNifResourceStop(ErlNifEnv*, void*);
-typedef void ErlNifResourceExit(ErlNifEnv*, void*);
 
 //#ifndef ERL_SYS_DRV
 typedef int ErlNifEvent; /* An event to be selected on. */

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -138,18 +138,18 @@ typedef struct
     void* ref_bin;
 }ErlNifBinary;
 
-typedef struct {
-    void (*dtor)(ErlNifEnv* env, void* obj);
-    void (*stop)(ErlNifEnv* env, void* obj); /* at ERL_NIF_SELECT_STOP event */
-} ErlNifResourceTypeInit;
-
-typedef struct enif_resource_type_t ErlNifResourceType;
-typedef void ErlNifResourceDtor(ErlNifEnv*, void*);
-typedef void ErlNifResourceStop(ErlNifEnv*, void*);
-
 //#ifndef ERL_SYS_DRV
 typedef int ErlNifEvent; /* An event to be selected on. */
 //#endif
+
+typedef struct enif_resource_type_t ErlNifResourceType;
+typedef void ErlNifResourceDtor(ErlNifEnv*, void*);
+typedef void ErlNifResourceStop(ErlNifEnv*, void*, ErlNifEvent, int is_direct_call);
+
+typedef struct {
+    ErlNifResourceDtor* dtor;
+    ErlNifResourceStop* stop;  /* at ERL_NIF_SELECT_STOP event */
+} ErlNifResourceTypeInit;
 
 typedef enum
 {

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -175,6 +175,8 @@ ERL_NIF_API_FUNC_DECL(size_t, enif_binary_to_term, (ErlNifEnv *env, const unsign
 ERL_NIF_API_FUNC_DECL(int, enif_port_command, (ErlNifEnv *env, const ErlNifPort* to_port, ErlNifEnv *msg_env, ERL_NIF_TERM msg));
 ERL_NIF_API_FUNC_DECL(int,enif_thread_type,(void));
 ERL_NIF_API_FUNC_DECL(int,enif_snprintf,(char * buffer, size_t size, const char *format, ...));
+ERL_NIF_API_FUNC_DECL(int,enif_select,(ErlNifEnv* env, ErlNifEvent e, enum ErlNifSelectFlags flags, void* obj, ERL_NIF_TERM ref));
+ERL_NIF_API_FUNC_DECL(ErlNifResourceType*,enif_open_resource_type_x,(ErlNifEnv*, const char* name_str, const ErlNifResourceTypeInit*, ErlNifResourceFlags flags, ErlNifResourceFlags* tried));
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
@@ -332,6 +334,8 @@ ERL_NIF_API_FUNC_DECL(int,enif_snprintf,(char * buffer, size_t size, const char 
 #  define enif_port_command ERL_NIF_API_FUNC_MACRO(enif_port_command)
 #  define enif_thread_type ERL_NIF_API_FUNC_MACRO(enif_thread_type)
 #  define enif_snprintf ERL_NIF_API_FUNC_MACRO(enif_snprintf)
+#  define enif_select ERL_NIF_API_FUNC_MACRO(enif_select)
+#  define enif_open_resource_type_x ERL_NIF_API_FUNC_MACRO(enif_open_resource_type_x)
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment)

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -95,7 +95,7 @@ extern void erts_pre_dirty_nif(ErtsSchedulerData *,
 			       struct erl_module_nif*);
 extern void erts_post_dirty_nif(struct enif_environment_t* env);
 #endif
-extern void erts_resource_stop(ErlNifResource* resource);
+extern void erts_resource_stop(ErlNifResource*, ErlNifEvent, int is_direct_call);
 extern Eterm erts_nif_taints(Process* p);
 extern void erts_print_nif_taints(fmtfn_t to, void* to_arg);
 void erts_unload_nif(struct erl_module_nif* nif);

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -450,7 +450,7 @@ forget_removed(struct pollset_info* psi)
 	    }
 	}
         if (resource) {
-            erts_resource_stop(resource);
+            erts_resource_stop(resource, (ErlNifEvent)fd, 0);
             enif_release_resource(resource->data);
         }
 
@@ -1436,7 +1436,7 @@ done:
 done_unknown:
     erts_smp_mtx_unlock(fd_mtx(fd));
     if (call_stop) {
-        erts_resource_stop(resource);
+        erts_resource_stop(resource, (ErlNifEvent)fd, 1);
         if (call_stop == CALL_STOP_AND_RELEASE) {
             enif_release_resource(resource->data);
         }
@@ -2141,6 +2141,10 @@ ERTS_CIO_EXPORT(erts_check_io_interrupt_timed)(int set,
     ERTS_CIO_POLL_INTR_TMD(pollset.ps, set, timeout_time);
 }
 
+/*
+ * Number of ignored events, for a lingering fd added by enif_select(),
+ * until we deselect fd-event from pollset.
+ */
 #define ERTS_NIF_DELAYED_DESELECT 20
 
 void

--- a/erts/emulator/sys/common/erl_check_io.h
+++ b/erts/emulator/sys/common/erl_check_io.h
@@ -34,6 +34,8 @@
 
 int driver_select_kp(ErlDrvPort, ErlDrvEvent, int, int);
 int driver_select_nkp(ErlDrvPort, ErlDrvEvent, int, int);
+int enif_select_kp(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
+int enif_select_nkp(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
 int driver_event_kp(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
 int driver_event_nkp(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
 Uint erts_check_io_size_kp(void);
@@ -136,4 +138,20 @@ typedef struct {
     ErtsIoTask iniotask;
     ErtsIoTask outiotask;
 } ErtsDrvSelectDataState;
+
+struct erts_nif_select_event {
+    Eterm pid;
+    Eterm immed;
+    Uint32 refn[ERTS_REF_NUMBERS];
+    Sint32 ddeselect_cnt; /* 0:  No delayed deselect in progress
+                           * 1:  Do deselect before next poll
+                           * >1: Countdown of ignored events
+                           */
+};
+
+typedef struct {
+    struct erts_nif_select_event in;
+    struct erts_nif_select_event out;
+} ErtsNifSelectDataState;
+
 #endif /* #ifndef ERL_CHECK_IO_INTERNAL__ */

--- a/erts/emulator/sys/common/erl_check_io.h
+++ b/erts/emulator/sys/common/erl_check_io.h
@@ -34,8 +34,8 @@
 
 int driver_select_kp(ErlDrvPort, ErlDrvEvent, int, int);
 int driver_select_nkp(ErlDrvPort, ErlDrvEvent, int, int);
-int enif_select_kp(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
-int enif_select_nkp(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
+enum ErlNifSelectReturn enif_select_kp(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
+enum ErlNifSelectReturn enif_select_nkp(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
 int driver_event_kp(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
 int driver_event_nkp(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
 Uint erts_check_io_size_kp(void);

--- a/erts/emulator/sys/common/erl_poll.c
+++ b/erts/emulator/sys/common/erl_poll.c
@@ -3030,6 +3030,7 @@ ERTS_POLL_EXPORT(erts_poll_get_selected_events)(ErtsPollSet ps,
 	    ev[fd] = 0;
 	else {
 	    ev[fd] = ps->fds_status[fd].events;
+            ASSERT(ps->fds_status[fd].used_events == ev[fd]);
             if (
 #if ERTS_POLL_USE_WAKEUP_PIPE
                 fd == ps->wake_fds[0] || fd == ps->wake_fds[1] ||

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -161,6 +161,7 @@ int erts_use_kernel_poll = 0;
 
 struct {
     int (*select)(ErlDrvPort, ErlDrvEvent, int, int);
+    int (*enif_select)(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
     int (*event)(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
     void (*check_io_as_interrupt)(void);
     void (*check_io_interrupt)(int);
@@ -184,6 +185,13 @@ driver_event(ErlDrvPort port, ErlDrvEvent event, ErlDrvEventData event_data)
     return (*io_func.event)(port, event, event_data);
 }
 
+int enif_select(ErlNifEnv* env, ErlNifEvent event,
+                enum ErlNifSelectFlags flags, void* obj, Eterm ref)
+{
+    return (*io_func.enif_select)(env, event, flags, obj, ref);
+}
+
+
 Eterm erts_check_io_info(void *p)
 {
     return (*io_func.info)(p);
@@ -201,6 +209,7 @@ init_check_io(void)
 {
     if (erts_use_kernel_poll) {
 	io_func.select			= driver_select_kp;
+        io_func.enif_select		= enif_select_kp;
 	io_func.event			= driver_event_kp;
 #ifdef ERTS_POLL_NEED_ASYNC_INTERRUPT_SUPPORT
 	io_func.check_io_as_interrupt	= erts_check_io_async_sig_interrupt_kp;
@@ -216,6 +225,7 @@ init_check_io(void)
     }
     else {
 	io_func.select			= driver_select_nkp;
+        io_func.enif_select		= enif_select_nkp;
 	io_func.event			= driver_event_nkp;
 #ifdef ERTS_POLL_NEED_ASYNC_INTERRUPT_SUPPORT
 	io_func.check_io_as_interrupt	= erts_check_io_async_sig_interrupt_nkp;

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -161,7 +161,7 @@ int erts_use_kernel_poll = 0;
 
 struct {
     int (*select)(ErlDrvPort, ErlDrvEvent, int, int);
-    int (*enif_select)(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
+    enum ErlNifSelectReturn (*enif_select)(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, Eterm);
     int (*event)(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
     void (*check_io_as_interrupt)(void);
     void (*check_io_interrupt)(int);

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -2176,6 +2176,7 @@ static ERL_NIF_TERM is_closed_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
 static void fd_resource_dtor(ErlNifEnv* env, void* obj)
 {
     struct fd_resource* rsrc = (struct fd_resource*)obj;
+    resource_dtor(env, obj);
     if (rsrc->fd >= 0)
         close(rsrc->fd);
 }

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -2042,7 +2042,7 @@ static ERL_NIF_TERM select_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
     enum ErlNifSelectFlags mode;
     void* obj;
     ERL_NIF_TERM ref;
-    int retval;
+    enum ErlNifSelectReturn retval;
 
     if (!get_fd(env, argv[0], &fdr)
         || !enif_get_uint(env, argv[1], &mode)
@@ -2056,7 +2056,7 @@ static ERL_NIF_TERM select_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
     fdr->was_selected = 1;
     retval = enif_select(env, fdr->fd, mode, obj, ref);
 
-    return enif_make_int(env, retval);
+    return enif_make_int(env, (int)retval);
 }
 
 static ERL_NIF_TERM pipe_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])


### PR DESCRIPTION
Function `enif_select()` is a new way for NIFs to wait for asynchronous notifications
when file descriptors become ready for either read or write operations.

Similar to `driver_select()` but for NIFs, with no need for dedicated threads
(custom, async or dirty) to do the waiting.

In short a NIF calls `enif_select()` for a file descriptor
then returns to Erlang to wait for a `ready_input` or `ready_output` message
then makes a NIF call to continue read or write.

**The purpose of this PR is mainly for people to try it out and give some early feedback on the API.**

For usage documentation see `erl_nif.xml` or the nif_SUITE:select test case code in this PR.

I have also done two example usages in this separate branch https://github.com/sverker/otp/commits/sverker/enif_select-examples:
* sverk_tcp - a client side TCP socket
* ttsl_nif - a NIF adaptation of the ttsl driver which is the terminal low-level interface for the Erlang shell.