### PR TITLE
HiPE: Fix ERL-278: Fix range analysis miscompilation bug

### DIFF
--- a/lib/hipe/cerl/erl_bif_types.erl
+++ b/lib/hipe/cerl/erl_bif_types.erl
@@ -2029,17 +2029,14 @@ arith_rem(Min1, Max1, Min2, Max2) ->
   Min1_geq_zero = infinity_geq(Min1, 0),
   Max1_leq_zero = infinity_geq(0, Max1),
   Max_range2 = infinity_max([infinity_abs(Min2), infinity_abs(Max2)]),
-  Max_range2_leq_zero = infinity_geq(0, Max_range2),
-  New_min = 
+  New_min =
     if Min1_geq_zero -> 0;
        Max_range2 =:= 0 -> 0;
-       Max_range2_leq_zero -> infinity_add(Max_range2, 1);
        true -> infinity_add(infinity_inv(Max_range2), 1)
     end,
   New_max = 
     if Max1_leq_zero -> 0;
        Max_range2 =:= 0 -> 0;
-       Max_range2_leq_zero -> infinity_add(infinity_inv(Max_range2), -1);
        true -> infinity_add(Max_range2, -1)
     end,
   {New_min, New_max}.

--- a/lib/hipe/icode/hipe_icode_range.erl
+++ b/lib/hipe/icode/hipe_icode_range.erl
@@ -392,14 +392,14 @@ widen(#range{range=Old}, #range{range=New}, T = #range{range=Wide}) ->
 -spec analyse_call(#icode_call{}, call_fun()) -> #icode_call{}.
 
 analyse_call(Call, LookupFun) ->
+  Args = hipe_icode:args(Call),
+  Fun = hipe_icode:call_fun(Call),
+  Type = hipe_icode:call_type(Call),
+  DstRanges = analyse_call_or_enter_fun(Fun, Args, Type, LookupFun),
   case hipe_icode:call_dstlist(Call) of
     [] ->
       Call;
     Dsts ->
-      Args = hipe_icode:args(Call),
-      Fun = hipe_icode:call_fun(Call),
-      Type = hipe_icode:call_type(Call),
-      DstRanges = analyse_call_or_enter_fun(Fun, Args, Type, LookupFun),
       NewDefs = [update_info(Var, R) || {Var,R} <- lists:zip(Dsts, DstRanges)],
       hipe_icode:subst_defines(lists:zip(Dsts, NewDefs), Call)
   end.

--- a/lib/hipe/icode/hipe_icode_range.erl
+++ b/lib/hipe/icode/hipe_icode_range.erl
@@ -395,6 +395,9 @@ analyse_call(Call, LookupFun) ->
   Args = hipe_icode:args(Call),
   Fun = hipe_icode:call_fun(Call),
   Type = hipe_icode:call_type(Call),
+  %% This call has side-effects (it might call LookupFun which sends messages to
+  %% hipe_icode_coordinator to update the argument ranges of Fun), and must thus
+  %% not be moved into the case statement.
   DstRanges = analyse_call_or_enter_fun(Fun, Args, Type, LookupFun),
   case hipe_icode:call_dstlist(Call) of
     [] ->

--- a/lib/hipe/icode/hipe_icode_range.erl
+++ b/lib/hipe/icode/hipe_icode_range.erl
@@ -1306,16 +1306,15 @@ range_rem(Range1, Range2) ->
   Min1_geq_zero = inf_geq(Min1, 0),
   Max1_leq_zero = inf_geq(0, Max1),
   Max_range2 = inf_max([inf_abs(Min2), inf_abs(Max2)]),
-  Max_range2_leq_zero = inf_geq(0, Max_range2),
   New_min = 
     if Min1_geq_zero ->	0;
-       Max_range2_leq_zero -> Max_range2;
-       true -> inf_inv(Max_range2)
+       Max_range2 =:= 0 -> 0;
+       true -> inf_add(inf_inv(Max_range2), 1)
     end,
   New_max = 
     if Max1_leq_zero -> 0;
-       Max_range2_leq_zero -> inf_inv(Max_range2);
-       true -> Max_range2
+       Max_range2 =:= 0 -> 0;
+       true -> inf_add(Max_range2, -1)
     end,
   range_init({New_min, New_max}, false).
 


### PR DESCRIPTION
HiPE's range analysis would not update the arguments of a callee when the result of the call was ignored, leading to an infinite loop in the following code, ending up in the second clause even when `N=0`:

```erlang
-module(test).
 
-export([f/0]).
 
f() ->
    g(4).
 
g(0) ->
    io:format("called with N=0! We should STOP!~n");
g(N) ->
    io:format("called with N=~B~n", [N]),
    receive after 250 -> ok end,
    g(N - 1),
    io:format("call with N=~B exiting normally~n", [N]).
```
Bug reported as [ERL-278](https://bugs.erlang.org/browse/ERL-278) by Rich Neswold.

Also: Sneak in a fix for suboptimal range analysis of the `rem` operator: the ranges would be one number too large: for example, the call `rem(any(), 9)` would result in `-9..9`, when `-8..8` would be the desired output.