### PR TITLE
epmd: require explicitly adding loopback address (see also #1075)

### DIFF
--- a/erts/doc/src/epmd.xml
+++ b/erts/doc/src/epmd.xml
@@ -11,7 +11,7 @@
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.
       You may obtain a copy of the License at
- 
+
           http://www.apache.org/licenses/LICENSE-2.0
 
       Unless required by applicable law or agreed to in writing, software
@@ -19,11 +19,11 @@
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
       See the License for the specific language governing permissions and
       limitations under the License.
-    
+
     </legalnotice>
 
     <title>epmd</title>
-    <prepared>Claes Wikstr&ouml;m</prepared>    
+    <prepared>Claes Wikstr&ouml;m</prepared>
     <responsible></responsible>
     <docno>1</docno>
     <approved></approved>
@@ -113,12 +113,12 @@
     <taglist>
       <tag><c><![CDATA[-address List]]></c></tag>
       <item>
-	<p>Lets this instance of <c>epmd</c> listen only on the
-	  comma-separated list of IP addresses and on the loopback address
-	  (which is implicitly added to the list if it has not been
-	  specified). This can also be set using environment variable
-	  <c><![CDATA[ERL_EPMD_ADDRESS]]></c>; see section <seealso
-	  marker="#environment_variables">Environment Variables</seealso>.</p>
+        <p>Let this instance of <c>epmd</c> listen only on the
+          comma-separated list of IP addresses. The list of IP addresses should
+          include the loopback address. This can also be set
+          using the <c><![CDATA[ERL_EPMD_ADDRESS]]></c> environment variable. See
+          the section <seealso marker="#environment_variables">Environment
+            variables</seealso> below.</p>
       </item>
       <tag><c><![CDATA[-port No]]></c></tag>
       <item>
@@ -258,12 +258,12 @@
     <taglist>
       <tag><c><![CDATA[ERL_EPMD_ADDRESS]]></c></tag>
       <item>
-	<p>Can be set to a comma-separated
-	  list of IP addresses, in which case the <c>epmd</c> daemon
-	  will listen only on the specified address(es) and on the
-	  loopback address (which is implicitly added to the list if it
-	  has not been specified). The default behavior is to listen on
-	  all available IP addresses.</p>
+        <p>This environment variable may be set to a comma-separated
+          list of IP addresses, in which case the <c>epmd</c> daemon
+          will listen only on the specified address(es). The list of
+          IP addresses should include the loopback address.
+          The default behaviour is to listen on
+          all available IP addresses.</p>
       </item>
       <tag><c><![CDATA[ERL_EPMD_PORT]]></c></tag>
       <item>

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -206,7 +206,6 @@ void run(EpmdVars *g)
   int i;
   int opt;
   unsigned short sport = g->port;
-  int bound = 0;
 
   node_init(g);
   g->conn = conn_init(g);
@@ -252,14 +251,6 @@ void run(EpmdVars *g)
       char *tmp = NULL;
       char *token = NULL;
 
-      /* Always listen on the loopback. */
-      SET_ADDR(iserv_addr[num_sockets],htonl(INADDR_LOOPBACK),sport);
-      num_sockets++;
-#if defined(EPMD6)
-      SET_ADDR6(iserv_addr[num_sockets],in6addr_loopback,sport);
-      num_sockets++;
-#endif
-
 	  if ((tmp = strdup(g->addresses)) == NULL)
 	{
 	  dbg_perror(g,"cannot allocate memory");
@@ -273,7 +264,6 @@ void run(EpmdVars *g)
 	  struct in_addr addr;
 #if defined(EPMD6)
 	  struct in6_addr addr6;
-	  struct sockaddr_storage *sa = &iserv_addr[num_sockets];
 
 	  if (inet_pton(AF_INET6,token,&addr6) == 1)
 	    {
@@ -295,15 +285,6 @@ void run(EpmdVars *g)
 	      dbg_tty_printf(g,0,"cannot parse IP address \"%s\"",token);
 	      epmd_cleanup_exit(g,1);
 	    }
-
-#if defined(EPMD6)
-	  if (sa->ss_family == AF_INET6 && IN6_IS_ADDR_LOOPBACK(&addr6))
-	      continue;
-
-	  if (sa->ss_family == AF_INET)
-#endif
-	  if (IS_ADDR_LOOPBACK(addr))
-	    continue;
 
 	  num_sockets++;
 
@@ -366,16 +347,10 @@ void run(EpmdVars *g)
 
       if ((listensock[i] = socket(sa->sa_family,SOCK_STREAM,0)) < 0)
 	{
-	  switch (errno) {
-	      case EAFNOSUPPORT:
-	      case EPROTONOSUPPORT:
-	          continue;
-	      default:
-	          dbg_perror(g,"error opening stream socket");
-	          epmd_cleanup_exit(g,1);
-	  }
+	  dbg_perror(g,"error opening stream socket");
+	  epmd_cleanup_exit(g,1);
 	}
-      g->listenfd[bound++] = listensock[i];
+      g->listenfd[i] = listensock[i];
 
 #if HAVE_DECL_IPV6_V6ONLY
       opt = 1;
@@ -440,11 +415,6 @@ void run(EpmdVars *g)
       }
       select_fd_set(g, listensock[i]);
     }
-  if (bound == 0) {
-      dbg_perror(g,"unable to bind any address");
-      epmd_cleanup_exit(g,1);
-  }
-  num_sockets = bound;
 #ifdef HAVE_SYSTEMD_DAEMON
     }
     if (g->is_systemd) {


### PR DESCRIPTION
ℹ️ **This is a rebase of #1075.**

Remove the implicit binding of the IPv4 and IPv6 loopback addresses.

Some methods of disabling IPv6 support on Linux and Windows removes the
IPv6 address from the interface.

This change also allows binding to IPv6 or IPv4 addresses only:

    # previous behaviour
    # tcp        0      0 127.0.0.1:4369          0.0.0.0:* LISTEN
    # tcp6       0      0 ::1:4369                :::* LISTEN
    ERL_EPMD_ADDRESS="127.0.0.1,::1" epmd

    # IPv4 ANY
    # tcp        0      0 127.0.0.1:4369          0.0.0.0:* LISTEN
    ERL_EPMD_ADDRESS="0.0.0.0" epmd

    # IPv6 ANY
    # tcp6       0      0 :::4369                 :::* LISTEN
    ERL_EPMD_ADDRESS="::" epmd

    # IPv6 loopback only
    # tcp6       0      0 ::1:4369                :::* LISTEN
    ERL_EPMD_ADDRESS="::1" epmd