### PR TITLE
Allow HiPE-enabled VMs to be built with --enable-m32-build

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -381,7 +381,6 @@ if test X${enable_m64_build} = Xyes; then
 else
 	if test X${enable_m32_build} = Xyes;
 	then
-		enable_hipe=no;
 		case $CFLAGS in
 		    *-m32*)
 			    ;;

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -642,10 +642,6 @@ dnl Ditto between ultrasparc and sparc64.
 dnl
 AC_MSG_CHECKING(whether compilation mode forces ARCH adjustment)
 case "$ARCH-$ac_cv_sizeof_void_p" in
-i386-8)
-	AC_MSG_RESULT(yes: adjusting ARCH=x86 to ARCH=amd64)
-	ARCH=amd64
-	;;
 x86-8)
 	AC_MSG_RESULT(yes: adjusting ARCH=x86 to ARCH=amd64)
 	ARCH=amd64
@@ -665,6 +661,14 @@ sparc64-4)
 ppc64-4)
 	AC_MSG_RESULT(yes: adjusting ARCH=ppc64 to ARCH=ppc)
 	ARCH=ppc
+	;;
+ppc-8)
+	AC_MSG_RESULT(yes: adjusting ARCH=ppc to ARCH=ppc64)
+	ARCH=ppc64
+	;;
+arm-8)
+	AC_MSG_RESULT(yes: adjusting ARCH=arm to ARCH=noarch)
+	ARCH=noarch
 	;;
 *)
 	AC_MSG_RESULT(no)

--- a/lib/hipe/llvm/Makefile
+++ b/lib/hipe/llvm/Makefile
@@ -73,8 +73,7 @@ include ../native.mk
 ERL_COMPILE_FLAGS += -Werror +inline +warn_export_vars #+warn_missing_spec
 
 # if in 32 bit backend define BIT32 symbol
-ARCH = $(shell echo $(TARGET) | sed 's/^\(x86_64\)-.*/64bit/')
-ifneq ($(ARCH), 64bit)
+ifneq ($(BITS64),yes)
 ERL_COMPILE_FLAGS += -DBIT32
 endif
 


### PR DESCRIPTION
For some reason, when the `--enable-m32-build` configure flag was introduced, it was made to imply `--disable-hipe`. However, there is no reason for this, as a fully working HiPE-enabled VM will be built even with `--enable-m32-build`.

The only exception is ErLLVM, which would effectively be targeting a 64-bit machine, and thus be nonfunctional. By having it explicitly tell `llc` which architecture it's supposed to be compiling for, ErLLVM now works even when running a 32-bit VM on a 64-bit OS.