### PR TITLE
RFC: Signal Service for OS Signals

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -239,6 +239,7 @@ atom Eq='=:='
 atom Eqeq='=='
 atom erl_tracer
 atom erlang
+atom erl_signal_server
 atom ERROR='ERROR'
 atom error_handler
 atom error_logger
@@ -590,6 +591,7 @@ atom set_tcw
 atom set_tcw_fake
 atom separate
 atom shared
+atom sighup
 atom silent
 atom size
 atom sl_alloc

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -592,6 +592,7 @@ atom set_tcw_fake
 atom separate
 atom shared
 atom sighup
+atom sigterm
 atom silent
 atom size
 atom sl_alloc

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -593,6 +593,7 @@ atom separate
 atom shared
 atom sighup
 atom sigterm
+atom sigusr1
 atom silent
 atom size
 atom sl_alloc

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -194,6 +194,7 @@ atom current_stacktrace
 atom data
 atom debug_flags
 atom decimals
+atom default
 atom delay_trap
 atom dexit
 atom depth
@@ -306,6 +307,7 @@ atom global
 atom Gt='>'
 atom grun
 atom group_leader
+atom handle
 atom have_dt_utag
 atom heap_block_size
 atom heap_size
@@ -566,7 +568,7 @@ atom running_procs
 atom runtime
 atom safe
 atom save_calls
-atom scheduler 
+atom scheduler
 atom scheduler_id
 atom schedulers_online
 atom scheme
@@ -594,6 +596,16 @@ atom shared
 atom sighup
 atom sigterm
 atom sigusr1
+atom sigusr2
+atom sigill
+atom sigchld
+atom sigabrt
+atom sigalrm
+atom sigstop
+atom sigint
+atom sigsegv
+atom sigtstp
+atom sigquit
 atom silent
 atom size
 atom sl_alloc

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -5273,7 +5273,7 @@ BIF_RETTYPE dt_restore_tag_1(BIF_ALIST_1)
 	    SEQ_TRACE_TOKEN(BIF_P) = am_have_dt_utag;
 	}
     }
-#else    
+#else
     if (BIF_ARG_1 != am_true) {
 	BIF_ERROR(BIF_P,BADARG);
     }
@@ -5281,4 +5281,16 @@ BIF_RETTYPE dt_restore_tag_1(BIF_ALIST_1)
     BIF_RET(am_true);
 }
 
+BIF_RETTYPE erts_internal_set_signal_2(BIF_ALIST_2) {
+    if (is_atom(BIF_ARG_1) && ((BIF_ARG_2 == am_ignore) ||
+                               (BIF_ARG_2 == am_default) ||
+                               (BIF_ARG_2 == am_handle))) {
+        if (!erts_set_signal(BIF_ARG_1, BIF_ARG_2))
+            goto error;
 
+        BIF_RET(am_true);
+    }
+
+error:
+    BIF_ERROR(BIF_P, BADARG);
+}

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -5280,17 +5280,3 @@ BIF_RETTYPE dt_restore_tag_1(BIF_ALIST_1)
 #endif
     BIF_RET(am_true);
 }
-
-BIF_RETTYPE erts_internal_set_signal_2(BIF_ALIST_2) {
-    if (is_atom(BIF_ARG_1) && ((BIF_ARG_2 == am_ignore) ||
-                               (BIF_ARG_2 == am_default) ||
-                               (BIF_ARG_2 == am_handle))) {
-        if (!erts_set_signal(BIF_ARG_1, BIF_ARG_2))
-            goto error;
-
-        BIF_RET(am_true);
-    }
-
-error:
-    BIF_ERROR(BIF_P, BADARG);
-}

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -668,6 +668,7 @@ gcbif erlang:ceil/1
 bif math:floor/1
 bif math:ceil/1
 bif math:fmod/2
+bif erts_internal:set_signal/2
 
 #
 # Obsolete

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -668,7 +668,7 @@ gcbif erlang:ceil/1
 bif math:floor/1
 bif math:ceil/1
 bif math:fmod/2
-bif erts_internal:set_signal/2
+bif os:set_signal/2
 
 #
 # Obsolete

--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -717,6 +717,8 @@ erl_crash_dump_v(char *file, int line, char* fmt, va_list args)
      * We have to be very very careful when doing this as the schedulers
      * could be anywhere.
      */
+    sys_init_suspend_handler();
+
     for (i = 0; i < erts_no_schedulers; i++) {
         erts_tid_t tid = ERTS_SCHEDULER_IX(i)->tid;
         if (!erts_equal_tids(tid,erts_thr_self()))

--- a/erts/emulator/beam/erl_bif_os.c
+++ b/erts/emulator/beam/erl_bif_os.c
@@ -203,3 +203,17 @@ BIF_RETTYPE os_unsetenv_1(BIF_ALIST_1)
     }
     BIF_RET(am_true);
 }
+
+BIF_RETTYPE os_set_signal_2(BIF_ALIST_2) {
+    if (is_atom(BIF_ARG_1) && ((BIF_ARG_2 == am_ignore) ||
+                               (BIF_ARG_2 == am_default) ||
+                               (BIF_ARG_2 == am_handle))) {
+        if (!erts_set_signal(BIF_ARG_1, BIF_ARG_2))
+            goto error;
+
+        BIF_RET(am_ok);
+    }
+
+error:
+    BIF_ERROR(BIF_P, BADARG);
+}

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -2220,7 +2220,6 @@ erl_start(int argc, char **argv)
 	init_break_handler();
     if (replace_intr)
 	erts_replace_intr();
-    sys_init_suspend_handler();
 #endif
 
     boot_argc = argc - i;  /* Number of arguments to init */

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1070,6 +1070,9 @@ void print_process_info(fmtfn_t, void *, Process*);
 void info(fmtfn_t, void *);
 void loaded(fmtfn_t, void *);
 
+/* sighandler sys.c */
+int erts_set_signal(Eterm signal, Eterm type);
+
 /* erl_arith.c */
 double erts_get_positive_zero_float(void);
 

--- a/erts/emulator/beam/register.c
+++ b/erts/emulator/beam/register.c
@@ -272,13 +272,13 @@ erts_whereis_name_to_id(Process *c_p, Eterm name)
     int ix;
     HashBucket* b;
 #ifdef ERTS_SMP
-    ErtsProcLocks c_p_locks = c_p ? ERTS_PROC_LOCK_MAIN : 0;
-
-#ifdef ERTS_ENABLE_LOCK_CHECK
-    if (c_p) ERTS_SMP_CHK_HAVE_ONLY_MAIN_PROC_LOCK(c_p);
-#endif
-
+    ErtsProcLocks c_p_locks = 0;
+    if (c_p) {
+        c_p_locks = ERTS_PROC_LOCK_MAIN;
+        ERTS_SMP_CHK_HAVE_ONLY_MAIN_PROC_LOCK(c_p);
+    }
     reg_safe_read_lock(c_p, &c_p_locks);
