### PR TITLE
stdlib(sys): install one debug function more times & fix bug

### DIFF
--- a/lib/stdlib/doc/src/sys.xml
+++ b/lib/stdlib/doc/src/sys.xml
@@ -265,8 +265,8 @@
     </func>
 
     <func>
-      <name name="install" arity="2"/>
-      <name name="install" arity="3"/>
+      <name name="install" arity="4"/>
+      <name name="install" arity="5"/>
       <fsummary>Install a debug function in the process.</fsummary>
       <desc>
         <p>Enables installation of alternative debug functions. An example of
@@ -330,7 +330,7 @@
       <fsummary>Remove a debug function from the process.</fsummary>
       <desc>
         <p>Removes an installed debug function from the
-          process. <c><anno>Func</anno></c> must be the same as previously
+          process. <c><anno>FuncId</anno></c> must be the same as previously
           installed.</p>
       </desc>
     </func>

--- a/lib/stdlib/src/sys.erl
+++ b/lib/stdlib/src/sys.erl
@@ -363,16 +363,12 @@ mfa(Name, Req, Timeout) ->
 
 %%--------------------------------------------------------------------------------------------------
 %% Func: handle_system_msg/6
-%% Purpose: Used by a process module that wishes to take care of
-%%          system messages.  The process receives a {system, From,
-%%          Msg} message, and passes the Msg to this function.
-%% Returns: This function *never* returns! It calls the function
-%%          Module:system_continue(Parent, NDebug, Misc)
-%%          there the process continues the execution or
-%%          Module:system_terminate(Reason, Parent, Debug, Misc) if
-%%          the process should terminate.
-%%          The Module must export system_continue/3, system_terminate/4
-%%          and format_status/2 for status information.
+%% Purpose: Used by a process module that wishes to take care of system messages.  The process
+%%          receives a {system, From, Msg} message, and passes the Msg to this function.
+%% Returns: This function *never* returns! It calls the function Module:system_continue(Parent,
+%%          NDebug, Misc) there the process continues the execution or Module:system_terminate(
+%%          Reason, Parent, Debug, Misc) if the process should terminate. The Module must export
+%%          system_continue/3, system_terminate/4 and format_status/2 for status information.
 %%--------------------------------------------------------------------------------------------------
 -spec handle_system_msg(Msg, From, Parent, Module, Debug, Misc) -> no_return() when
     Msg    :: term(),
@@ -402,8 +398,8 @@ handle_system_msg(SysState, Msg, From, Parent, Mod, Debug, Misc, Hib) ->
 
 %%--------------------------------------------------------------------------------------------------
 %% Func: handle_debug/4
-%% Purpose: Called by a process that wishes to debug an event.
-%%          Func is a formatting function, called as Func(Device, Event).
+%% Purpose: Called by a process that wishes to debug an event. Func is a formatting function, called
+%%          as Func(Device, Event).
 %% Returns: [debug_opts()]
 %%--------------------------------------------------------------------------------------------------
 -spec handle_debug(Debug, FormFunc, Extra, Event) -> [dbg_opt()] when
@@ -436,8 +432,7 @@ handle_debug([], _FormFunc, _State, _Event) ->
     [].
 
 %%--------------------------------------------------------------------------------------------------
-%% When a process is suspended, it can only respond to system
-%% messages.
+%% When a process is suspended, it can only respond to system messages.
 %%--------------------------------------------------------------------------------------------------
 suspend_loop(SysState, Parent, Mod, Debug, Misc, Hib) ->
     case Hib of
@@ -534,10 +529,13 @@ get_status(SysState, Parent, Mod, Debug, Misc) ->
 
 %%--------------------------------------------------------------------------------------------------
 %% These are the system debug commands.
-%% {trace,       true|false} -> io:format
-%% {log,         true|false|get|print} -> keeps the 10 last debug messages
-%% {log_to_file, FileName | false} -> io:format to file.
-%% {statistics,  true|false|get}   -> keeps track of messages in/out + reds.
+%% {trace,       true|false}                  -> io:format
+%% {log,         true|false|get|print}        -> keeps the 10 last debug messages
+%% {log_to_file, FileName | false}            -> io:format to file.
+%% {statistics,  true|false|get}              -> keeps track of messages in/out + reds.
+%% no_debug                                   -> Removes all debug commands.
+%% {install,     {FuncId, {Func, FuncState}}} -> Installs debug function.
+%% {remove,      FuncId}                      -> removes debug function.
 %%--------------------------------------------------------------------------------------------------
 debug_cmd({trace, true}, Debug) ->
     {ok, install_debug(trace, true, Debug)};
@@ -681,9 +679,8 @@ close_log_file(Debug) ->
 
 %%--------------------------------------------------------------------------------------------------
 %% Func: debug_options/1
-%% Purpose: Initiate a debug structure.  Called by a process that
-%%          wishes to initiate the debug structure without the
-%%          system messages.
+%% Purpose: Initiate a debug structure.  Called by a process that wishes to initiate the debug
+%%          structure without the system messages.
 %% Returns: [debug_opts()]
 %%--------------------------------------------------------------------------------------------------
 

--- a/lib/stdlib/src/sys.erl
+++ b/lib/stdlib/src/sys.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
+%%
 %% Copyright Ericsson AB 1996-2018. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,27 +14,52 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 -module(sys).
 
 %% External exports
--export([suspend/1, suspend/2, resume/1, resume/2,
-	 get_status/1, get_status/2,
-	 get_state/1, get_state/2,
-	 replace_state/2, replace_state/3,
-	 change_code/4, change_code/5,
-	 terminate/2, terminate/3,
-	 log/2, log/3, trace/2, trace/3, statistics/2, statistics/3,
-	 log_to_file/2, log_to_file/3, no_debug/1, no_debug/2,
-	 install/2, install/3, remove/2, remove/3]).
--export([handle_system_msg/6, handle_system_msg/7, handle_debug/4,
-	 print_log/1, get_debug/3, debug_options/1, suspend_loop_hib/6]).
+-export([suspend/1
+        ,suspend/2
+        ,resume/1
+        ,resume/2
+        ,get_status/1
+        ,get_status/2
+        ,get_state/1
+        ,get_state/2
+        ,replace_state/2
+        ,replace_state/3
+        ,change_code/4
+        ,change_code/5
+        ,terminate/2
+        ,terminate/3
+        ,log/2
+        ,log/3
+        ,trace/2
+        ,trace/3
+        ,statistics/2
+        ,statistics/3
+        ,log_to_file/2
+        ,log_to_file/3
+        ,no_debug/1
+        ,no_debug/2
+        ,install/2
+        ,install/3
+        ,remove/2
+        ,remove/3]).
 
