### PR TITLE
Maps inconsistency from 20.0 to OTP-21.0-rc1-84-gfefb15c576

### DIFF
--- a/lib/stdlib/test/maps_SUITE.erl
+++ b/lib/stdlib/test/maps_SUITE.erl
@@ -108,6 +108,8 @@ t_without_2(_Config) ->
     %% error case
     ?badmap(a,without,[[a,b],a]) = (catch maps:without([a,b],id(a))),
     ?badmap(a,without,[{a,b},a]) = (catch maps:without({a,b},id(a))),
+    ?badmap({0,<<>>,97},without,[[],{0,<<>>,97}]) = (catch maps:without([], {0,<<>>,97})),
+    ?badmap({0,<<>>,97},without,[[false, -20, -8],{0,<<>>,97}]) = (catch maps:without([false, -20, -8], {0, <<>>, 97})),
     ?badarg(without,[a,#{}]) = (catch maps:without(a,#{})),
     ok.
 
@@ -120,6 +122,8 @@ t_with_2(_Config) ->
     %% error case
     ?badmap(a,with,[[a,b],a]) = (catch maps:with([a,b],id(a))),
     ?badmap(a,with,[{a,b},a]) = (catch maps:with({a,b},id(a))),
+    ?badmap({0,<<>>,97},with,[[],{0,<<>>,97}]) = (catch maps:with([], {0,<<>>,97})),
+    ?badmap({0,<<>>,97},with,[[false, -20, -8],{0,<<>>,97}]) = (catch maps:with([false, -20, -8], {0, <<>>, 97})),
     ?badarg(with,[a,#{}]) = (catch maps:with(a,#{})),
     ok.
 


### PR DESCRIPTION
As part of writing some new QuickCheck model for maps iterators, I've run into the following inconsistency:

In Release 20.0:

```
Erlang/OTP 20 [erts-9.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V9.3  (abort with ^G)
1> maps:with([], {0, <<>>, 97}).
** exception error: {badmap,{0,<<>>,97}}
     in function  maps:with/2
        called as maps:with([],{0,<<>>,97})
2> 
```

Whereas in gfefb15c, we have:

```
Erlang/OTP 21 [RELEASE CANDIDATE 1] [erts-9.3.1] [source-b873e5cd6d] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]

Eshell V9.3.1  (abort with ^G)
1> maps:with([], {0, <<>>, 97}).
** exception error: bad argument
     in function  maps:with/2
        called as maps:with([],{0,<<>>,97})
2> 
```

The difference is in the error return.

The "map" `{0, <<>>, 97}` is the shrunk QuickCheck case, and this explains (partially), why this fails since it cannot be shrunk further. The culprit is the macro `?IS_ITERATOR(..)` which was changed in commit 0149a73d15d by @garazdawi. Since one can now pass an iterator, the quickcheck model generates an "iterator" randomly, which manages to pass the above macro (It is a tuple of size 3).

I currently think this is a bug.

* The `with/2` specification _requires_ a map. So the correct answer ought to be `{badmap, {0, <<>>, 97}}`.
* The change to the function `error_type/1` "captures too much" so to speak in this case. It assumes valid maps and iterators means that some other argument is bad (hence the badarg), but in the case of `with/2` and `without/2`, iterators are _not_ allowed.
* If code relies on matching the `badmap` error (Elixir, LFE, ...?), then they might be in for a surprise.

I've added test cases to `with/2` and `without/2` in `maps_SUITE`. It will currently fail on `master`, but if we accept the change in API, we better lock it down in test cases.

I have made no changes to the code yet, but I think the correct solution is to avoid the `error_type/1` function so the `?IS_ITERATOR(..)` overlap doesn't happen.

_NOTE:_ This is the first inconsistency I found, and as I work on the QuickCheck model I might find more. I can add them as PRs or add them to bugs.erlang.org, whichever you prefer.
