### PR TITLE
fix extra parameter in <type>

### DIFF
--- a/lib/ssh/doc/src/ssh_sftp.xml
+++ b/lib/ssh/doc/src/ssh_sftp.xml
@@ -425,7 +425,6 @@
       <type>
         <v>ChannelPid = pid()</v>
         <v>Handle = term()</v>
-        <v>Position = integer()</v>
         <v>Len = integer()</v>
 	<v>Timeout = timeout()</v>
         <v>Data = string() | binary()</v>


### PR DESCRIPTION
```erlang
Position = integer()
```
Parameter doesn't exist in `read/3,4`