### PR TITLE
Relay set/update indicator to handler callback changing_config

### DIFF
--- a/lib/kernel/doc/src/logger.xml
+++ b/lib/kernel/doc/src/logger.xml
@@ -1123,6 +1123,26 @@ logger:set_process_metadata(maps:merge(logger:get_process_metadata(), Meta)).
     </func>
 
     <func>
+      <name>HModule:filter_config(Config) -> FilteredConfig</name>
+      <fsummary>Remove internal data from configuration.</fsummary>
+      <type>
+	<v>Config = FilteredConfig =
+	  <seealso marker="#type-handler_config">handler_config()</seealso></v>
+      </type>
+      <desc>
+	<p>This callback function is optional.</p>
+	<p>The function is called when one of the Logger API functions
+	  for fetching the handler configuration is called, for
+	  example
+	  <seealso marker="#get_handler_config-1">
+	    <c>logger:get_handler_config/1</c></seealso>.</p>
+	<p>It allows the handler to remove internal data fields from
+	  its configuration data before it is returned to the
+	  caller.</p>
+      </desc>
+    </func>
+
+    <func>
       <name>HModule:log(LogEvent, Config) -> void()</name>
       <fsummary>Log the given log event.</fsummary>
       <type>

--- a/lib/kernel/doc/src/logger.xml
+++ b/lib/kernel/doc/src/logger.xml
@@ -748,6 +748,14 @@ start(_, []) ->
           exists, its associated value will be changed
           to the given value. If it does not exist, it will
           be added.</p>
+	<p>If the value is incomplete, which for example can be the
+	  case for the <c>config</c> key, it is up to the handler
+	  implementation how the unspecified parts are set. For all
+	  handlers in the Kernel application, unspecified data for
+	  the <c>config</c> key is set to default values. To update
+	  only specified data, and keep the existing configuration for
+	  the rest, use <seealso marker="#update_handler_config-3">
+	    <c>update_handler_config/3</c></seealso>.</p>
 	<p>See the definition of
 	  the <seealso marker="#type-handler_config">
 	    <c>handler_config()</c></seealso> type for more
@@ -933,6 +941,42 @@ logger:set_handler_config(HandlerId, maps:merge(Old, Config)).
     </func>
 
     <func>
+      <name name="update_handler_config" arity="3" clause_i="1"/>
+      <name name="update_handler_config" arity="3" clause_i="2"/>
+      <name name="update_handler_config" arity="3" clause_i="3"/>
+      <name name="update_handler_config" arity="3" clause_i="4"/>
+      <name name="update_handler_config" arity="3" clause_i="5"/>
+      <fsummary>Add or update configuration data for the specified
+        handler.</fsummary>
+      <type variable="HandlerId"/>
+      <type variable="Level" name_i="1"/>
+      <type variable="FilterDefault" name_i="2"/>
+      <type variable="Filters" name_i="3"/>
+      <type variable="Formatter" name_i="4"/>
+      <type variable="Config" name_i="5"/>
+      <type variable="Return"/>
+      <desc>
+        <p>Add or update configuration data for the specified
+          handler. If the given <c><anno>Key</anno></c> already
+          exists, its associated value will be changed
+          to the given value. If it does not exist, it will
+          be added.</p>
+	<p>If the value is incomplete, which for example can be the
+	  case for the <c>config</c> key, it is up to the handler
+	  implementation how the unspecified parts are set. For all
+	  handlers in the Kernel application, unspecified data for
+	  the <c>config</c> key is not changed. To reset unspecified
+	  data to default values,
+	  use <seealso marker="#set_handler_config-3">
+	    <c>set_handler_config/3</c></seealso>.</p>
+	<p>See the definition of
+	  the <seealso marker="#type-handler_config">
+	    <c>handler_config()</c></seealso> type for more
+	  information about the different parameters.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="update_primary_config" arity="1"/>
       <fsummary>Update primary configuration data for Logger.</fsummary>
       <desc>
@@ -1063,7 +1107,7 @@ logger:set_process_metadata(maps:merge(logger:get_process_metadata(), Meta)).
 	  <seealso marker="#set_handler_config-2">
 	    <c>set_handler_config/2,3</c></seealso>, and <c>update</c>
 	  if it originates from <seealso marker="#update_handler_config-2">
-	    <c>update_handler_config/2</c></seealso>. The handler can
+	    <c>update_handler_config/2,3</c></seealso>. The handler can
 	  use this parameteter to decide how to update the value of
 	  the <c>config</c> field, that is, the handler specific
 	  configuration data. Typically, if <c>SetOrUpdate</c>
@@ -1150,7 +1194,7 @@ logger:set_process_metadata(maps:merge(logger:get_process_metadata(), Meta)).
 	  <item><seealso marker="logger#set_handler_config-2">
 	      <c>logger:set_handler_config/2,3</c></seealso></item>
 	  <item><seealso marker="logger#update_handler_config-2">
-	      <c>logger:updata_handler_config/2</c></seealso></item>
+	      <c>logger:updata_handler_config/2,3</c></seealso></item>
 	  <item><seealso marker="logger#update_formatter_config-2">
 	      <c>logger:update_formatter_config/2</c></seealso></item>
 	</list>

--- a/lib/kernel/doc/src/logger.xml
+++ b/lib/kernel/doc/src/logger.xml
@@ -1041,10 +1041,11 @@ logger:set_process_metadata(maps:merge(logger:get_process_metadata(), Meta)).
     </func>
 
     <func>
-      <name>HModule:changing_config(Config1, Config2) -> {ok, Config3} | {error, Reason}</name>
+      <name>HModule:changing_config(SetOrUpdate, OldConfig, NewConfig) -> {ok, Config} | {error, Reason}</name>
       <fsummary>The configuration for this handler is about to change.</fsummary>
       <type>
