### PR TITLE
ssl: Correct key_usage check

### DIFF
--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -2233,13 +2233,12 @@ sign_algo(Alg) ->
 is_acceptable_hash_sign(Algos, _, _, KeyExAlgo, SupportedHashSigns) when 
       KeyExAlgo == dh_dss;
       KeyExAlgo == dh_rsa;
-      KeyExAlgo == ecdh_ecdsa;
       KeyExAlgo == ecdh_rsa;
       KeyExAlgo == ecdh_ecdsa
       ->
     %% *dh_* could be called only *dh in TLS-1.2
     is_acceptable_hash_sign(Algos, SupportedHashSigns); 
-is_acceptable_hash_sign(Algos, rsa, ecdsa, ecdh_rsa, SupportedHashSigns) ->
+is_acceptable_hash_sign(Algos, rsa, ecdsa, ecdhe_rsa, SupportedHashSigns) ->
     is_acceptable_hash_sign(Algos, SupportedHashSigns); 
 is_acceptable_hash_sign({_, rsa} = Algos, rsa, _, dhe_rsa, SupportedHashSigns) ->
     is_acceptable_hash_sign(Algos, SupportedHashSigns); 
@@ -2270,7 +2269,7 @@ is_acceptable_hash_sign(_, _, _, KeyExAlgo, _) when
       KeyExAlgo == ecdhe_anon     
       ->
     true; 
-is_acceptable_hash_sign(_,_, _,_,_) ->
+is_acceptable_hash_sign(_,_,_,_,_) ->
     false.					
 is_acceptable_hash_sign(Algos, SupportedHashSigns) ->
     lists:member(Algos, SupportedHashSigns).

--- a/lib/ssl/test/ssl_ECC.erl
+++ b/lib/ssl/test/ssl_ECC.erl
@@ -34,53 +34,65 @@
 
 %% ECDH_RSA 
 client_ecdh_rsa_server_ecdh_rsa(Config) when is_list(Config) ->
+    Ext = x509_test:extensions([{key_usage, [keyAgreement]}]),
     Suites = all_rsa_suites(Config),
     Default = ssl_test_lib:default_cert_chain_conf(),
-    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                        [[], [], [{extensions, Ext}]]},
                                                        {client_chain, Default}],
                                                       ecdh_rsa, ecdh_rsa, Config),
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 
                ssl_test_lib:ssl_options(SOpts, Config),
                [{check_keyex, ecdh_rsa}, {ciphers, Suites} | proplists:delete(check_keyex, Config)]).
 client_ecdhe_rsa_server_ecdh_rsa(Config)  when is_list(Config) ->
+    Ext = x509_test:extensions([{key_usage, [keyAgreement]}]),
     Suites = all_rsa_suites(Config),
     Default = ssl_test_lib:default_cert_chain_conf(),
-    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                        [[], [], [{extensions, Ext}]]},
                                                        {client_chain, Default}], 
                                                       ecdhe_rsa, ecdh_rsa, Config),
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 
                ssl_test_lib:ssl_options(SOpts, Config),  
                [{check_keyex, ecdh_rsa}, {ciphers, Suites} | proplists:delete(check_keyex, Config)]).
 client_ecdhe_ecdsa_server_ecdh_rsa(Config)  when is_list(Config) ->
+    Ext = x509_test:extensions([{key_usage, [keyAgreement]}]),
     Suites = all_rsa_suites(Config),
     Default = ssl_test_lib:default_cert_chain_conf(),
-    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                        [[], [], [{extensions, Ext}]]},
                                                        {client_chain, Default}],
                                                       ecdhe_ecdsa, ecdh_rsa, Config),
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 
-               ssl_test_lib:ssl_options(SOpts, Config),
-               [{check_keyex, ecdh_rsa}, {ciphers, Suites} | proplists:delete(check_keyex, Config)]).
+                            ssl_test_lib:ssl_options(SOpts, Config),
+                            [{check_keyex, ecdh_rsa}, {ciphers, Suites} | proplists:delete(check_keyex, Config)]).
 
 %% ECDHE_RSA    
 client_ecdh_rsa_server_ecdhe_rsa(Config)  when is_list(Config) ->
+    Ext = x509_test:extensions([{key_usage, [digitalSignature]}]),
     Default = ssl_test_lib:default_cert_chain_conf(),
-    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                        [[], [], [{extensions, Ext}]]},
                                                        {client_chain, Default}], 
                                                       ecdh_rsa, ecdhe_rsa, Config),
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 
                ssl_test_lib:ssl_options(SOpts, Config), 
                [{check_keyex, ecdhe_rsa} | proplists:delete(check_keyex, Config)]).
 client_ecdhe_rsa_server_ecdhe_rsa(Config)  when is_list(Config) ->
+    Ext = x509_test:extensions([{key_usage, [digitalSignature]}]),
     Default = ssl_test_lib:default_cert_chain_conf(),
