### PR TITLE
Correct handling of module name in compile:forms/1,2

### DIFF
--- a/lib/compiler/test/beam_validator_SUITE.erl
+++ b/lib/compiler/test/beam_validator_SUITE.erl
@@ -446,7 +446,7 @@ do_bin_opt(Mod, Asm) ->
 do_bin_opt(Transform, Mod, Asm0) ->
     Asm = Transform(Asm0),
     case compile:forms(Asm, [from_asm,no_postopt,return]) of
-	{ok,[],Code,_Warnings} when is_binary(Code) ->
+	{ok,Mod,Code,_Warnings} when is_binary(Code) ->
 	    ok;
 	{error,Errors0,_} ->
 	    %% beam_validator must return errors, not simply crash,


### PR DESCRIPTION
`compile:forms/1,2` is documented to return:

    {ok,ModuleName,BinaryOrCode}

However, if one of the options 'from_core', 'from_asm', or
'from_beam' is given, ModuleName will be returned as [].
A worse problem is that is that if one those options are
combined with the 'native' option, compilation will crash.

Correct `compile:forms/1,2` to pick up the module name from
the forms provided (either Core Erlang, Beam assembly code,
or a Beam file).

Reported here: https://bugs.erlang.org/browse/ERL-417