### PR TITLE
Compute MD5s in dialyzer using the .beam file

### DIFF
--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -148,7 +148,8 @@ chunks(File, Chunks, Options) ->
     try read_chunk_data(File, Chunks, Options)
     catch Error -> Error end.
 
--spec all_chunks(beam()) -> {'ok', 'beam_lib', [{chunkid(), dataB()}]}.
+-spec all_chunks(beam()) ->
+           {'ok', 'beam_lib', [{chunkid(), dataB()}]} | {'error', 'beam_lib', info_rsn()}.
 
 all_chunks(File) ->
     read_all_chunks(File).


### PR DESCRIPTION
The previous mechanism was based on the core file which
meant that for every module in the PLT, we had to fetch
its .beam file, retrieve Erlang AST, compile that down
to core, serialize it into a binary and then get its MD5.

In a project with stdlib, kernel, elixir and a small
application in the PLT,  relying on beam_lib sped up
--check_plt from 10s to 0.8s.

Other workflows, such as checking and adding new modules
to a PLT, have also seen improvements in the range of 2x
to 3x.
