### PR TITLE
Add enif_whereis() function

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -3002,6 +3002,63 @@ if (retval &amp; ERL_NIF_SELECT_STOP_CALLED) {
           <c>erl_drv_tsd_set</c></seealso>.</p>
       </desc>
     </func>
+
+    <func>
+      <name><ret>int</ret>
+        <nametext>enif_whereis_pid(ErlNifEnv *env,
+          ERL_NIF_TERM name, ErlNifPid *pid)</nametext></name>
+      <fsummary>Looks up a process by its registered name.</fsummary>
+      <desc>
+        <p>Looks up a process by its registered name.</p>
+        <taglist>
+          <tag><c>env</c></tag>
+          <item>The environment of the calling process. Must be <c>NULL</c>
+            only if calling from a created thread.</item>
+          <tag><c>name</c></tag>
+          <item>The name of a registered process, as an atom.</item>
+          <tag><c>*pid</c></tag>
+          <item>The <seealso marker="#ErlNifPid"><c>ErlNifPid</c></seealso>
+            in which the resolved process id is stored.</item>
+        </taglist>
+        <p>On success, sets <c>*pid</c> to the local process registered with
+          <c>name</c> and returns <c>true</c>. If <c>name</c> is not a
+          registered process, or is not an atom, <c>false</c> is returned and
+          <c>*pid</c> is unchanged.</p>
+        <p>Works as <seealso marker="erlang#whereis-1">
+          <c>erlang:whereis/1</c></seealso>, but restricted to processes. See
+          <seealso marker="#enif_whereis_port"><c>enif_whereis_port</c></seealso>
+          to resolve registered ports.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name><ret>int</ret>
+        <nametext>enif_whereis_port(ErlNifEnv *env,
+          ERL_NIF_TERM name, ErlNifPort *port)</nametext></name>
+      <fsummary>Looks up a port by its registered name.</fsummary>
+      <desc>
+        <p>Looks up a port by its registered name.</p>
+        <taglist>
+          <tag><c>env</c></tag>
+          <item>The environment of the calling process. Must be <c>NULL</c>
+            only if calling from a created thread.</item>
+          <tag><c>name</c></tag>
+          <item>The name of a registered port, as an atom.</item>
+          <tag><c>*port</c></tag>
+          <item>The <seealso marker="#ErlNifPort"><c>ErlNifPort</c></seealso>
+            in which the resolved port id is stored.</item>
+        </taglist>
+        <p>On success, sets <c>*port</c> to the port registered with
+          <c>name</c> and returns <c>true</c>. If <c>name</c> is not a
+          registered port, or is not an atom, <c>false</c> is returned and
+          <c>*port</c> is unchanged.</p>
+        <p>Works as <seealso marker="erlang#whereis-1">
+          <c>erlang:whereis/1</c></seealso>, but restricted to ports. See
+          <seealso marker="#enif_whereis_pid"><c>enif_whereis_pid</c></seealso>
+          to resolve registered processes.</p>
+      </desc>
+    </func>
+
   </funcs>
 
   <section>

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -181,6 +181,8 @@ ERL_NIF_API_FUNC_DECL(int, enif_monitor_process,(ErlNifEnv*,void* obj,const ErlN
 ERL_NIF_API_FUNC_DECL(int, enif_demonitor_process,(ErlNifEnv*,void* obj,const ErlNifMonitor *monitor));
 ERL_NIF_API_FUNC_DECL(int, enif_compare_monitors,(const ErlNifMonitor*,const ErlNifMonitor*));
 ERL_NIF_API_FUNC_DECL(ErlNifUInt64,enif_hash,(ErlNifHash type, ERL_NIF_TERM term, ErlNifUInt64 salt));
+ERL_NIF_API_FUNC_DECL(int, enif_whereis_pid, (ErlNifEnv *env, ERL_NIF_TERM name, ErlNifPid *pid));
+ERL_NIF_API_FUNC_DECL(int, enif_whereis_port, (ErlNifEnv *env, ERL_NIF_TERM name, ErlNifPort *port));
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
@@ -344,6 +346,8 @@ ERL_NIF_API_FUNC_DECL(ErlNifUInt64,enif_hash,(ErlNifHash type, ERL_NIF_TERM term
 #  define enif_demonitor_process ERL_NIF_API_FUNC_MACRO(enif_demonitor_process)
 #  define enif_compare_monitors ERL_NIF_API_FUNC_MACRO(enif_compare_monitors)
 #  define enif_hash ERL_NIF_API_FUNC_MACRO(enif_hash)
+#  define enif_whereis_pid ERL_NIF_API_FUNC_MACRO(enif_whereis_pid)
+#  define enif_whereis_port ERL_NIF_API_FUNC_MACRO(enif_whereis_port)
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment)

--- a/erts/emulator/test/dirty_nif_SUITE.erl
+++ b/erts/emulator/test/dirty_nif_SUITE.erl
@@ -34,7 +34,8 @@
 	 dirty_scheduler_exit/1, dirty_call_while_terminated/1,
 	 dirty_heap_access/1, dirty_process_info/1,
 	 dirty_process_register/1, dirty_process_trace/1,
-	 code_purge/1, dirty_nif_send_traced/1]).
+	 code_purge/1, dirty_nif_send_traced/1,
+	 nif_whereis/1, nif_whereis_parallel/1, nif_whereis_proxy/1]).
 
 -define(nif_stub,nif_stub_error(?LINE)).
 
