### PR TITLE
Fix broken doc links to gen_fsm design princ

### DIFF
--- a/system/doc/design_principles/des_princ.xml
+++ b/system/doc/design_principles/des_princ.xml
@@ -225,10 +225,8 @@ free(Ch, {Alloc, Free} = Channels) ->
     <list type="bulleted">
       <item><p><seealso marker="gen_server_concepts">gen_server</seealso></p>
       <p>For implementing the server of a client-server relation</p></item>
-      <item><p><seealso marker="fsm">gen_fsm</seealso></p>
-      <p>For implementing finite-state machines (Old)</p></item>
       <item><p><seealso marker="statem">gen_statem</seealso></p>
-      <p>For implementing state machines (New)</p></item>
+      <p>For implementing state machines</p></item>
       <item><p><seealso marker="events">gen_event</seealso></p>
       <p>For implementing event handling functionality</p></item>
       <item><p><seealso marker="sup_princ">supervisor</seealso></p>

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -411,14 +411,6 @@ StateName(EventType, EventContent, Data) ->
     <marker id="Example" />
     <title>Example</title>
     <p>
-      This example starts off as equivalent to the example in section
-      <seealso marker="fsm"><c>gen_fsm</c>&nbsp;Behavior</seealso>.
-      In later sections, additions and tweaks are made
-      using features in <c>gen_statem</c> that <c>gen_fsm</c> does not have.
-      The end of this chapter provides the example again
-      with all the added features.
-    </p>
-    <p>
       A door with a code lock can be seen as a state machine.
       Initially, the door is locked. When someone presses a button,
       an event is generated.


### PR DESCRIPTION
Fixed some broken doc links.

Question: Do we want to put some other text in the introduction to the example?