### PR TITLE
Fix encrypt_config_file and decrypt_config_file

### DIFF
--- a/lib/common_test/src/ct_config.erl
+++ b/lib/common_test/src/ct_config.erl
@@ -592,7 +592,7 @@ encrypt_config_file(SrcFileName, EncryptFileName, {file,KeyFile}) ->
 
 encrypt_config_file(SrcFileName, EncryptFileName, {key,Key}) ->
     _ = crypto:start(),
-    {Key,IVec} = make_crypto_key(Key),
+    {CryptoKey,IVec} = make_crypto_key(Key),
     case file:read_file(SrcFileName) of
 	{ok,Bin0} ->
 	    Bin1 = term_to_binary({SrcFileName,Bin0}),
@@ -600,7 +600,7 @@ encrypt_config_file(SrcFileName, EncryptFileName, {key,Key}) ->
 		       0 -> Bin1;
 		       N -> list_to_binary([Bin1,random_bytes(8-N)])
 		   end,
-	    EncBin = crypto:block_encrypt(des3_cbc, Key, IVec, Bin2),
+	    EncBin = crypto:block_encrypt(des3_cbc, CryptoKey, IVec, Bin2),
 	    case file:write_file(EncryptFileName, EncBin) of
 		ok ->
 		    io:format("~ts --(encrypt)--> ~ts~n",
@@ -631,10 +631,10 @@ decrypt_config_file(EncryptFileName, TargetFileName, {file,KeyFile}) ->
 
 decrypt_config_file(EncryptFileName, TargetFileName, {key,Key}) ->
     _ = crypto:start(),
-    {Key,IVec} = make_crypto_key(Key),
+    {CryptoKey,IVec} = make_crypto_key(Key),
     case file:read_file(EncryptFileName) of
 	{ok,Bin} ->
-	    DecBin = crypto:block_decrypt(des3_cbc, Key, IVec, Bin),
+	    DecBin = crypto:block_decrypt(des3_cbc, CryptoKey, IVec, Bin),
 	    case catch binary_to_term(DecBin) of
 		{'EXIT',_} ->
 		    {error,bad_file};


### PR DESCRIPTION
Variable Key is the input parameter and it will never match to the "Key" result of make_crypto_key/1 
In current case we'll always receive bad match when using encrypt_config_file and decrypt_config_file functions.