### PR TITLE
Fix link to the contribution guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We are grateful to the community for contributing bug fixes and improvements. Re
 
 ### Contribution Guide
 
-Read our [contribution guide](https://github.com/erlang/otp/wiki/contribution-guidelines) to learn about our development process, how to propose fixes and improvements, and how to test your changes to Erlang/OTP before submitting a pull request.
+Read our [contribution guide](CONTRIBUTING.md) to learn about our development process, how to propose fixes and improvements, and how to test your changes to Erlang/OTP before submitting a pull request.
 
 ### Help Wanted
 


### PR DESCRIPTION
The README.md file contains a currently-broken link to the wiki, and the instruction I _could_ find on the wiki only point to CONTRIBUTING.md, so that seems like the right place to point here. Should this be merged on a `maint` branch or on a master branch?