### PR TITLE
Supervisor restart backoff

### DIFF
--- a/lib/stdlib/doc/src/supervisor.xml
+++ b/lib/stdlib/doc/src/supervisor.xml
@@ -77,7 +77,9 @@
     <pre>
 sup_flags() = #{strategy => strategy(),         % optional
                 intensity => non_neg_integer(), % optional
-                period => pos_integer()}        % optional</pre>
+                period => pos_integer(),        % optional
+                min_delay => pos_integer(),     % optional
+                max_delay => pos_integer()}     % optional</pre>
 
     <p>A supervisor can have one of the following <em>restart strategies</em>
       specified with the <c>strategy</c> key in the above map:</p>
@@ -137,6 +139,18 @@ sup_flags() = #{strategy => strategy(),         % optional
       reason for the supervisor itself in that case will be <c>shutdown</c>.
       <c>intensity</c> defaults to <c>1</c> and <c>period</c> defaults to
       <c>5</c>.</p>
+
+    <p>In order not to use up all restart attempts in a very short time
+      before the error condition has had time to clear, a supervisor can
+      delay repeated restarts by exponential backoff, starting at
+      <c>min_delay</c> milliseconds and limited at <c>max_delay</c>
+      milliseconds. The delay happens asynchronously and does not block the
+      supervisor. By default, <c>min_delay</c> is 1 millisecond and
+      <c>max_delay</c> is 500 milliseconds. (In practice, in simple
+      situations like when the OS is still holding on to a socket, or the
+      Erlang process registry has not yet unregistered a name, only one or
+      two delayed restart attempts will typically be needed.) To disable
+      delayed restarts completely, set <c>max_delay</c> to zero.</p>
 
     <marker id="child_spec"/>
     <p>The type definition of a child specification is as follows:</p>

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1235,10 +1235,10 @@ remove_child(Child, State) ->
 %% Purpose: Check that Type is of correct type (!)
 %% Returns: {ok, state()} | Error
 %%-----------------------------------------------------------------
-init_state(SupName, Type, Mod, Args) ->
-    set_flags(Type, #state{name = supname(SupName,Mod),
-			   module = Mod,
-			   args = Args}).
+init_state(SupName, SupFlags, Mod, Args) ->
+    set_flags(SupFlags, #state{name = supname(SupName,Mod),
+                               module = Mod,
+                               args = Args}).
 
 set_flags(Flags, State) ->
     try check_flags(Flags) of

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -84,7 +84,8 @@
 %% Defaults
 -define(default_flags, #{strategy  => one_for_one,
 			 intensity => 1,
-			 period    => 5}).
+			 period    => 5000  % milliseconds internally
+                        }).
 -define(default_child_spec, #{restart  => permanent,
 			      type     => worker}).
 %% Default 'shutdown' is 5000 for workers and infinity for supervisors.
@@ -1245,7 +1246,8 @@ set_flags(Flags, State) ->
 	#{strategy := Strategy, intensity := MaxIntensity, period := Period} ->
 	    {ok, State#state{strategy = Strategy,
 			     intensity = MaxIntensity,
-			     period = Period}}
+			     period = Period * 1000  % milliseconds internally
+                            }}
     catch
 	Thrown -> Thrown
     end.
@@ -1396,7 +1398,7 @@ child_to_spec(#child{name = Name,
 %%% Add a new restart and calculate if the max restart
 %%% intensity has been reached (in that case the supervisor
 %%% shall terminate).
-%%% All restarts occurred inside the period amount of seconds
+%%% All restarts occurred inside the period amount of milliseconds
 %%% are kept in the #state.restarts queue.
 %%% Returns: {ok, State'} | {terminate, State'}
 %%% ------------------------------------------------------
@@ -1405,7 +1407,7 @@ add_restart(State) ->
     I = State#state.intensity,
     P = State#state.period,
     R = State#state.restarts,
-    Now = erlang:monotonic_time(1),
+    Now = erlang:monotonic_time(milli_seconds),
     R1 = enqueue_restart(Now, dequeue_restarts(R, Now, P)),
     State1 = State#state{restarts = R1},
     case restart_count(R1) of

--- a/lib/stdlib/test/supervisor_1.erl
+++ b/lib/stdlib/test/supervisor_1.erl
@@ -21,7 +21,7 @@
 %% Is used by the supervisor_SUITE test suite.  
 -module(supervisor_1).
 
--export([start_child/0, start_child/1, init/1]).
+-export([start_child/0, start_child/1, start_reg_child/0, init/1]).
 
 -export([handle_call/3, handle_info/2, terminate/2]).
 
@@ -50,6 +50,12 @@ start_child(Extra) ->
 start_child() ->
     gen_server:start_link(?MODULE, normal, []).
 
+start_reg_child() ->
+    gen_server:start_link(?MODULE, register, []).
+
+init(register) ->
+    register(child_name, self()),
+    init(normal);
 init(normal) ->
     process_flag(trap_exit, true),
     {ok, {}}.


### PR DESCRIPTION
We have encountered situations in production where a supervisor would use up all restart attempts within less than a millisecond, not giving transient errors any time to be cleared, which can bring down a whole system due to something as simple as a TCP port being held briefly by the OS before being reusable again, or even due to Erlang's own process registry not freeing a name quickly enough because of multicore cpu scheduling.

To fix this problem, this patch adds delayed child restart with incremental back-off. (This has been reworked from an older version, see http://erlang.org/pipermail/erlang-patches/2012-January/002575.html, and now piggy-backs on the more recent mechanism in supervisor.erl (e6e3179) which already ensures that each new restart is passed via the message dispatch.)

If immediate restart of a child fails, this delays further restart attempts in exponential increments from min_delay (at least 1 ms) up to max_delay. The maximum number of restarts is still decided by the intensity/period parameters, but this makes it possible to control how fast restarts will happen. Setting max_delay to zero disables delays.

The default value of max_delay has been set to 500 ms, i.e., does not get slower than two restart attempts per second, which seems a reasonable balance between hoping to restart as soon as possible but not retrying too quickly. Note though that unless you raise min_delay, it only reaches that level if restarting within (approx) 1ms, 2ms, 4ms, 8ms, 16ms etc. all have failed; this takes about 1s and up to 10 restart attempts, if the intensity/period setting allows it.

Because we consider the current behaviour to be a bug, which makes supervision trees completely useless in these naturally occurring cases of transient problems blocking a restart, we think that the backoff mechanism should be enabled by default, and not have to be explicitly enabled.