### PR TITLE
Auto-hibernation functionality for gen_server, gen_fsm, gen_event

### DIFF
--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -358,7 +358,7 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;Name = atom()</v>
         <v>&nbsp;GlobalName = ViaName = term()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {auto_hibernate_timeout,AutoHibernateTimeout} | {spawn_opt,SOpts}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {hibernate_after,HibernateAfterTimeout} | {spawn_opt,SOpts}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics | {log_to_file,FileName} | {install,{Func,FuncState}}</v>
         <v>&nbsp;&nbsp;SOpts = [term()]</v>
@@ -385,7 +385,7 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;Name = atom()</v>
         <v>&nbsp;GlobalName = ViaName = term()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {auto_hibernate_timeout,AutoHibernateTimeout} | {spawn_opt,SOpts}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {hibernate_after,HibernateAfterTimeout} | {spawn_opt,SOpts}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics | {log_to_file,FileName} | {install,{Func,FuncState}}</v>
         <v>&nbsp;&nbsp;SOpts = [term()]</v>
@@ -420,8 +420,8 @@ gen_event:stop             ----->  Module:terminate/2
               Thus, <c>{via,global,GlobalName}</c> is a valid reference.</p>
           </item>
           <item>
-            <p>If option <c>{auto_hibernate_timeout,AutoHibernateTimeout}</c> is present, the <c>gen_event</c>
-              process awaits any message for <c>AutoHibernateTimeout</c> milliseconds and
+            <p>If option <c>{hibernate_after,HibernateAfterTimeout}</c> is present, the <c>gen_event</c>
+              process awaits any message for <c>HibernateAfterTimeout</c> milliseconds and
               if no message is received, the process goes into hibernation automatically
               (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).</p>
           </item>

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -421,8 +421,8 @@ gen_event:stop             ----->  Module:terminate/2
           </item>
           <item>
             <p>If option <c>{auto_hibernate_timeout,AutoHibernateTimeout}</c> is present, the <c>gen_event</c>
-              process wait any message <c>AutoHibernateTimeout</c> milliseconds and
-              in case of no message was received, process goes into hibernation automatically
+              process awaits any message for <c>AutoHibernateTimeout</c> milliseconds and
+              if no message is received, the process goes into hibernation automatically
               (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).</p>
           </item>
         </list>

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -358,7 +358,7 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;Name = atom()</v>
         <v>&nbsp;GlobalName = ViaName = term()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {spawn_opt,SOpts}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {auto_hibernate_timeout,AutoHibernateTimeout} | {spawn_opt,SOpts}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics | {log_to_file,FileName} | {install,{Func,FuncState}}</v>
         <v>&nbsp;&nbsp;SOpts = [term()]</v>
@@ -385,7 +385,7 @@ gen_event:stop             ----->  Module:terminate/2
         <v>&nbsp;Name = atom()</v>
         <v>&nbsp;GlobalName = ViaName = term()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {spawn_opt,SOpts}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {auto_hibernate_timeout,AutoHibernateTimeout} | {spawn_opt,SOpts}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics | {log_to_file,FileName} | {install,{Func,FuncState}}</v>
         <v>&nbsp;&nbsp;SOpts = [term()]</v>
@@ -418,6 +418,12 @@ gen_event:stop             ----->  Module:terminate/2
               as the corresponding functions in
               <seealso marker="kernel:global"><c>global</c></seealso>.
               Thus, <c>{via,global,GlobalName}</c> is a valid reference.</p>
+          </item>
+          <item>
+            <p>If option <c>{auto_hibernate_timeout,AutoHibernateTimeout}</c> is present, the <c>gen_event</c>
+              process wait any message <c>AutoHibernateTimeout</c> milliseconds and
+              in case of no message was received, process goes into hibernation automatically
+              (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).</p>
           </item>
         </list>
         <p>If the event manager is successfully created, the function

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -199,7 +199,7 @@ gen_server:abcast     -----> Module:handle_cast/2
       <type>
         <v>Module = atom()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {auto_hibernate_timeout,AutoHibernateTimeout}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics</v>
         <v>&nbsp;&nbsp;&nbsp;&nbsp;| {log_to_file,FileName} | {install,{Func,FuncState}}</v>
@@ -334,7 +334,7 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>Module = atom()</v>
         <v>Args = term()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {spawn_opt,SOpts}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {auto_hibernate_timeout,AutoHibernateTimeout} | {spawn_opt,SOpts}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics | {log_to_file,FileName} | {install,{Func,FuncState}}</v>
         <v>&nbsp;&nbsp;SOpts = [term()]</v>
@@ -364,7 +364,7 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>Module = atom()</v>
         <v>Args = term()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {spawn_opt,SOpts}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {auto_hibernate_timeout,AutoHibernateTimeout} | {spawn_opt,SOpts}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics | {log_to_file,FileName} | {install,{Func,FuncState}}</v>
         <v>&nbsp;&nbsp;SOpts = [term()]</v>
@@ -415,6 +415,12 @@ gen_server:abcast     -----> Module:handle_cast/2
               process is allowed to spend <c>Time</c> milliseconds
               initializing or it is terminated and the start function
               returns <c>{error,timeout}</c>.</p>
+          </item>
+          <item>
+            <p>If option <c>{auto_hibernate_timeout,AutoHibernateTimeout}</c> is present, the <c>gen_server</c>
+              process wait any message <c>AutoHibernateTimeout</c> milliseconds and
+              in case of no message was received, process goes into hibernation automatically
+              (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).</p>
           </item>
           <item>
             <p>If option <c>{debug,Dbgs}</c> is present,

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -418,8 +418,8 @@ gen_server:abcast     -----> Module:handle_cast/2
           </item>
           <item>
             <p>If option <c>{auto_hibernate_timeout,AutoHibernateTimeout}</c> is present, the <c>gen_server</c>
-              process wait any message <c>AutoHibernateTimeout</c> milliseconds and
-              in case of no message was received, process goes into hibernation automatically
+              process awaits any message for <c>AutoHibernateTimeout</c> milliseconds and
+              if no message is received, the process goes into hibernation automatically
               (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).</p>
           </item>
           <item>

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -199,7 +199,7 @@ gen_server:abcast     -----> Module:handle_cast/2
       <type>
         <v>Module = atom()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {auto_hibernate_timeout,AutoHibernateTimeout}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {hibernate_after,HibernateAfterTimeout}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics</v>
         <v>&nbsp;&nbsp;&nbsp;&nbsp;| {log_to_file,FileName} | {install,{Func,FuncState}}</v>
@@ -334,7 +334,7 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>Module = atom()</v>
         <v>Args = term()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {auto_hibernate_timeout,AutoHibernateTimeout} | {spawn_opt,SOpts}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {hibernate_after,HibernateAfterTimeout} | {spawn_opt,SOpts}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics | {log_to_file,FileName} | {install,{Func,FuncState}}</v>
         <v>&nbsp;&nbsp;SOpts = [term()]</v>
@@ -364,7 +364,7 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>Module = atom()</v>
         <v>Args = term()</v>
         <v>Options = [Option]</v>
-        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {auto_hibernate_timeout,AutoHibernateTimeout} | {spawn_opt,SOpts}</v>
+        <v>&nbsp;Option = {debug,Dbgs} | {timeout,Time} | {hibernate_after,HibernateAfterTimeout} | {spawn_opt,SOpts}</v>
         <v>&nbsp;&nbsp;Dbgs = [Dbg]</v>
         <v>&nbsp;&nbsp;&nbsp;Dbg = trace | log | statistics | {log_to_file,FileName} | {install,{Func,FuncState}}</v>
         <v>&nbsp;&nbsp;SOpts = [term()]</v>
@@ -417,8 +417,8 @@ gen_server:abcast     -----> Module:handle_cast/2
               returns <c>{error,timeout}</c>.</p>
           </item>
           <item>
-            <p>If option <c>{auto_hibernate_timeout,AutoHibernateTimeout}</c> is present, the <c>gen_server</c>
-              process awaits any message for <c>AutoHibernateTimeout</c> milliseconds and
+            <p>If option <c>{hibernate_after,HibernateAfterTimeout}</c> is present, the <c>gen_server</c>
+              process awaits any message for <c>HibernateAfterTimeout</c> milliseconds and
               if no message is received, the process goes into hibernation automatically
               (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).</p>
           </item>

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -453,15 +453,15 @@ handle_event(_, _, State, Data) ->
       </desc>
     </datatype>
     <datatype>
-      <name name="auto_hibernate_timeout_opt"/>
+      <name name="hibernate_after_opt"/>
       <desc>
 	<p>
-      auto_hibernate_timeout option that can be used when starting
+          hibernate_after option that can be used when starting
 	  a <c>gen_statem</c> server through,
 	  <seealso marker="#enter_loop/4"><c>enter_loop/4-6</c></seealso>.
 	</p>
-    <p>If option<seealso marker="#type-auto_hibernate_timeout_opt"><c>{auto_hibernate_timeout,AutoHibernateTimeout}</c></seealso> is present, the <c>gen_statem</c>
-        process awaits any message for <c>AutoHibernateTimeout</c> milliseconds and
+    <p>If option<seealso marker="#type-hibernate_after_opt"><c>{hibernate_after,HibernateAfterTimeout}</c></seealso> is present, the <c>gen_statem</c>
+        process awaits any message for <c>HibernateAfterTimeout</c> milliseconds and
         if no message is received, the process goes into hibernation automatically
         (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).
     </p>
@@ -1566,8 +1566,8 @@ handle_event(_, _, State, Data) ->
             </p>
           </item>
           <item>
-            <p>If option<seealso marker="#type-auto_hibernate_timeout_opt"><c>{auto_hibernate_timeout,AutoHibernateTimeout}</c></seealso> is present, the <c>gen_statem</c>
-              process awaits any message for <c>AutoHibernateTimeout</c> milliseconds and
+            <p>If option<seealso marker="#type-hibernate_after_opt"><c>{hibernate_after,HibernateAfterTimeout}</c></seealso> is present, the <c>gen_statem</c>
+              process awaits any message for <c>HibernateAfterTimeout</c> milliseconds and
               if no message is received, the process goes into hibernation automatically
               (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).
             </p>

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -453,6 +453,21 @@ handle_event(_, _, State, Data) ->
       </desc>
     </datatype>
     <datatype>
+      <name name="auto_hibernate_timeout_opt"/>
+      <desc>
+	<p>
+      auto_hibernate_timeout option that can be used when starting
+	  a <c>gen_statem</c> server through,
+	  <seealso marker="#enter_loop/4"><c>enter_loop/4-6</c></seealso>.
+	</p>
+    <p>If option<seealso marker="#type-auto_hibernate_timeout_opt"><c>{auto_hibernate_timeout,AutoHibernateTimeout}</c></seealso> is present, the <c>gen_statem</c>
+        process awaits any message for <c>AutoHibernateTimeout</c> milliseconds and
+        if no message is received, the process goes into hibernation automatically
+        (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).
+    </p>
+      </desc>
+    </datatype>
+    <datatype>
       <name name="start_opt"/>
       <desc>
 	<p>
