### PR TITLE
erl_interface: fix bad memset

### DIFF
--- a/lib/erl_interface/src/legacy/erl_marshal.c
+++ b/lib/erl_interface/src/legacy/erl_marshal.c
@@ -107,7 +107,7 @@ static int init_cmp_num_class_p=1; /* initialize array, the first time */
 void erl_init_marshal(void)
 {
   if (init_cmp_array_p) {
-    memset(cmp_array, 0, CMP_ARRAY_SIZE);
+    memset(cmp_array, 0, sizeof cmp_array);
     cmp_array[ERL_SMALL_INTEGER_EXT] = ERL_NUM_CMP;
     cmp_array[ERL_INTEGER_EXT]       = ERL_NUM_CMP;
     cmp_array[ERL_FLOAT_EXT]         = ERL_NUM_CMP;


### PR DESCRIPTION
Compiling OTP-20.3.4 with GCC-7 generates the following warning:

 CC     /tmp/otp_src_20.3.4/lib/erl_interface/obj.st/x86_64-unknown-linux-gnu/erl_marshal.o
legacy/erl_marshal.c: In function 'erl_init_marshal':
legacy/erl_marshal.c:110:5: warning: 'memset' used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
     memset(cmp_array, 0, CMP_ARRAY_SIZE);
     ^~~~~~

CMP_ARRAY_SIZE (256) is the number of elements in that array, but the
elements are not char but enum, which is 4 bytes on e.g. x86-64.
This results in 3/4 of the array not being correctly initialized.

Idiomatic C is to pass sizeof cmp_array to memset(), so that's what I did.