### PR TITLE
Make 'slim' slim again

### DIFF
--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -194,7 +194,7 @@ build_file(Code, Attr, Dict, NumLabels, NumFuncs, ExtraChunks, SourceFile, Opts,
 
     Chunks = case member(slim, Opts) of
 		 true ->
-		     [Essentials,AttrChunk,CheckedChunks];
+		     [Essentials,AttrChunk];
 		 false ->
 		     [Essentials,LocChunk,AttrChunk,
 		      CompileChunk,CheckedChunks,LineChunk]


### PR DESCRIPTION
The undocumented compiler option 'slim' is used when compiling
the primary bootstrap. The purpose is to make the bootstrap smaller
and to avoid unnecessary churn in the git repository. That is,
the BEAM file should be different only if the actual code in the
file is different, and not if it has merely been re-compiled on
a different computer.

Two commits have fattened the 'slim' option. In 36f7087ae0f,
extra chunks are included even in slim BEAM files. In dfb899c0229f7,
the "Dbgi" were added as an extra chunk, causing it to be included
in slim files.

Make 'slim' slim again by only including the essential chunks and
the attribute chunk (as was the case before the {extra,...} option
was added).