### PR TITLE
Fix backwards equality check in aes cfb128 function

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -1848,7 +1848,7 @@ static ERL_NIF_TERM aes_cfb_128_crypt_nif(ErlNifEnv* env, int argc, const ERL_NI
     AES_cfb128_encrypt((unsigned char *) text.data,
                        enif_make_new_binary(env, text.size, &ret),
                        text.size, &aes_key, ivec_clone, &new_ivlen,
-                       (argv[3] != atom_true));
+                       (argv[3] == atom_true));
     CONSUME_REDS(env,text);
     return ret;
 }


### PR DESCRIPTION
The fix in #1393 had a backwards equality check for encrypt/decrypt. Because this is a chained cipher, the first 16 bytes end up getting 'encrypted' anyway, but after the first block, things go off the rails.

cc @IngelaAndin @kellymclaughlin 