### PR TITLE
fix generated encoding for xml files generated with emd2exml

### DIFF
--- a/make/emd2exml.in
+++ b/make/emd2exml.in
@@ -1214,7 +1214,7 @@ complete_output(#state{out = Out} = S) ->
 
 complete_output(S, [], Out) ->
     S#state{delayed_array = [],
-	    out = ["<?xml version=\"1.0\" encoding=\"utf8\" ?>", nl(),
+	    out = ["<?xml version=\"1.0\" encoding=\"utf-8\" ?>", nl(),
 		   "<!DOCTYPE chapter SYSTEM \"chapter.dtd\">", nl(),
 		   Out]};
 complete_output(S, [{delayed, IX}|Rest], Out) ->


### PR DESCRIPTION
DTRACE.xml and SYSTEMTRAP.xml set encoding to utf8 instead of utf-8
and make xmerl_scan:file/1,2 fail parsing them