### PR TITLE
Once again include get_map_elements in blocks

### DIFF
--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -67,6 +67,7 @@ norm({set,[],[S,D],{set_tuple_element,I}}) -> {set_tuple_element,S,D,I};
 norm({set,[D1,D2],[S],get_list})          -> {get_list,S,D1,D2};
 norm({set,[D],[S|Puts],{alloc,R,{put_map,Op,F}}}) ->
     {put_map,F,Op,S,D,R,{list,Puts}};
+%% get_map_elements is always handled in beam_split (moved out of block)
 norm({set,[],[],remove_message})   -> remove_message;
 norm({set,[],[],fclearerror}) -> fclearerror;
 norm({set,[],[],fcheckerror}) -> {fcheckerror,{f,0}}.

--- a/lib/compiler/src/beam_split.erl
+++ b/lib/compiler/src/beam_split.erl
@@ -59,6 +59,9 @@ split_block([{set,[D],[S|Puts],{alloc,R,{put_map,Op,{f,Lbl}=Fail}}}|Is],
 	    Bl, Acc) when Lbl =/= 0 ->
     split_block(Is, [], [{put_map,Fail,Op,S,D,R,{list,Puts}}|
 			 make_block(Bl, Acc)]);
+split_block([{set,Ds,[S|Ss],{get_map_elements,Fail}}|Is], Bl, Acc) ->
+    Gets = beam_utils:join_even(Ss,Ds),
+    split_block(Is, [], [{get_map_elements,Fail,S,{list,Gets}}|make_block(Bl, Acc)]);
 split_block([{set,[R],[],{try_catch,Op,L}}|Is], Bl, Acc) ->
     split_block(Is, [], [{Op,R,L}|make_block(Bl, Acc)]);
 split_block([{set,[],[],{line,_}=Line}|Is], Bl, Acc) ->

--- a/lib/compiler/src/beam_type.erl
+++ b/lib/compiler/src/beam_type.erl
@@ -481,6 +481,9 @@ update({set,[D],[S1,S2],{alloc,_,{gc_bif,Op,{f,0}}}}, Ts0) ->
 	unknown ->
 	    tdb_update([{D,kill}], Ts0)
     end;
+update({set,Dst,_Src,{get_map_elements,_}}, Ts0) ->
+    Kills = [{D,kill} || D <- Dst],
+    tdb_update(Kills, Ts0);
 update({set,[],_Src,_Op}, Ts0) -> Ts0;
 update({set,[D],_Src,_Op}, Ts0) ->
     tdb_update([{D,kill}], Ts0);
@@ -496,10 +499,6 @@ update({test,test_arity,_Fail,[Src,Arity]}, Ts0) ->
     tdb_update([{Src,{tuple,Arity,[]}}], Ts0);
 update({test,is_map,_Fail,[Src]}, Ts0) ->
     tdb_update([{Src,map}], Ts0);
-update({get_map_elements,_,Src,{list,Elems0}}, Ts0) ->
-    {_Ss,Ds} = beam_utils:split_even(Elems0),
-    Elems = [{Dst,kill} || Dst <- Ds],
-    tdb_update([{Src,map}|Elems], Ts0);
 update({test,is_nonempty_list,_Fail,[Src]}, Ts0) ->
     tdb_update([{Src,nonempty_list}], Ts0);
 update({test,is_eq_exact,_,[Reg,{atom,_}=Atom]}, Ts) ->

--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -26,7 +26,7 @@
 	 empty_label_index/0,index_label/3,index_labels/1,
 	 code_at/2,bif_to_test/3,is_pure_test/1,
 	 live_opt/1,delete_live_annos/1,combine_heap_needs/2,
-	 split_even/1]).
+	 join_even/2,split_even/1]).
 
 -export_type([code_index/0,module_code/0,instruction/0]).
 
@@ -272,6 +272,13 @@ combine_heap_needs(H1, H2) when is_integer(H1), is_integer(H2) ->
 
 split_even(Rs) -> split_even(Rs, [], []).
 
+%% join_even/1
+%% {[1,3,5],[2,4,6]} -> [1,2,3,4,5,6]
+
+-spec join_even(list(), list()) -> list().
+
+join_even([], []) -> [];
+join_even([S|Ss], [D|Ds]) -> [S,D|join_even(Ss, Ds)].
 
 %%%
 %%% Local functions.
@@ -804,6 +811,8 @@ live_opt_block([{set,Ds,Ss,Op}=I0|Is], Regs0, D, Acc) ->
 		       true = Live =< Live0,	%Assertion.
 		       I1 = {set,Ds,Ss,{alloc,Live,Alloc}},
 		       {I1,live_call(Live)};
+                   {get_map_elements,Fail} ->
+                       {I0, live_join_label(Fail, D, Regs1)};
 		   _ ->
 		       {I0,Regs1}
 	       end,

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -753,6 +753,14 @@ valfun_4({get_map_elements,{f,Fail},Src,{list,List}}, Vst) ->
 valfun_4(_, _) ->
     error(unknown_instruction).
 
+%% get_map_elements that extracts to only one register will either succeed
+%% or fail and leave the target register unaffected. With more keys, it can
+%% fail partially and pollute some of the targets.
+verify_get_map(Fail, Src, [Key,Val], Vst0) ->
+    assert_type(map, Src, Vst0),
+    assert_term(Key, Vst0),
+    Vst1 = branch_state(Fail, Vst0),
+    set_type_reg(term, Val, Vst1);
 verify_get_map(Fail, Src, List, Vst0) ->
     assert_type(map, Src, Vst0),
     Vst1 = foldl(fun(D, Vsti) ->


### PR DESCRIPTION
This was previously done, but it was found to be unsafe and first modified in
c2035ebb8b7bbdeee1ff03a348ba39edef1050b1 and then fully removed in
0c599bcad1e7f5f66dd2342ab27791048145e892.

Including get_map_elements in blocks is problematic because it can jump out
of the block and potentially pollute some of the target registers.

We solve this problem by only ever allowing the instruction to be the
first element of a block and by keeping track of "protected" registers when
optimising move instructions - in case of multi-key get_map_elements, we
consider the source register protected. Finally we perform proper liveness
analysis over the instruction when it's included as part of a block in
`beam_utils:live_opt`.

The changes pass all the tests introduced as failure cases when the optimisation
was initially limited and removed.

---

I run the emulator, stdlib & compiler suites on regular emulator without any failures.