### PR TITLE
remove includes from options filtered bc they don't effect codegen

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1603,7 +1603,6 @@ effects_code_generation(Option) ->
 	binary -> false;
 	verbose -> false;
 	{cwd,_} -> false;
-	{i,_} -> false;
 	{outdir, _} -> false;
 	_ -> true
     end.


### PR DESCRIPTION
This change results in rebar3 always recompiling every module because it thinks the compile options have changed for every module.

I do think the includes effect the code generation so do not think it should be dropped from the list of compile options. This patch changes it so it is still included.

The rest of the changes from https://github.com/erlang/otp/commit/dd0a39cdd7407cd739d02577e79c54ff0d78b7cf are untouched.