### PR TITLE
Available hash signature algs

### DIFF
--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -2152,13 +2152,9 @@ select_compression(_CompressionMetodes) ->
 
 available_signature_algs(undefined, _, _)  ->
     undefined;
-available_signature_algs(SupportedHashSigns, {Major, Minor}, AllVersions) when Major >= 3 andalso Minor >= 3 ->
-    case tls_record:lowest_protocol_version(AllVersions) of
-	{3, 3} ->
-	    #hash_sign_algos{hash_sign_algos = SupportedHashSigns};
-	_ ->
-	    undefined
-    end;	
+available_signature_algs(SupportedHashSigns, {Major, Minor}, _AllVersions)
+  when Major >= 3 andalso Minor >= 3 ->
+    #hash_sign_algos{hash_sign_algos = SupportedHashSigns};
 available_signature_algs(_, _, _) ->
     undefined.
 


### PR DESCRIPTION
  This patch does two things.

  It always use 'sslv3' in ClientHello record layer version. The spec is vague on this, but in practice there are servers that wants it (see e.g. https://security.stackexchange.com/a/26059/7866)

  It always includes "signature_algorithms" extension in tlsv1.2 ClientHello.
  According to the spec, the "signature_algorithms" extension should be sent (see https://tools.ietf.org/html/rfc5246#section-7.4.1.4.1).
  The spec has weasel words saying it MAY be omitted; in practice, it turns out
there are servers who are unwilling to accept this (e.g. https://adinsight.api.bingads.microsoft.com/Api/Advertiser/AdInsight/V10/AdInsightService.svc?wsdl).
