### PR TITLE
Document cleanup semantics for atomics and counters

### DIFF
--- a/erts/doc/src/atomics.xml
+++ b/erts/doc/src/atomics.xml
@@ -85,6 +85,8 @@
 	  bsl 64)-1</c>.</p>
 	  </item>
 	</taglist>
+        <p>Atomics are not tied to the current process and are automatically
+        garbage collected when they are no longer referenced.</p>
       </desc>
     </func>
 

--- a/erts/doc/src/counters.xml
+++ b/erts/doc/src/counters.xml
@@ -103,6 +103,8 @@
 	  acceptable.</p>
 	  </item>
 	</taglist>
+        <p>Counters are not tied to the current process and are automatically
+        garbage collected when they are no longer referenced.</p>
       </desc>
     </func>
 


### PR DESCRIPTION
Since ETS is the main mutable storage for Erlang,
developers may expect atomics and counters to
behave similarly to ETS when it comes to process
ownership and clean-up, so I decided to clarify the
behaviour.