### PR TITLE
Simplify building a lock-counting emulator

### DIFF
--- a/erts/Makefile
+++ b/erts/Makefile
@@ -40,8 +40,8 @@ all: $(FLAVORS)
 docs:
 	$(V_at)( cd doc/src && $(MAKE) $@ )
 
-.PHONY: debug opt clean
-debug opt clean:
+.PHONY: debug opt lcnt clean
+debug opt lcnt clean:
 	$(V_at)for d in emulator $(ERTSDIRS); do \
 		if test -d $$d; then \
 			( cd $$d && $(MAKE) $@ FLAVOR=$(FLAVOR) ) || exit $$? ; \
@@ -56,7 +56,9 @@ debug opt clean:
 
 .PHONY: $(FLAVORS)
 $(FLAVORS):
-	$(V_at)( $(MAKE) opt FLAVOR=$@ )
+	$(V_at)for type in $(TYPES); do \
+		( $(MAKE) $$type FLAVOR=$@ ); \
+	done
 
 # Make erl script and erlc in $(ERL_TOP)/bin which runs the compiled version
 # Note that erlc is not a script and requires extra handling on cygwin.
@@ -128,7 +130,9 @@ makefiles:
 .PHONY: release
 release:
 	$(V_at)for f in $(FLAVORS); do \
-		( cd emulator && $(MAKE) release FLAVOR=$$f ) \
+		for t in $(TYPES); do \
+		  ( cd emulator && $(MAKE) release FLAVOR=$$f TYPE=$$t ) \
+		done \
 	done
 	$(V_at)for d in $(ERTSDIRS) $(XINSTDIRS); do \
 		if test -d $$d; then \

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1002,6 +1002,7 @@ else
 fi
 
 FLAVORS=
+TYPES=opt
 ERTS_BUILD_SMP_EMU=$enable_smp_support
 AC_MSG_CHECKING(whether an emulator with smp support should be built)
 case $ERTS_BUILD_SMP_EMU in
@@ -1210,6 +1211,7 @@ esac
 
 AC_SUBST(ERTS_BUILD_PLAIN_EMU)
 AC_SUBST(FLAVORS)
+AC_SUBST(TYPES)
 
 case "$ERTS_BUILD_PLAIN_EMU-$ERTS_BUILD_SMP_EMU" in
      no-no)
@@ -1365,7 +1367,7 @@ else
 	AC_MSG_CHECKING(whether lock counters should be enabled)
 	AC_MSG_RESULT($enable_lock_count)
 	if test "x$enable_lock_count" != "xno"; then
-	    EMU_THR_DEFS="$EMU_THR_DEFS -DERTS_ENABLE_LOCK_COUNT"
+	    TYPES="$TYPES lcnt"
 	fi
 
 	case $host_os in

--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -239,6 +239,13 @@
       <item>
         <p>Useful for debugging. Prints the arguments sent to the emulator.</p>
       </item>
