### PR TITLE
Speed up the compiler

### DIFF
--- a/lib/compiler/src/beam_ssa_pre_codegen.erl
+++ b/lib/compiler/src/beam_ssa_pre_codegen.erl
@@ -2211,7 +2211,13 @@ linear_scan(#st{intervals=Intervals0,res=Res}=St0) ->
     Free = init_free(maps:to_list(Res)),
     Intervals1 = [init_interval(Int, Res) || Int <- Intervals0],
     Intervals = sort(Intervals1),
-    IsReserved = fun (#i{reg=Reg}) -> Reg =/= none end,
+    IsReserved = fun(#i{reg=Reg}) ->
+                         case Reg of
+                             none -> false;
+                             {prefer,{_,_}} -> false;
+                             {_,_} -> true
+                         end
+                 end,
     {UnhandledRes,Unhandled} = partition(IsReserved, Intervals),
     L = #l{unhandled_res=UnhandledRes,
            unhandled_any=Unhandled,free=Free},


### PR DESCRIPTION
@kostis noticed that the compiler on the `master` was much slower than the compiler in OTP 21 when compiling this module:

https://github.com/aggelgian/cuter/blob/master/src/cuter_binlib.erl

This pull request eliminates three bottlenecks in the compiler and reduces the compilation time from about three and half minutes down to about half a minute on my computer. See the individual commit messages for  details.