### PR TITLE
upgrade to a new release without a relup or rebooting the VM

### DIFF
--- a/lib/sasl/src/release_handler.erl
+++ b/lib/sasl/src/release_handler.erl
@@ -847,11 +847,18 @@ do_unpack_release(Root, RelDir, ReleaseName, Releases) ->
     %% systools:make_tar, where there is no copy of the .rel file in
     %% the releases/<vsn> dir. See OTP-9746.
     Dir = filename:join([RelDir, Vsn]),
-    copy_file(RelFile, Dir, false),
+
+    %% don't copy or delete RelFile if it is already under releases/<vsn>
+    _ = case filename:dirname(RelFile) of
+            Dir ->
+                ok;
+            _ ->
+                copy_file(RelFile, Dir, false),
+                _ = file:delete(RelFile)
+        end,
 
     %% Clean release
     _ = file:delete(Tar),
-    _ = file:delete(RelFile),
 
     {ok, NewReleases, Vsn}.
    


### PR DESCRIPTION
This function provides a way to go to a new release in the case you want to just do a restart and not a live upgrade but without rebooting the VM or requiring any appups or relup.

It includes the patch from #1580 as well because it partially needs it (at least to work smoothly when using release tarballs generated by relx) but I consider #1580 important on its own and separate as well.