### PR TITLE
Extend Travis CI to test more configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-language: erlang
-
-otp_release:
-  - 18.0
+language: c
 
 sudo: false
+
+os:
+  - linux
 
 addons:
   apt:
@@ -26,7 +26,6 @@ before_script:
   - export PATH=$ERL_TOP/bin:$PATH
   - export ERL_LIBS=''
   - export MAKEFLAGS=-j6
-  - kerl_deactivate
 
 script:
   - ./scripts/build-otp

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - export ERL_TOP=$PWD
   - export PATH=$ERL_TOP/bin:$PATH
   - export ERL_LIBS=''
-  - export MAKEFLAGS=-j6
+  - export MAKEFLAGS=-j4
 
 script:
   - ./scripts/build-otp

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,17 @@ addons:
       - g++
       - xsltproc
 
+matrix:
+  include:
+    - env: Linux32
+      os: linux
+      services:
+        - docker
+      script:
+        - ./scripts/build-docker-otp 32 sh -c "scripts/build-otp && ./otp_build tests && scripts/run-smoke-tests"
+      after_success:
+      after_script:
+
 before_script:
   - set -e
   - export ERL_TOP=$PWD
@@ -29,7 +40,7 @@ before_script:
 
 script:
   - ./scripts/build-otp
-  
+
 after_success:
   - $ERL_TOP/bin/dialyzer --build_plt --apps asn1 compiler crypto dialyzer edoc erts et hipe inets kernel mnesia observer public_key runtime_tools snmp ssh ssl stdlib syntax_tools wx xmerl --statistics
   - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps compiler erts kernel stdlib asn1 crypto dialyzer hipe parsetools public_key runtime_tools sasl tools --statistics

--- a/scripts/Dockerfile.32
+++ b/scripts/Dockerfile.32
@@ -8,6 +8,6 @@ RUN tar xzf otp.tar.gz
 
 WORKDIR /buildroot/otp/
 
-ENV MAKEFLAGS -j10
+ENV MAKEFLAGS -j4
 
 CMD ./scripts/build-otp

--- a/scripts/Dockerfile.32
+++ b/scripts/Dockerfile.32
@@ -1,10 +1,6 @@
 FROM erlang/ubuntu-build:32bit
 
-COPY ./otp.tar.gz /buildroot/
-
-WORKDIR /buildroot/
-
-RUN tar xzf otp.tar.gz
+ADD ./otp.tar.gz /buildroot/
 
 WORKDIR /buildroot/otp/
 

--- a/scripts/Dockerfile.32
+++ b/scripts/Dockerfile.32
@@ -1,0 +1,13 @@
+FROM erlang/ubuntu-build:32bit
+
+COPY ./otp.tar.gz /buildroot/
+
+WORKDIR /buildroot/
+
+RUN tar xzf otp.tar.gz
+
+WORKDIR /buildroot/otp/
+
+ENV MAKEFLAGS -j10
+
+CMD ./scripts/build-otp

--- a/scripts/Dockerfile.32.ubuntu
+++ b/scripts/Dockerfile.32.ubuntu
@@ -1,0 +1,5 @@
+FROM 32bit/ubuntu:16.04
+
+RUN apt-get update
+
+RUN apt-get --fix-missing -y install build-essential m4 libncurses5-dev libssh-dev unixodbc-dev libgmp3-dev fop xsltproc default-jdk git autoconf libwxbase3.0-dev libwxgtk3.0-dev

--- a/scripts/Dockerfile.64
+++ b/scripts/Dockerfile.64
@@ -1,0 +1,13 @@
+FROM erlang/ubuntu-build:64bit
+
+COPY ./otp.tar.gz /buildroot/
+
+WORKDIR /buildroot/
+
+RUN tar xzf otp.tar.gz
+
+WORKDIR /buildroot/otp/
+
+ENV MAKEFLAGS -j10
+
+CMD ./scripts/build-otp

--- a/scripts/Dockerfile.64
+++ b/scripts/Dockerfile.64
@@ -8,6 +8,6 @@ RUN tar xzf otp.tar.gz
 
 WORKDIR /buildroot/otp/
 
-ENV MAKEFLAGS -j10
+ENV MAKEFLAGS -j4
 
 CMD ./scripts/build-otp

--- a/scripts/Dockerfile.64
+++ b/scripts/Dockerfile.64
@@ -1,10 +1,6 @@
 FROM erlang/ubuntu-build:64bit
 
-COPY ./otp.tar.gz /buildroot/
-
-WORKDIR /buildroot/
-
-RUN tar xzf otp.tar.gz
+ADD ./otp.tar.gz /buildroot/
 
 WORKDIR /buildroot/otp/
 

