### PR TITLE
httpc_handler: use connect_timeout as timeout for proxy SSL connection

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -1635,14 +1635,14 @@ host_header(_, URI) ->
 tls_upgrade(#state{status = 
 		       {ssl_tunnel, 
 			#request{settings = 
-				     #http_options{ssl = {_, TLSOptions0} = SocketType},
+				     #http_options{ssl = {_, TLSOptions0} = SocketType, connect_timeout = ConnTimeout},
 				     address = {Host, _} = Address} = Request},
 		   session = #session{socket = TCPSocket} = Session0,
 		   options = Options} = State) ->
 
     TLSOptions = maybe_add_sni(Host, TLSOptions0),
 
-    case ssl:connect(TCPSocket, TLSOptions) of
+    case ssl:connect(TCPSocket, TLSOptions, ConnTimeout) of
 	{ok, TLSSocket} ->
 	    ClientClose = httpc_request:is_client_closing(Request#request.headers),
 	    SessionType = httpc_manager:session_type(Options),


### PR DESCRIPTION
Currently httpc_handler calls ssl:connect() with no timeout at all (means it's infinity). Since it's a blocking call, httpc_handler never receives a 'timeout' message.

Fix suggested is not the best possible implementation, but it does the trick.

In theory, it shall be handled in a very different way (e.g. asynchronously, following steps for SSL/TLS connection), but that requires somewhat large httpc_hanlder rewrite. Unless there are better ideas, of course.