### PR TITLE
Add a bit of documentation about restart_application

### DIFF
--- a/lib/sasl/doc/src/appup.xml
+++ b/lib/sasl/doc/src/appup.xml
@@ -255,7 +255,10 @@
     Note that, even if the application has been started before the
     release upgrade is performed, <c>restart_application</c> may only
     <c>load</c> it rather than <c>start</c> it, depending on the
-    application's <c>restart_type()</c>.
+    application's <c>start type</c>:
+    If <c>Type = load</c>, the application is only loaded.
+    If <c>Type = none</c>, the application is not loaded and not
+    started, although the code for its modules is loaded.
     </p>
     </section>
 

--- a/lib/sasl/doc/src/appup.xml
+++ b/lib/sasl/doc/src/appup.xml
@@ -249,9 +249,14 @@
     <pre>
 {restart_application, Application}
   Application = atom()</pre>
-    <p>Restarting an application means that the application is
-      stopped and then started again, similar to using the instructions
-      <c>remove_application</c> and <c>add_application</c> in sequence.</p>
+    <p>Restarting an application means that the application is stopped
+    and then started again, similar to using the instructions
+    <c>remove_application</c> and <c>add_application</c> in sequence.
+    Note that, even if the application has been started before the
+    release upgrade is performed, <c>restart_application</c> may only
+    <c>load</c> it rather than <c>start</c> it, depending on the
+    application's <c>restart_type()</c>.
+    </p>
     </section>
 
     <section>


### PR DESCRIPTION
It should be explicitly stated that the application will not actually be
restarted, depending on how it was originally started, even if it is
currently running.