### PR TITLE
Implement Signature Algorithms (TLS 1.3)

### DIFF
--- a/lib/eldap/test/make_certs.erl
+++ b/lib/eldap/test/make_certs.erl
@@ -348,7 +348,7 @@ req_cnf(C) ->
      "default_bits	= ", integer_to_list(C#config.default_bits), "\n"
      "RANDFILE		= $ROOTDIR/RAND\n"
      "encrypt_key	= no\n"
-     "default_md	= md5\n"
+     "default_md	= sha1\n"
      "#string_mask	= pkix\n"
      "x509_extensions	= ca_ext\n"
      "prompt		= no\n"
@@ -394,7 +394,7 @@ ca_cnf(C) ->
      ["crl_extensions = crl_ext\n" || C#config.v2_crls],
      "unique_subject  = no\n"
      "default_days	= 3600\n"
-     "default_md	= md5\n"
+     "default_md	= sha1\n"
      "preserve	        = no\n"
      "policy		= policy_match\n"
      "\n"

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -209,7 +209,24 @@
 		   elliptic_curves => [oid] | undefined,
 		   sni => string() | undefined}
        }</c></p></item>
-      
+
+       <tag><c>signature_scheme() =</c></tag>
+       <item>
+	 <p><c>rsa_pkcs1_sha256</c></p>
+	 <p><c>| rsa_pkcs1_sha384</c></p>
+	 <p><c>| rsa_pkcs1_sha512</c></p>
+	 <p><c>| ecdsa_secp256r1_sha256</c></p>
+	 <p><c>| ecdsa_secp384r1_sha384</c></p>
+	 <p><c>| ecdsa_secp521r1_sha512</c></p>
+	 <p><c>| rsa_pss_rsae_sha256</c></p>
+	 <p><c>| rsa_pss_rsae_sha384</c></p>
+	 <p><c>| rsa_pss_rsae_sha512</c></p>
+	 <p><c>| rsa_pss_pss_sha256</c></p>
+	 <p><c>| rsa_pss_pss_sha384</c></p>
+	 <p><c>| rsa_pss_pss_sha512</c></p>
+	 <p><c>| rsa_pkcs1_sha1</c></p>
+	 <p><c>| ecdsa_sha1</c></p>
+       </item>
 
     </taglist>
   </section>
@@ -709,6 +726,26 @@ fun(srp, Username :: string(), UserState :: term()) ->
 	that may be selected. Default support for {md5, rsa} removed in ssl-8.0
 	</p>
 	</item>
+	<tag><marker id="signature_algs_cert"/><c>{signature_algs_cert, [signature_scheme()]}</c></tag>
+	<item>
+	  <p>
+	    In addition to the signature_algorithms extension from TLS 1.2,
+	    <url href="http://www.ietf.org/rfc/rfc8446.txt#section-4.2.3">TLS 1.3
+	    (RFC 5246 Section 4.2.3)</url>adds the signature_algorithms_cert extension
+	    which enables having special requirements on the signatures used in the
+	    certificates that differs from the requirements on digital signatures as a whole.
+	    If this is not required this extension is not needed.
+	  </p>
+	  <p>
+	    The client will send a signature_algorithms_cert extension (ClientHello),
+	    if TLS version 1.3 or later is used, and the signature_algs_cert option is
+	    explicitly specified. By default, only the signature_algs extension is sent.
+	  </p>
+	  <p>
+	    The signature schemes shall be ordered according to the client's preference
+	    (favorite choice first).
+	  </p>
+	</item>
       </taglist>
    </section>
    
@@ -860,7 +897,6 @@ fun(srp, Username :: string(), UserState :: term()) ->
       negotiation, introduced in TLS-1.2. The algorithms will also be offered to the client if a
       client certificate is requested. For more details see the <seealso marker="#client_signature_algs">corresponding client option</seealso>.
       </p> </item>
-
     </taglist>
   </section>
   

