### PR TITLE
Move int_pow/2 and int_pow/3 from io_lib_format to math module. Export int_pow/2 for convenient integer computation.

### DIFF
--- a/lib/stdlib/doc/src/math.xml
+++ b/lib/stdlib/doc/src/math.xml
@@ -108,6 +108,14 @@ erf(X) = 2/sqrt(pi)*integral from 0 to X of exp(-t*t) dt.</pre>
       </desc>
     </func>
 
+    <func>
+      <name name="int_pow" arity="2"/>
+      <fsummary>Integer exponentiation function.</fsummary>
+      <desc>
+        <p>Right-to-left binary method. See Knuth, TAOCP Volume 2, section 4.6.3.</p>
+      </desc>
+    </func>
+
   </funcs>
 
   <section>

--- a/lib/stdlib/src/io_lib_format.erl
+++ b/lib/stdlib/src/io_lib_format.erl
@@ -505,10 +505,10 @@ scale(R, S, MPlus, MMinus, LowOk, HighOk, Float) ->
     %% table for int_pow(10, N) where we do not.
     if
         Est >= 0 ->
-            fixup(R, S * int_pow(10, Est), MPlus, MMinus, Est,
+            fixup(R, S * math:int_pow(10, Est), MPlus, MMinus, Est,
                   LowOk, HighOk);
         true ->
-            Scale = int_pow(10, -Est),
+            Scale = math:int_pow(10, -Est),
             fixup(R * Scale, S, MPlus * Scale, MMinus * Scale, Est,
                   LowOk, HighOk)
     end.
@@ -592,16 +592,6 @@ int_ceil(X) when is_float(X) ->
         Pos when Pos > 0 -> T + 1;
         _ -> T
     end.
-
-int_pow(X, 0) when is_integer(X) ->
-    1;
-int_pow(X, N) when is_integer(X), is_integer(N), N > 0 ->
-    int_pow(X, N, 1).
-
-int_pow(X, N, R) when N < 2 ->
-    R * X;
-int_pow(X, N, R) ->
-    int_pow(X * X, N bsr 1, case N band 1 of 1 -> R * X; 0 -> R end).
 
 log2floor(Int) when is_integer(Int), Int > 0 ->
     log2floor(Int, 0).

--- a/lib/stdlib/src/math.erl
+++ b/lib/stdlib/src/math.erl
@@ -19,7 +19,7 @@
 %%
 -module(math).
 
--export([pi/0]).
+-export([pi/0, int_pow/2]).
 
 %%% BIFs
 
@@ -156,3 +156,19 @@ tanh(_) ->
 -spec pi() -> float().
 
 pi() -> 3.1415926535897932.
+
+-spec int_pow(X, N) -> integer() when
+      X :: integer(),
+      N :: integer().
+
+int_pow(X, 0) when is_integer(X) ->
+    1;
+int_pow(X, N) when is_integer(X), is_integer(N), N > 0 ->
+    int_pow(X, N, 1).
+
+%% TAOCP Volume 2, section 4.6.3
+%% Right-to-left binary method
+int_pow(X, N, R) when N < 2 ->
+    R * X;
+int_pow(X, N, R) ->
+    int_pow(X * X, N bsr 1, case N band 1 of 1 -> R * X; 0 -> R end).

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -1255,17 +1255,7 @@ s10(S) ->
     rat_multiply({1,1}, {A*F + B, F}).
 
 pow10(X) ->
-    int_pow(10, X).
-
-int_pow(X, 0) when is_integer(X) ->
-    1;
-int_pow(X, N) when is_integer(X), is_integer(N), N > 0 ->
-    int_pow(X, N, 1).
-
-int_pow(X, N, R) when N < 2 ->
-    R * X;
-int_pow(X, N, R) ->
-    int_pow(X * X, N bsr 1, case N band 1 of 1 -> R * X; 0 -> R end).
+    math:int_pow(10, X).
 
 dec(F) when is_float(F) ->
     <<S:1, BE:11, M:52>> = <<F:64/float>>,


### PR DESCRIPTION
Why do we need this new feature?
================================

The ``pow/2`` function is based on floating-point arithmetic and so handle very
badly big integers.

In my exemples I use powers of 2 because I love them, but this is applicable
to other integers where you can't left shift.

The two problems are:

1) The results are wrong from 2^55 (which equals 36028797018963968):

	> math:pow(2,55).    
	36028797018963970.0 

2) Due to IEEE 754 standard limitations, you can't go higher than 2^1023:

	> math:pow(2,1024).
	** exception error: an error occurred when evaluating an arithmetic expression
	     in function  math:pow/2
	        called as math:pow(2,1024)


Risks or uncertain artifacts?
=============================

No.

How did you solve it?
=====================

I move the ``int_pow/2`` function from ``io_lib_format`` to ``math`` module and export it. 

Old users of ``pow/2`` will not see any change, and people dealing with big integers
will use ``int_pow/2``.

Performances?
=============

As the point is not to transform Erlang in a computer algebra system, I think
that performances are suitable for the usage: 2^100000 is computed in 0.1s
on my 2011 ThinkPad X220, making it usable two orders of magnitude of the power
higher than the old 2^1023 limit.

The pure Erlang implementation is notably more efficient than the Java BigInteger one.

Full benchmarks are available here:
https://github.com/fgallaire/ipow