### PR TITLE
ERL-327 On zero-size files attempt to read until EOF

### DIFF
--- a/erts/emulator/drivers/common/efile_drv.c
+++ b/erts/emulator/drivers/common/efile_drv.c
@@ -1328,8 +1328,8 @@ static void invoke_read_file(void *data)
          * anyway. Note: This will eat ZERO_FILE_CHUNK bytes for any 0 file
          * and free them immediately after (if the file was empty). */
         ERTS_ASSERT(size >= 0);
-        d->c.read_file.binp = driver_alloc_binary(size ? (size_t)size
-                                                       : ZERO_FILE_CHUNK);
+        d->c.read_file.binp = driver_alloc_binary(size != 0 ? (size_t)size
+                                                            : ZERO_FILE_CHUNK);
 
 	if (size < 0 || size != d->c.read_file.size || !d->c.read_file.binp) {
 	    d->result_ok = 0;
@@ -1340,7 +1340,7 @@ static void invoke_read_file(void *data)
     }
     /* Invariant: d->c.read_file.size >= d->c.read_file.offset */
     
-    if (! d->c.read_file.size) {
+    if (d->c.read_file.size != 0) {
         read_file_zero_size(d);
         goto chop_done;
     }

--- a/erts/emulator/drivers/common/efile_drv.c
+++ b/erts/emulator/drivers/common/efile_drv.c
@@ -1311,13 +1311,13 @@ static void invoke_read_file(void *data)
     size_t read_size;
     int chop;
     DTRACE_INVOKE_SETUP(FILE_READ_FILE);
-
+    
     if (! d->c.read_file.binp) { /* First invocation only */
 	int fd;
 	Sint64 size;
-
-	if (! (d->result_ok =
-	       efile_openfile(&d->errInfo, d->b,
+	
+	if (! (d->result_ok = 
+	       efile_openfile(&d->errInfo, d->b, 
 			      EFILE_MODE_READ, &fd, &size))) {
 	    goto done;
 	}
@@ -1339,7 +1339,7 @@ static void invoke_read_file(void *data)
 	d->c.read_file.offset = 0;
     }
     /* Invariant: d->c.read_file.size >= d->c.read_file.offset */
-
+    
     if (! d->c.read_file.size) {
         read_file_zero_size(d);
         goto chop_done;
@@ -1349,12 +1349,12 @@ static void invoke_read_file(void *data)
     if (! read_size) goto close;
     chop = d->again && read_size >= FILE_SEGMENT_READ*2;
     if (chop) read_size = FILE_SEGMENT_READ;
-    d->result_ok =
-	efile_read(&d->errInfo,
-		   EFILE_MODE_READ,
-		   (int) d->fd,
+    d->result_ok = 
+	efile_read(&d->errInfo, 
+		   EFILE_MODE_READ, 
+		   (int) d->fd, 
 		   d->c.read_file.binp->orig_bytes + d->c.read_file.offset,
-		   read_size,
+		   read_size, 
 		   &read_size);
     if (d->result_ok) {
 	d->c.read_file.offset += read_size;

--- a/erts/emulator/drivers/common/efile_drv.c
+++ b/erts/emulator/drivers/common/efile_drv.c
@@ -1340,9 +1340,9 @@ static void invoke_read_file(void *data)
     }
     /* Invariant: d->c.read_file.size >= d->c.read_file.offset */
     
-    if (d->c.read_file.size != 0) {
+    if (d->c.read_file.size == 0) {
         read_file_zero_size(d);
-        goto chop_done;
+        goto close;
     }
 
     read_size = (size_t) (d->c.read_file.size - d->c.read_file.offset);

--- a/erts/emulator/test/efile_SUITE.erl
+++ b/erts/emulator/test/efile_SUITE.erl
@@ -171,7 +171,7 @@ open_files(Name) ->
 %% a /proc directory), let's read some zero sized files 500 times each, while
 %% ensuring that response isn't empty << >>
 proc_zero_sized_files(Config) when is_list(Config) ->
-    {Type, Flavor} = os:type()
+    {Type, Flavor} = os:type(),
     %% Some files which exist on Linux but might be missing on other systems
     Inputs = ["/proc/cpuinfo",
               "/proc/meminfo",

--- a/erts/emulator/test/efile_SUITE.erl
+++ b/erts/emulator/test/efile_SUITE.erl
@@ -171,15 +171,21 @@ open_files(Name) ->
 %% a /proc directory), let's read some zero sized files 500 times each, while
 %% ensuring that response isn't empty << >>
 proc_zero_sized_files(Config) when is_list(Config) ->
+    {Type, Flavor} = os:type()
     %% Some files which exist on Linux but might be missing on other systems
     Inputs = ["/proc/cpuinfo",
               "/proc/meminfo",
               "/proc/partitions",
               "/proc/swaps",
               "/proc/version",
-              "/proc/uptime"],
+              "/proc/uptime",
+              %% curproc is present on freebsd
+              "/proc/curproc/cmdline"],
     case filelib:is_dir("/proc") of
-        false -> ok; % skip the test if no /proc
+        false -> {skip, "/proc not found"}; % skip the test if no /proc
+        _ when Type =:= unix andalso Flavor =:= sunos ->
+            %% SunOS has a /proc, but no zero sized special files
+            {skip, "sunos does not have any zero sized special files"};
         true ->
             %% Take away files which do not exist in proc
             Inputs1 = lists:filter(fun filelib:is_file/1, Inputs),


### PR DESCRIPTION
When read_file is invoked on a file with zero size, it will attempt to read ~256kb~ 64kb blocks until EOF then stop and return the result. Assuming most of files in `/proc/` are few kb in length, this typically should result in 1 allocation of ~256kb~ 64kb and 1 following reallocation down to the real size.