### PR TITLE
Make hipe compile option verify_gcsafe the default

### DIFF
--- a/lib/hipe/main/hipe_main.erl
+++ b/lib/hipe/main/hipe_main.erl
@@ -410,9 +410,9 @@ icode_to_rtl(MFA, Icode, Options, Servers) ->
         hipe_llvm_liveness:analyze(RtlCfg4)
     end,
   pp(RtlCfg5, MFA, rtl, pp_rtl, Options, Servers),
-  case proplists:get_bool(verify_gcsafe, Options) of
-    false -> ok;
-    true ->
+  case proplists:get_bool(no_verify_gcsafe, Options) of
+    true -> ok;
+    false ->
       ok = hipe_rtl_verify_gcsafe:check(RtlCfg5)
   end,
   LinearRTL1 = hipe_rtl_cfg:linearize(RtlCfg5),

--- a/lib/hipe/rtl/hipe_rtl_verify_gcsafe.erl
+++ b/lib/hipe/rtl/hipe_rtl_verify_gcsafe.erl
@@ -76,6 +76,7 @@ safe_primop(bs_allocate) -> true;
 safe_primop(bs_reallocate) -> true;
 safe_primop(bs_utf8_size) -> true;
 safe_primop(bs_get_utf8) -> true;
+safe_primop(bs_put_utf8) -> true;
 safe_primop(bs_utf16_size) -> true;
 safe_primop(bs_get_utf16) -> true;
 safe_primop(bs_validate_unicode_retract) -> true;


### PR DESCRIPTION
An extra sanity check introduced earlier by @margnus1 in #1621.

