### PR TITLE
Change gen_statem:call(_, _, {clean_timeout,infinity}) to use proxy

### DIFF
--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -1329,7 +1329,7 @@ handle_event(_, _, State, Data) ->
 	  <c><anno>T</anno></c> is the time-out time.
 	  <c>{clean_timeout,<anno>T</anno>}</c> works like
 	  just <c>T</c> described in the note above
-	  and uses a proxy process for <c>T &lt; infinity</c>,
+	  and uses a proxy process
 	  while <c>{dirty_timeout,<anno>T</anno>}</c>
 	  bypasses the proxy process which is more lightweight.
 	</p>
@@ -1339,8 +1339,12 @@ handle_event(_, _, State, Data) ->
 	    with <c>{dirty_timeout,<anno>T</anno>}</c>
 	    to avoid that the calling process dies when the call
 	    times out, you will have to be prepared to handle
-	    a late reply.
-	    So why not just let the calling process die?
+	    a late reply.  Note that there is an odd chance
+	    to get a late reply even with
+	    <c>{dirty_timeout,infinity}</c> or <c>infinity</c>
+	    for example in the event of network problems.
+	    So why not just let the calling process die
+	    by not catching the exception?
 	  </p>
 	</note>
 	<p>

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -510,8 +510,6 @@ call(ServerRef, Request, Timeout) ->
 
 parse_timeout(Timeout) ->
     case Timeout of
-	{clean_timeout,infinity} ->
-	    {dirty_timeout,infinity};
 	{clean_timeout,_} ->
 	    Timeout;
 	{dirty_timeout,_} ->


### PR DESCRIPTION
I would like community feedback on a changing a corner case for timeouts in `gen_statem:call(Server, Request, Timeout)` for OTP 21.0.

The `Timeout == {clean_timeout,infinity}` today means `{dirty_timeout,infinity}` i.e does not use a proxy process.  This was intended as an optimization.

But since in the event of network problems such as the connection going down and up the monitor set before sending `Request` may trigger causing the client call to fail, but the `Request` may actually have arrived at the server, which may reply so we get an unhandled late reply in the inbox.  Very rarely.

I think that giving the programmer the possibility to use a proxy process even for infinity timeout simplifies the semantics and may be found useful.

The behaviour for `Timeout == infinity` will still mean `{dirty_timeout,infinity}` that is: no proxy process. 