### PR TITLE
Mend leak of stacktrace in catch and try...catch

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -1814,14 +1814,48 @@ true</pre>
       <type name="stack_item"/>
       <desc>
         <p>Gets the call stack back-trace (<em>stacktrace</em>) of the
-          last exception in the calling process as a list of
+          for an exception that has just been caught in the calling process
+	  as a list of
           <c>{<anno>Module</anno>,<anno>Function</anno>,<anno>Arity</anno>,<anno>Location</anno>}</c>
           tuples. Field <c><anno>Arity</anno></c> in the first tuple can be the
           argument list of that function call instead of an arity integer,
           depending on the exception.</p>
-        <p>If there has not been any exceptions in a process, the
-          stacktrace is <c>[]</c>. After a code change for the process,
-          the stacktrace can also be reset to <c>[]</c>.</p>
+	<p><c>erlang:get_stacktrace/0</c> is only guaranteed to return
+	a stacktrace if called (directly or indirectly) from within the
+	scope of <c>try</c> expression. That is, the following call works:</p>
+<pre>
+try Expr
+catch
+  C:R ->
+   {C,R,erlang:get_stacktrace()}
+end</pre>
+	<p>As does this call:</p>
+<pre>
+try Expr
+catch
+  C:R ->
+   {C,R,helper()}
+end
+
+helper() ->
+  erlang:get_stacktrace().</pre>
+	<p>However, <c>erlang:get_stacktrace/0</c> will return
+	<c>[]</c> if it is called after the <c>try</c> expression as in
+	this example:</p>
+<pre>
+try Expr
+catch
+  C:R ->
+   {C,R,helper()}
+end,
+erlang:get_stacktrace().</pre>
+
+	<p>The stacktrace is <c>[]</c> no stacktrace is available,
+	for example if <c>erlang:get_stacktrace/0</c> is called
+	from outside a <c>try</c> expression.</p>
+	<note><p>Before OTP 20, the stacktrace for the latest exception
+	would usually be available until a new exception occurred.
+        </p></note>
         <p>The stacktrace is the same data as operator <c>catch</c>
           returns, for example:</p>
         <pre>
@@ -1847,6 +1881,21 @@ true</pre>
         <p>See also
           <seealso marker="#error/1"><c>error/1</c></seealso> and
           <seealso marker="#error/2"><c>error/2</c></seealso>.</p>
+	<note><p>If there is a tail-recursive call from the <c>try</c>
+	expression to a helper function, the stacktrace will not be
+	cleared until a new exception occurs. In the following example,
+	the huge list will be kept in the process until a new exception
+	occurs:</p>
+	  <pre>
+try
+  tuple_size(lists:duplicate(100000, $a))
+catch
+  C:R ->
+   tail_recursive_helper()
+end
+
+tail_recursive_helper() ->
+  {C,R,erlang:get_stacktrace()}.</pre></note>
       </desc>
     </func>
 

--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -1046,6 +1046,10 @@ do {                                            \
     if (!erts_new_bs_put_binary_all(ERL_BITS_ARGS_2((Src), (Unit)))) { goto badarg; }	\
  } while (0)
 
+#define KillStacktrace()                        \
+  do {                                          \
+    c_p->ftrace = NIL;                          \
+  } while (0)
 
 #define IsPort(Src, Fail) if (is_not_port(Src)) { Fail; }
 #define IsPid(Src, Fail) if (is_not_pid(Src)) { Fail; }

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -263,6 +263,9 @@ raise Trace Value => move Trace x=3 | move Value x=1 | move x=3 x=2 | i_raise
 
 i_raise
 
+kill_stacktrace
+%macro: kill_stacktrace KillStacktrace
+
 # Internal now, but could be useful to make known to the compiler.
 badarg j
 system_limit j

--- a/erts/emulator/test/trace_local_SUITE.erl
+++ b/erts/emulator/test/trace_local_SUITE.erl
@@ -1108,14 +1108,17 @@ x_exc_body(ExcOpts, {M,F}=Func, Args, Apply) ->
                 {rft,{?MODULE,exc,2},Value} ->
                     ok
             end,
+            erase(stacktrace),
             {value,Value}
     catch
         Thrown when Nocatch ->
+            put(stacktrace, erlang:get_stacktrace()),
             CR = {error,{nocatch,Thrown}},
             x_exc_exception(Rtt, M, F, Args, Arity, CR),
             expect({eft,{?MODULE,exc,2},CR}),
             CR;
         Class:Reason ->
