### PR TITLE
Documentation: use behaviour(ssh_daemon_channel)

### DIFF
--- a/lib/ssh/doc/src/using_ssh.xml
+++ b/lib/ssh/doc/src/using_ssh.xml
@@ -305,7 +305,7 @@ ok = erl_tar:close(HandleRead),
 
     <code type="erl" >
 -module(ssh_echo_server).
--behaviour(ssh_subsystem).
+-behaviour(ssh_daemon_channel).
 -record(state, {
 	  n,
 	  id,


### PR DESCRIPTION
In the SSH User's Guide, section 2.8 'Creating a Subsystem' uses
behaviour(ssh_subsystem) but should use behaviour(ssh_daemon_channel).
The renaming was updated in the Reference Manual but never reflected
in the User's Guide.