### PR TITLE
Fold is_function/1,2 during compilation

### DIFF
--- a/lib/compiler/src/erl_bifs.erl
+++ b/lib/compiler/src/erl_bifs.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2001-2017. All Rights Reserved.
+%% Copyright Ericsson AB 2001-2018. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -91,6 +91,7 @@ is_pure(erlang, is_bitstring, 1) -> true;
 %% erlang:is_builtin/3 depends on the state (i.e. the version of the emulator).
 is_pure(erlang, is_float, 1) -> true;
 is_pure(erlang, is_function, 1) -> true;
+is_pure(erlang, is_function, 2) -> true;
 is_pure(erlang, is_integer, 1) -> true;
 is_pure(erlang, is_list, 1) -> true;
 is_pure(erlang, is_map, 1) -> true;

--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -278,6 +278,8 @@ coverage(Config) when is_list(Config) ->
     a = cover_remove_non_vars_alias({a,b,c}),
     error = cover_will_match_lit_list(),
     {ok,[a]} = cover_is_safe_bool_expr(a),
+    false = cover_is_safe_bool_expr2(a),
+    ok = cover_eval_is_function(fun id/1),
 
     ok = cover_opt_guard_try(#cover_opt_guard_try{list=[a]}),
     error = cover_opt_guard_try(#cover_opt_guard_try{list=[]}),
@@ -341,12 +343,27 @@ cover_is_safe_bool_expr(X) ->
 	    false
     end.
 
+cover_is_safe_bool_expr2(X) ->
+    try
+	V = [X],
+    is_function(V, 1)
+    catch
+	_:_ ->
+	    false
+    end.
+
 cover_opt_guard_try(Msg) ->
     if
 	length(Msg#cover_opt_guard_try.list) =/= 1 ->
 	    error;
 	true ->
 	    ok
+    end.
+
+cover_eval_is_function(X) ->
+    case X of
+        {a,_} -> is_function(X);
+        _ -> ok
     end.
 
 bsm_an_inlined(<<_:8>>, _) -> ok;


### PR DESCRIPTION
This can often appear in code after inlining some higher-order
functions.

* mark is_function/2 as pure
* track function types in sys_core_fold
* use those types to eval is_function/1,2 at compile-time when possible