### PR TITLE
High performance atomic mutable counters

### DIFF
--- a/bootstrap/lib/stdlib/ebin/stdlib.app
+++ b/bootstrap/lib/stdlib/ebin/stdlib.app
@@ -27,6 +27,7 @@
 	     binary,
 	     c,
 	     calendar,
+             counters,
 	     dets,
              dets_server,
 	     dets_sup,

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -874,6 +874,7 @@ RUN_OBJS += \
 	$(OBJDIR)/erl_thr_queue.o	$(OBJDIR)/erl_sched_spec_pre_alloc.o \
 	$(OBJDIR)/erl_ptab.o		$(OBJDIR)/erl_map.o \
 	$(OBJDIR)/erl_msacc.o		$(OBJDIR)/erl_lock_flags.o \
+	$(OBJDIR)/erl_counters.o \
 	$(OBJDIR)/erl_io_queue.o
 
 LTTNG_OBJS = $(OBJDIR)/erlang_lttng.o

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -698,3 +698,12 @@ ubif erlang:map_get/2
 ubif erlang:is_map_key/2
 bif ets:internal_delete_all/2
 bif ets:internal_select_delete/2
+
+bif counters:new/2
+bif counters:get/2
+bif counters:put/3
+bif counters:add/3
+bif counters:add_get/3
+bif counters:size/1
+bif counters:max/1
+bif counters:min/1

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -334,6 +334,7 @@ type	GC_INFO_REQ	SHORT_LIVED	SYSTEM		gc_info_request
 type	PORT_DATA_HEAP	STANDARD	SYSTEM		port_data_heap
 type    MSACC           DRIVER          SYSTEM          microstate_accounting
 type	SYS_CHECK_REQ	SHORT_LIVED	SYSTEM		system_check_request
+type	COUNTERS	STANDARD	SYSTEM		counters
 
 #
 # Types used by system specific code

