### PR TITLE
Ingela/ssl/add ciphers to default/otp 14760

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -881,10 +881,10 @@ fun(srp, Username :: string(), UserState :: term()) ->
       <fsummary>Returns a list of all default or
       all supported cipher suites.</fsummary>
       <type>
-        <v> Supported = default | all </v>
+        <v> Supported = default | all | anonymous </v>
 	<v> Version = protocol_version() </v>
       </type>
-      <desc><p>Returns all default or all supported cipher suites for a
+      <desc><p>Returns all default or all supported (except anonymous), or all anonymous cipher suites for a
       TLS version</p>
     </desc>
     </func>

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -138,17 +138,20 @@
       <tag><c>sslsocket() =</c></tag>
       <item><p>opaque()</p></item>
 
-      <tag><marker id="type-protocol"/><c>protocol() =</c></tag>
+      <tag><marker id="type-protocol"/><c>protocol_version() =</c></tag>
       <item><p><c>sslv3 | tlsv1 | 'tlsv1.1' | 'tlsv1.2'</c></p></item>
 
       <tag><c>ciphers() =</c></tag>
-      <item><p><c>= [ciphersuite()] | string()</c></p>
-      <p>According to old API.</p></item>
+      <item><p><c>= [ciphersuite()]</c></p>
+      <p>Tuples and string formats accepted by versions
+      before ssl-8.2.4 will be converted for backwards compatibility</p></item>
 
       <tag><c>ciphersuite() =</c></tag>
-
-      <item><p><c>{key_exchange(), cipher(), MAC::hash()} |
-      {key_exchange(), cipher(), MAC::hash(), PRF::hash()}</c></p></item>
+      <item><p><c>
+      #{key_exchange := key_exchange(),
+        cipher := cipher(),
+        mac := MAC::hash() | aead,
+        prf := PRF::hash() | default_prf} </c></p></item>
 
       <tag><c>key_exchange()=</c></tag>
       <item><p><c>rsa | dhe_dss | dhe_rsa | dh_anon | psk | dhe_psk
@@ -164,6 +167,12 @@
 
       <tag><c>prf_random() =</c></tag>
       <item><p><c>client_random | server_random</c></p></item>
+
+      <tag><c>cipher_filters() =</c></tag>
+      <item><p><c> [{key_exchange | cipher | mac | prf, algo_filter()}])</c></p></item>
+
+      <tag><c>algo_filter() =</c></tag>
+      <item><p>fun(key_exchange() | cipher() | hash() | aead | default_prf) -> true | false </p></item>
 
       <tag><c>srp_param_type() =</c></tag>
       <item><p><c>srp_1024 | srp_1536 | srp_2048 | srp_3072
@@ -456,7 +465,7 @@ marker="public_key:public_key#pkix_path_validation-3">public_key:pkix_path_valid
       marker="public_key:public_key#pkix_path_validation-3">public_key:pkix_path_validation/3</seealso>
       with the selected CA as trusted anchor and the rest of the chain.</p></item>
 
-      <tag><c>{versions, [protocol()]}</c></tag>
+      <tag><c>{versions, [protocol_version()]}</c></tag>
       <item><p>TLS protocol versions supported by started clients and servers.
       This option overrides the application environment option
       <c>protocol_version</c>. If the environment option is not set, it defaults
@@ -829,14 +838,34 @@ fun(srp, Username :: string(), UserState :: term()) ->
   </section>
   
   <funcs>
+
+    <func>
+      <name>append_cipher_suites(Deferred, Suites) -> ciphers() </name>
+      <fsummary></fsummary>
+      <type>
+           <v>Deferred = ciphers() | cipher_filters() </v>
+	   <v>Suites  = ciphers() </v>
+      </type>
+      <desc><p>Make <c>Deferred</c> suites become the least preferred
+      suites, that is put them at the end of the cipher suite list
+      <c>Suites</c> after removing them from <c>Suites</c> if
+      present. <c>Deferred</c> may be a list of cipher suits or a
+      list of filters in which case the filters are use on  <c>Suites</c> to
+      extract the Deferred cipher list.</p> 
+      </desc>
+    </func>
+    
     <func>
       <name>cipher_suites() -></name>
