### PR TITLE
Execute the dropped_commands test case in port_SUITE

### DIFF
--- a/erts/emulator/test/port_SUITE.erl
+++ b/erts/emulator/test/port_SUITE.erl
@@ -159,7 +159,7 @@ suite() ->
 all() ->
     [otp_6224, {group, stream}, basic_ping, slow_writes,
      bad_packet, bad_port_messages, {group, options},
-     {group, multiple_packets}, parallell, dying_port,
+     {group, multiple_packets}, parallell, dying_port, dropped_commands,
      port_program_with_path, open_input_file_port,
      open_output_file_port, name1, env, huge_env, bad_env, cd,
      cd_relative, pipe_limit_env, bad_args,
@@ -569,6 +569,7 @@ dropped_commands(Config, Outputv, Cmd) ->
     [dropped_commands_test(Cmd) || _ <- lists:seq(1, 100)],
     timer:sleep(100),
     erl_ddll:unload_driver("echo_drv"),
+    os:unsetenv("ECHO_DRV_USE_OUTPUTV"),
     ok.
 
 dropped_commands_test(Cmd) ->


### PR DESCRIPTION
This test case was introduced in 5a42fa760c, but was never added to the list of test cases to execute.

Also, the commit fixes cleaning up the modified OS environment setting to prevent problems with later test cases using the `echo_drv` too.