### PR TITLE
Fix use-after-free on Windows in escript

### DIFF
--- a/erts/etc/common/escript.c
+++ b/erts/etc/common/escript.c
@@ -139,15 +139,6 @@ get_env(char *key)
 }
 
 static void
-free_env_val(char *value)
-{
-#ifdef __WIN32__
-    if (value)
-	efree(value);
-#endif
-}
-
-static void
 set_env(char *key, char *value)
 {
 #ifdef __WIN32__
@@ -422,7 +413,6 @@ main(int argc, char** argv)
     int eargv_size;
     int eargc_base;		/* How many arguments in the base of eargv. */
     char* emulator;
-    char* env;
     char* basename;
     char* def_emu_lookup_path;
     char scriptname[PMAX];
@@ -504,7 +494,7 @@ main(int argc, char** argv)
     }
 
     /* Determine path to emulator */
-    emulator = env = get_env("ESCRIPT_EMULATOR");
+    emulator = get_env("ESCRIPT_EMULATOR");
 
     if (emulator == NULL) {
 	emulator = get_default_emulator(def_emu_lookup_path);
@@ -518,7 +508,6 @@ main(int argc, char** argv)
      */
 
     PUSH(emulator);
-    free_env_val(env);
 
     PUSH("+B");
     PUSH2("-boot", "no_dot_erlang");


### PR DESCRIPTION
Since commit 385b18de6fd72672ed7d6736b30f56d6691d4433, the emulator path was not copied anymore before pushing it to the args vector (before it was done within the `push_words` function. Since on Windows `free_env_val` is not a NOP as it is on Unix systems, the string is freed and afterwards used, leading to strange errors like this:

     escript: Error executing 'àyI': 2

This is fixed by removing the `free_env_val` call.