### PR TITLE
Recognize 'deterministic' when given in a -compile() attribute

### DIFF
--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -182,7 +182,8 @@ build_file(Code, Attr, Dict, NumLabels, NumFuncs, ExtraChunks, SourceFile, Opts,
     Essentials1 = [iolist_to_binary(C) || C <- Essentials0],
     MD5 = module_md5(Essentials1),
     Essentials = finalize_fun_table(Essentials1, MD5),
-    {Attributes,Compile} = build_attributes(Opts, SourceFile, Attr, MD5),
+    {Attributes,Compile} = build_attributes(Opts, CompilerOpts, SourceFile,
+                                            Attr, MD5),
     AttrChunk = chunk(<<"Attr">>, Attributes),
     CompileChunk = chunk(<<"CInf">>, Compile),
 
@@ -264,16 +265,16 @@ flatten_exports(Exps) ->
 flatten_imports(Imps) ->
     list_to_binary(map(fun({M,F,A}) -> <<M:32,F:32,A:32>> end, Imps)).
 
-build_attributes(Opts, SourceFile, Attr, MD5) ->
+build_attributes(Opts, CompilerOpts, SourceFile, Attr, MD5) ->
     Misc0 = case SourceFile of
 		[] -> [];
 		[_|_] -> [{source,SourceFile}]
 	    end,
-    Misc = case member(slim, Opts) of
+    Misc = case member(slim, CompilerOpts) of
 	       false -> Misc0;
 	       true -> []
 	   end,
-    Compile = case member(deterministic, Opts) of
+    Compile = case member(deterministic, CompilerOpts) of
 		  false ->
 		      [{options,Opts},{version,?COMPILER_VSN}|Misc];
 		  true ->

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -119,9 +119,19 @@ file_1(Config) when is_list(Config) ->
     true = exists(Target),
     passed = run(Target, test, []),
 
+    %% Test option 'deterministic' as a compiler attribute.
+    Det = deterministic_module,
+    {DetPath, DetTarget} = get_files(Config, Det, "det_target"),
+    {ok,Det,DetCode} = compile:file(DetPath, [binary]),
+    {module,Det} = code:load_binary(Det, "", DetCode),
+    [{version,_}] = Det:module_info(compile),
+    true = code:delete(Det),
+    false = code:purge(Det),
+
     %% Cleanup.
     ok = file:delete(Target),
     ok = file:del_dir(filename:dirname(Target)),
+    ok = file:del_dir(filename:dirname(DetTarget)),
 
     %% There should not be any messages in the messages.
     receive

--- a/lib/compiler/test/compile_SUITE_data/deterministic_module.erl
+++ b/lib/compiler/test/compile_SUITE_data/deterministic_module.erl
@@ -1,0 +1,21 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(deterministic_module).
+-compile([deterministic]).


### PR DESCRIPTION
The compiler option 'deterministic' was only recognized when given
as an option to the compiler, not when it was specified in a
`-compile()` attribute in the source file.

https://bugs.erlang.org/browse/ERL-498