### PR TITLE
Check that the stack is initialized when an exception may occur

### DIFF
--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -1329,7 +1329,12 @@ branch_arities([Sz,{f,L}|T], Tuple, #vst{current=St}=Vst0)
     Vst = branch_state(L, Vst1),
     branch_arities(T, Tuple, Vst#vst{current=St}).
 
-branch_state(0, #vst{}=Vst) -> Vst;
+branch_state(0, #vst{}=Vst) ->
+    %% If the instruction fails, the stack may be scanned
+    %% looking for a catch tag. Therefore the Y registers
+    %% must be initialized at this point.
+    verify_y_init(Vst),
+    Vst;
 branch_state(L, #vst{current=St,branched=B}=Vst) ->
     Vst#vst{
       branched=case gb_trees:is_defined(L, B) of


### PR DESCRIPTION
Strengthen beam_validator to check that the stack is initialized
when an instruction with an {f,0} operand is executed.
For example, the following code sequence:

    {allocate,0,1}.
    {bif,element,{f,0},[{integer,1},{x,0}],{x,0}}.

should not be accepted because the stack may be scanned if
element/2 fails. That could cause a crash or other undefined
behavior if garbage on the stack looks like a catch tag.