### PR TITLE
Include ending dot in yecc's Header code example

### DIFF
--- a/lib/parsetools/doc/src/yecc.xml
+++ b/lib/parsetools/doc/src/yecc.xml
@@ -207,7 +207,7 @@
     <code>
 Header "%% Copyright (C)"
 "%% @private"
-"%% @Author John"</code>
+"%% @Author John".</code>
     <p>Next comes a declaration of the <c>nonterminal categories</c>
       to be used in the rules. For example:</p>
     <code type="none">


### PR DESCRIPTION
All yecc declarations must end in a dot (`.`). The code example for the
Header declaration doesn't include a trailing dot while all other code
examples do. This change adds that dot for consistency and to avoid any
potential confusion on the part of the reader.