### PR TITLE
Included config files relative to sys.config dir

### DIFF
--- a/lib/kernel/doc/src/config.xml
+++ b/lib/kernel/doc/src/config.xml
@@ -86,8 +86,13 @@
       <tag><c>File = string()</c></tag>
       <item>Name of another <c>.config</c> file.
         Extension <c>.config</c> can be omitted. It is
-        recommended to use absolute paths. A relative path is
-        relative the current working directory of the emulator.</item>
+        recommended to use absolute paths. If a relative path is used,
+        <c>File</c> is searched, first, relative from <c>sys.config</c> directory, then relative
+        to the current working directory of the emulator, for backward compatibility.
+        This allow to use a <c>sys.config</c> pointing out other <c>.config</c> files in a release
+        or in a node started manually using <c>-config ...</c> with same result whatever
+        the current working directory.
+        </item>
     </taglist>
     <p>When traversing the contents of <c>sys.config</c> and a filename
       is encountered, its contents are read and merged with the result

--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1996-2017. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2018. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@
 		keyfind/3, keydelete/3, keyreplace/4]).
 
 -include("application_master.hrl").
+-include("logger.hrl").
 
 -define(AC, ?MODULE). % Name of process
 
@@ -1271,9 +1272,7 @@ load(S, {ApplData, ApplEnv, IncApps, Descr, Id, Vsn, Apps}) ->
     NewEnv = merge_app_env(ApplEnv, ConfEnv),
     CmdLineEnv = get_cmd_env(Name),
     NewEnv2 = merge_app_env(NewEnv, CmdLineEnv),
-    NewEnv3 = keyreplaceadd(included_applications, 1, NewEnv2,
-			    {included_applications, IncApps}),
-    add_env(Name, NewEnv3),
+    add_env(Name, NewEnv2),
     Appl = #appl{name = Name, descr = Descr, id = Id, vsn = Vsn, 
 		 appl_data = ApplData, inc_apps = IncApps, apps = Apps},
     ets:insert(ac_tab, {{loaded, Name}, Appl}),
@@ -1291,7 +1290,7 @@ load(S, {ApplData, ApplEnv, IncApps, Descr, Id, Vsn, Apps}) ->
     {ok, NewS}.
 
 unload(AppName, S) ->
