### PR TITLE
erts: Fix possible heap corruption getting atomics

### DIFF
--- a/erts/emulator/beam/erl_bif_atomics.c
+++ b/erts/emulator/beam/erl_bif_atomics.c
@@ -133,7 +133,7 @@ static ERTS_INLINE Eterm bld_atomic(Process* proc, AtomicsRef* p,
         if ((Uint64)val <= MAX_SMALL)
             return make_small((Sint) val);
         else {
-            Uint hsz = ERTS_UINT64_HEAP_SIZE(val);
+            Uint hsz = ERTS_UINT64_HEAP_SIZE((Uint64)val);
             Eterm* hp = HAlloc(proc, hsz);
             return erts_uint64_to_big(val, &hp);
         }

--- a/erts/emulator/test/atomics_SUITE.erl
+++ b/erts/emulator/test/atomics_SUITE.erl
@@ -126,6 +126,9 @@ unsigned_limits(Config) when is_list(Config) ->
     Min = atomics:add_get(Ref, 1, 1),
     Max = atomics:sub_get(Ref, 1, 1),
 
+    atomics:put(Ref, 1, Max),
+    io:format("Max=~p~n", [atomics:get(Ref, 1)]),
+
     {'EXIT',{badarg,_}} = (catch atomics:add(Ref, 1, Max+1)),
     IncrMin = -(1 bsl (Bits-1)),
     ok = atomics:put(Ref, 1, -IncrMin),


### PR DESCRIPTION
Due to comparison as a signed integer, when getting an unsigned atomic
in the range 2^63-1..2^64-1 (when the most significant bit was set), the
heap could get corrupted when the integer was retrieved: hsz would get
set to zero, but the code proceeded to build a bignum.

```erlang
% ./bin/erl
Erlang/OTP 21 [erts-10.2] [source-3825199794] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [hipe]

Eshell V10.2  (abort with ^G)
1> A = atomics:new(1,[{signed,false}]).
#Ref<0.2526256236.2769682438.210844>
2> atomics:info(A).
#{max => 18446744073709551615,memory => 48,min => 0,size => 1}
3> atomics:put(A,1,18446744073709551615).
ok
4> atomics:get(A,1).
{value,{value,{value,{value,{value,{value,{value,{value,{value,{value,{value,{value,{value,{value,{value,...},
                                                                                                  [...]},
                                                                                           [{'A',...}]},
                                                                                    [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                                                                             [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                                                                      [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                                                               [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                                                        [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                                                 [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                                          [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                                   [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                            [{'A',#Ref<0.2526256236.2769682438.210844>}]},
                     [{'A',#Ref<0.2526256236.2769682438.210844>}]},
              [{'A',#Ref<0.2526256236.2769682438.210844>}]},
       [{'A',#Ref<0.2526256236.2769682438.210844>}]}
<hangs>
```

I think I managed to change the test suite to trigger it in a relatively benign way. This is what it looks on my machine with the changed test, but without the fix:
```
2> ts:run(emulator, atomics_SUITE, [batch]).
...
TEST INFO: 1 test(s), 5 case(s) in 1 suite(s)

Testing tests.emulator_test.atomics_SUITE: Starting test, 5 test cases
eheap_alloc: Cannot allocate 17456988308616 bytes of memory (of type "heap_frag").

Crash dump is being written to: /usr/local/src/otp/release/tests/test_server/emulator_erl_crash.dump...Test run exited with status 139
ok
```

This is on a debian amd64. `gcc --version` says `(Debian 8.2.0-12) 8.2.0` and `uname -a` says `Linux host 4.18.0-3-amd64 #1 SMP Debian 4.18.20-2 (2018-11-23) x86_64 GNU/Linux`
