### PR TITLE
Experimental usrsctp support

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1659,9 +1659,13 @@ if test "x$enable_sctp" != "xno" ; then
 	])
 fi
 
+AC_SUBST(LIBSCTP)
 if test "x$enable_sctp" != "xno" ; then
     AC_CHECK_HEADER(usrsctp.h,
-        [AC_DEFINE(HAVE_USRSCTP, [1],
+        [LIBSCTP=libusrsctp.dylib
+	AC_DEFINE(HAVE_SCTP_H, [1],
+	    [Define to 1 if you have the SCTP support])
+	AC_DEFINE(HAVE_USRSCTP, [1],
             [Define to 1 if you have the <usrsctp.h> header file])],
 	[],
 	[#if HAVE_SYS_SOCKET_H

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1659,6 +1659,17 @@ if test "x$enable_sctp" != "xno" ; then
 	])
 fi
 
+if test "x$enable_sctp" != "xno" ; then
+    AC_CHECK_HEADER(usrsctp.h,
+        [AC_DEFINE(HAVE_USRSCTP, [1],
+            [Define to 1 if you have the <usrsctp.h> header file])],
+	[],
+	[#if HAVE_SYS_SOCKET_H
+	 #include <sys/socket.h>
+	 #endif
+	])
+fi
+
 if test x"$ac_cv_header_netinet_sctp_h" = x"yes"; then
     AS_IF([test "x$enable_sctp" = "xlib"],
         AC_CHECK_LIB(sctp, sctp_bindx))

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1647,7 +1647,8 @@ AC_CHECK_HEADERS([sys/timerfd.h])
 
 dnl Check for kernel SCTP support
 AC_SUBST(LIBSCTP)
-if test "x$enable_sctp" != "xno" ; then
+if test "x$enable_sctp" != "xno" && \
+   test "x$enable_sctp" != "xusrsctp" ; then
     AC_CHECK_HEADER(netinet/sctp.h,
         [LIBSCTP=libsctp.so.1
 	 AC_DEFINE(HAVE_SCTP_H, [1],
@@ -1682,8 +1683,7 @@ if test "x$enable_sctp" = "xusrsctp" ; then
 	])
 fi
 
-if test x"$ac_cv_header_netinet_sctp_h" = x"yes" || \
-   test x"$ac_cv_header_usrsctp_h" = x"yes" ; then
+if test x"$ac_cv_header_netinet_sctp_h" = x"yes" ; then
     AS_IF([test "x$enable_sctp" = "xlib"],
         AC_CHECK_LIB(sctp, sctp_bindx))
     AC_CHECK_FUNCS([sctp_bindx sctp_peeloff sctp_getladdrs sctp_freeladdrs sctp_getpaddrs sctp_freepaddrs])
@@ -1715,6 +1715,38 @@ if test x"$ac_cv_header_netinet_sctp_h" = x"yes" || \
          #include <sys/socket.h>
          #endif
          #include <netinet/sctp.h>
+        ])
+fi
+
+if  test x"$ac_cv_header_usrsctp_h" = x"yes" ; then
+    AC_CHECK_DECLS([SCTP_UNORDERED, SCTP_ADDR_OVER, SCTP_ABORT,
+                    SCTP_EOF, SCTP_SENDALL, SCTP_ADDR_CONFIRMED,
+		    SCTP_DELAYED_ACK_TIME,
+		    SCTP_EMPTY, SCTP_UNCONFIRMED,
+		    SCTP_CLOSED, SCTPS_IDLE,
+		    SCTP_BOUND, SCTPS_BOUND,
+		    SCTP_LISTEN, SCTPS_LISTEN,
+		    SCTP_COOKIE_WAIT, SCTPS_COOKIE_WAIT,
+		    SCTP_COOKIE_ECHOED, SCTPS_COOKIE_ECHOED,
+		    SCTP_ESTABLISHED, SCTPS_ESTABLISHED,
+		    SCTP_SHUTDOWN_PENDING, SCTPS_SHUTDOWN_PENDING,
+		    SCTP_SHUTDOWN_SENT, SCTPS_SHUTDOWN_SENT,
+		    SCTP_SHUTDOWN_RECEIVED, SCTPS_SHUTDOWN_RECEIVED,
+		    SCTP_SHUTDOWN_ACK_SENT, SCTPS_SHUTDOWN_ACK_SENT], [], [],
+        [#if HAVE_SYS_SOCKET_H
+         #include <sys/socket.h>
+         #endif
+         #include <usrsctp.h>
+        ])
+    AC_CHECK_MEMBERS([struct sctp_paddrparams.spp_pathmtu,
+                      struct sctp_paddrparams.spp_sackdelay,
+                      struct sctp_paddrparams.spp_flags,
+                      struct sctp_remote_error.sre_data,
+                      struct sctp_send_failed.ssf_data], [], [],
+        [#if HAVE_SYS_SOCKET_H
+         #include <sys/socket.h>
+         #endif
+         #include <usrsctp.h>
         ])
 fi
 

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -175,7 +175,7 @@ AS_HELP_STRING([--enable-sctp=lib], [enable sctp support
 to link against the SCTP library])
 AS_HELP_STRING([--disable-sctp], [disable sctp support]),
 [ case "x$enableval" in
-      xno|xyes|xlib|x)
+      xno|xyes|xlib|xusrsctp|x)
           ;;
       x*)
           AC_MSG_ERROR("invalid value --enable-sctp=$enableval")
