### PR TITLE
macOS: Fix problems loading crypto

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3855,7 +3855,7 @@ case $host_os in
 	darwin*)
 		# Mach-O linker: a shared lib and a loadable
 		# object file is not the same thing.
-		DED_LDFLAGS="-bundle -flat_namespace -undefined suppress"
+		DED_LDFLAGS="-bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
 		case $ARCH in
 			amd64)
 				DED_LDFLAGS="-m64 $DED_LDFLAGS"


### PR DESCRIPTION
On macOS, it was not possible to start crypto after running
observer. (ERL_251)

On the beta of macOS 10.13 (High Sierra), crypto does not work
at all. (ERL-439)

The problem is that the use of the -flat_namespace option when
linking dynamic drivers such as the one for crypto. With that
option, all function names must be unique among all linked
libraries and frameworks, or the wrong function could be called.

Resolve the problem by using the two-level namespace as recommended by
Apple. We need to use the -bundle_loader option to point out beam.smp
when building all drivers and NIF libraries.

https://bugs.erlang.org/browse/ERL-251
https://bugs.erlang.org/browse/ERL-439