### PR TITLE
Introduce new "Dbgi" chunk

### DIFF
--- a/erts/preloaded/src/add_abstract_code
+++ b/erts/preloaded/src/add_abstract_code
@@ -28,12 +28,12 @@
 main([BeamFile,AbstrFile]) ->
     {ok,_,Chunks0} = beam_lib:all_chunks(BeamFile),
     {ok,Abstr} = file:consult(AbstrFile),
-    Chunks1 = lists:keyreplace("Abst", 1, Chunks0,
-			       {"Abst",term_to_binary({raw_abstract_v1,Abstr})}),
-    {"CInf",CInf0} = lists:keyfind("CInf", 1, Chunks1),
-    CInf = fix_options(CInf0),
-    Chunks = lists:keyreplace("CInf", 1, Chunks1, {"CInf",CInf}),
-    {ok,Module} = beam_lib:build_module(Chunks),
+    {"CInf",CInf0} = lists:keyfind("CInf", 1, Chunks0),
+    {CInf, COpts} = fix_options(CInf0),
+    Chunks1 = lists:keyreplace("CInf", 1, Chunks0, {"CInf",CInf}),
+    Chunks2 = lists:keyreplace("Dbgi", 1, Chunks1,
+                   {"Dbgi",term_to_binary({debug_info_v1,erl_abstract_code,{Abstr, COpts}})}),
+    {ok,Module} = beam_lib:build_module(Chunks2),
     ok = file:write_file(BeamFile, Module),
     init:stop().
 
@@ -42,4 +42,4 @@ fix_options(CInf0) ->
     {options,Opts0} = lists:keyfind(options, 1, CInf1),
     Opts = Opts0 -- [from_asm],
     CInf = lists:keyreplace(options, 1, CInf1, {options,Opts}),
-    term_to_binary(CInf).
+    {term_to_binary(CInf), Opts}.

--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -132,12 +132,10 @@
           <tag><c>debug_info</c></tag>
           <item>
             <marker id="debug_info"></marker>
-            <p>Includes debug information in the form of abstract code
-              (see
-              <seealso marker="erts:absform">The Abstract Format</seealso>
-              in ERTS User's Guide) in the compiled beam module. Tools
-	      such as Debugger, Xref, and Cover require
-	      the debug information to be included.</p>
+            <p>Includes debug information in the form of <seealso marker="erts:absform">
+              Erlang Abstract Format</seealso> in the <c>debug_info</c>
+              chunk of the compiled beam module. Tools such as Debugger,
+              Xref, and Cover require the debug information to be included.</p>
 
             <p><em>Warning</em>: Source code can be reconstructed from
               the debug information. Use encrypted debug information
@@ -145,6 +143,21 @@
 
             <p>For details, see
               <seealso marker="stdlib:beam_lib#debug_info">beam_lib(3)</seealso>.</p>
+          </item>
+
+          <tag><c>{debug_info, {Backend, Data}}</c></tag>
+          <item>
+            <marker id="debug_info"></marker>
+            <p>Includes custom debug information in the form of a
+              <c>Backend</c> module with custom <c>Data</c> in the compiled beam module.
+              The given module must implement a <c>debug_info/4</c> function
+              and is responsible for generating different code representations,
+              as described in the <c>debug_info</c> under
+              <seealso marker="stdlib:beam_lib#debug_info">beam_lib(3)</seealso>.</p>
+
+            <p><em>Warning</em>: Source code can be reconstructed from
+              the debug information. Use encrypted debug information
+              (<c>encrypt_debug_info</c>) to prevent this.</p>
           </item>
 
           <tag><c>{debug_info_key,KeyString}</c></tag>

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -198,9 +198,9 @@ expand_opts(Opts0) ->
     %% {debug_info_key,Key} implies debug_info.
     Opts = case {proplists:get_value(debug_info_key, Opts0),
 		 proplists:get_value(encrypt_debug_info, Opts0),
-		 proplists:get_bool(debug_info, Opts0)} of
+		 proplists:get_value(debug_info, Opts0)} of
 	       {undefined,undefined,_} -> Opts0;
