### PR TITLE
Fix kernel_app doc logger_level default from info to notice

### DIFF
--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -507,7 +507,7 @@ logger:debug(#{got => connection_request, id => Id, state => State},
 	      <c>logger_level</c></seealso>. It is changed during
 	    runtime with <seealso marker="logger#set_primary_config-2">
 	      <c>logger:set_primary_config(level,Level)</c></seealso>.</p>
-	  <p>Defaults to <c>info</c>.</p>
+	  <p>Defaults to <c>notice</c>.</p>
 	</item>
 	<tag><c>filters = [{FilterId,Filter}]</c></tag>
 	<item>


### PR DESCRIPTION
The doc says the default kernel logger_level is info, it should be notice.
Please refer to commit 0d52b992c30eff8604e5a5363510fea38c712263 for more info.