### PR TITLE
Update and fix systemtap trace example scripts

### DIFF
--- a/lib/runtime_tools/examples/dist.systemtap
+++ b/lib/runtime_tools/examples/dist.systemtap
@@ -19,18 +19,18 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("dist-monitor")
+probe process("beam.smp").mark("dist-monitor")
 {
     printf("monitor: pid %d, who %s, what %s, node %s, type %s, reason %s\n",
            pid(),
@@ -38,38 +38,38 @@ probe process("beam").mark("dist-monitor")
            user_string($arg5));
 }
 
-probe process("beam").mark("dist-port_busy")
+probe process("beam.smp").mark("dist-port_busy")
 {
     printf("dist port_busy: node %s, port %s, remote_node %s, blocked pid %s\n",
            user_string($arg1), user_string($arg2), user_string($arg3), user_string($arg4));
-    blocked_procs[user_string($arg4)] = timestamp;
+    blocked_procs[user_string($arg4)] = local_clock_ns();
 }
 
-probe process("beam").mark("dist-port_busy")
+probe process("beam.smp").mark("dist-port_busy")
 {
     printf("dist port_busy: node %s, port %s, remote_node %s, blocked pid %s\n",
            user_string($arg1), user_string($arg2), user_string($arg3), user_string($arg4));
-    blocked_procs[user_string($arg4)] = timestamp;
+    blocked_procs[user_string($arg4)] = local_clock_ns();
 }
 
-probe process("beam").mark("dist-output")
+probe process("beam.smp").mark("dist-output")
 {
     printf("dist output: node %s, port %s, remote_node %s bytes %d\n",
            user_string($arg1), user_string($arg2), user_string($arg3), $arg4);
 }
 
-probe process("beam").mark("dist-outputv")
+probe process("beam.smp").mark("dist-outputv")
 {
     printf("port outputv: node %s, port %s, remote_node %s bytes %d\n",
            user_string($arg1), user_string($arg2), user_string($arg3), $arg4);
 }
 
-probe process("beam").mark("process-scheduled")
+probe process("beam.smp").mark("process-scheduled")
 {
     pidstr = user_string($arg1);
     if (pidstr in blocked_procs) {
 	printf("blocked pid %s scheduled now, waited %d microseconds\n",
-		pidstr, (timestamp - blocked_procs[pidstr]) / 1000);
+		pidstr, (local_clock_ns() - blocked_procs[pidstr]) / 1000);
 	delete blocked_procs[pidstr];
     }
 }

--- a/lib/runtime_tools/examples/driver1.systemtap
+++ b/lib/runtime_tools/examples/driver1.systemtap
@@ -19,108 +19,102 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("driver-init")
+probe process("beam.smp").mark("driver__init")
 {
     printf("driver init name %s major %d minor %d flags %d\n",
 	   user_string($arg1), $arg2, $arg3, $arg4);
 }
 