-    {ok, IncApps} = get_env(AppName, included_applications),
+    {ok, IncApps} = get_key(AppName, included_applications),
     del_env(AppName),
     ets:delete(ac_tab, {loaded, AppName}),
     foldl(fun(App, S1) ->
@@ -1546,9 +1545,8 @@ do_change_apps(Applications, Config, OldAppls) ->
     %% Report errors, but do not terminate
     %% (backwards compatible behaviour)
     lists:foreach(fun({error, {SysFName, Line, Str}}) ->
-			  Str2 = lists:flatten(io_lib:format("~tp: ~w: ~ts~n",
-							     [SysFName, Line, Str])),
-			  error_logger:format(Str2, [])
+			  ?LOG_ERROR("~tp: ~w: ~ts~n",[SysFName, Line, Str],
+                                     #{error_logger=>#{tag=>error}})
 		  end,
 		  Errors),
 
@@ -1583,13 +1581,9 @@ do_change_appl({ok, {ApplData, Env, IncApps, Descr, Id, Vsn, Apps}},
     CmdLineEnv = get_cmd_env(AppName),
     NewEnv2 = merge_app_env(NewEnv1, CmdLineEnv),
 
-    %% included_apps is made into an env parameter as well
-    NewEnv3 = keyreplaceadd(included_applications, 1, NewEnv2,
-			    {included_applications, IncApps}),
-
     %% Update ets table with new application env
     del_env(AppName),
-    add_env(AppName, NewEnv3),
+    add_env(AppName, NewEnv2),
 
     OldAppl#appl{appl_data=ApplData,
 		 descr=Descr,
@@ -1631,8 +1625,9 @@ make_term(Str) ->
     end.
 
 handle_make_term_error(Mod, Reason, Str) ->
-    error_logger:format("application_controller: ~ts: ~ts~n",
-        [Mod:format_error(Reason), Str]),
+    ?LOG_ERROR("application_controller: ~ts: ~ts~n",
+               [Mod:format_error(Reason), Str],
+               #{error_logger=>#{tag=>error}}),
     throw({error, {bad_environment_value, Str}}).
 
 get_env_i(Name, #state{conf_data = ConfData}) when is_list(ConfData) ->
@@ -1819,8 +1814,9 @@ check_conf() ->
 				   %% Therefore read and merge contents.
 				   if
 				       BFName =:= "sys" ->
+					   DName = filename:dirname(FName),
 					   {ok, SysEnv, Errors} =
-					       check_conf_sys(NewEnv),
+					       check_conf_sys(NewEnv, [], [], DName),
 
 					   %% Report first error, if any, and
 					   %% terminate
@@ -1842,20 +1838,31 @@ check_conf() ->
     end.
 
 check_conf_sys(Env) ->
-    check_conf_sys(Env, [], []).
+    check_conf_sys(Env, [], [], []).
 
-check_conf_sys([File|T], SysEnv, Errors) when is_list(File) ->
+check_conf_sys([File|T], SysEnv, Errors, DName) when is_list(File),is_list(DName) ->
     BFName = filename:basename(File, ".config"),
     FName = filename:join(filename:dirname(File), BFName ++ ".config"),
-    case load_file(FName) of
+    LName = case filename:pathtype(FName) of
+               relative when (DName =/= []) ->
+                  % Check if relative to sys.config dir otherwise use legacy mode,
+                  % i.e relative to cwd.
+                  RName = filename:join(DName, FName),
+                  case erl_prim_loader:read_file_info(RName) of
+                     {ok, _} -> RName ;
+                     error   -> FName
+                  end;
+		_          -> FName
+	    end,
+    case load_file(LName) of
 	{ok, NewEnv} ->
-	    check_conf_sys(T, merge_env(SysEnv, NewEnv), Errors);
+	    check_conf_sys(T, merge_env(SysEnv, NewEnv), Errors, DName);
 	{error, {Line, _Mod, Str}} ->
-	    check_conf_sys(T, SysEnv, [{error, {FName, Line, Str}}|Errors])
+	    check_conf_sys(T, SysEnv, [{error, {LName, Line, Str}}|Errors], DName)
     end;
-check_conf_sys([Tuple|T], SysEnv, Errors) ->
-    check_conf_sys(T, merge_env(SysEnv, [Tuple]), Errors);
-check_conf_sys([], SysEnv, Errors) ->
+check_conf_sys([Tuple|T], SysEnv, Errors, DName) ->
+    check_conf_sys(T, merge_env(SysEnv, [Tuple]), Errors, DName);
+check_conf_sys([], SysEnv, Errors, _) ->
     {ok, SysEnv, lists:reverse(Errors)}.
 
 load_file(File) ->
@@ -1913,19 +1920,25 @@ config_error() ->
       "configuration file must contain ONE list ended by <dot>"}}.
 
 %%-----------------------------------------------------------------
-%% Info messages sent to error_logger
+%% Info messages sent to logger
 %%-----------------------------------------------------------------
 info_started(Name, Node) ->
-    Rep = [{application, Name},
-	   {started_at, Node}],
-    error_logger:info_report(progress, Rep).
+    ?LOG_INFO(#{label=>{application_controller,progress},
+                report=>[{application, Name},
+                         {started_at, Node}]},
+              #{domain=>[otp,sasl],
+                report_cb=>fun logger:format_otp_report/1,
+                logger_formatter=>#{title=>"PROGRESS REPORT"},
+                error_logger=>#{tag=>info_report,type=>progress}}).
 
 info_exited(Name, Reason, Type) ->
-    Rep = [{application, Name},
-	   {exited, Reason},
-	   {type, Type}],
-    error_logger:info_report(Rep).
-
+    ?LOG_NOTICE(#{label=>{application_controller,exit},
+                  report=>[{application, Name},
+                           {exited, Reason},
+                           {type, Type}]},
+                #{domain=>[otp],
+                  report_cb=>fun logger:format_otp_report/1,
+                  error_logger=>#{tag=>info_report,type=>std_info}}).
 
 %%-----------------------------------------------------------------
 %% Reply to all processes waiting this application to be started.  
@@ -2012,5 +2025,5 @@ to_string(Term) ->
 	true ->
 	    Term;
 	false ->
-	    lists:flatten(io_lib:format("~134217728p", [Term]))
+	    lists:flatten(io_lib:format("~0p", [Term]))
     end.

--- a/lib/kernel/test/application_SUITE.erl
+++ b/lib/kernel/test/application_SUITE.erl
@@ -37,7 +37,8 @@
 -export([config_change/1, persistent_env/1,
 	 distr_changed_tc1/1, distr_changed_tc2/1,
 	 ensure_started/1, ensure_all_started/1,
-	 shutdown_func/1, do_shutdown/1, shutdown_timeout/1, shutdown_deadlock/1]).
+	 shutdown_func/1, do_shutdown/1, shutdown_timeout/1, shutdown_deadlock/1,
+         config_relative_paths/1]).
 
 -define(TESTCASE, testcase_name).
 -define(testcase, proplists:get_value(?TESTCASE, Config)).
@@ -55,7 +56,7 @@ all() ->
      script_start, nodedown_start, permit_false_start_local,
      permit_false_start_dist, get_key, get_env, ensure_all_started,
      {group, distr_changed}, config_change, shutdown_func, shutdown_timeout,
-     shutdown_deadlock,
+     shutdown_deadlock, config_relative_paths,
      persistent_env].
 
 groups() -> 