-      <name>cipher_suites(Type) -> ciphers()</name>
+      <name>cipher_suites(Type) -> old_ciphers()</name>
       <fsummary>Returns a list of supported cipher suites.</fsummary>
       <type>
         <v>Type = erlang | openssl | all</v>
       </type>
-      <desc><p>Returns a list of supported cipher suites.
+      <desc>
+	<p>Returns a list of supported cipher suites.
+	This function will become deprecated in OTP 21, and replaced
+	by <seealso marker="#cipher_suites-2">ssl:cipher-suites/2</seealso>
 	<c>cipher_suites()</c> is equivalent to <c>cipher_suites(erlang).</c>
 	Type <c>openssl</c> is provided for backwards compatibility with the
 	old SSL, which used OpenSSL. <c>cipher_suites(all)</c> returns
@@ -844,12 +873,25 @@ fun(srp, Username :: string(), UserState :: term()) ->
 	in <c>cipher_suites(erlang)</c> but included in
 	<c>cipher_suites(all)</c> are not used unless explicitly configured
 	by the user.</p>
+      </desc>
+    </func>
+    
+   <func>
+      <name>cipher_suites(Supported, Version) ->  ciphers()</name>
+      <fsummary>Returns a list of all default or
+      all supported cipher suites.</fsummary>
+      <type>
+        <v> Supported = default | all </v>
+	<v> Version = protocol_version() </v>
+      </type>
+      <desc><p>Returns all default or all supported cipher suites for a
+      TLS version</p>
     </desc>
     </func>
 
     <func>
       <name>eccs() -></name>
-      <name>eccs(protocol()) -> [named_curve()]</name>
+      <name>eccs(protocol_version()) -> [named_curve()]</name>
       <fsummary>Returns a list of supported ECCs.</fsummary>
 
       <desc><p>Returns a list of supported ECCs. <c>eccs()</c>
@@ -1008,6 +1050,21 @@ fun(srp, Username :: string(), UserState :: term()) ->
       </desc>
     </func>
 
+      <func>
+      <name>filter_cipher_suites(Suites, Filters) -> ciphers()</name>
+      <fsummary></fsummary>
+      <type>
+	<v> Suites = ciphers()</v>
+        <v> Filters = cipher_filters()</v>
+      </type>
+      <desc><p>Removes cipher suites if any of the filter functions
+      returns false for any part of the cipher suite. This function
+      also calls default filter functions to make sure the cipher
+      suites are supported by crypto. If no filter function is supplied for some
+      part the default behaviour is fun(Algorithm) -> true.</p>
+    </desc>
+    </func>
+    
     <func>
       <name>format_error(Reason) -> string()</name>
       <fsummary>Returns an error string.</fsummary>
@@ -1103,6 +1160,22 @@ fun(srp, Username :: string(), UserState :: term()) ->
       </type>
       <desc>
         <p>Returns the address and port number of the peer.</p>
+      </desc>
+    </func>
+    
+      <func>
+      <name>prepend_cipher_suites(Preferred, Suites) -> ciphers()</name>
+      <fsummary></fsummary>
+      <type>
+        <v>Preferred = ciphers() | cipher_filters() </v>
+	<v>Suites = ciphers() </v>
+      </type>
+      <desc><p>Make <c>Preferred</c> suites become the most preferred
+      suites that is put them at the head of the cipher suite list
+      <c>Suites</c> after removing them from <c>Suites</c> if
+      present. <c>Preferred</c> may be a list of cipher suits or a
+      list of filters in which case the filters are use on <c>Suites</c> to
+      extract the preferred cipher list. </p>
       </desc>
     </func>
 
@@ -1332,7 +1405,7 @@ fun(srp, Username :: string(), UserState :: term()) ->
       <fsummary>Returns version information relevant for the
 	SSL application.</fsummary>
       <type>
