### PR TITLE
Honor the max heap size when copying literals after purging

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -3622,6 +3622,10 @@ erts_internal_garbage_collect_1(BIF_ALIST_1)
     default:        BIF_ERROR(BIF_P, BADARG);
     }
     erts_garbage_collect(BIF_P, 0, NULL, 0);
+    if (ERTS_PROC_IS_EXITING(BIF_P)) {
+        /* The max heap size limit was reached. */
+        return THE_NON_VALUE;
+    }
     return am_true;
 }
 


### PR DESCRIPTION
When a module has been purged from memory, any literals belonging
to that module will be copied to all processes that hold references
to them.

The max heap size limit would be ignored in the garbage collection
initiated when copying literals to a process. If the max heap size
was exceeded, the process would typically be terminated in the
following garbage collection.

Since the process would be killed anyway later, kill the process
before copying a literal that would make it exceed its max heap
size.

While at it, also fix a potential bug in `erlang:garbage_collect/0`.
If it was found that the max heap sized had been exceeded while
executing `erlang:garbage_collect/0`, the process would enter a
kind of zombie state instead of being properly terminated.