-%%-----------------------------------------------------------------
+-export([handle_system_msg/6
+        ,handle_system_msg/7
+        ,handle_debug/4
+        ,print_log/1
+        ,get_debug/3
+        ,debug_options/1
+        ,suspend_loop_hib/6]).
+
+%%--------------------------------------------------------------------------------------------------
 %% Types
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 
 -export_type([dbg_opt/0]).
 
@@ -44,271 +69,283 @@
 -type system_event() :: {'in', Msg :: _}
                       | {'in', Msg :: _, From :: _}
                       | {'out', Msg :: _, To :: _}
-                        | term().
+                      | term().
 -opaque dbg_opt()    :: {'trace', 'true'}
-                      | {'log',
-                         {N :: non_neg_integer(),
-                          [{Event :: system_event(),
-                            FuncState :: _,
-                            FormFunc :: format_fun()}]}}
-                      | {'statistics', {file:date_time(),
-                                        {'reductions', non_neg_integer()},
-                                        MessagesIn :: non_neg_integer(),
-                                        MessagesOut :: non_neg_integer()}}
+                      | {'log', {N :: non_neg_integer(), [{Event :: system_event()
+                                                          ,FuncState :: _
+                                                          ,FormFunc :: format_fun()}]}}
+                      | {'statistics', {file:date_time()
+                                       ,{'reductions', non_neg_integer()}
+                                       ,MessagesIn :: non_neg_integer()
+                                       ,MessagesOut :: non_neg_integer()}}
                       | {'log_to_file', file:io_device()}
                       | {Func :: dbg_fun(), FuncState :: term()}.
--type dbg_fun()      :: fun((FuncState :: _,
-                             Event :: system_event(),
-                             ProcState :: _) -> 'done' | (NewFuncState :: _)).
+-type dbg_fun()      :: fun((FuncState :: _, Event :: system_event(), ProcState :: _) ->
+                        'done' | (NewFuncState :: _)).
 
--type format_fun()   :: fun((Device :: io:device() | file:io_device(),
-			     Event :: system_event(),
-			     Extra :: term()) -> any()).
+-type format_fun()   :: fun((Device :: io:device() | file:io_device()
+                            ,Event :: system_event()
+                            ,Extra :: term()) ->
+                        any()).
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% System messages
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 -spec suspend(Name) -> 'ok' when
-      Name :: name().
-suspend(Name) -> send_system_msg(Name, suspend).
+    Name :: name().
+suspend(Name) ->
+    send_system_msg(Name, suspend).
 
 -spec suspend(Name, Timeout) -> 'ok' when
-      Name :: name(),
-      Timeout :: timeout().
-suspend(Name, Timeout) -> send_system_msg(Name, suspend, Timeout).
+    Name    :: name(),
+    Timeout :: timeout().
+suspend(Name, Timeout) ->
+    send_system_msg(Name, suspend, Timeout).
 
 -spec resume(Name) -> 'ok' when
-      Name :: name().
+    Name :: name().
 resume(Name) -> send_system_msg(Name, resume).
 
 -spec resume(Name, Timeout) -> 'ok' when
-      Name :: name(),
-      Timeout :: timeout().
-resume(Name, Timeout) -> send_system_msg(Name, resume, Timeout).
+    Name    :: name(),
+    Timeout :: timeout().
+resume(Name, Timeout) ->
+    send_system_msg(Name, resume, Timeout).
 
 -spec get_status(Name) -> Status when
-      Name :: name(),
-      Status :: {status, Pid :: pid(), {module, Module :: module()}, [SItem]},
-      SItem :: (PDict :: [{Key :: term(), Value :: term()}])
-             | (SysState :: 'running' | 'suspended')
-             | (Parent :: pid())
-             | (Dbg :: [dbg_opt()])
-             | (Misc :: term()).
-get_status(Name) -> send_system_msg(Name, get_status).
+    Name   :: name(),
+    Status :: {status, Pid :: pid(), {module, Module :: module()}, [SItem]},
+    SItem  :: (PDict :: [{Key :: term(), Value :: term()}])
+            | (SysState :: 'running' | 'suspended')
+            | (Parent :: pid())
+            | (Dbg :: [dbg_opt()])
+            | (Misc :: term()).
+get_status(Name) ->
+    send_system_msg(Name, get_status).
 
 -spec get_status(Name, Timeout) -> Status when
-      Name :: name(),
-      Timeout :: timeout(),
-      Status :: {status, Pid :: pid(), {module, Module :: module()}, [SItem]},
-      SItem :: (PDict :: [{Key :: term(), Value :: term()}])
+    Name    :: name(),
+    Timeout :: timeout(),
+    Status  :: {status, Pid :: pid(), {module, Module :: module()}, [SItem]},
+    SItem   :: (PDict :: [{Key :: term(), Value :: term()}])
              | (SysState :: 'running' | 'suspended')
              | (Parent :: pid())
              | (Dbg :: [dbg_opt()])
              | (Misc :: term()).
-get_status(Name, Timeout) -> send_system_msg(Name, get_status, Timeout).
+get_status(Name, Timeout) ->
+    send_system_msg(Name, get_status, Timeout).
 
 -spec get_state(Name) -> State when
-      Name :: name(),
-      State :: term().
+    Name  :: name(),
+    State :: term().
 get_state(Name) ->
     case send_system_msg(Name, get_state) of
-	{error, Reason} -> error(Reason);
-	State -> State
+        {error, Reason} ->
+            error(Reason);
+        State ->
+            State
     end.
 
 -spec get_state(Name, Timeout) -> State when
-      Name :: name(),
-      Timeout :: timeout(),
-      State :: term().
+    Name    :: name(),
+    Timeout :: timeout(),
+    State   :: term().
 get_state(Name, Timeout) ->
     case send_system_msg(Name, get_state, Timeout) of
-	{error, Reason} -> error(Reason);
-	State -> State
+        {error, Reason} ->
+            error(Reason);
+        State ->
+            State
     end.
 
 -spec replace_state(Name, StateFun) -> NewState when
-      Name :: name(),
-      StateFun :: fun((State :: term()) -> NewState :: term()),
-      NewState :: term().
+    Name     :: name(),
+    StateFun :: fun((State :: term()) -> NewState :: term()),
+    NewState :: term().
 replace_state(Name, StateFun) ->
     case send_system_msg(Name, {replace_state, StateFun}) of
-	{error, Reason} -> error(Reason);
-	State -> State
+        {error, Reason} ->
+            error(Reason);
+        State ->
+            State
     end.
 
 -spec replace_state(Name, StateFun, Timeout) -> NewState when