@@ -1548,6 +1563,13 @@ handle_event(_, _, State, Data) ->
 	      is allowed to spend <c>Time</c> milliseconds initializing
 	      or it terminates and the start function returns
 	      <seealso marker="#type-start_ret"><c>{error,timeout}</c></seealso>.
+            </p>
+          </item>
+          <item>
+            <p>If option<seealso marker="#type-auto_hibernate_timeout_opt"><c>{auto_hibernate_timeout,AutoHibernateTimeout}</c></seealso> is present, the <c>gen_statem</c>
+              process awaits any message for <c>AutoHibernateTimeout</c> milliseconds and
+              if no message is received, the process goes into hibernation automatically
+              (by calling <seealso marker="proc_lib#hibernate/3"><c>proc_lib:hibernate/3</c></seealso>).
             </p>
           </item>
           <item>

--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -26,7 +26,7 @@
 %%%
 %%% The standard behaviour should export init_it/6.
 %%%-----------------------------------------------------------------
--export([start/5, start/6, debug_options/2, auto_hibernate_timeout/1,
+-export([start/5, start/6, debug_options/2, hibernate_after/1,
 	 name/1, unregister_name/1, get_proc_name/1, get_parent/0,
 	 call/3, call/4, reply/2, stop/1, stop/3]).
 
@@ -408,10 +408,10 @@ spawn_opts(Options) ->
 	    []
     end.
 
-auto_hibernate_timeout(Options) ->
-	case lists:keyfind(auto_hibernate_timeout, 1, Options) of
-		{_,AutoHibernateTimeout} ->
-			AutoHibernateTimeout;
+hibernate_after(Options) ->
+	case lists:keyfind(hibernate_after, 1, Options) of
+		{_,HibernateAfterTimeout} ->
+			HibernateAfterTimeout;
 		false ->
 			infinity
 	end.

--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -26,7 +26,7 @@
 %%%
 %%% The standard behaviour should export init_it/6.
 %%%-----------------------------------------------------------------
--export([start/5, start/6, debug_options/2,
+-export([start/5, start/6, debug_options/2, auto_hibernate_timeout/1,
 	 name/1, unregister_name/1, get_proc_name/1, get_parent/0,
 	 call/3, call/4, reply/2, stop/1, stop/3]).
 
@@ -407,6 +407,14 @@ spawn_opts(Options) ->
 	false ->
 	    []
     end.
+
+auto_hibernate_timeout(Options) ->
+	case lists:keyfind(auto_hibernate_timeout, 1, Options) of
+		{_,AutoHibernateTimeout} ->
+			AutoHibernateTimeout;
+		false ->
+			infinity
+	end.
 
 debug_options(Name, Opts) ->
     case lists:keyfind(debug, 1, Opts) of

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -37,7 +37,7 @@
          stop/1, stop/3,
 	 notify/2, sync_notify/2,
 	 add_handler/3, add_sup_handler/3, delete_handler/3, swap_handler/3,
-	 swap_sup_handler/3, which_handlers/1, call/3, call/4, wake_hib/4]).
+	 swap_sup_handler/3, which_handlers/1, call/3, call/4, wake_hib/5]).
 
 -export([init_it/6,
 	 system_continue/3,
@@ -186,8 +186,9 @@ init_it(Starter, Parent, Name0, _, _, Options) ->
     process_flag(trap_exit, true),
     Name = gen:name(Name0),
     Debug = gen:debug_options(Name, Options),
+	AutoHibernateTimeout = gen:auto_hibernate_timeout(Options),
     proc_lib:init_ack(Starter, {ok, self()}),
-    loop(Parent, Name, [], Debug, false).
+    loop(Parent, Name, [], AutoHibernateTimeout, Debug, false).
 
 -spec add_handler(emgr_ref(), handler(), term()) -> term().
 add_handler(M, Handler, Args) -> rpc(M, {add_handler, Handler, Args}).
@@ -264,81 +265,83 @@ send(M, Cmd) ->
     M ! Cmd,
     ok.
 
-loop(Parent, ServerName, MSL, Debug, true) ->
-     proc_lib:hibernate(?MODULE, wake_hib, [Parent, ServerName, MSL, Debug]);
-loop(Parent, ServerName, MSL, Debug, _) ->
-    fetch_msg(Parent, ServerName, MSL, Debug, false).
+loop(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, true) ->
+     proc_lib:hibernate(?MODULE, wake_hib, [Parent, ServerName, MSL, AutoHibernateTimeout, Debug]);
+loop(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, _) ->
+    fetch_msg(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, false).
 
-wake_hib(Parent, ServerName, MSL, Debug) ->
-    fetch_msg(Parent, ServerName, MSL, Debug, true).
+wake_hib(Parent, ServerName, MSL, AutoHibernateTimeout, Debug) ->
+    fetch_msg(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, true).
 
-fetch_msg(Parent, ServerName, MSL, Debug, Hib) ->
+fetch_msg(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, Hib) ->
     receive
 	{system, From, Req} ->
 	    sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug,
-				  [ServerName, MSL, Hib],Hib);
+				  [ServerName, MSL, AutoHibernateTimeout, Hib],Hib);
 	{'EXIT', Parent, Reason} ->
 	    terminate_server(Reason, Parent, MSL, ServerName);
 	Msg when Debug =:= [] ->
-	    handle_msg(Msg, Parent, ServerName, MSL, []);
+	    handle_msg(Msg, Parent, ServerName, MSL, AutoHibernateTimeout, []);
 	Msg ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      ServerName, {in, Msg}),
-	    handle_msg(Msg, Parent, ServerName, MSL, Debug1)
+	    handle_msg(Msg, Parent, ServerName, MSL, AutoHibernateTimeout, Debug1)
+    after AutoHibernateTimeout ->
+	    proc_lib:hibernate(?MODULE, wake_hib, [Parent, ServerName, MSL, AutoHibernateTimeout, Debug])
     end.
 
-handle_msg(Msg, Parent, ServerName, MSL, Debug) ->
+handle_msg(Msg, Parent, ServerName, MSL, AutoHibernateTimeout, Debug) ->
     case Msg of
 	{notify, Event} ->
 	    {Hib,MSL1} = server_notify(Event, handle_event, MSL, ServerName),
-	    loop(Parent, ServerName, MSL1, Debug, Hib);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, Hib);
 	{_From, Tag, {sync_notify, Event}} ->
 	    {Hib, MSL1} = server_notify(Event, handle_event, MSL, ServerName),
 	    reply(Tag, ok),
-	    loop(Parent, ServerName, MSL1, Debug, Hib);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, Hib);
 	{'EXIT', From, Reason} ->
 	    MSL1 = handle_exit(From, Reason, MSL, ServerName),
-	    loop(Parent, ServerName, MSL1, Debug, false);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, false);
 	{_From, Tag, {call, Handler, Query}} ->
 	    {Hib, Reply, MSL1} = server_call(Handler, Query, MSL, ServerName),
 	    reply(Tag, Reply),
-	    loop(Parent, ServerName, MSL1, Debug, Hib);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, Hib);
 	{_From, Tag, {add_handler, Handler, Args}} ->
 	    {Hib, Reply, MSL1} = server_add_handler(Handler, Args, MSL),
 	    reply(Tag, Reply),
-	    loop(Parent, ServerName, MSL1, Debug, Hib);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, Hib);
 	{_From, Tag, {add_sup_handler, Handler, Args, SupP}} ->
 	    {Hib, Reply, MSL1} = server_add_sup_handler(Handler, Args, MSL, SupP),
 	    reply(Tag, Reply),
-	    loop(Parent, ServerName, MSL1, Debug, Hib);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, Hib);
 	{_From, Tag, {delete_handler, Handler, Args}} ->
 	    {Reply, MSL1} = server_delete_handler(Handler, Args, MSL,
 						  ServerName),
 	    reply(Tag, Reply),
-	    loop(Parent, ServerName, MSL1, Debug, false);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, false);
 	{_From, Tag, {swap_handler, Handler1, Args1, Handler2, Args2}} ->
 	    {Hib, Reply, MSL1} = server_swap_handler(Handler1, Args1, Handler2,
 						     Args2, MSL, ServerName),
 	    reply(Tag, Reply),
-	    loop(Parent, ServerName, MSL1, Debug, Hib);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, Hib);
 	{_From, Tag, {swap_sup_handler, Handler1, Args1, Handler2, Args2,
 		     Sup}} ->
 	    {Hib, Reply, MSL1} = server_swap_handler(Handler1, Args1, Handler2,
 						Args2, MSL, Sup, ServerName),
 	    reply(Tag, Reply),
-	    loop(Parent, ServerName, MSL1, Debug, Hib);
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, Hib);
 	{_From, Tag, stop} ->
 	    catch terminate_server(normal, Parent, MSL, ServerName),
 	    reply(Tag, ok);
 	{_From, Tag, which_handlers} ->
 	    reply(Tag, the_handlers(MSL)),
-	    loop(Parent, ServerName, MSL, Debug, false);
+	    loop(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, false);
 	{_From, Tag, get_modules} ->
 	    reply(Tag, get_modules(MSL)),
-	    loop(Parent, ServerName, MSL, Debug, false);
+	    loop(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, false);
 	Other  ->
 	    {Hib, MSL1} = server_notify(Other, handle_info, MSL, ServerName),
-	    loop(Parent, ServerName, MSL1, Debug, Hib)
+	    loop(Parent, ServerName, MSL1, AutoHibernateTimeout, Debug, Hib)
     end.
 
 terminate_server(Reason, Parent, MSL, ServerName) ->
@@ -392,18 +395,18 @@ terminate_supervised(Pid, Reason, MSL, SName) ->
 %%-----------------------------------------------------------------
 %% Callback functions for system messages handling.
 %%-----------------------------------------------------------------
-system_continue(Parent, Debug, [ServerName, MSL, Hib]) ->
-    loop(Parent, ServerName, MSL, Debug, Hib).
+system_continue(Parent, Debug, [ServerName, MSL, AutoHibernateTimeout, Hib]) ->
+    loop(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, Hib).
 
 -spec system_terminate(_, _, _, [_]) -> no_return().
-system_terminate(Reason, Parent, _Debug, [ServerName, MSL, _Hib]) ->
+system_terminate(Reason, Parent, _Debug, [ServerName, MSL, _AutoHibernateTimeout, _Hib]) ->
     terminate_server(Reason, Parent, MSL, ServerName).
 
 %%-----------------------------------------------------------------
 %% Module here is sent in the system msg change_code.  It specifies
 %% which module should be changed.
 %%-----------------------------------------------------------------
