### PR TITLE
Fix atom-leak during module's compilation with a lot of function clauses

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -108,16 +108,13 @@
 
 module(#c_module{defs=Ds0}=Mod, Opts) ->
     put(no_inline_list_funcs, not member(inline_list_funcs, Opts)),
-    case get(new_var_num) of
-	undefined -> put(new_var_num, 0);
-	_ -> ok
-    end,
     init_warnings(),
     Ds1 = [function_1(D) || D <- Ds0],
     erase(no_inline_list_funcs),
     {ok,Mod#c_module{defs=Ds1},get_warnings()}.
 
 function_1({#c_var{name={F,Arity}}=Name,B0}) ->
+    put(new_var_num, 0),
     try
 	B = find_fixpoint(fun(Core) ->
 				  %% This must be a fun!


### PR DESCRIPTION
For routing calls in our system we use auto generated erlang modules ([sample_module.zip](https://github.com/erlang/otp/files/1701463/sample_module.zip)).
Route function may contains thousands of functions clauses. When we try to compile such erlang module, compilation faild with "no more index entries in atom_tab". For 5000 function clauses we need 2 million atoms approximately.
As it turned out, the reason of the such behaviour is compiler generate unique atom variable for every variable in function (not function clause).
This fix change this behaviour, and now compiler generate unique atom variable only for function clause.