### PR TITLE
Add ets:whereis/1 for resolving table names -> tid()

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -696,3 +696,4 @@ bif erlang:iolist_to_iovec/1
 bif erts_internal:new_connection/1
 bif erts_internal:abort_connection/2
 bif erts_internal:map_next/3
+bif ets:whereis/1

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -487,6 +487,11 @@ Error: fun containing local Erlang function calls
             <p>The pid of the heir of the table, or <c>none</c> if no heir
               is set.</p>
           </item>
+          <tag><c>{id,</c><seealso marker="#type-tid">
+              <c>tid()</c></seealso><c>}</c></tag>
+          <item>
+            <p>The table identifier.</p>
+          </item>
           <tag><c>{keypos, integer() >= 1}</c></tag>
           <item>
             <p>The key position.</p>
@@ -2035,6 +2040,21 @@ true</pre>
           <item><c><anno>Pos</anno></c> &gt; object arity.</item>
           <item>The element to update is also the key.</item>
         </list>
+      </desc>
+    </func>
+
+    <func>
+      <name name="whereis" arity="1"/>
+      <fsummary>Retrieves the tid() of a named table.</fsummary>
+      <desc>
+        <p>This function returns the
+          <seealso marker="#type-tid"><c>tid()</c></seealso> of the named table
+          identified by <c><anno>TableName</anno></c>, or <c>undefined</c> if
+          no such table exists. The <c>tid()</c> can be used in place of the
+          table name in all operations, which is slightly faster since the name
+          does not have to be resolved on each call.</p>
+        <p>If the table is deleted, the <c>tid()</c> will be invalid even if
+          another named table is created with the same name.</p>
       </desc>
     </func>
   </funcs>

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -1079,10 +1079,13 @@ ets:select(Table, MatchSpec),</code>
           </item>
           <tag><c>named_table</c></tag>
           <item>
-            <p>If this option is present, name <c><anno>Name</anno></c> is
-              associated with the table identifier. The name can then
-              be used instead of the table identifier in subsequent
-              operations.</p>
+            <p>If this option is present, the table is registered under its
+              <c><anno>Name</anno></c> which can then be used instead of the
+              table identifier in subsequent operations.</p>
+            <p>The function will also return the <c><anno>Name</anno></c>
+              instead of the table identifier. To get the table identifier of a
+              named table, use
+              <seealso marker="#whereis/1"><c>whereis/1</c></seealso>.</p>
           </item>
           <tag><c>{keypos,<anno>Pos</anno>}</c></tag>
           <item>

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -73,7 +73,8 @@
          select_count/2, select_delete/2, select_replace/2, select_reverse/1,
          select_reverse/2, select_reverse/3, setopts/2, slot/2,
          take/2,
-         update_counter/3, update_counter/4, update_element/3]).
+         update_counter/3, update_counter/4, update_element/3,
+         whereis/1]).
 
 %% internal exports
 -export([internal_request_all/0]).
@@ -145,6 +146,7 @@ give_away(_, _, _) ->
       InfoList :: [InfoTuple],
       InfoTuple :: {compressed, boolean()}
                  | {heir, pid() | none}
+                 | {id, tid()}
                  | {keypos, pos_integer()}
                  | {memory, non_neg_integer()}
                  | {name, atom()}
@@ -162,7 +164,7 @@ info(_) ->
 
 -spec info(Tab, Item) -> Value | undefined when
       Tab :: tab(),
-      Item :: compressed | fixed | heir | keypos | memory
+      Item :: compressed | fixed | heir | id | keypos | memory
             | name | named_table | node | owner | protection
             | safe_fixed | safe_fixed_monotonic_time | size | stats | type
 	    | write_concurrency | read_concurrency,
@@ -510,6 +512,11 @@ update_counter(_, _, _, _) ->
       Value :: term().
 
 update_element(_, _, _) ->
+    erlang:nif_error(undef).
+
+-spec whereis(TableName) -> tid() | undefined when
+    TableName :: atom().
+whereis(_) ->
     erlang:nif_error(undef).
 
 %%% End of BIFs


### PR DESCRIPTION
This PR adds a function for resolving the tid() of named ETS tables, analogous to `erlang:whereis/1`.

http://erlang.org/pipermail/erlang-questions/2018-January/094616.html