### PR TITLE
HiPE: Support for literal tag, tests and bugfixes

### DIFF
--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -55,9 +55,6 @@ struct erl_node_; /* Declared in erl_node_tables.h */
 #if defined(ARCH_64)
 #  define TAG_PTR_MASK__	0x7
 #  if !defined(ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION)
-#    ifdef HIPE
-#      error Hipe on 64-bit needs a real mmap as it does not support the literal tag
-#    endif
 #    define TAG_LITERAL_PTR	0x4
 #  else
 #    undef TAG_LITERAL_PTR

--- a/erts/emulator/hipe/hipe_bif_list.m4
+++ b/erts/emulator/hipe/hipe_bif_list.m4
@@ -222,7 +222,7 @@ standard_bif_interface_2(nbif_rethrow, hipe_rethrow)
 standard_bif_interface_3(nbif_find_na_or_make_stub, hipe_find_na_or_make_stub)
 standard_bif_interface_2(nbif_nonclosure_address, hipe_nonclosure_address)
 nocons_nofail_primop_interface_0(nbif_fclearerror_error, hipe_fclearerror_error)
-standard_bif_interface_2(nbif_is_divisible, hipe_is_divisible)
+noproc_primop_interface_2(nbif_is_divisible, hipe_is_divisible)
 noproc_primop_interface_1(nbif_is_unicode, hipe_is_unicode)
 
 /*

--- a/erts/emulator/hipe/hipe_mkliterals.c
+++ b/erts/emulator/hipe/hipe_mkliterals.c
@@ -462,6 +462,15 @@ static const struct rts_param rts_params[] = {
       0
 #endif
     },
+    /* This flag is always defined, but its value is configuration-dependent. */
+    { 17, "ERTS_USE_LITERAL_TAG",
+      1,
+#if defined(TAG_LITERAL_PTR)
+      1
+#else
+      0
+#endif
+    },
     /* This parameter is always defined, but its value depends on ERTS_SMP. */
     { 19, "MSG_MESSAGE",
       1, offsetof(struct erl_mesg, m[0])

--- a/erts/emulator/hipe/hipe_native_bif.c
+++ b/erts/emulator/hipe/hipe_native_bif.c
@@ -506,16 +506,12 @@ int hipe_bs_validate_unicode_retract(ErlBinMatchBuffer* mb, Eterm arg)
     return 1;
 }
 
-/* Called via standard_bif_interface_2 */
-BIF_RETTYPE nbif_impl_hipe_is_divisible(NBIF_ALIST_2)
+Uint hipe_is_divisible(Uint dividend, Uint divisor)
 {
-    /* Arguments are Eterm-sized unsigned integers */
-    Uint dividend = BIF_ARG_1;
-    Uint divisor = BIF_ARG_2;
     if (dividend % divisor) {
-	BIF_ERROR(BIF_P, BADARG);
+        return 0;
     } else {
-	return NIL;
+        return 1;
     }
 }
 

--- a/erts/emulator/hipe/hipe_native_bif.h
+++ b/erts/emulator/hipe/hipe_native_bif.h
@@ -69,7 +69,7 @@ AEXTERN(Eterm,nbif_bs_get_utf16,(void));
 AEXTERN(Eterm,nbif_bs_validate_unicode,(Process*,Eterm));
 AEXTERN(Uint,nbif_is_unicode,(Eterm));
 AEXTERN(Eterm,nbif_bs_validate_unicode_retract,(void));
-AEXTERN(void,nbif_is_divisible,(Process*,Uint,Uint));
+AEXTERN(Uint,nbif_is_divisible,(Uint,Uint));
 
 AEXTERN(void,nbif_select_msg,(Process*));
 AEXTERN(Eterm,nbif_cmp_2,(void));
@@ -96,7 +96,7 @@ BIF_RETTYPE nbif_impl_hipe_bs_validate_unicode(NBIF_ALIST_1);
 Uint hipe_is_unicode(Eterm);
 struct erl_bin_match_buffer;
 int hipe_bs_validate_unicode_retract(struct erl_bin_match_buffer*, Eterm);
-BIF_RETTYPE nbif_impl_hipe_is_divisible(NBIF_ALIST_2);
+Uint hipe_is_divisible(Uint, Uint);
 
 #ifdef NO_FPE_SIGNALS
 AEXTERN(void,nbif_emulate_fpe,(Process*));

