### PR TITLE
Error when a non-DST time is passed to the httpd_util:rfc1123_date/1 function

### DIFF
--- a/lib/inets/src/http_server/httpd_util.erl
+++ b/lib/inets/src/http_server/httpd_util.erl
@@ -333,7 +333,9 @@ rfc1123_date(LocalTime) ->
     {{YYYY,MM,DD},{Hour,Min,Sec}} = 
 	case calendar:local_time_to_universal_time_dst(LocalTime) of
 	    [Gmt]   -> Gmt;
-	    [_,Gmt] -> Gmt
+	    [_,Gmt] -> Gmt;
+        % Should not happen, but handle the empty list to prevent an error.
+        [] -> LocalTime
 	end,
     DayNumber = calendar:day_of_the_week({YYYY,MM,DD}),
     lists:flatten(

--- a/lib/inets/test/httpd_basic_SUITE.erl
+++ b/lib/inets/test/httpd_basic_SUITE.erl
@@ -42,7 +42,8 @@ all() ->
      escaped_url_in_error_body,
      script_timeout,
      slowdose,
-     keep_alive_timeout
+     keep_alive_timeout,
+     invalid_rfc1123_date
     ].
 
 groups() -> 
@@ -381,6 +382,16 @@ slowdose(Config) when is_list(Config) ->
     after 6000 ->
 	    {error, closed} = gen_tcp:send(Socket, "Hey")
     end.
+
+%%-------------------------------------------------------------------------
+
+invalid_rfc1123_date() ->
+    [{doc, "Test that a non-DST date is handled correcly"}].
+invalid_rfc1123_date(Config) when is_list(Config) ->
+    Rfc1123FormattedDate = "Sun, 26 Mar 2017 01:00:00 GMT",
+    NonDSTDateTime = {{2017, 03, 26},{1, 0, 0}},
+    Rfc1123FormattedDate =:= httpd_util:rfc1123_date(NonDSTDateTime).
+
 
 %%-------------------------------------------------------------------------
 %% Internal functions


### PR DESCRIPTION
Rebased to master as requested in   #1404.

It causes a case-clause error, as the calender:local_time_to_universal_time_dst/1
can return an empty list, which is not currently handled.

When called with an invalid DST time:
1> httpd_util:rfc1123_date({{2017, 03, 26},{1, 0, 0}}).
   ** exception error: no case clause matching []
      in function  httpd_util:rfc1123_date/1 (httpd_util.erl, line 334)

To alleviate this, simply add a clause to handle the empty list and return the
original time in the expected rfc1123 format. This is the approach of other
modules which make use of the calender:local_time_to_universal_time_dst/1
function. The formatted date is then returned without error:

2> httpd_util:rfc1123_date({{2017, 03, 26},{1, 0, 0}}).
   "Sun, 26 Mar 2017 01:00:00 GMT"