### PR TITLE
Update erl_msg_tracer example

### DIFF
--- a/erts/doc/src/erl_tracer.xml
+++ b/erts/doc/src/erl_tracer.xml
@@ -653,7 +653,7 @@ ok
 &lt;0.37.0&gt;
 3&gt; erlang:trace(new, true, [send,{tracer, erl_msg_tracer, Tracer}]).
 0
-{&lt;0.39.0&gt;,&lt;0.27.0&gt;}
+{trace,&lt;0.39.0&gt;,&lt;0.27.0&gt;}
 4&gt; {ok, D} = file:open("/tmp/tmp.data",[write]).
 {trace,#Port&lt;0.486&gt;,&lt;0.40.0&gt;}
 {trace,&lt;0.40.0&gt;,&lt;0.21.0&gt;}
@@ -758,18 +758,21 @@ static ERL_NIF_TERM enabled(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
 /*
  * argv[0]: TraceTag, should only be 'send'
- * argv[1]: TracerState, process to send {argv[2], argv[4]} to
+ * argv[1]: TracerState, process to send {Tracee, Recipient} to
  * argv[2]: Tracee
- * argv[3]: Recipient
- * argv[4]: Options, ignored
+ * argv[3]: Message
+ * argv[4]: Options, map containing Recipient
  */
 static ERL_NIF_TERM trace(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ErlNifPid to_pid;
+    ERL_NIF_TERM recipient, msg;
 
     if (enif_get_local_pid(env, argv[1], &amp;to_pid)) {
-        ERL_NIF_TERM msg = enif_make_tuple3(env, enif_make_atom(env, "trace"), argv[2], argv[4]);
+      if (enif_get_map_value(env, argv[4], enif_make_atom(env, "extra"), &amp;recipient)) {
+        msg = enif_make_tuple3(env, enif_make_atom(env, "trace"), argv[2], recipient);
         enif_send(env, &amp;to_pid, NULL, msg);
+      }
     }
 
     return enif_make_atom(env, "ok");


### PR DESCRIPTION
After "Move tracer SecondTraceTerm to Opts map" in commit 115f0ba7
getting the receipient has to be done on a bit different way.