### PR TITLE
inet_db: fix a bug when .hosts file is never reloaded

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -1223,7 +1223,9 @@ handle_set_file(Option, Fname, TagTm, TagInfo, ParseFun, From,
 			    {ok, B, _} -> B;
 			    _ -> <<>>
 			end;
-		    _ -> <<>>
+		    _ ->
+			ets:insert(Db, {TagTm, times()}),
+			<<>>
 		end,
 	    handle_set_file(ParseFun, Bin, From, State);
 	false -> {reply,error,State}


### PR DESCRIPTION
If .hosts file does not exist when kernel application starts, it will never get reloaded.