### PR TITLE
Better error descriptions for ASN.1 encoding/decoding failures

### DIFF
--- a/lib/asn1/doc/src/asn1_getting_started.xml
+++ b/lib/asn1/doc/src/asn1_getting_started.xml
@@ -266,6 +266,10 @@ asn1ct:compile("H323-MESSAGES.asn1",[per]).      </pre>
         <c>{error, {asn1, Description}}</c> where
         <c>Description</c> is
         an Erlang term describing the error.</p>
+	<p>Currently, <c>Description</c> looks like this:
+	<c>{ErrorDescription, StackTrace}</c>. Applications should
+	not depend on the exact contents of <c>Description</c> as it
+	could change in the future.</p>
     </section>
   </section>
 

--- a/lib/asn1/src/asn1ct_gen.erl
+++ b/lib/asn1/src/asn1ct_gen.erl
@@ -802,11 +802,12 @@ result_line_1(Items) ->
 try_catch() ->
     ["  catch",nl,
      "    Class:Exception when Class =:= error; Class =:= exit ->",nl,
+     "      Stk = erlang:get_stacktrace(),",nl,
      "      case Exception of",nl,
-     "        {error,Reason}=Error ->",nl,
-     "          Error;",nl,
+     "        {error,{asn1,Reason}} ->",nl,
+     "          {error,{asn1,{Reason,Stk}}};",nl,
      "        Reason ->",nl,
-     "         {error,{asn1,Reason}}",nl,
+     "         {error,{asn1,{Reason,Stk}}}",nl,
      "      end",nl,
      "end."].
 

--- a/lib/asn1/src/asn1ct_imm.erl
+++ b/lib/asn1/src/asn1ct_imm.erl
@@ -879,10 +879,8 @@ flatten_map_cs_1([integer_default], {Int,_}) ->
     [{'_',Int}];
 flatten_map_cs_1([enum_default], {Int,_}) ->
     [{'_',["{asn1_enum,",Int,"}"]}];
-flatten_map_cs_1([enum_error], {Var,Cs}) ->
-    Vs = [V || {_,V} <- Cs],
-    [{'_',["exit({error,{asn1,{decode_enumerated,{",Var,",",
-	   {asis,Vs},"}}}})"]}];
+flatten_map_cs_1([enum_error], {Var,_}) ->
+    [{'_',["exit({error,{asn1,{decode_enumerated,",Var,"}}})"]}];
 flatten_map_cs_1([], _) -> [].
 
 flatten_hoist_align([[{align_bits,_,_}=Ab|T]|Cs]) ->

--- a/lib/asn1/src/asn1ct_imm.erl
+++ b/lib/asn1/src/asn1ct_imm.erl
@@ -41,7 +41,8 @@
          per_enc_extensions_map/4,
          per_enc_optional/2]).
 -export([per_enc_sof/5]).
--export([enc_absent/3,enc_append/1,enc_element/2,enc_maps_get/2]).
+-export([enc_absent/3,enc_append/1,enc_element/2,enc_maps_get/2,
+         enc_comment/1]).
 -export([enc_cg/2]).
 -export([optimize_alignment/1,optimize_alignment/2,
 	 dec_slim_cg/2,dec_code_gen/2]).
@@ -437,6 +438,9 @@ enc_maps_get(N, Val0) ->
     DstExpr = {expr,lists:concat(["#{",N,":=",Dst,"}"])},
     {var,SrcVar} = Val,
     {[{assign,DstExpr,SrcVar}],Dst0}.
+
+enc_comment(Comment) ->
+    {comment,Comment}.
 
 enc_cg(Imm0, false) ->
     Imm1 = enc_cse(Imm0),
@@ -1052,6 +1056,7 @@ split_off_nonbuilding(Imm) ->
 
 is_nonbuilding({assign,_,_}) -> true;
 is_nonbuilding({call,_,_,_,_}) -> true;
+is_nonbuilding({comment,_}) -> true;
 is_nonbuilding({lc,_,_,_,_}) -> true;
 is_nonbuilding({set,_,_}) -> true;
 is_nonbuilding({list,_,_}) -> true;