-      Name :: name(),
-      StateFun :: fun((State :: term()) -> NewState :: term()),
-      Timeout :: timeout(),
-      NewState :: term().
+    Name     :: name(),
+    StateFun :: fun((State :: term()) -> NewState :: term()),
+    Timeout  :: timeout(),
+    NewState :: term().
 replace_state(Name, StateFun, Timeout) ->
     case send_system_msg(Name, {replace_state, StateFun}, Timeout) of
-	{error, Reason} -> error(Reason);
-	State -> State
+        {error, Reason} ->
+            error(Reason);
+        State ->
+            State
     end.
 
 -spec change_code(Name, Module, OldVsn, Extra) -> 'ok' | {error, Reason} when
-      Name :: name(),
-      Module :: module(),
-      OldVsn :: 'undefined' | term(),
-      Extra :: term(),
-      Reason :: term().
+    Name   :: name(),
+    Module :: module(),
+    OldVsn :: 'undefined' | term(),
+    Extra  :: term(),
+    Reason :: term().
 change_code(Name, Mod, Vsn, Extra) ->
     send_system_msg(Name, {change_code, Mod, Vsn, Extra}).
 
--spec change_code(Name, Module, OldVsn, Extra, Timeout) ->
-                         'ok' | {error, Reason} when
-      Name :: name(),
-      Module :: module(),
-      OldVsn :: 'undefined' | term(),
-      Extra :: term(),
-      Timeout :: timeout(),
-      Reason :: term().
+-spec change_code(Name, Module, OldVsn, Extra, Timeout) -> 'ok' | {error, Reason} when
+    Name    :: name(),
+    Module  :: module(),
+    OldVsn  :: 'undefined' | term(),
+    Extra   :: term(),
+    Timeout :: timeout(),
+    Reason  :: term().
 change_code(Name, Mod, Vsn, Extra, Timeout) ->
     send_system_msg(Name, {change_code, Mod, Vsn, Extra}, Timeout).
 
 -spec terminate(Name, Reason) -> 'ok' when
-      Name :: name(),
-      Reason :: term().
+    Name   :: name(),
+    Reason :: term().
 terminate(Name, Reason) ->
     send_system_msg(Name, {terminate, Reason}).
 
 -spec terminate(Name, Reason, Timeout) -> 'ok' when
-      Name :: name(),
-      Reason :: term(),
-      Timeout :: timeout().
+    Name    :: name(),
+    Reason  :: term(),
+    Timeout :: timeout().
 terminate(Name, Reason, Timeout) ->
     send_system_msg(Name, {terminate, Reason}, Timeout).
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% Debug commands
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 
 -spec log(Name, Flag) -> 'ok' | {'ok', [system_event()]} when
-      Name :: name(),
-      Flag :: 'true' |
-              {'true', N :: pos_integer()}
-            | 'false' | 'get' | 'print'.
+    Name :: name(),
+    Flag :: 'true' | {'true', N :: pos_integer()} | 'false' | 'get' | 'print'.
 log(Name, Flag) ->
     send_system_msg(Name, {debug, {log, Flag}}).
 
 -spec log(Name, Flag, Timeout) -> 'ok' | {'ok', [system_event()]} when
-      Name :: name(),
-      Flag :: 'true' |
-              {'true', N :: pos_integer()}
-            | 'false' | 'get' | 'print',
-      Timeout :: timeout().
+    Name    :: name(),
+    Flag    :: 'true' | {'true', N :: pos_integer()} | 'false' | 'get' | 'print',
+    Timeout :: timeout().
 log(Name, Flag, Timeout) ->
     send_system_msg(Name, {debug, {log, Flag}}, Timeout).
 
 -spec trace(Name, Flag) -> 'ok' when
-      Name :: name(),
-      Flag :: boolean().
+    Name :: name(),
+    Flag :: boolean().
 trace(Name, Flag) ->
     send_system_msg(Name, {debug, {trace, Flag}}).
 
 -spec trace(Name, Flag, Timeout) -> 'ok' when
-      Name :: name(),
-      Flag :: boolean(),
-      Timeout :: timeout().
+    Name    :: name(),
+    Flag    :: boolean(),
+    Timeout :: timeout().
 trace(Name, Flag, Timeout) ->
     send_system_msg(Name, {debug, {trace, Flag}}, Timeout).
 
 -spec log_to_file(Name, Flag) -> 'ok' | {'error','open_file'} when
-      Name :: name(),
-      Flag :: (FileName :: string()) | 'false'.
+    Name :: name(),
+    Flag :: (FileName :: string()) | 'false'.
 log_to_file(Name, FileName) ->
     send_system_msg(Name, {debug, {log_to_file, FileName}}).
 
 -spec log_to_file(Name, Flag, Timeout) -> 'ok' | {'error','open_file'} when
-      Name :: name(),
-      Flag :: (FileName :: string()) | 'false',
-      Timeout :: timeout().
+    Name    :: name(),
+    Flag    :: (FileName :: string()) | 'false',
+    Timeout :: timeout().
 log_to_file(Name, FileName, Timeout) ->
     send_system_msg(Name, {debug, {log_to_file, FileName}}, Timeout).
 
 -spec statistics(Name, Flag) -> 'ok' | {'ok', Statistics} when
-      Name :: name(),
-      Flag :: 'true' | 'false' | 'get',
-      Statistics :: [StatisticsTuple] | no_statistics,
-      StatisticsTuple :: {'start_time', DateTime1}
-                       | {'current_time', DateTime2}
-                       | {'reductions', non_neg_integer()}
-                       | {'messages_in', non_neg_integer()}
-                       | {'messages_out', non_neg_integer()},
-      DateTime1 :: file:date_time(),
-      DateTime2 :: file:date_time().
+    Name            :: name(),
+    Flag            :: 'true' | 'false' | 'get',
+    Statistics      :: [StatisticsTuple] | no_statistics,
+    StatisticsTuple :: {'start_time', DateTime1}
+                     | {'current_time', DateTime2}
+                     | {'reductions', non_neg_integer()}
+                     | {'messages_in', non_neg_integer()}
+                     | {'messages_out', non_neg_integer()},
+    DateTime1       :: file:date_time(),
+    DateTime2       :: file:date_time().
 statistics(Name, Flag) ->
     send_system_msg(Name, {debug, {statistics, Flag}}).
 
 -spec statistics(Name, Flag, Timeout) -> 'ok' | {'ok', Statistics} when
