### PR TITLE
Fix broken receive mark after an exception

### DIFF
--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -1454,6 +1454,7 @@ handle_error(Process* c_p, BeamInstr* pc, Eterm* reg, ErtsCodeMFA *bif_mfa)
 	reg[3] = c_p->ftrace;
         if ((new_pc = next_catch(c_p, reg))) {
 	    c_p->cp = 0;	/* To avoid keeping stale references. */
+            c_p->msg.saved_last = 0;  /* No longer safe to use this position */
 	    return new_pc;
 	}
 	if (c_p->catches > 0) erts_exit(ERTS_ERROR_EXIT, "Catch not found");

--- a/erts/emulator/beam/erl_message.h
+++ b/erts/emulator/beam/erl_message.h
@@ -167,10 +167,9 @@ typedef struct {
     Sint len;            /* queue length */
 
     /*
-     * The following two fields are used by the recv_mark/1 and
+     * The following field is used by the recv_mark/1 and
      * recv_set/1 instructions.
      */
-    BeamInstr* mark;		/* address to rec_loop/2 instruction */
     ErtsMessage** saved_last;	/* saved last pointer */
 } ErlMessageQueue;
 
@@ -236,12 +235,17 @@ typedef struct erl_trace_message_queue__ {
      (p)->msg.len--; \
      if (__mp == NULL) \
          (p)->msg.last = (p)->msg.save; \
-     (p)->msg.mark = 0; \
 } while(0)
 
-/* Reset message save point (after receive match) */
-#define JOIN_MESSAGE(p) \
-     (p)->msg.save = &(p)->msg.first
+/*
+ * Reset message save point (after receive match).
+ * Also invalidate the saved position since it may no
+ * longer be safe to use.
+ */
+#define JOIN_MESSAGE(p) do {                    \
+    (p)->msg.save = &(p)->msg.first;            \
+    (p)->msg.saved_last = 0;                    \
+} while(0)
 
 /* Save current message */
 #define SAVE_MESSAGE(p) \

--- a/erts/emulator/beam/msg_instrs.tab
+++ b/erts/emulator/beam/msg_instrs.tab
@@ -43,27 +43,23 @@
 //  *
 //  */
 
-recv_mark(Dest) {
+i_recv_mark() {
     /*
-     * Save the current position in message buffer and the
-     * the label for the loop_rec/2 instruction for the
-     * the receive statement.
+     * Save the current position in message buffer.
      */
-    $SET_REL_I(c_p->msg.mark, $Dest);
     c_p->msg.saved_last = c_p->msg.last;
 }
 
 i_recv_set() {
     /*
-     * If the mark is valid (points to the loop_rec/2
-     * instruction that follows), we know that the saved
-     * position points to the first message that could
-     * possibly be matched out.
+     * If c_p->msg.saved_last is non-zero, it points to the first
+     * message that could possibly be matched out.
      *
-     * If the mark is invalid, we do nothing, meaning that
-     * we will look through all messages in the message queue.
+     * If c_p->msg.saved_last is zero, it means that it was invalidated
+     * because another receive was executed before this i_recv_set()
+     * instruction was reached.
      */
-    if (c_p->msg.mark == (BeamInstr *) ($NEXT_INSTRUCTION)) {
+    if (c_p->msg.saved_last) {
         c_p->msg.save = c_p->msg.saved_last;
     }
     SET_I($NEXT_INSTRUCTION);
@@ -131,6 +127,7 @@ i_loop_rec(Dest) {
             ASSERT(HTOP == c_p->htop && E == c_p->stop);
             /* TODO: Add DTrace probe for this bad message situation? */
             UNLINK_MESSAGE(c_p, msgp);
+            c_p->msg.saved_last = 0; /* Better safe than sorry. */
             msgp->next = NULL;
             erts_cleanup_messages(msgp);
             goto loop_rec__;

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -1565,7 +1565,12 @@ on_load
 #
 # R14A.
 #
-recv_mark f
+# Modified in OTP 21 because it turns out that we don't need the
+# label after all.
+#
+
+recv_mark f => i_recv_mark
+i_recv_mark
 
 recv_set Fail | label Lbl | loop_rec Lf Reg => \
    i_recv_set | label Lbl | loop_rec Lf Reg


### PR DESCRIPTION
The receive optimization that avoids scanning the entire message
queue could be unsafe when an exception was caught in the middle
of a recursive call to a function that does a receive.

Magnus Lång described the problem like this:

"If a recv_mark is executed, but the corresponding recv_set is bypassed
because of an exception, the receive queue marker remains. If a
function using this optimisation calls itself between recv_mark and
recv_set, and the inner function is abnormally exited between its
recv_mark and recv_set, but the exception is caught without unwinding
the outer call, the outer call will use the mark left by the inner
call and risk a deadlock."

There does not seem to be any way to fix this problem in the compiler,
except by disabling the optimization if there is any function
call between the creation of the reference and the receive statement.
That would make the optimization much less useful, so we don't
want to do that.

So we will have to fix the problem in the runtime system by clearing
the receive mark when an exception is caught.

https://bugs.erlang.org/browse/ERL-511