### PR TITLE
Add option 'deterministic' for reproducible builds

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -176,6 +176,14 @@
               <seealso marker="stdlib:beam_lib#debug_info">beam_lib(3)</seealso>.</p>
           </item>
 
+          <tag><c>deterministic</c></tag>
+          <item>
+            <p>Omit the <c>options</c> and <c>source</c> tuples in
+	    the list returned by <c>Module:module_info(compile)</c>.
+	    This option will make it easier to achieve reproducible builds.
+	    </p>
+          </item>
+
           <tag><c>makedep</c></tag>
           <item>
             <p>Produces a Makefile rule to track headers dependencies.

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -233,7 +233,12 @@ build_attributes(Opts, SourceFile, Attr, MD5) ->
 	       false -> Misc0;
 	       true -> []
 	   end,
-    Compile = [{options,Opts},{version,?COMPILER_VSN}|Misc],
+    Compile = case member(deterministic, Opts) of
+		  false ->
+		      [{options,Opts},{version,?COMPILER_VSN}|Misc];
+		  true ->
+		      [{version,?COMPILER_VSN}]
+	      end,
     {term_to_binary(set_vsn_attribute(Attr, MD5)),term_to_binary(Compile)}.
 
 build_line_table(Dict) ->

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -105,6 +105,14 @@ file_1(Config) when is_list(Config) ->
 
     {ok,simple} = compile:file(Simple, [{eprof,beam_z}]), %Coverage
 
+
+    %% Test option 'deterministic'.
+    {ok,simple} = compile:file(Simple, [deterministic]),
+    {module,simple} = c:l(simple),
+    [{version,_}] = simple:module_info(compile),
+    true = code:delete(simple),
+    false = code:purge(simple),
+
     ok = file:set_cwd(Cwd),
     true = exists(Target),
     passed = run(Target, test, []),


### PR DESCRIPTION
Add the option `deterministic` to make it easier to
achieve reproducible builds.

This option omits the {options,...} and {source,...} tuples in
M:module_info(compile), because those options may contain absolute
paths.

The author of ERL-310 suggested that only compiler options that
may contain absolute paths (such as {i,...}) should be excluded. But I
find it confusing to keep only some options.

Alternatives considered: Always omitting this information. Since this
information has been available for a long time, that would probably
break some workflows. As an example that some people care about
{source,...}, 2d785c07fbf9 made it possible to give a compiler option
to set {source,...}.

ERL-310