-      Name :: name(),
-      Flag :: 'true' | 'false' | 'get',
-      Statistics :: [StatisticsTuple] | no_statistics,
-      StatisticsTuple :: {'start_time', DateTime1}
-                       | {'current_time', DateTime2}
-                       | {'reductions', non_neg_integer()}
-                       | {'messages_in', non_neg_integer()}
-                       | {'messages_out', non_neg_integer()},
-      DateTime1 :: file:date_time(),
-      DateTime2 :: file:date_time(),
-      Timeout :: timeout().
+    Name            :: name(),
+    Flag            :: 'true' | 'false' | 'get',
+    Statistics      :: [StatisticsTuple] | no_statistics,
+    StatisticsTuple :: {'start_time', DateTime1}
+                     | {'current_time', DateTime2}
+                     | {'reductions', non_neg_integer()}
+                     | {'messages_in', non_neg_integer()}
+                     | {'messages_out', non_neg_integer()},
+    DateTime1       :: file:date_time(),
+    DateTime2       :: file:date_time(),
+    Timeout         :: timeout().
 statistics(Name, Flag, Timeout) ->
     send_system_msg(Name, {debug, {statistics, Flag}}, Timeout).
 
 -spec no_debug(Name) -> 'ok' when
-      Name :: name().
-no_debug(Name) -> send_system_msg(Name, {debug, no_debug}).
+    Name :: name().
+no_debug(Name) ->
+    send_system_msg(Name, {debug, no_debug}).
 
 -spec no_debug(Name, Timeout) -> 'ok' when
-      Name :: name(),
-      Timeout :: timeout().
-no_debug(Name, Timeout) -> send_system_msg(Name, {debug, no_debug}, Timeout).
+    Name    :: name(),
+    Timeout :: timeout().
+no_debug(Name, Timeout) ->
+    send_system_msg(Name, {debug, no_debug}, Timeout).
 
 -spec install(Name, FuncSpec) -> 'ok' when
-      Name :: name(),
-      FuncSpec :: {Func, FuncState},
-      Func :: dbg_fun(),
-      FuncState :: term().
+    Name      :: name(),
+    FuncSpec  :: {Func, FuncState},
+    Func      :: dbg_fun(),
+    FuncState :: term().
 install(Name, {Func, FuncState}) ->
     send_system_msg(Name, {debug, {install, {Func, FuncState}}}).
 
 -spec install(Name, FuncSpec, Timeout) -> 'ok' when
-      Name :: name(),
-      FuncSpec :: {Func, FuncState},
-      Func :: dbg_fun(),
-      FuncState :: term(),
-      Timeout :: timeout().
+    Name      :: name(),
+    FuncSpec  :: {Func, FuncState},
+    Func      :: dbg_fun(),
+    FuncState :: term(),
+    Timeout   :: timeout().
 install(Name, {Func, FuncState}, Timeout) ->
     send_system_msg(Name, {debug, {install, {Func, FuncState}}}, Timeout).
 
 -spec remove(Name, Func) -> 'ok' when
-      Name :: name(),
-      Func :: dbg_fun().
+    Name :: name(),
+    Func :: dbg_fun().
 remove(Name, Func) ->
     send_system_msg(Name, {debug, {remove, Func}}).
 
 -spec remove(Name, Func, Timeout) -> 'ok' when
-      Name :: name(),
-      Func :: dbg_fun(),
-      Timeout :: timeout().
+    Name    :: name(),
+    Func    :: dbg_fun(),
+    Timeout :: timeout().
 remove(Name, Func, Timeout) ->
     send_system_msg(Name, {debug, {remove, Func}}, Timeout).
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% All system messages sent are on the form {system, From, Msg}
 %% The receiving side should send Msg to handle_system_msg/5.
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 send_system_msg(Name, Request) ->
     case catch gen:call(Name, system, Request) of
-	{ok,Res} -> Res;
-	{'EXIT', Reason} -> exit({Reason, mfa(Name, Request)})
+        {ok,Res} ->
+            Res;
+        {'EXIT', Reason} ->
+            exit({Reason, mfa(Name, Request)})
     end.
 
 send_system_msg(Name, Request, Timeout) ->
     case catch gen:call(Name, system, Request, Timeout) of
-	{ok,Res} -> Res;
-	{'EXIT', Reason} -> exit({Reason, mfa(Name, Request, Timeout)})
+        {ok,Res} ->
+            Res;
+        {'EXIT', Reason} ->
+            exit({Reason, mfa(Name, Request, Timeout)})
     end.
 
 mfa(Name, {debug, {Func, Arg2}}) ->
