### PR TITLE
match wildcards in subjectAltNames

### DIFF
--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -1483,11 +1483,11 @@ verify_hostname_match_default(Ref, Pres) ->
 verify_hostname_match_default0(FQDN=[_|_], {cn,FQDN}) -> 
     not lists:member($*, FQDN);
 verify_hostname_match_default0(FQDN=[_|_], {cn,Name=[_|_]}) -> 
-    [F1|Fs] = string:tokens(FQDN, "."),
-    [N1|Ns] = string:tokens(Name, "."),
-    match_wild(F1,N1) andalso Fs==Ns;
-verify_hostname_match_default0({dns_id,R}, {dNSName,P}) ->
-    R==P;
+    verify_hostname_match_wildcard(FQDN, Name);
+verify_hostname_match_default0({dns_id,FQDN=[_|_]}, {dNSName,FQDN}) ->
+    not lists:member($*, FQDN);
+verify_hostname_match_default0({dns_id,FQDN=[_|_]}, {dNSName,Name=[_|_]}) ->
+    verify_hostname_match_wildcard(FQDN, Name);
 verify_hostname_match_default0({uri_id,R}, {uniformResourceIdentifier,P}) ->
     R==P;
 verify_hostname_match_default0({ip,R}, {iPAddress,P}) when length(P) == 4 ->
@@ -1519,6 +1519,11 @@ verify_hostname_match_default0({srv_id,R}, {?srvName_OID,P}) ->
     R==P;
 verify_hostname_match_default0(_, _) ->
     false.
+
+verify_hostname_match_wildcard(FQDN, Name) ->
+    [F1|Fs] = string:tokens(FQDN, "."),
+    [N1|Ns] = string:tokens(Name, "."),
+    match_wild(F1,N1) andalso Fs==Ns.
 
 ok({ok,X}) -> X.
 


### PR DESCRIPTION
Patch for matching referenceID against wildcards in dNSName SubjectAltNames, as described in JIRA [ERL-542](https://bugs.erlang.org/browse/ERL-542).

With this patch:
```
$ erl
Erlang/OTP 20 [erts-9.2] [source-b75317c37b] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V9.2  (abort with ^G)
1> ssl:start().
ok
2> ssl:connect("outlook.office365.com", 443, [{verify, verify_peer}, {cacertfile, "/etc/ssl/certs/ca-certificates.crt"}]).
{ok,{sslsocket,{gen_tcp,#Port<0.771>,tls_connection,
                        undefined},
               <0.82.0>}}
3> 
```