### PR TITLE
Move travis dialyzer logic to script file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,7 @@ script:
   - ./scripts/build-otp
 
 after_success:
-  - $ERL_TOP/bin/dialyzer --build_plt --apps asn1 compiler crypto dialyzer edoc erts et hipe inets kernel mnesia observer public_key runtime_tools snmp ssh ssl stdlib syntax_tools wx xmerl --statistics
-  - $ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps compiler erts kernel stdlib asn1 crypto dialyzer hipe parsetools public_key runtime_tools sasl tools --statistics
-  - $ERL_TOP/bin/dialyzer -n --apps common_test debugger edoc inets mnesia observer ssh ssl syntax_tools tools wx xmerl --statistics
+  - ./scripts/run-dialyzer
   - ./otp_build tests && make release_docs
 
 after_script:

--- a/scripts/run-dialyzer
+++ b/scripts/run-dialyzer
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+$ERL_TOP/bin/dialyzer --build_plt --apps asn1 compiler crypto dialyzer edoc erts et hipe inets kernel mnesia observer public_key runtime_tools snmp ssh ssl stdlib syntax_tools wx xmerl --statistics
+$ERL_TOP/bin/dialyzer -n -Wunknown -Wunmatched_returns --apps compiler erts kernel stdlib asn1 crypto dialyzer hipe parsetools public_key runtime_tools sasl tools --statistics
+$ERL_TOP/bin/dialyzer -n --apps common_test debugger edoc inets mnesia observer ssh ssl syntax_tools tools wx xmerl --statistics


### PR DESCRIPTION
Having it in a script allows it to be called from other tools then travis-ci.