-	<v>versions_info() = {app_vsn, string()} | {supported | available, [protocol()] </v>
+	<v>versions_info() = {app_vsn, string()} | {supported | available, [protocol_version()] </v>
       </type>
       <desc>
 	<p>Returns version information relevant for the SSL

--- a/lib/ssl/doc/src/using_ssl.xml
+++ b/lib/ssl/doc/src/using_ssl.xml
@@ -153,7 +153,51 @@ ok</code>
     </section>
   </section>
 
-   <section>
+  <section>
+    <title>Customizing cipher suits</title>
+
+    <p>Fetch default cipher suite list for an TLS/DTLS version. Change default
+    to all to get all possible cipher suites.</p>
+    <code type="erl">1>  Default = ssl:cipher_suites(default, 'tlsv1.2').
+    [#{cipher => aes_256_gcm,key_exchange => ecdhe_ecdsa,
+    mac => aead,prf => sha384}, ....]
+</code>
+
+    <p>In OTP 20 it is desirable to remove all cipher suites
+    that uses rsa kexchange (removed from default in 21) </p>
+    <code type="erl">2> NoRSA =
+    ssl:filter_cipher_suites(Default,
+                            [{key_exchange, fun(rsa) -> false;
+			                       (_) -> true end}]).
+    [...]
+    </code>
+
+    <p> Pick just a few suites </p>
+    <code type="erl"> 3> Suites =
+    ssl:filter_cipher_suites(Default,
+                            [{key_exchange, fun(ecdh_ecdsa) -> true;
+			                       (_) -> false end},
+                             {cipher, fun(aes_128_cbc) ->true;
+			                  (_) ->false end}]).
+    [#{cipher => aes_128_cbc,key_exchange => ecdh_ecdsa,
+     mac => sha256,prf => sha256},
+     #{cipher => aes_128_cbc,key_exchange => ecdh_ecdsa,mac => sha,
+     prf => default_prf}]
+    </code>
+    
+    <p> Make some particular suites the most preferred, or least
+    preferred by changing prepend to append.</p>
+    <code type="erl"> 4>ssl:prepend_cipher_suites(Suites, Default).
+  [#{cipher => aes_128_cbc,key_exchange => ecdh_ecdsa,
+     mac => sha256,prf => sha256},
+   #{cipher => aes_128_cbc,key_exchange => ecdh_ecdsa,mac => sha,
+     prf => default_prf},
+   #{cipher => aes_256_cbc,key_exchange => ecdhe_ecdsa,
+     mac => sha384,prf => sha384}, ...]
+    </code>
+  </section>      
+
+  <section>
     <title>Using an Engine Stored Key</title>
     
     <p>Erlang ssl application is able to use private keys provided

--- a/lib/ssl/src/dtls_v1.erl
+++ b/lib/ssl/src/dtls_v1.erl
@@ -21,7 +21,7 @@
 
 -include("ssl_cipher.hrl").
 
--export([suites/1, all_suites/1, hmac_hash/3, ecc_curves/1, 
+-export([suites/1, all_suites/1, anonymous_suites/1,hmac_hash/3, ecc_curves/1, 
          corresponding_tls_version/1, corresponding_dtls_version/1,
          cookie_secret/0, cookie_timeout/0]).
 
@@ -40,6 +40,12 @@ all_suites(Version) ->
                  end,
                  ssl_cipher:all_suites(corresponding_tls_version(Version))).
 
+anonymous_suites(Version) ->
+    lists:filter(fun(Cipher) -> 
+                         is_acceptable_cipher(ssl_cipher:suite_definition(Cipher)) 
+                 end, 
+                 ssl_cipher:anonymous_suites(corresponding_tls_version(Version))).
+                 
 hmac_hash(MacAlg, MacSecret, Value) ->
     tls_v1:hmac_hash(MacAlg, MacSecret, Value).
 

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -39,7 +39,9 @@
 	]).
 %% SSL/TLS protocol handling
 
