### PR TITLE
Turn some gcbifs to ubifs on 64bit systems

### DIFF
--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -608,8 +608,12 @@ $(TTF_DIR)/erl_dirty_bif_wrap.c \
 $(HIPE_NBIF_FILES) \
 	: $(TTF_DIR)/TABLES-GENERATED
 $(TTF_DIR)/TABLES-GENERATED: $(ATOMS) $(DIRTY_BIFS) $(BIFS) utils/make_tables
-	$(gen_verbose)LANG=C $(PERL) utils/make_tables -src $(TTF_DIR) -include $(TTF_DIR)\
-		-dst $(DS_TEST) -hipe $(HIPE) $(ATOMS) $(DIRTY_BIFS) $(BIFS) && echo $? >$(TTF_DIR)/TABLES-GENERATED
+	$(gen_verbose)LANG=C $(PERL) utils/make_tables \
+		-wordsize @EXTERNAL_WORD_SIZE@ \
+		-src $(TTF_DIR) \
+		-include $(TTF_DIR) \
+		-dst $(DS_TEST) \
+		-hipe $(HIPE) $(ATOMS) $(DIRTY_BIFS) $(BIFS) && echo $? >$(TTF_DIR)/TABLES-GENERATED
 GENERATE += $(TTF_DIR)/TABLES-GENERATED
 
 $(TTF_DIR)/erl_alloc_types.h: beam/erl_alloc.types utils/make_alloc_types

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -135,7 +135,11 @@ bif erlang:registered/0
 gcbif erlang:round/1
 ubif erlang:self/0
 bif erlang:setelement/3
+%if ARCH_64
+ubif erlang:size/1
+%else
 gcbif erlang:size/1
+%endif
 bif erlang:spawn/3
 bif erlang:spawn_link/3
 bif erlang:split_binary/2
@@ -480,7 +484,11 @@ bif erlang:list_to_existing_atom/1
 #
 ubif erlang:is_bitstring/1
 ubif erlang:tuple_size/1
+%if ARCH_64
+ubif erlang:byte_size/1
+%else
 gcbif erlang:byte_size/1
+%endif
 gcbif erlang:bit_size/1
 bif erlang:list_to_bitstring/1
 bif erlang:bitstring_to_list/1
@@ -622,7 +630,11 @@ bif io:printable_range/0
 bif re:inspect/2
 
 ubif erlang:is_map/1
+%if ARCH_64
+ubif erlang:map_size/1
+%else
 gcbif erlang:map_size/1
+%endif
 bif maps:find/2
 bif maps:get/2
 bif maps:from_list/1

