### PR TITLE
Make stacktraces consistent when backtrace_depth is 0

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1150,6 +1150,13 @@ BIF_RETTYPE raise_3(BIF_ALIST_3)
     /* Create stacktrace and store */
     if (erts_backtrace_depth < depth) {
 	depth = erts_backtrace_depth;
+        if (depth == 0) {
+            /*
+             * For consistency with stacktraces generated
+             * automatically, always include one element.
+             */
+            depth = 1;
+        }
 	must_copy = 1;
     }
     if (must_copy) {


### PR DESCRIPTION
It is allowed to set the backtrace depth to 0, but when
an exception is catched the stacktrace will still contain
one element:

    1> erlang:system_flag(backtrace_depth, 0).
    8
    2> catch error(badarg).
    {'EXIT',{badarg,[{shell,apply_fun,3,
                        [{file,"shell.erl"},{line,908}]}]}}

However, when an exception is raised using `erlang:raise/3`, there
will be no elements in the stacktrace:

    3> catch erlang:raise(error, badarg, [{fake,name,[arg],[]}]).
    {'EXIT',{badarg,[]}}

Since the `error_handler` module uses `erlang:raise/3` to
raise an exception when an undefined function is called,
there will not be any stacktrace when calling an undefined
function:

    4> catch undef_module:undef_name(some_argument).
    {'EXIT',{undef,[]}}

Fix this inconsistency by changing `erlang:raise/3` so that
it always includes one element in the stacktrace:

    3> catch erlang:raise(error, badarg, [{fake,name,[arg],[]}]).
    {'EXIT',{badarg,[{fake,name,[arg],[]}]}}
    4> catch undef_module:undef_name(some_argument).
    {'EXIT',{undef,[{undef_module,undef_name,[some_argument],[]}]}}