### PR TITLE
Use ssh as the default remote shell

### DIFF
--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -464,7 +464,7 @@
       </item>
       <tag><c><![CDATA[-rsh Program]]></c></tag>
       <item>
-        <p>Specifies an alternative to <c><![CDATA[rsh]]></c> for starting a
+        <p>Specifies an alternative to <c><![CDATA[ssh]]></c> for starting a
           slave node on a remote host; see
           <seealso marker="stdlib:slave"><c>slave(3)</c></seealso>.</p>
       </item>

--- a/lib/common_test/test_server/ts_install.erl
+++ b/lib/common_test/test_server/ts_install.erl
@@ -268,7 +268,7 @@ add_vars(Vars0, Opts0) ->
     {Opts, [{longnames, LongNames},
 	    {platform_id, PlatformId},
 	    {platform_filename, PlatformFilename},
-	    {rsh_name, os:getenv("ERL_RSH", "rsh")},
+	    {rsh_name, os:getenv("ERL_RSH", "ssh")},
 	    {platform_label, PlatformLabel},
 	    {ts_net_dir, Mounted},
 	    {erl_flags, []},

--- a/lib/erl_interface/src/prog/erl_start.c
+++ b/lib/erl_interface/src/prog/erl_start.c
@@ -97,7 +97,7 @@
 #endif
 
 #ifndef RSH
-#define RSH "/usr/bin/rsh"
+#define RSH "/usr/bin/ssh"
 #endif
 
 #ifndef HAVE_SOCKLEN_T

--- a/lib/inets/examples/httpd_load_test/hdlt_slave.erl
+++ b/lib/inets/examples/httpd_load_test/hdlt_slave.erl
@@ -54,7 +54,7 @@
 %% 1. There must be an ssh program on computer; if not an error
 %%    is returned.
 %%
-%% 2. The hosts must be configured to allowed 'ssh' access without
+%% 2. The hosts must be configured to allow 'ssh' access without
 %%    prompts for password.
 %%
 %% The slave node will have its filer and user server redirected

--- a/lib/inets/examples/httpd_load_test/hdlt_slave.erl
+++ b/lib/inets/examples/httpd_load_test/hdlt_slave.erl
@@ -44,18 +44,17 @@
 %% this to work is that the 'erl' program can be found in PATH.
 %%
 %% If the master and slave are on different hosts, start/N uses
-%% the 'rsh' program to spawn an Erlang node on the other host.
+%% the 'ssh' program to spawn an Erlang node on the other host.
 %% Alternative, if the master was started as
 %% 'erl -sname xxx -rsh my_rsh...', then 'my_rsh' will be used instead
-%% of 'rsh' (this is useful for systems where the rsh program is named
-%% 'remsh').
+%% of 'ssh' (this is useful for systems still using rsh or remsh).
 %%
 %% For this to work, the following conditions must be fulfilled:
 %%
-%% 1. There must be an Rsh program on computer; if not an error
+%% 1. There must be an ssh program on computer; if not an error
 %%    is returned.
 %%
-%% 2. The hosts must be configured to allowed 'rsh' access without
+%% 2. The hosts must be configured to allowed 'ssh' access without
 %%    prompts for password.
 %%
 %% The slave node will have its filer and user server redirected
@@ -244,7 +243,7 @@ register_unique_name(Number) ->
 
 %% Makes up the command to start the nodes.
 %% If the node should run on the local host, there is
-%% no need to use rsh.
+%% no need to use ssh.
 
 mk_cmd(Host, Name, Paths, Args, Waiter, Prog) ->
     PaPaths = [[" -pa ", Path] || Path <- Paths], 

--- a/lib/mnesia/examples/bench/README
+++ b/lib/mnesia/examples/bench/README
@@ -46,7 +46,7 @@ you need to:
 
  - put the $ERL_TOP/bin directory in your path on all nodes
  - bind IP adresses to hostnames (e.g via DNS or /etc/hosts)
- - enable usage of rsh so it does not prompt for password
+ - enable usage of ssh so it does not prompt for password
 
 If you cannot achieve this, it is possible to run the benchmark
 anyway, but it requires more manual work to be done for each

--- a/lib/stdlib/doc/src/slave.xml
+++ b/lib/stdlib/doc/src/slave.xml
@@ -56,6 +56,13 @@
     <pre>
 -rsh Program</pre>
 
+    <p>Note that the command specified with the <c>-rsh</c> flag is
+      treated as a file name which may contain spaces. It is thus not
+      possible to include any command line options. The remote node will
+      be launched as <c>"$RSH" "$REMOTE_HOSTNAME" erl -detached -noinput
+      ...</c>, so the
+      <c>erl</c> command must be found in the path on the remote host.</p>
+
     <p>The slave node is to use the same file system at the master. At
       least, Erlang/OTP is to be installed in the same place on both
       computers and the same version of Erlang is to be used.</p>

--- a/lib/stdlib/doc/src/slave.xml
+++ b/lib/stdlib/doc/src/slave.xml
@@ -39,17 +39,17 @@
       done through the master.</p>
 
     <p>Slave nodes on other hosts than the current one are started with
-      the <c>rsh</c> program. The user must be allowed to <c>rsh</c> to
+      the <c>ssh</c> program. The user must be allowed to <c>ssh</c> to
       the remote hosts without being prompted for a password. This can
-      be arranged in a number of ways (for details, see the <c>rsh</c>
+      be arranged in a number of ways (for details, see the <c>ssh</c>
       documentation). A slave node started on the same host
       as the master inherits certain environment values from the master,
       such as the current directory and the environment variables. For
       what can be assumed about the environment when a slave is started
-      on another host, see the documentation for the <c>rsh</c>
+      on another host, see the documentation for the <c>ssh</c>
       program.</p>
 
-    <p>An alternative to the <c>rsh</c> program can be specified on
+    <p>An alternative to the <c>ssh</c> program can be specified on
       the command line to
       <seealso marker="erts:erl#erl"><c>erl(1)</c></seealso> as follows:</p>
 
@@ -166,7 +166,9 @@ slave:start(H, Name, Arg).</code>
           </item>
           <tag><c>no_rsh</c></tag>
           <item>
-            <p>There is no <c>rsh</c> program on the computer.</p>
+            <p>No remote shell program was found on the computer. Note
+            that <c>ssh</c> is used by default, but this can be overridden
+            with the <c>-rsh</c> flag.</p>
           </item>
           <tag><c>{already_running, <anno>Node</anno>}</c></tag>
           <item>

--- a/lib/stdlib/src/slave.erl
+++ b/lib/stdlib/src/slave.erl
@@ -114,7 +114,7 @@ relay1(Pid) ->
 %% 1. There must be an ssh program on computer; if not an error
 %%    is returned.
 %%
-%% 2. The hosts must be configured to allowed 'ssh' access without
+%% 2. The hosts must be configured to allow 'ssh' access without
 %%    prompts for password.
 %%
 %% The slave node will have its filer and user server redirected
@@ -341,9 +341,7 @@ do_quote_progname([Prog,Arg|Args]) ->
 		lists:flatten(lists:map(fun(X) -> [" ",X] end, [Arg|Args]))
     end.
 
-%% Give the user an opportunity to run another program,
-%% than the "rsh".  On HP-UX rsh is called remsh; thus HP users
-%% must start erlang as erl -rsh remsh.
+%% Give the user an opportunity to run another program than "ssh".
 %%
 %% Also checks that the given program exists.
 %%

--- a/lib/stdlib/src/slave.erl
+++ b/lib/stdlib/src/slave.erl
@@ -104,18 +104,17 @@ relay1(Pid) ->
 %% this to work is that the 'erl' program can be found in PATH.
 %%
 %% If the master and slave are on different hosts, start/N uses
-%% the 'rsh' program to spawn an Erlang node on the other host.
+%% the 'ssh' program to spawn an Erlang node on the other host.
 %% Alternative, if the master was started as
 %% 'erl -sname xxx -rsh my_rsh...', then 'my_rsh' will be used instead
-%% of 'rsh' (this is useful for systems where the rsh program is named
-%% 'remsh').
+%% of 'ssh' (this is useful for systems still using rsh or remsh).
 %%
 %% For this to work, the following conditions must be fulfilled:
 %%
-%% 1. There must be an Rsh program on computer; if not an error
+%% 1. There must be an ssh program on computer; if not an error
 %%    is returned.
 %%
-%% 2. The hosts must be configured to allowed 'rsh' access without
+%% 2. The hosts must be configured to allowed 'ssh' access without
 %%    prompts for password.
 %%
 %% The slave node will have its filer and user server redirected
@@ -286,7 +285,7 @@ register_unique_name(Number) ->
 
 %% Makes up the command to start the nodes.
 %% If the node should run on the local host, there is
-%% no need to use rsh.
+%% no need to use a remote shell.
 
 mk_cmd(Host, Name, Args, Waiter, Prog0) ->
     Prog = quote_progname(Prog0),
@@ -354,7 +353,7 @@ rsh() ->
     Rsh =
 	case init:get_argument(rsh) of
 	    {ok, [[Prog]]} -> Prog;
-	    _ -> "rsh"
+	    _ -> "ssh"
 	end,
     case os:find_executable(Rsh) of
 	false -> {error, no_rsh};


### PR DESCRIPTION
How about moving away from "rsh" for starting slave nodes etc? On some distros, rsh is a link to ssh, so it kind of works anysay, but I'm not sure if this is something that should be relied on. Better to make ssh the official default, I think. I have updated all relevant places I could find.

I also discovered that test_server checks for an undocumented environment variable ERL_RSH. The only use of this that I could find in the wild was tsung.