### PR TITLE
SSH: To accept trailing space in protocol version

### DIFF
--- a/lib/ssh/src/ssh_transport.erl
+++ b/lib/ssh/src/ssh_transport.erl
@@ -2011,7 +2011,6 @@ same(Algs) ->  [{client2server,Algs}, {server2client,Algs}].
 trim_tail(Str) ->
     lists:reverse(trim_head(lists:reverse(Str))).
 
-trim_head([$\s|Cs]) -> trim_head(Cs);
 trim_head([$\t|Cs]) -> trim_head(Cs);
 trim_head([$\n|Cs]) -> trim_head(Cs);
 trim_head([$\r|Cs]) -> trim_head(Cs);


### PR DESCRIPTION
Solaris 11, OpenSSH7.3p1 or higher versions of the server is sending protocol version string with a trailing space which causes key exchange failure error as below
{error,{"Key exchange failed",{error,bad_signature}}} or {error,"Key exchange failed"}