### PR TITLE
beam_lib: Clarify the beam() type in code and documentation

### DIFF
--- a/lib/hipe/main/hipe.erl
+++ b/lib/hipe/main/hipe.erl
@@ -542,7 +542,7 @@ file(File) ->
 				|  {'error', term()}
 				     when Mod :: mod().
 file(File, Options) when is_atom(File) ->
-  case beam_lib:info(File) of
+  case beam_lib:info(atom_to_list(File)) of
     L when is_list(L) ->
       {module, Mod} = lists:keyfind(module, 1, L),
       case compile(Mod, File, Options) of

--- a/lib/stdlib/doc/src/beam_lib.xml
+++ b/lib/stdlib/doc/src/beam_lib.xml
@@ -180,8 +180,8 @@ io:fwrite("~s~n", [erl_prettypr:format(erl_syntax:form_list(AC))]).</code>
       <name name="beam"/>
       <desc>
         <p>Each of the functions described below accept either the
-          module name, the filename, or a binary containing the BEAM
-          module.</p>
+        filename (as a string) or a binary containing the BEAM
+        module.</p>
       </desc>
     </datatype>
     <datatype>

--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -53,7 +53,7 @@
 
 %%-------------------------------------------------------------------------
 
--type beam() :: module() | file:filename() | binary().
+-type beam() :: file:filename() | binary().
 -type debug_info() :: {DbgiVersion :: atom(), Backend :: module(), Data :: term()} | 'no_debug_info'.
 
 -type forms()     :: [erl_parse:abstract_form() | erl_parse:form_info()].


### PR DESCRIPTION
The type `beam()` in the `beam_lib` module is confusing:

    -type beam() :: module() | file:filename() | binary().

It says that the module name can be used to identify the BEAM module
to be accessed, but passing in the module name only works if the BEAM
file is located in the current working directory because the module
is not searched for in the code path.

The reason that is allowed to pass in the module name as an atom is
for backward compatibility. A long time ago, atoms instead of strings
were used as filenames. For that reason, `filename` and `file` still
accept atoms as filenames (although the practice is frown
upon). `beam_lib` accepts an atom as the filename for the same reason.

To make it less confusing, change the type to:

    -type beam() :: file:filename() | binary() | atom().

Also, make it clear in the description of the `beam_type()`
in the documentation that the code path is not searched.

**Update**: I have updated the type and documentation as suggested by Kostis. See the commit message.


https://bugs.erlang.org/browse/ERL-696