### PR TITLE
epmd: Move -systemd position in -help output

### DIFF
--- a/erts/epmd/src/epmd.c
+++ b/erts/epmd/src/epmd.c
@@ -437,6 +437,11 @@ static void usage(EpmdVars *g)
     fprintf(stderr, "        epmd -kill even if there "
 	    "are registered nodes.\n");
     fprintf(stderr, "        Also allows forced unregister (epmd -stop).\n");
+#ifdef HAVE_SYSTEMD_DAEMON
+    fprintf(stderr, "    -systemd\n");
+    fprintf(stderr, "        Wait for socket from systemd. The option makes sense\n");
+    fprintf(stderr, "        when started from .socket unit.\n");
+#endif /* HAVE_SYSTEMD_DAEMON */
     fprintf(stderr, "\nDbgExtra options\n");
     fprintf(stderr, "    -packet_timeout Seconds\n");
     fprintf(stderr, "        Set the number of seconds a connection can be\n");
@@ -462,11 +467,6 @@ static void usage(EpmdVars *g)
     fprintf(stderr, "        Forcibly unregisters a name with epmd\n");
     fprintf(stderr, "        (only allowed if -relaxed_command_check was given when \n");
     fprintf(stderr, "        epmd was started).\n");
-#ifdef HAVE_SYSTEMD_DAEMON
-    fprintf(stderr, "    -systemd\n");
-    fprintf(stderr, "        Wait for socket from systemd. The option makes sense\n");
-    fprintf(stderr, "        when started from .socket unit.\n");
-#endif /* HAVE_SYSTEMD_DAEMON */
     epmd_cleanup_exit(g,1);
 }
 


### PR DESCRIPTION
-systemd option help is currently shown in "Interactive options" section.
The option is not interactive one.

Fixes: b7c95eabf601 ("Add systemd socket activation for epmd")
Signed-off-by: Matwey V. Kornilov <matwey.kornilov@gmail.com>