### PR TITLE
Remove time-consuming ethread_SUITE from smoke tests

### DIFF
--- a/erts/test/system_smoke.spec
+++ b/erts/test/system_smoke.spec
@@ -1,4 +1,3 @@
-{suites,"../system_test",[ethread_SUITE]}.
 {cases,"../system_test",otp_SUITE,
  [undefined_functions,
   deprecated_not_in_obsolete,


### PR DESCRIPTION
The ethread_SUITE is unlikely to ever find a real bug
introduced in a pull request, but it frequently times
out when run by Travis CI.