### PR TITLE
Optimise creation of anonymous functions

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -1742,6 +1742,10 @@ true</pre>
           <item>
             <p><c>Pid</c> is the process identifier of the process
               that originally created the fun.</p>
+            <p>It might point to the <c>init</c> process if the
+              <c>Fun</c> was statically allocated when module was
+              loaded (this optimisation is performed for local
+              functions that do not capture the enviornment).</p>
           </item>
           <tag><c>{index, Index}</c></tag>
           <item>

--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -108,6 +108,7 @@ process_killer(void)
 		    erts_exit(0, "");
 		switch(j) {
 		case 'k':
+                    ASSERT(erts_init_process_id != ERTS_INVALID_PID);
                     /* Send a 'kill' exit signal from init process */
                     erts_proc_sig_send_exit(NULL, erts_init_process_id,
                                             rp->common.id, am_kill, NIL,

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -128,7 +128,7 @@ const Eterm etp_hole_marker = 0;
 
 static int modified_sched_thread_suggested_stack_size = 0;
 
-Eterm erts_init_process_id;
+Eterm erts_init_process_id = ERTS_INVALID_PID;
 
 /*
  * Note about VxWorks: All variables must be initialized by executable code,
@@ -2258,6 +2258,7 @@ erl_start(int argc, char **argv)
 
     erts_init_process_id = erl_first_process_otp("otp_ring0", NULL, 0,
                                                  boot_argc, boot_argv);
+	ASSERT(erts_init_process_id != ERTS_INVALID_PID);
 
     {
 	/*

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -963,12 +963,16 @@ dump_module_literals(fmtfn_t to, void *to_arg, ErtsLiteralArea* lit_area)
                     }
                     erts_putc(to, to_arg, '\n');
                 }
-            } else if (is_export_header(w)) {
+            } else if (is_export_header(w) || is_fun_header(w)) {
                 dump_externally(to, to_arg, term);
                 erts_putc(to, to_arg, '\n');
             }
             size = 1 + header_arity(w);
             switch (w & _HEADER_SUBTAG_MASK) {
+            case FUN_SUBTAG:
+                ASSERT(((ErlFunThing*)(htop))->num_free == 0);
+                size += 1;
+                break;
             case MAP_SUBTAG:
                 if (is_flatmap_header(w)) {
                     size += 1 + flatmap_get_size(htop);

--- a/erts/emulator/test/code_SUITE_data/literals.erl
+++ b/erts/emulator/test/code_SUITE_data/literals.erl
@@ -19,7 +19,8 @@
 %%
 
 -module(literals).
--export([a/0,b/0,huge_bignum/0,binary/0,unused_binaries/0,bits/0]).
+-export([a/0,b/0,huge_bignum/0,funs/0,
+         binary/0,unused_binaries/0,bits/0]).
 -export([msg1/0,msg2/0,msg3/0,msg4/0,msg5/0]).
 
 a() ->
@@ -108,3 +109,8 @@ msg2() -> {"hello","world"}.
 msg3() -> <<"halloj">>.
 msg4() -> #{ 1=> "hello", b => "world"}.
 msg5() -> {1,2,3,4,5,6}.
+
+funs() ->
+    %% Literal funs (in a non-literal list).
+    [fun ?MODULE:a/0,
+     fun() -> ok end].                          %No environment.

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -1679,7 +1679,7 @@ make_fun() ->
     receive {Pid, Fun} -> Fun end.
 
 make_fun(Pid) ->
-    Pid ! {self(), fun make_fun/1}.
+    Pid ! {self(), fun (X) -> {X, Pid} end}.
 
 fun_pid(Fun) ->
     erlang:fun_info(Fun, pid).


### PR DESCRIPTION
This intorduces a similar optimisation for normal funs
to what was introduced for external funs in #1725.
It is possible to allocate the fun as a literal, if it does not capture
the environemt (i.e. it does not close over any variables).
Unfortunately it's not possible to do this in the compiler due to
problems with representation of such functions in the `.beam` files.
Fortunately, we can do this in the loader.

Simple evaluation shows that functions that don't capture the
enviornment consistute over 60% of all funs in the source code of
Erlang/OTP itself.

The only downside is that we lose a meningful value in the `pid` field
of the fun. The goal of this field, beyond debugging, was to be
able to identify the original node of a function. To be able to still do
this, the functions that are created in the loader are assigned the init
pid as the creator.