### PR TITLE
Add an option for http_uri:parse/2 to return query as proplist.

### DIFF
--- a/lib/inets/doc/src/http_uri.xml
+++ b/lib/inets/doc/src/http_uri.xml
@@ -117,7 +117,7 @@
         <v>Options = [Option]</v> 
         <v>Option = {ipv6_host_with_brackets, boolean()} | 
                     {scheme_defaults, scheme_defaults()} |
-                    {fragment, boolean()} |
+                    {fragment, boolean()} | {parse_query, boolean()} |
                     {scheme_validation_fun, fun()}]</v>
         <v>Result = {Scheme, UserInfo, Host, Port, Path, Query} |
                     {Scheme, UserInfo, Host, Port, Path, Query, Fragment}</v>
@@ -140,7 +140,10 @@
 	provided, otherwise the parsing fails.</p>
 
         <p>If the fragment option is <c>true</c>, the URI fragment is returned as
-          part of the parsing result, otherwise it is ignored.</p>
+        part of the parsing result, otherwise it is ignored.</p>
+
+        <p>If the parse_query option is <c>true</c>, the Query is returned as
+        proplist, otherwise it is ignored.</p>
 
         <p>Scheme validation fun is to be defined as follows:</p>
 

--- a/lib/inets/test/uri_SUITE.erl
+++ b/lib/inets/test/uri_SUITE.erl
@@ -106,7 +106,14 @@ scheme(Config) when is_list(Config) ->
 
 queries(Config) when is_list(Config) ->
     {ok, {http,[],"localhost",8888,"/foobar.html","?foo=bar&foobar=42"}} =
-	http_uri:parse("http://localhost:8888/foobar.html?foo=bar&foobar=42").
+	http_uri:parse("http://localhost:8888/foobar.html?foo=bar&foobar=42"),
+    {ok, {http,[],"localhost",8888,"/foobar.html",[]}} =
+	http_uri:parse("http://localhost:8888/foobar.html?",[{parse_query,true}]),
+    {ok, {http,[],"localhost",8888,"/foobar.html",[{"foo", ""}]}} =
+	http_uri:parse("http://localhost:8888/foobar.html?foo",[{parse_query,true}]),
+    {ok, {http,[],"localhost",8888,"/foobar.html",[{"foo", "bar"},{"foobar", "42"}]}} =
+	http_uri:parse("http://localhost:8888/foobar.html?foo=bar&foobar=42",
+                       [{parse_query,true}]).
 
 fragments(Config) when is_list(Config) ->
     {ok, {http,[],"localhost",80,"/",""}} =


### PR DESCRIPTION
It's my fist patch but I hope it will be useful.

I added new option for http_uri:parse/2 parse_query to return query as proplists. I didn't change default behavior so it shouldn't break something.

```
1> U = "http://localhost:8888/foobar.html?foo=bar&foobar=42".
"http://localhost:8888/foobar.html?foo=bar&foobar=42"
2> http_uri:parse(U).
{ok,{http,[],"localhost",8888,"/foobar.html",
          "?foo=bar&foobar=42"}}
3> http_uri:parse(U, [{parse_query,true}]).
{ok,{http,[],"localhost",8888,"/foobar.html",
          [{"foo","bar"},{"foobar","42"}]}}
```