### PR TITLE
Remove low memory need for HiPE on x86_64

### DIFF
--- a/erts/doc/src/erts_alloc.xml
+++ b/erts/doc/src/erts_alloc.xml
@@ -68,8 +68,7 @@
        fixed size data types.</item>
       <tag><c>exec_alloc</c></tag>
       <item>Allocator used by the <seealso marker="hipe:HiPE_app"><c>HiPE</c></seealso>
-        application for native executable code on specific architectures
-        (x86_64).</item>
+        application for native executable code.</item>
       <tag><c>std_alloc</c></tag>
       <item>Allocator used for most memory blocks not allocated through any of
         the other allocators described above.</item>
@@ -663,19 +662,6 @@
             Erlang code on 64-bit architectures. Defaults to <c>1024</c>
             (that is, 1 GB), which is usually sufficient.
             The flag is ignored on 32-bit architectures.</p>
-        </item>
-      </taglist>
-    </section>
-
-    <section>
-      <title>Special Flag for exec_alloc</title>
-      <taglist>
-        <tag><marker id="MXscs"/><c><![CDATA[+MXscs <size in MB>]]></c></tag>
-        <item>
-          <p><c>exec_alloc</c> super carrier size (in MB). The amount of
-            <em>virtual</em> address space reserved for native executable code
-            used by the <seealso marker="hipe:HiPE_app"><c>HiPE</c></seealso> application
-            on specific architectures (x86_64). Defaults to <c>512</c>.</p>
         </item>
       </taglist>
     </section>

--- a/erts/emulator/beam/erl_alloc_util.c
+++ b/erts/emulator/beam/erl_alloc_util.c
@@ -872,7 +872,7 @@ erts_alcu_literal_32_mseg_dealloc(Allctr_t *allctr, void *seg, Uint size,
 #elif defined(ARCH_64) && defined(ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION)
 
 /* For allocators that have their own mmapper (super carrier),
- * like literal_alloc and exec_alloc on amd64
+ * like literal_alloc.
  */
 void*
 erts_alcu_mmapper_mseg_alloc(Allctr_t *allctr, Uint *size_p, Uint flags)
@@ -914,10 +914,10 @@ erts_alcu_mmapper_mseg_dealloc(Allctr_t *allctr, void *seg, Uint size,
 }
 #endif /* ARCH_64 && ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION */
 
-#if defined(ERTS_ALC_A_EXEC) && !defined(ERTS_HAVE_EXEC_MMAPPER)
+#if defined(ERTS_ALC_A_EXEC)
 
 /*
- * For exec_alloc on non-amd64 that just need memory with PROT_EXEC
+ * For exec_alloc that need memory with PROT_EXEC
  */
 void*
 erts_alcu_exec_mseg_alloc(Allctr_t *allctr, Uint *size_p, Uint flags)
@@ -956,7 +956,7 @@ erts_alcu_exec_mseg_dealloc(Allctr_t *allctr, void *seg, Uint size, Uint flags)
     ASSERT(r == 0); (void)r;
     erts_alcu_mseg_dealloc(allctr, seg, size, flags);
 }
-#endif /* ERTS_ALC_A_EXEC && !ERTS_HAVE_EXEC_MMAPPER */
+#endif /* ERTS_ALC_A_EXEC */
 
 #endif /* HAVE_ERTS_MSEG */
 

