### PR TITLE
Types chunk

### DIFF
--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -21,7 +21,7 @@
 
 -module(beam_asm).
 
--export([module/6]).
+-export([module/8]).
 -export([encode/2]).
 
 -export_type([fail/0,label/0,reg/0,src/0,module_code/0,function_name/0]).
@@ -59,20 +59,28 @@
 
 -type records() :: [erl_parse:abstract_form()].
 
--spec module(module_code(), records(), exports(), [_], [compile:option()], [compile:option()]) ->
+-type fa()   :: {atom(), arity()}.   % function+arity
+-type ta()   :: {atom(), arity()}.   % type+arity
+
+-type types() :: [{ta(), string()}].
+
+-type specs() :: [{fa(), string()}].
+
+-spec module(module_code(), types(), specs(), records(), exports(), [_],
+             [compile:option()], [compile:option()]) ->
                     {'ok',binary()}.
 
-module(Code, Records, Abst, SourceFile, Opts, CompilerOpts) ->
-    {ok, assemble(Code, Records, Abst, SourceFile, Opts, CompilerOpts)}.
+module(Code, Types, Specs, Records, Abst, SourceFile, Opts, CompilerOpts) ->
+    {ok, assemble(Code, Types, Specs, Records, Abst, SourceFile, Opts, CompilerOpts)}.
 
-assemble({Mod,Exp0,Attr0,Asm0,NumLabels}, Records, Abst, SourceFile, Opts, CompilerOpts) ->
+assemble({Mod,Exp0,Attr0,Asm0,NumLabels}, Types, Specs, Records, Abst, SourceFile, Opts, CompilerOpts) ->
     {1,Dict0} = beam_dict:atom(Mod, beam_dict:new()),
     {0,Dict1} = beam_dict:fname(atom_to_list(Mod) ++ ".erl", Dict0),
     NumFuncs = length(Asm0),
     {Asm,Attr} = on_load(Asm0, Attr0),
     Exp = cerl_sets:from_list(Exp0),
     {Code,Dict2} = assemble_1(Asm, Exp, Dict1, []),
-    build_file(Code, Attr, Dict2, NumLabels, NumFuncs, Records, Abst, SourceFile, Opts, CompilerOpts).
+    build_file(Code, Attr, Dict2, NumLabels, NumFuncs, Types, Specs, Records, Abst, SourceFile, Opts, CompilerOpts).
 
 on_load(Fs0, Attr0) ->
     case proplists:get_value(on_load, Attr0) of
@@ -115,7 +123,7 @@ assemble_function([H|T], Acc, Dict0) ->
 assemble_function([], Code, Dict) ->
     {Code, Dict}.
 
