### PR TITLE
Honour options set when using xmerl_scan:string/2

### DIFF
--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -293,7 +293,10 @@ string(Str, Options) ->
     {Res,Tail}.
 
 int_string(Str, Options,FileName) ->
-    {ok,  XMLBase} = file:get_cwd(),
+    {ok, XMLBase}=case lists:keysearch(xmlbase,1,Options) of
+      {value,{_,Val}} -> {ok, Val}
+      false -> file:get_cwd()
+    end
     int_string(Str, Options, XMLBase, FileName).
 
 int_string(Str, Options, XMLBase, FileName) ->


### PR DESCRIPTION
This also fixes a very annoying performance issue when using xmerl as when processing a lot of xml using this function the calls to file:cwd() get backed up in the file_server. This will make it possible to at least avoid those calls.

This is my first MR to OTP so let me know if I have missed anything... 