### PR TITLE
Fix bug when beam_jump removes put_tuple instructions

### DIFF
--- a/lib/compiler/src/beam_jump.erl
+++ b/lib/compiler/src/beam_jump.erl
@@ -128,7 +128,7 @@
 %%% on the program state.
 %%% 
 
--import(lists, [reverse/1,reverse/2,foldl/3]).
+-import(lists, [dropwhile/2,reverse/1,reverse/2,foldl/3]).
 
 -type instruction() :: beam_utils:instruction().
 
@@ -411,14 +411,19 @@ opt_useless_loads([{test,_,{f,L},_}=I|Is], L, St) ->
 opt_useless_loads(Is, _L, St) ->
     {Is,St}.
 
-opt_useless_block_loads([{set,[Dst],_,_}=I|Is], L, Index) ->
-    BlockJump = [{block,Is},{jump,{f,L}}],
+opt_useless_block_loads([{set,[Dst],_,_}=I|Is0], L, Index) ->
+    BlockJump = [{block,Is0},{jump,{f,L}}],
     case beam_utils:is_killed(Dst, BlockJump, Index) of
         true ->
-            %% The register is killed and not used, we can remove the load
+            %% The register is killed and not used, we can remove the load.
+            %% Remove any `put` instructions in case we just
+            %% removed a `put_tuple` instruction.
+            Is = dropwhile(fun({set,_,_,put}) -> true;
+                              (_) -> false
+                           end, Is0),
             opt_useless_block_loads(Is, L, Index);
         false ->
-            [I|opt_useless_block_loads(Is, L, Index)]
+            [I|opt_useless_block_loads(Is0, L, Index)]
     end;
 opt_useless_block_loads([I|Is], L, Index) ->
     [I|opt_useless_block_loads(Is, L, Index)];

--- a/lib/compiler/test/beam_jump_SUITE.erl
+++ b/lib/compiler/test/beam_jump_SUITE.erl
@@ -21,7 +21,8 @@
 
 -export([all/0,suite/0,groups/0,init_per_suite/1,end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
-	 undefined_label/1,ambiguous_catch_try_state/1]).
+	 undefined_label/1,ambiguous_catch_try_state/1,
+         build_tuple/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]}].
@@ -32,7 +33,8 @@ all() ->
 groups() ->
     [{p,[parallel],
       [undefined_label,
-       ambiguous_catch_try_state
+       ambiguous_catch_try_state,
+       build_tuple
       ]}].
 
 init_per_suite(Config) ->
@@ -72,3 +74,16 @@ river() -> song.
 checks(Wanted) ->
     %% Must be one line to cause the unsafe optimization.
     {catch case river() of sheet -> begin +Wanted, if "da" -> Wanted end end end, catch case river() of sheet -> begin + Wanted, if "da" -> Wanted end end end}.
+
+-record(message2, {id, p1}).
+-record(message3, {id, p1, p2}).
+
+build_tuple(_Config) ->
+    {'EXIT',{{badrecord,message3},_}} = (catch do_build_tuple(#message2{})),
+    ok.
+
+do_build_tuple(Message) ->
+    if is_record(Message, message2) ->
+	    Res = {res, rand:uniform(100)},
+	    {Message#message3.id, Res}
+    end.


### PR DESCRIPTION
`beam_jump` could remove a `put_tuple` instruction when the
tuple would not be used, but it would leave the following
`put` instructions. Make sure they are removed.

https://bugs.erlang.org/browse/ERL-759