### PR TITLE
Support random floating point number generation

### DIFF
--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -669,6 +669,35 @@
     </func>
 
     <func>
+      <name>rand_uniform_float() -> F</name>
+      <fsummary>Generate a random floating point number between 0.0 and 1.0</fsummary>
+      <type>
+        <v>F = float()</v>
+      </type>
+      <desc>
+        <p>Generate a random floating pointer number <c><![CDATA[<F>, 0.0 =< <F> < 1.0.]]></c> Uses the
+	<c>crypto</c> library pseudo-random number generator.
+	    </p>
+        <note><p>The generated values shall present no more than 51 bits of effective entropy.</p></note>
+      </desc>
+    </func>
+
+    <func>
+      <name>rand_uniform_float(Lo, Hi) -> F</name>
+      <fsummary>Generate a random floating point number</fsummary>
+      <type>
+        <v>Lo, Hi = number()</v>
+        <v>F = float()</v>
+      </type>
+      <desc>
+        <p>Generate a random floating pointer number <c><![CDATA[<F>, Lo =< <F> < Hi.]]></c> Uses the
+	<c>crypto</c> library pseudo-random number generator.
+    <c>Hi</c> must be larger than <c>Lo</c>.</p>
+        <note><p>The generated values shall present no more than 51 bits of effective entropy.</p></note>
+      </desc>
+    </func>
+
+    <func>
       <name>sign(Algorithm, DigestType, Msg, Key) -> binary()</name>
       <fsummary> Create digital signature.</fsummary>
       <type>

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -31,6 +31,8 @@
 -export([cmac/3, cmac/4]).
 -export([exor/2, strong_rand_bytes/1, mod_pow/3]).
 -export([rand_uniform/2]).
+-export([rand_uniform_float/0]).
+-export([rand_uniform_float/2]).
 -export([block_encrypt/3, block_decrypt/3, block_encrypt/4, block_decrypt/4]).
 -export([next_iv/2, next_iv/3]).
 -export([stream_init/2, stream_init/3, stream_encrypt/2, stream_decrypt/2]).
@@ -288,6 +290,8 @@ stream_decrypt(State, Data0) ->
 -spec strong_rand_bytes(non_neg_integer()) -> binary().
 -spec rand_uniform(crypto_integer(), crypto_integer()) ->
 			  crypto_integer().
+-spec rand_uniform_float() -> float().
+-spec rand_uniform_float(number(), number()) -> float().
 
 strong_rand_bytes(Bytes) ->
     case strong_rand_bytes_nif(Bytes) of
@@ -324,6 +328,19 @@ rand_uniform_pos(_,_) ->
     error(badarg).
 
 rand_uniform_nif(_From,_To) -> ?nif_stub.
