### PR TITLE
Expand rr support in cerl and etp

### DIFF
--- a/erts/etc/unix/Makefile
+++ b/erts/etc/unix/Makefile
@@ -30,7 +30,8 @@ opt debug lcnt: etc
 etc: etp-commands
 
 etp-commands: etp-commands.in
-	$(gen_verbose)sed 's:@ERL_TOP@:${ERL_TOP}:g' etp-commands.in > etp-commands
+	$(gen_verbose)sed -e 's:@ERL_TOP@:${ERL_TOP}:g' \
+	etp-commands.in > etp-commands
 
 .PHONY: docs
 docs:

--- a/erts/etc/unix/cerl.src
+++ b/erts/etc/unix/cerl.src
@@ -224,7 +224,13 @@ while [ $# -gt 0 ]; do
 	    shift
 	    cargs="$cargs -rr"
 	    run_rr=yes
-	    skip_erlexec=yes
+            case "$1" in
+                "replay"|"ps")
+                    ;;
+                *)
+	            skip_erlexec=yes
+                    ;;
+            esac
 	    ;;
 	*)
 	    break
@@ -307,7 +313,26 @@ if [ "x$GDB" = "x" ]; then
 	exec $taskset1 valgrind $valgrind_xml $valgrind_log $valgrind_misc_flags $BINDIR/$EMU_NAME $sched_arg $emu_xargs "$@"
 
     elif [ $run_rr = yes ]; then
-	exec rr record --ignore-nested $BINDIR/$EMU_NAME $emu_xargs "$@"
+        if [ $1 = replay ]; then
+            shift
+            cmdfile="/tmp/.cerlgdb.$$"
+            echo "set \$etp_beam_executable = \"$BINDIR/$EMU_NAME\"" > $cmdfile
+            if [ "$1" = "-p" ]; then
+                echo 'set $etp_rr_run_until_beam = 1' >> $cmdfile
+            fi
+            cat $ROOTDIR/erts/etc/unix/etp-commands.in >> $cmdfile
+            exec rr replay -x $cmdfile $*
+        elif [ $1 = ps ]; then
+            shift
+            rr ps $* | head -1
+            ChildSetup=`rr ps $* | grep 'erl_child_setup' | awk '{ print $2 }'`
+            for CS in $ChildSetup; do
+                rr ps $* | grep -E "^$CS"
+            done
+            exit 0
+        else
+	    exec rr record --ignore-nested $BINDIR/$EMU_NAME $emu_xargs "$@"
+        fi
     else
 	exec $EXEC $xargs ${1+"$@"}
     fi

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -149,7 +149,7 @@ define etp-1
       else
         # (($arg0) & 0x3) == 0
         if (($arg0) == etp_the_non_value)
-          printf "<the non-value>"
+          printf "<the-non-value>"
         else
           etp-cp-1 ($arg0)
         end
@@ -1241,7 +1241,7 @@ define etp-sig-int
     if $etp_sig_tag != etp_the_non_value
       etp-1 $etp_sig_tag 0
     else
-      print "!ENCODED-DIST-MSG"
+      printf "!ENCODED-DIST-MSG"
     end
     if ($arg0)->m[1] != $etp_nil
       printf " @token= "
@@ -1251,7 +1251,7 @@ define etp-sig-int
     etp-1 ($arg0)->m[2] 0
   else
     if ($etp_sig_tag & 0x3f) != 0x30
-      print "!INVALID-SIGNAL"
+      printf "!INVALID-SIGNAL"
     else
       set $etp_sig_op = (($etp_sig_tag >> 6) & 0xff)
       set $etp_sig_type = (($etp_sig_tag >> 14) & 0xff)
@@ -4326,6 +4326,20 @@ document etp-show
 %---------------------------------------------------------------------------
 end
 
+define etp-rr-run-until-beam
+  source @ERL_TOP@/erts/etc/unix/etp-rr-run-until-beam.py
+end
+
+document etp-rr-run-until-beam
+%---------------------------------------------------------------------------
+% etp-rr-run-until-beam
+%
+% Use this gdb macro to make cerl -rr replay -p PID walk until
+% the correct execute has been made. You may have to change the
+% file that is used to debug with.
+%---------------------------------------------------------------------------
+end
+
 ############################################################################
 # Init
 #
@@ -4359,11 +4373,19 @@ document etp-init
 %---------------------------------------------------------------------------
 end
 
+macro define offsetof(t, f) &((t *) 0)->f)
+
 define hook-run
   set $_exitsignal = -1
 end
 
+handle SIGPIPE nostop
+
 etp-init
 help etp-init
-etp-show
-etp-system-info
+if $etp_rr_run_until_beam
+  help etp-rr-run-until-beam
+else
+  etp-show
+  etp-system-info
+end

