### PR TITLE
Log actual http status code of response.

### DIFF
--- a/lib/inets/src/http_server/mod_log.erl
+++ b/lib/inets/src/http_server/mod_log.erl
@@ -105,8 +105,8 @@ do(Info) ->
 		    Code = proplists:get_value(code,Head,unknown),
 		    transfer_log(Info, "-", AuthUser, Date, Code, Size),
 		    {proceed, Info#mod.data};
-		{_StatusCode, Response} ->
-		    transfer_log(Info,"-",AuthUser,Date,200,
+		{StatusCode, Response} ->
+		    transfer_log(Info,"-",AuthUser, Date, StatusCode,
 				 httpd_util:flatlength(Response)),
 		    {proceed,Info#mod.data};
 		undefined ->


### PR DESCRIPTION
The status code provided by other modules was being
ignored and 200 (OK) was logged for all responses.

Issue ERL-443.