### PR TITLE
Remove obsolete information from the Efficiency Guide

### DIFF
--- a/system/doc/efficiency_guide/binaryhandling.xml
+++ b/system/doc/efficiency_guide/binaryhandling.xml
@@ -32,12 +32,9 @@
     <file>binaryhandling.xml</file>
   </header>
 
-  <p>In R12B, the most natural way to construct and match binaries is
-  significantly faster than in earlier releases.</p>
+  <p>Binaries can be efficiently built in the following way:</p>
 
-  <p>To construct a binary, you can simply write as follows:</p>
-
-  <p><em>DO</em> (in R12B) / <em>REALLY DO NOT</em> (in earlier releases)</p>
+  <p><em>DO</em></p>
   <code type="erl"><![CDATA[
 my_list_to_binary(List) ->
     my_list_to_binary(List, <<>>).
@@ -47,21 +44,13 @@ my_list_to_binary([H|T], Acc) ->
 my_list_to_binary([], Acc) ->
     Acc.]]></code>  
 
-  <p>In releases before R12B, <c>Acc</c> is copied in every iteration.
-  In R12B, <c>Acc</c> is copied only in the first iteration and extra
-  space is allocated at the end of the copied binary. In the next iteration,
-  <c>H</c> is written into the extra space. When the extra space runs out,
-  the binary is reallocated with more extra space. The extra space allocated
-  (or reallocated) is twice the size of the
-  existing binary data, or 256, whichever is larger.</p>
+  <p>Binaries can be efficiently matched like this:</p>
 
-  <p>The most natural way to match binaries is now the fastest:</p>
-
-  <p><em>DO</em> (in R12B)</p>
+  <p><em>DO</em></p>
   <code type="erl"><![CDATA[
 my_binary_to_list(<<H,T/binary>>) ->
     [H|my_binary_to_list(T)];
-my_binary_to_list(<<>>) -> [].]]></code>  
+my_binary_to_list(<<>>) -> [].]]></code>
 
   <section>
     <title>How Binaries are Implemented</title>
@@ -138,10 +127,7 @@ my_binary_to_list(<<>>) -> [].]]></code>
       pointer to the binary data. For each field that is matched out of
       a binary, the position in the match context is incremented.</p>
 
-    <p>In R11B, a match context was only used during a binary matching
-    operation.</p>
-
-    <p>In R12B, the compiler tries to avoid generating code that
+    <p>The compiler tries to avoid generating code that
     creates a sub binary, only to shortly afterwards create a new match
     context and discard the sub binary. Instead of creating a sub binary,
     the match context is kept.</p>
@@ -155,7 +141,7 @@ my_binary_to_list(<<>>) -> [].]]></code>
 
   <section>
     <title>Constructing Binaries</title>
