### PR TITLE
Fix include-path regression caused by ca3867d

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1562,7 +1562,6 @@ effects_code_generation(Option) ->
 	binary -> false;
 	verbose -> false;
 	{cwd,_} -> false;
-	{i,_} -> false;
 	{outdir, _} -> false;
 	_ -> true
     end.


### PR DESCRIPTION
Hello All!
This is just a cherry-picked commit erlang/otp@3c24f3803a504d20b604f9608a8c80ae31750fb3 which is still missing in maint-20 branch. So we're experiencing strange issues like this one - eproxus/meck#195.