### PR TITLE
Enforce filename length of 256 chars on erl_tar

### DIFF
--- a/lib/stdlib/src/erl_tar.erl
+++ b/lib/stdlib/src/erl_tar.erl
@@ -263,7 +263,7 @@ format_error(Term) ->
 
 %% Length of these fields.
 
--define(th_name_len, 100).
+-define(th_name_len, 256).
 -define(th_mode_len, 8).
 -define(th_uid_len, 8).
 -define(th_gid_len, 8).


### PR DESCRIPTION
As the documentation correctly points out, the filename limit
for "ustar" tar files is of 256 characters, which is supported by
modern `tar` implementations.

Therefore instead of limiting the filename on the "soft" limit
of 100, we should allow it to be 256 characters long to avoid
restraining developers working on modern GNU systems.