### PR TITLE
Add lib/compiler/scripts/smoke

### DIFF
--- a/lib/compiler/scripts/.gitignore
+++ b/lib/compiler/scripts/.gitignore
@@ -1,0 +1,1 @@
+/smoke-build

--- a/lib/compiler/scripts/smoke
+++ b/lib/compiler/scripts/smoke
@@ -1,0 +1,122 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+-mode(compile).
+
+main(_Args) ->
+    setup(),
+    clone_elixir(),
+    build_elixir(),
+    test_elixir(),
+    setup_mix(),
+    smoke(main),
+    smoke(rabbitmq),
+    halt(0).
+
+setup() ->
+    ScriptsDir = scripts_dir(),
+    SmokeBuildDir = filename:join(ScriptsDir, "smoke-build"),
+    _ = file:make_dir(SmokeBuildDir),
+    ok = file:set_cwd(SmokeBuildDir),
+    ok.
+
+clone_elixir() ->
+    {ok,SmokeDir} = file:get_cwd(),
+    DotGitDir = filename:join([SmokeDir,"elixir",".git"]),
+    ElixirRepo = "git@github.com:elixir-lang/elixir.git",
+    case filelib:is_dir(DotGitDir) of
+        false ->
+            cmd("git clone " ++ ElixirRepo);
+        true ->
+            GetHeadSHA1 = "cd elixir && git rev-parse --verify HEAD",
+            Before = os:cmd(GetHeadSHA1),
+            cmd("cd elixir && git pull --ff-only origin master"),
+            case os:cmd(GetHeadSHA1) of
+                Before ->
+                    ok;
+                _After ->
+                    %% There were some changes. Clean to force a re-build.
+                    cmd("cd elixir && make clean")
+            end
+    end.
+
+build_elixir() ->
+    cmd("cd elixir && make compile").
+
+test_elixir() ->
+    cmd("cd elixir && make test_stdlib").
+
+setup_mix() ->
+    MixExsFile = filename:join(scripts_dir(), "smoke-mix.exs"),
+    {ok,MixExs} = file:read_file(MixExsFile),
+    ok = file:write_file("mix.exs", MixExs),
+
+    {ok,SmokeDir} = file:get_cwd(),
+    ElixirBin = filename:join([SmokeDir,"elixir","bin"]),
+    PATH = ElixirBin ++ ":" ++ os:getenv("PATH"),
+    os:putenv("PATH", PATH),
+    mix("local.rebar --force"),
+    ok.
+
+smoke(Set) ->
+    os:putenv("SMOKE_DEPS_SET", atom_to_list(Set)),
+    _ = file:delete("mix.lock"),
+    cmd("touch mix.exs"),
+    mix("deps.clean --all"),
+    mix("deps.get"),
+    mix("deps.compile"),
+    ok.
+
+scripts_dir() ->
+    Root = code:lib_dir(compiler),
+    filename:join(Root, "scripts").
+
+mix(Cmd) ->
+    cmd("mix " ++ Cmd).
+
+cmd(Cmd) ->
+    run("sh", ["-c",Cmd]).
+
+run(Program0, Args) ->
+    Program = case os:find_executable(Program0) of
+		  Path when is_list(Path) ->
+		      Path;
+		  false ->
+		      abort("Unable to find program: ~s\n", [Program0])
+	      end,
+    Cmd = case {Program0,Args} of
+              {"sh",["-c"|ShCmd]} ->
+                  ShCmd;
+              {_,_} ->
+                  lists:join(" ", [Program0|Args])
+          end,
+    io:format("\n# ~s\n", [Cmd]),
+    Options = [{args,Args},binary,exit_status,stderr_to_stdout],
+    try open_port({spawn_executable,Program}, Options) of
+	Port ->
+	    case run_loop(Port, <<>>) of
+                0 ->
+                    ok;
+                ExitCode ->
+                    abort("*** Failed with exit code: ~p\n",
+                          [ExitCode])
+            end
+    catch
+	error:_ ->
+	    abort("Failed to execute ~s\n", [Program0])
+    end.
+
+run_loop(Port, Output) ->
+    receive
+	{Port,{exit_status,Status}} ->
+	    Status;
+	{Port,{data,Bin}} ->
+            io:put_chars(Bin),
+	    run_loop(Port, <<Output/binary,Bin/binary>>);
+	Msg ->
+	    io:format("L: ~p~n", [Msg]),
+	    run_loop(Port, Output)
+    end.
+
+abort(Format, Args) ->
+    io:format(Format, Args),
+    halt(1).

