### PR TITLE
Mnesia: note first, next, prev and last vs fragmented tables

### DIFF
--- a/lib/mnesia/doc/src/Mnesia_chap5.xmlsrc
+++ b/lib/mnesia/doc/src/Mnesia_chap5.xmlsrc
@@ -226,8 +226,10 @@
         not known beforehand, all fragments are searched for
         matching records.</p>
       <p>Notice that in <c>ordered_set</c> tables, the records
-        are ordered per fragment, and the the order is undefined in
-        results returned by <c>select</c> and <c>match_object</c>.</p>
+        are ordered per fragment, and the order is undefined in
+        results returned by <c>select</c> and <c>match_object</c>,
+        as well as <c>first</c>, <c>next</c>, <c>prev</c> and
+        <c>last</c>.</p>
       <p>The following code illustrates how a <c>Mnesia</c> table is
         converted to be a fragmented table and how more fragments
         are added later:</p>


### PR DESCRIPTION
In the Table Fragmentation documentation section, note that the
functions first/1, next/2, prev/2 and last/1 return elements in an
undefined order for fragmented tables.

Also remove superfluous "the".