### PR TITLE
stdlib: Make pP insert no line breaks with field width zero

### DIFF
--- a/lib/stdlib/doc/src/io.xml
+++ b/lib/stdlib/doc/src/io.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>1996</year><year>2017</year>
+      <year>1996</year><year>2018</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -332,11 +332,22 @@ Here T = [{attributes,[[{id,age,1.5},
           {tag,{'PRIVATE',3}},
           {mode,implicit}]
 ok</pre>
+
+            <p>As from Erlang/OTP 21.0, a field width of value
+	      <c>0</c> can be used for specifying that a line is
+	      infinitely long, which means that no line breaks
+	      are inserted. For example:</p>
+
+	    <pre>
+5> <input>io:fwrite("~0p~n", [lists:seq(1, 30)]).</input>
+[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30]
+ok</pre>
+
             <p>When the modifier <c>l</c> is specified, no detection of
               printable character lists takes place, for example:</p>
             <pre>
-5> <input>S = [{a,"a"}, {b, "b"}].</input>
-6> <input>io:fwrite("~15p~n", [S]).</input>
+6> <input>S = [{a,"a"}, {b, "b"}],
+   io:fwrite("~15p~n", [S]).</input>
 [{a,"a"},
  {b,"b"}]
 ok

--- a/lib/stdlib/src/io_lib_pretty.erl
+++ b/lib/stdlib/src/io_lib_pretty.erl
@@ -131,6 +131,8 @@ print(Term, Col, Ll, D, M0, T, RecDefFun, Enc, Str) when is_tuple(Term);
     %% use Len as CHAR_MAX if M0 = -1
     M = max_cs(M0, Len),
     if
+        Ll =:= 0 ->
+            write(If);
         Len < Ll - Col, Len =< M ->
             %% write the whole thing on a single line when there is room
             write(If);

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -31,7 +31,7 @@
          otp_10836/1, io_lib_width_too_small/1,
          io_with_huge_message_queue/1, format_string/1,
 	 maps/1, coverage/1, otp_14178_unicode_atoms/1, otp_14175/1,
-         otp_14285/1, limit_term/1, otp_14983/1]).
+         otp_14285/1, limit_term/1, otp_14983/1, otp_15103/1]).
 
 -export([pretty/2, trf/3]).
 
@@ -63,7 +63,7 @@ all() ->
      io_lib_print_binary_depth_one, otp_10302, otp_10755, otp_10836,
      io_lib_width_too_small, io_with_huge_message_queue,
      format_string, maps, coverage, otp_14178_unicode_atoms, otp_14175,
-     otp_14285, limit_term, otp_14983].
+     otp_14285, limit_term, otp_14983, otp_15103].
 
 %% Error cases for output.
 error_1(Config) when is_list(Config) ->
@@ -2615,3 +2615,21 @@ trf(Format, Args, T) ->
 
 trf(Format, Args, T, Opts) ->
     lists:flatten(io_lib:format(Format, Args, [{chars_limit, T}|Opts])).
+
+otp_15103(_Config) ->
+    T = lists:duplicate(5, {a,b,c}),
+
+    S1 = io_lib:format("~0p", [T]),
+    "[{a,b,c},{a,b,c},{a,b,c},{a,b,c},{a,b,c}]" = lists:flatten(S1),
+    S2 = io_lib:format("~-0p", [T]),
+    "[{a,b,c},{a,b,c},{a,b,c},{a,b,c},{a,b,c}]" = lists:flatten(S2),
+    S3 = io_lib:format("~1p", [T]),
+    "[{a,\n  b,\n  c},\n {a,\n  b,\n  c},\n {a,\n  b,\n  c},\n {a,\n  b,\n"
+    "  c},\n {a,\n  b,\n  c}]" = lists:flatten(S3),
+
+    S4 = io_lib:format("~0P", [T, 5]),
+    "[{a,b,c},{a,b,...},{a,...},{...}|...]" = lists:flatten(S4),
+    S5 = io_lib:format("~1P", [T, 5]),
+    "[{a,\n  b,\n  c},\n {a,\n  b,...},\n {a,...},\n {...}|...]" =
+        lists:flatten(S5),
+    ok.


### PR DESCRIPTION
See also https://bugs.erlang.org/browse/ERL-607.

A zero field width used to insert line breaks "everywhere", but with
this patch no line breaks are inserted.
