### PR TITLE
fix win32 share filename join/split

### DIFF
--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -439,6 +439,10 @@ join(Name1, Name2) when is_atom(Name2) ->
 join1([UcLetter, $:|Rest], RelativeName, [], win32)
 when is_integer(UcLetter), UcLetter >= $A, UcLetter =< $Z ->
     join1(Rest, RelativeName, [$:, UcLetter+$a-$A], win32);
+join1([$\\,$\\|Rest], RelativeName, [], win32) ->
+    join1([$/,$/|Rest], RelativeName, [], win32);
+join1([$/,$/|Rest], RelativeName, [], win32) ->
+    join1(Rest, RelativeName, [$/,$/], win32);
 join1([$\\|Rest], RelativeName, Result, win32) ->
     join1([$/|Rest], RelativeName, Result, win32);
 join1([$/|Rest], RelativeName, [$., $/|Result], OsType) ->
@@ -449,6 +453,8 @@ join1([], [], Result, OsType) ->
     maybe_remove_dirsep(Result, OsType);
 join1([], RelativeName, [$:|Rest], win32) ->
     join1(RelativeName, [], [$:|Rest], win32);
+join1([], RelativeName, [$/,$/|Result], win32) ->
+    join1(RelativeName, [], [$/,$/|Result], win32);
 join1([], RelativeName, [$/|Result], OsType) ->
     join1(RelativeName, [], [$/|Result], OsType);
 join1([], RelativeName, [$., $/|Result], OsType) ->
@@ -467,6 +473,10 @@ join1([Atom|Rest], RelativeName, Result, OsType) when is_atom(Atom) ->
 join1b(<<UcLetter, $:, Rest/binary>>, RelativeName, [], win32)
 when is_integer(UcLetter), UcLetter >= $A, UcLetter =< $Z ->
     join1b(Rest, RelativeName, [$:, UcLetter+$a-$A], win32);
+join1b(<<$\\,$\\,Rest/binary>>, RelativeName, [], win32) ->
+    join1b(<<$/,$/,Rest/binary>>, RelativeName, [], win32);
+join1b(<<$/,$/,Rest/binary>>, RelativeName, [], win32) ->
+    join1b(Rest, RelativeName, [$/,$/], win32);
 join1b(<<$\\,Rest/binary>>, RelativeName, Result, win32) ->
     join1b(<<$/,Rest/binary>>, RelativeName, Result, win32);
 join1b(<<$/,Rest/binary>>, RelativeName, [$., $/|Result], OsType) ->
@@ -477,6 +487,8 @@ join1b(<<>>, <<>>, Result, OsType) ->
     list_to_binary(maybe_remove_dirsep(Result, OsType));
 join1b(<<>>, RelativeName, [$:|Rest], win32) ->
     join1b(RelativeName, <<>>, [$:|Rest], win32);
+join1b(<<>>, RelativeName, [$/,$/|Result], win32) ->
+    join1b(RelativeName, <<>>, [$/,$/|Result], win32);
 join1b(<<>>, RelativeName, [$/|Result], OsType) ->
     join1b(RelativeName, <<>>, [$/|Result], OsType);
 join1b(<<>>, RelativeName, [$., $/|Result], OsType) ->
@@ -490,6 +502,8 @@ maybe_remove_dirsep([$/, $:, Letter], win32) ->
     [Letter, $:, $/];
 maybe_remove_dirsep([$/], _) ->
     [$/];
+maybe_remove_dirsep([$/,$/|Name], win32) ->
+    [$/,$/|lists:reverse(Name)];
 maybe_remove_dirsep([$/|Name], _) ->
     lists:reverse(Name);
 maybe_remove_dirsep(Name, _) ->
@@ -679,6 +693,9 @@ win32_splitb(<<Letter0,$:,Rest/binary>>) when ?IS_DRIVELETTER(Letter0) ->
     Letter = fix_driveletter(Letter0),
     L = binary:split(Rest,[<<"/">>,<<"\\">>],[global]),
     [<<Letter,$:>> | [ X || X <- L, X =/= <<>> ]];
