### PR TITLE
inets: fix scheme validation in http_uri:parse when binary URI

### DIFF
--- a/lib/inets/src/http_lib/http_uri.erl
+++ b/lib/inets/src/http_lib/http_uri.erl
@@ -197,7 +197,7 @@ extract_scheme(Str, Opts) ->
 	{value, {scheme_validation_fun, Fun}} when is_function(Fun) ->
 	    case Fun(Str) of
 		valid ->
-		    {ok, list_to_atom(http_util:to_lower(Str))};
+		    {ok, to_atom(http_util:to_lower(Str))};
 		{error, Error} ->
 		    {error, Error}
 	    end;

--- a/lib/inets/test/uri_SUITE.erl
+++ b/lib/inets/test/uri_SUITE.erl
@@ -52,6 +52,7 @@ all() ->
      escaped,
      hexed_query,
      scheme_validation,
+     scheme_validation_bin,
      encode_decode
     ].
 
@@ -272,6 +273,26 @@ scheme_validation(Config) when is_list(Config) ->
     {ok, {https,[],"localhost",443,"/",""}} =
 	http_uri:parse("https://localhost#fragment",
 		       [{scheme_validation_fun, none}]).
+
+scheme_validation_bin(Config) when is_list(Config) ->
+    {ok, {http,<<>>,<<"localhost">>,80,<<"/">>,<<>>}} =
+        http_uri:parse(<<"http://localhost#fragment">>),
+
+    ValidationFun =
+        fun(<<"http">>) -> valid;
+           (_) -> {error, bad_scheme}
+        end,
+
+    {ok, {http,<<>>,<<"localhost">>,80,<<"/">>,<<>>}} =
+        http_uri:parse(<<"http://localhost#fragment">>,
+                       [{scheme_validation_fun, ValidationFun}]),
+    {error, bad_scheme} =
+        http_uri:parse(<<"https://localhost#fragment">>,
+                       [{scheme_validation_fun, ValidationFun}]),
+    %% non-fun scheme_validation_fun works as no option passed
+    {ok, {https,<<>>,<<"localhost">>,443,<<"/">>,<<>>}} =
+        http_uri:parse(<<"https://localhost#fragment">>,
+                       [{scheme_validation_fun, none}]).
 
 encode_decode(Config) when is_list(Config) ->
     ?assertEqual("foo%20bar", http_uri:encode("foo bar")),


### PR DESCRIPTION
I noticed this following work on #1724 .

I ran tests for inets app:
```
Testing tests.inets_test: TEST COMPLETE, 238 ok, 0 failed, 319 skipped of 557 test cases
```