### PR TITLE
Explain why the AM becomes group leader

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2068,8 +2068,15 @@ end</pre>
           Typically, this is used when a process started from a
           certain shell is to have another group leader than
           <c>init</c>.</p>
+        <p>The group leader should be rarely changed in
+          applications with a supervision tree, because OTP
+          assumes the group leader of their processes is
+          their application master.</p>
         <p>See also
-          <seealso marker="#group_leader/0"><c>group_leader/0</c></seealso>.</p>
+          <seealso marker="#group_leader/0"><c>group_leader/0</c></seealso>
+          and <seealso marker="doc/design_principles:applications#stopping">OTP
+          design principles</seealso> related to starting and stopping
+          applications.</p>
       </desc>
     </func>
 

--- a/lib/kernel/doc/src/application.xml
+++ b/lib/kernel/doc/src/application.xml
@@ -318,8 +318,13 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
           <c>{error,{not_started,App}}</c> is returned, where <c>App</c>
           is the name of the missing application.</p>
         <p>The application controller then creates an <em>application master</em>
-	  for the application. The application master is
-          the group leader of all the processes in the application.
+          for the application. The application master becomes the
+          group leader of all the processes in the application. I/O is
+          forwarded to the previous group leader, though, this is just
+          a way to identify processes that belong to the application.
+          Used for example to find itself from any process, or,
+          reciprocally, to kill them all when it terminates.</p>
+        <p>
           The application master starts the application by calling
           the application callback function <c>Module:start/2</c> as
           defined by the application specification key <c>mod</c>.</p>
@@ -608,4 +613,3 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
       <seealso marker="app">app(4)</seealso></p>
   </section>
 </erlref>
-

--- a/lib/kernel/src/application_master.erl
+++ b/lib/kernel/src/application_master.erl
@@ -118,6 +118,10 @@ init(Parent, Starter, ApplData, Type) ->
     link(Parent),
     process_flag(trap_exit, true),
     OldGleader = group_leader(),
+    %% We become the group leader, but forward all I/O to OldGleader.
+    %% This is just a way to identify processes that belong to the
+    %% application. Used for example to find ourselves from any
+    %% process, or, reciprocally, to kill them all when we terminate.
     group_leader(self(), self()),
     %% Insert ourselves as master for the process.  This ensures that
     %% the processes in the application can use get_env/1 at startup.

--- a/system/doc/design_principles/applications.xml
+++ b/system/doc/design_principles/applications.xml
@@ -363,9 +363,13 @@ ok
       application are running.</p>
     <marker id="application_master"></marker>
     <p>The application controller then creates an
-    <em>application master</em> for the application. The application master
-      is the group leader of all the processes in the application.
-      The application master starts the application by calling
+      <em>application master</em> for the application. The application
+      master becomes the group leader of all the processes in the
+      application. I/O is forwarded to the previous group leader,
+      though, this is just a way to identify processes that belong to
+      the application. Used for example to find itself from any process,
+      or, reciprocally, to kill them all when it terminates.</p>
+    <p>The application master starts the application by calling
       the application callback function <c>start/2</c> in the module,
       and with the start argument, defined by the <c>mod</c> key in
       the <c>.app</c> file.</p>


### PR DESCRIPTION
I think it is not obvious for the reader of the code why do application masters become group leader of their applications.

You can kind of infer it if you read a lot, connect the dots, and allow yourself to conclude that this is the intention despite it does not seem motivated by I/O... but if you are told right away, you not only get the picture upfront, but also have official confimation rather than leaving yourself with a conjecture :).

The comment itself comes in part from my own research, and also from feedback from @ferd in the mailing list (thanks again!).