### PR TITLE
Add a new SSL option; client_cert_verify_fun

### DIFF
--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1640,6 +1640,8 @@ digitally_signed(Version, Hashes, HashAlgo, PrivateKey) ->
 	    throw(?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE, bad_key(PrivateKey)))
     end.
 
+do_digitally_signed(_Version, Hash, HashAlgo, Key) when is_function(Key) ->
+    Key(Hash, HashAlgo);
 do_digitally_signed({3, Minor}, Hash, HashAlgo, Key) when Minor >= 3 ->
     public_key:sign({digest, Hash}, HashAlgo, Key);
 do_digitally_signed(_Version, Hash, HashAlgo, #'DSAPrivateKey'{} = Key) ->

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -143,7 +143,8 @@
 	  eccs,
 	  honor_ecc_order            :: boolean(),
 	  v2_hello_compatible        :: boolean(),
-          max_handshake_size         :: integer()
+	  max_handshake_size         :: integer(),
+	  client_cert_verify_fun   :: fun()
          }).
 
 -record(socket_options,

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -144,7 +144,7 @@
 	  honor_ecc_order            :: boolean(),
 	  v2_hello_compatible        :: boolean(),
 	  max_handshake_size         :: integer(),
-	  client_cert_verify_fun   :: fun()
+	  client_cert_verify_fun   :: fun() | 'undefined'
          }).
 
 -record(socket_options,


### PR DESCRIPTION
TLS client certificates work by, once the client key exchange in the TLS
handshake completes, the client can send proof it has access to the key
described by the client certificate. It does this by signing a hash of
all the handshake messages sent up to that point on the TLS session. See
RFC 5246 Section 7.4.8 for more details.

This patch allows the user to specify a function to do the signing,
rather than requiring the user to supply the key directly. This is
useful when using a hardware security module, where a key is stored in
such a way that it can not be read out directly, data must be fed into
the HSM to be signed, and the resulting signature is the output.

This is just a WIP to see if people think this feature is useful and implemented correctly. I am happy to write documentation and tests if the basic idea seems valuable.