### PR TITLE
Smoke test HiPE in the 32-bit build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       services:
         - docker
       script:
-        - ./scripts/build-docker-otp 32 sh -c "scripts/build-otp && ./otp_build tests && scripts/run-smoke-tests"
+        - ./scripts/build-docker-otp 32 sh -c "scripts/build-otp && ./otp_build tests && scripts/run-smoke-tests && bin/dialyzer --build_plt --apps erts kernel stdlib"
       after_success:
       after_script:
 


### PR DESCRIPTION
HiPE is tested when running dialyzer in the 64-bit build. To avoid
running out of memory or time, dialyzer is not run in the 32-bit
build job.

Do a smoke test of HiPE by letting dialyzer create a small PLT.

We could catch more bugs by using `configure --enable-native-libs`,
but I am worried that the build would not finish in 50 minutes
(the time limit for a Travis job).