### PR TITLE
Update documentation for ct:timetrap/1

### DIFF
--- a/lib/common_test/doc/src/ct.xml
+++ b/lib/common_test/doc/src/ct.xml
@@ -1522,7 +1522,7 @@
         <v>Hours = integer()</v>
         <v>Mins = integer()</v>
         <v>Secs = integer()</v>
-        <v>Millisecs = integer() | float()</v>
+        <v>Millisecs = integer()</v>
         <v>Func = {M, F, A} | function()</v>
         <v>M = atom()</v>
         <v>F = atom()</v>


### PR DESCRIPTION
Even when `ct:sleep/1` accepts `Millisecs` as floats, `ct:timetrap/1` does not.
If you try to use it in a test, you get an error similar to the following one:
```erlang
{invalid_time_format,0.1}
```