### PR TITLE
Make reltool correctly handle Windows 'ERL_LIBS'

### DIFF
--- a/lib/reltool/src/reltool_utils.erl
+++ b/lib/reltool/src/reltool_utils.erl
@@ -47,6 +47,9 @@
 
 	 call/2, cast/2, reply/3]).
 
+%% For testing
+-export([erl_libs/2]).
+
 -include_lib("kernel/include/file.hrl").
 -include_lib("wx/include/wx.hrl").
 -include("reltool.hrl").
@@ -55,7 +58,15 @@ root_dir() ->
     code:root_dir().
 
 erl_libs() ->
-    string:lexemes(os:getenv("ERL_LIBS", ""), ":;").
+    erl_libs(os:getenv("ERL_LIBS", ""), os:type()).
+
+erl_libs(ErlLibs, OsType) when is_list(ErlLibs) ->
+  Sep =
+    case OsType of
+      {win32, _} -> ";";
+      _          -> ":"
+    end,
+  string:lexemes(ErlLibs, Sep).
 
 lib_dirs(Dir) ->
     case erl_prim_loader:list_dir(Dir) of

--- a/lib/reltool/test/reltool_server_SUITE.erl
+++ b/lib/reltool/test/reltool_server_SUITE.erl
@@ -142,7 +142,8 @@ all() ->
      use_selected_vsn,
      use_selected_vsn_relative_path,
      non_standard_vsn_id,
-     undefined_regexp].
+     undefined_regexp,
+     windows_erl_libs].
 
 groups() -> 
     [].
@@ -2546,10 +2547,21 @@ undefined_regexp(_Config) ->
     ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Checks that reltool_utils can correctly read Windows ERL_LIBS
+
+windows_erl_libs(_Config) ->
+    WinErlLibs =
+        "C:\Program Files\Erlang Libs;C:\Program Files\More Erlang Libs",
+    Ret = reltool_utils:erl_libs(WinErlLibs, {win32, nt}),
+    ?m(["C:\Program Files\Erlang Libs","C:\Program Files\More Erlang Libs"],
+       Ret),
+    ok.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Library functions
 
 erl_libs() ->
-    string:lexemes(os:getenv("ERL_LIBS", ""), ":;").
+    reltool_utils:erl_libs().
 
 datadir(Config) ->
     %% Removes the trailing slash...

--- a/lib/reltool/test/reltool_server_SUITE.erl
+++ b/lib/reltool/test/reltool_server_SUITE.erl
@@ -2551,9 +2551,9 @@ undefined_regexp(_Config) ->
 
 windows_erl_libs(_Config) ->
     WinErlLibs =
-        "C:\Program Files\Erlang Libs;C:\Program Files\More Erlang Libs",
+        "C:\\Program Files\\Erlang Libs;C:\\Program Files\\More Erlang Libs",
     Ret = reltool_utils:erl_libs(WinErlLibs, {win32, nt}),
-    ?m(["C:\Program Files\Erlang Libs","C:\Program Files\More Erlang Libs"],
+    ?m(["C:\\Program Files\\Erlang Libs","C:\\Program Files\\More Erlang Libs"],
        Ret),
     ok.
 


### PR DESCRIPTION
Without this patch reltool would also try to split strings like "C:\foo" into ["C","\foo"].