+      <tag><c><![CDATA[-emu_type Type]]></c></tag>
+      <item>
+        <p>Start an emulator of a different type. For example, to start
+	the lock-counter emualator, use <c>-emu_type lcnt</c>. (The emulator
+	must already be built. Use the <c>configure</c> option
+	<c>--enable-lock-counter</c> to build the lock-counter emulator.)</p>
+      </item>
       <tag><c><![CDATA[-env Variable Value]]></c></tag>
       <item>
         <p>Sets the host OS environment variable <c><![CDATA[Variable]]></c> to

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -184,17 +184,6 @@ static char *plusz_val_switches[] = {
 #endif
 
 #define SMP_SUFFIX	  ".smp"
-#define DEBUG_SUFFIX      ".debug"
-#define EMU_TYPE_SUFFIX_LENGTH  strlen(DEBUG_SUFFIX)
-
-/*
- * Define flags for different memory architectures.
- */
-#define EMU_TYPE_SMP		0x0001
-
-#ifdef __WIN32__
-#define EMU_TYPE_DEBUG		0x0004
-#endif
 
 void usage(const char *switchname);
 static void usage_format(char *format, ...);
@@ -221,7 +210,7 @@ static void *erealloc(void *p, size_t size);
 static void efree(void *p);
 static char* strsave(char* string);
 static int is_one_of_strings(char *str, char *strs[]);
-static char *write_str(char *to, char *from);
+static char *write_str(char *to, const char *from);
 static void get_home(void);
 static void add_epmd_port(void);
 #ifdef __WIN32__
@@ -255,9 +244,8 @@ static int verbose = 0;		/* If non-zero, print some extra information. */
 static int start_detached = 0;	/* If non-zero, the emulator should be
 				 * started detached (in the background).
 				 */
-static int emu_type = 0;	/* If non-zero, start beam.ARCH or beam.ARCH.exe
-				 * instead of beam or beam.exe, where ARCH is defined by flags. */
-static int emu_type_passed = 0;	/* Types explicitly set */
+static int start_smp_emu = 0;   /* Start the smp emulator. */
+static const char* emu_type = 0; /* Type of emulator (lcnt, valgrind, etc) */
 
 #ifdef __WIN32__
 static char *start_emulator_program = NULL; /* For detachec mode - 
@@ -352,11 +340,11 @@ free_env_val(char *value)
 }
 
 /*
- * Add the architecture suffix to the program name if needed,
- * except on Windows, where we insert it just before ".DLL".
+ * Add the type and architecture suffix to the program name if needed.
+ * On Windows, we insert it just before ".DLL".
  */
 static char*
-add_extra_suffixes(char *prog, int type)
+add_extra_suffixes(char *prog)
 {
    char *res;
    char *p;
@@ -366,16 +354,10 @@ add_extra_suffixes(char *prog, int type)
    int dll = 0;
 #endif
 
-   if (!type) {
-       return prog;
-   }
-
    len = strlen(prog);
 
-   /* Worst-case allocation */
-   p = emalloc(len +
-	       EMU_TYPE_SUFFIX_LENGTH +
-	       + 1);
+   /* Allocate enough extra space for suffixes */
+   p = emalloc(len + 100);
    res = p;
    p = write_str(p, prog);
 
@@ -392,13 +374,11 @@ add_extra_suffixes(char *prog, int type)
    }
 #endif
 
-#ifdef __WIN32__
-   if (type & EMU_TYPE_DEBUG) {
-       p = write_str(p, DEBUG_SUFFIX);
-       type &= ~(EMU_TYPE_DEBUG);
+   if (emu_type) {
+       p = write_str(p, ".");
+       p = write_str(p, emu_type);
    }
-#endif
-   if (type == EMU_TYPE_SMP) {
+   if (start_smp_emu) {
        p = write_str(p, SMP_SUFFIX);
    }
 #ifdef __WIN32__
@@ -489,12 +469,11 @@ int main(int argc, char **argv)
     cpuinfo = erts_cpu_info_create();
     /* '-smp auto' is default */ 
 #ifdef ERTS_HAVE_SMP_EMU
-    emu_type |= EMU_TYPE_SMP;
+    start_smp_emu = 1;
 #endif
 
 #if defined(__WIN32__) && defined(WIN32_ALWAYS_DEBUG)
-    emu_type_passed |= EMU_TYPE_DEBUG;
-    emu_type |= EMU_TYPE_DEBUG;
+    emu_type = "debug";
 #endif
 
     /* We need to do this before the ordinary processing. */
@@ -519,57 +498,42 @@ int main(int argc, char **argv)
 
 		if (strcmp(argv[i+1], "auto") == 0) {
 		    i++;
-		smp_auto:
-		    emu_type_passed |= EMU_TYPE_SMP;
-#if defined(ERTS_HAVE_PLAIN_EMU) && !defined(ERTS_HAVE_SMP_EMU)
-                    emu_type &= ~EMU_TYPE_SMP;
-#else
-                    emu_type |= EMU_TYPE_SMP;
-#endif
-		}
-		else if (strcmp(argv[i+1], "enable") == 0) {
+		} else if (strcmp(argv[i+1], "enable") == 0) {
 		    i++;
 		smp_enable:
-		    emu_type_passed |= EMU_TYPE_SMP;
-#ifdef ERTS_HAVE_SMP_EMU
-		    emu_type |= EMU_TYPE_SMP;
-#else
+                    ;
+#if !defined(ERTS_HAVE_SMP_EMU)
 		    usage_notsup("-smp enable", "");
 #endif
-		}
-		else if (strcmp(argv[i+1], "disable") == 0) {
+		} else if (strcmp(argv[i+1], "disable") == 0) {
 		    i++;
 		smp_disable:
-		    emu_type_passed &= ~EMU_TYPE_SMP;
 #ifdef ERTS_HAVE_PLAIN_EMU
-		    emu_type &= ~EMU_TYPE_SMP;
+                    start_smp_emu = 0;
 #else
                     usage_notsup("-smp disable", " Use \"+S 1\" instead.");
 #endif
-		}
-		else {
+		} else {
 		smp:
-
-		    emu_type_passed |= EMU_TYPE_SMP;
-#ifdef ERTS_HAVE_SMP_EMU
-		    emu_type |= EMU_TYPE_SMP;
-#else
+                    ;
+#if !defined(ERTS_HAVE_SMP_EMU)
 		    usage_notsup("-smp", "");
 #endif
 		}
 	    } else if (strcmp(argv[i], "-smpenable") == 0) {
 		goto smp_enable;
 	    } else if (strcmp(argv[i], "-smpauto") == 0) {
-		goto smp_auto;
+                ;
 	    } else if (strcmp(argv[i], "-smpdisable") == 0) {
 		goto smp_disable;
-#ifdef __WIN32__
-	    } else if (strcmp(argv[i], "-debug") == 0) {
-		emu_type_passed |= EMU_TYPE_DEBUG;
-		emu_type |= EMU_TYPE_DEBUG;
-#endif
 	    } else if (strcmp(argv[i], "-extra") == 0) {
 		break;
+	    } else if (strcmp(argv[i], "-emu_type") == 0) {
+		if (i + 1 >= argc) {
+                    usage(argv[i]);
+                }
+                emu_type = argv[i+1];
+                i++;
 	    }
 	}
 	i++;
@@ -582,7 +546,7 @@ int main(int argc, char **argv)
 	if (strcmp(malloc_lib, "libc") != 0)
 	    usage("+MYm");
     }