-system_code_change([ServerName, MSL, Hib], Module, OldVsn, Extra) ->
+system_code_change([ServerName, MSL, AutoHibernateTimeout, Hib], Module, OldVsn, Extra) ->
     MSL1 = lists:zf(fun(H) when H#handler.module =:= Module ->
 			    {ok, NewState} =
 				Module:code_change(OldVsn,
@@ -412,12 +415,12 @@ system_code_change([ServerName, MSL, Hib], Module, OldVsn, Extra) ->
 		       (_) -> true
 		    end,
 		    MSL),
-    {ok, [ServerName, MSL1, Hib]}.
+    {ok, [ServerName, MSL1, AutoHibernateTimeout, Hib]}.
 
-system_get_state([_ServerName, MSL, _Hib]) ->
+system_get_state([_ServerName, MSL, _AutoHibernateTimeout, _Hib]) ->
     {ok, [{Mod,Id,State} || #handler{module=Mod, id=Id, state=State} <- MSL]}.
 
-system_replace_state(StateFun, [ServerName, MSL, Hib]) ->
+system_replace_state(StateFun, [ServerName, MSL, AutoHibernateTimeout, Hib]) ->
     {NMSL, NStates} =
 		lists:unzip([begin
 				 Cur = {Mod,Id,State},
@@ -429,7 +432,7 @@ system_replace_state(StateFun, [ServerName, MSL, Hib]) ->
 					 {HS, Cur}
 				 end
 			     end || #handler{module=Mod, id=Id, state=State}=HS <- MSL]),
-    {ok, NStates, [ServerName, NMSL, Hib]}.
+    {ok, NStates, [ServerName, NMSL, AutoHibernateTimeout, Hib]}.
 
 %%-----------------------------------------------------------------
 %% Format debug messages.  Print them as the call-back module sees
@@ -798,7 +801,7 @@ get_modules(MSL) ->
 %% Status information
 %%-----------------------------------------------------------------
 format_status(Opt, StatusData) ->
-    [PDict, SysState, Parent, _Debug, [ServerName, MSL, _Hib]] = StatusData,
+    [PDict, SysState, Parent, _Debug, [ServerName, MSL, _AutoHibernateTimeout, _Hib]] = StatusData,
     Header = gen:format_status_header("Status for event handler",
                                       ServerName),
     FmtMSL = [case erlang:function_exported(Mod, format_status, 2) of

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -287,7 +287,7 @@ fetch_msg(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, Hib) ->
 				      ServerName, {in, Msg}),
 	    handle_msg(Msg, Parent, ServerName, MSL, AutoHibernateTimeout, Debug1)
     after AutoHibernateTimeout ->
-	    proc_lib:hibernate(?MODULE, wake_hib, [Parent, ServerName, MSL, AutoHibernateTimeout, Debug])
+	    loop(Parent, ServerName, MSL, AutoHibernateTimeout, Debug, true)
     end.
 
 handle_msg(Msg, Parent, ServerName, MSL, AutoHibernateTimeout, Debug) ->

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -329,8 +329,8 @@ enter_loop(Mod, Options, StateName, StateData, ServerName, Timeout) ->
     Name = gen:get_proc_name(ServerName),
     Parent = gen:get_parent(),
     Debug = gen:debug_options(Name, Options),
-	AutoHibernateTimeout = gen:auto_hibernate_timeout(Options),
-    loop(Parent, Name, StateName, StateData, Mod, Timeout, AutoHibernateTimeout, Debug).
+	HibernateAfterTimeout = gen:hibernate_after(Options),
+    loop(Parent, Name, StateName, StateData, Mod, Timeout, HibernateAfterTimeout, Debug).
 
 %%% ---------------------------------------------------
 %%% Initiate the new process.
@@ -344,14 +344,14 @@ init_it(Starter, self, Name, Mod, Args, Options) ->
 init_it(Starter, Parent, Name0, Mod, Args, Options) ->
     Name = gen:name(Name0),
     Debug = gen:debug_options(Name, Options),
-	AutoHibernateTimeout = gen:auto_hibernate_timeout(Options),
+	HibernateAfterTimeout = gen:hibernate_after(Options),
 	case catch Mod:init(Args) of
 	{ok, StateName, StateData} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
-	    loop(Parent, Name, StateName, StateData, Mod, infinity, AutoHibernateTimeout, Debug);
+	    loop(Parent, Name, StateName, StateData, Mod, infinity, HibernateAfterTimeout, Debug);
 	{ok, StateName, StateData, Timeout} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
-	    loop(Parent, Name, StateName, StateData, Mod, Timeout, AutoHibernateTimeout, Debug);
+	    loop(Parent, Name, StateName, StateData, Mod, Timeout, HibernateAfterTimeout, Debug);
 	{stop, Reason} ->
 	    gen:unregister_name(Name0),
 	    proc_lib:init_ack(Starter, {error, Reason}),
@@ -373,77 +373,77 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 %%-----------------------------------------------------------------
 %% The MAIN loop
 %%-----------------------------------------------------------------
-loop(Parent, Name, StateName, StateData, Mod, hibernate, AutoHibernateTimeout, Debug) ->
+loop(Parent, Name, StateName, StateData, Mod, hibernate, HibernateAfterTimeout, Debug) ->
     proc_lib:hibernate(?MODULE,wake_hib,
-		       [Parent, Name, StateName, StateData, Mod, AutoHibernateTimeout,
+		       [Parent, Name, StateName, StateData, Mod, HibernateAfterTimeout,
 			Debug]);
 
-loop(Parent, Name, StateName, StateData, Mod, infinity, AutoHibernateTimeout, Debug) ->
+loop(Parent, Name, StateName, StateData, Mod, infinity, HibernateAfterTimeout, Debug) ->
 	receive
 		Msg ->
-			decode_msg(Msg,Parent, Name, StateName, StateData, Mod, infinity, AutoHibernateTimeout, Debug, false)
-	after AutoHibernateTimeout ->
-		loop(Parent, Name, StateName, StateData, Mod, hibernate, AutoHibernateTimeout, Debug)
+			decode_msg(Msg,Parent, Name, StateName, StateData, Mod, infinity, HibernateAfterTimeout, Debug, false)
+	after HibernateAfterTimeout ->
+		loop(Parent, Name, StateName, StateData, Mod, hibernate, HibernateAfterTimeout, Debug)
 	end;
 
-loop(Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug) ->
+loop(Parent, Name, StateName, StateData, Mod, Time, HibernateAfterTimeout, Debug) ->
     Msg = receive
 	      Input ->
 		    Input
 	  after Time ->
 		  {'$gen_event', timeout}
 	  end,
-    decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug, false).
+    decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, HibernateAfterTimeout, Debug, false).
 
-wake_hib(Parent, Name, StateName, StateData, Mod, AutoHibernateTimeout, Debug) ->
+wake_hib(Parent, Name, StateName, StateData, Mod, HibernateAfterTimeout, Debug) ->
     Msg = receive
 	      Input ->
 		  Input
 	  end,
-    decode_msg(Msg, Parent, Name, StateName, StateData, Mod, hibernate, AutoHibernateTimeout, Debug, true).
+    decode_msg(Msg, Parent, Name, StateName, StateData, Mod, hibernate, HibernateAfterTimeout, Debug, true).
 
-decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug, Hib) ->
+decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, HibernateAfterTimeout, Debug, Hib) ->
     case Msg of
         {system, From, Req} ->
 	    sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug,
-				  [Name, StateName, StateData, Mod, Time, AutoHibernateTimeout], Hib);
+				  [Name, StateName, StateData, Mod, Time, HibernateAfterTimeout], Hib);
 	{'EXIT', Parent, Reason} ->
 	    terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug);
 	_Msg when Debug =:= [] ->
-	    handle_msg(Msg, Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout);
+	    handle_msg(Msg, Parent, Name, StateName, StateData, Mod, Time, HibernateAfterTimeout);
 	_Msg ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      {Name, StateName}, {in, Msg}),
 	    handle_msg(Msg, Parent, Name, StateName, StateData,
-		       Mod, Time, AutoHibernateTimeout, Debug1)
+		       Mod, Time, HibernateAfterTimeout, Debug1)
     end.
 
 %%-----------------------------------------------------------------
 %% Callback functions for system messages handling.
 %%-----------------------------------------------------------------
-system_continue(Parent, Debug, [Name, StateName, StateData, Mod, Time, AutoHibernateTimeout]) ->
-    loop(Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug).
+system_continue(Parent, Debug, [Name, StateName, StateData, Mod, Time, HibernateAfterTimeout]) ->
+    loop(Parent, Name, StateName, StateData, Mod, Time, HibernateAfterTimeout, Debug).
 
 -spec system_terminate(term(), _, _, [term(),...]) -> no_return().
 
 system_terminate(Reason, _Parent, Debug,
-		 [Name, StateName, StateData, Mod, _Time, _AutoHibernateTimeout]) ->
+		 [Name, StateName, StateData, Mod, _Time, _HibernateAfterTimeout]) ->
     terminate(Reason, Name, [], Mod, StateName, StateData, Debug).
 
-system_code_change([Name, StateName, StateData, Mod, Time, AutoHibernateTimeout],
+system_code_change([Name, StateName, StateData, Mod, Time, HibernateAfterTimeout],
 		   _Module, OldVsn, Extra) ->
     case catch Mod:code_change(OldVsn, StateName, StateData, Extra) of
 	{ok, NewStateName, NewStateData} ->
-	    {ok, [Name, NewStateName, NewStateData, Mod, Time, AutoHibernateTimeout]};
+	    {ok, [Name, NewStateName, NewStateData, Mod, Time, HibernateAfterTimeout]};
 	Else -> Else
     end.
 
-system_get_state([_Name, StateName, StateData, _Mod, _Time, _AutoHibernateTimeout]) ->
+system_get_state([_Name, StateName, StateData, _Mod, _Time, _HibernateAfterTimeout]) ->
     {ok, {StateName, StateData}}.
 
-system_replace_state(StateFun, [Name, StateName, StateData, Mod, Time, AutoHibernateTimeout]) ->
+system_replace_state(StateFun, [Name, StateName, StateData, Mod, Time, HibernateAfterTimeout]) ->
     Result = {NStateName, NStateData} = StateFun({StateName, StateData}),
-    {ok, Result, [Name, NStateName, NStateData, Mod, Time, AutoHibernateTimeout]}.
+    {ok, Result, [Name, NStateName, NStateData, Mod, Time, HibernateAfterTimeout]}.
 
 %%-----------------------------------------------------------------
 %% Format debug messages.  Print them as the call-back module sees
@@ -478,19 +478,19 @@ print_event(Dev, return, {Name, StateName}) ->
     io:format(Dev, "*DBG* ~p switched to state ~w~n",
 	      [Name, StateName]).
 
-handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, AutoHibernateTimeout) -> %No debug here
+handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, HibernateAfterTimeout) -> %No debug here
     From = from(Msg),
     case catch dispatch(Msg, Mod, StateName, StateData) of
 	{next_state, NStateName, NStateData} ->	    
-	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, AutoHibernateTimeout, []);
+	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, HibernateAfterTimeout, []);
 	{next_state, NStateName, NStateData, Time1} ->
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, AutoHibernateTimeout, []);
+	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, HibernateAfterTimeout, []);
         {reply, Reply, NStateName, NStateData} when From =/= undefined ->
 	    reply(From, Reply),