+win32_splitb(<<Slash,Slash,Rest/binary>>) when Slash =:= $\\ ->
+    L = binary:split(Rest,[<<"/">>,<<"\\">>],[global]),
+    [<<"//">> | [ X || X <- L, X =/= <<>> ]];
 win32_splitb(<<Slash,Rest/binary>>) when ((Slash =:= $\\) orelse (Slash =:= $/)) ->
     L = binary:split(Rest,[<<"/">>,<<"\\">>],[global]),
     [<<$/>> | [ X || X <- L, X =/= <<>> ]];
@@ -690,6 +707,8 @@ win32_splitb(Name) ->
 unix_split(Name) ->
     split(Name, [], unix).
 
+win32_split([$\\,$\\|Rest]) ->
+    split(Rest, [[$/,$/]], win32);
 win32_split([$\\|Rest]) ->
     win32_split([$/|Rest]);
 win32_split([X, $\\|Rest]) when is_integer(X) ->

--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -453,8 +453,8 @@ join1([], [], Result, OsType) ->
     maybe_remove_dirsep(Result, OsType);
 join1([], RelativeName, [$:|Rest], win32) ->
     join1(RelativeName, [], [$:|Rest], win32);
-join1([], RelativeName, [$/,$/|Result], win32) ->
-    join1(RelativeName, [], [$/,$/|Result], win32);
+%% REMOVE -- join1([], RelativeName, [$/,$/|Result], win32) ->
+%% REMOVE --     join1(RelativeName, [], [$/,$/|Result], win32);
 join1([], RelativeName, [$/|Result], OsType) ->
     join1(RelativeName, [], [$/|Result], OsType);
 join1([], RelativeName, [$., $/|Result], OsType) ->
@@ -502,8 +502,8 @@ maybe_remove_dirsep([$/, $:, Letter], win32) ->
     [Letter, $:, $/];
 maybe_remove_dirsep([$/], _) ->
     [$/];
-maybe_remove_dirsep([$/,$/|Name], win32) ->
-    [$/,$/|lists:reverse(Name)];
+maybe_remove_dirsep([$/,$/], win32) ->
+    [$/,$/];
 maybe_remove_dirsep([$/|Name], _) ->
     lists:reverse(Name);
 maybe_remove_dirsep(Name, _) ->
@@ -693,7 +693,7 @@ win32_splitb(<<Letter0,$:,Rest/binary>>) when ?IS_DRIVELETTER(Letter0) ->
     Letter = fix_driveletter(Letter0),
     L = binary:split(Rest,[<<"/">>,<<"\\">>],[global]),
     [<<Letter,$:>> | [ X || X <- L, X =/= <<>> ]];
-win32_splitb(<<Slash,Slash,Rest/binary>>) when Slash =:= $\\ ->
+win32_splitb(<<Slash,Slash,Rest/binary>>) when ((Slash =:= $\\) orelse (Slash =:= $/)) ->
     L = binary:split(Rest,[<<"/">>,<<"\\">>],[global]),
     [<<"//">> | [ X || X <- L, X =/= <<>> ]];
 win32_splitb(<<Slash,Rest/binary>>) when ((Slash =:= $\\) orelse (Slash =:= $/)) ->
@@ -707,7 +707,7 @@ win32_splitb(Name) ->
 unix_split(Name) ->
     split(Name, [], unix).
 
-win32_split([$\\,$\\|Rest]) ->
+win32_split([Slash,Slash|Rest]) when ((Slash =:= $\\) orelse (Slash =:= $/)) ->
     split(Rest, [[$/,$/]], win32);
 win32_split([$\\|Rest]) ->
     win32_split([$/|Rest]);

--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -453,8 +453,6 @@ join1([], [], Result, OsType) ->
     maybe_remove_dirsep(Result, OsType);
 join1([], RelativeName, [$:|Rest], win32) ->
     join1(RelativeName, [], [$:|Rest], win32);
-%% REMOVE -- join1([], RelativeName, [$/,$/|Result], win32) ->
-%% REMOVE --     join1(RelativeName, [], [$/,$/|Result], win32);
 join1([], RelativeName, [$/|Result], OsType) ->
     join1(RelativeName, [], [$/|Result], OsType);
 join1([], RelativeName, [$., $/|Result], OsType) ->

--- a/lib/stdlib/test/filename_SUITE.erl
+++ b/lib/stdlib/test/filename_SUITE.erl
@@ -107,6 +107,17 @@ absname(Config) when is_list(Config) ->
             [Drive|":/erlang/src"] = filename:absname([Drive|":erlang/src"]),
             "a:/erlang" = filename:absname("a:erlang"),
 
