### PR TITLE
inets: fix profile used in persistent_connection tests in httpc_SUITE

### DIFF
--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -227,7 +227,7 @@ init_per_testcase(pipeline, Config) ->
 init_per_testcase(persistent_connection, Config) ->
     inets:start(httpc, [{profile, persistent}]),
     httpc:set_options([{keep_alive_timeout, 50000},
-		       {max_keep_alive_length, 3}], persistent_connection),
+		       {max_keep_alive_length, 3}], persistent),
 
     Config;
 init_per_testcase(wait_for_whole_response, Config) ->


### PR DESCRIPTION
I see no impact for this in tests at the moment though it looks like a typo.