### PR TITLE
Optimise equality comparisons

### DIFF
--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -413,8 +413,17 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl R=xy C=ian => i_is_eq_exact_immed Lbl R C
+is_eq_exact Lbl S S =>
+is_eq_exact Lbl C1=c C2=c => move C1 x | is_eq_exact Lbl x C2
+is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
+
+is_eq_exact Lbl R=xy n => is_nil Lbl R
+is_eq_exact Lbl R=xy C=ia => i_is_eq_exact_immed Lbl R C
 is_eq_exact Lbl R=xy C=q => i_is_eq_exact_literal Lbl R C
+
+is_ne_exact Lbl S S => jump Lbl
+is_ne_exact Lbl C1=c C2=c => move C1 x | is_ne_exact Lbl x C2
+is_ne_exact Lbl C=c R=xy => is_ne_exact Lbl R C
 
 is_ne_exact Lbl R=xy C=ian => i_is_ne_exact_immed Lbl R C
 is_ne_exact Lbl R=xy C=q => i_is_ne_exact_literal Lbl R C
@@ -429,7 +438,9 @@ i_is_ne_exact_literal f xy c
 
 is_eq_exact Lbl Y=y X=x => is_eq_exact Lbl X Y
 is_eq_exact f x xy
-is_eq_exact f s s
+is_eq_exact f y y
+
+is_ne_exact f S S
 
 is_lt f x x
 is_lt f x c
@@ -444,8 +455,6 @@ is_ge f c x
 %cold
 is_ge f s s
 %hot
-
-is_ne_exact f s s
 
 is_eq f s s
 

--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -32,6 +32,11 @@
 
 -import(lists, [map/2,member/2,sort/1,reverse/1,splitwith/2]).
 
+-define(is_const(Val), (element(1, Val) =:= integer orelse
+                        element(1, Val) =:= float orelse
+                        element(1, Val) =:= atom orelse
+                        element(1, Val) =:= literal)).
+
 %% instruction() describes all instructions that are used during optimzation
 %% (from beam_a to beam_z).
 -type instruction() :: atom() | tuple().
@@ -197,10 +202,20 @@ bif_to_test('>', [A,B], Fail) -> {test,is_lt,Fail,[B,A]};
 bif_to_test('<', [_,_]=Ops, Fail) -> {test,is_lt,Fail,Ops};
 bif_to_test('>=', [_,_]=Ops, Fail) -> {test,is_ge,Fail,Ops};
 bif_to_test('==', [A,nil], Fail) -> {test,is_nil,Fail,[A]};
+bif_to_test('==', [nil,A], Fail) -> {test,is_nil,Fail,[A]};
+bif_to_test('==', [C,A], Fail) when ?is_const(C) ->
+    {test,is_eq,Fail,[A,C]};
 bif_to_test('==', [_,_]=Ops, Fail) -> {test,is_eq,Fail,Ops};
+bif_to_test('/=', [C,A], Fail) when ?is_const(C) ->
+    {test,is_ne,Fail,[A,C]};
 bif_to_test('/=', [_,_]=Ops, Fail) -> {test,is_ne,Fail,Ops};
 bif_to_test('=:=', [A,nil], Fail) -> {test,is_nil,Fail,[A]};
+bif_to_test('=:=', [nil,A], Fail) -> {test,is_nil,Fail,[A]};
+bif_to_test('=:=', [C,A], Fail) when ?is_const(C) ->
+    {test,is_eq_exact,Fail,[A,C]};
 bif_to_test('=:=', [_,_]=Ops, Fail) -> {test,is_eq_exact,Fail,Ops};
+bif_to_test('=/=', [C,A], Fail) when ?is_const(C) ->
+    {test,is_ne_exact,Fail,[A,C]};
 bif_to_test('=/=', [_,_]=Ops, Fail) -> {test,is_ne_exact,Fail,Ops};
 bif_to_test(is_record, [_,_,_]=Ops, Fail) -> {test,is_record,Fail,Ops}.
 

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -1291,6 +1291,10 @@ rel_ops(Config) when is_list(Config) ->
     true = any_atom /= id(42),
     true = [] /= id(42),
 
+    %% Coverage of beam_utils:bif_to_test/3
+    Empty = id([]),
+    ?T(==, [], Empty),
+
     ok.
 
 -undef(TestOp).


### PR DESCRIPTION
* In both loader and compiler, make sure constants are always the second
  operand - many passes of the compiler assume that's always the case.
* In loader rewrite is_eq_exact with different arguments to unconditional jump,
  with same arguments skip the instruction.
* In loader rewrite is_ne_exact with same arguments to unconditional jump,
  with different arguments skip the instruction.
* All of the above allow to replace is_eq_exact_fss with is_eq_exact_fyy and
  is_ne_exact_fss with is_ne_exact_fSS as those are the only possibilities left.