### PR TITLE
Add a test for utf8 function names

### DIFF
--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -145,7 +145,7 @@ format_1(#k_local{name=N,arity=A}, Ctxt) ->
     "local " ++ format_fa_pair({N,A}, Ctxt);
 format_1(#k_remote{mod=M,name=N,arity=A}, _Ctxt) ->
     %% This is for our internal translator.
-    io_lib:format("remote ~s:~s/~w", [format(M),format(N),A]);
+    io_lib:format("remote ~ts:~ts/~w", [format(M),format(N),A]);
 format_1(#k_internal{name=N,arity=A}, Ctxt) ->
     "internal " ++ format_fa_pair({N,A}, Ctxt);
 format_1(#k_seq{arg=A,body=B}, Ctxt) ->


### PR DESCRIPTION
This PR improves the coverage for UTF8 function names in compile_SUITE. Someone [reported on the mailing list](http://erlang.org/pipermail/erlang-questions/2017-May/092290.html) the feature no longer works. The test pass as of ffa80a41370025ed2fb95967e731f13cc7e45e4f but I still need to run it on latest master.

UPDATE: the test also passes on machine after rebuilding on current master.