### PR TITLE
Simplify interface to beam_asm by using maps

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1361,7 +1361,16 @@ beam_asm(#compile{ifile=File,code=Code0,
 			 (Other) -> Other
 		      end, Opts0),
     Opts2 = [O || O <- Opts1, effects_code_generation(O)],
-    case beam_asm:module(Code0, Abst, Source, Opts2) of
+    {Mod,Exp,Attr,Asm,NumLabels} = Code0,
+    case beam_asm:module(#{mod => Mod,
+                           exp => Exp,
+                           attr => Attr,
+                           asm => Asm,
+                           num_labels => NumLabels,
+                           abst => Abst,
+                           source_file => Source,
+                           opts => Opts2})
+    of
 	{ok,Code} -> {ok,St#compile{code=Code,abstract_code=[]}}
     end.
 


### PR DESCRIPTION
@bjorng I first made this patch to use in my records-chunk branch, but then it got conflicts with changes you had made upstream, so I dropped it. I just want to check if you like the idea; in that case we could use it across all the passes, not just here. A map is much more flexible than the ugly Code tuple currently used, making it easy to add new information to pass on between passes.