### PR TITLE
Doc: use that node name between code and commands

### DIFF
--- a/system/doc/getting_started/conc_prog.xml
+++ b/system/doc/getting_started/conc_prog.xml
@@ -627,7 +627,7 @@ ping finished</pre>
 %%% Change the function below to return the name of the node where the
 %%% messenger server runs
 server_node() ->
-    messenger@bill.
+    messenger@super.
 
 %%% This is the server process for the "messenger"
 %%% the user list has the format [{ClientPid1, Name1},{ClientPid22, Name2},...]


### PR DESCRIPTION
The `server_node()` function in the sample code was referring to `messenger@bill`, while the commands that follow use `messenger@super` as node name.

Making both names consistent make it easier for newbies to test the code. (Well, I think)