-probe process("beam").mark("driver-start")
+probe process("beam.smp").mark("driver__start")
 {
     printf("driver start pid %s driver name %s port %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("driver-stop")
+probe process("beam.smp").mark("driver__stop")
 {
     printf("driver stop pid %s driver name %s port %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("driver-finish")
+probe process("beam.smp").mark("driver__finish")
 {
     printf("driver finish driver name %s\n",
            user_string($arg1));
 }
 
-probe process("beam").mark("driver-flush")
+probe process("beam.smp").mark("driver__flush")
 {
     printf("driver flush pid %s port %s port name %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("driver-output")
+probe process("beam.smp").mark("driver__output")
 {
     printf("driver output pid %s port %s port name %s bytes %d\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3), $arg4);
 }
 
-probe process("beam").mark("driver-outputv")
+probe process("beam.smp").mark("driver__outputv")
 {
     printf("driver outputv pid %s port %s port name %s bytes %d\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3), $arg4);
 }
 
-probe process("beam").mark("driver-control")
+probe process("beam.smp").mark("driver__control")
 {
     printf("driver control pid %s port %s port name %s command %d bytes %d\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3), $arg4, $arg5);
 }
 
-probe process("beam").mark("driver-call")
+probe process("beam.smp").mark("driver__call")
 {
     printf("driver call pid %s port %s port name %s command %d bytes %d\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3), $arg4, $arg5);
 }
 
-probe process("beam").mark("driver-event")
-{
-    printf("driver event pid %s port %s port name %s\n",
-	   user_string($arg1), user_string($arg2), user_string($arg3));
-}
-
-probe process("beam").mark("driver-ready_input")
+probe process("beam.smp").mark("driver__ready_input")
 {
     printf("driver ready_input pid %s port %s port name %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("driver-ready_output")
+probe process("beam.smp").mark("driver__ready_output")
 {
     printf("driver ready_output pid %s port %s port name %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("driver-timeout")
+probe process("beam.smp").mark("driver__timeout")
 {
     printf("driver timeout pid %s port %s port name %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("driver-ready_async")
+probe process("beam.smp").mark("driver__ready_async")
 {
     printf("driver ready_async pid %s port %s port name %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("driver-process_exit")
+probe process("beam.smp").mark("driver__process_exit")
 {
     printf("driver process_exit pid %s port %s port name %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("driver-stop_select")
+probe process("beam.smp").mark("driver__stop_select")
 {
     printf("driver stop_select driver name %s\n", user_string($arg1));
 }

--- a/lib/runtime_tools/examples/function-calls.systemtap
+++ b/lib/runtime_tools/examples/function-calls.systemtap
@@ -18,51 +18,51 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("local-function-entry")
+probe process("beam.smp").mark("local-function-entry")
 {
     printf("pid %s enter (local) %s depth %d\n",
 	   user_string($arg1), user_string($arg2), $arg3);
 }
 
-probe process("beam").mark("global-function-entry")
+probe process("beam.smp").mark("global-function-entry")
 {
     printf("pid %s enter (global)  %s depth %d\n",
 	   user_string($arg1), user_string($arg2), $arg3);
 }
 
-probe process("beam").mark("function-return")
+probe process("beam.smp").mark("function-return")
 {
     printf("pid %s return %s depth %d\n",
 	   user_string($arg1), user_string($arg2), $arg3);
 }
 
-probe process("beam").mark("bif-entry")
+probe process("beam.smp").mark("bif-entry")
 {
     printf("pid %s BIF entry  mfa %s\n", user_string($arg1), user_string($arg2));
 }
 
-probe process("beam").mark("bif-return")
+probe process("beam.smp").mark("bif-return")
 {
     printf("pid %s BIF return mfa %s\n", user_string($arg1), user_string($arg2));
 }
 
-probe process("beam").mark("nif-entry")
+probe process("beam.smp").mark("nif-entry")
 {
     printf("pid %s NIF entry  mfa %s\n", user_string($arg1), user_string($arg2));
 }
 
-probe process("beam").mark("nif-return")
+probe process("beam.smp").mark("nif-return")
 {
     printf("pid %s NIF return mfa %s\n", user_string($arg1), user_string($arg2));
 }

--- a/lib/runtime_tools/examples/garbage-collection.systemtap
+++ b/lib/runtime_tools/examples/garbage-collection.systemtap
@@ -18,33 +18,33 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("gc_major-start")
+probe process("beam.smp").mark("gc_major-start")
 {
     printf("GC major start pid %s need %d words\n", user_string($arg1), $arg2);
 }
 
-probe process("beam").mark("gc_minor-start")
+probe process("beam.smp").mark("gc_minor-start")
 {
     printf("GC minor start pid %s need %d words\n", user_string($arg1), $arg2);
 }
 
-probe process("beam").mark("gc_major-end")
+probe process("beam.smp").mark("gc_major-end")
 {
     printf("GC major end pid %s reclaimed %d words\n", user_string($arg1), $arg2);
 }
 
-probe process("beam").mark("gc_minor-start")
+probe process("beam.smp").mark("gc_minor-start")
 {
     printf("GC minor end pid %s reclaimed %d words\n", user_string($arg1), $arg2);
 }

--- a/lib/runtime_tools/examples/memory1.systemtap
+++ b/lib/runtime_tools/examples/memory1.systemtap
@@ -18,34 +18,34 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("copy-struct")
+probe process("beam.smp").mark("copy-struct")
 {
     printf("copy_struct %d bytes\n", $arg1);
 }
 
-probe process("beam").mark("copy-object")
+probe process("beam.smp").mark("copy-object")
 {
     printf("copy_object pid %s %d bytes\n", user_string($arg1), $arg2);
 }
 
-probe process("beam").mark("process-heap_grow")
+probe process("beam.smp").mark("process-heap_grow")
 {
     printf("proc heap grow pid %s %d -> %d bytes\n", user_string($arg1),
 	   $arg2, $arg3);
 }
 
-probe process("beam").mark("process-heap_shrink")
+probe process("beam.smp").mark("process-heap_shrink")
 {
     printf("proc heap shrink pid %s %d -> %d bytes\n", user_string($arg1),
 	   $arg2, $arg3);

--- a/lib/runtime_tools/examples/messages.systemtap
+++ b/lib/runtime_tools/examples/messages.systemtap
@@ -18,15 +18,15 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
 probe begin
@@ -38,7 +38,7 @@ probe begin
     printf("\n");
 }
 
-probe process("beam").mark("message-send")
+probe process("beam.smp").mark("message-send")
 {
     if ($arg4 == 0 && $arg5 == 0 && $arg6 == 0) {
         printf("send:   %s -> %s: %d words\n",
@@ -51,7 +51,7 @@ probe process("beam").mark("message-send")
     }
 }
 
-probe process("beam").mark("message-send-remote")
+probe process("beam.smp").mark("message-send-remote")
 {
     if ($arg5 == 0 && $arg6 == 0 && $arg7 == 0) {
         printf("send :  %s -> %s %s: %d words\n",
@@ -64,7 +64,7 @@ probe process("beam").mark("message-send-remote")
     }
 }
 
-probe process("beam").mark("message-queued")
+probe process("beam.smp").mark("message-queued")
 {
     if ($arg4 == 0 && $arg5 == 0 && $arg6 == 0) {
         printf("queued: %s: %d words, queue len %d\n", user_string($arg1), $arg2, $arg3);
@@ -75,7 +75,7 @@ probe process("beam").mark("message-queued")
     }
 }
 
-probe process("beam").mark("message-receive")
+probe process("beam.smp").mark("message-receive")
 {
     if ($arg4 == 0 && $arg5 == 0 && $arg6 == 0) {
         printf("receive: %s: %d words, queue len %d\n",

--- a/lib/runtime_tools/examples/port1.systemtap
+++ b/lib/runtime_tools/examples/port1.systemtap
@@ -18,15 +18,15 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
 probe begin
@@ -96,19 +96,19 @@ probe begin
         driver_map["udp_inet", 62] = "BINDX";
 }
 
-probe process("beam").mark("port-open")
+probe process("beam.smp").mark("port-open")
 {
     printf("port open pid %s port name %s port %s\n",
            user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("port-command")
+probe process("beam.smp").mark("port-command")
 {
     printf("port command pid %s port %s port name %s command type %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3), user_string($arg4));
 }
 
-probe process("beam").mark("port-control")
+probe process("beam.smp").mark("port-control")
 {
     cmd = driver_map[user_string($arg3), $arg4];
     cmd_str = (cmd == "") ? "unknown" : cmd;
@@ -118,34 +118,34 @@ probe process("beam").mark("port-control")
 
 /* port-exit is fired as a result of port_close() or exit signal */
 
-probe process("beam").mark("port-exit")
+probe process("beam.smp").mark("port-exit")
 {
     printf("port exit pid %s port %s port name %s reason %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3), user_string($arg4));
 }
 
-probe process("beam").mark("port-connect")
+probe process("beam.smp").mark("port-connect")
 {
     printf("port connect pid %s port %s port name %s new pid %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3), user_string($arg4));
 }
 
-probe process("beam").mark("port-busy")
+probe process("beam.smp").mark("port-busy")
 {
     printf("port busy %s\n", user_string($arg1));
 }
 
-probe process("beam").mark("port-not_busy")
+probe process("beam.smp").mark("port-not_busy")
 {
     printf("port not busy %s\n", user_string($arg1));
 }
 
-probe process("beam").mark("aio_pool-add")
+probe process("beam.smp").mark("aio_pool-add")
 {
     printf("async I/O pool add thread %d queue len %d\n", $arg1, $arg2);
 }
 
-probe process("beam").mark("aio_pool-get")
+probe process("beam.smp").mark("aio_pool-get")
 {
     printf("async I/O pool get thread %d queue len %d\n", $arg1, $arg2);
 }

--- a/lib/runtime_tools/examples/process-scheduling.systemtap
+++ b/lib/runtime_tools/examples/process-scheduling.systemtap
@@ -18,28 +18,28 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("process-scheduled")
+probe process("beam.smp").mark("process-scheduled")
 {
     printf("  Schedule pid %s mfa %s\n", user_string($arg1), user_string($arg2));
 }
 
-probe process("beam").mark("process-unscheduled")
+probe process("beam.smp").mark("process-unscheduled")
 {
     printf("Unschedule pid %s\n", user_string($arg1));
 }
 
-probe process("beam").mark("process-hibernate")
+probe process("beam.smp").mark("process-hibernate")
 {
     printf("  Hibernate pid %s resume mfa %s\n",
      user_string($arg1), user_string($arg2));

--- a/lib/runtime_tools/examples/spawn-exit.systemtap
+++ b/lib/runtime_tools/examples/spawn-exit.systemtap
@@ -18,34 +18,34 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("process-spawn")
+probe process("beam.smp").mark("process-spawn")
 {
     printf("pid %s mfa %s\n", user_string($arg1), user_string($arg2));
 }
 
-probe process("beam").mark("process-exit")
+probe process("beam.smp").mark("process-exit")
 {
     printf("pid %s reason %s\n", user_string($arg1), user_string($arg2));
 }
 
-probe process("beam").mark("process-exit_signal")
+probe process("beam.smp").mark("process-exit_signal")
 {
     printf("sender %s -> pid %s reason %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3));
 }
 
-probe process("beam").mark("process-exit_signal-remote")
+probe process("beam.smp").mark("process-exit_signal-remote")
 {
     printf("sender %s -> node %s pid %s reason %s\n",
 	   user_string($arg1), user_string($arg2), user_string($arg3), user_string($arg4));

--- a/lib/runtime_tools/examples/user-probe-n.systemtap
+++ b/lib/runtime_tools/examples/user-probe-n.systemtap
@@ -18,18 +18,19 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("user_trace-n0")
+
+probe process("beam.smp").mark("user_trace-n0")
 {
     printf("probe n0: %s %s %d %d %d %d '%s' '%s' '%s' '%s'\n",
            user_string($arg1),
@@ -41,7 +42,7 @@ probe process("beam").mark("user_trace-n0")
            $arg9 == NULL ? "" : user_string($arg9));
 }
 
-probe process("beam").mark("user_trace-n1")
+probe process("beam.smp").mark("user_trace-n1")
 {
     printf("probe n1: %s %s %d %d %d %d '%s' '%s' '%s' '%s'\n",
            user_string($arg1),

--- a/lib/runtime_tools/examples/user-probe.systemtap
+++ b/lib/runtime_tools/examples/user-probe.systemtap
@@ -18,23 +18,23 @@
  * %CopyrightEnd%
  */
 /*
- * Note: This file assumes that you're using the non-SMP-enabled Erlang
- *       virtual machine, "beam".  The SMP-enabled VM is called "beam.smp".
+ * Note: This file assumes that you're using the SMP-enabled Erlang
+ *       virtual machine, "beam.smp".
  *       Note that other variations of the virtual machine also have
  *       different names, e.g. the debug build of the SMP-enabled VM
  *       is "beam.debug.smp".
  *
  *       To use a different virtual machine, replace each instance of
- *       "beam" with "beam.smp" or the VM name appropriate to your
- *       environment.
+ *       "beam.smp" with "beam.debug.smp" or the VM name appropriate
+ *       to your environment.
  */
 
-probe process("beam").mark("user_trace-s1")
+probe process("beam.smp").mark("user_trace-s1")
 {
     printf("%s\n", user_string($arg1));
 }
 
-probe process("beam").mark("user_trace-i4s4")
+probe process("beam.smp").mark("user_trace-i4s4")
 {
     printf("%s %s %d %d %d %d '%s' '%s' '%s' '%s'\n",
            user_string($arg1),


### PR DESCRIPTION
- Update all scripts to use the beam.smp emulator, since the non-SMP one
  is gone
- Fix some scripts that had been copied directly from dtrace and were
  invalid either for functions or for probe names
- Removed a driver__event probe check since it appears to not exist

I'm not aware of any tests for these, but I did a manual check for all of them,
aside from `lib/runtime_tools/examples/user-probe-n.systemtap` which I could
load without error, but have no idea how to trigger. Only `user-probe.systemtap`
appears to be triggerable through the `dyntrace` module, through the
`user_trace-i4s4` probe.