### PR TITLE
Fix a proliferated typo in ssl

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -146,8 +146,8 @@ socket_control(Connection, Socket, Pid, Transport) ->
 -spec socket_control(tls_connection | dtls_connection, port(), pid(), atom(), pid()| undefined) -> 
     {ok, #sslsocket{}} | {error, reason()}.  
 %%--------------------------------------------------------------------	    
-socket_control(Connection, Socket, Pid, Transport, udp_listner) ->
-    %% dtls listner process must have the socket control
+socket_control(Connection, Socket, Pid, Transport, udp_listener) ->
+    %% dtls listener process must have the socket control
     {ok, Connection:socket(Pid, Transport, Socket, Connection, undefined)};
 
 socket_control(tls_connection = Connection, Socket, Pid, Transport, ListenTracker) ->


### PR DESCRIPTION
While trying out #1518 I found a typo which proliferated through some of the `ssl` library modules. At this point it probably doesn't do any harm, but making it consistent with the module name (`dtls_udp_listener`) and the spellchecker can't do either.