### PR TITLE
Add erlang:system_info(atom_count)

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -7224,8 +7224,8 @@ ok
     </func>
 
     <func>
-      <name name="system_info" arity="1" clause_i="11"/>
       <name name="system_info" arity="1" clause_i="12"/>
+      <name name="system_info" arity="1" clause_i="13"/>
       <fsummary>Information about the CPU topology of the system.</fsummary>
       <type name="cpu_topology"/>
       <type name="level_entry"/>
@@ -7325,12 +7325,12 @@ ok
     </func>
 
     <func>
-      <name name="system_info" arity="1" clause_i="28"/>
       <name name="system_info" arity="1" clause_i="29"/>
-      <name name="system_info" arity="1" clause_i="37"/>
+      <name name="system_info" arity="1" clause_i="30"/>
       <name name="system_info" arity="1" clause_i="38"/>
       <name name="system_info" arity="1" clause_i="39"/>
       <name name="system_info" arity="1" clause_i="40"/>
+      <name name="system_info" arity="1" clause_i="41"/>
       <fsummary>Information about the default process heap settings.</fsummary>
       <type name="message_queue_data"/>
       <type name="max_heap_size"/>
@@ -7408,7 +7408,7 @@ ok
       <name name="system_info" arity="1" clause_i="8"/>
       <name name="system_info" arity="1" clause_i="9"/>
       <name name="system_info" arity="1" clause_i="10"/>
-      <name name="system_info" arity="1" clause_i="13"/>
+      <name name="system_info" arity="1" clause_i="11"/>
       <name name="system_info" arity="1" clause_i="14"/>
       <name name="system_info" arity="1" clause_i="15"/>
       <name name="system_info" arity="1" clause_i="16"/>
@@ -7423,14 +7423,14 @@ ok
       <name name="system_info" arity="1" clause_i="25"/>
       <name name="system_info" arity="1" clause_i="26"/>
       <name name="system_info" arity="1" clause_i="27"/>
-      <name name="system_info" arity="1" clause_i="30"/>
+      <name name="system_info" arity="1" clause_i="28"/>
       <name name="system_info" arity="1" clause_i="31"/>
       <name name="system_info" arity="1" clause_i="32"/>
       <name name="system_info" arity="1" clause_i="33"/>
       <name name="system_info" arity="1" clause_i="34"/>
       <name name="system_info" arity="1" clause_i="35"/>
       <name name="system_info" arity="1" clause_i="36"/>
-      <name name="system_info" arity="1" clause_i="41"/>
+      <name name="system_info" arity="1" clause_i="37"/>
       <name name="system_info" arity="1" clause_i="42"/>
       <name name="system_info" arity="1" clause_i="43"/>
       <name name="system_info" arity="1" clause_i="44"/>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -7460,11 +7460,18 @@ ok
       <name name="system_info" arity="1" clause_i="68"/>
       <name name="system_info" arity="1" clause_i="69"/>
       <name name="system_info" arity="1" clause_i="70"/>
+      <name name="system_info" arity="1" clause_i="71"/>
       <fsummary>Information about the system.</fsummary>
       <desc>
         <p>Returns various information about the current system
           (emulator) as specified by <c><anno>Item</anno></c>:</p>
         <taglist>
+          <tag><c>atom_count</c></tag>
+          <item>
+            <marker id="system_info_atom_count"></marker>
+            <p>Returns the number of atoms currently existing at the
+              local node. The value is given as an integer.</p>
+          </item>
           <tag><c>atom_limit</c></tag>
           <item>
             <marker id="system_info_atom_limit"></marker>

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2863,6 +2863,9 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
     else if (ERTS_IS_ATOM_STR("atom_limit",BIF_ARG_1)) {
         BIF_RET(make_small(erts_get_atom_limit()));
     }
+    else if (ERTS_IS_ATOM_STR("atom_count",BIF_ARG_1)) {
+        BIF_RET(make_small(atom_table_size()));
+    }
     else if (ERTS_IS_ATOM_STR("tolerant_timeofday",BIF_ARG_1)) {
 	if (erts_has_time_correction()
 	    && erts_time_offset_state() == ERTS_TIME_OFFSET_FINAL) {

--- a/erts/emulator/test/system_info_SUITE.erl
+++ b/erts/emulator/test/system_info_SUITE.erl
@@ -36,7 +36,8 @@
 -export([all/0, suite/0]).
 
 -export([process_count/1, system_version/1, misc_smoke_tests/1,
-         heap_size/1, wordsize/1, memory/1, ets_limit/1, atom_limit/1]).
+         heap_size/1, wordsize/1, memory/1, ets_limit/1, atom_limit/1,
+         atom_count/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -44,7 +45,7 @@ suite() ->
 
 all() -> 
     [process_count, system_version, misc_smoke_tests,
-     heap_size, wordsize, memory, ets_limit, atom_limit].
+     heap_size, wordsize, memory, ets_limit, atom_limit, atom_count].
 
 %%%
 %%% The test cases -------------------------------------------------------------
@@ -550,3 +551,13 @@ get_atom_limit(Config, AtomsMax) ->
     end,
     stop_node(Node),
     Res.
+
+%% Verify that system_info(atom_count) works.
+atom_count(Config) when is_list(Config) ->
+    Limit = erlang:system_info(atom_limit),
+    Count1 = erlang:system_info(atom_count),
+    list_to_atom(integer_to_list(erlang:unique_integer())),
+    Count2 = erlang:system_info(atom_count),
+    true = Limit >= Count2,
+    true = Count2 > Count1,
+    ok.

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2532,6 +2532,7 @@ tuple_to_list(_Tuple) ->
       Alloc :: atom();
          ({allocator_sizes, Alloc}) -> [_] when %% More or less anything
       Alloc :: atom();
+         (atom_count) -> pos_integer();
          (atom_limit) -> pos_integer();
          (build_type) -> opt | debug | purify | quantify | purecov |
                          gcov | valgrind | gprof | lcnt | frmptr;


### PR DESCRIPTION
We want to be able to monitor the number of atoms in the atom table, and know the hard limit.  Apparently that information is currently only available in very convoluted ways (parse the output of erlang:system_info(info)).  Therefore we suggest this extension to erlang:system_info/1 which returns something like the following:

1> erlang:system_info(atom_table).
[{entries,7325},{limit,1048576},{size,8192}]