@@ -1932,6 +1937,8 @@ enc_opt({'cond',Cs0}, St0) ->
 	    {Cs,Type} = enc_opt_cond_1(Cs1, Type0, [{Cond,Imm}]),
 	    {{'cond',Cs},St0#ost{t=Type}}
     end;
+enc_opt({comment,_}=Imm, St) ->
+    {Imm,St#ost{t=undefined}};
 enc_opt({cons,H0,T0}, St0) ->
     {H,#ost{t=TypeH}=St1} = enc_opt(H0, St0),
     {T,#ost{t=TypeT}=St} = enc_opt(T0, St1),
@@ -2321,6 +2328,9 @@ enc_cg({block,Imm}) ->
     enc_cg(Imm),
     emit([nl,
 	  "end"]);
+enc_cg({seq,{comment,Comment},Then}) ->
+    emit(["%% ",Comment,nl]),
+    enc_cg(Then);
 enc_cg({seq,First,Then}) ->
     enc_cg(First),
     emit([com,nl]),
@@ -2619,6 +2629,8 @@ enc_opt_al({call,per_common,encode_unconstrained_number,[_]}=Call, _) ->
     {[Call],0};
 enc_opt_al({call,_,_,_,_}=Call, Al) ->
     {[Call],Al};
+enc_opt_al({comment,_}=Imm, Al) ->
+    {[Imm],Al};
 enc_opt_al({'cond',Cs0}, Al0) ->
     {Cs,Al} = enc_opt_al_cond(Cs0, Al0),
     {[{'cond',Cs}],Al};
@@ -2714,6 +2726,8 @@ per_fixup([{apply,_,_}=H|T]) ->
 per_fixup([{block,Block}|T]) ->
     [{block,per_fixup(Block)}|per_fixup(T)];
 per_fixup([{'assign',_,_}=H|T]) ->
+    [H|per_fixup(T)];
+per_fixup([{comment,_}=H|T]) ->
     [H|per_fixup(T)];
 per_fixup([{'cond',Cs0}|T]) ->
     Cs = [[C|per_fixup(Act)] || [C|Act] <- Cs0],

--- a/lib/asn1/src/asn1rtt_per_common.erl
+++ b/lib/asn1/src/asn1rtt_per_common.erl
@@ -140,6 +140,8 @@ encode_relative_oid(Val) when is_tuple(Val) ->
 encode_relative_oid(Val) when is_list(Val) ->
     list_to_binary([e_object_element(X)||X <- Val]).
 
+encode_unconstrained_number(Val) when not is_integer(Val) ->
+    exit({error,{asn1,{illegal_integer,Val}}});
 encode_unconstrained_number(Val) when Val >= 0 ->
     if
 	Val < 16#80 ->

--- a/lib/asn1/test/asn1_SUITE_data/Prim.asn1
+++ b/lib/asn1/test/asn1_SUITE_data/Prim.asn1
@@ -18,6 +18,8 @@ BEGIN
   IntExpPri ::=  [PRIVATE 51] EXPLICIT INTEGER
   IntExpApp ::=  [APPLICATION 52] EXPLICIT INTEGER
 
+  IntConstrained ::= INTEGER (0..255)
+
   IntEnum ::=  INTEGER {first(1),last(31)}
 
   Enum ::=  ENUMERATED {monday(1),tuesday(2),wednesday(3),thursday(4),

--- a/lib/asn1/test/ber_decode_error.erl
+++ b/lib/asn1/test/ber_decode_error.erl
@@ -26,47 +26,40 @@ run([]) ->
     {ok,B}  = 'Constructed':encode('S3', {'S3',17}),
     [T,L|V] = binary_to_list(B),
     Bytes = list_to_binary([T,L+3|V] ++ [2,1,3]),
-    case 'Constructed':decode('S3', Bytes) of
-	{error,{asn1,{unexpected,_}}} -> ok
-    end,
+    {unexpected,_} = dec_error('S3', Bytes),
 
     %% Unexpected bytes must be accepted if there is an extensionmark
     {ok,{'S3ext',17}} = 'Constructed':decode('S3ext', Bytes),
 
     %% Truncated tag.
-    {error,{asn1,{invalid_tag,_}}} =
-	(catch 'Constructed':decode('I', <<31,255,255>>)),
+    {invalid_tag,_} = dec_error('I', <<31,255,255>>),
 
     %% Overlong tag.
-    {error,{asn1,{invalid_tag,_}}} =
-	(catch 'Constructed':decode('I', <<31,255,255,255,127>>)),
+    {invalid_tag,_} = dec_error('I', <<31,255,255,255,127>>),
 
     %% Invalid length.
-    {error,{asn1,{invalid_length,_}}} =
-	(catch 'Constructed':decode('I', <<8,255>>)),
+    {invalid_length,_} = dec_error('I', <<8,255>>),
 
     %% Other errors.
-    {error,{asn1,{invalid_value,_}}} =
-	(catch 'Constructed':decode('I', <<>>)),
+    {invalid_value,_} = dec_error('I', <<>>),
 
-    {error,{asn1,{invalid_value,_}}} =
-	(catch 'Constructed':decode('I', <<8,7>>)),
+    {invalid_value,_} = dec_error('I', <<8,7>>),
 
     %% Short indefinite length. Make sure that the decoder doesn't look
     %% beyond the end of binary when looking for a 0,0 terminator.
-    {error,{asn1,{invalid_length,_}}} =
-	(catch 'Constructed':decode('S', sub(<<8,16#80,0,0>>, 3))),
-    {error,{asn1,{invalid_length,_}}} =
-	(catch 'Constructed':decode('S', sub(<<8,16#80,0,0>>, 2))),
-    {error,{asn1,{invalid_length,_}}} =
-	(catch 'Constructed':decode('S', sub(<<40,16#80,1,1,255,0,0>>, 6))),
-    {error,{asn1,{invalid_length,_}}} =
-	(catch 'Constructed':decode('S', sub(<<40,16#80,1,1,255,0,0>>, 5))),
+    {invalid_length,_} = dec_error('S', sub(<<8,16#80,0,0>>, 3)),
+    {invalid_length,_} = dec_error('S', sub(<<8,16#80,0,0>>, 2)),
+    {invalid_length,_} = dec_error('S', sub(<<40,16#80,1,1,255,0,0>>, 6)),
+    {invalid_length,_} = dec_error('S', sub(<<40,16#80,1,1,255,0,0>>, 5)),
 
     %% A primitive must not be encoded with an indefinite length.
-    {error,{asn1,{invalid_length,_}}} =
-	(catch 'Constructed':decode('OS', <<4,128,4,3,97,98,99,0,0>>)),
+    {invalid_length,_} = dec_error('OS', <<4,128,4,3,97,98,99,0,0>>),
     ok.
+
+dec_error(T, Bin) ->
+    {error,{asn1,{Reason,Stk}}} = 'Constructed':decode(T, Bin),
+    [{_,_,_,_}|_] = Stk,
+    Reason.
 
 sub(Bin, Bytes) ->
     <<B:Bytes/binary,_/binary>> = Bin,

--- a/lib/asn1/test/testChoPrim.erl
+++ b/lib/asn1/test/testChoPrim.erl
@@ -31,10 +31,10 @@ bool(Rules) ->
     roundtrip('ChoCon', {int2,233}),
     case Rules of
 	ber ->
-	    {error,{asn1,{invalid_choice_type,wrong}}} =
-		(catch 'ChoPrim':encode('ChoCon', {wrong,233})),
-	    {error,{asn1,{invalid_choice_tag,_WrongTag}}} =
-		(catch 'ChoPrim':decode('ChoCon', <<131,2,0,233>>));
+	    {error,{asn1,{{invalid_choice_type,wrong},[_|_]}}} =
+                 (catch 'ChoPrim':encode('ChoCon', {wrong,233})),
+	    {error,{asn1,{{invalid_choice_tag,_WrongTag},[_|_]}}} =
+                 (catch 'ChoPrim':decode('ChoCon', <<131,2,0,233>>));
 	per ->
 	    ok;
 	uper ->

--- a/lib/asn1/test/testInfObjectClass.erl
+++ b/lib/asn1/test/testInfObjectClass.erl
@@ -33,19 +33,29 @@ main(Rule) ->
     roundtrip('Seq', Val),
     
     %% OTP-5783
-    {error,{asn1,{'Type not compatible with table constraint',
-		  {component,'ArgumentType'},
-		  {value,_},_}}} = 'InfClass':encode('Seq', {'Seq',12,13,1}),
+    {'Type not compatible with table constraint',
+     {component,'ArgumentType'},
+     {value,_},_} = enc_error('Seq', {'Seq',12,13,1}),
     Bytes2 = case Rule of
 		 ber ->
 		     <<48,9,2,1,12,2,1,11,2,1,1>>;
 		 _ ->
 		     <<1,12,1,11,1,1>>
 	     end,
-    {error,{asn1,{'Type not compatible with table constraint',
-		  {{component,_},
-		   {value,_B},_}}}} = 'InfClass':decode('Seq', Bytes2),
+    {'Type not compatible with table constraint',
+     {{component,_},
+      {value,_B},_}} = dec_error('Seq', Bytes2),
     ok.
 
 roundtrip(T, V) ->
     asn1_test_lib:roundtrip('InfClass', T, V).
+
+enc_error(T, V) ->
+    {error,{asn1,{Reason,Stk}}} = 'InfClass':encode(T, V),
+    [{_,_,_,_}|_] = Stk,
+    Reason.
+
+dec_error(T, Bin) ->
+    {error,{asn1,{Reason,Stk}}} = 'InfClass':decode(T, Bin),
+    [{_,_,_,_}|_] = Stk,
+    Reason.

--- a/lib/asn1/test/testPrim.erl
+++ b/lib/asn1/test/testPrim.erl
@@ -195,7 +195,8 @@ roundtrip(Type, Value, ExpectedValue) ->
 enc_error(T, V) ->
     case get(no_ok_wrapper) of
 	false ->
-	    {error,{asn1,Reason}} = 'Prim':encode(T, V),
+	    {error,{asn1,{Reason,Stk}}} = 'Prim':encode(T, V),
+            [{_,_,_,_}|_] = Stk,
             Reason;
 	true ->
 	    try 'Prim':encode(T, V) of

--- a/lib/asn1/test/testPrim.erl
+++ b/lib/asn1/test/testPrim.erl
@@ -34,15 +34,12 @@ bool(Rules) ->
     Types = ['Bool','BoolCon','BoolPri','BoolApp',
 	     'BoolExpCon','BoolExpPri','BoolExpApp'],
     [roundtrip(T, V) || T <- Types, V <- [true,false]],
-    case Rules of
-	ber ->
-	    [begin
-		 {error,{asn1,{encode_boolean,517}}} = enc_error(T, 517)
-	     end || T <- Types],
-	    ok;
-	_ ->
-	    ok
-    end.
+    Tag = case Rules of
+              ber -> encode_boolean;
+              _ -> illegal_boolean
+          end,
+    [{Tag,517} = enc_error(T, 517) || T <- Types],
+    ok.
 
 
 int(Rules) ->
@@ -60,10 +57,22 @@ int(Rules) ->
 	      123456789,12345678901234567890,
 	      -1,-2,-3,-4,-100,-127,-255,-256,-257,
 	      -1234567890,-2147483648],
-    [roundtrip(T, V) ||
-	T <- ['Int','IntCon','IntPri','IntApp',
-	      'IntExpCon','IntExpPri','IntExpApp'],
-	V <- [1|Values]],
+    Types = ['Int','IntCon','IntPri','IntApp',
+             'IntExpCon','IntExpPri','IntExpApp'],
+    _ = [roundtrip(T, V) || T <- Types, V <- [1|Values]],
+    Tag = case Rules of
+              ber -> encode_integer;
+              _ -> illegal_integer
+          end,
+    _ = [{Tag,V} = enc_error(T, V) ||
+            T <- Types, V <- [atom,42.0,{a,b,c}]],
+    case Rules of
+        ber ->
+            ok;
+        _ ->
+            _ = [{Tag,V} = enc_error('IntConstrained', V) ||
+                    V <- [atom,-1,256,42.0]]
+    end,
 
     %%==========================================================
     %% IntEnum ::=  INTEGER {first(1),last(31)} 
@@ -119,7 +128,11 @@ enum(Rules) ->
 
     roundtrip('Enum', monday),
     roundtrip('Enum', thursday),
-    {error,{asn1,{_,4}}} = enc_error('Enum', 4),
+    Tag = case Rules of
+              ber -> enumerated_not_in_range;
+              _ -> illegal_enumerated
+          end,
+    {Tag,4} = enc_error('Enum', 4),
 
     case Rules of
 	Per when Per =:= per; Per =:= uper ->
@@ -182,13 +195,14 @@ roundtrip(Type, Value, ExpectedValue) ->
 enc_error(T, V) ->
     case get(no_ok_wrapper) of
 	false ->
-	    'Prim':encode(T, V);
+	    {error,{asn1,Reason}} = 'Prim':encode(T, V),
+            Reason;
 	true ->
 	    try 'Prim':encode(T, V) of
 		_ ->
 		    ?t:fail()
 	    catch
-		_:Reason ->
+		_:{error,{asn1,Reason}} ->
 		    Reason
 	    end
     end.


### PR DESCRIPTION
The generated encode/2 and decode/2 functions can return cryptic error messages. Consider this ASN.1 spec:
    
    T DEFINITIONS AUTOMATIC TAGS ::=
    BEGIN
      S ::= SEQUENCE {
        b BOOLEAN,
        i INTEGER (1..100),
        j INTEGER (0..7),
        s OCTET STRING
      }
    END
    
In OTP 19, the error terms will look like this:
    
    Eshell V8.2  (abort with ^G)
    1> asn1ct:compile('T', [ber]).
    ok
    2> rr('T').
    ['S']
    3> 'T':encode('S', #'S'{}).
    {error,{asn1,{encode_boolean,undefined}}}
    4> 'T':encode('S', #'S'{b=false}).
    {error,{asn1,{encode_integer,undefined}}}
    5> 'T':encode('S', #'S'{b=false,i=7,j=0}).
    {error,{asn1,function_clause}}
    
Some error terms are clearer than other. In the first error term, it is clear that the error refers to the 'b' field, since there is only one BOOLEAN in 'S'. The second error term could refer to either 'i' or 'j'. The last error term... well... in this case we can infer that it must refer to 's'.

The easiest way to provide more information is to include the stack trace with line numbers in the error term:
    
    3> 'T':encode('S', #'S'{b=false}).
    {error,{asn1,{{encode_integer,undefined},
                  [{'T',encode_integer,2,[{file,"T.erl"},{line,240}]},
                   {'T',enc_S,2,[{file,"T.erl"},{line,102}]},
                   {'T',encode,2,[{file,"T.erl"},{line,36}]},
                   {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,674}]},
                   {shell,exprs,7,[{file,"shell.erl"},{line,686}]},
                   {shell,eval_exprs,7,[{file,"shell.erl"},{line,641}]},
                   {shell,eval_loop,3,[{file,"shell.erl"},{line,626}]}]}}}
    
By looking at the generated Erlang code, we can see that encoding failed for 'i'.
    
This is an compatible change. All that the documentation says is that the format of the error tuple is:
    
      {error,{asn1,Description}}
    
With this change, Description is always a tuple:
    
      {ErrorDescription,StackTrace}
    
Alternatives considered: Providing more information in the error term itself and make sure there can be no 'function_clause', 'badarg', or 'badmatch' exceptions. That would be possible, but it would require a lot of work and it would increase the size of the generated code and make it slower. Therefore, this solution was rejected.

