### PR TITLE
ssl: Fix two invalid gen_statem returns

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -1193,7 +1193,7 @@ handle_call({shutdown, read_write = How}, From, StateName,
                 ok ->
                     {next_state, StateName, State#state{terminated = true}, [{reply, From, ok}]};
                 Error ->
-                    {stop, StateName, State#state{terminated = true}, [{reply, From, Error}]}
+                    {stop_and_reply, {shutdown, normal}, {reply, From, Error}, State#state{terminated = true}}
             end
     catch
         throw:Return ->
@@ -1206,7 +1206,7 @@ handle_call({shutdown, How0}, From, StateName,
 	ok ->
 	    {next_state, StateName, State, [{reply, From, ok}]};
 	Error ->
-            {stop, StateName, State, [{reply, From, Error}]}
+            {stop_and_reply, {shutdown, normal}, {reply, From, Error}, State}
     end;
 handle_call({recv, _N, _Timeout}, From, _,  
 		  #state{socket_options = 


### PR DESCRIPTION
They produce crashes like the following occasionally:

``` erlang
** Reason for termination = error:{bad_return_from_state_function,
                                   {stop,connection,
                                    {state,client,
                                     {#Ref<0.341079929.3670802433.158048>,
                                      <0.446.0>},
                                     gen_tcp,tls_connection,tcp,tcp_closed,
```

Not sure how to reproduce reliably to write a test.

I also changed the stop Reason to mirror what is done on other socket errors, instead of having a reason that will produce logs.