### PR TITLE
ERL-558 Add the missing function clause for string:prefix

### DIFF
--- a/lib/stdlib/src/string.erl
+++ b/lib/stdlib/src/string.erl
@@ -412,8 +412,11 @@ to_number(_, Number, Rest, _, Tail) ->
 -spec prefix(String::unicode:chardata(), Prefix::unicode:chardata()) ->
                     'nomatch' | unicode:chardata().
 prefix(Str, Prefix0) ->
-    Prefix = unicode:characters_to_list(Prefix0),
-    case prefix_1(Str, Prefix) of
+    Result = case unicode:characters_to_list(Prefix0) of
+                 [] -> Str;
+                 Prefix -> prefix_1(Str, Prefix)
+             end,
+    case Result of
         [] when is_binary(Str) -> <<>>;
         Res -> Res
     end.
@@ -1054,7 +1057,6 @@ take_tc(Bin, N, {GCs,_,_}=Seps0) when is_binary(Bin) ->
             end
     end.
 
-prefix_1(Str, []) -> Str;
 prefix_1(Cs0, [GC]) ->
     case unicode_util:gc(Cs0) of
         [GC|Cs] -> Cs;

--- a/lib/stdlib/src/string.erl
+++ b/lib/stdlib/src/string.erl
@@ -411,7 +411,6 @@ to_number(_, Number, Rest, _, Tail) ->
 %% Return the remaining string with prefix removed or else nomatch
 -spec prefix(String::unicode:chardata(), Prefix::unicode:chardata()) ->
                     'nomatch' | unicode:chardata().
-prefix(Str, []) -> Str;
 prefix(Str, Prefix0) ->
     Prefix = unicode:characters_to_list(Prefix0),
     case prefix_1(Str, Prefix) of
@@ -1055,6 +1054,7 @@ take_tc(Bin, N, {GCs,_,_}=Seps0) when is_binary(Bin) ->
             end
     end.
 
+prefix_1(Str, []) -> Str;
 prefix_1(Cs0, [GC]) ->
     case unicode_util:gc(Cs0) of
         [GC|Cs] -> Cs;

--- a/lib/stdlib/test/string_SUITE.erl
+++ b/lib/stdlib/test/string_SUITE.erl
@@ -485,6 +485,10 @@ to_float(_) ->
 prefix(_) ->
     ?TEST("", ["a"], nomatch),
     ?TEST("a", [""], "a"),
+    ?TEST("a", [[[]]], "a"),
+    ?TEST("a", [<<>>], "a"),
+    ?TEST("a", [[<<>>]], "a"),
+    ?TEST("a", [[[<<>>]]], "a"),
     ?TEST("b", ["a"], nomatch),
     ?TEST("a", ["a"], ""),
     ?TEST("å", ["a"], nomatch),


### PR DESCRIPTION
The `string:prefix` function will result in function clause exception in `string:prefix_1` if the second argument is an empty binary. So, `string:prefix(<<"abc">>, <<>>)` will not match any function clauses. This PR fixes this issue.