--- a/scripts/Dockerfile.64.ubuntu
+++ b/scripts/Dockerfile.64.ubuntu
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+
+RUN apt-get update
+
+RUN apt-get --fix-missing -y install build-essential m4 libncurses5-dev libssh-dev unixodbc-dev libgmp3-dev fop xsltproc default-jdk git autoconf libwxbase3.0-dev libwxgtk3.0-dev

--- a/scripts/build-docker-otp
+++ b/scripts/build-docker-otp
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 if [ $# -lt 1 ]; then
-    echo "Usage $0 32|64 [command]"
+    echo "Usage $0 32|64 [command] [arg]..."
     exit 1
 fi
 
 ARCH="$1"
+shift
 
 git archive --format=tar.gz --prefix=otp/ HEAD >otp.tar.gz
 
 docker build -t otp --file scripts/Dockerfile.$ARCH .
-docker run --volume="$PWD/logs:/buildroot/otp/logs" -i --rm otp $2
+docker run --volume="$PWD/logs:/buildroot/otp/logs" -i --rm otp ${1+"$@"}

--- a/scripts/build-docker-otp
+++ b/scripts/build-docker-otp
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]; then
+    echo "Usage $0 32|64 [command]"
+    exit 1
+fi
+
+ARCH="$1"
+
+git archive --format=tar.gz --prefix=otp/ HEAD >otp.tar.gz
+
+docker build -t otp --file scripts/Dockerfile.$ARCH .
+docker run --volume="$PWD/logs:/buildroot/otp/logs" -i --rm otp $2

--- a/scripts/build-docker-otp
+++ b/scripts/build-docker-otp
@@ -8,7 +8,8 @@ fi
 ARCH="$1"
 shift
 
-git archive --format=tar.gz --prefix=otp/ HEAD >otp.tar.gz
+git archive --format=tar.gz --prefix=otp/ HEAD >scripts/otp.tar.gz
 
-docker build -t otp --file scripts/Dockerfile.$ARCH .
+docker build -t otp --file scripts/Dockerfile.$ARCH scripts
+rm scripts/otp.tar.gz
 docker run --volume="$PWD/logs:/buildroot/otp/logs" -i --rm otp ${1+"$@"}

--- a/scripts/build-otp
+++ b/scripts/build-otp
@@ -14,7 +14,7 @@ function progress {
 }
 
 function do_and_log {
-    log="scripts/latest-log.$$"
+    log="logs/latest-log.$$"
     echo "" >$log
     echo -n "$1..."
     (progress $log) &
@@ -31,6 +31,10 @@ function do_and_log {
         exit 1
     fi
 }
+
+if [ ! -d "logs" ]; then
+    mkdir logs
+fi
 
 do_and_log "Autoconfing" autoconf
 do_and_log "Configuring" configure

--- a/scripts/run-smoke-tests
+++ b/scripts/run-smoke-tests
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -ev
 
+if [ -z "$ERL_TOP" ]; then
+    ERL_TOP=$(pwd)
+fi
+
 cd $ERL_TOP/release/tests/test_server
 $ERL_TOP/bin/erl -s ts install -s ts smoke_test batch -s init stop
 

--- a/scripts/run-smoke-tests
+++ b/scripts/run-smoke-tests
@@ -5,10 +5,17 @@ if [ -z "$ERL_TOP" ]; then
     ERL_TOP=$(pwd)
 fi
 
-cd $ERL_TOP/release/tests/test_server
-$ERL_TOP/bin/erl -s ts install -s ts smoke_test batch -s init stop
+function run_smoke_tests {
+    cd $ERL_TOP/release/tests/test_server
+    $ERL_TOP/bin/erl -s ts install -s ts smoke_test batch -s init stop
 
-if grep -q '=failed *[1-9]' ct_run.test_server@*/*/run.*/suite.log; then
-    echo "One or more tests failed."
-    exit 1
-fi
+    if grep -q '=failed *[1-9]' ct_run.test_server@*/*/run.*/suite.log; then
+        echo "One or more tests failed."
+        exit 1
+    fi
+    rm -rf ct_run.test_server@*
+}
+
+run_smoke_tests
+ERL_FLAGS="-smp disable" run_smoke_tests
+


### PR DESCRIPTION
* Run the smoke test for both the SMP and non-SMP run-time systems.

* Build and run smoke test Erlang/OTP on a 32-bit Ubuntu distribution using Docker.

* Only use 4 parallel `make` jobs to conserve memory (Travis will kill jobs that run out of memory).
