### PR TITLE
Making callbacks in OTP behaviours optional

### DIFF
--- a/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_incorrect_args
+++ b/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_incorrect_args
@@ -1,4 +1,4 @@
 
-gen_server_incorrect_args.erl:3: Undefined callback function init/1 (behaviour 'gen_server')
+gen_server_incorrect_args.erl:3: Undefined callback function handle_cast/2 (behaviour 'gen_server')
 gen_server_incorrect_args.erl:7: The inferred return type of handle_call/3 ({'no'} | {'ok'}) has nothing in common with {'noreply',_} | {'noreply',_,'hibernate' | 'infinity' | non_neg_integer()} | {'reply',_,_} | {'stop',_,_} | {'reply',_,_,'hibernate' | 'infinity' | non_neg_integer()} | {'stop',_,_,_}, which is the expected return type for the callback of gen_server behaviour
 gen_server_incorrect_args.erl:7: The inferred type for the 2nd argument of handle_call/3 ('boo' | 'foo') is not a supertype of {pid(),_}, which is expected type for this argument in the callback of the gen_server behaviour

--- a/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_incorrect_args
+++ b/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_incorrect_args
@@ -1,8 +1,4 @@
 
-gen_server_incorrect_args.erl:3: Undefined callback function code_change/3 (behaviour 'gen_server')
-gen_server_incorrect_args.erl:3: Undefined callback function handle_cast/2 (behaviour 'gen_server')
-gen_server_incorrect_args.erl:3: Undefined callback function handle_info/2 (behaviour 'gen_server')
 gen_server_incorrect_args.erl:3: Undefined callback function init/1 (behaviour 'gen_server')
-gen_server_incorrect_args.erl:3: Undefined callback function terminate/2 (behaviour 'gen_server')
 gen_server_incorrect_args.erl:7: The inferred return type of handle_call/3 ({'no'} | {'ok'}) has nothing in common with {'noreply',_} | {'noreply',_,'hibernate' | 'infinity' | non_neg_integer()} | {'reply',_,_} | {'stop',_,_} | {'reply',_,_,'hibernate' | 'infinity' | non_neg_integer()} | {'stop',_,_,_}, which is the expected return type for the callback of gen_server behaviour
 gen_server_incorrect_args.erl:7: The inferred type for the 2nd argument of handle_call/3 ('boo' | 'foo') is not a supertype of {pid(),_}, which is expected type for this argument in the callback of the gen_server behaviour

--- a/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_missing_callbacks
+++ b/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_missing_callbacks
@@ -1,2 +1,2 @@
 
-gen_server_missing_callbacks.erl:3: Undefined callback function init/1 (behaviour 'gen_server')
+gen_server_missing_callbacks.erl:3: Undefined callback function handle_cast/2 (behaviour 'gen_server')

--- a/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_missing_callbacks
+++ b/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_missing_callbacks
@@ -1,3 +1,2 @@
 
-gen_server_missing_callbacks.erl:3: Undefined callback function handle_cast/2 (behaviour 'gen_server')
-gen_server_missing_callbacks.erl:3: Undefined callback function handle_info/2 (behaviour 'gen_server')
+gen_server_missing_callbacks.erl:3: Undefined callback function init/1 (behaviour 'gen_server')

--- a/lib/dialyzer/test/behaviour_SUITE_data/results/vars_in_beh_spec
+++ b/lib/dialyzer/test/behaviour_SUITE_data/results/vars_in_beh_spec
@@ -1,2 +1,3 @@
 
-vars_in_beh_spec.erl:3: Undefined callback function init/1 (behaviour 'gen_server')
+vars_in_beh_spec.erl:3: Undefined callback function handle_call/3 (behaviour 'gen_server')
+vars_in_beh_spec.erl:3: Undefined callback function handle_cast/2 (behaviour 'gen_server')

--- a/lib/dialyzer/test/behaviour_SUITE_data/results/vars_in_beh_spec
+++ b/lib/dialyzer/test/behaviour_SUITE_data/results/vars_in_beh_spec
@@ -1,6 +1,2 @@
 
-vars_in_beh_spec.erl:3: Undefined callback function handle_call/3 (behaviour 'gen_server')
-vars_in_beh_spec.erl:3: Undefined callback function handle_cast/2 (behaviour 'gen_server')
-vars_in_beh_spec.erl:3: Undefined callback function handle_info/2 (behaviour 'gen_server')
 vars_in_beh_spec.erl:3: Undefined callback function init/1 (behaviour 'gen_server')
-vars_in_beh_spec.erl:3: Undefined callback function terminate/2 (behaviour 'gen_server')

--- a/lib/dialyzer/test/behaviour_SUITE_data/src/gen_server_missing_callbacks.erl
+++ b/lib/dialyzer/test/behaviour_SUITE_data/src/gen_server_missing_callbacks.erl
@@ -4,10 +4,13 @@
 
 -export([start_link/0]).
 
--export([handle_call/3, terminate/2, code_change/3]).
+-export([init/1, handle_call/3, terminate/2, code_change/3]).
 
 start_link() ->
     gen_server:start_link({local, myserver}, ?MODULE, [], []).
+
+init([]) ->
+    ignore.
 
 handle_call(_Request, _From, State) ->
     Reply = ok,

--- a/lib/dialyzer/test/behaviour_SUITE_data/src/gen_server_missing_callbacks.erl
+++ b/lib/dialyzer/test/behaviour_SUITE_data/src/gen_server_missing_callbacks.erl
@@ -4,13 +4,10 @@
 
 -export([start_link/0]).
 
--export([init/1, handle_call/3, terminate/2, code_change/3]).
+-export([handle_call/3, terminate/2, code_change/3]).
 
 start_link() ->
     gen_server:start_link({local, myserver}, ?MODULE, [], []).
-
-init([]) ->
-    ignore.
 
 handle_call(_Request, _From, State) ->
     Reply = ok,

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -579,6 +579,12 @@ gen_event:stop             ----->  Module:terminate/2
         <v>Extra = term()</v>
       </type>
       <desc>
+         <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_event</c> module provides a default
+            implementation of this function that returns
+            <c>{ok, State}</c>.</p>
+        </note>
         <p>This function is called for an installed event handler that
           is to update its internal state during a release
           upgrade/downgrade, that is, when the instruction
@@ -671,6 +677,13 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;&nbsp;Id = term()</v>
       </type>
       <desc>
+         <note>
+          <p>This callback is optional, so callback modules need not
+            export it. If
+            <seealso marker="#call/3"><c>call/3,4</c></seealso> is called
+            when handle_call is not exported in the callback module
+            the event handler will crash with an <c>undef</c> exit reason.</p>
+        </note>
         <p>Whenever an event manager receives a request sent using
           <seealso marker="#call/3"><c>call/3,4</c></seealso>,
           this function is called for
@@ -759,6 +772,12 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;&nbsp;Id = term()</v>
       </type>
       <desc>
+         <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_event</c> module provides a default
+            implementation of this function that drops the <c>Info</c>
+            message and returns <c>{ok, State}</c>.</p>
+        </note>
         <p>This function is called for each installed event handler when
           an event manager receives any other message than an event or
           a synchronous request (or a system message).</p>
@@ -815,6 +834,11 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;Args = Reason = Term = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_event</c> module provides a default
+            implementation without cleanup.</p>
+        </note>
         <p>Whenever an event handler is deleted from an event manager,
           this function is called. It is to be the opposite of
           <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -579,11 +579,12 @@ gen_event:stop             ----->  Module:terminate/2
         <v>Extra = term()</v>
       </type>
       <desc>
-         <note>
-          <p>This callback is optional, so callback modules need not
-            export it. The <c>gen_event</c> module provides a default
-            implementation of this function that returns
-            <c>{ok, State}</c>.</p>
+        <note>
+          <p>This callback is optional, so callback modules need not export it.
+            If a release upgrade/downgrade with <c>Change={advanced,Extra}</c>
+            specified in the <c>.appup</c> file is made when <c>code_change/3</c>
+            isn't implemented the event handler will crash with an <c>undef</c> error
+            reason.</p>
         </note>
         <p>This function is called for an installed event handler that
           is to update its internal state during a release
@@ -677,7 +678,7 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;&nbsp;Id = term()</v>
       </type>
       <desc>
-         <note>
+        <note>
           <p>This callback is optional, so callback modules need not
             export it. If
             <seealso marker="#call/3"><c>call/3,4</c></seealso> is called
@@ -772,11 +773,11 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;&nbsp;Id = term()</v>
       </type>
       <desc>
-         <note>
+        <note>
           <p>This callback is optional, so callback modules need not
             export it. The <c>gen_event</c> module provides a default
-            implementation of this function that drops the <c>Info</c>
-            message and returns <c>{ok, State}</c>.</p>
+            implementation of this function that logs about the unexpected
+            <c>Info</c> message, drops it and returns <c>{noreply, State}</c>.</p>
         </note>
         <p>This function is called for each installed event handler when
           an event manager receives any other message than an event or

--- a/lib/stdlib/doc/src/gen_fsm.xml
+++ b/lib/stdlib/doc/src/gen_fsm.xml
@@ -563,10 +563,11 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
       </type>
       <desc>
         <note>
