### PR TITLE
make erlang:process_info/1 not retrieve messages

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -4881,7 +4881,6 @@ RealSystem = system + MissedSystem</code>
           <item><c>initial_call</c></item>
           <item><c>status</c></item>
           <item><c>message_queue_len</c></item>
-          <item><c>messages</c></item>
           <item><c>links</c></item>
           <item><c>dictionary</c></item>
           <item><c>trap_exit</c></item>

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -717,7 +717,6 @@ static Eterm pi_1_keys[] = {
     am_initial_call,
     am_status,
     am_message_queue_len,
-    am_messages,
     am_links,
     am_dictionary,
     am_trap_exit,

--- a/lib/common_test/src/test_server_ctrl.erl
+++ b/lib/common_test/src/test_server_ctrl.erl
@@ -5164,7 +5164,7 @@ display_info([Pid|T], R, M) ->
 			   Other
 		   end,
 	    Reds  = fetch(reductions, Info),
-	    LM = length(fetch(messages, Info)),
+	    LM = fetch(message_queue_len, Info),
 	    pformat(io_lib:format("~w", [Pid]),
 		    io_lib:format("~tw", [Call]),
 		    io_lib:format("~tw", [Curr]), Reds, LM),

--- a/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_tm.erl
+++ b/lib/dialyzer/test/r9c_SUITE_data/src/mnesia/mnesia_tm.erl
@@ -2051,7 +2051,7 @@ display_pid_info(Pid) ->
 			   Other
 		   end,
 	    Reds  = fetch(reductions, Info),
-	    LM = length(fetch(messages, Info)),
+	    LM = fetch(message_queue_len, Info),
 	    pformat(io_lib:format("~p", [Pid]),
 		    io_lib:format("~p", [Call]),
 		    io_lib:format("~p", [Curr]), Reds, LM)

--- a/lib/mnesia/src/mnesia_tm.erl
+++ b/lib/mnesia/src/mnesia_tm.erl
@@ -2212,7 +2212,7 @@ display_pid_info(Pid) ->
 			   Other
 		   end,
 	    Reds  = fetch(reductions, Info),
-	    LM = length(fetch(messages, Info)),
+	    LM = fetch(message_queue_len, Info),
 	    pformat(io_lib:format("~p", [Pid]),
 		    io_lib:format("~tp", [Call]),
 		    io_lib:format("~tp", [Curr]), Reds, LM)

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -564,7 +564,7 @@ display_info(Pid) ->
 			   Other
 		   end,
 	    Reds = fetch(reductions, Info),
-	    LM = length(fetch(messages, Info)),
+	    LM = fetch(message_queue_len, Info),
 	    HS = fetch(heap_size, Info),
 	    SS = fetch(stack_size, Info),
 	    iformat(w(Pid), mfa_string(Call),
@@ -882,7 +882,7 @@ portinfo(Id) ->
 procline(Name, Info, Pid) ->
     Call = initial_call(Info),
     Reds  = fetch(reductions, Info),
-    LM = length(fetch(messages, Info)),
+    LM = fetch(message_queue_len, Info),
     procformat(io_lib:format("~tw",[Name]),
 	       io_lib:format("~w",[Pid]),
 	       io_lib:format("~ts",[mfa_string(Call)]),


### PR DESCRIPTION
process_info/1 retrieves a number of properties related to a process,
including the list of messages in its mailbox.  This is potentially
unsafe if the target process has a large number of queued messages:

- there is no a priori upper bound on the amount of memory being
  allocated to hold that list, and
- the loop to retrieve the messages is uninterruptible, so the
  Erlang scheduler where this executes blocks for the duration

We've seen process_info/1 bring down heavily loaded nodes on more
than one occasion.  At least once it appeared to have blocked the
Erlang heart process from executing, causing the external heart to
kill the VM.

Consequently this removes 'messages' from the list of process_info
tags to retrieve for process_info/1.  Note that process_info/1 still
retrieves 'message_queue_len', and process_info/2 can still retrieve
'messages' when asked to.

A few places in the OTP libraries need minor adjustments, since they
want 'message_queue_len' but compute it from the length of the list
of messages.