### PR TITLE
Reduce memory consumption during compilation

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -147,8 +147,8 @@ env_compiler_options() -> env_default_opts().
 %%  Local functions
 %%
 
--define(pass(P), {P,fun P/1}).
--define(pass(P,T), {P,fun T/1,fun P/1}).
+-define(pass(P), {P,fun P/2}).
+-define(pass(P,T), {P,fun T/1,fun P/2}).
 
 env_default_opts() ->
     Key = "ERL_COMPILER_OPTIONS",
@@ -287,7 +287,6 @@ format_error_reason(Reason) ->
 		  ifile=""    :: file:filename(),
 		  ofile=""    :: file:filename(),
 		  module=[],
-		  code=[],
 		  core_code=[],
 		  abstract_code=[],		%Abstract code for debugger.
 		  options=[]  :: [option()],	%Options for compilation
@@ -300,14 +299,14 @@ internal({forms,Forms}, Opts0) ->
     {_,Ps} = passes(forms, Opts0),
     Source = proplists:get_value(source, Opts0, ""),
     Opts1 = proplists:delete(source, Opts0),
-    Compile = #compile{code=Forms,options=Opts1,mod_options=Opts1},
-    internal_comp(Ps, Source, "", Compile);
+    Compile = #compile{options=Opts1,mod_options=Opts1},
+    internal_comp(Ps, Forms, Source, "", Compile);
 internal({file,File}, Opts) ->
     {Ext,Ps} = passes(file, Opts),
     Compile = #compile{options=Opts,mod_options=Opts},
-    internal_comp(Ps, File, Ext, Compile).
+    internal_comp(Ps, none, File, Ext, Compile).
 
-internal_comp(Passes, File, Suffix, St0) ->
+internal_comp(Passes, Code0, File, Suffix, St0) ->
     Dir = filename:dirname(File),
     Base = filename:basename(File, Suffix),
     St1 = St0#compile{filename=File, dir=Dir, base=Base,
@@ -317,36 +316,41 @@ internal_comp(Passes, File, Suffix, St0) ->
     Run0 = case member(time, Opts) of
 	       true  ->
 		   io:format("Compiling ~tp\n", [File]),
-		   fun run_tc/2;
-	       false -> fun({_Name,Fun}, St) -> catch Fun(St) end
+		   fun run_tc/3;
+	       false ->
+                   fun({_Name,Fun}, Code, St) ->
+                           catch Fun(Code, St)
+                   end
 	   end,
     Run = case keyfind(eprof, 1, Opts) of
 	      {eprof,EprofPass} ->
-		  fun(P, St) ->
-			  run_eprof(P, EprofPass, St)
+		  fun(P, Code, St) ->
+			  run_eprof(P, Code, EprofPass, St)
 		  end;
 	      false ->
 		  Run0
 	  end,
-    case fold_comp(Passes, Run, St1) of
-	{ok,St2} -> comp_ret_ok(St2);
+    case fold_comp(Passes, Run, Code0, St1) of
+	{ok,Code,St2} -> comp_ret_ok(Code, St2);
 	{error,St2} -> comp_ret_err(St2)
     end.
 
