### PR TITLE
Add compile_info option to compile

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -123,6 +123,17 @@
 	    in the Efficiency Guide.</p>
           </item>
 
+          <tag><c>{compile_info, [{atom(), term()}]}</c></tag>
+          <item>
+            <p>Allows compilers built on top of <c>compile</c> to attach
+            extra compilation metadata to the <c>compile_info</c> chunk
+            in the generated beam file.</p>
+
+            <p>It is advised for compilers to remove all non-deterministic
+            information if the <c>deterministic</c> option is supported and
+            it was supplied by the user.</p>
+          </item>
+
           <tag><c>compressed</c></tag>
           <item>
             <p>The compiler will compress the generated object code,


### PR DESCRIPTION
This allows compilers built on top of the compile module
to attach external compilation metadata to the compile_info
chunk.

For example, Erlang uses this chunk to store the compiler
version. Elixir and LFE may augment this by also adding
their own compiler versions, which can be useful when
debugging.

The deterministic option does not affect the user supplied
compile_info. It is therefore the responsibility of external
compilers to guarantee any added information does not violate
the determinsitic option, if such option is supported.

Finally, this code moves the building of the compile_info
options to the compile module instead of beam_asm, moving
all of the option mangling code to a single place.