### PR TITLE
Refactor '%live' and '%def' annotations

### DIFF
--- a/lib/compiler/src/beam_a.erl
+++ b/lib/compiler/src/beam_a.erl
@@ -58,7 +58,8 @@ rename_instrs([{call_only,A,F}|Is]) ->
 rename_instrs([{call_ext_only,A,F}|Is]) ->
     [{call_ext,A,F},return|rename_instrs(Is)];
 rename_instrs([{'%live',_}|Is]) ->
-    %% When compiling from old .S files.
+    %% Ignore old type of live annotation. Only happens when compiling
+    %% from very old .S files.
     rename_instrs(Is);
 rename_instrs([I|Is]) ->
     [rename_instr(I)|rename_instrs(Is)];

--- a/lib/compiler/src/beam_record.erl
+++ b/lib/compiler/src/beam_record.erl
@@ -71,7 +71,7 @@ rewrite([{test,test_arity,Fail,[Src,N]}=TA,
             I = {test,is_tagged_tuple,Fail,[Src,N,Atom]},
             rewrite(Is, Idx, Def, [I|Acc])
     end;
-rewrite([{block,[{'%def',Def}|Bl]}|Is], Idx, _Def, Acc) ->
+rewrite([{block,[{'%anno',{def,Def}}|Bl]}|Is], Idx, _Def, Acc) ->
     rewrite(Is, Idx, Def, [{block,Bl}|Acc]);
 rewrite([{label,L}=I|Is], Idx0, Def, Acc) ->
     Idx = beam_utils:index_label(L, Acc, Idx0),


### PR DESCRIPTION
The annotations in the optimizing passes currently looks like this:

    {'%live',NumRegistersUsed,RegistersUsedBitmap}
    {'%def',RegistersDefinedBitmap}

(NumRegistersUsed is no longer used.)

When I attempted to extend some optimizations, I found that I had to
add additional clauses to tolerate/handle both types of
annotations. That problem would only get worse if any more annotations
are added in the future.

To simplify annotation handling, this commit wraps both types of
annotations in a `{'%anno',_}` tuple:

    {'%anno',{used,RegistersUsedBitmap}}
    {'%anno',{def,RegistersDefinedBitmap}}

The `'%live'` annotation has been renamed to `used` to make it somewhat
clearer what it means, and the unused NumRegistersUsed part of the
old annotation has been removed.

Alternatives considered: My first attempt was to wrap the annotation
in a `set` tuple so that there would only be `set` tuples in a block.
For example:

    {set,[],[],{anno,{live,RegistersUsedBitmap}}}

It was not as convenient as expected. Annotations often need to be
handled specially from other instructions in a block. When they are
wrapped in a `set` tuple, they can very easily be handled incorrectly
or passed on to the next pass. That causes subtle errors or worse
code, and it can be difficult to debug.

Therefore, my conclusion is that annotations should be distinct from
other instructions, to make it obvious when one has failed to handle
an annotation.