### PR TITLE
Implement escaping of special characters in wildcards

### DIFF
--- a/lib/stdlib/doc/src/filelib.xml
+++ b/lib/stdlib/doc/src/filelib.xml
@@ -217,6 +217,11 @@
         <p>Other characters represent themselves. Only filenames that
           have exactly the same character in the same position match.
           Matching is case-sensitive, for example, "a" does not match "A".</p>
+	<p>Directory separators must always be written as <c>/</c>, even on
+	Windows.</p>
+	<p>A character preceded by <c>\</c> loses its special meaning. Note
+	that <c>\</c> must be written as <c>\\</c> in a string literal.
+	For example, "\\?*" will match any filename starting with <c>?</c>.</p>
         <p>Notice that multiple "*" characters are allowed
           (as in Unix wildcards, but opposed to Windows/DOS wildcards).</p>
         <p><em>Examples:</em></p>


### PR DESCRIPTION
Allow characters with special meaning to be escaped using
\ (which must be writen as \\\\ in a string). That allows
matching of filenames containing characters that are special
in wildcards.

This is an incompatible change, but note that the use of backslashes in wildcards would already work differently on Windows and Unix. Take for example this call:
    
         filelib:wildcard("a\\b")
    
On Windows, filelib:wildcard/1 would look for a directory named "a", and a file or directory named "b" inside it.
    
On Unix, `filelib:wildcard/1` would look for a file named "a\\b".
    
With this commit applied, filelib:wildcard/1 will look for a file named "ab" on both Windows and Unix.

https://bugs.erlang.org/browse/ERL-451