-fold_comp([{delay,Ps0}|Passes], Run, #compile{options=Opts}=St) ->
+fold_comp([{delay,Ps0}|Passes], Run, Code, #compile{options=Opts}=St) ->
     Ps = select_passes(Ps0, Opts) ++ Passes,
-    fold_comp(Ps, Run, St);
-fold_comp([{Name,Test,Pass}|Ps], Run, St) ->
+    fold_comp(Ps, Run, Code, St);
+fold_comp([{Name,Test,Pass}|Ps], Run, Code, St) ->
     case Test(St) of
 	false ->				%Pass is not needed.
-	    fold_comp(Ps, Run, St);
+	    fold_comp(Ps, Run, Code, St);
 	true ->					%Run pass in the usual way.
-	    fold_comp([{Name,Pass}|Ps], Run, St)
+	    fold_comp([{Name,Pass}|Ps], Run, Code, St)
     end;
-fold_comp([{Name,Pass}|Ps], Run, St0) ->
-    case Run({Name,Pass}, St0) of
-	{ok,St1} -> fold_comp(Ps, Run, St1);
-	{error,_St1} = Error -> Error;
+fold_comp([{Name,Pass}|Ps], Run, Code0, St0) ->
+    case Run({Name,Pass}, Code0, St0) of
+	{ok,Code,St1} ->
+            fold_comp(Ps, Run, Code, St1);
+	{error,_St1}=Error ->
+            Error;
 	{'EXIT',Reason} ->
 	    Es = [{St0#compile.ifile,[{none,?MODULE,{crash,Name,Reason}}]}],
 	    {error,St0#compile{errors=St0#compile.errors ++ Es}};
@@ -354,11 +358,11 @@ fold_comp([{Name,Pass}|Ps], Run, St0) ->
 	    Es = [{St0#compile.ifile,[{none,?MODULE,{bad_return,Name,Other}}]}],
 	    {error,St0#compile{errors=St0#compile.errors ++ Es}}
     end;
-fold_comp([], _Run, St) -> {ok,St}.
+fold_comp([], _Run, Code, St) -> {ok,Code,St}.
 
-run_tc({Name,Fun}, St) ->
+run_tc({Name,Fun}, Code, St) ->
     T1 = erlang:monotonic_time(),
-    Val = (catch Fun(St)),
+    Val = (catch Fun(Code, St)),
     T2 = erlang:monotonic_time(),
     Elapsed = erlang:convert_time_unit(T2 - T1, native, millisecond),
     Mem0 = erts_debug:flat_size(Val)*erlang:system_info(wordsize),
@@ -367,17 +371,17 @@ run_tc({Name,Fun}, St) ->
 	      [Name,Elapsed/1000,Mem]),
     Val.
 
-run_eprof({Name,Fun}, Name, St) ->
+run_eprof({Name,Fun}, Code, Name, St) ->
     io:format("~p: Running eprof\n", [Name]),
     c:appcall(tools, eprof, start_profiling, [[self()]]),
-    Val = (catch Fun(St)),
+    Val = (catch Fun(Code, St)),
     c:appcall(tools, eprof, stop_profiling, []),
     c:appcall(tools, eprof, analyze, []),
     Val;
-run_eprof({_,Fun}, _, St) ->
-    catch Fun(St).
+run_eprof({_,Fun}, Code, _, St) ->
+    catch Fun(Code, St).
 
-comp_ret_ok(#compile{code=Code,warnings=Warn0,module=Mod,options=Opts}=St) ->
+comp_ret_ok(Code, #compile{warnings=Warn0,module=Mod,options=Opts}=St) ->
     case werror(St) of
         true ->
             case member(report_warnings, Opts) of
@@ -532,21 +536,21 @@ pass(_) -> none.
 %%
 
 select_passes([{pass,Mod}|Ps], Opts) ->
-    F = fun(St) ->
-		case catch Mod:module(St#compile.code, St#compile.options) of
+    F = fun(Code0, St) ->
+		case catch Mod:module(Code0, St#compile.options) of
 		    {ok,Code} ->
-			{ok,St#compile{code=Code}};
+			{ok,Code,St};
 		    {ok,Code,Ws} ->
-			{ok,St#compile{code=Code,warnings=St#compile.warnings++Ws}};
+			{ok,Code,St#compile{warnings=St#compile.warnings++Ws}};
 		    {error,Es} ->
 			{error,St#compile{errors=St#compile.errors ++ Es}}
 		end
 	end,
     [{Mod,F}|select_passes(Ps, Opts)];
 select_passes([{src_listing,Ext}|_], _Opts) ->
-    [{listing,fun (St) -> src_listing(Ext, St) end}];
+    [{listing,fun (Code, St) -> src_listing(Ext, Code, St) end}];
 select_passes([{listing,Ext}|_], _Opts) ->
-    [{listing,fun (St) -> listing(Ext, St) end}];
+    [{listing,fun (Code, St) -> listing(Ext, Code, St) end}];
 select_passes([done|_], _Opts) ->
     [];
 select_passes([{done,Ext}|_], Opts) ->
@@ -662,14 +666,14 @@ core_passes() ->
     [{iff,clint0,?pass(core_lint_module)},
      {delay,
       [{unless,no_copt,
-       [{core_old_inliner,fun test_old_inliner/1,fun core_old_inliner/1},
+       [{core_old_inliner,fun test_old_inliner/1,fun core_old_inliner/2},
 	{iff,doldinline,{listing,"oldinline"}},
 	{pass,sys_core_fold},
 	{iff,dcorefold,{listing,"corefold"}},
-	{core_inline_module,fun test_core_inliner/1,fun core_inline_module/1},
+	{core_inline_module,fun test_core_inliner/1,fun core_inline_module/2},
 	{iff,dinline,{listing,"inline"}},
         {core_fold_after_inlining,fun test_any_inliner/1,
-         fun core_fold_module_after_inlining/1},
+         fun core_fold_module_after_inlining/2},
 	?pass(core_transforms)]},
        {iff,dcopt,{listing,"copt"}},
        {iff,'to_core',{done,"core"}}]}
@@ -741,7 +745,7 @@ asm_passes() ->
      | binary_passes()].
 
 binary_passes() ->
-    [{native_compile,fun test_native/1,fun native_compile/1},
+    [{native_compile,fun test_native/1,fun native_compile/2},
      {unless,binary,?pass(save_binary,not_werror)}].
 
 %%%
@@ -749,9 +753,9 @@ binary_passes() ->
 %%%
 
 %% Remove the target file so we don't have an old one if the compilation fail.
-remove_file(St) ->
+remove_file(Code, St) ->
     _ = file:delete(St#compile.ofile),
-    {ok,St}.
+    {ok,Code,St}.
 
 -record(asm_module, {module,
 		     exports,
@@ -799,28 +803,28 @@ collect_asm([{attributes, Attr} | Rest], R) ->
 collect_asm([X | Rest], R) ->
     collect_asm(Rest, R#asm_module{code=R#asm_module.code++[X]}).
 
-beam_consult_asm(St) ->
+beam_consult_asm(_Code, St) ->
     case file:consult(St#compile.ifile) of
-	{ok, Forms0} ->
+	{ok,Forms0} ->
             Encoding = epp:read_encoding(St#compile.ifile),
-	    {Module, Forms} = preprocess_asm_forms(Forms0),
-	    {ok,St#compile{module=Module, code=Forms, encoding=Encoding}};
+	    {Module,Forms} = preprocess_asm_forms(Forms0),
+	    {ok,Forms,St#compile{module=Module,encoding=Encoding}};
 	{error,E} ->
 	    Es = [{St#compile.ifile,[{none,?MODULE,{open,E}}]}],
 	    {error,St#compile{errors=St#compile.errors ++ Es}}
     end.
 
-read_beam_file(St) ->
+read_beam_file(_Code, St) ->
     case file:read_file(St#compile.ifile) of
 	{ok,Beam} ->
 	    Infile = St#compile.ifile,
 	    case no_native_compilation(Infile, St) of
 		true ->
-		    {ok,St#compile{module=none,code=none}};
+		    {ok,none,St#compile{module=none}};
 		false ->
 		    Mod0 = filename:rootname(filename:basename(Infile)),
 		    Mod = list_to_atom(Mod0),
-		    {ok,St#compile{module=Mod,code=Beam,ofile=Infile}}
+		    {ok,Beam,St#compile{module=Mod,ofile=Infile}}
 	    end;
 	{error,E} ->
 	    Es = [{St#compile.ifile,[{none,?MODULE,{open,E}}]}],
@@ -839,17 +843,17 @@ no_native_compilation(BeamFile, #compile{options=Opts0}) ->
 	_ -> false
     end.
 
-parse_module(St0) ->
+parse_module(_Code, St0) ->
     case do_parse_module(utf8, St0) of
-	{ok,_}=Ret ->
+	{ok,_,_}=Ret ->
 	    Ret;
 	{error,_}=Ret ->
 	    Ret;
 	{invalid_unicode,File,Line} ->
 	    case do_parse_module(latin1, St0) of
-		{ok,St} ->
+		{ok,Code,St} ->
 		    Es = [{File,[{Line,?MODULE,reparsing_invalid_unicode}]}],
-		    {ok,St#compile{warnings=Es++St#compile.warnings}};
+		    {ok,Code,St#compile{warnings=Es++St#compile.warnings}};
 		{error,St} ->
 		    Es = [{File,[{Line,?MODULE,reparsing_invalid_unicode}]}],
 		    {error,St#compile{errors=Es++St#compile.errors}}
@@ -867,13 +871,13 @@ do_parse_module(DefEncoding, #compile{ifile=File,options=Opts,dir=Dir}=St) ->
 	    Encoding = proplists:get_value(encoding, Extra),
 	    case find_invalid_unicode(Forms, File) of
 		none ->
-		    {ok,St#compile{code=Forms,encoding=Encoding}};
+		    {ok,Forms,St#compile{encoding=Encoding}};
 		{invalid_unicode,_,_}=Ret ->
 		    case Encoding of
 			none ->
 			    Ret;
 			_ ->
-			    {ok,St#compile{code=Forms,encoding=Encoding}}
+			    {ok,Forms,St#compile{encoding=Encoding}}
 		    end
 	    end;
 	{error,E} ->
@@ -892,7 +896,7 @@ find_invalid_unicode([H|T], File0) ->
     end;
 find_invalid_unicode([], _) -> none.
 
-parse_core(St) ->
+parse_core(_Code, St) ->
     case file:read_file(St#compile.ifile) of
 	{ok,Bin} ->
 	    case core_scan:string(binary_to_list(Bin)) of
@@ -900,7 +904,7 @@ parse_core(St) ->
 		    case core_parse:parse(Toks) of
 			{ok,Mod} ->
 			    Name = (Mod#c_module.name)#c_literal.val,
-			    {ok,St#compile{module=Name,code=Mod}};
+			    {ok,Mod,St#compile{module=Name}};
 			{error,E} ->
 			    Es = [{St#compile.ifile,[E]}],
 			    {error,St#compile{errors=St#compile.errors ++ Es}}
@@ -937,31 +941,36 @@ clean_parse_transforms_1([], Acc) -> reverse(Acc).
 
 transforms(Os) -> [ M || {parse_transform,M} <- Os ].
 
-transform_module(#compile{options=Opt,code=Code0}=St0) ->
+transform_module(Code0, #compile{options=Opt}=St) ->
     %% Extract compile options from code into options field.
     case transforms(Opt ++ compile_options(Code0)) of
-	[] -> {ok,St0};				%No parse transforms.
+	[] ->
+            %% No parse transforms.
+            {ok,Code0,St};
 	Ts ->
 	    %% Remove parse_transform attributes from the abstract code to
 	    %% prevent parse transforms to be run more than once.
 	    Code = clean_parse_transforms(Code0),
-	    St = St0#compile{code=Code},
-	    foldl_transform(St, Ts)
+	    foldl_transform(Ts, Code, St)
     end.
 
-foldl_transform(St, [T|Ts]) ->
+foldl_transform([T|Ts], Code0, St) ->
     Name = "transform " ++ atom_to_list(T),
     case code:ensure_loaded(T) =:= {module,T} andalso
-                erlang:function_exported(T, parse_transform, 2) of
+        erlang:function_exported(T, parse_transform, 2) of
         true ->
-            Fun = fun(S) ->
-                         T:parse_transform(S#compile.code, S#compile.options)
+            Fun = fun(Code, S) ->
+                          T:parse_transform(Code, S#compile.options)
                   end,
             Run = case member(time, St#compile.options) of
-                      true  -> fun run_tc/2;
-                      false -> fun({_Name,F}, S) -> catch F(S) end
+                      true  ->
+                          fun run_tc/3;
+                      false ->
+                          fun({_Name,F}, Code, S) ->
+                                  catch F(Code, S)
+                          end
                   end,
-            case Run({Name, Fun}, St) of
+            case Run({Name, Fun}, Code0, St) of
                 {error,Es,Ws} ->
                     {error,St#compile{warnings=St#compile.warnings ++ Ws,
                                       errors=St#compile.errors ++ Es}};
@@ -970,41 +979,44 @@ foldl_transform(St, [T|Ts]) ->
                                               {parse_transform,T,R}}]}],
                     {error,St#compile{errors=St#compile.errors ++ Es}};
                 {warning, Forms, Ws} ->
-                    foldl_transform(
-                      St#compile{code=Forms,
-                                 warnings=St#compile.warnings ++ Ws}, Ts);
+                    foldl_transform(Ts, Forms,
+                                    St#compile{warnings=St#compile.warnings ++ Ws});
                 Forms ->
-                    foldl_transform(St#compile{code=Forms}, Ts)
+                    foldl_transform(Ts, Forms, St)
             end;
         false ->
             Es = [{St#compile.ifile,[{none,compile,
                                       {undef_parse_transform,T}}]}],
             {error,St#compile{errors=St#compile.errors ++ Es}}
     end;
-foldl_transform(St, []) -> {ok,St}.
+foldl_transform([], Code, St) -> {ok,Code,St}.
 
 get_core_transforms(Opts) -> [M || {core_transform,M} <- Opts].
 
-core_transforms(St) ->
+core_transforms(Code, St) ->
     %% The options field holds the complete list of options at this
     Ts = get_core_transforms(St#compile.options),
-    foldl_core_transforms(St, Ts).
+    foldl_core_transforms(Ts, Code, St).
 
-foldl_core_transforms(St, [T|Ts]) ->
+foldl_core_transforms([T|Ts], Code0, St) ->
     Name = "core transform " ++ atom_to_list(T),
-    Fun = fun(S) -> T:core_transform(S#compile.code, S#compile.options) end,
+    Fun = fun(Code, S) -> T:core_transform(Code, S#compile.options) end,
     Run = case member(time, St#compile.options) of
-	      true  -> fun run_tc/2;
-	      false -> fun({_Name,F}, S) -> catch F(S) end
+	      true ->
+                  fun run_tc/3;
+	      false ->
+                  fun({_Name,F}, Code, S) ->
+                          catch F(Code, S)
+                  end
 	  end,
-    case Run({Name, Fun}, St) of
+    case Run({Name, Fun}, Code0, St) of
 	{'EXIT',R} ->
 	    Es = [{St#compile.ifile,[{none,compile,{core_transform,T,R}}]}],
 	    {error,St#compile{errors=St#compile.errors ++ Es}};
 	Forms ->
-	    foldl_core_transforms(St#compile{code=Forms}, Ts)
+	    foldl_core_transforms(Ts, Forms, St)
     end;
-foldl_core_transforms(St, []) -> {ok,St}.
+foldl_core_transforms([], Code, St) -> {ok,Code,St}.
 
 %%% Fetches the module name from a list of forms. The module attribute must
 %%% be present.
@@ -1025,31 +1037,28 @@ add_default_base(St, Forms) ->
 	    St
     end.
 
-lint_module(St) ->
-    case erl_lint:module(St#compile.code,
-			 St#compile.ifile, St#compile.options) of
+lint_module(Code, St) ->
+    case erl_lint:module(Code, St#compile.ifile, St#compile.options) of
 	{ok,Ws} ->
 	    %% Insert name of module as base name, if needed. This is
 	    %% for compile:forms to work with listing files.
-	    St1 = add_default_base(St, St#compile.code),
-	    {ok,St1#compile{warnings=St1#compile.warnings ++ Ws}};
+	    St1 = add_default_base(St, Code),
+	    {ok,Code,St1#compile{warnings=St1#compile.warnings ++ Ws}};
 	{error,Es,Ws} ->
 	    {error,St#compile{warnings=St#compile.warnings ++ Ws,
 			      errors=St#compile.errors ++ Es}}
     end.
 
-core_lint_module(St) ->
-    case core_lint:module(St#compile.code, St#compile.options) of
+core_lint_module(Code, St) ->
+    case core_lint:module(Code, St#compile.options) of
 	{ok,Ws} ->
-	    {ok,St#compile{warnings=St#compile.warnings ++ Ws}};
+	    {ok,Code,St#compile{warnings=St#compile.warnings ++ Ws}};
 	{error,Es,Ws} ->
 	    {error,St#compile{warnings=St#compile.warnings ++ Ws,
 			      errors=St#compile.errors ++ Es}}
     end.
 
-makedep(#compile{code=Code,options=Opts}=St) ->
-    Ifile = St#compile.ifile,
-    Ofile = St#compile.ofile,
+makedep(Code0, #compile{ifile=Ifile,ofile=Ofile,options=Opts}=St) ->
 
     %% Get the target of the Makefile rule.
     Target0 =
@@ -1081,7 +1090,7 @@ makedep(#compile{code=Code,options=Opts}=St) ->
     %% List the dependencies (includes) for this target.
     {MainRule,PhonyRules} = makedep_add_headers(
       Ifile,          % The input file name.
-      Code,           % The parsed source.
+      Code0,          % The parsed source.
       [],             % The list of dependencies already added.
       length(Target), % The current line length.
       Target,         % The target.
@@ -1101,7 +1110,8 @@ makedep(#compile{code=Code,options=Opts}=St) ->
 		   true -> MainRule ++ PhonyRules;
 		   _ -> MainRule
 	       end,
-    {ok,St#compile{code=iolist_to_binary([Makefile,"\n"])}}.
+    Code = iolist_to_binary([Makefile,"\n"]),
+    {ok,Code,St}.
 
 makedep_add_headers(Ifile, [{attribute,_,file,{File,_}}|Rest],
 		    Included, LineLen, MainTarget, Phony, Opts) ->
@@ -1166,7 +1176,7 @@ makedep_add_header(Ifile, Included, LineLen, MainTarget, Phony, File) ->
 	    end
     end.
 
-makedep_output(#compile{code=Code,options=Opts,ofile=Ofile}=St) ->
+makedep_output(Code, #compile{options=Opts,ofile=Ofile}=St) ->
     %% Write this Makefile (Code) to the selected output.
     %% If no output is specified, the default is to write to a file named after
     %% the output file.
@@ -1208,7 +1218,7 @@ makedep_output(#compile{code=Code,options=Opts,ofile=Ofile}=St) ->
 		    CloseOutput -> ok = file:close(Output1);
 		    true -> ok
 		end,
-		{ok,St}
+		{ok,Code,St}
 	    catch
 		error:_ ->
 		    %% Couldn't write to output Makefile.
@@ -1225,33 +1235,33 @@ makedep_output(#compile{code=Code,options=Opts,ofile=Ofile}=St) ->
 	    {error,St#compile{errors=St#compile.errors++[Err]}}
     end.
 
-expand_records(#compile{code=Code0,options=Opts}=St0) ->
+expand_records(Code0, #compile{options=Opts}=St) ->
     Code = erl_expand_records:module(Code0, Opts),
-    {ok,St0#compile{code=Code}}.
+    {ok,Code,St}.
 
-core(#compile{code=Forms,options=Opts0}=St) ->
+core(Forms, #compile{options=Opts0}=St) ->
     Opts1 = lists:flatten([C || {attribute,_,compile,C} <- Forms] ++ Opts0),
     Opts = expand_opts(Opts1),
     {ok,Core,Ws} = v3_core:module(Forms, Opts),
     Mod = cerl:concrete(cerl:module_name(Core)),
-    {ok,St#compile{module=Mod,code=Core,options=Opts,
-		   warnings=St#compile.warnings++Ws}}.
+    {ok,Core,St#compile{module=Mod,options=Opts,
+                        warnings=St#compile.warnings++Ws}}.
 
-core_fold_module_after_inlining(#compile{code=Code0,options=Opts}=St) ->
+core_fold_module_after_inlining(Code0, #compile{options=Opts}=St) ->
     %% Inlining may produce code that generates spurious warnings.
     %% Ignore all warnings.
     {ok,Code,_Ws} = sys_core_fold:module(Code0, Opts),
-    {ok,St#compile{code=Code}}.
+    {ok,Code,St}.
 
-v3_kernel(#compile{code=Code0,options=Opts,warnings=Ws0}=St) ->
+v3_kernel(Code0, #compile{options=Opts,warnings=Ws0}=St) ->
     {ok,Code,Ws} = v3_kernel:module(Code0, Opts),
     case Ws =:= [] orelse test_core_inliner(St) of
 	false ->
-	    {ok,St#compile{code=Code,warnings=Ws0++Ws}};
+	    {ok,Code,St#compile{warnings=Ws0++Ws}};
 	true ->
 	    %% cerl_inline may produce code that generates spurious
 	    %% warnings. Ignore any such warnings.
-	    {ok,St#compile{code=Code}}
+	    {ok,Code,St}
     end.
 
 test_old_inliner(#compile{options=Opts}) ->
@@ -1275,23 +1285,23 @@ test_core_inliner(#compile{options=Opts}) ->
 test_any_inliner(St) ->
     test_old_inliner(St) orelse test_core_inliner(St).
 
-core_old_inliner(#compile{code=Code0,options=Opts}=St) ->
+core_old_inliner(Code0, #compile{options=Opts}=St) ->
     {ok,Code} = sys_core_inline:module(Code0, Opts),
-    {ok,St#compile{code=Code}}.
+    {ok,Code,St}.
 
-core_inline_module(#compile{code=Code0,options=Opts}=St) ->
+core_inline_module(Code0, #compile{options=Opts}=St) ->
     Code = cerl_inline:core_transform(Code0, Opts),
-    {ok,St#compile{code=Code}}.
+    {ok,Code,St}.
 
-save_abstract_code(#compile{ifile=File}=St) ->
-    case abstract_code(St) of
-	{ok,Code} ->
-	    {ok,St#compile{abstract_code=Code}};
+save_abstract_code(Code, #compile{ifile=File}=St) ->
+    case abstract_code(Code, St) of
+	{ok,Abstr} ->
+	    {ok,Code,St#compile{abstract_code=Abstr}};
 	{error,Es} ->
 	    {error,St#compile{errors=St#compile.errors ++ [{File,Es}]}}
     end.
 
-abstract_code(#compile{code=Code0,options=Opts,ofile=OFile}) ->
+abstract_code(Code0, #compile{options=Opts,ofile=OFile}) ->
     Code = erl_parse:anno_to_term(Code0),
     Abstr = erlang:term_to_binary({raw_abstract_v1,Code}, [compressed]),
     case member(encrypt_debug_info, Opts) of
@@ -1313,7 +1323,7 @@ abstract_code(#compile{code=Code0,options=Opts,ofile=OFile}) ->
 		    end
 	    end;
 	false ->
-	    {ok, Abstr}
+	    {ok,Abstr}
     end.
 
 encrypt_abs_code(Abstr, Key0) ->
@@ -1351,18 +1361,17 @@ encrypt({des3_cbc=Type,Key,IVec,BlockSize}, Bin0) ->
     TypeString = atom_to_list(Type),
     list_to_binary([0,length(TypeString),TypeString,Bin]).
 
-save_core_code(St) ->
-    {ok,St#compile{core_code=cerl:from_records(St#compile.code)}}.
+save_core_code(Code, St) ->
+    {ok,Code,St#compile{core_code=cerl:from_records(Code)}}.
 
-beam_asm(#compile{ifile=File,code=Code0,
-		  abstract_code=Abst,mod_options=Opts0}=St) ->
+beam_asm(Code0, #compile{ifile=File,abstract_code=Abst,mod_options=Opts0}=St) ->
     Source = paranoid_absname(File),
     Opts1 = lists:map(fun({debug_info_key,_}) -> {debug_info_key,'********'};
 			 (Other) -> Other
 		      end, Opts0),
     Opts2 = [O || O <- Opts1, effects_code_generation(O)],
     case beam_asm:module(Code0, Abst, Source, Opts2) of
-	{ok,Code} -> {ok,St#compile{code=Code,abstract_code=[]}}
+	{ok,Code} -> {ok,Code,St#compile{abstract_code=[]}}
     end.
 
 paranoid_absname(""=File) ->
@@ -1386,17 +1395,17 @@ is_native_enabled([no_native|_]) -> false;
 is_native_enabled([_|Opts]) -> is_native_enabled(Opts);
 is_native_enabled([]) -> false.
 
-native_compile(#compile{code=none}=St) -> {ok,St};
-native_compile(St) ->
+native_compile(none, St) -> {ok,none,St};
+native_compile(Code, St) ->
     case erlang:system_info(hipe_architecture) of
 	undefined ->
 	    Ws = [{St#compile.ifile,[{none,compile,no_native_support}]}],
-	    {ok,St#compile{warnings=St#compile.warnings ++ Ws}};
+	    {ok,Code,St#compile{warnings=St#compile.warnings ++ Ws}};
 	_ ->
-	    native_compile_1(St)
+	    native_compile_1(Code, St)
     end.
 
-native_compile_1(St) ->
+native_compile_1(Code, St) ->
     Opts0 = St#compile.options,
     IgnoreErrors = member(ignore_native_errors, Opts0),
     Opts = case keyfind(hipe, 1, Opts0) of
@@ -1406,10 +1415,10 @@ native_compile_1(St) ->
 	   end,
     try hipe:compile(St#compile.module,
 		     St#compile.core_code,
-		     St#compile.code,
+		     Code,
 		     Opts) of
 	{ok,{_Type,Bin}=T} when is_binary(Bin) ->
-	    {ok,embed_native_code(St, T)};
+	    {ok,embed_native_code(Code, T),St};
 	{error,R} ->
 	    case IgnoreErrors of
 		true ->
@@ -1432,13 +1441,13 @@ native_compile_1(St) ->
 	    end
     end.
 
-embed_native_code(St, {Architecture,NativeCode}) ->
-    {ok, _, Chunks0} = beam_lib:all_chunks(St#compile.code),
+embed_native_code(Code, {Architecture,NativeCode}) ->
+    {ok, _, Chunks0} = beam_lib:all_chunks(Code),
     ChunkName = hipe_unified_loader:chunk_name(Architecture),
     Chunks1 = lists:keydelete(ChunkName, 1, Chunks0),
     Chunks = Chunks1 ++ [{ChunkName,NativeCode}],
-    {ok, BeamPlusNative} = beam_lib:build_module(Chunks),
-    St#compile{code=BeamPlusNative}.
+    {ok,BeamPlusNative} = beam_lib:build_module(Chunks),
+    BeamPlusNative.
 
 %% effects_code_generation(Option) -> true|false.
 %%  Determine whether the option could have any effect on the
@@ -1458,18 +1467,17 @@ effects_code_generation(Option) ->
 	_ -> true
     end.
 
-save_binary(#compile{code=none}=St) -> {ok,St};
-save_binary(#compile{module=Mod,ofile=Outfile,
-		     options=Opts}=St) ->
+save_binary(none, St) -> {ok,none,St};
+save_binary(Code, #compile{module=Mod,ofile=Outfile,options=Opts}=St) ->
     %% Test that the module name and output file name match.
     case member(no_error_module_mismatch, Opts) of
 	true ->
-	    save_binary_1(St);
+	    save_binary_1(Code, St);
 	false ->
 	    Base = filename:rootname(filename:basename(Outfile)),
 	    case atom_to_list(Mod) of
 		Base ->
-		    save_binary_1(St);
+		    save_binary_1(Code, St);
 		_ ->
 		    Es = [{St#compile.ofile,
 			   [{none,?MODULE,{module_name,Mod,Base}}]}],
@@ -1477,14 +1485,14 @@ save_binary(#compile{module=Mod,ofile=Outfile,
 	    end
     end.
 
-save_binary_1(St) ->
+save_binary_1(Code, St) ->
     Ofile = St#compile.ofile,
     Tfile = tmpfile(Ofile),		%Temp working file
-    case write_binary(Tfile, St#compile.code, St) of
+    case write_binary(Tfile, Code, St) of
 	ok ->
 	    case file:rename(Tfile, Ofile) of
 		ok ->
-		    {ok,St};
+		    {ok,none,St};
 		{error,RenameError} ->
 		    Es0 = [{Ofile,[{none,?MODULE,{rename,Tfile,Ofile,
 						  RenameError}}]}],
@@ -1624,29 +1632,29 @@ pre_defs([]) -> [].
 inc_paths(Opts) ->
     [ P || {i,P} <- Opts, is_list(P) ].
 
-src_listing(Ext, St) ->
+src_listing(Ext, Code, St) ->
     listing(fun (Lf, {_Mod,_Exp,Fs}) -> do_src_listing(Lf, Fs);
 		(Lf, Fs) -> do_src_listing(Lf, Fs) end,
-	    Ext, St).
+	    Ext, Code, St).
 
 do_src_listing(Lf, Fs) ->
     Opts = [lists:keyfind(encoding, 1, io:getopts(Lf))],
     foreach(fun (F) -> io:put_chars(Lf, [erl_pp:form(F, Opts),"\n"]) end,
 	    Fs).
 
-listing(Ext, St0) ->
+listing(Ext, Code, St0) ->
     St = St0#compile{encoding = none},
-    listing(fun(Lf, Fs) -> beam_listing:module(Lf, Fs) end, Ext, St).
+    listing(fun(Lf, Fs) -> beam_listing:module(Lf, Fs) end, Ext, Code, St).
 
-listing(LFun, Ext, St) ->
+listing(LFun, Ext, Code, St) ->
     Lfile = outfile(St#compile.base, Ext, St#compile.options),
     case file:open(Lfile, [write,delayed_write]) of
 	{ok,Lf} ->
-            Code = restore_expanded_types(Ext, St#compile.code),
+            Code = restore_expanded_types(Ext, Code),
             output_encoding(Lf, St),
 	    LFun(Lf, Code),
 	    ok = file:close(Lf),
-	    {ok,St};
+	    {ok,Code,St};
 	{error,Error} ->
 	    Es = [{Lfile,[{none,compile,{write_error,Error}}]}],
 	    {error,St#compile{errors=St#compile.errors ++ Es}}


### PR DESCRIPTION
Rewrite `compile` so that it does not keep the code from two compiler passes in memory at once. The main reason is to help dialyzer reduce memory usage, but it could possibly also improve performance when compiling huge files.