### PR TITLE
hipe: Fix alignment of byte-sized constants

### DIFF
--- a/lib/hipe/arm/hipe_arm_assemble.erl
+++ b/lib/hipe/arm/hipe_arm_assemble.erl
@@ -38,7 +38,7 @@ assemble(CompiledCode, Closures, Exports, Options) ->
 	  || {MFA, Defun} <- CompiledCode],
   %%
   {ConstAlign,ConstSize,ConstMap,RefsFromConsts} =
-    hipe_pack_constants:pack_constants(Code, 4),
+    hipe_pack_constants:pack_constants(Code),
   %%
   {CodeSize,CodeBinary,AccRefs,LabelMap,ExportMap} =
     encode(translate(Code, ConstMap), Options),

--- a/lib/hipe/llvm/hipe_llvm_merge.erl
+++ b/lib/hipe/llvm/hipe_llvm_merge.erl
@@ -13,7 +13,7 @@ finalize(CompiledCode, Closures, Exports) ->
   Code = [{MFA, [], ConstTab}
 	  || {MFA, _, _ , ConstTab, _, _} <- CompiledCode1],
   {ConstAlign, ConstSize, ConstMap, RefsFromConsts} =
-    hipe_pack_constants:pack_constants(Code, ?ARCH_REGISTERS:alignment()),
+    hipe_pack_constants:pack_constants(Code),
   %% Compute total code size separately as a sanity check for alignment
   CodeSize = compute_code_size(CompiledCode1, 0),
   %% io:format("Code Size (pre-computed): ~w~n", [CodeSize]),

--- a/lib/hipe/misc/hipe_consttab.erl
+++ b/lib/hipe/misc/hipe_consttab.erl
@@ -193,7 +193,7 @@ insert_block({ConstTab, RefToLabels, NextLabel}, ElementType, InitList) ->
   ReferredLabels = get_labels(InitList, []),
   NewRefTo = ReferredLabels ++ RefToLabels,
   {NewTa, Id} = insert_const({ConstTab, NewRefTo, NextLabel}, 
-			     block, word_size(), false,
+			     block, size_of(ElementType), false,
 			     {ElementType,InitList}),
   {insert_backrefs(NewTa, Id, ReferredLabels), Id}.
 

--- a/lib/hipe/misc/hipe_consttab.erl
+++ b/lib/hipe/misc/hipe_consttab.erl
@@ -69,9 +69,7 @@
 %%    A hipe_consttab is a tuple {Data, ReferedLabels, NextConstLabel}
 %% @type hipe_constlbl().
 %%   An abstract datatype for referring to data.
-%% @type element_type() = byte | word | ctab_array()
-%% @type ctab_array() = {ctab_array, Type::element_type(),
-%%                                   NoElements::pos_integer()}
+%% @type element_type() = byte | word
 %% @type block() = [integer() | label_ref()]
 %% @type label_ref() = {label, Label::code_label()}
 %% @type code_label() = hipe_sparc:label_name() | hipe_x86:label_name()
@@ -116,8 +114,7 @@
 -type label_ref()    :: {'label', code_label()}.
 -type block()	     :: [hipe_constlbl() | label_ref()].
 
--type ctab_array()   :: {'ctab_array', 'byte' | 'word', pos_integer()}.
--type element_type() :: 'byte' | 'word' | ctab_array().
+-type element_type() :: 'byte' | 'word'.
 
 -type sort_order()   :: term(). % XXX: FIXME
 
@@ -262,13 +259,9 @@ get_labels([], Acc) ->
   
 %% @spec size_of(element_type()) -> pos_integer()
 %% @doc Returns the size in bytes of an element_type.
-%%  The is_atom/1 guard in the clause handling arrays
-%%  constraints the argument to 'byte' | 'word'
 -spec size_of(element_type()) -> pos_integer().
 size_of(byte) -> 1;
-size_of(word) -> word_size();
-size_of({ctab_array,S,N}) when is_atom(S), is_integer(N), N > 0 ->
-    N * size_of(S).
+size_of(word) -> word_size().
 
 %% @spec decompose({element_type(), block()}) -> [byte()]
 %% @doc Turns a block into a list of bytes.

--- a/lib/hipe/misc/hipe_pack_constants.erl
+++ b/lib/hipe/misc/hipe_pack_constants.erl
@@ -64,8 +64,8 @@
 -spec pack_constants([{mfa(),[_],hipe_consttab()}], ct_alignment()) ->
        {ct_alignment(), non_neg_integer(), packed_const_map(), mfa_refs_map()}.
 
