### PR TITLE
Lift the type restrictions on seq_trace token labels

### DIFF
--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -45,7 +45,8 @@
 #define DFLAG_MAP_TAG             0x20000
 #define DFLAG_BIG_CREATION        0x40000
 #define DFLAG_SEND_SENDER         0x80000
-#define DFLAG_NO_MAGIC            0x100000 /* internal for pending connection */
+#define DFLAG_BIG_SEQTRACE_LABELS 0x100000
+#define DFLAG_NO_MAGIC            0x200000 /* internal for pending connection */
 
 /* Mandatory flags for distribution */
 #define DFLAG_DIST_MANDATORY (DFLAG_EXTENDED_REFERENCES         \
@@ -73,7 +74,8 @@
                             | DFLAG_UTF8_ATOMS                \
                             | DFLAG_MAP_TAG                   \
                             | DFLAG_BIG_CREATION              \
-                            | DFLAG_SEND_SENDER)
+                            | DFLAG_SEND_SENDER               \
+                            | DFLAG_BIG_SEQTRACE_LABELS)
 
 /* Flags addable by local distr implementations */
 #define DFLAG_DIST_ADDABLE    DFLAG_DIST_DEFAULT

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -1807,9 +1807,6 @@ Eterm erts_seq_trace(Process *p, Eterm arg1, Eterm arg2,
 	return old_value;
     }
     else if (arg1 == am_label) {
-	if (! is_small(arg2)) {
-	    return THE_NON_VALUE;
-	}
         new_seq_trace_token(p);
 	if (build_result) {
 	    old_value = SEQ_TRACE_TOKEN_LABEL(p);

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -2508,25 +2508,20 @@ restart:
             if (have_no_seqtrace(SEQ_TRACE_TOKEN(c_p)))
 		*esp++ = NIL;
 	    else {
-		Eterm sender = SEQ_TRACE_TOKEN_SENDER(c_p);
-		Uint sender_sz = is_immed(sender) ? 0 : size_object(sender);
-		ehp = HAllocX(build_proc, 6 + sender_sz, HEAP_XTRA);
-		if (sender_sz) {
-		    sender = copy_struct(sender, sender_sz, &ehp, &MSO(build_proc));
-		}
- 		*esp++ = make_tuple(ehp);
- 		ehp[0] = make_arityval(5);
- 		ehp[1] = SEQ_TRACE_TOKEN_FLAGS(c_p);
- 		ehp[2] = SEQ_TRACE_TOKEN_LABEL(c_p);
- 		ehp[3] = SEQ_TRACE_TOKEN_SERIAL(c_p);
-		ehp[4] = sender;
- 		ehp[5] = SEQ_TRACE_TOKEN_LASTCNT(c_p);
-		ASSERT(SEQ_TRACE_TOKEN_ARITY(c_p) == 5);
-		ASSERT(is_immed(ehp[1]));
-		ASSERT(is_immed(ehp[2]));
-		ASSERT(is_immed(ehp[3]));
-		ASSERT(is_immed(ehp[5]));
-	    } 
+                Eterm token;
+                Uint token_sz;
+
+                ASSERT(SEQ_TRACE_TOKEN_ARITY(c_p) == 5);
+                ASSERT(is_immed(SEQ_TRACE_TOKEN_FLAGS(c_p)));
+                ASSERT(is_immed(SEQ_TRACE_TOKEN_SERIAL(c_p)));
+                ASSERT(is_immed(SEQ_TRACE_TOKEN_LASTCNT(c_p)));
+
+                token = SEQ_TRACE_TOKEN(c_p);
+                token_sz = size_object(token);
+
+                ehp = HAllocX(build_proc, token_sz, HEAP_XTRA);
+                *esp++ = copy_struct(token, token_sz, &ehp, &MSO(build_proc));
+	    }
 	    break;
         case matchEnableTrace:
             ASSERT(c_p == self);

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -315,7 +315,7 @@ erts_queue_dist_message(Process *rcvr,
 
             dtrace_proc_str(rcvr, receiver_name);
             if (have_seqtrace(token)) {
-                tok_label = signed_val(SEQ_TRACE_T_LABEL(token));
+                tok_label = SEQ_TRACE_T_DTRACE_LABEL(token);
                 tok_lastcnt = signed_val(SEQ_TRACE_T_LASTCNT(token));
                 tok_serial = signed_val(SEQ_TRACE_T_SERIAL(token));
             }
@@ -640,7 +640,8 @@ erts_send_message(Process* sender,
 	    seq_trace_update_send(sender);
 	    seq_trace_output(stoken, message, SEQ_TRACE_SEND,
 			     receiver->common.id, sender);
-	    seq_trace_size = 6; /* TUPLE5 */
+
+	    seq_trace_size = size_object(stoken);
 	}
 #ifdef USE_VM_PROBES
         if (DT_UTAG_FLAGS(sender) & DT_UTAG_SPREADING) {
@@ -689,7 +690,7 @@ erts_send_message(Process* sender,
 	}
         if (DTRACE_ENABLED(message_send)) {
             if (have_seqtrace(stoken)) {
-		tok_label = signed_val(SEQ_TRACE_T_LABEL(stoken));
+                tok_label = SEQ_TRACE_T_DTRACE_LABEL(stoken);
 		tok_lastcnt = signed_val(SEQ_TRACE_T_LASTCNT(stoken));
 		tok_serial = signed_val(SEQ_TRACE_T_SERIAL(stoken));
 	    }

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -3069,7 +3069,7 @@ handle_message_enqueued_tracing(Process *c_p,
         Eterm seq_trace_token = ERL_MESSAGE_TOKEN(msg);
 
         if (seq_trace_token != NIL && is_tuple(seq_trace_token)) {
-            tok_label = signed_val(SEQ_TRACE_T_LABEL(seq_trace_token));
+            tok_label = SEQ_TRACE_T_DTRACE_LABEL(seq_trace_token);
             tok_lastcnt = signed_val(SEQ_TRACE_T_LASTCNT(seq_trace_token));
             tok_serial = signed_val(SEQ_TRACE_T_SERIAL(seq_trace_token));
         }

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1250,7 +1250,24 @@ void erts_check_for_holes(Process* p);
 #define SEQ_TRACE_T_SENDER(token)   (*(tuple_val(token) + 4))
 #define SEQ_TRACE_T_LASTCNT(token)  (*(tuple_val(token) + 5))
 
+#ifdef USE_VM_PROBES
+/* The dtrace probe for seq_trace only supports 'int' labels, so we represent
+ * all values that won't fit into a 32-bit signed integer as ERTS_SINT32_MIN
+ * (bigints, tuples, etc). */
+
+#define SEQ_TRACE_T_DTRACE_LABEL(token) \
+    DTRACE_SEQ_TRACE_LABEL__(SEQ_TRACE_T_LABEL(token))
+
+#define DTRACE_SEQ_TRACE_LABEL__(label_term) \
+    (is_small((label_term)) ? \
+        ((signed_val((label_term)) <= ERTS_SINT32_MAX && \
+          signed_val((label_term)) >= ERTS_SINT32_MIN) ? \
+             signed_val((label_term)) : ERTS_SINT32_MIN) \
+        : ERTS_SINT32_MIN)
+#endif
+
 /*
+
  * Possible flags for the flags field in ErlSpawnOpts below.
  */
 

--- a/erts/emulator/beam/erlang_dtrace.d
+++ b/erts/emulator/beam/erlang_dtrace.d
@@ -55,7 +55,8 @@ provider erlang {
      * @param sender the PID (string form) of the sender
      * @param receiver the PID (string form) of the receiver
      * @param size the size of the message being delivered (words)
-     * @param token_label for the sender's sequential trace token
+     * @param token_label for the sender's sequential trace token. This will be
+     *        INT_MIN if the label does not fit into a 32-bit integer.
      * @param token_previous count for the sender's sequential trace token
      * @param token_current count for the sender's sequential trace token
      */
@@ -73,7 +74,8 @@ provider erlang {
      * @param node_name the Erlang node name (string form) of the receiver
      * @param receiver the PID/name (string form) of the receiver
      * @param size the size of the message being delivered (words)
-     * @param token_label for the sender's sequential trace token
+     * @param token_label for the sender's sequential trace token. This will be
+     *        INT_MIN if the label does not fit into a 32-bit integer.
      * @param token_previous count for the sender's sequential trace token
      * @param token_current count for the sender's sequential trace token
      */
@@ -98,7 +100,8 @@ provider erlang {
      * @param receiver the PID (string form) of the receiver
      * @param size the size of the message being delivered (words)
      * @param queue_len length of the queue of the receiving process
-     * @param token_label for the sender's sequential trace token
+     * @param token_label for the sender's sequential trace token. This will be
+     *        INT_MIN if the label does not fit into a 32-bit integer.
      * @param token_previous count for the sender's sequential trace token
      * @param token_current count for the sender's sequential trace token
      */
@@ -122,7 +125,8 @@ provider erlang {
      * @param receiver the PID (string form) of the receiver
      * @param size the size of the message being delivered (words)
      * @param queue_len length of the queue of the receiving process
-     * @param token_label for the sender's sequential trace token
+     * @param token_label for the sender's sequential trace token. This will be
+     *        INT_MIN if the label does not fit into a 32-bit integer.
      * @param token_previous count for the sender's sequential trace token
      * @param token_current count for the sender's sequential trace token
      */
@@ -273,7 +277,8 @@ provider erlang {
      * @param node_name the Erlang node name (string form) of the receiver
      * @param receiver the PID (string form) of the process receiving EXIT signal
      * @param reason the reason for the exit (may be truncated)
-     * @param token_label for the sender's sequential trace token
+     * @param token_label for the sender's sequential trace token. This will be
+     *        INT_MIN if the label does not fit into a 32-bit integer.
      * @param token_previous count for the sender's sequential trace token
      * @param token_current count for the sender's sequential trace token
      */

--- a/erts/emulator/beam/msg_instrs.tab
+++ b/erts/emulator/beam/msg_instrs.tab
@@ -229,7 +229,7 @@ remove_message() {
         dtrace_proc_str(c_p, receiver_name);
         token2 = SEQ_TRACE_TOKEN(c_p);
         if (have_seqtrace(token2)) {
-            tok_label = signed_val(SEQ_TRACE_T_LABEL(token2));
+            tok_label = SEQ_TRACE_T_DTRACE_LABEL(token2);
             tok_lastcnt = signed_val(SEQ_TRACE_T_LASTCNT(token2));
             tok_serial = signed_val(SEQ_TRACE_T_SERIAL(token2));
         }

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -366,29 +366,11 @@ typedef UWord BeamInstr;
 #    define HAVE_INT64 1
 typedef unsigned long Uint64;
 typedef long          Sint64;
-#    ifdef ULONG_MAX
-#      define ERTS_UINT64_MAX ULONG_MAX
-#    endif
-#    ifdef LONG_MAX
-#      define ERTS_SINT64_MAX LONG_MAX
-#    endif
-#    ifdef LONG_MIN
-#      define ERTS_SINT64_MIN LONG_MIN
-#    endif
 #    define ErtsStrToSint64 strtol
 #  elif SIZEOF_LONG_LONG == 8
 #    define HAVE_INT64 1
 typedef unsigned long long Uint64;
 typedef long long          Sint64;
-#    ifdef ULLONG_MAX
-#      define ERTS_UINT64_MAX ULLONG_MAX
-#    endif
-#    ifdef LLONG_MAX
-#      define ERTS_SINT64_MAX LLONG_MAX
-#    endif
-#    ifdef LLONG_MIN
-#      define ERTS_SINT64_MIN LLONG_MIN
-#    endif
 #    define ErtsStrToSint64 strtoll
 #  else
 #    error "No 64-bit integer type found"
@@ -402,7 +384,7 @@ typedef long long          Sint64;
 #  define ERTS_SINT64_MAX ((Sint64) ((((Uint64) 1) << 63)-1))
 #endif
 #ifndef ERTS_SINT64_MIN
-#  define ERTS_SINT64_MIN (-1*(((Sint64) 1) << 63))
+#  define ERTS_SINT64_MIN ((Sint64) ((((Uint64) 1) << 63)))
 #endif
 
 #if SIZEOF_LONG == 4
@@ -415,6 +397,16 @@ typedef int          Sint32;
 #error Found no appropriate type to use for 'Uint32' and 'Sint32'
 #endif
 
+#ifndef ERTS_UINT32_MAX
+#  define ERTS_UINT32_MAX (~((Uint32) 0))
+#endif
+#ifndef ERTS_SINT32_MAX
+#  define ERTS_SINT32_MAX ((Sint32) ((((Uint32) 1) << 31)-1))
+#endif
+#ifndef ERTS_SINT32_MIN
+#  define ERTS_SINT32_MIN ((Sint32) ((((Uint32) 1) << 31)))
+#endif
+
 #if SIZEOF_INT == 2
 typedef unsigned int Uint16;
 typedef int          Sint16;
@@ -423,6 +415,16 @@ typedef unsigned short Uint16;
 typedef short          Sint16;
 #else
 #error Found no appropriate type to use for 'Uint16' and 'Sint16'
+#endif
+
+#ifndef ERTS_UINT16_MAX
+#  define ERTS_UINT16_MAX (~((Uint16) 0))
+#endif
+#ifndef ERTS_SINT16_MAX
+#  define ERTS_SINT16_MAX ((Sint16) ((((Uint16) 1) << 15)-1))
+#endif
+#ifndef ERTS_SINT16_MIN
+#  define ERTS_SINT16_MIN ((Sint16) ((((Uint16) 1) << 15)))
 #endif
 
 #if CHAR_BIT == 8

--- a/lib/kernel/doc/src/seq_trace.xml
+++ b/lib/kernel/doc/src/seq_trace.xml
@@ -80,13 +80,18 @@ seq_trace:set_token(OldToken), % activate the trace token again
         <p>Sets the individual <c><anno>Component</anno></c> of the trace token to
           <c><anno>Val</anno></c>. Returns the previous value of the component.</p>
         <taglist>
-          <tag><c>set_token(label, <anno>Integer</anno>)</c></tag>
+          <tag><c>set_token(label, <anno>Label</anno>)</c></tag>
           <item>
-            <p>The <c>label</c> component is an integer which
+            <p>The <c>label</c> component is a term which
               identifies all events belonging to the same sequential
               trace. If several sequential traces can be active
               simultaneously, <c>label</c> is used to identify
               the separate traces. Default is 0.</p>
+            <warning>
+              <p>Labels were restricted to small signed integers (28 bits)
+                prior to OTP 21. The trace token will be silenty dropped if it
+                crosses over to a node that does not support the label.</p>
+            </warning>
           </item>
           <tag><c>set_token(serial, SerialValue)</c></tag>
           <item>

--- a/lib/kernel/include/dist.hrl
+++ b/lib/kernel/include/dist.hrl
@@ -41,6 +41,7 @@
 -define(DFLAG_MAP_TAG, 16#20000).
 -define(DFLAG_BIG_CREATION, 16#40000).
 -define(DFLAG_SEND_SENDER, 16#80000).
+-define(DFLAG_BIG_SEQTRACE_LABELS, 16#100000).
 
 %% Also update dflag2str() in ../src/dist_util.erl
 %% when adding flags...

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -113,6 +113,8 @@ dflag2str(?DFLAG_BIG_CREATION) ->
     "BIG_CREATION";
 dflag2str(?DFLAG_SEND_SENDER) ->
     "SEND_SENDER";
+dflag2str(?DFLAG_BIG_SEQTRACE_LABELS) ->
+    "BIG_SEQTRACE_LABELS";
 dflag2str(_) ->
     "UNKNOWN".
 

--- a/lib/kernel/src/seq_trace.erl
+++ b/lib/kernel/src/seq_trace.erl
@@ -41,7 +41,7 @@
 
 -type flag()       :: 'send' | 'receive' | 'print' | 'timestamp' | 'monotonic_timestamp' | 'strict_monotonic_timestamp'.
 -type component()  :: 'label' | 'serial' | flag().
--type value()      :: (Integer :: non_neg_integer())
+-type value()      :: (Label :: term())
                     | {Previous :: non_neg_integer(),
                        Current :: non_neg_integer()}
                     | (Bool :: boolean()).
@@ -58,10 +58,6 @@ set_token([]) ->
 set_token({Flags,Label,Serial,_From,Lastcnt}) ->
     F = decode_flags(Flags),
     set_token2([{label,Label},{serial,{Lastcnt, Serial}} | F]).
-
-%% We limit the label type to always be a small integer because erl_interface
-%% expects that, the BIF can however "unofficially" handle atoms as well, and
-%% atoms can be used if only Erlang nodes are involved
 
 -spec set_token(Component, Val) -> {Component, OldVal} when
       Component :: component(),


### PR DESCRIPTION
This PR allows the use of any term as a `seq_trace` token label, making it easier to use this functionality in concert with tracing libraries like OpenCensus and OpenTracing that use very large identifiers.

This also fixes a crash when a label that did not fit into an immediate on a 32-bit emulator was sent from a 64-bit emulator to a 32-bit one.

http://erlang.org/pipermail/erlang-questions/2018-January/094638.html
@tsloughter