@@ -51,7 +52,9 @@ all() ->
      dirty_process_register,
      dirty_process_trace,
      code_purge,
-     dirty_nif_send_traced].
+     dirty_nif_send_traced,
+     nif_whereis,
+     nif_whereis_parallel].
 
 init_per_suite(Config) ->
     case erlang:system_info(dirty_cpu_schedulers) of
@@ -531,6 +534,137 @@ mcall(Node, Funs) ->
                       end
               end, Refs).
 
+%% Test enif_whereis_...
+%% These tests are mostly identical to their counterparts in nif_SUITE.erl,
+%% with just name and count changes in the first few lines.
+
+nif_whereis(Config) when is_list(Config) ->
+    erl_ddll:try_load(?config(data_dir, Config), echo_drv, []),
+
+    RegName = dirty_nif_whereis_test_thing,
+    undefined = erlang:whereis(RegName),
+    false = whereis_term(pid, RegName),
+
+    Mgr = self(),
+    Ref = make_ref(),
+    ProcMsg = {Ref, ?LINE},
+    PortMsg = ?MODULE_STRING " whereis hello\n",
+
+    {Pid, Mon} = spawn_monitor(?MODULE, nif_whereis_proxy, [Ref]),
+    true = register(RegName, Pid),
+    Pid = erlang:whereis(RegName),
+    Pid = whereis_term(pid, RegName),
+    false = whereis_term(port, RegName),
+    false = whereis_term(pid, [RegName]),
+
+    ok = whereis_send(pid, RegName, {forward, Mgr, ProcMsg}),
+    ok = receive ProcMsg -> ok end,
+
+    Pid ! {Ref, quit},
+    ok = receive {'DOWN', Mon, process, Pid, normal} -> ok end,
+    undefined = erlang:whereis(RegName),
+    false = whereis_term(pid, RegName),
+
+    Port = open_port({spawn, echo_drv}, [eof]),
+    true = register(RegName, Port),
+    Port = erlang:whereis(RegName),
+    Port = whereis_term(port, RegName),
+    false = whereis_term(pid, RegName),
+    false = whereis_term(port, [RegName]),
+
+    ok = whereis_send(port, RegName, PortMsg),
+    ok = receive {Port, {data, PortMsg}} -> ok end,
+
+    port_close(Port),
+    undefined = erlang:whereis(RegName),
+    false = whereis_term(port, RegName),
+    ok.
+
+nif_whereis_parallel(Config) when is_list(Config) ->
+
+    %% try to be at least a little asymetric
+    NProcs = trunc(3.5 * erlang:system_info(schedulers)),
+    NSeq = lists:seq(1, NProcs),
+    Names = [list_to_atom("dirty_nif_whereis_proc_" ++ integer_to_list(N))
+            || N <- NSeq],
+    Mgr = self(),
+    Ref = make_ref(),
+
+    NotReg = fun(Name) ->
+        erlang:whereis(Name) == undefined
+    end,
+    PidReg = fun({Name, Pid, _Mon}) ->
+        erlang:whereis(Name) == Pid andalso whereis_term(pid, Name) == Pid
+    end,
+    RecvDown = fun({_Name, Pid, Mon}) ->
+        receive {'DOWN', Mon, process, Pid, normal} -> true
+        after   1500 -> false end
+    end,
+    RecvNum = fun(N) ->
+        receive {N, Ref} -> true
+        after   1500 -> false end
+    end,
+
+    true = lists:all(NotReg, Names),
+
+    %% {Name, Pid, Mon}
+    Procs = lists:map(
+        fun(N) ->
+            Name = lists:nth(N, Names),
+            Prev = lists:nth((if N == 1 -> NProcs; true -> (N - 1) end), Names),
+            Next = lists:nth((if N == NProcs -> 1; true -> (N + 1) end), Names),
+            {Pid, Mon} = spawn_monitor(
+                ?MODULE, nif_whereis_proxy, [{N, Ref, Mgr, [Prev, Next]}]),
+            true = register(Name, Pid),
+            {Name, Pid, Mon}
+        end, NSeq),
+
+    true = lists:all(PidReg, Procs),
+
+    %% tell them all to 'fire' as fast as we can
+    [P ! {Ref, send_proc} || {_, P, _} <- Procs],
+
+    %% each gets forwarded through two processes
+    true = lists:all(RecvNum, NSeq),
+    true = lists:all(RecvNum, NSeq),
+
+    %% tell them all to 'quit' by name
+    [N ! {Ref, quit} || {N, _, _} <- Procs],
+    true = lists:all(RecvDown, Procs),
+    true = lists:all(NotReg, Names),
+    ok.
+
+%% exported to be spawned by MFA by whereis tests
+nif_whereis_proxy({N, Ref, Mgr, Targets} = Args) ->
+    receive
+        {forward, To, Data} ->
+            To ! Data,
+            nif_whereis_proxy(Args);
+        {Ref, quit} ->
+            ok;
+        {Ref, send_port} ->
+            Msg = ?MODULE_STRING " whereis " ++ integer_to_list(N) ++ "\n",
+            lists:foreach(
+                fun(T) ->
+                    ok = whereis_send(port, T, Msg)
+                end, Targets),
+            nif_whereis_proxy(Args);
+        {Ref, send_proc} ->
+            lists:foreach(
+                fun(T) ->
+                    ok = whereis_send(pid, T, {forward, Mgr, {N, Ref}})
+                end, Targets),
+            nif_whereis_proxy(Args)
+    end;
+nif_whereis_proxy(Ref) ->
+    receive
+        {forward, To, Data} ->
+            To ! Data,
+            nif_whereis_proxy(Ref);
+        {Ref, quit} ->
+            ok
+    end.
+
 %% The NIFs:
 lib_loaded() -> false.
 call_dirty_nif(_,_,_) -> ?nif_stub.
