### PR TITLE
Export types documented for http_uri module

### DIFF
--- a/lib/inets/doc/src/http_uri.xml
+++ b/lib/inets/doc/src/http_uri.xml
@@ -118,7 +118,7 @@
         <v>Option = {ipv6_host_with_brackets, boolean()} | 
                     {scheme_defaults, scheme_defaults()} |
                     {fragment, boolean()} |
-                    {scheme_validation_fun, fun()}]</v>
+                    {scheme_validation_fun, fun()}</v>
         <v>Result = {Scheme, UserInfo, Host, Port, Path, Query} |
                     {Scheme, UserInfo, Host, Port, Path, Query, Fragment}</v>
 	<v>Scheme = scheme()</v>
@@ -152,6 +152,13 @@ fun(SchemeStr :: string() | binary()) ->
 
         <p>It is called before scheme string gets converted into scheme atom and
         thus possible atom leak could be prevented</p>
+
+        <warning>
+          <p>The scheme portion of the URI gets converted into atom,
+          meaning that atom leak may occur. Specifying a scheme
+          validation fun is recommended unless the URI is already
+          sanitized.</p>
+        </warning>
 
         <marker id="encode"></marker>
       </desc>

--- a/lib/inets/doc/src/http_uri.xml
+++ b/lib/inets/doc/src/http_uri.xml
@@ -45,7 +45,6 @@
       this module:</p>
     <p><c>boolean() = true | false</c></p>
     <p><c>string()</c> = list of ASCII characters</p>
-    <p><c>unicode_binary()</c> = binary() with characters encoded in the UTF-8 coding standard</p>
 
   </section>
   
@@ -54,22 +53,22 @@
     <p>Type definitions that are related to URI:</p>
     
 <taglist>
-       <tag><c>uri() = string() | unicode:unicode_binary()</c></tag>
+       <tag><c>uri() = string() | binary()</c></tag>
        <item><p>Syntax according to the URI definition in RFC 3986,
        for example, "http://www.erlang.org/"</p></item>
-       <tag><c>user_info() = string() | unicode:unicode_binary()</c></tag>
+       <tag><c>user_info() = string() | binary()</c></tag>
        <item><p></p></item>
        <tag><c>scheme() = atom()</c></tag>
        <item><p>Example: http, https</p></item>
-       <tag><c>host() = string() | unicode:unicode_binary()</c></tag>
+       <tag><c>host() = string() | binary()</c></tag>
        <item><p></p></item>
-       <tag><c>port() = pos_integer()</c></tag>
+       <tag><c>port() = inet:port_number()</c></tag>
        <item><p></p></item>
-       <tag><c>path() = string() | unicode:unicode_binary()</c></tag>
+       <tag><c>path() = string() | binary()</c></tag>
        <item><p>Represents a file path or directory path</p></item>
-       <tag><c>query() = string() | unicode:unicode_binary()</c></tag>
+       <tag><c>query() = string() | binary()</c></tag>
        <item><p></p></item>
-       <tag><c>fragment() = string() | unicode:unicode_binary()</c></tag>
+       <tag><c>fragment() = string() | binary()</c></tag>
        <item><p></p></item>
      </taglist>
    
@@ -84,7 +83,7 @@
       
       <fsummary>Decodes a hexadecimal encoded URI.</fsummary>
       <type>
-        <v>HexEncodedURI = string() | unicode:unicode_binary() - A possibly hexadecimal encoded URI</v>
+        <v>HexEncodedURI = string() | binary() - A possibly hexadecimal encoded URI</v>
         <v>URI = uri()</v>
       </type>
 
@@ -99,7 +98,7 @@
       <fsummary>Encodes a hexadecimal encoded URI.</fsummary>
       <type>
         <v>URI = uri()</v>
-        <v>HexEncodedURI = string() | unicode:unicode_binary() - Hexadecimal encoded URI</v>
+        <v>HexEncodedURI = string() | binary() - Hexadecimal encoded URI</v>
       </type>
 
       <desc>
