### PR TITLE
beam_type: Eliminate compiler crash when arithmetic expression fails

### DIFF
--- a/lib/compiler/src/beam_type.erl
+++ b/lib/compiler/src/beam_type.erl
@@ -1114,4 +1114,5 @@ verified_type(nonempty_list=T) -> T;
 verified_type({tuple,_,Sz,[]}=T) when is_integer(Sz) -> T;
 verified_type({tuple,_,Sz,[_]}=T) when is_integer(Sz) -> T;
 verified_type({tuple_element,_,_}=T) -> T;
-verified_type(float=T) -> T.
+verified_type(float=T) -> T;
+verified_type(none=T) -> T.

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -157,6 +157,10 @@ coverage(Config) ->
              [_|_] ->
                  ok
          end,
+
+    %% Cover beam_type:verified_type(none).
+    {'EXIT',{badarith,_}} = (catch (id(2) / id(1)) band 16#ff),
+
     ok.
 
 booleans(_Config) ->


### PR DESCRIPTION
The compiler would crash when compiling code such as:

     (A / B) band 16#ff

The type for the expression would be `none`, but `beam_type:verified_type/1`
did not handle `none`.

https://bugs.erlang.org/browse/ERL-829