### PR TITLE
Fix GC bug for HiPE primop bs_put_utf8

### DIFF
--- a/erts/emulator/hipe/hipe_bif_list.m4
+++ b/erts/emulator/hipe/hipe_bif_list.m4
@@ -245,7 +245,7 @@ noproc_primop_interface_2(nbif_eq_2, eq)
 nofail_primop_interface_3(nbif_bs_get_integer_2, erts_bs_get_integer_2)
 nofail_primop_interface_3(nbif_bs_get_binary_2, erts_bs_get_binary_2)
 nofail_primop_interface_3(nbif_bs_get_float_2, erts_bs_get_float_2)
-standard_bif_interface_3(nbif_bs_put_utf8, hipe_bs_put_utf8)
+nocons_nofail_primop_interface_3(nbif_bs_put_utf8, hipe_bs_put_utf8)
 standard_bif_interface_3(nbif_bs_put_utf16be, hipe_bs_put_utf16be)
 standard_bif_interface_3(nbif_bs_put_utf16le, hipe_bs_put_utf16le)
 ifdef(`nogc_bif_interface_1',`

--- a/erts/emulator/hipe/hipe_mkliterals.c
+++ b/erts/emulator/hipe/hipe_mkliterals.c
@@ -535,6 +535,11 @@ static const struct rts_param rts_params[] = {
 static unsigned int literals_crc;
 static unsigned int system_crc;
 
+/*
+ * Change this version value to detect incompatible changes in primop interface.
+ */
+#define PRIMOP_ABI_VSN 0x090300  /* erts-9.3 */
+
 static void compute_crc(void)
 {
     unsigned int crc_value;
@@ -550,6 +555,8 @@ static void compute_crc(void)
     for (i = 0; i < NR_PARAMS; ++i)
 	if (rts_params[i].is_defined)
 	    crc_value = crc_update_int(crc_value, &rts_params[i].value);
+
+    crc_value ^= PRIMOP_ABI_VSN;
     crc_value &= 0x07FFFFFF;
     system_crc = crc_value;
 }

--- a/erts/emulator/hipe/hipe_native_bif.c
+++ b/erts/emulator/hipe/hipe_native_bif.c
@@ -398,12 +398,8 @@ Eterm hipe_bs_utf8_size(Eterm arg)
 	return make_small(4);
 }
 
-BIF_RETTYPE nbif_impl_hipe_bs_put_utf8(NBIF_ALIST_3)
+Eterm hipe_bs_put_utf8(Process* p, Eterm arg, byte* base, Uint offset)
 {
-    Process* p = BIF_P;
-    Eterm arg = BIF_ARG_1;
-    byte* base = (byte*) BIF_ARG_2;
-    Uint offset = (Uint) BIF_ARG_3;
     byte *save_bin_buf;
     Uint save_bin_offset;
     int res;
@@ -419,7 +415,8 @@ BIF_RETTYPE nbif_impl_hipe_bs_put_utf8(NBIF_ALIST_3)
     erts_current_bin = save_bin_buf;
     erts_bin_offset = save_bin_offset;
     if (res == 0)
-	BIF_ERROR(p, BADARG);
+        return 0;
+    ASSERT(new_offset != 0);
     return new_offset;
 }
 

--- a/erts/emulator/hipe/hipe_native_bif.h
+++ b/erts/emulator/hipe/hipe_native_bif.h
@@ -88,7 +88,7 @@ Binary *hipe_bs_reallocate(Binary*, int);
 int hipe_bs_put_small_float(Process*, Eterm, Uint, byte*, unsigned, unsigned);
 void hipe_bs_put_bits(Eterm, Uint, byte*, unsigned, unsigned);
 Eterm hipe_bs_utf8_size(Eterm);
-BIF_RETTYPE nbif_impl_hipe_bs_put_utf8(NBIF_ALIST_3);
+Eterm hipe_bs_put_utf8(Process*, Eterm arg, byte* base, Uint offset);
 Eterm hipe_bs_utf16_size(Eterm);
 BIF_RETTYPE nbif_impl_hipe_bs_put_utf16be(NBIF_ALIST_3);
 BIF_RETTYPE nbif_impl_hipe_bs_put_utf16le(NBIF_ALIST_3);

--- a/lib/hipe/main/hipe.app.src
+++ b/lib/hipe/main/hipe.app.src
@@ -236,4 +236,4 @@
   {applications, [kernel,stdlib]},
   {env, []},
   {runtime_dependencies, ["syntax_tools-1.6.14","stdlib-3.4","kernel-5.3",
-			  "erts-9.2","compiler-5.0"]}]}.
+			  "erts-9.3","compiler-5.0"]}]}.

--- a/lib/hipe/rtl/hipe_rtl_binary_construct.erl
+++ b/lib/hipe/rtl/hipe_rtl_binary_construct.erl
@@ -168,9 +168,13 @@ gen_rtl(BsOP, Dst, Args, TrueLblName, FalseLblName, SystemLimitLblName, ConstTab
 
 	  bs_put_utf8 ->
 	    [_Src, _Base, _Offset] = Args,
-	    NewDsts = get_real(Dst),
-	    [hipe_rtl:mk_call(NewDsts, bs_put_utf8, Args,
-			      TrueLblName, FalseLblName, not_remote)];
+	    [NewOffs] = get_real(Dst),
+            RetLbl = hipe_rtl:mk_new_label(),
+            [hipe_rtl:mk_call([NewOffs], bs_put_utf8, Args,
+                              hipe_rtl:label_name(RetLbl), [], not_remote),
+             RetLbl,
+             hipe_rtl:mk_branch(NewOffs, ne, hipe_rtl:mk_imm(0),
+                                TrueLblName, FalseLblName, 0.99)];
 
 	  bs_utf16_size ->
 	    case Dst of


### PR DESCRIPTION
According to discussion in https://github.com/erlang/otp/pull/1642

I also added a PRIMOP_ABI_VSN version number as a way to detect incompatible changes like this in load time.

@margnus1