### PR TITLE
Improve no-pie solution from bug report ERL-294

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2836,9 +2836,10 @@ if test X${enable_hipe} = Xyes && test X$ARCH = Xamd64; then
 		     saved_LDFLAGS=$LDFLAGS
 		     LDFLAGS="-no-pie $LDFLAGS"
 		     AC_TRY_LINK(,, [],
-			[AC_MSG_WARN([Linked does not accept option -no-pie])
-			 LDFLAGS=$saved_LDFLAGS])])
-
+			[LDFLAGS="-fno-PIE $saved_LDFLAGS"
+			 AC_TRY_LINK(,, [],
+			    [AC_MSG_WARN([Linked does not accept option -no-pie nor -fno-PIE])
+			     LDFLAGS=$saved_LDFLAGS])])])
 fi
 
 


### PR DESCRIPTION
Some linkers, for example on Gentoo Hardened, do not accept the -no-pie
flag but require the -fno-PIE flag instead.

Plus some white-space clean-up.