+            "//foo" = filename:absname("//foo"),
+            "//foo/bar" = filename:absname("//foo/bar"),
+            "//foo/\bar" = filename:absname("//foo/\bar"),
+            "//foo/bar/baz" = filename:absname("//foo/bar\\baz"),
+            "//foo/bar/baz" = filename:absname("//foo\\bar/baz"),
+            "//foo" = filename:absname("\\\\foo"),
+            "//foo/bar" = filename:absname("\\\\foo/bar"),
+            "//foo/\bar" = filename:absname("\\\\foo/\bar"),
+            "//foo/bar/baz" = filename:absname("\\\\foo/bar\\baz"),
+            "//foo/bar/baz" = filename:absname("\\\\foo\\bar/baz"),
+
             file:set_cwd(Cwd),
             ok;
         {unix, _} ->
@@ -166,6 +177,23 @@ absname_2(Config) when is_list(Config) ->
             [Drive|":/erlang/src"] = filename:absname([Drive|":erlang/src"],
                                                       [Drive|":/"]),
             "a:/erlang" = filename:absname("a:erlang", [Drive|":/"]),
+
+            "//foo" = filename:absname("foo","//"),
+            "//foo/bar" = filename:absname("foo/bar", "//"),
+            "//foo/bar" = filename:absname("bar", "//foo"),
+            "//bar" = filename:absname("/bar", "//foo"),
+            "//foo/bar/baz" = filename:absname("bar/baz", "//foo"),
+            "//bar/baz" = filename:absname("//bar/baz", "//foo"),
+            "//\bar" = filename:absname("/\bar", "//foo"),
+            "//foo" = filename:absname("foo","\\\\"),
+            "//foo/bar" = filename:absname("foo/bar", "\\\\"),
+            "//foo/bar" = filename:absname("bar", "\\\\foo"),
+            "//bar" = filename:absname("/bar", "\\\\foo"),
+            "//foo/bar/baz" = filename:absname("bar/baz", "\\\\foo"),
+            "//bar/baz" = filename:absname("\\\\bar/baz", "\\\\foo"),
+            "//\bar" = filename:absname("/\bar", "\\\\foo"),
+            "//bar/baz" = filename:absname("\\\\bar/baz", "//foo"),
+            "//bar/baz" = filename:absname("//bar/baz", "\\\\foo"),
 
             ok;
         _ ->
@@ -244,6 +272,18 @@ dirname(Config) when is_list(Config) ->
             "A:usr" = filename:dirname("A:usr/foo.erl"),
             "/usr" = filename:dirname("\\usr\\foo.erl"),
             "/" = filename:dirname("\\usr"),
+            "//foo/bar" = filename:dirname("//foo/bar/baz.erl"),
+            "//foo/\bar" = filename:dirname("//foo/\bar/baz.erl"),
+            "//foo/bar" = filename:dirname("//foo\\bar/baz.erl"),
+            "//foo/bar" = filename:dirname("\\\\foo/bar/baz.erl"),
+            "//foo/\bar" = filename:dirname("\\\\foo/\bar/baz.erl"),
+            "//foo/bar" = filename:dirname("\\\\foo\\bar/baz.erl"),
+            "//foo" = filename:dirname("//foo/baz.erl"),
+            "//foo" = filename:dirname("//foo/\baz.erl"),
+            "//foo" = filename:dirname("//foo\\baz.erl"),
+            "//foo" = filename:dirname("\\\\foo/baz.erl"),
+            "//foo" = filename:dirname("\\\\foo/\baz.erl"),
+            "//foo" = filename:dirname("\\\\foo\\baz.erl"),
             "A:" = filename:dirname("A:");
         _ -> true
     end,

--- a/lib/stdlib/test/filename_SUITE.erl
+++ b/lib/stdlib/test/filename_SUITE.erl
@@ -348,8 +348,27 @@ join(Config) when is_list(Config) ->
             "//foo" = filename:join("\\\\", "foo"),
             "//foo/bar" = filename:join("\\\\", "foo\\\\bar"),
             "//foo/bar/baz" = filename:join("\\\\foo", "bar\\\\baz"),
