### PR TITLE
ERL-822 Fix sftpd interop for SSH_FXP_STAT

### DIFF
--- a/lib/ssh/src/ssh_sftpd.erl
+++ b/lib/ssh/src/ssh_sftpd.erl
@@ -508,11 +508,8 @@ close_our_file({_,Fd}, FileMod, FS0) ->
     FS1.
 
 %%% stat: do the stat
-stat(Vsn, ReqId, Data, State, F) when Vsn =< 3->
-    <<?UINT32(BLen), BPath:BLen/binary>> = Data,
-    stat(ReqId, unicode:characters_to_list(BPath), State, F);
-stat(Vsn, ReqId, Data, State, F) when Vsn >= 4->
-    <<?UINT32(BLen), BPath:BLen/binary, ?UINT32(_Flags)>> = Data,
+stat(Vsn, ReqId, Data, State, F) ->
+    <<?UINT32(BLen), BPath:BLen/binary, _/binary>> = Data,
     stat(ReqId, unicode:characters_to_list(BPath), State, F).
 
 fstat(Vsn, ReqId, Data, State) when Vsn =< 3->


### PR DESCRIPTION
Some SFTP client's have been discover to claim one version of the
protocol and send messages in a different version.

In the spirit of Postel's law, we can for SSH_FXP_STAT, ignore the
differences in the protocol, as we are not doing anything with the flags
anyway.

I looked through the test cases and there where no tests for different versions of retrieve_attributes, so this change will just improve code coverage with the existing tests. Hope this is ok.