-          <p>This callback is optional, so callback modules need not
-            export it. The <c>gen_fsm</c> module provides a default
-            implementation of this function that returns
-            <c>{ok, StateName, StateData}</c>.</p>
+          <p>This callback is optional, so callback modules need not export it.
+            If a release upgrade/downgrade with <c>Change={advanced,Extra}</c>
+            specified in the <c>appup</c> file is made when <c>code_change/4</c>
+            isn't implemented the process will crash with an <c>undef</c> exit
+            reason.</p>
         </note>
         <p>This function is called by a <c>gen_fsm</c> process when it is to
           update its internal state data during a release upgrade/downgrade,
@@ -663,13 +664,6 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
-        <note>
-          <p>This callback is optional, so callback modules need not
-            export it. If it is not exported in the callback module
-            the server will crash with an <c>undef</c> exit reason if
-            <seealso marker="#send_all_state_event/2">
-            <c>send_all_state_event/2</c></seealso> is called.</p>
-        </note>
         <p>Whenever a <c>gen_fsm</c> process receives an event sent using
           <seealso marker="#send_all_state_event/2">
           <c>send_all_state_event/2</c></seealso>,
@@ -702,8 +696,9 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <note>
           <p>This callback is optional, so callback modules need not
             export it. The <c>gen_fsm</c> module provides a default
-            implementation of this function that drops the <c>Info</c>
-            message and returns <c>{next_state, StateName, StateData}</c>.</p>
+            implementation of this function that logs about the unexpected
+            <c>Info</c> message, drops it and returns
+            <c>{next_state, StateName, StateData}</c>.</p>
         </note>
         <p>This function is called by a <c>gen_fsm</c> process when it receives
           any other message than a synchronous or asynchronous event (or a
@@ -737,14 +732,6 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
-        <note>
-          <p>This callback is optional, so callback modules need not
-            export it. If it is not exported in the callback module
-            the server will crash with an <c>undef</c> exit reason if
-            <seealso marker="#sync_send_all_state_event/2">
-            <c>sync_send_all_state_event/2,3</c></seealso>,
-            is called.</p>
-        </note>
         <p>Whenever a <c>gen_fsm</c> process receives an event sent using
           <seealso marker="#sync_send_all_state_event/2">
           <c>sync_send_all_state_event/2,3</c></seealso>,
@@ -800,6 +787,16 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <p>If the initialization fails, the function returns
           <c>{stop,Reason}</c>, where <c>Reason</c> is any term,
           or <c>ignore</c>.</p>
+        <note>
+          <p>
+            This callback is optional, so a callback module does not need
+            to export it, but most do.  If this function is not exported,
+            the <c>gen_fsm</c> should be started through
+            <seealso marker="proc_lib"><c>proc_lib</c></seealso>
+            and
+            <seealso marker="#enter_loop/4"><c>enter_loop/4-6</c></seealso>.
+          </p>
+        </note>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/gen_fsm.xml
+++ b/lib/stdlib/doc/src/gen_fsm.xml
@@ -562,6 +562,12 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <v>Extra = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_fsm</c> module provides a default
+            implementation of this function that returns
+            <c>{ok, StateName, StateData}</c>.</p>
+        </note>
         <p>This function is called by a <c>gen_fsm</c> process when it is to
           update its internal state data during a release upgrade/downgrade,
           that is, when instruction <c>{update,Module,Change,...}</c>,
@@ -657,6 +663,13 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. If it is not exported in the callback module
+            the server will crash with an <c>undef</c> exit reason if
+            <seealso marker="#send_all_state_event/2">
+            <c>send_all_state_event/2</c></seealso> is called.</p>
+        </note>
         <p>Whenever a <c>gen_fsm</c> process receives an event sent using
           <seealso marker="#send_all_state_event/2">
           <c>send_all_state_event/2</c></seealso>,
@@ -686,6 +699,12 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <v>&nbsp;Reason = normal | term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_fsm</c> module provides a default
+            implementation of this function that drops the <c>Info</c>
+            message and returns <c>{next_state, StateName, StateData}</c>.</p>
+        </note>
         <p>This function is called by a <c>gen_fsm</c> process when it receives
           any other message than a synchronous or asynchronous event (or a
           system message).</p>
@@ -718,6 +737,14 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. If it is not exported in the callback module
+            the server will crash with an <c>undef</c> exit reason if
+            <seealso marker="#sync_send_all_state_event/2">
+            <c>sync_send_all_state_event/2,3</c></seealso>,
+            is called.</p>
+        </note>
         <p>Whenever a <c>gen_fsm</c> process receives an event sent using
           <seealso marker="#sync_send_all_state_event/2">
           <c>sync_send_all_state_event/2,3</c></seealso>,
@@ -899,6 +926,11 @@ gen_fsm:sync_send_all_state_event -----> Module:handle_sync_event/4
         <v>StateData = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_fsm</c> module provides a default
+            implementation without cleanup.</p>
+        </note>
         <p>This function is called by a <c>gen_fsm</c> process when it is about
           to terminate. It is to be the opposite of
           <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -505,10 +505,11 @@ gen_server:abcast     -----> Module:handle_cast/2
       </type>
       <desc>
         <note>
-          <p>This callback is optional, so callback modules need not
-            export it. The <c>gen_server</c> module provides a default
-            implementation of this function that returns
-            <c>{ok, State}</c>.</p>
+          <p>This callback is optional, so callback modules need not export it.
+            If a release upgrade/downgrade with <c>Change={advanced,Extra}</c>
+            specified in the <c>appup</c> file is made when <c>code_change/3</c>
+            isn't implemented the process will crash with an <c>undef</c> exit
+            reason.</p>
         </note>
         <p>This function is called by a <c>gen_server</c> process when it is
           to update its internal state during a release upgrade/downgrade,
@@ -612,14 +613,6 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
-        <note>
-          <p>This callback is optional, so callback modules need not
-            export it. If it is not exported in the callback module
-            the server will crash with an <c>undef</c> exit reason if
-            <seealso marker="#call/2"><c>call/2,3</c></seealso> or
-            <seealso marker="#multi_call/2"><c>multi_call/2,3,4</c></seealso>,
-            is called.</p>
-        </note>
         <p>Whenever a <c>gen_server</c> process receives a request sent using
           <seealso marker="#call/2"><c>call/2,3</c></seealso> or
           <seealso marker="#multi_call/2"><c>multi_call/2,3,4</c></seealso>,
@@ -680,14 +673,6 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
-         <note>
-           <p>This callback is optional, so callback modules need not
-            export it. If it is not exported in the callback module
-            the server will crash with an <c>undef</c> exit reason if
-            <seealso marker="#cast/2"><c>cast/2</c></seealso> or
-            <seealso marker="#abcast/2"><c>abcast/2,3</c></seealso>,
-            is called.</p>
-        </note>
         <p>Whenever a <c>gen_server</c> process receives a request sent using
           <seealso marker="#cast/2"><c>cast/2</c></seealso> or
           <seealso marker="#abcast/2"><c>abcast/2,3</c></seealso>,
@@ -715,8 +700,8 @@ gen_server:abcast     -----> Module:handle_cast/2
         <note>
           <p>This callback is optional, so callback modules need not
             export it. The <c>gen_server</c> module provides a default
-            implementation of this function that drops the <c>Info</c>
-            message and returns <c>{noreply, State}</c>.</p>
+            implementation of this function that logs about the unexpected
+            <c>Info</c> message, drops it and returns <c>{noreply, State}</c>.</p>
         </note>
         <p>This function is called by a <c>gen_server</c> process when a
           time-out occurs or when it receives any other message than a
@@ -767,6 +752,16 @@ gen_server:abcast     -----> Module:handle_cast/2
         <p>If the initialization fails, the function is to return
           <c>{stop,Reason}</c>, where <c>Reason</c> is any term, or
           <c>ignore</c>.</p>
+        <note>
+          <p>
+            This callback is optional, so a callback module does not need
+            to export it, but most do.  If this function is not exported,
+            the <c>gen_server</c> should be started through
+            <seealso marker="proc_lib"><c>proc_lib</c></seealso>
+            and
+            <seealso marker="#enter_loop/3"><c>enter_loop/3-5</c></seealso>.
+          </p>
+        </note>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -504,6 +504,12 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>Reason = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_server</c> module provides a default
+            implementation of this function that returns
+            <c>{ok, State}</c>.</p>
+        </note>
         <p>This function is called by a <c>gen_server</c> process when it is
           to update its internal state during a release upgrade/downgrade,
           that is, when the instruction <c>{update,Module,Change,...}</c>,
@@ -606,6 +612,14 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. If it is not exported in the callback module
+            the server will crash with an <c>undef</c> exit reason if
+            <seealso marker="#call/2"><c>call/2,3</c></seealso> or
+            <seealso marker="#multi_call/2"><c>multi_call/2,3,4</c></seealso>,
+            is called.</p>
+        </note>
         <p>Whenever a <c>gen_server</c> process receives a request sent using
           <seealso marker="#call/2"><c>call/2,3</c></seealso> or
           <seealso marker="#multi_call/2"><c>multi_call/2,3,4</c></seealso>,
@@ -666,6 +680,14 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
+         <note>
+           <p>This callback is optional, so callback modules need not
+            export it. If it is not exported in the callback module
+            the server will crash with an <c>undef</c> exit reason if
+            <seealso marker="#cast/2"><c>cast/2</c></seealso> or
+            <seealso marker="#abcast/2"><c>abcast/2,3</c></seealso>,
+            is called.</p>
+        </note>
         <p>Whenever a <c>gen_server</c> process receives a request sent using
           <seealso marker="#cast/2"><c>cast/2</c></seealso> or
           <seealso marker="#abcast/2"><c>abcast/2,3</c></seealso>,
@@ -690,6 +712,12 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>&nbsp;Reason = normal | term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_server</c> module provides a default
+            implementation of this function that drops the <c>Info</c>
+            message and returns <c>{noreply, State}</c>.</p>
+        </note>
         <p>This function is called by a <c>gen_server</c> process when a
           time-out occurs or when it receives any other message than a
           synchronous or asynchronous request (or a system message).</p>
@@ -750,6 +778,11 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>State = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_server</c> module provides a default
+            implementation without cleanup.</p>
+        </note>
         <p>This function is called by a <c>gen_server</c> process when it is
           about to terminate. It is to be the opposite of
           <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -1644,6 +1644,12 @@ handle_event(_, _, State, Data) ->
 	<v>Reason = term()</v>
       </type>
       <desc>
+        <note>
+          <p>This callback is optional, so callback modules need not
+            export it. The <c>gen_statem</c> module provides a default
+            implementation of this function that returns
+            <c>{ok, OldState, OldData}</c>.</p>
+        </note>
         <p>
 	  This function is called by a <c>gen_statem</c> when it is to
 	  update its internal state during a release upgrade/downgrade,

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -1645,10 +1645,11 @@ handle_event(_, _, State, Data) ->
       </type>
       <desc>
         <note>
-          <p>This callback is optional, so callback modules need not
-            export it. The <c>gen_statem</c> module provides a default
-            implementation of this function that returns
-            <c>{ok, OldState, OldData}</c>.</p>
+          <p>This callback is optional, so callback modules need not export it.
+            If a release upgrade/downgrade with <c>Change={advanced,Extra}</c>
+            specified in the <c>.appup</c> file is made when <c>code_change/4</c>
+            isn't implemented the process will crash with an <c>undef</c> exit
+            reason.</p>
         </note>
         <p>
 	  This function is called by a <c>gen_statem</c> when it is to

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -109,7 +109,9 @@
       State :: term(),
       Status :: term().
 
--optional_callbacks([format_status/2]).
+-optional_callbacks(
+    [handle_call/2, handle_info/2, terminate/2, code_change/3,
+     format_status/2]).
 
 %%---------------------------------------------------------------------------
 
@@ -404,10 +406,15 @@ system_terminate(Reason, Parent, _Debug, [ServerName, MSL, _Hib]) ->
 %%-----------------------------------------------------------------
 system_code_change([ServerName, MSL, Hib], Module, OldVsn, Extra) ->
     MSL1 = lists:zf(fun(H) when H#handler.module =:= Module ->
-			    {ok, NewState} =
-				Module:code_change(OldVsn,
-						   H#handler.state, Extra),
-			    {true, H#handler{state = NewState}};
+			case erlang:function_exported(Module, code_change, 3) of
+			    true ->
+				{ok, NewState} =
+				    Module:code_change(OldVsn,
+							H#handler.state, Extra),
+				{true, H#handler{state = NewState}};
+			    _ ->
+				{true, H}
+			end;
 		       (_) -> true
 		    end,
 		    MSL),
@@ -577,6 +584,8 @@ server_update(Handler1, Func, Event, SName) ->
 	    do_terminate(Mod1, Handler1, remove_handler, State,
 			 remove, SName, normal),
 	    no;
+	{'EXIT', {undef, [{Mod1, handle_info, [_,_], _}|_]}} ->
+	    {ok, Handler1};
 	Other ->
 	    do_terminate(Mod1, Handler1, {error, Other}, State,
 			 Event, SName, crash),
@@ -698,9 +707,15 @@ server_call_update(Handler1, Query, SName) ->
     end.
 
 do_terminate(Mod, Handler, Args, State, LastIn, SName, Reason) ->
-    Res = (catch Mod:terminate(Args, State)),
-    report_terminate(Handler, Reason, Args, State, LastIn, SName, Res),
-    Res.
+    case erlang:function_exported(Mod, terminate, 2) of
+	true ->
+	    Res = (catch Mod:terminate(Args, State)),
+	    report_terminate(Handler, Reason, Args, State, LastIn, SName, Res),
+	    Res;
+	_ ->
+	    report_terminate(Handler, Reason, Args, State, LastIn, SName, ok),
+	    ok
+    end.
 
 report_terminate(Handler, crash, {error, Why}, State, LastIn, SName, _) ->
     report_terminate(Handler, Why, State, LastIn, SName);

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -297,9 +297,7 @@
     %% for every StateName in your state machine but the state name
     %% 'state_name' does of course not have to be used.
     %%
-    handle_event/4, % For callback_mode() =:= handle_event_function
-    terminate/3, % Has got a default implementation
-    code_change/4 % Has got a default implementation
+    handle_event/4 % For callback_mode() =:= handle_event_function
    ]).
 
 %% Type validation functions
@@ -728,26 +726,21 @@ system_code_change(
     state := State,
     data := Data} = S,
   _Mod, OldVsn, Extra) ->
-    case erlang:function_exported(Module, code_change, 4) of
-	true ->
-	    case
-		try Module:code_change(OldVsn, State, Data, Extra)
-		catch
-		    Result -> Result
-		end
- 	   of
-		{ok,NewState,NewData} ->
-		    {ok,
-		     S#{callback_mode := undefined,
-			state := NewState,
-			data := NewData}};
-		{ok,_} = Error ->
-		    error({case_clause,Error});
-		Error ->
-		    Error
-	    end;
-	_ ->
-	    {ok, S}
+    case
+	try Module:code_change(OldVsn, State, Data, Extra)
+	catch
+	    Result -> Result
+	end
+	   of
+	{ok,NewState,NewData} ->
+	    {ok,
+	     S#{callback_mode := undefined,
+		state := NewState,
+		data := NewData}};
+	{ok,_} = Error ->
+	    error({case_clause,Error});
+	Error ->
+	    Error
     end.
 
 system_get_state(#{state := State, data := Data}) ->

--- a/lib/stdlib/test/dummy_h.erl
+++ b/lib/stdlib/test/dummy_h.erl
@@ -22,7 +22,7 @@
 %% Test event handler for gen_event_SUITE.erl
 
 -export([init/1, handle_event/2, handle_call/2, handle_info/2,
-	 terminate/2, code_change/3]).
+	 terminate/2]).
 
 init(make_error) ->
     {error, my_error};
