### PR TITLE
Correct the ref's ids incrementation logic

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpLocalNode.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpLocalNode.java
@@ -166,7 +166,8 @@ public class OtpLocalNode extends AbstractNode {
             refId[0] = 0;
 
             refId[1]++;
-            if (refId[1] == 0) {
+            if (refId[1] == Integer.MAX_VALUE) {
+                refId[1] = 0;
                 refId[2]++;
             }
         }


### PR DESCRIPTION
Fix logical bug in OtpLocalNode ids array incrementation for OtpErlangRef object, which doesn't allow to use 3 ints (18 + 32 + 32 bits) entirely.