@@ -324,7 +361,7 @@ mfa(Name, Req, Timeout) ->
     {M, F, A} = mfa(Name, Req),
     {M, F, A ++ [Timeout]}.
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% Func: handle_system_msg/6
 %% Purpose: Used by a process module that wishes to take care of
 %%          system messages.  The process receives a {system, From,
@@ -336,45 +373,44 @@ mfa(Name, Req, Timeout) ->
 %%          the process should terminate.
 %%          The Module must export system_continue/3, system_terminate/4
 %%          and format_status/2 for status information.
-%%-----------------------------------------------------------------
--spec handle_system_msg(Msg, From, Parent, Module, Debug, Misc) ->
-                               no_return() when
-      Msg :: term(),
-      From :: {pid(), Tag :: _},
-      Parent :: pid(),
-      Module :: module(),
-      Debug :: [dbg_opt()],
-      Misc :: term().
+%%--------------------------------------------------------------------------------------------------
+-spec handle_system_msg(Msg, From, Parent, Module, Debug, Misc) -> no_return() when
+    Msg    :: term(),
+    From   :: {pid(), Tag :: _},
+    Parent :: pid(),
+    Module :: module(),
+    Debug  :: [dbg_opt()],
+    Misc   :: term().
 handle_system_msg(Msg, From, Parent, Module, Debug, Misc) ->
     handle_system_msg(running, Msg, From, Parent, Module, Debug, Misc, false).
 
 handle_system_msg(Msg, From, Parent, Mod, Debug, Misc, Hib) ->
-   handle_system_msg(running, Msg, From, Parent, Mod, Debug, Misc, Hib).
+    handle_system_msg(running, Msg, From, Parent, Mod, Debug, Misc, Hib).
 
 handle_system_msg(SysState, Msg, From, Parent, Mod, Debug, Misc, Hib) ->
     case do_cmd(SysState, Msg, Parent, Mod, Debug, Misc) of
-	{suspended, Reply, NDebug, NMisc} ->
-	    _ = gen:reply(From, Reply),
-	    suspend_loop(suspended, Parent, Mod, NDebug, NMisc, Hib);
-	{running, Reply, NDebug, NMisc} ->
-	    _ = gen:reply(From, Reply),
+        {suspended, Reply, NDebug, NMisc} ->
+            _ = gen:reply(From, Reply),
+            suspend_loop(suspended, Parent, Mod, NDebug, NMisc, Hib);
+        {running, Reply, NDebug, NMisc} ->
+            _ = gen:reply(From, Reply),
             Mod:system_continue(Parent, NDebug, NMisc);
-	{{terminating, Reason}, Reply, NDebug, NMisc} ->
-	    _ = gen:reply(From, Reply),
-	    Mod:system_terminate(Reason, Parent, NDebug, NMisc)
+        {{terminating, Reason}, Reply, NDebug, NMisc} ->
+            _ = gen:reply(From, Reply),
+            Mod:system_terminate(Reason, Parent, NDebug, NMisc)
     end.
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% Func: handle_debug/4
 %% Purpose: Called by a process that wishes to debug an event.
 %%          Func is a formatting function, called as Func(Device, Event).
 %% Returns: [debug_opts()]
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 -spec handle_debug(Debug, FormFunc, Extra, Event) -> [dbg_opt()] when
-      Debug :: [dbg_opt()],
-      FormFunc :: format_fun(),
-      Extra :: term(),
-      Event :: system_event().
+    Debug    :: [dbg_opt()],
+    FormFunc :: format_fun(),
+    Extra    :: term(),
+    Event    :: system_event().
 handle_debug([{trace, true} | T], FormFunc, State, Event) ->
     print_event({Event, State, FormFunc}),
     [{trace, true} | handle_debug(T, FormFunc, State, Event)];
@@ -389,40 +425,41 @@ handle_debug([{statistics, StatData} | T], FormFunc, State, Event) ->
     [{statistics, NStatData} | handle_debug(T, FormFunc, State, Event)];
 handle_debug([{Func, FuncState} | T], FormFunc, State, Event) ->
     case catch Func(FuncState, Event, State) of
-	done -> handle_debug(T, FormFunc, State, Event);
-	{'EXIT', _} -> handle_debug(T, FormFunc, State, Event);
-	NFuncState ->		     
-	    [{Func, NFuncState} | handle_debug(T, FormFunc, State, Event)]
+        done ->
+            handle_debug(T, FormFunc, State, Event);
+        {'EXIT', _} ->
+            handle_debug(T, FormFunc, State, Event);
+        NFuncState ->
+            [{Func, NFuncState} | handle_debug(T, FormFunc, State, Event)]
     end;
 handle_debug([], _FormFunc, _State, _Event) ->
     [].
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% When a process is suspended, it can only respond to system
 %% messages.
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 suspend_loop(SysState, Parent, Mod, Debug, Misc, Hib) ->
     case Hib of
-	true ->
-	   suspend_loop_hib(SysState, Parent, Mod, Debug, Misc, Hib);
-	_ ->
-	    receive
-		{system, From, Msg} ->
-		    handle_system_msg(SysState, Msg, From, Parent, Mod, Debug, Misc, Hib);
-		{'EXIT', Parent, Reason} ->
-		    Mod:system_terminate(Reason, Parent, Debug, Misc)
-	    end
+        true ->
+            suspend_loop_hib(SysState, Parent, Mod, Debug, Misc, Hib);
+        _ ->
+            receive
+                {system, From, Msg} ->
+                    handle_system_msg(SysState, Msg, From, Parent, Mod, Debug, Misc, Hib);
+                {'EXIT', Parent, Reason} ->
+                    Mod:system_terminate(Reason, Parent, Debug, Misc)
+            end
     end.
 
 suspend_loop_hib(SysState, Parent, Mod, Debug, Misc, Hib) ->
     receive
-	{system, From, Msg} ->
-	    handle_system_msg(SysState, Msg, From, Parent, Mod, Debug, Misc, Hib);
-	{'EXIT', Parent, Reason} ->
+        {system, From, Msg} ->
+            handle_system_msg(SysState, Msg, From, Parent, Mod, Debug, Misc, Hib);
+        {'EXIT', Parent, Reason} ->
             Mod:system_terminate(Reason, Parent, Debug, Misc)
     after 0 -> % Not a system message, go back into hibernation
-	 proc_lib:hibernate(?MODULE, suspend_loop_hib, [SysState, Parent, Mod, 
-							Debug, Misc, Hib])
+        proc_lib:hibernate(?MODULE, suspend_loop_hib, [SysState, Parent, Mod, Debug, Misc, Hib])
     end.
 
 
@@ -443,8 +480,7 @@ do_cmd(SysState, {debug, What}, _Parent, _Mod, Debug, Misc) ->
     {SysState, Res, NDebug, Misc};
 do_cmd(_, {terminate, Reason}, _Parent, _Mod, Debug, Misc) ->
     {{terminating, Reason}, ok, Debug, Misc};
-do_cmd(suspended, {change_code, Module, Vsn, Extra}, _Parent,
-       Mod, Debug, Misc) ->
+do_cmd(suspended, {change_code, Module, Vsn, Extra}, _Parent, Mod, Debug, Misc) ->
     {Res, NMisc} = do_change_code(Mod, Module, Vsn, Extra, Misc),
     {suspended, Res, Debug, NMisc};
 do_cmd(SysState, Other, _Parent, _Mod, Debug, Misc) ->
@@ -452,36 +488,36 @@ do_cmd(SysState, Other, _Parent, _Mod, Debug, Misc) ->
 
 do_get_state(Mod, Misc) ->
     case erlang:function_exported(Mod, system_get_state, 1) of
-	true ->
-	    try
-		{ok, State} = Mod:system_get_state(Misc),
-		State
-	    catch
-		Cl:Exc ->
-		    {error, {callback_failed,{Mod,system_get_state},{Cl,Exc}}}
-	    end;
-	false ->
-	    Misc
+        true ->
+            try
+                {ok, State} = Mod:system_get_state(Misc),
+                State
+            catch
+                Cl:Exc ->
+                    {error, {callback_failed,{Mod,system_get_state},{Cl,Exc}}}
+            end;
+        false ->
+            Misc
     end.
 
 do_replace_state(StateFun, Mod, Misc) ->
     case erlang:function_exported(Mod, system_replace_state, 2) of
-	true ->
-	    try
-		{ok, State, NMisc} = Mod:system_replace_state(StateFun, Misc),
-		{State, NMisc}
-	    catch
-		Cl:Exc ->
-		    {{error, {callback_failed,{Mod,system_replace_state},{Cl,Exc}}}, Misc}
-	    end;
-	false ->
-	    try
-		NMisc = StateFun(Misc),
-		{NMisc, NMisc}
-	    catch
-		Cl:Exc ->
-		    {{error, {callback_failed,StateFun,{Cl,Exc}}}, Misc}
-	    end
+        true ->
+            try
+                {ok, State, NMisc} = Mod:system_replace_state(StateFun, Misc),
+                {State, NMisc}
+            catch
+                Cl:Exc ->
+                    {{error, {callback_failed,{Mod,system_replace_state},{Cl,Exc}}}, Misc}
+            end;
+        false ->
+            try
+                NMisc = StateFun(Misc),
+                {NMisc, NMisc}
+            catch
+                Cl:Exc ->
+                    {{error, {callback_failed,StateFun,{Cl,Exc}}}, Misc}
+            end
     end.
 
 get_status(SysState, Parent, Mod, Debug, Misc) ->
@@ -494,16 +530,15 @@ get_status(SysState, Parent, Mod, Debug, Misc) ->
             _ ->
                 Misc
         end,
-    {status, self(), {module, Mod},
-     [PDict, SysState, Parent, Debug, FmtMisc]}.
+    {status, self(), {module, Mod}, [PDict, SysState, Parent, Debug, FmtMisc]}.
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% These are the system debug commands.
 %% {trace,       true|false} -> io:format
 %% {log,         true|false|get|print} -> keeps the 10 last debug messages
 %% {log_to_file, FileName | false} -> io:format to file.
 %% {statistics,  true|false|get}   -> keeps track of messages in/out + reds.
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 debug_cmd({trace, true}, Debug) ->
     {ok, install_debug(trace, true, Debug)};
 debug_cmd({trace, false}, Debug) ->
@@ -528,10 +563,10 @@ debug_cmd({log_to_file, false}, Debug) ->
 debug_cmd({log_to_file, FileName}, Debug) ->
     NDebug = close_log_file(Debug),
     case file:open(FileName, [write,{encoding,utf8}]) of
-	{ok, Fd} ->
-	    {ok, install_debug(log_to_file, Fd, NDebug)};
-	_Error ->
-	    {{error, open_file}, NDebug}
+        {ok, Fd} ->
+            {ok, install_debug(log_to_file, Fd, NDebug)};
+        _Error ->
+            {{error, open_file}, NDebug}
     end;
 debug_cmd({statistics, true}, Debug) ->
     {ok, install_debug(statistics, init_stat(), Debug)};
@@ -552,92 +587,108 @@ debug_cmd(_Unknown, Debug) ->
 
 do_change_code(Mod, Module, Vsn, Extra, Misc) ->
     case catch Mod:system_code_change(Misc, Module, Vsn, Extra) of
-	{ok, NMisc} -> {ok, NMisc};
-	Else -> {{error, Else}, Misc}
+        {ok, NMisc} ->
+            {ok, NMisc};
+        Else ->
+            {{error, Else}, Misc}
     end.
 
-print_event(X) -> print_event(standard_io, X).
+print_event(X) ->
+    print_event(standard_io, X).
 
 print_event(Dev, {Event, State, FormFunc}) ->
     FormFunc(Dev, Event, State).
 
-init_stat() -> {erlang:localtime(), process_info(self(), reductions), 0, 0}.
+init_stat() ->
+    {erlang:localtime(), process_info(self(), reductions), 0, 0}.
 
 get_stat({Time, {reductions, Reds}, In, Out}) ->
     {reductions, Reds2} = process_info(self(), reductions),
-    [{start_time, Time}, {current_time, erlang:localtime()},
-     {reductions, Reds2 - Reds}, {messages_in, In}, {messages_out, Out}];
+    [{start_time, Time}
+    ,{current_time, erlang:localtime()}
+    ,{reductions, Reds2 - Reds}
+    ,{messages_in, In}
+    ,{messages_out, Out}];
 get_stat(_) ->
     no_statistics.
 
-stat({in, _Msg}, {Time, Reds, In, Out}) -> {Time, Reds, In+1, Out};
-stat({in, _Msg, _From}, {Time, Reds, In, Out}) -> {Time, Reds, In+1, Out};
-stat({out, _Msg, _To}, {Time, Reds, In, Out}) -> {Time, Reds, In, Out+1};
-stat(_, StatData) -> StatData.
+stat({in, _Msg}, {Time, Reds, In, Out}) ->
+    {Time, Reds, In+1, Out};
+stat({in, _Msg, _From}, {Time, Reds, In, Out}) ->
+    {Time, Reds, In+1, Out};
+stat({out, _Msg, _To}, {Time, Reds, In, Out}) ->
+    {Time, Reds, In, Out+1};
+stat(_, StatData) ->
+    StatData.
 
 trim(N, LogData) ->
     lists:sublist(LogData, 1, N-1).
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% Debug structure manipulating functions
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 install_debug(Item, Data, Debug) ->
     case get_debug2(Item, Debug, undefined) of
-	undefined -> [{Item, Data} | Debug];
-	_ -> Debug
+        undefined ->
+            [{Item, Data} | Debug];
+        _ ->
+            Debug
     end.
-remove_debug(Item, Debug) -> lists:keydelete(Item, 1, Debug).
+
+remove_debug(Item, Debug) ->
+    lists:keydelete(Item, 1, Debug).
 
 -spec get_debug(Item, Debug, Default) -> term() when
-      Item :: 'log' | 'statistics',
-      Debug :: [dbg_opt()],
-      Default :: term().
-get_debug(Item, Debug, Default) -> 
+    Item    :: 'log' | 'statistics',
+    Debug   :: [dbg_opt()],
+    Default :: term().
+get_debug(Item, Debug, Default) ->
     get_debug2(Item, Debug, Default).
 
 %% Workaround: accepts more Item types than get_debug/3.
 get_debug2(Item, Debug, Default) ->
     case lists:keysearch(Item, 1, Debug) of
-	{value, {Item, Data}} -> Data;
-	_ -> Default
+        {value, {Item, Data}} ->
+            Data;
+        _ ->
+            Default
     end.
 
 -spec print_log(Debug) -> 'ok' when
-      Debug :: [dbg_opt()].
+    Debug :: [dbg_opt()].
 print_log(Debug) ->
     {_N, Logs} = get_debug(log, Debug, {0, []}),
-    lists:foreach(fun print_event/1,
-		  lists:reverse(Logs)).
-    
+    lists:foreach(fun print_event/1, lists:reverse(Logs)).
+
 close_log_file(Debug) ->
     case get_debug2(log_to_file, Debug, []) of
-	[] ->
-	    Debug;
-	Fd -> 
-	    ok = file:close(Fd),
-	    remove_debug(log_to_file, Debug)
+        [] ->
+            Debug;
+        Fd ->
+            ok = file:close(Fd),
+            remove_debug(log_to_file, Debug)
     end.
 
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 %% Func: debug_options/1
 %% Purpose: Initiate a debug structure.  Called by a process that
 %%          wishes to initiate the debug structure without the
 %%          system messages.
 %% Returns: [debug_opts()]
-%%-----------------------------------------------------------------
+%%--------------------------------------------------------------------------------------------------
 
 -spec debug_options(Options) -> [dbg_opt()] when
-      Options :: [Opt],
-      Opt :: 'trace'
-           | 'log'
-           | {'log', pos_integer()}
-           | 'statistics'
-           | {'log_to_file', FileName}
-           | {'install', FuncSpec},
-      FileName :: file:name(),
-      FuncSpec :: {Func, FuncState},
-      Func :: dbg_fun(),
-      FuncState :: term().
+    Options   :: [Opt],
+    Opt       :: 'trace'
+               | 'log'
+               | {'log', pos_integer()}
+               | 'statistics'
+               | {'log_to_file', FileName}
+               | {'install', FuncSpec},
+    FileName  :: file:name(),
+    FuncSpec  :: {Func, FuncState},
+    Func      :: dbg_fun(),
+    FuncState :: term().
 debug_options(Options) ->
     debug_options(Options, []).
 
@@ -651,14 +702,14 @@ debug_options([statistics | T], Debug) ->
     debug_options(T, install_debug(statistics, init_stat(), Debug));
 debug_options([{log_to_file, FileName} | T], Debug) ->
     case file:open(FileName, [write,{encoding,utf8}]) of
-	{ok, Fd} ->
-	    debug_options(T, install_debug(log_to_file, Fd, Debug));
-	_Error ->
-	    debug_options(T, Debug)
+        {ok, Fd} ->
+            debug_options(T, install_debug(log_to_file, Fd, Debug));
+        _Error ->
+            debug_options(T, Debug)
     end;
 debug_options([{install, {Func, FuncState}} | T], Debug) ->
     debug_options(T, install_debug(Func, FuncState, Debug));
 debug_options([_ | T], Debug) ->
     debug_options(T, Debug);
-debug_options([], Debug) -> 
+debug_options([], Debug) ->
     Debug.

--- a/lib/stdlib/test/sys_SUITE.erl
+++ b/lib/stdlib/test/sys_SUITE.erl
@@ -18,10 +18,26 @@
 %% %CopyrightEnd%
 %%
 -module(sys_SUITE).
--export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
-	 init_per_group/2,end_per_group/2,log/1,log_to_file/1,
-	 stats/1,trace/1,suspend/1,install/1,special_process/1]).
--export([handle_call/3,terminate/2,init/1]).
+
+-export([all/0
+        ,suite/0
+        ,groups/0
+        ,init_per_suite/1
+        ,end_per_suite/1
+        ,init_per_group/2
+        ,end_per_group/2
+        ,log/1
+        ,log_to_file/1
+        ,stats/1
+        ,trace/1
+        ,suspend/1
+        ,install/1
+        ,special_process/1]).
+
+-export([handle_call/3
+        ,terminate/2
+        ,init/1]).
+
 -include_lib("common_test/include/ct.hrl").
 
 -define(server,sys_SUITE_server).
