### PR TITLE
Fix bug in compact representation of float_to_list/2

### DIFF
--- a/erts/emulator/sys/common/erl_sys_common_misc.c
+++ b/erts/emulator/sys/common/erl_sys_common_misc.c
@@ -176,6 +176,7 @@ sys_double_to_chars_fast(double f, char *buffer, int buffer_size, int decimals,
     double af;
     Uint64 int_part, frac_part;
     int neg;
+    int  has_decimals = decimals != 0;
     char *p = buffer;
 
     if (decimals < 0)
@@ -257,7 +258,7 @@ sys_double_to_chars_fast(double f, char *buffer, int buffer_size, int decimals,
     }
 
     /* Delete trailing zeroes */
-    if (compact)
+    if (compact && has_decimals)
         p = find_first_trailing_zero(p);
     *p = '\0';
     return p - buffer;

--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -161,6 +161,7 @@ t_float_to_string(Config) when is_list(Config) ->
     test_fts("1.000",1.0,   [{decimals,   3}]),
     test_fts("1.0",1.0, [{decimals, 1}]),
     test_fts("1.0",1.0, [{decimals, 3}, compact]),
+    test_fts("10",10.0, [{decimals, 0}, compact]),
     test_fts("1.12",1.123, [{decimals, 2}]),
     test_fts("1.123",1.123, [{decimals, 3}]),
     test_fts("1.123",1.123, [{decimals, 3}, compact]),


### PR DESCRIPTION
Presently it's deleting 0's in the non-fractional part of the number in this edge case:
```erlang
1> float_to_list(10.0, [{decimals, 0}, compact]).
"1"
2> float_to_list(1000.0, [{decimals, 0}, compact]).
"1"
```