### PR TITLE
Fix observer application crash

### DIFF
--- a/lib/observer/src/cdv_detail_wx.erl
+++ b/lib/observer/src/cdv_detail_wx.erl
@@ -55,7 +55,7 @@ init([Id, Data, ParentFrame, Callback, Parent]) ->
 	    end,
 	    {stop,normal};
 	{info,Info} ->
-	    observer_lib:display_info_dialog(Info),
+	    observer_lib:display_info_dialog(ParentFrame,Info),
 	    {stop,normal}
     end.
 

--- a/lib/observer/src/observer_app_wx.erl
+++ b/lib/observer/src/observer_app_wx.erl
@@ -191,8 +191,8 @@ handle_event(#wx{event=#wxMouse{type=Type, x=X0, y=Y0}},
     end;
 
 handle_event(#wx{event=#wxCommand{type=command_menu_selected}},
-	     State = #state{sel=undefined}) ->
-    observer_lib:display_info_dialog("Select process first"),
+	     State = #state{panel=Panel,sel=undefined}) ->
+    observer_lib:display_info_dialog(Panel,"Select process first"),
     {noreply, State};
 
 handle_event(#wx{id=?ID_PROC_INFO, event=#wxCommand{type=command_menu_selected}},
@@ -205,7 +205,7 @@ handle_event(#wx{id=?ID_PROC_MSG, event=#wxCommand{type=command_menu_selected}},
     case observer_lib:user_term(Panel, "Enter message", "") of
 	cancel ->         ok;
 	{ok, Term} ->     Pid ! Term;
-	{error, Error} -> observer_lib:display_info_dialog(Error)
+	{error, Error} -> observer_lib:display_info_dialog(Panel,Error)
     end,
     {noreply, State};
 
@@ -214,7 +214,7 @@ handle_event(#wx{id=?ID_PROC_KILL, event=#wxCommand{type=command_menu_selected}}
     case observer_lib:user_term(Panel, "Enter Exit Reason", "kill") of
 	cancel ->         ok;
 	{ok, Term} ->     exit(Pid, Term);
-	{error, Error} -> observer_lib:display_info_dialog(Error)
+	{error, Error} -> observer_lib:display_info_dialog(Panel,Error)
     end,
     {noreply, State};
 

--- a/lib/observer/src/observer_lib.erl
+++ b/lib/observer/src/observer_lib.erl
@@ -20,7 +20,7 @@
 -module(observer_lib).
 
 -export([get_wx_parent/1,
-	 display_info_dialog/1, display_yes_no_dialog/1,
+	 display_info_dialog/2, display_yes_no_dialog/1,
 	 display_progress_dialog/2, destroy_progress_dialog/0,
 	 wait_for_progress/0, report_progress/1,
 	 user_term/3, user_term_multiline/3,
@@ -105,10 +105,10 @@ setup_timer(Bool, {Timer, Old}) ->
     timer:cancel(Timer),
     setup_timer(Bool, {false, Old}).
 
-display_info_dialog(Str) ->
-    display_info_dialog("",Str).
-display_info_dialog(Title,Str) ->
-    Dlg = wxMessageDialog:new(wx:null(), Str, [{caption,Title}]),
+display_info_dialog(Parent,Str) ->
+    display_info_dialog(Parent,"",Str).
+display_info_dialog(Parent,Title,Str) ->
+    Dlg = wxMessageDialog:new(Parent, Str, [{caption,Title}]),
     wxMessageDialog:showModal(Dlg),
     wxMessageDialog:destroy(Dlg),
     ok.
@@ -724,7 +724,7 @@ progress_loop(Title,PD,Caller) ->
 		if is_list(Reason) -> Reason;
 		   true -> file:format_error(Reason)
 		end,
-	    display_info_dialog("Crashdump Viewer Error",FailMsg),
+	    display_info_dialog(PD,"Crashdump Viewer Error",FailMsg),
 	    Caller ! error,
 	    unregister(?progress_handler),
 	    unlink(Caller);

--- a/lib/observer/src/observer_port_wx.erl
+++ b/lib/observer/src/observer_port_wx.erl
@@ -273,7 +273,7 @@ handle_info({portinfo_open, PortIdStr},
     Port = lists:keyfind(PortIdStr, #port.id_str, Ports),
     NewOpened =
         case Port of
-            undefined ->
+            false ->
                 Opened;
             _ ->
                 display_port_info(Grid, Port, Opened)

--- a/lib/observer/src/observer_port_wx.erl
+++ b/lib/observer/src/observer_port_wx.erl
@@ -267,10 +267,18 @@ handle_cast(Event, _State) ->
     error({unhandled_cast, Event}).
 
 handle_info({portinfo_open, PortIdStr},
-	    State = #state{grid=Grid, ports=Ports, open_wins=Opened}) ->
-    Port = lists:keyfind(PortIdStr,#port.id_str,Ports),
-    NewOpened = display_port_info(Grid, Port, Opened),
-    {noreply, State#state{open_wins = NewOpened}};
+	    State = #state{node=Node, grid=Grid, opt=Opt, open_wins=Opened}) ->
+    Ports0 = get_ports(Node),
+    Ports = update_grid(Grid, Opt, Ports0),
+    Port = lists:keyfind(PortIdStr, #port.id_str, Ports),
+    NewOpened =
+        case Port of
+            undefined ->
+                Opened;
+            _ ->
+                display_port_info(Grid, Port, Opened)
+        end,
+    {noreply, State#state{ports=Ports, open_wins=NewOpened}};
 
 handle_info(refresh_interval, State = #state{node=Node, grid=Grid, opt=Opt,
                                              ports=OldPorts}) ->

--- a/lib/observer/src/observer_procinfo.erl
+++ b/lib/observer/src/observer_procinfo.erl
@@ -92,7 +92,7 @@ init([Pid, ParentFrame, Parent]) ->
 	    observer_wx:return_to_localnode(ParentFrame, node(Pid)),
 	    {stop, badrpc};
 	  process_undefined ->
-	    observer_lib:display_info_dialog("No such alive process"),
+	    observer_lib:display_info_dialog(ParentFrame,"No such alive process"),
 	    {stop, normal}
     end.
 

--- a/lib/observer/src/observer_tv_wx.erl
+++ b/lib/observer/src/observer_tv_wx.erl
@@ -238,8 +238,9 @@ handle_info(not_active, State = #state{timer = Timer0}) ->
     Timer = observer_lib:stop_timer(Timer0),
     {noreply, State#state{timer=Timer}};
 
-handle_info({error, Error}, #state{opt=Opt}=State) ->
-    handle_error(Error),
+handle_info({error, Error}, #state{panel=Panel,opt=Opt}=State) ->
+    Str = io_lib:format("ERROR: ~s~n",[Error]),
+    observer_lib:display_info_dialog(Panel,Str),
     case Opt#opt.type of
         mnesia -> wxMenuBar:check(observer_wx:get_menubar(), ?ID_ETS, true);
         _ -> ok
@@ -364,10 +365,6 @@ list_to_strings([]) -> "None";
 list_to_strings([A]) -> integer_to_list(A);
 list_to_strings([A|B]) ->
     integer_to_list(A) ++ " ," ++ list_to_strings(B).
-
-handle_error(Foo) ->
-    Str = io_lib:format("ERROR: ~s~n",[Foo]),
-    observer_lib:display_info_dialog(Str).
 
 update_grid(Grid, Opt, Tables) ->
     wx:batch(fun() -> update_grid2(Grid, Opt, Tables) end).

--- a/lib/observer/src/observer_wx.erl
+++ b/lib/observer/src/observer_wx.erl
@@ -467,10 +467,10 @@ handle_info(_Info, State) ->
 
 stop_servers(#state{node=Node, log=LogOn, sys_panel=Sys, pro_panel=Procs, tv_panel=TVs,
 		    trace_panel=Trace, app_panel=Apps, perf_panel=Perfs,
-		    allc_panel=Alloc} = _State) ->
+		    allc_panel=Alloc, port_panel=Ports} = _State) ->
     LogOn andalso rpc:block_call(Node, rb, stop, []),
     Me = self(),
-    Tabs = [Sys, Procs, TVs, Trace, Apps, Perfs, Alloc],
+    Tabs = [Sys, Procs, Ports, TVs, Trace, Apps, Perfs, Alloc],
     Stop = fun() ->
 		   try
 		       _ = [wx_object:stop(Panel) || Panel <- Tabs],
@@ -580,9 +580,10 @@ get_active_pid(#state{notebook=Notebook, pro_panel=Pro, sys_panel=Sys,
 
 pid2panel(Pid, #state{pro_panel=Pro, sys_panel=Sys,
 		      tv_panel=Tv, trace_panel=Trace, app_panel=App,
-		      perf_panel=Perf, allc_panel=Alloc}) ->
+		      perf_panel=Perf, allc_panel=Alloc, port_panel=Port}) ->
     case Pid of
 	Pro -> "Processes";
+        Port -> "Ports";
 	Sys -> "System";
 	Tv -> "Table Viewer" ;
 	Trace -> ?TRACE_STR;

--- a/lib/observer/test/observer_SUITE.erl
+++ b/lib/observer/test/observer_SUITE.erl
@@ -34,7 +34,8 @@
 
 %% Test cases
 -export([app_file/1, appup_file/1,
-	 basic/1, process_win/1, table_win/1
+	 basic/1, process_win/1, table_win/1,
+         port_win_when_tab_not_initiated/1
 	]).
 
 %% Default timetrap timeout (set in init_per_testcase)
@@ -49,7 +50,8 @@ groups() ->
     [{gui, [],
       [basic,
        process_win,
-       table_win
+       table_win,
+       port_win_when_tab_not_initiated
       ]
      }].
 
@@ -299,6 +301,17 @@ table_win(Config) when is_list(Config) ->
     observer:stop(),
     ok.
 
+%% Test PR-1296/OTP-14151
+%% Clicking a link to a port before the port tab has been activated the
+%% first time crashes observer.
+port_win_when_tab_not_initiated(Config) ->
+    {ok,Port} = gen_tcp:listen(0,[]),
+    ok = observer:start(),
+    Notebook = setup_whitebox_testing(),
+    observer ! {open_link,erlang:port_to_list(Port)},
+    timer:sleep(1000),
+    observer:stop(),
+    ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
- start erl
- run observer:start()
- Click the “Applications” tab
- Double click on the “standard_error” process in the kernel application supervisor graph
- Click on a #Port<..> under links
- Observer crash