+            put(stacktrace, erlang:get_stacktrace()),
             CR = {Class,Reason},
             x_exc_exception(Rtt, M, F, Args, Arity, CR),
             expect({eft,{?MODULE,exc,2},CR}),
@@ -1156,7 +1159,8 @@ x_exc_exception(_Rtt, M, F, _, Arity, CR) ->
     expect({eft,{M,F,Arity},CR}).
 
 x_exc_stacktrace() ->
-    x_exc_stacktrace(erlang:get_stacktrace()).
+    x_exc_stacktrace(get(stacktrace)).
+
 %% Truncate stacktrace to below exc/2
 x_exc_stacktrace([{?MODULE,x_exc,4,_}|_]) -> [];
 x_exc_stacktrace([{?MODULE,x_exc_func,4,_}|_]) -> [];

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -65,6 +65,7 @@ MODULES =  \
 	beam_reorder \
 	beam_record \
 	beam_split \
+	beam_stk \
 	beam_trim \
 	beam_type \
 	beam_utils \

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -349,6 +349,8 @@ make_op({'%',_}, Dict) ->
 make_op({line,Location}, Dict0) ->
     {Index,Dict} = beam_dict:line(Location, Dict0),
     encode_op(line, [Index], Dict);
+make_op({bif, kill_stacktrace=I, {f,_}, [], _Dest}, Dict) ->
+    encode_op(I, [], Dict);
 make_op({bif, Bif, {f,_}, [], Dest}, Dict) ->
     %% BIFs without arguments cannot fail.
     encode_op(bif0, [{extfunc, erlang, Bif, 0}, Dest], Dict);

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -1165,6 +1165,12 @@ resolve_inst({get_map_elements,Args0},_,_,_) ->
     {get_map_elements,FLbl,Src,{list,List}};
 
 %%
+%% 20.0
+%%
+resolve_inst({kill_stacktrace=I,[]},_,_,_) ->
+    I;
+
+%%
 %% Catches instructions that are not yet handled.
 %%
 resolve_inst(X,_,_,_) -> ?exit({resolve_inst,X}).

--- a/lib/compiler/src/beam_disasm.hrl
+++ b/lib/compiler/src/beam_disasm.hrl
@@ -27,7 +27,8 @@
 %%      PROPER TYPES FOR THE SET OF BEAM INSTRUCTIONS.
 %%
 -type beam_instr() :: 'bs_init_writable' | 'fclearerror' | 'if_end'
-                    | 'remove_message' | 'return' | 'send' | 'timeout'
+                    | 'kill_stacktrace' | 'remove_message'
+                    | 'return' | 'send' | 'timeout'
                     | tuple().  %% XXX: Very underspecified - FIX THIS
 
 %%-----------------------------------------------------------------------

--- a/lib/compiler/src/beam_split.erl
+++ b/lib/compiler/src/beam_split.erl
@@ -52,6 +52,8 @@ split_block([{set,[R],As,{bif,N,{f,Lbl}=Fail}}|Is], Bl, Acc) when Lbl =/= 0 ->
     split_block(Is, [], [{bif,N,Fail,As,R}|make_block(Bl, Acc)]);
 split_block([{set,[R],As,{bif,raise,{f,_}=Fail}}|Is], Bl, Acc) ->
     split_block(Is, [], [{bif,raise,Fail,As,R}|make_block(Bl, Acc)]);
+split_block([{set,[R],[],{bif,kill_stacktrace=Op,{f,_}=Fail}}|Is], Bl, Acc) ->
+    split_block(Is, [], [{bif,Op,Fail,[],R}|make_block(Bl, Acc)]);
 split_block([{set,[R],As,{alloc,Live,{gc_bif,N,{f,Lbl}=Fail}}}|Is], Bl, Acc)
   when Lbl =/= 0 ->
     split_block(Is, [], [{gc_bif,N,Fail,Live,As,R}|make_block(Bl, Acc)]);

