### PR TITLE
tools: Allow Emake options to be passed in explicitly

### DIFF
--- a/lib/tools/doc/src/make.xml
+++ b/lib/tools/doc/src/make.xml
@@ -43,15 +43,15 @@
       <fsummary>Compile a set of modules.</fsummary>
       <type>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = noexec | load | netload | &lt;compiler option&gt;</v>
+	<v>&nbsp;Option = noexec | load | netload | {emake, Emake} | &lt;compiler option&gt;</v>
       </type>
       <desc>
-        <p>This function first looks in the current working directory
-          for a file named <c>Emakefile</c> (see below) specifying the
-          set of modules to compile and the compile options to use. If
-          no such file is found, the set of modules to compile
-          defaults to all modules in the current working
-          directory.</p>
+      <p>This function determines the set of modules to compile and the
+          compile options to use, by first looking for the <c>emake</c> make
+          option, if not present reads the configuration from a file named
+          <c>Emakefile</c> (see below). If no such file is found, the
+          set of modules to compile defaults to all modules in the
+          current working directory.</p>
         <p>Traversing the set of modules, it then recompiles every module for
           which at least one of the following conditions apply:</p>
         <list type="bulleted">
@@ -77,6 +77,9 @@
           <item><c>netload</c>          <br></br>
 
            Net load mode. Loads all recompiled modules on all known nodes.</item>
+          <item><c>{emake, Emake}</c>          <br></br>
+
+           Rather than reading the <c>Emakefile</c> specify configuration explicitly.</item>
         </list>
         <p>All items in <c>Options</c> that are not make options are assumed
           to be compiler options and are passed as-is to
@@ -108,9 +111,10 @@
 
   <section>
     <title>Emakefile</title>
-    <p><c>make:all/0,1</c> and <c>make:files/1,2</c> looks in the
-      current working directory for a file named <c>Emakefile</c>. If
-      it exists, <c>Emakefile</c> should contain elements like this:</p>
+    <p><c>make:all/0,1</c> and <c>make:files/1,2</c> first looks for
+      <c>{emake, Emake}</c> in options, then in the current working directory
+      for a file named <c>Emakefile</c>. If present <c>Emake</c> should
+      contain elements like this:</p>
     <code type="none">
 Modules.
 {Modules,Options}.    </code>

--- a/lib/tools/test/make_SUITE.erl
+++ b/lib/tools/test/make_SUITE.erl
@@ -20,7 +20,7 @@
 -module(make_SUITE).
 
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
-         init_per_group/2,end_per_group/2, make_all/1, make_files/1]).
+         init_per_group/2,end_per_group/2, make_all/1, make_files/1, emake_opts/1]).
 -export([otp_6057_init/1,
          otp_6057_a/1, otp_6057_b/1, otp_6057_c/1,
          otp_6057_end/1]).
@@ -40,7 +40,7 @@
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
-    [make_all, make_files, {group, otp_6057}].
+    [make_all, make_files, emake_opts, {group, otp_6057}].
 
 groups() -> 
     [{otp_6057,[],[otp_6057_a, otp_6057_b,
@@ -86,6 +86,20 @@ make_files(Config) when is_list(Config) ->
     ensure_no_messages(),
     ok.
 
+emake_opts(Config) when is_list(Config) ->
+    Current = prepare_data_dir(Config),
+
+    %% prove that emake is used in opts instead of local Emakefile
+    Opts = [{emake, [test8, test9]}],
+    error = make:all(Opts),
+    error = make:files([test9], Opts),
+    "test8.beam" = ensure_exists([test8]),
+    "test9.beam" = ensure_exists([test9]),
+    "test5.S" = ensure_exists(["test5"],".S"),
+
+    file:set_cwd(Current),
+    ensure_no_messages(),
+    ok.
 
 %% Moves to the data directory of this suite, clean it from any object
 %% files (*.jam for a JAM emulator).  Returns the previous directory.


### PR DESCRIPTION
This allows build scripts to use emake without needing to generate
an Emakefile before running make:all/0,1 or make:file/1,2.

Please see original Pull Request #77, which I didnt get round to
finishing before it was closed, and I deleted my previous otp fork.