### PR TITLE
ERL-338 (ssl) CRL check not working for revoked certs

### DIFF
--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -125,10 +125,10 @@ file_to_crls(File, DbHandle) ->
 %% Description:  Validates ssl/tls specific extensions
 %%--------------------------------------------------------------------
 validate(_,{extension, #'Extension'{extnID = ?'id-ce-extKeyUsage',
-				    extnValue = KeyUse}}, {Role, _,_, _, _}) ->
+				    extnValue = KeyUse}}, R = {Role, _,_, _, _}) ->
     case is_valid_extkey_usage(KeyUse, Role) of
 	true ->
-	    {valid, Role};
+	    {valid, R};
 	false ->
 	    {fail, {bad_cert, invalid_ext_key_usage}}
     end;


### PR DESCRIPTION
This pull request is not a complete bug fix and should NOT be merged as-is.

I sent a version of this report to the mailing list too but it seems that's no longer in use.

I'm trying to get the ssl application to recognise a revoked cert, e.g. https://revoked.badssl.com but I can't get this to work with Erlang 19.2 downloaded from homebrew on macOS Sierra 10.12.2 (SSL 8.1)

This uses the crl_check feature added in Feb 2015: 4e0a5e36b38e3f15ed8f7d700d26f2424a47111c

```erlang
ssl:start().
ssl:connect(
    "revoked.badssl.com", 443, [
        {depth, 9},
        {cacertfile, "ca-certificates.crt"},
        {crl_check, peer},
        {crl_cache, {
            ssl_crl_cache, { internal, [{http, 1000}] }
        }},
        {verify_fun, {fun
            (Cert, {bad_cert, _} = Reason, UserState) ->
                io:format("bad_cert ~p~n", [Reason]),
                {fail, Reason};
            (_,{extension, Ext}, UserState) ->
                {unknown, UserState};
            (Cert, valid, UserState) ->
                {valid, UserState};
            (Cert, valid_peer, UserState) ->
                {valid, UserState}
        end, []}}
    ]
).

-> {ok, ...}
```

It also doesn't work with `{crl_check, true}`

Changes made to `ssl_certificate:validate` appear to be preventing CRL validation from happening when an `id-ce-extKeyUsage` extension is present in the cert before the `DistributionPoint` extension.
https://github.com/erlang/otp/blob/448e8aca77dd29ed5b37d56f0700d24ac26a7243/lib/ssl/src/ssl_certificate.erl#L131


When called from the `validation_fun_and_state` the `NewSslState` "role" gets converted from a tuple e.g.:
```erlang
{client,8207,#Ref<0.0.4.895>,peer,{ssl_crl_cache, {{_, _},[{http,1000}]}}}
```

into a single atom:
```erlang
client
```

so that when `apply_user_fun` is called, the `crl_check` function isn't run.

https://github.com/erlang/otp/blob/448e8aca77dd29ed5b37d56f0700d24ac26a7243/lib/ssl/src/ssl_handshake.erl#L1546

This PR modifies `ssl_certificate:validate` to return the full role, but results in a `revocation_status_undetermined` failure in the `verify_fun` instead of `{revoked, _}` and causes a `failed_to_decode_certificate` error for valid certs.

@IngelaAndin, any ideas?