### PR TITLE
fix ERL-481 ecpkParameters representation

### DIFF
--- a/lib/public_key/doc/src/public_key_records.xml
+++ b/lib/public_key/doc/src/public_key_records.xml
@@ -171,9 +171,9 @@
 #'ECPrivateKey'{
           version,       % integer()
 	  privateKey,    % binary()  
-	  parameters,    % der_encoded() - {'EcpkParameters', #'ECParameters'{}} |
-	                                   {'EcpkParameters', {namedCurve, oid()}} |
-	                                   {'EcpkParameters', 'NULL'} % Inherited by CA
+          parameters,    % {ecParameters, #'ECParameters'{}} |
+                         % {namedCurve, Oid::tuple()} |
+                         % {implicitlyCA, 'NULL'}
 	  publicKey      % bitstring()
 	  }.
 	  

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -102,6 +102,7 @@ init_per_testcase(TestCase, Config) ->
 	ssh_hostkey_fingerprint_sha384 -> init_fingerprint_testcase([sha384], Config);
 	ssh_hostkey_fingerprint_sha512 -> init_fingerprint_testcase([sha512], Config);
 	ssh_hostkey_fingerprint_list   -> init_fingerprint_testcase([sha,md5], Config);
+    ec_pem_encode_generated        -> init_ec_pem_encode_generated(Config);
 	_ -> init_common_per_testcase(Config)
     end.
 	
@@ -241,6 +242,12 @@ ec_pem2(Config) when is_list(Config) ->
     ECPemNoEndNewLines = strip_superfluous_newlines(ECPrivPem),
     ECPemNoEndNewLines = strip_superfluous_newlines(public_key:pem_encode([Entry1, Entry2])).
 
+
+init_ec_pem_encode_generated(Config) ->
+    case catch true = lists:member('secp384r1', crypto:ec_curves()) of
+        {'EXIT', _} -> {skip, {'secp384r1', not_supported}};
+        _           -> init_common_per_testcase(Config)
+    end.
 
 ec_pem_encode_generated() ->
     [{doc, "PEM-encode generated EC key"}].

--- a/lib/public_key/test/public_key_SUITE_data/ec_key2.pem
+++ b/lib/public_key/test/public_key_SUITE_data/ec_key2.pem
@@ -1,0 +1,29 @@
+-----BEGIN EC PARAMETERS-----
+MIIBwgIBATBNBgcqhkjOPQEBAkIB////////////////////////////////////
+//////////////////////////////////////////////////8wgZ4EQgH/////
+////////////////////////////////////////////////////////////////
+/////////////////ARBUZU+uWGOHJofkpohoLaFQO6i2nJbmbMV87i0iZGO8Qnh
+Vhk5Uex+k3sWUsC9O7G/BzVz34g9LDTx70Uf1GtQPwADFQDQnogAKRy4U5bMZxc5
+MoSqoNpkugSBhQQAxoWOBrcEBOnNnj7LZiOVtEKcZIE5BT+1Ifgor2BrTT26oUte
+d+/nWSj+HcEnov+o3jNIs8GFakKb+X5+McLlvWYBGDkpaniaO8AEXIpftCx9G9mY
+9URJV5tEaBevvRcnPmYsl+5ymV70JkDFULkBP60HYTU8cIaicsJAiL6Udp/RZlAC
+QgH///////////////////////////////////////////pRhoeDvy+Wa3/MAUj3
+CaXQO7XJuImcR667b7cekThkCQIBAQ==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MIICnQIBAQRCAVE6lUKRj5AE8Cw21A+iPWhXSg+XNuerrTyeFERY6AtOrRJ9mTQ3
+Av3xjiM3zhZy2KWnm62hvkvlGbZ7iDKcqg2GoIIBxjCCAcICAQEwTQYHKoZIzj0B
+AQJCAf//////////////////////////////////////////////////////////
+////////////////////////////MIGeBEIB////////////////////////////
+//////////////////////////////////////////////////////////wEQVGV
+PrlhjhyaH5KaIaC2hUDuotpyW5mzFfO4tImRjvEJ4VYZOVHsfpN7FlLAvTuxvwc1
+c9+IPSw08e9FH9RrUD8AAxUA0J6IACkcuFOWzGcXOTKEqqDaZLoEgYUEAMaFjga3
+BATpzZ4+y2YjlbRCnGSBOQU/tSH4KK9ga009uqFLXnfv51ko/h3BJ6L/qN4zSLPB
+hWpCm/l+fjHC5b1mARg5KWp4mjvABFyKX7QsfRvZmPVESVebRGgXr70XJz5mLJfu
+cple9CZAxVC5AT+tB2E1PHCGonLCQIi+lHaf0WZQAkIB////////////////////
+///////////////////////6UYaHg78vlmt/zAFI9wml0Du1ybiJnEeuu2+3HpE4
+ZAkCAQGhgYkDgYYABAFLBJzBphlIJmSPuXzTDTnZpL7A0fnyqit9V3TBvaOcL6Iw
+6m2TpXvNakxi8Flj0Ok4hdRt+YhawFs0bmzZCT8kfAFs7p55BPHk7FaMZaba77R8
+4V6MhUJSKLc0I/XQBtvoOgVlPJ0MPOndnIxPspCPll886yxG5kOMUAx3HjFg16RT
+eA==
+-----END EC PRIVATE KEY-----


### PR DESCRIPTION
- type spec ecpk_parameters() added to represent DER-encodable ecpkParameters
- type spec ecpk_parameters_api() added to represent ecpkParameters provided by the user through public_key
API functions
- API is now more generous in its input, and more strict in its output.
- update to public key records documentation
- add tests, including tests against EC key with explicit curve parameters
- also fixes ERL-480

Note: ssl tests aren't working well on my system.  I get a number of failures on `maint` and on this branch.