### PR TITLE
epmd: allow alternative to dns resolving for nodename

### DIFF
--- a/erts/doc/src/Makefile
+++ b/erts/doc/src/Makefile
@@ -74,6 +74,7 @@ XML_CHAPTER_FILES = \
 	match_spec.xml \
 	crash_dump.xml \
 	alt_dist.xml \
+	alt_disco.xml \
 	driver.xml \
 	absform.xml \
 	inet_cfg.xml \

--- a/erts/doc/src/alt_disco.xml
+++ b/erts/doc/src/alt_disco.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE chapter SYSTEM "chapter.dtd">
+
+<chapter>
+  <header>
+    <copyright>
+      <year>2018</year><year>2018</year>
+      <holder>Ericsson AB. All Rights Reserved.</holder>
+    </copyright>
+    <legalnotice>
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+    </legalnotice>
+
+    <title>How to Implement an Alternative Service Discovery for Erlang Distribution
+    </title>
+    <prepared>Timmo Verlaan</prepared>
+    <responsible></responsible>
+    <docno></docno>
+    <approved></approved>
+    <checked></checked>
+    <date>2018-04-25</date>
+    <rev>PA1</rev>
+    <file>alt_disco.xml</file>
+  </header>
+  <p>
+    This section describes how to implement an alternative discovery mechanism
+    for Erlang distribution. Discovery is normally done using DNS and the
+    Erlang Port Mapper Daemon (EPMD) for port discovery.
+  </p>
+
+  <note><p>
+    Support for alternative service discovery mechanisms was added in Erlang/OTP
+    21.
+  </p></note>
+
+
+  <section>
+    <title>Introduction</title>
+    <p>To implement your own service discovery module you have to write your own
+    EPMD module. The <seealso marker="kernel:erl_epmd">EPMD module</seealso> is
+    responsible for providing the location of another node. The distribution
+    modules (<c>inet_tcp_dist</c>/<c>inet_tls_dist</c>) call the EPMD module to
+    get the IP address and port of the other node. The EPMD module that is part
+    of Erlang/OTP will resolve the hostname using DNS and uses the EPMD unix
+    process to get the port of another node. The EPMD unix process does this by
+    connecting to the other node on a well-known port, port 4369.</p>
+  </section>
+
+  <section>
+    <title>Discovery module</title>
+    <p>The discovery module needs to implement the same API as the regular
+    <seealso marker="kernel:erl_epmd">EPMD module</seealso>. However, instead of
+    communicating with EPMD you can connect to any service to find out
+    connection details of other nodes. A discovery module is enabled
+    by setting <seealso marker="erts:erl#epmd_module">-epmd_module</seealso>
+    when starting erlang. The discovery module must implement the following
+    callbacks:</p>
+
+    <taglist>
+      <tag><seealso marker="kernel:erl_epmd#start_link/0">start_link/0</seealso></tag>
+      <item>Start any processes needed by the discovery module.</item>
+      <tag><seealso marker="kernel:erl_epmd#names/1">names/1</seealso></tag>
+      <item>Return node names held by the registrar for the given host.</item>
+      <tag><seealso marker="kernel:erl_epmd#register_node/2">register_node/2</seealso></tag>
+      <item>Register the given node name with the registrar.</item>
+      <tag><seealso marker="kernel:erl_epmd#port_please/3">port_please/3</seealso></tag>
+      <item>Return the distribution port used by the given node.</item>
+    </taglist>
+
+    <p>The discovery module may implement the following callback:</p>
+
+    <taglist>
+      <tag><seealso marker="kernel:erl_epmd#address_please/3">address_please/3</seealso></tag>
+      <item><p>Return the address of the given node.
+        If not implemented, <seealso marker="kernel:inet#gethostbyname/1">
+        inet:gethostbyname/1</seealso> will be used instead</p>
+        <p>This callback may also return the port of the given node. In that case
+        <seealso marker="kernel:erl_epmd#port_please/3">port_please/3</seealso>
+        may be omitted.</p></item>
+    </taglist>
+  </section>
+</chapter>

--- a/erts/doc/src/part.xml
+++ b/erts/doc/src/part.xml
@@ -37,6 +37,7 @@
   <xi:include href="match_spec.xml"/>
   <xi:include href="crash_dump.xml"/>
   <xi:include href="alt_dist.xml"/>
