### PR TITLE
jinterface: add package name for Java 9

### DIFF
--- a/lib/jinterface/java_src/pom.xml.src
+++ b/lib/jinterface/java_src/pom.xml.src
@@ -76,6 +76,17 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>com.ericsson.otp.erlang</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.10.3</version>
 				<executions>


### PR DESCRIPTION
The Java 9 module system requires a module name to be defined. If none is provided, a default one is used derived from the JAR name, but that one is not very unique and can create problems. The recommended module name is the longest common package name for the source code included.

The only change made is to JAR metadata, so it would be safe to merge in the maint branch too, if deemed necessary. 