### PR TITLE
ERL-61: Fixes the issue where kernel crashes if the hostname is 64 characters

### DIFF
--- a/erts/emulator/beam/erl_mtrace.c
+++ b/erts/emulator/beam/erl_mtrace.c
@@ -572,7 +572,7 @@ void erts_mtrace_pre_init(void)
 
 void erts_mtrace_init(char *receiver, char *nodename)
 {
-    char hostname[MAXHOSTNAMELEN];
+    char hostname[MAXHOSTNAMELEN + 1];
     char pid[21]; /* enough for a 64 bit number */
 
     socket_desc = ERTS_SOCK_INVALID_SOCKET;
@@ -613,9 +613,10 @@ void erts_mtrace_init(char *receiver, char *nodename)
 	}
 	tracep = trace_buffer;
 	endp = trace_buffer + TRACE_BUF_SZ;
-	if (erts_sock_gethostname(hostname, MAXHOSTNAMELEN) != 0)
+        /* gethostname requires that the len is max(hostname) + 1 */
+	if (erts_sock_gethostname(hostname, MAXHOSTNAMELEN + 1) != 0)
 	    hostname[0] = '\0';
-	hostname[MAXHOSTNAMELEN-1] = '\0';
+	hostname[MAXHOSTNAMELEN] = '\0';
 	sys_get_pid(pid, sizeof(pid));
 	write_trace_header(nodename ? nodename : "", pid, hostname);
 	erts_mtrace_update_heap_size();

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -8345,10 +8345,10 @@ static ErlDrvData inet_start(ErlDrvPort port, int size, int protocol)
     return (ErlDrvData)desc;
 }
 
-
-#ifndef MAXHOSTNAMELEN
-#define MAXHOSTNAMELEN 256
-#endif
+/* MAXHOSTNAMELEN could be 64 or 255 depending
+on the platform. Instead, use INET_MAXHOSTNAMELEN
+which is always 255 across all platforms */
+#define INET_MAXHOSTNAMELEN 255
 
 /*
 ** common TCP/UDP/SCTP control command
@@ -8525,13 +8525,14 @@ static ErlDrvSSizeT inet_ctl(inet_descriptor* desc, int cmd, char* buf,
     }
 	
     case INET_REQ_GETHOSTNAME: { /* get host name */
-	char tbuf[MAXHOSTNAMELEN];
+	char tbuf[INET_MAXHOSTNAMELEN + 1];
 
 	DEBUGF(("inet_ctl(%ld): GETHOSTNAME\r\n", (long)desc->port)); 
 	if (len != 0)
 	    return ctl_error(EINVAL, rbuf, rsize);
 
-	if (IS_SOCKET_ERROR(sock_hostname(tbuf, MAXHOSTNAMELEN)))
+        /* gethostname requires len to be max(hostname) + 1 */
+	if (IS_SOCKET_ERROR(sock_hostname(tbuf, INET_MAXHOSTNAMELEN + 1)))
 	    return ctl_error(sock_errno(), rbuf, rsize);
 	return ctl_reply(INET_REP_OK, tbuf, strlen(tbuf), rbuf, rsize);
     }

--- a/lib/erl_interface/src/connect/ei_connect.c
+++ b/lib/erl_interface/src/connect/ei_connect.c
@@ -497,7 +497,8 @@ int ei_connect_init(ei_cnode* ec, const char* this_node_name,
     }
 #endif /* _REENTRANT */
     
