### PR TITLE
Fix spec for erl_epmd:port_please

### DIFF
--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -77,8 +77,8 @@ stop() ->
 %%
 
 -spec port_please(Name, Host) -> {ok, Port, Version} | noport when
-	  Name :: string(),
-	  Host :: inet:ip_address(),
+	  Name :: atom() | string(),
+	  Host :: atom() | string() | inet:ip_address(),
 	  Port :: non_neg_integer(),
 	  Version :: non_neg_integer().
 
@@ -86,8 +86,8 @@ port_please(Node, Host) ->
   port_please(Node, Host, infinity).
 
 -spec port_please(Name, Host, Timeout) -> {ok, Port, Version} | noport when
-	  Name :: string(),
-	  Host :: inet:ip_address(),
+	  Name :: atom() | string(),
+	  Host :: atom() | string() | inet:ip_address(),
 	  Timeout :: non_neg_integer() | infinity,
 	  Port :: non_neg_integer(),
 	  Version :: non_neg_integer().


### PR DESCRIPTION
It accepts both atoms and strings for the node and host name,
plus IP tuples for the host name.

Noticed the missing spec while debugging Dialyzer warnings in RabbitMQ. It's been using strings for both arguments for some time. The docs seem to generate their spec from the code so no changes needed there.