### PR TITLE
Use os:getenv/2 where possible

### DIFF
--- a/erts/emulator/test/smoke_test_SUITE.erl
+++ b/erts/emulator/test/smoke_test_SUITE.erl
@@ -56,7 +56,7 @@ end_per_testcase(_Case, Config) when is_list(Config) ->
 %%%
 
 boot_combo(Config) when is_list(Config) ->
-    ZFlags = os:getenv("ERL_ZFLAGS"),
+    ZFlags = os:getenv("ERL_ZFLAGS", ""),
     NOOP = fun () -> ok end,
     A42 = fun () ->
 		  case erlang:system_info(threads) of
@@ -87,10 +87,7 @@ boot_combo(Config) when is_list(Config) ->
 	%% A lot more combos could be implemented...
 	ok
     after
-	os:putenv("ERL_ZFLAGS", case ZFlags of
-				    false -> "";
-				    _ -> ZFlags
-				end)
+	os:putenv("ERL_ZFLAGS", ZFlags)
     end.
 
 native_atomics(Config) when is_list(Config) ->

--- a/lib/common_test/src/ct.erl
+++ b/lib/common_test/src/ct.erl
@@ -390,11 +390,7 @@ testcases(TestDir, Suite) ->
     end.
 
 make_and_load(Dir, Suite) ->
-    EnvInclude =
-	case os:getenv("CT_INCLUDE_PATH") of
-	    false -> [];
-	    CtInclPath -> string:lexemes(CtInclPath, [$:,$ ,$,])
-	end,
+    EnvInclude = string:lexemes(os:getenv("CT_INCLUDE_PATH", ""), [$:,$ ,$,]),
     StartInclude =
 	case init:get_argument(include) of
 	    {ok,[Dirs]} -> Dirs;

--- a/lib/common_test/test/ct_config_SUITE.erl
+++ b/lib/common_test/test/ct_config_SUITE.erl
@@ -211,16 +211,10 @@ reformat_events(Events, EH) ->
 %%% Test related to 'localtime' will often fail if the test host is
 %%% time warping, so let's just skip the 'dynamic' tests then.
 skip_dynamic() ->
-    case os:getenv("TS_EXTRA_PLATFORM_LABEL") of
-	TSExtraPlatformLabel when is_list(TSExtraPlatformLabel) ->
-	    case string:find(TSExtraPlatformLabel,"TimeWarpingOS") of
-		nomatch -> false;
-		_ -> true
-	    end;
-	_ ->
-	    false
+    case string:find(os:getenv("TS_EXTRA_PLATFORM_LABEL", ""), "TimeWarpingOS") of
+	nomatch -> false;
+	_ -> true
     end.
-
 
 
 %%%-----------------------------------------------------------------

--- a/lib/observer/src/cdv_wx.erl
+++ b/lib/observer/src/cdv_wx.erl
@@ -448,10 +448,7 @@ maybe_warn_filename(FileName) ->
         true ->
             continue;
         false ->
-            DumpName = case os:getenv("ERL_CRASH_DUMP") of
-                           false -> filename:absname("erl_crash.dump");
-                           Name -> filename:absname(Name)
-                       end,
+            DumpName = filename:absname(os:getenv("ERL_CRASH_DUMP", "erl_crash.dump")),
             case filename:absname(FileName) of
                 DumpName ->
                     Warning =

--- a/lib/xmerl/src/xmerl_sax_parser_base.erlsrc
+++ b/lib/xmerl/src/xmerl_sax_parser_base.erlsrc
@@ -3679,7 +3679,7 @@ create_tempfile(Template) ->
 		    false ->
 			case os:getenv("TEMP") of
 			    false ->
-				throw({error, "Variabel TMP or TEMP doesn't exist"});
+				throw({error, "Variable TMP or TEMP doesn't exist"});
 			    P2 ->
 				P2
 			end;


### PR DESCRIPTION
Hello!
Let's use os:getenv/2 even more instead of the following code:

```erlang
case os:getenv(SomeEnv) of
    false -> DefaultVal;
    Val -> Val
end.
```