### PR TITLE
Add guards for compute_key/4 (ecdh)

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -590,7 +590,12 @@ compute_key(srp, UserPublic, {HostPublic, HostPrivate},
     srp_host_secret_nif(Verifier, ensure_int_as_bin(HostPrivate), Scrambler,
                           UserPubBin, Prime));
 
-compute_key(ecdh, Others, My, Curve) ->
+compute_key(ecdh, Others, My, Curve) when (is_binary(Others)
+                                            orelse is_map(Others)
+                                            orelse is_tuple(Others))
+                                            andalso (is_binary(My)
+                                            orelse is_map(My)
+                                            orelse is_tuple(My)) ->
     ecdh_compute_key_nif(ensure_int_as_bin(Others),
 			 nif_curve_params(Curve),
 			 ensure_int_as_bin(My)).


### PR DESCRIPTION
This PR adds guards on compute_key/4 (ecdh) as a preventative measure in regards to ERL-673.