### PR TITLE
Reduce size of the log file for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
   - kerl_deactivate
 
 script:
-  - ./otp_build all -a
+  - ./scripts/build-otp
   
 after_success:
   - $ERL_TOP/bin/dialyzer --build_plt --apps asn1 compiler crypto dialyzer edoc erts et hipe inets kernel mnesia observer public_key runtime_tools snmp ssh ssl stdlib syntax_tools wx xmerl --statistics

--- a/scripts/build-otp
+++ b/scripts/build-otp
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+function do_and_log {
+    log="scripts/latest-log.$$"
+    echo -n "$1... "
+    if ./otp_build $2 $3 >$log 2>&1; then
+        echo "done."
+    else
+        echo "failed."
+        tail -n 200 $log
+        echo "*** Failed ***"
+        exit 1
+    fi
+}
+
+do_and_log "Autoconfing" autoconf
+do_and_log "Configuring" configure
+do_and_log "Building OTP" boot -a
+
+exit 0


### PR DESCRIPTION
The huge log files are problematic. Add shell scripts that
captures the log output to a temporary file and only display
the log file if an error occurs.