### PR TITLE
Add types and specs for all compiler modules

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -126,7 +126,7 @@ ERL_COMPILE_FLAGS += +native
 endif
 ERL_COMPILE_FLAGS += +inline +warn_unused_import \
  -Werror \
- -I../../stdlib/include -I$(EGEN) -W
+ -I../../stdlib/include -I$(EGEN) -W +warn_missing_spec
 
 # ----------------------------------------------------
 # Targets

--- a/lib/compiler/src/beam_a.erl
+++ b/lib/compiler/src/beam_a.erl
@@ -25,6 +25,9 @@
 
 -export([module/2]).
 
+-spec module(beam_asm:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc}, _Opt) ->
     Fs = [function(F) || F <- Fs0],
     {ok,{Mod,Exp,Attr,Fs,Lc}}.

--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -25,6 +25,9 @@
 -export([module/2]).
 -import(lists, [reverse/1,reverse/2,foldl/3,member/2]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc}, _Opt) ->
     Fs = [function(F) || F <- Fs0],
     {ok,{Mod,Exp,Attr,Fs,Lc}}.

--- a/lib/compiler/src/beam_bs.erl
+++ b/lib/compiler/src/beam_bs.erl
@@ -25,6 +25,9 @@
 -export([module/2]).
 -import(lists, [mapfoldl/3,reverse/1]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc0}, _Opt) ->
     {Fs,Lc} = mapfoldl(fun function/2, Lc0, Fs0),
     {ok,{Mod,Exp,Attr,Fs,Lc}}.

--- a/lib/compiler/src/beam_dead.erl
+++ b/lib/compiler/src/beam_dead.erl
@@ -29,6 +29,10 @@
 
 -import(lists, [mapfoldl/3,reverse/1]).
 
+
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,_}, _Opts) ->
     {Fs1,Lc1} = beam_clean:clean_labels(Fs0),
     {Fs,Lc} = mapfoldl(fun function/2, Lc1, Fs1),

--- a/lib/compiler/src/beam_dict.erl
+++ b/lib/compiler/src/beam_dict.erl
@@ -148,10 +148,7 @@ string(Str, Dict) when is_list(Str) ->
 lambda(Lbl, NumFree, #asm{lambdas={OldIndex,Lambdas0}}=Dict) ->
     %% Set Index the same as OldIndex.
     Index = OldIndex,
-    %% Initialize OldUniq to 0. It will be set to an unique value
-    %% based on the MD5 checksum of the BEAM code for the module.
-    OldUniq = 0,
-    Lambdas = [{Lbl,{OldIndex,Lbl,Index,NumFree,OldUniq}}|Lambdas0],
+    Lambdas = [{Lbl,{Index,Lbl,NumFree}}|Lambdas0],
     {OldIndex,Dict#asm{lambdas={OldIndex+1,Lambdas}}}.
 
 %% Returns the index for a literal (adding it to the literal table if necessary).
@@ -239,8 +236,11 @@ lambda_table(#asm{locals=Loc0,lambdas={NumLambdas,Lambdas0}}) ->
     Lambdas1 = sofs:relation(Lambdas0),
     Loc = sofs:relation([{Lbl,{F,A}} || {F,A,Lbl} <- Loc0]),
     Lambdas2 = sofs:relative_product1(Lambdas1, Loc),
+    %% Initialize OldUniq to 0. It will be set to an unique value
+    %% based on the MD5 checksum of the BEAM code for the module.
+    OldUniq = 0,
     Lambdas = [<<F:32,A:32,Lbl:32,Index:32,NumFree:32,OldUniq:32>> ||
-		  {{_,Lbl,Index,NumFree,OldUniq},{F,A}} <- sofs:to_external(Lambdas2)],
+		  {{Index,Lbl,NumFree},{F,A}} <- sofs:to_external(Lambdas2)],
     {NumLambdas,Lambdas}.
 
 %% Returns the literal table.

--- a/lib/compiler/src/beam_dict.erl
+++ b/lib/compiler/src/beam_dict.erl
@@ -28,7 +28,7 @@
 	 string_table/1,lambda_table/1,literal_table/1,
 	 line_table/1]).
 
--type label() :: non_neg_integer().
+-type label() :: beam_asm:label().
 
 -type index() :: non_neg_integer().
 
@@ -38,13 +38,16 @@
 -type line_tab()   :: #{{Fname :: index(), Line :: term()} => index()}.
 -type literal_tab() :: dict:dict(Literal :: term(), index()).
 
