### PR TITLE
erl_eval doesn't keep the stacktrace when exceptions occur

### DIFF
--- a/lib/stdlib/src/erl_eval.erl
+++ b/lib/stdlib/src/erl_eval.erl
@@ -661,6 +661,8 @@ do_apply(Func, As, Bs0, Ef, RBs) ->
             ret_expr(F(Func, As), Bs0, RBs)
     end.
 
+do_apply(erlang, get_stacktrace, [], Bs0, _, RBs) ->
+    ret_expr(get('$stacktrace'), Bs0, RBs);
 do_apply(Mod, Func, As, Bs0, Ef, RBs) ->
     case Ef of
         none when RBs =:= value ->
@@ -916,6 +918,7 @@ try_clauses(B, Cases, Catches, AB, Bs, Lf, Ef, RBs) ->
 	    %% Rethrow
 	    erlang:raise(Class, Reason, stacktrace());
 	Class:Reason ->
+	    put('$stacktrace', erlang:get_stacktrace()),
 %%% 	    %% Set stacktrace
 %%% 	    try erlang:raise(Class, Reason, stacktrace())
 %%% 	    catch _:_ -> ok 


### PR DESCRIPTION
Opening this to have a discussion on what the best way to fix this is. This one is a hack, meant to demonstrate where it goes wrong.

A larger background discussion on this issue can be seen at https://github.com/ninenines/erlang.mk/issues/699

In short, `erl_eval` eats up exception stacktraces when try..catch is used, and so does `erl -eval`. There's a lot of `erl -eval` use in erlang.mk and in a handful of them it would be good to get the correct exception.

`erl_eval` seems to have no way to keep the stacktrace around, I think it simply was not implemented. The attached patch provide a quick solution, but most likely not good enough to be in OTP. I would like to add a proper patch into OTP.

I think a patch similar to this except instead of using the process dictionary we would use a special variable name could work. What do you think? If you have better suggestions, I will be happy to implement a fix.