### PR TITLE
Documentation: tuple funs are unsupported

### DIFF
--- a/lib/erl_interface/doc/src/erl_call.xml
+++ b/lib/erl_interface/doc/src/erl_call.xml
@@ -193,7 +193,7 @@ erl_call -s -a 'erlang halt' -n madonna
     <p>To apply with many arguments:</p>
 
     <code type="none"><![CDATA[
-erl_call -s -a 'lists map [{math,sqrt},[1,4,9,16,25]]' -n madonna
+erl_call -s -a 'lists seq [1,10]' -n madonna
     ]]></code>
 
     <p>To evaluate some expressions


### PR DESCRIPTION
In the efficiency guide, note that support for "tuple funs" was
removed in R16B.

Remove use of tuple fun from erl_call documentation.  It seems like
fun math:sqrt/1 isn't parsed correctly by erl_call, so I replaced the
example with a simpler one that doesn't require a fun.