### PR TITLE
Support dumping of external fun literals to a crash dump

### DIFF
--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -942,6 +942,9 @@ dump_module_literals(fmtfn_t to, void *to_arg, ErtsLiteralArea* lit_area)
                     }
                     erts_putc(to, to_arg, '\n');
                 }
+            } else if (is_export_header(w)) {
+                dump_externally(to, to_arg, term);
+                erts_putc(to, to_arg, '\n');
             }
             size = 1 + header_arity(w);
             switch (w & _HEADER_SUBTAG_MASK) {


### PR DESCRIPTION
63e1c58d27ab (PR #1725) started to compile external funs
as literals.

This commit updates the dumping of literal areas to dump
external fun literals to the crash dump.