-pack_constants(Data, Align) ->
-  pack_constants(Data, 0, Align, 0, [], []).
+pack_constants(Data, _Align) ->
+  pack_constants(Data, 0, 1, 0, [], []).
 
 pack_constants([{MFA,_,ConstTab}|Rest], Size, Align, ConstNo, Acc, Refs) ->
   Labels = hipe_consttab:labels(ConstTab),

--- a/lib/hipe/misc/hipe_pack_constants.erl
+++ b/lib/hipe/misc/hipe_pack_constants.erl
@@ -21,7 +21,7 @@
 %%
 
 -module(hipe_pack_constants).
--export([pack_constants/2, slim_refs/1, slim_constmap/1,
+-export([pack_constants/1, slim_refs/1, slim_constmap/1,
         find_const/2, mk_data_relocs/2, slim_sorted_exportmap/3]).
 
 -include("hipe_consttab.hrl").
@@ -45,8 +45,8 @@
 
 -record(pcm_entry, {mfa       :: mfa(),
 		    label     :: hipe_constlbl(),
-                   const_num :: const_num(),
-                   start     :: addr(),
+                    const_num :: const_num(),
+                    start     :: addr(),
 		    type      :: 0 | 1 | 2,
 		    raw_data  :: raw_data()}).
 -type pcm_entry() :: #pcm_entry{}.
@@ -61,11 +61,11 @@
 
 %%-----------------------------------------------------------------------------
 
--spec pack_constants([{mfa(),[_],hipe_consttab()}], ct_alignment()) ->
+-spec pack_constants([{mfa(),[_],hipe_consttab()}]) ->
        {ct_alignment(), non_neg_integer(), packed_const_map(), mfa_refs_map()}.
 
-pack_constants(Data, _Align) ->
-  pack_constants(Data, 0, 1, 0, [], []).
+pack_constants(Data) ->
+  pack_constants(Data, 0, 1, 0, [], []).	% 1 = byte alignment
 
 pack_constants([{MFA,_,ConstTab}|Rest], Size, Align, ConstNo, Acc, Refs) ->
   Labels = hipe_consttab:labels(ConstTab),

--- a/lib/hipe/ppc/hipe_ppc_assemble.erl
+++ b/lib/hipe/ppc/hipe_ppc_assemble.erl
@@ -40,7 +40,7 @@ assemble(CompiledCode, Closures, Exports, Options) ->
 	  || {MFA, Defun} <- CompiledCode],
   %%
   {ConstAlign,ConstSize,ConstMap,RefsFromConsts} =
-    hipe_pack_constants:pack_constants(Code, hipe_rtl_arch:word_size()),
+    hipe_pack_constants:pack_constants(Code),
   %%
   {CodeSize,CodeBinary,AccRefs,LabelMap,ExportMap} =
     encode(translate(Code, ConstMap), Options),

--- a/lib/hipe/sparc/hipe_sparc_assemble.erl
+++ b/lib/hipe/sparc/hipe_sparc_assemble.erl
@@ -39,7 +39,7 @@ assemble(CompiledCode, Closures, Exports, Options) ->
 	  || {MFA, Defun} <- CompiledCode],
   %%
   {ConstAlign,ConstSize,ConstMap,RefsFromConsts} =
-    hipe_pack_constants:pack_constants(Code, 4),
+    hipe_pack_constants:pack_constants(Code),
   %%
   {CodeSize,CodeBinary,AccRefs,LabelMap,ExportMap} =
     encode(translate(Code, ConstMap), Options),

--- a/lib/hipe/x86/hipe_x86_assemble.erl
+++ b/lib/hipe/x86/hipe_x86_assemble.erl
@@ -69,7 +69,7 @@ assemble(CompiledCode, Closures, Exports, Options) ->
 	  || {MFA, Defun} <- CompiledCode],
   %%
   {ConstAlign,ConstSize,ConstMap,RefsFromConsts} =
-    hipe_pack_constants:pack_constants(Code, ?HIPE_X86_REGISTERS:alignment()),
+    hipe_pack_constants:pack_constants(Code),
   %%
   {CodeSize,CodeBinary,AccRefs,LabelMap,ExportMap} =
     encode(translate(Code, ConstMap, Options), Options),


### PR DESCRIPTION
The first commit (Fix alignment of byte-sized constants) fixes a behavior seen on NetBSD/amd64 reported as ERL-376.  The other two commits cleanup the code that handles the constant table by removing code that is no longer used.