### PR TITLE
Rewrite a call of a literal external fun to a direct call

### DIFF
--- a/lib/compiler/test/fun_SUITE.erl
+++ b/lib/compiler/test/fun_SUITE.erl
@@ -194,6 +194,17 @@ external(Config) when is_list(Config) ->
     ?APPLY2(ListsMod, ListsMap, 2),
     ?APPLY2(ListsMod, ListsMap, ListsArity),
 
+    42 = (fun erlang:abs/1)(-42),
+    42 = (id(fun erlang:abs/1))(-42),
+    42 = apply(fun erlang:abs/1, [-42]),
+    42 = apply(id(fun erlang:abs/1), [-42]),
+    6 = (fun lists:sum/1)([1,2,3]),
+    6 = (id(fun lists:sum/1))([1,2,3]),
+
+    {'EXIT',{{badarity,_},_}} = (catch (fun lists:sum/1)(1, 2, 3)),
+    {'EXIT',{{badarity,_},_}} = (catch (id(fun lists:sum/1))(1, 2, 3)),
+    {'EXIT',{{badarity,_},_}} = (catch apply(fun lists:sum/1, [1,2,3])),
+
     ok.
 
 call_me(I) ->


### PR DESCRIPTION
Rewrite calls such as:

    (fun erlang:abs/1)(-42)

to:

    erlang:abs(-42)

While we are at it, also add rewriting of `apply/2` with a fixed
number of arguments to a direct call of the fun. For example:

    apply(F, [A,B])

would be rewritten to:

    F(A, B)

https://bugs.erlang.org/browse/ERL-614