### PR TITLE
Don't crash lcnt server before first data arrived

### DIFF
--- a/lib/tools/doc/src/lcnt.xml
+++ b/lib/tools/doc/src/lcnt.xml
@@ -371,7 +371,7 @@
 		<v>Serial = integer()</v>
 	    </type>
 	    <desc>
-		<p>Creates a process id with creation 0. Example:</p>
+		<p>Creates a process id with creation 0.</p>
 	    </desc>
 	</func>
 

--- a/lib/tools/src/lcnt.erl
+++ b/lib/tools/src/lcnt.erl
@@ -943,7 +943,7 @@ print_state_information(#state{locks = Locks} = State) ->
     print(kv("#tries",          s(Stats#stats.tries))),
     print(kv("#colls",          s(Stats#stats.colls))),
     print(kv("wait time",       s(Stats#stats.time) ++ " us" ++ " ( " ++ s(Stats#stats.time/1000000) ++ " s)")),
-    print(kv("percent of duration", s(Stats#stats.time/State#state.duration*100) ++ " %")),
+    print(kv("percent of duration", s(percent(Stats#stats.time, State#state.duration)) ++ " %")),
     ok.
 
 


### PR DESCRIPTION
Also remove "Example" without an example from docs