### PR TITLE
Reflect actual timer:tc behaviour in documentation

### DIFF
--- a/lib/stdlib/doc/src/timer.xml
+++ b/lib/stdlib/doc/src/timer.xml
@@ -270,8 +270,8 @@
           <item>
             <p>Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
               <anno>Arguments</anno>)</c> and measures the elapsed real time as 
-              reported by <seealso marker="kernel:os#timestamp/0">
-              <c>os:timestamp/0</c></seealso>.</p>
+              reported by <seealso marker="erlang#monotonic_time/0">
+              <c>erlang:monotonic_time/0</c></seealso>.</p>
             <p>Returns <c>{<anno>Time</anno>, <anno>Value</anno>}</c>, where
               <c><anno>Time</anno></c> is the elapsed real time in
               <em>microseconds</em>, and <c><anno>Value</anno></c> is what is


### PR DESCRIPTION
It was switched to monotnic_time from timestamp 3 years ago
in d927209aa36fe370eb4ecf0a081923b0b951458b

(hope I got the formatting right copied it from another place where monotonic_time was references)

Thanks for Erlang/OTP :green_heart: 