### PR TITLE
Move erts IO Polling to dedicated threads

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3545,6 +3545,7 @@ fi
 #
 AC_MSG_CHECKING(whether kernel poll support should be enabled)
 ERTS_ENABLE_KERNEL_POLL=no
+ERTS_BUILD_FALLBACK_POLL=no
 case $enable_kernel_poll-$have_kernel_poll in
     no-*)
 	AC_MSG_RESULT(no; disabled by user);;
@@ -3555,11 +3556,16 @@ case $enable_kernel_poll-$have_kernel_poll in
     *)
 	case $have_kernel_poll in
 	    epoll)
-		AC_DEFINE(HAVE_SYS_EPOLL_H, 1, [Define if you have the <sys/epoll.h> header file.]);;
+		AC_DEFINE(HAVE_SYS_EPOLL_H, 1, [Define if you have the <sys/epoll.h> header file.])
+                ERTS_BUILD_FALLBACK_POLL=yes
+                ;;
 	    /dev/poll)
-		AC_DEFINE(HAVE_SYS_DEVPOLL_H, 1, [Define if you have <sys/devpoll.h> header file.]);;
+		AC_DEFINE(HAVE_SYS_DEVPOLL_H, 1, [Define if you have <sys/devpoll.h> header file.])
+                ;;
 	    kqueue)
-		AC_DEFINE(HAVE_SYS_EVENT_H, 1, [Define if you have <sys/event.h> header file.]);;
+		AC_DEFINE(HAVE_SYS_EVENT_H, 1, [Define if you have <sys/event.h> header file.])
+                ERTS_BUILD_FALLBACK_POLL=yes
+                ;;
 	    *)
 		AC_MSG_ERROR(configure.in need to be updated);;
 	esac
@@ -3567,7 +3573,7 @@ case $enable_kernel_poll-$have_kernel_poll in
 	AC_DEFINE(ERTS_ENABLE_KERNEL_POLL, 1, [Define if you have kernel poll and want to use it])
 	AC_MSG_RESULT([yes; $have_kernel_poll]);;
 esac
-AC_SUBST(ERTS_ENABLE_KERNEL_POLL)
+AC_SUBST(ERTS_BUILD_FALLBACK_POLL)
 
 AC_MSG_CHECKING([whether putenv() stores a copy of the key-value pair])
 AC_TRY_RUN([

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3463,62 +3463,24 @@ case $poll_works-$host_os in
 esac
 
 #
-# If kqueue() found, check that it can be selected or polled on...
+# If kqueue() found
 #
 if test $have_kernel_poll = kqueue; then
-	if test $poll_works = yes; then
-		kqueue_with=poll
-	else
-		kqueue_with=select
-	fi
-	AC_MSG_CHECKING([whether kqueue() fd can be ${kqueue_with}()ed on])
-	AC_TRY_RUN([
-#include <stdlib.h>
-#include <sys/types.h>
-#include <sys/event.h>
-#include <sys/time.h>
-#ifdef ERTS_USE_POLL
-#include <poll.h>
-#else
-#include <unistd.h>
-#endif
-int main(void) {
-    int kq = kqueue();
-    if (kq < 0) return 2;
-    {
-#ifdef ERTS_USE_POLL
-	struct pollfd pfds = {kq, POLLIN, 0};
-	if (poll(&pfds, 1, 0) < 0) return 1;
-#else
-	struct timeval tv = {0, 0};
-	fd_set set; FD_ZERO(&set); FD_SET(kq, &set);
-	if (select(kq+1, &set, NULL, NULL, &tv) < 0) return 1;
-#endif
-    }
-    return 0;
-}
-	],
-	ok_kqueue=yes,
-	ok_kqueue=no,
-	[
-	case X$erl_xcomp_kqueue in
-	    X) ok_kqueue=cross;;
-	    Xyes|Xno) ok_kqueue=$erl_xcomp_kqueue;;
-	    *) AC_MSG_ERROR([Bad erl_xcomp_kqueue value: $erl_xcomp_kqueue]);;
-	esac
-	])
-	AC_MSG_RESULT($ok_kqueue);
-	case $ok_kqueue in
-	    yes)
-		;;
-	    cross)
-		have_kernel_poll=no
-		AC_MSG_WARN([result no guessed because of cross compilation]);;
-	    *)
-		have_kernel_poll=no;;
-	esac
+## Some OS X kernel version seems to have bugs in them with regards to kqueue
+## Disable kernel poll on those versions
+   AC_MSG_CHECKING([whether host os has known kqueue bugs])
+   case $host_os in
+     # Any OS X version < 16 has known problems with using kqueue
+     # so we don't use it there. See erl_poll.c for details.
+     darwin[[0-9]].*|darwin1[[0-5]].*)
+        AC_MSG_RESULT([yes, disabling kernel poll])
+        have_kernel_poll=no
+        ;;
+     *)
+        AC_MSG_RESULT([no])
+        ;;
+   esac
 fi
-
 #
 # If epoll() found, check that it is level triggered.
 #

--- a/erts/doc/src/driver_entry.xml
+++ b/erts/doc/src/driver_entry.xml
@@ -196,10 +196,7 @@ typedef struct erl_drv_entry {
 			 char **rbuf, ErlDrvSizeT rlen, unsigned int *flags);
                                 /* Works mostly like 'control', a synchronous
                                    call into the driver */
-    void (*event)(ErlDrvData drv_data, ErlDrvEvent event,
-                  ErlDrvEventData event_data);
-                                /* Called when an event selected by
-                                   driver_event() has occurred */
+    void* unused_event_callback;
     int extended_marker;        /* ERL_DRV_EXTENDED_MARKER */
     int major_version;          /* ERL_DRV_EXTENDED_MAJOR_VERSION */
     int minor_version;          /* ERL_DRV_EXTENDED_MINOR_VERSION */

--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -1296,25 +1296,6 @@
               <seealso marker="erlang#system_info_cpu_topology">
               <c>erlang:system_info(cpu_topology)</c></seealso>.</p>
           </item>
-          <tag><marker id="+secio"/><c>+secio true|false</c></tag>
-          <item>
-            <p>Enables or disables eager check I/O scheduling. Defaults
-              to <c>true</c>. The default was changed from <c>false</c>
-              as from ERTS 7.0. The behavior before this
-              flag was introduced corresponds to <c>+secio false</c>.</p>
-            <p>The flag effects when schedulers will check for I/O
-              operations possible to execute, and when such I/O operations
-              will execute. As the parameter name implies,
-              schedulers are more eager to check for I/O when
-              <c>true</c> is passed. This, however, also implies that
-              execution of outstanding I/O operation is not
-              prioritized to the same extent as when <c>false</c> is
-              passed.</p>
-            <p><seealso marker="erlang#system_info_eager_check_io">
-              <c>erlang:system_info(eager_check_io)</c></seealso>
-              returns the value of this parameter used when starting
-              the virtual machine.</p>
-          </item>
           <tag><marker id="+sfwi"/><c>+sfwi Interval</c></tag>
           <item>
             <p>Sets scheduler-forced wakeup interval. All run queues are

--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -762,13 +762,36 @@
           <seealso marker="erlang#process_flag_message_queue_data">
           <c>process_flag(message_queue_data, MQD)</c></seealso>.</p>
       </item>
-      <tag><c><![CDATA[+K true | false]]></c></tag>
+      <tag><marker id="+IOp"/><c>+IOp PollSets</c></tag>
       <item>
-        <p>Enables or disables the kernel poll functionality if supported by
-          the emulator. Defaults to <c><![CDATA[false]]></c> (disabled).
-          If the emulator does not support kernel poll, and flag
-          <c><![CDATA[+K]]></c> is passed to the emulator, a warning is
-          issued at startup.</p>
+        <p>Sets the number of IO pollsets to use when polling for I/O.
+          This option is only used on platforms that support concurrent
+          updates of a pollset, otherwise the same number of pollsets
+          are used as IO poll threads.
+          The default is 1.
+        </p>
+      </item>
+      <tag><marker id="+IOt"/><c>+IOt PollThreads</c></tag>
+      <item>
+        <p>Sets the number of IO poll threads to use when polling for I/O.
+          The maximum number of poll threads allowed is 1024. The default is 1.
+        </p>
+      </item>
+      <tag><marker id="+IOPp"/><c>+IOPp PollSetsPercentage</c></tag>
+      <item>
+        <p>Similar to <seealso marker="#+IOp"><c>+IOp</c></seealso> but uses
+          percentages to set the number of IO pollsets to create, based on the
+          number of poll threads configured. If both <c>+IOPp</c> and <c>+IOp</c>
+          are used, <c>+IOPp</c> is ignored.
+        </p>
+      </item>
+      <tag><marker id="+IOPt"/><c>+IOPt PollThreadsPercentage</c></tag>
+      <item>
+        <p>Similar to <seealso marker="#+IOt"><c>+IOt</c></seealso> but uses
+          percentages to set the number of IO poll threads to create, based on
+          the number of schedulers configures. If both <c>+IOPt</c> and
+          <c>+IOt</c> are used, <c>+IOPt</c> is ignored.
+        </p>
       </item>
       <tag><c><![CDATA[+l]]></c></tag>
       <item>

--- a/erts/doc/src/erl_driver.xml
+++ b/erts/doc/src/erl_driver.xml
@@ -157,7 +157,7 @@
     </note>
 
     <p>Most functions in this API are <em>not</em> thread-safe, that is,
-      they <em>cannot</em> be called from any thread. Functions
+      they <em>cannot</em> be called from arbitrary threads. Functions
       that are not documented as thread-safe can only be called from
       driver callbacks or function calls descending from a driver
       callback call. Notice that driver callbacks can be called from

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -8023,15 +8023,6 @@ ok
               The return value will always be <c>false</c>, as the
               <c>elib_malloc</c> allocator has been removed.</p>
           </item>
-          <tag><marker id="system_info_eager_check_io"/>
-            <c>eager_check_io</c></tag>
-          <item>
-            <p>Returns the value of command-line flag
-              <seealso marker="erl#+secio"><c>+secio</c></seealso> in
-              <c>erl(1)</c>, which is either <c>true</c> or <c>false</c>.
-              For information about the different values, see the
-              documentation of the command-line flag.</p>
-          </item>
           <tag><c>ets_limit</c></tag>
           <item>
             <p>Returns the maximum number of ETS tables allowed. This

--- a/erts/doc/src/erts_alloc.xml
+++ b/erts/doc/src/erts_alloc.xml
@@ -87,9 +87,9 @@
         the number of system calls made.</item>
     </taglist>
 
-    <p><c>sys_alloc</c> and <c>literal_alloc</c> are always enabled and
-      cannot be disabled. <c>exec_alloc</c> is only available if it is needed
-      and cannot be disabled. <c>mseg_alloc</c> is always enabled if it is
+    <p><c>sys_alloc</c>, <c>literal_alloc</c> and <c>temp_alloc</c> are always
+      enabled and cannot be disabled. <c>exec_alloc</c> is only available if it
+      is needed and cannot be disabled. <c>mseg_alloc</c> is always enabled if it is
       available and an allocator that uses it is enabled. All other
       allocators can be <seealso marker="#M_e">enabled or disabled</seealso>.
       By default all allocators are enabled.

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -251,7 +251,7 @@ endif
 HIPEBEAMLDFLAGS=$($(ARCH)BEAMLDFLAGS)
 endif
 
-ERTS_ENABLE_KERNEL_POLL=@ERTS_ENABLE_KERNEL_POLL@
+ERTS_BUILD_FALLBACK_POLL=@ERTS_BUILD_FALLBACK_POLL@
 
 #
 #
@@ -928,17 +928,15 @@ $(STATIC_NIF_LIBS) $(STATIC_DRIVER_LIBS):
 	echo "=== Leaving lib after making static libs"
 endif
 
-ifeq ($(ERTS_ENABLE_KERNEL_POLL),yes)
+ifeq ($(ERTS_BUILD_FALLBACK_POLL),yes)
 OS_OBJS += 	$(OBJDIR)/erl_poll.kp.o \
-		$(OBJDIR)/erl_check_io.kp.o \
-		$(OBJDIR)/erl_poll.nkp.o \
-		$(OBJDIR)/erl_check_io.nkp.o
+		$(OBJDIR)/erl_poll.nkp.o
 else
-OS_OBJS +=	$(OBJDIR)/erl_poll.o \
-		$(OBJDIR)/erl_check_io.o
+OS_OBJS +=	$(OBJDIR)/erl_poll.o
 endif
 
-OS_OBJS +=	$(OBJDIR)/erl_mseg.o \
+OS_OBJS +=	$(OBJDIR)/erl_check_io.o \
+		$(OBJDIR)/erl_mseg.o \
 		$(OBJDIR)/erl_mmap.o \
 		$(OBJDIR)/erl_$(ERLANG_OSTYPE)_sys_ddll.o \
 		$(OBJDIR)/erl_mtrace_sys_wrap.o \
@@ -1112,7 +1110,7 @@ else
 SED_PREFIX=
 endif
 
-ifeq ($(ERTS_ENABLE_KERNEL_POLL),yes)
+ifeq ($(ERTS_BUILD_FALLBACK_POLL),yes)
 SED_SUFFIX=;$(SED_REPL_POLL);$(SED_REPL_CHK_IO)
 else
 SED_SUFFIX=

--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -385,6 +385,7 @@ set_default_temp_alloc_opts(struct au_init *ip)
     SET_DEFAULT_ALLOC_OPTS(ip);
     ip->enable			= AU_ALLOC_DEFAULT_ENABLE(1);
     ip->thr_spec		= 1;
+    ip->disable_allowed         = 0;
     ip->carrier_migration_allowed = 0;
     ip->atype			= AFIT;
     ip->init.util.name_prefix	= "temp_";
@@ -1492,8 +1493,7 @@ handle_args(int *argc, char **argv, erts_alc_hndl_args_init_t *init)
 	&init->ll_alloc,
 	&init->driver_alloc,
 	&init->fix_alloc,
-	&init->sl_alloc,
-	&init->temp_alloc
+	&init->sl_alloc
 	/* test_alloc not affected by +Mea??? or +Mu???  */
     };
     int aui_sz = (int) sizeof(aui)/sizeof(aui[0]);

--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -644,8 +644,6 @@ erts_alloc_init(int *argc, char **argv, ErtsAllocInitOpts *eaiop)
 	= ERTS_MONITOR_SH_SIZE * sizeof(Uint);
     fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_NLINK_SH)]
 	= ERTS_LINK_SH_SIZE * sizeof(Uint);
-    fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_DRV_EV_D_STATE)]
-	= sizeof(ErtsDrvEventDataState);
     fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_DRV_SEL_D_STATE)]
 	= sizeof(ErtsDrvSelectDataState);
     fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_NIF_SEL_D_STATE)]

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -351,7 +351,6 @@ type	SYS_CHECK_REQ	SHORT_LIVED	SYSTEM		system_check_request
 type  	TEMP_TERM 	TEMPORARY	SYSTEM		temp_term
 type	DRV_TAB		LONG_LIVED	SYSTEM		drv_tab
 type	DRV_EV_STATE	LONG_LIVED	SYSTEM		driver_event_state
-type	DRV_EV_D_STATE	FIXED_SIZE	SYSTEM		driver_event_data_state
 type	DRV_SEL_D_STATE	FIXED_SIZE	SYSTEM		driver_select_data_state
 type	NIF_SEL_D_STATE	FIXED_SIZE	SYSTEM		enif_select_data_state
 type	FD_LIST		SHORT_LIVED	SYSTEM		fd_list

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -354,7 +354,6 @@ type	DRV_EV_STATE	LONG_LIVED	SYSTEM		driver_event_state
 type	DRV_SEL_D_STATE	FIXED_SIZE	SYSTEM		driver_select_data_state
 type	NIF_SEL_D_STATE	FIXED_SIZE	SYSTEM		enif_select_data_state
 type	FD_LIST		SHORT_LIVED	SYSTEM		fd_list
-type	ACTIVE_FD_ARR	SHORT_LIVED	SYSTEM		active_fd_array
 type	POLLSET		LONG_LIVED	SYSTEM		pollset
 type	POLLSET_UPDREQ	SHORT_LIVED	SYSTEM		pollset_update_req
 type	POLL_FDS	LONG_LIVED	SYSTEM		poll_fds

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2843,7 +2843,7 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 	BIF_RET(am_disabled);
     }
     else if (ERTS_IS_ATOM_STR("eager_check_io",BIF_ARG_1)) {
-	BIF_RET(erts_eager_check_io ? am_true : am_false);
+	BIF_RET(am_true);
     }
     else if (ERTS_IS_ATOM_STR("literal_test",BIF_ARG_1)) {
 #ifdef ERTS_HAVE_IS_IN_LITERAL_RANGE

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -98,9 +98,6 @@ static char erts_system_version[] = ("Erlang/OTP " ERLANG_OTP_RELEASE
 #ifdef HIPE
 				     " [hipe]"
 #endif	
-#ifdef ERTS_ENABLE_KERNEL_POLL
-				     " [kernel-poll:%s]"
-#endif	
 #ifdef ET_DEBUG
 #if ET_DEBUG
 				     " [type-assertions]"
@@ -372,9 +369,6 @@ erts_print_system_version(fmtfn_t to, void *arg, Process *c_p)
 		      , total, online
 		      , dirty_cpu, dirty_cpu_onln, dirty_io
 		      , erts_async_max_threads
-#ifdef ERTS_ENABLE_KERNEL_POLL
-		      , erts_use_kernel_poll ? "true" : "false"
-#endif
 	);
 }
 
@@ -2696,7 +2690,7 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 	BIF_RET(make_small(CONTEXT_REDS));
     } else if (ERTS_IS_ATOM_STR("kernel_poll", BIF_ARG_1)) {
 #ifdef ERTS_ENABLE_KERNEL_POLL
-	BIF_RET(erts_use_kernel_poll ? am_true : am_false);
+	BIF_RET(am_true);
 #else
 	BIF_RET(am_false);
 #endif    

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -46,6 +46,7 @@
 #include "erl_thr_progress.h"
 #include "erl_bif_unique.h"
 #include "erl_map.h"
+#include "erl_check_io.h"
 #define ERTS_PTAB_WANT_DEBUG_FUNCS__
 #include "erl_ptab.h"
 #include "erl_time.h"

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -3574,15 +3574,13 @@ BIF_RETTYPE erts_debug_get_internal_state_1(BIF_ALIST_1)
 	    szp = &sz;
 	    hpp = NULL;
 	    while (1) {
-		res = erts_bld_tuple(hpp, szp, 4,
+		res = erts_bld_tuple(hpp, szp, 3,
 				     erts_bld_uint(hpp, szp,
 						   (Uint) no_errors),
 				     erts_bld_uint(hpp, szp,
 						   (Uint) ciodi.no_used_fds),
 				     erts_bld_uint(hpp, szp,
-						   (Uint) ciodi.no_driver_select_structs),
-				     erts_bld_uint(hpp, szp,
-						   (Uint) ciodi.no_driver_event_structs));
+						   (Uint) ciodi.no_driver_select_structs));
 		if (hpp)
 		    break;
 		hp = HAlloc(BIF_P, sz);

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -3574,13 +3574,15 @@ BIF_RETTYPE erts_debug_get_internal_state_1(BIF_ALIST_1)
 	    szp = &sz;
 	    hpp = NULL;
 	    while (1) {
-		res = erts_bld_tuple(hpp, szp, 3,
+		res = erts_bld_tuple(hpp, szp, 4,
 				     erts_bld_uint(hpp, szp,
 						   (Uint) no_errors),
 				     erts_bld_uint(hpp, szp,
 						   (Uint) ciodi.no_used_fds),
 				     erts_bld_uint(hpp, szp,
-						   (Uint) ciodi.no_driver_select_structs));
+						   (Uint) ciodi.no_driver_select_structs),
+                                     erts_bld_uint(hpp, szp,
+                                                   (Uint) ciodi.no_enif_select_structs));
 		if (hpp)
 		    break;
 		hp = HAlloc(BIF_P, sz);

--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -148,14 +148,6 @@ typedef struct _erl_drv_event* ErlDrvEvent; /* An event to be selected on. */
 typedef struct _erl_drv_port* ErlDrvPort; /* A port descriptor. */
 typedef struct _erl_drv_port* ErlDrvThreadData; /* Thread data. */
 
-#if !defined(__WIN32__) && !defined(_WIN32) && !defined(_WIN32_) && !defined(USE_SELECT)
-struct erl_drv_event_data {
-    short events;
-    short revents;
-};
-#endif
-typedef struct erl_drv_event_data *ErlDrvEventData; /* Event data */
-
 typedef struct {
     unsigned long megasecs;
     unsigned long secs;
@@ -270,10 +262,7 @@ typedef struct erl_drv_entry {
 			 unsigned int *flags); /* Works mostly like 'control',
 						  a synchronous
 						  call into the driver. */
-    void (*event)(ErlDrvData drv_data, ErlDrvEvent event,
-		  ErlDrvEventData event_data);
-                                /* Called when an event selected by 
-				   driver_event() has occurred */
+    void (*unused_event_callback)(void);
     int extended_marker;	/* ERL_DRV_EXTENDED_MARKER */
     int major_version;		/* ERL_DRV_EXTENDED_MAJOR_VERSION */
     int minor_version;		/* ERL_DRV_EXTENDED_MINOR_VERSION */
@@ -340,8 +329,6 @@ EXTERN void erl_drv_busy_msgq_limits(ErlDrvPort port,
 				     ErlDrvSizeT *high);
 
 EXTERN int driver_select(ErlDrvPort port, ErlDrvEvent event, int mode, int on);
-EXTERN int driver_event(ErlDrvPort port, ErlDrvEvent event, 
-			ErlDrvEventData event_data);
 
 EXTERN int driver_output(ErlDrvPort port, char *buf, ErlDrvSizeT len);
 EXTERN int driver_output2(ErlDrvPort port, char *hbuf, ErlDrvSizeT hlen,

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -1748,22 +1748,9 @@ erl_start(int argc, char **argv)
 		    erts_usage();
 		}
 	    }
-	    else if (has_prefix("ecio", sub_param)) {
-		arg = get_arg(sub_param+4, argv[i+1], &i);
-#ifndef __OSE__
-		if (sys_strcmp("true", arg) == 0)
-		    erts_eager_check_io = 1;
-		else
-#endif
-		if (sys_strcmp("false", arg) == 0)
-		    erts_eager_check_io = 0;
-		else {
-		    erts_fprintf(stderr,
-				 "bad schedule eager check I/O value '%s'\n",
-				 arg);
-		    erts_usage();
-		}
-	    }
+            else if (has_prefix("ecio", sub_param)) {
+                /* ignore argument, eager check io no longer used */
+            }
 	    else if (has_prefix("pp", sub_param)) {
 		arg = get_arg(sub_param+2, argv[i+1], &i);
 		if (sys_strcmp(arg, "true") == 0)

--- a/erts/emulator/beam/erl_lock_check.c
+++ b/erts/emulator/beam/erl_lock_check.c
@@ -113,7 +113,6 @@ static erts_lc_lock_order_t erts_lock_order[] = {
     {	"drv_ev_state_grow",			NULL,   		},
     {	"drv_ev_state",				"address"		},
     {	"safe_hash",				"address"		},
-    {   "pollset_rm_list",                      NULL                    },
     {   "removed_fd_pre_alloc_lock",            "address"               },
     {   "state_prealloc",                       NULL                    },
     {	"schdlr_sspnd",				NULL			},

--- a/erts/emulator/beam/erl_lock_count.c
+++ b/erts/emulator/beam/erl_lock_count.c
@@ -554,16 +554,6 @@ erts_lock_flags_t erts_lcnt_get_category_mask() {
     return lcnt_category_mask__;
 }
 
-#ifdef ERTS_ENABLE_KERNEL_POLL
-/* erl_poll/erl_check_io only exports one of these variants at a time, and we
- * may need to use either one depending on emulator startup flags. */
-void erts_lcnt_update_pollset_locks_nkp(int);
-void erts_lcnt_update_pollset_locks_kp(int);
-
-void erts_lcnt_update_cio_locks_nkp(int);
-void erts_lcnt_update_cio_locks_kp(int);
-#endif
-
 void erts_lcnt_set_category_mask(erts_lock_flags_t mask) {
     erts_lock_flags_t changed_categories;
 
@@ -590,16 +580,6 @@ void erts_lcnt_set_category_mask(erts_lock_flags_t mask) {
     }
 
     if(changed_categories & ERTS_LOCK_FLAGS_CATEGORY_IO) {
-#ifdef ERTS_ENABLE_KERNEL_POLL
-        if(erts_use_kernel_poll) {
-            erts_lcnt_update_pollset_locks_kp(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
-        } else {
-            erts_lcnt_update_pollset_locks_nkp(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
-        }
-#else
-        erts_lcnt_update_pollset_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
-#endif
-
         erts_lcnt_update_cio_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
         erts_lcnt_update_driver_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
         erts_lcnt_update_port_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);

--- a/erts/emulator/beam/erl_lock_count.c
+++ b/erts/emulator/beam/erl_lock_count.c
@@ -593,16 +593,14 @@ void erts_lcnt_set_category_mask(erts_lock_flags_t mask) {
 #ifdef ERTS_ENABLE_KERNEL_POLL
         if(erts_use_kernel_poll) {
             erts_lcnt_update_pollset_locks_kp(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
-            erts_lcnt_update_cio_locks_kp(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
         } else {
             erts_lcnt_update_pollset_locks_nkp(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
-            erts_lcnt_update_cio_locks_nkp(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
         }
 #else
         erts_lcnt_update_pollset_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
-        erts_lcnt_update_cio_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
 #endif
 
+        erts_lcnt_update_cio_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
         erts_lcnt_update_driver_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
         erts_lcnt_update_port_locks(mask & ERTS_LOCK_FLAGS_CATEGORY_IO);
     }

--- a/erts/emulator/beam/erl_msacc.h
+++ b/erts/emulator/beam/erl_msacc.h
@@ -318,8 +318,8 @@ ERTS_GLB_INLINE
 void erts_msacc_set_state_um__(ErtsMsAcc *msacc, Uint new_state, int increment) {
     if (ERTS_UNLIKELY(msacc->unmanaged)) {
         erts_mtx_lock(&msacc->mtx);
-        msacc->state = new_state;
         if (ERTS_LIKELY(!msacc->perf_counter)) {
+            msacc->state = new_state;
             erts_mtx_unlock(&msacc->mtx);
             return;
         }

--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -36,6 +36,7 @@
 #include "erl_check_io.h"
 #include "dtrace-wrapper.h"
 #include "lttng-wrapper.h"
+#include "erl_check_io.h"
 #include <stdarg.h>
 
 /*

--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -582,12 +582,10 @@ static ERTS_INLINE void
 reset_executed_io_task_handle(ErtsPortTask *ptp)
 {
     if (ptp->u.alive.handle) {
-	ErtsIoTask *itp = ErtsContainerStruct(ptp->u.alive.handle, ErtsIoTask, task);
-
 	ASSERT(ptp == handle2task(ptp->u.alive.handle));
-	erts_io_notify_port_task_executed(ptp->u.alive.handle);
-	reset_port_task_handle(ptp->u.alive.handle);
-	erts_check_io_interrupt(itp->pollset, 1);
+        /* The port task handle is reset inside task_executed */
+	erts_io_notify_port_task_executed(ptp->type, ptp->u.alive.handle,
+                                          reset_port_task_handle);
     }
 }
 

--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -147,10 +147,10 @@ static void begin_port_cleanup(Port *pp,
 			       ErtsPortTask **execq,
 			       int *processing_busy_q_p);
 
-ERTS_SCHED_PREF_QUICK_ALLOC_IMPL(port_task,
-				 ErtsPortTask,
-				 1000,
-				 ERTS_ALC_T_PORT_TASK)
+ERTS_THR_PREF_QUICK_ALLOC_IMPL(port_task,
+                               ErtsPortTask,
+                               1000,
+                               ERTS_ALC_T_PORT_TASK)
 
 ERTS_SCHED_PREF_QUICK_ALLOC_IMPL(busy_caller_table,
 				 ErtsPortTaskBusyCallerTable,
@@ -2096,6 +2096,7 @@ erts_dequeue_port(ErtsRunQueue *rq)
 void
 erts_port_task_init(void)
 {
-    init_port_task_alloc();
+    init_port_task_alloc(erts_no_schedulers + erts_no_poll_threads
+                         + 1); /* aux_thread */
     init_busy_caller_table_alloc();
 }

--- a/erts/emulator/beam/erl_port_task.h
+++ b/erts/emulator/beam/erl_port_task.h
@@ -61,11 +61,6 @@ typedef enum {
     ERTS_PORT_TASK_PROC_SIG
 } ErtsPortTaskType;
 
-#ifdef ERTS_INCLUDE_SCHEDULER_INTERNALS
-/* NOTE: Do not access any of the exported variables directly */
-extern erts_atomic_t erts_port_task_outstanding_io_tasks;
-#endif
-
 #define ERTS_PTS_FLG_IN_RUNQ			(((erts_aint32_t) 1) <<  0)
 #define ERTS_PTS_FLG_EXEC			(((erts_aint32_t) 1) <<  1)
 #define ERTS_PTS_FLG_HAVE_TASKS			(((erts_aint32_t) 1) <<  2)
@@ -138,10 +133,6 @@ ERTS_GLB_INLINE void erts_port_task_sched_lock(ErtsPortTaskSched *ptsp);
 ERTS_GLB_INLINE void erts_port_task_sched_unlock(ErtsPortTaskSched *ptsp);
 ERTS_GLB_INLINE int erts_port_task_sched_lock_is_locked(ErtsPortTaskSched *ptsp);
 ERTS_GLB_INLINE void erts_port_task_sched_enter_exiting_state(ErtsPortTaskSched *ptsp);
-
-#ifdef ERTS_INCLUDE_SCHEDULER_INTERNALS
-ERTS_GLB_INLINE int erts_port_task_have_outstanding_io_tasks(void);
-#endif
 
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 
@@ -220,21 +211,10 @@ erts_port_task_sched_enter_exiting_state(ErtsPortTaskSched *ptsp)
     erts_atomic32_read_bor_nob(&ptsp->flags, ERTS_PTS_FLG_EXITING);
 }
 
-#ifdef ERTS_INCLUDE_SCHEDULER_INTERNALS
-
-ERTS_GLB_INLINE int
-erts_port_task_have_outstanding_io_tasks(void)
-{
-    return (erts_atomic_read_acqb(&erts_port_task_outstanding_io_tasks)
-	    != 0);
-}
-
-#endif /* ERTS_INCLUDE_SCHEDULER_INTERNALS */
-
 #endif
 
 #ifdef ERTS_INCLUDE_SCHEDULER_INTERNALS
-int erts_port_task_execute(ErtsRunQueue *, Port **);
+void erts_port_task_execute(ErtsRunQueue *, Port **);
 void erts_port_task_init(void);
 #endif
 

--- a/erts/emulator/beam/erl_port_task.h
+++ b/erts/emulator/beam/erl_port_task.h
@@ -56,7 +56,6 @@ typedef erts_atomic_t ErtsPortTaskHandle;
 typedef enum {
     ERTS_PORT_TASK_INPUT,
     ERTS_PORT_TASK_OUTPUT,
-    ERTS_PORT_TASK_EVENT,
     ERTS_PORT_TASK_TIMEOUT,
     ERTS_PORT_TASK_DIST_CMD,
     ERTS_PORT_TASK_PROC_SIG

--- a/erts/emulator/beam/erl_port_task.h
+++ b/erts/emulator/beam/erl_port_task.h
@@ -218,6 +218,9 @@ void erts_port_task_execute(ErtsRunQueue *, Port **);
 void erts_port_task_init(void);
 #endif
 
+/* generated for 'port_task' quick allocator */
+void erts_port_task_pre_alloc_init_thread(void);
+
 void erts_port_task_tmp_handle_detach(ErtsPortTaskHandle *);
 int erts_port_task_abort(ErtsPortTaskHandle *);
 

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -199,7 +199,7 @@ int erts_dio_sched_thread_suggested_stack_size = -1;
 ErtsLcPSDLocks erts_psd_required_locks[ERTS_PSD_SIZE];
 #endif
 
-static struct {
+static struct ErtsSchedBusyWait_ {
     int aux_work;
     int tse;
     int sys_schedule;
@@ -214,19 +214,19 @@ static ErtsAuxWorkData *aux_thread_aux_work_data;
 #define ERTS_SCHDLR_SSPND_CHNG_ONLN		(((erts_aint32_t) 1) << 2)
 #define ERTS_SCHDLR_SSPND_CHNG_DCPU_ONLN	(((erts_aint32_t) 1) << 3)
 
-typedef struct {
+typedef struct ErtsMultiSchedulingBlock_ {
     int ongoing;
     ErtsProcList *blckrs;
     ErtsProcList *chngq;
 } ErtsMultiSchedulingBlock;
 
-typedef struct {
+typedef struct ErtsSchedTypeCounters_ {
     Uint32 normal;
     Uint32 dirty_cpu;
     Uint32 dirty_io;
 } ErtsSchedTypeCounters;
 
-static struct {
+static struct ErtsSchedSuspend_ {
     erts_mtx_t mtx;
     ErtsSchedTypeCounters online;
     ErtsSchedTypeCounters curr_online;
@@ -1136,13 +1136,11 @@ dirty_sched_wall_time_change(ErtsSchedulerData *esdp, int working)
     mod++;
     erts_atomic32_set_nob(&esdp->sched_wall_time.u.mod, mod);
 
-#if 0
     if (!working) {
-        ERTS_MSACC_SET_STATE_M_X(ERTS_MSACC_STATE_BUSY_WAIT);
+        ERTS_MSACC_SET_STATE_X(ERTS_MSACC_STATE_BUSY_WAIT);
     } else {
-        ERTS_MSACC_SET_STATE_M_X(ERTS_MSACC_STATE_OTHER);
+        ERTS_MSACC_SET_STATE_X(ERTS_MSACC_STATE_OTHER);
     }
-#endif
 }
 
 

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -24,6 +24,8 @@
 #  include "config.h"
 #endif
 
+#define ERTS_WANT_BREAK_HANDLING
+
 #include <stddef.h> /* offsetof() */
 #include "sys.h"
 #include "erl_vm.h"
@@ -50,6 +52,7 @@
 #include "erl_time.h"
 #include "erl_nfunc_sched.h"
 #include "erl_check_io.h"
+#include "erl_poll.h"
 
 #define ERTS_CHECK_TIME_REDS CONTEXT_REDS
 #define ERTS_DELAYED_WAKEUP_INFINITY (~(Uint64) 0)
@@ -208,6 +211,7 @@ static struct ErtsSchedBusyWait_ {
 int erts_disable_proc_not_running_opt;
 
 static ErtsAuxWorkData *aux_thread_aux_work_data;
+static ErtsAuxWorkData *poll_thread_aux_work_data;
 
 #define ERTS_SCHDLR_SSPND_CHNG_NMSB		(((erts_aint32_t) 1) << 0)
 #define ERTS_SCHDLR_SSPND_CHNG_MSB		(((erts_aint32_t) 1) << 1)
@@ -432,6 +436,7 @@ typedef union {
 static ErtsAlignedSchedulerSleepInfo *aligned_sched_sleep_info;
 static ErtsAlignedSchedulerSleepInfo *aligned_dirty_cpu_sched_sleep_info;
 static ErtsAlignedSchedulerSleepInfo *aligned_dirty_io_sched_sleep_info;
+static ErtsAlignedSchedulerSleepInfo *aligned_poll_thread_sleep_info;
 
 static Uint last_reductions;
 static Uint last_exact_reductions;
@@ -499,9 +504,13 @@ ERTS_SCHED_PREF_QUICK_ALLOC_IMPL(proclist,
 				 200,
 				 ERTS_ALC_T_PROC_LIST)
 
+#define ERTS_POLL_THREAD_SLEEP_INFO_IX(IX)                              \
+        (ASSERT(0 <= ((int) (IX))                                       \
+                && ((int) (IX)) < ((int) erts_no_poll_threads)),        \
+         &aligned_poll_thread_sleep_info[(IX)].ssi)
 #define ERTS_SCHED_SLEEP_INFO_IX(IX)					\
-    (ASSERT(-1 <= ((int) (IX))					        \
-		 && ((int) (IX)) < ((int) erts_no_schedulers)),		\
+    (ASSERT(((int)-1) <= ((int) (IX))                 \
+            && ((int) (IX)) < ((int) erts_no_schedulers)),		\
      &aligned_sched_sleep_info[(IX)].ssi)
 #define ERTS_DIRTY_CPU_SCHED_SLEEP_INFO_IX(IX)				\
     (ASSERT(0 <= ((int) (IX))					        \
@@ -1560,14 +1569,14 @@ erts_sched_finish_poke(ErtsSchedulerSleepInfo *ssi,
 {
     switch (flags & ERTS_SSI_FLGS_SLEEP_TYPE) {
     case ERTS_SSI_FLG_POLL_SLEEPING:
-	erts_check_io_interrupt(ssi->esdp->pollset, 1);
+	erts_check_io_interrupt(ssi->psi, 1);
 	break;
     case ERTS_SSI_FLG_POLL_SLEEPING|ERTS_SSI_FLG_TSE_SLEEPING:
 	/*
 	 * Thread progress blocking while poll sleeping; need
 	 * to signal on both...
 	 */
-	erts_check_io_interrupt(ssi->esdp->pollset, 1);
+	erts_check_io_interrupt(ssi->psi, 1);
 	/* fall through */
     case ERTS_SSI_FLG_TSE_SLEEPING:
 	erts_tse_set(ssi->event);
@@ -2827,36 +2836,6 @@ erts_set_aux_work_timeout(int ix, erts_aint32_t type, int enable)
     return old;
 }
 
-
-
-static ERTS_INLINE void
-sched_waiting_sys(Uint no, ErtsRunQueue *rq)
-{
-    ERTS_LC_ASSERT(erts_lc_runq_is_locked(rq));
-    ASSERT(rq->waiting >= 0);
-    (void) ERTS_RUNQ_FLGS_SET(rq, (ERTS_RUNQ_FLG_OUT_OF_WORK
-				   | ERTS_RUNQ_FLG_HALFTIME_OUT_OF_WORK));
-    rq->waiting++;
-    rq->waiting *= -1;
-    rq->woken = 0;
-    if (erts_system_profile_flags.scheduler)
-	profile_scheduler(make_small(no), am_inactive);
-}
-
-static ERTS_INLINE void
-sched_active_sys(Uint no, ErtsRunQueue *rq)
-{
-    ERTS_LC_ASSERT(erts_lc_runq_is_locked(rq));
-
-    ASSERT(!ERTS_RUNQ_IX_IS_DIRTY(rq->ix));
-
-    ASSERT(rq->waiting < 0);
-    rq->waiting *= -1;
-    rq->waiting--;
-    if (erts_system_profile_flags.scheduler)
-	profile_scheduler(make_small(no), am_active);
-}
-
 Uint
 erts_active_schedulers(void)
 {
@@ -2866,13 +2845,6 @@ erts_active_schedulers(void)
 
     return as;
 }
-
-static ERTS_INLINE int
-prepare_for_sys_schedule(int non_blocking)
-{
-    return 1;
-}
-
 
 static ERTS_INLINE void
 sched_waiting(Uint no, ErtsRunQueue *rq)
@@ -3045,7 +3017,7 @@ sched_set_sleeptype(ErtsSchedulerSleepInfo *ssi, erts_aint32_t sleep_type)
 	erts_tse_reset(ssi->event);
     else {
 	ASSERT(sleep_type == ERTS_SSI_FLG_POLL_SLEEPING);
-	erts_check_io_interrupt(ssi->esdp->pollset, 0);
+        erts_check_io_interrupt(ssi->psi, 0);
     }
 
     while (1) {
@@ -3113,6 +3085,12 @@ thr_prgr_fin_wait(void *vssi)
 
 static void init_aux_work_data(ErtsAuxWorkData *awdp, ErtsSchedulerData *esdp, char *dawwp);
 
+void
+erts_aux_thread_poke()
+{
+    erts_sched_poke(ERTS_SCHED_SLEEP_INFO_IX(-1));
+}
+
 static void *
 aux_thread(void *unused)
 {
@@ -3121,6 +3099,7 @@ aux_thread(void *unused)
     erts_aint32_t aux_work;
     ErtsThrPrgrCallbacks callbacks;
     int thr_prgr_active = 1;
+    ERTS_MSACC_DECLARE_CACHE();
 
 #ifdef ERTS_ENABLE_LOCK_CHECK
     {
@@ -3144,8 +3123,13 @@ aux_thread(void *unused)
     init_aux_work_data(awdp, NULL, NULL);
     awdp->ssi = ssi;
 
+#if ERTS_POLL_USE_FALLBACK
+    ssi->psi = erts_create_pollset_thread(-1);
+#endif
 
     sched_prep_spin_wait(ssi);
+
+    ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_OTHER);
 
     while (1) {
 	erts_aint32_t flgs;
@@ -3155,6 +3139,109 @@ aux_thread(void *unused)
 	    if (!thr_prgr_active)
 		erts_thr_progress_active(NULL, thr_prgr_active = 1);
 	    aux_work = handle_aux_work(awdp, aux_work, 1);
+            ERTS_MSACC_UPDATE_CACHE();
+	    if (aux_work && erts_thr_progress_update(NULL))
+		erts_thr_progress_leader_update(NULL);
+	}
+
+	if (!aux_work) {
+
+#ifdef ERTS_BREAK_REQUESTED
+            if (ERTS_BREAK_REQUESTED)
+                erts_do_break_handling();
+#endif
+
+	    if (thr_prgr_active)
+		erts_thr_progress_active(NULL, thr_prgr_active = 0);
+
+#if ERTS_POLL_USE_FALLBACK
+
+	    flgs = sched_spin_wait(ssi, 0);
+
+	    if (flgs & ERTS_SSI_FLG_SLEEPING) {
+		ASSERT(flgs & ERTS_SSI_FLG_WAITING);
+		flgs = sched_set_sleeptype(ssi, ERTS_SSI_FLG_POLL_SLEEPING);
+		if (flgs & ERTS_SSI_FLG_SLEEPING) {
+		    ASSERT(flgs & ERTS_SSI_FLG_POLL_SLEEPING);
+		    ASSERT(flgs & ERTS_SSI_FLG_WAITING);
+                    erts_check_io(ssi->psi);
+		}
+            }
+#else
+            erts_thr_progress_prepare_wait(NULL);
+
+	    flgs = sched_spin_wait(ssi, 0);
+
+	    if (flgs & ERTS_SSI_FLG_SLEEPING) {
+		flgs = sched_set_sleeptype(ssi, ERTS_SSI_FLG_TSE_SLEEPING);
+		if (flgs & ERTS_SSI_FLG_SLEEPING) {
+                    int res;
+		    ASSERT(flgs & ERTS_SSI_FLG_TSE_SLEEPING);
+		    ASSERT(flgs & ERTS_SSI_FLG_WAITING);
+                    ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_SLEEP);
+                    do {
+                        res = erts_tse_wait(ssi->event);
+                    } while (res == EINTR);
+                    ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_OTHER);
+		}
+            }
+            erts_thr_progress_finalize_wait(NULL);
+#endif
+	}
+
+	flgs = sched_prep_spin_wait(ssi);
+    }
+    return NULL;
+}
+
+static void *
+poll_thread(void *arg)
+{
+    int id = (int)(UWord)arg;
+    ErtsAuxWorkData *awdp = poll_thread_aux_work_data+id;
+    ErtsSchedulerSleepInfo *ssi = ERTS_POLL_THREAD_SLEEP_INFO_IX(id);
+    erts_aint32_t aux_work;
+    ErtsThrPrgrCallbacks callbacks;
+    int thr_prgr_active = 1;
+    struct erts_poll_thread *psi = erts_create_pollset_thread(id);
+    ERTS_MSACC_DECLARE_CACHE();
+
+#ifdef ERTS_ENABLE_LOCK_CHECK
+    {
+	char buf[] = "poll_thread";
+	erts_lc_set_thread_name(buf);
+    }
+#endif
+
+    erts_port_task_pre_alloc_init_thread();
+    ssi->event = erts_tse_fetch();
+
+    erts_msacc_init_thread("poll", id, 0);
+
+    callbacks.arg = (void *) ssi;
+    callbacks.wakeup = thr_prgr_wakeup;
+    callbacks.prepare_wait = thr_prgr_prep_wait;
+    callbacks.wait = thr_prgr_wait;
+    callbacks.finalize_wait = thr_prgr_fin_wait;
+
+    erts_thr_progress_register_managed_thread(NULL, &callbacks, 0);
+    init_aux_work_data(awdp, NULL, NULL);
+    awdp->ssi = ssi;
+    ssi->psi = psi;
+
+    sched_prep_spin_wait(ssi);
+
+    ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_OTHER);
+
+    while (1) {
+	erts_aint32_t flgs;
+
+	aux_work = erts_atomic32_read_acqb(&ssi->aux_work);
+	if (aux_work) {
+	    if (!thr_prgr_active)
+		erts_thr_progress_active(NULL, thr_prgr_active = 1);
+	    aux_work = handle_aux_work(awdp, aux_work, 1);
+            ERTS_MSACC_UPDATE_CACHE();
 	    if (aux_work && erts_thr_progress_update(NULL))
 		erts_thr_progress_leader_update(NULL);
 	}
@@ -3162,23 +3249,18 @@ aux_thread(void *unused)
 	if (!aux_work) {
 	    if (thr_prgr_active)
 		erts_thr_progress_active(NULL, thr_prgr_active = 0);
-	    erts_thr_progress_prepare_wait(NULL);
 
 	    flgs = sched_spin_wait(ssi, 0);
 
 	    if (flgs & ERTS_SSI_FLG_SLEEPING) {
 		ASSERT(flgs & ERTS_SSI_FLG_WAITING);
-		flgs = sched_set_sleeptype(ssi, ERTS_SSI_FLG_TSE_SLEEPING);
+		flgs = sched_set_sleeptype(ssi, ERTS_SSI_FLG_POLL_SLEEPING);
 		if (flgs & ERTS_SSI_FLG_SLEEPING) {
-		    int res;
-		    ASSERT(flgs & ERTS_SSI_FLG_TSE_SLEEPING);
+		    ASSERT(flgs & ERTS_SSI_FLG_POLL_SLEEPING);
 		    ASSERT(flgs & ERTS_SSI_FLG_WAITING);
-		    do {
-			res = erts_tse_wait(ssi->event);
-		    } while (res == EINTR);
+                    erts_check_io(psi);
 		}
 	    }
-	    erts_thr_progress_finalize_wait(NULL);
 	}
 
 	flgs = sched_prep_spin_wait(ssi);
@@ -3219,272 +3301,135 @@ scheduler_wait(int *fcalls, ErtsSchedulerData *esdp, ErtsRunQueue *rq)
         dirty_active(esdp, -1);
     }
 
-    /*
-     * If all schedulers are waiting, one of them *should*
-     * be waiting in erl_sys_schedule()
-     */
+    sched_waiting(esdp->no, rq);
 
-    if (ERTS_SCHEDULER_IS_DIRTY(esdp) || !prepare_for_sys_schedule(0)) {
+    erts_runq_unlock(rq);
 
-	sched_waiting(esdp->no, rq);
+    spincount = sched_busy_wait.tse;
 
-	erts_runq_unlock(rq);
+    if (ERTS_SCHEDULER_IS_DIRTY(esdp))
+        dirty_sched_wall_time_change(esdp, working = 0);
+    else if (thr_prgr_active != working)
+        sched_wall_time_change(esdp, working = thr_prgr_active);
 
-	spincount = sched_busy_wait.tse;
+    while (1) {
+        ErtsMonotonicTime current_time = 0;
 
-	if (ERTS_SCHEDULER_IS_DIRTY(esdp))
-	    dirty_sched_wall_time_change(esdp, working = 0);
-        else if (thr_prgr_active != working)
-	    sched_wall_time_change(esdp, working = thr_prgr_active);
-
-	while (1) {
-	    ErtsMonotonicTime current_time = 0;
-
-	    aux_work = erts_atomic32_read_acqb(&ssi->aux_work);
-	    if (aux_work && !ERTS_SCHEDULER_IS_DIRTY(esdp)) {
-		if (!thr_prgr_active) {
-		    erts_thr_progress_active(esdp, thr_prgr_active = 1);
-		    sched_wall_time_change(esdp, 1);
-		}
-		aux_work = handle_aux_work(&esdp->aux_work_data, aux_work, 1);
-                ERTS_MSACC_UPDATE_CACHE();
-		if (aux_work && erts_thr_progress_update(esdp))
-		    erts_thr_progress_leader_update(esdp);
-	    }
-
-	    if (aux_work) {
-		if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
-		    flgs = erts_atomic32_read_acqb(&ssi->flags);
-		    current_time = erts_get_monotonic_time(esdp);
-		    if (current_time >= erts_next_timeout_time(esdp->next_tmo_ref)) {
-			if (!thr_prgr_active) {
-			    erts_thr_progress_active(esdp, thr_prgr_active = 1);
-			    sched_wall_time_change(esdp, 1);
-			}
-			erts_bump_timers(esdp->timer_wheel, current_time);
-		    }
-		}
-	    }
-	    else {
-		ErtsMonotonicTime timeout_time;
-		int do_timeout = 0;
-		if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
-		    timeout_time = erts_check_next_timeout_time(esdp);
-		    current_time = erts_get_monotonic_time(esdp);
-		    do_timeout = (current_time >= timeout_time);
-		} else {
-		    current_time = 0;
-		    timeout_time = ERTS_MONOTONIC_TIME_MAX;
-		}
-		if (do_timeout) {
-		    if (!thr_prgr_active) {
-			erts_thr_progress_active(esdp, thr_prgr_active = 1);
-			sched_wall_time_change(esdp, 1);
-		    }
-		}
-		else {
-		    if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
-			if (thr_prgr_active) {
-			    erts_thr_progress_active(esdp, thr_prgr_active = 0);
-			    sched_wall_time_change(esdp, 0);
-			}
-			erts_thr_progress_prepare_wait(esdp);
-		    }
-
-		    flgs = sched_spin_wait(ssi, spincount);
-		    if (flgs & ERTS_SSI_FLG_SLEEPING) {
-			ASSERT(flgs & ERTS_SSI_FLG_WAITING);
-			flgs = sched_set_sleeptype(ssi, ERTS_SSI_FLG_TSE_SLEEPING);
-			if (flgs & ERTS_SSI_FLG_SLEEPING) {
-			    int res;
-			    ASSERT(flgs & ERTS_SSI_FLG_TSE_SLEEPING);
-			    ASSERT(flgs & ERTS_SSI_FLG_WAITING);
-			    current_time = ERTS_SCHEDULER_IS_DIRTY(esdp) ? 0 :
-				erts_get_monotonic_time(esdp);
-			    do {
-				Sint64 timeout;
-				if (current_time >= timeout_time)
-				    break;
-				if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
-				    timeout = ERTS_MONOTONIC_TO_NSEC(timeout_time
-								     - current_time
-								     - 1) + 1;
-				} else
-				    timeout = -1;
-                                ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
-				res = erts_tse_twait(ssi->event, timeout);
-                                ERTS_MSACC_POP_STATE_M();
-				current_time = ERTS_SCHEDULER_IS_DIRTY(esdp) ? 0 :
-				    erts_get_monotonic_time(esdp);
-			    } while (res == EINTR);
-			}
-		    }
-		    if (!ERTS_SCHEDULER_IS_DIRTY(esdp))
-			erts_thr_progress_finalize_wait(esdp);
-		}
-		if (!ERTS_SCHEDULER_IS_DIRTY(esdp) && current_time >= timeout_time)
-		    erts_bump_timers(esdp->timer_wheel, current_time);
-	    }
-
-	    if (!(flgs & ERTS_SSI_FLG_WAITING)) {
-		ASSERT(!(flgs & ERTS_SSI_FLG_SLEEPING));
-		break;
-	    }
-
-	    flgs = sched_prep_cont_spin_wait(ssi);
-	    spincount = sched_busy_wait.aux_work;
-
-	    if (!(flgs & ERTS_SSI_FLG_WAITING)) {
-		ASSERT(!(flgs & ERTS_SSI_FLG_SLEEPING));
-		break;
-	    }
-
-	}
-
-	if (flgs & ~(ERTS_SSI_FLG_SUSPENDED|ERTS_SSI_FLG_MSB_EXEC))
-	    erts_atomic32_read_band_nob(&ssi->flags,
-                                            (ERTS_SSI_FLG_SUSPENDED
-                                             | ERTS_SSI_FLG_MSB_EXEC));
-
-	if (ERTS_SCHEDULER_IS_DIRTY(esdp))
-	    dirty_sched_wall_time_change(esdp, working = 1);
-        else if (!thr_prgr_active) {
-	    erts_thr_progress_active(esdp, thr_prgr_active = 1);
-	    sched_wall_time_change(esdp, 1);
+        aux_work = erts_atomic32_read_acqb(&ssi->aux_work);
+        if (aux_work && !ERTS_SCHEDULER_IS_DIRTY(esdp)) {
+            if (!thr_prgr_active) {
+                erts_thr_progress_active(esdp, thr_prgr_active = 1);
+                sched_wall_time_change(esdp, 1);
+            }
+            aux_work = handle_aux_work(&esdp->aux_work_data, aux_work, 1);
+            ERTS_MSACC_UPDATE_CACHE();
+            if (aux_work && erts_thr_progress_update(esdp))
+                erts_thr_progress_leader_update(esdp);
         }
 
-	erts_runq_lock(rq);
-	sched_active(esdp->no, rq);
+        if (aux_work) {
+            if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
+                flgs = erts_atomic32_read_acqb(&ssi->flags);
+                current_time = erts_get_monotonic_time(esdp);
+                if (current_time >= erts_next_timeout_time(esdp->next_tmo_ref)) {
+                    if (!thr_prgr_active) {
+                        erts_thr_progress_active(esdp, thr_prgr_active = 1);
+                        sched_wall_time_change(esdp, 1);
+                    }
+                    erts_bump_timers(esdp->timer_wheel, current_time);
+                }
+            }
+        }
+        else {
+            ErtsMonotonicTime timeout_time;
+            int do_timeout = 0;
+            if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
+                timeout_time = erts_check_next_timeout_time(esdp);
+                current_time = erts_get_monotonic_time(esdp);
+                do_timeout = (current_time >= timeout_time);
+            } else {
+                current_time = 0;
+                timeout_time = ERTS_MONOTONIC_TIME_MAX;
+            }
+            if (do_timeout) {
+                if (!thr_prgr_active) {
+                    erts_thr_progress_active(esdp, thr_prgr_active = 1);
+                    sched_wall_time_change(esdp, 1);
+                }
+            }
+            else {
+                if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
+                    if (thr_prgr_active) {
+                        erts_thr_progress_active(esdp, thr_prgr_active = 0);
+                        sched_wall_time_change(esdp, 0);
+                    }
+                    erts_thr_progress_prepare_wait(esdp);
+                }
+
+                flgs = sched_spin_wait(ssi, spincount);
+                if (flgs & ERTS_SSI_FLG_SLEEPING) {
+                    ASSERT(flgs & ERTS_SSI_FLG_WAITING);
+                    flgs = sched_set_sleeptype(ssi, ERTS_SSI_FLG_TSE_SLEEPING);
+                    if (flgs & ERTS_SSI_FLG_SLEEPING) {
+                        int res;
+                        ASSERT(flgs & ERTS_SSI_FLG_TSE_SLEEPING);
+                        ASSERT(flgs & ERTS_SSI_FLG_WAITING);
+                        current_time = ERTS_SCHEDULER_IS_DIRTY(esdp) ? 0 :
+                            erts_get_monotonic_time(esdp);
+                        do {
+                            Sint64 timeout;
+                            if (current_time >= timeout_time)
+                                break;
+                            if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
+                                timeout = ERTS_MONOTONIC_TO_NSEC(timeout_time
+                                                                 - current_time
+                                                                 - 1) + 1;
+                            } else
+                                timeout = -1;
+                            ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
+                            res = erts_tse_twait(ssi->event, timeout);
+                            ERTS_MSACC_POP_STATE_M();
+                            current_time = ERTS_SCHEDULER_IS_DIRTY(esdp) ? 0 :
+                                erts_get_monotonic_time(esdp);
+                        } while (res == EINTR);
+                    }
+                }
+                if (!ERTS_SCHEDULER_IS_DIRTY(esdp))
+                    erts_thr_progress_finalize_wait(esdp);
+            }
+            if (!ERTS_SCHEDULER_IS_DIRTY(esdp) && current_time >= timeout_time)
+                erts_bump_timers(esdp->timer_wheel, current_time);
+        }
+
+        if (!(flgs & ERTS_SSI_FLG_WAITING)) {
+            ASSERT(!(flgs & ERTS_SSI_FLG_SLEEPING));
+            break;
+        }
+
+        flgs = sched_prep_cont_spin_wait(ssi);
+        spincount = sched_busy_wait.aux_work;
+
+        if (!(flgs & ERTS_SSI_FLG_WAITING)) {
+            ASSERT(!(flgs & ERTS_SSI_FLG_SLEEPING));
+            break;
+        }
 
     }
-    else
-    {
 
-	esdp->function_calls = 0;
-	*fcalls = 0;
+    if (flgs & ~(ERTS_SSI_FLG_SUSPENDED|ERTS_SSI_FLG_MSB_EXEC))
+        erts_atomic32_read_band_nob(&ssi->flags,
+                                        (ERTS_SSI_FLG_SUSPENDED
+                                         | ERTS_SSI_FLG_MSB_EXEC));
 
-	ASSERT(!ERTS_SCHEDULER_IS_DIRTY(esdp));
-
-	sched_waiting_sys(esdp->no, rq);
-
-	erts_runq_unlock(rq);
-
-	ASSERT(working);
-	sched_wall_time_change(esdp, working = 0);
-
-	spincount = sched_busy_wait.sys_schedule;
-	if (spincount == 0)
-	    goto sys_aux_work;
-
-	while (spincount-- > 0) {
-	    ErtsMonotonicTime current_time;
-
-	sys_poll_aux_work:
-
-	    if (working)
-		sched_wall_time_change(esdp, working = 0);
-
-	    ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_CHECK_IO);
-
-            LTTNG2(scheduler_poll, esdp->no, 1);
-	    erl_sys_schedule(1); /* Might give us something to do */
-
-	    ERTS_MSACC_POP_STATE_M();
-
-	    if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
-		current_time = erts_get_monotonic_time(esdp);
-		if (current_time >= erts_next_timeout_time(esdp->next_tmo_ref))
-		    erts_bump_timers(esdp->timer_wheel, current_time);
-	    }
-
-	sys_aux_work:
-
-	    aux_work = erts_atomic32_read_acqb(&ssi->aux_work);
-	    if (aux_work && !ERTS_SCHEDULER_IS_DIRTY(esdp)) {
-		if (!working)
-		    sched_wall_time_change(esdp, working = 1);
-		if (!thr_prgr_active)
-		    erts_thr_progress_active(esdp, thr_prgr_active = 1);
-		aux_work = handle_aux_work(&esdp->aux_work_data, aux_work, 1);
-                ERTS_MSACC_UPDATE_CACHE();
-		if (aux_work && erts_thr_progress_update(esdp))
-		    erts_thr_progress_leader_update(esdp);
-	    }
-
-	    flgs = erts_atomic32_read_acqb(&ssi->flags);
-	    if (!(flgs & ERTS_SSI_FLG_WAITING)) {
-		ASSERT(!(flgs & ERTS_SSI_FLG_SLEEPING));
-		goto sys_woken;
-	    }
-	}
-
-	erts_runq_lock(rq);
-
-	if (aux_work) {
-	    erts_runq_unlock(rq);
-	    goto sys_poll_aux_work;
-	}
-	flgs = sched_set_sleeptype(ssi, ERTS_SSI_FLG_POLL_SLEEPING);
-	if (!(flgs & ERTS_SSI_FLG_SLEEPING)) {
-	    if (!(flgs & ERTS_SSI_FLG_WAITING)) {
-		ASSERT(!(flgs & ERTS_SSI_FLG_SLEEPING));
-		goto sys_locked_woken;
-	    }
-	    erts_runq_unlock(rq);
-	    flgs = sched_prep_cont_spin_wait(ssi);
-	    if (!(flgs & ERTS_SSI_FLG_WAITING)) {
-		ASSERT(!(flgs & ERTS_SSI_FLG_SLEEPING));
-		goto sys_woken;
-	    }
-	    goto sys_poll_aux_work;
-	}
-
-	ASSERT(flgs & ERTS_SSI_FLG_POLL_SLEEPING);
-	ASSERT(flgs & ERTS_SSI_FLG_WAITING);
-
-	erts_runq_unlock(rq);
-
-	if (working)
-	    sched_wall_time_change(esdp, working = 0);
-
-	if (thr_prgr_active)
-	    erts_thr_progress_active(esdp, thr_prgr_active = 0);
-
-	ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_CHECK_IO);
-        LTTNG2(scheduler_poll, esdp->no, 0);
-
-	erl_sys_schedule(0);
-
-	ERTS_MSACC_POP_STATE_M();
-
-	if (!ERTS_SCHEDULER_IS_DIRTY(esdp)) {
-	    ErtsMonotonicTime current_time = erts_get_monotonic_time(esdp);
-	    if (current_time >= erts_next_timeout_time(esdp->next_tmo_ref))
-		erts_bump_timers(esdp->timer_wheel, current_time);
-	}
-
-	flgs = sched_prep_cont_spin_wait(ssi);
-	if (flgs & ERTS_SSI_FLG_WAITING)
-	    goto sys_aux_work;
-
-    sys_woken:
-	if (!thr_prgr_active)
-	    erts_thr_progress_active(esdp, thr_prgr_active = 1);
-	erts_runq_lock(rq);
-    sys_locked_woken:
-	if (!thr_prgr_active) {
-	    erts_runq_unlock(rq);
-	    erts_thr_progress_active(esdp, thr_prgr_active = 1);
-	    erts_runq_lock(rq);
-	}
-	if (flgs & ~(ERTS_SSI_FLG_SUSPENDED|ERTS_SSI_FLG_MSB_EXEC))
-	    erts_atomic32_read_band_nob(&ssi->flags,
-                                            (ERTS_SSI_FLG_SUSPENDED
-                                             | ERTS_SSI_FLG_MSB_EXEC));
-	if (!working)
-	    sched_wall_time_change(esdp, working = 1);
-	sched_active_sys(esdp->no, rq);
+    if (ERTS_SCHEDULER_IS_DIRTY(esdp))
+        dirty_sched_wall_time_change(esdp, working = 1);
+    else if (!thr_prgr_active) {
+        erts_thr_progress_active(esdp, thr_prgr_active = 1);
+        sched_wall_time_change(esdp, 1);
     }
+
+    erts_runq_lock(rq);
+    sched_active(esdp->no, rq);
 
     if (ERTS_SCHEDULER_IS_DIRTY(esdp))
         dirty_active(esdp, 1);
@@ -5755,7 +5700,6 @@ init_scheduler_data(ErtsSchedulerData* esdp, int num,
     esdp->run_queue = runq;
     if (ERTS_RUNQ_IX_IS_DIRTY(runq->ix)) {
 	esdp->no = 0;
-        esdp->pollset = NULL;
         if (runq == ERTS_DIRTY_CPU_RUNQ)
             esdp->type = ERTS_SCHED_DIRTY_CPU;
         else {
@@ -5775,7 +5719,6 @@ init_scheduler_data(ErtsSchedulerData* esdp, int num,
         esdp->type = ERTS_SCHED_NORMAL;
 	esdp->no = (Uint) num;
 	esdp->dirty_no = 0;
-        esdp->pollset = erts_get_pollset(num);
         runq->scheduler = esdp;
     }
     esdp->dirty_shadow_process = shadow_proc;
@@ -5787,8 +5730,6 @@ init_scheduler_data(ErtsSchedulerData* esdp, int num,
 				    | ERTS_PSFLG_PROXY));
 	shadow_proc->static_flags = ERTS_STC_FLG_SHADOW_PROC;
     }
-
-    esdp->function_calls = 0;
 
     ssi->esdp = esdp;
     esdp->ssi = ssi;
@@ -5821,8 +5762,8 @@ init_scheduler_data(ErtsSchedulerData* esdp, int num,
 }
 
 void
-erts_init_scheduling(int no_schedulers, int no_schedulers_online
-		     , int no_dirty_cpu_schedulers, int no_dirty_cpu_schedulers_online,
+erts_init_scheduling(int no_schedulers, int no_schedulers_online, int no_poll_threads,
+		     int no_dirty_cpu_schedulers, int no_dirty_cpu_schedulers_online,
 		     int no_dirty_io_schedulers
 		     )
 {
@@ -5849,6 +5790,7 @@ erts_init_scheduling(int no_schedulers, int no_schedulers_online
     ASSERT(no_dirty_cpu_schedulers >= 1);
     ASSERT(no_dirty_cpu_schedulers_online <= no_schedulers_online);
     ASSERT(no_dirty_cpu_schedulers_online >= 1);
+    ASSERT(erts_no_poll_threads == no_poll_threads);
 
     /* Create and initialize run queues */
 
@@ -5946,7 +5888,7 @@ erts_init_scheduling(int no_schedulers, int no_schedulers_online
     erts_no_total_schedulers += no_dirty_io_schedulers;
 
     /* Create and initialize scheduler sleep info */
-    no_ssi = n+1;
+    no_ssi = n + 1 /* aux thread */;
     aligned_sched_sleep_info =
 	erts_alloc_permanent_cache_aligned(
 	    ERTS_ALC_T_SCHDLR_SLP_INFO,
@@ -5957,12 +5899,13 @@ erts_init_scheduling(int no_schedulers, int no_schedulers_online
 	ssi->next = NULL;
 	ssi->prev = NULL;
 #endif
+        ssi->esdp = NULL;
 	erts_atomic32_init_nob(&ssi->flags, 0);
 	ssi->event = NULL; /* initialized in sched_thread_func */
 	erts_atomic32_init_nob(&ssi->aux_work, 0);
     }
 
-    aligned_sched_sleep_info++;
+    aligned_sched_sleep_info += 1 /* aux thread */;
 
     aligned_dirty_cpu_sched_sleep_info =
 	erts_alloc_permanent_cache_aligned(
@@ -5982,6 +5925,18 @@ erts_init_scheduling(int no_schedulers, int no_schedulers_online
 	ErtsSchedulerSleepInfo *ssi = &aligned_dirty_io_sched_sleep_info[ix].ssi;
 	erts_atomic32_init_nob(&ssi->flags, 0);
 	ssi->event = NULL; /* initialized in sched_dirty_io_thread_func */
+	erts_atomic32_init_nob(&ssi->aux_work, 0);
+    }
+
+    aligned_poll_thread_sleep_info =
+        erts_alloc_permanent_cache_aligned(
+	    ERTS_ALC_T_SCHDLR_SLP_INFO,
+	    no_poll_threads*sizeof(ErtsAlignedSchedulerSleepInfo));
+    for (ix = 0; ix < no_poll_threads; ix++) {
+        ErtsSchedulerSleepInfo *ssi = &aligned_poll_thread_sleep_info[ix].ssi;
+        ssi->esdp = NULL;
+	erts_atomic32_init_nob(&ssi->flags, 0);
+	ssi->event = NULL; /* initialized in poll_thread */
 	erts_atomic32_init_nob(&ssi->aux_work, 0);
     }
 
@@ -6041,10 +5996,13 @@ erts_init_scheduling(int no_schedulers, int no_schedulers_online
     erts_atomic32_init_nob(&debug_wait_completed_count, 0); /* debug only */
     debug_wait_completed_flags = 0;
 
-
     aux_thread_aux_work_data =
 	erts_alloc_permanent_cache_aligned(ERTS_ALC_T_SCHDLR_DATA,
 					   sizeof(ErtsAuxWorkData));
+
+    poll_thread_aux_work_data =
+	erts_alloc_permanent_cache_aligned(ERTS_ALC_T_SCHDLR_DATA,
+					   no_poll_threads * sizeof(ErtsAuxWorkData));
 
     init_no_runqs(no_schedulers_online, no_schedulers_online);
     balance_info.last_active_runqs = no_schedulers;
@@ -7034,12 +6992,8 @@ sched_set_suspended_sleeptype(ErtsSchedulerSleepInfo *ssi,
 			   | ERTS_SSI_FLG_WAITING
 			   | ERTS_SSI_FLG_SUSPENDED);
 
-    if (sleep_type == ERTS_SSI_FLG_TSE_SLEEPING)
-	erts_tse_reset(ssi->event);
-    else {
-	ASSERT(sleep_type == ERTS_SSI_FLG_POLL_SLEEPING);
-	erts_check_io_interrupt(ssi->esdp->pollset, 0);
-    }
+    ASSERT(sleep_type == ERTS_SSI_FLG_TSE_SLEEPING);
+    erts_tse_reset(ssi->event);
 
     while (1) {
 	oflgs = erts_atomic32_cmpxchg_acqb(&ssi->flags, nflgs, xflgs);
@@ -7291,17 +7245,6 @@ msb_scheduler_type_switch(ErtsSchedType sched_type,
     if (exec_type != ERTS_SCHED_NORMAL)
         schdlr_sspnd.last_msb_dirty_type = exec_type;
     else {
-        erts_aint32_t calls;
-        /*
-         * Going back to normal scheduler after
-         * dirty execution; make sure it will check
-         * for I/O...
-         */
-        if (ERTS_USE_MODIFIED_TIMING())
-            calls = ERTS_MODIFIED_TIMING_INPUT_REDS + 1;
-        else
-            calls = INPUT_REDUCTIONS + 1;
-        esdp->function_calls = calls;
 
         if ((nrml_prio == ERTS_MSB_NONE_PRIO_BIT)
             & ((dcpu_prio != ERTS_MSB_NONE_PRIO_BIT)
@@ -7376,7 +7319,7 @@ msb_scheduler_type_switch(ErtsSchedType sched_type,
 }
 
 static ERTS_INLINE void
-suspend_dirty_scheduler_sleep(ErtsSchedulerData *esdp)
+suspend_normal_scheduler_sleep(ErtsSchedulerData *esdp)
 {
     ErtsSchedulerSleepInfo *ssi = esdp->ssi;
     erts_aint32_t flgs = sched_spin_suspended(ssi,
@@ -7399,36 +7342,9 @@ suspend_dirty_scheduler_sleep(ErtsSchedulerData *esdp)
 }
 
 static ERTS_INLINE void
-suspend_normal_scheduler_sleep(ErtsSchedulerData *esdp)
+suspend_dirty_scheduler_sleep(ErtsSchedulerData *esdp)
 {
-    ErtsSchedulerSleepInfo *ssi = esdp->ssi;
-    erts_aint32_t flgs;
-    int spincount;
-
-    spincount = sched_busy_wait.sys_schedule;
-
-    while (spincount-- > 0) {
-
-        erl_sys_schedule(1);
-
-        flgs = erts_smp_atomic32_read_acqb(&ssi->flags);
-        if (flgs != (ERTS_SSI_FLG_SLEEPING
-                     | ERTS_SSI_FLG_WAITING
-                     | ERTS_SSI_FLG_SUSPENDED)) {
-            return;
-        }
-    }
-
-    flgs = sched_set_suspended_sleeptype(ssi, ERTS_SSI_FLG_POLL_SLEEPING);
-    if (flgs != (ERTS_SSI_FLG_SLEEPING
-                 | ERTS_SSI_FLG_POLL_SLEEPING
-                 | ERTS_SSI_FLG_WAITING
-                 | ERTS_SSI_FLG_SUSPENDED)) {
-        return;
-    }
-
-    /* Sleep on pollset... */
-    erl_sys_schedule(0);
+    suspend_normal_scheduler_sleep(esdp);
 }
 
 static void
@@ -7662,8 +7578,10 @@ suspend_scheduler(ErtsSchedulerData *esdp)
                             erts_thr_progress_active(esdp, thr_prgr_active = 0);
                             sched_wall_time_change(esdp, 0);
                         }
+                        erts_thr_progress_prepare_wait(NULL);
                         suspend_normal_scheduler_sleep(esdp);
-                        current_time = erts_get_monotonic_time(esdp);;
+                        erts_thr_progress_finalize_wait(NULL);
+                        current_time = erts_get_monotonic_time(esdp);
                     }
 
                     if (current_time >= timeout_time) {
@@ -8493,17 +8411,17 @@ sched_dirty_io_thread_func(void *vesdp)
     return NULL;
 }
 
-static ethr_tid aux_tid;
-
 void
 erts_start_schedulers(void)
 {
+    ethr_tid tid;
     int res = 0;
     Uint actual;
     Uint wanted = erts_no_schedulers;
     Uint wanted_no_schedulers = erts_no_schedulers;
     char name[16];
     ethr_thr_opts opts = ETHR_THR_OPTS_DEFAULT_INITER;
+    int ix;
 
     opts.detached = 1;
 
@@ -8548,7 +8466,6 @@ erts_start_schedulers(void)
     erts_no_schedulers = actual;
 
     {
-	int ix;
 	for (ix = 0; ix < erts_no_dirty_cpu_schedulers; ix++) {
 	    ErtsSchedulerData *esdp = ERTS_DIRTY_CPU_SCHEDULER_IX(ix);
 	    erts_snprintf(opts.name, 16, "%d_dirty_cpu_scheduler", ix + 1);
@@ -8571,9 +8488,17 @@ erts_start_schedulers(void)
 
     erts_snprintf(opts.name, 16, "aux");
 
-    res = ethr_thr_create(&aux_tid, aux_thread, NULL, &opts);
+    res = ethr_thr_create(&tid, aux_thread, NULL, &opts);
     if (res != 0)
 	erts_exit(ERTS_ERROR_EXIT, "Failed to create aux thread\n");
+
+    for (ix = 0; ix < erts_no_poll_threads; ix++) {
+        erts_snprintf(opts.name, 16, "%d_poller", ix);
+
+        res = ethr_thr_create(&tid, poll_thread, (void*)(UWord)ix, &opts);
+        if (res != 0)
+            erts_exit(ERTS_ERROR_EXIT, "Failed to create poll thread\n");
+    }
 
     if (actual < 1)
 	erts_exit(ERTS_ERROR_EXIT,
@@ -9641,7 +9566,6 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
     ErtsRunQueue *rq;
     int context_reds;
     int fcalls;
-    int input_reductions;
     int actual_reds;
     int reds;
     Uint32 flags;
@@ -9661,11 +9585,9 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 
     if (ERTS_USE_MODIFIED_TIMING()) {
 	context_reds = ERTS_MODIFIED_TIMING_CONTEXT_REDS;
-	input_reductions = ERTS_MODIFIED_TIMING_INPUT_REDS;
     }
     else {
 	context_reds = CONTEXT_REDS;
-	input_reductions = INPUT_REDUCTIONS;
     }
 
     ERTS_LC_ASSERT(ERTS_SCHEDULER_IS_DIRTY(erts_get_scheduler_data())
@@ -9685,7 +9607,6 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 	}
 	rq = erts_get_runq_current(esdp);
 	ASSERT(esdp);
-	fcalls = esdp->function_calls;
 	actual_reds = reds = 0;
 	erts_runq_lock(rq);
     } else {
@@ -9711,8 +9632,6 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 	    reds = ERTS_PROC_MIN_CONTEXT_SWITCH_REDS_COST;
 	esdp->virtual_reds = 0;
 
-        esdp->function_calls += reds;
-	fcalls = esdp->function_calls;
 	ASSERT(esdp && esdp == erts_get_scheduler_data());
 
 	rq = erts_get_runq_current(esdp);
@@ -9802,16 +9721,6 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 
 	ERTS_CHK_NO_PROC_LOCKS;
 
-	if (is_normal_sched) {
-	    if (esdp->check_time_reds >= ERTS_CHECK_TIME_REDS)
-		(void) erts_get_monotonic_time(esdp);
-
-	    if (esdp->last_monotonic_time >= erts_next_timeout_time(esdp->next_tmo_ref)) {
-		erts_runq_unlock(rq);
-		erts_bump_timers(esdp->timer_wheel, esdp->last_monotonic_time);
-		erts_runq_lock(rq);
-	    }
-	}
     }
 
     ERTS_LC_ASSERT(!is_normal_sched || !erts_thr_progress_is_blocking());
@@ -9822,6 +9731,16 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 	ErtsMigrationPath *mp;
 
 	if (is_normal_sched) {
+
+	    if (esdp->check_time_reds >= ERTS_CHECK_TIME_REDS)
+		(void) erts_get_monotonic_time(esdp);
+
+	    if (esdp->last_monotonic_time >= erts_next_timeout_time(esdp->next_tmo_ref)) {
+		erts_runq_unlock(rq);
+		erts_bump_timers(esdp->timer_wheel, esdp->last_monotonic_time);
+		erts_runq_lock(rq);
+	    }
+
 	    if (rq->check_balance_reds <= 0)
 		check_balance(rq);
 
@@ -9950,37 +9869,6 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 	    non_empty_runq(rq);
 
 	    goto check_activities_to_run;
-	}
-	else if (is_normal_sched
-		 && (fcalls > input_reductions
-		     && prepare_for_sys_schedule(!0))) {
-	    ErtsMonotonicTime current_time;
-	    /*
-	     * Schedule system-level activities.
-	     */
-
-	    ERTS_MSACC_PUSH_STATE_CACHED_M();
-
-	    esdp->function_calls = 0;
-	    fcalls = 0;
-
-#if 0 /* Not needed since we wont wait in sys schedule */
-	    erts_check_io_interrupt(esdp->pollset, 0);
-#endif
-	    erts_runq_unlock(rq);
-
-            ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_CHECK_IO);
-            LTTNG2(scheduler_poll, esdp->no, 1);
-
-	    erl_sys_schedule(1);
-	    ERTS_MSACC_POP_STATE_M();
-
-	    current_time = erts_get_monotonic_time(esdp);
-	    if (current_time >= erts_next_timeout_time(esdp->next_tmo_ref))
-		erts_bump_timers(esdp->timer_wheel, current_time);
-
-	    erts_runq_lock(rq);
-	    goto continue_check_activities_to_run;
 	}
 
         if (flags & ERTS_RUNQ_FLG_MISC_OP)

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -174,7 +174,6 @@ extern BeamInstr beam_exit[];
 extern BeamInstr beam_continue_exit[];
 
 int ERTS_WRITE_UNLIKELY(erts_default_spo_flags) = SPO_ON_HEAP_MSGQ;
-int ERTS_WRITE_UNLIKELY(erts_eager_check_io) = 1;
 int ERTS_WRITE_UNLIKELY(erts_sched_compact_load);
 int ERTS_WRITE_UNLIKELY(erts_sched_balance_util) = 0;
 Uint ERTS_WRITE_UNLIKELY(erts_no_schedulers);

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -49,6 +49,7 @@
 #define ERTS_WANT_TIMER_WHEEL_API
 #include "erl_time.h"
 #include "erl_nfunc_sched.h"
+#include "erl_check_io.h"
 
 #define ERTS_CHECK_TIME_REDS CONTEXT_REDS
 #define ERTS_DELAYED_WAKEUP_INFINITY (~(Uint64) 0)
@@ -1563,14 +1564,14 @@ erts_sched_finish_poke(ErtsSchedulerSleepInfo *ssi, erts_aint32_t flags)
 {
     switch (flags & ERTS_SSI_FLGS_SLEEP_TYPE) {
     case ERTS_SSI_FLG_POLL_SLEEPING:
-	erts_sys_schedule_interrupt(1);
+	erts_check_io_interrupt(1);
 	break;
     case ERTS_SSI_FLG_POLL_SLEEPING|ERTS_SSI_FLG_TSE_SLEEPING:
 	/*
 	 * Thread progress blocking while poll sleeping; need
 	 * to signal on both...
 	 */
-	erts_sys_schedule_interrupt(1);
+	erts_check_io_interrupt(1);
 	/* fall through */
     case ERTS_SSI_FLG_TSE_SLEEPING:
 	erts_tse_set(ssi->event);
@@ -3084,7 +3085,7 @@ sched_set_sleeptype(ErtsSchedulerSleepInfo *ssi, erts_aint32_t sleep_type)
 	erts_tse_reset(ssi->event);
     else {
 	ASSERT(sleep_type == ERTS_SSI_FLG_POLL_SLEEPING);
-	erts_sys_schedule_interrupt(0);
+	erts_check_io_interrupt(0);
     }
 
     while (1) {
@@ -10049,7 +10050,7 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 	    fcalls = 0;
 
 #if 0 /* Not needed since we wont wait in sys schedule */
-	    erts_sys_schedule_interrupt(0);
+	    erts_check_io_interrupt(0);
 #endif
 	    erts_runq_unlock(rq);
 

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -3129,6 +3129,7 @@ aux_thread(void *unused)
     }
 #endif
 
+    erts_port_task_pre_alloc_init_thread();
     ssi->event = erts_tse_fetch();
 
     erts_msacc_init_thread("aux", 1, 1);
@@ -3184,9 +3185,6 @@ aux_thread(void *unused)
     }
     return NULL;
 }
-
-static void suspend_scheduler(ErtsSchedulerData *esdp);
-
 
 static void
 scheduler_wait(int *fcalls, ErtsSchedulerData *esdp, ErtsRunQueue *rq)
@@ -8341,6 +8339,7 @@ sched_thread_func(void *vesdp)
     Uint no = esdp->no;
     erts_tse_t *tse;
 
+    erts_port_task_pre_alloc_init_thread();
     erts_sched_init_time_sup(esdp);
 
     if (no == 1)

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -369,6 +369,7 @@ struct ErtsSchedulerSleepInfo_ {
     ErtsSchedulerSleepInfo *prev;
     erts_atomic32_t flags;
     erts_tse_t *event;
+    struct erts_poll_thread *psi;
     erts_atomic32_t aux_work;
 };
 
@@ -632,8 +633,6 @@ struct ErtsSchedulerData_ {
     void *match_pseudo_process; /* erl_db_util.c:db_prog_match() */
     Process *free_process;
     ErtsThrPrgrData thr_progress_data;
-    struct pollset_info* pollset;
-    int function_calls;
     ErtsSchedulerSleepInfo *ssi;
     Process *current_process;
     ErtsSchedType type;
@@ -1534,9 +1533,7 @@ extern int erts_system_profile_ts_type;
 void erts_pre_init_process(void);
 void erts_late_init_process(void);
 void erts_early_init_scheduling(int);
-void erts_init_scheduling(int, int
-			  , int, int, int
-			  );
+void erts_init_scheduling(int, int, int, int, int, int);
 void erts_execute_dirty_system_task(Process *c_p);
 int erts_set_gc_state(Process *c_p, int enable);
 Eterm erts_sched_wall_time_request(Process *c_p, int set, int enable,
@@ -2473,6 +2470,7 @@ void erts_notify_inc_runq(ErtsRunQueue *runq);
 
 void erts_sched_finish_poke(ErtsSchedulerSleepInfo *, erts_aint32_t);
 ERTS_GLB_INLINE void erts_sched_poke(ErtsSchedulerSleepInfo *ssi);
+void erts_aux_thread_poke(void);
 
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -105,7 +105,6 @@ struct saved_calls {
 };
 
 extern Export exp_send, exp_receive, exp_timeout;
-extern int erts_eager_check_io;
 extern int erts_sched_compact_load;
 extern int erts_sched_balance_util;
 extern Uint erts_no_schedulers;

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -364,6 +364,7 @@ typedef struct {
 } ErtsSchedulerSleepList;
 
 struct ErtsSchedulerSleepInfo_ {
+    struct ErtsSchedulerData_ *esdp;
     ErtsSchedulerSleepInfo *next;
     ErtsSchedulerSleepInfo *prev;
     erts_atomic32_t flags;
@@ -631,6 +632,8 @@ struct ErtsSchedulerData_ {
     void *match_pseudo_process; /* erl_db_util.c:db_prog_match() */
     Process *free_process;
     ErtsThrPrgrData thr_progress_data;
+    struct pollset_info* pollset;
+    int function_calls;
     ErtsSchedulerSleepInfo *ssi;
     Process *current_process;
     ErtsSchedType type;

--- a/erts/emulator/beam/erl_threads.h
+++ b/erts/emulator/beam/erl_threads.h
@@ -454,7 +454,6 @@ ERTS_GLB_INLINE void erts_rwmtx_runlock(erts_rwmtx_t *rwmtx);
 ERTS_GLB_INLINE void erts_rwmtx_rwunlock(erts_rwmtx_t *rwmtx);
 ERTS_GLB_INLINE int erts_lc_rwmtx_is_rlocked(erts_rwmtx_t *mtx);
 ERTS_GLB_INLINE int erts_lc_rwmtx_is_rwlocked(erts_rwmtx_t *mtx);
-
 ERTS_GLB_INLINE void erts_spinlock_init(erts_spinlock_t *lock,
                                         char *name,
                                         Eterm extra,

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -1449,7 +1449,6 @@ monitor_long_schedule_port(Port *pp, ErtsPortTaskType type, Uint time)
     case ERTS_PORT_TASK_TIMEOUT: op = am_timeout; break;
     case ERTS_PORT_TASK_INPUT: op = am_input; break;
     case ERTS_PORT_TASK_OUTPUT: op = am_output; break;
-    case ERTS_PORT_TASK_EVENT: op = am_event; break;
     case ERTS_PORT_TASK_DIST_CMD: op = am_dist_cmd; break;
     default: op = am_undefined; break;
     }

--- a/erts/emulator/beam/erl_vm.h
+++ b/erts/emulator/beam/erl_vm.h
@@ -46,7 +46,7 @@
  */
 #define ERTS_X_REGS_ALLOCATED (MAX_REG+3)
 
-#define INPUT_REDUCTIONS (2 * CONTEXT_REDS)
+#define INPUT_REDUCTIONS (CONTEXT_REDS / 4)
 
 #define H_DEFAULT_SIZE  233        /* default (heap + stack) min size */
 #define VH_DEFAULT_SIZE  32768     /* default virtual (bin) heap min size (words) */

--- a/erts/emulator/beam/erl_vm.h
+++ b/erts/emulator/beam/erl_vm.h
@@ -46,8 +46,6 @@
  */
 #define ERTS_X_REGS_ALLOCATED (MAX_REG+3)
 
-#define INPUT_REDUCTIONS (CONTEXT_REDS / 4)
-
 #define H_DEFAULT_SIZE  233        /* default (heap + stack) min size */
 #define VH_DEFAULT_SIZE  32768     /* default virtual (bin) heap min size (words) */
 #define H_DEFAULT_MAX_SIZE 0       /* default max heap size is off */

--- a/erts/emulator/beam/erlang_lttng.h
+++ b/erts/emulator/beam/erlang_lttng.h
@@ -159,21 +159,6 @@ TRACEPOINT_EVENT(
 
 TRACEPOINT_EVENT(
     org_erlang_otp,
-    driver_event,
-    TP_ARGS(
-        char*, pid,
-        char*, port,
-        char*, driver
-    ),
-    TP_FIELDS(
-        ctf_string(pid, pid)
-        ctf_string(port, port)
-        ctf_string(driver, driver)
-    )
-)
-
-TRACEPOINT_EVENT(
-    org_erlang_otp,
     driver_timeout,
     TP_ARGS(
         char*, pid,

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1101,7 +1101,6 @@ void erts_save_stacktrace(Process* p, struct StackTrace* s, int depth);
 typedef struct {
     Eterm delay_time;
     int context_reds;
-    int input_reds;
 } ErtsModifiedTimings;
 
 extern Export *erts_delay_trap;

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -222,8 +222,6 @@ struct erts_driver_t_ {
 			 char *buf, ErlDrvSizeT len,
 			 char **rbuf, ErlDrvSizeT rlen, /* Might be NULL */
 			 unsigned int *flags);
-    void (*event)(ErlDrvData drv_data, ErlDrvEvent event,
-		  ErlDrvEventData event_data);
     void (*ready_input)(ErlDrvData drv_data, ErlDrvEvent event); 
     void (*ready_output)(ErlDrvData drv_data, ErlDrvEvent event);  
     void (*timeout)(ErlDrvData drv_data);

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -5390,24 +5390,17 @@ erts_stale_drv_select(Eterm port,
     switch (mode) {
     case ERL_DRV_READ | ERL_DRV_WRITE:
 	type = "Input/Output";
-	goto deselect;
     case ERL_DRV_WRITE:
 	type = "Output";
-	goto deselect;
     case ERL_DRV_READ:
 	type = "Input";
-    deselect:
-	if (deselect) {
-	    driver_select(drv_port, hndl,
-			  mode | ERL_DRV_USE_NO_CALLBACK,
-			  0);
-	}
-	break;
     default:
-	type = "Event";
-	if (deselect)
-	    driver_event(drv_port, hndl, NULL);
-	break;
+        type = "";
+    }
+    if (deselect) {
+        driver_select(drv_port, hndl,
+                      mode | ERL_DRV_USE_NO_CALLBACK,
+                      0);
     }
 
     dsbufp = erts_create_logger_dsbuf();
@@ -7511,14 +7504,6 @@ no_output_callback(ErlDrvData drv_data, char *buf, ErlDrvSizeT len)
 }
 
 static void
-no_event_callback(ErlDrvData drv_data, ErlDrvEvent event, ErlDrvEventData event_data)
-{
-    Port *prt = get_current_port();
-    report_missing_drv_callback(prt, "Event", "event()");
-    driver_event(ERTS_Port2ErlDrvPort(prt), event, NULL);
-}
-
-static void
 no_ready_input_callback(ErlDrvData drv_data, ErlDrvEvent event)
 {
     Port *prt = get_current_port();
@@ -7585,7 +7570,6 @@ init_driver(erts_driver_t *drv, ErlDrvEntry *de, DE_Handle *handle)
     drv->outputv = de->outputv;
     drv->control = de->control;
     drv->call = de->call;
-    drv->event = de->event ? de->event : no_event_callback;
     drv->ready_input = de->ready_input ? de->ready_input : no_ready_input_callback;
     drv->ready_output = de->ready_output ? de->ready_output : no_ready_output_callback;
     drv->timeout = de->timeout ? de->timeout : no_timeout_callback;

--- a/erts/emulator/beam/safe_hash.c
+++ b/erts/emulator/beam/safe_hash.c
@@ -260,16 +260,17 @@ void* safe_hash_erase(SafeHash* h, void* tmpl)
 }
 
 /*
-** Call 'func(obj,func_arg2)' for all objects in table. NOT SAFE!!!
+** Call 'func(obj,func_arg2,func_arg3)' for all objects in table. NOT SAFE!!!
 */
-void safe_hash_for_each(SafeHash* h, void (*func)(void *, void *), void *func_arg2)
+void safe_hash_for_each(SafeHash* h, void (*func)(void *, void *, void *),
+                        void *func_arg2, void *func_arg3)
 {
     int i;
 
     for (i = 0; i <= h->size_mask; i++) {
 	SafeHashBucket* b = h->tab[i];
 	while (b != NULL) {
-	    (*func)((void *) b, func_arg2);
+	    (*func)((void *) b, func_arg2, func_arg3);
 	    b = b->next;
 	}
     }

--- a/erts/emulator/beam/safe_hash.h
+++ b/erts/emulator/beam/safe_hash.h
@@ -95,7 +95,7 @@ void* safe_hash_get(SafeHash*, void*);
 void* safe_hash_put(SafeHash*, void*);
 void* safe_hash_erase(SafeHash*, void*);
 
-void  safe_hash_for_each(SafeHash*, void (*func)(void *, void *), void *);
+void  safe_hash_for_each(SafeHash*, void (*func)(void *, void *, void *), void *, void *);
 
 #ifdef ERTS_ENABLE_LOCK_COUNT
 void erts_lcnt_enable_hash_lock_count(SafeHash*, erts_lock_flags_t, int);

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -992,10 +992,6 @@ erts_refc_read(erts_refc_t *refcp, erts_aint_t min_val)
 
 #endif /* #if ERTS_GLB_INLINE_INCL_FUNC_DEF */
 
-#ifdef ERTS_ENABLE_KERNEL_POLL
-extern int erts_use_kernel_poll;
-#endif
-
 #define sys_memcpy(s1,s2,n)  memcpy(s1,s2,n)
 #define sys_memmove(s1,s2,n) memmove(s1,s2,n)
 #define sys_memcmp(s1,s2,n)  memcmp(s1,s2,n)

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -790,7 +790,6 @@ void fini_getenv_state(GETENV_STATE *);
 typedef struct {
     int no_used_fds;
     int no_driver_select_structs;
-    int no_driver_event_structs;
 } ErtsCheckIoDebugInfo;
 int erts_check_io_debug(ErtsCheckIoDebugInfo *ip);
 

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -575,8 +575,6 @@ __decl_noreturn void __noreturn erts_exit(int n, char*, ...);
     erts_exit(ERTS_ABORT_EXIT, "%s:%d:%s(): Internal error: %s\n", \
 	     __FILE__, __LINE__, __func__, What)
 
-Eterm erts_check_io_info(void *p);
-
 UWord erts_sys_get_page_size(void);
 
 /* Size of misc memory allocated from system dependent code */
@@ -739,8 +737,6 @@ extern char *erts_sys_ddll_error(int code);
 /*
  * System interfaces for startup.
  */
-void erts_sys_schedule_interrupt(int set);
-void erts_sys_schedule_interrupt_timed(int, ErtsMonotonicTime);
 void erts_sys_main_thread(void);
 
 extern int erts_sys_prepare_crash_dump(int secs);

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -790,6 +790,7 @@ void fini_getenv_state(GETENV_STATE *);
 typedef struct {
     int no_used_fds;
     int no_driver_select_structs;
+    int no_enif_select_structs;
 } ErtsCheckIoDebugInfo;
 int erts_check_io_debug(ErtsCheckIoDebugInfo *ip);
 

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -148,10 +148,11 @@ struct removed_fd {
 #ifdef ERTS_SYS_CONTINOUS_FD_NUMBERS
 static int max_fds = -1;
 #endif
-#define DRV_EV_STATE_LOCK_CNT 16
+
+#define DRV_EV_STATE_LOCK_CNT 128
 static union {
     erts_mtx_t lck;
-    byte _cache_line_alignment[64];
+    byte _cache_line_alignment[ERTS_ALC_CACHE_LINE_ALIGN_SIZE(sizeof(erts_mtx_t))];
 }drv_ev_state_locks[DRV_EV_STATE_LOCK_CNT];
 
 static ERTS_INLINE erts_mtx_t* fd_mtx(ErtsSysFdType fd)

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -2368,6 +2368,7 @@ typedef struct {
     int used_fds;
     int num_errors;
     int no_driver_select_structs;
+    int no_enif_select_structs;
 #ifdef ERTS_SYS_CONTINOUS_FD_NUMBERS
     int internal_fds;
     ErtsPollEvents *epep;
@@ -2392,6 +2393,8 @@ static void doit_erts_check_io_debug(void *vstate, void *vcounters)
 
     if (state->driver.select)
 	counters->no_driver_select_structs++;
+    if (state->driver.nif)
+        counters->no_enif_select_structs++;
 
 #ifdef ERTS_SYS_CONTINOUS_FD_NUMBERS
     if (state->events || ep_events) {
@@ -2614,6 +2617,7 @@ ERTS_CIO_EXPORT(erts_check_io_debug)(ErtsCheckIoDebugInfo *ciodip)
     ErtsDrvEventState null_des;
 
     null_des.driver.select = NULL;
+    null_des.driver.nif = NULL;
     null_des.driver.stop.drv_ptr = NULL;
     null_des.events = 0;
     null_des.remove_cnt = 0;
@@ -2636,6 +2640,7 @@ ERTS_CIO_EXPORT(erts_check_io_debug)(ErtsCheckIoDebugInfo *ciodip)
     counters.used_fds = 0;
     counters.num_errors = 0;
     counters.no_driver_select_structs = 0;
+    counters.no_enif_select_structs = 0;
 
 #ifdef ERTS_SYS_CONTINOUS_FD_NUMBERS
     len = erts_atomic_read_nob(&drv_ev_state_len);
@@ -2654,10 +2659,12 @@ ERTS_CIO_EXPORT(erts_check_io_debug)(ErtsCheckIoDebugInfo *ciodip)
 
     ciodip->no_used_fds = counters.used_fds;
     ciodip->no_driver_select_structs = counters.no_driver_select_structs;
+    ciodip->no_enif_select_structs = counters.no_enif_select_structs;
 
     erts_printf("\n");
     erts_printf("used fds=%d\n", counters.used_fds);
     erts_printf("Number of driver_select() structures=%d\n", counters.no_driver_select_structs);
+    erts_printf("Number of enif_select() structures=%d\n", counters.no_enif_select_structs);
 #ifdef ERTS_SYS_CONTINOUS_FD_NUMBERS
     erts_printf("internal fds=%d\n", counters.internal_fds);
 #endif

--- a/erts/emulator/sys/common/erl_check_io.h
+++ b/erts/emulator/sys/common/erl_check_io.h
@@ -30,38 +30,6 @@
 #include "sys.h"
 #include "erl_sys_driver.h"
 
-#ifdef ERTS_ENABLE_KERNEL_POLL
-
-int driver_select_kp(ErlDrvPort, ErlDrvEvent, int, int);
-int driver_select_nkp(ErlDrvPort, ErlDrvEvent, int, int);
-int enif_select_kp(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, const ErlNifPid*, Eterm);
-int enif_select_nkp(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, const ErlNifPid*, Eterm);
-int driver_event_kp(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
-int driver_event_nkp(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
-Uint erts_check_io_size_kp(void);
-Uint erts_check_io_size_nkp(void);
-Eterm erts_check_io_info_kp(void *);
-Eterm erts_check_io_info_nkp(void *);
-int erts_check_io_max_files_kp(void);
-int erts_check_io_max_files_nkp(void);
-void erts_check_io_interrupt_kp(int);
-void erts_check_io_interrupt_nkp(int);
-void erts_check_io_interrupt_timed_kp(int, ErtsMonotonicTime);
-void erts_check_io_interrupt_timed_nkp(int, ErtsMonotonicTime);
-void erts_check_io_kp(int);
-void erts_check_io_nkp(int);
-void erts_init_check_io_kp(void);
-void erts_init_check_io_nkp(void);
-int erts_check_io_debug_kp(ErtsCheckIoDebugInfo *);
-int erts_check_io_debug_nkp(ErtsCheckIoDebugInfo *);
-
-#ifdef ERTS_ENABLE_LOCK_COUNT
-void erts_lcnt_update_cio_locks_kp(int enable);
-void erts_lcnt_update_cio_locks_nkp(int enable);
-#endif
-
-#else /* !ERTS_ENABLE_KERNEL_POLL */
-
 Uint erts_check_io_size(void);
 Eterm erts_check_io_info(void *);
 int erts_check_io_max_files(void);
@@ -69,7 +37,6 @@ void erts_check_io_interrupt(int);
 void erts_check_io_interrupt_timed(int, ErtsMonotonicTime);
 void erts_check_io(int);
 void erts_init_check_io(void);
-
 #ifdef ERTS_ENABLE_LOCK_COUNT
 void erts_lcnt_update_cio_locks(int enable);
 #endif

--- a/erts/emulator/sys/common/erl_check_io.h
+++ b/erts/emulator/sys/common/erl_check_io.h
@@ -41,8 +41,6 @@ void erts_init_check_io(void);
 void erts_lcnt_update_cio_locks(int enable);
 #endif
 
-#endif
-
 extern erts_atomic_t erts_check_io_time;
 
 typedef struct {
@@ -84,22 +82,6 @@ erts_io_notify_port_task_executed(ErtsPortTaskHandle *pthp)
 #else
 #  define ERTS_CIO_DEFER_ACTIVE_EVENTS 0
 #endif
-
-/*
- * ErtsDrvEventDataState is used by driver_event() which is almost never
- * used. We allocate ErtsDrvEventDataState separate since we dont wan't
- * the size of ErtsDrvEventState to increase due to driver_event()
- * information.
- */
-typedef struct {
-    Eterm port;
-    ErlDrvEventData data;
-    ErtsPollEvents removed_events;
-#if ERTS_CIO_DEFER_ACTIVE_EVENTS
-    ErtsPollEvents deferred_events;
-#endif
-    ErtsIoTask iotask;
-} ErtsDrvEventDataState;
 
 typedef struct {
     Eterm inport;

--- a/erts/emulator/sys/common/erl_poll.c
+++ b/erts/emulator/sys/common/erl_poll.c
@@ -18,9 +18,8 @@
  * %CopyrightEnd%
  */
 
-/*
- * Description:	Poll interface suitable for ERTS with or without
- *              SMP support.
+/**
+ * @description Poll interface suitable for ERTS
  *
  *		The interface is currently implemented using:
  *		- select
@@ -29,12 +28,36 @@
  *              - epoll with poll or select as fallback
  *              - kqueue with poll or select as fallback
  *
- *		Some time in the future it will also be
- *		implemented using Solaris ports.
  *
+ * @author Rickard Green
+ * @author Lukas Larsson
  *
+ * There are two major different implementations off IO polling in this
+ * file. The concurrent and non-concurrent implementations.
+ * When available epoll/kqueue are used to implement the concurrent
+ * versions. poll, select and dev/poll use non-concurrent updates.
  *
- * Author: 	Rickard Green
+ * Concurrent version:
+ *   In the concurrent version erts_poll_control directly modifies
+ *   the kernel pollset without waking the thread that is waiting
+ *   on events. Also the ErtsPollResFd type is directly mapped to
+ *   the native event type, so no extra copying is needed. Note that
+ *   as no locking at all is done, fds can be triggered that have been
+ *   removed from the pollset. The check_io layer has to deal with this.
+ *
+ * Non-concurrent version:
+ *   In the non-concurrent version, the pollset has an internal representation
+ *   of the pollset that is updated by erts_poll_control. When an fd is updated,
+ *   its number is placed in the update request queue and then the waiting thread
+ *   is woken in order to see the change. The internal data in the pollset is
+ *   protected by a mutex that has to be taken by both the modifying and waiting
+ *   thread at different times.
+ *
+ *   The non-concurrent pollset cannot have fd's closed in it while a thread is
+ *   waiting on that fd. In order to fix this, when an ERTS_POLL_OP_DEL command
+ *   is issued, the fd is marked as closing and the waiting thread is woken. The
+ *   fd is then returned in the waiting threads results as ERTS_POLL_EV_NONE.
+ *
  */
 
 #ifdef HAVE_CONFIG_H
@@ -62,6 +85,8 @@
 #  ifdef SYS_SELECT_H
 #    include <sys/select.h>
 #  endif
+#elif defined(_DARWIN_UNLIMITED_SELECT)
+#  undef _DARWIN_UNLIMITED_SELECT
 #endif
 #ifdef NO_SYSCONF
 #  if ERTS_POLL_USE_SELECT
@@ -83,20 +108,35 @@
 #error "Missing implementation of erts_poll()"
 #endif
 
-#if defined(ERTS_KERNEL_POLL_VERSION) && !ERTS_POLL_USE_KERNEL_POLL
-#error "Missing kernel poll implementation of erts_poll()"
-#endif
-
-#if defined(ERTS_NO_KERNEL_POLL_VERSION) && ERTS_POLL_USE_KERNEL_POLL
-#error "Kernel poll used when it shouldn't be used"
-#endif
-
 #if 0
-#define ERTS_POLL_DEBUG_PRINT
+#define ERTS_POLL_DEBUG_PRINT 1
+
+#define DEBUG_PRINT(FMT, PS, ...)                                       \
+    do {                                                                \
+        int myerrno = errno;                                            \
+        erts_printf("%d: " FMT "\r\n", (PS)->id, ##__VA_ARGS__);        \
+        errno = myerrno;                                                \
+    } while(0)
+
+/* Define to print info about modifications done to each fd */
+#define DEBUG_PRINT_FD(FMT, PS, FD, ...) DEBUG_PRINT("%d: " FMT, PS, FD, ##__VA_ARGS__)
+/* Define to print entry and exit from erts_poll_wait (can be very spammy) */
+//#define DEBUG_PRINT_WAIT(FMT, PS, ...) DEBUG_PRINT(FMT, PS, ##__VA_ARGS__)
+
+#else
+#define ERTS_POLL_DEBUG_PRINT 0
+#define DEBUG_PRINT(...)
+#endif
+
+#ifndef DEBUG_PRINT_FD
+#define DEBUG_PRINT_FD(...)
+#endif
+#ifndef DEBUG_PRINT_WAIT
+#define DEBUG_PRINT_WAIT(...)
 #endif
 
 
-#ifdef _DARWIN_UNLIMITED_SELECT
+#if defined(_DARWIN_UNLIMITED_SELECT) && ERTS_POLL_USE_SELECT
 typedef struct {
     size_t sz;
     fd_set* ptr;
@@ -142,25 +182,11 @@ int ERTS_SELECT(int nfds, ERTS_fd_set *readfds, ERTS_fd_set *writefds,
 #  define ERTS_SELECT	select
 #endif
 
-#define ERTS_POLL_USE_BATCH_UPDATE_POLLSET (ERTS_POLL_USE_DEVPOLL \
-					    || ERTS_POLL_USE_KQUEUE)
+#define ERTS_POLL_IS_FALLBACK (ERTS_POLL_USE_POLL || ERTS_POLL_USE_SELECT) && ERTS_ENABLE_KERNEL_POLL
 
-#define ERTS_POLL_USE_CONCURRENT_UPDATE ERTS_POLL_USE_EPOLL
+#define ERTS_POLL_USE_CONCURRENT_UPDATE (ERTS_POLL_USE_EPOLL || ERTS_POLL_USE_KQUEUE)
 
-#define ERTS_POLL_COALESCE_KP_RES (ERTS_POLL_USE_KQUEUE || ERTS_POLL_USE_EPOLL)
-
-#define ERTS_POLLSET_LOCK(PS) \
-  erts_mtx_lock(&(PS)->mtx)
-#define ERTS_POLLSET_UNLOCK(PS) \
-  erts_mtx_unlock(&(PS)->mtx)
-
-#define ERTS_POLLSET_SET_POLLED_CHK(PS) \
-  ((int) erts_atomic32_xchg_nob(&(PS)->polled, (erts_aint32_t) 1))
-#define ERTS_POLLSET_UNSET_POLLED(PS) \
-  erts_atomic32_set_nob(&(PS)->polled, (erts_aint32_t) 0)
-#define ERTS_POLLSET_IS_POLLED(PS) \
-  ((int) erts_atomic32_read_nob(&(PS)->polled))
-
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 
 #define ERTS_POLLSET_SET_HAVE_UPDATE_REQUESTS(PS) \
   erts_atomic32_set_nob(&(PS)->have_update_requests, (erts_aint32_t) 1)
@@ -169,16 +195,27 @@ int ERTS_SELECT(int nfds, ERTS_fd_set *readfds, ERTS_fd_set *writefds,
 #define ERTS_POLLSET_HAVE_UPDATE_REQUESTS(PS) \
   ((int) erts_atomic32_read_nob(&(PS)->have_update_requests))
 
-#if ERTS_POLL_USE_FALLBACK
-#  if ERTS_POLL_USE_POLL
-#    define ERTS_POLL_NEED_FALLBACK(PS) ((PS)->no_poll_fds > 1)
-#  elif ERTS_POLL_USE_SELECT
-#    define ERTS_POLL_NEED_FALLBACK(PS) ((PS)->no_select_fds > 1)
-#  endif
+#define ERTS_POLLSET_LOCK(PS) \
+  erts_mtx_lock(&(PS)->mtx)
+#define ERTS_POLLSET_UNLOCK(PS) \
+  erts_mtx_unlock(&(PS)->mtx)
+
+#else
+
+#define ERTS_POLLSET_SET_HAVE_UPDATE_REQUESTS(PS)
+#define ERTS_POLLSET_UNSET_HAVE_UPDATE_REQUESTS(PS)
+#define ERTS_POLLSET_HAVE_UPDATE_REQUESTS(PS) 0
+
+#define ERTS_POLLSET_LOCK(PS)
+#define ERTS_POLLSET_UNLOCK(PS)
+
 #endif
+
 /*
  * --- Data types ------------------------------------------------------------
  */
+
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 
 #define ERTS_POLLSET_UPDATE_REQ_BLOCK_SIZE 128
 
@@ -189,42 +226,19 @@ struct ErtsPollSetUpdateRequestsBlock_ {
     int fds[ERTS_POLLSET_UPDATE_REQ_BLOCK_SIZE];
 };
 
-
-
 #  define ERTS_POLL_FD_FLG_INURQ	(((unsigned short) 1) << 0)
-#if ERTS_POLL_USE_FALLBACK
-#  define ERTS_POLL_FD_FLG_INFLBCK	(((unsigned short) 1) << 1)
-#  define ERTS_POLL_FD_FLG_USEFLBCK	(((unsigned short) 1) << 2)
-#endif
-#  define ERTS_POLL_FD_FLG_RST		(((unsigned short) 1) << 3)
+#  define ERTS_POLL_FD_FLG_RST		(((unsigned short) 1) << 1)
+
 typedef struct {
 #if ERTS_POLL_USE_POLL
     int pix;
 #endif
+
     ErtsPollEvents used_events;
     ErtsPollEvents events;
-#if ERTS_POLL_COALESCE_KP_RES
-    unsigned short res_ev_ix;
-#endif
     unsigned short flags;
 
 } ErtsFdStatus;
-
-
-#if ERTS_POLL_COALESCE_KP_RES
-/* res_ev_ix max value */
-#define ERTS_POLL_MAX_RES ((1 << sizeof(unsigned short)*8) - 1)
-#endif
-
-#if ERTS_POLL_USE_KQUEUE
-
-#define ERTS_POLL_KQ_OP_HANDLED			1
-#define ERTS_POLL_KQ_OP_DEL_R			2
-#define ERTS_POLL_KQ_OP_DEL_W			3
-#define ERTS_POLL_KQ_OP_ADD_R			4
-#define ERTS_POLL_KQ_OP_ADD_W			5
-#define ERTS_POLL_KQ_OP_ADD2_R			6
-#define ERTS_POLL_KQ_OP_ADD2_W			7
 
 #endif
 
@@ -233,196 +247,172 @@ typedef struct {
  * get unique names in debugger for kp/nkp
  */
 struct ERTS_POLL_EXPORT(erts_pollset) {
-    ErtsPollSet next;
+    int id;
     int internal_fd_limit;
-    ErtsFdStatus *fds_status;
     erts_atomic_t no_of_user_fds;
-    int fds_status_len;
+
 #if ERTS_POLL_USE_KERNEL_POLL
     int kp_fd;
-    int res_events_len;
-#if ERTS_POLL_USE_EPOLL
-    struct epoll_event *res_events;
-#elif ERTS_POLL_USE_KQUEUE
-    struct kevent *res_events;
-#elif ERTS_POLL_USE_DEVPOLL
-    struct pollfd *res_events;
-#endif
 #endif /* ERTS_POLL_USE_KERNEL_POLL */
+
 #if ERTS_POLL_USE_POLL
     int next_poll_fds_ix;
     int no_poll_fds;
     int poll_fds_len;
-    struct pollfd*poll_fds;
+    struct pollfd *poll_fds;
 #elif ERTS_POLL_USE_SELECT
     int next_sel_fd;
     int max_fd;
-#if ERTS_POLL_USE_FALLBACK
-    int no_select_fds;
-#endif
     ERTS_fd_set input_fds;
     ERTS_fd_set res_input_fds;
     ERTS_fd_set output_fds;
     ERTS_fd_set res_output_fds;
+#elif ERTS_POLL_USE_DEVPOLL
+    struct pollfd *poll_fds;
+    int poll_fds_ix;
 #endif
+
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
+    ErtsFdStatus *fds_status;
+    int fds_status_len;
     ErtsPollSetUpdateRequestsBlock update_requests;
     ErtsPollSetUpdateRequestsBlock *curr_upd_req_block;
     erts_atomic32_t have_update_requests;
-    erts_atomic32_t polled;
     erts_mtx_t mtx;
     int wake_fds[2];
-#if ERTS_POLL_USE_TIMERFD
-    int timer_fd;
-#endif
-#if ERTS_POLL_USE_FALLBACK
-    int fallback_used;
-#endif
     erts_atomic32_t wakeup_state;
-    erts_atomic64_t timeout_time;
-#ifdef ERTS_POLL_COUNT_AVOIDED_WAKEUPS
-    erts_atomic_t no_avoided_wakeups;
-    erts_atomic_t no_avoided_interrupts;
-    erts_atomic_t no_interrupt_timed;
 #endif
 };
 
 void erts_silence_warn_unused_result(long unused);
 static void fatal_error(char *format, ...);
-static void fatal_error_async_signal_safe(char *error_str);
 
 static int max_fds = -1;
-static ErtsPollSet pollsets;
-static erts_mtx_t pollsets_lock;
 
 #if ERTS_POLL_USE_POLL
+
+#if !ERTS_POLL_IS_FALLBACK
+static ERTS_INLINE short ev2pollev(ErtsPollEvents ev)
+{
+    return ERTS_POLL_EV_E2N(ev);
+}
+
+static ERTS_INLINE ErtsPollEvents pollev2ev(short ev)
+{
+    return ERTS_POLL_EV_N2E(ev);
+}
+
+#else /* ERTS_POLL_IS_FALLBACK */
 
 static ERTS_INLINE short
 ev2pollev(ErtsPollEvents ev)
 {
-#if !ERTS_POLL_USE_FALLBACK || ERTS_POLL_USE_KQUEUE
-    return ERTS_POLL_EV_E2N(ev);
-#else /* Note, we only map events we are interested in */
     short res_ev = (short) 0;
     if (ev & ERTS_POLL_EV_IN)
-	res_ev |= ERTS_POLL_EV_NKP_IN;
+       res_ev |= ERTS_POLL_EV_NKP_IN;
     if (ev & ERTS_POLL_EV_OUT)
-	res_ev |= ERTS_POLL_EV_NKP_OUT;
+       res_ev |= ERTS_POLL_EV_NKP_OUT;
     return res_ev;
-#endif
 }
 
 static ERTS_INLINE ErtsPollEvents
 pollev2ev(short ev)
 {
-#if !ERTS_POLL_USE_FALLBACK || ERTS_POLL_USE_KQUEUE
-    return ERTS_POLL_EV_N2E(ev);
-#else /* Note, we only map events we are interested in */
     ErtsPollEvents res_ev = (ErtsPollEvents) 0;
     if (ev & ERTS_POLL_EV_NKP_IN)
-	res_ev |= ERTS_POLL_EV_IN;
+       res_ev |= ERTS_POLL_EV_IN;
     if (ev & ERTS_POLL_EV_NKP_OUT)
-	res_ev |= ERTS_POLL_EV_OUT;
+       res_ev |= ERTS_POLL_EV_OUT;
     if (ev & ERTS_POLL_EV_NKP_ERR)
-	res_ev |= ERTS_POLL_EV_ERR;
+       res_ev |= ERTS_POLL_EV_ERR;
     if (ev & ERTS_POLL_EV_NKP_NVAL)
-	res_ev |= ERTS_POLL_EV_NVAL;
-    return res_ev;
-#endif
+       res_ev |= ERTS_POLL_EV_NVAL;
+   return res_ev;
 }
 
-#endif
+#endif /* !ERTS_POLL_IS_FALLBACK */
+
+#endif /* ERTS_POLL_USE_POLL */
+
 
 #ifdef HARD_DEBUG
 static void check_poll_result(ErtsPollResFd pr[], int len);
-#if ERTS_POLL_USE_DEVPOLL
-static void check_poll_status(ErtsPollSet ps);
-#endif /* ERTS_POLL_USE_DEVPOLL */
 #endif /* HARD_DEBUG */
-#ifdef ERTS_POLL_DEBUG_PRINT
+#if ERTS_POLL_USE_DEVPOLL && defined(DEBUG)
+static void check_poll_status(ErtsPollSet *ps);
+#endif /* ERTS_POLL_USE_DEVPOLL && DEBUG */
 static void print_misc_debug_info(void);
+#if ERTS_POLL_USE_EPOLL
+uint32_t epoll_events(int kp_fd, int fd);
 #endif
 
-static ERTS_INLINE void
-init_timeout_time(ErtsPollSet ps)
-{
-    erts_atomic64_init_nob(&ps->timeout_time,
-			   (erts_aint64_t) ERTS_MONOTONIC_TIME_MAX);
-}
-
-static ERTS_INLINE void
-set_timeout_time(ErtsPollSet ps, ErtsMonotonicTime time)
-{
-    erts_atomic64_set_relb(&ps->timeout_time,
-			   (erts_aint64_t) time);
-}
-
-static ERTS_INLINE ErtsMonotonicTime
-get_timeout_time(ErtsPollSet ps)
-{
-    return (ErtsMonotonicTime) erts_atomic64_read_acqb(&ps->timeout_time);
-}
 
 #define ERTS_POLL_NOT_WOKEN	0
 #define ERTS_POLL_WOKEN		-1
 #define ERTS_POLL_WOKEN_INTR	1
 
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 static ERTS_INLINE void
-reset_wakeup_state(ErtsPollSet ps)
+reset_wakeup_state(ErtsPollSet *ps)
 {
     erts_atomic32_set_mb(&ps->wakeup_state, ERTS_POLL_NOT_WOKEN);
 }
+#endif
 
 static ERTS_INLINE int
-is_woken(ErtsPollSet ps)
+is_woken(ErtsPollSet *ps)
 {
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     return erts_atomic32_read_acqb(&ps->wakeup_state) != ERTS_POLL_NOT_WOKEN;
+#else
+    return 0;
+#endif
 }
 
 static ERTS_INLINE int
-is_interrupted_reset(ErtsPollSet ps)
+is_interrupted_reset(ErtsPollSet *ps)
 {
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     return (erts_atomic32_xchg_acqb(&ps->wakeup_state, ERTS_POLL_NOT_WOKEN)
 	    == ERTS_POLL_WOKEN_INTR);
+#else
+    return 0;
+#endif
 }
 
 static ERTS_INLINE void
-woke_up(ErtsPollSet ps)
+woke_up(ErtsPollSet *ps)
 {
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     erts_aint32_t wakeup_state = erts_atomic32_read_acqb(&ps->wakeup_state);
     if (wakeup_state == ERTS_POLL_NOT_WOKEN)
 	(void) erts_atomic32_cmpxchg_nob(&ps->wakeup_state,
 					 ERTS_POLL_WOKEN,
 					 ERTS_POLL_NOT_WOKEN);
     ASSERT(erts_atomic32_read_nob(&ps->wakeup_state) != ERTS_POLL_NOT_WOKEN);
+#endif
 }
 
 /*
  * --- Wakeup pipe -----------------------------------------------------------
  */
 
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 
 static ERTS_INLINE void
-wake_poller(ErtsPollSet ps, int interrupted, int async_signal_safe)
+wake_poller(ErtsPollSet *ps, int interrupted)
 {
     int wake;
-    if (async_signal_safe)
-	wake = 1;
-    else {
-	erts_aint32_t wakeup_state;
-	if (!interrupted)
-	    wakeup_state = erts_atomic32_cmpxchg_relb(&ps->wakeup_state,
-						      ERTS_POLL_WOKEN,
-						      ERTS_POLL_NOT_WOKEN);
-	else
-            wakeup_state = erts_atomic32_xchg_relb(&ps->wakeup_state,
-                                                   ERTS_POLL_WOKEN_INTR);
-	wake = wakeup_state == ERTS_POLL_NOT_WOKEN;
-    }
-    /*
-     * NOTE: This function might be called from signal handlers in the
-     *       non-smp case; therefore, it has to be async-signal safe in
-     *       the non-smp case.
-     */
+    erts_aint32_t wakeup_state;
+    if (!interrupted)
+        wakeup_state = erts_atomic32_cmpxchg_relb(&ps->wakeup_state,
+                                                  ERTS_POLL_WOKEN,
+                                                  ERTS_POLL_NOT_WOKEN);
+    else
+        wakeup_state = erts_atomic32_xchg_relb(&ps->wakeup_state,
+                                               ERTS_POLL_WOKEN_INTR);
+    wake = wakeup_state == ERTS_POLL_NOT_WOKEN;
+
     if (wake) {
 	ssize_t res;
 	if (ps->wake_fds[1] < 0)
@@ -432,29 +422,27 @@ wake_poller(ErtsPollSet ps, int interrupted, int async_signal_safe)
 	    res = write(ps->wake_fds[1], "!", 1);
 	} while (res < 0 && errno == EINTR);
 	if (res <= 0 && errno != ERRNO_BLOCK) {
-	    if (async_signal_safe)
-		fatal_error_async_signal_safe(__FILE__
-					      ":XXX:wake_poller(): "
-					      "Failed to write on wakeup pipe\n");
-	    else
-		fatal_error("%s:%d:wake_poller(): "
-			    "Failed to write to wakeup pipe fd=%d: "
-			    "%s (%d)\n",
-			    __FILE__, __LINE__,
-			    ps->wake_fds[1],
-			    erl_errno_id(errno), errno);
+            fatal_error("%s:%d:wake_poller(): "
+                        "Failed to write to wakeup pipe fd=%d: "
+                        "%s (%d)\n",
+                        __FILE__, __LINE__,
+                        ps->wake_fds[1],
+                        erl_errno_id(errno), errno);
 	}
     }
 }
 
 static ERTS_INLINE void
-cleanup_wakeup_pipe(ErtsPollSet ps)
+cleanup_wakeup_pipe(ErtsPollSet *ps)
 {
+    int intr = 0;
     int fd = ps->wake_fds[0];
     int res;
     do {
 	char buf[32];
 	res = read(fd, buf, sizeof(buf));
+	if (res > 0)
+	    intr = 1;
     } while (res > 0 || (res < 0 && errno == EINTR));
     if (res < 0 && errno != ERRNO_BLOCK) {
 	fatal_error("%s:%d:cleanup_wakeup_pipe(): "
@@ -464,10 +452,12 @@ cleanup_wakeup_pipe(ErtsPollSet ps)
 		    fd,
 		    erl_errno_id(errno), errno);
     }
+    if (intr)
+	erts_atomic32_set_nob(&ps->wakeup_state, ERTS_POLL_WOKEN_INTR);
 }
 
 static void
-create_wakeup_pipe(ErtsPollSet ps)
+create_wakeup_pipe(ErtsPollSet *ps)
 {
     int do_wake = 0;
     int wake_fds[2];
@@ -484,20 +474,13 @@ create_wakeup_pipe(ErtsPollSet ps)
     SET_NONBLOCKING(wake_fds[0]);
     SET_NONBLOCKING(wake_fds[1]);
 
-#ifdef ERTS_POLL_DEBUG_PRINT
-    erts_printf("wakeup fds = {%d, %d}\n", wake_fds[0], wake_fds[1]);
-#endif
+    DEBUG_PRINT("wakeup fds = {%d, %d}", ps, wake_fds[0], wake_fds[1]);
 
     ERTS_POLL_EXPORT(erts_poll_control)(ps,
 					wake_fds[0],
+                                        ERTS_POLL_OP_ADD,
 					ERTS_POLL_EV_IN,
-					1, &do_wake);
-#if ERTS_POLL_USE_FALLBACK
-    /* We depend on the wakeup pipe being handled by kernel poll */
-    if (ps->fds_status[wake_fds[0]].flags & ERTS_POLL_FD_FLG_INFLBCK)
-	fatal_error("%s:%d:create_wakeup_pipe(): Internal error\n",
-		    __FILE__, __LINE__);
-#endif
+                                        &do_wake);
     if (ps->internal_fd_limit <= wake_fds[1])
 	ps->internal_fd_limit = wake_fds[1] + 1;
     if (ps->internal_fd_limit <= wake_fds[0])
@@ -508,80 +491,11 @@ create_wakeup_pipe(ErtsPollSet ps)
 
 
 /*
- * --- timer fd -----------------------------------------------------------
- */
-
-#if ERTS_POLL_USE_TIMERFD
-
-/* We use the timerfd when using epoll_wait to get high accuracy
-   timeouts, i.e. we want to sleep with < ms accuracy. */
-
-static void
-create_timerfd(ErtsPollSet ps)
-{
-    int do_wake = 0;
-    int timer_fd;
-    timer_fd = timerfd_create(CLOCK_MONOTONIC,0);
-    ERTS_POLL_EXPORT(erts_poll_control)(ps,
-					timer_fd,
-					ERTS_POLL_EV_IN,
-					1, &do_wake);
-#if ERTS_POLL_USE_FALLBACK
-    /* We depend on the wakeup pipe being handled by kernel poll */
-    if (ps->fds_status[timer_fd].flags & ERTS_POLL_FD_FLG_INFLBCK)
-	fatal_error("%s:%d:create_wakeup_pipe(): Internal error\n",
-		    __FILE__, __LINE__);
-#endif
-    if (ps->internal_fd_limit <= timer_fd)
-	ps->internal_fd_limit = timer_fd + 1;
-    ps->timer_fd = timer_fd;
-}
-
-static ERTS_INLINE void
-timerfd_set(ErtsPollSet ps, struct itimerspec *its)
-{
-#ifdef DEBUG
-    struct itimerspec old_its;
-    int res;
-    res = timerfd_settime(ps->timer_fd, 0, its, &old_its);
-    ASSERT(res == 0);
-    ASSERT(old_its.it_interval.tv_sec == 0 &&
-           old_its.it_interval.tv_nsec == 0 &&
-           old_its.it_value.tv_sec == 0 &&
-           old_its.it_value.tv_nsec == 0);
-
-#else
-    timerfd_settime(ps->timer_fd, 0, its, NULL);
-#endif
-}
-
-static ERTS_INLINE int
-timerfd_clear(ErtsPollSet ps, int res, int max_res) {
-
-    struct itimerspec its;
-    /* we always have to clear the timer */
-    its.it_interval.tv_sec = 0;
-    its.it_interval.tv_nsec = 0;
-    its.it_value.tv_sec = 0;
-    its.it_value.tv_nsec = 0;
-    timerfd_settime(ps->timer_fd, 0, &its, NULL);
-
-    /* only timeout fd triggered */
-    if (res == 1 && ps->res_events[0].data.fd == ps->timer_fd)
-        return 0;
-
-    return res;
-}
-
-#endif /* ERTS_POLL_USE_TIMERFD */
-
-
-/*
  * --- Poll set update requests ----------------------------------------------
  */
 
 static ERTS_INLINE void
-enqueue_update_request(ErtsPollSet ps, int fd)
+enqueue_update_request(ErtsPollSet *ps, int fd)
 {
     ErtsPollSetUpdateRequestsBlock *urqbp;
 
@@ -596,13 +510,11 @@ enqueue_update_request(ErtsPollSet ps, int fd)
     urqbp = ps->curr_upd_req_block;
 
     if (urqbp->len == ERTS_POLLSET_UPDATE_REQ_BLOCK_SIZE) {
-	ASSERT(!urqbp->next);
 	urqbp = erts_alloc(ERTS_ALC_T_POLLSET_UPDREQ,
 			   sizeof(ErtsPollSetUpdateRequestsBlock));
-	ps->curr_upd_req_block->next = urqbp;
-	ps->curr_upd_req_block = urqbp;
-	urqbp->next = NULL;
+	urqbp->next = ps->curr_upd_req_block;
 	urqbp->len = 0;
+	ps->curr_upd_req_block = urqbp;
     }
 
     ps->fds_status[fd].flags |= ERTS_POLL_FD_FLG_INURQ;
@@ -610,28 +522,29 @@ enqueue_update_request(ErtsPollSet ps, int fd)
 }
 
 static ERTS_INLINE void
-free_update_requests_block(ErtsPollSet ps,
+free_update_requests_block(ErtsPollSet *ps,
 			   ErtsPollSetUpdateRequestsBlock *urqbp)
 {
     if (urqbp != &ps->update_requests)
 	erts_free(ERTS_ALC_T_POLLSET_UPDREQ, (void *) urqbp);
     else {
-	urqbp->next = NULL;
 	urqbp->len = 0;
     }
 }
 
+#endif /* !ERTS_POLL_USE_CONCURRENT_UPDATE */
 
 /*
  * --- Growing poll set structures -------------------------------------------
  */
 
-#ifndef ERTS_KERNEL_POLL_VERSION   /* only one shared implementation */
+#if !ERTS_NO_KERNEL_POLL_VERSION || !ERTS_ENABLE_KERNEL_POLL
+/* only one shared implementation */
 
 #define ERTS_FD_TABLE_MIN_LENGTH	1024
 #define ERTS_FD_TABLE_EXP_THRESHOLD	(2048*1024)
 
-int erts_poll_new_table_len (int old_len, int need_len)
+int erts_poll_new_table_len(int old_len, int need_len)
 {
     int new_len;
 
@@ -641,7 +554,7 @@ int erts_poll_new_table_len (int old_len, int need_len)
     }
     else {
         new_len = old_len;
-        do {            
+        do {
             if (new_len < ERTS_FD_TABLE_EXP_THRESHOLD)
                 new_len *= 2;
             else
@@ -654,30 +567,9 @@ int erts_poll_new_table_len (int old_len, int need_len)
 }
 #endif
 
-#if ERTS_POLL_USE_KERNEL_POLL
-static void
-grow_res_events(ErtsPollSet ps, int new_len)
-{
-    size_t new_size = sizeof(
-#if ERTS_POLL_USE_EPOLL
-	struct epoll_event
-#elif ERTS_POLL_USE_DEVPOLL
-	struct pollfd
-#elif ERTS_POLL_USE_KQUEUE
-	struct kevent
-#endif
-	) * erts_poll_new_table_len(ps->res_events_len, new_len);
-    /* We do not need to save previously stored data */
-    if (ps->res_events)
-	erts_free(ERTS_ALC_T_POLL_RES_EVS, ps->res_events);
-    ps->res_events = erts_alloc(ERTS_ALC_T_POLL_RES_EVS, new_size);
-    ps->res_events_len = new_len;
-}
-#endif /* ERTS_POLL_USE_KERNEL_POLL */
-
 #if ERTS_POLL_USE_POLL
 static void
-grow_poll_fds(ErtsPollSet ps, int min_ix)
+grow_poll_fds(ErtsPollSet *ps, int min_ix)
 {
     int i;
     int new_len = erts_poll_new_table_len(ps->poll_fds_len, min_ix + 1);
@@ -725,8 +617,9 @@ ensure_select_fds(int fd, ERTS_fd_set* in, ERTS_fd_set* out)
 #  define ensure_select_fds(fd, in, out) do {} while(0)
 #endif /* _DARWIN_UNLIMITED_SELECT */
 
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 static void
-grow_fds_status(ErtsPollSet ps, int min_fd)
+grow_fds_status(ErtsPollSet *ps, int min_fd)
 {
     int i;
     int new_len = erts_poll_new_table_len(ps->fds_status_len, min_fd + 1);
@@ -745,95 +638,290 @@ grow_fds_status(ErtsPollSet ps, int min_fd)
 #endif
 	ps->fds_status[i].used_events = (ErtsPollEvents) 0;
 	ps->fds_status[i].events = (ErtsPollEvents) 0;
-#if ERTS_POLL_COALESCE_KP_RES
-	ps->fds_status[i].res_ev_ix = (unsigned short) ERTS_POLL_MAX_RES;
-#endif
 	ps->fds_status[i].flags = (unsigned short) 0;
     }
     ps->fds_status_len = new_len;
 }
+#endif
 
 /*
  * --- Selecting fd to poll on -----------------------------------------------
  */
 
-#if ERTS_POLL_USE_FALLBACK
-static int update_fallback_pollset(ErtsPollSet ps, int fd);
-#endif
-
-static ERTS_INLINE int
-need_update(ErtsPollSet ps, int fd)
+#if ERTS_POLL_USE_EPOLL
+static int
+update_pollset(ErtsPollSet *ps, int fd, ErtsPollOp op, ErtsPollEvents events)
 {
-#if ERTS_POLL_USE_KERNEL_POLL
-    int reset;
+    int res;
+    int epoll_op = EPOLL_CTL_MOD;
+    struct epoll_event epe_templ;
+    struct epoll_event epe;
+
+    epe_templ.events = ERTS_POLL_EV_E2N(events) | EPOLLONESHOT;
+    epe_templ.data.fd = fd;
+
+#ifdef VALGRIND
+    /* Silence invalid valgrind warning ... */
+    memset((void *) &epe.data, 0, sizeof(epoll_data_t));
 #endif
 
-    ASSERT(fd < ps->fds_status_len);
-
-#if ERTS_POLL_USE_KERNEL_POLL
-    reset = (int) (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_RST);
-    if (reset && !ps->fds_status[fd].used_events) {
-	ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_RST;
-	reset = 0;
+    switch (op) {
+    case ERTS_POLL_OP_DEL:
+	/* A note on EPOLL_CTL_DEL: linux kernel versions before 2.6.9
+	   need a non-NULL event pointer even though it is ignored... */
+        epoll_op = EPOLL_CTL_DEL;
+        epe_templ.events = 0;
+	erts_atomic_dec_nob(&ps->no_of_user_fds);
+        break;
+    case ERTS_POLL_OP_ADD:
+        epoll_op = EPOLL_CTL_ADD;
+	erts_atomic_inc_nob(&ps->no_of_user_fds);
+        break;
+    case ERTS_POLL_OP_MOD:
+        epoll_op = EPOLL_CTL_MOD;
+        break;
+    default:
+        ASSERT(0);
+        break;
     }
-#else
-    ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_RST;
-#endif
 
-    if (ps->fds_status[fd].used_events != ps->fds_status[fd].events)
-	return 1;
+    do {
+	/* We init 'epe' every time since epoll_ctl() may modify it
+	   (not declared const and not documented as const). */
+	epe.events = epe_templ.events;
+	epe.data.fd = epe_templ.data.fd;
+	res = epoll_ctl(ps->kp_fd, epoll_op, fd, &epe);
+    } while (res != 0 && errno == EINTR);
 
-#if ERTS_POLL_USE_KERNEL_POLL
-    return reset;
-#else
-    return 0;
+#if ERTS_POLL_DEBUG_PRINT
+    {
+	int saved_errno = errno;
+	DEBUG_PRINT_FD("%s = epoll_ctl(%d, %s, %d, {0x%x, %d})",
+                       ps, fd,
+                       res == 0 ? "0" : erl_errno_id(errno),
+                       ps->kp_fd,
+                       (epoll_op == EPOLL_CTL_ADD
+                        ? "EPOLL_CTL_ADD"
+                        : (epoll_op == EPOLL_CTL_MOD
+                           ? "EPOLL_CTL_MOD"
+                           : (epoll_op == EPOLL_CTL_DEL
+                              ? "EPOLL_CTL_DEL"
+                              : "UNKNOWN"))),
+                       fd,
+                       epe_templ.events,
+                       fd);
+	errno = saved_errno;
+    }
 #endif
+    if (res != 0) {
+	switch (op) {
+	case ERTS_POLL_OP_MOD:
+	    epe.events = 0;
+	    do {
+		/* We init 'epe' every time since epoll_ctl() may modify it
+		   (not declared const and not documented as const). */
+		epe.events = 0;
+		epe.data.fd = fd;
+		res = epoll_ctl(ps->kp_fd, EPOLL_CTL_DEL, fd, &epe);
+	    } while (res != 0 && errno == EINTR);
+	/* Fall through ... */
+	case ERTS_POLL_OP_ADD: {
+	    erts_atomic_dec_nob(&ps->no_of_user_fds);
+            res = ERTS_POLL_EV_NVAL;
+	    break;
+	}
+	case ERTS_POLL_OP_DEL: {
+	    /*
+	     * Since we use a lazy update approach EPOLL_CTL_DEL will
+	     * frequently fail. This since epoll automatically removes
+	     * a filedescriptor that is closed from the poll set.
+	     */
+	    res = 0;
+	    break;
+	}
+	default:
+	    fatal_error("%s:%d:update_pollset(): Internal error\n",
+			__FILE__, __LINE__);
+	    break;
+	}
+    } else {
+        res = events;
+    }
+    return res;
 }
 
-#if ERTS_POLL_USE_BATCH_UPDATE_POLLSET
+#endif /* ERTS_POLL_USE_EPOLL */
 
 #if ERTS_POLL_USE_KQUEUE
-#define ERTS_POLL_MIN_BATCH_BUF_SIZE 128
+
+/* Some versions of the EV_SET macro used kevp multiple times,
+   so we define out own version that make sure that it is safe
+   to do kevp++ in the argument list. */
+#define ERTS_EV_SET(kevp, a, b, c, f) do {              \
+        struct kevent *kevp_ = kevp;                    \
+        EV_SET(kevp_, a, b, c, 0, 0, f);                \
+    } while(0)
+
+static int
+update_pollset(ErtsPollSet *ps, int fd, ErtsPollOp op, ErtsPollEvents events)
+{
+    int res = 0, len = 0;
+    struct kevent evts[2];
+    struct timespec ts = {0, 0};
+
+#ifdef EV_DISPATCH
+    /* If we have EV_DISPATCH we use it. The kevent descriptions for both
+       read and write are added on OP_ADD and removed on OP_DEL. And then
+       after than only EV_ENABLE|EV_DISPATCH are used.
+
+       It could be possible to not modify the pollset when disabling and/or
+       deleting events, but that may cause the poll threads to be awoken
+       a lot more than they should so we take the cost here instead of
+       in the poll thread.
+
+       Note: We need to have EV_DISPATCH both when the event is enabled and
+       disabled, as otherwise the event may be triggered twice on each re-arm.
+       Not sure if this is intended or not (can't find anything about it in the
+       man page), but it seems to be the way it works...
+    */
+
+    if (op == ERTS_POLL_OP_DEL) {
+        erts_atomic_dec_nob(&ps->no_of_user_fds);
+        /* We could probably skip this delete, do we want to? */
+        ERTS_EV_SET(&evts[len++], fd, EVFILT_READ, EV_DELETE, (void *) 0);
+        ERTS_EV_SET(&evts[len++], fd, EVFILT_WRITE, EV_DELETE, (void *) 0);
+    } else if (op == ERTS_POLL_OP_ADD) {
+        uint32_t flags;
+        erts_atomic_inc_nob(&ps->no_of_user_fds);
+
+        flags = EV_ADD|EV_DISPATCH;
+        flags |= ((events & ERTS_POLL_EV_IN) ? 0 : EV_DISABLE);
+        ERTS_EV_SET(&evts[len++], fd, EVFILT_READ, flags, (void *) ERTS_POLL_EV_IN);
+
+        flags = EV_ADD|EV_DISPATCH;
+        flags |= ((events & ERTS_POLL_EV_OUT) ? 0 : EV_DISABLE);
+        ERTS_EV_SET(&evts[len++], fd, EVFILT_WRITE, flags, (void *) ERTS_POLL_EV_OUT);
+    } else {
+        uint32_t flags;
+        ASSERT(op == ERTS_POLL_OP_MOD);
+
+        flags = EV_DISPATCH;
+        flags |= (events & ERTS_POLL_EV_IN) ? EV_ENABLE : EV_DISABLE;
+        ERTS_EV_SET(&evts[len++], fd, EVFILT_READ, flags, (void *) ERTS_POLL_EV_IN);
+
+        flags = EV_DISPATCH;
+        flags |= (events & ERTS_POLL_EV_OUT) ? EV_ENABLE : EV_DISABLE;
+        ERTS_EV_SET(&evts[len++], fd, EVFILT_WRITE, flags, (void *) ERTS_POLL_EV_OUT);
+    }
 #else
-#define ERTS_POLL_MIN_BATCH_BUF_SIZE 64
+    uint32_t flags = EV_ADD|EV_ONESHOT;
+
+    if (op == ERTS_POLL_OP_DEL) {
+        erts_atomic_dec_nob(&ps->no_of_user_fds);
+        /* We don't do anything when a delete is issued. The fds will be removed
+           when they are triggered, or when they are closed. */
+        events = 0;
+    } else if (op == ERTS_POLL_OP_ADD) {
+        erts_atomic_inc_nob(&ps->no_of_user_fds);
+    }
+
+    if (events & ERTS_POLL_EV_IN) {
+        ERTS_EV_SET(&evts[len++], fd, EVFILT_READ, flags, (void *) ERTS_POLL_EV_IN);
+    }
+    if (events & ERTS_POLL_EV_OUT) {
+        ERTS_EV_SET(&evts[len++], fd, EVFILT_WRITE, flags, (void *) ERTS_POLL_EV_OUT);
+    }
+
+#endif
+    if (len)
+        do {
+            res = kevent(ps->kp_fd, evts, len, NULL, 0, &ts);
+        } while (res < 0 && errno == EINTR);
+#if ERTS_POLL_DEBUG_PRINT
+    {
+        int saved_errno = errno, i;
+        char keventb[255], *keventbp = keventb;
+        if (res < 0)
+            keventbp += sprintf(keventbp,"%s = ",erl_errno_id(saved_errno));
+        else
+            keventbp += sprintf(keventbp,"%d = ",res);
+        keventbp += sprintf(keventbp, "kevent(%d, {",ps->kp_fd);
+        for (i = 0; i < len; i++) {
+            const char *flags = "UNKNOWN";
+            if (evts[i].flags == EV_DELETE) flags = "EV_DELETE";
+            if (evts[i].flags == (EV_ADD|EV_ONESHOT)) flags = "EV_ADD|EV_ONESHOT";
+#ifdef EV_DISPATCH
+            if (evts[i].flags == (EV_ADD|EV_DISPATCH)) flags = "EV_ADD|EV_DISPATCH";
+            if (evts[i].flags == (EV_ADD|EV_DISABLE)) flags = "EV_ADD|EV_DISABLE";
+            if (evts[i].flags == (EV_ENABLE|EV_DISPATCH)) flags = "EV_ENABLE|EV_DISPATCH";
+            if (evts[i].flags == EV_DISABLE) flags = "EV_DISABLE";
+            if (evts[i].flags == (EV_DISABLE|EV_DISPATCH)) flags = "EV_DISABLE|EV_DISABLE";
 #endif
 
-typedef struct {
-    int len;
-    int size;
-#if ERTS_POLL_USE_DEVPOLL
-    struct pollfd *buf;
-#elif ERTS_POLL_USE_KQUEUE
-    struct kevent *buf;
-    struct kevent *ebuf;
+            keventbp += sprintf(keventbp, "%s{%lu, %s, %s}",i > 0 ? ", " : "",
+                                evts[i].ident,
+                                (evts[i].filter == EVFILT_READ
+                                 ? "EVFILT_READ"
+                                 : (evts[i].filter == EVFILT_WRITE
+                                    ? "EVFILT_WRITE"
+                                    : "UNKNOWN")), flags);
+        }
+        keventbp += sprintf(keventbp, "}, %d)", len);
+        DEBUG_PRINT_FD("%s", ps, fd, keventb);
+        errno = saved_errno;
+    }
 #endif
-} ErtsPollBatchBuf;
+    if (res < 0) {
+        if (op != ERTS_POLL_OP_DEL) {
+#ifdef EV_RECEIPT
+            struct kevent receipt_evts[2];
+            len = 0;
+            ERTS_EV_SET(&evts[len++], fd, EVFILT_WRITE, EV_DELETE|EV_RECEIPT, (void *) 0);
+            ERTS_EV_SET(&evts[len++], fd, EVFILT_READ, EV_DELETE|EV_RECEIPT, (void *) 0);
+            do {
+                res = kevent(ps->kp_fd, evts, len, receipt_evts, 2, &ts);
+            } while (res < 0 && errno == EINTR);
+#else
+            ERTS_EV_SET(&evts[0], fd, EVFILT_WRITE, EV_DELETE, (void *) 0);
+            do {
+                res = kevent(ps->kp_fd, evts, 1, NULL, 0, &ts);
+            } while (res < 0 && errno == EINTR);
+            ERTS_EV_SET(&evts[0], fd, EVFILT_READ, EV_DELETE, (void *) 0);
+            do {
+                res = kevent(ps->kp_fd, evts, 1, NULL, 0, &ts);
+            } while (res < 0 && errno == EINTR);
+#endif
+            if (op == ERTS_POLL_OP_ADD)
+                erts_atomic_dec_nob(&ps->no_of_user_fds);
+            return ERTS_POLL_EV_NVAL;
+        }
+        return 0;
+    }
+    return events;
+}
 
+#endif /* ERTS_POLL_USE_KQUEUE */
+
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 
 static ERTS_INLINE void
-setup_batch_buf(ErtsPollSet ps, ErtsPollBatchBuf *bbp)
+init_batch_update(ErtsPollSet *ps, int len)
 {
-    bbp->len = 0;
 #if ERTS_POLL_USE_DEVPOLL
-    bbp->size = ps->res_events_len;
-    bbp->buf = ps->res_events;
-#elif ERTS_POLL_USE_KQUEUE
-    bbp->size = ps->res_events_len/2;
-    bbp->buf = ps->res_events;
-    bbp->ebuf = bbp->buf + bbp->size;
+    ASSERT(ps->poll_fds == NULL);
+    ps->poll_fds = erts_alloc(ERTS_ALC_T_TMP, sizeof(struct pollfd) * len);
+    ps->poll_fds_ix = 0;
 #endif
 }
 
-
-#if ERTS_POLL_USE_DEVPOLL
-
-static void
-write_batch_buf(ErtsPollSet ps, ErtsPollBatchBuf *bbp)
+static ERTS_INLINE void
+write_batch_update(ErtsPollSet *ps)
 {
+#if ERTS_POLL_USE_DEVPOLL
     ssize_t wres;
-    char *buf = (char *) bbp->buf;
-    size_t buf_size = sizeof(struct pollfd)*bbp->len;
-    
+    char *buf = (char *) ps->poll_fds;
+    size_t buf_size = sizeof(struct pollfd)*ps->poll_fds_ix;
+
     while (1) {
 	wres = write(ps->kp_fd, (void *) buf, buf_size);
 	if (wres < 0) {
@@ -845,6 +933,30 @@ write_batch_buf(ErtsPollSet ps, ErtsPollBatchBuf *bbp)
 			__FILE__, __LINE__,
 			erl_errno_id(errno), errno);
 	}
+#if ERTS_POLL_DEBUG_PRINT
+        {
+            int saved_errno = errno, i;
+            char devpollb[2048], *devpollbp = devpollb;
+            devpollbp += sprintf(devpollbp, "%d = devpoll(%d, {", wres, ps->kp_fd);
+            for (i = 0; i < wres / sizeof(struct pollfd); i++) {
+                if (devpollbp == devpollb)
+                    devpollbp += sprintf(devpollbp, "%d = devpoll(%d, {", wres, ps->kp_fd);
+                devpollbp += sprintf(devpollbp, "%s{fd = %d, events = %s}",
+                                     i > 0 ? ", " : "",
+                                     ps->poll_fds[i].fd,
+                                     ev2str(ps->poll_fds[i].events));
+                if (devpollbp - devpollb > 512) {
+                    devpollbp += sprintf(devpollbp, "}, %d)", ps->poll_fds_ix);
+                    DEBUG_PRINT("%s", ps, devpollb);
+                    devpollbp = devpollb;
+                }
+            }
+            devpollbp += sprintf(devpollbp, "}, %d)", ps->poll_fds_ix);
+            DEBUG_PRINT("%s", ps, devpollb);
+            errno = saved_errno;
+        }
+#endif
+
 	buf_size -= wres;
 	if (buf_size <= 0)
 	    break;
@@ -855,483 +967,54 @@ write_batch_buf(ErtsPollSet ps, ErtsPollBatchBuf *bbp)
 	fatal_error("%s:%d:write_devpoll_buf(): Internal error\n",
 		    __FILE__, __LINE__);
     }
-    bbp->len = 0;
+    erts_free(ERTS_ALC_T_TMP, ps->poll_fds);
+    ps->poll_fds = NULL;
+#endif
 }
 
-#elif ERTS_POLL_USE_KQUEUE
-
-static void
-write_batch_buf(ErtsPollSet ps, ErtsPollBatchBuf *bbp)
+static ERTS_INLINE int
+need_update(ErtsPollSet *ps, int fd, int *resetp)
 {
-    int res;
-    int len = bbp->len;
-    struct kevent *buf = bbp->buf;
-    struct timespec ts = {0, 0};
-
-    do {
-	res = kevent(ps->kp_fd, buf, len, NULL, 0, &ts);
-    } while (res < 0 && errno == EINTR);
-    if (res < 0) {
-	int i;
-	struct kevent *ebuf = bbp->ebuf;
-	do {
-	    res = kevent(ps->kp_fd, buf, len, ebuf, len, &ts);
-	} while (res < 0 && errno == EINTR);
-	if (res < 0) {
-	    fatal_error("%s:%d: kevent() failed: %s (%d)\n",
-			__FILE__, __LINE__, erl_errno_id(errno), errno);
-	}
-	for (i = 0; i < res; i++) {
-	    if (ebuf[i].flags & EV_ERROR) {
-		short filter;
-		int fd = (int) ebuf[i].ident;
-
-		switch ((int) (long) ebuf[i].udata) {
-
-		    /*
-		     * Since we use a lazy update approach EV_DELETE will
-		     * frequently fail. This since kqueue automatically
-		     * removes a file descriptor that is closed from the
-		     * poll set.
-		     */
-		case ERTS_POLL_KQ_OP_DEL_R:
-		case ERTS_POLL_KQ_OP_DEL_W:
-		case ERTS_POLL_KQ_OP_HANDLED:
-		    break;
-
-		    /*
-		     * According to the kqueue man page EVFILT_READ support
-		     * does not imply EVFILT_WRITE support; therefore,
-		     * if an EV_ADD fail, we may have to remove other
-		     * events on this fd in the kqueue pollset before
-		     * adding fd to the fallback pollset.
-		     */
-		case ERTS_POLL_KQ_OP_ADD_W:
-		    if (ps->fds_status[fd].used_events & ERTS_POLL_EV_IN) {
-			filter = EVFILT_READ;
-			goto rm_add_fb;
-		    }
-		    goto add_fb;
-		case ERTS_POLL_KQ_OP_ADD_R:
-		    if (ps->fds_status[fd].used_events & ERTS_POLL_EV_OUT) {
-			filter = EVFILT_WRITE;
-			goto rm_add_fb;
-		    }
-		    goto add_fb;
-		case ERTS_POLL_KQ_OP_ADD2_W:
-		case ERTS_POLL_KQ_OP_ADD2_R: {
-		    int j;
-		    for (j = i+1; j < res; j++) {
-			if (fd == (int) ebuf[j].ident) {
-			    ebuf[j].udata = (void *) ERTS_POLL_KQ_OP_HANDLED;
-			    if (!(ebuf[j].flags & EV_ERROR)) {
-				switch ((int) (long) ebuf[j].udata) {
-				case ERTS_POLL_KQ_OP_ADD2_W:
-				    filter = EVFILT_WRITE;
-				    goto rm_add_fb;
-				case ERTS_POLL_KQ_OP_ADD2_R:
-				    filter = EVFILT_READ;
-				    goto rm_add_fb;
-				default:
-				    fatal_error("%s:%d:write_batch_buf(): "
-						"Internal error",
-						__FILE__, __LINE__);
-				    break;
-				}
-			    }
-			    goto add_fb;
-			}
-		    }
-		    /* The other add succeded... */
-		    filter = ((((int) (long) ebuf[i].udata)
-			       == ERTS_POLL_KQ_OP_ADD2_W)
-			      ? EVFILT_READ
-			      : EVFILT_WRITE);
-		rm_add_fb:
-		    { 
-			struct kevent kev;
-			struct timespec ts = {0, 0};
-			EV_SET(&kev, fd, filter, EV_DELETE, 0, 0, 0);
-			(void) kevent(ps->kp_fd, &kev, 1, NULL, 0, &ts);
-		    }
-
-		add_fb:
-		    ps->fds_status[fd].flags |= ERTS_POLL_FD_FLG_USEFLBCK;
-		    ASSERT(ps->fds_status[fd].used_events);
-		    ps->fds_status[fd].used_events = 0;
-		    erts_atomic_dec_nob(&ps->no_of_user_fds);
-		    update_fallback_pollset(ps, fd);
-		    ASSERT(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK);
-		    break;
-		}
-		default:
-		    fatal_error("%s:%d:write_batch_buf(): Internal error",
-				__FILE__, __LINE__);
-		    break;
-		}
-	    }
-	}
-    }
-    bbp->len = 0;
-}
-
-#endif /* ERTS_POLL_USE_KQUEUE */
-
-static ERTS_INLINE void
-batch_update_pollset(ErtsPollSet ps, int fd, ErtsPollBatchBuf *bbp)
-{
-    int buf_len;
-#if ERTS_POLL_USE_DEVPOLL
-    short events;
-    struct pollfd *buf;
-#elif ERTS_POLL_USE_KQUEUE
-    struct kevent *buf;
-#endif
-
-#ifdef ERTS_POLL_DEBUG_PRINT
-    erts_printf("Doing lazy update on fd=%d\n", fd);
-#endif
-
-    if (!need_update(ps, fd))
-	return;
-
-    /* Make sure we have room for at least maximum no of entries
-       per fd */
-    if (bbp->size - bbp->len < 2)
-	write_batch_buf(ps, bbp);
-
-    buf_len = bbp->len;
-    buf = bbp->buf;
-
+    int reset;
     ASSERT(fd < ps->fds_status_len);
 
-#if ERTS_POLL_USE_DEVPOLL
-    events = ERTS_POLL_EV_E2N(ps->fds_status[fd].events);
-    if (!events) {
-	buf[buf_len].events = POLLREMOVE;
-	erts_atomic_dec_nob(&ps->no_of_user_fds);
-    }
-    else if (!ps->fds_status[fd].used_events) {
-	buf[buf_len].events = events;
-	erts_atomic_inc_nob(&ps->no_of_user_fds);
-    }
-    else {
-	if ((ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_RST)
-	    || (ps->fds_status[fd].used_events & ~events)) {
-	    /* Reset or removed events... */
-	    buf[buf_len].fd = fd;
-	    buf[buf_len].events = POLLREMOVE;
-	    buf[buf_len++].revents = 0;
-	}
-	buf[buf_len].events = events;
-    }
-    buf[buf_len].fd = fd;
-    buf[buf_len++].revents = 0;
-
-#elif ERTS_POLL_USE_KQUEUE
-
-    if (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK) {
-	if (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_USEFLBCK)
-	    update_fallback_pollset(ps, fd);
-	else { /* Remove from fallback and try kqueue */
-	    ErtsPollEvents events = ps->fds_status[fd].events;
-	    ps->fds_status[fd].events = (ErtsPollEvents) 0;
-	    update_fallback_pollset(ps, fd);
-	    ASSERT(!(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK));
-	    if (events) {
-		ps->fds_status[fd].events = events;
-		goto try_kqueue;
-	    }
-	}
-    }
-    else {
-	ErtsPollEvents events, used_events;
-	int mod_w, mod_r;
-    try_kqueue:
-	events = ERTS_POLL_EV_E2N(ps->fds_status[fd].events);
-	used_events = ERTS_POLL_EV_E2N(ps->fds_status[fd].used_events);
-	if (!(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_RST)) {
-	    if (!used_events &&
-		(events & ERTS_POLL_EV_IN) && (events & ERTS_POLL_EV_OUT))
-		goto do_add_rw;
-	    mod_r = ((events & ERTS_POLL_EV_IN)
-		     != (used_events & ERTS_POLL_EV_IN));
-	    mod_w = ((events & ERTS_POLL_EV_OUT)
-		     != (used_events & ERTS_POLL_EV_OUT));
-	    goto do_mod;
-	}
-	else { /* Reset */
-	    if ((events & ERTS_POLL_EV_IN) && (events & ERTS_POLL_EV_OUT)) {
-	    do_add_rw:
-		EV_SET(&buf[buf_len], fd, EVFILT_READ, EV_ADD,
-		       0, 0, (void *) ERTS_POLL_KQ_OP_ADD2_R);
-		buf_len++;
-		EV_SET(&buf[buf_len], fd, EVFILT_WRITE, EV_ADD,
-		       0, 0, (void *) ERTS_POLL_KQ_OP_ADD2_W);
-		buf_len++;
-
-	    }
-	    else {
-		mod_r = 1;
-		mod_w = 1;
-	    do_mod:
-		if (mod_r) {
-		    if (events & ERTS_POLL_EV_IN) {
-			EV_SET(&buf[buf_len], fd, EVFILT_READ, EV_ADD,
-			       0, 0, (void *) ERTS_POLL_KQ_OP_ADD_R);
-			buf_len++;
-		    }
-		    else if (used_events & ERTS_POLL_EV_IN) {
-			EV_SET(&buf[buf_len], fd, EVFILT_READ, EV_DELETE,
-			       0, 0, (void *) ERTS_POLL_KQ_OP_DEL_R);
-			buf_len++;
-		    }
-		}
-		if (mod_w) {
-		    if (events & ERTS_POLL_EV_OUT) {
-			EV_SET(&buf[buf_len], fd, EVFILT_WRITE, EV_ADD,
-			       0, 0, (void *) ERTS_POLL_KQ_OP_ADD_W);
-			buf_len++;
-		    }
-		    else if (used_events & ERTS_POLL_EV_OUT) {
-			EV_SET(&buf[buf_len], fd, EVFILT_WRITE, EV_DELETE,
-			       0, 0, (void *) ERTS_POLL_KQ_OP_DEL_W);
-			buf_len++;
-		    }
-		}
-	    }
-	}
-	if (used_events) {
-	    if (!events) {
-		erts_atomic_dec_nob(&ps->no_of_user_fds);
-	    }
-	}
-	else {
-	    if (events)
-		erts_atomic_inc_nob(&ps->no_of_user_fds);
-	}
-	ASSERT((events & ~(ERTS_POLL_EV_IN|ERTS_POLL_EV_OUT)) == 0);
-	ASSERT((used_events & ~(ERTS_POLL_EV_IN|ERTS_POLL_EV_OUT)) == 0);
-    }	    
-
-#endif
-
+    reset = (int) (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_RST);
     ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_RST;
-    ps->fds_status[fd].used_events = ps->fds_status[fd].events;
 
-    bbp->len = buf_len;
+    *resetp = reset;
+
+    if (reset || ps->fds_status[fd].used_events != ps->fds_status[fd].events)
+	return 1;
+
+    return 0;
 }
 
-#else /* !ERTS_POLL_USE_BATCH_UPDATE_POLLSET */
-
-#if ERTS_POLL_USE_EPOLL
-static int
-#if ERTS_POLL_USE_CONCURRENT_UPDATE
-conc_update_pollset(ErtsPollSet ps, int fd, int *update_fallback)
-#else
-update_pollset(ErtsPollSet ps, int fd)
-#endif
+static int update_pollset(ErtsPollSet *ps, ErtsPollResFd pr[], int fd)
 {
-    int res;
-    int op;
-    struct epoll_event epe_templ;
-    struct epoll_event epe;
-
+    int res = 0, reset = 0;
+    ErtsPollEvents events = ps->fds_status[fd].events;
     ASSERT(fd < ps->fds_status_len);
 
-    if (!need_update(ps, fd))
-	return 0;
-
-#ifdef ERTS_POLL_DEBUG_PRINT
-    erts_printf("Doing update on fd=%d\n", fd);
-#endif
-    if (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK) {
-#if ERTS_POLL_USE_CONCURRENT_UPDATE
-	if (!*update_fallback) {
-	    *update_fallback = 1;
-	    return 0;
-	}
-#endif
-	if (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_USEFLBCK) {
-	    return update_fallback_pollset(ps, fd);
-	}
-	else { /* Remove from fallback and try epoll */
-	    ErtsPollEvents events = ps->fds_status[fd].events;
-	    ps->fds_status[fd].events = (ErtsPollEvents) 0;
-	    res = update_fallback_pollset(ps, fd);
-	    ASSERT(!(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK));
-	    if (!events)
-		return res;
-	    ps->fds_status[fd].events = events;
-	}
-    }
-
-    epe_templ.events = ERTS_POLL_EV_E2N(ps->fds_status[fd].events);
-    epe_templ.data.fd = fd;
-
-#ifdef VALGRIND
-    /* Silence invalid valgrind warning ... */
-    memset((void *) &epe.data, 0, sizeof(epoll_data_t));
-#endif
-
-    if (epe_templ.events && ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_RST) {
-	do {
-	    /* We init 'epe' every time since epoll_ctl() may modify it
-	       (not declared const and not documented as const). */
-	    epe.events = epe_templ.events;
-	    epe.data.fd = epe_templ.data.fd;
-	    res = epoll_ctl(ps->kp_fd, EPOLL_CTL_DEL, fd, &epe);
-	} while (res != 0 && errno == EINTR);
-	erts_atomic_dec_nob(&ps->no_of_user_fds);
-	ps->fds_status[fd].used_events = 0;
-    }
-
-    if (!epe_templ.events) {
-	/* A note on EPOLL_CTL_DEL: linux kernel versions before 2.6.9
-	   need a non-NULL event pointer even though it is ignored... */
-	op = EPOLL_CTL_DEL;
-	erts_atomic_dec_nob(&ps->no_of_user_fds);
-    }
-    else if (!ps->fds_status[fd].used_events) {
-	op = EPOLL_CTL_ADD;
-	erts_atomic_inc_nob(&ps->no_of_user_fds);
-    }
-    else {
-	op = EPOLL_CTL_MOD;
-    }
-
-    do {
-	/* We init 'epe' every time since epoll_ctl() may modify it
-	   (not declared const and not documented as const). */
-	epe.events = epe_templ.events;
-	epe.data.fd = epe_templ.data.fd;
-	res = epoll_ctl(ps->kp_fd, op, fd, &epe);
-    } while (res != 0 && errno == EINTR);
-
-#if defined(ERTS_POLL_DEBUG_PRINT) && 1
-    {
-	int saved_errno = errno;
-	erts_printf("%s = epoll_ctl(%d, %s, %d, {Ox%x, %d})\n",
-		     res == 0 ? "0" : erl_errno_id(errno),
-		     ps->kp_fd,
-		     (op == EPOLL_CTL_ADD
-		      ? "EPOLL_CTL_ADD"
-		      : (op == EPOLL_CTL_MOD
-			 ? "EPOLL_CTL_MOD"
-			 : (op == EPOLL_CTL_DEL
-			    ? "EPOLL_CTL_DEL"
-			    : "UNKNOWN"))),
-		     fd,
-		     epe_templ.events,
-		     fd);
-	errno = saved_errno;
-    }
-#endif
-    if (res == 0)
-	ps->fds_status[fd].used_events = ps->fds_status[fd].events;
-    else {
-	switch (op) {
-	case EPOLL_CTL_MOD:
-	    epe.events = 0;
-	    do {
-		/* We init 'epe' every time since epoll_ctl() may modify it
-		   (not declared const and not documented as const). */
-		epe.events = 0;
-		epe.data.fd = fd;
-		res = epoll_ctl(ps->kp_fd, EPOLL_CTL_DEL, fd, &epe);
-	    } while (res != 0 && errno == EINTR);
-	    ps->fds_status[fd].used_events = 0;
-	/* Fall through ... */
-	case EPOLL_CTL_ADD: {
-	    ps->fds_status[fd].flags |= ERTS_POLL_FD_FLG_USEFLBCK;
-	    erts_atomic_dec_nob(&ps->no_of_user_fds);
-#if ERTS_POLL_USE_CONCURRENT_UPDATE
-	    if (!*update_fallback) {
-		*update_fallback = 1;
-		return 0;
-	    }
-#endif
-	    ASSERT(!(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK));
-	    res = update_fallback_pollset(ps, fd);
-	    ASSERT(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK);
-	    break;
-	}
-	case EPOLL_CTL_DEL: {
-	    /*
-	     * Since we use a lazy update approach EPOLL_CTL_DEL will
-	     * frequently fail. This since epoll automatically removes
-	     * a filedescriptor that is closed from the poll set.
-	     */
-	    ps->fds_status[fd].used_events = 0;
-	    res = 0;
-	    break;
-	}
-	default:
-	    fatal_error("%s:%d:update_pollset(): Internal error\n",
-			__FILE__, __LINE__);
-	    break;
-	}
-    }
-    ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_RST;
-    return res;
-}
-
-#if ERTS_POLL_USE_CONCURRENT_UPDATE
-static int
-update_pollset(ErtsPollSet ps, int fd)
-{
-    int update_fallback = 1;
-    return conc_update_pollset(ps, fd, &update_fallback);
-}
-#endif
-
-#endif /* ERTS_POLL_USE_EPOLL */
-
-#endif /* ERTS_POLL_USE_BATCH_UPDATE_POLLSET */
-
-#if ERTS_POLL_USE_POLL || ERTS_POLL_USE_SELECT || ERTS_POLL_USE_FALLBACK
-
-#if ERTS_POLL_USE_FALLBACK
-static int update_fallback_pollset(ErtsPollSet ps, int fd)
-#else
-static int update_pollset(ErtsPollSet ps, int fd)
-#endif
-{
-#ifdef ERTS_POLL_DEBUG_PRINT
-#if ERTS_POLL_USE_FALLBACK
-    erts_printf("Doing fallback update on fd=%d\n", fd);
-#else
-    erts_printf("Doing update on fd=%d\n", fd);
-#endif
-#endif
-
-    ASSERT(fd < ps->fds_status_len);
-#if ERTS_POLL_USE_FALLBACK
-    ASSERT(ps->fds_status[fd].used_events
-	   ? (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK)
-	   : (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_USEFLBCK));
-#endif
-
-    if (!need_update(ps, fd))
-	return 0;
-
-#if ERTS_POLL_USE_FALLBACK
-    ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_RST;
-#endif
+    if (!need_update(ps, fd, &reset))
+	return res;
 
 #if ERTS_POLL_USE_POLL	/* --- poll -------------------------------- */
-    if (!ps->fds_status[fd].events) {
+    if (!events) {
 	int pix = ps->fds_status[fd].pix;
 	int last_pix;
+
+        if (reset) {
+            /* When a fd has been reset, we tell the caller of erts_poll_wait
+               this by setting the fd as ERTS_POLL_EV_NONE */
+            ERTS_POLL_RES_SET_FD(&pr[res], fd);
+            ERTS_POLL_RES_SET_EVTS(&pr[res], ERTS_POLL_EV_NONE);
+            DEBUG_PRINT_FD("trig %s (poll)", ps, fd, ev2str(ERTS_POLL_EV_NONE));
+            res++;
+        }
+
 	if (pix < 0) {
-#if ERTS_POLL_USE_FALLBACK
-	    ASSERT(!(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK));
-#endif
-	    return -1;
+	    return res;
 	}
-#if ERTS_POLL_USE_FALLBACK
-	ASSERT(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK);
-#endif
 	erts_atomic_dec_nob(&ps->no_of_user_fds);
 	last_pix = --ps->no_poll_fds;
 	if (pix != last_pix) {
@@ -1348,126 +1031,151 @@ static int update_pollset(ErtsPollSet ps, int fd)
 	/* Clear this fd status */
 	ps->fds_status[fd].pix = -1;
 	ps->fds_status[fd].used_events = (ErtsPollEvents) 0;
-#if ERTS_POLL_USE_FALLBACK
-	ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_INFLBCK;
-#endif
+
     }
     else {
 	int pix = ps->fds_status[fd].pix;
 	if (pix < 0) {
-#if ERTS_POLL_USE_FALLBACK
-	    ASSERT(!(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK)
-		    || fd == ps->kp_fd);
-#endif
 	    erts_atomic_inc_nob(&ps->no_of_user_fds);
 	    ps->fds_status[fd].pix = pix = ps->no_poll_fds++;
 	    if (pix >= ps->poll_fds_len)
 		grow_poll_fds(ps, pix);
 	    ps->poll_fds[pix].fd = fd;
 	    ps->fds_status[fd].pix = pix;
-#if ERTS_POLL_USE_FALLBACK
-	    ps->fds_status[fd].flags |= ERTS_POLL_FD_FLG_INFLBCK;
-#endif
 	}
 
-#if ERTS_POLL_USE_FALLBACK
-	ASSERT(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK);
-#endif
-
 	/* Events to be used in next poll */
-	ps->poll_fds[pix].events = ev2pollev(ps->fds_status[fd].events);
+	ps->poll_fds[pix].events = ev2pollev(events);
 	if (ps->poll_fds[pix].revents) {
 	    /* Remove result events that we should not poll for anymore */
 	    ps->poll_fds[pix].revents
 		&= ev2pollev(~(~ps->fds_status[fd].used_events
-			       & ps->fds_status[fd].events));
+			       & events));
 	}
 	/* Save events to be used in next poll */
-	ps->fds_status[fd].used_events = ps->fds_status[fd].events;
+	ps->fds_status[fd].used_events = events;
     }
-    return 0;
+    return res;
 #elif ERTS_POLL_USE_SELECT	/* --- select ------------------------------ */
-    {
-	ErtsPollEvents events = ps->fds_status[fd].events;
-	ensure_select_fds(fd, &ps->input_fds, &ps->output_fds);
-	if ((ERTS_POLL_EV_IN & events)
-	    != (ERTS_POLL_EV_IN & ps->fds_status[fd].used_events)) {
-	    if (ERTS_POLL_EV_IN & events) {
-		ERTS_FD_SET(fd, &ps->input_fds);
-	    }
-	    else {
-		ERTS_FD_CLR(fd, &ps->input_fds);
-	    }
-	}
-	if ((ERTS_POLL_EV_OUT & events)
-	    != (ERTS_POLL_EV_OUT & ps->fds_status[fd].used_events)) {
-	    if (ERTS_POLL_EV_OUT & events) {
-		ERTS_FD_SET(fd, &ps->output_fds);
-	    }
-	    else {
-		ERTS_FD_CLR(fd, &ps->output_fds);
-	    }
-	}
+    if (!events) {
 
-	if (!ps->fds_status[fd].used_events) {
-	    ASSERT(events);
-	    erts_atomic_inc_nob(&ps->no_of_user_fds);
-#if ERTS_POLL_USE_FALLBACK
-	    ps->no_select_fds++;
-	    ps->fds_status[fd].flags |= ERTS_POLL_FD_FLG_INFLBCK;
-#endif
-	}
-	else if (!events) {
-	    ASSERT(ps->fds_status[fd].used_events);
-	    erts_atomic_dec_nob(&ps->no_of_user_fds);
-	    ps->fds_status[fd].events = events;
-#if ERTS_POLL_USE_FALLBACK
-	    ps->no_select_fds--;
-	    ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_INFLBCK;
-#endif
-	}
+        if (reset) {
+            /* When a fd has been reset, we tell the caller of erts_poll_wait
+               this by setting the fd as ERTS_POLL_EV_NONE */
+            ERTS_POLL_RES_SET_FD(&pr[res], fd);
+            ERTS_POLL_RES_SET_EVTS(&pr[res], ERTS_POLL_EV_NONE);
+            DEBUG_PRINT_FD("trig %s (select)", ps, fd, ev2str(ERTS_POLL_EV_NONE));
+            res++;
+        }
+
+        ERTS_FD_CLR(fd, &ps->input_fds);
+        ERTS_FD_CLR(fd, &ps->output_fds);
+
+        if (ps->fds_status[fd].used_events) {
+            erts_atomic_dec_nob(&ps->no_of_user_fds);
+            ps->fds_status[fd].used_events = (ErtsPollEvents) 0;
+        }
+
+        if (fd == ps->max_fd) {
+            int max = ps->max_fd;
+            for (max = ps->max_fd; max >= 0; max--)
+                if (ps->fds_status[max].used_events)
+                    break;
+            ps->max_fd = max;
+        }
+
+    } else {
+
+	ensure_select_fds(fd, &ps->input_fds, &ps->output_fds);
+
+        if (!ps->fds_status[fd].used_events)
+            erts_atomic_inc_nob(&ps->no_of_user_fds);
+
+        if (events & ERTS_POLL_EV_IN)
+            ERTS_FD_SET(fd, &ps->input_fds);
+        else
+            ERTS_FD_CLR(fd, &ps->input_fds);
+
+        if (events & ERTS_POLL_EV_OUT)
+            ERTS_FD_SET(fd, &ps->output_fds);
+        else
+            ERTS_FD_CLR(fd, &ps->output_fds);
 
 	ps->fds_status[fd].used_events = events;
 
-	if (events && fd > ps->max_fd)
-	    ps->max_fd = fd;
-	else if (!events && fd == ps->max_fd) {
-	    int max = ps->max_fd;
-	    for (max = ps->max_fd; max >= 0; max--)
-		if (ps->fds_status[max].used_events)
-		    break;
-	    ps->max_fd = max;
-	}
+        if (fd > ps->max_fd)
+            ps->max_fd = fd;
     }
-    return 0;
+
+    return res;
+#elif ERTS_POLL_USE_DEVPOLL
+
+    if (!events) {
+
+        if (reset) {
+            /* When a fd has been reset, we tell the caller of erts_poll_wait
+               this by setting the fd as ERTS_POLL_EV_NONE */
+            ERTS_POLL_RES_SET_FD(&pr[res], fd);
+            ERTS_POLL_RES_SET_EVTS(&pr[res], ERTS_POLL_EV_NONE);
+            DEBUG_PRINT_FD("trig %s (devpoll)", ps, fd, ev2str(ERTS_POLL_EV_NONE));
+            res++;
+        }
+
+        ps->poll_fds[ps->poll_fds_ix].fd = fd;
+        ps->poll_fds[ps->poll_fds_ix].revents = 0;
+        ps->poll_fds[ps->poll_fds_ix++].events = POLLREMOVE;
+
+        if (ps->fds_status[fd].used_events) {
+            erts_atomic_dec_nob(&ps->no_of_user_fds);
+            ps->fds_status[fd].used_events = 0;
+        }
+
+    } else {
+        if (!ps->fds_status[fd].used_events) {
+            erts_atomic_inc_nob(&ps->no_of_user_fds);
+        }
+        ps->poll_fds[ps->poll_fds_ix].fd = fd;
+        ps->poll_fds[ps->poll_fds_ix].revents = 0;
+        ps->poll_fds[ps->poll_fds_ix++].events = ERTS_POLL_EV_E2N(events);
+        ps->fds_status[fd].used_events = ps->fds_status[fd].events;
+    }
+
+    return res;
 #endif
 }
 
-#endif /* ERTS_POLL_USE_POLL || ERTS_POLL_USE_SELECT || ERTS_POLL_USE_FALLBACK */
-
-
-static void
-handle_update_requests(ErtsPollSet ps)
+static int
+handle_update_requests(ErtsPollSet *ps, ErtsPollResFd pr[], int no_fds)
 {
-    ErtsPollSetUpdateRequestsBlock *urqbp = &ps->update_requests;
-#if ERTS_POLL_USE_BATCH_UPDATE_POLLSET
-    ErtsPollBatchBuf bb;
-    setup_batch_buf(ps, &bb);
-#endif
+    int res = 0;
+    ErtsPollSetUpdateRequestsBlock *urqbp = ps->curr_upd_req_block;
 
     while (urqbp) {
 	ErtsPollSetUpdateRequestsBlock *free_urqbp = urqbp;
 	int i;
 	int len = urqbp->len;
+
+        init_batch_update(ps, len);
+
 	for (i = 0; i < len; i++) {
 	    int fd = urqbp->fds[i];
 	    ASSERT(fd < ps->fds_status_len);
-	    ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_INURQ;
-#if ERTS_POLL_USE_BATCH_UPDATE_POLLSET
-	    batch_update_pollset(ps, fd, &bb);
-#else
-	    update_pollset(ps, fd);
-#endif
+            ASSERT(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INURQ);
+
+            /* We have run out of PollResFd slots to put results in,
+               so we yield here and return later for more. */
+            if (res == no_fds && pr != NULL) {
+                memmove(urqbp->fds, urqbp->fds+i, sizeof(int) * (len - i));
+                urqbp->len -= i;
+                ps->curr_upd_req_block = urqbp;
+                write_batch_update(ps);
+                return res;
+            }
+
+            if (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INURQ) {
+                ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_INURQ;
+                res += update_pollset(ps, pr + res, fd);
+            }
 	}
 
 	free_urqbp = urqbp;
@@ -1475,12 +1183,9 @@ handle_update_requests(ErtsPollSet ps)
 
 	free_update_requests_block(ps, free_urqbp);
 
-    }
+        write_batch_update(ps);
 
-#if ERTS_POLL_USE_BATCH_UPDATE_POLLSET
-    if (bb.len)
-	write_batch_buf(ps, &bb);
-#endif
+    }
 
     ps->curr_upd_req_block = &ps->update_requests;
 
@@ -1489,16 +1194,19 @@ handle_update_requests(ErtsPollSet ps)
 #endif
 
     ERTS_POLLSET_UNSET_HAVE_UPDATE_REQUESTS(ps);
+    return res;
 }
 
+#endif /* !ERTS_POLL_USE_CONCURRENT_UPDATE */
 
 static ERTS_INLINE ErtsPollEvents
-poll_control(ErtsPollSet ps, int fd, ErtsPollEvents events, int on, int *do_wake)
+poll_control(ErtsPollSet *ps, int fd, ErtsPollOp op,
+             ErtsPollEvents events, int *do_wake)
 {
     ErtsPollEvents new_events;
 
     if (fd < ps->internal_fd_limit || fd >= max_fds) {
-	if (fd < 0) {
+	if (fd < 0 || fd >= max_fds) {
 	    new_events = ERTS_POLL_EV_ERR;
 	    goto done;
 	}
@@ -1508,115 +1216,55 @@ poll_control(ErtsPollSet ps, int fd, ErtsPollEvents events, int on, int *do_wake
 	    goto done;
 	}
 #endif
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 	if (fd == ps->wake_fds[0] || fd == ps->wake_fds[1]) {
-	    new_events = ERTS_POLL_EV_NVAL;
-	    goto done;
-	}
-#if ERTS_POLL_USE_TIMERFD
-	if (fd == ps->timer_fd) {
 	    new_events = ERTS_POLL_EV_NVAL;
 	    goto done;
 	}
 #endif
     }
 
+#if ERTS_POLL_USE_CONCURRENT_UPDATE
+
+    new_events = update_pollset(ps, fd, op, events);
+
+#else /* !ERTS_POLL_USE_CONCURRENT_UPDATE */
     if (fd >= ps->fds_status_len)
 	grow_fds_status(ps, fd);
 
     ASSERT(fd < ps->fds_status_len);
 
+    if (op == ERTS_POLL_OP_DEL) {
+        ps->fds_status[fd].flags |= ERTS_POLL_FD_FLG_RST;
+        ps->fds_status[fd].events = 0;
+        *do_wake = 1;
+    } else if (op == ERTS_POLL_OP_ADD) {
+        ASSERT(ps->fds_status[fd].events == 0);
+        ps->fds_status[fd].events = events;
+        *do_wake = 1;
+    } else {
+        ASSERT(op == ERTS_POLL_OP_MOD);
+        ps->fds_status[fd].events = events;
+        *do_wake = 1;
+    }
     new_events = ps->fds_status[fd].events;
 
-    if (events == 0) {
-	*do_wake = 0;
-	goto done;
-    }
-
-    if (on)
-	new_events |= events;
-    else
-	new_events &= ~events;
-
-    if (new_events == (ErtsPollEvents) 0) {
-	ps->fds_status[fd].flags |= ERTS_POLL_FD_FLG_RST;
-#if ERTS_POLL_USE_FALLBACK
-	ps->fds_status[fd].flags &= ~ERTS_POLL_FD_FLG_USEFLBCK;
-#endif
-    }
-
-    ps->fds_status[fd].events = new_events;
-
-    if (new_events == ps->fds_status[fd].used_events
-	&& !(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_RST)
-	) {
-	*do_wake = 0;
-	goto done;
-    }
-
-
-#if ERTS_POLL_USE_CONCURRENT_UPDATE
-    if (ERTS_POLLSET_IS_POLLED(ps)) {
-	int update_fallback = 0;
-	conc_update_pollset(ps, fd, &update_fallback);
-	if (!update_fallback) {
-	    *do_wake = 0; /* no need to wake kernel poller */
-	    goto done;
-	}
-    }
-#endif
-
     enqueue_update_request(ps, fd);
-	
-    /*
-     * If new events have been added, we need to wake up the
-     * polling thread, but if events have been removed we don't.
-     */
-    if ((new_events && (ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_RST))
-	|| (~ps->fds_status[fd].used_events & new_events))
-	*do_wake = 1;
 
+#endif /* !ERTS_POLL_USE_CONCURRENT_UPDATE */
 
  done:
-#ifdef ERTS_POLL_DEBUG_PRINT
-     erts_printf("0x%x = poll_control(ps, %d, 0x%x, %s) do_wake=%d\n",
-		 (int) new_events, fd, (int) events, (on ? "on" : "off"), *do_wake);
-#endif
+    DEBUG_PRINT_FD("%s = %s(%p, %d, %s, %s) do_wake=%d",
+                   ps, fd, ev2str(new_events), __FUNCTION__, ps,
+                   fd, op2str(op), ev2str(events), *do_wake);
     return new_events;
 }
 
-void
-ERTS_POLL_EXPORT(erts_poll_controlv)(ErtsPollSet ps,
-				     ErtsPollControlEntry pcev[],
-				     int len)
-{
-    int i;
-    int do_wake;
-    int final_do_wake = 0;
-
-    ERTS_POLLSET_LOCK(ps);
-
-    for (i = 0; i < len; i++) {
-	do_wake = 0;
-	pcev[i].events = poll_control(ps,
-				      pcev[i].fd,
-				      pcev[i].events,
-				      pcev[i].on,
-				      &do_wake);
-	final_do_wake |= do_wake;
-    }
-
-    ERTS_POLLSET_UNLOCK(ps);
-
-    if (final_do_wake)
-	wake_poller(ps, 0, 0);
-
-}
-
 ErtsPollEvents
-ERTS_POLL_EXPORT(erts_poll_control)(ErtsPollSet ps,
+ERTS_POLL_EXPORT(erts_poll_control)(ErtsPollSet *ps,
 				    ErtsSysFdType fd,
+                                    ErtsPollOp op,
 				    ErtsPollEvents events,
-				    int on,
 				    int* do_wake) /* In: Wake up polling thread */
 				                  /* Out: Poller is woken */
 {
@@ -1624,13 +1272,15 @@ ERTS_POLL_EXPORT(erts_poll_control)(ErtsPollSet ps,
 
     ERTS_POLLSET_LOCK(ps);
 
-    res = poll_control(ps, fd, events, on, do_wake);
+    res = poll_control(ps, fd, op, events, do_wake);
 
     ERTS_POLLSET_UNLOCK(ps);
 
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     if (*do_wake) {
-	wake_poller(ps, 0, 0);
+	wake_poller(ps, 0);
     }
+#endif
 
     return res;
 }
@@ -1642,180 +1292,60 @@ ERTS_POLL_EXPORT(erts_poll_control)(ErtsPollSet ps,
 #if ERTS_POLL_USE_KERNEL_POLL
 
 static ERTS_INLINE int
-save_kp_result(ErtsPollSet ps, ErtsPollResFd pr[], int max_res, int chk_fds_res)
+ERTS_POLL_EXPORT(save_result)(ErtsPollSet *ps, ErtsPollResFd pr[], int max_res, int chk_fds_res, int ebadf)
 {
-    int res = 0;
-    int i;
-    int n = chk_fds_res < max_res ? chk_fds_res : max_res;
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE || ERTS_POLL_DEBUG_PRINT
+    int n = chk_fds_res < max_res ? chk_fds_res : max_res, i;
+    int res = n;
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     int wake_fd = ps->wake_fds[0];
-#if ERTS_POLL_USE_TIMERFD
-    int timer_fd = ps->timer_fd;
 #endif
 
     for (i = 0; i < n; i++) {
-
-#if ERTS_POLL_USE_EPOLL		/* --- epoll ------------------------------- */
-
-	if (ps->res_events[i].events) {
-	    int fd = ps->res_events[i].data.fd;
-	    int ix;
-	    ErtsPollEvents revents;
-	    if (fd == wake_fd) {
-		cleanup_wakeup_pipe(ps);
-		continue;
-	    }
-#if ERTS_POLL_USE_TIMERFD
-            if (fd == timer_fd) {
-                continue;
-            }
-#endif
-	    ASSERT(!(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK));
-	    /* epoll_wait() can repeat the same fd in result array... */
-	    ix = (int) ps->fds_status[fd].res_ev_ix;
-	    ASSERT(ix >= 0);
-	    if (ix >= res || pr[ix].fd != fd) {
-		ix = res;
-		pr[ix].fd = fd;
-		pr[ix].events = (ErtsPollEvents) 0;
-	    }
-
-	    revents = ERTS_POLL_EV_N2E(ps->res_events[i].events);
-	    pr[ix].events |= revents;
-	    if (revents) {
-		if (res == ix) {
-		    ps->fds_status[fd].res_ev_ix = (unsigned short) ix;
-		    res++;
-		}
-	    }
-	}
-
-#elif ERTS_POLL_USE_KQUEUE	/* --- kqueue ------------------------------ */
-
-	struct kevent *ev;
-	int fd;
-	int ix;
-
-	ev = &ps->res_events[i];
-	fd = (int) ev->ident;
-	ASSERT(fd < ps->fds_status_len);
-	ASSERT(!(ps->fds_status[fd].flags & ERTS_POLL_FD_FLG_INFLBCK));
-	ix = (int) ps->fds_status[fd].res_ev_ix;
-
-	ASSERT(ix >= 0);
-	if (ix >= res || pr[ix].fd != fd) {
-	    ix = res;
-	    pr[ix].fd = (int) ev->ident;
-	    pr[ix].events = (ErtsPollEvents) 0;
-	}
-
-	if (ev->filter == EVFILT_READ) {
-	    if (fd == wake_fd) {
-		cleanup_wakeup_pipe(ps);
-		continue;
-	    }
-	    pr[ix].events |= ERTS_POLL_EV_IN;
-	}
-	else if (ev->filter == EVFILT_WRITE)
-	    pr[ix].events |= ERTS_POLL_EV_OUT;
-	if (ev->flags & (EV_ERROR|EV_EOF)) {
-	    if ((ev->flags & EV_ERROR) && (((int) ev->data) == EBADF))
-		pr[ix].events |= ERTS_POLL_EV_NVAL;
-	    else
-		pr[ix].events |= ERTS_POLL_EV_ERR;
-	}
-	if (pr[ix].events) {
-	    if (res == ix) {
-		ps->fds_status[fd].res_ev_ix = (unsigned short) ix;
-		res++;
-	    }
-	}
-
-#elif ERTS_POLL_USE_DEVPOLL	/* --- devpoll ----------------------------- */
-
-	if (ps->res_events[i].revents) {
-	    int fd = ps->res_events[i].fd;
-	    ErtsPollEvents revents;
-	    if (fd == wake_fd) {
-		cleanup_wakeup_pipe(ps);
-		continue;
-	    }
-#if ERTS_POLL_USE_TIMERFD
-	    if (fd == timer_fd) {
-		continue;
-	    }
-#endif
-	    revents = ERTS_POLL_EV_N2E(ps->res_events[i].events);
-	    pr[res].fd = fd;
-	    pr[res].events = revents;
-	    res++;
-	}
-
+        int fd = ERTS_POLL_RES_GET_FD(&pr[i]);
+#ifdef DEBUG_PRINT_MODE
+        ErtsPollEvents evts = ERTS_POLL_RES_GET_EVTS(pr+i);
 #endif
 
+        DEBUG_PRINT_FD("trig %s (%s)", ps, fd,
+                       ev2str(evts),
+#if ERTS_POLL_USE_KQUEUE
+                       "kqueue"
+#elif ERTS_POLL_USE_EPOLL
+                       "epoll"
+#else
+                       "/dev/poll"
+#endif
+            );
+
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
+
+        if (fd == wake_fd) {
+            cleanup_wakeup_pipe(ps);
+            ERTS_POLL_RES_SET_EVTS(&pr[i], ERTS_POLL_EV_NONE);
+        } else {
+            /* Reset the events to emulate ONESHOT semantics */
+            ps->fds_status[fd].events = 0;
+            enqueue_update_request(ps, fd);
+        }
+#endif
     }
 
     return res;
+#else
+    ASSERT(chk_fds_res <= max_res);
+    return chk_fds_res;
+#endif
 }
 
-#endif /* ERTS_POLL_USE_KERNEL_POLL */
-
-#if ERTS_POLL_USE_FALLBACK
-
-static int
-get_kp_results(ErtsPollSet ps, ErtsPollResFd pr[], int max_res)
-{
-    int res;
-#if ERTS_POLL_USE_KQUEUE
-    struct timespec ts = {0, 0};
-#endif
-
-    if (max_res > ps->res_events_len)
-	grow_res_events(ps, max_res);
-
-    do {
-#if ERTS_POLL_USE_EPOLL
-	res = epoll_wait(ps->kp_fd, ps->res_events, max_res, 0);
-#elif ERTS_POLL_USE_KQUEUE
-	res = kevent(ps->kp_fd, NULL, 0, ps->res_events, max_res, &ts);
-#endif
-    } while (res < 0 && errno == EINTR);
-
-    if (res < 0) {
-	fatal_error("%s:%d: %s() failed: %s (%d)\n",
-		    __FILE__, __LINE__,
-#if ERTS_POLL_USE_EPOLL
-		    "epoll_wait",
-#elif ERTS_POLL_USE_KQUEUE
-		    "kevent",
-#endif
-		    erl_errno_id(errno), errno);
-    }
-
-    return save_kp_result(ps, pr, max_res, res);
-}
-
-#endif /* ERTS_POLL_USE_FALLBACK */
-
-
+#else /* !ERTS_POLL_USE_KERNEL_POLL */
 
 static ERTS_INLINE int
-save_poll_result(ErtsPollSet ps, ErtsPollResFd pr[], int max_res,
-		 int chk_fds_res, int ebadf)
+ERTS_POLL_EXPORT(save_result)(ErtsPollSet *ps, ErtsPollResFd pr[], int max_res, int chk_fds_res, int ebadf)
 {
-#if ERTS_POLL_USE_DEVPOLL
-    return save_kp_result(ps, pr, max_res, chk_fds_res);
-#elif ERTS_POLL_USE_FALLBACK
-    if (!ps->fallback_used)
-	return save_kp_result(ps, pr, max_res, chk_fds_res);
-    else
-#endif /* ERTS_POLL_USE_FALLBACK */
-    {
-
 #if ERTS_POLL_USE_POLL	/* --- poll -------------------------------- */
 	int res = 0;
-#if !ERTS_POLL_USE_FALLBACK
 	int wake_fd = ps->wake_fds[0];
-#endif
 	int i, first_ix, end_ix;
 
 	/*
@@ -1832,23 +1362,30 @@ save_poll_result(ErtsPollSet ps, ErtsPollResFd pr[], int max_res,
 		if (ps->poll_fds[i].revents != (short) 0) {
 		    int fd = ps->poll_fds[i].fd;
 		    ErtsPollEvents revents;
-#if ERTS_POLL_USE_FALLBACK
-		    if (fd == ps->kp_fd) {
-			res += get_kp_results(ps, &pr[res], max_res-res);
-			i++;
-			continue;
-		    }
-#else
 		    if (fd == wake_fd) {
 			cleanup_wakeup_pipe(ps);
 			i++;
 			continue;
 		    }
-#endif
 		    revents = pollev2ev(ps->poll_fds[i].revents);
-		    pr[res].fd = fd;
-		    pr[res].events = revents;
+		    ERTS_POLL_RES_SET_FD(&pr[res], fd);
+		    ERTS_POLL_RES_SET_EVTS(&pr[res], revents);
+
+                    /* If an fd returns as error, we may want to check the
+                       update_requests queue to see if it has been reset
+                       before delivering the result?!?! This should allow
+                       the user to do driver_dselect + close without waiting
+                       for stop_select... */
+
+                    DEBUG_PRINT_FD("trig %s (poll)", ps, ERTS_POLL_RES_GET_FD(&pr[res]),
+                                   ev2str(ERTS_POLL_RES_GET_EVTS(&pr[res])));
+
 		    res++;
+
+                    /* Clear the events for this fd in order to mimic
+                       how epoll ONESHOT works */
+                    ps->fds_status[fd].events = 0;
+                    enqueue_update_request(ps, fd);
 		}
 		i++;
 	    }
@@ -1864,9 +1401,7 @@ save_poll_result(ErtsPollSet ps, ErtsPollResFd pr[], int max_res,
 
 #elif ERTS_POLL_USE_SELECT	/* --- select ------------------------------ */
 	int res = 0;
-#if !ERTS_POLL_USE_FALLBACK
 	int wake_fd = ps->wake_fds[0];
-#endif
 	int fd, first_fd, end_fd;
 
 	/*
@@ -1879,29 +1414,23 @@ save_poll_result(ErtsPollSet ps, ErtsPollResFd pr[], int max_res,
 	if (!ebadf) {
 	    while (1) {
 		while (fd < end_fd && res < max_res) {
-
-		    pr[res].events = (ErtsPollEvents) 0;
+                    ErtsPollEvents events = 0;
 		    if (ERTS_FD_ISSET(fd, &ps->res_input_fds)) {
-#if ERTS_POLL_USE_FALLBACK
-			if (fd == ps->kp_fd) {
-			    res += get_kp_results(ps, &pr[res], max_res-res);
-			    fd++;
-			    continue;
-			}
-#else
 			if (fd == wake_fd) {
 			    cleanup_wakeup_pipe(ps);
 			    fd++;
 			    continue;
 			}
-#endif
-			pr[res].events |= ERTS_POLL_EV_IN;
+			events |= ERTS_POLL_EV_IN;
 		    }
 		    if (ERTS_FD_ISSET(fd, &ps->res_output_fds))
-			pr[res].events |= ERTS_POLL_EV_OUT;
-		    if (pr[res].events) {
-			pr[res].fd = fd;
+			events |= ERTS_POLL_EV_OUT;
+		    if (events) {
+                        ERTS_POLL_RES_SET_FD(&pr[res], fd);
+                        ERTS_POLL_RES_SET_EVTS(&pr[res], events);
 			res++;
+                        ps->fds_status[fd].events = 0;
+                        enqueue_update_request(ps, fd);
 		    }
 		    fd++;
 		}
@@ -1934,7 +1463,7 @@ save_poll_result(ErtsPollSet ps, ErtsPollResFd pr[], int max_res,
 			if (ps->fds_status[fd].events & ERTS_POLL_EV_OUT) {
 			    oset = &ps->res_output_fds;
 			    ERTS_FD_ZERO(oset);
-			    ERTS_FD_SET(fd, oset);			
+			    ERTS_FD_SET(fd, oset);
 			}
 			do {
 			    /* Initiate 'tv' each time;
@@ -1943,49 +1472,31 @@ save_poll_result(ErtsPollSet ps, ErtsPollResFd pr[], int max_res,
 			    sres = ERTS_SELECT(ps->max_fd+1, iset, oset, NULL, &tv);
 			} while (sres < 0 && errno == EINTR);
 			if (sres < 0) {
-#if ERTS_POLL_USE_FALLBACK
-			    if (fd == ps->kp_fd) {
-				res += get_kp_results(ps,
-						      &pr[res],
-						      max_res-res);
-				fd++;
-				continue;
-			    }
-#else
 			    if (fd == wake_fd) {
 				cleanup_wakeup_pipe(ps);
 				fd++;
 				continue;
 			    }
-#endif
-			    pr[res].fd = fd;
-			    pr[res].events = ERTS_POLL_EV_NVAL;
+                            ERTS_POLL_RES_SET_FD(&pr[res], fd);
+                            ERTS_POLL_RES_SET_EVTS(&pr[res], ERTS_POLL_EV_NVAL);
 			    res++;
 			}
 			else if (sres > 0) {
-			    pr[res].fd = fd;
+                            ErtsPollEvents events = 0;
+                            ERTS_POLL_RES_SET_FD(&pr[res], fd);
 			    if (iset && ERTS_FD_ISSET(fd, iset)) {
-#if ERTS_POLL_USE_FALLBACK
-				if (fd == ps->kp_fd) {
-				    res += get_kp_results(ps,
-							  &pr[res],
-							  max_res-res);
-				    fd++;
-				    continue;
-				}
-#else
 				if (fd == wake_fd) {
 				    cleanup_wakeup_pipe(ps);
 				    fd++;
 				    continue;
 				}
-#endif
-				pr[res].events |= ERTS_POLL_EV_IN;
+				events |= ERTS_POLL_EV_IN;
 			    }
 			    if (oset && ERTS_FD_ISSET(fd, oset)) {
-				pr[res].events |= ERTS_POLL_EV_OUT;
+				events |= ERTS_POLL_EV_OUT;
 			    }
-			    ASSERT(pr[res].events);
+			    ASSERT(events);
+                            ERTS_POLL_RES_SET_EVTS(&pr[res], events);
 			    res++;
 			}
 		    }
@@ -2000,353 +1511,145 @@ save_poll_result(ErtsPollSet ps, ErtsPollResFd pr[], int max_res,
 	}
 	ps->next_sel_fd = fd;
 	return res;
-#endif
-    }
+#endif /* ERTS_POLL_USE_SELECT */
 }
 
-static ERTS_INLINE ErtsMonotonicTime
-get_timeout(ErtsPollSet ps,
-	    int resolution,
-	    ErtsMonotonicTime timeout_time)
-{
-    ErtsMonotonicTime timeout, save_timeout_time;
-
-    if (timeout_time == ERTS_POLL_NO_TIMEOUT) {
-	save_timeout_time = ERTS_MONOTONIC_TIME_MIN;
-	timeout = 0;
-    }
-    else {
-	ErtsMonotonicTime diff_time, current_time;
-	current_time = erts_get_monotonic_time(NULL);
-	diff_time = timeout_time - current_time;
-	if (diff_time <= 0) {
-	    save_timeout_time = ERTS_MONOTONIC_TIME_MIN;
-	    timeout = 0;
-	}
-	else {
-	    save_timeout_time = current_time;
-	    switch (resolution) {
-	    case 1000:
-		/* Round up to nearest even milli second */
-		timeout = ERTS_MONOTONIC_TO_MSEC(diff_time - 1) + 1;
-		if (timeout > (ErtsMonotonicTime) INT_MAX)
-		    timeout = (ErtsMonotonicTime) INT_MAX;
-		save_timeout_time += ERTS_MSEC_TO_MONOTONIC(timeout);
-		timeout -= ERTS_PREMATURE_TIMEOUT(timeout, 1000);
-		break;
-	    case 1000000:
-		/* Round up to nearest even micro second */
-		timeout = ERTS_MONOTONIC_TO_USEC(diff_time - 1) + 1;
-		save_timeout_time += ERTS_USEC_TO_MONOTONIC(timeout);
-		timeout -= ERTS_PREMATURE_TIMEOUT(timeout, 1000*1000);
-		break;
-	    case 1000000000:
-		/* Round up to nearest even nano second */
-		timeout = ERTS_MONOTONIC_TO_NSEC(diff_time - 1) + 1;
-		save_timeout_time += ERTS_NSEC_TO_MONOTONIC(timeout);
-		timeout -= ERTS_PREMATURE_TIMEOUT(timeout, 1000*1000*1000);
-		break;
-	    default:
-		ERTS_INTERNAL_ERROR("Invalid resolution");
-		timeout = 0;
-		save_timeout_time = 0;
-		break;
-	    }
-	}
-    }
-    set_timeout_time(ps, save_timeout_time);
-    return timeout;
-}
-
-#if ERTS_POLL_USE_SELECT
+#endif /* !ERTS_POLL_USE_KERNEL_POLL */
 
 static ERTS_INLINE int
-get_timeout_timeval(ErtsPollSet ps,
-		    SysTimeval *tvp,
-		    ErtsMonotonicTime timeout_time)
-{
-    ErtsMonotonicTime timeout = get_timeout(ps,
-					    1000*1000,
-					    timeout_time);
-
-    if (!timeout) {
-	tvp->tv_sec = 0;
-	tvp->tv_usec = 0;
-
-	return 0;
-    }
-    else {
-	ErtsMonotonicTime sec = timeout/(1000*1000);
-	tvp->tv_sec = sec;
-	tvp->tv_usec = timeout - sec*(1000*1000);
-
-	ASSERT(tvp->tv_sec >= 0);
-	ASSERT(tvp->tv_usec >= 0);
-	ASSERT(tvp->tv_usec < 1000*1000);
-
-	return !0;
-    }
-
-}
-
-#endif
-
-#if ERTS_POLL_USE_KQUEUE || (ERTS_POLL_USE_POLL && defined(HAVE_PPOLL)) || ERTS_POLL_USE_TIMERFD
-
-static ERTS_INLINE int
-get_timeout_timespec(ErtsPollSet ps,
-		     struct timespec *tsp,
-		     ErtsMonotonicTime timeout_time)
-{
-    ErtsMonotonicTime timeout = get_timeout(ps,
-					    1000*1000*1000,
-					    timeout_time);
-
-    if (!timeout) {
-	tsp->tv_sec = 0;
-	tsp->tv_nsec = 0;
-	return 0;
-    }
-    else {
-	ErtsMonotonicTime sec = timeout/(1000*1000*1000);
-	tsp->tv_sec = sec;
-	tsp->tv_nsec = timeout - sec*(1000*1000*1000);
-
-	ASSERT(tsp->tv_sec >= 0);
-	ASSERT(tsp->tv_nsec >= 0);
-	ASSERT(tsp->tv_nsec < 1000*1000*1000);
-
-	return !0;
-    }
-}
-
-#endif
-
-#if ERTS_POLL_USE_TIMERFD
-
-static ERTS_INLINE int
-get_timeout_itimerspec(ErtsPollSet ps,
-                       struct itimerspec *itsp,
-                       ErtsMonotonicTime timeout_time)
-{
-
-    itsp->it_interval.tv_sec = 0;
-    itsp->it_interval.tv_nsec = 0;
-
-    return get_timeout_timespec(ps, &itsp->it_value, timeout_time);
-}
-
-#endif
-
-static ERTS_INLINE int
-check_fd_events(ErtsPollSet ps, ErtsMonotonicTime timeout_time, int max_res)
+check_fd_events(ErtsPollSet *ps, ErtsPollResFd pr[], int do_wait, int max_res)
 {
     int res;
-    ERTS_MSACC_PUSH_STATE_M();
-    if (erts_atomic_read_nob(&ps->no_of_user_fds) == 0
-	&& timeout_time == ERTS_POLL_NO_TIMEOUT) {
-	/* Nothing to poll and zero timeout; done... */
-	return 0;
-    }
-    else {
-	int timeout;
-#if ERTS_POLL_USE_FALLBACK
-	if (!(ps->fallback_used = ERTS_POLL_NEED_FALLBACK(ps))) {
+    int timeout = do_wait ? -1 : 0;
+    DEBUG_PRINT_WAIT("Entering check_fd_events(), do_wait=%d", ps, do_wait);
+    {
+#if ERTS_POLL_USE_EPOLL                /* --- epoll ------------------------------- */
+        res = epoll_wait(ps->kp_fd, pr, max_res, timeout);
 
-#if ERTS_POLL_USE_EPOLL		/* --- epoll ------------------------------- */
-	    if (max_res > ps->res_events_len)
-		grow_res_events(ps, max_res);
-#if ERTS_POLL_USE_TIMERFD
-            {
-                struct itimerspec its;
-                timeout = get_timeout_itimerspec(ps, &its, timeout_time);
-                if (timeout) {
-                    erts_thr_progress_prepare_wait(NULL);
-                    ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
-                    timerfd_set(ps, &its);
-                    res = epoll_wait(ps->kp_fd, ps->res_events, max_res, -1);
-                    res = timerfd_clear(ps, res, max_res);
-                } else {
-                    res = epoll_wait(ps->kp_fd, ps->res_events, max_res, 0);
-                }
-            }
-#else /* !ERTS_POLL_USE_TIMERFD */
-	    timeout = (int) get_timeout(ps, 1000, timeout_time);
-            if (timeout) {
-		erts_thr_progress_prepare_wait(NULL);
-                ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
-            }
-	    res = epoll_wait(ps->kp_fd, ps->res_events, max_res, timeout);
-#endif /* !ERTS_POLL_USE_TIMERFD */
-#elif ERTS_POLL_USE_KQUEUE	/* --- kqueue ------------------------------ */
-	    struct timespec ts;
-	    if (max_res > ps->res_events_len)
-		grow_res_events(ps, max_res);
-	    timeout = get_timeout_timespec(ps, &ts, timeout_time);
-            if (timeout) {
-		erts_thr_progress_prepare_wait(NULL);
-		ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
-            }
-	    res = kevent(ps->kp_fd, NULL, 0, ps->res_events, max_res, &ts);
-#endif				/* ----------------------------------------- */
-	}
-	else /* use fallback (i.e. poll() or select()) */
-#endif /* ERTS_POLL_USE_FALLBACK */
-	{
+#elif ERTS_POLL_USE_KQUEUE     /* --- kqueue ------------------------------ */
+        struct timespec ts = {0, 0};
+        struct timespec *tsp = timeout ? NULL : &ts;
+        res = kevent(ps->kp_fd, NULL, 0, pr, max_res, tsp);
+#elif ERTS_POLL_USE_DEVPOLL	/* --- devpoll ----------------------------- */
+        /*
+         * The ioctl() will fail with EINVAL on Solaris 10 if dp_nfds
+         * is set too high. dp_nfds should not be set greater than
+         * the maximum number of file descriptors in the poll set.
+         */
+        struct dvpoll poll_res;
+        int nfds = (int) erts_atomic_read_nob(&ps->no_of_user_fds) + 1 /* wakeup pipe */;
+        poll_res.dp_nfds = nfds < max_res ? nfds : max_res;
+        poll_res.dp_fds = pr;
+        poll_res.dp_timeout = timeout;
+        res = ioctl(ps->kp_fd, DP_POLL, &poll_res);
 
-#if ERTS_POLL_USE_DEVPOLL	/* --- devpoll ----------------------------- */
-	    /*
-	     * The ioctl() will fail with EINVAL on Solaris 10 if dp_nfds
-	     * is set too high. dp_nfds should not be set greater than
-	     * the maximum number of file descriptors in the poll set.
-	     */
-	    struct dvpoll poll_res;
-	    int nfds = (int) erts_atomic_read_nob(&ps->no_of_user_fds);
-	    nfds++; /* Wakeup pipe */
-	    timeout = (int) get_timeout(ps, 1000, timeout_time);
-	    poll_res.dp_nfds = nfds < max_res ? nfds : max_res;
-	    if (poll_res.dp_nfds > ps->res_events_len)
-		grow_res_events(ps, poll_res.dp_nfds);
-	    poll_res.dp_fds = ps->res_events;
-	    if (timeout) {
-		erts_thr_progress_prepare_wait(NULL);
-                ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
-            }
-	    poll_res.dp_timeout = timeout;
-	    res = ioctl(ps->kp_fd, DP_POLL, &poll_res);
-#elif ERTS_POLL_USE_POLL && defined(HAVE_PPOLL)	/* --- ppoll ---------------- */
-            struct timespec ts;
-	    timeout = get_timeout_timespec(ps, &ts, timeout_time);
-            if (timeout) {
-		erts_thr_progress_prepare_wait(NULL);
-		ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
-            }
-            res = ppoll(ps->poll_fds, ps->no_poll_fds, &ts, NULL);
 #elif ERTS_POLL_USE_POLL        /* --- poll --------------------------------- */
-	    timeout = (int) get_timeout(ps, 1000, timeout_time);
 
-	    if (timeout) {
-		erts_thr_progress_prepare_wait(NULL);
-		ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
-            }
-	    res = poll(ps->poll_fds, ps->no_poll_fds, timeout);
+        res = poll(ps->poll_fds, ps->no_poll_fds, timeout);
+
 #elif ERTS_POLL_USE_SELECT	/* --- select ------------------------------ */
-	    SysTimeval to;
-	    timeout = get_timeout_timeval(ps, &to, timeout_time);
+        SysTimeval tv = {0, 0};
+        SysTimeval *tvp = timeout ? NULL : &tv;
 
-	    ERTS_FD_COPY(&ps->input_fds, &ps->res_input_fds);
-	    ERTS_FD_COPY(&ps->output_fds, &ps->res_output_fds);
+        ERTS_FD_COPY(&ps->input_fds, &ps->res_input_fds);
+        ERTS_FD_COPY(&ps->output_fds, &ps->res_output_fds);
 
-	    if (timeout) {
-		erts_thr_progress_prepare_wait(NULL);
-		ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
-	    }
-	    res = ERTS_SELECT(ps->max_fd + 1,
-			      &ps->res_input_fds,
-			      &ps->res_output_fds,
-			      NULL,
-			      &to);
-	    if (timeout) {
-		erts_thr_progress_finalize_wait(NULL);
-		ERTS_MSACC_POP_STATE_M();
-	    }
-	    if (res < 0
-		&& errno == EBADF
-		&& ERTS_POLLSET_HAVE_UPDATE_REQUESTS(ps)) {
-		/*
-		 * This may have happened because another thread deselected
-		 * a fd in our poll set and then closed it, i.e. the driver
-		 * behaved correctly. We wan't to avoid looking for a bad
-		 * fd, that may even not exist anymore. Therefore, handle
-		 * update requests and try again.
-		 *
-		 * We don't know how much of the timeout is left; therfore,
-		 * we use a zero timeout. If no error occur and no events
-		 * have triggered, we fake an EAGAIN error and let the caller
-		 * restart us.
-		 */
-		to.tv_sec = 0;
-		to.tv_usec = 0;
-		ERTS_POLLSET_LOCK(ps);
-		handle_update_requests(ps);
-		ERTS_POLLSET_UNLOCK(ps);
-		res = ERTS_SELECT(ps->max_fd + 1,
-				  &ps->res_input_fds,
-				  &ps->res_output_fds,
-				  NULL,
-				  &to);
-		if (res == 0) {
-		    errno = EAGAIN;
-		    res = -1;
-		}
-	    }
-	    return res;
+        res = ERTS_SELECT(ps->max_fd + 1,
+                          &ps->res_input_fds,
+                          &ps->res_output_fds,
+                          NULL,
+                          tvp);
 #endif				/* ----------------------------------------- */
-	}
-	if (timeout) {
-	    erts_thr_progress_finalize_wait(NULL);
-	    ERTS_MSACC_POP_STATE_M();
-	}
-	return res;
     }
+    DEBUG_PRINT_WAIT("Leaving check_fd_events(), res=%d", ps, res);
+    return res;
 }
 
 int
-ERTS_POLL_EXPORT(erts_poll_wait)(ErtsPollSet ps,
+ERTS_POLL_EXPORT(erts_poll_wait)(ErtsPollSet *ps,
 				 ErtsPollResFd pr[],
-				 int *len,
-				 ErtsMonotonicTime timeout_time)
+				 int *len)
 {
-    ErtsMonotonicTime to;
-    int res, no_fds;
+    int res, no_fds, used_fds = 0;
     int ebadf = 0;
+    int do_wait;
     int ps_locked = 0;
+    ERTS_MSACC_DECLARE_CACHE();
 
     no_fds = *len;
-#ifdef ERTS_POLL_MAX_RES
-    if (no_fds >= ERTS_POLL_MAX_RES)
-	no_fds = ERTS_POLL_MAX_RES;
-#endif
-
     *len = 0;
+    ASSERT(no_fds > 0);
 
-#ifdef ERTS_POLL_DEBUG_PRINT
-    erts_printf("Entering erts_poll_wait(), timeout_time=%bps\n",
-		timeout_time);
-#endif
-
-    if (ERTS_POLLSET_SET_POLLED_CHK(ps)) {
-	res = EINVAL; /* Another thread is in erts_poll_wait()
-			 on this pollset... */
-	goto done;
-    }
-
-    to = (is_woken(ps)
-	  ? ERTS_POLL_NO_TIMEOUT /* Use zero timeout */
-	  : timeout_time);
-
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     if (ERTS_POLLSET_HAVE_UPDATE_REQUESTS(ps)) {
 	ERTS_POLLSET_LOCK(ps);
-	handle_update_requests(ps);
+	used_fds = handle_update_requests(ps, pr, no_fds);
 	ERTS_POLLSET_UNLOCK(ps);
+
+        if (used_fds == no_fds) {
+            *len = used_fds;
+            return 0;
+        }
+    }
+#endif
+
+    do_wait = !is_woken(ps) && used_fds == 0;
+
+    DEBUG_PRINT_WAIT("Entering %s(), do_wait=%d", ps, __FUNCTION__, do_wait);
+
+    if (do_wait) {
+        erts_thr_progress_prepare_wait(NULL);
+        ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_SLEEP);
     }
 
     while (1) {
-	res = check_fd_events(ps, to, no_fds);
+	res = check_fd_events(ps, pr + used_fds, do_wait, no_fds - used_fds);
+
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
+        if (res < 0
+            && errno == EBADF
+            && ERTS_POLLSET_HAVE_UPDATE_REQUESTS(ps)) {
+            /*
+             * This may have happened because another thread deselected
+             * a fd in our poll set and then closed it, i.e. the driver
+             * behaved correctly. We wan't to avoid looking for a bad
+             * fd, that may even not exist anymore. Therefore, handle
+             * update requests and try again. This behaviour should only
+             * happen when using SELECT as the polling mechanism.
+             */
+            ERTS_POLLSET_LOCK(ps);
+            used_fds += handle_update_requests(ps, pr + used_fds, no_fds - used_fds);
+            if (used_fds == no_fds) {
+                *len = used_fds;
+                ERTS_POLLSET_UNLOCK(ps);
+                return 0;
+            }
+            res = check_fd_events(ps, pr + used_fds, 0, no_fds - used_fds);
+            /* Keep the lock over the non-blocking poll in order to not
+               get any nasty races happening. */
+            ERTS_POLLSET_UNLOCK(ps);
+            if (res == 0) {
+                errno = EAGAIN;
+                res = -1;
+            }
+        }
+#endif
+
 	if (res != 0)
 	    break;
-	if (to == ERTS_POLL_NO_TIMEOUT)
-	    break;
-	if (erts_get_monotonic_time(NULL) >= timeout_time)
-	    break;
+        if (!do_wait)
+            break;
+    }
+
+    if (do_wait) {
+        erts_thr_progress_finalize_wait(NULL);
+        ERTS_MSACC_UPDATE_CACHE();
+        ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_CHECK_IO);
     }
 
     woke_up(ps);
 
-    if (res == 0) {
-	res = ETIMEDOUT;
-    }
-    else if (res < 0) {
+    if (res < 0) {
 #if ERTS_POLL_USE_SELECT
 	if (errno == EBADF) {
 	    ebadf = 1;
@@ -2363,26 +1666,21 @@ ERTS_POLL_EXPORT(erts_poll_wait)(ErtsPollSet ps,
 	ps_locked = 1;
 	ERTS_POLLSET_LOCK(ps);
 
-	no_fds = save_poll_result(ps, pr, no_fds, res, ebadf);
+	used_fds += ERTS_POLL_EXPORT(save_result)(ps, pr + used_fds, no_fds - used_fds, res, ebadf);
 
 #ifdef HARD_DEBUG
-	check_poll_result(pr, no_fds);
+	check_poll_result(pr, used_fds);
 #endif
 
-	res = (no_fds == 0 ? (is_interrupted_reset(ps) ? EINTR : EAGAIN) : 0);
-	*len = no_fds;
+	res = (used_fds == 0 ? (is_interrupted_reset(ps) ? EINTR : EAGAIN) : 0);
+	*len = used_fds;
     }
 
     if (ps_locked)
 	ERTS_POLLSET_UNLOCK(ps);
-    ERTS_POLLSET_UNSET_POLLED(ps);
 
- done:
-    set_timeout_time(ps, ERTS_MONOTONIC_TIME_MAX);
-#ifdef ERTS_POLL_DEBUG_PRINT
-    erts_printf("Leaving %s = erts_poll_wait()\n",
-		 res == 0 ? "0" : erl_errno_id(res));
-#endif
+    DEBUG_PRINT_WAIT("Leaving %s = %s(len = %d)", ps,
+                     res == 0 ? "0" : erl_errno_id(res), __FUNCTION__, *len);
 
     return res;
 }
@@ -2392,40 +1690,14 @@ ERTS_POLL_EXPORT(erts_poll_wait)(ErtsPollSet ps,
  */
 
 void
-ERTS_POLL_EXPORT(erts_poll_interrupt)(ErtsPollSet ps, int set)
+ERTS_POLL_EXPORT(erts_poll_interrupt)(ErtsPollSet *ps, int set)
 {
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     if (!set)
 	reset_wakeup_state(ps);
     else
-	wake_poller(ps, 1, 0);
-}
-
-
-/*
- * erts_poll_interrupt_timed():
- *   If 'set' != 0, interrupt thread blocked in erts_poll_wait() if it
- * is not guaranteed that it will timeout before 'msec' milli seconds.
- */
-void
-ERTS_POLL_EXPORT(erts_poll_interrupt_timed)(ErtsPollSet ps,
-					    int set,
-					    ErtsMonotonicTime timeout_time)
-{
-    if (!set)
-	reset_wakeup_state(ps);
-    else {
-	ErtsMonotonicTime max_wait_time = get_timeout_time(ps);
-	if (max_wait_time > timeout_time)
-	    wake_poller(ps, 1, 0);
-#ifdef ERTS_POLL_COUNT_AVOIDED_WAKEUPS
-	else {
-	    if (ERTS_POLLSET_IS_POLLED(ps))
-		erts_atomic_inc_nob(&ps->no_avoided_wakeups);
-	    erts_atomic_inc_nob(&ps->no_avoided_interrupts);
-	}
-	erts_atomic_inc_nob(&ps->no_interrupt_timed);
+	wake_poller(ps, 1);
 #endif
-    }
 }
 
 int
@@ -2438,13 +1710,18 @@ ERTS_POLL_EXPORT(erts_poll_max_fds)(void)
  */
 
 void
-ERTS_POLL_EXPORT(erts_poll_init)(void)
+ERTS_POLL_EXPORT(erts_poll_init)(int *concurrent_updates)
 {
-    erts_mtx_init(&pollsets_lock, "pollsets_lock", NIL,
-        ERTS_LOCK_FLAGS_PROPERTY_STATIC | ERTS_LOCK_FLAGS_CATEGORY_IO);
-    pollsets = NULL;
 
     errno = 0;
+
+    if (concurrent_updates) {
+#if ERTS_POLL_USE_CONCURRENT_UPDATE
+        *concurrent_updates = 1;
+#else
+        *concurrent_updates = 0;
+#endif
+    }
 
 #if !defined(NO_SYSCONF)
     max_fds = sysconf(_SC_OPEN_MAX);
@@ -2464,37 +1741,28 @@ ERTS_POLL_EXPORT(erts_poll_init)(void)
 	fatal_error("erts_poll_init(): Failed to get max number of files: %s\n",
 		    erl_errno_id(errno));
 
-#ifdef ERTS_POLL_DEBUG_PRINT
     print_misc_debug_info();
-#endif
 }
 
-ErtsPollSet
-ERTS_POLL_EXPORT(erts_poll_create_pollset)(void)
+ErtsPollSet *
+ERTS_POLL_EXPORT(erts_poll_create_pollset)(int id)
 {
 #if ERTS_POLL_USE_KERNEL_POLL
     int kp_fd;
 #endif
-    ErtsPollSet ps = erts_alloc(ERTS_ALC_T_POLLSET,
+    ErtsPollSet *ps = erts_alloc(ERTS_ALC_T_POLLSET,
 				sizeof(struct ERTS_POLL_EXPORT(erts_pollset)));
+    ps->id = id;
     ps->internal_fd_limit = 0;
-    ps->fds_status = NULL;
-    ps->fds_status_len = 0;
     erts_atomic_init_nob(&ps->no_of_user_fds, 0);
 #if ERTS_POLL_USE_KERNEL_POLL
     ps->kp_fd = -1;
 #if ERTS_POLL_USE_EPOLL
     kp_fd = epoll_create(256);
-    ps->res_events_len = 0;
-    ps->res_events = NULL;
 #elif ERTS_POLL_USE_DEVPOLL
     kp_fd = open("/dev/poll", O_RDWR);
-    ps->res_events_len = 0;
-    ps->res_events = NULL;
 #elif ERTS_POLL_USE_KQUEUE
     kp_fd = kqueue();
-    ps->res_events_len = 0;
-    ps->res_events = NULL;
 #endif
     if (kp_fd < 0)
 	fatal_error("erts_poll_create_pollset(): Failed to "
@@ -2508,10 +1776,6 @@ ERTS_POLL_EXPORT(erts_poll_create_pollset)(void)
 		    ": %s (%d)\n",
 		    erl_errno_id(errno), errno);
 #endif /* ERTS_POLL_USE_KERNEL_POLL */
-#if ERTS_POLL_USE_BATCH_UPDATE_POLLSET
-    /* res_events is also used as write buffer */
-    grow_res_events(ps, ERTS_POLL_MIN_BATCH_BUF_SIZE);
-#endif
 #if ERTS_POLL_USE_POLL
     ps->next_poll_fds_ix = 0;
     ps->no_poll_fds = 0;
@@ -2520,9 +1784,6 @@ ERTS_POLL_EXPORT(erts_poll_create_pollset)(void)
 #elif ERTS_POLL_USE_SELECT
     ps->next_sel_fd = 0;
     ps->max_fd = -1;
-#if ERTS_POLL_USE_FALLBACK
-    ps->no_select_fds = 0;
-#endif
 #ifdef _DARWIN_UNLIMITED_SELECT
     ps->input_fds.sz = 0;
     ps->input_fds.ptr = NULL;
@@ -2539,117 +1800,29 @@ ERTS_POLL_EXPORT(erts_poll_create_pollset)(void)
     ERTS_FD_ZERO(&ps->res_output_fds);
 #endif
 #endif
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
+    ps->fds_status = NULL;
+    ps->fds_status_len = 0;
     ps->update_requests.next = NULL;
     ps->update_requests.len = 0;
     ps->curr_upd_req_block = &ps->update_requests;
     erts_atomic32_init_nob(&ps->have_update_requests, 0);
-    erts_atomic32_init_nob(&ps->polled, 0);
     erts_mtx_init(&ps->mtx, "pollset", NIL, ERTS_LOCK_FLAGS_CATEGORY_IO);
-    erts_atomic32_init_nob(&ps->wakeup_state, (erts_aint32_t) 0);
-    create_wakeup_pipe(ps);
-#if ERTS_POLL_USE_TIMERFD
-    create_timerfd(ps);
-#endif
-#if ERTS_POLL_USE_FALLBACK
-    if (kp_fd >= ps->fds_status_len)
-	grow_fds_status(ps, kp_fd);
-    /* Force kernel poll fd into fallback (poll/select) set */
-    ps->fds_status[kp_fd].flags
-	|= ERTS_POLL_FD_FLG_INFLBCK|ERTS_POLL_FD_FLG_USEFLBCK;
-    {
-	int do_wake = 0;
-	ERTS_POLL_EXPORT(erts_poll_control)(ps, kp_fd, ERTS_POLL_EV_IN, 1,
-					    &do_wake);
-    }    
 #endif
 #if ERTS_POLL_USE_KERNEL_POLL
     if (ps->internal_fd_limit <= kp_fd)
 	ps->internal_fd_limit = kp_fd + 1;
     ps->kp_fd = kp_fd;
 #endif
-    init_timeout_time(ps);
-#ifdef ERTS_POLL_COUNT_AVOIDED_WAKEUPS
-    erts_atomic_init_nob(&ps->no_avoided_wakeups, 0);
-    erts_atomic_init_nob(&ps->no_avoided_interrupts, 0);
-    erts_atomic_init_nob(&ps->no_interrupt_timed, 0);
-#endif
-    handle_update_requests(ps);
-#if ERTS_POLL_USE_FALLBACK
-    ps->fallback_used = 0;
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
+    erts_atomic32_init_nob(&ps->wakeup_state, (erts_aint32_t) 0);
+    create_wakeup_pipe(ps);
+    handle_update_requests(ps, NULL, 0);
+    cleanup_wakeup_pipe(ps);
 #endif
     erts_atomic_set_nob(&ps->no_of_user_fds, 0); /* Don't count wakeup pipe and fallback fd */
 
-    erts_mtx_lock(&pollsets_lock);
-    ps->next = pollsets;
-    pollsets = ps;
-    erts_mtx_unlock(&pollsets_lock);
-
     return ps;
-}
-
-void
-ERTS_POLL_EXPORT(erts_poll_destroy_pollset)(ErtsPollSet ps)
-{
-
-    if (ps->fds_status)
-	erts_free(ERTS_ALC_T_FD_STATUS, (void *) ps->fds_status);
-
-#if ERTS_POLL_USE_EPOLL
-    if (ps->kp_fd >= 0)
-	close(ps->kp_fd);
-    if (ps->res_events)
-	erts_free(ERTS_ALC_T_POLL_RES_EVS, (void *) ps->res_events);
-#elif ERTS_POLL_USE_DEVPOLL
-    if (ps->kp_fd >= 0)
-	close(ps->kp_fd);
-    if (ps->res_events)
-	erts_free(ERTS_ALC_T_POLL_RES_EVS, (void *) ps->res_events);
-#elif ERTS_POLL_USE_POLL
-    if (ps->poll_fds)
-	erts_free(ERTS_ALC_T_POLL_FDS, (void *) ps->poll_fds);
-#elif ERTS_POLL_USE_SELECT
-#ifdef _DARWIN_UNLIMITED_SELECT
-    if (ps->input_fds.ptr)
-	erts_free(ERTS_ALC_T_SELECT_FDS, (void *) ps->input_fds.ptr);
-    if (ps->res_input_fds.ptr)
-	erts_free(ERTS_ALC_T_SELECT_FDS, (void *) ps->res_input_fds.ptr);
-    if (ps->output_fds.ptr)
-	erts_free(ERTS_ALC_T_SELECT_FDS, (void *) ps->output_fds.ptr);
-    if (ps->res_output_fds.ptr)
-	erts_free(ERTS_ALC_T_SELECT_FDS, (void *) ps->res_output_fds.ptr);
-#endif
-#endif
-    {
-	ErtsPollSetUpdateRequestsBlock *urqbp = ps->update_requests.next;
-	while (urqbp) {
-	    ErtsPollSetUpdateRequestsBlock *free_urqbp = urqbp;
-	    urqbp = urqbp->next;
-	    free_update_requests_block(ps, free_urqbp);
-	}
-    }
-    erts_mtx_destroy(&ps->mtx);
-    if (ps->wake_fds[0] >= 0)
-	close(ps->wake_fds[0]);
-    if (ps->wake_fds[1] >= 0)
-	close(ps->wake_fds[1]);
-#if ERTS_POLL_USE_TIMERFD
-    if (ps->timer_fd >= 0)
-        close(ps->timer_fd);
-#endif
-
-    erts_mtx_lock(&pollsets_lock);
-    if (ps == pollsets)
-	pollsets = pollsets->next;
-    else {
-	ErtsPollSet prev_ps;
-	for (prev_ps = pollsets; ps != prev_ps->next; prev_ps = prev_ps->next)
-            ;
-	ASSERT(ps == prev_ps->next);
-	prev_ps->next = ps->next;
-    }
-    erts_mtx_unlock(&pollsets_lock);
-
-    erts_free(ERTS_ALC_T_POLLSET, (void *) ps);
 }
 
 /*
@@ -2657,22 +1830,18 @@ ERTS_POLL_EXPORT(erts_poll_destroy_pollset)(ErtsPollSet ps)
  */
 
 void
-ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet ps, ErtsPollInfo *pip)
+ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet *ps, ErtsPollInfo *pip)
 {
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     int pending_updates;
+#endif
     Uint size = 0;
 
     ERTS_POLLSET_LOCK(ps);
 
     size += sizeof(struct ERTS_POLL_EXPORT(erts_pollset));
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     size += ps->fds_status_len*sizeof(ErtsFdStatus);
-
-#if ERTS_POLL_USE_EPOLL
-    size += ps->res_events_len*sizeof(struct epoll_event);
-#elif ERTS_POLL_USE_DEVPOLL
-    size += ps->res_events_len*sizeof(struct pollfd);
-#elif ERTS_POLL_USE_KQUEUE
-    size += ps->res_events_len*sizeof(struct kevent);
 #endif
 
 #if ERTS_POLL_USE_POLL
@@ -2684,6 +1853,7 @@ ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet ps, ErtsPollInfo *pip)
 #endif
 #endif
 
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     {
 	ErtsPollSetUpdateRequestsBlock *urqbp = ps->update_requests.next;
 	pending_updates = ps->update_requests.len;
@@ -2693,8 +1863,9 @@ ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet ps, ErtsPollInfo *pip)
 	    urqbp = urqbp->next;
 	}
     }
+#endif
 
-    pip->primary = 
+    pip->primary =
 #if ERTS_POLL_USE_KQUEUE
 	"kqueue"
 #elif ERTS_POLL_USE_EPOLL
@@ -2708,17 +1879,7 @@ ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet ps, ErtsPollInfo *pip)
 #endif
 	;
 
-    pip->fallback = 
-#if !ERTS_POLL_USE_FALLBACK
-	NULL
-#elif ERTS_POLL_USE_POLL
-	"poll"
-#elif ERTS_POLL_USE_SELECT
-	"select"
-#endif
-	;
-
-    pip->kernel_poll = 
+    pip->kernel_poll =
 #if !ERTS_POLL_USE_KERNEL_POLL
 	NULL
 #elif ERTS_POLL_USE_KQUEUE
@@ -2733,40 +1894,21 @@ ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet ps, ErtsPollInfo *pip)
     pip->memory_size = size;
 
     pip->poll_set_size = (int) erts_atomic_read_nob(&ps->no_of_user_fds);
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     pip->poll_set_size++; /* Wakeup pipe */
-#if ERTS_POLL_USE_TIMERFD
-    pip->poll_set_size++; /* timerfd */
-#endif
-
-    pip->fallback_poll_set_size =
-#if !ERTS_POLL_USE_FALLBACK
-	0
-#elif ERTS_POLL_USE_POLL
-	ps->no_poll_fds
-#elif ERTS_POLL_USE_SELECT
-	ps->no_select_fds
-#endif
-	;
-
-#if ERTS_POLL_USE_FALLBACK
-    /* If only kp_fd is in fallback poll set we don't use fallback... */
-    if (pip->fallback_poll_set_size == 1)
-	pip->fallback_poll_set_size = 0;
-    else
-	pip->poll_set_size++; /* kp_fd */
 #endif
 
     pip->lazy_updates =
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 	1
+#else
+	0
+#endif
 	;
 
     pip->pending_updates = 
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 	pending_updates
-	;
-
-    pip->batch_updates = 
-#if ERTS_POLL_USE_BATCH_UPDATE_POLLSET
-	1
 #else
 	0
 #endif
@@ -2780,13 +1922,15 @@ ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet ps, ErtsPollInfo *pip)
 #endif
 	;
 
-    pip->max_fds = max_fds;
-
-#ifdef ERTS_POLL_COUNT_AVOIDED_WAKEUPS
-    pip->no_avoided_wakeups = erts_atomic_read_nob(&ps->no_avoided_wakeups);
-    pip->no_avoided_interrupts = erts_atomic_read_nob(&ps->no_avoided_interrupts);
-    pip->no_interrupt_timed = erts_atomic_read_nob(&ps->no_interrupt_timed);
+    pip->is_fallback =
+#if ERTS_POLL_IS_FALLBACK
+        1
+#else
+        0
 #endif
+        ;
+
+    pip->max_fds = max_fds;
 
     ERTS_POLLSET_UNLOCK(ps);
 
@@ -2822,35 +1966,60 @@ fatal_error(char *format, ...)
     abort();
 }
 
-static void
-fatal_error_async_signal_safe(char *error_str)
-{
-    if (ERTS_SOMEONE_IS_CRASH_DUMPING || ERTS_GOT_SIGUSR1) {
-	/* See comment above in fatal_error() */
-	return;
-    }
-    if (error_str) {
-	int len = 0;
-	while (error_str[len])
-	    len++;
-	if (len) {
-	    /* async signal safe */
-	    erts_silence_warn_unused_result(write(2, error_str, len));
-	}
-    }
-    abort();
-}
- 
 /*
  * --- Debug -----------------------------------------------------------------
  */
 
+#if ERTS_POLL_USE_EPOLL
+uint32_t epoll_events(int kp_fd, int fd)
+{
+    /* For epoll we read the information about what is selected upon from the proc fs.*/
+    char fname[30];
+    FILE *f;
+    unsigned int pos, flags, mnt_id;
+    int line = 0;
+    sprintf(fname,"/proc/%d/fdinfo/%d",getpid(), kp_fd);
+    f = fopen(fname,"r");
+    if (!f) {
+        fprintf(stderr,"failed to open file %s, errno = %d\n", fname, errno);
+        ASSERT(0);
+        return 0;
+    }
+    if (fscanf(f,"pos:\t%x\nflags:\t%x", &pos, &flags) != 2) {
+        fprintf(stderr,"failed to parse file %s, errno = %d\n", fname, errno);
+        ASSERT(0);
+        return 0;
+    }
+    if (fscanf(f,"\nmnt_id:\t%x\n", &mnt_id));
+    line += 3;
+    while (!feof(f)) {
+        /* tfd:       10 events: 40000019 data:       180000000a */
+        int ev_fd;
+        uint32_t events;
+        uint64_t data;
+        if (fscanf(f,"tfd:%d events:%x data:%lx\n", &ev_fd, &events, &data) != 3) {
+            fprintf(stderr,"failed to parse file %s on line %d, errno = %d\n", fname,
+                    line,
+                    errno);
+            return 0;
+        }
+        if (fd == ev_fd) {
+            fclose(f);
+            return events;
+        }
+    }
+    fclose(f);
+    return 0;
+}
+#endif
+
 void
-ERTS_POLL_EXPORT(erts_poll_get_selected_events)(ErtsPollSet ps,
+ERTS_POLL_EXPORT(erts_poll_get_selected_events)(ErtsPollSet *ps,
 						ErtsPollEvents ev[],
 						int len)
 {
     int fd;
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     ERTS_POLLSET_LOCK(ps);
     for (fd = 0; fd < len; fd++) {
 	if (fd >= ps->fds_status_len)
@@ -2859,9 +2028,6 @@ ERTS_POLL_EXPORT(erts_poll_get_selected_events)(ErtsPollSet ps,
 	    ev[fd] = ps->fds_status[fd].events;
             if (
                 fd == ps->wake_fds[0] || fd == ps->wake_fds[1] ||
-#if ERTS_POLL_USE_TIMERFD
-                fd == ps->timer_fd ||
-#endif
 #if ERTS_POLL_USE_KERNEL_POLL
                 fd == ps->kp_fd ||
 #endif
@@ -2870,7 +2036,50 @@ ERTS_POLL_EXPORT(erts_poll_get_selected_events)(ErtsPollSet ps,
 	}
     }
     ERTS_POLLSET_UNLOCK(ps);
+#elif ERTS_POLL_USE_EPOLL
 
+    /* For epoll we read the information about what is selected upon from the proc fs.*/
+    char fname[30];
+    FILE *f;
+    unsigned int pos, flags, mnt_id;
+    int line = 0;
+    sprintf(fname,"/proc/%d/fdinfo/%d",getpid(), ps->kp_fd);
+    for (fd = 0; fd < len; fd++)
+        ev[fd] = ERTS_POLL_EV_NONE;
+    f = fopen(fname,"r");
+    if (!f) {
+        fprintf(stderr,"failed to open file %s, errno = %d\n", fname, errno);
+        return;
+    }
+    if (fscanf(f,"pos:\t%x\nflags:\t%x", &pos, &flags) != 2) {
+        fprintf(stderr,"failed to parse file %s, errno = %d\n", fname, errno);
+        ASSERT(0);
+        return;
+    }
+    if (fscanf(f,"\nmnt_id:\t%x\n", &mnt_id));
+    line += 3;
+    while (!feof(f)) {
+        /* tfd:       10 events: 40000019 data:       180000000a */
+        int fd;
+        uint32_t events;
+        uint64_t data;
+        if (fscanf(f,"tfd:%d events:%x data:%lx\n", &fd, &events, &data) != 3) {
+            fprintf(stderr,"failed to parse file %s on line %d, errno = %d\n",
+                    fname, line, errno);
+            ASSERT(0);
+            return;
+        }
+        data &= 0xFFFFFFFF;
+        ASSERT(fd == data);
+        /* Events are the events that are being monitored, which of course include
+           error and hup events, but we are only interested in IN/OUT events */
+        ev[fd] = (ERTS_POLL_EV_IN|ERTS_POLL_EV_OUT) & ERTS_POLL_EV_N2E(events);
+        line++;
+    }
+#else
+    for (fd = 0; fd < len; fd++)
+        ev[fd] = ERTS_POLL_EV_NONE;
+#endif
 }
 
 #ifdef HARD_DEBUG
@@ -2890,10 +2099,10 @@ check_poll_result(ErtsPollResFd pr[], int len)
 }
 
 
-#if ERTS_POLL_USE_DEVPOLL
+#if ERTS_POLL_USE_DEVPOLL && defined(DEBUG)
 
 static void
-check_poll_status(ErtsPollSet ps)
+check_poll_status(ErtsPollSet *ps)
 {
     int i;
     for (i = 0; i < ps->fds_status_len; i++) {
@@ -2925,30 +2134,24 @@ check_poll_status(ErtsPollSet ps)
 #endif /* ERTS_POLL_USE_DEVPOLL */
 #endif /* HARD_DEBUG */
 
-#ifdef ERTS_POLL_DEBUG_PRINT
 static void
 print_misc_debug_info(void)
 {
-    erts_printf("erts_poll using: %s lazy_updates:%s batch_updates:%s\n",
+#if ERTS_POLL_DEBUG_PRINT
+    erts_printf("erts_poll using: %s lazy_updates:%s\n",
 #if ERTS_POLL_USE_KQUEUE
 		"kqueue"
 #elif ERTS_POLL_USE_EPOLL
 		"epoll"
 #elif ERTS_POLL_USE_DEVPOLL
 		"/dev/poll"
-#endif
-#if ERTS_POLL_USE_FALLBACK
-		"-"
-#endif
-#if ERTS_POLL_USE_POLL
+#elif ERTS_POLL_USE_POLL
 		"poll"
 #elif ERTS_POLL_USE_SELECT
 		"select"
 #endif
 		,
-		"true"
-		,
-#if ERTS_POLL_USE_BATCH_UPDATE_POLLSET
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
 		"true"
 #else
 		"false"
@@ -2967,29 +2170,20 @@ print_misc_debug_info(void)
 #ifdef FD_SETSIZE
     erts_printf("FD_SETSIZE=%d\n", FD_SETSIZE);
 #endif
-}
-    
 #endif
+}
 
 #ifdef ERTS_ENABLE_LOCK_COUNT
-static void erts_lcnt_enable_pollset_lock_count(ErtsPollSet pollset, int enable) {
+void ERTS_POLL_EXPORT(erts_lcnt_enable_pollset_lock_count)(ErtsPollSet *pollset, int enable)
+{
+#if !ERTS_POLL_USE_CONCURRENT_UPDATE
     if(enable) {
         erts_lcnt_install_new_lock_info(&pollset->mtx.lcnt, "pollset_rm", NIL,
             ERTS_LOCK_TYPE_MUTEX | ERTS_LOCK_FLAGS_CATEGORY_IO);
     } else {
         erts_lcnt_uninstall(&pollset->mtx.lcnt);
     }
-}
-
-void ERTS_POLL_EXPORT(erts_lcnt_update_pollset_locks)(int enable) {
-    ErtsPollSet iterator;
-
-    erts_mtx_lock(&pollsets_lock);
-
-    for(iterator = pollsets; iterator != NULL; iterator = iterator->next) {
-        erts_lcnt_enable_pollset_lock_count(iterator, enable);
-    }
-
-    erts_mtx_unlock(&pollsets_lock);
+#endif
+    return;
 }
 #endif

--- a/erts/emulator/sys/common/erl_poll.c
+++ b/erts/emulator/sys/common/erl_poll.c
@@ -228,7 +228,11 @@ typedef struct {
 
 #endif
 
-struct ErtsPollSet_ {
+/*
+ * This struct is not really exported, but it's nice to
+ * get unique names in debugger for kp/nkp
+ */
+struct ERTS_POLL_EXPORT(erts_pollset) {
     ErtsPollSet next;
     int internal_fd_limit;
     ErtsFdStatus *fds_status;
@@ -2472,7 +2476,7 @@ ERTS_POLL_EXPORT(erts_poll_create_pollset)(void)
     int kp_fd;
 #endif
     ErtsPollSet ps = erts_alloc(ERTS_ALC_T_POLLSET,
-				sizeof(struct ErtsPollSet_));
+				sizeof(struct ERTS_POLL_EXPORT(erts_pollset)));
     ps->internal_fd_limit = 0;
     ps->fds_status = NULL;
     ps->fds_status_len = 0;
@@ -2660,7 +2664,7 @@ ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet ps, ErtsPollInfo *pip)
 
     ERTS_POLLSET_LOCK(ps);
 
-    size += sizeof(struct ErtsPollSet_);
+    size += sizeof(struct ERTS_POLL_EXPORT(erts_pollset));
     size += ps->fds_status_len*sizeof(ErtsFdStatus);
 
 #if ERTS_POLL_USE_EPOLL

--- a/erts/emulator/sys/common/erl_poll.c
+++ b/erts/emulator/sys/common/erl_poll.c
@@ -1930,6 +1930,14 @@ ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet *ps, ErtsPollInfo *pip)
 #endif
         ;
 
+    pip->batch_updates =
+#if ERTS_POLL_USE_DEVPOLL
+        1
+#else
+        0
+#endif
+        ;
+
     pip->max_fds = max_fds;
 
     ERTS_POLLSET_UNLOCK(ps);

--- a/erts/emulator/sys/common/erl_poll.h
+++ b/erts/emulator/sys/common/erl_poll.h
@@ -195,7 +195,7 @@ typedef Uint32 ErtsPollEvents;
 
 #endif
 
-typedef struct ErtsPollSet_ *ErtsPollSet;
+typedef struct ERTS_POLL_EXPORT(erts_pollset) *ErtsPollSet;
 
 typedef struct {
     ErtsSysFdType fd;

--- a/erts/emulator/sys/common/erl_poll.h
+++ b/erts/emulator/sys/common/erl_poll.h
@@ -225,6 +225,7 @@ typedef struct {
     long no_avoided_interrupts;
     long no_interrupt_timed;
 #endif
+    int active_fds;
 } ErtsPollInfo;
 
 void		ERTS_POLL_EXPORT(erts_poll_interrupt)(ErtsPollSet,

--- a/erts/emulator/sys/common/erl_poll.h
+++ b/erts/emulator/sys/common/erl_poll.h
@@ -18,11 +18,31 @@
  * %CopyrightEnd%
  */
 
-/*
- * Description:	Poll interface suitable for ERTS with or without
- *              SMP support.
+/**
+ * @description: Poll interface suitable for ERTS with SMP support.
  *
- * Author: 	Rickard Green
+ * @author: 	Rickard Green
+ * @author: 	Lukas Larsson
+ *
+ * This header file exports macros and functions that are used to
+ * react to I/O polling events from file descriptors or wait-able
+ * objects. The API exported is the following:
+ *
+ * defines:
+ *   ERTS_POLL_EV_NONE - No events have been set. This is not the same as 0.
+ *   ERTS_POLL_EV_IN   - Represent an IN event
+ *   ERTS_POLL_EV_OUT  - Represent an OUT event
+ *   ERTS_POLL_EV_ERR  - Represent an error event
+ *   ERTS_POLL_EV_NVAL - Represent an invalid event
+ *
+ * macro functions:
+ *   ErtsSysFdType ERTS_POLL_RES_GET_FD(ErtsPollResFd *evt);
+ *   void ERTS_POLL_RES_SET_FD(ErtsPollResFd *evt, ErtsSysFdType fd);
+ *   ErtsPollEvents ERTS_POLL_RES_GET_EVTS(ErtsPollResFd *evt)
+ *   void ERTS_POLL_RES_SET_EVTS(ErtsPollResFd *evt, ErtsPollEvents fd);
+ *
+ * functions:
+ *   See erl_poll_api.h
  */
 
 #ifndef ERL_POLL_H__
@@ -32,32 +52,26 @@
 
 #define ERTS_POLL_NO_TIMEOUT ERTS_MONOTONIC_TIME_MIN
 
-#if 0
-#define ERTS_POLL_COUNT_AVOIDED_WAKEUPS
-#endif
-
 #ifdef ERTS_ENABLE_KERNEL_POLL
-#  if defined(ERTS_KERNEL_POLL_VERSION)
-#    define ERTS_POLL_EXPORT(FUNC) FUNC ## _kp
+#  undef ERTS_ENABLE_KERNEL_POLL
+#  define ERTS_ENABLE_KERNEL_POLL 1
+#  if defined(ERTS_NO_KERNEL_POLL_VERSION)
+#    define ERTS_POLL_EXPORT(FUNC) FUNC ## _flbk
+#    undef ERTS_NO_KERNEL_POLL_VERSION
+#    define ERTS_NO_KERNEL_POLL_VERSION 1
+#    define ERTS_KERNEL_POLL_VERSION 0
 #  else
-#    define ERTS_POLL_EXPORT(FUNC) FUNC ## _nkp
-#    undef ERTS_POLL_DISABLE_KERNEL_POLL
-#    define ERTS_POLL_DISABLE_KERNEL_POLL
+#    undef ERTS_KERNEL_POLL_VERSION
+#    define ERTS_KERNEL_POLL_VERSION 1
+#    define ERTS_NO_KERNEL_POLL_VERSION 0
+#    define ERTS_POLL_EXPORT(FUNC) FUNC
 #  endif
 #else
 #    define ERTS_POLL_EXPORT(FUNC) FUNC
-#    undef ERTS_POLL_DISABLE_KERNEL_POLL
-#    define ERTS_POLL_DISABLE_KERNEL_POLL
+#    define ERTS_ENABLE_KERNEL_POLL 0
+#    define ERTS_NO_KERNEL_POLL_VERSION 1
+#    define ERTS_KERNEL_POLL_VERSION 0
 #endif
-
-#ifdef ERTS_POLL_DISABLE_KERNEL_POLL
-#  undef HAVE_SYS_EPOLL_H
-#  undef HAVE_SYS_EVENT_H
-#  undef HAVE_SYS_DEVPOLL_H
-#endif
-
-#undef ERTS_POLL_USE_KERNEL_POLL
-#define ERTS_POLL_USE_KERNEL_POLL 0
 
 #undef ERTS_POLL_USE_KQUEUE
 #define ERTS_POLL_USE_KQUEUE 0
@@ -70,68 +84,96 @@
 #undef ERTS_POLL_USE_SELECT
 #define ERTS_POLL_USE_SELECT 0
 
-#if defined(HAVE_SYS_EVENT_H)
-#  undef ERTS_POLL_USE_KQUEUE
-#  define ERTS_POLL_USE_KQUEUE 1
-#  undef ERTS_POLL_USE_KERNEL_POLL
-#  define ERTS_POLL_USE_KERNEL_POLL 1
-#elif defined(HAVE_SYS_EPOLL_H)
-#  undef ERTS_POLL_USE_EPOLL
-#  define ERTS_POLL_USE_EPOLL 1
-#  undef ERTS_POLL_USE_KERNEL_POLL
-#  define ERTS_POLL_USE_KERNEL_POLL 1
-#elif defined(HAVE_SYS_DEVPOLL_H)
-#  undef ERTS_POLL_USE_DEVPOLL
-#  define ERTS_POLL_USE_DEVPOLL 1
-#  undef ERTS_POLL_USE_KERNEL_POLL
-#  define ERTS_POLL_USE_KERNEL_POLL 1
+/* Defines which structure that erts_poll_wait should use to wait with
+   and how events should be represented */
+#define ERTS_POLL_USE_EPOLL_EVS 0
+#define ERTS_POLL_USE_KQUEUE_EVS 0
+#define ERTS_POLL_USE_DEVPOLL_EVS 0
+#define ERTS_POLL_USE_POLL_EVS 0
+#define ERTS_POLL_USE_SELECT_EVS 0
+
+#define ERTS_POLL_USE_KERNEL_POLL ERTS_KERNEL_POLL_VERSION
+
+#if ERTS_ENABLE_KERNEL_POLL
+#  if defined(HAVE_SYS_EVENT_H)
+#    undef ERTS_POLL_USE_KQUEUE_EVS
+#    define ERTS_POLL_USE_KQUEUE_EVS 1
+#    undef ERTS_POLL_USE_KQUEUE
+#    define ERTS_POLL_USE_KQUEUE ERTS_KERNEL_POLL_VERSION
+#  elif defined(HAVE_SYS_EPOLL_H)
+#    undef ERTS_POLL_USE_EPOLL_EVS
+#    define ERTS_POLL_USE_EPOLL_EVS 1
+#    undef ERTS_POLL_USE_EPOLL
+#    define ERTS_POLL_USE_EPOLL ERTS_KERNEL_POLL_VERSION
+#  elif defined(HAVE_SYS_DEVPOLL_H)
+#    undef ERTS_POLL_USE_DEVPOLL_EVS
+#    define ERTS_POLL_USE_DEVPOLL_EVS 1
+#    undef ERTS_POLL_USE_DEVPOLL
+#    define ERTS_POLL_USE_DEVPOLL ERTS_KERNEL_POLL_VERSION
+#  else
+#    error "Missing kernel poll implementation of erts_poll()"
+#  endif
 #endif
 
-#define ERTS_POLL_USE_FALLBACK (ERTS_POLL_USE_KQUEUE || ERTS_POLL_USE_EPOLL)
-
-#if !ERTS_POLL_USE_KERNEL_POLL || ERTS_POLL_USE_FALLBACK
+#if ERTS_NO_KERNEL_POLL_VERSION
 #  if defined(ERTS_USE_POLL)
+#    undef ERTS_POLL_USE_POLL_EVS
+#    define ERTS_POLL_USE_POLL_EVS 1
 #    undef ERTS_POLL_USE_POLL
 #    define ERTS_POLL_USE_POLL 1
 #  elif !defined(__WIN32__)
+#    undef ERTS_POLL_USE_SELECT_EVS
+#    define ERTS_POLL_USE_SELECT_EVS 1
 #    undef ERTS_POLL_USE_SELECT
 #    define ERTS_POLL_USE_SELECT 1
 #  endif
 #endif
 
-#define ERTS_POLL_USE_TIMERFD 0
+#define ERTS_POLL_USE_FALLBACK (ERTS_POLL_USE_KQUEUE || ERTS_POLL_USE_EPOLL)
 
 typedef Uint32 ErtsPollEvents;
-#undef ERTS_POLL_EV_E2N
+
+typedef enum {
+    ERTS_POLL_OP_ADD = 0, /* Add the FD to the pollset */
+    ERTS_POLL_OP_MOD = 1, /* Modify the FD in the pollset */
+    ERTS_POLL_OP_DEL = 2  /* Delete the FD from the pollset */
+} ErtsPollOp;
+
+#define op2str(op) (op == ERTS_POLL_OP_ADD ? "add" :            \
+                    (op == ERTS_POLL_OP_MOD ? "mod" : "del"))
 
 #if defined(__WIN32__)	/* --- win32  --------------------------------------- */
 
-#define ERTS_POLL_EV_IN   1
-#define ERTS_POLL_EV_OUT  2
-#define ERTS_POLL_EV_ERR  4
-#define ERTS_POLL_EV_NVAL 8
+#define ERTS_POLL_EV_IN    1
+#define ERTS_POLL_EV_OUT   2
+#define ERTS_POLL_EV_ERR   4
+#define ERTS_POLL_EV_NVAL  8
 
-#elif ERTS_POLL_USE_EPOLL	/* --- epoll ------------------------------- */
+#define ERTS_POLL_EV_E2N(EV) 		(EV)
+#define ERTS_POLL_EV_N2E(EV) 		(EV)
+
+#elif ERTS_POLL_USE_EPOLL_EVS	/* --- epoll ------------------------------- */
 
 #include <sys/epoll.h>
-
-#ifdef HAVE_SYS_TIMERFD_H
-#include <sys/timerfd.h>
-#undef ERTS_POLL_USE_TIMERFD
-#define ERTS_POLL_USE_TIMERFD 1
-#endif
 
 #define ERTS_POLL_EV_E2N(EV) \
   ((uint32_t) (EV))
 #define ERTS_POLL_EV_N2E(EV) \
-  ((ErtsPollEvents) (EV))
+  ((ErtsPollEvents) (EV) & ~EPOLLONESHOT)
 
 #define ERTS_POLL_EV_IN			ERTS_POLL_EV_N2E(EPOLLIN)
 #define ERTS_POLL_EV_OUT		ERTS_POLL_EV_N2E(EPOLLOUT)
 #define ERTS_POLL_EV_NVAL		ERTS_POLL_EV_N2E(EPOLLET)
 #define ERTS_POLL_EV_ERR		ERTS_POLL_EV_N2E(EPOLLERR|EPOLLHUP)
 
-#elif ERTS_POLL_USE_DEVPOLL	/* --- devpoll ----------------------------- */
+typedef struct epoll_event ErtsPollResFd;
+
+#define ERTS_POLL_RES_GET_FD(evt) ((ErtsSysFdType)((evt)->data.fd))
+#define ERTS_POLL_RES_SET_FD(evt, ident) (evt)->data.fd = ident
+#define ERTS_POLL_RES_GET_EVTS(evt) ERTS_POLL_EV_N2E((evt)->events)
+#define ERTS_POLL_RES_SET_EVTS(evt, evts) (evt)->events = ERTS_POLL_EV_E2N(evts)
+
+#elif ERTS_POLL_USE_DEVPOLL_EVS	/* --- devpoll ----------------------------- */
 
 #include <sys/devpoll.h>
 
@@ -145,12 +187,37 @@ typedef Uint32 ErtsPollEvents;
 #define ERTS_POLL_EV_NVAL		ERTS_POLL_EV_N2E(POLLNVAL)
 #define ERTS_POLL_EV_ERR		ERTS_POLL_EV_N2E(POLLERR|POLLHUP)
 
-#elif ERTS_POLL_USE_KQUEUE	/* --- kqueue ------------------------------ */
+typedef struct pollfd ErtsPollResFd;
+
+#define ERTS_POLL_RES_GET_FD(evt) ((ErtsSysFdType)((evt)->fd))
+#define ERTS_POLL_RES_SET_FD(evt, ident) (evt)->fd = ident
+#define ERTS_POLL_RES_GET_EVTS(evt) ERTS_POLL_EV_N2E((evt)->revents)
+#define ERTS_POLL_RES_SET_EVTS(evt, evts) (evt)->revents = ERTS_POLL_EV_E2N(evts)
+
+#elif ERTS_POLL_USE_KQUEUE_EVS	/* --- kqueue ------------------------------ */
 /* Kqueue use fallback defines (poll() or select()) */
+
+#include <sys/event.h>
+
+#ifdef ERTS_USE_POLL
+#  undef ERTS_POLL_USE_POLL_EVS
+#  define ERTS_POLL_USE_POLL_EVS   1
+#elif !defined(__WIN32__)
+#  undef ERTS_POLL_USE_SELECT_EVS
+#  define ERTS_POLL_USE_SELECT_EVS 1
 #endif
 
-#if ERTS_POLL_USE_POLL	/* --- poll -------------------------------- */
+typedef struct kevent ErtsPollResFd;
 
+#define ERTS_POLL_RES_GET_FD(evt) ((ErtsSysFdType)((evt)->ident))
+#define ERTS_POLL_RES_SET_FD(evt, fd) (evt)->ident = fd
+#define ERTS_POLL_RES_GET_EVTS(evt) ERTS_POLL_EV_N2E((ErtsPollEvents)(evt)->udata)
+#define ERTS_POLL_RES_SET_EVTS(evt, evts) (evt)->udata = (void*)(UWord)(ERTS_POLL_EV_E2N(evts))
+
+#endif
+
+#if ERTS_POLL_USE_POLL_EVS
+				/* --- poll -------------------------------- */
 #include <poll.h>
 
 #define ERTS_POLL_EV_NKP_E2N(EV) \
@@ -169,7 +236,7 @@ typedef Uint32 ErtsPollEvents;
 #define ERTS_POLL_EV_NKP_NVAL		ERTS_POLL_EV_N2E(POLLNVAL)
 #define ERTS_POLL_EV_NKP_ERR		ERTS_POLL_EV_N2E(POLLERR|POLLHUP)
 
-#elif ERTS_POLL_USE_SELECT	/* --- select ------------------------------ */
+#elif ERTS_POLL_USE_SELECT_EVS	/* --- select ------------------------------ */
 
 #define ERTS_POLL_EV_NKP_E2N(EV) (EV)
 #define ERTS_POLL_EV_NKP_N2E(EV) (EV)
@@ -195,71 +262,65 @@ typedef Uint32 ErtsPollEvents;
 
 #endif
 
-typedef struct ERTS_POLL_EXPORT(erts_pollset) *ErtsPollSet;
+#if !ERTS_ENABLE_KERNEL_POLL
 
-typedef struct {
-    ErtsSysFdType fd;
-    ErtsPollEvents events;
-    int on;
-} ErtsPollControlEntry;
-
-typedef struct {
+typedef struct _ErtsPollResFd {
     ErtsSysFdType fd;
     ErtsPollEvents events;
 } ErtsPollResFd;
 
+#define ERTS_POLL_RES_GET_FD(evt) (evt)->fd
+#define ERTS_POLL_RES_SET_FD(evt, ident) (evt)->fd = (ident)
+#define ERTS_POLL_RES_GET_EVTS(evt) ERTS_POLL_EV_N2E((evt)->events)
+#define ERTS_POLL_RES_SET_EVTS(evt, evts) (evt)->events = ERTS_POLL_EV_E2N(evts)
+
+#endif
+
+#define ERTS_POLL_EV_NONE (UINT_MAX & ~(ERTS_POLL_EV_IN|ERTS_POLL_EV_OUT|ERTS_POLL_EV_NVAL|ERTS_POLL_EV_ERR))
+
+#define ev2str(ev)                                                     \
+    (((ev) == 0 || (ev) == ERTS_POLL_EV_NONE) ? "NONE" :               \
+     ((ev) == ERTS_POLL_EV_IN ? "IN" :                                 \
+      ((ev) == ERTS_POLL_EV_OUT ? "OUT" :                              \
+       ((ev) == (ERTS_POLL_EV_IN|ERTS_POLL_EV_OUT) ? "IN|OUT" :        \
+        ((ev) & ERTS_POLL_EV_ERR ? "ERR" :                             \
+         ((ev) & ERTS_POLL_EV_NVAL ? "NVAL" : "OTHER"))))))
+
+
+typedef struct ERTS_POLL_EXPORT(erts_pollset) ErtsPollSet;
+
 typedef struct {
     char *primary;
-    char *fallback;
     char *kernel_poll;
     Uint memory_size;
-    int poll_set_size;
-    int fallback_poll_set_size;
+    Uint poll_set_size;
     int lazy_updates;
-    int pending_updates;
+    Uint pending_updates;
     int batch_updates;
     int concurrent_updates;
-    int max_fds;
-#ifdef ERTS_POLL_COUNT_AVOIDED_WAKEUPS
-    long no_avoided_wakeups;
-    long no_avoided_interrupts;
-    long no_interrupt_timed;
-#endif
-    int active_fds;
+    int is_fallback;
+    Uint max_fds;
+    Uint active_fds;
+    Uint poll_threads;
 } ErtsPollInfo;
 
-void		ERTS_POLL_EXPORT(erts_poll_interrupt)(ErtsPollSet,
-						      int);
-void		ERTS_POLL_EXPORT(erts_poll_interrupt_timed)(ErtsPollSet,
-							    int,
-							    ErtsMonotonicTime);
-ErtsPollEvents	ERTS_POLL_EXPORT(erts_poll_control)(ErtsPollSet,
-						    ErtsSysFdType,
-						    ErtsPollEvents,
-						    int on,
-						    int* wake_poller
-						    );
-void		ERTS_POLL_EXPORT(erts_poll_controlv)(ErtsPollSet,
-						     ErtsPollControlEntry [],
-						     int on);
-int		ERTS_POLL_EXPORT(erts_poll_wait)(ErtsPollSet,
-						 ErtsPollResFd [],
-						 int *,
-						 ErtsMonotonicTime);
-int		ERTS_POLL_EXPORT(erts_poll_max_fds)(void);
-void		ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet,
-						 ErtsPollInfo *);
-ErtsPollSet	ERTS_POLL_EXPORT(erts_poll_create_pollset)(void);
-void		ERTS_POLL_EXPORT(erts_poll_destroy_pollset)(ErtsPollSet);
-void		ERTS_POLL_EXPORT(erts_poll_init)(void);
-void		ERTS_POLL_EXPORT(erts_poll_get_selected_events)(ErtsPollSet,
-								ErtsPollEvents [],
-								int);
-
-int erts_poll_new_table_len(int old_len, int need_len);
-
-#ifdef ERTS_ENABLE_LOCK_COUNT
-void ERTS_POLL_EXPORT(erts_lcnt_update_pollset_locks)(int enable);
+#if defined(ERTS_POLL_USE_FALLBACK) && ERTS_KERNEL_POLL_VERSION
+#  undef ERTS_POLL_EXPORT
+#  define ERTS_POLL_EXPORT(FUNC) FUNC ## _flbk
+#  include "erl_poll_api.h"
+#  undef ERTS_POLL_EXPORT
+#  define ERTS_POLL_EXPORT(FUNC) FUNC
+#elif !defined(ERTS_POLL_USE_FALLBACK)
+#  define ERTS_POLL_USE_FALLBACK 0
 #endif
+
+#include "erl_poll_api.h"
+
+/**
+ * Get the next size of the array that holds the file descriptors.
+ * This function is used in order for the check io array and the
+ * pollset array to be of the same size.
+ */
+int erts_poll_new_table_len(int old_len, int need_len);
 
 #endif /* #ifndef ERL_POLL_H__ */

--- a/erts/emulator/sys/common/erl_poll.h
+++ b/erts/emulator/sys/common/erl_poll.h
@@ -134,9 +134,9 @@
 typedef Uint32 ErtsPollEvents;
 
 typedef enum {
-    ERTS_POLL_OP_ADD = 0, /* Add the FD to the pollset */
-    ERTS_POLL_OP_MOD = 1, /* Modify the FD in the pollset */
-    ERTS_POLL_OP_DEL = 2  /* Delete the FD from the pollset */
+    ERTS_POLL_OP_ADD = 0,          /* Add the FD to the pollset */
+    ERTS_POLL_OP_MOD = 1,          /* Modify the FD in the pollset */
+    ERTS_POLL_OP_DEL = 2           /* Delete the FD from the pollset */
 } ErtsPollOp;
 
 #define op2str(op) (op == ERTS_POLL_OP_ADD ? "add" :            \

--- a/erts/emulator/sys/common/erl_poll_api.h
+++ b/erts/emulator/sys/common/erl_poll_api.h
@@ -1,0 +1,122 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2006-2016. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+/**
+ * @description: Poll interface functions
+ * @author Lukas Larsson
+ *
+ * The functions in the header are used to interact with the poll
+ * implementation. Iff the kernel-poll implementation needs a fallback
+ * pollset, then all functions are exported twice. Once with a _flbk
+ * suffix and once without any suffix. If no fallback is needed, then
+ * only the non-suffix version is exported.
+ */
+
+/**
+ * Initialize the poll implementation. Has to be called before any other function.
+ * @param[out] concurrent_waiters if not NULL, set to 1 if more then one thread
+ * is allowed to wait in the pollsets at the same time.
+ */
+void ERTS_POLL_EXPORT(erts_poll_init)(int *concurrent_waiters);
+/**
+ * @brief Create a new pollset.
+ * @param id The unique debug id of this pollset.
+ */
+ErtsPollSet *ERTS_POLL_EXPORT(erts_poll_create_pollset)(int id);
+
+/**
+ * Modify the contents of a pollset. This function can be called while one
+ * (or possibly more) thread is waiting in the pollset.
+ *
+ * @param ps the pollset to modify
+ * @param fd the file descriptor to modify
+ * @param op the type of operation to do. Normal usage is ADD,MOD...MOD,DEL.
+ * @param evts the events that we are changing interest to. Ignored if op is DEL.
+ * @param[in] wake_poller if set to 1 any thread waiting in the pollset will be woken.
+ *   This parameter is ignored if the pollset supports concurrent waiters.
+ * @param[out] wake_poller set to 1 if the waiting thread was woken.
+ * @return The events set, or ERTS_POLL_EV_NVAL if it was not possible to add the
+ * fd to the pollset.
+ */
+ErtsPollEvents ERTS_POLL_EXPORT(erts_poll_control)(ErtsPollSet *ps,
+                                                   ErtsSysFdType fd,
+                                                   ErtsPollOp op,
+                                                   ErtsPollEvents evts,
+                                                   int *wake_poller);
+
+/**
+ * Wait for events to be ready in the pollset. If the erts_poll_init call
+ * set concurrent_waiters to 1, then multiple threads are allowed to call
+ * this function at the same time.
+ *
+ * When an event has been triggered on a fd, that event is disabled. To
+ * re-enable it the implementation has to call erts_poll_control again.
+ *
+ * @param ps the pollset to wait for events in
+ * @param res an array of fd results that the ready fds are put in.
+ * @param[in] length the length of the res array
+ * @param[out] length the number of ready events returned in res
+ * @return 0 on success, else the ERRNO of the error that happened.
+ */
+int ERTS_POLL_EXPORT(erts_poll_wait)(ErtsPollSet *ps,
+                                     ErtsPollResFd res[],
+                                     int *length);
+/**
+ * Interrupt the thread waiting in the pollset. This function should be called
+ * with set = 0 before any thread calls erts_poll_wait in order to clear any
+ * interrupts that have happened while the thread was awake.
+ *
+ * This function has no effect on pollsets that support concurrent waiters.
+ *
+ * @param ps the pollset to wake
+ * @param set if 1, interrupt the pollset, if 0 clear the interrupt flag.
+ */
+void ERTS_POLL_EXPORT(erts_poll_interrupt)(ErtsPollSet *ps, int set);
+
+/* Debug functions */
+
+/**
+ * Get the maximum number of fds supported by the pollset
+ */
+int ERTS_POLL_EXPORT(erts_poll_max_fds)(void);
+/**
+ * Get information about the given pollset
+ */
+void ERTS_POLL_EXPORT(erts_poll_info)(ErtsPollSet *ps,
+                                      ErtsPollInfo *info);
+/**
+ * Get information about which events are currently selected.
+ *
+ * The unix fd is used to index into the array, so naturally this function does
+ * not work on windows. If the pollset cannot figure out what the selected
+ * events for a given fd is, it is set to ERTS_POLL_EV_NONE.
+ *
+ * @param ps the pollset to get events from
+ * @param evts an array of which events are selected on.
+ */
+void ERTS_POLL_EXPORT(erts_poll_get_selected_events)(ErtsPollSet *ps,
+                                                     ErtsPollEvents evts[],
+                                                     int length);
+
+#ifdef ERTS_ENABLE_LOCK_COUNT
+/**
+ * Enable lock counting of any locks within the pollset.
+ */
+void ERTS_POLL_EXPORT(erts_lcnt_enable_pollset_lock_count)(ErtsPollSet *, int enable);
+#endif

--- a/erts/emulator/sys/common/erl_sys_common_misc.c
+++ b/erts/emulator/sys/common/erl_sys_common_misc.c
@@ -45,14 +45,6 @@
 #endif
 #endif
 
-/*
- * erts_check_io_time is used by the erl_check_io implementation. The
- * global erts_check_io_time variable is declared here since there
- * (often) exist two versions of erl_check_io (kernel-poll and
- * non-kernel-poll), and we dont want two versions of this variable.
- */
-erts_atomic_t erts_check_io_time;
-
 /* Written once and only once */
 
 static int filename_encoding = ERL_FILENAME_UNKNOWN;

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -131,121 +131,6 @@ static int replace_intr = 0;
 /* assume yes initially, ttsl_init will clear it */
 int using_oldshell = 1;
 
-#ifdef ERTS_ENABLE_KERNEL_POLL
-
-int erts_use_kernel_poll = 0;
-
-struct {
-    int (*select)(ErlDrvPort, ErlDrvEvent, int, int);
-    int (*enif_select)(ErlNifEnv*, ErlNifEvent, enum ErlNifSelectFlags, void*, const ErlNifPid*, Eterm);
-    int (*event)(ErlDrvPort, ErlDrvEvent, ErlDrvEventData);
-    void (*check_io_as_interrupt)(void);
-    void (*check_io_interrupt)(int);
-    void (*check_io_interrupt_tmd)(int, ErtsMonotonicTime);
-    void (*check_io)(int);
-    Uint (*size)(void);
-    Eterm (*info)(void *);
-    int (*check_io_debug)(ErtsCheckIoDebugInfo *);
-} io_func = {0};
-
-
-int
-driver_select(ErlDrvPort port, ErlDrvEvent event, int mode, int on)
-{
-    return (*io_func.select)(port, event, mode, on);
-}
-
-int
-driver_event(ErlDrvPort port, ErlDrvEvent event, ErlDrvEventData event_data)
-{
-    return (*io_func.event)(port, event, event_data);
-}
-
-int enif_select(ErlNifEnv* env, ErlNifEvent event,
-                enum ErlNifSelectFlags flags, void* obj, const ErlNifPid* pid, Eterm ref)
-{
-    return (*io_func.enif_select)(env, event, flags, obj, pid, ref);
-}
-
-
-Eterm erts_check_io_info(void *p)
-{
-    return (*io_func.info)(p);
-}
-
-int
-erts_check_io_debug(ErtsCheckIoDebugInfo *ip)
-{
-    return (*io_func.check_io_debug)(ip);
-}
-
-
-static void
-init_check_io(void)
-{
-    if (erts_use_kernel_poll) {
-	io_func.select			= driver_select_kp;
-        io_func.enif_select		= enif_select_kp;
-	io_func.event			= driver_event_kp;
-	io_func.check_io_interrupt	= erts_check_io_interrupt_kp;
-	io_func.check_io_interrupt_tmd	= erts_check_io_interrupt_timed_kp;
-	io_func.check_io		= erts_check_io_kp;
-	io_func.size			= erts_check_io_size_kp;
-	io_func.info			= erts_check_io_info_kp;
-	io_func.check_io_debug		= erts_check_io_debug_kp;
-	erts_init_check_io_kp();
-	max_files = erts_check_io_max_files_kp();
-    }
-    else {
-	io_func.select			= driver_select_nkp;
-        io_func.enif_select		= enif_select_nkp;
-	io_func.event			= driver_event_nkp;
-	io_func.check_io_interrupt	= erts_check_io_interrupt_nkp;
-	io_func.check_io_interrupt_tmd	= erts_check_io_interrupt_timed_nkp;
-	io_func.check_io		= erts_check_io_nkp;
-	io_func.size			= erts_check_io_size_nkp;
-	io_func.info			= erts_check_io_info_nkp;
-	io_func.check_io_debug		= erts_check_io_debug_nkp;
-	erts_init_check_io_nkp();
-	max_files = erts_check_io_max_files_nkp();
-    }
-}
-
-#define ERTS_CHK_IO_AS_INTR()	(*io_func.check_io_interrupt)(1)
-#define ERTS_CHK_IO_INTR	(*io_func.check_io_interrupt)
-#define ERTS_CHK_IO_INTR_TMD	(*io_func.check_io_interrupt_tmd)
-#define ERTS_CHK_IO		(*io_func.check_io)
-#define ERTS_CHK_IO_SZ		(*io_func.size)
-
-#else /* !ERTS_ENABLE_KERNEL_POLL */
-
-static void
-init_check_io(void)
-{
-    erts_init_check_io();
-    max_files = erts_check_io_max_files();
-}
-
-#define ERTS_CHK_IO_AS_INTR()	erts_check_io_interrupt(1)
-#define ERTS_CHK_IO_INTR	erts_check_io_interrupt
-#define ERTS_CHK_IO_INTR_TMD	erts_check_io_interrupt_timed
-#define ERTS_CHK_IO		erts_check_io
-#define ERTS_CHK_IO_SZ		erts_check_io_size
-
-#endif
-
-void
-erts_sys_schedule_interrupt(int set)
-{
-    ERTS_CHK_IO_INTR(set);
-}
-
-void
-erts_sys_schedule_interrupt_timed(int set, ErtsMonotonicTime timeout_time)
-{
-    ERTS_CHK_IO_INTR_TMD(set, timeout_time);
-}
-
 UWord
 erts_sys_get_page_size(void)
 {
@@ -261,7 +146,7 @@ erts_sys_get_page_size(void)
 Uint
 erts_sys_misc_mem_sz(void)
 {
-    Uint res = ERTS_CHK_IO_SZ();
+    Uint res = erts_check_io_size();
     res += erts_atomic_read_mb(&sys_misc_mem_sz);
     return res;
 }
@@ -625,7 +510,7 @@ break_requested(void)
       erts_exit(ERTS_INTR_EXIT, "");
 
   ERTS_SET_BREAK_REQUESTED;
-  ERTS_CHK_IO_AS_INTR(); /* Make sure we don't sleep in poll */
+  erts_check_io_sig_interrupt();
 }
 
 static RETSIGTYPE request_break(int signum)
@@ -813,7 +698,7 @@ erts_sys_unix_later_init(void)
 
 int sys_max_files(void)
 {
-   return(max_files);
+   return max_files;
 }
 
 /************************** OS info *******************************/
@@ -1198,7 +1083,7 @@ erl_debug(char* fmt, ...)
 void
 erl_sys_schedule(int runnable)
 {
-    ERTS_CHK_IO(!runnable);
+    erts_check_io(!runnable);
     ERTS_LC_ASSERT(!erts_thr_progress_is_blocking());
 }
 
@@ -1417,6 +1302,8 @@ get_value(char* rest, char** argv, int* ip)
     return rest;
 }
 
+int erts_use_kernel_poll = 0;
+
 #endif /* ERTS_ENABLE_KERNEL_POLL */
 
 void
@@ -1475,7 +1362,9 @@ erl_sys_args(int* argc, char** argv)
     }
 #endif
 
-    init_check_io();
+    erts_init_check_io();
+    max_files = erts_check_io_max_files();
+
 
     init_smp_sig_notify();
     init_smp_sig_suspend();

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -510,7 +510,7 @@ break_requested(void)
       erts_exit(ERTS_INTR_EXIT, "");
 
   ERTS_SET_BREAK_REQUESTED;
-  erts_check_io_sig_interrupt();
+  erts_check_io_interrupt(1);
 }
 
 static RETSIGTYPE request_break(int signum)

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -499,6 +499,7 @@ static void signal_notify_requested(Eterm type) {
 static ERTS_INLINE void
 break_requested(void)
 {
+    int i;
   /*
    * just set a flag - checked for and handled by
    * scheduler threads erts_check_io() (not signal handler).
@@ -510,7 +511,10 @@ break_requested(void)
       erts_exit(ERTS_INTR_EXIT, "");
 
   ERTS_SET_BREAK_REQUESTED;
-  erts_check_io_interrupt(1);
+  for (i=0; i < erts_no_schedulers; i++) {
+       /* Make sure we don't sleep in poll */
+      erts_check_io_interrupt(ERTS_SCHEDULER_IX(i)->pollset, 1);
+  }
 }
 
 static RETSIGTYPE request_break(int signum)

--- a/erts/emulator/sys/win32/erl_poll.c
+++ b/erts/emulator/sys/win32/erl_poll.c
@@ -34,6 +34,7 @@
  */
 
 /*#define HARDDEBUG */
+/*#define HARDTRACE */
 #ifdef HARDDEBUG
 #ifdef HARDTRACE
 #define HARDTRACEF(X) my_debug_printf##X
@@ -50,7 +51,7 @@ static void my_debug_printf(char *fmt, ...)
     va_start(args, fmt);
     erts_vsnprintf(buffer,1024,fmt,args);
     va_end(args);
-    erts_fprintf(stderr,"%s\r\n",buffer);
+    erts_printf("%s\r\n",buffer);
 }
 #else
 #define HARDTRACEF(X)
@@ -278,16 +279,13 @@ struct erts_pollset {
     Waiter** waiter;
     int allocated_waiters;  /* Size ow waiter array */ 
     int num_waiters;	    /* Number of waiter threads. */
-    int restore_events;        /* Tells us to restore waiters events 
-				  next time around */
     HANDLE event_io_ready;     /* To be used when waiting for io */
     /* These are used to wait for workers to enter standby */
     volatile int standby_wait_counter; /* Number of threads to wait for */
     CRITICAL_SECTION standby_crit;     /* CS to guard the counter */
-    HANDLE standby_wait_event;         /* Event signalled when counte == 0 */
+    HANDLE standby_wait_event;         /* Event signalled when counter == 0 */
     erts_atomic32_t wakeup_state;
     erts_mtx_t mtx;
-    erts_atomic64_t timeout_time;
 };
 
 
@@ -352,39 +350,19 @@ do { \
     wait_standby(PS); \
  } while(0)
 
-static ERTS_INLINE void
-init_timeout_time(ErtsPollSet ps)
-{
-    erts_atomic64_init_nob(&ps->timeout_time,
-			   (erts_aint64_t) ERTS_MONOTONIC_TIME_MAX);
-}
-
-static ERTS_INLINE void
-set_timeout_time(ErtsPollSet ps, ErtsMonotonicTime time)
-{
-    erts_atomic64_set_relb(&ps->timeout_time,
-			   (erts_aint64_t) time);
-}
-
-static ERTS_INLINE ErtsMonotonicTime
-get_timeout_time(ErtsPollSet ps)
-{
-    return (ErtsMonotonicTime) erts_atomic64_read_acqb(&ps->timeout_time);
-}
-
 #define ERTS_POLL_NOT_WOKEN		((erts_aint32_t) 0)
 #define ERTS_POLL_WOKEN_IO_READY	((erts_aint32_t) 1)
 #define ERTS_POLL_WOKEN_INTR		((erts_aint32_t) 2)
 #define ERTS_POLL_WOKEN_TIMEDOUT	((erts_aint32_t) 3)
 
 static ERTS_INLINE int
-is_io_ready(ErtsPollSet ps)
+is_io_ready(ErtsPollSet *ps)
 {
     return erts_atomic32_read_nob(&ps->wakeup_state) == ERTS_POLL_WOKEN_IO_READY;
 }
 
 static ERTS_INLINE void
-woke_up(ErtsPollSet ps)
+woke_up(ErtsPollSet *ps)
 {
     if (erts_atomic32_read_nob(&ps->wakeup_state) == ERTS_POLL_NOT_WOKEN)
 	erts_atomic32_cmpxchg_nob(&ps->wakeup_state,
@@ -407,7 +385,7 @@ woke_up(ErtsPollSet ps)
 }
 
 static ERTS_INLINE int
-wakeup_cause(ErtsPollSet ps)
+wakeup_cause(ErtsPollSet *ps)
 {
     int res;
     erts_aint32_t wakeup_state = erts_atomic32_read_acqb(&ps->wakeup_state);
@@ -430,46 +408,8 @@ wakeup_cause(ErtsPollSet ps)
     return res;
 }
 
-static ERTS_INLINE DWORD
-poll_wait_timeout(ErtsPollSet ps, ErtsMonotonicTime timeout_time)
-{
-    ErtsMonotonicTime current_time, diff_time, timeout;
-
-    if (timeout_time == ERTS_POLL_NO_TIMEOUT) {
-    no_timeout:
-	set_timeout_time(ps, ERTS_MONOTONIC_TIME_MIN);
-	woke_up(ps);
-	return (DWORD) 0;
-    }
-
-    current_time = erts_get_monotonic_time(NULL);
-    diff_time = timeout_time - current_time;
-    if (diff_time <= 0)
-	goto no_timeout;
-
-    /* Round up to nearest milli second */
-    timeout = (ERTS_MONOTONIC_TO_MSEC(diff_time - 1) + 1);
-    if (timeout > INT_MAX)
-	timeout = INT_MAX; /* Also prevents DWORD overflow */
-
-    set_timeout_time(ps, current_time + ERTS_MSEC_TO_MONOTONIC(timeout));
-
-    ResetEvent(ps->event_io_ready);
-    /*
-     * Since we don't know the internals of ResetEvent() we issue
-     * a memory barrier as a safety precaution ensuring that
-     * the load of wakeup_state wont be reordered with stores made
-     * by ResetEvent().
-     */
-    ERTS_THR_MEMORY_BARRIER;
-    if (erts_atomic32_read_nob(&ps->wakeup_state) != ERTS_POLL_NOT_WOKEN)
-	return (DWORD) 0;
-
-    return (DWORD) timeout;
-}
-
 static ERTS_INLINE void
-wake_poller(ErtsPollSet ps, int io_ready)
+wake_poller(ErtsPollSet *ps, int io_ready)
 {
     erts_aint32_t wakeup_state;
     if (io_ready) {
@@ -504,13 +444,13 @@ wake_poller(ErtsPollSet ps, int io_ready)
 }
 
 static ERTS_INLINE void
-reset_io_ready(ErtsPollSet ps)
+reset_io_ready(ErtsPollSet *ps)
 {
     erts_atomic32_set_nob(&ps->wakeup_state, ERTS_POLL_NOT_WOKEN);
 }
 
 static ERTS_INLINE void
-restore_io_ready(ErtsPollSet ps)
+restore_io_ready(ErtsPollSet *ps)
 {
     erts_atomic32_set_nob(&ps->wakeup_state, ERTS_POLL_WOKEN_IO_READY);
 }
@@ -520,13 +460,13 @@ restore_io_ready(ErtsPollSet ps)
  * notifying a poller thread about I/O ready.
  */
 static ERTS_INLINE void
-notify_io_ready(ErtsPollSet ps)
+notify_io_ready(ErtsPollSet *ps)
 {
     wake_poller(ps, 1);
 }
 
 static ERTS_INLINE void
-reset_interrupt(ErtsPollSet ps)
+reset_interrupt(ErtsPollSet *ps)
 {
     /* We need to keep io-ready if set */
     erts_aint32_t wakeup_state = erts_atomic32_read_nob(&ps->wakeup_state);
@@ -543,12 +483,12 @@ reset_interrupt(ErtsPollSet ps)
 }
 
 static ERTS_INLINE void
-set_interrupt(ErtsPollSet ps)
+set_interrupt(ErtsPollSet *ps)
 {
     wake_poller(ps, 0);
 }
 
-static void setup_standby_wait(ErtsPollSet ps, int num_threads)
+static void setup_standby_wait(ErtsPollSet *ps, int num_threads)
 {
     EnterCriticalSection(&(ps->standby_crit));
     ps->standby_wait_counter = num_threads;
@@ -556,7 +496,7 @@ static void setup_standby_wait(ErtsPollSet ps, int num_threads)
     LeaveCriticalSection(&(ps->standby_crit));
 }
 
-static void signal_standby(ErtsPollSet ps) 
+static void signal_standby(ErtsPollSet *ps)
 {
     EnterCriticalSection(&(ps->standby_crit));
     --(ps->standby_wait_counter);
@@ -570,7 +510,7 @@ static void signal_standby(ErtsPollSet ps)
     LeaveCriticalSection(&(ps->standby_crit));
 }
 
-static void wait_standby(ErtsPollSet ps)
+static void wait_standby(ErtsPollSet *ps)
 {
     WaitForSingleObject(ps->standby_wait_event,INFINITE);
 }
@@ -638,7 +578,7 @@ static void consistency_check(Waiter* w)
 
 #endif
 
-static void new_waiter(ErtsPollSet ps)
+static void new_waiter(ErtsPollSet *ps)
 {
     register Waiter* w;
     DWORD tid;			/* Id for thread. */
@@ -732,7 +672,7 @@ static void *break_waiter(void *param)
 static void *threaded_waiter(void *param)
 {
     register Waiter* w = (Waiter *) param;
-    ErtsPollSet ps = (ErtsPollSet) w->xdata;
+    ErtsPollSet *ps = (ErtsPollSet*) w->xdata;
 #ifdef HARD_POLL_DEBUG2
     HANDLE oold_fired[64];
     int num_oold_fired;
@@ -835,9 +775,9 @@ event_happened:
 	    ASSERT(i >= WAIT_OBJECT_0+1);
 	    i -= WAIT_OBJECT_0;
 	    ASSERT(i >= 1);
-	    w->active_events--;
 	    HARDDEBUGF(("i = %d, a,h,t = %d,%d,%d",i,
 			w->active_events, w->highwater, w->total_events));
+	    w->active_events--;
 #ifdef HARD_POLL_DEBUG2
 	    fired[num_fired++] = w->events[i];
 #endif
@@ -867,7 +807,7 @@ event_happened:
  * The actual adding and removing from pollset utilities 
  */
 
-static int set_driver_select(ErtsPollSet ps, HANDLE event, ErtsPollEvents mode)
+static int set_driver_select(ErtsPollSet *ps, HANDLE event, ErtsPollEvents mode)
 {
     int i;
     int best_waiter = -1;	/* The waiter with lowest number of events. */
@@ -957,13 +897,13 @@ static int set_driver_select(ErtsPollSet ps, HANDLE event, ErtsPollEvents mode)
 #endif
     erts_mtx_unlock(&w->mtx);
     START_WAITER(ps,w);
-    HARDDEBUGF(("add select %d %d %d %d",best_waiter,
+    HARDDEBUGF(("%d: add select %d %d %d %d", event, best_waiter,
 		w->active_events,w->highwater,w->total_events));
     return mode;
 }
 
 
-static int cancel_driver_select(ErtsPollSet ps, HANDLE event)
+static int cancel_driver_select(ErtsPollSet *ps, HANDLE event)
 {
     int i;
 
@@ -1018,7 +958,7 @@ static int cancel_driver_select(ErtsPollSet ps, HANDLE event)
  * Interface functions
  */
 
-void  erts_poll_interrupt(ErtsPollSet ps, int set /* bool */)
+void  erts_poll_interrupt(ErtsPollSet *ps, int set /* bool */)
 {
     HARDTRACEF(("In erts_poll_interrupt(%d)",set));
     if (!set)
@@ -1028,35 +968,23 @@ void  erts_poll_interrupt(ErtsPollSet ps, int set /* bool */)
     HARDTRACEF(("Out erts_poll_interrupt(%d)",set));
 }
 
-void erts_poll_interrupt_timed(ErtsPollSet ps,
-			       int set /* bool */,
-			       ErtsMonotonicTime timeout_time)
-{
-    HARDTRACEF(("In erts_poll_interrupt_timed(%d,%ld)",set,timeout_time));
-    if (!set)
-	reset_interrupt(ps);
-    else if (get_timeout_time(ps) > timeout_time)
-	set_interrupt(ps);
-    HARDTRACEF(("Out erts_poll_interrupt_timed"));
-}
-
 
 /*
  * Windows is special, there is actually only one event type, and
  * the only difference between ERTS_POLL_EV_IN and ERTS_POLL_EV_OUT
  * is which driver callback will eventually be called.
  */
-static ErtsPollEvents do_poll_control(ErtsPollSet ps,
-				      ErtsSysFdType fd,
-				      ErtsPollEvents pe,
-				      int on /* bool */)
+static ErtsPollEvents do_poll_control(ErtsPollSet *ps,
+                                      ErtsSysFdType fd,
+                                      ErtsPollOp op,
+                                      ErtsPollEvents pe)
 {
     HANDLE event = (HANDLE) fd;
     ErtsPollEvents mode;
     ErtsPollEvents result;
     ASSERT(event != INVALID_HANDLE_VALUE);
 
-    if (on) {
+    if (op != ERTS_POLL_OP_DEL) {
 	if (pe & ERTS_POLL_EV_IN || !(pe & ERTS_POLL_EV_OUT )) {
 	    mode = ERTS_POLL_EV_IN;
 	} else {
@@ -1069,51 +997,30 @@ static ErtsPollEvents do_poll_control(ErtsPollSet ps,
     return result;
 }
 
-ErtsPollEvents erts_poll_control(ErtsPollSet ps,
+ErtsPollEvents erts_poll_control(ErtsPollSet *ps,
 				 ErtsSysFdType fd,
+                                 ErtsPollOp op,
 				 ErtsPollEvents pe,
-				 int on,
 				 int* do_wake) /* In: Wake up polling thread */
 				               /* Out: Poller is woken */
 {
     ErtsPollEvents result;
-    HARDTRACEF(("In erts_poll_control(0x%08X, %u, %d)",(unsigned long) fd, (unsigned) pe, on));
+    HARDTRACEF(("In erts_poll_control(0x%08X, %s, %s)",
+                (unsigned long) fd, op2str(op), ev2str(pe)));
     ERTS_POLLSET_LOCK(ps);
-    result=do_poll_control(ps,fd,pe,on);
+    result=do_poll_control(ps, fd, op, pe);
     ERTS_POLLSET_UNLOCK(ps);
     *do_wake = 0; /* Never any need to wake polling threads on windows */
     HARDTRACEF(("Out erts_poll_control -> %u",(unsigned) result));
     return result;
 }
 
-void erts_poll_controlv(ErtsPollSet ps,
-			ErtsPollControlEntry pcev[],
-			int len)
-{
-    int i;
-    int hshur = 0;
-    int do_wake = 0;
-
-    HARDTRACEF(("In erts_poll_controlv(%d)",len));
-    ERTS_POLLSET_LOCK(ps);
-
-    for (i = 0; i < len; i++) {
-	pcev[i].events = do_poll_control(ps,
-					 pcev[i].fd,
-					 pcev[i].events,
-					 pcev[i].on);
-    }
-    ERTS_POLLSET_UNLOCK(ps);
-    HARDTRACEF(("Out erts_poll_controlv"));
-}
-
-int erts_poll_wait(ErtsPollSet ps,
+int erts_poll_wait(ErtsPollSet *ps,
 		   ErtsPollResFd pr[],
-		   int *len,
-		   ErtsMonotonicTime timeout_time)
+		   int *len)
 {
     int no_fds;
-    DWORD timeout;
+    DWORD timeout = INFINITE;
     EventData* ev;
     int res = 0;
     int num = 0;
@@ -1124,42 +1031,6 @@ int erts_poll_wait(ErtsPollSet ps,
     HARDTRACEF(("In erts_poll_wait"));
     ERTS_POLLSET_LOCK(ps);
 
-    if (!is_io_ready(ps) && ps->restore_events) {
-	HARDDEBUGF(("Restore events: %d",ps->num_waiters));
-	ps->restore_events = 0;
-	for (i = 0; i < ps->num_waiters; ++i) {
-	   Waiter* w = ps->waiter[i];
-	   erts_mtx_lock(&w->mtx);
-	   HARDDEBUGF(("Maybe reset %d %d %d %d",i,
-		       w->active_events,w->highwater,w->total_events));
-	   if (w->active_events < w->total_events) {
-	       erts_mtx_unlock(&w->mtx);
-	       STOP_WAITER(ps,w);
-	       HARDDEBUGF(("Need reset %d %d %d %d",i,
-			   w->active_events,w->highwater,w->total_events));
-	       erts_mtx_lock(&w->mtx);	       
-	       /* Need reset, just check that it doesn't have got more to tell */
-	       if (w->highwater != w->active_events) {
-		   HARDDEBUGF(("Oups!"));
-		   /* Oups, got signalled before we took the lock, can't reset */
-		   if(!is_io_ready(ps)) {
-		       erts_exit(ERTS_ERROR_EXIT,"Internal error: "
-				"Inconsistent io structures in erl_poll.\n");
-		   }
-		   START_WAITER(ps,w);
-		   erts_mtx_unlock(&w->mtx);
-		   ps->restore_events = 1; 
-		   continue;
-	       }
-	       w->active_events = w->highwater =  w->total_events;
-	       START_WAITER(ps,w);
-	       erts_mtx_unlock(&w->mtx);
-	   } else {
-	       erts_mtx_unlock(&w->mtx);
-	   }
-	}
-    }
-
     no_fds = *len;
 
 #ifdef ERTS_POLL_MAX_RES
@@ -1167,11 +1038,18 @@ int erts_poll_wait(ErtsPollSet ps,
 	no_fds = ERTS_POLL_MAX_RES;
 #endif
 
-    timeout = poll_wait_timeout(ps, timeout_time);
+    ResetEvent(ps->event_io_ready);
+    /*
+     * Since we don't know the internals of ResetEvent() we issue
+     * a memory barrier as a safety precaution ensuring that
+     * the load of wakeup_state wont be reordered with stores made
+     * by ResetEvent().
+     */
+    ERTS_THR_MEMORY_BARRIER;
+    if (erts_atomic32_read_nob(&ps->wakeup_state) != ERTS_POLL_NOT_WOKEN)
+       timeout = (DWORD) 0;
 
-    /*HARDDEBUGF(("timeout = %ld",(long) timeout));*/
-
-    if (timeout > 0 && !erts_atomic32_read_nob(&break_waiter_state)) {
+    if (!erts_atomic32_read_nob(&break_waiter_state)) {
 	HANDLE harr[2] = {ps->event_io_ready, break_happened_event};
 	int num_h = 2;
         ERTS_MSACC_PUSH_STATE_M();
@@ -1215,7 +1093,7 @@ int erts_poll_wait(ErtsPollSet ps,
 
     reset_io_ready(ps);
 
-    n = ps->num_waiters;	
+    n = ps->num_waiters;
 
     for (i = 0; i < n; i++) {
 	Waiter* w = ps->waiter[i];
@@ -1241,11 +1119,10 @@ int erts_poll_wait(ErtsPollSet ps,
 		HARDDEBUGF(("To many FD's to report!"));
 		goto done;
 	    }
-	    HARDDEBUGF(("SET! Restore events"));
-	    ps->restore_events = 1;
 	    HARDDEBUGF(("Report %d,%d",i,j));
-	    pr[num].fd = (ErtsSysFdType) w->events[j];
-	    pr[num].events = w->evdata[j]->mode;
+	    ERTS_POLL_RES_SET_FD(&pr[num], w->events[j]);
+	    ERTS_POLL_RES_SET_EVTS(&pr[num], w->evdata[j]->mode);
+            remove_event_from_set(w, j);
 #ifdef HARD_POLL_DEBUG
 	    poll_debug_reported(w->events[j],w->highwater | (j << 16));
 	    poll_debug_reported(w->events[j],first | (last << 16));
@@ -1253,13 +1130,14 @@ int erts_poll_wait(ErtsPollSet ps,
 	    ++num;
 	}
 
+        w->total_events = w->highwater = w->active_events;
+
 #ifdef DEBUG
 	consistency_check(w);
 #endif
 	erts_mtx_unlock(&w->mtx);
     }
  done:
-    set_timeout_time(ps, ERTS_MONOTONIC_TIME_MAX);
     *len = num;
     ERTS_POLLSET_UNLOCK(ps);
     HARDTRACEF(("Out erts_poll_wait"));
@@ -1274,7 +1152,7 @@ int erts_poll_max_fds(void)
     return res;
 }
 
-void erts_poll_info(ErtsPollSet ps,
+void erts_poll_info(ErtsPollSet *ps,
 		    ErtsPollInfo *pip)
 {
     Uint size = 0;
@@ -1299,15 +1177,11 @@ void erts_poll_info(ErtsPollSet ps,
 
     pip->primary = "WaitForMultipleObjects"; 
 
-    pip->fallback = NULL;
-
     pip->kernel_poll = NULL;
 
     pip->memory_size = size;
 
     pip->poll_set_size = num_events;
-
-    pip->fallback_poll_set_size = 0;
 
     pip->lazy_updates = 0;
 
@@ -1316,6 +1190,8 @@ void erts_poll_info(ErtsPollSet ps,
     pip->batch_updates = 0;
 
     pip->concurrent_updates = 0;
+
+    pip->is_fallback = 0;
     ERTS_POLLSET_UNLOCK(ps);
 
     pip->max_fds = erts_poll_max_fds();
@@ -1323,9 +1199,9 @@ void erts_poll_info(ErtsPollSet ps,
 
 }
 
-ErtsPollSet erts_poll_create_pollset(void)
+ErtsPollSet *erts_poll_create_pollset(int no)
 {
-    ErtsPollSet ps = SEL_ALLOC(ERTS_ALC_T_POLLSET,
+    ErtsPollSet *ps = SEL_ALLOC(ERTS_ALC_T_POLLSET,
 			       sizeof(struct erts_pollset));
     HARDTRACEF(("In erts_poll_create_pollset"));
 
@@ -1337,17 +1213,15 @@ ErtsPollSet erts_poll_create_pollset(void)
     ps->standby_wait_counter = 0;
     ps->event_io_ready = CreateManualEvent(FALSE);
     ps->standby_wait_event = CreateManualEvent(FALSE); 
-    ps->restore_events = 0;
 
     erts_atomic32_init_nob(&ps->wakeup_state, ERTS_POLL_NOT_WOKEN);
     erts_mtx_init(&ps->mtx, "pollset", NIL, ERTS_LOCK_FLAGS_CATEGORY_IO);
-    init_timeout_time(ps);
 
     HARDTRACEF(("Out erts_poll_create_pollset"));
     return ps;
 }
 
-void erts_poll_destroy_pollset(ErtsPollSet ps)
+void erts_poll_destroy_pollset(ErtsPollSet *ps)
 {
     int i;
     HARDTRACEF(("In erts_poll_destroy_pollset"));
@@ -1378,13 +1252,15 @@ void erts_poll_destroy_pollset(ErtsPollSet ps)
 /*
  * Actually mostly initializes the friend module sys_interrupt...
  */
-void  erts_poll_init(void)
+void  erts_poll_init(int *concurrent_updates)
 {
-    erts_tid_t thread;
 
 #ifdef HARD_POLL_DEBUG
     poll_debug_init();
 #endif
+
+    if (concurrent_updates)
+        *concurrent_updates = 0;
 
     HARDTRACEF(("In erts_poll_init"));
     erts_sys_break_event = CreateManualEvent(FALSE);
@@ -1394,21 +1270,26 @@ void  erts_poll_init(void)
     break_happened_event = CreateManualEvent(FALSE);
     erts_atomic32_init_nob(&break_waiter_state, 0); 
 
+    HARDTRACEF(("Out erts_poll_init"));
+}
+
+void erts_poll_late_init(void)
+{
+    erts_tid_t thread;
     erts_thr_create(&thread, &break_waiter, NULL, NULL);
     ERTS_UNSET_BREAK_REQUESTED;
-    HARDTRACEF(("Out erts_poll_init"));
 }
 
 /*
  * Non windows friendly interface, not used when fd's are not continous
  */
-void  erts_poll_get_selected_events(ErtsPollSet ps,
+void  erts_poll_get_selected_events(ErtsPollSet *ps,
 				    ErtsPollEvents ev[],
 				    int len)
 {
     int i;
     HARDTRACEF(("In erts_poll_get_selected_events"));
     for (i = 0; i < len; ++i)
-	ev[i] = 0;
+	ev[i] = ERTS_POLL_EV_NONE;
     HARDTRACEF(("Out erts_poll_get_selected_events"));
 }

--- a/erts/emulator/sys/win32/erl_poll.c
+++ b/erts/emulator/sys/win32/erl_poll.c
@@ -274,7 +274,7 @@ typedef struct _Waiter {
 /*
  * The structure for a pollset. There can currently be only one...
  */
-struct ErtsPollSet_ {
+struct erts_pollset {
     Waiter** waiter;
     int allocated_waiters;  /* Size ow waiter array */ 
     int num_waiters;	    /* Number of waiter threads. */
@@ -1284,7 +1284,7 @@ void erts_poll_info(ErtsPollSet ps,
     HARDTRACEF(("In erts_poll_info"));
     ERTS_POLLSET_LOCK(ps);
 
-    size += sizeof(struct ErtsPollSet_);
+    size += sizeof(struct erts_pollset);
     size += sizeof(Waiter *) * ps->allocated_waiters;
     for (i = 0; i < ps->num_waiters; ++i) {
 	Waiter *w = ps->waiter[i];
@@ -1326,7 +1326,7 @@ void erts_poll_info(ErtsPollSet ps,
 ErtsPollSet erts_poll_create_pollset(void)
 {
     ErtsPollSet ps = SEL_ALLOC(ERTS_ALC_T_POLLSET,
-			       sizeof(struct ErtsPollSet_));
+			       sizeof(struct erts_pollset));
     HARDTRACEF(("In erts_poll_create_pollset"));
 
     ps->num_waiters = 0;

--- a/erts/emulator/sys/win32/erl_poll.c
+++ b/erts/emulator/sys/win32/erl_poll.c
@@ -1052,15 +1052,15 @@ int erts_poll_wait(ErtsPollSet *ps,
     if (!erts_atomic32_read_nob(&break_waiter_state)) {
 	HANDLE harr[2] = {ps->event_io_ready, break_happened_event};
 	int num_h = 2;
-        ERTS_MSACC_PUSH_STATE_M();
+        ERTS_MSACC_PUSH_STATE();
 
 	HARDDEBUGF(("Start waiting %d [%d]",num_h, (int) timeout));
 	ERTS_POLLSET_UNLOCK(ps);
 	erts_thr_progress_prepare_wait(NULL);
-        ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_SLEEP);
+        ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_SLEEP);
 	WaitForMultipleObjects(num_h, harr, FALSE, timeout);
 	erts_thr_progress_finalize_wait(NULL);
-        ERTS_MSACC_POP_STATE_M();
+        ERTS_MSACC_POP_STATE();
 	ERTS_POLLSET_LOCK(ps);
 	HARDDEBUGF(("Stop waiting %d [%d]",num_h, (int) timeout));
 	woke_up(ps);

--- a/erts/emulator/sys/win32/erl_win_dyn_driver.h
+++ b/erts/emulator/sys/win32/erl_win_dyn_driver.h
@@ -40,7 +40,6 @@ WDD_TYPEDEF(int, driver_exit, (ErlDrvPort, int));
 WDD_TYPEDEF(int, driver_failure_eof, (ErlDrvPort));
 WDD_TYPEDEF(void, erl_drv_busy_msgq_limits, (ErlDrvPort, ErlDrvSizeT *, ErlDrvSizeT *));
 WDD_TYPEDEF(int, driver_select, (ErlDrvPort, ErlDrvEvent, int, int));
-WDD_TYPEDEF(int, driver_event, (ErlDrvPort, ErlDrvEvent,ErlDrvEventData));
 WDD_TYPEDEF(int, driver_output, (ErlDrvPort, char *, ErlDrvSizeT));
 WDD_TYPEDEF(int, driver_output2, (ErlDrvPort, char *, ErlDrvSizeT ,char *, ErlDrvSizeT));
 WDD_TYPEDEF(int, driver_output_binary, (ErlDrvPort, char *, ErlDrvSizeT, ErlDrvBinary*, ErlDrvSizeT, ErlDrvSizeT));
@@ -162,7 +161,7 @@ typedef struct {
     WDD_FTYPE(driver_failure_eof) *driver_failure_eof;
     WDD_FTYPE(erl_drv_busy_msgq_limits) *erl_drv_busy_msgq_limits;
     WDD_FTYPE(driver_select) *driver_select;
-    WDD_FTYPE(driver_event) *driver_event;
+    void *REMOVED_driver_event;
     WDD_FTYPE(driver_output) *driver_output;
     WDD_FTYPE(driver_output2) *driver_output2;
     WDD_FTYPE(driver_output_binary) *driver_output_binary;
@@ -276,7 +275,6 @@ extern TWinDynDriverCallbacks WinDynDriverCallbacks;
 #define driver_failure_eof (WinDynDriverCallbacks.driver_failure_eof)
 #define erl_drv_busy_msgq_limits (WinDynDriverCallbacks.erl_drv_busy_msgq_limits)
 #define driver_select (WinDynDriverCallbacks.driver_select)
-#define driver_event (WinDynDriverCallbacks.driver_event)
 #define driver_output (WinDynDriverCallbacks.driver_output)
 #define driver_output2 (WinDynDriverCallbacks.driver_output2)
 #define driver_output_binary (WinDynDriverCallbacks.driver_output_binary)
@@ -414,7 +412,7 @@ do {				                        \
 ((W).driver_failure_eof) = driver_failure_eof;		\
 ((W).erl_drv_busy_msgq_limits) = erl_drv_busy_msgq_limits;\
 ((W).driver_select) = driver_select;			\
-((W).driver_event) = driver_event;			\
+((W).REMOVED_driver_event) = NULL;			\
 ((W).driver_output) = driver_output;			\
 ((W).driver_output2) = driver_output2;			\
 ((W).driver_output_binary) = driver_output_binary;	\

--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -3248,18 +3248,6 @@ erl_sys_late_init(void)
     /* do nothing */
 }
 
-void
-erts_sys_schedule_interrupt(int set)
-{
-    erts_check_io_interrupt(set);
-}
-
-void
-erts_sys_schedule_interrupt_timed(int set, ErtsMonotonicTime timeout_time)
-{
-    erts_check_io_interrupt_timed(set, timeout_time);
-}
-
 /*
  * Called from schedule() when it runs out of runnable processes,
  * or when Erlang code has performed INPUT_REDUCTIONS reduction
@@ -3271,4 +3259,3 @@ erl_sys_schedule(int runnable)
     erts_check_io(!runnable);
     ERTS_LC_ASSERT(!erts_thr_progress_is_blocking());
 }
-

--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -3235,27 +3235,16 @@ void erl_sys_init(void)
 	SetStdHandle(STD_ERROR_HANDLE, GetStdHandle(STD_OUTPUT_HANDLE));
     }
     erts_sys_init_float();
-    erts_init_check_io();
 
     /* Suppress windows error message popups */
     SetErrorMode(SetErrorMode(0) |
 		 SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX); 
 }
+void erts_poll_late_init(void);
 
 void
 erl_sys_late_init(void)
 {
     /* do nothing */
-}
-
-/*
- * Called from schedule() when it runs out of runnable processes,
- * or when Erlang code has performed INPUT_REDUCTIONS reduction
- * steps. runnable == 0 iff there are no runnable Erlang processes.
- */
-void
-erl_sys_schedule(int runnable)
-{
-    erts_check_io(!runnable);
-    ERTS_LC_ASSERT(!erts_thr_progress_is_blocking());
+    erts_poll_late_init();
 }

--- a/erts/emulator/test/driver_SUITE.erl
+++ b/erts/emulator/test/driver_SUITE.erl
@@ -2258,8 +2258,8 @@ z_test(Config) when is_list(Config) ->
 
 check_io_debug() ->
     get_stable_check_io_info(),
-    {NoErrorFds, NoUsedFds, NoDrvSelStructs} = CheckIoDebug
-    = erts_debug:get_internal_state(check_io_debug),
+    {NoErrorFds, NoUsedFds, NoDrvSelStructs, NoEnifSelStructs}
+        = CheckIoDebug = erts_debug:get_internal_state(check_io_debug),
     HasGetHost = has_gethost(),
     ct:log("check_io_debug: ~p~n"
            "HasGetHost: ~p",[CheckIoDebug, HasGetHost]),
@@ -2272,6 +2272,7 @@ check_io_debug() ->
             %% one extra used fd that is not selected on
             ok
     end,
+    0 = NoEnifSelStructs,
     ok.
 
 has_gethost() ->

--- a/erts/emulator/test/driver_SUITE.erl
+++ b/erts/emulator/test/driver_SUITE.erl
@@ -45,7 +45,6 @@
          io_ready_exit/1,
          use_fallback_pollset/1,
          bad_fd_in_pollset/1,
-         driver_event/1,
          fd_change/1,
          steal_control/1,
          otp_6602/1,
@@ -58,11 +57,9 @@
          ioq_exit_ready_output/1,
          ioq_exit_timeout/1,
          ioq_exit_ready_async/1,
-         ioq_exit_event/1,
          ioq_exit_ready_input_async/1,
          ioq_exit_ready_output_async/1,
          ioq_exit_timeout_async/1,
-         ioq_exit_event_async/1,
          zero_extended_marker_garb_drv/1,
          invalid_extended_marker_drv/1,
          larger_major_vsn_drv/1,
@@ -139,7 +136,7 @@ suite() ->
 all() -> %% Keep a_test first and z_test last...
     [a_test, outputv_errors, outputv_echo, queue_echo, {group, timer},
      driver_unloaded, io_ready_exit, use_fallback_pollset,
-     bad_fd_in_pollset, driver_event, fd_change,
+     bad_fd_in_pollset, fd_change,
      steal_control, otp_6602, driver_system_info_base_ver,
      driver_system_info_prev_ver,
      driver_system_info_current_ver, driver_monitor,
@@ -163,9 +160,9 @@ groups() ->
        timer_change]},
      {ioq_exit, [],
       [ioq_exit_ready_input, ioq_exit_ready_output,
-       ioq_exit_timeout, ioq_exit_ready_async, ioq_exit_event,
+       ioq_exit_timeout, ioq_exit_ready_async,
        ioq_exit_ready_input_async, ioq_exit_ready_output_async,
-       ioq_exit_timeout_async, ioq_exit_event_async]}].
+       ioq_exit_timeout_async]}].
 
 init_per_suite(Config) ->
     Config.
@@ -778,7 +775,6 @@ io_ready_exit(Config) when is_list(Config) ->
 -define(CHKIO_STOP, 0).
 -define(CHKIO_USE_FALLBACK_POLLSET, 1).
 -define(CHKIO_BAD_FD_IN_POLLSET, 2).
--define(CHKIO_DRIVER_EVENT, 3).
 -define(CHKIO_FD_CHANGE, 4).
 -define(CHKIO_STEAL, 5).
 -define(CHKIO_STEAL_AUX, 6).
@@ -827,11 +823,6 @@ use_fallback_pollset(Config) when is_list(Config) ->
 bad_fd_in_pollset(Config) when is_list(Config) ->
     chkio_test_fini(chkio_test(chkio_test_init(Config),
                                ?CHKIO_BAD_FD_IN_POLLSET,
-                               fun () -> sleep(1000) end)).
-
-driver_event(Config) when is_list(Config) ->
-    chkio_test_fini(chkio_test(chkio_test_init(Config),
-                               ?CHKIO_DRIVER_EVENT,
                                fun () -> sleep(1000) end)).
 
 fd_change(Config) when is_list(Config) ->
@@ -1336,11 +1327,9 @@ driver_monitor(Config) when is_list(Config) ->
 -define(IOQ_EXIT_READY_OUTPUT, 2).
 -define(IOQ_EXIT_TIMEOUT, 3).
 -define(IOQ_EXIT_READY_ASYNC, 4).
--define(IOQ_EXIT_EVENT, 5).
 -define(IOQ_EXIT_READY_INPUT_ASYNC, 6).
 -define(IOQ_EXIT_READY_OUTPUT_ASYNC, 7).
 -define(IOQ_EXIT_TIMEOUT_ASYNC, 8).
--define(IOQ_EXIT_EVENT_ASYNC, 9).
 
 ioq_exit_test(Config, TestNo) ->
     Drv = ioq_exit_drv,
@@ -1393,9 +1382,6 @@ ioq_exit_timeout(Config) when is_list(Config) ->
 ioq_exit_ready_async(Config) when is_list(Config) ->
     ioq_exit_test(Config, ?IOQ_EXIT_READY_ASYNC).
 
-ioq_exit_event(Config) when is_list(Config) ->
-    ioq_exit_test(Config, ?IOQ_EXIT_EVENT).
-
 ioq_exit_ready_input_async(Config) when is_list(Config) ->
     ioq_exit_test(Config, ?IOQ_EXIT_READY_INPUT_ASYNC).
 
@@ -1404,9 +1390,6 @@ ioq_exit_ready_output_async(Config) when is_list(Config) ->
 
 ioq_exit_timeout_async(Config) when is_list(Config) ->
     ioq_exit_test(Config, ?IOQ_EXIT_TIMEOUT_ASYNC).
-
-ioq_exit_event_async(Config) when is_list(Config) ->
-    ioq_exit_test(Config, ?IOQ_EXIT_EVENT_ASYNC).
 
 
 vsn_mismatch_test(Config, LoadResult) ->
@@ -2275,7 +2258,7 @@ z_test(Config) when is_list(Config) ->
 
 check_io_debug() ->
     get_stable_check_io_info(),
-    {NoErrorFds, NoUsedFds, NoDrvSelStructs, NoDrvEvStructs} = CheckIoDebug
+    {NoErrorFds, NoUsedFds, NoDrvSelStructs} = CheckIoDebug
     = erts_debug:get_internal_state(check_io_debug),
     HasGetHost = has_gethost(),
     ct:log("check_io_debug: ~p~n"
@@ -2289,7 +2272,6 @@ check_io_debug() ->
             %% one extra used fd that is not selected on
             ok
     end,
-    0 = NoDrvEvStructs,
     ok.
 
 has_gethost() ->

--- a/erts/emulator/test/driver_SUITE_data/chkio_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/chkio_drv.c
@@ -511,6 +511,9 @@ chkio_drv_ready_input(ErlDrvData drv_data, ErlDrvEvent event)
 	    driver_failure_atom(cddp->port, "input_fd_not_found");
 	break;
     }
+    case CHKIO_FD_CHANGE:
+        /* This may be triggered when an fd is closed while being selected on. */
+        break;
     case CHKIO_STEAL:
 	break;
     case CHKIO_STEAL_AUX:

--- a/erts/emulator/test/driver_SUITE_data/missing_callback_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/missing_callback_drv.c
@@ -41,10 +41,6 @@
 typedef struct {
     int ofd;
     int ifd;
-    int efd;
-#ifdef HAVE_POLL_H
-    struct erl_drv_event_data edata;
-#endif
 } mcd_data_t;
 
 static ErlDrvData start(ErlDrvPort port, char *command);
@@ -90,7 +86,6 @@ start(ErlDrvPort port, char *command)
 
     mcd->ofd = -1;
     mcd->ifd = -1;
-    mcd->efd = -1;
 
 #ifdef UNIX
 
@@ -105,15 +100,6 @@ start(ErlDrvPort port, char *command)
 	goto error;
     if (driver_select(port, (ErlDrvEvent) (long) mcd->ifd, DO_READ, 1) != 0)
 	goto error;
-
-#ifdef HAVE_POLL_H
-    mcd->efd = open("/dev/null", O_WRONLY);
-    if (mcd->efd < 0)
-	goto error;
-    mcd->edata.events = POLLOUT;
-    mcd->edata.revents = 0;
-    driver_event(port, (ErlDrvEvent) (long) mcd->efd, &mcd->edata);
-#endif
 #endif
 
     driver_set_timer(port, 0);
@@ -135,10 +121,6 @@ stop(ErlDrvData data)
 	    close(mcd->ofd);
 	if (mcd->ifd >= 0)
 	    close(mcd->ifd);
-#ifdef HAVE_POLL_H
-	if (mcd->efd >= 0)
-	    close(mcd->efd);
-#endif
 #endif
 	driver_free(mcd);
     }

--- a/erts/emulator/test/lttng_SUITE.erl
+++ b/erts/emulator/test/lttng_SUITE.erl
@@ -81,7 +81,6 @@ end_per_testcase(Case, _Config) ->
 
 %% Not tested yet
 %%   org_erlang_otp:driver_process_exit
-%%   org_erlang_otp:driver_event
 
 %% tracepoints
 %%
@@ -100,7 +99,6 @@ end_per_testcase(Case, _Config) ->
 %%   org_erlang_otp:driver_flush
 %%   org_erlang_otp:driver_stop_select
 %%   org_erlang_otp:driver_timeout
-%%   org_erlang_otp:driver_event
 %%   org_erlang_otp:driver_ready_output
 %%   org_erlang_otp:driver_ready_input
 %%   org_erlang_otp:driver_output
@@ -431,7 +429,6 @@ txt() ->
       "%%   org_erlang_otp:driver_flush\n"
       "%%   org_erlang_otp:driver_stop_select\n"
       "%%   org_erlang_otp:driver_timeout\n"
-      "%%   org_erlang_otp:driver_event\n"
       "%%   org_erlang_otp:driver_ready_output\n"
       "%%   org_erlang_otp:driver_ready_input\n"
       "%%   org_erlang_otp:driver_output\n"

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -25,13 +25,14 @@
 %%-define(CHECK(Exp,Got), Exp = Got).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -export([all/0, suite/0, groups/0,
          init_per_group/2, end_per_group/2,
 	 init_per_testcase/2, end_per_testcase/2,
          basic/1, reload_error/1, upgrade/1, heap_frag/1,
          t_on_load/1,
-         select/1,
+         select/1, select_steal/1,
          monitor_process_a/1,
          monitor_process_b/1,
          monitor_process_c/1,
@@ -42,9 +43,9 @@
 	 types/1, many_args/1, binaries/1, get_string/1, get_atom/1,
 	 maps/1,
 	 api_macros/1,
-	 from_array/1, iolist_as_binary/1, resource/1, resource_binary/1, 
+	 from_array/1, iolist_as_binary/1, resource/1, resource_binary/1,
 	 resource_takeover/1,
-	 threading/1, send/1, send2/1, send3/1, send_threaded/1, neg/1, 
+	 threading/1, send/1, send2/1, send3/1, send_threaded/1, neg/1,
 	 is_checks/1,
 	 get_length/1, make_atom/1, make_string/1, reverse_list_test/1,
 	 otp_9828/1,
@@ -79,7 +80,7 @@ all() ->
     [{group, G} || G <- api_groups()]
         ++
     [reload_error, heap_frag, types, many_args,
-     select,
+     select, select_steal,
      {group, monitor},
      monitor_frenzy,
      hipe,
@@ -144,7 +145,8 @@ init_per_testcase(nif_whereis_threaded, Config) ->
         true -> Config;
         false -> {skip, "No thread support"}
     end;
-init_per_testcase(select, Config) ->
+init_per_testcase(Select, Config) when Select =:= select;
+                                       Select =:= select_steal ->
     case os:type() of
         {win32,_} ->
             {skip, "Test not yet implemented for windows"};
@@ -152,6 +154,9 @@ init_per_testcase(select, Config) ->
             Config
     end;
 init_per_testcase(_Case, Config) ->
+    %% Clear any resource dtor data before test starts in case another tc
+    %% left it in a bad state
+    catch last_resource_dtor_call(),
     Config.
 
 end_per_testcase(t_on_load, _Config) ->
@@ -590,7 +595,71 @@ select_3(_Config) ->
     {_,_,2} = last_resource_dtor_call(),
     ok.
 
-check_stop_ret(?ERL_NIF_SELECT_STOP_CALLED) -> ok;    
+%% @doc The stealing child process for the select_steal test. Duplicates given
+%% W/RFds and runs select on them to steal
+select_steal_child_process(Parent, RFd) ->
+    %% Duplicate the resource with the same FD
+    {R2Fd, _R2Ptr} = dupe_resource_nif(RFd),
+    Ref2 = make_ref(),
+
+    %% Try to select from the child pid (steal from parent)
+    ?assertEqual(0, select_nif(R2Fd, ?ERL_NIF_SELECT_READ, R2Fd, null, Ref2)),
+    ?assertEqual([], flush(0)),
+    ?assertEqual(eagain, read_nif(R2Fd, 1)),
+
+    %% Check that now events arrive to this temporary process
+    Parent ! {self(), stage1}, % signal parent to send the <<"stolen1">>
+
+    %% Receive <<"stolen1">> via enif_select
+    ?assertEqual(0, select_nif(R2Fd, ?ERL_NIF_SELECT_READ, R2Fd, null, Ref2)),
+    ?assertMatch([{select, R2Fd, Ref2, ready_input}], flush()),
+    ?assertEqual(<<"stolen1">>, read_nif(R2Fd, 7)),
+
+    clear_select_nif(R2Fd),
+
+    % do not do this here - stop_selecting(R2Fd, R2Rsrc, Ref2),
+    Parent ! {self(), done}.
+
+%% @doc Similar to select/1 test, make a double ended pipe. Then try to steal
+%% the socket, see what happens.
+select_steal(Config) when is_list(Config) ->
+    ensure_lib_loaded(Config),
+
+    Ref = make_ref(),
+    {{RFd, RPtr}, {WFd, WPtr}} = pipe_nif(),
+
+    %% Bind the socket to current pid in enif_select
+    ?assertEqual(0, select_nif(RFd, ?ERL_NIF_SELECT_READ, RFd, null, Ref)),
+    ?assertEqual([], flush(0)),
+
+    %% Spawn a process and do some stealing
+    Parent = self(),
+    Pid = spawn_link(fun() -> select_steal_child_process(Parent, RFd) end),
+
+    %% Signal from the child to send the first message
+    {Pid, stage1} = receive_any(),
+    ?assertEqual(ok, write_nif(WFd, <<"stolen1">>)),
+
+    ?assertMatch([{Pid, done}], flush(1)),  % synchronize with the child
+
+    %% Try to select from the parent pid (steal back)
+    ?assertEqual(0, select_nif(RFd, ?ERL_NIF_SELECT_READ, RFd, Pid, Ref)),
+
+    %% Ensure that no data is hanging and close.
+    %% Rfd is stolen at this point.
+    check_stop_ret(select_nif(WFd, ?ERL_NIF_SELECT_STOP, WFd, null, Ref)),
+    ?assertMatch([{fd_resource_stop, WPtr, _}], flush()),
+    {1, {WPtr, 1}} = last_fd_stop_call(),
+
+    check_stop_ret(select_nif(RFd, ?ERL_NIF_SELECT_STOP, RFd, null, Ref)),
+    ?assertMatch([{fd_resource_stop, RPtr, _}], flush()),
+    {1, {RPtr, 1}} = last_fd_stop_call(),
+
+    ?assert(is_closed_nif(WFd)),
+
+    ok.
+
+check_stop_ret(?ERL_NIF_SELECT_STOP_CALLED) -> ok;
 check_stop_ret(?ERL_NIF_SELECT_STOP_SCHEDULED) -> ok.
 
 write_full(W, C) ->
@@ -3193,10 +3262,12 @@ binary_to_term_nif(_, _, _) -> ?nif_stub.
 port_command_nif(_, _) -> ?nif_stub.
 format_term_nif(_,_) -> ?nif_stub.
 select_nif(_,_,_,_,_) -> ?nif_stub.
+dupe_resource_nif(_) -> ?nif_stub.
 pipe_nif() -> ?nif_stub.
 write_nif(_,_) -> ?nif_stub.
 read_nif(_,_) -> ?nif_stub.
 is_closed_nif(_) -> ?nif_stub.
+clear_select_nif(_) -> ?nif_stub.
 last_fd_stop_call() -> ?nif_stub.
 alloc_monitor_resource_nif() -> ?nif_stub.
 monitor_process_nif(_,_,_,_) -> ?nif_stub.

--- a/erts/emulator/test/statistics_SUITE.erl
+++ b/erts/emulator/test/statistics_SUITE.erl
@@ -674,6 +674,16 @@ msacc_test(TmpFile) ->
     ets:insert(Tid, {1, hello}),
     ets:delete(Tid),
 
+    %% Check some IO
+    {ok, L} = gen_tcp:listen(0, [{active, true},{reuseaddr,true}]),
+    {ok, Port} = inet:port(L),
+    Pid = spawn(fun() ->
+                        {ok, S} = gen_tcp:accept(L),
+                        (fun F() -> receive M -> F() end end)()
+                end),
+    {ok, C} = gen_tcp:connect("localhost", Port, []),
+    [begin gen_tcp:send(C,"hello"),timer:sleep(1) end || _ <- lists:seq(1,100)],
+
     %% Collect some garbage
     [erlang:garbage_collect() || _ <- lists:seq(1,100)],
 

--- a/erts/emulator/test/z_SUITE.erl
+++ b/erts/emulator/test/z_SUITE.erl
@@ -330,7 +330,7 @@ display_check_io(ChkIo) ->
     ok.
 
 get_check_io_info() ->
-    ChkIo = erlang:system_info(check_io),
+    ChkIo = driver_SUITE:get_check_io_total(erlang:system_info(check_io)),
     PendUpdNo = case lists:keysearch(pending_updates, 1, ChkIo) of
 		    {value, {pending_updates, PendNo}} ->
 			PendNo;

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -810,6 +810,28 @@ int main(int argc, char **argv)
 		      add_Eargs(argv[i+1]);
 		      i++;
 		      break;
+		  case 'I':
+                      if (argv[i][2] == 'O' && (argv[i][3] == 't' || argv[i][3] == 'p')) {
+                          if (argv[i][4] != '\0')
+                              goto the_default;
+                          argv[i][0] = '-';
+                          add_Eargs(argv[i]);
+                          add_Eargs(argv[i+1]);
+                          i++;
+                          break;
+                      }
+                      if (argv[i][2] == 'O' && argv[i][3] == 'P' &&
+                          (argv[i][4] == 't' || argv[i][4] == 'p')) {
+                          if (argv[i][5] != '\0')
+                              goto the_default;
+                          argv[i][0] = '-';
+                          add_Eargs(argv[i]);
+                          add_Eargs(argv[i+1]);
+                          i++;
+                          break;
+                      }
+                      usage(argv[i]);
+                      break;
 		  case 'S':
 		      if (argv[i][2] == 'P') {
 			  if (argv[i][3] != '\0')

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -2316,40 +2316,46 @@ end
 define etp-port-sched-flags-int
 # Args: int
 #
-  if ($arg0 & 0x1)
+  if ($arg0 & (1 << 0))
     printf " in-run-queue"
   end
-  if ($arg0 & 0x2)
+  if ($arg0 & (1 << 1))
     printf " executing"
   end
-  if ($arg0 & 0x4)
+  if ($arg0 & (1 << 2))
     printf " have-tasks"
   end
-  if ($arg0 & 0x8)
+  if ($arg0 & (1 << 3))
     printf " exited"
   end
-  if ($arg0 & 0x10)
+  if ($arg0 & (1 << 4))
     printf " busy-port"
   end
-  if ($arg0 & 0x20)
+  if ($arg0 & (1 << 5))
     printf " busy-port-q"
   end
-  if ($arg0 & 0x40)
+  if ($arg0 & (1 << 6))
     printf " chk-unset-busy-port-q"
   end
-  if ($arg0 & 0x80)
+  if ($arg0 & (1 << 7))
     printf " have-busy-tasks"
   end
-  if ($arg0 & 0x100)
+  if ($arg0 & (1 << 8))
     printf " have-nosuspend-tasks"
   end
-  if ($arg0 & 0x200)
+  if ($arg0 & (1 << 9))
     printf " parallelism"
   end
-  if ($arg0 & 0x400)
+  if ($arg0 & (1 << 10))
     printf " force-sched"
   end
-  if ($arg0 & 0xfffff800)
+  if ($arg0 & (1 << 11))
+    printf " exiting"
+  end
+  if ($arg0 & (1 << 12))
+    printf " exec-imm"
+  end
+  if ($arg0 & 0xffffc000)
     printf " GARBAGE"
   end
   printf "\n"
@@ -2848,6 +2854,14 @@ define etp-run-queue-info-internal
   set $rq_flags = *((Uint32 *) &($runq->flags))
   etp-rq-flags-int $rq_flags
   printf "  Pointer: (ErtsRunQueue *) %p\n", $runq
+end
+
+define etp-fds
+  if $_exitsignal == -1
+    call erts_check_io_debug(0)
+  else
+    printf "Not yet implemented for core files"
+  end
 end
 
 define etp-disasm-1
@@ -4312,6 +4326,10 @@ document etp-init
 %     $ROOTDIR/erts/etc/unix/etp-commands
 % Also, erl and erlc must be in the path.
 %---------------------------------------------------------------------------
+end
+
+define hook-run
+  set $_exitsignal = -1
 end
 
 etp-init

--- a/system/doc/tutorial/port_driver.c
+++ b/system/doc/tutorial/port_driver.c
@@ -51,8 +51,7 @@ ErlDrvEntry example_driver_entry = {
 				   queue */
     NULL,                       /* F_PTR call, much like control, sync call
 				   to driver */
-    NULL,                       /* F_PTR event, called when an event selected 
-				   by driver_event() occurs. */
+    NULL,                       /* unused */
     ERL_DRV_EXTENDED_MARKER,    /* int extended marker, Should always be 
 				   set to indicate driver versioning */
     ERL_DRV_EXTENDED_MAJOR_VERSION, /* int major_version, should always be 


### PR DESCRIPTION
This PR implements a solution to the problem described in https://bugs.erlang.org/browse/ERL-140.

The implementation moves all IO polling out from the main scheduler loops into separate dedicated thread(s). By default one thread is started to be the poller and all file descriptors (or waitable objects) are handled by it using a kernel-poll mechanism.
It is possible to tune the number of polling threads using the `+IOt` and `+IOPt` options. e.g. `+IOt 2` will start 2 polling threads, `+IOPt 50` will start 50% as many polling threads as there are schedulers.
It is possible to tune the number of poll-sets using the `+IOp` and `+IOPp` options. On Linux and BSD it is possible to have 1..t poll-sets configured, on all other OSs the number of poll-sets have to be equal to the number of poll-threads.

On operating systems that can do concurrent updates of the kernel poll-set (linux and bsd), the new implementation has no global locks that need to be taken when updating the poll-set. On operating systems that cannot do concurrent updates, there is still a lock per poll-set that has to be taken.

The `+K` flag no longer has any effect and is ignored. If the user wants to not use kernel-poll, this can now be achieved through a configure flag when building the emulator.

## Implementation details

### Linux and BSD

The basic flow of operation for handling a driver_select call is as follows:
* driver_select is called in a linked-in driver in a scheduler thread
  * the fd is used to hash into a global array to find it's slot
    * the hash is protected by striped mutexes
  * the port that was interested in the fd event in the slot
  * the pollset is modified to reflect the new interest using `epoll_ctl(kp_fd, EPOLL_CTL_ADD, fd, { .events = EPOLLIN|EPOLLONESHOT, .data = fd })`
* During all this, the poll-threads are using `epoll_wait`
  * When the event comes one poll-thread will be woken (because we use ONESHOT)
  * It looks for the correct slot and locks it
  * Delivers the correct signal to the port which calls ready_input/output

### Solaris/Windows/non-kernel poll

Basically the same flow happens, the major difference is that the actual inserting into the poll-set is done by the poll-thread itself instead of by the scheduler threads.

### Benchmarking

I've done quite a bit of benchmarking, mainly to make sure that we don't get any regressions when using this approach. The throughput and latency figures look promising, through I don't really have access to any great benchmarks or hardware to run them on. So if you have any socket IO intensive benchmarks, please run them and report back with the good or bad results.

### Outstanding issues

There are a few testcases that still fail on various platforms due to testcase timing issues, and some new testcases have to be written for the new erts options.

Enjoy