### PR TITLE
Add clarification on nil type

### DIFF
--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -567,6 +567,10 @@ Expr1 <input>op</input> Expr2</pre>
       order is defined:</p>
     <pre>
 number &lt; atom &lt; reference &lt; fun &lt; port &lt; pid &lt; tuple &lt; map &lt; nil &lt; list &lt; bit string</pre>
+    <p><pre>nil</pre> in the previous expression represents the empty list
+      (i.e. <c>[]</c>), which is regarded as a separate type from
+      <c>list/0</c>. That's why <c>nil &lt; list</c>.
+    </p>
     <p>Lists are compared element by element. Tuples are ordered by
       size, two tuples with the same size are compared element by
       element.</p>


### PR DESCRIPTION
As explained by @psyeugenic on Slack:
> empty list `[]` is regarded as a separate type from `list()`, `[]` < `list()`
> i.e. nil is `[]`