@@ -1660,9 +1660,17 @@ if test "x$enable_sctp" != "xno" ; then
 fi
 
 AC_SUBST(LIBSCTP)
-if test "x$enable_sctp" != "xno" ; then
+if test "x$enable_sctp" = "xusrsctp" ; then
+    case $host_os in
+	darwin*)
+	    SCTPLIB=libusrsctp.dylib
+	    ;;
+	linux*)
+	    SCTPLIB=libusrsctp.so
+	    ;;
+    esac
     AC_CHECK_HEADER(usrsctp.h,
-        [LIBSCTP=libusrsctp.dylib
+        [LIBSCTP=$SCTPLIB
 	AC_DEFINE(HAVE_SCTP_H, [1],
 	    [Define to 1 if you have the SCTP support])
 	AC_DEFINE(HAVE_USRSCTP, [1],
@@ -1674,7 +1682,8 @@ if test "x$enable_sctp" != "xno" ; then
 	])
 fi
 
-if test x"$ac_cv_header_netinet_sctp_h" = x"yes"; then
+if test x"$ac_cv_header_netinet_sctp_h" = x"yes" || \
+   test x"$ac_cv_header_usrsctp_h" = x"yes" ; then
     AS_IF([test "x$enable_sctp" = "xlib"],
         AC_CHECK_LIB(sctp, sctp_bindx))
     AC_CHECK_FUNCS([sctp_bindx sctp_peeloff sctp_getladdrs sctp_freeladdrs sctp_getpaddrs sctp_freepaddrs])

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -353,6 +353,8 @@ type	SYS_CHECK_REQ	SHORT_LIVED	SYSTEM		system_check_request
 type  	TEMP_TERM 	TEMPORARY	SYSTEM		temp_term
 type	DRV_TAB		LONG_LIVED	SYSTEM		drv_tab
 type	DRV_EV_STATE	LONG_LIVED	SYSTEM		driver_event_state
+type	DRV_SCTP_SOCK	LONG_LIVED	SYSTEM		driver_sctp_sock
+type	DRV_EV_D_STATE	FIXED_SIZE	SYSTEM		driver_event_data_state
 type	DRV_SEL_D_STATE	FIXED_SIZE	SYSTEM		driver_select_data_state
 type	NIF_SEL_D_STATE	FIXED_SIZE	SYSTEM		enif_select_data_state
 type	FD_LIST		SHORT_LIVED	SYSTEM		fd_list

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -353,8 +353,6 @@ type	SYS_CHECK_REQ	SHORT_LIVED	SYSTEM		system_check_request
 type  	TEMP_TERM 	TEMPORARY	SYSTEM		temp_term
 type	DRV_TAB		LONG_LIVED	SYSTEM		drv_tab
 type	DRV_EV_STATE	LONG_LIVED	SYSTEM		driver_event_state
-type	DRV_SCTP_SOCK	LONG_LIVED	SYSTEM		driver_sctp_sock
-type	DRV_EV_D_STATE	FIXED_SIZE	SYSTEM		driver_event_data_state
 type	DRV_SEL_D_STATE	FIXED_SIZE	SYSTEM		driver_select_data_state
 type	NIF_SEL_D_STATE	FIXED_SIZE	SYSTEM		enif_select_data_state
 type	FD_LIST		SHORT_LIVED	SYSTEM		fd_list
@@ -364,6 +362,7 @@ type	POLL_FDS	LONG_LIVED	SYSTEM		poll_fds
 type	POLL_RES_EVS	LONG_LIVED	SYSTEM		poll_result_events
 type	FD_STATUS	LONG_LIVED	SYSTEM		fd_status
 type	SELECT_FDS	LONG_LIVED	SYSTEM		select_fds
+type	DRV_SCTP_SOCK	LONG_LIVED	SYSTEM		driver_sctp_sock
 
 +if unix
 

--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -38,7 +38,11 @@
 #endif
 
 #include "erl_drv_nif.h"
-
+#if SIZEOF_VOID_P == SIZEOF_LONG
+typedef unsigned long Eterm;
+#elif SIZEOF_VOID_P == SIZEOF_INT
+typedef unsigned int Eterm;
+#endif
 #include <stdlib.h>
 
 #if defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_)
@@ -342,6 +346,9 @@ EXTERN ErlDrvSizeT driver_vec_to_buf(ErlIOVec *ev, char *buf, ErlDrvSizeT len);
 EXTERN int driver_set_timer(ErlDrvPort port, unsigned long time);
 EXTERN int driver_cancel_timer(ErlDrvPort port);
 EXTERN int driver_read_timer(ErlDrvPort port, unsigned long *time_left);
+EXTERN Eterm driver_erts_drvport2id(ErlDrvPort port);
+EXTERN int driver_port_task_input_schedule(Eterm port);
+EXTERN int driver_port_task_output_schedule(Eterm port);
 
 /*
  * Inform runtime system about lengthy work.

--- a/erts/emulator/beam/erl_driver_global.h
+++ b/erts/emulator/beam/erl_driver_global.h
@@ -1,0 +1,9 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef HAVE_USRSCTP
+extern int sctp_raw_ipv4;
+extern int sctp_raw_ipv6;
+extern int sctp_raw_route;
+#endif

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -50,6 +50,7 @@
 #define ERTS_WANT_TIMER_WHEEL_API
 #include "erl_time.h"
 #include "erl_check_io.h"
+#include "erl_driver_global.h"
 
 #ifdef HIPE
 #include "hipe_mode_switch.h"	/* for hipe_mode_switch_init() */
@@ -2105,6 +2106,18 @@ erl_start(int argc, char **argv)
 				 "Invalid ets busy wait threshold: %s\n", arg);
 		    erts_usage();
 		}
