### PR TITLE
Add project-wide Emacs settings file

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,9 @@
+;; Project-wide Emacs settings
+(
+ ;; `nil' settings apply to all language modes
+ (nil
+  ;; Use only spaces for indentation
+  (indent-tabs-mode . nil))
+ (c-mode
+  ;; In C code, indentation is four spaces
+  (c-basic-offset . 4)))


### PR DESCRIPTION
Add a .dir-locals.el file, which applies indentation-related settings
when editing any file in the project with Emacs.

Inspired by #1278, which recommends certain Emacs settings to comply with the coding standard. Let's have those settings apply automatically.