@@ -75,9 +75,6 @@ handle_info(wake, _State) ->
     {ok, []};
 handle_info(gnurf, _State) ->
     {ok, []};
-handle_info({call_undef_fun, Mod, Fun}, State) ->
-    Mod:Fun(),
-    {ok, State};
 handle_info(Info, Parent) ->
     Parent ! {dummy_h, Info},
     {ok, Parent}.
@@ -94,8 +91,3 @@ terminate(_Reason, {undef_in_terminate, {Mod, Fun}}) ->
 terminate(_Reason, _State) ->
     ok.
 
-code_change(_OldVsn, {undef_in_code_change, {Mod, Fun}} = State, _Extra) ->
-    Mod:Fun(),
-    {ok, State};
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.

--- a/lib/stdlib/test/erl_internal_SUITE.erl
+++ b/lib/stdlib/test/erl_internal_SUITE.erl
@@ -104,8 +104,8 @@ optional_callbacks(gen_server) ->
     [{handle_info, 2}, {init, 1}, {terminate, 2}, {code_change, 3},
      {format_status, 2}];
 optional_callbacks(gen_fsm) ->
-    [{handle_event,3}, {handle_sync_event,4}, {handle_info,3},
-     {terminate,3}, {code_change,4}, {format_status,2}];
+    [{handle_info,3}, {init,1}, {terminate,3}, {code_change,4},
+     {format_status,2}];
 optional_callbacks(gen_event) ->
     [{handle_call, 2}, {handle_info, 2}, {terminate, 2},
      {code_change, 3}, {format_status, 2}];

--- a/lib/stdlib/test/erl_internal_SUITE.erl
+++ b/lib/stdlib/test/erl_internal_SUITE.erl
@@ -101,8 +101,8 @@ callbacks(supervisor) ->
 optional_callbacks(application) ->
     [];
 optional_callbacks(gen_server) ->
-    [{handle_call,3}, {handle_cast,2}, {handle_info,2},
-     {terminate,2}, {code_change,3}, {format_status,2}];
+    [{handle_info, 2}, {init, 1}, {terminate, 2}, {code_change, 3},
+     {format_status, 2}];
 optional_callbacks(gen_fsm) ->
     [{handle_event,3}, {handle_sync_event,4}, {handle_info,3},
      {terminate,3}, {code_change,4}, {format_status,2}];

--- a/lib/stdlib/test/erl_internal_SUITE.erl
+++ b/lib/stdlib/test/erl_internal_SUITE.erl
@@ -97,7 +97,8 @@ callbacks(supervisor) ->
 optional_callbacks(application) ->
     [];
 optional_callbacks(gen_server) ->
