### PR TITLE
Fix JIRA issue status for wanted contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In short:
 
 *   Go to the JIRA issue tracker at [bugs.erlang.org] [7] to
     see reported issues which you can contribute to.
-    Search for issues with the status *Contribution Needed*.
+    Search for issues with the status *Help Wanted*.
 
 
 Bug Reports


### PR DESCRIPTION
The README stated that in order to contribute I should search 

> for issues with the status *Contribution Needed*

Browsing https://bugs.erlang.org/ it seems the status got renamed to "Help Wanted."

This PR updates the README accordingly.