-    emu = add_extra_suffixes(emu, emu_type);
+    emu = add_extra_suffixes(emu);
     emu_name = strsave(emu);
     erts_snprintf(tmpStr, sizeof(tmpStr), "%s" DIRSEP "%s" BINARY_EXT, bindir, emu);
     emu = strsave(tmpStr);
@@ -1176,7 +1140,11 @@ int main(int argc, char **argv)
     {
 	execv(emu, Eargsp);
     }
-    error("Error %d executing \'%s\'.", errno, emu);
+    if (errno == ENOENT) {
+        error("The emulator \'%s\' does not exist.", emu);
+    } else {
+        error("Error %d executing \'%s\'.", errno, emu);
+    }
     return 1;
 #endif
 }
@@ -1376,7 +1344,7 @@ is_one_of_strings(char *str, char *strs[])
     return 0;
 }
 
-static char *write_str(char *to, char *from)
+static char *write_str(char *to, const char *from)
 {
     while (*from)
 	*(to++) = *(from++);
@@ -1902,6 +1870,7 @@ read_args_file(char *filename)
 #undef EAF_QUOTE
 #undef SAVE_CHAR
 }
+
 
 typedef struct {
     char **argv;

--- a/erts/etc/unix/Makefile
+++ b/erts/etc/unix/Makefile
@@ -24,7 +24,7 @@ include $(ERL_TOP)/make/target.mk
 include $(ERL_TOP)/make/$(TARGET)/otp.mk
 include ../../vsn.mk
 
-opt debug: etc
+opt debug lcnt: etc
 
 .PHONY: etc
 etc: etp-commands

--- a/erts/start_scripts/Makefile
+++ b/erts/start_scripts/Makefile
@@ -68,7 +68,7 @@ include $(LIBPATH)/stdlib/vsn.mk
 
 ##############################################################################
 
-debug opt script: rel $(INSTALL_SCRIPTS) $(RELEASES_SRC)
+debug opt lcnt script: rel $(INSTALL_SCRIPTS) $(RELEASES_SRC)
 
 rel:	$(REL_SCRIPTS)
 

--- a/lib/tools/doc/src/lcnt_chapter.xml
+++ b/lib/tools/doc/src/lcnt_chapter.xml
@@ -48,29 +48,19 @@
     </p>
     <section>
 	<title> Enabling lock-counting </title>
-	<p>For investigation of locks in the emulator we use an internal tool called <c>lcnt</c> (short for lock-count). The VM needs to be compiled with this option enabled. To enable this, use:</p>
+	<p>For investigation of locks in the emulator we use an internal tool called <c>lcnt</c> (short for lock-count). The VM needs to be compiled with this option enabled.
+	To compile a lock-counting VM along with a normal VM, use:</p>
 
 	<pre>
 cd $ERL_TOP
-./configure --enable-lock-counter
-	</pre>
-
-	<p>
-	    Another way to enable this alongside a normal VM is to compile it at emulator directory level, much like a debug build. To compile it this way do the following,
-	</p>
+./configure --enable-lock-counter</pre>
+	<p>Start the lock-counting VM like this:</p>
 	<pre>
-cd $ERL_TOP/erts/emulator
-make lcnt FLAVOR=smp
-	</pre>
-	<p> and then starting Erlang with,</p>
+$ERL_TOP/bin/erl -emu_type lcnt</pre>
+	<p>To verify that lock counting is enabled check that <c>[lock-counting]</c> appears in the status text when the VM is started.</p>
 	<pre>
-$ERL_TOP/bin/cerl -lcnt
-	</pre>
-	<p>To verify that you lock-counting enabled check that <c>[lock-counting]</c> appears in the status text when the VM is started.</p>
-	<pre>
-Erlang R13B03 (erts-5.7.4) [source] [64-bit] [smp:8:8] [rq:8] [async-threads:0] [hipe]
- [kernel-poll:false] [lock-counting]
-	</pre>
+Erlang/OTP 20 [erts-9.0] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe]
+ [kernel-poll:false] [lock-counting]</pre>
     </section>
     <section>
 	<title>Getting started</title>