+
+
+rand_uniform_float() ->
+    Sign = 0, % positive
+    Exponent = 1023, % on the interval [1.0, 2.0[
+    Fraction = rand_uniform_pos(0, 1 bsl 52), % the whole interval above
+    <<Value:64/big-float>> = <<Sign:1, Exponent:11, Fraction:52>>,
+    Value - 1.0.
+
+rand_uniform_float(From, To) when is_number(From), is_number(To), To > From ->
+    Range = To - From,
+    From + (rand_uniform_float() * Range).
+
 
 -spec rand_seed(binary()) -> ok.
 rand_seed(Seed) ->

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -36,7 +36,8 @@ all() ->
      {group, non_fips},
      mod_pow,
      exor,
-     rand_uniform
+     rand_uniform,
+     rand_uniform_float
     ].
 
 groups() ->
@@ -468,6 +469,64 @@ rand_uniform() ->
 rand_uniform(Config) when is_list(Config) ->
     rand_uniform_aux_test(10),
     10 = byte_size(crypto:strong_rand_bytes(10)).
+
+%%--------------------------------------------------------------------
+rand_uniform_float() ->
+    [{doc, "rand_uniform_float testing"}].
+rand_uniform_float(Config) when is_list(Config) ->
+    rand_uniform_float_aux_test(1000,  -1.0e42,  -1.0e2),
+
+    rand_uniform_float_aux_test(1000,  -1.0e42,  -1.0),
+    rand_uniform_float_aux_test(1000,  -1.0e2,   -1.0),
+
+    rand_uniform_float_aux_test(1000,  -1.0e42,  -1.0e-2),
+    rand_uniform_float_aux_test(1000,  -1.0e2,   -1.0e-2),
+    rand_uniform_float_aux_test(1000,  -1.0,     -1.0e-2),
+
+    rand_uniform_float_aux_test(1000,  -1.0e42,  -1.0e-42),
+    rand_uniform_float_aux_test(1000,  -1.0e2,   -1.0e-42),
+    rand_uniform_float_aux_test(1000,  -1.0,     -1.0e-42),
+    rand_uniform_float_aux_test(1000,  -1.0e-2,  -1.0e-42),
+
+    rand_uniform_float_aux_test(1000,  -1.0e42,   0.0),
+    rand_uniform_float_aux_test(1000,  -1.0e2,    0.0),
+    rand_uniform_float_aux_test(1000,  -1.0,      0.0),
+    rand_uniform_float_aux_test(1000,  -1.0e-2,   0.0),
+    rand_uniform_float_aux_test(1000,  -1.0e-42,  0.0),
+
+    rand_uniform_float_aux_test(1000,  -1.0e42,   1.0e-2),
+    rand_uniform_float_aux_test(1000,  -1.0e2,    1.0e-2),
+    rand_uniform_float_aux_test(1000,  -1.0,      1.0e-2),
+    rand_uniform_float_aux_test(1000,  -1.0e-2,   1.0e-2),
+    rand_uniform_float_aux_test(1000,  -1.0e-42,  1.0e-2),
+    rand_uniform_float_aux_test(1000,   0.0,      1.0e-2),
+
+    rand_uniform_float_aux_test(1000,  -1.0e42,   1.0),
+    rand_uniform_float_aux_test(1000,  -1.0e2,    1.0),
+    rand_uniform_float_aux_test(1000,  -1.0,      1.0),
+    rand_uniform_float_aux_test(1000,  -1.0e-2,   1.0),
+    rand_uniform_float_aux_test(1000,  -1.0e-42,  1.0),
+    rand_uniform_float_aux_test(1000,   0.0,      1.0),
+    rand_uniform_float_aux_test(1000,   1.0e-2,   1.0),
+
+    rand_uniform_float_aux_test(1000,  -1.0e42,   1.0e2),
+    rand_uniform_float_aux_test(1000,  -1.0e2,    1.0e2),
+    rand_uniform_float_aux_test(1000,  -1.0,      1.0e2),
+    rand_uniform_float_aux_test(1000,  -1.0e-2,   1.0e2),
+    rand_uniform_float_aux_test(1000,  -1.0e-42,  1.0e2),
+    rand_uniform_float_aux_test(1000,   0.0,      1.0e2),
+    rand_uniform_float_aux_test(1000,   1.0e-2,   1.0e2),
+    rand_uniform_float_aux_test(1000,   1.0,      1.0e2),
+
+    rand_uniform_float_aux_test(1000,  -1.0e42,   1.0e42),
+    rand_uniform_float_aux_test(1000,  -1.0e2,    1.0e42),
+    rand_uniform_float_aux_test(1000,  -1.0,      1.0e42),
+    rand_uniform_float_aux_test(1000,  -1.0e-2,   1.0e42),
+    rand_uniform_float_aux_test(1000,  -1.0e-42,  1.0e42),
+    rand_uniform_float_aux_test(1000,   0.0,      1.0e42),
+    rand_uniform_float_aux_test(1000,   1.0e-2,   1.0e42),
+    rand_uniform_float_aux_test(1000,   1.0,      1.0e42),
+    rand_uniform_float_aux_test(1000,   1.0e2,    1.0e42).
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------
@@ -931,6 +990,24 @@ crypto_rand_uniform(L,H) ->
 	false ->
 	    ct:fail({"Not in interval", R1, L, H})
     end.
+
+rand_uniform_float_aux_test(NumberOfSamples, MinSample, MaxSample) ->
+    Generator =
+        case {MinSample, MaxSample} of
+            {0.0, 1.0} -> fun crypto:rand_uniform_float/0;
+            _          -> fun () -> crypto:rand_uniform_float(MinSample, MaxSample) end
+        end,
+
+    Samples = [Generator() || _ <- lists:seq(1, NumberOfSamples)],
+
+    % Verify all samples are within bounds
+    %
+    lists:foreach(
+      fun (Sample) ->
+              Sample >= MinSample orelse exit({sample_less_than_minimum, Sample}),
+              Sample < MaxSample orelse exit({sample_greater_or_equal_to_maximum, Sample})
+      end,
+      Samples).
 
 %%--------------------------------------------------------------------
 %% Test data ------------------------------------------------


### PR DESCRIPTION
This PR proposes two new additions to the `crypto`  module, both named `rand_uniform_float`, for effortless generation of pseudo-random floating point numbers:

- `crypto:rand_uniform_float/0`: generates values on the open interval [0.0, 1.0[
- `crypto:rand_uniform_float/2`: generates values on an arbitrary open interval [Lo, Hi[

Generated values are limited to an effective entropy of up to 51 bits but are expected to be uniformly distributed throughout the specified ranges. Having these handy should avoid common pitfalls when people manually implement this functionality while not taking into account some intrinsic peculiarities.
