### PR TITLE
beam_validator: Strengthen validation of GC instructions

### DIFF
--- a/lib/compiler/src/beam_type.erl
+++ b/lib/compiler/src/beam_type.erl
@@ -367,6 +367,8 @@ flt_need_heap_2({set,_,_,get_list}, H, Fl) ->
     {[],H,Fl};
 flt_need_heap_2({set,_,_,{try_catch,_,_}}, H, Fl) ->
     {[],H,Fl};
+flt_need_heap_2({set,_,_,init}, H, Fl) ->
+    {[],H,Fl};
 %% All other instructions should cause the insertion of an allocation
 %% instruction if needed.
 flt_need_heap_2(_, H, Fl) ->

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -529,9 +529,10 @@ valfun_4({bif,Op,{f,Fail},Src,Dst}, Vst0) ->
     Type = bif_type(Op, Src, Vst),
     set_type_reg(Type, Dst, Vst);
 valfun_4({gc_bif,Op,{f,Fail},Live,Src,Dst}, #vst{current=St0}=Vst0) ->
+    verify_live(Live, Vst0),
+    verify_y_init(Vst0),
     St = kill_heap_allocation(St0),
     Vst1 = Vst0#vst{current=St},
-    verify_live(Live, Vst1),
     Vst2 = branch_state(Fail, Vst1),
     Vst = prune_x_regs(Live, Vst2),
     validate_src(Src, Vst),
@@ -685,6 +686,7 @@ valfun_4({bs_utf16_size,{f,Fail},A,Dst}, Vst) ->
     set_type_reg({integer,[]}, Dst, branch_state(Fail, Vst));
 valfun_4({bs_init2,{f,Fail},Sz,Heap,Live,_,Dst}, Vst0) ->
     verify_live(Live, Vst0),
+    verify_y_init(Vst0),
     if
 	is_integer(Sz) ->
 	    ok;
@@ -697,6 +699,7 @@ valfun_4({bs_init2,{f,Fail},Sz,Heap,Live,_,Dst}, Vst0) ->
     set_type_reg(binary, Dst, Vst);
 valfun_4({bs_init_bits,{f,Fail},Sz,Heap,Live,_,Dst}, Vst0) ->
     verify_live(Live, Vst0),
+    verify_y_init(Vst0),
     if
 	is_integer(Sz) ->
 	    ok;
@@ -709,6 +712,7 @@ valfun_4({bs_init_bits,{f,Fail},Sz,Heap,Live,_,Dst}, Vst0) ->
     set_type_reg(binary, Dst, Vst);
 valfun_4({bs_append,{f,Fail},Bits,Heap,Live,_Unit,Bin,_Flags,Dst}, Vst0) ->
     verify_live(Live, Vst0),
+    verify_y_init(Vst0),
     assert_term(Bits, Vst0),
     assert_term(Bin, Vst0),
     Vst1 = heap_alloc(Heap, Vst0),
@@ -944,6 +948,7 @@ deallocate(#vst{current=St}=Vst) ->
 
 test_heap(Heap, Live, Vst0) ->
     verify_live(Live, Vst0),
+    verify_y_init(Vst0),
     Vst = prune_x_regs(Live, Vst0),
     heap_alloc(Heap, Vst).
 


### PR DESCRIPTION
beam_validator did not verify that the Y registers were initialized
before executing the following instructions that could cause a GC:

    bs_append/8
    bs_init2/6
    bs_init_bits/6
    gc_bif1/5
    gc_bif2/6
    gc_bif3/7
    test_heap/2

That means that, for example, an incorrect optimization that replaced
an 'allocate_zero' instruction with an 'allocate' instruction when it
was not safe, would not be rejected by beam_validtor, but would
instead cause a crash or other undefined behavior at runtime.