### PR TITLE
Fix dirty scheduler collapse

### DIFF
--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -517,7 +517,8 @@ do_break(void)
 
     erts_printf("\n"
 		"BREAK: (a)bort (c)ontinue (p)roc info (i)nfo (l)oaded\n"
-		"       (v)ersion (k)ill (D)b-tables (d)istribution\n");
+		"       (v)ersion (k)ill (D)b-tables (d)istribution\n"
+		"       (s)cheduler info (dirty cpu)\n");
 
     while (1) {
 	if ((i = sys_get_key(0)) <= 0)
@@ -538,6 +539,18 @@ do_break(void)
 	    return;
 	case 'p':
 	    process_info(ERTS_PRINT_STDOUT, NULL);
+	    return;
+	case 's':
+	    for (i = 0; i < erts_no_dirty_cpu_schedulers; i++) {
+#if defined(ERTS_HAVE_TRY_CATCH)
+		ERTS_SYS_TRY_CATCH(
+		    erts_print_scheduler_info(ERTS_PRINT_STDOUT, NULL, ERTS_DIRTY_CPU_SCHEDULER_IX(i)),
+		    erts_cbprintf(ERTS_PRINT_STDOUT, NULL, "** crashed **\n"));
+#else	    /* take the risk for testing on macosx */
+		erts_print_scheduler_info(ERTS_PRINT_STDOUT, NULL, ERTS_DIRTY_CPU_SCHEDULER_IX(i));
+#endif
+
+	    }
 	    return;
 	case 'm':
 	    return;

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -12717,6 +12717,30 @@ erts_print_scheduler_info(fmtfn_t to, void *to_arg, ErtsSchedulerData *esdp)
     }
     erts_print(to, to_arg, "\n");
 
+    if (esdp->type == ERTS_SCHED_DIRTY_CPU) {
+	ErtsRunQueue *rq;
+	ErtsSchedulerSleepInfo *ssi;
+	ErtsSchedulerSleepList *sl;
+	int max = erts_no_dirty_cpu_schedulers + 3;
+	int i = 0;
+	rq = ERTS_DIRTY_CPU_RUNQ;
+	sl = &rq->sleepers;
+	erts_spin_lock(&sl->lock);
+	ssi = sl->list;
+	erts_print(to, to_arg, "Scheduler Run Queue Len: %d\n", rq->len);
+	erts_print(to, to_arg, "Scheduler Sleeper List: ");
+	while(ssi) {
+	    erts_print(to, to_arg, "%x ", ssi);
+	    ssi = ssi->next;
+	    if(i++ > max) {
+		erts_print(to, to_arg, "hit max; stopping");
+		break;
+	    }
+	}
+	erts_spin_unlock(&sl->lock);
+	erts_print(to, to_arg, "\n");
+    }
+
     if (esdp->type == ERTS_SCHED_NORMAL) {
         erts_print(to, to_arg, "Current Port: ");
         if (esdp->current_port)

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -363,7 +363,7 @@ typedef struct {
 struct ErtsSchedulerSleepInfo_ {
     struct ErtsSchedulerData_ *esdp;
     ErtsSchedulerSleepInfo *next;
-    ErtsSchedulerSleepInfo *prev;
+    erts_atomic32_t in_sleepers_list;
     erts_atomic32_t flags;
     erts_tse_t *event;
     struct erts_poll_thread *psi;


### PR DESCRIPTION
I have been having issues with dirty schedulers dropping down to only perform work on a few of the online schedulers.
And there is a problem with the list of sleeping schedulers that can be inconsistent.
In some cases, at least when suspending schedulers the schedulers are re-added to the sleepers list.
Can be illustrated with suspending some schedulers with erlang:system_flag/2 providing dirty_cpu_schedulers_online.

In some cases the list of sleeping schedulers became a loop with only one scheduler.
So the only woken up scheduler was that one when there was job arriving.

[collapsed_dirty_scheduler_sleeper_list.txt](https://github.com/erlang/otp/files/2603389/collapsed_dirty_scheduler_sleeper_list.txt)

This PR propose a fix that has been working for me so far.
It is trying to make sure that a scheduler are only added once to the list of sleeping schedulers.
Please have a look and tell me what needs to be changed, if you are to accept this change.

First commit is just to be able to print some dirty_cpu_scheduler info from the break handler.
That commit should probably be removed since it will also add the same information to the crash dump. It was added to be able to check the state of the sleepers list before and after the change.
  