### PR TITLE
kernel: Added clean function for saved shell history when shell history is enabled

### DIFF
--- a/lib/kernel/src/group_history.erl
+++ b/lib/kernel/src/group_history.erl
@@ -18,7 +18,7 @@
 %% %CopyrightEnd%
 %%
 -module(group_history).
--export([load/0, add/1]).
+-export([load/0, add/1, clean/0]).
 
 %% Make a minimal size that should encompass set of lines and then make
 %% a file rotation for N files of this size.
@@ -95,6 +95,16 @@ add(Line, enabled) ->
     end;
 add(_Line, disabled) ->
     ok.
+
+%% @doc cleans the default erlang history log and once you close the
+%% session and restart the session, your saved histories will not persist
+-spec clean() -> ok | {error, _HistoryStatus}.
+clean() -> clean(history_status()).
+
+clean(enabled) ->
+    disk_log:truncate(?LOG_NAME);
+clean(disabled) ->
+    {error, history_not_enabled}.
 
 %%%%%%%%%%%%%%%
 %%% PRIVATE %%%


### PR DESCRIPTION
- Enabling Shell History using ERL_AFLAGS allowed users to persist their erlang shell history across
multiple sessions

- But, if the user wants to delete the previously saved shell histories, it's not possible

- Hence, added a new clean function, which allows the user to delete the saved history via `group_history.erl`