-	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, AutoHibernateTimeout, []);
+	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, HibernateAfterTimeout, []);
         {reply, Reply, NStateName, NStateData, Time1} when From =/= undefined ->
 	    reply(From, Reply),
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, AutoHibernateTimeout, []);
+	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, HibernateAfterTimeout, []);
 	{stop, Reason, NStateData} ->
 	    terminate(Reason, Name, Msg, Mod, StateName, NStateData, []);
 	{stop, Reason, Reply, NStateData} when From =/= undefined ->
@@ -509,23 +509,23 @@ handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, AutoHibernateTim
 		      Name, Msg, Mod, StateName, StateData, [])
     end.
 
-handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, AutoHibernateTimeout, Debug) ->
+handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, HibernateAfterTimeout, Debug) ->
     From = from(Msg),
     case catch dispatch(Msg, Mod, StateName, StateData) of
 	{next_state, NStateName, NStateData} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      {Name, NStateName}, return),
-	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, AutoHibernateTimeout, Debug1);
+	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, HibernateAfterTimeout, Debug1);
 	{next_state, NStateName, NStateData, Time1} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      {Name, NStateName}, return),
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, AutoHibernateTimeout, Debug1);
+	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, HibernateAfterTimeout, Debug1);
         {reply, Reply, NStateName, NStateData} when From =/= undefined ->
 	    Debug1 = reply(Name, From, Reply, Debug, NStateName),
-	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, AutoHibernateTimeout, Debug1);
+	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, HibernateAfterTimeout, Debug1);
         {reply, Reply, NStateName, NStateData, Time1} when From =/= undefined ->
 	    Debug1 = reply(Name, From, Reply, Debug, NStateName),
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, AutoHibernateTimeout, Debug1);
+	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, HibernateAfterTimeout, Debug1);
 	{stop, Reason, NStateData} ->
 	    terminate(Reason, Name, Msg, Mod, StateName, NStateData, Debug);
 	{stop, Reason, Reply, NStateData} when From =/= undefined ->
@@ -656,7 +656,7 @@ get_msg(Msg) -> Msg.
 %% Status information
 %%-----------------------------------------------------------------
 format_status(Opt, StatusData) ->
-    [PDict, SysState, Parent, Debug, [Name, StateName, StateData, Mod, _Time, _AutoHibernateTimeout]] =
+    [PDict, SysState, Parent, Debug, [Name, StateName, StateData, Mod, _Time, _HibernateAfterTimeout]] =
 	StatusData,
     Header = gen:format_status_header("Status for state machine",
                                       Name),

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -383,7 +383,7 @@ loop(Parent, Name, StateName, StateData, Mod, infinity, AutoHibernateTimeout, De
 		Msg ->
 			decode_msg(Msg,Parent, Name, StateName, StateData, Mod, infinity, AutoHibernateTimeout, Debug, false)
 	after AutoHibernateTimeout ->
-		proc_lib:hibernate(?MODULE,wake_hib, [Parent, Name, StateName, StateData, Mod, AutoHibernateTimeout, Debug])
+		loop(Parent, Name, StateName, StateData, Mod, hibernate, AutoHibernateTimeout, Debug)
 	end;
 
 loop(Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug) ->

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -113,7 +113,7 @@
 	 sync_send_all_state_event/2, sync_send_all_state_event/3,
 	 reply/2,
 	 start_timer/2,send_event_after/2,cancel_timer/1,
-	 enter_loop/4, enter_loop/5, enter_loop/6, wake_hib/6]).
+	 enter_loop/4, enter_loop/5, enter_loop/6, wake_hib/7]).
 
 %% Internal exports
 -export([init_it/6,
@@ -329,7 +329,8 @@ enter_loop(Mod, Options, StateName, StateData, ServerName, Timeout) ->
     Name = gen:get_proc_name(ServerName),
     Parent = gen:get_parent(),
     Debug = gen:debug_options(Name, Options),
-    loop(Parent, Name, StateName, StateData, Mod, Timeout, Debug).
+	AutoHibernateTimeout = gen:auto_hibernate_timeout(Options),
+    loop(Parent, Name, StateName, StateData, Mod, Timeout, AutoHibernateTimeout, Debug).
 
 %%% ---------------------------------------------------
 %%% Initiate the new process.
@@ -343,13 +344,14 @@ init_it(Starter, self, Name, Mod, Args, Options) ->
 init_it(Starter, Parent, Name0, Mod, Args, Options) ->
     Name = gen:name(Name0),
     Debug = gen:debug_options(Name, Options),
-    case catch Mod:init(Args) of
+	AutoHibernateTimeout = gen:auto_hibernate_timeout(Options),
+	case catch Mod:init(Args) of
 	{ok, StateName, StateData} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
-	    loop(Parent, Name, StateName, StateData, Mod, infinity, Debug);
+	    loop(Parent, Name, StateName, StateData, Mod, infinity, AutoHibernateTimeout, Debug);
 	{ok, StateName, StateData, Timeout} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
-	    loop(Parent, Name, StateName, StateData, Mod, Timeout, Debug);
+	    loop(Parent, Name, StateName, StateData, Mod, Timeout, AutoHibernateTimeout, Debug);
 	{stop, Reason} ->
 	    gen:unregister_name(Name0),
 	    proc_lib:init_ack(Starter, {error, Reason}),
@@ -371,68 +373,77 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 %%-----------------------------------------------------------------
 %% The MAIN loop
 %%-----------------------------------------------------------------
-loop(Parent, Name, StateName, StateData, Mod, hibernate, Debug) ->
+loop(Parent, Name, StateName, StateData, Mod, hibernate, AutoHibernateTimeout, Debug) ->
     proc_lib:hibernate(?MODULE,wake_hib,
-		       [Parent, Name, StateName, StateData, Mod, 
+		       [Parent, Name, StateName, StateData, Mod, AutoHibernateTimeout,
 			Debug]);
-loop(Parent, Name, StateName, StateData, Mod, Time, Debug) ->
+
+loop(Parent, Name, StateName, StateData, Mod, infinity, AutoHibernateTimeout, Debug) ->
+	receive
+		Msg ->
+			decode_msg(Msg,Parent, Name, StateName, StateData, Mod, infinity, AutoHibernateTimeout, Debug, false)
+	after AutoHibernateTimeout ->
+		proc_lib:hibernate(?MODULE,wake_hib, [Parent, Name, StateName, StateData, Mod, AutoHibernateTimeout, Debug])
+	end;
+
+loop(Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug) ->
     Msg = receive
 	      Input ->
 		    Input
 	  after Time ->
 		  {'$gen_event', timeout}
 	  end,
-    decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, Debug, false).
+    decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug, false).
 
-wake_hib(Parent, Name, StateName, StateData, Mod, Debug) ->
+wake_hib(Parent, Name, StateName, StateData, Mod, AutoHibernateTimeout, Debug) ->
     Msg = receive
 	      Input ->
 		  Input
 	  end,
-    decode_msg(Msg, Parent, Name, StateName, StateData, Mod, hibernate, Debug, true).
+    decode_msg(Msg, Parent, Name, StateName, StateData, Mod, hibernate, AutoHibernateTimeout, Debug, true).
 
-decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, Debug, Hib) ->
+decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug, Hib) ->
     case Msg of
         {system, From, Req} ->
 	    sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug,
-				  [Name, StateName, StateData, Mod, Time], Hib);
+				  [Name, StateName, StateData, Mod, Time, AutoHibernateTimeout], Hib);
 	{'EXIT', Parent, Reason} ->
 	    terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug);
 	_Msg when Debug =:= [] ->
-	    handle_msg(Msg, Parent, Name, StateName, StateData, Mod, Time);
+	    handle_msg(Msg, Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout);
 	_Msg ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      {Name, StateName}, {in, Msg}),
 	    handle_msg(Msg, Parent, Name, StateName, StateData,
-		       Mod, Time, Debug1)
+		       Mod, Time, AutoHibernateTimeout, Debug1)
     end.
 
 %%-----------------------------------------------------------------
 %% Callback functions for system messages handling.
 %%-----------------------------------------------------------------
-system_continue(Parent, Debug, [Name, StateName, StateData, Mod, Time]) ->
-    loop(Parent, Name, StateName, StateData, Mod, Time, Debug).
+system_continue(Parent, Debug, [Name, StateName, StateData, Mod, Time, AutoHibernateTimeout]) ->
+    loop(Parent, Name, StateName, StateData, Mod, Time, AutoHibernateTimeout, Debug).
 
 -spec system_terminate(term(), _, _, [term(),...]) -> no_return().
 
 system_terminate(Reason, _Parent, Debug,
-		 [Name, StateName, StateData, Mod, _Time]) ->
+		 [Name, StateName, StateData, Mod, _Time, _AutoHibernateTimeout]) ->
     terminate(Reason, Name, [], Mod, StateName, StateData, Debug).
 
-system_code_change([Name, StateName, StateData, Mod, Time],
+system_code_change([Name, StateName, StateData, Mod, Time, AutoHibernateTimeout],
 		   _Module, OldVsn, Extra) ->
     case catch Mod:code_change(OldVsn, StateName, StateData, Extra) of
 	{ok, NewStateName, NewStateData} ->
-	    {ok, [Name, NewStateName, NewStateData, Mod, Time]};
+	    {ok, [Name, NewStateName, NewStateData, Mod, Time, AutoHibernateTimeout]};
 	Else -> Else
     end.
 
-system_get_state([_Name, StateName, StateData, _Mod, _Time]) ->
+system_get_state([_Name, StateName, StateData, _Mod, _Time, _AutoHibernateTimeout]) ->
     {ok, {StateName, StateData}}.
 
-system_replace_state(StateFun, [Name, StateName, StateData, Mod, Time]) ->
+system_replace_state(StateFun, [Name, StateName, StateData, Mod, Time, AutoHibernateTimeout]) ->
     Result = {NStateName, NStateData} = StateFun({StateName, StateData}),
-    {ok, Result, [Name, NStateName, NStateData, Mod, Time]}.
+    {ok, Result, [Name, NStateName, NStateData, Mod, Time, AutoHibernateTimeout]}.
 
 %%-----------------------------------------------------------------
 %% Format debug messages.  Print them as the call-back module sees
@@ -467,19 +478,19 @@ print_event(Dev, return, {Name, StateName}) ->
     io:format(Dev, "*DBG* ~p switched to state ~w~n",
 	      [Name, StateName]).
 
-handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time) -> %No debug here
+handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, AutoHibernateTimeout) -> %No debug here
     From = from(Msg),
     case catch dispatch(Msg, Mod, StateName, StateData) of
 	{next_state, NStateName, NStateData} ->	    
-	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, []);
+	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, AutoHibernateTimeout, []);
 	{next_state, NStateName, NStateData, Time1} ->
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, []);
+	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, AutoHibernateTimeout, []);
         {reply, Reply, NStateName, NStateData} when From =/= undefined ->
 	    reply(From, Reply),
