### PR TITLE
Fix hipe bug in binary <<X/utf32>> construction

### DIFF
--- a/erts/emulator/hipe/hipe_amd64_bifs.m4
+++ b/erts/emulator/hipe/hipe_amd64_bifs.m4
@@ -463,6 +463,43 @@ ASYM($1):
 #endif')
 
 /*
+ * nogc_bif_interface_1(nbif_name, cbif_name)
+ *
+ * Generate native interface for a bif with implicit P
+ * The bif can fail but cannot do GC.
+ */
+
+define(nogc_bif_interface_1,
+`
+#ifndef HAVE_$1
+#`define' HAVE_$1
+	TEXT
+	.align	4
+	GLOBAL(ASYM($1))
+ASYM($1):
+	/* set up the parameters */
+	movq	P, %rdi
+	NBIF_ARG(%rsi,1,0)
+
+	/* make the call on the C stack */
+	SWITCH_ERLANG_TO_C
+	pushq	%rsi
+	movq	%rsp, %rsi	/* Eterm* BIF__ARGS */
+	sub	$(8), %rsp	/* stack frame 16-byte alignment */
+	CALL_BIF($2)
+	add	$(1*8 + 8), %rsp
+	SWITCH_C_TO_ERLANG
+
+	/* throw exception if failure, otherwise return */
+	TEST_GOT_EXN
+	jz	nbif_1_simple_exception
+	NBIF_RET(1)
+	SET_SIZE(ASYM($1))
+	TYPE_FUNCTION(ASYM($1))
+#endif')
+
+
+/*
  * noproc_primop_interface_0(nbif_name, cbif_name)
  * noproc_primop_interface_1(nbif_name, cbif_name)
  * noproc_primop_interface_2(nbif_name, cbif_name)

--- a/erts/emulator/hipe/hipe_bif0.tab
+++ b/erts/emulator/hipe/hipe_bif0.tab
@@ -140,3 +140,4 @@ atom bs_validate_unicode_retract
 atom emulate_fpe
 atom emasculate_binary
 atom is_divisible
+atom is_unicode

--- a/erts/emulator/hipe/hipe_bif_list.m4
+++ b/erts/emulator/hipe/hipe_bif_list.m4
@@ -223,6 +223,7 @@ standard_bif_interface_3(nbif_find_na_or_make_stub, hipe_find_na_or_make_stub)
 standard_bif_interface_2(nbif_nonclosure_address, hipe_nonclosure_address)
 nocons_nofail_primop_interface_0(nbif_fclearerror_error, hipe_fclearerror_error)
 standard_bif_interface_2(nbif_is_divisible, hipe_is_divisible)
+noproc_primop_interface_1(nbif_is_unicode, hipe_is_unicode)
 
 /*
  * Mbox primops with implicit P parameter.

--- a/erts/emulator/hipe/hipe_bif_list.m4
+++ b/erts/emulator/hipe/hipe_bif_list.m4
@@ -247,7 +247,11 @@ nofail_primop_interface_3(nbif_bs_get_float_2, erts_bs_get_float_2)
 standard_bif_interface_3(nbif_bs_put_utf8, hipe_bs_put_utf8)
 standard_bif_interface_3(nbif_bs_put_utf16be, hipe_bs_put_utf16be)
 standard_bif_interface_3(nbif_bs_put_utf16le, hipe_bs_put_utf16le)
+ifdef(`nogc_bif_interface_1',`
+nogc_bif_interface_1(nbif_bs_validate_unicode, hipe_bs_validate_unicode)
+',`
 standard_bif_interface_1(nbif_bs_validate_unicode, hipe_bs_validate_unicode)
+')
 
 /*
  * Bit-syntax primops without any P parameter.

--- a/erts/emulator/hipe/hipe_native_bif.c
+++ b/erts/emulator/hipe/hipe_native_bif.c
@@ -495,6 +495,12 @@ BIF_RETTYPE nbif_impl_hipe_bs_validate_unicode(NBIF_ALIST_1)
     return NIL;
 }
 
+Uint hipe_is_unicode(Eterm arg)
+{
+    return (Uint) validate_unicode(arg);
+}
+
+
 int hipe_bs_validate_unicode_retract(ErlBinMatchBuffer* mb, Eterm arg)
 {
     if (!validate_unicode(arg)) {

--- a/erts/emulator/hipe/hipe_native_bif.h
+++ b/erts/emulator/hipe/hipe_native_bif.h
@@ -67,6 +67,7 @@ AEXTERN(Eterm,nbif_bs_put_utf16be,(Process*,Eterm,byte*,unsigned int));
 AEXTERN(Eterm,nbif_bs_put_utf16le,(Process*,Eterm,byte*,unsigned int));
 AEXTERN(Eterm,nbif_bs_get_utf16,(void));
 AEXTERN(Eterm,nbif_bs_validate_unicode,(Process*,Eterm));
+AEXTERN(Uint,nbif_is_unicode,(Eterm));
 AEXTERN(Eterm,nbif_bs_validate_unicode_retract,(void));
 AEXTERN(void,nbif_is_divisible,(Process*,Uint,Uint));
 
@@ -92,6 +93,7 @@ Eterm hipe_bs_utf16_size(Eterm);
 BIF_RETTYPE nbif_impl_hipe_bs_put_utf16be(NBIF_ALIST_3);
 BIF_RETTYPE nbif_impl_hipe_bs_put_utf16le(NBIF_ALIST_3);
 BIF_RETTYPE nbif_impl_hipe_bs_validate_unicode(NBIF_ALIST_1);
+Uint hipe_is_unicode(Eterm);
 struct erl_bin_match_buffer;
 int hipe_bs_validate_unicode_retract(struct erl_bin_match_buffer*, Eterm);
 BIF_RETTYPE nbif_impl_hipe_is_divisible(NBIF_ALIST_2);

--- a/erts/emulator/hipe/hipe_primops.h
+++ b/erts/emulator/hipe/hipe_primops.h
@@ -66,6 +66,7 @@ PRIMOP_LIST(am_bs_put_utf16be, &nbif_bs_put_utf16be)
 PRIMOP_LIST(am_bs_put_utf16le, &nbif_bs_put_utf16le)
 PRIMOP_LIST(am_bs_get_utf16, &nbif_bs_get_utf16)
 PRIMOP_LIST(am_bs_validate_unicode, &nbif_bs_validate_unicode)
+PRIMOP_LIST(am_is_unicode, &nbif_is_unicode)
 PRIMOP_LIST(am_bs_validate_unicode_retract, &nbif_bs_validate_unicode_retract)
 
 PRIMOP_LIST(am_is_divisible, &nbif_is_divisible)

--- a/lib/hipe/main/hipe.app.src
+++ b/lib/hipe/main/hipe.app.src
@@ -236,4 +236,4 @@
   {applications, [kernel,stdlib]},
   {env, []},
   {runtime_dependencies, ["syntax_tools-1.6.14","stdlib-3.4","kernel-5.3",
-			  "erts-9.0","compiler-5.0"]}]}.
+			  "erts-9.2","compiler-5.0"]}]}.

--- a/lib/hipe/rtl/hipe_rtl_binary_construct.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_construct.erl
@@ -195,8 +195,13 @@ gen_rtl(BsOP, Dst, Args, TrueLblName, FalseLblName, SystemLimitLblName, ConstTab
 
 	  bs_validate_unicode ->
 	    [_Arg] = Args,
-	    [hipe_rtl:mk_call([], bs_validate_unicode, Args,
-			      TrueLblName, FalseLblName, not_remote)];
+            [IsUnicode] = create_regs(1),
+            RetLbl = hipe_rtl:mk_new_label(),
+            [hipe_rtl:mk_call([IsUnicode], is_unicode, Args,
+                              hipe_rtl:label_name(RetLbl), [], not_remote),
+             RetLbl,
+             hipe_rtl:mk_branch(IsUnicode, ne, hipe_rtl:mk_imm(0),
+                                TrueLblName, FalseLblName, 0.99)];
 
 	  bs_final ->
 	    Zero = hipe_rtl:mk_imm(0),


### PR DESCRIPTION
This is a x86_64-only fix for hipe compiled code running binary constructions like

`<<X/utf32>>`

The **problem** is the generated code calls bif/primop `hipe_bs_validate_unicode` before it writes to the binary. But `hipe_bs_validate_unicode` may trigger GC in which case the binary data is written to the old deallocated heap and the constructed binary on the new heap will contain random bytes.

My **solution** is to introduce a new bif wrapper `nogc_bif_interface_1` for `hipe_bs_validate_unicode` that never triggers GC. So far I've only done it for x86_64.

To write test code that reliably **reproduces** the scenario where `hipe_bs_validate_unicode` will trigger GC is not trivial. Instead I did a commit where `hipe_bs_validate_unicode` always trigger GC. Remove the top revert-commit, (re)build the VM, compile the supplied module `t` as native, run `t:go()` and watch `<<X/utf32>>` return random bytes.

@kostis @mikpe 

**Is there a better way to fix this? Maybe change the generated native code.**



