### PR TITLE
HiPE: Fix --enable-native-libs --enable-m32-build

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -354,14 +354,12 @@ fi
 AC_SUBST(DEFAULT_VERBOSITY)
 
 if test X${enable_m64_build} = Xyes; then
-	enable_hipe=no
 	CFLAGS="-m64 $CFLAGS"
 	export CFLAGS
 	LDFLAGS="-m64 $LDFLAGS"
 	export LDFLAGS
 fi
 if test X${enable_m32_build} = Xyes; then
-	enable_hipe=no
 	CFLAGS="-m32 $CFLAGS"
 	export CFLAGS
 	LDFLAGS="-m32 $LDFLAGS"


### PR DESCRIPTION
This fixes a mistake in 6d8c39229 where a few `enable_hipe=no` that makes the build fail when building with both `--enable-native-libs` and `--enable-m32-build` slipped through.