### PR TITLE
Clean up variable-related cruft in new SSA passes

### DIFF
--- a/lib/compiler/src/beam_ssa_dead.erl
+++ b/lib/compiler/src/beam_ssa_dead.erl
@@ -180,7 +180,7 @@ shortcut_2(L, Bs0, UnsetVars0, St) ->
                     %% We have a potentially suitable br.
                     %% Now update the set of variables that will never
                     %% be set if this block will be skipped.
-                    UnsetVars1 = [V || #b_set{dst=#b_var{name=V}} <- Is],
+                    UnsetVars1 = [V || #b_set{dst=V} <- Is],
                     UnsetVars = ordsets:union(UnsetVars0,
                                               ordsets:from_list(UnsetVars1)),
 
@@ -315,7 +315,7 @@ get_block(L, St) ->
 is_br_safe(UnsetVars, Br, #st{us=Us}=St) ->
     %% Check that none of the unset variables will be used.
     case Br of
-        #b_br{bool=#b_var{name=V},succ=Succ,fail=Fail} ->
+        #b_br{bool=#b_var{}=V,succ=Succ,fail=Fail} ->
             #{Succ:=Used0,Fail:=Used1} = Us,
 
             %% A two-way branch never branches to a phi node, so there
@@ -922,7 +922,7 @@ used_vars([{L,#b_blk{is=Is}=Blk}|Bs], UsedVars0, Skip0) ->
     %% can be skipped (does not bind any variable used
     %% in successor).
 
-    Defined0 = [Def || #b_set{dst=#b_var{name=Def}} <- Is],
+    Defined0 = [Def || #b_set{dst=Def} <- Is],
     Defined = ordsets:from_list(Defined0),
     MaySkip = ordsets:is_disjoint(Defined, Used0),
     case MaySkip of
@@ -957,7 +957,7 @@ used_vars_phis(Is, L, Live0, UsedVars0) ->
             UsedVars;
         [_|_] ->
             PhiArgs = append([Args || #b_set{args=Args} <- Phis]),
-            case [{P,V} || {#b_var{name=V},P} <- PhiArgs] of
+            case [{P,V} || {#b_var{}=V,P} <- PhiArgs] of
                 [_|_]=PhiVars ->
                     PhiLive0 = rel2fam(PhiVars),
                     PhiLive = [{{L,P},ordsets:union(ordsets:from_list(Vs), Live0)} ||
@@ -975,7 +975,7 @@ used_vars_blk(#b_blk{is=Is,last=Last}, Used0) ->
 
 used_vars_is([#b_set{op=phi}|Is], Used) ->
     used_vars_is(Is, Used);
-used_vars_is([#b_set{dst=#b_var{name=Dst}}=I|Is], Used0) ->
+used_vars_is([#b_set{dst=Dst}=I|Is], Used0) ->
     Used1 = ordsets:union(Used0, beam_ssa:used(I)),
     Used = ordsets:del_element(Dst, Used1),
     used_vars_is(Is, Used);

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -158,7 +158,7 @@ format_op({Prefix,Name}) ->
 format_op(Name) ->
     io_lib:format("~p", [Name]).
 
-format_register(#b_var{name=V}, #{registers:=Regs}) ->
+format_register(#b_var{}=V, #{registers:=Regs}) ->
     {Tag,N} = maps:get(V, Regs),
     io_lib:format("~p~p", [Tag,N]);
 format_register(_, #{}) -> "".
@@ -224,9 +224,9 @@ format_anno_1(Anno) ->
             [io_lib:format("  %% Anno: ~p\n", [Anno])]
     end.
 
-format_live_interval(#b_var{name=V}=Dst, #{live_intervals:=Intervals}) ->
+format_live_interval(#b_var{}=Dst, #{live_intervals:=Intervals}) ->
     case Intervals of
-        #{V:=Rs0} ->
+        #{Dst:=Rs0} ->
             Rs1 = [io_lib:format("~p..~p", [Start,End]) ||
                       {Start,End} <- Rs0],
             Rs = lists:join(" ", Rs1),

--- a/lib/compiler/src/beam_ssa_recv.erl
+++ b/lib/compiler/src/beam_ssa_recv.erl
@@ -166,7 +166,7 @@ ref_in_tuple(Tuple, Blocks) ->
     beam_ssa:fold_instrs_rpo(F, [0], no, Blocks).
 
 opt_ref_used(RecvLbl, Ref, Blocks) ->
-    Vs = #{{var,Ref}=>ref,ref=>Ref,ref_matched=>false},
+    Vs = #{Ref=>ref,ref=>Ref,ref_matched=>false},
     case opt_ref_used_1(RecvLbl, Vs, Blocks) of
         used -> true;
         not_used -> false;
@@ -183,7 +183,7 @@ opt_ref_used_1(L, Vs0, Blocks) ->
     end.
 
 opt_ref_used_is([#b_set{op=peek_message,dst=Msg}|Is], Vs0) ->
-    Vs = Vs0#{{var,Msg}=>message},
+    Vs = Vs0#{Msg=>message},
     opt_ref_used_is(Is, Vs);
 opt_ref_used_is([#b_set{op={bif,Bif},args=Args,dst=Dst}=I|Is],
                 Vs0) ->
@@ -254,15 +254,14 @@ ref_used_in([], _) -> done.
 
 update_vars(#b_set{args=Args,dst=Dst}, Vs) ->
     Vars = [V || #b_var{}=V <- Args],
-    All = all(fun(V) ->
-                      Var = {var,V},
+    All = all(fun(Var) ->
                       case Vs of
                           #{Var:=message} -> true;
                           #{} -> false
                       end
               end, Vars),
     case All of
-        true -> Vs#{{var,Dst}=>message};
+        true -> Vs#{Dst=>message};
         false -> Vs
     end.
 
@@ -270,9 +269,7 @@ update_vars(#b_set{args=Args,dst=Dst}, Vs) ->
 %%  Return 'true' if Args denotes a comparison between the
 %%  reference and message or part of the message.
 
-is_ref_msg_comparison([#b_var{}=A1,#b_var{}=A2], Vs) ->
-    V1 = {var,A1},
-    V2 = {var,A2},
+is_ref_msg_comparison([#b_var{}=V1,#b_var{}=V2], Vs) ->
     case Vs of
         #{V1:=ref,V2:=message} -> true;
         #{V1:=message,V2:=ref} -> true;


### PR DESCRIPTION
When we first set out to rewrite the assembly passes in SSA format we weren't sure whether we'd want to be able to add annotations to variables. To play it safe we used variable names everywhere instead of the whole `#b_var{}` record so it would be trivial to add the field later on, but at the cost of having to pack and unpack the name pretty often.

It turns out we didn't need these annotations in the end, so this PR cleans things up.