--- a/lib/ssl/src/dtls_handshake.erl
+++ b/lib/ssl/src/dtls_handshake.erl
@@ -194,7 +194,7 @@ handle_client_hello(Version,
 		    ?ALERT_REC(?FATAL, ?INSUFFICIENT_SECURITY);
 		_ ->
 		    #{key_exchange := KeyExAlg} = ssl_cipher_format:suite_definition(CipherSuite),
-		    case ssl_handshake:select_hashsign(ClientHashSigns, Cert, KeyExAlg, 
+		    case ssl_handshake:select_hashsign({ClientHashSigns, undefined}, Cert, KeyExAlg,
 						       SupportedHashSigns, TLSVersion) of
 			#alert{} = Alert ->
 			    Alert;

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -1041,8 +1041,8 @@ handle_options(Opts0, Role, Host) ->
 		  alpn_preferred_protocols, next_protocols_advertised,
 		  client_preferred_next_protocols, log_alert, log_level,
 		  server_name_indication, honor_cipher_order, padding_check, crl_check, crl_cache,
-		  fallback, signature_algs, eccs, honor_ecc_order, beast_mitigation,
-                  max_handshake_size, handshake, customize_hostname_check],
+		  fallback, signature_algs, signature_algs_cert, eccs, honor_ecc_order,
+                  beast_mitigation, max_handshake_size, handshake, customize_hostname_check],
     SockOpts = lists:foldl(fun(Key, PropList) ->
 				   proplists:delete(Key, PropList)
 			   end, Opts, SslOptions),
@@ -1645,6 +1645,14 @@ new_ssl_options([{signature_algs, Value} | Rest], #ssl_options{} = Opts, RecordC
 					 handle_hashsigns_option(Value, 
 								 tls_version(RecordCB:highest_protocol_version()))}, 
 		    RecordCB);
+new_ssl_options([{signature_algs_cert, Value} | Rest], #ssl_options{} = Opts, RecordCB) ->
+    new_ssl_options(
+      Rest,
+      Opts#ssl_options{signature_algs_cert =
+                           handle_signature_algorithms_option(
+                             Value,
+                             tls_version(RecordCB:highest_protocol_version()))},
+      RecordCB);
 new_ssl_options([{protocol, dtls = Value} | Rest], #ssl_options{} = Opts, dtls_record = RecordCB) -> 
     new_ssl_options(Rest, Opts#ssl_options{protocol = Value}, RecordCB);
 new_ssl_options([{protocol, tls = Value} | Rest], #ssl_options{} = Opts, tls_record = RecordCB) -> 

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -975,10 +975,7 @@ handle_options(Opts0, Role, Host) ->
                            proplists:get_value(
                              signature_algs_cert,
                              Opts,
-                             default_option_role(server,
-                                                 tls_v1:default_signature_schemes(HighestVersion),
-                                                 Role
-                                                )),
+                             undefined),  %% Do not send by default
                            tls_version(HighestVersion)),
 		    %% Server side option
 		    reuse_session = handle_option(reuse_session, Opts, ReuseSessionFun),
@@ -1326,8 +1323,6 @@ handle_signature_algorithms_option(Value, Version) when is_list(Value)
 	_ ->
 	    Value
     end;
-handle_signature_algorithms_option(_, Version)  when Version >= {3, 4} ->
-    handle_signature_algorithms_option(tls_v1:default_signature_schemes(Version), Version);
 handle_signature_algorithms_option(_, _Version) ->
     undefined.
 

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -857,7 +857,9 @@ certify(internal, #certificate_request{} = CertRequest,
 	       role = client,
 	       ssl_options = #ssl_options{signature_algs = SupportedHashSigns},
 	       negotiated_version = Version} = State0, Connection) ->
-    case ssl_handshake:select_hashsign(CertRequest, Cert, SupportedHashSigns, ssl:tls_version(Version)) of
+    case ssl_handshake:select_hashsign(CertRequest, Cert,
+                                       SupportedHashSigns,
+                                       ssl:tls_version(Version)) of
 	#alert {} = Alert ->
 	    handle_own_alert(Alert, Version, ?FUNCTION_NAME, State0);
 	NegotiatedHashSign -> 

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1015,11 +1015,16 @@ client_hello_extensions(Version, CipherSuites,
         {3,4} ->
             HelloExtensions#{client_hello_versions => 
                                  #client_hello_versions{versions = Versions},
-                             signature_algs_cert => 
-                                 #signature_scheme_list{signature_scheme_list = SignatureSchemes}};
+                             signature_algs_cert =>
+                                 signature_scheme_list(SignatureSchemes)};
         _Else ->
             HelloExtensions
     end.
