### PR TITLE
Add a no_native option to modules with an on_load

### DIFF
--- a/lib/asn1/src/asn1rt_nif.erl
+++ b/lib/asn1/src/asn1rt_nif.erl
@@ -26,6 +26,7 @@
 	 decode_ber_tlv/1,
 	 encode_ber_tlv/1]).
 
+-compile(no_native).
 -on_load(load_nif/0).
 
 -define(ASN1_NIF_VSN,1).

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -56,6 +56,7 @@
 %%-type ec_curve() :: ec_named_curve() | ec_curve_spec().
 %%-type ec_key() :: {Curve :: ec_curve(), PrivKey :: binary() | undefined, PubKey :: ec_point() | undefined}.
 
+-compile(no_native).
 -on_load(on_load/0).
 -define(CRYPTO_NIF_VSN,302).
 

--- a/lib/runtime_tools/src/dyntrace.erl
+++ b/lib/runtime_tools/src/dyntrace.erl
@@ -61,8 +61,8 @@
          enabled_garbage_collection/3,
          enabled/3]).
 
-
 -export([user_trace_i4s4/9]). % Know what you're doing!
+-compile(no_native).
 -on_load(on_load/0).
 
 -type probe_arg() :: integer() | iolist().


### PR DESCRIPTION
This is a poor man's solution that allows to build and test the
Erlang/OTP system with all files compiled to native code simply
by setting the ERL_COMPILER_OPTS environment variable.
Better solutions, like automatically setting the no_native option
whenever the compiler sees an on_load attribute, obviously exist
but require more time to implement.