### PR TITLE
Add include_ellipsis option to ASN.1 compiler

### DIFF
--- a/lib/asn1/doc/src/asn1ct.xml
+++ b/lib/asn1/doc/src/asn1ct.xml
@@ -288,6 +288,20 @@ File3.asn</pre>
               list or a binary. Earlier versions of the compiler ignored
               those following bytes.</p>
           </item>
+          <tag><c>include_ellipsis</c></tag>
+          <item>
+            <p>
+	      <c>SET</c> or <c>SEQUENCE</c> types that are extensible will
+	      have an <c>'$ellipsis'</c> element included in the
+	      record.
+	    </p>
+	    <p>
+	      During decoding, the <c>'$ellipsis'</c> element (or key,
+	      if maps are used) will be set to any extension data in
+	      the form returned by <c>asn1rt_nif:decode_ber_tlv/1</c>
+	    </p>
+	    <p><c>'$ellipsis'</c> is ignored when encoding</p>
+	  </item>
 	  <tag><c>no_ok_wrapper</c></tag>
 	  <item>
 	    <p>With this option, the generated <c>encode/2</c>

--- a/lib/asn1/src/asn1ct.erl
+++ b/lib/asn1/src/asn1ct.erl
@@ -41,7 +41,7 @@
 	 maybe_rename_function/3,current_sindex/0,
 	 set_current_sindex/1,maybe_saved_sindex/2,
 	 parse_and_save/2,verbose/3,warning/3,warning/4,error/3,format_error/1]).
--export([get_bit_string_format/0,use_legacy_types/0]).
+-export([get_bit_string_format/0,use_legacy_types/0,include_ellipsis/0]).
 
 -include("asn1_records.hrl").
 -include_lib("stdlib/include/erl_compile.hrl").
@@ -831,6 +831,7 @@ generate({M,CodeTuple}, OutFile, EncodingRule, Options) ->
                  classes=Classes,objects=Objects,objsets=ObjectSets},
     setup_bit_string_format(Options),
     setup_legacy_erlang_types(Options),
+    setup_include_ellipsis(Options),
     asn1ct_table:new(check_functions),
 
     Gen = init_gen_record(EncodingRule, Options),
@@ -896,6 +897,12 @@ legacy_forced_info(Opt) ->
 
 use_legacy_types() ->
     get(use_legacy_erlang_types).