@@ -542,6 +676,8 @@ dirty_call_while_terminated_nif(_) -> ?nif_stub.
 dirty_sleeper() -> ?nif_stub.
 dirty_sleeper(_) -> ?nif_stub.
 dirty_heap_access_nif(_) -> ?nif_stub.
+whereis_term(_Type,_Name) -> ?nif_stub.
+whereis_send(_Type,_Name,_Msg) -> ?nif_stub.
 
 nif_stub_error(Line) ->
     exit({nif_not_loaded,module,?MODULE,line,Line}).

--- a/erts/emulator/test/dirty_nif_SUITE_data/Makefile.src
+++ b/erts/emulator/test/dirty_nif_SUITE_data/Makefile.src
@@ -1,6 +1,6 @@
 
 NIF_LIBS = dirty_nif_SUITE@dll@
 
-all: $(NIF_LIBS)
+all: $(NIF_LIBS) echo_drv@dll@
 
 @SHLIB_RULES@

--- a/erts/emulator/test/dirty_nif_SUITE_data/dirty_nif_SUITE.c
+++ b/erts/emulator/test/dirty_nif_SUITE_data/dirty_nif_SUITE.c
@@ -25,8 +25,35 @@
 #include <unistd.h>
 #endif
 
+/*
+ * Hack to get around this function missing from the NIF API.
+ * TODO: Add this function/macro in the appropriate place, probably with
+ *       enif_make_pid() in erl_nif_api_funcs.h
+ */
+#ifndef enif_make_port
+#define enif_make_port(ENV, PORT) ((void)(ENV),(const ERL_NIF_TERM)((PORT)->port_id))
+#endif
+
+static ERL_NIF_TERM atom_badarg;
+static ERL_NIF_TERM atom_error;
+static ERL_NIF_TERM atom_false;
+static ERL_NIF_TERM atom_lookup;
+static ERL_NIF_TERM atom_ok;
+static ERL_NIF_TERM atom_pid;
+static ERL_NIF_TERM atom_port;
+static ERL_NIF_TERM atom_send;
+
 static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 {
+    atom_badarg = enif_make_atom(env, "badarg");
+    atom_error = enif_make_atom(env, "error");
+    atom_false = enif_make_atom(env,"false");
+    atom_lookup = enif_make_atom(env, "lookup");
+    atom_ok = enif_make_atom(env,"ok");
+    atom_pid = enif_make_atom(env, "pid");
+    atom_port = enif_make_atom(env, "port");
+    atom_send = enif_make_atom(env, "send");
+
     return 0;
 }
 
