### PR TITLE
Deprecate the non-smp emulators

### DIFF
--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -343,10 +343,12 @@ use the `--prefix` argument like this: `./configure --prefix=<Dir>`.
 Some of the available `configure` options are:
 
 *   `--prefix=PATH` - Specify installation prefix.
-
-*   `--{enable,disable}-threads` - Thread support. This is enabled by default if possible.
-*   `--{enable,disable}-smp-support` - SMP support (enabled by default if
-    a usable POSIX thread library or native Windows threads is found)
+*   `--enable-plain-emulator` - Build a threaded emulator that only
+    uses one scheduler. This emulator type is deprecated and will be
+    removed in a future release.
+*   `--disable-threads` - Build a non-threaded emulator. This emulator type
+    is deprecated and will be
+    removed in a future release.
 *   `--{enable,disable}-kernel-poll` - Kernel poll support (enabled by
     default if possible)
 *   `--{enable,disable}-hipe` - HiPE support (enabled by default on supported

--- a/configure.in
+++ b/configure.in
@@ -207,16 +207,12 @@ AC_MSG_CHECKING([OTP version])
 AC_MSG_RESULT([$OTP_VSN])
 AC_SUBST(OTP_VSN)
 
-AC_ARG_ENABLE(threads,
-AS_HELP_STRING([--enable-threads], [enable async thread support])
-AS_HELP_STRING([--disable-threads], [disable async thread support]))
-
 AC_ARG_ENABLE(dirty-schedulers,
 AS_HELP_STRING([--enable-dirty-schedulers], [enable dirty scheduler support]))
 
-AC_ARG_ENABLE(smp-support,
-AS_HELP_STRING([--enable-smp-support], [enable smp support])
-AS_HELP_STRING([--disable-smp-support], [disable smp support]))
+AC_ARG_ENABLE(plain-emulator,
+AS_HELP_STRING([--enable-plain-emulator], [enable threaded non-smp emulator])
+AS_HELP_STRING([--disable-plain-emulator], [disable threaded non-smp emulator]))
 
 AC_ARG_WITH(termcap,
 AS_HELP_STRING([--with-termcap], [use termcap (default)])

--- a/erts/Makefile
+++ b/erts/Makefile
@@ -20,9 +20,9 @@
 
 .NOTPARALLEL:
 
-include $(ERL_TOP)/make/output.mk
 include $(ERL_TOP)/make/target.mk
 include vsn.mk
+include $(ERL_TOP)/make/$(TARGET)/otp.mk
 
 # ----------------------------------------------------------------------
 
@@ -33,10 +33,8 @@ ifeq ($(NO_START_SCRIPTS),)
 ERTSDIRS += start_scripts
 endif
 
-EXTRA_FLAVORS=smp
-
 .PHONY: all
-all: smp opt
+all: $(FLAVORS)
 
 .PHONY: docs
 docs:
@@ -56,9 +54,9 @@ debug opt clean:
 # - don't use them in scripts or assume they will always stay like this!
 #
 
-.PHONY: $(EXTRA_FLAVORS)
-$(EXTRA_FLAVORS):
-	$(V_at)( cd emulator && $(MAKE) opt FLAVOR=$@ )
+.PHONY: $(FLAVORS)
+$(FLAVORS):
+	$(V_at)( $(MAKE) opt FLAVOR=$@ )
 
 # Make erl script and erlc in $(ERL_TOP)/bin which runs the compiled version
 # Note that erlc is not a script and requires extra handling on cygwin.
@@ -129,7 +127,7 @@ makefiles:
 
 .PHONY: release
 release:
-	$(V_at)for f in plain $(EXTRA_FLAVORS) ; do \
+	$(V_at)for f in $(FLAVORS); do \
 		( cd emulator && $(MAKE) release FLAVOR=$$f ) \
 	done
 	$(V_at)for d in $(ERTSDIRS) $(XINSTDIRS); do \

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -154,6 +154,14 @@ AS_HELP_STRING([--disable-smp-support], [disable smp support]),
     *)  enable_smp_support=yes ;;
   esac ], enable_smp_support=unknown)
 