+            "//foo/bar/baz" = filename:join("\\\\foo", "bar\\baz"),
+            "//foo/bar/baz" = filename:join("\\\\foo\\bar", baz),
+            "//foo/\bar/baz" = filename:join("\\\\foo/\bar", baz),
+            "//foo/bar/baz" = filename:join("\\\\foo/bar", baz),
             "//bar/baz" = filename:join("\\\\foo", "\\\\bar\\baz"),
+            "//bar/baz" = filename:join("\\\\foo", "//bar\\baz"),
+            "//bar/baz" = filename:join("\\\\foo", "//bar/baz"),
+            "//bar/baz" = filename:join("\\\\foo", "\\\\bar/baz"),
             "//d/e/f/g" = filename:join("a//b/c", "//d//e/f/g"),
+            "//" = filename:join("//", ""),
+            "//foo" = filename:join("//", "foo"),
+            "//foo/bar" = filename:join("//", "foo\\\\bar"),
+            "//foo/bar/baz" = filename:join("//foo", "bar\\\\baz"),
+            "//foo/bar/baz" = filename:join("//foo", "bar\\baz"),
+            "//foo/bar/baz" = filename:join("//foo\\bar", baz),
+            "//foo/\bar/baz" = filename:join("//foo/\bar", baz),
+            "//foo/bar/baz" = filename:join("//foo/bar", baz),
+            "//bar/baz" = filename:join("//foo", "\\\\bar\\baz"),
+            "//bar/baz" = filename:join("//foo", "//bar\\baz"),
+            "//bar/baz" = filename:join("//foo", "//bar/baz"),
+            "//bar/baz" = filename:join("//foo", "\\\\bar/baz"),
             ok;
         _ ->
             "/" = filename:join(["//"]),
@@ -411,10 +430,14 @@ split(Config) when is_list(Config) ->
                 filename:split("a:msdev\\include"),
             ["//","foo"] =
                 filename:split("\\\\foo"),
+            ["//","foo"] =
+                filename:split("//foo"),
             ["//","foo","bar"] =
                 filename:split("\\\\foo\\\\bar"),
             ["//","foo","baz"] =
                 filename:split("\\\\foo\\baz"),
+            ["//","foo","baz"] =
+                filename:split("//foo\\baz"),
             ok;
         _ ->
 	    ok
@@ -725,7 +748,26 @@ join_bin(Config) when is_list(Config) ->
             <<"//foo/bar">> = filename:join(<<"\\\\">>, <<"foo\\\\bar">>),
             <<"//foo/bar/baz">> = filename:join(<<"\\\\foo">>, <<"bar\\\\baz">>),
             <<"//bar/baz">> = filename:join(<<"\\\\foo">>, <<"\\\\bar\\baz">>),
+            <<"//foo/bar/baz">> = filename:join(<<"\\\\foo\\bar">>, baz),
+            <<"//foo/\bar/baz">> = filename:join(<<"\\\\foo/\bar">>, baz),
+            <<"//foo/bar/baz">> = filename:join(<<"\\\\foo/bar">>, baz),
+            <<"//bar/baz">> = filename:join(<<"\\\\foo">>, <<"\\\\bar\\baz">>),
+            <<"//bar/baz">> = filename:join(<<"\\\\foo">>, <<"//bar\\baz">>),
+            <<"//bar/baz">> = filename:join(<<"\\\\foo">>, <<"//bar/baz">>),
+            <<"//bar/baz">> = filename:join(<<"\\\\foo">>, <<"\\\\bar/baz">>),
             <<"//d/e/f/g">> = filename:join([<<"a//b/c">>, <<"//d//e/f/g">>]),
+            <<"//">> = filename:join(<<"//">>, <<"">>),
+            <<"//foo">> = filename:join(<<"//">>, <<"foo">>),
+            <<"//foo/bar">> = filename:join(<<"//">>, <<"foo\\\\bar">>),
+            <<"//foo/bar/baz">> = filename:join(<<"//foo">>, <<"bar\\\\baz">>),
+            <<"//bar/baz">> = filename:join(<<"//foo">>, <<"\\\\bar\\baz">>),
+            <<"//foo/bar/baz">> = filename:join(<<"//foo\\bar">>, baz),
+            <<"//foo/\bar/baz">> = filename:join(<<"//foo/\bar">>, baz),
+            <<"//foo/bar/baz">> = filename:join(<<"//foo/bar">>, baz),
+            <<"//bar/baz">> = filename:join(<<"//foo">>, <<"\\\\bar\\baz">>),
+            <<"//bar/baz">> = filename:join(<<"//foo">>, <<"//bar\\baz">>),
+            <<"//bar/baz">> = filename:join(<<"//foo">>, <<"//bar/baz">>),
+            <<"//bar/baz">> = filename:join(<<"//foo">>, <<"\\\\bar/baz">>),
             ok;
         _ ->
             <<"/">> = filename:join([<<"//">>]),
