### PR TITLE
Reference Manual: Remove references to OTP releases before R13A

### DIFF
--- a/system/doc/reference_manual/character_set.xml
+++ b/system/doc/reference_manual/character_set.xml
@@ -32,9 +32,9 @@
 
   <section>
     <title>Character Set</title>
-    <p>Since Erlang 4.8/OTP R5A, the syntax of Erlang tokens is extended to
-      allow the use of the full ISO-8859-1 (Latin-1) character set. This
-      is noticeable in the following ways:</p>
+    <p>The syntax of Erlang tokens allow the use of the full
+    ISO-8859-1 (Latin-1) character set. This is noticeable in the
+    following ways:</p>
     <list type="bulleted">
       <item>
         <p>All the Latin-1 printable characters can be used and are

--- a/system/doc/reference_manual/data_types.xml
+++ b/system/doc/reference_manual/data_types.xml
@@ -50,10 +50,7 @@
       <item><em><c>base</c></em><c>#</c><em><c>value</c></em>      <br></br>
 
        Integer with the base <em><c>base</c></em>, that must be an
-       integer in the range 2..36.      <br></br>
-
-       In Erlang 5.2/OTP R9B and earlier versions, the allowed range
-       is 2..16.</item>
+       integer in the range 2..36.</item>
     </list>
     <p><em>Examples:</em></p>
     <pre>

--- a/system/doc/reference_manual/errors.xml
+++ b/system/doc/reference_manual/errors.xml
@@ -49,8 +49,7 @@
       The Erlang programming language has built-in features for
       handling of run-time errors.</p>
     <p>A run-time error can also be emulated by calling
-      <c>erlang:error(Reason)</c> or <c>erlang:error(Reason, Args)</c>
-      (those appeared in Erlang 5.4/OTP-R10).</p>
+      <c>erlang:error(Reason)</c> or <c>erlang:error(Reason, Args)</c>.</p>
     <p>A run-time error is another name for an exception
       of class <c>error</c>.
       </p>
@@ -79,7 +78,6 @@
     <p>Exceptions are run-time errors or generated errors and 
       are of three different classes, with different origins. The
       <seealso marker="expressions#try">try</seealso> expression 
-      (new in Erlang 5.4/OTP R10B)
       can distinguish between the different classes, whereas the
       <seealso marker="expressions#catch">catch</seealso>
       expression cannot. They are described in
@@ -94,7 +92,7 @@
         <cell align="left" valign="middle"><c>error</c></cell>
         <cell align="left" valign="middle">Run-time error,
         for example, <c>1+a</c>, or the process called
-        <c>erlang:error/1,2</c> (new in Erlang 5.4/OTP R10B)</cell>
+        <c>erlang:error/1,2</c></cell>
       </row>
       <row>
         <cell align="left" valign="middle"><c>exit</c></cell>
@@ -111,7 +109,7 @@
       and a stack trace (which aids in finding the code location of
       the exception).</p>
     <p>The stack trace can be retrieved using
-      <c>erlang:get_stacktrace/0</c> (new in Erlang 5.4/OTP R10B)
+      <c>erlang:get_stacktrace/0</c>
       from within a <c>try</c> expression, and is returned for 
       exceptions of class <c>error</c> from a <c>catch</c> expression.</p>
     <p>An exception of class <c>error</c> is also known as a run-time 

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -123,10 +123,9 @@ member(_Elem, []) ->
       or <c>receive</c> expression must be bound in all branches 
       to have a value outside the expression. Otherwise they
       are regarded as 'unsafe' outside the expression.</p>
-    <p>For the <c>try</c> expression introduced in 
-      Erlang 5.4/OTP R10B, variable scoping is limited so that
+    <p>For the <c>try</c> expression variable scoping is limited so that
       variables bound in the expression are always 'unsafe' outside 
-      the expression. This is to be improved.</p>
+      the expression.</p>
   </section>
 
   <section>
@@ -189,7 +188,6 @@ f([$p,$r,$e,$f,$i,$x | Str]) -> ...</pre>
       <pre>
 case {Value, Result} of
     {?THRESHOLD+1, ok} -> ...</pre>
-      <p>This feature was added in Erlang 5.0/OTP R7.</p>
     </section>
   </section>
 
@@ -1348,8 +1346,8 @@ catch
         ExceptionBodyN
 end</code>
     <p>This is an enhancement of
-      <seealso marker="#catch">catch</seealso> that appeared in
-      Erlang 5.4/OTP R10B. It gives the possibility to:</p>
+      <seealso marker="#catch">catch</seealso>.
+      It gives the possibility to:</p>
     <list type="bulleted">
       <item>Distinguish between different exception classes.</item>
       <item>Choose to handle only the desired ones.</item>

--- a/system/doc/reference_manual/introduction.xml
+++ b/system/doc/reference_manual/introduction.xml
@@ -80,8 +80,8 @@
       <item>A <em>list</em> is any number of items. For example,
        an argument list can consist of zero, one, or more arguments.</item>
     </list>
-    <p>If a feature has been added recently, in Erlang 5.0/OTP R7 or
-      later, this is mentioned in the text.</p>
+    <p>If a feature has been added in R13A or later,
+    this is mentioned in the text.</p>
   </section>
 
   <section>

--- a/system/doc/reference_manual/macros.xml
+++ b/system/doc/reference_manual/macros.xml
@@ -286,7 +286,6 @@ t.erl:5: Warning: -warning("Macro VERSION not defined -- using default version."
       argument, is expanded to a string containing the tokens of
       the argument. This is similar to the <c>#arg</c> stringifying
       construction in C.</p>
-    <p>The feature was added in Erlang 5.0/OTP R7.</p>
     <p><em>Example:</em></p>
     <code type="none">
 -define(TESTCALL(Call), io:format("Call ~s: ~w~n", [??Call, Call])).

--- a/system/doc/reference_manual/records.xml
+++ b/system/doc/reference_manual/records.xml
@@ -72,9 +72,9 @@
     <pre>
 #Name{Field1=Expr1,...,FieldK=ExprK, _=ExprL}</pre>
     <p>Omitted fields then get the value of evaluating <c>ExprL</c>
-      instead of their default values. This feature was added in
-      Erlang 5.1/OTP R8 and is primarily intended to be used to create
-      patterns for ETS and Mnesia match functions.</p>
+    instead of their default values. This feature is primarily
+    intended to be used to create patterns for ETS and Mnesia match
+    functions.</p>
     <p><em>Example:</em></p>
     <pre>
 -record(person, {name, phone, address}).


### PR DESCRIPTION
Stop mentioning when a change occurred if it occurred before R13A.