@@ -1568,7 +1569,8 @@ loop5606(Pid) ->
 	    
 %% Tests get_env/* functions.
 get_env(Conf) when is_list(Conf) ->
-    {ok, _}   = application:get_env(kernel, error_logger),
+    ok = application:set_env(kernel, new_var, new_val),
+    {ok, new_val} = application:get_env(kernel, new_var),
     undefined = application:get_env(undefined_app, a),
     undefined = application:get_env(kernel, error_logger_xyz),
     default   = application:get_env(kernel, error_logger_xyz, default),
@@ -1602,8 +1604,7 @@ get_key(Conf) when is_list(Conf) ->
     {ok, [{init, [kalle]}, {takeover, []}, {go, [sune]}]} =
 	rpc:call(Cp1, application, get_key, [appinc, start_phases]),
     {ok, Env} = rpc:call(Cp1, application, get_key, [appinc ,env]),
-    [{included_applications,[appinc1,appinc2]},
-	   {own2,val2},{own_env1,value1}] = lists:sort(Env),
+    [{own2,val2},{own_env1,value1}] = lists:sort(Env),
     {ok, []} = rpc:call(Cp1, application, get_key, [appinc, modules]),
     {ok, {application_starter, [ch_sup, {appinc, 41, 43}] }} = 
 	rpc:call(Cp1, application, get_key, [appinc, mod]),
@@ -1624,8 +1625,7 @@ get_key(Conf) when is_list(Conf) ->
 		{mod, {application_starter, [ch_sup, {appinc, 41, 43}] }}, 
 		{start_phases, [{init, [kalle]}, {takeover, []}, {go, [sune]}]}]} = 
 	rpc:call(Cp1, application, get_all_key, [appinc]),
-    [{included_applications,[appinc1,appinc2]},
-	   {own2,val2},{own_env1,value1}] = lists:sort(Env),
+    [{own2,val2},{own_env1,value1}] = lists:sort(Env),
 
     {ok, "Test of new app file, including appnew"} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, description}),
@@ -1642,8 +1642,7 @@ get_key(Conf) when is_list(Conf) ->
     {ok, [{init, [kalle]}, {takeover, []}, {go, [sune]}]} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, start_phases}),
     {ok, Env} = gen_server:call({global, {ch,41}}, {get_pid_key, env}),
-    [{included_applications,[appinc1,appinc2]},
-	   {own2,val2},{own_env1,value1}] = lists:sort(Env),
+    [{own2,val2},{own_env1,value1}] = lists:sort(Env),
     {ok, []} = 
 	gen_server:call({global, {ch,41}}, {get_pid_key, modules}),
     {ok, {application_starter, [ch_sup, {appinc, 41, 43}] }} = 
@@ -1670,8 +1669,7 @@ get_key(Conf) when is_list(Conf) ->
 		{mod, {application_starter, [ch_sup, {appinc, 41, 43}] }}, 
 		{start_phases, [{init, [kalle]}, {takeover, []}, {go, [sune]}]}]} = 
 	gen_server:call({global, {ch,41}}, get_pid_all_key),
-    [{included_applications,[appinc1,appinc2]},
-	   {own2,val2},{own_env1,value1}] = lists:sort(Env),
+    [{own2,val2},{own_env1,value1}] = lists:sort(Env),
     
     stop_node_nice(Cp1),
     ok.
@@ -2076,6 +2074,42 @@ shutdown_deadlock(Config) when is_list(Config) ->
     application:unload(deadlock), % clean up!
     ok.
 
+
+%%-----------------------------------------------------------------
+%% Relative paths in sys.config
+%%-----------------------------------------------------------------
+config_relative_paths(Config) ->
+    Dir = ?config(priv_dir,Config),
+    SubDir = filename:join(Dir,"subdir"),
+    Sys = filename:join(SubDir,"sys.config"),
+    ok = filelib:ensure_dir(Sys),
+    ok = file:write_file(Sys,"[\"../up.config\",\"current\"].\n"),
+
+    Up = filename:join(Dir,"up.config"),
+    ok = file:write_file(Up,"[{app1,[{key1,value}]}].\n"),
+
+    {ok,Cwd} = file:get_cwd(),
+    Current1 = filename:join(Cwd,"current.config"),
+    ok = file:write_file(Current1,"[{app1,[{key2,value1}]}].\n"),
+
+    N1 = list_to_atom(lists:concat([?FUNCTION_NAME,"_1"])),
+    {ok,Node1} = start_node(N1,filename:rootname(Sys)),
+    ok = rpc:call(Node1, application, load, [app1()]),
+    {ok, value} = rpc:call(Node1, application, get_env,[app1,key1]),
+    {ok, value1} = rpc:call(Node1, application, get_env,[app1,key2]),
+
+    Current2 = filename:join(SubDir,"current.config"),
+    ok = file:write_file(Current2,"[{app1,[{key2,value2}]}].\n"),
+
+    N2 = list_to_atom(lists:concat([?FUNCTION_NAME,"_2"])),
+    {ok, Node2} = start_node(N2,filename:rootname(Sys)),
+    ok = rpc:call(Node2, application, load, [app1()]),
+    {ok, value} = rpc:call(Node2, application, get_env,[app1,key1]),
+    {ok, value2} = rpc:call(Node2, application, get_env,[app1,key2]),
+
+    stop_node_nice([Node1,Node2]),
+
+    ok.
 
 %%-----------------------------------------------------------------
 %% Utility functions


### PR DESCRIPTION
This permit same result when using a sys.config file in a release or starting manually a node with -config ... .
For backward compatibility, if file is not found relative to sys.config, it is searched from working directory like before.