### PR TITLE
Call get_stacktrace/0 in a safer way

### DIFF
--- a/lib/stdlib/src/escript.erl
+++ b/lib/stdlib/src/escript.erl
@@ -284,8 +284,9 @@ start(EscriptOptions) ->
             io:format("escript: ~s\n", [Str]),
             my_halt(127);
         _:Reason ->
+            Stk = erlang:get_stacktrace(),
             io:format("escript: Internal error: ~p\n", [Reason]),
-            io:format("~p\n", [erlang:get_stacktrace()]),
+            io:format("~p\n", [Stk]),
             my_halt(127)
     end.
 


### PR DESCRIPTION
Call `erlang:get_stacktrace` as soon as possible after an expression has been caught. Don't call other functions before calling `erlang:get_stacktrace`, since they may change the stacktrace.