-    <p>In R12B, appending to a binary or bitstring
+    <p>Appending to a binary or bitstring
     is specially optimized by the <em>runtime system</em>:</p>
 
   <code type="erl"><![CDATA[
@@ -292,7 +278,7 @@ Bin = <<Bin1,...>>  %% Bin1 will be COPIED
 
     <p>Let us revisit the example in the beginning of the previous section:</p>
 
-  <p><em>DO</em> (in R12B)</p>
+  <p><em>DO</em></p>
   <code type="erl"><![CDATA[
 my_binary_to_list(<<H,T/binary>>) ->
     [H|my_binary_to_list(T)];
@@ -304,15 +290,14 @@ my_binary_to_list(<<>>) -> [].]]></code>
   byte of the binary. 1 byte is matched out and the match context
   is updated to point to the second byte in the binary.</p>
 
-  <p>In R11B, at this point a
-  <seealso marker="#sub_binary">sub binary</seealso>
-  would be created. In R12B,
-  the compiler sees that there is no point in creating a sub binary,
-  because there will soon be a call to a function (in this case,
+  <p>At this point it would make sense to create a
+  <seealso marker="#sub_binary">sub binary</seealso>,
+  but in this particular example the compiler sees that
+  there will soon be a call to a function (in this case,
   to <c>my_binary_to_list/1</c> itself) that immediately will
   create a new match context and discard the sub binary.</p>
 
-  <p>Therefore, in R12B, <c>my_binary_to_list/1</c> calls itself
+  <p>Therefore <c>my_binary_to_list/1</c> calls itself
   with the match context instead of with a sub binary. The instruction
   that initializes the matching operation basically does nothing
   when it sees that it was passed a match context instead of a binary.</p>
@@ -321,34 +306,10 @@ my_binary_to_list(<<>>) -> [].]]></code>
   the match context will simply be discarded (removed in the next
   garbage collection, as there is no longer any reference to it).</p>
 
-  <p>To summarize, <c>my_binary_to_list/1</c> in R12B only needs to create
-  <em>one</em> match context and no sub binaries. In R11B, if the binary
-  contains <em>N</em> bytes, <em>N+1</em> match contexts and <em>N</em>
-  sub binaries are created.</p>
+  <p>To summarize, <c>my_binary_to_list/1</c> only needs to create
+  <em>one</em> match context and no sub binaries.</p>
 
-  <p>In R11B, the fastest way to match binaries is as follows:</p>
-
-  <p><em>DO NOT</em> (in R12B)</p>
-  <code type="erl"><![CDATA[
-my_complicated_binary_to_list(Bin) ->
-    my_complicated_binary_to_list(Bin, 0).
-
-my_complicated_binary_to_list(Bin, Skip) ->
-    case Bin of
-	<<_:Skip/binary,Byte,_/binary>> ->
-	    [Byte|my_complicated_binary_to_list(Bin, Skip+1)];
-	<<_:Skip/binary>> ->
-	    []
-    end.]]></code>
-
-  <p>This function cleverly avoids building sub binaries, but it cannot
-  avoid building a match context in each recursion step.
-  Therefore, in both R11B and R12B,
-  <c>my_complicated_binary_to_list/1</c> builds <em>N+1</em> match
-  contexts. (In a future Erlang/OTP release, the compiler might be able
-  to generate code that reuses the match context.)</p>
-
-  <p>Returning to <c>my_binary_to_list/1</c>, notice that the match context
+  <p>Notice that the match context in <c>my_binary_to_list/1</c>
   was discarded when the entire binary had been traversed. What happens if
   the iteration stops before it has reached the end of the binary? Will
   the optimization still work?</p>
@@ -544,5 +505,15 @@ count3(<<>>, Count) -> Count.]]></code>
   not matched out.</p>
   </section>
   </section>
+
+  <section>
+    <title>Historical Note</title>
+
+    <p>Binary handling was significantly improved in R12B. Because
+    code that was efficient in R11B might not be efficient in R12B,
+    and vice versa, earlier revisions of this Efficiency Guide contained
+    some information about binary handling in R11B.</p>
+  </section>
+
 </chapter>
 

--- a/system/doc/efficiency_guide/commoncaveats.xml
+++ b/system/doc/efficiency_guide/commoncaveats.xml
@@ -148,10 +148,10 @@ multiple_setelement(T0) ->
 
     <p><c>size/1</c> returns the size for both tuples and binaries.</p>
 
-    <p>Using the new BIFs <c>tuple_size/1</c> and <c>byte_size/1</c>, introduced
-    in R12B, gives the compiler and the runtime system more opportunities for
-    optimization. Another advantage is that the new BIFs can help Dialyzer to
-    find more bugs in your program.</p>
+    <p>Using the BIFs <c>tuple_size/1</c> and <c>byte_size/1</c>
+    gives the compiler and the runtime system more opportunities for
+    optimization. Another advantage is that the BIFs give Dialyzer more
+    type information.</p>
   </section>
 
   <section>

--- a/system/doc/efficiency_guide/functions.xml
+++ b/system/doc/efficiency_guide/functions.xml
@@ -183,15 +183,6 @@ explicit_map_pairs(Map, Xs0, Ys0) ->
        A fun contains an (indirect) pointer to the function that implements
        the fun.</p>
 
-       <warning><p><em>Tuples are not fun(s)</em>.
-       A "tuple fun", <c>{Module,Function}</c>, is not a fun.
-       The cost for calling a "tuple fun" is similar to that
-       of <c>apply/3</c> or worse.
-       Using "tuple funs" is <em>strongly discouraged</em>,
-       as they might not be supported in a future Erlang/OTP release,
-       and because there exists a superior alternative from R10B,
-       namely the <c>fun Module:Function/Arity</c> syntax.</p></warning>
-
        <p><c>apply/3</c> must look up the code for the function to execute
        in a hash table. It is therefore always slower than a
        direct call or a fun call.</p>

--- a/system/doc/efficiency_guide/functions.xml
+++ b/system/doc/efficiency_guide/functions.xml
@@ -65,7 +65,7 @@ atom_map1(six) -> 6.</code>
      thus, quite efficient even if there are many values) to select which
      one of the first three clauses to execute (if any).</item>
 
-     <item>>If none of the first three clauses match, the fourth clause
+     <item>If none of the first three clauses match, the fourth clause
      match as a variable always matches.</item>
 
      <item>If the guard test <c>is_integer(Int)</c> succeeds, the fourth

