### PR TITLE
Add {continue, Term} and handle_continue/2 to gen_server

### DIFF
--- a/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_incorrect_args
+++ b/lib/dialyzer/test/behaviour_SUITE_data/results/gen_server_incorrect_args
@@ -1,5 +1,5 @@
 
 gen_server_incorrect_args.erl:3: Undefined callback function handle_cast/2 (behaviour gen_server)
 gen_server_incorrect_args.erl:3: Undefined callback function init/1 (behaviour gen_server)
-gen_server_incorrect_args.erl:7: The inferred return type of handle_call/3 ({'no'} | {'ok'}) has nothing in common with {'noreply',_} | {'noreply',_,'hibernate' | 'infinity' | non_neg_integer()} | {'reply',_,_} | {'stop',_,_} | {'reply',_,_,'hibernate' | 'infinity' | non_neg_integer()} | {'stop',_,_,_}, which is the expected return type for the callback of the gen_server behaviour
+gen_server_incorrect_args.erl:7: The inferred return type of handle_call/3 ({'no'} | {'ok'}) has nothing in common with {'noreply',_} | {'noreply',_,'hibernate' | 'infinity' | non_neg_integer() | {'continue',_}} | {'reply',_,_} | {'stop',_,_} | {'reply',_,_,'hibernate' | 'infinity' | non_neg_integer() | {'continue',_}} | {'stop',_,_,_}, which is the expected return type for the callback of the gen_server behaviour
 gen_server_incorrect_args.erl:7: The inferred type for the 2nd argument of handle_call/3 ('boo' | 'foo') is not a supertype of {pid(),_}, which is expected type for this argument in the callback of the gen_server behaviour

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -60,6 +60,8 @@ gen_server:abcast     -----> Module:handle_cast/2
 
 -                     -----> Module:handle_info/2
 
+-                     -----> Module:handle_continue/2
+
 -                     -----> Module:terminate/2
 
 -                     -----> Module:code_change/3</pre>
@@ -88,6 +90,13 @@ gen_server:abcast     -----> Module:handle_cast/2
       implies at least two garbage collections (when hibernating and
       shortly after waking up) and is not something you want to do
       between each call to a busy server.</p>
+
+    <p>If the <c>gen_server</c> process needs to perform an action
+      immediately after initialization or to break the execution of a
+      callback into multiple steps, it can return <c>{continue,Continue}</c>
+      in place of the time-out or hibernation value, which will immediately
+      invoke the <c>handle_continue/2</c> callback.</p>
+
   </description>
 
   <funcs>
@@ -610,12 +619,15 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>State = term()</v>
         <v>Result = {reply,Reply,NewState} | {reply,Reply,NewState,Timeout}</v> 
         <v>&nbsp;&nbsp;| {reply,Reply,NewState,hibernate}</v>
+        <v>&nbsp;&nbsp;| {reply,Reply,NewState,{continue,Continue}}</v>
         <v>&nbsp;&nbsp;| {noreply,NewState} | {noreply,NewState,Timeout}</v> 
         <v>&nbsp;&nbsp;| {noreply,NewState,hibernate}</v>
+        <v>&nbsp;&nbsp;| {noreply,NewState,{continue,Continue}}</v>
         <v>&nbsp;&nbsp;| {stop,Reason,Reply,NewState} | {stop,Reason,NewState}</v>
         <v>&nbsp;Reply = term()</v>
         <v>&nbsp;NewState = term()</v>
         <v>&nbsp;Timeout = int()>=0 | infinity</v>
+        <v>&nbsp;Continue = term()</v>
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
@@ -673,9 +685,11 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>State = term()</v>
         <v>Result = {noreply,NewState} | {noreply,NewState,Timeout}</v>
         <v>&nbsp;&nbsp;| {noreply,NewState,hibernate}</v>
+        <v>&nbsp;&nbsp;| {noreply,NewState,{continue,Continue}}</v>
         <v>&nbsp;&nbsp;| {stop,Reason,NewState}</v>
         <v>&nbsp;NewState = term()</v>
         <v>&nbsp;Timeout = int()>=0 | infinity</v>
+        <v>&nbsp;Continue = term()</v>
         <v>&nbsp;Reason = term()</v>
       </type>
       <desc>
@@ -690,6 +704,41 @@ gen_server:abcast     -----> Module:handle_cast/2
     </func>
 
     <func>
