### PR TITLE
Searchable uncovered lines in HTML output from cover

### DIFF
--- a/lib/tools/priv/styles.css
+++ b/lib/tools/priv/styles.css
@@ -65,6 +65,7 @@ table td.hits {
 }
 table td.hits {
   width: 10px;
+  text-align: right;
   padding: 2px 5px;
   color: rgba(0, 0, 0, 0.6);
   background-color: #f0f0f0;

--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -2569,6 +2569,7 @@ table_data(Line, L, N) ->
    "<td class=\"hits\">",maybe_integer_to_list(N),"</td>\n",
    "<td class=\"source\"><code>",LineNoNL,"</code></td>\n</tr>\n"].
 
+maybe_integer_to_list(0) -> "<pre style=\"display: inline;\">:-(</pre>";
 maybe_integer_to_list(N) when is_integer(N) -> integer_to_list(N);
 maybe_integer_to_list(_) -> "".
 


### PR DESCRIPTION
Prior to #1807 , uncovered lines could be found by searching for " 0.." in the HTML page generated by cover:analyse_to_file/1,2. The pull request removed the two dots after the number of hits, which made it much harder to find the uncovered lines.

This PR introduces a sad face, :-( , instead of the single 0 character, which should make the search easier.

Other suggestions for the uncovered marker has been
* "---" (discarded because many modules contain comment lines consisting of dashes)
* "-0-" 
* ".0."
* "uncov"
* "uncovered"

I did go for the sad face because, next after the discarded "---", I thought it looked the best. But I'm willing to change it to any of the above, or other suggestion, that gets more votes (please comment).

![uncov-sad-face](https://user-images.githubusercontent.com/3234528/51486220-63ed9c00-1da0-11e9-992a-fa331b0e66ca.png)
