### PR TITLE
Prevent timeout failure

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -666,9 +666,9 @@ user_hello({call, From}, cancel, #state{negotiated_version = Version} = State, _
                      Version, ?FUNCTION_NAME, State);
 user_hello({call, From}, {handshake_continue, NewOptions, Timeout}, #state{hello = Hello,
                                                                            role = Role,
-                                                                           start_or_recv_from = RecvFrom,
+                                                                           start_or_recv_from = _RecvFrom,
                                                                            ssl_options = Options0} = State0, _Connection) ->
-    Timer = start_or_recv_cancel_timer(Timeout, RecvFrom),
+    Timer = start_or_recv_cancel_timer(Timeout, From),
     Options = ssl:handle_options(NewOptions, Options0#ssl_options{handshake = full}),
     State = ssl_config(Options, Role, State0, continue),
     {next_state, hello, State#state{start_or_recv_from = From,


### PR DESCRIPTION

Prevent timeout failure  …
At this point RecvFrom is undefined, replaced with From.
Steps to reproduce - call handshake_continue with very low timeout (1) and see crash report with
exception error: {bad_reply_action_from_state_function,
                         {reply,undefined,{error,timeout}}}