### PR TITLE
Do not allow an empty string as node name

### DIFF
--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -1432,7 +1432,7 @@ validate_hostname([$@|HostPart] = Host) ->
     end.
 
 valid_name_head(Head) ->
-    {ok, MP} = re:compile("^[0-9A-Za-z_\\-]*$", [unicode]),
+    {ok, MP} = re:compile("^[0-9A-Za-z_\\-]+$", [unicode]),
         case re:run(Head, MP) of
             {match, _} ->
                 true;


### PR DESCRIPTION
Passing -sname '' or -sname '@bar' to erl would result in an obscure
error message "Protocol 'inet_tcp': register/listen error: epmd_close"
because the check for valid names did not disallow the empty string.