--- a/erts/emulator/beam/erl_counters.c
+++ b/erts/emulator/beam/erl_counters.c
@@ -1,0 +1,190 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2018. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+/*
+ * Purpose:  High performance counters.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <stddef.h> /* offsetof */
+
+#include "sys.h"
+#include "export.h"
+#include "bif.h"
+#include "erl_threads.h"
+#include "big.h"
+#include "erl_binary.h"
+#include "erl_bif_unique.h"
+
+typedef struct
+{
+    UWord vlen;
+    erts_atomic_t v[1];
+}CountersRef;
+
+static int counters_destructor(Binary *unused)
+{
+    return 1;
+}
+
+BIF_RETTYPE counters_new_2(BIF_ALIST_2)
+{
+    CountersRef* p;
+    Binary* mbin;
+    UWord i, cnt;
+    Uint bytes;
+    Eterm* hp;
+
+    if (!term_to_UWord(BIF_ARG_1, &cnt)
+        || cnt == 0
+        || BIF_ARG_2 != NIL) {
+
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    if (cnt > (ERTS_UWORD_MAX / sizeof(p->v[0])))
+        BIF_ERROR(BIF_P, SYSTEM_LIMIT);
+
+    bytes = offsetof(CountersRef, v) + cnt*sizeof(p->v[0]),
+    mbin = erts_create_magic_binary_x(bytes,
+                                      counters_destructor,
+                                      ERTS_ALC_T_COUNTERS,
+                                      1);
+    p = ERTS_MAGIC_BIN_UNALIGNED_DATA(mbin);
+    p->vlen = cnt;
+    for (i=0; i < cnt; i++) {
+        erts_atomic_init_nob(&p->v[i], 0);
+    }
+    hp = HAlloc(BIF_P, ERTS_MAGIC_REF_THING_SIZE);
+    return erts_mk_magic_ref(&hp, &MSO(BIF_P), mbin);
+}
+
+static ERTS_INLINE int get_ref(Eterm ref, CountersRef** pp)
+{
+    Binary* mbin;
+    if (!is_internal_magic_ref(ref))
+        return 0;
+
+    mbin = erts_magic_ref2bin(ref);
+    if (ERTS_MAGIC_BIN_DESTRUCTOR(mbin) != counters_destructor)
+        return 0;
+    *pp = ERTS_MAGIC_BIN_UNALIGNED_DATA(mbin);
+    return 1;
+}
+
+static ERTS_INLINE int get_ref_ix(Eterm ref, Eterm ix,
+                                  CountersRef** pp, UWord* ixp)
+{
+    return (get_ref(ref, pp)
+            && term_to_UWord(ix, ixp)
+            && *ixp < (*pp)->vlen);
+}
+
+static ERTS_INLINE Eterm bld_counter(Process* p, SWord val)
+{
+    if (IS_SSMALL(val))
+        return make_small((Sint) val);
+    else {
+        Eterm* hp = HAlloc(p, BIG_UWORD_HEAP_SIZE(si64));
+        return small_to_big(val, hp);
+    }
+}
+
+BIF_RETTYPE counters_put_3(BIF_ALIST_3)
+{
+    CountersRef* p;
+    UWord ix;
+    SWord val;
+
+    if (!get_ref_ix(BIF_ARG_1, BIF_ARG_2, &p, &ix)
+        || !term_to_Sint(BIF_ARG_3, &val)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+    erts_atomic_set_mb(&p->v[ix], val);
+    return am_ok;
+}
+
+BIF_RETTYPE counters_get_2(BIF_ALIST_2)
+{
+    CountersRef* p;
+    UWord ix;
+
+    if (!get_ref_ix(BIF_ARG_1, BIF_ARG_2, &p, &ix)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+    return bld_counter(BIF_P, erts_atomic_read_mb(&p->v[ix]));
+}
+
+BIF_RETTYPE counters_add_3(BIF_ALIST_3)
+{
+    CountersRef* p;
+    UWord ix;
+    SWord incr;
+
+    if (!get_ref_ix(BIF_ARG_1, BIF_ARG_2, &p, &ix)
+        || !term_to_Sint(BIF_ARG_3, &incr)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+    erts_atomic_add_mb(&p->v[ix], incr);
+    return am_ok;
+}
+
+BIF_RETTYPE counters_add_get_3(BIF_ALIST_3)
+{
+    CountersRef* p;
+    UWord ix;
+    SWord incr;
+
+    if (!get_ref_ix(BIF_ARG_1, BIF_ARG_2, &p, &ix)
+        || !term_to_Sint(BIF_ARG_3, &incr)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+    return bld_counter(BIF_P, erts_atomic_add_read_mb(&p->v[ix], incr));
+}
+
+BIF_RETTYPE counters_size_1(BIF_ALIST_1)
+{
+    CountersRef* p;
+
+    if (!get_ref(BIF_ARG_1, &p))
+        BIF_ERROR(BIF_P, BADARG);
+    return bld_counter(BIF_P, p->vlen);
+}
+
+BIF_RETTYPE counters_max_1(BIF_ALIST_1)
+{
+    CountersRef* p;
+
+    if (!get_ref(BIF_ARG_1, &p))
+        BIF_ERROR(BIF_P, BADARG);
+    return bld_counter(BIF_P, ERTS_SWORD_MAX);
+}
+
+BIF_RETTYPE counters_min_1(BIF_ALIST_1)
+{
+    CountersRef* p;
+
+    if (!get_ref(BIF_ARG_1, &p))
+        BIF_ERROR(BIF_P, BADARG);
+    return bld_counter(BIF_P, ERTS_SWORD_MIN);
+}

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -325,6 +325,7 @@ typedef long          Sint  erts_align_attribute(sizeof(long));
 #define UWORD_CONSTANT(Const) Const##UL
 #define ERTS_UWORD_MAX ULONG_MAX
 #define ERTS_SWORD_MAX LONG_MAX
+#define ERTS_SWORD_MIN LONG_MIN
 #define ERTS_SIZEOF_ETERM SIZEOF_LONG
 #define ErtsStrToSint strtol
 #elif SIZEOF_VOID_P == SIZEOF_INT
@@ -335,6 +336,7 @@ typedef int          Sint  erts_align_attribute(sizeof(int));
 #define UWORD_CONSTANT(Const) Const##U
 #define ERTS_UWORD_MAX UINT_MAX
 #define ERTS_SWORD_MAX INT_MAX
+#define ERTS_SWORD_MIN INT_MIN
 #define ERTS_SIZEOF_ETERM SIZEOF_INT
 #define ErtsStrToSint strtol
 #elif SIZEOF_VOID_P == SIZEOF_LONG_LONG
@@ -345,6 +347,7 @@ typedef long long          Sint  erts_align_attribute(sizeof(long long));
 #define UWORD_CONSTANT(Const) Const##ULL
 #define ERTS_UWORD_MAX ULLONG_MAX
 #define ERTS_SWORD_MAX LLONG_MAX
+#define ERTS_SWORD_MIN LLONG_MIN
 #define ERTS_SIZEOF_ETERM SIZEOF_LONG_LONG
 #if defined(__WIN32__)
 #define ErtsStrToSint _strtoi64

--- a/lib/stdlib/doc/src/Makefile
+++ b/lib/stdlib/doc/src/Makefile
@@ -44,6 +44,7 @@ XML_REF3_FILES = \
 	binary.xml \
 	c.xml \
 	calendar.xml \
+	counters.xml \
 	dets.xml \
 	dict.xml \
 	digraph.xml \

--- a/lib/stdlib/doc/src/counters.xml
+++ b/lib/stdlib/doc/src/counters.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE erlref SYSTEM "erlref.dtd">
+
+<erlref>
+  <header>
+    <copyright>
+      <year>2018</year>
+      <holder>Ericsson AB. All Rights Reserved.</holder>
+    </copyright>
+    <legalnotice>
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+    </legalnotice>
+
+    <title>counters</title>
+  </header>
+  <module>counters</module>
+  <modulesummary>Counters Functions</modulesummary>
+  <description>
+    <p>This module provides a set of functions to do atomic operations towards
+    mutable word sized counter variables. The implementation utilizes only
+    atomic hardware instructions without any software level locking, which makes
+    it very efficient for concurrent access. The counters are organized into
+    arrays with the follwing semantics:</p>
+    <list type="bulleted">
+      <item>
+	<p>Counters are signed word sized. That is 32-bit (-2147483648 to
+	+2147483647) or 64-bit (-9223372036854775808 to
+	+9223372036854775807) depending on cpu hardware architecture.</p>
+      </item>
+      <item>
+	<p>Counters wrap around at overflow and underflow operations.</p>
+      </item>
+      <item>
+	<p>All counter operations are atomic. No intermediate results can be
+	seen. Concurrent mutable operations to the same counter are
+	serialized. The result of one mutation can only be the input to one
+	following mutation.</p>
+      </item>
+      <item>
+	<p>All counter operations are ordered (using hardware memory
+	barriers). If counter B is updated <em>after</em> counter A, then that
+	is how it will appear to any concurrent readers. No one can read the new
+	value of B and then read the old value of A.</p>
+      </item>
+      <item>
+	<p>Indexes into counter arrays are zero-based. A counter array of
+	arity N contains N counters with index from 0 to N-1.</p>
+      </item>
+    </list>
+  </description>
+
+  <datatypes>
+    <datatype>
+      <name name="counters_ref"/>
+      <desc><p>Identifies a counter array returned from
+        <seealso marker="#new/2"><c>new/2</c></seealso>.</p>
+      </desc>
+    </datatype>
+  </datatypes>
+
+  <funcs>
+    <func>
+      <name name="new" arity="2"/>
+      <fsummary>Create counter array</fsummary>
+      <desc>
+        <p>Create a new counter array of <c><anno>Arity</anno></c> counters.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="put" arity="3"/>
+      <fsummary>Set counter value</fsummary>
+      <desc>
+        <p>Set counter to <c><anno>Value</anno></c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="get" arity="2"/>
+      <fsummary>Read counter value</fsummary>
+      <desc>
+        <p>Read counter value.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="add" arity="3"/>
+      <fsummary>Add to counter</fsummary>
+      <desc>
+        <p>Add <c><anno>Incr</anno></c> to counter.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="add_get" arity="3"/>
+      <fsummary>Atomic add and get</fsummary>
+      <desc>
+        <p>Atomic addition and return of the result.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="sub" arity="3"/>
+      <fsummary>Subtract from counter</fsummary>
+      <desc>
+        <p>Subtract <c><anno>Decr</anno></c> from counter.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="sub_get" arity="3"/>
+      <fsummary>Atomic sub and get</fsummary>
+      <desc>
+        <p>Atomic subtraction and return of the result.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="size" arity="1"/>
+      <fsummary>The size of counter array</fsummary>
+      <desc>
+        <p>Returns the number of counters in a counter array.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="max" arity="1"/>
+      <fsummary>The highest counter value</fsummary>
+      <desc>
+        <p>Returns the highest value a counter in this array can hold.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="min" arity="1"/>
+      <fsummary>The lowest counter value</fsummary>
+      <desc>
+	<p>Returns the lowest value a counter in this array can hold.</p>
+      </desc>
+    </func>
+
+ </funcs>
+</erlref>

--- a/lib/stdlib/doc/src/ref_man.xml
+++ b/lib/stdlib/doc/src/ref_man.xml
@@ -39,6 +39,7 @@
   <xi:include href="binary.xml"/>
   <xi:include href="c.xml"/>
   <xi:include href="calendar.xml"/>
+  <xi:include href="counters.xml"/>
   <xi:include href="dets.xml"/>
   <xi:include href="dict.xml"/>
   <xi:include href="digraph.xml"/>

--- a/lib/stdlib/doc/src/specs.xml
+++ b/lib/stdlib/doc/src/specs.xml
@@ -6,6 +6,7 @@
   <xi:include href="../specs/specs_binary.xml"/>
   <xi:include href="../specs/specs_c.xml"/>
   <xi:include href="../specs/specs_calendar.xml"/>
+  <xi:include href="../specs/specs_counters.xml"/>
   <xi:include href="../specs/specs_dets.xml"/>
   <xi:include href="../specs/specs_dict.xml"/>
   <xi:include href="../specs/specs_digraph.xml"/>

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -47,6 +47,7 @@ MODULES= \
 	binary \
 	c \
 	calendar \
+	counters \
 	dets \
 	dets_server \
 	dets_sup \

--- a/lib/stdlib/src/counters.erl
+++ b/lib/stdlib/src/counters.erl
@@ -1,0 +1,93 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2018. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%% Purpose : Main counters API module.
+
+-module(counters).
+
+-export([new/2, add/3, add_get/3, sub/3, sub_get/3, put/3, get/2,
+         size/1, max/1, min/1]).
+
+-export_type([counters_ref/0]).
+
+-opaque counters_ref() :: reference().
+
+
+-spec new(Arity, Opts) -> counters_ref() when
+      Arity :: pos_integer(),
+      Opts :: [].
+new(_Arity, _Opts) ->
+    erlang:nif_error(undef).
+
+-spec put(Ref, Ix, Value) -> ok when
+      Ref  :: counters_ref(),
+      Ix :: integer(),
+      Value :: integer().
+put(_Ref, _Ix, _Value) ->
+    erlang:nif_error(undef).
+
+-spec get(Ref, Ix) -> integer() when
+      Ref  :: counters_ref(),
+      Ix :: integer().
+get(_Ref, _Ix) ->
+    erlang:nif_error(undef).
+
+-spec add(Ref, Ix, Incr) -> ok when
+      Ref  :: counters_ref(),
+      Ix :: integer(),
+      Incr :: integer().
+add(_Ref, _Ix, _Incr) ->
+    erlang:nif_error(undef).
+
+-spec add_get(Ref, Ix, Incr) -> integer() when
+      Ref  :: counters_ref(),
+      Ix :: integer(),
+      Incr :: integer().
+add_get(_Ref, _Ix, _Incr) ->
+    erlang:nif_error(undef).
+
+-spec sub(Ref, Ix, Decr) -> ok when
+      Ref  :: counters_ref(),
+      Ix :: integer(),
+      Decr :: integer().
+sub(Ref, Ix, Decr) ->
+    ?MODULE:add(Ref, Ix, -Decr).
+
+-spec sub_get(Ref, Ix, Decr) -> integer() when
+      Ref  :: counters_ref(),
+      Ix :: integer(),
+      Decr :: integer().
+sub_get(Ref, Ix, Decr) ->
+    ?MODULE:add_get(Ref, Ix, -Decr).
+
+-spec size(Ref) -> integer() when
+      Ref  :: counters_ref().
+size(_Ref) ->
+    erlang:nif_error(undef).
+
+-spec max(Ref) -> integer() when
+      Ref  :: counters_ref().
+max(_Ref) ->
+    erlang:nif_error(undef).
+
+-spec min(Ref) -> integer() when
+      Ref  :: counters_ref().
+min(_Ref) ->
+    erlang:nif_error(undef).

--- a/lib/stdlib/src/stdlib.app.src
+++ b/lib/stdlib/src/stdlib.app.src
@@ -27,6 +27,7 @@
 	     binary,
 	     c,
 	     calendar,
+             counters,
 	     dets,
              dets_server,
 	     dets_sup,

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -13,6 +13,7 @@ MODULES= \
 	binref \
 	c_SUITE \
 	calendar_SUITE \
+	counters_SUITE \
 	dets_SUITE \
 	dict_SUITE \
 	dict_test_lib \

--- a/lib/stdlib/test/counters_SUITE.erl
+++ b/lib/stdlib/test/counters_SUITE.erl
@@ -1,0 +1,71 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2018. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(counters_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile(export_all).
+
+suite() -> [{ct_hooks,[ts_install_cth]}].
+
+all() ->
+    [basic, bad, limits].
+
+basic(Config) when is_list(Config) ->
+    Ref = counters:new(10,[]),
+    0 = counters:get(Ref, 7),
+    ok = counters:put(Ref, 7, 3),
+    ok = counters:add(Ref, 7, 14),
+    17 = counters:get(Ref, 7),
+    20 = counters:add_get(Ref, 7, 3),
+    -3 = counters:add_get(Ref, 7, -23),
+    17 = counters:add_get(Ref, 7, 20),
+    ok = counters:sub(Ref, 7, 4),
+    13 = counters:get(Ref, 7),
+    -7 = counters:sub_get(Ref, 7, 20),
+    3 = counters:sub_get(Ref, 7, -10),
+    ok.
+
+bad(Config) when is_list(Config) ->
+    {'EXIT',{badarg,_}} = (catch counters:new(0,[])),
+    {'EXIT',{badarg,_}} = (catch counters:new(10,[bad])),
+    Ref = counters:new(10,[]),
+    {'EXIT',{badarg,_}} = (catch counters:get(1742, 7)),
+    {'EXIT',{badarg,_}} = (catch counters:get(make_ref(), 7)),
+    {'EXIT',{badarg,_}} = (catch counters:get(Ref, -1)),
+    {'EXIT',{badarg,_}} = (catch counters:get(Ref, 10)),
+    {'EXIT',{badarg,_}} = (catch counters:get(Ref, 7.0)),
+    ok.
+
+
+limits(Config) when is_list(Config) ->
+    Ref = counters:new(1,[]),
+
+    Max = counters:max(Ref),
+    Min = counters:min(Ref),
+    0 = counters:get(Ref, 0),
+    Max = counters:add_get(Ref, 0, Max),
+    Min = counters:add_get(Ref, 0, 1),
+    Max = counters:sub_get(Ref, 0, 1),
+
+    {'EXIT',{badarg,_}} = (catch counters:add(Ref, 0, Max+1)),
+    {'EXIT',{badarg,_}} = (catch counters:add(Ref, 0, Min-1)),
+
+    ok.


### PR DESCRIPTION
Closed and replaced by #1961

This is a new module 'counters' that provides functions to do atomic operations towards **mutable word sized counter variables**. The implementation utilizes only atomic hardware instructions without any software level locking, which makes it very efficient for concurrent access. The counters are organized into arrays with the follwing semantics:

- Counters are signed word sized. That is 32-bit (-2147483648 to +2147483647) or 64-bit (-9223372036854775808 to +9223372036854775807) depending on cpu hardware architecture.
- Counters wrap around at overflow and underflow operations.
- All counter operations are atomic. No intermediate results can be seen. Concurrent mutable operations to the same counter are serialized. The result of one mutation can only be the input to one following mutation.
- All counter operations are ordered (using hardware memory barriers). If counter B is updated **after** counter A, then that is how it will appear to any concurrent readers. No one can read the new value of B and then read the old value of A.
- Indexes into counter arrays are zero-based. A counter array of arity N contains N counters with index from 0 to N-1.

Create counter array with
`counters:new(Arity, Opts) -> Ref.`

Atomic read/write operation on one counter:
`counters:put(Ref, Ix, Value) -> ok.`
`counters:get(Ref, Ix) -> Value.`
`counters:add(Ref, Ix, Incr) -> ok.`
`counters:add_get(Ref, Ix, Incr) -> Value.`
`counters:sub(Ref, Ix, Decr) -> ok.`
`counters:sub_get(Ref, Ix, Decr) -> Value.`

And some static info about a counter array:
`counters:size(Ref) -> Arity.`
`counters:max(Ref) -> MaxValue.`
`counters:min(Ref) -> MinValue.`
