### PR TITLE
erts: Fix configure check when cross-compiling

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -581,7 +581,8 @@ if test "X$PROFILE_INSTR_GENERATE" = "Xtrue"; then
            PROFILE_INSTR_USE=false])
         rm -f default.profdata
       fi],
-     [])
+     [],
+     [AC_MSG_NOTICE([Disabling PGO when cross-compiling])])
    rm -f *.profraw
    CFLAGS=$saved_CFLAGS;
 fi


### PR DESCRIPTION
Without the `action-if-cross-compiling`  argument to [AC_RUN_IFELSE](https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Runtime.html) the configure steps fails with the following message when cross-compiling:

```
configure: error: cannot run test program while cross compiling
```