### PR TITLE
Fix case_clause error

### DIFF
--- a/lib/observer/src/observer_pro_wx.erl
+++ b/lib/observer/src/observer_pro_wx.erl
@@ -465,7 +465,8 @@ init_table_holder(Parent, Accum0, Attrs) ->
     Backend = spawn_link(node(), observer_backend, procs_info, [self()]),
     Accum = case Accum0 of
                 true -> true;
-                false -> []
+                false -> [];
+                [] -> []
             end,
     table_holder(#holder{parent=Parent,
 			 info=array:new(),


### PR DESCRIPTION
This fixes the following error when running `observer:start()`

```
(rabbit@shostakovich)23> observer:start().
{error,{{case_clause,[]},
        [{observer_pro_wx,init_table_holder,3,
                          [{file,"observer_pro_wx.erl"},{line,466}]}]}}
```