### PR TITLE
Rename argv[0] from beam to invoking program name

### DIFF
--- a/erts/etc/common/ct_run.c
+++ b/erts/etc/common/ct_run.c
@@ -82,6 +82,9 @@ static int eargc;		/* Number of arguments in eargv. */
 
 static void error(char* format, ...);
 static void* emalloc(size_t size);
+#ifdef HAVE_COPYING_PUTENV
+static void efree(void *p);
+#endif
 static char* strsave(char* string);
 static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
@@ -119,6 +122,30 @@ char *strerror(int errnum)
 }
 #endif /* !HAVE_STRERROR */
 
+
+static void
+set_env(char *key, char *value)
+{
+#ifdef __WIN32__
+    WCHAR wkey[MAXPATHLEN];
+    WCHAR wvalue[MAXPATHLEN];
+    MultiByteToWideChar(CP_UTF8, 0, key, -1, wkey, MAXPATHLEN);
+    MultiByteToWideChar(CP_UTF8, 0, value, -1, wvalue, MAXPATHLEN);
+    if (!SetEnvironmentVariableW(wkey, wvalue))
+        error("SetEnvironmentVariable(\"%s\", \"%s\") failed!", key, value);
+#else
+    size_t size = strlen(key) + 1 + strlen(value) + 1;
+    char *str = emalloc(size);
+    sprintf(str, "%s=%s", key, value);
+    if (putenv(str) != 0)
+        error("putenv(\"%s\") failed!", str);
+#ifdef HAVE_COPYING_PUTENV
+    efree(str);
+#endif
+#endif
+}
+
+
 #ifdef __WIN32__
 int wmain(int argc, wchar_t **wcargv)
 {
@@ -153,6 +180,11 @@ int main(int argc, char** argv)
     argv0 = argv;
 
     emulator = get_default_emulator(argv[0]);
+
+    /*
+     * Add scriptname to env
+     */
+    set_env("ESCRIPT_NAME", argv[0]);
 
     /*
      * Allocate the argv vector to be used for arguments to Erlang.
@@ -455,6 +487,14 @@ erealloc(void *p, size_t size)
     if (res == NULL)
     error("Insufficient memory");
     return res;
+}
+#endif
+
+#ifdef HAVE_COPYING_PUTENV
+static void
+efree(void *p)
+{
+    free(p);
 }
 #endif
 

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -583,8 +583,12 @@ int main(int argc, char **argv)
     erts_snprintf(tmpStr, sizeof(tmpStr), "%s" DIRSEP "%s" BINARY_EXT, bindir, emu);
     emu = strsave(tmpStr);
 
-    add_Eargs(emu);		/* Will be argv[0] -- necessary! */
-
+    s = get_env("ESCRIPT_NAME");
+    if(s) {
+        add_Eargs(s);         /* argv[0] = scriptname*/
+    } else {
+        add_Eargs(progname);  /* argv[0] = erl or cerl */
+    }
     /*
      * Add the bindir to the path (unless it is there already).
      */

--- a/erts/etc/common/escript.c
+++ b/erts/etc/common/escript.c
@@ -155,6 +155,29 @@ free_env_val(char *value)
 	efree(value);
 #endif
 }
+
+static void
+set_env(char *key, char *value)
+{
+#ifdef __WIN32__
+    WCHAR wkey[MAXPATHLEN];
+    WCHAR wvalue[MAXPATHLEN];
+    MultiByteToWideChar(CP_UTF8, 0, key, -1, wkey, MAXPATHLEN);
+    MultiByteToWideChar(CP_UTF8, 0, value, -1, wvalue, MAXPATHLEN);
+    if (!SetEnvironmentVariableW(wkey, wvalue))
+        error("SetEnvironmentVariable(\"%s\", \"%s\") failed!", key, value);
+#else
+    size_t size = strlen(key) + 1 + strlen(value) + 1;
+    char *str = emalloc(size);
+    sprintf(str, "%s=%s", key, value);
+    if (putenv(str) != 0)
+        error("putenv(\"%s\") failed!", str);
+#ifdef HAVE_COPYING_PUTENV
+    efree(str);
+#endif
+#endif
+}
+
 /*
  * Find absolute path to this program
  */
@@ -548,7 +571,12 @@ main(int argc, char** argv)
     while (--eargc_base >= 0) {
 	UNSHIFT(eargv_base[eargc_base]);
     }
-    
+
+    /*
+     * Add scriptname to env
+     */
+    set_env("ESCRIPT_NAME", scriptname);
+
     /*
      * Invoke Erlang with the collected options.
      */

--- a/erts/etc/common/typer.c
+++ b/erts/etc/common/typer.c
@@ -64,6 +64,9 @@ static int eargc;		/* Number of arguments in eargv. */
 
 static void error(char* format, ...);
 static void* emalloc(size_t size);
+#ifdef HAVE_COPYING_PUTENV
+static void efree(void *p);
+#endif
 static char* strsave(char* string);
 static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
@@ -101,6 +104,29 @@ char *strerror(int errnum)
 }
 #endif /* !HAVE_STRERROR */
 
+static void
+set_env(char *key, char *value)
+{
+#ifdef __WIN32__
+    WCHAR wkey[MAXPATHLEN];
+    WCHAR wvalue[MAXPATHLEN];
+    MultiByteToWideChar(CP_UTF8, 0, key, -1, wkey, MAXPATHLEN);
+    MultiByteToWideChar(CP_UTF8, 0, value, -1, wvalue, MAXPATHLEN);
+    if (!SetEnvironmentVariableW(wkey, wvalue))
+        error("SetEnvironmentVariable(\"%s\", \"%s\") failed!", key, value);
+#else
+    size_t size = strlen(key) + 1 + strlen(value) + 1;
+    char *str = emalloc(size);
+    sprintf(str, "%s=%s", key, value);
+    if (putenv(str) != 0)
+        error("putenv(\"%s\") failed!", str);
+#ifdef HAVE_COPYING_PUTENV
+    efree(str);
+#endif
+#endif
+}
+
+
 #ifdef __WIN32__
 int wmain(int argc, wchar_t **wcargv)
 {
@@ -129,6 +155,10 @@ main(int argc, char** argv)
 #endif
 
     emulator = get_default_emulator(argv[0]);
+    /*
+     * Add scriptname to env
+     */
+    set_env("ESCRIPT_NAME", argv[0]);
 
     /*
      * Allocate the argv vector to be used for arguments to Erlang.
@@ -350,6 +380,14 @@ erealloc(void *p, size_t size)
     if (res == NULL)
     error("Insufficient memory");
     return res;
+}
+#endif
+
+#ifdef HAVE_COPYING_PUTENV
+static void
+efree(void *p)
+{
+    free(p);
 }
 #endif
 


### PR DESCRIPTION
Allows ps and htop to display the invoking program/script name
instead of beam[.smp] on unix(es).