### PR TITLE
zlib: avoid undefined behaviour

### DIFF
--- a/erts/emulator/zlib/inflate.c
+++ b/erts/emulator/zlib/inflate.c
@@ -1507,7 +1507,7 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
+    if (strm == Z_NULL || strm->state == Z_NULL) return -1UL << 16;
     state = (struct inflate_state FAR *)strm->state;
     return ((long)(state->back) << 16) +
         (state->mode == COPY ? state->length :


### PR DESCRIPTION
Building OTP-21.0.4 with Clang-6.0.1 causes the following warning:

```
zlib/inflate.c:1510:61: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
                                                        ~~~ ^
```
(gcc also complains with -Wextra, but not with just -Wall)

Undefined behaviour is bad as it changes how compilers interpret and translate the code, which can lead to things like boundary checks being removed.

Fix this instance by changing the literal to unsigned.