### PR TITLE
Fix type create_option() in mnesia

### DIFF
--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -151,7 +151,8 @@
         {'snmp', SnmpStruct::term()} |
         {'storage_properties', [{Backend::module(), [BackendProp::_]}]} |
         {'type', 'set' | 'ordered_set' | 'bag'} |
-        {'local_content', boolean()}.
+        {'local_content', boolean()} |
+        {'user_properties', proplists:proplist()}.
 
 -type t_result(Res) :: {'atomic', Res} | {'aborted', Reason::term()}.
 -type activity() :: 'ets' | 'async_dirty' | 'sync_dirty' | 'transaction' | 'sync_transaction' |


### PR DESCRIPTION
The create_option() type in mnesia lacks the ```user_properties``` field
which is used by mnesia in various places.

How to reproduce the issue:

The following minimal project where ```{user_properties, []}``` is included in ```mnesia:create_table/2``` options demonstrates the Dialyzer warning in OTP-20:
https://github.com/aboroska/dialyzer-mnesia-test2

Run ```rebar3 dialyzer``` and under OTP-20 Dialyzers warns:

    src/t2.erl
      13: Function test/0 has no local return

This fix eliminates the warning.

The type ```proplists:proplist()``` seems appropriate. See for example the following line where it is accessed:
https://github.com/erlang/otp/blob/master/lib/mnesia/src/mnesia_bup.erl#L106 


