### PR TITLE
Include more otp_SUITE tests cases in the smoke test

### DIFF
--- a/erts/test/system_smoke.spec
+++ b/erts/test/system_smoke.spec
@@ -1,3 +1,8 @@
 {suites,"../system_test",[ethread_SUITE]}.
-{cases,"../system_test",otp_SUITE,[undefined_functions]}.
+{cases,"../system_test",otp_SUITE,
+ [undefined_functions,
+  deprecated_not_in_obsolete,
+  obsolete_but_not_deprecated,
+  call_to_size_1,
+  call_to_now_0]}.
 {skip_cases,"../system_test",ethread_SUITE,[max_threads],"Skip"}.


### PR DESCRIPTION
For the benefit of Travis CI, include more test cases from
otp_SUITE in the smoke test. That will avoid having to run
a pull request through the daily builds to find those kind
of minor issues.