### PR TITLE
Combine blocks when running beam_block the second time

### DIFF
--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -36,13 +36,11 @@ module({Mod,Exp,Attr,Fs0,Lc}, Opts) ->
 function({function,Name,Arity,CLabel,Is0}, Blockify) ->
     try
 	%% Collect basic blocks and optimize them.
-        Is2 = case Blockify of
-                  true ->
-                      Is1 = blockify(Is0),
-                      embed_lines(Is1);
-                  false ->
-                      Is0
+        Is1 = case Blockify of
+                  false -> Is0;
+                  true -> blockify(Is0)
               end,
+        Is2 = embed_lines(Is1),
         Is3 = local_cse(Is2),
         Is4 = beam_utils:anno_defs(Is3),
         Is5 = move_allocates(Is4),
@@ -138,6 +136,11 @@ embed_lines([{block,B2},{line,_}=Line,{block,B1}|T], Acc) ->
     embed_lines([B|T], Acc);
 embed_lines([{block,B1},{line,_}=Line|T], Acc) ->
     B = {block,[{set,[],[],Line}|B1]},
+    embed_lines([B|T], Acc);
+embed_lines([{block,B2},{block,B1}|T], Acc) ->
+    %% This can only happen when beam_block is run for
+    %% the second time.
+    B = {block,B1++B2},
     embed_lines([B|T], Acc);
 embed_lines([I|Is], Acc) ->
     embed_lines(Is, [I|Acc]);

--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -628,7 +628,13 @@ cse_find(Expr, Es) ->
     end.
 
 cse_expr({set,[D],Ss,{bif,N,_}}) ->
-    {ok,D,{{bif,N},Ss}};
+    case D of
+        {fr,_} ->
+            %% There are too many things that can go wrong.
+            none;
+        _ ->
+            {ok,D,{{bif,N},Ss}}
+    end;
 cse_expr({set,[D],Ss,{alloc,_,{gc_bif,N,_}}}) ->
     {ok,D,{{gc_bif,N},Ss}};
 cse_expr({set,[D],Ss,put_list}) ->

--- a/lib/compiler/src/beam_clean.erl
+++ b/lib/compiler/src/beam_clean.erl
@@ -24,7 +24,7 @@
 -export([module/2]).
 -export([bs_clean_saves/1]).
 -export([clean_labels/1]).
--import(lists, [foldl/3,reverse/1,filter/2]).
+-import(lists, [foldl/3,reverse/1]).
 
 -spec module(beam_utils:module_code(), [compile:option()]) ->
                     {'ok',beam_utils:module_code()}.
@@ -303,8 +303,21 @@ maybe_remove_lines(Fs, Opts) ->
     end.
 
 remove_lines([{function,N,A,Lbl,Is0}|T]) ->
-    Is = filter(fun({line,_}) -> false;
-		   (_)  -> true
-		end, Is0),
+    Is = remove_lines_fun(Is0),
     [{function,N,A,Lbl,Is}|remove_lines(T)];
 remove_lines([]) -> [].
+
+remove_lines_fun([{line,_}|Is]) ->
+    remove_lines_fun(Is);
+remove_lines_fun([{block,Bl0}|Is]) ->
+    Bl = remove_lines_block(Bl0),
+    [{block,Bl}|remove_lines_fun(Is)];
+remove_lines_fun([I|Is]) ->
+    [I|remove_lines_fun(Is)];
+remove_lines_fun([]) -> [].
+
+remove_lines_block([{set,_,_,{line,_}}|Is]) ->
+    remove_lines_block(Is);
+remove_lines_block([I|Is]) ->
+    [I|remove_lines_block(Is)];
+remove_lines_block([]) -> [].

--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -73,7 +73,8 @@ norm({set,[D],[S|Puts],{alloc,R,{put_map,Op,F}}}) ->
     {put_map,F,Op,S,D,R,{list,Puts}};
 norm({set,[],[],remove_message})   -> remove_message;
 norm({set,[],[],fclearerror}) -> fclearerror;
-norm({set,[],[],fcheckerror}) -> {fcheckerror,{f,0}}.
+norm({set,[],[],fcheckerror}) -> {fcheckerror,{f,0}};
+norm({set,[],[],{line,_}=Line}) -> Line.
 
 norm_allocate({_Zero,nostack,Nh,[]}, Regs) ->
     [{test_heap,Nh,Regs}];

--- a/lib/compiler/src/beam_split.erl
+++ b/lib/compiler/src/beam_split.erl
@@ -50,8 +50,9 @@ split_block([{set,[R],[_,_,_]=As,{bif,is_record,{f,Lbl}}}|Is], Bl, Acc) ->
     split_block(Is, [], [{bif,is_record,{f,Lbl},As,R}|make_block(Bl, Acc)]);
 split_block([{set,[R],As,{bif,N,{f,Lbl}=Fail}}|Is], Bl, Acc) when Lbl =/= 0 ->
     split_block(Is, [], [{bif,N,Fail,As,R}|make_block(Bl, Acc)]);
-split_block([{set,[R],As,{bif,raise,{f,_}=Fail}}|Is], Bl, Acc) ->
-    split_block(Is, [], [{bif,raise,Fail,As,R}|make_block(Bl, Acc)]);
+split_block([{set,[],[],{line,_}=Line},
+             {set,[R],As,{bif,raise,{f,_}=Fail}}|Is], Bl, Acc) ->
+    split_block(Is, [], [{bif,raise,Fail,As,R},Line|make_block(Bl, Acc)]);
 split_block([{set,[R],As,{alloc,Live,{gc_bif,N,{f,Lbl}=Fail}}}|Is], Bl, Acc)
   when Lbl =/= 0 ->
     split_block(Is, [], [{gc_bif,N,Fail,Live,As,R}|make_block(Bl, Acc)]);
@@ -61,8 +62,6 @@ split_block([{set,[D],[S|Puts],{alloc,R,{put_map,Op,{f,Lbl}=Fail}}}|Is],
 			 make_block(Bl, Acc)]);
 split_block([{set,[R],[],{try_catch,Op,L}}|Is], Bl, Acc) ->
     split_block(Is, [], [{Op,R,L}|make_block(Bl, Acc)]);
-split_block([{set,[],[],{line,_}=Line}|Is], Bl, Acc) ->
-    split_block(Is, [], [Line|make_block(Bl, Acc)]);
 split_block([I|Is], Bl, Acc) ->
     split_block(Is, [I|Bl], Acc);
 split_block([], Bl, Acc) -> make_block(Bl, Acc).


### PR DESCRIPTION
I was so happy that the commit (1a029efd1ad47f) that ran `beam_block` a second time improved the code in so many modules, that I didn't think of logical next step: to combine adjacent blocks before running  `beam_block` the second time.

It turns that combining blocks provide many opportunities for optimizations, eliminating register shuffling in many modules and doing more common sub expression elimination in the `wx` application.
