### PR TITLE
fix double parenthesis and badly formatter <v> tags

### DIFF
--- a/lib/et/doc/src/et_collector.xml
+++ b/lib/et/doc/src/et_collector.xml
@@ -46,7 +46,8 @@
         <v>option() = {parent_pid, pid()} | {event_order, event_order()} | {dict_insert, {filter, collector}, collector_fun()} | {dict_insert, {filter, event_filter_name()}, event_filter_fun()} | {dict_insert, {subscriber, pid()}, dict_val()} | {dict_insert, dict_key(), dict_val()} | {dict_delete, dict_key()} | {trace_client, trace_client()} | {trace_global, boolean()} |  {trace_pattern, trace_pattern()} | {trace_port, integer()} |  {trace_max_queue, integer()}</v>
         <v>event_order() = trace_ts | event_ts</v>
         <v>trace_pattern() = {report_module(), extended_dbg_match_spec()} | undefined</v>
-        <v>report_module() = atom() | undefined &lt;v>extended_dbg_match_spec()() = detail_level() | dbg_match_spec()</v>
+        <v>report_module() = atom() | undefined</v>
+        <v>extended_dbg_match_spec() = detail_level() | dbg_match_spec()</v>
         <v>detail_level() = min | max | integer(X) when X =&lt; 0, X >= 100</v>
         <v>trace_client() =  {event_file, file_name()} | {dbg_trace_type(), dbg_trace_parameters()}</v>
         <v>file_name() = string()</v>
@@ -221,7 +222,7 @@
         <v>CollectorPid = pid()</v>
         <v>RawPattern = {report_module(), extended_dbg_match_spec()}</v>
         <v>report_module() = atom() | undefined</v>
-        <v>extended_dbg_match_spec()() = detail_level() | dbg_match_spec()</v>
+        <v>extended_dbg_match_spec() = detail_level() | dbg_match_spec()</v>
         <v>RawPattern = detail_level()</v>
         <v>detail_level() = min | max | integer(X) when X =&lt; 0, X >= 100</v>
         <v>TracePattern = {report_module(), dbg_match_spec_match_spec()}</v>
@@ -348,7 +349,8 @@
         <v>done() = 0</v>
         <v>forward() = infinity | integer(X) where X > 0</v>
         <v>backward() = '-infinity' | integer(X) where X &lt; 0</v>
-        <v>Fun = fun(Event, Acc) -> NewAcc &lt;v>Acc = NewAcc = term()</v>
+        <v>Fun = fun(Event, Acc) -> NewAcc</v>
+        <v>Acc = NewAcc = term()</v>
       </type>
       <desc>
         <p>Iterate over the currently stored events.</p>

--- a/lib/et/doc/src/et_selector.xml
+++ b/lib/et/doc/src/et_selector.xml
@@ -90,7 +90,9 @@
       <fsummary>Transforms trace data and makes an event record out of it</fsummary>
 
       <type>
-        <v>Mod = module_name() | undefined &lt;v>module_name() = atom() &lt;v>ValidTraceData = erlang_trace_data() | record(event)</v>
+          <v>Mod = module_name() | undefined</v>
+          <v>module_name() = atom()</v>
+          <v>ValidTraceData = erlang_trace_data() | record(event)</v>
         <v>erlang_trace_data() = {trace, Pid, Label, Info} |  {trace, Pid, Label, Info, Extra} |  {trace_ts, Pid, Label, Info, ReportedTS} |  {trace_ts, Pid, Label, Info, Extra, ReportedTS} |  {seq_trace, Label, Info} |  {seq_trace, Label, Info, ReportedTS} |  {drop, NumberOfDroppedItems}</v>
       </type>
 

--- a/lib/et/src/et_collector.erl
+++ b/lib/et/src/et_collector.erl
@@ -509,7 +509,7 @@ get_global_pid() ->
 %% CollectorPid = pid()
 %% RawPattern = {report_module(), extended_dbg_match_spec()}
 %% report_module() = atom() | undefined
