### PR TITLE
(Slightly) optimize catch and try/catch

### DIFF
--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -857,8 +857,7 @@ catch(Y, Fail) {
 }
 
 catch_end(Y) {
-    c_p->catches--;
-    make_blank($Y);
+    $try_end($Y);
     if (is_non_value(r(0))) {
         c_p->fvalue = NIL;
         if (x(1) == am_throw) {
@@ -888,12 +887,15 @@ catch_end(Y) {
 try_end(Y) {
     c_p->catches--;
     make_blank($Y);
-    if (is_non_value(r(0))) {
-        c_p->fvalue = NIL;
-        r(0) = x(1);
-        x(1) = x(2);
-        x(2) = x(3);
-    }
+}
+
+try_case(Y) {
+    $try_end($Y);
+    ASSERT(is_non_value(r(0)));
+    c_p->fvalue = NIL;
+    r(0) = x(1);
+    x(1) = x(2);
+    x(2) = x(3);
 }
 
 try_case_end(Src) {

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -188,7 +188,8 @@ catch_end y
 
 # Try/catch.
 try Y F => catch Y F
-try_case Y => try_end Y
+
+try_case y
 try_end y
 
 %cold

--- a/lib/compiler/src/beam_receive.erl
+++ b/lib/compiler/src/beam_receive.erl
@@ -207,6 +207,8 @@ opt_update_regs({label,Lbl}, R, L) ->
 	    %% A catch label for a previously seen catch instruction is OK.
 	    {R,L}
     end;
+opt_update_regs({'try',_,{f,Lbl}}, R, L) ->
+    {R,gb_sets:add(Lbl, L)};
 opt_update_regs({try_end,_}, R, L) ->
     {R,L};
 opt_update_regs({line,_}, R, L) ->

--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -825,8 +825,14 @@ live_opt([{select,_,Src,Fail,List}=I|Is], Regs0, D, Acc) ->
     Regs1 = x_live([Src], Regs0),
     Regs = live_join_labels([Fail|List], D, Regs1),
     live_opt(Is, Regs, D, [I|Acc]);
-live_opt([{try_case,_}=I|Is], _, D, Acc) ->
-    live_opt(Is, live_call(1), D, [I|Acc]);
+live_opt([{try_case,Y}=I|Is], Regs0, D, Acc) ->
+    Regs = live_call(1),
+    case Regs0 of
+        0 ->
+            live_opt(Is, Regs, D, [{try_end,Y}|Acc]);
+        _ ->
+            live_opt(Is, live_call(1), D, [I|Acc])
+    end;
 live_opt([{loop_rec,_Fail,_Dst}=I|Is], _, D, Acc) ->
     live_opt(Is, 0, D, [I|Acc]);
 live_opt([timeout=I|Is], _, D, Acc) ->

--- a/lib/hipe/icode/hipe_beam_to_icode.erl
+++ b/lib/hipe/icode/hipe_beam_to_icode.erl
@@ -2296,6 +2296,12 @@ split_code([First|Code], Label, Instr) ->
 
 split_code([Instr|Code], Label, Instr, Prev, As) when Prev =:= Label ->
   split_code_final(Code, As);  % drop both label and instruction
+split_code([{icode_end_try}|_]=Code, Label, {try_case,_}, Prev, As)
+  when Prev =:= Label ->
+  %% The try_case has been replaced with try_end as an optimization.
+  %% Keep this instruction, since it might be the only try_end instruction
+  %% for this try/catch block.
+  split_code_final(Code, As);  % drop label
 split_code([Other|_Code], Label, Instr, Prev, _As) when Prev =:= Label ->
   ?EXIT({missing_instr_after_label, Label, Instr, [Other, Prev | _As]});
 split_code([Other|Code], Label, Instr, Prev, As) ->


### PR DESCRIPTION
This PR contains several improvements to catch and try/catch. The commit message for each commit gives more details. Here are the highlights:

* A catch that ignores its return value such as this code:

```
catch side_effect(),
...

```

will no longer build a stack trace.

* There are several minor optimizations, both in the compiler and run-time system, for try/catch.

* The optimization of receive that can avoid rescanning the entire message queue will now work for this code:

         Ref = make_ref(),
         try
             side_effect()
         catch _:_ ->
              ok
         end,
         receive
            %% Clauses that all match Ref.
            .
            .
            .
         end

(try/catch used to prevent the optimization.)