### PR TITLE
Fix incorrect handling of floating point instructions

### DIFF
--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -222,6 +222,7 @@ move_allocates_1([I|Is], Acc) ->
     move_allocates_1(Is, [I|Acc]);
 move_allocates_1([], Acc) -> Acc.
 
+alloc_may_pass({set,_,[{fr,_}],fmove}) -> false;
 alloc_may_pass({set,_,_,{alloc,_,_}}) -> false;
 alloc_may_pass({set,_,_,{set_tuple_element,_}}) -> false;
 alloc_may_pass({set,_,_,put_list}) -> false;

--- a/lib/compiler/test/beam_block_SUITE.erl
+++ b/lib/compiler/test/beam_block_SUITE.erl
@@ -22,7 +22,7 @@
 -export([all/0,suite/0,groups/0,init_per_suite/1,end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
 	 get_map_elements/1,otp_7345/1,move_opt_across_gc_bif/1,
-	 erl_202/1,repro/1,local_cse/1]).
+	 erl_202/1,repro/1,local_cse/1,second_block_pass/1]).
 
 %% The only test for the following functions is that
 %% the code compiles and is accepted by beam_validator.
@@ -41,7 +41,8 @@ groups() ->
        move_opt_across_gc_bif,
        erl_202,
        repro,
-       local_cse
+       local_cse,
+       second_block_pass
       ]}].
 
 init_per_suite(Config) ->
@@ -294,6 +295,15 @@ local_cse_4() ->
 
 do_local_cse_4(X, Y, Z) ->
     {X,Y,Z}.
+
+%% Tests previously found bugs when running beam_block the second time.
+
+second_block_pass(_Config) ->
+    [#{dts:=5.0}] = second_1([#{dts => 10.0}], 2.0),
+    ok.
+
+second_1(Fs, TS) ->
+    [F#{dts=>DTS / TS} || #{dts:=DTS} = F <- Fs].
 
 %%%
 %%% Common functions.


### PR DESCRIPTION
1a029efd1ad47f started to run the beam_block pass a second time.

Since it is run after introduction of the optimized floating point
instructions, it must handle those instructions correctly.
In particular, it must be careful when hoisting allocation
instructions. For example, the following code:

    {test_heap,{alloc,[{words,0},{floats,1}]},5}.
       .
       .
       .
    {fmove,{fr,2},{x,0}}.
    {allocate_zero,1,4}.

must not be rewritten to:

    {test_heap,{alloc,[{words,0},{floats,1}]},5}.
       .
       .
       .
    {allocate_zero,1,4}.
    {fmove,{fr,2},{x,0}}.

because beam_validator will not consider it safe. (The code may
actually be safe depending on what the code between the two allocation
instructions do.)

https://bugs.erlang.org/browse/ERL-555