+  <xi:include href="alt_disco.xml"/>
   <xi:include href="absform.xml"/>
   <xi:include href="tty.xml"/>
   <xi:include href="driver.xml"/>

--- a/erts/emulator/test/distribution_SUITE.erl
+++ b/erts/emulator/test/distribution_SUITE.erl
@@ -73,7 +73,7 @@
          dist_evil_parallel_receiver/0]).
 
 %% epmd_module exports
--export([start_link/0, register_node/2, register_node/3, port_please/2]).
+-export([start_link/0, register_node/2, register_node/3, port_please/2, address_please/3]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -2085,6 +2085,11 @@ port_please(_Name, _Ip) ->
 	    Version = 5,
 	    {port, Port, Version}
     end.
+
+address_please(_Name, _Address, _AddressFamily) ->
+    %% Use localhost.
+    IP = {127,0,0,1},
+    {ok, IP}.
 
 %%% Utilities
 

--- a/lib/kernel/doc/src/Makefile
+++ b/lib/kernel/doc/src/Makefile
@@ -42,6 +42,7 @@ XML_REF3_FILES = application.xml \
 	disk_log.xml \
 	erl_boot_server.xml \
 	erl_ddll.xml \
+	erl_epmd.xml \
 	erl_prim_loader_stub.xml \
 	erlang_stub.xml \
 	error_handler.xml \

--- a/lib/kernel/doc/src/erl_epmd.xml
+++ b/lib/kernel/doc/src/erl_epmd.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE erlref SYSTEM "erlref.dtd">
+
+<erlref>
+  <header>
+    <copyright>
+      <year>2018</year><year>2018</year>
+      <holder>Ericsson AB. All Rights Reserved.</holder>
+    </copyright>
+    <legalnotice>
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+    </legalnotice>
+
+    <title>erl_epmd</title>
+    <prepared>Timmo Verlaan</prepared>
+    <docno>1</docno>
+    <date>2018-02-19</date>
+    <rev>A</rev>
+  </header>
+  <module>erl_epmd</module>
+  <modulesummary>
+    Erlang interface towards epmd
+  </modulesummary>
+  <description>
+    <p>This module communicates with the EPMD daemon, see <seealso
+    marker="erts:epmd">epmd</seealso>. To implement your own epmd module please
+    see <seealso marker="erts:alt_disco">ERTS User's Guide: How to Implement an
+    Alternative Service Discovery for Erlang Distribution</seealso></p>
+  </description>
+
+  <funcs>
+    <func>
+      <name name="start_link" arity="0"/>
+      <fsummary>Callback for erl_distribution supervisor.</fsummary>
+      <desc>
+        <p>This function is invoked as this module is added as a child of the
+        <c>erl_distribution</c> supervisor.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="register_node" arity="2"/>
+      <name name="register_node" arity="3"/>
+      <fsummary>Registers the node with <c>epmd</c>.</fsummary>
+      <desc>
+        <p>Registers the node with <c>epmd</c> and tells epmd what port will be
+        used for the current node. It returns a creation number. This number is
+        incremented on each register to help with identifying if a node is
+        reconnecting to epmd.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="port_please" arity="2"/>
+      <name name="port_please" arity="3"/>
+      <fsummary>Returns the port number for a given node.</fsummary>
+      <desc>
+        <p>Requests the distribution port for the given node of an EPMD
+        instance. Together with the port it returns a distribution protocol
+        version which has been 5 since Erlang/OTP R6.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="address_please" arity="3"/>
+      <fsummary>Returns address and port.</fsummary>
+      <desc>
+        <p>Called by the distribution module. Resolves the <c>Host</c> to an IP
+        address.</p>
+        <p>Another epmd module may return port and distribution protocol version
+        as well.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="names" arity="1"/>
+      <fsummary>Names of Erlang nodes at a host.</fsummary>
+      <desc>
+        <p>Called by <seealso marker="net_adm"><c>net_adm:names/0</c></seealso>.
+        <c>Host</c> defaults to the localhost. Returns the names and associated
+        port numbers of the Erlang nodes that <c>epmd</c> registered at the
+        specified host. Returns <c>{error, address}</c> if <c>epmd</c> is not
+        operational.</p>
+        <p><em>Example:</em></p>
+        <pre>
+(arne@dunn)1> <input>erl_epmd:names(localhost).</input>
+{ok,[{"arne",40262}]}</pre>
+      </desc>
+    </func>
+  </funcs>
+
+</erlref>
+

--- a/lib/kernel/doc/src/ref_man.xml
+++ b/lib/kernel/doc/src/ref_man.xml
@@ -38,6 +38,7 @@
   <xi:include href="disk_log.xml"/>
   <xi:include href="erl_boot_server.xml"/>
   <xi:include href="erl_ddll.xml"/>
+  <xi:include href="erl_epmd.xml"/>
   <xi:include href="erl_prim_loader_stub.xml"/>
   <xi:include href="erlang_stub.xml"/>
   <xi:include href="error_handler.xml"/>

--- a/lib/kernel/doc/src/specs.xml
+++ b/lib/kernel/doc/src/specs.xml
@@ -6,6 +6,7 @@
   <xi:include href="../specs/specs_disk_log.xml"/>
   <xi:include href="../specs/specs_erl_boot_server.xml"/>
   <xi:include href="../specs/specs_erl_ddll.xml"/>
+  <xi:include href="../specs/specs_erl_epmd.xml"/>
   <xi:include href="../specs/specs_erl_prim_loader_stub.xml"/>
   <xi:include href="../specs/specs_erlang_stub.xml"/>
   <xi:include href="../specs/specs_error_handler.xml"/>

--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -29,10 +29,20 @@
 -define(port_please_failure2(Term), noop).
 -endif.
 
+-ifndef(erlang_daemon_port).
+-define(erlang_daemon_port, 4369).
+-endif.
+-ifndef(epmd_dist_high).
+-define(epmd_dist_high, 4370).
+-endif.
+-ifndef(epmd_dist_low).
+-define(epmd_dist_low, 4370).
+-endif.
+
 %% External exports
 -export([start/0, start_link/0, stop/0, port_please/2, 
 	 port_please/3, names/0, names/1,
-	 register_node/2, register_node/3, open/0, open/1, open/2]).
+	 register_node/2, register_node/3, address_please/3, open/0, open/1, open/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, 
@@ -53,7 +63,7 @@
 start() ->
     gen_server:start({local, erl_epmd}, ?MODULE, [], []).
 
-
+-spec start_link() -> {ok, pid()} | ignore | {error,term()}.
 start_link() ->
     gen_server:start_link({local, erl_epmd}, ?MODULE, [], []).
 
@@ -66,8 +76,21 @@ stop() ->
 %% return {port, P, Version} | noport
 %%
 
+-spec port_please(Name, Host) -> {ok, Port, Version} | noport when
+	  Name :: string(),
+	  Host :: inet:ip_address(),
+	  Port :: non_neg_integer(),
+	  Version :: non_neg_integer().
+
 port_please(Node, Host) ->
   port_please(Node, Host, infinity).
+
+-spec port_please(Name, Host, Timeout) -> {ok, Port, Version} | noport when
+	  Name :: string(),
+	  Host :: inet:ip_address(),
+	  Timeout :: non_neg_integer() | infinity,
+	  Port :: non_neg_integer(),
+	  Version :: non_neg_integer().
 
 port_please(Node,HostName, Timeout) when is_atom(HostName) ->
   port_please1(Node,atom_to_list(HostName), Timeout);
@@ -92,9 +115,20 @@ port_please1(Node,HostName, Timeout) ->
       Else
   end.
 
+-spec names() -> {ok, [{Name, Port}]} | {error, Reason} when
+	  Name :: string(),
+	  Port :: non_neg_integer(),
+	  Reason :: address | file:posix().
+
 names() ->
     {ok, H} = inet:gethostname(),
     names(H).
+
+-spec names(Host) -> {ok, [{Name, Port}]} | {error, Reason} when
+      Host :: atom() | string() | inet:ip_address(),
+      Name :: string(),
+      Port :: non_neg_integer(),
+      Reason :: address | file:posix().
 
 names(HostName) when is_atom(HostName); is_list(HostName) ->
   case inet:gethostbyname(HostName) of
@@ -106,15 +140,39 @@ names(HostName) when is_atom(HostName); is_list(HostName) ->
 names(EpmdAddr) ->
   get_names(EpmdAddr).
 
+-spec register_node(Name, Port) -> Result when
+	  Name :: string(),
+	  Port :: non_neg_integer(),
+	  Creation :: non_neg_integer(),
+	  Result :: {ok, Creation} | {error, already_registered} | term().
 
 register_node(Name, PortNo) ->
-    register_node(Name, PortNo, inet).
+	register_node(Name, PortNo, inet).
+
+-spec register_node(Name, Port, Driver) -> Result when
+	  Name :: string(),
+	  Port :: non_neg_integer(),
+	  Driver :: inet_tcp | inet6_tcp | inet | inet6,
+	  Creation :: non_neg_integer(),
+	  Result :: {ok, Creation} | {error, already_registered} | term().
+
 register_node(Name, PortNo, inet_tcp) ->
     register_node(Name, PortNo, inet);
 register_node(Name, PortNo, inet6_tcp) ->
     register_node(Name, PortNo, inet6);
 register_node(Name, PortNo, Family) ->
     gen_server:call(erl_epmd, {register, Name, PortNo, Family}, infinity).
+
+-spec address_please(Name, Host, AddressFamily) -> Success | {error, term()} when
+	  Name :: string(),
+	  Host :: string() | inet:ip_address(),
+	  AddressFamily :: inet | inet6,
+	  Port :: non_neg_integer(),
+	  Version :: non_neg_integer(),
+	  Success :: {ok, inet:ip_address()} | {ok, inet:ip_address(), Port, Version}.
+
+address_please(_Name, Host, AddressFamily) ->
+	inet:getaddr(Host, AddressFamily).
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_server

--- a/lib/kernel/src/inet_tcp_dist.erl
+++ b/lib/kernel/src/inet_tcp_dist.erl
@@ -283,73 +283,22 @@ do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
     ?trace("~p~n",[{inet_tcp_dist,self(),setup,Node}]),
     [Name, Address] = splitnode(Driver, Node, LongOrShortNames),
     AddressFamily = Driver:family(),
-    case inet:getaddr(Address, AddressFamily) of
+    ErlEpmd = net_kernel:epmd_module(),
+    {ARMod, ARFun} = get_address_resolver(ErlEpmd),
+    Timer = dist_util:start_timer(SetupTime),
+    case ARMod:ARFun(Name, Address, AddressFamily) of
+	{ok, Ip, TcpPort, Version} ->
+		?trace("address_please(~p) -> version ~p~n",
+			[Node,Version]),
+		do_setup_connect(Driver, Kernel, Node, Address, AddressFamily,
+		                 Ip, TcpPort, Version, Type, MyNode, Timer);
 	{ok, Ip} ->
-	    Timer = dist_util:start_timer(SetupTime),
-	    ErlEpmd = net_kernel:epmd_module(),
 	    case ErlEpmd:port_please(Name, Ip) of
 		{port, TcpPort, Version} ->
 		    ?trace("port_please(~p) -> version ~p~n", 
 			   [Node,Version]),
-		    dist_util:reset_timer(Timer),
-		    case
-			Driver:connect(
-			  Ip, TcpPort,
-			  connect_options([{active, false}, {packet, 2}]))
-		    of
-			{ok, Socket} ->
-			    HSData = #hs_data{
-			      kernel_pid = Kernel,
-			      other_node = Node,
-			      this_node = MyNode,
-			      socket = Socket,
-			      timer = Timer,
-			      this_flags = 0,
-			      other_version = Version,
-			      f_send = fun Driver:send/2,
-			      f_recv = fun Driver:recv/3,
-			      f_setopts_pre_nodeup = 
-			      fun(S) ->
-				      inet:setopts
-					(S, 
-					 [{active, false},
-					  {packet, 4},
-					  nodelay()])
-			      end,
-			      f_setopts_post_nodeup = 
-			      fun(S) ->
-				      inet:setopts
-					(S, 
-					 [{active, true},
-					  {deliver, port},
-					  {packet, 4},
-					  nodelay()])
-			      end,
-
-			      f_getll = fun inet:getll/1,
-			      f_address = 
-			      fun(_,_) ->
-				      #net_address{
-				   address = {Ip,TcpPort},
-				   host = Address,
-				   protocol = tcp,
-				   family = AddressFamily}
-			      end,
-			      mf_tick = fun(S) -> ?MODULE:tick(Driver, S) end,
-			      mf_getstat = fun ?MODULE:getstat/1,
-			      request_type = Type,
-			      mf_setopts = fun ?MODULE:setopts/2,
-			      mf_getopts = fun ?MODULE:getopts/2
-			     },
-			    dist_util:handshake_we_started(HSData);
-			_ ->
-			    %% Other Node may have closed since 
-			    %% port_please !
-			    ?trace("other node (~p) "
-				   "closed since port_please.~n", 
-				   [Node]),
-			    ?shutdown(Node)
-		    end;
+			do_setup_connect(Driver, Kernel, Node, Address, AddressFamily,
+			                 Ip, TcpPort, Version, Type, MyNode, Timer);
 		_ ->
 		    ?trace("port_please (~p) "
 			   "failed.~n", [Node]),
