### PR TITLE
[stdlib/sys.erl] Fix sys module's debug statistics not including the out message count when using gen_server:call/2.

### DIFF
--- a/lib/stdlib/doc/src/sys.xml
+++ b/lib/stdlib/doc/src/sys.xml
@@ -102,7 +102,7 @@
       then treated in the debug function. For example, <c>trace</c>
       formats the system events to the terminal.
       </p>
-    <p>Three predefined system events are used when a
+    <p>Four predefined system events are used when a
       process receives or sends a message. The process can also define its
       own system events. It is always up to the process itself
       to format these events.</p>

--- a/lib/stdlib/src/sys.erl
+++ b/lib/stdlib/src/sys.erl
@@ -44,6 +44,7 @@
 -type system_event() :: {'in', Msg :: _}
                       | {'in', Msg :: _, From :: _}
                       | {'out', Msg :: _, To :: _}
+                      | {'out', Msg :: _, To :: _, State :: _}
                         | term().
 -opaque dbg_opt()    :: {'trace', 'true'}
                       | {'log',
@@ -573,6 +574,7 @@ get_stat(_) ->
 stat({in, _Msg}, {Time, Reds, In, Out}) -> {Time, Reds, In+1, Out};
 stat({in, _Msg, _From}, {Time, Reds, In, Out}) -> {Time, Reds, In+1, Out};
 stat({out, _Msg, _To}, {Time, Reds, In, Out}) -> {Time, Reds, In, Out+1};
+stat({out, _Msg, _To, _State}, {Time, Reds, In, Out}) -> {Time, Reds, In, Out+1};
 stat(_, StatData) -> StatData.
 
 trim(N, LogData) ->

--- a/lib/stdlib/test/sys_SUITE.erl
+++ b/lib/stdlib/test/sys_SUITE.erl
@@ -84,7 +84,7 @@ stats(Config) when is_list(Config) ->
     {ok,-44} = public_call(44),
     {ok,Stats} = sys:statistics(?server,get),
     true = lists:member({messages_in,1}, Stats),
-    true = lists:member({messages_out,0}, Stats),
+    true = lists:member({messages_out,1}, Stats),
     ok = sys:statistics(?server,false),
     {status,_Pid,{module,_Mod},[_PDict,running,Self,_,_]} =
 	sys:get_status(?server),

--- a/system/doc/design_principles/spec_proc.xml
+++ b/system/doc/design_principles/spec_proc.xml
@@ -312,7 +312,7 @@ sys:handle_debug(Deb, Func, Info, Event) => Deb1</code>
             define what a system event is and how it is to be
             represented. Typically at least incoming and outgoing
             messages are considered system events and represented by
-            the tuples <c>{in,Msg[,From]}</c> and <c>{out,Msg,To}</c>,
+            the tuples <c>{in,Msg[,From]}</c> and <c>{out,Msg,To[,State]}</c>,
             respectively.</item>
       </list>
       <p><c>handle_debug</c> returns an updated debug structure


### PR DESCRIPTION
Currently, in sys:stat/2, the message out only count for system events with format `{out,
Msg, To}`. However, the gen_server:reply/5 will call sys:handle_debug/4
with format `{out, Reply, To, State}`. That will make the message out
count fail to pattern matching.

Here's the bug repro step:

```
-module(foo).
-behavior(gen_server).

-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).

init(_) -> {ok, []}.
handle_call(_, _, State) -> {reply, ok, State}.
handle_cast(_, State) -> {noreply, State}.
handle_info(_, State) -> {noreply, State}.
```

```
Erlang/OTP 20 [erts-9.2] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Eshell V9.2  (abort with ^G)
1> {ok, Pid} = gen_server:start(foo, [], []).
{ok,<0.66.0>}
2> sys:trace(Pid, true).
ok
3> sys:statistics(Pid, true).
ok
4> gen_server:call(Pid, 1).
*DBG* <0.66.0> got call 1 from <0.64.0>
*DBG* <0.66.0> sent ok to <0.64.0>, new state []
ok
5> sys:statistics(Pid, get).
{ok,[{start_time,{{2018,3,22},{20,24,38}}},
     {current_time,{{2018,3,22},{20,24,46}}},
     {reductions,96},
     {messages_in,1},
     {messages_out,0}]}
```

The `{message_out,0}` should be `{message_out,1}` as the gen_server process do send a reply back.

I'm not sure if this is the desire behavior, or the message_out is suppose to be 0 even if it does a gen_server reply. Please take a look. Thanks!