### PR TITLE
gen_statem exports types related to starting & naming

### DIFF
--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -67,6 +67,14 @@
 %% Type that is exported just to be documented
 -export_type([transition_option/0]).
 
+%% Type exports for start_link & friends
+-export_type(
+   [server_name/0,
+    server_ref/0,
+    hibernate_after_opt/0,
+    start_opt/0,
+    start_ret/0]).
+
 %%%==========================================================================
 %%% Interface functions.
 %%%==========================================================================


### PR DESCRIPTION
Currently, a user of gen_statem cannot use gen_statem types
related to naming & starting in their behaviour implementations

As an example, we cannot do:

```erlang
-spec start_link(Options) -> gen_statem:start_ret() when
      Options :: some_complex_thing().
start_link(Options) ->
    gen_statem:start_link(?MODULE, [Opts], []).
```

As dialyzer, if configured to complain about unknown types, will
warn that the type `gen_statem:start_ret()` is unknown.

Likewise, for the same reason, we cannot do:

```erlang
-spec do_call_to_gen_statem(ServerRef) -> Reply when
      ServerRef :: gen_statem:server_ref(),
      Reply :: term().
do_call_to_gen_statem(ServerRef) ->
    gen_statem:call(ServerRef, do_thing).
```

This fixes that by exporting the appropriate types