### PR TITLE
Define OTP_MINOR_VERSION and ?OTP_MINOR_VERSION

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -9053,6 +9053,17 @@ ok
               <seealso marker="doc/system_principles:versions">
               System principles</seealso> in System Documentation.</p>
           </item>
+          <tag><marker id="system_info_otp_minor_version"/>
+            <c>otp_minor_version</c></tag>
+          <item>
+            <p>Returns a string containing the OTP minor version number of the
+              OTP release that the currently executing ERTS application
+              is part of. For example, if the OTP version is 21.2.3,
+              this would return "2".</p>
+          <p>For more information, see the description of versions in
+              <seealso marker="doc/system_principles:versions">
+              System principles</seealso> in System Documentation.</p>
+          </item>
           <tag><marker id="system_info_port_parallelism"/>
             <c>port_parallelism</c></tag>
           <item>

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2832,6 +2832,10 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 	int n = sizeof(ERLANG_OTP_RELEASE)-1;
 	hp = HAlloc(BIF_P, 2*n);
 	BIF_RET(buf_to_intlist(&hp, ERLANG_OTP_RELEASE, n, NIL));
+    } else if (ERTS_IS_ATOM_STR("otp_minor_version", BIF_ARG_1)) {
+	int n = sizeof(ERLANG_OTP_MINOR_VERSION)-1;
+	hp = HAlloc(BIF_P, 2*n);
+	BIF_RET(buf_to_intlist(&hp, ERLANG_OTP_MINOR_VERSION, n, NIL));
     } else if (ERTS_IS_ATOM_STR("driver_version", BIF_ARG_1)) {
 	char buf[42];
 	int n = erts_snprintf(buf, 42, "%d.%d",

--- a/erts/emulator/test/system_info_SUITE.erl
+++ b/erts/emulator/test/system_info_SUITE.erl
@@ -124,6 +124,7 @@ misc_smoke_tests(Config) when is_list(Config) ->
     true = is_binary(erlang:system_info(procs)),
     true = is_binary(erlang:system_info(loaded)),
     true = is_binary(erlang:system_info(dist)),
+    true = is_list(erlang:system_info(otp_minor_version)),
     ok = try erlang:system_info({cpu_topology,erts_get_cpu_topology_error_case}), fail catch error:badarg -> ok end,
     true = lists:member(erlang:system_info(tolerant_timeofday), [enabled, disabled]),
     ok.

--- a/erts/emulator/utils/make_version
+++ b/erts/emulator/utils/make_version
@@ -45,6 +45,9 @@ defined $release or die "No otp release specified";
 my $otp_version = shift;
 defined $otp_version or die "No otp version specified";
 
+my ($otp_minor_version) = $otp_version =~ m/^\d+\.(\d+)/;
+defined $otp_minor_version or die "No otp minor version detected in OTP version $otp_version";
+
 my $version = shift;
 defined $version or die "No version name specified";
 
@@ -58,6 +61,7 @@ print FILE <<EOF;
 /* This file was created by 'make_version' -- don't modify. */
 #define ERLANG_OTP_RELEASE "$release"
 #define ERLANG_OTP_VERSION "$otp_version"
+#define ERLANG_OTP_MINOR_VERSION "$otp_minor_version"
 #define ERLANG_VERSION "$version"
 #if ERTS_SAVED_COMPILE_TIME
 #  define ERLANG_COMPILE_DATE "$time_str"

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -577,6 +577,7 @@ predef_macros(File) ->
     Machine = list_to_atom(erlang:system_info(machine)),
     Anno = line1(),
     OtpVersion = list_to_integer(erlang:system_info(otp_release)),
+    OtpMinVersion = list_to_integer(erlang:system_info(otp_minor_version)), 
     Defs = [{'FILE', 	           {none,[{string,Anno,File}]}},
 	    {'FUNCTION_NAME',      undefined},
 	    {'FUNCTION_ARITY',     undefined},
@@ -587,7 +588,8 @@ predef_macros(File) ->
 	    {'BASE_MODULE_STRING', undefined},
 	    {'MACHINE',	           {none,[{atom,Anno,Machine}]}},
 	    {Machine,	           {none,[{atom,Anno,true}]}},
-	    {'OTP_RELEASE',	   {none,[{integer,Anno,OtpVersion}]}}
+	    {'OTP_RELEASE',	   {none,[{integer,Anno,OtpVersion}]}},
+	    {'OTP_MINOR_VERSION', {none, [{integer, Anno, OtpMinVersion}]}}
 	   ],
     maps:from_list(Defs).
 

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -801,7 +801,7 @@ otp_8130(Config) when is_list(Config) ->
     ['BASE_MODULE','BASE_MODULE_STRING','BEAM','FILE',
      'FUNCTION_ARITY','FUNCTION_NAME',
      'LINE','MACHINE','MODULE','MODULE_STRING',
-     'OTP_RELEASE'] = PreDefMacs,
+     'OTP_RELEASE', 'OTP_MINOR_VERSION'] = PreDefMacs,
     {ok,[{'-',_},{atom,_,file}|_]} = epp:scan_erl_form(Epp),
     {ok,[{'-',_},{atom,_,module}|_]} = epp:scan_erl_form(Epp),
     {ok,[{atom,_,t}|_]} = epp:scan_erl_form(Epp),
@@ -1234,7 +1234,15 @@ test_if(Config) ->
 	     "-else.\n"
 	     "t() -> ok.\n"
 	     "-endif.\n">>,
-	   ok}
+	     ok},
+
+      {if_9,
+	   <<"-if(?OTP_MINOR_VERSION >= 0).\n"
+	     "t() -> ok.\n"
+	     "-else.\n"
+	     "a bug.\n"
+	     "-endif.\n">>,
+         ok}
 	 ],
     [] = run(Config, Ts),
 

--- a/system/doc/reference_manual/macros.xml
+++ b/system/doc/reference_manual/macros.xml
@@ -155,6 +155,11 @@ bar(X) ->
         application is part of, as an integer. For details, see
         <seealso marker="erts:erlang#system_info/1"><c>erlang:system_info(otp_release)</c></seealso>.
         This macro was introduced in OTP release 21.</item>
+      <tag><c>?OTP_MINOR_VERSION</c></tag>
+      <item>The OTP minor version of the release that the currently executing ERTS
+        application is part of, as an integer. For details, see
+        <seealso marker="erts:erlang#system_info/1"><c>erlang:system_info(otp_minor_version)</c></seealso>.
+        This macro was introduced in OTP release 21.</item>
     </taglist>
   </section>
 


### PR DESCRIPTION
In order to test for and control the presence of new features that may be introduced in a minor version we need to be able to programmatically detect the minor version of an OTP release.

This PR defines OTP_MINOR_VERSION and makes it available via `erlang:system_info/1` and as the macro `?OTP_MINOR_VERSION` ala `?OTP_RELEASE`.  

  - modified erts/emulator/utils/make_version to extract the minor
    version from the OTP_RELASE version string and define in it
    erl_version.h
  - added conditional in erts/emulator/beam/erl_bif_info.c to return
    to OTP_MINOR_VERSION if arg was the atom otp_minor_version
  - Modified lib/stdlib/src/epp.erl to pre-define ?OTP_MINOR_VERSION
  - Modified tests in erts/emulator/test/system_info_SUITE and
    lib/stdlib/test/epp_SUITE to ensure the presence of the string value
    via system_info/1 and the integer value via ?OTP_MINOR_VERSION