### PR TITLE
Correct type specification in ssl:prf/5

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -569,7 +569,7 @@ renegotiate(#sslsocket{pid = {Listen,_}}) when is_port(Listen) ->
 
 %%--------------------------------------------------------------------
 -spec prf(#sslsocket{}, binary() | 'master_secret', binary(),
-	  binary() | prf_random(), non_neg_integer()) ->
+	  [binary() | prf_random()], non_neg_integer()) ->
 		 {ok, binary()} | {error, reason()}.
 %%
 %% Description: use a ssl sessions TLS PRF to generate key material

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -264,7 +264,7 @@ renegotiation(ConnectionPid) ->
 
 %%--------------------------------------------------------------------
 -spec prf(pid(), binary() | 'master_secret', binary(),
-	  binary() | ssl:prf_random(), non_neg_integer()) ->
+	  [binary() | ssl:prf_random()], non_neg_integer()) ->
 		 {ok, binary()} | {error, reason()} | {'EXIT', term()}.
 %%
 %% Description: use a ssl sessions TLS PRF to generate key material


### PR DESCRIPTION
The type specification for this function did not match
either the documentation or the implementation. The
Seed argument should be a list.

Issue ERL-442.