### PR TITLE
Make calls to get_stacktrace/0 future-proof

### DIFF
--- a/lib/common_test/src/ct_util.erl
+++ b/lib/common_test/src/ct_util.erl
@@ -201,14 +201,7 @@ do_start(Parent, Mode, LogDir, Verbosity) ->
 	ok ->
 	    Parent ! {self(),started};
 	{fail,CTHReason} ->
-	    ErrorInfo = if is_atom(CTHReason) ->
-				io_lib:format("{~p,~p}",
-					      [CTHReason,
-					       erlang:get_stacktrace()]);
-			   true ->
-				CTHReason
-			end,
-	    ct_logs:tc_print('Suite Callback',ErrorInfo,[]),
+	    ct_logs:tc_print('Suite Callback',CTHReason,[]),
 	    self() ! {{stop,{self(),{user_error,CTHReason}}},
 		      {Parent,make_ref()}}
     catch

--- a/lib/snmp/src/agent/snmp_generic.erl
+++ b/lib/snmp/src/agent/snmp_generic.erl
@@ -413,20 +413,21 @@ table_check_status(NameDb, Col, ?'RowStatus_createAndGo', RowIndex, Cols) ->
 	false -> 
 	    % it's ok to use snmpa_local_db:table_construct_row since it's
 	    % side effect free and we only use the result temporary.
-	    case catch snmpa_local_db:table_construct_row(
+	    try snmpa_local_db:table_construct_row(
 			 NameDb, RowIndex, ?'RowStatus_createAndGo', Cols) of
-		{'EXIT', _Reason} ->
-		    ?vtrace(
-		       "failed construct row (createAndGo): "
-		       " n   Reason: ~p"
-		       " n   Stack:  ~p",
-		       [_Reason, erlang:get_stacktrace()]),
-		    {noCreation, Col}; % Bad RowIndex
 		Row ->
 		    case lists:member(noinit, tuple_to_list(Row)) of
 			false -> {noError, 0};
 			_Found -> {inconsistentValue, Col}
 		    end
+            catch
+                _:_Reason ->
+		    ?vtrace(
+		       "failed construct row (createAndGo): "
+		       " n   Reason: ~p"
+		       " n   Stack:  ~p",
+		       [_Reason, erlang:get_stacktrace()]),
+		    {noCreation, Col}           % Bad RowIndex
 	    end;
 	true -> {inconsistentValue, Col}
     end;
@@ -435,17 +436,18 @@ table_check_status(NameDb, Col, ?'RowStatus_createAndGo', RowIndex, Cols) ->
 table_check_status(NameDb, Col, ?'RowStatus_createAndWait', RowIndex, Cols) ->
     case table_row_exists(NameDb, RowIndex) of
 	false ->
-	    case catch snmpa_local_db:table_construct_row(
+	    try snmpa_local_db:table_construct_row(
 			 NameDb, RowIndex, ?'RowStatus_createAndGo', Cols) of
-		{'EXIT', _Reason} ->
+		_Row ->
+		    {noError, 0}
+            catch
+                _:_Reason ->
 		    ?vtrace(
 		       "failed construct row (createAndWait): "
 		       " n   Reason: ~p"
 		       " n   Stack:  ~p",
 		       [_Reason, erlang:get_stacktrace()]),
-		    {noCreation, Col}; % Bad RowIndex
-		_Row ->
-		    {noError, 0}
+		    {noCreation, Col}           % Bad RowIndex
 	    end;
 	true -> {inconsistentValue, Col}
     end;

--- a/lib/stdlib/src/qlc.erl
+++ b/lib/stdlib/src/qlc.erl
@@ -1392,8 +1392,10 @@ next_loop(Pid, L, N) when N =/= 0 ->
         {caught, throw, Error, [?THROWN_ERROR | _]} ->
             Error;
         {caught, Class, Reason, Stacktrace} ->
-            _ = (catch erlang:error(foo)),
-            erlang:raise(Class, Reason, Stacktrace ++ erlang:get_stacktrace());
+            CurrentStacktrace = try erlang:error(foo)
+                                catch error:_ -> erlang:get_stacktrace()
+                                end,
+            erlang:raise(Class, Reason, Stacktrace ++ CurrentStacktrace);
         error ->
             erlang:error({qlc_cursor_pid_no_longer_exists, Pid})
     end;


### PR DESCRIPTION
In the future (not OTP 20), `erlang:get_stacktrace/0` will probably only work inside a the `catch` block of a `try` expression. 

Fix a few modules to use `try` instead of `catch`, and move the call of the `erlang:get_stackrace/0` into the `try` expression.
