### PR TITLE
Fix inadvertently suppressed warning for unused variable

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2262,8 +2262,7 @@ expr({'fun',Line,Body}, Vt, St) ->
 	    {[],St};
 	{function,M,F,A} ->
 	    %% New in R15.
-	    {Bvt, St1} = expr_list([M,F,A], Vt, St),
-	    {vtupdate(Bvt, Vt),St1}
+	    expr_list([M,F,A], Vt, St)
     end;
 expr({named_fun,_,'_',Cs}, Vt, St) ->
     fun_clauses(Cs, Vt, St);

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -67,7 +67,8 @@
          record_errors/1, otp_11879_cont/1,
          non_latin1_module/1, otp_14323/1,
          stacktrace_syntax/1,
-         otp_14285/1, otp_14378/1]).
+         otp_14285/1, otp_14378/1,
+         external_funs/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -88,7 +89,7 @@ all() ->
      maps, maps_type, maps_parallel_match,
      otp_11851, otp_11879, otp_13230,
      record_errors, otp_11879_cont, non_latin1_module, otp_14323,
-     stacktrace_syntax, otp_14285, otp_14378].
+     stacktrace_syntax, otp_14285, otp_14378, external_funs].
 
 groups() -> 
     [{unused_vars_warn, [],
@@ -4131,6 +4132,21 @@ otp_14285(Config) ->
            {errors,
             [{1,erl_lint,E4}],
             []}}],
+    run(Config, Ts),
+    ok.
+
+external_funs(Config) when is_list(Config) ->
+    Ts = [{external_funs_1,
+           %% ERL-762: Unused variable warning not being emitted.
+           <<"f() ->
+                BugVar = process_info(self()),
+                if true -> fun m:f/1 end.
+              f(M, F) ->
+                BugVar = process_info(self()),
+                if true -> fun M:F/1 end.">>,
+           [],
+           {warnings,[{2,erl_lint,{unused_var,'BugVar'}},
+                      {5,erl_lint,{unused_var,'BugVar'}}]}}],
     run(Config, Ts),
     ok.
 


### PR DESCRIPTION
An external fun could inadvertently suppress warnings for
unused variables, such as in this example:

    bug() ->
        BugVar = foo(),
        if true ->
            fun m:f/1
        end.

There would be no warning that `BugVar` was unused.

The bug was introduced in ff432e262e652, which was the commit
that extended external funs to allow variables.

https://bugs.erlang.org/browse/ERL-762