### PR TITLE
Delay creation of stack frames

### DIFF
--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -22,7 +22,7 @@
 
 -module(beam_utils).
 -export([is_killed_block/2,is_killed/3,is_killed_at/3,
-	 is_not_used/3,
+	 is_not_used/3,usage/3,
 	 empty_label_index/0,index_label/3,index_labels/1,replace_labels/4,
 	 code_at/2,bif_to_test/3,is_pure_test/1,
 	 live_opt/1,delete_live_annos/1,combine_heap_needs/2,
@@ -61,6 +61,23 @@
 -record(live,
 	{lbl :: code_index(),            %Label to code index.
 	 res :: result_cache()}).        %Result cache for each label.
+
+%% usage(Register, [Instruction], State) -> killed|not_used|used.
+%%  Determine the usage of Register in the instruction sequence.
+%%  The return value is one of:
+%%
+%%  killed   - The register is not used in any way.
+%%  not_used - The register is referenced only by an allocating instruction
+%%             (the actual value does not matter).
+%%  used     - The register is used (its value do matter).
+
+-spec usage(beam_asm:reg(), [instruction()], code_index()) ->
+  'killed' | 'not_used' | 'used'.
+
+usage(R, Is, D) ->
+    St = #live{lbl=D,res=gb_trees:empty()},
+    {Usage,_} = check_liveness(R, Is, St),
+    Usage.
 
 
 %% is_killed_block(Register, [Instruction]) -> true|false

--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -380,9 +380,16 @@ check_liveness(R, [{bs_init,_,_,none,Ss,Dst}|Is], St) ->
 check_liveness(R, [{bs_init,_,_,Live,Ss,Dst}|Is], St) ->
     case R of
 	{x,X} ->
-	    case X < Live orelse member(R, Ss) of
-		true -> {used,St};
-		false -> {killed,St}
+            case member(R, Ss) of
+                true ->
+                    {used,St};
+                false ->
+                    if
+                        X < Live ->
+                            not_used(check_liveness(R, Is, St));
+                        true ->
+                            {killed,St}
+                    end
 	    end;
 	{y,_} ->
 	    case member(R, Ss) of

--- a/lib/compiler/test/beam_utils_SUITE.erl
+++ b/lib/compiler/test/beam_utils_SUITE.erl
@@ -122,6 +122,15 @@ bs_init(_Config) ->
     {'EXIT',{badarg,_}} = (catch do_bs_init_2([0.5])),
     {'EXIT',{badarg,_}} = (catch do_bs_init_2([-1])),
     {'EXIT',{badarg,_}} = (catch do_bs_init_2([1 bsl 32])),
+
+    <<>> = do_bs_init_3({tag,0}, 0, 0),
+    <<0>> = do_bs_init_3({tag,0}, 2, 1),
+
+    <<"_build/shared">> = do_bs_init_4([], false),
+    <<"abc/shared">> = do_bs_init_4(<<"abc">>, false),
+    <<"foo/foo">> = do_bs_init_4(<<"foo">>, true),
+    error = do_bs_init_4([], not_boolean),
+
     ok.
 
 do_bs_init_1([?MODULE], Sz) ->
@@ -139,6 +148,45 @@ do_bs_init_2(SigNos) ->
 	    erlang:error(badarg)
     >>.
 
+do_bs_init_3({tag,Pos}, Offset, Len) ->
+    N0 = Offset - Pos,
+    N = if N0 > Len -> Len;
+           true -> N0
+        end,
+    <<0:N/unit:8>>.
+
+do_bs_init_4(Arg1, Arg2) ->
+    Build =
+        case id(Arg1) of
+            X when X =:= [] orelse X =:= false -> <<"_build">>;
+            X -> X
+        end,
+    case id(Arg2) of
+        true ->
+            id(<<case Build of
+                     Rewrite when is_binary(Rewrite) ->
+                         Rewrite;
+                     Rewrite ->
+                         id(Rewrite)
+                 end/binary,
+                 "/",
+                 case id(<<"foo">>) of
+                     Rewrite when is_binary(Rewrite) ->
+                         Rewrite;
+                     Rewrite ->
+                         id(Rewrite)
+                 end/binary>>);
+        false ->
+            id(<<case Build of
+                     Rewrite when is_binary(Rewrite) ->
+                         Rewrite;
+                     Rewrite ->
+                         id(Rewrite)
+                 end/binary,
+                 "/shared">>);
+        Other ->
+            error
+    end.
 
 bs_save(_Config) ->
     {a,30,<<>>} = do_bs_save(<<1:1,30:5>>),

--- a/lib/compiler/test/beam_utils_SUITE.erl
+++ b/lib/compiler/test/beam_utils_SUITE.erl
@@ -25,7 +25,7 @@
 	 is_not_killed/1,is_not_used_at/1,
 	 select/1,y_catch/1,otp_8949_b/1,liveopt/1,coverage/1,
          y_registers/1,user_predef/1,scan_f/1,cafu/1,
-         receive_label/1]).
+         receive_label/1,read_size_file_version/1]).
 -export([id/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
@@ -50,7 +50,8 @@ groups() ->
        y_registers,
        user_predef,
        scan_f,
-       cafu
+       cafu,
+       read_size_file_version
       ]}].
 
 init_per_suite(Config) ->
@@ -443,6 +444,19 @@ do_receive_label(Rec) ->
         {From,Message} when Rec#rec_label.bool ->
             From ! {ok,Message},
             do_receive_label(Rec)
+    end.
+
+read_size_file_version(_Config) ->
+    ok = do_read_size_file_version({ok,<<42>>}),
+    {ok,7777} = do_read_size_file_version({ok,<<7777:32>>}),
+    ok.
+
+do_read_size_file_version(E) ->
+    case E of
+	{ok,<<Version>>} when Version =:= 42 ->
+            ok;
+	{ok,<<MaxFiles:32>>} ->
+            {ok,MaxFiles}
     end.
 
 %% The identity function.


### PR DESCRIPTION
`v3_codegen` currently wraps a stack frame around each clause in a function (unless the clause is simple without any `case` or other complex constructions).
    
Consider this function:
    
    f({a,X}) ->
        A = abs(X),
        case A of
            0 ->
                {result,"0"};
            _ ->
                {result,integer_to_list(A)}
        end;
    f(_) ->
        error.
    
The first clause needs a stack frame because there is a function call to `integer_to_list/1` not in the tail position. `v3_codegen` currently wraps the entire first clause in stack frame.
    
We can delay the creation of the stack frame, and create a stack frame in each arm of the `case` (if needed):
    
    f({a,X}) ->
        A = abs(X),
        case A of
            0 ->
            %% Don't create a stack frame here.
                {result,"0"};
            _ ->
            %% Create a stack frame here.
                {result,integer_to_list(A)}
        end;
    f(_) ->
        error.
    
There are pros and cons of this approach.
    
The cons are that the code size may increase if there are many `case` clauses and each needs its own stack frame. The allocation instructions may also interfere with other optimizations, but new optimizations also introduced in this pull request will mitigate most of those issues (see the individual commit messages for a description of those optimizations).
    
The pros are the following:
    
* For some clauses in a `case`, there is no need to create any stack frame at all.
    
* Often when moving an allocation instruction into a `case` clause, the slightly cheaper 'allocate' instruction can be used instead of `allocate_zero`. There is also the possibility that the allocate instruction can be be combined with a `test_heap` instruction.
    
* Each stack frame for each arm of the `case` will have exactly as many slots as needed.
