### PR TITLE
Optimize non-strict equality check of binaries differing in size

### DIFF
--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -3152,6 +3152,9 @@ tailrecur_ne:
 		    int cmp;
 		    byte* a_ptr;
 		    byte* b_ptr;
+		    if (eq_only && a_size != b_size) {
+		        RETURN_NEQ(a_size - b_size);
+		    }
 		    ERTS_GET_BINARY_BYTES(a, a_ptr, a_bitoffs, a_bitsize);
 		    ERTS_GET_BINARY_BYTES(b, b_ptr, b_bitoffs, b_bitsize);
 		    if ((a_bitsize | b_bitsize | a_bitoffs | b_bitoffs) == 0) {


### PR DESCRIPTION
This commit brings the perform of a non-strict equality check of
binaries into the same range as strict ones.

Currently, these checks can be significantly slower because they go
through the general comparison code which doesn't have an optimization
to check the size before comparing contents in the case that it's
checking equality.

--

Hopefully I've got this right, there were two things that were unclear to me from the contribution guidelines.

Firstly, this isn't really a bug fix or an enhancement (in the way it's described), so I wasn't sure what the testing requirement is. In any case, I've run the complete test suite before and after the change and the results are the same either way.

Secondly, the whitespace in this file is unusual to me, it's a mixture of tabs and spaces on the same line - I've configured my editor locally according to the contribution guidelines (two spaces, no tabs), so of course this all aligns nicely in my editor, but not so much in a diff - naturally I'm happy to reformat if that's appropriate.