--- a/erts/emulator/beam/bif_instrs.tab
+++ b/erts/emulator/beam/bif_instrs.tab
@@ -55,7 +55,7 @@ CALL_GUARD_BIF(BF, TmpReg, Dst) {
 // to the code for the next clause.  We don't support tracing
 // of guard BIFs.
 
-bif1(Fail, Bif, Src, Dst) {
+i_bif1(Fail, Bif, Src, Dst) {
     ErtsBifFunc bf;
     Eterm tmp_reg[1];
 
@@ -70,7 +70,7 @@ bif1(Fail, Bif, Src, Dst) {
 // Guard BIF in body.  It can fail like any BIF.  No trace support.
 //
 
-bif1_body(Bif, Src, Dst) {
+i_bif1_body(Bif, Src, Dst) {
     ErtsBifFunc bf;
     Eterm tmp_reg[1];
 

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -125,15 +125,20 @@ BIF_RETTYPE map_size_1(BIF_ALIST_1) {
 	flatmap_t *mp = (flatmap_t*)flatmap_val(BIF_ARG_1);
 	BIF_RET(make_small(flatmap_get_size(mp)));
     } else if (is_hashmap(BIF_ARG_1)) {
-	Eterm *head, *hp, res;
-	Uint size, hsz=0;
+#ifdef ARCH_64
+        BIF_RET(make_small(hashmap_size(BIF_ARG_1)));
+#else
+	Eterm *hp;
+	Uint size;
 
-	head = hashmap_val(BIF_ARG_1);
-	size = head[1];
-	(void) erts_bld_uint(NULL, &hsz, size);
-	hp = HAlloc(BIF_P, hsz);
-	res = erts_bld_uint(&hp, NULL, size);
-	BIF_RET(res);
+        size = hashmap_size(BIF_ARG_1);
+        if (IS_USMALL(0, size)) {
+            BIF_RET(make_small(size));
+        } else {
+	    hp = HAlloc(BIF_P, BIG_UINT_HEAP_SIZE);
+            BIF_RET(uint_to_big(size, hp));
+        }
+#endif
     }
 
     BIF_P->fvalue = BIF_ARG_1;

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -1002,7 +1002,18 @@ bif1 Fail Bif=u$bif:erlang:get/1 Src=s Dst=d => gen_get(Src, Dst)
 
 bif2 Jump=j u$bif:erlang:element/2 S1=s S2=xy Dst=d => gen_element(Jump, S1, S2, Dst)
 
-bif1 p Bif S1 Dst => bif1_body Bif S1 Dst
+#
+# Old guard BIFs that creates heap fragments are no longer allowed.
+#
+bif1 Fail u$bif:erlang:length/1 s d => too_old_compiler
+bif1 Fail u$bif:erlang:size/1 s d => too_old_compiler
+bif1 Fail u$bif:erlang:abs/1 s d => too_old_compiler
+bif1 Fail u$bif:erlang:float/1 s d => too_old_compiler
+bif1 Fail u$bif:erlang:round/1 s d => too_old_compiler
+bif1 Fail u$bif:erlang:trunc/1 s d => too_old_compiler
+
+bif1 p Bif S1 Dst => i_bif1_body Bif S1 Dst
+bif1 Fail Bif Src Dst => i_bif1 Fail Bif Src Dst
 
 bif2 p Bif S1 S2 Dst => i_bif2_body Bif S1 S2 Dst
 bif2 Fail Bif S1 S2 Dst => i_bif2 Fail Bif S1 S2 Dst
@@ -1023,8 +1034,8 @@ i_fast_element xy j? I d
 
 i_element xy j? s d
 
-bif1 f? b s d
-bif1_body b s d
+i_bif1 f? b s d
+i_bif1_body b s d
 i_bif2 f? b s s d
 i_bif2_body b s s d
 
@@ -1575,17 +1586,22 @@ i_int_bnot Fail Src=c Live Dst => move Src x | i_int_bnot Fail x Live Dst
 i_int_bnot j? S t d
 
 #
-# Old guard BIFs that creates heap fragments are no longer allowed.
+# 64bit assumes map and binary size fit in small
 #
-bif1 Fail u$bif:erlang:length/1 s d => too_old_compiler
-bif1 Fail u$bif:erlang:size/1 s d => too_old_compiler
-bif1 Fail u$bif:erlang:abs/1 s d => too_old_compiler
-bif1 Fail u$bif:erlang:float/1 s d => too_old_compiler
-bif1 Fail u$bif:erlang:round/1 s d => too_old_compiler
-bif1 Fail u$bif:erlang:trunc/1 s d => too_old_compiler
+%if ARCH_64
+gc_bif1 Fail I Bif=u$bif:erlang:map_size/1 Src Dst => \
+    bif1 Fail Bif Src Dst
+gc_bif1 Fail I Bif=u$bif:erlang:byte_size/1 Src Dst => \
+    bif1 Fail Bif Src Dst
+gc_bif1 p I Bif=u$bif:erlang:size/1 Src Dst => \
+    i_bif1_body Bif Src Dst
+gc_bif1 Fail I Bif=u$bif:erlang:size/1 Src Dst => \
+    i_bif1 Fail Bif Src Dst
+%endif
+
 
 #
-# Guard BIFs.
+# GC Guard BIFs.
 #
 gc_bif1 Fail I Bif Src Dst => \
 	gen_guard_bif1(Fail, I, Bif, Src, Dst)

--- a/erts/emulator/utils/make_tables
+++ b/erts/emulator/utils/make_tables
@@ -31,6 +31,7 @@ use File::Basename;
 # Options:
 #    -src directory	Where to write generated C source files (default ".").
 #    -include directory Where to generate generated C header files (default ".").
+#    -DVAR_NAME=VAR_VALUE
 #
 # Output:
 #    <-src>/erl_am.c
@@ -61,6 +62,14 @@ my @bif;
 my @bif_info;
 my $dirty_schedulers_test = 'no';
 my $hipe = 'no';
+my $wordsize = 32;
+
+#
+# Pre-processor.
+#
+my @if_val;
+my @if_line;
+my %defs;
 
 while (@ARGV && $ARGV[0] =~ /^-(\w+)/) {
     my $opt = shift;
@@ -80,15 +89,65 @@ while (@ARGV && $ARGV[0] =~ /^-(\w+)/) {
 	$hipe = shift;
 	die "No -hipe argument specified"
 	    unless defined $hipe;
+    } elsif($opt eq '-wordsize') {
+        $wordsize = shift;
+        die "No -wordsize argument specified"
+            unless defined $wordsize;
+    } elsif($opt =~ /^D(\w+)=(\w+)/) {
+        $defs{$1} = $2;
     } else {
 	usage("bad option: $opt");
     }
 }
 
+if ($wordsize == 32) {
+    $defs{'ARCH_32'} = 1;
+    $defs{'ARCH_64'} = 0;
+} elsif ($wordsize == 64) {
+    $defs{'ARCH_32'} = 0;
+    $defs{'ARCH_64'} = 1;
+}
 
 while (<>) {
     next if /^#/;
     next if /^\s*$/;
+
+    #
+    # Handle %if
+    #
+    if (/^\%if (\w+)/) {
+        my $name = $1;
+        my $val = $defs{$name};
+        defined $val or error("'$name' is undefined");
+        push @if_val, $val;
+        push @if_line, $.;
+        next;
+    } elsif (/^\%unless (\w+)/) {
+        my $name = $1;
+        my $val = $defs{$name};
+        defined $val or error("'$name' is undefined");
+        push @if_val, !$val;
+        push @if_line, $.;
+        next;
+    } elsif (/^\%else$/) {
+        unless (@if_line) {
+            error("%else without a preceding %if/%unless");
+        }
+        $if_line[$#if_line] = $.;
+        $if_val[$#if_val] = !$if_val[$#if_val];
+        next;
+    } elsif (/^\%endif$/) {
+        unless (@if_line) {
+            error("%endif without a preceding %if/%unless/%else");
+        }
+        pop @if_val;
+        pop @if_line;
+        next;
+    }
+    if (@if_val and not $if_val[$#if_val]) {
+        next;
+    }
+
     my($type, @args) = split;
     if ($type eq 'atom') {
 	save_atoms(@args);
@@ -302,7 +361,7 @@ for ($i = 0; $i < @bif; $i++) {
 }
 
 #
-# Generate erl_gc_bifs.c.
+# Generate erl_guard_bifs.c.
 #
 
 open_file("$src/erl_guard_bifs.c");


### PR DESCRIPTION
BIFs `erlang:size/1`, `erlang:byte_size/1` and `erlang:map_size/1` on 64bit systems would never trigger GC, so they can be implemented as regular non-gc BIFs - they are slightly more efficient.
The change is done only in the VM and the loader - the compiler always produces gc_bif instructions for those BIFs.

The fact that size of bianries fits into small ints on 64bits is already leveraged in the new `bs_get/set_position` instructions. If byte size of binaries will fit into a small, so will a size of a map since the size indicates number of words instead of bytes.

Additionally:
  * change `erlang:map_size/1` implementation not to allocate a bigint if the hashmap size fits in a small, which should be the common case.
  * change the instruction names to `i_bif1` and `i_bif1_body` for consistency
  * support `%if` sequences in `make_tables` `.tab` files similar to files generated by `beam_makeops`