### PR TITLE
Fixed typos across code comments and docs

### DIFF
--- a/bootstrap/lib/kernel/include/inet.hrl
+++ b/bootstrap/lib/kernel/include/inet.hrl
@@ -22,7 +22,7 @@
 
 -record(hostent,
 	{
-	 h_name		  :: inet:hostname(),	%% offical name of host
+	 h_name		  :: inet:hostname(),	%% official name of host
 	 h_aliases = []   :: [inet:hostname()],	%% alias list
 	 h_addrtype	  :: 'inet' | 'inet6',	%% host address type
 	 h_length	  :: non_neg_integer(),	%% length of address

--- a/bootstrap/lib/kernel/include/inet_sctp.hrl
+++ b/bootstrap/lib/kernel/include/inet_sctp.hrl
@@ -120,7 +120,7 @@
 	}).
 
 %% sctp_partial_delivery_event: XXX: Not clear whether it is delivered to
-%%				the Sender or to the Recepient (probably the
+%%				the Sender or to the Recipient (probably the
 %%				former). Currently, there is only 1 possible
 %%				value for "indication":
 -record(sctp_pdapi_event,

--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -638,7 +638,7 @@
           this value also applies to command-line parameters and environment
           variables (see section <seealso
           marker="stdlib:unicode_usage#unicode_in_environment_and_parameters">
-          Unicode in Enviroment and Parameters</seealso> in the STDLIB
+          Unicode in Environment and Parameters</seealso> in the STDLIB
           User's Guide).</p>
       </item>
       <tag><c><![CDATA[+fnu[{w|i|e}]]]></c></tag>
@@ -674,7 +674,7 @@
           this value also applies to command-line parameters and environment
           variables (see section <seealso
           marker="stdlib:unicode_usage#unicode_in_environment_and_parameters">
-          Unicode in Enviroment and Parameters</seealso> in the STDLIB
+          Unicode in Environment and Parameters</seealso> in the STDLIB
           User's Guide).</p>
       </item>
       <tag><c><![CDATA[+fna[{w|i|e}]]]></c></tag>
@@ -695,7 +695,7 @@
           this value also applies to command-line parameters and environment
           variables (see section <seealso
           marker="stdlib:unicode_usage#unicode_in_environment_and_parameters">
-          Unicode in Enviroment and Parameters</seealso> in the STDLIB
+          Unicode in Environment and Parameters</seealso> in the STDLIB
           User's Guide).</p>
       </item>
       <tag><c><![CDATA[+hms Size]]></c></tag>

--- a/erts/doc/src/erl_tracer.xml
+++ b/erts/doc/src/erl_tracer.xml
@@ -103,7 +103,7 @@
           <item>If set the tracer has been requested to include a
             time stamp.</item>
           <tag><c>extra</c></tag>
-          <item>If set the tracepoint has included additonal data about
+          <item>If set the tracepoint has included additional data about
             the trace event. What the additional data is depends on which
             <c>TraceTag</c> has been triggered. The <c>extra</c> trace data
             corresponds to the fifth element in the trace tuples described in

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -4591,7 +4591,7 @@ RealSystem = system + MissedSystem</code>
         <p>If the process potentially can get many messages,
           you are advised to set the flag to <c>off_heap</c>. This
           because a garbage collection with many messages placed on
-          the heap can become extremly expensive and the process can
+          the heap can become extremely expensive and the process can
           consume large amounts of memory. Performance of the
           actual message passing is however generally better when not
           using flag <c>off_heap</c>.</p>

--- a/erts/doc/src/erts_alloc.xml
+++ b/erts/doc/src/erts_alloc.xml
@@ -452,7 +452,7 @@
             utilization value &gt; 0 is used, allocator instances
             are allowed to abandon multiblock carriers. If <c>de</c> (default
             enabled) is passed instead of a <c><![CDATA[<utilization>]]></c>,
-            a recomended non-zero utilization value is used. The value
+            a recommended non-zero utilization value is used. The value
             chosen depends on the allocator type and can be changed between
             ERTS versions. Defaults to <c>de</c>, but this
             can be changed in the future.</p>

--- a/erts/doc/src/notes.xml
+++ b/erts/doc/src/notes.xml
@@ -564,7 +564,7 @@
       <list>
         <item>
           <p>
-	    Fixed a VM crash that occured in a garbage collection of
+	    Fixed a VM crash that occurred in a garbage collection of
 	    a process when it had received binaries. This bug was
 	    introduced in ERTS version 8.0 (OTP 19.0).</p>
           <p>
@@ -581,7 +581,7 @@
       <list>
         <item>
           <p>
-	    Fixed a VM crash that occured in garbage collection of a
+	    Fixed a VM crash that occurred in garbage collection of a
 	    process when it had received maps over the distribution.
 	    This bug was introduced in ERTS version 8.0 (OTP 19.0).</p>
           <p>
@@ -5682,7 +5682,7 @@
 	    dependent, so applications aiming to be portable should
 	    consider using <c>{ipv6_v6only,true}</c> when creating an
 	    <c>inet6</c> listening/destination socket, and if
-	    neccesary also create an <c>inet</c> socket on the same
+	    necessary also create an <c>inet</c> socket on the same
 	    port for IPv4 traffic. See the documentation.</p>
           <p>
 	    Own Id: OTP-8928 Aux Id: kunagi-193 [104] </p>
@@ -6063,7 +6063,7 @@
 	    This change of default value will reduce lock contention
 	    on ETS tables using the <c>read_concurrency</c> option at
 	    the expense of memory consumption when the amount of
-	    schedulers and logical processors are beween 8 and 64.
+	    schedulers and logical processors are between 8 and 64.
 	    For more information, see documentation of the <c>+rg</c>
 	    command line argument of <c>erl(1)</c>.</p>
           <p>
@@ -7040,7 +7040,7 @@
           <p>
 	    For the subsection about process_flag(save_calls, N)
 	    there's an unrelated paragraph about process priorities
-	    which was copied from the preceeding subsection regarding
+	    which was copied from the preceding subsection regarding
 	    process_flag(priority, Level). (Thanks to Filipe David
 	    Manana)</p>
           <p>
@@ -8255,7 +8255,7 @@
         <item>
           <p>
 	    Wx on MacOS X generated complains on stderr about certain
-	    cocoa functions not beeing called from the "Main thread".
+	    cocoa functions not being called from the "Main thread".
 	    This is now corrected.</p>
           <p>
 	    Own Id: OTP-9081</p>
@@ -9246,7 +9246,7 @@
         </item>
         <item>
 	    <p>The <c>empd</c> program could loop and consume 100%
-	    CPU time if an unexpected error ocurred in
+	    CPU time if an unexpected error occurred in
 	    <c>listen()</c> or <c>accept()</c>. Now <c>epmd</c> will
 	    terminate if a non-recoverable error occurs. (Thanks to
 	    Michael Santos.)</p>

--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -126,7 +126,7 @@ do {                                     \
 
 /*
  * We reuse some of fields in the save area in the process structure.
- * This is safe to do, since this space is only activly used when
+ * This is safe to do, since this space is only actively used when
  * the process is switched out.
  */
 #define REDS_IN(p)  ((p)->def_arg_reg[5])
@@ -220,7 +220,7 @@ BeamInstr* em_call_bif_e;
 
 /* NOTE These should be the only variables containing trace instructions.
 **      Sometimes tests are form the instruction value, and sometimes
-**      for the refering variable (one of these), and rouge references
+**      for the referring variable (one of these), and rouge references
 **      will most likely cause chaos.
 */
 BeamInstr beam_return_to_trace[1];   /* OpCode(i_return_to_trace) */
@@ -2993,7 +2993,7 @@ do {						\
  }
 
  /*
-  * An error occured in an arithmetic operation or test that could
+  * An error occurred in an arithmetic operation or test that could
   * appear either in a head or in a body.
   * In a head, execution should continue at failure address in Arg(0).
   * In a body, Arg(0) == 0 and an exception should be raised.
@@ -6268,7 +6268,7 @@ apply_bif_error_adjustment(Process *p, Export *ep,
 	 * stackframe correct. Without the following adjustment,
 	 * 'p->cp' will point into the function that called
 	 * current function when handling the error. We add a
-	 * dummy stackframe in order to achive this.
+	 * dummy stackframe in order to achieve this.
 	 *
 	 * Note that these BIFs unconditionally will cause
 	 * an exception to be raised. That is, our modifications
@@ -6612,7 +6612,7 @@ erts_hibernate(Process* c_p, Eterm module, Eterm function, Eterm args, Eterm* re
 #ifndef ERTS_SMP
 	if (ERTS_PROC_IS_EXITING(c_p)) {
 	    /*
-	     * See comment in the begining of the function...
+	     * See comment in the beginning of the function...
 	     *
 	     * This second test is needed since gc might be traced.
 	     */

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -467,7 +467,7 @@ demonitor_local_port(Process *origin, Eterm ref, Eterm target)
 }
 
 /* Can return atom true, false, yield, internal_error, badarg or
- * THE_NON_VALUE if error occured or trap has been set up
+ * THE_NON_VALUE if error occurred or trap has been set up
  */
 static
 BIF_RETTYPE demonitor(Process *c_p, Eterm ref, Eterm *multip)
@@ -597,7 +597,7 @@ BIF_RETTYPE demonitor_2(BIF_ALIST_2)
 
     switch (demonitor(BIF_P, BIF_ARG_1, &multi)) {
     case THE_NON_VALUE:
-        /* If other error occured or trap has been set up - pass through */
+        /* If other error occurred or trap has been set up - pass through */
         BIF_RET(THE_NON_VALUE);
     case am_false:
 	if (info)

--- a/erts/emulator/beam/binary.c
+++ b/erts/emulator/beam/binary.c
@@ -102,7 +102,7 @@ new_binary(Process *p, byte *buf, Uint len)
     pb->flags = 0;
 
     /*
-     * Miscellanous updates. Return the tagged binary.
+     * Miscellaneous updates. Return the tagged binary.
      */
     OH_OVERHEAD(&(MSO(p)), pb->size / sizeof(Eterm));
     return make_binary(pb);
@@ -139,7 +139,7 @@ Eterm erts_new_mso_binary(Process *p, byte *buf, Uint len)
     pb->flags = 0;
 
     /*
-     * Miscellanous updates. Return the tagged binary.
+     * Miscellaneous updates. Return the tagged binary.
      */
     OH_OVERHEAD(&(MSO(p)), pb->size / sizeof(Eterm));
     return make_binary(pb);

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -264,7 +264,7 @@ static void doit_monitor_net_exits(ErtsMonitor *mon, void *vnecp)
 	goto done;
 
     if (mon->type == MON_ORIGIN) {
-	/* local pid is beeing monitored */
+	/* local pid is being monitored */
 	rmon = erts_remove_monitor(&ERTS_P_MONITORS(rp), mon->ref);
 	/* ASSERT(rmon != NULL); nope, can happen during process exit */
 	if (rmon != NULL) {
@@ -795,7 +795,7 @@ erts_dsig_send_unlink(ErtsDSigData *dsdp, Eterm local, Eterm remote)
 }
 
 
-/* A local process that's beeing monitored by a remote one exits. We send:
+/* A local process that's being monitored by a remote one exits. We send:
    {DOP_MONITOR_P_EXIT, Local pid or name, Remote pid, ref, reason},
    which is rather sad as only the ref is needed, no pid's... */
 int

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -115,8 +115,8 @@ extern int erts_is_alive;
  * erts_dsig_prepare() prepares a send of a distributed signal.
  * One of the values defined below are returned. If the returned
  * value is another than ERTS_DSIG_PREP_CONNECTED, the
- * distributed signal cannot be sent before apropriate actions
- * have been taken. Apropriate actions would typically be setting
+ * distributed signal cannot be sent before appropriate actions
+ * have been taken. Appropriate actions would typically be setting
  * up the connection.
  */
 

--- a/erts/emulator/beam/dtrace-wrapper.h
+++ b/erts/emulator/beam/dtrace-wrapper.h
@@ -74,7 +74,7 @@
 
 #if defined(_SDT_PROBE) && !defined(STAP_PROBE11)
 /* SLF: This is Ubuntu 11-style SystemTap hackery */
-/* work arround for missing STAP macro */
+/* workaround for missing STAP macro */
 #define STAP_PROBE11(provider,name,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11) \
   _SDT_PROBE(provider, name, 11, \
              (arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11))

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -65,7 +65,7 @@
 
 # --- Allocator declarations -------------------------------------------------
 #
-# If, and only if, the same thread performes *all* allocations,
+# If, and only if, the same thread performs *all* allocations,
 # reallocations and deallocations of all memory types that are handled
 # by a specific allocator (<ALLOCATOR> in type declaration), set 
 # <MULTI_THREAD> for this specific allocator to false; otherwise, set

--- a/erts/emulator/beam/erl_alloc_util.c
+++ b/erts/emulator/beam/erl_alloc_util.c
@@ -5186,7 +5186,7 @@ erts_alcu_sz_info(Allctr_t *allctr,
 
     ERTS_ALCU_DBG_CHK_THR_ACCESS(allctr);
 
-    /* Update sbc values not continously updated */
+    /* Update sbc values not continuously updated */
     allctr->sbcs.blocks.curr.no
 	= allctr->sbcs.curr.norm.mseg.no + allctr->sbcs.curr.norm.sys_alloc.no;
     allctr->sbcs.blocks.max.no = allctr->sbcs.max.no;
@@ -5272,7 +5272,7 @@ erts_alcu_info(Allctr_t *allctr,
 
     ERTS_ALCU_DBG_CHK_THR_ACCESS(allctr);
 
-    /* Update sbc values not continously updated */
+    /* Update sbc values not continuously updated */
     allctr->sbcs.blocks.curr.no
 	= allctr->sbcs.curr.norm.mseg.no + allctr->sbcs.curr.norm.sys_alloc.no;
     allctr->sbcs.blocks.max.no = allctr->sbcs.max.no;

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -380,7 +380,7 @@ static void ac_compute_failure_functions(ACTrie *act, ACNode **qbuff)
 		qbuff[qt++] = child;
 		/* Search for correct failure function, follow the parent's
 		   failure function until you find a similar transition
-		   funtion to this child's */
+		   function to this child's */
 		r =  parent->h;
 		while (r != NULL && r->g[i] == NULL) {
 		    r = r->h;

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -2834,7 +2834,7 @@ sweep_off_heap(Process *p, int fullsweep)
     prev = &MSO(p).first;
     ptr = MSO(p).first;
 
-    /* Firts part of the list will reside on the (old) new-heap.
+    /* First part of the list will reside on the (old) new-heap.
      * Keep if moved, otherwise deref.
      */
     while (ptr) {

--- a/erts/emulator/beam/erl_lock_count.h
+++ b/erts/emulator/beam/erl_lock_count.h
@@ -129,7 +129,7 @@ typedef struct {
 
 typedef struct erts_lcnt_lock_stats_s {
     /* "tries" and "colls" needs to be atomic since
-     * trylock busy does not aquire a lock and there
+     * trylock busy does not acquire a lock and there
      * is no post action to rectify the situation
      */
 

--- a/erts/emulator/beam/erl_monitors.c
+++ b/erts/emulator/beam/erl_monitors.c
@@ -24,7 +24,7 @@
  * key in the monitor case and the pid of the linked process as key in the 
  * link case. Lookups the order of the references is somewhat special. Local 
  * references are strictly smaller than remote references and are sorted 
- * by inlined comparision functionality. Remote references are handled by the
+ * by inlined comparison functionality. Remote references are handled by the
  * usual cmp function.
  * Each Monitor is tagged with different tags depending on which end of the 
  * monitor it is.
@@ -154,7 +154,7 @@ static ErtsMonitor *create_monitor(Uint type, Eterm ref, Eterm pid, Eterm name)
      n->type = (Uint16) type;
      n->balance = 0;            /* Always the same initial value */
      n->name = name; /* atom() or [] */
-     CP_LINK_VAL(n->ref, hp, ref); /*XXX Unneccesary check, never immediate*/
+     CP_LINK_VAL(n->ref, hp, ref); /*XXX Unnecessary check, never immediate*/
      CP_LINK_VAL(n->pid, hp, pid);
 
      return n;

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -5050,7 +5050,7 @@ check_balance(ErtsRunQueue *c_rq)
 	    sched_util_balancing = 1;
 	    /*
 	     * In order to avoid renaming a large amount of fields
-	     * we write utilization values instead of lenght values
+	     * we write utilization values instead of length values
 	     * in the 'max_len' and 'migration_limit' fields...
 	     */
 	    for (qix = 0; qix < blnc_no_rqs; qix++) {

--- a/erts/emulator/beam/erl_ptab.c
+++ b/erts/emulator/beam/erl_ptab.c
@@ -474,7 +474,7 @@ erts_ptab_init_table(ErtsPTab *ptab,
 	 * we don't want to shrink the size to ERTS_PTAB_MAX_SIZE/2.
 	 *
 	 * In order to fix this, we insert a pointer from the table
-	 * to the invalid_element, wich will be interpreted as a
+	 * to the invalid_element, which will be interpreted as a
 	 * slot currently being modified. This way we will be able to
 	 * have ERTS_PTAB_MAX_SIZE-1 valid elements in the table while
 	 * still having a table size of the power of 2.

--- a/erts/emulator/beam/erl_time_sup.c
+++ b/erts/emulator/beam/erl_time_sup.c
@@ -1502,7 +1502,7 @@ static time_t gregday(int year, int month, int day)
     pyear = gyear - 1;
     ndays = (pyear/4) - (pyear/100) + (pyear/400) + pyear*365 + 366;
   }
-  /* number of days in all months preceeding month */
+  /* number of days in all months preceding month */
   for (m = 1; m < month; m++)
     ndays += mdays[m];
   /* Extra day if leap year and March or later */

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -3431,7 +3431,7 @@ void erts_init_io(int port_tab_size,
 			 NULL,
 			 (ErtsPTabElementCommon *) &erts_invalid_port.common,
 			 port_tab_size,
-			 common_element_size, /* Doesn't need to be excact */
+			 common_element_size, /* Doesn't need to be exact */
 			 "port_table",
 			 legacy_port_tab,
 			 1);

--- a/erts/emulator/drivers/common/efile_drv.c
+++ b/erts/emulator/drivers/common/efile_drv.c
@@ -2331,9 +2331,9 @@ file_async_ready(ErlDrvData e, ErlDrvThreadData data)
 	free_read(data);
 	break;
       case FILE_READ_LINE:
-	  /* The read_line stucture differs from the read structure.
-	     The data->read_offset and d->c.read_line.read_offset are copies, as are 
-	     data->read_size and d->c.read_line.read_size 
+	  /* The read_line structure differs from the read structure.
+	     The data->read_offset and d->c.read_line.read_offset are copies, as are
+	     data->read_size and d->c.read_line.read_size
              The read_line function does not kniow in advance how large the binary has to be,
 	     why new allocation (but not reallocation of the old binary, for obvious reasons) 
 	     may happen in the worker thread. */

--- a/erts/emulator/drivers/common/gzio.c
+++ b/erts/emulator/drivers/common/gzio.c
@@ -308,7 +308,7 @@ ErtsGzFile erts_gzopen (path, mode)
 /* ===========================================================================
      Read a byte from a gz_stream; update next_in and avail_in. Return EOF
    for end of file.
-   IN assertion: the stream s has been sucessfully opened for reading.
+   IN assertion: the stream s has been successfully opened for reading.
 */
 local int get_byte(s)
     gz_stream *s;

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -728,7 +728,7 @@ static int is_nonzero(const char *s, size_t n)
 #define TCP_ADDF_PENDING_SHUTDOWN \
 		(TCP_ADDF_PENDING_SHUT_WR | TCP_ADDF_PENDING_SHUT_RDWR)
 #define TCP_ADDF_SHOW_ECONNRESET   64 /* Tell user about incoming RST */
-#define TCP_ADDF_DELAYED_ECONNRESET 128 /* An ECONNRESET error occured on send or shutdown */
+#define TCP_ADDF_DELAYED_ECONNRESET 128 /* An ECONNRESET error occurred on send or shutdown */
 #define TCP_ADDF_SHUTDOWN_WR_DONE 256 /* A shutdown(sock, SHUT_WR) or SHUT_RDWR was made */
 #define TCP_ADDF_LINGER_ZERO 	  512 /* Discard driver queue on port close */
 
@@ -4132,8 +4132,8 @@ static char *inet_set_faddress(int family, inet_address* dst,
 
 /* Get a inaddr structure
 ** src = inaddr structure
-** *len is the lenght of structure
 ** dst is filled with [F,P1,P0,X1,....] 
+** *len is the length of structure
 ** where F is the family code (coded)
 ** and *len is the length of dst on return 
 ** (suitable to deliver to erlang)

--- a/erts/emulator/drivers/unix/sig_drv.c
+++ b/erts/emulator/drivers/unix/sig_drv.c
@@ -18,7 +18,7 @@
  * %CopyrightEnd%
  */
 
-/* Purpose: demonstrate how to include interupt handlers in erlang */
+/* Purpose: demonstrate how to include interrupt handlers in erlang */
 
 #ifdef HAVE_CONFIG_H
 #  include "config.h"

--- a/erts/emulator/internal_doc/DelayedDealloc.md
+++ b/erts/emulator/internal_doc/DelayedDealloc.md
@@ -19,7 +19,7 @@ the Erlang VM where memory allocation/deallocation is frequent and
 references to memory also are passed around between threads this
 solution will also scale poorly due to lock contention.
 
-Functionality Used to Adress This problem
+Functionality Used to Address This problem
 -----------------------------------------
 
 In order to reduce contention due to locking of allocator instances we
@@ -44,12 +44,12 @@ deallocation.
 The "message box" is implemented using a lock free single linked list
 through the memory blocks to deallocate. The order of the elements in
 this list is not important. Insertion of new free blocks will be made
-somewhere near the end of this list. Requirering that the new blocks
+somewhere near the end of this list. Requiring that the new blocks
 need to be inserted at the end would cause unnecessary contention when
 large amount of memory blocks are inserted simultaneous by multiple
 threads.
 
-The data structure refering to this single linked list cover two cache
+The data structure referring to this single linked list cover two cache
 lines. One cache line containing information about the head of the
 list, and one cache line containing information about the tail of the
 list. This in order to reduce cache line ping ponging of this data
@@ -65,21 +65,21 @@ list. In the uncontended case it will point to the end of the list,
 but when simultaneous insert operations are performed it will point to
 something near the end of the list.
 
-When insterting an element one will try to write a pointer to the new
+When inserting an element one will try to write a pointer to the new
 element in the next pointer of the element pointed to by the last
 pointer. This is done using an atomic compare and swap that expects
-the next pointer to be `NULL`. If this succeds the thread performing
+the next pointer to be `NULL`. If this succeeds the thread performing
 this operation moves the last pointer to point to the newly inserted
 element.
 
 If the atomic compare and swap described above failed, the last
 pointer didn't point to the last element. In this case we need to
-insert the new element somewhere inbetween the element that the last
+insert the new element somewhere between the element that the last
 pointer pointed to and the actual last element. If we do it this way
 the last pointer will eventually end up at the last element when
 threads stop adding new elements. When trying to insert somewhere near
 the end and failing to do so, the inserting thread sometimes moves to
-the next element and somtimes tries with the same element again. This
+the next element and sometimes tries with the same element again. This
 in order to spread the inserted elements during heavy contention. That
 is, we try to spread the modifications of memory to different
 locations instead of letting all threads continue to try to modify the
@@ -87,7 +87,7 @@ same location in memory.
 
 ### Head ###
 
-The head contains pointers to begining of the list (`head.first`), and
+The head contains pointers to beginning of the list (`head.first`), and
 to the first block which other threads may refer to
 (`head.unref_end`). Blocks between these pointers are only refered to
 by the head part of the data structure which is only used by the
@@ -142,7 +142,7 @@ contains this "marker" element.
 
 ### Contention ###
 
-When elements are continously inserted by threads not owning the
+When elements are continuously inserted by threads not owning the
 allocator instance, the thread owning the allocator instance will be
 able to work more or less undisturbed by other threads at the head end
 of the list. At the tail end large amounts of simultaneous inserts may

--- a/erts/emulator/internal_doc/PortSignals.md
+++ b/erts/emulator/internal_doc/PortSignals.md
@@ -204,7 +204,7 @@ high limit is 8 KB and the low limit is 4 KB.
 
 Previously all operations sending signals to ports began by acquiring
 the port lock, then performed preparations for sending the signal, and
-then finaly sent the signal. The preparations typically included
+then finally sent the signal. The preparations typically included
 inspecting the state of the port, and preparing the data to pass along
 with the signal. The preparation of data is frequently quite time
 consuming, and did not really depend on the port. That is we would

--- a/erts/emulator/internal_doc/SuperCarrier.md
+++ b/erts/emulator/internal_doc/SuperCarrier.md
@@ -151,7 +151,7 @@ To find the smallest free segment that will satisfy a carrier allocation
 size (`stree`). We search in this tree at allocation. If no free segment of
 sufficient size was found, the area (`sa` or `sua`) is instead expanded.
 If two or more free segments with equal size exist, the one at lowest
-address is choosen for `sa` and highest address for `sua`.
+address is chosen for `sa` and highest address for `sua`.
 
 At carrier deallocation, we want to coalesce with any adjacent free
 segments, to form one large free segment. To do that, all free

--- a/erts/emulator/internal_doc/ThreadProgress.md
+++ b/erts/emulator/internal_doc/ThreadProgress.md
@@ -60,7 +60,7 @@ threads are managed threads.
 ### Thread Progress Events ###
 
 Any thread in the system may use the thread progress functionality in
-order to determine when the following events have occured at least
+order to determine when the following events have occurred at least
 once in all managed threads:
 
 1.  The thread has returned from other code to a known state in the
@@ -160,7 +160,7 @@ calling the following functions:
 *   `int erts_thr_progress_leader_update(ErtsSchedulerData *esdp)` -
     Leader update thread progress.
 
-Unmanaged threads can delay thread progress beeing made:
+Unmanaged threads can delay thread progress being made:
 
 *   `ErtsThrPrgrDelayHandle erts_thr_progress_unmanaged_delay(void)` -
     Delay thread progress.
@@ -251,7 +251,7 @@ doing so. If not zero, the leader isn't allowed to increment the
 global counter, and needs to wait before it can do this. When it is
 zero, it swaps the `waiting` and `current` counters before increasing
 the global counter. From now on the new `waiting` counter will
-decrease, so that it eventualy will reach zero, making it possible to
+decrease, so that it eventually will reach zero, making it possible to
 increment the global counter the next time. If we only used one
 reference counter it would potentially be held above zero for ever by
 different unmanaged threads.
@@ -261,7 +261,7 @@ prevent the next increment of the global counter, but instead the
 increment after that. This is sufficient since the global counter
 needs to be incremented two times before thread progress has been
 made. It is also desirable not to prevent the first increment, since
-the likelyhood increases that the delay is withdrawn before any
+the likelihood increases that the delay is withdrawn before any
 increment of the global counter is delayed. That is, the operation
 will cause as little disruption as possible.
 

--- a/erts/emulator/internal_doc/Tracing.md
+++ b/erts/emulator/internal_doc/Tracing.md
@@ -51,7 +51,7 @@ the new instrumented code. Normally loaded code can only be reached
 through external functions calls. Trace settings must be activated
 instantaneously without the need of external function calls.
 
-The choosen solution is instead for tracing to use the technique of
+The chosen solution is instead for tracing to use the technique of
 replication applied on the data structures for breakpoints. Two
 generations of breakpoints are kept and indentified by index of 0 and
 1. The global atomic variables `erts_active_bp_index` will determine

--- a/erts/emulator/pcre/pcre_exec.c
+++ b/erts/emulator/pcre/pcre_exec.c
@@ -1134,7 +1134,7 @@ for (;;)
     the result of a recursive call to match() whatever happened so it was
     possible to reduce stack usage by turning this into a tail recursion,
     except in the case of a possibly empty group. However, now that there is
-    the possiblity of (*THEN) occurring in the final alternative, this
+    the possibility of (*THEN) occurring in the final alternative, this
     optimization is no longer always possible.
 
     We can optimize if we know there are no (*THEN)s in the pattern; at present

--- a/erts/emulator/sys/common/erl_mseg.c
+++ b/erts/emulator/sys/common/erl_mseg.c
@@ -378,7 +378,7 @@ static ERTS_INLINE int cache_bless_segment(ErtsMsegAllctr_t *ma, void *seg, UWor
 
     ASSERT(!MSEG_FLG_IS_2POW(flags) || (MSEG_FLG_IS_2POW(flags) && MAP_IS_ALIGNED(seg) && IS_2POW(size)));
 
-    /* The idea is that sbc caching is prefered over mbc caching.
+    /* The idea is that sbc caching is preferred over mbc caching.
      * Blocks are normally allocated in mb carriers and thus cached there.
      * Large blocks has no such cache and it is up to mseg to cache them to speed things up.
      */

--- a/erts/emulator/sys/unix/erl_child_setup.h
+++ b/erts/emulator/sys/unix/erl_child_setup.h
@@ -17,7 +17,7 @@
  * 
  * %CopyrightEnd%
  *
- * This file defines the interface inbetween erts and child_setup.
+ * This file defines the interface between erts and child_setup.
  */
 
 #ifndef _ERL_UNIX_FORKER_H

--- a/erts/emulator/sys/win32/erl_poll.c
+++ b/erts/emulator/sys/win32/erl_poll.c
@@ -842,9 +842,9 @@ event_happened:
 	    ASSERT(WAIT_OBJECT_0 < i && i < WAIT_OBJECT_0+w->active_events);
 	    notify_io_ready(ps);
 
-	    /* 
-	     * The main thread wont start working on our arrays untill we're
-	     * stopped, so we can work in peace although the main thread runs 
+	    /*
+	     * The main thread wont start working on our arrays until we're
+	     * stopped, so we can work in peace although the main thread runs
 	     */
 	    ASSERT(i >= WAIT_OBJECT_0+1);
 	    i -= WAIT_OBJECT_0;

--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -496,7 +496,7 @@ struct driver_data {
     int outBufSize;		/* Size of output buffer. */
     byte *outbuf;		/* Buffer to use for overlapped write. */
     ErlDrvPort port_num;	/* The port handle. */
-    int packet_bytes;		/* 0: continous stream, 1, 2, or 4: the number
+    int packet_bytes;		/* 0: continuous stream, 1, 2, or 4: the number
 				 * of bytes in the packet header.
 				 */
     HANDLE port_pid;		/* PID of the port process. */
@@ -1427,7 +1427,7 @@ int parse_command(wchar_t* cmd){
  *
  * If new == NULL we just calculate the length.
  *
- * The reason for having to quote all of the is becasue CreateProcessW removes
+ * The reason for having to quote all of the is because CreateProcessW removes
  * one level of escaping since it takes a single long command line rather
  * than the argument chunks that unix uses.
  */
@@ -2486,7 +2486,7 @@ output(ErlDrvData drv_data, char* buf, ErlDrvSizeT len)
  *	event object has been signaled, indicating that there is
  *	something to read on the corresponding file handle.
  *
- *	If the port is working in the continous stream mode (packet_bytes == 0),
+ *	If the port is working in the continuous stream mode (packet_bytes == 0),
  *	whatever data read will be sent straight to Erlang.
  *
  * Results:
@@ -2527,7 +2527,7 @@ ready_input(ErlDrvData drv_data, ErlDrvEvent ready_event)
 #endif
 
     if (error == NO_ERROR) {
-	if (pb == 0) { /* Continous stream. */
+	if (pb == 0) { /* Continuous stream. */
 #ifdef DEBUG
 	    DEBUGF(("ready_input: %d: ", bytesRead));
 	    erl_bin_write(dp->inbuf, 16, bytesRead);

--- a/erts/emulator/test/binary_SUITE.erl
+++ b/erts/emulator/test/binary_SUITE.erl
@@ -1008,7 +1008,7 @@ ordering(Config) when is_list(Config) ->
 
     ok.
 
-%% Test that comparisions between binaries with different alignment work.
+%% Test that comparison between binaries with different alignment work.
 unaligned_order(Config) when is_list(Config) ->
     L = lists:seq(0, 7),
     [test_unaligned_order(I, J) || I <- L, J <- L], 

--- a/erts/emulator/test/bs_match_int_SUITE.erl
+++ b/erts/emulator/test/bs_match_int_SUITE.erl
@@ -247,7 +247,7 @@ match_huge_int(Config) when is_list(Config) ->
 	8 ->
 	    %% An attempt will be made to allocate heap space for
 	    %% the bignum (which will probably fail); only if the
-	    %% allocation succeds will the matching fail because
+	    %% allocation succeeds will the matching fail because
 	    %% the binary is too small.
 	    ok
     end,

--- a/erts/emulator/test/call_trace_SUITE.erl
+++ b/erts/emulator/test/call_trace_SUITE.erl
@@ -233,7 +233,7 @@ basic() ->
     trace_func({'_','_','_'}, false),
     [b,a] = lists:reverse([a,b]),
 
-    %% Read out the remaing trace messages.
+    %% Read out the remaining trace messages.
 
     ?MODULE:expect({trace,Self,call,{lists,seq,[1,10]}}),
     ?MODULE:expect({trace,Self,call,{erlang,list_to_integer,["777"]}}),

--- a/erts/emulator/test/ddll_SUITE.erl
+++ b/erts/emulator/test/ddll_SUITE.erl
@@ -805,7 +805,7 @@ reference_count(Config) when is_list(Config) ->
 
     Pid1 ! {self(), die},
     test_server:sleep(200),   % Give time to unload.
-    % Verify that the driver was automaticly unloaded when the
+    % Verify that the driver was automatically unloaded when the
     % process died.
     {error, not_loaded}=erl_ddll:unload_driver(echo_drv),
     ok.

--- a/erts/emulator/test/dirty_nif_SUITE.erl
+++ b/erts/emulator/test/dirty_nif_SUITE.erl
@@ -214,7 +214,7 @@ dirty_call_while_terminated(Config) when is_list(Config) ->
     undefined = process_info(Dirty, status),
     false = erlang:is_process_alive(Dirty),
     false = lists:member(Dirty, processes()),
-    %% Binary still refered by Dirty process not yet cleaned up
+    %% Binary still referred by Dirty process not yet cleaned up
     %% since the dirty nif has not yet returned...
     {value, {BinAddr, 4711, 2}} = lists:keysearch(4711, 2,
 						  element(2,

--- a/erts/emulator/test/estone_SUITE.erl
+++ b/erts/emulator/test/estone_SUITE.erl
@@ -708,7 +708,7 @@ alloc(I) ->
 
 %% Time to call bif's
 %% Lot's of element stuff which reflects the record code which
-%% is becomming more and more common
+%% is becoming more and more common
 bif_dispatch(0) ->
     0;
 bif_dispatch(I) ->

--- a/erts/emulator/test/float_SUITE.erl
+++ b/erts/emulator/test/float_SUITE.erl
@@ -208,7 +208,7 @@ span_cmp(Axis, Incr, Length) ->
 %% for both negative and positive numbers.
 %%
 %% Axis: The number around which to do the tests eg. (1 bsl 58) - 1.0
-%% Incr: How much to increment the test numbers inbetween each test.
+%% Incr: How much to increment the test numbers in-between each test.
 %% Length: Length/2 is the number of Incr away from Axis to test on the
 %%         negative and positive plane.
 %% Diff: How much the float and int should differ when comparing

--- a/erts/emulator/test/hibernate_SUITE.erl
+++ b/erts/emulator/test/hibernate_SUITE.erl
@@ -349,7 +349,7 @@ clean_dict() ->
     lists:foreach(fun ({Key, _}) -> erase(Key) end, Dict).
 
 %%
-%% Wake up and then immediatly bif trap with a lengthy computation.
+%% Wake up and then immediately bif trap with a lengthy computation.
 %%
 
 wake_up_and_bif_trap(Config) when is_list(Config) ->

--- a/erts/emulator/test/match_spec_SUITE.erl
+++ b/erts/emulator/test/match_spec_SUITE.erl
@@ -646,7 +646,7 @@ destructive_in_test_bif(Config) when is_list(Config) ->
 			       ([],[{'_',[],[{message,{get_tcw}}]}],trace),
     ok.
 
-%% Test that the comparision between boxed and small does not crash emulator
+%% Test that the comparison between boxed and small does not crash emulator
 boxed_and_small(Config) when is_list(Config) ->
     {ok, Node} = start_node(match_spec_suite_other),
     ok = rpc:call(Node,?MODULE,do_boxed_and_small,[]),

--- a/erts/emulator/test/node_container_SUITE.erl
+++ b/erts/emulator/test/node_container_SUITE.erl
@@ -153,7 +153,7 @@ ttbtteq_do_remote(RNode) ->
 %%
 %% Test case: round_trip_eq
 %%
-%% Tests that node containers that are sent beteen nodes stay equal to themselves.
+%% Tests that node containers that are sent between nodes stay equal to themselves.
 round_trip_eq(Config) when is_list(Config) ->
     ThisNode = {node(), erlang:system_info(creation)},
     NodeFirstName = get_nodefirstname(),

--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -108,7 +108,7 @@ t_float(Config) when is_list(Config) ->
     4294967305.0 = float(id(4294967305)),
     -4294967305.0 = float(id(-4294967305)),
 
-    %% Extremly big bignums.
+    %% Extremely big bignums.
     Big = id(list_to_integer(id(lists:duplicate(2000, $1)))),
     {'EXIT', {badarg, _}} = (catch float(Big)),
 

--- a/erts/emulator/test/port_SUITE.erl
+++ b/erts/emulator/test/port_SUITE.erl
@@ -2131,7 +2131,7 @@ ping(Config, Sizes, HSize, CmdLine, Options) ->
 %% Sizes = Size of packets to generated.
 %% HSize = Header size: 1, 2, or 4
 %% CmdLine = Additional command line options.
-%% Options = Addtional port options.
+%% Options = Additional port options.
 
 expect_input(Config, Sizes, HSize, CmdLine, Options) ->
     expect_input1(Config, Sizes, {HSize, CmdLine, Options}, [], []).

--- a/erts/emulator/test/port_SUITE_data/port_test.c
+++ b/erts/emulator/test/port_SUITE_data/port_test.c
@@ -41,7 +41,7 @@ extern int errno;
 typedef struct {
     char* progname;	        /* Name of this program (from argv[0]). */
     int header_size;	        /* Number of bytes in each packet header:
-				 * 1, 2, or 4, or 0 for a continous byte stream. */
+				 * 1, 2, or 4, or 0 for a continuous byte stream. */
     int fd_from_erl;	        /* File descriptor from Erlang. */
     int fd_to_erl;	        /* File descriptor to Erlang. */
     unsigned char* io_buf;      /* Buffer for file i/o. */

--- a/erts/emulator/test/port_bif_SUITE_data/port_test.c
+++ b/erts/emulator/test/port_bif_SUITE_data/port_test.c
@@ -39,7 +39,7 @@ extern int errno;
 typedef struct {
     char* progname;	        /* Name of this program (from argv[0]). */
     int header_size;	        /* Number of bytes in each packet header:
-				 * 1, 2, or 4, or 0 for a continous byte stream. */
+				 * 1, 2, or 4, or 0 for a continuous byte stream. */
     int fd_from_erl;	        /* File descriptor from Erlang. */
     int fd_to_erl;	        /* File descriptor to Erlang. */
     unsigned char* io_buf;      /* Buffer for file i/o. */

--- a/erts/emulator/test/system_info_SUITE.erl
+++ b/erts/emulator/test/system_info_SUITE.erl
@@ -174,7 +174,7 @@ memory(Config) when is_list(Config) ->
     %%
 
     erts_debug:set_internal_state(available_internal_state, true),
-    %% Use a large heap size on the controling process in
+    %% Use a large heap size on the controlling process in
     %% order to avoid changes in its heap size during
     %% comparisons.
     MinHeapSize = process_flag(min_heap_size, 1024*1024), 

--- a/erts/emulator/test/time_SUITE.erl
+++ b/erts/emulator/test/time_SUITE.erl
@@ -132,7 +132,7 @@ local_to_univ_utc(Config) when is_list(Config) ->
     end.
 
 
-%% Tests conversion from univeral to local time.
+%% Tests conversion from universal to local time.
 
 univ_to_local(Config) when is_list(Config) ->
     test_univ_to_local(test_data()).

--- a/erts/emulator/test/z_SUITE.erl
+++ b/erts/emulator/test/z_SUITE.erl
@@ -226,7 +226,7 @@ pollset_size(Config) when is_list(Config) ->
 				 "Pollset size information not available"}
 		  end;
 	      false ->
-		  %% Somtimes we have fewer descriptors in the
+		  %% Sometimes we have fewer descriptors in the
 		  %% pollset at the end than when we started, but
 		  %% that is ok as long as there are at least 2
 		  %% descriptors (dist listen socket and

--- a/erts/epmd/test/epmd_SUITE.erl
+++ b/erts/epmd/test/epmd_SUITE.erl
@@ -838,7 +838,7 @@ no_live_killing(Config) when is_list(Config) ->
 %% sends TCP RST at wrong time
 socket_reset_before_alive2_reply_is_written(Config) when is_list(Config) ->
     %% - delay_write for easier triggering of race condition
-    %% - relaxed_command_check for gracefull shutdown of epmd even if there
+    %% - relaxed_command_check for graceful shutdown of epmd even if there
     %%   is stuck node.
     ok = epmdrun("-delay_write 1 -relaxed_command_check"),
 

--- a/erts/etc/common/inet_gethost.c
+++ b/erts/etc/common/inet_gethost.c
@@ -2717,7 +2717,7 @@ BOOL close_mesq(MesQ *q)
 	LeaveCriticalSection(&(q->crit));
 	return FALSE;
     }
-    /* Noone else is supposed to use this object any more */
+    /* No one else is supposed to use this object any more */
     LeaveCriticalSection(&(q->crit));
     DeleteCriticalSection(&(q->crit));
     CloseHandle(q->data_present);

--- a/erts/etc/unix/README
+++ b/erts/etc/unix/README
@@ -42,7 +42,7 @@ Note that the Install script will terminate if it detects problems -
 you will have to correct them and re-run the script. If everything
 goes well, the last printout should be:
 
-Erlang installation sucessfully completed
+Erlang installation successfully completed
 
 If it isn't, something went wrong - check the printouts to find out
 what it was.

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -2875,7 +2875,7 @@ document etp-disasm
 %---------------------------------------------------------------------------
 % etp-disasm StartI EndI
 %
-% Disassemble the code inbetween StartI and EndI
+% Disassemble the code between StartI and EndI
 %---------------------------------------------------------------------------
 end
 

--- a/erts/etc/unix/run_erl.c
+++ b/erts/etc/unix/run_erl.c
@@ -553,7 +553,7 @@ static void pass_on(pid_t childpid)
 		FD_ZERO(&readfds);
 		FD_ZERO(&writefds);
 	    } else {
-		/* Some error occured */
+		/* Some error occurred */
 		ERRNO_ERR0(LOG_ERR,"Error in select.");
 		exit(1);
 	    }

--- a/erts/include/internal/gcc/ethr_atomic.h
+++ b/erts/include/internal/gcc/ethr_atomic.h
@@ -28,7 +28,7 @@
  *
  *       Due to this we cannot use the __ATOMIC_SEQ_CST
  *       memory model. For more information see the comment
- *       in the begining of ethr_membar.h in this directory.
+ *       in the beginning of ethr_membar.h in this directory.
  */
 
 #undef ETHR_INCLUDE_ATOMIC_IMPL__

--- a/erts/include/internal/gcc/ethr_dw_atomic.h
+++ b/erts/include/internal/gcc/ethr_dw_atomic.h
@@ -28,7 +28,7 @@
  *
  *       Due to this we cannot use the __ATOMIC_SEQ_CST
  *       memory model. For more information see the comment
- *       in the begining of ethr_membar.h in this directory.
+ *       in the beginning of ethr_membar.h in this directory.
  */
 
 #undef ETHR_INCLUDE_DW_ATOMIC_IMPL__

--- a/lib/asn1/examples/recordnames.txt
+++ b/lib/asn1/examples/recordnames.txt
@@ -1,6 +1,6 @@
 For each ASN1 types SET and SEQUENCE a record is generated in the .hrl
 file with the same name as the corresponding type.
-A decoded value is also returned as a record with the apropriate name.
+A decoded value is also returned as a record with the appropriate name.
 An internally defined type as the type in component 'a' in the
 following example will result in a record with name 'Seq_a':
 

--- a/lib/dialyzer/RELEASE_NOTES
+++ b/lib/dialyzer/RELEASE_NOTES
@@ -181,7 +181,7 @@ Version 1.8.0 (in Erlang/OTP R12B-2)
  - Dialyzer has a new warning option -Wunmatched_returns which warns for
    function calls that ignore the return value.
    This catches many common programming errors (e.g. calling file:close/1
-   and not checking for the absense of errors), interface discrepancies
+   and not checking for the absence of errors), interface discrepancies
    (e.g. a function returning multiple values when in reality the function
    is void and only called for its side-effects), calling the wrong function
    (e.g. io_lib:format/1 instead of io:format/1), and even possible

--- a/lib/dialyzer/src/dialyzer_callgraph.erl
+++ b/lib/dialyzer/src/dialyzer_callgraph.erl
@@ -365,7 +365,7 @@ ets_lookup_set(Key, Table) ->
 
 %% The core tree must be labeled as by cerl_trees:label/1 (or /2).
 %% The set of labels in the tree must be disjoint from the set of
-%% labels already occuring in the callgraph.
+%% labels already occurring in the callgraph.
 
 -spec scan_core_tree(cerl:c_module(), callgraph()) ->
         {[mfa_or_funlbl()], [callgraph_edge()]}.

--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -1363,7 +1363,7 @@ do_clause(C, Arg, ArgType0, OrigArgType, Map, State, Warns) ->
 		{{Tag, PatTypes}, false};
 	      false ->
 		%% Try to find out if this is a default clause in a list
-		%% comprehension and supress this. A real Hack(tm)
+		%% comprehension and suppress this. A real Hack(tm)
 		Force0 =
 		  case is_compiler_generated(cerl:get_ann(C)) of
 		    true ->

--- a/lib/dialyzer/test/opaque_SUITE_data/src/recrec/dialyzer_dataflow.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/recrec/dialyzer_dataflow.erl
@@ -1340,7 +1340,7 @@ do_clause(C, Arg, ArgType0, OrigArgType, Map, State) ->
 		{{Tag, PatTypes}, false};
 	      false ->
 		%% Try to find out if this is a default clause in a list
-		%% comprehension and supress this. A real Hack(tm)
+		%% comprehension and suppress this. A real Hack(tm)
 		Force0 =
 		  case is_compiler_generated(cerl:get_ann(C)) of
 		    true ->

--- a/lib/dialyzer/test/options1_SUITE_data/src/compiler/beam_disasm.erl
+++ b/lib/dialyzer/test/options1_SUITE_data/src/compiler/beam_disasm.erl
@@ -565,7 +565,7 @@ resolve_inst({make_fun2,Args},_,_,Lbls,Lambdas) ->
     [OldIndex] = resolve_args(Args),
     {value,{OldIndex,{F,A,_Lbl,_Index,NumFree,OldUniq}}} =
 	lists:keysearch(OldIndex, 1, Lambdas),
-    [{_,{M,_,_}}|_] = Lbls,			% Slighly kludgy.
+    [{_,{M,_,_}}|_] = Lbls,			% Slightly kludgy.
     {make_fun2,{M,F,A},OldIndex,OldUniq,NumFree};
 resolve_inst(Instr, Imports, Str, Lbls, _Lambdas) ->
     resolve_inst(Instr, Imports, Str, Lbls).

--- a/lib/dialyzer/test/options1_SUITE_data/src/compiler/cerl_inline.erl
+++ b/lib/dialyzer/test/options1_SUITE_data/src/compiler/cerl_inline.erl
@@ -951,7 +951,7 @@ i_letrec(Es, B, Xs, Ctxt, Ren, Env, S) ->
 
     %% Finally, we create new letrec-bindings for any and all
     %% residualised definitions. All referenced functions should have
-    %% been visited; the call to `visit' below is expected to retreive a
+    %% been visited; the call to `visit' below is expected to retrieve a
     %% cached expression.
     Rs1 = keep_referenced(Rs, S4),
     {Es1, S5} = mapfoldl(fun (R, S) ->
@@ -997,7 +997,7 @@ i_apply(E, Ctxt, Ren, Env, S) ->
     %% location could be recycled after the flag has been tested, but
     %% there is no real advantage to that, because in practice, only
     %% 4-5% of all created store locations will ever be reused, while
-    %% there will be a noticable overhead for managing the free list.)
+    %% there will be a noticeable overhead for managing the free list.)
     case st__get_app_inlined(L, S3) of
         true ->
             %% The application was inlined, so we have the final
@@ -2007,7 +2007,7 @@ residualize_operand(Opnd, E, S) ->
     case st__get_opnd_effect(Opnd#opnd.loc, S) of
         true ->
             %% The operand has not been visited, so we do that now, but
-            %% in `effect' context. (Waddell's algoritm does some stuff
+            %% in `effect' context. (Waddell's algorithm does some stuff
             %% here to account specially for the operand size, which
             %% appears unnecessary.)
             {E1, S1} = i(Opnd#opnd.expr, effect, Opnd#opnd.ren,

--- a/lib/dialyzer/test/options1_SUITE_data/src/compiler/rec_env.erl
+++ b/lib/dialyzer/test/options1_SUITE_data/src/compiler/rec_env.erl
@@ -469,7 +469,7 @@ get(Key, Env) ->
 -define(MINIMUM_RANGE, 1000).
 -define(START_RANGE_FACTOR, 50).
 -define(MAX_RETRIES, 2).      % retries before enlarging range
--define(ENLARGE_FACTOR, 10).  % range enlargment factor
+-define(ENLARGE_FACTOR, 10).  % range enlargement factor
 
 -ifdef(DEBUG).
 %% If you want to use these process dictionary counters, make sure to

--- a/lib/dialyzer/test/options1_SUITE_data/src/compiler/sys_pre_expand.erl
+++ b/lib/dialyzer/test/options1_SUITE_data/src/compiler/sys_pre_expand.erl
@@ -316,7 +316,7 @@ record_test_in_guard(Line, Term, Name, Vs, St) ->
     %%            code bloat.)
     %%        (4) Xref may be run on the abstract code, so the name in the
     %%            abstract code must be erlang:is_record/3.
-    %%        (5) To achive both (3) and (4) at the same time, set the name
+    %%        (5) To achieve both (3) and (4) at the same time, set the name
     %%            here to erlang:is_record/3, but mark it as compiler-generated.
     %%            The v3_core pass will change the name to erlang:internal_is_record/3.
     Fs = record_fields(Name, St),

--- a/lib/dialyzer/test/options1_SUITE_data/src/compiler/v3_codegen.erl
+++ b/lib/dialyzer/test/options1_SUITE_data/src/compiler/v3_codegen.erl
@@ -1667,7 +1667,7 @@ bs_function({function,Name,Arity,CLabel,Asm0}=Func) ->
 
 %%%
 %%% Pass 1: Found out which bs_restore's that are needed. For now we assume
-%%% that a bs_restore is needed unless it is directly preceeded by a bs_save.
+%%% that a bs_restore is needed unless it is directly preceded by a bs_save.
 %%%
 
 bs_needed([{bs_save,Name},{bs_restore,Name}|T], N, _BsUsed, Dict) ->

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct.erl
@@ -520,7 +520,7 @@ save_automatic_tagged_types([_M|Ms]) ->
 %% remove_in_set_imports/3 :
 %% input: list with tuples of each module's imports and module name
 %% respectively.
-%% output: one list with same format but each occured import from a
+%% output: one list with same format but each occurred import from a
 %% module in the input set (IMNameL) is removed.
 remove_in_set_imports([{{imports,ImpL},_ModName}|Rest],InputMNameL,Acc) ->
     NewImpL = remove_in_set_imports1(ImpL,InputMNameL,[]),
@@ -1628,7 +1628,7 @@ tlv_tag1(<<1:1,PartialTag:7,Buffer/binary>>,Acc) ->
     tlv_tag1(Buffer,(Acc bsl 7) bor PartialTag).
 
 %% reads the content from the configuration file and returns the
-%% selected part choosen by InfoType. Assumes that the config file
+%% selected part chosen by InfoType. Assumes that the config file
 %% content is an Erlang term.
 read_config_file(ModuleName,InfoType) when atom(InfoType) ->
     CfgList = read_config_file(ModuleName),

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct_check.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct_check.erl
@@ -4028,7 +4028,7 @@ check_sequence(S,Type,Comps)  ->
 	    {CRelInf,NewComps2} = componentrelation_leadingattr(S,NewComps),
 %	    io:format("CRelInf: ~p~n",[CRelInf]),
 %	    io:format("NewComps2: ~p~n",[NewComps2]),
-	    %% CompListWithTblInf has got a lot unecessary info about
+	    %% CompListWithTblInf has got a lot unnecessary info about
 	    %% the involved class removed, as the class of the object
 	    %% set.
 	    CompListWithTblInf = get_tableconstraint_info(S,Type,NewComps2),
@@ -4686,7 +4686,7 @@ any_component_relation(_,[],_,_,Acc) ->
 %% evaluate_atpath/4 finds out whether the at notation refers to the
 %% search level. The list of referenced names in the AtNot list shall
 %% begin with a name that exists on the level it refers to. If the
-%% found AtPath is refering to the same sub-branch as the simple table
+%% found AtPath is referring to the same sub-branch as the simple table
 %% has, then there shall not be any leading attribute info on this
 %% level.
 evaluate_atpath(_,[],Cnames,{innermost,AtPath=[Ref|_Refs]}) ->
@@ -4857,7 +4857,7 @@ innertype_comprel1(S,T = #type{def=Def,constraint=Cons,tablecinf=TCI},Path) ->
 	case Cons of
 	    [{componentrelation,{_,_,ObjectSet},AtList}|_Rest] ->
 		%% This AtList must have an "outermost" at sign to be
-		%% relevent here.
+		%% relevant here.
 		[{_,AL=[#'Externalvaluereference'{value=_Attr}|_R1]}|_R2]
 		    = AtList,
 %%		#'ObjectClassFieldType'{class=ClassDef} = Def,

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct_constructed_ber.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct_constructed_ber.erl
@@ -1259,7 +1259,7 @@ gen_dec_line(Erules,TopType,Cname,CTags,Type,OptOrMand,DecObjInf)  ->
 	end,
     case DecObjInf of
 	{Cname,ObjSet} -> % this must be the component were an object is
-	    %% choosen from the object set according to the table
+	    %% chosen from the object set according to the table
 	    %% constraint.
 	    {[{ObjSet,Cname,asn1ct_gen:mk_var(asn1ct_name:curr(term))}],
 	     PostpDec};

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct_constructed_ber_bin_v2.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct_constructed_ber_bin_v2.erl
@@ -1096,7 +1096,7 @@ gen_dec_line(Erules,TopType,Cname,CTags,Type,OptOrMand,DecObjInf)  ->
 	end,
     case DecObjInf of
 	{Cname,ObjSet} -> % this must be the component were an object is
-	    %% choosen from the object set according to the table
+	    %% chosen from the object set according to the table
 	    %% constraint.
 	    {[{ObjSet,Cname,asn1ct_gen:mk_var(asn1ct_name:curr(term))}],
 	     PostpDec};

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct_parser2.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1ct_parser2.erl
@@ -2721,7 +2721,7 @@ prioritize_error(ErrList) ->
 				end,
 				NewErrList),
 	    case SplitErrs of
-		{[],UndefPosErrs} -> % if no error with Positon exists
+		{[],UndefPosErrs} -> % if no error with Position exists
 		    lists:last(UndefPosErrs);
 		{IntPosErrs,_} ->
 		    IntPosReasons = lists:map(fun(X)->element(2,X) end,IntPosErrs),

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_ber_bin.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_ber_bin.erl
@@ -1036,7 +1036,7 @@ decode_real2(Buffer0, Form, Len, RemBytes1) ->
 %%
 %% bitstring NamedBitList
 %% Val can be  of:
-%% - [identifiers] where only named identifers are set to one,
+%% - [identifiers] where only named identifiers are set to one,
 %%   the Constraint must then have some information of the
 %%   bitlength.
 %% - [list of ones and zeroes] all bits

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_ber_bin_v2.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_ber_bin_v2.erl
@@ -1034,7 +1034,7 @@ decode_real_notag(_Buffer, _Form) ->
 %%
 %% bitstring NamedBitList
 %% Val can be  of:
-%% - [identifiers] where only named identifers are set to one,
+%% - [identifiers] where only named identifiers are set to one,
 %%   the Constraint must then have some information of the
 %%   bitlength.
 %% - [list of ones and zeroes] all bits

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_per.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_per.erl
@@ -823,7 +823,7 @@ decode_enumerated(Buffer,C,NamedNumberTup) when tuple(NamedNumberTup) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% bitstring NamedBitList
 %% Val can be  of:
-%% - [identifiers] where only named identifers are set to one,
+%% - [identifiers] where only named identifiers are set to one,
 %%   the Constraint must then have some information of the
 %%   bitlength.
 %% - [list of ones and zeroes] all bits

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_per_bin.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_per_bin.erl
@@ -1000,7 +1000,7 @@ decode_enumerated(Buffer,C,NamedNumberTup) when tuple(NamedNumberTup) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% bitstring NamedBitList
 %% Val can be  of:
-%% - [identifiers] where only named identifers are set to one,
+%% - [identifiers] where only named identifiers are set to one,
 %%   the Constraint must then have some information of the
 %%   bitlength.
 %% - [list of ones and zeroes] all bits

--- a/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_per_bin_rt2ct.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/asn1/asn1rt_per_bin_rt2ct.erl
@@ -1059,7 +1059,7 @@ decode_enumerated(Buffer,C,NamedNumberTup) when tuple(NamedNumberTup) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% bitstring NamedBitList
 %% Val can be  of:
-%% - [identifiers] where only named identifers are set to one,
+%% - [identifiers] where only named identifiers are set to one,
 %%   the Constraint must then have some information of the
 %%   bitlength.
 %% - [list of ones and zeroes] all bits

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/ftp.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/ftp.erl
@@ -108,7 +108,7 @@ user(Pid, User, Pass) ->
   gen_server:call(Pid, {user, User, Pass}, infinity).
 
 %% user(Pid, User, Pass,Acc)
-%% Purpose:  Login whith a supplied account name
+%% Purpose:  Login with a supplied account name
 %% Args:     Pid = pid(), User = Pass = Acc = string()
 %% Returns:  ok | {error, euser} | {error, econn} | {error, eacct}
 user(Pid, User, Pass,Acc) ->

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/http.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/http.erl
@@ -24,7 +24,7 @@
 %%%      - RFC 3310 Authentication and Key Agreement (AKA) (not yet!)
 %%%      - HTTP/1.1 Specification Errata found at
 %%%        http://world.std.com/~lawrence/http_errata.html
-%%%    Additionaly follows the following recommendations:
+%%%    Additionally follows the following recommendations:
 %%%      - RFC 3143 Known HTTP Proxy/Caching Problems (not yet!)
 %%%      - draft-nottingham-hdrreg-http-00.txt (not yet!)
 %%%

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/http_lib.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/http_lib.erl
@@ -697,7 +697,7 @@ lookup(Key,Val) ->
 %%% This code is for parsing trailer headers in chunked messages.
 %%% Will be deprecated whenever I have found an alternative working solution!
 %%% Note:
-%%% - The header names are returned slighly different from what the what
+%%% - The header names are returned slightly different from what the what
 %%%   inet_drv returns
 read_headers_old(Scheme,Socket,Timeout) ->
     read_headers_old(<<>>,Scheme,Socket,Timeout,[],[]).

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/httpc_manager.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/httpc_manager.erl
@@ -95,7 +95,7 @@ abort_session(Addr,Sid,Msg) ->
 next_request(Addr,Sid) ->
     gen_server:call(?HMACALL,{next_request,Addr,Sid},infinity).
 
-%%% Session handler has succeded to set up a new session, now register
+%%% Session handler has succeed to set up a new session, now register
 %%% the socket
 register_socket(Addr,Sid,Socket) ->
     gen_server:cast(?HMACALL,{register_socket,Addr,Sid,Socket}).

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/httpd_manager.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/httpd_manager.erl
@@ -224,7 +224,7 @@ is_blocked(ServerRef) ->
 
 
 %%
-%% Module API. Theese functions are intended for use from modules only.
+%% Module API. These functions are intended for use from modules only.
 %%
 
 config_lookup(Port, Query) ->

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/httpd_parse.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/httpd_parse.erl
@@ -109,7 +109,7 @@ get_persistens(HTTPVersion,ParsedHeader,ConfigDB)->
 		%%If it is version prio to 1.1 kill the conneciton
 		[$H, $T, $T, $P, $\/, $1, $.,N] ->
 		    case httpd_util:key1search(ParsedHeader,"connection","keep-alive")of
-			%%if the connection isnt ordered to go down let it live
+			%%if the connection isn't ordered to go down let it live
 			%%The keep-alive value is the older http/1.1 might be older
 			%%Clients that use it.
 			"keep-alive" when N >= 49 ->

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/jnets_httpd.hrl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/jnets_httpd.hrl
@@ -60,7 +60,7 @@
 %	  request_line,        % string() Request Line
 	  headers,             % #req_headers{} Parsed request headers
 	  entity_body= <<>>,   % binary() Body of request
-	  connection,          % boolean() true if persistant connection
+	  connection,          % boolean() true if persistent connection
 	  status_code,         % int() Status code
 	  logging              % int() 0=No logging
 	                       %       1=Only mod_log present

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_auth_mnesia.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_auth_mnesia.erl
@@ -53,7 +53,7 @@ store_directory_data(Directory, DirData) ->
 %% API
 %%
 
-%% Compability API
+%% Compatibility API
 
 
 store_user(UserName, Password, Port, Dir, AccessPassword) ->

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_esi.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_esi.erl
@@ -440,7 +440,7 @@ try_new_erl_scheme_method(Info,Env,Input,Mod,Func)->
 
 
 %%----------------------------------------------------------------------
-%%The function recieves the data from the process that generates the page
+%%The function receives the data from the process that generates the page
 %%and send the data to the client through the mod_cgi:send function
 %%----------------------------------------------------------------------
 

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_htaccess.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_htaccess.erl
@@ -272,10 +272,10 @@ controlIfAllowed(AllowedNetworks,UserNetwork,IfAllowed,IfDenied)->
     end.
 
 
-%---------------------------------------------------------------------%
-%The Denycontrol isn't neccessary to preform since the allow control  %
-%override the deny control                                            %
-%---------------------------------------------------------------------%
+%--------------------------------------------------------------------%
+%The Denycontrol isn't necessary to preform since the allow control  %
+%override the deny control                                           %
+%--------------------------------------------------------------------%
 controlDenyAllow(DeniedNetworks,AllowedNetworks,UserNetwork)->
     case AllowedNetworks of
 	[{allow,all}]->
@@ -657,7 +657,7 @@ getData2(HtAccessFileNames,SplittedPath,Info)->
 
 %----------------------------------------------------------------------
 %HtAccessFilenames is a list the names the accesssfiles can have
-%Path is the shortest match agains all alias and documentroot
+%Path is the shortest match against all alias and documentroot
 %rest of splitted path is a list of the parts of the path
 %Info is the mod recod from the server
 %----------------------------------------------------------------------

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_range.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_range.erl
@@ -80,7 +80,7 @@ send_range_response(Path,Info,Ranges,FileInfo,LastModified)->
 	    send_range_response(Path,Info,Start,Stop,FileInfo,LastModified)
     end.
 %%More than one range specified
-%%Send a multipart reponse to the user
+%%Send a multipart response to the user
 %
 %%An example of an multipart range response
 

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_responsecontrol.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/mod_responsecontrol.erl
@@ -48,8 +48,8 @@ do(Info) ->
 
 
 %%----------------------------------------------------------------------
-%%Control that the request header did not contians any limitations
-%%wheather a response shall be createed or not
+%%Control that the request header did not contains any limitations
+%%whether a response shall be created or not
 %%----------------------------------------------------------------------
 
 do_responsecontrol(Info) ->

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia.erl
@@ -431,7 +431,7 @@ wrap_trans(State, Fun, Args, Retries, Mod, Kind) ->
 %% read lock is only set on the first node
 %% Nodes may either be a list of nodes or one node as an atom
 %% Mnesia on all Nodes must be connected to each other, but
-%% it is not neccessary that they are up and running.
+%% it is not necessary that they are up and running.
 
 lock(LockItem, LockKind) ->
     case get(mnesia_activity_state) of

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_bup.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_bup.erl
@@ -775,7 +775,7 @@ restore_tables([Rec | Recs], Header, Schema, State = {local, LocalTabs, L}) ->
 restore_tables([], _Header, _Schema, State) ->
     State.
 
-%% Creates all neccessary dat files and inserts
+%% Creates all necessary dat files and inserts
 %% the table definitions in the schema table
 %%
 %% Returns a list of local_tab tuples for all local tables

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_checkpoint.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_checkpoint.erl
@@ -332,7 +332,7 @@ really_retain(Name, Tab) ->
 %%
 %% {min, MinTabs}
 %%   Minimize redundancy and only keep checkpoint info together with
-%%   one replica, preferrably at the local node. If any node involved
+%%   one replica, preferably at the local node. If any node involved
 %%   the checkpoint goes down, the checkpoint is deactivated.
 %%
 %% {max, MaxTabs}
@@ -345,7 +345,7 @@ really_retain(Name, Tab) ->
 %% {ram_overrides_dump, Tabs}
 %%   Only applicable for ram_copies. Bool controls which versions of
 %%   the records that should be included in the checkpoint state.
-%%   true means that the latest comitted records in ram (i.e. the
+%%   true means that the latest committed records in ram (i.e. the
 %%   records that the application accesses) should be included
 %%   in the checkpoint. false means that the records dumped to
 %%   dat-files (the records that will be loaded at startup) should

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_loader.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_loader.erl
@@ -61,7 +61,7 @@ do_get_disc_copy2(Tab, Reason, Storage, Type) when Storage == disc_copies ->
     Repair = mnesia_monitor:get_env(auto_repair),
     Args = [{keypos, 2}, public, named_table, Type],
     case Reason of
-	{dumper, _} -> %% Resources allready allocated
+	{dumper, _} -> %% Resources already allocated
 	    ignore;
 	_ ->
 	    mnesia_monitor:mktab(Tab, Args),
@@ -82,7 +82,7 @@ do_get_disc_copy2(Tab, Reason, Storage, Type) when Storage == disc_copies ->
 do_get_disc_copy2(Tab, Reason, Storage, Type) when Storage == ram_copies ->
     Args = [{keypos, 2}, public, named_table, Type],
     case Reason of
-	{dumper, _} -> %% Resources allready allocated
+	{dumper, _} -> %% Resources already allocated
 	    ignore;
 	_ ->
 	    mnesia_monitor:mktab(Tab, Args),

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_locker.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_locker.erl
@@ -170,14 +170,14 @@ loop(State) ->
 	    end;
 
 	%% If test_set_sticky fails, we send this to all nodes
-	%% after aquiring a real write lock on Oid
+	%% after acquiring a real write lock on Oid
 
 	{stick, {Tab, _}, N} ->
 	    ?ets_insert(mnesia_sticky_locks, {Tab, N}),
 	    loop(State);
 
 	%% The caller which sends this message, must have first
-	%% aquired a write lock on the entire table
+	%% acquired a write lock on the entire table
 	{unstick, Tab} ->
 	    ?ets_delete(mnesia_sticky_locks, Tab),
 	    loop(State);
@@ -738,11 +738,11 @@ dirty_sticky_lock(Tab, Key, Nodes, Lock) ->
 sticky_wlock_table(Tid, Store, Tab) ->
     sticky_lock(Tid, Store, {Tab, ?ALL}, write).
 
-%% aquire a wlock on Oid
+%% acquire a wlock on Oid
 %% We store a {Tabname, write, Tid} in all locktables
 %% on all nodes containing a copy of Tabname
 %% We also store an item {{locks, Tab, Key}, write} in the
-%% local store when we have aquired the lock.
+%% local store when we have acquired the lock.
 %%
 wlock(Tid, Store, Oid) ->
     {Tab, Key} = Oid,

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_monitor.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_monitor.erl
@@ -144,7 +144,7 @@ check_protocol([{Node, {accept, Mon, _Version, Protocol}} | Tail], Protocols) ->
 	    end,
 	    [node(Mon) | check_protocol(Tail, Protocols)];
 	false  ->
-	    unlink(Mon), % Get rid of unneccessary link
+	    unlink(Mon), % Get rid of unnecessary link
 	    check_protocol(Tail, Protocols)
     end;
 check_protocol([{Node, {reject, _Mon, Version, Protocol}} | Tail], Protocols) ->

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_schema.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_schema.erl
@@ -1265,7 +1265,7 @@ make_change_table_copy_type(Tab, Node, ToS) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% change index functions ....
-%% Pos is allready added by 1 in both of these functions
+%% Pos is already added by 1 in both of these functions
 
 add_table_index(Tab, Pos) ->
     schema_transaction(fun() -> do_add_table_index(Tab, Pos) end).

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_tm.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_tm.erl
@@ -1615,7 +1615,7 @@ commit_participant(Coord, Tid, Bin, C0, DiscNs, _RamNs) ->
 
 do_abort(Tid, Bin) when binary(Bin) ->
     %% Possible optimization:
-    %% If we want we could pass arround a flag
+    %% If we want we could pass around a flag
     %% that tells us whether the binary contains
     %% schema ops or not. Only if the binary
     %% contains schema ops there are meningful

--- a/lib/dialyzer/test/small_SUITE_data/src/tuple1.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/tuple1.erl
@@ -2,7 +2,7 @@
 %%% File    : tuple1.erl
 %%% Author  : Tobias Lindahl <tobiasl@csd.uu.se>
 %%% Description : Exposed two bugs in the analysis;
-%%%               one supressed warning and one crash.
+%%%               one suppressed warning and one crash.
 %%%
 %%% Created : 13 Nov 2006 by Tobias Lindahl <tobiasl@csd.uu.se>
 %%%-------------------------------------------------------------------

--- a/lib/diameter/include/diameter_gen.hrl
+++ b/lib/diameter/include/diameter_gen.hrl
@@ -424,7 +424,7 @@ d(true, _, Name, Avp, Acc) ->
 
 %% ... or not. Failures here won't be visible since they're a "normal"
 %% occurrence if the peer sends a faulty AVP that we need to respond
-%% sensibly to. Log the occurence for traceability, but the peer will
+%% sensibly to. Log the occurrence for traceability, but the peer will
 %% also receive info in the resulting answer message.
 d(false, Reason, Name, Avp, {Avps, Acc}) ->
     Stack = diameter_lib:get_stacktrace(),

--- a/lib/diameter/src/base/diameter_callback.erl
+++ b/lib/diameter/src/base/diameter_callback.erl
@@ -35,7 +35,7 @@
 %% in a callback applied to the atom-valued callback name and argument
 %% list. For all callbacks not to this module, the 'extra' field is a
 %% list of additional arguments, following arguments supplied by
-%% diameter but preceeding those of the diameter:evaluable() being
+%% diameter but preceding those of the diameter:evaluable() being
 %% applied.
 %%
 %% For example, the following config to diameter:start_service/2, in

--- a/lib/diameter/src/base/diameter_config.erl
+++ b/lib/diameter/src/base/diameter_config.erl
@@ -865,7 +865,7 @@ init_cb(List) ->
                    V <- [proplists:get_value(F, List, D)]],
     #diameter_callback{} = list_to_tuple([diameter_callback | Values]).
 
-%% Retreive and validate.
+%% Retrieve and validate.
 get_opt(Key, List, Def, Other) ->
     init_opt(Key, get_opt(Key, List, Def), [Def|Other]).
 

--- a/lib/diameter/src/base/diameter_peer_fsm.erl
+++ b/lib/diameter/src/base/diameter_peer_fsm.erl
@@ -356,7 +356,7 @@ handle_info(T, #state{} = State) ->
 
 %% Note that there's no guarantee that the service and transport
 %% capabilities are good enough to build a CER/CEA that can be
-%% succesfully encoded. It's not checked at diameter:add_transport/2
+%% successfully encoded. It's not checked at diameter:add_transport/2
 %% since this can be called before creating the service.
 
 %% terminate/2

--- a/lib/diameter/src/info/diameter_info.erl
+++ b/lib/diameter/src/info/diameter_info.erl
@@ -195,7 +195,7 @@ format(Tables, SFun, CFun)
 %%%
 %%% Description: Pretty-print records in a named tables as collected
 %%%              from local and remote nodes. Each table listing is
-%%%              preceeded by a banner.
+%%%              preceded by a banner.
 %%% ----------------------------------------------------------
 
 format(Local, Remote, SFun) ->

--- a/lib/diameter/src/transport/diameter_sctp.erl
+++ b/lib/diameter/src/transport/diameter_sctp.erl
@@ -402,7 +402,7 @@ handle_info(T, #transport{} = S) ->
 handle_info(T, #listener{} = S) ->
     {noreply, #listener{} = l(T,S)}.
 
-%% Prior to the possiblity of setting pool_size on in transport
+%% Prior to the possibility of setting pool_size on in transport
 %% configuration, a new accepting transport was only started following
 %% the death of a predecessor, so that there was only at most one
 %% previously started transport process waiting for an association.

--- a/lib/diameter/test/diameter_pool_SUITE.erl
+++ b/lib/diameter/test/diameter_pool_SUITE.erl
@@ -115,7 +115,7 @@ connect(ClientProt, ServerProt) ->
     %% 'up' events. (Although it's likely.)
     sleep(),
     {9,5} = count("server", LRef, accept), %% 5 connections + 4 accepting
-    %% Ensure ther are still the expected number of accepting transports
+    %% Ensure there are still the expected number of accepting transports
     %% after stopping the client service.
     ok = diameter:stop_service("client"),
     sleep(),

--- a/lib/edoc/src/edoc_tags.erl
+++ b/lib/edoc/src/edoc_tags.erl
@@ -227,7 +227,7 @@ filter_tags([#tag{name = N, line = L} = T | Ts], Tags, Where, Ts1) ->
 filter_tags([], _, _, Ts) ->
     lists:reverse(Ts).
 
-%% Check occurrances of tags.
+%% Check occurrences of tags.
 
 check_tags(Ts, Allow, Single, Where) ->
     check_tags(Ts, Allow, Single, Where, false, sets:new()).

--- a/lib/eldap/test/README
+++ b/lib/eldap/test/README
@@ -16,7 +16,7 @@ To start slapd:
 
 This will however not work, since slapd is guarded by apparmor that checks that slapd does not access other than allowed files...
 
-To make a local extension of alowed operations:
+To make a local extension of allowed operations:
     sudo emacs /etc/apparmor.d/local/usr.sbin.slapd
 
 and, after the change (yes, at least on Ubuntu it is right to edit ../local/.. but run with another file):

--- a/lib/erl_interface/src/README
+++ b/lib/erl_interface/src/README
@@ -11,7 +11,7 @@ Also, assertions are enabled, meaning that the code will be a
 little bit slower.  In the final release, there will be two
 alternative libraries shipped, with and without assertions.
 
-If an assertion triggers, there will be a printout similiar to this
+If an assertion triggers, there will be a printout similar to this
 one:
 
 	Assertion failed: ep != NULL in erl_eterm.c, line 694

--- a/lib/erl_interface/src/legacy/erl_marshal.c
+++ b/lib/erl_interface/src/legacy/erl_marshal.c
@@ -1626,7 +1626,7 @@ static int cmp_refs(unsigned char **e1, unsigned char **e2)
     if (cre1 != cre2)
 	return cre1 < cre2 ? -1 : 1;
 
-    /* ... and then finaly ids. */
+    /* ... and then finally ids. */
     if (n1 != n2) {
 	unsigned char zero[] = {0, 0, 0, 0};
 	if (n1 > n2)
@@ -1791,7 +1791,7 @@ static int cmp_exe2(unsigned char **e1, unsigned char **e2)
         if      (port1.creation < port2.creation) return -1;
         else if (port1.creation > port2.creation) return 1;
 
-      /* ... and then finaly ids. */
+      /* ... and then finally ids. */
         if      (port1.id < port2.id) return -1;
         else if (port1.id > port2.id) return 1;
 

--- a/lib/erl_interface/src/misc/ei_locking.c
+++ b/lib/erl_interface/src/misc/ei_locking.c
@@ -76,8 +76,8 @@ ei_mutex_t *ei_mutex_create(void)
   return l;
 }
 
-/* 
- * Free a mutex and the structure asociated with it.
+/*
+ * Free a mutex and the structure associated with it.
  *
  * This function attempts to obtain the mutex before releasing it;
  * If nblock == 1 and the mutex was unavailable, the function will

--- a/lib/erl_interface/test/ei_decode_SUITE.erl
+++ b/lib/erl_interface/test/ei_decode_SUITE.erl
@@ -99,7 +99,7 @@ test_ei_decode_ulonglong(Config) when is_list(Config) ->
 
 
 %% ######################################################################## %%
-%% A "character" for us is an 8 bit integer, alwasy positive, i.e.
+%% A "character" for us is an 8 bit integer, always positive, i.e.
 %% it is unsigned.
 %% FIXME maybe the API should change to use "unsigned char" to be clear?!
 

--- a/lib/erl_interface/test/erl_eterm_SUITE.erl
+++ b/lib/erl_interface/test/erl_eterm_SUITE.erl
@@ -31,7 +31,7 @@
 %%% 2. Constructing terms (the erl_mk_xxx() functions and erl_copy_term()).
 %%% 3. Extracting & info functions (erl_hd(), erl_length() etc).
 %%% 4. I/O list functions.
-%%% 5. Miscellanous functions.
+%%% 5. Miscellaneous functions.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 -export([all/0, suite/0,

--- a/lib/eunit/doc/src/notes.xml
+++ b/lib/eunit/doc/src/notes.xml
@@ -498,7 +498,7 @@
       <list>
         <item>
           <p>
-	    Miscellanous updates.</p>
+	    Miscellaneous updates.</p>
           <p>
 	    Own Id: OTP-8038</p>
         </item>

--- a/lib/hipe/cerl/cerl_to_icode.erl
+++ b/lib/hipe/cerl/cerl_to_icode.erl
@@ -2621,7 +2621,7 @@ icode_switch_val(Arg, Fail, Length, Cases) ->
     hipe_icode:mk_switch_val(Arg, Fail, Length, Cases).
 
 icode_switch_tuple_arity(Arg, Fail, Length, Cases) ->
-    SortedCases = lists:keysort(1, Cases), %% immitate BEAM compiler - Kostis
+    SortedCases = lists:keysort(1, Cases), %% imitate BEAM compiler - Kostis
     hipe_icode:mk_switch_tuple_arity(Arg, Fail, Length, SortedCases).
 
 

--- a/lib/hipe/doc/src/notes.xml
+++ b/lib/hipe/doc/src/notes.xml
@@ -1297,7 +1297,7 @@
       <list>
         <item>
           <p>
-	    Miscellanous updates.</p>
+	    Miscellaneous updates.</p>
           <p>
 	    Own Id: OTP-8038</p>
         </item>

--- a/lib/hipe/flow/cfg.inc
+++ b/lib/hipe/flow/cfg.inc
@@ -212,7 +212,7 @@ info_update(CFG, I) ->
 -ifndef(GEN_CFG).
 
 -spec other_entrypoints(cfg()) -> [cfg_lbl()].
-%% @doc Returns a list of labels that are refered to from the data section.
+%% @doc Returns a list of labels that are referred to from the data section.
 
 other_entrypoints(CFG) ->
   hipe_consttab:referred_labels(data(CFG)).

--- a/lib/hipe/flow/hipe_dominators.erl
+++ b/lib/hipe/flow/hipe_dominators.erl
@@ -317,7 +317,7 @@ updateCell(Value, Field, WD) ->
 %%>----------------------------------------------------------------------<
 %% Procedure : dfs/1
 %% Purpose   : The main purpose of this function is to traverse the CFG in
-%%             a depth first order. It is aslo used to initialize certain 
+%%             a depth first order. It is also used to initialize certain
 %%             elements defined in a workDataCell.
 %% Arguments : CFG - a Control Flow Graph representation
 %% Returns   : A table (WorkData) and the total number of elements in

--- a/lib/hipe/llvm/hipe_rtl_to_llvm.erl
+++ b/lib/hipe/llvm/hipe_rtl_to_llvm.erl
@@ -1431,7 +1431,7 @@ relocs_to_list(Relocs) ->
 %%         constants/labels.
 handle_relocations(Relocs, Data, Fun) ->
   RelocsList = relocs_to_list(Relocs),
-  %% Seperate Relocations according to their type
+  %% Separate Relocations according to their type
   {CallList, AtomList, ClosureList, ClosureLabels, SwitchList} =
     seperate_relocs(RelocsList),
   %% Create code to declare atoms
@@ -1474,7 +1474,7 @@ handle_relocations(Relocs, Data, Fun) ->
   LocalVariables = AtomLoad ++ ClosureLoad ++ ConstLoad,
   {Relocs4, ExternalDeclarations, LocalVariables}.
 
-%% @doc Seperate relocations according to their type.
+%% @doc Separate relocations according to their type.
 seperate_relocs(Relocs) ->
   seperate_relocs(Relocs, [], [], [], [], []).
 

--- a/lib/hipe/opt/hipe_schedule.erl
+++ b/lib/hipe/opt/hipe_schedule.erl
@@ -1337,10 +1337,10 @@ cd([{N,I}|Xs], DAG, PrevBr, PrevUnsafe, PrevOthers) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Function    : cd_branch_to_other_deps
 %% Argument    : N   - index of branch
-%%               Ms  - list of indexes of "others" preceeding instrs
+%%               Ms  - list of indexes of "others" preceding instrs
 %%               DAG - dependence graph
 %% Returns     : DAG - new graph
-%% Description : Makes preceeding instrs fixed so they don't bypass a branch
+%% Description : Makes preceding instrs fixed so they don't bypass a branch
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 cd_branch_to_other_deps(_, [], DAG) ->
     DAG;

--- a/lib/hipe/opt/hipe_spillmin_color.erl
+++ b/lib/hipe/opt/hipe_spillmin_color.erl
@@ -119,7 +119,7 @@ color_heuristic(IG, Min, Max, Safe, MaxNodes, Target, MaxDepth) ->
       end;
     _ ->
       %% This can be increased from 2, and by this the heuristic can be
-      %% exited earlier, but the same can be achived by decreasing the
+      %% exited earlier, but the same can be achieved by decreasing the
       %% recursion depth. This should not be decreased below 2.
       case (Max - Min) < 2 of
         true ->

--- a/lib/inets/test/httpd_test_data/server_root/conf/httpd.conf
+++ b/lib/inets/test/httpd_test_data/server_root/conf/httpd.conf
@@ -128,7 +128,7 @@ SecurityDiskLogSize 200000 10
 
 MaxClients 50
 
-# KeepAlive set the flag for persistent connections. For peristent connections
+# KeepAlive set the flag for persistent connections. For persistent connections
 # set KeepAlive to on. To use One request per connection set the flag to off
 # Note: The value has changed since previous version of INETS.
 KeepAlive on

--- a/lib/inets/test/old_httpd_SUITE_data/server_root/conf/httpd.conf
+++ b/lib/inets/test/old_httpd_SUITE_data/server_root/conf/httpd.conf
@@ -128,7 +128,7 @@ SecurityDiskLogSize 200000 10
 
 MaxClients 50
 
-# KeepAlive set the flag for persistent connections. For peristent connections
+# KeepAlive set the flag for persistent connections. For persistent connections
 # set KeepAlive to on. To use One request per connection set the flag to off
 # Note: The value has changed since previous version of INETS.
 KeepAlive on

--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java
@@ -30,7 +30,7 @@ import java.util.Random;
  * received from the peer.
  *
  * <p>
- * This abstract class provides the neccesary methods to maintain the actual
+ * This abstract class provides the necessary methods to maintain the actual
  * connection and encode the messages and headers in the proper format according
  * to the Erlang distribution protocol. Subclasses can use these methods to
  * provide a more or less transparent communication channel as desired.

--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpMbox.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpMbox.java
@@ -38,7 +38,7 @@ package com.ericsson.otp.erlang;
  * <p>
  * Mailboxes can be named, either at creation or later. Messages can be sent to
  * named mailboxes and named Erlang processes without knowing the
- * {@link OtpErlangPid pid} that identifies the mailbox. This is neccessary in
+ * {@link OtpErlangPid pid} that identifies the mailbox. This is necessary in
  * order to set up initial communication between parts of an application. Each
  * mailbox can have at most one name.
  * </p>

--- a/lib/kernel/doc/src/notes.xml
+++ b/lib/kernel/doc/src/notes.xml
@@ -108,7 +108,7 @@
         <item>
           <p>
 	    Close stdin of commands run in os:cmd. This is a
-	    backwards compatiblity fix that restores the behaviour of
+	    backwards compatibility fix that restores the behaviour of
 	    pre 19.0 os:cmd.</p>
           <p>
 	    Own Id: OTP-13867 Aux Id: seq13178 </p>
@@ -1445,7 +1445,7 @@
 	    dependent, so applications aiming to be portable should
 	    consider using <c>{ipv6_v6only,true}</c> when creating an
 	    <c>inet6</c> listening/destination socket, and if
-	    neccesary also create an <c>inet</c> socket on the same
+	    necessary also create an <c>inet</c> socket on the same
 	    port for IPv4 traffic. See the documentation.</p>
           <p>
 	    Own Id: OTP-8928 Aux Id: kunagi-193 [104] </p>

--- a/lib/kernel/include/inet.hrl
+++ b/lib/kernel/include/inet.hrl
@@ -22,7 +22,7 @@
 
 -record(hostent,
 	{
-	 h_name		  :: inet:hostname(),	%% offical name of host
+	 h_name		  :: inet:hostname(),	%% official name of host
 	 h_aliases = []   :: [inet:hostname()],	%% alias list
 	 h_addrtype	  :: 'inet' | 'inet6',	%% host address type
 	 h_length	  :: non_neg_integer(),	%% length of address

--- a/lib/kernel/src/inet_parse.erl
+++ b/lib/kernel/src/inet_parse.erl
@@ -701,8 +701,8 @@ dup(N, E, L) when is_integer(N), N >= 1 ->
 
 
 
-%% Convert IPv4 adress to ascii
-%% Convert IPv6 / IPV4 adress to ascii (plain format)
+%% Convert IPv4 address to ascii
+%% Convert IPv6 / IPV4 address to ascii (plain format)
 ntoa({A,B,C,D}) ->
     integer_to_list(A) ++ "." ++ integer_to_list(B) ++ "." ++ 
 	integer_to_list(C) ++ "." ++ integer_to_list(D);

--- a/lib/kernel/src/inet_udp.erl
+++ b/lib/kernel/src/inet_udp.erl
@@ -113,7 +113,7 @@ fdopen(Fd, Opts) ->
 %% Here's how:
 %%   Reverse the list.
 %%   For each head option go through the tail and remove
-%%   all occurences of the same option from the tail.
+%%   all occurrences of the same option from the tail.
 %%   Store that head option and iterate using the new tail.
 %%   Return the list of stored head options.
 optuniquify(List) ->
@@ -122,8 +122,8 @@ optuniquify(List) ->
 optuniquify([], Result) ->
     Result;
 optuniquify([Opt | Tail], Result) ->
-    %% Remove all occurences of Opt in Tail, 
-    %% prepend Opt to Result, 
+    %% Remove all occurrences of Opt in Tail,
+    %% prepend Opt to Result,
     %% then iterate back here.
     optuniquify(Opt, Tail, [], Result).
 

--- a/lib/kernel/test/application_SUITE.erl
+++ b/lib/kernel/test/application_SUITE.erl
@@ -1498,7 +1498,7 @@ otp_5363(Conf) when is_list(Conf) ->
 %% Ticket: OTP-5606
 %% Slogan: Problems with starting a distributed application
 %%-----------------------------------------------------------------
-%% Test of several processes simultanously starting the same
+%% Test of several processes simultaneously starting the same
 %% distributed application.
 otp_5606(Conf) when is_list(Conf) ->
 

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -233,7 +233,7 @@ time_ping(Node) ->
     erlang:convert_time_unit(T1 - T0, native, millisecond).
 
 %% Keep the connection with the client node up.
-%% This is neccessary as the client node runs with much shorter
+%% This is necessary as the client node runs with much shorter
 %% tick time !!
 keep_conn(Node) ->
     sleep(1),
@@ -1059,7 +1059,7 @@ monitor_nodes_otp_6481_test(Config, TestType) when is_list(Config) ->
     RemotePid = spawn(Node,
 		      fun () ->
 			      receive after 1500 -> ok end,
-			      %% infinit loop of msgs
+			      %% infinite loop of msgs
 			      %% we want an endless stream of messages and the kill
 			      %% the node mercilessly.
 			      %% We then want to ensure that the nodedown message arrives

--- a/lib/kernel/test/erl_distribution_wb_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_wb_SUITE.erl
@@ -30,7 +30,7 @@
 
 %% 1)
 %%
-%% Connections are now always set up symetrically with respect to
+%% Connections are now always set up symmetrically with respect to
 %% publication. If connecting node doesn't send DFLAG_PUBLISHED
 %% the other node wont send DFLAG_PUBLISHED. If the connecting
 %% node send DFLAG_PUBLISHED but the other node doesn't send

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -18,7 +18,7 @@
 %% %CopyrightEnd%
 %%
 
-%% This is a developement feature when developing a new file module,
+%% This is a development feature when developing a new file module,
 %% ugly but practical.
 -ifndef(FILE_MODULE).
 -define(FILE_MODULE, file).

--- a/lib/kernel/test/file_SUITE_data/realmen.html
+++ b/lib/kernel/test/file_SUITE_data/realmen.html
@@ -237,7 +237,7 @@ destroy most of the interesting uses for EQUIVALENCE, and make it
 impossible to modify the operating system code with negative
 subscripts. Worst of all, bounds checking is inefficient.
 
-<LI> Source code maintainance systems. A Real Programmer keeps his
+<LI> Source code maintenance systems. A Real Programmer keeps his
 code locked up in a card file, because it implies that its owner
 cannot leave his important programs unguarded [5].
 
@@ -396,7 +396,7 @@ double stuff Oreos for special occasions.
 
 <LI> Underneath the Oreos is a flow-charting template, left there by
 the previous occupant of the office. (Real Programmers write programs,
-not documentation. Leave that to the maintainence people.)
+not documentation. Leave that to the maintenance people.)
 
 </UL> <P>
 

--- a/lib/megaco/src/text/megaco_text_gen_prev3a.hrl
+++ b/lib/megaco/src/text/megaco_text_gen_prev3a.hrl
@@ -424,7 +424,7 @@ enc_TransactionReply(#'TransactionReply'{transactionId        = Tid,
 					 transactionResult    = Res,
 					 %% These fields are actually not 
 					 %% supported in this implementation,
-					 %% but because the messanger module
+					 %% but because the messenger module
 					 %% cannot see any diff between the
 					 %% various v3 implementations...
 					 segmentNumber        = asn1_NOVALUE,

--- a/lib/megaco/src/text/megaco_text_gen_prev3b.hrl
+++ b/lib/megaco/src/text/megaco_text_gen_prev3b.hrl
@@ -424,7 +424,7 @@ enc_TransactionReply(#'TransactionReply'{transactionId        = Tid,
 					 transactionResult    = Res,
 					 %% These fields are actually not 
 					 %% supported in this implementation,
-					 %% but because the messanger module
+					 %% but because the messenger module
 					 %% cannot see any diff between the
 					 %% various v3 implementations...
 					 segmentNumber        = asn1_NOVALUE,

--- a/lib/megaco/src/text/megaco_text_gen_prev3c.hrl
+++ b/lib/megaco/src/text/megaco_text_gen_prev3c.hrl
@@ -434,7 +434,7 @@ enc_TransactionReply(#'TransactionReply'{transactionId        = Tid,
 					 transactionResult    = Res, 
 					 %% These fields are actually not 
 					 %% supported in this implementation,
-					 %% but because the messanger module
+					 %% but because the messenger module
 					 %% cannot see any diff between the
 					 %% various v3 implementations...
    					 segmentNumber        = asn1_NOVALUE,

--- a/lib/mnesia/src/mnesia_monitor.erl
+++ b/lib/mnesia/src/mnesia_monitor.erl
@@ -169,7 +169,7 @@ check_protocol([{Node, {accept, Mon, Version, Protocol}} | Tail], Protocols) ->
 	    verbose("Failed to connect with ~p. ~p protocols rejected. "
 		    "expected version = ~p, expected protocol = ~p~n",
 		    [Node, Protocols, Version, Protocol]),
-	    unlink(Mon), % Get rid of unneccessary link
+	    unlink(Mon), % Get rid of unnecessary link
 	    check_protocol(Tail, Protocols)
     end;
 check_protocol([{Node, {reject, _Mon, Version, Protocol}} | Tail], Protocols) ->

--- a/lib/mnesia/src/mnesia_schema.erl
+++ b/lib/mnesia/src/mnesia_schema.erl
@@ -1941,7 +1941,7 @@ make_change_table_copy_type(Tab, Node, ToS) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% change index functions ....
-%% Pos is allready added by 1 in both of these functions
+%% Pos is already added by 1 in both of these functions
 
 add_table_index(Tab, Pos) ->
     schema_transaction(fun() -> do_add_table_index(Tab, Pos) end).

--- a/lib/orber/src/orber_iiop.hrl
+++ b/lib/orber/src/orber_iiop.hrl
@@ -279,8 +279,8 @@
 %%----------------------------------------------------------------------
 %% Profile Body
 %%
-%% iiop_version: describes the version of IIOP that the agent at the 
-%%		specified adress is prepared to receive.
+%% iiop_version: describes the version of IIOP that the agent at the
+%%		specified address is prepared to receive.
 %% host: identifies the internet host to which the GIOP messages
 %%		for the specified object may be sent.
 %% port: contains the TCP?IP port number where the target agnet is listening

--- a/lib/orber/src/orber_initial_references.erl
+++ b/lib/orber/src/orber_initial_references.erl
@@ -89,7 +89,7 @@ install(Timeout, Options) ->
 		end,
     
     Wait = mnesia:wait_for_tables([orber_references], Timeout),
-    %% Check if any error has occured yet. If there are errors, return them.
+    %% Check if any error has occurred yet. If there are errors, return them.
     if
 	DB_Result == {atomic, ok},
 	Wait == ok ->

--- a/lib/orber/src/orber_objectkeys.erl
+++ b/lib/orber/src/orber_objectkeys.erl
@@ -344,7 +344,7 @@ install(Timeout, Options) ->
 		end,
     
     Wait = mnesia:wait_for_tables([orber_objkeys], Timeout),
-    %% Check if any error has occured yet. If there are errors, return them.
+    %% Check if any error has occurred yet. If there are errors, return them.
     if
 	DB_Result == {atomic, ok},
 	Wait == ok ->

--- a/lib/parsetools/src/leex.erl
+++ b/lib/parsetools/src/leex.erl
@@ -1264,7 +1264,7 @@ pack_dfa([], _, Rs, PDFA) -> {PDFA,Rs}.
 %%      {Action, AcceptLength, CurrTokLen, RestChars, Line, State}.
 
 %% The return CurrTokLen is always the current number of characters
-%% scanned in the current token. The returns have the follwoing
+%% scanned in the current token. The returns have the following
 %% meanings:
 %% {Action, AcceptLength, RestChars, Line} -
 %%  The scanner has reached an accepting end-state, for example after
@@ -1281,7 +1281,7 @@ pack_dfa([], _, Rs, PDFA) -> {PDFA,Rs}.
 %%
 %% {reject, AcceptLength, CurrTokLen, RestChars, Line, State} -
 %% {Action, AcceptLength, CurrTokLen, RestChars, Line, State} -
-%%  The scanner has reached a non-accepting transistion state. If
+%%  The scanner has reached a non-accepting transition state. If
 %%  RestChars == [] we need to get more characters to continue.
 %%  Otherwise if 'reject' then no accepting state has been reached it
 %%  is an error. If we have an Action and AcceptLength then these are

--- a/lib/public_key/asn1/PKCS-8.asn1
+++ b/lib/public_key/asn1/PKCS-8.asn1
@@ -26,7 +26,7 @@ BEGIN
 
 -- This import is really unnecessary since ALGORITHM-IDENTIFIER is defined as a 
 -- TYPE-IDENTIFIER
--- Renome this import and replace all occurences of ALGORITHM-IDENTIFIER with
+-- Rename this import and replace all occurrences of ALGORITHM-IDENTIFIER with
 -- TYPE-IDENTIFIER as a workaround for weaknesses in the ASN.1 compiler
 --AlgorithmIdentifier, ALGORITHM-IDENTIFIER
 --        FROM PKCS5v2-0 {iso(1) member-body(2) us(840) rsadsi(113549)

--- a/lib/snmp/test/snmp_manager_test.erl
+++ b/lib/snmp/test/snmp_manager_test.erl
@@ -1760,7 +1760,7 @@ do_simple_sync_get2(Node, TargetName, Oids, Get, PostVerify)
 	 "~n   Rem:   ~w", [Reply, _Rem]),
 
     %% verify that the operation actually worked:
-    %% The order should be the same, so no need to seach 
+    %% The order should be the same, so no need to search
     ?line ok = case Reply of
 		   {noError, 0, [#varbind{oid   = ?sysObjectID_instance,
 					  value = SysObjectID}, 
@@ -2709,7 +2709,7 @@ do_simple_set2(Node, TargetName, VAVs, Set, PostVerify) ->
 	 "~n   Rem:   ~w", [Reply, _Rem]),
 
     %% verify that the operation actually worked:
-    %% The order should be the same, so no need to seach 
+    %% The order should be the same, so no need to search
     %% The value we get should be exactly the same as we sent
     ?line ok = case Reply of
 		   {noError, 0, [#varbind{oid   = ?sysName_instance,
@@ -5118,10 +5118,10 @@ inform_swarm_collector(N) ->
 
 %% Note that we need to deal with re-transmissions!
 %% That is, the agent did not receive the ack in time,
-%% and therefor did a re-transmit. This means that we 
-%% expect to receive more inform's then we actually 
-%% sent. So for sucess we assume: 
-%% 
+%% and therefor did a re-transmit. This means that we
+%% expect to receive more inform's then we actually
+%% sent. So for success we assume:
+%%
 %%     SentAckCnt =  N
 %%     RespCnt    =  N
 %%     RecvCnt    >= N

--- a/lib/ssh/src/ssh_sftp.erl
+++ b/lib/ssh/src/ssh_sftp.erl
@@ -294,7 +294,7 @@ read(Pid, Handle, Len) ->
 read(Pid, Handle, Len, FileOpTimeout) ->
     call(Pid, {read,false,Handle, Len}, FileOpTimeout).
 
-%% TODO this ought to be a cast! Is so in all practial meaning
+%% TODO this ought to be a cast! Is so in all practical meaning
 %% even if it is obscure!
 apread(Pid, Handle, Offset, Len) ->
     call(Pid, {pread,true,Handle, Offset, Len}, infinity).
@@ -313,12 +313,12 @@ write(Pid, Handle, Data) ->
 write(Pid, Handle, Data, FileOpTimeout) ->
     call(Pid, {write,false,Handle,Data}, FileOpTimeout).
 
-%% TODO this ought to be a cast! Is so in all practial meaning
+%% TODO this ought to be a cast! Is so in all practical meaning
 %% even if it is obscure!
 apwrite(Pid, Handle, Offset, Data) ->
     call(Pid, {pwrite,true,Handle,Offset,Data}, infinity).
 
-%% TODO this ought to be a cast!  Is so in all practial meaning
+%% TODO this ought to be a cast!  Is so in all practical meaning
 %% even if it is obscure!
 awrite(Pid, Handle, Data) ->
     call(Pid, {write,true,Handle,Data}, infinity).

--- a/lib/ssh/src/ssh_transport.erl
+++ b/lib/ssh/src/ssh_transport.erl
@@ -481,7 +481,7 @@ handle_kex_dh_gex_request(#ssh_msg_kex_dh_gex_request_old{n = NBits},
     %% This message was in the draft-00 of rfc4419
     %% (https://tools.ietf.org/html/draft-ietf-secsh-dh-group-exchange-00)
     %% In later drafts and the rfc is "is used for backward compatibility".
-    %% Unfortunatly the rfc does not specify how to treat the parameter n
+    %% Unfortunately the rfc does not specify how to treat the parameter n
     %% if there is no group of that modulus length :(
     %% The draft-00 however specifies that n is the "... number of bits
     %% the subgroup should have at least".

--- a/lib/ssh/test/ssh_to_openssh_SUITE.erl
+++ b/lib/ssh/test/ssh_to_openssh_SUITE.erl
@@ -442,7 +442,7 @@ erlang_server_openssh_client_renegotiate(Config) ->
 	ssh_test_lib:rcv_expected(Expect, OpenSsh, ?TIMEOUT)
     of
 	_ ->
-	    %% Unfortunatly we can't check that there has been a renegotiation, just trust OpenSSH.
+	    %% Unfortunately we can't check that there has been a renegotiation, just trust OpenSSH.
 	    ssh:stop_daemon(Pid)
     catch
 	throw:{skip,R} -> {skip,R}

--- a/lib/ssl/src/dtls_record.erl
+++ b/lib/ssl/src/dtls_record.erl
@@ -393,7 +393,7 @@ init_connection_state_seq(_, ConnnectionStates) ->
 					    integer().
 %%
 %% Description: Returns the epoch the connection_state record
-%% that is currently defined as the current conection state.
+%% that is currently defined as the current connection state.
 %%--------------------------------------------------------------------
 current_connection_state_epoch(#{current_read := #{epoch := Epoch}},
 			       read) ->

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -1017,7 +1017,7 @@ terminate(_, _, #state{terminated = true}) ->
     %% Happens when user closes the connection using ssl:close/1
     %% we want to guarantee that Transport:close has been called
     %% when ssl:close/1 returns unless it is a downgrade where
-    %% we want to guarantee that close alert is recived before 
+    %% we want to guarantee that close alert is received before
     %% returning. In both cases terminate has been run manually
     %% before run by gen_statem which will end up here
     ok;

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -67,7 +67,7 @@
 				      connection_state().
 %%
 %% Description: Returns the instance of the connection_state map
-%% that is currently defined as the current conection state.
+%% that is currently defined as the current connection state.
 %%--------------------------------------------------------------------
 current_connection_state(ConnectionStates, read) ->
     maps:get(current_read, ConnectionStates);
@@ -79,7 +79,7 @@ current_connection_state(ConnectionStates, write) ->
 				      connection_state().
 %%
 %% Description: Returns the instance of the connection_state map
-%% that is pendingly defined as the pending conection state.
+%% that is pendingly defined as the pending connection state.
 %%--------------------------------------------------------------------
 pending_connection_state(ConnectionStates, read) ->
     maps:get(pending_read, ConnectionStates);

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -88,7 +88,7 @@ client_hello(Host, Port, ConnectionStates,
 		    #hello_extensions{}, {ssl_cipher:hash(), ssl_cipher:sign_algo()} | undefined} |
 		   #alert{}.
 %%
-%% Description: Handles a recieved hello message
+%% Description: Handles a received hello message
 %%--------------------------------------------------------------------
 hello(#server_hello{server_version = Version, random = Random,
 		    cipher_suite = CipherSuite,

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -407,7 +407,7 @@ is_pair(Hash, rsa, Hashs) ->
     AtLeastMd5 = Hashs -- [md2,md4],
     lists:member(Hash, AtLeastMd5).
 
-%% list ECC curves in prefered order
+%% list ECC curves in preferred order
 -spec ecc_curves(1..3 | all) -> [named_curve()].
 ecc_curves(all) ->
     [sect571r1,sect571k1,secp521r1,brainpoolP512r1,

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -273,7 +273,7 @@ start_timer(Time, Msg) ->
 send_event_after(Time, Event) ->
     erlang:start_timer(Time, self(), {'$gen_event', Event}).
 
-%% Returns the remaing time for the timer if Ref referred to 
+%% Returns the remaining time for the timer if Ref referred to
 %% an active timer/send_event_after, false otherwise.
 cancel_timer(Ref) ->
     case erlang:cancel_timer(Ref) of

--- a/lib/stdlib/src/io_lib.erl
+++ b/lib/stdlib/src/io_lib.erl
@@ -28,7 +28,7 @@
 %% Most of the code here is derived from the original prolog versions and
 %% from similar code written by Joe Armstrong and myself.
 %%
-%% This module has been split into seperate modules:
+%% This module has been split into separate modules:
 %% io_lib        - basic write and utilities
 %% io_lib_format - formatted output
 %% io_lib_fread  - formatted input

--- a/lib/stdlib/src/proplists.erl
+++ b/lib/stdlib/src/proplists.erl
@@ -83,7 +83,7 @@ property(Key, Value) ->
 
 %% ---------------------------------------------------------------------
 
-%% @doc Unfolds all occurences of atoms in <code>ListIn</code> to tuples
+%% @doc Unfolds all occurrences of atoms in <code>ListIn</code> to tuples
 %% <code>{Atom, true}</code>.
 %%
 %% @see compact/1

--- a/lib/stdlib/test/base64_SUITE.erl
+++ b/lib/stdlib/test/base64_SUITE.erl
@@ -82,7 +82,7 @@ base64_decode(Config) when is_list(Config) ->
     Alphabet = list_to_binary(lists:seq(0, 255)),
     Alphabet = base64:decode(base64:encode(Alphabet)),
 
-    %% Encoded base 64 strings may be devided by non base 64 chars.
+    %% Encoded base 64 strings may be divided by non base 64 chars.
     %% In this cases whitespaces.
     "0123456789!@#0^&*();:<>,. []{}" =
 	base64:decode_to_string(

--- a/lib/wx/api_gen/gen_util.erl
+++ b/lib/wx/api_gen/gen_util.erl
@@ -203,7 +203,7 @@ replace_and_remove([$; | R], Acc) ->
 replace_and_remove([$@ | R], Acc) ->
     replace_and_remove(R, [directive|Acc]);
 
-replace_and_remove([_E|R], Acc) ->       %% Ignore everthing else
+replace_and_remove([_E|R], Acc) ->       %% Ignore everything else
     replace_and_remove(R, Acc);
 replace_and_remove([], Acc) ->
     Acc.

--- a/lib/wx/api_gen/wx_gen_cpp.erl
+++ b/lib/wx/api_gen/wx_gen_cpp.erl
@@ -627,7 +627,7 @@ decode_arg(N,#type{name="wxArrayString"},Place,A0) ->
     w(" int * ~sLen = (int *) bp; bp += 4;~n", [N]),
     case Place of
 	arg -> w(" wxArrayString ~s;~n", [N]);
-	opt -> ignore %% Allready declared
+	opt -> ignore %% Already declared
     end,
     w(" int ~sASz = 0, * ~sTemp;~n", [N,N]),
     w(" for(int i=0; i < *~sLen; i++) {~n", [N]),

--- a/lib/xmerl/src/xmerl_regexp.erl
+++ b/lib/xmerl/src/xmerl_regexp.erl
@@ -1154,7 +1154,7 @@ comp_crs([], Last) -> [{Last,maxchar}].
 %% build_dfa(NFA, NfaStartState) -> {DFA,DfaStartState}.
 %%  Build a DFA from an NFA using "subset construction". The major
 %%  difference from the book is that we keep the marked and unmarked
-%%  DFA states in seperate lists. New DFA states are added to the
+%%  DFA states in separate lists. New DFA states are added to the
 %%  unmarked list and states are marked by moving them to the marked
 %%  list. We assume that the NFA accepting state numbers are in
 %%  ascending order for the rules and use ordsets to keep this order.

--- a/system/doc/efficiency_guide/bench.erl
+++ b/system/doc/efficiency_guide/bench.erl
@@ -355,7 +355,7 @@ create_html_report(ResultList) ->
 
     {ok, OutputFile} = file:open("index.html", [write]),
 
-    %% Create the begining of the result html-file.
+    %% Create the beginning of the result html-file.
     Head = Title = "Benchmark Results",
     io:put_chars(OutputFile, "<html>\n"),
     io:put_chars(OutputFile, "<head>\n"),


### PR DESCRIPTION
This is fixed PR based on #1295 without removing trailing spaces.

Commits are split based on path where typo was found. I can reorder them and create two commits:
1. Changes to code comments
2. Changes to docs (only 8 html/xml files)