### PR TITLE
fix: have some sys configs with one -config flag

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -1833,7 +1833,7 @@ check_conf() ->
 			       {error, {Line, _Mod, Str}} ->
 				   throw({error, {FName, Line, Str}})
 			   end
-		   end, [], lists:foldr(fun erlang:'++'/2, [], Files))};
+		   end, [], lists:append(Files))};
 	_ -> {ok, []}
     end.
 

--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -1801,7 +1801,7 @@ check_conf() ->
     case init:get_argument(config) of
 	{ok, Files} ->
 	    {ok, lists:foldl(
-		   fun([File], Env) ->
+		   fun(File, Env) ->
 			   BFName = filename:basename(File,".config"),
 			   FName = filename:join(filename:dirname(File),
 						 BFName ++ ".config"),
@@ -1833,7 +1833,7 @@ check_conf() ->
 			       {error, {Line, _Mod, Str}} ->
 				   throw({error, {FName, Line, Str}})
 			   end
-		   end, [], Files)};
+		   end, [], lists:foldr(fun erlang:'++'/2, [], Files))};
 	_ -> {ok, []}
     end.
 


### PR DESCRIPTION
```sh
~ $ echo []. > sys.config
~ $ echo []. > sys2.config
~ $ erl -config sys.config sys2.config 
```
```erlang
2018-12-23 23:42:00.004390 Error in process ~p with exit value:~n~p~n
	<0.42.0>
	{{case_clause,{'EXIT',{function_clause,[{application_controller,'-check_conf/0-fun-0-',[["sys.config","sys2.config"],[]],[{file,"application_controller.erl"},{line,1804}]},{lists,foldl,3,[{file,"lists.erl"},{line,1263}]},{application_controller,check_conf,0,[{file,"application_controller.erl"},{line,1803}]},{application_controller,init,2,[{file,"application_controller.erl"},{line,486}]}]}}},[{application_controller,init,2,[{file,"application_controller.erl"},{line,486}]}]}
{"could not start kernel pid",application_controller,"{{case_clause,{'EXIT',{function_clause,[{application_controller,'-check_conf/0-fun-0-',[[\"sys.config\",\"sys2.config\"],[]],[{file,\"application_controller.erl\"},{line,1804}]},{lists,foldl,3,[{file,\"lists.erl\"},{line,1263}]},{application_controller,check_conf,0,[{file,\"application_controller.erl\"},{line,1803}]},{application_controller,init,2,[{file,\"application_controller.erl\"},{line,486}]}]}}},[{application_controller,init,2,[{file,\"application_controller.erl\"},{line,486}]}]}"}
could not start kernel pid (application_controller) ({{case_clause,{'EXIT',{function_clause,[{application_controller,'-check_conf/0-fun-0-',[["sys.config","sys2.config"],[]],[{file,"application_contro

Crash dump is being written to: erl_crash.dump...done
```
Because [here](https://github.com/erlang/otp/blob/OTP-21.2.1/lib/kernel/src/application_controller.erl#L1802) we have `[["sys.config", "sys2.config"]]` and [here](https://github.com/erlang/otp/blob/OTP-21.2.1/lib/kernel/src/application_controller.erl#L1804) it does not be matched. So we have to run:  
```sh
~ $ erl -config sys.config -config sys2.config 
```
```erlang
Erlang/OTP 21 [erts-10.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe]
Eshell V10.1  (abort with ^G)
1>
```

I was adding `dynamic configuration` based changes in sys config files and I found this. Sorry if branch name does not relate to this.