### PR TITLE
Logger configuration and various fixes

### DIFF
--- a/lib/kernel/doc/src/config.xml
+++ b/lib/kernel/doc/src/config.xml
@@ -37,10 +37,10 @@
       data in the system configuration file <c>Name.config</c>.</p>
     <p>Configuration parameter values in the configuration file
       override the values in the application resource files (see
-      <seealso marker="app"><c>app(4)</c></seealso>.
+      <seealso marker="app"><c>app(4)</c></seealso>).
       The values in the configuration file can be
       overridden by command-line flags (see
-      <seealso marker="erts:erl"><c>erts:erl(1)</c></seealso>.</p>
+      <seealso marker="erts:erl"><c>erts:erl(1)</c></seealso>).</p>
     <p>The value of a configuration parameter is retrieved by calling
       <c>application:get_env/1,2</c>.</p>
   </description>

--- a/lib/kernel/doc/src/error_logger.xml
+++ b/lib/kernel/doc/src/error_logger.xml
@@ -181,17 +181,21 @@ ok</pre>
     <func>
       <name name="get_format_depth" arity="0"/>
       <fsummary>Get the value of the Kernel application variable
-                <c>logger_format_depth</c>.</fsummary>
+                <c>error_logger_format_depth</c>.</fsummary>
       <desc>
 	<p>Returns <c>max(10, Depth)</c>, where <c>Depth</c> is the
-	value of
-	<seealso marker="kernel_app#logger_format_depth">
-	logger_format_depth</seealso>
+	value of <c>error_logger_format_depth</c>
 	in the Kernel application, if Depth is an integer. Otherwise,
 	<c>unlimited</c> is returned.</p>
-	<p>For backwards compatibility, the value
-	  of <c>error_logger_format_depth</c> is used
-	  if <c>logger_format_depth</c> is not set.</p>
+	<note>
+	  <p>The <c>error_logger_format_depth</c> variable
+	    is <seealso marker="kernel_app#deprecated-configuration-parameters">
+	    deprecated</seealso> since
+	    the <seealso marker="logger">Logger API</seealso> was
+	    introduced in OTP-21. The variable, and this function, are
+	    kept for backwards compatibility since they still might be
+	    used by legacy report handlers.</p>
+	</note>
       </desc>
     </func>
     <func>

--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -165,78 +165,34 @@
         <p>Permissions are described in
 	  <seealso marker="application#permit/2"><c>application:permit/2</c></seealso>.</p>
       </item>
-      <tag><c>logger_dest = Value</c></tag>
+      <tag><marker id="logger"/><c>logger = [Config]</c></tag>
       <item>
-        <p><c>Value</c> is one of:</p>
-        <taglist>
-          <tag><c>tty</c></tag>
-          <item><p>Installs the standard handler, <seealso marker="logger_std_h">
-	   <c>logger_std_h(3)</c></seealso>, with <c>type</c> set
-           to <c>standard_io</c>. This is the default
-           option.</p></item>
-          <tag><c>{file, FileName}</c></tag>
-          <item><p>Installs the standard handler, <seealso marker="logger_std_h">
-	   <c>logger_std_h(3)</c></seealso>, with <c>type</c> set
-           to <c>{file, FileName}</c>, where <c>FileName</c>
-           is a string. The file is opened with encoding UTF-8.</p></item>
-          <tag><c>{disk_log, FileName}</c></tag>
-          <item><p>Installs the disk_log handler, <seealso marker="logger_disk_log_h">
-	   <c>logger_disk_log_h(3)</c></seealso>, with <c>file</c> set
-           to <c>FileName</c> (a string), and possibly other disk_log
-           parameters set by the environment variables
-	   <c>logger_disk_log_type</c>, <c>logger_disk_log_maxfiles</c> and
-	   <c>logger_disk_log_maxbytes</c>,
-           see <seealso marker="#disk_log_vars">below</seealso>. The
-           file is opened with encoding UTF-8.</p></item>
-          <tag><c>false</c></tag>
-          <item>
-            <p>No standard handler is installed, but
-              the initial, primitive handler is kept, printing
-              raw event messages to <c>tty</c>.</p>
-          </item>
-          <tag><c>silent</c></tag>
-          <item>
-            <p>No standard handler is started, and the initial,
-              primitive handler is removed.</p>
-          </item>
-        </taglist>
+        <p>Specifies how <seealso marker="logger"><c>logger</c></seealso> should be
+          configured.</p>
+        <p>For more details and examples, see the <seealso marker="logger_chapter#logger">
+          Configuration</seealso> section in the <seealso marker="logger_chapter">
+          Logger User's Guide</seealso>.
+        </p>
       </item>
-      <tag><c>logger_level = Level</c></tag>
+      <tag><marker id="logger_level"/><c>logger_level = Level</c></tag>
       <item>
-        <p><c>Value = emergency | alert | critical | error | warning |
+        <p><c>Level = emergency | alert | critical | error | warning |
 	    notice | info | debug</c></p>
 	  <p>This parameter specifies which log levels to log. The
 	    specified level, and all levels that are more severe, will
 	    be logged.</p>
