### PR TITLE
Replace string-to-int with string-to-number

### DIFF
--- a/lib/tools/emacs/erlang-skels.el
+++ b/lib/tools/emacs/erlang-skels.el
@@ -1985,7 +1985,7 @@ configured off."
 The first character of DD is space if the value is less than 10."
   (let ((date (current-time-string)))
     (format "%2d %s %s"
-            (string-to-int (substring date 8 10))
+            (string-to-number (substring date 8 10))
             (substring date 4 7)
             (substring date -4))))
 

--- a/lib/tools/emacs/erlang_appwiz.el
+++ b/lib/tools/emacs/erlang_appwiz.el
@@ -468,7 +468,7 @@ Call the function `erlang-menu-init' after modifying this variable.")
 The first character of DD is *not* space if the value is less than 10."
   (let ((date (current-time-string)))
     (format "%d %s %s"
-	    (string-to-int (substring date 8 10))
+	    (string-to-number (substring date 8 10))
 	    (substring date 4 7)
 	    (substring date -4))))
 


### PR DESCRIPTION
string-to-int has been an obsolete alias for string-to-number since
Emacs 22.1, and in Emacs 26.1 the alias has been removed.  Let's
update the Erlang mode.