### PR TITLE
Introduce a put_tuple2 instruction

### DIFF
--- a/erts/emulator/beam/beam_debug.c
+++ b/erts/emulator/beam/beam_debug.c
@@ -786,8 +786,8 @@ print_op(fmtfn_t to, void *to_arg, int op, int size, BeamInstr* addr)
 	    }
 	}
 	break;
-    case op_i_put_tuple_xI:
-    case op_i_put_tuple_yI:
+    case op_put_tuple2_xI:
+    case op_put_tuple2_yI:
     case op_new_map_dtI:
     case op_update_map_assoc_sdtI:
     case op_update_map_exact_jsdtI:

--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -559,17 +559,19 @@ update_list(Hd, Dst) {
     HTOP += 2;
 }
 
-i_put_tuple := i_put_tuple.make.fill;
-
-i_put_tuple.make(Dst) {
-    $Dst = make_tuple(HTOP);
-}
-
-i_put_tuple.fill(Arity) {
+put_tuple2(Dst, Arity) {
     Eterm* hp = HTOP;
     Eterm arity = $Arity;
 
+    /*
+     * If operands are not packed (in the 32-bit VM),
+     * is is not safe to use $Dst directly after I
+     * has been updated.
+     */
+    Eterm* dst_ptr = &($Dst);
+
     //| -no_next
+    ASSERT(arity != 0);
     *hp++ = make_arityval(arity);
     I = $NEXT_INSTRUCTION;
     do {
@@ -586,6 +588,7 @@ i_put_tuple.fill(Arity) {
             break;
         }
     } while (--arity != 0);
+    *dst_ptr = make_tuple(HTOP);
     HTOP = hp;
     ASSERT(VALID_INSTR(* (Eterm *)I));
     Goto(*I);

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -483,9 +483,16 @@ is_eq f? s s
 is_ne f? s s
 
 #
-# Putting things.
+# Putting tuples.
+#
+# Code compiled with OTP 22 and later uses put_tuple2 to
+# to construct a tuple.
+#
+# Code compiled before OTP 22 uses put_tuple + one put instruction
+# per element. Translate to put_tuple2.
 #
 
+i_put_tuple/2
 put_tuple Arity Dst => i_put_tuple Dst u
 
 i_put_tuple Dst Arity Puts=* | put S1 | put S2 | \
@@ -495,10 +502,12 @@ i_put_tuple Dst Arity Puts=* | put S1 | put S2 | \
 i_put_tuple Dst Arity Puts=* | put S => \
 	    tuple_append_put(Arity, Dst, Puts, S)
 
-i_put_tuple/2
+i_put_tuple Dst Arity Puts=* => put_tuple2 Dst Arity Puts
 
-i_put_tuple xy I
+put_tuple2 xy I
 
+#
+# Putting lists.
 #
 # The instruction "put_list Const [] Dst" were generated in rare
 # circumstances up to and including OTP 18. Starting with OTP 19,

--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -89,6 +89,7 @@ collect({move,S,D})          -> {set,[D],[S],move};
 collect({put_list,S1,S2,D})  -> {set,[D],[S1,S2],put_list};
 collect({put_tuple,A,D})     -> {set,[D],[],{put_tuple,A}};
 collect({put,S})             -> {set,[],[S],put};
+collect({put_tuple2,D,{list,Els}}) -> {set,[D],Els,put_tuple2};
 collect({get_tuple_element,S,I,D}) -> {set,[D],[S],{get_tuple_element,I}};
 collect({set_tuple_element,S,D,I}) -> {set,[],[S,D],{set_tuple_element,I}};
 collect({get_hd,S,D})  ->       {set,[D],[S],get_hd};

--- a/lib/compiler/src/beam_except.erl
+++ b/lib/compiler/src/beam_except.erl
@@ -113,14 +113,7 @@ dig_out_block([{set,[{x,0}],[{atom,if_clause}],move}]) ->
     {yes,if_end,[]};
 dig_out_block([{set,[{x,0}],[{literal,{Exc,Value}}],move}|Is]) ->
     translate_exception(Exc, {literal,Value}, Is, 0);
-dig_out_block([{set,[{x,0}],[Tuple],move},
-	       {set,[],[Value],put},
-	       {set,[],[{atom,Exc}],put},
-	       {set,[Tuple],[],{put_tuple,2}}|Is]) ->
-    translate_exception(Exc, Value, Is, 3);
-dig_out_block([{set,[],[Value],put},
-	       {set,[],[{atom,Exc}],put},
-	       {set,[{x,0}],[],{put_tuple,2}}|Is]) ->
+dig_out_block([{set,[{x,0}],[{atom,Exc},Value],put_tuple2}|Is]) ->
     translate_exception(Exc, Value, Is, 3);
 dig_out_block(_) -> no.
 

--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -65,6 +65,7 @@ norm({set,[D],[S],move})          -> {move,S,D};
 norm({set,[D],[S],fmove})         -> {fmove,S,D};
 norm({set,[D],[S],fconv})         -> {fconv,S,D};
 norm({set,[D],[S1,S2],put_list})  -> {put_list,S1,S2,D};
+norm({set,[D],Els,put_tuple2})    -> {put_tuple2,D,{list,Els}};
 norm({set,[D],[],{put_tuple,A}})  -> {put_tuple,A,D};
 norm({set,[],[S],put})            -> {put,S};
 norm({set,[D],[S],{get_tuple_element,I}}) -> {get_tuple_element,S,I,D};

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -286,6 +286,8 @@ classify_heap_need(put_list, _) ->
     {put,2};
 classify_heap_need(put_tuple_arity, [#b_literal{val=Words}]) ->
     {put,Words+1};
+classify_heap_need(put_tuple, Elements) ->
+    {put,length(Elements)+1};
 classify_heap_need({bif,Name}, Args) ->
     case is_gc_bif(Name, Args) of
         false -> neutral;
@@ -1360,6 +1362,8 @@ cg_instr(get_tuple_element=Op, [Src,{integer,N}], Dst) ->
     [{Op,Src,N,Dst}];
 cg_instr(put_list=Op, [Hd,Tl], Dst) ->
     [{Op,Hd,Tl,Dst}];
+cg_instr(put_tuple, Elements, Dst) ->
+    [{put_tuple2,Dst,{list,Elements}}];
 cg_instr(put_tuple_arity, [{integer,Arity}], Dst) ->
     [{put_tuple,Arity,Dst}];
 cg_instr(put_tuple_elements, Elements, _Dst) ->

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -349,6 +349,12 @@ valfun_1({put_list,A,B,Dst}, Vst0) ->
     assert_term(B, Vst0),
     Vst = eat_heap(2, Vst0),
     set_type_reg(cons, Dst, Vst);
+valfun_1({put_tuple2,Dst,{list,Elements}}, Vst0) ->
+    _ = [assert_term(El, Vst0) || El <- Elements],
+    Size = length(Elements),
+    Vst = eat_heap(Size+1, Vst0),
+    Type = {tuple,Size},
+    set_type_reg(Type, Dst, Vst);
 valfun_1({put_tuple,Sz,Dst}, Vst0) when is_integer(Sz) ->
     Vst1 = eat_heap(1, Vst0),
     Vst = set_type_reg(tuple_in_progress, Dst, Vst1),

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -259,13 +259,13 @@ expand_opt(r19, Os) ->
 expand_opt(r20, Os) ->
     expand_opt_before_21(Os);
 expand_opt(r21, Os) ->
-    Os;
+    [no_put_tuple2|Os];
 expand_opt({debug_info_key,_}=O, Os) ->
     [encrypt_debug_info,O|Os];
 expand_opt(O, Os) -> [O|Os].
 
 expand_opt_before_21(Os) ->
-    [no_get_hd_tl,no_ssa_opt_record,no_utf8_atoms|Os].
+    [no_put_tuple2,no_get_hd_tl,no_ssa_opt_record,no_utf8_atoms|Os].
 
 %% format_error(ErrorDescriptor) -> string()
 

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -573,3 +573,8 @@ BEAM_FORMAT_NUMBER=0
 ## @doc  Get the tail (or cdr) part of a list (a cons cell) from Source and
 ##       put it into the register Tail.
 163: get_tl/2
+
+## @spec put_tuple2  Destination Elements
+## @doc  Build a tuple with the elements in the list Elements and put it
+##       put into register Destination.
+164: put_tuple2/2

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1476,18 +1476,22 @@ bc_options(Config) ->
     101 = highest_opcode(DataDir, small_float, [no_get_hd_tl,no_line_info]),
 
     103 = highest_opcode(DataDir, big,
-                         [no_get_hd_tl,no_ssa_opt_record,
+                         [no_put_tuple2,
+                          no_get_hd_tl,no_ssa_opt_record,
                           no_line_info,no_stack_trimming]),
 
     125 = highest_opcode(DataDir, small_float,
                          [no_get_hd_tl,no_line_info,no_ssa_opt_float]),
 
     132 = highest_opcode(DataDir, small,
-                         [no_get_hd_tl,no_ssa_opt_record,no_ssa_opt_float,no_line_info]),
+                         [no_put_tuple2,no_get_hd_tl,no_ssa_opt_record,
+                          no_ssa_opt_float,no_line_info]),
 
-    136 = highest_opcode(DataDir, big, [no_get_hd_tl,no_ssa_opt_record,no_line_info]),
+    136 = highest_opcode(DataDir, big, [no_put_tuple2,no_get_hd_tl,
+                                        no_ssa_opt_record,no_line_info]),
 
-    153 = highest_opcode(DataDir, big, [no_get_hd_tl,no_ssa_opt_record]),
+    153 = highest_opcode(DataDir, big, [no_put_tuple2,no_get_hd_tl,
+                                        no_ssa_opt_record]),
     153 = highest_opcode(DataDir, big, [r16]),
     153 = highest_opcode(DataDir, big, [r17]),
     153 = highest_opcode(DataDir, big, [r18]),
@@ -1499,9 +1503,10 @@ bc_options(Config) ->
     158 = highest_opcode(DataDir, small_maps, [r18]),
     158 = highest_opcode(DataDir, small_maps, [r19]),
     158 = highest_opcode(DataDir, small_maps, [r20]),
-    158 = highest_opcode(DataDir, small_maps, []),
+    158 = highest_opcode(DataDir, small_maps, [r21]),
 
-    163 = highest_opcode(DataDir, big, []),
+    164 = highest_opcode(DataDir, small_maps, []),
+    164 = highest_opcode(DataDir, big, []),
 
     ok.
 


### PR DESCRIPTION
Sometimes when building a tuple, there is no way to avoid an
extra `move` instruction. Consider this code:

    make_tuple(A) -> {ok,A}.

The corresponding BEAM code looks like this:

    {test_heap,3,1}.
    {put_tuple,2,{x,1}}.
    {put,{atom,ok}}.
    {put,{x,0}}.
    {move,{x,1},{x,0}}.
    return.

To avoid overwriting the source register `{x,0}`, a `move`
instruction is necessary.

The problem doesn't exist when building a list:

    %% build_list(A) -> [A].
    {test_heap,2,1}.
    {put_list,{x,0},nil,{x,0}}.
    return.

Introduce a new `put_tuple2` instruction that builds a tuple in a
single instruction, so that the `move` instruction can be eliminated:

    %% make_tuple(A) -> {ok,A}.
    {test_heap,3,1}.
    {put_tuple2,{x,0},{list,[{atom,ok},{x,0}]}}.
    return.

Note that the BEAM loader already combines `put_tuple` and `put`
instructions into an internal instruction similar to `put_tuple2`.
Therefore the introduction of the new instruction will not speed up
execution of tuple building itself, but it will be less work for
the loader to load the new instruction.