### PR TITLE
httpc 301 redirect: Do not assert scheme ports are equal

### DIFF
--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -425,11 +425,11 @@ resolve_uri(Scheme, Host, Port, Path, Query, URI) ->
 resolve_uri(Scheme, Host, Port, Path, Query, URI, Map0) ->
     case maps:is_key(scheme, URI) of
         true ->
-            Port = get_port(URI),
+            Port0 = get_port(URI),
             maybe_add_query(
               Map0#{scheme => maps:get(scheme, URI),
                    host => maps:get(host, URI),
-                   port => Port,
+                   port => Port0,
                    path => maps:get(path, URI)},
               URI);
         false ->

--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -423,24 +423,24 @@ resolve_uri(Scheme, Host, Port, Path, Query, URI) ->
     resolve_uri(Scheme, Host, Port, Path, Query, URI, #{}).
 %%
 resolve_uri(Scheme, Host, Port, Path, Query, URI, Map0) ->
-    case maps:is_key(scheme, URI) of
-        true ->
-            Port0 = get_port(URI),
+    case maps:get(scheme, URI, undefined) of
+        undefined ->
+            Port0 = get_port(Scheme, URI),
+            Map = Map0#{scheme => Scheme,
+                        port => Port0},
+            resolve_authority(Host, Port, Path, Query, URI, Map);
+        URIScheme ->
+            Port0 = get_port(URIScheme, URI),
             maybe_add_query(
-              Map0#{scheme => maps:get(scheme, URI),
-                   host => maps:get(host, URI),
-                   port => Port0,
-                   path => maps:get(path, URI)},
-              URI);
-        false ->
-            Map = Map0#{scheme => Scheme},
-            URI1 = URI#{scheme => Scheme},
-            resolve_authority(Host, Port, Path, Query, URI1, Map)
+              Map0#{scheme => URIScheme,
+                    host => maps:get(host, URI),
+                    port => Port0,
+                    path => maps:get(path, URI)},
+              URI)
     end.
 
 
-get_port(URI) ->
-    Scheme = maps:get(scheme, URI),
+get_port(Scheme, URI) ->
     case maps:get(port, URI, undefined) of
         undefined ->
             get_default_port(Scheme);
@@ -458,15 +458,13 @@ get_default_port("https") ->
 resolve_authority(Host, Port, Path, Query, RelURI, Map) ->
     case maps:is_key(host, RelURI) of
         true ->
-            Port0 = get_port(RelURI),
             maybe_add_query(
               Map#{host => maps:get(host, RelURI),
-                   port => Port0,
                    path => maps:get(path, RelURI)},
               RelURI);
         false ->
             Map1 = Map#{host => Host,
-                    port => Port},
+                        port => Port},
             resolve_path(Path, Query, RelURI, Map1)
     end.
 

--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -457,10 +457,10 @@ get_default_port("https") ->
 resolve_authority(Host, Port, Path, Query, RelURI, Map) ->
     case maps:is_key(host, RelURI) of
         true ->
-            Port = get_port(RelURI),
+            Port0 = get_port(RelURI),
             maybe_add_query(
               Map#{host => maps:get(host, RelURI),
-                   port => Port,
+                   port => Port0,
                    path => maps:get(path, RelURI)},
               RelURI);
         false ->

--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -434,7 +434,8 @@ resolve_uri(Scheme, Host, Port, Path, Query, URI, Map0) ->
               URI);
         false ->
             Map = Map0#{scheme => Scheme},
-            resolve_authority(Host, Port, Path, Query, URI, Map)
+            URI1 = URI#{scheme => Scheme},
+            resolve_authority(Host, Port, Path, Query, URI1, Map)
     end.
 
 


### PR DESCRIPTION
When handling 301 redirects from http -> https on Erlang 21.0.1, the
following error is encountered:

```
8> Options = [].
9> httpc:request(head, {"http://rhye.org", []}, Options, []).
{error,{shutdown,{{error,{badmatch,443}},
                  [{httpc_response,resolve_uri,7,
                                   [{file,"/usr/local/lib/erlang/lib/inets-7.0/src/http_client/httpc_response.erl"},
                                    {line,431}]},
                   {httpc_response,redirect,2,
                                   [{file,"/usr/local/lib/erlang/lib/inets-7.0/src/http_client/httpc_response.erl"},
                                    {line,396}]},
                   {httpc_handler,handle_response,1,
                                  [{file,"httpc_handler.erl"},{line,1052}]},
                   {httpc_handler,handle_info,2,
                                  [{file,"httpc_handler.erl"},{line,283}]},
                   {gen_server,try_dispatch,4,
                               [{file,"gen_server.erl"},{line,637}]},
                   {gen_server,handle_msg,6,
                               [{file,"gen_server.erl"},{line,711}]},
                   {proc_lib,init_p_do_apply,3,
                             [{file,"proc_lib.erl"},{line,249}]}]}}}
```

This seems to be caused by the following code in `resolve_uri`:
```erlang
resolve_uri(Scheme, Host, Port, Path, Query, URI, Map0) ->
    case maps:is_key(scheme, URI) of
        true ->
            Port = get_port(URI)
```

The value of `Port` passed in to `resolve_uri` here is 80, since the
original URL is http. However, since the redirected URL is https, the
`get_port` call returns 443, which is not equal to 80, and crashes.

Assigning to a new variable seems to fix redirects.