-    [{format_status,2}];
+    [{handle_call,3}, {handle_cast,2}, {handle_info,2},
+     {terminate,2}, {code_change,3}, {format_status,2}];
 optional_callbacks(gen_fsm) ->
     [{format_status,2}];
 optional_callbacks(gen_event) ->

--- a/lib/stdlib/test/erl_internal_SUITE.erl
+++ b/lib/stdlib/test/erl_internal_SUITE.erl
@@ -60,7 +60,7 @@ end_per_testcase(_Case, _Config) ->
 %% Check that the behaviour callbacks are correctly defined.
 behav(_) ->
     Modules = [application, gen_server, gen_fsm, gen_event,
-               supervisor_bridge, supervisor],
+               gen_statem, supervisor_bridge, supervisor],
     lists:foreach(fun check_behav/1, Modules).
 
 check_behav(Module) ->
@@ -89,6 +89,10 @@ callbacks(gen_event) ->
     [{init,1}, {handle_event,2}, {handle_call,2},
      {handle_info,2}, {terminate,2}, {code_change,3},
      {format_status,2}];
+callbacks(gen_statem) ->
+    [{init, 1}, {callback_mode, 0}, {state_name, 3},
+     {handle_event, 4}, {terminate, 3}, {code_change, 4},
+     {format_status, 2}];
 callbacks(supervisor_bridge) ->
     [{init,1}, {terminate,2}];
 callbacks(supervisor) ->
@@ -104,6 +108,9 @@ optional_callbacks(gen_fsm) ->
 optional_callbacks(gen_event) ->
     [{handle_call,2}, {handle_info,2}, {terminate,2},
      {code_change,3}, {format_status,2}];
+optional_callbacks(gen_statem) ->
+    [{init, 1}, {format_status, 2}, {state_name, 3},
+     {handle_event, 4}, {terminate, 3}, {code_change, 4}];
 optional_callbacks(supervisor_bridge) ->
     [];
 optional_callbacks(supervisor) ->

--- a/lib/stdlib/test/erl_internal_SUITE.erl
+++ b/lib/stdlib/test/erl_internal_SUITE.erl
@@ -102,7 +102,8 @@ optional_callbacks(gen_server) ->
 optional_callbacks(gen_fsm) ->
     [{format_status,2}];
 optional_callbacks(gen_event) ->
-    [{format_status,2}];
+    [{handle_call,2}, {handle_info,2}, {terminate,2},
+     {code_change,3}, {format_status,2}];
 optional_callbacks(supervisor_bridge) ->
     [];
 optional_callbacks(supervisor) ->

--- a/lib/stdlib/test/erl_internal_SUITE.erl
+++ b/lib/stdlib/test/erl_internal_SUITE.erl
@@ -107,8 +107,8 @@ optional_callbacks(gen_fsm) ->
     [{handle_event,3}, {handle_sync_event,4}, {handle_info,3},
      {terminate,3}, {code_change,4}, {format_status,2}];
 optional_callbacks(gen_event) ->
-    [{handle_call,2}, {handle_info,2}, {terminate,2},
-     {code_change,3}, {format_status,2}];
+    [{handle_call, 2}, {handle_info, 2}, {terminate, 2},
+     {code_change, 3}, {format_status, 2}];
 optional_callbacks(gen_statem) ->
     [{init, 1}, {format_status, 2}, {state_name, 3},
      {handle_event, 4}, {terminate, 3}, {code_change, 4}];

--- a/lib/stdlib/test/erl_internal_SUITE.erl
+++ b/lib/stdlib/test/erl_internal_SUITE.erl
@@ -104,7 +104,8 @@ optional_callbacks(gen_server) ->
     [{handle_call,3}, {handle_cast,2}, {handle_info,2},
      {terminate,2}, {code_change,3}, {format_status,2}];
 optional_callbacks(gen_fsm) ->
-    [{format_status,2}];
+    [{handle_event,3}, {handle_sync_event,4}, {handle_info,3},
+     {terminate,3}, {code_change,4}, {format_status,2}];
 optional_callbacks(gen_event) ->
     [{handle_call,2}, {handle_info,2}, {terminate,2},
      {code_change,3}, {format_status,2}];

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -3049,48 +3049,48 @@ behaviour_multiple(Config) when is_list(Config) ->
 	   []},
 
 	  {behaviour3,
-           <<"-behaviour(gen_server).
+           <<"-behaviour(gen_event).
               -behaviour(supervisor).
-              -export([handle_call/3,handle_cast/2,handle_info/2]).
-              handle_call(_, _, _) -> ok.
-              handle_cast(_, _) -> ok.
+              -export([handle_call/2,handle_event/2,handle_info/2]).
+              handle_call(_, _) -> ok.
+              handle_event(_, _) -> ok.
               handle_info(_, _) -> ok.
              ">>,
            [],
-	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{init,1},gen_server}},
+	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{init,1},gen_event}},
 		      {2,erl_lint,{undefined_behaviour_func,{init,1},supervisor}},
 		      {2,
 		       erl_lint,
-		       {conflicting_behaviours,{init,1},supervisor,1,gen_server}}]}},
+		       {conflicting_behaviours,{init,1},supervisor,1,gen_event}}]}},
 	  {american_behavior3,
-           <<"-behavior(gen_server).
+           <<"-behavior(gen_event).
               -behavior(supervisor).
-              -export([handle_call/3,handle_cast/2,handle_info/2]).
-              handle_call(_, _, _) -> ok.
-              handle_cast(_, _) -> ok.
+              -export([handle_call/2,handle_event/2,handle_info/2]).
+              handle_call(_, _) -> ok.
+              handle_event(_, _) -> ok.
               handle_info(_, _) -> ok.
              ">>,
            [],
-	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{init,1},gen_server}},
+	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{init,1},gen_event}},
 		      {2,erl_lint,{undefined_behaviour_func,{init,1},supervisor}},
 		      {2,
 		       erl_lint,
-		       {conflicting_behaviours,{init,1},supervisor,1,gen_server}}]}},
+		       {conflicting_behaviours,{init,1},supervisor,1,gen_event}}]}},
 
 	  {behaviour4,
-           <<"-behaviour(gen_server).
+           <<"-behaviour(gen_event).
               -behaviour(gen_fsm).
               -behaviour(supervisor).
-              -export([init/1,handle_call/3,handle_cast/2,
+              -export([init/1,handle_call/2,handle_event/2,
                        handle_info/2,handle_info/3,
                        handle_event/3,handle_sync_event/4,
                        code_change/3,code_change/4,
                        terminate/2,terminate/3,terminate/4]).
               init(_) -> ok.
-              handle_call(_, _, _) -> ok.
+              handle_call(_, _) -> ok.
               handle_event(_, _, _) -> ok.
               handle_sync_event(_, _, _, _) -> ok.
-              handle_cast(_, _) -> ok.
+              handle_event(_, _) -> ok.
               handle_info(_, _) -> ok.
               handle_info(_, _, _) -> ok.
               code_change(_, _, _) -> ok.
@@ -3102,10 +3102,10 @@ behaviour_multiple(Config) when is_list(Config) ->
            [],
 	   {warnings,[{2,
 		       erl_lint,
-		       {conflicting_behaviours,{init,1},gen_fsm,1,gen_server}},
+		       {conflicting_behaviours,{init,1},gen_fsm,1,gen_event}},
 		      {3,
 		       erl_lint,
-		       {conflicting_behaviours,{init,1},supervisor,1,gen_server}}]}}
+		       {conflicting_behaviours,{init,1},supervisor,1,gen_event}}]}}
 	 ],
     [] = run(Config, Ts),
     ok.

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -3057,10 +3057,7 @@ behaviour_multiple(Config) when is_list(Config) ->
               handle_info(_, _) -> ok.
              ">>,
            [],