--- a/lib/compiler/src/beam_stk.erl
+++ b/lib/compiler/src/beam_stk.erl
@@ -1,0 +1,76 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% Purpose: Make sure that kill_stacktrace instructions don't destroy
+%%          last call optimization.
+
+-module(beam_stk).
+-export([module/2]).
+-import(lists, [reverse/1]).
+
+-spec module(beam_asm:module_code(), [compile:option()]) ->
+                    {'ok',beam_utils:module_code()}.
+
+module({Mod,Exp,Attr,Fs0,Lc}, _Opt) ->
+    Fs = [function(F) || F <- Fs0],
+    {ok,{Mod,Exp,Attr,Fs,Lc}}.
+
+function({function,Name,Arity,CLabel,Is0}) ->
+    try
+        Is = backward(reverse(Is0), #{}, []),
+	{function,Name,Arity,CLabel,Is}
+    catch
+	Class:Error ->
+	    Stack = erlang:get_stacktrace(),
+	    io:fwrite("Function: ~w/~w\n", [Name,Arity]),
+	    erlang:raise(Class, Error, Stack)
+    end.
+
+backward([{label,L}=I|Is], Map0, [{bif,kill_stacktrace,_,_,_}=KillStk,
+                                  {deallocate,_}=D,
+                                  return=Ret|_]=Acc) ->
+    Seq = [KillStk,D,Ret],
+    Map = Map0#{L=>Seq},
+    backward(Is, Map, [I|Acc]);
+backward([{jump,{f,L}}=Jump|Is], Map, Acc) ->
+    case Map of
+        #{L:=Seq} ->
+            backward(Is, Map, Seq ++ Acc);
+        #{} ->
+            backward(Is, Map, [Jump|Acc])
+    end;
+backward([{bif,kill_stacktrace,_,_,_}=I|Is], Map,
+         [{bif,kill_stacktrace,_,_,_}|Acc]) ->
+    backward(Is, Map, [I|Acc]);
+backward([{call,_,_}=Call|Is], Map, Acc0) ->
+    Acc = preserve_last_call_opt(Acc0),
+    backward(Is, Map, [Call|Acc]);
+backward([{call_ext,_,_}=Call|Is], Map, Acc0) ->
+    Acc = preserve_last_call_opt(Acc0),
+    backward(Is, Map, [Call|Acc]);
+backward([I|Is], Map, Acc) ->
+    backward(Is, Map, [I|Acc]);
+backward([], _, Acc) -> Acc.
+
+preserve_last_call_opt([{bif,kill_stacktrace,_,_,_}|
+                        [{deallocate,_}|_]=Acc]) ->
+    %% Remove the kill_stacktrace instruction to preserve
+    %% the last-call optimization.
+    Acc;
+preserve_last_call_opt(Acc) -> Acc.

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -214,13 +214,15 @@ expand_opt(report, Os) ->
 expand_opt(return, Os) ->
     [return_errors,return_warnings|Os];
 expand_opt(r16, Os) ->
-    [no_record_opt,no_utf8_atoms|Os];
+    [no_record_opt,no_utf8_atoms,no_kill_stacktrace|Os];
 expand_opt(r17, Os) ->
-    [no_record_opt,no_utf8_atoms|Os];
+    [no_record_opt,no_utf8_atoms,no_kill_stacktrace|Os];
 expand_opt(r18, Os) ->
-    [no_record_opt,no_utf8_atoms|Os];
+    [no_record_opt,no_utf8_atoms,no_kill_stacktrace|Os];
 expand_opt(r19, Os) ->
-    [no_record_opt,no_utf8_atoms|Os];
+    [no_record_opt,no_utf8_atoms,no_kill_stacktrace|Os];
+expand_opt(r20, Os) ->
+    Os;
 expand_opt({debug_info_key,_}=O, Os) ->
     [encrypt_debug_info,O|Os];
 expand_opt(no_float_opt, Os) ->
@@ -722,6 +724,8 @@ asm_passes() ->
     [{delay,
       [{pass,beam_a},
        {iff,da,{listing,"a"}},
+       {pass,beam_stk},
+       {iff,dstk,{listing,"stk"}},
        {unless,no_postopt,
 	[{unless,no_reorder,{pass,beam_reorder}},
 	 {iff,dre,{listing,"reorder"}},
@@ -1859,6 +1863,7 @@ pre_load() ->
          beam_record,
 	 beam_reorder,
 	 beam_split,
+	 beam_stk,
 	 beam_trim,
 	 beam_type,
 	 beam_utils,

--- a/lib/compiler/src/compiler.app.src
+++ b/lib/compiler/src/compiler.app.src
@@ -40,6 +40,7 @@
 	     beam_reorder,
 	     beam_record,
 	     beam_split,
+	     beam_stk,
 	     beam_trim,
 	     beam_type,
 	     beam_utils,

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -538,8 +538,15 @@ BEAM_FORMAT_NUMBER=0
 157: has_map_fields/3
 158: get_map_elements/3
 
+# OTP 20
+
 ## @spec is_tagged_tuple Lbl Reg N Atom
 ## @doc Test the type of Reg and jumps to Lbl if it is not a tuple.
 ##      Test the arity of Reg and jumps to Lbl if it is not N.
 ##      Test the first element of the tuple and jumps to Lbl if it is not Atom.
 159: is_tagged_tuple/4
+
+## @spec kill_stacktrace
+## @doc Kill the stacktrace (p->ftrace) when leaving a try...catch or catch scope to
+##      avoiding keeping a potentially huge term in the process for a long time.
+160: kill_stacktrace/0

--- a/lib/compiler/src/v3_codegen.erl
+++ b/lib/compiler/src/v3_codegen.erl
@@ -1348,9 +1348,14 @@ internal_cg(bs_init_writable=I, As, Rs, Le, Vdb, Bef, St) ->
     {Sis,Int} = cg_setup_call(As, Bef, Le#l.i, Vdb),
     Reg = load_vars(Rs, clear_regs(Int#sr.reg)),
     {Sis++[I],clear_dead(Int#sr{reg=Reg}, Le#l.i, Vdb),St};
-internal_cg(raise, As, Rs, Le, Vdb, Bef, St) ->
+internal_cg(raise=I, As, Rs, Le, Vdb, Bef, St) ->
     %% raise can be treated like a guard BIF.
-    bif_cg(raise, As, Rs, Le, Vdb, Bef, St).
+    bif_cg(I, As, Rs, Le, Vdb, Bef, St);
+internal_cg(kill_stacktrace=I0, As, Rs, Le, Vdb, Bef, St0) ->
+    %% kill_stacktrace can be treated like a guard BIF.
+    {Is0,Aft,St} = bif_cg(I0, As, Rs, Le, Vdb, Bef, St0),
+    Is = [I || I <- Is0, I =/= {line,[]}],
+    {Is,Aft,St}.
 
 %% bif_cg(Bif, [Arg], [Ret], Le, Vdb, StackReg, State) ->
 %%      {[Ainstr],StackReg,State}.

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -35,7 +35,8 @@
 	 cover/1, env/1, core/1,
 	 core_roundtrip/1, asm/1, optimized_guards/1,
 	 sys_pre_attributes/1, dialyzer/1,
-	 warnings/1, pre_load_check/1, env_compiler_options/1
+	 warnings/1, pre_load_check/1, env_compiler_options/1,
+         bc_options/1
 	]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
@@ -52,7 +53,7 @@ all() ->
      strict_record, utf8_atoms, extra_chunks,
      cover, env, core, core_roundtrip, asm, optimized_guards,
      sys_pre_attributes, dialyzer, warnings, pre_load_check,
-     env_compiler_options, custom_debug_info].
+     env_compiler_options, custom_debug_info, bc_options].
 
 groups() -> 
     [].
@@ -1346,6 +1347,47 @@ env_compiler_options(_Config) ->
         Expected = compile:env_compiler_options()
     end,
     lists:foreach(F, Cases).
+
+%% Test options for compatibility with previous major versions of OTP.
+
+bc_options(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+
+    101 = highest_opcode(DataDir, small_float, [no_line_info]),
+
+    103 = highest_opcode(DataDir, big, [no_record_opt,no_kill_stacktrace,no_line_info,no_stack_trimming]),
+
+    125 = highest_opcode(DataDir, small_float, [no_line_info,no_float_opt]),
+
+    132 = highest_opcode(DataDir, small, [no_record_opt,no_kill_stacktrace,no_float_opt,no_line_info]),
+
+    136 = highest_opcode(DataDir, big, [no_record_opt,no_kill_stacktrace,no_line_info]),
+
+    153 = highest_opcode(DataDir, big, [no_record_opt,no_kill_stacktrace]),
+    153 = highest_opcode(DataDir, big, [r16]),
+    153 = highest_opcode(DataDir, big, [r17]),
+    153 = highest_opcode(DataDir, big, [r18]),
+    153 = highest_opcode(DataDir, big, [r19]),
+    153 = highest_opcode(DataDir, small_float, [r16]),
+    153 = highest_opcode(DataDir, small_float, [r20]),
+
+    158 = highest_opcode(DataDir, small_maps, [r17]),
+    158 = highest_opcode(DataDir, small_maps, [r18]),
+    158 = highest_opcode(DataDir, small_maps, [r19]),
+    158 = highest_opcode(DataDir, small_maps, [r20]),
+
+    159 = highest_opcode(DataDir, big, [no_kill_stacktrace]),
+
+    160 = highest_opcode(DataDir, big, [r20]),
+
+    ok.
+
+highest_opcode(DataDir, Mod, Opt) ->
+    Src = filename:join(DataDir, atom_to_list(Mod)++".erl"),
+    {ok,Mod,Beam} = compile:file(Src, [binary|Opt]),
+    {ok,{Mod,[{"Code",Code}]}} = beam_lib:chunks(Beam, ["Code"]),
+    <<16:32,0:32,HighestOpcode:32,_/binary>> = Code,
+    HighestOpcode.
 
 %%%
 %%% Utilities.

--- a/lib/compiler/test/compile_SUITE_data/small_float.erl
+++ b/lib/compiler/test/compile_SUITE_data/small_float.erl
@@ -1,0 +1,5 @@
+-module(small_float).
+-export([f/1]).
+
+f(F) when is_float(F) ->
+    F / 2.

--- a/lib/compiler/test/misc_SUITE.erl
+++ b/lib/compiler/test/misc_SUITE.erl
@@ -191,6 +191,10 @@ silly_coverage(Config) when is_list(Config) ->
 		     {label,2}|non_proper_list]}],99},
     expect_error(fun() -> beam_a:module(BeamAInput, []) end),
 
+    %% beam_stk
+    BeamStkInput = BeamAInput,
+    expect_error(fun() -> beam_stk:module(BeamStkInput, []) end),
+
     %% beam_reorder
     BlockInput = {?MODULE,[{foo,0}],[],
 		  [{function,foo,0,2,

--- a/lib/hipe/icode/hipe_beam_to_icode.erl
+++ b/lib/hipe/icode/hipe_beam_to_icode.erl
@@ -1158,6 +1158,13 @@ trans_fun([{put_map_exact,{f,Lbl},Map,Dst,_N,{list,Pairs}}|Instructions], Env) -
       end,
   [MapMove, TempMapMove, PutInstructions | trans_fun(Instructions, Env2)];
 %%--------------------------------------------------------------------
+%% Instructions added in Spring 2017 (20.0).
+%%--------------------------------------------------------------------
+trans_fun([kill_stacktrace|Instructions], Env) ->
+  %% XXX: Add instructions for killing the stacktrace.
+  trans_fun(Instructions,Env);
+
+%%--------------------------------------------------------------------
 %%--- ERROR HANDLING ---
 %%--------------------------------------------------------------------
 trans_fun([X|_], _) ->


### PR DESCRIPTION
p->ftrace holds the stacktrace from the last exception in
the process. If the last exception was a 'function_clause' or
a 'badarg' from a BIF call, the arguments for the call are also
stored in p->ftrace. The arguments could potentially be huge.

p->ftrace is user by erlang:get_stacktrace/0 to retrieve the
stacktrace for last exception in a process.

To eliminate this leak, we must do a slightly incomptible change
to how erlang:get_stacktrace/0 works. It will only return a stacktrace
when called from within the scope of try...catch. The following will
work:
 ```
 try
    ...
  catch
    C:R ->
      Stk = erlang:get_stacktrace(), %% Will return a stacktrace.
      {C,R,Stk}
  end.
```
The following will also work:
  ```
try
    ...
  catch
    C:R ->
      Stk = helper(),
      {C,R,Stk}
  end.

helper() ->
  erlang:get_stacktrace().  %% Will return a stacktrace.
```
The following will no longer work:
```
 try
    ...
  catch
    C:R ->
      ...
  end,
  erlang:get_stacktrace() %% Will return [].
```
There is a another complication. Consider this code:
```
  try
    ...
  catch
    C:R ->
      tail_recursive_helper(C, R)
  end.

tail_recursive_helper(C, R) ->
  {C,R,erlang:get_stacktrace()}.
```
If we insert an instruction that clears the stacktrace after the call
to tail_recursive_helper/2, the call will no longer be tail-recursive.
If we want to preserve tail recursion and still make
erlang:get_stacktrace/0 return a stacktrace, we can't clear the
stacktrace in p->ftrace.

Since destroying tail recursion could have worse consequences than
keeping the stacktrace, we will not clear the stacktrace in this case.

In the case of an old-style 'catch', erlang:get_stacktrace/0 will work
if it is used before the function that executes the 'catch' returns.
That is, the following examples will work:
```
f1() ->
  ...,
  (catch ...),
  ...,
  erlang:get_stacktrace(),
  ...

f2() ->
  ...,
  (catch ...),
  ...,
  {error,helper()}.

helper() ->
  erlang:get_stacktrace().

```
If there is a tail-recursive call to a helper function, the
stacktrace will not be cleared from the process:
```
f3() ->
  ...,
  (catch ...),
  ...,
  helper().

helper() ->
  erlang:get_stacktrace().
```