### PR TITLE
Correction of type abstract_expr -> abstract_expr() in erl_parse

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -841,7 +841,7 @@ Erlang code.
 -type af_record_field(T) :: {'record_field', anno(), af_field_name(), T}.
 
 -type af_map_pattern() ::
-        {'map', anno(), [af_assoc_exact(abstract_expr)]}.
+        {'map', anno(), [af_assoc_exact(abstract_expr())]}.
 
 -type abstract_type() :: af_annotated_type()
                        | af_atom()


### PR DESCRIPTION
The error in the type was discovered during the development of https://github.com/josefs/Gradualizer .

Due to the lack of a type checker, I'm unable to provide a test case for the type. Dialyzer obviously didn't catch this one.