### PR TITLE
Fix false Dialyzer warnings for erl_tar:table/1

### DIFF
--- a/lib/stdlib/src/erl_tar.erl
+++ b/lib/stdlib/src/erl_tar.erl
@@ -189,7 +189,7 @@ table(Name) ->
 %% Returns a list of names of the files in the tar file Name.
 %% Options accepted: compressed, verbose, cooked.
 -spec table(open_handle(), [compressed | verbose | cooked]) ->
-                   {ok, [tar_entry()]} | {error, term()}.
+                   {ok, [string() | tar_entry()]} | {error, term()}.
 table(Name, Opts) when is_list(Opts) ->
     foldl_read(Name, fun table1/4, [], table_opts(Opts)).
 


### PR DESCRIPTION
'tar_entry()' values are only returned if we specify the 'verbose' option when calling table/2, which table/1 doesn't do.

Now, it appears that Dialyzer as of OTP 20 is clever enough to realize that the return type of table/1 must intersect with the return type of table/2, and so it ignores the fact that table/1 says it returns strings, and therefore its callers are expected to be dealing with 'tar_entry()' tuples, and never with strings.

This is obviously a mismatch between what the code does and what the spec says is does, leading to false Dialyzer warnings on code that uses table/1 (and, presumably, also table/2 when called without
the 'verbose' option.)