### PR TITLE
better printing function names in unicode

### DIFF
--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -767,7 +767,7 @@ print_exports(X) when length(X) > 16 ->
     split_print_exports(X);
 print_exports([]) -> ok;
 print_exports([{F, A} |Tail]) ->
-    format("         ~w/~w~n",[F, A]),
+    format("         ~tw/~w~n",[F, A]),
     print_exports(Tail).
 
 split_print_exports(L) ->


### PR DESCRIPTION
for this example code https://gist.github.com/anonymous/2e8babd349167a49eb6f6d55ec0505c9

```erl
1> m(hello).
Module: hello
MD5: 1fc4fe3182fd886e9f03e2748f27e24c
Compiled: No compile time info available
Object file: /src/hello.beam
Compiler options:  []
Exports:
         'hello_\x{44E}\x{43D}\x{438}\x{43A}\x{43E}\x{434}_\x{4E16}\x{754C},'/0
         main/1
         module_info/0
         module_info/1
ok
```

becomes

```erl
2> m(hello).
Module: hello
MD5: 1fc4fe3182fd886e9f03e2748f27e24c
Compiled: No compile time info available
Object file: /src/hello.beam
Compiler options:  []
Exports:
         'hello_юникод_世界,'/0
         main/1
         module_info/0
         module_info/1
ok
```