### PR TITLE
madvise on pooled carriers

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1438,7 +1438,7 @@ dnl Some Linuxes needs <sys/socketio.h> instead of <sys/sockio.h>
 dnl
 AC_CHECK_HEADERS(fcntl.h limits.h unistd.h syslog.h dlfcn.h ieeefp.h \
                  sys/types.h sys/stropts.h sys/sysctl.h \
-                 sys/ioctl.h sys/time.h sys/uio.h \
+                 sys/ioctl.h sys/time.h sys/uio.h sys/mman.h \
                  sys/socket.h sys/sockio.h sys/socketio.h \
                  net/errno.h malloc.h arpa/nameser.h libdlpi.h \
 		 pty.h util.h libutil.h utmp.h langinfo.h poll.h sdkddkver.h)

--- a/erts/emulator/beam/erl_alloc_util.c
+++ b/erts/emulator/beam/erl_alloc_util.c
@@ -2604,14 +2604,14 @@ blk_mark_unused_pages(Allctr_t *allocator, Block_t *block) {
     slice_align_to_page(&slice);
     if (!slice.sz) { return; } /* was not able to fit any full pages */
     erts_mem_advise(&slice);
-#if defined(_WIN32)
-#error "TODO https://blogs.msdn.microsoft.com/oldnewthing/20170113-00/?p=95185"
+#if defined(ERTS_USING_WINDOWS_DECOMMIT)
+    #error "TODO https://blogs.msdn.microsoft.com/oldnewthing/20170113-00/?p=95185"
 #endif
 }
 
 
 /* Enable this if madvise is available, otherwise calls to it are eliminated */
-#if !defined (MADV_FREE)
+#if defined (ERTS_USING_WINDOWS_DECOMMIT)
 static void ERTS_INLINE
 blk_unmark_unused_pages(Allctr_t *allocator, Block_t *block) {
     /*  NOTE: This is not called on Linux if MADV_FREE is detected
@@ -2644,7 +2644,7 @@ carrier_mark_pages_unused(Allctr_t *allocator, Carrier_t *carrier) {
 static void
 carrier_mark_pages_used_again(Allctr_t *allocator, Carrier_t *carrier) {
     /* For Linux with MADV_FREE eliminate this loop, as it is doing nothing */
-#if !defined (MADV_FREE)
+#if defined (ERTS_USING_WINDOWS_DECOMMIT)
     Block_t *block = MBC_TO_FIRST_BLK(allocator, carrier);
     while (1) {
         if (IS_FREE_BLK(block)) {


### PR DESCRIPTION
To @garazdawi 
Carriers moved to the unused pool have their free blocks marked as unused for OS
Optimisation is added to avoid double-claiming already claimed memory pages, when coalescing (merging) adjacent blocks

Implementation for POSIX systems which have `<sys/mman.h>` available
For Windows implementation is missing **and will create a compile time error** but suggestions are copied from https://blogs.msdn.microsoft.com/oldnewthing/20170113-00/?p=95185

TODO: Populate windows-specific functions in `erl_mmap.h`
TODO: Replace call to `getpagesize()` for Windows.
TODO: Remove relevant `#error` directives from `erts_alloc_util.c` and `erl_mmap.h`