### PR TITLE
Support expirable gen calls

### DIFF
--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -125,7 +125,7 @@ gen_server:abcast     -----> Module:handle_cast/2
 
     <func>
       <name>call(ServerRef, Request) -> Reply</name>
-      <name>call(ServerRef, Request, Timeout) -> Reply</name>
+      <name>call(ServerRef, Request, Options) -> Reply</name>
       <fsummary>Make a synchronous call to a generic server.</fsummary>
       <type>
         <v>ServerRef = Name | {Name,Node} | {global,GlobalName}</v>
@@ -133,6 +133,8 @@ gen_server:abcast     -----> Module:handle_cast/2
         <v>&nbsp;Node = atom()</v>
         <v>&nbsp;GlobalName = ViaName = term()</v>
         <v>Request = term()</v>
+        <v>Options = [Option] | Timeout</v>
+        <v>Option = {timeout, Timeout} | expirable</v>
         <v>Timeout = int()>0 | infinity</v>
         <v>Reply = term()</v>
       </type>


### PR DESCRIPTION
This PR proposes an implementation of expirable `gen` calls, following a recent mailing list [thread](http://erlang.org/pipermail/erlang-questions/2018-January/094667.html) where this idea was first mentioned by @jlouis and then further discussed.

The rationale behind it is to minimize the impact of common overload patterns of singleton `gen` processes, where work delivered to a slow consumer risks piling up until either work production slows down or resource exhaustion is reached in a feedback loop, as [succinctly exposed](http://erlang.org/pipermail/erlang-questions/2018-January/094662.html) by @maxlapshin on the same thread.

The core of the presented solution lies on optionally attaching an `Expiration` value to the call message, in native units of monotonic time. When the consumer (`gen_server`, `gen_statem`, ...) receives the call message it will compare the current monotonic timestamp against the expiration value and, if it's equal or greater, the call will be ignored.

Because monotonic timestamps originating on different nodes are not comparable, for this to work when calling a remote `gen_server` a temporary process is spawned remotely that's responsible for determining the expiration timestamp, attaching it to the call message and dispatching the call to the process.

In order to avoid the overhead of performing all of the above unless strictly necessary, un-expirable calls are still sent and processed in the same way. For the same reason, local expirable calls don't make use of temporary processes as remote ones do. There's no interface breakage other than for `gen` consumer behaviours that desire to support expirable calls.