### PR TITLE
Crypto AES CFB 128 bugfix

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -1405,13 +1405,20 @@ static ERL_NIF_TERM block_crypt_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM
         return enif_raise_exception(env, atom_notsup);
     }
 
-    if ((argv[0] == atom_aes_cfb8 || argv[0] == atom_aes_cfb128)
+    if (argv[0] == atom_aes_cfb8
         && (key.size == 24 || key.size == 32)) {
         /* Why do EVP_CIPHER_CTX_set_key_length() fail on these key sizes?
          * Fall back on low level API
          */
         return aes_cfb_8_crypt(env, argc-1, argv+1);
     }
+    else if (argv[0] == atom_aes_cfb128
+        && (key.size == 24 || key.size == 32)) {
+        /* Why do EVP_CIPHER_CTX_set_key_length() fail on these key sizes?
+         * Fall back on low level API
+         */
+        return aes_cfb_128_crypt_nif(env, argc-1, argv+1);
+   }
 
     ivec_size  = EVP_CIPHER_iv_length(cipher);
 

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -822,6 +822,8 @@ sha_mac_96(Key, Data) -> hmac(sha, Key, Data, 12).
 block_crypt_nif(_Type, _Key, _Ivec, _Text, _IsEncrypt) -> ?nif_stub.
 block_crypt_nif(_Type, _Key, _Text, _IsEncrypt) -> ?nif_stub.
 
+aes_cfb_128_crypt_nif(_Key, _Ivec, _Text, _IsEncrypt) -> ?nif_stub.
+
 check_des3_key(Key) ->
     case lists:map(fun erlang:iolist_to_binary/1, Key) of
         ValidKey = [B1, B2, B3] when byte_size(B1) =:= 8,
@@ -915,7 +917,9 @@ blowfish_ofb64_encrypt(Key, IVec, Data) ->
 -spec aes_cfb_128_decrypt(iodata(), binary(), iodata()) -> binary().
 
 aes_cfb_128_encrypt(Key, IVec, Data) ->
-    block_encrypt(aes_cfb128, Key, IVec, Data).
+    %% block_encrypt(aes_cfb128, Key, IVec, Data).
+    aes_cfb_128_crypt_nif(Key, IVec, Data, true).
+
 
 aes_cfb_128_decrypt(Key, IVec, Data) ->
     block_decrypt(aes_cfb128, Key, IVec, Data).

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -358,6 +358,16 @@ block_cipher({Type, Key,  PlainText}) ->
 	    ct:fail({{crypto, block_decrypt, [Type, Key, CipherText]}, {expected, Plain}, {got, Other}})
     end;
 
+block_cipher({aes_cfb128, Key,  IV, PlainText}) ->
+    Plain = iolist_to_binary(PlainText),
+    CipherText = crypto:aes_cfb_128_encrypt(Key, IV, PlainText),
+    case crypto:block_decrypt(aes_cfb128, Key, IV, CipherText) of
+        Plain ->
+            ok;
+        Other ->
+            ct:fail({{crypto, block_decrypt, [aes_cfb128, Key, IV, CipherText]}, {expected, Plain}, {got, Other}})
+    end;
+
 block_cipher({Type, Key,  IV, PlainText}) ->
     Plain = iolist_to_binary(PlainText),
     CipherText = crypto:block_encrypt(Type, Key, IV, PlainText),


### PR DESCRIPTION
Demonstrate and fix a bug with AES CFB 128 for certain key sizes introduced
with the Erlang 19.0 release. The code in the `block_crypt_nif` function
in the crypto.c source file incorrectly calls `aes_cfb_8_crypt` when the
specified cipher is `aes_cfb8` *or* `aes_cfb128` and the key size is 24 or
32. The `aes_cfb_8_crypt` function calls the` AES_cfb8_encrypt` function
from the openssl interface, but this is incorrect when the cipher is
`aes_cfb128`.

Unfortunately the test cases in the crypto test suite are insufficient
to detect an issue like this because it exercises the encryption and
decryption roundtrip using the same incorrect underlying function. The
problem was observed when trying to update an application to Erlang 19
that attempted to decrypt data that was encrypted using `aes_cfb128` by
another source. 

The first commit contains changes to the crypto application and test suite to 
demonstrate the bug with a failing `aes_cfb128` test case. The second commit 
fixes the bug and the altered `aes_cfb128` test case passes.

I am happy to rework this for final submission to only include the net changes 
required to fix the bug and as a single commit, but I structured it as two 
commits to provide an easy way to show the problem and to demonstrate the 
fix works properly.

