### PR TITLE
dialyzer: Do not emit warnings for unreachable funs

### DIFF
--- a/lib/dialyzer/test/small_SUITE_data/results/unused_funs
+++ b/lib/dialyzer/test/small_SUITE_data/results/unused_funs
@@ -1,0 +1,5 @@
+
+unused_funs.erl:10: The pattern 'error' can never match the type 'other_error'
+unused_funs.erl:15: Function not_used/0 will never be called
+unused_funs.erl:19: Function foo/1 will never be called
+unused_funs.erl:7: Function test/0 has no local return

--- a/lib/dialyzer/test/small_SUITE_data/src/unused_funs.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/unused_funs.erl
@@ -1,0 +1,21 @@
+%% See also ERL-593.
+
+-module(unused_funs).
+
+-export([test/0]).
+
+test() -> % "has no local return"
+    Var = outer_scope,
+    case other_error of
+        error -> % "can never match"
+            %% No warnings "no local return" and "_ = 1 can never match 0" (!)
+            foo(fun() -> {Var, 1 = 0} end)
+    end.
+
+not_used() -> % "will never be called"
+    %% No warnings "no local return" and "1 can never match 0".
+    foo(fun() -> 1 = 0 end).
+
+foo(Fun) -> % "will never be called"
+    1 = 0, % No pattern match warning (foo/1 is not traversed at all).
+    Fun().


### PR DESCRIPTION
Warnings are not generated for funs residing in dead code.

In particular, warnings like "The created fun has no local return" are
no longer generated for funs declared in clauses or functions that
cannot be run.