### PR TITLE
fix size of fmt_double()'s format_str[] buffer

### DIFF
--- a/erts/lib_src/common/erl_printf_format.c
+++ b/erts/lib_src/common/erl_printf_format.c
@@ -326,7 +326,7 @@ static int fmt_double(fmtfn_t fn,void*arg,double val,
 {
     int res;
     int fi = 0;
-    char format_str[7];
+    char format_str[8];
     char sbuf[32];
     char *bufp = sbuf;
     double dexp;


### PR DESCRIPTION
fmt_double() may write up to 8 characters into its format_str[] buffer, which however only has room for 7 characters.  Adjust its size to match the code.

This case could be triggered by a call to erts_printf_format() with any floating-point format that also includes #, and + or a space, which may be uncommon, but a nif or driver could issue it.

I'm also very uneasy about the use of sprintf() instead of snprintf() in fmt_double(), but I understand that older versions of Windows only has the rather different _snprintf(), so I'm not changing that.  Even so, snprintf() could easily be emulated on top of _snprintf().