+
+setup_include_ellipsis(Opts) ->
+    put(include_ellipsis, lists:member(include_ellipsis, Opts)).
+
+include_ellipsis() ->
+    get(include_ellipsis).
 
 setup_bit_string_format(Opts) ->
     Format = case {lists:member(compact_bit_string, Opts),

--- a/lib/asn1/test/Makefile
+++ b/lib/asn1/test/Makefile
@@ -44,6 +44,7 @@ MODULES= \
 	testConstraints \
 	testDef \
 	testExtensionDefault \
+	testIncludeEllipsis \
 	testOpt \
 	testSeqDefault \
 	testSeqExtension \

--- a/lib/asn1/test/asn1_SUITE.erl
+++ b/lib/asn1/test/asn1_SUITE.erl
@@ -149,6 +149,7 @@ groups() ->
        testDER,
        testDEFAULT,
        testExtensionDefault,
+       testIncludeEllipsis,
        testMvrasn6,
        testContextSwitchingTypes,
        testOpenTypeImplicitTag,
@@ -450,6 +451,13 @@ testExtensionDefault(Config) ->
 testExtensionDefault(Config, Rule, Opts) ->
     asn1_test_lib:compile_all(["ExtensionDefault"], Config, [Rule|Opts]),
     testExtensionDefault:main(Rule).
+
+testIncludeEllipsis(Config) ->
+    test(Config, fun testIncludeEllipsis/3,
+         [{ber,[include_ellipsis]}]).
+testIncludeEllipsis(Config, Rule, Opts) ->
+    asn1_test_lib:compile_all(['IncludeEllipsis'], Config, [Rule|Opts]),
+    testIncludeEllipsis:main(Rule).
 
 testMaps(Config) ->
     test(Config, fun testMaps/3,

--- a/lib/asn1/test/asn1_SUITE_data/IncludeEllipsis.asn1
+++ b/lib/asn1/test/asn1_SUITE_data/IncludeEllipsis.asn1
@@ -1,0 +1,12 @@
+IncludeEllipsis DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+Message ::= SEQUENCE {
+    id INTEGER (0..5),
+    ...,
+    priority Priority DEFAULT low
+}
+Priority ::= ENUMERATED { low(0), high(1), ... }
+
+END

--- a/lib/asn1/test/testIncludeEllipsis.erl
+++ b/lib/asn1/test/testIncludeEllipsis.erl
@@ -1,0 +1,78 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%%
+-module(testIncludeEllipsis).
+
+-export([main/1]).
+
+main(_Erule) ->
+    %% test the case where there are no extension data in the encoded bytes
+    roundtrip_nv('Message', {'Message',3,high}),
+    map_roundtrip('Message', #{id=>4,priority=>high}),
+    roundtrip_ed('Message', {'Message',3,high}, <<4, 1, 99>>),
+    roundtrip_ed('Message', {'Message',3,high}, <<4, 1, 99, 4, 1, 98>>),
+    map_roundtrip_ed('Message', #{id=>4,priority=>high}, <<4, 1, 99>>),
+    map_roundtrip_ed('Message', #{id=>4,priority=>high}, <<4, 1, 99, 4, 1, 98>>),
+    ok.
+
+roundtrip_nv(Type, Value) ->
+    roundtrip(Type, Value, undefined, erlang:append_element(Value,asn1_NOVALUE)).
+
+roundtrip_ed(Type, Value, ED) ->
+    DecED = dec_ed(ED),
+    roundtrip(Type, Value, ED, erlang:append_element(Value,DecED)).
+
+roundtrip(Type, Value, ED, Expected) ->
+    %% asn1_test_lib:roundtrip/3 will invoke map_roundtrip/3, which will
+    %% not work in this case. Therefore, implement the roundtrip ourselves.
+    M = 'IncludeEllipsis',
+    {ok,Enc} = M:encode(Type, Value),
+    EncEd = if ED == undefined -> Enc;
+               true ->
+                    <<Tag, Len, Data/binary>> = Enc,
+                    <<Tag, (Len + size(ED)), Data/binary, ED/binary>>
+            end,
+    {ok,Expected} = M:decode(Type, EncEd),
+    ok.
+
+map_roundtrip(Type, Value) ->
+    map_roundtrip(Type, Value, undefined, Value).
+
+map_roundtrip_ed(Type, Value, ED) ->
+    DecED = dec_ed(ED),
+    map_roundtrip(Type, Value, ED, Value#{'$ellipsis' => DecED}).
+
+map_roundtrip(Type, Value, ED, Expected) ->
+    M = 'maps_IncludeEllipsis',
+    Enc = M:encode(Type, Value),
+    EncEd = if ED == undefined -> Enc;
+               true ->
+                    <<Tag, Len, Data/binary>> = Enc,
+                    <<Tag, (Len + size(ED)), Data/binary, ED/binary>>
+            end,
+    Expected = M:decode(Type, EncEd),
+    ok.
+
+dec_ed(<<>>) ->
+    [];
+dec_ed(Bin) ->
+    {Dec,Rem} = asn1rt_nif:decode_ber_tlv(Bin),
+    [Dec | dec_ed(Rem)].
+


### PR DESCRIPTION
This option is currently only implemented for BER. It is ignored for
other encodings.

ASN.1 modules compiled with this flag will have an '$ellipsis'
elemented added to the record deinition for any extensible SET or
SEQUENCE.

When decoding, any extension elements will be added to the '$ellipsis'
element or key in the form returned by asn1rt_nif:decode_ber_tlv/1.

When encoding '$ellipsis' is ignored.

Example:
`Ex ::= SEQUENCE {
    id INTEGER (0..5),
    ... }
`
becomes:
`-record('Ex', {id, '$ellipsis' = asn1_NOVALUE}).`

```
> 'Ex':decode('Ex',<<48,3,128,1,3>>).
{ok,#'Ex'{id = 3,'$ellipsis' = asn1_NOVALUE}}

7> 'Ex':decode('Ex',<<48,7,128,1,3,4,2,0,199>>).
{ok,#'Ex'{id = 3,'$ellipsis' = [{4,<<0,199>>}]}}
```