@@ -122,9 +121,10 @@
                     {scheme_validation_fun, fun()}]</v>
         <v>Result = {Scheme, UserInfo, Host, Port, Path, Query} |
                     {Scheme, UserInfo, Host, Port, Path, Query, Fragment}</v>
+	<v>Scheme = scheme()</v>
 	<v>UserInfo = user_info()</v>
 	<v>Host = host()</v>
-	<v>Port = pos_integer()</v>
+	<v>Port = inet:port_number()</v>
 	<v>Path = path()</v>
 	<v>Query = query()</v>
         <v>Fragment = fragment()</v>
@@ -146,7 +146,7 @@
         <p>Scheme validation fun is to be defined as follows:</p>
 
 	<code>
-fun(SchemeStr :: string() | unicode:unicode_binary()) ->
+fun(SchemeStr :: string() | binary()) ->
 	valid |	{error, Reason :: term()}.
 	</code>
 
@@ -162,7 +162,7 @@ fun(SchemeStr :: string() | unicode:unicode_binary()) ->
       <fsummary>A list of the scheme and their default ports.</fsummary>
       <type>
         <v>SchemeDefaults = [{scheme(), default_scheme_port_number()}] </v> 
-	<v>default_scheme_port_number() = pos_integer()</v>
+	<v>default_scheme_port_number() = inet:port_number()</v>
       </type>
       <desc>
         <p>Provides a list of the scheme and their default 

--- a/lib/inets/src/http_lib/http_uri.erl
+++ b/lib/inets/src/http_lib/http_uri.erl
@@ -81,13 +81,15 @@
 -type hex_uri() :: string() | binary(). %% Hexadecimal encoded URI.
 -type maybe_hex_uri() :: string() | binary(). %% A possibly hexadecimal encoded URI.
 
+-type scheme_defaults() :: [{scheme(), default_scheme_port_number()}].
+-type scheme_validation_fun() :: fun((SchemeStr :: string() | binary()) ->
+                                            valid | {error, Reason :: term()}).
+
 %%%=========================================================================
 %%%  API
 %%%=========================================================================
 
--spec scheme_defaults() ->
-    [{scheme(), default_scheme_port_number()}].
-
+-spec scheme_defaults() -> scheme_defaults().
 scheme_defaults() ->
     [{http,  80}, 
      {https, 443}, 
@@ -106,7 +108,10 @@ parse(AbsURI) ->
     parse(AbsURI, []).
 
 -spec parse(uri(), [Option]) -> {ok, parse_result()} | {error, term()} when
-      Option :: {atom(), term()}.
+      Option :: {ipv6_host_with_brackets, boolean()} |
+                {scheme_defaults, scheme_defaults()} |
+                {fragment, boolean()} |
+                {scheme_validation_fun, scheme_validation_fun()}.
 parse(AbsURI, Opts) ->
     case parse_scheme(AbsURI, Opts) of
 	{error, Reason} ->

--- a/lib/inets/src/http_lib/http_uri.erl
+++ b/lib/inets/src/http_lib/http_uri.erl
@@ -111,7 +111,7 @@ parse(AbsURI) ->
       Option :: {ipv6_host_with_brackets, boolean()} |
                 {scheme_defaults, scheme_defaults()} |
                 {fragment, boolean()} |
-                {scheme_validation_fun, scheme_validation_fun()}.
+                {scheme_validation_fun, scheme_validation_fun() | none}.
 parse(AbsURI, Opts) ->
     case parse_scheme(AbsURI, Opts) of
 	{error, Reason} ->


### PR DESCRIPTION
From the `http_uri` module documentation it may be intended that the listed types are exported by the module, and I have seen at least a couple of projects using those types as exported ([example](https://github.com/for-GET/jesse/blob/1.5.0/src/jesse.erl#L80)). I think it makes sense, hence this PR.

I consider this more a bug fix that a new feature, hence I based on `maint`. If you prefer I base on `master`, please let me know and I will be happy to do so.

-----

BTW I have not understood the `marker`s in the documentation e.g. https://github.com/erlang/otp/blob/OTP-20.2.4/lib/inets/doc/src/http_uri.xml#L78