### PR TITLE
stdlib: Add function lists:search/2

### DIFF
--- a/lib/stdlib/doc/src/lists.xml
+++ b/lib/stdlib/doc/src/lists.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>1996</year><year>2017</year>
+      <year>1996</year><year>2018</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -767,6 +767,18 @@ length(lists:seq(From, To, Incr)) =:= (To - From + Incr) div Incr</code>
           <c><anno>List3</anno></c>. <c><anno>List2</anno></c> contains the
           first <c><anno>N</anno></c> elements and <c><anno>List3</anno></c>
           the remaining elements (the <c><anno>N</anno></c>th tail).</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="search" arity="2"/>
+      <fsummary>Find the first element that satisfies a predicate.</fsummary>
+      <desc>
+        <p>If there is a <c><anno>Value</anno></c> in <c><anno>List</anno></c>
+          such that <c><anno>Pred</anno>(<anno>Value</anno>)</c> returns
+          <c>true</c>, returns <c>{value, <anno>Value</anno>}</c>
+          for the first such <c><anno>Value</anno></c>,
+          otherwise returns <c>false</c>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1996-2016. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2018. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -38,8 +38,8 @@
 
 -export([all/2,any/2,map/2,flatmap/2,foldl/3,foldr/3,filter/2,
 	 partition/2,zf/2,filtermap/2,
-	 mapfoldl/3,mapfoldr/3,foreach/2,takewhile/2,dropwhile/2,splitwith/2,
-	 split/2,
+	 mapfoldl/3,mapfoldr/3,foreach/2,takewhile/2,dropwhile/2,
+         search/2, splitwith/2,split/2,
 	 join/2]).
 
 %%% BIFs
@@ -1398,6 +1398,19 @@ dropwhile(Pred, [Hd|Tail]=Rest) ->
 	false -> Rest
     end;
 dropwhile(Pred, []) when is_function(Pred, 1) -> [].
+
+-spec search(Pred, List) -> {value, Value} | false when
+      Pred :: fun((T) -> boolean()),
+      List :: [T],
+      Value :: T.
+
+search(Pred, [Hd|Tail]) ->
+    case Pred(Hd) of
+        true -> {value, Hd};
+        false -> search(Pred, Tail)
+    end;
+search(Pred, []) when is_function(Pred, 1) ->
+    false.
 
 -spec splitwith(Pred, List) -> {List1, List2} when
       Pred :: fun((T) -> boolean()),

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %% 
-%% Copyright Ericsson AB 1997-2017. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2018. All Rights Reserved.
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@
 	 filter_partition/1, 
 	 join/1,
 	 otp_5939/1, otp_6023/1, otp_6606/1, otp_7230/1,
-	 suffix/1, subtract/1, droplast/1, hof/1]).
+	 suffix/1, subtract/1, droplast/1, search/1, hof/1]).
 
 %% Sort randomized lists until stopped.
 %%
@@ -121,7 +121,7 @@ groups() ->
      {zip, [parallel], [zip_unzip, zip_unzip3, zipwith, zipwith3]},
      {misc, [parallel], [reverse, member, dropwhile, takewhile,
 			 filter_partition, suffix, subtract, join,
-			 hof, droplast]}
+			 hof, droplast, search]}
     ].
 
 init_per_suite(Config) ->
@@ -2613,6 +2613,20 @@ droplast(Config) when is_list(Config) ->
     {'EXIT', {function_clause, _}} = (catch lists:droplast([])),
     {'EXIT', {function_clause, _}} = (catch lists:droplast(x)),
 
+    ok.
+
+%% Test lists:search/2
+search(Config) when is_list(Config) ->
+    F = fun(I) -> I rem 2 =:= 0 end,
+    F2 = fun(A, B) -> A > B end,
+
+    {value, 2} = lists:search(F, [1,2,3,4]),
+    false = lists:search(F, [1,3,5,7]),
+    false = lists:search(F, []),
+
+    %% Error cases.
+    {'EXIT',{function_clause,_}} = (catch lists:search(badfun, [])),
+    {'EXIT',{function_clause,_}} = (catch lists:search(F2, [])),
     ok.
 
 %% Briefly test the common high-order functions to ensure they


### PR DESCRIPTION
This is essentially PR 102, https://github.com/erlang/otp/pull/102.

The OTP Technical Board decided to change the name of the function to
search/2.