### PR TITLE
Teach httpc to honour server connection close

### DIFF
--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -312,8 +312,7 @@
         <v>Body = string() | binary()</v>
         <v>Profile = profile() | pid()</v>
 	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-        <v>Reason = {connect_failed, term()} | 
-                    {send_failed, term()} | term()</v>
+        <v>Reason = term()</v>
       </type>
 
       <desc>

--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -253,8 +253,9 @@ handle_call(Request, From, State) ->
 	Result ->
 	    Result
     catch
-	_:Reason ->
-	    {stop, {shutdown, Reason} , State}
+	Class:Reason ->
+            ST = erlang:get_stacktrace(),
+	    {stop, {shutdown, {{Class, Reason}, ST}}, State}
     end.		
 
 
@@ -269,8 +270,9 @@ handle_cast(Msg, State) ->
 	Result ->
 	    Result
     catch
-	_:Reason ->
-	    {stop, {shutdown, Reason} , State}
+	Class:Reason ->
+            ST = erlang:get_stacktrace(),
+	    {stop, {shutdown, {{Class, Reason}, ST}}, State}
     end.		
 
 %%--------------------------------------------------------------------
@@ -284,8 +286,9 @@ handle_info(Info, State) ->
 	Result ->
 	    Result
     catch
-	_:Reason ->
-	    {stop, {shutdown, Reason} , State}
+	Class:Reason ->
+            ST = erlang:get_stacktrace(),
+	    {stop, {shutdown, {{Class, Reason}, ST}}, State}
     end.		
 
 %%--------------------------------------------------------------------
@@ -569,11 +572,12 @@ do_handle_info({Proto, _Socket, Data},
 	    activate_once(Session),
 	    {noreply, State#state{mfa = NewMFA}}
     catch
-	_:Reason ->
+	Class:Reason ->
+            ST = erlang:get_stacktrace(),
 	    ClientReason = {could_not_parse_as_http, Data}, 
 	    ClientErrMsg = httpc_response:error(Request, ClientReason),
 	    NewState     = answer_request(Request, ClientErrMsg, State),
-	    {stop, {shutdown, Reason}, NewState}
+	    {stop, {shutdown, {{Class, Reason}, ST}}, NewState}
     end;
 
 do_handle_info({Proto, Socket, Data}, 

--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -48,12 +48,10 @@
           queue_timer         :: reference() | 'undefined'
          }).
 
--type session_failed() :: {'connect_failed',term()} | {'send_failed',term()}.
-
 -record(state, 
         {
           request                   :: request() | 'undefined',
-          session                   :: session() | session_failed() | 'undefined',
+          session                   :: session() | 'undefined',
           status_line,               % {Version, StatusCode, ReasonPharse}
           headers                   :: http_response_h() | 'undefined',
           body                      :: binary() | 'undefined',
@@ -294,23 +292,6 @@ handle_info(Info, State) ->
 %% Function: terminate(Reason, State) -> _  (ignored by gen_server)
 %% Description: Shutdown the httpc_handler
 %%--------------------------------------------------------------------
-
-%% Init error there is no socket to be closed.
-terminate(normal, 
-          #state{request = Request, 
-                 session = {send_failed, _} = Reason} = State) ->
-    maybe_send_answer(Request, 
-                      httpc_response:error(Request, Reason), 
-                      State),
-    ok; 
-
-terminate(normal, 
-          #state{request = Request, 
-                 session = {connect_failed, _} = Reason} = State) ->
-    maybe_send_answer(Request, 
-                      httpc_response:error(Request, Reason), 
-                      State),
-    ok; 
 
 terminate(normal, #state{session = undefined}) ->
     ok;  

--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -58,7 +58,7 @@
           mfa,                       % {Module, Function, Args}
           pipeline = queue:new()    :: queue:queue(),
           keep_alive = queue:new()  :: queue:queue(),
-          status,   % undefined | new | pipeline | keep_alive | close | {ssl_tunnel, Request}
+          status                    :: undefined | new | pipeline | keep_alive | close | {ssl_tunnel, request()},
           canceled = [],             % [RequestId]
           max_header_size = nolimit :: nolimit | integer(),
           max_body_size = nolimit   :: nolimit | integer(),

--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -253,8 +253,7 @@ handle_call(Request, From, State) ->
 	Result ->
 	    Result
     catch
-	Class:Reason ->
-            ST = erlang:get_stacktrace(),
+	Class:Reason:ST ->
 	    {stop, {shutdown, {{Class, Reason}, ST}}, State}
     end.		
 
@@ -270,8 +269,7 @@ handle_cast(Msg, State) ->
 	Result ->
 	    Result
     catch
-	Class:Reason ->
-            ST = erlang:get_stacktrace(),
+	Class:Reason:ST ->
 	    {stop, {shutdown, {{Class, Reason}, ST}}, State}
     end.		
 
@@ -286,8 +284,7 @@ handle_info(Info, State) ->
 	Result ->
 	    Result
     catch
-	Class:Reason ->
-            ST = erlang:get_stacktrace(),
+	Class:Reason:ST ->
 	    {stop, {shutdown, {{Class, Reason}, ST}}, State}
     end.		
 
@@ -572,8 +569,7 @@ do_handle_info({Proto, _Socket, Data},
 	    activate_once(Session),
 	    {noreply, State#state{mfa = NewMFA}}
     catch
-	Class:Reason ->
-            ST = erlang:get_stacktrace(),
+	Class:Reason:ST ->
 	    ClientReason = {could_not_parse_as_http, Data}, 
 	    ClientErrMsg = httpc_response:error(Request, ClientReason),
 	    NewState     = answer_request(Request, ClientErrMsg, State),

--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -83,7 +83,6 @@ whole_body(Body, Length) ->
 %% result(Response, Request) ->
 %%   Response - {StatusLine, Headers, Body}
 %%   Request - #request{}
-%%   Session - #tcp_session{}
 %%                                   
 %% Description: Checks the status code ...
 %%-------------------------------------------------------------------------

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -269,7 +269,7 @@ end_per_testcase(Case, Config)
                        {failed, _} -> true;
                        {skipped, _} -> false
                    end,
-    if ShallCleanup ->
+    if ShallCleanup =:= true ->
             httpc:request(url(group_name(Config), "/just_close.html", Config)),
             ok;
        true ->

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -233,7 +233,7 @@ init_per_testcase(pipeline, Config) ->
 init_per_testcase(persistent_connection, Config) ->
     inets:start(httpc, [{profile, persistent}]),
     httpc:set_options([{keep_alive_timeout, 50000},
-		       {max_keep_alive_length, 3}], persistent_connection),
+		       {max_keep_alive_length, 3}], persistent),
 
     Config;
 init_per_testcase(wait_for_whole_response, Config) ->


### PR DESCRIPTION
I experienced intermittent `socket_closed_remotely` errors in tests using httpc as client. I managed to reproduce re-attempting same request multiple times (sometimes failing after a few hundred requests, sometimes after a handful of requests). I traced the HTTP and TCP traffic while reproducing symptom, and I narrowed the trace down to a `Connection: close` by the server not being honoured by httpc. I then wrote an isolated test for httpc - in this PR - confirming my diagnosis. I wrote a patch for httpc and tested it (with the httpc_SUITE).

I noticed there are some hits searching on the Web for `socket_closed_remotely` using httpc, and the relevant reference is https://bugs.erlang.org/browse/ERL-473 . Though, even if symptom is the same, I am not sure this is the same issue.

I am basing on maint - and not on master - as I read that support for `Connection: close` from server is MUST(please refer to commit message for details). If you prefer me to base on master please let me know.