### PR TITLE
Fix typo in child spec for file_server

### DIFF
--- a/lib/kernel/src/kernel.erl
+++ b/lib/kernel/src/kernel.erl
@@ -123,7 +123,7 @@ init([]) ->
              restart => permanent,
              shutdown => 2000,
              type => worker,
-             modeules => [file, file_server, file_io_server, prim_file]},
+             modules => [file, file_server, file_io_server, prim_file]},
 
     StdError = #{id => standard_error,
                  start => {standard_error, start_link, []},


### PR DESCRIPTION
'modeules' -> 'modules'

Introduced in 3edc6dbf8f150bb6ba7c800ed5cc379771f8b279 (present in 20.0-rc1, but
not in the 19 release series).