+      <name>Module:handle_continue(Continue, State) -> Result</name>
+      <fsummary>Handle a continue instruction.</fsummary>
+      <type>
+        <v>Continue = term()</v>
+        <v>State = term()</v>
+        <v>Result = {noreply,NewState} | {noreply,NewState,Timeout}</v>
+        <v>&nbsp;&nbsp;| {noreply,NewState,hibernate}</v>
+        <v>&nbsp;&nbsp;| {noreply,NewState,{continue,Continue}}</v>
+        <v>&nbsp;&nbsp;| {stop,Reason,NewState}</v>
+        <v>&nbsp;NewState = term()</v>
+        <v>&nbsp;Timeout = int()>=0 | infinity</v>
+        <v>&nbsp;Continue = term()</v>
+        <v>&nbsp;Reason = normal | term()</v>
+      </type>
+      <desc>
+        <note>
+          <p>This callback is optional, so callback modules need to
+            export it only if they return <c>{continue,Continue}</c>
+            from another callback. If continue is used and the callback
+            is not implemented, the process will exit with <c>undef</c>
+            error.</p>
+        </note>
+        <p>This function is called by a <c>gen_server</c> process whenever
+          a previous callback returns <c>{continue, Continue}</c>.
+          <c>handle_continue/2</c> is invoked immediately after the previous
+          callback, which makes it useful for performing work after
+          initialization or for splitting the work in a callback in
+          multiple steps, updating the process state along the way.</p>
+        <p>For a description of the other arguments and possible return values,
+          see <seealso marker="#Module:handle_call/3">
+          <c>Module:handle_call/3</c></seealso>.</p>
+      </desc>
+    </func>
+
+    <func>
       <name>Module:handle_info(Info, State) -> Result</name>
       <fsummary>Handle an incoming message.</fsummary>
       <type>
@@ -697,6 +746,7 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>State = term()</v>
         <v>Result = {noreply,NewState} | {noreply,NewState,Timeout}</v>
         <v>&nbsp;&nbsp;| {noreply,NewState,hibernate}</v>
+        <v>&nbsp;&nbsp;| {noreply,NewState,{continue,Continue}}</v>
         <v>&nbsp;&nbsp;| {stop,Reason,NewState}</v>
         <v>&nbsp;NewState = term()</v>
         <v>&nbsp;Timeout = int()>=0 | infinity</v>
@@ -726,7 +776,7 @@ gen_server:abcast     -----> Module:handle_cast/2
       <type>
         <v>Args = term()</v>
         <v>Result =  {ok,State} | {ok,State,Timeout} | {ok,State,hibernate}</v>
-        <v>&nbsp;| {stop,Reason} | ignore</v>
+        <v>&nbsp;| {ok,State,{continue,Continue}} | {stop,Reason} | ignore</v>
         <v>&nbsp;State = term()</v>
         <v>&nbsp;Timeout = int()>=0 | infinity</v>
         <v>&nbsp;Reason = term()</v>

--- a/lib/stdlib/test/erl_internal_SUITE.erl
+++ b/lib/stdlib/test/erl_internal_SUITE.erl
@@ -80,7 +80,7 @@ callbacks(application) ->
 callbacks(gen_server) ->
     [{init,1}, {handle_call,3}, {handle_cast,2},
      {handle_info,2}, {terminate,2}, {code_change,3},
-     {format_status,2}];
+     {format_status,2}, {handle_continue, 2}];
 callbacks(gen_fsm) ->
     [{init,1}, {handle_event,3}, {handle_sync_event,4},
      {handle_info,3}, {terminate,3}, {code_change,4},
@@ -101,7 +101,7 @@ callbacks(supervisor) ->
 optional_callbacks(application) ->
     [];
 optional_callbacks(gen_server) ->
-    [{handle_info, 2}, {terminate, 2}, {code_change, 3}, {format_status, 2}];
+    [{handle_info, 2}, {handle_continue, 2}, {terminate, 2}, {code_change, 3}, {format_status, 2}];
 optional_callbacks(gen_fsm) ->
     [{handle_info, 3}, {terminate, 3}, {code_change, 4}, {format_status, 2}];
 optional_callbacks(gen_event) ->

--- a/lib/stdlib/test/gen_server_SUITE_data/oc_server.erl
+++ b/lib/stdlib/test/gen_server_SUITE_data/oc_server.erl
@@ -22,7 +22,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start/0]).
+-export([start/0, start/1]).
 
 %% gen_server callbacks
 -export([init/1]).
@@ -30,8 +30,12 @@
 -record(state, {}).
 
 start() ->
-    gen_server:start({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start(?MODULE, ok, []).
 
-init([]) ->
-    {ok, #state{}}.
+start(continue) ->
+    gen_server:start(?MODULE, continue, []).
 
+init(ok) ->
+    {ok, #state{}};
+init(continue) ->
+    {ok, #state{}, {continue, continue}}.


### PR DESCRIPTION
If the gen_server process needs to perform an action immediately
after initialization or to break the execution of a callback into
multiple steps, it can return {continue, term()} in place of the
time-out or hibernation value, which will immediately invoke the
handle_continue/2 callback with the given term.

This provides a more accessible approach to after initialization
compared to proc_lib+enter_loop that is also guaranteed to be
safe.

It also allows callbacks that need to do lengthy or stateful work
to checkpoint the state throughout multiple iterations. This can
be useful, for example, when implementing behaviours on top of
gen_server.

This is continuation of PR #1429.