### PR TITLE
Emacs: Consider arity when jumping to definitions

### DIFF
--- a/lib/tools/emacs/erlang-start.el
+++ b/lib/tools/emacs/erlang-start.el
@@ -115,18 +115,15 @@ A function suitable for `eldoc-documentation-function'.\n\n(fn)" nil nil)
 
 ;;
 ;; Ignore files ending in ".jam", ".vee", and ".beam" when performing
-;; file completion.
+;; file completion and in dired omit mode.
 ;;
 
 ;;;###autoload
 (let ((erl-ext '(".jam" ".vee" ".beam")))
   (while erl-ext
-    (let ((cie completion-ignored-extensions))
-      (while (and cie (not (string-equal (car cie) (car erl-ext))))
-        (setq cie (cdr cie)))
-      (if (null cie)
-          (setq completion-ignored-extensions
-                (cons (car erl-ext) completion-ignored-extensions))))
+    (add-to-list 'completion-ignored-extensions (car erl-ext))
+    (when (boundp 'dired-omit-extensions)
+      (add-to-list 'dired-omit-extensions (car erl-ext)))
     (setq erl-ext (cdr erl-ext))))
 
 


### PR DESCRIPTION
Only the xref front-end introduced in Emacs 25 consider arity.  It is
not implemented for older emacsen.

Look for manual page files in lib/erlang/man in erlang-root-dir.  Also
do not give up in erlang-man-module when not finding the manual page
file.  Call manual-entry as a fallback.

Do not bother to populate menu-bar with man pages when menu-bar-mode
is nil.

Add erlang extensions also to dired-omit-extensions.

Remove some support for Emacs 18 and 19.