### PR TITLE
Allow changing source paths presented in stack traces

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -203,7 +203,8 @@
           <tag><c>deterministic</c></tag>
           <item>
             <p>Omit the <c>options</c> and <c>source</c> tuples in
-	    the list returned by <c>Module:module_info(compile)</c>.
+            the list returned by <c>Module:module_info(compile)</c>, and
+            reduce the paths in stack traces to the module name alone.
 	    This option will make it easier to achieve reproducible builds.
 	    </p>
           </item>
@@ -347,8 +348,8 @@ module.beam: module.erl \
 
 	  <tag><c>{source,FileName}</c></tag>
           <item>
-            <p>Sets the value of the source, as returned by
-              <c>module_info(compile)</c>.</p>
+            <p>Overrides the source file name as presented in
+              <c>module_info(compile)</c> and stack traces.</p>
           </item>
 
 	  <tag><c>{outdir,Dir}</c></tag>

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -931,11 +931,17 @@ parse_module(_Code, St0) ->
     end.
 
 do_parse_module(DefEncoding, #compile{ifile=File,options=Opts,dir=Dir}=St) ->
+    SourceName0 = proplists:get_value(source, Opts, File),
+    SourceName = case member(deterministic, Opts) of
+                     true -> filename:basename(SourceName0);
+                     false -> SourceName0
+                 end,
     R = epp:parse_file(File,
-		       [{includes,[".",Dir|inc_paths(Opts)]},
-			{macros,pre_defs(Opts)},
-			{default_encoding,DefEncoding},
-			extra]),
+                       [{includes,[".",Dir|inc_paths(Opts)]},
+                        {source_name, SourceName},
+                        {macros,pre_defs(Opts)},
+                        {default_encoding,DefEncoding},
+                        extra]),
     case R of
 	{ok,Forms,Extra} ->
 	    Encoding = proplists:get_value(encoding, Extra),

--- a/lib/stdlib/doc/src/epp.xml
+++ b/lib/stdlib/doc/src/epp.xml
@@ -124,6 +124,10 @@
       <fsummary>Open a file for preprocessing.</fsummary>
       <desc>
         <p>Opens a file for preprocessing.</p>
+        <p>If you want to change the file name of the implicit -file()
+          attributes inserted during preprocessing, you can do with
+          <c>{source_name, <anno>SourceName</anno>}</c>. If unset it will
+          default to the name of the opened file.</p>
         <p>If <c>extra</c> is specified in
           <c><anno>Options</anno></c>, the return value is
           <c>{ok, <anno>Epp</anno>, <anno>Extra</anno>}</c> instead
@@ -169,6 +173,10 @@
         <p>Preprocesses and parses an Erlang source file.
           Notice that tuple <c>{eof, <anno>Line</anno>}</c> returned at the
           end of the file is included as a "form".</p>
+        <p>If you want to change the file name of the implicit -file()
+          attributes inserted during preprocessing, you can do with
+          <c>{source_name, <anno>SourceName</anno>}</c>. If unset it will
+          default to the name of the opened file.</p>
         <p>If <c>extra</c> is specified in
          <c><anno>Options</anno></c>, the return value is
          <c>{ok, [<anno>Form</anno>], <anno>Extra</anno>}</c> instead

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -29,7 +29,7 @@
          otp_8562/1, otp_8665/1, otp_8911/1, otp_10302/1, otp_10820/1,
          otp_11728/1, encoding/1, extends/1,  function_macro/1,
 	 test_error/1, test_warning/1, otp_14285/1,
-	 test_if/1]).
+	 test_if/1,source_name/1]).
 
 -export([epp_parse_erl_form/2]).
 
@@ -70,7 +70,7 @@ all() ->
      overload_mac, otp_8388, otp_8470, otp_8562,
      otp_8665, otp_8911, otp_10302, otp_10820, otp_11728,
      encoding, extends, function_macro, test_error, test_warning,
-     otp_14285, test_if].
+     otp_14285, test_if, source_name].
 
 groups() -> 
     [{upcase_mac, [], [upcase_mac_1, upcase_mac_2]},
@@ -1702,6 +1702,18 @@ function_macro(Config) ->
 
     ok.
 
+source_name(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    File = filename:join(DataDir, "source_name.erl"),
+
+    source_name_1(File, "/test/gurka.erl"),
+    source_name_1(File, "gaffel.erl"),
+
+    ok.
+
+source_name_1(File, Expected) ->
+    Res = epp:parse_file(File, [{source_name, Expected}]),
+    {ok, [{attribute,_,file,{Expected,_}} | _Forms]} = Res.
 
 check(Config, Tests) ->
     eval_tests(Config, fun check_test/2, Tests).

--- a/lib/stdlib/test/epp_SUITE_data/source_name.erl
+++ b/lib/stdlib/test/epp_SUITE_data/source_name.erl
@@ -1,0 +1,27 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 2018. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+-module(source_name).
+-export([ok/0]).
+
+%% Changing source name should not affect headers
+-include("bar.hrl").
+
+ok() -> ok.


### PR DESCRIPTION
When pre-processing a file, `epp` will automatically insert `-file()` attributes to let the compiler know what file an expression belongs to. This information is then used in error reports and stack traces.

The current behavior is that the pre-processor will always use the path as passed to `erlc` for these attributes, so the only way to prevent leaking information about the build environment is to invoke `erlc` in the folder the source file resides in.

This PR aims to remedy that. When the `+source` flag is given the pre-processor will use that instead of the actual file path for these attributes. It also fixes a related bug in the `+deterministic` flag.

https://bugs.erlang.org/browse/ERL-706