### PR TITLE
beam_validator: Use set_aliased_type in more operations

### DIFF
--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -572,7 +572,7 @@ valfun_4({bif,tuple_size,{f,Fail},[Tuple],Dst}=I, Vst0) ->
     TupleType0 = get_term_type(Tuple, Vst0),
     Vst1 = branch_state(Fail, Vst0),
     TupleType = upgrade_tuple_type({tuple,[0]}, TupleType0),
-    Vst = set_type(TupleType, Tuple, Vst1),
+    Vst = set_aliased_type(TupleType, Tuple, Vst1),
     set_type_reg_expr({integer,[]}, I, Dst, Vst);
 valfun_4({bif,element,{f,Fail},[Pos,Tuple],Dst}, Vst0) ->
     TupleType0 = get_term_type(Tuple, Vst0),
@@ -589,20 +589,20 @@ valfun_4(raw_raise=I, Vst) ->
 valfun_4({bif,map_get,{f,Fail},[_Key,Map]=Src,Dst}, Vst0) ->
     validate_src(Src, Vst0),
     Vst1 = branch_state(Fail, Vst0),
-    Vst = set_type(map, Map, Vst1),
+    Vst = set_aliased_type(map, Map, Vst1),
     Type = propagate_fragility(term, Src, Vst),
     set_type_reg(Type, Dst, Vst);
 valfun_4({bif,is_map_key,{f,Fail},[_Key,Map]=Src,Dst}, Vst0) ->
     validate_src(Src, Vst0),
     Vst1 = branch_state(Fail, Vst0),
-    Vst = set_type(map, Map, Vst1),
+    Vst = set_aliased_type(map, Map, Vst1),
     Type = propagate_fragility(bool, Src, Vst),
     set_type_reg(Type, Dst, Vst);
 valfun_4({bif,Op,{f,Fail},[Cons]=Src,Dst}, Vst0)
   when Op =:= hd; Op =:= tl ->
     validate_src(Src, Vst0),
     Vst1 = branch_state(Fail, Vst0),
-    Vst = set_type(cons, Cons, Vst1),
+    Vst = set_aliased_type(cons, Cons, Vst1),
     Type0 = bif_type(Op, Src, Vst),
     Type = propagate_fragility(Type0, Src, Vst),
     set_type_reg(Type, Dst, Vst);

--- a/lib/compiler/test/beam_validator_SUITE.erl
+++ b/lib/compiler/test/beam_validator_SUITE.erl
@@ -34,7 +34,7 @@
 	 undef_label/1,illegal_instruction/1,failing_gc_guard_bif/1,
 	 map_field_lists/1,cover_bin_opt/1,
 	 val_dsetel/1,bad_tuples/1,bad_try_catch_nesting/1,
-         receive_stacked/1]).
+         receive_stacked/1,aliased_types/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -63,7 +63,7 @@ groups() ->
        undef_label,illegal_instruction,failing_gc_guard_bif,
        map_field_lists,cover_bin_opt,val_dsetel,
        bad_tuples,bad_try_catch_nesting,
-       receive_stacked]}].
+       receive_stacked,aliased_types]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -578,6 +578,21 @@ receive_stacked(Config) ->
     {ok,Mod,_} = compile:file(File, [binary]),
 
     ok.
+
+%% ERL-735: validator failed to track types on aliased registers, rejecting
+%% legitimate optimizations.
+%%
+%%    move x0 y0
+%%    bif hd L1 x0
+%%    get_hd y0     %% The validator failed to see that y0 was a list
+aliased_types(Config) when is_list(Config) ->
+    Bug = lists:seq(1, 5),
+    if
+        Config =/= [gurka, gaffel] -> %% Pointless branch.
+            _ = hd(Bug),
+            lists:seq(1, 5),
+            hd(Bug)
+    end.
 
 %%%-------------------------------------------------------------------------
 


### PR DESCRIPTION
`hd/1` and friends only tracked types for their direct inputs, failing validation for legal code that used an aliased register.

https://bugs.erlang.org/browse/ERL-735