+
     if (c_p && !c_p_locks)
         erts_smp_proc_lock(c_p, ERTS_PROC_LOCK_MAIN);
 #endif

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -487,20 +487,6 @@ extern volatile int erts_break_requested;
 void erts_do_break_handling(void);
 #endif
 
-#ifdef ERTS_WANT_GOT_SIGUSR1
-#  ifndef UNIX
-#    define ERTS_GOT_SIGUSR1 0
-#  else
-#    ifdef ERTS_SMP
-extern erts_smp_atomic32_t erts_got_sigusr1;
-#      define ERTS_GOT_SIGUSR1 ((int) erts_smp_atomic32_read_mb(&erts_got_sigusr1))
-#    else
-extern volatile int erts_got_sigusr1;
-#      define ERTS_GOT_SIGUSR1 erts_got_sigusr1
-#    endif
-#  endif
-#endif
-
 #ifdef ERTS_SMP
 extern erts_smp_atomic32_t erts_writing_erl_crash_dump;
 extern erts_tsd_key_t erts_is_crash_dumping_key;

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -851,9 +851,12 @@ int erts_sys_unsetenv(char *key);
 char *erts_read_env(char *key);
 void erts_free_read_env(void *value);
 
+#if defined(ERTS_SMP)
 #if defined(ERTS_THR_HAVE_SIG_FUNCS) && !defined(ETHR_UNUSABLE_SIGUSRX)
 extern void sys_thr_resume(erts_tid_t tid);
 extern void sys_thr_suspend(erts_tid_t tid);
+#define ERTS_SYS_SUSPEND_SIGNAL SIGUSR2
+#endif
 #endif
 
 /* utils.c */

--- a/erts/emulator/sys/common/erl_poll.c
+++ b/erts/emulator/sys/common/erl_poll.c
@@ -51,7 +51,6 @@
 #ifndef WANT_NONBLOCKING
 #  define WANT_NONBLOCKING
 #endif
-#define ERTS_WANT_GOT_SIGUSR1
 
 #include "erl_poll.h"
 #if ERTS_POLL_USE_KQUEUE

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -110,9 +110,8 @@ erts_smp_atomic_t sys_misc_mem_sz;
 static void smp_sig_notify(int signum);
 static int sig_notify_fds[2] = {-1, -1};
 
-#if !defined(ETHR_UNUSABLE_SIGUSRX) && defined(ERTS_THR_HAVE_SIG_FUNCS)
+#ifdef ERTS_SYS_SUSPEND_SIGNAL
 static int sig_suspend_fds[2] = {-1, -1};
-#define ERTS_SYS_SUSPEND_SIGNAL SIGUSR2
 #endif
 
 #endif

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -699,7 +699,7 @@ static RETSIGTYPE suspend_signal(int signum)
   SIGHUP     Term     Hangup detected on controlling terminal or death of controlling process
  !SIGINT     Term     Interrupt from keyboard
   SIGQUIT    Core     Quit from keyboard
-  SIGILL     Core     Illegal Instruction
+ !SIGILL     Core     Illegal Instruction
   SIGABRT    Core     Abort signal from abort(3)
  !SIGFPE     Core     Floating point exception
  !SIGKILL    Term     Kill signal
@@ -725,7 +725,7 @@ signalterm_to_signum(Eterm signal)
     case am_sighup:  return SIGHUP;
     /* case am_sigint:  return SIGINT; */
     case am_sigquit: return SIGQUIT;
-    case am_sigill:  return SIGILL;
+    /* case am_sigill:  return SIGILL; */
     case am_sigabrt: return SIGABRT;
     /* case am_sigsegv: return SIGSEGV; */
     case am_sigalrm: return SIGALRM;
