### PR TITLE
Fix some unmatched_return warnings

### DIFF
--- a/lib/common_test/src/ct_release_test.erl
+++ b/lib/common_test/src/ct_release_test.erl
@@ -554,11 +554,11 @@ target_system(Apps,CreateDir,InstallDir,{FromVsn,_,AllAppsVsns,Path}) ->
 
     %% create start_erl.data, sys.config and start.src
     StartErlData = filename:join([InstallDir, "releases", "start_erl.data"]),
-    write_file(StartErlData, io_lib:fwrite("~s ~s~n", [ErtsVsn, FromVsn])),
+    ok = write_file(StartErlData, io_lib:fwrite("~s ~s~n", [ErtsVsn, FromVsn])),
     SysConfig = filename:join([InstallDir, "releases", FromVsn, "sys.config"]),
-    write_file(SysConfig, "[]."),
+    ok = write_file(SysConfig, "[]."),
     StartSrc = filename:join(ErtsBinDir,"start.src"),
-    write_file(StartSrc,start_script()),
+    ok = write_file(StartSrc,start_script()),
     ok = file:change_mode(StartSrc,8#0755),
 
     %% Make start_erl executable
@@ -620,7 +620,7 @@ upgrade_system(Apps, FromRel, CreateDir, InstallDir, {_,ToVsn,_,_}) ->
 			      [{path,[FromPath]},
 			       {outdir,CreateDir}]]),
     SysConfig = filename:join([CreateDir, "sys.config"]),
-    write_file(SysConfig, "[]."),
+    ok = write_file(SysConfig, "[]."),
 
     ok = systools(make_tar,[RelName,[{erts,code:root_dir()}]]),
 
@@ -858,7 +858,7 @@ subst_file(Src, Dest, Vars, Opts) ->
     {ok, Bin} = file:read_file(Src),
     Conts = unicode:characters_to_list(Bin),
     NConts = subst(Conts, Vars),
-    write_file(Dest, NConts),
+    ok = write_file(Dest, NConts),
     case lists:member(preserve, Opts) of
         true ->
             {ok, FileInfo} = file:read_file_info(Src),

--- a/lib/common_test/src/ct_release_test.erl
+++ b/lib/common_test/src/ct_release_test.erl
@@ -528,7 +528,7 @@ target_system(Apps,CreateDir,InstallDir,{FromVsn,_,AllAppsVsns,Path}) ->
 				     {path,Path}]]),
 
     %% Unpack the tar to complete the installation
-    erl_tar:extract(RelName ++ ".tar.gz", [{cwd, InstallDir}, compressed]),
+    ok = erl_tar:extract(RelName ++ ".tar.gz", [{cwd, InstallDir}, compressed]),
 
     %% Add bin and log dirs
     BinDir = filename:join([InstallDir, "bin"]),

--- a/lib/common_test/src/ct_util.erl
+++ b/lib/common_test/src/ct_util.erl
@@ -192,7 +192,10 @@ do_start(Parent, Mode, LogDir, Verbosity) ->
 	    ok
     end,
 
-    ct_default_gl:start_link(group_leader()),
+    case ct_default_gl:start_link(group_leader()) of
+        {ok, _} -> ok;
+        ignore -> ok
+    end,
 
     {StartTime,TestLogDir} = ct_logs:init(Mode, Verbosity),
 

--- a/lib/common_test/src/cth_log_redirect.erl
+++ b/lib/common_test/src/cth_log_redirect.erl
@@ -124,7 +124,8 @@ start_log_handler() ->
                   shutdown=>2000,
                   type=>worker,
                   modules=>[?MODULE]},
-            {ok,_} = supervisor:start_child(logger_sup,ChildSpec);
+            {ok,_} = supervisor:start_child(logger_sup,ChildSpec),
+            ok;
         _Pid ->
             ok
     end,


### PR DESCRIPTION
This PR fixes most of the unmatched return Dialyzer warnings in `common_test`.
The only one remaining is:
<pre>
ct_release_test.erl:531: Expression produces a value of type 'ok' | {'error',_} | {'ok',[{string(),binary()}]}, but this value is unmatched
</pre>
that somebody with more familiarity with the code should handle.