### PR TITLE
erts: Fix missing HiPE trampolines on arm (master only)

### DIFF
--- a/erts/emulator/hipe/hipe_bif0.c
+++ b/erts/emulator/hipe/hipe_bif0.c
@@ -1121,7 +1121,7 @@ static struct hipe_mfa_info* mod2mfa_put(struct hipe_mfa_info* mfa)
 struct hipe_ref {
     struct hipe_ref_head head;    /* list of refs to same calleee */
     void *address;
-#if defined(arm) || defined(__powerpc__) || defined(__ppc__) || defined(__powerpc64__)
+#if defined(__arm__) || defined(__powerpc__) || defined(__ppc__) || defined(__powerpc64__)
     void *trampoline;
 #endif
     unsigned int flags;
@@ -1549,7 +1549,7 @@ BIF_RETTYPE hipe_bifs_add_ref_2(BIF_ALIST_2)
 
     ref = erts_alloc(ERTS_ALC_T_HIPE, sizeof(struct hipe_ref));
     ref->address = address;
-#if defined(arm) || defined(__powerpc__) || defined(__ppc__) || defined(__powerpc64__)
+#if defined(__arm__) || defined(__powerpc__) || defined(__ppc__) || defined(__powerpc64__)
     ref->trampoline = trampoline;
 #endif
     ref->flags = flags;
@@ -1864,7 +1864,7 @@ void hipe_redirect_to_module(Module* modp)
 	    if (ref->flags & REF_FLAG_IS_LOAD_MFA)
 		res = hipe_patch_insn(ref->address, (Uint)p->remote_address, am_load_mfa);
 	    else {
-#if defined(arm) || defined(__powerpc__) || defined(__ppc__) || defined(__powerpc64__)
+#if defined(__arm__) || defined(__powerpc__) || defined(__ppc__) || defined(__powerpc64__)
                 void* trampoline = ref->trampoline;
 #else
                 void* trampoline = NULL;


### PR DESCRIPTION
Commit 8bb80fe76f5b by @sverker replaced the `__arm__` macro used to test for the arm
architecture in `hipe_bif0` with the `arm` macro, which is not universally
available. As this replacement is not motivated in the commit message,
nor replicated in any other file that uses the `__arm__` macro, this
seems to be an accident, and this PR reverts the replacement.

When compiled in an environment without the `arm` macro, upgrading hipe
code would occasionally not patch relocations to the new module due to
being out of range for a shortjump, and a trampoline not being provided
to do a longjump. Since this type of relocation patches are not expected
to be able to fail, there is no error handling and aside from a
`hipe_redirect_to_module: patch failed` message, code upgrade would
proceed and lead to various incorrect behaviour.