--- a/erts/etc/unix/etp-rr-run-until-beam.py
+++ b/erts/etc/unix/etp-rr-run-until-beam.py
@@ -1,0 +1,45 @@
+#
+# %CopyrightBegin%
+#
+# Copyright Ericsson AB 2013-2016. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# %CopyrightEnd%
+#
+
+has_exited = False
+
+def stop_handler (event):
+  global has_exited
+  if isinstance(event, gdb.SignalEvent):
+    print("exit code: %s" % (event.stop_signal))
+    has_exited = True
+
+gdb.events.stop.connect (stop_handler)
+
+gdb.execute('continue')
+
+while not has_exited:
+  r = gdb.execute('when', to_string=True)
+  m = re.match("[^0-9]*([0-9]+)", r)
+  if m:
+    event = int(m.group(1));
+    gdb.execute('start ' + str(event + 1));
+    gdb.execute('continue')
+
+gdb.events.stop.disconnect (stop_handler)
+
+gdb.execute('file ' + str(gdb.parse_and_eval("$etp_beam_executable")))
+gdb.execute('break main')
+gdb.execute('reverse-continue')


### PR DESCRIPTION
This PR adds more support for [rr](https://rr-project.org/) into cerl and etp. The cerl commands added are:

* cerl -rr ps [-a] ...
* cerl -rr replay [-p PID] ...

These commands are especially usefull when debugging distributed applications using rr.

Example usage:

Start an rr session and create an child node that we make call `erlang:display(hello)`

```
> cerl -rr -sname test
rr: Saving execution to trace directory `/home/eluklar/.local/share/rr/beam.smp-60'.
Erlang/OTP 21 [erts-10.2.3] [source-aef5f4dcfe] [64-bit] [smp:1:1] [ds:1:1:10] [async-threads:1] [hipe]

Eshell V10.2.3  (abort with ^G)
(test@elxd3291v0k)1> erlang:open_port({spawn,"cerl -sname test1"},[]).
#Port<0.9>
(test@elxd3291v0k)2> rpc:call(test1@elxd3291v0k, erlang, display, [hello]).
true
(test@elxd3291v0k)3> flush().
Shell got {#Port<0.9>,
           {data,"Eshell V10.2.3  (abort with ^G)\n(test1@elxd3291v0k)1> "}}
Shell got {#Port<0.9>,{data,"hello\r\n"}}
ok
(test@elxd3291v0k)4> init:stop().
ok
```

List all erlang emulators started in the rr session:

```
> cerl -rr ps
PID	PPID	EXIT	CMD
1665	--	0	/home/eluklar/git/otp2/bin/x86_64-unknown-linux-gnu/beam.smp -- -root /home/eluklar/git/otp2 -progname /home/eluklar/git/otp2/bin/cerl -rr -- -home /home/eluklar -- -sname test
1700	1669	0	sh -c exec cerl -sname test1
```

Start a rr replay of the child node. (I've cut out a lot of the gdb printouts for brevity)

```
> cerl -rr replay -p 1700
GNU gdb (Ubuntu 7.7.1-0ubuntu5~14.04.3) 7.7.1
%---------------------------------------------------------------------------
% etp-rr-run-until-beam
%
% Use this gdb macro to make cerl -rr replay -p PID walk until
% the correct execute has been made. You may have to change the
% file that is used to debug with.
%---------------------------------------------------------------------------
Remote debugging using 127.0.0.1:1942

--------------------------------------------------
 ---> Reached target process 1700 at event 12742.
--------------------------------------------------
(rr)
```

Run the `etp-rr-run-until-beam` gdb python script to make rr go to the correct `exec` instance within the process.

```
(rr) etp-rr-run-until-beam
etp-rr-run-until-beam

--------------------------------------------------
 ---> Reached target process 1700 at event 20184.
--------------------------------------------------

Program received signal SIGPIPE, Broken pipe.
[Switching to Thread 1700.1732]
0x0000000070000005 in ?? ()
exit code: SIGPIPE
Breakpoint 1 at 0x44c6a0: file sys/unix/erl_main.c, line 29.

Program received signal SIGPIPE, Broken pipe.
0x0000000070000005 in ?? ()
(rr)
```

We can now use the normal rr command in this sub node, e.g. use `reverse-continue` to go to the start of the run and then set a break when we call `erlang:display/1` and then print the argument of that bif call.

```
(rr) reverse-continue
Continuing.
[Switching to Thread 1700.1700]

Breakpoint 1, main (argc=12, argv=0x7fff2e203598) at sys/unix/erl_main.c:29
29	{
(rr) b display_1 
Breakpoint 2 at 0x4f6950: file beam/bif.c, line 3740.
(rr) c
Continuing.
[New Thread 1700.1734]
[Switching to Thread 1700.1734]

Breakpoint 2, display_1 (A__p=0x7f8dfc3c7718, BIF__ARGS=0x7f8dfc7c0100, 
    A__I=0x7f8dfb476338) at beam/bif.c:3740
3740	{
(rr) etp BIF__ARGS[0]
hello.
(rr)
```