### PR TITLE
Don't allow module names with non-latin1 characters

### DIFF
--- a/lib/stdlib/doc/src/unicode_usage.xml
+++ b/lib/stdlib/doc/src/unicode_usage.xml
@@ -62,6 +62,10 @@
 
 	<item><p>In Erlang/OTP 17.0, the encoding default for Erlang
 	source files was switched to UTF-8.</p></item>
+
+	<item><p>In Erlang/OTP 20.0, atoms and function can contain
+	Unicode characters. Module names are still restricted to
+	the ISO-Latin-1 range.</p></item>
       </list>
 
     <p>This section outlines the current Unicode support and gives some
@@ -339,9 +343,10 @@
       <tag>The language</tag>
       <item>
         <p>Having the source code in UTF-8 also allows you to write string
-          literals containing Unicode characters with code points &gt; 255,
-          although atoms, module names, and function names are restricted to
-          the ISO Latin-1 range. Binary literals, where you use type
+          literals, function names, and atoms containing Unicode
+	  characters with code points &gt; 255.
+          Module names are still restricted to the ISO Latin-1 range.
+	  Binary literals, where you use type
           <c>/utf8</c>, can also be expressed using Unicode characters &gt; 255.
           Having module names using characters other than 7-bit ASCII can cause
           trouble on operating systems with inconsistent file naming schemes,
@@ -432,15 +437,17 @@ external_charlist() = maybe_improper_list(char() | external_unicode_binary() |
 
   <section>
     <title>Basic Language Support</title>
-    <p><marker id="unicode_in_erlang"/>As from Erlang/OTP R16, Erlang source
-      files can be written in UTF-8 or bytewise (<c>latin1</c>) encoding. For
-      information about how to state the encoding of an Erlang source file, see
-      the <seealso marker="stdlib:epp#encoding"><c>epp(3)</c></seealso> module.
-      Strings and comments can be written using Unicode, but functions must
-      still be named using characters from the ISO Latin-1 character set, and
-      atoms are restricted to the same ISO Latin-1 range. These restrictions in
-      the language are of course independent of the encoding of the source
-      file.</p>
+    <p><marker id="unicode_in_erlang"/>As from Erlang/OTP R16, Erlang
+    source files can be written in UTF-8 or bytewise (<c>latin1</c>)
+    encoding. For information about how to state the encoding of an
+    Erlang source file, see the <seealso
+    marker="stdlib:epp#encoding"><c>epp(3)</c></seealso> module.  As
+    from Erlang/OTP R16, strings and comments can be written using
+    Unicode.  As from Erlang/OTP 20, also atoms and functions can be
+    written using Unicode. Modules names must still be named using
+    characters from the ISO Latin-1 character set.  (These
+    restrictions in the language are independent of the encoding of
+    the source file.)</p>
 
     <section>
       <title>Bit Syntax</title>

--- a/system/doc/reference_manual/character_set.xml
+++ b/system/doc/reference_manual/character_set.xml
@@ -102,13 +102,15 @@
       <tcaption>Character Classes</tcaption>
     </table>
     <p>In Erlang/OTP R16B the syntax of Erlang tokens was extended to
-       handle Unicode. The support is limited to
-       string literals and comments. Atoms, module names, and
-       function names are restricted to the ISO-Latin-1 range.
+       handle Unicode. The support was limited to
+       string literals and comments.
        More about the usage of Unicode in Erlang source files
        can be found in <seealso
        marker="stdlib:unicode_usage#unicode_in_erlang">STDLIB's User's
        Guide</seealso>.</p>
+       <p>From Erlang/OTP 20, atoms and function names are also allowed
+       to contain Unicode characters outside the ISO-Latin-1 range.
+       Module names are still restricted to the ISO-Latin-1 range.</p>
   </section>
   <section>
     <title>Source File Encoding</title>


### PR DESCRIPTION
In OTP 20, all Unicode characters are allowed in atoms.

However, we have decided that we will not allow non-latin1
characters in module names in OTP 20. This restriction may
be lifted in a future major release of OTP.

Enforce the restriction in erl_lint, so that it will be a
compilation error to have a module name containing non-latin1
characters. That means that tools such as debugger, xref,
dialyzer, syntax_tools, and so on, do not have to be modified
to handle non-latin1 module names.