### PR TITLE
Make tuple calls opt-in

### DIFF
--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -6354,7 +6354,7 @@ BeamInstr *I, Uint stack_offset)
 {
     int arity;
     Export* ep;
-    Eterm tmp, this;
+    Eterm tmp;
 
     /*
      * Check the arguments which should be of the form apply(Module,
@@ -6377,20 +6377,8 @@ BeamInstr *I, Uint stack_offset)
 
     while (1) {
 	Eterm m, f, a;
-	/* The module argument may be either an atom or an abstract module
-	 * (currently implemented using tuples, but this might change).
-	 */
-	this = THE_NON_VALUE;
-	if (is_not_atom(module)) {
-	    Eterm* tp;
 
-	    if (is_not_tuple(module)) goto error;
-	    tp = tuple_val(module);
-	    if (arityval(tp[0]) < 1) goto error;
-	    this = module;
-	    module = tp[1];
-	    if (is_not_atom(module)) goto error;
-	}
+	if (is_not_atom(module)) goto error;
 
 	if (module != am_erlang || function != am_apply)
 	    break;
@@ -6425,9 +6413,7 @@ BeamInstr *I, Uint stack_offset)
     }
     /*
      * Walk down the 3rd parameter of apply (the argument list) and copy
-     * the parameters to the x registers (reg[]). If the module argument
-     * was an abstract module, add 1 to the function arity and put the
-     * module argument in the n+1st x register as a THIS reference.
+     * the parameters to the x registers (reg[]).
      */
 
     tmp = args;
@@ -6443,9 +6429,6 @@ BeamInstr *I, Uint stack_offset)
     }
     if (is_not_nil(tmp)) {	/* Must be well-formed list */
 	goto error;
-    }
-    if (this != THE_NON_VALUE) {
-        reg[arity++] = this;
     }
 
     /*
@@ -6485,18 +6468,7 @@ fixed_apply(Process* p, Eterm* reg, Uint arity,
 	return 0;
     }
 
-    /* The module argument may be either an atom or an abstract module
-     * (currently implemented using tuples, but this might change).
-     */
-    if (is_not_atom(module)) {
-	Eterm* tp;
-        if (is_not_tuple(module)) goto error;
-        tp = tuple_val(module);
-        if (arityval(tp[0]) < 1) goto error;
-        module = tp[1];
-        if (is_not_atom(module)) goto error;
-        ++arity;
-    }
+    if (is_not_atom(module)) goto error;
 
     /* Handle apply of apply/3... */
     if (module == am_erlang && function == am_apply && arity == 3)


### PR DESCRIPTION
Tuple calls is the ability to invoke a function on a tuple
as first argument:

    1> Var = dict:new().
    {dict,0,16,16,8,80,48,
          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
          {{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}}
    2> Var:size().
    0

This behaviour is considered by most to be undesired and confusing,
especially when it comes to errors. For example, imagine you invoke
"Mod:new()" where a Mod is an atom and you accidentally pass {ok, dict}.
It raises:

    {undef,[{ok,new,[{ok,dict}],[]},...]}

As it attempts to invoke ok:new/1, which is really hard to debug
as there is no call to new/1 on the source code.

Furthemore, this behaviour is implemented at the VM level, which
imposes such semantics on all languages running on BEAM.

Since we cannot remove the behaviour above, this proposal makes the
behaviour opt-in with a compiler flag:

    -compile(tuple_calls).

This means that, if a codebase relies on this functionality, they
can keep compatibility by configuring their build tool to
always use the 'tuple_calls' flag or explicitly on each module.

As long as the compile attribute above is listed, the codebase will
work on old and new Erlang versions alike. The only downside of the
current implementation is that modules compiled on OTP 20 that rely
on 'tuple_calls' will have to be recompiled to run with 'tuple_calls'
on OTP 21+.

`stdlib`, `emulator` and `compiler` test suites have been tested and
successfully passed after this change.