### PR TITLE
Kernel/STDLIB: Remove references to OTP R12B and earlier

### DIFF
--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -258,7 +258,7 @@ zip:create("mnesia-4.4.7.ez",
     both strings and atoms, but a future release will probably only allow
     the arguments that are documented.</p>
 
-    <p>As from Erlang/OTP R12B, functions in this module generally fail with an
+    <p>Functions in this module generally fail with an
     exception if they are passed an incorrect type (for example, an integer or a tuple
     where an atom is expected). An error tuple is returned if the argument type
     is correct, but there are some other errors (for example, a non-existing directory

--- a/lib/kernel/doc/src/config.xml
+++ b/lib/kernel/doc/src/config.xml
@@ -77,8 +77,8 @@
       to update the application configurations.</p>
     <p>This means that specifying another <c>.config</c> file, or more
       <c>.config</c> files, leads to inconsistent update of application
-      configurations. Therefore, in Erlang 5.4/OTP R10B, the syntax of
-      <c>sys.config</c> was extended to allow pointing out other
+      configurations. There is, however, a syntax for
+      <c>sys.config</c> that allows pointing out other
       <c>.config</c> files:</p>
     <code type="none">
 [{Application, [{Par, Val}]} | File].</code>

--- a/lib/kernel/doc/src/seq_trace.xml
+++ b/lib/kernel/doc/src/seq_trace.xml
@@ -427,12 +427,6 @@ prev_cnt := tcurr</code>
       built with <c>Erl_Interface</c> only maintains one trace token, which
       means that the C-node appears as one process from
       the sequential tracing point of view.</p>
-    <p>To be able to perform sequential tracing between
-      distributed Erlang nodes, the distribution protocol has been
-      extended (in a backward compatible way). An Erlang node
-      supporting sequential tracing can communicate with an older
-      (Erlang/OTP R3B) node but messages passed within that node can
-      not be traced.</p>
   </section>
 
   <section>

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -541,10 +541,6 @@ Error: fun containing local Erlang function calls
           <c><anno>Tab</anno></c> is
           not of the correct type, or if <c><anno>Item</anno></c> is not
           one of the allowed values, a <c>badarg</c> exception is raised.</p>
-        <warning>
-          <p>In Erlang/OTP R11B and earlier, this function would not fail but
-            return <c>undefined</c> for invalid values for <c>Item</c>.</p>
-        </warning>
           <p>In addition to the <c>{<anno>Item</anno>,<anno>Value</anno>}</c>
             pairs defined for <seealso marker="#info/1"><c>info/1</c></seealso>,
             the following items are allowed:</p>

--- a/lib/stdlib/doc/src/gen_fsm.xml
+++ b/lib/stdlib/doc/src/gen_fsm.xml
@@ -534,11 +534,6 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
           the function call fails.</p>
         <p>Return value <c>Reply</c> is defined in the return value
           of <c>Module:StateName/3</c>.</p>
-	<note>
-          <p>The ancient behavior of sometimes consuming the server
-          exit message if the server died during the call while
-          linked to the client was removed in Erlang 5.6/OTP R12B.</p>
-	</note>
       </desc>
     </func>
   </funcs>

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -162,11 +162,6 @@ gen_server:abcast     -----> Module:handle_cast/2
           of <c>Module:handle_call/3</c>.</p>
         <p>The call can fail for many reasons, including time-out and the
           called <c>gen_server</c> process dying before or during the call.</p>
-	<note>
-        <p>The ancient behavior of sometimes consuming the server
-          exit message if the server died during the call while
-          linked to the client was removed in Erlang 5.6/OTP R12B.</p>
-	</note>
       </desc>
     </func>
 


### PR DESCRIPTION
In the documentation for Kernel and STDLIB, I have removed references to OTP R12B and earlier releases. Exceptions: I have kept the references in the documentations `global` and `error_logger` documentation because there still exist options to revert to a previous behavior.