### PR TITLE
Introduce the no_spawn_compiler_process option

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -415,6 +415,17 @@ module.beam: module.erl \
               is not documented, and can change between releases.</p>
           </item>
 
+          <tag><c>no_spawn_compiler_process</c></tag>
+          <item>
+            <p>By default, all code is compiled in a separate process
+              which is terminated at the end of compilation. However,
+              some tools, like Dialyzer or compilers for other BEAM languages,
+              may already manage their own worker processes and spawning
+              an extra process may slow the compilation down.
+              In such scenarios, you can pass this option to stop the
+              compiler from spawning an additional process.</p>
+          </item>
+
           <tag><c>no_strict_record_tests</c></tag>
           <item>
             <p>This option is not recommended.</p>

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -210,8 +210,11 @@ do_compile(Input, Opts0) ->
                               {error,Reason}
                       end
              end,
-    %% Dialyzer has already spawned workers.
-    case lists:member(dialyzer, Opts) of
+    %% Some tools, like Dialyzer, has already spawned workers
+    %% and spawning extra workers actually slow the compilation
+    %% down instead of speeding it up, so we provide a mechanism
+    %% to bypass the compiler process.
+    case lists:member(no_spawn_compiler_process, Opts) of
         true ->
             IntFun();
         false ->

--- a/lib/dialyzer/src/dialyzer_utils.erl
+++ b/lib/dialyzer/src/dialyzer_utils.erl
@@ -643,7 +643,7 @@ sets_filter([Mod|Mods], ExpTypes) ->
 src_compiler_opts() ->
   [no_copt, to_core, binary, return_errors,
    no_inline, strict_record_tests, strict_record_updates,
-   dialyzer].
+   dialyzer, no_spawn_compiler_process].
 
 -spec format_errors([{module(), string()}]) -> [string()].
 


### PR DESCRIPTION
By default, all code is compiled in a separate process
which is terminated at the end of compilation. However,
some tools, like Dialyzer or compilers for other BEAM languages,
may already manage their own worker processes and spawning
an extra process may slow the compilation down.
In such scenarios, you can pass this option to stop the
compiler from spawning an additional process.

This is particularly important for compilers emitting core code
as the annotation in core may end-up allocating a lot of memory
when copied to a new process.

This generalizes commit 657760e18087b0cdbaecc5e96e46f6f66bc9497a.

Thanks to @bjorng for helping me find the root cause for the
higher memory usage and slower compilation times.