### PR TITLE
erts: Add start_time to process_info/2

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -5153,7 +5153,7 @@ RealSystem = system + MissedSystem</code>
           </item>
           <tag><c>{start_time, <anno>StartTime</anno>}</c></tag>
           <item>
-            <p><c><anno>StartTime</anno></c> is system time in seconds when
+            <p><c><anno>StartTime</anno></c> is Erlang monotonic time when
               the process was started.</p>
           </item>
           <tag><c>{status, <anno>Status</anno>}</c></tag>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -5151,6 +5151,11 @@ RealSystem = system + MissedSystem</code>
             <p><c><anno>Size</anno></c> is the stack size, in words,
               of the process.</p>
           </item>
+          <tag><c>{start_time, <anno>StartTime</anno>}</c></tag>
+          <item>
+            <p><c><anno>StartTime</anno></c> is system time in seconds when
+              the process was started.</p>
+          </item>
           <tag><c>{status, <anno>Status</anno>}</c></tag>
           <item>
             <p><c><anno>Status</anno></c> is the status of the process and is

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -628,6 +628,7 @@ atom spawned
 atom ssl_tls
 atom stack_size
 atom start
+atom start_time
 atom status
 atom static
 atom stderr_to_stdout

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -655,7 +655,8 @@ static Eterm pi_args[] = {
     am_current_stacktrace,
     am_message_queue_data,
     am_garbage_collection_info,
-    am_magic_ref
+    am_magic_ref,
+    am_start_time
 };
 
 #define ERTS_PI_ARGS ((int) (sizeof(pi_args)/sizeof(Eterm)))
@@ -707,6 +708,7 @@ pi_arg2ix(Eterm arg)
     case am_message_queue_data:			return 32;
     case am_garbage_collection_info:		return 33;
     case am_magic_ref:                          return 34;
+    case am_start_time:                         return 35;
     default:					return -1;
     }
 }
