### PR TITLE
Make --enable-native-libs use option verify_gcsafe

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -123,7 +123,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 
 ifeq ($(NATIVE_LIBS_ENABLED),yes)
-ERL_COMPILE_FLAGS += +native
+ERL_COMPILE_FLAGS += +native "+{hipe,[verify_gcsafe]}"
 endif
 ERL_COMPILE_FLAGS += +inline +warn_unused_import \
  -Werror \

--- a/lib/dialyzer/src/Makefile
+++ b/lib/dialyzer/src/Makefile
@@ -89,7 +89,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 
 ifeq ($(NATIVE_LIBS_ENABLED),yes)
-ERL_COMPILE_FLAGS += +native
+ERL_COMPILE_FLAGS += +native "+{hipe,[verify_gcsafe]}"
 endif
 ERL_COMPILE_FLAGS += +warn_export_vars +warn_unused_import +warn_untyped_record +warn_missing_spec +warnings_as_errors
 

--- a/lib/hipe/native.mk
+++ b/lib/hipe/native.mk
@@ -1,6 +1,6 @@
 ifeq ($(NATIVE_LIBS_ENABLED),yes)
 ifndef SECONDARY_BOOTSTRAP
-ERL_COMPILE_FLAGS += +native
+ERL_COMPILE_FLAGS += +native "+{hipe,[verify_gcsafe]}"
 else
 EBIN = ../boot_ebin
 endif

--- a/lib/kernel/src/Makefile
+++ b/lib/kernel/src/Makefile
@@ -152,7 +152,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 
 ifeq ($(NATIVE_LIBS_ENABLED),yes)
-ERL_COMPILE_FLAGS += +native
+ERL_COMPILE_FLAGS += +native "+{hipe,[verify_gcsafe]}"
 endif
 ERL_COMPILE_FLAGS += -I../include -Werror
 

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -154,7 +154,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 
 ifeq ($(NATIVE_LIBS_ENABLED),yes)
-ERL_COMPILE_FLAGS += +native
+ERL_COMPILE_FLAGS += +native "+{hipe,[verify_gcsafe]}"
 endif
 ERL_COMPILE_FLAGS += -I../include -I../../kernel/include -Werror
 

--- a/lib/syntax_tools/src/Makefile
+++ b/lib/syntax_tools/src/Makefile
@@ -27,7 +27,7 @@ INCLUDE=../include
 ERL_COMPILE_FLAGS += -pa $(EBIN) -pa ./ -I$(INCLUDE)
 
 ifeq ($(NATIVE_LIBS_ENABLED),yes)
-ERL_COMPILE_FLAGS += +native
+ERL_COMPILE_FLAGS += +native "+{hipe,[verify_gcsafe]}"
 endif
 ERL_COMPILE_FLAGS += +nowarn_shadow_vars +warn_unused_import #-Werror # +warn_missing_spec +warn_untyped_record
 


### PR DESCRIPTION
@margnus1 
Our test run with `--enable-native-libs` still crash occasionally, accessing broken terms.

Trying to troubleshoot this, this PR adds the new hipe compile option `verify_gcsafe` for all modules compiled with hipe by `--enable-native-libs`.

This is the result:
```
<HiPE (v 3.16.1)> Error: [hipe:864]: INTERNAL ERROR
while compiling string:btoken/2
crash reason: {gcunsafe_live_over_call,
                  {string,btoken,2},
                  {label,26},
                  {call,
                      [{rtl_reg,47,true}],
                      bs_put_utf8,
                      [{rtl_var,30,live},{rtl_reg,46,false},{rtl_imm,0}],
                      not_remote,42,43,[]},
                  {rtl_reg,46,false}}
  in function  hipe_rtl_verify_gcsafe:verify_live/1 (hipe_rtl_verify_gcsafe.erl, line 61)
  in call from lists:foreach/2 
  in call from hipe_rtl_verify_gcsafe:check_instrs/2 (hipe_rtl_verify_gcsafe.erl, line 50)
  in call from lists:foreach/2 
  in call from hipe_rtl_verify_gcsafe:check/1 (hipe_rtl_verify_gcsafe.erl, line 25)
  in call from hipe_main:icode_to_rtl/4 (hipe_main.erl, line 416)
  in call from hipe_main:compile_icode/5 (hipe_main.erl, line 113)
  in call from hipe:finalize_fun_sequential/3 (hipe.erl, line 835)
```

Is this the same GC problem as before for `bs_put_utf8`?
