### PR TITLE
Fix spec for erl_syntax_lib:analyze_type_application/1

### DIFF
--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -1981,7 +1981,7 @@ analyze_application(Node) ->
 %%
 %% @see analyze_type_name/1
 
--type typeName() :: atom() | {module(), atom(), arity()} | {atom(), arity()}.
+-type typeName() :: atom() | {module(), {atom(), arity()}} | {atom(), arity()}.
 
 -spec analyze_type_application(erl_syntax:syntaxTree()) -> typeName().
 


### PR DESCRIPTION
The spec for [`erl_syntax_lib:analyze_type_application/1`](https://github.com/erlang/otp/blob/OTP-21.0.3/lib/syntax_tools/src/erl_syntax_lib.erl#L1984-L1986) says it can return `{module(), atom(), arity()}` but in the documentation and in the actual code, the function and arity are wrapped in an inner tuple: `{module(), {atom(), arity()}}`.

I erroneously get this error...
```
The pattern {_Mod, {_Fn, _Arity}} can never match
  the type atom() | {atom(),byte()} | {atom(),atom(),byte()}
```
...when I run dialyzer on this file:
```erlang
-module(analyze_type_application).
-export([f/1]).
-include_lib("eunit/include/eunit.hrl").
f(SyntaxTree) ->
    case erl_syntax_lib:analyze_type_application(SyntaxTree) of
        {_Mod, {_Fn, _Arity}} -> remote;
        {_Fn, _Arity} -> local
    end.

f_test() ->
    remote = f(erl_syntax:type_application(
                 erl_syntax:atom(mod),
                 erl_syntax:atom(fn),
                 [])).
```
