### PR TITLE
lists:subtract (operator --) trapping

### DIFF
--- a/erts/emulator/beam/erl_bif_lists.c
+++ b/erts/emulator/beam/erl_bif_lists.c
@@ -29,11 +29,17 @@
 #include "sys.h"
 #include "erl_vm.h"
 #include "global.h"
-#include "erl_process.h"
-#include "error.h"
 #include "bif.h"
+#include "erl_binary.h"
+
+static Export subtract_trap_export;
 
 static Eterm keyfind(int Bif, Process* p, Eterm Key, Eterm Pos, Eterm List);
+
+void erts_init_bif_lists() {
+    erts_init_trap_export(&subtract_trap_export, am_lists, am_subtract, 2,
+                          &subtract_2);
+}
 
 static BIF_RETTYPE append(Process* p, Eterm A, Eterm B)
 {
@@ -146,99 +152,12 @@ BIF_RETTYPE append_2(BIF_ALIST_2)
     return append(BIF_P, BIF_ARG_1, BIF_ARG_2);
 }
 
-///*
-// * erlang:'--'/2
-// * Calculates A -- B for two lists; complexity proportional to len(A)*len(B)
-// */
-//static Eterm subtract_old(Process* p, Eterm A, Eterm B)
-//{
-//    static const int SMALL_VEC_SIZE = 10;
-//    Eterm list;
-//    Eterm *hp;
-//    Uint need;
-//    Eterm res;
-//    Eterm small_vec[SMALL_VEC_SIZE];   /* Preallocated memory for small lists */
-//    Eterm *copy_of_a;
-//    Eterm *vp;
-//    Sint len_a;
-//    Sint len_b, n_deleted;
-//
-//    if ((len_a = erts_list_length(A)) < 0) {
-//        BIF_ERROR(p, BADARG);
-//    }
-//    if ((len_b = erts_list_length(B)) < 0) {
-//        BIF_ERROR(p, BADARG);
-//    }
-//
-//    if (len_a == 0)
-//        BIF_RET(NIL);
-//    if (len_b == 0)
-//        BIF_RET(A);
-//
-//    /* allocate element vector */
-//    if (len_a <= SMALL_VEC_SIZE)
-//        copy_of_a = small_vec;
-//    else
-//        copy_of_a = (Eterm *) erts_alloc(ERTS_ALC_T_TMP, len_a * sizeof(Eterm));
-//
-//    /* PUT ALL ELEMENTS IN VP */
-//    vp = copy_of_a;
-//    list = A;
-//    for (Sint i = len_a; i > 0; i--) {
-//        Eterm *listp = list_val(list);
-//        *vp++ = CAR(listp);
-//        list = CDR(listp);
-//    }
-//
-//    /* UNMARK ALL DELETED CELLS
-//     * Iterate over B and for each element of B try delete it from A once
-//     */
-//    n_deleted = 0;  /* number of deleted elements */
-//    for (Eterm listb = B; is_list(listb);) {
-//        Eterm *listp = list_val(listb);
-//        Eterm elem = CAR(listp);
-//        vp = copy_of_a;
-//        /* Iterate over copy of A, and for each first occurrence of each element
-//         * from B - mark it as non value */
-//        for (Sint i = len_a; i > 0; i--) {
-//            if (is_value(*vp) && eq(*vp, elem)) {
-//                *vp = THE_NON_VALUE;
-//                n_deleted++;
-//                break;
-//            }
-//            vp++;
-//        }
-//        listb = CDR(listp);
-//    }
-//
-//    if (n_deleted == len_a) { /* All deleted? Return a [] */
-//        res = NIL;
-//    } else if (n_deleted == 0) { /* None deleted? Return the original A */
-//        res = A;
-//    } else { /* Deleted some elements and A still not empty - Rebuild a new A */
-//        res = NIL;
-//        need = (Uint) (2 * (len_a - n_deleted));
-//        hp = HAlloc(p, need);
-//        vp = copy_of_a + len_a - 1;
-//        while (vp >= copy_of_a) {
-//            if (is_value(*vp)) {
-//                res = CONS(hp, *vp, res);
-//                hp += 2;
-//            }
-//            vp--;
-//        }
-//    }
-//    if (copy_of_a != small_vec) {
-//        erts_free(ERTS_ALC_T_TMP, (void *) copy_of_a);
-//    }
-//    BIF_RET(res);
-//}
 
 /* If list size (precalculated outside of this fun) fits into static_array, then
  * use it and copy elements from list to it. Otherwise allocate a new array and
  * copy elements into it. */
 static Eterm *
