### PR TITLE
ErlNifEntry destructor

### DIFF
--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1966,6 +1966,9 @@ static void close_lib(struct erl_module_nif* lib)
 	lib->entry.unload(&msg_env.env, lib->priv_data);
         post_nif_noproc(&msg_env);
     }
+    if (lib->entry.dtor != NULL) {
+        lib->entry.dtor(lib->entry.dtor_data);
+    }
     if (!erts_is_static_nif(lib->handle))
       erts_sys_ddll_close(lib->handle);
     lib->handle = NULL;
@@ -3173,6 +3176,13 @@ static struct erl_module_nif* create_lib(const ErlNifEntry* src)
         }
         dst->funcs = lib->_funcs_copy_;
         dst->options = 0;
+    }
+    if (AT_LEAST_VERSION(src, 2, 12)) {
+        dst->dtor = src->dtor;
+        dst->dtor_data = src->dtor_data;
+    } else {
+        dst->dtor = NULL;
+        dst->dtor_data = NULL;
     }
     return lib;
 };

--- a/erts/emulator/test/nif_SUITE_data/Makefile.src
+++ b/erts/emulator/test/nif_SUITE_data/Makefile.src
@@ -8,7 +8,8 @@ NIF_LIBS = nif_SUITE.1@dll@ \
 	   nif_mod.3.2_0@dll@ \
 	   nif_mod.1.2_4@dll@ \
 	   nif_mod.2.2_4@dll@ \
-	   nif_mod.3.2_4@dll@
+	   nif_mod.3.2_4@dll@ \
+	   entry_dtor@dll@
 
 all: $(NIF_LIBS) basic@dll@ rwlock@dll@ tsd@dll@ echo_drv@dll@
 

--- a/erts/emulator/test/nif_SUITE_data/entry_dtor.c
+++ b/erts/emulator/test/nif_SUITE_data/entry_dtor.c
@@ -1,0 +1,28 @@
+#include <erl_nif.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+
+static ERL_NIF_TERM run(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    return enif_make_atom(env, "ok");
+}
+
+static ErlNifFunc nif_funcs[] =
+{
+    {"run", 0, run}
+};
+
+static void dtor(void* dtor_data)
+{
+	/* write marker file */
+	FILE *f;
+	f = fopen("entry_dtor_marker.txt", "w");
+	if(f)
+	{
+		fprintf(f, "%d.\n", (int)dtor_data);
+	}
+	fclose(f);
+}
+
+ERL_NIF_INIT2(tester,nif_funcs,NULL,NULL,NULL,NULL,dtor,(void*)123)


### PR DESCRIPTION
Adds `dtor` and `dtor_data` members to `ErlNifEntry`.  When the shared library containing the NIF module is unloaded from the system, a non-NULL `dtor`
will be invoked with `dtor_data`.  The purpose of this destructor is to free a heap-allocated `ErlNifEntry` and its associated arrays and strings.

The use case for this is NIF modules written in Rust or any other language that has difficulty forming static C strings and structures.  The
existing options in Rust are to use awkward and error prone constructs for a static solution as seen in
[erlang_nif-sys](https://github.com/goertzenator/erlang_nif-sys), or use heap-allocated data and accept that they will leak when unloaded as seen
in [rustler](https://github.com/hansihe/Rustler).

NIF modules written in C will always have a NULL destructor because it's `ErlNifEntry` is always static.