### PR TITLE
Do not allocate a new tuple when the value is the same

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -2545,13 +2545,17 @@ BIF_RETTYPE setelement_3(BIF_ALIST_3)
 	goto error;
     }
 
-    hp = HAlloc(BIF_P, size);
+    if (ptr[ix] == BIF_ARG_3) {
+        BIF_RET(BIF_ARG_2);
+    } else {
+        hp = HAlloc(BIF_P, size);
 
-    /* copy the tuple */
-    resp = hp;
-    sys_memcpy(hp, ptr, sizeof(Eterm)*size);
-    resp[ix] = BIF_ARG_3;
-    BIF_RET(make_tuple(resp));
+        /* copy the tuple */
+        resp = hp;
+        sys_memcpy(hp, ptr, sizeof(Eterm)*size);
+        resp[ix] = BIF_ARG_3;
+        BIF_RET(make_tuple(resp));
+    }
 }
 
 /**********************************************************************/


### PR DESCRIPTION
**NOTE**: This patch is **wrong**. Do not merge, see the first comment.

This patch optimizes tuple operations to not allocate new tuple
when an element is being replaced by the exact same value in memory.

Imagine this very common idiom:

    Record#my_record{key = compute_new_value(Value, Condition)}

where:

    compute_new_x(X, true) -> X + 1;
    compute_new_x(X, false) -> X;

In many cases, we are not changing the value in `key`, however
the code prior to this patch would still allocate a new tuple.
This optimization changes this.

The cost of optimization is minimum, as it only adds a C array
access plus a pointer comparison. The major benefit is reducing
the GC pressure by avoiding allocating data.

We have only changed erlang:setelement/3. The benchmarks basically
create a tuple and perform the same operations, roughly 20000 times,
once replacing the key with the same value, and another with a
different value.

For a tuple with 4 elements, replacing the fourth element 20000 times
went from 557us to 388us.

For a tuple with 8 elements, replacing the fourth element 20000 times
went from 641us to 421us.
