### PR TITLE
New attributes argtag and since to name

### DIFF
--- a/lib/erl_docgen/priv/dtd/erlref.dtd
+++ b/lib/erl_docgen/priv/dtd/erlref.dtd
@@ -25,6 +25,7 @@
 <!ELEMENT erlref              (header,module,modulesummary,description, 
 			       (section|funcs|datatypes)*,authors?) >
 <!ELEMENT module              (#PCDATA) >
+<!ATTLIST module              since CDATA #IMPLIED>
 <!ELEMENT modulesummary       (#PCDATA) >
 
 <!-- `name' is used in common.refs.dtd and must therefore 
@@ -34,4 +35,6 @@
                                arity CDATA #IMPLIED
 	                       clause_i CDATA #IMPLIED
                                anchor CDATA #IMPLIED
-                               n_vars CDATA #IMPLIED>
+                               n_vars CDATA #IMPLIED
+                               argtag CDATA #IMPLIED
+	                       since CDATA #IMPLIED>


### PR DESCRIPTION
Introduce new attributes argtag and since to the name element. The since attribute is also added to the module element.

This allows to specify in which OTP release a specific function was introduced