@@ -778,10 +820,14 @@ split_bin(Config) when is_list(Config) ->
                 filename:split(<<"a:msdev\\include">>),
             [<<"//">>,<<"foo">>] =
                 filename:split(<<"\\\\foo">>),
+            [<<"//">>,<<"foo">>] =
+                filename:split(<<"//foo">>),
             [<<"//">>,<<"foo">>,<<"bar">>] =
                 filename:split(<<"\\\\foo\\\\bar">>),
             [<<"//">>,<<"foo">>,<<"baz">>] =
                 filename:split(<<"\\\\foo\\baz">>),
+            [<<"//">>,<<"foo">>,<<"baz">>] =
+                filename:split(<<"//foo\\baz">>),
             ok;
         _ ->
             ok

--- a/lib/stdlib/test/filename_SUITE.erl
+++ b/lib/stdlib/test/filename_SUITE.erl
@@ -289,7 +289,6 @@ join(Config) when is_list(Config) ->
     %% join/1 and join/2 (OTP-12158) by using help function
     %% filename_join/2.
     "/" = filename:join(["/"]),
-    "/" = filename:join(["//"]),
     "usr/foo.erl" = filename_join("usr","foo.erl"),
     "/src/foo.erl" = filename_join(usr, "/src/foo.erl"),
     "/src/foo.erl" = filename_join("/src/",'foo.erl'),
@@ -301,7 +300,6 @@ join(Config) when is_list(Config) ->
     "a/b/c/d/e/f/g" = filename_join("a//b/c/", "d//e/f/g"),
     "a/b/c/d/e/f/g" = filename_join("a//b/c", "d//e/f/g"),
     "/d/e/f/g" = filename_join("a//b/c", "/d//e/f/g"),
-    "/d/e/f/g" = filename:join("a//b/c", "//d//e/f/g"),
 
     "foo/bar" = filename_join([$f,$o,$o,$/,[]], "bar"),
 
@@ -332,6 +330,7 @@ join(Config) when is_list(Config) ->
 
     case os:type() of
         {win32, _} ->
+            "//" = filename:join(["//"]),
             "d:/" = filename:join(["D:/"]),
             "d:/" = filename:join(["D:\\"]),
             "d:/abc" = filename_join("D:/", "abc"),
@@ -345,8 +344,16 @@ join(Config) when is_list(Config) ->
             "c:/usr/foo.erl" = filename:join(["A:","C:/usr","foo.erl"]),
             "c:usr/foo.erl" = filename:join(["A:","C:usr","foo.erl"]),
             "d:/foo" = filename:join([$D, $:, $/, []], "foo"),
+            "//" = filename:join("\\\\", ""),
+            "//foo" = filename:join("\\\\", "foo"),
+            "//foo/bar" = filename:join("\\\\", "foo\\\\bar"),
+            "//foo/bar/baz" = filename:join("\\\\foo", "bar\\\\baz"),
+            "//bar/baz" = filename:join("\\\\foo", "\\\\bar\\baz"),
+            "//d/e/f/g" = filename:join("a//b/c", "//d//e/f/g"),
             ok;
         _ ->
+            "/" = filename:join(["//"]),
+            "/d/e/f/g" = filename:join("a//b/c", "//d//e/f/g"),
             ok
     end.
 
@@ -402,6 +409,12 @@ split(Config) when is_list(Config) ->
                 filename:split("a:\\msdev\\include"),
             ["a:","msdev","include"] =
                 filename:split("a:msdev\\include"),
+            ["//","foo"] =
+                filename:split("\\\\foo"),
+            ["//","foo","bar"] =
+                filename:split("\\\\foo\\\\bar"),
+            ["//","foo","baz"] =
+                filename:split("\\\\foo\\baz"),
             ok;
         _ ->
 	    ok