--- a/erts/emulator/beam/erl_alloc_util.h
+++ b/erts/emulator/beam/erl_alloc_util.h
@@ -199,7 +199,7 @@ void* erts_alcu_mmapper_mseg_realloc(Allctr_t*, void *seg, Uint old_size, Uint *
 void  erts_alcu_mmapper_mseg_dealloc(Allctr_t*, void *seg, Uint size, Uint flags);
 # endif
 
-# if defined(ERTS_ALC_A_EXEC) && !defined(ERTS_HAVE_EXEC_MMAPPER)
+# if defined(ERTS_ALC_A_EXEC)
 void* erts_alcu_exec_mseg_alloc(Allctr_t*, Uint *size_p, Uint flags);
 void* erts_alcu_exec_mseg_realloc(Allctr_t*, void *seg, Uint old_size, Uint *new_size_p);
 void  erts_alcu_exec_mseg_dealloc(Allctr_t*, void *seg, Uint size, Uint flags);

--- a/erts/emulator/sys/common/erl_mmap.c
+++ b/erts/emulator/sys/common/erl_mmap.c
@@ -1371,32 +1371,6 @@ os_mmap_virtual(char *ptr, UWord size, int exec)
     int flags = ERTS_MMAP_VIRTUAL_FLAGS;
     void* res;
 
-#ifdef ERTS_ALC_A_EXEC
-    if (exec) {
-        ASSERT(!ptr);
-        /* OTP-19.0: Nice hack below cut-and-pasted from hipe_amd64.c */
-
-#  ifdef MAP_32BIT
-        /* If we got MAP_32BIT (Linux), then use that to ask for low memory */
-        flags |= MAP_32BIT;
-#  else
-        /* FreeBSD doesn't have MAP_32BIT, and it doesn't respect
-           a plain map_hint (returns high mappings even though the
-           hint refers to a free area), so we have to use both map_hint
-           and MAP_FIXED to get addresses below the 2GB boundary.
-           This is even worse than the Linux/ppc64 case.
-           Similarly, Solaris 10 doesn't have MAP_32BIT,
-           and it doesn't respect a plain map_hint. */
-        ptr = (char*)(512*1024*1024); /* 0.5GB */
-
-#    if defined(__FreeBSD__) || defined(__sun__)
-        flags |= MAP_FIXED;
-#    endif
-#  endif /* !MAP_32BIT */
-    }
-#else /* !ERTS_ALC_A_EXEC */
-    ASSERT(!exec);
-#endif
     res = mmap((void *) ptr, (size_t) size, ERTS_MMAP_VIRTUAL_PROT,
                flags, ERTS_MMAP_FD, 0);
     if (res == (void *) MAP_FAILED)

--- a/erts/emulator/sys/common/erl_mmap.c
+++ b/erts/emulator/sys/common/erl_mmap.c
@@ -358,10 +358,6 @@ char* erts_literals_start;
 UWord erts_literals_size;
 #endif
 
-#ifdef ERTS_HAVE_EXEC_MMAPPER
-ErtsMemMapper erts_exec_mmapper;
-#endif
-
 
 #define ERTS_MMAP_SIZE_SC_SA_INC(SZ) 						\
     do {									\

--- a/erts/emulator/sys/common/erl_mmap.c
+++ b/erts/emulator/sys/common/erl_mmap.c
@@ -296,11 +296,10 @@ typedef struct {
 }ErtsFreeSegMap;
 
 struct ErtsMemMapper_ {
-    int (*reserve_physical)(char *, UWord, int exec);
+    int (*reserve_physical)(char *, UWord);
     void (*unreserve_physical)(char *, UWord);
     int supercarrier;
     int no_os_mmap;
-    int executable;   /* is client a native code allocator? */
     /*
      * Super unaligned area is located above super aligned
      * area. That is, `sa.bot` is beginning of the super
@@ -1236,7 +1235,6 @@ Eterm build_free_seg_list(Process* p, ErtsFreeSegMap* map)
 
 #if HAVE_MMAP
 #  define ERTS_MMAP_PROT		(PROT_READ|PROT_WRITE)
-#  define ERTS_MMAP_PROT_EXEC		(PROT_READ|PROT_WRITE|PROT_EXEC)
 #  if defined(MAP_ANONYMOUS)
 #    define ERTS_MMAP_FLAGS		(MAP_ANON|MAP_PRIVATE)
 #    define ERTS_MMAP_FD		(-1)
@@ -1250,26 +1248,24 @@ Eterm build_free_seg_list(Process* p, ErtsFreeSegMap* map)
 #endif
 
 static ERTS_INLINE void *
-os_mmap(void *hint_ptr, UWord size, int try_superalign, int executable)
+os_mmap(void *hint_ptr, UWord size, int try_superalign)
 {
 #if HAVE_MMAP
-    const int prot = executable ? ERTS_MMAP_PROT_EXEC : ERTS_MMAP_PROT;
     void *res;
 #ifdef MAP_ALIGN
     if (try_superalign)
-	res = mmap((void *) ERTS_SUPERALIGNED_SIZE, size, prot,
+	res = mmap((void *) ERTS_SUPERALIGNED_SIZE, size, ERTS_MMAP_PROT,
 		   ERTS_MMAP_FLAGS|MAP_ALIGN, ERTS_MMAP_FD, 0);
     else
 #endif
-	res = mmap((void *) hint_ptr, size, prot,
+	res = mmap((void *) hint_ptr, size, ERTS_MMAP_PROT,
 		   ERTS_MMAP_FLAGS, ERTS_MMAP_FD, 0);
     if (res == MAP_FAILED)
 	return NULL;
     return res;
 #elif HAVE_VIRTUALALLOC
-    const DWORD prot = executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
     return (void *) VirtualAlloc(NULL, (SIZE_T) size,
-				 MEM_COMMIT|MEM_RESERVE, prot);
+				 MEM_COMMIT|MEM_RESERVE, PAGE_READWRITE);
 #else
 #  error "missing mmap() or similar"
 #endif
@@ -1326,7 +1322,6 @@ os_mremap(void *ptr, UWord old_size, UWord new_size, int try_superalign)
 #if HAVE_MMAP
 
 #define ERTS_MMAP_RESERVE_PROT		(ERTS_MMAP_PROT)
-#define ERTS_MMAP_RESERVE_PROT_EXEC	(ERTS_MMAP_PROT_EXEC)
 #define ERTS_MMAP_RESERVE_FLAGS		(ERTS_MMAP_FLAGS|MAP_FIXED)
 #define ERTS_MMAP_UNRESERVE_PROT	(PROT_NONE)
 #if defined(__FreeBSD__)
@@ -1342,10 +1337,9 @@ os_mremap(void *ptr, UWord old_size, UWord new_size, int try_superalign)
 #endif /* __FreeBSD__ */
 
 static int
-os_reserve_physical(char *ptr, UWord size, int exec)
+os_reserve_physical(char *ptr, UWord size)
 {
-    const int prot = exec ? ERTS_MMAP_RESERVE_PROT_EXEC : ERTS_MMAP_RESERVE_PROT;
-    void *res = mmap((void *) ptr, (size_t) size, prot,
+    void *res = mmap((void *) ptr, (size_t) size, ERTS_MMAP_RESERVE_PROT,
 		     ERTS_MMAP_RESERVE_FLAGS, ERTS_MMAP_FD, 0);
     if (res == (void *) MAP_FAILED)
 	return 0;
@@ -1362,7 +1356,7 @@ os_unreserve_physical(char *ptr, UWord size)
 }
 
 static void *
-os_mmap_virtual(char *ptr, UWord size, int exec)
+os_mmap_virtual(char *ptr, UWord size)
 {
     int flags = ERTS_MMAP_VIRTUAL_FLAGS;
     void* res;
@@ -1381,7 +1375,7 @@ os_mmap_virtual(char *ptr, UWord size, int exec)
 
 #endif /* ERTS_HAVE_OS_MMAP */
 
-static int reserve_noop(char *ptr, UWord size, int exec)
+static int reserve_noop(char *ptr, UWord size)
 {
 #ifdef ERTS_MMAP_DEBUG_FILL_AREAS
     Uint32 *uip, *end = (Uint32 *) (ptr + size);
@@ -1424,7 +1418,7 @@ alloc_desc_insert_free_seg(ErtsMemMapper* mm,
 
 #if ERTS_HAVE_OS_MMAP
     if (!mm->no_os_mmap) {
-        ptr = os_mmap(mm->desc.new_area_hint, ERTS_PAGEALIGNED_SIZE, 0, 0);
+        ptr = os_mmap(mm->desc.new_area_hint, ERTS_PAGEALIGNED_SIZE, 0);
         if (ptr) {
             mm->desc.new_area_hint = ptr+ERTS_PAGEALIGNED_SIZE;
             ERTS_MMAP_SIZE_OS_INC(ERTS_PAGEALIGNED_SIZE);
@@ -1443,7 +1437,7 @@ alloc_desc_insert_free_seg(ErtsMemMapper* mm,
     da_map = &mm->sua.map;
     desc = lookup_free_seg(da_map, ERTS_PAGEALIGNED_SIZE);
     if (desc) {
-	if (mm->reserve_physical(desc->start, ERTS_PAGEALIGNED_SIZE, 0))
+	if (mm->reserve_physical(desc->start, ERTS_PAGEALIGNED_SIZE))
 	    ERTS_MMAP_SIZE_SC_SUA_INC(ERTS_PAGEALIGNED_SIZE);
 	else
 	    desc = NULL;
@@ -1453,7 +1447,7 @@ alloc_desc_insert_free_seg(ErtsMemMapper* mm,
 	da_map = &mm->sa.map;
 	desc = lookup_free_seg(da_map, ERTS_PAGEALIGNED_SIZE);
 	if (desc) {
-	    if (mm->reserve_physical(desc->start, ERTS_PAGEALIGNED_SIZE, 0))
+	    if (mm->reserve_physical(desc->start, ERTS_PAGEALIGNED_SIZE))
 		ERTS_MMAP_SIZE_SC_SA_INC(ERTS_PAGEALIGNED_SIZE);
 	    else
 		desc = NULL;
@@ -1514,7 +1508,7 @@ erts_mmap(ErtsMemMapper* mm, Uint32 flags, UWord *sizep)
 	    if (desc) {
 		seg = desc->start;
 		end = seg+asize;
-		if (!mm->reserve_physical(seg, asize, mm->executable))
+		if (!mm->reserve_physical(seg, asize))
 		    goto supercarrier_reserve_failure;
 		if (desc->end == end) {
 		    delete_free_seg(&mm->sua.map, desc);
@@ -1529,8 +1523,7 @@ erts_mmap(ErtsMemMapper* mm, Uint32 flags, UWord *sizep)
 	    }
 
 	    if (asize <= mm->sua.bot - mm->sa.top) {
-		if (!mm->reserve_physical(mm->sua.bot - asize, asize,
-                                          mm->executable))
+		if (!mm->reserve_physical(mm->sua.bot - asize, asize))
 		    goto supercarrier_reserve_failure;
 		mm->sua.bot -= asize;
 		seg = mm->sua.bot;
@@ -1546,8 +1539,7 @@ erts_mmap(ErtsMemMapper* mm, Uint32 flags, UWord *sizep)
 	    char *start = seg = desc->start;
 	    seg = (char *) ERTS_SUPERALIGNED_CEILING(seg);
 	    end = seg+asize;
-	    if (!mm->reserve_physical(start, (UWord) (end - start),
-                                      mm->executable))
+	    if (!mm->reserve_physical(start, (UWord) (end - start)))
 		goto supercarrier_reserve_failure;
 	    ERTS_MMAP_SIZE_SC_SA_INC(asize);
 	    if (desc->end == end) {
@@ -1579,8 +1571,7 @@ erts_mmap(ErtsMemMapper* mm, Uint32 flags, UWord *sizep)
 
 	    if (asize + (seg - start) <= mm->sua.bot - start) {
 		end = seg + asize;
-		if (!mm->reserve_physical(start, (UWord) (end - start),
-                                          mm->executable))
+		if (!mm->reserve_physical(start, (UWord) (end - start)))
 		    goto supercarrier_reserve_failure;
 		mm->sa.top = end;
 		ERTS_MMAP_SIZE_SC_SA_INC(asize);
@@ -1602,8 +1593,7 @@ erts_mmap(ErtsMemMapper* mm, Uint32 flags, UWord *sizep)
 
 		seg = (char *) ERTS_SUPERALIGNED_CEILING(org_start);
 		end = seg + asize;
-		if (!mm->reserve_physical(seg, (UWord) (org_end - seg),
-                                          mm->executable))
+		if (!mm->reserve_physical(seg, (UWord) (org_end - seg)))
 		    goto supercarrier_reserve_failure;
 		ERTS_MMAP_SIZE_SC_SUA_INC(asize);
 		if (org_start != seg) {
@@ -1636,13 +1626,13 @@ erts_mmap(ErtsMemMapper* mm, Uint32 flags, UWord *sizep)
     /* Map using OS primitives */
     if (!(ERTS_MMAPFLG_SUPERCARRIER_ONLY & flags) && !mm->no_os_mmap) {
 	if (!(ERTS_MMAPFLG_SUPERALIGNED & flags)) {
-	    seg = os_mmap(NULL, asize, 0, mm->executable);
+	    seg = os_mmap(NULL, asize, 0);
 	    if (!seg)
 		goto failure;
 	}
 	else {
 	    asize = ERTS_SUPERALIGNED_CEILING(*sizep);
-	    seg = os_mmap(NULL, asize, 1, mm->executable);
+	    seg = os_mmap(NULL, asize, 1);
 	    if (!seg)
 		goto failure;
 
@@ -1652,8 +1642,7 @@ erts_mmap(ErtsMemMapper* mm, Uint32 flags, UWord *sizep)
 
 		os_munmap(seg, asize);
 
-		ptr = os_mmap(NULL, asize + ERTS_SUPERALIGNED_SIZE, 1,
-                              mm->executable);
+		ptr = os_mmap(NULL, asize + ERTS_SUPERALIGNED_SIZE, 1);
 		if (!ptr)
 		    goto failure;
 
@@ -1988,8 +1977,7 @@ erts_mremap(ErtsMemMapper* mm,
 
 	    if (next && new_end <= next->end) {
 		if (!mm->reserve_physical(((char *) ptr) + old_size,
-                                          asize - old_size,
-                                          mm->executable))
+                                          asize - old_size))
 		    goto supercarrier_reserve_failure;
 		if (new_end < next->end)
 		    resize_free_seg(&mm->sua.map, next, new_end, next->end);
@@ -2007,8 +1995,7 @@ erts_mremap(ErtsMemMapper* mm,
 	    if (end == mm->sa.top) {
 		if (new_end <= mm->sua.bot) {
 		    if (!mm->reserve_physical(((char *) ptr) + old_size,
-                                              asize - old_size,
-                                              mm->executable))
+                                              asize - old_size))
 			goto supercarrier_reserve_failure;
 		    mm->sa.top = new_end;
 		    new_ptr = ptr;
@@ -2020,8 +2007,7 @@ erts_mremap(ErtsMemMapper* mm,
 		adjacent_free_seg(&mm->sa.map, start, end, &prev, &next);
 		if (next && new_end <= next->end) {
 		    if (!mm->reserve_physical(((char *) ptr) + old_size,
-                                              asize - old_size,
-                                              mm->executable))
+                                              asize - old_size))
 			goto supercarrier_reserve_failure;
 		    if (new_end < next->end)
 			resize_free_seg(&mm->sa.map, next, new_end, next->end);
@@ -2141,7 +2127,7 @@ static void hard_dbg_mseg_init(void);
 #endif
 
 void
-erts_mmap_init(ErtsMemMapper* mm, ErtsMMapInit *init, int executable)
+erts_mmap_init(ErtsMemMapper* mm, ErtsMMapInit *init)
 {
     static int is_first_call = 1;
     int virtual_map = 0;
@@ -2173,7 +2159,6 @@ erts_mmap_init(ErtsMemMapper* mm, ErtsMMapInit *init, int executable)
     mm->supercarrier = 0;
     mm->reserve_physical = reserve_noop;
     mm->unreserve_physical = unreserve_noop;
-    mm->executable = executable;
 
 #if HAVE_MMAP && !defined(MAP_ANON)
     mm->mmap_fd = open("/dev/zero", O_RDWR);
@@ -2195,7 +2180,7 @@ erts_mmap_init(ErtsMemMapper* mm, ErtsMMapInit *init, int executable)
 	ptr = (char *) ERTS_PAGEALIGNED_CEILING(init->virtual_range.start);
 	end = (char *) ERTS_PAGEALIGNED_FLOOR(init->virtual_range.end);
 	sz = end - ptr;
-	start = os_mmap_virtual(ptr, sz, executable);
+	start = os_mmap_virtual(ptr, sz);
 	if (!start || start > ptr || start >= end)
 	    erts_exit(1,
 		     "erts_mmap: Failed to create virtual range for super carrier\n");
@@ -2220,7 +2205,7 @@ erts_mmap_init(ErtsMemMapper* mm, ErtsMMapInit *init, int executable)
 	sz = ERTS_PAGEALIGNED_CEILING(init->scs);
 #ifdef ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION
 	if (!init->scrpm) {
-	    start = os_mmap_virtual(NULL, sz, executable);
+	    start = os_mmap_virtual(NULL, sz);
 	    mm->reserve_physical = os_reserve_physical;
 	    mm->unreserve_physical = os_unreserve_physical;
 	    virtual_map = 1;
@@ -2232,7 +2217,7 @@ erts_mmap_init(ErtsMemMapper* mm, ErtsMMapInit *init, int executable)
 	     * The whole supercarrier will by physically
 	     * reserved all the time.
 	     */
-	    start = os_mmap(NULL, sz, 1, executable);
+	    start = os_mmap(NULL, sz, 1);
 	}
 	if (!start)
 	    erts_exit(1,
@@ -2306,7 +2291,7 @@ erts_mmap_init(ErtsMemMapper* mm, ErtsMMapInit *init, int executable)
 	    mm->sua.top -= ERTS_PAGEALIGNED_SIZE;
 	    mm->size.supercarrier.used.total += ERTS_PAGEALIGNED_SIZE;
 #ifdef ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION
-	    if (!virtual_map || os_reserve_physical(mm->sua.top, ERTS_PAGEALIGNED_SIZE, 0))
+	    if (!virtual_map || os_reserve_physical(mm->sua.top, ERTS_PAGEALIGNED_SIZE))
 #endif
 		add_free_desc_area(mm, mm->sua.top, end);
             mm->desc.reserved += (end - mm->sua.top) / sizeof(ErtsFreeSegDesc);
@@ -2319,7 +2304,7 @@ erts_mmap_init(ErtsMemMapper* mm, ErtsMMapInit *init, int executable)
 	 * will be used for free segment descritors.
 	 */
 #ifdef ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION
-	if (virtual_map && !os_reserve_physical(start, mm->sa.bot - start, 0))
+	if (virtual_map && !os_reserve_physical(start, mm->sa.bot - start))
 	    erts_exit(1, "erts_mmap: Failed to reserve physical memory for descriptors\n");
 #endif
 	mm->desc.unused_start = start;

--- a/erts/emulator/sys/common/erl_mmap.h
+++ b/erts/emulator/sys/common/erl_mmap.h
@@ -135,7 +135,7 @@ void *erts_mmap(ErtsMemMapper*, Uint32 flags, UWord *sizep);
 void erts_munmap(ErtsMemMapper*, Uint32 flags, void *ptr, UWord size);
 void *erts_mremap(ErtsMemMapper*, Uint32 flags, void *ptr, UWord old_size, UWord *sizep);
 int erts_mmap_in_supercarrier(ErtsMemMapper*, void *ptr);
-void erts_mmap_init(ErtsMemMapper*, ErtsMMapInit*, int executable);
+void erts_mmap_init(ErtsMemMapper*, ErtsMMapInit*);
 struct erts_mmap_info_struct
 {
     UWord sizes[6];

--- a/erts/emulator/sys/common/erl_mmap.h
+++ b/erts/emulator/sys/common/erl_mmap.h
@@ -93,11 +93,6 @@ typedef struct {
 #define ERTS_MMAP_INIT_LITERAL_INITER \
     {{NULL, NULL}, {NULL, NULL}, ERTS_LITERAL_VIRTUAL_AREA_SIZE, 1, (1 << 10), 0}
 
-#define ERTS_HIPE_EXEC_VIRTUAL_AREA_SIZE (UWORD_CONSTANT(512)*1024*1024)
-
-#define ERTS_MMAP_INIT_HIPE_EXEC_INITER \
-    {{NULL, NULL}, {NULL, NULL}, ERTS_HIPE_EXEC_VIRTUAL_AREA_SIZE, 1, (1 << 10), 0}
-
 
 #define ERTS_SUPERALIGNED_SIZE \
     (1 << ERTS_MMAP_SUPERALIGNED_BITS)
@@ -163,15 +158,6 @@ extern ErtsMemMapper erts_dflt_mmapper;
 
 #  if defined(ARCH_64)
 extern ErtsMemMapper erts_literal_mmapper;
-#  endif
-
-#  if defined(ERTS_ALC_A_EXEC) && defined(__x86_64__)
-   /*
-    * On x86_64, exec_alloc employs its own super carrier 'erts_exec_mmaper'
-    * to ensure low memory for HiPE AMD64 small code model.
-    */
-#   define ERTS_HAVE_EXEC_MMAPPER
-extern ErtsMemMapper erts_exec_mmapper;
 #  endif
 
 # endif /* ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION */

--- a/erts/emulator/sys/common/erl_mseg.c
+++ b/erts/emulator/sys/common/erl_mseg.c
@@ -1406,9 +1406,9 @@ erts_mseg_init(ErtsMsegInit_t *init)
     erts_mtx_init(&init_atoms_mutex, "mseg_init_atoms", NIL,
         ERTS_LOCK_FLAGS_PROPERTY_STATIC | ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
 
-    erts_mmap_init(&erts_dflt_mmapper, &init->dflt_mmap, 0);
+    erts_mmap_init(&erts_dflt_mmapper, &init->dflt_mmap);
 #if defined(ARCH_64) && defined(ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION)
-    erts_mmap_init(&erts_literal_mmapper, &init->literal_mmap, 0);
+    erts_mmap_init(&erts_literal_mmapper, &init->literal_mmap);
 #endif
 
     if (!IS_2POW(GET_PAGE_SIZE))

--- a/erts/emulator/sys/common/erl_mseg.c
+++ b/erts/emulator/sys/common/erl_mseg.c
@@ -1406,12 +1406,6 @@ erts_mseg_init(ErtsMsegInit_t *init)
     erts_mtx_init(&init_atoms_mutex, "mseg_init_atoms", NIL,
         ERTS_LOCK_FLAGS_PROPERTY_STATIC | ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
 
-#ifdef ERTS_HAVE_EXEC_MMAPPER
-    /* Initialize erts_exec_mapper *FIRST*, to increase probability
-     * of getting low memory for HiPE AMD64's small code model.
-     */
-    erts_mmap_init(&erts_exec_mmapper, &init->exec_mmap, 1);
-#endif
     erts_mmap_init(&erts_dflt_mmapper, &init->dflt_mmap, 0);
 #if defined(ARCH_64) && defined(ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION)
     erts_mmap_init(&erts_literal_mmapper, &init->literal_mmap, 0);

--- a/erts/emulator/sys/common/erl_mseg.h
+++ b/erts/emulator/sys/common/erl_mseg.h
@@ -61,7 +61,6 @@ typedef struct {
     Uint nos;
     ErtsMMapInit dflt_mmap;
     ErtsMMapInit literal_mmap;
-    ErtsMMapInit exec_mmap;
 } ErtsMsegInit_t;
 
 #define ERTS_MSEG_INIT_DEFAULT_INITIALIZER				\
@@ -72,7 +71,6 @@ typedef struct {
     1000,		/* cci:   Cache check interval		*/	\
     ERTS_MMAP_INIT_DEFAULT_INITER,					\
     ERTS_MMAP_INIT_LITERAL_INITER,                                      \
-    ERTS_MMAP_INIT_HIPE_EXEC_INITER                                     \
 }
 
 typedef struct {


### PR DESCRIPTION
Thanks to @bhuztez  and #1669 
no longer any need to hog lots of low virtual memory for HiPE code allocations on x86_64.
