### PR TITLE
Prevent BEAM crash when message being sent via dist is larger than 2Gb

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1698,6 +1698,7 @@ ebif_bang_2(BIF_ALIST_2)
 #define SEND_INTERNAL_ERROR	(-6)
 #define SEND_AWAIT_RESULT	(-7)
 #define SEND_YIELD_CONTINUE     (-8)
+#define SEND_SYSTEM_LIMIT		(-9)
 
 
 static Sint remote_send(Process *p, DistEntry *dep,
@@ -1737,6 +1738,8 @@ static Sint remote_send(Process *p, DistEntry *dep,
 	    res = SEND_YIELD_RETURN;
 	else if (code == ERTS_DSIG_SEND_CONTINUE)
 	    res = SEND_YIELD_CONTINUE;
+	else if (code == ERTS_DSIG_SEND_TOO_LRG)
+	    res = SEND_SYSTEM_LIMIT;
 	else
 	    res = 0;
 	break;
@@ -2057,6 +2060,9 @@ BIF_RETTYPE send_3(BIF_ALIST_3)
     case SEND_BADARG:
 	ERTS_BIF_PREP_ERROR(retval, p, BADARG);
 	break;
+    case SEND_SYSTEM_LIMIT:
+	ERTS_BIF_PREP_ERROR(retval, p, SYSTEM_LIMIT);
+	break;
     case SEND_USER_ERROR:
 	ERTS_BIF_PREP_ERROR(retval, p, EXC_ERROR);
 	break;
@@ -2112,6 +2118,10 @@ static BIF_RETTYPE dsend_continue_trap_1(BIF_ALIST_1)
     case ERTS_DSIG_SEND_CONTINUE: { /*SEND_YIELD_CONTINUE*/
 	BUMP_ALL_REDS(BIF_P);
 	BIF_TRAP1(&dsend_continue_trap_export, BIF_P, BIF_ARG_1);
+    }
+    case ERTS_DSIG_SEND_TOO_LRG: { /*SEND_SYSTEM_LIMIT*/
+	erts_set_gc_state(BIF_P, 1);
+	BIF_ERROR(BIF_P, SYSTEM_LIMIT);
     }
     default:
 	erts_exit(ERTS_ABORT_EXIT, "dsend_continue_trap invalid result %d\n", (int)result);
@@ -2169,6 +2179,9 @@ Eterm erl_send(Process *p, Eterm to, Eterm msg)
 	break;
     case SEND_BADARG:
 	ERTS_BIF_PREP_ERROR(retval, p, BADARG);
+	break;
+    case SEND_SYSTEM_LIMIT:
+	ERTS_BIF_PREP_ERROR(retval, p, SYSTEM_LIMIT);
 	break;
     case SEND_USER_ERROR:
 	ERTS_BIF_PREP_ERROR(retval, p, EXC_ERROR);

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -1937,6 +1937,10 @@ erts_dsig_send(ErtsDSigData *dsdp, struct erts_dsig_send_context* ctx)
 	    ASSERT(ctx->obuf->ext_endp <= &ctx->obuf->data[0] + ctx->data_size);
 
 	    ctx->data_size = ctx->obuf->ext_endp - ctx->obuf->extp;
+	    if (ctx->data_size > (Uint) INT_MAX) {
+		retval = ERTS_DSIG_SEND_TOO_LRG;
+		goto done;
+	    }
 
             ctx->obuf->hopefull_flags = ctx->u.ec.hopefull_flags;
 	    /*

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -376,6 +376,7 @@ typedef struct {
 #define ERTS_DSIG_SEND_OK	0
 #define ERTS_DSIG_SEND_YIELD	1
 #define ERTS_DSIG_SEND_CONTINUE 2
+#define ERTS_DSIG_SEND_TOO_LRG  3
 
 extern int erts_dsig_send_link(ErtsDSigData *, Eterm, Eterm);
 extern int erts_dsig_send_msg(Eterm, Eterm, ErtsSendContext*);


### PR DESCRIPTION
There is a check for dist message size. If it exceeds INT_MAX, BEAM exits (sigabrt). 

While it could've been a case of absurdly large message 10 years ago, nowadays it's quite possible to have a data structure of this size. However it is questionable if the message should be sent or not. My suggestion would be to reject sending these messages (but do not crash entire VM).

Fixes this:
https://bugs.erlang.org/browse/ERL-484