### PR TITLE
Add daemon-mode pid file creation when not configured for systemd

### DIFF
--- a/erts/epmd/src/epmd.h
+++ b/erts/epmd/src/epmd.h
@@ -20,6 +20,9 @@
 
 /* The port number is defined in a makefile */
 
+/* The name and path to the pid file */
+#define EPMD_PIDFILE "/var/run/epmd.pid"
+
 /* Definitions of message codes */
 
 /* Registration and queries */


### PR DESCRIPTION
Signaling systemd only works on systems actually using it; this adds pidfile creation for daemon mode when HAVE_SYSTEMD_DAEMON is not set (eg, openrc or other sysvinit-style systems).  Yes, it could be fancier, and does not address privilege dropping.  Use it as you see fit.