### PR TITLE
Document ssl_session_cache_api's size/1 callback

### DIFF
--- a/lib/ssl/doc/src/ssl_session_cache_api.xml
+++ b/lib/ssl/doc/src/ssl_session_cache_api.xml
@@ -11,7 +11,7 @@
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.
       You may obtain a copy of the License at
- 
+
           http://www.apache.org/licenses/LICENSE-2.0
 
       Unless required by applicable law or agreed to in writing, software
@@ -62,8 +62,8 @@
     </taglist>
 
   </section>
-  
-  <funcs>   
+
+  <funcs>
 
     <func>
       <name>delete(Cache, Key) -> _</name>
@@ -134,7 +134,7 @@
          </p>
       </desc>
     </func>
-    
+
     <func>
       <name>select_session(Cache, PartialKey) -> [session()]</name>
       <fsummary>Selects sessions that can be reused.</fsummary>
@@ -146,6 +146,21 @@
       <desc>
 	<p>Selects sessions that can be reused. Is to be callable
 	from any process.
+	</p>
+      </desc>
+    </func>
+
+    <func>
+      <name>size(Cache) -> integer()</name>
+      <fsummary>Returns the number of sessions in the cache.</fsummary>
+      <type>
+	<v>Cache = cache_ref()</v>
+      </type>
+      <desc>
+	<p>Returns the number of sessions in the cache. If size
+	exceeds the maximum number of sessions, the current cache
+	entries will be invalidated regardless of their remaining
+	lifetime. Is to be callable from any process.
 	</p>
       </desc>
     </func>
@@ -178,7 +193,7 @@
 	</p>
       </desc>
     </func>
-    
-  </funcs> 
-  
+
+  </funcs>
+
 </erlref>


### PR DESCRIPTION
The size/1 callback was added as a non-optional callback in
42b8a29dbae1d626f32bc16dd81a129caf741138 but wasn't added to the
documentation for the ssl_session_cache_api behavior.

Signed-off-by: Steven Danna <steve@chef.io>