### PR TITLE
Do not treat binaries as top level in dbg_ieval

### DIFF
--- a/lib/debugger/src/dbg_ieval.erl
+++ b/lib/debugger/src/dbg_ieval.erl
@@ -1033,7 +1033,7 @@ expr({send,Line,To0,Msg0}, Bs0, Ieval0) ->
 
 %% Binary
 expr({bin,Line,Fs}, Bs0, Ieval0) ->
-    Ieval = Ieval0#ieval{line=Line},
+    Ieval = Ieval0#ieval{line=Line,top=false},
     try
 	eval_bits:expr_grp(Fs, Bs0,
 			   fun (E, B) -> expr(E, B, Ieval) end,

--- a/lib/debugger/test/int_eval_SUITE.erl
+++ b/lib/debugger/test/int_eval_SUITE.erl
@@ -29,7 +29,8 @@
 	 bifs_outside_erlang/1, spawning/1, applying/1,
 	 catch_and_throw/1, external_call/1, test_module_info/1,
 	 apply_interpreted_fun/1, apply_uninterpreted_fun/1,
-	 interpreted_exit/1, otp_8310/1, stacktrace/1, maps/1]).
+	 interpreted_exit/1, otp_8310/1, stacktrace/1, maps/1,
+	 call_inside_binary/1]).
 
 %% Helpers.
 -export([applier/3]).
@@ -45,7 +46,8 @@ all() ->
     [bifs_outside_erlang, spawning, applying,
      catch_and_throw, external_call, test_module_info,
      apply_interpreted_fun, apply_uninterpreted_fun,
-     interpreted_exit, otp_8310, stacktrace, maps].
+     interpreted_exit, otp_8310, stacktrace, maps,
+     call_inside_binary].
 
 groups() -> 
     [].
@@ -275,6 +277,9 @@ maps(Config) when is_list(Config) ->
     [#{hello := 0, price := 0}] = spawn_eval(fun () -> ?IM:update_in_fun() end),
     ok.
 
+call_inside_binary(Config) when is_list(Config) ->
+    <<"1">> = ?IM:call_inside_binary(fun erlang:integer_to_binary/1),
+    ok.
 
 do_eval(Config, Mod) ->
     DataDir = proplists:get_value(data_dir, Config),

--- a/lib/debugger/test/int_eval_SUITE_data/my_int_eval_module.erl
+++ b/lib/debugger/test/int_eval_SUITE_data/my_int_eval_module.erl
@@ -31,6 +31,7 @@
 -export([f/1, f_try/1, f_catch/1]).
 -export([otp_5837/1, otp_8310/0]).
 -export([empty_map_update/1, update_in_fun/0]).
+-export([call_inside_binary/1]).
 
 %% Internal exports.
 -export([echo/2,my_subtract/2,catch_a_ball/0,throw_a_ball/0]).
@@ -248,3 +249,6 @@ empty_map_update(Map) -> Map#{}.
 
 update_in_fun() ->
     lists:map(fun (X) -> X#{price := 0} end, [#{hello => 0, price => nil}]).
+
+call_inside_binary(Fun) ->
+    <<(Fun(1))/binary>>.


### PR DESCRIPTION
Prior to this change, calls inside binaries were
treated as top level which would cause the `Fun(Arg)`
call inside `<<Fun(Arg)/binary>>` to return an internal
dbg_ieval tuple and ultimately error with badarg.