### PR TITLE
Eliminate incorrect get_stacktrace/0 warning

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -3238,13 +3238,13 @@ icrt_clauses(Cs, In, Vt, St0) ->
 icrt_clauses(Cs, Vt, St) ->
     mapfoldl(fun (C, St0) -> icrt_clause(C, Vt, St0) end, St, Cs).
 
-icrt_clause({clause,_Line,H,G,B}, Vt0, St0) ->
+icrt_clause({clause,_Line,H,G,B}, Vt0, #lint{catch_scope=Scope}=St0) ->
     {Hvt,Binvt,St1} = head(H, Vt0, St0),
     Vt1 = vtupdate(Hvt, Binvt),
     {Gvt,St2} = guard(G, vtupdate(Vt1, Vt0), St1),
     Vt2 = vtupdate(Gvt, Vt1),
     {Bvt,St3} = exprs(B, vtupdate(Vt2, Vt0), St2),
-    {vtupdate(Bvt, Vt2),St3}.
+    {vtupdate(Bvt, Vt2),St3#lint{catch_scope=Scope}}.
 
 icrt_export(Vts, Vt, {Tag,Attrs}, St) ->
     {_File,Loc} = loc(Attrs, St),

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -4104,7 +4104,27 @@ get_stacktrace(Config) ->
            [],
            {warnings,[{4,erl_lint,{get_stacktrace,wrong_part_of_try}},
                       {13,erl_lint,{get_stacktrace,after_try}},
-                      {22,erl_lint,{get_stacktrace,after_try}}]}}],
+                      {22,erl_lint,{get_stacktrace,after_try}}]}},
+          {multiple_catch_clauses,
+           <<"maybe_error(Arg) ->
+                try 5 / Arg
+                catch
+                    error:badarith ->
+                        _Stacktrace = erlang:get_stacktrace(),
+                        try io:nl()
+                        catch
+                            error:_ -> io:format('internal error')
+                        end;
+                    error:badarg ->
+                        _Stacktrace = erlang:get_stacktrace(),
+                        try io:format(qwe)
+                        catch
+                            error:_ -> io:format('internal error')
+                        end
+                end.
+             ">>,
+           [],
+           []}],
 
     run(Config, Ts),
     ok.


### PR DESCRIPTION
There could be a false warning for `erlang:get_stacktrace/0`
being outside a try block when it was actually inside a try
block.

https://bugs.erlang.org/browse/ERL-478