### PR TITLE
Add merge_env/1 and merge_env/2

### DIFF
--- a/lib/kernel/doc/src/application.xml
+++ b/lib/kernel/doc/src/application.xml
@@ -238,6 +238,37 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
       </desc>
     </func>
     <func>
+      <name name="set_env" arity="1" since="OTP 22.0"/>
+      <name name="set_env" arity="2" since="OTP 22.0"/>
+      <fsummary>Sets the configuration parameters of multiple applications.</fsummary>
+      <desc>
+        <p>Sets the configuration <c><anno>Config</anno></c> for multiple
+          applications. It is equivalent to calling <c>set_env/4</c> on
+          each application individially, except it is more efficient.
+          The given <c><anno>Config</anno></c> is validated before the
+          configuration is set.</p>
+        <p><c>set_env/2</c> uses the standard <c>gen_server</c> time-out
+          value (5000 ms). Option <c>timeout</c> can be specified
+          if another time-out value is useful, for example, in situations
+          where the application controller is heavily loaded.</p>
+        <p>Option <c>persistent</c> can be set to <c>true</c>
+          to guarantee that parameters set with <c>set_env/2</c>
+          are not overridden by those defined in the application resource
+          file on load. This means that persistent values will stick after the application
+          is loaded and also on application reload.</p>
+        <p><c>set_env/1</c> is equivalent to <c>set_env(Config, [])</c>.</p>
+        <warning>
+          <p>Use this function only if you know what you are doing,
+            that is, on your own applications. It is very
+            application-dependent and
+            configuration parameter-dependent when and how often
+            the value is read by the application. Careless use
+            of this function can put the application in a
+            weird, inconsistent, and malfunctioning state.</p>
+        </warning>
+      </desc>
+    </func>
+    <func>
       <name name="permit" arity="2" since=""/>
       <fsummary>Change the permission for an application to run at a node.</fsummary>
       <desc>

--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -25,7 +25,7 @@
 	 which_applications/0, which_applications/1,
 	 loaded_applications/0, permit/2]).
 -export([ensure_started/1, ensure_started/2]).
--export([set_env/3, set_env/4, unset_env/2, unset_env/3]).
+-export([set_env/1, set_env/2, set_env/3, set_env/4, unset_env/2, unset_env/3]).
 -export([get_env/1, get_env/2, get_env/3, get_all_env/0, get_all_env/1]).
 -export([get_key/1, get_key/2, get_all_key/0, get_all_key/1]).
 -export([get_application/0, get_application/1, info/0]).
@@ -278,6 +278,26 @@ loaded_applications() ->
 
 info() -> 
     application_controller:info().
+
+-spec set_env(Config) -> 'ok' when
+      Config :: [{Application, Env}],
+      Application :: atom(),
+      Env :: [{Par :: atom(), Val :: term()}].
+
+set_env(Config) when is_list(Config) ->
+    set_env(Config, []).
+
+-spec set_env(Config, Opts) -> 'ok' when
+      Config :: [{Application, Env}],
+      Application :: atom(),
+      Env :: [{Par :: atom(), Val :: term()}],
+      Opts :: [{timeout, timeout()} | {persistent, boolean()}].
+
+set_env(Config, Opts) when is_list(Config), is_list(Opts) ->
+    case application_controller:set_env(Config, Opts) of
+	ok -> ok;
+	{error, Msg} -> erlang:error({badarg, Msg}, [Config, Opts])
+    end.
 
 -spec set_env(Application, Par, Val) -> 'ok' when
       Application :: atom(),


### PR DESCRIPTION
This makes it simpler and faster to set the configuration of multiple
applications at once, which improves other configuration engines
such as cuttlefish and Elixir's `config.exs`.

While it is possible to achieve the same behaviour by calling
`application:set_env/4` in a loop, such approach requires a lot
of back and forth between the client and the application controller
and having a specialized function speeds up the process.