### PR TITLE
Fix kernel_app doc logger_level defaults

### DIFF
--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -192,7 +192,7 @@
 	<p>To change the primary log level at runtime, use
           <seealso marker="logger#set_primary_config/2">
             <c>logger:set_primary_config(level, Level)</c></seealso>.</p>
-	<p>Defaults to <c>info</c>.</p>
+	<p>Defaults to <c>notice</c>.</p>
       </item>
       <tag><marker id="logger_sasl_compatible"/>
 	<c>logger_sasl_compatible = true | false</c></tag>


### PR DESCRIPTION
The doc says the default kernel logger_level is [info](https://github.com/erlang/otp/blob/OTP-21.0.3/lib/kernel/doc/src/kernel_app.xml#L195), it should be [notice](https://github.com/erlang/otp/blob/OTP-21.0.3/lib/kernel/src/kernel.app.src#L143).
```
% erl
Erlang/OTP 21 [erts-10.0.3] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [dtrace]

Eshell V10.0.3  (abort with ^G)
1> application:get_env(kernel,logger_level).
{ok,notice}
```

Also the doc says the logger_level can include [all|none](https://github.com/erlang/otp/blob/OTP-21.0.3/lib/kernel/doc/src/kernel_app.xml#L191), however it crashes the beam now.
```
%  erl -kernel logger_level all
2018-07-15 09:40:22.934138 Invalid logger config: ~p
	{logger_level,all}
2018-07-15 09:40:22.934813 std_info            #{label=>{application_controller,exit},report=>[{application,kernel},{exited,{bad_return,{{kernel,start,[normal,[]]},{'EXIT',{{badmatch,{error,{bad_config,{kernel,{logger_level,all}}}}},[{kernel,start,2,[{file,"kernel.erl"},{line,34}]},{application_master,start_it_old,4,[{file,"application_master.erl"},{line,277}]}]}}}}},{type,permanent}]}
{"Kernel pid terminated",application_controller,"{application_start_failure,kernel,{bad_return,{{kernel,start,[normal,[]]},{'EXIT',{{badmatch,{error,{bad_config,{kernel,{logger_level,all}}}}},[{kernel,start,2,[{file,\"kernel.erl\"},{line,34}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,277}]}]}}}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,kernel,{bad_return,{{kernel,start,[normal,[]]},{'EXIT',{{badmatch,{error,{bad_config,{kernel,{logger_level,all}}}}},[{kernel,

Crash dump is being written to: erl_crash.dump...done
```

Saw it's been fixed in [here](https://github.com/erlang/otp/commit/48824be3d833b13a35b92652df372c6ce3c190a0), so after the merge the doc should be good.