### PR TITLE
Explicitly disable HiPE's range analysis

### DIFF
--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -31,6 +31,10 @@
 -include_lib("common_test/include/ct.hrl").
 -import(lists, [foreach/2]).
 
+%% The range analysis of the HiPE compiler results in a system limit error
+%% during compilation instead of at runtime, so do not perform this analysis.
+-compile([{hipe, [no_icode_range]}]).
+
 suite() ->
     [{ct_hooks,[ts_install_cth]},
      {timetrap, {minutes, 1}}].


### PR DESCRIPTION
when/if compiling this file to native code to check its exception
behaviour.  Related to the discussion in #1596.