### PR TITLE
erl_mseg.c: don't use invalid indices in - > cache_powered_node[]

### DIFF
--- a/erts/emulator/sys/common/erl_mseg.c
+++ b/erts/emulator/sys/common/erl_mseg.c
@@ -87,6 +87,7 @@ static const int debruijn[32] = {
 
 #define CACHE_AREAS      (32 - MSEG_ALIGN_BITS)
 
+/* FIXME: segment sizes > 2 GB result in bogus negative indices */
 #define SIZE_TO_CACHE_AREA_IDX(S)   (LOG2((S)) - MSEG_ALIGN_BITS)
 #define MAX_CACHE_SIZE   (30)
 
@@ -396,6 +397,9 @@ static ERTS_INLINE int cache_bless_segment(ErtsMsegAllctr_t *ma, void *seg, UWor
 	if (MSEG_FLG_IS_2POW(flags)) {
 	    int ix = SIZE_TO_CACHE_AREA_IDX(size);
 
+            if (ix < 0)
+                return 0;
+
 	    ASSERT(ix < CACHE_AREAS);
 	    ASSERT((1 << (ix + MSEG_ALIGN_BITS)) == size);
 
@@ -470,6 +474,9 @@ static ERTS_INLINE void *cache_get_segment(ErtsMsegAllctr_t *ma, UWord *size_p, 
 	UWord csize;
 
 	ASSERT(IS_2POW(size));
+
+        if (ix < 0)
+            return NULL;
 
 	for( i = ix; i < CACHE_AREAS; i++) {
 


### PR DESCRIPTION
The power-of-two cache in erl_mseg.c only handles segment up to 2GB in size.  Attempts to allocate larger segment (a valid operation) cause the SIZE_TO_CACHE_AREA_IDX() macro to return bogus negative values, resulting in out-of-bounds indexing in ->cache_powered_node[].

The simplest fix is to just not cache power-of-two segments > 2GB, which is what this patch does.

It might be possible to put such segments on ->cache_unpowered_node instead, but the logic in cache_bless_segment() looks like it really doesn't want powers-of-two segments there, so I opted not to.

Longer-term, the LOG2() and CACHE_AREAS macros need updating for 64-bit environments.