@@ -51,7 +67,7 @@ end_per_group(_GroupName, Config) ->
     Config.
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 log(Config) when is_list(Config) ->
     {ok,_Server} = start(),
@@ -151,8 +167,10 @@ install(Config) when is_list(Config) ->
 
 get_messages() ->
     receive
-	Msg -> [Msg|get_messages()]
-    after 1 -> []
+        Msg ->
+            [Msg|get_messages()]
+    after 1 ->
+        []
     end.
 
 special_process(Config) when is_list(Config) ->
@@ -165,66 +183,74 @@ spec_proc(Mod) ->
     ok = sys:trace(Mod,true),
     1 = Ch = Mod:alloc(),
     Free = lists:seq(2,100),
-    Replace = case sys:get_state(Mod) of
-		  {[Ch],Free} ->
-		      fun({A,F}) ->
-			      Free = F,
-			      {A,[2,3,4]}
-		      end;
-		  {state,[Ch],Free} ->
-		      fun({state,A,F}) ->
-			      Free = F,
-			      {state,A,[2,3,4]}
-		      end
-	      end,
+    Replace =
+        case sys:get_state(Mod) of
+            {[Ch],Free} ->
+                fun({A,F}) ->
+                    Free = F,
+                    {A,[2,3,4]}
+                end;
+            {state,[Ch],Free} ->
+                fun({state,A,F}) ->
+                    Free = F,
+                    {state,A,[2,3,4]}
+                end
+        end,
     case sys:replace_state(Mod, Replace) of
