### PR TITLE
dialyzer: Improve handling of complex guards

### DIFF
--- a/lib/dialyzer/test/small_SUITE_data/results/left_assoc
+++ b/lib/dialyzer/test/small_SUITE_data/results/left_assoc
@@ -1,0 +1,2 @@
+
+left_assoc.erl:93: The variable __@2 can never match since previous clauses completely covered the type binary()

--- a/lib/dialyzer/test/small_SUITE_data/src/left_assoc.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/left_assoc.erl
@@ -1,0 +1,96 @@
+-module(left_assoc).
+
+%% As pointed out in ERL-680, analyzing guards with short circuit
+%% operators becomes very slow as the number of left associations
+%% grows.
+
+-spec from_iso8601('Elixir.String':t(), 'Elixir.Calendar':calendar()) ->
+                          {ok, t()} | {error, atom()}.
+
+-export_type([t/0]).
+
+-type t() ::
+        #{'__struct__' := 'Elixir.Date',
+          calendar := 'Elixir.Calendar':calendar(),
+          day := 'Elixir.Calendar':day(),
+          month := 'Elixir.Calendar':month(),
+          year := 'Elixir.Calendar':year()}.
+
+-export([from_iso8601/1,
+         from_iso8601/2]).
+
+from_iso8601(__@1) ->
+    from_iso8601(__@1, 'Elixir.Calendar.ISO').
+
+from_iso8601(<<45/integer,_rest@1/binary>>, _calendar@1) ->
+    case raw_from_iso8601(_rest@1, _calendar@1) of
+        {ok,#{year := _year@1} = _date@1} ->
+            {ok,_date@1#{year := - _year@1}};
+        __@1 ->
+            __@1
+    end;
+from_iso8601(<<_rest@1/binary>>, _calendar@1) ->
+    raw_from_iso8601(_rest@1, _calendar@1).
+
+raw_from_iso8601(_string@1, _calendar@1) ->
+    case _string@1 of
+        <<_y1@1/integer,
+          _y2@1/integer,
+          _y3@1/integer,
+          _y4@1/integer,
+          45/integer,
+          _m1@1/integer,
+          _m2@1/integer,
+          45/integer,
+          _d1@1/integer,
+          _d2@1/integer>>
+          when
+              ((((((((((((((_y1@1 >= 48
+                            andalso
+                            _y1@1 =< 57)
+                           andalso
+                           _y2@1 >= 48)
+                          andalso
+                          _y2@1 =< 57)
+                         andalso
+                         _y3@1 >= 48)
+                        andalso
+                        _y3@1 =< 57)
+                       andalso
+                       _y4@1 >= 48)
+                      andalso
+                      _y4@1 =< 57)
+                     andalso
+                     _m1@1 >= 48)
+                    andalso
+                    _m1@1 =< 57)
+                   andalso
+                   _m2@1 >= 48)
+                  andalso
+                  _m2@1 =< 57)
+                 andalso
+                 _d1@1 >= 48)
+                andalso
+                _d1@1 =< 57)
+               andalso
+               _d2@1 >= 48)
+              andalso
+              _d2@1 =< 57 ->
+            {ok,
+             #{year => (_y1@1 - 48) * 1000 + (_y2@1 - 48) * 100
+               +
+                   (_y3@1 - 48) * 10
+               +
+                   (_y4@1 - 48),
+               month => (_m1@1 - 48) * 10 + (_m2@1 - 48),
+               day => (_d1@1 - 48) * 10 + (_d2@1 - 48),
+               calendar => _calendar@1,
+               '__struct__' => 'Elixir.Date'}};
+        __@1 ->
+            case __@1 of
+                _ ->
+                    {error,invalid_format};
+                __@2 ->
+                    error({with_clause,__@2})
+            end
+    end.


### PR DESCRIPTION
See also https://bugs.erlang.org/browse/ERL-680.

The right associative short circuit expressions 'andalso' and 'orelse'
are expanded by the Compiler (see v3_core) into 'case' expressions. If
parentheses are used to enforce left associativeness, variables are
introduced, and the time needed by Dialyzer increases exponentially.

Rather than trying to fix Dialyzer itself, v3_core now rewrites
repeated use of 'andalso' ('orelse') into right associative
expressions before creating the 'case' expressions.