### PR TITLE
Fix unhandled exceptions in otp_internal module

### DIFF
--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -548,7 +548,7 @@ obsolete_1(queue, lait, 1) ->
 obsolete_1(overload, _, _) ->
     {removed, "removed in OTP 19"};
 obsolete_1(rpc, safe_multi_server_call, A) when A =:= 2; A =:= 3 ->
-    {removed, {rpc, multi_server_call, A}};
+    {removed, {rpc, multi_server_call, A}, "removed in OTP 19"};
 
 %% Added in OTP 20.
 


### PR DESCRIPTION
The following calls:
  - `otp_internal:obsolete(rpc, safe_multi_server_call, 2).`
  - `otp_internal:obsolete(rpc, safe_multi_server_call, 3).`

throw an unhandled exception.

The return value of `obsolete_1/3` is amended to match the relevant pattern of `obsolete/3`.

This bug was found using [CutEr](https://github.com/aggelgian/cuter).