-	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, []);
+	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, AutoHibernateTimeout, []);
         {reply, Reply, NStateName, NStateData, Time1} when From =/= undefined ->
 	    reply(From, Reply),
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, []);
+	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, AutoHibernateTimeout, []);
 	{stop, Reason, NStateData} ->
 	    terminate(Reason, Name, Msg, Mod, StateName, NStateData, []);
 	{stop, Reason, Reply, NStateData} when From =/= undefined ->
@@ -498,23 +509,23 @@ handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time) -> %No debug her
 		      Name, Msg, Mod, StateName, StateData, [])
     end.
 
-handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, Debug) ->
+handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, AutoHibernateTimeout, Debug) ->
     From = from(Msg),
     case catch dispatch(Msg, Mod, StateName, StateData) of
 	{next_state, NStateName, NStateData} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      {Name, NStateName}, return),
-	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, Debug1);
+	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, AutoHibernateTimeout, Debug1);
 	{next_state, NStateName, NStateData, Time1} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      {Name, NStateName}, return),
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, Debug1);
+	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, AutoHibernateTimeout, Debug1);
         {reply, Reply, NStateName, NStateData} when From =/= undefined ->
 	    Debug1 = reply(Name, From, Reply, Debug, NStateName),
-	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, Debug1);
+	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, AutoHibernateTimeout, Debug1);
         {reply, Reply, NStateName, NStateData, Time1} when From =/= undefined ->
 	    Debug1 = reply(Name, From, Reply, Debug, NStateName),
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, Debug1);
+	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, AutoHibernateTimeout, Debug1);
 	{stop, Reason, NStateData} ->
 	    terminate(Reason, Name, Msg, Mod, StateName, NStateData, Debug);
 	{stop, Reason, Reply, NStateData} when From =/= undefined ->
@@ -645,7 +656,7 @@ get_msg(Msg) -> Msg.
 %% Status information
 %%-----------------------------------------------------------------
 format_status(Opt, StatusData) ->
-    [PDict, SysState, Parent, Debug, [Name, StateName, StateData, Mod, _Time]] =
+    [PDict, SysState, Parent, Debug, [Name, StateName, StateData, Mod, _Time, _AutoHibernateTimeout]] =
 	StatusData,
     Header = gen:format_status_header("Status for state machine",
                                       Name),

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -501,7 +501,7 @@ handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, HibernateAfterTi
         {'EXIT', {undef, [{Mod, handle_info, [_,_,_], _}|_]}} ->
             error_logger:warning_msg("** Undefined handle_info in ~p~n"
                                      "** Unhandled message: ~p~n", [Mod, Msg]),
-            loop(Parent, Name, StateName, StateData, Mod, infinity, []);
+            loop(Parent, Name, StateName, StateData, Mod, infinity, HibernateAfterTimeout, []);
 	{'EXIT', What} ->
 	    terminate(What, Name, Msg, Mod, StateName, StateData, []);
 	Reply ->

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -372,7 +372,7 @@ loop(Parent, Name, State, Mod, infinity, AutoHibernateTimeout, Debug) ->
 		Msg ->
 			decode_msg(Msg, Parent, Name, State, Mod, infinity, AutoHibernateTimeout, Debug, false)
 	after AutoHibernateTimeout ->
-		proc_lib:hibernate(?MODULE,wake_hib,[Parent, Name, State, Mod, AutoHibernateTimeout, Debug])
+		loop(Parent, Name, State, Mod, hibernate, AutoHibernateTimeout, Debug)
 	end;
 
 loop(Parent, Name, State, Mod, Time, AutoHibernateTimeout, Debug) ->

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -94,7 +94,7 @@
 	 cast/2, reply/2,
 	 abcast/2, abcast/3,
 	 multi_call/2, multi_call/3, multi_call/4,
-	 enter_loop/3, enter_loop/4, enter_loop/5, wake_hib/5]).
+	 enter_loop/3, enter_loop/4, enter_loop/5, wake_hib/6]).
 
 %% System exports
 -export([system_continue/3,
@@ -307,7 +307,8 @@ enter_loop(Mod, Options, State, ServerName, Timeout) ->
     Name = gen:get_proc_name(ServerName),
     Parent = gen:get_parent(),
     Debug = gen:debug_options(Name, Options),
-    loop(Parent, Name, State, Mod, Timeout, Debug).
+	AutoHibernateTimeout = gen:auto_hibernate_timeout(Options),
+    loop(Parent, Name, State, Mod, Timeout, AutoHibernateTimeout, Debug).
 
 %%%========================================================================
 %%% Gen-callback functions
@@ -325,13 +326,14 @@ init_it(Starter, self, Name, Mod, Args, Options) ->
 init_it(Starter, Parent, Name0, Mod, Args, Options) ->
     Name = gen:name(Name0),
     Debug = gen:debug_options(Name, Options),
+	AutoHibernateTimeout = gen:auto_hibernate_timeout(Options),
     case catch Mod:init(Args) of
 	{ok, State} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
-	    loop(Parent, Name, State, Mod, infinity, Debug);
+	    loop(Parent, Name, State, Mod, infinity, AutoHibernateTimeout, Debug);
 	{ok, State, Timeout} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
-	    loop(Parent, Name, State, Mod, Timeout, Debug);
+	    loop(Parent, Name, State, Mod, Timeout, AutoHibernateTimeout, Debug);
 	{stop, Reason} ->
 	    %% For consistency, we must make sure that the
 	    %% registered name (if any) is unregistered before
@@ -362,37 +364,46 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 %%% ---------------------------------------------------
 %%% The MAIN loop.
 %%% ---------------------------------------------------
-loop(Parent, Name, State, Mod, hibernate, Debug) ->
-    proc_lib:hibernate(?MODULE,wake_hib,[Parent, Name, State, Mod, Debug]);
-loop(Parent, Name, State, Mod, Time, Debug) ->
+loop(Parent, Name, State, Mod, hibernate, AutoHibernateTimeout, Debug) ->
+    proc_lib:hibernate(?MODULE,wake_hib,[Parent, Name, State, Mod, AutoHibernateTimeout, Debug]);
+
+loop(Parent, Name, State, Mod, infinity, AutoHibernateTimeout, Debug) ->
+	receive
+		Msg ->
+			decode_msg(Msg, Parent, Name, State, Mod, infinity, AutoHibernateTimeout, Debug, false)
+	after AutoHibernateTimeout ->
+		proc_lib:hibernate(?MODULE,wake_hib,[Parent, Name, State, Mod, AutoHibernateTimeout, Debug])
+	end;
+
+loop(Parent, Name, State, Mod, Time, AutoHibernateTimeout, Debug) ->
     Msg = receive
 	      Input ->
 		    Input
 	  after Time ->
 		  timeout
 	  end,
-    decode_msg(Msg, Parent, Name, State, Mod, Time, Debug, false).
+    decode_msg(Msg, Parent, Name, State, Mod, Time, AutoHibernateTimeout, Debug, false).
 
-wake_hib(Parent, Name, State, Mod, Debug) ->
+wake_hib(Parent, Name, State, Mod, AutoHibernateTimeout, Debug) ->
     Msg = receive
 	      Input ->
 		  Input
 	  end,
-    decode_msg(Msg, Parent, Name, State, Mod, hibernate, Debug, true).
+    decode_msg(Msg, Parent, Name, State, Mod, hibernate, AutoHibernateTimeout, Debug, true).
 
-decode_msg(Msg, Parent, Name, State, Mod, Time, Debug, Hib) ->
+decode_msg(Msg, Parent, Name, State, Mod, Time, AutoHibernateTimeout, Debug, Hib) ->
     case Msg of
 	{system, From, Req} ->
 	    sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug,
-				  [Name, State, Mod, Time], Hib);
+				  [Name, State, Mod, Time, AutoHibernateTimeout], Hib);
 	{'EXIT', Parent, Reason} ->
 	    terminate(Reason, Name, undefined, Msg, Mod, State, Debug);
 	_Msg when Debug =:= [] ->
-	    handle_msg(Msg, Parent, Name, State, Mod);
+	    handle_msg(Msg, Parent, Name, State, Mod, AutoHibernateTimeout);
 	_Msg ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      Name, {in, Msg}),
-	    handle_msg(Msg, Parent, Name, State, Mod, Debug1)
+	    handle_msg(Msg, Parent, Name, State, Mod, AutoHibernateTimeout, Debug1)
     end.
 
 %%% ---------------------------------------------------
@@ -659,65 +670,65 @@ try_terminate(Mod, Reason, State) ->
 %%% Message handling functions
 %%% ---------------------------------------------------
 
-handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod) ->
+handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod, AutoHibernateTimeout) ->
     Result = try_handle_call(Mod, Msg, From, State),
     case Result of
 	{ok, {reply, Reply, NState}} ->
 	    reply(From, Reply),
-	    loop(Parent, Name, NState, Mod, infinity, []);
+	    loop(Parent, Name, NState, Mod, infinity, AutoHibernateTimeout, []);
 	{ok, {reply, Reply, NState, Time1}} ->
 	    reply(From, Reply),
-	    loop(Parent, Name, NState, Mod, Time1, []);
+	    loop(Parent, Name, NState, Mod, Time1, AutoHibernateTimeout, []);
 	{ok, {noreply, NState}} ->
-	    loop(Parent, Name, NState, Mod, infinity, []);
+	    loop(Parent, Name, NState, Mod, infinity, AutoHibernateTimeout, []);
 	{ok, {noreply, NState, Time1}} ->
-	    loop(Parent, Name, NState, Mod, Time1, []);
+	    loop(Parent, Name, NState, Mod, Time1, AutoHibernateTimeout, []);
 	{ok, {stop, Reason, Reply, NState}} ->
 	    {'EXIT', R} = 
 		(catch terminate(Reason, Name, From, Msg, Mod, NState, [])),
 	    reply(From, Reply),
 	    exit(R);
-	Other -> handle_common_reply(Other, Parent, Name, From, Msg, Mod, State)
+	Other -> handle_common_reply(Other, Parent, Name, From, Msg, Mod, AutoHibernateTimeout, State)
     end;
-handle_msg(Msg, Parent, Name, State, Mod) ->
+handle_msg(Msg, Parent, Name, State, Mod, AutoHibernateTimeout) ->
     Reply = try_dispatch(Msg, Mod, State),
-    handle_common_reply(Reply, Parent, Name, undefined, Msg, Mod, State).
+    handle_common_reply(Reply, Parent, Name, undefined, Msg, Mod, AutoHibernateTimeout, State).
 
-handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod, Debug) ->
+handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod, AutoHibernateTimeout, Debug) ->
     Result = try_handle_call(Mod, Msg, From, State),
     case Result of
 	{ok, {reply, Reply, NState}} ->
 	    Debug1 = reply(Name, From, Reply, NState, Debug),
-	    loop(Parent, Name, NState, Mod, infinity, Debug1);
+	    loop(Parent, Name, NState, Mod, infinity, AutoHibernateTimeout, Debug1);
 	{ok, {reply, Reply, NState, Time1}} ->
 	    Debug1 = reply(Name, From, Reply, NState, Debug),
