### PR TITLE
Reword docs related to the runtime system mode

### DIFF
--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -360,11 +360,12 @@
       </item>
       <tag><c><![CDATA[-mode interactive | embedded]]></c></tag>
       <item>
-        <p>Indicates if the system is to load code dynamically
-          (<c><![CDATA[interactive]]></c>), or if all code is to be loaded
-          during system initialization (<c><![CDATA[embedded]]></c>); see
-          <seealso marker="kernel:code"><c>code(3)</c></seealso>.
-          Defaults to <c><![CDATA[interactive]]></c>.</p>
+        <p>Modules are auto loaded when they are first referenced if the
+          runtime system runs in <c><![CDATA[interactive]]></c> mode, which is
+          the default. In <c><![CDATA[embedded]]></c> mode modules are not auto
+          loaded. The latter is recommended when the boot script preloads all
+          modules, as conventionally happens in OTP releases. See
+          <seealso marker="kernel:code"><c>code(3)</c></seealso></p>.
       </item>
       <tag><c><![CDATA[-name Name]]></c></tag>
       <item>
@@ -1693,4 +1694,3 @@ code:load_abs("..../user_default").    ]]></code>
       <seealso marker="tools:make"><c>make(3)</c></seealso></p>
   </section>
 </comref>
-

--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -32,8 +32,8 @@
 %%                         (Optional - default efile)
 %%        -hosts [Node]  : List of hosts from which we can boot.
 %%                         (Mandatory if -loader inet)
-%%        -mode embedded : Load all modules at startup, no automatic loading
-%%        -mode interactive : Auto load modules (default system behaviour).
+%%        -mode interactive : Auto load modules not needed at startup (default system behaviour).
+%%        -mode embedded : Load all modules in the boot script, disable auto loading.
 %%        -path          : Override path in bootfile.
 %%        -pa Path+      : Add my own paths first.
 %%        -pz Path+      : Add my own paths last.

--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -34,25 +34,27 @@
     <p>This module contains the interface to the Erlang
       <em>code server</em>, which deals with the loading of compiled
       code into a running Erlang runtime system.</p>
-    <p>The runtime system can be started in <em>embedded</em> or
-      <em>interactive</em> mode. Which one is decided by command-line
+    <p>The runtime system can be started in <em>interactive</em> or
+      <em>embedded</em> mode. Which one is decided by the command-line
       flag <c>-mode</c>:</p>
     <pre>
 % <input>erl -mode interactive</input></pre>
     <p>The modes are as follows:</p>
     <list type="bulleted">
       <item>
-        <p>In embedded mode, all code is loaded during system startup
-          according to the boot script. (Code can also be loaded later
-          by explicitly ordering the code server to do so).</p>
-      </item>
-      <item>
         <p>In interactive mode, which is default, only some code is loaded
-	  during system startup, basically the modules needed by the runtime
+          during system startup, basically the modules needed by the runtime
           system. Other code is dynamically loaded when first
           referenced. When a call to a function in a certain module is
           made, and the module is not loaded, the code server searches
           for and tries to load the module.</p>
+      </item>
+      <item>
+        <p>In embedded mode, modules are not auto loaded. Trying to use
+        a module that has not been loaded results in an error. This mode is
+        recommended when the boot script loads all modules, as it is
+        typically done in OTP releases. (Code can still be loaded later
+        by explicitly ordering the code server to do so).</p>
       </item>
     </list>
     <p>To prevent accidentally reloading of modules affecting the Erlang


### PR DESCRIPTION
This patch rewords the docs related to the runtime system mode.

It addresses two things:

* Makes clear that embedded mode disables autoloading.
* Explains which modules are eager loaded in embedded mode.

Looking for a balance between being accurate and concise, I have taken these compromises:

* The descriptions do not mention the code path. The documentation of `-pa` and friends and the concept of code path itself is enough contextual information.
* The descriptions of interactive mode do not mention what `init` lazy loads, except in the documentation of `init` itself (and still there, there is only a vague one-liner). I believe interactive mode for readers of `erl` or `code` docs is mostly about being able to autoload anything in the code path, and the fact that init skips some `primLoad`s is not that important (good to know for boot times, or if you want to tinker, but could be considered to be an internal optimization).
* The descriptions of embedded mode are not very detailed about the role of the boot script. They hint to the reader that what is there is what is preloaded, but indirectly. I believe it reads quite straightforward and communicates what we want. Also, links to releases with the same stroke, which is I guess the most important use case for embedded mode in practice and may help the reader build a mental model. Again, the documentation of `init` focuses more on the boot script.

Finally, a cosmetic change since I was on it is to document first the default. I find that to be a more natural order.


