### PR TITLE
ErLLVM: Drop support for LLVM<3.9 in R20

### DIFF
--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -958,9 +958,11 @@ struct process {
     Eterm* stop;		/* Stack top */
     Eterm* heap;		/* Heap start */
     Eterm* hend;		/* Heap end */
+    Eterm* abandoned_heap;
     Uint heap_sz;		/* Size of heap in words */
     Uint min_heap_size;         /* Minimum size of heap (in words). */
     Uint min_vheap_size;        /* Minimum size of virtual heap (in words). */
+    Uint max_heap_size;         /* Maximum size of heap (in words). */
 
 #if !defined(NO_FPE_SIGNALS) || defined(HIPE)
     volatile unsigned long fp_exception;
@@ -971,16 +973,6 @@ struct process {
        to enable smaller & faster addressing modes on the x86. */
     struct hipe_process_state hipe;
 #endif
-
-    /*
-     * Moved to after "struct hipe_process_state hipe", as a temporary fix for
-     * LLVM hard-coding offsetof(struct process, hipe.nstack) (sic!)
-     * (see void X86FrameLowering::adjustForHiPEPrologue(...) in
-     * lib/Target/X86/X86FrameLowering.cpp).
-     *
-     * Used to be below "Eterm* hend".
-     */
-    Eterm* abandoned_heap;
 
     /*
      * Saved x registers.
@@ -1061,7 +1053,6 @@ struct process {
     Eterm *old_hend;            /* Heap pointers for generational GC. */
     Eterm *old_htop;
     Eterm *old_heap;
-    Uint max_heap_size;         /* Maximum size of heap (in words). */
     Uint16 gen_gcs;		/* Number of (minor) generational GCs. */
     Uint16 max_gen_gcs;		/* Max minor gen GCs before fullsweep. */
     ErlOffHeap off_heap;	/* Off-heap data updated by copy_struct(). */

--- a/erts/emulator/hipe/hipe_mode_switch.c
+++ b/erts/emulator/hipe/hipe_mode_switch.c
@@ -174,33 +174,6 @@ void hipe_mode_switch_init(void)
 	make_catch(beam_catches_cons(hipe_beam_pc_throw, BEAM_CATCHES_NIL));
 
     hipe_mfa_info_table_init();
-
-#if (defined(__i386__) || defined(__x86_64__)) && defined(__linux__)
-    /* Verify that the offset of c-p->hipe does not change.
-       The ErLLVM hipe backend depends on it being in a specific
-       position. Kostis et al has promised to fix this in upstream
-       llvm by OTP 20, so it should be possible to remove these asserts
-       after that. */
-    ERTS_CT_ASSERT(sizeof(ErtsPTabElementCommon) ==
-                   (sizeof(Eterm) +                   /* id */
-                    sizeof(((ErtsPTabElementCommon*)0)->refc) +
-                    sizeof(ErtsTracer) +              /* tracer */
-                    sizeof(Uint) +                    /* trace_flags */
-                    sizeof(erts_smp_atomic_t) +       /* timer */
-                    sizeof(((ErtsPTabElementCommon*)0)->u)));
-
-    ERTS_CT_ASSERT(offsetof(Process, hipe) ==
-                   (sizeof(ErtsPTabElementCommon) +   /* common */
-                    sizeof(Eterm*) +                  /* htop */
-                    sizeof(Eterm*) +                  /* stop */
-                    sizeof(Eterm*) +                  /* heap */
-                    sizeof(Eterm*) +                  /* hend */
-                    sizeof(Uint) +                    /* heap_sz */
-                    sizeof(Uint) +                    /* min_heap_size */
-                    sizeof(Uint) +                    /* min_vheap_size */
-                    sizeof(volatile unsigned long))); /* fp_exception */
-#endif
-
 }
 
 void hipe_set_call_trap(Uint *bfun, void *nfun, int is_closure)

--- a/lib/hipe/llvm/hipe_llvm.erl
+++ b/lib/hipe/llvm/hipe_llvm.erl
@@ -862,7 +862,7 @@ pp_ins(Dev, Ver, I) ->
         true -> write(Dev, "volatile ");
         false -> ok
       end,
-      pp_dereference_type(Dev, Ver, load_p_type(I)),
+      pp_dereference_type(Dev, load_p_type(I)),
       write(Dev, [" ", load_pointer(I), " "]),
       case load_alignment(I) of
         [] -> ok;
@@ -898,7 +898,7 @@ pp_ins(Dev, Ver, I) ->
         true -> write(Dev, "inbounds ");
         false -> ok
       end,
-      pp_dereference_type(Dev, Ver, getelementptr_p_type(I)),
+      pp_dereference_type(Dev, getelementptr_p_type(I)),
       write(Dev, [" ", getelementptr_value(I)]),
       pp_typed_idxs(Dev, getelementptr_typed_idxs(I)),
       write(Dev, "\n");
@@ -959,10 +959,8 @@ pp_ins(Dev, Ver, I) ->
       pp_args(Dev, fun_def_arglist(I)),
       write(Dev, ") "),
       pp_options(Dev, fun_def_fn_attrs(I)),
-      case Ver >= {3,7} of false -> ok; true ->
-	  write(Dev, "personality i32 (i32, i64, i8*,i8*)* "
-		"@__gcc_personality_v0 ")
-      end,
+      write(Dev, "personality i32 (i32, i64, i8*,i8*)* "
+	    "@__gcc_personality_v0 "),
       case fun_def_align(I) of
         [] -> ok;
         N -> write(Dev, ["align ", N])
@@ -997,12 +995,7 @@ pp_ins(Dev, Ver, I) ->
       pp_type(Dev, const_decl_type(I)),
       write(Dev, [" ", const_decl_value(I), "\n"]);
     #llvm_landingpad{} ->
-      write(Dev, "landingpad { i8*, i32 } "),
-      case Ver < {3,7} of false -> ok; true ->
-	  write(Dev, "personality i32 (i32, i64, i8*,i8*)* "
-		"@__gcc_personality_v0 ")
-      end,
-      write(Dev, "cleanup\n");
+      write(Dev, "landingpad { i8*, i32 } cleanup\n");
     #llvm_asm{} ->
       write(Dev, [asm_instruction(I), "\n"]);
     #llvm_adj_stack{} ->
@@ -1011,15 +1004,7 @@ pp_ins(Dev, Ver, I) ->
       pp_type(Dev, adj_stack_type(I)),
       write(Dev, [" ", adj_stack_offset(I),")\n"]);
     #llvm_meta{} ->
-      write(Dev, ["!", meta_id(I), " = "]),
-      Named = case string:to_integer(meta_id(I)) of
-		{_, ""} -> false;
-		_ -> true
-	      end,
-      case Ver < {3,6} andalso not Named of
-	true -> write(Dev, "metadata !{metadata ");
-	false -> write(Dev, "!{ ")
-      end,
+      write(Dev, ["!", meta_id(I), " = !{ "]),
       write(Dev, string:join([if is_list(Op) -> ["!\"", Op, "\""];
 				 is_integer(Op) -> ["i32 ", integer_to_list(Op)];
 				 is_record(Op, llvm_meta) ->
@@ -1030,15 +1015,10 @@ pp_ins(Dev, Ver, I) ->
       exit({?MODULE, pp_ins, {"Unknown LLVM instruction", Other}})
   end.
 
-%% @doc Print the type of a dereference in an LLVM instruction using syntax
-%% parsable by the specified LLVM version.
-pp_dereference_type(Dev, Ver, Type) ->
-  case Ver >= {3,7} of
-    false -> ok;
-    true ->
-      pp_type(Dev, pointer_type(Type)),
-      write(Dev, ", ")
-  end,
+%% @doc Print the type of a dereference in an LLVM instruction.
+pp_dereference_type(Dev, Type) ->
+  pp_type(Dev, pointer_type(Type)),
+  write(Dev, ", "),
   pp_type(Dev, Type).
 
 %% @doc Pretty-print a list of types

--- a/lib/hipe/main/hipe.erl
+++ b/lib/hipe/main/hipe.erl
@@ -655,7 +655,7 @@ run_compiler_1(Name, DisasmFun, IcodeFun, Options) ->
 	      case proplists:get_bool(to_llvm, Opts0) andalso
 		not llvm_support_available() of
 		true ->
-		  ?error_msg("No LLVM version 3.4 or greater "
+		  ?error_msg("No LLVM version 3.9 or greater "
 			     "found in $PATH; aborting "
 			     "native code compilation.\n", []),
 		  ?EXIT(cant_find_required_llvm_version);
@@ -1585,7 +1585,7 @@ check_options(Opts) ->
 -spec llvm_support_available() -> boolean().
 
 llvm_support_available() ->
-  get_llvm_version() >= {3,4}.
+  get_llvm_version() >= {3,9}.
 
 -type llvm_version() :: {Major :: integer(), Minor :: integer()}.
 


### PR DESCRIPTION
LLVM<3.9 hard-codes an ERTS-internal PCB offset that was going to be changed in R19. Workarounds were implemented (see #1038) while LLVM was generalised so that the PCB offset did not need to be hard-coded. That generalisation was released with LLVM 3.9 (see https://reviews.llvm.org/D20363), and with this PR, those workarounds are dropped, removing ErLLVM support for LLVM<3.9 in R20.