### PR TITLE
Improves accumulator fun in xmerl_scan

### DIFF
--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -474,8 +474,6 @@ event(_X, S) ->
 %% into multiple objects (in which case {Acc',Pos',S'} should be returned.)
 %% If {Acc',S'} is returned, Pos will be incremented by 1 by default.
 %% Below is an example of an acceptable operation
-acc(X = #xmlText{value = Text}, Acc, S) ->
-    {[X#xmlText{value = Text}|Acc], S};
 acc(X, Acc, S) ->
     {[X|Acc], S}.
 

--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -474,6 +474,8 @@ event(_X, S) ->
 %% into multiple objects (in which case {Acc',Pos',S'} should be returned.)
 %% If {Acc',S'} is returned, Pos will be incremented by 1 by default.
 %% Below is an example of an acceptable operation
+acc(#xmlText{value = Text}, [X = #xmlText{value = AccText}], S) ->
+    {[X#xmlText{value = AccText ++ Text}], S};
 acc(X, Acc, S) ->
     {[X|Acc], S}.
 

--- a/lib/xmerl/test/xmerl_SUITE.erl
+++ b/lib/xmerl/test/xmerl_SUITE.erl
@@ -55,7 +55,7 @@ groups() ->
      {misc, [],
       [latin1_alias, syntax_bug1, syntax_bug2, syntax_bug3,
        pe_ref1, copyright, testXSEIF, export_simple1, export,
-       default_attrs_bug, xml_ns]},
+       default_attrs_bug, xml_ns, scan_splits_string_bug]},
      {eventp_tests, [], [sax_parse_and_export]},
      {ticket_tests, [],
       [ticket_5998, ticket_7211, ticket_7214, ticket_7430,
@@ -267,6 +267,10 @@ xml_ns(Config) ->
      []
     } = xmerl_scan:string(Doc2, [{namespace_conformant, true}]),
     ok.
+
+scan_splits_string_bug(_Config) ->
+    {#xmlElement{ content = [#xmlText{ value = "Jimmy Zöger" }] }, []}
+        = xmerl_scan:string("<name>Jimmy Z&#246;ger</name>").
 
 pe_ref1(Config) ->
     file:set_cwd(datadir(Config)),
@@ -533,8 +537,7 @@ ticket_7430(Config) ->
              {xmlElement,a,a,[],
               {xmlNamespace,[],[]},
               [],1,[],
-              [{xmlText,[{a,1}],1,[],"é",text},
-               {xmlText,[{a,1}],2,[],"\né",text}],
+              [{xmlText,[{a,1}],1,[],"é\né",text}],
               [],_,undeclared} ->
                  ok;
              _ ->


### PR DESCRIPTION
Improves accumulator fun in `xmerl_scan` so that only one `#xmlText` record is returned for strings which have character references (e.g. `&#246;`). 

Today:

```
> xmerl_scan:string("<name>Jimmy Z&#246;ger</name>").
{{xmlElement,name,name,[],
             {xmlNamespace,[],[]},
             [],1,[],
             [{xmlText,[{name,1}],1,[],"Jimmy Z",text},
              {xmlText,[{name,1}],2,[],"öger",text}],
             [],"/Users/jyzr/",undeclared},
 []}
```

As I see it, only one `#xmlText` record should be in the content of the `#xmlElement`. If there's a reason for the current behaviour, please enlighten me :)

I have not run the suites locally, hopefully there's a bot which will help me.