### PR TITLE
Dialyzer should not throw away spec information because of overspec

### DIFF
--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -475,7 +475,7 @@ encode_alloc_list_1([{floats,Floats}|T], Dict, Acc0) ->
 encode_alloc_list_1([], Dict, Acc) ->
     {iolist_to_binary(Acc),Dict}.
 
--spec encode(non_neg_integer(), pos_integer()) -> iodata().
+-spec encode(non_neg_integer(), integer()) -> iodata().
 
 encode(Tag, N) when N < 0 ->
     encode1(Tag, negative_to_bytes(N));

--- a/lib/dialyzer/src/dialyzer_contracts.erl
+++ b/lib/dialyzer/src/dialyzer_contracts.erl
@@ -197,6 +197,10 @@ check_contracts(Contracts, Callgraph, FunTypes, ModOpaques) ->
 		      false ->
 			[{MFA, Contract}|NewContracts]
 		    end;
+                  {error, {extra_range, _, _}} ->
+                    %% do not treat extra range as an error in this check
+                    %% since that prevents discovering other actual errors
+                    [{MFA, Contract}|NewContracts];
 		  {error, _Error} -> NewContracts
 		end;
 	      error -> NewContracts

--- a/lib/dialyzer/test/small_SUITE_data/results/chars
+++ b/lib/dialyzer/test/small_SUITE_data/results/chars
@@ -1,4 +1,4 @@
 
-chars.erl:29: Invalid type specification for function chars:f/1. The success typing is (#{'b':=50}) -> 'ok'
-chars.erl:32: Function t1/0 has no local return
-chars.erl:32: The call chars:f(#{'b':=50}) breaks the contract (#{'a':=49,'b'=>50,'c'=>51}) -> 'ok'
+chars.erl:37: Invalid type specification for function chars:f/1. The success typing is (#{'b':=50}) -> 'ok'
+chars.erl:40: Function t1/0 has no local return
+chars.erl:40: The call chars:f(#{'b':=50}) breaks the contract (#{'a':=49,'b'=>50,'c'=>51}) -> 'ok'

--- a/lib/dialyzer/test/small_SUITE_data/results/extra_range
+++ b/lib/dialyzer/test/small_SUITE_data/results/extra_range
@@ -1,0 +1,4 @@
+
+extra_range.erl:29: The pattern 'ok' can never match the type 'error'
+extra_range.erl:43: The pattern 'no' can never match the type 'maybe' | 'yes'
+extra_range.erl:58: The pattern 'maybe' can never match the type 'no' | 'yes'

--- a/lib/dialyzer/test/small_SUITE_data/src/chars.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/chars.erl
@@ -12,17 +12,25 @@
 -spec t() -> $0-$0..$9-$0| $?.
 
 t() ->
-    c(#r{f = $z - 3}),
+    r(#r{f = $z - 3}),
+    r(#r{f = 97}),
+    c($/),
     c($z - 3),
     c($B).
 
 -spec c(cs()) -> $3-$0..$9-$0.
-
-c($A + 1) -> 2;
+c($A + 1) -> $9-$0;
 c(C) ->
     case C of
-        $z - 3 -> 3;
-        #r{f = $z - 3} -> 7
+        $z - 3 -> $3-$0;
+        _ -> $7-$0
+    end.
+
+-spec r(#r{f :: $a..$z}) -> ok | error.
+r(R) ->
+    case R of
+        #r{f = $z - 3} -> error;
+        _ -> ok
     end.
 
 %% Display contract with character in warning:

--- a/lib/dialyzer/test/small_SUITE_data/src/extra_range.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/extra_range.erl
@@ -1,0 +1,59 @@
+%% Test that a spec containing more items than actually returned
+%% (whether by accident or by benign overspeccing) does not prevent
+%% detection of impossible matches.
+
+-module(extra_range).
+
+-export([t1/2, t2/2, t3/2, t4/2]).
+
+-dialyzer([no_return]).
+
+%% this spec matches the behaviour of the code
+-spec normal(integer()) -> ok | error.
+normal(1) -> ok;
+normal(2) -> error.
+
+t1(X, Y) when is_integer(X), is_integer(Y) ->
+    ok = normal(X),
+    error = normal(Y),
+    ok.
+
+
+%% this spec has a typo, which should cause anyone trying to match on
+%% `ok = typo(X)' to get a warning, because `ok' is not in the spec
+-spec typo(integer()) -> ook | error.
+typo(1) -> ok;
+typo(2) -> error.
+
+t2(X, Y) when is_integer(X), is_integer(Y) ->
+    ok = typo(X),  % warning expected - not allowed according to spec
+    error = typo(Y),
+    ok.
+
+
+%% this is overspecified, and should cause a warning for trying
+%% to match on `no = over(X)', because it cannot succeed and either
+%% the spec should be updated or the code should be extended
+-spec over(integer()) -> yes | no | maybe.
+over(1) -> yes;
+over(_) -> maybe.
+
+t3(X, Y) when is_integer(X), is_integer(Y) ->
+    yes = over(X),
+    no = over(Y),  % warning expected - spec or code needs fixing
+    maybe = over(X + Y),
+    ok.
+
+
+%% this is underspecified, which should cause anyone trying to match on
+%% `maybe = under(X)' to get a warning, because `maybe' is not in the spec
+-spec under(integer()) -> yes | no.
+under(1) -> yes;
+under(2) -> no;
+under(_) -> maybe.
+
+t4(X, Y) when is_integer(X), is_integer(Y) ->
+    yes = under(X),
+    no = under(Y),
+    maybe = under(X + Y), % warning expected - not in spec
+    ok.


### PR DESCRIPTION
This fixes a problem where Dialyzer did not warn about the following situation, because it discarded information unnecessarily:
```
-spec f(integer()) -> ook | error.
f(1) -> ok;
f(2) -> error.

t(X) when is_integer(X) ->
    ok = f(X).  % quietly accepted
```

If the spec was simply missing an entry, you got a warning even without this fix:
```
-spec f(integer()) -> error.  % forgot to mention that 'ok' is valid
f(1) -> ok;
f(2) -> error.

t(X) when is_integer(X) ->
    ok = f(X).  % warns about invalid match
```
The extraneous information in the first case simply made Dialyzer forget that there was any spec at all.