### PR TITLE
kernel: Added clean function for saved shell history when shell history is enabled

### DIFF
--- a/lib/kernel/src/group_history.erl
+++ b/lib/kernel/src/group_history.erl
@@ -18,7 +18,7 @@
 %% %CopyrightEnd%
 %%
 -module(group_history).
--export([load/0, add/1]).
+-export([load/0, add/1, clean/0]).
 
 %% Make a minimal size that should encompass set of lines and then make
 %% a file rotation for N files of this size.
@@ -95,6 +95,16 @@ add(Line, enabled) ->
     end;
 add(_Line, disabled) ->
     ok.
+
+%% @doc cleans the default erlang history log and once you close the
+%% session and restart the session, your saved histories will not persist
+-spec clean() -> ok | {error, _HistoryStatus}.
+clean() -> clean(history_status()).
+
+clean(enabled) ->
+    disk_log:truncate(?LOG_NAME);
+clean(disabled) ->
+    {error, history_not_enabled}.
 
 %%%%%%%%%%%%%%%
 %%% PRIVATE %%%

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -29,7 +29,7 @@
 	 i/3,pid/3,m/0,m/1,mm/0,lm/0,
 	 bt/1, q/0,
 	 erlangrc/0,erlangrc/1,bi/1, flush/0, regs/0, uptime/0,
-	 nregs/0,pwd/0,ls/0,ls/1,cd/1,memory/1,memory/0, xm/1]).
+	 nregs/0,pwd/0,ls/0,ls/1,cd/1,memory/1,memory/0, xm/1, clean_history/0]).
 
 -export([display_info/1]).
 -export([appcall/4]).
@@ -70,7 +70,8 @@ help() ->
 		   "nregs()    -- information about all registered processes\n"
 		   "uptime()   -- print node uptime\n"
 		   "xm(M)      -- cross reference check a module\n"
-		   "y(File)    -- generate a Yecc parser\n">>).
+		   "y(File)    -- generate a Yecc parser\n"
+           "clean_history()    -- clears the saved erl shell history\n">>).
 
 %% c(Module)
 %%  Compile a module/file.
@@ -1043,4 +1044,13 @@ appcall(App, M, F, Args) ->
 		Stk ->
 		    erlang:raise(error, undef, Stk)
 	    end
+    end.
+
+%% Cleans the erl shell history if Shell history is enabled
+clean_history() ->
+    case code:ensure_loaded(group_history) of
+        {module, group_history} ->
+            group_history:clean();
+        {error, nofile} ->
+            erlang:raise(error, undef, "Group history module not found!")
     end.

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -1052,5 +1052,5 @@ clean_history() ->
         {module, group_history} ->
             group_history:clean();
         {error, nofile} ->
-            erlang:raise(error, undef, "Group history module not found!")
+            erlang:error("Group history module not found! Please check your OTP version.")
     end.

--- a/lib/stdlib/src/shell_default.erl
+++ b/lib/stdlib/src/shell_default.erl
@@ -28,7 +28,7 @@
 	 erlangrc/1,bi/1, regs/0, flush/0,pwd/0,ls/0,ls/1,cd/1, 
          y/1, y/2,
 	 xm/1, bt/1, q/0,
-	 ni/0, nregs/0]).
+	 ni/0, nregs/0, clean_history/0]).
 
 -export([ih/0,iv/0,im/0,ii/1,ii/2,iq/1,ini/1,ini/2,inq/1,ib/2,ib/3,
 	 ir/2,ir/3,ibd/2,ibe/2,iba/3,ibc/3,
@@ -100,7 +100,7 @@ uptime()        -> c:uptime().
 xm(Mod)         -> c:xm(Mod).
 y(File)         -> c:y(File).
 y(File, Opts)   -> c:y(File, Opts).
-
+clean_history() -> c:clean_history().
 iaa(Flag)       -> calli(iaa, [Flag]).
 iaa(Flag,Fnk)   -> calli(iaa, [Flag,Fnk]).
 ist(Flag)       -> calli(ist, [Flag]).


### PR DESCRIPTION
- Enabling Shell History using ERL_AFLAGS allowed users to persist their erlang shell history across
multiple sessions

- But, if the user wants to delete the previously saved shell histories, it's not possible

- Hence, added a new clean function, which allows the user to delete the saved history via `group_history.erl`