+
+signature_scheme_list(undefined) ->
+    undefined;
+signature_scheme_list(SignatureSchemes) ->
+    #signature_scheme_list{signature_scheme_list = SignatureSchemes}.
 
 handle_client_hello_extensions(RecordCB, Random, ClientCipherSuites,
                                Exts, Version,

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -276,6 +276,7 @@ handle_client_hello(Version,
 	true ->
             Curves = maps:get(elliptic_curves, HelloExt, undefined),
             ClientHashSigns = maps:get(signature_algs, HelloExt, undefined),
+            ClientSignatureSchemes = maps:get(signature_algs_cert, HelloExt, undefined),
 	    AvailableHashSigns = ssl_handshake:available_signature_algs(
 				   ClientHashSigns, SupportedHashSigns, Cert, Version),
 	    ECCCurve = ssl_handshake:select_curve(Curves, SupportedECCs, ECCOrder),
@@ -289,8 +290,10 @@ handle_client_hello(Version,
                     ?ALERT_REC(?FATAL, ?INSUFFICIENT_SECURITY, no_suitable_ciphers);
 		_ ->
 		    #{key_exchange := KeyExAlg} = ssl_cipher_format:suite_definition(CipherSuite),
-		    case ssl_handshake:select_hashsign(ClientHashSigns, Cert, KeyExAlg, 
-                                                       SupportedHashSigns, Version) of
+		    case ssl_handshake:select_hashsign({ClientHashSigns, ClientSignatureSchemes},
+                                                       Cert, KeyExAlg,
+                                                       SupportedHashSigns,
+                                                       Version) of
 			#alert{} = Alert ->
 			    Alert;
 			HashSign ->

--- a/lib/ssl/test/make_certs.erl
+++ b/lib/ssl/test/make_certs.erl
@@ -365,7 +365,7 @@ req_cnf(Root, C) ->
      "default_bits	= ", integer_to_list(C#config.default_bits), "\n"
      "RANDFILE		= $ROOTDIR/RAND\n"
      "encrypt_key	= no\n"
-     "default_md	= md5\n"
+     "default_md	= sha1\n"
      "#string_mask	= pkix\n"
      "x509_extensions	= ca_ext\n"
      "prompt		= no\n"
@@ -415,7 +415,7 @@ ca_cnf(
      ["crl_extensions = crl_ext\n" || C#config.v2_crls],
      "unique_subject  = no\n"
      "default_days	= 3600\n"
-     "default_md	= md5\n"
+     "default_md	= sha1\n"
      "preserve	        = no\n"
      "policy		= policy_match\n"
      "\n"
@@ -499,7 +499,7 @@ ca_cnf(
      ["crl_extensions = crl_ext\n" || C#config.v2_crls],
      "unique_subject  = no\n"
      "default_days	= 3600\n"
-     "default_md	= md5\n"
+     "default_md	= sha1\n"
      "preserve	        = no\n"
      "policy		= policy_match\n"
      "\n"

--- a/lib/ssl/test/ssl_basic_SUITE.erl
+++ b/lib/ssl/test/ssl_basic_SUITE.erl
@@ -3570,14 +3570,14 @@ conf_signature_algs(Config) when is_list(Config) ->
 	ssl_test_lib:start_server([{node, ServerNode}, {port, 0}, 
 				   {from, self()}, 
 				   {mfa, {ssl_test_lib, send_recv_result, []}},
-				   {options,  [{active, false}, {signature_algs, [{sha256, rsa}]} | ServerOpts]}]),
+				   {options,  [{active, false}, {signature_algs, [{sha, rsa}]} | ServerOpts]}]),
     Port = ssl_test_lib:inet_port(Server),
     Client = 
 	ssl_test_lib:start_client([{node, ClientNode}, {port, Port}, 
 				   {host, Hostname},
 				   {from, self()}, 
 				   {mfa, {ssl_test_lib, send_recv_result, []}},
-				   {options, [{active, false}, {signature_algs, [{sha256, rsa}]} | ClientOpts]}]),
+				   {options, [{active, false}, {signature_algs, [{sha, rsa}]} | ClientOpts]}]),
     
     ct:log("Testcase ~p, Client ~p  Server ~p ~n",
 			 [self(), Client, Server]),

--- a/lib/ssl/test/ssl_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_handshake_SUITE.erl
@@ -163,11 +163,11 @@ ignore_hassign_extension_pre_tls_1_2(Config) ->
     Opts = proplists:get_value(server_opts, Config),
     CertFile = proplists:get_value(certfile, Opts),
     [{_, Cert, _}] = ssl_test_lib:pem_to_der(CertFile),
-    HashSigns = #hash_sign_algos{hash_sign_algos = [{sha512, rsa}, {sha, dsa}]},
-    {sha512, rsa} = ssl_handshake:select_hashsign(HashSigns, Cert, ecdhe_rsa, tls_v1:default_signature_algs({3,3}), {3,3}),
+    HashSigns = #hash_sign_algos{hash_sign_algos = [{sha512, rsa}, {sha, dsa}, {sha, rsa}]},
+    {sha512, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs({3,3}), {3,3}),
     %%% Ignore
-    {md5sha, rsa} = ssl_handshake:select_hashsign(HashSigns, Cert, ecdhe_rsa, tls_v1:default_signature_algs({3,2}), {3,2}),
-    {md5sha, rsa} = ssl_handshake:select_hashsign(HashSigns, Cert, ecdhe_rsa, tls_v1:default_signature_algs({3,0}), {3,0}).
+    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs({3,2}), {3,2}),
+    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs({3,0}), {3,0}).
 
 unorded_chain(Config) when is_list(Config) ->
     DefConf = ssl_test_lib:default_cert_chain_conf(),

--- a/lib/ssl/test/ssl_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_handshake_SUITE.erl
@@ -25,6 +25,7 @@
 -compile(export_all).
 
 -include_lib("common_test/include/ct.hrl").
+-include("ssl_alert.hrl").
 -include("ssl_internal.hrl").
 -include("tls_handshake.hrl").
 -include_lib("public_key/include/public_key.hrl").
@@ -41,7 +42,7 @@ all() -> [decode_hello_handshake,
 	  decode_empty_server_sni_correctly,
 	  select_proper_tls_1_2_rsa_default_hashsign,
 	  ignore_hassign_extension_pre_tls_1_2,
-          unorded_chain].
+	  unorded_chain, signature_algorithms].
 
 %%--------------------------------------------------------------------
 init_per_suite(Config) ->
@@ -55,7 +56,9 @@ init_per_group(_GroupName, Config) ->
 end_per_group(_,Config) ->
     Config.
 
-init_per_testcase(ignore_hassign_extension_pre_tls_1_2, Config0) ->
+init_per_testcase(TC, Config0) when
+      TC =:= ignore_hassign_extension_pre_tls_1_2 orelse
+      TC =:= signature_algorithms ->
     catch crypto:stop(),
     try crypto:start() of
 	ok ->
@@ -187,6 +190,55 @@ unorded_chain(Config) when is_list(Config) ->
     {ok, _, OrderedChain} = 
         ssl_certificate:certificate_chain(PeerCert, ets:new(foo, []), ExtractedCerts, UnordedChain).
 
+
+signature_algorithms(Config) ->
+    Opts = proplists:get_value(server_opts, Config),
+    CertFile = proplists:get_value(certfile, Opts),
+    io:format("Cert = ~p~n", [CertFile]),
+    [{_, Cert, _}] = ssl_test_lib:pem_to_der(CertFile),
+    HashSigns0 = #hash_sign_algos{
+                   hash_sign_algos = [{sha512, rsa},
+                                      {sha, dsa},
+                                      {sha, rsa}]},
+    Schemes0 = #signature_scheme_list{
+                 signature_scheme_list = [rsa_pkcs1_sha1,
+                                          ecdsa_sha1]},
+    {sha512, rsa} = ssl_handshake:select_hashsign(
+                      {HashSigns0, Schemes0},
+                      Cert, ecdhe_rsa,
+                      tls_v1:default_signature_algs({3,3}),
+                      {3,3}),
+    HashSigns1 = #hash_sign_algos{
+                    hash_sign_algos = [{sha, dsa},
+                                      {sha, rsa}]},
+    {sha, rsa} = ssl_handshake:select_hashsign(
+                      {HashSigns1, Schemes0},
+                      Cert, ecdhe_rsa,
+                      tls_v1:default_signature_algs({3,3}),
+                   {3,3}),
+    Schemes1 = #signature_scheme_list{
+                  signature_scheme_list = [rsa_pkcs1_sha256,
+                                           ecdsa_sha1]},
+    %% Signature not supported
+    #alert{} = ssl_handshake:select_hashsign(
+                 {HashSigns1, Schemes1},
+                 Cert, ecdhe_rsa,
+                 tls_v1:default_signature_algs({3,3}),
+                 {3,3}),
+    %% No scheme, hashsign is used
+    {sha, rsa} = ssl_handshake:select_hashsign(
+                   {HashSigns1, undefined},
+                   Cert, ecdhe_rsa,
+                   tls_v1:default_signature_algs({3,3}),
+                   {3,3}),
+    HashSigns2 = #hash_sign_algos{
+                    hash_sign_algos = [{sha, dsa}]},
+    %% Signature not supported
+    #alert{} = ssl_handshake:select_hashsign(
+                 {HashSigns2, Schemes1},
+                 Cert, ecdhe_rsa,
+                 tls_v1:default_signature_algs({3,3}),
+                 {3,3}).
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------


### PR DESCRIPTION
Implement handling of the signature algorithms extension described by RFC 8446. This pull request updates the behavior of legacy TLS versions to align them with RFC 8446 (TLS 1.3) and RFC 5246 (TLS 1.2).
