### PR TITLE
erts: Fix bug where break would not trigger on windows

### DIFF
--- a/erts/emulator/sys/win32/erl_poll.c
+++ b/erts/emulator/sys/win32/erl_poll.c
@@ -362,11 +362,11 @@ is_io_ready(ErtsPollSet *ps)
 }
 
 static ERTS_INLINE void
-woke_up(ErtsPollSet *ps)
+woke_up(ErtsPollSet *ps, int waketype)
 {
     if (erts_atomic32_read_nob(&ps->wakeup_state) == ERTS_POLL_NOT_WOKEN)
 	erts_atomic32_cmpxchg_nob(&ps->wakeup_state,
-				  ERTS_POLL_WOKEN_TIMEDOUT,
+				  waketype,
 				  ERTS_POLL_NOT_WOKEN);
 #ifdef DEBUG
     {
@@ -960,12 +960,12 @@ static int cancel_driver_select(ErtsPollSet *ps, HANDLE event)
 
 void  erts_poll_interrupt(ErtsPollSet *ps, int set /* bool */)
 {
-    HARDTRACEF(("In erts_poll_interrupt(%d)",set));
+    HARDTRACEF(("In erts_poll_interrupt(%p, %d)",ps,set));
     if (!set)
 	reset_interrupt(ps);
     else
 	set_interrupt(ps);
-    HARDTRACEF(("Out erts_poll_interrupt(%d)",set));
+    HARDTRACEF(("Out erts_poll_interrupt(%p, %d)",ps,set));
 }
 
 
@@ -1051,19 +1051,20 @@ int erts_poll_wait(ErtsPollSet *ps,
 
     if (!erts_atomic32_read_nob(&break_waiter_state)) {
 	HANDLE harr[2] = {ps->event_io_ready, break_happened_event};
-	int num_h = 2;
+	int num_h = 2, handle;
         ERTS_MSACC_PUSH_STATE();
 
 	HARDDEBUGF(("Start waiting %d [%d]",num_h, (int) timeout));
 	ERTS_POLLSET_UNLOCK(ps);
 	erts_thr_progress_prepare_wait(NULL);
         ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_SLEEP);
-	WaitForMultipleObjects(num_h, harr, FALSE, timeout);
+	handle = WaitForMultipleObjects(num_h, harr, FALSE, timeout);
 	erts_thr_progress_finalize_wait(NULL);
         ERTS_MSACC_POP_STATE();
 	ERTS_POLLSET_LOCK(ps);
 	HARDDEBUGF(("Stop waiting %d [%d]",num_h, (int) timeout));
-	woke_up(ps);
+        if (handle == WAIT_OBJECT_0)
+            woke_up(ps, ERTS_POLL_WOKEN_TIMEDOUT);
     }
 
     ERTS_UNSET_BREAK_REQUESTED;
@@ -1075,7 +1076,10 @@ int erts_poll_wait(ErtsPollSet *ps,
 	erts_mtx_unlock(&break_waiter_lock);
 	switch (break_state) {
 	case  BREAK_WAITER_GOT_BREAK:
+            woke_up(ps, ERTS_POLL_WOKEN_INTR);
 	    ERTS_SET_BREAK_REQUESTED;
+            /* Wake aux thread to get handle break */
+            erts_aux_thread_poke();
 	    break;
 	case  BREAK_WAITER_GOT_HALT:
 	    erts_exit(0,"");


### PR DESCRIPTION
This bug was introduced in 988f5f5e8061ce2. The aux_thread needs to be poked as it is the thread that handles all break actions.

Reported in http://erlang.org/pipermail/erlang-questions/2018-July/095902.html and https://bugs.erlang.org/browse/ERL-672