### PR TITLE
Make sure that Travis fails when test cases fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ after_success:
   - ./otp_build tests && make release_docs
 
 after_script:
-  - cd $ERL_TOP/release/tests/test_server && $ERL_TOP/bin/erl -s ts install -s ts smoke_test batch -s init stop
+  - ./scripts/run-smoke-tests

--- a/erts/emulator/test/emulator_smoke.spec
+++ b/erts/emulator/test/emulator_smoke.spec
@@ -1,3 +1,9 @@
-{suites,"../emulator_test",[smoke_test_SUITE,time_SUITE]}.
-{cases,"../emulator_test",crypto_SUITE,[t_md5]}.
-{cases,"../emulator_test",float_SUITE,[fpe,cmp_integer]}.
+{define,'Dir',"../emulator_test"}.
+{suites,'Dir',[smoke_test_SUITE]}.
+{suites,'Dir',[time_SUITE]}.
+{skip_cases,'Dir',time_SUITE,
+    [univ_to_local,local_to_univ],"Depends on CET timezone"}.
+{skip_cases,'Dir',time_SUITE,
+    [consistency],"Not reliable in October and March"}.
+{cases,'Dir',crypto_SUITE,[t_md5]}.
+{cases,'Dir',float_SUITE,[fpe,cmp_integer]}.

--- a/scripts/run-smoke-tests
+++ b/scripts/run-smoke-tests
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ev
+
+cd $ERL_TOP/release/tests/test_server
+$ERL_TOP/bin/erl -s ts install -s ts smoke_test batch -s init stop
+
+if grep -q '=failed *[1-9]' ct_run.test_server@*/*/run.*/suite.log; then
+    echo "One or more tests failed."
+    exit 1
+fi


### PR DESCRIPTION
Travis CI already runs some tests suites, but the result of tests were not checked. In fact, two test cases always failed.

This pull request omits three problematic test cases from the smoke test spec, two of which always failed when run in Travis CI. The second commit adds a check of the test case logs to ensure that Travis CI fails if any of the test cases fail.