### PR TITLE
erl_alloc: align ErtsAllocatorState_t

### DIFF
--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -114,7 +114,7 @@ typedef union {
     char align_afa[ERTS_ALC_CACHE_LINE_ALIGN_SIZE(sizeof(AFAllctr_t))];
     AOFFAllctr_t aoffa;
     char align_aoffa[ERTS_ALC_CACHE_LINE_ALIGN_SIZE(sizeof(AOFFAllctr_t))];
-} ErtsAllocatorState_t;
+} ErtsAllocatorState_t erts_align_attribute(ERTS_CACHE_LINE_SIZE);
 
 static ErtsAllocatorState_t std_alloc_state;
 static ErtsAllocatorState_t ll_alloc_state;


### PR DESCRIPTION
ErtsAllocatorState_t instances need to be at least 8-byte aligned, but the code doesn't ensure that.  GCC hides the issue by over-aligning global variables, but Clang does not do that, causing alignment errors in 32-bit builds.  Fixed by adding an alignment directive to the type definition.

Although the alignment check only requires 8-byte alignment, the type definition appears to want cache line alignment, so I used that.

See ERL-677 for background.