### PR TITLE
XML namespace may, but need not, be declared

### DIFF
--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -2309,6 +2309,8 @@ expanded_name(Name, [], #xmlNamespace{default = URI}, S) ->
 expanded_name(Name, N = {"xmlns", Local}, #xmlNamespace{nodes = Ns}, S) ->
     {_, Value} = lists:keyfind(Local, 1, Ns),
     case Name of
+	'xmlns:xml' when Value =:= 'http://www.w3.org/XML/1998/namespace' ->
+	    N;
 	'xmlns:xml' when Value =/= 'http://www.w3.org/XML/1998/namespace' ->
 	    ?fatal({xml_prefix_cannot_be_redeclared, Value}, S);
 	'xmlns:xmlns' ->
@@ -2323,6 +2325,9 @@ expanded_name(Name, N = {"xmlns", Local}, #xmlNamespace{nodes = Ns}, S) ->
 		    N
 	    end
     end;
+expanded_name(_Name, {"xml", Local}, _NS, _S) ->
+    % XML namespace can be implicit.
+    {'http://www.w3.org/XML/1998/namespace', list_to_atom(Local)};
 expanded_name(_Name, {Prefix, Local}, #xmlNamespace{nodes = Ns}, S) ->
     case lists:keysearch(Prefix, 1, Ns) of
 	{value, {_, URI}} ->

--- a/lib/xmerl/test/xmerl_SUITE.erl
+++ b/lib/xmerl/test/xmerl_SUITE.erl
@@ -55,7 +55,7 @@ groups() ->
      {misc, [],
       [latin1_alias, syntax_bug1, syntax_bug2, syntax_bug3,
        pe_ref1, copyright, testXSEIF, export_simple1, export,
-       default_attrs_bug]},
+       default_attrs_bug, implicit_xml_ns, explicit_xml_ns]},
      {eventp_tests, [], [sax_parse_and_export]},
      {ticket_tests, [],
       [ticket_5998, ticket_7211, ticket_7214, ticket_7430,
@@ -238,6 +238,34 @@ default_attrs_bug(Config) ->
                                #xmlAttribute{name = a, value = "explicit"}]},
      []
     } = xmerl_scan:string(Doc2, [{default_attrs, true}]).
+
+implicit_xml_ns(Config) ->
+    {#xmlElement{attributes = [#xmlAttribute{
+        name = 'xml:lang',
+        expanded_name = {'http://www.w3.org/XML/1998/namespace', lang},
+        nsinfo = {"xml", "lang"},
+        namespace = #xmlNamespace{default = [], nodes = []}
+     }]},
+     []
+    } = xmerl_scan:string("<a xml:lang='en_US'/>", [{namespace_conformant, true}]).
+
+explicit_xml_ns(Config) ->
+    {#xmlElement{attributes = [
+      #xmlAttribute{
+        name = 'xml:lang',
+        expanded_name = {'http://www.w3.org/XML/1998/namespace', lang},
+        nsinfo = {"xml", "lang"},
+        namespace = #xmlNamespace{default = [], nodes = [{"xml", 'http://www.w3.org/XML/1998/namespace'}]}
+      },
+      #xmlAttribute{
+        name = 'xmlns:xml',
+        expanded_name = {"xmlns", "xml"},
+        nsinfo = {"xmlns", "xml"},
+        namespace = #xmlNamespace{default = [], nodes = [{"xml", 'http://www.w3.org/XML/1998/namespace'}]}
+      }
+     ]},
+     []
+    } = xmerl_scan:string("<a xml:lang='en_US' xmlns:xml='http://www.w3.org/XML/1998/namespace'/>", [{namespace_conformant, true}]).
 
 pe_ref1(Config) ->
     file:set_cwd(datadir(Config)),


### PR DESCRIPTION
In xmerl application, the namespace declaration
xmlns:xml="http://www.w3.org/XML/1998/namespace"
should be assumed as implicit, when processing
elements with no explicit XML namespace declaration.

The parser should also allow to declare the xml
namespace if its value matches the reserved one.

See https://www.w3.org/TR/xml-names/#xmlReserved