### PR TITLE
Fix anonymous suites regression and protocol error

### DIFF
--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -774,10 +774,8 @@ decode_suites('3_bytes', Dec) ->
 %%====================================================================
 
 available_suites(UserSuites, Version) ->
-    lists:filtermap(fun(Suite) ->
-			    lists:member(Suite, ssl_cipher:all_suites(Version) ++
-						ssl_cipher:anonymous_suites(Version))
-		    end, UserSuites).
+    VersionSuites = ssl_cipher:all_suites(Version) ++ ssl_cipher:anonymous_suites(Version),
+    lists:filtermap(fun(Suite) -> lists:member(Suite, VersionSuites) end, UserSuites).
 
 available_suites(ServerCert, UserSuites, Version, undefined, Curve) ->
     ssl_cipher:filter(ServerCert, available_suites(UserSuites, Version))

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -775,7 +775,8 @@ decode_suites('3_bytes', Dec) ->
 
 available_suites(UserSuites, Version) ->
     lists:filtermap(fun(Suite) ->
-			    lists:member(Suite, ssl_cipher:all_suites(Version))
+			    lists:member(Suite, ssl_cipher:all_suites(Version) ++
+						ssl_cipher:anonymous_suites(Version))
 		    end, UserSuites).
 
 available_suites(ServerCert, UserSuites, Version, undefined, Curve) ->
@@ -1056,7 +1057,9 @@ select_curve(undefined, _, _) ->
 %%
 %% Description: Handles signature_algorithms hello extension (server)
 %%--------------------------------------------------------------------
-select_hashsign(_, undefined, _,  _, _Version) ->
+select_hashsign(_, _, KeyExAlgo, _, _Version) when KeyExAlgo == dh_anon;
+                                                   KeyExAlgo == ecdh_anon;
+                                                   KeyExAlgo == srp_anon ->
     {null, anon};
 %% The signature_algorithms extension was introduced with TLS 1.2. Ignore it if we have
 %% negotiated a lower version.


### PR DESCRIPTION
Anonymous cipher suites were broken in master altogether, and there was an earlier issue where the server would send a signature with ServerKeyExchange if a certificate was configured, even if an anonymous suite was actually negotiated.