### PR TITLE
Add more information to the Observer

### DIFF
--- a/lib/observer/src/observer_lib.erl
+++ b/lib/observer/src/observer_lib.erl
@@ -297,6 +297,8 @@ to_str(No) when is_integer(No) ->
     integer_to_list(No);
 to_str(Float) when is_float(Float) ->
     io_lib:format("~.3f", [Float]);
+to_str({trunc, Float}) when is_float(Float) ->
+    float_to_list(Float, [{decimals,0}]);
 to_str(Term) ->
     io_lib:format("~w", [Term]).
 

--- a/lib/runtime_tools/src/observer_backend.erl
+++ b/lib/runtime_tools/src/observer_backend.erl
@@ -63,9 +63,7 @@ sys_info() ->
 			  end,
 
     {{_,Input},{_,Output}} = erlang:statistics(io),
-    [{process_count, erlang:system_info(process_count)},
-     {process_limit, erlang:system_info(process_limit)},
-     {uptime, element(1, erlang:statistics(wall_clock))},
+    [{uptime, element(1, erlang:statistics(wall_clock))},
      {run_queue, erlang:statistics(run_queue)},
      {io_input, Input},
      {io_output,  Output},
@@ -86,7 +84,17 @@ sys_info() ->
      {thread_pool_size, erlang:system_info(thread_pool_size)},
      {wordsize_internal, erlang:system_info({wordsize, internal})},
      {wordsize_external, erlang:system_info({wordsize, external})},
-     {alloc_info, alloc_info()}
+     {alloc_info, alloc_info()},
+     {process_count, erlang:system_info(process_count)},
+     {atom_limit,  erlang:system_info(atom_limit)},
+     {atom_count, erlang:system_info(atom_count)},
+     {process_limit, erlang:system_info(process_limit)},
+     {process_count, erlang:system_info(process_count)},
+     {port_limit, erlang:system_info(port_limit)},
+     {port_count, erlang:system_info(port_count)},
+     {ets_limit,  erlang:system_info(ets_limit)},
+     {ets_count, length(ets:all())},
+     {dist_buf_busy_limit, erlang:system_info(dist_buf_busy_limit)}
      | MemInfo].
 
 alloc_info() ->


### PR DESCRIPTION
Add other two panels: first one: 'System limits' and second one 'Limit Statistics'
Show infomations as atom_limit,process_limit,port_limit and counts.


The result is:
![observer_info](https://user-images.githubusercontent.com/386987/26886118-e419cdce-4ba4-11e7-8ef3-1bcd542619ce.png)

