### PR TITLE
set ERL_DRV_FLAG_SOFT_BUSY for sctp driver

### DIFF
--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -1218,7 +1218,7 @@ static struct erl_drv_entry sctp_inet_driver_entry =
     ERL_DRV_EXTENDED_MARKER,
     ERL_DRV_EXTENDED_MAJOR_VERSION,
     ERL_DRV_EXTENDED_MINOR_VERSION,
-    ERL_DRV_FLAG_USE_PORT_LOCKING,
+    ERL_DRV_FLAG_USE_PORT_LOCKING|ERL_DRV_FLAG_SOFT_BUSY,
     NULL,
     NULL, /* process_exit */
     inet_stop_select,


### PR DESCRIPTION
This patch is required in order to use sctp as a distributed Erlang protocol.

I don't know if this is all that is needed. I'm opening this PR in hopes to get feedback. I noticed that with `inet_tcp` the dist module uses `send` with `[force]` for `ticket`. There is not way to send this option to `inet_sctp:send` at this time and it does not send any options to `port_command`. Should that change?