### PR TITLE
Fix integer overflow when set a large maximum value for atom table

### DIFF
--- a/erts/emulator/beam/atom.h
+++ b/erts/emulator/beam/atom.h
@@ -36,7 +36,7 @@
 /* Internal atom cache needs MAX_ATOM_TABLE_SIZE to be less than an
    unsigned 32 bit integer. See external.c(erts_encode_ext_dist_header_setup)
    for more details. */
-#define MAX_ATOM_TABLE_SIZE ((MAX_ATOM_INDEX + 1 < (UWORD_CONSTANT(1) << 32)) ? MAX_ATOM_INDEX + 1 : (UWORD_CONSTANT(1) << 32))
+#define MAX_ATOM_TABLE_SIZE ((MAX_ATOM_INDEX + 1 < (UWORD_CONSTANT(1) << 32)) ? MAX_ATOM_INDEX + 1 : ((UWORD_CONSTANT(1) << 31) - 1)) /* Here we use maximum signed interger value to avoid integer overflow */
 #else
 #define MAX_ATOM_TABLE_SIZE (MAX_ATOM_INDEX + 1)
 #endif

--- a/erts/emulator/beam/index.c
+++ b/erts/emulator/beam/index.c
@@ -58,7 +58,7 @@ IndexTable*
 erts_index_init(ErtsAlcType_t type, IndexTable* t, char* name,
 		int size, int limit, HashFunctions fun)
 {
-    Uint base_size = ((limit+INDEX_PAGE_SIZE-1)/INDEX_PAGE_SIZE)*sizeof(IndexSlot*);
+    Uint base_size = (((Uint)limit+INDEX_PAGE_SIZE-1)/INDEX_PAGE_SIZE)*sizeof(IndexSlot*);
     hash_init(type, &t->htable, name, 3*size/4, fun);
 
     t->size = 0;


### PR DESCRIPTION
When setting maximum atom table size using `+t` option, there will be a integer overflow for a large size.

```
$ erl +t2147482625
ll_alloc: Cannot allocate 18446744073692774400 bytes of memory (of type "atom_tab").
```
The overflow is caused by the arithmetic operations on `int` type in the following line in [index.c](https://github.com/erlang/otp/blob/OTP-20.1.5/erts/emulator/beam/index.c#L61)
    
    Uint base_size = ((limit+INDEX_PAGE_SIZE-1)/INDEX_PAGE_SIZE)*sizeof(IndexSlot*);

We can use above example `2147482625` to illustrate how the overflow occurs.

```
expression                      decimal value   binary value (32 bits)              note
INDEX_PAGE_SIZE                 1024            0b00000000000000000000010000000000  defined in index.h
limit                           2147482625      0b01111111111111111111110000000001  user's input
limit+INDEX_PAGE_SIZE           -2147483647     0b10000000000000000000000000000001  overflow occurs here
last_result-1                   -2147483648     0b10000000000000000000000000000000
last_result/INDEX_PAGE_SIZE     -2097152        0b11111111111000000000000000000000  Two's complement division is using arithmetic right shift
last_result*sizeof(IndexSlot*)  -16777216       0b11111111000000000000000000000000  On 64-bit Erlang, size of pointer is 8 bytes
``` 

Before it assign `-16777216` to `base_size`, it needs to resize from `int` type to `long` type (`Uint` is `unsigned long` type defined in sys.h). Then it will change the type from `long` to `unsigned long`.

```
expression                    decimal value          binary value (64 bits)
last_result                   -1677216                                               0b11111111000000000000000000000000
(long) last_result            -1677216               0b1111111111111111111111111111111111111111000000000000000000000000
Uint base_size = last_result  18446744073692774400   0b1111111111111111111111111111111111111111000000000000000000000000
```
And that gives the error message above.

Note:
In [atom.h](https://github.com/erlang/otp/blob/OTP-20.1.5/erts/emulator/beam/atom.h#L39), the `MAX_ATOM_TABLE_SIZE` is `(UWORD_CONSTANT(1) << 32)`, namely `4294967296` for 64 bits Erlang. However, in [erl_init.c](https://github.com/erlang/otp/blob/OTP-20.1.5/erts/emulator/beam/erl_init.c#L2024), the user input is stored in a `long` type, however the [variable](https://github.com/erlang/otp/blob/OTP-20.1.5/erts/emulator/beam/erl_init.c#L208) holding it is a `int` type, so there would also be overflow happened here.

```
/* atom.h */
#define MAX_ATOM_TABLE_SIZE ((MAX_ATOM_INDEX + 1 < (UWORD_CONSTANT(1) << 32)) ? MAX_ATOM_INDEX + 1 : (UWORD_CONSTANT(1) << 32))

/* erl_init.c */
int erts_atom_table_size = ATOM_LIMIT;
...
erts_atom_table_size = strtol(arg, NULL, 10);  /* overflow occurs here, if user's input is MAX_ATOM_TABLE_SIZE 4294967296, then it will overflow to 0 */
```

Therefore even the intention for the maximum atom size is `1UL << 32 = 4294967296`, but the actual maximum is `(1 << 31) - 1 = 2147483647`(the maximum value a 4 bytes signed int can hold).

After the fix, it will behave like this:
```
$ erl +t2147483647
Erlang/OTP 21 [DEVELOPMENT] [erts-9.1.4] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe]

Eshell V9.1.4  (abort with ^G)
1> erlang:system_info(atom_limit).
2147483647

$ erl +t2147483648
bad atom table size 2147483648
```