-    if (gethostname(thishostname, EI_MAXHOSTNAMELEN) == -1) {
+    /* gethostname requires len to be max(hostname) + 1 */
+    if (gethostname(thishostname, EI_MAXHOSTNAMELEN+1) == -1) {
 #ifdef __WIN32__
 	EI_TRACE_ERR1("ei_connect_init","Failed to get host name: %d",
 		      WSAGetLastError());
@@ -613,7 +614,8 @@ int ei_connect_tmo(ei_cnode* ec, char *nodename, unsigned ms)
     hp = ei_gethostbyname_r(hostname,&host,buffer,1024,&ei_h_errno);
     if (hp == NULL) {
 	char thishostname[EI_MAXHOSTNAMELEN+1];
-	if (gethostname(thishostname,EI_MAXHOSTNAMELEN) < 0) {
+        /* gethostname requies len to be max(hostname) + 1*/
+	if (gethostname(thishostname,EI_MAXHOSTNAMELEN+1) < 0) {
 	    EI_TRACE_ERR0("ei_connect_tmo",
 			  "Failed to get name of this host");
 	    erl_errno = EHOSTUNREACH;
@@ -636,7 +638,8 @@ int ei_connect_tmo(ei_cnode* ec, char *nodename, unsigned ms)
 #else /* __WIN32__ */
     if ((hp = ei_gethostbyname(hostname)) == NULL) {
 	char thishostname[EI_MAXHOSTNAMELEN+1];
-	if (gethostname(thishostname,EI_MAXHOSTNAMELEN) < 0) {
+        /* gethostname requires len to be max(hostname) + 1 */
+	if (gethostname(thishostname,EI_MAXHOSTNAMELEN+1) < 0) {
 	    EI_TRACE_ERR1("ei_connect_tmo",
 			  "Failed to get name of this host: %d", 
 			  WSAGetLastError());

--- a/lib/erl_interface/src/prog/erl_call.c
+++ b/lib/erl_interface/src/prog/erl_call.c
@@ -325,7 +325,8 @@ int erl_call(int argc, char **argv)
       initWinSock();
 #endif
 
-      if (gethostname(h_hostname, EI_MAXHOSTNAMELEN) < 0) {
+      /* gethostname requires len to be max(hostname) + 1 */
+      if (gethostname(h_hostname, EI_MAXHOSTNAMELEN+1) < 0) {
 	  fprintf(stderr,"erl_call: failed to get host name: %d\n", errno);
 	  exit(1);
       }

--- a/lib/ic/test/c_client_erl_server_SUITE_data/c_client.c
+++ b/lib/ic/test/c_client_erl_server_SUITE_data/c_client.c
@@ -58,7 +58,7 @@
 #include "erl_interface.h"
 #include "m_i.h"
 
-#define HOSTNAMESZ 256
+#define HOSTNAMESZ 255
 #define NODENAMESZ 512
 
 #define INBUFSZ 10
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
     
     progname = argv[0];
     host[HOSTNAMESZ] = '\0';
-    if (gethostname(host, HOSTNAMESZ) < 0) {
+    if (gethostname(host, HOSTNAMESZ + 1) < 0) {
 	fprintf(stderr, "Can't find own hostname\n");
 	done(1);
     } 

--- a/lib/ic/test/c_client_erl_server_proto_SUITE_data/c_client.c
+++ b/lib/ic/test/c_client_erl_server_proto_SUITE_data/c_client.c
@@ -61,7 +61,7 @@
 #include "erl_interface.h"
 #include "m_i.h"
 
-#define HOSTNAMESZ 256
+#define HOSTNAMESZ 255
 #define NODENAMESZ 512
 
 #define INBUFSZ 10
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
     
     progname = argv[0];
     host[HOSTNAMESZ] = '\0';
-    if (gethostname(host, HOSTNAMESZ) < 0) {
+    if (gethostname(host, HOSTNAMESZ + 1) < 0) {
 	fprintf(stderr, "Can't find own hostname\n");
 	done(1);
     } 

--- a/lib/ic/test/c_client_erl_server_proto_tmo_SUITE_data/c_client.c
+++ b/lib/ic/test/c_client_erl_server_proto_tmo_SUITE_data/c_client.c
@@ -61,7 +61,7 @@
 #include "erl_interface.h"
 #include "m_i.h"
 
-#define HOSTNAMESZ 256
+#define HOSTNAMESZ 255
 #define NODENAMESZ 512
 
 #define INBUFSZ 10
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
     
     progname = argv[0];
     host[HOSTNAMESZ] = '\0';
-    if (gethostname(host, HOSTNAMESZ) < 0) {
+    if (gethostname(host, HOSTNAMESZ + 1) < 0) {
 	fprintf(stderr, "Can't find own hostname\n");
 	done(1);
     } 

--- a/lib/ic/test/erl_client_c_server_SUITE_data/c_server.c
+++ b/lib/ic/test/erl_client_c_server_SUITE_data/c_server.c
@@ -81,7 +81,7 @@ static void showtime(MyTimeval *start, MyTimeval *stop);
 static void usage(void);
 static void done(int r);
 
-#define HOSTNAMESZ 	256
+#define HOSTNAMESZ 	255
 #define NODENAMESZ 	512
 #define INBUFSZ 	 10
 #define OUTBUFSZ 	  0
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
     
     progname = argv[0];
     host[HOSTNAMESZ] = '\0';
-    if (gethostname(host, HOSTNAMESZ) < 0) {
+    if (gethostname(host, HOSTNAMESZ + 1) < 0) {
 	fprintf(stderr, "Can't find own hostname\n");
 	done(1);
     } 

--- a/lib/ic/test/erl_client_c_server_proto_SUITE_data/c_server.c
+++ b/lib/ic/test/erl_client_c_server_proto_SUITE_data/c_server.c
@@ -81,7 +81,7 @@ static void showtime(MyTimeval *start, MyTimeval *stop);
 static void usage(void);
 static void done(int r);
 
-#define HOSTNAMESZ 	256
+#define HOSTNAMESZ 	255
 #define NODENAMESZ 	512
 #define INBUFSZ 	 10
 #define OUTBUFSZ 	  0
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
     
     progname = argv[0];
     host[HOSTNAMESZ] = '\0';
-    if (gethostname(host, HOSTNAMESZ) < 0) {
+    if (gethostname(host, HOSTNAMESZ + 1) < 0) {
 	fprintf(stderr, "Can't find own hostname\n");
 	done(1);
     } 


### PR DESCRIPTION
Some OSes allow hostname to be 64 characters  (linux) whereas others allow 255 characters (mac). Erlang runs fine on mac with 255 characters hostname. However, on linux, it crashes if the hostname to be 64 characters. This patch fixes the issue. Further, it tries to unify the hostname handling at different places. 