### PR TITLE
edoc: show specs more like Erlang code for conciseness & grep-ability

### DIFF
--- a/lib/edoc/src/otpsgml_layout.erl
+++ b/lib/edoc/src/otpsgml_layout.erl
@@ -706,27 +706,8 @@ t_fun(Es) ->
 		 [") -> "] ++ t_utype(get_elem(type, Es))).
 
 t_abstype(Es) ->
-%    ([t_name(get_elem(qualifiedName, Es)), "("]
-%     ++ seq(fun t_type_elem/1, get_elem(type, Es), [")"])).
-    case split_at_colon(t_name(get_elem(erlangName, Es)),[]) of
-	{Mod,Type} -> 
-	    [Type, "("] ++ 
-		seq(fun t_utype_elem/1, get_elem(type, Es), [")"]) ++ 
-		[" (see module ", Mod, ")"];
-	Type ->
-	    [Type, "("] ++ 
-		seq(fun t_utype_elem/1, get_elem(type, Es), [")"])
-    end.
-
-%% Split at one colon, but not at two (or more)
-split_at_colon([$:,$:|_]=Rest,Acc) ->
-    lists:reverse(Acc)++Rest;
-split_at_colon([$:|Type],Acc) ->
-    {lists:reverse(Acc),Type};
-split_at_colon([Char|Rest],Acc) ->
-    split_at_colon(Rest,[Char|Acc]);
-split_at_colon([],Acc) ->
-    lists:reverse(Acc).
+    [t_name(get_elem(erlangName, Es)), "("] ++
+        seq(fun t_utype_elem/1, get_elem(type, Es), [")"]).
 
 % t_par(Es) ->
 %     T = t_type(get_content(type, Es)),


### PR DESCRIPTION
As far as the git history goes on github.com/erlang/otp,
edoc is written to transform a spec written

```erlang
-spec add(ConnSpec::imap:connspec()) -> supervisor:startchild_ret().
```

into this single documentation line (which can get pretty long, cut here):

```erlang
add(ConnSpec::connspec() (see module imap)) ->
  startchild_ret() (see module supervisor)
```

This patch changes this behavior to have edoc transform the spec into

```erlang
add(ConnSpec::imap:connspec()) -> supervisor:startchild_ret()
```

which helps for functions with long lists of arguments (in my opnion).
This patch also changes the way multiline specs are transformed.
Before:

```erlang
key_for(Account, Type) -> {n, l, {switchboard, {Type, Account}}}
    Account = account() (see module imap)
    Type = keytype()
```

After:

```erlang
key_for(Account, Type) -> {n, l, {switchboard, {Type, Account}}}
    Account = imap:account()
    Type = keytype()
```

Future work could consider transforming every spec into their
multiline version as well as add href links to the types
that are missing them.