### PR TITLE
add hibernate_after to the gen options type spec

### DIFF
--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -49,6 +49,7 @@
                     | {'logfile', string()}.
 -type option()     :: {'timeout', timeout()}
 		    | {'debug', [debug_flag()]}
+		    | {'hibernate_after', timeout()}
 		    | {'spawn_opt', [proc_lib:spawn_option()]}.
 -type options()    :: [option()].
 


### PR DESCRIPTION
`hibernate_after` is a supported option and included in the documentation but wasn't added to the type spec.