### PR TITLE
Add syntax in try/catch to retrieve the stacktrace directly

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -1985,39 +1985,26 @@ true</pre>
       <fsummary>Get the call stack back-trace of the last exception.</fsummary>
       <type name="stack_item"/>
       <desc>
-        <p>Gets the call stack back-trace (<em>stacktrace</em>) for an
-          exception that has just been caught
-	  in the calling process as a list of
-          <c>{<anno>Module</anno>,<anno>Function</anno>,<anno>Arity</anno>,<anno>Location</anno>}</c>
-          tuples. Field <c><anno>Arity</anno></c> in the first tuple can be the
-          argument list of that function call instead of an arity integer,
-          depending on the exception.</p>
+	<warning><p><c>erlang:get_stacktrace/0</c> is deprecated and will stop working
+	in a future release.</p></warning>
+      <p>Instead of using <c>erlang:get_stacktrace/0</c> to retrieve
+      the call stack back-trace, use the following syntax:</p>
+<pre>
+try Expr
+catch
+  Class:Reason:Stacktrace ->
+   {Class,Reason,Stacktrace}
+end</pre>
+        <p><c>erlang:get_stacktrace/0</c> retrieves the call stack back-trace
+        (<em>stacktrace</em>) for an exception that has just been
+        caught in the calling process as a list of
+        <c>{<anno>Module</anno>,<anno>Function</anno>,<anno>Arity</anno>,<anno>Location</anno>}</c>
+        tuples. Field <c><anno>Arity</anno></c> in the first tuple can
+        be the argument list of that function call instead of an arity
+        integer, depending on the exception.</p>
         <p>If there has not been any exceptions in a process, the
           stacktrace is <c>[]</c>. After a code change for the process,
           the stacktrace can also be reset to <c>[]</c>.</p>
-	<p><c>erlang:get_stacktrace/0</c> is only guaranteed to return
-	a stacktrace if called (directly or indirectly) from within the
-	scope of a <c>try</c> expression. That is, the following call works:</p>
-<pre>
-try Expr
-catch
-  C:R ->
-   {C,R,erlang:get_stacktrace()}
-end</pre>
-	<p>As does this call:</p>
-<pre>
-try Expr
-catch
-  C:R ->
-   {C,R,helper()}
-end
-
-helper() ->
-  erlang:get_stacktrace().</pre>
-
-        <warning><p>In a future release,
-        <c>erlang:get_stacktrace/0</c> will return <c>[]</c> if called
-        from outside a <c>try</c> expression.</p></warning>
         <p>The stacktrace is the same data as operator <c>catch</c>
           returns, for example:</p>
         <pre>

--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -924,3 +924,8 @@ i_raise() {
     //| -no_next
 }
 
+build_stacktrace() {
+    SWAPOUT;
+    x(0) = build_stacktrace(c_p, x(0));
+    SWAPIN;
+}

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -1575,3 +1575,9 @@ i_recv_mark
 recv_set Fail | label Lbl | loop_rec Lf Reg => \
    i_recv_set | label Lbl | loop_rec Lf Reg
 i_recv_set
+
+#
+# OTP 21.
+#
+
+build_stacktrace

--- a/erts/emulator/hipe/hipe_bif2.c
+++ b/erts/emulator/hipe/hipe_bif2.c
@@ -190,3 +190,8 @@ BIF_RETTYPE hipe_bifs_llvm_fix_pinned_regs_0(BIF_ALIST_0)
 {
     BIF_RET(am_ok);
 }
+
+BIF_RETTYPE hipe_bifs_build_stacktrace_1(BIF_ALIST_1)
+{
+    BIF_RET(build_stacktrace(BIF_P, BIF_ARG_1));
+}

--- a/erts/emulator/hipe/hipe_bif2.tab
+++ b/erts/emulator/hipe/hipe_bif2.tab
@@ -32,3 +32,4 @@ bif hipe_bifs:modeswitch_debug_on/0
 bif hipe_bifs:modeswitch_debug_off/0
 bif hipe_bifs:debug_native_called/2
 bif hipe_bifs:llvm_fix_pinned_regs/0
+bif hipe_bifs:build_stacktrace/1

--- a/erts/emulator/hipe/hipe_bif_list.m4
+++ b/erts/emulator/hipe/hipe_bif_list.m4
@@ -186,6 +186,7 @@ gc_bif_interface_1(nbif_erase_1, erase_1)
 gc_bif_interface_1(nbif_erts_internal_garbage_collect_1, erts_internal_garbage_collect_1)
 gc_nofail_primop_interface_1(nbif_gc_1, hipe_gc)
 gc_bif_interface_2(nbif_put_2, put_2)
+gc_bif_interface_2(nbif_hipe_bifs_build_stacktrace, hipe_bifs_build_stacktrace_1)
 
 /*
  * Debug BIFs that need read access to the full state.

--- a/erts/emulator/hipe/hipe_native_bif.h
+++ b/erts/emulator/hipe/hipe_native_bif.h
@@ -104,6 +104,9 @@ void hipe_emulate_fpe(Process*);
 AEXTERN(void,nbif_emasculate_binary,(Eterm));
 void hipe_emasculate_binary(Eterm);
 
+AEXTERN(BIF_RETTYPE,nbif_hipe_bifs_build_stacktrace,(Process*,Eterm));
+BIF_RETTYPE hipe_bifs_build_stacktrace_1(BIF_ALIST_1);
+
 /*
  * Stuff that is different in SMP and non-SMP.
  */

--- a/erts/emulator/hipe/hipe_primops.h
+++ b/erts/emulator/hipe/hipe_primops.h
@@ -83,6 +83,7 @@ PRIMOP_LIST(am_emulate_fpe, &nbif_emulate_fpe)
 #endif
 PRIMOP_LIST(am_emasculate_binary, &nbif_emasculate_binary)
 PRIMOP_LIST(am_debug_native_called, &nbif_hipe_bifs_debug_native_called)
+PRIMOP_LIST(am_build_stacktrace, &nbif_hipe_bifs_build_stacktrace)
 
 #if defined(__sparc__)
 #include "hipe_sparc_primops.h"

--- a/erts/emulator/test/binary_SUITE.erl
+++ b/erts/emulator/test/binary_SUITE.erl
@@ -1472,13 +1472,13 @@ error_after_yield(Type, M, F, AN, AFun, TrapFunc) ->
 					   apply(M, F, A),
 					   exit({unexpected_success, {M, F, A}})
 				       catch
-					   error:Type ->
+					   error:Type:Stk ->
 					       erlang:trace(self(),false,[running,{tracer,Tracer}]),
 					       %% We threw the exception from the native
 					       %% function we trapped to, but we want
 					       %% the BIF that originally was called
 					       %% to appear in the stack trace.
-					       [{M, F, A, _} | _] = erlang:get_stacktrace()
+					       [{M, F, A, _} | _] = Stk
 				       end
 			       end),
     receive

