### PR TITLE
file: match enoent and enotdir in path_open

### DIFF
--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -1413,7 +1413,7 @@ path_open_first([Path|Rest], Name, Mode, LastError) ->
 	    case open(FileName, Mode) of
 		{ok, Fd} ->
 		    {ok, Fd, FileName};
-		{error, enoent} ->
+		{error, Reason} when Reason =:= enoent; Reason =:= enotdir ->
 		    path_open_first(Rest, Name, Mode, LastError);
 		Error ->
 		    Error


### PR DESCRIPTION
… file:path_open.

Problem description:
If for erlc use flag -I with some file (not a directory), compiler stops to search with {error, enotdir}.
Need to continue search in all pathes with option -I.