-	<v>Config1 = Config2 = Config3 =
+	<v>SetOrUpdate = set | update</v>
+	<v>OldConfig = NewConfig = Config =
 	  <seealso marker="#type-handler_config">handler_config()</seealso></v>
 	<v>Reason = term()</v>
       </type>
@@ -1053,12 +1054,25 @@ logger:set_process_metadata(maps:merge(logger:get_process_metadata(), Meta)).
 	<p>The function is called on a temporary process when the
 	  configuration for a handler is about to change. The purpose
 	  is to verify and act on the new configuration.</p>
-	<p><c>Config1</c> is the existing configuration
-	  and <c>Config2</c> is the new configuration.</p>
+	<p><c>OldConfig</c> is the existing configuration
+	  and <c>NewConfig</c> is the new configuration.</p>
 	<p>The handler identity is associated with the <c>id</c> key
-	  in <c>Config1</c>.</p>
+	  in <c>OldConfig</c>.</p>
+	<p><c>SetOrUpdate</c> has the value <c>set</c> if the
+	  configuration change originates from a call to
+	  <seealso marker="#set_handler_config-2">
+	    <c>set_handler_config/2,3</c></seealso>, and <c>update</c>
+	  if it originates from <seealso marker="#update_handler_config-2">
+	    <c>update_handler_config/2</c></seealso>. The handler can
+	  use this parameteter to decide how to update the value of
+	  the <c>config</c> field, that is, the handler specific
+	  configuration data. Typically, if <c>SetOrUpdate</c>
+	  equals <c>set</c>, values that are not specified must be
+	  given their default values. If <c>SetOrUpdate</c>
+	  equals <c>update</c>, the values found in <c>OldConfig</c>
+	  must be used instead.</p>
 	<p>If everything succeeds, the callback function must return a
-	  possibly adjusted configuration in <c>{ok,Config3}</c>.</p>
+	  possibly adjusted configuration in <c>{ok,Config}</c>.</p>
 	<p>If the configuration is faulty, the callback function must
 	  return <c>{error,Reason}</c>.</p>
       </desc>

