### PR TITLE
Add typespecs for netns and bind_to_device options

### DIFF
--- a/lib/kernel/src/gen_sctp.erl
+++ b/lib/kernel/src/gen_sctp.erl
@@ -118,6 +118,8 @@ open() ->
                    | inet:address_family()
                    | {port,Port}
 		   | {type,SockType}
+                   | {netns, file:filename_all()}
+                   | {bind_to_device, binary()}
                    | option(),
               IP :: inet:ip_address() | any | loopback,
               Port :: inet:port_number(),

--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -102,6 +102,8 @@
         inet:address_family() |
         {port, inet:port_number()} |
         {tcp_module, module()} |
+        {netns, file:filename_all()} |
+        {bind_to_device, binary()} |
         option().
 -type listen_option() ::
         {ip, inet:socket_address()} |
@@ -111,6 +113,8 @@
         {port, inet:port_number()} |
         {backlog, B :: non_neg_integer()} |
         {tcp_module, module()} |
+        {netns, file:filename_all()} |
+        {bind_to_device, binary()} |
         option().
 -type socket() :: port().
 

--- a/lib/kernel/src/gen_udp.erl
+++ b/lib/kernel/src/gen_udp.erl
@@ -97,6 +97,8 @@ open(Port) ->
               | {ifaddr, inet:socket_address()}
               | inet:address_family()
               | {port, inet:port_number()}
+              | {netns, file:filename_all()}
+              | {bind_to_device, binary()}
               | option(),
       Socket :: socket(),
       Reason :: inet:posix().


### PR DESCRIPTION
Some networking functions accept the options netns (to switch network
namespaces) and bind_to_device (to bind to a device with
SO_BINDTODEVICE), but these functions are not annotated to accept these
options, which causes dialyzer to raise issues.

This patch applies these type specs to the options for
gen_tcp:connect/3,4, gen_tcp:listen/2, gen_udp:open/1,2, and
gen_sctp:open/0,1,2, as these are the documented functions which accept
the netns and bind_to_device options.