@@ -360,6 +309,71 @@ do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 		   "failed (~p).~n", [Node,_Other]),
 	    ?shutdown(Node)
     end.
+
+%%
+%% Actual setup of connection
+%%
+do_setup_connect(Driver, Kernel, Node, Address, AddressFamily,
+                 Ip, TcpPort, Version, Type, MyNode, Timer) ->
+	dist_util:reset_timer(Timer),
+	case
+	Driver:connect(
+	  Ip, TcpPort,
+	  connect_options([{active, false}, {packet, 2}]))
+	of
+	{ok, Socket} ->
+		HSData = #hs_data{
+		  kernel_pid = Kernel,
+		  other_node = Node,
+		  this_node = MyNode,
+		  socket = Socket,
+		  timer = Timer,
+		  this_flags = 0,
+		  other_version = Version,
+		  f_send = fun Driver:send/2,
+		  f_recv = fun Driver:recv/3,
+		  f_setopts_pre_nodeup =
+		  fun(S) ->
+			  inet:setopts
+			(S,
+			 [{active, false},
+			  {packet, 4},
+			  nodelay()])
+		  end,
+		  f_setopts_post_nodeup =
+		  fun(S) ->
+			  inet:setopts
+			(S,
+			 [{active, true},
+			  {deliver, port},
+			  {packet, 4},
+			  nodelay()])
+		  end,
+
+		  f_getll = fun inet:getll/1,
+		  f_address =
+		  fun(_,_) ->
+			  #net_address{
+		   address = {Ip,TcpPort},
+		   host = Address,
+		   protocol = tcp,
+		   family = AddressFamily}
+		  end,
+		  mf_tick = fun(S) -> ?MODULE:tick(Driver, S) end,
+		  mf_getstat = fun ?MODULE:getstat/1,
+		  request_type = Type,
+		  mf_setopts = fun ?MODULE:setopts/2,
+		  mf_getopts = fun ?MODULE:getopts/2
+		 },
+		dist_util:handshake_we_started(HSData);
+	_ ->
+		%% Other Node may have closed since
+		%% discovery !
+		?trace("other node (~p) "
+		   "closed since discovery (port_please).~n",
+		   [Node]),
+		?shutdown(Node)
+	end.
 
 connect_options(Opts) ->
     case application:get_env(kernel, inet_dist_connect_options) of
@@ -428,6 +442,16 @@ get_tcp_address(Driver, Socket) ->
 		  protocol = tcp,
 		  family = Driver:family()
 		 }.
+
+%% ------------------------------------------------------------
+%% Determine if EPMD module supports address resolving. Default
+%% is to use inet:getaddr/2.
+%% ------------------------------------------------------------
+get_address_resolver(EpmdModule) ->
+    case erlang:function_exported(EpmdModule, address_please, 3) of
+        true -> {EpmdModule, address_please};
+        _    -> {inet, getaddr}
+    end.
 
 %% ------------------------------------------------------------
 %% Do only accept new connection attempts from nodes at our


### PR DESCRIPTION
This makes it possible to create a custom integration with a
key-value store for example. The key would then point to the
actual address. You would have to write your own epmd module
to make use of that feature.

I have not contributed to erlang/otp before so it's kind of new to me. I have read the contributing guidelines, but I'm not sure if this change requires any of the mentioned steps (except for documentation which I will fix, if this PR is even 'considerable'). Please let me know if I'm missing or not understanding something there.

Having said that I also have "my own" tcp dist and epmd module that implements something alike here (although in Elixir): https://github.com/tverlaan/inet_tcp_dist/