@@ -257,6 +284,147 @@ static ERL_NIF_TERM dirty_heap_access_nif(ErlNifEnv* env, int argc, const ERL_NI
     return res;
 }
 
+/*
+ * enif_whereis_... tests
+ * subset of the functions in nif_SUITE.c
+ */
+
+enum {
+    /* results */
+    WHEREIS_SUCCESS,
+    WHEREIS_ERROR_TYPE,
+    WHEREIS_ERROR_LOOKUP,
+    WHEREIS_ERROR_SEND,
+    /* types */
+    WHEREIS_LOOKUP_PID,     /* enif_whereis_pid() */
+    WHEREIS_LOOKUP_PORT     /* enif_whereis_port() */
+};
+
+typedef union {
+    ErlNifPid   pid;
+    ErlNifPort  port;
+} whereis_term_data_t;
+
+static int whereis_type(ERL_NIF_TERM type)
+{
+    if (enif_is_identical(type, atom_pid))
+        return WHEREIS_LOOKUP_PID;
+
+    if (enif_is_identical(type, atom_port))
+        return WHEREIS_LOOKUP_PORT;
+
+    return WHEREIS_ERROR_TYPE;
+}
+
+static int whereis_lookup_internal(
+    ErlNifEnv* env, int type, ERL_NIF_TERM name, whereis_term_data_t* out)
+{
+    if (type == WHEREIS_LOOKUP_PID)
+        return enif_whereis_pid(env, name, & out->pid)
+            ? WHEREIS_SUCCESS : WHEREIS_ERROR_LOOKUP;
+
+    if (type == WHEREIS_LOOKUP_PORT)
+        return enif_whereis_port(env, name, & out->port)
+            ? WHEREIS_SUCCESS : WHEREIS_ERROR_LOOKUP;
+
+    return WHEREIS_ERROR_TYPE;
+}
+
+static int whereis_send_internal(
+    ErlNifEnv* env, int type, whereis_term_data_t* to, ERL_NIF_TERM msg)
+{
+    if (type == WHEREIS_LOOKUP_PID)
+        return enif_send(env, & to->pid, NULL, msg)
+            ? WHEREIS_SUCCESS : WHEREIS_ERROR_SEND;
+
+    if (type == WHEREIS_LOOKUP_PORT)
+        return enif_port_command(env, & to->port, NULL, msg)
+            ? WHEREIS_SUCCESS : WHEREIS_ERROR_SEND;
+
+    return WHEREIS_ERROR_TYPE;
+}
+
+static int whereis_lookup_term(
+    ErlNifEnv* env, int type, ERL_NIF_TERM name, ERL_NIF_TERM* out)
+{
+    whereis_term_data_t res;
+    int rc = whereis_lookup_internal(env, type, name, &res);
+    if (rc == WHEREIS_SUCCESS) {
+        switch (type) {
+            case WHEREIS_LOOKUP_PID:
+                *out = enif_make_pid(env, & res.pid);
+                break;
+            case WHEREIS_LOOKUP_PORT:
+                *out = enif_make_port(env, & res.port);
+                break;
+            default:
+                rc = WHEREIS_ERROR_TYPE;
+                break;
+        }
+    }
+    return rc;
+}
+
+static ERL_NIF_TERM whereis_result_term(ErlNifEnv* env, int result)
+{
+    ERL_NIF_TERM err;
+    switch (result)
+    {
+        case WHEREIS_SUCCESS:
+            return atom_ok;
+        case WHEREIS_ERROR_LOOKUP:
+            err = atom_lookup;
+            break;
+        case WHEREIS_ERROR_SEND:
+            err = atom_send;
+            break;
+        case WHEREIS_ERROR_TYPE:
+            err = atom_badarg;
+            break;
+        default:
+            err = enif_make_int(env, -result);
+            break;
+    }
+    return enif_make_tuple2(env, atom_error, err);
+}
+
+/* whereis_term(Type, Name) -> pid() | port() | false */
+static ERL_NIF_TERM
+whereis_term(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ERL_NIF_TERM ret;
+    int type, rc;
+
+    if (argc != 2)  /* allow non-atom name for testing */
+        return enif_make_badarg(env);
+
+    if ((type = whereis_type(argv[0])) == WHEREIS_ERROR_TYPE)
+        return enif_make_badarg(env);
+
+    rc = whereis_lookup_term(env, type, argv[1], &ret);
+    return (rc == WHEREIS_SUCCESS) ? ret : atom_false;
+}
+
+/* whereis_send(Type, Name, Message) -> ok | {error, Reason} */
+static ERL_NIF_TERM
+whereis_send(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    whereis_term_data_t to;
+    int type, rc;
+
+    if (argc != 3 || !enif_is_atom(env, argv[1]))
+        return enif_make_badarg(env);
+
+    if ((type = whereis_type(argv[0])) == WHEREIS_ERROR_TYPE)
+        return enif_make_badarg(env);
+
+    rc = whereis_lookup_internal(env, type, argv[1], & to);
+    if (rc == WHEREIS_SUCCESS)
+        rc = whereis_send_internal(env, type, & to, argv[2]);
+
+    return whereis_result_term(env, rc);
+}
+
 
 static ErlNifFunc nif_funcs[] =
 {
@@ -269,7 +437,9 @@ static ErlNifFunc nif_funcs[] =
     {"dirty_sleeper", 0, dirty_sleeper, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"dirty_sleeper", 1, dirty_sleeper, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"dirty_call_while_terminated_nif", 1, dirty_call_while_terminated_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-    {"dirty_heap_access_nif", 1, dirty_heap_access_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND}
+    {"dirty_heap_access_nif", 1, dirty_heap_access_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"whereis_send", 3, whereis_send, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"whereis_term", 2, whereis_term, ERL_NIF_DIRTY_JOB_CPU_BOUND}
 };
 
 ERL_NIF_INIT(dirty_nif_SUITE,nif_funcs,load,NULL,NULL,NULL)

--- a/erts/emulator/test/dirty_nif_SUITE_data/echo_drv.c
+++ b/erts/emulator/test/dirty_nif_SUITE_data/echo_drv.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include "erl_driver.h"
+
+static ErlDrvPort erlang_port;
+static ErlDrvData echo_start(ErlDrvPort, char *);
+static void from_erlang(ErlDrvData, char*, ErlDrvSizeT);
+static ErlDrvSSizeT echo_call(ErlDrvData drv_data, unsigned int command,
+			      char *buf, ErlDrvSizeT len,
+			      char **rbuf, ErlDrvSizeT rlen, unsigned *ret_flags);
+static ErlDrvEntry echo_driver_entry = { 
+    NULL,			/* Init */
+    echo_start,
+    NULL,			/* Stop */
+    from_erlang,
+    NULL,			/* Ready input */
+    NULL,			/* Ready output */
+    "echo_drv",
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    echo_call,
+    NULL,
+    ERL_DRV_EXTENDED_MARKER,
+    ERL_DRV_EXTENDED_MAJOR_VERSION,
+    ERL_DRV_EXTENDED_MINOR_VERSION,
+    0,
+    NULL,
+    NULL,
+    NULL
+};
+
+DRIVER_INIT(echo_drv)
+{
+    return &echo_driver_entry;
+}
+
+static ErlDrvData
+echo_start(ErlDrvPort port, char *buf)
+{
+    return (ErlDrvData) port;
+}
+
+static void
+from_erlang(ErlDrvData data, char *buf, ErlDrvSizeT count)
+{
+    driver_output((ErlDrvPort) data, buf, count);
+}
+
+static ErlDrvSSizeT
+echo_call(ErlDrvData drv_data, unsigned int command,
+	  char *buf, ErlDrvSizeT len, char **rbuf, ErlDrvSizeT rlen,
+	  unsigned *ret_flags)
+{
+    *rbuf = buf;
+    *ret_flags |= DRIVER_CALL_KEEP_BUFFER;
+    return len;
+}
+

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -52,6 +52,15 @@ static ErlNifMutex* dbg_trace_lock;
 #define DBG_TRACE4(FMT, A, B, C, D)
 #endif
 
+/*
+ * Hack to get around this function missing from the NIF API.
+ * TODO: Add this function/macro in the appropriate place, probably with
+ *       enif_make_pid() in erl_nif_api_funcs.h
+ */
+#ifndef enif_make_port
+#define enif_make_port(ENV, PORT) ((void)(ENV),(const ERL_NIF_TERM)((PORT)->port_id))
+#endif
+
 static int static_cntA; /* zero by default */
 static int static_cntB = NIF_SUITE_LIB_VER * 100;
 
@@ -76,6 +85,11 @@ static ERL_NIF_TERM atom_stats;
 static ERL_NIF_TERM atom_done;
 static ERL_NIF_TERM atom_stop;
 static ERL_NIF_TERM atom_null;
+static ERL_NIF_TERM atom_pid;
+static ERL_NIF_TERM atom_port;
+static ERL_NIF_TERM atom_send;
+static ERL_NIF_TERM atom_lookup;
+static ERL_NIF_TERM atom_badarg;
 
 typedef struct
 {
@@ -170,6 +184,9 @@ static ErlNifResourceTypeInit frenzy_rt_init = {
     frenzy_resource_down
 };
 
+static ErlNifResourceType* whereis_resource_type;
+static void whereis_thread_resource_dtor(ErlNifEnv* env, void* obj);
+
 static int get_pointer(ErlNifEnv* env, ERL_NIF_TERM term, void** pp)
 {
     ErlNifBinary bin;
@@ -223,6 +240,9 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 						      &frenzy_rt_init,
 						      ERL_NIF_RT_CREATE, NULL);
 
+    whereis_resource_type = enif_open_resource_type(env, NULL, "nif_SUITE.whereis",
+                            whereis_thread_resource_dtor, ERL_NIF_RT_CREATE, NULL);
+
     atom_false = enif_make_atom(env,"false");
     atom_true = enif_make_atom(env,"true");
     atom_self = enif_make_atom(env,"self");
@@ -244,6 +264,11 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
     atom_done = enif_make_atom(env,"done");
     atom_stop = enif_make_atom(env,"stop");
     atom_null = enif_make_atom(env,"null");
+    atom_pid = enif_make_atom(env, "pid");
+    atom_port = enif_make_atom(env, "port");
+    atom_send = enif_make_atom(env, "send");
+    atom_lookup = enif_make_atom(env, "lookup");
+    atom_badarg = enif_make_atom(env, "badarg");
 
     *priv_data = data;
     return 0;
@@ -1135,6 +1160,237 @@ static void fill(void* dst, unsigned bytes, int seed)
 	*ptr++ = seed;
 	seed += 7;
     }
+}
+
+/* enif_whereis_... tests */
+
+enum {
+    /* results */
+    WHEREIS_SUCCESS,
+    WHEREIS_ERROR_TYPE,
+    WHEREIS_ERROR_LOOKUP,
+    WHEREIS_ERROR_SEND,
+    /* types */
+    WHEREIS_LOOKUP_PID,     /* enif_whereis_pid() */
+    WHEREIS_LOOKUP_PORT     /* enif_whereis_port() */
+};
+
+typedef union {
+    ErlNifPid   pid;
+    ErlNifPort  port;
+} whereis_term_data_t;
+
+/* single use, no cross-thread access/serialization */
+typedef struct {
+    ErlNifEnv* env;
+    ERL_NIF_TERM name;
+    whereis_term_data_t res;
+    ErlNifTid tid;
+    int type;
+} whereis_thread_resource_t;
+
+static whereis_thread_resource_t* whereis_thread_resource_create(void)
+{
+    whereis_thread_resource_t* rp = (whereis_thread_resource_t*)
+        enif_alloc_resource(whereis_resource_type, sizeof(*rp));
+    memset(rp, 0, sizeof(*rp));
+    rp->env = enif_alloc_env();
+
+    return rp;
+}
+
+static void whereis_thread_resource_dtor(ErlNifEnv* env, void* obj)
+{
+    whereis_thread_resource_t* rp = (whereis_thread_resource_t*) obj;
+    enif_free_env(rp->env);
+}
+
+static int whereis_type(ERL_NIF_TERM type)
+{
+    if (enif_is_identical(type, atom_pid))
+        return WHEREIS_LOOKUP_PID;
+
+    if (enif_is_identical(type, atom_port))
+        return WHEREIS_LOOKUP_PORT;
+
+    return WHEREIS_ERROR_TYPE;
+}
+
+static int whereis_lookup_internal(
+    ErlNifEnv* env, int type, ERL_NIF_TERM name, whereis_term_data_t* out)
+{
+    if (type == WHEREIS_LOOKUP_PID)
+        return enif_whereis_pid(env, name, & out->pid)
+            ? WHEREIS_SUCCESS : WHEREIS_ERROR_LOOKUP;
+
+    if (type == WHEREIS_LOOKUP_PORT)
+        return enif_whereis_port(env, name, & out->port)
+            ? WHEREIS_SUCCESS : WHEREIS_ERROR_LOOKUP;
+
+    return WHEREIS_ERROR_TYPE;
+}
+
+static int whereis_send_internal(
+    ErlNifEnv* env, int type, whereis_term_data_t* to, ERL_NIF_TERM msg)
+{
+    if (type == WHEREIS_LOOKUP_PID)
+        return enif_send(env, & to->pid, NULL, msg)
+            ? WHEREIS_SUCCESS : WHEREIS_ERROR_SEND;
+
+    if (type == WHEREIS_LOOKUP_PORT)
+        return enif_port_command(env, & to->port, NULL, msg)
+            ? WHEREIS_SUCCESS : WHEREIS_ERROR_SEND;
+
+    return WHEREIS_ERROR_TYPE;
+}
+
+static int whereis_resolved_term(
+    ErlNifEnv* env, int type, whereis_term_data_t* res, ERL_NIF_TERM* out)
+{
+    switch (type) {
+        case WHEREIS_LOOKUP_PID:
+            *out = enif_make_pid(env, & res->pid);
+            break;
+        case WHEREIS_LOOKUP_PORT:
+            *out = enif_make_port(env, & res->port);
+            break;
+        default:
+            return WHEREIS_ERROR_TYPE;
+    }
+    return WHEREIS_SUCCESS;
+}
+
+static ERL_NIF_TERM whereis_result_term(ErlNifEnv* env, int result)
+{
+    ERL_NIF_TERM err;
+    switch (result)
+    {
+        case WHEREIS_SUCCESS:
+            return atom_ok;
+        case WHEREIS_ERROR_LOOKUP:
+            err = atom_lookup;
+            break;
+        case WHEREIS_ERROR_SEND:
+            err = atom_send;
+            break;
+        case WHEREIS_ERROR_TYPE:
+            err = atom_badarg;
+            break;
+        default:
+            err = enif_make_int(env, -result);
+            break;
+    }
+    return enif_make_tuple2(env, atom_error, err);
+}
+
+static void* whereis_lookup_thread(void* arg)
+{
+    whereis_thread_resource_t* rp = (whereis_thread_resource_t*) arg;
+    int rc;
+
+    /* enif_whereis_xxx should work with allocated or null env */
+    rc = whereis_lookup_internal(
+        ((rp->type == WHEREIS_LOOKUP_PID) ? NULL : rp->env),
+        rp->type, rp->name, & rp->res);
+
+    return (((char*) NULL) + rc);
+}
+
+/* whereis_term(Type, Name) -> pid() | port() | false */
+static ERL_NIF_TERM
+whereis_term(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    whereis_term_data_t res;
+    ERL_NIF_TERM ret;
+    int type, rc;
+
+    if (argc != 2)  /* allow non-atom name for testing */
+        return enif_make_badarg(env);
+
+    if ((type = whereis_type(argv[0])) == WHEREIS_ERROR_TYPE)
+        return enif_make_badarg(env);
+
+    rc = whereis_lookup_internal(env, type, argv[1], & res);
+    if (rc == WHEREIS_SUCCESS) {
+        rc = whereis_resolved_term(env, type, & res, & ret);
+    }
+    return (rc == WHEREIS_SUCCESS) ? ret : atom_false;
+}
+
+/* whereis_send(Type, Name, Message) -> ok | {error, Reason} */
+static ERL_NIF_TERM
+whereis_send(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    whereis_term_data_t to;
+    int type, rc;
+
+    if (argc != 3 || !enif_is_atom(env, argv[1]))
+        return enif_make_badarg(env);
+
+    if ((type = whereis_type(argv[0])) == WHEREIS_ERROR_TYPE)
+        return enif_make_badarg(env);
+
+    rc = whereis_lookup_internal(env, type, argv[1], & to);
+    if (rc == WHEREIS_SUCCESS)
+        rc = whereis_send_internal(env, type, & to, argv[2]);
+
+    return whereis_result_term(env, rc);
+}
+
+/* whereis_thd_lookup(Type, Name) -> {ok, Resource} | {error, SysErrno} */
+static ERL_NIF_TERM
+whereis_thd_lookup(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    whereis_thread_resource_t* rp;
+    int type, rc;
+
+    if (argc != 2 || !enif_is_atom(env, argv[1]))
+        return enif_make_badarg(env);
+
+    if ((type = whereis_type(argv[0])) == WHEREIS_ERROR_TYPE)
+        return enif_make_badarg(env);
+
+    rp = whereis_thread_resource_create();
+    rp->type = type;
+    rp->name = enif_make_copy(rp->env, argv[1]);
+
+    rc = enif_thread_create(
+        "nif_SUITE:whereis_thd", & rp->tid, whereis_lookup_thread, rp, NULL);
+
+    if (rc == 0) {
+        return enif_make_tuple2(env, atom_ok, enif_make_resource(env, rp));
+    }
+    else {
+        enif_release_resource(rp);
+        return enif_make_tuple2(env, atom_error, enif_make_int(env, rc));
+    }
+}
+
+/* whereis_thd_result(Resource) -> {ok, pid() | port()} | {error, ErrNum} */
+static ERL_NIF_TERM
+whereis_thd_result(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    whereis_thread_resource_t* rp;
+    ERL_NIF_TERM ret;
+    char* thdret; /* so we can keep compilers happy converting to int */
+    int rc;
+
+    if (argc != 1
+    || !enif_get_resource(env, argv[0], whereis_resource_type, (void**) & rp))
+        return enif_make_badarg(env);
+
+    if ((rc = enif_thread_join(rp->tid, (void**) & thdret)) != 0)
+        return enif_make_tuple2(env, atom_error, enif_make_int(env, rc));
+    
+    rc = (int)(thdret - ((char*) NULL));
+    if (rc == WHEREIS_SUCCESS) {
+        rc = whereis_resolved_term(env, rp->type, & rp->res, & ret);
+    }
+    ret = (rc == WHEREIS_SUCCESS)
+        ? enif_make_tuple2(env, atom_ok, ret) : whereis_result_term(env, rc);
+    
+    enif_release_resource(rp);
+    return ret;
 }
 
 #define MAKE_TERM_REUSE_LEN 16
