### PR TITLE
Use a portable way to lookup the home directory

### DIFF
--- a/lib/dialyzer/src/dialyzer_plt.erl
+++ b/lib/dialyzer/src/dialyzer_plt.erl
@@ -234,12 +234,8 @@ contains_mfa(#plt{info = Info, contracts = Contracts}, MFA) ->
 get_default_plt() ->
   case os:getenv("DIALYZER_PLT") of
     false ->
-      case os:getenv("HOME") of
-	false ->
-	  plt_error("The HOME environment variable needs to be set " ++
-		    "so that Dialyzer knows where to find the default PLT");
-	HomeDir -> filename:join(HomeDir, ".dialyzer_plt")
-      end;
+      {ok,[[HomeDir]]} = init:get_argument(home),
+      filename:join(HomeDir, ".dialyzer_plt");
     UserSpecPlt -> UserSpecPlt
   end.
 

--- a/lib/observer/src/observer_wx.erl
+++ b/lib/observer/src/observer_wx.erl
@@ -636,7 +636,8 @@ create_connect_dialog(connect, #state{frame = Frame}) ->
 
     wxWindow:setSizerAndFit(Dialog, VSizer),
     wxSizer:setSizeHints(VSizer, Dialog),
-    CookiePath = filename:join(os:getenv("HOME"), ".erlang.cookie"),
+    {ok,[[HomeDir]]} = init:get_argument(home),
+    CookiePath = filename:join(HomeDir, ".erlang.cookie"),
     DefaultCookie = case filelib:is_file(CookiePath) of
 			true ->
 			    {ok, Bin} = file:read_file(CookiePath),

--- a/lib/tools/examples/xref_examples.erl
+++ b/lib/tools/examples/xref_examples.erl
@@ -7,7 +7,7 @@
 %% ${HOME}/unused_locals.txt.
 script() ->
     Root = code:root_dir(),
-    Dir = os:getenv("HOME"),
+    {ok,[[Dir]]} = init:get_argument(home),
     Server = s,
     xref:start(Server),
     {ok, _Relname} = xref:add_release(Server, code:lib_dir(), {name,otp}),


### PR DESCRIPTION
Fix for [ERL-161](https://bugs.erlang.org/browse/ERL-161).

Use `init:get_argument(home)` to find the location of the home directory. That will work on all platforms (including Windows).
    
Note that the run-time system will fail to start if `HOME` (or the equivalent on Windows) is not set. Therefore, it can be assumed that `init:get_argument(home)` will not fail.

This PR updates dialyzer, observer, and an xref example in tools. Other uses of `os:getenv("HOME")` are either harmless or appropriate.