### PR TITLE
Error when a non-DST time is passed to the httpd_util:rfc1123_date/1 function

### DIFF
--- a/lib/inets/src/http_server/httpd_util.erl
+++ b/lib/inets/src/http_server/httpd_util.erl
@@ -333,7 +333,9 @@ rfc1123_date(LocalTime) ->
     {{YYYY,MM,DD},{Hour,Min,Sec}} = 
 	case calendar:local_time_to_universal_time_dst(LocalTime) of
 	    [Gmt]   -> Gmt;
-	    [_,Gmt] -> Gmt
+	    [_,Gmt] -> Gmt;
+        % Should not happen, but handle the empty list to prevent an error.
+        [] -> LocalTime
 	end,
     DayNumber = calendar:day_of_the_week({YYYY,MM,DD}),
     lists:flatten(


### PR DESCRIPTION
It causes a case-clause error, as the calender:local_time_to_universal_time_dst/1
can return an empty list, which is not currently handled.

When called with an invalid DST time:
1> httpd_util:rfc1123_date({{2017, 03, 26},{1, 0, 0}}).
   ** exception error: no case clause matching []
      in function  httpd_util:rfc1123_date/1 (httpd_util.erl, line 334)

To alleviate this, simply add a clause to handle the empty list and return the
original time in the expected rfc1123 format. This is the approach of other
modules which make use of the calender:local_time_to_universal_time_dst/1
function. The formatted date is then returned without error:

2> httpd_util:rfc1123_date({{2017, 03, 26},{1, 0, 0}}).
   "Sun, 26 Mar 2017 01:00:00 GMT"