### PR TITLE
add option to not check sys.config file when building tarball

### DIFF
--- a/lib/sasl/doc/src/release_handler.xml
+++ b/lib/sasl/doc/src/release_handler.xml
@@ -61,6 +61,7 @@
     <list type="bulleted">
       <item>A release upgrade file, <c>relup</c></item>
       <item>A system configuration file, <c>sys.config</c></item>
+      <item>A system configuration source file, <c>sys.config.src</c></item>
     </list>
     <p>The <c>relup</c> file contains instructions for how to upgrade
       to, or downgrade from, this version of the release.</p>
@@ -819,4 +820,3 @@ release_handler:set_unpacked(RelFile, [{myapp,"1.0","/home/user"},...]).
       <seealso marker="systools"><c>systools(3)</c></seealso></p>
   </section>
 </erlref>
-

--- a/lib/sasl/doc/src/systools.xml
+++ b/lib/sasl/doc/src/systools.xml
@@ -349,10 +349,11 @@ myapp-1/ebin/myapp.app
           the release version as specified in <c>Name.rel</c>.</p>
         <p><c>releases/RelVsn</c> contains the boot script
           <c>Name.boot</c> renamed to <c>start.boot</c> and, if found,
-          the files <c>relup</c> and <c>sys.config</c>. These files
+          the files <c>relup</c> and <c>sys.config</c> or <c>sys.config.src</c>. These files
           are searched for in the same directory as <c>Name.rel</c>,
           in the current working directory, and in any directories
-          specified using option <c>path</c>.</p>
+          specified using option <c>path</c>. In the case of <c>sys.config</c>
+          it is not included if <c>sys.config.src</c> is found.</p>
         <p>If the release package is to contain a new Erlang runtime
           system, the <c>bin</c> directory of the specified runtime
           system <c>{erts,Dir}</c> is copied to <c>erts-ErtsVsn/bin</c>.</p>
@@ -397,4 +398,3 @@ myapp-1/ebin/myapp.app
       <seealso marker="script"><c>script(4)</c></seealso></p>
   </section>
 </erlref>
-

--- a/lib/sasl/src/systools_make.erl
+++ b/lib/sasl/src/systools_make.erl
@@ -310,6 +310,7 @@ add_apply_upgrade(Script,Args) ->
 %%                  RelVsn/start.boot
 %%                         relup
 %%                         sys.config
+%%                         sys.config.src
 %%         erts-EVsn[/bin]
 %%-----------------------------------------------------------------
 
@@ -1552,6 +1553,7 @@ create_kernel_procs(Appls) ->
 %%                  RelVsn/start.boot
 %%                         relup
 %%                         sys.config
+%%                         sys.config.src
 %%         erts-EVsn[/bin]
 %%
 %% The VariableN.tar.gz files can also be stored as own files not
@@ -1707,14 +1709,18 @@ add_system_files(Tar, RelName, Release, Path1) ->
 	    add_to_tar(Tar, Relup, filename:join(RelVsnDir, "relup"))
     end,
 
-    case lookup_file("sys.config", Path) of
-	false ->
-	    ignore;
-	Sys ->
-	    check_sys_config(Sys),
-	    add_to_tar(Tar, Sys, filename:join(RelVsnDir, "sys.config"))
+    case lookup_file("sys.config.src", Path) of
+        false ->
+            case lookup_file("sys.config", Path) of
+                false ->
+                    ignore;
+                Sys ->
+	            check_sys_config(Sys),
+	            add_to_tar(Tar, Sys, filename:join(RelVsnDir, "sys.config"))
+            end;
+        SysSrc ->
+            add_to_tar(Tar, SysSrc, filename:join(RelVsnDir, "sys.config.src"))
     end,
-    
     ok.
 
 lookup_file(Name, [Dir|Path]) ->

--- a/system/doc/design_principles/release_structure.xml
+++ b/system/doc/design_principles/release_structure.xml
@@ -208,8 +208,8 @@ releases/ch_rel-1.rel</pre>
       is therefore now instead duplicated in the tar file so no manual
       copying is necessary.</p>
     <p>If a <c>relup</c> file and/or a system configuration file called
-      <c>sys.config</c> is found, these files are also included in
-      the release package. See
+      <c>sys.config</c>, or a <c>sys.config.src</c>, is found, these files
+      are also included in the release package. See
       <seealso marker="release_handling#req">Release Handling</seealso>.</p>
     <p>Options can be set to make the release package include source
       code and the ERTS binary as well.</p>
@@ -240,7 +240,7 @@ $ROOT/lib/App1-AVsn1/ebin
        <item><c>erts-EVsn/bin</c> - Erlang runtime system executables</item>
        <item><c>releases/Vsn</c> - <c>.rel</c> file and boot script
        <c>start.boot</c>; if present in the release package, <c>relup</c>
-       and/or <c>sys.config</c></item>
+       and/or <c>sys.config</c> or <c>sys.config.src</c></item>
        <item><c>bin</c> - Top-level Erlang runtime system executables</item>
      </list>
     <p>Applications are not required to be located under directory

--- a/system/doc/system_principles/create_target.xmlsrc
+++ b/system/doc/system_principles/create_target.xmlsrc
@@ -263,6 +263,14 @@ os> <input>/usr/local/erl-target/bin/erl -boot /usr/local/erl-target/releases/FI
       current directory create not only the file <c>mysystem.rel</c>,
       but also file <c>sys.config</c>, the latter file is tacitly
       put in the appropriate directory.</p>
+    <p>However, it can also be convenient to replace variables in
+       within a <c>sys.config</c> on the target after unpacking but
+       before running the release. If you have a <c>sys.config.src</c>
+       it will be included and is not required to be a valid Erlang term
+       file like <c>sys.config</c>. Before running the release you must
+       have a valid <c>sys.config</c> in the same directory, so using
+       <c>sys.config.src</c> requires having some tool to populate what is
+       needed and write <c>sys.config</c> to disk before booting the release.</p>
   </section>
 
   <section>


### PR DESCRIPTION
The run scripts generated by rebar3 (relx) support replacing environment variable in `sys.config` and `vm.args`. A common issue people encounter with this is they attempt like:

```
{port, ${PORT}}
```

This fails because it is not a valid Erlang term file, so `systools:make_tar` will fail. So only strings or single quoted atoms are able to be used.

This patch adds a option to `make_tar` that tells it not to try to consult the `sys.config` file and to just include it as is.

I realized I still need to add it to the docs of `systools:make_tar`, but is this an acceptable feature?