@@ -2968,7 +3224,11 @@ static ErlNifFunc nif_funcs[] =
     {"monitor_process_nif", 4, monitor_process_nif},
     {"demonitor_process_nif", 2, demonitor_process_nif},
     {"compare_monitors_nif", 2, compare_monitors_nif},
-    {"monitor_frenzy_nif", 4, monitor_frenzy_nif}
+    {"monitor_frenzy_nif", 4, monitor_frenzy_nif},
+    {"whereis_send", 3, whereis_send},
+    {"whereis_term", 2, whereis_term},
+    {"whereis_thd_lookup", 2, whereis_thd_lookup},
+    {"whereis_thd_result", 1, whereis_thd_result}
 };
 
 ERL_NIF_INIT(nif_SUITE,nif_funcs,load,NULL,upgrade,unload)


### PR DESCRIPTION
#### Why do we need this new feature?

There are cases when a NIF needs to send a message, using `enif_send()`, to a long-lived process with a registered name.

A common use-case is logging, where asynchronous fire-and-forget messages are the norm.

There can also be cases where a yielding or dirty NIF or background thread may request a callback from a service with additional information it needs to complete its operation, yielding or waiting (with suitable timeouts, etc) until its state has been updated through the NIF module's API.

NIFs can only send messages to pids, and the lack of name resolution leaves a complicated dance between separate monitoring processes and the NIF as the only way to keep a NIF informed of the whereabouts of such long-lived processes.

Providing a reliable, built-in facility for NIFs to resolve process (or port) names simplifies these use cases considerably.

#### Risks or uncertain artifacts?

Testing has not exposed any significant risk.

The implementation behaves as expected on regular and dirty scheduler threads as well as non-scheduler threads.

By constraining the `enif_whereis_...()` functions to their minimal scopes and using patterns consistent with related functions, the implementation, testing, and maintenance burden is low.

The API and behavior of existing functions is unchanged.

#### How did you solve it?

While extending `enif_send()` to operate on a pid or an atom (as `erlang:send/2` does) was attractive, it would have entailed changing the type of its `to_pid` parameter and thereby breaking backward compatibility.

The same consideration applies to `enif_port_command()`.

That leaves a choice between 1, 2, or 3 new functions:

 1. `enif_whereis()`
 2. `enif_whereis_pid()` and `enif_whereis_port()`
 3. All of the above.

While option (1), directly mimicking the behavior of `erlang:whereis/1`, is appealing, it poses potential problems if `pid()` or `port()` are subsequently implemented as non-integral types that must be bound to an owning `ErlNifEnv` instance.

Therefore, option (2) has been chosen to use `ErlNifPid`/`ErlNifPort` structures in the API to maintain proper term ownership semantics.