### PR TITLE
Support generation of strong random numbers

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -429,6 +429,7 @@ static ERL_NIF_TERM aes_ige_crypt_nif(ErlNifEnv* env, int argc, const ERL_NIF_TE
 static ERL_NIF_TERM aes_ctr_stream_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM aes_ctr_stream_encrypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM strong_rand_bytes_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+static ERL_NIF_TERM strong_rand_uniform_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM rand_uniform_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM mod_exp_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM dss_verify_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
@@ -501,6 +502,7 @@ static ErlNifFunc nif_funcs[] = {
     {"aes_ctr_stream_encrypt", 2, aes_ctr_stream_encrypt},
     {"aes_ctr_stream_decrypt", 2, aes_ctr_stream_encrypt},
     {"strong_rand_bytes_nif", 1, strong_rand_bytes_nif},
+    {"strong_rand_uniform_nif", 2, strong_rand_uniform_nif},
     {"rand_uniform_nif", 2, rand_uniform_nif},
     {"mod_exp_nif", 4, mod_exp_nif},
     {"dss_verify_nif", 4, dss_verify_nif},
@@ -2329,6 +2331,38 @@ static ERL_NIF_TERM bin_from_bn(ErlNifEnv* env, const BIGNUM *bn)
     BN_bn2bin(bn, bin_ptr);
 
     return term;
+}
+
+static ERL_NIF_TERM strong_rand_uniform_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{/* (Lo,Hi) */
+    BIGNUM *bn_from = NULL, *bn_to, *bn_rand;
+    unsigned char* data;
+    unsigned dlen;
+    ERL_NIF_TERM ret;
+
+    if (!get_bn_from_mpint(env, argv[0], &bn_from)
+	|| !get_bn_from_mpint(env, argv[1], &bn_rand)) {
+	if (bn_from) BN_free(bn_from);
+	return enif_make_badarg(env);
+    }
+
+    bn_to = BN_new();
+    BN_sub(bn_to, bn_rand, bn_from);
+    if (BN_rand_range(bn_rand, bn_to) != 1) {
+        ret = atom_false;
+    }
+    else {
+        BN_add(bn_rand, bn_rand, bn_from);
+        dlen = BN_num_bytes(bn_rand);
+        data = enif_make_new_binary(env, dlen+4, &ret);
+        put_int32(data, dlen);
+        BN_bn2bin(bn_rand, data+4);
+        ERL_VALGRIND_MAKE_MEM_DEFINED(data+4, dlen);
+    }
+    BN_free(bn_rand);
+    BN_free(bn_from);
+    BN_free(bn_to);
+    return ret;
 }
 
 static ERL_NIF_TERM rand_uniform_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -742,7 +742,7 @@
 
         <p><em>Example</em></p>
         <pre>
-crypto:rand_seed(),
+_ = crypto:rand_seed(),
 _IntegerValue = rand:uniform(42), % [1; 42]
 _FloatValue = rand:uniform().     % [0.0; 1.0]</pre>
       </desc>

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -658,10 +658,13 @@
       </type>
       <desc>
         <p>Set the seed for PRNG to the given binary. This calls the
-	RAND_seed function from openssl. Only use this if the system
-	you are running on does not have enough "randomness" built in.
-	Normally this is when <seealso marker="#strong_rand_bytes/1">
-	strong_rand_bytes/1</seealso> returns <c>low_entropy</c></p>
+        RAND_seed function from openssl. Only use this if the system
+        you are running on does not have enough "randomness" built in.
+        Normally this is when either
+        <seealso marker="#strong_rand_bytes/1">strong_rand_bytes/1</seealso>,
+        <seealso marker="#strong_rand_uniform/0">strong_rand_uniform/0</seealso> or
+        <seealso marker="#strong_rand_uniform/1">strong_rand_uniform/1</seealso>
+        throws <c>low_entropy</c></p>
       </desc>
     </func>
 
@@ -728,6 +731,41 @@
 	failed due to lack of secure "randomness".</p>
       </desc>
     </func>
+
+    <func>
+      <name>strong_rand_uniform() -> X</name>
+      <fsummary>Generate a random floating point number between 0.0 and 1.0</fsummary>
+      <type>
+        <v>X = float()</v>
+      </type>
+      <desc>
+        <p>Generates a random floating pointer number uniformly distributed
+        in the value range <c><![CDATA[X, 0.0 < X < 1.0.]]></c>
+        Uses a cryptographically secure prng seeded and periodically mixed with operating system
+        provided entropy. By default this is the <c>BN_rand_range</c> method from OpenSSL.</p>
+        <p>May throw exception <c>low_entropy</c> in case the random generator
+        failed due to lack of secure "randomness".</p>
+        <note><p>The generated values shall present no more than 51 bits of effective entropy.</p></note>
+      </desc>
+    </func>
+
+    <func>
+      <name>strong_rand_uniform(N) -> X</name>
+      <fsummary>Generate a random positive integer between 1 and N</fsummary>
+      <type>
+        <v>N = pos_integer()</v>
+        <v>X = 1..N</v>
+      </type>
+      <desc>
+        <p>Generates a a random positive integer uniformly distributed
+        in the value range <c><![CDATA[X, 1 =< X =< N.]]></c>
+        Uses a cryptographically secure prng seeded and periodically mixed with operating system
+        provided entropy. By default this is the <c>BN_rand_range</c> method from OpenSSL.</p>
+        <p>May throw exception <c>low_entropy</c> in case the random generator
+        failed due to lack of secure "randomness".</p>
+      </desc>
+    </func>
+
     <func>
       <name>stream_init(Type, Key) -> State</name>
       <fsummary></fsummary>

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -660,10 +660,8 @@
         <p>Set the seed for PRNG to the given binary. This calls the
         RAND_seed function from openssl. Only use this if the system
         you are running on does not have enough "randomness" built in.
-        Normally this is when either
-        <seealso marker="#strong_rand_bytes/1">strong_rand_bytes/1</seealso>,
-        <seealso marker="#strong_rand_range/1">strong_rand_range/1</seealso> or
-        <seealso marker="#strong_rand_float/0">strong_rand_float/0</seealso>
+        Normally this is when
+        <seealso marker="#strong_rand_bytes/1">strong_rand_bytes/1</seealso>
         throws <c>low_entropy</c></p>
       </desc>
     </func>
@@ -729,40 +727,6 @@
         this is the <c>RAND_bytes</c> method from OpenSSL.</p>
 	<p>May throw exception <c>low_entropy</c> in case the random generator
 	failed due to lack of secure "randomness".</p>
-      </desc>
-    </func>
-
-    <func>
-      <name>strong_rand_range(N) -> binary()</name>
-      <fsummary>Generate a random non-negative integer between 0 and N</fsummary>
-      <type>
-        <v>N = pos_integer() | binary()</v>
-      </type>
-      <desc>
-        <p>Generates a random non-negative integer uniformly distributed
-        in the value range <c><![CDATA[X, 0 =< X < N.]]></c>
-        Uses a cryptographically secure prng seeded and periodically mixed with operating system
-        provided entropy. By default this is the <c>BN_rand_range</c> method from OpenSSL.</p>
-        <p>Returns binary representation.</p>
-        <p>May throw exception <c>low_entropy</c> in case the random generator
-        failed due to lack of secure "randomness".</p>
-      </desc>
-    </func>
-
-    <func>
-      <name>strong_rand_float() -> X</name>
-      <fsummary>Generate a random floating point number between 0.0 and 1.0</fsummary>
-      <type>
-        <v>X = float()</v>
-      </type>
-      <desc>
-        <p>Generates a random floating pointer number uniformly distributed
-        in the value range <c><![CDATA[X, 0.0 =< X < 1.0.]]></c>
-        Uses a cryptographically secure prng seeded and periodically mixed with operating system
-        provided entropy. By default this is the <c>BN_rand_range</c> method from OpenSSL.</p>
-        <p>May throw exception <c>low_entropy</c> in case the random generator
-        failed due to lack of secure "randomness".</p>
-        <note><p>The generated values shall present no more than 51 bits of effective entropy.</p></note>
       </desc>
     </func>
 

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -744,7 +744,7 @@
         <pre>
 _ = crypto:rand_seed(),
 _IntegerValue = rand:uniform(42), % [1; 42]
-_FloatValue = rand:uniform().     % [0.0; 1.0]</pre>
+_FloatValue = rand:uniform().     % [0.0; 1.0[</pre>
       </desc>
     </func>
 

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -662,8 +662,8 @@
         you are running on does not have enough "randomness" built in.
         Normally this is when either
         <seealso marker="#strong_rand_bytes/1">strong_rand_bytes/1</seealso>,
-        <seealso marker="#strong_rand_uniform/0">strong_rand_uniform/0</seealso> or
-        <seealso marker="#strong_rand_uniform/1">strong_rand_uniform/1</seealso>
+        <seealso marker="#strong_rand_range/1">strong_rand_range/1</seealso> or
+        <seealso marker="#strong_rand_float/0">strong_rand_float/0</seealso>
         throws <c>low_entropy</c></p>
       </desc>
     </func>
@@ -733,36 +733,36 @@
     </func>
 
     <func>
-      <name>strong_rand_uniform() -> X</name>
+      <name>strong_rand_range(N) -> binary()</name>
+      <fsummary>Generate a random non-negative integer between 0 and N</fsummary>
+      <type>
+        <v>N = pos_integer() | binary()</v>
+      </type>
+      <desc>
+        <p>Generates a random non-negative integer uniformly distributed
+        in the value range <c><![CDATA[X, 0 =< X < N.]]></c>
+        Uses a cryptographically secure prng seeded and periodically mixed with operating system
+        provided entropy. By default this is the <c>BN_rand_range</c> method from OpenSSL.</p>
+        <p>Returns binary representation.</p>
+        <p>May throw exception <c>low_entropy</c> in case the random generator
+        failed due to lack of secure "randomness".</p>
+      </desc>
+    </func>
+
+    <func>
+      <name>strong_rand_float() -> X</name>
       <fsummary>Generate a random floating point number between 0.0 and 1.0</fsummary>
       <type>
         <v>X = float()</v>
       </type>
       <desc>
         <p>Generates a random floating pointer number uniformly distributed
-        in the value range <c><![CDATA[X, 0.0 < X < 1.0.]]></c>
+        in the value range <c><![CDATA[X, 0.0 =< X < 1.0.]]></c>
         Uses a cryptographically secure prng seeded and periodically mixed with operating system
         provided entropy. By default this is the <c>BN_rand_range</c> method from OpenSSL.</p>
         <p>May throw exception <c>low_entropy</c> in case the random generator
         failed due to lack of secure "randomness".</p>
         <note><p>The generated values shall present no more than 51 bits of effective entropy.</p></note>
-      </desc>
-    </func>
-
-    <func>
-      <name>strong_rand_uniform(N) -> X</name>
-      <fsummary>Generate a random positive integer between 1 and N</fsummary>
-      <type>
-        <v>N = pos_integer()</v>
-        <v>X = 1..N</v>
-      </type>
-      <desc>
-        <p>Generates a a random positive integer uniformly distributed
-        in the value range <c><![CDATA[X, 1 =< X =< N.]]></c>
-        Uses a cryptographically secure prng seeded and periodically mixed with operating system
-        provided entropy. By default this is the <c>BN_rand_range</c> method from OpenSSL.</p>
-        <p>May throw exception <c>low_entropy</c> in case the random generator
-        failed due to lack of secure "randomness".</p>
       </desc>
     </func>
 

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -767,6 +767,35 @@
     </func>
 
     <func>
+      <name>rand_seed() -> rand:state()</name>
+      <fsummary>Strong random number generation plugin state</fsummary>>
+      <desc>
+        Creates state object for <seealso marker="stdlib:rand">random number generation</seealso>,
+        in order to generate cryptographically strong random numbers
+        (based on OpenSSL's <c>BN_rand_range</c>),
+        and saves it on process dictionary before returning it as well.
+        See also <seealso marker="stdlib:rand#seed-1">rand:seed/1</seealso>
+
+        <p><em>Example</em></p>
+        <pre>
+crypto:rand_seed(),
+_IntegerValue = rand:uniform(42), % [1; 42]
+_FloatValue = rand:uniform().     % [0.0; 1.0]</pre>
+      </desc>
+    </func>
+
+    <func>
+      <name>rand_seed_s() -> rand:state()</name>
+      <fsummary>Strong random number generation plugin state</fsummary>>
+      <desc>
+        Creates state object for <seealso marker="stdlib:rand">random number generation</seealso>,
+        in order to generate cryptographically strongly random numbers
+        (based on OpenSSL's <c>BN_rand_range</c>).
+        See also <seealso marker="stdlib:rand#seed_s-1">rand:seed_s/1</seealso>
+      </desc>
+    </func>
+
+    <func>
       <name>stream_init(Type, Key) -> State</name>
       <fsummary></fsummary>
       <type>

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -32,6 +32,10 @@
 -export([exor/2, strong_rand_bytes/1, mod_pow/3]).
 -export([rand_seed/0]).
 -export([rand_seed_s/0]).
+-export([rand_plugin_next/1]).
+-export([rand_plugin_uniform/1]).
+-export([rand_plugin_uniform/2]).
+-export([rand_plugin_jump/1]).
 -export([rand_uniform/2]).
 -export([block_encrypt/3, block_decrypt/3, block_encrypt/4, block_decrypt/4]).
 -export([next_iv/2, next_iv/3]).
@@ -305,12 +309,12 @@ rand_seed() ->
     rand:seed(rand_seed_s()).
 
 rand_seed_s() ->
-    {#{ type => crypto,
+    {#{ type => ?MODULE,
         max => infinity,
-        next => fun rand_plugin_next/1,
-        uniform => fun rand_plugin_uniform/1,
-        uniform_n => fun rand_plugin_uniform/2,
-        jump => fun rand_plugin_jump/1},
+        next => fun ?MODULE:rand_plugin_next/1,
+        uniform => fun ?MODULE:rand_plugin_uniform/1,
+        uniform_n => fun ?MODULE:rand_plugin_uniform/2,
+        jump => fun ?MODULE:rand_plugin_jump/1},
      no_seed}.
 
 rand_plugin_next(Seed) ->

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -30,8 +30,8 @@
 -export([hmac/3, hmac/4, hmac_init/2, hmac_update/2, hmac_final/1, hmac_final_n/2]).
 -export([cmac/3, cmac/4]).
 -export([exor/2, strong_rand_bytes/1, mod_pow/3]).
--export([strong_rand_uniform/0]).
--export([strong_rand_uniform/1]).
+-export([strong_rand_range/1]).
+-export([strong_rand_float/0]).
 -export([rand_uniform/2]).
 -export([block_encrypt/3, block_decrypt/3, block_encrypt/4, block_decrypt/4]).
 -export([next_iv/2, next_iv/3]).
@@ -288,8 +288,8 @@ stream_decrypt(State, Data0) ->
 %% RAND - pseudo random numbers using RN_ and BN_ functions in crypto lib
 %%
 -spec strong_rand_bytes(non_neg_integer()) -> binary().
--spec strong_rand_uniform() -> float().
--spec strong_rand_uniform(pos_integer()) -> pos_integer().
+-spec strong_rand_range(pos_integer() | binary()) -> binary().
+-spec strong_rand_float() -> float().
 -spec rand_uniform(crypto_integer(), crypto_integer()) ->
 			  crypto_integer().
 
@@ -301,36 +301,28 @@ strong_rand_bytes(Bytes) ->
 strong_rand_bytes_nif(_Bytes) -> ?nif_stub.
 
 
-strong_rand_uniform() ->
-    Sign = 0, % positive
-    Exponent = 1023, % on the interval [1.0, 2.0[
-    Fraction = strong_rand_uniform(1, 1 bsl 52), % the whole interval above (except 1.0)
-    <<Value:64/big-float>> = <<Sign:1, Exponent:11, Fraction:52>>,
-    Value - 1.0.
-
-strong_rand_uniform(N) when is_integer(N), N >= 1 ->
-    1 + strong_rand_uniform(0, N).
-
-strong_rand_uniform(From, To) when is_binary(From), is_binary(To) ->
-    case strong_rand_uniform_nif(From,To) of
+strong_rand_range(Range) when is_integer(Range), Range > 0 ->
+    BinRange = int_to_bin(Range),
+    strong_rand_range(BinRange);
+strong_rand_range(BinRange) when is_binary(BinRange) ->
+    case strong_rand_range_nif(BinRange) of
         false ->
             erlang:error(low_entropy);
-        <<Len:32/integer, MSB, Rest/binary>> when MSB > 127 ->
-            <<(Len + 1):32/integer, 0, MSB, Rest/binary>>;
-        Whatever ->
-            Whatever
-    end;
-strong_rand_uniform(From, To) when is_integer(From), is_integer(To), From < To ->
-    BinFrom = mpint(From),
-    BinTo = mpint(To),
-    case strong_rand_uniform(BinFrom, BinTo) of
-        Result when is_binary(Result) ->
-            erlint(Result);
-        Other ->
-            Other
+        <<BinResult/binary>> ->
+            BinResult
     end.
 
-strong_rand_uniform_nif(_From, _To) -> ?nif_stub.
+strong_rand_range_nif(_BinRange) -> ?nif_stub.
+
+
+strong_rand_float() ->
+    % This could be optimized by having its own NIF
+    Sign = 0, % positive
+    Exponent = 1023, % on the interval [1.0, 2.0[
+    BinFraction = strong_rand_range(1 bsl 52), % the whole interval above
+    Fraction = bin_to_int(BinFraction),
+    <<Value:64/big-float>> = <<Sign:1, Exponent:11, Fraction:52>>,
+    Value - 1.0.
 
 
 rand_uniform(From,To) when is_binary(From), is_binary(To) ->

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -30,8 +30,6 @@
 -export([hmac/3, hmac/4, hmac_init/2, hmac_update/2, hmac_final/1, hmac_final_n/2]).
 -export([cmac/3, cmac/4]).
 -export([exor/2, strong_rand_bytes/1, mod_pow/3]).
--export([strong_rand_range/1]).
--export([strong_rand_float/0]).
 -export([rand_seed/0]).
 -export([rand_seed_s/0]).
 -export([rand_uniform/2]).
@@ -290,8 +288,6 @@ stream_decrypt(State, Data0) ->
 %% RAND - pseudo random numbers using RN_ and BN_ functions in crypto lib
 %%
 -spec strong_rand_bytes(non_neg_integer()) -> binary().
--spec strong_rand_range(pos_integer() | binary()) -> binary().
--spec strong_rand_float() -> float().
 -spec rand_seed() -> rand:state().
 -spec rand_seed_s() -> rand:state().
 -spec rand_uniform(crypto_integer(), crypto_integer()) ->
@@ -303,29 +299,6 @@ strong_rand_bytes(Bytes) ->
         Bin -> Bin
     end.
 strong_rand_bytes_nif(_Bytes) -> ?nif_stub.
-
-
-strong_rand_range(Range) when is_integer(Range), Range > 0 ->
-    BinRange = int_to_bin(Range),
-    strong_rand_range(BinRange);
-strong_rand_range(BinRange) when is_binary(BinRange) ->
-    case strong_rand_range_nif(BinRange) of
-        false ->
-            erlang:error(low_entropy);
-        <<BinResult/binary>> ->
-            BinResult
-    end.
-strong_rand_range_nif(_BinRange) -> ?nif_stub.
-
-
-strong_rand_float() ->
-    % This could be optimized by having its own NIF
-    Sign = 0, % positive
-    Exponent = 1023, % on the interval [1.0, 2.0[
-    BinFraction = strong_rand_range(1 bsl 52), % the whole interval above
-    Fraction = bin_to_int(BinFraction),
-    <<Value:64/big-float>> = <<Sign:1, Exponent:11, Fraction:52>>,
-    Value - 1.0.
 
 
 rand_seed() ->
@@ -351,6 +324,27 @@ rand_plugin_uniform(Max, State) ->
 
 rand_plugin_jump(State) ->
     State.
+
+strong_rand_range(Range) when is_integer(Range), Range > 0 ->
+    BinRange = int_to_bin(Range),
+    strong_rand_range(BinRange);
+strong_rand_range(BinRange) when is_binary(BinRange) ->
+    case strong_rand_range_nif(BinRange) of
+        false ->
+            erlang:error(low_entropy);
+        <<BinResult/binary>> ->
+            BinResult
+    end.
+strong_rand_range_nif(_BinRange) -> ?nif_stub.
+
+strong_rand_float() ->
+    % This could be optimized by having its own NIF
+    Sign = 0, % positive
+    Exponent = 1023, % on the interval [1.0, 2.0[
+    BinFraction = strong_rand_range(1 bsl 52), % the whole interval above
+    Fraction = bin_to_int(BinFraction),
+    <<Value:64/big-float>> = <<Sign:1, Exponent:11, Fraction:52>>,
+    Value - 1.0.
 
 
 rand_uniform(From,To) when is_binary(From), is_binary(To) ->

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -37,8 +37,6 @@ all() ->
      mod_pow,
      exor,
      rand_uniform,
-     strong_rand_range,
-     strong_rand_float,
      rand_plugin,
      rand_plugin_s
     ].
@@ -488,44 +486,6 @@ rand_uniform() ->
 rand_uniform(Config) when is_list(Config) ->
     rand_uniform_aux_test(10),
     10 = byte_size(crypto:strong_rand_bytes(10)).
-
-%%--------------------------------------------------------------------
-strong_rand_range() ->
-    [{doc, "strong_rand_range testing"}].
-strong_rand_range(Config) when is_list(Config) ->
-    MaxCeiling = 1 bsl 32,
-    Ceilings = [1 | % edge case where only 0 can be generated
-                [binary:decode_unsigned(crypto:strong_rand_range(MaxCeiling), big)
-                 || _ <- lists:seq(1, 99)]],
-
-    allmap(
-      fun (Ceiling) ->
-              case Ceiling >= 0 andalso Ceiling < MaxCeiling of
-                  false ->
-                      {false, ct:fail({"Ceiling not in interval", Ceiling, 0, MaxCeiling})};
-                  true ->
-                      Samples = [binary:decode_unsigned(crypto:strong_rand_range(Ceiling), big)
-                                 || _ <- lists:seq(1, 100)],
-                      allmap(
-                        fun (V) ->
-                                (V >= 0 andalso V < Ceiling)
-                                orelse {false, ct:fail({"Sample not in interval", V, 0, Ceiling})}
-                        end,
-                        Samples)
-              end
-      end,
-      Ceilings).
-
-strong_rand_float() ->
-    [{doc, "strong_rand_float testing"}].
-strong_rand_float(Config) when is_list(Config) ->
-    Samples = [crypto:strong_rand_float() || _ <- lists:seq(1, 10000)],
-    allmap(
-       fun (V) ->
-               (V >= 0.0 andalso V < 1.0)
-               orelse {false, ct:fail({"Not in interval", V, 0.0, 1.0})}
-        end,
-       Samples).
 
 %%--------------------------------------------------------------------
 rand_plugin() ->

--- a/lib/stdlib/doc/src/rand.xml
+++ b/lib/stdlib/doc/src/rand.xml
@@ -120,18 +120,26 @@ S0 = rand:seed_s(exsplus),
 {SND0, S2} = rand:normal_s(S1),</pre>
 
     <note>
-      <p>This random number generator is not cryptographically
-        strong. If a strong cryptographic random number generator is
-        needed, use one of functions in the
-        <seealso marker="crypto:crypto"><c>crypto</c></seealso>
-        module, for example, <seealso marker="crypto:crypto">
-        <c>crypto:strong_rand_bytes/1</c></seealso>.</p>
+      <p>The builtin random number generator algorithms are not
+        cryptographically strong. If a cryptographically strong
+        random number generator is needed, use something like
+        <seealso marker="crypto:crypto#rand_seed-0"><c>crypto:rand_seed/0</c></seealso>.
+      </p>
     </note>
 
   </description>
   <datatypes>
     <datatype>
+      <name name="builtin_alg"/>
+    </datatype>
+    <datatype>
       <name name="alg"/>
+    </datatype>
+    <datatype>
+      <name name="alg_handler"/>
+    </datatype>
+    <datatype>
+      <name name="alg_seed"/>
     </datatype>
     <datatype>
       <name name="state"/>
@@ -216,7 +224,7 @@ S0 = rand:seed_s(exsplus),
       <desc>
         <marker id="seed-1"/>
         <p>Seeds random number generation with the specifed algorithm and
-          time-dependent data if <anno>AlgOrExpState</anno> is an algorithm.</p>
+          time-dependent data if <anno>AlgOrStateOrExpState</anno> is an algorithm.</p>
         <p>Otherwise recreates the exported seed in the process dictionary,
           and returns the state. See also
           <seealso marker="#export_seed-0"><c>export_seed/0</c></seealso>.</p>
@@ -237,7 +245,7 @@ S0 = rand:seed_s(exsplus),
       <fsummary>Seed random number generator.</fsummary>
       <desc>
         <p>Seeds random number generation with the specifed algorithm and
-          time-dependent data if <anno>AlgOrExpState</anno> is an algorithm.</p>
+          time-dependent data if <anno>AlgOrStateOrExpState</anno> is an algorithm.</p>
         <p>Otherwise recreates the exported seed and returns the state.
           See also <seealso marker="#export_seed-0">
           <c>export_seed/0</c></seealso>.</p>

--- a/lib/stdlib/src/rand.erl
+++ b/lib/stdlib/src/rand.erl
@@ -88,15 +88,15 @@ seed(Alg) ->
     seed_put(seed_s(Alg)).
 
 -spec seed_s(AlgOrStateOrExpState::builtin_alg() | state() | export_state()) -> state().
-seed_s(Alg) when is_atom(Alg) ->
-    seed_s(Alg, {erlang:phash2([{node(),self()}]),
-		 erlang:system_time(),
-		 erlang:unique_integer()});
 seed_s({AlgHandler, _Seed} = State) when is_map(AlgHandler) ->
     State;
 seed_s({Alg0, Seed}) ->
     {Alg,_SeedFun} = mk_alg(Alg0),
-    {Alg, Seed}.
+    {Alg, Seed};
+seed_s(Alg) ->
+    seed_s(Alg, {erlang:phash2([{node(),self()}]),
+		 erlang:system_time(),
+		 erlang:unique_integer()}).
 
 %% seed/2: seeds RNG with the algorithm and given values
 %% and returns the NEW state.

--- a/lib/stdlib/src/rand.erl
+++ b/lib/stdlib/src/rand.erl
@@ -58,7 +58,7 @@
 %% Algorithm state
 -type state() :: {alg_handler(), alg_seed()}.
 -type builtin_alg() :: exs64 | exsplus | exs1024.
--type alg() :: builtin_alg() | term().
+-type alg() :: builtin_alg() | atom().
 -type export_state() :: {alg(), alg_seed()}.
 -export_type([builtin_alg/0, alg/0, alg_handler/0, alg_seed/0, state/0, export_state/0]).
 


### PR DESCRIPTION
This PR proposes two new additions to the crypto module, both named `strong_rand_uniform,` for effortless generation of cryptographically secure numbers:

    crypto:strong_rand_uniform/0: generates floats on the open interval ]0.0, 1.0[
    crypto:strong_rand_uniform/1: generates integers on an arbitrary closed interval [1, N]

These follow the same interfaces as `rand:uniform/0` and `rand:uniform/1`, and both use OpenSSL's `BN_rand_range` method.

Generated floating point values are limited to an effective entropy of up to 51 bits but are expected to be uniformly distributed between 0.0 and 1.0.

Supersedes #1363.