### PR TITLE
gen_fsm-depre-20: fix gen_fsm deprecation recommendations after 20.0

### DIFF
--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -63,9 +63,9 @@ obsolete_1(gen_fsm, start, 4) ->
     {deprecated, {gen_statem, start, 4}};
 
 obsolete_1(gen_fsm, start_link, 3) ->
-    {deprecated, {gen_statem, start, 3}};
+    {deprecated, {gen_statem, start_link, 3}};
 obsolete_1(gen_fsm, start_link, 4) ->
-    {deprecated, {gen_statem, start, 4}};
+    {deprecated, {gen_statem, start_link, 4}};
 
 obsolete_1(gen_fsm, stop, 1) ->
     {deprecated, {gen_statem, stop, 1}};
@@ -83,9 +83,9 @@ obsolete_1(gen_fsm, reply, 2) ->
     {deprecated, {gen_statem, reply, 2}};
 
 obsolete_1(gen_fsm, send_event, 2) ->
-    {deprecated, {gen_statem, cast, 1}};
+    {deprecated, {gen_statem, cast, 2}};
 obsolete_1(gen_fsm, send_all_state_event, 2) ->
-    {deprecated, {gen_statem, cast, 1}};
+    {deprecated, {gen_statem, cast, 2}};
 
 obsolete_1(gen_fsm, sync_send_event, 2) ->
     {deprecated, {gen_statem, call, 2}};

--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -98,11 +98,11 @@ obsolete_1(gen_fsm, sync_send_all_state_event, 3) ->
     {deprecated, {gen_statem, call, 3}};
 
 obsolete_1(gen_fsm, start_timer, 2) ->
-    {deprecated, {erlang, start_timer, 2}};
+    {deprecated, {erlang, start_timer, 3}};
 obsolete_1(gen_fsm, cancel_timer, 1) ->
     {deprecated, {erlang, cancel_timer, 1}};
 obsolete_1(gen_fsm, send_event_after, 2) ->
-    {deprecated, {erlang, send_after, 2}};
+    {deprecated, {erlang, send_after, 3}};
 
 %% *** CRYPTO added in OTP 20 ***
 


### PR DESCRIPTION
When compiling a gen_fsm written before gen_statem was introduced, the deprecation warnings do not seem on point:


* it is suggested to replace calls to `gen_fsm:start_link/3` with `gen_statem:start/3` even though gen_fsm.xml suggests `start_link`

* `gen_fsm:send_event/2` with `gen_statem:cast/1` instead of `/2` (`/1` does not even exist)