### PR TITLE
ssl: Add the unexpected message to #alert{}

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -999,8 +999,8 @@ handle_common_event(internal, #change_cipher_spec{type = <<1>>}, StateName,
 				StateName, State);
 handle_common_event(_Type, Msg, StateName, #state{negotiated_version = Version} = State, 
 		    _) ->
-    Alert =  ?ALERT_REC(?FATAL,?UNEXPECTED_MESSAGE),
-    handle_own_alert(Alert, Version, {StateName, Msg}, State).
+    Alert =  ?ALERT_REC(?FATAL,?UNEXPECTED_MESSAGE, {unexpected_msg, Msg}),
+    handle_own_alert(Alert, Version, StateName, State).
 
 handle_call({application_data, _Data}, _, _, _, _) ->
     %% In renegotiation priorities handshake, send data when handshake is finished


### PR DESCRIPTION
 ssl: Add the unexpected message to `#alert{}` in `handle_common_event()`, instead of passing it to `handle_own_alert()` after wrapping it in a tuple with `StateName` (i.e. `{StateName, Msg}`).

The `StateName` is passed to `handle_normal_shutdown()` and to `alert_user()`. The latter has a clause matching it against `connection`. Unfortunately, when the argument was in fact `{StateName, Msg}`, another clause was executed which dropped the `active` flag value and forced it to `false`, even if the state was actually `connection`. It meant that later in `send_or_reply()`, the alert was not propagated to the user, even though it should (`active` set to `true` or `once`).

Now that `handle_common_event()` always passes the actual `StateName`, the problem is fixed.