### PR TITLE
Fix HiPE build for FreeBSD

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2871,8 +2871,11 @@ AC_CHECK_PROG(M4, m4, m4)
 if test X${enable_hipe} != Xno; then
     if test X$ac_cv_sizeof_void_p != X4 && test X$ARCH = Xamd64; then
         dnl HiPE cannot run on x86_64 without MAP_FIXED and MAP_NORESERVE
+        dnl - but don't require MAP_NORESERVE on FreeBSD,
+        dnl see emulator/sys/common/erl_mmap.h
 	AC_CHECK_DECLS([MAP_FIXED, MAP_NORESERVE], [], [], [#include <sys/mman.h>])
-	if test X$ac_cv_have_decl_MAP_FIXED != Xyes || test X$ac_cv_have_decl_MAP_NORESERVE != Xyes; then
+	if test X$ac_cv_have_decl_MAP_FIXED != Xyes || \
+            (test X$ac_cv_have_decl_MAP_NORESERVE != Xyes && $OPSYS != freebsd); then
 	    if test X${enable_hipe} = Xyes; then
 	        AC_MSG_ERROR([HiPE on x86_64 needs MAP_FIXED and MAP_NORESERVE flags for mmap()])
 	    else

--- a/erts/emulator/drivers/unix/unix_efile.c
+++ b/erts/emulator/drivers/unix/unix_efile.c
@@ -23,7 +23,11 @@
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
 #endif
-#if defined(HAVE_POSIX_FALLOCATE) && !defined(__sun) && !defined(__sun__)
+#if defined(HAVE_POSIX_FALLOCATE) && !defined(__sun) && !defined(__sun__) && !defined(__FreeBSD__)
+/*
+ * On FreeBSD, we must leave _XOPEN_SOURCE undefined in order for the prototype
+ * of finite() (potentially used in sys/unix/erl_unix_sys.h) to be included.
+ */
 #define _XOPEN_SOURCE 600
 #endif
 #if !defined(_GNU_SOURCE) && defined(HAVE_LINUX_FALLOC_H)


### PR DESCRIPTION
FreeBSD used to define a MAP_NORESERVE that didn't do anything, but this
has been removed in current versions. While building HiPE on a FreeBSD
version without MAP_NORESERVE worked fine in 18.3.4, it fails in
configure for 20.2.3. Looking at the "maint" branch, it seems that
between these versions, commit 6c5277b1543 removed the requirement (that
apparently wasn't an actual requirement in 18) for MAP_NORESERVE on
FreeBSD in erts/emulator/sys/common/erl_mmap.h, and commit 03b00985c18
added the requirement in erts/configure.in. The change to configure.in
makes it consistent with erl_mmap.h.

Building on FreeBSD (with gcc) revealed another problem, not present
with HiPE enabled in 18 nor with HiPE disabled in 20: the compilation of
erts/emulator/drivers/unix/unix_efile.c fails due to a missing prototype
for finite(). The prototype isn't actually missing, but is hidden due to
the definition of _XOPEN_SOURCE in unix_efile.c (in 18 with HiPE
enabled, this generated a warning, but it causes failure due to the use
of -Werror=implicit in 20). To fix this, unix_efile.c was changed to
leave _XOPEN_SOURCE undefined also for FreeBSD.

As test case, build on e.g. FreeBSD 11.1 with gcc and --enable-hipe.