+	    }
+	    else if (has_prefix("sctp_raw_ipv4", sub_param)) {
+		arg = get_arg(sub_param+13, argv[i+1], &i);
+		sctp_raw_ipv4 = atoi(arg);
+	    }
+	    else if (has_prefix("sctp_raw_ipv6", sub_param)) {
+		arg = get_arg(sub_param+13, argv[i+1], &i);
+		sctp_raw_ipv6 = atoi(arg);
+	    }
+	    else if (has_prefix("sctp_raw_route", sub_param)) {
+		arg = get_arg(sub_param+14, argv[i+1], &i);
+		sctp_raw_route = atoi(arg);
 	    }
 	    else {
 		erts_fprintf(stderr, "bad -z option %s\n", argv[i]);

--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -1569,7 +1569,10 @@ abort_nosuspend:
 fail:
 
     if (dhndl != ERTS_THR_PRGR_DHANDLE_MANAGED)
-	erts_port_dec_refc(pp);
+    {	
+	if(pp)
+	    erts_port_dec_refc(pp);
+    }
 
     if (ptp) {
         abort_signal_task(pp, ERTS_PROC2PORT_SIG_ABORT,

--- a/erts/emulator/beam/safe_hash.c
+++ b/erts/emulator/beam/safe_hash.c
@@ -29,8 +29,8 @@
 
 #include "safe_hash.h"
 
-/* Currently only used by erl_check_io on Windows */
-#ifndef ERTS_SYS_CONTINOUS_FD_NUMBERS
+/* Currently only used by erl_check_io on Windows and USRSCTP if enabled */
+#if !defined(ERTS_SYS_CONTINOUS_FD_NUMBERS) || defined(HAVE_USRSCTP)
 
 
 static ERTS_INLINE void set_size(SafeHash* h, int size)

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -68,6 +68,7 @@
 
 
 #include "erl_driver.h"
+#include "erl_driver_global.h"
 
 /* The IS_SOCKET_ERROR macro below is used for portability reasons. While
    POSIX specifies that errors from socket-related system calls should be
@@ -485,6 +486,9 @@ static void (*p_sctp_freepaddrs)(struct sockaddr *addrs) = NULL;
 #endif /* ifndef HAVE_USRSCTP */
 
 #ifdef HAVE_USRSCTP
+int sctp_raw_ipv4 = 0;
+int sctp_raw_ipv6 = 0;
+int sctp_raw_route = 0;
 static typeof(usrsctp_bindx) *p_sctp_bindx = NULL;
 static typeof(usrsctp_getladdrs) *p_sctp_getladdrs = NULL;
 static typeof(usrsctp_freeladdrs) *p_sctp_freeladdrs = NULL;
@@ -4339,13 +4343,14 @@ static int inet_init()
 		    p_sctp_freepaddrs = ptr;
 		} else
 		    usrsctp_available = 0;
+
 		if (usrsctp_available)
 		{
 		    inet_init_sctp();
 #ifdef SCTP_DEBUG 
-		    p_usrsctp_init(0, NULL, usrsctp_debug_printf);
+		    p_usrsctp_init(0, NULL, usrsctp_debug_printf, sctp_raw_ipv4, sctp_raw_ipv6, sctp_raw_route);
 #else
-		    p_usrsctp_init(0, NULL, NULL);
+		    p_usrsctp_init(0, NULL, NULL,sctp_raw_ipv4, sctp_raw_ipv6, sctp_raw_route);
 #endif
 		    drop_root_priv();
 		    usrsctp_init_socket_hash();

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -4117,18 +4117,6 @@ static void inet_init_sctp(void) {
 }
 
 #ifdef HAVE_USRSCTP
-/* Haven't figured out any good way of opening a raw socket
-   without beeing root on macos.
-   could add code for using the setuid_socket_wrapper.
-   but for now; set beam to be setuid root.
-   uid will be dropped once the raw socket is open.
-   aka usrsctp has initialized */
-static void drop_root_priv(void)
-{
-    ASSERT(seteuid(getuid()) == 0);
-    ASSERT(setegid(getgid()) == 0);
-}
-
 #ifdef SCTP_DEBUG
 static void usrsctp_debug_printf(const char *format, ...)
 {
@@ -4352,7 +4340,6 @@ static int inet_init()
 #else
 		    p_usrsctp_init(0, NULL, NULL,sctp_raw_ipv4, sctp_raw_ipv6, sctp_raw_route);
 #endif
-		    drop_root_priv();
 		    usrsctp_init_socket_hash();
 		    p_usrsctp_sysctl_set_sctp_delayed_sack_time_default(10);
 #ifdef SCTP_DEBUG

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -7618,11 +7618,14 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 #ifdef HAVE_USRSCTP
 	erl_drv_mutex_lock(desc->recv_mtx);
 	desc->recv = desc->active;
-	erl_drv_mutex_unlock(desc->recv_mtx);
 	if(desc->active) {
-	    if(p_usrsctp_readable(desc->usrsctp_sock))
+	    if(p_usrsctp_readable(desc->usrsctp_sock)) {
+		if (desc->recv == INET_ONCE)
+		    desc->recv = INET_PASSIVE;
 		driver_port_task_input_schedule(driver_erts_drvport2id(desc->port));
+	    }
 	}
+	erl_drv_mutex_unlock(desc->recv_mtx);
 #else
 	sock_select(desc, (FD_READ|FD_CLOSE), (desc->active > 0));
 #endif

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -2904,7 +2904,8 @@ static void drv_usrsctp_free(void *des)
 {
     erts_free(ERTS_ALC_T_DRV_SCTP_SOCK, (void *) des); 
 }
-static void usrsctp_init_socket_hash()
+
+static void usrsctp_init_socket_hash(void)
 {
     SafeHashFunctions hf;
     hf.hash = &drv_usrsctp_hash;
@@ -4118,10 +4119,10 @@ static void inet_init_sctp(void) {
    but for now; set beam to be setuid root.
    uid will be dropped once the raw socket is open.
    aka usrsctp has initialized */
-static void drop_root_priv()
+static void drop_root_priv(void)
 {
-    seteuid(getuid());
-    setegid(getgid());
+    ASSERT(seteuid(getuid()) == 0);
+    ASSERT(setegid(getgid()) == 0);
 }
 
 #ifdef SCTP_DEBUG
@@ -6923,7 +6924,7 @@ static char* sctp_get_sendparams(struct sctp_sndinfo* si, char* curr)
 {
     int eflags;
     int cflags;
-    
+
     si->snd_sid       = get_int16(curr);		curr += 2;
 
     /* The "flags" are already ORed at the Erlang side, here we
@@ -6940,7 +6941,7 @@ static char* sctp_get_sendparams(struct sctp_sndinfo* si, char* curr)
     si->snd_ppid	    = sock_htonl(get_int32(curr));
 							curr += 4;
     si->snd_context	    = get_int32(curr);		curr += 4;
-			      get_int32(curr);		curr += 4;  /* ignore time to live */
+							curr += 4;  /* ignore time to live */
     si->snd_assoc_id	    = GET_ASSOC_ID  (curr);	curr += ASSOC_ID_LEN;
 
     return curr;
@@ -7200,6 +7201,7 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 	{
 #ifdef HAVE_USRSCTP
 	    curr += 4;
+	    continue;
 #else
 	    arg.ival= get_int32 (curr);	  curr += 4;
 	    proto   = SOL_SOCKET;
@@ -7213,6 +7215,7 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 	{
 #ifdef HAVE_USRSCTP
 	    curr += 4;
+	    continue;
 #else
 	    arg.ival= get_int32 (curr);	  curr += 4;
 	    proto   = SOL_SOCKET;
@@ -7227,6 +7230,7 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 	{
 #ifdef HAVE_USRSCTP
 	    curr += 4;
+	    continue;
 #else
 	    arg.ival= get_int32 (curr);	  curr += 4;
 	    proto   = SOL_SOCKET;
@@ -7245,6 +7249,7 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 	{
 #ifdef HAVE_USRSCTP
 	    curr += 4;
+	    continue;
 #else
 	    arg.ival= get_int32 (curr);	  curr += 4;
 	    proto   = SOL_IP;
@@ -7263,6 +7268,7 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 	{
 #ifdef HAVE_USRSCTP
 	    curr += 4;
+	    continue;
 #else
 	    arg.ival= get_int32 (curr);	  curr += 4;
 	    proto   = SOL_IPV6;
@@ -7280,6 +7286,7 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 	{
 #ifdef HAVE_USRSCTP
 	    curr += 4;
+	    continue;
 #else
 	    arg.ival= get_int32 (curr);   curr += 4;
 	    proto   = IPPROTO_IPV6;
@@ -7400,6 +7407,7 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 	    /* XXX: do we need to convert the Ind into network byte order??? */
 #ifdef HAVE_USRSCTP
 	    curr += 4;
+	    continue;
 #else
 	    arg.ad.ssb_adaptation_ind = sock_htonl (get_int32(curr));  curr += 4;
 
@@ -7510,6 +7518,7 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 	    CHKLEN(curr, 9);
 #ifdef HAVE_USRSCTP
 	    curr += 9;
+	    continue;
 #else
 	    /* We do not support "sctp_authentication_event" -- it is not
 	       implemented in Linux Kernel SCTP anyway.   Just in case if

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -2979,8 +2979,8 @@ static void usrsctp_event_rcv_callback(struct socket *sock, void *arg)
 	if(desc->recv) {
 	    if(desc->recv == INET_ONCE) {
 		desc->recv = INET_PASSIVE;
-		erl_drv_mutex_unlock(desc->recv_mtx);
 	    }
+	    erl_drv_mutex_unlock(desc->recv_mtx);
 	    driver_port_task_input_schedule(drv_sock->port);
 	} else
 	    erl_drv_mutex_unlock(desc->recv_mtx);

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -12239,7 +12239,7 @@ static int packet_inet_input(udp_descriptor* udesc, HANDLE event)
 	if (IS_SCTP(desc)) {
 	    unsigned int infotype = 0;
 	    socklen_t infolen = SCTP_ANC_BUFF_SIZE;
-	    char dummyread[1];
+	    char dummyread[3];
 	    iov->iov_base = udesc->i_ptr; /* Data will come here    */
 	    iov->iov_len = desc->bufsz; /* Remaining buffer space */
 	    
@@ -12252,7 +12252,7 @@ static int packet_inet_input(udp_descriptor* udesc, HANDLE event)
 	    mhdr.msg_flags	= 0;	   /* To be filled by "recvmsg"    */
 	   
 	    /* read bytes from notif fd */
-	    read(desc->s, dummyread, 1);
+	    read(desc->s, dummyread, 3);
 	    /* Do the actual SCTP receive: */
 	    DEBUGF(("usrsctp_recvv about to be called %x\r\n", desc->usrsctp_sock));
 	    n = p_usrsctp_recvv(desc->usrsctp_sock,

--- a/erts/emulator/sys/common/erl_sys_common_misc.c
+++ b/erts/emulator/sys/common/erl_sys_common_misc.c
@@ -31,6 +31,7 @@
 
 #include "sys.h"
 #include "global.h"
+#include "erl_port.h"
 
 #if defined(__APPLE__) && defined(__MACH__) && !defined(__DARWIN__)
 #define __DARWIN__ 1
@@ -304,4 +305,20 @@ sys_double_to_chars_fast(double f, char *buffer, int buffer_size, int decimals,
 
     *p = '\0';
     return p - buffer;
+}
+
+/* used usrsctp in inet_drv.c to schedule port on usrsocket event */
+Eterm driver_erts_drvport2id(ErlDrvPort drvport)
+{
+    return erts_drvport2id(drvport);
+}
+
+int driver_port_task_input_schedule(Eterm port)
+{
+    return erts_port_task_schedule(port, NULL, ERTS_PORT_TASK_INPUT, -1);
+}
+
+int driver_port_task_output_schedule(Eterm port)
+{
+    return erts_port_task_schedule(port, NULL, ERTS_PORT_TASK_OUTPUT, -1);
 }

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -167,6 +167,11 @@ static char *plusz_val_switches[] = {
     "dbbl",
     "dntgc",
     "ebwt",
+#ifdef HAVE_USRSCTP
+    "sctp_raw_ipv4",
+    "sctp_raw_ipv6",
+    "sctp_raw_route",
+#endif
     NULL
 };
 


### PR DESCRIPTION
Experimental support for usrsctplib. Any feedback appreciated.

The main idea is to use usrsctplib from within the emulator using `gen_sctp` as for the current SCTP support.
But this makes the SCTP stack run within the beam.
This mainly enabled me to have SCTP on macOS without running unsigned sctp kernel extensions.
It might also be possible to get usrsctplib support to work on windows.
I have only tested on macOS and Linux.

Some modifications has been made to usrsctp which can be found on below github repo and branch. I.e. passing already opened raw sockets to the lib and event callback support when socket is ready.
https://github.com/falkevik/usrsctp/tree/event_callback_support

So how to try it.
First install the usrsctplib from the above branch.
When done you can enable usrsctp support when configuring otp.
`./configure --enable-sctp=usrsctp` should start looking for the usrsctp header.

When done and compiled as usual.
On Linux you can go with adding cap_net_raw; `setcap cap_net_raw+ep /path/to/beam.smp`.
On macOS I pass already opened raw sockets as arguments to the beam.
New flags are `+zsctp_raw_ipv4 <fd>` `+zsctp_raw_ipv6 <fd>` `+zsctp_raw_route <fd>`
setuid_socket_warp can be used for this, which is slightly modified to set additional options on the raw socket before dropping privileges.
`setuid_socket_wrap -t +zsctp_raw_ipv4,sctp -T +zsctp_raw_ipv6,sctp -z +zsctp_raw_route,sctp`

So to the actual code changes, the idea is that when not enabled it should not affect at all.
This need extra code review I think, there a lot of `#ifdef`s that might have ended up badly.

There are some other changes that I need feedback on how to do it properly.
Since we don't have any real file descriptor that we can put in the` select`/`poll` I register a callback when socket is ready to be read.
When this callback is invoked, I check if the socket are in active mode or not.
If it is in active mode, the port are scheduled to be run `erts_port_task_schedule` as select would have done if the fd was ready.

To be able to use this call from the inet_drv driver I had to make them available from somewhere.
Currently in `erts/emulator/sys/common/erl_sys_common_misc.c`, where to put this kind of code?