--- a/lib/compiler/scripts/smoke-mix.exs
+++ b/lib/compiler/scripts/smoke-mix.exs
@@ -1,0 +1,95 @@
+defmodule Smoke.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :smoke,
+      version: "0.1.0",
+      elixir: "~> 1.8",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    case :os.getenv('SMOKE_DEPS_SET') do
+      'main' ->
+	[
+	  {:bear, "~> 0.8.7"},
+	  {:cloudi_core, "~> 1.7"},
+	  {:concuerror, "~> 0.20.0"},
+	  {:cowboy, "~> 2.6.1"},
+	  {:ecto, "~> 3.0.6"},
+	  {:ex_doc, "~> 0.19.3"},
+	  {:distillery, "~> 2.0.12"},
+	  {:erlydtl, "~> 0.12.1"},
+	  {:gen_smtp, "~> 0.13.0"},
+	  {:getopt, "~> 1.0.1"},
+	  {:gettext, "~> 0.16.1"},
+	  {:gpb, "~> 4.6"},
+	  {:gproc, "~> 0.8.0"},
+	  {:graphql, "~> 0.15.0", hex: :graphql_erl},
+	  {:hackney, "~> 1.15.0"},
+	  {:ibrowse, "~> 4.4.1"},
+	  {:jose, "~> 1.9.0"},
+	  {:lager, "~> 3.6"},
+	  {:locus, "~> 1.6"},
+	  {:nimble_parsec, "~> 0.5.0"},
+	  {:phoenix, "~> 1.4.0"},
+	  {:riak_pb, "~> 2.3"},
+	  {:scalaris, git: "https://github.com/scalaris-team/scalaris",
+	   compile: build_scalaris()},
+	  {:tdiff, "~> 0.1.2"},
+	  {:webmachine, "~> 1.11"},
+	  {:wings, git: "https://github.com/dgud/wings.git",
+	   compile: build_wings()},
+	  {:zotonic_stdlib, "~> 1.0"},
+	]
+      'rabbitmq' ->
+	[{:rabbit_common, "~> 3.7"}]
+      _ ->
+	[]
+    end
+  end
+
+  defp build_scalaris do
+    # Only compile the Erlang code.
+
+    """
+    echo '-include("rt_simple.hrl").' >include/rt.hrl
+    (cd src && erlc -W0 -I ../include -I ../contrib/log4erl/include -I ../contrib/yaws/include *.erl)
+    (cd src/comm_layer && erlc -W0 -I ../../include -I *.erl)
+    (cd src/cp && erlc -W0 -I ../../include -I *.erl)
+    (cd src/crdt && erlc -W0 -I ../../include -I *.erl)
+    (cd src/json && erlc -W0 -I ../../include -I *.erl)
+    (cd src/paxos && erlc -W0 -I ../../include -I *.erl)
+    (cd src/rbr && erlc -W0 -I ../../include -I *.erl)
+    (cd src/rrepair && erlc -W0 -I ../../include -I *.erl)
+    (cd src/time && erlc -W0 -I ../../include -I *.erl)
+    (cd src/transactions && erlc -W0 -I ../../include -I *.erl)
+    (cd src/tx && erlc -W0 -I ../../include -I *.erl)
+    """
+  end
+
+  defp build_wings do
+    # If the Erlang system is not installed, the build will
+    # crash in plugins_src/accel when attempting to build
+    # the accel driver. Since there is very little Erlang code in
+    # the directory, skip the entire directory.
+
+    """
+    echo "all:\n\t" >plugins_src/accel/Makefile
+    git commit -a -m'Disable for smoke testing'
+    git tag -a -m'Smoke test' vsmoke_test
+    make
+    """
+  end
+end


### PR DESCRIPTION
Add `lib/compiler/scripts/smoke` for smoke testing the compiler (that
is, test that the compiler does not crash during compilation).

`smoke` first installs Elixir and mix. It then uses `mix` to download
a number of `hex` packages and compile them.

We don't intend to use `smoke` in our daily builds or Travis, but to run
it manually during compiler development.