--- a/system/doc/efficiency_guide/introduction.xml
+++ b/system/doc/efficiency_guide/introduction.xml
@@ -46,14 +46,6 @@
     to find out where the performance bottlenecks are and optimize only the
     bottlenecks. Let other code stay as clean as possible.</p>
 
-    <p>Fortunately, compiler and runtime optimizations introduced in
-    Erlang/OTP R12B makes it easier to write code that is both clean and
-    efficient. For example, the ugly workarounds needed in R11B and earlier
-    releases to get the most speed out of binary pattern matching are
-    no longer necessary. In fact, the ugly code is slower
-    than the clean code (because the clean code has become faster, not
-    because the uglier code has become slower).</p>
-    
     <p>This Efficiency Guide cannot really teach you how to write efficient
     code. It can give you a few pointers about what to avoid and what to use,
     and some understanding of how certain language features are implemented.

--- a/system/doc/efficiency_guide/listhandling.xml
+++ b/system/doc/efficiency_guide/listhandling.xml
@@ -90,7 +90,7 @@ tail_recursive_fib(N, Current, Next, Fibs) ->
     <p>Lists comprehensions still have a reputation for being slow.
     They used to be implemented using funs, which used to be slow.</p>
 
-    <p>In recent Erlang/OTP releases (including R12B), a list comprehension:</p>
+    <p>A list comprehension:</p>
 
     <code type="erl"><![CDATA[
 [Expr(E) || E <- List]]]></code>
@@ -102,7 +102,7 @@ tail_recursive_fib(N, Current, Next, Fibs) ->
     [Expr(E)|'lc^0'(Tail, Expr)];
 'lc^0'([], _Expr) -> [].</code>
 
-    <p>In R12B, if the result of the list comprehension will <em>obviously</em>
+    <p>If the result of the list comprehension will <em>obviously</em>
     not be used, a list will not be constructed. For example, in this code:</p>
     
     <code type="erl"><![CDATA[
@@ -130,6 +130,14 @@ some_function(...),
     Expr(E),
     'lc^0'(Tail, Expr);
 'lc^0'([], _Expr) -> [].</code>
+
+    <p>The compiler also understands that assigning to '_' means that
+    the value will not used. Therefore, the code in the following example
+    will also be optimized:</p>
+
+    <code type="erl"><![CDATA[
+_ = [io:put_chars(E) || E <- List],
+ok.]]></code>
 
   </section>
 
@@ -209,11 +217,11 @@ some_function(...),
   <section>
     <title>Recursive List Functions</title>
 
-    <p>In Section 7.2, the following myth was exposed:
+    <p>In section about myths, the following myth was exposed:
     <seealso marker="myths#tail_recursive">Tail-Recursive Functions
     are Much Faster Than Recursive Functions</seealso>.</p>
 
-    <p>To summarize, in R12B there is usually not much difference between
+    <p>There is usually not much difference between
     a body-recursive list function and tail-recursive function that reverses
     the list at the end. Therefore, concentrate on writing beautiful code
     and forget about the performance of your list functions. In the

--- a/system/doc/efficiency_guide/processes.xml
+++ b/system/doc/efficiency_guide/processes.xml
@@ -146,14 +146,14 @@ loop() ->
     <section>
       <title>Constant Pool</title>
 
-      <p>Constant Erlang terms (also called <em>literals</em>) are now
+      <p>Constant Erlang terms (also called <em>literals</em>) are
       kept in constant pools; each loaded module has its own pool.
-      The following function does no longer build the tuple every time
+      The following function does not build the tuple every time
       it is called (only to have it discarded the next time the garbage
       collector was run), but the tuple is located in the module's
       constant pool:</p>
 
-    <p><em>DO</em> (in R12B and later)</p>
+    <p><em>DO</em></p>
       <code type="erl">
 days_in_month(M) ->
     element(M, {31,28,31,30,31,30,31,31,30,31,30,31}).</code>
@@ -235,9 +235,7 @@ true
       return the same value. Sharing has been lost.</p>
 
       <p>In a future Erlang/OTP release, it might be implemented a
-      way to (optionally) preserve sharing. There are no plans to make
-      preserving of sharing the default behaviour, as that would
-      penalize the vast majority of Erlang applications.</p>
+      way to (optionally) preserve sharing.</p>
     </section>
   </section>
 


### PR DESCRIPTION
Many sections last had a major update for the R12 release. Since R12 was released some time ago, we can stop pretending that everything released in R12 is brand new.