### PR TITLE
Fix disksup:get_disksup_data() for High Sierra

### DIFF
--- a/lib/os_mon/src/disksup.erl
+++ b/lib/os_mon/src/disksup.erl
@@ -285,7 +285,7 @@ check_disk_space({unix, sunos4}, Port, Threshold) ->
     Result = my_cmd("df", Port),
     check_disks_solaris(skip_to_eol(Result), Threshold);
 check_disk_space({unix, darwin}, Port, Threshold) ->
-    Result = my_cmd("/bin/df -i -k -t ufs,hfs", Port),
+    Result = my_cmd("/bin/df -i -k -t ufs,hfs,apfs", Port),
     check_disks_susv3(skip_to_eol(Result), Threshold).
 
 % This code works for Linux and FreeBSD as well


### PR DESCRIPTION
On macOS 10.13 (High Sierra), disksup cannot grab information
for any disks that use the new APFS file system. The reason
is that the invocation of /bin/df explicitly limits the
type of file systems to show:

    /bin/df -i -k -t ufs,hfs

Add 'apfs' to also look at disks with APFS:

    /bin/df -i -k -t ufs,hfs,apfs

That also works on older versions of macOS.

An alternative solution would be to use the -l flag to only
show local file systems. However, that would mean that USB
memory sticks would also show up, and it might not be desirable
to monitor them.

https://bugs.erlang.org/browse/ERL-461