+AC_ARG_ENABLE(plain-emulator,
+AS_HELP_STRING([--enable-plain-emulator], [enable plain emulator])
+AS_HELP_STRING([--disable-plain-emulator], [disable plain emulator]),
+[ case "$enableval" in
+    no) enable_plain_emulator=no ;;
+    *)  enable_plain_emulator=yes ;;
+  esac ], enable_plain_emulator=unknown)
+
 AC_ARG_ENABLE(smp-require-native-atomics,
 	      AS_HELP_STRING([--disable-smp-require-native-atomics],
                              [disable the SMP requirement of a native atomic implementation]),
@@ -993,7 +1001,7 @@ else
     found_threads=yes
 fi
 
-
+FLAVORS=
 ERTS_BUILD_SMP_EMU=$enable_smp_support
 AC_MSG_CHECKING(whether an emulator with smp support should be built)
 case $ERTS_BUILD_SMP_EMU in
@@ -1078,6 +1086,9 @@ EOF
 
 if test $ERTS_BUILD_SMP_EMU = yes; then
 
+        DEFAULT_FLAVOR=smp
+        FLAVORS="$FLAVORS smp"
+
 	if test $found_threads = no; then
 	    AC_MSG_ERROR([cannot build smp enabled emulator since no thread library was found])
 	fi
@@ -1152,6 +1163,66 @@ EOF
 fi
 
 AC_SUBST(ERTS_BUILD_SMP_EMU)
+
+ERTS_BUILD_PLAIN_EMU=$enable_plain_emulator
+AC_MSG_CHECKING(whether an emulator without smp support should be built)
+case $ERTS_BUILD_PLAIN_EMU in
+    yes)
+	AC_MSG_RESULT(yes; enabled by user)
+	;;
+    no)
+	AC_MSG_RESULT(no; disabled by user)
+	;;
+    unknown)
+        case "$enable_threads-$ERTS_BUILD_SMP_EMU" in
+            no-*)
+                ERTS_BUILD_PLAIN_EMU=yes
+                AC_MSG_RESULT(yes)
+                ;;
+            *-no)
+                ERTS_BUILD_PLAIN_EMU=yes
+                AC_MSG_RESULT(yes; enabled as smp emulator was disabled)
+                ;;
+            *)
+                ERTS_BUILD_PLAIN_EMU=no
+                AC_MSG_RESULT(no)
+                ;;
+        esac
+        ;;
+esac
+
+case $ERTS_BUILD_PLAIN_EMU in
+     yes)
+     	AC_DEFINE(ERTS_HAVE_PLAIN_EMU, 1, [Define if the non-smp emulator is built])
+        FLAVORS="$FLAVORS plain"
+        test -f "$ERL_TOP/erts/CONF_INFO" || echo "" > "$ERL_TOP/erts/CONF_INFO"
+        cat >> $ERL_TOP/erts/CONF_INFO <<EOF
+
+            The PLAIN aka NON-SMP emulator has been enabled.
+            This is a DEPRECATED feature scheduled for removal
+            in a future major release.
+
+EOF
+        ;;
+     no)
+        ;;
+esac
+
+AC_SUBST(ERTS_BUILD_PLAIN_EMU)
+AC_SUBST(FLAVORS)
+
+case "$ERTS_BUILD_PLAIN_EMU-$ERTS_BUILD_SMP_EMU" in
+     no-no)
+          AC_MSG_ERROR([both smp and non-smp emulators have been disabled, one of them has to be enabled])
+          ;;
+     *-no)
+          DEFAULT_FLAVOR=plain
+          ;;
+        *)
+          ;;
+esac
+
+AC_SUBST(DEFAULT_FLAVOR)
 
 AC_CHECK_FUNCS([posix_fadvise closefrom])
 AC_CHECK_HEADERS([linux/falloc.h])
@@ -4953,7 +5024,6 @@ AC_CONFIG_FILES([
   include/internal/$host/ethread.mk:include/internal/ethread.mk.in
   include/internal/$host/erts_internal.mk:include/internal/erts_internal.mk.in
   lib_src/$host/Makefile:lib_src/Makefile.in
-  Makefile:Makefile.in
   ../make/$host/otp.mk:../make/otp.mk.in
   ../make/$host/otp_ded.mk:../make/otp_ded.mk.in
 ])

--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -513,11 +513,11 @@
 	  system with SMP support is available. <c>-smp auto</c> starts
 	  the Erlang runtime system with SMP support enabled if it is
 	  available and more than one logical processor is detected.
