### PR TITLE
Explicitly allow custom keys in the .app file

### DIFF
--- a/lib/kernel/doc/src/app.xml
+++ b/lib/kernel/doc/src/app.xml
@@ -231,6 +231,8 @@ ApplicationVersion = string()</code>
 	  applications are expected to be correct in OTP 18.</p></warning>
       </item>
     </taglist>
+    <p>In addition to the ones speficied above, application resource files
+      are allowed to include custom keys in the property list.</p>
   </section>
 
   <section>


### PR DESCRIPTION
This is really a question in the shape of a patch :).

The documentation in http://erlang.org/doc/man/app.html suggests to me that the property list is the one specified there, with those specified keys. But I have seen that some applications include custom keys, see for example [hackney.app.src](https://github.com/benoitc/hackney/blob/master/src/hackney.app.src), or [poolboy.app.src](https://github.com/devinus/poolboy/blob/master/src/poolboy.app.src), which contain keys `maintainers`, `licenses`, and `links`.

Those particular keys are there because [they are processed by rebar3_hex](https://github.com/tsloughter/rebar3_hex/blob/2afad6063305eafa00384b09b2dd1e4ca6bb150a/src/rebar3_hex_pkg.erl#L159-L162).

The question for someone generating application resource files is: is that technically valid and thus the proposed patch says something true? or it isn't, the patch is not good, and `rebar3_hex` should revise that contract and move that metadata somewhere else?