--export([cipher_suites/0, cipher_suites/1, eccs/0, eccs/1, versions/0, 
+-export([cipher_suites/0, cipher_suites/1, cipher_suites/2, filter_cipher_suites/2,
+         prepend_cipher_suites/2, append_cipher_suites/2,
+         eccs/0, eccs/1, versions/0, 
          format_error/1, renegotiate/1, prf/5, negotiated_protocol/1, 
 	 connection_information/1, connection_information/2]).
 %% Misc
@@ -379,17 +381,91 @@ negotiated_protocol(#sslsocket{pid = Pid}) ->
 cipher_suites() ->
     cipher_suites(erlang).
 %%--------------------------------------------------------------------
--spec cipher_suites(erlang | openssl | all) -> [ssl_cipher:old_erl_cipher_suite() | string()].
+-spec cipher_suites(erlang | openssl | all) -> 
+                           [ssl_cipher:old_erl_cipher_suite() | string()].
 %% Description: Returns all supported cipher suites.
 %%--------------------------------------------------------------------
 cipher_suites(erlang) ->
     [ssl_cipher:erl_suite_definition(Suite) || Suite <- available_suites(default)];
 
 cipher_suites(openssl) ->
-    [ssl_cipher:openssl_suite_name(Suite) || Suite <- available_suites(default)];
+    [ssl_cipher:openssl_suite_name(Suite) ||
+        Suite <- available_suites(default)];
 
 cipher_suites(all) ->
     [ssl_cipher:erl_suite_definition(Suite) || Suite <- available_suites(all)].
+
+%%--------------------------------------------------------------------
+-spec cipher_suites(default | all, tls_record:tls_version() | dtls_record:dtls_version() |
+                    tls_record:tls_atom_version() |  dtls_record:dtls_atom_version()) -> 
+                           [ssl_cipher:erl_cipher_suite()].
+%% Description: Returns all default and all supported cipher suites for a
+%% TLS/DTLS version
+%%--------------------------------------------------------------------
+cipher_suites(Base, Version) when Version == 'tlsv1.2';
+                                  Version == 'tlsv1.1';
+                                  Version == tlsv1;
+                                  Version == sslv3 ->
+    cipher_suites(Base, tls_record:protocol_version(Version));
+cipher_suites(Base, Version)  when Version == 'dtlsv1.2';
+                                   Version == 'dtlsv1'->
+    cipher_suites(Base, dtls_record:protocol_version(Version));                   
+cipher_suites(Base, Version) ->
+    [ssl_cipher:suite_definition(Suite) || Suite <- supported_suites(Base, Version)].
+
+%%--------------------------------------------------------------------
+-spec filter_cipher_suites([ssl_cipher:erl_cipher_suite()], 
+                           [{key_exchange | cipher | mac | prf, fun()}] | []) -> 
+                                  [ssl_cipher:erl_cipher_suite()].
+%% Description: Removes cipher suites if any of the filter functions returns false
+%% for any part of the cipher suite. This function also calls default filter functions
+%% to make sure the cipher suite are supported by crypto.
+%%--------------------------------------------------------------------
+filter_cipher_suites(Suites, Filters0) ->
+    #{key_exchange_filters := KexF,
+      cipher_filters := CipherF,
+      mac_filters := MacF,
+      prf_filters := PrfF}
+        = ssl_cipher:crypto_support_filters(),
+    Filters = #{key_exchange_filters => add_filter(proplists:get_value(key_exchange, Filters0), KexF),
+                cipher_filters => add_filter(proplists:get_value(cipher, Filters0), CipherF),
+                mac_filters => add_filter(proplists:get_value(mac, Filters0), MacF),
+                prf_filters => add_filter(proplists:get_value(prf, Filters0), PrfF)},
+    ssl_cipher:filter_suites(Suites, Filters).
+%%--------------------------------------------------------------------
+-spec prepend_cipher_suites([ssl_cipher:erl_cipher_suite()] | 
+                            [{key_exchange | cipher | mac | prf, fun()}],
+                            [ssl_cipher:erl_cipher_suite()]) -> 
+                                   [ssl_cipher:erl_cipher_suite()].
+%% Description: Make <Preferred> suites become the most prefered
+%%      suites that is put them at the head of the cipher suite list
+%%      and remove them from <Suites> if present. <Preferred> may be a
+%%      list of cipher suits or a list of filters in which case the
+%%      filters are use on Suites to extract the the preferred
+%%      cipher list.
+%% --------------------------------------------------------------------
+prepend_cipher_suites([First | _] = Preferred, Suites0) when is_map(First) ->
+    Suites = Preferred ++ (Suites0 -- Preferred),
+    Suites;
+prepend_cipher_suites(Filters, Suites) ->
+    Preferred = filter_cipher_suites(Suites, Filters), 
+    Preferred ++ (Suites -- Preferred).
+%%--------------------------------------------------------------------
+-spec append_cipher_suites(Deferred :: [ssl_cipher:erl_cipher_suite()] | 
+                                       [{key_exchange | cipher | mac | prf, fun()}],
+                           [ssl_cipher:erl_cipher_suite()]) -> 
+                                  [ssl_cipher:erl_cipher_suite()].
+%% Description: Make <Deferred> suites suites become the 
+%% least prefered suites that is put them at the end of the cipher suite list
+%% and removed them from <Suites> if present.
+%%
+%%--------------------------------------------------------------------
+append_cipher_suites([First | _] = Deferred, Suites0) when is_map(First)->
+    Suites = (Suites0 -- Deferred) ++ Deferred,
+    Suites;
+append_cipher_suites(Filters, Suites) ->
+    Deferred = filter_cipher_suites(Suites, Filters), 
+    (Suites -- Deferred) ++  Deferred.
 
 %%--------------------------------------------------------------------
 -spec eccs() -> tls_v1:curves().
@@ -636,10 +712,15 @@ tls_version({254, _} = Version) ->
 available_suites(default) ->  
     Version = tls_record:highest_protocol_version([]),			  
     ssl_cipher:filter_suites(ssl_cipher:suites(Version));
-
 available_suites(all) ->  
     Version = tls_record:highest_protocol_version([]),			  
     ssl_cipher:filter_suites(ssl_cipher:all_suites(Version)).
+
+supported_suites(default, Version) ->  
+    ssl_cipher:suites(Version);
+
+supported_suites(all, Version) ->  
+    ssl_cipher:all_suites(Version).
 
 do_listen(Port, #config{transport_info = {Transport, _, _, _}} = Config, tls_connection) ->
     tls_socket:listen(Transport, Port, Config);
@@ -1150,7 +1231,10 @@ handle_cipher_option(Value, Version)  when is_list(Value) ->
 binary_cipher_suites(Version, []) -> 
     %% Defaults to all supported suites that does
     %% not require explicit configuration
-    ssl_cipher:filter_suites(ssl_cipher:suites(tls_version(Version)));
+    default_binary_suites(Version);
+binary_cipher_suites(Version, [Map|_] = Ciphers0) when is_map(Map) ->
+    Ciphers = [ssl_cipher:suite(C) || C <- Ciphers0],
+    binary_cipher_suites(Version, Ciphers);
 binary_cipher_suites(Version, [Tuple|_] = Ciphers0) when is_tuple(Tuple) ->
     Ciphers = [ssl_cipher:suite(tuple_to_map(C)) || C <- Ciphers0],
     binary_cipher_suites(Version, Ciphers);
@@ -1160,7 +1244,7 @@ binary_cipher_suites(Version, [Cipher0 | _] = Ciphers0) when is_binary(Cipher0) 
 	[] ->
 	    %% Defaults to all supported suites that does
 	    %% not require explicit configuration
-	    ssl_cipher:filter_suites(ssl_cipher:suites(tls_version(Version)));
+	    default_binary_suites(Version);
 	Ciphers ->
 	    Ciphers
     end;
@@ -1172,6 +1256,9 @@ binary_cipher_suites(Version, Ciphers0)  ->
     %% Format: "RC4-SHA:RC4-MD5"
     Ciphers = [ssl_cipher:openssl_suite(C) || C <- string:lexemes(Ciphers0, ":")],
     binary_cipher_suites(Version, Ciphers).
+
+default_binary_suites(Version) ->
+    ssl_cipher:filter_suites(ssl_cipher:suites(tls_version(Version))).
 
 tuple_to_map({Kex, Cipher, Mac}) ->
     #{key_exchange => Kex,
@@ -1462,3 +1549,8 @@ reject_alpn_next_prot_options([Opt| AlpnNextOpts], Opts) ->
         false ->
             reject_alpn_next_prot_options(AlpnNextOpts, Opts)
     end.
+
+add_filter(undefined, Filters) ->
+    Filters;
+add_filter(Filter, Filters) ->
+    [Filter | Filters].

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -1268,8 +1268,18 @@ tuple_to_map({Kex, Cipher, Mac}) ->
 tuple_to_map({Kex, Cipher, Mac, Prf}) ->
     #{key_exchange => Kex,
       cipher => Cipher,
-      mac => Mac,
+      mac => tuple_to_map_mac(Cipher, Mac),
       prf => Prf}.
+
+%% Backwards compatible
+tuple_to_map_mac(aes_128_gcm, _) -> 
+    aead;
+tuple_to_map_mac(aes_256_gcm, _) -> 
+    aead;
+tuple_to_map_mac(chacha20_poly1305, _) ->
+    aead;
+tuple_to_map_mac(_, MAC) ->
+    MAC.
 
 handle_eccs_option(Value, Version) when is_list(Value) ->
     {_Major, Minor} = tls_version(Version),

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -54,7 +54,7 @@
 -type key_algo()          :: null | rsa | dhe_rsa | dhe_dss | ecdhe_ecdsa| ecdh_ecdsa | ecdh_rsa| srp_rsa| srp_dss | psk | dhe_psk | rsa_psk | dh_anon | ecdh_anon | srp_anon.
 -type erl_cipher_suite()  :: #{key_exchange := key_algo(),
                                cipher := cipher(),
-                               mac    := hash(),
+                               mac    := hash() | aead,
                                prf    := hash() | default_prf %% Old cipher suites, version dependent
                               }.  
 -type old_erl_cipher_suite() :: {key_algo(), cipher(), hash()} % Pre TLS 1.2 
