### PR TITLE
epmd: add option to bind to network interface on Linux

### DIFF
--- a/erts/doc/src/epmd.xml
+++ b/erts/doc/src/epmd.xml
@@ -127,6 +127,22 @@
 	  <c><![CDATA[ERL_EPMD_PORT]]></c>; see section <seealso
 	  marker="#environment_variables">Environment Variables</seealso>.</p>
       </item>
+      <tag><c><![CDATA[-interface Name]]></c></tag>
+      <item>
+	<p>Bind this instance of <c>epmd</c> listen socket to the specified
+	  interface. This can also be set using environment variable
+	  <c><![CDATA[ERL_EPMD_INTERFACE]]></c>; see section <seealso
+	  marker="#environment_variables">Environment Variables</seealso>.</p>
+	<p>This option uses the Linux-specific socket option
+	  <c>SO_BINDTODEVICE</c>, such as in Linux kernel 2.0.30 or later,
+	  and therefore only exists when the runtime system
+	  is compiled for such an operating system.</p>
+	<p>epmd also needs elevated privileges, either running as superuser or
+	  (for Linux) having capability <c>CAP_NET_RAW</c>.</p>
+	<p>The primary use case for this option is to bind epmd into a
+	  <url href="http://www.kernel.org/doc/Documentation/networking/vrf.txt">Linux VRF instance</url>.
+	</p>
+      </item>
       <tag><c><![CDATA[-d | -debug]]></c></tag>
       <item>
 	<p>Enables debug output. The more <c>-d</c> flags specified, the more
@@ -272,6 +288,12 @@
 	  be specified to allow several instances of <c>epmd</c>, representing
 	  independent clusters of nodes, to co-exist on the same host.
 	  All nodes in a cluster must use the same <c>epmd</c> port number.</p>
+      </item>
+      <tag><c><![CDATA[ERL_EPMD_INTERFACE]]></c></tag>
+      <item>
+	<p>If set, <c>epmd</c> will bind it sockets to that interface (Linux only).
+	  See <seealso marker="#daemon_flags">Option -interface</seealso> for
+	  additional restrictions.</p>
       </item>
       <tag><c><![CDATA[ERL_EPMD_RELAXED_COMMAND_CHECK]]></c></tag>
       <item>

--- a/erts/epmd/src/epmd.c
+++ b/erts/epmd/src/epmd.c
@@ -36,6 +36,9 @@ static void usage(EpmdVars *);
 static void run_daemon(EpmdVars*);
 static char* get_addresses(void);
 static int get_port_no(void);
+#if defined(SO_BINDTODEVICE)
+static char* get_interface(void);
+#endif
 static int check_relaxed(void);
 #ifdef __WIN32__
 static int has_console(void);
@@ -163,6 +166,9 @@ int main(int argc, char** argv)
 
     g->addresses      = get_addresses();
     g->port           = get_port_no();
+#if defined(SO_BINDTODEVICE)
+    g->interface     = get_interface();
+#endif
     g->debug          = 0;
 
     g->silent         = 0; 
@@ -227,6 +233,13 @@ int main(int argc, char** argv)
 		((g->port = atoi(argv[1])) == 0))
 	      usage(g);
 	    argv += 2; argc -= 2;
+#if defined(SO_BINDTODEVICE)
+	} else if (strcmp(argv[0], "-interface") == 0) {
+	    if (argc == 1)
+	      usage(g);
+	    g->interface = argv[1];
+	    argv += 2; argc -= 2;
+#endif
 	} else if (strcmp(argv[0], "-names") == 0) {
 	    if (argc == 1)
 		epmd_call(g, EPMD_NAMES_REQ);
@@ -423,6 +436,10 @@ static void usage(EpmdVars *g)
     fprintf(stderr, "    -port No\n");
     fprintf(stderr, "        Let epmd listen to another port than default %d\n",
 	    EPMD_PORT_NO);
+#if defined(SO_BINDTODEVICE)
+    fprintf(stderr, "    -interface Name\n");
+    fprintf(stderr, "        Bind epmd's socket to the specified interface\n");
+#endif
     fprintf(stderr, "    -d\n");
     fprintf(stderr, "    -debug\n");
     fprintf(stderr, "        Enable debugging. This will give a log to\n");
@@ -614,4 +631,9 @@ static int check_relaxed(void)
     char* port_str = getenv("ERL_EPMD_RELAXED_COMMAND_CHECK");
     return (port_str != NULL) ? 1 : 0;
 }
-
+#if defined(SO_BINDTODEVICE)
+static char* get_interface(void)
+{
+    return getenv("ERL_EPMD_INTERFACE");
+}
+#endif

--- a/erts/epmd/src/epmd_cli.c
+++ b/erts/epmd/src/epmd_cli.c
@@ -147,6 +147,14 @@ static int conn_to_epmd(EpmdVars *g)
     connect_sock = socket(AF_INET6, SOCK_STREAM, 0);
     if (connect_sock>=0) {
 
+#if defined(SO_BINDTODEVICE)
+    if (g->interface && g->interface[0]) {
+        if (setsockopt(connect_sock, SOL_SOCKET, SO_BINDTODEVICE, g->interface,
+                       strlen(g->interface) + 1) < 0)
+            goto error;
+    }
+#endif
+
     if (connect(connect_sock, (struct sockaddr*)&address, salen) == 0)
 	return connect_sock;
 
@@ -159,6 +167,14 @@ static int conn_to_epmd(EpmdVars *g)
     connect_sock = socket(AF_INET, SOCK_STREAM, 0);
     if (connect_sock<0)
 	goto error;
+
+#if defined(SO_BINDTODEVICE)
+    if (g->interface && g->interface[0]) {
+        if (setsockopt(connect_sock, SOL_SOCKET, SO_BINDTODEVICE, g->interface,
+                       strlen(g->interface) + 1) < 0)
+            goto error;
+    }
+#endif
 
     if (connect(connect_sock, (struct sockaddr*)&address, salen) < 0)
 	goto error;

--- a/erts/epmd/src/epmd_int.h
+++ b/erts/epmd/src/epmd_int.h
@@ -347,6 +347,9 @@ typedef struct {
   fd_set orig_read_mask;
   int listenfd[MAX_LISTEN_SOCKETS];
   char *addresses;
+#if defined(SO_BINDTODEVICE)
+  char *interface;
+#endif
   char **argv;
 #ifdef HAVE_SYSTEMD_DAEMON
   int is_systemd;

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -388,6 +388,17 @@ void run(EpmdVars *g)
 	}
 #endif
 
+#if defined(SO_BINDTODEVICE)
+      if (g->interface && g->interface[0]) {
+          if (setsockopt(listensock[i], SOL_SOCKET, SO_BINDTODEVICE,
+                         g->interface, strlen(g->interface) + 1) < 0)
+          {
+              dbg_perror(g,"can't bind to interface");
+              epmd_cleanup_exit(g,1);
+          }
+      }
+#endif
+
       /*
        * Note that we must not enable the SO_REUSEADDR on Windows,
        * because addresses will be reused even if they are still in use.


### PR DESCRIPTION
Binding a interface on Linux is required to support VRF-Lite
instance properly. Such instance can for example be use to
seperate management and payload network traffic.

Once the bind_to_device socket option has landed, the kernels inet_dist_listen_options and inet_dist_connect_options configuration parameters can be used to bind distribution sockets to
network devices.

This adds the same capability to epmd.