### PR TITLE
Configure signal handler for USR1 even if +Bi is specified.

### DIFF
--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -822,9 +822,6 @@ void erts_replace_intr(void) {
 void init_break_handler(void)
 {
    sys_signal(SIGINT, request_break);
-#ifndef ETHR_UNUSABLE_SIGUSRX
-   sys_signal(SIGUSR1, user_signal1);
-#endif /* #ifndef ETHR_UNUSABLE_SIGUSRX */
    sys_signal(SIGQUIT, do_quit);
 }
 
@@ -838,6 +835,9 @@ void sys_init_suspend_handler(void)
 void
 erts_sys_unix_later_init(void)
 {
+#ifndef ETHR_UNUSABLE_SIGUSRX
+   sys_signal(SIGUSR1, user_signal1);
+#endif /* #ifndef ETHR_UNUSABLE_SIGUSRX */
     sys_signal(SIGTERM, request_stop);
 }
 


### PR DESCRIPTION
Follow up to b04b835572e8f737d7437b2fa706652fb7e3e311 (OTP-14358)

init_break_handler function is not called if +Bi parameter is specified,
so SIGUSR1 handler was not registered. This causes erlang node to stop
without generating a crash dump. Fixed by moving SIGUSR handler setup to
erts_sys_unix_later_init same way as SIGTERM.