@@ -685,32 +685,32 @@ suite_definition(?TLS_RSA_PSK_WITH_AES_256_CBC_SHA) ->
 suite_definition(?TLS_PSK_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => psk, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_PSK_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => psk, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_DHE_PSK_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => dhe_psk, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_DHE_PSK_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => dhe_psk, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_RSA_PSK_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => rsa_psk, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_RSA_PSK_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => rsa_psk, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_PSK_WITH_AES_128_CBC_SHA256) ->
     #{key_exchange => psk, 
@@ -989,42 +989,42 @@ suite_definition(?TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384) ->
 suite_definition(?TLS_RSA_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => rsa, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_RSA_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => rsa, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_DHE_RSA_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => dhe_rsa, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_DHE_RSA_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => dhe_rsa, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_DH_RSA_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => dh_rsa, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_DH_RSA_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => dh_rsa, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_DHE_DSS_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => dhe_dss, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_DHE_DSS_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => dhe_dss, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_DH_DSS_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => dh_dss, 
@@ -1034,74 +1034,74 @@ suite_definition(?TLS_DH_DSS_WITH_AES_128_GCM_SHA256) ->
 suite_definition(?TLS_DH_DSS_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => dh_dss, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_DH_anon_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => dh_anon, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_DH_anon_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => dh_anon, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 %% RFC 5289 ECC AES-GCM Cipher Suites
 suite_definition(?TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => ecdhe_ecdsa, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => ecdhe_ecdsa, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => ecdh_ecdsa, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => ecdh_ecdsa, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => ecdhe_rsa, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => ecdhe_rsa, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 suite_definition(?TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256) ->
     #{key_exchange => ecdh_rsa, 
       cipher => aes_128_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384) ->
     #{key_exchange => ecdh_rsa, 
       cipher => aes_256_gcm, 
-      mac => null, 
+      mac => aead, 
       prf => sha384};
 %% draft-agl-tls-chacha20poly1305-04 Chacha20/Poly1305 Suites
 suite_definition(?TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256) ->
     #{key_exchange => ecdhe_rsa, 
       cipher => chacha20_poly1305, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256) ->
     #{key_exchange => ecdhe_ecdsa, 
       cipher => chacha20_poly1305, 
