### PR TITLE
Add RSA key generation [ERL-165]

### DIFF
--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -315,8 +315,11 @@
 	May throw exception <c>low_entropy</c> in case the random generator
 	failed due to lack of secure "randomness".
 	</p>
-	<note><p>RSA key generation is only available if the runtime was built with the
-	<strong>experimental</strong> dirty scheduler feature.</p></note>
+	<note>
+	  <p>RSA key generation is only available if the runtime was
+	  built with dirty scheduler support. Otherwise, attempting to
+	  generate an RSA key will throw exception <c>notsup</c>.</p>
+	</note>
       </desc>
     </func>
 

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -77,7 +77,7 @@
 
     <code>rsa_private() = [key_value()] = [E, N, D] | [E, N, D, P1, P2, E1, E2, C] </code>
     <p>Where E is the public exponent, N is public modulus and D is
-    the private exponent.The longer key format contains redundant
+    the private exponent. The longer key format contains redundant
     information that will make the calculation faster. P1,P2 are first
     and second prime factors. E1,E2 are first and second exponents. C
     is the CRT coefficient. Terminology is taken from <url href="http://www.ietf.org/rfc/rfc3477.txt"> RFC 3447</url>.</p>
@@ -311,7 +311,7 @@
       </type>
       <desc>
 	<p>Generates a public key of type <c>Type</c>.
-	See also <seealso marker="public_key:public_key#generate_key-1">public_key:generate_key/1</seealso>
+	See also <seealso marker="public_key:public_key#generate_key-1">public_key:generate_key/1</seealso>.
 	May throw exception <c>low_entropy</c> in case the random generator
 	failed due to lack of secure "randomness".
 	</p>

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -298,22 +298,25 @@
    <func>
       <name>generate_key(Type, Params) -> {PublicKey, PrivKeyOut} </name>
       <name>generate_key(Type, Params, PrivKeyIn) -> {PublicKey, PrivKeyOut} </name>
-      <fsummary>Generates a public keys of type <c>Type</c></fsummary>
+      <fsummary>Generates a public key of type <c>Type</c></fsummary>
       <type>
-	<v> Type = dh | ecdh | srp </v>
-	<v>Params = dh_params() | ecdh_params() | SrpUserParams | SrpHostParams </v>
+	<v> Type = dh | ecdh | rsa | srp </v>
+	<v>Params = dh_params() | ecdh_params() | RsaParams | SrpUserParams | SrpHostParams </v>
+	<v>RsaParams = {ModulusSizeInBits::integer(), PublicExponent::key_value()}</v>
 	<v>SrpUserParams = {user, [Generator::binary(), Prime::binary(), Version::atom()]}</v>
 	<v>SrpHostParams = {host, [Verifier::binary(), Generator::binary(), Prime::binary(), Version::atom()]}</v>
-	<v>PublicKey =  dh_public() | ecdh_public() | srp_public() </v>
+	<v>PublicKey =  dh_public() | ecdh_public() | rsa_public() | srp_public() </v>
 	<v>PrivKeyIn = undefined | dh_private() | ecdh_private() | srp_private() </v>
-	<v>PrivKeyOut =  dh_private() | ecdh_private() | srp_private() </v>
+	<v>PrivKeyOut =  dh_private() | ecdh_private() | rsa_private() | srp_private() </v>
       </type>
       <desc>
-	<p>Generates public keys of type <c>Type</c>.
+	<p>Generates a public key of type <c>Type</c>.
 	See also <seealso marker="public_key:public_key#generate_key-1">public_key:generate_key/1</seealso>
 	May throw exception <c>low_entropy</c> in case the random generator
 	failed due to lack of secure "randomness".
 	</p>
+	<note><p>RSA key generation is only available if the runtime was built with the
+	<strong>experimental</strong> dirty scheduler feature.</p></note>
       </desc>
     </func>
 

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -445,6 +445,10 @@ generate_key(srp, {user, [Generator, Prime, Version]}, PrivateArg)
 	      end,
     user_srp_gen_key(Private, Generator, Prime);
 
