### PR TITLE
Remove trace-specific terms from docs for table-oriented matchspecs

### DIFF
--- a/erts/doc/src/match_spec.xml
+++ b/erts/doc/src/match_spec.xml
@@ -169,10 +169,9 @@
         <c><![CDATA[is_reference]]></c> | <c><![CDATA[is_tuple]]></c> |
         <c><![CDATA[is_map]]></c> | <c><![CDATA[is_binary]]></c> |
         <c><![CDATA[is_function]]></c> | <c><![CDATA[is_record]]></c> |
-        <c><![CDATA[is_seq_trace]]></c> | <c><![CDATA['and']]></c> |
-        <c><![CDATA['or']]></c> | <c><![CDATA['not']]></c> |
-        <c><![CDATA['xor']]></c> | <c><![CDATA['andalso']]></c> |
-        <c><![CDATA['orelse']]></c>
+        <c><![CDATA['and']]></c> | <c><![CDATA['or']]></c> |
+        <c><![CDATA['not']]></c> | <c><![CDATA['xor']]></c> |
+        <c><![CDATA['andalso']]></c> | <c><![CDATA['orelse']]></c>
       </item>
       <item>ConditionExpression ::= ExprMatchVariable | { GuardFunction } |
         { GuardFunction, ConditionExpression, ... } | TermConstruct
@@ -202,8 +201,7 @@
         <c><![CDATA['>=']]></c> | <c><![CDATA['<']]></c> |
         <c><![CDATA['=<']]></c> | <c><![CDATA['=:=']]></c> |
         <c><![CDATA['==']]></c> | <c><![CDATA['=/=']]></c> |
-        <c><![CDATA['/=']]></c> | <c><![CDATA[self]]></c> |
-        <c><![CDATA[get_tcw]]></c>
+        <c><![CDATA['/=']]></c> | <c><![CDATA[self]]></c>
       </item>
       <item>MatchBody ::= [ ConditionExpression, ... ]
       </item>


### PR DESCRIPTION
This removes the matchspec instructions `is_seq_trace` and `get_tcw/0`
from the documentation for table-oriented matchspecs.

This is likely correct as both are already documented under "Functions
Allowed Only for Tracing", despite appearing in the list of possible
options for table specs.

The following observations further back this change up:

```erl
erlang:match_spec_test([whatever], [{'_', [], [{is_seq_trace}]}], trace).
%=> {ok,true,[],[]}
erlang:match_spec_test({whatever}, [{'_', [], [{is_seq_trace}]}], table).
%=> {error,[{error,"Special form 'is_seq_trace' used in wrong dialect."}]}

erlang:match_spec_test([whatever], [{'_', [], [{get_tcw}]}], trace).
%=> {ok,true,[],[]}
erlang:match_spec_test({whatever}, [{'_', [], [{get_tcw}]}], table).
%=> {error,[{error,"Function get_tcw/0 cannot be called in this context."}]}
```