### PR TITLE
Add nif I/O Queue API

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -344,6 +344,78 @@ return term;</code>
             <c>enif_convert_time_unit()</c></seealso></item>
       </list>
       </item>
+      <tag><marker id="enif_ioq"/>I/O Queues</tag>
+      <item>
+        <p>The Erlang nif library contains function for easily working
+          with I/O vectors as used by the unix system call <c>writev</c>.
+          The I/O Queue is not thread safe, so some other synchronization
+          mechanism has to be used.</p>
+          <list type="bulleted">
+            <item><seealso marker="#SysIOVec">
+            <c>SysIOVec</c></seealso></item>
+            <item><seealso marker="#ErlNifIOVec">
+            <c>ErlNifIOVec</c></seealso></item>
+            <item><seealso marker="#enif_ioq_create">
+            <c>enif_ioq_create()</c></seealso></item>
+            <item><seealso marker="#enif_ioq_destroy">
+            <c>enif_ioq_destroy()</c></seealso></item>
+            <item><seealso marker="#enif_ioq_enq">
+            <c>enif_ioq_enq()</c></seealso></item>
+            <item><seealso marker="#enif_ioq_deq">
+            <c>enif_ioq_deq()</c></seealso></item>
+            <item><seealso marker="#enif_ioq_peek">
+            <c>enif_ioq_peek()</c></seealso></item>
+            <item><seealso marker="#enif_inspect_iolist_as_iovec">
+            <c>enif_inspect_iolist_as_iovec()</c></seealso></item>
+            <item><seealso marker="#enif_free_iovec">
+            <c>enif_free_iovec()</c></seealso></item>
+          </list>
+        <p>Typical usage when writing to a file descriptor looks like this:</p>
+          <code type="none"><![CDATA[
+int writeiolist(ErlNifEnv *env, ERL_NIF_TERM term, ErlNifIOQueue *q, int fd) {
+    ErlNifIOVec vec, *iovec = &vec;
+    SysIOVec *sysiovec;
+    int iovcnt, n;
+    size_t skipbytes = 0;
+    int myerrno;
+
+    if (enif_ioq_size(q) == 0) {
+        /* If I/O queue is empty we just inspect the iolist. */
+        if (!enif_inspect_iolist_as_iovec(env, term, &iovec))
+            return -2; /* invalid iolist */
+        sysiovec = iovec->iov;
+        iovcnt = iovec->iovcnt;
+    } else {
+        /* If I/O contains data we enqueue the iolist and then
+           peek the data to write out of the queue. */
+        if (!enif_ioq_enq(env, q, term, 0))
+            return -2; /* invalid iolist */
+        sysiovec = enif_ioq_peek(q, &iovcnt);
+    }
+
+    /* Attempt to write the data */
+    n = writev(fd, iovec->iov, iovec->iovcnt);
+    myerrno = errno;
+
+    if (enif_ioq_size(q) == 0) {
+        /* If the I/O queue was initially empty we enqueue any
+           remaining data into the queue for writing later. */
+        if (n >= 0) {
+            if (n < iovec->size)
+                enif_ioq_enqv(q, iovec, n);
+        }
+    } else {
+        /* Dequeue any data that was written from the queue. */
+        if (n > 0)
+            enif_ioq_deq(q, n, NULL);
+    }
+
+    /* return n, which is either number of bytes written or -1 if
+       some error happened */
+    errno = myerrno;
+    return n;
+}]]></code>
+      </item>
       <tag><marker id="lengthy_work"/>Long-running NIFs</tag>
       <item>
         <p>As mentioned in the <seealso marker="#WARNING">warning</seealso> text
