### PR TITLE
Avoid object code terminology on general docs/messages

### DIFF
--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -1425,7 +1425,7 @@ load_atom_table(LoaderState* stp, ErtsAtomEncoding enc)
 	ap = atom_tab(atom_val(stp->atom[1]));
 	sys_memcpy(sbuf, ap->name, ap->len);
 	sbuf[ap->len] = '\0';
-	LoadError1(stp, "module name in object code is %s", sbuf);
+	LoadError1(stp, "bytecode exists but it defines a module named %s", sbuf);
     }
 
     return 1;

--- a/lib/kernel/doc/src/application.xml
+++ b/lib/kernel/doc/src/application.xml
@@ -189,7 +189,7 @@
         <p>Loads the application specification for an application into
           the application controller. It also loads the application
           specifications for any included applications. Notice that
-          the function does not load the Erlang object code.</p>
+          the function does not load any module bytecode into memory.</p>
         <p>The application can be specified by its name <c><anno>Application</anno></c>.
           In this case, the application controller searches the code
           path for the application resource file <c><anno>Application</anno>.app</c>
@@ -430,8 +430,7 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
         <p>Unloads the application specification for <c><anno>Application</anno></c>
           from the application controller. It also unloads
           the application specifications for any included applications.
-          Notice that the function does not purge the Erlang
-          object code.</p>
+          Notice that the function does not purge any module bytecode from memory.</p>
       </desc>
     </func>
     <func>

--- a/lib/kernel/doc/src/rpc.xml
+++ b/lib/kernel/doc/src/rpc.xml
@@ -273,7 +273,7 @@
 	  or <c>{badrpc, <anno>Reason</anno>}</c> for failing calls.
           <c><anno>Timeout</anno></c> is a time (integer) in milliseconds, or
           <c>infinity</c>.</p>
-        <p>The following example is useful when new object code is to
+        <p>The following example is useful when module bytecode is to
           be loaded on all nodes in the network, and indicates
           some side effects that RPCs can produce:</p>
         <code type="none">

--- a/lib/stdlib/doc/src/filename.xml
+++ b/lib/stdlib/doc/src/filename.xml
@@ -395,7 +395,7 @@ true
           case, the module must be known by the code server, that is,
           <c>code:which(<anno>Module</anno>)</c> must succeed.</p>
         <p><c><anno>Rules</anno></c> describes how the source directory can be
-          found when the object code directory is known. It is a list of
+          found when the module directory is known. It is a list of
           tuples <c>{<anno>BinSuffix</anno>, <anno>SourceSuffix</anno>}</c> and
           is interpreted as follows: if the end of the directory name where the
           object is located matches <c><anno>BinSuffix</anno></c>, then the

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -248,7 +248,7 @@ safe_recompile(File, Options, BeamFile) ->
             Error
     end.
 
-%% Compile the file and load the resulting object code (if any).
+%% Compile the file and load the resulting module bytecode (if any).
 %% Automatically ensures that there is an outdir option, by default the
 %% directory of File, and that a 'from' option will be passed to match the
 %% actual source suffix if needed (unless already specified).

--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -857,7 +857,7 @@ climb(T, [_|Acc]) ->
 %% known by the code manager, i.e. code:which/1 should succeed.
 %%
 %% Rules describes how the source directory should be found given
-%% the directory for the object code.  Each rule is on the form
+%% the directory for the module.  Each rule is on the form
 %% {BinSuffix, SourceSuffix}, and is interpreted like this:
 %% If the end of directory name where the object is located matches
 %% BinSuffix, then the suffix will be replaced with SourceSuffix


### PR DESCRIPTION
Although the object code terminology is introduced in the code
and debugger modules, the terminology is mostly unknown to
developers unless they have interacted with those modules
directly.

Therefore when reading the docs and stumbling against object
code for the first time, the term is often puzzling. This is
particularly troublesome in case insensitive filesystems, where
attempting to invoke a module with the wrong case leads to
confusing error messages:

    1> erlpress_core:foo().
    beam/beam_load.c(1428): Error loading module 'erlpress_core':
      module name in object code is erlPress_core

    Loading of erlPress_core.beam failed: :badfile

This commit restricts the object code terminology to the
low-level code and int APIs, using module or bytecode
elsewhere, where the distinction between module name, bytecode
and object code is relevant.