### PR TITLE
httpc: fixed bug when user callback was not called after "remote_close" socket error (ERL-455)

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -735,12 +735,9 @@ maybe_send_answer(#request{from = answer_sent}, _Reason, State) ->
 maybe_send_answer(Request, Answer, State) ->
     answer_request(Request, Answer, State).
 
-deliver_answer(#request{from = From} = Request) 
-  when is_pid(From) ->
+deliver_answer(#request{from = From} = Request) ->
     Response = httpc_response:error(Request, socket_closed_remotely),
-    httpc_response:send(From, Response);
-deliver_answer(_Request) ->
-    ok.
+    httpc_response:send(From, Response).
 
 %%%--------------------------------------------------------------------
 %%% Internal functions


### PR DESCRIPTION
Problem and  test case are described in https://bugs.erlang.org/browse/ERL-455