### PR TITLE
base64:decode(List) optimized reimplementation

### DIFF
--- a/lib/stdlib/src/base64.erl
+++ b/lib/stdlib/src/base64.erl
@@ -115,7 +115,7 @@ encode_binary(Bin) ->
 decode(Bin) when is_binary(Bin) ->
     decode_binary(<<>>, Bin);
 decode(List) when is_list(List) ->
-    decode_list(<<>>, List).
+    decode_list(List, <<>>).
 
 -spec mime_decode(Base64) -> Data when
       Base64 :: ascii_string() | ascii_binary(),
@@ -262,39 +262,39 @@ mime_decode_binary_after_eq(Result0, <<>>, Eq) ->
             Result
     end.
 
-decode_list(A, [C1 | Cs]) ->
+decode_list([C1 | Cs], A) ->
     case element(C1, ?DECODE_MAP) of
-        ws -> decode_list(A, Cs);
-        B1 -> decode_list(A, B1, Cs)
+        ws -> decode_list(Cs, A);
+        B1 -> decode_list(Cs, A, B1)
     end;
-decode_list(A, []) ->
+decode_list([], A) ->
     A.
 
-decode_list(A, B1, [C2 | Cs]) ->
+decode_list([C2 | Cs], A, B1) ->
     case element(C2, ?DECODE_MAP) of
-        ws -> decode_list(A, B1, Cs);
-        B2 -> decode_list(A, B1, B2, Cs)
+        ws -> decode_list(Cs, A, B1);
+        B2 -> decode_list(Cs, A, B1, B2)
     end.
 
-decode_list(A, B1, B2, [C3 | Cs]) ->
+decode_list([C3 | Cs], A, B1, B2) ->
     case element(C3, ?DECODE_MAP) of
-        ws -> decode_list(A, B1, B2, Cs);
-        B3 -> decode_list(A, B1, B2, B3, Cs)
+        ws -> decode_list(Cs, A, B1, B2);
+        B3 -> decode_list(Cs, A, B1, B2, B3)
     end.
 
-decode_list(A, B1, B2, B3, [C4 | Cs]) ->
+decode_list([C4 | Cs], A, B1, B2, B3) ->
     case element(C4, ?DECODE_MAP) of
-        ws                -> decode_list(A, B1, B2, B3, Cs);
-        eq when B3 =:= eq -> only_ws(<<A/binary,B1:6,(B2 bsr 4):2>>, Cs);
-        eq                -> only_ws(<<A/binary,B1:6,B2:6,(B3 bsr 2):4>>, Cs);
-        B4                -> decode_list(<<A/binary,B1:6,B2:6,B3:6,B4:6>>, Cs)
+        ws                -> decode_list(Cs, A, B1, B2, B3);
+        eq when B3 =:= eq -> only_ws(Cs, <<A/binary,B1:6,(B2 bsr 4):2>>);
+        eq                -> only_ws(Cs, <<A/binary,B1:6,B2:6,(B3 bsr 2):4>>);
+        B4                -> decode_list(Cs, <<A/binary,B1:6,B2:6,B3:6,B4:6>>)
     end.
 
-only_ws(A, []) ->
+only_ws([], A) ->
     A;
-only_ws(A, [C | Cs]) ->
+only_ws([C | Cs], A) ->
     case element(C, ?DECODE_MAP) of
-        ws -> only_ws(A, Cs);
+        ws -> only_ws(Cs, A);
         _ -> erlang:error(function_clause)
     end.
 


### PR DESCRIPTION
Reimplement base64:decode/1, for the List input case, to be 2x to 3x faster (3x for longer inputs).

The speedup comes from:

1. Avoiding extra scan of the input by merging the pre-processing step (whitespace removal) into the conversion loop.

2. Accumulating the output into a binary in the right order.

3. Appending a number of octets at a time rather than 6 bits at a time as decode(Binary) does.

4. Using bit-syntax to append a sequence of bit-fields (making up a number of octets) rather than manually combining them and calculating the octet values.

This reimplementation also checks the tail of the input more carefully, similar to the decode(Binary) code.

Similar improvements could be implemented in the other variants, but this case is the one that hurt us the most.

Implemented by Mikael Pettersson and Tobias Lindahl (both @ Klarna).