-build_file(Code, Attr, Dict, NumLabels, NumFuncs, Records, Abst, SourceFile, Opts, CompilerOpts) ->
+build_file(Code, Attr, Dict, NumLabels, NumFuncs, Types, Specs, Records, Abst, SourceFile, Opts, CompilerOpts) ->
     %% Create the code chunk.
 
     CodeChunk = chunk(<<"Code">>,
@@ -188,6 +196,8 @@ build_file(Code, Attr, Dict, NumLabels, NumFuncs, Records, Abst, SourceFile, Opt
     Essentials = finalize_fun_table(Essentials1, MD5),
     {Attributes,Compile} = build_attributes(Opts, SourceFile, Attr, MD5),
     AttrChunk = chunk(<<"Attr">>, Attributes),
+    TypesChunk = types_chunk(Types),
+    SpecsChunk = specs_chunk(Specs),
     RecsChunk = records_chunk(Records),
     CompileChunk = chunk(<<"CInf">>, Compile),
 
@@ -200,7 +210,8 @@ build_file(Code, Attr, Dict, NumLabels, NumFuncs, Records, Abst, SourceFile, Opt
 		 true ->
 		     [Essentials,AttrChunk,AbstChunk];
 		 false ->
-		     [Essentials,LocChunk,AttrChunk,RecsChunk,
+		     [Essentials,LocChunk,AttrChunk,
+                      TypesChunk,SpecsChunk,RecsChunk,
 		      CompileChunk,AbstChunk,LineChunk]
 	     end,
     build_form(<<"BEAM">>, Chunks).
@@ -213,6 +224,16 @@ atom_encoding(Opts) ->
 
 atom_chunk_name(utf8) -> <<"AtU8">>;
 atom_chunk_name(latin1) -> <<"Atom">>.
+
+types_chunk([]) ->
+    <<>>;
+types_chunk(Types) ->
+    chunk(<<"Type">>, term_to_binary({raw_types_v1, Types})).
+
+specs_chunk([]) ->
+    <<>>;
+specs_chunk(Specs) ->
+    chunk(<<"Spec">>, term_to_binary({raw_specs_v1, Specs})).
 
 records_chunk([]) ->
     <<>>;

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -21,7 +21,7 @@
 
 -module(beam_asm).
 
--export([module/5]).
+-export([module/6]).
 -export([encode/2]).
 
 -export_type([fail/0,label/0,reg/0,src/0,module_code/0,function_name/0]).
@@ -57,20 +57,22 @@
 -type module_code() ::
         {module(),[_],[_],[asm_function()],pos_integer()}.
 
--spec module(module_code(), exports(), [_], [compile:option()], [compile:option()]) ->
+-type records() :: [erl_parse:abstract_form()].
+
+-spec module(module_code(), records(), exports(), [_], [compile:option()], [compile:option()]) ->
                     {'ok',binary()}.
 
-module(Code, Abst, SourceFile, Opts, CompilerOpts) ->
-    {ok,assemble(Code, Abst, SourceFile, Opts, CompilerOpts)}.
+module(Code, Records, Abst, SourceFile, Opts, CompilerOpts) ->
+    {ok, assemble(Code, Records, Abst, SourceFile, Opts, CompilerOpts)}.
 
-assemble({Mod,Exp0,Attr0,Asm0,NumLabels}, Abst, SourceFile, Opts, CompilerOpts) ->
+assemble({Mod,Exp0,Attr0,Asm0,NumLabels}, Records, Abst, SourceFile, Opts, CompilerOpts) ->
     {1,Dict0} = beam_dict:atom(Mod, beam_dict:new()),
     {0,Dict1} = beam_dict:fname(atom_to_list(Mod) ++ ".erl", Dict0),
     NumFuncs = length(Asm0),
     {Asm,Attr} = on_load(Asm0, Attr0),
     Exp = cerl_sets:from_list(Exp0),
     {Code,Dict2} = assemble_1(Asm, Exp, Dict1, []),
-    build_file(Code, Attr, Dict2, NumLabels, NumFuncs, Abst, SourceFile, Opts, CompilerOpts).
+    build_file(Code, Attr, Dict2, NumLabels, NumFuncs, Records, Abst, SourceFile, Opts, CompilerOpts).
 
 on_load(Fs0, Attr0) ->
     case proplists:get_value(on_load, Attr0) of
@@ -113,7 +115,7 @@ assemble_function([H|T], Acc, Dict0) ->
 assemble_function([], Code, Dict) ->
     {Code, Dict}.
 
-build_file(Code, Attr, Dict, NumLabels, NumFuncs, Abst, SourceFile, Opts, CompilerOpts) ->
+build_file(Code, Attr, Dict, NumLabels, NumFuncs, Records, Abst, SourceFile, Opts, CompilerOpts) ->
     %% Create the code chunk.
 
     CodeChunk = chunk(<<"Code">>,
@@ -186,6 +188,7 @@ build_file(Code, Attr, Dict, NumLabels, NumFuncs, Abst, SourceFile, Opts, Compil
     Essentials = finalize_fun_table(Essentials1, MD5),
     {Attributes,Compile} = build_attributes(Opts, SourceFile, Attr, MD5),
     AttrChunk = chunk(<<"Attr">>, Attributes),
+    RecsChunk = records_chunk(Records),
     CompileChunk = chunk(<<"CInf">>, Compile),
 
     %% Create the abstract code chunk.
@@ -193,12 +196,11 @@ build_file(Code, Attr, Dict, NumLabels, NumFuncs, Abst, SourceFile, Opts, Compil
     AbstChunk = chunk(<<"Abst">>, Abst),
 
     %% Create IFF chunk.
-
     Chunks = case member(slim, Opts) of
 		 true ->
 		     [Essentials,AttrChunk,AbstChunk];
 		 false ->
-		     [Essentials,LocChunk,AttrChunk,
+		     [Essentials,LocChunk,AttrChunk,RecsChunk,
 		      CompileChunk,AbstChunk,LineChunk]
 	     end,
     build_form(<<"BEAM">>, Chunks).
@@ -211,6 +213,11 @@ atom_encoding(Opts) ->
 
 atom_chunk_name(utf8) -> <<"AtU8">>;
 atom_chunk_name(latin1) -> <<"Atom">>.
+
+records_chunk([]) ->
+    <<>>;
+records_chunk(Records) ->
+    chunk(<<"Recs">>, term_to_binary({raw_records_v1, Records})).
 
 %% finalize_fun_table(Essentials, MD5) -> FinalizedEssentials
 %%  Update the 'old_uniq' field in the entry for each fun in the

--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -68,7 +68,7 @@
                    | 'exports' | 'labeled_exports'
                    | 'imports' | 'indexed_imports'
                    | 'locals' | 'labeled_locals'
-                   | 'atoms' | 'records'.
+                   | 'atoms' | 'types' | 'specs' | 'records'.
 -type chunkref()  :: chunkname() | chunkid().
 
 -type attrib_entry()   :: {Attribute :: atom(), [AttributeValue :: term()]}.
@@ -85,7 +85,9 @@
                    | {'indexed_imports', [{index(), module(), Function :: atom(), arity()}]}
                    | {'locals', [{atom(), arity()}]}
                    | {'labeled_locals', [labeled_entry()]}
-                   | {'records', [{atom(), [atom()]}]}
+                   | {'types', [erl_parse:abstract_form()]}
+                   | {'specs', [erl_parse:abstract_form()]}
+                   | {'records', [erl_parse:abstract_form()]}
                    | {'atoms', [{integer(), atom()}]}.
 
 %% Error reasons
@@ -686,6 +688,22 @@ chunk_to_data(atoms=Id, _Chunk, _File, Cs, AtomTable0, _Mod) ->
     AtomTable = ensure_atoms(AtomTable0, Cs),
     Atoms = ets:tab2list(AtomTable),
     {AtomTable, {Id, lists:sort(Atoms)}};
+chunk_to_data(types=Id, Chunk, File, _Cs, AtomTable, _Mod) ->
+    try
+	{raw_types_v1, Records} = binary_to_term(Chunk),
+	{AtomTable, {Id, lists:sort(Records)}}
+    catch
+	error:_ ->
+	    error({invalid_chunk, File, chunk_name_to_id(Id, File)})
+    end;
+chunk_to_data(specs=Id, Chunk, File, _Cs, AtomTable, _Mod) ->
+    try
+	{raw_specs_v1, Records} = binary_to_term(Chunk),
+	{AtomTable, {Id, lists:sort(Records)}}
+    catch
+	error:_ ->
+	    error({invalid_chunk, File, chunk_name_to_id(Id, File)})
+    end;
 chunk_to_data(records=Id, Chunk, File, _Cs, AtomTable, _Mod) ->
     try
 	{raw_records_v1, Records} = binary_to_term(Chunk),
@@ -715,6 +733,8 @@ chunk_name_to_id(labeled_locals, _)  -> "LocT";
 chunk_name_to_id(attributes, _)      -> "Attr";
 chunk_name_to_id(abstract_code, _)   -> "Abst";
 chunk_name_to_id(compile_info, _)    -> "CInf";
+chunk_name_to_id(types, _)           -> "Type";
+chunk_name_to_id(specs, _)           -> "Spec";
 chunk_name_to_id(records, _)         -> "Recs";
 chunk_name_to_id(Other, File) -> 
     error({unknown_chunk, File, Other}).

--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -68,7 +68,7 @@
                    | 'exports' | 'labeled_exports'
                    | 'imports' | 'indexed_imports'
                    | 'locals' | 'labeled_locals'
-                   | 'atoms'.
+                   | 'atoms' | 'records'.
 -type chunkref()  :: chunkname() | chunkid().
 
 -type attrib_entry()   :: {Attribute :: atom(), [AttributeValue :: term()]}.
@@ -85,6 +85,7 @@
                    | {'indexed_imports', [{index(), module(), Function :: atom(), arity()}]}
                    | {'locals', [{atom(), arity()}]}
                    | {'labeled_locals', [labeled_entry()]}
+                   | {'records', [{atom(), [atom()]}]}
                    | {'atoms', [{integer(), atom()}]}.
 
 %% Error reasons
@@ -685,6 +686,14 @@ chunk_to_data(atoms=Id, _Chunk, _File, Cs, AtomTable0, _Mod) ->
     AtomTable = ensure_atoms(AtomTable0, Cs),
     Atoms = ets:tab2list(AtomTable),
     {AtomTable, {Id, lists:sort(Atoms)}};
+chunk_to_data(records=Id, Chunk, File, _Cs, AtomTable, _Mod) ->
+    try
+	{raw_records_v1, Records} = binary_to_term(Chunk),
+	{AtomTable, {Id, lists:sort(Records)}}
+    catch
+	error:_ ->
+	    error({invalid_chunk, File, chunk_name_to_id(Id, File)})
+    end;
 chunk_to_data(ChunkName, Chunk, File,
 	      Cs, AtomTable, _Mod) when is_atom(ChunkName) ->
     case catch symbols(Chunk, AtomTable, Cs, ChunkName) of
@@ -706,6 +715,7 @@ chunk_name_to_id(labeled_locals, _)  -> "LocT";
 chunk_name_to_id(attributes, _)      -> "Attr";
 chunk_name_to_id(abstract_code, _)   -> "Abst";
 chunk_name_to_id(compile_info, _)    -> "CInf";
+chunk_name_to_id(records, _)         -> "Recs";
 chunk_name_to_id(Other, File) -> 
     error({unknown_chunk, File, Other}).
 

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -1213,26 +1213,35 @@ find_file(File) ->
 read_file_records(File, Opts) ->
     case filename:extension(File) of
         ".beam" ->
-            case beam_lib:chunks(File, [abstract_code,"CInf"]) of
-                {ok,{_Mod,[{abstract_code,{Version,Forms}},{"CInf",CB}]}} ->
-                    case record_attrs(Forms) of
-                        [] when Version =:= raw_abstract_v1 ->
-                            [];
-                        [] -> 
-                            %% If the version is raw_X, then this test
-                            %% is unnecessary.
-                            try_source(File, CB);
-                        Records -> 
-                            Records
-                    end;
-                {ok,{_Mod,[{abstract_code,no_abstract_code},{"CInf",CB}]}} ->
-                    try_source(File, CB);
-                Error ->
-                    %% Could be that the "Abst" chunk is missing (pre R6).
-                    Error
+            case beam_lib:chunks(File, [records]) of
+                {ok,{_Mod,[{records,Records}]}} ->
+                    Records;
+                _ ->
+                    %% could be that the "Recs" chunk is missing
+                    try_abstract_code(File)
             end;
         _ ->
             parse_file(File, Opts)
+    end.
+
+try_abstract_code(File) ->
+    case beam_lib:chunks(File, [abstract_code,"CInf"]) of
+        {ok,{_Mod,[{abstract_code,{Version,Forms}},{"CInf",CB}]}} ->
+            case record_attrs(Forms) of
+                [] when Version =:= raw_abstract_v1 ->
+                    [];
+                [] -> 
+                    %% If the version is raw_X, then this test
+                    %% is unnecessary.
+                    try_source(File, CB);
+                Records -> 
+                    Records
+            end;
+        {ok,{_Mod,[{abstract_code,no_abstract_code},{"CInf",CB}]}} ->
+            try_source(File, CB);
+        Error ->
+            %% Could be that the "Abst" chunk is missing (pre R6).
+            Error
     end.
 
 %% This is how the debugger searches for source files. See int.erl.

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -739,7 +739,8 @@ used_record_defs(E, RT) ->
 used_records(E, U0, RT) ->
     case used_records(E) of
         {name,Name,E1} ->
-            U = used_records(ets:lookup(RT, Name), [Name | U0], RT),
+            [{_,Attr}] = ets:lookup(RT, Name),
+            U = used_records(Attr, [Name | U0], RT),
             used_records(E1, U, RT);
         {expr,[E1 | Es]} ->
             used_records(Es, used_records(E1, U0, RT), RT);


### PR DESCRIPTION
This is another experimental branch to continue the discussion, based on the latest version of the #1310 branch (adding a records chunk). In this branch I have also added (separate) chunks for types and for specs. Here I have used a text representation for the info in the chunks, and also changed the record chunk to use text. For example:
```
    2> beam_lib:chunks(foo,[types]).
    {ok,{foo,[{types,[{{bork,0},"-type bork() :: [urk()].\n"},
                      {{urk,0},"-opaque urk() :: any().\n"}]}]}}
    3> beam_lib:chunks(foo,[specs]).  
    {ok,{foo,[{specs,[{{f,0},"-spec f() -> bork().\n"}]}]}}
    4> beam_lib:chunks(foo,[records]).
    {ok,{foo,[{records,[{urk,"-record(urk,{x=0,y,z=undefined}).\n"}]}]}}
```
Only specs for exported functions and exported types and opaques are included.
Note that the opaque type has been changed to `:: any()` to hide the actual implementation. If a record field is initialized by a nonconstant expression, it is replaced with 'undefined'.