-	  <p>This configuration parameter is used both for the global
-	    logger level, and for the standard handler started by
-	    the Kernel application (see <c>logger_dest</c> variable above).</p>
+	    <p>It is possible to change this variable at run-time
+            using <seealso marker="logger:set_logger_config/1">
+            <c>logger:set_logger_config(#{ level => error })</c></seealso>.
+            .</p>
 	  <p>The default value is <c>info</c>.</p>
-      </item>
-      <tag><marker id="disk_log_vars"/>
-	<c>logger_disk_log_type = halt | wrap</c></tag>
-      <item/>
-      <tag><c>logger_disk_log_maxfiles = integer()</c></tag>
-      <item/>
-      <tag><c>logger_disk_log_maxbytes = integer()</c></tag>
-      <item>
-	<p>If <c>logger_dest</c> is set to {disk_log,File}, then these
-	  parameters specify the configuration to use when opening the
-	  disk log file. They specify the type of disk log, the
-	  maximum number of files (if the type is wrap) and the
-	  maximum size of each file, respectively.</p>
-	<p>The default values are:</p>
-	<code>
-logger_disk_log_type = wrap
-logger_disk_log_maxfiles = 10
-logger_disk_log_maxbytes = 1048576</code>
       </item>
       <tag><marker id="logger_sasl_compatible"/>
 	<c>logger_sasl_compatible = boolean()</c></tag>
       <item>
-	<p>If this parameter is set to true, then the logger handler
-	  started by kernel will not log any progress-, crash-, or
-	  supervisor reports. If the SASL application is started,
+	<p>If this parameter is set to true, then the <c>default</c> logger handler
+	  will not log any progress-, crash-, or supervisor reports.
+          If the SASL application is started,
 	  these log events will be sent to a second handler instance
 	  named <c>sasl_h</c>, according to values of the SASL
 	  environment variables <c>sasl_error_logger</c>
@@ -247,6 +203,8 @@ logger_disk_log_maxbytes = 1048576</code>
 	<p>See chapter <seealso marker="logger_chapter#compatibility">Backwards
 	  compatibility with error_logger</seealso> for more
 	  information about handling of the so called SASL reports.</p>
+        <note><p>This configuration option only effects the <c>default</c>
+          and <c>sasl</c> handler. Any other handlers are uneffected.</p></note>
       </item>
       <tag><marker id="logger_log_progress"/>
 	<c>logger_log_progress = boolean()</c></tag>
@@ -254,51 +212,13 @@ logger_disk_log_maxbytes = 1048576</code>
 	<p>If <c>logger_sasl_compatible = false</c>,
 	  then <c>logger_log_progress</c> specifies if progress
 	  reports from <c>supervisor</c>
-	  and <c>application_controller</c> shall be logged or
-	  not.</p>
+	  and <c>application_controller</c> shall be logged by the
+          default logger.</p>
 	<p>If <c>logger_sasl_compatible = true</c>,
 	  then <c>logger_log_progress</c> is ignored.</p>
-      </item>
-      <tag><marker id="logger_format_depth"/>
-	<c>logger_format_depth = Depth</c></tag>
-      <item>
-	<p>Can be used to limit the size of the
-	formatted output from the logger handlers.</p>
-
-        <p><c>Depth</c> is a positive integer representing the maximum
-        depth to which terms are printed by the logger
-        handlers included in OTP. This
-        configuration parameter is used by the default formatter,
-	<seealso marker="logger_formatter"><c>logger_formatter(3)</c></seealso>,
-	unless the formatter's <c>depth</c> parameter is explicitly set.
-	(If you have implemented your own formatter, this configuration
-	parameter has no effect on that.)</p>
-
-	<p><c>Depth</c> is used as follows: Format strings
-	received by the formatter are rewritten.
-	The format controls <c>~p</c> and <c>~w</c> are replaced with
-	<c>~P</c> and <c>~W</c>, respectively, and <c>Depth</c> is
-	used as the depth parameter. For details, see
-	<seealso marker="stdlib:io#format/2"><c>io:format/2</c></seealso>
-	in STDLIB.</p>
-
-	<note><p>A reasonable starting value for <c>Depth</c> is
-	<c>30</c>. We recommend to test crashing various processes in your
-	application, examine the logs from the crashes, and then
-	increase or decrease the value.</p></note>
-      </item>
-      <tag><c>logger_max_size = integer() | unlimited</c></tag>
-      <item>
-	<p>This parameter specifies a hard maximum size limit (number
-	  of characters) each log event can have when printed by the
-	  default logger formatter. If the resulting string after
-	  formatting an event is bigger than this, it will be
-	  truncated before printed to the handler's destination.</p>
-      </item>
-      <tag><c>logger_utc = boolean()</c></tag>
-      <item>
-	<p>If set to <c>true</c>, the default formatter will display
-	  all dates in Universal Coordinated Time.</p>
+        <p>The default value is <c>false</c></p>
+        <note><p>This configuration option only effects the <c>default</c>
+          and <c>sasl</c> handler. Any other handlers are uneffected.</p></note>
       </item>
       <tag><c>global_groups = [GroupTuple]</c></tag>
       <item>
@@ -572,9 +492,20 @@ MaxT = TickTime + TickTime / 4</code>
       variables are not set.</p>
     <taglist>
       <tag><c>error_logger</c></tag>
-      <item>Replaced by <c>logger_dest</c></item>
+      <item>Replaced by setting the type of the default
+      <seealso marker="logger_std_h#type"><c>logger_std_h</c></seealso>
+      to the same value. Example:
+      <code type="none">
+erl -kernel logger '[{handler,default,logger_std_h,#{logger_std_h=>#{type=>{file,"/tmp/erlang.log"}}}}]'
+      </code>
+      </item>
       <tag><c>error_logger_format_depth</c></tag>
-      <item>Replaced by <c>logger_format_depth</c></item>
+      <item>Replaced by setting the <seealso marker="logger_formatter#depth"><c>depth</c></seealso>
+      parameter of the default handlers formatter. Example:
+      <code type="none">
+erl -kernel logger '[{handler,default,logger_std_h,#{formatter=>{logger_formatter,#{legacy_header=>true,template=>[{logger_formatter,header},"\n",msg,"\n"],depth=>10}}}]'
+      </code>
+      </item>
     </taglist>
     <p>See <seealso marker="logger_chapter#compatibility">Backwards
 	compatibility with error_logger</seealso> for more

--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -181,11 +181,10 @@
 	  <p>This parameter specifies which log levels to log. The
 	    specified level, and all levels that are more severe, will
 	    be logged.</p>
-	    <p>It is possible to change this variable at run-time
-            using <seealso marker="logger:set_logger_config/1">
-            <c>logger:set_logger_config(#{ level => error })</c></seealso>.
-            .</p>
 	  <p>The default value is <c>info</c>.</p>
+	  <p>To change the global log level at run-time, use
+            <seealso marker="logger#set_logger_config/2">
+            <c>logger:set_logger_config(level, error)</c></seealso>.</p>
       </item>
       <tag><marker id="logger_sasl_compatible"/>
 	<c>logger_sasl_compatible = boolean()</c></tag>

--- a/lib/kernel/doc/src/logger.xml
+++ b/lib/kernel/doc/src/logger.xml
@@ -33,10 +33,49 @@
     <file>logger.xml</file>
   </header>
   <module>logger</module>
-  <modulesummary>API module for the logger application.</modulesummary>
+  <modulesummary>API module for the logger.</modulesummary>
 
   <description>
-
+    <p>
+      This module is the main logger API. It contains functions that allow
+      application to use a single log API and the system to manage those log
+      events independently. To log events the logger
+      <seealso marker="#macros">macros</seealso> should be used. For instance,
+      to log a new error log event:</p>
+      <code>
+?LOG_ERROR("error happened because: ~p",[Reason]). %% With macro
+logger:error("error happened because: ~p",[Reason]). %% Without macro
+      </code>
+      <p>This log event will then be sent to the configured log handlers which
+      by default means that it will be printed to the console. If you want
+      your systems logs to be printed to a file instead of the console you
+      have to configure the default handler to do so. The simplest way is
+      to include the following in your <seealso marker="config"><c>sys.config</c></seealso>.</p>
+      <code>
+[{kernel,
+  [{logger,
+    [{handler,default,logger_std_h,
+      #{logger_std_h=>#{type=>{file,"path/to/file.log"}}}}]}]}].
+      </code>
+    <p>
+      For more information about:
+    </p>
+    <list type="bulleted">
+      <item>how to use the API,
+        see <seealso marker="logger_chapter">the User's Guide</seealso>.</item>
+      <item>how to configure logger,
+        see the <seealso marker="logger_chapter#configuration">Configuration</seealso>
+        section in the User's Guide.</item>
+      <item>the convinience macros in logger.hrl,
+        see <seealso marker="#macros">the macro section</seealso>.</item>
+      <item>what the builtin formatter can do,
+        see <seealso marker="logger_formatter">logger_formatter</seealso>.</item>
+      <item>what the builtin handlers can do,
+        see <seealso marker="logger_std_h">logger_std_h</seealso> and
+        <seealso marker="logger_disk_log_h">logger_disk_log_h</seealso>.</item>
+      <item>what builtin filters are available,
+      see <seealso marker="logger_filters">logger_filters</seealso>.</item>
+    </list>
   </description>
 
   <datatypes>
@@ -348,16 +387,16 @@
             <code><![CDATA[1> logger:i(print).
 Current logger configuration:
   Level: info
-  FilterDefault: log
+  Filter Default: log
   Filters:
   Handlers:
-    Id: logger_std_h
+    Id: default
       Module:    logger_std_h
       Level:     info
       Formatter:
         Module: logger_formatter
-        Config: #{template => [{logger_formatter,header},"\n",msg,"\n"],
-                  legacy_header => true}
+        Config: #{legacy_header => true,single_line => false,
+                  template => [{logger_formatter,header},"\n",msg,"\n"]}
       Filter Default: stop
       Filters:
         Id: stop_progress
@@ -550,6 +589,56 @@ Current logger configuration:
     </func>
 
     <func>
+      <name name="add_handlers" arity="1" clause_i="1"/>
+      <fsummary>Setup logger handlers from the applications configuration parameters.</fsummary>
+      <desc>
+        <p>Reads the application configuration parameter <c>logger</c> and
+          calls <c>logger:add_handlers/1</c> with it contents.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="add_handlers" arity="1" clause_i="2"/>
+      <fsummary>Setup logger handlers.</fsummary>
+      <type name="config_handler"/>
+      <desc>
+        <p>This function should be used by custom logger handlers to make
+        configuration consistent no matter which handler the system uses.
+        Normal usage to to add a call to <c>logger:add_handlers/1</c>
+        just after the processes that the handler needs are started
+        and pass the applications logger config as an argument. Eg.</p>
+        <code>
+-behaviour(application).
+start(_, []) ->
+    case supervisor:start_link({local, my_sup}, my_sup, []) of
+        {ok, Pid} ->
+            ok = logger:add_handlers(my_app),
+            {ok, Pid, []};
+        Error -> Error
+     end.</code>
+       <p>This will read the <c>logger</c> configuration parameter from
+         the handler application and start the configured handlers. The contents
+         of the configuration use the same rules as the
+         <seealso marker="logger_chapter#handler-configuration">logger handler configuration</seealso>.
+       </p>
+       <p>If the handler is meant to replace the default handler the kernels
+         default handlers have to be disabled before the new handler is added.
+         A <c>sys.config</c> file that disables the kernel handler and adds
+         a custom handler could looks like this:</p>
+         <code>
+[{kernel,
+  [{logger,
+    %% Disable the default kernel handler
+    [{handler,default,undefined}]}]},
+ {my_app,
+  [{logger,
+    %% Enable this handler as the default
+    [{handler,default,my_handler,#{}}]}]}].
+         </code>
+      </desc>
+    </func>
+
+    <func>
       <name name="set_logger_config" arity="1"/>
       <fsummary>Set configuration data for the logger.</fsummary>
       <desc>
@@ -650,7 +739,7 @@ Current logger configuration:
 	<p>If process metadata exists for the current process, this
 	  function behaves as if it was implemented as follows:</p>
 	<code type="erl">
-logger:set_process_metadata(maps:merge(logger:get_process_metadata(),Meta))
+logger:set_process_metadata(maps:merge(logger:get_process_metadata(),Meta)).
 	</code>
 	<p>If no process metadata exists, the function behaves as
 	  <seealso marker="#set_process_metadata-1">

--- a/lib/kernel/doc/src/logger.xml
+++ b/lib/kernel/doc/src/logger.xml
@@ -645,11 +645,12 @@ start(_, []) ->
         <p>Set configuration data for the logger. This overwrites the
           current logger configuration.</p>
 	<p>To modify the existing configuration,
-	  use <seealso marker="#set_logger_config-2"><c>set_logger_config/2</c>
-	  </seealso>, or read the current configuration
+	  use <seealso marker="#update_logger_config-1">
+	    <c>update_logger_config/1</c></seealso>, or, if a more
+	  complex merge is needed, read the current configuration
 	  with <seealso marker="#get_logger_config-0"><c>get_logger_config/0</c>
-	  </seealso>, then merge in your added or updated
-	  associations before writing it back.</p>
+	  </seealso>, then do the merge before writing the new
+	  configuration back with this function.</p>
 	<p>If a key is removed compared to the current configuration,
 	  the default value is used.</p>
       </desc>
@@ -662,7 +663,23 @@ start(_, []) ->
         <p>Add or update configuration data for the logger. If the
           given <c><anno>Key</anno></c> already exists, its associated
           value will be changed to <c><anno>Value</anno></c>. If it
-          doesn't exist, it will be added.</p>
+          does not exist, it will be added.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="update_logger_config" arity="1"/>
+      <fsummary>Update configuration data for the logger.</fsummary>
+      <desc>
+        <p>Update configuration data for the logger. This function
+          behaves as if it was implemented as follows:</p>
+	<code type="erl">
+{ok,Old} = logger:get_logger_config(),
+logger:set_logger_config(maps:merge(Old,Config)).
+	</code>
+	<p>To overwrite the existing configuration without any merge,
+	  use <seealso marker="#set_logger_config-1"><c>set_logger_config/1</c>
+	  </seealso>.</p>
       </desc>
     </func>
 
@@ -673,11 +690,12 @@ start(_, []) ->
         <p>Set configuration data for the specified handler. This
           overwrites the current handler configuration.</p>
 	<p>To modify the existing configuration,
-	  use <seealso marker="#set_handler_config-3"><c>set_handler_config/3</c>
-	  </seealso>, or read the current configuration
+	  use <seealso marker="#update_handler_config-2">
+	    <c>update_handler_config/2</c></seealso>, or, if a more
+	  complex merge is needed, read the current configuration
 	  with <seealso marker="#get_handler_config-1"><c>get_handler_config/1</c>
-	  </seealso>, then merge in your added or updated
-	  associations before writing it back.</p>
+	  </seealso>, then do the merge before writing the new
+	  configuration back with this function.</p>
 	<p>If a key is removed compared to the current configuration,
 	  and the key is know by Logger, the default value is used. If
 	  it is a custom key, then it is up to the handler
@@ -694,8 +712,24 @@ start(_, []) ->
         <p>Add or update configuration data for the specified
           handler. If the given <c><anno>Key</anno></c> already
           exists, its associated value will be changed
-          to <c><anno>Value</anno></c>. If it doesn't exist, it will
+          to <c><anno>Value</anno></c>. If it does not exist, it will
           be added.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="update_handler_config" arity="2"/>
+      <fsummary>Update configuration data for the specified handler.</fsummary>
+      <desc>
+        <p>Update configuration data for the specified handler. This function
+          behaves as if it was implemented as follows:</p>
+	<code type="erl">
+{ok,{_,Old}} = logger:get_handler_config(HandlerId),
+logger:set_handler_config(HandlerId,maps:merge(Old,Config)).
+	</code>
+	<p>To overwrite the existing configuration without any merge,
+	  use <seealso marker="#set_handler_config-2"><c>set_handler_config/2</c>
+	  </seealso>.</p>
       </desc>
     </func>
 

--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -248,11 +248,97 @@
   <section>
     <title>Configuration</title>
 
+    <p>Logger can be configured either when the system starts through
+      <seealso marker="config">configuration parameters</seealso>,
+      or at run-time by using the <seealso marker="logger">logger</seealso>
+      API. The recommended approach is to do the initial configuration in
+      the <c>sys.config</c> file and then use the API when some configuration
+      has to be changed at run-time, such as the logging level.</p>
+
     <section>
-      <title>Application environment variables</title>
-      <p>See <seealso marker="kernel_app#configuration">Kernel(6)</seealso> for
-	information about the application environment variables that can
-	be used for configuring logger.</p>
+      <title>Application configuration parameters</title>
+      <p>Logger is best configured by using the configuration parameters
+      of kernel. There are three possible configuration parameters:
+      <seealso marker="#logger"><c>logger</c></seealso>,
+      <seealso marker="kernel_app#logger_level"><c>logger_level</c></seealso>,
+      <seealso marker="kernel_app#logger_sasl_compatible"><c>logger_sasl_compatible</c></seealso> and
+      <seealso marker="kernel_app#logger_log_progress"><c>logger_log_progress</c></seealso>.
+      logger_level, logger_sasl_compatible and logger_log_progress are described in the
+      <seealso marker="kernel_app#configuration">Kernel Configuration</seealso>,
+      while <c>logger</c> is described below.</p>
+      <section>
+        <marker id="logger"/>
+        <title>logger</title>
+        <p>The <c>logger</c> application configuration parameter is used to configure
+          three different logger aspects; handlers, logger filters and module levels.
+          The configuration is a list containing tagged tuples that look like this:</p>
+        <taglist>
+          <tag><c>DisableHandler = {handler,default,undefined}</c></tag>
+          <item>Disable the default handler. This will allow another application
+            to add its own default handler. See <seealso marker="logger#add_handlers/1">
+            <c>logger:add_handlers/1</c></seealso> for more details.</item>
+          <tag><c>AddHandler = {handler,HandlerId,Module,HandlerConfig}</c></tag>
+          <item>Add a handler as if <seealso marker="logger:add_handler/3">
+            <c>logger:add_handler(HandlerId,Module,HandlerConfig)</c></seealso> had been
+            called.</item>
+          <tag><c>Filters = {filters, FilterDefault, [Filter]}</c><br/>
+          <c>FilterDefault = log | stop</c><br/>
+          <c>Filter = {FilterId, {FilterFun, FilterConfig}}</c></tag>
+          <item>Add the specified <seealso marker="logger#add_logger_filter/2">
+          logger filters</seealso>. Only one entry is allowed of this option.</item>
+          <tag><c>ModuleLevel</c></tag>
+          <item><c>{module_level, Level, [Module]}</c>,
+            this option configures the <seealso marker="logger#set_module_level/2">
+            module log level</seealso> to be used. It is possible to have multiple
+            <c>module_level</c> entries.</item>
+        </taglist>
+        <p>Examples:</p>
+        <list>
+          <item>
+          <p>Output logs into a the file &quot;logs/erlang.log&quot;</p>
+            <code>
+[{kernel,
+  [{logger,
+    [{handler, default, logger_std_h,
+      #{ logger_std_h => #{ type => {file,"log/erlang.log"}}}}]}]}].
+            </code>
+          </item>
+          <item>
+          <p>Output logs in single line format</p>
+            <code>
+[{kernel,
+  [{logger,
+    [{handler, default, logger_std_h,
+      #{ formatter => { logger_formatter,#{ single_line => true}}}}]}]}].
+            </code>
+          </item>
+          <item>
+          <p>Add the pid to each log event</p>
+            <code>
+[{kernel,
+  [{logger,
+    [{handler, default, logger_std_h,
+      #{ formatter => { logger_formatter,
+                        #{ template => [time," ",pid," ",msg,"\n"]}}
+       }}]}]}].
+            </code>
+          </item>
+          <item>
+          <p>Use a different file for debug logging</p>
+            <code>
+[{kernel,
+  [{logger,
+    [{handler, default, logger_std_h,
+      #{ level => error,
+         logger_std_h => #{ type => {file, "log/erlang.log"}}}},
+     {handler, info, logger_std_h,
+      #{ level => debug,
+         logger_std_h => #{ type => {file, "log/debug.log"}}}}
+     ]}]}].
+            </code>
+          </item>
+        </list>
+      </section>
     </section>
 
     <section>
@@ -330,6 +416,13 @@
 	      <c>logger_formatter</c></seealso>, and <c>Extra</c> is
 	      it's configuration map.</p>
 	</item>
+        <tag>HandlerConfig, <c>term() = term()</c></tag>
+        <item>
+          Any keys not listed above are considered to be handler specific
+          configuration. The configuration of the Kernel handlers can be found in
+          <seealso marker="logger_std_h"><c>logger_std_h</c></seealso> and
+          <seealso marker="logger_disk_log_h"><c>logger_disk_log_h</c></seealso>.
+        </item>
       </taglist>
 
       <p>Note that <c>level</c> and <c>filters</c> are obeyed by

--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -136,7 +136,7 @@
 	<item>
 	  <p>Filters can be set on the logger or on a handler. Logger
 	    filters are applied first, and if passed, the handler filters
-	    for each handler are applied. The handler plugin is only
+	    for each handler are applied. The handler callback is only
 	    called if all handler filters for the handler in question also
 	    pass.</p>
 
@@ -159,7 +159,7 @@
 
 	  <code>format(Log,Extra) -> unicode:chardata()</code>
 
-	  <p>The formatter plugin is called by each handler, and the
+	  <p>The formatter callback is called by each handler, and the
 	    returned string can be printed to the handler's destination
 	    (stdout, file, ...).</p>
 	</item>
@@ -214,8 +214,8 @@
 	<tag><c>logger_filters:level/2</c></tag>
 	<item>
 	  <p>This filter provides a way of filtering log events based
-	    on the log level. See <seealso marker="logger_filters#domain-2">
-	    <c>logger_filters:domain/2</c></seealso></p>
+	    on the log level. See <seealso marker="logger_filters#level-2">
+	    <c>logger_filters:level/2</c></seealso></p>
 	</item>
 
 	<tag><c>logger_filters:progress/2</c></tag>
@@ -518,7 +518,7 @@ error_logger:add_report_handler/1,2.
 	  handler named <c>sasl_h</c>.</p>
 	<p>All SASL reports have a metadata
 	  field <c>domain=>[beam,erlang,otp,sasl]</c>, which can be
-	  used, for example, by filters to to stop or allow the
+	  used, for example, by filters to stop or allow the
 	  events.</p>
       </item>
     </taglist>

--- a/lib/kernel/doc/src/logger_disk_log_h.xml
+++ b/lib/kernel/doc/src/logger_disk_log_h.xml
@@ -121,11 +121,11 @@ logger:add_handler(my_disk_log_h, logger_disk_log_h,
                               #{filesync_repeat_interval => 1000}}).
     </code>
     <p>In order to use the disk_log handler instead of the default standard
-    handler when starting en Erlang node, use the kernel configuration parameter
-    <seealso marker="kernel_app#configuration"><c>logger_dest</c></seealso> with
-    value <c>{disk_log,FileName}</c>. Example:</p>
+    handler when starting en Erlang node, change the Kernel default logger to
+    use disk_log. Example:</p>
     <code type="none">
-erl -kernel logger_dest '{disk_log,"./system_disk_log"}'
+erl -kernel logger '[{handler,default,logger_disk_log_h,
+                      #{ disk_log_opts => #{ file => "./system_disk_log"}}}]'
     </code>
   </description>
 

--- a/lib/kernel/doc/src/logger_filters.xml
+++ b/lib/kernel/doc/src/logger_filters.xml
@@ -78,6 +78,10 @@
 	    <tag><c><anno>Compare</anno> = equals</c></tag>
 	    <item><p>The filter matches if <c>Domain</c> is equal
 	      to <c>MatchDomain</c>.</p></item>
+	    <tag><c><anno>Compare</anno> = differs</c></tag>
+	    <item><p>The filter matches if <c>Domain</c> differs
+	      from <c>MatchDomain</c>, or if there is no domain field
+	      in metadata.</p></item>
 	    <tag><c><anno>Compare</anno> = no_domain</c></tag>
 	    <item><p>The filter matches if there is no domain field in
 	      metadata. In this case <c><anno>MatchDomain</anno></c> shall

--- a/lib/kernel/doc/src/logger_formatter.xml
+++ b/lib/kernel/doc/src/logger_formatter.xml
@@ -155,11 +155,40 @@
 	  and <c>single_line</c>. See <seealso marker="#default_templates">Default
 	  Templates</seealso> for more information</p>
       </item>
-      <tag><c>utc = boolean()</c></tag>
+      <tag><c>time_designator = byte()</c></tag>
       <item>
-	<p>If set to <c>true</c>, all dates are displayed in Universal
-	  Coordinated Time.</p>
-	<p>Default is <c>false</c>.</p>
+	<p>Timestamps are formatted according to RFC3339, and the time
+	  designator is the character used as date and time
+	  separator.</p>
+	<p>Default is <c>$T</c>.</p>
+	<p>The value of this parameter is used as
+	  the <c>time_designator</c> option
+	  to <seealso marker="stdlib:calendar#system_time_to_rfc3339-2">
+	    <c>calendar:system_time_to_rcf3339/2</c></seealso>.</p>
+      </item>
+      <tag><c>time_offset = integer() | [byte()]</c></tag>
+      <item>
+	<p>The time offset, either a string or an integer, to be
+	  used when formatting the timestamp.</p>
+	<p>An empty string is interpreted as local time. The
+	  values <c>"Z"</c>, <c>"z"</c> or <c>0</c> are interpreted as
+	  Universal Coordinated Time (UTC).</p>
+	<p>Strings, other than <c>"Z"</c>, <c>"z"</c>, or <c>""</c>,
+	  must be on the form <c>±[hh]:[mm]</c>, for
+	  example <c>"-02:00"</c> or <c>"+00:00"</c>.</p>
+	<p>Integers must be in microseconds, meaning that the
+	  offset <c>7200000000</c> is equivalent
+	  to <c>"+02:00"</c>.</p>
+	<p>The default value is an empty string, meaning that
+	  timestamps are displayed in local time. However, for
+	  backwards compatibility, if the SASL environment
+	  variable <seealso marker="sasl:sasl_app#utc_log">
+	    <c>utc_log</c></seealso><c>=true</c>, the default is
+	  changed to <c>"Z"</c>, meaning that timestamps are displayed
+	  in UTC.</p>
+	<p>The value of this parameter is used as the <c>offset</c>
+	  option to <seealso marker="stdlib:calendar#system_time_to_rfc3339-2">
+	    <c>calendar:system_time_to_rcf3339/2</c></seealso>.</p>
       </item>
     </taglist>
   </section>
@@ -174,7 +203,7 @@
 
     <p>The log event used in the examples is:</p>
     <code>
-?LOG_ERROR("name: ~p~nexit_reason: ~p",[my_reg_name,"It crashed"])</code>
+?LOG_ERROR("name: ~p~nexit_reason: ~p",[my_name,"It crashed"])</code>
 
     <taglist>
       <tag><c>legacy_header=true</c></tag>
@@ -182,9 +211,9 @@
 	<p>Default template: <c>[{logger_formatter,header},"\n",msg,"\n"]</c></p>
 
 	<p>Example log entry:</p>
-	<code>
-=ERROR REPORT==== 29-Dec-2017::13:30:51.245123 ===
-name: my_reg_name
+	<code type="none">
+2018-05-16T11:55:50.448382+02:00 error:
+name: my_name
 exit_reason: "It crashed"</code>
 
 	<p>Notice that all eight levels might occur in the heading,
@@ -198,7 +227,7 @@ exit_reason: "It crashed"</code>
 	<p>Default template: <c>[time," ",level,": ",msg,"\n"]</c></p>
 
 	<p>Example log entry:</p>
-	<code>2017-12-29 13:31:49.640317 error: name: my_reg_name, exit_reason: "It crashed"</code>
+	<code type="none">2018-05-16T11:55:50.448382+02:00 error: name: my_name, exit_reason: "It crashed"</code>
       </item>
 
       <tag><c>legacy_header=false, single_line=false</c></tag>
@@ -206,9 +235,9 @@ exit_reason: "It crashed"</code>
 	<p>Default template: <c>[time," ",level,":\n",msg,"\n"]</c></p>
 
 	<p>Example log entry:</p>
-	<code>
-2017-12-29 13:32:25.191925 error:
-name: my_reg_name
+	<code type="none">
+2018-05-16T11:55:50.448382+02:00 error:
+name: my_name
 exit_reason: "It crashed"</code>
       </item>
     </taglist>

--- a/lib/kernel/doc/src/logger_formatter.xml
+++ b/lib/kernel/doc/src/logger_formatter.xml
@@ -66,7 +66,7 @@
 	    be truncated by the <c>max_size</c> parameter.</p>
 	</note>
       </item>
-      <tag><c>depth = pos_integer() | unlimited</c></tag>
+      <tag><marker id="depth"/><c>depth = pos_integer() | unlimited</c></tag>
       <item>
 	<p>A positive integer representing the maximum depth to
 	  which terms shall be printed by this formatter. Format

--- a/lib/kernel/doc/src/logger_std_h.xml
+++ b/lib/kernel/doc/src/logger_std_h.xml
@@ -40,7 +40,7 @@
       application. Multiple instances of this handler can be added to
       logger, and each instance will print logs to <c>standard_io</c>,
       <c>standard_error</c> or to file. The default instance that starts
-      with kernel is named <c>logger_std_h</c> - which is the name to be used
+      with kernel is named <c>default</c> - which is the name to be used
       for reconfiguration.</p>
     <p>The handler has an overload protection mechanism that will keep the handler
       process and the kernel application alive during a high load of log 
@@ -57,7 +57,7 @@
        are stored in a sub map with the key <c>logger_std_h</c>. The following
        keys and values may be specified:</p>
     <taglist>
-      <tag><c>type</c></tag>
+      <tag><marker id="type"/><c>type</c></tag>
       <item>
 	<p>This will have the value <c>standard_io</c>, <c>standard_error</c>,
 	<c>{file,LogFileName}</c>, or <c>{file,LogFileName,LogFileOpts}</c>,
@@ -105,11 +105,10 @@ logger:add_handler(my_standard_h, logger_std_h,
     </code>
     <p>In order to configure the default handler (that starts initially with
     the kernel application) to log to file instead of <c>standard_io</c>,
-    use the kernel configuration parameter
-    <seealso marker="kernel_app#configuration"><c>logger_dest</c></seealso> with
-    value <c>{file,FileName}</c>. Example:</p>
+    change the Kernel default logger to use a file. Example:</p>
     <code type="none">
-erl -kernel logger_dest '{file,"./erl.log"}'
+erl -kernel logger '[{handler,default,logger_std_h,
+                      #{ logger_std_h => #{ type => {file,"./log.log"}}}}]'
     </code>
     <p>An example of how to replace the standard handler with a disk_log handler
     at startup can be found in the manual of

--- a/lib/kernel/doc/src/ref_man.xml
+++ b/lib/kernel/doc/src/ref_man.xml
@@ -32,9 +32,11 @@
 
   </description>
   <xi:include href="kernel_app.xml"/>
+  <xi:include href="app.xml"/>
   <xi:include href="application.xml"/>
   <xi:include href="auth.xml"/>
   <xi:include href="code.xml"/>
+  <xi:include href="config.xml"/>
   <xi:include href="disk_log.xml"/>
   <xi:include href="erl_boot_server.xml"/>
   <xi:include href="erl_ddll.xml"/>
@@ -67,6 +69,4 @@
   <xi:include href="user.xml"/>
   <xi:include href="wrap_log_reader.xml"/>
   <xi:include href="zlib_stub.xml"/>
-  <xi:include href="app.xml"/>
-  <xi:include href="config.xml"/>
 </application>

--- a/lib/kernel/src/error_logger.erl
+++ b/lib/kernel/src/error_logger.erl
@@ -540,7 +540,6 @@ tty(false) ->
     delete_report_handler(error_logger_tty_h).
 
 %%%-----------------------------------------------------------------
-
 -spec limit_term(term()) -> term().
 
 limit_term(Term) ->
@@ -552,4 +551,9 @@ limit_term(Term) ->
 -spec get_format_depth() -> 'unlimited' | pos_integer().
 
 get_format_depth() ->
-    logger:get_format_depth().
+    case application:get_env(kernel, error_logger_format_depth) of
+	{ok, Depth} when is_integer(Depth) ->
+	    max(10, Depth);
+	undefined ->
+	    unlimited
+    end.

--- a/lib/kernel/src/error_logger.erl
+++ b/lib/kernel/src/error_logger.erl
@@ -529,15 +529,36 @@ logfile(filename) ->
       Flag :: boolean().
 
 tty(true) ->
-    case lists:member(error_logger_tty_h, which_report_handlers()) of
-	false ->
-	    add_report_handler(error_logger_tty_h, []);
-	true ->
-	    ignore
-    end,
+    _ = case lists:member(error_logger_tty_h, which_report_handlers()) of
+            false ->
+                case logger:get_handler_config(default) of
+                    {ok,{logger_std_h,#{logger_std_h:=#{type:=standard_io}}}} ->
+                        logger:remove_handler_filter(default,
+                                                     error_logger_tty_false);
+                    _ ->
+                        logger:add_handler(error_logger_tty_true,logger_std_h,
+                                           #{filter_default=>stop,
+                                             filters=>?DEFAULT_HANDLER_FILTERS(
+                                                         [beam,erlang,otp]),
+                                             formatter=>{?DEFAULT_FORMATTER,
+                                                         ?DEFAULT_FORMAT_CONFIG},
+                                             logger_std_h=>#{type=>standard_io}})
+                end;
+            true ->
+                ok
+        end,
     ok;
 tty(false) ->
-    delete_report_handler(error_logger_tty_h).
+    delete_report_handler(error_logger_tty_h),
+    _ = logger:remove_handler(error_logger_tty_true),
+    _ = case logger:get_handler_config(default) of
+            {ok,{logger_std_h,#{logger_std_h:=#{type:=standard_io}}}} ->
+                logger:add_handler_filter(default,error_logger_tty_false,
+                                          {fun(_,_) -> stop end, ok});
+            _ ->
+                ok
+        end,
+    ok.
 
 %%%-----------------------------------------------------------------
 -spec limit_term(term()) -> term().

--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -69,7 +69,7 @@
 
 %% Types that can be used from other modules -- alphabetically ordered.
 -export_type([date_time/0, fd/0, file_info/0, filename/0, filename_all/0,
-              io_device/0, name/0, name_all/0, posix/0]).
+              io_device/0, mode/0, name/0, name_all/0, posix/0]).
 
 %%% Includes and defines
 -include("file_int.hrl").

--- a/lib/kernel/src/kernel.app.src
+++ b/lib/kernel/src/kernel.app.src
@@ -140,7 +140,10 @@
                 inet_db,
                 pg2]},
   {applications, []},
-  {env, []},
+  {env, [{logger_level, info},
+         {logger_sasl_compatible, false},
+         {logger_log_progress, false}
+        ]},
   {mod, {kernel, []}},
   {runtime_dependencies, ["erts-10.0", "stdlib-3.5", "sasl-3.0"]}
  ]

--- a/lib/kernel/src/kernel.erl
+++ b/lib/kernel/src/kernel.erl
@@ -30,17 +30,13 @@
 %%% Callback functions for the kernel application.
 %%%-----------------------------------------------------------------
 start(_, []) ->
+    %% Setup the logger and configure the kernel logger environment
+    ok = logger:internal_init_logger(),
     case supervisor:start_link({local, kernel_sup}, kernel, []) of
 	{ok, Pid} ->
             ok = erl_signal_handler:start(),
-            %% add error handler
-            case logger:setup_standard_handler() of
-                ok -> {ok, Pid, []};
-                Error ->
-                    %% Not necessary since the node will crash anyway:
-                    exit(Pid, shutdown),
-                    Error
-            end;
+            ok = logger:add_handlers(kernel),
+            {ok, Pid, []};
 	Error -> Error
     end.
 
@@ -147,7 +143,7 @@ init([]) ->
     case init:get_argument(mode) of
         {ok, [["minimal"]]} ->
             {ok, {SupFlags,
-                  [Code, File, StdError, User, Config, RefC, SafeSup, LoggerSup]}};
+                  [Code, File, StdError, User, LoggerSup, Config, RefC, SafeSup]}};
         _ ->
             Rpc = #{id => rex,
                     start => {rpc, start_link, []},

--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -40,6 +40,7 @@
          set_module_level/2, reset_module_level/1,
          set_logger_config/1, set_logger_config/2,
          set_handler_config/2, set_handler_config/3,
+         update_logger_config/1, update_handler_config/2,
          get_logger_config/0, get_handler_config/1,
          add_handlers/1]).
 
@@ -360,6 +361,17 @@ set_handler_config(HandlerId,Key,Value) ->
       Config :: config().
 set_handler_config(HandlerId,Config) ->
     logger_server:set_config(HandlerId,Config).
+
+-spec update_logger_config(Config) -> ok | {error,term()} when
+      Config :: config().
+update_logger_config(Config) ->
+    logger_server:update_config(logger,Config).
+
+-spec update_handler_config(HandlerId,Config) -> ok | {error,term()} when
+      HandlerId :: handler_id(),
+      Config :: config().
+update_handler_config(HandlerId,Config) ->
+    logger_server:update_config(HandlerId,Config).
 
 -spec get_logger_config() -> {ok,Config} when
       Config :: config().

--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -51,7 +51,6 @@
 -export([set_process_metadata/1, update_process_metadata/1,
          unset_process_metadata/0, get_process_metadata/0]).
 -export([i/0, i/1]).
--export([limit_term/1, get_format_depth/0, get_max_size/0, get_utc_config/0]).
 
 %% Basic report formatting
 -export([format_report/1, format_otp_report/1]).
@@ -704,65 +703,6 @@ get_default_handler_filters() ->
 
 get_logger_env() ->
     application:get_env(kernel, logger, []).
-
-%%%-----------------------------------------------------------------
--spec limit_term(term()) -> term().
-
-limit_term(Term) ->
-    try get_format_depth() of
-        unlimited -> Term;
-        D -> io_lib:limit_term(Term, D)
-    catch error:badarg ->
-            %% This could happen during system termination, after
-            %% application_controller process is dead.
-            unlimited
-    end.
-
--spec get_format_depth() -> 'unlimited' | pos_integer().
-
-get_format_depth() ->
-    Depth =
-        case application:get_env(kernel, logger_format_depth) of
-            {ok, D} when is_integer(D) ->
-                D;
-            undefined ->
-                case application:get_env(kernel, error_logger_format_depth) of
-                    {ok, D} when is_integer(D) ->
-                        D;
-                    undefined ->
-                        unlimited
-                end
-        end,
-    max(10, Depth).
-
--spec get_max_size() -> 'unlimited' | pos_integer().
-
-get_max_size() ->
-    case application:get_env(kernel, logger_max_size) of
-	{ok, Size} when is_integer(Size) ->
-	    max(50, Size);
-	undefined ->
-	    unlimited
-    end.
-
--spec get_utc_config() -> boolean().
-
-get_utc_config() ->
-    %% Kernel's logger_utc configuration overrides SASL utc_log, which
-    %% in turn overrides stdlib config - in order to have uniform
-    %% timestamps in log messages
-    case application:get_env(kernel, logger_utc) of
-        {ok, Val} -> Val;
-        undefined ->
-            case application:get_env(sasl, utc_log) of
-                {ok, Val} -> Val;
-                undefined ->
-                    case application:get_env(stdlib, utc_log) of
-                        {ok, Val} -> Val;
-                        undefined -> false
-                    end
-            end
-    end.
 
 %%%-----------------------------------------------------------------
 %%% Internal

--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -40,14 +40,17 @@
          set_module_level/2, reset_module_level/1,
          set_logger_config/1, set_logger_config/2,
          set_handler_config/2, set_handler_config/3,
-         get_logger_config/0, get_handler_config/1]).
+         get_logger_config/0, get_handler_config/1,
+         add_handlers/1]).
+
+%% Private configuration
+-export([internal_init_logger/0]).
 
 %% Misc
 -export([compare_levels/2]).
 -export([set_process_metadata/1, update_process_metadata/1,
          unset_process_metadata/0, get_process_metadata/0]).
 -export([i/0, i/1]).
--export([setup_standard_handler/0, replace_simple_handler/3]).
 -export([limit_term/1, get_format_depth/0, get_max_size/0, get_utc_config/0]).
 
 %% Basic report formatting
@@ -93,8 +96,10 @@
                     term() => term()}.
 -type timestamp() :: integer().
 
+-type config_handler() :: {handler, handler_id(), module(), config()}.
+
 -export_type([log/0,level/0,report/0,msg_fun/0,metadata/0,config/0,handler_id/0,
-              filter_id/0,filter/0,filter_arg/0,filter_return/0]).
+              filter_id/0,filter/0,filter_arg/0,filter_return/0, config_handler/0]).
 
 %%%-----------------------------------------------------------------
 %%% API
@@ -504,118 +509,184 @@ print_module_levels({Module,Level}) ->
 print_module_levels(ModuleLevels) ->
     lists:map(fun print_module_levels/1, ModuleLevels).
 
--spec setup_standard_handler() -> ok | {error,term()}.
-setup_standard_handler() ->
-    case get_logger_type() of
-        {ok,silent} ->
-            Level = get_logger_level(),
-            ok = set_logger_config(level,Level),
-            remove_handler(logger_simple);
-        {ok,Type} ->
-            Level = get_logger_level(),
-            ok = set_logger_config(level,Level),
-            Filters = get_logger_filters(),
-            setup_standard_handler(Type,#{level=>Level,
-                                          filter_default=>stop,
-                                          filters=>Filters});
-        Error ->
-            Error
-    end.
+-spec internal_init_logger() -> ok | {error,term()}.
+%% This function is responsible for config of the logger
+%% This is done before add_handlers because we want the
+%% logger settings to take effect before the kernel supervisor
+%% tree is started.
+internal_init_logger() ->
+    try
+        ok = logger:set_logger_config(level, get_logger_level()),
+        ok = logger:set_logger_config(filter_default, get_logger_filter_default()),
 
--spec setup_standard_handler(Type,Config) -> ok | {error,term()} when
-      Type :: tty | standard_io | standard_error | {file,File} |
-              {file,File,Modes} | {disk_log,LogOpts} | false,
-      File :: file:filename(),
-      Modes :: [term()], % [file:mode()], or more specific?
-      Config :: config(),
-      LogOpts :: map().
-setup_standard_handler(false,#{level:=Level,filters:=Filters}) ->
-    case set_handler_config(logger_simple,level,Level) of
-        ok ->
-            set_handler_config(logger_simple,filters,Filters);
-        Error ->
-            Error
-    end;
-setup_standard_handler(Type,Config) ->
-    {Module,TypeConfig} = get_type_config(Type),
-    replace_simple_handler(?STANDARD_HANDLER,
-                           Module,
-                           maps:merge(Config,TypeConfig)).
+        [case logger:add_logger_filter(Id, Filter) of
+             ok -> ok;
+             {error, Reason} -> throw(Reason)
+         end || {Id, Filter} <- get_logger_filters()],
 
--spec replace_simple_handler(Id,Module,Config) -> ok | {error,term()} when
-      Id :: handler_id(),
-      Module :: module(),
-      Config :: config().
-replace_simple_handler(Id,Module,Config) ->
-    _ = code:ensure_loaded(Module),
-    DoBuffer = erlang:function_exported(Module,swap_buffer,2),
-    case add_handler(Id,Module,Config#{wait_for_buffer=>DoBuffer}) of
-        ok ->
-            if DoBuffer ->
-                    {ok,Buffered} = logger_simple:get_buffer(),
-                    _ = remove_handler(logger_simple),
-                    Module:swap_buffer(?STANDARD_HANDLER,Buffered);
-               true ->
-                    _ = remove_handler(logger_simple),
-                    ok
-            end,
-            ok;
-        Error ->
-            Error
-    end.
+        _ = [[case logger:set_module_level(Module, Level) of
+                  ok -> ok;
+                  {error, Reason} -> throw(Reason)
+              end || Module <- Modules]
+             || {module_level, Level, Modules} <- get_logger_env()],
 
-get_logger_type() ->
-    Type0 =
-        case application:get_env(kernel, logger_dest) of
-            undefined ->
-                application:get_env(kernel, error_logger);
-            T ->
-                T
+        case logger:set_handler_config(logger_simple,filters,
+                                       get_default_handler_filters()) of
+            ok -> ok;
+            {error,{not_found,logger_simple}} -> ok
         end,
-    case Type0 of
+
+        init_kernel_handlers()
+    catch throw:Reason ->
+            ?LOG_ERROR("Invalid logger config: ~p", [Reason]),
+            {error, {bad_config, {kernel, Reason}}}
+    end.
+
+-spec init_kernel_handlers() -> ok | {error,term()}.
+%% Setup the kernel environment variables to be correct
+%% The actual handlers are started by a call to add_handlers.
+init_kernel_handlers() ->
+    try
+        case get_logger_type() of
+            {ok,silent} ->
+                ok = logger:remove_handler(logger_simple);
+            {ok,false} ->
+                ok;
+            {ok,Type} ->
+                init_default_config(Type)
+        end
+    catch throw:Reason ->
+            ?LOG_ERROR("Invalid default handler config: ~p", [Reason]),
+            {error, {bad_config, {kernel, Reason}}}
+    end.
+
+-spec add_handlers(Application) -> ok | {error,term()} when
+      Application :: atom();
+                    (HandlerConfig) -> ok | {error,term()} when
+      HandlerConfig :: [config_handler()].
+%% This function is responsible for resolving the handler config
+%% and then starting the correct handlers. This is done after the
+%% kernel supervisor tree has been started as it needs the logger_sup.
+add_handlers(App) when is_atom(App) ->
+    add_handlers(application:get_env(App, logger, []));
+add_handlers(HandlerConfig) ->
+    try
+        check_logger_config(HandlerConfig),
+        DefaultAdded =
+            lists:foldl(
+              fun({handler, default = Id, Module, Config}, _)
+                    when not is_map_key(filters, Config) ->
+                      %% The default handler should have a couple of extra filters
+                      %% set on it by default.
+                      DefConfig = #{ filter_default => stop,
+                                     filters => get_default_handler_filters()},
+                      setup_handler(Id, Module, maps:merge(DefConfig,Config)),
+                      true;
+                 ({handler, Id, Module, Config}, Default) ->
+                      setup_handler(Id, Module, Config),
+                      Default orelse Id == default;
+                 (_, Default) -> Default
+              end, false, HandlerConfig),
+        %% If a default handler was added we try to remove the simple_logger
+        %% If the simple logger exists it will replay its log events
+        %% to the handler(s) added in the fold above.
+        _ = [case logger:remove_handler(logger_simple) of
+                 ok -> ok;
+                 {error,{not_found,logger_simple}} -> ok
+             end || DefaultAdded],
+        ok
+    catch throw:Reason ->
+            ?LOG_ERROR("Invalid logger handler config: ~p", [Reason]),
+            {error, {bad_config, {handler, Reason}}}
+    end.
+
+setup_handler(Id, Module, Config) ->
+    case logger:add_handler(Id, Module, Config) of
+        ok -> ok;
+        {error, Reason} -> throw(Reason)
+    end.
+
+check_logger_config(_) ->
+    ok.
+
+-spec get_logger_type() -> {ok, standard_io | false | silent |
+                            {file, file:name_all()} |
+                            {file, file:name_all(), [file:mode()]}}.
+get_logger_type() ->
+    case application:get_env(kernel, error_logger) of
         {ok, tty} ->
-            {ok, tty};
+            {ok, standard_io};
         {ok, {file, File}} when is_list(File) ->
             {ok, {file, File}};
         {ok, {file, File, Modes}} when is_list(File), is_list(Modes) ->
             {ok, {file, File, Modes}};
-        {ok, {disk_log, File}} when is_list(File) ->
-            {ok, {disk_log, get_disk_log_config(File)}};
         {ok, false} ->
             {ok, false};
         {ok, silent} ->
             {ok, silent};
         undefined ->
-            {ok, tty}; % default value
+            case lists:member({handler,default,undefined}, get_logger_env()) of
+                true ->
+                    {ok, false};
+                false ->
+                    {ok, standard_io} % default value
+            end;
         {ok, Bad} ->
-            {error,{bad_config, {kernel, {logger_dest, Bad}}}}
+            throw({error_logger, Bad})
     end.
 
-get_disk_log_config(File) ->
-    Config1 =
-        case application:get_env(kernel,logger_disk_log_maxfiles) of
-            undefined -> #{};
-            {ok,MF} -> #{max_no_files=>MF}
-        end,
-    Config2 =
-        case application:get_env(kernel,logger_disk_log_maxbytes) of
-            undefined -> Config1;
-            {ok,MB} -> Config1#{max_no_bytes=>MB}
-        end,
-    Config3 =
-        case application:get_env(kernel,logger_disk_log_type) of
-            undefined -> Config2;
-            {ok,T} -> Config1#{type=>T}
-        end,
-    Config3#{file=>File}.
-
 get_logger_level() ->
-    case application:get_env(kernel,logger_level) of
-        undefined -> info;
-        {ok,Level} when ?IS_LEVEL(Level) -> Level
+    case application:get_env(kernel,logger_level,info) of
+        Level when ?IS_LEVEL(Level) ->
+            Level;
+        Level ->
+            throw({logger_level, Level})
+    end.
+
+get_logger_filter_default() ->
+    case lists:keyfind(filters,1,get_logger_env()) of
+        {filters,Default,_} ->
+            Default;
+        false ->
+            log
     end.
 
 get_logger_filters() ->
+    lists:foldl(
+      fun({filters, _, Filters}, _Acc) ->
+              Filters;
+         (_, Acc) ->
+              Acc
+      end, [], get_logger_env()).
+
+%% This function looks at the kernel logger environment
+%% and updates it so that the correct logger is configured
+init_default_config(Type) when Type==standard_io;
+                                Type==standard_error;
+                                element(1,Type)==file ->
+    Env = get_logger_env(),
+    DefaultConfig = #{logger_std_h=>#{type=>Type}},
+    NewLoggerEnv =
+        case lists:keyfind(default, 2, Env) of
+            {handler, default, Module, Config} ->
+                lists:map(
+                  fun({handler, default, logger_std_h, _}) ->
+                          %% Only want to add the logger_std_h config
+                          %% if not configured by user AND the default
+                          %% handler is still the logger_std_h.
+                          {handler, default, Module, maps:merge(DefaultConfig,Config)};
+                     (Other) ->
+                          Other
+                  end, Env);
+            _ ->
+                %% Nothing has been configured, use default
+                [{handler, default, logger_std_h, DefaultConfig} | Env]
+        end,
+    application:set_env(kernel, logger, NewLoggerEnv, [{timeout,infinity}]);
+init_default_config(Type) ->
+    throw({illegal_logger_type,Type}).
+
+get_default_handler_filters() ->
     case application:get_env(kernel, logger_sasl_compatible, false) of
         true ->
             ?DEFAULT_HANDLER_FILTERS([beam,erlang,otp]);
@@ -631,18 +702,8 @@ get_logger_filters() ->
             Extra ++ ?DEFAULT_HANDLER_FILTERS([beam,erlang,otp,sasl])
     end.
 
-get_type_config({disk_log,LogOpts}) ->
-    {logger_disk_log_h,#{disk_log_opts=>LogOpts}};
-get_type_config(tty) ->
-    %% This is only for backwards compatibility with error_logger and
-    %% old kernel and sasl environment variables
-    get_type_config(standard_io);
-get_type_config(Type) when Type==standard_io;
-                           Type==standard_error;
-                           element(1,Type)==file ->
-    {logger_std_h,#{logger_std_h=>#{type=>Type}}};
-get_type_config(Type) ->
-    {error,{illegal_logger_type,Type}}.
+get_logger_env() ->
+    application:get_env(kernel, logger, []).
 
 %%%-----------------------------------------------------------------
 -spec limit_term(term()) -> term().

--- a/lib/kernel/src/logger_config.erl
+++ b/lib/kernel/src/logger_config.erl
@@ -31,7 +31,7 @@
 -include("logger_internal.hrl").
 
 new(Name) ->
-    _ = ets:new(Name,[set,protected,named_table]),
+    _ = ets:new(Name,[set,protected,named_table,{write_concurrency,true}]),
     ets:whereis(Name).
 
 delete(Tid,Id) ->

--- a/lib/kernel/src/logger_filters.erl
+++ b/lib/kernel/src/logger_filters.erl
@@ -38,6 +38,7 @@ domain(#{meta:=Meta}=Log,{Action,Compare,MatchDomain})
        (Compare==prefix_of orelse
         Compare==starts_with orelse
         Compare==equals orelse
+        Compare==differs orelse
         Compare==no_domain) andalso
        is_list(MatchDomain) ->
     filter_domain(Compare,Meta,MatchDomain,on_match(Action,Log));
@@ -87,9 +88,12 @@ filter_domain(starts_with,#{domain:=Domain},MatchDomain,OnMatch) ->
     is_prefix(MatchDomain,Domain,OnMatch);
 filter_domain(equals,#{domain:=Domain},Domain,OnMatch) ->
     OnMatch;
+filter_domain(differs,#{domain:=Domain},MatchDomain,OnMatch)
+  when Domain=/=MatchDomain ->
+    OnMatch;
 filter_domain(Action,Meta,_,OnMatch) ->
     case maps:is_key(domain,Meta) of
-        false when Action==no_domain -> OnMatch;
+        false when Action==no_domain; Action==differs -> OnMatch;
         _ -> ignore
     end.
 

--- a/lib/kernel/src/logger_internal.hrl
+++ b/lib/kernel/src/logger_internal.hrl
@@ -22,7 +22,7 @@
 -define(LOGGER_KEY,'$logger_config$').
 -define(HANDLER_KEY,'$handler_config$').
 -define(LOGGER_META_KEY,'$logger_metadata$').
--define(STANDARD_HANDLER, logger_std_h).
+-define(STANDARD_HANDLER, default).
 -define(DEFAULT_HANDLER_FILTERS,
         ?DEFAULT_HANDLER_FILTERS([beam,erlang,otp])).
 -define(DEFAULT_HANDLER_FILTERS(Domain),

--- a/lib/kernel/src/logger_server.erl
+++ b/lib/kernel/src/logger_server.erl
@@ -27,7 +27,7 @@
          add_filter/2, remove_filter/2,
          set_module_level/2, reset_module_level/1,
          cache_module_level/1,
-         set_config/2, set_config/3]).
+         set_config/2, set_config/3, update_config/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -92,16 +92,21 @@ cache_module_level(Module) ->
 
 
 set_config(Owner,Key,Value) ->
-    case sanity_check(Owner,Key,Value) of
-        ok -> call({update_config,Owner,#{Key=>Value}});
-        Error -> Error
-    end.
+    update_config(Owner,#{Key=>Value}).
 
 set_config(Owner,Config0) ->
     case sanity_check(Owner,Config0) of
         ok ->
             Config = maps:merge(default_config(Owner),Config0),
             call({set_config,Owner,Config});
+        Error ->
+            Error
+    end.
+
+update_config(Owner, Config) ->
+    case sanity_check(Owner,Config) of
+        ok ->
+            call({update_config,Owner,Config});
         Error ->
             Error
     end.

--- a/lib/kernel/test/Makefile
+++ b/lib/kernel/test/Makefile
@@ -79,6 +79,7 @@ MODULES= \
 	logger_legacy_SUITE \
 	logger_simple_SUITE \
 	logger_std_h_SUITE \
+	logger_test_lib \
 	os_SUITE \
 	pg2_SUITE \
 	seq_trace_SUITE \

--- a/lib/kernel/test/error_logger_warn_SUITE.erl
+++ b/lib/kernel/test/error_logger_warn_SUITE.erl
@@ -480,9 +480,12 @@ rb_utc() ->
     UtcLog=case application:get_env(sasl,utc_log) of
                {ok,true} ->
                    true;
-               _AllOthers ->
+               {ok,false} ->
                    application:set_env(sasl,utc_log,true),
-                   false
+                   false;
+               undefined ->
+                   application:set_env(sasl,utc_log,true),
+                   undefined
            end,
     application:start(sasl),
     rb:start([{report_dir, rd()}]),
@@ -494,7 +497,12 @@ rb_utc() ->
     Sum=one_rb_findstr([],"UTC"),
     rb:stop(),
     application:stop(sasl),
-    application:set_env(sasl,utc_log,UtcLog),
+    case UtcLog of
+        undefined ->
+            application:unset_env(sasl,utc_log);
+        _ ->
+            application:set_env(sasl,utc_log,UtcLog)
+    end,
     stop_node(Node),
     ok.
     

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -544,28 +544,64 @@ config_sanity_check(_Config) ->
         logger:set_handler_config(h1,formatter,bad),
     {error,{invalid_module,{bad}}} =
         logger:set_handler_config(h1,formatter,{{bad},cfg}),
-    {error,{invalid_formatter_config,bad}} =
+    {error,{invalid_formatter_config,logger_formatter,bad}} =
         logger:set_handler_config(h1,formatter,{logger_formatter,bad}),
-    {error,{invalid_formatter_config,{bad,bad}}} =
+    {error,{invalid_formatter_config,logger_formatter,{bad,bad}}} =
         logger:set_handler_config(h1,formatter,{logger_formatter,#{bad=>bad}}),
-    {error,{invalid_formatter_config,{template,bad}}} =
+    {error,{invalid_formatter_config,logger_formatter,{template,bad}}} =
         logger:set_handler_config(h1,formatter,{logger_formatter,
                                                 #{template=>bad}}),
-    {error,{invalid_formatter_template,[1]}} =
+    {error,{invalid_formatter_template,logger_formatter,[1]}} =
         logger:set_handler_config(h1,formatter,{logger_formatter,
                                                 #{template=>[1]}}),
     ok = logger:set_handler_config(h1,formatter,{logger_formatter,
                                                  #{template=>[]}}),
-    {error,{invalid_formatter_config,{single_line,bad}}} =
+    {error,{invalid_formatter_config,logger_formatter,{single_line,bad}}} =
         logger:set_handler_config(h1,formatter,{logger_formatter,
                                                 #{single_line=>bad}}),
     ok = logger:set_handler_config(h1,formatter,{logger_formatter,
                                                  #{single_line=>true}}),
-    {error,{invalid_formatter_config,{legacy_header,bad}}} =
+    {error,{invalid_formatter_config,logger_formatter,{legacy_header,bad}}} =
         logger:set_handler_config(h1,formatter,{logger_formatter,
                                                 #{legacy_header=>bad}}),
     ok = logger:set_handler_config(h1,formatter,{logger_formatter,
                                                  #{legacy_header=>true}}),
+    {error,{invalid_formatter_config,logger_formatter,{report_cb,bad}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{report_cb=>bad}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{report_cb=>fun(R) ->
+                                                                      {"~p",[R]}
+                                                              end}}),
+    {error,{invalid_formatter_config,logger_formatter,{utc,bad}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{utc=>bad}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{utc=>true}}),
+    {error,{invalid_formatter_config,logger_formatter,{chars_limit,bad}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{chars_limit=>bad}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{chars_limit=>unlimited}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{chars_limit=>4}}),
+    {error,{invalid_formatter_config,logger_formatter,{depth,bad}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{depth=>bad}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{depth=>unlimited}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{depth=>4}}),
+    {error,{invalid_formatter_config,logger_formatter,{max_size,bad}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{max_size=>bad}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{max_size=>unlimited}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{max_size=>4}}),
+    ok = logger:set_handler_config(h1,formatter,{module,config}),
+    {error,{callback_crashed,{error,{badmatch,3},[{?MODULE,check_config,1,_}]}}} =
+        logger:set_handler_config(h1,formatter,{?MODULE,crash}),
     ok = logger:set_handler_config(h1,custom,custom),
     ok.
 
@@ -877,3 +913,8 @@ test_macros(emergency=Level) ->
 %%% Called by macro ?TRY(X)
 my_try(Fun) ->
     try Fun() catch C:R -> {C,R} end.
+
+check_config(crash) ->
+    erlang:error({badmatch,3});
+check_config(_) ->
+    ok.

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -40,18 +40,18 @@ suite() ->
     [{timetrap,{seconds,30}}].
 
 init_per_suite(Config) ->
-    case logger:get_handler_config(logger_std_h) of
+    case logger:get_handler_config(?STANDARD_HANDLER) of
         {ok,StdH} ->
-            ok = logger:remove_handler(logger_std_h),
-            [{logger_std_h,StdH}|Config];
+            ok = logger:remove_handler(?STANDARD_HANDLER),
+            [{default_handler,StdH}|Config];
         _ ->
             Config
     end.
 
 end_per_suite(Config) ->
-    case ?config(logger_std_h,Config) of
+    case ?config(default_handler,Config) of
         {HMod,HConfig} ->
-            ok = logger:add_handler(logger_std_h,HMod,HConfig);
+            ok = logger:add_handler(?STANDARD_HANDLER,HMod,HConfig);
         _ ->
             ok
     end.
@@ -434,7 +434,7 @@ handler_failed(_Config) ->
         logger:add_handler(h1,?MODULE,#{filter_default=>true}),
     {error,{invalid_formatter,[]}} =
         logger:add_handler(h1,?MODULE,#{formatter=>[]}),
-    ok = logger:add_handler(h1,nomodule,#{filter_default=>log}),
+    {error,{invalid_handler,_}} = logger:add_handler(h1,nomodule,#{filter_default=>log}),
     logger:info(?map_rep),
     check_no_log(),
     #{logger:=#{handlers:=Ids1},

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -580,11 +580,6 @@ config_sanity_check(_Config) ->
                                                  #{report_cb=>fun(R) ->
                                                                       {"~p",[R]}
                                                               end}}),
-    {error,{invalid_formatter_config,logger_formatter,{utc,bad}}} =
-        logger:set_handler_config(h1,formatter,{logger_formatter,
-                                                #{utc=>bad}}),
-    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
-                                                 #{utc=>true}}),
     {error,{invalid_formatter_config,logger_formatter,{chars_limit,bad}}} =
         logger:set_handler_config(h1,formatter,{logger_formatter,
                                                 #{chars_limit=>bad}}),
@@ -610,6 +605,42 @@ config_sanity_check(_Config) ->
     {error,{callback_crashed,{error,{badmatch,3},[{?MODULE,check_config,1,_}]}}} =
         logger:set_handler_config(h1,formatter,{?MODULE,crash}),
     ok = logger:set_handler_config(h1,custom,custom),
+
+    %% Old utc parameter is no longer allowed (replaced by time_offset)
+    {error,{invalid_formatter_config,logger_formatter,{utc,true}}} =
+         logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{utc=>true}}),
+    {error,{invalid_formatter_config,logger_formatter,{time_offset,bad}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{time_offset=>bad}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{time_offset=>0}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{time_offset=>""}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{time_offset=>"Z"}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{time_offset=>"z"}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{time_offset=>"-0:0"}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{time_offset=>"+10:13"}}),
+
+    {error,{invalid_formatter_config,logger_formatter,{time_offset,"+0"}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{time_offset=>"+0"}}),
+
+    {error,{invalid_formatter_config,logger_formatter,{time_designator,bad}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{time_designator=>bad}}),
+    {error,{invalid_formatter_config,logger_formatter,{time_designator,"s"}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{time_designator=>"s"}}),
+    {error,{invalid_formatter_config,logger_formatter,{time_designator,0}}} =
+        logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                #{time_designator=>0}}),
+    ok = logger:set_handler_config(h1,formatter,{logger_formatter,
+                                                 #{time_designator=>$\s}}),
     ok.
 
 config_sanity_check(cleanup,_Config) ->

--- a/lib/kernel/test/logger_disk_log_h_SUITE.erl
+++ b/lib/kernel/test/logger_disk_log_h_SUITE.erl
@@ -328,7 +328,8 @@ formatter_fail(Config) ->
     logger:add_handler(Name, logger_disk_log_h, HConfig),
     Pid = whereis(Name),
     true = is_pid(Pid),
-    {ok,#{handlers:=H}} = logger:get_logger_config(),
+    #{handlers:=HC1} = logger:i(),
+    H = [Id || {Id,_,_} <- HC1],
     true = lists:member(Name,H),
 
     %% Formatter is added automatically
@@ -357,7 +358,8 @@ formatter_fail(Config) ->
 
     %% Check that handler is still alive and was never dead
     Pid = whereis(Name),
-    {ok,#{handlers:=H}} = logger:get_logger_config(),
+    #{handlers:=HC2} = logger:i(),
+    H = [Id || {Id,_,_} <- HC2],
     ok.
 
 formatter_fail(cleanup,_Config) ->

--- a/lib/kernel/test/logger_env_var_SUITE.erl
+++ b/lib/kernel/test/logger_env_var_SUITE.erl
@@ -1,4 +1,4 @@
-%
+%%
 %% %CopyrightBegin%
 %%
 %% Copyright Ericsson AB 2018. All Rights Reserved.
@@ -21,83 +21,64 @@
 
 -compile(export_all).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kernel/src/logger_internal.hrl").
 
--define(all_vars,[{kernel,logger_dest},
-                  {kernel,logger_level},
-                  {kernel,logger_log_progress},
-                  {kernel,logger_sasl_compatible},
-                  {kernel,error_logger}]).
+-import(logger_test_lib,[setup/2,log/3,sync_and_read/3]).
 
 suite() ->
-    [{timetrap,{seconds,30}}].
+    [{timetrap,{seconds,60}},
+     {ct_hooks,[logger_test_lib]}].
 
 init_per_suite(Config) ->
-    Env = [{App,Key,application:get_env(App,Key)} || {App,Key} <- ?all_vars],
-    Removed = cleanup(),
-    [{env,Env},{logger,Removed}|Config].
-
-end_per_suite(Config) ->
-    [application:set_env(App,Key,Val) ||
-        {App,Key,Val} <- ?config(env,Config),
-        Val =/= undefined],
-    Hs = ?config(logger,Config),
-    [ok = logger:add_handler(Id,Mod,C) || {Id,Mod,C} <- Hs],
-    ok.
-
-init_per_group(_Group, Config) ->
     Config.
 
-end_per_group(_Group, _Config) ->
-    ok.
-
-init_per_testcase(_TestCase, Config) ->
-    Config.
-
-end_per_testcase(Case, Config) ->
-    try apply(?MODULE,Case,[cleanup,Config])
-    catch error:undef -> ok
-    end,
-    cleanup(),
+end_per_suite(_Config) ->
     ok.
 
 groups() ->
-    [].
+    [{error_logger,[],[error_logger_tty,
+                       error_logger_tty_sasl_compatible,
+                       error_logger_false,
+                       error_logger_false_progress,
+                       error_logger_false_sasl_compatible,
+                       error_logger_silent,
+                       error_logger_silent_sasl_compatible,
+                       error_logger_file]},
+     {logger,[],[logger_file,
+                 logger_file_sasl_compatible,
+                 logger_file_log_progress,
+                 logger_file_no_filter,
+                 logger_file_no_filter_level,
+                 logger_file_formatter,
+                 logger_filters,
+                 logger_filters_stop,
+                 logger_module_level,
+                 logger_disk_log,
+                 logger_disk_log_formatter,
+                 logger_undefined,
+                 logger_many_handlers_default_first,
+                 logger_many_handlers_default_last
+                ]},
+     {bad,[],[bad_error_logger,
+              bad_level,
+              bad_sasl_compatibility,
+              bad_progress]}].
 
-all() -> 
+all() ->
     [default,
      default_sasl_compatible,
-     dest_tty,
-     dest_tty_sasl_compatible,
-     dest_false,
-     dest_false_progress,
-     dest_false_sasl_compatible,
-     dest_silent,
-     dest_silent_sasl_compatible,
-     dest_file_old,
-     dest_file,
-     dest_disk_log,
-     %% disk_log_vars, % or test this in logger_disk_log_SUITE?
      sasl_compatible_false,
      sasl_compatible_false_no_progress,
      sasl_compatible,
-     bad_dest%% ,
-     %% bad_level,
-     %% bad_sasl_compatibility,
-     %% bad_progress
+     {group,bad},
+     {group,error_logger},
+     {group,logger}
     ].
 
 default(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              undefined,
-                              undefined, % dest
-                              undefined, % level
-                              undefined, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    {logger_std_h,logger_std_h,StdC} = lists:keyfind(logger_std_h,1,Hs),
-    true = is_pid(whereis(logger_std_h)),
+    {ok,#{handlers:=Hs},_Node} = setup(Config,[]),
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
     info = maps:get(level,StdC),
     StdFilters = maps:get(filters,StdC),
     {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
@@ -105,18 +86,12 @@ default(Config) ->
     true = lists:keymember(stop_progress,1,StdFilters),
     false = lists:keymember(logger_simple,1,Hs),
     false = lists:keymember(sasl_h,1,Hs),
-    false = is_pid(whereis(sasl_h)),
     ok.
 
 default_sasl_compatible(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              undefined,
-                              undefined, % dest
-                              undefined, % level
-                              true, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    {logger_std_h,logger_std_h,StdC} = lists:keyfind(logger_std_h,1,Hs),
-    true = is_pid(whereis(logger_std_h)),
+    {ok,#{handlers:=Hs},_Node} = setup(Config,
+                                       [{logger_sasl_compatible,true}]),
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
     info = maps:get(level,StdC),
     StdFilters = maps:get(filters,StdC),
     {domain,{_,{log,prefix_of,[beam,erlang,otp]}}} =
@@ -124,18 +99,11 @@ default_sasl_compatible(Config) ->
     false = lists:keymember(stop_progress,1,StdFilters),
     false = lists:keymember(logger_simple,1,Hs),
     true = lists:keymember(sasl_h,1,Hs),
-    true = is_pid(whereis(sasl_h)),
     ok.
 
-dest_tty(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              tty, % dest
-                              undefined, % level
-                              undefined, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    {logger_std_h,logger_std_h,StdC} = lists:keyfind(logger_std_h,1,Hs),
-    true = is_pid(whereis(logger_std_h)),
+error_logger_tty(Config) ->
+    {ok,#{handlers:=Hs},_Node} = setup(Config,[{error_logger,tty}]),
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
     info = maps:get(level,StdC),
     StdFilters = maps:get(filters,StdC),
     {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
@@ -143,18 +111,13 @@ dest_tty(Config) ->
     true = lists:keymember(stop_progress,1,StdFilters),
     false = lists:keymember(logger_simple,1,Hs),
     false = lists:keymember(sasl_h,1,Hs),
-    false = is_pid(whereis(sasl_h)),
     ok.
 
-dest_tty_sasl_compatible(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              tty, % dest
-                              undefined, % level
-                              true, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    {logger_std_h,logger_std_h,StdC} = lists:keyfind(logger_std_h,1,Hs),
-    true = is_pid(whereis(logger_std_h)),
+error_logger_tty_sasl_compatible(Config) ->
+    {ok,#{handlers:=Hs},_Node} = setup(Config,
+                                       [{error_logger,tty},
+                                        {logger_sasl_compatible,true}]),
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
     info = maps:get(level,StdC),
     StdFilters = maps:get(filters,StdC),
     {domain,{_,{log,prefix_of,[beam,erlang,otp]}}} =
@@ -162,19 +125,17 @@ dest_tty_sasl_compatible(Config) ->
     false = lists:keymember(stop_progress,1,StdFilters),
     false = lists:keymember(logger_simple,1,Hs),
     true = lists:keymember(sasl_h,1,Hs),
-    true = is_pid(whereis(sasl_h)),
     ok.
 
-dest_false(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              false, % dest
-                              notice, % level
-                              undefined, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    false = lists:keymember(logger_std_h,1,Hs),
+error_logger_false(Config) ->
+    {ok,#{handlers:=Hs,logger:=L},_Node} =
+        setup(Config,
+              [{error_logger,false},
+               {logger_level,notice}]),
+    false = lists:keymember(?STANDARD_HANDLER,1,Hs),
     {logger_simple,logger_simple,SimpleC} = lists:keyfind(logger_simple,1,Hs),
-    notice = maps:get(level,SimpleC),
+    info = maps:get(level,SimpleC),
+    notice = maps:get(level,L),
     SimpleFilters = maps:get(filters,SimpleC),
     {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
         lists:keyfind(domain,1,SimpleFilters),
@@ -182,16 +143,16 @@ dest_false(Config) ->
     false = lists:keymember(sasl_h,1,Hs),
     ok.
 
-dest_false_progress(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              false, % dest
-                              notice, % level
-                              undefined, % sasl comp (default=false)
-                              true), % progress (default=false)
-    false = lists:keymember(logger_std_h,1,Hs),
+error_logger_false_progress(Config) ->
+    {ok,#{handlers:=Hs,logger:=L},_Node} =
+        setup(Config,
+              [{error_logger,false},
+               {logger_level,notice},
+               {logger_log_progress,true}]),
+    false = lists:keymember(?STANDARD_HANDLER,1,Hs),
     {logger_simple,logger_simple,SimpleC} = lists:keyfind(logger_simple,1,Hs),
-    notice = maps:get(level,SimpleC),
+    info = maps:get(level,SimpleC),
+    notice = maps:get(level,L),
     SimpleFilters = maps:get(filters,SimpleC),
     {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
         lists:keyfind(domain,1,SimpleFilters),
@@ -199,253 +160,472 @@ dest_false_progress(Config) ->
     false = lists:keymember(sasl_h,1,Hs),
     ok.
 
-dest_false_sasl_compatible(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              false, % dest
-                              notice, % level
-                              true, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    false = lists:keymember(logger_std_h,1,Hs),
+error_logger_false_sasl_compatible(Config) ->
+    {ok,#{handlers:=Hs,logger:=L},_Node} =
+        setup(Config,
+              [{error_logger,false},
+               {logger_level,notice},
+               {logger_sasl_compatible,true}]),
+    false = lists:keymember(?STANDARD_HANDLER,1,Hs),
     {logger_simple,logger_simple,SimpleC} = lists:keyfind(logger_simple,1,Hs),
-    notice = maps:get(level,SimpleC),
+    info = maps:get(level,SimpleC),
+    notice = maps:get(level,L),
     SimpleFilters = maps:get(filters,SimpleC),
     {domain,{_,{log,prefix_of,[beam,erlang,otp]}}} =
         lists:keyfind(domain,1,SimpleFilters),
     false = lists:keymember(stop_progress,1,SimpleFilters),
     true = lists:keymember(sasl_h,1,Hs),
-    true = is_pid(whereis(sasl_h)),
     ok.
 
-dest_silent(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              silent, % dest
-                              undefined, % level
-                              undefined, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    false = lists:keymember(logger_std_h,1,Hs),
+error_logger_silent(Config) ->
+    {ok,#{handlers:=Hs},_Node} = setup(Config,
+                                       [{error_logger,silent}]),
+    false = lists:keymember(?STANDARD_HANDLER,1,Hs),
     false = lists:keymember(logger_simple,1,Hs),
     false = lists:keymember(sasl_h,1,Hs),
     ok.
 
-dest_silent_sasl_compatible(Config) ->
-    {ok,{_Log,Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              silent, % dest
-                              undefined, % level
-                              true, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    false = lists:keymember(logger_std_h,1,Hs),
+error_logger_silent_sasl_compatible(Config) ->
+    {ok,#{handlers:=Hs},_Node} = setup(Config,
+                                       [{error_logger,silent},
+                                        {logger_sasl_compatible,true}]),
+    false = lists:keymember(?STANDARD_HANDLER,1,Hs),
     false = lists:keymember(logger_simple,1,Hs),
     true = lists:keymember(sasl_h,1,Hs),
-    true = is_pid(whereis(sasl_h)),
     ok.
 
 
-dest_file_old(Config) ->
-    {ok,{Log,_Hs}} = setup(Config,?FUNCTION_NAME,
-                              error_logger,
-                              file, % dest
-                              undefined, % level
-                              undefined, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    check_log(Log,
-              file, % dest
-              0), % progress in std logger
+error_logger_file(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,_Hs,Node} = setup(Config,
+                          [{error_logger,{file,Log}}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      0),% progress in std logger
     ok.
-    
 
-dest_file(Config) ->
-    {ok,{Log,_Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              file, % dest
-                              undefined, % level
-                              undefined, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    check_log(Log,
-              file, % dest
-              0), % progress in std logger
-    ok.
-    
 
-dest_disk_log(Config) ->
-    {ok,{Log,_Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              disk_log, % dest
-                              undefined, % level
-                              undefined, % sasl comp (default=false)
-                              undefined), % progress (default=false)
-    check_log(Log,
-              disk_log, % dest
-              0), % progress in std logger
+logger_file(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs},Node}
+        = setup(Config,
+                [{logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{logger_std_h=>#{type=>{file,Log}}}}]}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      0),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    StdFilters = maps:get(filters,StdC),
+    {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
+        lists:keyfind(domain,1,StdFilters),
+    true = lists:keymember(stop_progress,1,StdFilters),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+
     ok.
-    
+
+logger_file_sasl_compatible(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs},Node}
+        = setup(Config,
+                [{logger_sasl_compatible,true},
+                 {logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{logger_std_h=>#{type=>{file,Log}}}}]}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      0),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    StdFilters = maps:get(filters,StdC),
+    {domain,{_,{log,prefix_of,[beam,erlang,otp]}}} =
+        lists:keyfind(domain,1,StdFilters),
+    false = lists:keymember(stop_progress,1,StdFilters),
+    false = lists:keymember(logger_simple,1,Hs),
+    true = lists:keymember(sasl_h,1,Hs),
+
+    ok.
+
+logger_file_log_progress(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs},Node}
+        = setup(Config,
+                [{logger_log_progress,true},
+                 {logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{logger_std_h=>#{type=>{file,Log}}}}]}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      6),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    StdFilters = maps:get(filters,StdC),
+    {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
+        lists:keyfind(domain,1,StdFilters),
+    false = lists:keymember(stop_progress,1,StdFilters),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+
+    ok.
+
+logger_file_no_filter(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs},Node}
+        = setup(Config,
+                [{logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{filter_default=>log,filters=>[],
+                      logger_std_h=>#{type=>{file,Log}}}}]}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      6),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    [] = maps:get(filters,StdC),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+
+    ok.
+
+logger_file_no_filter_level(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs},Node}
+        = setup(Config,
+                [{logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{filters=>[],level=>error,
+                      logger_std_h=>#{type=>{file,Log}}}}]}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      0,% progress in std logger
+                      error),% level
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    error = maps:get(level,StdC),
+    [] = maps:get(filters,StdC),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+
+    ok.
+
+logger_file_formatter(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs},Node}
+        = setup(Config,
+                [{logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{filters=>[],
+                      formatter=>{logger_formatter,#{}},
+                      logger_std_h=>#{type=>{file,Log}}}}]}]),
+    check_single_log(Node,Log,
+                     file,% dest
+                     6),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    [] = maps:get(filters,StdC),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+
+    ok.
+
+logger_filters(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs,logger:=Logger},Node}
+        = setup(Config,
+                [{logger_log_progress,true},
+                 {logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{logger_std_h=>#{type=>{file,Log}}}},
+                   {filters,log,[{stop_progress,{fun logger_filters:progress/2,stop}}]}
+                  ]}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      0),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    StdFilters = maps:get(filters,StdC),
+    {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
+        lists:keyfind(domain,1,StdFilters),
+    false = lists:keymember(stop_progress,1,StdFilters),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+    LoggerFilters = maps:get(filters,Logger),
+    true = lists:keymember(stop_progress,1,LoggerFilters),
+
+    ok.
+
+logger_filters_stop(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs,logger:=Logger},Node}
+        = setup(Config,
+                [{logger_log_progress,true},
+                 {logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{filters=>[],
+                      logger_std_h=>#{type=>{file,Log}}}},
+                   {filters,stop,[{log_error,{fun logger_filters:level/2,{log,gt,info}}}]}
+                  ]}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      0,
+                      notice),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    [] = maps:get(filters,StdC),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+    LoggerFilters = maps:get(filters,Logger),
+    true = lists:keymember(log_error,1,LoggerFilters),
+
+    ok.
+
+logger_module_level(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs,module_levels:=ModuleLevels},Node}
+        = setup(Config,
+                [{logger_log_progress,true},
+                 {logger,
+                  [{handler,?STANDARD_HANDLER,logger_std_h,
+                    #{logger_std_h=>#{type=>{file,Log}}}},
+                   {module_level,error,[supervisor]}
+                  ]}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      3),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_std_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    StdFilters = maps:get(filters,StdC),
+    {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
+        lists:keyfind(domain,1,StdFilters),
+    false = lists:keymember(stop_progress,1,StdFilters),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+    [{supervisor,error}] = ModuleLevels,
+    ok.
+
+logger_disk_log(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs},Node}
+        = setup(Config,
+                [{logger,
+                  [{handler,?STANDARD_HANDLER,logger_disk_log_h,
+                    #{disk_log_opts=>#{file=>Log}}}]}]),
+    check_default_log(Node,Log,
+                      disk_log,% dest
+                      0),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_disk_log_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    StdFilters = maps:get(filters,StdC),
+    {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
+        lists:keyfind(domain,1,StdFilters),
+    true = lists:keymember(stop_progress,1,StdFilters),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+
+    ok.
+
+logger_disk_log_formatter(Config) ->
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,#{handlers:=Hs},Node}
+        = setup(Config,
+                [{logger,
+                  [{handler,?STANDARD_HANDLER,logger_disk_log_h,
+                    #{filters=>[],
+                      formatter=>{logger_formatter,#{}},
+                      disk_log_opts=>#{file=>Log}}}]}]),
+    check_single_log(Node,Log,
+                     disk_log,% dest
+                     6),% progress in std logger
+
+    {?STANDARD_HANDLER,logger_disk_log_h,StdC} = lists:keyfind(?STANDARD_HANDLER,1,Hs),
+    info = maps:get(level,StdC),
+    [] = maps:get(filters,StdC),
+    false = lists:keymember(logger_simple,1,Hs),
+    false = lists:keymember(sasl_h,1,Hs),
+
+    ok.
+
+logger_undefined(Config) ->
+    {ok,#{handlers:=Hs,logger:=L},_Node} =
+        setup(Config,[{logger,[{handler,?STANDARD_HANDLER,undefined}]}]),
+    false = lists:keymember(?STANDARD_HANDLER,1,Hs),
+    {logger_simple,logger_simple,SimpleC} = lists:keyfind(logger_simple,1,Hs),
+    info = maps:get(level,SimpleC),
+    info = maps:get(level,L),
+    SimpleFilters = maps:get(filters,SimpleC),
+    {domain,{_,{log,prefix_of,[beam,erlang,otp,sasl]}}} =
+        lists:keyfind(domain,1,SimpleFilters),
+    true = lists:keymember(stop_progress,1,SimpleFilters),
+    false = lists:keymember(sasl_h,1,Hs),
+    ok.
+
+logger_many_handlers_default_first(Config) ->
+    LogErr = file(Config,logger_many_handlers_default_first_error),
+    LogInfo = file(Config,logger_many_handlers_default_first_info),
+
+    logger_many_handlers(
+      Config,[{logger,
+               [{handler,?STANDARD_HANDLER,logger_std_h,
+                 #{level=>error,
+                   filters=>[],
+                   formatter=>{logger_formatter,#{}},
+                   logger_std_h=>#{type=>{file,LogErr}}}
+                },
+                {handler,info,logger_std_h,
+                 #{level=>info,
+                   filters=>[{level,{fun logger_filters:level/2,{stop,gteq,error}}}],
+                   logger_std_h=>#{type=>{file,LogInfo}}}
+                }
+               ]}], LogErr, LogInfo, 6).
+
+%% Test that we can add multiple handlers with the default last
+logger_many_handlers_default_last(Config) ->
+    LogErr = file(Config,logger_many_handlers_default_last_error),
+    LogInfo = file(Config,logger_many_handlers_default_last_info),
+    logger_many_handlers(
+      Config,[{logger,
+               [{handler,info,logger_std_h,
+                 #{level=>info,
+                   filters=>[{level,{fun logger_filters:level/2,{stop,gteq,error}}}],
+                   logger_std_h=>#{type=>{file,LogInfo}}}
+                },
+                {handler,?STANDARD_HANDLER,logger_std_h,
+                 #{level=>error,
+                   filters=>[],
+                   formatter=>{logger_formatter,#{}},
+                   logger_std_h=>#{type=>{file,LogErr}}}
+                }
+               ]}], LogErr, LogInfo, 7).
+
+logger_many_handlers(Config, Env, LogErr, LogInfo, NumProgress) ->
+    {ok,#{handlers:=Hs},Node} = setup(Config,Env),
+    check_single_log(Node,LogErr,
+                     file,% dest
+                     0,% progress in std logger
+                     error), % level
+    ok = rpc:call(Node,logger_std_h,filesync,[info]),
+    {ok, Bin} = file:read_file(LogInfo),
+    ct:log("Log content:~n~s",[Bin]),
+    match(Bin,<<"PROGRESS REPORT">>,NumProgress,info,info),
+    match(Bin,<<"ALERT REPORT">>,0,alert,info),
+
+    ok.
 
 sasl_compatible_false(Config) ->
-    {ok,{Log,_Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              file, % dest
-                              undefined, % level
-                              false, % sasl comp
-                              true), % progress
-    check_log(Log,
-              file, % dest
-              4), % progress in std logger
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,_Hs,Node} = setup(Config,
+                          [{error_logger,{file,Log}},
+                           {logger_sasl_compatible,false},
+                           {logger_log_progress,true}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      6),% progress in std logger
     ok.
 
 sasl_compatible_false_no_progress(Config) ->
-    {ok,{Log,_Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              file, % dest
-                              undefined, % level
-                              false, % sasl comp
-                              false), % progress
-    check_log(Log,
-              file, % dest
-              0), % progress in std logger
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,_Hs,Node} = setup(Config,
+                          [{error_logger,{file,Log}},
+                           {logger_sasl_compatible,false},
+                           {logger_log_progress,false}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      0),% progress in std logger
     ok.
 
 sasl_compatible(Config) ->
-    {ok,{Log,_Hs}} = setup(Config,?FUNCTION_NAME,
-                              logger_dest,
-                              file, % dest
-                              undefined, % level
-                              true, % sasl comp
-                              undefined), % progress
-    check_log(Log,
-              file, % dest
-              0), % progress in std logger
+    Log = file(Config,?FUNCTION_NAME),
+    {ok,_Hs,Node} = setup(Config,
+                          [{error_logger,{file,Log}},
+                           {sasl_compatible,true}]),
+    check_default_log(Node,Log,
+                      file,% dest
+                      0),% progress in std logger
     ok.
 
-bad_dest(Config) ->
-    {error,{bad_config,{kernel,{logger_dest,baddest}}}} =
-        setup(Config,?FUNCTION_NAME,
-              logger_dest,
-              baddest,
-              undefined,
-              undefined,
-              undefined).
+bad_error_logger(Config) ->
+    error = setup(Config,[{error_logger,baddest}]).
 
 bad_level(Config) ->
-    error =
-        setup(Config,?FUNCTION_NAME,
-              logger_dest,
-              tty,
-              badlevel,
-              undefined,
-              undefined).
+    error = setup(Config,[{logger_level,badlevel}]).
 
 bad_sasl_compatibility(Config) ->
-    error =
-        setup(Config,?FUNCTION_NAME,
-              logger_dest,
-              tty,
-              info,
-              badcomp,
-              undefined).
+    error = setup(Config,[{logger_sasl_compatible,badcomp}]).
 
 bad_progress(Config) ->
-    error =
-        setup(Config,?FUNCTION_NAME,
-              logger_dest,
-              tty,
-              info,
-              undefined,
-              badprogress).
+    error = setup(Config,[{logger_log_progress,badprogress}]).
 
 %%%-----------------------------------------------------------------
 %%% Internal
-setup(Config,Func,DestVar,Dest,Level,SaslComp,Progress) ->
-    ok = logger:add_handler(logger_simple,logger_simple,
-                            #{filter_default=>log,
-                              logger_simple=>#{buffer=>true}}),
-    Dir = ?config(priv_dir,Config),
-    File = lists:concat([?MODULE,"_",Func,".log"]),
-    Log = filename:join(Dir,File),
-    case Dest of
-        undefined ->
-            ok;
-        F when F==file; F==disk_log ->
-            application:set_env(kernel,DestVar,{Dest,Log});
-        _ ->
-            application:set_env(kernel,DestVar,Dest)
-    end,
-    case Level of
-        undefined ->
-            ok;
-        _ ->
-           application:set_env(kernel,logger_level,Level)
-    end,
-    case SaslComp of
-        undefined ->
-            ok;
-        _ ->
-            application:set_env(kernel,logger_sasl_compatible,SaslComp)
-    end,
-    case Progress of
-        undefined ->
-            ok;
-        _ ->
-            application:set_env(kernel,logger_log_progress,Progress)
-    end,
-    case logger:setup_standard_handler() of
-        ok ->
-            application:start(sasl),
-            StdH = case Dest of
-                       NoH when NoH==false; NoH==silent -> false;
-                       _ -> true
-                   end,
-            StdH = is_pid(whereis(?STANDARD_HANDLER)),
-            SaslH = if SaslComp -> true;
-                       true -> false
-                    end,
-            SaslH = is_pid(whereis(sasl_h)),
-            {ok,{Log,maps:get(handlers,logger:i())}};
-        Error ->
-            Error
-    end.
+file(Config,Func) ->
+    filename:join(proplists:get_value(priv_dir,Config),
+                  lists:concat([Func,".log"])).
 
-check_log(Log,Dest,NumProgress) ->
-    ok = logger:alert("dummy1"),
-    ok = logger:debug("dummy1"),
+check_default_log(Node,Log,Dest,NumProgress) ->
+    check_default_log(Node,Log,Dest,NumProgress,info).
+check_default_log(Node,Log,Dest,NumProgress,Level) ->
+
+    {ok,Bin1,Bin2} = check_log(Node,Log,Dest),
+
+    match(Bin1,<<"PROGRESS REPORT">>,NumProgress,info,Level),
+    match(Bin1,<<"ALERT REPORT">>,1,alert,Level),
+    match(Bin1,<<"INFO REPORT">>,0,info,Level),
+    match(Bin1,<<"DEBUG REPORT">>,0,debug,Level),
+
+    match(Bin2,<<"INFO REPORT">>,1,info,Level),
+    match(Bin2,<<"DEBUG REPORT">>,0,debug,Level),
+    ok.
+
+check_single_log(Node,Log,Dest,NumProgress) ->
+    check_single_log(Node,Log,Dest,NumProgress,info).
+check_single_log(Node,Log,Dest,NumProgress,Level) ->
+
+    {ok,Bin1,Bin2} = check_log(Node,Log,Dest),
+
+    match(Bin1,<<"info:">>,NumProgress,info,Level),
+    match(Bin1,<<"alert:">>,1,alert,Level),
+    match(Bin1,<<"debug:">>,0,debug,Level),
+
+    match(Bin2,<<"info:">>,NumProgress+1,info,Level),
+    match(Bin2,<<"debug:">>,0,debug,Level),
+
+    ok.
+
+check_log(Node,Log,Dest) ->
+
+    ok = log(Node,alert,["dummy1"]),
+    ok = log(Node,debug,["dummy1"]),
 
     %% Check that there are progress reports (supervisor and
     %% application_controller) and an error report (the call above) in
     %% the log. There should not be any info reports yet.
-    {ok,Bin1} = sync_and_read(Dest,Log),
+    {ok,Bin1} = sync_and_read(Node,Dest,Log),
     ct:log("Log content:~n~s",[Bin1]),
-    match(Bin1,<<"PROGRESS REPORT">>,NumProgress),
-    match(Bin1,<<"ALERT REPORT">>,1),
-    match(Bin1,<<"INFO REPORT">>,0),
-    match(Bin1,<<"DEBUG REPORT">>,0),
 
     %% Then stop sasl and see that the info report from
     %% application_controller is there
-    ok = application:stop(sasl),
-    {ok,Bin2} = sync_and_read(Dest,Log),
+    ok = rpc:call(Node,application,stop,[sasl]),
+    {ok,Bin2} = sync_and_read(Node,Dest,Log),
     ct:log("Log content:~n~s",[Bin2]),
-    match(Bin2,<<"INFO REPORT">>,1),
-    match(Bin1,<<"DEBUG REPORT">>,0),
-    ok.
+    {ok,Bin1,Bin2}.
 
-match(Bin,Pattern,0) ->
+match(Bin,Pattern,0,_,_) ->
     nomatch = re:run(Bin,Pattern,[{capture,none}]);
-match(Bin,Pattern,N) ->
-    {match,M} = re:run(Bin,Pattern,[{capture,all},global]),
-    N = length(M).
-
-sync_and_read(disk_log,Log) ->
-    logger_disk_log_h:disk_log_sync(?STANDARD_HANDLER),
-    file:read_file(Log ++ ".1");
-sync_and_read(file,Log) ->
-    logger_std_h:filesync(?STANDARD_HANDLER),
-    file:read_file(Log).
-
-cleanup() ->
-    application:stop(sasl),
-    [application:unset_env(App,Key) || {App,Key} <- ?all_vars],
-    #{handlers:=Hs0} = logger:i(),
-    Hs = lists:keydelete(cth_log_redirect,1,Hs0),
-    [ok = logger:remove_handler(Id) || {Id,_,_} <- Hs],
-    Hs.
+match(Bin,Pattern,N,LogLevel,ConfLevel) ->
+    case logger:compare_levels(LogLevel,ConfLevel) of
+        lt -> match(Bin,Pattern,0,LogLevel,ConfLevel);
+        _ ->
+            {match,M} = re:run(Bin,Pattern,[{capture,all},global]),
+            N = length(M)
+    end.

--- a/lib/kernel/test/logger_filters_SUITE.erl
+++ b/lib/kernel/test/logger_filters_SUITE.erl
@@ -81,6 +81,8 @@ domain(_Config) ->
     stop = logger_filters:domain(?dlog([]),{stop,starts_with,[]}),
     L3 = logger_filters:domain(L3=?dlog([]),{log,equals,[]}),
     stop = logger_filters:domain(?dlog([]),{stop,equals,[]}),
+    ignore = logger_filters:domain(?dlog([]),{log,differs,[]}),
+    ignore = logger_filters:domain(?dlog([]),{stop,differs,[]}),
     ignore = logger_filters:domain(?dlog([]),{log,no_domain,[]}),
     ignore = logger_filters:domain(?dlog([]),{stop,no_domain,[]}),
 
@@ -90,15 +92,19 @@ domain(_Config) ->
     ignore = logger_filters:domain(?dlog([a]),{stop,starts_with,[a,b]}),
     ignore = logger_filters:domain(?dlog([a]),{log,equals,[a,b]}),
     ignore = logger_filters:domain(?dlog([a]),{stop,equals,[a,b]}),
+    L5 = logger_filters:domain(L5=?dlog([a]),{log,differs,[a,b]}),
+    stop = logger_filters:domain(?dlog([a]),{stop,differs,[a,b]}),
     ignore = logger_filters:domain(?dlog([a]),{log,no_domain,[a,b]}),
     ignore = logger_filters:domain(?dlog([a]),{stop,no_domain,[a,b]}),
 
     ignore = logger_filters:domain(?dlog([a,b]),{log,prefix_of,[a]}),
     ignore = logger_filters:domain(?dlog([a,b]),{stop,prefix_of,[a]}),
-    L5 = logger_filters:domain(L5=?dlog([a,b]),{log,starts_with,[a]}),
+    L6 = logger_filters:domain(L6=?dlog([a,b]),{log,starts_with,[a]}),
     stop = logger_filters:domain(?dlog([a,b]),{stop,starts_with,[a]}),
     ignore = logger_filters:domain(?dlog([a,b]),{log,equals,[a]}),
     ignore = logger_filters:domain(?dlog([a,b]),{stop,equals,[a]}),
+    L7 = logger_filters:domain(L7=?dlog([a,b]),{log,differs,[a]}),
+    stop = logger_filters:domain(?dlog([a,b]),{stop,differs,[a]}),
     ignore = logger_filters:domain(?dlog([a,b]),{log,no_domain,[a]}),
     ignore = logger_filters:domain(?dlog([a,b]),{stop,no_domain,[a]}),
 
@@ -108,26 +114,33 @@ domain(_Config) ->
     ignore = logger_filters:domain(?ndlog,{stop,starts_with,[a]}),
     ignore = logger_filters:domain(?ndlog,{log,equals,[a]}),
     ignore = logger_filters:domain(?ndlog,{stop,equals,[a]}),
-    L6 = logger_filters:domain(L6=?ndlog,{log,no_domain,[a]}),
+    L8 = logger_filters:domain(L8=?ndlog,{log,differs,[a]}),
+    stop = logger_filters:domain(?ndlog,{stop,differs,[a]}),
+    L9 = logger_filters:domain(L9=?ndlog,{log,no_domain,[a]}),
     stop = logger_filters:domain(?ndlog,{stop,no_domain,[a]}),
 
-    L7 = logger_filters:domain(L7=?dlog([a,b,c,d]),{log,prefix_of,[a,b,c,d]}),
+    L10 = logger_filters:domain(L10=?dlog([a,b,c,d]),{log,prefix_of,[a,b,c,d]}),
     stop = logger_filters:domain(?dlog([a,b,c,d]),{stop,prefix_of,[a,b,c,d]}),
-    L8 = logger_filters:domain(L8=?dlog([a,b,c,d]),{log,starts_with,[a,b,c,d]}),
+    L11 = logger_filters:domain(L11=?dlog([a,b,c,d]),{log,starts_with,[a,b,c,d]}),
     stop = logger_filters:domain(?dlog([a,b,c,d]),{stop,starts_with,[a,b,c,d]}),
-    L9 = logger_filters:domain(L9=?dlog([a,b,c,d]),{log,equals,[a,b,c,d]}),
+    L12 = logger_filters:domain(L12=?dlog([a,b,c,d]),{log,equals,[a,b,c,d]}),
     stop = logger_filters:domain(?dlog([a,b,c,d]),{stop,equals,[a,b,c,d]}),
+    ignore = logger_filters:domain(?dlog([a,b,c,d]),{log,differs,[a,b,c,d]}),
+    ignore = logger_filters:domain(?dlog([a,b,c,d]),{stop,differs,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog([a,b,c,d]),{log,no_domain,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog([a,b,c,d]),{stop,no_domain,[a,b,c,d]}),
 
     %% A domain field in meta which is not a list is allowed by the
-    %% filter, but it will never match.
+    %% filter, but since MatchDomain is always a list of atoms, only
+    %% Action=differs can ever match.
     ignore = logger_filters:domain(?dlog(dummy),{log,prefix_of,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog(dummy),{stop,prefix_of,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog(dummy),{log,starts_with,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog(dummy),{stop,starts_with,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog(dummy),{log,equals,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog(dummy),{stop,equals,[a,b,c,d]}),
+    L13 = logger_filters:domain(L13=?dlog(dummy),{log,differs,[a,b,c,d]}),
+    stop = logger_filters:domain(?dlog(dummy),{stop,differs,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog(dummy),{log,no_domain,[a,b,c,d]}),
     ignore = logger_filters:domain(?dlog(dummy),{stop,no_domain,[a,b,c,d]}),
 

--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -73,7 +73,7 @@ all() ->
 default(_Config) ->
     String1 = format(info,{"~p",[term]},#{},#{}),
     ct:log(String1),
-    [_Date,_Time,"info:","term\n"] = string:lexemes(String1," "),
+    [_DateTime,"info:","term\n"] = string:lexemes(String1," "),
 
     Time = timestamp(),
     ExpectedTimestamp = default_time_format(Time),
@@ -364,7 +364,7 @@ chars_limit(_Config) ->
                  lists:seq(1,100),
                  maps:from_list(lists:zip(lists:seq(1,100),
                                           lists:duplicate(100,value)))]},
-    Meta = #{time=>"2018-04-26  9:15:40.449879"},
+    Meta = #{time=>timestamp()},
     Template = [time," - ", msg, "\n"],
     FC = #{template=>Template,
            depth=>unlimited,
@@ -376,7 +376,7 @@ chars_limit(_Config) ->
     L1 = string:length(String1),
     ct:log("String1: ~p~nLength1: ~p~n",[lists:flatten(String1),L1]),
     true = L1 > CL1,
-    true = L1 < CL1 + 10,
+    true = L1 < CL1 + 15,
 
     String2 = format(info,FA,Meta,FC#{chars_limit=>CL1,depth=>10}),
     L2 = string:length(String2),
@@ -388,13 +388,13 @@ chars_limit(_Config) ->
     L3 = string:length(String3),
     ct:log("String3: ~p~nLength3: ~p~n",[lists:flatten(String3),L3]),
     true = L3 > CL3,
-    true = L3 < CL3 + 10,
+    true = L3 < CL3 + 15,
 
     String4 = format(info,FA,Meta,FC#{chars_limit=>CL3,depth=>10}),
     L4 = string:length(String4),
     ct:log("String4: ~p~nLength4: ~p~n",[lists:flatten(String4),L4]),
     true = L4 > CL3,
-    true = L4 < CL3 + 10,
+    true = L4 < CL3 + 15,
 
     %% Test that max_size truncates the string which is limited by
     %% depth and chars_limit
@@ -433,29 +433,58 @@ format_mfa(_Config) ->
     ok.
     
 format_time(_Config) ->
-    Time1 = timestamp(),
-    ExpectedTimestamp1 = default_time_format(Time1),
-    String1 = format(info,{"~p",[term]},#{time=>Time1},#{}),
-    ct:log(String1),
-    " info: term\n" = string:prefix(String1,ExpectedTimestamp1),
+    Time = timestamp(),
+    Meta = #{time=>Time},
+    FC = #{template=>[time]},
+    Msg = {string,""},
+    ExpectedLocal = default_time_format(Time,false),
+    ExpectedUtc = default_time_format(Time,true),
 
-    Time2 = timestamp(),
-    ExpectedTimestamp2 = default_time_format(Time2,true),
-    String2 = format(info,{"~p",[term]},#{time=>Time2},#{utc=>true}),
-    ct:log(String2),
-    " info: term\n" = string:prefix(String2,ExpectedTimestamp2),
+    %% default - local time
+    ExpectedLocal = format(info,Msg,Meta,FC),
 
-    %% application:set_env(kernel,logger_utc,true),
-    %% Time3 = timestamp(),
-    %% ExpectedTimestamp3 = default_time_format(Time3,true),
-    %% String3 = format(info,{"~p",[term]},#{time=>Time3},#{}),
-    %% ct:log(String3),
-    %% " info: term\n" = string:prefix(String3,ExpectedTimestamp3),
+    %% time_offset config parameter to formatter
+    ExpectedLocal = format(info,Msg,Meta,FC#{time_offset=>""}),
+    ExpectedUtc = format(info,Msg,Meta,FC#{time_offset=>"Z"}),
+
+    %% stdlib utc_log works when time_offset parameter is not set
+    application:set_env(stdlib,utc_log,true),
+    ExpectedUtc = format(info,Msg,Meta,FC),
+
+    %% sasl utc_log overwrites stdlib utc_log
+    application:set_env(sasl,utc_log,false),
+    ExpectedLocal = format(info,Msg,Meta,FC),
+
+    %% sasl utc_log overwrites stdlib utc_log
+    application:set_env(sasl,utc_log,true),
+    application:set_env(stdlib,utc_log,false),
+    ExpectedUtc = format(info,Msg,Meta,FC),
+
+    %% time_offset config parameter to formatter
+    %% overwrites sasl and stdlib utc_log
+    application:set_env(sasl,utc_log,false),
+    ExpectedUtc = format(info,Msg,Meta,FC#{time_offset=>"Z"}),
+
+    %% time_offset config parameter to formatter
+    %% overwrites sasl and stdlib utc_log
+    application:set_env(sasl,utc_log,true),
+    application:set_env(stdlib,utc_log,true),
+    ExpectedLocal = format(info,Msg,Meta,FC#{time_offset=>""}),
+
+    %% time_designator config parameter to formatter
+    ExpectedLocalS = default_time_format(Time,false,$\s),
+    ExpectedUtcS = default_time_format(Time,true,$\s),
+
+    ExpectedLocalS = format(info,Msg,Meta,FC#{time_offset=>"",
+                                              time_designator=>$\s}),
+    ExpectedUtcS = format(info,Msg,Meta,FC#{time_offset=>"Z",
+                                            time_designator=>$\s}),
 
     ok.
 
 format_time(cleanup,_Config) ->
-    application:unset_env(kernel,logger_utc),
+    application:unset_env(sasl,utc_log),
+    application:unset_env(stdlib,utc_log),
     ok.
 
 level_or_msg_in_meta(_Config) ->
@@ -514,22 +543,17 @@ format(Log,Config) ->
 default_time_format(Timestamp) ->
     default_time_format(Timestamp,false).
 
-default_time_format(Timestamp0,Utc) when is_integer(Timestamp0) ->
-    Timestamp=Timestamp0+erlang:time_offset(microsecond),
-    %% calendar:system_time_to_rfc3339(Time,[{unit,microsecond}]).
-    Micro = Timestamp rem 1000000,
-    Sec = Timestamp div 1000000,
-    UniversalTime =  erlang:posixtime_to_universaltime(Sec),
-    {Date,Time} =
-        if Utc -> UniversalTime;
-           true -> erlang:universaltime_to_localtime(UniversalTime)
-        end,
-    default_time_format(Date,Time,Micro).
+default_time_format(Timestamp,Utc) ->
+    default_time_format(Timestamp,Utc,$T).
 
-default_time_format({Y,M,D},{H,Min,S},Micro) ->
-    lists:flatten(
-      io_lib:format("~4w-~2..0w-~2..0w ~2w:~2..0w:~2..0w.~6..0w",
-                    [Y,M,D,H,Min,S,Micro])).
+default_time_format(Timestamp0,Utc,Sep) ->
+    Timestamp=Timestamp0+erlang:time_offset(microsecond),
+    Offset = if Utc -> "Z";
+                true -> ""
+             end,
+    calendar:system_time_to_rfc3339(Timestamp,[{unit,microsecond},
+                                               {time_designator,Sep},
+                                               {offset,Offset}]).
 
 integer(Str) ->
     is_integer(list_to_integer(Str)).

--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -341,7 +341,7 @@ depth(_Config) ->
                {"~p",[[1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0]]},
                #{},
                #{template=>Template}),
-    application:set_env(kernel,logger_format_depth,12),
+    application:set_env(kernel,error_logger_format_depth,12),
     "[1,2,3,4,5,6,7,8,9,0,1|...]" =
         format(info,
                {"~p",[[1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0]]},
@@ -361,7 +361,7 @@ depth(_Config) ->
                  depth=>unlimited}),
     ok.
 depth(cleanup,_Config) ->
-    application:unset_env(kernel,logger_format_depth),
+    application:unset_env(kernel,error_logger_format_depth),
     ok.
 
 chars_limit(_Config) ->

--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -297,22 +297,22 @@ max_size(_Config) ->
             single_line=>false},
     "12345678901234567890" =
         format(info,{"12345678901234567890",[]},#{},Cfg),
-    application:set_env(kernel,logger_max_size,11),
-    "12345678901234567890" = % min value is 50, so this is not limited
-        format(info,{"12345678901234567890",[]},#{},Cfg),
-    "12345678901234567890123456789012345678901234567..." = % 50
-        format(info,
-               {"123456789012345678901234567890123456789012345678901234567890",
-                []},
-               #{},
-               Cfg),
-    application:set_env(kernel,logger_max_size,53),
-    "12345678901234567890123456789012345678901234567890..." = %53
-        format(info,
-               {"123456789012345678901234567890123456789012345678901234567890",
-                []},
-               #{},
-               Cfg),
+    %% application:set_env(kernel,logger_max_size,11),
+    %% "12345678901234567890" = % min value is 50, so this is not limited
+    %%     format(info,{"12345678901234567890",[]},#{},Cfg),
+    %% "12345678901234567890123456789012345678901234567..." = % 50
+    %%     format(info,
+    %%            {"123456789012345678901234567890123456789012345678901234567890",
+    %%             []},
+    %%            #{},
+    %%            Cfg),
+    %% application:set_env(kernel,logger_max_size,53),
+    %% "12345678901234567890123456789012345678901234567890..." = %53
+    %%     format(info,
+    %%            {"123456789012345678901234567890123456789012345678901234567890",
+    %%             []},
+    %%            #{},
+    %%            Cfg),
     "123456789012..." =
         format(info,{"12345678901234567890",[]},#{},Cfg#{max_size=>15}),
     "12345678901234567890" =
@@ -337,12 +337,6 @@ depth(_Config) ->
                #{template=>Template}),
     application:set_env(kernel,error_logger_format_depth,11),
     "[1,2,3,4,5,6,7,8,9,0|...]" =
-        format(info,
-               {"~p",[[1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0]]},
-               #{},
-               #{template=>Template}),
-    application:set_env(kernel,error_logger_format_depth,12),
-    "[1,2,3,4,5,6,7,8,9,0,1|...]" =
         format(info,
                {"~p",[[1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0]]},
                #{},
@@ -451,12 +445,12 @@ format_time(_Config) ->
     ct:log(String2),
     " info: term\n" = string:prefix(String2,ExpectedTimestamp2),
 
-    application:set_env(kernel,logger_utc,true),
-    Time3 = timestamp(),
-    ExpectedTimestamp3 = default_time_format(Time3,true),
-    String3 = format(info,{"~p",[term]},#{time=>Time3},#{}),
-    ct:log(String3),
-    " info: term\n" = string:prefix(String3,ExpectedTimestamp3),
+    %% application:set_env(kernel,logger_utc,true),
+    %% Time3 = timestamp(),
+    %% ExpectedTimestamp3 = default_time_format(Time3,true),
+    %% String3 = format(info,{"~p",[term]},#{time=>Time3},#{}),
+    %% ct:log(String3),
+    %% " info: term\n" = string:prefix(String3,ExpectedTimestamp3),
 
     ok.
 

--- a/lib/kernel/test/logger_std_h_SUITE.erl
+++ b/lib/kernel/test/logger_std_h_SUITE.erl
@@ -50,11 +50,12 @@
                           end).
 
 suite() ->
-    [{timetrap,{seconds,30}}].
+    [{timetrap,{seconds,30}},
+     {ct_hooks,[logger_test_lib]}].
 
 init_per_suite(Config) ->
     timer:start(),                              % to avoid progress report
-    {ok,{?STANDARD_HANDLER,#{formatter:=OrigFormatter}}} =
+    {ok,{logger_std_h,#{formatter:=OrigFormatter}}} =
         logger:get_handler_config(?STANDARD_HANDLER),
     [{formatter,OrigFormatter}|Config].
 
@@ -322,29 +323,32 @@ config_fail(cleanup,_Config) ->
     logger:remove_handler(?MODULE).
 
 crash_std_h_to_file(Config) ->
-    crash_std_h(Config,?FUNCTION_NAME,logger_dest,file).
+    Dir = ?config(priv_dir,Config),
+    Log = filename:join(Dir,lists:concat([?MODULE,"_",?FUNCTION_NAME,".log"])),
+    crash_std_h(Config,?FUNCTION_NAME,
+                [{handler,default,logger_std_h,
+                  #{ logger_std_h => #{ type => {file, Log} }}}],
+                file, Log).
 crash_std_h_to_file(cleanup,_Config) ->
     crash_std_h(cleanup).
 
 crash_std_h_to_disk_log(Config) ->
-    crash_std_h(Config,?FUNCTION_NAME,logger_dest,disk_log).
+    Dir = ?config(priv_dir,Config),
+    Log = filename:join(Dir,lists:concat([?MODULE,"_",?FUNCTION_NAME,".log"])),
+    crash_std_h(Config,?FUNCTION_NAME,
+                [{handler,default,logger_disk_log_h,
+                  #{ disk_log_opts => #{ file => Log }}}],
+                disk_log,Log).
 crash_std_h_to_disk_log(cleanup,_Config) ->
     crash_std_h(cleanup).
 
-crash_std_h(Config,Func,Var,Type) ->
+crash_std_h(Config,Func,Var,Type,Log) ->
     Dir = ?config(priv_dir,Config),
-    File = lists:concat([?MODULE,"_",Func,".log"]),
-    Log = filename:join(Dir,File),
+    SysConfig = filename:join(Dir,lists:concat([?MODULE,"_",Func,".config"])),
+    ok = file:write_file(SysConfig, io_lib:format("[{kernel,[{logger,~p}]}].",[Var])),
     Pa = filename:dirname(code:which(?MODULE)),
-    TypeAndLog =
-        case os:type() of
-            {win32,_} ->
-                lists:concat([" {",Type,",\\\"",Log,"\\\"}"]);
-            _ ->
-                lists:concat([" \'{",Type,",\"",Log,"\"}\'"])
-        end,
-    Args = lists:concat([" -kernel ",Var,TypeAndLog," -pa ",Pa]),
     Name = lists:concat([?MODULE,"_",Func]),
+    Args = lists:concat([" -config ",filename:rootname(SysConfig)," -pa ",Pa]),
     ct:pal("Starting ~p with ~tp", [Name,Args]),
     %% Start a node which prints kernel logs to the destination specified by Type
     {ok,Node} = test_server:start_node(Name, peer, [{args, Args}]),
@@ -585,7 +589,7 @@ write_failure(Config) ->
     Dir = ?config(priv_dir, Config),
     File = lists:concat([?MODULE,"_",?FUNCTION_NAME,".log"]),
     Log = filename:join(Dir, File),
-    Node = start_std_h_on_new_node(Config, ?FUNCTION_NAME, Log),
+    Node = start_std_h_on_new_node(Config, Log),
     false = (undefined == rpc:call(Node, ets, whereis, [?TEST_HOOKS_TAB])),
     rpc:call(Node, ets, insert, [?TEST_HOOKS_TAB,{tester,self()}]),
     rpc:call(Node, ?MODULE, set_internal_log, [?MODULE,internal_log]),
@@ -622,7 +626,7 @@ sync_failure(Config) ->
     Dir = ?config(priv_dir, Config),
     File = lists:concat([?MODULE,"_",?FUNCTION_NAME,".log"]),
     Log = filename:join(Dir, File),
-    Node = start_std_h_on_new_node(Config, ?FUNCTION_NAME, Log),
+    Node = start_std_h_on_new_node(Config, Log),
     false = (undefined == rpc:call(Node, ets, whereis, [?TEST_HOOKS_TAB])),
     rpc:call(Node, ets, insert, [?TEST_HOOKS_TAB,{tester,self()}]),
     rpc:call(Node, ?MODULE, set_internal_log, [?MODULE,internal_log]),
@@ -658,21 +662,12 @@ sync_failure(cleanup, _Config) ->
     Nodes = nodes(),
     [test_server:stop_node(Node) || Node <- Nodes].
 
-start_std_h_on_new_node(_Config, Func, Log) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Dest =
-        case os:type() of
-            {win32,_} ->
-                lists:concat([" {file,\\\"",Log,"\\\"}"]);
-            _ ->
-                lists:concat([" \'{file,\"",Log,"\"}\'"])
-        end,
-    Args = lists:concat([" -kernel ",logger_dest,Dest," -pa ",Pa]),
-    Name = lists:concat([?MODULE,"_",Func]),
-    ct:pal("Starting ~s with ~tp", [Name,Args]),
-    {ok,Node} = test_server:start_node(Name, peer, [{args, Args}]),
-    Pid = rpc:call(Node,erlang,whereis,[?STANDARD_HANDLER]),
-    true = is_pid(Pid),
+start_std_h_on_new_node(Config, Log) ->
+    {ok,_,Node} =
+        logger_test_lib:setup(
+          Config,
+          [{logger,[{handler,default,logger_std_h,
+                     #{ logger_std_h => #{ type => {file,Log}}}}]}]),
     ok = rpc:call(Node,logger,set_handler_config,[?STANDARD_HANDLER,formatter,
                                                   {?MODULE,nl}]),
     Node.

--- a/lib/kernel/test/logger_std_h_SUITE.erl
+++ b/lib/kernel/test/logger_std_h_SUITE.erl
@@ -242,7 +242,8 @@ formatter_fail(Config) ->
                               filters=>?DEFAULT_HANDLER_FILTERS([?MODULE])}),
     Pid = whereis(?MODULE),
     true = is_pid(Pid),
-    {ok,#{handlers:=H}} = logger:get_logger_config(),
+    #{handlers:=HC1} = logger:i(),
+    H = [Id || {Id,_,_} <- HC1],
     true = lists:member(?MODULE,H),
 
     %% Formatter is added automatically
@@ -271,7 +272,8 @@ formatter_fail(Config) ->
 
     %% Check that handler is still alive and was never dead
     Pid = whereis(?MODULE),
-    {ok,#{handlers:=H}} = logger:get_logger_config(),
+    #{handlers:=HC2} = logger:i(),
+    H = [Id || {Id,_,_} <- HC2],
 
     ok.
 

--- a/lib/kernel/test/logger_test_lib.erl
+++ b/lib/kernel/test/logger_test_lib.erl
@@ -1,0 +1,82 @@
+%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2018. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(logger_test_lib).
+
+-include_lib("kernel/src/logger_internal.hrl").
+
+-export([setup/2, log/3, sync_and_read/3]).
+
+-export([init/2,
+         pre_init_per_suite/3, pre_init_per_testcase/4,
+         post_end_per_testcase/5, post_end_per_suite/3]).
+
+setup(Config,Vars) ->
+    FuncStr = lists:concat([proplists:get_value(suite, Config), "_",
+                            proplists:get_value(tc, Config)]),
+    ConfigFileName = filename:join(proplists:get_value(priv_dir, Config), FuncStr),
+    file:write_file(ConfigFileName ++ ".config", io_lib:format("[{kernel, ~p}].",[Vars])),
+    case test_server:start_node(proplists:get_value(tc, Config), slave,
+                                [{args, ["-pa ",filename:dirname(code:which(?MODULE)),
+                                         " -boot start_sasl -kernel start_timer true "
+                                         "-config ",ConfigFileName]}]) of
+        {ok, Node} ->
+            L = rpc:call(Node, logger, i, []),
+            ct:log("~p",[L]),
+            {ok, L, Node};
+        {error, Reason} ->
+            ct:log("Failed to start node: ~p",[Reason]),
+            error
+    end.
+
+log(Node, F, A) ->
+    log(Node, logger, F, A).
+log(Node, M, F, A) ->
+    MD = #{ gl => rpc:call(Node, erlang, whereis, [logger]) },
+    rpc:call(Node, M, F, A ++ [MD]).
+
+sync_and_read(Node,disk_log,Log) ->
+    rpc:call(Node,logger_disk_log_h,disk_log_sync,[?STANDARD_HANDLER]),
+    file:read_file(Log ++ ".1");
+sync_and_read(Node, file,Log) ->
+    ok = rpc:call(Node,logger_std_h,filesync,[?STANDARD_HANDLER]),
+    file:read_file(Log).
+
+
+init(_, _) ->
+    {ok, []}.
+
+pre_init_per_suite(_Suite, Config, State) ->
+    {[{nodes, nodes()} | Config], State}.
+
+pre_init_per_testcase(Suite, TC, Config, State) ->
+    cleanup(Config),
+    {[{suite, Suite}, {tc, TC} | Config], State}.
+
+post_end_per_testcase(_, _TC, Config, Res, State) ->
+    cleanup(Config),
+    {Res, State}.
+
+post_end_per_suite(_, Config, State) ->
+    cleanup(Config),
+    {Config, State}.
+
+cleanup(Config) ->
+    [test_server:stop_node(N) || N <- nodes(),
+                                 not lists:member(N, proplists:get_value(nodes, Config))].

--- a/lib/sasl/doc/src/sasl_app.xml
+++ b/lib/sasl/doc/src/sasl_app.xml
@@ -119,22 +119,18 @@
         <p>Formats and writes <em>supervisor reports</em>, <em>crash
         reports</em>, and <em>progress reports</em> to <c>stdio</c>.
         This error logger event handler uses
-	<seealso marker="kernel:kernel_app#logger_format_depth"><c>logger_format_depth</c></seealso>
+	<seealso marker="kernel:kernel_app#deprecated-configuration-parameters"><c>error_logger_format_depth</c></seealso>
 	in the Kernel application to limit how much detail is printed
-	in crash and supervisor reports. If <c>logger_format_depth</c>
-	is not set, it uses the old <c>error_logger_format_depth</c>
-	instead.</p>
+	in crash and supervisor reports.</p>
       </item>
       <tag><c>sasl_report_file_h</c></tag>
       <item>
         <p>Formats and writes <em>supervisor reports</em>, <em>crash
         report</em>, and <em>progress report</em> to a single file.
         This error logger event handler uses
-	<seealso marker="kernel:kernel_app#logger_format_depth"><c>logger_format_depth</c></seealso>
+	<seealso marker="kernel:kernel_app#deprecated-configuration-parameters"><c>error_logger_format_depth</c></seealso>
 	in the Kernel application to limit the details printed in
-	crash and supervisor reports. If <c>logger_format_depth</c> is
-	not set, it uses the old <c>error_logger_format_depth</c>
-	instead.</p>
+	crash and supervisor reports.</p>
       </item>
     </taglist>
     <p>A similar behaviour, but still using the new logger API, can be

--- a/lib/sasl/doc/src/sasl_app.xml
+++ b/lib/sasl/doc/src/sasl_app.xml
@@ -86,12 +86,6 @@
           <c>RELDIR</c> is used. By default, this is
           <c>$OTP_ROOT/releases</c>.</p>
       </item>
-      <tag><c><![CDATA[utc_log = true | false ]]></c></tag>
-      <item>
-        <p>If set to <c>true</c>, all dates in textual log outputs are
-          displayed in Universal Coordinated Time with the string
-          <c>UTC</c> appended.</p>
-      </item>
     </taglist>
   </section>
 
@@ -174,6 +168,12 @@
         <p>Restricts the error logging performed by the specified
           <c>sasl_error_logger</c> to error reports or progress reports,
           or both. Default is <c>all</c>.</p>
+      </item>
+      <tag><marker id="utc_log"/><c><![CDATA[utc_log = true | false ]]></c></tag>
+      <item>
+        <p>If set to <c>true</c>, all dates in textual log outputs are
+          displayed in Universal Coordinated Time with the string
+          <c>UTC</c> appended.</p>
       </item>
     </taglist>
 

--- a/lib/sasl/src/sasl.erl
+++ b/lib/sasl/src/sasl.erl
@@ -142,7 +142,9 @@ add_sasl_logger(Dest, Level) ->
                             #{level=>Level,
                               filter_default=>stop,
                               filters=>
-                                  [{sasl_domain,
+                                  [{remote_gl,
+                                    {fun logger_filters:remote_gl/2,stop}},
+                                   {sasl_domain,
                                     {fun logger_filters:domain/2,
                                      {log,equals,[beam,erlang,otp,sasl]}}}],
                               logger_std_h=>#{type=>Dest},

--- a/lib/sasl/test/sasl_report_SUITE.erl
+++ b/lib/sasl/test/sasl_report_SUITE.erl
@@ -54,7 +54,7 @@ gen_server_crash_unicode(Config) ->
 
 gen_server_crash(Config, Encoding) ->
     StopFilter = {fun(_,_) -> stop end, ok},
-    logger:add_handler_filter(logger_std_h,stop_all,StopFilter),
+    logger:add_handler_filter(default,stop_all,StopFilter),
     logger:add_handler_filter(cth_log_redirect,stop_all,StopFilter),
     try
 	do_gen_server_crash(Config, Encoding)
@@ -62,7 +62,7 @@ gen_server_crash(Config, Encoding) ->
         ok = application:unset_env(kernel, logger_sasl_compatible),
 	ok = application:unset_env(sasl, sasl_error_logger),
 	ok = application:unset_env(kernel, error_logger_format_depth),
-        logger:remove_handler_filter(logger_std_h,stop_all),
+        logger:remove_handler_filter(default,stop_all),
         logger:remove_handler_filter(cth_log_redirect,stop_all)
     end,
     ok.
@@ -83,8 +83,10 @@ do_gen_server_crash(Config, Encoding) ->
     error_logger:logfile({open,KernelLog}),
     application:start(sasl),
     logger:i(print),
+    ct:log("error_logger handlers: ~p",[error_logger:which_report_handlers()]),
 
     crash_me(),
+
 
     error_logger:logfile(close),
     application:stop(sasl),

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -934,14 +934,14 @@ format_log(#{label:={gen_server,terminate},
 			end
 		end;
 	    _ ->
-		logger:limit_term(Reason)
+		error_logger:limit_term(Reason)
 	end,    
     {ClientFmt,ClientArgs} = format_client_log(Client),
     {"** Generic server ~tp terminating \n"
      "** Last message in was ~tp~n"
      "** When Server state == ~tp~n"
      "** Reason for termination == ~n** ~tp~n" ++ ClientFmt,
-     [Name, Msg, logger:limit_term(State), Reason1] ++ ClientArgs};
+     [Name, Msg, error_logger:limit_term(State), Reason1] ++ ClientArgs};
 format_log(#{label:={gen_server,no_handle_info},
              module:=Mod,
              message:=Msg}) ->

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -1938,7 +1938,7 @@ format_log(#{label:={gen_statem,terminate},
 	    _ -> {Reason,Stacktrace}
 	end,
     [LimitedP, LimitedFmtData, LimitedFixedReason] =
-        [logger:limit_term(D) || D <- [P, FmtData, FixedReason]],
+        [error_logger:limit_term(D) || D <- [P, FmtData, FixedReason]],
     CBMode =
 	 case StateEnter of
 	     true ->

--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -553,10 +553,10 @@ get_ancestors(Pid) ->
 %% assumed that all report handlers call proc_lib:format().
 get_messages(Pid) ->
     Messages = get_process_messages(Pid),
-    {messages, logger:limit_term(Messages)}.
+    {messages, error_logger:limit_term(Messages)}.
 
 get_process_messages(Pid) ->
-    Depth = logger:get_format_depth(),
+    Depth = error_logger:get_format_depth(),
     case Pid =/= self() orelse Depth =:= unlimited of
         true ->
             {messages, Messages} = get_process_info(Pid, messages),
@@ -586,7 +586,7 @@ get_cleaned_dictionary(Pid) ->
 
 cleaned_dict(Dict) ->
     CleanDict = clean_dict(Dict),
-    logger:limit_term(CleanDict).
+    error_logger:limit_term(CleanDict).
 
 clean_dict([{'$ancestors',_}|Dict]) ->
     clean_dict(Dict);
@@ -756,7 +756,7 @@ check(Res)               -> Res.
       Args :: [term()].
 report_cb(#{label:={proc_lib,crash},
             report:=CrashReport}) ->
-    Depth = logger:get_format_depth(),
+    Depth = error_logger:get_format_depth(),
     get_format_and_args(CrashReport, utf8, Depth).
 
 -spec format(CrashReport) -> string() when


### PR DESCRIPTION
Most logger configuration that was possible through kernel application variables have been moved into a common 'logger' application environment in kernel.

Now all the configuration possible through the logger API can be done as sys config.

The handler started by kernel has been renamed to 'default' instead of logger_std_h.

There is a new logger:add_handlers/1 function that given an application name can be used to setup handlers in other applications.

Configuring the default handler to use a file instead of standard_io looks like this:

```
[{kernel,
  [{logger,
    [{handler, default, logger_std_h,
      #{ logger_std_h => #{ type => {file,"log/erlang.log"}}}}]}]}].
```

It is a bit more verbose than we would have liked, but will have to do for now. There are more examples in the Logger User's Guide.

The PR also contains a bunch of other commits doing various, mostly documentation related fixes to Logger.