### PR TITLE
Reduce register shuffling in receive clauses

### DIFF
--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -593,6 +593,10 @@ check_liveness(R, [{allocate_zero,N,Live}|Is], St) ->
 check_liveness(R, [{get_list,S,D1,D2}|Is], St) ->
     I = {block,[{set,[D1,D2],[S],get_list}]},
     check_liveness(R, [I|Is], St);
+check_liveness(R, [remove_message|Is], St) ->
+    check_liveness(R, Is, St);
+check_liveness({x,X}, [build_stacktrace|_], St) when X > 0 ->
+    {killed,St};
 check_liveness(_R, Is, St) when is_list(Is) ->
     %% Not implemented. Conservatively assume that the register is used.
     {used,St}.


### PR DESCRIPTION
Handle a few more instructions in `beam_utils`. That will allow
`beam_reorder` to reorder more instructions, delaying more `get_tuple_element`
instructions and reducing register shuffling in receive clauses.