### PR TITLE
system/doc/reference_manual/: fix a typo

### DIFF
--- a/system/doc/reference_manual/data_types.xml
+++ b/system/doc/reference_manual/data_types.xml
@@ -452,7 +452,7 @@ hello
 &lt;&lt;"77">>
 16> <input>float_to_binary(7.0).</input>
 &lt;&lt;"7.00000000000000000000e+00">>
-17> <input>binary_to_float(&lt;&lt;"7.000e+00>>").</input>
+17> <input>binary_to_float(&lt;&lt;"7.000e+00">>).</input>
 7.0</pre>
   </section>
 </chapter>


### PR DESCRIPTION
see http://erlang.org/doc/reference_manual/data_types.html#id77115

```erlang
17> binary_to_float(<<"7.000e+00>>").
7.0
```