### PR TITLE
add proplist typespec to doc

### DIFF
--- a/lib/stdlib/src/proplists.erl
+++ b/lib/stdlib/src/proplists.erl
@@ -39,6 +39,7 @@
 %% etc.</p>
 %%
 %% % @type property() = atom() | tuple()
+%% % @type proplist() = [property()]
 
 -module(proplists).
 


### PR DESCRIPTION
I suppose proplist type spec is forgotten, as it is exported and not mentioned in the documentation.
I use it all over my programms in spec and I think I am not alone.