### PR TITLE
remove_message does not store any pointer to x0

### DIFF
--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -142,8 +142,7 @@ BEAM_FORMAT_NUMBER=0
 20: send/0
 
 ## @spec remove_message
-## @doc  Unlink the current message from the message queue and store a
-##       pointer to the message in x(0). Remove any timeout.
+## @doc  Unlink the current message from the message queue. Remove any timeout.
 21: remove_message/0
 
 ## @spec timeout


### PR DESCRIPTION
remove_message just remove messages without writing to any register.
Compiler is already generating code like:

{get_tuple_element,{x,0},1,{x,0}}.
remove_message.
{jump,{f,6}}

That clearly uses x0 for other purposes.