+generate_key(rsa, {ModulusSize, PublicExponent}, undefined) ->
+    Private = rsa_generate_key_nif(ModulusSize, ensure_int_as_bin(PublicExponent)),
+    { lists:sublist(Private, 2), Private };
+
 generate_key(ecdh, Curve, PrivKey) ->
     ec_key_generate(nif_curve_params(Curve), ensure_int_as_bin(PrivKey)).
 
@@ -780,6 +784,11 @@ rsa_verify_nif(_Type, _Digest, _Signature, _Key) -> ?nif_stub.
 ecdsa_verify_nif(_Type, _Digest, _Signature, _Curve, _Key) -> ?nif_stub.
 
 %% Public Keys  --------------------------------------------------------------------
+%% RSA Rivest-Shamir-Adleman functions
+%%
+
+rsa_generate_key_nif(_Bits, _Exp) -> ?nif_stub.
+
 %% DH Diffie-Hellman functions
 %% 
 

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -119,7 +119,8 @@ groups() ->
      {sha384, [], [hash, hmac]},
      {sha512, [], [hash, hmac]},
      {rsa, [], [sign_verify,
-                public_encrypt
+                public_encrypt,
+                generate
                ]},
      {dss, [], [sign_verify]},
      {ecdsa, [], [sign_verify]},
@@ -246,6 +247,21 @@ init_per_testcase(cmac, Config) ->
         _Else ->
             % The CMAC functionality was introduced in OpenSSL 1.0.1
             {skip, "OpenSSL is too old"}
+    end;
+init_per_testcase(generate, Config) ->
+    case proplists:get_value(type, Config) of
+	rsa ->
+	    % RSA key generation is a lengthy process, and is only available
+	    % if dirty CPU scheduler support was enabled for this runtime.
+	    case try erlang:system_info(dirty_cpu_schedulers) of
+		     N -> N > 0
+		 catch
+		     error:badarg -> false
+		 end of
+		true -> Config;
+		false -> {skip, "RSA key generation requires dirty scheduler support."}
+	    end;
+	_ -> Config
     end;
 init_per_testcase(_Name,Config) ->
     Config.
@@ -756,7 +772,10 @@ do_generate({ecdh = Type, Curve, Priv, Pub}) ->
 	    ok;
 	{Other, _} ->
 	    ct:fail({{crypto, generate_key, [Type, Priv, Curve]}, {expected, Pub}, {got, Other}})
-    end.
+    end;
+do_generate({rsa = Type, Mod, Exp}) ->
+    {Pub,Priv} = crypto:generate_key(Type, {Mod,Exp}),
+    do_sign_verify({rsa, sha256, Pub, Priv, rsa_plain()}).
 
 notsup(Fun, Args) ->
     Result =
@@ -1008,7 +1027,8 @@ group_config(rsa = Type, Config) ->
                   rsa_oaep(),
                   no_padding()
                  ],
-    [{sign_verify, SignVerify}, {pub_priv_encrypt, PubPrivEnc} | Config];
+    Generate = [{rsa, 1024, 3}, {rsa, 2048, 17}, {rsa, 3072, 65537}],
+    [{sign_verify, SignVerify}, {pub_priv_encrypt, PubPrivEnc}, {generate, Generate} | Config];
 group_config(dss = Type, Config) ->
     Msg = dss_plain(),
     Public = dss_params() ++ [dss_public()], 

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -1027,7 +1027,7 @@ group_config(rsa = Type, Config) ->
                   rsa_oaep(),
                   no_padding()
                  ],
-    Generate = [{rsa, 1024, 3}, {rsa, 2048, 17}, {rsa, 3072, 65537}],
+    Generate = [{rsa, 2048, 3}, {rsa, 3072, 65537}],
     [{sign_verify, SignVerify}, {pub_priv_encrypt, PubPrivEnc}, {generate, Generate} | Config];
 group_config(dss = Type, Config) ->
     Msg = dss_plain(),


### PR DESCRIPTION
This adds support for RSA key generation using `generate_key(rsa, {bits, e})` (see the [ERL-165](https://bugs.erlang.org/browse/ERL-165) bug comments section).

Key generation is slow, so this relies on being able to schedule the computation using `ERL_NIF_DIRTY_JOB_CPU_BOUND`. The test case should be automatically skipped if dirty schedulers aren't available.

I've tested this on an erlang linked against openssl 1.0.1, but it should work with 0.9.8 and 1.1.0 as well.