### PR TITLE
Allow undefined macros when building zlib

### DIFF
--- a/erts/emulator/zlib/zlib.mk
+++ b/erts/emulator/zlib/zlib.mk
@@ -62,6 +62,9 @@ ZLIB_CFLAGS = $(subst -O2, -O3, $(CONFIGURE_CFLAGS) $(DEFS) $(THR_DEFS))
 endif # debug
 endif # gcov
 
+# Don't fail if _LFS64_LARGEFILE is undefined
+ZLIB_CFLAGS := $(filter-out -Werror=undef,$(ZLIB_CFLAGS))
+
 ifeq ($(TARGET), win32)
 $(ZLIB_LIBRARY): $(ZLIB_OBJS)
 	$(V_AR) -out:$@ $(ZLIB_OBJS)


### PR DESCRIPTION
When building Erlang on a system that uses the Musl C library, it's
possible to get the following error:

    In file included from zlib/adler32.c:11:0:
    zlib/zutil.h:172:39: error: "_LFS64_LARGEFILE" is not defined [-Werror=undef]
         (!defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0)
                                           ^~~~~~~~~~~~~~~~
    cc1: some warnings being treated as errors

On the same systems, zlib is built without `-Werror=undef` so do the
same when building it with Erlang.

Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>