### PR TITLE
erlang-mode: fix void variable align-rules-list error

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -77,7 +77,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'cl))
-(eval-when-compile (require 'align))
+(require 'align)
 
 ;; Variables:
 


### PR DESCRIPTION
erlang-mode crashes with the following error:

`Symbol’s value as variable is void: align-rules-list`

caused by #1728