### PR TITLE
do not call abort_signal_task() with invalid data

### DIFF
--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -1567,8 +1567,9 @@ fail:
 	erts_port_dec_refc(pp);
 
     if (ptp) {
-        abort_signal_task(pp, ERTS_PROC2PORT_SIG_ABORT,
-                          ptp->type, &ptp->u.alive.td, 0);
+        if (ptp->type == ERTS_PORT_TASK_PROC_SIG)
+            abort_signal_task(pp, ERTS_PROC2PORT_SIG_ABORT,
+                              ptp->type, &ptp->u.alive.td, 0);
 	port_task_free(ptp);
     }
 


### PR DESCRIPTION
erts_port_task_schedule() has a label "fail" where it calls abort_signal_task().  It doesn't check the type of the port first, meaning it may do the call for non-ERTS_PORT_TASK_PROC_SIG ports, and in those cases abort_signal_task() calls through an uninitialized function pointer, causing a segfault.

This fix checks the type before allowing the call, which seems to cure the problem.

See https://bugs.erlang.org/browse/ERL-621 for background.

I am also concerned about the abort_nosuspend_task() call, but don't have a test case showing a malfunction there.