### PR TITLE
Specify that mnesia:start/0 is async

### DIFF
--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -2077,6 +2077,13 @@ mnesia:create_table(employee,
       <fsummary>Starts a local Mnesia system.</fsummary>
       <desc>
       <marker id="start"></marker>
+        <p>Mnesia startup is asynchronous. The function call
+	        <c>mnesia:start()</c> returns the atom <c>ok</c> and then
+          starts to initialize the different tables. Depending on the
+          size of the database, this can take some time, and the
+          application programmer must wait for the tables that the
+          application needs before they can be used. This is achieved
+          by using the function <c>mnesia:wait_for_tables/2</c>.</p>
         <p>The startup procedure for a set of Mnesia nodes is a
           fairly complicated operation. A Mnesia system consists
           of a set of nodes, with Mnesia started locally on all


### PR DESCRIPTION
As an Elixir beginner I was having a hard time transforming/migrating tables after `mnesia:start()` or `Amnesia.start()` in my case. Maybe I was going about it wrong and should have read the guide right away, but it took me a while to find out that I needed to use `mnesia:wait_for_tables/2`. IMHO this should be documented for future newcomers like myself. The paragraph I copy-pasted from the Mnesia guide and put it at the top since I believe it's more important than the rest of the info. If you disagree with that or with the wording, it's okay by me, but please at least specify that it's async and point to `mnesia:wait_for_tables/2`.
I apologize if this is common knowledge, but I'm still learning 🙂 