--- a/erts/emulator/test/call_trace_SUITE.erl
+++ b/erts/emulator/test/call_trace_SUITE.erl
@@ -1116,8 +1116,8 @@ get_deep_4_loc(Arg) ->
         deep_4(Arg),
         ct:fail(should_not_return_to_here)
     catch
-        _:_ ->
-            [{?MODULE,deep_4,1,Loc0}|_] = erlang:get_stacktrace(),
+        _:_:Stk ->
+            [{?MODULE,deep_4,1,Loc0}|_] = Stk,
             Loc0
     end.
 

--- a/erts/emulator/test/dirty_bif_SUITE.erl
+++ b/erts/emulator/test/dirty_bif_SUITE.erl
@@ -108,90 +108,80 @@ dirty_bif_exception(Config) when is_list(Config) ->
 			      erts_debug:dirty_cpu(error, Error),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty_cpu,[error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk1 ->
+				  [{erts_debug,dirty_cpu,[error, Error],_}|_] = Stk1,
 				  ok
 			  end,
 			  try
 			      apply(erts_debug,dirty_cpu,[error, Error]),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty_cpu,[error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk2 ->
+				  [{erts_debug,dirty_cpu,[error, Error],_}|_] = Stk2,
 				  ok
 			  end,
 			  try
 			      erts_debug:dirty_io(error, Error),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty_io,[error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk3 ->
+				  [{erts_debug,dirty_io,[error, Error],_}|_] = Stk3,
 				  ok
 			  end,
 			  try
 			      apply(erts_debug,dirty_io,[error, Error]),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty_io,[error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk4 ->
+				  [{erts_debug,dirty_io,[error, Error],_}|_] = Stk4,
 				  ok
 			  end,
 			  try
 			      erts_debug:dirty(normal, error, Error),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty,[normal, error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk5 ->
+				  [{erts_debug,dirty,[normal, error, Error],_}|_] = Stk5,
 				  ok
 			  end,
 			  try
 			      apply(erts_debug,dirty,[normal, error, Error]),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty,[normal, error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk6 ->
+				  [{erts_debug,dirty,[normal, error, Error],_}|_] = Stk6,
 				  ok
 			  end,
 			  try
 			      erts_debug:dirty(dirty_cpu, error, Error),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty,[dirty_cpu, error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk7 ->
+				  [{erts_debug,dirty,[dirty_cpu, error, Error],_}|_] = Stk7,
 				  ok
 			  end,
 			  try
 			      apply(erts_debug,dirty,[dirty_cpu, error, Error]),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty,[dirty_cpu, error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk8 ->
+				  [{erts_debug,dirty,[dirty_cpu, error, Error],_}|_] = Stk8,
 				  ok
 			  end,
 			  try
 			      erts_debug:dirty(dirty_io, error, Error),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty,[dirty_io, error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk9 ->
+				  [{erts_debug,dirty,[dirty_io, error, Error],_}|_] = Stk9,
 				  ok
 			  end,
 			  try
 			      apply(erts_debug,dirty,[dirty_io, error, Error]),
 			      ct:fail(expected_exception)
 			  catch
-			      error:ErrorType ->
-				  [{erts_debug,dirty,[dirty_io, error, Error],_}|_]
-				      = erlang:get_stacktrace(),
+			      error:ErrorType:Stk10 ->
+				  [{erts_debug,dirty,[dirty_io, error, Error],_}|_] = Stk10,
 				  ok
 			  end
 		  end,
@@ -204,25 +194,22 @@ dirty_bif_multischedule_exception(Config) when is_list(Config) ->
     try
 	erts_debug:dirty_cpu(reschedule,1001)
     catch
-	error:badarg ->
-	    [{erts_debug,dirty_cpu,[reschedule, 1001],_}|_]
-		= erlang:get_stacktrace(),
+	error:badarg:Stk1 ->
+	    [{erts_debug,dirty_cpu,[reschedule, 1001],_}|_] = Stk1,
 	    ok
     end,
     try
 	erts_debug:dirty_io(reschedule,1001)
     catch
-	error:badarg ->
-	    [{erts_debug,dirty_io,[reschedule, 1001],_}|_]
-		= erlang:get_stacktrace(),
+	error:badarg:Stk2 ->
+	    [{erts_debug,dirty_io,[reschedule, 1001],_}|_] = Stk2,
 	    ok
     end,
     try
 	erts_debug:dirty(normal,reschedule,1001)
     catch
-	error:badarg ->
-	    [{erts_debug,dirty,[normal,reschedule,1001],_}|_]
-		= erlang:get_stacktrace(),
+	error:badarg:Stk3 ->
+	    [{erts_debug,dirty,[normal,reschedule,1001],_}|_] = Stk3,
 	    ok
     end.
 

--- a/erts/emulator/test/dirty_nif_SUITE.erl
+++ b/erts/emulator/test/dirty_nif_SUITE.erl
@@ -109,9 +109,8 @@ dirty_nif_exception(Config) when is_list(Config) ->
 	call_dirty_nif_exception(1),
 	ct:fail(expected_badarg)
     catch
-	error:badarg ->
-	    [{?MODULE,call_dirty_nif_exception,[1],_}|_] =
-		erlang:get_stacktrace(),
+	error:badarg:Stk1 ->
+	    [{?MODULE,call_dirty_nif_exception,[1],_}|_] = Stk1,
 	    ok
     end,
     try
@@ -121,9 +120,8 @@ dirty_nif_exception(Config) when is_list(Config) ->
 	call_dirty_nif_exception(0),
 	ct:fail(expected_badarg)
     catch
-	error:badarg ->
-	    [{?MODULE,call_dirty_nif_exception,[0],_}|_] =
-		erlang:get_stacktrace(),
+	error:badarg:Stk2 ->
+	    [{?MODULE,call_dirty_nif_exception,[0],_}|_] = Stk2,
 	    ok
     end,
     %% this checks that a dirty NIF can raise various terms as
@@ -138,8 +136,8 @@ nif_raise_exceptions(NifFunc) ->
                             erlang:apply(?MODULE,NifFunc,[Term]),
                             ct:fail({expected,Term})
                         catch
-                            error:Term ->
-                                [{?MODULE,NifFunc,[Term],_}|_] = erlang:get_stacktrace(),
+                            error:Term:Stk ->
+                                [{?MODULE,NifFunc,[Term],_}|_] = Stk,
                                 ok
                         end
                 end, ok, ExcTerms).

--- a/erts/emulator/test/driver_SUITE.erl
+++ b/erts/emulator/test/driver_SUITE.erl
@@ -2614,8 +2614,8 @@ rpc(Config, Fun) ->
                                 Result
                                     = try Fun() of
                                           Res -> Res
-                                      catch E:R ->
-                                              {'EXIT',E,R,erlang:get_stacktrace()}
+                                      catch E:R:Stk ->
+                                              {'EXIT',E,R,Stk}
                                       end,
                                 Self ! {Ref, Result}
                         end),

--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -395,12 +395,12 @@ raise(Conf) when is_list(Conf) ->
     try 
         try foo({'div',{1,0}}) 
         catch
-            error:badarith ->
+            error:badarith:A0 ->
                 put(raise, A0 = erlang:get_stacktrace()),
                 erlang:raise(error, badarith, A0)
         end
     catch
-        error:badarith ->
+        error:badarith:A1 ->
             A1 = erlang:get_stacktrace(),
             A1 = get(raise)
     end,

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -2257,9 +2257,8 @@ nif_schedule(Config) when is_list(Config) ->
     {B,A} = call_nif_schedule(A, B),
     ok = try call_nif_schedule(1, 2)
 	 catch
-	     error:badarg ->
-		 [{?MODULE,call_nif_schedule,[1,2],_}|_] =
-		     erlang:get_stacktrace(),
+	     error:badarg:Stk ->
+		 [{?MODULE,call_nif_schedule,[1,2],_}|_] = Stk,
 		 ok
 	 end,
     ok.
@@ -2429,8 +2428,8 @@ nif_raise_exceptions(NifFunc) ->
                             erlang:apply(?MODULE,NifFunc,[Term]),
                             ct:fail({expected,Term})
                         catch
-                            error:Term ->
-                                [{?MODULE,NifFunc,[Term],_}|_] = erlang:get_stacktrace(),
+                            error:Term:Stk ->
+                                [{?MODULE,NifFunc,[Term],_}|_] = Stk,
                                 ok
                         end
                 end, ok, ExcTerms).

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -1165,6 +1165,13 @@ resolve_inst({get_map_elements,Args0},_,_,_) ->
     {get_map_elements,FLbl,Src,{list,List}};
 
 %%
+%% OTP 21.
+%%
+
+resolve_inst({build_stacktrace,[]},_,_,_) ->
+    build_stacktrace;
+
+%%
 %% Catches instructions that are not yet handled.
 %%
 resolve_inst(X,_,_,_) -> ?exit({resolve_inst,X}).

--- a/lib/compiler/src/beam_disasm.hrl
+++ b/lib/compiler/src/beam_disasm.hrl
@@ -26,7 +26,8 @@
 %%      IT SHOULD BE MOVED TO A FILE THAT DEFINES (AND EXPORTS)
 %%      PROPER TYPES FOR THE SET OF BEAM INSTRUCTIONS.
 %%
--type beam_instr() :: 'bs_init_writable' | 'fclearerror' | 'if_end'
+-type beam_instr() :: 'bs_init_writable' | 'build_stacktrace'
+                    | 'fclearerror' | 'if_end'
                     | 'remove_message' | 'return' | 'send' | 'timeout'
                     | tuple().  %% XXX: Very underspecified - FIX THIS
 

--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -781,6 +781,8 @@ live_opt([{block,Bl0}|Is], Regs0, D, Acc) ->
     {Bl,Regs} = live_opt_block(reverse(Bl0), Regs0, D, [Live0]),
     Live = {'%live',live_regs(Regs),Regs},
     live_opt(Is, Regs, D, [{block,[Live|Bl]}|Acc]);
+live_opt([build_stacktrace=I|Is], _, D, Acc) ->
+    live_opt(Is, live_call(1), D, [I|Acc]);
 live_opt([{label,L}=I|Is], Regs, D0, Acc) ->
     D = gb_trees:insert(L, Regs, D0),
     live_opt(Is, Regs, D, [I|Acc]);

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -294,6 +294,8 @@ valfun_1({bs_context_to_binary,Ctx}, #vst{current=#st{x=Xs}}=Vst) ->
     end;
 valfun_1(bs_init_writable=I, Vst) ->
     call(I, 1, Vst);
+valfun_1(build_stacktrace=I, Vst) ->
+    call(I, 1, Vst);
 valfun_1({move,{y,_}=Src,{y,_}=Dst}, Vst) ->
     %% The stack trimming optimization may generate a move from an initialized
     %% but unassigned Y register to another Y register.

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -545,3 +545,12 @@ BEAM_FORMAT_NUMBER=0
 ##      Test the arity of Reg and jumps to Lbl if it is not N.
 ##      Test the first element of the tuple and jumps to Lbl if it is not Atom.
 159: is_tagged_tuple/4
+
+# OTP 21
+
+## @spec build_stacktrace
+## @doc  Given the raw stacktrace in x(0), build a cooked stacktrace suitable
+##       for human consumption. Store it in x(0). Destroys all other registers.
+##       Do a garbage collection if necessary to allocate space on the heap
+##       for the result.
+160: build_stacktrace/0

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -415,6 +415,8 @@ expr(#c_call{module=M0,name=N0}=Call0, Ctxt, Sub) ->
 	no -> call(Call, M1, N1, Sub);
 	{yes,Seq} -> expr(Seq, Ctxt, Sub)
     end;
+expr(#c_primop{name=#c_literal{val=build_stacktrace}}, effect, _Sub) ->
+    void();
 expr(#c_primop{args=As0}=Prim, _, Sub) ->
     As1 = expr_list(As0, value, Sub),
     Prim#c_primop{args=As1};

--- a/lib/compiler/src/v3_codegen.erl
+++ b/lib/compiler/src/v3_codegen.erl
@@ -1656,6 +1656,11 @@ internal_cg(bs_init_writable=I, As, Rs, Le, Vdb, Bef, St) ->
     {Sis,Int} = cg_setup_call(As, Bef, Le#l.i, Vdb),
     Reg = load_vars(Rs, clear_regs(Int#sr.reg)),
     {Sis++[I],clear_dead(Int#sr{reg=Reg}, Le#l.i, Vdb),St};
+internal_cg(build_stacktrace=I, As, Rs, Le, Vdb, Bef, St) ->
+    %% This behaves like a function call.
+    {Sis,Int} = cg_setup_call(As, Bef, Le#l.i, Vdb),
+    Reg = load_vars(Rs, clear_regs(Int#sr.reg)),
+    {Sis++[I],clear_dead(Int#sr{reg=Reg}, Le#l.i, Vdb),St};
 internal_cg(raise, As, Rs, Le, Vdb, Bef, St) ->
     %% raise can be treated like a guard BIF.
     bif_cg(raise, As, Rs, Le, Vdb, Bef, St).

--- a/lib/compiler/test/beam_validator_SUITE.erl
+++ b/lib/compiler/test/beam_validator_SUITE.erl
@@ -421,9 +421,9 @@ try_bin_opt(Mod) ->
     try
 	do_bin_opt(Mod)
     catch
-	Class:Error ->
+	Class:Error:Stk ->
 	    io:format("~p: ~p ~p\n~p\n",
-		      [Mod,Class,Error,erlang:get_stacktrace()]),
+		      [Mod,Class,Error,Stk]),
 	    error
     end.
 

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -500,9 +500,8 @@ do_kernel_listing({M,A}) ->
 	    io:format("*** compilation failure '~p' for module ~s\n",
 		      [Error,M]),
 	    error;
-	Class:Error ->
-	    io:format("~p: ~p ~p\n~p\n",
-		      [M,Class,Error,erlang:get_stacktrace()]),
+	Class:Error:Stk ->
+	    io:format("~p: ~p ~p\n~p\n", [M,Class,Error,Stk]),
 	    error
     end.
 
@@ -902,9 +901,8 @@ do_core_pp({M,A}, Outdir) ->
 	    io:format("*** compilation failure '~p' for module ~s\n",
 		      [Error,M]),
 	    error;
-	Class:Error ->
-	    io:format("~p: ~p ~p\n~p\n",
-		      [M,Class,Error,erlang:get_stacktrace()]),
+	Class:Error:Stk ->
+	    io:format("~p: ~p ~p\n~p\n", [M,Class,Error,Stk]),
 	    error
     end.
 
@@ -961,9 +959,8 @@ do_core_roundtrip(Beam, Outdir) ->
 	    io:format("*** compilation failure '~p' for file ~s\n",
 		      [Error,Beam]),
 	    error;
-	Class:Error ->
-	    io:format("~p: ~p ~p\n~p\n",
-		      [Beam,Class,Error,erlang:get_stacktrace()]),
+	Class:Error:Stk ->
+	    io:format("~p: ~p ~p\n~p\n", [Beam,Class,Error,Stk]),
 	    error
     end.
 
@@ -1148,9 +1145,8 @@ do_asm(Beam, Outdir) ->
 			  [Other,AsmFile]),
 		error
 	end
-    catch Class:Error ->
-	    io:format("~p: ~p ~p\n~p\n",
-		      [M,Class,Error,erlang:get_stacktrace()]),
+    catch Class:Error:Stk ->
+	    io:format("~p: ~p ~p\n~p\n", [M,Class,Error,Stk]),
 	    error
     end.
 
@@ -1167,9 +1163,8 @@ do_opt_guards(Beam) ->
     try
 	{ok,M,Asm} = compile:forms(A, ['S']),
 	do_opt_guards_mod(Asm)
-    catch Class:Error ->
-	    io:format("~p: ~p ~p\n~p\n",
-		      [M,Class,Error,erlang:get_stacktrace()]),
+    catch Class:Error:Stk ->
+	    io:format("~p: ~p ~p\n~p\n", [M,Class,Error,Stk]),
 	    error
     end.
 

--- a/lib/compiler/test/misc_SUITE.erl
+++ b/lib/compiler/test/misc_SUITE.erl
@@ -318,8 +318,7 @@ expect_error(Fun) ->
 	    io:format("~p", [Any]),
 	    ct:fail(call_was_supposed_to_fail)
     catch
-	Class:Reason ->
-	    Stk = erlang:get_stacktrace(),
+	Class:Reason:Stk ->
 	    io:format("~p:~p\n~p\n", [Class,Reason,Stk]),
 	    case {Class,Reason} of
 		{error,undef} ->

--- a/lib/compiler/test/receive_SUITE.erl
+++ b/lib/compiler/test/receive_SUITE.erl
@@ -222,9 +222,8 @@ do_ref_opt(Source, PrivDir) ->
 		    collect_recv_opt_instrs(Code)
 	end,
 	ok
-    catch Class:Error ->
-	    io:format("~s: ~p ~p\n~p\n",
-		      [Source,Class,Error,erlang:get_stacktrace()]),
+    catch Class:Error:Stk ->
+	    io:format("~s: ~p ~p\n~p\n", [Source,Class,Error,Stk]),
 	    error
     end.
 

--- a/lib/compiler/test/trycatch_SUITE.erl
+++ b/lib/compiler/test/trycatch_SUITE.erl
@@ -26,7 +26,8 @@
 	 nested_of/1,nested_catch/1,nested_after/1,
 	 nested_horrid/1,last_call_optimization/1,bool/1,
 	 plain_catch_coverage/1,andalso_orelse/1,get_in_try/1,
-	 hockey/1,handle_info/1,catch_in_catch/1,grab_bag/1]).
+	 hockey/1,handle_info/1,catch_in_catch/1,grab_bag/1,
+         stacktrace/1,nested_stacktrace/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -42,7 +43,8 @@ groups() ->
        after_oops,eclectic,rethrow,nested_of,nested_catch,
        nested_after,nested_horrid,last_call_optimization,
        bool,plain_catch_coverage,andalso_orelse,get_in_try,
-       hockey,handle_info,catch_in_catch,grab_bag]}].
+       hockey,handle_info,catch_in_catch,grab_bag,
+       stacktrace,nested_stacktrace]}].
 
 
 init_per_suite(Config) ->
@@ -1038,6 +1040,124 @@ grab_bag(_Config) ->
     22 = (catch 22),
 
     ok.
+
+stacktrace(_Config) ->
+    V = [make_ref()|self()],
+    case ?MODULE:module_info(native) of
+        false ->
+            {value2,{caught1,badarg,[{erlang,abs,[V],_}|_]}} =
+                stacktrace_1({'abs',V}, error, {value,V}),
+            {caught2,{error,badarith},[{erlang,'+',[0,a],_},
+                                       {?MODULE,my_add,2,_}|_]} =
+                stacktrace_1({'div',{1,0}}, error, {'add',{0,a}});
+        true ->
+            {value2,{caught1,badarg,[{?MODULE,my_abs,1,_}|_]}} =
+                stacktrace_1({'abs',V}, error, {value,V}),
+            {caught2,{error,badarith},[{?MODULE,my_add,2,_}|_]} =
+                stacktrace_1({'div',{1,0}}, error, {'add',{0,a}})
+    end,
+    {caught2,{error,{try_clause,V}},[{?MODULE,stacktrace_1,3,_}|_]} =
+        stacktrace_1({value,V}, error, {value,V}),
+    {caught2,{throw,V},[{?MODULE,foo,1,_}|_]} =
+        stacktrace_1({value,V}, error, {throw,V}),
+
+    try
+        stacktrace_2()
+    catch
+        error:{badmatch,_}:Stk2 ->
+            [{?MODULE,stacktrace_2,0,_},
+             {?MODULE,stacktrace,1,_}|_] = Stk2,
+            Stk2 = erlang:get_stacktrace(),
+            ok
+    end,
+
+    try
+        stacktrace_3(a, b)
+    catch
+        error:function_clause:Stk3 ->
+            Stk3 = erlang:get_stacktrace(),
+            case lists:module_info(native) of
+                false ->
+                    [{lists,prefix,[a,b],_}|_] = Stk3;
+                true ->
+                    [{lists,prefix,2,_}|_] = Stk3
+            end
+    end,
+
+    try
+        throw(x)
+    catch
+        throw:x:IntentionallyUnused ->
+            ok
+    end.
+
+stacktrace_1(X, C1, Y) ->
+    try try foo(X) of
+            C1 -> value1
+        catch
+            C1:D1:Stk1 ->
+                Stk1 = erlang:get_stacktrace(),
+                {caught1,D1,Stk1}
+        after
+            foo(Y)
+        end of
+        V2 -> {value2,V2}
+    catch
+        C2:D2:Stk2 -> {caught2,{C2,D2},Stk2=erlang:get_stacktrace()}
+    end.
+
+stacktrace_2() ->
+    ok = erlang:process_info(self(), current_function),
+    ok.
+
+stacktrace_3(A, B) ->
+    {ok,lists:prefix(A, B)}.
+
+nested_stacktrace(_Config) ->
+    V = [{make_ref()}|[self()]],
+    value1 = nested_stacktrace_1({{value,{V,x1}},void,{V,x1}},
+                                 {void,void,void}),
+    case ?MODULE:module_info(native) of
+        false ->
+            {caught1,
+             [{erlang,'+',[V,x1],_},{?MODULE,my_add,2,_}|_],
+             value2} =
+                nested_stacktrace_1({{'add',{V,x1}},error,badarith},
+                                    {{value,{V,x2}},void,{V,x2}}),
+            {caught1,
+             [{erlang,'+',[V,x1],_},{?MODULE,my_add,2,_}|_],
+             {caught2,[{erlang,abs,[V],_}|_]}} =
+                nested_stacktrace_1({{'add',{V,x1}},error,badarith},
+                                    {{'abs',V},error,badarg});
+        true ->
+            {caught1,
+             [{?MODULE,my_add,2,_}|_],
+             value2} =
+                nested_stacktrace_1({{'add',{V,x1}},error,badarith},
+                                    {{value,{V,x2}},void,{V,x2}}),
+            {caught1,
+             [{?MODULE,my_add,2,_}|_],
+             {caught2,[{?MODULE,my_abs,1,_}|_]}} =
+                nested_stacktrace_1({{'add',{V,x1}},error,badarith},
+                                    {{'abs',V},error,badarg})
+    end,
+    ok.
+
+nested_stacktrace_1({X1,C1,V1}, {X2,C2,V2}) ->
+    try foo(X1) of
+        V1 -> value1
+    catch
+        C1:V1:S1 ->
+            S1 = erlang:get_stacktrace(),
+            T2 = try foo(X2) of
+                     V2 -> value2
+                 catch
+                     C2:V2:S2 ->
+                         S2 = erlang:get_stacktrace(),
+                         {caught2,S2}
+                 end,
+            {caught1,S1,T2}
+    end.
 
 
 id(I) -> I.

--- a/lib/compiler/test/z_SUITE.erl
+++ b/lib/compiler/test/z_SUITE.erl
@@ -54,8 +54,7 @@ do_loaded([{M,_}|Ms], E0) ->
 	    _ = M:module_info(functions),
 	    E0
 	catch
-	    C:Error ->
-		Stk = erlang:get_stacktrace(),
+	    C:Error:Stk ->
 		io:format("~p:~p\n~p\n", [C,Error,Stk]),
 		E0 + 1
 	end,

--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -299,6 +299,7 @@ traverse(Tree, Map, State) ->
 	  match_fail -> t_none();
 	  raise -> t_none();
 	  bs_init_writable -> t_from_term(<<>>);
+          build_stacktrace -> t_list();
 	  Other -> erlang:error({'Unsupported primop', Other})
 	end,
       {State, Map, Type};

--- a/lib/dialyzer/src/dialyzer_typesig.erl
+++ b/lib/dialyzer/src/dialyzer_typesig.erl
@@ -418,6 +418,7 @@ traverse(Tree, DefinedVars, State) ->
 	match_fail -> throw(error);
 	raise -> throw(error);
 	bs_init_writable -> {State, t_from_term(<<>>)};
+	build_stacktrace -> {State, t_list()};
 	Other -> erlang:error({'Unsupported primop', Other})
       end;
     'receive' ->

--- a/lib/hipe/icode/hipe_beam_to_icode.erl
+++ b/lib/hipe/icode/hipe_beam_to_icode.erl
@@ -1159,6 +1159,11 @@ trans_fun([{put_map_exact,{f,Lbl},Map,Dst,_N,{list,Pairs}}|Instructions], Env) -
 	  gen_put_map_instrs(new, exact, TempMapVar, Dst, new, Pairs, Env1)
       end,
   [MapMove, TempMapMove, PutInstructions | trans_fun(Instructions, Env2)];
+%%--- build_stacktrace ---
+trans_fun([build_stacktrace|Instructions], Env) ->
+  Vars = [mk_var({x,0})], %{x,0} is implict arg and dst
+  [hipe_icode:mk_primop(Vars,build_stacktrace,Vars),
+   trans_fun(Instructions, Env)];
 %%--------------------------------------------------------------------
 %%--- ERROR HANDLING ---
 %%--------------------------------------------------------------------

--- a/lib/hipe/icode/hipe_icode_primops.erl
+++ b/lib/hipe/icode/hipe_icode_primops.erl
@@ -132,6 +132,7 @@ is_safe({hipe_bs_primop, {bs_match_string, _, _}}) -> false;
 is_safe({hipe_bs_primop, {bs_append, _, _, _, _}}) -> false;
 is_safe({hipe_bs_primop, {bs_private_append, _, _}}) -> false;
 is_safe({hipe_bs_primop, bs_init_writable}) -> true;
+is_safe(build_stacktrace) -> true;
 is_safe(#mkfun{}) -> true;
 is_safe(#unsafe_element{}) -> true;
 is_safe(#unsafe_update_element{}) -> true;
@@ -234,6 +235,7 @@ fails({hipe_bs_primop, bs_final}) -> false;
 fails({hipe_bs_primop, {bs_append, _, _, _, _}}) -> true;
 fails({hipe_bs_primop, {bs_private_append, _, _}}) -> true;
 fails({hipe_bs_primop, bs_init_writable}) -> true;
+fails(build_stacktrace) -> false;
 fails(#mkfun{}) -> false;
 fails(#unsafe_element{}) -> false;
 fails(#unsafe_update_element{}) -> false;
@@ -731,6 +733,8 @@ type(Primop, Args) ->
       erl_types:t_any();
     debug_native_called ->
       erl_types:t_any();
+    build_stacktrace ->
+      erl_types:t_list();
     {M, F, A} ->
       erl_bif_types:type(M, F, A, Args)
   end.
@@ -903,6 +907,8 @@ type(Primop) ->
       erl_types:t_any();
 %%% -----------------------------------------------------
 %%% Other
+    build_stacktrace ->
+      erl_types:t_any();
     #closure_element{} ->
       erl_types:t_any();
     redtest ->

--- a/lib/hipe/icode/hipe_icode_range.erl
+++ b/lib/hipe/icode/hipe_icode_range.erl
@@ -1186,7 +1186,8 @@ basic_type(unsafe_hd) -> not_analysed;
 basic_type(unsafe_tl) -> not_int;
 basic_type(#element{}) -> not_analysed;
 basic_type(#unsafe_element{}) -> not_analysed;
-basic_type(#unsafe_update_element{}) -> not_analysed.
+basic_type(#unsafe_update_element{}) -> not_analysed;
+basic_type(build_stacktrace) -> not_int.
 
 -spec analyse_bs_get_integer(integer(), integer(), boolean()) -> range_tuple().
 

--- a/lib/hipe/rtl/hipe_rtl_primops.erl
+++ b/lib/hipe/rtl/hipe_rtl_primops.erl
@@ -394,6 +394,8 @@ gen_primop({Op,Dst,Args,Cont,Fail}, IsGuard, ConstTab) ->
 	    end;
 	  debug_native_called -> 
 	    [hipe_rtl:mk_call(Dst, Op, Args, Cont, Fail, not_remote)];
+          build_stacktrace ->
+	    [hipe_rtl:mk_call(Dst, Op, Args, Cont, Fail, not_remote)];
 
 	  %% Only names listed above are accepted! MFA:s are not primops!
 	  _ ->

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -29,6 +29,10 @@ clause_args clause_guard clause_body
 expr expr_100 expr_150 expr_160 expr_200 expr_300 expr_400 expr_500
 expr_600 expr_700 expr_800
 expr_max
+pat_expr pat_expr_200 pat_expr_300 pat_expr_400 pat_expr_500
+pat_expr_600 pat_expr_700 pat_expr_800
+pat_expr_max map_pat_expr record_pat_expr
+pat_argument_list pat_exprs
 list tail
 list_comprehension lc_expr lc_exprs
 binary_comprehension
@@ -66,7 +70,7 @@ char integer float atom string var
 'spec' 'callback' % helper
 dot.
 
-Expect 2.
+Expect 0.
 
 Rootsymbol form.
 
@@ -210,7 +214,7 @@ function_clause -> atom clause_args clause_guard clause_body :
 	{clause,?anno('$1'),element(3, '$1'),'$2','$3','$4'}.
 
 
-clause_args -> argument_list : element(1, '$1').
+clause_args -> pat_argument_list : element(1, '$1').
 
 clause_guard -> 'when' guard : '$2'.
 clause_guard -> '$empty' : [].
@@ -275,6 +279,53 @@ expr_max -> receive_expr : '$1'.
 expr_max -> fun_expr : '$1'.
 expr_max -> try_expr : '$1'.
 
+pat_expr -> pat_expr_200 '=' pat_expr : {match,?anno('$2'),'$1','$3'}.
+pat_expr -> pat_expr_200 : '$1'.
+
+pat_expr_200 -> pat_expr_300 comp_op pat_expr_300 :
+	?mkop2('$1', '$2', '$3').
+pat_expr_200 -> pat_expr_300 : '$1'.
+
+pat_expr_300 -> pat_expr_400 list_op pat_expr_300 :
+	?mkop2('$1', '$2', '$3').
+pat_expr_300 -> pat_expr_400 : '$1'.
+
+pat_expr_400 -> pat_expr_400 add_op pat_expr_500 :
+	?mkop2('$1', '$2', '$3').
+pat_expr_400 -> pat_expr_500 : '$1'.
+
+pat_expr_500 -> pat_expr_500 mult_op pat_expr_600 :
+	?mkop2('$1', '$2', '$3').
+pat_expr_500 -> pat_expr_600 : '$1'.
+
+pat_expr_600 -> prefix_op pat_expr_700 :
+	?mkop1('$1', '$2').
+pat_expr_600 -> map_pat_expr : '$1'.
+pat_expr_600 -> pat_expr_700 : '$1'.
+
+pat_expr_700 -> record_pat_expr : '$1'.
+pat_expr_700 -> pat_expr_800 : '$1'.
+
+pat_expr_800 -> pat_expr_max : '$1'.
+
+pat_expr_max -> var : '$1'.
+pat_expr_max -> atomic : '$1'.
+pat_expr_max -> list : '$1'.
+pat_expr_max -> binary : '$1'.
+pat_expr_max -> tuple : '$1'.
+pat_expr_max -> '(' pat_expr ')' : '$2'.
+
+map_pat_expr -> '#' map_tuple :
+	{map, ?anno('$1'),'$2'}.
+map_pat_expr -> pat_expr_max '#' map_tuple :
+	{map, ?anno('$2'),'$1','$3'}.
+map_pat_expr -> map_pat_expr '#' map_tuple :
+	{map, ?anno('$2'),'$1','$3'}.
+
+record_pat_expr -> '#' atom '.' atom :
+	{record_index,?anno('$1'),element(3, '$2'),'$4'}.
+record_pat_expr -> '#' atom record_tuple :
+	{record,?anno('$1'),element(3, '$2'),'$3'}.
 
 list -> '[' ']' : {nil,?anno('$1')}.
 list -> '[' expr tail : {cons,?anno('$1'),'$2','$3'}.
@@ -397,6 +448,10 @@ case_expr -> 'case' expr 'of' cr_clauses 'end' :
 cr_clauses -> cr_clause : ['$1'].
 cr_clauses -> cr_clause ';' cr_clauses : ['$1' | '$3'].
 
+%% FIXME: merl in syntax_tools depends on patterns in a 'case' being
+%% full expressions. Therefore, we can't use pat_expr here. There
+%% should be a better way.
+
 cr_clause -> expr clause_guard clause_body :
 	{clause,?anno('$1'),['$1'],'$2','$3'}.
 
@@ -424,11 +479,11 @@ integer_or_var -> var : '$1'.
 fun_clauses -> fun_clause : ['$1'].
 fun_clauses -> fun_clause ';' fun_clauses : ['$1' | '$3'].
 
-fun_clause -> argument_list clause_guard clause_body :
+fun_clause -> pat_argument_list clause_guard clause_body :
 	{Args,Anno} = '$1',
 	{clause,Anno,'fun',Args,'$2','$3'}.
 
-fun_clause -> var argument_list clause_guard clause_body :
+fun_clause -> var pat_argument_list clause_guard clause_body :
 	{clause,element(2, '$1'),element(3, '$1'),element(1, '$2'),'$3','$4'}.
 
 try_expr -> 'try' exprs 'of' cr_clauses try_catch :
@@ -446,13 +501,13 @@ try_catch -> 'after' exprs 'end' :
 try_clauses -> try_clause : ['$1'].
 try_clauses -> try_clause ';' try_clauses : ['$1' | '$3'].
 
-try_clause -> expr clause_guard clause_body :
+try_clause -> pat_expr clause_guard clause_body :
 	A = ?anno('$1'),
 	{clause,A,[{tuple,A,[{atom,A,throw},'$1',{var,A,'_'}]}],'$2','$3'}.
-try_clause -> atom ':' expr clause_guard clause_body :
+try_clause -> atom ':' pat_expr clause_guard clause_body :
 	A = ?anno('$1'),
 	{clause,A,[{tuple,A,['$1','$3',{var,A,'_'}]}],'$4','$5'}.
-try_clause -> var ':' expr clause_guard clause_body :
+try_clause -> var ':' pat_expr clause_guard clause_body :
 	A = ?anno('$1'),
 	{clause,A,[{tuple,A,['$1','$3',{var,A,'_'}]}],'$4','$5'}.
 
@@ -460,9 +515,14 @@ try_clause -> var ':' expr clause_guard clause_body :
 argument_list -> '(' ')' : {[],?anno('$1')}.
 argument_list -> '(' exprs ')' : {'$2',?anno('$1')}.
 
+pat_argument_list -> '(' ')' : {[],?anno('$1')}.
+pat_argument_list -> '(' pat_exprs ')' : {'$2',?anno('$1')}.
 
 exprs -> expr : ['$1'].
 exprs -> expr ',' exprs : ['$1' | '$3'].
+
+pat_exprs -> pat_expr : ['$1'].
+pat_exprs -> pat_expr ',' pat_exprs : ['$1' | '$3'].
 
 guard -> exprs : ['$1'].
 guard -> exprs ';' guard : ['$1'|'$3'].

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -41,7 +41,7 @@ record_expr record_tuple record_field record_fields
 map_expr map_tuple map_field map_field_assoc map_field_exact map_fields map_key
 if_expr if_clause if_clauses case_expr cr_clause cr_clauses receive_expr
 fun_expr fun_clause fun_clauses atom_or_var integer_or_var
-try_expr try_catch try_clause try_clauses
+try_expr try_catch try_clause try_clauses try_opt_stacktrace
 function_call argument_list
 exprs guard
 atomic strings
@@ -504,13 +504,15 @@ try_clauses -> try_clause ';' try_clauses : ['$1' | '$3'].
 try_clause -> pat_expr clause_guard clause_body :
 	A = ?anno('$1'),
 	{clause,A,[{tuple,A,[{atom,A,throw},'$1',{var,A,'_'}]}],'$2','$3'}.
-try_clause -> atom ':' pat_expr clause_guard clause_body :
+try_clause -> atom ':' pat_expr try_opt_stacktrace clause_guard clause_body :
 	A = ?anno('$1'),
-	{clause,A,[{tuple,A,['$1','$3',{var,A,'_'}]}],'$4','$5'}.
-try_clause -> var ':' pat_expr clause_guard clause_body :
+	{clause,A,[{tuple,A,['$1','$3',{var,A,'$4'}]}],'$5','$6'}.
+try_clause -> var ':' pat_expr try_opt_stacktrace clause_guard clause_body :
 	A = ?anno('$1'),
-	{clause,A,[{tuple,A,['$1','$3',{var,A,'_'}]}],'$4','$5'}.
+	{clause,A,[{tuple,A,['$1','$3',{var,A,'$4'}]}],'$5','$6'}.
 
+try_opt_stacktrace -> ':' var : element(3, '$2').
+try_opt_stacktrace -> '$empty' : '_'.
 
 argument_list -> '(' ')' : {[],?anno('$1')}.
 argument_list -> '(' exprs ')' : {'$2',?anno('$1')}.

--- a/lib/syntax_tools/src/erl_prettypr.erl
+++ b/lib/syntax_tools/src/erl_prettypr.erl
@@ -774,9 +774,17 @@ lay_2(Node, Ctxt) ->
 	class_qualifier ->
 	    Ctxt1 = set_prec(Ctxt, max_prec()),
 	    D1 = lay(erl_syntax:class_qualifier_argument(Node), Ctxt1),
-	    D2 = lay(erl_syntax:class_qualifier_body(Node), Ctxt1),
-	    beside(D1, beside(text(":"), D2));
-
+            D2 = lay(erl_syntax:class_qualifier_body(Node), Ctxt1),
+            Stacktrace = erl_syntax:class_qualifier_stacktrace(Node),
+            case erl_syntax:variable_name(Stacktrace) of
+                '_' ->
+                    beside(D1, beside(text(":"), D2));
+                _ ->
+                    D3 = lay(erl_syntax:class_qualifier_stacktrace(Node),
+                             Ctxt1),
+                    beside(D1, beside(beside(text(":"), D2),
+                                      beside(text(":"), D3)))
+            end;
 	comment ->
 	    D = stack_comment_lines(
 		  erl_syntax:comment_text(Node)),

--- a/system/doc/reference_manual/errors.xml
+++ b/system/doc/reference_manual/errors.xml
@@ -108,13 +108,54 @@
       (see <seealso marker="#exit_reasons">Exit Reason</seealso>),
       and a stack trace (which aids in finding the code location of
       the exception).</p>
-    <p>The stack trace can be retrieved using
-      <c>erlang:get_stacktrace/0</c>
-      from within a <c>try</c> expression, and is returned for 
+    <p>The stack trace can be be bound to a variable from within
+      a <c>try</c> expression, and is returned for
       exceptions of class <c>error</c> from a <c>catch</c> expression.</p>
     <p>An exception of class <c>error</c> is also known as a run-time 
       error.</p>
+
+      <section>
+	<title>The call-stack back trace (stacktrace)</title>
+        <p>The stack back-trace (<em>stacktrace</em>) is a list of
+          <c>{Module,Function,Arity,Location}</c>
+          tuples. The field <c>Arity</c> in the first tuple can be the
+          argument list of that function call instead of an arity integer,
+          depending on the exception.</p>
+
+	<p><c>Location</c> is a (possibly empty) list of two-tuples
+	that can indicate the location in the source code of the
+	function.  The first element is an atom describing the type of
+	information in the second element. The following items can
+	occur:</p>
+	<taglist>
+          <tag><c>file</c></tag>
+          <item>The second element of the tuple is a string (list of
+          characters) representing the filename of the source file
+          of the function.
+          </item>
+          <tag><c>line</c></tag>
+          <item>The second element of the tuple is the line number
+          (an integer &gt; 0) in the source file
+          where the exception occurred or the function was called.
+          </item>
+	</taglist>
+	<warning><p>Developers should rely on stacktrace entries only for
+	debugging purposes.</p>
+	<p>The VM performs tail call optimization, which
+	does not add new entries to the stacktrace, and also limits stacktraces
+	to a certain depth. Furthermore, compiler options, optimizations and
+	future changes may add or remove stacktrace entries, causing any code
+	that expects the stacktrace to be in a certain order or contain specific
+	items to fail.</p>
+	<p>The only exception to this rule is the class <c>error</c> with the
+	reason <c>undef</c> which is guaranteed to include the <c>Module</c>,
+	<c>Function</c> and <c>Arity</c> of the attempted
+	function as the first stacktrace entry.</p>
+	</warning>
+      </section>
+
   </section>
+
 
   <section>
     <title>Handling of Run-time Errors in Erlang</title>

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -1340,9 +1340,9 @@ hello</pre>
     <code type="none">
 try Exprs
 catch
-    [Class1:]ExceptionPattern1 [when ExceptionGuardSeq1] ->
+    Class1:ExceptionPattern1[:Stacktrace] [when ExceptionGuardSeq1] ->
         ExceptionBody1;
-    [ClassN:]ExceptionPatternN [when ExceptionGuardSeqN] ->
+    ClassN:ExceptionPatternN[:Stacktrace] [when ExceptionGuardSeqN] ->
         ExceptionBodyN
 end</code>
     <p>This is an enhancement of
@@ -1362,10 +1362,12 @@ end</code>
       the evaluation. In that case the exception is caught and
       the patterns <c>ExceptionPattern</c> with the right exception
       class <c>Class</c> are sequentially matched against the caught
-      exception. An omitted <c>Class</c> is shorthand for <c>throw</c>.
-      If a match succeeds and the optional guard sequence
+      exception. If a match succeeds and the optional guard sequence
       <c>ExceptionGuardSeq</c> is true, the corresponding
       <c>ExceptionBody</c> is evaluated to become the return value.</p>
+    <p><c>Stacktrace</c>, if specified, must be the name of a variable
+      (not a pattern). The stack trace is bound to the variable when
+      the corresponding <c>ExceptionPattern</c> matches.</p>
     <p>If an exception occurs during evaluation of <c>Exprs</c> but
       there is no matching <c>ExceptionPattern</c> of the right
       <c>Class</c> with a true guard sequence, the exception is passed
@@ -1373,6 +1375,18 @@ end</code>
       expression.</p>
     <p>If an exception occurs during evaluation of <c>ExceptionBody</c>,
       it is not caught.</p>
+    <p>It is allowed to omit <c>Class</c> and <c>Stacktrace</c>.
+      An omitted <c>Class</c> is shorthand for <c>throw</c>:</p>
+
+    <code type="none">
+try Exprs
+catch
+    ExceptionPattern1 [when ExceptionGuardSeq1] ->
+        ExceptionBody1;
+    ExceptionPatternN [when ExceptionGuardSeqN] ->
+        ExceptionBodyN
+end</code>
+
     <p>The <c>try</c> expression can have an <c>of</c>
       section:
       </p>
@@ -1384,10 +1398,10 @@ try Exprs of
     PatternN [when GuardSeqN] ->
         BodyN
 catch
-    [Class1:]ExceptionPattern1 [when ExceptionGuardSeq1] ->
+    Class1:ExceptionPattern1[:Stacktrace] [when ExceptionGuardSeq1] ->
         ExceptionBody1;
     ...;
-    [ClassN:]ExceptionPatternN [when ExceptionGuardSeqN] ->
+    ClassN:ExceptionPatternN[:Stacktrace] [when ExceptionGuardSeqN] ->
         ExceptionBodyN
 end</code>
     <p>If the evaluation of <c>Exprs</c> succeeds without an exception,
@@ -1408,10 +1422,10 @@ try Exprs of
     PatternN [when GuardSeqN] ->
         BodyN
 catch
-    [Class1:]ExceptionPattern1 [when ExceptionGuardSeq1] ->
+    Class1:ExceptionPattern1[:Stacktrace] [when ExceptionGuardSeq1] ->
         ExceptionBody1;
     ...;
-    [ClassN:]ExceptionPatternN [when ExceptionGuardSeqN] ->
+    ClassN:ExceptionPatternN[:Stacktrace] [when ExceptionGuardSeqN] ->
         ExceptionBodyN
 after
     AfterBody
@@ -1470,7 +1484,7 @@ try Expr
 catch
     throw:Term -> Term;
     exit:Reason -> {'EXIT',Reason}
-    error:Reason -> {'EXIT',{Reason,erlang:get_stacktrace()}}
+    error:Reason:Stk -> {'EXIT',{Reason,Stk}}
 end</code>
   </section>
 


### PR DESCRIPTION
This PR adds a new syntax for retrieving the stacktrace without calling `erlang:get_stacktrace/0`. That allow us to deprecate `erlang:get_stacktrace/0` and ultimately remove it.

The problem with `erlang:get_stacktrace/0` is that it can keep huge terms in a process for an indefinite time after an exception. The stacktrace can be huge after a `function_clause` exception or a failed call to a BIF or operator, because the arguments for the call will be included in the stacktrace. For example:

```
1> catch abs(lists:seq(1, 1000)).
{'EXIT',{badarg,[{erlang,abs,
                         [[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20|...]],
                         []},
                 {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,674}]},
                 {erl_eval,expr,5,[{file,"erl_eval.erl"},{line,431}]},
                 {shell,exprs,7,[{file,"shell.erl"},{line,687}]},
                 {shell,eval_exprs,7,[{file,"shell.erl"},{line,642}]},
                 {shell,eval_loop,3,[{file,"shell.erl"},{line,627}]}]}}
2> erlang:get_stacktrace().
[{erlang,abs,
         [[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,
           23,24|...]],
         []},
 {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,674}]},
 {erl_eval,expr,5,[{file,"erl_eval.erl"},{line,431}]},
 {shell,exprs,7,[{file,"shell.erl"},{line,687}]},
 {shell,eval_exprs,7,[{file,"shell.erl"},{line,642}]},
 {shell,eval_loop,3,[{file,"shell.erl"},{line,627}]}]
3>
```

We can extend the syntax for clauses in try/catch to optionally bind the stacktrace to a variable.

Here is an example using the current syntax:

    try
      Expr
    catch C:E ->
      Stk = erlang:get_stacktrace(),
      .
      .
      .

In the new syntax, it would look like:

    try
      Expr
    catch
      C:E:Stk ->
       .
       .
       .
Only a variable (not a pattern) is allowed in the stacktrace position, to discourage matching of the stacktrace. (Matching would also be expensive, because the raw format of the stacktrace would have to be converted to the cooked form before matching.)

Note that:

    try
      Expr
    catch E ->
      .
      .
      .

is a shorthand for:

    try
      Expr
    catch throw:E ->
      .
      .
      .
If the stacktrace is to be retrieved for a throw, the `throw:`
prefix must be explicitly included:

    try
      Expr
    catch throw:E:Stk ->
      .
      .
      .