-      mac => null, 
+      mac => aead, 
       prf => sha256};
 suite_definition(?TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256) ->
     #{key_exchange => dhe_rsa, 
       cipher => chacha20_poly1305, 
-      mac => null, 
+      mac => aead, 
       prf => sha256}.
 
 %%--------------------------------------------------------------------
@@ -1289,32 +1289,32 @@ suite(#{key_exchange := rsa_psk,
 %%% TLS 1.2 PSK Cipher Suites RFC 5487
 suite(#{key_exchange := psk, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_PSK_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := psk, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_PSK_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := dhe_psk, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_DHE_PSK_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := dhe_psk, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_DHE_PSK_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := rsa_psk, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_RSA_PSK_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := rsa_psk, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_RSA_PSK_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := psk, 
@@ -1546,119 +1546,119 @@ suite(#{key_exchange := ecdh_rsa,
 %% RFC 5288 AES-GCM Cipher Suites
 suite(#{key_exchange := rsa, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_RSA_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := rsa, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_RSA_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := dhe_rsa, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_DHE_RSA_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := dhe_rsa, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_DHE_RSA_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := dh_rsa, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_DH_RSA_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := dh_rsa, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_DH_RSA_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := dhe_dss, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_DHE_DSS_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := dhe_dss, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_DHE_DSS_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := dh_dss, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_DH_DSS_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := dh_dss, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_DH_DSS_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := dh_anon, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_DH_anon_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := dh_anon, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_DH_anon_WITH_AES_256_GCM_SHA384;
 %% RFC 5289 ECC AES-GCM Cipher Suites
 suite(#{key_exchange := ecdhe_ecdsa, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := ecdhe_ecdsa, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := ecdh_ecdsa, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := ecdh_ecdsa, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := ecdhe_rsa, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := ecdhe_rsa, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384;
 suite(#{key_exchange := ecdh_rsa, 
         cipher := aes_128_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256;
 suite(#{key_exchange := ecdh_rsa, 
         cipher := aes_256_gcm, 
-        mac := null, 
+        mac := aead, 
         prf := sha384}) ->
     ?TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384;
 %% draft-agl-tls-chacha20poly1305-04 Chacha20/Poly1305 Suites
 suite(#{key_exchange := ecdhe_rsa, 
         cipher := chacha20_poly1305,  
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256;
 suite(#{key_exchange := ecdhe_ecdsa, 
         cipher := chacha20_poly1305, 
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256;
 suite(#{key_exchange := dhe_rsa, 
         cipher := chacha20_poly1305,  
-        mac := null, 
+        mac := aead, 
         prf := sha256}) ->
     ?TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256.
 


### PR DESCRIPTION
Changes cipher suites to be maps instead of tuples to make handling of the sets of algorithms that a cipher suite represent easier.  Will handle tuples as input for backwards compatibility. 

Also use a more logical default value for mac in AEAD suites.

Also add new API functions to make customization  of cipher suites easier, requiring less effort  for the user.  This will also mean some old cipher_suite functions will become deprecated in 21.