### PR TITLE
HiPE: Fix off-by-one bug in register allocators

### DIFF
--- a/lib/hipe/regalloc/hipe_coalescing_regalloc.erl
+++ b/lib/hipe/regalloc/hipe_coalescing_regalloc.erl
@@ -914,7 +914,7 @@ findCheapest([Node|Nodes], IG, Cost, Cheapest, SpillLimit) ->
 %% limit are extremely expensive.
 
 getCost(Node, IG, SpillLimit) ->
-  case Node > SpillLimit of
+  case Node >= SpillLimit of
     true -> inf;
     false -> hipe_ig:node_spill_cost(Node, IG)
   end.

--- a/lib/hipe/regalloc/hipe_graph_coloring_regalloc.erl
+++ b/lib/hipe/regalloc/hipe_graph_coloring_regalloc.erl
@@ -209,8 +209,8 @@ color(IG, Spill, PhysRegs, SpillIx, SpillLimit, NumNodes, Target,
 
   %% Any nodes above the spillimit must be colored first...
   MustNotSpill = 
-    if NumNodes > SpillLimit+1 ->
-	sort_on_degree(lists:seq(SpillLimit+1,NumNodes-1) -- Low,IG);
+    if NumNodes > SpillLimit ->
+	sort_on_degree(lists:seq(SpillLimit,NumNodes-1) -- Low,IG);
        true -> []
     end,
       
@@ -401,7 +401,7 @@ spill_costs([{N,Info}|Ns], IG, Vis, Spill, SpillLimit, Target) ->
 	    true ->
 	      spill_costs(Ns, IG, Vis, Spill, SpillLimit, Target);
 	    false ->
-	      if N > SpillLimit ->
+	      if N >= SpillLimit ->
 		  spill_costs(Ns, IG, Vis, Spill, SpillLimit, Target);
 		 true ->
 		  [{spill_cost_of(N,Spill)/Deg,N} | 

--- a/lib/hipe/regalloc/hipe_optimistic_regalloc.erl
+++ b/lib/hipe/regalloc/hipe_optimistic_regalloc.erl
@@ -1933,7 +1933,7 @@ findCheapest([Node|Nodes], IG, Cost, Cheapest, SpillLimit) ->
 %% limit are extremely expensive.
 
 getCost(Node, IG, SpillLimit) ->
-  case Node > SpillLimit of
+  case Node >= SpillLimit of
     true -> inf;
     false ->
       SpillCost = hipe_ig:node_spill_cost(Node, IG),


### PR DESCRIPTION
The register allocators accept a low-water mark called `SpillLimit`
which indicates which temporaries they must not spill. However, it
turns out they do not agree with `hipe_regalloc_loop`, which provides
`SpillLimit`, on whether it is an inclusive or exclusive bound.

This caused the register allocators to occasionally spill the first
"unspillable" temporary. This caused a failure in a newly added
assertion, added by #1380, when hipe-compiling `dets_v9` on x86.