### PR TITLE
Fix name capture problem in sys_core_fold

### DIFF
--- a/lib/compiler/src/sys_core_inline.erl
+++ b/lib/compiler/src/sys_core_inline.erl
@@ -143,7 +143,7 @@ inline_inline(#ifun{body=B,weight=Iw}=If, Is) ->
 		     case find_inl(F, A, Is) of
 			 #ifun{vars=Vs,body=B2,weight=W} when W < Iw ->
 			     #c_let{vars=Vs,
-				     arg=core_lib:make_values(As),
+				     arg=kill_id_anns(core_lib:make_values(As)),
 				    body=kill_id_anns(B2)};
 			 _Other -> Call
 		     end;
@@ -160,7 +160,7 @@ inline_func(#fstat{def={Name,F0}}=Fstat, Is) ->
 		     case find_inl(F, A, Is) of
 			 #ifun{vars=Vs,body=B} ->
 			     {#c_let{vars=Vs,
-				     arg=core_lib:make_values(As),
+				     arg=kill_id_anns(core_lib:make_values(As)),
 				     body=kill_id_anns(B)},
 			      true};			%Have modified
 			 _Other -> {Call,Mod}

--- a/lib/compiler/test/core_SUITE.erl
+++ b/lib/compiler/test/core_SUITE.erl
@@ -29,7 +29,7 @@
 	 bs_shadowed_size_var/1,
 	 cover_v3_kernel_1/1,cover_v3_kernel_2/1,cover_v3_kernel_3/1,
 	 cover_v3_kernel_4/1,cover_v3_kernel_5/1,
-         non_variable_apply/1]).
+         non_variable_apply/1,name_capture/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -58,7 +58,7 @@ groups() ->
        bs_shadowed_size_var,
        cover_v3_kernel_1,cover_v3_kernel_2,cover_v3_kernel_3,
        cover_v3_kernel_4,cover_v3_kernel_5,
-       non_variable_apply
+       non_variable_apply,name_capture
       ]}].
 
 
@@ -93,6 +93,7 @@ end_per_group(_GroupName, Config) ->
 ?comp(cover_v3_kernel_4).
 ?comp(cover_v3_kernel_5).
 ?comp(non_variable_apply).
+?comp(name_capture).
 
 try_it(Mod, Conf) ->
     Src = filename:join(proplists:get_value(data_dir, Conf),

--- a/lib/compiler/test/core_SUITE_data/name_capture.core
+++ b/lib/compiler/test/core_SUITE_data/name_capture.core
@@ -1,0 +1,110 @@
+module 'name_capture' ['module_info'/0,
+		       'module_info'/1,
+		       'name_capture'/0]
+    attributes ['compile' =
+		    [{'inline',[{'badarg_exit',2}]}]]
+'name_capture'/0 =
+    fun () ->
+	case <> of
+	  <> when 'true' ->
+	      let <_0> =
+		  catch
+		      apply 'first'/1
+			  ('badarg')
+	      in  case _0 of
+		    <{'EXIT',{'badarg',_7}}> when 'true' ->
+			let <Seq> =
+			    call 'lists':'seq'
+				(7, 17)
+			in  case apply 'first'/1
+				     ({'ok',Seq}) of
+			      <_8>
+				  when call 'erlang':'=:='
+					(_8,
+					 Seq) ->
+				  let <SomeOtherTerm> =
+				      {'some','other','term'}
+				  in  let <_5> =
+					  catch
+					      apply 'first'/1
+						  (SomeOtherTerm)
+				      in  case _5 of
+					    <{'EXIT',_9}>
+						when call 'erlang':'=:='
+						      (_9,
+						       SomeOtherTerm) ->
+						'ok'
+					    <_6> when 'true' ->
+						primop 'match_fail'
+						    ({'badmatch',_6})
+					  end
+			      <_3> when 'true' ->
+				  primop 'match_fail'
+				      ({'badmatch',_3})
+			    end
+		    <_1> when 'true' ->
+			primop 'match_fail'
+			    ({'badmatch',_1})
+		  end
+	  <> when 'true' ->
+	      primop 'match_fail'
+		  ({'function_clause'})
+	end
+'first'/1 =
+    fun (_0) ->
+	case _0 of
+	  <Tab> when 'true' ->
+	      let <_1> =
+		  apply 'treq'/2
+		      (Tab, 'first')
+		      %% The _1 variable in the `let` must be renamed
+		      %% to avoid a name capture problem.
+	      in  let <_0,_1> =
+		      <_1,[Tab|[]]>
+		  in  case <_0,_1> of
+			<'badarg',A> when 'true' ->
+			    call 'erlang':'error'
+				('badarg', A)
+			<{'ok',Reply},_X_A> when 'true' ->
+			    Reply
+			<Reply,_X_A> when 'true' ->
+			    call 'erlang':'exit'
+				(Reply)
+			<_3,_2> when 'true' ->
+			    primop 'match_fail'
+				({'function_clause',_3,_2})
+		      end
+	  <_2> when 'true' ->
+	      primop 'match_fail'
+		  ({'function_clause',_2})
+	end
+'treq'/2 =
+    fun (_0,_1) ->
+	case <_0,_1> of
+	  <Action,_4> when 'true' ->
+	      Action
+	  <_3,_2> when 'true' ->
+	      primop 'match_fail'
+		  ({'function_clause',_3,_2})
+	end
+'module_info'/0 =
+    fun () ->
+	case <> of
+	  <> when 'true' ->
+	      call 'erlang':'get_module_info'
+		  ('name_capture')
+	  <> when 'true' ->
+	      primop 'match_fail'
+		  ({'function_clause'})
+	end
+'module_info'/1 =
+    fun (_0) ->
+	case _0 of
+	  <X> when 'true' ->
+	      call 'erlang':'get_module_info'
+		  ('name_capture', X)
+	  <_1> when 'true' ->
+	      primop 'match_fail'
+		  ({'function_clause',_1})
+	end
+end


### PR DESCRIPTION
The compiler could produce incorrect code in rare circsumstance when the old inliner was used (invoked using the `[{inline,F/A}]` compiler option. This pull request also includes a minor bug fix of the old inliner to avoid spurious warnings.

The bug seems to have been present since `sys_core_fold` was introduced in OTP R7, but not discovered until now. Therefore, its seems to be sufficient to fix the bug in `master`.

See the commit message for the second commit for an in-depth explanation of the bug.