### PR TITLE
HiPE: Fix check for when ErLLVM is available

### DIFF
--- a/lib/hipe/main/hipe.erl
+++ b/lib/hipe/main/hipe.erl
@@ -196,7 +196,7 @@
  	 file/1,
 	 file/2,
 	 get_llvm_version/0,
-	 llvm_support_available/0,
+	 erllvm_is_supported/0,
 	 load/1,
 	 help/0,
 	 help_hiper/0,
@@ -653,7 +653,7 @@ run_compiler_1(Name, DisasmFun, IcodeFun, Options) ->
 				   get(hipe_target_arch)),
 	    Opts =
 	      case proplists:get_bool(to_llvm, Opts0) andalso
-		not llvm_support_available() of
+		not llvm_version_is_OK() of
 		true ->
 		  ?error_msg("No LLVM version 3.9 or greater "
 			     "found in $PATH; aborting "
@@ -1607,9 +1607,15 @@ check_options(Opts) ->
       ok
   end.
 
--spec llvm_support_available() -> boolean().
+-spec erllvm_is_supported() -> boolean().
+erllvm_is_supported() ->
+  %% XXX: The test should really check the _target_ architecture,
+  %%      (hipe_target_arch), but there's no guarantee it's set.
+  Arch = erlang:system_info(hipe_architecture),
+  lists:member(Arch, [amd64, x86]) andalso llvm_version_is_OK().
 
-llvm_support_available() ->
+-spec llvm_version_is_OK() -> boolean().
+llvm_version_is_OK() ->
   get_llvm_version() >= {3,9}.
 
 -type llvm_version() :: {Major :: integer(), Minor :: integer()}.

--- a/lib/hipe/test/hipe_testsuite_driver.erl
+++ b/lib/hipe/test/hipe_testsuite_driver.erl
@@ -170,7 +170,7 @@ run(TestCase, Dir, _OutDir) ->
     {ok, TestCase} = hipe:c(TestCase, [o0|HiPEOpts]),
     ok = TestCase:test(),
     ToLLVM = try TestCase:to_llvm() catch error:undef -> true end,
-    case ToLLVM andalso hipe:llvm_support_available() of
+    case ToLLVM andalso hipe:erllvm_is_supported() of
 	true ->
 	    {ok, TestCase} = hipe:c(TestCase, [to_llvm|HiPEOpts]),
 	    ok = TestCase:test();

--- a/lib/kernel/test/code_SUITE.erl
+++ b/lib/kernel/test/code_SUITE.erl
@@ -525,7 +525,7 @@ upgrade(Config) ->
             T = [beam, hipe],
             [upgrade_do(DataDir, Client, T) || Client <- T],
 
-            case hipe:llvm_support_available() of
+            case hipe:erllvm_is_supported() of
                 false -> ok;
                 true  ->
                     T2 = [beam, hipe_llvm],


### PR DESCRIPTION
The previous check whether ErLLVM could be enabled and/or tested simply
checked whether a suitable version of the LLVM tool chain was present
in the path. Obviously this is not enough: there should also be a check
that we are running in an architecture on which the ErLLVM compiler
has been ported. Fix the function that provides this functionality and
also rename it in order to more appropriately describe what it does.

In principle, this change introduces a backwards incompatibility as the
function is one of those exported by the `hipe' module, but this
function was not documented and the chances that it has been used
somewhere else that the test suite are pretty low (if not zero).