### PR TITLE
Make all compiler options work in the option list

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -695,12 +695,13 @@ module.beam: module.erl \
 	</note>
 	
 	<note>
-	<p>The options <c>{nowarn_unused_function, FAs}</c>,
-          <c>{nowarn_bif_clash, FAs}</c>, and 
-          <c>{nowarn_deprecated_function, MFAs}</c> are only
-          recognized when given in files. They are not affected by
-	  options <c>warn_unused_function</c>, <c>warn_bif_clash</c>, or 
-          <c>warn_deprecated_function</c>.</p>
+	<p>Before OTP 22, the option <c>{nowarn_deprecated_function,
+	MFAs}</c> was only recognized when given in the file with
+	attribute <c>-compile()</c>. (The option
+	<c>{nowarn_unused_function,FAs}</c> was incorrectly documented
+	to only work in a file, but it also worked when given in the
+	option list.) Starting from OTP 22, all options that can be
+	given in the file can also be given in the option list.</p>
 	</note>
 
         <p>For debugging of the compiler, or for pure curiosity,

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -831,13 +831,15 @@ bif_clashes(Forms, #lint{nowarn_bif_clash=Nowarn} = St) ->
 
 %% not_deprecated(Forms, State0) -> State
 
-not_deprecated(Forms, St0) ->
+not_deprecated(Forms, #lint{compile=Opts}=St0) ->
     %% There are no line numbers in St0#lint.compile.
     MFAsL = [{MFA,L} ||
                 {attribute, L, compile, Args} <- Forms,
                 {nowarn_deprecated_function, MFAs0} <- lists:flatten([Args]),
                 MFA <- lists:flatten([MFAs0])],
-    Nowarn = [MFA || {MFA,_L} <- MFAsL],
+    Nowarn = [MFA ||
+                 {nowarn_deprecated_function, MFAs0} <- Opts,
+                 MFA <- lists:flatten([MFAs0])],
     ML = [{M,L} || {{M,_F,_A},L} <- MFAsL, is_atom(M)],
     St1 = foldl(fun ({M,L}, St2) ->
                         check_module_name(M, L, St2)

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -68,7 +68,7 @@
          non_latin1_module/1, otp_14323/1,
          stacktrace_syntax/1,
          otp_14285/1, otp_14378/1,
-         external_funs/1]).
+         external_funs/1,otp_15456/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -89,7 +89,8 @@ all() ->
      maps, maps_type, maps_parallel_match,
      otp_11851, otp_11879, otp_13230,
      record_errors, otp_11879_cont, non_latin1_module, otp_14323,
-     stacktrace_syntax, otp_14285, otp_14378, external_funs].
+     stacktrace_syntax, otp_14285, otp_14378, external_funs,
+     otp_15456].
 
 groups() -> 
     [{unused_vars_warn, [],
@@ -2115,6 +2116,61 @@ otp_5362(Config) when is_list(Config) ->
 			  "removed in R15; use the re module instead"}}]}}
 
 	 ],
+
+    [] = run(Config, Ts),
+    ok.
+
+%% OTP-15456. All compiler options can now be given in the option list
+%% (as opposed to only in files).
+otp_15456(Config) when is_list(Config) ->
+    Ts = [
+          %% {nowarn_deprecated_function,[{M,F,A}]} can now be given
+          %% in the option list as well as in an attribute.
+          %% Wherever it occurs, it is not affected by
+          %% warn_deprecated_function.
+          {otp_15456_1,
+           <<"-compile({nowarn_deprecated_function,{erlang,now,0}}).
+              -export([foo/0]).
+
+              foo() ->
+                  {erlang:now(), random:seed0(), random:seed(1, 2, 3),
+                   random:uniform(), random:uniform(42)}.
+           ">>,
+           {[{nowarn_deprecated_function,{random,seed0,0}},
+             {nowarn_deprecated_function,[{random,uniform,0},
+                                          {random,uniform,1}]},
+             %% There should be no warnings when attempting to
+             %% turn of warnings for functions that are not
+             %% deprecated or not used in the module.
+             {nowarn_deprecated_function,{random,uniform_s,1}},
+             {nowarn_deprecated_function,{erlang,abs,1}},
+             warn_deprecated_function]},
+           {warnings,[{5,erl_lint,
+                       {deprecated,{random,seed,3},
+                        "the 'random' module is deprecated; "
+                        "use the 'rand' module instead"}}]}},
+
+          %% {nowarn_unused_function,[{M,F,A}]} can be given
+          %% in the option list as well as in an attribute.
+          %% It was incorrectly documented to only work when
+          %% given in an attribute.
+          {otp_15456_2,
+           <<"-compile({nowarn_unused_function,foo/0}).
+              foo() -> ok.
+              bar() -> ok.
+              foobar() -> ok.
+              barf(_) -> ok.
+              other() -> ok.
+           ">>,
+           {[{nowarn_unused_function,[{bar,0},{foobar,0}]},
+             {nowarn_unused_function,{barf,1}},
+             %% There should be no warnings when attempting to
+             %% turn of warnings for unused functions that are not
+             %% defined in the module.
+             {nowarn_unused_function,{not_defined_in_module,1}},
+             warn_unused_function]},
+           {warnings,[{6,erl_lint,{unused_function,{other,0}}}]}
+          }],
 
     [] = run(Config, Ts),
     ok.


### PR DESCRIPTION
Before OTP 22, the option `{nowarn_deprecated_function,MFAs}` was only
recognized when given in the file with the attribute
`-compile()`. (The option `{nowarn_unused_function,FAs}`
was incorrectly documented to only work in a file, but it also
worked when given in the option list.) Starting from OTP 22, all
options that can be given in the file can also be given in the option
list.