### PR TITLE
Eliminate unnecessary 'move' instructions

### DIFF
--- a/lib/compiler/src/v3_codegen.erl
+++ b/lib/compiler/src/v3_codegen.erl
@@ -884,12 +884,19 @@ select_extract_bin([{var,Hd}], Size, Unit, binary, Flags, Vf,
 %%   calculcated by v3_life is too conservative to be useful for this purpose.)
 %%   'true' means that the code that follows will definitely not use the context
 %%   again (because it is a block, not guard or matching code); 'false' that we
-%%   are not sure (there is either a guard, or more matching, either which may
-%%   reference the context again).
+%%   are not sure (there could be more matching).
 
-is_context_unused(#l{ke=Ke}) -> is_context_unused(Ke);
-is_context_unused({block,_}) -> true;
-is_context_unused(_) -> false.
+is_context_unused(#l{ke=Ke}) ->
+    is_context_unused(Ke);
+is_context_unused({alt,_First,Then}) ->
+    %% {alt,First,Then} can be used for different purposes. If the Then part
+    %% is a block, it means that matching has finished and is used for a guard
+    %% to choose between the matched clauses.
+    is_context_unused(Then);
+is_context_unused({block,_}) ->
+    true;
+is_context_unused(_) ->
+    false.
 
 select_bin_end(#l{ke={val_clause,{bin_end,Ctx},B}},
 	       Ivar, Tf, Bef, St0) ->

--- a/lib/compiler/test/bs_match_SUITE.erl
+++ b/lib/compiler/test/bs_match_SUITE.erl
@@ -39,7 +39,7 @@
 	 match_string_opt/1,select_on_integer/1,
 	 map_and_binary/1,unsafe_branch_caching/1,
 	 bad_literals/1,good_literals/1,constant_propagation/1,
-	 parse_xml/1,get_payload/1]).
+	 parse_xml/1,get_payload/1,escape/1]).
 
 -export([coverage_id/1,coverage_external_ignore/2]).
 
@@ -71,7 +71,7 @@ groups() ->
        match_string_opt,select_on_integer,
        map_and_binary,unsafe_branch_caching,
        bad_literals,good_literals,constant_propagation,parse_xml,
-       get_payload]}].
+       get_payload,escape]}].
 
 
 init_per_suite(Config) ->
@@ -1523,6 +1523,21 @@ do_get_payload(ExtHdr) ->
     ExtHdrOptions = ExtHdr#ext_header.ext_hdr_opts,
     <<_:13,_:35>> = ExtHdr#ext_header.ext_hdr_opts,
     ExtHdrOptions.
+
+escape(_Config) ->
+    0 = escape(<<>>, 0),
+    1 = escape(<<128>>, 0),
+    2 = escape(<<128,255>>, 0),
+    42 = escape(<<42>>, 0),
+    50 = escape(<<42,8>>, 0),
+    ok.
+
+escape(<<Byte, Rest/bits>>, Pos) when Byte >= 127 ->
+    escape(Rest, Pos + 1);
+escape(<<Byte, Rest/bits>>, Pos) ->
+    escape(Rest, Pos + Byte);
+escape(<<_Rest/bits>>, Pos) ->
+    Pos.
 
 check(F, R) ->
     R = F().


### PR DESCRIPTION
The compiler could sometimes emit unnecessary 'move'
instructions in the code for binary matching, for
example for this function:

```
escape(<<Byte, Rest/bits>>, Pos) when Byte >= 127 ->
    escape(Rest, Pos + 1);
escape(<<Byte, Rest/bits>>, Pos) ->
    escape(Rest, Pos + Byte);
escape(<<_Rest/bits>>, Pos) ->
    Pos.
```

The generated code would look like this:

```
{function, escape, 2, 2}.
  {label,1}.
    {line,[{location,"t.erl",17}]}.
    {func_info,{atom,t},{atom,escape},2}.
  {label,2}.
    {test,bs_start_match2,{f,1},2,[{x,0},0],{x,0}}.
    {test,bs_get_integer2,
          {f,4},
          2,
          [{x,0},
           {integer,8},
           1,
           {field_flags,[{anno,[17,{file,"t.erl"}]},unsigned,big]}],
          {x,2}}.
    {'%',{bin_opt,[17,{file,"t.erl"}]}}.
    {move,{x,0},{x,3}}.                              %% UNECESSARY!
    {test,is_ge,{f,3},[{x,2},{integer,127}]}.
    {line,[{location,"t.erl",18}]}.
    {gc_bif,'+',{f,0},4,[{x,1},{integer,1}],{x,1}}.
    {move,{x,3},{x,0}}.                              %% UNECESSARY!
    {call_only,2,{f,2}}.
  {label,3}.
    {line,[{location,"t.erl",20}]}.
    {gc_bif,'+',{f,0},4,[{x,1},{x,2}],{x,1}}.
    {move,{x,3},{x,0}}.                              %% UNECESSARY!
    {call_only,2,{f,2}}.
  {label,4}.
    {move,{x,1},{x,0}}.
    return.
```

The redundant 'move' instructions have been marked.

To avoid the 'move' instructions, we can extend the existing
function is_context_unused/1 in v3_codegen. If v3_codegen can
know that the match context will not be used again, it can reuse
the register for the match context and avoid the extra 'move'
instructions.

https://bugs.erlang.org/browse/ERL-444