### PR TITLE
Documentation: fix link to erlang(3) man page

### DIFF
--- a/system/doc/reference_manual/introduction.xml
+++ b/system/doc/reference_manual/introduction.xml
@@ -87,7 +87,7 @@
   <section>
     <title>Complete List of BIFs</title>
     <p>For a complete list of BIFs, their arguments and return values,
-      see <seealso marker="erts:erlang#process_flag/2">erlang(3)</seealso>
+      see <seealso marker="erts:erlang">erlang(3)</seealso>
       manual page in ERTS.</p>
   </section>
 


### PR DESCRIPTION
I don't see why this should point to `process_flag/2`. Let's make it not
do that.