### PR TITLE
Fixed ssl_options typespec for key

### DIFF
--- a/lib/ssl/src/ssl_api.hrl
+++ b/lib/ssl/src/ssl_api.hrl
@@ -42,7 +42,8 @@
 			 {verify, verify_type()} |
 			 {verify_fun, {fun(), InitialUserState::term()}} |
                          {fail_if_no_peer_cert, boolean()} | {depth, integer()} |
-                         {cert, Der::binary()} | {certfile, path()} | {key, Der::binary()} |
+                         {cert, Der::binary()} | {certfile, path()} |
+                         {key, {private_key_type(), Der::binary()}} |
                          {keyfile, path()} | {password, string()} | {cacerts, [Der::binary()]} |
                          {cacertfile, path()} | {dh, Der::binary()} | {dhfile, path()} |
                          {user_lookup_fun, {fun(), InitialUserState::term()}} |
@@ -64,5 +65,12 @@
 -type transport_option() :: {cb_info, {CallbackModule::atom(), DataTag::atom(),
 				       ClosedTag::atom(), ErrTag::atom()}}.
 -type prf_random() :: client_random | server_random.
+
+-type private_key_type() :: rsa | %% Backwards compatibility
+                            dsa | %% Backwards compatibility
+                            'RSAPrivateKey' |
+                            'DSAPrivateKey' |
+                            'ECPrivateKey' |
+                            'PrivateKeyInfo'.
 
 -endif. % -ifdef(ssl_api).


### PR DESCRIPTION
This fixes [ERL-721](https://bugs.erlang.org/browse/ERL-721)

Dialyzer would complain when using the `key` option of `ssl_option()`, e.g. for `ssl:listen/2`

I'm not sure if this can be tested (with a unit test). I built it locally and tested with my own project that Dialyzer would no longer complain.

