### PR TITLE
Derive `erlang-shell-mode` properly from `comint-mode`

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -5166,7 +5166,6 @@ future, a new shell on an already running host will be started."
 ;; e.g. it does not assume that we are running an inferior
 ;; Erlang, there exists a lot of other possibilities.
 
-
 (defvar erlang-shell-buffer-name "*erlang*"
   "The name of the Erlang link shell buffer.")
 
@@ -5177,46 +5176,28 @@ Also see the description of `ielm-prompt-read-only'."
   :type 'boolean
   :package-version '(erlang . "2.8.0"))
 
-(defvar erlang-shell-mode-map nil
+(defvar erlang-shell-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "\M-\t"    'erlang-complete-tag)
+
+    ;; Normally the other way around.
+    (define-key map "\C-a"     'comint-bol)
+    (define-key map "\C-c\C-a" 'beginning-of-line)
+
+    (define-key map "\C-d"     nil)     ; Was `comint-delchar-or-maybe-eof'
+    (define-key map "\M-\C-m"  'compile-goto-error)
+    map)
   "Keymap used by Erlang shells.")
-
-
-(defvar erlang-shell-mode-hook nil
-  "User functions to run when an Erlang shell is started.
-
-This hook is used to change the behaviour of Erlang mode.  It is
-normally used by the user to personalise the programming environment.
-When used in a site init file, it could be used to customise Erlang
-mode for all users on the system.
-
-The function added to this hook is run every time a new Erlang
-shell is started.
-
-See also `erlang-load-hook', a hook which is run once, when Erlang
-mode is loaded, and `erlang-mode-hook' which is run every time a new
-Erlang source file is loaded into Emacs.")
-
 
 (defvar erlang-input-ring-file-name "~/.erlang_history"
   "When non-nil, file name used to store Erlang shell history information.")
 
-
-(defun erlang-shell-mode ()
+(define-derived-mode erlang-shell-mode comint-mode "Erlang Shell"
   "Major mode for interacting with an Erlang shell.
-
-We assume that we already are in Comint mode.
 
 The following special commands are available:
 \\{erlang-shell-mode-map}"
-  (interactive)
-  (setq major-mode 'erlang-shell-mode)
-  (setq mode-name "Erlang Shell")
   (erlang-mode-variables)
-  (if erlang-shell-mode-map
-      nil
-    (setq erlang-shell-mode-map (copy-keymap comint-mode-map))
-    (erlang-shell-mode-commands erlang-shell-mode-map))
-  (use-local-map erlang-shell-mode-map)
   ;; Needed when compiling directly from the Erlang shell.
   (setq compilation-last-buffer (current-buffer))
   (setq comint-prompt-regexp "^[^>=]*> *")
@@ -5230,7 +5211,6 @@ The following special commands are available:
             'inferior-erlang-strip-delete nil t)
   (add-hook 'comint-output-filter-functions
             'inferior-erlang-strip-ctrl-m nil t)
-
   (setq comint-input-ring-file-name erlang-input-ring-file-name)
   (comint-read-input-ring t)
   (make-local-variable 'kill-buffer-hook)
@@ -5249,8 +5229,7 @@ The following special commands are available:
                    (define-key map [menu-bar compilation]
                      (cons "Errors" compilation-menu-map)))
                map))))
-  (erlang-tags-init)
-  (run-hooks 'erlang-shell-mode-hook))
+  (erlang-tags-init))
 
 
 (defun erlang-mouse-2-command (event)
@@ -5271,13 +5250,6 @@ Selects Comint or Compilation mode command as appropriate."
   (if (consp (get-text-property (line-beginning-position) 'message))
       (call-interactively (lookup-key compilation-mode-map "\C-m"))
     (call-interactively (lookup-key comint-mode-map "\C-m"))))
-
-(defun erlang-shell-mode-commands (map)
-  (define-key map "\M-\t"    'erlang-complete-tag)
-  (define-key map "\C-a"     'comint-bol) ; Normally the other way around.
-  (define-key map "\C-c\C-a" 'beginning-of-line)
-  (define-key map "\C-d"     nil)       ; Was `comint-delchar-or-maybe-eof'
-  (define-key map "\M-\C-m"  'compile-goto-error))
 
 ;;;
 ;;; Inferior Erlang -- Run an Erlang shell as a subprocess.


### PR DESCRIPTION
[`define-derived-mode`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Derived-Modes.html) is the recommended way to created derived major modes.

Using `define-derive-mode` gives us the keymap, hook etc. for free, and makes all `comint-mode` functionality automatically available (instead of having to be manually set up).

**Note**: it may be a good idea to separate the Emacs stuff into its own repo. This is what languages like [Clojure](https://github.com/clojure-emacs/clojure-mode) and [Julia](https://github.com/JuliaEditorSupport/julia-emacs) do. This makes it easier for those interested in improving editor functionality to contribute.