### PR TITLE
Short-circuit code:ensure_loaded for already-loaded modules

### DIFF
--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -149,8 +149,11 @@ load_file(Mod) when is_atom(Mod) ->
 -spec ensure_loaded(Module) -> {module, Module} | {error, What} when
       Module :: module(),
       What :: embedded | badfile | nofile | on_load_failure.
-ensure_loaded(Mod) when is_atom(Mod) -> 
-    call({ensure_loaded,Mod}).
+ensure_loaded(Mod) when is_atom(Mod) ->
+    case erlang:module_loaded(Mod) of
+        true -> {module, Mod};
+        false -> call({ensure_loaded,Mod})
+    end.
 
 %% XXX File as an atom is allowed only for backwards compatibility.
 -spec load_abs(Filename) -> load_ret() when


### PR DESCRIPTION
This checks if the module is already loaded using erlang:module_loaded
before calling the code server. This should improve performance of the
call significantly since the case where module is already loaded is the
common one.

The change shouldn't cause any problems. It's worth noting that
code:ensure_modules_loaded already does a similar check.