### PR TITLE
Add a piece of advice against naming branches 'maint' or 'master'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ for more information.
 
 You can contribute to Erlang/OTP by opening a Pull Request.
 
+Make sure you create a new branch for your pull request with `git checkout -b new-branch-name`.
+Never do your work directly on `maint` or `master`.
+
 ## Fixing a bug
 
 * In most cases, pull requests for bug fixes should be based on the `maint` branch.


### PR DESCRIPTION
When a branch named 'maint' or 'master' is merged, the commit
message for the merge will be confusing.