-%% extended_dbg_match_spec()() = detail_level() | dbg_match_spec()
+%% extended_dbg_match_spec() = detail_level() | dbg_match_spec()
 %% RawPattern = detail_level()
 %% detail_level() = min | max | integer(X) when X =< 0, X >= 100
 %% TracePattern = {report_module(), dbg_match_spec_match_spec()}

--- a/lib/ftp/doc/src/ftp.xml
+++ b/lib/ftp/doc/src/ftp.xml
@@ -314,7 +314,7 @@
       <fsummary>Transfers a binary into a remote file.</fsummary>
       <type>
         <v>Pid = pid()</v>
-        <v>Bin = binary()()</v>
+        <v>Bin = binary()</v>
         <v>RemoteFile = string()</v>
         <v>Reason = restriction_reason()| shortage_reason() | common_reason()</v>
       </type>
@@ -736,7 +736,7 @@
       <fsummary>Transfers a binary into a remote file.</fsummary>
       <type>
         <v>Pid = pid()</v>
-        <v>Bin = binary()()</v>
+        <v>Bin = binary()</v>
         <v>RemoteFile = string()</v>
         <v>Reason = restriction_reason() | common_reason() | shortage_reason()</v>
       </type>

--- a/lib/inets/doc/src/mod_security.xml
+++ b/lib/inets/doc/src/mod_security.xml
@@ -135,7 +135,8 @@
       <type>
         <v>What = atom()</v>
         <v>Port = integer()</v>
-        <v>Address = {A,B,C,D} | string() &lt;v>Dir   = string()</v>
+        <v>Address = {A,B,C,D} | string()</v>
+        <v>Dir   = string()</v>
         <v>Data = [Info]</v>
         <v>Info = {Name, Value}</v>
       </type>

--- a/lib/mnesia/doc/src/mnesia_frag_hash.xml
+++ b/lib/mnesia/doc/src/mnesia_frag_hash.xml
@@ -130,7 +130,7 @@
       <name>key_to_frag_number(State, Key) -> FragNum | abort(Reason)</name>
       <fsummary>Resolves the key of a record into a fragment number.</fsummary>
       <type>
-        <v>FragNum = integer()()</v>
+        <v>FragNum = integer()</v>
         <v>Reason = term()</v>
       </type>
       <desc>

--- a/lib/reltool/doc/src/reltool.xml
+++ b/lib/reltool/doc/src/reltool.xml
@@ -806,7 +806,7 @@ target_spec()       = [target_spec()]
       <name>stop(Pid) -> ok | {error, Reason}</name>
       <fsummary>Stop a server or window process</fsummary>
       <type>
-        <v>Pid     = server_pid() | window_pid()()</v>
+        <v>Pid     = server_pid() | window_pid()</v>
         <v>Reason  = reason()</v>
       </type>
       <desc><p>Stop a server or window process</p></desc>

--- a/lib/tftp/doc/src/tftp.xml
+++ b/lib/tftp/doc/src/tftp.xml
@@ -150,7 +150,7 @@
 
    <tag><c>{logger, Module}</c></tag>
       <item>
-        <p><c>Module = module()()</c></p>
+        <p><c>Module = module()</c></p>
 
         <p>Callback module for customized logging of errors, warnings, and
 	  info messages. The callback module must implement the
@@ -220,7 +220,7 @@
       <name>info(daemons) -> [{Pid, Options}]</name>
       <fsummary>Returns information about all daemons.</fsummary>
       <type>
-        <v>Pid = [pid()()]</v>
+        <v>Pid = [pid()]</v>
         <v>Options = [option()]</v>
         <v>Reason = term()</v>
       </type>
@@ -233,7 +233,7 @@
       <name>info(servers) -> [{Pid, Options}]</name>
       <fsummary>Returns information about all servers.</fsummary>
       <type>
-        <v>Pid = [pid()()]</v>
+        <v>Pid = [pid()]</v>
         <v>Options = [option()]</v>
         <v>Reason = term()</v>
       </type>


### PR DESCRIPTION
There were some spec types with double parenthesis.

Also some type declarations didn't have a closing `</v>` so the next one was misplaces and were rendered incorrectly.

Fixed all the ones I could grep.