### PR TITLE
fix return type of mnesia:change_config

### DIFF
--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -278,7 +278,7 @@ stop() ->
 	Other -> Other
     end.
 
--spec change_config(Config::atom(), Value::_) -> ok | {error, term()}.
+-spec change_config(Config::atom(), Value::_) -> {ok, _} | {error, term()}.
 change_config(extra_db_nodes, Ns) when is_list(Ns) ->
     mnesia_controller:connect_nodes(Ns);
 change_config(dc_dump_limit, N) when is_number(N), N > 0 ->

--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -168,6 +168,9 @@
 -type snmp_struct() :: [{atom(), snmp_type() | tuple_of(snmp_type())}].
 -type snmp_type() :: 'fix_string' | 'string' | 'integer'.
 -type tuple_of(_T) :: tuple().
+-type config_key() :: extra_db_nodes | dc_dump_limit.
+-type config_value() :: [node()] | number().
+-type config_result() :: {ok, config_value()} | {error, term()}.
 
 -define(DEFAULT_ACCESS, ?MODULE).
 
@@ -278,7 +281,8 @@ stop() ->
 	Other -> Other
     end.
 
--spec change_config(Config::atom(), Value::_) -> {ok, _} | {error, term()}.
+-spec change_config(Config::config_key(), Value::config_value()) ->
+	  config_result().
 change_config(extra_db_nodes, Ns) when is_list(Ns) ->
     mnesia_controller:connect_nodes(Ns);
 change_config(dc_dump_limit, N) when is_number(N), N > 0 ->


### PR DESCRIPTION
I have this code: 
`{ok, _} = mnesia:change_config(extra_db_nodes, [Node])`

The dialyzer in OTP 21 started giving the next error:
`The pattern {'ok', _} can never match the type {'error',_}`

Based on the code it seems dialyzer is right and typespec is wrong