### PR TITLE
Add behaviour to define callbacks for via registries

### DIFF
--- a/lib/kernel/src/Makefile
+++ b/lib/kernel/src/Makefile
@@ -133,6 +133,7 @@ MODULES = \
 	user \
 	user_drv \
 	user_sup \
+	via_registry \
 	raw_file_io \
 	raw_file_io_compressed \
 	raw_file_io_inflate \

--- a/lib/kernel/src/kernel.app.src
+++ b/lib/kernel/src/kernel.app.src
@@ -88,6 +88,7 @@
              dist_ac,
              erl_ddll,
              erl_epmd,
+	     via_registry,
 	     erts_debug,
              gen_tcp,
              gen_udp,

--- a/lib/kernel/src/via_registry.erl
+++ b/lib/kernel/src/via_registry.erl
@@ -1,0 +1,34 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2017. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(via_registry).
+
+%% Provides callbacks required for custom registires (i.e. {via, Module, Name}
+
+%% Callbacks
+
+-callback register_name(Name, Pid) -> 'yes' | 'no' when
+      Name :: term(),
+      Pid :: pid().
+
+-callback unregister_name(Name) -> _ when
+      Name :: term().
+
+-callback whereis_name(Name) -> pid() | 'undefined' when
+      Name :: term().


### PR DESCRIPTION
This new behaviour defines the three callbacks required for custom registries (i.e. `{via, Module, Name}`).

If accepted, and once added to bootstrap, a second PR will be added to add this behaviour to `global`.