--- a/lib/hipe/icode/hipe_icode.erl
+++ b/lib/hipe/icode/hipe_icode.erl
@@ -515,10 +515,12 @@
 	 annotate_variable/2,  %% annotate_var_or_reg(VarOrReg, Type)
 	 unannotate_variable/1,%% unannotate_var_or_reg(VarOrReg)
 	 mk_reg/1,               %% mk_reg(Id)
+	 mk_reg_gcsafe/1,        %% mk_reg_gcsafe(Id)
 	 mk_fvar/1,              %% mk_fvar(Id)
 	 mk_new_var/0,           %% mk_new_var()
 	 mk_new_fvar/0,          %% mk_new_fvar()
 	 mk_new_reg/0,           %% mk_new_reg()
+	 mk_new_reg_gcsafe/0,    %% mk_new_reg_gcsafe()
 	 mk_phi/1,               %% mk_phi(Id)
 	 mk_phi/2                %% mk_phi(Id, ArgList)
 	]).
@@ -1260,14 +1262,22 @@ is_var(_) -> false.
 -spec mk_reg(non_neg_integer()) -> #icode_variable{kind::'reg'}.
 mk_reg(V) -> #icode_variable{name=V, kind=reg}.
 
--spec reg_name(#icode_variable{kind::'reg'}) -> non_neg_integer().
-reg_name(#icode_variable{name=Name, kind=reg}) -> Name.
+-spec mk_reg_gcsafe(non_neg_integer()) -> #icode_variable{kind::'reg_gcsafe'}.
+mk_reg_gcsafe(V) -> #icode_variable{name=V, kind=reg_gcsafe}.
 
--spec reg_is_gcsafe(#icode_variable{kind::'reg'}) -> 'false'.
-reg_is_gcsafe(#icode_variable{kind=reg}) -> false. % for now
+-spec reg_name(#icode_variable{kind::'reg'|'reg_gcsafe'})
+	      -> non_neg_integer().
+reg_name(#icode_variable{name=Name, kind=reg})        -> Name;
+reg_name(#icode_variable{name=Name, kind=reg_gcsafe}) -> Name.
+
+-spec reg_is_gcsafe(#icode_variable{kind::'reg'}) -> 'false';
+		   (#icode_variable{kind::'reg_gcsafe'}) -> 'true'.
+reg_is_gcsafe(#icode_variable{kind=reg})        -> false;
+reg_is_gcsafe(#icode_variable{kind=reg_gcsafe}) -> true.
 
 -spec is_reg(icode_argument()) -> boolean().
-is_reg(#icode_variable{kind=reg}) -> true;
+is_reg(#icode_variable{kind=reg})        -> true;
+is_reg(#icode_variable{kind=reg_gcsafe}) -> true;
 is_reg(_) -> false.
 
 -spec mk_fvar(non_neg_integer()) -> #icode_variable{kind::'fvar'}.
@@ -1674,6 +1684,16 @@ mk_new_fvar() ->
 -spec mk_new_reg() -> icode_reg().
 mk_new_reg() ->
   mk_reg(hipe_gensym:get_next_var(icode)).
+
+%%
+%% @doc Makes a new gcsafe register; that is, a register that is allowed to be
+%% live over calls and other operations that might cause GCs and thus move heap
+%% data around.
+%%
+
+-spec mk_new_reg_gcsafe() -> icode_reg().
+mk_new_reg_gcsafe() ->
+  mk_reg_gcsafe(hipe_gensym:get_next_var(icode)).
 
 %%
 %% @doc Makes a new label.

--- a/lib/hipe/icode/hipe_icode.hrl
+++ b/lib/hipe/icode/hipe_icode.hrl
@@ -41,9 +41,9 @@
 
 -type variable_annotation() :: {atom(), any(), fun((any()) -> string())}.
 
--record(icode_variable, {name :: non_neg_integer(), 
-			 kind :: 'var' | 'reg' | 'fvar',
-			 annotation = [] :: [] | variable_annotation()}). 
+-record(icode_variable, {name :: non_neg_integer(),
+			 kind :: 'var' | 'reg' | 'reg_gcsafe' | 'fvar',
+			 annotation = [] :: [] | variable_annotation()}).
 
 %%---------------------------------------------------------------------
 %% Type declarations for Icode instructions
@@ -66,7 +66,7 @@
 -type icode_funcall()   :: mfa() | icode_primop().
 
 -type icode_var()	:: #icode_variable{kind::'var'}.
--type icode_reg()	:: #icode_variable{kind::'reg'}.
+-type icode_reg()	:: #icode_variable{kind::'reg'|'reg_gcsafe'}.
 -type icode_fvar()	:: #icode_variable{kind::'fvar'}.
 -type icode_argument()	:: #icode_const{} | #icode_variable{}.
 -type icode_term_arg()	:: icode_var() | #icode_const{}.

--- a/lib/hipe/icode/hipe_icode_liveness.erl
+++ b/lib/hipe/icode/hipe_icode_liveness.erl
@@ -77,6 +77,7 @@ print_var(#icode_variable{name=V, kind=Kind, annotation=T}) ->
   case Kind of
     var -> io:format("v~p", [V]);
     reg -> io:format("r~p", [V]);
+    reg_gcsafe -> io:format("rs~p", [V]);
     fvar -> io:format("fv~p", [V])
   end,
   case T of

--- a/lib/hipe/icode/hipe_icode_pp.erl
+++ b/lib/hipe/icode/hipe_icode_pp.erl
@@ -230,7 +230,10 @@ pp_arg(Dev, Arg) ->
 	  case hipe_icode:is_reg(Arg) of
 	    true ->
 	      N = hipe_icode:reg_name(Arg),
-	      io:format(Dev, "r~p", [N]);
+	      case hipe_icode:reg_is_gcsafe(Arg) of
+		true  -> io:format(Dev, "rs~p", [N]);
+		false -> io:format(Dev, "r~p", [N])
+	      end;
 	    false ->
 	      N = hipe_icode:fvar_name(Arg),
 	      io:format(Dev, "fv~p", [N])

--- a/lib/hipe/main/hipe.app.src
+++ b/lib/hipe/main/hipe.app.src
@@ -179,6 +179,7 @@
 	     hipe_rtl_to_sparc,
 	     hipe_rtl_to_x86,
 	     hipe_rtl_varmap,
+	     hipe_rtl_verify_gcsafe,
 	     hipe_segment_trees,
 	     hipe_sdi,
 	     hipe_sparc,

--- a/lib/hipe/main/hipe.erl
+++ b/lib/hipe/main/hipe.erl
@@ -1414,6 +1414,7 @@ opt_keys() ->
      use_clusters,
      use_jumptable,
      verbose,
+     verify_gcsafe,
      %% verbose_spills,
      x87].
 
@@ -1510,7 +1511,8 @@ opt_negations() ->
    {no_use_callgraph, use_callgraph},
    {no_use_clusters, use_clusters},
    {no_use_inline_atom_search, use_inline_atom_search},
-   {no_use_indexing, use_indexing}].
+   {no_use_indexing, use_indexing},
+   {no_verify_gcsafe, verify_gcsafe}].
 
 %% Don't use negative forms in right-hand sides of aliases and expansions!
 %% We only expand negations once, before the other expansions are done.

--- a/lib/hipe/main/hipe_main.erl
+++ b/lib/hipe/main/hipe_main.erl
@@ -410,6 +410,11 @@ icode_to_rtl(MFA, Icode, Options, Servers) ->
         hipe_llvm_liveness:analyze(RtlCfg4)
     end,
   pp(RtlCfg5, MFA, rtl, pp_rtl, Options, Servers),
+  case proplists:get_bool(verify_gcsafe, Options) of
+    false -> ok;
+    true ->
+      ok = hipe_rtl_verify_gcsafe:check(RtlCfg5)
+  end,
   LinearRTL1 = hipe_rtl_cfg:linearize(RtlCfg5),
   LinearRTL2 = hipe_rtl_cleanup_const:cleanup(LinearRTL1),
   %% hipe_rtl:pp(standard_io, LinearRTL2),

--- a/lib/hipe/rtl/Makefile
+++ b/lib/hipe/rtl/Makefile
@@ -50,7 +50,7 @@ HIPE_MODULES = hipe_rtl hipe_rtl_cfg \
 	  hipe_rtl_ssa hipe_rtl_ssa_const_prop \
 	  hipe_rtl_cleanup_const hipe_rtl_symbolic hipe_rtl_lcm \
 	  hipe_rtl_ssapre hipe_rtl_binary hipe_rtl_ssa_avail_expr \
-	  hipe_rtl_arch hipe_tagscheme
+	  hipe_rtl_arch hipe_tagscheme hipe_rtl_verify_gcsafe
 else
 HIPE_MODULES =
 endif

--- a/lib/hipe/rtl/hipe_rtl.erl
+++ b/lib/hipe/rtl/hipe_rtl.erl
@@ -1740,7 +1740,10 @@ pp_reg(Dev, Arg) ->
     true ->
       pp_hard_reg(Dev, reg_index(Arg));
     false ->
-      io:format(Dev, "r~w", [reg_index(Arg)])
+      case reg_is_gcsafe(Arg) of
+        true -> io:format(Dev, "rs~w", [reg_index(Arg)]);
+        false -> io:format(Dev, "r~w", [reg_index(Arg)])
+      end
   end.
 
 pp_var(Dev, Arg) ->

--- a/lib/hipe/rtl/hipe_rtl_binary_construct.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_construct.erl
@@ -865,7 +865,7 @@ get_base_offset_size(Binary, SrcBase, SrcOffset, SrcSize, FLName) ->
    JoinLbl,
    hipe_tagscheme:test_heap_binary(Orig, HeapLblName, REFCLblName),
    HeapLbl,
-   hipe_rtl:mk_alu(SrcBase, Orig, add, hipe_rtl:mk_imm(?HEAP_BIN_DATA-2)),
+   hipe_tagscheme:get_field_addr_from_term({heap_bin, {data, 0}}, Orig, SrcBase),
    hipe_rtl:mk_goto(EndLblName),
    REFCLbl,
    hipe_tagscheme:get_field_from_term({proc_bin,bytes}, Orig, SrcBase),

--- a/lib/hipe/rtl/hipe_rtl_binary_construct.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_construct.erl
@@ -359,7 +359,8 @@ not_writable_code(Bin, SizeReg, Dst, Base, Offset, Unit,
 allocate_writable(Dst, Base, UsedBytes, TotBytes, TotSize) ->
   Zero = hipe_rtl:mk_imm(0),
   [NextLbl] = create_lbls(1),
-  [EndSubSize, EndSubBitSize, ProcBin] = create_regs(3),
+  [EndSubSize, EndSubBitSize] = create_regs(2),
+  [ProcBin] = create_unsafe_regs(1),
   [hipe_rtl:mk_call([Base], bs_allocate, [UsedBytes],
 		    hipe_rtl:label_name(NextLbl), [], not_remote),
    NextLbl,
@@ -586,12 +587,12 @@ const_init2(Size, Dst, Base, Offset, TrueLblName) ->
     false ->
       ByteSize = hipe_rtl:mk_new_reg(),
       [hipe_rtl:mk_gctest(?PROC_BIN_WORDSIZE+?SUB_BIN_WORDSIZE),
-       hipe_rtl:mk_move(Offset, hipe_rtl:mk_imm(0)),
        hipe_rtl:mk_move(ByteSize, hipe_rtl:mk_imm(Size)),
        hipe_rtl:mk_call([Base], bs_allocate, [ByteSize],
 			hipe_rtl:label_name(NextLbl), [], not_remote),
        NextLbl,
        hipe_tagscheme:create_refc_binary(Base, ByteSize, Dst),
+       hipe_rtl:mk_move(Offset, hipe_rtl:mk_imm(0)),
        hipe_rtl:mk_goto(TrueLblName)]
   end.
 
@@ -634,13 +635,12 @@ var_init2(Size, Dst, Base, Offset, TrueLblName, SystemLimitLblName, FalseLblName
   Log2WordSize = hipe_rtl_arch:log2_word_size(),
   WordSize = hipe_rtl_arch:word_size(),
   [ContLbl, HeapLbl, REFCLbl, NextLbl] = create_lbls(4),
-  [USize, Tmp] = create_unsafe_regs(2),
+  [USize, Tmp] = create_regs(2),
   [get_word_integer(Size, USize, SystemLimitLblName, FalseLblName),
    hipe_rtl:mk_branch(USize, leu, hipe_rtl:mk_imm(?MAX_BINSIZE),
 		      hipe_rtl:label_name(ContLbl),
 		      SystemLimitLblName),
    ContLbl,
-   hipe_rtl:mk_move(Offset, hipe_rtl:mk_imm(0)),
    hipe_rtl:mk_branch(USize, leu, hipe_rtl:mk_imm(?MAX_HEAP_BIN_SIZE),
 		      hipe_rtl:label_name(HeapLbl),
 		      hipe_rtl:label_name(REFCLbl)),
@@ -650,6 +650,7 @@ var_init2(Size, Dst, Base, Offset, TrueLblName, SystemLimitLblName, FalseLblName
    hipe_rtl:mk_alu(Tmp, Tmp, add, hipe_rtl:mk_imm(?SUB_BIN_WORDSIZE)),
    hipe_rtl:mk_gctest(Tmp),
    hipe_tagscheme:create_heap_binary(Base, USize, Dst),
+   hipe_rtl:mk_move(Offset, hipe_rtl:mk_imm(0)),
    hipe_rtl:mk_goto(TrueLblName),
    REFCLbl,
    hipe_rtl:mk_gctest(?PROC_BIN_WORDSIZE+?SUB_BIN_WORDSIZE),
@@ -657,6 +658,7 @@ var_init2(Size, Dst, Base, Offset, TrueLblName, SystemLimitLblName, FalseLblName
 		    hipe_rtl:label_name(NextLbl), [], not_remote),
    NextLbl,
    hipe_tagscheme:create_refc_binary(Base, USize, Dst),
+   hipe_rtl:mk_move(Offset, hipe_rtl:mk_imm(0)),
    hipe_rtl:mk_goto(TrueLblName)].
 
 var_init_bits(Size, Dst, Base, Offset, TrueLblName, SystemLimitLblName, FalseLblName) ->

--- a/lib/hipe/rtl/hipe_rtl_binary_construct.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_construct.erl
@@ -1210,6 +1210,12 @@ is_divisible(Dividend, Divisor, SuccLbl, FailLbl) ->
       [hipe_rtl:mk_branch(Dividend, 'and', Mask, eq, SuccLbl, FailLbl, 0.99)];
     false ->
       %% We need division, fall back to a primop
-      [hipe_rtl:mk_call([], is_divisible, [Dividend, hipe_rtl:mk_imm(Divisor)],
-			SuccLbl, FailLbl, not_remote)]
+      [Tmp] = create_regs(1),
+      RetLbl = hipe_rtl:mk_new_label(),
+      [hipe_rtl:mk_call([Tmp], is_divisible,
+                        [Dividend, hipe_rtl:mk_imm(Divisor)],
+                        hipe_rtl:label_name(RetLbl), [], not_remote),
+       RetLbl,
+       hipe_rtl:mk_branch(Tmp, ne, hipe_rtl:mk_imm(0),
+                          SuccLbl, FailLbl, 0.99)]
   end.

--- a/lib/hipe/rtl/hipe_rtl_binary_match.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_match.erl
@@ -730,7 +730,7 @@ get_base(Orig,Base) ->
   [hipe_tagscheme:test_heap_binary(Orig, hipe_rtl:label_name(HeapLbl),
 				   hipe_rtl:label_name(REFCLbl)),
    HeapLbl,
-   hipe_rtl:mk_alu(Base, Orig, 'add', hipe_rtl:mk_imm(?HEAP_BIN_DATA-2)),
+   hipe_tagscheme:get_field_addr_from_term({heap_bin, {data, 0}}, Orig, Base),
    hipe_rtl:mk_goto(hipe_rtl:label_name(EndLbl)),
    REFCLbl,
    get_field_from_term({proc_bin, flags}, Orig, Flags),
@@ -740,7 +740,7 @@ get_base(Orig,Base) ->
    WritableLbl,
    hipe_rtl:mk_call([], emasculate_binary, [Orig], [], [], 'not_remote'),
    NotWritableLbl,
-   hipe_rtl:mk_load(Base, Orig, hipe_rtl:mk_imm(?PROC_BIN_BYTES-2)),
+   get_field_from_term({proc_bin, bytes}, Orig, Base),
    EndLbl].
 
 extract_matchstate_var(binsize, Ms) ->

--- a/lib/hipe/rtl/hipe_rtl_binary_match.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_match.erl
@@ -842,12 +842,12 @@ make_dyn_prep(SizeReg, CCode) ->
 %%------------------------------------------------------------------------
 
 get_unaligned_int(Dst1, Size, Base, Offset, Shiftr, Type, TrueLblName) ->
-  [Reg] = create_regs(1),
+  [Reg] = create_gcsafe_regs(1),
   [get_maybe_unaligned_int_to_reg(Reg, Size, Base, Offset, Shiftr, Type),
    do_bignum_code(Size, Type, Reg, Dst1, TrueLblName)].
 
 get_maybe_unaligned_int_to_reg(Reg, Size, Base, Offset, Shiftr, Type) ->
-  [LowBits] = create_regs(1),
+  [LowBits] = create_gcsafe_regs(1),
   [AlignedLbl, UnAlignedLbl, EndLbl] = create_lbls(3),
   [hipe_rtl:mk_alub(LowBits, Offset, 'and', hipe_rtl:mk_imm(?LOW_BITS),
 		    eq, hipe_rtl:label_name(AlignedLbl), 
@@ -1001,7 +1001,7 @@ do_bignum_code(Size, {Signedness,_}, Src, Dst1, TrueLblName)
     end.
 
 signed_bignum(Dst1, Src, TrueLblName) ->
-  Tmp1 = hipe_rtl:mk_new_reg(),
+  Tmp1 = hipe_rtl:mk_new_reg_gcsafe(),
   BignumLabel = hipe_rtl:mk_new_label(),
   [hipe_tagscheme:realtag_fixnum(Dst1, Src),
    hipe_tagscheme:realuntag_fixnum(Tmp1, Dst1),

--- a/lib/hipe/rtl/hipe_rtl_cleanup_const.erl
+++ b/lib/hipe/rtl/hipe_rtl_cleanup_const.erl
@@ -69,9 +69,9 @@ cleanup_instr([Const|Left], I, Acc) ->
   case I of
     X when is_record(X, fp_unop) orelse is_record(X, fp) ->
       Fdst = hipe_rtl:mk_new_fpreg(),
-      Fconv = hipe_tagscheme:unsafe_untag_float(Fdst, Dst),		  
+      Fconv = lists:flatten(hipe_tagscheme:unsafe_untag_float(Fdst, Dst)),
       NewI = hipe_rtl:subst_uses([{Const, Fdst}], I),
-      cleanup_instr(Left, NewI, Fconv ++ [Load|Acc]);
+      cleanup_instr(Left, NewI, lists:reverse(Fconv, [Load|Acc]));
     _ ->
       NewI = hipe_rtl:subst_uses([{Const, Dst}], I),
       cleanup_instr(Left, NewI, [Load|Acc])

--- a/lib/hipe/rtl/hipe_rtl_lcm.erl
+++ b/lib/hipe/rtl/hipe_rtl_lcm.erl
@@ -226,13 +226,12 @@ insert_exprs(CFG, _, _, _, _, BetweenMap, []) ->
 insert_exprs(CFG, Pred, Succ, ExprMap, IdMap, BetweenMap, [ExprId|Exprs]) ->
   Expr = expr_id_map_get_expr(IdMap, ExprId),
   Instr = expr_map_get_instr(ExprMap, Expr),
-  case hipe_rtl_cfg:succ(CFG, Pred) of
-    [_] ->
+  case try_insert_expr_last(CFG, Pred, Instr) of
+    {ok, NewCFG} ->
       pp_debug("  Inserted last: ", []),
       pp_debug_instr(Instr),
-      NewCFG = insert_expr_last(CFG, Pred, Instr),
       insert_exprs(NewCFG, Pred, Succ, ExprMap, IdMap, BetweenMap, Exprs);
-    _ ->
+    not_safe ->
       case hipe_rtl_cfg:pred(CFG, Succ) of
         [_] ->
 	  pp_debug("  Inserted first: ", []),
@@ -252,25 +251,31 @@ insert_exprs(CFG, Pred, Succ, ExprMap, IdMap, BetweenMap, [ExprId|Exprs]) ->
 %% Recursively goes through the code in a block and returns a new block
 %% with the new code inserted second to last (assuming the last expression
 %% is a branch operation).
-insert_expr_last(CFG0, Label, Instr) ->
-  Code0 = hipe_bb:code(hipe_rtl_cfg:bb(CFG0, Label)),
-  %% FIXME: Use hipe_bb:butlast() instead?
-  Code1 = insert_expr_last_work(Label, Instr, Code0),
-  hipe_rtl_cfg:bb_add(CFG0, Label, hipe_bb:mk_bb(Code1)).
+try_insert_expr_last(CFG0, Label, Instr) ->
+  case hipe_rtl_cfg:succ(CFG0, Label) of
+    [_] ->
+      Code0 = hipe_bb:code(hipe_rtl_cfg:bb(CFG0, Label)),
+      case insert_expr_last_work(Instr, Code0) of
+        not_safe -> not_safe;
+        Code1 ->
+          {ok, hipe_rtl_cfg:bb_add(CFG0, Label, hipe_bb:mk_bb(Code1))}
+      end;
+    _ -> not_safe
+  end.
 
 %%=============================================================================
 %% Recursively goes through the code in a block and returns a new block
 %% with the new code inserted second to last (assuming the last expression
 %% is a branch operation).
-insert_expr_last_work(_, Instr, []) ->
-  %% This case should not happen since this means that block was completely 
-  %% empty when the function was called. For compatibility we insert it last.
-  [Instr];
-insert_expr_last_work(_, Instr, [Code1]) ->
+insert_expr_last_work(_Instr, [#call{}]) ->
+  %% Call instructions clobber all expressions; we musn't insert the expression
+  %% before it
+  not_safe;
+insert_expr_last_work(Instr, [Code1]) ->
   %% We insert the code next to last.
   [Instr, Code1];
-insert_expr_last_work(Label, Instr, [Code|Codes]) ->
-  [Code|insert_expr_last_work(Label, Instr, Codes)].
+insert_expr_last_work(Instr, [Code|Codes]) ->
+  [Code|insert_expr_last_work(Instr, Codes)].
 
 %%=============================================================================
 %% Inserts expression first in the block for the given label.
@@ -305,7 +310,8 @@ insert_expr_between(CFG0, BetweenMap, Pred, Succ, Instr) ->
     {value, Label} ->
       pp_debug("    Using existing new bb for edge (~w,~w) with label ~w~n", 
 	       [Pred, Succ, Label]),
-      {insert_expr_last(CFG0, Label, Instr), BetweenMap}
+      {ok, NewCfg} = try_insert_expr_last(CFG0, Label, Instr),
+      {NewCfg, BetweenMap}
   end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/hipe/rtl/hipe_rtl_varmap.erl
+++ b/lib/hipe/rtl/hipe_rtl_varmap.erl
@@ -105,7 +105,7 @@ icode_var2rtl_var(Var, Map) ->
 	{reg, IsGcSafe} ->
 	  NewVar =
 	    case IsGcSafe of
-	      %% true -> hipe_rtl:mk_new_reg_gcsafe();
+              true -> hipe_rtl:mk_new_reg_gcsafe();
 	      false -> hipe_rtl:mk_new_reg()
 	    end,
 	  {NewVar, insert(Var, NewVar, Map)}

--- a/lib/hipe/rtl/hipe_rtl_verify_gcsafe.erl
+++ b/lib/hipe/rtl/hipe_rtl_verify_gcsafe.erl
@@ -1,0 +1,88 @@
+%% -*- mode: erlang; erlang-indent-level: 2 -*-
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+-module(hipe_rtl_verify_gcsafe).
+
+-export([check/1]).
+
+-include("../flow/cfg.hrl").              %% needed for the specs
+-include("hipe_rtl.hrl").
+
+check(CFG) ->
+  Liveness = hipe_rtl_liveness:analyze(CFG),
+  put({?MODULE, 'fun'}, CFG#cfg.info#cfg_info.'fun'),
+  lists:foreach(
+    fun(Lb) ->
+        put({?MODULE, label}, Lb),
+        Liveout = hipe_rtl_liveness:liveout(Liveness, Lb),
+        BB = hipe_rtl_cfg:bb(CFG, Lb),
+        check_instrs(lists:reverse(hipe_bb:code(BB)), Liveout)
+    end, hipe_rtl_cfg:labels(CFG)),
+  erase({?MODULE, 'fun'}),
+  erase({?MODULE, label}),
+  erase({?MODULE, instr}),
+  ok.
+
+check_instrs([], _Livein) -> ok;
+check_instrs([I|Is], LiveOut) ->
+  Def = ordsets:from_list(hipe_rtl:defines(I)),
+  Use = ordsets:from_list(hipe_rtl:uses(I)),
+  LiveOver = ordsets:subtract(LiveOut, Def),
+  LiveIn = ordsets:union(LiveOver, Use),
+  case (hipe_rtl:is_call(I)
+        andalso not safe_primop(hipe_rtl:call_fun(I)))
+    orelse is_record(I, gctest)
+  of
+    false -> ok;
+    true ->
+      put({?MODULE, instr}, I),
+      lists:foreach(fun verify_live/1, LiveOver)
+  end,
+  check_instrs(Is, LiveIn).
+
+verify_live(T) ->
+  case hipe_rtl:is_reg(T) of
+    false -> ok;
+    true ->
+      case hipe_rtl:reg_is_gcsafe(T) of
+        true -> ok;
+        false ->
+          error({gcunsafe_live_over_call,
+                 get({?MODULE, 'fun'}),
+                 {label, get({?MODULE, label})},
+                 get({?MODULE, instr}),
+                 T})
+      end
+  end.
+
+%% Primops that can't gc
+%% Note: This information is essentially duplicated from hipe_bif_list.m4
+safe_primop(is_divisible) -> true;
+safe_primop(is_unicode) -> true;
+safe_primop(cmp_2) -> true;
+safe_primop(eq_2) -> true;
+safe_primop(bs_allocate) -> true;
+safe_primop(bs_reallocate) -> true;
+safe_primop(bs_utf8_size) -> true;
+safe_primop(bs_get_utf8) -> true;
+safe_primop(bs_utf16_size) -> true;
+safe_primop(bs_get_utf16) -> true;
+safe_primop(bs_validate_unicode_retract) -> true;
+safe_primop(bs_put_small_float) -> true;
+safe_primop(bs_put_bits) -> true;
+safe_primop(emasculate_binary) -> true;
+safe_primop(atomic_inc) -> true;
+%% Not noproc but manually verified
+safe_primop(bs_put_big_integer) -> true;
+safe_primop(_) -> false.

--- a/lib/hipe/ssa/hipe_ssa.inc
+++ b/lib/hipe/ssa/hipe_ssa.inc
@@ -463,20 +463,20 @@ updateStatementDefs([], Statement, Current, Acc) ->
 %%----------------------------------------------------------------------
 
 updateIndices(Current, Variable) ->
-  case ?CODE:is_var(Variable) of
-    true ->
-      NewVar = ?CODE:mk_new_var(),
-      {NewVar,gb_trees:enter(Variable, NewVar, Current)};
-    false ->
-      case is_fp_temp(Variable) of
-	true ->
-	  NewFVar = mk_new_fp_temp(),
-	  {NewFVar,gb_trees:enter(Variable, NewFVar, Current)};
-	false ->
-	  NewReg = ?CODE:mk_new_reg(),
-	  {NewReg,gb_trees:enter(Variable, NewReg, Current)}
-      end
-  end.
+  New =
+    case ?CODE:is_var(Variable) of
+      true -> ?CODE:mk_new_var();
+      false ->
+        case is_fp_temp(Variable) of
+          true -> mk_new_fp_temp();
+          false ->
+            case ?CODE:reg_is_gcsafe(Variable) of
+              true -> ?CODE:mk_new_reg_gcsafe();
+              false -> ?CODE:mk_new_reg()
+            end
+        end
+    end,
+  {New, gb_trees:enter(Variable, New, Current)}.
 
 %%----------------------------------------------------------------------
 %% Procedure : updateSuccPhi/4

--- a/lib/hipe/test/hipe_testsuite_driver.erl
+++ b/lib/hipe/test/hipe_testsuite_driver.erl
@@ -161,7 +161,8 @@ run(TestCase, Dir, _OutDir) ->
     %% 		  end, DataFiles),
     %% try
     ok = TestCase:test(),
-    HiPEOpts = try TestCase:hipe_options() catch error:undef -> [] end,
+    HiPEOpts0 = try TestCase:hipe_options() catch error:undef -> [] end,
+    HiPEOpts = HiPEOpts0 ++ hipe_options(),
     {ok, TestCase} = hipe:c(TestCase, HiPEOpts),
     ok = TestCase:test(),
     {ok, TestCase} = hipe:c(TestCase, [o1|HiPEOpts]),
@@ -179,3 +180,6 @@ run(TestCase, Dir, _OutDir) ->
     %% 	lists:foreach(fun (DF) -> ok end, % = file:delete(DF) end,
     %% 		      [filename:join(OutDir, D) || D <- DataFiles])
     %% end.
+
+hipe_options() ->
+    [verify_gcsafe].


### PR DESCRIPTION
This PR adds support for tagged literals to HiPE. Tagged literals is one of the mechanisms the Erlang VM can use to identify what data is literal, and what is dynamically allocated. Adding this support will allow HiPE to be used on platforms where this mechanism is used.

I expect the performace to be worse when using literal tagging as the generated code is uglier. The bad code does however give the optimisers some room to stretch their legs, for once. As a result of this, two previously unknown bugs in the Lazy Code Motion optimiser were exposed and fixed.

To be able to reliably reproduce these bugs (as they rely on the garbage collector to hit at the wrong time) the test for these bugs is in the form of a validation pass that is run on the intermediary code as part of the HiPE test suite. The validation pass detects an entire class of bugs, and also serves as a test for the bug fixed by #1607.