### PR TITLE
Make Linux OOM killer avoid killing heart process

### DIFF
--- a/lib/kernel/doc/src/heart.xml
+++ b/lib/kernel/doc/src/heart.xml
@@ -107,6 +107,25 @@
         runtime system, whether the crash dump file is written or not.</p>
       </item>
     </taglist>
+    <p>When running on Linux, <c>heart</c> is at risk of being killed
+      by the OOM killer in low memory situations, since it is a child
+      of the Erlang runtime process which presumably is using a lot of
+      memory. <c>heart</c> attempts to change its "OOM score adjustment"
+      so that it can keep running and restart the Erlang runtime system
+      if needed. In order to do that when not running as root, it
+      needs to have the capability <c>CAP_SYS_RESOURCE</c>. You can use
+      the following command to set the capability for the <c>heart</c>
+      binary:</p>
+    <pre>
+% <input>setcap CAP_SYS_RESOURCE+ep /path/to/heart</input></pre>
+    <p>If it fails to change the OOM score adjustment, <c>heart</c>
+      will ignore the error and continue as usual. You can set
+      the environment variable <c>HEART_DEBUG</c> to a non-empty
+      value to see debugging output, or you can use the following
+      command to check if the adjustment has been changed to
+      <c>-1000</c> from the default <c>0</c>:</p>
+      <pre>
+% <input>cat /proc/$(pidof heart)/oom_score_adj</input></pre>
     <p>In the following descriptions, all functions fail with reason
       <c>badarg</c> if <c>heart</c> is not started.</p>
   </description>


### PR DESCRIPTION
When a Linux system runs out of memory, the Linux out-of-memory killer
selects a process to kill.  It then first kills the child processes of
that process, and if that didn't free enough memory, it kills the
process itself.

The Erlang "heart" program is run as a child process of the Erlang VM,
so if an Erlang VM is chosen, the OOM killer will first kill the heart
process and then the Erlang VM itself, defeating the purpose of having
a heart process.

This change, taken from port-linux.c in OpenSSH, attempts to change
the OOM score adjustment for the heart process, such that it will
never be killed by the OOM killer.  It then reverts this change when
restarting the Erlang VM, so that this invincibility doesn't get
passed on.

For this to work when running heart as a non-root user, the heart
binary needs to have the CAP_SYS_RESOURCE capability set:

    setcap CAP_SYS_RESOURCE+ep /path/to/heart

---

I'm not sure if that `setcap` command ought to be run by the makefile when installing, or if so where to add it.

I was thinking about making this optional, either at compile time or at run time, but I decided not to, because:

- this is the behaviour that users expect; people get surprised when their Erlang node is killed by the OOM killer and heart doesn't restart it.
- you pretty much have to enable it explicitly anyway, either by setting the capability for the heart binary or by running your Erlang node as root. Otherwise, heart sticks to the previous behaviour.

Though I'm opened to be persuaded otherwise.