### PR TITLE
Fix typos: lenght -> length

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2321,8 +2321,8 @@ spawn_opt(_Tuple) ->
       Total_Reductions :: non_neg_integer(),
       Reductions_Since_Last_Call :: non_neg_integer();
                 (run_queue) -> non_neg_integer();
-                (run_queue_lengths) -> [RunQueueLenght] when
-      RunQueueLenght :: non_neg_integer();
+                (run_queue_lengths) -> [RunQueueLength] when
+      RunQueueLength :: non_neg_integer();
                 (runtime) -> {Total_Run_Time, Time_Since_Last_Call} when
       Total_Run_Time :: non_neg_integer(),
       Time_Since_Last_Call :: non_neg_integer();
@@ -2336,8 +2336,8 @@ spawn_opt(_Tuple) ->
       TotalTime   :: non_neg_integer();
 		(total_active_tasks) -> ActiveTasks when
       ActiveTasks :: non_neg_integer();
-                (total_run_queue_lengths) -> TotalRunQueueLenghts when
-      TotalRunQueueLenghts :: non_neg_integer();
+                (total_run_queue_lengths) -> TotalRunQueueLengths when
+      TotalRunQueueLengths :: non_neg_integer();
                 (wall_clock) -> {Total_Wallclock_Time,
                                  Wallclock_Time_Since_Last_Call} when
       Total_Wallclock_Time :: non_neg_integer(),

--- a/lib/asn1/src/asn1ct_check.erl
+++ b/lib/asn1/src/asn1ct_check.erl
@@ -4948,7 +4948,7 @@ componentrelation_leadingattr(S,CompList) ->
 
 %%FIXME expand_ExtAddGroups([C#'ExtensionAdditionGroup'{components=ExtAdds}|T],
 %% 		    CurrPos,PosAcc,CompAcc) ->
-%%     expand_ExtAddGroups(T,CurrPos+ L = lenght(ExtAdds),[{CurrPos,L}|PosAcc],ExtAdds++CompAcc);
+%%     expand_ExtAddGroups(T,CurrPos+ L = length(ExtAdds),[{CurrPos,L}|PosAcc],ExtAdds++CompAcc);
 %% expand_ExtAddGroups([C|T],CurrPos,PosAcc,CompAcc) ->
 %%     expand_ExtAddGroups(T,CurrPos+ 1,PosAcc,[C|CompAcc]);
 %% expand_ExtAddGroups([],_CurrPos,PosAcc,CompAcc) ->

--- a/lib/asn1/test/asn1_SUITE_data/testobj.erl
+++ b/lib/asn1/test/asn1_SUITE_data/testobj.erl
@@ -967,7 +967,7 @@ pdu_pdp() ->
      116,101,115,116,  % lable1 = test
      4,                % length lable2
      116,101,115,116,  % lable2 = test
-     4,                % lenght lable3
+     4,                % length lable3
      116,101,115,116,  % lable3 = test
      4,                % length lable3
      116,101,115,116,  % lable4 = test

--- a/lib/dialyzer/test/r9c_SUITE_data/src/inets/httpd_response.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/inets/httpd_response.erl
@@ -34,7 +34,7 @@
 -define(PROCEED_RESPONSE(StatusCode, Info),
 	{proceed,
 	 [{response,{already_sent, StatusCode,
-		     httpd_util:key1search(Info#mod.data,content_lenght)}}]}).
+		     httpd_util:key1search(Info#mod.data,content_length)}}]}).
 
 
 -include("httpd.hrl").

--- a/lib/inets/doc/src/notes.xml
+++ b/lib/inets/doc/src/notes.xml
@@ -713,7 +713,7 @@
       <list>
         <item>
           <p>
-	    Gracefully handle invalid content-lenght headers instead
+	    Gracefully handle invalid content-length headers instead
 	    of crashing in list_to_integer.</p>
           <p>
 	    Own Id: OTP-12429</p>

--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -434,7 +434,7 @@ format_response({StatusLine, Headers, Body}) ->
     Length = list_to_integer(Headers#http_response_h.'content-length'),
     {NewBody, Data} = 
 	case Length of
-	    -1 -> % When no lenght indicator is provided
+	    -1 -> % When no length indicator is provided
 		{Body, <<>>};
 	    Length when (Length =< size(Body)) ->
 		<<BodyThisReq:Length/binary, Next/binary>> = Body,

--- a/lib/inets/test/httpd_1_1.erl
+++ b/lib/inets/test/httpd_1_1.erl
@@ -405,11 +405,11 @@ getRangeSize(Head)->
 	    {multiPart, BoundaryString};
 	_X1 ->
 	    case re:run(Head, ?CONTENT_RANGE "bytes=.*\r\n", [{capture, first}]) of
-		{match, [{Start, Lenght}]} ->
+		{match, [{Start, Length}]} ->
 		    %% Get the range data remove the fieldname and the
 		    %% end of line.
 		    RangeInfo = string:substr(Head, Start + 1 + 20, 
-					      Lenght - (20 +2)),
+					      Length - (20 +2)),
 		    rangeSize(string:strip(RangeInfo));
 		_X2 ->
 		    error

--- a/lib/orber/src/cdr_encode.erl
+++ b/lib/orber/src/cdr_encode.erl
@@ -683,7 +683,7 @@ enc_fixed(_Env, Digits, Scale, Fixed, _Bytes, _Len) ->
     orber:dbg("[~p] cdr_encode:enc_fixed(~p, ~p, ~p)~n"
 	      "The supplied fixed type incorrect. Check that the 'digits' and 'scale' field~n"
 	      "match the definition in the IDL-specification. The value field must be~n"
-	      "a list of Digits lenght.", 
+	      "a list of Digits length.", 
 	      [?LINE, Digits, Scale, Fixed], ?DEBUG_LEVEL),
     corba:raise(#'MARSHAL'{completion_status=?COMPLETED_MAYBE}).
 

--- a/lib/stdlib/doc/src/notes.xml
+++ b/lib/stdlib/doc/src/notes.xml
@@ -3163,7 +3163,7 @@
           <p>
 	    Two bugs in io:format for ~F.~Ps has been corrected. When
 	    length(S) >= abs(F) > P, the precision P was incorrectly
-	    ignored. When F == P > lenght(S) the result was
+	    ignored. When F == P > length(S) the result was
 	    incorrectly left adjusted. Bug found by Ali Yakout who
 	    also provided a fix.</p>
           <p>


### PR DESCRIPTION
In the docs for [erlang:statistics/1](http://erlang.org/doc/man/erlang.html#statistics-1), I noticed a typo in `RunQueueLenght`. Searching the code base revealed a few more places where this typo was made.  I fixed them all in this PR.

Note that I don't have an erlang dev environment set up so I haven't tried running anything with these changes, but since it was a mechanical find/replace in my text editor it should be ok, I think :).