### PR TITLE
No need X Windows' headers and libraries to build Erlang since v20.0

### DIFF
--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -77,8 +77,6 @@ also find the utilities needed for building the documentation.
 
     Download from <http://www.oracle.com/technetwork/java/javase/downloads>.
     We have also tested with IBM's JDK 1.6.0.
-*   X Windows -- Development headers and libraries are needed
-    to build the Erlang/OTP application `gs` on Unix/Linux.
 *   `flex` -- Headers and libraries are needed to build the flex
     scanner for the `megaco` application on Unix/Linux.
 *   wxWidgets -- Toolkit for GUI applications.


### PR DESCRIPTION
Since OTP-20.0, the gs application has been removed.

Please refer to OTP-13703 in the following link
http://erlang.org/download/otp_src_20.0-rc1.readme for further info.