### PR TITLE
Fixes in erl_parse:abstract_type/0 type

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -872,7 +872,7 @@ Erlang code.
 -type af_fun_type() :: {'type', anno(), 'fun', []}
                      | {'type', anno(), 'fun', [{'type', anno(), 'any'} |
                                                 abstract_type()]}
-                     | {'type', anno(), 'fun', af_function_type()}.
+                     | af_function_type().
 
 -type af_integer_range_type() ::
         {'type', anno(), 'range', [af_singleton_integer_type()]}.

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -924,8 +924,8 @@ Erlang code.
 -type af_function_constraint() :: [af_constraint()].
 
 -type af_constraint() :: {'type', anno(), 'constraint',
-                          af_lit_atom('is_subtype'),
-                          [af_type_variable() | abstract_type()]}. % [V, T]
+                          [af_lit_atom('is_subtype') |
+                           [af_type_variable() | abstract_type()]]}. % [IsSubtype, [V, T]]
 
 -type af_singleton_integer_type() :: af_integer()
                                    | af_character()

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -928,6 +928,7 @@ Erlang code.
                           [af_type_variable() | abstract_type()]}. % [V, T]
 
 -type af_singleton_integer_type() :: af_integer()
+                                   | af_character()
                                    | af_unary_op(af_singleton_integer_type())
                                    | af_binary_op(af_singleton_integer_type()).
 


### PR DESCRIPTION
- Add literal character to `erl_parse:abstract_type/0` type

  This is allowed since 19.3 (commit 6d238032) and documented since commit
  744fb920.

- Fix `erl_parse:af_fun_type()`

  `af_function_type()` already contains the `{'type', anno(), 'fun', ...}`
  tuple so it does not have to be wrapped again.

- Fix `erl_parse:af_constraint()`

  Add missing list wrapper.