-maybe_allocate_list(Sint src_size, Eterm *static_array, Sint static_size) {
+subtract_maybe_alloc(Sint src_size, Eterm *static_array, Sint static_size) {
     Eterm *dst;
     if (src_size > static_size) {
         dst = (Eterm *) erts_alloc(ERTS_ALC_T_TMP, src_size * sizeof(Eterm));
@@ -249,9 +168,9 @@ maybe_allocate_list(Sint src_size, Eterm *static_array, Sint static_size) {
 }
 
 
+/* Copy elements from list 'src' into 'dst' */
 static ERTS_INLINE void
-copy_list(Eterm src, Sint src_size, Eterm *dst) {
-    /* Copy elements from list 'src' into 'dst' */
+subtract_copy_list(Eterm src, Sint src_size, Eterm *dst) {
     Eterm *dst_p = dst;
     for (Sint i = src_size - 1; i >= 0; i--) {
         const Eterm *src_p = list_val(src);
@@ -264,7 +183,7 @@ copy_list(Eterm src, Sint src_size, Eterm *dst) {
 /* Naive search of val in array of array_sz elements.
  * Returns index where found or -1 if not found */
 static ERTS_INLINE Sint
-find_in_array(Eterm val, const Eterm *array_p, Sint array_sz) {
+subtract_find_in_array(Eterm val, const Eterm *array_p, Sint array_sz) {
     for (Sint i = array_sz - 1; i >= 0; i--) {
         if (eq(val, array_p[i])) {
             return i;
@@ -274,109 +193,359 @@ find_in_array(Eterm val, const Eterm *array_p, Sint array_sz) {
 }
 
 
+enum { SUBTRACT_SMALL_VEC_SIZE = 10 };
+#define SUBTRACT_SPECIAL_VALUE am_bif_return_trap
+
+typedef enum {
+    SUBTRACT_STEP_LEN_A = 1, /* calculate length of A */
+    SUBTRACT_STEP_LEN_B = 2, /* calculate length of B */
+    SUBTRACT_STEP_SCAN = 3   /* scan A and copy elements not in B to result */
+} ErtsSubtractFsmState;
+
+/* Context used for trapping length calculation */
+typedef struct {
+    Eterm iter;
+    Sint count;
+} ErtsSubtractLengthContext;
+
+/* Context used for trapping scanning of inputs */
+typedef struct {
+    /* Preallocated memory for small lists */
+    Eterm small_vec_a[SUBTRACT_SMALL_VEC_SIZE];
+    Eterm small_vec_b[SUBTRACT_SMALL_VEC_SIZE];
+
+    /* Dynamically allocated copy of B, for shrinking it when elements are
+     * found and removed */
+    Eterm *copy_of_b;
+
+    /* iterator over A when subtracting and moving remaining elts */
+    Eterm iter_a;
+
+    /* Dynamically allocated result output array (on TMP heap) */
+    Eterm *result_array;
+    Sint result_size;
+} ErtsSubtractScanContext;
+
+typedef struct {
+    /* Allows doing work in stages possibly interrupting on large inputs */
+    ErtsSubtractFsmState fsm_state;
+    Sint len_a;
+    Sint len_b;
+    union {
+        ErtsSubtractLengthContext len;
+        ErtsSubtractScanContext scan;
+    } s;
+} ErtsSubtractContext;
+
+
+/*
+ * Return either NIL, A or build new result list from state.result_array
+ */
+static ERTS_INLINE Eterm
+subtract_build_result(Process *p, Eterm A, ErtsSubtractContext *context) {
+    const ErtsSubtractScanContext *s = &context->s.scan;
+    const Sint result_size = s->result_size;
+    Eterm *write_p;
+    const Eterm *read_p;
+    Eterm res;
+
+    if (result_size == 0) { /* All deleted? Return a [] */
+        return NIL;
+    } else if (result_size == context->len_a) {
+        /* None deleted? Return the original A */
+        return A;
+    }
+
+    /* Deleted some elements and A still not empty - Rebuild the new A */
+    write_p = HAlloc(p, (Uint) (2 * result_size));
+    read_p = s->result_array + result_size - 1;
+    res = NIL;
+    while (read_p >= s->result_array) {
+        if (is_value(*read_p)) {
+            res = CONS(write_p, *read_p, res);
+            write_p += 2;
+        }
+        read_p--;
+    }
+    return res;
+}
+
+
+/* Constructor for state struct, called on creation */
+static ERTS_INLINE void
+subtractcontext_ctor(ErtsSubtractContext *context) {
+    memset((void *)context, 0, sizeof(ErtsSubtractContext));
+    context->fsm_state = SUBTRACT_STEP_LEN_A;
+    /* Some platforms have different idea of NULL, remember to set fields 
+     * when transitioning to the SCAN step */
+}
+
+
+static int
+subtractcontext_dtor(ErtsSubtractContext *context) {
+    ErtsSubtractScanContext *s;
+    if (context->fsm_state != SUBTRACT_STEP_SCAN) {
+        /* nothing to do if we didn't allocate any memory yet */
+        return 1;
+    }
+
+    s = &context->s.scan;
+    if (s->result_array && s->result_array != s->small_vec_a) {
+        erts_free(ERTS_ALC_T_TMP, (void *) s->result_array);
+        s->result_array = NULL;
+    }
+    if (s->copy_of_b && s->copy_of_b != s->small_vec_b) {
+        erts_free(ERTS_ALC_T_TMP, (void *) s->copy_of_b);
+        s->copy_of_b = NULL;
+    }
+    return 1;
+}
+
+
+/* Called when magic binary with ErtsSubtractContext is destroyed */
+static int
+subtractcontext_binary_dtor(Binary *context_bin) {
+    ErtsSubtractContext *ctx = ERTS_MAGIC_BIN_DATA(context_bin);
+    return subtractcontext_dtor(ctx);
+}
+
+
+/* Prepare magic ref to magic binary with our state.
+ * The magic binary with context in it should already be created.
+ * Return a triple {A, B, MagicRef}
+ */
+static ERTS_INLINE Eterm
+subtract_create_returnstate(Process *p, Eterm A, Eterm B, Binary *context_b) {
+    const static int TUPLE3_SIZE = 3 + 1;
+    Eterm *hp = HAlloc(p, ERTS_MAGIC_REF_THING_SIZE + TUPLE3_SIZE);
+    Eterm state_binref = erts_mk_magic_ref(&hp, &MSO(p), context_b);
+    BUMP_ALL_REDS(p);
+    return TUPLE3(hp, A, B, state_binref);
+}
+
+
+/* Iterate over A and for each element that is present in B, skip it
+ * in A and remove it from B (by moving last element of B in its place and
+ * making B shorter), otherwise that element is copied to the result.
+ * Repeat until either end of A is reached or B is empty.
+ *
+ * Result is built in s->result_array of Eterm[result_size]
+ */
+static Eterm
+subtract_fsm_scan(Process *p, Eterm A, ErtsSubtractContext *context) {
+    ErtsSubtractScanContext *s = &context->s.scan;
+    Eterm iter_a = s->iter_a; /* load iterator from state */
+
+    /* A is guaranteed to be proper list, otherwise erts_list_length() call at
+     * start will fail */
+    while (is_list(iter_a)) {
+        const Eterm *ptr_a = list_val(iter_a);
+        Sint found_at = subtract_find_in_array(CAR(ptr_a), s->copy_of_b,
+                                               context->len_b);
+        if (found_at >= 0) {
+            /* Remove elem from B and skip; shrink B by 1 */
+            context->len_b--;
+            s->copy_of_b[found_at] = s->copy_of_b[context->len_b];
+
+            if (context->len_b == 0) {
+                iter_a = CDR(ptr_a);
+
+                /* B is empty at this point, so copy remaining A elements */
+                while (is_list(iter_a)) {
+                    ptr_a = list_val(iter_a);
+                    s->result_array[s->result_size] = CAR(ptr_a);
+                    s->result_size++;
+                    iter_a = CDR(ptr_a);
+                }
+                break; /* nothing left in B, end search here */
+            }
+        } else {
+            s->result_array[s->result_size] = CAR(ptr_a);
+            s->result_size++;
+        }
+        iter_a = CDR(ptr_a);
+    }
+
+    s->iter_a = iter_a; /* save iterator */
+    return subtract_build_result(p, A, context);
+}
+
+
+/*
+ * Stage 0 creates binary state for subsequent stages
+ */
+static Binary *
+subtract_fsm_construct_context(Process *_p, Eterm A, Eterm B) {
+    ErtsSubtractContext *context;
+
+    /* Context stored in magic binary. If this is not null, we will be trapping
+     * periodically otherwise we will run operation till the end & return. */
+    Binary *state_bin = NULL;
+
+    /* Allocate tmp binary and use it for state */
+    state_bin = erts_create_magic_binary(sizeof(ErtsSubtractContext),
+                                         subtractcontext_binary_dtor);
+
+    context = ERTS_MAGIC_BIN_DATA(state_bin);
+    subtractcontext_ctor(context);
+
+    return state_bin;
+}
+
+
+/*
+ * Setup variables for entering length calculation state.
+ */
+static ERTS_INLINE void
+subtract_enter_state_len_of(Eterm T, ErtsSubtractContext *context) {
+    ErtsSubtractLengthContext *lc = &context->s.len;
+    lc->count = 0;
+    lc->iter = T;
+}
+
+
+/*
+ * Stages 1 and 2 perform length calculation on lists A and B respectively.
+ * Possibly trapping if the lists are too long.
+ * Reentering this stage
+ */
+static Eterm
+subtract_fsm_len(Process *p, ErtsSubtractContext *context) {
+    context->s.len.count = erts_list_length(context->s.len.iter);
+    return am_true;
+}
+
+
+/* Stage 3 creates binary or on-stack state and performs the subtraction
+ * also possibly trapping if the inputs are too long. */
+static ERTS_INLINE void
+subtract_enter_state_scan(Process *p, Eterm A, Eterm B,
+                          ErtsSubtractContext *context) {
+    ErtsSubtractScanContext *s = &context->s.scan;
+    s->result_array = subtract_maybe_alloc(context->len_a, s->small_vec_a,
+                                           SUBTRACT_SMALL_VEC_SIZE);
+    s->copy_of_b = subtract_maybe_alloc(context->len_b, s->small_vec_b,
+                                        SUBTRACT_SMALL_VEC_SIZE);
+    subtract_copy_list(B, context->len_b, s->copy_of_b);
+
+    /* Initialise loop counters and run the loop */
+    s->result_size = 0;
+    s->iter_a = A;
+}
+
+
+/* Unpack the state triple and based on step field do something.
+ * To enter here, A must be NON VALUE and B must be {OrigA, OrigB, MagicBin}
+ */
+static ERTS_INLINE Eterm
+subtract_switch(Process *p, Eterm special_arg, Eterm a_b_state) {
+    Binary *magic_bin;
+    ErtsSubtractContext *context;
+    Eterm *a_b_state_ptr;
+    Eterm orig_A, orig_B;
+
+    ERTS_ASSERT(special_arg == SUBTRACT_SPECIAL_VALUE);
+    ERTS_ASSERT(is_tuple(a_b_state));
+    ERTS_ASSERT(is_tuple_arity(a_b_state, 3));
+    a_b_state_ptr = tuple_val(a_b_state);
+    orig_A = a_b_state_ptr[1];
+    orig_B = a_b_state_ptr[2];
+
+    magic_bin = erts_magic_ref2bin(a_b_state_ptr[3]);
+    context = ERTS_MAGIC_BIN_DATA(magic_bin);
+
+    switch (context->fsm_state) {
+        case SUBTRACT_STEP_LEN_A: {
+            Eterm res = subtract_fsm_len(p, context);
+            Sint count;
+            if (res != am_true) {
+                BIF_TRAP2(&subtract_trap_export, p,
+                          SUBTRACT_SPECIAL_VALUE, a_b_state);
+            }
+            count = context->s.len.count;
+            /* Returning true means length is done, result in s.len.count */
+            if (count < 0) {
+                BIF_ERROR(p, BADARG);
+            }
+            if (count == 0) {
+                BIF_RET(NIL);
+            }
+            context->len_a = count;
+            context->fsm_state = SUBTRACT_STEP_LEN_B;
+            subtract_enter_state_len_of(orig_B, context);
+            /* FALL THROUGH */
+        }
+
+        case SUBTRACT_STEP_LEN_B: {
+            Eterm res = subtract_fsm_len(p, context);
+            Sint count;
+            if (res != am_true) {
+                BIF_TRAP2(&subtract_trap_export, p,
+                          SUBTRACT_SPECIAL_VALUE, a_b_state);
+            }
+            if (NULL != 0) {
+                /* Some platforms have different idea of NULL, set fields like this */
+                context->s.scan.result_array = NULL;
+                context->s.scan.copy_of_b = NULL;
+            }
+            count = context->s.len.count;
+            /* Returning true means length is done, result in s.len.count */
+            if (count < 0) {
+                BIF_ERROR(p, BADARG);
+            }
+            if (count == 0) {
+                BIF_RET(orig_A);
+            }
+            context->len_b = count;
+            context->fsm_state = SUBTRACT_STEP_SCAN;
+            subtract_enter_state_scan(p, orig_A, orig_B, context);
+            /* FALL THROUGH */
+        }
+
+        case SUBTRACT_STEP_SCAN: {
+            Eterm res = subtract_fsm_scan(p, orig_A, context);
+            if (res == SUBTRACT_SPECIAL_VALUE) {
+                BIF_TRAP2(&subtract_trap_export, p,
+                          SUBTRACT_SPECIAL_VALUE, a_b_state);
+            }
+            subtractcontext_dtor(context);
+            BIF_RET(res);
+        }
+    }
+    BIF_ERROR(p, EXC_BADFUN); /* bloop. Unreachable, should not be here */
+}
+
+
 /*
  * erlang:'--'/2
  * Calculates A -- B for two lists; complexity proportional to len(A)*len(B)
  *
  * B is copied into a flat array and gets shrunk every time a value from B is
  * found in A, this speeds up the search as B gets shorter.
+ *
+ * Args: A :: proper_list(), B :: proper_list() - create state and enter stage0
+ * Args: A :: nonvalue(), B :: {list(), list(), magic_binary()} - continue
+ *  The binary contains ErtsSubtractContext struct.
+ *  The step field in state will define next action.
  */
-static Eterm subtract(Process* p, Eterm A, Eterm B)
-{
-    static const int SMALL_VEC_SIZE = 10;
-    Eterm res;
-    Eterm small_vec_a[SMALL_VEC_SIZE]; /* Preallocated memory for small lists */
-    Eterm small_vec_b[SMALL_VEC_SIZE];
-    Eterm *result_array;
-    Eterm *copy_of_b;
-    Eterm iter_a; /* iterator over A when subtracting and moving remaining elts */
-    Sint len_a;
-    Sint len_b;
-    Sint result_size;
+static Eterm
+subtract(Process *p, Eterm A, Eterm B) {
+    if (A != SUBTRACT_SPECIAL_VALUE && ! is_tuple(B)) {
+        /* This is initial call entry from Erlang, both args are lists, no ctx
+         * is yet created. So create state here. */
+        Binary *state_bin = subtract_fsm_construct_context(p, A, B);
 
-    if ((len_a = erts_list_length(A)) < 0) {
-        BIF_ERROR(p, BADARG);
-    }
-    if ((len_b = erts_list_length(B)) < 0) {
-        BIF_ERROR(p, BADARG);
+        /* Enter now with state */
+        ErtsSubtractContext *context = ERTS_MAGIC_BIN_DATA(state_bin);
+        subtract_enter_state_len_of(A, context);
+        return subtract_switch(
+                p, SUBTRACT_SPECIAL_VALUE,
+                subtract_create_returnstate(p, A, B, state_bin));
     }
 
-    if (len_a == 0) {
-        BIF_RET(NIL);
-    }
-    if (len_b == 0) {
-        BIF_RET(A);
-    }
-
-//    fprintf(stderr, "len_a=%li len_b=%li\n", len_a, len_b);
-
-    /* Allocate space for copies of A (result goes there) and B
-     * Leave result_array uninitialised
-     * Copy elements from B into allocated space copy_of_b
-     */
-    result_array = maybe_allocate_list(len_a, small_vec_a, SMALL_VEC_SIZE);
-    copy_of_b = maybe_allocate_list(len_b, small_vec_b, SMALL_VEC_SIZE);
-    copy_list(B, len_b, copy_of_b);
-
-    /* Iterate over A and for each element that is present in B, skip it
-     * in A and remove it from B (by moving last element of B in its place and
-     * making B shorter), otherwise that element is copied to the result.
-     * Repeat until either end of A is reached or B is empty.
-     */
-    result_size = 0;
-    iter_a = A;
-    for (Sint i = len_a; i > 0; i--) {
-        const Eterm *ptr_a = list_val(iter_a);
-        Sint found_at = find_in_array(CAR(ptr_a), copy_of_b, len_b);
-        if (found_at >= 0) {
-            /* Remove elem from B and skip */
-            len_b--;
-            copy_of_b[found_at] = copy_of_b[len_b]; /* shrink B by 1 */
-
-            if (len_b == 0) {
-                iter_a = CDR(ptr_a);
-
-                /* B is empty at this point, so copy remaining A elements */
-                while (is_list(iter_a)) {
-                    ptr_a = list_val(iter_a);
-                    result_array[result_size] = CAR(ptr_a);
-                    result_size++;
-                    iter_a = CDR(ptr_a);
-                }
-                break; /* nothing left in B, end search here */
-            }
-        } else {
-            result_array[result_size] = CAR(ptr_a);
-            result_size++;
-        }
-        iter_a = CDR(ptr_a);
-    }
-
-//    fprintf(stderr, "remaining_b=%li res_size=%li\n", len_b, result_size);
-
-    if (result_size == 0) { /* All deleted? Return a [] */
-        res = NIL;
-    } else if (result_size == len_a) { /* None deleted? Return the original A */
-        res = A;
-    } else { /* Deleted some elements and A still not empty - Rebuild a new A */
-        Eterm *hp = HAlloc(p, (Uint) (2 * result_size));
-        Eterm *vp = result_array + result_size - 1;
-        res = NIL;
-        while (vp >= result_array) {
-            if (is_value(*vp)) {
-                res = CONS(hp, *vp, res);
-                hp += 2;
-            }
-            vp--;
-        }
-    }
-    if (result_array != small_vec_a) {
-        erts_free(ERTS_ALC_T_TMP, (void *) result_array);
-    }
-    if (copy_of_b != small_vec_b) {
-        erts_free(ERTS_ALC_T_TMP, (void *) copy_of_b);
-    }
-    BIF_RET(res);
+    /* Continue. There A must be non value and B must be triple
+     * {OrigA, OrigB, StateMagicBin} */
+    return subtract_switch(p, A, B);
 }
 
 

--- a/erts/emulator/beam/erl_bif_lists.c
+++ b/erts/emulator/beam/erl_bif_lists.c
@@ -146,92 +146,239 @@ BIF_RETTYPE append_2(BIF_ALIST_2)
     return append(BIF_P, BIF_ARG_1, BIF_ARG_2);
 }
 
+///*
+// * erlang:'--'/2
+// * Calculates A -- B for two lists; complexity proportional to len(A)*len(B)
+// */
+//static Eterm subtract_old(Process* p, Eterm A, Eterm B)
+//{
+//    static const int SMALL_VEC_SIZE = 10;
+//    Eterm list;
+//    Eterm *hp;
+//    Uint need;
+//    Eterm res;
+//    Eterm small_vec[SMALL_VEC_SIZE];   /* Preallocated memory for small lists */
+//    Eterm *copy_of_a;
+//    Eterm *vp;
+//    Sint len_a;
+//    Sint len_b, n_deleted;
+//
+//    if ((len_a = erts_list_length(A)) < 0) {
+//        BIF_ERROR(p, BADARG);
+//    }
+//    if ((len_b = erts_list_length(B)) < 0) {
+//        BIF_ERROR(p, BADARG);
+//    }
+//
+//    if (len_a == 0)
+//        BIF_RET(NIL);
+//    if (len_b == 0)
+//        BIF_RET(A);
+//
+//    /* allocate element vector */
+//    if (len_a <= SMALL_VEC_SIZE)
+//        copy_of_a = small_vec;
+//    else
+//        copy_of_a = (Eterm *) erts_alloc(ERTS_ALC_T_TMP, len_a * sizeof(Eterm));
+//
+//    /* PUT ALL ELEMENTS IN VP */
+//    vp = copy_of_a;
+//    list = A;
+//    for (Sint i = len_a; i > 0; i--) {
+//        Eterm *listp = list_val(list);
+//        *vp++ = CAR(listp);
+//        list = CDR(listp);
+//    }
+//
+//    /* UNMARK ALL DELETED CELLS
+//     * Iterate over B and for each element of B try delete it from A once
+//     */
+//    n_deleted = 0;  /* number of deleted elements */
+//    for (Eterm listb = B; is_list(listb);) {
+//        Eterm *listp = list_val(listb);
+//        Eterm elem = CAR(listp);
+//        vp = copy_of_a;
+//        /* Iterate over copy of A, and for each first occurrence of each element
+//         * from B - mark it as non value */
+//        for (Sint i = len_a; i > 0; i--) {
+//            if (is_value(*vp) && eq(*vp, elem)) {
+//                *vp = THE_NON_VALUE;
+//                n_deleted++;
+//                break;
+//            }
+//            vp++;
+//        }
+//        listb = CDR(listp);
+//    }
+//
+//    if (n_deleted == len_a) { /* All deleted? Return a [] */
+//        res = NIL;
+//    } else if (n_deleted == 0) { /* None deleted? Return the original A */
+//        res = A;
+//    } else { /* Deleted some elements and A still not empty - Rebuild a new A */
+//        res = NIL;
+//        need = (Uint) (2 * (len_a - n_deleted));
+//        hp = HAlloc(p, need);
+//        vp = copy_of_a + len_a - 1;
+//        while (vp >= copy_of_a) {
+//            if (is_value(*vp)) {
+//                res = CONS(hp, *vp, res);
+//                hp += 2;
+//            }
+//            vp--;
+//        }
+//    }
+//    if (copy_of_a != small_vec) {
+//        erts_free(ERTS_ALC_T_TMP, (void *) copy_of_a);
+//    }
+//    BIF_RET(res);
+//}
+
+/* If list size (precalculated outside of this fun) fits into static_array, then
+ * use it and copy elements from list to it. Otherwise allocate a new array and
+ * copy elements into it. */
+static Eterm *
+maybe_allocate_list(Sint src_size, Eterm *static_array, Sint static_size) {
+    Eterm *dst;
+    if (src_size > static_size) {
+        dst = (Eterm *) erts_alloc(ERTS_ALC_T_TMP, src_size * sizeof(Eterm));
+    } else {
+        dst = static_array;
+    }
+    return dst;
+}
+
+
+static ERTS_INLINE void
+copy_list(Eterm src, Sint src_size, Eterm *dst) {
+    /* Copy elements from list 'src' into 'dst' */
+    Eterm *dst_p = dst;
+    for (Sint i = src_size - 1; i >= 0; i--) {
+        const Eterm *src_p = list_val(src);
+        *dst_p++ = CAR(src_p);
+        src = CDR(src_p);
+    }
+}
+
+
+/* Naive search of val in array of array_sz elements.
+ * Returns index where found or -1 if not found */
+static ERTS_INLINE Sint
+find_in_array(Eterm val, const Eterm *array_p, Sint array_sz) {
+    for (Sint i = array_sz - 1; i >= 0; i--) {
+        if (eq(val, array_p[i])) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+
 /*
  * erlang:'--'/2
+ * Calculates A -- B for two lists; complexity proportional to len(A)*len(B)
+ *
+ * B is copied into a flat array and gets shrunk every time a value from B is
+ * found in A, this speeds up the search as B gets shorter.
  */
-
-#define SMALL_VEC_SIZE 10
 static Eterm subtract(Process* p, Eterm A, Eterm B)
 {
-    Eterm  list;
-    Eterm* hp;
-    Uint  need;
-    Eterm  res;
-    Eterm small_vec[SMALL_VEC_SIZE];	/* Preallocated memory for small lists */
-    Eterm* vec_p;
-    Eterm* vp;
-    Sint i;
-    Sint n;
-    Sint m;
-    
-    if ((n = erts_list_length(A)) < 0) {
-	BIF_ERROR(p, BADARG);
+    static const int SMALL_VEC_SIZE = 10;
+    Eterm res;
+    Eterm small_vec_a[SMALL_VEC_SIZE]; /* Preallocated memory for small lists */
+    Eterm small_vec_b[SMALL_VEC_SIZE];
+    Eterm *result_array;
+    Eterm *copy_of_b;
+    Eterm iter_a; /* iterator over A when subtracting and moving remaining elts */
+    Sint len_a;
+    Sint len_b;
+    Sint result_size;
+
+    if ((len_a = erts_list_length(A)) < 0) {
+        BIF_ERROR(p, BADARG);
     }
-    if ((m = erts_list_length(B)) < 0) {
-	BIF_ERROR(p, BADARG);
+    if ((len_b = erts_list_length(B)) < 0) {
+        BIF_ERROR(p, BADARG);
     }
-    
-    if (n == 0)
-	BIF_RET(NIL);
-    if (m == 0)
-	BIF_RET(A);
-    
-    /* allocate element vector */
-    if (n <= SMALL_VEC_SIZE)
-	vec_p = small_vec;
-    else
-	vec_p = (Eterm*) erts_alloc(ERTS_ALC_T_TMP, n * sizeof(Eterm));
-    
-    /* PUT ALL ELEMENTS IN VP */
-    vp = vec_p;
-    list = A;
-    i = n;
-    while(i--) {
-	Eterm* listp = list_val(list);
-	*vp++ = CAR(listp);
-	list = CDR(listp);
+
+    if (len_a == 0) {
+        BIF_RET(NIL);
     }
-    
-    /* UNMARK ALL DELETED CELLS */
-    list = B;
-    m = 0;  /* number of deleted elements */
-    while(is_list(list)) {
-	Eterm* listp = list_val(list);
-	Eterm  elem = CAR(listp);
-	i = n;
-	vp = vec_p;
-	while(i--) {
-	    if (is_value(*vp) && eq(*vp, elem)) {
-		*vp = THE_NON_VALUE;
-		m++;
-		break;
-	    }
-	    vp++;
-	}
-	list = CDR(listp);
+    if (len_b == 0) {
+        BIF_RET(A);
     }
-    
-    if (m == n)      /* All deleted ? */
-	res = NIL;
-    else if (m == 0)  /* None deleted ? */
-	res = A;
-    else {			/* REBUILD LIST */
-	res = NIL;
-	need = 2*(n - m);
-	hp = HAlloc(p, need);
-	vp = vec_p + n - 1;
-	while(vp >= vec_p) {
-	    if (is_value(*vp)) {
-		res = CONS(hp, *vp, res);
-		hp += 2;
-	    }
-	    vp--;
-	}
+
+//    fprintf(stderr, "len_a=%li len_b=%li\n", len_a, len_b);
+
+    /* Allocate space for copies of A (result goes there) and B
+     * Leave result_array uninitialised
+     * Copy elements from B into allocated space copy_of_b
+     */
+    result_array = maybe_allocate_list(len_a, small_vec_a, SMALL_VEC_SIZE);
+    copy_of_b = maybe_allocate_list(len_b, small_vec_b, SMALL_VEC_SIZE);
+    copy_list(B, len_b, copy_of_b);
+
+    /* Iterate over A and for each element that is present in B, skip it
+     * in A and remove it from B (by moving last element of B in its place and
+     * making B shorter), otherwise that element is copied to the result.
+     * Repeat until either end of A is reached or B is empty.
+     */
+    result_size = 0;
+    iter_a = A;
+    for (Sint i = len_a; i > 0; i--) {
+        const Eterm *ptr_a = list_val(iter_a);
+        Sint found_at = find_in_array(CAR(ptr_a), copy_of_b, len_b);
+        if (found_at >= 0) {
+            /* Remove elem from B and skip */
+            len_b--;
+            copy_of_b[found_at] = copy_of_b[len_b]; /* shrink B by 1 */
+
+            if (len_b == 0) {
+                iter_a = CDR(ptr_a);
+
+                /* B is empty at this point, so copy remaining A elements */
+                while (is_list(iter_a)) {
+                    ptr_a = list_val(iter_a);
+                    result_array[result_size] = CAR(ptr_a);
+                    result_size++;
+                    iter_a = CDR(ptr_a);
+                }
+                break; /* nothing left in B, end search here */
+            }
+        } else {
+            result_array[result_size] = CAR(ptr_a);
+            result_size++;
+        }
+        iter_a = CDR(ptr_a);
     }
-    if (vec_p != small_vec)
-	erts_free(ERTS_ALC_T_TMP, (void *) vec_p);
+
+//    fprintf(stderr, "remaining_b=%li res_size=%li\n", len_b, result_size);
+
+    if (result_size == 0) { /* All deleted? Return a [] */
+        res = NIL;
+    } else if (result_size == len_a) { /* None deleted? Return the original A */
+        res = A;
+    } else { /* Deleted some elements and A still not empty - Rebuild a new A */
+        Eterm *hp = HAlloc(p, (Uint) (2 * result_size));
+        Eterm *vp = result_array + result_size - 1;
+        res = NIL;
+        while (vp >= result_array) {
+            if (is_value(*vp)) {
+                res = CONS(hp, *vp, res);
+                hp += 2;
+            }
+            vp--;
+        }
+    }
+    if (result_array != small_vec_a) {
+        erts_free(ERTS_ALC_T_TMP, (void *) result_array);
+    }
+    if (copy_of_b != small_vec_b) {
+        erts_free(ERTS_ALC_T_TMP, (void *) copy_of_b);
+    }
     BIF_RET(res);
 }
+
 
 BIF_RETTYPE ebif_minusminus_2(BIF_ALIST_2)
 {

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -353,6 +353,7 @@ erl_init(int ncpu,
     erts_init_bif();
     erts_init_bif_chksum();
     erts_init_bif_binary();
+    erts_init_bif_lists();
     erts_init_bif_re();
     erts_init_unicode(); /* after RE to get access to PCRE unicode */
     erts_init_external();

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -1947,7 +1947,7 @@ static Eterm erts_term_to_binary_int(Process* p, Eterm Term, int level, Uint fla
 	    context_b = erts_create_magic_binary(sizeof(TTBContext),    \
                                                  ttb_context_destructor);   \
 	    context =  ERTS_MAGIC_BIN_DATA(context_b);			\
-	    sys_memcpy(context,&c_buff,sizeof(TTBContext));		\
+	    sys_memcpy(context,&c_buff,sizeof(TTBContext));			\
 	}								\
     } while (0)
 

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -1947,13 +1947,14 @@ static Eterm erts_term_to_binary_int(Process* p, Eterm Term, int level, Uint fla
 	    context_b = erts_create_magic_binary(sizeof(TTBContext),    \
                                                  ttb_context_destructor);   \
 	    context =  ERTS_MAGIC_BIN_DATA(context_b);			\
-	    sys_memcpy(context,&c_buff,sizeof(TTBContext));			\
+	    sys_memcpy(context,&c_buff,sizeof(TTBContext));		\
 	}								\
     } while (0)
 
 #define RETURN_STATE()							\
     do {								\
-	hp = HAlloc(p, ERTS_MAGIC_REF_THING_SIZE+3);                    \
+	static const int TUPLE2_SIZE = 2 + 1;				\
+	hp = HAlloc(p, ERTS_MAGIC_REF_THING_SIZE + TUPLE2_SIZE);        \
 	c_term = erts_mk_magic_ref(&hp, &MSO(p), context_b);            \
 	res = TUPLE2(hp, Term, c_term);					\
 	BUMP_ALL_REDS(p);                                               \

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -877,6 +877,10 @@ erts_bld_port_info(Eterm **hpp,
 
 void erts_bif_info_init(void);
 
+/* erl_bif_lists.c */
+
+void erts_init_bif_lists(void);
+
 /* bif.c */
 
 void erts_queue_monitor_message(Process *,


### PR DESCRIPTION
* Before transforming algorithm into a trappable FSM improved `lists:subtract` (`--`) performance by ~11% on random inputs by reversing the algorithm (instead of eliminating elements in A for each element in B, I now shrink B by moving last element in place of eliminated element). On sorted inputs the performance is actually 5-10% lower.
* Algorithm is now a 5-state FSM: 1) Calculate length A; 2) Calculate length B; 3) Copy B to temp array; 4) Subtract B from A, shrinking B as elements in B are consumed; 5) Copy result array to result on process heap.
* All FSM steps are re-entrable and interruptible ( and use some reasonable numbers to limit work (300-600 elements for copying or comparing until it will BIF_TRAP).
* Trap re-enters via `lists:subtract/2` with first arg=`'bif_return_trap'` and second arg `{A, B, MagicBinary}`
* Algorithm for length is trappable and pure and can be reused elsewhere.
* Algorithms for copy list to array and copy array to list are also pure and can be reused elsewhere.
* Should be fairly easily back-portable: Only adds a large block of code to `erl_bif_lists.c` and constructor call to `erl_init`.