-	  <c>-smp disable</c> starts a runtime system without SMP support.</p>
+	  <c>-smp disable</c> starts a runtime system without SMP support.
+           The runtime system without SMP support is deprecated and will
+           be removed in a future major release.</p>
         <note>
-          <p>The runtime system with SMP support is not available on all
-            supported platforms. See also flag
-            <seealso marker="#+S"><c>+S</c></seealso>.</p>
+          <p>See also flag<seealso marker="#+S"><c>+S</c></seealso>.</p>
         </note>
       </item>
       <tag><c><![CDATA[-version]]></c> (emulator flag)</tag>

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -175,7 +175,23 @@ endif
 # NOTE: When adding a new type update ERL_BUILD_TYPE_MARKER in sys/unix/sys.c
 #
 
-ifeq ($(FLAVOR),smp)
+FLAVOR=$(DEFAULT_FLAVOR)
+
+ifeq ($(FLAVOR),plain)
+
+DS_SUPPORT=no
+DS_TEST=no
+
+FLAVOR_MARKER=
+FLAVOR_FLAGS=
+ENABLE_ALLOC_TYPE_VARS += nofrag
+M4FLAGS +=
+
+else # FLAVOR
+
+# If flavor isn't one of the above, it *is* smp flavor...
+override FLAVOR=smp
+
 FLAVOR_MARKER=.smp
 FLAVOR_FLAGS=-DERTS_SMP
 ENABLE_ALLOC_TYPE_VARS += smp nofrag
@@ -196,29 +212,14 @@ DS_SUPPORT=no
 DS_TEST=no
 endif # DIRTY_SCHEDULER_SUPPORT
 
-else # FLAVOR
-
-DS_SUPPORT=no
-DS_TEST=no
-
-# If flavor isn't one of the above, it *is* plain flavor...
-override FLAVOR=plain
-FLAVOR_MARKER=
-FLAVOR_FLAGS=
-ENABLE_ALLOC_TYPE_VARS += nofrag
-M4FLAGS +=
-endif
+endif # FLAVOR
 
 TF_MARKER=$(TYPEMARKER)$(FLAVOR_MARKER)
 
-ifeq ($(FLAVOR)-@ERTS_BUILD_SMP_EMU@,smp-no)
-VOID_EMULATOR = '*** SMP emulator disabled by configure'
-else
 ifeq ($(TYPE)-@HAVE_VALGRIND@,valgrind-no)
 VOID_EMULATOR = '*** valgrind emulator disabled by configure'
 else
 VOID_EMULATOR =
-endif
 endif
 
 OPSYS=@OPSYS@

--- a/erts/emulator/test/scheduler_SUITE.erl
+++ b/erts/emulator/test/scheduler_SUITE.erl
@@ -1087,12 +1087,8 @@ scheduler_threads(Config) when is_list(Config) ->
     {Sched, SchedOnln, _} = get_sstate(Config, ""),
     %% Configure half the number of both the scheduler threads and
     %% the scheduler threads online.
-    {HalfSched, HalfSchedOnln} = case SmpSupport of
-                                     false -> {1,1};
-                                     true ->
-                                         {Sched div 2,
-                                          SchedOnln div 2}
-                                 end,
+    {HalfSched, HalfSchedOnln} = {lists:max([1,Sched div 2]),
+                                  lists:max([1,SchedOnln div 2])},
     {HalfSched, HalfSchedOnln, _} = get_sstate(Config, "+SP 50:50"),
     %% Use +S to configure 4x the number of scheduler threads and
     %% 4x the number of scheduler threads online, but alter that
@@ -1149,12 +1145,8 @@ dirty_scheduler_threads(Config) when is_list(Config) ->
 dirty_scheduler_threads_test(Config) ->
     SmpSupport = erlang:system_info(smp_support),
     {Sched, SchedOnln, _} = get_dsstate(Config, ""),
-    {HalfSched, HalfSchedOnln} = case SmpSupport of
-                                     false -> {1,1};
-                                     true ->
-                                         {Sched div 2,
-                                          SchedOnln div 2}
-                                 end,
+    {HalfSched, HalfSchedOnln} = {lists:max([1,Sched div 2]),
+                                  lists:max([1,SchedOnln div 2])},
     Cmd1 = "+SDcpu "++integer_to_list(HalfSched)++":"++
 	integer_to_list(HalfSchedOnln),
     {HalfSched, HalfSchedOnln, _} = get_dsstate(Config, Cmd1),

