### PR TITLE
beam_type: Fix unsafe optimization

### DIFF
--- a/lib/compiler/src/beam_type.erl
+++ b/lib/compiler/src/beam_type.erl
@@ -559,7 +559,7 @@ update({bs_save2,_,_}, Ts) ->
 update({bs_restore2,_,_}, Ts) ->
     Ts;
 update({bs_context_to_binary,Dst}, Ts) ->
-    tdb_store(Dst, {binary,1}, Ts);
+    tdb_store(Dst, any, Ts);
 update({test,bs_start_match2,_,_,[Src,_],Dst}, Ts0) ->
     Ts = tdb_meet(Src, {binary,1}, Ts0),
     tdb_copy(Src, Dst, Ts);

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -23,7 +23,7 @@
 	 init_per_group/2,end_per_group/2,
 	 integers/1,coverage/1,booleans/1,setelement/1,cons/1,
 	 tuple/1,record_float/1,binary_float/1,float_compare/1,
-	 arity_checks/1,elixir_binaries/1]).
+	 arity_checks/1,elixir_binaries/1,find_best/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -43,7 +43,8 @@ groups() ->
        binary_float,
        float_compare,
        arity_checks,
-       elixir_binaries
+       elixir_binaries,
+       find_best
       ]}].
 
 init_per_suite(Config) ->
@@ -291,6 +292,33 @@ elixir_bitstring_3(Bar) when is_bitstring(Bar) ->
           Rewrite ->
               list_to_bitstring(Rewrite)
       end/bitstring>>.
+
+find_best(_Config) ->
+    ok = find_best([a], nil),
+    ok = find_best([<<"a">>], nil),
+    {error,_} = find_best([], nil),
+    ok.
+
+%% Failed because beam_type assumed that the operand
+%% for bs_context_binary must be a binary. Not true!
+find_best([a|Tail], Best) ->
+    find_best(Tail,
+      case Best of
+          X when X =:= nil orelse X =:= false -> a;
+          X -> X
+      end);
+find_best([<<"a">>|Tail], Best) ->
+    find_best(Tail,
+      case Best of
+          X when X =:= nil orelse X =:= false -> <<"a">>;
+          X -> X
+      end);
+find_best([], a) ->
+    ok;
+find_best([], <<"a">>) ->
+    ok;
+find_best([], nil) ->
+    {error,<<"should not get here">>}.
 
 
 id(I) ->


### PR DESCRIPTION
beam_type assumed that the operand for the bs_context_to_binary
instruction must be a binary. That is not correct;
bs_context_to_binary accepts anything. Based on the incorrect
assumption, beam_type would remove other test instructions.

The bug was introduced in eee8655788d2, which was supposed
to be just a refactoring commit.

https://bugs.erlang.org/browse/ERL-655