-	{[Ch],[2,3,4]} -> ok;
-	{state,[Ch],[2,3,4]} -> ok
+        {[Ch],[2,3,4]} ->
+            ok;
+        {state,[Ch],[2,3,4]} ->
+            ok
     end,
     ok = Mod:free(Ch),
     case sys:get_state(Mod) of
-	{[],[1,2,3,4]} -> ok;
-	{state,[],[1,2,3,4]} -> ok
+        {[],[1,2,3,4]} ->
+            ok;
+        {state,[],[1,2,3,4]} ->
+            ok
     end,
-    {ok,[{start_time,_},
-	 {current_time,_},
-	 {reductions,_},
-	 {messages_in,2},
-	 {messages_out,1}]} = sys:statistics(Mod,get),
+    {ok,[{start_time,_}
+        ,{current_time,_}
+        ,{reductions,_}
+        ,{messages_in,2}
+        ,{messages_out,1}]} = sys:statistics(Mod,get),
     ok = sys:statistics(Mod,false),
     [] = sys:replace_state(Mod, fun(_) -> [] end),
     process_flag(trap_exit,true),
-    ok = case catch sys:get_state(Mod) of
-	     [] ->
-		 ok;
-	     {'EXIT',{{callback_failed,
-		       {Mod,system_get_state},{throw,fail}},_}} ->
-		 ok
-	 end,
+    ok =
+        case catch sys:get_state(Mod) of
+            [] ->
+                ok;
+            {'EXIT',{{callback_failed,
+                {Mod,system_get_state},{throw,fail}},_}} ->
+                ok
+        end,
     ok = sys:terminate(Mod, normal),
     {ok,_} = Mod:start_link(4),
-    ok = case catch sys:replace_state(Mod, fun(_) -> {} end) of
-	     {} ->
-		 ok;
-	     {'EXIT',{{callback_failed,
-		       {Mod,system_replace_state},{throw,fail}},_}} ->
-		 ok
-	 end,
+    ok =
+        case catch sys:replace_state(Mod, fun(_) -> {} end) of
+            {} ->
+                ok;
+            {'EXIT',{{callback_failed,
+                {Mod,system_replace_state},{throw,fail}},_}} ->
+                ok
+        end,
     ok = sys:terminate(Mod, normal),
     {ok,_} = Mod:start_link(4),
     StateFun = fun(_) -> error(fail) end,
