### PR TITLE
ssl: Correct check for delayed close due to undliverd data

### DIFF
--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -923,6 +923,7 @@ handle_alerts(_, {stop, _, _} = Stop) ->
     Stop;
 handle_alerts([#alert{level = ?WARNING, description = ?CLOSE_NOTIFY} | _Alerts], 
               {next_state, connection = StateName, #state{user_data_buffer = Buffer,
+                                                          socket_options = #socket_options{active = false},
                                                           protocol_buffers = #protocol_buffers{tls_cipher_texts = CTs}} = 
                    State}) when (Buffer =/= <<>>) orelse
                                 (CTs =/= []) -> 


### PR DESCRIPTION
Could cause connection processes not terminate when they should