### PR TITLE
Support e2k platform

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -640,6 +640,7 @@ case $chk_arch_ in
     armv7l)	ARCH=arm;;
     armv7hl)	ARCH=arm;;
     tile)	ARCH=tile;;
+    e2k)       ARCH=e2k;;
     *)	 	ARCH=noarch;;
 esac
 

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -21,7 +21,7 @@
 #ifndef __SYS_H__
 #define __SYS_H__
 
-#if !defined(__GNUC__)
+#if !defined(__GNUC__) || defined(__e2k__)
 #  define ERTS_AT_LEAST_GCC_VSN__(MAJ, MIN, PL) 0
 #elif !defined(__GNUC_MINOR__)
 #  define ERTS_AT_LEAST_GCC_VSN__(MAJ, MIN, PL) \


### PR DESCRIPTION
We have made porting Erlang to the e2k platform (Elbrus: https://en.wikipedia.org/wiki/Elbrus-8S). This platform is uses the lcc (v1.21.18) compiler, based on the old stripped-down version of the gcc (4.8.0). Because gcc is truncated, some built-in functions do not work correctly, for example __builtin_choose_expr. In this pull request I propose a solution for this error.