-	       {_,_,false} -> [debug_info|Opts0];
+	       {_,_,undefined} -> [debug_info|Opts0];
 	       {_,_,_} -> Opts0
 	   end,
     foldr(fun expand_opt/2, [], Opts).
@@ -302,7 +302,7 @@ format_error_reason(Reason) ->
 		  ofile=""    :: file:filename(),
 		  module=[]   :: module() | [],
 		  core_code=[] :: cerl:c_module() | [],
-		  abstract_code=[] :: binary() | [], %Abstract code for debugger.
+		  abstract_code=[] :: abstract_code(), %Abstract code for debugger.
 		  options=[]  :: [option()],  %Options for compilation
 		  mod_options=[]  :: [option()], %Options for module_info
                   encoding=none :: none | epp:source_encoding(),
@@ -1315,50 +1315,63 @@ core_inline_module(Code0, #compile{options=Opts}=St) ->
     Code = cerl_inline:core_transform(Code0, Opts),
     {ok,Code,St}.
 
-save_abstract_code(Code, #compile{ifile=File}=St) ->
-    case abstract_code(Code, St) of
-	{ok,Abstr} ->
-	    {ok,Code,St#compile{abstract_code=Abstr}};
-	{error,Es} ->
-	    {error,St#compile{errors=St#compile.errors ++ [{File,Es}]}}
-    end.
+save_abstract_code(Code, St) ->
+    {ok,Code,St#compile{abstract_code=erl_parse:anno_to_term(Code)}}.
 
-abstract_code(Code0, #compile{options=Opts,ofile=OFile}) ->
-    Code = erl_parse:anno_to_term(Code0),
-    Abstr = erlang:term_to_binary({raw_abstract_v1,Code}, [compressed]),
-    case member(encrypt_debug_info, Opts) of
+debug_info(#compile{module=Module,mod_options=Opts0,ofile=OFile,abstract_code=Abst}) ->
+    AbstOpts = cleanup_compile_options(Opts0),
+    Opts1 = proplists:delete(debug_info, Opts0),
+    {Backend,Metadata,Opts2} =
+	case proplists:get_value(debug_info, Opts0, false) of
+	    {OptBackend,OptMetadata} when is_atom(OptBackend) -> {OptBackend,OptMetadata,Opts1};
+	    false -> {erl_abstract_code,{none,AbstOpts},Opts1};
+	    true -> {erl_abstract_code,{Abst,AbstOpts},[debug_info | Opts1]}
+	end,
+    DebugInfo = erlang:term_to_binary({debug_info_v1,Backend,Metadata}, [compressed]),
+
+    case member(encrypt_debug_info, Opts2) of
 	true ->
-	    case keyfind(debug_info_key, 1, Opts) of
-		{_,Key} ->
-		    encrypt_abs_code(Abstr, Key);
+	    case lists:keytake(debug_info_key, 1, Opts2) of
+		{value,{_, Key},Opts3} ->
+		    encrypt_debug_info(DebugInfo, Key, [{debug_info_key,'********'} | Opts3]);
 		false ->
-		    %% Note: #compile.module has not been set yet.
-		    %% Here is an approximation that should work for
-		    %% all valid cases.
-		    Module = list_to_atom(filename:rootname(filename:basename(OFile))),
-		    Mode = proplists:get_value(crypto_mode, Opts, des3_cbc),
+		    Mode = proplists:get_value(crypto_mode, Opts2, des3_cbc),
 		    case beam_lib:get_crypto_key({debug_info, Mode, Module, OFile}) of
 			error ->
 			    {error, [{none,?MODULE,no_crypto_key}]};
 			Key ->
-			    encrypt_abs_code(Abstr, {Mode, Key})
+			    encrypt_debug_info(DebugInfo, {Mode, Key}, Opts2)
 		    end
 	    end;
 	false ->
-	    {ok,Abstr}
+	    {ok,DebugInfo,Opts2}
     end.
 
-encrypt_abs_code(Abstr, Key0) ->
+encrypt_debug_info(DebugInfo, Key, Opts) ->
     try
-	RealKey = generate_key(Key0),
+	RealKey = generate_key(Key),
 	case start_crypto() of
-	    ok -> {ok,encrypt(RealKey, Abstr)};
+	    ok -> {ok,encrypt(RealKey, DebugInfo),Opts};
 	    {error,_}=E -> E
 	end
     catch
 	error:_ ->
 	    {error,[{none,?MODULE,bad_crypto_key}]}
     end.
+
+cleanup_compile_options(Opts) ->
+    lists:filter(fun keep_compile_option/1, Opts).
+
+%% We are storing abstract, not asm or core.
+keep_compile_option(from_asm) -> false;
+keep_compile_option(from_core) -> false;
+%% Parse transform and macros have already been applied.
+keep_compile_option({parse_transform, _}) -> false;
+keep_compile_option({d, _, _}) -> false;
+%% Do not affect compilation result on future calls.
+keep_compile_option({outdir, _}) -> false;
+keep_compile_option(warnings_as_errors) -> false;
+keep_compile_option(Option) -> effects_code_generation(Option).
 
 start_crypto() ->
     try crypto:start() of
@@ -1386,16 +1399,16 @@ encrypt({des3_cbc=Type,Key,IVec,BlockSize}, Bin0) ->
 save_core_code(Code, St) ->
     {ok,Code,St#compile{core_code=cerl:from_records(Code)}}.
 
-beam_asm(Code0, #compile{ifile=File,abstract_code=Abst,extra_chunks=ExtraChunks,
-			 options=CompilerOpts,mod_options=Opts0}=St) ->
-    Source = paranoid_absname(File),
-    Opts1 = lists:map(fun({debug_info_key,_}) -> {debug_info_key,'********'};
-			 (Other) -> Other
-		      end, Opts0),
-    Opts2 = [O || O <- Opts1, effects_code_generation(O)],
-    Chunks = [{<<"Abst">>, Abst} | ExtraChunks],
-    case beam_asm:module(Code0, Chunks, Source, Opts2, CompilerOpts) of
-	{ok,Code} -> {ok,Code,St#compile{abstract_code=[]}}
+beam_asm(Code0, #compile{ifile=File,extra_chunks=ExtraChunks,options=CompilerOpts}=St) ->
+    case debug_info(St) of
+	{ok,DebugInfo,Opts0} ->
+	    Source = paranoid_absname(File),
+	    Opts1 = [O || O <- Opts0, effects_code_generation(O)],
+	    Chunks = [{<<"Dbgi">>, DebugInfo} | ExtraChunks],
+	    {ok,Code} = beam_asm:module(Code0, Chunks, Source, Opts1, CompilerOpts),
+	    {ok,Code,St#compile{abstract_code=[]}};
+	{error,Es} ->
+	    {error,St#compile{errors=St#compile.errors ++ [{File,Es}]}}
     end.
 
 paranoid_absname(""=File) ->
@@ -1479,7 +1492,7 @@ embed_native_code(Code, {Architecture,NativeCode}) ->
 %%  errors will be reported).
 
 effects_code_generation(Option) ->
-    case Option of 
+    case Option of
 	beam -> false;
 	report_warnings -> false;
 	report_errors -> false;

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1369,8 +1369,6 @@ keep_compile_option(from_core) -> false;
 keep_compile_option({parse_transform, _}) -> false;
 keep_compile_option({d, _, _}) -> false;
 %% Do not affect compilation result on future calls.
-keep_compile_option({outdir, _}) -> false;
-keep_compile_option(warnings_as_errors) -> false;
 keep_compile_option(Option) -> effects_code_generation(Option).
 
 start_crypto() ->
@@ -1498,9 +1496,11 @@ effects_code_generation(Option) ->
 	report_errors -> false;
 	return_errors-> false;
 	return_warnings-> false;
+	warnings_as_errors -> false;
 	binary -> false;
 	verbose -> false;
 	{cwd,_} -> false;
+	{outdir, _} -> false;
 	_ -> true
     end.
 

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -184,11 +184,8 @@ form({function,_,_,_,_}=F0, Module, Opts) ->
 form({attribute,_,module,Mod}, Module, _Opts) ->
     true = is_atom(Mod),
     Module#imodule{name=Mod};
-form({attribute,_,file,{File,_Line}}, Module, _Opts) ->
-    Module#imodule{file=File};
-form({attribute,_,compile,_}, Module, _Opts) ->
-    %% Ignore compilation options.
-    Module;
+form({attribute,_,file,{File,_Line}}=F, #imodule{attrs=As}=Module, _Opts) ->
+    Module#imodule{file=File, attrs=[attribute(F)|As]};
 form({attribute,_,import,_}, Module, _Opts) ->
     %% Ignore. We have no futher use for imports.
     Module;
@@ -201,9 +198,8 @@ form(_, Module, _Opts) ->
     %% Ignore uninteresting forms such as 'eof'.
     Module.
 
-attribute(Attribute) ->
-    Fun = fun(A) ->  [erl_anno:location(A)] end,
-    {attribute,Line,Name,Val0} = erl_parse:map_anno(Fun, Attribute),
+attribute({attribute,A,Name,Val0}) ->
+    Line = [erl_anno:location(A)],
     Val = if
 	      is_list(Val0) -> Val0;
 	      true -> [Val0]

--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -148,6 +148,8 @@ include_attribute(opaque) -> false;
 include_attribute(export_type) -> false;
 include_attribute(record) -> false;
 include_attribute(optional_callbacks) -> false;
+include_attribute(file) -> false;
+include_attribute(compile) -> false;
 include_attribute(_) -> true.
 
 function({#c_var{name={F,Arity}=FA},Body}, St0) ->

--- a/lib/compiler/test/compilation_SUITE.erl
+++ b/lib/compiler/test/compilation_SUITE.erl
@@ -319,7 +319,7 @@ self_compile_1(Config, Prefix, Opts) ->
     %% Compile the compiler. (In this node to get better coverage.)
     CompA = make_compiler_dir(Priv, Prefix++"compiler_a"),
     VsnA = Version ++ ".0",
-    compile_compiler(compiler_src(), CompA, VsnA, [clint0,clint|Opts]),
+    compile_compiler(compiler_src(), CompA, VsnA, Opts),
 
     %% Compile the compiler again using the newly compiled compiler.
     %% (In another node because reloading the compiler would disturb cover.)

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -27,6 +27,7 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
 	 init_per_group/2,end_per_group/2,
 	 app_test/1,appup_test/1,
+	 debug_info/4, custom_debug_info/1,
 	 file_1/1, forms_2/1, module_mismatch/1, big_file/1, outdir/1,
 	 binary/1, makedep/1, cond_and_ifdef/1, listings/1, listings_big/1,
 	 other_output/1, kernel_listing/1, encrypted_abstr/1,
@@ -51,7 +52,7 @@ all() ->
      strict_record, utf8_atoms, extra_chunks,
      cover, env, core, core_roundtrip, asm, optimized_guards,
      sys_pre_attributes, dialyzer, warnings, pre_load_check,
-     env_compiler_options].
+     env_compiler_options, custom_debug_info].
 
 groups() -> 
     [].
@@ -504,17 +505,23 @@ encrypted_abstr_1(Simple, Target) ->
     {ok,simple} = compile:file(Simple,
 				     [debug_info,{debug_info_key,Key},
 				      {outdir,TargetDir}]),
-    verify_abstract(Target),
+    verify_abstract(Target, erl_abstract_code),
 
     {ok,simple} = compile:file(Simple,
 				     [{debug_info_key,Key},
 				      {outdir,TargetDir}]),
-    verify_abstract(Target),
+    verify_abstract(Target, erl_abstract_code),
 
     {ok,simple} = compile:file(Simple,
 				     [debug_info,{debug_info_key,{des3_cbc,Key}},
 				      {outdir,TargetDir}]),
-    verify_abstract(Target),
+    verify_abstract(Target, erl_abstract_code),
+
+    {ok,simple} = compile:file(Simple,
+				     [{debug_info,{?MODULE,ok}},
+				      {debug_info_key,Key},
+				      {outdir,TargetDir}]),
+    verify_abstract(Target, ?MODULE),
 
     {ok,{simple,[{compile_info,CInfo}]}} =
 	beam_lib:chunks(Target, [compile_info]),
@@ -539,7 +546,7 @@ encrypted_abstr_1(Simple, Target) ->
     NewKey = "better use another key here",
     write_crypt_file(["[{debug_info,des3_cbc,simple,\"",NewKey,"\"}].\n"]),
     {ok,simple} = compile:file(Simple, [encrypt_debug_info,report]),
-    verify_abstract("simple.beam"),
+    verify_abstract("simple.beam", erl_abstract_code),
     ok = file:delete(".erlang.crypt"),
     beam_lib:clear_crypto_key_fun(),
     {error,beam_lib,{key_missing_or_invalid,"simple.beam",abstract_code}} =
@@ -572,9 +579,10 @@ encrypted_abstr_no_crypto(Simple, Target) ->
 				{outdir,TargetDir},report]),
     ok.
     
-verify_abstract(Target) ->
-    {ok,{simple,[Chunk]}} = beam_lib:chunks(Target, [abstract_code]),
-    {abstract_code,{raw_abstract_v1,_}} = Chunk.
+verify_abstract(Beam, Backend) ->
+    {ok,{simple,[Abst, Dbgi]}} = beam_lib:chunks(Beam, [abstract_code, debug_info]),
+    {abstract_code,{raw_abstract_v1,_}} = Abst,
+    {debug_info,{debug_info_v1,Backend,_}} = Dbgi.
 
 has_crypto() ->
     try
@@ -593,6 +601,26 @@ install_crypto_key(Key) ->
     ok = beam_lib:crypto_key_fun(F).
 
 %% Miscellanous tests, mainly to get better coverage.
+debug_info(erlang_v1, Module, ok, _Opts) ->
+    {ok, [Module]};
+debug_info(erlang_v1, Module, error, _Opts) ->
+    {error, unknown_format}.
+
+custom_debug_info(Config) when is_list(Config) ->
+    {Simple,_} = get_files(Config, simple, "file_1"),
+
+    {ok,simple,OkBin} = compile:file(Simple, [binary, {debug_info,{?MODULE,ok}}]), %Coverage
+    {ok,{simple,[{abstract_code,{raw_abstract_v1,[simple]}}]}} =
+	beam_lib:chunks(OkBin, [abstract_code]),
+    {ok,{simple,[{debug_info,{debug_info_v1,?MODULE,ok}}]}} =
+	beam_lib:chunks(OkBin, [debug_info]),
+
+    {ok,simple,ErrorBin} = compile:file(Simple, [binary, {debug_info,{?MODULE,error}}]), %Coverage
+    {ok,{simple,[{abstract_code,no_abstract_code}]}} =
+	beam_lib:chunks(ErrorBin, [abstract_code]),
+    {ok,{simple,[{debug_info,{debug_info_v1,?MODULE,error}}]}} =
+	beam_lib:chunks(ErrorBin, [debug_info]).
+
 cover(Config) when is_list(Config) ->
     io:format("~p\n", [compile:options()]),
     ok.

--- a/lib/dialyzer/src/dialyzer_plt.erl
+++ b/lib/dialyzer/src/dialyzer_plt.erl
@@ -470,12 +470,11 @@ compute_md5_from_file(File) ->
       Msg = io_lib:format("Not a regular file: ~s\n", [File]),
       throw({dialyzer_error, Msg});
     true ->
-      case dialyzer_utils:get_abstract_code_from_beam(File) of
-	error ->
-	  Msg = io_lib:format("Could not get abstract code for file: ~s (please recompile it with +debug_info)\n", [File]),
-	  throw({dialyzer_error, Msg});
-	{ok, Abs} ->
-	  erlang:md5(term_to_binary(Abs))
+      case dialyzer_utils:get_core_from_beam(File) of
+	{error, Error} ->
+	  throw({dialyzer_error, Error});
+	{ok, Core} ->
+	  erlang:md5(term_to_binary(Core))
       end
   end.
 

--- a/lib/stdlib/doc/src/beam_lib.xml
+++ b/lib/stdlib/doc/src/beam_lib.xml
@@ -42,10 +42,10 @@
       and the corresponding identifiers are as follows:</p>
 
     <list type="bulleted">
-      <item><c>abstract_code ("Abst")</c></item>
       <item><c>atoms ("Atom")</c></item>
       <item><c>attributes ("Attr")</c></item>
       <item><c>compile_info ("CInf")</c></item>
+      <item><c>debug_info ("Dbgi")</c></item>
       <item><c>exports ("ExpT")</c></item>
       <item><c>imports ("ImpT")</c></item>
       <item><c>indexed_imports ("ImpT")</c></item>
@@ -60,9 +60,8 @@
     <title>Debug Information/Abstract Code</title>
     <p>Option <c>debug_info</c> can be specified to the Compiler (see
       <seealso marker="compiler:compile#debug_info"><c>compile(3)</c></seealso>)
-      to have debug information in the form of abstract code (see section
-      <seealso marker="erts:absform">The Abstract Format</seealso> in the
-      ERTS User's Guide) stored in the <c>abstract_code</c> chunk.
+      to have debug information, such as <seealso marker="erts:absform">Erlang
+      Abstract Format</seealso>, stored in the <c>debug_info</c> chunk.
       Tools such as Debugger and Xref require the debug information to
       be included.</p>
 
@@ -79,7 +78,7 @@
 
   <section>
     <title>Reconstruct Source Code</title>
-    <p>The following example shows how to reconstruct source code from
+    <p>The following example shows how to reconstruct Erlang source code from
       the debug information in a BEAM file <c>Beam</c>:</p>
 
     <code type="none">
@@ -117,7 +116,7 @@ io:fwrite("~s~n", [erl_prettypr:format(erl_syntax:form_list(AC))]).</code>
 
     <list type="ordered">
       <item>
-        <p>Use Compiler option <c>{debug_info,Key}</c>, see
+        <p>Use Compiler option <c>{debug_info_key,Key}</c>, see
           <seealso marker="compiler:compile#debug_info_key"><c>compile(3)</c></seealso>
           and function
           <seealso marker="#crypto_key_fun/1"><c>crypto_key_fun/1</c></seealso>
@@ -198,11 +197,31 @@ io:fwrite("~s~n", [erl_prettypr:format(erl_syntax:form_list(AC))]).</code>
     <datatype>
       <name name="chunkid"/>
       <desc>
-        <p>"Abst" | "Attr" | "CInf" | "ExpT" | "ImpT" | "LocT" | "Atom"</p>
+        <p>"Attr" | "CInf" | "Dbgi" | "ExpT" | "ImpT" | "LocT" | "AtU8"</p>
       </desc>
     </datatype>
     <datatype>
       <name name="dataB"/>
+    </datatype>
+    <datatype>
+      <name name="debug_info"/>
+      <desc>
+        <p>The format stored in the <c>debug_info</c> chunk.
+          To retrieve particular code representation from the backend,
+          <c>Backend:debug_info(Format, Module, Data, Opts)</c> must be
+          invoked. <c>Format</c> is an atom, such as <c>erlang_v1</c> for
+          the Erlang Abstract Format or <c>core_v1</c> for Core Erlang.
+          <c>Module</c> is the module represented by the beam file and
+          <c>Data</c> is the value stored in the debug info chunk.
+          <c>Opts</c> is any list of values supported by the <c>Backend</c>.
+          <c>Backend:debug_info/4</c> must return <c>{ok, Code}</c> or
+          <c>{error, Term}</c>.</p>
+
+        <p>Developers must always invoke the <c>debug_info/4</c> function
+          and never rely on the <c>Data</c> stored in the <c>debug_info</c>
+          chunk, as it is opaque and may change at any moment. <c>no_debug_info</c>
+          means that chunk <c>"Dbgi"</c> is present, but empty.</p>
+      </desc>
     </datatype>
     <datatype>
       <name name="abst_code"/>
@@ -210,6 +229,8 @@ io:fwrite("~s~n", [erl_prettypr:format(erl_syntax:form_list(AC))]).</code>
         <p>It is not checked that the forms conform to the abstract format
           indicated by <c><anno>AbstVersion</anno></c>. <c>no_abstract_code</c>
           means that chunk <c>"Abst"</c> is present, but empty.</p>
+        <p>For modules compiled with OTP 20 onwards, the <c>abst_code</c> chunk
+          is automatically computed from the <c>debug_info</c> chunk.</p>
       </desc>
     </datatype>
     <datatype>
@@ -346,7 +367,7 @@ io:fwrite("~s~n", [erl_prettypr:format(erl_syntax:form_list(AC))]).</code>
       <desc>
         <p>Registers an unary fun
           that is called if <c>beam_lib</c> must read an
-          <c>abstract_code</c> chunk that has been encrypted. The fun
+          <c>debug_info</c> chunk that has been encrypted. The fun
           is held in a process that is started by the function.</p>
         <p>If a fun is already registered when attempting to
           register a fun, <c>{error, exists}</c> is returned.</p>
@@ -443,7 +464,8 @@ CryptoKeyFun(clear) -> term()</code>
       <desc>
         <p>Removes all chunks from a BEAM
           file except those needed by the loader. In particular,
-          the debug information (chunk <c>abstract_code</c>) is removed.</p>
+          the debug information (chunk <c>debug_info</c> and <c>abstract_code</c>)
+          is removed.</p>
       </desc>
     </func>
 
@@ -454,9 +476,9 @@ CryptoKeyFun(clear) -> term()</code>
       <desc>
         <p>Removes all chunks except
           those needed by the loader from BEAM files. In particular,
-          the debug information (chunk <c>abstract_code</c>) is removed.
-          The returned list contains one element for each specified filename,
-          in the same order as in <c>Files</c>.</p>
+          the debug information (chunk <c>debug_info</c> and <c>abstract_code</c>)
+          is removed. The returned list contains one element for each
+          specified filename, in the same order as in <c>Files</c>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -58,6 +58,7 @@ MODULES= \
 	edlin \
 	edlin_expand \
 	epp \
+	erl_abstract_code \
 	erl_anno \
 	erl_bits \
 	erl_compile \

--- a/lib/stdlib/src/erl_abstract_code.erl
+++ b/lib/stdlib/src/erl_abstract_code.erl
@@ -1,0 +1,28 @@
+-module(erl_abstract_code).
+-export([debug_info/4]).
+
+debug_info(_Format, _Module, {none,_CompilerOpts}, _Opts) ->
+    {error, missing};
+debug_info(erlang_v1, _Module, {AbstrCode,_CompilerOpts}, _Opts) ->
+    {ok, AbstrCode};
+debug_info(core_v1, _Module, {AbstrCode,CompilerOpts}, Opts) ->
+    CoreOpts = add_core_returns(delete_reports(CompilerOpts ++ Opts)),
+    try compile:noenv_forms(AbstrCode, CoreOpts) of
+	{ok, _, Core, _} -> {ok, Core};
+	_What -> {error, failed_conversion}
+    catch
+	error:_ -> {error, failed_conversion}
+    end;
+debug_info(_, _, _, _) ->
+    {error, unknown_format}.
+
+delete_reports(Opts) ->
+    [Opt || Opt <- Opts, not is_report_option(Opt)].
+
+is_report_option(report) -> true;
+is_report_option(report_errors) -> true;
+is_report_option(report_warnings) -> true;
+is_report_option(_) -> false.
+
+add_core_returns(Opts) ->
+    [to_core, return_errors, return_warnings] ++ Opts.

--- a/lib/stdlib/src/stdlib.app.src
+++ b/lib/stdlib/src/stdlib.app.src
@@ -39,6 +39,7 @@
 	     edlin_expand,
 	     epp,
 	     eval_bits,
+             erl_abstract_code,
              erl_anno,
 	     erl_bits,
 	     erl_compile,


### PR DESCRIPTION
Many tools in the Erlang ecosystem expect the Erlang Abstract Code chunk to exist or, if it doesn't exist, it automatically generates one from the source code, if it can find the source. This restricts the usage of the tooling for some languages and leads to code duplication in different tools.

To solve this issue for languages that compile directly to Core, such as LFE, I have earlier proposed a chunk that stores Core AST. However, even if we add such chunk, I could see the following problems:

  1. Storing the Core AST chunk still does not provide a feature where chunks are calculated on the fly from the source if the chunk is not present

  2. Adding a new chunk could potentially make the situation worse because tools in the future may work directly on those new chunks, forcing compilers to add both Erlang Abstract Format and Code AST chunks to the .beam file. In fact, if we go in this direction, I could see we ending-up in a situation where Elixir has to store Elixir, Erlang and Core ASTs on .beam.

Therefore, I would like the ability to store abstract code on beam such that:

  1. The abstract code is stored once but is able to be retrieved in different formats
  2. If the abstract code is omitted, we should still provide the ability to retrieve it from source, regardless of the language, if desired

Therefore I propose us to introduce a new chunk which allows any abstract code to be stored but also includes a backend module that will be used for performing conversions or source lookup.

### Proposal: The "Dbgi" chunk

I propose to introduce a new chunk, called "Dbgi", with the following format:

    {debug_info_v1, Backend, Metadata | none}

Once the chunk is fetched, we can retrieve the actual debug information as follows:

    Backend:debug_info(Format, Module, Metadata, Opts) -> {ok, Code} | {error, Reason}

Where `Format` is the desired format (erlang, core, elixir, lfe, etc), `Module` is the module we are fetching the debug info for and `Opts` may include `[allow_source_lookup]`, which would instruct the backend to lookup the debug information from source if it is not available.

As an example, an implementation for the Erlang abstract format would return something like:

    {debug_info_v1, erl_abstract_code, AbstractCode}

Where `erl_abstract_code` could be defined as:

```erlang
-module(erl_abstract_code).
-compile(debug_info/4).

debug_info(Format, Module, none, Opts) ->
  case proplists:get_boolean(from_source, Opts) of
    true -> debug_info(Format, Module, fetch_from_source(Module), Opts);
    false -> {error, missing}
  end;
debug_info(erlang, _Module, Code, _Opts) ->
  {ok, Code};
debug_info(core, _Module, Code, _Opts) ->
  %% convert to core
debug_info(_, _, _, _) ->
  {error, unknown_format}.
```

As you can see, this approach provides many benefits:

  1. The logic that retrieves, converts and potentially fetches the abstract code from source is encapsulated in a single module instead of scattered around different projects like dbg, dialyzer, cover, etc

  2. It allows the `debug_info` to be stored in any format desired by a given compiler. This way LFE can store LFE AST and translate to core accordingly, Elixir can store Elixir AST and convert to either core or erlang, etc.

  3. Finally, by allowing `{debug_info, {Backend, Metadata}}` to be given to `compile:forms/2`, we can allow all language compilers to leverage the current infra-structure for debug_info and debug_info_key instead of rolling their own

This approach is also backwards compatible. `beam_lib:chunks(Module, [abstract_code])` can look into "Dbgi" and invoke the proper backend conversion in case the "Abst" chunk is no longer available. If a tool is attempting to access "Abst" chunk directly, the fact the chunk no longer exists should not be an issue as the chunk is optional.

The PR includes the changes to the `compile` module. If the general direction is agreed on, I will improve the docs, add tests and do the relevant changes to `beam_lib` and change some of the tooling to prove the proposal is sound. Later we will submit pull requests to update the remaining of the tooling as necessary (updating the rest of the tooling can be done in another step as this PR aims to be backwards compatible).

/cc @j14159 @rvirding
