### PR TITLE
Remove query keyword residues

### DIFF
--- a/lib/compiler/test/compilation_SUITE_data/opt_crash.erl
+++ b/lib/compiler/test/compilation_SUITE_data/opt_crash.erl
@@ -33,7 +33,7 @@ test() ->
                {userinfo,nil},
                fun() -> nil end},
             nil},
-         {'query',nil}}},
+         {query,nil}}},
 
    {absoluteURI,
       {scheme,_},
@@ -43,7 +43,7 @@ test() ->
                {userinfo,nil},
                HostportBefore},
             nil},
-         {'query',nil}}} = URI_Before,
+         {query,nil}}} = URI_Before,
 
    %% ... some funky code ommitted, not relevant ...
 
@@ -55,7 +55,7 @@ test() ->
                {userinfo,nil},
                HostportAfter},
             nil},
-         {'query',nil}}} = URI_Before,
+         {query,nil}}} = URI_Before,
    %% NOTE: I intended to write URI_After instead of URI_Before
    %% but the accident revealed that when you add the line below,
    %% it causes internal error in v3_codegen on compilation

--- a/lib/kernel/doc/src/inet_res.xml
+++ b/lib/kernel/doc/src/inet_res.xml
@@ -130,7 +130,7 @@ dns_header() = DnsHeader
     inet_dns:header(DnsHeader) ->
         [ {id, integer()}
         | {qr, boolean()}
-        | {opcode, 'query' | iquery | status | integer()}
+        | {opcode, query | iquery | status | integer()}
         | {aa, boolean()}
         | {tc, boolean()}
         | {rd, boolean()}

--- a/lib/observer/src/observer_traceoptions_wx.erl
+++ b/lib/observer/src/observer_traceoptions_wx.erl
@@ -618,7 +618,7 @@ create_styled_txtctrl(Parent) ->
 
 keyWords() ->
     L = ["after","begin","case","try","cond","catch","andalso","orelse",
-	 "end","fun","if","let","of","query","receive","when","bnot","not",
+	 "end","fun","if","let","of","receive","when","bnot","not",
 	 "div","rem","band","and","bor","bxor","bsl","bsr","or","xor"],
     lists:flatten([K ++ " " || K <- L] ++ [0]).
 

--- a/lib/reltool/src/reltool_mod_win.erl
+++ b/lib/reltool/src/reltool_mod_win.erl
@@ -833,7 +833,7 @@ load_code(Ed, Code) when is_binary(Code) ->
 
 keyWords() ->
     L = ["after","begin","case","try","cond","catch","andalso","orelse",
-	 "end","fun","if","let","of","query","receive","when","bnot","not",
+	 "end","fun","if","let","of","receive","when","bnot","not",
 	 "div","rem","band","and","bor","bxor","bsl","bsr","or","xor"],
     lists:flatten([K ++ " " || K <- L] ++ [0]).
 

--- a/lib/stdlib/src/erl_pp.erl
+++ b/lib/stdlib/src/erl_pp.erl
@@ -598,8 +598,6 @@ lexpr({'fun',_,{clauses,Cs},Extra}, _Prec, Opts) ->
 lexpr({named_fun,_,Name,Cs,Extra}, _Prec, Opts) ->
     {force_nl,fun_info(Extra),
      {list,[{first,['fun', " "],fun_clauses(Cs, Opts, {named, Name})},'end']}};
-lexpr({'query',_,Lc}, _Prec, Opts) ->
-    {list,[{step,leaf("query"),lexpr(Lc, 0, Opts)},'end']};
 lexpr({call,_,{remote,_,{atom,_,M},{atom,_,F}=N}=Name,Args}, Prec, Opts) ->
     case erl_internal:bif(M, F, length(Args)) of
         true ->

--- a/lib/wx/examples/demo/demo.erl
+++ b/lib/wx/examples/demo/demo.erl
@@ -411,7 +411,7 @@ find(Ed) ->
 
 keyWords() ->
     L = ["after","begin","case","try","cond","catch","andalso","orelse",
-	 "end","fun","if","let","of","query","receive","when","bnot","not",
+	 "end","fun","if","let","of","receive","when","bnot","not",
 	 "div","rem","band","and","bor","bxor","bsl","bsr","or","xor"],
     lists:flatten([K ++ " " || K <- L] ++ [0]).
 


### PR DESCRIPTION
There are still some query residues used as a keyword. Remove them.
query was no longer a keyword since the commit 0dc3a29744bed0b7f483ad72e19773dc0982ea50 2012-11-19.