### PR TITLE
Fix remote-call error in ms_transform

### DIFF
--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -556,8 +556,8 @@ tg({call, Line, {remote,_,{atom,_,erlang},{atom, Line2, FunName}},ParaList},
 			       FunName,length(ParaList)}}) 
     end;
 tg({call, Line, {remote,_,{atom,_,ModuleName},
-		 {atom, _, FunName}},_ParaList},B) ->
-    throw({error,Line,{?ERR_GENREMOTECALL+B#tgd.eb,ModuleName,FunName}});
+		 {atom, _, FunName}},ParaList},B) ->
+    throw({error,Line,{?ERR_GENREMOTECALL+B#tgd.eb,ModuleName,FunName,length(ParaList)}});
 tg({cons,Line, H, T},B) -> 
     {cons, Line, tg(H,B), tg(T,B)};
 tg({nil, Line},_B) ->


### PR DESCRIPTION
Before this patch the following call resulted in the below error
```
1> dbg:fun2ms(fun(_) -> m:f() end).
Error: Unknown error code {122,m,f}
```

Now it is properly formatted as
```
1> dbg:fun2ms(fun(_) -> m:f() end).
Error: fun containing the remote function call 'm:f/0' (called in body) cannot be translated into match_spec
```

I couldn't find any tests for exact error codes and formatting in `ms_transform_SUITE`. Let me know if I should add one.