-	    loop(Parent, Name, NState, Mod, Time1, Debug1);
+	    loop(Parent, Name, NState, Mod, Time1, AutoHibernateTimeout, Debug1);
 	{ok, {noreply, NState}} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name,
 				      {noreply, NState}),
-	    loop(Parent, Name, NState, Mod, infinity, Debug1);
+	    loop(Parent, Name, NState, Mod, infinity, AutoHibernateTimeout, Debug1);
 	{ok, {noreply, NState, Time1}} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name,
 				      {noreply, NState}),
-	    loop(Parent, Name, NState, Mod, Time1, Debug1);
+	    loop(Parent, Name, NState, Mod, Time1, AutoHibernateTimeout, Debug1);
 	{ok, {stop, Reason, Reply, NState}} ->
 	    {'EXIT', R} = 
 		(catch terminate(Reason, Name, From, Msg, Mod, NState, Debug)),
 	    _ = reply(Name, From, Reply, NState, Debug),
 	    exit(R);
 	Other ->
-	    handle_common_reply(Other, Parent, Name, From, Msg, Mod, State, Debug)
+	    handle_common_reply(Other, Parent, Name, From, Msg, Mod, AutoHibernateTimeout, State, Debug)
     end;
-handle_msg(Msg, Parent, Name, State, Mod, Debug) ->
+handle_msg(Msg, Parent, Name, State, Mod, AutoHibernateTimeout, Debug) ->
     Reply = try_dispatch(Msg, Mod, State),
-    handle_common_reply(Reply, Parent, Name, undefined, Msg, Mod, State, Debug).
+    handle_common_reply(Reply, Parent, Name, undefined, Msg, Mod, AutoHibernateTimeout, State, Debug).
 
-handle_common_reply(Reply, Parent, Name, From, Msg, Mod, State) ->
+handle_common_reply(Reply, Parent, Name, From, Msg, Mod, AutoHibernateTimeout, State) ->
     case Reply of
 	{ok, {noreply, NState}} ->
-	    loop(Parent, Name, NState, Mod, infinity, []);
+	    loop(Parent, Name, NState, Mod, infinity, AutoHibernateTimeout, []);
 	{ok, {noreply, NState, Time1}} ->
-	    loop(Parent, Name, NState, Mod, Time1, []);
+	    loop(Parent, Name, NState, Mod, Time1, AutoHibernateTimeout, []);
 	{ok, {stop, Reason, NState}} ->
 	    terminate(Reason, Name, From, Msg, Mod, NState, []);
 	{'EXIT', ExitReason, ReportReason} ->
@@ -726,16 +737,16 @@ handle_common_reply(Reply, Parent, Name, From, Msg, Mod, State) ->
 	    terminate({bad_return_value, BadReply}, Name, From, Msg, Mod, State, [])
     end.
 
-handle_common_reply(Reply, Parent, Name, From, Msg, Mod, State, Debug) ->
+handle_common_reply(Reply, Parent, Name, From, Msg, Mod, AutoHibernateTimeout, State, Debug) ->
     case Reply of
 	{ok, {noreply, NState}} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name,
 				      {noreply, NState}),
-	    loop(Parent, Name, NState, Mod, infinity, Debug1);
+	    loop(Parent, Name, NState, Mod, infinity, AutoHibernateTimeout, Debug1);
 	{ok, {noreply, NState, Time1}} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name,
 				      {noreply, NState}),
-	    loop(Parent, Name, NState, Mod, Time1, Debug1);
+	    loop(Parent, Name, NState, Mod, Time1, AutoHibernateTimeout, Debug1);
 	{ok, {stop, Reason, NState}} ->
 	    terminate(Reason, Name, From, Msg, Mod, NState, Debug);
 	{'EXIT', ExitReason, ReportReason} ->
@@ -753,26 +764,26 @@ reply(Name, {To, Tag}, Reply, State, Debug) ->
 %%-----------------------------------------------------------------
 %% Callback functions for system messages handling.
 %%-----------------------------------------------------------------
-system_continue(Parent, Debug, [Name, State, Mod, Time]) ->
-    loop(Parent, Name, State, Mod, Time, Debug).
+system_continue(Parent, Debug, [Name, State, Mod, Time, AutoHibernateTimeout]) ->
+    loop(Parent, Name, State, Mod, Time, AutoHibernateTimeout, Debug).
 
 -spec system_terminate(_, _, _, [_]) -> no_return().
 
-system_terminate(Reason, _Parent, Debug, [Name, State, Mod, _Time]) ->
+system_terminate(Reason, _Parent, Debug, [Name, State, Mod, _Time, _AutoHibernateTimeout]) ->
     terminate(Reason, Name, undefined, [], Mod, State, Debug).
 
-system_code_change([Name, State, Mod, Time], _Module, OldVsn, Extra) ->
+system_code_change([Name, State, Mod, Time, AutoHibernateTimeout], _Module, OldVsn, Extra) ->
     case catch Mod:code_change(OldVsn, State, Extra) of
-	{ok, NewState} -> {ok, [Name, NewState, Mod, Time]};
+	{ok, NewState} -> {ok, [Name, NewState, Mod, Time, AutoHibernateTimeout]};
 	Else -> Else
     end.
 
-system_get_state([_Name, State, _Mod, _Time]) ->
+system_get_state([_Name, State, _Mod, _Time, _AutoHibernateTimeout]) ->
     {ok, State}.
 
-system_replace_state(StateFun, [Name, State, Mod, Time]) ->
+system_replace_state(StateFun, [Name, State, Mod, Time, AutoHibernateTimeout]) ->
     NState = StateFun(State),
-    {ok, NState, [Name, NState, Mod, Time]}.
+    {ok, NState, [Name, NState, Mod, Time, AutoHibernateTimeout]}.
 
 %%-----------------------------------------------------------------
 %% Format debug messages.  Print them as the call-back module sees
@@ -802,10 +813,10 @@ print_event(Dev, Event, Name) ->
 %%% Terminate the server.
 %%% ---------------------------------------------------
 
+
 -spec terminate(_, _, _, _, _, _, _) -> no_return().
 terminate(Reason, Name, From, Msg, Mod, State, Debug) ->
     terminate(Reason, Reason, Name, From, Msg, Mod, State, Debug).
-
 -spec terminate(_, _, _, _, _, _, _, _) -> no_return().
 terminate(ExitReason, ReportReason, Name, From, Msg, Mod, State, Debug) ->
     Reply = try_terminate(Mod, ExitReason, State),
@@ -851,7 +862,7 @@ error_info(Reason, Name, From, Msg, State, Debug) ->
 		end;
 	    _ ->
 		Reason
-	end,
+	end,    
     {ClientFmt, ClientArgs} = client_stacktrace(From),
     format("** Generic server ~p terminating \n"
            "** Last message in was ~p~n"
@@ -860,7 +871,6 @@ error_info(Reason, Name, From, Msg, State, Debug) ->
 	   [Name, Msg, State, Reason1] ++ ClientArgs),
     sys:print_log(Debug),
     ok.
-
 client_stacktrace(undefined) ->
     {"", []};
 client_stacktrace({From, _Tag}) ->
@@ -885,7 +895,7 @@ client_stacktrace(From) when is_pid(From) ->
 %% Status information
 %%-----------------------------------------------------------------
 format_status(Opt, StatusData) ->
-    [PDict, SysState, Parent, Debug, [Name, State, Mod, _Time]] = StatusData,
+    [PDict, SysState, Parent, Debug, [Name, State, Mod, _Time, _AutoHibernateTimeout]] = StatusData,
     Header = gen:format_status_header("Status for generic server", Name),
     Log = sys:get_debug(log, Debug, []),
     Specfic = case format_status(Opt, Mod, PDict, State) of

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -369,9 +369,12 @@ event_type(Type) ->
 	 Dbgs ::
 	   ['trace' | 'log' | 'statistics' | 'debug'
 	    | {'logfile', string()}]}.
+-type auto_hibernate_timeout_opt() ::
+	{'auto_hibernate_timeout', AutoHibernateTimeout :: timeout()}.
 -type start_opt() ::
 	debug_opt()
       | {'timeout', Time :: timeout()}
+	  | auto_hibernate_timeout_opt()
       | {'spawn_opt', [proc_lib:spawn_option()]}.
 -type start_ret() ::  {'ok', pid()} | 'ignore' | {'error', term()}.
 
@@ -544,14 +547,14 @@ reply({To,Tag}, Reply) when is_pid(To) ->
 %% started by proc_lib into a state machine using
 %% the same arguments as you would have returned from init/1
 -spec enter_loop(
-	Module :: module(), Opts :: [debug_opt()],
+	Module :: module(), Opts :: [debug_opt() | auto_hibernate_timeout_opt()],
 	State :: state(), Data :: data()) ->
 			no_return().
 enter_loop(Module, Opts, State, Data) ->
     enter_loop(Module, Opts, State, Data, self()).
 %%
 -spec enter_loop(
-	Module :: module(), Opts :: [debug_opt()],
+	Module :: module(), Opts :: [debug_opt() | auto_hibernate_timeout_opt()],
 	State :: state(), Data :: data(),
 	Server_or_Actions ::
 	  server_name() | pid() | [action()]) ->
@@ -565,7 +568,7 @@ enter_loop(Module, Opts, State, Data, Server_or_Actions) ->
     end.
 %%
 -spec enter_loop(
-	Module :: module(), Opts :: [debug_opt()],
+	Module :: module(), Opts :: [debug_opt() | auto_hibernate_timeout_opt()],
 	State :: state(), Data :: data(),
 	Server :: server_name() | pid(),
 	Actions :: [action()] | action()) ->
@@ -605,7 +608,8 @@ enter(Module, Opts, State, Data, Server, Actions, Parent) ->
     %% The values should already have been type checked
     Name = gen:get_proc_name(Server),
     Debug = gen:debug_options(Name, Opts),
-    Events = [],
+	AutoHibernateTimeout = gen:auto_hibernate_timeout(Opts),
+	Events = [],
     P = [],
     Event = {internal,init_state},
     %% We enforce {postpone,false} to ensure that
@@ -648,6 +652,7 @@ enter(Module, Opts, State, Data, Server, Actions, Parent) ->
       timer_refs => TimerRefs,
       timer_types => TimerTypes,
       hibernate => Hibernate,
+	  auto_hibernate_timeout => AutoHibernateTimeout,
       cancel_timers => CancelTimers
      },
     NewDebug = sys_debug(Debug, S, State, {enter,Event,State}),
@@ -854,109 +859,117 @@ loop_hibernate(Parent, Debug, S) ->
        {wakeup_from_hibernate,3}}).
 
 %% Entry point for wakeup_from_hibernate/3
