### PR TITLE
filename join/split fixed for win32 share

### DIFF
--- a/lib/public_key/doc/src/public_key.xml
+++ b/lib/public_key/doc/src/public_key.xml
@@ -883,8 +883,8 @@ fun(#'DistributionPoint'{}, #'CertificateList'{},
     </type>
     <desc>
       <p>This function checks that the <i>Presented Identifier</i> (e.g hostname) in a peer certificate
-      conforms with the Expected Identifier that the client wants to connect to.
-      This functions is intended to be added as an extra client check to the peer certificate when performing
+      is in agreement with the <i>Reference Identifier</i> that the client expects to be connected to.
+      The function is intended to be added as an extra client check of the peer certificate when performing
       <seealso marker="public_key:public_key#pkix_path_validation-3">public_key:pkix_path_validation/3</seealso>
       </p>
       <p>See <url href="https://tools.ietf.org/html/rfc6125">RFC 6125</url>
@@ -897,7 +897,8 @@ fun(#'DistributionPoint'{}, #'CertificateList'{},
       <p>The <c>{OtherRefId,term()}</c> is defined by the user and is passed to the <c>match_fun</c>, if defined.
       If that term is a binary, it will be converted to a string.
       </p>
-      <p>The <c>ip</c> takes a 4-tuple or a 
+      <p>The <c>ip</c> Reference ID takes an <seealso marker="inet:inet#type-ip_address">inet:ip_address()</seealso>
+      or an ip address in string format (E.g "10.0.1.1" or "1234::5678:9012") as second element.
       </p>
     </desc>
   </func>

--- a/lib/public_key/src/pubkey_ssh.erl
+++ b/lib/public_key/src/pubkey_ssh.erl
@@ -29,7 +29,15 @@
 	]).
 
 -define(UINT32(X), X:32/unsigned-big-integer).
--define(STRING(X), ?UINT32((size(X))), (X)/binary).
+-define(STRING(X), ?UINT32((byte_size(X))), (X)/binary).
+
+-define(DEC_BIN(X,Len),   ?UINT32(Len), X:Len/binary ).
+-define(DEC_MPINT(I,Len), ?DEC_INT(I,Len) ).
+-define(DEC_INT(I,Len),   ?UINT32(Len), I:Len/big-signed-integer-unit:8 ).
+
+-define(Empint(X),  (mpint(X))/binary ).
+-define(Estring(X), (string(X))/binary ).
+
 
 %% Max encoded line length is 72, but conformance examples use 68
 %% Comment from rfc 4716: "The following are some examples of public
@@ -47,12 +55,12 @@
 %% Description: Decodes a ssh file-binary.
 %%--------------------------------------------------------------------
 decode(Bin, public_key)->
-    case binary:match(Bin, begin_marker()) of
-	nomatch ->
-	    openssh_decode(Bin, openssh_public_key);
-	_ ->
-	    rfc4716_decode(Bin)
-    end;
+    PKtype =
+        case binary:match(Bin, begin_marker()) of
+            nomatch -> openssh_public_key;
+            _ -> rfc4716_public_key
+        end,
+    decode(Bin, PKtype);
 decode(Bin, rfc4716_public_key) ->
     rfc4716_decode(Bin);
 decode(Bin, ssh2_pubkey) ->
@@ -164,26 +172,8 @@ join_entry([Line | Lines], Entry) ->
     join_entry(Lines, [Line | Entry]).
 
 
-rfc4716_pubkey_decode(<<?UINT32(Len), Type:Len/binary,
-			?UINT32(SizeE), E:SizeE/binary,
-			?UINT32(SizeN), N:SizeN/binary>>) when Type == <<"ssh-rsa">> ->
-    #'RSAPublicKey'{modulus = erlint(SizeN, N),
-		    publicExponent = erlint(SizeE, E)};
+rfc4716_pubkey_decode(BinKey) -> ssh2_pubkey_decode(BinKey).
 
