### PR TITLE
Add missing annotations in instrs.tab

### DIFF
--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -238,6 +238,7 @@ HANDLE_APPLY_FUN_ERROR() {
 }
 
 DISPATCH_FUN(I) {
+    //| -no_next
     SET_I($I);
     Dispatchfun();
 }
@@ -299,6 +300,7 @@ i_call_fun_last(Fun, Deallocate) {
 }
 
 return() {
+    //| -no_next
     SET_I(c_p->cp);
     DTRACE_RETURN_FROM_PC(c_p);
 
@@ -951,6 +953,7 @@ build_stacktrace() {
 }
 
 raw_raise() {
+    //| -no_prefetch
     Eterm class = x(0);
     Eterm value = x(1);
     Eterm stacktrace = x(2);


### PR DESCRIPTION
Dispatching a function and return never use the next instruction.
It's unlikely for raw_raise to use the next instruction.