-loop_receive(Parent, Debug, S) ->
+loop_receive(Parent, Debug, #{cancel_timers := 0, auto_hibernate_timeout := AutoHibernateTimeout} = S) when is_integer(AutoHibernateTimeout) ->
     receive
 	Msg ->
-	    case Msg of
-		{system,Pid,Req} ->
-		    #{hibernate := Hibernate} = S,
-		    %% Does not return but tail recursively calls
-		    %% system_continue/3 that jumps to loop/3
-		    sys:handle_system_msg(
-		      Req, Pid, Parent, ?MODULE, Debug, S,
-		      Hibernate);
-		{'EXIT',Parent,Reason} = EXIT ->
-		    %% EXIT is not a 2-tuple therefore
-		    %% not an event but this will stand out
-		    %% in the crash report...
-		    Q = [EXIT],
-		    terminate(exit, Reason, ?STACKTRACE(), Debug, S, Q);
-		{timeout,TimerRef,TimerMsg} ->
-		    #{timer_refs := TimerRefs,
-		      timer_types := TimerTypes,
-		      hibernate := Hibernate} = S,
-		    case TimerRefs of
-			#{TimerRef := TimerType} ->
-			    %% We know of this timer; is it a running
-			    %% timer or a timer being cancelled that
-			    %% managed to send a late timeout message?
-			    case TimerTypes of
+		handle_received_msg(Msg, Parent, Debug, S)
+	after
+	    AutoHibernateTimeout ->
+		    loop_hibernate(Parent, Debug, S)
+    end;
+loop_receive(Parent, Debug, S) ->
+	receive
+		Msg ->
+			handle_received_msg(Msg, Parent, Debug, S)
+	end.
+
+handle_received_msg({system,Pid,Req}, Parent, Debug, S) ->
+	#{hibernate := Hibernate} = S,
+	%% Does not return but tail recursively calls
+	%% system_continue/3 that jumps to loop/3
+	sys:handle_system_msg(
+		Req, Pid, Parent, ?MODULE, Debug, S,
+		Hibernate);
+handle_received_msg({'EXIT',Parent,Reason} = EXIT, Parent, Debug, S) ->
+	%% EXIT is not a 2-tuple therefore
+	%% not an event but this will stand out
+	%% in the crash report...
+	Q = [EXIT],
+	terminate(exit, Reason, ?STACKTRACE(), Debug, S, Q);
+handle_received_msg({timeout,TimerRef,TimerMsg} = Msg, Parent, Debug, S) ->
+	#{timer_refs := TimerRefs,
+		timer_types := TimerTypes,
+		hibernate := Hibernate} = S,
+	case TimerRefs of
+		#{TimerRef := TimerType} ->
+			%% We know of this timer; is it a running
+			%% timer or a timer being cancelled that
+			%% managed to send a late timeout message?
+			case TimerTypes of
 				#{TimerType := TimerRef} ->
-				    %% The timer type maps back to this
-				    %% timer ref, so it was a running timer
-				    Event = {TimerType,TimerMsg},
-				    %% Unregister the triggered timeout
-				    NewTimerRefs =
-					maps:remove(TimerRef, TimerRefs),
-				    NewTimerTypes =
-					maps:remove(TimerType, TimerTypes),
-				    loop_receive_result(
-				      Parent, Debug,
-				      S#{
-					timer_refs := NewTimerRefs,
-					timer_types := NewTimerTypes},
-				      Hibernate,
-				      Event);
+					%% The timer type maps back to this
+					%% timer ref, so it was a running timer
+					Event = {TimerType,TimerMsg},
+					%% Unregister the triggered timeout
+					NewTimerRefs =
+						maps:remove(TimerRef, TimerRefs),
+					NewTimerTypes =
+						maps:remove(TimerType, TimerTypes),
+					loop_receive_result(
+						Parent, Debug,
+						S#{
+							timer_refs := NewTimerRefs,
+							timer_types := NewTimerTypes},
+						Hibernate,
+						Event);
 				_ ->
-				    %% This was a late timeout message
-				    %% from timer being cancelled, so
-				    %% ignore it and expect a cancel_timer
-				    %% msg shortly
-				    loop_receive(Parent, Debug, S)
-			    end;
-			_ ->
-			    %% Not our timer; present it as an event
-			    Event = {info,Msg},
-			    loop_receive_result(
-			      Parent, Debug, S, Hibernate, Event)
-		    end;
-		{cancel_timer,TimerRef,_} ->
-		    #{timer_refs := TimerRefs,
-		      cancel_timers := CancelTimers,
-		      hibernate := Hibernate} = S,
-		    case TimerRefs of
-			#{TimerRef := _} ->
-			    %% We must have requested a cancel
-			    %% of this timer so it is already
-			    %% removed from TimerTypes
-			    NewTimerRefs =
-				maps:remove(TimerRef, TimerRefs),
-			    NewCancelTimers = CancelTimers - 1,
-			    NewS =
-				S#{
-				  timer_refs := NewTimerRefs,
-				  cancel_timers := NewCancelTimers},
-			    if
-				Hibernate =:= true, NewCancelTimers =:= 0 ->
-				    %% No more cancel_timer msgs to expect;
-				    %% we can hibernate
-				    loop_hibernate(Parent, Debug, NewS);
-				NewCancelTimers >= 0 -> % Assert
-				    loop_receive(Parent, Debug, NewS)
-			    end;
-			_ ->
-			    %% Not our cancel_timer msg;
-			    %% present it as an event
-			    Event = {info,Msg},
-			    loop_receive_result(
-			      Parent, Debug, S, Hibernate, Event)
-		    end;
+					%% This was a late timeout message
+					%% from timer being cancelled, so
+					%% ignore it and expect a cancel_timer
+					%% msg shortly
+					loop_receive(Parent, Debug, S)
+			end;
 		_ ->
-		    %% External msg
-		    #{hibernate := Hibernate} = S,
-		    Event =
-			case Msg of
-			    {'$gen_call',From,Request} ->
+			%% Not our timer; present it as an event
+			Event = {info,Msg},
+			loop_receive_result(
+				Parent, Debug, S, Hibernate, Event)
+	end;
+handle_received_msg({cancel_timer,TimerRef,_} = Msg, Parent, Debug, S) ->
+	#{timer_refs := TimerRefs,
+		cancel_timers := CancelTimers,
+		hibernate := Hibernate} = S,
+	case TimerRefs of
+		#{TimerRef := _} ->
+			%% We must have requested a cancel
+			%% of this timer so it is already
+			%% removed from TimerTypes
+			NewTimerRefs =
+				maps:remove(TimerRef, TimerRefs),
+			NewCancelTimers = CancelTimers - 1,
+			NewS =
+				S#{
+					timer_refs := NewTimerRefs,
+					cancel_timers := NewCancelTimers},
+			if
+				Hibernate =:= true, NewCancelTimers =:= 0 ->
+					%% No more cancel_timer msgs to expect;
+					%% we can hibernate
+					loop_hibernate(Parent, Debug, NewS);
+				NewCancelTimers >= 0 -> % Assert
+					loop_receive(Parent, Debug, NewS)
+			end;
+		_ ->
+			%% Not our cancel_timer msg;
+			%% present it as an event
+			Event = {info,Msg},
+			loop_receive_result(
+				Parent, Debug, S, Hibernate, Event)
+	end;
+handle_received_msg(Msg, Parent, Debug, S) ->
+	%% External msg
+	#{hibernate := Hibernate} = S,
+	Event =
+		case Msg of
+			{'$gen_call',From,Request} ->
 				{{call,From},Request};
-			    {'$gen_cast',E} ->
+			{'$gen_cast',E} ->
 				{cast,E};
-			    _ ->
+			_ ->
 				{info,Msg}
-			end,
-		    loop_receive_result(
-		      Parent, Debug, S, Hibernate, Event)
-	    end
-    end.
+		end,
+	loop_receive_result(
+		Parent, Debug, S, Hibernate, Event).
 
 loop_receive_result(
   Parent, Debug,

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -369,12 +369,12 @@ event_type(Type) ->
 	 Dbgs ::
 	   ['trace' | 'log' | 'statistics' | 'debug'
 	    | {'logfile', string()}]}.
--type auto_hibernate_timeout_opt() ::
-	{'auto_hibernate_timeout', AutoHibernateTimeout :: timeout()}.
+-type hibernate_after_opt() ::
+	{'hibernate_after', HibernateAfterTimeout :: timeout()}.
 -type start_opt() ::
 	debug_opt()
       | {'timeout', Time :: timeout()}
-	  | auto_hibernate_timeout_opt()
+	  | hibernate_after_opt()
       | {'spawn_opt', [proc_lib:spawn_option()]}.
 -type start_ret() ::  {'ok', pid()} | 'ignore' | {'error', term()}.
 
@@ -547,14 +547,14 @@ reply({To,Tag}, Reply) when is_pid(To) ->
 %% started by proc_lib into a state machine using
 %% the same arguments as you would have returned from init/1
 -spec enter_loop(
-	Module :: module(), Opts :: [debug_opt() | auto_hibernate_timeout_opt()],
+	Module :: module(), Opts :: [debug_opt() | hibernate_after_opt()],
 	State :: state(), Data :: data()) ->
 			no_return().
 enter_loop(Module, Opts, State, Data) ->
     enter_loop(Module, Opts, State, Data, self()).
 %%
 -spec enter_loop(
-	Module :: module(), Opts :: [debug_opt() | auto_hibernate_timeout_opt()],
+	Module :: module(), Opts :: [debug_opt() | hibernate_after_opt()],
 	State :: state(), Data :: data(),
 	Server_or_Actions ::
 	  server_name() | pid() | [action()]) ->
@@ -568,7 +568,7 @@ enter_loop(Module, Opts, State, Data, Server_or_Actions) ->
     end.
 %%
 -spec enter_loop(
-	Module :: module(), Opts :: [debug_opt() | auto_hibernate_timeout_opt()],
+	Module :: module(), Opts :: [debug_opt() | hibernate_after_opt()],
 	State :: state(), Data :: data(),
 	Server :: server_name() | pid(),
 	Actions :: [action()] | action()) ->
@@ -608,7 +608,7 @@ enter(Module, Opts, State, Data, Server, Actions, Parent) ->
     %% The values should already have been type checked
     Name = gen:get_proc_name(Server),
     Debug = gen:debug_options(Name, Opts),
-	AutoHibernateTimeout = gen:auto_hibernate_timeout(Opts),
+	HibernateAfterTimeout = gen:hibernate_after(Opts),
 	Events = [],
     P = [],
     Event = {internal,init_state},
@@ -652,7 +652,7 @@ enter(Module, Opts, State, Data, Server, Actions, Parent) ->
       timer_refs => TimerRefs,
       timer_types => TimerTypes,
       hibernate => Hibernate,
-	  auto_hibernate_timeout => AutoHibernateTimeout,
+	  hibernate_after => HibernateAfterTimeout,
       cancel_timers => CancelTimers
      },
     NewDebug = sys_debug(Debug, S, State, {enter,Event,State}),
@@ -859,12 +859,12 @@ loop_hibernate(Parent, Debug, S) ->
        {wakeup_from_hibernate,3}}).
 
 %% Entry point for wakeup_from_hibernate/3
