### PR TITLE
Make iolist_size/1 yield

### DIFF
--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -345,16 +345,17 @@ type	COUNTERS	STANDARD	SYSTEM		erl_bif_counters
 # Types used by system specific code
 #
 
-type  	TEMP_TERM 	TEMPORARY	SYSTEM		temp_term
-type	DRV_TAB		LONG_LIVED	SYSTEM		drv_tab
-type	DRV_EV_STATE	LONG_LIVED	SYSTEM		driver_event_state
-type	DRV_SEL_D_STATE	FIXED_SIZE	SYSTEM		driver_select_data_state
-type	NIF_SEL_D_STATE	FIXED_SIZE	SYSTEM		enif_select_data_state
-type	POLLSET		LONG_LIVED	SYSTEM		pollset
-type	POLLSET_UPDREQ	SHORT_LIVED	SYSTEM		pollset_update_req
-type	POLL_FDS	LONG_LIVED	SYSTEM		poll_fds
-type	FD_STATUS	LONG_LIVED	SYSTEM		fd_status
-type	SELECT_FDS	LONG_LIVED	SYSTEM		select_fds
+type  	TEMP_TERM       	TEMPORARY	SYSTEM		temp_term
+type  	SHORT_LIVED_TERM 	SHORT_LIVED	SYSTEM		short_lived_term
+type	DRV_TAB		        LONG_LIVED	SYSTEM		drv_tab
+type	DRV_EV_STATE	        LONG_LIVED	SYSTEM		driver_event_state
+type	DRV_SEL_D_STATE	        FIXED_SIZE	SYSTEM		driver_select_data_state
+type	NIF_SEL_D_STATE	        FIXED_SIZE	SYSTEM		enif_select_data_state
+type	POLLSET		        LONG_LIVED	SYSTEM		pollset
+type	POLLSET_UPDREQ	        SHORT_LIVED	SYSTEM		pollset_update_req
+type	POLL_FDS	        LONG_LIVED	SYSTEM		poll_fds
+type	FD_STATUS	        LONG_LIVED	SYSTEM		fd_status
+type	SELECT_FDS	        LONG_LIVED	SYSTEM		select_fds
 
 +if unix
 

--- a/erts/emulator/beam/erl_dirty_bif.tab
+++ b/erts/emulator/beam/erl_dirty_bif.tab
@@ -57,7 +57,6 @@ dirty-cpu erts_debug:lcnt_clear/0
 #  and debug purposes only. We really do *not* want to execute these
 #  on dirty schedulers on a real system.
 
-dirty-cpu-test erlang:iolist_size/1
 dirty-cpu-test erlang:make_tuple/2
 dirty-cpu-test erlang:make_tuple/3
 dirty-cpu-test erlang:append_element/2

--- a/erts/emulator/test/emulator_bench.spec
+++ b/erts/emulator/test/emulator_bench.spec
@@ -1,1 +1,2 @@
 {groups,"../emulator_test",estone_SUITE,[estone_bench]}.
+{groups,"../emulator_test",binary_SUITE,[iolist_size_benchmarks]}.


### PR DESCRIPTION
The iolist_size/1 function did not yield even if the input list was
very long and a call to the function did only consume a single
reduction. This commit fixes these problems.