### PR TITLE
erts/time_correction.xml: remove extra closing parenthesis

### DIFF
--- a/erts/doc/src/time_correction.xml
+++ b/erts/doc/src/time_correction.xml
@@ -940,7 +940,7 @@ EventTag = {Time, UMI}</code>
       </item>
       <item>
         <seealso marker="erlang#system_info_os_system_time_source">
-	<c>erlang:system_info(os_system_time_source)</c></seealso>)
+	<c>erlang:system_info(os_system_time_source)</c></seealso>
       </item>
     </list>
 


### PR DESCRIPTION
you can see it here: http://erlang.org/doc/apps/erts/time_correction.html#support-of-both-new-and-old-otp-releases