@@ -1652,6 +1654,14 @@ process_info_aux(Process *BIF_P,
 	(void) bld_magic_ref_bin_list(NULL, &sz, &MSO(rp));
 	hp = HAlloc(BIF_P, sz);
 	res = bld_magic_ref_bin_list(&hp, NULL, &MSO(rp));
+	break;
+    }
+
+    case am_start_time: {
+	Uint hsz = 3;
+	(void) erts_bld_uint(NULL, &hsz, rp->approx_started);
+	hp = HAlloc(BIF_P, hsz);
+	res = erts_bld_uint(&hp, NULL, rp->approx_started);
 	break;
     }
 

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -1659,9 +1659,10 @@ process_info_aux(Process *BIF_P,
 
     case am_start_time: {
 	Uint hsz = 3;
-	(void) erts_bld_uint(NULL, &hsz, rp->approx_started);
+	ErtsMonotonicTime start_time = rp->start_time + ERTS_MONOTONIC_OFFSET_NATIVE;
+	(void) erts_bld_monotonic_time(NULL, &hsz, start_time);
 	hp = HAlloc(BIF_P, hsz);
-	res = erts_bld_uint(&hp, NULL, rp->approx_started);
+	res = erts_bld_monotonic_time(&hp, NULL, start_time);
 	break;
     }
 

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -12285,6 +12285,7 @@ alloc_process(ErtsRunQueue *rq, erts_aint32_t state)
 {
     ErtsEarlyProcInit init_arg;
     Process *p;
+    ErtsSchedulerData *esdp = erts_get_scheduler_data();
 
     p = erts_alloc_fnf(ERTS_ALC_T_PROC, sizeof(Process));
     if (!p)
@@ -12308,7 +12309,7 @@ alloc_process(ErtsRunQueue *rq, erts_aint32_t state)
 
     ASSERT(internal_pid_serial(p->common.id) <= ERTS_MAX_PID_SERIAL);
     
-    p->approx_started = erts_get_approx_time();
+    p->start_time = erts_get_monotonic_time(esdp),
     p->rcount = 0;
     p->heap = NULL;
 
@@ -12750,7 +12751,7 @@ void erts_init_empty_process(Process *p)
     p->def_arg_reg[5] = 0;
 
     p->parent = NIL;
-    p->approx_started = 0;
+    p->start_time = 0;
     p->static_flags = 0;
 
     p->common.u.alive.started_interval = 0;

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1057,7 +1057,7 @@ struct process {
      * Information mainly for post-mortem use (erl crash dump).
      */
     Eterm parent;		/* Pid of process that created this process. */
-    erts_approx_time_t approx_started; /* Time when started. */
+    ErtsMonotonicTime start_time;	/* Time when started. */
 
     Uint32 static_flags;        /* Flags that do *not* change */
 

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -425,6 +425,7 @@ etwice_high(Low) ->
 
 %% Tests the process_info/2 BIF.
 t_process_info(Config) when is_list(Config) ->
+    NowTime = erlang:system_time(seconds),
     [] = process_info(self(), registered_name),
     register(my_name, self()),
     {registered_name, my_name} = process_info(self(), registered_name),
@@ -450,6 +451,11 @@ t_process_info(Config) when is_list(Config) ->
 
     Gleader = group_leader(),
     {group_leader, Gleader} = process_info(self(), group_leader),
+
+    %% start_time is system time in seconds
+    {start_time, StartTime} = process_info(self(), start_time),
+    true = (abs(StartTime - NowTime) =< 1),
+
     {'EXIT',{badarg,_Info}} = (catch process_info('not_a_pid')),
     ok.
 

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -425,7 +425,7 @@ etwice_high(Low) ->
 
 %% Tests the process_info/2 BIF.
 t_process_info(Config) when is_list(Config) ->
-    NowTime = erlang:system_time(seconds),
+    NowTime = erlang:monotonic_time(),
     [] = process_info(self(), registered_name),
     register(my_name, self()),
     {registered_name, my_name} = process_info(self(), registered_name),
@@ -454,7 +454,8 @@ t_process_info(Config) when is_list(Config) ->
 
     %% start_time is system time in seconds
     {start_time, StartTime} = process_info(self(), start_time),
-    true = (abs(StartTime - NowTime) =< 1),
+    true = (StartTime < NowTime),
+    true = (NowTime - StartTime < erlang:convert_time_unit(1, seconds, native)),
 
     {'EXIT',{badarg,_Info}} = (catch process_info('not_a_pid')),
     ok.

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2236,7 +2236,7 @@ process_flag(_Flag, _Value) ->
       {registered_name, [] | (Atom :: atom())} |
       {sequential_trace_token, [] | (SequentialTraceToken :: term())} |
       {stack_size, Size :: non_neg_integer()} |
-      {start_time, StartTime :: non_neg_integer()} |
+      {start_time, StartTime :: integer()} |
       {status, Status :: exiting | garbage_collecting | waiting | running | runnable | suspended} |
       {suspending,
        SuspendeeList :: [{Suspendee :: pid(),

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2191,6 +2191,7 @@ process_flag(_Flag, _Value) ->
       registered_name |
       sequential_trace_token |
       stack_size |
+      start_time |
       status |
       suspending |
       total_heap_size |
@@ -2235,6 +2236,7 @@ process_flag(_Flag, _Value) ->
       {registered_name, [] | (Atom :: atom())} |
       {sequential_trace_token, [] | (SequentialTraceToken :: term())} |
       {stack_size, Size :: non_neg_integer()} |
+      {start_time, StartTime :: non_neg_integer()} |
       {status, Status :: exiting | garbage_collecting | waiting | running | runnable | suspended} |
       {suspending,
        SuspendeeList :: [{Suspendee :: pid(),


### PR DESCRIPTION
This PR makes possible to get process start time.

Internal process struct already had approx_started field
containing system time at the moment the process was started.
Now it is possible to get this value via process_info/2.

This is useful for system analysis. Sometimes you want to know how long
given process is running, but currently you need logs or special code
(e.g. storing start time in process dictionary) to get that information.