### PR TITLE
Add start_distribution to kernel environment

### DIFF
--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -369,6 +369,14 @@ MaxT = TickTime + TickTime / 4</code>
           performed. This option ensures that <c>global</c> is
           synchronized.</p>
       </item>
+      <tag><c>start_distribution = true | false</c></tag>
+      <item>
+        <p>Starts all distribution services, such as <c>rpc</c>,
+          <c>global</c>, and <c>net_kernel</c> if the parameter is
+          <c>true</c>. This parameter is to be set to <c>false</c>
+          for systems who want to disable all distribution functionality.</p>
+        <p>Defaults to <c>true</c>.</p>
+      </item>
       <tag><c>start_dist_ac = true | false</c></tag>
       <item>
         <p>Starts the <c>dist_ac</c> server if the parameter is


### PR DESCRIPTION
Sometimes you may want to start Erlang without any
of its distribution services. This commit adds an
environment configuration that allows so.

Because the servers we don't start here are a subset
of the servers not started on minimal mode, we do
have a guarantee that the system can still operate
as the system operates without those apps on minimal
mode.