@@ -630,7 +643,6 @@ extension_bin(Config) when is_list(Config) ->
     
 join_bin(Config) when is_list(Config) ->
     <<"/">> = filename:join([<<"/">>]),
-    <<"/">> = filename:join([<<"//">>]),
     <<"usr/foo.erl">> = filename:join(<<"usr">>,<<"foo.erl">>),
     <<"/src/foo.erl">> = filename:join(usr, <<"/src/foo.erl">>),
     <<"/src/foo.erl">> = filename:join([<<"/src/">>,'foo.erl']),
@@ -642,7 +654,6 @@ join_bin(Config) when is_list(Config) ->
     <<"a/b/c/d/e/f/g">> = filename:join([<<"a//b/c/">>, <<"d//e/f/g">>]),
     <<"a/b/c/d/e/f/g">> = filename:join([<<"a//b/c">>, <<"d//e/f/g">>]),
     <<"/d/e/f/g">> = filename:join([<<"a//b/c">>, <<"/d//e/f/g">>]),
-    <<"/d/e/f/g">> = filename:join([<<"a//b/c">>, <<"//d//e/f/g">>]),
 
     <<"foo/bar">> = filename:join([$f,$o,$o,$/,[]], <<"bar">>),
 
@@ -695,6 +706,7 @@ join_bin(Config) when is_list(Config) ->
 
     case os:type() of
         {win32, _} ->
+            <<"//">> = filename:join([<<"//">>]),
             <<"d:/">> = filename:join([<<"D:/">>]),
             <<"d:/">> = filename:join([<<"D:\\">>]),
             <<"d:/abc">> = filename:join([<<"D:/">>, <<"abc">>]),
@@ -708,8 +720,16 @@ join_bin(Config) when is_list(Config) ->
             <<"c:/usr/foo.erl">> = filename:join([<<"A:">>,<<"C:/usr">>,<<"foo.erl">>]),
             <<"c:usr/foo.erl">> = filename:join([<<"A:">>,<<"C:usr">>,<<"foo.erl">>]),
             <<"d:/foo">> = filename:join([$D, $:, $/, []], <<"foo">>),
+            <<"//">> = filename:join(<<"\\\\">>, <<"">>),
+            <<"//foo">> = filename:join(<<"\\\\">>, <<"foo">>),
+            <<"//foo/bar">> = filename:join(<<"\\\\">>, <<"foo\\\\bar">>),
+            <<"//foo/bar/baz">> = filename:join(<<"\\\\foo">>, <<"bar\\\\baz">>),
+            <<"//bar/baz">> = filename:join(<<"\\\\foo">>, <<"\\\\bar\\baz">>),
+            <<"//d/e/f/g">> = filename:join([<<"a//b/c">>, <<"//d//e/f/g">>]),
             ok;
         _ ->
+            <<"/">> = filename:join([<<"//">>]),
+            <<"/d/e/f/g">> = filename:join([<<"a//b/c">>, <<"//d//e/f/g">>]),
             ok
     end.
 
@@ -756,6 +776,12 @@ split_bin(Config) when is_list(Config) ->
                 filename:split(<<"a:\\msdev\\include">>),
             [<<"a:">>,<<"msdev">>,<<"include">>] =
                 filename:split(<<"a:msdev\\include">>),
+            [<<"//">>,<<"foo">>] =
+                filename:split(<<"\\\\foo">>),
+            [<<"//">>,<<"foo">>,<<"bar">>] =
+                filename:split(<<"\\\\foo\\\\bar">>),
+            [<<"//">>,<<"foo">>,<<"baz">>] =
+                filename:split(<<"\\\\foo\\baz">>),
             ok;
         _ ->
             ok


### PR DESCRIPTION
Previously : https://github.com/erlang/otp/pull/1591

#### Currently
``` erlang
> filename:join("\\\\", "foo").
"/foo"
> filename:split("\\\\foo").
["/","foo"]
```
#### Fixed by this PR
``` erlang
> filename:join("\\\\", "foo").
"//test"
> filename:split("\\\\foo").
["//","test"]
```

As per instructions https://github.com/erlang/otp/pull/1591#issuecomment-336933567
A clean PR with single commit