### PR TITLE
fix integer truncation bugs in error logger path

### DIFF
--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -140,7 +140,7 @@ Eterm*
 erts_set_hole_marker(Eterm* ptr, Uint sz)
 {
     Eterm* p = ptr;
-    int i;
+    Uint i;
 
     for (i = 0; i < sz; i++) {
 	*p++ = ERTS_HOLE_MARKER;
@@ -1990,7 +1990,7 @@ static void do_send_logger_message(Eterm *hp, ErlOffHeap *ohp, ErlHeapFragment *
    {notify,{info_msg,gleader,{emulator,format,[args]}}} |
    {notify,{error,gleader,{emulator,format,[args]}}} |
    {notify,{warning_msg,gleader,{emulator,format,[args}]}} */
-static int do_send_to_logger(Eterm tag, Eterm gleader, char *buf, int len)
+static int do_send_to_logger(Eterm tag, Eterm gleader, char *buf, size_t len)
 {
     Uint sz;
     Eterm gl;
@@ -2003,7 +2003,7 @@ static int do_send_to_logger(Eterm tag, Eterm gleader, char *buf, int len)
 
     ASSERT(is_atom(tag));
 
-    if (len <= 0) {
+    if (len == 0) {
 	return -1;
     }
 
@@ -2036,7 +2036,7 @@ static int do_send_to_logger(Eterm tag, Eterm gleader, char *buf, int len)
 }
 
 static int do_send_term_to_logger(Eterm tag, Eterm gleader,
-				  char *buf, int len, Eterm args)
+				  char *buf, size_t len, Eterm args)
 {
     Uint sz;
     Eterm gl;
@@ -2077,13 +2077,13 @@ static int do_send_term_to_logger(Eterm tag, Eterm gleader,
 }
 
 static ERTS_INLINE int
-send_info_to_logger(Eterm gleader, char *buf, int len)
+send_info_to_logger(Eterm gleader, char *buf, size_t len)
 {
     return do_send_to_logger(am_info_msg, gleader, buf, len);
 }
 
 static ERTS_INLINE int
-send_warning_to_logger(Eterm gleader, char *buf, int len)
+send_warning_to_logger(Eterm gleader, char *buf, size_t len)
 {
     Eterm tag;
     switch (erts_error_logger_warnings) {
@@ -2095,13 +2095,13 @@ send_warning_to_logger(Eterm gleader, char *buf, int len)
 }
 
 static ERTS_INLINE int
-send_error_to_logger(Eterm gleader, char *buf, int len)
+send_error_to_logger(Eterm gleader, char *buf, size_t len)
 {
     return do_send_to_logger(am_error, gleader, buf, len);
 }
 
 static ERTS_INLINE int
-send_error_term_to_logger(Eterm gleader, char *buf, int len, Eterm args)
+send_error_term_to_logger(Eterm gleader, char *buf, size_t len, Eterm args)
 {
     return do_send_term_to_logger(am_error, gleader, buf, len, args);
 }


### PR DESCRIPTION
Sending a large term to the error logger has two problems related
to the size and sign of the variables used to represent lengths:

- the API functions (erts_send_error_term_to_logger() et al) perform
  an unchecked narrowing conversion from size_t to int when passing
  dsbufp->str_len to the internal functions; this may both truncate
  the length and make it negative

- do_send_term_to_logger() and do_send_to_logger() multiply the
  int-typed length by 2 before widening it to Uint and adding a few
  more values; the intermediate product may overflow causing loss
  of high bits and a change of sign; if the intermediate product is
  negative the final size will be an extremely large positive value

The end result is that the computed buffer size can be arbitrarily
wrong, either too small or too large.

While reviewing this code I also found and fixed a potential narrowing
bug in erts_set_hole_marker().

--
I don't have a test case, but this is based on analysis of a SIGSEGV
posted to the mailing list: http://erlang.org/pipermail/erlang-questions/2018-April/095285.html