+-type lambda_info() :: {label(),{index(),label(),non_neg_integer()}}.
+-type lambda_tab() :: {non_neg_integer(),[lambda_info()]}.
+
 -record(asm,
 	{atoms = #{}                :: atom_tab(),
 	 exports = []		    :: [{label(), arity(), label()}],
 	 locals = []		    :: [{label(), arity(), label()}],
 	 imports = gb_trees:empty() :: import_tab(),
 	 strings = <<>>		    :: binary(),	%String pool
-	 lambdas = {0,[]},				%[{...}]
+	 lambdas = {0,[]}           :: lambda_tab(),
 	 literals = dict:new()	    :: literal_tab(),
 	 fnames = #{}               :: fname_tab(),
 	 lines = #{}                :: line_tab(),
@@ -181,6 +184,9 @@ line([{location,Name,Line}], #asm{lines=Lines,num_lines=N}=Dict0) ->
 	    Index = maps:size(Lines) + 1,
             {Index, Dict1#asm{lines=Lines#{Key=>Index},num_lines=N+1}}
     end.
+
+-spec fname(nonempty_string(), bdict()) ->
+                   {non_neg_integer(), bdict()}.
 
 fname(Name, #asm{fnames=Fnames}=Dict) ->
     case Fnames of

--- a/lib/compiler/src/beam_except.erl
+++ b/lib/compiler/src/beam_except.erl
@@ -33,6 +33,9 @@
 
 -import(lists, [reverse/1]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc}, _Opt) ->
     Fs = [function(F) || F <- Fs0],
     {ok,{Mod,Exp,Attr,Fs,Lc}}.
@@ -49,9 +52,9 @@ function({function,Name,Arity,CLabel,Is0}) ->
     end.
 
 -record(st,
-	{lbl,					%func_info label
-	 loc,					%location for func_info
-	 arity					%arity for function
+	{lbl :: beam_asm:label(),              %func_info label
+	 loc :: [_],                           %location for func_info
+	 arity :: arity()                       %arity for function
 	 }).
 
 function_1(Is0) ->

--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -25,6 +25,9 @@
 
 -import(lists, [reverse/1,reverse/2]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs,Lc}, _Opt) ->
     {ok,{Mod,Exp,Attr,[function(F) || F <- Fs],Lc}}.
 

--- a/lib/compiler/src/beam_listing.erl
+++ b/lib/compiler/src/beam_listing.erl
@@ -21,14 +21,24 @@
 
 -export([module/2]).
 
+-include("core_parse.hrl").
+-include("v3_kernel.hrl").
 -include("v3_life.hrl").
 
 -import(lists, [foreach/2]).
 
-module(File, Core) when element(1, Core) == c_module ->
+-type code() :: cerl:c_module()
+              | beam_utils:module_code()
+              | #k_mdef{}
+              | {module(),_,_,_}                %v3_life
+              | [_].                            %form-based format
+
+-spec module(file:io_device(), code()) -> 'ok'.
+
+module(File, #c_module{}=Core) ->
     %% This is a core module.
     io:put_chars(File, core_pp:format(Core));
-module(File, Kern) when element(1, Kern) == k_mdef ->
+module(File, #k_mdef{}=Kern) ->
     %% This is a kernel module.
     io:put_chars(File, v3_kernel_pp:format(Kern));
     %%io:put_chars(File, io_lib:format("~p~n", [Kern]));

--- a/lib/compiler/src/beam_peep.erl
+++ b/lib/compiler/src/beam_peep.erl
@@ -24,6 +24,9 @@
 
 -import(lists, [reverse/1,member/2]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,_}, _Opts) ->
     %% First coalesce adjacent labels.
     {Fs1,Lc} = beam_clean:clean_labels(Fs0),

--- a/lib/compiler/src/beam_receive.erl
+++ b/lib/compiler/src/beam_receive.erl
@@ -65,6 +65,9 @@
 %%% as the SomeUniqInteger.
 %%%
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc}, _Opts) ->
     Fs = [function(F) || F <- Fs0],
     Code = {Mod,Exp,Attr,Fs,Lc},

--- a/lib/compiler/src/beam_reorder.erl
+++ b/lib/compiler/src/beam_reorder.erl
@@ -23,6 +23,9 @@
 -export([module/2]).
 -import(lists, [member/2,reverse/1]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc}, _Opt) ->
     Fs = [function(F) || F <- Fs0],
     {ok,{Mod,Exp,Attr,Fs,Lc}}.

--- a/lib/compiler/src/beam_split.erl
+++ b/lib/compiler/src/beam_split.erl
@@ -23,6 +23,9 @@
 
 -import(lists, [reverse/1]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc}, _Opts) ->
     Fs = [split_blocks(F) || F <- Fs0],
     {ok,{Mod,Exp,Attr,Fs,Lc}}.

--- a/lib/compiler/src/beam_trim.erl
+++ b/lib/compiler/src/beam_trim.erl
@@ -24,9 +24,12 @@
 -import(lists, [reverse/1,reverse/2,splitwith/2,sort/1]).
 
 -record(st,
-	{safe,					%Safe labels.
-	 lbl					%Code at each label.
+	{safe :: gb_sets:set(beam_asm:label()), %Safe labels.
+	 lbl :: beam_utils:code_index()         %Code at each label.
 	 }).
+
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
 
 module({Mod,Exp,Attr,Fs0,Lc}, _Opts) ->
     Fs = [function(F) || F <- Fs0],

--- a/lib/compiler/src/beam_type.erl
+++ b/lib/compiler/src/beam_type.erl
@@ -26,6 +26,9 @@
 -import(lists, [filter/2,foldl/3,keyfind/3,member/2,
 		reverse/1,reverse/2,sort/1]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc}, _Opts) ->
     Fs = [function(F) || F <- Fs0],
     {ok,{Mod,Exp,Attr,Fs,Lc}}.

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -32,6 +32,10 @@
 -import(lists, [reverse/1,foldl/3,foreach/2,dropwhile/2]).
 
 %% To be called by the compiler.
+
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
 module({Mod,Exp,Attr,Fs,Lc}=Code, _Opts)
   when is_atom(Mod), is_list(Exp), is_list(Attr), is_integer(Lc) ->
     case validate(Mod, Fs) of

--- a/lib/compiler/src/beam_z.erl
+++ b/lib/compiler/src/beam_z.erl
@@ -26,6 +26,9 @@
 
 -import(lists, [dropwhile/2]).
 
+-spec module(beam_utils:module_code(), [compile:option()]) ->
+                    {'ok',beam_asm:module_code()}.
+
 module({Mod,Exp,Attr,Fs0,Lc}, _Opt) ->
     Fs = [function(F) || F <- Fs0],
     {ok,{Mod,Exp,Attr,Fs,Lc}}.

--- a/lib/compiler/src/cerl.erl
+++ b/lib/compiler/src/cerl.erl
@@ -1584,6 +1584,8 @@ ann_make_list(_, [], Node) ->
 %% @doc Returns <code>true</code> if <code>Node</code> is an abstract
 %% map constructor, otherwise <code>false</code>.
 
+-type map_op() :: #c_literal{val::'assoc'} | #c_literal{val::'exact'}.
+
 -spec is_c_map(cerl()) -> boolean().
 
 is_c_map(#c_map{}) ->
@@ -1679,8 +1681,16 @@ update_c_map(#c_map{is_pat=true}=Old, M, Es) ->
 update_c_map(#c_map{is_pat=false}=Old, M, Es) ->
     ann_c_map(get_ann(Old), M, Es).
 
+-spec map_pair_key(c_map_pair()) -> cerl().
+
 map_pair_key(#c_map_pair{key=K}) -> K.
+
+-spec map_pair_val(c_map_pair()) -> cerl().
+
 map_pair_val(#c_map_pair{val=V}) -> V.
+
+-spec map_pair_op(c_map_pair()) -> map_op().
+
 map_pair_op(#c_map_pair{op=Op}) -> Op.
 
 -spec c_map_pair(cerl(), cerl()) -> c_map_pair().
@@ -1698,6 +1708,8 @@ c_map_pair_exact(Key,Val) ->
 
 ann_c_map_pair(As,Op,K,V) ->
     #c_map_pair{op=Op, key = K, val=V, anno = As}.
+
+-spec update_c_map_pair(c_map_pair(), map_op(), cerl(), cerl()) -> c_map_pair().
 
 update_c_map_pair(Old,Op,K,V) ->
     #c_map_pair{op=Op, key=K, val=V, anno = get_ann(Old)}.

--- a/lib/compiler/src/core_scan.erl
+++ b/lib/compiler/src/core_scan.erl
@@ -49,12 +49,36 @@
 
 -import(lists, [reverse/1]).
 
+-type location() :: integer().
+-type category() :: atom().
+-type symbol() :: atom() | float() | integer() | string().
+-type token() :: {category(), Anno :: location(), symbol()}
+               | {category(), Anno :: location()}.
+-type tokens() :: [token()].
+-type error_description() :: term().
+-type error_info() :: {erl_anno:location(), module(), error_description()}.
+
 %% string([Char]) ->
 %% string([Char], StartPos) ->
 %%    {ok, [Tok], EndPos} |
 %%    {error, {Pos,core_scan,What}, EndPos}
 
+-spec string(String) -> Return when
+      String :: string(),
+      Return :: {'ok', Tokens :: tokens(), EndLocation}
+              | {'error', ErrorInfo :: error_info(), ErrorLocation},
+      EndLocation :: location(),
+      ErrorLocation :: location().
+
 string(Cs) -> string(Cs, 1).
+
+-spec string(String, StartLocation) -> Return when
+      String :: string(),
+      Return :: {'ok', Tokens :: tokens(), EndLocation}
+              | {'error', ErrorInfo :: error_info(), ErrorLocation},
+      StartLocation :: location(),
+      EndLocation :: location(),
+      ErrorLocation :: location().
 
 string(Cs, Sp) ->
     %% Add an 'eof' to always get correct handling.

--- a/lib/compiler/src/sys_pre_attributes.erl
+++ b/lib/compiler/src/sys_pre_attributes.erl
@@ -25,10 +25,10 @@
 
 -define(OPTION_TAG, attributes).
 
--record(state, {forms,
-		pre_ops = [],
-		post_ops = [],
-		options}).
+-record(state, {forms :: [form()],
+		pre_ops = [] :: [op()],
+		post_ops = [] :: [op()],
+                options :: [option()]}).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Inserts, deletes and replaces Erlang compiler attributes.
@@ -58,6 +58,20 @@
 %% overs will be those replace operations that not has been performed
 %% due to that the pre_transform pass did not find the attribute plus
 %% all insert operations.
+
+-type attribute() :: atom().
+-type value() :: term().
+-type form() :: {function, integer(), atom(), arity(), _}
+              | {attribute, integer(), attribute(), _}.
+-type option() :: compile:option()
+                | {'attribute', 'insert', attribute(), value()}
+                | {'attribute', 'replace', attribute(), value()}
+                | {'attribute', 'delete', attribute()}.
+-type op() :: {'insert', attribute(), value()}
+            | {'replace', attribute(), value()}
+            | {'delete', attribute()}.
+
+-spec parse_transform([form()], [option()]) -> [form()].
 
 parse_transform(Forms, Options) ->
     S = #state{forms = Forms, options = Options},

--- a/lib/compiler/src/v3_codegen.erl
+++ b/lib/compiler/src/v3_codegen.erl
@@ -69,6 +69,10 @@
 	     stk=[],				%Stack table
 	     res=[]}).				%Reserved regs: [{reserved,I,V}]
 
+-type life_module() :: {module(),_,_,[_]}.
+
+-spec module(life_module(), [compile:option()]) -> {'ok',beam_asm:module_code()}.
+
 module({Mod,Exp,Attr,Forms}, _Options) ->
     {Fs,St} = functions(Forms, {atom,Mod}),
     {ok,{Mod,Exp,Attr,Fs,St#cg.lcount}}.

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -47,7 +47,7 @@
 
 canno(Cthing) -> element(2, Cthing).
 
--spec format(cerl:cerl()) -> iolist().
+-spec format(#k_mdef{}) -> iolist().
 
 format(Node) -> format(Node, #ctxt{}).
 

--- a/lib/compiler/src/v3_life.erl
+++ b/lib/compiler/src/v3_life.erl
@@ -52,9 +52,14 @@
 -include("v3_kernel.hrl").
 -include("v3_life.hrl").
 
+-type fa() :: {atom(),arity()}.
+
 %% These are not defined in v3_kernel.hrl.
 get_kanno(Kthing) -> element(2, Kthing).
 %%set_kanno(Kthing, Anno) -> setelement(2, Kthing, Anno).
+
+-spec module(#k_mdef{}, [compile:option()]) ->
+                    {'ok',{module(),[fa()],[_],[_]}}.
 
 module(#k_mdef{name=M,exports=Es,attributes=As,body=Fs0}, _Opts) ->
     Fs1 = functions(Fs0, []),
@@ -415,6 +420,10 @@ add_var(V, F, L, Vdb) ->
 
 vdb_new(Vs) ->
     sort([{V,0,0} || {var,V} <- Vs]).
+
+-type var() :: atom().
+
+-spec vdb_find(var(), [vdb_entry()]) -> 'error' | vdb_entry().
 
 vdb_find(V, Vdb) ->
     case lists:keyfind(V, 1, Vdb) of

--- a/lib/compiler/src/v3_life.hrl
+++ b/lib/compiler/src/v3_life.hrl
@@ -20,8 +20,10 @@
 %% This record contains variable life-time annotation for a
 %% kernel expression.  Added by v3_life, used by v3_codegen.
 
+-type vdb_entry() :: {atom(),non_neg_integer(),non_neg_integer()}.
+
 -record(l, {ke,					%Kernel expression
-	    i=0,				%Op number
-	    vdb=[],				%Variable database
-	    a}).				%Core annotation
+	    i=0 :: non_neg_integer(),           %Op number
+	    vdb=[] :: [vdb_entry()],            %Variable database
+	    a=[] :: [term()]}).                 %Core annotation
 


### PR DESCRIPTION
All exported functions now have specs. Also, except for the records in `core_parse.hrl` and `v3_kernel.hrl`, all record fields now have types.