### PR TITLE
Travis CI: Avoid that builds gets killed for inactivity

### DIFF
--- a/scripts/build-otp
+++ b/scripts/build-otp
@@ -1,12 +1,31 @@
 #!/bin/bash
 
+function progress {
+    local file=$1
+    ls=$(ls -l $file)
+    while [ true ]; do
+	sleep 10
+	new_ls=$(ls -l $file)
+	if [ "$new_ls" != "$ls" ]; then
+	    echo -n "."
+	fi
+        ls="$new_ls"
+    done
+}
+
 function do_and_log {
     log="scripts/latest-log.$$"
-    echo -n "$1... "
+    echo "" >$log
+    echo -n "$1..."
+    (progress $log) &
+    pid=$!
+    disown
     if ./otp_build $2 $3 >$log 2>&1; then
-        echo "done."
+	kill $pid >/dev/null 2>&1
+        echo " done."
     else
-        echo "failed."
+	kill $pid >/dev/null 2>&1
+        echo " failed."
         tail -n 200 $log
         echo "*** Failed ***"
         exit 1


### PR DESCRIPTION
Travis CI will kill build jobs that have not produced output for
10 minutes.

The OTP build was never killed because of inactivity before 74796de9c7739
(which started to capture the output in a temporary file). After that
commit, now and then a build would be killed because it did not finish
in 10 minutes.

Update the build script to periodically print a ".", but only if the
size of the log file has changed. That way, if there is a real hanging
during the build, Travis CI will still kill the build.