### PR TITLE
Omit port from Host header on redirect to well-known port

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -524,7 +524,7 @@ handle_request(Method, Url,
 	    Options       = request_options(Options0), 
 	    Sync          = proplists:get_value(sync,   Options),
 	    Stream        = proplists:get_value(stream, Options),
-	    Host2         = header_host(Scheme, Host, Port), 
+	    Host2         = http_request:normalize_host(Scheme, Host, Port),
 	    HeadersRecord = header_record(NewHeaders, Host2, HTTPOptions),
 	    Receiver      = proplists:get_value(receiver, Options),
 	    SocketOpts    = proplists:get_value(socket_opts, Options),
@@ -1033,14 +1033,6 @@ validate_verbose(BadValue) ->
 
 bad_option(Option, BadValue) ->
     throw({error, {bad_option, Option, BadValue}}).
-
-
-header_host(https, Host, 443 = _Port) ->
-    Host;
-header_host(http, Host, 80 = _Port) ->
-    Host;
-header_host(_Scheme, Host, Port) ->
-    Host ++ ":" ++ integer_to_list(Port).
 
 
 header_record(NewHeaders, Host, #http_options{version = Version}) ->

--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -362,8 +362,9 @@ redirect(Response = {StatusLine, Headers, Body}, Request) ->
 		    {ok, error(Request, Reason), Data};
 		%% Automatic redirection
 		{ok, {Scheme, _, Host, Port, Path,  Query}} -> 
+		    HostPort = http_request:normalize_host(Scheme, Host, Port),
 		    NewHeaders = 
-			(Request#request.headers)#http_request_h{host = Host++":"++integer_to_list(Port)},
+			(Request#request.headers)#http_request_h{host = HostPort},
 		    NewRequest = 
 			Request#request{redircount = 
 					Request#request.redircount+1,

--- a/lib/inets/src/http_lib/http_request.erl
+++ b/lib/inets/src/http_lib/http_request.erl
@@ -22,7 +22,7 @@
 
 -include("http_internal.hrl").
 
--export([headers/2, http_headers/1, is_absolut_uri/1, key_value/1]).
+-export([headers/2, http_headers/1, is_absolut_uri/1, key_value/1, normalize_host/3]).
 
 
 key_value(KeyValueStr) ->
@@ -84,6 +84,22 @@ is_absolut_uri("https://" ++ _) ->
     true;
 is_absolut_uri(_) ->
     false.
+
+%%-------------------------------------------------------------------------
+%% normalize_host(Scheme, Host, Port) -> string()
+%%   Scheme - http | https
+%%   Host - string()
+%%   Port - integer()
+%%
+%% Description: returns a normalized Host header value, with the port
+%% number omitted for well-known ports
+%%-------------------------------------------------------------------------
+normalize_host(https, Host, 443 = _Port) ->
+    Host;
+normalize_host(http, Host, 80 = _Port) ->
+    Host;
+normalize_host(_Scheme, Host, Port) ->
+    Host ++ ":" ++ integer_to_list(Port).
 
 %%%========================================================================
 %%% Internal functions


### PR DESCRIPTION
ERL-316, as part of 19.3, adds the port number to the Host header
upon automatic redirection. The port number is included even if it
is a well-known port (80, 443). This is different from the
behaviour of most HTTP clients, as well as httpc's own for new
requests.

The added port number can lead to problems such as this one, where
the request signature assumes the client will not send the :443
suffix on redirection to an https URL:
https://github.com/nerves-project/nerves/issues/96

I was unable to add a test case, since that would require a server
on a well-known port, but I manually verified that the GitHub/S3
signing issue was indeed resolved with this patch.