### PR TITLE
sys_core_fold: Fix unsafe optimization of non-variable apply

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -395,10 +395,10 @@ expr(#c_receive{clauses=Cs0,timeout=T0,action=A0}=Recv, Ctxt, Sub) ->
 expr(#c_apply{anno=Anno,op=Op0,args=As0}=App, _, Sub) ->
     Op1 = expr(Op0, value, Sub),
     As1 = expr_list(As0, value, Sub),
-    case Op1 of
-	#c_var{} ->
+    case cerl:is_data(Op1) of
+        false ->
 	    App#c_apply{op=Op1,args=As1};
-	_ ->
+	true ->
 	    add_warning(App, invalid_call),
 	    Err = #c_call{anno=Anno,
 			  module=#c_literal{val=erlang},

--- a/lib/compiler/test/core_SUITE.erl
+++ b/lib/compiler/test/core_SUITE.erl
@@ -28,7 +28,8 @@
 	 map_core_test/1,eval_case/1,bad_boolean_guard/1,
 	 bs_shadowed_size_var/1,
 	 cover_v3_kernel_1/1,cover_v3_kernel_2/1,cover_v3_kernel_3/1,
-	 cover_v3_kernel_4/1,cover_v3_kernel_5/1]).
+	 cover_v3_kernel_4/1,cover_v3_kernel_5/1,
+         non_variable_apply/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -56,7 +57,8 @@ groups() ->
        map_core_test,eval_case,bad_boolean_guard,
        bs_shadowed_size_var,
        cover_v3_kernel_1,cover_v3_kernel_2,cover_v3_kernel_3,
-       cover_v3_kernel_4,cover_v3_kernel_5
+       cover_v3_kernel_4,cover_v3_kernel_5,
+       non_variable_apply
       ]}].
 
 
@@ -90,7 +92,7 @@ end_per_group(_GroupName, Config) ->
 ?comp(cover_v3_kernel_3).
 ?comp(cover_v3_kernel_4).
 ?comp(cover_v3_kernel_5).
-
+?comp(non_variable_apply).
 
 try_it(Mod, Conf) ->
     Src = filename:join(proplists:get_value(data_dir, Conf),

--- a/lib/compiler/test/core_SUITE_data/non_variable_apply.core
+++ b/lib/compiler/test/core_SUITE_data/non_variable_apply.core
@@ -1,0 +1,80 @@
+module 'non_variable_apply' ['module_info'/0,
+			     'module_info'/1,
+			     'non_variable_apply'/0]
+    attributes []
+
+'non_variable_apply'/0 =
+    %% Line 4
+    fun () ->
+	case <> of
+	  <> when 'true' ->
+	      let <OkFun> =
+		  fun (_@c0) ->
+		      %% Line 5
+		      case _@c0 of
+			<'ok'> when 'true' ->
+			    'ok'
+			( <_@c1> when 'true' ->
+			      ( primop 'match_fail'
+				    ({'function_clause',_@c1})
+				-| [{'function_name',{'-non_variable_apply/0-fun-0-',1}}] )
+			  -| ['compiler_generated'] )
+		      end
+	      in  let <F> =
+		      fun (_@c5,_@c4) ->
+			  %% Line 6
+			  case <_@c5,_@c4> of
+			    <F,X> when 'true' ->
+			        apply apply 'id'/1 (F) (X)
+			    ( <_@c7,_@c6> when 'true' ->
+				  ( primop 'match_fail'
+					({'function_clause',_@c7,_@c6})
+				    -| [{'function_name',{'-non_variable_apply/0-fun-1-',2}}] )
+			      -| ['compiler_generated'] )
+			  end
+		  in  %% Line 9
+		      apply F
+			  (OkFun, 'ok')
+	  ( <> when 'true' ->
+		( primop 'match_fail'
+		      ({'function_clause'})
+		  -| [{'function_name',{'non_variable_apply',0}}] )
+	    -| ['compiler_generated'] )
+	end
+'id'/1 =
+    %% Line 11
+    fun (_@c0) ->
+	case _@c0 of
+	  <I> when 'true' ->
+	      I
+	  ( <_@c1> when 'true' ->
+		( primop 'match_fail'
+		      ({'function_clause',_@c1})
+		  -| [{'function_name',{'id',1}}] )
+	    -| ['compiler_generated'] )
+	end
+'module_info'/0 =
+    fun () ->
+	case <> of
+	  <> when 'true' ->
+	      call 'erlang':'get_module_info'
+		  ('non_variable_apply')
+	  ( <> when 'true' ->
+		( primop 'match_fail'
+		      ({'function_clause'})
+		  -| [{'function_name',{'module_info',0}}] )
+	    -| ['compiler_generated'] )
+	end
+'module_info'/1 =
+    fun (_@c0) ->
+	case _@c0 of
+	  <X> when 'true' ->
+	      call 'erlang':'get_module_info'
+		  ('non_variable_apply', X)
+	  ( <_@c1> when 'true' ->
+		( primop 'match_fail'
+		      ({'function_clause',_@c1})
+		  -| [{'function_name',{'module_info',1}}] )
+	    -| ['compiler_generated'] )
+	end
+end


### PR DESCRIPTION
The sys_core_fold pass would do an unsafe "optimization" when an
apply operation did not have a variable in the function position
as in the following example:

```
> cat test1.core
module 'test1' ['test1'/2]
    attributes []
'i'/1 =
  fun (_f) -> _f
'test1'/2 =
  fun (_f, _x) ->
    apply apply 'i'/1 (_f) (_x)
end
> erlc test1.core
no_file: Warning: invalid function call
```

Reported-by: Mikael Pettersson