-rfc4716_pubkey_decode(<<?UINT32(Len), Type:Len/binary,
-			?UINT32(SizeP), P:SizeP/binary,
-			?UINT32(SizeQ), Q:SizeQ/binary,
-			?UINT32(SizeG), G:SizeG/binary,
-			?UINT32(SizeY), Y:SizeY/binary>>) when Type == <<"ssh-dss">> ->
-    {erlint(SizeY, Y),
-     #'Dss-Parms'{p = erlint(SizeP, P),
-		  q = erlint(SizeQ, Q),
-		  g = erlint(SizeG, G)}};
-rfc4716_pubkey_decode(<<?UINT32(Len), ECDSA_SHA2_etc:Len/binary,
-			?UINT32(SizeId), Id:SizeId/binary,
-			?UINT32(SizeQ), Q:SizeQ/binary>>) ->
-    <<"ecdsa-sha2-", Id/binary>> = ECDSA_SHA2_etc,
-    {#'ECPoint'{point = Q}, {namedCurve,public_key:ssh_curvename2oid(Id)}}.
 
 openssh_decode(Bin, FileType) ->
     Lines = binary:split(Bin, <<"\n">>, [global]),
@@ -267,17 +257,13 @@ decode_comment(Comment) ->
 
 openssh_pubkey_decode(Type,  Base64Enc) ->
     try
-	ssh2_pubkey_decode(Type,  base64:mime_decode(Base64Enc))
+        <<?DEC_BIN(Type,_TL), Bin/binary>> = base64:mime_decode(Base64Enc),
+	ssh2_pubkey_decode(Type,  Bin)
     catch
 	_:_ ->
 	    {Type, base64:mime_decode(Base64Enc)}
     end.
 
-
-erlint(MPIntSize, MPIntValue) ->
-    Bits= MPIntSize * 8,
-    <<Integer:Bits/integer>> = MPIntValue,
-    Integer.
 
 ssh1_rsa_pubkey_decode(MBin, EBin) ->
     #'RSAPublicKey'{modulus = integer_decode(MBin),
@@ -411,71 +397,37 @@ comma_list_encode([Option | Rest], Acc) ->
 
 
 ssh2_pubkey_encode(#'RSAPublicKey'{modulus = N, publicExponent = E}) ->
-    ssh2_pubkey_encode({#'RSAPublicKey'{modulus = N, publicExponent = E}, 'ssh-rsa'});
-
-ssh2_pubkey_encode({Key, 'rsa-sha2-256'}) -> ssh2_pubkey_encode({Key, 'ssh-rsa'});
-ssh2_pubkey_encode({Key, 'rsa-sha2-512'}) -> ssh2_pubkey_encode({Key, 'ssh-rsa'});
-ssh2_pubkey_encode({#'RSAPublicKey'{modulus = N, publicExponent = E}, SignAlg}) ->
-    SignAlgName = list_to_binary(atom_to_list(SignAlg)),
-    StrLen = size(SignAlgName),
-    EBin = mpint(E),
-    NBin = mpint(N),
-    <<?UINT32(StrLen), SignAlgName:StrLen/binary,
-      EBin/binary,
-      NBin/binary>>;
-ssh2_pubkey_encode({{_,#'Dss-Parms'{}}=Key, _}) ->
-    ssh2_pubkey_encode(Key);
+    <<?STRING(<<"ssh-rsa">>), ?Empint(E), ?Empint(N)>>;
 ssh2_pubkey_encode({Y,  #'Dss-Parms'{p = P, q = Q, g = G}}) ->
-    TypeStr = <<"ssh-dss">>,
-    StrLen = size(TypeStr),
-    PBin = mpint(P),
-    QBin = mpint(Q),
-    GBin = mpint(G),
-    YBin = mpint(Y),
-    <<?UINT32(StrLen), TypeStr:StrLen/binary,
-      PBin/binary,
-      QBin/binary,
-      GBin/binary,
-      YBin/binary>>;
-ssh2_pubkey_encode({{#'ECPoint'{},_}=Key, _}) ->
-    ssh2_pubkey_encode(Key);
+    <<?STRING(<<"ssh-dss">>), ?Empint(P), ?Empint(Q), ?Empint(G), ?Empint(Y)>>;
 ssh2_pubkey_encode(Key={#'ECPoint'{point = Q}, {namedCurve,OID}}) ->
-    TypeStr = key_type(Key),
-    StrLen = size(TypeStr),
-    IdB = public_key:oid2ssh_curvename(OID),
-    <<?UINT32(StrLen), TypeStr:StrLen/binary,
-      (string(IdB))/binary,
-      (string(Q))/binary>>.
+    Curve = public_key:oid2ssh_curvename(OID),
+    <<?STRING(key_type(Key)), ?Estring(Curve), ?Estring(Q)>>.
 
 
-ssh2_pubkey_decode(Bin = <<?UINT32(Len), Type:Len/binary, _/binary>>) ->
+ssh2_pubkey_decode(<<?DEC_BIN(Type,_TL), Bin/binary>>) ->
     ssh2_pubkey_decode(Type, Bin).
 
-ssh2_pubkey_decode(<<"rsa-sha2-256">>, Bin) -> ssh2_pubkey_decode(<<"ssh-rsa">>, Bin);
-ssh2_pubkey_decode(<<"rsa-sha2-512">>, Bin) -> ssh2_pubkey_decode(<<"ssh-rsa">>, Bin);
+%% ssh2_pubkey_decode(<<"rsa-sha2-256">>, Bin) -> ssh2_pubkey_decode(<<"ssh-rsa">>, Bin);
+%% ssh2_pubkey_decode(<<"rsa-sha2-512">>, Bin) -> ssh2_pubkey_decode(<<"ssh-rsa">>, Bin);
 ssh2_pubkey_decode(<<"ssh-rsa">>,
-		   <<?UINT32(Len),   _:Len/binary,
-		     ?UINT32(SizeE), E:SizeE/binary,
-		     ?UINT32(SizeN), N:SizeN/binary>>) ->
-    #'RSAPublicKey'{modulus = erlint(SizeN, N),
-		    publicExponent = erlint(SizeE, E)};
+                   <<?DEC_INT(E, _EL),
+                     ?DEC_INT(N, _NL)>>) ->
+    #'RSAPublicKey'{modulus = N,
+		    publicExponent = E};
 
 ssh2_pubkey_decode(<<"ssh-dss">>,
-		   <<?UINT32(Len),   _:Len/binary,
-		     ?UINT32(SizeP), P:SizeP/binary,
-		     ?UINT32(SizeQ), Q:SizeQ/binary,
-		     ?UINT32(SizeG), G:SizeG/binary,
-		     ?UINT32(SizeY), Y:SizeY/binary>>) ->
-    {erlint(SizeY, Y),
-     #'Dss-Parms'{p = erlint(SizeP, P),
-		  q = erlint(SizeQ, Q),
-		  g = erlint(SizeG, G)}};
+                   <<?DEC_INT(P, _PL),
+                     ?DEC_INT(Q, _QL),
+                     ?DEC_INT(G, _GL),
+                     ?DEC_INT(Y, _YL)>>) ->
+    {Y, #'Dss-Parms'{p = P,
+                     q = Q,
+                     g = G}};
 
 ssh2_pubkey_decode(<<"ecdsa-sha2-",Id/binary>>,
-		   <<?UINT32(Len), ECDSA_SHA2_etc:Len/binary,
-		     ?UINT32(SizeId), Id:SizeId/binary,
-		     ?UINT32(SizeQ), Q:SizeQ/binary>>) ->
-    <<"ecdsa-sha2-", Id/binary>> = ECDSA_SHA2_etc,
+                   <<?DEC_BIN(Id, _IL),
+                     ?DEC_BIN(Q, _QL)>>) ->
     {#'ECPoint'{point = Q}, {namedCurve,public_key:ssh_curvename2oid(Id)}}.
 
 
@@ -575,17 +527,16 @@ mpint(X) -> mpint_pos(X).
 
 mpint_neg(X) ->
     Bin = int_to_bin_neg(X, []),
-    Sz = byte_size(Bin),
-    <<?UINT32(Sz), Bin/binary>>.
+    <<?STRING(Bin)>>.
     
 mpint_pos(X) ->
     Bin = int_to_bin_pos(X, []),
     <<MSB,_/binary>> = Bin,
-    Sz = byte_size(Bin),
     if MSB band 16#80 == 16#80 ->
-	    <<?UINT32((Sz+1)), 0, Bin/binary>>;
+            B = << 0, Bin/binary>>,
+	    <<?STRING(B)>>;
        true ->
-	    <<?UINT32(Sz), Bin/binary>>
+	    <<?STRING(Bin)>>
     end.
 
 int_to_bin_pos(0,Ds=[_|_]) ->
@@ -602,7 +553,8 @@ int_to_bin_neg(X,Ds) ->
 string(X) when is_binary(X) ->
     << ?STRING(X) >>;
 string(X) ->
-    << ?STRING(list_to_binary(X)) >>.
+    B = list_to_binary(X),
+    << ?STRING(B) >>.
 
 is_ssh_curvename(Id) -> try public_key:ssh_curvename2oid(Id) of _ -> true
 			catch _:_  -> false

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -942,7 +942,6 @@ ssh_decode(SshBin, Type) when is_binary(SshBin),
 %%--------------------------------------------------------------------
 -spec ssh_encode([{public_key(), Attributes::list()}], ssh_file()) -> binary()
 	      ; (public_key(), ssh2_pubkey) -> binary()
-	      ; ({public_key(),atom()}, ssh2_pubkey) -> binary()
 	      .
 %%
 %% Description: Encodes a list of ssh file entries (public keys and

--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -439,6 +439,10 @@ join(Name1, Name2) when is_atom(Name2) ->
 join1([UcLetter, $:|Rest], RelativeName, [], win32)
 when is_integer(UcLetter), UcLetter >= $A, UcLetter =< $Z ->
     join1(Rest, RelativeName, [$:, UcLetter+$a-$A], win32);
+join1([$\\,$\\|Rest], RelativeName, [], win32) ->
+    join1([$/,$/|Rest], RelativeName, [], win32);
+join1([$/,$/|Rest], RelativeName, [], win32) ->
+    join1(Rest, RelativeName, [$/,$/], win32);
 join1([$\\|Rest], RelativeName, Result, win32) ->
     join1([$/|Rest], RelativeName, Result, win32);
 join1([$/|Rest], RelativeName, [$., $/|Result], OsType) ->
@@ -449,6 +453,8 @@ join1([], [], Result, OsType) ->
     maybe_remove_dirsep(Result, OsType);
 join1([], RelativeName, [$:|Rest], win32) ->
     join1(RelativeName, [], [$:|Rest], win32);
+join1([], RelativeName, [$/,$/|Result], win32) ->
+    join1(RelativeName, [], [$/,$/|Result], win32);
 join1([], RelativeName, [$/|Result], OsType) ->
     join1(RelativeName, [], [$/|Result], OsType);
 join1([], RelativeName, [$., $/|Result], OsType) ->
@@ -467,6 +473,10 @@ join1([Atom|Rest], RelativeName, Result, OsType) when is_atom(Atom) ->
 join1b(<<UcLetter, $:, Rest/binary>>, RelativeName, [], win32)
 when is_integer(UcLetter), UcLetter >= $A, UcLetter =< $Z ->
     join1b(Rest, RelativeName, [$:, UcLetter+$a-$A], win32);
+join1b(<<$\\,$\\,Rest/binary>>, RelativeName, [], win32) ->
+    join1b(<<$/,$/,Rest/binary>>, RelativeName, [], win32);
+join1b(<<$/,$/,Rest/binary>>, RelativeName, [], win32) ->
+    join1b(Rest, RelativeName, [$/,$/], win32);
 join1b(<<$\\,Rest/binary>>, RelativeName, Result, win32) ->
     join1b(<<$/,Rest/binary>>, RelativeName, Result, win32);
 join1b(<<$/,Rest/binary>>, RelativeName, [$., $/|Result], OsType) ->
@@ -477,6 +487,8 @@ join1b(<<>>, <<>>, Result, OsType) ->
     list_to_binary(maybe_remove_dirsep(Result, OsType));
 join1b(<<>>, RelativeName, [$:|Rest], win32) ->
     join1b(RelativeName, <<>>, [$:|Rest], win32);
+join1b(<<>>, RelativeName, [$/,$/|Result], win32) ->
+    join1b(RelativeName, <<>>, [$/,$/|Result], win32);
 join1b(<<>>, RelativeName, [$/|Result], OsType) ->
     join1b(RelativeName, <<>>, [$/|Result], OsType);
 join1b(<<>>, RelativeName, [$., $/|Result], OsType) ->
@@ -490,6 +502,8 @@ maybe_remove_dirsep([$/, $:, Letter], win32) ->
     [Letter, $:, $/];
 maybe_remove_dirsep([$/], _) ->
     [$/];
+maybe_remove_dirsep([$/,$/|Name], win32) ->
+    [$/,$/|lists:reverse(Name)];
 maybe_remove_dirsep([$/|Name], _) ->
     lists:reverse(Name);
 maybe_remove_dirsep(Name, _) ->
@@ -679,6 +693,9 @@ win32_splitb(<<Letter0,$:,Rest/binary>>) when ?IS_DRIVELETTER(Letter0) ->
     Letter = fix_driveletter(Letter0),
     L = binary:split(Rest,[<<"/">>,<<"\\">>],[global]),
     [<<Letter,$:>> | [ X || X <- L, X =/= <<>> ]];
+win32_splitb(<<Slash,Slash,Rest/binary>>) when Slash =:= $\\ ->
+    L = binary:split(Rest,[<<"/">>,<<"\\">>],[global]),
+    [<<"//">> | [ X || X <- L, X =/= <<>> ]];
 win32_splitb(<<Slash,Rest/binary>>) when ((Slash =:= $\\) orelse (Slash =:= $/)) ->
     L = binary:split(Rest,[<<"/">>,<<"\\">>],[global]),
     [<<$/>> | [ X || X <- L, X =/= <<>> ]];
@@ -690,6 +707,8 @@ win32_splitb(Name) ->
 unix_split(Name) ->
     split(Name, [], unix).
 
+win32_split([$\\,$\\|Rest]) ->
+    split(Rest, [[$/,$/]], win32);
 win32_split([$\\|Rest]) ->
     win32_split([$/|Rest]);
 win32_split([X, $\\|Rest]) when is_integer(X) ->

--- a/lib/stdlib/test/filename_SUITE.erl
+++ b/lib/stdlib/test/filename_SUITE.erl
@@ -289,7 +289,6 @@ join(Config) when is_list(Config) ->
     %% join/1 and join/2 (OTP-12158) by using help function
     %% filename_join/2.
     "/" = filename:join(["/"]),
-    "/" = filename:join(["//"]),
     "usr/foo.erl" = filename_join("usr","foo.erl"),
     "/src/foo.erl" = filename_join(usr, "/src/foo.erl"),
     "/src/foo.erl" = filename_join("/src/",'foo.erl'),
@@ -301,7 +300,6 @@ join(Config) when is_list(Config) ->
     "a/b/c/d/e/f/g" = filename_join("a//b/c/", "d//e/f/g"),
     "a/b/c/d/e/f/g" = filename_join("a//b/c", "d//e/f/g"),
     "/d/e/f/g" = filename_join("a//b/c", "/d//e/f/g"),
-    "/d/e/f/g" = filename:join("a//b/c", "//d//e/f/g"),
 
     "foo/bar" = filename_join([$f,$o,$o,$/,[]], "bar"),
 
@@ -332,6 +330,7 @@ join(Config) when is_list(Config) ->
 
     case os:type() of
         {win32, _} ->
+            "//" = filename:join(["//"]),
             "d:/" = filename:join(["D:/"]),
             "d:/" = filename:join(["D:\\"]),
             "d:/abc" = filename_join("D:/", "abc"),
@@ -345,8 +344,16 @@ join(Config) when is_list(Config) ->
             "c:/usr/foo.erl" = filename:join(["A:","C:/usr","foo.erl"]),
             "c:usr/foo.erl" = filename:join(["A:","C:usr","foo.erl"]),
             "d:/foo" = filename:join([$D, $:, $/, []], "foo"),
+            "//" = filename:join("\\\\", ""),
+            "//foo" = filename:join("\\\\", "foo"),
+            "//foo/bar" = filename:join("\\\\", "foo\\\\bar"),
+            "//foo/bar/baz" = filename:join("\\\\foo", "bar\\\\baz"),
+            "//bar/baz" = filename:join("\\\\foo", "\\\\bar\\baz"),
+            "//d/e/f/g" = filename:join("a//b/c", "//d//e/f/g"),
             ok;
         _ ->
+            "/" = filename:join(["//"]),
+            "/d/e/f/g" = filename:join("a//b/c", "//d//e/f/g"),
             ok
     end.
 
@@ -402,6 +409,12 @@ split(Config) when is_list(Config) ->
                 filename:split("a:\\msdev\\include"),
             ["a:","msdev","include"] =
                 filename:split("a:msdev\\include"),
+            ["//","foo"] =
+                filename:split("\\\\foo"),
+            ["//","foo","bar"] =
+                filename:split("\\\\foo\\\\bar"),
+            ["//","foo","baz"] =
+                filename:split("\\\\foo\\baz"),
             ok;
         _ ->
 	    ok
@@ -630,7 +643,6 @@ extension_bin(Config) when is_list(Config) ->
     
 join_bin(Config) when is_list(Config) ->
     <<"/">> = filename:join([<<"/">>]),
-    <<"/">> = filename:join([<<"//">>]),
     <<"usr/foo.erl">> = filename:join(<<"usr">>,<<"foo.erl">>),
     <<"/src/foo.erl">> = filename:join(usr, <<"/src/foo.erl">>),
     <<"/src/foo.erl">> = filename:join([<<"/src/">>,'foo.erl']),
@@ -642,7 +654,6 @@ join_bin(Config) when is_list(Config) ->
     <<"a/b/c/d/e/f/g">> = filename:join([<<"a//b/c/">>, <<"d//e/f/g">>]),
     <<"a/b/c/d/e/f/g">> = filename:join([<<"a//b/c">>, <<"d//e/f/g">>]),
     <<"/d/e/f/g">> = filename:join([<<"a//b/c">>, <<"/d//e/f/g">>]),
-    <<"/d/e/f/g">> = filename:join([<<"a//b/c">>, <<"//d//e/f/g">>]),
 
     <<"foo/bar">> = filename:join([$f,$o,$o,$/,[]], <<"bar">>),
 
@@ -695,6 +706,7 @@ join_bin(Config) when is_list(Config) ->
 
     case os:type() of
         {win32, _} ->
+            <<"//">> = filename:join([<<"//">>]),
             <<"d:/">> = filename:join([<<"D:/">>]),
             <<"d:/">> = filename:join([<<"D:\\">>]),
             <<"d:/abc">> = filename:join([<<"D:/">>, <<"abc">>]),
@@ -708,8 +720,16 @@ join_bin(Config) when is_list(Config) ->
             <<"c:/usr/foo.erl">> = filename:join([<<"A:">>,<<"C:/usr">>,<<"foo.erl">>]),
             <<"c:usr/foo.erl">> = filename:join([<<"A:">>,<<"C:usr">>,<<"foo.erl">>]),
             <<"d:/foo">> = filename:join([$D, $:, $/, []], <<"foo">>),
+            <<"//">> = filename:join(<<"\\\\">>, <<"">>),
+            <<"//foo">> = filename:join(<<"\\\\">>, <<"foo">>),
+            <<"//foo/bar">> = filename:join(<<"\\\\">>, <<"foo\\\\bar">>),
+            <<"//foo/bar/baz">> = filename:join(<<"\\\\foo">>, <<"bar\\\\baz">>),
+            <<"//bar/baz">> = filename:join(<<"\\\\foo">>, <<"\\\\bar\\baz">>),
+            <<"//d/e/f/g">> = filename:join([<<"a//b/c">>, <<"//d//e/f/g">>]),
             ok;
         _ ->
+            <<"/">> = filename:join([<<"//">>]),
+            <<"/d/e/f/g">> = filename:join([<<"a//b/c">>, <<"//d//e/f/g">>]),
             ok
     end.
 
@@ -756,6 +776,12 @@ split_bin(Config) when is_list(Config) ->
                 filename:split(<<"a:\\msdev\\include">>),
             [<<"a:">>,<<"msdev">>,<<"include">>] =
                 filename:split(<<"a:msdev\\include">>),
+            [<<"//">>,<<"foo">>] =
+                filename:split(<<"\\\\foo">>),
+            [<<"//">>,<<"foo">>,<<"bar">>] =
+                filename:split(<<"\\\\foo\\\\bar">>),
+            [<<"//">>,<<"foo">>,<<"baz">>] =
+                filename:split(<<"\\\\foo\\baz">>),
             ok;
         _ ->
             ok


### PR DESCRIPTION
Previously : https://github.com/erlang/otp/pull/901

#### Currently
``` erlang
> filename:join("\\\\", "foo").
"/foo"
> filename:split("\\\\foo").
["/","foo"]
```
#### Fixed by this PR
``` erlang
> filename:join("\\\\", "foo").
"\\\\test"
> filename:split("\\\\foo").
["\\\\","test"]
```
#### Answers to https://github.com/erlang/otp/pull/901#issuecomment-197860031
> It seems that your new code will accept "//" or "" in any position in a filename, not only at the beginning.

Yes, both join and split accepts (in stead of `function_caluse`) but **correct / valid** path is returned. As demonstrated in test cases below:
```erlang
"\\\\" = filename:join("\\\\", ""),
"\\\\foo" = filename:join("\\\\", "foo"),
"\\\\foo/bar" = filename:join("\\\\", "foo\\\\bar"),
"\\\\foo/bar/baz" = filename:join("\\\\foo", "bar\\\\baz"),
"\\\\bar/baz" = filename:join("\\\\foo", "\\\\bar\\baz"),
...
["\\\\","foo"] = filename:split("\\\\foo"),
["\\\\","foo","bar"] = filename:split("\\\\foo\\\\bar"),
["\\\\","foo","baz"] = filename:split("\\\\foo\\baz"),
```

> We will need test cases before we can consider including this patch in OTP. 

Test cases are also provided