### PR TITLE
Erl compare ext lists bug (ERL-705)

### DIFF
--- a/lib/erl_interface/src/legacy/erl_marshal.c
+++ b/lib/erl_interface/src/legacy/erl_marshal.c
@@ -1803,7 +1803,7 @@ static int cmp_exe2(unsigned char **e1, unsigned char **e2)
       k = 0;
       while (1) {
 	  if (k++ == min){
-	      if (i == j) return 0;
+	      if (i == j) return compare_top_ext(e1 , e2);
 	      if (i < j) return -1;
 	      return 1;
 	  }

--- a/lib/erl_interface/test/erl_ext_SUITE_data/ext_test.c
+++ b/lib/erl_interface/test/erl_ext_SUITE_data/ext_test.c
@@ -88,6 +88,11 @@ TESTCASE(compare_list) {
     // erlang:term_to_binary([0, 1000])
     unsigned char term4[] = {131,108,0,0,0,2,97,0,98,0,0,3,232,106};
 
+    // erlang:term_to_binary([a|b])
+    unsigned char term5a[] = {131,108,0,0,0,1,100,0,1,97,100,0,1,98};
+    // erlang:term_to_binary([a|c])
+    unsigned char term5b[] = {131,108,0,0,0,1,100,0,1,97,100,0,1,99};
+
     erl_init(NULL, 0);
     start_a = term1;
     start_b = term2;
@@ -102,6 +107,13 @@ TESTCASE(compare_list) {
     end_b   = term4 + sizeof(term4);
 
     test_compare_ext("lists1", start_a, end_a, start_b, end_b, -1);
+
+    start_a = term5a;
+    start_b = term5b;
+    end_a   = term5a + sizeof(term5a);
+    end_b   = term5b + sizeof(term5b);
+
+    test_compare_ext("lists5", start_a, end_a, start_b, end_b, -1);
 
     report(1);
 }


### PR DESCRIPTION
erl_compare_ext() eventually calls cmp_exe2() for compound terms, and that function doesn't consider the tail for lists.
This means erl_compare_ext() considers the external representation of these two terms to be equal:
```
[a|b]
[a|c]
```

But it gets worse! These terms are also considered equal:

```
{<<1,2,3>>, [901,902], 224}
{<<1,2,3>>, [901,902], 228}
```

