### PR TITLE
Document that current_function can be undefined

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -5182,11 +5182,13 @@ RealSystem = system + MissedSystem</code>
               changed or removed without prior notice.</p>
           </item>
           <tag><c>{current_function, {<anno>Module</anno>,
-            <anno>Function</anno>, Arity}}</c></tag>
+            <anno>Function</anno>, Arity} | undefined}</c></tag>
           <item>
             <p><c><anno>Module</anno></c>, <c><anno>Function</anno></c>,
               <c><anno>Arity</anno></c> is
-              the current function call of the process.</p>
+              the current function call of the process. The value
+              <c>undefined</c> can be returned if the process is
+              currently executing native compiled code.</p>
           </item>
           <tag><c>{current_location, {<anno>Module</anno>,
             <anno>Function</anno>, <anno>Arity</anno>,

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2295,7 +2295,7 @@ process_flag(_Flag, _Value) ->
                             non_neg_integer()}]} |
       {catchlevel, CatchLevel :: non_neg_integer()} |
       {current_function,
-       {Module :: module(), Function :: atom(), Arity :: arity()}} |
+       {Module :: module(), Function :: atom(), Arity :: arity()} | undefined} |
       {current_location,
        {Module :: module(), Function :: atom(), Arity :: arity(),
         Location :: [{file, Filename :: string()} | % not a stack_item()!


### PR DESCRIPTION
If a process is executing native-compiled code, process_info(Pid,
current_function) may return the atom undefined instead of an MFA.