### PR TITLE
Add re:version/0

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -392,6 +392,7 @@ bif erl_ddll:demonitor/1
 #
 # Bifs in the re module 
 #
+bif re:version/0
 bif re:compile/1
 bif re:compile/2
 bif re:run/2

--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -477,6 +477,17 @@ build_compile_result(Process *p, Eterm error_tag, pcre *result, int errcode, con
  * Compile BIFs
  */
 
+BIF_RETTYPE
+re_version_0(BIF_ALIST_0)
+{
+    Eterm ret;
+    size_t version_size = 0;
+    byte *version = (byte *) erts_pcre_version();
+    version_size = strlen((const char *) version);
+    ret = new_binary(BIF_P, version, version_size);
+    BIF_RET(ret);
+}
+
 static BIF_RETTYPE
 re_compile(Process* p, Eterm arg1, Eterm arg2)
 {

--- a/lib/stdlib/doc/src/re.xml
+++ b/lib/stdlib/doc/src/re.xml
@@ -5,7 +5,7 @@
   <header>
     <copyright>
       <year>2007</year>
-      <year>2016</year>
+      <year>2017</year>
       <holder>Ericsson AB, All Rights Reserved</holder>
     </copyright>
     <legalnotice>
@@ -77,6 +77,14 @@
   </datatypes>
 
   <funcs>
+    <func>
+      <name name="version" arity="0"/>
+      <fsummary>Gives the PCRE version of the system in a string format</fsummary>
+      <desc>
+      <p>The return of this function is a string with the PCRE version of the system that was used in the Erlang/OTP compilation.</p>
+      </desc>
+    </func>
+
     <func>
       <name name="compile" arity="1"/>
       <fsummary>Compile a regular expression into a match program</fsummary>

--- a/lib/stdlib/src/re.erl
+++ b/lib/stdlib/src/re.erl
@@ -33,7 +33,12 @@
 
 %%% BIFs
 
--export([compile/1, compile/2, run/2, run/3, inspect/2]).
+-export([version/0, compile/1, compile/2, run/2, run/3, inspect/2]).
+
+-spec version() -> binary().
+
+version() ->
+    erlang:nif_error(undef).
 
 -spec compile(Regexp) -> {ok, MP} | {error, ErrSpec} when
       Regexp :: iodata(),

--- a/lib/stdlib/test/re_SUITE.erl
+++ b/lib/stdlib/test/re_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2008-2016. All Rights Reserved.
+%% Copyright Ericsson AB 2008-2017. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 	 run_options/1,combined_options/1,replace_autogen/1,
 	 global_capture/1,replace_input_types/1,replace_return/1,
 	 split_autogen/1,split_options/1,split_specials/1,
-	 error_handling/1,pcre_cve_2008_2371/1,
+	 error_handling/1,pcre_cve_2008_2371/1,re_version/1,
 	 pcre_compile_workspace_overflow/1,re_infinite_loop/1, 
 	 re_backwards_accented/1,opt_dupnames/1,opt_all_names/1,inspect/1,
 	 opt_no_start_optimize/1,opt_never_utf/1,opt_ucp/1,
@@ -45,7 +45,7 @@ all() ->
      pcre_compile_workspace_overflow, re_infinite_loop, 
      re_backwards_accented, opt_dupnames, opt_all_names, 
      inspect, opt_no_start_optimize,opt_never_utf,opt_ucp,
-     match_limit, sub_binaries].
+     match_limit, sub_binaries, re_version].
 
 groups() -> 
     [].
@@ -190,6 +190,14 @@ run_options(Config) when is_list(Config) ->
     {match,[{0,10},{3,4},{-1,0},{4,3}]} = re:run("ABCabcdABC",MP3,[{capture,all,index}]),
     {match,[<<"ABCabcdABC">>,<<"abcd">>,<<>>,<<"bcd">>]} = re:run("ABCabcdABC",MP3,[{capture,all,binary}]),
     {match,["ABCabcdABC","abcd",[],"bcd"]} = re:run("ABCabcdABC",MP3,[{capture,all,list}]),
+    ok.
+
+
+
+%% Test the version is retorned correctly
+re_version(_Config) ->
+    Version = re:version(),
+    {match,[Version]} = re:run(Version,"^[0-9]\\.[0-9]{2} 20[0-9]{2}-[0-9]{2}-[0-9]{2}",[{capture,all,binary}]),
     ok.
 
 


### PR DESCRIPTION
This modification is only to let to know to the Erlang coder what is the PCRE version in use compiled inside of the BEAM machine and in use by re module in a binary way:

```
> re:version().
<<"8.02 2010-03-19">>
```