### PR TITLE
Ref ordering fix (ERL-690)

### DIFF
--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -3122,7 +3122,7 @@ tailrecur_ne:
 		ASSERT(alen == blen);
 		for (i = (Sint) alen - 1; i >= 0; i--)
 		    if (anum[i] != bnum[i])
-			RETURN_NEQ((Sint32) (anum[i] - bnum[i]));
+			RETURN_NEQ(anum[i] < bnum[i] ? -1 : 1);
 		goto pop_next;
 	    case (_TAG_HEADER_EXTERNAL_REF >> _TAG_PRIMARY_SIZE):
 		if (is_internal_ref(b)) {

--- a/erts/emulator/test/ref_SUITE.erl
+++ b/erts/emulator/test/ref_SUITE.erl
@@ -22,6 +22,7 @@
 
 -export([all/0, suite/0]).
 -export([wrap_1/1]).
+-export([compare_list/1, compare_ets/1]).
 
 -export([loop_ref/1]).
 
@@ -32,7 +33,7 @@ suite() ->
      {timetrap, {minutes, 2}}].
 
 all() -> 
-    [wrap_1].
+    [wrap_1, compare_list, compare_ets].
 
 %% Check that refs don't wrap around easily.
 wrap_1(Config) when is_list(Config) ->
@@ -53,3 +54,28 @@ loop_ref(Parent) ->
 loop_ref(R, R, _) -> ok;
 loop_ref(R0, _, N) ->
     loop_ref(R0, make_ref(), N+1).
+
+%% Check that ref ordering works
+compare_list(Config) when is_list(Config) ->
+    %% Although this test uses external refs, it would apply the same to plain refs
+    ExtRef1 = <<131,114,0,3,100,0,3,110,64,98,3, 0,0,173,156, 0,216,0,4, 0,0,0,0>>,
+    ExtRef2 = <<131,114,0,3,100,0,3,110,64,98,3, 0,1,31,27,   129,4,0,1, 0,0,0,0>>,
+
+    Ref1 = binary_to_term(ExtRef1), %% #Ref<n@b.0.14155780.44444>
+    Ref2 = binary_to_term(ExtRef2), %% #Ref<n@b.0.2164523009.73499>
+    OrderedList = [Ref1, Ref2],
+    OrderedList = lists:sort(OrderedList),
+    ok.
+
+%% This is the scarier case since it makes terms "invisible" in ets or Mnesia
+%% (the underlying fault cause is the same as compare_list/1)
+compare_ets(Config) when is_list(Config) ->
+    W2s = [610350147,899574699,2994196869,686384822,2397690439, 923302211],
+    ExtRefBase = <<131,114,0,3,100,0,3,110,64,98,3>>,
+    ExtRefs = [<<ExtRefBase/binary, 1:32, W2:32, 0:32>> || W2 <- W2s],
+    Refs = [binary_to_term(Bin) || Bin <- ExtRefs],
+
+    Ets = ets:new(refbug, [ordered_set]),
+    ets:insert(Ets, [{Ref,Ref} || Ref <- Refs]),
+    0 = length([R || R <- ets:tab2list(Ets), ets:lookup(Ets, element(1,R)) == []]),
+    ok.


### PR DESCRIPTION
This tests & fixes the ref ordering described in ERL-690



#Ref ordering is broken in all versions since at least R13B03 (the earliest in github). It does work in R12B03.

The comparison takes the difference of two Uint32 and casts it to Sint32 which is the wrong thing to do. For example, 2200000000 - 1 is positive, but sadly (Sint32)(22000000000-1) is negative.

The scary thing here is that it can make terms "invisible" in ets or Mnesia ram_copies or disc_copies tables.

`

    W2s = [610350147,899574699,2994196869,686384822,2397690439, 923302211],
    ExtRefBase = <<131,114,0,3,100,0,3,110,64,98,3>>,
    ExtRefs = [<<ExtRefBase/binary, 1:32, W2:32, 0:32>> || W2 <- W2s],
    Refs = [binary_to_term(Bin) || Bin <- ExtRefs],

    Ets = ets:new(refbug, [ordered_set]),
    ets:insert(Ets, [{Ref,Ref} || Ref <- Refs]),
    0 = length([R || R<-ets:tab2list(Ets), ets:lookup(Ets, element(1,R)) == []]),
    ok.
`
