### PR TITLE
Fix syntactic issues in EDoc comments across some libs

### DIFF
--- a/lib/compiler/src/cerl_trees.erl
+++ b/lib/compiler/src/cerl_trees.erl
@@ -351,10 +351,9 @@ mapfold(F, S0, T) ->
   mapfold(fun(T0, A) -> {T0, A} end, F, S0, T).
 
 
-%% @spec mapfold(Pre, Post, Initial::term(), Tree::cerl()) ->
-%%           {cerl(), term()}
-%%
-%%    Pre = Post = (cerl(), term()) -> {cerl(), term()}
+%% @spec mapfold(Pre, Post, Initial::term(), Tree::cerl()) -> {cerl(), term()}
+%%       Pre  = (cerl(), term()) -> {cerl(), term()}
+%%       Post = (cerl(), term()) -> {cerl(), term()}
 %%
 %% @doc Does a combined map/fold operation on the nodes of the
 %% tree. It begins by calling <code>Pre</code> on the tree, using the

--- a/lib/edoc/src/edoc_doclet.erl
+++ b/lib/edoc/src/edoc_doclet.erl
@@ -40,7 +40,7 @@
 
 -import(edoc_report, [report/2, warning/2]).
 
-%% @headerfile "edoc_doclet.hrl"
+%% @headerfile "../include/edoc_doclet.hrl"
 -include("../include/edoc_doclet.hrl").
 
 -define(EDOC_APP, edoc).

--- a/lib/kernel/src/hipe_unified_loader.erl
+++ b/lib/kernel/src/hipe_unified_loader.erl
@@ -453,7 +453,7 @@ make_beam_stub(Mod, LoaderState, MD5, Beam, FunDefs, ClosuresToPatch) ->
 %%========================================================================
 %% Patching 
 %%  @spec patch(refs(), BaseAddress::integer(), ConstAndZone::term(),
-%%              FunDefs::term(), TrampolineMap::term()) -> 'ok'.
+%%              FunDefs::term(), TrampolineMap::term()) -> 'ok'
 %%   @type refs()=[{RefType::integer(), Reflist::reflist()} | refs()]
 %%
 %%   @type reflist()=   [{Data::term(), Offsets::offests()}|reflist()]


### PR DESCRIPTION
See https://github.com/erszcz/docsh/issues/23 for an explanation about how the files were found.

This PR doesn't add any meaningful documentation, it only makes `edoc:get_doc(File, [])` on the files in question not result in an error anymore.