### PR TITLE
Optimize binary match from 10% up to 70x

### DIFF
--- a/lib/stdlib/test/stdlib.spec
+++ b/lib/stdlib/test/stdlib.spec
@@ -1,4 +1,4 @@
 {suites,"../stdlib_test",all}.
 {skip_groups,"../stdlib_test",stdlib_bench_SUITE,
-             [base64,gen_server,gen_statem,unicode],
+             [binary,base64,gen_server,gen_statem,unicode],
              "Benchmark only"}.


### PR DESCRIPTION
The idea is to use `memchr` on the first lookup for `binary:match/2` and also after every match on `binary:matches/2`.

This speeds up binary matching and binary splitting by 4x in some cases and by 70x in other scenarios (when the last character in the needle does not occur in the subject).

The reason to use memchr is that it is highly specialized in most modern operating systems, often implemented in assembly and using SIMD instructions.

The implementation uses the reduction count to figure out how many bytes should be read with memchr.

Huge thanks to @k0kubun to pointing me towards SIMD and memchr. And thanks to @citizen428 for the pairing.

PS: I know the OTP team is busy this week so feel free to let this sit for a while. :)