--- a/erts/emulator/test/smoke_test_SUITE.erl
+++ b/erts/emulator/test/smoke_test_SUITE.erl
@@ -66,17 +66,10 @@ boot_combo(Config) when is_list(Config) ->
 			  ok
 		  end
 	  end,
-    SMPDisable = fun () -> false = erlang:system_info(smp_support) end,
     try
 	chk_boot(Config, "+Ktrue", NOOP),
 	chk_boot(Config, "+A42", A42),
-	chk_boot(Config, "-smp disable", SMPDisable),
 	chk_boot(Config, "+Ktrue +A42", A42),
-	chk_boot(Config, "-smp disable +A42",
-		 fun () -> SMPDisable(), A42() end),
-	chk_boot(Config, "-smp disable +Ktrue", SMPDisable),
-	chk_boot(Config, "-smp disable +Ktrue +A42",
-		 fun () -> SMPDisable(), A42() end),
 	%% A lot more combos could be implemented...
 	ok
     after

--- a/erts/emulator/test/statistics_SUITE.erl
+++ b/erts/emulator/test/statistics_SUITE.erl
@@ -329,9 +329,9 @@ scheduler_wall_time_test(Type) ->
         %% 50% load
         HalfHogs = [StartHog() || _ <- lists:seq(1, (Schedulers-1) div 2)],
         HalfDirtyCPUHogs = [StartDirtyHog(dirty_cpu)
-                            || _ <- lists:seq(1, DirtyCPUSchedulers div 2)],
+                            || _ <- lists:seq(1, lists:max([1,DirtyCPUSchedulers div 2]))],
         HalfDirtyIOHogs = [StartDirtyHog(dirty_io)
-                           || _ <- lists:seq(1, DirtyIOSchedulers div 2)],
+                           || _ <- lists:seq(1, lists:max([1,DirtyIOSchedulers div 2]))],
         HalfLoad = lists:sum(get_load(Type)) div TotLoadSchedulers,
         if Schedulers < 2, HalfLoad > 80 -> ok; %% Ok only one scheduler online and one hog
            %% We want roughly 50% load

--- a/lib/hipe/rtl/Makefile
+++ b/lib/hipe/rtl/Makefile
@@ -118,10 +118,12 @@ else
 TYPE_STR=
 endif
 
-ifeq ($(FLAVOR),smp)
-FLAVOR_STR=.smp
-else
+FLAVOR=$(DEFAULT_FLAVOR)
+
+ifeq ($(FLAVOR),plain)
 FLAVOR_STR=
+else
+FLAVOR_STR=.smp
 endif
 
 ifeq ($(XCOMP),yes)

--- a/make/emd2exml.in
+++ b/make/emd2exml.in
@@ -1,6 +1,6 @@
 #!@ENV@ escript
 %% -*- erlang -*-
-%%! -smp disable
+%%!
 
 %%
 %% %CopyrightBegin%

--- a/make/otp.mk.in
+++ b/make/otp.mk.in
@@ -47,6 +47,9 @@ CROSS_COMPILING = @CROSS_COMPILING@
 # ----------------------------------------------------
 DEFAULT_TARGETS =  opt debug release release_docs clean docs
 
+DEFAULT_FLAVOR=@DEFAULT_FLAVOR@
+FLAVORS=@FLAVORS@
+
 # Slash separated list of return values from $(origin VAR)
 # that are untrusted - set default in this file instead.
 # The list is not space separated since some return values

--- a/scripts/build-otp
+++ b/scripts/build-otp
@@ -37,7 +37,7 @@ if [ ! -d "logs" ]; then
 fi
 
 do_and_log "Autoconfing" autoconf
-do_and_log "Configuring" configure
+do_and_log "Configuring" configure --enable-plain-emulator
 do_and_log "Building OTP" boot -a
 
 exit 0


### PR DESCRIPTION
This pr changes the default builds to not include the non-smp aka plain emulator when built. Instead you have to supply the `--enable-plain-emulator` configure option in order for it to be built.

The non-smp emulators (threaded and non-threaded) are also deprecated and a warning is printed when they are enabled.

The non-smp emulators will be removed in OTP-21.
