### PR TITLE
Fix net_kernel:connect_node/1 to local node

### DIFF
--- a/lib/kernel/doc/src/net_kernel.xml
+++ b/lib/kernel/doc/src/net_kernel.xml
@@ -102,8 +102,10 @@ $ <input>erl -sname foobar</input></pre>
       <fsummary>Establish a connection to a node.</fsummary>
       <desc>
         <p>Establishes a connection to <c><anno>Node</anno></c>. Returns
-          <c>true</c> if successful, <c>false</c> if not, and <c>ignored</c>
-          if the local node is not alive.</p>
+          <c>true</c> if a connection was established or was already
+	  established or if <c><anno>Node</anno></c> is the local node
+	  itself. Returns <c>false</c> if the connection attempt failed, and
+	  <c>ignored</c> if the local node is not alive.</p>
       </desc>
     </func>
 

--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -472,7 +472,7 @@ handle_call({passive_cnct, Node}, From, State) ->
 %% Explicit connect
 %% The response is delayed until the connection is up and running.
 %%
-handle_call({connect, _, Node, _, _}, From, State) when Node =:= node() ->
+handle_call({connect, _, Node}, From, State) when Node =:= node() ->
     async_reply({reply, true, State}, From);
 handle_call({connect, Type, Node}, From, State) ->
     verbose({connect, Type, Node}, 1, State),

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -25,6 +25,7 @@
 	 init_per_group/2,end_per_group/2]).
 
 -export([tick/1, tick_change/1,
+         connect_node/1,
          nodenames/1, hostnames/1,
          illegal_nodenames/1, hidden_node/1,
 	 setopts/1,
@@ -70,6 +71,7 @@ suite() ->
 
 all() -> 
     [tick, tick_change, nodenames, hostnames, illegal_nodenames,
+     connect_node,
      hidden_node, setopts,
      table_waste, net_setuptime, inet_dist_options_options,
      {group, monitor_nodes}].
@@ -104,6 +106,12 @@ init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
     Config.
 
 end_per_testcase(_Func, _Config) ->
+    ok.
+
+connect_node(Config) when is_list(Config) ->
+    Connected = nodes(connected),
+    true = net_kernel:connect_node(node()),
+    Connected = nodes(connected),
     ok.
 
 tick(Config) when is_list(Config) ->


### PR DESCRIPTION
to be no-op and return true
as it always has before OTP-21.0.

https://bugs.erlang.org/browse/ERL-643
