### PR TITLE
ERL-453 Optimized away atoms are reintroduced during ASM stage

### DIFF
--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -68,7 +68,18 @@ assemble({Mod,Exp0,Attr0,Asm0,NumLabels}, ExtraChunks, SourceFile, Opts, Compile
     {Asm,Attr} = on_load(Asm0, Attr0),
     Exp = cerl_sets:from_list(Exp0),
     {Code,Dict2} = assemble_1(Asm, Exp, Dict1, []),
-    build_file(Code, Attr, Dict2, NumLabels, NumFuncs, ExtraChunks, SourceFile, Opts, CompilerOpts).
+
+    %% Populate atom dict with atoms that were optimized away during Core Fold
+    %% Atoms may possibly exist in atom Dict, but we attempt to add them anyway
+    OptAtoms = proplists:get_value(optimized_away_atoms, Attr0, []),
+    Dict3 = lists:foldl(
+        fun(A, D0) ->
+            {_, D1} = beam_dict:atom(A, D0),
+            D1
+        end, Dict2, OptAtoms),
+
+    build_file(Code, Attr, Dict3, NumLabels, NumFuncs, ExtraChunks, SourceFile,
+               Opts, CompilerOpts).
 
 on_load(Fs0, Attr0) ->
     case proplists:get_value(on_load, Attr0) of

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -71,7 +71,7 @@ assemble({Mod,Exp0,Attr0,Asm0,NumLabels}, ExtraChunks, SourceFile, Opts, Compile
 
     %% Populate atom dict with atoms that were optimized away during Core Fold
     %% Atoms may possibly exist in atom Dict, but we attempt to add them anyway
-    OptAtoms = proplists:get_value(optimized_away_atoms, Attr0, []),
+    OptAtoms = proplists:get_value(<<"optimized_away_atoms">>, Attr0, []),
     Dict3 = lists:foldl(
         fun(A, D0) ->
             {_, D1} = beam_dict:atom(A, D0),

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -103,7 +103,8 @@
 -type yes_no_maybe() :: 'yes' | 'no' | 'maybe'.
 -type sub() :: #sub{}.
 
--define(OPT_ATOMS_TAB, sys_core_fold_opt_atoms).
+%% Process dictionary key for collection of optimized away atoms
+-define(OPT_ATOMS_PD_KEY, 'sys_core_fold:optimized_away_atoms').
 
 -spec module(cerl:c_module(), [compile:option()]) ->
 	{'ok', cerl:c_module(), [_]}.
@@ -117,19 +118,19 @@ module(#c_module{defs=Ds0}=Mod, Opts) ->
     init_warnings(),
 
     %% Collect atoms which are optimized away
-    _Tid = ets:new(?OPT_ATOMS_TAB, [named_table, protected]),
+    erlang:put(?OPT_ATOMS_PD_KEY, cerl_sets:new()),
 
     Ds1 = [function_1(D) || D <- Ds0],
     erase(no_inline_list_funcs),
 
-    KFun = fun({K, _}) -> K end, % to take only key from pairs
-
     %% Get all keys from ETS table, and append a new attribute
-    %% -optimized_away_atoms([a, b, ...])
-    OptAtoms = ordsets:from_list(lists:map(KFun, ets:tab2list(?OPT_ATOMS_TAB))),
-    ets:delete(?OPT_ATOMS_TAB),
-    OptAttribute = [{#c_literal{val =optimized_away_atoms},
-                     #c_literal{val=OptAtoms}}],
+    %% -<<"optimized_away_atoms">>([a, b, ...])
+    OptAtoms = cerl_sets:to_list(erlang:get(?OPT_ATOMS_PD_KEY)),
+
+    %% Module attribute name for optimized away atoms, as binary to avoid conflict
+    %% with other user-defined module attributes
+    OptAttribute = [{#c_literal{val = <<"optimized_away_atoms">>},
+                     #c_literal{val = OptAtoms}}],
     OptAttrs = Mod#c_module.attrs ++ OptAttribute,
 
     {ok, Mod#c_module{defs = Ds1, attrs=OptAttrs}, get_warnings()}.
@@ -139,7 +140,8 @@ module(#c_module{defs=Ds0}=Mod, Opts) ->
 %% code anymore.
 optimized_away_atoms([]) -> ok;
 optimized_away_atoms([#c_literal{val=A} | Tail]) when is_atom(A) ->
-    ets:insert(?OPT_ATOMS_TAB, {A, undefined}),
+    Set0 = erlang:get(?OPT_ATOMS_PD_KEY),
+    erlang:put(?OPT_ATOMS_PD_KEY, cerl_sets:add_element(A, Set0)),
     optimized_away_atoms(Tail);
 optimized_away_atoms([_ | Tail]) ->
     optimized_away_atoms(Tail).
@@ -224,7 +226,7 @@ opt_guard_try(#c_seq{arg=Arg,body=Body0}=Seq) ->
 		    %% a guard and that we must keep the call).
 		    Seq#c_seq{body=Body};
 		true ->
-		    optimized_away_atoms([Mod, Name] ++ Args),
+		    optimized_away_atoms([Mod, Name | Args]),
 		    %% The BIF has no side effects, so it can
 		    %% be safely removed.
 		    Body
@@ -815,7 +817,7 @@ fold_call_1(Call, Mod, Name, Args, Sub) ->
     case erl_bifs:is_pure(Mod, Name, NumArgs) of
 	false -> Call;				%Not pure - keep call.
 	true ->
-	    optimized_away_atoms([Mod, Name] ++ Args),
+	    optimized_away_atoms([Mod, Name | Args]),
 	    fold_call_2(Call, Mod, Name, Args, Sub)
     end.
 

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -103,6 +103,8 @@
 -type yes_no_maybe() :: 'yes' | 'no' | 'maybe'.
 -type sub() :: #sub{}.
 
+-define(OPT_ATOMS_TAB, sys_core_fold_opt_atoms).
+
 -spec module(cerl:c_module(), [compile:option()]) ->
 	{'ok', cerl:c_module(), [_]}.
 
@@ -113,9 +115,34 @@ module(#c_module{defs=Ds0}=Mod, Opts) ->
 	_ -> ok
     end,
     init_warnings(),
+
+    %% Collect atoms which are optimized away
+    _Tid = ets:new(?OPT_ATOMS_TAB, [named_table, protected]),
+
     Ds1 = [function_1(D) || D <- Ds0],
     erase(no_inline_list_funcs),
-    {ok,Mod#c_module{defs=Ds1},get_warnings()}.
+
+    KFun = fun({K, _}) -> K end, % to take only key from pairs
+
+    %% Get all keys from ETS table, and append a new attribute
+    %% -optimized_away_atoms([a, b, ...])
+    OptAtoms = ordsets:from_list(lists:map(KFun, ets:tab2list(?OPT_ATOMS_TAB))),
+    ets:delete(?OPT_ATOMS_TAB),
+    OptAttribute = [{#c_literal{val =optimized_away_atoms},
+                     #c_literal{val=OptAtoms}}],
+    OptAttrs = Mod#c_module.attrs ++ OptAttribute,
+
+    {ok, Mod#c_module{defs = Ds1, attrs=OptAttrs}, get_warnings()}.
+
+%% Pick up atoms from list and add them to the ETS table.
+%% Then BEAM atom table will be populated even if they aren't mentioned in the
+%% code anymore.
+optimized_away_atoms([]) -> ok;
+optimized_away_atoms([#c_literal{val=A} | Tail]) when is_atom(A) ->
+    ets:insert(?OPT_ATOMS_TAB, {A, undefined}),
+    optimized_away_atoms(Tail);
+optimized_away_atoms([_ | Tail]) ->
+    optimized_away_atoms(Tail).
 
 function_1({#c_var{name={F,Arity}}=Name,B0}) ->
     try
@@ -197,6 +224,7 @@ opt_guard_try(#c_seq{arg=Arg,body=Body0}=Seq) ->
 		    %% a guard and that we must keep the call).
 		    Seq#c_seq{body=Body};
 		true ->
+		    optimized_away_atoms([Mod, Name] ++ Args),
 		    %% The BIF has no side effects, so it can
 		    %% be safely removed.
 		    Body
@@ -786,7 +814,9 @@ fold_call_1(Call, Mod, Name, Args, Sub) ->
     NumArgs = length(Args),
     case erl_bifs:is_pure(Mod, Name, NumArgs) of
 	false -> Call;				%Not pure - keep call.
-	true -> fold_call_2(Call, Mod, Name, Args, Sub)
+	true ->
+	    optimized_away_atoms([Mod, Name] ++ Args),
+	    fold_call_2(Call, Mod, Name, Args, Sub)
     end.
 
 fold_call_2(Call, Module, Name, Args, Sub) ->


### PR DESCRIPTION
The bug https://bugs.erlang.org/browse/ERL-453 says that atoms used in code, which was removed by optimizer, should remain in the module in order for `*_to_existing_atom` to work.

* In sys_core_fold I collect optimized away atoms in special protected ETS table.
* The collected atoms are stored as module attribute `-optimized_away_atoms([a, b, c...]).`, some of atoms here may be used elsewhere in the code and will look like false positives. They are listed here because some piece of code was eliminated which contained such an atom.
* BEAM ASM stage reads this attribute and reintroduces removed atoms into the atom dict.
* The bug is gone.

## Possible problems?
* There is no option to control/disable this feature.
* Possibly a mention in documentation is needed? This does not introduce a new behaviour, it just restores expected behaviour for `*_to_existing_atom` for cases when the atom was optimized away and eliminated.