### PR TITLE
ssl: Generalize DTLS packet multiplexing

### DIFF
--- a/lib/ssl/src/Makefile
+++ b/lib/ssl/src/Makefile
@@ -54,8 +54,8 @@ MODULES= \
         ssl_connection_sup \
         ssl_listen_tracker_sup\
 	dtls_connection_sup \
-	dtls_udp_listener\
-	dtls_udp_sup \
+	dtls_packet_demux \
+	dtls_listener_sup \
 	ssl_dist_sup\
         ssl_dist_admin_sup\
         ssl_dist_connection_sup\

--- a/lib/ssl/src/dtls_listener_sup.erl
+++ b/lib/ssl/src/dtls_listener_sup.erl
@@ -23,7 +23,7 @@
 %% Purpose: Supervisor for a procsses dispatching upd datagrams to
 %% correct DTLS handler 
 %%----------------------------------------------------------------------
--module(dtls_udp_sup).
+-module(dtls_listener_sup).
 
 -behaviour(supervisor).
 
@@ -52,10 +52,10 @@ init(_O) ->
     MaxT = 3600,
    
     Name = undefined, % As simple_one_for_one is used.
-    StartFunc = {dtls_udp_listener, start_link, []},
+    StartFunc = {dtls_packet_demux, start_link, []},
     Restart = temporary, % E.g. should not be restarted
     Shutdown = 4000,
-    Modules = [dtls_udp_listener],
+    Modules = [dtls_packet_demux],
     Type = worker,
     
     ChildSpec = {Name, StartFunc, Restart, Shutdown, Type, Modules},

--- a/lib/ssl/src/dtls_socket.erl
+++ b/lib/ssl/src/dtls_socket.erl
@@ -22,31 +22,31 @@
 -include("ssl_internal.hrl").
 -include("ssl_api.hrl").
 
