### PR TITLE
Emacs: require align from compiled erlang.el as well

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -77,7 +77,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'cl))
-(eval-when-compile (require 'align))
+(require 'align)
 
 ;; Variables:
 


### PR DESCRIPTION
eval-when-compile requires when compiling but not when running the
produced compiled byte-code.  That is enough for the cl library
since it is used only for macros that can be expanded at compile
time.  But align is needed at runtime as well.