### PR TITLE
Update global name typespec

### DIFF
--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -122,7 +122,7 @@
 -type add_handler_ret()  :: ok | term() | {'EXIT',term()}.
 -type del_handler_ret()  :: ok | term() | {'EXIT',term()}.
 
--type emgr_name() :: {'local', atom()} | {'global', atom()}
+-type emgr_name() :: {'local', atom()} | {'global', term()}
                    | {'via', atom(), term()}.
 -type debug_flag() :: 'trace' | 'log' | 'statistics' | 'debug'
                     | {'logfile', string()}.
@@ -130,7 +130,7 @@
                 | {'debug', [debug_flag()]}
                 | {'spawn_opt', [proc_lib:spawn_option()]}
                 | {'hibernate_after', timeout()}.
--type emgr_ref()  :: atom() | {atom(), atom()} |  {'global', atom()}
+-type emgr_ref()  :: atom() | {atom(), atom()} |  {'global', term()}
                    | {'via', atom(), term()} | pid().
 -type start_ret() :: {'ok', pid()} | {'error', term()}.
 
@@ -146,7 +146,7 @@
 %% start_link()
 %% start_link(MgrName | Options)
 %% start_link(MgrName, Options)
-%%    MgrName ::= {local, atom()} | {global, atom()} | {via, atom(), term()}
+%%    MgrName ::= {local, atom()} | {global, term()} | {via, atom(), term()}
 %%    Options ::= [{timeout, Timeout} | {debug, [Flag]} | {spawn_opt,SOpts}]
 %%       Flag ::= trace | log | {logfile, File} | statistics | debug
 %%          (debug == log && statistics)

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -166,7 +166,7 @@
 %%% start(Name, Mod, Args, Options)
 %%% start_link(Mod, Args, Options)
 %%% start_link(Name, Mod, Args, Options) where:
-%%%    Name ::= {local, atom()} | {global, atom()} | {via, atom(), term()}
+%%%    Name ::= {local, atom()} | {global, term()} | {via, atom(), term()}
 %%%    Mod  ::= atom(), callback module implementing the 'real' server
 %%%    Args ::= term(), init arguments (to Mod:init/1)
 %%%    Options ::= [{timeout, Timeout} | {debug, [Flag]}]


### PR DESCRIPTION
Global names don't have to be a single atom (see http://erlang.org/doc/man/global.html).

More evidence (test_event_handler echos whatever it receives):
```
1> Name = {global, {one, two}}. 
{global,{one,two}}
2> gen_event:start_link(Name).
{ok,<0.91.0>}
3> gen_event:add_handler(Name, test_event_handler, []).
ok
4> gen_event:notify(Name, event).
Got event: event
ok
5> Name2 = {global, <<"not_an_atom">>}.
{global,<<"not_an_atom">>}
6> gen_event:start_link(Name2).                        
{ok,<0.96.0>}
7> gen_event:add_handler(Name2, test_event_handler, []).
ok
8> gen_event:notify(Name2, event).                      
Got event: event
ok
```