### PR TITLE
reltool: Add load_dot_erlang rel option

### DIFF
--- a/lib/reltool/doc/src/reltool.xml
+++ b/lib/reltool/doc/src/reltool.xml
@@ -503,6 +503,7 @@ sys()               = {root_dir, root_dir()}
                     | {incl_cond, incl_cond()}
                     | {boot_rel, boot_rel()}
                     | {rel, rel_name(), rel_vsn(), [rel_app()]}
+                    | {rel, rel_name(), rel_vsn(), [rel_app()], [rel_opt()]}
                     | {relocatable, relocatable()}
                     | {app_file, app_file()}
                     | {debug_info, debug_info()}
@@ -534,6 +535,7 @@ rel_app()           = app_name()
                     | {app_name(), app_type()} 
                     | {app_name(), [incl_app()]}
                     | {app_name(), app_type(), [incl_app()]}
+rel_opt()           = {load_dot_erlang, boolean()}
 app_name()          = atom()
 app_type()          = permanent | transient | temporary | load | none
 app_vsn()           = string()

--- a/lib/reltool/doc/src/reltool_examples.xml
+++ b/lib/reltool/doc/src/reltool_examples.xml
@@ -313,9 +313,12 @@ Erlang/OTP 20 [erts-10.0] [source-c13b302] [64-bit] [smp:4:4] [ds:4:4:10] [async
 [hipe] [kernel-poll:false]
 Eshell V10.0  (abort with ^G)
 1&gt;
-1&gt; {ok, Server} = reltool:start_server([{config, {sys, [{boot_rel, "NAME"},
-                                                        {rel, "NAME", "VSN",
-                                                        [sasl]}]}}]).
+1&gt; {ok, Server} = reltool:start_server([{config,
+                                         {sys,
+                                          [{boot_rel, "NAME"},
+                                           {rel, "NAME", "VSN",
+                                            [sasl],
+                                            [{load_dot_erlang, false}]}]}}]).
 {ok,&lt;0.1288.0&gt;}
 2&gt;
 2&gt; reltool:get_config(Server).

--- a/lib/reltool/src/reltool.hrl
+++ b/lib/reltool/src/reltool.hrl
@@ -61,6 +61,7 @@
                           | {app_name(), app_type()}
                           | {app_name(), [incl_app()]}
                           | {app_name(), app_type(), [incl_app()]}.
+-type rel_opt()          :: {load_dot_erlang, boolean()}.
 -type mod()              :: {incl_cond, incl_cond()}
                           | {debug_info, debug_info()}.
 -type app()              :: {vsn, app_vsn()}
@@ -92,6 +93,8 @@
                           | {lib_dirs, [lib_dir()]}
                           | {boot_rel, boot_rel()}
                           | {rel, rel_name(), rel_vsn(), [rel_app()]}
+                          | {rel, rel_name(), rel_vsn(),
+                             [rel_app()], [rel_opt()]}
                           | {relocatable, relocatable()}
                           | {erts, app()}
                           | {escript, escript_file(), [escript()]}

--- a/lib/reltool/src/reltool_server.erl
+++ b/lib/reltool/src/reltool_server.erl
@@ -1483,6 +1483,18 @@ decode(#sys{rels = Rels} = Sys, [{rel, Name, Vsn, RelApps} | SysKeyVals])
     Rel = #rel{name = Name, vsn = Vsn, rel_apps = []},
     Rel2 = decode(Rel, RelApps),
     decode(Sys#sys{rels = [Rel2 | Rels]}, SysKeyVals);
+decode(#sys{rels = Rels} = Sys, [{rel, Name, Vsn, RelApps, Opts} | SysKeyVals])
+  when is_list(Name), is_list(Vsn), is_list(RelApps), is_list(Opts) ->
+    Rel1 = lists:foldl(fun(Opt, Rel0) ->
+        case Opt of
+            {load_dot_erlang, Value} when is_boolean(Value) ->
+                Rel0#rel{load_dot_erlang = Value};
+            _ ->
+                reltool_utils:throw_error("Illegal rel option: ~tp", [Opt])
+        end
+    end, #rel{name = Name, vsn = Vsn, rel_apps = []}, Opts),
+    Rel2 = decode(Rel1, RelApps),
+    decode(Sys#sys{rels = [Rel2 | Rels]}, SysKeyVals);
 decode(#sys{} = Sys, [{Key, Val} | KeyVals]) ->
     Sys3 =
         case Key of

--- a/lib/reltool/test/reltool_server_SUITE.erl
+++ b/lib/reltool/test/reltool_server_SUITE.erl
@@ -102,6 +102,7 @@ all() ->
      create_release,
      create_release_sort,
      create_script,
+     create_script_without_dot_erlang,
      create_script_sort,
      create_target,
      create_target_unicode,
@@ -248,9 +249,9 @@ get_config(_Config) ->
 		    {app,stdlib,[{incl_cond,include},{vsn,undefined},
 				 {lib_dir,StdLibDir}]},
 		    {boot_rel,"start_clean"},
-                    {rel,"no_dot_erlang","1.0",[]},
-		    {rel,"start_clean","1.0",[]},
-		    {rel,"start_sasl","1.0",[sasl]},
+                    {rel,"no_dot_erlang","1.0",[],[{load_dot_erlang,false}]},
+		    {rel,"start_clean","1.0",[],[{load_dot_erlang,true}]},
+		    {rel,"start_sasl","1.0",[sasl],[{load_dot_erlang,true}]},
 		    {emu_name,"beam"},
 		    {relocatable,true},
 		    {profile,development},
@@ -279,9 +280,9 @@ get_config(_Config) ->
 		    {app,stdlib,[{incl_cond,include},{vsn,StdVsn},
 				 {lib_dir,StdLibDir},{mod,_,[]}|_]},
 		    {boot_rel,"start_clean"},
-                    {rel,"no_dot_erlang","1.0",[]},
-		    {rel,"start_clean","1.0",[]},
-		    {rel,"start_sasl","1.0",[sasl]},
+                    {rel,"no_dot_erlang","1.0",[],[{load_dot_erlang,false}]},
+		    {rel,"start_clean","1.0",[],[{load_dot_erlang,true}]},
+		    {rel,"start_sasl","1.0",[sasl],[{load_dot_erlang,true}]},
 		    {emu_name,"beam"},
 		    {relocatable,true},
 		    {profile,development},
@@ -548,6 +549,32 @@ create_script(_Config) ->
     %% ?m(OrigScript2, Script2),
     
     ?m(equal, diff_script(OrigScript, Script)),
+
+    %% A release defaults to load_dot_erlang == true
+    {script, {RelName, RelVsn}, ScriptInstructions} = Script,
+    ?m(true, lists:member({apply,{c,erlangrc,[]}}, ScriptInstructions)),
+
+    %% Stop server
+    ?m(ok, reltool:stop(Pid)),
+    ok.
+
+create_script_without_dot_erlang(_Config) ->
+    %% Configure the server
+    RelName = "Just testing",
+    RelVsn = "1.0",
+    Config =
+        {sys,
+         [
+          {lib_dirs, []},
+          {boot_rel, RelName},
+          {rel, RelName, RelVsn, [stdlib, kernel], [{load_dot_erlang, false}]}
+         ]},
+    {ok, Pid} = ?msym({ok, _}, reltool:start_server([{config, Config}])),
+
+    %% Confirm that load_dot_erlang == false was used
+    {ok, Script} = ?msym({ok, _}, reltool:get_script(Pid, RelName)),
+    {script, {RelName, RelVsn}, ScriptInstructions} = Script,
+    ?m(false, lists:member({apply,{c,erlangrc,[]}}, ScriptInstructions)),
 
     %% Stop server
     ?m(ok, reltool:stop(Pid)),
@@ -2107,9 +2134,9 @@ save_config(Config) ->
 		     {app,stdlib,[{incl_cond,include},{vsn,undefined},
 				  {lib_dir,undefined}]},
 		     {boot_rel,"start_clean"},
-                     {rel,"no_dot_erlang","1.0",[]},
-		     {rel,"start_clean","1.0",[]},
-		     {rel,"start_sasl","1.0",[sasl]},
+                     {rel,"no_dot_erlang","1.0",[],[{load_dot_erlang,false}]},
+		     {rel,"start_clean","1.0",[],[{load_dot_erlang,true}]},
+		     {rel,"start_sasl","1.0",[sasl],[{load_dot_erlang,true}]},
 		     {emu_name,"beam"},
 		     {relocatable,true},
 		     {profile,development},
@@ -2148,9 +2175,9 @@ save_config(Config) ->
 		     {app,stdlib,[{incl_cond,include},{vsn,StdVsn},
 				  {lib_dir,StdLibDir},{mod,_,[]}|_]},
 		     {boot_rel,"start_clean"},
-                     {rel,"no_dot_erlang","1.0",[]},
-		     {rel,"start_clean","1.0",[]},
-		     {rel,"start_sasl","1.0",[sasl]},
+                     {rel,"no_dot_erlang","1.0",[],[{load_dot_erlang,false}]},
+		     {rel,"start_clean","1.0",[],[{load_dot_erlang,true}]},
+		     {rel,"start_sasl","1.0",[sasl],[{load_dot_erlang,true}]},
 		     {emu_name,"beam"},
 		     {relocatable,true},
 		     {profile,development},


### PR DESCRIPTION
This adds a rel tuple to the reltool release specific configuration format
as {rel, Name, Vsn, RelApps, Opts} to support the use of
{rel, Name, Vsn, RelApps, [{load_dot_erlang, false}]} for preventing
the insertion of {apply,{c,erlangrc,[]}} into the release script file
and the release boot file.

This change makes it possible to prevent releases generated with reltool
from attempting to load a ${HOME}/.erlang file which is desirable for
production deployment of Erlang, to have greater control of what BEAM
evaluates.  The ${HOME}/.erlang file lacks visibility and its location on
the filesystem separate from where the release lives means it can be
misused in a way that lacks visibility.