### PR TITLE
use normal file names for eunit reports

### DIFF
--- a/lib/eunit/src/eunit_surefire.erl
+++ b/lib/eunit/src/eunit_surefire.erl
@@ -424,6 +424,7 @@ escape_suitename(String) ->
 escape_suitename([], Acc) -> lists:reverse(Acc);
 escape_suitename([$  | Tail], Acc) -> escape_suitename(Tail, [$_ | Acc]);
 escape_suitename([$' | Tail], Acc) -> escape_suitename(Tail, Acc);
+escape_suitename([$" | Tail], Acc) -> escape_suitename(Tail, Acc);
 escape_suitename([$/ | Tail], Acc) -> escape_suitename(Tail, [$: | Acc]);
 escape_suitename([$\\ | Tail], Acc) -> escape_suitename(Tail, [$: | Acc]);
 escape_suitename([Char | Tail], Acc) when Char < $! -> escape_suitename(Tail, Acc);


### PR DESCRIPTION
The surefire reports get called `TEXT-file_"foo.app".xml`, which creates all sorts of problems in the shell. I suggest that double quotes are removed like the single ones.