### PR TITLE
Add an option to control the paths used in -include_lib()

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -386,6 +386,14 @@ module.beam: module.erl \
             </list>
           </item>
 
+          <tag><c>{include_lib_paths,[{'application', "RootDir"}]}</c></tag>
+          <item>
+            <p>Provides explicit application paths for <c>-include_lib</c>
+              directives, ignoring the code server. Note that this list must be
+              exhaustive as the directive will not fall back to using the code
+              server when this option has been specified.</p>
+          </item>
+
           <tag><c>{d,Macro}</c></tag>
           <item></item>
           <tag><c>{d,Macro,Value}</c></tag>

--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -386,7 +386,7 @@ module.beam: module.erl \
             </list>
           </item>
 
-          <tag><c>{include_lib_paths,[{'application', "RootDir"}]}</c></tag>
+          <tag><c>{include_lib_paths,[{'application', "AppDir"}]}</c></tag>
           <item>
             <p>Provides explicit application paths for <c>-include_lib</c>
               directives, ignoring the code server. Note that this list must be

--- a/lib/compiler/test/compile_SUITE_data/include_lib_paths/include/file.hrl
+++ b/lib/compiler/test/compile_SUITE_data/include_lib_paths/include/file.hrl
@@ -1,0 +1,4 @@
+
+%% This is a bogus header mirroring kernel/include/file.hrl that will tell us
+%% whether we managed to override the -include_lib() path.
+-record(gurka, {gaffel}).

--- a/lib/stdlib/doc/src/epp.xml
+++ b/lib/stdlib/doc/src/epp.xml
@@ -124,6 +124,11 @@
       <fsummary>Open a file for preprocessing.</fsummary>
       <desc>
         <p>Opens a file for preprocessing.</p>
+        <p>The <c>{include_lib_paths, <anno>IncludeLibPaths</anno>}</c> option
+          can be used to explicitly provide the application paths used for
+          <c>-include_lib()</c> directives instead of asking the code server.
+          The provided list must be exhaustive as the directive will not fall
+          back to the code server when this option is specified.</p>
         <p>If you want to change the file name of the implicit -file()
           attributes inserted during preprocessing, you can do with
           <c>{source_name, <anno>SourceName</anno>}</c>. If unset it will
@@ -173,6 +178,11 @@
         <p>Preprocesses and parses an Erlang source file.
           Notice that tuple <c>{eof, <anno>Line</anno>}</c> returned at the
           end of the file is included as a "form".</p>
+        <p>The <c>{include_lib_paths, <anno>IncludeLibPaths</anno>}</c> option
+          can be used to explicitly provide the application paths used for
+          <c>-include_lib()</c> directives instead of asking the code server.
+          The provided list must be exhaustive as the directive will not fall
+          back to the code server when this option is specified.</p>
         <p>If you want to change the file name of the implicit -file()
           attributes inserted during preprocessing, you can do with
           <c>{source_name, <anno>SourceName</anno>}</c>. If unset it will

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -121,7 +121,7 @@ open(Name, File, StartLocation, Path, Pdm) ->
 		  {'includes', IncludePath :: [DirectoryName :: file:name()]} |
                   {'include_lib_paths',
                     IncludeLibPaths :: [{Application :: atom(),
-                                         RootDirectory :: file:name()}]} |
+                                         AppDirectory :: file:name()}]} |
 		  {'source_name', SourceName :: file:name()} |
 		  {'macros', PredefMacros :: macros()} |
 		  {'name',FileName :: file:name()} |
@@ -256,7 +256,7 @@ parse_file(Ifile, Path, Predefs) ->
       Options :: [{'includes', IncludePath :: [DirectoryName :: file:name()]} |
                   {'include_lib_paths',
                     IncludeLibPaths :: [{Application :: atom(),
-                                         RootDirectory :: file:name()}]} |
+                                         AppDirectory :: file:name()}]} |
 		  {'source_name', SourceName :: file:name()} |
 		  {'macros', PredefMacros :: macros()} |
 		  {'default_encoding', DefEncoding :: source_encoding()} |

--- a/lib/stdlib/test/epp_SUITE_data/include_lib_paths/nested/test.hrl
+++ b/lib/stdlib/test/epp_SUITE_data/include_lib_paths/nested/test.hrl
@@ -1,0 +1,1 @@
+%% This is just a dummy.


### PR DESCRIPTION
This PR gives the user control over the paths used in `-include_lib()` directives instead of relying on the `ERL_LIBS` of the build environment. It's not airtight since `-behavior()` and parse transformations are still handled with the build environment's paths, but it's a step in the right direction.

More details can be found in [ERL-711](https://bugs.erlang.org/browse/ERL-711).