### PR TITLE
Fix observer term conversion error spelling

### DIFF
--- a/lib/observer/src/cdv_bin_cb.erl
+++ b/lib/observer/src/cdv_bin_cb.erl
@@ -58,7 +58,7 @@ binary_to_term_fun(Bin) ->
 	    try binary_to_term(Bin) of
 		Term -> plain_html(io_lib:format("~p",[Term]))
 	    catch error:badarg ->
-		    Warning = "This binary can not be coverted to an Erlang term",
+		    Warning = "This binary can not be converted to an Erlang term",
 		    observer_html_lib:warning(Warning)
 	    end
     end.


### PR DESCRIPTION
In the observer UI, when inspecting state, the error given when attempting to convert a bad term contains a spelling mistake.