### PR TITLE
Generalize optimization of "one-armed" cases

### DIFF
--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -26,7 +26,8 @@
 	 unused_multiple_values_error/1,unused_multiple_values/1,
 	 multiple_aliases/1,redundant_boolean_clauses/1,
 	 mixed_matching_clauses/1,unnecessary_building/1,
-	 no_no_file/1,configuration/1,supplies/1]).
+	 no_no_file/1,configuration/1,supplies/1,
+         redundant_stack_frame/1]).
 
 -export([foo/0,foo/1,foo/2,foo/3]).
 
@@ -45,7 +46,8 @@ groups() ->
        unused_multiple_values_error,unused_multiple_values,
        multiple_aliases,redundant_boolean_clauses,
        mixed_matching_clauses,unnecessary_building,
-       no_no_file,configuration,supplies]}].
+       no_no_file,configuration,supplies,
+       redundant_stack_frame]}].
 
 
 init_per_suite(Config) ->
@@ -526,5 +528,27 @@ supplies(_Config) ->
     end.
 
 do_supplies(#{1 := Value}) when byte_size(Value), byte_size(kg) -> working.
+
+redundant_stack_frame(_Config) ->
+    {1,2} = do_redundant_stack_frame(#{x=>1,y=>2}),
+    {'EXIT',{{badkey,_,x},_}} = (catch do_redundant_stack_frame(#{y=>2})),
+    {'EXIT',{{badkey,_,y},_}} = (catch do_redundant_stack_frame(#{x=>1})),
+    ok.
+
+do_redundant_stack_frame(Map) ->
+    %% There should not be a stack frame for this function.
+    X = case Map of
+            #{x := X0} ->
+                X0;
+            #{} ->
+                erlang:error({badkey, Map, x})
+        end,
+    Y = case Map of
+            #{y := Y0} ->
+                Y0;
+            #{} ->
+                erlang:error({badkey, Map, y})
+        end,
+    {X, Y}.
 
 id(I) -> I.


### PR DESCRIPTION
In general, a 'case' expression will force a stack frame.

However, for an one-armed 'case':
```
  case Expr of
     Pat1 ->
       DoSomething;
     Pat2 ->
       erlang:error(bad)
  end.
```
at the end of a function there is no need to allocate a
stack frame

In sys_core_fold there is an optimization that takes advantage
of this by rewriting code such as:
```
  case Expr of
     Pat1 ->
       DoSomething;
     Pat2 ->
       erlang:error(bad)
  end,
  MoreCode.
```
to:
```
  case Expr of
     Pat1 ->
       DoSomething,
       MoreCode;
     Pat2 ->
       erlang:error(bad)
  end.
```
However, that optimization would not be applied if there
were more than one failing clause such as in this code:
```
  case Expr of
     Pat1 ->
       DoSomething,
       MoreCode;
     Pat2 ->
       erlang:error(bad);
     _ ->
       erlang:error(case_clause)
  end.
```

Generalize the optimization to handle any number of failing
clauses at the end of the case.

Reported-by: bugs.erlang.org/browse/ERL-452