### PR TITLE
hipe_llvm_main: fix tmpfs dir on FreeBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ i686-pc-linux-gnu
 x86_64-unknown-linux-gnu
 i386-apple-darwin[0-9]*.[0-9]*.[0-9]*
 x86_64-apple-darwin[0-9]*.[0-9]*.[0-9]*
+x86_64-unknown-freebsd[0-9]*.[0-9]*
 sparc-sun-solaris[0-9]*.[0-9]*
 i386-pc-solaris[0-9]*.[0-9]*
 i386-unknown-freebsd[0-9]*.[0-9]*

--- a/lib/hipe/llvm/hipe_llvm_main.erl
+++ b/lib/hipe/llvm/hipe_llvm_main.erl
@@ -527,7 +527,7 @@ unique_folder(FunName, Arity, Options) ->
       true ->  %% Store folder in current directory
         DirName;
       false -> %% Temporarily store folder in tempfs (/dev/shm/)
-        "/dev/shm/" ++ DirName
+        tmpfs_folder() ++ DirName
     end,
   %% Make sure it does not exist
   case dir_exists(Dir) of
@@ -535,6 +535,14 @@ unique_folder(FunName, Arity, Options) ->
       unique_folder(FunName, Arity, Options);
     false ->
       Dir
+  end.
+
+tmpfs_folder() ->
+  case os:type() of
+    {unix, linux} ->
+      "/dev/shm/";
+    {unix, _} -> %% Fallback to tmp dir. e.g. FreeBSD
+      "/tmp/"
   end.
 
 %% @doc Function that checks that a given Filename is an existing Directory

--- a/lib/hipe/llvm/hipe_llvm_main.erl
+++ b/lib/hipe/llvm/hipe_llvm_main.erl
@@ -526,7 +526,7 @@ unique_folder(FunName, Arity, Options) ->
     case proplists:get_bool(llvm_save_temps, Options) of
       true ->  %% Store folder in current directory
         DirName;
-      false -> %% Temporarily store folder in tempfs (/dev/shm/)
+      false -> %% Temporarily store folder in tempfs or tmp dir
         tmpfs_folder() ++ DirName
     end,
   %% Make sure it does not exist


### PR DESCRIPTION
Upstream this patch from FreeBSD Ports:
https://svnweb.freebsd.org/ports/head/lang/erlang-runtime21/files/patch-lib_hipe_llvm_hipe__llvm__main.erl?revision=473434&view=markup