### PR TITLE
Make io_lib:unscan_format/1 work with pad char and default precision

### DIFF
--- a/lib/stdlib/src/io_lib_format.erl
+++ b/lib/stdlib/src/io_lib_format.erl
@@ -95,7 +95,7 @@ print([]) ->
     [].
 
 print(C, F, Ad, P, Pad, Encoding, Strings) ->
-    [$~] ++ print_field_width(F, Ad) ++ print_precision(P) ++
+    [$~] ++ print_field_width(F, Ad) ++ print_precision(P, Pad) ++
         print_pad_char(Pad) ++ print_encoding(Encoding) ++
         print_strings(Strings) ++ [C].
 
@@ -103,8 +103,9 @@ print_field_width(none, _Ad) -> "";
 print_field_width(F, left) -> integer_to_list(-F);
 print_field_width(F, right) -> integer_to_list(F).
 
-print_precision(none) -> "";
-print_precision(P) -> [$. | integer_to_list(P)].
+print_precision(none, $\s) -> "";
+print_precision(none, _Pad) -> ".";  % pad must be second dot
+print_precision(P, _Pad) -> [$. | integer_to_list(P)].
 
 print_pad_char($\s) -> ""; % default, no need to make explicit
 print_pad_char(Pad) -> [$., Pad].

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -2005,6 +2005,7 @@ writes(N, F1) ->
 
 format_string(_Config) ->
     %% All but padding is tested by fmt/2.
+    "xxxxxxxsss" = fmt("~10..xs", ["sss"]),
     "xxxxxxsssx" = fmt("~10.4.xs", ["sss"]),
     "xxxxxxsssx" = fmt("~10.4.*s", [$x, "sss"]),
     ok.


### PR DESCRIPTION
When the scan_format/unscan_format stuff was included in OTP, it was slightly modified from the original implementation. At some point this detail was lost: you can specify a pad character but use default precision by having an empty precision field.