### PR TITLE
Fix a crash when compiling variable-sized binary comprehensions

### DIFF
--- a/lib/compiler/test/bs_bincomp_SUITE.erl
+++ b/lib/compiler/test/bs_bincomp_SUITE.erl
@@ -26,7 +26,7 @@
 	 init_per_group/2,end_per_group/2,
 	 byte_aligned/1,bit_aligned/1,extended_byte_aligned/1,
 	 extended_bit_aligned/1,mixed/1,filters/1,trim_coverage/1,
-	 nomatch/1,sizes/1,general_expressions/1]).
+	 nomatch/1,sizes/1,general_expressions/1,matched_out_size/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -35,7 +35,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 all() -> 
     [byte_aligned, bit_aligned, extended_byte_aligned,
      extended_bit_aligned, mixed, filters, trim_coverage,
-     nomatch, sizes, general_expressions].
+     nomatch, sizes, general_expressions, matched_out_size].
 
 groups() -> 
     [].
@@ -337,6 +337,13 @@ general_expressions(_) ->
     ok.
 
 -undef(BAD).
+
+matched_out_size(Config) when is_list(Config) ->
+    <<1, 2>> = matched_out_size_1(<<4, 1:4, 4, 2:4>>),
+    ok.
+
+matched_out_size_1(Binary) ->
+    << <<X>> || <<S, X:S>> <= Binary>>.
 
 cs_init() ->
     erts_debug:set_internal_state(available_internal_state, true),


### PR DESCRIPTION
Code like the following would crash the compiler, as it generated illegal code to determine the size of the produced binary.

```erlang
test(Binary) ->
    << <<X>> || <<S, X:S>> <= Binary >>.
```

https://bugs.erlang.org/browse/ERL-665