### PR TITLE
Fix bug in binary matching

### DIFF
--- a/lib/compiler/src/beam_bsm.erl
+++ b/lib/compiler/src/beam_bsm.erl
@@ -310,7 +310,18 @@ btb_reaches_match_2([{test,bs_start_match2,{f,F},Live,[Bin,_],Ctx}|Is],
     end;
 btb_reaches_match_2([{test,_,{f,F},Ss}=I|Is], Regs, D0) ->
     btb_ensure_not_used(Ss, I, Regs),
-    D = btb_follow_branch(F, Regs, D0),
+    D1 = btb_follow_branch(F, Regs, D0),
+    D = case Is of
+            [{bs_context_to_binary,_}|_] ->
+                %% bs_context_to_binary following a test instruction
+                %% probably needs the current position to be saved as
+                %% the new start position, but we can't be sure.
+                %% Therefore, conservatively disable the optimization
+                %% (instead of forcing a saving of the position).
+                D1#btb{must_save=true,must_not_save=true};
+            _ ->
+                D1
+        end,
     btb_reaches_match_1(Is, Regs, D);
 btb_reaches_match_2([{test,_,{f,F},_,Ss,_}=I|Is], Regs, D0) ->
     btb_ensure_not_used(Ss, I, Regs),


### PR DESCRIPTION
The compiler generates incorrect code for the following example:

    decode_binary(_, <<Length, Data/binary>>) ->
      case {Length, Data} of
        {0, _} ->
          %% When converting the match context back to a binary,
          %% Data will be set to the entire original binary,
          %% that is, to <<0>> instead of <<>>.
          {{0, 0, 0}, Data};
        {4, <<Y:16/little, M, D, Rest/binary>>} ->
          {{Y, M, D}, Rest}
      end.

The problem is the delayed sub binary creation optimization, which
is not safe to do in this case.

This commit introduces a heuristic that will disable the delayed
sub binary creation optimization for this example.  Unfortunately, the
heuristic may turn off the optimization when it would actually be
safe. In the OTP codebase, the optimization is turned off in two
instances, once in string.erl and once in dets_v9.erl.

https://bugs.erlang.org/browse/ERL-689