-	   {warnings,[{1,erl_lint,
-		       {undefined_behaviour_func,{code_change,3},gen_server}},
-		      {1,erl_lint,{undefined_behaviour_func,{init,1},gen_server}},
-		      {1,erl_lint,{undefined_behaviour_func,{terminate,2},gen_server}},
+	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{init,1},gen_server}},
 		      {2,erl_lint,{undefined_behaviour_func,{init,1},supervisor}},
 		      {2,
 		       erl_lint,
@@ -3074,10 +3071,7 @@ behaviour_multiple(Config) when is_list(Config) ->
               handle_info(_, _) -> ok.
              ">>,
            [],
-	   {warnings,[{1,erl_lint,
-		       {undefined_behaviour_func,{code_change,3},gen_server}},
-		      {1,erl_lint,{undefined_behaviour_func,{init,1},gen_server}},
-		      {1,erl_lint,{undefined_behaviour_func,{terminate,2},gen_server}},
+	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{init,1},gen_server}},
 		      {2,erl_lint,{undefined_behaviour_func,{init,1},supervisor}},
 		      {2,
 		       erl_lint,

--- a/lib/stdlib/test/gen_event_SUITE_data/oc_event.erl
+++ b/lib/stdlib/test/gen_event_SUITE_data/oc_event.erl
@@ -1,0 +1,40 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(oc_event).
+
+-behaviour(gen_event).
+
+%% API
+-export([start/0]).
+
+%% gen_event callbacks
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+
+start() ->
+    {ok, Pid} = gen_event:start({local, ?SERVER}),
+    gen_event:add_handler(?SERVER, ?MODULE, []),
+    {ok, Pid}.
+
+init([]) ->
+    {ok, #state{}}.

--- a/lib/stdlib/test/gen_fsm_SUITE_data/oc_fsm.erl
+++ b/lib/stdlib/test/gen_fsm_SUITE_data/oc_fsm.erl
@@ -1,0 +1,48 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(oc_fsm).
+
+-behaviour(gen_fsm).
+
+%% API
+-export([start/0]).
+
+%% gen_fsm callbacks
+-export([init/1,
+         state_name/2,
+         state_name/3]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+
+start() ->
+    gen_fsm:start({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    {ok, state_name, #state{}}.
+
+state_name(_Event, State) ->
+    {next_state, state_name, State}.
+
+state_name(_Event, _From, State) ->
+    Reply = ok,
+    {reply, Reply, state_name, State}.
+

--- a/lib/stdlib/test/gen_server_SUITE.erl
+++ b/lib/stdlib/test/gen_server_SUITE.erl
@@ -34,7 +34,10 @@
 	 spec_init_global_registered_parent/1,
 	 otp_5854/1, hibernate/1, otp_7669/1, call_format_status/1,
 	 error_format_status/1, terminate_crash_format/1,
-	 get_state/1, replace_state/1, call_with_huge_message_queue/1
+	 get_state/1, replace_state/1, call_with_huge_message_queue/1,
+	 oc_handle_call/1, oc_handle_cast/1, oc_handle_info/1,
+	 oc_code_change/1, oc_terminate1/1, oc_terminate2/1,
+	 ui_handle_info/1, ui_code_change/1, ui_terminate/1
 	]).
 
 -export([stop1/1, stop2/1, stop3/1, stop4/1, stop5/1, stop6/1, stop7/1,
@@ -50,7 +53,7 @@
 
 %% The gen_server behaviour
 -export([init/1, handle_call/3, handle_cast/2,
-	 handle_info/2, terminate/2, format_status/2]).
+	 handle_info/2, code_change/3, terminate/2, format_status/2]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -66,11 +69,18 @@ all() ->
      otp_7669,
      call_format_status, error_format_status, terminate_crash_format,
      get_state, replace_state,
-     call_with_huge_message_queue].
+     call_with_huge_message_queue, {group, optional_callbacks},
+     {group, undef_in_callbacks}].
 
 groups() -> 
     [{stop, [],
-      [stop1, stop2, stop3, stop4, stop5, stop6, stop7, stop8, stop9, stop10]}].
+      [stop1, stop2, stop3, stop4, stop5, stop6, stop7, stop8, stop9, stop10]},
+     {optional_callbacks, [],
+      [oc_handle_call, oc_handle_cast, oc_handle_info, oc_code_change,
+       oc_terminate1, oc_terminate2]},
+     {undef_in_callbacks, [],
+      [ui_handle_info, ui_code_change, ui_terminate]}].
+
 
 init_per_suite(Config) ->
     Config.
@@ -78,6 +88,11 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
+init_per_group(optional_callbacks, Config) ->
+    DataDir = ?config(data_dir, Config),
+    Server = filename:join(DataDir, "oc_server.erl"),
+    {ok, oc_server} = compile:file(Server),
+    Config;
 init_per_group(_GroupName, Config) ->
     Config.
 
@@ -93,6 +108,7 @@ init_per_testcase(Case, Config) when Case == call_remote1;
 				     Case == call_remote_n3 ->
     {ok,N} = start_node(hubba),
     [{node,N} | Config];
+
 init_per_testcase(_Case, Config) ->
     Config.
 
@@ -1260,6 +1276,131 @@ echo_loop() ->
 	    echo_loop()
     end.
 
+%% Test that the server crashes correctly if the handle_call callback is
+%% not exported in the callback module
+oc_handle_call(Config) when is_list(Config) ->
+    {ok, Server} = gen_server:start(oc_server, [], []),
+    try
+        gen_server:call(Server, call_msg),
+        ct:fail(should_crash)
+    catch exit:{{undef, [{oc_server, handle_call, _, _}|_]},
+                {gen_server, call, _}} ->
+        ok
+    end.
+
+%% Test that the server crashes correctly if the handle_cast callback is
+%% not exported in the callback module
+oc_handle_cast(Config) when is_list(Config) ->
+    {ok, Server} = gen_server:start(oc_server, [], []),
+    MRef = monitor(process, Server),
+    gen_server:cast(Server, cast_msg),
+    verify_undef_down(MRef, Server, oc_server, handle_cast),
+    ok.
+
+%% Test the default implementation of handle_info if the callback module
+%% does not export it
+oc_handle_info(Config) when is_list(Config) ->
+    {ok, Server} = gen_server:start(oc_server, [], []),
+    MRef = monitor(process, Server),
+    Server ! hej,
+    wait_until_processed(Server, hej, 10),
+    receive
+        {'DOWN', MRef, process, Server, _} ->
+            ct:fail(should_not_crash)
+    after 500 ->
+        ok
+    end,
+    gen_server:stop(Server),
+    ok.
+
+%% Test the default implementation of code_change if the callback module
+%% does not export it
+oc_code_change(Config) when is_list(Config) ->
+    {ok, Server} = gen_server:start(oc_server, [], []),
+    ok = fake_upgrade(Server, oc_server).
+
+%% Test the default implementation of terminate if the callback module
+%% does not export it
+oc_terminate1(Config) when is_list(Config) ->
+    {ok, Server} = gen_server:start(oc_server, [], []),
+    MRef = monitor(process, Server),
+    ok = gen_server:stop(Server),
+    ok = verify_down_reason(MRef, Server, normal).
+
+%% Test the default implementation of terminate if the callback module
+%% does not export it
+oc_terminate2(Config) when is_list(Config) ->
+    {ok, Server} = gen_server:start(oc_server, [], []),
+    MRef = monitor(process, Server),
+    ok = gen_server:stop(Server, {error, test}, infinity),
+    ok = verify_down_reason(MRef, Server, {error, test}).
+
+%% Test that the server crashes correctly if the handle_info callback is
+%% calling an undefined function
+ui_handle_info(Config) when is_list(Config) ->
+    {ok, Server} = gen_server:start(?MODULE, [], []),
+    MRef = monitor(process, Server),
+    Server ! {call_undef_fun, test, undef_fun},
+    verify_undef_down(MRef, Server, test, undef_fun),
+    ok.
+
+%% Test that the server crashes correctly if the code_change callback is
+%% calling an undefined function
+ui_code_change(Config) when is_list(Config) ->
+    State =  {undef_in_code_change, {test, undef_fun}},
+    {ok, Server} = gen_server:start(?MODULE, {state, State}, []),
+    {error, {'EXIT', {undef, [{test, undef_fun, _, _}|_]}}}
+        = fake_upgrade(Server, ?MODULE).
+
+%% Test that the server crashes correctly if the terminate callback is
+%% calling an undefined function
+ui_terminate(Config) when is_list(Config) ->
+    State = {undef_in_terminate, {test, undef_fun}},
+    {ok, Server} = gen_server:start(?MODULE, {state, State}, []),
+    try
+        gen_server:stop(Server),
+        ct:fail(failed)
+    catch
+        exit:{undef, [{test, undef_fun, _, _}|_]} ->
+            ok
+    end.
+
+verify_down_reason(MRef, Server, Reason) ->
+    receive
+        {'DOWN', MRef, process, Server, Reason} ->
+            ok
+    after 5000 ->
+        ct:fail(failed)
+    end.
+
+verify_undef_down(MRef, Pid, Mod, Fun) ->
+    ok = receive
+        {'DOWN', MRef, process, Pid,
+         {undef, [{Mod, Fun, _, _}|_]}} ->
+            ok
+    after 5000 ->
+        ct:fail(should_crash)
+    end.
+
+fake_upgrade(Pid, Mod) ->
+    sys:suspend(Pid),
+    sys:replace_state(Pid, fun(State) -> {new, State} end),
+    Ret = sys:change_code(Pid, Mod, old_vsn, []),
+    ok = sys:resume(Pid),
+    Ret.
+
+wait_until_processed(_Pid, _Message, 0) ->
+    ct:fail(not_processed);
+wait_until_processed(Pid, Message, N) ->
+    {messages, Messages} = erlang:process_info(Pid, messages),
+    case lists:member(Message, Messages) of
+        true ->
+            timer:sleep(100),
+            wait_until_processed(Pid, Message, N-1);
+        false ->
+            ok
+    end.
+
 %%--------------------------------------------------------------
 %% Help functions to spec_init_*
 start_link(Init, Options) ->
@@ -1383,6 +1524,9 @@ handle_call(stop_shutdown, _From, State) ->
     {stop,shutdown,State};
 handle_call(shutdown_reason, _From, _State) ->
     exit({shutdown,reason});
+handle_call({call_undef_fun, Mod, Fun}, _From, State) ->
+    Mod:Fun(),
+    {reply, ok, State};
 handle_call(stop_shutdown_reason, _From, State) ->
     {stop,{shutdown,stop_reason},State}.
 
@@ -1396,6 +1540,9 @@ handle_cast(hibernate_now, _State) ->
 handle_cast(hibernate_later, _State) ->
     timer:send_after(1000,self(),hibernate_now),
     {noreply, []};
+handle_cast({call_undef_fun, Mod, Fun}, State) ->
+    Mod:Fun(),
+    {noreply, State};
 handle_cast({From, stop}, State) ->
     io:format("BAZ"),
     {stop, {From,stopped}, State}.
@@ -1420,6 +1567,9 @@ handle_info(timeout, {delayed_cast, From}) ->
 handle_info(timeout, {delayed_info, From}) ->
     From ! {self(), delayed_info},
     {noreply, []};
+handle_info({call_undef_fun, Mod, Fun}, State) ->
+    Mod:Fun(),
+    {noreply, State};
 handle_info({From, handle_info}, _State) ->
     From ! {self(), handled_info},
     {noreply, []};
@@ -1433,6 +1583,12 @@ handle_info({From, stop}, State) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
+code_change(_OldVsn,
+            {new, {undef_in_code_change, {Mod, Fun}}} = State,
+            _Extra) ->
+    Mod:Fun(),
+    {ok, State}.
+
 terminate({From, stopped}, _State) ->
     io:format("FOOBAR"),
     From ! {self(), stopped},
@@ -1442,6 +1598,9 @@ terminate({From, stopped_info}, _State) ->
     ok;
 terminate(_, crash_terminate) ->
     exit({crash, terminate});
+terminate(_, {undef_in_terminate, {Mod, Fun}}) ->
+    Mod:Fun(),
+    ok;
 terminate(_Reason, _State) ->
     ok.
 

--- a/lib/stdlib/test/gen_server_SUITE_data/oc_server.erl
+++ b/lib/stdlib/test/gen_server_SUITE_data/oc_server.erl
@@ -1,0 +1,37 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(oc_server).
+
+-behaviour(gen_server).
+
+%% API
+-export([start/0]).
+
+%% gen_server callbacks
+-export([init/1]).
+
+-record(state, {}).
+
+start() ->
+    gen_server:start({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    {ok, #state{}}.
+

--- a/lib/stdlib/test/gen_statem_SUITE.erl
+++ b/lib/stdlib/test/gen_statem_SUITE.erl
@@ -40,7 +40,8 @@ all() ->
      shutdown, stop_and_reply, state_enter, event_order,
      state_timeout, event_types, code_change,
      {group, sys},
-     hibernate, enter_loop].
+     hibernate, enter_loop, {group, optional_callbacks},
+     ui_code_change, ui_terminate].
 
 groups() ->
     [{start, [], tcs(start)},
@@ -50,7 +51,8 @@ groups() ->
      {abnormal, [], tcs(abnormal)},
      {abnormal_handle_event, [], tcs(abnormal)},
      {sys, [], tcs(sys)},
-     {sys_handle_event, [], tcs(sys)}].
+     {sys_handle_event, [], tcs(sys)},
+     {optional_callbacks, [], tcs(optional_callbacks)}].
 
 tcs(start) ->
     [start1, start2, start3, start4, start5, start6, start7,
@@ -62,8 +64,9 @@ tcs(abnormal) ->
 tcs(sys) ->
     [sys1, call_format_status,
      error_format_status, terminate_crash_format,
-     get_state, replace_state].
-
+     get_state, replace_state];
+tcs(optional_callbacks) ->
+    [oc_code_change, oc_terminate1, oc_terminate2].
 
 init_per_suite(Config) ->
     Config.
@@ -77,6 +80,11 @@ init_per_group(GroupName, Config)
        GroupName =:= abnormal_handle_event;
        GroupName =:= sys_handle_event ->
     [{callback_mode,handle_event_function}|Config];
+init_per_group(optional_callbacks, Config) ->
+    DataDir = ?config(data_dir, Config),
+    StatemPath = filename:join(DataDir, "oc_statem.erl"),
+    {ok, oc_statem} = compile:file(StatemPath),
+    Config;
 init_per_group(_GroupName, Config) ->
     Config.
 
@@ -1393,6 +1401,56 @@ enter_loop(Reg1, Reg2) ->
 	    gen_statem:enter_loop(?MODULE, [], state0, [])
     end.
 
+oc_code_change(_Config) ->
+    {ok, Statem} = gen_statem:start(oc_statem, [], []),
+    ok = fake_upgrade(Statem, oc_statem).
+
+ui_code_change(_Config) ->
+    Data =  {undef_in_code_change, {?MODULE, code_change}},
+    {ok, Statem} = gen_statem:start(?MODULE, {data, Data}, []),
+    {error, {'EXIT', {undef, [{?MODULE, code_change, _, _}|_]}}}
+        = fake_upgrade(Statem, ?MODULE),
+    ok.
+
+fake_upgrade(Pid, Mod) ->
+    sys:suspend(Pid),
+    sys:replace_state(Pid, fun(State) -> {new, State} end),
+    Ret = sys:change_code(Pid, Mod, old_vsn, []),
+    ok = sys:resume(Pid),
+    Ret.
+
+oc_terminate1(_Config) ->
+    {ok, Statem} = gen_statem:start(oc_statem, [], []),
+    MRef = monitor(process, Statem),
+    ok = gen_statem:stop(Statem),
+    verify_down(Statem, MRef, normal),
+    ok.
+
+oc_terminate2(_Config) ->
+    Reason = {error, test},
+    {ok, Statem} = oc_statem:start(),
+    MRef = monitor(process, Statem),
+    ok = gen_statem:stop(Statem, Reason, infinity),
+    verify_down(Statem, MRef, Reason).
+
+ui_terminate(_Config) ->
+    Data =  {undef_in_terminate, {?MODULE, terminate}},
+    {ok, Statem} = gen_statem:start(?MODULE, {data, Data}, []),
+    try
+        gen_statem:stop(Statem),
+        ct:fail(should_crash)
+    catch
+        exit:{undef, [{?MODULE, terminate, _, _}|_]} ->
+            ok
+    end.
+
+verify_down(Statem, MRef, Reason) ->
+    receive
+        {'DOWN', MRef, process, Statem, Reason} ->
+            ok
+    after 5000 ->
+        ct:fail(default_terminate_failed)
+    end.
 
 %% Test the order for multiple {next_event,T,C}
 next_events(Config) ->
@@ -1571,6 +1629,9 @@ callback_mode() ->
 
 terminate(_, _State, crash_terminate) ->
     exit({crash,terminate});
+terminate(_, _State, {undef_in_terminate, {Mod, Fun}}) ->
+    Mod:Fun(),
+    ok;
 terminate({From,stopped}, State, _Data) ->
     From ! {self(),{stopped,State}},
     ok;
@@ -1846,6 +1907,10 @@ wrap_result(Result) ->
 
 
 
+code_change(_OldVsn, State, {idle, {undef_in_code_change, {Mod, Fun}}} = Data,
+            _CallbackMode) ->
+    Mod:Fun(),
+    {ok, State, Data};
 code_change(OldVsn, State, Data, CallbackMode) ->
     io:format(
       "code_change(~p, ~p, ~p, ~p)~n", [OldVsn,State,Data,CallbackMode]),

--- a/lib/stdlib/test/gen_statem_SUITE_data/oc_statem.erl
+++ b/lib/stdlib/test/gen_statem_SUITE_data/oc_statem.erl
@@ -1,0 +1,40 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(oc_statem).
+
+-behaviour(gen_statem).
+
+%% API
+-export([start/0]).
+
+%% gen_statem callbacks
+-export([init/1, callback_mode/0]).
+
+start() ->
+    gen_statem:start({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    {ok, state_name, #{}}.
+
+callback_mode() ->
+    handle_event_function.
+
+
+

--- a/lib/wx/src/wx_object.erl
+++ b/lib/wx/src/wx_object.erl
@@ -39,6 +39,10 @@
 %%     {wxObject, State} | {wxObject, State, Timeout} |
 %%         ignore | {stop, Reason}
 %%
+%%   Asynchronous window event handling: <br/>
+%%   handle_event(#wx{}, State)  should return <br/>
+%%    {noreply, State} | {noreply, State, Timeout} | {stop, Reason, State} 
+%%
 %% The user module can export the following callback functions:
 %%
 %%   handle_call(Msg, {From, Tag}, State) should return <br/>
@@ -49,10 +53,6 @@
 %%   handle_cast(Msg, State) should return <br/>
 %%    {noreply, State} | {noreply, State, Timeout} |
 %%        {stop, Reason, State}  
-%%
-%%   Asynchronous window event handling: <br/>
-%%   handle_event(#wx{}, State)  should return <br/>
-%%    {noreply, State} | {noreply, State, Timeout} | {stop, Reason, State} 
 %%
 %% If the above are not exported but called, the wx_object process will crash.
 %% The user module can also export:
@@ -158,7 +158,7 @@
     {'ok', NewState :: term()} | {'error', Reason :: term()}.
 
 -optional_callbacks(
-    [handle_event/2, handle_call/3, handle_cast/2, handle_info/2,
+    [handle_call/3, handle_cast/2, handle_info/2,
      handle_sync_event/3, terminate/2, code_change/3]).
 
 %% System exports
@@ -549,14 +549,9 @@ system_terminate(Reason, _Parent, Debug, [Name, State, Mod, _Time]) ->
 
 %% @hidden
 system_code_change([Name, State, Mod, Time], _Module, OldVsn, Extra) ->
-    case erlang:function_exported(Mod, code_change, 3) of
-        true ->
-            case catch Mod:code_change(OldVsn, State, Extra) of
-                {ok, NewState} -> {ok, [Name, NewState, Mod, Time]};
-                Else -> Else
-            end;
-        _ ->
-            {ok, [Name, State, Mod, Time]}
+    case catch Mod:code_change(OldVsn, State, Extra) of
+        {ok, NewState} -> {ok, [Name, NewState, Mod, Time]};
+        Else -> Else
     end.
 
 %%-----------------------------------------------------------------

--- a/lib/wx/src/wx_object.erl
+++ b/lib/wx/src/wx_object.erl
@@ -39,19 +39,31 @@
 %%     {wxObject, State} | {wxObject, State, Timeout} |
 %%         ignore | {stop, Reason}
 %%
+%% The user module can export the following callback functions:
+%%
 %%   handle_call(Msg, {From, Tag}, State) should return <br/>
 %%    {reply, Reply, State} | {reply, Reply, State, Timeout} |
 %%        {noreply, State} | {noreply, State, Timeout} |
 %%        {stop, Reason, Reply, State}  
 %%
+%%   handle_cast(Msg, State) should return <br/>
+%%    {noreply, State} | {noreply, State, Timeout} |
+%%        {stop, Reason, State}  
+%%
 %%   Asynchronous window event handling: <br/>
 %%   handle_event(#wx{}, State)  should return <br/>
 %%    {noreply, State} | {noreply, State, Timeout} | {stop, Reason, State} 
 %%
+%% If the above are not exported but called, the wx_object process will crash.
+%% The user module can also export:
+%%
 %%   Info is message e.g. {'EXIT', P, R}, {nodedown, N}, ...  <br/>
 %%   handle_info(Info, State)  should return , ...  <br/>
 %%    {noreply, State} | {noreply, State, Timeout} | {stop, Reason, State} 
-%% 
+%%
+%% If a message is sent to the wx_object process when handle_info is not
+%% exported, the message will be dropped and ignored.
+%%
 %%   When stop is returned in one of the functions above with Reason =
 %% normal | shutdown | Term, terminate(State) is called. It lets the
 %% user module clean up, it is always called when server terminates or
@@ -135,6 +147,8 @@
     {'noreply', NewState :: term()} |
     {'noreply', NewState :: term(), timeout() | 'hibernate'} |
     {'stop', Reason :: term(), NewState :: term()}.
+-callback handle_sync_event(Request :: #wx{}, Ref :: #wx_ref{}, State :: term()) ->
+    ok.
 -callback terminate(Reason :: ('normal' | 'shutdown' | {'shutdown', term()} |
                                term()),
                     State :: term()) ->
@@ -143,6 +157,9 @@
                       Extra :: term()) ->
     {'ok', NewState :: term()} | {'error', Reason :: term()}.
 
+-optional_callbacks(
+    [handle_event/2, handle_call/3, handle_cast/2, handle_info/2,
+     handle_sync_event/3, terminate/2, code_change/3]).
 
 %% System exports
 -export([system_continue/3,
@@ -426,6 +443,7 @@ dispatch(Msg = #wx{}, Mod, State) ->
     Mod:handle_event(Msg, State);
 dispatch(Info, Mod, State) ->
     Mod:handle_info(Info, State).
+
 %% @hidden
 handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod) ->
     case catch Mod:handle_call(Msg, From, State) of
@@ -447,8 +465,12 @@ handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod) ->
 	Other -> handle_common_reply(Other, Name, Msg, Mod, State, [])
     end;
 handle_msg(Msg, Parent, Name, State, Mod) ->
-    Reply = (catch dispatch(Msg, Mod, State)),
-    handle_no_reply(Reply, Parent, Name, Msg, Mod, State, []).
+    case catch dispatch(Msg, Mod, State) of
+        {'EXIT', {undef, [{Mod, handle_info, [_,_], _}|_]}} ->
+            handle_no_reply({noreply, State}, Parent, Name, Msg, Mod, State, []);
+        Reply ->
+            handle_no_reply(Reply, Parent, Name, Msg, Mod, State, [])
+    end.
 
 %% @hidden
 handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod, Debug) ->
@@ -527,9 +549,14 @@ system_terminate(Reason, _Parent, Debug, [Name, State, Mod, _Time]) ->
 
 %% @hidden
 system_code_change([Name, State, Mod, Time], _Module, OldVsn, Extra) ->
-    case catch Mod:code_change(OldVsn, State, Extra) of
-	{ok, NewState} -> {ok, [Name, NewState, Mod, Time]};
-	Else -> Else
+    case erlang:function_exported(Mod, code_change, 3) of
+        true ->
+            case catch Mod:code_change(OldVsn, State, Extra) of
+                {ok, NewState} -> {ok, [Name, NewState, Mod, Time]};
+                Else -> Else
+            end;
+        _ ->
+            {ok, [Name, State, Mod, Time]}
     end.
 
 %%-----------------------------------------------------------------
@@ -560,7 +587,7 @@ print_event(Dev, Event, Name) ->
 %%% ---------------------------------------------------
 %% @hidden
 terminate(Reason, Name, Msg, Mod, State, Debug) ->
-    case catch Mod:terminate(Reason, State) of
+    case try_terminate(Mod, Reason, State) of
 	{'EXIT', R} ->
 	    error_info(R, Name, Msg, State, Debug),
 	    exit(R);
@@ -577,6 +604,15 @@ terminate(Reason, Name, Msg, Mod, State, Debug) ->
 		    exit(Reason)
 	    end
     end.
+
+try_terminate(Mod, Reason, State) ->
+    case erlang:function_exported(Mod, terminate, 2) of
+        true ->
+            catch Mod:terminate(Reason, State);
+        _ ->
+            ok
+    end.
+
 %% @hidden
 error_info(_Reason, application_controller, _Msg, _State, _Debug) ->
     ok;

--- a/lib/wx/test/Makefile
+++ b/lib/wx/test/Makefile
@@ -29,6 +29,7 @@ APPDIR = $(shell dirname $(PWD))
 ERL_COMPILE_FLAGS = -pa $(APPDIR)/ebin
 
 Mods =  wxt wx_test_lib wx_obj_test \
+	wx_oc_object \
 	wx_app_SUITE \
 	wx_basic_SUITE \
 	wx_event_SUITE \

--- a/lib/wx/test/wx_basic_SUITE.erl
+++ b/lib/wx/test/wx_basic_SUITE.erl
@@ -49,10 +49,15 @@ suite() -> [{ct_hooks,[ts_install_cth]}, {timetrap,{minutes,2}}].
 
 all() -> 
     [silent_start, create_window, several_apps, wx_api, wx_misc,
-     data_types, wx_object].
+     data_types, wx_object, {group, optional_callbacks},
+     {group, undef_in_callbacks}].
 
 groups() -> 
-    [].
+    [{optional_callbacks, [],
+     [oc_handle_event, oc_handle_call, oc_handle_cast, oc_handle_info,
+      oc_code_change, oc_terminate1, oc_terminate2]},
+     {undef_in_callbacks, [],
+      [ui_handle_info, ui_code_change, ui_terminate]}].
 
 init_per_group(_GroupName, Config) ->
     Config.
@@ -425,6 +430,169 @@ wx_object(Config) ->
 	   end),
     catch wx:destroy(),
     ok.
+
+%% Test that the server crashes correctly if the handle_event callback is
+%% not exported in the callback module
+oc_handle_event(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+oc_handle_event(_Config) ->
+    wx:new(),
+    {_, _, _, Pid} = wx_object:start(wx_oc_object, [], []),
+    MRef = monitor(process, Pid),
+    %% Mock a call to handle_event
+    Pid ! {wx, a, b, c, d},
+    ok = receive
+        {'DOWN', MRef, process, Pid,
+         {undef, [{wx_oc_object, handle_event, _, _}|_]}} ->
+            ok
+    after 5000 ->
+        ct:fail(should_crash)
+    end.
+
+%% Test that the server crashes correctly if the handle_call callback is
+%% not exported in the callback module
+oc_handle_call(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+oc_handle_call(_Config) ->
+    wx:new(),
+    Frame = wx_object:start(wx_oc_object, [], []),
+    try
+        wx_object:call(Frame, call_msg),
+        ct:fail(should_crash)
+    catch error:{{undef, [{wx_oc_object,handle_call, _, _}|_]},
+                              {wx_object,call,_}} ->
+        ok
+    end.
+
+%% Test that the server crashes correctly if the handle_cast callback is
+%% not exported in the callback module
+oc_handle_cast(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+oc_handle_cast(_Config) ->
+    wx:new(),
+    {_, _, _, Pid} = Frame = wx_object:start(wx_oc_object, [], []),
+    MRef = monitor(process, Pid),
+    wx_object:cast(Frame, cast_msg),
+    ok = receive
+        {'DOWN', MRef, process, Pid,
+         {undef, [{wx_oc_object, handle_cast, _, _}|_]}} ->
+            ok
+    after 5000 ->
+        ct:fail(should_crash)
+    end.
+
+%% Test the default implementation of handle_info if the callback module
+%% does not export it
+oc_handle_info(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+oc_handle_info(_Config) ->
+    wx:new(),
+    {_, _, _, Pid} = wx_object:start(wx_oc_object, [], []),
+    MRef = monitor(process, Pid),
+    Pid ! test,
+    receive
+        {'DOWN', MRef, process, Pid, _} ->
+            ct:fail(should_not_crash)
+    after 500 ->
+        ok
+    end,
+    ok = wx_object:stop(Pid).
+
+%% Test the default implementation of code_change if the callback module
+%% does not export it
+oc_code_change(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+oc_code_change(_Config) ->
+    wx:new(),
+    {_, _, _, Pid} = wx_object:start(wx_oc_object, [], []),
+    sys:suspend(Pid),
+    sys:replace_state(Pid, fun([P, S, M, T]) -> [P, {new, S}, M, T] end),
+    ok = sys:change_code(Pid, wx_oc_object, old_vsn, []),
+    ok = sys:resume(Pid),
+    ok = wx_object:stop(Pid).
+
+%% Test the default implementation of terminate if the callback module
+%% does not export it
+oc_terminate1(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+oc_terminate1(_Config) ->
+    ok = terminate([], normal).
+
+%% Test the default implementation of terminate if the callback module
+%% does not export it
+oc_terminate2(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+oc_terminate2(_Config) ->
+    ok = terminate([{error, test}, infinity], {error, test}).
+
+terminate(ArgsTl, Reason) ->
+    wx:new(),
+    {_, _, _, Pid} = wx_object:start(wx_oc_object, [], []),
+    MRef = monitor(process, Pid),
+    ok = apply(wx_object, stop, [Pid|ArgsTl]),
+    receive
+        {'DOWN', MRef, process, Pid, Reason} ->
+            ok
+    after 1000 ->
+        ct:fail(failed)
+    end.
+
+%% Test that the server crashes correctly if the handle_info callback is
+%% calling an undefined function
+ui_handle_info(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+ui_handle_info(_Config) ->
+    wx:new(),
+    Init = ui_init_fun(),
+    {_, _, _, Pid} = wx_object:start(wx_obj_test,
+                                     [{parent, self()}, {init, Init}], []),
+    unlink(Pid),
+    MRef = monitor(process, Pid),
+    Pid ! {call_undef_fun, {wx_obj_test, handle_info}},
+    receive
+        {'DOWN', MRef, process, Pid,
+         {undef, [{wx_obj_test, handle_info, _, _}|_]}} ->
+            ok
+    after 1000 ->
+        ct:fail(failed)
+    end,
+    ok.
+
+%% Test that the server crashes correctly if the code_change callback is
+%% calling an undefined function
+ui_code_change(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+ui_code_change(_Config) ->
+    wx:new(),
+    Init = ui_init_fun(),
+    {_, _, _, Pid} = wx_object:start(wx_obj_test,
+                                     [{parent, self()}, {init, Init},
+                                      {code_change, {wx_obj_test, code_change}}], []),
+    sys:suspend(Pid),
+    sys:replace_state(Pid, fun([P, S, M, T]) -> [P, {new, S}, M, T] end),
+    {error, {'EXIT', {undef, [{wx_obj_test, code_change, _, _}|_]}}}
+        = sys:change_code(Pid, wx_obj_test, old_vsn, []),
+    ok = sys:resume(Pid),
+    ok.
+
+%% Test that the server crashes correctly if the terminate callback is
+%% calling an undefined function
+ui_terminate(TestInfo) when is_atom(TestInfo) -> wx_test_lib:tc_info(TestInfo);
+ui_terminate(_Config) ->
+    wx:new(),
+    Init = ui_init_fun(),
+    Frame = wx_object:start(wx_obj_test,
+                            [{parent, self()}, {init, Init},
+                             {terminate, {wx_obj_test, terminate}}], []),
+    try
+        wx_object:stop(Frame),
+        ct:fail(should_crash)
+    catch error:{{undef, [{wx_obj_test, terminate, _, _}|_]}, _} ->
+        ok
+    end.
+
+ui_init_fun() ->
+    Init = fun() ->
+        Frame0 = wxFrame:new(wx:null(), ?wxID_ANY, "Test wx_object", [{size, {500, 400}}]),
+        Frame = wx_object:set_pid(Frame0, self()),
+        Sz = wxBoxSizer:new(?wxHORIZONTAL),
+        Panel = wxPanel:new(Frame),
+        wxSizer:add(Sz, Panel, [{flag, ?wxEXPAND}, {proportion, 1}]),
+        wxWindow:show(Frame),
+        {Frame, {Frame, Panel}}
+    end,
+    Init.
 
 check_events(Msgs) ->
     check_events(Msgs, 0,0).

--- a/lib/wx/test/wx_obj_test.erl
+++ b/lib/wx/test/wx_obj_test.erl
@@ -98,10 +98,6 @@ terminate(What, #state{parent=Pid, opts=Opts, user_state=US}) ->
     Pid ! {terminate, What},
     ok.
 
-code_change(_, {new, #state{opts=Opts} = State}, _) ->
-    {Mod, Fun} = proplists:get_value(code_change, Opts),
-    Mod:Fun(),
-    State;
 code_change(Ver1, Ver2, State = #state{parent=Pid}) ->
     Pid ! {code_change, Ver1, Ver2},
     State.

--- a/lib/wx/test/wx_obj_test.erl
+++ b/lib/wx/test/wx_obj_test.erl
@@ -79,6 +79,9 @@ handle_cast(What, State = #state{parent=Pid}) ->
     Pid ! {cast, What},
     {noreply, State}.
 
+handle_info({call_undef_fun, {Mod, Fun}}, State) ->
+    Mod:Fun(),
+    {noreply, State};
 handle_info(What, State = #state{parent=Pid}) ->
     Pid ! {info, What},
     {noreply, State}.
@@ -87,12 +90,18 @@ terminate(What, #state{parent=Pid, opts=Opts, user_state=US}) ->
     case proplists:get_value(terminate, Opts) of
 	undefined ->
 	    ok;
+	{Mod, Fun} ->
+	    Mod:Fun();
 	Terminate ->
 	    Terminate(US)
     end,
     Pid ! {terminate, What},
     ok.
 
+code_change(_, {new, #state{opts=Opts} = State}, _) ->
+    {Mod, Fun} = proplists:get_value(code_change, Opts),
+    Mod:Fun(),
+    State;
 code_change(Ver1, Ver2, State = #state{parent=Pid}) ->
     Pid ! {code_change, Ver1, Ver2},
     State.

--- a/lib/wx/test/wx_oc_object.erl
+++ b/lib/wx/test/wx_oc_object.erl
@@ -1,0 +1,44 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017. All Rights Reserved
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+%% See the License for the specific language governing permissions and
+%% limitations under the License
+%%
+%% %CopyrightEnd%
+%%
+-module(wx_oc_object).
+-include_lib("wx/include/wx.hrl").
+
+-behaviour(wx_object).
+
+%% gen_server callbacks
+-export([init/1]).
+
+-record(state, {}).
+
+init([]) ->
+    Init = fun() ->
+        Frame0 = wxFrame:new(wx:null(), ?wxID_ANY, "Test wx_object", [{size, {500, 400}}]),
+        Frame = wx_object:set_pid(Frame0, self()),
+        Sz = wxBoxSizer:new(?wxHORIZONTAL),
+        Panel = wxPanel:new(Frame),
+        wxSizer:add(Sz, Panel, [{flag, ?wxEXPAND}, {proportion, 1}]),
+        wxWindow:show(Frame),
+        {Frame, {Frame, Panel}}
+    end,
+    {Obj, _UserState} = Init(),
+    {Obj, #state{}};
+init([Init]) ->
+    {Obj, _UserState} = Init(),
+    {Obj, #state{}}.


### PR DESCRIPTION
When implementing e.g. a gen_server, one doesn't always need all the callbacks, but end up copy
pasting or writing "empty" functions since they has to be exported to fit the behaviour. This
pr makes callbacks that are not always needed optional for the otp behaviours.

The question now is if we have chosen the right defaults for the callbacks?
I list the defaults below, feedback is welcome!

gen_event:

````erlang
handle_call(Request, State) ->
    % defaults to a crash
handle_info(_Info, State) ->
    {ok, State}. % just drops the info message
terminate(_Arg, _State) ->
    ok. % does no cleanup
code_change(_OldVsn, State, _Extra) ->
    {ok, State}. % assumes that no state change is needed
````

gen_fsm:
````erlang
handle_event(Event, StateName, StateData) ->
    % defaults to a crash
handle_sync_event(Event, From, StateName, StateData) ->
    % defaults to a crash
handle_info(_Info, StateName, StateData) ->
    {next_state, StateName, StateData}. % just drops the info message
terminate(_Reason, _StateName, _StateData) ->
    ok. % does no cleanup
code_change(_OldVsn, StateName, StateData, _Extra) ->
    {ok, StateName, StateData}. % assumes that no state change is needed
````
gen_server:
````erlang
handle_call(Request, From, State) ->
    % defaults to a crash
handle_cast(Request, State) ->
    % defaults to a crash
handle_info(_Info, State) ->
    {noreply, State}. % just drops the info message
terminate(_Reason, _State) ->
    ok. % does no cleanup
code_change(_OldVsn, State, _Extra) ->
    {ok, State}. % assumes that no state change is needed
````
gen_statem:
````erlang
terminate(_Reason, _State, _Data) ->
    ok. % does no cleanup
code_change(_OldVsn, State, Data, _Extra) ->
    {ok, State, Data}. % assumes that no state change is needed
````