### PR TITLE
odbc: Fix stack corruption in get_diagnos in odbcserver

### DIFF
--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -2749,6 +2749,11 @@ static diagnos get_diagnos(SQLSMALLINT handleType, SQLHANDLE handle, Boolean ext
 	    errmsg_buffer_size = errmsg_buffer_size - errmsg_size;
 	    acc_errmsg_size = acc_errmsg_size + errmsg_size;
 	    current_errmsg_pos = current_errmsg_pos + errmsg_size;
+	} else if(result == SQL_SUCCESS_WITH_INFO && errmsg_size >= errmsg_buffer_size) {
+	    memcpy(diagnos.sqlState, current_sql_state, SQL_STATE_SIZE);
+	    diagnos.nativeError = nativeError;
+	    acc_errmsg_size = errmsg_buffer_size;
+	    break;
 	} else {
 	    break;
 	}


### PR DESCRIPTION
SQLGetDiagRec can fill output buffer and return SQL_SUCCESS_WITH_INFO.
In that case we can not use strcat on diagnos.error_msg as it will write
outside allocated space.
Correctly set acc_errmsg_size in such case.

See also ERL-808 at bugs.erlang.org.