### PR TITLE
Fix SSL connection downgrade

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -233,17 +233,13 @@ close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_, _, _}
     Transport:close(ListenSocket).
 
 %%--------------------------------------------------------------------
--spec  close(#sslsocket{}, timeout() | {pid(), integer()}) -> term().
+-spec  close(#sslsocket{}, timeout() | {pid(), timeout()}) -> term().
 %%
 %% Description: Close an ssl connection
 %%--------------------------------------------------------------------
-close(#sslsocket{pid = TLSPid},
-      {Pid, Timeout} = DownGrade) when is_pid(TLSPid),
-				       is_pid(Pid),
-				       (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
+close(#sslsocket{pid = TLSPid}, {Pid, _Timeout} = DownGrade) when is_pid(TLSPid), is_pid(Pid) ->
     ssl_connection:close(TLSPid, {close, DownGrade});
-close(#sslsocket{pid = TLSPid}, Timeout) when is_pid(TLSPid),
-					      (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
+close(#sslsocket{pid = TLSPid}, Timeout) when is_pid(TLSPid) ->
     ssl_connection:close(TLSPid, {close, Timeout});
 close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_, _, _}}}}, _) ->
     Transport:close(ListenSocket).
@@ -270,8 +266,7 @@ send(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport, _, _, _}
 %%--------------------------------------------------------------------
 recv(Socket, Length) ->
     recv(Socket, Length, infinity).
-recv(#sslsocket{pid = Pid}, Length, Timeout) when is_pid(Pid),
-						  (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity)->
+recv(#sslsocket{pid = Pid}, Length, Timeout) when is_pid(Pid) ->
     ssl_connection:recv(Pid, Length, Timeout);
 recv(#sslsocket{pid = {udp,_}}, _, _) ->
     {error,enotconn};

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -455,7 +455,16 @@ setopts(#sslsocket{pid = Pid}, Options0) when is_pid(Pid), is_list(Options0)  ->
 	_:_ ->
 	    {error, {options, {not_a_proplist, Options0}}}
     end;
-
+setopts(#sslsocket{pid = {{udp, _}, #config{transport_info = {Transport,_,_,_}}}} = ListenSocket, Options) when is_list(Options) ->
+    try dtls_socket:setopts(Transport, ListenSocket, Options) of
+	ok ->
+	    ok;
+	{error, InetError} ->
+	    {error, {options, {socket_options, Options, InetError}}}
+    catch
+	_:Error ->
+	    {error, {options, {socket_options, Options, Error}}}
+    end;
 setopts(#sslsocket{pid = {_, #config{transport_info = {Transport,_,_,_}}}} = ListenSocket, Options) when is_list(Options) ->
     try tls_socket:setopts(Transport, ListenSocket, Options) of
 	ok ->

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -856,7 +856,8 @@ handle_call({close, {Pid, Timeout}}, From, StateName, State0, Connection) when i
     %% When downgrading an TLS connection to a transport connection
     %% we must recive the close alert from the peer before releasing the 
     %% transport socket.
-    {next_state, downgrade, State#state{terminated = true}, [{timeout, Timeout, downgrade}]};
+    Alert =  ?ALERT_REC(?WARNING, ?CLOSE_NOTIFY),
+    {next_state, downgrade, State#state{terminated = true}, [{next_event, internal, Alert}]};
 handle_call({close, _} = Close, From, StateName, State, Connection) ->
     %% Run terminate before returning so that the reuseaddr
     %% inet-option works properly

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -1030,7 +1030,7 @@ terminate(Reason, connection, #state{negotiated_version = Version,
 				     connection_states = ConnectionStates0, 
 				     ssl_options = #ssl_options{padding_check = Check},
 				     transport_cb = Transport, socket = Socket
-				    } = State) ->
+				    } = State) when Reason =/= downgrade ->
     handle_trusted_certs_db(State),
     {BinAlert, ConnectionStates} = terminate_alert(Reason, Version, ConnectionStates0, Connection),
     Connection:send(Transport, Socket, BinAlert),

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -2011,7 +2011,8 @@ hibernate_after(connection = StateName,
 hibernate_after(StateName, State, Actions) ->
     {next_state, StateName, State, Actions}.
  
-terminate_alert(normal, Version, ConnectionStates, Connection)  ->
+terminate_alert(Reason, Version, ConnectionStates, Connection) when Reason == normal;
+									 Reason == downgrade ->
     Connection:encode_alert(?ALERT_REC(?WARNING, ?CLOSE_NOTIFY),
 		     Version, ConnectionStates);
 terminate_alert({Reason, _}, Version, ConnectionStates, Connection) when Reason == close;


### PR DESCRIPTION
ssl:close(Socket, {Pid, Timeout}) returned {handle_call,{'EXIT',{{badmatch,[<<21,3,3,0,48>>,<<..........
An error occurred at line: 1034 in ssl_connection.erl
`{BinAlert, ConnectionStates} = terminate_alert(Reason, Version, ConnectionStates0, Connection),`