--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -384,7 +384,7 @@ logger:debug(#{got => connection_request, id => Id, state => State},
 
     <p>In addition to the mandatory callback function <c>log/2</c>, a
       handler module can export the optional callback
-      functions <c>adding_handler/1</c>, <c>changing_config/2</c>
+      functions <c>adding_handler/1</c>, <c>changing_config/3</c>
       and <c>removing_handler/1</c>. See
       section <seealso marker="logger#handler_callback_functions">Handler
       Callback Functions</seealso> in the logger(3) manual page for
@@ -1024,7 +1024,7 @@ ok</pre>
     <list>
       <item><c>adding_handler(Config)</c></item>
       <item><c>removing_handler(Config)</c></item>
-      <item><c>changing_config(OldConfig, NewConfig)</c></item>
+      <item><c>changing_config(SetOrUpdate, OldConfig, NewConfig)</c></item>
     </list>
     <p>When a handler is added, by for example a call
       to <seealso marker="logger#add_handler-3">
@@ -1045,7 +1045,7 @@ ok</pre>
       or <seealso marker="logger#update_handler_config/2">
 	<c>logger:update_handler_config/2</c></seealso> is called,
       Logger
-      calls <c>HModule:changing_config(OldConfig, NewConfig)</c>. If
+      calls <c>HModule:changing_config(SetOrUpdate, OldConfig, NewConfig)</c>. If
       this function returns <c>{ok,NewConfig1}</c>, Logger
       writes <c>NewConfig1</c> to the configuration database.</p>
 

--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -555,7 +555,7 @@ logger:debug(#{got => connection_request, id => Id, state => State},
 	<item><seealso marker="logger#set_handler_config-2">
 	    <c>set_handler_config/2,3</c></seealso></item>
 	<item><seealso marker="logger#update_handler_config-2">
-	    <c>update_handler_config/2</c></seealso></item>
+	    <c>update_handler_config/2,3</c></seealso></item>
 	<item><seealso marker="logger#add_handler_filter-3">
 	    <c>add_handler_filter/3</c></seealso></item>
 	<item><seealso marker="logger#remove_handler_filter-2">
@@ -704,9 +704,13 @@ logger:debug(#{got => connection_request, id => Id, state => State},
           <item>
 	    <p>If <c>HandlerId</c> is <c>default</c>, then this entry
 	      modifies the default handler, equivalent to calling</p>
-	    <pre><seealso marker="logger#set_handler_config-2">
-		logger:set_handler_config(default, Module, HandlerConfig)
-	      </seealso></pre>
+	    <pre><seealso marker="logger#remove_handler-1">
+		logger:remove_handler(default)
+	    </seealso></pre>
+	    <p>followed by</p>
+	    <pre><seealso marker="logger#add_handler-3">
+		logger:add_handler(default, Module, HandlerConfig)
+	    </seealso></pre>
 	    <p>For all other values of <c>HandlerId</c>, this entry
 	      adds a new handler, equivalent to calling</p>
 	    <pre><seealso marker="logger:add_handler/3">
@@ -1043,7 +1047,7 @@ ok</pre>
     <p>When <seealso marker="logger#set_handler_config-2">
 	<c>logger:set_handler_config/2,3</c></seealso>
       or <seealso marker="logger#update_handler_config/2">
-	<c>logger:update_handler_config/2</c></seealso> is called,
+	<c>logger:update_handler_config/2,3</c></seealso> is called,
       Logger
       calls <c>HModule:changing_config(SetOrUpdate, OldConfig, NewConfig)</c>. If
       this function returns <c>{ok,NewConfig1}</c>, Logger

--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -384,8 +384,8 @@ logger:debug(#{got => connection_request, id => Id, state => State},
 
     <p>In addition to the mandatory callback function <c>log/2</c>, a
       handler module can export the optional callback
-      functions <c>adding_handler/1</c>, <c>changing_config/3</c>
-      and <c>removing_handler/1</c>. See
+      functions <c>adding_handler/1</c>, <c>changing_config/3</c>,
+      <c>filter_config/1</c>, and <c>removing_handler/1</c>. See
       section <seealso marker="logger#handler_callback_functions">Handler
       Callback Functions</seealso> in the logger(3) manual page for
       more information about these function.</p>
@@ -1029,6 +1029,7 @@ ok</pre>
       <item><c>adding_handler(Config)</c></item>
       <item><c>removing_handler(Config)</c></item>
       <item><c>changing_config(SetOrUpdate, OldConfig, NewConfig)</c></item>
+      <item><c>filter_config(Config)</c></item>
     </list>
     <p>When a handler is added, by for example a call
       to <seealso marker="logger#add_handler-3">
@@ -1052,6 +1053,13 @@ ok</pre>
       calls <c>HModule:changing_config(SetOrUpdate, OldConfig, NewConfig)</c>. If
       this function returns <c>{ok,NewConfig1}</c>, Logger
       writes <c>NewConfig1</c> to the configuration database.</p>
+    <p>When <seealso marker="logger#get_config-0">
+	<c>logger:get_config/0</c></seealso> or
+      <seealso marker="logger#get_handler_config-0">
+	<c>logger:get_handler_config/0,1</c></seealso> is called,
+      Logger calls <c>HModule:filter_config(Config)</c>. This function
+      must return the handler configuration where internal data is
+      removed.</p>
 
     <p>A simple handler that prints to the terminal can be implemented
       as follows:</p>

--- a/lib/kernel/doc/src/logger_disk_log_h.xml
+++ b/lib/kernel/doc/src/logger_disk_log_h.xml
@@ -66,6 +66,10 @@
 	corresponds to the <c>name</c> property in the
 	<seealso marker="disk_log#open-1"><c>dlog_option()</c></seealso>
 	datatype.</p>
+	<p>The value is set when the handler is added, and it can not
+	  be changed in runtime.</p>
+	<p>Defaults to the same name as the handler identity, in the
+	  current directory.</p>
       </item>
       <tag><c>type</c></tag>
       <item>
@@ -73,6 +77,8 @@
 	corresponds to the <c>type</c> property in the
 	<seealso marker="disk_log#open-1"><c>dlog_option()</c></seealso>
 	datatype.</p>
+	<p>The value is set when the handler is added, and it can not
+	  be changed in runtime.</p>
 	<p>Defaults to <c>wrap</c>.</p>
       </item>
       <tag><c>max_no_files</c></tag>
@@ -82,6 +88,8 @@
 	corresponds to the <c>MaxNoFiles</c> element in the <c>size</c> property in the
 	<seealso marker="disk_log#open-1"><c>dlog_option()</c></seealso>
 	datatype.</p>
+	<p>The value is set when the handler is added, and it can not
+	  be changed in runtime.</p>
 	<p>Defaults to <c>10</c>.</p>
 	<p>The setting has no effect on a halt log.</p>
       </item>
@@ -93,6 +101,8 @@
 	corresponds to the <c>MaxNoBytes</c> element in the <c>size</c> property in the
 	<seealso marker="disk_log#open-1"><c>dlog_option()</c></seealso>
 	datatype.</p>
+	<p>The value is set when the handler is added, and it can not
+	  be changed in runtime.</p>
 	<p>Defaults to <c>1048576</c> bytes for a wrap log, and
 	<c>infinity</c> for a halt log.</p>
       </item>

--- a/lib/kernel/doc/src/logger_std_h.xml
+++ b/lib/kernel/doc/src/logger_std_h.xml
@@ -74,7 +74,9 @@
 	  circular logging. Use the disk_log handler,
 	  <seealso marker="logger_disk_log_h"><c>logger_disk_log_h</c></seealso>,
 	  for this.</p>
-	<p> Defaults to <c>standard_io</c>.</p>
+	<p>The value is set when the handler is added, and it can not
+	  be changed in runtime.</p>
+	<p>Defaults to <c>standard_io</c>.</p>
       </item>
       <tag><c>filesync_repeat_interval</c></tag>
       <item>

--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -43,7 +43,8 @@
          get_module_level/0, get_module_level/1,
          set_primary_config/1, set_primary_config/2,
          set_handler_config/2, set_handler_config/3,
-         update_primary_config/1, update_handler_config/2,
+         update_primary_config/1,
+         update_handler_config/2, update_handler_config/3,
          update_formatter_config/2, update_formatter_config/3,
          get_primary_config/0, get_handler_config/1,
          get_handler_config/0, get_handler_ids/0, get_config/0,
@@ -422,6 +423,29 @@ set_handler_config(HandlerId,Config) ->
       Config :: primary_config().
 update_primary_config(Config) ->
     logger_server:update_config(primary,Config).
+
+-spec update_handler_config(HandlerId,level,Level) -> Return when
+      HandlerId :: handler_id(),
+      Level :: level() | all | none,
+      Return :: ok | {error,term()};
+                        (HandlerId,filter_default,FilterDefault) -> Return when
+      HandlerId :: handler_id(),
+      FilterDefault :: log | stop,
+      Return :: ok | {error,term()};
+                        (HandlerId,filters,Filters) -> Return when
+      HandlerId :: handler_id(),
+      Filters :: [{filter_id(),filter()}],
+      Return :: ok | {error,term()};
+                        (HandlerId,formatter,Formatter) -> Return when
+      HandlerId :: handler_id(),
+      Formatter :: {module(), formatter_config()},
+      Return :: ok | {error,term()};
+                        (HandlerId,config,Config) -> Return when
+      HandlerId :: handler_id(),
+      Config :: term(),
+      Return :: ok | {error,term()}.
+update_handler_config(HandlerId,Key,Value) ->
+    logger_server:update_config(HandlerId,Key,Value).
 
 -spec update_handler_config(HandlerId,Config) -> ok | {error,term()} when
       HandlerId :: handler_id(),

--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -463,7 +463,14 @@ get_primary_config() ->
       HandlerId :: handler_id(),
       Config :: handler_config().
 get_handler_config(HandlerId) ->
-    logger_config:get(?LOGGER_TABLE,HandlerId).
+    case logger_config:get(?LOGGER_TABLE,HandlerId) of
+        {ok,#{module:=Module}=Config} ->
+            {ok,try Module:filter_config(Config)
+                catch _:_ -> Config
+                end};
+        Error ->
+            Error
+    end.
 
 -spec get_handler_config() -> [Config] when
       Config :: handler_config().

--- a/lib/kernel/src/logger_disk_log_h.erl
+++ b/lib/kernel/src/logger_disk_log_h.erl
@@ -33,7 +33,8 @@
          terminate/2, code_change/3]).
 
 %% logger callbacks
--export([log/2, adding_handler/1, removing_handler/1, changing_config/3]).
+-export([log/2, adding_handler/1, removing_handler/1, changing_config/3,
+         filter_config/1]).
 
 %% handler internal
 -export([log_handler_info/4]).
@@ -246,6 +247,11 @@ log(LogEvent, Config = #{id := Name,
     true = is_process_alive(HPid),
     Bin = logger_h_common:log_to_binary(LogEvent, Config),
     logger_h_common:call_cast_or_drop(Name, HPid, ModeTab, Bin).
+
+%%%-----------------------------------------------------------------
+%%% Remove internal fields from configuration
+filter_config(#{config:=HConfig}=Config) ->
+    Config#{config=>maps:without([handler_pid,mode_tab],HConfig)}.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/lib/kernel/src/logger_h_common.erl
+++ b/lib/kernel/src/logger_h_common.erl
@@ -306,8 +306,11 @@ stop_or_restart(Name, {shutdown,Reason={overloaded,_Name,_QLen,_Mem}},
                         exit(HandlerPid, kill)
                 end,
                 case ConfigResult of
-                    {ok,#{module:=HMod}=HConfig} when is_integer(RestartAfter) ->
+                    {ok,#{module:=HMod}=HConfig0} when is_integer(RestartAfter) ->
                         _ = logger:remove_handler(Name),
+                        HConfig = try HMod:filter_config(HConfig0)
+                                  catch _:_ -> HConfig0
+                                  end,
                         _ = timer:apply_after(RestartAfter, logger, add_handler,
                                               [Name,HMod,HConfig]);
                     {ok,_} ->

--- a/lib/kernel/src/logger_server.erl
+++ b/lib/kernel/src/logger_server.erl
@@ -27,7 +27,8 @@
          add_filter/2, remove_filter/2,
          set_module_level/2, unset_module_level/0,
          unset_module_level/1, cache_module_level/1,
-         set_config/2, set_config/3, update_config/2,
+         set_config/2, set_config/3,
+         update_config/2, update_config/3,
          update_formatter_config/2]).
 
 %% gen_server callbacks
@@ -116,6 +117,14 @@ set_config(Owner,Config) ->
     case sanity_check(Owner,Config) of
         ok ->
             call({change_config,set,Owner,Config});
+        Error ->
+            Error
+    end.
+
+update_config(Owner,Key,Value) ->
+    case sanity_check(Owner,Key,Value) of
+        ok ->
+            call({change_config,update,Owner,Key,Value});
         Error ->
             Error
     end.

--- a/lib/kernel/src/logger_std_h.erl
+++ b/lib/kernel/src/logger_std_h.erl
@@ -35,7 +35,8 @@
          terminate/2, code_change/3]).
 
 %% logger callbacks
--export([log/2, adding_handler/1, removing_handler/1, changing_config/3]).
+-export([log/2, adding_handler/1, removing_handler/1, changing_config/3,
+         filter_config/1]).
 
 %% handler internal
 -export([log_handler_info/4]).
@@ -229,6 +230,11 @@ log(LogEvent, Config = #{id := Name,
     true = is_process_alive(HPid),
     Bin = logger_h_common:log_to_binary(LogEvent, Config),
     logger_h_common:call_cast_or_drop(Name, HPid, ModeTab, Bin).
+
+%%%-----------------------------------------------------------------
+%%% Remove internal fields from configuration
+filter_config(#{config:=HConfig}=Config) ->
+    Config#{config=>maps:without([handler_pid,mode_tab],HConfig)}.
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -246,6 +246,18 @@ change_config(_Config) ->
     {ok,C4} = logger:get_handler_config(h1),
     C4 = C3#{custom:=new_custom},
 
+    %% Change handler config: Id and module can not be changed
+    {error,{illegal_config_change,Old,New}} =
+        logger:set_handler_config(h1,id,newid),
+    %% Check that only the faulty field is included in return
+    [{id,h1}] = maps:to_list(Old),
+    [{id,newid}] = maps:to_list(New),
+    %% Check that both fields are included when both are changed
+    {error,{illegal_config_change,
+            #{id:=h1,module:=?MODULE},
+            #{id:=newid,module:=newmodule}}} =
+        logger:set_handler_config(h1,#{id=>newid,module=>newmodule}),
+
     %% Change primary config: Single key
     PConfig0 = logger:get_primary_config(),
     ok = logger:set_primary_config(level,warning),

--- a/lib/kernel/test/logger_disk_log_h_SUITE.erl
+++ b/lib/kernel/test/logger_disk_log_h_SUITE.erl
@@ -92,6 +92,7 @@ all() ->
      disk_log_opts,
      default_formatter,
      logging,
+     filter_config,
      errors,
      formatter_fail,
      config_fail,
@@ -301,6 +302,20 @@ logging(Config) ->
 logging(cleanup, _Config) ->
     Name = list_to_atom(lists:concat([?FUNCTION_NAME,"_1"])),
     remove_and_stop(Name).
+
+filter_config(_Config) ->
+    ok = logger:add_handler(?MODULE,logger_disk_log_h,#{}),
+    {ok,#{config:=HConfig}=Config} = logger:get_handler_config(?MODULE),
+    HConfig = maps:without([handler_pid,mode_tab],HConfig),
+
+    FakeFullHConfig = HConfig#{handler_pid=>self(),mode_tab=>erlang:make_ref()},
+    #{config:=HConfig} =
+        logger_disk_log_h:filter_config(Config#{config=>FakeFullHConfig}),
+    ok.
+
+filter_config(cleanup,_Config) ->
+    logger:remove_handler(?MODULE),
+    ok.
 
 errors(Config) ->
     PrivDir = ?config(priv_dir,Config),

--- a/lib/kernel/test/logger_std_h_SUITE.erl
+++ b/lib/kernel/test/logger_std_h_SUITE.erl
@@ -319,11 +319,10 @@ config_fail(_Config) ->
     ok = logger:add_handler(?MODULE,logger_std_h,
                             #{filter_default=>log,
                               formatter=>{?MODULE,self()}}),
-    {error,{illegal_config_change,_,_}} =
+    {error,{illegal_config_change,#{config:=#{type:=_}},#{config:=#{type:=_}}}} =
         logger:set_handler_config(?MODULE,config,
                                   #{type=>{file,"file"}}),
-    {error,{illegal_config_change,_,_}} =
-        logger:set_handler_config(?MODULE,id,bad),
+
     {error,{invalid_levels,_}} =
         logger:set_handler_config(?MODULE,config,
                                   #{sync_mode_qlen=>100,
@@ -331,6 +330,15 @@ config_fail(_Config) ->
     {error,{invalid_config,logger_std_h,{filesync_rep_int,2000}}} =
         logger:set_handler_config(?MODULE, config,
                                   #{filesync_rep_int => 2000}),
+
+    %% Read-only fields may (accidentially) be included in the change,
+    %% but it won't take effect
+    {ok,C} = logger:get_handler_config(?MODULE),
+    ok = logger:set_handler_config(?MODULE,config,
+                                   #{handler_pid=>self(),
+                                     mode_tab=>erlang:make_ref()}),
+    {ok,C} = logger:get_handler_config(?MODULE),
+
     ok.
 
 config_fail(cleanup,_Config) ->
@@ -457,8 +465,25 @@ reconfig(Config) ->
       overload_kill_qlen := ?OVERLOAD_KILL_QLEN,
       overload_kill_mem_size := ?OVERLOAD_KILL_MEM_SIZE,
       overload_kill_restart_after := ?OVERLOAD_KILL_RESTART_AFTER,
-      filesync_repeat_interval := ?FILESYNC_REPEAT_INTERVAL} =
+      filesync_repeat_interval := ?FILESYNC_REPEAT_INTERVAL} = DefaultInfo =
         logger_std_h:info(?MODULE),
+
+    {ok,
+     #{config:=
+           #{type := standard_io,
+             sync_mode_qlen := ?SYNC_MODE_QLEN,
+             drop_mode_qlen := ?DROP_MODE_QLEN,
+             flush_qlen := ?FLUSH_QLEN,
+             burst_limit_enable := ?BURST_LIMIT_ENABLE,
+             burst_limit_max_count := ?BURST_LIMIT_MAX_COUNT,
+             burst_limit_window_time := ?BURST_LIMIT_WINDOW_TIME,
+             overload_kill_enable := ?OVERLOAD_KILL_ENABLE,
+             overload_kill_qlen := ?OVERLOAD_KILL_QLEN,
+             overload_kill_mem_size := ?OVERLOAD_KILL_MEM_SIZE,
+             overload_kill_restart_after := ?OVERLOAD_KILL_RESTART_AFTER,
+             filesync_repeat_interval := ?FILESYNC_REPEAT_INTERVAL} =
+           DefaultHConf}}
+        = logger:get_handler_config(?MODULE),
 
     ok = logger:set_handler_config(?MODULE, config,
                                    #{sync_mode_qlen => 1,
@@ -485,7 +510,77 @@ reconfig(Config) ->
       overload_kill_qlen := 100000,
       overload_kill_mem_size := 10000000,
       overload_kill_restart_after := infinity,
-      filesync_repeat_interval := no_repeat} = logger_std_h:info(?MODULE),
+      filesync_repeat_interval := no_repeat} = Info = logger_std_h:info(?MODULE),
+
+    {ok,#{config :=
+              #{type := standard_io,
+                sync_mode_qlen := 1,
+                drop_mode_qlen := 2,
+                flush_qlen := 3,
+                burst_limit_enable := false,
+                burst_limit_max_count := 10,
+                burst_limit_window_time := 10,
+                overload_kill_enable := true,
+                overload_kill_qlen := 100000,
+                overload_kill_mem_size := 10000000,
+                overload_kill_restart_after := infinity,
+                filesync_repeat_interval := no_repeat} = HConf}} =
+        logger:get_handler_config(?MODULE),
+
+    ok = logger:update_handler_config(?MODULE, config,
+                                      #{flush_qlen => ?FLUSH_QLEN}),
+    {ok,#{config:=C1}} = logger:get_handler_config(?MODULE),
+    ct:log("C1: ~p",[C1]),
+    C1 = HConf#{flush_qlen => ?FLUSH_QLEN},
+
+    ok = logger:set_handler_config(?MODULE, config, #{sync_mode_qlen => 1}),
+    {ok,#{config:=C2}} = logger:get_handler_config(?MODULE),
+    ct:log("C2: ~p",[C2]),
+    C2 = DefaultHConf#{sync_mode_qlen => 1},
+
+    ok = logger:set_handler_config(?MODULE, config, #{drop_mode_qlen => 100}),
+    {ok,#{config:=C3}} = logger:get_handler_config(?MODULE),
+    ct:log("C3: ~p",[C3]),
+    C3 = DefaultHConf#{drop_mode_qlen => 100},
+
+    ok = logger:update_handler_config(?MODULE, config, #{sync_mode_qlen => 1}),
+    {ok,#{config:=C4}} = logger:get_handler_config(?MODULE),
+    ct:log("C4: ~p",[C4]),
+    C4 = DefaultHConf#{sync_mode_qlen => 1,
+                       drop_mode_qlen => 100},
+
+    ok = logger:remove_handler(?MODULE),
+
+    File = filename:join(Dir,lists:concat([?FUNCTION_NAME,".log"])),
+    ok = logger:add_handler(?MODULE,
+                            logger_std_h,
+                            #{config => #{type => {file,File}},
+                              filter_default=>log,
+                              filters=>?DEFAULT_HANDLER_FILTERS([?MODULE]),
+                              formatter=>{?MODULE,self()}}),
+
+    {ok,#{config:=#{filesync_repeat_interval:=FSI}=FileHConfig}} =
+        logger:get_handler_config(?MODULE),
+    ok = logger:update_handler_config(?MODULE,config,
+                                      #{filesync_repeat_interval=>FSI+2000}),
+    {ok,#{config:=C5}} = logger:get_handler_config(?MODULE),
+    ct:log("C5: ~p",[C5]),
+    C5 = FileHConfig#{filesync_repeat_interval=>FSI+2000},
+
+    %% You are not allowed to actively set 'type' in runtime, since
+    %% this is a write once field.
+    {error, {illegal_config_change,_,_}} =
+        logger:set_handler_config(?MODULE,config,#{type=>standard_io}),
+    {ok,#{config:=C6}} = logger:get_handler_config(?MODULE),
+    ct:log("C6: ~p",[C6]),
+    C6 = C5,
+
+    %%  ... but if you don't specify 'type', then set_handler_config shall
+    %%  NOT reset it to its default value
+    ok = logger:set_handler_config(?MODULE,config,#{sync_mode_qlen=>1}),
+    {ok,#{config:=C7}} = logger:get_handler_config(?MODULE),
+    ct:log("C7: ~p",[C7]),
+    C7 = FileHConfig#{sync_mode_qlen=>1},
     ok.
 
 reconfig(cleanup, _Config) ->
@@ -561,8 +656,8 @@ sync(Config) ->
 
     %% check that if there's no repeated filesync active,
     %% a filesync is still performed when handler goes idle
-    logger:set_handler_config(?MODULE, config,
-                              #{filesync_repeat_interval => no_repeat}),
+    ok = logger:update_handler_config(?MODULE, config,
+                                      #{filesync_repeat_interval => no_repeat}),
     no_repeat = maps:get(filesync_repeat_interval, logger_std_h:info(?MODULE)),
     %% The following timer is to make sure the time from last log
     %% ("second") to next ("third") is long enough, so the a flush is
@@ -592,12 +687,12 @@ sync(Config) ->
     start_tracer([{logger_std_h,handle_cast,2}],
                  [OneSync || _ <- lists:seq(1, 1 + trunc(WaitT/SyncInt))]),
 
-    logger:set_handler_config(?MODULE, config,
-                              #{filesync_repeat_interval => SyncInt}),
+    ok = logger:update_handler_config(?MODULE, config,
+                                      #{filesync_repeat_interval => SyncInt}),
     SyncInt = maps:get(filesync_repeat_interval, logger_std_h:info(?MODULE)),
     timer:sleep(WaitT),
-    logger:set_handler_config(?MODULE, config,
-                              #{filesync_repeat_interval => no_repeat}),
+    ok = logger:update_handler_config(?MODULE, config,
+                                      #{filesync_repeat_interval => no_repeat}),
     check_tracer(100),
     ok.
 sync(cleanup, _Config) ->
@@ -652,7 +747,7 @@ sync_failure(Config) ->
     rpc:call(Node, ?MODULE, set_result, [file_datasync,ok]),
     
     SyncInt = 500,
-    ok = rpc:call(Node, logger, set_handler_config,
+    ok = rpc:call(Node, logger, update_handler_config,
                   [?STANDARD_HANDLER, config,
                    #{filesync_repeat_interval => SyncInt}]),
     Info = rpc:call(Node, logger_std_h, info, [?STANDARD_HANDLER]),
@@ -718,7 +813,7 @@ op_switch_to_sync_file(Config) ->
                                        drop_mode_qlen => NumOfReqs+1,
                                        flush_qlen => 2*NumOfReqs,
                                        burst_limit_enable => false}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     %%    TRecvPid = start_op_trace(),
     send_burst({n,NumOfReqs}, seq, {chars,79}, notice),
     Lines = count_lines(Log),
@@ -747,7 +842,7 @@ op_switch_to_sync_tty(Config) ->
                                        drop_mode_qlen => NumOfReqs+1,
                                        flush_qlen => 2*NumOfReqs,
                                        burst_limit_enable => false}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     send_burst({n,NumOfReqs}, seq, {chars,79}, notice),
     ok.
 op_switch_to_sync_tty(cleanup, _Config) ->
@@ -770,7 +865,7 @@ op_switch_to_drop_file(Config) ->
                                              flush_qlen =>
                                                  Procs*NumOfReqs*Bursts,
                                              burst_limit_enable => false}},
-                ok = logger:set_handler_config(?MODULE, NewHConfig),
+                ok = logger:update_handler_config(?MODULE, NewHConfig),
                 %% It sometimes happens that the handler gets the
                 %% requests in a slow enough pace so that dropping
                 %% never occurs. Therefore, lets generate a number of
@@ -807,7 +902,7 @@ op_switch_to_drop_tty(Config) ->
                                        flush_qlen =>
                                            Procs*NumOfReqs+1,
                                        burst_limit_enable => false}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     send_burst({n,NumOfReqs}, {spawn,Procs,0}, {chars,79}, notice),
     ok.
 op_switch_to_drop_tty(cleanup, _Config) ->
@@ -832,7 +927,7 @@ op_switch_to_flush_file(Config) ->
                                              drop_mode_qlen => 300,
                                              flush_qlen => 300,
                                              burst_limit_enable => false}},    
-                ok = logger:set_handler_config(?MODULE, NewHConfig),
+                ok = logger:update_handler_config(?MODULE, NewHConfig),
                 NumOfReqs = 1500,
                 Procs = 10,
                 Bursts = 10,
@@ -879,7 +974,7 @@ op_switch_to_flush_tty(Config) ->
                                        drop_mode_qlen => 100,
                                        flush_qlen => 100,
                                        burst_limit_enable => false}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     NumOfReqs = 1000,
     Procs = 100,
     send_burst({n,NumOfReqs}, {spawn,Procs,0}, {chars,79}, notice),
@@ -895,7 +990,7 @@ limit_burst_disabled(Config) ->
                                        burst_limit_window_time => 2000,
                                        drop_mode_qlen => 200,
                                        flush_qlen => 300}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     NumOfReqs = 100,
     send_burst({n,NumOfReqs}, seq, {chars,79}, notice),
     Logged = count_lines(Log),
@@ -915,7 +1010,7 @@ limit_burst_enabled_one(Config) ->
                                        burst_limit_window_time => 2000,
                                        drop_mode_qlen => 200,
                                        flush_qlen => 300}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     NumOfReqs = 100,
     send_burst({n,NumOfReqs}, seq, {chars,79}, notice),
     Logged = count_lines(Log),
@@ -936,7 +1031,7 @@ limit_burst_enabled_period(Config) ->
                                        burst_limit_window_time => BurstTWin,
                                        drop_mode_qlen => 20000,
                                        flush_qlen => 20001}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
 
     Windows = 3,
     Sent = send_burst({t,BurstTWin*Windows}, seq, {chars,79}, notice),
@@ -956,7 +1051,7 @@ kill_disabled(Config) ->
         HConfig#{config=>StdHConfig#{overload_kill_enable=>false,
                                      overload_kill_qlen=>10,
                                      overload_kill_mem_size=>100}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     NumOfReqs = 100,
     send_burst({n,NumOfReqs}, seq, {chars,79}, notice),
     Logged = count_lines(Log),
@@ -977,7 +1072,7 @@ qlen_kill_new(Config) ->
                                      overload_kill_qlen=>10,
                                      overload_kill_mem_size=>Mem0+50000,
                                      overload_kill_restart_after=>RestartAfter}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     MRef = erlang:monitor(process, Pid0),
     NumOfReqs = 100,
     Procs = 4,
@@ -1011,7 +1106,7 @@ qlen_kill_std(_Config) ->
     %% File = lists:concat([?MODULE,"_",?FUNCTION_NAME,".log"]),
     %% Log = filename:join(Dir, File),
     %% Node = start_std_h_on_new_node(Config, ?FUNCTION_NAME, Log),
-    %% ok = rpc:call(Node, logger, set_handler_config,
+    %% ok = rpc:call(Node, logger, update_handler_config,
     %%               [?STANDARD_HANDLER, config,
     %%                #{overload_kill_enable=>true,
     %%                  overload_kill_qlen=>10,
@@ -1028,7 +1123,7 @@ mem_kill_new(Config) ->
                                      overload_kill_qlen=>50000,
                                      overload_kill_mem_size=>Mem0+500,
                                      overload_kill_restart_after=>RestartAfter}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     MRef = erlang:monitor(process, Pid0),
     NumOfReqs = 100,
     Procs = 4,
@@ -1067,7 +1162,7 @@ restart_after(Config) ->
         HConfig#{config=>StdHConfig#{overload_kill_enable=>true,
                                      overload_kill_qlen=>10,
                                      overload_kill_restart_after=>infinity}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig1),
+    ok = logger:update_handler_config(?MODULE, NewHConfig1),
     MRef1 = erlang:monitor(process, whereis(h_proc_name())),
     %% kill handler
     send_burst({n,100}, {spawn,4,0}, {chars,79}, notice),
@@ -1082,14 +1177,15 @@ restart_after(Config) ->
             ct:pal("Handler state = ~p", [Info1]),
             ct:fail("Handler not dead! It should not have survived this!")
     end,
-    
+
     {Log,_,_} = start_handler(?MODULE, ?FUNCTION_NAME, Config),
     RestartAfter = ?OVERLOAD_KILL_RESTART_AFTER,
+
     NewHConfig2 =
         HConfig#{config=>StdHConfig#{overload_kill_enable=>true,
                                      overload_kill_qlen=>10,
                                      overload_kill_restart_after=>RestartAfter}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig2),
+    ok = logger:update_handler_config(?MODULE, NewHConfig2),
     Pid0 = whereis(h_proc_name()),
     MRef2 = erlang:monitor(process, Pid0),
     %% kill handler
@@ -1123,7 +1219,7 @@ handler_requests_under_load(Config) ->
                                        drop_mode_qlen => 1000,
                                        flush_qlen => 2000,
                                        burst_limit_enable => false}},
-    ok = logger:set_handler_config(?MODULE, NewHConfig),
+    ok = logger:update_handler_config(?MODULE, NewHConfig),
     Pid = spawn_link(fun() -> send_requests(?MODULE, 1, [{filesync,[]},
                                                          {info,[]},
                                                          {reset,[]},
@@ -1155,9 +1251,9 @@ send_requests(HName, TO, Reqs = [{Req,Res}|Rs]) ->
             Result =
                 case Req of
                     change_config ->
-                        logger:set_handler_config(HName, config,
-                                                  #{overload_kill_enable =>
-                                                        false});
+                        logger:update_handler_config(HName, config,
+                                                     #{overload_kill_enable =>
+                                                           false});
                     Func ->
                         logger_std_h:Func(HName)
                 end,

--- a/lib/kernel/test/logger_std_h_SUITE.erl
+++ b/lib/kernel/test/logger_std_h_SUITE.erl
@@ -108,6 +108,7 @@ all() ->
      add_remove_instance_file1,
      add_remove_instance_file2,
      default_formatter,
+     filter_config,
      errors,
      formatter_fail,
      config_fail,
@@ -202,6 +203,20 @@ default_formatter(_Config) ->
     ct:capture_stop(),
     [Msg] = ct:capture_get(),
     match = re:run(Msg,"=NOTICE REPORT====.*\n"++M1,[{capture,none}]),
+    ok.
+
+filter_config(_Config) ->
+    ok = logger:add_handler(?MODULE,logger_std_h,#{}),
+    {ok,#{config:=HConfig}=Config} = logger:get_handler_config(?MODULE),
+    HConfig = maps:without([handler_pid,mode_tab],HConfig),
+
+    FakeFullHConfig = HConfig#{handler_pid=>self(),mode_tab=>erlang:make_ref()},
+    #{config:=HConfig} =
+        logger_std_h:filter_config(Config#{config=>FakeFullHConfig}),
+    ok.
+
+filter_config(cleanup,_Config) ->
+    logger:remove_handler(?MODULE),
     ok.
 
 errors(Config) ->


### PR DESCRIPTION
### Background:
The existing functions logger:set_handler_config/2 and logger:update_handler_config/2 are both used for changing the configuration for a handler. The difference between them is in how they affect configuration parameters that are not specified in the input data:

* set_handler_config/2 resets unspecified parameters to their default values
* update_handler_config/2 leaves unspecified parameters unchanged.

This is all well, for all parameters except the 'config' key, which points out data that is specific to the handler implementation. For example, for the built-in handler logger_std_h, the config key is associated with a map that in turn can contain up to around 12 different associations. Logger itself has no knowledge of this data structure, and therefore calls the handler callback changing_config/2 to sanity check and verify that the change is ok. This callback, however, is exactly the same for the two functions above, meaning that the handler can not distinguish between a set and an update. Consequently, the current behavior is that the handler specific configuration is always 'updated', and there is no way to reset any part of it to its default values (except, of course, by explicitly specifying the default values as input data).

### Suggested solution implemented in this PR:

1. add a new parameter, SetOrUpdate, to the handler callback changing_config, so that
    *logger:set_handler_config/2 and set_handler_config/3 calls
     `HandlerModule:changing_config(set,OldConfig,NewConfig).`
    *logger:update_handler_config/2 calls
     `HandlerModule:changing_config(update,OldConfig,NewConfig).` 

2. add logger:update_handler_config/3, for completeness.

3. in logger_std_h and logger_disk_log_h, obey the new SetOrUpdate parameter in the changing_config callback so that logger:set_handler_config/2,3 causes unspecified fields in the handler specific configuration map to be reset to default values.

**Notice** also that in an attempt to follow the principle of least surprise, configuration parameters that are 'write-once' are never reset to default values by set_handler_config/2,3. A write-once parameter is, for example, the 'type' parameter for logger_std_h, which specifies if the log destination is a file or stdout/stderr. So, given that your default handler prints to a file, the following will NOT attempt to reset the 'type' field to standard_io:

`logger:set_handler_config(default,config,#{})`

but it will reset all other logger_std_h specific parameters (e.g. sync_mode_qlen, drop_mode_qlen, etc.).

### Backwards compatibility:

If changing_config/3 does not exist, but changing_config/2 does, then logger calls changing_config(OldConfig,NewConfig) as before.

### Filter config:

In addition to pure configuration data, logger_std_h and logger_disk_log_h both store some state data (read-only) in their configuration maps. These consist of the pid of the handler process, and a reference to an ets table related to overload protection. These parameters are needed on the client process for handling log events. They are, however, not configurable and do not really belong to the handler configuration. I have therefore added a new optional handler callback:

`filter_config(Config) -> FilteredConfig`

which is called from logger:get_config/0 and get_handler_config/0,1, with the handler data read from the configuration database. This allows the handler to clean up its data (i.e. remove internal data) before returning it from the Logger API.