-    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                        [[], [], [{extensions, Ext}]]},
                                                        {client_chain, Default}], 
                                                       ecdhe_rsa, ecdhe_rsa, Config),
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 
-               ssl_test_lib:ssl_options(SOpts, Config),  
+                            ssl_test_lib:ssl_options(SOpts, Config),
                [{check_keyex, ecdhe_rsa} | proplists:delete(check_keyex, Config)]).
 client_ecdhe_ecdsa_server_ecdhe_rsa(Config)  when is_list(Config) ->
+    Ext = x509_test:extensions([{key_usage, [digitalSignature]}]),
     Default = ssl_test_lib:default_cert_chain_conf(),
-    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                        [[], [], [{extensions, Ext}]]},
                                                        {client_chain, Default}],
                                                       ecdh_ecdsa, ecdhe_rsa, Config),
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 
@@ -122,24 +134,30 @@ client_ecdhe_ecdsa_server_ecdh_ecdsa(Config)  when is_list(Config) ->
 
 %% ECDHE_ECDSA
 client_ecdh_rsa_server_ecdhe_ecdsa(Config)  when is_list(Config) ->
-     Default = ssl_test_lib:default_cert_chain_conf(),
-    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+    Ext = x509_test:extensions([{key_usage, [digitalSignature]}]),
+    Default = ssl_test_lib:default_cert_chain_conf(),
+    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                        [[], [], [{extensions, Ext}]]},
                                                        {client_chain, Default}], 
                                                       ecdh_rsa, ecdhe_ecdsa, Config), 
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 
                ssl_test_lib:ssl_options(SOpts, Config), 
                [{check_keyex, ecdhe_ecdsa} | proplists:delete(check_keyex, Config)]).
 client_ecdh_ecdsa_server_ecdhe_ecdsa(Config)  when is_list(Config) ->
+    Ext = x509_test:extensions([{key_usage, [digitalSignature]}]),
     Default = ssl_test_lib:default_cert_chain_conf(),
-    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+    {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                        [[], [], [{extensions, Ext}]]},
                                                        {client_chain, Default}], 
                                                       ecdh_ecdsa, ecdhe_ecdsa, Config), 
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 
                ssl_test_lib:ssl_options(SOpts, Config),
                [{check_keyex, ecdhe_ecdsa} | proplists:delete(check_keyex, Config)]).
 client_ecdhe_ecdsa_server_ecdhe_ecdsa(Config)  when is_list(Config) ->
+    Ext = x509_test:extensions([{key_usage, [digitalSignature]}]),
     Default = ssl_test_lib:default_cert_chain_conf(),
-     {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default}, 
+     {COpts, SOpts} = ssl_test_lib:make_ec_cert_chains([{server_chain,
+                                                         [[], [], [{extensions, Ext}]]},
                                                         {client_chain, Default}], 
                                                        ecdhe_ecdsa, ecdhe_ecdsa, Config),
     ssl_test_lib:basic_test(ssl_test_lib:ssl_options(COpts, Config), 


### PR DESCRIPTION
This is the whole fix for the ssl problems in  OTP-21- RC1
 
What seemed like a simple refactor to avoid some hard code lists resulted in several problems both in the code and the test cases where discovered related to (EC)DH(E) and the key-usage extension. Some of the code removed is probably confusing, as I was confused too before properly understanding the problem.

The Key Usage extension is described in section 4.2.1.3 of X.509, with the following possible flags:

  KeyUsage ::= BIT STRING {
       digitalSignature        (0),
       nonRepudiation          (1), -- recent editions of X.509 have
                            -- renamed this bit to contentCommitment
       keyEncipherment         (2),
       dataEncipherment        (3),
       keyAgreement            (4),
       keyCertSign             (5),
       cRLSign                 (6),
       encipherOnly            (7),
       decipherOnly            (8) }
In SSL/TLS, when the server certificate contains a RSA key, then:

either a DHE or ECDHE cipher suite is used, in which case the RSA key
is used for a signature (see section 7.4.3 of RFC 5246: the "Server
Key Exchange" message); this exercises the digitalSignature key usage;

or "plain RSA" is used, with a random value (the 48-byte pre-master
secret) being encrypted by the client with the server's public key
(see section 7.4.7.1 of RFC 5246); this is right in the definition of
the keyEncipherment key usage flag.

dataEncipherment does not apply, because what is encrypted is not
directly meaningful data, but a value which is mostly generated
randomly and used to derive symmetric keys. keyAgreement does not
apply either, because that one is for key agreement algorithms which
are not a case of asymmetric encryption (e.g. Diffie-Hellman). The
keyAgreement usage flag would appear in a certificate which contains a
DH key, not a RSA key. nonRepudiation is not used, because whatever is
signed as part of a SSL/TLS key exchange cannot be used as proof for a
third party (there is nothing in a SSL/TLS tunnel that the client
could record and then use to convince a judge when tring to sue the
server itself; the data which is exchanged within the tunnel is not
signed by the server).

When a ECDSA key is used then "keyAgreement" flag is needed for beeing
ECDH "capable" (as opposed to ephemeral ECDHE)