### PR TITLE
maps:new/0 is no longer a BIF

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -629,7 +629,6 @@ bif maps:from_list/1
 bif maps:is_key/2
 bif maps:keys/1
 bif maps:merge/2
-bif maps:new/0
 bif maps:put/3
 bif maps:remove/2
 bif maps:update/3

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -1505,25 +1505,6 @@ int hashmap_key_hash_cmp(Eterm* ap, Eterm* bp)
     return ap ? -1 : 1;
 }
 
-/* maps:new/0 */
-
-BIF_RETTYPE maps_new_0(BIF_ALIST_0) {
-    Eterm* hp;
-    Eterm tup;
-    flatmap_t *mp;
-
-    hp    = HAlloc(BIF_P, (MAP_HEADER_FLATMAP_SZ + 1));
-    tup   = make_tuple(hp);
-    *hp++ = make_arityval(0);
-
-    mp    = (flatmap_t*)hp;
-    mp->thing_word = MAP_HEADER_FLATMAP;
-    mp->size = 0;
-    mp->keys = tup;
-
-    BIF_RET(make_flatmap(mp));
-}
-
 /* maps:put/3 */
 
 BIF_RETTYPE maps_put_3(BIF_ALIST_3) {

--- a/lib/stdlib/src/maps.erl
+++ b/lib/stdlib/src/maps.erl
@@ -21,7 +21,7 @@
 -module(maps).
 
 -export([get/3, filter/2,fold/3,
-         map/2, size/1,
+         map/2, size/1, new/0,
          update_with/3, update_with/4,
          without/2, with/2,
          iterator/1, next/1]).
@@ -29,7 +29,7 @@
 %% BIFs
 -export([get/2, find/2, from_list/1,
          is_key/2, keys/1, merge/2,
-         new/0, put/3, remove/2, take/2,
+         put/3, remove/2, take/2,
          to_list/1, update/3, values/1]).
 
 -opaque iterator() :: {term(), term(), iterator()}
@@ -91,13 +91,6 @@ keys(_) -> erlang:nif_error(undef).
 merge(_,_) -> erlang:nif_error(undef).
 
 
-
--spec new() -> Map when
-    Map :: map().
-
-new() -> erlang:nif_error(undef).
-
-
 %% Shadowed by erl_bif_types: maps:put/3
 -spec put(Key,Value,Map1) -> Map2 when
     Key :: term(),
@@ -156,6 +149,11 @@ update(_,_,_) -> erlang:nif_error(undef).
 values(_) -> erlang:nif_error(undef).
 
 %% End of BIFs
+
+-spec new() -> Map when
+    Map :: #{}.
+
+new() -> #{}.
 
 -spec update_with(Key,Fun,Map1) -> Map2 when
       Key :: term(),


### PR DESCRIPTION
Implementing it in Erlang allows taking advantage of the literal pool
optimisation, this means the function implemented in Erlang does no
allocations, while the BIF had to allocate new map each time it was
called. Benchmarks show the function is also slightly faster now.