@@ -745,12 +745,12 @@ signum_to_signalterm(int signum)
     switch (signum) {
     case SIGHUP:  return am_sighup;
     /* case SIGINT:  return am_sigint; */    /* ^c */
-    case SIGILL:  return am_sigill;
+    case SIGQUIT: return am_sigquit;   /* ^\ */
+    /* case SIGILL:  return am_sigill; */
     case SIGABRT: return am_sigabrt;
     /* case SIGSEGV: return am_sigsegv; */
     case SIGALRM: return am_sigalrm;
     case SIGTERM: return am_sigterm;
-    case SIGQUIT: return am_sigquit;   /* ^\ */
     case SIGUSR1: return am_sigusr1;
     case SIGUSR2: return am_sigusr2;
     case SIGCHLD: return am_sigchld;

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -698,7 +698,7 @@ static RETSIGTYPE suspend_signal(int signum)
  Signal      Action   Comment
  ─────────────────────────────────────────────────────────────
   SIGHUP     Term     Hangup detected on controlling terminal or death of controlling process
-  SIGINT     Term     Interrupt from keyboard
+ !SIGINT     Term     Interrupt from keyboard
   SIGQUIT    Core     Quit from keyboard
   SIGILL     Core     Illegal Instruction
   SIGABRT    Core     Abort signal from abort(3)
@@ -724,7 +724,7 @@ signalterm_to_signum(Eterm signal)
 {
     switch (signal) {
     case am_sighup:  return SIGHUP;
-    case am_sigint:  return SIGINT;
+    /* case am_sigint:  return SIGINT; */
     case am_sigquit: return SIGQUIT;
     case am_sigill:  return SIGILL;
     case am_sigabrt: return SIGABRT;
@@ -745,7 +745,7 @@ signum_to_signalterm(int signum)
 {
     switch (signum) {
     case SIGHUP:  return am_sighup;
-    case SIGINT:  return am_sigint;    /* ^c */
+    /* case SIGINT:  return am_sigint; */    /* ^c */
     case SIGILL:  return am_sigill;
     case SIGABRT: return am_sigabrt;
     /* case SIGSEGV: return am_sigsegv; */

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -153,7 +153,7 @@ volatile int erts_break_requested = 0;
 static struct termios initial_tty_mode;
 static int replace_intr = 0;
 /* assume yes initially, ttsl_init will clear it */
-int using_oldshell = 1; 
+int using_oldshell = 1;
 
 #ifdef ERTS_ENABLE_KERNEL_POLL
 
@@ -798,11 +798,11 @@ void erts_replace_intr(void) {
 
   if (isatty(0)) {
     tcgetattr(0, &mode);
-    
+
     /* here's an example of how to replace ctrl-c with ctrl-u */
     /* mode.c_cc[VKILL] = 0;
        mode.c_cc[VINTR] = CKILL; */
-    
+
     mode.c_cc[VINTR] = 0;	/* disable ctrl-c */
     tcsetattr(0, TCSANOW, &mode);
     replace_intr = 1;
@@ -856,10 +856,7 @@ get_number(char **str_ptr)
     }
 }
 
-void
-os_flavor(char* namebuf, 	/* Where to return the name. */
-	  unsigned size) 	/* Size of name buffer. */
-{
+void os_flavor(char* namebuf, unsigned size) {
     struct utsname uts;		/* Information about the system. */
     char* s;
 
@@ -872,22 +869,16 @@ os_flavor(char* namebuf, 	/* Where to return the name. */
     strcpy(namebuf, uts.sysname);
 }
 
-void
-os_version(pMajor, pMinor, pBuild)
-int* pMajor;			/* Pointer to major version. */
-int* pMinor;			/* Pointer to minor version. */
-int* pBuild;			/* Pointer to build number. */
-{
+void os_version(int *pMajor, int *pMinor, int *pBuild) {
     struct utsname uts;		/* Information about the system. */
     char* release;		/* Pointer to the release string:
-				 * X.Y or X.Y.Z.
-				 */
+				 * X.Y or X.Y.Z.  */
 
     (void) uname(&uts);
     release = uts.release;
-    *pMajor = get_number(&release);
-    *pMinor = get_number(&release);
-    *pBuild = get_number(&release);
+    *pMajor = get_number(&release); /* Pointer to major version. */
+    *pMinor = get_number(&release); /* Pointer to minor version. */
+    *pBuild = get_number(&release); /* Pointer to build number. */
 }
 
 void init_getenv_state(GETENV_STATE *state)
@@ -922,7 +913,7 @@ void erts_do_break_handling(void)
 {
     struct termios temp_mode;
     int saved = 0;
-    
+
     /*
      * Most functions that do_break() calls are intentionally not thread safe;
      * therefore, make sure that all threads but this one are blocked before
@@ -940,14 +931,14 @@ void erts_do_break_handling(void)
       tcsetattr(0,TCSANOW,&initial_tty_mode);
       saved = 1;
     }
-    
+
     /* call the break handling function, reset the flag */
     do_break();
 
     ERTS_UNSET_BREAK_REQUESTED;
 
     fflush(stdout);
-    
+
     /* after break we go back to saved settings */
     if (using_oldshell && !replace_intr) {
       SET_NONBLOCKING(1);
@@ -1055,36 +1046,11 @@ erts_sys_unsetenv(char *key)
     return res;
 }
 
-void
-sys_init_io(void)
-{
-}
-
-#if (0) /* unused? */
-static int write_fill(fd, buf, len)
-int fd, len;
-char *buf;
-{
-    int i, done = 0;
-    
-    do {
-	if ((i = write(fd, buf+done, len-done)) < 0) {
-	    if (errno != EINTR)
-		return (i);
-	    i = 0;
-	}
-	done += i;
-    } while (done < len);
-    return (len);
-}
-#endif
+void sys_init_io(void) { }
+void erts_sys_alloc_init(void) { }
 
 extern const char pre_loaded_code[];
 extern Preload pre_loaded[];
-
-void erts_sys_alloc_init(void)
-{
-}
 
 #if ERTS_HAVE_ERTS_SYS_ALIGNED_ALLOC
 void *erts_sys_aligned_alloc(UWord alignment, UWord size)
@@ -1186,9 +1152,7 @@ void sys_preload_end(Preload* p)
    Here we assume that all schedulers are stopped so that erl_poll
    does not interfere with the select below.
 */
-int sys_get_key(fd)
-int fd;
-{
+int sys_get_key(int fd) {
     int c, ret;
     unsigned char rbuf[64];
     fd_set fds;
@@ -1207,15 +1171,14 @@ int fd;
         if (c <= 0)
             return c;
     }
-
-    return rbuf[0]; 
+    return rbuf[0];
 }
 
 
 extern int erts_initialized;
 void
 erl_assert_error(const char* expr, const char* func, const char* file, int line)
-{   
+{
     fflush(stdout);
     fprintf(stderr, "%s:%d:%s() Assertion failed: %s\n",
             file, line, func, expr);
@@ -1240,7 +1203,7 @@ erl_debug(char* fmt, ...)
 {
     char sbuf[1024];		/* Temporary buffer. */
     va_list va;
-    
+
     if (debug_log) {
 	va_start(va, fmt);
 	vsprintf(sbuf, fmt, va);
@@ -1388,9 +1351,9 @@ init_smp_sig_suspend(void) {
 int erts_darwin_main_thread_pipe[2];
 int erts_darwin_main_thread_result_pipe[2];
 
-static void initialize_darwin_main_thread_pipes(void) 
+static void initialize_darwin_main_thread_pipes(void)
 {
-    if (pipe(erts_darwin_main_thread_pipe) < 0 || 
+    if (pipe(erts_darwin_main_thread_pipe) < 0 ||
 	pipe(erts_darwin_main_thread_result_pipe) < 0) {
 	erts_exit(ERTS_ERROR_EXIT,"Fatal error initializing Darwin main thread stealing");
     }
@@ -1556,5 +1519,4 @@ erl_sys_args(int* argc, char** argv)
 	    argv[j++] = argv[i];
     }
     *argc = j;
-
 }

--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -294,6 +294,10 @@ int erts_sys_prepare_crash_dump(int secs)
     return 0;
 }
 
+int erts_set_signal(Eterm signal, Eterm type) {
+    return 0;
+}
+
 static void
 init_console(void)
 {

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -85,6 +85,7 @@ MODULES= \
 	num_bif_SUITE \
 	message_queue_data_SUITE \
 	op_SUITE \
+	os_signal_SUITE \
 	port_SUITE \
 	port_bif_SUITE \
 	process_SUITE \

--- a/erts/emulator/test/os_signal_SUITE.erl
+++ b/erts/emulator/test/os_signal_SUITE.erl
@@ -1,0 +1,354 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+%%
+%% File:    os_signal_SUITE.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2017-01-13
+%%
+
+-module(os_signal_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-export([all/0, suite/0]).
+-export([init_per_testcase/2, end_per_testcase/2]).
+-export([init_per_suite/1, end_per_suite/1]).
+
+-export([set_alarm/1, fork/0, get_exit_code/1]).
+
+% Test cases
+-export([set_unset/1,
+         t_sighup/1,
+         t_sigusr1/1,
+         t_sigusr2/1,
+         t_sigterm/1,
+         t_sigalrm/1,
+         t_sigchld/1,
+         t_sigchld_fork/1]).
+
+-define(signal_server, erl_signal_server).
+
+suite() ->
+    [{ct_hooks,[ts_install_cth]},
+     {timetrap, {minutes, 2}}].
+
+all() ->
+    case os:type() of
+        {win32, _} -> [];
+        _ -> [set_unset,
+              t_sighup,
+              t_sigusr1,
+              t_sigusr2,
+              t_sigterm,
+              t_sigalrm,
+              t_sigchld,
+              t_sigchld_fork]
+    end.
+
+init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
+    Pid = erlang:whereis(?signal_server),
+    true = erlang:unregister(?signal_server),
+    [{signal_server, Pid}|Config].
+
+end_per_testcase(_Func, Config) ->
+    case proplists:get_value(signal_server, Config) of
+        undefined -> ok;
+        Pid ->
+            true = erlang:register(?signal_server, Pid),
+            ok
+    end.
+
+init_per_suite(Config) ->
+    load_nif(Config),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% tests
+
+set_unset(_Config) ->
+    Signals = [sighup, %sigint,
+               sigquit, sigill,
+               sigabrt,
+               sigalrm, sigterm,
+               sigusr1, sigusr2,
+               sigchld,
+               sigstop, sigtstp],
+    F1 = fun(Sig) -> true = erts_internal:set_signal(Sig,handle) end,
+    F2 = fun(Sig) -> true = erts_internal:set_signal(Sig,default) end,
+    F3 = fun(Sig) -> true = erts_internal:set_signal(Sig,ignore) end,
+    %% set handle
+    ok = lists:foreach(F1, Signals),
+    %% set ignore
+    ok = lists:foreach(F2, Signals),
+    %% set default
+    ok = lists:foreach(F3, Signals),
+    ok.
+
+t_sighup(_Config) ->
+    Pid1 = setup_service(),
+    OsPid = os:getpid(),
+    erts_internal:set_signal(sighup, handle),
+    ok = kill("HUP", OsPid),
+    ok = kill("HUP", OsPid),
+    ok = kill("HUP", OsPid),
+    Msgs1 = fetch_msgs(Pid1),
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    [{notify,sighup},
+     {notify,sighup},
+     {notify,sighup}] = Msgs1,
+    %% no proc
+    ok = kill("HUP", OsPid),
+    ok = kill("HUP", OsPid),
+    ok = kill("HUP", OsPid),
+    %% ignore
+    Pid2 = setup_service(),
+    erts_internal:set_signal(sighup, ignore),
+    ok = kill("HUP", OsPid),
+    ok = kill("HUP", OsPid),
+    ok = kill("HUP", OsPid),
+    Msgs2 = fetch_msgs(Pid2),
+    io:format("Msgs2: ~p~n", [Msgs2]),
+    [] = Msgs2,
+    %% reset to handle (it's the default)
+    erts_internal:set_signal(sighup, handle),
+    ok.
+
+t_sigusr1(_Config) ->
+    Pid1 = setup_service(),
+    OsPid = os:getpid(),
+    erts_internal:set_signal(sigusr1, handle),
+    ok = kill("USR1", OsPid),
+    ok = kill("USR1", OsPid),
+    ok = kill("USR1", OsPid),
+    Msgs1 = fetch_msgs(Pid1),
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    [{notify,sigusr1},
+     {notify,sigusr1},
+     {notify,sigusr1}] = Msgs1,
+    %% no proc
+    ok = kill("USR1", OsPid),
+    ok = kill("USR1", OsPid),
+    ok = kill("USR1", OsPid),
+    %% ignore
+    Pid2 = setup_service(),
+    erts_internal:set_signal(sigusr1, ignore),
+    ok = kill("USR1", OsPid),
+    ok = kill("USR1", OsPid),
+    ok = kill("USR1", OsPid),
+    Msgs2 = fetch_msgs(Pid2),
+    io:format("Msgs2: ~p~n", [Msgs2]),
+    [] = Msgs2,
+    %% reset to ignore (it's the default)
+    erts_internal:set_signal(sigusr1, handle),
+    ok.
+
+t_sigusr2(_Config) ->
+    Pid1 = setup_service(),
+    OsPid = os:getpid(),
+    erts_internal:set_signal(sigusr2, handle),
+    ok = kill("USR2", OsPid),
+    ok = kill("USR2", OsPid),
+    ok = kill("USR2", OsPid),
+    Msgs1 = fetch_msgs(Pid1),
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    [{notify,sigusr2},
+     {notify,sigusr2},
+     {notify,sigusr2}] = Msgs1,
+    %% no proc
+    ok = kill("USR2", OsPid),
+    ok = kill("USR2", OsPid),
+    ok = kill("USR2", OsPid),
+    %% ignore
+    Pid2 = setup_service(),
+    erts_internal:set_signal(sigusr2, ignore),
+    ok = kill("USR2", OsPid),
+    ok = kill("USR2", OsPid),
+    ok = kill("USR2", OsPid),
+    Msgs2 = fetch_msgs(Pid2),
+    io:format("Msgs2: ~p~n", [Msgs2]),
+    [] = Msgs2,
+    %% reset to ignore (it's the default)
+    erts_internal:set_signal(sigusr2, ignore),
+    ok.
+
+t_sigterm(_Config) ->
+    Pid1 = setup_service(),
+    OsPid = os:getpid(),
+    erts_internal:set_signal(sigterm, handle),
+    ok = kill("TERM", OsPid),
+    ok = kill("TERM", OsPid),
+    ok = kill("TERM", OsPid),
+    Msgs1 = fetch_msgs(Pid1),
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    [{notify,sigterm},
+     {notify,sigterm},
+     {notify,sigterm}] = Msgs1,
+    %% no proc
+    ok = kill("TERM", OsPid),
+    ok = kill("TERM", OsPid),
+    ok = kill("TERM", OsPid),
+    %% ignore
+    Pid2 = setup_service(),
+    erts_internal:set_signal(sigterm, ignore),
+    ok = kill("TERM", OsPid),
+    ok = kill("TERM", OsPid),
+    ok = kill("TERM", OsPid),
+    Msgs2 = fetch_msgs(Pid2),
+    io:format("Msgs2: ~p~n", [Msgs2]),
+    [] = Msgs2,
+    %% reset to handle (it's the default)
+    erts_internal:set_signal(sigterm, handle),
+    ok.
+
+t_sigchld(_Config) ->
+    Pid1 = setup_service(),
+    OsPid = os:getpid(),
+    erts_internal:set_signal(sigchld, handle),
+    ok = kill("CHLD", OsPid),
+    ok = kill("CHLD", OsPid),
+    ok = kill("CHLD", OsPid),
+    Msgs1 = fetch_msgs(Pid1),
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    [{notify,sigchld},
+     {notify,sigchld},
+     {notify,sigchld}] = Msgs1,
+    %% no proc
+    ok = kill("CHLD", OsPid),
+    ok = kill("CHLD", OsPid),
+    ok = kill("CHLD", OsPid),
+    %% ignore
+    Pid2 = setup_service(),
+    erts_internal:set_signal(sigchld, ignore),
+    ok = kill("CHLD", OsPid),
+    ok = kill("CHLD", OsPid),
+    ok = kill("CHLD", OsPid),
+    Msgs2 = fetch_msgs(Pid2),
+    io:format("Msgs2: ~p~n", [Msgs2]),
+    [] = Msgs2,
+    %% reset to handle (it's the default)
+    erts_internal:set_signal(sigchld, ignore),
+    ok.
+
+
+t_sigalrm(_Config) ->
+    Pid1 = setup_service(),
+    true = erts_internal:set_signal(sigalrm, handle),
+    ok = os_signal_SUITE:set_alarm(1),
+    receive after 3000 -> ok end,
+    Msgs1 = fetch_msgs(Pid1),
+    [{notify,sigalrm}] = Msgs1,
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    erts_internal:set_signal(sigalrm, ignore),
+    Pid2 = setup_service(),
+    ok = os_signal_SUITE:set_alarm(1),
+    receive after 3000 -> ok end,
+    Msgs2 = fetch_msgs(Pid2),
+    [] = Msgs2,
+    io:format("Msgs2: ~p~n", [Msgs2]),
+    Pid3 = setup_service(),
+    erts_internal:set_signal(sigalrm, handle),
+    ok = os_signal_SUITE:set_alarm(1),
+    receive after 3000 -> ok end,
+    Msgs3 = fetch_msgs(Pid3),
+    [{notify,sigalrm}] = Msgs3,
+    io:format("Msgs3: ~p~n", [Msgs3]),
+    erts_internal:set_signal(sigalrm, ignore),
+    ok.
+
+t_sigchld_fork(_Config) ->
+    Pid1 = setup_service(),
+    true = erts_internal:set_signal(sigchld, handle),
+    {ok,OsPid} = os_signal_SUITE:fork(),
+    receive after 3000 -> ok end,
+    Msgs1 = fetch_msgs(Pid1),
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    [{notify,sigchld}] = Msgs1,
+    {ok,Status} = os_signal_SUITE:get_exit_code(OsPid),
+    io:format("exit status from ~w : ~w~n", [OsPid,Status]),
+    42 = Status,
+    %% reset to ignore (it's the default)
+    erts_internal:set_signal(sigchld, ignore),
+    ok.
+
+
+%% nif stubs
+
+set_alarm(_Secs) -> no.
+fork() -> no.
+get_exit_code(_OsPid) -> no.
+
+%% aux
+
+setup_service() ->
+    Pid = spawn_link(fun msgs/0),
+    true = erlang:register(?signal_server, Pid),
+    Pid.
+
+msgs() ->
+    msgs([]).
+msgs(Ms) ->
+    receive
+        {Pid, fetch_msgs} -> Pid ! {self(), lists:reverse(Ms)};
+        Msg ->
+            msgs([Msg|Ms])
+    end.
+
+fetch_msgs(Pid) ->
+    Pid ! {self(), fetch_msgs},
+    receive {Pid, Msgs} -> Msgs end.
+
+kill(Signal, Pid) ->
+    {0,_} = run("kill", ["-s", Signal, Pid]),
+    receive after 200 -> ok end,
+    ok.
+
+load_nif(Config) ->
+    Path = proplists:get_value(data_dir, Config),
+    ok = erlang:load_nif(filename:join(Path,"os_signal_nif"), 0).
+
+run(Program0, Args) -> run(".", Program0, Args).
+run(Cwd, Program0, Args) when is_list(Cwd) ->
+    Program = case os:find_executable(Program0) of
+                  Path when is_list(Path) ->
+                      Path;
+                  false ->
+                      exit(no)
+              end,
+    Options = [{args,Args},binary,exit_status,stderr_to_stdout,
+               {line,4096}, {cd, Cwd}],
+    try open_port({spawn_executable,Program}, Options) of
+        Port ->
+            run_loop(Port, [])
+    catch
+        error:_ ->
+                      exit(no)
+    end.
+
+run_loop(Port, Output) ->
+    receive
+        {Port,{exit_status,Status}} ->
+            {Status,lists:reverse(Output)};
+        {Port,{data,{eol,Bin}}} ->
+            run_loop(Port, [Bin|Output]);
+        _Msg ->
+            run_loop(Port, Output)
+    end.

--- a/erts/emulator/test/os_signal_SUITE.erl
+++ b/erts/emulator/test/os_signal_SUITE.erl
@@ -86,7 +86,7 @@ end_per_suite(_Config) ->
 
 set_unset(_Config) ->
     Signals = [sighup, %sigint,
-               sigquit, sigill,
+               sigquit, %sigill,
                sigabrt,
                sigalrm, sigterm,
                sigusr1, sigusr2,

--- a/erts/emulator/test/os_signal_SUITE.erl
+++ b/erts/emulator/test/os_signal_SUITE.erl
@@ -92,9 +92,9 @@ set_unset(_Config) ->
                sigusr1, sigusr2,
                sigchld,
                sigstop, sigtstp],
-    F1 = fun(Sig) -> true = erts_internal:set_signal(Sig,handle) end,
-    F2 = fun(Sig) -> true = erts_internal:set_signal(Sig,default) end,
-    F3 = fun(Sig) -> true = erts_internal:set_signal(Sig,ignore) end,
+    F1 = fun(Sig) -> ok = os:set_signal(Sig,handle) end,
+    F2 = fun(Sig) -> ok = os:set_signal(Sig,default) end,
+    F3 = fun(Sig) -> ok = os:set_signal(Sig,ignore) end,
     %% set handle
     ok = lists:foreach(F1, Signals),
     %% set ignore
@@ -106,7 +106,7 @@ set_unset(_Config) ->
 t_sighup(_Config) ->
     Pid1 = setup_service(),
     OsPid = os:getpid(),
-    erts_internal:set_signal(sighup, handle),
+    os:set_signal(sighup, handle),
     ok = kill("HUP", OsPid),
     ok = kill("HUP", OsPid),
     ok = kill("HUP", OsPid),
@@ -121,7 +121,7 @@ t_sighup(_Config) ->
     ok = kill("HUP", OsPid),
     %% ignore
     Pid2 = setup_service(),
-    erts_internal:set_signal(sighup, ignore),
+    os:set_signal(sighup, ignore),
     ok = kill("HUP", OsPid),
     ok = kill("HUP", OsPid),
     ok = kill("HUP", OsPid),
@@ -129,13 +129,13 @@ t_sighup(_Config) ->
     io:format("Msgs2: ~p~n", [Msgs2]),
     [] = Msgs2,
     %% reset to handle (it's the default)
-    erts_internal:set_signal(sighup, handle),
+    os:set_signal(sighup, handle),
     ok.
 
 t_sigusr1(_Config) ->
     Pid1 = setup_service(),
     OsPid = os:getpid(),
-    erts_internal:set_signal(sigusr1, handle),
+    os:set_signal(sigusr1, handle),
     ok = kill("USR1", OsPid),
     ok = kill("USR1", OsPid),
     ok = kill("USR1", OsPid),
@@ -150,7 +150,7 @@ t_sigusr1(_Config) ->
     ok = kill("USR1", OsPid),
     %% ignore
     Pid2 = setup_service(),
-    erts_internal:set_signal(sigusr1, ignore),
+    os:set_signal(sigusr1, ignore),
     ok = kill("USR1", OsPid),
     ok = kill("USR1", OsPid),
     ok = kill("USR1", OsPid),
@@ -158,13 +158,13 @@ t_sigusr1(_Config) ->
     io:format("Msgs2: ~p~n", [Msgs2]),
     [] = Msgs2,
     %% reset to ignore (it's the default)
-    erts_internal:set_signal(sigusr1, handle),
+    os:set_signal(sigusr1, handle),
     ok.
 
 t_sigusr2(_Config) ->
     Pid1 = setup_service(),
     OsPid = os:getpid(),
-    erts_internal:set_signal(sigusr2, handle),
+    os:set_signal(sigusr2, handle),
     ok = kill("USR2", OsPid),
     ok = kill("USR2", OsPid),
     ok = kill("USR2", OsPid),
@@ -179,7 +179,7 @@ t_sigusr2(_Config) ->
     ok = kill("USR2", OsPid),
     %% ignore
     Pid2 = setup_service(),
-    erts_internal:set_signal(sigusr2, ignore),
+    os:set_signal(sigusr2, ignore),
     ok = kill("USR2", OsPid),
     ok = kill("USR2", OsPid),
     ok = kill("USR2", OsPid),
@@ -187,13 +187,13 @@ t_sigusr2(_Config) ->
     io:format("Msgs2: ~p~n", [Msgs2]),
     [] = Msgs2,
     %% reset to ignore (it's the default)
-    erts_internal:set_signal(sigusr2, ignore),
+    os:set_signal(sigusr2, ignore),
     ok.
 
 t_sigterm(_Config) ->
     Pid1 = setup_service(),
     OsPid = os:getpid(),
-    erts_internal:set_signal(sigterm, handle),
+    os:set_signal(sigterm, handle),
     ok = kill("TERM", OsPid),
     ok = kill("TERM", OsPid),
     ok = kill("TERM", OsPid),
@@ -208,7 +208,7 @@ t_sigterm(_Config) ->
     ok = kill("TERM", OsPid),
     %% ignore
     Pid2 = setup_service(),
-    erts_internal:set_signal(sigterm, ignore),
+    os:set_signal(sigterm, ignore),
     ok = kill("TERM", OsPid),
     ok = kill("TERM", OsPid),
     ok = kill("TERM", OsPid),
@@ -216,13 +216,13 @@ t_sigterm(_Config) ->
     io:format("Msgs2: ~p~n", [Msgs2]),
     [] = Msgs2,
     %% reset to handle (it's the default)
-    erts_internal:set_signal(sigterm, handle),
+    os:set_signal(sigterm, handle),
     ok.
 
 t_sigchld(_Config) ->
     Pid1 = setup_service(),
     OsPid = os:getpid(),
-    erts_internal:set_signal(sigchld, handle),
+    os:set_signal(sigchld, handle),
     ok = kill("CHLD", OsPid),
     ok = kill("CHLD", OsPid),
     ok = kill("CHLD", OsPid),
@@ -237,7 +237,7 @@ t_sigchld(_Config) ->
     ok = kill("CHLD", OsPid),
     %% ignore
     Pid2 = setup_service(),
-    erts_internal:set_signal(sigchld, ignore),
+    os:set_signal(sigchld, ignore),
     ok = kill("CHLD", OsPid),
     ok = kill("CHLD", OsPid),
     ok = kill("CHLD", OsPid),
@@ -245,19 +245,19 @@ t_sigchld(_Config) ->
     io:format("Msgs2: ~p~n", [Msgs2]),
     [] = Msgs2,
     %% reset to handle (it's the default)
-    erts_internal:set_signal(sigchld, ignore),
+    os:set_signal(sigchld, ignore),
     ok.
 
 
 t_sigalrm(_Config) ->
     Pid1 = setup_service(),
-    true = erts_internal:set_signal(sigalrm, handle),
+    ok = os:set_signal(sigalrm, handle),
     ok = os_signal_SUITE:set_alarm(1),
     receive after 3000 -> ok end,
     Msgs1 = fetch_msgs(Pid1),
     [{notify,sigalrm}] = Msgs1,
     io:format("Msgs1: ~p~n", [Msgs1]),
-    erts_internal:set_signal(sigalrm, ignore),
+    os:set_signal(sigalrm, ignore),
     Pid2 = setup_service(),
     ok = os_signal_SUITE:set_alarm(1),
     receive after 3000 -> ok end,
@@ -265,18 +265,18 @@ t_sigalrm(_Config) ->
     [] = Msgs2,
     io:format("Msgs2: ~p~n", [Msgs2]),
     Pid3 = setup_service(),
-    erts_internal:set_signal(sigalrm, handle),
+    os:set_signal(sigalrm, handle),
     ok = os_signal_SUITE:set_alarm(1),
     receive after 3000 -> ok end,
     Msgs3 = fetch_msgs(Pid3),
     [{notify,sigalrm}] = Msgs3,
     io:format("Msgs3: ~p~n", [Msgs3]),
-    erts_internal:set_signal(sigalrm, ignore),
+    os:set_signal(sigalrm, ignore),
     ok.
 
 t_sigchld_fork(_Config) ->
     Pid1 = setup_service(),
-    true = erts_internal:set_signal(sigchld, handle),
+    ok = os:set_signal(sigchld, handle),
     {ok,OsPid} = os_signal_SUITE:fork(),
     receive after 3000 -> ok end,
     Msgs1 = fetch_msgs(Pid1),
@@ -286,7 +286,7 @@ t_sigchld_fork(_Config) ->
     io:format("exit status from ~w : ~w~n", [OsPid,Status]),
     42 = Status,
     %% reset to ignore (it's the default)
-    erts_internal:set_signal(sigchld, ignore),
+    os:set_signal(sigchld, ignore),
     ok.
 
 

--- a/erts/emulator/test/os_signal_SUITE_data/Makefile.src
+++ b/erts/emulator/test/os_signal_SUITE_data/Makefile.src
@@ -1,0 +1,6 @@
+
+NIF_LIBS = os_signal_nif@dll@
+
+all: $(NIF_LIBS)
+
+@SHLIB_RULES@

--- a/erts/emulator/test/os_signal_SUITE_data/os_signal_nif.c
+++ b/erts/emulator/test/os_signal_SUITE_data/os_signal_nif.c
@@ -1,0 +1,66 @@
+#include <sys/wait.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#include <erl_nif.h>
+
+static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+{
+    return 0;
+}
+
+static ERL_NIF_TERM set_alarm(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    int t;
+    if (!enif_get_int(env, argv[0], &t)) {
+        return enif_make_badarg(env);
+    }
+
+    alarm(t);
+
+    return enif_make_atom(env, "ok");
+}
+
+static ERL_NIF_TERM fork_0(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    pid_t pid;
+
+    pid = fork();
+
+    if (pid == 0) {
+        /* child */
+        exit(42);
+    }
+
+    return enif_make_tuple(env, 2,
+            enif_make_atom(env, "ok"),
+            enif_make_int(env, (int)pid));
+}
+
+static ERL_NIF_TERM get_exit_code(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    int x;
+    pid_t pid;
+    if (!enif_get_int(env, argv[0], &x)) {
+        return enif_make_badarg(env);
+    }
+
+    pid = (pid_t) x;
+
+    waitpid(pid, &x, 0);
+
+    return enif_make_tuple(env, 2,
+            enif_make_atom(env, "ok"),
+            enif_make_int(env, WEXITSTATUS(x)));
+}
+
+
+static ErlNifFunc nif_funcs[] =
+{
+    {"set_alarm", 1, set_alarm},
+    {"fork", 0, fork_0},
+    {"get_exit_code", 1, get_exit_code}
+};
+
+ERL_NIF_INIT(os_signal_SUITE,nif_funcs,load,NULL,NULL,NULL)

--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -11,7 +11,7 @@
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.
       You may obtain a copy of the License at
- 
+
           http://www.apache.org/licenses/LICENSE-2.0
 
       Unless required by applicable law or agreed to in writing, software
@@ -19,7 +19,7 @@
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
       See the License for the specific language governing permissions and
       limitations under the License.
-    
+
     </legalnotice>
 
     <title>kernel</title>
@@ -55,6 +55,60 @@
     <p>Two standard error logger event handlers are defined in
       the Kernel application. These are described in
       <seealso marker="error_logger"><c>error_logger(3)</c></seealso>.</p>
+  </section>
+
+  <section>
+      <title>OS Signal Event Handler</title>
+      <p>Asynchronous OS signals may be subscribed to via the Kernel applications event manager
+          (see <seealso marker="doc/design_principles:des_princ">OTP Design Principles</seealso> and
+          <seealso marker="stdlib:gen_event"><c>gen_event(3)</c></seealso>) registered as <c>erl_signal_server</c>.
+          A default signal handler is installed which handles the following signals:</p>
+          <taglist>
+              <tag><c>sigusr1</c></tag>
+              <item><p>The default handler will halt Erlang and produce a crashdump
+                      with slogan "Received SIGUSR1".
+                      This is equivalent to calling <c>erlang:halt("Received SIGUSR1")</c>.
+              </p></item>
+
+              <tag><c>sigquit</c></tag>
+              <item><p>The default handler will halt Erlang immediately.
+                      This is equivalent to calling <c>erlang:halt()</c>.
+              </p></item>
+
+              <tag><c>sigterm</c></tag>
+              <item><p>The default handler will terminate Erlang normally.
+                      This is equivalent to calling <c>init:stop()</c>.
+              </p></item>
+          </taglist>
+
+          <section>
+              <title>Events</title>
+              <p>Any event handler added to <c>erl_signal_server</c> must handle the following events.</p>
+              <taglist>
+                  <tag><c>sighup</c></tag>
+                  <item><p>Hangup detected on controlling terminal or death of controlling process</p></item>
+                  <tag><c>sigquit</c></tag>
+                  <item><p>Quit from keyboard</p></item>
+                  <tag><c>sigabrt</c></tag>
+                  <item><p>Abort signal from abort</p></item>
+                  <tag><c>sigalrm</c></tag>
+                  <item><p>Timer signal from alarm</p></item>
+                  <tag><c>sigterm</c></tag>
+                  <item><p>Termination signal</p></item>
+                  <tag><c>sigusr1</c></tag>
+                  <item><p>User-defined signal 1</p></item>
+                  <tag><c>sigusr2</c></tag>
+                  <item><p>User-defined signal 2</p></item>
+                  <tag><c>sigchld</c></tag>
+                  <item><p>Child process stopped or terminated</p></item>
+                  <tag><c>sigstop</c></tag>
+                  <item><p>Stop process</p></item>
+                  <tag><c>sigtstp</c></tag>
+                  <item><p>Stop typed at terminal</p></item>
+              </taglist>
+
+              <p>Setting OS signals are described in <seealso marker="os#set_signal/2"><c>os:set_signal/2</c></seealso>.</p>
+          </section>
   </section>
 
   <section>
@@ -405,4 +459,3 @@ MaxT = TickTime + TickTime / 4</code>
       <seealso marker="stdlib:timer"><c>timer(3)</c></seealso></p>
   </section>
 </appref>
-

--- a/lib/kernel/doc/src/os.xml
+++ b/lib/kernel/doc/src/os.xml
@@ -11,7 +11,7 @@
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.
       You may obtain a copy of the License at
- 
+
           http://www.apache.org/licenses/LICENSE-2.0
 
       Unless required by applicable law or agreed to in writing, software
@@ -19,7 +19,7 @@
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
       See the License for the specific language governing permissions and
       limitations under the License.
-    
+
     </legalnotice>
 
     <title>os</title>
@@ -152,6 +152,32 @@ DirOut = os:cmd("dir"), % on Win32 platform</code>
 	<p>On Unix platforms, the environment is set using UTF-8 encoding
 	  if Unicode filename translation is in effect. On Windows, the
 	  environment is set using wide character interfaces.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="set_signal" arity="2"/>
+      <fsummary>Enables or disables handling of OS signals.</fsummary>
+      <desc>
+          <p>Enables or disables OS signals.</p>
+          <p>Each signal my be set to one of the following options:</p>
+          <taglist>
+              <tag><c>ignore</c></tag>
+              <item>
+                  This signal will be ignored.
+              </item>
+
+              <tag><c>default</c></tag>
+              <item>
+                  This signal will use the default signal handler for the operating system.
+              </item>
+
+              <tag><c>handle</c></tag>
+              <item>
+                  This signal will notify <c>erl_signal_server</c> when it is received by
+                  the Erlang runtime system.
+              </item>
+          </taglist>
       </desc>
     </func>
 
@@ -296,4 +322,3 @@ calendar:now_to_universal_time(TS),
     </func>
   </funcs>
 </erlref>
-

--- a/lib/kernel/src/Makefile
+++ b/lib/kernel/src/Makefile
@@ -71,6 +71,7 @@ MODULES = \
 	erl_distribution \
 	erl_epmd \
 	erl_reply \
+	erl_signal_handler \
 	erts_debug \
 	error_handler \
 	error_logger \

--- a/lib/kernel/src/erl_signal_handler.erl
+++ b/lib/kernel/src/erl_signal_handler.erl
@@ -1,0 +1,47 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2013. All Rights Reserved.
+%%
+%% The contents of this file are subject to the Erlang Public License,
+%% Version 1.1, (the "License"); you may not use this file except in
+%% compliance with the License. You should have received a copy of the
+%% Erlang Public License along with this software. If not, it can be
+%% retrieved online at http://www.erlang.org/.
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(erl_signal_handler).
+-behaviour(gen_event).
+-export([init/1, format_status/2,
+         handle_event/2, handle_call/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state,{}).
+
+init(_Args) ->
+    {ok, #state{}}.
+
+handle_event(_SignalMsg, S) ->
+    {ok, S}.
+
+handle_info(_Info, S) ->
+    {ok, S}.
+
+handle_call(_Request, S) ->
+    {ok, ok, S}.
+
+format_status(_Opt, [_Pdict,_S]) ->
+    ok.
+
+code_change(_OldVsn, S, _Extra) ->
+    {ok, S}.
+
+terminate(_Args, _S) ->
+    ok.

--- a/lib/kernel/src/erl_signal_handler.erl
+++ b/lib/kernel/src/erl_signal_handler.erl
@@ -31,6 +31,9 @@ init(_Args) ->
 handle_event(sigusr1, S) ->
     erlang:halt("Received SIGUSR1"),
     {ok, S};
+handle_event(sigquit, S) ->
+    erlang:halt(),
+    {ok, S};
 handle_event(sigterm, S) ->
     error_logger:info_msg("SIGTERM received - shutting down~n"),
     ok = init:stop(),

--- a/lib/kernel/src/erl_signal_handler.erl
+++ b/lib/kernel/src/erl_signal_handler.erl
@@ -28,6 +28,10 @@
 init(_Args) ->
     {ok, #state{}}.
 
+handle_event(sigterm, S) ->
+    error_logger:info_msg("SIGTERM received - shutting down~n"),
+    ok = init:stop(),
+    {ok, S};
 handle_event(_SignalMsg, S) ->
     {ok, S}.
 

--- a/lib/kernel/src/erl_signal_handler.erl
+++ b/lib/kernel/src/erl_signal_handler.erl
@@ -28,6 +28,9 @@
 init(_Args) ->
     {ok, #state{}}.
 
+handle_event(sigusr1, S) ->
+    erlang:halt("Received SIGUSR1"),
+    {ok, S};
 handle_event(sigterm, S) ->
     error_logger:info_msg("SIGTERM received - shutting down~n"),
     ok = init:stop(),

--- a/lib/kernel/src/kernel.app.src
+++ b/lib/kernel/src/kernel.app.src
@@ -34,6 +34,7 @@
 	     erl_boot_server,
 	     erl_distribution,
 	     erl_reply,
+             erl_signal_handler,
 	     error_handler,
 	     error_logger,
 	     file,

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -29,7 +29,7 @@
 
 -export([getenv/0, getenv/1, getenv/2, getpid/0,
          perf_counter/0, perf_counter/1,
-         putenv/2, system_time/0, system_time/1,
+         putenv/2, set_signal/2, system_time/0, system_time/1,
 	 timestamp/0, unsetenv/1]).
 
 -spec getenv() -> [string()].
@@ -102,6 +102,15 @@ timestamp() ->
       VarName :: string().
 
 unsetenv(_) ->
+    erlang:nif_error(undef).
+
+-spec set_signal(Signal, Option) -> 'ok' when
+      Signal :: 'sighup'  | 'sigquit' | 'sigabrt' | 'sigalrm' |
+                'sigterm' | 'sigusr1' | 'sigusr2' | 'sigchld' |
+                'sigstop' | 'sigtstp',
+      Option :: 'default' | 'handle' | 'ignore'.
+
+set_signal(_Signal, _Option) ->
     erlang:nif_error(undef).
 
 %%% End of BIFs


### PR DESCRIPTION
In todays Erlang runtime system OS signals cannot be handled by an Erlang developer. Some signals are used internally by `erts`, for instance
* `SIGUSR1` is used to generate crashdumps,
* `SIGUSR2` is used to halt threads in a crashdump,
* `SIGQUIT` is used to halt Erlang immediately,
* `SIGINT` is used for a break-handler which is only intended to be used for debugging and
* `SIGTERM` (from 19.3) will halt Erlang via init:stop/0.

With this PR a `gen_event` server, `erl_signal_server`, is started to handle enabled signals from the operating system. A default handler is installed to mimic the previous behavior of above signals except for `SIGINT`. The break-handler still uses `SIGINT` internally.

Subscribable signals with this PR are: `SIGHUP`, `SIGILL`, `SIGABRT`, `SIGALRM`, `SIGTERM`, `SIGQUIT`, `SIGUSR1`, `SIGUSR2`, `SIGCHLD`, `SIGSTOP`, `SIGTSTP`.

Signals can be enabled with `erts_internal:set_signal(Signal, Option)`, where `Signal` is any subscribable signal, i.e. `sighup` or `sigusr1`, and `Option` is one of `handle`, `ignore` or `default`. By setting `handle` for a signal it means that a notification will be sent to `erl_signal_server` once that signal has been received from the OS.

Names are up for debate of course. As is the usability of this feature. `SIGTERM` and `SIGHUP` was the initial driving force for this.