### PR TITLE
ErLLVM: Preserve precise BEAM tailcall semantics

### DIFF
--- a/lib/hipe/llvm/hipe_llvm.erl
+++ b/lib/hipe/llvm/hipe_llvm.erl
@@ -934,7 +934,7 @@ pp_ins(Dev, Ver, I) ->
       end,
       case call_is_tail(I) of
         true -> write(Dev, "tail ");
-        false -> ok
+        false -> write(Dev, "notail ")
       end,
       write(Dev, ["call ", call_cconv(I), " "]),
       pp_options(Dev, call_ret_attrs(I)),


### PR DESCRIPTION
The BEAM compiler chooses not to perform tailcall optimisations for some
calls in tail position, for example to some built-in functions. However,
when the ErLLVM HiPE backend is used, LLVM may choose to perform
tailcall optimisation on these calls, breaking the expected semantics.

To preserve the precise semantics exhibited by BEAM, the `notail`
marker, present in LLVM since version 3.8, is added to call instructions
that BEAM has not turned into tail calls, which inhibits LLVM from
performing tail-call optimisation in turn.

This change affects #1682, which adds some new tests to the HiPE
test suite that are sensitive to this difference in semantics.