--export([send/3, listen/3, accept/3, connect/4, socket/4, setopts/3, getopts/3, getstat/3, 
+-export([send/3, listen/2, accept/3, connect/4, socket/4, setopts/3, getopts/3, getstat/3, 
 	 peername/2, sockname/2, port/2, close/2]).
 -export([emulated_options/0, emulated_options/1, internal_inet_values/0, default_inet_values/0, default_cb_info/0]).
 
 send(Transport, {{IP,Port},Socket}, Data) ->
     Transport:send(Socket, IP, Port, Data).
 
-listen(gen_udp = Transport, Port, #config{transport_info = {Transport, _, _, _},
-					  ssl = SslOpts, 
-					  emulated = EmOpts,
-					  inet_user = Options} = Config) ->
+listen(Port, #config{transport_info = TransportInfo,
+                           ssl = SslOpts, 
+                           emulated = EmOpts,
+                           inet_user = Options} = Config) ->
     
     
-    case dtls_udp_sup:start_child([Port, emulated_socket_options(EmOpts, #socket_options{}), 
+    case dtls_listener_sup:start_child([Port, TransportInfo, emulated_socket_options(EmOpts, #socket_options{}), 
 				   Options ++ internal_inet_values(), SslOpts]) of
 	{ok, Pid} ->
-	    {ok, #sslsocket{pid = {udp, Config#config{udp_handler = {Pid, Port}}}}};
+	    {ok, #sslsocket{pid = {dtls, Config#config{dtls_handler = {Pid, Port}}}}};
 	Err = {error, _} ->
 	    Err
     end.
 
-accept(udp, #config{transport_info = {Transport = gen_udp,_,_,_},
+accept(dtls, #config{transport_info = {Transport,_,_,_},
 		    connection_cb = ConnectionCb,
-		    udp_handler = {Listner, _}}, _Timeout) -> 
-    case dtls_udp_listener:accept(Listner, self()) of
+		    dtls_handler = {Listner, _}}, _Timeout) -> 
+    case dtls_packet_demux:accept(Listner, self()) of
 	{ok, Pid, Socket} ->
 	    {ok, socket(Pid, Transport, {Listner, Socket}, ConnectionCb)};
 	{error, Reason} ->
@@ -69,7 +69,9 @@ connect(Address, Port, #config{transport_info = {Transport, _, _, _} = CbInfo,
     end.
 
 close(gen_udp, {_Client, _Socket}) ->
-    ok.
+    ok;
+close(Transport, {_Client, Socket}) ->
+    Transport:close(Socket).
 
 socket(Pid, gen_udp = Transport, {{_, _}, Socket}, ConnectionCb) ->
     #sslsocket{pid = Pid, 
@@ -79,18 +81,18 @@ socket(Pid, Transport, Socket, ConnectionCb) ->
     #sslsocket{pid = Pid, 
 	       %% "The name "fd" is keept for backwards compatibility
 	       fd = {Transport, Socket, ConnectionCb}}.
-setopts(_, #sslsocket{pid = {udp, #config{udp_handler = {ListenPid, _}}}}, Options) ->
+setopts(_, #sslsocket{pid = {dtls, #config{dtls_handler = {ListenPid, _}}}}, Options) ->
     SplitOpts = tls_socket:split_options(Options),
-    dtls_udp_listener:set_sock_opts(ListenPid, SplitOpts);
+    dtls_packet_demux:set_sock_opts(ListenPid, SplitOpts);
 %%% Following clauses will not be called for emulated options, they are  handled in the connection process
 setopts(gen_udp, Socket, Options) ->
     inet:setopts(Socket, Options);
 setopts(Transport, Socket, Options) ->
     Transport:setopts(Socket, Options).
 
-getopts(_, #sslsocket{pid = {udp, #config{udp_handler = {ListenPid, _}}}}, Options) ->
+getopts(_, #sslsocket{pid = {dtls, #config{dtls_handler = {ListenPid, _}}}}, Options) ->
     SplitOpts = tls_socket:split_options(Options),
-    dtls_udp_listener:get_sock_opts(ListenPid, SplitOpts);
+    dtls_packet_demux:get_sock_opts(ListenPid, SplitOpts);
 getopts(gen_udp,  #sslsocket{pid = {Socket, #config{emulated = EmOpts}}}, Options) ->
     {SockOptNames, EmulatedOptNames} = tls_socket:split_options(Options),
     EmulatedOpts = get_emulated_opts(EmOpts, EmulatedOptNames),
@@ -112,7 +114,7 @@ getstat(gen_udp, {_,Socket}, Options) ->
 	inet:getstat(Socket, Options);
 getstat(Transport, Socket, Options) ->
 	Transport:getstat(Socket, Options).
-peername(udp, _) ->
+peername(_, undefined) ->
     {error, enotconn};
 peername(gen_udp, {_, {Client, _Socket}}) ->
     {ok, Client};

--- a/lib/ssl/src/ssl.app.src
+++ b/lib/ssl/src/ssl.app.src
@@ -17,8 +17,8 @@
 	       dtls_socket,
 	       dtls_v1,
 	       dtls_connection_sup,
-	       dtls_udp_listener,
-	       dtls_udp_sup,
+	       dtls_packet_demux,
+	       dtls_listener_sup,
 	       %% API
 	       ssl,  %% Main API		  
 	       tls,  %% TLS specific

--- a/lib/ssl/src/ssl_connection_sup.erl
+++ b/lib/ssl/src/ssl_connection_sup.erl
@@ -51,12 +51,12 @@ init([]) ->
     ListenOptionsTracker = listen_options_tracker_child_spec(), 
     
     DTLSConnetionManager = dtls_connection_manager_child_spec(),
-    DTLSUdpListeners = dtls_udp_listeners_spec(),
+    DTLSListeners = dtls_listeners_spec(),
 
     {ok, {{one_for_one, 10, 3600}, [TLSConnetionManager, 
 				    ListenOptionsTracker,
 				    DTLSConnetionManager, 
-				    DTLSUdpListeners
+				    DTLSListeners
 				   ]}}.
 
     
@@ -91,9 +91,9 @@ listen_options_tracker_child_spec() ->
     Type = supervisor,
     {Name, StartFunc, Restart, Shutdown, Type, Modules}.
 
-dtls_udp_listeners_spec() ->
-    Name = dtls_udp_listener,  
-    StartFunc = {dtls_udp_sup, start_link, []},
+dtls_listeners_spec() ->
+    Name = dtls_listener,  
+    StartFunc = {dtls_listener_sup, start_link, []},
     Restart = permanent, 
     Shutdown = 4000,
     Modules = [],

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -160,7 +160,7 @@
 -record(config, {ssl,               %% SSL parameters
 		 inet_user,         %% User set inet options
 		 emulated,          %% Emulated option list or "inherit_tracker" pid
-		 udp_handler,
+		 dtls_handler,
 		 inet_ssl,          %% inet options for internal ssl socket
 		 transport_info,                 %% Callback info
 		 connection_cb


### PR DESCRIPTION
We want to prepare the code for more advanced DTLS usage and possibility
to run over SCTP. First assumption was that the demultiplexer process
"dtls listener" was needed for UDP only and SCTP could be made more TLS
like. However the assumption seems not to hold. This commit prepares
for customization possibilities.