--- a/make/otp.mk.in
+++ b/make/otp.mk.in
@@ -49,6 +49,7 @@ DEFAULT_TARGETS =  opt debug release release_docs clean docs
 
 DEFAULT_FLAVOR=@DEFAULT_FLAVOR@
 FLAVORS=@FLAVORS@
+TYPES=@TYPES@
 
 # Slash separated list of return values from $(origin VAR)
 # that are untrusted - set default in this file instead.

--- a/make/otp_subdir.mk
+++ b/make/otp_subdir.mk
@@ -19,13 +19,13 @@
 #
 # Make include file for otp
 
-.PHONY: debug opt release docs release_docs tests release_tests \
+.PHONY: debug opt lcnt release docs release_docs tests release_tests \
 	clean depend valgrind static_lib
 
 #
 # Targets that don't affect documentation directories
 #
-opt debug release docs release_docs tests release_tests clean depend valgrind static_lib:
+opt debug lcnt release docs release_docs tests release_tests clean depend valgrind static_lib:
 	@set -e ;							\
 	app_pwd=`pwd` ;							\
 	if test -f vsn.mk; then						\


### PR DESCRIPTION
This PR makes it easier to run the lock-counting emulator in a production system.

There is a new behavior for this `configure` option:

    ./configure --enable-lock-counter

The option used to make the default emulator a lock-counting emulator. It will now build an additional emulator. `make install` will install both the standard emulator and the lock-counting emulator.

Start the lock-counting emulator like this:

    erl -emu_type lcnt

The `emu_type` option can be used to start any special emulator that have been built in the `erts/emulator` directory. That is, `erl -emu_type debug` will start the emulator that has been built like this:

    (cd erts/emulator && make debug)

On Windows only, `erl -debug` would start the debug-compiled emulator. That option has been removed, since `-emu_type debug` can be used instead.