@@ -813,6 +885,36 @@ typedef enum {
           </item>
         </taglist>
       </item>
+      <tag><marker id="SysIOVec"/><c>SysIOVec</c></tag>
+      <item>
+        <p>A system I/O vector, as used by <c>writev</c> on
+          Unix and <c>WSASend</c> on Win32. It is used in
+          <c>ErlNifIOVec</c> and by
+          <seealso marker="#enif_ioq_peek"><c>enif_ioq_peek</c></seealso>.</p>
+      </item>
+      <tag><marker id="ErlNifIOVec"/><c>ErlNifIOVec</c></tag>
+      <item>
+        <code type="none">
+typedef struct {
+  int iovcnt;
+  size_t size;
+  SysIOVec* iov;
+} ErlNifIOVec;</code>
+        <p>An I/O vector containing <c>iovcnt</c> <c>SysIOVec</c>s
+          pointing to the data. It is used by
+          <seealso marker="#enif_inspect_iolist_as_iovec">
+            <c>enif_inspect_iolist_as_iovec</c></seealso> and
+          <seealso marker="#enif_ioq_enqv">
+            <c>enif_ioq_enqv</c></seealso>.</p>
+      </item>
+      <tag><marker id="ErlNifIOQueueOpts"/><c>ErlNifIOQueueOpts</c></tag>
+      <item>
+        Options to configure a <c>ErlNifIOQueue</c>.
+        <taglist>
+          <tag>ERL_NIF_IOQ_NORMAL</tag>
+          <item><p>Create a normal I/O Queue</p></item>
+        </taglist>
+      </item>
     </taglist>
   </section>
 
@@ -1119,6 +1221,29 @@ typedef enum {
     </func>
 
     <func>
+      <name><ret>void</ret>
+        <nametext>enif_free_iovec(ErlNifIOvec* iov)</nametext></name>
+      <fsummary>Free an ErlIOVec</fsummary>
+      <desc>
+        <p>Frees an io vector returned from
+          <seealso marker="#enif_inspect_iolist_as_iovec">
+            <c>enif_inspect_iolist_as_iovec</c></seealso>.
+          This is needed only if a <c>NULL</c> environment is passed to
+          <seealso marker="#enif_inspect_iolist_as_iovec">
+          <c>enif_inspect_iolist_as_iovec</c></seealso>.</p>
+          <code type="none"><![CDATA[
+ErlNifIOVec *iovec = NULL;
+if (!enif_inspect_iolist_as_iovec(NULL, term, iovec))
+  return 0;
+
+// Do things with the iovec
+
+/* Free the iovector, possibly in another thread or nif function call */
+enif_free_iovec(iovec);]]></code>
+      </desc>
+    </func>
+
+    <func>
       <name><ret>int</ret><nametext>enif_get_atom(ErlNifEnv* env, ERL_NIF_TERM
         term, char* buf, unsigned size, ErlNifCharEncoding encode)</nametext>
       </name>
@@ -1410,6 +1535,131 @@ typedef enum {
         <p>Returns <c>true</c> on success, or <c>false</c> if <c>iolist</c> is
           not an iolist.</p>
       </desc> 
+    </func>
+
+    <func>
+      <name><ret>int</ret><nametext>enif_inspect_iolist_as_iovec(ErlNifEnv*
+        env, ERL_NIF_TERM iolist, ErlNifIOVec** iovec)</nametext></name>
+      <fsummary>Inspect the content of an iolist.</fsummary>
+      <desc>
+        <p>Inspects the iolist and returns it's contents as one or more
+           contigious buffers returned in <c>iovec</c>.
+           When calling this function, <c>iovec</c> should contain a
+           pointer to <c>NULL</c> or a ErlNifIOVec structure that should
+           be used if possible. e.g.
+        </p>
+
+        <code type="none">
+/* Don't use a pre-allocated structure */
+ErlNifIOVec *iovec = NULL;
+enif_inspect_iolist_as_iovec(env, term, &amp;iovec)
+
+/* Use a stack-allocated vector as an optimization vectors with few elements */
+ErlNifIOVec vec, *iovec = &amp;vec;
+enif_inspect_iolist_as_iovec(env, term, &amp;iovec);</code>
+        <p>The contents of the <c>iovec</c> is valid until the called nif
+           function returns. If the <c>iovec</c> should be valid
+           after the nif call returns, it is possible to call this function
+           with a <c>NULL</c> environment. If no environment is given
+           the <c>iovec</c> owns the data in the vector and it has to be
+           expicitly free's using <seealso marker="#enif_free_iovec">
+           <c>enif_free_iovec</c></seealso>.</p>
+        <p>Returns <c>true</c> on success, or <c>false</c> if <c>iolist</c> is
+          not an iolist.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>ErlNifIOQueue *</ret>
+      <nametext>enif_ioq_create(ErlNifIOQueueOpts opts)</nametext></name>
+      <fsummary>Create a new IO Queue</fsummary>
+      <desc>
+        <p>Create a new I/O Queue that can be used to store data.
+          <c>opts</c> has to be set to <c>ERL_NIF_IOQ_NORMAL</c>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>void</ret>
+      <nametext>enif_ioq_destroy(ErlNifIOQueue *q)</nametext></name>
+      <fsummary>Destroy an IO Queue and free it's content</fsummary>
+      <desc>
+        <p>Destroy the I/O queue and free all of it's contents</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>int</ret>
+      <nametext>enif_ioq_deq(ErlNifIOQueue *q, size_t count, size_t *size)</nametext></name>
+      <fsummary>Dequeue count bytes from the IO Queue</fsummary>
+      <desc>
+        <p>Dequeue <c>count</c> bytes from the I/O queue.
+          If <c>size</c> is not <c>NULL</c>, the new size of the queue
+          is placed there.</p>
+        <p>Returns <c>true</c> on success, or <c>false</c> if the I/O does
+          not contain <c>count</c> bytes. On failure the queue is left un-altered.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>int</ret>
+      <nametext>enif_ioq_enq(ErlNifEnv *env, ErlNifIOQueue *q, ERL_NIF_TERM iolist,
+      size_t skip)</nametext></name>
+      <fsummary>Enqueue the iolist into the IO Queue</fsummary>
+      <desc>
+        <p>Enqueue the <c>iolist</c> into <c>q</c> skipping the first <c>skip</c> bytes.</p>
+        <p><c>env</c> can be either <c>NULL</c> or a valid nif environment.</p>
+        <p>Returns <c>true</c> on success, or <c>false</c> if the <c>iolist</c>
+          is not a valid iolist, or <c>skip</c> is more then or equal to the size
+          of <c>iolist</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>int</ret>
+      <nametext>enif_ioq_enq_binary(ErlNifIOQueue *q, ErlNifBinary *bin, size_t skip)</nametext></name>
+      <fsummary>Enqueue the binary into the IO Queue</fsummary>
+      <desc>
+        <p>Enqueue the <c>bin</c> into <c>q</c> skipping the first <c>skip</c> bytes.</p>
+        <p>Returns <c>true</c> on success, or <c>false</c> if <c>skip</c> is more
+        then or equal to the size of <c>bin</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>int</ret>
+      <nametext>enif_ioq_enqv(ErlNifIOQueue *q, ErlNifIOVec *iovec, size_t skip)</nametext></name>
+      <fsummary>Enqueue the iovec into the IO Queue</fsummary>
+      <desc>
+        <p>Enqueue the <c>iovec</c> into <c>q</c> skipping the first <c>skip</c> bytes.</p>
+        <p>Returns <c>true</c> on success, or <c>false</c> if <c>skip</c> is more
+        then or equal to the size of <c>iovec</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>SysIOVec *</ret>
+      <nametext>enif_ioq_peek(ErlNifIOQueue *q, int *iovlen)</nametext></name>
+      <fsummary>Peek inside the IO Queue</fsummary>
+      <desc>
+        <p>Get the I/O queue as a pointer to an array of <c>SysIOVec</c>s.
+          It also returns the number of elements in <c>iovlen</c>.
+          This is the only way to get data out of the queue.</p>
+        <p>Nothing is removed from the queue by this function, that must be done
+          with <seealso marker="#enif_ioq_deq"><c>enif_ioq_deq</c></seealso>.</p>
+         <p>The returned array is suitable to use with the Unix system
+          call <c>writev</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>size_t</ret>
+      <nametext>enif_ioq_size(ErlNifIOQueue *q)</nametext></name>
+      <fsummary>Get the current size of the IO Queue</fsummary>
+      <desc>
+        <p>Get the size of <c>q</c>.</p>
+      </desc>
     </func>
 
     <func>

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -807,7 +807,7 @@ RUN_OBJS = \
 	$(OBJDIR)/erl_bif_binary.o      $(OBJDIR)/erl_ao_firstfit_alloc.o \
 	$(OBJDIR)/erl_thr_queue.o	$(OBJDIR)/erl_sched_spec_pre_alloc.o \
 	$(OBJDIR)/erl_ptab.o		$(OBJDIR)/erl_map.o \
-	$(OBJDIR)/erl_msacc.o
+	$(OBJDIR)/erl_msacc.o           $(OBJDIR)/erl_io_queue.o
 
 LTTNG_OBJS = $(OBJDIR)/erlang_lttng.o
 NIF_OBJS = $(OBJDIR)/erl_tracer_nif.o

--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -40,7 +40,6 @@
 #include "erl_drv_nif.h"
 
 #include <stdlib.h>
-#include <sys/types.h>	/* ssize_t */
 
 #if defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_)
 #ifndef STATIC_ERLANG_DRIVER
@@ -48,24 +47,6 @@
 #define ERL_DRIVER_TYPES_ONLY
 #define WIN32_DYNAMIC_ERL_DRIVER
 #endif
-/*
- * This structure can be cast to a WSABUF structure.
- */
-typedef struct _SysIOVec {
-    unsigned long iov_len;
-    char* iov_base;
-} SysIOVec;
-#else  /* Unix */
-#  ifdef HAVE_SYS_UIO_H
-#    include <sys/types.h>
-#    include <sys/uio.h>
-typedef struct iovec SysIOVec;
-#  else
-typedef struct {
-    char* iov_base;
-    size_t iov_len;
-} SysIOVec;
-#  endif
 #endif
 
 #ifndef EXTERN

--- a/erts/emulator/beam/erl_drv_nif.h
+++ b/erts/emulator/beam/erl_drv_nif.h
@@ -144,8 +144,25 @@ typedef signed int ErlNapiSInt;
 #define ERTS_NAPI_USEC__	2
 #define ERTS_NAPI_NSEC__	3
 
+#if (defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_))
+/*
+ * This structure can be cast to a WSABUF structure.
+ */
+typedef struct _SysIOVec {
+    unsigned long iov_len;
+    char* iov_base;
+} SysIOVec;
+#else  /* Unix */
+#  include <sys/types.h>
+#  ifdef HAVE_SYS_UIO_H
+#    include <sys/uio.h>
+typedef struct iovec SysIOVec;
+#  else
+typedef struct {
+    char* iov_base;
+    size_t iov_len;
+} SysIOVec;
+#  endif
+#endif
+
 #endif  /* __ERL_DRV_NIF_H__ */
-
-
-
-

--- a/erts/emulator/beam/erl_io_queue.c
+++ b/erts/emulator/beam/erl_io_queue.c
@@ -1,0 +1,730 @@
+/*
+ * %CopyrightBegin%
+ * 
+ * Copyright Ericsson AB 2017. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * %CopyrightEnd%
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "sys.h"
+#include "global.h"
+#include "erl_bits.h"
+#include "erl_io_queue.h"
+
+static void free_binary(ErtsIOQBinary *b, int driver);
+static ErtsIOQBinary *alloc_binary(Uint size, char *source, void **iov_base, int driver);
+
+void erts_ioq_init(ErtsIOQueue *q, ErtsAlcType_t alct, int driver)
+{
+
+    ERTS_CT_ASSERT(offsetof(ErlNifIOVec,flags) == sizeof(ErtsIOVecCommon));
+    ERTS_CT_ASSERT(sizeof(ErlIOVec) == sizeof(ErtsIOVecCommon));
+    ERTS_CT_ASSERT(sizeof(size_t) == sizeof(ErlDrvSizeT));
+    ERTS_CT_ASSERT(sizeof(size_t) == sizeof(Uint));
+
+    q->alct = alct;
+    q->driver = driver;
+    q->size = 0;
+    q->v_head = q->v_tail = q->v_start = q->v_small;
+    q->v_end = q->v_small + ERTS_SMALL_IO_QUEUE;
+    q->b_head = q->b_tail = q->b_start = q->b_small;
+    q->b_end = q->b_small + ERTS_SMALL_IO_QUEUE;
+}
+
+void erts_ioq_clear(ErtsIOQueue *q)
+{
+    ErtsIOQBinary** binp = q->b_head;
+    int driver = q->driver;
+
+    if (q->v_start != q->v_small)
+	erts_free(q->alct, (void *) q->v_start);
+
+    while(binp < q->b_tail) {
+	if (*binp != NULL)
+            free_binary(*binp, driver);
+	binp++;
+    }
+    if (q->b_start != q->b_small)
+	erts_free(q->alct, (void *) q->b_start);
+    q->v_start = q->v_end = q->v_head = q->v_tail = NULL;
+    q->b_start = q->b_end = q->b_head = q->b_tail = NULL;
+    q->size = 0;
+}
+
+static void free_binary(ErtsIOQBinary *b, int driver)
+{
+    if (driver)
+        driver_free_binary(&b->driver);
+    else if (erts_refc_dectest(&b->nif.refc, 0) == 0)
+        erts_bin_free(&b->nif);
+}
+
+static ErtsIOQBinary *alloc_binary(Uint size, char *source, void **iov_base, int driver)
+{
+    if (driver) {
+        ErlDrvBinary *bin = driver_alloc_binary(size);
+        if (!bin) return NULL;
+        sys_memcpy(bin->orig_bytes, source, size);
+        *iov_base = bin->orig_bytes;
+        return (ErtsIOQBinary *)bin;
+    } else {
+        /* This clause can be triggered in enif_ioq_enq_binary is used */
+        Binary *bin = erts_bin_nrml_alloc(size);
+        if (!bin) return NULL;
+        erts_refc_init(&bin->refc, 1);
+        sys_memcpy(bin->orig_bytes, source, size);
+        *iov_base = bin->orig_bytes;
+        return (ErtsIOQBinary *)bin;
+    }
+}
+
+Uint erts_ioq_size(ErtsIOQueue *q)
+{
+    return q->size;
+}
+
+/* expand queue to hold n elements in tail or head */
+static int expandq(ErtsIOQueue* q, int n, int tail)
+/* tail: 0 if make room in head, make room in tail otherwise */
+{
+    int h_sz;  /* room before header */
+    int t_sz;  /* room after tail */
+    int q_sz;  /* occupied */
+    int nvsz;
+    SysIOVec* niov;
+    ErtsIOQBinary** nbinv;
+
+    h_sz = q->v_head - q->v_start;
+    t_sz = q->v_end -  q->v_tail;
+    q_sz = q->v_tail - q->v_head;
+
+    if (tail && (n <= t_sz)) /* do we need to expand tail? */
+	return 0;
+    else if (!tail && (n <= h_sz))  /* do we need to expand head? */
+	return 0;
+    else if (n > (h_sz + t_sz)) { /* need to allocate */
+	/* we may get little extra but it ok */
+	nvsz = (q->v_end - q->v_start) + n;
+
+	niov = erts_alloc_fnf(q->alct, nvsz * sizeof(SysIOVec));
+	if (!niov)
+	    return -1;
+	nbinv = erts_alloc_fnf(q->alct, nvsz * sizeof(ErtsIOQBinary**));
+	if (!nbinv) {
+	    erts_free(q->alct, (void *) niov);
+	    return -1;
+	}
+	if (tail) {
+	    sys_memcpy(niov, q->v_head, q_sz*sizeof(SysIOVec));
+	    if (q->v_start != q->v_small)
+		erts_free(q->alct, (void *) q->v_start);
+	    q->v_start = niov;
+	    q->v_end = niov + nvsz;
+	    q->v_head = q->v_start;
+	    q->v_tail = q->v_head + q_sz;
+
+	    sys_memcpy(nbinv, q->b_head, q_sz*sizeof(ErtsIOQBinary*));
+	    if (q->b_start != q->b_small)
+		erts_free(q->alct, (void *) q->b_start);
+	    q->b_start = nbinv;
+	    q->b_end = nbinv + nvsz;
+	    q->b_head = q->b_start;
+	    q->b_tail = q->b_head + q_sz;
+	}
+	else {
+	    sys_memcpy(niov+nvsz-q_sz, q->v_head, q_sz*sizeof(SysIOVec));
+	    if (q->v_start != q->v_small)
+		erts_free(q->alct, (void *) q->v_start);
+	    q->v_start = niov;
+	    q->v_end = niov + nvsz;
+	    q->v_tail = q->v_end;
+	    q->v_head = q->v_tail - q_sz;
+
+	    sys_memcpy(nbinv+nvsz-q_sz, q->b_head, q_sz*sizeof(ErtsIOQBinary*));
+	    if (q->b_start != q->b_small)
+		erts_free(q->alct, (void *) q->b_start);
+	    q->b_start = nbinv;
+	    q->b_end = nbinv + nvsz;
+	    q->b_tail = q->b_end;
+	    q->b_head = q->b_tail - q_sz;
+	}
+    }
+    else if (tail) {  /* move to beginning to make room in tail */
+	sys_memmove(q->v_start, q->v_head, q_sz*sizeof(SysIOVec));
+	q->v_head = q->v_start;
+	q->v_tail = q->v_head + q_sz;
+	sys_memmove(q->b_start, q->b_head, q_sz*sizeof(ErtsIOQBinary*));
+	q->b_head = q->b_start;
+	q->b_tail = q->b_head + q_sz;
+    }
+    else {   /* move to end to make room */
+	sys_memmove(q->v_end-q_sz, q->v_head, q_sz*sizeof(SysIOVec));
+	q->v_tail = q->v_end;
+	q->v_head = q->v_tail-q_sz;
+	sys_memmove(q->b_end-q_sz, q->b_head, q_sz*sizeof(ErtsIOQBinary*));
+	q->b_tail = q->b_end;
+	q->b_head = q->b_tail-q_sz;
+    }
+
+    return 0;
+}
+
+static
+int skip(ErtsIOVec* vec, Uint skipbytes,
+         SysIOVec **iovp, ErtsIOQBinary ***binvp,
+         Uint *lenp)
+{
+    int n;
+    Uint len;
+    SysIOVec* iov;
+    ErtsIOQBinary** binv;
+
+    if (vec->common.size <= skipbytes)
+	return -1;
+
+    iov = vec->common.iov;
+    binv = vec->common.binv;
+    n = vec->common.vsize;
+    /* we use do here to strip iov_len=0 from beginning */
+    do {
+	len = iov->iov_len;
+	if (len <= skipbytes) {
+	    skipbytes -= len;
+	    iov++;
+	    binv++;
+	    n--;
+	}
+	else {
+	    iov->iov_base = ((char *)(iov->iov_base)) + skipbytes;
+	    iov->iov_len -= skipbytes;
+	    skipbytes = 0;
+	}
+    } while(skipbytes > 0);
+
+    *binvp = binv;
+    *iovp = iov;
+    *lenp = len;
+
+    return n;
+}
+
+/* Put elements from vec at q tail */
+int erts_ioq_enqv(ErtsIOQueue *q, ErtsIOVec *eiov, Uint skipbytes)
+{
+    int n;
+    Uint len;
+    Uint size = eiov->common.size - skipbytes;
+    SysIOVec *iov;
+    ErtsIOQBinary** binv;
+    ErtsIOQBinary*  b;
+
+    if (q == NULL)
+	return -1;
+
+    n = skip(eiov, skipbytes, &iov, &binv, &len);
+
+    if (n < 0)
+        return n;
+
+    if (q->v_tail + n >= q->v_end)
+	if (expandq(q, n, 1))
+            return -1;
+
+    /* Queue and reference all binaries (remove zero length items) */
+    while(n--) {
+	if ((len = iov->iov_len) > 0) {
+	    if ((b = *binv) == NULL) { /* special case create binary ! */
+		b = alloc_binary(len, iov->iov_base, (void**)&q->v_tail->iov_base,
+                                 q->driver);
+                if (!b) return -1;
+		*q->b_tail++ = b;
+		q->v_tail->iov_len = len;
+		q->v_tail++;
+	    }
+	    else {
+                if (q->driver)
+                    driver_binary_inc_refc(&b->driver);
+                else
+                    erts_refc_inc(&b->nif.refc, 1);
+		*q->b_tail++ = b;
+		*q->v_tail++ = *iov;
+	    }
+	}
+	iov++;
+	binv++;
+    }
+    q->size += size;      /* update total size in queue */
+    return 0;
+}
+
+/* Put elements from vec at q head */
+int erts_ioq_pushqv(ErtsIOQueue *q, ErtsIOVec* vec, Uint skipbytes)
+{
+    int n;
+    Uint len;
+    Uint size = vec->common.size - skipbytes;
+    SysIOVec* iov;
+    ErtsIOQBinary** binv;
+    ErtsIOQBinary* b;
+
+    if (q == NULL)
+	return -1;
+
+    n = skip(vec, skipbytes, &iov, &binv, &len);
+
+    if (n < 0)
+        return n;
+
+    if (q->v_head - n < q->v_start)
+	if (expandq(q, n, 0))
+            return -1;
+
+    /* Queue and reference all binaries (remove zero length items) */
+    iov += (n-1);  /* move to end */
+    binv += (n-1); /* move to end */
+    while(n--) {
+	if ((len = iov->iov_len) > 0) {
+	    if ((b = *binv) == NULL) { /* special case create binary ! */
+                if (q->driver) {
+                    ErlDrvBinary *bin = driver_alloc_binary(len);
+                    if (!bin) return -1;
+                    sys_memcpy(bin->orig_bytes, iov->iov_base, len);
+                    b = (ErtsIOQBinary *)bin;
+                    q->v_head->iov_base = bin->orig_bytes;
+                }
+		*--q->b_head = b;
+		q->v_head--;
+		q->v_head->iov_len = len;
+	    }
+	    else {
+                if (q->driver)
+                    driver_binary_inc_refc(&b->driver);
+                else
+                    erts_refc_inc(&b->nif.refc, 1);
+		*--q->b_head = b;
+		*--q->v_head = *iov;
+	    }
+	}
+	iov--;
+	binv--;
+    }
+    q->size += size;      /* update total size in queue */
+    return 0;
+}
+
+
+/*
+** Remove size bytes from queue head
+** Return number of bytes that remain in queue
+*/
+int erts_ioq_deq(ErtsIOQueue *q, Uint size)
+{
+    Uint len;
+
+    if ((q == NULL) || (q->size < size))
+	return -1;
+    q->size -= size;
+    while (size > 0) {
+	ASSERT(q->v_head != q->v_tail);
+
+	len = q->v_head->iov_len;
+	if (len <= size) {
+	    size -= len;
+            free_binary(*q->b_head, q->driver);
+	    *q->b_head++ = NULL;
+	    q->v_head++;
+	}
+	else {
+	    q->v_head->iov_base = ((char *)(q->v_head->iov_base)) + size;
+	    q->v_head->iov_len -= size;
+	    size = 0;
+	}
+    }
+
+    /* restart pointers (optimised for enq) */
+    if (q->v_head == q->v_tail) {
+	q->v_head = q->v_tail = q->v_start;
+	q->b_head = q->b_tail = q->b_start;
+    }
+    return 0;
+}
+
+
+Uint erts_ioq_peekqv(ErtsIOQueue *q, ErtsIOVec *ev) {
+    ASSERT(ev);
+
+    if (! q) {
+	return (Uint) -1;
+    } else {
+	if ((ev->common.vsize = q->v_tail - q->v_head) == 0) {
+	    ev->common.size = 0;
+	    ev->common.iov = NULL;
+	    ev->common.binv = NULL;
+	} else {
+	    ev->common.size = q->size;
+	    ev->common.iov = q->v_head;
+	    ev->common.binv = q->b_head;
+	}
+	return q->size;
+    }
+}
+
+SysIOVec* erts_ioq_peekq(ErtsIOQueue *q, int* vlenp)  /* length of io-vector */
+{
+
+    if (q == NULL) {
+	*vlenp = -1;
+	return NULL;
+    }
+    if ((*vlenp = (q->v_tail - q->v_head)) == 0)
+	return NULL;
+    return q->v_head;
+}
+
+/* Fills a possibly deep list of chars and binaries into vec
+** Small characters are first stored in the buffer buf of length ln
+** binaries found are copied and linked into msoh
+** Return  vector length on succsess,
+**        -1 on overflow
+**        -2 on type error
+*/
+
+static ERTS_INLINE void
+io_list_to_vec_set_vec(SysIOVec **iov, ErtsIOQBinary ***binv,
+                       ErtsIOQBinary *bin, byte *ptr, Uint len,
+                       int *vlen)
+{
+    while (len > MAX_SYSIOVEC_IOVLEN) {
+        (*iov)->iov_base = ptr;
+        (*iov)->iov_len = MAX_SYSIOVEC_IOVLEN;
+        ptr += MAX_SYSIOVEC_IOVLEN;
+        len -= MAX_SYSIOVEC_IOVLEN;
+        (*iov)++;
+        (*vlen)++;
+        *(*binv)++ = bin;
+    }
+    (*iov)->iov_base = ptr;
+    (*iov)->iov_len = len;
+    *(*binv)++ = bin;
+    (*iov)++;
+    (*vlen)++;
+}
+
+int
+erts_ioq_iolist_to_vec(Eterm obj,	  /* io-list */
+                       SysIOVec* iov,	  /* io vector */
+                       ErtsIOQBinary** binv,       /* binary reference vector */
+                       ErtsIOQBinary* cbin,        /* binary to store characters */
+                       Uint bin_limit,  /* small binaries limit */
+                       int driver)
+{
+    DECLARE_ESTACK(s);
+    Eterm* objp;
+    byte *buf  = NULL;
+    Uint len = 0;
+    Uint csize  = 0;
+    int vlen   = 0;
+    byte* cptr;
+
+    if (cbin) {
+        if (driver) {
+            buf = (byte*)cbin->driver.orig_bytes;
+            len = cbin->driver.orig_size;
+        } else {
+            buf = (byte*)cbin->nif.orig_bytes;
+            len = cbin->nif.orig_size;
+        }
+    }
+    cptr = buf;
+
+    goto L_jump_start;  /* avoid push */
+
+    while (!ESTACK_ISEMPTY(s)) {
+	obj = ESTACK_POP(s);
+    L_jump_start:
+	if (is_list(obj)) {
+	L_iter_list:
+	    objp = list_val(obj);
+	    obj = CAR(objp);
+	    if (is_byte(obj)) {
+		if (len == 0)
+		    goto L_overflow;
+		*buf++ = unsigned_val(obj);
+		csize++;
+		len--;
+	    } else if (is_binary(obj)) {
+		ESTACK_PUSH(s, CDR(objp));
+		goto handle_binary;
+	    } else if (is_list(obj)) {
+		ESTACK_PUSH(s, CDR(objp));
+		goto L_iter_list;    /* on head */
+	    } else if (!is_nil(obj)) {
+		goto L_type_error;
+	    }
+	    obj = CDR(objp);
+	    if (is_list(obj))
+		goto L_iter_list; /* on tail */
+	    else if (is_binary(obj)) {
+		goto handle_binary;
+	    } else if (!is_nil(obj)) {
+		goto L_type_error;
+	    }
+	} else if (is_binary(obj)) {
+	    Eterm real_bin;
+	    Uint offset;
+	    Eterm* bptr;
+	    Uint size;
+	    int bitoffs;
+	    int bitsize;
+
+	handle_binary:
+	    size = binary_size(obj);
+	    ERTS_GET_REAL_BIN(obj, real_bin, offset, bitoffs, bitsize);
+	    ASSERT(bitsize == 0);
+	    bptr = binary_val(real_bin);
+	    if (*bptr == HEADER_PROC_BIN) {
+		ProcBin* pb = (ProcBin *) bptr;
+		if (bitoffs != 0) {
+		    if (len < size) {
+			goto L_overflow;
+		    }
+		    erts_copy_bits(pb->bytes+offset, bitoffs, 1,
+				   (byte *) buf, 0, 1, size*8);
+		    csize += size;
+		    buf += size;
+		    len -= size;
+		} else if (bin_limit && size < bin_limit) {
+		    if (len < size) {
+			goto L_overflow;
+		    }
+		    sys_memcpy(buf, pb->bytes+offset, size);
+		    csize += size;
+		    buf += size;
+		    len -= size;
+		} else {
+                    ErtsIOQBinary *qbin;
+		    if (csize != 0) {
+                        io_list_to_vec_set_vec(&iov, &binv, cbin,
+                                               cptr, csize, &vlen);
+			cptr = buf;
+			csize = 0;
+		    }
+		    if (pb->flags) {
+			erts_emasculate_writable_binary(pb);
+		    }
+                    if (driver)
+                        qbin = (ErtsIOQBinary*)Binary2ErlDrvBinary(pb->val);
+                    else
+                        qbin = (ErtsIOQBinary*)pb->val;
+
+                    io_list_to_vec_set_vec(
+                        &iov, &binv, qbin,
+                        pb->bytes+offset, size, &vlen);
+		}
+	    } else {
+		ErlHeapBin* hb = (ErlHeapBin *) bptr;
+		if (len < size) {
+		    goto L_overflow;
+		}
+		copy_binary_to_buffer(buf, 0,
+				      ((byte *) hb->data)+offset, bitoffs,
+				      8*size);
+		csize += size;
+		buf += size;
+		len -= size;
+	    }
+	} else if (!is_nil(obj)) {
+	    goto L_type_error;
+	}
+    }
+
+    if (csize != 0) {
+        io_list_to_vec_set_vec(&iov, &binv, cbin, cptr, csize, &vlen);
+    }
+
+    DESTROY_ESTACK(s);
+    return vlen;
+
+ L_type_error:
+    DESTROY_ESTACK(s);
+    return -2;
+
+ L_overflow:
+    DESTROY_ESTACK(s);
+    return -1;
+}
+
+static ERTS_INLINE int
+io_list_vec_count(Eterm obj, Uint *v_size,
+                  Uint *c_size, Uint *b_size, Uint *in_clist,
+                  Uint *p_v_size, Uint *p_c_size, Uint *p_in_clist,
+                  Uint blimit)
+{
+    Uint size = binary_size(obj);
+    Eterm real;
+    ERTS_DECLARE_DUMMY(Uint offset);
+    int bitoffs;
+    int bitsize;
+    ERTS_GET_REAL_BIN(obj, real, offset, bitoffs, bitsize);
+    if (bitsize != 0) return 1;
+    if (thing_subtag(*binary_val(real)) == REFC_BINARY_SUBTAG &&
+	bitoffs == 0) {
+	*b_size += size;
+        if (*b_size < size) return 2;
+	*in_clist = 0;
+        ++*v_size;
+        /* If iov_len is smaller then Uint we split the binary into*/
+        /* multiple smaller (2GB) elements in the iolist.*/
+	*v_size += size / MAX_SYSIOVEC_IOVLEN;
+        if (size >= blimit) {
+            *p_in_clist = 0;
+            ++*p_v_size;
+        } else {
+            *p_c_size += size;
+            if (!*p_in_clist) {
+                *p_in_clist = 1;
+                ++*p_v_size;
+            }
+        }
+    } else {
+	*c_size += size;
+        if (*c_size < size) return 2;
+	if (!*in_clist) {
+	    *in_clist = 1;
+	    ++*v_size;
+	}
+	*p_c_size += size;
+	if (!*p_in_clist) {
+	    *p_in_clist = 1;
+	    ++*p_v_size;
+	}
+    }
+    return 0;
+}
+
+#define IO_LIST_VEC_COUNT(obj)                                          \
+    do {                                                                \
+        switch (io_list_vec_count(obj, &v_size, &c_size,                \
+                                  &b_size, &in_clist,                   \
+                                  &p_v_size, &p_c_size, &p_in_clist,    \
+                                  blimit)) {                            \
+        case 1: goto L_type_error;                                      \
+        case 2: goto L_overflow_error;                                  \
+        default: break;                                                 \
+        }                                                               \
+    } while(0)
+
+/* 
+ * Returns 0 if successful and a non-zero value otherwise.
+ *
+ * Return values through pointers:
+ *    *vsize      - SysIOVec size needed for a writev
+ *    *csize      - Number of bytes not in binary (in the common binary)
+ *    *pvsize     - SysIOVec size needed if packing small binaries
+ *    *pcsize     - Number of bytes in the common binary if packing
+ *    *total_size - Total size of iolist in bytes
+ */
+int
+erts_ioq_iolist_vec_len(Eterm obj, int* vsize, Uint* csize,
+                        Uint* pvsize, Uint* pcsize,
+                        Uint* total_size, Uint blimit)
+{
+    DECLARE_ESTACK(s);
+    Eterm* objp;
+    Uint v_size = 0;
+    Uint c_size = 0;
+    Uint b_size = 0;
+    Uint in_clist = 0;
+    Uint p_v_size = 0;
+    Uint p_c_size = 0;
+    Uint p_in_clist = 0;
+    Uint total;
+
+    goto L_jump_start;  /* avoid a push */
+
+    while (!ESTACK_ISEMPTY(s)) {
+	obj = ESTACK_POP(s);
+    L_jump_start:
+	if (is_list(obj)) {
+	L_iter_list:
+	    objp = list_val(obj);
+	    obj = CAR(objp);
+
+	    if (is_byte(obj)) {
+		c_size++;
+		if (c_size == 0) {
+		    goto L_overflow_error;
+		}
+		if (!in_clist) {
+		    in_clist = 1;
+		    v_size++;
+		}
+		p_c_size++;
+		if (!p_in_clist) {
+		    p_in_clist = 1;
+		    p_v_size++;
+		}
+	    }
+	    else if (is_binary(obj)) {
+                IO_LIST_VEC_COUNT(obj);
+	    }
+	    else if (is_list(obj)) {
+		ESTACK_PUSH(s, CDR(objp));
+		goto L_iter_list;   /* on head */
+	    }
+	    else if (!is_nil(obj)) {
+		goto L_type_error;
+	    }
+
+	    obj = CDR(objp);
+	    if (is_list(obj))
+		goto L_iter_list;   /* on tail */
+	    else if (is_binary(obj)) {  /* binary tail is OK */
+		IO_LIST_VEC_COUNT(obj);
+	    }
+	    else if (!is_nil(obj)) {
+		goto L_type_error;
+	    }
+	}
+	else if (is_binary(obj)) {
+	    IO_LIST_VEC_COUNT(obj);
+	}
+	else if (!is_nil(obj)) {
+	    goto L_type_error;
+	}
+    }
+
+    total = c_size + b_size;
+    if (total < c_size) {
+	goto L_overflow_error;
+    }
+    *total_size = total;
+
+    DESTROY_ESTACK(s);
+    *vsize = v_size;
+    *csize = c_size;
+    *pvsize = p_v_size;
+    *pcsize = p_c_size;
+    return 0;
+
+ L_type_error:
+ L_overflow_error:
+    DESTROY_ESTACK(s);
+    return 1;
+}

--- a/erts/emulator/beam/erl_io_queue.h
+++ b/erts/emulator/beam/erl_io_queue.h
@@ -1,0 +1,201 @@
+/*
+ * %CopyrightBegin%
+ * 
+ * Copyright Ericsson AB 2017. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * %CopyrightEnd%
+ */
+
+/*
+ * Description: A queue used for storing binary data that should be
+ *              passed to writev or similar functions. Used by both
+ *              the nif and driver api.
+ *
+ * Author:      Lukas Larsson
+ */
+
+#ifndef ERL_IO_QUEUE_H__TYPES__
+#define ERL_IO_QUEUE_H__TYPES__
+
+#define ERTS_BINARY_TYPES_ONLY__
+#include "erl_binary.h"
+#undef ERTS_BINARY_TYPES_ONLY__
+#include "erl_nif.h"
+
+#ifdef DEBUG
+#define MAX_SYSIOVEC_IOVLEN (1ull << (32 - 1))
+#else
+#define MAX_SYSIOVEC_IOVLEN (1ull << (sizeof(((SysIOVec*)0)->iov_len) * 8 - 1))
+#endif
+
+#define ERTS_SMALL_IO_QUEUE 5
+
+typedef union {
+    ErlDrvBinary driver;
+    Binary nif;
+} ErtsIOQBinary;
+
+typedef struct {
+    int vsize;         /* length of vectors */
+    Uint size;         /* total size in bytes */
+    SysIOVec* iov;
+    ErtsIOQBinary** binv;
+} ErtsIOVecCommon;
+
+typedef union {
+    ErtsIOVecCommon common;
+    ErlIOVec driver;
+    ErlNifIOVec nif;
+} ErtsIOVec;
+
+/* head/tail represent the data in the queue
+ * start/end represent the edges of the allocated queue
+ * small is used when the number of iovec elements is < SMALL_IO_QUEUE
+ */
+typedef struct erts_io_queue {
+    ErtsAlcType_t alct;
+    int driver;
+    Uint size;       /* total size in bytes */
+
+    SysIOVec* v_start;
+    SysIOVec* v_end;
+    SysIOVec* v_head;
+    SysIOVec* v_tail;
+    SysIOVec  v_small[ERTS_SMALL_IO_QUEUE];
+
+    ErtsIOQBinary **b_start;
+    ErtsIOQBinary **b_end;
+    ErtsIOQBinary **b_head;
+    ErtsIOQBinary **b_tail;
+    ErtsIOQBinary  *b_small[ERTS_SMALL_IO_QUEUE];
+
+} ErtsIOQueue;
+
+#endif /* ERL_IO_QUEUE_H__TYPES__ */
+
+#if !defined(ERL_IO_QUEUE_H) && !defined(ERTS_IO_QUEUE_TYPES_ONLY__)
+#define ERL_IO_QUEUE_H
+
+#include "erl_binary.h"
+#include "erl_bits.h"
+
+void erts_ioq_init(ErtsIOQueue *q, ErtsAlcType_t alct, int driver);
+void erts_ioq_clear(ErtsIOQueue *q);
+Uint erts_ioq_size(ErtsIOQueue *q);
+int erts_ioq_enqv(ErtsIOQueue *q, ErtsIOVec *vec, Uint skip);
+int erts_ioq_pushqv(ErtsIOQueue *q, ErtsIOVec *vec, Uint skip);
+int erts_ioq_deq(ErtsIOQueue *q, Uint Uint);
+Uint erts_ioq_peekqv(ErtsIOQueue *q, ErtsIOVec *ev);
+SysIOVec *erts_ioq_peekq(ErtsIOQueue *q, int *vlenp);
+Uint erts_ioq_sizeq(ErtsIOQueue *q);
+
+int erts_ioq_iolist_vec_len(Eterm obj, int* vsize, Uint* csize,
+                            Uint* pvsize, Uint* pcsize,
+                            Uint* total_size, Uint blimit);
+int erts_ioq_iolist_to_vec(Eterm obj, SysIOVec* iov,
+                           ErtsIOQBinary** binv, ErtsIOQBinary* cbin,
+                           Uint bin_limit, int driver_binary);
+
+ERTS_GLB_INLINE
+int erts_ioq_iodata_vec_len(Eterm obj, int* vsize, Uint* csize,
+                            Uint* pvsize, Uint* pcsize,
+                            Uint* total_size, Uint blimit);
+ERTS_GLB_INLINE
+int erts_ioq_iodata_to_vec(Eterm obj, SysIOVec* iov,
+                           ErtsIOQBinary** binv, ErtsIOQBinary* cbin,
+                           Uint bin_limit, int driver_binary);
+
+
+#if ERTS_GLB_INLINE_INCL_FUNC_DEF
+
+ERTS_GLB_INLINE
+int erts_ioq_iodata_vec_len(Eterm obj, int* vsize, Uint* csize,
+                            Uint* pvsize, Uint* pcsize,
+                            Uint* total_size, Uint blimit) {
+  if (is_binary(obj)) {
+    /* We optimize for when we get a procbin without a bit-offset
+     * that fits in one iov slot
+     */
+    Eterm real_bin;
+    byte bitoffs;
+    byte bitsize;
+    ERTS_DECLARE_DUMMY(Uint offset);
+    Uint size = binary_size(obj);
+    ERTS_GET_REAL_BIN(obj, real_bin, offset, bitoffs, bitsize);
+    if (size < MAX_SYSIOVEC_IOVLEN && bitoffs == 0 && bitsize == 0) {
+      *vsize = 1;
+      *pvsize = 1;
+      if (thing_subtag(*binary_val(real_bin)) == REFC_BINARY_SUBTAG) {
+          *csize = 0;
+          *pcsize = 0;
+      } else {
+          *csize = size;
+          *pcsize = size;
+      }
+      *total_size = size;
+      return 0;
+    }
+  }
+
+  return erts_ioq_iolist_vec_len(obj, vsize, csize,
+                                 pvsize, pcsize, total_size, blimit);
+}
+
+ERTS_GLB_INLINE
+int erts_ioq_iodata_to_vec(Eterm obj,
+                           SysIOVec *iov,
+                           ErtsIOQBinary **binv,
+                           ErtsIOQBinary  *cbin,
+                           Uint bin_limit,
+                           int driver)
+{
+    if (is_binary(obj)) {
+        Eterm real_bin;
+        byte bitoffs;
+        byte bitsize;
+        Uint offset;
+        Uint size = binary_size(obj);
+        ERTS_GET_REAL_BIN(obj, real_bin, offset, bitoffs, bitsize);
+        if (size < MAX_SYSIOVEC_IOVLEN && bitoffs == 0 && bitsize == 0) {
+            Eterm *bptr = binary_val(real_bin);
+            if (thing_subtag(*bptr) == REFC_BINARY_SUBTAG) {
+                ProcBin *pb = (ProcBin *)bptr;
+                if (pb->flags)
+                    erts_emasculate_writable_binary(pb);
+                iov[0].iov_base = pb->bytes+offset;
+                iov[0].iov_len = size;
+                if (driver)
+                    binv[0] = (ErtsIOQBinary*)Binary2ErlDrvBinary(pb->val);
+                else
+                    binv[0] = (ErtsIOQBinary*)pb->val;
+                return 1;
+            } else {
+                ErlHeapBin* hb = (ErlHeapBin *)bptr;
+                byte *buf = driver ? (byte*)cbin->driver.orig_bytes :
+                    (byte*)cbin->nif.orig_bytes;
+		copy_binary_to_buffer(buf, 0, ((byte *) hb->data)+offset, 0, 8*size);
+                iov[0].iov_base = buf;
+                iov[0].iov_len = size;
+                binv[0] = cbin;
+                return 1;
+            }
+        }
+    }
+    return erts_ioq_iolist_to_vec(obj, iov, binv, cbin, bin_limit, driver);
+}
+
+#endif
+
+#endif /* ERL_IO_QUEUE_H */

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -55,6 +55,7 @@
 #include "dtrace-wrapper.h"
 #include "erl_process.h"
 #include "erl_bif_unique.h"
+#include "erl_io_queue.h"
 #undef ERTS_WANT_NFUNC_SCHED_INTERNALS__
 #define ERTS_WANT_NFUNC_SCHED_INTERNALS__
 #include "erl_nfunc_sched.h"
@@ -3269,6 +3270,193 @@ int enif_compare_monitors(const ErlNifMonitor *monitor1,
 {
     return sys_memcmp((void *) monitor1, (void *) monitor2,
                       ERTS_REF_THING_SIZE*sizeof(Eterm));
+}
+
+ErlNifIOQueue *enif_ioq_create(ErlNifIOQueueOpts opts)
+{
+    ErlNifIOQueue *q;
+
+    if (opts != ERL_NIF_IOQ_NORMAL)
+        return NULL;
+
+    q = enif_alloc(sizeof(ErlNifIOQueue));
+    if (!q) return NULL;
+    erts_ioq_init(q, ERTS_ALC_T_NIF, 0);
+
+    return q;
+}
+
+void enif_ioq_destoy(ErlNifIOQueue *q)
+{
+    erts_ioq_clear(q);
+    enif_free(q);
+}
+
+#define ERL_NIF_IOVEC_FLAGS_STACK (1 << 0)
+
+/* If env == NULL, return value has to be free'd using
+ * enif_free_iovec(iov). We have to note if the iov is stack
+ * allocated or not in order to know if we have to free it or not.
+ * ErlNifIOVec stack;
+ * ErlNifIOVec *iov = NULL;
+ * if (!enif_inspect_iolist_as_iovec(term, &iov))
+ *   return badarg;
+ *
+ * if (q)
+ *   enif_ioq_enqv(q, iov, 0);
+ * else
+ *   enif_free_iovec(iov);
+ */
+int enif_inspect_iolist_as_iovec(ErlNifEnv *env, ERL_NIF_TERM term, ErlNifIOVec **iovp)
+{
+    int i, vsize, iov_offset, binv_offset, alloc_size;
+    Uint csize, pvsize, pcsize, total_size, blimit;
+    ErlNifIOVec *niov = *iovp;
+    ErtsIOVec *iov;
+    SysIOVec* ivp;
+    ErtsIOQBinary **bvp, *cbin = NULL;
+    ErlNifBinary nif_cbin;
+    char *ptr;
+
+    if (erts_ioq_iodata_vec_len(term, &vsize, &csize, &pvsize, &pcsize,
+                                &total_size, 64))
+        return 0;
+
+    if (niov && vsize < ERL_NIF_IOVEC_SIZE) {
+        /* Do NOT pack */
+        blimit = 0;
+
+        iov = (ErtsIOVec*)niov;
+        ivp = iov->nif.iov = niov->small_iov;
+        bvp = iov->common.binv = (ErtsIOQBinary**)niov->small_ref_bin;
+        niov->flags = ERL_NIF_IOVEC_FLAGS_STACK;
+
+    } else {
+        /* Do pack if we don't use the provided iov structure */
+        vsize = pvsize;
+        csize = pcsize;
+        blimit = 64;
+
+        iov_offset = ERTS_ALC_DATA_ALIGN_SIZE(sizeof(ErlNifIOVec));
+	binv_offset = iov_offset;
+	binv_offset += ERTS_ALC_DATA_ALIGN_SIZE(vsize*sizeof(SysIOVec));
+	alloc_size = binv_offset;
+	alloc_size += vsize*sizeof(Binary *);
+
+        if (env) {
+            ErlNifBinary bin;
+            if (!enif_alloc_binary(alloc_size, &bin))
+                return 0; /* out of memory */
+            ptr = (char*)bin.data;
+            enif_make_binary(env, &bin);
+        } else {
+            ptr = enif_alloc(alloc_size);
+        }
+
+        iov = (ErtsIOVec *) ptr;
+        ivp = iov->nif.iov = (SysIOVec *) (ptr + iov_offset);
+        bvp = iov->common.binv = (ErtsIOQBinary **) (ptr + binv_offset);
+        niov = &iov->nif;
+        niov->flags = 0;
+        *iovp = niov;
+    }
+
+    if (csize) {
+        if (!enif_alloc_binary(csize, &nif_cbin))
+            return 0; /* out of memory */
+        else
+            cbin = (ErtsIOQBinary*)nif_cbin.ref_bin;
+    }
+
+    iov->nif.iovcnt = erts_ioq_iodata_to_vec(term, ivp, bvp, cbin, blimit, 0);
+    iov->nif.size = total_size;
+
+    if (env) {
+        /* If we have an environment, we attach the allocated
+           data to that environment. The GC will take care of
+           releasing it later on. */
+        if (csize)
+            enif_make_binary(env, &nif_cbin);
+    } else {
+        /* Increment the refc of all the binaries */
+        for (i = 0; i < iov->nif.iovcnt; i++)
+            if (bvp[i]) erts_refc_inc(&bvp[i]->nif.refc, 1);
+        if (csize)
+            enif_release_binary(&nif_cbin);
+    }
+
+    return 1;
+}
+
+
+void enif_free_iovec(ErlNifIOVec *iov)
+{
+    int i;
+    /* Decrement the refc of all the binaries */
+    for (i = 0; i < iov->iovcnt; i++) {
+        Binary *bptr = ((Binary**)iov->ref_bins)[i];
+        /* bptr can be null if enq_binary was used */
+        if (bptr && erts_refc_dectest(&bptr->refc, 0) == 0) {
+            erts_bin_free(bptr);
+        }
+    }
+    if (iov->flags == 0)
+        enif_free(iov);
+}
+
+/* */
+int enif_ioq_enqv(ErlNifIOQueue *q, ErlNifIOVec *iov, size_t skip)
+{
+    return !erts_ioq_enqv(q, (ErtsIOVec*)iov, skip);
+}
+
+int enif_ioq_enq(ErlNifEnv *env, ErlNifIOQueue *q, ERL_NIF_TERM term, size_t skip)
+{
+    ErlNifIOVec vec;
+    ErlNifIOVec *iovec = &vec;
+    int res;
+
+    if (!enif_inspect_iolist_as_iovec(env, term, &iovec))
+        return 0;
+
+    res = enif_ioq_enqv(q, iovec, skip);
+
+    if (!env)
+        enif_free_iovec(iovec);
+
+    return res;
+}
+
+int enif_ioq_enq_binary(ErlNifIOQueue *q, ErlNifBinary *bin, size_t skip)
+{
+    ErlNifIOVec vec = {1, bin->size, NULL, NULL, ERL_NIF_IOVEC_FLAGS_STACK };
+    Binary *ref_bin = (Binary*)bin->ref_bin;
+    vec.iov = vec.small_iov;
+    vec.ref_bins = vec.small_ref_bin;
+    vec.iov[0].iov_base = bin->data;
+    vec.iov[0].iov_len = bin->size;
+    ((Binary**)(vec.ref_bins))[0] = ref_bin;
+
+    return enif_ioq_enqv(q, &vec, skip);
+}
+
+size_t enif_ioq_size(ErlNifIOQueue *q)
+{
+    return erts_ioq_size(q);
+}
+
+int enif_ioq_deq(ErlNifIOQueue *q, size_t elems, size_t *size)
+{
+    if (erts_ioq_deq(q, elems) == -1)
+        return 0;
+    if (size)
+        *size = erts_ioq_size(q);
+    return 1;
+}
+
+SysIOVec *enif_ioq_peek(ErlNifIOQueue *q, int *iovlen)
+{
+    return erts_ioq_peekq(q, iovlen);
 }
 
 /***************************************************************************

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -50,6 +50,7 @@
 ** 2.9: 18.2 enif_getenv
 ** 2.10: Time API
 ** 2.11: 19.0 enif_snprintf 
+** 2.12: 20.0 add enif_queue
 */
 #define ERL_NIF_MAJOR_VERSION 2
 #define ERL_NIF_MINOR_VERSION 12
@@ -235,6 +236,28 @@ typedef enum {
 typedef enum {
     ERL_NIF_BIN2TERM_SAFE = 0x20000000
 } ErlNifBinaryToTerm;
+
+#define ERL_NIF_IOVEC_SIZE 16
+
+typedef struct erl_nif_io_vec {
+    int iovcnt;  /* length of vectors */
+    size_t size; /* total size in bytes */
+    SysIOVec *iov;
+
+    /* internals (avert your eyes) */
+    void **ref_bins; /* Binary[] */
+    int flags;
+
+    /* Used when stack allocating the io vec */
+    SysIOVec small_iov[ERL_NIF_IOVEC_SIZE];
+    void *small_ref_bin[ERL_NIF_IOVEC_SIZE];
+} ErlNifIOVec;
+
+typedef struct erts_io_queue ErlNifIOQueue;
+
+typedef enum {
+    ERL_NIF_IOQ_NORMAL = 1
+} ErlNifIOQueueOpts;
 
 /*
  * Return values from enif_thread_type(). Negative values

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -180,6 +180,21 @@ ERL_NIF_API_FUNC_DECL(ErlNifResourceType*,enif_open_resource_type_x,(ErlNifEnv*,
 ERL_NIF_API_FUNC_DECL(int, enif_monitor_process,(ErlNifEnv*,void* obj,const ErlNifPid*,ErlDrvMonitor *monitor));
 ERL_NIF_API_FUNC_DECL(int, enif_demonitor_process,(ErlNifEnv*,void* obj,const ErlDrvMonitor *monitor));
 ERL_NIF_API_FUNC_DECL(int, enif_compare_monitors,(const ErlNifMonitor*,const ErlNifMonitor*));
+ERL_NIF_API_FUNC_DECL(ErlNifIOQueue *,enif_ioq_create,(ErlNifIOQueueOpts opts));
+ERL_NIF_API_FUNC_DECL(void,enif_ioq_destoy,(ErlNifIOQueue *q));
+
+ERL_NIF_API_FUNC_DECL(int,enif_ioq_enq,(ErlNifEnv *env, ErlNifIOQueue *q, ERL_NIF_TERM term, size_t skip));
+ERL_NIF_API_FUNC_DECL(int,enif_ioq_enq_binary,(ErlNifIOQueue *q, ErlNifBinary *bin, size_t skip));
+ERL_NIF_API_FUNC_DECL(int,enif_ioq_enqv,(ErlNifIOQueue *q, ErlNifIOVec *iov, size_t skip));
+
+ERL_NIF_API_FUNC_DECL(size_t,enif_ioq_size,(ErlNifIOQueue *q));
+ERL_NIF_API_FUNC_DECL(int,enif_ioq_deq,(ErlNifIOQueue *q, size_t count, size_t *size));
+
+ERL_NIF_API_FUNC_DECL(SysIOVec*,enif_ioq_peek,(ErlNifIOQueue *q, int *iovlen));
+
+ERL_NIF_API_FUNC_DECL(int,enif_inspect_iolist_as_iovec,(ErlNifEnv *env, ERL_NIF_TERM term, ErlNifIOVec **iov));
+ERL_NIF_API_FUNC_DECL(void,enif_free_iovec,(ErlNifIOVec *iov));
+
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
@@ -342,6 +357,16 @@ ERL_NIF_API_FUNC_DECL(int, enif_compare_monitors,(const ErlNifMonitor*,const Erl
 #  define enif_monitor_process ERL_NIF_API_FUNC_MACRO(enif_monitor_process)
 #  define enif_demonitor_process ERL_NIF_API_FUNC_MACRO(enif_demonitor_process)
 #  define enif_compare_monitors ERL_NIF_API_FUNC_MACRO(enif_compare_monitors)
+#  define enif_ioq_create ERL_NIF_API_FUNC_MACRO(enif_ioq_create)
+#  define enif_ioq_destoy ERL_NIF_API_FUNC_MACRO(enif_ioq_destoy)
+#  define enif_ioq_enq ERL_NIF_API_FUNC_MACRO(enif_ioq_enq)
+#  define enif_ioq_enq_binary ERL_NIF_API_FUNC_MACRO(enif_ioq_enq_binary)
+#  define enif_ioq_enqv ERL_NIF_API_FUNC_MACRO(enif_ioq_enqv)
+#  define enif_ioq_size ERL_NIF_API_FUNC_MACRO(enif_ioq_size)
+#  define enif_ioq_deq ERL_NIF_API_FUNC_MACRO(enif_ioq_deq)
+#  define enif_ioq_peek ERL_NIF_API_FUNC_MACRO(enif_ioq_peek)
+#  define enif_inspect_iolist_as_iovec ERL_NIF_API_FUNC_MACRO(enif_inspect_iolist_as_iovec)
+#  define enif_free_iovec ERL_NIF_API_FUNC_MACRO(enif_free_iovec)
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment)

--- a/erts/emulator/beam/erl_port.h
+++ b/erts/emulator/beam/erl_port.h
@@ -31,6 +31,9 @@ typedef struct ErtsProc2PortSigData_ ErtsProc2PortSigData;
 #include "erl_ptab.h"
 #include "erl_thr_progress.h"
 #include "erl_trace.h"
+#define ERTS_IO_QUEUE_TYPES_ONLY__
+#include "erl_io_queue.h"
+#undef ERTS_IO_QUEUE_TYPES_ONLY__
 
 #ifndef __WIN32__
 #define ERTS_DEFAULT_MAX_PORTS (1 << 16)
@@ -75,23 +78,8 @@ typedef struct erts_driver_t_ erts_driver_t;
 #define ERTS_Port2ErlDrvPort(PH) ((ErlDrvPort) (PH))
 #endif
 
-#define SMALL_IO_QUEUE 5   /* Number of fixed elements */
+typedef ErtsIOQueue ErlPortIOQueue;
 
-typedef struct {
-    ErlDrvSizeT size;       /* total size in bytes */
-
-    SysIOVec* v_start;
-    SysIOVec* v_end;
-    SysIOVec* v_head;
-    SysIOVec* v_tail;
-    SysIOVec  v_small[SMALL_IO_QUEUE];
-
-    ErlDrvBinary** b_start;
-    ErlDrvBinary** b_end;
-    ErlDrvBinary** b_head;
-    ErlDrvBinary** b_tail;
-    ErlDrvBinary*  b_small[SMALL_IO_QUEUE];
-} ErlIOQueue;
 
 typedef struct line_buf {  /* Buffer used in line oriented I/O */
     ErlDrvSizeT bufsiz;      /* Size of character buffer */
@@ -172,7 +160,7 @@ struct _erl_drv_port {
     Uint bytes_in;		/* Number of bytes read */
     Uint bytes_out;		/* Number of bytes written */
 
-    ErlIOQueue ioq;              /* driver accessible i/o queue */
+    ErlPortIOQueue ioq;          /* driver accessible i/o queue */
     DistEntry *dist_entry;       /* Dist entry used in DISTRIBUTION */
     char *name;		         /* String used in the open */
     erts_driver_t* drv_ptr;

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -52,6 +52,7 @@
 #include "erl_bif_unique.h"
 #include "erl_hl_timer.h"
 #include "erl_time.h"
+#include "erl_io_queue.h"
 
 extern ErlDrvEntry fd_driver_entry;
 extern ErlDrvEntry vanilla_driver_entry;
@@ -108,7 +109,7 @@ static void driver_monitor_unlock_pdl(Port *p);
 #define ERL_SMALL_IO_BIN_LIMIT (4*ERL_ONHEAP_BIN_LIMIT)
 #define SMALL_WRITE_VEC  16
 
-static ERTS_INLINE ErlIOQueue*
+static ERTS_INLINE ErlPortIOQueue*
 drvport2ioq(ErlDrvPort drvport)
 {
     Port *prt = erts_thr_drvport2port(drvport, 0);
@@ -123,11 +124,11 @@ is_port_ioq_empty(Port *pp)
     int res;
     ERTS_SMP_LC_ASSERT(erts_lc_is_port_locked(pp));
     if (!pp->port_data_lock)
-	res = (pp->ioq.size == 0);
+	res = (erts_ioq_size(&pp->ioq) == 0);
     else {
 	ErlDrvPDL pdl = pp->port_data_lock;
 	erts_mtx_lock(&pdl->mtx);
-	res = (pp->ioq.size == 0);
+	res = (erts_ioq_size(&pp->ioq) == 0);
 	erts_mtx_unlock(&pdl->mtx);
     }
     return res;
@@ -142,14 +143,14 @@ erts_is_port_ioq_empty(Port *pp)
 Uint
 erts_port_ioq_size(Port *pp)
 {
-    int res;
+    ErlDrvSizeT res;
     ERTS_SMP_LC_ASSERT(erts_lc_is_port_locked(pp));
     if (!pp->port_data_lock)
-	res = pp->ioq.size;
+	res = erts_ioq_size(&pp->ioq);
     else {
 	ErlDrvPDL pdl = pp->port_data_lock;
 	erts_mtx_lock(&pdl->mtx);
-	res = pp->ioq.size;
+	res = erts_ioq_size(&pp->ioq);
 	erts_mtx_unlock(&pdl->mtx);
     }
     return (Uint) res;
@@ -513,41 +514,17 @@ erts_port_free(Port *prt)
 */
 static void initq(Port* prt)
 {
-    ErlIOQueue* q = &prt->ioq;
-
     ERTS_LC_ASSERT(!prt->port_data_lock);
-
-    q->size = 0;
-    q->v_head = q->v_tail = q->v_start = q->v_small;
-    q->v_end = q->v_small + SMALL_IO_QUEUE;
-    q->b_head = q->b_tail = q->b_start = q->b_small;
-    q->b_end = q->b_small + SMALL_IO_QUEUE;
+    erts_ioq_init(&prt->ioq, ERTS_ALC_T_IOQ, 1);
 }
 
 static void stopq(Port* prt)
 {
-    ErlIOQueue* q;
-    ErlDrvBinary** binp;
 
     if (prt->port_data_lock)
 	driver_pdl_lock(prt->port_data_lock);
 
-    q = &prt->ioq;
-    binp = q->b_head;
-
-    if (q->v_start != q->v_small)
-	erts_free(ERTS_ALC_T_IOQ, (void *) q->v_start);
-
-    while(binp < q->b_tail) {
-	if (*binp != NULL)
-	    driver_free_binary(*binp);
-	binp++;
-    }
-    if (q->b_start != q->b_small)
-	erts_free(ERTS_ALC_T_IOQ, (void *) q->b_start);
-    q->v_start = q->v_end = q->v_head = q->v_tail = NULL;
-    q->b_start = q->b_end = q->b_head = q->b_tail = NULL;
-    q->size = 0;
+    erts_ioq_clear(&prt->ioq);
 
     if (prt->port_data_lock) {
 	driver_pdl_unlock(prt->port_data_lock);
@@ -927,311 +904,6 @@ int erts_port_handle_xports(Port *prt)
     return reds;
 }
 #endif
-
-/* Fills a possibly deep list of chars and binaries into vec
-** Small characters are first stored in the buffer buf of length ln
-** binaries found are copied and linked into msoh
-** Return  vector length on succsess,
-**        -1 on overflow
-**        -2 on type error
-*/
-
-#ifdef DEBUG
-#define MAX_SYSIOVEC_IOVLEN (1ull << (32 - 1))
-#else
-#define MAX_SYSIOVEC_IOVLEN (1ull << (sizeof(((SysIOVec*)0)->iov_len) * 8 - 1))
-#endif
-
-static ERTS_INLINE void
-io_list_to_vec_set_vec(SysIOVec **iov, ErlDrvBinary ***binv,
-                        ErlDrvBinary *bin, byte *ptr, Uint len,
-                        int *vlen)
-{
-    while (len > MAX_SYSIOVEC_IOVLEN) {
-        (*iov)->iov_base = ptr;
-        (*iov)->iov_len = MAX_SYSIOVEC_IOVLEN;
-        ptr += MAX_SYSIOVEC_IOVLEN;
-        len -= MAX_SYSIOVEC_IOVLEN;
-        (*iov)++;
-        (*vlen)++;
-        *(*binv)++ = bin;
-    }
-    (*iov)->iov_base = ptr;
-    (*iov)->iov_len = len;
-    *(*binv)++ = bin;
-    (*iov)++;
-    (*vlen)++;
-}
-
-static int
-io_list_to_vec(Eterm obj,	/* io-list */
-	       SysIOVec* iov,	/* io vector */
-	       ErlDrvBinary** binv, /* binary reference vector */
-	       ErlDrvBinary* cbin, /* binary to store characters */
-	       ErlDrvSizeT bin_limit)	/* small binaries limit */
-{
-    DECLARE_ESTACK(s);
-    Eterm* objp;
-    byte *buf  = (byte*)cbin->orig_bytes;
-    Uint len = cbin->orig_size;
-    Uint csize  = 0;
-    int vlen   = 0;
-    byte* cptr = buf;
-
-    goto L_jump_start;  /* avoid push */
-
-    while (!ESTACK_ISEMPTY(s)) {
-	obj = ESTACK_POP(s);
-    L_jump_start:
-	if (is_list(obj)) {
-	L_iter_list:
-	    objp = list_val(obj);
-	    obj = CAR(objp);
-	    if (is_byte(obj)) {
-		if (len == 0)
-		    goto L_overflow;
-		*buf++ = unsigned_val(obj);
-		csize++;
-		len--;
-	    } else if (is_binary(obj)) {
-		ESTACK_PUSH(s, CDR(objp));
-		goto handle_binary;
-	    } else if (is_list(obj)) {
-		ESTACK_PUSH(s, CDR(objp));
-		goto L_iter_list;    /* on head */
-	    } else if (!is_nil(obj)) {
-		goto L_type_error;
-	    }	    
-	    obj = CDR(objp);
-	    if (is_list(obj))
-		goto L_iter_list; /* on tail */
-	    else if (is_binary(obj)) {
-		goto handle_binary;
-	    } else if (!is_nil(obj)) {
-		goto L_type_error;
-	    }
-	} else if (is_binary(obj)) {
-	    Eterm real_bin;
-	    Uint offset;
-	    Eterm* bptr;
-	    ErlDrvSizeT size;
-	    int bitoffs;
-	    int bitsize;
-
-	handle_binary:
-	    size = binary_size(obj);
-	    ERTS_GET_REAL_BIN(obj, real_bin, offset, bitoffs, bitsize);
-	    ASSERT(bitsize == 0);
-	    bptr = binary_val(real_bin);
-	    if (*bptr == HEADER_PROC_BIN) {
-		ProcBin* pb = (ProcBin *) bptr;
-		if (bitoffs != 0) {
-		    if (len < size) {
-			goto L_overflow;
-		    }
-		    erts_copy_bits(pb->bytes+offset, bitoffs, 1,
-				   (byte *) buf, 0, 1, size*8);
-		    csize += size;
-		    buf += size;
-		    len -= size;
-		} else if (bin_limit && size < bin_limit) {
-		    if (len < size) {
-			goto L_overflow;
-		    }
-		    sys_memcpy(buf, pb->bytes+offset, size);
-		    csize += size;
-		    buf += size;
-		    len -= size;
-		} else {
-		    if (csize != 0) {
-                        io_list_to_vec_set_vec(&iov, &binv, cbin,
-                                               cptr, csize, &vlen);
-			cptr = buf;
-			csize = 0;
-		    }
-		    if (pb->flags) {
-			erts_emasculate_writable_binary(pb);
-		    }
-                    io_list_to_vec_set_vec(
-                        &iov, &binv, Binary2ErlDrvBinary(pb->val),
-                        pb->bytes+offset, size, &vlen);
-		}
-	    } else {
-		ErlHeapBin* hb = (ErlHeapBin *) bptr;
-		if (len < size) {
-		    goto L_overflow;
-		}
-		copy_binary_to_buffer(buf, 0,
-				      ((byte *) hb->data)+offset, bitoffs,
-				      8*size);
-		csize += size;
-		buf += size;
-		len -= size;
-	    }
-	} else if (!is_nil(obj)) {
-	    goto L_type_error;
-	}
-    }
-
-    if (csize != 0) {
-        io_list_to_vec_set_vec(&iov, &binv, cbin, cptr, csize, &vlen);
-    }
-
-    DESTROY_ESTACK(s);
-    return vlen;
-
- L_type_error:
-    DESTROY_ESTACK(s);
-    return -2;
-
- L_overflow:
-    DESTROY_ESTACK(s);
-    return -1;
-}
-
-#define IO_LIST_VEC_COUNT(obj)						\
-do {									\
-    Uint _size = binary_size(obj);					\
-    Eterm _real;							\
-    ERTS_DECLARE_DUMMY(Uint _offset);					\
-    int _bitoffs;							\
-    int _bitsize;							\
-    ERTS_GET_REAL_BIN(obj, _real, _offset, _bitoffs, _bitsize);		\
-    if (_bitsize != 0) goto L_type_error;				\
-    if (thing_subtag(*binary_val(_real)) == REFC_BINARY_SUBTAG &&	\
-	_bitoffs == 0) {						\
-	b_size += _size;                                                \
-        if (b_size < _size) goto L_overflow_error;			\
-	in_clist = 0;							\
-        v_size++;                                                       \
-        /* If iov_len is smaller then Uint we split the binary into*/   \
-        /* multiple smaller (2GB) elements in the iolist.*/             \
-	v_size += _size / MAX_SYSIOVEC_IOVLEN;                          \
-        if (_size >= ERL_SMALL_IO_BIN_LIMIT) {				\
-            p_in_clist = 0;						\
-            p_v_size++;							\
-        } else {							\
-            p_c_size += _size;						\
-            if (!p_in_clist) {						\
-                p_in_clist = 1;						\
-                p_v_size++;						\
-            }								\
-        }								\
-    } else {								\
-	c_size += _size;						\
-        if (c_size < _size) goto L_overflow_error;			\
-	if (!in_clist) {						\
-	    in_clist = 1;						\
-	    v_size++;							\
-	}								\
-	p_c_size += _size;						\
-	if (!p_in_clist) {						\
-	    p_in_clist = 1;						\
-	    p_v_size++;							\
-	}								\
-    }									\
-} while (0)
-
-
-/* 
- * Returns 0 if successful and a non-zero value otherwise.
- *
- * Return values through pointers:
- *    *vsize      - SysIOVec size needed for a writev
- *    *csize      - Number of bytes not in binary (in the common binary)
- *    *pvsize     - SysIOVec size needed if packing small binaries
- *    *pcsize     - Number of bytes in the common binary if packing
- *    *total_size - Total size of iolist in bytes
- */
-
-static int 
-io_list_vec_len(Eterm obj, int* vsize, Uint* csize,
-		Uint* pvsize, Uint* pcsize,
-		ErlDrvSizeT* total_size)
-{
-    DECLARE_ESTACK(s);
-    Eterm* objp;
-    Uint v_size = 0;
-    Uint c_size = 0;
-    Uint b_size = 0;
-    Uint in_clist = 0;
-    Uint p_v_size = 0;
-    Uint p_c_size = 0;
-    Uint p_in_clist = 0;
-    Uint total;
-
-    goto L_jump_start;  /* avoid a push */
-
-    while (!ESTACK_ISEMPTY(s)) {
-	obj = ESTACK_POP(s);
-    L_jump_start:
-	if (is_list(obj)) {
-	L_iter_list:
-	    objp = list_val(obj);
-	    obj = CAR(objp);
-
-	    if (is_byte(obj)) {
-		c_size++;
-		if (c_size == 0) {
-		    goto L_overflow_error;
-		}
-		if (!in_clist) {
-		    in_clist = 1;
-		    v_size++;
-		}
-		p_c_size++;
-		if (!p_in_clist) {
-		    p_in_clist = 1;
-		    p_v_size++;
-		}
-	    }
-	    else if (is_binary(obj)) {
-		IO_LIST_VEC_COUNT(obj);
-	    }
-	    else if (is_list(obj)) {
-		ESTACK_PUSH(s, CDR(objp));
-		goto L_iter_list;   /* on head */
-	    }
-	    else if (!is_nil(obj)) {
-		goto L_type_error;
-	    }
-
-	    obj = CDR(objp);
-	    if (is_list(obj))
-		goto L_iter_list;   /* on tail */
-	    else if (is_binary(obj)) {  /* binary tail is OK */
-		IO_LIST_VEC_COUNT(obj);
-	    }
-	    else if (!is_nil(obj)) {
-		goto L_type_error;
-	    }
-	}
-	else if (is_binary(obj)) {
-	    IO_LIST_VEC_COUNT(obj);
-	}
-	else if (!is_nil(obj)) {
-	    goto L_type_error;
-	}
-    }
-
-    total = c_size + b_size;
-    if (total < c_size) {
-	goto L_overflow_error;
-    }
-    *total_size = (ErlDrvSizeT) total;
-
-    DESTROY_ESTACK(s);
-    *vsize = v_size;
-    *csize = c_size;
-    *pvsize = p_v_size;
-    *pcsize = p_c_size;
-    return 0;
-
- L_type_error:
- L_overflow_error:
-    DESTROY_ESTACK(s);
-    return 1;
-}
 
 typedef enum {
     ERTS_TRY_IMM_DRV_CALL_OK,
@@ -1802,8 +1474,7 @@ cleanup_scheduled_outputv(ErlIOVec *ev, ErlDrvBinary *cbinp)
     int i;
     /* Need to free all binaries */
     for (i = 1; i < ev->vsize; i++)
-	if (ev->binv[i])
-	    driver_free_binary(ev->binv[i]);
+        driver_free_binary(ev->binv[i]);
     if (cbinp)
 	driver_free_binary(cbinp);
 }
@@ -1972,15 +1643,14 @@ erts_port_output_async(Port *prt, Eterm from, Eterm list)
     size_t size;
     int task_flags;
     ErtsProc2PortSigCallback port_sig_callback;
-    ErlDrvBinary *cbin = NULL;
-    ErlIOVec *evp = NULL;
+    ErtsIOQBinary *cbin = NULL;
+    ErtsIOVec *evp = NULL;
     char *buf = NULL;
     ErtsPortTaskHandle *ns_pthp;
 
     if (drv->outputv) {
-        ErlIOVec ev;
 	SysIOVec* ivp;
-	ErlDrvBinary**  bvp;
+	ErtsIOQBinary**  bvp;
         int vsize;
 	Uint csize;
 	Uint pvsize;
@@ -1990,91 +1660,63 @@ erts_port_output_async(Port *prt, Eterm from, Eterm list)
         char *ptr;
         int i;
 
-        Eterm* bptr = NULL;
-        Uint offset;
+        if (erts_ioq_iodata_vec_len(list, &vsize, &csize, &pvsize, &pcsize,
+                                    &size, ERL_SMALL_IO_BIN_LIMIT))
+            goto bad_value;
 
-        if (is_binary(list)) {
-            /* We optimize for when we get a procbin without offset */
-            Eterm real_bin;
-            int bitoffs;
-            int bitsize;
-            ERTS_GET_REAL_BIN(list, real_bin, offset, bitoffs, bitsize);
-            bptr = binary_val(real_bin);
-            if (*bptr == HEADER_PROC_BIN && bitoffs == 0) {
-                size = binary_size(list);
-                vsize = 1;
-            } else
-                bptr = NULL;
+        /* To pack or not to pack (small binaries) ...? */
+        if (vsize >= SMALL_WRITE_VEC) {
+            /* Do pack */
+            vsize = pvsize + 1;
+            csize = pcsize;
+            blimit = ERL_SMALL_IO_BIN_LIMIT;
         }
-
-        if (!bptr) {
-            if (io_list_vec_len(list, &vsize, &csize, &pvsize, &pcsize, &size))
-                goto bad_value;
-
-            /* To pack or not to pack (small binaries) ...? */
-            if (vsize >= SMALL_WRITE_VEC) {
-                /* Do pack */
-                vsize = pvsize + 1;
-                csize = pcsize;
-                blimit = ERL_SMALL_IO_BIN_LIMIT;
-            }
-            cbin = driver_alloc_binary(csize);
+        if (csize) {
+            cbin = (ErtsIOQBinary *)driver_alloc_binary(csize);
             if (!cbin)
                 erts_alloc_enomem(ERTS_ALC_T_DRV_BINARY, ERTS_SIZEOF_Binary(csize));
         }
-
 
         iov_offset = ERTS_ALC_DATA_ALIGN_SIZE(sizeof(ErlIOVec));
 	binv_offset = iov_offset;
         binv_offset += ERTS_ALC_DATA_ALIGN_SIZE((vsize+1)*sizeof(SysIOVec));
         alloc_size = binv_offset;
-	alloc_size += (vsize+1)*sizeof(ErlDrvBinary *);
+	alloc_size += (vsize+1)*sizeof(ErtsIOQBinary *);
 
         sigdp = erts_port_task_alloc_p2p_sig_data_extra(alloc_size, (void**)&ptr);
 
-        evp = (ErlIOVec *) ptr;
-        ivp = evp->iov = (SysIOVec *) (ptr + iov_offset);
-        bvp = evp->binv = (ErlDrvBinary **) (ptr + binv_offset);
+        evp = (ErtsIOVec *) ptr;
+        ivp = evp->driver.iov = (SysIOVec *) (ptr + iov_offset);
+        bvp = evp->common.binv = (ErtsIOQBinary **) (ptr + binv_offset);
 
         ivp[0].iov_base = NULL;
 	ivp[0].iov_len = 0;
 	bvp[0] = NULL;
 
-        if (bptr) {
-            ProcBin* pb = (ProcBin *) bptr;
-
-            ivp[1].iov_base = pb->bytes+offset;
-            ivp[1].iov_len = size;
-            bvp[1] = Binary2ErlDrvBinary(pb->val);
-
-            evp->vsize = 1;
-        } else {
-
-            evp->vsize = io_list_to_vec(list, ivp+1, bvp+1, cbin, blimit);
-            if (evp->vsize < 0) {
-                if (evp != &ev)
-                    erts_free(ERTS_ALC_T_DRV_CMD_DATA, evp);
-                driver_free_binary(cbin);
-                goto bad_value;
-            }
+        evp->driver.vsize = erts_ioq_iodata_to_vec(list, ivp+1, bvp+1, cbin,
+                                                   blimit, 1);
+        if (evp->driver.vsize < 0) {
+            erts_free(ERTS_ALC_T_DRV_CMD_DATA, evp);
+            driver_free_binary(&cbin->driver);
+            goto bad_value;
         }
 #if 0
 	/* This assertion may say something useful, but it can
         be falsified during the emulator test suites. */
 	ASSERT(evp->vsize == vsize);
 #endif
-	evp->vsize++;
-	evp->size = size;  /* total size */
+	evp->driver.vsize++;
+	evp->driver.size = size;  /* total size */
 
         /* Need to increase refc on all binaries */
-        for (i = 1; i < evp->vsize; i++)
+        for (i = 1; i < evp->driver.vsize; i++)
             if (bvp[i])
-                driver_binary_inc_refc(bvp[i]);
+                driver_binary_inc_refc(&bvp[i]->driver);
 
 	sigdp->flags = ERTS_P2P_SIG_TYPE_OUTPUTV;
 	sigdp->u.outputv.from = from;
-	sigdp->u.outputv.evp = evp;
-	sigdp->u.outputv.cbinp = cbin;
+	sigdp->u.outputv.evp = &evp->driver;
+	sigdp->u.outputv.cbinp = &cbin->driver;
 	port_sig_callback = port_sig_outputv;
     } else {
         ErlDrvSizeT ERTS_DECLARE_DUMMY(r);
@@ -2115,7 +1757,7 @@ erts_port_output_async(Port *prt, Eterm from, Eterm list)
 
     if (res != ERTS_PORT_OP_SCHEDULED) {
 	if (drv->outputv)
-	    cleanup_scheduled_outputv(evp, cbin);
+	    cleanup_scheduled_outputv(&evp->driver, &cbin->driver);
 	else
 	    cleanup_scheduled_output(buf);
 	return 1;
@@ -2153,8 +1795,8 @@ erts_port_output(Process *c_p,
     erts_aint32_t sched_flags, busy_flgs, invalid_flags;
     int task_flags;
     ErtsProc2PortSigCallback port_sig_callback;
-    ErlDrvBinary *cbin = NULL;
-    ErlIOVec *evp = NULL;
+    ErtsIOQBinary *cbin = NULL;
+    ErtsIOVec *evp = NULL;
     char *buf = NULL;
     int force_immediate_call = (flags & ERTS_PORT_SIG_FLG_FORCE_IMM_CALL);
     int async_nosuspend;
@@ -2200,11 +1842,11 @@ erts_port_output(Process *c_p,
     }
 #endif
     if (drv->outputv) {
-	ErlIOVec ev;
+	ErtsIOVec ev;
 	SysIOVec iv[SMALL_WRITE_VEC];
-	ErlDrvBinary* bv[SMALL_WRITE_VEC];
+	ErtsIOQBinary* bv[SMALL_WRITE_VEC];
 	SysIOVec* ivp;
-	ErlDrvBinary**  bvp;
+	ErtsIOQBinary**  bvp;
 	int vsize;
 	Uint csize;
 	Uint pvsize;
@@ -2212,18 +1854,19 @@ erts_port_output(Process *c_p,
 	Uint blimit;
 	size_t iov_offset, binv_offset, alloc_size;
 
-	if (io_list_vec_len(list, &vsize, &csize, &pvsize, &pcsize, &size))
+	if (erts_ioq_iodata_vec_len(list, &vsize, &csize, &pvsize, &pcsize,
+                                    &size, ERL_SMALL_IO_BIN_LIMIT))
 	    goto bad_value;
 
 	iov_offset = ERTS_ALC_DATA_ALIGN_SIZE(sizeof(ErlIOVec));
 	binv_offset = iov_offset;
 	binv_offset += ERTS_ALC_DATA_ALIGN_SIZE((vsize+1)*sizeof(SysIOVec));
 	alloc_size = binv_offset;
-	alloc_size += (vsize+1)*sizeof(ErlDrvBinary *);
+	alloc_size += (vsize+1)*sizeof(ErtsIOQBinary *);
 
 	if (try_call && vsize < SMALL_WRITE_VEC) {
-	    ivp = ev.iov = iv;
-	    bvp = ev.binv = bv;
+	    ivp = ev.common.iov = iv;
+	    bvp = ev.common.binv = bv;
 	    evp = &ev;
 	}
 	else {
@@ -2234,9 +1877,9 @@ erts_port_output(Process *c_p,
                 sigdp = erts_port_task_alloc_p2p_sig_data_extra(
                     alloc_size, (void**)&ptr);
             }
-	    evp = (ErlIOVec *) ptr;
-	    ivp = evp->iov = (SysIOVec *) (ptr + iov_offset);
-	    bvp = evp->binv = (ErlDrvBinary **) (ptr + binv_offset);
+	    evp = (ErtsIOVec *) ptr;
+	    ivp = evp->driver.iov = (SysIOVec *) (ptr + iov_offset);
+	    bvp = evp->common.binv = (ErtsIOQBinary **) (ptr + binv_offset);
 	}
 
 	/* To pack or not to pack (small binaries) ...? */
@@ -2252,23 +1895,26 @@ erts_port_output(Process *c_p,
 	}
 	/* Use vsize and csize from now on */
 
-	cbin = driver_alloc_binary(csize);
-	if (!cbin)
-	    erts_alloc_enomem(ERTS_ALC_T_DRV_BINARY, ERTS_SIZEOF_Binary(csize));
+        if (csize) {
+            cbin = (ErtsIOQBinary *)driver_alloc_binary(csize);
+            if (!cbin)
+                erts_alloc_enomem(ERTS_ALC_T_DRV_BINARY, ERTS_SIZEOF_Binary(csize));
+        }
 
 	/* Element 0 is for driver usage to add header block */
 	ivp[0].iov_base = NULL;
 	ivp[0].iov_len = 0;
 	bvp[0] = NULL;
-	evp->vsize = io_list_to_vec(list, ivp+1, bvp+1, cbin, blimit);
-	if (evp->vsize < 0) {
+	evp->driver.vsize = erts_ioq_iodata_to_vec(list, ivp+1, bvp+1,
+                                                   cbin, blimit, 1);
+	if (evp->driver.vsize < 0) {
             if (evp != &ev) {
                 if (try_call)
                     erts_free(ERTS_ALC_T_TMP, evp);
                 else
                     erts_port_task_free_p2p_sig_data(sigdp);
             }
-	    driver_free_binary(cbin);
+            driver_free_binary(&cbin->driver);
 	    goto bad_value;
 	}
 #if 0
@@ -2276,19 +1922,19 @@ erts_port_output(Process *c_p,
 	   be falsified during the emulator test suites. */
 	ASSERT(evp->vsize == vsize);
 #endif
-	evp->vsize++;
-	evp->size = size;  /* total size */
+	evp->driver.vsize++;
+	evp->driver.size = size;  /* total size */
 
 	if (!try_call) {
 	    int i;
 	    /* Need to increase refc on all binaries */
-	    for (i = 1; i < evp->vsize; i++)
-		if (bvp[i])
-		    driver_binary_inc_refc(bvp[i]);
+	    for (i = 1; i < evp->driver.vsize; i++)
+                if (bvp[i])
+                    driver_binary_inc_refc(&bvp[i]->driver);
 	}
 	else {
 	    int i;
-	    ErlIOVec *new_evp;
+	    ErtsIOVec *new_evp;
 	    ErtsTryImmDrvCallResult try_call_res;
 	    ErtsTryImmDrvCallState try_call_state
 		= ERTS_INIT_TRY_IMM_DRV_CALL_STATE(
@@ -2311,14 +1957,14 @@ erts_port_output(Process *c_p,
 				    from,
 				    prt,
 				    drv,
-				    evp);
+				    &evp->driver);
 		if (force_immediate_call)
 		    finalize_force_imm_drv_call(&try_call_state);
 		else
 		    finalize_imm_drv_call(&try_call_state);
 		/* Fall through... */
 	    case ERTS_TRY_IMM_DRV_CALL_INVALID_PORT:
-		driver_free_binary(cbin);
+		driver_free_binary(&cbin->driver);
 		if (evp != &ev) {
                     ASSERT(!sigdp);
 		    erts_free(ERTS_ALC_T_TMP, evp);
@@ -2332,7 +1978,7 @@ erts_port_output(Process *c_p,
 		sched_flags = try_call_state.sched_flags;
 		if (async_nosuspend
 		    && (sched_flags & (busy_flgs|ERTS_PTS_FLG_EXIT))) {
-		    driver_free_binary(cbin);
+		    driver_free_binary(&cbin->driver);
                     if (evp != &ev) {
                         ASSERT(!sigdp);
 			erts_free(ERTS_ALC_T_TMP, evp);
@@ -2347,9 +1993,9 @@ erts_port_output(Process *c_p,
 	    }
 
 	    /* Need to increase refc on all binaries */
-	    for (i = 1; i < evp->vsize; i++)
+	    for (i = 1; i < evp->driver.vsize; i++)
 		if (bvp[i])
-		    driver_binary_inc_refc(bvp[i]);
+		    driver_binary_inc_refc(&bvp[i]->driver);
 
             /* The port task and iovec is allocated in the
                same structure as an optimization. This
@@ -2362,18 +2008,18 @@ erts_port_output(Process *c_p,
 	    if (evp != &ev) {
                 /* Copy from TMP alloc to port task */
 		sys_memcpy((void *) new_evp, (void *) evp, alloc_size);
-		new_evp->iov = (SysIOVec *) (((char *) new_evp)
-					     + iov_offset);
-		bvp = new_evp->binv = (ErlDrvBinary **) (((char *) new_evp)
-							 + binv_offset);
+		new_evp->driver.iov = (SysIOVec *) (((char *) new_evp)
+                                                    + iov_offset);
+		bvp = new_evp->common.binv = (ErtsIOQBinary **) (((char *) new_evp)
+                                                                 + binv_offset);
 
 #ifdef DEBUG
-		ASSERT(new_evp->vsize == evp->vsize);
-		ASSERT(new_evp->size == evp->size);
-		for (i = 0; i < evp->vsize; i++) {
-		    ASSERT(new_evp->iov[i].iov_len == evp->iov[i].iov_len);
-		    ASSERT(new_evp->iov[i].iov_base == evp->iov[i].iov_base);
-		    ASSERT(new_evp->binv[i] == evp->binv[i]);
+		ASSERT(new_evp->driver.vsize == evp->driver.vsize);
+		ASSERT(new_evp->driver.size == evp->driver.size);
+		for (i = 0; i < evp->driver.vsize; i++) {
+		    ASSERT(new_evp->driver.iov[i].iov_len == evp->driver.iov[i].iov_len);
+		    ASSERT(new_evp->driver.iov[i].iov_base == evp->driver.iov[i].iov_base);
+		    ASSERT(new_evp->driver.binv[i] == evp->driver.binv[i]);
 		}
 #endif
 
@@ -2382,24 +2028,24 @@ erts_port_output(Process *c_p,
 	    else { /* from stack allocated structure; offsets may differ */
 
 		sys_memcpy((void *) new_evp, (void *) evp, sizeof(ErlIOVec));
-		new_evp->iov = (SysIOVec *) (((char *) new_evp)
-					     + iov_offset);
-		sys_memcpy((void *) new_evp->iov,
-			   (void *) evp->iov,
-			   evp->vsize * sizeof(SysIOVec));
-		new_evp->binv = (ErlDrvBinary **) (((char *) new_evp)
-						   + binv_offset);
-		sys_memcpy((void *) new_evp->binv,
-			   (void *) evp->binv,
-			   evp->vsize * sizeof(ErlDrvBinary *));
+		new_evp->driver.iov = (SysIOVec *) (((char *) new_evp)
+                                                    + iov_offset);
+		sys_memcpy((void *) new_evp->driver.iov,
+			   (void *) evp->driver.iov,
+			   evp->driver.vsize * sizeof(SysIOVec));
+		new_evp->common.binv = (ErtsIOQBinary **) (((char *) new_evp)
+                                                           + binv_offset);
+		sys_memcpy((void *) new_evp->common.binv,
+			   (void *) evp->common.binv,
+			   evp->driver.vsize * sizeof(ErtsIOQBinary *));
 
 #ifdef DEBUG
-		ASSERT(new_evp->vsize == evp->vsize);
-		ASSERT(new_evp->size == evp->size);
-		for (i = 0; i < evp->vsize; i++) {
-		    ASSERT(new_evp->iov[i].iov_len == evp->iov[i].iov_len);
-		    ASSERT(new_evp->iov[i].iov_base == evp->iov[i].iov_base);
-		    ASSERT(new_evp->binv[i] == evp->binv[i]);
+		ASSERT(new_evp->driver.vsize == evp->driver.vsize);
+		ASSERT(new_evp->driver.size == evp->driver.size);
+		for (i = 0; i < evp->driver.vsize; i++) {
+		    ASSERT(new_evp->driver.iov[i].iov_len == evp->driver.iov[i].iov_len);
+		    ASSERT(new_evp->driver.iov[i].iov_base == evp->driver.iov[i].iov_base);
+		    ASSERT(new_evp->driver.binv[i] == evp->driver.binv[i]);
 		}
 #endif
 
@@ -2410,8 +2056,8 @@ erts_port_output(Process *c_p,
 
 	sigdp->flags = ERTS_P2P_SIG_TYPE_OUTPUTV;
 	sigdp->u.outputv.from = from;
-	sigdp->u.outputv.evp = evp;
-	sigdp->u.outputv.cbinp = cbin;
+	sigdp->u.outputv.evp = &evp->driver;
+	sigdp->u.outputv.cbinp = &cbin->driver;
 	port_sig_callback = port_sig_outputv;
     }
     else {
@@ -2553,7 +2199,7 @@ erts_port_output(Process *c_p,
 
     if (res != ERTS_PORT_OP_SCHEDULED) {
 	if (drv->outputv)
-	    cleanup_scheduled_outputv(evp, cbin);
+	    cleanup_scheduled_outputv(&evp->driver, &cbin->driver);
 	else
 	    cleanup_scheduled_output(buf);
 	return res;
@@ -7160,227 +6806,19 @@ driver_pdl_dec_refc(ErlDrvPDL pdl)
     return refc;
 }
 
-/* expand queue to hold n elements in tail or head */
-static int expandq(ErlIOQueue* q, int n, int tail)
-/* tail: 0 if make room in head, make room in tail otherwise */
-{
-    int h_sz;  /* room before header */
-    int t_sz;  /* room after tail */
-    int q_sz;  /* occupied */
-    int nvsz;
-    SysIOVec* niov;
-    ErlDrvBinary** nbinv;
-
-    h_sz = q->v_head - q->v_start;
-    t_sz = q->v_end -  q->v_tail;
-    q_sz = q->v_tail - q->v_head;
-
-    if (tail && (n <= t_sz)) /* do we need to expand tail? */
-	return 0;
-    else if (!tail && (n <= h_sz))  /* do we need to expand head? */
-	return 0;
-    else if (n > (h_sz + t_sz)) { /* need to allocate */
-	/* we may get little extra but it ok */
-	nvsz = (q->v_end - q->v_start) + n; 
-
-	niov = erts_alloc_fnf(ERTS_ALC_T_IOQ, nvsz * sizeof(SysIOVec));
-	if (!niov)
-	    return -1;
-	nbinv = erts_alloc_fnf(ERTS_ALC_T_IOQ, nvsz * sizeof(ErlDrvBinary**));
-	if (!nbinv) {
-	    erts_free(ERTS_ALC_T_IOQ, (void *) niov);
-	    return -1;
-	}
-	if (tail) {
-	    sys_memcpy(niov, q->v_head, q_sz*sizeof(SysIOVec));
-	    if (q->v_start != q->v_small)
-		erts_free(ERTS_ALC_T_IOQ, (void *) q->v_start);
-	    q->v_start = niov;
-	    q->v_end = niov + nvsz;
-	    q->v_head = q->v_start;
-	    q->v_tail = q->v_head + q_sz;
-
-	    sys_memcpy(nbinv, q->b_head, q_sz*sizeof(ErlDrvBinary*));
-	    if (q->b_start != q->b_small)
-		erts_free(ERTS_ALC_T_IOQ, (void *) q->b_start);
-	    q->b_start = nbinv;
-	    q->b_end = nbinv + nvsz;
-	    q->b_head = q->b_start;
-	    q->b_tail = q->b_head + q_sz;	
-	}
-	else {
-	    sys_memcpy(niov+nvsz-q_sz, q->v_head, q_sz*sizeof(SysIOVec));
-	    if (q->v_start != q->v_small)
-		erts_free(ERTS_ALC_T_IOQ, (void *) q->v_start);
-	    q->v_start = niov;
-	    q->v_end = niov + nvsz;
-	    q->v_tail = q->v_end;
-	    q->v_head = q->v_tail - q_sz;
-	    
-	    sys_memcpy(nbinv+nvsz-q_sz, q->b_head, q_sz*sizeof(ErlDrvBinary*));
-	    if (q->b_start != q->b_small)
-		erts_free(ERTS_ALC_T_IOQ, (void *) q->b_start);
-	    q->b_start = nbinv;
-	    q->b_end = nbinv + nvsz;
-	    q->b_tail = q->b_end;
-	    q->b_head = q->b_tail - q_sz;
-	}
-    }
-    else if (tail) {  /* move to beginning to make room in tail */
-	sys_memmove(q->v_start, q->v_head, q_sz*sizeof(SysIOVec));
-	q->v_head = q->v_start;
-	q->v_tail = q->v_head + q_sz;
-	sys_memmove(q->b_start, q->b_head, q_sz*sizeof(ErlDrvBinary*));
-	q->b_head = q->b_start;
-	q->b_tail = q->b_head + q_sz;
-    }
-    else {   /* move to end to make room */
-	sys_memmove(q->v_end-q_sz, q->v_head, q_sz*sizeof(SysIOVec));
-	q->v_tail = q->v_end;
-	q->v_head = q->v_tail-q_sz;
-	sys_memmove(q->b_end-q_sz, q->b_head, q_sz*sizeof(ErlDrvBinary*));
-	q->b_tail = q->b_end;
-	q->b_head = q->b_tail-q_sz;
-    }
-
-    return 0;
-}
-
-
-
 /* Put elements from vec at q tail */
 int driver_enqv(ErlDrvPort ix, ErlIOVec* vec, ErlDrvSizeT skip)
 {
-    int n;
-    size_t len;
-    ErlDrvSizeT size;
-    SysIOVec* iov;
-    ErlDrvBinary** binv;
-    ErlDrvBinary*  b;
-    ErlIOQueue* q = drvport2ioq(ix);
-
-    if (q == NULL)
-	return -1;
-
-    ASSERT(vec->size >= skip);       /* debug only */
-    if (vec->size <= skip)
-	return 0;
-    size = vec->size - skip;
-
-    iov = vec->iov;
-    binv = vec->binv;
-    n = vec->vsize;
-
-    /* we use do here to strip iov_len=0 from beginning */
-    do {
-	len = iov->iov_len;
-	if (len <= skip) {
-	    skip -= len;
-	    iov++;
-	    binv++;
-	    n--;
-	}
-	else {
-	    iov->iov_base = ((char *)(iov->iov_base)) + skip;
-	    iov->iov_len -= skip;
-	    skip = 0;
-	}
-    } while(skip > 0);
-
-    if (q->v_tail + n >= q->v_end)
-	expandq(q, n, 1);
-
-    /* Queue and reference all binaries (remove zero length items) */
-    while(n--) {
-	if ((len = iov->iov_len) > 0) {
-	    if ((b = *binv) == NULL) { /* speical case create binary ! */
-		b = driver_alloc_binary(len);
-		sys_memcpy(b->orig_bytes, iov->iov_base, len);
-		*q->b_tail++ = b;
-		q->v_tail->iov_len = len;
-		q->v_tail->iov_base = b->orig_bytes;
-		q->v_tail++;
-	    }
-	    else {
-		driver_binary_inc_refc(b);
-		*q->b_tail++ = b;
-		*q->v_tail++ = *iov;
-	    }
-	}
-	iov++;
-	binv++;
-    }
-    q->size += size;      /* update total size in queue */
-    return 0;
+    ASSERT(vec->size >= skip);
+    return erts_ioq_enqv(drvport2ioq(ix), (ErtsIOVec*)vec, skip);
 }
 
 /* Put elements from vec at q head */
 int driver_pushqv(ErlDrvPort ix, ErlIOVec* vec, ErlDrvSizeT skip)
 {
-    int n;
-    size_t len;
-    ErlDrvSizeT size;
-    SysIOVec* iov;
-    ErlDrvBinary** binv;
-    ErlDrvBinary* b;
-    ErlIOQueue* q = drvport2ioq(ix);
-
-    if (q == NULL)
-	return -1;
-
-    if (vec->size <= skip)
-	return 0;
-    size = vec->size - skip;
-
-    iov = vec->iov;
-    binv = vec->binv;
-    n = vec->vsize;
-
-    /* we use do here to strip iov_len=0 from beginning */
-    do {
-	len = iov->iov_len;
-	if (len <= skip) {
-	    skip -= len;
-	    iov++;
-	    binv++;
-	    n--;
-	}
-	else {
-	    iov->iov_base = ((char *)(iov->iov_base)) + skip;
-	    iov->iov_len -= skip;
-	    skip = 0;
-	}
-    } while(skip > 0);
-
-    if (q->v_head - n < q->v_start)
-	expandq(q, n, 0);
-
-    /* Queue and reference all binaries (remove zero length items) */
-    iov += (n-1);  /* move to end */
-    binv += (n-1); /* move to end */
-    while(n--) {
-	if ((len = iov->iov_len) > 0) {
-	    if ((b = *binv) == NULL) { /* speical case create binary ! */
-		b = driver_alloc_binary(len);
-		sys_memcpy(b->orig_bytes, iov->iov_base, len);
-		*--q->b_head = b;
-		q->v_head--;
-		q->v_head->iov_len = len;
-		q->v_head->iov_base = b->orig_bytes;
-	    }
-	    else {
-		driver_binary_inc_refc(b);
-		*--q->b_head = b;
-		*--q->v_head = *iov;
-	    }
-	}
-	iov--;
-	binv--;
-    }
-    q->size += size;      /* update total size in queue */
-    return 0;
+    ASSERT(vec->size >= skip);
+    return erts_ioq_pushqv(drvport2ioq(ix), (ErtsIOVec*)vec, skip);
 }
-
 
 /*
 ** Remove size bytes from queue head
@@ -7388,79 +6826,31 @@ int driver_pushqv(ErlDrvPort ix, ErlIOVec* vec, ErlDrvSizeT skip)
 */
 ErlDrvSizeT driver_deq(ErlDrvPort ix, ErlDrvSizeT size)
 {
-    ErlIOQueue* q = drvport2ioq(ix);
-    ErlDrvSizeT len;
-
-    if ((q == NULL) || (q->size < size))
-	return -1;
-    q->size -= size;
-    while (size > 0) {
-	ASSERT(q->v_head != q->v_tail);
-
-	len = q->v_head->iov_len;
-	if (len <= size) {
-	    size -= len;
-	    driver_free_binary(*q->b_head);
-	    *q->b_head++ = NULL;
-	    q->v_head++;
-	}
-	else {
-	    q->v_head->iov_base = ((char *)(q->v_head->iov_base)) + size;
-	    q->v_head->iov_len -= size;
-	    size = 0;
-	}
-    }
-
-    /* restart pointers (optimised for enq) */
-    if (q->v_head == q->v_tail) {
-	q->v_head = q->v_tail = q->v_start;
-	q->b_head = q->b_tail = q->b_start;
-    }
-    return q->size;
+    ErlPortIOQueue *q = drvport2ioq(ix);
+    if (erts_ioq_deq(q, size) == -1)
+        return -1;
+    return erts_ioq_size(q);
 }
 
 
-ErlDrvSizeT driver_peekqv(ErlDrvPort ix, ErlIOVec *ev) {
-    ErlIOQueue *q = drvport2ioq(ix);
-    ASSERT(ev);
-
-    if (! q) {
-	return (ErlDrvSizeT) -1;
-    } else {
-	if ((ev->vsize = q->v_tail - q->v_head) == 0) {
-	    ev->size = 0;
-	    ev->iov = NULL;
-	    ev->binv = NULL;
-	} else {
-	    ev->size = q->size;
-	    ev->iov = q->v_head;
-	    ev->binv = q->b_head;
-	}
-	return q->size;
-    }
+ErlDrvSizeT driver_peekqv(ErlDrvPort ix, ErlIOVec *ev)
+{
+    return erts_ioq_peekqv(drvport2ioq(ix), (ErtsIOVec*)ev);
 }
 
 SysIOVec* driver_peekq(ErlDrvPort ix, int* vlenp)  /* length of io-vector */
 {
-    ErlIOQueue* q = drvport2ioq(ix);
-
-    if (q == NULL) {
-	*vlenp = -1;
-	return NULL;
-    }
-    if ((*vlenp = (q->v_tail - q->v_head)) == 0)
-	return NULL;
-    return q->v_head;
+    return erts_ioq_peekq(drvport2ioq(ix), vlenp);
 }
 
 
 ErlDrvSizeT driver_sizeq(ErlDrvPort ix)
 {
-    ErlIOQueue* q = drvport2ioq(ix);
+    ErlPortIOQueue *q = drvport2ioq(ix);
 
     if (q == NULL)
-	return (size_t) -1;
-    return q->size;
+	return (ErlDrvSizeT) -1;
+    return erts_ioq_size(q);
 }
 
 

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -51,6 +51,7 @@
 #include "erl_ptab.h"
 #include "erl_check_io.h"
 #include "erl_bif_unique.h"
+#include "erl_io_queue.h"
 #define ERTS_WANT_TIMER_WHEEL_API
 #include "erl_time.h"
 #ifdef HIPE

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -2717,12 +2717,16 @@ nif_ioq_run([{Action, Name, N}|T], State)
   when Action =:= enq; Action =:= enqv;
        Action =:= enqb; Action =:= enqbraw ->
     nif_ioq_run([{Action, Name, N, 0}|T], State);
-nif_ioq_run([{Action, Name, N, Skip} = H|T], State)
+nif_ioq_run([{Action, Name, N, Skip}|T], State)
   when Action =:= enq; Action =:= enqv;
        Action =:= enqb; Action =:= enqbraw ->
+
+
     #{ q := IOQ, b := B } = Q = maps:get(Name, State),
     true = ioq_nif(size, IOQ) == iolist_size(B),
 
+    %% Sanitize the log output a bit so that it doesn't become too large.
+    H = {Action, Name, try iolist_size(N) of Sz -> Sz catch _:_ -> N end, Skip},
     ct:log("~p", [H]),
 
     Data = nif_ioq_payload(N),

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -170,6 +170,12 @@ static ErlNifResourceTypeInit frenzy_rt_init = {
     frenzy_resource_down
 };
 
+static ErlNifResourceType* ioq_resource_type;
+static void ioq_resource_dtor(ErlNifEnv* env, void* obj);
+struct ioq_resource {
+    ErlNifIOQueue *q;
+};
+
 static int get_pointer(ErlNifEnv* env, ERL_NIF_TERM term, void** pp)
 {
     ErlNifBinary bin;
@@ -223,6 +229,9 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 						      &frenzy_rt_init,
 						      ERL_NIF_RT_CREATE, NULL);
 
+    ioq_resource_type = enif_open_resource_type(env,NULL,"ioq",
+                                                ioq_resource_dtor,
+                                                ERL_NIF_RT_CREATE, NULL);
     atom_false = enif_make_atom(env,"false");
     atom_true = enif_make_atom(env,"true");
     atom_self = enif_make_atom(env,"self");
@@ -2125,7 +2134,6 @@ static ERL_NIF_TERM format_term(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
     return enif_make_binary(env,&obin);
 }
 
-
 static int get_fd(ErlNifEnv* env, ERL_NIF_TERM term, struct fd_resource** rsrc)
 {
     if (!enif_get_resource(env, term, fd_resource_type, (void**)rsrc)) {
@@ -2851,7 +2859,232 @@ static void frenzy_resource_down(ErlNifEnv* env, void* obj, ErlNifPid* pid,
     abort();
 }
 
+/*********** testing ioq ************/
 
+static void ioq_resource_dtor(ErlNifEnv* env, void* obj) {
+
+}
+
+#ifndef __WIN32__
+static int writeiolist(ErlNifEnv *env, ERL_NIF_TERM term, ErlNifIOQueue *q, int fd) {
+    ErlNifIOVec vec, *iovec = &vec;
+    SysIOVec *sysiovec;
+    int iovcnt, n;
+    size_t skipbytes = 0;
+    int myerrno;
+
+    if (enif_ioq_size(q) == 0) {
+        /* If I/O queue is empty we just inspect the iolist. */
+        if (!enif_inspect_iolist_as_iovec(env, term, &iovec))
+            return -2; /* invalid iolist */
+        sysiovec = iovec->iov;
+        iovcnt = iovec->iovcnt;
+    } else {
+        /* If I/O contains data we enqueue the iolist and then
+           peek the data to write out of the queue. */
+        if (!enif_ioq_enq(env, q, term, 0))
+            return -2; /* invalid iolist */
+        sysiovec = enif_ioq_peek(q, &iovcnt);
+    }
+
+    /* Attempt to write the data */
+    n = writev(fd, iovec->iov, iovec->iovcnt);
+    myerrno = errno;
+
+    if (enif_ioq_size(q) == 0) {
+        /* If the I/O queue was initially empty we enqueue any
+           remaining data into the queue for writing later. */
+        if (n >= 0) {
+            if (n < iovec->size)
+                enif_ioq_enqv(q, iovec, n);
+        }
+    } else {
+        /* Dequeue any data that was written from the queue. */
+        if (n > 0)
+            enif_ioq_deq(q, n, NULL);
+    }
+
+    /* return n, which is either number of bytes written or -1 if
+       some error happened */
+    errno = myerrno;
+    return n;
+}
+#endif
+
+static ERL_NIF_TERM ioq(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    struct ioq_resource *ioq;
+    ERL_NIF_TERM ret;
+    if (enif_is_identical(argv[0], enif_make_atom(env, "create"))) {
+        ErlNifIOQueue *q = enif_ioq_create(ERL_NIF_IOQ_NORMAL);
+        ioq = (struct ioq_resource *)enif_alloc_resource(ioq_resource_type,
+                                                         sizeof(*ioq));
+        ioq->q = q;
+        ret = enif_make_resource(env, ioq);
+        enif_release_resource(ioq);
+        return ret;
+    } else if (enif_is_identical(argv[0], enif_make_atom(env, "inspect"))) {
+        ErlNifIOVec vec, *iovec = NULL;
+        int i, iovcnt;
+        ERL_NIF_TERM *elems;
+        ErlNifEnv *myenv = NULL;
+
+        if (enif_is_identical(argv[2], enif_make_atom(env, "use_stack")))
+            iovec = &vec;
+        if (enif_is_identical(argv[3], enif_make_atom(env, "use_env")))
+            myenv = env;
+        if (!enif_inspect_iolist_as_iovec(myenv, argv[1], &iovec))
+            return enif_make_badarg(env);
+
+        iovcnt = iovec->iovcnt;
+        elems = enif_alloc(sizeof(ERL_NIF_TERM) * iovcnt);
+
+        for (i = 0; i < iovcnt; i++) {
+            ErlNifBinary bin;
+            if (!enif_alloc_binary(iovec->iov[i].iov_len, &bin)) {
+                enif_free_iovec(iovec);
+                enif_free(elems);
+                return enif_make_badarg(env);
+            }
+            memcpy(bin.data, iovec->iov[i].iov_base, iovec->iov[i].iov_len);
+            elems[i] = enif_make_binary(env, &bin);
+        }
+        if (!myenv)
+            enif_free_iovec(iovec);
+        return enif_make_list_from_array(env, elems, iovcnt);
+    } else {
+        unsigned skip;
+        if (!enif_get_resource(env, argv[1], ioq_resource_type, (void**)&ioq)
+            || !ioq->q)
+            return enif_make_badarg(env);
+
+        if (enif_is_identical(argv[0], enif_make_atom(env, "example"))) {
+#ifndef __WIN32__
+            int fd[2], res = 0, cnt = 0;
+            char buff[255];
+            pipe(fd);
+            fcntl(fd[0], F_SETFL, fcntl(fd[0], F_GETFL) | O_NONBLOCK);
+            fcntl(fd[1], F_SETFL, fcntl(fd[1], F_GETFL) | O_NONBLOCK);
+
+            /* Write until pipe buffer is full */
+            do {
+                cnt += res;
+                res = writeiolist(env, argv[2], ioq->q, fd[1]);
+            } while (res > 0);
+
+            /* Put some more data into the I/O queue */
+            writeiolist(env, argv[2], ioq->q, fd[2]);
+
+            res = 0;
+            do {
+                cnt -= res;
+                res = read(fd[0], buff, sizeof(buff));
+            } while (res > 0);
+
+            /* Write remaining data */
+            res = 0;
+            do {
+                cnt += res;
+                res = writeiolist(env, enif_make_list(env, 0), ioq->q, fd[1]);
+            } while (res > 0);
+
+            /* Read what is left */
+            res = 0;
+            do {
+                cnt -= res;
+                res = read(fd[0], buff, sizeof(buff));
+            } while (res > 0);
+
+            close(fd[0]);
+            close(fd[1]);
+
+            /* Check that we read as much as we wrote */
+            if (cnt == 0 && enif_ioq_size(ioq->q) == 0)
+                return enif_make_atom(env, "true");
+            return enif_make_int(env, cnt);
+#else
+            return enif_make_atom(env, "true");
+#endif
+        }
+        if (enif_is_identical(argv[0], enif_make_atom(env, "destroy"))) {
+            enif_ioq_destoy(ioq->q);
+            ioq->q = NULL;
+            return enif_make_atom(env, "false");
+        } else if (enif_is_identical(argv[0], enif_make_atom(env, "enq"))) {
+            if (!enif_get_uint(env, argv[3], &skip))
+                return enif_make_badarg(env);
+
+            if (!enif_ioq_enq(env, ioq->q, argv[2], skip))
+                return enif_make_badarg(env);
+
+            return enif_make_atom(env, "true");
+        } else if (enif_is_identical(argv[0], enif_make_atom(env, "enqv"))) {
+            ErlNifIOVec vec, *iovec = &vec;
+            if (!enif_get_uint(env, argv[3], &skip) ||
+                !enif_inspect_iolist_as_iovec(env, argv[2], &iovec))
+                return enif_make_badarg(env);
+
+            if (!enif_ioq_enqv(ioq->q, iovec, skip))
+                return enif_make_badarg(env);
+
+            return enif_make_atom(env, "true");
+        } else if (enif_is_identical(argv[0], enif_make_atom(env, "enqb"))) {
+            ErlNifBinary bin;
+            if (!enif_get_uint(env, argv[3], &skip) ||
+                !enif_inspect_binary(env, argv[2], &bin))
+                return enif_make_badarg(env);
+
+            if (!enif_ioq_enq_binary(ioq->q, &bin, skip))
+                return enif_make_badarg(env);
+
+            return enif_make_atom(env, "true");
+        } else if (enif_is_identical(argv[0], enif_make_atom(env, "enqbraw"))) {
+            ErlNifBinary bin;
+            ErlNifBinary localbin;
+            if (!enif_get_uint(env, argv[3], &skip) ||
+                !enif_inspect_binary(env, argv[2], &bin) ||
+                !enif_alloc_binary(bin.size, &localbin))
+                return enif_make_badarg(env);
+
+            memcpy(localbin.data, bin.data, bin.size);
+            if (!enif_ioq_enq_binary(ioq->q, &localbin, skip))
+                return enif_make_badarg(env);
+
+            return enif_make_atom(env, "true");
+        } else if (enif_is_identical(argv[0], enif_make_atom(env, "peek"))) {
+            int iovlen, num, i, off = 0;
+            SysIOVec *iov = enif_ioq_peek(ioq->q, &iovlen);
+            ErlNifBinary bin;
+
+            if (!enif_get_int(env, argv[2], &num) || !enif_alloc_binary(num, &bin))
+                return enif_make_badarg(env);
+
+            for (i = 0; i < iovlen && num > 0; i++) {
+                int to_copy = num < iov[i].iov_len ? num : iov[i].iov_len;
+                memcpy(bin.data + off, iov[i].iov_base, to_copy);
+                num -= to_copy;
+                off += to_copy;
+            }
+
+            return enif_make_binary(env, &bin);
+        } else if (enif_is_identical(argv[0], enif_make_atom(env, "deq"))) {
+            int num;
+            ErlNifUInt64 sz;
+            if (!enif_get_int(env, argv[2], &num))
+                return enif_make_badarg(env);
+
+            if (!enif_ioq_deq(ioq->q, num, &sz))
+                return enif_make_badarg(env);
+
+            return enif_make_uint64(env, sz);
+        } else if (enif_is_identical(argv[0], enif_make_atom(env, "size"))) {
+            ErlNifUInt64 size = enif_ioq_size(ioq->q);
+            return enif_make_uint64(env, size);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
 
 static ErlNifFunc nif_funcs[] =
 {
@@ -2942,7 +3175,11 @@ static ErlNifFunc nif_funcs[] =
     {"monitor_process_nif", 4, monitor_process_nif},
     {"demonitor_process_nif", 2, demonitor_process_nif},
     {"compare_monitors_nif", 2, compare_monitors_nif},
-    {"monitor_frenzy_nif", 4, monitor_frenzy_nif}
+    {"monitor_frenzy_nif", 4, monitor_frenzy_nif},
+    {"ioq_nif", 1, ioq},
+    {"ioq_nif", 2, ioq},
+    {"ioq_nif", 3, ioq},
+    {"ioq_nif", 4, ioq}
 };
 
 ERL_NIF_INIT(nif_SUITE,nif_funcs,load,NULL,upgrade,unload)

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -3069,14 +3069,17 @@ static ERL_NIF_TERM ioq(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
             return enif_make_binary(env, &bin);
         } else if (enif_is_identical(argv[0], enif_make_atom(env, "deq"))) {
             int num;
-            ErlNifUInt64 sz;
+            size_t sz;
+            ErlNifUInt64 sz64;
             if (!enif_get_int(env, argv[2], &num))
                 return enif_make_badarg(env);
 
             if (!enif_ioq_deq(ioq->q, num, &sz))
                 return enif_make_badarg(env);
 
-            return enif_make_uint64(env, sz);
+            sz64 = sz;
+
+            return enif_make_uint64(env, sz64);
         } else if (enif_is_identical(argv[0], enif_make_atom(env, "size"))) {
             ErlNifUInt64 size = enif_ioq_size(ioq->q);
             return enif_make_uint64(env, size);


### PR DESCRIPTION
Add functions to the Erlang nif API for easily working with I/O vectors as used by the unix system call writev.

Added functions:
  * enif_ioq_create()
  * enif_ioq_destroy()
  * enif_ioq_enq()
 * enif_ioq_enq_binary()
 * enif_ioq_enqv()
 * enif_ioq_size()
 * enif_ioq_deq()
 * enif_ioq_peek()
 * enif_inspect_iolist_as_iovec()
 * enif_free_iovec()

Much of the implementation is shared with how the I/O Queue in linked-in drivers work.

Two remaining issues to think about before merging:

- [ ] Inspection, how do we let the user know that there is data in the queue? Is this an issue? i.e. the same information as `port_info(P, queue_size)` gives.
- [ ] Trapping, with large amounts of data (especially a large list) the call can take a very long time. Do we need enif_inspect_iolist_as_iovec to be able to yield control back to the user?