### PR TITLE
update doc

### DIFF
--- a/system/doc/tutorial/erl_interface.xmlsrc
+++ b/system/doc/tutorial/erl_interface.xmlsrc
@@ -162,8 +162,8 @@ int main() {
       the include files <c>erl_interface.h</c> and <c>ei.h</c>, and
       also to the libraries <c>erl_interface</c> and <c>ei</c>:</p>
     <pre>
-unix> <input>gcc -o extprg -I/usr/local/otp/lib/erl_interface-3.2.1/include \\ </input>
-<input>      -L/usr/local/otp/lib/erl_interface-3.2.1/lib \\ </input>
+unix> <input>gcc -o extprg -I/usr/local/otp/lib/erl_interface-3.9.2/include \\ </input>
+<input>      -L/usr/local/otp/lib/erl_interface-3.9.2/lib \\ </input>
 <input>      complex.c erl_comm.c ei.c -lerl_interface -lei</input></pre>
     <p>In Erlang/OTP R5B and later versions of OTP, the <c>include</c>
       and <c>lib</c> directories are situated under

--- a/system/doc/tutorial/erl_interface.xmlsrc
+++ b/system/doc/tutorial/erl_interface.xmlsrc
@@ -184,7 +184,7 @@ Eshell V4.9.1.2 (abort with ^G)
 {ok,complex2}</pre>
     <p><em>Step 3.</em> Run the example:</p>
     <pre>
-2> <input>complex2:start("extprg").</input>
+2> <input>complex2:start("./extprg").</input>
 &lt;0.34.0>
 3> <input>complex2:foo(3).</input>
 4

--- a/system/doc/tutorial/erl_interface.xmlsrc
+++ b/system/doc/tutorial/erl_interface.xmlsrc
@@ -164,7 +164,7 @@ int main() {
     <pre>
 unix> <input>gcc -o extprg -I/usr/local/otp/lib/erl_interface-3.9.2/include \\ </input>
 <input>      -L/usr/local/otp/lib/erl_interface-3.9.2/lib \\ </input>
-<input>      complex.c erl_comm.c ei.c -lerl_interface -lei</input></pre>
+<input>      complex.c erl_comm.c ei.c -lerl_interface -lei -lpthread</input></pre>
     <p>In Erlang/OTP R5B and later versions of OTP, the <c>include</c>
       and <c>lib</c> directories are situated under
       <c>OTPROOT/lib/erl_interface-VSN</c>, where <c>OTPROOT</c> is


### PR DESCRIPTION
I compile in CentOS 7 amd64, use
```
gcc -o extprg -I/usr/lib64/erlang/lib/erl_interface-3.9.2/include -L/usr/lib64/erlang/lib/erl_interface-3.9.2/lib complex.c erl_comm.c ei.c -lerl_interface -lei
```
output 
```
/usr/lib64/erlang/lib/erl_interface-3.9.2/lib/libei.a(ei_pthreads.o): In function `__erl_errno_place':
(.text+0xf7): undefined reference to `pthread_once'
/usr/lib64/erlang/lib/erl_interface-3.9.2/lib/libei.a(ei_pthreads.o): In function `__erl_errno_place':
(.text+0x11f): undefined reference to `pthread_getspecific'
/usr/lib64/erlang/lib/erl_interface-3.9.2/lib/libei.a(ei_pthreads.o): In function `__erl_errno_place':
(.text+0x147): undefined reference to `pthread_setspecific'
/usr/lib64/erlang/lib/erl_interface-3.9.2/lib/libei.a(ei_pthreads.o): In function `__erl_errno_place':
(.text+0x156): undefined reference to `pthread_getspecific'
/usr/lib64/erlang/lib/erl_interface-3.9.2/lib/libei.a(ei_pthreads.o): In function `erl_errno_key_alloc':
(.text+0x1f): undefined reference to `pthread_key_create'
/usr/lib64/erlang/lib/erl_interface-3.9.2/lib/libei.a(ei_pthreads.o): In function `ei_m_trylock':
(.text+0xa1): undefined reference to `pthread_mutex_trylock'
collect2: error: ld returned 1 exit status
```
And I add the `-lpthread` flag, it works.
Not tested in other OS.

And the exec info below:
```
 2> complex2:start("extprg").
<0.64.0>
3> sh: line 0: exec: extprg: not found

3> complex2:start("./extprg").
<0.66.0>
```
With `pwd`, it works better. 