### PR TITLE
Fix a few minor issues in the lcnt documentation

### DIFF
--- a/lib/tools/doc/src/lcnt.xml
+++ b/lib/tools/doc/src/lcnt.xml
@@ -38,7 +38,7 @@
     <modulesummary>A runtime system Lock Profiling tool.</modulesummary>
     <description>
 	<p>The <c>lcnt</c> module is used to profile the internal ethread locks in the
-	    Erlang Runtime System. With <c>lcnt</c> enabled, Internal counters in the
+	    Erlang Runtime System. With <c>lcnt</c> enabled, internal counters in the
 	    runtime system are updated each time a lock is taken. The counters stores
 	    information about the number of acquisition tries and the number of collisions
 	    that has occurred during the acquisition tries. The counters also record the
@@ -47,17 +47,17 @@
 	<p>
 	    The data produced by the lock counters will give an estimate on how well
 	    the runtime system will behave from a parallelizable view point for the
-	    scenarios tested. This tool was mainly developed to help erlang runtime
+	    scenarios tested. This tool was mainly developed to help Erlang runtime
 	    developers iron out potential and generic bottlenecks.
 	</p>
 	<p>Locks in the emulator are named after what type of resource they protect and where
 	    in the emulator they are initialized, those are lock 'classes'. Most of those
 	    locks are also instantiated several times, and given unique identifiers, to increase
 	    locking granularity. Typically an instantiated lock protects a disjunct set of
-	    the resource, i.e ets-tables, processes or ports. In other cases it protects a
-	    specific range of a resource, e.g. <c>pix_lock</c> which protects index to process
+	    the resource, for example ets tables, processes or ports. In other cases it protects a
+	    specific range of a resource, for example <c>pix_lock</c> which protects index to process
 	    mappings, and is given a unique number within the class. A unique lock in <c>lcnt</c>
-	    is referenced by a name (class) and an identifier, <c>{Name, Id}</c>.
+	    is referenced by a name (class) and an identifier: <c>{Name, Id}</c>.
 	</p>
 	<p>Some locks in the system are static and protects global resources, for example
 	    <c>bif_timers</c> and the <c>run_queue</c> locks. Other locks are dynamic and not

--- a/lib/tools/doc/src/lcnt_chapter.xml
+++ b/lib/tools/doc/src/lcnt_chapter.xml
@@ -42,7 +42,7 @@
 	completed its access to the resource and unlocked it. The <c>lcnt</c> tool measures these lock conflicts.
     </p>
     <p>
-	Locks has an inherent cost in execution time and memory space. It takes time initialize, destroy, aquiring or releasing locks. To decrease lock contention it
+	Locks have an inherent cost in execution time and memory space. It takes time initialize, destroy, aquiring or releasing locks. To decrease lock contention it
 	some times necessary to use finer grained locking strategies. This will usually also increase the locking overhead and hence there is a tradeoff
 	between lock contention and overhead. In general, lock contention increases with the number of threads running concurrently. The <c>lcnt</c> tool does not measure locking overhead.
     </p>
@@ -77,7 +77,7 @@ Erlang R13B03 (erts-5.7.4) [source] [64-bit] [smp:8:8] [rq:8] [async-threads:0] 
 	<p>Once you have a lock counting enabled VM the module <c>lcnt</c> can be used. The module is intended to be used from the current running nodes shell. To access remote nodes use <c>lcnt:clear(Node)</c> and <c>lcnt:collect(Node)</c>. </p>
 
 	<p>All locks are continuously monitored and its statistics updated. Use <c>lcnt:clear/0</c> to initially clear all counters before running any specific tests. This command will also reset the duration timer internally.</p>
-	<p>To retrieve lock statistics information use, <c>lcnt:collect/0,1</c>. The collect operation will start a <c>lcnt</c> server if it not already started. All collected data will be built into an erlang term and uploaded to the server and a duration time will also be uploaded. This duration is the time between <c>lcnt:clear/0,1</c> and <c>lcnt:collect/0,1</c>.</p>
+	<p>To retrieve lock statistics information, use <c>lcnt:collect/0,1</c>. The collect operation will start a <c>lcnt</c> server if it not already started. All collected data will be built into an Erlang term and uploaded to the server and a duration time will also be uploaded. This duration is the time between <c>lcnt:clear/0,1</c> and <c>lcnt:collect/0,1</c>.</p>
 
 	<p>Once the data is collected to the server it can be filtered, sorted and printed in many different ways.</p>
 	<p>See the <seealso marker="lcnt">reference manual</seealso> for a description of each function.</p>


### PR DESCRIPTION
We generally avoid abbreviations such as "e.g." and "i.e." in
the documentation. We write "Erlang", not "erlang" (except when
referring to the erlang module).