### PR TITLE
 Init EC_POINT *my_point and EC_GROUP *group to NULL (resolves ERL-673)

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -3755,9 +3755,9 @@ static ERL_NIF_TERM ecdh_compute_key_nif(ErlNifEnv* env, int argc, const ERL_NIF
     EC_KEY* key = NULL;
     int field_size = 0;
     int i;
-    EC_GROUP *group;
+    EC_GROUP *group = NULL;
     const BIGNUM *priv_key;
-    EC_POINT *my_ecpoint;
+    EC_POINT *my_ecpoint = NULL;
     EC_KEY *other_ecdh = NULL;
 
     if (!get_ec_key(env, argv[1], argv[2], atom_undefined, &key))
@@ -3767,7 +3767,7 @@ static ERL_NIF_TERM ecdh_compute_key_nif(ErlNifEnv* env, int argc, const ERL_NIF
     priv_key = EC_KEY_get0_private_key(key);
 
     if (!term2point(env, argv[0], group, &my_ecpoint)) {
-	goto out_err;
+	    goto out_err;
     }
 
     if ((other_ecdh = EC_KEY_new()) == NULL


### PR DESCRIPTION
The segv in ERL-673 happens due to a dangling pointer created in term2point. Solution is to set the EC_POINT *my_point to NULL. For good measure we do the same for EC_GROUP *group. This change most likely needs to be applied across the board, for good measure. 