### PR TITLE
Fix internal consistency failure caused by beam_except

### DIFF
--- a/lib/compiler/test/beam_except_SUITE.erl
+++ b/lib/compiler/test/beam_except_SUITE.erl
@@ -21,7 +21,7 @@
 
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
-	 multiple_allocs/1,coverage/1]).
+	 multiple_allocs/1,bs_get_tail/1,coverage/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -31,6 +31,7 @@ all() ->
 groups() ->
     [{p,[parallel],
       [multiple_allocs,
+       bs_get_tail,
        coverage]}].
 
 init_per_suite(Config) ->
@@ -62,6 +63,17 @@ place(lee) ->
 
 conditions() ->
     (talking = going) = storage + [large = wanted].
+
+bs_get_tail(Config) ->
+    {<<"abc">>,0,0,Config} = bs_get_tail_1(id(<<0:32, "abc">>), 0, 0, Config),
+    {'EXIT',
+     {function_clause,
+      [{?MODULE,bs_get_tail_1,[<<>>,0,0,Config],_}|_]}} =
+        (catch bs_get_tail_1(id(<<>>), 0, 0, Config)),
+    ok.
+
+bs_get_tail_1(<<_:32, Rest/binary>>, Z1, Z2, F1) ->
+    {Rest,Z1,Z2,F1}.
 
 coverage(_) ->
     File = {file,"fake.erl"},
@@ -98,6 +110,8 @@ coverage(_) ->
     ok.
 
 fake_function_clause(A) -> error(function_clause, [A,42.0]).
+
+id(I) -> I.
 
 -file("fake.erl", 1).
 fc(a) ->	                                %Line 2


### PR DESCRIPTION
Fix a bug where the number of live registers in a `bs_get_tail`
instruction was too low.

Consider this example:

    -export([bs_get_tail/2]).
    bs_get_tail(Bin, Config) ->
        bs_get_tail_1(Bin, 0, 0, Config).

    bs_get_tail_1(<<_:32, Rest/binary>>, Z1, Z2, F1) ->
        {Rest,Z1,Z2,F1}.

`beam_validator` would emit the following diagnostics:

    t: function bs_get_tail_1/4+2:
      Internal consistency check failed - please report this bug.
      Instruction: {func_info,{atom,t},{atom,bs_get_tail_1},4}
      Error:       {uninitialized_reg,{x,3}}:

Here is the part of the code that generates the `function_clause`
exception before the optimization:

    {test_heap,6,4}.
    {put_list,{x,3},nil,{x,2}}.
    {put_list,{integer,0},{x,2},{x,2}}.
    {put_list,{integer,0},{x,2},{x,2}}.
    {bs_set_position,{x,1},{x,0}}.
    {bs_get_tail,{x,1},{x,0},3}.     %3 live registers.
    {test_heap,2,3}.
    {put_list,{x,0},{x,2},{x,1}}.
    {move,{atom,function_clause},{x,0}}.
    {line,[{location,"t.erl",8}]}.
    {call_ext_only,2,{extfunc,erlang,error,2}}.

The `bs_get_tail` instruction expects that 3 registers will be live
at this point. `beam_except` rewrites the code like this:

    {bs_set_position,{x,1},{x,0}}.
    {bs_get_tail,{x,1},{x,0},3}.    %Still 3. Too low.
    {move,{integer,0},{x,1}}.
    {move,{integer,0},{x,2}}.
    {jump,{f,3}}.

Now the number of live registers in `bs_get_tail` is too low,
because the `{x,3}` register will become undefined.

This commit adds code to update the number of live registers
in the `bs_get_tail` instruction, producing this code:

    {bs_set_position,{x,1},{x,0}}.
    {bs_get_tail,{x,1},{x,0},4}.    %Adjusted to 4.
    {move,{integer,0},{x,1}}.
    {move,{integer,0},{x,2}}.
    {jump,{f,3}}.