### PR TITLE
Fix non-delivery of ssl_closed message in active once

### DIFF
--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -429,6 +429,7 @@ handle_info({CloseTag, Socket}, StateName,
             %% Fixes non-delivery of final TLS record in {active, once}.
             %% Basically allows the application the opportunity to set {active, once} again
             %% and then receive the final message.
+            self() ! {CloseTag, Socket},
             next_event(StateName, no_record, State)
     end;
 handle_info(Msg, StateName, State) ->


### PR DESCRIPTION
The commit 8b10920 (OTP 19.3.1) fixed the non-delivery of final TLS record in {active, once}, but this causes the ssl_closed message to be lost when the TCP connection closes before ssl:close/1. The patch restores the behavior of OTP 18.

This is the second part to fix https://bugs.erlang.org/browse/ERL-420