### PR TITLE
fix logic mistake in pcre_study.c:set_start_bits()

### DIFF
--- a/erts/emulator/pcre/pcre_study.c
+++ b/erts/emulator/pcre/pcre_study.c
@@ -1253,7 +1253,7 @@ do
           for (c = 0; c < 16; c++) start_bits[c] |= map[c];
           for (c = 128; c < 256; c++)
             {
-            if ((map[c/8] && (1 << (c&7))) != 0)
+            if ((map[c/8] & (1 << (c&7))) != 0)
               {
               int d = (c >> 6) | 0xc0;            /* Set bit for this starter */
               start_bits[d/8] |= (1 << (d&7));    /* and then skip on to the */


### PR DESCRIPTION
Compiling OTP-19.3 with gcc-7.0.1 throws the following warning:

 CC	/tmp/otp/erts/emulator/pcre/obj/x86_64-unknown-linux-gnu/opt/pcre_study.o
/tmp/otp/erts/emulator/pcre/pcre_study.c: In function 'set_start_bits':
/tmp/otp/erts/emulator/pcre/pcre_study.c:1256:33: warning: '<<' in boolean context, did you mean '<' ? [-Wint-in-bool-context]
             if ((map[c/8] && (1 << (c&7))) != 0)
                              ~~~^~~~~~~~~
This is supposed to test if a specific bit in map[c/8] is set, but due
to the erroneous '&&' it actually tests if any bit in map[c/8] is set.

Fixed by backporting upstream pcre svn rev. 1639.

OTP-20 is not affected since its pcre is newer and includes this fix.