### PR TITLE
Allow multiple modifier characters in io:format control sequences

### DIFF
--- a/lib/stdlib/doc/src/io.xml
+++ b/lib/stdlib/doc/src/io.xml
@@ -137,11 +137,11 @@
 Hello world!
 ok</pre>
         <p>The general format of a control sequence is <c>~F.P.PadModC</c>.</p>
-        <p>Character <c>C</c> determines the type of control sequence
-          to be used, <c>F</c> and <c>P</c> are optional numeric
-          arguments. If <c>F</c>, <c>P</c>, or <c>Pad</c> is <c>*</c>,
-          the next argument in <c>Data</c> is used as the numeric value
-          of <c>F</c> or <c>P</c>.</p>
+        <p>The character <c>C</c> determines the type of control sequence
+          to be used. It is the only required field. All of <c>F</c>,
+          <c>P</c>, <c>Pad</c>, and <c>Mod</c> are optional. For example,
+          to use a <c>#</c> for <c>Pad</c> but use the default values for
+          <c>F</c> and <c>P</c>, you can write <c>~..#C</c>.</p>
         <list type="bulleted">
         <item>
           <p><c>F</c> is the <c>field width</c> of the printed argument. A
@@ -167,13 +167,26 @@ ok</pre>
             The default padding character is <c>' '</c> (space).</p>
         </item>
         <item>
-          <p><c>Mod</c> is the control sequence modifier. It is a
-            single character that changes the interpretation of
-            <c>Data</c>. This can be <c>t</c>, for Unicode translation,
-            or <c>l</c>, for stopping <c>p</c> and <c>P</c> from
-            detecting printable characters.</p>
+          <p><c>Mod</c> is the control sequence modifier. This is
+            one or more characters that change the interpretation of
+            <c>Data</c>. The current modifiers are <c>t</c>, for Unicode
+            translation, and <c>l</c>, for stopping <c>p</c> and <c>P</c>
+            from detecting printable characters.</p>
         </item>
       </list>
+        <p>If <c>F</c>, <c>P</c>, or <c>Pad</c> is a <c>*</c> character,
+        the next argument in <c>Data</c> is used as the value.
+        For example:</p>
+        <pre>
+1> <input>io:fwrite("~*.*.0f~n",[9, 5, 3.14159265]).</input>
+003.14159
+ok</pre>
+        <p>To use a literal <c>*</c> character as <c>Pad</c>, it must be
+          passed as an argument:</p>
+        <pre>
+2> <input>io:fwrite("~*.*.*f~n",[9, 5, $*, 3.14159265]).</input>
+**3.14159
+ok</pre>
         <p><em>Available control sequences:</em></p>
         <taglist>
           <tag><c>~</c></tag>

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -3971,6 +3971,8 @@ extract_sequence(3, [$.,_|Fmt], Need) ->
     extract_sequence(4, Fmt, Need);
 extract_sequence(3, Fmt, Need) ->
     extract_sequence(4, Fmt, Need);
+extract_sequence(4, [$t, $l | Fmt], Need) ->
+    extract_sequence(4, [$l, $t | Fmt], Need);
 extract_sequence(4, [$t, $c | Fmt], Need) ->
     extract_sequence(5, [$c|Fmt], Need);
 extract_sequence(4, [$t, $s | Fmt], Need) ->
@@ -3987,8 +3989,14 @@ extract_sequence(4, [$t, C | _Fmt], _Need) ->
     {error,"invalid control ~t" ++ [C]};
 extract_sequence(4, [$l, $p | Fmt], Need) ->
     extract_sequence(5, [$p|Fmt], Need);
+extract_sequence(4, [$l, $t, $p | Fmt], Need) ->
+    extract_sequence(5, [$p|Fmt], Need);
 extract_sequence(4, [$l, $P | Fmt], Need) ->
     extract_sequence(5, [$P|Fmt], Need);
+extract_sequence(4, [$l, $t, $P | Fmt], Need) ->
+    extract_sequence(5, [$P|Fmt], Need);
+extract_sequence(4, [$l, $t, C | _Fmt], _Need) ->
+    {error,"invalid control ~lt" ++ [C]};
 extract_sequence(4, [$l, C | _Fmt], _Need) ->
     {error,"invalid control ~l" ++ [C]};
 extract_sequence(4, Fmt, Need) ->

--- a/lib/stdlib/src/io_lib_format.erl
+++ b/lib/stdlib/src/io_lib_format.erl
@@ -126,25 +126,23 @@ collect_cseq(Fmt0, Args0) ->
     {F,Ad,Fmt1,Args1} = field_width(Fmt0, Args0),
     {P,Fmt2,Args2} = precision(Fmt1, Args1),
     {Pad,Fmt3,Args3} = pad_char(Fmt2, Args2),
-    {Encoding,Fmt4,Args4} = encoding(Fmt3, Args3),
-    {Strings,Fmt5,Args5} = strings(Fmt4, Args4),
-    {C,As,Fmt6,Args6} = collect_cc(Fmt5, Args5),
-    FormatSpec = #{control_char => C, args => As, width => F, adjust => Ad,
-                   precision => P, pad_char => Pad, encoding => Encoding,
-                   strings => Strings},
-    {FormatSpec,Fmt6,Args6}.
+    Spec0 = #{width => F,
+              adjust => Ad,
+              precision => P,
+              pad_char => Pad,
+              encoding => latin1,
+              strings => true},
+    {Spec1,Fmt4} = modifiers(Fmt3, Spec0),
+    {C,As,Fmt5,Args4} = collect_cc(Fmt4, Args3),
+    Spec2 = Spec1#{control_char => C, args => As},
+    {Spec2,Fmt5,Args4}.
 
-encoding([$t|Fmt],Args) ->
-    true = hd(Fmt) =/= $l,
-    {unicode,Fmt,Args};
-encoding(Fmt,Args) ->
-    {latin1,Fmt,Args}.
-
-strings([$l|Fmt],Args) ->
-    true = hd(Fmt) =/= $t,
-    {false,Fmt,Args};
-strings(Fmt,Args) ->
-    {true,Fmt,Args}.
+modifiers([$t|Fmt], Spec) ->
+    modifiers(Fmt, Spec#{encoding => unicode});
+modifiers([$l|Fmt], Spec) ->
+    modifiers(Fmt, Spec#{strings => false});
+modifiers(Fmt, Spec) ->
+    {Spec, Fmt}.
 
 field_width([$-|Fmt0], Args0) ->
     {F,Fmt,Args} = field_value(Fmt0, Args0),


### PR DESCRIPTION
Currently, the t and l modifiers are not allowed at the same time. This means that unicode atoms cannot be printed at the same time as suppressing detection of printable lists:
``` 
    13> io:fwrite("~lp~n", [{[666],list_to_atom([666])}]).
    {[666],'\x{29A}'}
    14> io:fwrite("~tp~n", [{[666],list_to_atom([666])}]).
    {"ʚ",'ʚ'}
```
with this patch, you can also do:
```
    15> io:fwrite("~ltp~n", [{[666],list_to_atom([666])}]).
    {[666],'ʚ'}
```
Note: the erl_lint:extract_sequence() function could probably be completely rewritten in a simpler and nicer way using the io_lib:scan_format() functionality, but I don't have time for such things right now.