-    ok = case catch sys:replace_state(Mod, StateFun) of
-	     {} ->
-		 ok;
-	     {'EXIT',{{callback_failed,
-		       {Mod,system_replace_state},{error,fail}},_}} ->
-		 ok;
-	     {'EXIT',{{callback_failed,StateFun,{error,fail}},_}} ->
-		 ok
-	 end,
+    ok =
+        case catch sys:replace_state(Mod, StateFun) of
+            {} ->
+                ok;
+            {'EXIT',{{callback_failed,
+                {Mod,system_replace_state},{error,fail}},_}} ->
+                ok;
+            {'EXIT',{{callback_failed,StateFun,{error,fail}},_}} ->
+                ok
+        end,
     ok = sys:terminate(Mod, normal).
 
-%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Dummy server
 
 public_call(Arg) ->
@@ -247,5 +273,3 @@ handle_call(stop,_From,State) ->
 
 terminate(_Reason, _State) ->
     ok.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%    


### PR DESCRIPTION
Hi. First let's find the bug.  
Suppose that i want to install a debug function on `kernel_sup` process:
```erl
1> F = fun(_, _, _) -> io:format("done~n"), new_state end.
#Fun<erl_eval.18.118419387>

2> sys:install(kernel_sup, {F, state}).
ok

3> sys:get_status(kernel_sup).
{status,<0.35.0>,
        {module,gen_server},
        [[{'$initial_call',{supervisor,kernel,1}},
          {'$ancestors',[<0.34.0>]}],
         running,<0.34.0>,
         [{#Fun<erl_eval.18.118419387>,state}], %% It's here
         [{header,"Status for generic server kernel_sup"},
          ...

4> supervisor:count_children(kernel_sup).
done
[{specs,11},{active,10},{supervisors,4},{workers,7}]

%% I can't install this function again
5> sys:install(kernel_sup, {F, state}).
ok

6> supervisor:count_children(kernel_sup).
done
[{specs,11},{active,10},{supervisors,4},{workers,7}]

7> sys:get_status(kernel_sup).           
{status,<0.35.0>,
        {module,gen_server},
        [[{'$initial_call',{supervisor,kernel,1}},
          {'$ancestors',[<0.34.0>]}],
         running,<0.34.0>,
         [{#Fun<erl_eval.18.118419387>,new_state}], %% We have just previous function
         [{header,"Status for generic server kernel_sup"},
          ...

%% I will add new function
8> F2 = fun(_, _, _) -> io:format("done~n"), undefined end.
#Fun<erl_eval.18.118419387>

9> sys:install(kernel_sup, {F2, undefined}).               
ok
10> sys:get_status(kernel_sup).                             
{status,<0.35.0>,
        {module,gen_server},
        [[{'$initial_call',{supervisor,kernel,1}},
          {'$ancestors',[<0.34.0>]}],
         running,<0.34.0>,
         [{#Fun<erl_eval.18.118419387>,undefined}, %% Added
          {#Fun<erl_eval.18.118419387>,new_state}],
         [{header,"Status for generic server kernel_sup"},
          ...
%% Test
11> supervisor:count_children(kernel_sup).                  
done
done
[{specs,11},{active,10},{supervisors,4},{workers,7}]

%% Can i add it again ???
12> sys:install(kernel_sup, {F2, undefined}).
ok

13> sys:install(kernel_sup, {F2, undefined}).
ok

14> sys:install(kernel_sup, {F2, undefined}).
ok

15> sys:get_status(kernel_sup).              
{status,<0.35.0>,
        {module,gen_server},
        [[{'$initial_call',{supervisor,kernel,1}},
          {'$ancestors',[<0.34.0>]}],
         running,<0.34.0>,
         [{#Fun<erl_eval.18.118419387>,undefined}, %% They have been added !
          {#Fun<erl_eval.18.118419387>,undefined},
          {#Fun<erl_eval.18.118419387>,undefined},
          {#Fun<erl_eval.18.118419387>,undefined},
          {#Fun<erl_eval.18.118419387>,new_state}],
         [{header,"Status for generic server kernel_sup"},
         ...
16> supervisor:count_children(kernel_sup).   
done
done
done
done
done
[{specs,11},{active,10},{supervisors,4},{workers,7}]
```
Because [here](https://github.com/erlang/otp/blob/maint/lib/stdlib/src/sys.erl#L586) we assume that function does not exist but it exists and its state is `undefined`!  
I'm writing new Erlang monitoring app. I want to install debug function to erlang processes and send their I/O to websockets. But i can't install same function more times on one process for sending I/O to more than one websocket process. I think it's good to add same debug function more times on a process. This pull request fixes above bug and can support this feature.

New `install` function:
```erl
 1> F = fun(_, _, _) -> io:format("done~n"), undefined end.
#Fun<erl_eval.18.99386804>

2> FuncState = undefined.
undefined

3> sys:install(kernel_sup, func_id_1, F, FuncState).
ok

%% I can't add any function with func_id_1 again
4> sys:install(kernel_sup, func_id_1, F, FuncState).
{error,already_exists}

5> sys:install(kernel_sup, func_id_2, F, FuncState).
ok

6> sys:install(kernel_sup, func_id_3, F, FuncState).
ok

7> supervisor:count_children(kernel_sup).
done
done
done
[{specs,12},{active,11},{supervisors,4},{workers,8}]

8> sys:get_status(kernel_sup).                      
{status,<0.37.0>,
        {module,gen_server},
        [[{'$initial_call',{supervisor,kernel,1}},
          {'$ancestors',[<0.36.0>]}],
         running,<0.36.0>,
         [{func_id_3,{#Fun<erl_eval.18.99386804>,undefined}}, %% here
          {func_id_2,{#Fun<erl_eval.18.99386804>,undefined}},
          {func_id_1,{#Fun<erl_eval.18.99386804>,undefined}}],
         [{header,"Status for generic server kernel_sup"}, 
         ...

9> sys:remove(kernel_sup, func_id_1).
ok

10> sys:remove(kernel_sup, func_id_1).
{error,not_found}

11> sys:get_status(kernel_sup).       
{status,<0.37.0>,
        {module,gen_server},
        [[{'$initial_call',{supervisor,kernel,1}},
          {'$ancestors',[<0.36.0>]}],
         running,<0.36.0>,
         [{func_id_3,{#Fun<erl_eval.18.99386804>,undefined}}, %% func_id_1 has been removed
          {func_id_2,{#Fun<erl_eval.18.99386804>,undefined}}],
         [{header,"Status for generic server kernel_sup"},
         ...
```