-loop_receive(Parent, Debug, #{cancel_timers := 0, auto_hibernate_timeout := AutoHibernateTimeout} = S) when is_integer(AutoHibernateTimeout) ->
+loop_receive(Parent, Debug, #{cancel_timers := 0, hibernate_after := HibernateAfterTimeout} = S) when is_integer(HibernateAfterTimeout) ->
     receive
 	Msg ->
 		handle_received_msg(Msg, Parent, Debug, S)
 	after
-	    AutoHibernateTimeout ->
+	    HibernateAfterTimeout ->
 		    loop_hibernate(Parent, Debug, S)
     end;
 loop_receive(Parent, Debug, S) ->

--- a/lib/stdlib/test/dummy_h.erl
+++ b/lib/stdlib/test/dummy_h.erl
@@ -43,6 +43,9 @@ handle_event(hibernate, _State) ->
    {ok,[],hibernate};
 handle_event(wakeup, _State) ->
     {ok,[]};
+handle_event({From, handle_event}, _State) ->
+    From ! handled_event,
+    {ok,[]};
 handle_event(Event, Parent) ->
     Parent ! {dummy_h, Event},
     {ok, Parent}.
@@ -74,6 +77,9 @@ handle_info(sleep, _State) ->
 handle_info(wake, _State) ->
     {ok, []};
 handle_info(gnurf, _State) ->
+    {ok, []};
+handle_info({From, handle_info}, _State) ->
+    From ! handled_info,
     {ok, []};
 handle_info(Info, Parent) ->
     Parent ! {dummy_h, Info},

--- a/lib/stdlib/test/gen_event_SUITE.erl
+++ b/lib/stdlib/test/gen_event_SUITE.erl
@@ -307,12 +307,12 @@ hibernate(Config) when is_list(Config) ->
     ok.
 
 auto_hibernate(Config) when is_list(Config) ->
-    AutoHibernateTimeout = 100,
+    HibernateAfterTimeout = 100,
     State = {auto_hibernate_state},
-    {ok,Pid} = gen_event:start({local, auto_hibernate_handler}, [{auto_hibernate_timeout, AutoHibernateTimeout}]),
+    {ok,Pid} = gen_event:start({local, auto_hibernate_handler}, [{hibernate_after, HibernateAfterTimeout}]),
     %% After init test
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     ok = gen_event:add_handler(auto_hibernate_handler, dummy_h, [State]),
     %% Get state test
@@ -321,7 +321,7 @@ auto_hibernate(Config) when is_list(Config) ->
     %% Call test
     {ok, hejhopp} = gen_event:call(auto_hibernate_handler, dummy_h, hejsan),
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% Event test
     ok = gen_event:notify(auto_hibernate_handler, {self(), handle_event}),
@@ -332,7 +332,7 @@ auto_hibernate(Config) when is_list(Config) ->
         ct:fail(event)
     end,
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% Info test
     Pid ! {self(), handle_info},
@@ -343,7 +343,7 @@ auto_hibernate(Config) when is_list(Config) ->
         ct:fail(info)
     end,
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     ok = gen_event:stop(auto_hibernate_handler),
     ok.

--- a/lib/stdlib/test/gen_fsm_SUITE.erl
+++ b/lib/stdlib/test/gen_fsm_SUITE.erl
@@ -703,12 +703,12 @@ hibernate(Config) when is_list(Config) ->
 %% Auto hibernation
 auto_hibernate(Config) when is_list(Config) ->
     OldFl = process_flag(trap_exit, true),
-    AutoHibernateTimeout = 100,
+    HibernateAfterTimeout = 100,
     State = {auto_hibernate_state},
-    {ok, Pid} = gen_fsm:start_link({local, my_test_name_auto_hibernate}, ?MODULE, {state_data, State}, [{auto_hibernate_timeout, AutoHibernateTimeout}]),
+    {ok, Pid} = gen_fsm:start_link({local, my_test_name_auto_hibernate}, ?MODULE, {state_data, State}, [{hibernate_after, HibernateAfterTimeout}]),
     %% After init test
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% Get state test
     {_, State} = sys:get_state(my_test_name_auto_hibernate),
@@ -716,19 +716,19 @@ auto_hibernate(Config) when is_list(Config) ->
     %% Sync send event test
     'alive!' = gen_fsm:sync_send_event(Pid,'alive?'),
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% Send event test
     ok = gen_fsm:send_all_state_event(Pid,{'alive?', self()}),
     wfor(yes),
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% Info test
     Pid ! {self(), handle_info},
     wfor({Pid, handled_info}),
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     stop_it(Pid),
     receive

--- a/lib/stdlib/test/gen_server_SUITE.erl
+++ b/lib/stdlib/test/gen_server_SUITE.erl
@@ -732,14 +732,14 @@ hibernate(Config) when is_list(Config) ->
 
 auto_hibernate(Config) when is_list(Config) ->
     OldFl = process_flag(trap_exit, true),
-    AutoHibernateTimeout = 100,
+    HibernateAfterTimeout = 100,
     State = {auto_hibernate_state},
     {ok, Pid} =
         gen_server:start_link({local, my_test_name_auto_hibernate},
-            gen_server_SUITE, {state,State}, [{auto_hibernate_timeout, AutoHibernateTimeout}]),
+            gen_server_SUITE, {state,State}, [{hibernate_after, HibernateAfterTimeout}]),
     %% After init test
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% Get state test
     State = sys:get_state(my_test_name_auto_hibernate),
@@ -747,7 +747,7 @@ auto_hibernate(Config) when is_list(Config) ->
     %% Call test
     ok = gen_server:call(my_test_name_auto_hibernate, started_p),
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% Cast test
     ok = gen_server:cast(my_test_name_auto_hibernate, {self(),handle_cast}),
@@ -758,7 +758,7 @@ auto_hibernate(Config) when is_list(Config) ->
         ct:fail(cast)
     end,
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% Info test
     Pid ! {self(),handle_info},
@@ -769,7 +769,7 @@ auto_hibernate(Config) when is_list(Config) ->
         ct:fail(info)
     end,
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
 
     ok = gen_server:call(my_test_name_auto_hibernate, stop),

--- a/lib/stdlib/test/gen_statem_SUITE.erl
+++ b/lib/stdlib/test/gen_statem_SUITE.erl
@@ -40,7 +40,7 @@ all() ->
      shutdown, stop_and_reply, state_enter, event_order,
      state_timeout, event_types, generic_timers, code_change,
      {group, sys},
-     hibernate, enter_loop, {group, undef_callbacks},
+     hibernate, auto_hibernate, enter_loop, {group, undef_callbacks},
      undef_in_terminate].
 
 groups() ->
@@ -1284,6 +1284,55 @@ hibernate(Config) ->
     end,
     ok = verify_empty_msgq().
 
+%% Auto-hibernation timeout
+auto_hibernate(Config) ->
+    OldFl = process_flag(trap_exit, true),
+    AutoHibernateTimeout = 100,
+
+    {ok,Pid} =
+        gen_statem:start_link(
+            ?MODULE, start_arg(Config, []), [{auto_hibernate_timeout, AutoHibernateTimeout}]),
+    %% After init test
+    is_not_in_erlang_hibernate(Pid),
+    timer:sleep(AutoHibernateTimeout),
+    is_in_erlang_hibernate(Pid),
+    %% After info test
+    Pid ! {hping, self()},
+    receive
+        {Pid, hpong} ->
+            ok
+    after 1000 ->
+        ct:fail(info)
+    end,
+    is_not_in_erlang_hibernate(Pid),
+    timer:sleep(AutoHibernateTimeout),
+    is_in_erlang_hibernate(Pid),
+    %% After cast test
+    ok = gen_statem:cast(Pid, {hping, self()}),
+    receive
+        {Pid, hpong} ->
+            ok
+    after 1000 ->
+        ct:fail(cast)
+    end,
+    is_not_in_erlang_hibernate(Pid),
+    timer:sleep(AutoHibernateTimeout),
+    is_in_erlang_hibernate(Pid),
+    %% After call test
+    hpong = gen_statem:call(Pid, hping),
+    is_not_in_erlang_hibernate(Pid),
+    timer:sleep(AutoHibernateTimeout),
+    is_in_erlang_hibernate(Pid),
+
+    stop_it(Pid),
+    process_flag(trap_exit, OldFl),
+    receive
+        {'EXIT',Pid,normal} -> ok
+    after 5000 ->
+        ct:fail(gen_statem_did_not_die)
+    end,
+    ok = verify_empty_msgq().
+
 is_in_erlang_hibernate(Pid) ->
     receive after 1 -> ok end,
     is_in_erlang_hibernate_1(200, Pid).
@@ -1704,6 +1753,14 @@ terminate(_Reason, _State, _Data) ->
 
 %% State functions
 
+idle(info, {hping,Pid}, _Data) ->
+    Pid ! {self(), hpong},
+    keep_state_and_data;
+idle(cast, {hping,Pid}, Data) ->
+    Pid ! {self(), hpong},
+    {keep_state, Data};
+idle({call, From}, hping, _Data) ->
+    {keep_state_and_data, [{reply, From, hpong}]};
 idle(cast, {connect,Pid}, Data) ->
     Pid ! accept,
     {next_state,wfor_conf,Data,infinity}; % NoOp timeout just to test API

--- a/lib/stdlib/test/gen_statem_SUITE.erl
+++ b/lib/stdlib/test/gen_statem_SUITE.erl
@@ -1287,14 +1287,14 @@ hibernate(Config) ->
 %% Auto-hibernation timeout
 auto_hibernate(Config) ->
     OldFl = process_flag(trap_exit, true),
-    AutoHibernateTimeout = 100,
+    HibernateAfterTimeout = 100,
 
     {ok,Pid} =
         gen_statem:start_link(
-            ?MODULE, start_arg(Config, []), [{auto_hibernate_timeout, AutoHibernateTimeout}]),
+            ?MODULE, start_arg(Config, []), [{hibernate_after, HibernateAfterTimeout}]),
     %% After init test
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% After info test
     Pid ! {hping, self()},
@@ -1305,7 +1305,7 @@ auto_hibernate(Config) ->
         ct:fail(info)
     end,
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% After cast test
     ok = gen_statem:cast(Pid, {hping, self()}),
@@ -1316,12 +1316,12 @@ auto_hibernate(Config) ->
         ct:fail(cast)
     end,
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
     %% After call test
     hpong = gen_statem:call(Pid, hping),
     is_not_in_erlang_hibernate(Pid),
-    timer:sleep(AutoHibernateTimeout),
+    timer:sleep(HibernateAfterTimeout),
     is_in_erlang_hibernate(Pid),
 
     stop_it(Pid),


### PR DESCRIPTION
There are a lot of implementations of gen_server, gen_event, gen_fsm in our projects. A lot of them has have small message flow, and at present time we are doing 'hibernate' all of them manually.

So, we decided implement auto-hibernation functionality in the gen_server, gen_event, gen_fsm. In case of no any messages in gen_server, gen_event, gen_fsm during AutoHibernateTimeout milliseconds, process goes into hibernation automatically.

We think than described functionality will be useful for other developers. By default auto-hibernation functionality disable, so default behaviour for gen_server, gen_event, gen_fsm doesn't change.

We have make changed in gen_server, gen_fsm, gen_event modules. There is add unit tests for realized functionality, description for auto_hibernate_timeout option.