### PR TITLE
Introduce application environment providers

### DIFF
--- a/bootstrap/lib/kernel/ebin/kernel.app
+++ b/bootstrap/lib/kernel/ebin/kernel.app
@@ -25,6 +25,7 @@
   {vsn, "5.4.3"},
   {modules, [application,
 	     application_controller,
+             application_env_cli_provider,
 	     application_master,
 	     application_starter,
 	     auth,

--- a/lib/kernel/src/Makefile
+++ b/lib/kernel/src/Makefile
@@ -55,6 +55,7 @@ RELSYSDIR = $(RELEASE_PATH)/lib/kernel-$(KERNEL_VSN)
 MODULES = \
 	application \
 	application_controller \
+	application_env_cli_provider \
 	application_master \
 	application_starter \
 	auth \

--- a/lib/kernel/src/application_env_cli_provider.erl
+++ b/lib/kernel/src/application_env_cli_provider.erl
@@ -1,0 +1,41 @@
+-module(application_env_cli_provider).
+-include("logger.hrl").
+-export([load/2]).
+
+load(App, Env) ->
+    try
+        case init:get_argument(App) of
+            {ok, Args} ->
+               {ok, lists:foldl(fun conv/2, Env, Args)};
+            _ ->
+               {ok, []}
+        end
+    catch
+        throw:Error -> Error
+    end.
+
+conv([BareKey, BareVal | T], Acc) ->
+    Key = make_term(BareKey),
+    Val = make_term(BareVal),
+    conv(T, [{Key, Val} | lists:keydelete(Key, 1, Acc)]);
+conv(_, Acc) ->
+    Acc.
+
+make_term(Str) ->
+    case erl_scan:string(Str) of
+        {ok, Tokens, _} ->
+            case erl_parse:parse_term(Tokens ++ [{dot, erl_anno:new(1)}]) of
+                {ok, Term} ->
+                    Term;
+                {error, {_,M,Reason}} ->
+                    handle_make_term_error(M, Reason, Str)
+            end;
+        {error, {_,M,Reason}, _} ->
+            handle_make_term_error(M, Reason, Str)
+    end.
+
+handle_make_term_error(Mod, Reason, Str) ->
+    ?LOG_ERROR("application_controller: ~ts: ~ts~n",
+               [Mod:format_error(Reason), Str],
+               #{error_logger=>#{tag=>error}}),
+    throw({error, {bad_environment_value, Str}}).

--- a/lib/kernel/src/kernel.app.src
+++ b/lib/kernel/src/kernel.app.src
@@ -25,6 +25,7 @@
   {vsn, "%VSN%"},
   {modules, [application,
 	     application_controller,
+	     application_env_cli_provider,
 	     application_master,
 	     application_starter,
 	     auth,

--- a/lib/sasl/src/systools_make.erl
+++ b/lib/sasl/src/systools_make.erl
@@ -1529,6 +1529,7 @@ mandatory_modules() ->
      %% Keep this list sorted.
      application,
      application_controller,
+     application_env_cli_provider,
      application_master,
      code,
      code_server,


### PR DESCRIPTION
Hi everyone,

This is a proof of concept to introduce application environment providers to Erlang/OTP.

## The problem as we know it

Whenever an application is loaded, it loads the environment data from two places:

  * from config files, such as sys.config, which are parsed and stored inside the `application_controller`
  * from cli, such as `-app key value`, which are stored in `init`

Other systems may provide their own configuration too, such as [cuttlefish](https://github.com/basho/cuttlefish) and [Elixir's Mix configuration](https://hexdocs.pm/mix/Mix.Config.html). The way those solutions work is by writing directly against the application controller configuration storage by using the `application:set_env/4` with the `[{persistent, true}]` flag.

This approach has certain issues.

First of all, it means all configuration data has to be loaded upfront and copied into the application storage. This typically requires us to invoke the `application_controller` process for each key in each application, which is not efficient.

The second issue is that the `application:set_env/4` API that exists today changes both the application environment AND the configuration storage. Consider this following Erlang session where the config file contains the entry `[{foo, [{bar, baz}]}]`:

```erlang
$ erl -config foo.config
erl> application:get_all_env(foo).
[]
```

Since the `foo` application is not loaded and no environment key was set, it correctly returns `[]`. Now imagine we have the same config file translated to Elixir:

```elixir
$ iex --config foo.exs
iex> :application.get_all_env(:foo)
[{:bar, :baz}]
```

Unfortunately we no longer get an empty list because the only way Elixir can load configuration into the system is by using `application:set_env/4`, which sets both the environment key and the configuration.

Originally, I was going to send two different pull requests to solve each issue individually, by introducing new functions and new options. Then I quickly realized that I was trying to provide ways to change the internal data kept by the `application_controller`. The new functions would only increase the API surface and it would still be limitted by the decisions done in `application_controller`. Is there a better way?

## Environment providers

The idea behind this pull request is very simple. We introduce environment providers, which are called whenever the application is loaded. It receives the application name and the current environment and returns `{ok, NewEnv} | {error, Reason}`.

As a proof of concept, this pull requests extracts the CLI handling into a separate module, called `application_env_cli_provider` that exports this API. Developers will be able to write their own providers, that read data from different places, and hook into the application loading mechanism.

## The application env config provider?

As said initially, the environment data is loaded from both `config` files, which are stored in the `application_controller`, and cli. We have made the `cli` a provider, but what about `config` files?

While it would be great to also make the current config its own provider too, it is currently coupled to `application_controller` in different places:

  * On `init`, the `application_controller` checks if the configuration is properly formatted
  * On `change_application_data`, the `application_controller` updates the config data too
  * On `set_env/4` and `unset_env/4` the configuration data is changed if the permanent flag is given

If we choose to make the config provider its own process, say `application_env_config_provider`, we would need to change all boot scripts to start it before the `application_controller` and also change all hot code swapping recipes to update the config storage before updating the applications. I find this too disruptive.

One intermediate approach is to store the config data into ets tables and still have the `application_controller` invoke some functions in the `application_env_config_provider` to fill the `ets` table up. Unfortunately it won't provide a complete isolation between `application_controller` and the provider, but the code will be better oganized and more consistent.

Or, alternatively, we don't make config a provider at all.

## Next steps

Assuming the OTP team agrees with this direction, there is a minimal amount of work to do before merging this:

  * Add `application:prepend_env_provider(NewProvider)` and `application:append_env_provider(NewProvider)` to the `application` module with the relevant tests and docs

  * Decide if we are going to make the current config its own provider too

Thanks for reading!
