### PR TITLE
Store messages for 'rex' and 'error_logger' off heap

### DIFF
--- a/lib/kernel/src/error_logger.erl
+++ b/lib/kernel/src/error_logger.erl
@@ -360,8 +360,12 @@ init(Max) when is_integer(Max) ->
 %% go back.
 init({go_back, _PostState}) ->  
     {ok, {?buffer_size, 0, []}};
-init(_) ->  %% Start and just relay to other
-    {ok, []}.             %% node if node(GLeader) =/= node().
+init(_) ->
+    %% The error logger process may receive a huge amount of
+    %% messages. Make sure that they are stored off heap to
+    %% avoid exessive GCs.
+    process_flag(message_queue_data, off_heap),
+    {ok, []}.
 
 -spec handle_event(term(), state()) -> {'ok', state()}.
 

--- a/lib/kernel/src/rpc.erl
+++ b/lib/kernel/src/rpc.erl
@@ -67,17 +67,27 @@
 
 %%------------------------------------------------------------------------
 
+
+%% The rex server may receive a huge amount of
+%% messages. Make sure that they are stored off heap to
+%% avoid exessive GCs.
+
+-define(SPAWN_OPTS, [{spawn_opt,[{message_queue_data,off_heap}]}]).
+
 %% Remote execution and broadcasting facility
 
 -spec start() -> {'ok', pid()} | 'ignore' | {'error', term()}.
 
 start() ->
-    gen_server:start({local,?NAME}, ?MODULE, [], []).
+    gen_server:start({local,?NAME}, ?MODULE, [], ?SPAWN_OPTS).
 
 -spec start_link() -> {'ok', pid()} | 'ignore' | {'error', term()}.
 
 start_link() ->
-    gen_server:start_link({local,?NAME}, ?MODULE, [], []).
+    %% The rex server process may receive a huge amount of
+    %% messages. Make sure that they are stored off heap to
+    %% avoid exessive GCs.
+    gen_server:start_link({local,?NAME}, ?MODULE, [], ?SPAWN_OPTS).
 
 -spec stop() -> term().
 

--- a/lib/kernel/test/error_logger_SUITE.erl
+++ b/lib/kernel/test/error_logger_SUITE.erl
@@ -30,6 +30,7 @@
 
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
 	 init_per_group/2,end_per_group/2, 
+         off_heap/1,
 	 error_report/1, info_report/1, error/1, info/1,
 	 emulator/1, tty/1, logfile/1, add/1, delete/1]).
 
@@ -45,7 +46,7 @@ suite() ->
      {timetrap,{minutes,1}}].
 
 all() -> 
-    [error_report, info_report, error, info, emulator, tty,
+    [off_heap, error_report, info_report, error, info, emulator, tty,
      logfile, add, delete].
 
 groups() -> 
@@ -63,6 +64,16 @@ init_per_group(_GroupName, Config) ->
 end_per_group(_GroupName, Config) ->
     Config.
 
+
+%%-----------------------------------------------------------------
+
+off_heap(_Config) ->
+    %% The error_logger process may receive a huge amount of
+    %% messages. Make sure that they are stored off heap to
+    %% avoid exessive GCs.
+    MQD = message_queue_data,
+    {MQD,off_heap} = process_info(whereis(error_logger), MQD),
+    ok.
 
 %%-----------------------------------------------------------------
 

--- a/lib/kernel/test/rpc_SUITE.erl
+++ b/lib/kernel/test/rpc_SUITE.erl
@@ -21,7 +21,8 @@
 
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
 	 init_per_group/2,end_per_group/2]).
--export([call/1, block_call/1, multicall/1, multicall_timeout/1, 
+-export([off_heap/1,
+         call/1, block_call/1, multicall/1, multicall_timeout/1,
 	 multicall_dies/1, multicall_node_dies/1,
 	 called_dies/1, called_node_dies/1, 
 	 called_throws/1, call_benchmark/1, async_call/1]).
@@ -35,7 +36,7 @@ suite() ->
      {timetrap,{minutes,2}}].
 
 all() -> 
-    [call, block_call, multicall, multicall_timeout,
+    [off_heap, call, block_call, multicall, multicall_timeout,
      multicall_dies, multicall_node_dies, called_dies,
      called_node_dies, called_throws, call_benchmark,
      async_call].
@@ -55,6 +56,13 @@ init_per_group(_GroupName, Config) ->
 end_per_group(_GroupName, Config) ->
     Config.
 
+off_heap(_Config) ->
+    %% The rex server process may receive a huge amount of
+    %% messages. Make sure that they are stored off heap to
+    %% avoid exessive GCs.
+    MQD = message_queue_data,
+    {MQD,off_heap} = process_info(whereis(rex), MQD),
+    ok.
 
 
 %% Test different rpc calls.


### PR DESCRIPTION
Performance for processes that receive huge amounts of
messages can be increased by storing the incoming messages
outside the heap (that avoids copying the message in a
garbage collection).

Two OTP processes that are known to receive many messages
are 'rex' (used by 'rpc') and 'error_logger'.