### PR TITLE
fix output formatting in several HiPE debug BIFs

### DIFF
--- a/erts/emulator/hipe/hipe_risc_stack.c
+++ b/erts/emulator/hipe/hipe_risc_stack.c
@@ -47,8 +47,10 @@ static void print_slot(Eterm *sp, unsigned int live)
     printf(" | 0x%0*lx | 0x%0*lx | ",
 	   2*(int)sizeof(long), (unsigned long)sp,
 	   2*(int)sizeof(long), val);
-    if (live)
+    if (live) {
+	fflush(stdout);
 	erts_printf("%.30T", val);
+    }
     printf("\r\n");
 }
 
@@ -68,7 +70,9 @@ void hipe_print_nstack(Process *p)
 	[0 ... 2*sizeof(long)+3] = '-'
     };
 
-    printf(" |      NATIVE  STACK      |\r\n");
+    printf(" | %*s NATIVE   STACK %*s |\r\n",
+	   2*(int)sizeof(long)-5, "",
+	   2*(int)sizeof(long)-4, "");
     printf(" |%s|%s|\r\n", dashes, dashes);
     printf(" | %*s | 0x%0*lx |\r\n",
 	   2+2*(int)sizeof(long), "heap",

--- a/erts/emulator/hipe/hipe_x86_stack.c
+++ b/erts/emulator/hipe/hipe_x86_stack.c
@@ -43,8 +43,10 @@ static void print_slot(Eterm *sp, unsigned int live)
     printf(" | 0x%0*lx | 0x%0*lx | ",
 	   2*(int)sizeof(long), (unsigned long)sp,
 	   2*(int)sizeof(long), val);
-    if (live)
+    if (live) {
+	fflush(stdout);
 	erts_printf("%.30T", val);
+    }
     printf("\r\n");
 }
 
@@ -74,7 +76,9 @@ void hipe_print_nstack(Process *p)
     sdesc0.livebits[0] = ~1;
     sdesc = &sdesc0;
 
-    printf(" |      NATIVE  STACK      |\r\n");
+    printf(" | %*s NATIVE   STACK %*s |\r\n",
+	   2*(int)sizeof(long)-5, "",
+	   2*(int)sizeof(long)-4, "");
     printf(" |%s|%s|\r\n", dashes, dashes);
     printf(" | %*s | 0x%0*lx |\r\n",
 	   2+2*(int)sizeof(long), "heap",


### PR DESCRIPTION
Fix formatting in hipe_bifs:show_pcb/1, hipe_bifs:show_estack/1,
and hipe_bifs:show_nstack/1.

fflush(stdout) before switching from printf() to erts_printf() to
avoid garbled output.

Adjust field lengths to work on both 64- and 32-bit systems.

Tested on Linux/x86_64 (64-bit) and Linux/ARMv7 (32-bit).