### PR TITLE
Allow OPTIONS HTTP/1.1 method according to RFC 2616

### DIFF
--- a/lib/inets/src/http_server/httpd_request.erl
+++ b/lib/inets/src/http_server/httpd_request.erl
@@ -110,6 +110,8 @@ validate("PATCH", Uri, "HTTP/1." ++ _N) ->
     validate_uri(Uri);
 validate("TRACE", Uri, "HTTP/1." ++ N) when hd(N) >= $1 ->
     validate_uri(Uri);
+validate("OPTIONS", Uri, "HTTP/1." ++ N) when hd(N) >= $1 ->
+    validate_uri(Uri);
 validate(Method, Uri, Version) ->
     case validate_version(Version) of
 	true ->


### PR DESCRIPTION
OPTIONS  method is currently unsupported. It is required for access control for cross-site requests. Example of mod_options.erl:
```erlang
-module(mod_options).
-export([do/1]).
-include_lib("inets/include/httpd.hrl").

do(#mod{method = Method} = ModData) ->
    case Method of
        "OPTIONS" ->
            {break, [{response, {response, [
                {code, 200},
                {"Access-Control-Allow-Headers", "Authorization"},
                {"Access-Control-Allow-Methods", "GET, POST, OPTIONS"},
                {"Access-Control-Allow-Origin", "*"}
            ], []}}]};
        _ -> {proceed, ModData#mod.data}
    end.
```
