### PR TITLE
Include question mark in query string on redirect

### DIFF
--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -398,7 +398,7 @@ redirect(Response = {_, Headers, _}, Request) ->
                     THost = http_util:maybe_add_brackets(maps:get(host, URIMap), Brackets),
                     TPort = maps:get(port, URIMap),
                     TPath = maps:get(path, URIMap),
-                    TQuery = maps:get(query, URIMap, ""),
+                    TQuery = add_question_mark(maps:get(query, URIMap, "")),
                     NewURI = uri_string:normalize(
                                uri_string:recompose(URIMap)),
                     HostPort = http_request:normalize_host(TScheme, THost, TPort),
@@ -417,6 +417,14 @@ redirect(Response = {_, Headers, _}, Request) ->
             end
     end.
 
+add_question_mark(<<>>) ->
+    <<>>;
+add_question_mark([]) ->
+    [];
+add_question_mark(Comp) when is_binary(Comp) ->
+    <<$?, Comp/binary>>;
+add_question_mark(Comp) when is_list(Comp) ->
+    [$?|Comp].
 
 %% RFC3986 - 5.2.2.  Transform References
 resolve_uri(Scheme, Host, Port, Path, Query, URI) ->


### PR DESCRIPTION
According to the code in httpc.erl, [the pquery parameter in the
`#request` record should start with a question mark](https://github.com/erlang/otp/blob/bc22321f10c1ad71fb7e28275a8e6ed26a34d4ab/lib/inets/src/http_client/httpc.erl#L545-L552). However, when
a server returned a 403 response, the Location header was parsed
and the question mark was not added to the beginning of the query
string. This ultimately causes the redirect to fail, as instead of
redirecting to "/path?query", httpc redirected to "/pathquery".

Note: this PR copies the query string code from httpc.erl to
httpc_response.erl. Maybe we should move those to a separate
module but I am not familiar enough with the codebase to say
if this is desirable OR even if we have such a place. Feedback
is welcome.