### PR TITLE
Remove inets from runtime dependencies in tools

### DIFF
--- a/lib/tools/src/tools.app.src
+++ b/lib/tools/src/tools.app.src
@@ -41,7 +41,6 @@
 	]
   },
   {runtime_dependencies, ["stdlib-3.1","runtime_tools-1.8.14",
-			  "kernel-3.0","inets-5.10","erts-7.0",
-			  "compiler-5.0"]}
+			  "kernel-3.0","erts-7.0","compiler-5.0"]}
  ]
 }. 


### PR DESCRIPTION
Commit d8ff1e3 removed cover_web and therefore
tools no longer depends on inets.