### PR TITLE
Eliminate bogus warning when using tuple calls

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -2626,7 +2626,8 @@ cfun(#ifun{anno=A,id=Id,vars=Args,clauses=Lcs,fc=Lfc}, _As, St0) ->
      [],A#a.us,St2}.
 
 c_call_erl(Fun, Args) ->
-    cerl:c_call(cerl:c_atom(erlang), cerl:c_atom(Fun), Args).
+    As = [compiler_generated],
+    cerl:ann_c_call(As, cerl:c_atom(erlang), cerl:c_atom(Fun), Args).
 
 %% lit_vars(Literal) -> [Var].
 

--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -42,7 +42,7 @@
 	 comprehensions/1,maps/1,maps_bin_opt_info/1,
          redundant_boolean_clauses/1,
 	 latin1_fallback/1,underscore/1,no_warnings/1,
-	 bit_syntax/1,inlining/1]).
+	 bit_syntax/1,inlining/1,tuple_calls/1]).
 
 init_per_testcase(_Case, Config) ->
     Config.
@@ -64,7 +64,8 @@ groups() ->
        bin_opt_info,bin_construction,comprehensions,maps,
        maps_bin_opt_info,
        redundant_boolean_clauses,latin1_fallback,
-       underscore,no_warnings,bit_syntax,inlining]}].
+       underscore,no_warnings,bit_syntax,inlining,
+       tuple_calls]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -945,6 +946,20 @@ inlining(Config) ->
               add(1, 0) -> 1;
               add(1, Y) -> 1 + Y;
               add(X, Y) -> X + Y.
+           ">>,
+           [],
+           []}
+	 ],
+    run(Config, Ts),
+    ok.
+
+tuple_calls(Config) ->
+    %% Make sure that no spurious warnings are generated.
+    Ts = [{inlining_1,
+           <<"-compile(tuple_calls).
+              dispatch(X) ->
+                (list_to_atom(\"prefix_\" ++
+                atom_to_list(suffix))):doit(X).
            ">>,
            [],
            []}


### PR DESCRIPTION
There would be a bogus warning when compiling the following
function with the `tuple_calls` option:

    dispatch(X) ->
        (list_to_atom("prefix_" ++ atom_to_list(suffix))):doit(X).

The warning would look like this:

    no_file: this expression will fail with a 'badarg' exception

https://bugs.erlang.org/browse/ERL-838