### PR TITLE
Update inet.xml. Note buffer relation to MTU

### DIFF
--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -659,7 +659,8 @@ get_tcpi_sacked(Sock) ->
           <tag><c>{buffer, Size}</c></tag>
           <item>
             <p>The size of the user-level software buffer used by
-              the driver. Not to be confused with options <c>sndbuf</c>
+              the driver. The default is 1460. 
+              Not to be confused with options <c>sndbuf</c>
               and <c>recbuf</c>, which correspond to the
               Kernel socket buffers. It is recommended
               to have <c>val(buffer) &gt;= max(val(sndbuf),val(recbuf))</c> to
@@ -670,6 +671,9 @@ get_tcpi_sacked(Sock) ->
               usually become larger, you are encouraged to use
               <seealso marker="#getopts/2"><c>getopts/2</c></seealso>
               to analyze the behavior of your operating system.</p>
+            <p>Note that this is also the maximum amount of data that can be
+	       received from a single recv call. If you are using higher than 
+	       normal MTU consider setting buffer higher.</p> 
           </item>
           <tag><c>{delay_send, Boolean}</c></tag>
           <item>


### PR DESCRIPTION
The documentation does not indicate this is the buffer responsible for the maximum bytes we can receive from a recv call.