### PR TITLE
Implement fragmentation of large distribution messages

### DIFF
--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -532,7 +532,7 @@ io:format("old/unused name ~ts at port ~p, fd = ~p ~n",
     <marker id="distribution_handshake"/>
     <title>Distribution Handshake</title>
     <p>This section describes the distribution handshake protocol introduced
-      in Erlang/OTP R6. The handshake has remaining almost the same since then.</p>
+      in Erlang/OTP R6. The handshake has remained almost the same since then.</p>
 
     <section>
       <title>General</title>
@@ -979,6 +979,7 @@ DiB == gen_digest(ChA, ICA)?
       <tag><c>EXIT</c></tag>
       <item>
         <p><c>{3, FromPid, ToPid, Reason}</c></p>
+        <p>This signal is sent when a link has been broken</p>
       </item>
       <tag><c>UNLINK</c></tag>
       <item>
@@ -1001,6 +1002,7 @@ DiB == gen_digest(ChA, ICA)?
       <tag><c>EXIT2</c></tag>
       <item>
         <p><c>{8, FromPid, ToPid, Reason}</c></p>
+        <p>This signal is sent by a call to the erlang:exit/2 bif</p>
       </item>
     </taglist>
   </section>

--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -899,7 +899,7 @@ DiB == gen_digest(ChA, ICA)?
       <item>
         <p>
           <seealso marker="erl_ext_dist#distribution_header">Distribution header
-          describing the atom cache.
+          describing the atom cache and fragmented distribution messages.
           </seealso>
         </p>
       </item>

--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -532,11 +532,7 @@ io:format("old/unused name ~ts at port ~p, fd = ~p ~n",
     <marker id="distribution_handshake"/>
     <title>Distribution Handshake</title>
     <p>This section describes the distribution handshake protocol introduced
-      in Erlang/OTP R6. This description was previously located in
-      <c>$ERL_TOP/lib/kernel/internal_doc/distribution_handshake.txt</c> and
-      has more or less been copied and "formatted" here. It has been almost
-      unchanged since 1999, but the handshake has not changed much since then
-      either.</p>
+      in Erlang/OTP R6. The handshake has remaining almost the same since then.</p>
 
     <section>
       <title>General</title>
@@ -847,6 +843,18 @@ DiB == gen_digest(ChA, ICA)?
 	    of the <c>SEND_TT</c> control message.
 	  </p>
         </item>
+        <tag><c>-define(DFLAG_BIG_SEQTRACE_LABELS, 16#100000).</c></tag>
+        <item>
+          <p>The node understands any term as the seqtrace label.</p>
+        </item>
+        <tag><c>-define(DFLAG_EXIT_PAYLOAD, 16#400000).</c></tag>
+        <item>
+          <p>Use the <c>PAYLOAD_EXIT</c>, <c>PAYLOAD_EXIT_TT</c>,
+          <c>PAYLOAD_EXIT2</c>, <c>PAYLOAD_EXIT2_TT</c>
+          and <c>PAYLOAD_MONITOR_P_EXIT</c>
+          <seealso marker="#control_message">control message</seealso>s
+          instead of the non-PAYLOAD variants.</p>
+        </item>
       </taglist>
       <p>
 	There is also function <c>dist_util:strict_order_flags/0</c>
@@ -859,7 +867,7 @@ DiB == gen_digest(ChA, ICA)?
   <section>
     <marker id="connected_nodes"/>
     <title>Protocol between Connected Nodes</title>
-    <p>As from ERTS 5.7.2 the runtime system passes a distribution flag
+    <p>Since ERTS 5.7.2 (OTP R13B) the runtime system passes a distribution flag
       in the handshake stage that enables the use of a
       <seealso marker="erl_ext_dist#distribution_header">distribution header
       </seealso> on all messages passed. Messages passed between nodes have in
@@ -878,7 +886,7 @@ DiB == gen_digest(ChA, ICA)?
         <cell align="center"><c>ControlMessage</c></cell>
         <cell align="center"><c>Message</c></cell>
       </row>
-      <tcaption>Format of Messages Passed between Nodes (as from ERTS 5.7.2)
+      <tcaption>Format of Messages Passed between Nodes (as from ERTS 5.7.2 (OTP R13B))
       </tcaption>
     </table>
 
@@ -887,15 +895,23 @@ DiB == gen_digest(ChA, ICA)?
       <item>
         <p>Equal to d + n + m.</p>
       </item>
+      <tag><c>DistributionHeader</c></tag>
+      <item>
+        <p>
+          <seealso marker="erl_ext_dist#distribution_header">Distribution header
+          describing the atom cache.
+          </seealso>
+        </p>
+      </item>
       <tag><c>ControlMessage</c></tag>
       <item>
         <p>A tuple passed using the external format of Erlang.</p>
       </item>
       <tag><c>Message</c></tag>
       <item>
-        <p>The message sent to another node using the '!' (in external format).
-          Notice that <c>Message</c> is only passed in combination with a
-          <c>ControlMessage</c> encoding a send ('!').</p>
+        <p>The message sent to another node using the '!'
+          or the reason for a EXIT, EXIT2 or DOWN signal using
+          the external term format.</p>
       </item>
     </taglist>
 
@@ -903,7 +919,7 @@ DiB == gen_digest(ChA, ICA)?
       number is omitted from the terms that follow a distribution header
       </seealso>.</p>
 
-    <p>Nodes with an ERTS version earlier than 5.7.2 does not pass the
+    <p>Nodes with an ERTS version earlier than 5.7.2 (OTP R13B) does not pass the
       distribution flag that enables the distribution header. Messages passed
       between nodes have in this case the following format:</p>
 
@@ -920,7 +936,7 @@ DiB == gen_digest(ChA, ICA)?
         <cell align="center"><c>ControlMessage</c></cell>
         <cell align="center"><c>Message</c></cell>
       </row>
-      <tcaption>Format of Messages Passed between Nodes (before ERTS 5.7.2)
+      <tcaption>Format of Messages Passed between Nodes (before ERTS 5.7.2 (OTP R13B))
       </tcaption>
     </table>
 
@@ -1007,7 +1023,7 @@ DiB == gen_digest(ChA, ICA)?
         <p><c>{16, FromPid, Unused, ToName, TraceToken}</c></p>
         <p>Followed by <c>Message</c>.</p>
         <p><c>Unused</c> is kept for backward compatibility.</p>
-      </item>      
+      </item>
       <tag><c>EXIT2_TT</c></tag>
       <item>
         <p><c>{18, FromPid, ToPid, TraceToken, Reason}</c></p>
@@ -1061,7 +1077,7 @@ DiB == gen_digest(ChA, ICA)?
         <p><c>{22, FromPid, ToPid}</c></p>
         <p>Followed by <c>Message</c>.</p>
 	<p>
-	  This control messages replace the <c>SEND</c> control
+	  This control message replaces the <c>SEND</c> control
 	  message and will be sent when the distribution flag
 	  <seealso marker="erl_dist_protocol#dflags"><c>DFLAG_SEND_SENDER</c></seealso>
 	  has been negotiated in the connection setup handshake.
@@ -1080,7 +1096,7 @@ DiB == gen_digest(ChA, ICA)?
         <p><c>{23, FromPid, ToPid, TraceToken}</c></p>
         <p>Followed by <c>Message</c>.</p>
 	<p>
-	  This control messages replace the <c>SEND_TT</c> control
+	  This control message replaces the <c>SEND_TT</c> control
 	  message and will be sent when the distribution flag
 	  <seealso marker="erl_dist_protocol#dflags"><c>DFLAG_SEND_SENDER</c></seealso>
 	  has been negotiated in the connection setup handshake.
@@ -1093,6 +1109,74 @@ DiB == gen_digest(ChA, ICA)?
 	  control messages will be sent in the same direction
 	  on the connection.
 	</p></note>
+      </item>
+    </taglist>
+  </section>
+
+  <section>
+    <title>New Ctrlmessages for Erlang/OTP 22</title>
+    <note><p>
+      Messages encoded before the connection has
+      been set up may still use the non-PAYLOAD variant.
+      However, once a PAYLOAD control message has been sent,
+      no more non-PAYLOAD control messages will be sent in
+      the same direction on the connection.
+    </p></note>
+    <taglist>
+      <tag><c>PAYLOAD_EXIT</c></tag>
+      <item>
+        <p><c>{24, FromPid, ToPid}</c></p>
+        <p>Followed by <c>Reason</c>.</p>
+	<p>
+	  This control message replaces the <c>EXIT</c> control
+	  message and will be sent when the distribution flag
+	  <seealso marker="erl_dist_protocol#dflags"><c>DFLAG_EXIT_PAYLOAD</c></seealso>
+	  has been negotiated in the connection setup handshake.
+	</p>
+      </item>
+      <tag><c>PAYLOAD_EXIT_TT</c></tag>
+      <item>
+        <p><c>{25, FromPid, ToPid}</c></p>
+        <p>Followed by <c>Reason</c>.</p>
+	<p>
+	  This control message replaces the <c>EXIT_TT</c> control
+	  message and will be sent when the distribution flag
+	  <seealso marker="erl_dist_protocol#dflags"><c>DFLAG_EXIT_PAYLOAD</c></seealso>
+	  has been negotiated in the connection setup handshake.
+	</p>
+      </item>
+      <tag><c>PAYLOAD_EXIT2</c></tag>
+      <item>
+        <p><c>{26, FromPid, ToPid}</c></p>
+        <p>Followed by <c>Reason</c>.</p>
+	<p>
+	  This control message replaces the <c>EXIT2</c> control
+	  message and will be sent when the distribution flag
+	  <seealso marker="erl_dist_protocol#dflags"><c>DFLAG_EXIT_PAYLOAD</c></seealso>
+	  has been negotiated in the connection setup handshake.
+	</p>
+      </item>
+      <tag><c>PAYLOAD_EXIT2_TT</c></tag>
+      <item>
+        <p><c>{27, FromPid, ToPid}</c></p>
+        <p>Followed by <c>Reason</c>.</p>
+	<p>
+	  This control message replaces the <c>EXIT2_TT</c> control
+	  message and will be sent when the distribution flag
+	  <seealso marker="erl_dist_protocol#dflags"><c>DFLAG_EXIT_PAYLOAD</c></seealso>
+	  has been negotiated in the connection setup handshake.
+	</p>
+      </item>
+      <tag><c>PAYLOAD_MONITOR_P_EXIT</c></tag>
+      <item>
+        <p><c>{28, FromPid, ToPid, Ref}</c></p>
+        <p>Followed by <c>Reason</c>.</p>
+	<p>
+	  This control message replaces the <c>MONITOR_P_EXIT</c> control
+	  message and will be sent when the distribution flag
+	  <seealso marker="erl_dist_protocol#dflags"><c>DFLAG_EXIT_PAYLOAD</c></seealso>
+	  has been negotiated in the connection setup handshake.
+	</p>
       </item>
     </taglist>
   </section>

--- a/erts/doc/src/erl_ext_dist.xml
+++ b/erts/doc/src/erl_ext_dist.xml
@@ -136,15 +136,8 @@
     </note>
   </section>
 
-  <section>  
+  <section>
     <title>Distribution Header</title>
-    <p>
-      <marker id="distribution_header"/>
-      As from ERTS 5.7.2 the old atom cache protocol was
-      dropped and a new one was introduced. This protocol
-      introduced the distribution header. Nodes with an ERTS version
-      earlier than 5.7.2 can still communicate with new nodes,
-      but no distribution header and no atom cache are used.</p>
     <p>
       The distribution header only contains an atom cache
       reference section, but can in the future contain more

--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -885,19 +885,22 @@ void process_main(Eterm * x_reg_array, FloatDef* f_reg_array)
 #include "beam_warm.h"
 
  OpCase(normal_exit): {
-     SWAPOUT;
+     HEAVY_SWAPOUT;
      c_p->freason = EXC_NORMAL;
      c_p->arity = 0; /* In case this process will ever be garbed again. */
      ERTS_UNREQ_PROC_MAIN_LOCK(c_p);
      erts_do_exit_process(c_p, am_normal);
      ERTS_REQ_PROC_MAIN_LOCK(c_p);
+     HEAVY_SWAPIN;
      goto do_schedule;
  }
 
  OpCase(continue_exit): {
+     HEAVY_SWAPOUT;
      ERTS_UNREQ_PROC_MAIN_LOCK(c_p);
      erts_continue_exit_process(c_p);
      ERTS_REQ_PROC_MAIN_LOCK(c_p);
+     HEAVY_SWAPIN;
      goto do_schedule;
  }
 

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -6108,7 +6108,8 @@ erts_release_literal_area(ErtsLiteralArea* literal_area)
             }
         default:
             ASSERT(is_external_header(oh->thing_word));
-            erts_deref_node_entry(((ExternalThing*)oh)->node);
+            erts_deref_node_entry(((ExternalThing*)oh)->node,
+                                  make_boxed(&oh->thing_word));
         }
         oh = oh->next;
     }

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -4063,10 +4063,12 @@ BIF_RETTYPE list_to_pid_1(BIF_ALIST_1)
       if (is_nil(dep->cid))
 	  goto bad;
       
-      enp = erts_find_or_insert_node(dep->sysname, dep->creation);
+      etp = (ExternalThing *) HAlloc(BIF_P, EXTERNAL_THING_HEAD_SIZE + 1);
+      
+      enp = erts_find_or_insert_node(dep->sysname, dep->creation,
+                                     make_boxed(&etp->header));
       ASSERT(enp != erts_this_node);
 
-      etp = (ExternalThing *) HAlloc(BIF_P, EXTERNAL_THING_HEAD_SIZE + 1);
       etp->header = make_external_pid_header(1);
       etp->next = MSO(BIF_P).first;
       etp->node = enp;
@@ -4130,10 +4132,11 @@ BIF_RETTYPE list_to_port_1(BIF_ALIST_1)
       if (is_nil(dep->cid))
 	  goto bad;
 
-      enp = erts_find_or_insert_node(dep->sysname, dep->creation);
+      etp = (ExternalThing *) HAlloc(BIF_P, EXTERNAL_THING_HEAD_SIZE + 1);
+      enp = erts_find_or_insert_node(dep->sysname, dep->creation,
+                                     make_boxed(&etp->header));
       ASSERT(enp != erts_this_node);
 
-      etp = (ExternalThing *) HAlloc(BIF_P, EXTERNAL_THING_HEAD_SIZE + 1);
       etp->header = make_external_port_header(1);
       etp->next = MSO(BIF_P).first;
       etp->node = enp;
@@ -4236,9 +4239,6 @@ BIF_RETTYPE list_to_ref_1(BIF_ALIST_1)
       if (is_nil(dep->cid))
 	  goto bad;
       
-      enp = erts_find_or_insert_node(dep->sysname, dep->creation);
-      ASSERT(enp != erts_this_node);
-
       hsz = EXTERNAL_THING_HEAD_SIZE;
 #if defined(ARCH_64)
       hsz += n/2 + 1;
@@ -4247,6 +4247,11 @@ BIF_RETTYPE list_to_ref_1(BIF_ALIST_1)
 #endif
 
       etp = (ExternalThing *) HAlloc(BIF_P, hsz);
+
+      enp = erts_find_or_insert_node(dep->sysname, dep->creation,
+                                     make_boxed(&etp->header));
+      ASSERT(enp != erts_this_node);
+
       etp->header = make_external_ref_header(n/2);
       etp->next = BIF_P->off_heap.first;
       etp->node = enp;

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -225,6 +225,7 @@ BIF_RETTYPE link_1(BIF_ALIST_1)
             code = erts_dsig_send_link(&dsd, BIF_P->common.id, BIF_ARG_1);
             if (code == ERTS_DSIG_SEND_YIELD)
                 ERTS_BIF_YIELD_RETURN(BIF_P, am_true);
+            ASSERT(code == ERTS_DSIG_SEND_OK);
             BIF_RET(am_true);
             break;
         }
@@ -2094,6 +2095,7 @@ BIF_RETTYPE send_3(BIF_ALIST_3)
     ctx->return_term = am_ok;
     ctx->dss.reds = (Sint) (ERTS_BIF_REDS_LEFT(p) * TERM_TO_BINARY_LOOP_FACTOR);
     ctx->dss.phase = ERTS_DSIG_SEND_PHASE_INIT;
+    ctx->dss.from = BIF_P->common.id;
 
     while (is_list(l)) {
 	if (CAR(list_val(l)) == am_noconnect) {
@@ -2246,6 +2248,7 @@ Eterm erl_send(Process *p, Eterm to, Eterm msg)
     ctx->return_term = msg;
     ctx->dss.reds = (Sint) (ERTS_BIF_REDS_LEFT(p) * TERM_TO_BINARY_LOOP_FACTOR);
     ctx->dss.phase = ERTS_DSIG_SEND_PHASE_INIT;
+    ctx->dss.from = p->common.id;
 
     result = do_send(p, to, msg, &ref, ctx);
 

--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -129,7 +129,7 @@ typedef struct {
     void *to_arg;
 } PrintMonitorContext;
 
-static void doit_print_link(ErtsLink *lnk, void *vpcontext)
+static int doit_print_link(ErtsLink *lnk, void *vpcontext, Sint reds)
 {
     PrintMonitorContext *pcontext = vpcontext;
     fmtfn_t to = pcontext->to;
@@ -141,10 +141,11 @@ static void doit_print_link(ErtsLink *lnk, void *vpcontext)
     } else {
 	erts_print(to, to_arg, ", %T", lnk->other.item);
     }
+    return 1;
 }
     
 
-static void doit_print_monitor(ErtsMonitor *mon, void *vpcontext)
+static int doit_print_monitor(ErtsMonitor *mon, void *vpcontext, Sint reds)
 {
     ErtsMonitorData *mdp;
     PrintMonitorContext *pcontext = vpcontext;
@@ -196,6 +197,7 @@ static void doit_print_monitor(ErtsMonitor *mon, void *vpcontext)
         /* ignore other monitors... */
         break;
     }
+    return 1;
 }
 			       
 /* Display info about an individual Erlang process */

--- a/erts/emulator/beam/copy.c
+++ b/erts/emulator/beam/copy.c
@@ -854,7 +854,7 @@ Eterm copy_struct_x(Eterm obj, Uint sz, Eterm** hpp, ErlOffHeap* off_heap, Uint 
 	    case EXTERNAL_REF_SUBTAG:
 		{
 		  ExternalThing *etp = (ExternalThing *) objp;
-		  erts_refc_inc(&etp->node->refc, 2);
+		  erts_ref_node_entry(etp->node, 2, make_boxed(htop));
 		}
 	    L_off_heap_node_container_common:
 		{
@@ -1660,7 +1660,7 @@ Uint copy_shared_perform(Eterm obj, Uint size, erts_shcopy_t *info,
 	    case EXTERNAL_REF_SUBTAG:
 	    {
 		ExternalThing *etp = (ExternalThing *) ptr;
-		erts_refc_inc(&etp->node->refc, 2);
+                erts_ref_node_entry(etp->node, 2, make_boxed(hp));
 	    }
 	  off_heap_node_container_common:
 	    {
@@ -1866,7 +1866,7 @@ Eterm copy_shallow(Eterm* ERTS_RESTRICT ptr, Uint sz, Eterm** hpp,
 	    case EXTERNAL_REF_SUBTAG:
 		{
 		    ExternalThing* etp = (ExternalThing *) (tp-1);
-		    erts_refc_inc(&etp->node->refc, 2);
+                    erts_ref_node_entry(etp->node, 2, make_boxed(hp-1));
 		}
 	    off_heap_common:
 		{

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -142,16 +142,6 @@ typedef enum {
 } ErtsDSigPrepLock;
 
 
-typedef struct {
-    Process *proc;
-    DistEntry *dep;
-    Eterm node;   /* used if dep == NULL */
-    Eterm cid;
-    Eterm connection_id;
-    int no_suspend;
-    Uint32 flags;
-} ErtsDSigData;
-
 /* Must be larger or equal to 16 */
 #ifdef DEBUG
 #define ERTS_DIST_FRAGMENT_SIZE 16
@@ -181,124 +171,6 @@ extern int erts_is_alive;
 #define ERTS_DSIG_PREP_NOT_ALIVE	3
 /* Pending connection; signals can be enqueued */
 #define ERTS_DSIG_PREP_PENDING	        4
-
-ERTS_GLB_INLINE int erts_dsig_prepare(ErtsDSigData *,
-				      DistEntry*,
-				      Process *,
-                                      ErtsProcLocks,
-				      ErtsDSigPrepLock,
-				      int,
-				      int);
-
-ERTS_GLB_INLINE
-void erts_schedule_dist_command(Port *, DistEntry *);
-
-int erts_auto_connect(DistEntry* dep, Process *proc, ErtsProcLocks proc_locks);
-
-#if ERTS_GLB_INLINE_INCL_FUNC_DEF
-
-ERTS_GLB_INLINE int 
-erts_dsig_prepare(ErtsDSigData *dsdp,
-		  DistEntry *dep,
-		  Process *proc,
-                  ErtsProcLocks proc_locks,
-		  ErtsDSigPrepLock dspl,
-		  int no_suspend,
-		  int connect)
-{
-    int res;
-
-    if (!erts_is_alive)
-	return ERTS_DSIG_PREP_NOT_ALIVE;
-    if (!dep) {
-        ASSERT(!connect);
-        return ERTS_DSIG_PREP_NOT_CONNECTED;
-    }
-
-#ifdef ERTS_ENABLE_LOCK_CHECK
-    if (connect) {
-        erts_proc_lc_might_unlock(proc, proc_locks);
-    }
-#endif
-
-retry:
-    erts_de_rlock(dep);
-
-    if (dep->state == ERTS_DE_STATE_CONNECTED) {
-	res = ERTS_DSIG_PREP_CONNECTED;
-    }
-    else if (dep->state == ERTS_DE_STATE_PENDING) {
-	res = ERTS_DSIG_PREP_PENDING;
-    }
-    else if (dep->state == ERTS_DE_STATE_EXITING) {
-	res = ERTS_DSIG_PREP_NOT_CONNECTED;
-	goto fail;
-    }
-    else if (connect) {
-        ASSERT(dep->state == ERTS_DE_STATE_IDLE);
-        erts_de_runlock(dep);
-        if (!erts_auto_connect(dep, proc, proc_locks)) {
-            return ERTS_DSIG_PREP_NOT_ALIVE;
-        }
-	goto retry;
-    }
-    else {
-        ASSERT(dep->state == ERTS_DE_STATE_IDLE);
-	res = ERTS_DSIG_PREP_NOT_CONNECTED;
-	goto fail;
-    }
-
-    if (no_suspend) {
-	if (erts_atomic32_read_acqb(&dep->qflgs) & ERTS_DE_QFLG_BUSY) {
-	    res = ERTS_DSIG_PREP_WOULD_SUSPEND;
-	    goto fail;
-	}
-    }
-    dsdp->proc = proc;
-    dsdp->dep = dep;
-    dsdp->cid = dep->cid;
-    dsdp->connection_id = dep->connection_id;
-    dsdp->no_suspend = no_suspend;
-    dsdp->flags = dep->flags;
-    if (dspl == ERTS_DSP_NO_LOCK)
-	erts_de_runlock(dep);
-    return res;
-
- fail:
-    erts_de_runlock(dep);
-    return res;
-}
-
-ERTS_GLB_INLINE
-void erts_schedule_dist_command(Port *prt, DistEntry *dist_entry)
-{
-    DistEntry *dep;
-    Eterm id;
-
-    if (prt) {
-	ERTS_LC_ASSERT(erts_lc_is_port_locked(prt));
-	ASSERT((erts_atomic32_read_nob(&prt->state)
-		& ERTS_PORT_SFLGS_DEAD) == 0);
-
-        dep = (DistEntry*) erts_prtsd_get(prt, ERTS_PRTSD_DIST_ENTRY);
-        ASSERT(dep);
-	id = prt->common.id;
-    }
-    else {
-	ASSERT(dist_entry);
-	ERTS_LC_ASSERT(erts_lc_rwmtx_is_rlocked(&dist_entry->rwmtx)
-			   || erts_lc_rwmtx_is_rwlocked(&dist_entry->rwmtx));
-	ASSERT(is_internal_port(dist_entry->cid));
-
- 	dep = dist_entry;
-	id = dep->cid;
-    }
-
-    if (!erts_atomic_xchg_mb(&dep->dist_cmd_scheduled, 1))
-	erts_port_task_schedule(id, &dep->dist_cmd, ERTS_PORT_TASK_DIST_CMD);
-}
-
-#endif
 
 #ifdef DEBUG
 #define ERTS_DBG_CHK_NO_DIST_LNK(D, R, L) \
@@ -363,15 +235,26 @@ enum erts_dsig_send_phase {
     ERTS_DSIG_SEND_PHASE_SEND
 };
 
-struct erts_dsig_send_context {
-    enum erts_dsig_send_phase phase;
-    Sint reds;
+typedef struct erts_dsig_send_context {
+    int connect;
+    int no_suspend;
+    int no_trap;
 
     Eterm ctl;
     Eterm msg;
     Eterm from;
-    int force_busy;
-    int force_encode;
+    Eterm ctl_heap[6];
+    Eterm return_term;
+
+    DistEntry *dep;
+    Eterm node;   /* used if dep == NULL */
+    Eterm cid;
+    Eterm connection_id;
+    int deref_dep;
+
+    enum erts_dsig_send_phase phase;
+    Sint reds;
+
     Uint32 max_finalize_prepend;
     Uint data_size, dhdr_ext_size;
     ErtsAtomCacheMap *acmp;
@@ -383,20 +266,8 @@ struct erts_dsig_send_context {
 	TTBSizeContext sc;
 	TTBEncodeContext ec;
     }u;
-};
 
-typedef struct {
-    int suspend;
-    int connect;
-
-    Eterm ctl_heap[6];
-    ErtsDSigData dsd;
-    DistEntry *dep;
-    int deref_dep;
-    struct erts_dsig_send_context dss;
-
-    Eterm return_term;
-}ErtsSendContext;
+} ErtsDSigSendContext;
 
 typedef struct dist_sequences DistSeqNode;
 
@@ -408,21 +279,21 @@ typedef struct dist_sequences DistSeqNode;
 #define ERTS_DSIG_SEND_CONTINUE 2
 #define ERTS_DSIG_SEND_TOO_LRG  3
 
-extern int erts_dsig_send_link(ErtsDSigData *, Eterm, Eterm);
-extern int erts_dsig_send_msg(Eterm, Eterm, ErtsSendContext*);
-extern int erts_dsig_send_exit_tt(ErtsDSigData *, Eterm, Eterm, Eterm, Eterm);
-extern int erts_dsig_send_unlink(ErtsDSigData *, Eterm, Eterm);
-extern int erts_dsig_send_reg_msg(Eterm, Eterm, ErtsSendContext*);
-extern int erts_dsig_send_group_leader(ErtsDSigData *, Eterm, Eterm);
-extern int erts_dsig_send_exit(ErtsDSigData *, Eterm, Eterm, Eterm, Eterm);
-extern int erts_dsig_send_exit2(ErtsSendContext *, Eterm, Eterm, Eterm);
-extern int erts_dsig_send_demonitor(ErtsDSigData *, Eterm, Eterm, Eterm, int);
-extern int erts_dsig_send_monitor(ErtsDSigData *, Eterm, Eterm, Eterm);
-extern int erts_dsig_send_m_exit(ErtsDSigData *, Eterm, Eterm, Eterm, Eterm, Eterm);
+extern int erts_dsig_send_msg(ErtsDSigSendContext*, Eterm, Eterm);
+extern int erts_dsig_send_reg_msg(ErtsDSigSendContext*, Eterm, Eterm);
+extern int erts_dsig_send_link(ErtsDSigSendContext *, Eterm, Eterm);
+extern int erts_dsig_send_exit_tt(ErtsDSigSendContext *, Eterm, Eterm, Eterm, Eterm);
+extern int erts_dsig_send_unlink(ErtsDSigSendContext *, Eterm, Eterm);
+extern int erts_dsig_send_group_leader(ErtsDSigSendContext *, Eterm, Eterm);
+extern int erts_dsig_send_exit(ErtsDSigSendContext *, Eterm, Eterm, Eterm);
+extern int erts_dsig_send_exit2(ErtsDSigSendContext *, Eterm, Eterm, Eterm);
+extern int erts_dsig_send_demonitor(ErtsDSigSendContext *, Eterm, Eterm, Eterm);
+extern int erts_dsig_send_monitor(ErtsDSigSendContext *, Eterm, Eterm, Eterm);
+extern int erts_dsig_send_m_exit(ErtsDSigSendContext *, Eterm, Eterm, Eterm, Eterm);
 
-extern int erts_dsig_send(ErtsDSigData *dsdp, struct erts_dsig_send_context* ctx);
+extern int erts_dsig_send(ErtsDSigSendContext *dsdp);
 extern int erts_dsend_context_dtor(Binary*);
-extern Eterm erts_dsend_export_trap_context(Process* p, ErtsSendContext* ctx);
+extern Eterm erts_dsend_export_trap_context(Process* p, ErtsDSigSendContext* ctx);
 
 extern int erts_dist_command(Port *prt, int reds);
 extern void erts_dist_port_not_busy(Port *prt);
@@ -436,4 +307,14 @@ extern void erts_dist_seq_tree_foreach(
     DistEntry *dep,
     int (*func)(ErtsDistExternal *, void*, Sint), void *args);
 
+extern int erts_dsig_prepare(ErtsDSigSendContext *,
+                             DistEntry*,
+                             Process *,
+                             ErtsProcLocks,
+                             ErtsDSigPrepLock,
+                             int,
+                             int,
+                             int);
+
+int erts_auto_connect(DistEntry* dep, Process *proc, ErtsProcLocks proc_locks);
 #endif

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -404,5 +404,4 @@ extern Uint erts_dist_cache_size(void);
 
 extern Sint erts_abort_connection_rwunlock(DistEntry *dep);
 
-
 #endif

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -415,7 +415,7 @@ extern int erts_dsig_send_unlink(ErtsDSigData *, Eterm, Eterm);
 extern int erts_dsig_send_reg_msg(Eterm, Eterm, ErtsSendContext*);
 extern int erts_dsig_send_group_leader(ErtsDSigData *, Eterm, Eterm);
 extern int erts_dsig_send_exit(ErtsDSigData *, Eterm, Eterm, Eterm, Eterm);
-extern int erts_dsig_send_exit2(ErtsDSigData *, Eterm, Eterm, Eterm);
+extern int erts_dsig_send_exit2(ErtsSendContext *, Eterm, Eterm, Eterm);
 extern int erts_dsig_send_demonitor(ErtsDSigData *, Eterm, Eterm, Eterm, int);
 extern int erts_dsig_send_monitor(ErtsDSigData *, Eterm, Eterm, Eterm);
 extern int erts_dsig_send_m_exit(ErtsDSigData *, Eterm, Eterm, Eterm, Eterm, Eterm);

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -47,6 +47,7 @@
 #define DFLAG_SEND_SENDER         0x80000
 #define DFLAG_BIG_SEQTRACE_LABELS 0x100000
 #define DFLAG_NO_MAGIC            0x200000 /* internal for pending connection */
+#define DFLAG_EXIT_PAYLOAD        0x400000
 
 /* Mandatory flags for distribution */
 #define DFLAG_DIST_MANDATORY (DFLAG_EXTENDED_REFERENCES         \
@@ -75,7 +76,8 @@
                             | DFLAG_MAP_TAG                   \
                             | DFLAG_BIG_CREATION              \
                             | DFLAG_SEND_SENDER               \
-                            | DFLAG_BIG_SEQTRACE_LABELS)
+                            | DFLAG_BIG_SEQTRACE_LABELS       \
+                            | DFLAG_EXIT_PAYLOAD)
 
 /* Flags addable by local distr implementations */
 #define DFLAG_DIST_ADDABLE    DFLAG_DIST_DEFAULT
@@ -99,26 +101,35 @@
                                | DFLAG_BIG_CREATION)
 
 /* opcodes used in distribution messages */
-#define DOP_LINK		1
-#define DOP_SEND		2
-#define DOP_EXIT		3
-#define DOP_UNLINK		4
+enum {
+    DOP_LINK                = 1,
+    DOP_SEND                = 2,
+    DOP_EXIT                = 3,
+    DOP_UNLINK              = 4,
 /* Ancient DOP_NODE_LINK (5) was here, can be reused */
-#define DOP_REG_SEND		6
-#define DOP_GROUP_LEADER	7
-#define DOP_EXIT2		8
+    DOP_REG_SEND            = 6,
+    DOP_GROUP_LEADER        = 7,
+    DOP_EXIT2               = 8,
 
-#define DOP_SEND_TT		12
-#define DOP_EXIT_TT		13
-#define DOP_REG_SEND_TT		16
-#define DOP_EXIT2_TT		18
+    DOP_SEND_TT             = 12,
+    DOP_EXIT_TT             = 13,
+    DOP_REG_SEND_TT         = 16,
+    DOP_EXIT2_TT            = 18,
 
-#define DOP_MONITOR_P		19
-#define DOP_DEMONITOR_P		20
-#define DOP_MONITOR_P_EXIT	21
+    DOP_MONITOR_P           = 19,
+    DOP_DEMONITOR_P         = 20,
+    DOP_MONITOR_P_EXIT      = 21,
 
-#define DOP_SEND_SENDER         22
-#define DOP_SEND_SENDER_TT      23
+    DOP_SEND_SENDER         = 22,
+    DOP_SEND_SENDER_TT      = 23,
+
+    /* These are used when DFLAG_EXIT_PAYLOAD is detected */
+    DOP_PAYLOAD_EXIT           = 24,
+    DOP_PAYLOAD_EXIT_TT        = 25,
+    DOP_PAYLOAD_EXIT2          = 26,
+    DOP_PAYLOAD_EXIT2_TT       = 27,
+    DOP_PAYLOAD_MONITOR_P_EXIT = 28
+};
 
 /* distribution trap functions */
 extern Export* dmonitor_node_trap;
@@ -346,6 +357,7 @@ struct erts_dsig_send_context {
     Eterm ctl;
     Eterm msg;
     int force_busy;
+    int force_encode;
     Uint32 max_finalize_prepend;
     Uint data_size, dhdr_ext_size;
     ErtsAtomCacheMap *acmp;

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -275,6 +275,7 @@ type	ML_DIST		STANDARD	SYSTEM		monitor_link_dist
 type	PF3_ARGS	SHORT_LIVED	PROCESSES	process_flag_3_arguments
 type	SETUP_CONN_ARG	SHORT_LIVED	PROCESSES	setup_connection_argument
 type    LIST_TRAP       SHORT_LIVED     PROCESSES       list_bif_trap_state
+type    CONT_EXIT_TRAP  SHORT_LIVED     PROCESSES       continue_exit_trap_state
 
 type	ENVIRONMENT	SYSTEM		SYSTEM		environment
 

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -276,6 +276,7 @@ type	PF3_ARGS	SHORT_LIVED	PROCESSES	process_flag_3_arguments
 type	SETUP_CONN_ARG	SHORT_LIVED	PROCESSES	setup_connection_argument
 type    LIST_TRAP       SHORT_LIVED     PROCESSES       list_bif_trap_state
 type    CONT_EXIT_TRAP  SHORT_LIVED     PROCESSES       continue_exit_trap_state
+type    SEQ_YIELD_STATE SHORT_LIVED     SYSTEM          dist_seq_yield_state
 
 type	ENVIRONMENT	SYSTEM		SYSTEM		environment
 

--- a/erts/emulator/beam/erl_alloc_util.c
+++ b/erts/emulator/beam/erl_alloc_util.c
@@ -7503,7 +7503,7 @@ static int gather_ahist_scan(Allctr_t *allocator,
     return blocks_scanned;
 }
 
-static void gather_ahist_append_result(hist_tree_t *node, void *arg)
+static int gather_ahist_append_result(hist_tree_t *node, void *arg, Sint reds)
 {
     gather_ahist_t *state = (gather_ahist_t*)arg;
 
@@ -7537,6 +7537,7 @@ static void gather_ahist_append_result(hist_tree_t *node, void *arg)
 
     /* Plain free is intentional. */
     free(node);
+    return 1;
 }
 
 static void gather_ahist_send(gather_ahist_t *state)
@@ -7595,11 +7596,11 @@ static int gather_ahist_finish(void *arg)
         state->building_result = 1;
     }
 
-    if (hist_tree_rbt_foreach_destroy_yielding(&state->hist_tree,
-                                               &gather_ahist_append_result,
-                                               state,
-                                               &state->hist_tree_yield,
-                                               BLOCKSCAN_REDUCTIONS)) {
+    if (!hist_tree_rbt_foreach_destroy_yielding(&state->hist_tree,
+                                                &gather_ahist_append_result,
+                                                state,
+                                                &state->hist_tree_yield,
+                                                BLOCKSCAN_REDUCTIONS)) {
         return 1;
     }
 
@@ -7608,10 +7609,11 @@ static int gather_ahist_finish(void *arg)
     return 0;
 }
 
-static void gather_ahist_destroy_result(hist_tree_t *node, void *arg)
+static int gather_ahist_destroy_result(hist_tree_t *node, void *arg, Sint reds)
 {
     (void)arg;
     free(node);
+    return 1;
 }
 
 static void gather_ahist_abort(void *arg)

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -3912,7 +3912,7 @@ struct free_fixations_ctx
     SWord cnt;
 };
 
-static void free_fixations_op(DbFixation* fix, void* vctx)
+static int free_fixations_op(DbFixation* fix, void* vctx, Sint reds)
 {
     struct free_fixations_ctx* ctx = (struct free_fixations_ctx*) vctx;
     erts_aint_t diff;
@@ -3949,6 +3949,7 @@ static void free_fixations_op(DbFixation* fix, void* vctx)
         ERTS_ETS_MISC_MEM_ADD(-sizeof(DbFixation));
     }
     ctx->cnt++;
+    return 1;
 }
 
 int erts_db_execute_free_fixation(Process* p, DbFixation* fix)
@@ -4093,7 +4094,7 @@ struct fixing_procs_info_ctx
     Eterm list;
 };
 
-static void fixing_procs_info_op(DbFixation* fix, void* vctx)
+static int fixing_procs_info_op(DbFixation* fix, void* vctx, Sint reds)
 {
     struct fixing_procs_info_ctx* ctx = (struct fixing_procs_info_ctx*) vctx;
     Eterm* hp;
@@ -4103,6 +4104,7 @@ static void fixing_procs_info_op(DbFixation* fix, void* vctx)
     tpl = TUPLE2(hp, fix->procs.p->common.id, make_small(fix->counter));
     hp += 3;
     ctx->list = CONS(hp, tpl, ctx->list);
+    return 1;
 }
 
 static Eterm table_info(Process* p, DbTable* tb, Eterm What)

--- a/erts/emulator/beam/erl_db.h
+++ b/erts/emulator/beam/erl_db.h
@@ -111,7 +111,7 @@ typedef enum {
 } ErtsDbSpinCount;
 
 void init_db(ErtsDbSpinCount);
-int erts_db_process_exiting(Process *, ErtsProcLocks);
+int erts_db_process_exiting(Process *, ErtsProcLocks, void **);
 int erts_db_execute_free_fixation(Process*, DbFixation*);
 void db_info(fmtfn_t, void *, int);
 void erts_db_foreach_table(void (*)(DbTable *, void *), void *);

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -3312,7 +3312,7 @@ void db_cleanup_offheap_comp(DbTerm* obj)
 	default:
 	    ASSERT(is_external_header(u.hdr->thing_word));
 	    ASSERT(u.pb != &tmp);
-	    erts_deref_node_entry(u.ext->node);
+	    erts_deref_node_entry(u.ext->node, make_boxed(u.ep));
 	    break;
 	}
     }

--- a/erts/emulator/beam/erl_hl_timer.h
+++ b/erts/emulator/beam/erl_hl_timer.h
@@ -56,7 +56,7 @@ void erts_cancel_proc_timer(Process *);
 void erts_set_port_timer(Port *, Sint64);
 void erts_cancel_port_timer(Port *);
 Sint64 erts_read_port_timer(Port *);
-int erts_cancel_bif_timers(Process *, ErtsBifTimers **, void **);
+int erts_cancel_bif_timers(Process *, ErtsBifTimers **, void **, int);
 int erts_detach_accessor_bif_timers(Process *, ErtsBifTimers *, void **);
 ErtsHLTimerService *erts_create_timer_service(void);
 void erts_hl_timer_init(void);

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -181,7 +181,7 @@ erts_cleanup_offheap(ErlOffHeap *offheap)
 	    break;
 	default:
 	    ASSERT(is_external_header(u.hdr->thing_word));
-	    erts_deref_node_entry(u.ext->node);
+	    erts_deref_node_entry(u.ext->node, make_boxed(u.ep));
 	    break;
 	}
     }

--- a/erts/emulator/beam/erl_message.h
+++ b/erts/emulator/beam/erl_message.h
@@ -455,8 +455,6 @@ Sint erts_move_messages_off_heap(Process *c_p);
 Sint erts_complete_off_heap_message_queue_change(Process *c_p);
 Eterm erts_change_message_queue_management(Process *c_p, Eterm new_state);
 
-int erts_decode_dist_message(Process *, ErtsProcLocks, ErtsMessage *, int);
-
 void erts_cleanup_messages(ErtsMessage *mp);
 
 void *erts_alloc_message_ref(void);

--- a/erts/emulator/beam/erl_monitor_link.c
+++ b/erts/emulator/beam/erl_monitor_link.c
@@ -335,7 +335,7 @@ ml_rbt_delete(ErtsMonLnkNode **root, ErtsMonLnkNode *ml)
 
 static void
 ml_rbt_foreach(ErtsMonLnkNode *root,
-               void (*func)(ErtsMonLnkNode *, void *),
+               ErtsMonLnkNodeFunc func,
                void *arg)
 {
     mon_lnk_rbt_foreach(root, func, arg);
@@ -348,7 +348,7 @@ typedef struct {
 
 static int
 ml_rbt_foreach_yielding(ErtsMonLnkNode *root,
-                        void (*func)(ErtsMonLnkNode *, void *),
+                        ErtsMonLnkNodeFunc func,
                         void *arg,
                         void **vyspp,
                         Sint limit)
@@ -362,7 +362,7 @@ ml_rbt_foreach_yielding(ErtsMonLnkNode *root,
 	ysp = &ys;
     res = mon_lnk_rbt_foreach_yielding(ysp->root, func, arg,
                                        &ysp->rbt_ystate, limit);
-    if (res == 0) {
+    if (res > 0) {
 	if (ysp != &ys)
 	    erts_free(ERTS_ALC_T_ML_YIELD_STATE, ysp);
 	*vyspp = NULL;
@@ -383,22 +383,22 @@ ml_rbt_foreach_yielding(ErtsMonLnkNode *root,
 }
 
 typedef struct {
-    void (*func)(ErtsMonLnkNode *, void *);
+    ErtsMonLnkNodeFunc func;
     void *arg;
 } ErtsMonLnkForeachDeleteContext;
 
-static void
-rbt_wrap_foreach_delete(ErtsMonLnkNode *ml, void *vctxt)
+static int
+rbt_wrap_foreach_delete(ErtsMonLnkNode *ml, void *vctxt, Sint reds)
 {
     ErtsMonLnkForeachDeleteContext *ctxt = vctxt;
     ERTS_ML_ASSERT(ml->flags & ERTS_ML_FLG_IN_TABLE);
     ml->flags &= ~ERTS_ML_FLG_IN_TABLE;
-    ctxt->func(ml, ctxt->arg);
+    return ctxt->func(ml, ctxt->arg, reds);
 }
 
 static void
 ml_rbt_foreach_delete(ErtsMonLnkNode **root,
-                      void (*func)(ErtsMonLnkNode *, void *),
+                      ErtsMonLnkNodeFunc func,
                       void *arg)
 {
     ErtsMonLnkForeachDeleteContext ctxt;
@@ -411,7 +411,7 @@ ml_rbt_foreach_delete(ErtsMonLnkNode **root,
 
 static int
 ml_rbt_foreach_delete_yielding(ErtsMonLnkNode **root,
-                               void (*func)(ErtsMonLnkNode *, void *),
+                               ErtsMonLnkNodeFunc func,
                                void *arg,
                                void **vyspp,
                                Sint limit)
@@ -433,7 +433,7 @@ ml_rbt_foreach_delete_yielding(ErtsMonLnkNode **root,
                                                (void *) &ctxt,
                                                &ysp->rbt_ystate,
                                                limit);
-    if (res == 0) {
+    if (res > 0) {
 	if (ysp != &ys)
 	    erts_free(ERTS_ALC_T_ML_YIELD_STATE, ysp);
 	*vyspp = NULL;
@@ -459,12 +459,11 @@ ml_rbt_foreach_delete_yielding(ErtsMonLnkNode **root,
 
 static int
 ml_dl_list_foreach_yielding(ErtsMonLnkNode *list,
-                            void (*func)(ErtsMonLnkNode *, void *),
+                            ErtsMonLnkNodeFunc func,
                             void *arg,
                             void **vyspp,
-                            Sint limit)
+                            Sint reds)
 {
-    Sint cnt = 0;
     ErtsMonLnkNode *ml = (ErtsMonLnkNode *) *vyspp;
 
     ERTS_ML_ASSERT(!ml || list);
@@ -475,28 +474,26 @@ ml_dl_list_foreach_yielding(ErtsMonLnkNode *list,
     if (ml) {
         do {
             ERTS_ML_ASSERT(ml->flags & ERTS_ML_FLG_IN_TABLE);
-            func(ml, arg);
+            reds -= func(ml, arg, reds);
             ml = ml->node.list.next;
-            cnt++;
-        } while (ml != list && cnt < limit);
+        } while (ml != list && reds > 0);
         if (ml != list) {
             *vyspp = (void *) ml;
-            return 1; /* yield */
+            return 0; /* yield */
         }
     }
 
     *vyspp = NULL;
-    return 0; /* done */
+    return reds <= 0 ? 1 : reds; /* done */
 }
 
 static int
 ml_dl_list_foreach_delete_yielding(ErtsMonLnkNode **list,
-                                   void (*func)(ErtsMonLnkNode *, void *),
+                                   ErtsMonLnkNodeFunc func,
                                    void *arg,
                                    void **vyspp,
-                                   Sint limit)
+                                   Sint reds)
 {
-    Sint cnt = 0;
     ErtsMonLnkNode *first = *list;
     ErtsMonLnkNode *ml = (ErtsMonLnkNode *) *vyspp;
 
@@ -510,19 +507,18 @@ ml_dl_list_foreach_delete_yielding(ErtsMonLnkNode **list,
             ErtsMonLnkNode *next = ml->node.list.next;
             ERTS_ML_ASSERT(ml->flags & ERTS_ML_FLG_IN_TABLE);
             ml->flags &= ~ERTS_ML_FLG_IN_TABLE;
-            func(ml, arg);
+            reds -= func(ml, arg, reds);
             ml = next;
-            cnt++;
-        } while (ml != first && cnt < limit);
+        } while (ml != first && reds > 0);
         if (ml != first) {
             *vyspp = (void *) ml;
-            return 1; /* yield */
+            return 0; /* yield */
         }
     }
 
     *vyspp = NULL;
     *list = NULL;
-    return 0; /* done */
+    return reds <= 0 ? 1 : reds; /* done */
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\
@@ -666,91 +662,91 @@ erts_monitor_tree_delete(ErtsMonitor **root, ErtsMonitor *mon)
 
 void
 erts_monitor_tree_foreach(ErtsMonitor *root,
-                          void (*func)(ErtsMonitor *, void *),
+                          ErtsMonitorFunc func,
                           void *arg)
 {
     ml_rbt_foreach((ErtsMonLnkNode *) root,
-                   (void (*)(ErtsMonLnkNode*, void*)) func,
+                   (ErtsMonLnkNodeFunc) func,
                    arg);
 }
 
 int
 erts_monitor_tree_foreach_yielding(ErtsMonitor *root,
-                                   void (*func)(ErtsMonitor *, void *),
+                                   ErtsMonitorFunc func,
                                    void *arg,
                                    void **vyspp,
                                    Sint limit)
 {
     return ml_rbt_foreach_yielding((ErtsMonLnkNode *) root,
-                                   (void (*)(ErtsMonLnkNode*, void*)) func,
+                                   (int (*)(ErtsMonLnkNode*, void*, Sint)) func,
                                    arg, vyspp, limit);
 }
 
 void
 erts_monitor_tree_foreach_delete(ErtsMonitor **root,
-                                 void (*func)(ErtsMonitor *, void *),
+                                 ErtsMonitorFunc func,
                                  void *arg)
 {
     ml_rbt_foreach_delete((ErtsMonLnkNode **) root,
-                          (void (*)(ErtsMonLnkNode*, void*)) func,
+                          (int (*)(ErtsMonLnkNode*, void*, Sint)) func,
                           arg);
 }
 
 int
 erts_monitor_tree_foreach_delete_yielding(ErtsMonitor **root,
-                                          void (*func)(ErtsMonitor *, void *),
+                                          ErtsMonitorFunc func,
                                           void *arg,
                                           void **vyspp,
                                           Sint limit)
 {
     return ml_rbt_foreach_delete_yielding((ErtsMonLnkNode **) root,
-                                          (void (*)(ErtsMonLnkNode*, void*)) func,
+                                          (int (*)(ErtsMonLnkNode*, void*, Sint)) func,
                                           arg, vyspp, limit);
 }
 
 void
 erts_monitor_list_foreach(ErtsMonitor *list,
-                          void (*func)(ErtsMonitor *, void *),
+                          ErtsMonitorFunc func,
                           void *arg)
 {
     void *ystate = NULL;
-    while (ml_dl_list_foreach_yielding((ErtsMonLnkNode *) list,
-                                       (void (*)(ErtsMonLnkNode *, void *)) func,
-                                       arg, &ystate, (Sint) INT_MAX));
+    while (!ml_dl_list_foreach_yielding((ErtsMonLnkNode *) list,
+                                        (int (*)(ErtsMonLnkNode *, void *, Sint)) func,
+                                        arg, &ystate, (Sint) INT_MAX));
 }
 
 int
 erts_monitor_list_foreach_yielding(ErtsMonitor *list,
-                                   void (*func)(ErtsMonitor *, void *),
+                                   ErtsMonitorFunc func,
                                    void *arg,
                                    void **vyspp,
                                    Sint limit)
 {
     return ml_dl_list_foreach_yielding((ErtsMonLnkNode *) list,
-                                       (void (*)(ErtsMonLnkNode *, void *)) func,
+                                       (int (*)(ErtsMonLnkNode *, void *, Sint)) func,
                                        arg, vyspp, limit);
 }
 
 void
 erts_monitor_list_foreach_delete(ErtsMonitor **list,
-                                 void (*func)(ErtsMonitor *, void *),
+                                 ErtsMonitorFunc func,
                                  void *arg)
 {
     void *ystate = NULL;
-    while (ml_dl_list_foreach_delete_yielding((ErtsMonLnkNode **) list,
-                                              (void (*)(ErtsMonLnkNode*, void*)) func,
-                                              arg, &ystate, (Sint) INT_MAX));
+    while (!ml_dl_list_foreach_delete_yielding((ErtsMonLnkNode **) list,
+                                               (int (*)(ErtsMonLnkNode*, void*, Sint)) func,
+                                               arg, &ystate, (Sint) INT_MAX));
 }
 
 int
 erts_monitor_list_foreach_delete_yielding(ErtsMonitor **list,
-                                          void (*func)(ErtsMonitor *, void *),
+                                          ErtsMonitorFunc func,
                                           void *arg,
                                           void **vyspp,
                                           Sint limit)
 {
     return ml_dl_list_foreach_delete_yielding((ErtsMonLnkNode **) list,
-                                              (void (*)(ErtsMonLnkNode*, void*)) func,
+                                              (int (*)(ErtsMonLnkNode*, void*, Sint)) func,
                                               arg, vyspp, limit);
 }
 
@@ -1074,92 +1070,92 @@ erts_link_tree_delete(ErtsLink **root, ErtsLink *lnk)
 
 void
 erts_link_tree_foreach(ErtsLink *root,
-                       void (*func)(ErtsLink *, void *),
+                       ErtsLinkFunc func,
                        void *arg)
 {
     ml_rbt_foreach((ErtsMonLnkNode *) root,
-                   (void (*)(ErtsMonLnkNode*, void*)) func,
+                   (ErtsMonLnkNodeFunc) func,
                    arg);
 
 }
 
 int
 erts_link_tree_foreach_yielding(ErtsLink *root,
-                                void (*func)(ErtsLink *, void *),
+                                ErtsLinkFunc func,
                                 void *arg,
                                 void **vyspp,
                                 Sint limit)
 {
     return ml_rbt_foreach_yielding((ErtsMonLnkNode *) root,
-                                   (void (*)(ErtsMonLnkNode*, void*)) func,
+                                   (ErtsMonLnkNodeFunc) func,
                                    arg, vyspp, limit);
 }
 
 void
 erts_link_tree_foreach_delete(ErtsLink **root,
-                              void (*func)(ErtsLink *, void *),
+                              ErtsLinkFunc func,
                               void *arg)
 {
     ml_rbt_foreach_delete((ErtsMonLnkNode **) root,
-                          (void (*)(ErtsMonLnkNode*, void*)) func,
+                          (ErtsMonLnkNodeFunc) func,
                           arg);
 }
 
 int
 erts_link_tree_foreach_delete_yielding(ErtsLink **root,
-                                       void (*func)(ErtsLink *, void *),
+                                       ErtsLinkFunc func,
                                        void *arg,
                                        void **vyspp,
                                        Sint limit)
 {
     return ml_rbt_foreach_delete_yielding((ErtsMonLnkNode **) root,
-                                          (void (*)(ErtsMonLnkNode*, void*)) func,
+                                          (ErtsMonLnkNodeFunc) func,
                                           arg, vyspp, limit);
 }
 
 void
 erts_link_list_foreach(ErtsLink *list,
-                       void (*func)(ErtsLink *, void *),
+                       ErtsLinkFunc func,
                        void *arg)
 {
     void *ystate = NULL;
-    while (ml_dl_list_foreach_yielding((ErtsMonLnkNode *) list,
-                                       (void (*)(ErtsMonLnkNode *, void *)) func,
-                                       arg, &ystate, (Sint) INT_MAX));
+    while (!ml_dl_list_foreach_yielding((ErtsMonLnkNode *) list,
+                                        (ErtsMonLnkNodeFunc) func,
+                                        arg, &ystate, (Sint) INT_MAX));
 }
 
 int
 erts_link_list_foreach_yielding(ErtsLink *list,
-                                void (*func)(ErtsLink *, void *),
+                                ErtsLinkFunc func,
                                 void *arg,
                                 void **vyspp,
                                 Sint limit)
 {
     return ml_dl_list_foreach_yielding((ErtsMonLnkNode *) list,
-                                       (void (*)(ErtsMonLnkNode *, void *)) func,
+                                       (ErtsMonLnkNodeFunc) func,
                                        arg, vyspp, limit);
 }
 
 void
 erts_link_list_foreach_delete(ErtsLink **list,
-                               void (*func)(ErtsLink *, void *),
+                               ErtsLinkFunc func,
                                void *arg)
 {
     void *ystate = NULL;
-    while (ml_dl_list_foreach_delete_yielding((ErtsMonLnkNode **) list,
-                                              (void (*)(ErtsMonLnkNode*, void*)) func,
-                                              arg, &ystate, (Sint) INT_MAX));
+    while (!ml_dl_list_foreach_delete_yielding((ErtsMonLnkNode **) list,
+                                               (ErtsMonLnkNodeFunc) func,
+                                               arg, &ystate, (Sint) INT_MAX));
 }
 
 int
 erts_link_list_foreach_delete_yielding(ErtsLink **list,
-                                       void (*func)(ErtsLink *, void *),
+                                       int (*func)(ErtsLink *, void *, Sint),
                                        void *arg,
                                        void **vyspp,
                                        Sint limit)
 {
     return ml_dl_list_foreach_delete_yielding((ErtsMonLnkNode **) list,
-                                              (void (*)(ErtsMonLnkNode*, void*)) func,
+                                              (ErtsMonLnkNodeFunc) func,
                                               arg, vyspp, limit);
 }
 

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -2357,12 +2357,13 @@ rmon_refc_read(ErtsResourceMonitors *rms)
     return rms->refc & ERTS_RESOURCE_REFC_MASK;
 }
 
-static void dtor_demonitor(ErtsMonitor* mon, void* context)
+static int dtor_demonitor(ErtsMonitor* mon, void* context, Sint reds)
 {
     ASSERT(erts_monitor_is_origin(mon));
     ASSERT(is_internal_pid(mon->other.item));
 
     erts_proc_sig_send_demonitor(mon);
+    return 1;
 }
 
 #  define NIF_RESOURCE_DTOR &nif_resource_dtor

--- a/erts/emulator/beam/erl_node_tables.c
+++ b/erts/emulator/beam/erl_node_tables.c
@@ -1544,16 +1544,18 @@ static void insert_monitor_data(ErtsMonitor *mon, int type, Eterm id)
     mdp->origin.flags |= ERTS_ML_FLG_DBG_VISITED;
 }
 
-static void insert_monitor(ErtsMonitor *mon, void *idp)
+static int insert_monitor(ErtsMonitor *mon, void *idp, Sint reds)
 {
     Eterm id = *((Eterm *) idp);
     insert_monitor_data(mon, MONITOR_REF, id);
+    return 1;
 }
 
-static void clear_visited_monitor(ErtsMonitor *mon, void *p)
+static int clear_visited_monitor(ErtsMonitor *mon, void *p, Sint reds)
 {
     ErtsMonitorData *mdp = erts_monitor_to_data(mon);
     mdp->origin.flags &= ~ERTS_ML_FLG_DBG_VISITED;
+    return 1;
 }
 
 static void
@@ -1621,16 +1623,18 @@ static void insert_link_data(ErtsLink *lnk, int type, Eterm id)
     ldp->a.flags |= ERTS_ML_FLG_DBG_VISITED;
 }
 
-static void insert_link(ErtsLink *lnk, void *idp)
+static int insert_link(ErtsLink *lnk, void *idp, Sint reds)
 {
     Eterm id = *((Eterm *) idp);
     insert_link_data(lnk, LINK_REF, id);
+    return 1;
 }
 
-static void clear_visited_link(ErtsLink *lnk, void *p)
+static int clear_visited_link(ErtsLink *lnk, void *p, Sint reds)
 {
     ErtsLinkData *ldp = erts_link_to_data(lnk);
     ldp->a.flags &= ~ERTS_ML_FLG_DBG_VISITED;
+    return 1;
 }
 
 static void
@@ -1798,18 +1802,20 @@ insert_sig_offheap(ErlOffHeap *ohp, void *arg)
     insert_offheap(ohp, SIGNAL_REF, proc->common.id);
 }
 
-static void
-insert_sig_monitor(ErtsMonitor *mon, void *arg)
+static int
+insert_sig_monitor(ErtsMonitor *mon, void *arg, Sint reds)
 {
     Process *proc = arg;
     insert_monitor_data(mon, SIGNAL_REF, proc->common.id);
+    return 1;
 }
 
-static void
-insert_sig_link(ErtsLink *lnk, void *arg)
+static int
+insert_sig_link(ErtsLink *lnk, void *arg, Sint reds)
 {
     Process *proc = arg;
     insert_link_data(lnk, SIGNAL_REF, proc->common.id);
+    return 1;
 }
 
 static void

--- a/erts/emulator/beam/erl_node_tables.c
+++ b/erts/emulator/beam/erl_node_tables.c
@@ -1516,7 +1516,7 @@ insert_offheap(ErlOffHeap *oh, int type, Eterm id)
 		}
 	    }
             else if (IsSendCtxBinary(u.mref->mb)) {
-                ErtsSendContext* ctx = ERTS_MAGIC_BIN_DATA(u.mref->mb);
+                ErtsDSigSendContext* ctx = ERTS_MAGIC_BIN_DATA(u.mref->mb);
                 if (ctx->deref_dep)
                     insert_dist_entry(ctx->dep, type, id, 0);
             }

--- a/erts/emulator/beam/erl_node_tables.h
+++ b/erts/emulator/beam/erl_node_tables.h
@@ -176,12 +176,53 @@ struct dist_entry_ {
     struct dist_sequences *sequences; /* Ongoing distribution sequences */
 };
 
+/*
+#define ERL_NODE_BOOKKEEP
+ * Bookkeeping of ErlNode inc and dec operations to help debug refc problems.
+ * This is best used together with cerl -rr. Type the below into gdb:
+ * gdb:
+set pagination off
+set $i = 0
+set $node = referred_nodes[$node_ix].node
+while $i < $node->slot.counter
+ printf "%p: ", $node->books[$i].term
+ etp-1 $node->books[$i].who
+ printf " "
+ p $node->books[$i].what
+ set $i++
+end
+
+  * Then save that into a file called test.txt and run the below in
+  * an erlang shell in order to get all inc/dec that do not have a
+  * match.
+
+f(), {ok, B} = file:read_file("test.txt").
+Vs = [begin [Val, _, _, _, What] = All = string:lexemes(Ln, " "),{Val,What,All} end || Ln <- string:lexemes(B,"\n")].
+Accs = lists:foldl(fun({V,<<"ERL_NODE_INC">>,_},M) -> Val = maps:get(V,M,0), M#{ V => Val + 1 }; ({V,<<"ERL_NODE_DEC">>,_},M) -> Val = maps:get(V,M,0), M#{ V => Val - 1 } end, #{}, Vs).
+lists:usort(lists:filter(fun({V,N}) -> N /= 0 end, maps:to_list(Accs))).
+
+ * There are bound to be bugs in the the instrumentation code, but
+ * atleast this is a place to start when hunting refc bugs.
+ *
+ */
+#ifdef ERL_NODE_BOOKKEEP
+struct erl_node_bookkeeping {
+    Eterm who;
+    Eterm term;
+    enum { ERL_NODE_INC, ERL_NODE_DEC } what;
+};
+#endif
+
 typedef struct erl_node_ {
   HashBucket hash_bucket;	/* Hash bucket */
   erts_refc_t refc;		/* Reference count */
   Eterm	sysname;		/* name@host atom for efficiency */
   Uint32 creation;		/* Creation */
   DistEntry *dist_entry;	/* Corresponding dist entry */
+#ifdef ERL_NODE_BOOKKEEP
+  struct erl_node_bookkeeping books[1024];
+  erts_atomic_t slot;
+#endif
 } ErlNode;
 
 
@@ -214,7 +255,7 @@ void erts_dist_table_info(fmtfn_t, void *);
 void erts_set_dist_entry_not_connected(DistEntry *);
 void erts_set_dist_entry_pending(DistEntry *);
 void erts_set_dist_entry_connected(DistEntry *, Eterm, Uint);
-ErlNode *erts_find_or_insert_node(Eterm, Uint32);
+ErlNode *erts_find_or_insert_node(Eterm, Uint32, Eterm);
 void erts_schedule_delete_node(ErlNode *);
 void erts_set_this_node(Eterm, Uint);
 Uint erts_node_table_size(void);
@@ -232,18 +273,38 @@ DistEntry *erts_dhandle_to_dist_entry(Eterm dhandle, Uint32* connection_id);
 Eterm erts_build_dhandle(Eterm **hpp, ErlOffHeap*, DistEntry*, Uint32 conn_id);
 Eterm erts_make_dhandle(Process *c_p, DistEntry*, Uint32 conn_id);
 
-ERTS_GLB_INLINE void erts_deref_node_entry(ErlNode *np);
+ERTS_GLB_INLINE void erts_init_node_entry(ErlNode *np, erts_aint_t val);
+ERTS_GLB_INLINE erts_aint_t erts_ref_node_entry(ErlNode *np, int min_val, Eterm term);
+ERTS_GLB_INLINE void erts_deref_node_entry(ErlNode *np, Eterm term);
 ERTS_GLB_INLINE void erts_de_rlock(DistEntry *dep);
 ERTS_GLB_INLINE void erts_de_runlock(DistEntry *dep);
 ERTS_GLB_INLINE void erts_de_rwlock(DistEntry *dep);
 ERTS_GLB_INLINE void erts_de_rwunlock(DistEntry *dep);
+#ifdef ERL_NODE_BOOKKEEP
+void erts_node_bookkeep(ErlNode *, Eterm , int);
+#else
+#define erts_node_bookkeep(...)
+#endif
 
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 
 ERTS_GLB_INLINE void
-erts_deref_node_entry(ErlNode *np)
+erts_init_node_entry(ErlNode *np, erts_aint_t val)
 {
-    ASSERT(np);
+    erts_refc_init(&np->refc, val);
+}
+
+ERTS_GLB_INLINE erts_aint_t
+erts_ref_node_entry(ErlNode *np, int min_val, Eterm term)
+{
+    erts_node_bookkeep(np, term, ERL_NODE_INC);
+    return erts_refc_inctest(&np->refc, min_val);
+}
+
+ERTS_GLB_INLINE void
+erts_deref_node_entry(ErlNode *np, Eterm term)
+{
+    erts_node_bookkeep(np, term, ERL_NODE_DEC);
     if (erts_refc_dectest(&np->refc, 0) == 0)
 	erts_schedule_delete_node(np);
 }

--- a/erts/emulator/beam/erl_node_tables.h
+++ b/erts/emulator/beam/erl_node_tables.h
@@ -98,11 +98,22 @@ struct ErtsDistOutputBuf_ {
     byte *alloc_endp;
 #endif
     ErtsDistOutputBuf *next;
-    Uint hopefull_flags;
+    Binary *bin;
+    /* Pointers to the distribution header,
+       if NULL the distr header is in the extp */
+    byte *hdrp;
+    byte *hdr_endp;
+    /* Pointers to the ctl + payload */
     byte *extp;
     byte *ext_endp;
+    /* Start of payload and hopefull_flags, used by transcode */
+    Uint hopefull_flags;
     byte *msg_start;
-    byte data[1];
+    /* start of the ext buffer, this is not always the same as extp
+       as the atom cache handling can use less then the allotted buffer.
+       This value is needed to calculate the size of this output buffer.*/
+    byte *ext_start;
+
 };
 
 typedef struct {
@@ -161,6 +172,8 @@ struct dist_entry_ {
     ErtsThrPrgrLaterOp later_op;
 
     struct transcode_context* transcode_ctx;
+
+    struct dist_sequences *sequences; /* Ongoing distribution sequences */
 };
 
 typedef struct erl_node_ {

--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -2094,7 +2094,7 @@ begin_port_cleanup(Port *pp, ErtsPortTask **execqp, int *processing_busy_q_p)
 
 	    erts_snprintf(port_str, sizeof(DTRACE_CHARBUF_NAME(port_str)), "%T", pp->common.id);
 	    while (plp2 != NULL) {
-		erts_snprintf(pid_str, sizeof(DTRACE_CHARBUF_NAME(pid_str)), "%T", plp2->pid);
+		erts_snprintf(pid_str, sizeof(DTRACE_CHARBUF_NAME(pid_str)), "%T", plp2->u.pid);
 		DTRACE2(process_port_unblocked, pid_str, port_str);
 	    }
 	}

--- a/erts/emulator/beam/erl_printf_term.c
+++ b/erts/emulator/beam/erl_printf_term.c
@@ -487,6 +487,8 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
 			PRINT_UWORD(res, fn, arg, 'u', 0, 1, octet);
 			++bytep;
 			--bytesize;
+                        if ((*dcount)-- <= 0)
+                            goto L_done;
 		    }
 		    if (bitsize) {
 			Uint bits = bitoffs + bitsize;
@@ -521,6 +523,8 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
 			PRINT_CHAR(res, fn, arg, octet);
 			++bytep;
 			--bytesize;
+                        if ((*dcount)-- <= 0)
+                            goto L_done;
 		    }
 		    PRINT_STRING(res, fn, arg, "\">>");
 		}

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -265,7 +265,7 @@ destroy_dist_proc_demonitor(ErtsSigDistProcDemonitor *dmon)
     Eterm ref = dmon->ref;
     if (is_external(ref)) {
         ExternalThing *etp = external_thing_ptr(ref);
-        erts_deref_node_entry(etp->node);
+        erts_deref_node_entry(etp->node, ref);
     }
     erts_free(ERTS_ALC_T_DIST_DEMONITOR, dmon);
 }
@@ -300,7 +300,8 @@ destroy_sig_dist_link_op(ErtsSigDistLinkOp *sdlnk)
 {
     ASSERT(is_external_pid(sdlnk->remote));
     ASSERT(boxed_val(sdlnk->remote) == &sdlnk->heap[0]);
-    erts_deref_node_entry(((ExternalThing *) &sdlnk->heap[0])->node);
+    erts_deref_node_entry(((ExternalThing *) &sdlnk->heap[0])->node,
+                          make_boxed(&sdlnk->heap[0]));
     erts_free(ERTS_ALC_T_SIG_DATA, sdlnk);
 }
 

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -36,6 +36,7 @@
 #include "erl_port_task.h"
 #include "erl_trace.h"
 #include "beam_bp.h"
+#include "erl_binary.h"
 #include "big.h"
 #include "erl_gc.h"
 #include "bif.h"
@@ -80,7 +81,10 @@
 #define ERTS_SIG_Q_TYPE_ADJUST_TRACE_INFO \
     ERTS_SIG_Q_TYPE_MAX
 
-#define ERTS_SIG_IS_EXTERNAL(sig) is_non_value(get_exit_signal_data(sig)->reason)
+#define ERTS_SIG_IS_GEN_EXIT(sig)                                       \
+    (ERTS_PROC_SIG_TYPE(((ErtsSignal *) sig)->common.tag) == ERTS_SIG_Q_TYPE_GEN_EXIT)
+#define ERTS_SIG_IS_GEN_EXIT_EXTERNAL(sig)                              \
+    (ASSERT(ERTS_SIG_IS_GEN_EXIT(sig)),is_non_value(get_exit_signal_data(sig)->reason))
 
 Process *ERTS_WRITE_UNLIKELY(erts_dirty_process_signal_handler);
 Process *ERTS_WRITE_UNLIKELY(erts_dirty_process_signal_handler_high);
@@ -114,8 +118,6 @@ typedef struct {
     Eterm message;
     Eterm from;
     Eterm reason;
-    struct erl_dist_external *dist_ext;
-    ErlHeapFragment *heap_frag;
     union {
         Eterm ref;
         int normal_kills;
@@ -945,13 +947,15 @@ erts_proc_sig_get_external(ErtsMessage *msgp)
 {
     if (ERTS_SIG_IS_EXTERNAL_MSG(msgp)) {
         return erts_get_dist_ext(msgp->data.heap_frag);
-    } else if (ERTS_SIG_IS_NON_MSG(msgp) && ERTS_SIG_IS_EXTERNAL(msgp)) {
+    } else if (ERTS_SIG_IS_NON_MSG(msgp) &&
+               ERTS_SIG_IS_GEN_EXIT(msgp) &&
+               ERTS_SIG_IS_GEN_EXIT_EXTERNAL(msgp)) {
         ErtsDistExternal *edep;
         ErtsExitSignalData *xsigd = get_exit_signal_data(msgp);
         ASSERT(ERTS_PROC_SIG_TYPE(((ErtsSignal *) msgp)->common.tag) == ERTS_SIG_Q_TYPE_GEN_EXIT);
         ASSERT(is_non_value(xsigd->reason));
         if (msgp->hfrag.next == NULL)
-            edep = (ErtsDistExternal*)((void*)xsigd) + sizeof(ErtsExitSignalData);
+            edep = (ErtsDistExternal*)(xsigd + 1);
         else
             edep = erts_get_dist_ext(msgp->hfrag.next);
         return edep;
@@ -965,6 +969,7 @@ static void
 send_gen_exit_signal(Process *c_p, Eterm from_tag,
                      Eterm from, Eterm to,
                      Sint16 op, Eterm reason, ErtsDistExternal *dist_ext,
+                     ErlHeapFragment *dist_ext_hfrag,
                      Eterm ref, Eterm token, int normal_kills)
 {
     ErtsExitSignalData *xsigd;
@@ -972,7 +977,7 @@ send_gen_exit_signal(Process *c_p, Eterm from_tag,
     ErtsMessage *mp;
     ErlHeapFragment *hfrag;
     ErlOffHeap *ohp;
-    Uint hsz, from_sz, reason_sz, ref_sz, token_sz;
+    Uint hsz, from_sz, reason_sz, ref_sz, token_sz, dist_ext_sz;
     int seq_trace;
 #ifdef USE_VM_PROBES
     Eterm s_utag, utag;
@@ -984,7 +989,7 @@ send_gen_exit_signal(Process *c_p, Eterm from_tag,
 
     ASSERT(is_immed(from_tag));
 
-    hsz = sizeof(ErtsExitSignalData)/sizeof(Uint);
+    hsz = sizeof(ErtsExitSignalData)/sizeof(Eterm);
 
     seq_trace = c_p && have_seqtrace(token);
     if (seq_trace)
@@ -1012,6 +1017,8 @@ send_gen_exit_signal(Process *c_p, Eterm from_tag,
     ref_sz = size_object(ref);
     hsz += ref_sz;
 
+    /* The reason was part of the control message,
+       just use copy it into the xsigd */
     if (is_value(reason)) {
         reason_sz = size_object(reason);
         hsz += reason_sz;
@@ -1032,6 +1039,11 @@ send_gen_exit_signal(Process *c_p, Eterm from_tag,
             ERTS_INTERNAL_ERROR("Invalid exit signal op");
             break;
         }
+    } else if (dist_ext != NULL && dist_ext_hfrag == NULL) {
+        /* The message was not fragmented so we need to create space
+           for a single dist_ext element */
+        dist_ext_sz = erts_dist_ext_size(dist_ext) / sizeof(Eterm);
+        hsz += dist_ext_sz;
     }
 
     /*
@@ -1087,13 +1099,12 @@ send_gen_exit_signal(Process *c_p, Eterm from_tag,
 
     hfrag->used_size = hp - start_hp;
 
-    xsigd = (ErtsExitSignalData *) (char *) hp;
+    xsigd = (ErtsExitSignalData *) hp;
 
     xsigd->message = s_message;
     xsigd->from = s_from;
     xsigd->reason = s_reason;
-    xsigd->dist_ext = dist_ext;
-    xsigd->heap_frag = NULL;
+    hfrag->next = dist_ext_hfrag;
 
     if (is_nil(s_ref))
         xsigd->u.normal_kills = normal_kills;
@@ -1101,6 +1112,15 @@ send_gen_exit_signal(Process *c_p, Eterm from_tag,
         ASSERT(is_ref(s_ref));
         xsigd->u.ref = s_ref;
     }
+
+    hp += sizeof(ErtsExitSignalData)/sizeof(Eterm);
+
+    if (dist_ext != NULL && dist_ext_hfrag == NULL && is_non_value(reason)) {
+        erts_make_dist_ext_copy(dist_ext, (ErtsDistExternal *) hp);
+        hp += dist_ext_sz;
+    }
+
+    ASSERT(hp == mp->hfrag.mem + mp->hfrag.alloc_size);
 
     if (seq_trace)
         do_seq_trace_output(to, s_token, s_message);
@@ -1234,17 +1254,18 @@ erts_proc_sig_send_exit(Process *c_p, Eterm from, Eterm to,
         from_tag = dep->sysname;
     }
     send_gen_exit_signal(c_p, from_tag, from, to, ERTS_SIG_Q_OP_EXIT,
-                         reason, NULL, NIL, token, normal_kills);
+                         reason, NULL, NULL, NIL, token, normal_kills);
 }
 
 void
 erts_proc_sig_send_dist_exit(DistEntry *dep,
                              Eterm from, Eterm to,
                              ErtsDistExternal *dist_ext,
+                             ErlHeapFragment *hfrag,
                              Eterm reason, Eterm token)
 {
     send_gen_exit_signal(NULL, dep->sysname, from, to, ERTS_SIG_Q_OP_EXIT,
-                         reason, dist_ext, NIL, token, 0);
+                         reason, dist_ext, hfrag, NIL, token, 0);
 
 }
 
@@ -1259,7 +1280,7 @@ erts_proc_sig_send_link_exit(Process *c_p, Eterm from, ErtsLink *lnk,
     if (is_not_immed(reason) || is_not_nil(token)) {
         ASSERT(is_internal_pid(from) || is_internal_port(from));
         send_gen_exit_signal(c_p, from, from, to, ERTS_SIG_Q_OP_EXIT_LINKED,
-                             reason, NULL, NIL, token, 0);
+                             reason, NULL, NULL, NIL, token, 0);
     }
     else {
         /* Pass signal using old link structure... */
@@ -1315,10 +1336,11 @@ void
 erts_proc_sig_send_dist_link_exit(DistEntry *dep,
                                   Eterm from, Eterm to,
                                   ErtsDistExternal *dist_ext,
+                                  ErlHeapFragment *hfrag,
                                   Eterm reason, Eterm token)
 {
     send_gen_exit_signal(NULL, dep->sysname, from, to, ERTS_SIG_Q_OP_EXIT_LINKED,
-                         reason, dist_ext, NIL, token, 0);
+                         reason, dist_ext, hfrag, NIL, token, 0);
 
 }
 
@@ -1342,6 +1364,7 @@ void
 erts_proc_sig_send_dist_monitor_down(DistEntry *dep, Eterm ref,
                                      Eterm from, Eterm to,
                                      ErtsDistExternal *dist_ext,
+                                     ErlHeapFragment *hfrag,
                                      Eterm reason)
 {
     Eterm monitored, heap[3];
@@ -1351,7 +1374,7 @@ erts_proc_sig_send_dist_monitor_down(DistEntry *dep, Eterm ref,
         monitored = from;
     send_gen_exit_signal(NULL, dep->sysname, monitored,
                          to, ERTS_SIG_Q_OP_MONITOR_DOWN,
-                         reason, dist_ext, ref, NIL, 0);
+                         reason, dist_ext, hfrag, ref, NIL, 0);
 }
 
 void
@@ -1422,7 +1445,7 @@ erts_proc_sig_send_monitor_down(ErtsMonitor *mon, Eterm reason)
         }
         send_gen_exit_signal(NULL, from_tag, monitored,
                              to, ERTS_SIG_Q_OP_MONITOR_DOWN,
-                             reason, NULL, mdp->ref, NIL, 0);
+                             reason, NULL, NULL, mdp->ref, NIL, 0);
     }
     erts_monitor_release(mon);
 }
@@ -2105,9 +2128,9 @@ handle_exit_signal(Process *c_p, ErtsSigRecvTracing *tracing,
         }
 
         /* This GEN_EXIT was received from another node, decode the exit reason */
-        if (ERTS_SIG_IS_EXTERNAL(sig))
+        if (ERTS_SIG_IS_GEN_EXIT_EXTERNAL(sig))
             erts_proc_sig_decode_dist(c_p, ERTS_PROC_LOCK_MAIN, sig, 1);
-        
+
         reason = xsigd->reason;
 
         if (is_non_value(reason)) {
@@ -2115,17 +2138,14 @@ handle_exit_signal(Process *c_p, ErtsSigRecvTracing *tracing,
             ignore = !0;
             destroy = !0;
         }
-        
+
         if (!ignore) {
 
             if ((op != ERTS_SIG_Q_OP_EXIT || reason != am_kill)
                 && (c_p->flags & F_TRAP_EXIT)) {
                 convert_prepared_sig_to_msg(c_p, sig,
                                             xsigd->message, next_nm_sig);
-                ASSERT(sig->hfrag.next == NULL);
-                sig->hfrag.next = xsigd->heap_frag;
                 conv_msg = sig;
-                
             }
             else if (reason == am_normal && !xsigd->u.normal_kills) {
                 /* Ignore it... */
@@ -2991,50 +3011,29 @@ erts_proc_sig_decode_dist(Process *proc, ErtsProcLocks proc_locks,
                           ErtsMessage *msgp, int force_off_heap)
 {
     ErtsHeapFactory factory;
+    ErlHeapFragment *hfrag;
     Eterm msg;
-    ErlHeapFragment *bp;
     Sint need;
-    int decode_in_heap_frag;
-    ErtsDistExternal *dist_ext;
+    ErtsDistExternal *edep;
     ErtsExitSignalData *xsigd = NULL;
 
-    decode_in_heap_frag = (force_off_heap
-			   || !(proc_locks & ERTS_PROC_LOCK_MAIN)
-			   || (proc->flags & F_OFF_HEAP_MSGQ));
-
-    if (ERTS_SIG_IS_EXTERNAL_MSG(msgp))
-        dist_ext = msgp->data.dist_ext;
-    else {
+    edep = erts_proc_sig_get_external(msgp);
+    if (!ERTS_SIG_IS_EXTERNAL_MSG(msgp))
         xsigd = get_exit_signal_data(msgp);
-        ASSERT(ERTS_PROC_SIG_TYPE(((ErtsSignal *) msgp)->common.tag) == ERTS_SIG_Q_TYPE_GEN_EXIT);
-        ASSERT(is_non_value(xsigd->reason));
-        dist_ext = xsigd->dist_ext;
-    }
 
-    if (dist_ext->heap_size >= 0)
-	need = dist_ext->heap_size;
+    if (edep->heap_size >= 0)
+	need = edep->heap_size;
     else {
-	need = erts_decode_dist_ext_size(dist_ext);
+	need = erts_decode_dist_ext_size(edep, 1);
 	if (need < 0) {
-	    /* bad msg; remove it... */
-	    if (is_not_immed(ERL_MESSAGE_TOKEN(msgp))) {
-		bp = erts_dist_ext_trailer(dist_ext);
-		erts_cleanup_offheap(&bp->off_heap);
-	    }
-	    erts_free_dist_ext_copy(dist_ext);
-	    dist_ext = NULL;
+	    /* bad signal; remove it... */
 	    return 0;
 	}
 
-	dist_ext->heap_size = need;
+	edep->heap_size = need;
     }
 
-    if (is_not_immed(ERL_MESSAGE_TOKEN(msgp))) {
-	bp = erts_dist_ext_trailer(dist_ext);
-	need += bp->used_size;
-    }
-
-    if (xsigd) {
+    if (ERTS_SIG_IS_NON_MSG(msgp)) {
         switch (ERTS_PROC_SIG_OP(ERL_MESSAGE_TERM(msgp))) {
         case ERTS_SIG_Q_OP_EXIT:
         case ERTS_SIG_Q_OP_EXIT_LINKED:
@@ -3051,26 +3050,22 @@ erts_proc_sig_decode_dist(Process *proc, ErtsProcLocks proc_locks,
         }
     }
 
-    if (decode_in_heap_frag)
-	erts_factory_heap_frag_init(&factory, new_message_buffer(need));
-    else
-	erts_factory_proc_prealloc_init(&factory, proc, need);
+    hfrag = new_message_buffer(need);
+    erts_factory_heap_frag_init(&factory, hfrag);
 
-    ASSERT(dist_ext->heap_size >= 0);
-    if (is_not_immed(ERL_MESSAGE_TOKEN(msgp))) {
-	ErlHeapFragment *heap_frag;
-	heap_frag = erts_dist_ext_trailer(dist_ext);
-	ERL_MESSAGE_TOKEN(msgp) = copy_struct(ERL_MESSAGE_TOKEN(msgp),
-					      heap_frag->used_size,
-					      &factory.hp,
-					      factory.off_heap);
-	erts_cleanup_offheap(&heap_frag->off_heap);
+    ASSERT(edep->heap_size >= 0);
+
+    msg = erts_decode_dist_ext(&factory, edep, 1);
+
+    if (is_non_value(msg)) {
+        erts_factory_undo(&factory);
+        return 0;
     }
 
-    msg = erts_decode_dist_ext(&factory, dist_ext);
-    if (!xsigd) {
+    if (ERTS_SIG_IS_MSG(msgp)) {
         ERL_MESSAGE_TERM(msgp) = msg;
-        msgp->data.attached = NULL;
+        if (msgp->data.heap_frag == &msgp->hfrag)
+            msgp->data.heap_frag = ERTS_MSG_COMBINED_HFRAG;
     } else {
         switch (ERTS_PROC_SIG_OP(ERL_MESSAGE_TERM(msgp))) {
         case ERTS_SIG_Q_OP_EXIT:
@@ -3089,22 +3084,21 @@ erts_proc_sig_decode_dist(Process *proc, ErtsProcLocks proc_locks,
         }
         xsigd->reason = msg;
     }
-    erts_free_dist_ext_copy(dist_ext);
 
-    if (is_non_value(msg)) {
-	erts_factory_undo(&factory);
-	return 0;
-    }
+    erts_free_dist_ext_copy(edep);
 
     erts_factory_close(&factory);
 
-    ASSERT(!msgp->data.heap_frag || xsigd);
+    hfrag = factory.heap_frags;
+    while (hfrag->next)
+        hfrag = hfrag->next;
 
-    if (decode_in_heap_frag) {
-        if (!xsigd)
-            msgp->data.heap_frag = factory.heap_frags;
-        else
-            xsigd->heap_frag = factory.heap_frags;
+    if (ERTS_SIG_IS_MSG(msgp) && msgp->data.heap_frag != ERTS_MSG_COMBINED_HFRAG) {
+        hfrag->next = msgp->data.heap_frag;
+        msgp->data.heap_frag = factory.heap_frags;
+    } else {
+        hfrag->next = msgp->hfrag.next;
+        msgp->hfrag.next = factory.heap_frags;
     }
 
     return 1;
@@ -3274,8 +3268,9 @@ erts_proc_sig_handle_incoming(Process *c_p, erts_aint32_t *statep,
                 xsigd = get_exit_signal_data(sig);
 
                 /* This GEN_EXIT was received from another node, decode the exit reason */
-                if (ERTS_SIG_IS_EXTERNAL(sig))
-                    erts_proc_sig_decode_dist(c_p, ERTS_PROC_LOCK_MAIN, sig, 1);
+                if (ERTS_SIG_IS_GEN_EXIT_EXTERNAL(sig))
+                    if (!erts_proc_sig_decode_dist(c_p, ERTS_PROC_LOCK_MAIN, sig, 1))
+                        break; /* Decode failed, just remove signal */
 
                 omon = erts_monitor_tree_lookup(ERTS_P_MONITORS(c_p),
                                                 xsigd->u.ref);
@@ -4375,11 +4370,13 @@ handle_msg_tracing(Process *c_p, ErtsSigRecvTracing *tracing,
             return -1; /* Yield... */
         }
         if (ERTS_SIG_IS_EXTERNAL_MSG(sig)) {
-            cnt++;
+            cnt += 50; /* Decode is expensive... */
             if (!erts_proc_sig_decode_dist(c_p, ERTS_PROC_LOCK_MAIN,
                                            sig, 0)) {
                 /* Bad dist message; remove it... */
                 remove_mq_m_sig(c_p, sig, next_sig, next_nm_sig);
+                sig->next = NULL;
+                erts_cleanup_messages(sig);
                 sig = *next_sig;
                 continue;
             }
@@ -4451,18 +4448,12 @@ erts_proc_sig_prep_msgq_for_inspection(Process *c_p,
 
 	if (ERTS_SIG_IS_EXTERNAL_MSG(mp)) {
 	    /* decode it... */
-	    if (mp->data.attached)
-		erts_proc_sig_decode_dist(rp, rp_locks, mp, !0);
-
-	    msg = ERL_MESSAGE_TERM(mp);
-
-	    if (is_non_value(msg)) {
+            if (!erts_proc_sig_decode_dist(rp, rp_locks, mp, !0)) {
 		ErtsMessage *bad_mp = mp;
 		/*
 		 * Bad distribution message; remove
 		 * it from the queue...
 		 */
-		ASSERT(!mp->data.attached);
 
 		ASSERT(*mpp == bad_mp);
 
@@ -4474,6 +4465,8 @@ erts_proc_sig_prep_msgq_for_inspection(Process *c_p,
 		erts_cleanup_messages(bad_mp);
 		continue;
 	    }
+
+	    msg = ERL_MESSAGE_TERM(mp);
 	}
 
 	ASSERT(is_value(msg));
@@ -4632,12 +4625,21 @@ debug_foreach_sig_fake_oh(Eterm term,
 
 }
 
+static void
+debug_foreach_sig_external(ErtsMessage *msgp,
+                           void (*ext_func)(ErtsDistExternal *, void *),
+                           void *arg)
+{
+    ext_func(erts_proc_sig_get_external(msgp), arg);
+}
+
 void
 erts_proc_sig_debug_foreach_sig(Process *c_p,
                                 void (*msg_func)(ErtsMessage *, void *),
                                 void (*oh_func)(ErlOffHeap *, void *),
                                 ErtsMonitorFunc mon_func,
                                 ErtsLinkFunc lnk_func,
+                                void (*ext_func)(ErtsDistExternal *, void *),
                                 void *arg)
 {
     ErtsMessage *queue[] = {c_p->sig_qs.first, c_p->sig_qs.cont, c_p->sig_inq.first};
@@ -4646,10 +4648,10 @@ erts_proc_sig_debug_foreach_sig(Process *c_p,
     for (qix = 0; qix < sizeof(queue)/sizeof(queue[0]); qix++) {
         ErtsMessage *sig;
         for (sig = queue[qix]; sig; sig = sig->next) {
-            
-            if (ERTS_SIG_IS_MSG(sig))
+
+            if (ERTS_SIG_IS_MSG(sig)) {
                 msg_func(sig, arg);
-            else {
+            } else {
                 Eterm tag;
                 Uint16 type;
                 int op;
@@ -4668,7 +4670,10 @@ erts_proc_sig_debug_foreach_sig(Process *c_p,
                 case ERTS_SIG_Q_OP_MONITOR_DOWN:
                     switch (type) {
                     case ERTS_SIG_Q_TYPE_GEN_EXIT:
-                        debug_foreach_sig_heap_frags(&sig->hfrag, oh_func, arg);
+                        if (ERTS_SIG_IS_GEN_EXIT_EXTERNAL(sig))
+                            debug_foreach_sig_external(sig, ext_func, arg);
+                        else
+                            debug_foreach_sig_heap_frags(&sig->hfrag, oh_func, arg);
                         break;
                     case ERTS_LNK_TYPE_PORT:
                     case ERTS_LNK_TYPE_PROC:

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -3854,7 +3854,7 @@ erts_proc_sig_handle_exit(Process *c_p, Sint *redsp)
             break;
 
         case ERTS_SIG_Q_OP_MONITOR: {
-            ErtsProcExitContext pectxt = {c_p, am_noproc};
+            ErtsProcExitContext pectxt = {c_p, am_noproc, NULL, NULL, NIL};
             erts_proc_exit_handle_monitor((ErtsMonitor *) sig,
                                           (void *) &pectxt, -1);
             cnt += 4;

--- a/erts/emulator/beam/erl_proc_sig_queue.h
+++ b/erts/emulator/beam/erl_proc_sig_queue.h
@@ -740,7 +740,7 @@ erts_proc_sig_handle_incoming(Process *c_p, erts_aint32_t *statep,
  *                              queue.
  */
 int
-erts_proc_sig_handle_exit(Process *c_p, int *redsp);
+erts_proc_sig_handle_exit(Process *c_p, Sint *redsp);
 
 /**
  *
@@ -970,8 +970,8 @@ void
 erts_proc_sig_debug_foreach_sig(Process *c_p,
                                 void (*msg_func)(ErtsMessage *, void *),
                                 void (*oh_func)(ErlOffHeap *, void *),
-                                void (*mon_func)(ErtsMonitor *, void *),
-                                void (*lnk_func)(ErtsLink *, void *),
+                                ErtsMonitorFunc mon_func,
+                                ErtsLinkFunc lnk_func,
                                 void *arg);
 
 extern Process *erts_dirty_process_signal_handler;

--- a/erts/emulator/beam/erl_proc_sig_queue.h
+++ b/erts/emulator/beam/erl_proc_sig_queue.h
@@ -228,6 +228,9 @@ erts_proc_sig_send_exit(Process *c_p, Eterm from, Eterm to,
  *
  * @param[in]     dist_ext      The exit reason in external term format
  *
+ * @param[in]     hfrag         Heap frag with trace token and dist_ext
+ *                              iff available, otherwise NULL.
+ *
  * @param[in]     reason        Exit reason.
  *
  * @param[in]     token         Seq trace token.
@@ -237,6 +240,7 @@ void
 erts_proc_sig_send_dist_exit(DistEntry *dep,
                              Eterm from, Eterm to,
                              ErtsDistExternal *dist_ext,
+                             ErlHeapFragment *hfrag,
                              Eterm reason, Eterm token);
 
 /**
@@ -322,6 +326,9 @@ erts_proc_sig_send_unlink(Process *c_p, ErtsLink *lnk);
  *
  * @param[in]     dist_ext      The exit reason in external term format
  *
+ * @param[in]     hfrag         Heap frag with trace token and dist_ext
+ *                              iff available, otherwise NULL.
+ *
  * @param[in]     reason        Exit reason.
  *
  * @param[in]     token         Seq trace token.
@@ -331,6 +338,7 @@ void
 erts_proc_sig_send_dist_link_exit(struct dist_entry_ *dep,
                                   Eterm from, Eterm to,
                                   ErtsDistExternal *dist_ext,
+                                  ErlHeapFragment *hfrag,
                                   Eterm reason, Eterm token);
 
 /**
@@ -426,6 +434,9 @@ erts_proc_sig_send_monitor(ErtsMonitor *mon, Eterm to);
  *
  * @param[in]     dist_ext      The exit reason in external term format
  *
+ * @param[in]     hfrag         Heap frag with trace token and dist_ext
+ *                              iff available, otherwise NULL.
+ *
  * @param[in]     reason        Exit reason.
  *
  */
@@ -433,6 +444,7 @@ void
 erts_proc_sig_send_dist_monitor_down(DistEntry *dep, Eterm ref,
                                      Eterm from, Eterm to,
                                      ErtsDistExternal *dist_ext,
+                                     ErlHeapFragment *hfrag,
                                      Eterm reason);
 
 /**
@@ -1035,6 +1047,7 @@ erts_proc_sig_debug_foreach_sig(Process *c_p,
                                 void (*oh_func)(ErlOffHeap *, void *),
                                 ErtsMonitorFunc mon_func,
                                 ErtsLinkFunc lnk_func,
+                                void (*ext_func)(ErtsDistExternal *, void *),
                                 void *arg);
 
 extern Process *erts_dirty_process_signal_handler;

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -12111,6 +12111,7 @@ erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt, Sint reds)
             case ERTS_DSIG_PREP_PENDING:
                 if (dist->connection_id == dsd.connection_id) {
                     code = erts_dsig_send_m_exit(&dsd,
+                                                 c_p->common.id,
                                                  watcher,
                                                  watched,
                                                  mdp->ref,

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -12085,7 +12085,7 @@ erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt, Sint reds)
         case ERTS_MON_TYPE_DIST_PROC: {
             ErtsMonLnkDist *dist;
             DistEntry *dep;
-            ErtsDSigData dsd;
+            ErtsDSigSendContext ctx;
             int code;
             Eterm watcher;
             Eterm watched;
@@ -12104,14 +12104,13 @@ erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt, Sint reds)
             ASSERT(dep);
             dist = ((ErtsMonitorDataExtended *) mdp)->dist;
             ASSERT(dist);
-            code = erts_dsig_prepare(&dsd, dep, NULL, 0,
-                                     ERTS_DSP_NO_LOCK, 0, 0);
+            code = erts_dsig_prepare(&ctx, dep, NULL, 0,
+                                     ERTS_DSP_NO_LOCK, 1, 1, 0);
             switch (code) {
             case ERTS_DSIG_PREP_CONNECTED:
             case ERTS_DSIG_PREP_PENDING:
-                if (dist->connection_id == dsd.connection_id) {
-                    code = erts_dsig_send_m_exit(&dsd,
-                                                 c_p->common.id,
+                if (dist->connection_id == ctx.connection_id) {
+                    code = erts_dsig_send_m_exit(&ctx,
                                                  watcher,
                                                  watched,
                                                  mdp->ref,
@@ -12164,7 +12163,7 @@ erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt, Sint reds)
         case ERTS_MON_TYPE_DIST_PROC: {
             ErtsMonLnkDist *dist;
             DistEntry *dep;
-            ErtsDSigData dsd;
+            ErtsDSigSendContext ctx;
             int code;
             Eterm watched;
 
@@ -12181,17 +12180,16 @@ erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt, Sint reds)
                 ASSERT(is_external_pid(watched));
 		dep = external_pid_dist_entry(watched);
             }
-            code = erts_dsig_prepare(&dsd, dep, NULL, 0,
-                                     ERTS_DSP_NO_LOCK, 0, 0);
+            code = erts_dsig_prepare(&ctx, dep, NULL, 0,
+                                     ERTS_DSP_NO_LOCK, 1, 1, 0);
             switch (code) {
             case ERTS_DSIG_PREP_CONNECTED:
             case ERTS_DSIG_PREP_PENDING:
-                if (dist->connection_id == dsd.connection_id) {
-                    code = erts_dsig_send_demonitor(&dsd,
+                if (dist->connection_id == ctx.connection_id) {
+                    code = erts_dsig_send_demonitor(&ctx,
                                                     c_p->common.id,
                                                     watched,
-                                                    mdp->ref,
-                                                    1);
+                                                    mdp->ref);
                     ASSERT(code == ERTS_DSIG_SEND_OK);
                 }
             default:
@@ -12247,7 +12245,7 @@ erts_proc_exit_handle_link(ErtsLink *lnk, void *vctxt, Sint reds)
         DistEntry *dep;
         ErtsMonLnkDist *dist;
         ErtsLink *dlnk;
-        ErtsDSigData dsd;
+        ErtsDSigSendContext ctx;
         int code;
 
         dlnk = erts_link_to_other(lnk, &ldp);
@@ -12261,12 +12259,12 @@ erts_proc_exit_handle_link(ErtsLink *lnk, void *vctxt, Sint reds)
         if (!erts_link_dist_delete(dlnk))
             ldp = NULL;
 
-        code = erts_dsig_prepare(&dsd, dep, c_p, 0, ERTS_DSP_NO_LOCK, 0, 0);
+        code = erts_dsig_prepare(&ctx, dep, c_p, 0, ERTS_DSP_NO_LOCK, 1, 1, 0);
         switch (code) {
         case ERTS_DSIG_PREP_CONNECTED:
         case ERTS_DSIG_PREP_PENDING:
-            if (dist->connection_id == dsd.connection_id) {
-                code = erts_dsig_send_exit_tt(&dsd,
+            if (dist->connection_id == ctx.connection_id) {
+                code = erts_dsig_send_exit_tt(&ctx,
                                               c_p->common.id,
                                               lnk->other.item,
                                               reason,

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -735,12 +735,6 @@ erts_pre_init_process(void)
 #endif
 }
 
-static void
-release_process(void *vproc)
-{
-    erts_proc_dec_refc((Process *) vproc);
-}
-
 /* initialize the scheduler */
 void
 erts_init_process(int ncpu, int proc_tab_size, int legacy_proc_tab)
@@ -752,7 +746,7 @@ erts_init_process(int ncpu, int proc_tab_size, int legacy_proc_tab)
 
     erts_ptab_init_table(&erts_proc,
 			 ERTS_ALC_T_PROC_TABLE,
-			 release_process,
+			 NULL,
 			 (ErtsPTabElementCommon *) &erts_invalid_process.common,
 			 proc_tab_size,
 			 sizeof(Process),
@@ -6519,8 +6513,7 @@ schedule_out_process(ErtsRunQueue *c_rq, erts_aint32_t state, Process *p,
 
 	n &= ~running_flgs;
 	if ((!!(a & (ERTS_PSFLG_ACTIVE_SYS|ERTS_PSFLG_DIRTY_ACTIVE_SYS))
-	    | ((a & (ERTS_PSFLG_ACTIVE|ERTS_PSFLG_SUSPENDED)) == ERTS_PSFLG_ACTIVE))
-            & !(a & ERTS_PSFLG_FREE)) {
+	    | ((a & (ERTS_PSFLG_ACTIVE|ERTS_PSFLG_SUSPENDED)) == ERTS_PSFLG_ACTIVE))) {
 	    enqueue = check_enqueue_in_prio_queue(p, &enq_prio, &n, a);
 	}
 	a = erts_atomic32_cmpxchg_mb(&p->state, n, e);
@@ -6555,7 +6548,6 @@ schedule_out_process(ErtsRunQueue *c_rq, erts_aint32_t state, Process *p,
     else {
 	Process* sched_p;
 
-        ASSERT(!(n & ERTS_PSFLG_FREE));
 	ASSERT(!(n & ERTS_PSFLG_SUSPENDED) || (n & (ERTS_PSFLG_ACTIVE_SYS
 						    | ERTS_PSFLG_DIRTY_ACTIVE_SYS)));
 
@@ -6685,8 +6677,8 @@ change_proc_schedule_state(Process *p,
 
 	enqueue = ERTS_ENQUEUE_NOT;
 
-	if (a & ERTS_PSFLG_FREE)
-	    break; /* We don't want to schedule free processes... */
+        if ((a & (ERTS_PSFLG_FREE|ERTS_PSFLG_ACTIVE)) == ERTS_PSFLG_FREE)
+            break; /* If free and not active, do not schedule */
 
 	if (clear_state_flags)
 	    n &= ~clear_state_flags;
@@ -8131,7 +8123,8 @@ done:
 ErtsSchedSuspendResult
 erts_block_multi_scheduling(Process *p, ErtsProcLocks plocks, int on, int normal, int all)
 {
-    int resume_proc, ix, res, have_unlocked_plocks = 0;
+    ErtsSchedSuspendResult res;
+    int resume_proc, ix, have_unlocked_plocks = 0;
     ErtsProcList *plp;
     ErtsMultiSchedulingBlock *msbp;
     erts_aint32_t chng_flg;
@@ -9629,7 +9622,8 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 
 	    while (1) {
 		erts_aint32_t exp, new;
-		int run_process;
+		int run_process, not_running, exiting_on_normal_sched,
+                    not_suspended, not_exiting_on_dirty_sched;
 		new = exp = state;
 		new &= psflg_band_mask;
 		/*
@@ -9638,29 +9632,33 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 		 * scheduler, and not suspended (and not in a
 		 * state where suspend should be ignored).
 		 */
-		run_process = (((!(state & (ERTS_PSFLG_RUNNING
-					    | ERTS_PSFLG_RUNNING_SYS
-					    | ERTS_PSFLG_DIRTY_RUNNING
-					    | ERTS_PSFLG_DIRTY_RUNNING_SYS
-					    | ERTS_PSFLG_FREE)))
-				| (((state & (ERTS_PSFLG_RUNNING
+                not_running = !(state & (ERTS_PSFLG_RUNNING
+                                         | ERTS_PSFLG_RUNNING_SYS
+                                         | ERTS_PSFLG_DIRTY_RUNNING
+                                         | ERTS_PSFLG_DIRTY_RUNNING_SYS
+                                         | ERTS_PSFLG_FREE));
+                exiting_on_normal_sched =
+                    ((state & (ERTS_PSFLG_RUNNING
+                               | ERTS_PSFLG_ACTIVE
+                               | ERTS_PSFLG_RUNNING_SYS
+                               | ERTS_PSFLG_DIRTY_RUNNING_SYS
+                               | ERTS_PSFLG_EXITING))
+                     == (ERTS_PSFLG_EXITING|ERTS_PSFLG_ACTIVE))
+                    & (!!is_normal_sched);
 
-					      | ERTS_PSFLG_FREE
-					      | ERTS_PSFLG_RUNNING_SYS
-					      | ERTS_PSFLG_DIRTY_RUNNING_SYS
-					      | ERTS_PSFLG_EXITING))
-				    == ERTS_PSFLG_EXITING)
-				   & (!!is_normal_sched))
-				   )
-			       & ((state & (ERTS_PSFLG_SUSPENDED
-					    | ERTS_PSFLG_EXITING
-					    | ERTS_PSFLG_FREE
-					    | ERTS_PSFLG_ACTIVE_SYS
-					    | ERTS_PSFLG_DIRTY_ACTIVE_SYS))
-				  != ERTS_PSFLG_SUSPENDED)
-                               & (!(state & ERTS_PSFLG_EXITING)
-                                  | (!!is_normal_sched))
-                    );
+
+                not_suspended = ((state & (ERTS_PSFLG_SUSPENDED
+                                           | ERTS_PSFLG_EXITING
+                                           | ERTS_PSFLG_FREE
+                                           | ERTS_PSFLG_ACTIVE_SYS
+                                           | ERTS_PSFLG_DIRTY_ACTIVE_SYS))
+                                 != ERTS_PSFLG_SUSPENDED);
+
+                not_exiting_on_dirty_sched = !(state & ERTS_PSFLG_EXITING) | (!!is_normal_sched);
+
+		run_process = (not_running | exiting_on_normal_sched)
+                    & not_suspended
+                    & not_exiting_on_dirty_sched;
 
 		if (run_process) {
 		    if (state & (ERTS_PSFLG_ACTIVE_SYS
@@ -9951,7 +9949,7 @@ trace_schedule_in(Process *p, erts_aint32_t state)
     /* Clear tracer if it has been removed */
     if (erts_is_tracer_proc_enabled(p, ERTS_PROC_LOCK_MAIN, &p->common)) {
 
-        if (state & ERTS_PSFLG_EXITING) {
+        if (state & ERTS_PSFLG_EXITING && p->u.terminate) {
             if (ARE_TRACE_FLAGS_ON(p, F_TRACE_SCHED_EXIT))
                 trace_sched(p, ERTS_PROC_LOCK_MAIN, am_in_exiting);
         }
@@ -9975,12 +9973,9 @@ trace_schedule_out(Process *p, erts_aint32_t state)
     if (IS_TRACED_FL(p, F_TRACE_CALLS) && !(state & ERTS_PSFLG_FREE))
         erts_schedule_time_break(p, ERTS_BP_CALL_TIME_SCHEDULE_OUT);
 
-    if ((state & (ERTS_PSFLG_FREE|ERTS_PSFLG_EXITING)) == ERTS_PSFLG_EXITING) {
+    if (state & ERTS_PSFLG_EXITING && p->u.terminate) {
         if (ARE_TRACE_FLAGS_ON(p, F_TRACE_SCHED_EXIT))
-            trace_sched(p, ERTS_PROC_LOCK_MAIN,
-                        ((state & ERTS_PSFLG_FREE)
-                         ? am_out_exited
-                         : am_out_exiting));
+            trace_sched(p, ERTS_PROC_LOCK_MAIN, am_out_exiting);
     }
     else {
         if (ARE_TRACE_FLAGS_ON(p, F_TRACE_SCHED) ||
@@ -12323,11 +12318,8 @@ erts_do_exit_process(Process* p, Eterm reason)
 
     set_self_exiting(p, reason, NULL, NULL, NULL);
 
-    if (IS_TRACED(p)) {
-	if (IS_TRACED_FL(p, F_TRACE_CALLS))
-	    erts_schedule_time_break(p, ERTS_BP_CALL_TIME_SCHEDULE_EXITING);
-
-    }
+    if (IS_TRACED_FL(p, F_TRACE_CALLS))
+        erts_schedule_time_break(p, ERTS_BP_CALL_TIME_SCHEDULE_EXITING);
 
     erts_trace_check_exiting(p->common.id);
 
@@ -12342,9 +12334,8 @@ erts_do_exit_process(Process* p, Eterm reason)
 
     erts_proc_unlock(p, ERTS_PROC_LOCKS_ALL_MINOR);
 
-    if (IS_TRACED_FL(p,F_TRACE_PROCS))
+    if (IS_TRACED_FL(p, F_TRACE_PROCS))
         trace_proc(p, ERTS_PROC_LOCK_MAIN, p, am_exit, reason);
-
 
     /*
      * p->u.initial of this process can *not* be used anymore;
@@ -12352,277 +12343,368 @@ erts_do_exit_process(Process* p, Eterm reason)
      */
     p->u.terminate = NULL;
 
+    BUMP_REDS(p, 100);
+
     erts_continue_exit_process(p);
 }
+
+enum continue_exit_phase {
+    ERTS_CONTINUE_EXIT_TIMERS,
+    ERTS_CONTINUE_EXIT_BLCKD_MSHED,
+    ERTS_CONTINUE_EXIT_BLCKD_NMSHED,
+    ERTS_CONTINUE_EXIT_USING_DB,
+    ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS,
+    ERTS_CONTINUE_EXIT_FREE,
+    ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS_AFTER,
+    ERTS_CONTINUE_EXIT_LINKS,
+    ERTS_CONTINUE_EXIT_MONITORS,
+    ERTS_CONTINUE_EXIT_LT_MONITORS,
+    ERTS_CONTINUE_EXIT_HANDLE_PROC_SIG,
+};
+
+struct continue_exit_state {
+    enum continue_exit_phase phase;
+    ErtsLink *links;
+    ErtsMonitor *monitors;
+    ErtsMonitor *lt_monitors;
+    Eterm reason;
+    ErtsProcExitContext pectxt;
+    DistEntry *dep;
+    void *yield_state;
+};
 
 void
 erts_continue_exit_process(Process *p)
 {
-    ErtsLink *links;
-    ErtsMonitor *monitors;
-    ErtsMonitor *lt_monitors;
+    struct continue_exit_state static_state, *trap_state = &static_state;
     ErtsProcLocks curr_locks = ERTS_PROC_LOCK_MAIN;
-    Eterm reason = p->fvalue;
-    DistEntry *dep = NULL;
     erts_aint32_t state;
     int delay_del_proc = 0;
-    ErtsProcExitContext pectxt;
-
+    Sint reds = ERTS_BIF_REDS_LEFT(p);
 #ifdef DEBUG
     int yield_allowed = 1;
 #endif
+
+    if (p->u.terminate) {
+        trap_state = p->u.terminate;
+    } else {
+        trap_state->phase = ERTS_CONTINUE_EXIT_TIMERS;
+        trap_state->reason = p->fvalue;
+        trap_state->dep = NULL;
+        trap_state->yield_state = NULL;
+    }
 
     ERTS_LC_ASSERT(ERTS_PROC_LOCK_MAIN == erts_proc_lc_my_proc_locks(p));
 
     ASSERT(ERTS_PROC_IS_EXITING(p));
 
     ASSERT(erts_proc_read_refc(p) > 0);
-    if (p->bif_timers) {
-	if (erts_cancel_bif_timers(p, &p->bif_timers, &p->u.terminate)) {
-	    ASSERT(erts_proc_read_refc(p) > 0);
-	    goto yield;
-	}
-	ASSERT(erts_proc_read_refc(p) > 0);
-	p->bif_timers = NULL;
-    }
 
-    if (p->flags & F_SCHDLR_ONLN_WAITQ)
-	abort_sched_onln_chng_waitq(p);
+    switch (trap_state->phase) {
+    case ERTS_CONTINUE_EXIT_TIMERS:
+        if (p->bif_timers) {
+            reds = erts_cancel_bif_timers(p, &p->bif_timers, &trap_state->yield_state, reds);
+            if (reds <= 0) goto yield;
+            p->bif_timers = NULL;
+        }
 
-    if (p->flags & F_HAVE_BLCKD_MSCHED) {
-	ErtsSchedSuspendResult ssr;
-	ssr = erts_block_multi_scheduling(p, ERTS_PROC_LOCK_MAIN, 0, 0, 1);
-	switch (ssr) {
-	case ERTS_SCHDLR_SSPND_YIELD_RESTART:
-	    goto yield;
-	case ERTS_SCHDLR_SSPND_DONE_MSCHED_BLOCKED:
-	case ERTS_SCHDLR_SSPND_DONE_NMSCHED_BLOCKED:
-	case ERTS_SCHDLR_SSPND_YIELD_DONE_MSCHED_BLOCKED:
-	case ERTS_SCHDLR_SSPND_YIELD_DONE_NMSCHED_BLOCKED:
-	case ERTS_SCHDLR_SSPND_DONE:
-	case ERTS_SCHDLR_SSPND_YIELD_DONE:
-	    p->flags &= ~F_HAVE_BLCKD_MSCHED;
-	    break;
-	case ERTS_SCHDLR_SSPND_EINVAL:
-	default:
-	    erts_exit(ERTS_ABORT_EXIT, "%s:%d: Internal error: %d\n",
-		      __FILE__, __LINE__, (int) ssr);
-	}
-    }
-    if (p->flags & F_HAVE_BLCKD_NMSCHED) {
-	ErtsSchedSuspendResult ssr;
-	ssr = erts_block_multi_scheduling(p, ERTS_PROC_LOCK_MAIN, 0, 1, 1);
-	switch (ssr) {
-	case ERTS_SCHDLR_SSPND_YIELD_RESTART:
-	    goto yield;
-	case ERTS_SCHDLR_SSPND_DONE_MSCHED_BLOCKED:
-	case ERTS_SCHDLR_SSPND_DONE_NMSCHED_BLOCKED:
-	case ERTS_SCHDLR_SSPND_YIELD_DONE_MSCHED_BLOCKED:
-	case ERTS_SCHDLR_SSPND_YIELD_DONE_NMSCHED_BLOCKED:
-	case ERTS_SCHDLR_SSPND_DONE:
-	case ERTS_SCHDLR_SSPND_YIELD_DONE:
-	    p->flags &= ~F_HAVE_BLCKD_MSCHED;
-	    break;
-	case ERTS_SCHDLR_SSPND_EINVAL:
-	default:
-	    erts_exit(ERTS_ABORT_EXIT, "%s:%d: Internal error: %d\n",
-		     __FILE__, __LINE__, (int) ssr);
-	}
-    }
+        if (p->flags & F_SCHDLR_ONLN_WAITQ) {
+            abort_sched_onln_chng_waitq(p);
+            reds -= 100;
+        }
 
-    if (p->flags & F_USING_DB) {
-	if (erts_db_process_exiting(p, ERTS_PROC_LOCK_MAIN))
-	    goto yield;
-	p->flags &= ~F_USING_DB;
-    }
+        trap_state->phase = ERTS_CONTINUE_EXIT_BLCKD_MSHED;
+        if (reds <= 0) goto yield;
+    case ERTS_CONTINUE_EXIT_BLCKD_MSHED:
 
-    erts_set_gc_state(p, 1);
-    state = erts_atomic32_read_acqb(&p->state);
-    if ((state & ERTS_PSFLG_SYS_TASKS) || p->dirty_sys_tasks) {
-	if (cleanup_sys_tasks(p, state, CONTEXT_REDS) >= CONTEXT_REDS/2)
-	    goto yield;
-    }
+        if (p->flags & F_HAVE_BLCKD_MSCHED) {
+            ErtsSchedSuspendResult ssr;
+            ssr = erts_block_multi_scheduling(p, ERTS_PROC_LOCK_MAIN, 0, 0, 1);
+            switch (ssr) {
+            case ERTS_SCHDLR_SSPND_DONE:
+            case ERTS_SCHDLR_SSPND_DONE_MSCHED_BLOCKED:
+            case ERTS_SCHDLR_SSPND_DONE_NMSCHED_BLOCKED:
+                p->flags &= ~F_HAVE_BLCKD_MSCHED;
+                break;
+            default:
+                erts_exit(ERTS_ABORT_EXIT, "%s:%d: Internal error: %d\n",
+                          __FILE__, __LINE__, (int) ssr);
+            }
+            reds -= 100;
+        }
+
+        trap_state->phase = ERTS_CONTINUE_EXIT_BLCKD_NMSHED;
+        if (reds <= 0) goto yield;
+    case ERTS_CONTINUE_EXIT_BLCKD_NMSHED:
+
+        if (p->flags & F_HAVE_BLCKD_NMSCHED) {
+            ErtsSchedSuspendResult ssr;
+            ssr = erts_block_multi_scheduling(p, ERTS_PROC_LOCK_MAIN, 0, 1, 1);
+            switch (ssr) {
+            case ERTS_SCHDLR_SSPND_DONE:
+            case ERTS_SCHDLR_SSPND_DONE_MSCHED_BLOCKED:
+            case ERTS_SCHDLR_SSPND_DONE_NMSCHED_BLOCKED:
+                p->flags &= ~F_HAVE_BLCKD_MSCHED;
+                break;
+            default:
+                erts_exit(ERTS_ABORT_EXIT, "%s:%d: Internal error: %d\n",
+                          __FILE__, __LINE__, (int) ssr);
+            }
+            reds -= 100;
+        }
+
+        trap_state->yield_state = NULL;
+        trap_state->phase = ERTS_CONTINUE_EXIT_USING_DB;
+        if (reds <= 0) goto yield;
+    case ERTS_CONTINUE_EXIT_USING_DB:
+
+        if (p->flags & F_USING_DB) {
+            if (erts_db_process_exiting(p, ERTS_PROC_LOCK_MAIN, &trap_state->yield_state))
+                goto yield;
+            p->flags &= ~F_USING_DB;
+        }
+
+        erts_set_gc_state(p, 1);
+
+        trap_state->phase = ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS;
+    case ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS:
+        
+        state = erts_atomic32_read_acqb(&p->state);
+        if ((state & ERTS_PSFLG_SYS_TASKS) || p->dirty_sys_tasks) {
+            reds -= cleanup_sys_tasks(p, state, reds);
+            if (reds <= 0) goto yield;
+        }
+
+        trap_state->phase = ERTS_CONTINUE_EXIT_FREE;
+    case ERTS_CONTINUE_EXIT_FREE:
 
 #ifdef DEBUG
-    erts_proc_lock(p, ERTS_PROC_LOCK_STATUS);
-    ASSERT(ERTS_PROC_GET_DELAYED_GC_TASK_QS(p) == NULL);
-    ASSERT(p->dirty_sys_tasks == NULL);
-    erts_proc_unlock(p, ERTS_PROC_LOCK_STATUS);
+        erts_proc_lock(p, ERTS_PROC_LOCK_STATUS);
+        ASSERT(ERTS_PROC_GET_DELAYED_GC_TASK_QS(p) == NULL);
+        ASSERT(p->dirty_sys_tasks == NULL);
+        erts_proc_unlock(p, ERTS_PROC_LOCK_STATUS);
 #endif
 
-    if (p->flags & F_USING_DDLL) {
-	erts_ddll_proc_dead(p, ERTS_PROC_LOCK_MAIN);
-	p->flags &= ~F_USING_DDLL;
+        if (p->flags & F_USING_DDLL) {
+            erts_ddll_proc_dead(p, ERTS_PROC_LOCK_MAIN);
+            p->flags &= ~F_USING_DDLL;
+        }
+
+        /*
+         * The registered name *should* be the last "erlang resource" to
+         * cleanup.
+         */
+        if (p->common.u.alive.reg) {
+            (void) erts_unregister_name(p, ERTS_PROC_LOCK_MAIN, NULL, THE_NON_VALUE);
+            ASSERT(!p->common.u.alive.reg);
+        }
+
+        erts_proc_lock(p, ERTS_PROC_LOCKS_ALL_MINOR);
+        curr_locks = ERTS_PROC_LOCKS_ALL;
+
+        /*
+         * Note! The monitor and link fields will be overwritten 
+         * by erts_ptab_delete_element() below.
+         */
+        trap_state->links = ERTS_P_LINKS(p);
+        trap_state->monitors = ERTS_P_MONITORS(p);
+        trap_state->lt_monitors = ERTS_P_LT_MONITORS(p);
+
+        {
+            /* Do *not* use erts_get_runq_proc() */
+            ErtsRunQueue *rq;
+            rq = erts_get_runq_current(erts_proc_sched_data(p));
+
+            erts_runq_lock(rq);
+
+            ASSERT(p->scheduler_data);
+            ASSERT(p->scheduler_data->current_process == p);
+            ASSERT(p->scheduler_data->free_process == NULL);
+
+            /* Time of death! */
+            erts_ptab_delete_element(&erts_proc, &p->common);
+
+            erts_runq_unlock(rq);
+        }
+
+        /*
+         * All "erlang resources" have to be deallocated before this point,
+         * e.g. registered name, so monitoring and linked processes can
+         * be sure that all interesting resources have been deallocated
+         * when the monitors and/or links hit.
+         */
+
+        {
+            /* Inactivate and notify free */
+            erts_aint32_t n, e, a = erts_atomic32_read_nob(&p->state);
+            int refc_inced = 0;
+            while (1) {
+                n = e = a;
+                ASSERT(a & ERTS_PSFLG_EXITING);
+                n |= ERTS_PSFLG_FREE;
+                if ((n & ERTS_PSFLG_IN_RUNQ) && !refc_inced) {
+                    erts_proc_inc_refc(p);
+                    refc_inced = 1;
+                }
+                a = erts_atomic32_cmpxchg_mb(&p->state, n, e);
+                if (a == e)
+                    break;
+            }
+
+            if (refc_inced && !(n & ERTS_PSFLG_IN_RUNQ))
+                erts_proc_dec_refc(p);
+        }
+
+        trap_state->dep = ((p->flags & F_DISTRIBUTION)
+                      ? ERTS_PROC_SET_DIST_ENTRY(p, NULL)
+                      : NULL);
+
+
+        erts_proc_unlock(p, ERTS_PROC_LOCKS_ALL_MINOR);
+        curr_locks = ERTS_PROC_LOCK_MAIN;
+        trap_state->phase = ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS_AFTER;
+    case ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS_AFTER:
+        /*
+         * It might show up signal prio elevation tasks until we
+         * have entered free state. Cleanup such tasks now.
+         */
+
+        state = erts_atomic32_read_acqb(&p->state);
+        if ((state & ERTS_PSFLG_SYS_TASKS) || p->dirty_sys_tasks) {
+            reds -= cleanup_sys_tasks(p, state, reds);
+            if (reds <= 0) goto yield;
+        }
+
+        /* Needs to be unlocked for erts_do_net_exits to work?!? */
+        // erts_proc_unlock(p, ERTS_PROC_LOCK_MAIN);
+
+#ifdef DEBUG
+        erts_proc_lock(p, ERTS_PROC_LOCK_STATUS);
+        ASSERT(p->sys_task_qs == NULL);
+        erts_proc_unlock(p, ERTS_PROC_LOCK_STATUS);
+#endif
+
+        if (trap_state->dep) {
+            erts_do_net_exits(trap_state->dep,
+                              (trap_state->reason == am_kill) ? am_killed : trap_state->reason);
+            erts_deref_dist_entry(trap_state->dep);
+        }
+
+        trap_state->pectxt.c_p = p;
+        trap_state->pectxt.reason = trap_state->reason;
+
+        erts_proc_lock(p, ERTS_PROC_LOCK_MSGQ);
+
+        erts_proc_sig_fetch(p);
+
+        erts_proc_unlock(p, ERTS_PROC_LOCK_MSGQ);
+
+        reds -= 1000;
+
+        trap_state->yield_state = NULL;
+        trap_state->phase = ERTS_CONTINUE_EXIT_LINKS;
+        if (reds <= 0) goto yield;
+    case ERTS_CONTINUE_EXIT_LINKS:
+
+        reds = erts_link_tree_foreach_delete_yielding(
+            &trap_state->links,
+            erts_proc_exit_handle_link,
+            (void *) &trap_state->pectxt,
+            &trap_state->yield_state,
+            reds);
+        if (reds <= 0)
+            goto yield;
+
+        ASSERT(!trap_state->links);
+        trap_state->yield_state = NULL;
+        trap_state->phase = ERTS_CONTINUE_EXIT_MONITORS;
+    case ERTS_CONTINUE_EXIT_MONITORS:
+
+    reds = erts_monitor_tree_foreach_delete_yielding(
+            &trap_state->monitors,
+            erts_proc_exit_handle_monitor,
+            (void *) &trap_state->pectxt,
+            &trap_state->yield_state,
+            reds);
+        if (reds <= 0)
+            goto yield;
+
+        ASSERT(!trap_state->monitors);
+        trap_state->yield_state = NULL;
+        trap_state->phase = ERTS_CONTINUE_EXIT_LT_MONITORS;
+    case ERTS_CONTINUE_EXIT_LT_MONITORS:
+
+        reds = erts_monitor_list_foreach_delete_yielding(
+            &trap_state->lt_monitors,
+            erts_proc_exit_handle_monitor,
+            (void *) &trap_state->pectxt,
+            &trap_state->yield_state,
+            reds);
+        if (reds <= 0)
+            goto yield;
+
+        ASSERT(!trap_state->lt_monitors);
+        trap_state->phase = ERTS_CONTINUE_EXIT_HANDLE_PROC_SIG;
+    case ERTS_CONTINUE_EXIT_HANDLE_PROC_SIG: {
+        Sint r = reds;
+        erts_aint_t state;
+
+        if (!erts_proc_sig_handle_exit(p, &r))
+            goto yield;
+
+        reds -= r;
+
+        /*
+         * From this point on we are no longer allowed to yield
+         * this process.
+         */
+
+        /* Set state to not active as we don't want this process
+           to be scheduled in again after this. */
+        state = erts_atomic32_read_band_relb(&p->state,
+                                             ~(ERTS_PSFLG_ACTIVE
+                                               | ERTS_PSFLG_ACTIVE_SYS
+                                               | ERTS_PSFLG_DIRTY_ACTIVE_SYS));
+
+        ASSERT(p->scheduler_data);
+        ASSERT(p->scheduler_data->current_process == p);
+        ASSERT(p->scheduler_data->free_process == NULL);
+
+        p->scheduler_data->current_process = NULL;
+        p->scheduler_data->free_process = p;
+
+        if (state & (ERTS_PSFLG_DIRTY_RUNNING
+                     | ERTS_PSFLG_DIRTY_RUNNING_SYS)) {
+            p->flags |= F_DELAYED_DEL_PROC;
+            delay_del_proc = 1;
+            /*
+             * The dirty scheduler decrease refc
+             * when done with the process...
+             */
+        }
+
+        erts_schedule_thr_prgr_later_cleanup_op(
+            (void (*)(void*))erts_proc_dec_refc,
+            (void *) &p->common,
+            &p->common.u.release,
+            sizeof(Process));
+
+#ifdef DEBUG
+        yield_allowed = 0;
+#endif
+        break;
+    }
     }
 
-    /*
-     * The registered name *should* be the last "erlang resource" to
-     * cleanup.
-     */
-    if (p->common.u.alive.reg) {
-	(void) erts_unregister_name(p, ERTS_PROC_LOCK_MAIN, NULL, THE_NON_VALUE);
-	ASSERT(!p->common.u.alive.reg);
+    if (trap_state != &static_state) {
+        erts_free(ERTS_ALC_T_CONT_EXIT_TRAP, trap_state);
+        p->u.terminate = NULL;
     }
+    
+    ERTS_CHK_HAVE_ONLY_MAIN_PROC_LOCK(p);
 
     if (IS_TRACED_FL(p, F_TRACE_SCHED_EXIT))
         trace_sched(p, curr_locks, am_out_exited);
-
-    erts_proc_lock(p, ERTS_PROC_LOCKS_ALL_MINOR);
-    curr_locks = ERTS_PROC_LOCKS_ALL;
-
-    /*
-     * From this point on we are no longer allowed to yield
-     * this process.
-     */
-#ifdef DEBUG
-    yield_allowed = 0;
-#endif
-
-    /*
-     * Note! The monitor and link fields will be overwritten 
-     * by erts_ptab_delete_element() below.
-     */
-    links = ERTS_P_LINKS(p);
-    monitors = ERTS_P_MONITORS(p);
-    lt_monitors = ERTS_P_LT_MONITORS(p);
-
-    {
-	/* Do *not* use erts_get_runq_proc() */
-	ErtsRunQueue *rq;
-	rq = erts_get_runq_current(erts_proc_sched_data(p));
-
-	erts_runq_lock(rq);
-
-	ASSERT(p->scheduler_data);
-	ASSERT(p->scheduler_data->current_process == p);
-	ASSERT(p->scheduler_data->free_process == NULL);
-
-	p->scheduler_data->current_process = NULL;
-	p->scheduler_data->free_process = p;
-
-	/* Time of death! */
-	erts_ptab_delete_element(&erts_proc, &p->common);
-
-	erts_runq_unlock(rq);
-    }
-
-    /*
-     * All "erlang resources" have to be deallocated before this point,
-     * e.g. registered name, so monitoring and linked processes can
-     * be sure that all interesting resources have been deallocated
-     * when the monitors and/or links hit.
-     */
-
-    {
-	/* Inactivate and notify free */
-	erts_aint32_t n, e, a = erts_atomic32_read_nob(&p->state);
-	int refc_inced = 0;
-	while (1) {
-	    n = e = a;
-	    ASSERT(a & ERTS_PSFLG_EXITING);
-	    n |= ERTS_PSFLG_FREE;
-	    n &= ~(ERTS_PSFLG_ACTIVE
-                   | ERTS_PSFLG_ACTIVE_SYS
-                   | ERTS_PSFLG_DIRTY_ACTIVE_SYS);
-	    if ((n & ERTS_PSFLG_IN_RUNQ) && !refc_inced) {
-		erts_proc_inc_refc(p);
-		refc_inced = 1;
-	    }
-	    a = erts_atomic32_cmpxchg_mb(&p->state, n, e);
-	    if (a == e)
-		break;
-	}
-
-        if (a & (ERTS_PSFLG_DIRTY_RUNNING
-                 | ERTS_PSFLG_DIRTY_RUNNING_SYS)) {
-	    p->flags |= F_DELAYED_DEL_PROC;
-	    delay_del_proc = 1;
-	    /*
-	     * The dirty scheduler decrease refc
-             * when done with the process...
-	     */
-	}
-
-	if (refc_inced && !(n & ERTS_PSFLG_IN_RUNQ))
-	    erts_proc_dec_refc(p);
-    }
-
-    dep = ((p->flags & F_DISTRIBUTION)
-           ? ERTS_PROC_SET_DIST_ENTRY(p, NULL)
-           : NULL);
-
-
-    /*
-     * It might show up signal prio elevation tasks until we
-     * have entered free state. Cleanup such tasks now.
-     */
-    state = erts_atomic32_read_acqb(&p->state);
-    if (!(state & ERTS_PSFLG_SYS_TASKS))
-        erts_proc_unlock(p, ERTS_PROC_LOCKS_ALL);
-    else {
-        erts_proc_unlock(p, ERTS_PROC_LOCKS_ALL_MINOR);
-
-        do {
-            (void) cleanup_sys_tasks(p, state, CONTEXT_REDS);
-            state = erts_atomic32_read_acqb(&p->state);
-        } while (state & ERTS_PSFLG_SYS_TASKS);
-        
-        erts_proc_unlock(p, ERTS_PROC_LOCK_MAIN);
-    }
-
-#ifdef DEBUG
-    erts_proc_lock(p, ERTS_PROC_LOCK_STATUS);
-    ASSERT(p->sys_task_qs == NULL);
-    erts_proc_unlock(p, ERTS_PROC_LOCK_STATUS);
-#endif
-
-    if (dep) {
-        erts_do_net_exits(dep, (reason == am_kill) ? am_killed : reason);
-        erts_deref_dist_entry(dep);
-    }
-
-    pectxt.c_p = p;
-    pectxt.reason = reason;
-
-    erts_proc_lock(p, ERTS_PROC_LOCK_MAIN|ERTS_PROC_LOCK_MSGQ);
-
-    erts_proc_sig_fetch(p);
-
-    erts_proc_unlock(p, ERTS_PROC_LOCK_MSGQ);
-
-    if (links) {
-        erts_link_tree_foreach_delete(&links,
-                                      erts_proc_exit_handle_link,
-                                      (void *) &pectxt);
-        ASSERT(!links);
-    }
-
-    if (monitors) {
-        erts_monitor_tree_foreach_delete(&monitors,
-                                         erts_proc_exit_handle_monitor,
-                                         (void *) &pectxt);
-        ASSERT(!monitors);
-    }
-
-    if (lt_monitors) {
-        erts_monitor_list_foreach_delete(&lt_monitors,
-                                         erts_proc_exit_handle_monitor,
-                                         (void *) &pectxt);
-        ASSERT(!lt_monitors);
-    }
-
-    /*
-     * erts_proc_sig_handle_exit() implements yielding.
-     * However, this function cannot handle it yet... loop
-     * until done...
-     */
-    while (!0) {
-        int reds = CONTEXT_REDS;
-        if (erts_proc_sig_handle_exit(p, &reds))
-            break;
-    }
-
-    ERTS_CHK_HAVE_ONLY_MAIN_PROC_LOCK(p);
 
     erts_flush_trace_messages(p, ERTS_PROC_LOCK_MAIN);
 
@@ -12639,9 +12721,26 @@ erts_continue_exit_process(Process *p)
 
     ERTS_LC_ASSERT(curr_locks == erts_proc_lc_my_proc_locks(p));
     ERTS_LC_ASSERT(ERTS_PROC_LOCK_MAIN & curr_locks);
+    ASSERT(erts_proc_read_refc(p) > 0);
+
+    if (trap_state == &static_state) {
+        trap_state = erts_alloc(ERTS_ALC_T_CONT_EXIT_TRAP, sizeof(*trap_state));
+        sys_memcpy(trap_state, &static_state, sizeof(*trap_state));
+        p->u.terminate = trap_state;
+    }
+
+    ASSERT(p->scheduler_data);
+    ASSERT(p->scheduler_data->current_process == p);
+    ASSERT(p->scheduler_data->free_process == NULL);
+
+    if (trap_state->phase >= ERTS_CONTINUE_EXIT_FREE) {
+        p->scheduler_data->current_process = NULL;
+        p->scheduler_data->free_process = p;
+    }
 
     p->i = (BeamInstr *) beam_continue_exit;
 
+    /* Why is this lock take??? */
     if (!(curr_locks & ERTS_PROC_LOCK_STATUS)) {
 	erts_proc_lock(p, ERTS_PROC_LOCK_STATUS);
 	curr_locks |= ERTS_PROC_LOCK_STATUS;

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -12055,8 +12055,8 @@ erts_set_self_exiting(Process *c_p, Eterm reason)
         add2runq(enqueue, enq_prio, c_p, state, NULL);
 }
 
-void
-erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt)
+int
+erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt, Sint reds)
 {
     Process *c_p = ((ErtsProcExitContext *) vctxt)->c_p;
     Eterm reason = ((ErtsProcExitContext *) vctxt)->reason;
@@ -12215,10 +12215,11 @@ erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt)
         erts_monitor_release_both(mdp);
     else if (mon)
         erts_monitor_release(mon);
+    return 1;
 }
 
-void
-erts_proc_exit_handle_link(ErtsLink *lnk, void *vctxt)
+int
+erts_proc_exit_handle_link(ErtsLink *lnk, void *vctxt, Sint reds)
 {
     Process *c_p = ((ErtsProcExitContext *) vctxt)->c_p;
     Eterm reason = ((ErtsProcExitContext *) vctxt)->reason;
@@ -12288,6 +12289,7 @@ erts_proc_exit_handle_link(ErtsLink *lnk, void *vctxt)
         erts_link_release_both(ldp);
     else if (lnk)
         erts_link_release(lnk);
+    return 1;
 }
 
 /* this function fishishes a process and propagates exit messages - called

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1820,8 +1820,8 @@ typedef struct {
     Process *c_p;
     Eterm reason;
 } ErtsProcExitContext;
-void erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt);
-void erts_proc_exit_handle_link(ErtsLink *lnk, void *vctxt);
+int erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt, Sint reds);
+int erts_proc_exit_handle_link(ErtsLink *lnk, void *vctxt, Sint reds);
 
 Eterm erts_get_process_priority(erts_aint32_t state);
 Eterm erts_set_process_priority(Process *p, Eterm prio);

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -100,16 +100,18 @@ erts_deep_process_dump(fmtfn_t to, void *to_arg)
     dump_binaries(to, to_arg, all_binaries);
 }
 
-static void
-monitor_size(ErtsMonitor *mon, void *vsize)
+static int
+monitor_size(ErtsMonitor *mon, void *vsize, Sint reds)
 {
     *((Uint *) vsize) += erts_monitor_size(mon);
+    return 1;
 }
 
-static void
-link_size(ErtsMonitor *lnk, void *vsize)
+static int
+link_size(ErtsMonitor *lnk, void *vsize, Sint reds)
 {
     *((Uint *) vsize) += erts_link_size(lnk);
+    return 1;
 }
 
 Uint erts_process_memory(Process *p, int include_sigs_in_transit)

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -191,11 +191,11 @@ static ERTS_INLINE void
 dump_msg(fmtfn_t to, void *to_arg, ErtsMessage *mp)
 {
     if (ERTS_SIG_IS_MSG((ErtsSignal *) mp)) {
-        Eterm mesg = ERL_MESSAGE_TERM(mp);
-        if (is_value(mesg))
-            dump_element(to, to_arg, mesg);
+        Eterm mesg;
+        if (ERTS_SIG_IS_INTERNAL_MSG(mp))
+            dump_element(to, to_arg, ERL_MESSAGE_TERM(mp));
         else
-            dump_dist_ext(to, to_arg, mp->data.dist_ext);
+            dump_dist_ext(to, to_arg, erts_get_dist_ext(mp->data.heap_frag));
         mesg = ERL_MESSAGE_TOKEN(mp);
         erts_print(to, to_arg, ":");
         dump_element(to, to_arg, mesg);
@@ -267,6 +267,7 @@ dump_dist_ext(fmtfn_t to, void *to_arg, ErtsDistExternal *edep)
     else {
 	byte *e;
 	size_t sz;
+        int i;
 
 	if (!(edep->flags & ERTS_DIST_EXT_ATOM_TRANS_TAB))
 	    erts_print(to, to_arg, "D0:");
@@ -276,8 +277,8 @@ dump_dist_ext(fmtfn_t to, void *to_arg, ErtsDistExternal *edep)
 	    for (i = 0; i < edep->attab.size; i++)
 		dump_element(to, to_arg, edep->attab.atom[i]);
 	}
-	sz = edep->ext_endp - edep->extp;
-	e = edep->extp;
+	sz = edep->data->ext_endp - edep->data->extp;
+	e = edep->data->extp;
 	if (edep->flags & ERTS_DIST_EXT_DFLAG_HDR) {
 	    ASSERT(*e != VERSION_MAGIC);
 	    sz++;
@@ -288,15 +289,19 @@ dump_dist_ext(fmtfn_t to, void *to_arg, ErtsDistExternal *edep)
 	erts_print(to, to_arg, "E%X:", sz);
         if (edep->flags & ERTS_DIST_EXT_DFLAG_HDR) {
             byte sbuf[3];
-            int i = 0;
+
+            i = 0;
 
             sbuf[i++] = VERSION_MAGIC;
-            while (i < sizeof(sbuf) && e < edep->ext_endp) {
+            while (i < sizeof(sbuf) && e < edep->data->ext_endp) {
                 sbuf[i++] = *e++;
             }
             erts_print_base64(to, to_arg, sbuf, i);
         }
-        erts_print_base64(to, to_arg, e, edep->ext_endp - e);
+        erts_print_base64(to, to_arg, e, edep->data->ext_endp - e);
+        for (i = 1; i < edep->data->frag_id; i++)
+            erts_print_base64(to, to_arg, edep->data[i].extp,
+                              edep->data[i].ext_endp - edep->data[i].extp);
     }
 }
 

--- a/erts/emulator/beam/erl_ptab.h
+++ b/erts/emulator/beam/erl_ptab.h
@@ -68,8 +68,11 @@ typedef struct {
 	    Uint64 started_interval;
 	    struct reg_proc *reg;
 	    ErtsLink *links;
-	    ErtsMonitor *monitors;
+             /* Local target monitors, double linked list
+                contains the remote part of local monitors  */
             ErtsMonitor *lt_monitors;
+             /* other monitors, rb tree */
+	    ErtsMonitor *monitors;
 	} alive;
 
 	/* --- While being released --- */

--- a/erts/emulator/beam/erl_rbtree.h
+++ b/erts/emulator/beam/erl_rbtree.h
@@ -161,7 +161,7 @@
  *
  * - void <ERTS_RBT_PREFIX>_rbt_foreach(
  *                         ERTS_RBT_T *tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
  *                         void *arg);
  *         Operate by calling the operator 'op' on each element.
  *         Order is undefined.
@@ -170,7 +170,7 @@
  *
  * - void <ERTS_RBT_PREFIX>_rbt_foreach_destroy(
  *                         ERTS_RBT_T *tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
  *                         void *arg);
  *         Operate by calling the operator 'op' on each element.
  *         Order is undefined. Each element should be destroyed
@@ -180,39 +180,46 @@
  *
  * - int <ERTS_RBT_PREFIX>_rbt_foreach_yielding(
  *                         ERTS_RBT_T *tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
  *                         void *arg,
  *                         <ERTS_RBT_PREFIX>_rbt_yield_state_t *ystate,
- *                         Sint ylimit);
+ *                         Sint reds);
  *         Operate by calling the operator 'op' on each element.
  *         Order is undefined.
  *
- *         Yield when 'ylimit' elements has been processed. True is
- *         returned when yielding, and false is returned when
- *         the whole tree has been processed. The tree should not be
- *         modified until all of it has been processed.
+ *         Yield when 'reds' reductions has been processed. The 'op'
+ *         function return the number of reductions that each element
+ *         took to process. The number of reductions remaining is returned,
+ *         meaning that if 0 is returned, there are more elements to be
+ *         processed. If a value greater than 0 is returned the foreach has
+ *         ended. The tree should not be modified until all of it has been
+ *         processed.
  *
  *         'arg' is passed as argument to 'op'.
  *
  * - int <ERTS_RBT_PREFIX>_rbt_foreach_destroy_yielding(
  *                         ERTS_RBT_T *tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
  *                         void *arg,
  *                         <ERTS_RBT_PREFIX>_rbt_yield_state_t *ystate,
- *                         Sint ylimit);
+ *                         Sint reds);
  *         Operate by calling the operator 'op' on each element.
  *         Order is undefined. Each element should be destroyed
  *         by 'op'.
  *
- *         Yield when 'ylimit' elements has been processed. True is
- *         returned when yielding, and false is returned when
- *         the whole tree has been processed.
+ *         Yield when 'reds' reductions has been processed. The 'op'
+ *         function return the number of reductions that each element
+ *         took to process. The number of reductions remaining is returned,
+ *         meaning that if 0 is returned, there are more elements to be
+ *         processed. If a value greater than 0 is returned the foreach has
+ *         ended. The tree should not be modified until all of it has been
+ *         processed.
  *
  *         'arg' is passed as argument to 'op'.
  *
  * - void <ERTS_RBT_PREFIX>_rbt_foreach_small(
  *                         ERTS_RBT_T *tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
  *                         void *arg);
  *         Operate by calling the operator 'op' on each element from
  *         smallest towards larger elements.
@@ -221,7 +228,7 @@
  *
  * - void <ERTS_RBT_PREFIX>_rbt_foreach_large(
  *                         ERTS_RBT_T *tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
  *                         void *arg);
  *         Operate by calling the operator 'op' on each element from
  *         largest towards smaller elements.
@@ -230,40 +237,46 @@
  *
  * - int <ERTS_RBT_PREFIX>_rbt_foreach_small_yielding(
  *                         ERTS_RBT_T *tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
  *                         void *arg,
  *                         <ERTS_RBT_PREFIX>_rbt_yield_state_t *ystate,
- *                         Sint ylimit);
+ *                         Sint reds);
  *         Operate by calling the operator 'op' on each element from
  *         smallest towards larger elements.
  *
- *         Yield when 'ylimit' elements has been processed. True is
- *         returned when yielding, and false is returned when
- *         the whole tree has been processed. The tree should not be
- *         modified until all of it has been processed.
+ *         Yield when 'reds' reductions has been processed. The 'op'
+ *         function return the number of reductions that each element
+ *         took to process. The number of reductions remaining is returned,
+ *         meaning that if 0 is returned, there are more elements to be
+ *         processed. If a value greater than 0 is returned the foreach has
+ *         ended. The tree should not be modified until all of it has been
+ *         processed.
  *
  *         'arg' is passed as argument to 'op'.
  *
  * - int <ERTS_RBT_PREFIX>_rbt_foreach_large_yielding(
  *                         ERTS_RBT_T *tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
  *                         void *arg,
  *                         <ERTS_RBT_PREFIX>_rbt_yield_state_t *ystate,
- *                         Sint ylimit);
+ *                         Sint reds);
  *         Operate by calling the operator 'op' on each element from
  *         largest towards smaller elements.
  *
- *         Yield when 'ylimit' elements has been processed. True is
- *         returned when yielding, and false is returned when
- *         the whole tree has been processed. The tree should not be
- *         modified until all of it has been processed.
+ *         Yield when 'reds' reductions has been processed. The 'op'
+ *         function return the number of reductions that each element
+ *         took to process. The number of reductions remaining is returned,
+ *         meaning that if 0 is returned, there are more elements to be
+ *         processed. If a value greater than 0 is returned the foreach has
+ *         ended. The tree should not be modified until all of it has been
+ *         processed.
  *
  *         'arg' is passed as argument to 'op'.
  *
  * - void <ERTS_RBT_PREFIX>_rbt_foreach_small_destroy(
  *                         ERTS_RBT_T **tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
- *                         void (*destr)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
+ *                         int (*destr)(ERTS_RBT_T *, void *),
  *                         void *arg);
  *         Operate by calling the operator 'op' on each element from
  *         smallest towards larger elements.
@@ -277,8 +290,8 @@
  *
  * - void <ERTS_RBT_PREFIX>_rbt_foreach_large_destroy(
  *                         ERTS_RBT_T **tree,
- *                         void (*op)(ERTS_RBT_T *, void *),
- *                         void (*destr)(ERTS_RBT_T *, void *),
+ *                         int (*op)(ERTS_RBT_T *, void *),
+ *                         int (*destr)(ERTS_RBT_T *, void *),
  *                         void *arg);
  *         Operate by calling the operator 'op' on each element from
  *         largest towards smaller elements.
@@ -292,11 +305,11 @@
  *
  * - int <ERTS_RBT_PREFIX>_rbt_foreach_small_destroy_yielding(
  *                        ERTS_RBT_T **tree,
- *                        void (*op)(ERTS_RBT_T *, void *),
- *                        void (*destr)(ERTS_RBT_T *, void *),
+ *                        int (*op)(ERTS_RBT_T *, void *),
+ *                        int (*destr)(ERTS_RBT_T *, void *),
  *                        void *arg,
  *                        <ERTS_RBT_PREFIX>_rbt_yield_state_t *ystate,
- *                        Sint ylimit);
+ *                        Sint reds);
  *         Operate by calling the operator 'op' on each element from
  *         smallest towards larger elements.
  *
@@ -305,20 +318,23 @@
  *         Note that elements are often destroyed in another order
  *         than the order that the elements are operated on.
  *
- *         Yield when 'ylimit' elements has been processed. True is
- *         returned when yielding, and false is returned when
- *         the whole tree has been processed. The tree should not be
- *         modified until all of it has been processed.
+ *         Yield when 'reds' reductions has been processed. The 'op' and
+ *         'destr' functions return the number of reductions that each element
+ *         took to process. The number of reductions remaining is returned,
+ *         meaning that if 0 is returned, there are more elements to be
+ *         processed. If a value greater than 0 is returned the foreach has
+ *         ended. The tree should not be modified until all of it has been
+ *         processed.
  *
  *         'arg' is passed as argument to 'op' and 'destroy'.
  *
  * - int <ERTS_RBT_PREFIX>_rbt_foreach_large_destroy_yielding(
  *                        ERTS_RBT_T **tree,
- *                        void (*op)(ERTS_RBT_T *, void *),
- *                        void (*destr)(ERTS_RBT_T *, void *),
+ *                        int (*op)(ERTS_RBT_T *, void *),
+ *                        int (*destr)(ERTS_RBT_T *, void *),
  *                        void *arg,
  *                        <ERTS_RBT_PREFIX>_rbt_yield_state_t *ystate,
- *                        Sint ylimit);
+ *                        Sint reds);
  *         Operate by calling the operator 'op' on each element from
  *         largest towards smaller elements.
  *
@@ -327,10 +343,13 @@
  *         Note that elements are often destroyed in another order
  *         than the order that the elements are operated on.
  *
- *         Yield when 'ylimit' elements has been processed. True is
- *         returned when yielding, and false is returned when
- *         the whole tree has been processed. The tree should not be
- *         modified until all of it has been processed.
+ *         Yield when 'reds' reductions has been processed. The 'op' and
+ *         'destr' functions return the number of reductions that each element
+ *         took to process. The number of reductions remaining is returned,
+ *         meaning that if 0 is returned, there are more elements to be
+ *         processed. If a value greater than 0 is returned the foreach has
+ *         ended. The tree should not be modified until all of it has been
+ *         processed.
  *
  *         'arg' is passed as argument to 'op' and 'destroy'.
  *
@@ -447,17 +466,6 @@
 #  define ERTS_RBT_API_INLINE__ ERTS_INLINE
 #endif
 
-#ifndef ERTS_RBT_YIELD_STAT_INITER
-#  define ERTS_RBT_YIELD_STAT_INITER {NULL, 0}
-#endif
-#ifndef ERTS_RBT_YIELD_STAT_INIT
-#  define ERTS_RBT_YIELD_STAT_INIT(YS) \
-    do {                               \
-        (YS)->x = NULL;                \
-        (YS)->up = 0;                  \
-    } while (0)
-#endif
-
 #define ERTS_RBT_CONCAT_MACRO_VALUES___(X, Y) \
     X ## Y
 #define ERTS_RBT_CONCAT_MACRO_VALUES__(X, Y) \
@@ -470,7 +478,37 @@
 typedef struct {
     ERTS_RBT_T *x;
     int up;
+#ifdef DEBUG
+    int debug_red_adj;
+#endif
 } ERTS_RBT_YIELD_STATE_T__;
+
+#define ERTS_RBT_CALLBACK_FOREACH_FUNC(NAME) int (*NAME)(ERTS_RBT_T *, void *, Sint)
+
+#ifndef ERTS_RBT_YIELD_STAT_INITER
+#  ifdef DEBUG
+#    define ERTS_RBT_YIELD_STAT_INITER {NULL, 0, CONTEXT_REDS}
+#  else
+#    define ERTS_RBT_YIELD_STAT_INITER {NULL, 0}
+#  endif
+#endif
+#ifndef ERTS_RBT_YIELD_STAT_INIT
+#  define ERTS_RBT_YIELD_STAT_INIT__(YS)                                \
+    do {                                                                \
+        (YS)->x = NULL;                                                 \
+        (YS)->up = 0;                                                   \
+    } while (0)
+#  ifdef DEBUG
+#    define ERTS_RBT_YIELD_STAT_INIT(YS)        \
+    do {                                        \
+        ERTS_RBT_YIELD_STAT_INIT__(YS);         \
+        (YS)->debug_red_adj = CONTEXT_REDS;     \
+    } while(0)
+#  else
+#    define ERTS_RBT_YIELD_STAT_INIT(YS) ERTS_RBT_YIELD_STAT_INIT__(YS)
+#  endif
+#endif
+
 
 #define ERTS_RBT_FUNC__(Name) \
     ERTS_RBT_CONCAT_MACRO_VALUES__(ERTS_RBT_PREFIX, _rbt_ ## Name)
@@ -1302,11 +1340,11 @@ ERTS_RBT_FUNC__(largest)(ERTS_RBT_T *root)
 static ERTS_INLINE int
 ERTS_RBT_FUNC__(foreach_unordered__)(ERTS_RBT_T **root,
 				     int destroying,
-				     void (*op)(ERTS_RBT_T *, void *),
+				     ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 				     void *arg,
-				     int yielding,
+                                     int yielding,
 				     ERTS_RBT_YIELD_STATE_T__ *ystate,
-				     Sint ylimit)
+				     Sint reds)
 {
     ERTS_RBT_T *c, *p, *x;
 
@@ -1314,13 +1352,17 @@ ERTS_RBT_FUNC__(foreach_unordered__)(ERTS_RBT_T **root,
 
     if (yielding && ystate->x) {
 	x = ystate->x;
+#ifdef DEBUG
+        if (ystate->debug_red_adj > 0)
+            ystate->debug_red_adj -= 100;
+#endif
 	ERTS_RBT_ASSERT(ystate->up);
 	goto restart_up;
     }
     else {
 	x = *root;
 	if (!x)
-	    return 0;
+	    return reds;
 	if (destroying)
 	    *root = NULL;
     }
@@ -1346,10 +1388,10 @@ ERTS_RBT_FUNC__(foreach_unordered__)(ERTS_RBT_T **root,
 #ifdef ERTS_RBT_DEBUG
 	    int cdir;
 #endif
-	    if (yielding && ylimit-- <= 0) {
+	    if (yielding && reds <= 0) {
 		ystate->x = x;
 		ystate->up = 1;
-		return 1;
+		return 0;
 	    }
 
 	restart_up:
@@ -1375,14 +1417,20 @@ ERTS_RBT_FUNC__(foreach_unordered__)(ERTS_RBT_T **root,
 	    }
 #endif
 
-	    (*op)(x, arg);
+            reds -= (*op)(x, arg, reds);
+#ifdef DEBUG
+            if (yielding)
+                reds -= ystate->debug_red_adj;
+#endif
 
 	    if (!p) {
+                /* Done */
 		if (yielding) {
 		    ystate->x = NULL;
 		    ystate->up = 0;
+                    return reds <= 0 ? 1 : reds;
 		}
-		return 0; /* Done */
+                return 1;
 	    }
 
 	    c = ERTS_RBT_GET_RIGHT(p);
@@ -1407,20 +1455,26 @@ static ERTS_INLINE int
 ERTS_RBT_FUNC__(foreach_ordered__)(ERTS_RBT_T **root,
 				   int from_small,
 				   int destroying,
-				   void (*op)(ERTS_RBT_T *, void *),
-				   void (*destroy)(ERTS_RBT_T *, void *),
+                                   ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
+                                   ERTS_RBT_CALLBACK_FOREACH_FUNC(destroy),
 				   void *arg,
-				   int yielding,
+                                   int yielding,
 				   ERTS_RBT_YIELD_STATE_T__ *ystate,
-				   Sint ylimit)
+				   Sint reds)
 {
     ERTS_RBT_T *c, *p, *x;
 
     ERTS_RBT_ASSERT(!yielding || ystate);
     ERTS_RBT_ASSERT(!destroying || destroy);
+    ERTS_RBT_ASSERT(!yielding || yop);
+    ERTS_RBT_ASSERT(yielding || op);
 
     if (yielding && ystate->x) {
 	x = ystate->x;
+#ifdef DEBUG
+        if (ystate->debug_red_adj > 0)
+            ystate->debug_red_adj -= 100;
+#endif
 	if (ystate->up)
 	    goto restart_up;
 	else
@@ -1429,7 +1483,7 @@ ERTS_RBT_FUNC__(foreach_ordered__)(ERTS_RBT_T **root,
     else {
 	x = *root;
 	if (!x)
-	    return 0;
+	    return reds;
 	if (destroying)
 	    *root = NULL;
     }
@@ -1445,12 +1499,16 @@ ERTS_RBT_FUNC__(foreach_ordered__)(ERTS_RBT_T **root,
 		x = c;
 	    }
 
-	    (*op)(x, arg);
+            reds -= (*op)(x, arg, reds);
+#ifdef DEBUG
+            if (yielding)
+                reds -= ystate->debug_red_adj;
+#endif
 
-	    if (yielding && --ylimit <= 0) {
+	    if (yielding && reds <= 0) {
 		ystate->x = x;
 		ystate->up = 0;
-		return 1;
+		return 0;
 	    }
 
 	restart_down:
@@ -1472,12 +1530,16 @@ ERTS_RBT_FUNC__(foreach_ordered__)(ERTS_RBT_T **root,
 				     ? ERTS_RBT_GET_LEFT(p)
 				     : ERTS_RBT_GET_RIGHT(p)) == x);
 
-		    (*op)(p, arg);
+                    reds -= (*op)(p, arg, reds);
+#ifdef DEBUG
+                    if (yielding)
+                        reds -= ystate->debug_red_adj;
+#endif
 
-		    if (yielding && --ylimit <= 0) {
+		    if (yielding && reds <= 0) {
 			ystate->x = x;
 			ystate->up = 1;
-			return 1;
+			return 0;
 		    restart_up:
 			p = ERTS_RBT_GET_PARENT(x);
 		    }
@@ -1510,15 +1572,20 @@ ERTS_RBT_FUNC__(foreach_ordered__)(ERTS_RBT_T **root,
 		}
 #endif
 
-		(*destroy)(x, arg);
+		reds -= (*destroy)(x, arg, reds);
+#ifdef DEBUG
+                if (yielding)
+                    reds -= ystate->debug_red_adj;
+#endif
 	    }
 
 	    if (!p) {
 		if (yielding) {
 		    ystate->x = NULL;
 		    ystate->up = 0;
+                    return reds <= 0 ? 1 : reds;
 		}
-		return 0; /* Done */
+		return 1; /* Done */
 	    }
 	    x = p;
 	}
@@ -1531,7 +1598,7 @@ ERTS_RBT_FUNC__(foreach_ordered__)(ERTS_RBT_T **root,
 
 static ERTS_RBT_API_INLINE__ void
 ERTS_RBT_FUNC__(foreach)(ERTS_RBT_T *root,
-			 void (*op)(ERTS_RBT_T *, void *),
+			 ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 			 void *arg)
 {
     (void) ERTS_RBT_FUNC__(foreach_unordered__)(&root, 0, op, arg,
@@ -1544,7 +1611,7 @@ ERTS_RBT_FUNC__(foreach)(ERTS_RBT_T *root,
 
 static ERTS_RBT_API_INLINE__ void
 ERTS_RBT_FUNC__(foreach_small)(ERTS_RBT_T *root,
-			       void (*op)(ERTS_RBT_T *, void *),
+			       ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 			       void *arg)
 {
     (void) ERTS_RBT_FUNC__(foreach_ordered__)(&root, 1, 0,
@@ -1558,7 +1625,7 @@ ERTS_RBT_FUNC__(foreach_small)(ERTS_RBT_T *root,
 
 static ERTS_RBT_API_INLINE__ void
 ERTS_RBT_FUNC__(foreach_large)(ERTS_RBT_T *root,
-			       void (*op)(ERTS_RBT_T *, void *),
+			       ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 			       void *arg)
 {
     (void) ERTS_RBT_FUNC__(foreach_ordered__)(&root, 0, 0,
@@ -1572,13 +1639,13 @@ ERTS_RBT_FUNC__(foreach_large)(ERTS_RBT_T *root,
 
 static ERTS_RBT_API_INLINE__ int
 ERTS_RBT_FUNC__(foreach_yielding)(ERTS_RBT_T *root,
-				  void (*op)(ERTS_RBT_T *, void *),
+				  ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 				  void *arg,
 				  ERTS_RBT_YIELD_STATE_T__ *ystate,
-				  Sint ylimit)
+				  Sint reds)
 {
     return ERTS_RBT_FUNC__(foreach_unordered__)(&root, 0, op, arg,
-						1, ystate, ylimit);
+						1, ystate, reds);
 }
 
 #endif /* ERTS_RBT_WANT_FOREACH_YIELDING */
@@ -1587,14 +1654,14 @@ ERTS_RBT_FUNC__(foreach_yielding)(ERTS_RBT_T *root,
 
 static ERTS_RBT_API_INLINE__ int
 ERTS_RBT_FUNC__(foreach_small_yielding)(ERTS_RBT_T *root,
-					void (*op)(ERTS_RBT_T *, void *),
+					ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 					void *arg,
 					ERTS_RBT_YIELD_STATE_T__ *ystate,
-					Sint ylimit)
+					Sint reds)
 {
     return ERTS_RBT_FUNC__(foreach_ordered__)(&root, 1, 0,
 					      op, NULL, arg,
-					      1, ystate, ylimit);
+					      1, ystate, reds);
 }
 
 #endif /* ERTS_RBT_WANT_FOREACH_SMALL_YIELDING */
@@ -1603,14 +1670,14 @@ ERTS_RBT_FUNC__(foreach_small_yielding)(ERTS_RBT_T *root,
 
 static ERTS_RBT_API_INLINE__ int
 ERTS_RBT_FUNC__(foreach_large_yielding)(ERTS_RBT_T *root,
-					void (*op)(ERTS_RBT_T *, void *),
+					ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 					void *arg,
 					ERTS_RBT_YIELD_STATE_T__ *ystate,
-					Sint ylimit)
+					Sint reds)
 {
     return ERTS_RBT_FUNC__(foreach_ordered__)(&root, 0, 0,
 					      op, NULL, arg,
-					      1, ystate, ylimit);
+					      1, ystate, reds);
 }
 
 #endif /* ERTS_RBT_WANT_FOREACH_LARGE_YIELDING */
@@ -1619,11 +1686,11 @@ ERTS_RBT_FUNC__(foreach_large_yielding)(ERTS_RBT_T *root,
 
 static ERTS_RBT_API_INLINE__ void
 ERTS_RBT_FUNC__(foreach_destroy)(ERTS_RBT_T **root,
-				 void (*op)(ERTS_RBT_T *, void *),
+				 ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 				 void *arg)
 {
     (void) ERTS_RBT_FUNC__(foreach_unordered__)(root, 1, op, arg,
-						0, NULL, 0);
+                                                0, NULL, 0);
 }
 
 #endif /* ERTS_RBT_WANT_FOREACH_DESTROY */
@@ -1632,8 +1699,8 @@ ERTS_RBT_FUNC__(foreach_destroy)(ERTS_RBT_T **root,
 
 static ERTS_RBT_API_INLINE__ void
 ERTS_RBT_FUNC__(foreach_small_destroy)(ERTS_RBT_T **root,
-				       void (*op)(ERTS_RBT_T *, void *),
-				       void (*destr)(ERTS_RBT_T *, void *),
+				       ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
+				       ERTS_RBT_CALLBACK_FOREACH_FUNC(destr),
 				       void *arg)
 {
     (void) ERTS_RBT_FUNC__(foreach_ordered__)(root, 1, 1,
@@ -1647,8 +1714,8 @@ ERTS_RBT_FUNC__(foreach_small_destroy)(ERTS_RBT_T **root,
 
 static ERTS_RBT_API_INLINE__ void
 ERTS_RBT_FUNC__(foreach_large_destroy)(ERTS_RBT_T **root,
-				       void (*op)(ERTS_RBT_T *, void *),
-				       void (*destr)(ERTS_RBT_T *, void *),
+				       ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
+				       ERTS_RBT_CALLBACK_FOREACH_FUNC(destr),
 				       void *arg)
 {
     (void) ERTS_RBT_FUNC__(foreach_ordered__)(root, 0, 1,
@@ -1662,13 +1729,13 @@ ERTS_RBT_FUNC__(foreach_large_destroy)(ERTS_RBT_T **root,
 
 static ERTS_RBT_API_INLINE__ int
 ERTS_RBT_FUNC__(foreach_destroy_yielding)(ERTS_RBT_T **root,
-					  void (*op)(ERTS_RBT_T *, void *),
+					  ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
 					  void *arg,
 					  ERTS_RBT_YIELD_STATE_T__ *ystate,
-					  Sint ylimit)
+					  Sint reds)
 {
     return ERTS_RBT_FUNC__(foreach_unordered__)(root, 1, op, arg,
-						1, ystate, ylimit);
+						1, ystate, reds);
 }
 
 #endif /* ERTS_RBT_WANT_FOREACH_DESTROY_YIELDING */
@@ -1677,15 +1744,15 @@ ERTS_RBT_FUNC__(foreach_destroy_yielding)(ERTS_RBT_T **root,
 
 static ERTS_RBT_API_INLINE__ int
 ERTS_RBT_FUNC__(foreach_small_destroy_yielding)(ERTS_RBT_T **root,
-						void (*op)(ERTS_RBT_T *, void *),
-						void (*destr)(ERTS_RBT_T *, void *),
+						ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
+						ERTS_RBT_CALLBACK_FOREACH_FUNC(destr),
 						void *arg,
 						ERTS_RBT_YIELD_STATE_T__ *ystate,
-						Sint ylimit)
+						Sint reds)
 {
     return ERTS_RBT_FUNC__(foreach_ordered__)(root, 1, 1,
 					      op, destr, arg,
-					      1, ystate, ylimit);
+					      1, ystate, reds);
 }
 
 #endif /* ERTS_RBT_WANT_FOREACH_SMALL_DESTROY_YIELDING */
@@ -1694,15 +1761,15 @@ ERTS_RBT_FUNC__(foreach_small_destroy_yielding)(ERTS_RBT_T **root,
 
 static ERTS_RBT_API_INLINE__ int
 ERTS_RBT_FUNC__(foreach_large_destroy_yielding)(ERTS_RBT_T **root,
-						void (*op)(ERTS_RBT_T *, void *),
-						void (*destr)(ERTS_RBT_T *, void *),
+						ERTS_RBT_CALLBACK_FOREACH_FUNC(op),
+						ERTS_RBT_CALLBACK_FOREACH_FUNC(destr),
 						void *arg,
 						ERTS_RBT_YIELD_STATE_T__ *ystate,
-						Sint ylimit)
+						Sint reds)
 {
     return ERTS_RBT_FUNC__(foreach_ordered__)(root, 0, 1,
 					      op, destr, arg,
-					      1, ystate, ylimit);
+					      1, ystate, reds);
 }
 
 #endif /* ERTS_RBT_WANT_FOREACH_LARGE_DESTROY_YIELDING */
@@ -1855,6 +1922,7 @@ ERTS_RBT_FUNC__(hdbg_check_tree)(ERTS_RBT_T *root, ERTS_RBT_T *n)
 #ifdef ERTS_RBT_UNDEF
 #  undef ERTS_RBT_PREFIX
 #  undef ERTS_RBT_T
+#  undef ERTS_RBT_CALLBACK_FOREACH_FUNC
 #  undef ERTS_RBT_KEY_T
 #  undef ERTS_RBT_FLAGS_T
 #  undef ERTS_RBT_INIT_EMPTY_TNODE

--- a/erts/emulator/beam/erl_time_sup.c
+++ b/erts/emulator/beam/erl_time_sup.c
@@ -1911,8 +1911,8 @@ typedef struct {
     ErtsTimeOffsetMonitorInfo *to_mon_info;
 } ErtsTimeOffsetMonitorContext;
 
-static void
-save_time_offset_monitor(ErtsMonitor *mon, void *vcntxt)
+static int
+save_time_offset_monitor(ErtsMonitor *mon, void *vcntxt, Sint reds)
 {
     ErtsTimeOffsetMonitorContext *cntxt;
     ErtsMonitorData *mdp = erts_monitor_to_data(mon);
@@ -1935,7 +1935,7 @@ save_time_offset_monitor(ErtsMonitor *mon, void *vcntxt)
 
     cntxt->to_mon_info[mix].ref
 	= make_internal_ref(&cntxt->to_mon_info[mix].heap[0]);
-
+    return 1;
 }
 
 static void

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -262,19 +262,12 @@ erts_finalize_atom_cache_map(ErtsAtomCacheMap *acmp, Uint32 dflags)
     if (acmp) {
 	int long_atoms = 0; /* !0 if one or more atoms are longer than 255. */
 	int i;
-	int sz;
-	int fix_sz
-	    = 1 /* VERSION_MAGIC */
-	    + 1 /* DIST_HEADER */
-	    + 1 /* dist header flags */
-	    + 1 /* number of internal cache entries */
-	    ;
+	int sz = 0;
 	int min_sz;
         ASSERT(dflags & DFLAG_UTF8_ATOMS);
 	ASSERT(acmp->hdr_sz < 0);
 	/* Make sure cache update instructions fit */
-	min_sz = fix_sz+(2+4)*acmp->sz;
-	sz = fix_sz;
+	min_sz = (2+4)*acmp->sz;
 	for (i = 0; i < acmp->sz; i++) {
 	    Atom *a;
 	    Eterm atom;
@@ -302,17 +295,28 @@ erts_finalize_atom_cache_map(ErtsAtomCacheMap *acmp, Uint32 dflags)
 }
 
 Uint
-erts_encode_ext_dist_header_size(ErtsAtomCacheMap *acmp)
+erts_encode_ext_dist_header_size(ErtsAtomCacheMap *acmp, Uint fragments)
 {
     if (!acmp)
 	return 0;
     else {
+        int fix_sz
+            = 1 /* VERSION_MAGIC */
+            + 1 /* DIST_HEADER */
+            + 1 /* dist header flags */
+            + 1 /* number of internal cache entries */
+            ;
 	ASSERT(acmp->hdr_sz >= 0);
-	return acmp->hdr_sz;
+        if (fragments > 1)
+            fix_sz += 8 /* sequence id */
+                + 8 /* number of fragments */
+                ;
+        return fix_sz + acmp->hdr_sz;
     }
 }
 
-byte *erts_encode_ext_dist_header_setup(byte *ctl_ext, ErtsAtomCacheMap *acmp)
+byte *erts_encode_ext_dist_header_setup(byte *ctl_ext, ErtsAtomCacheMap *acmp,
+                                        Uint fragments, Eterm from)
 {
     /* Maximum number of atom must be less than the maximum of a 32 bits
        unsigned integer. Check is done in erl_init.c, erl_start function. */
@@ -346,10 +350,35 @@ byte *erts_encode_ext_dist_header_setup(byte *ctl_ext, ErtsAtomCacheMap *acmp)
 	put_int8(acmp->sz, ep);
 	--ep;
 	put_int8(dist_hdr_flags, ep);
-	*--ep = DIST_HEADER;
-	*--ep = VERSION_MAGIC;
+        if (fragments > 1) {
+            ASSERT(is_pid(from));
+            ep -= 8;
+            put_int64(fragments, ep);
+            ep -= 8;
+            put_int64(from, ep);
+            *--ep = DIST_FRAG_HEADER;
+        } else {
+            *--ep = DIST_HEADER;
+        }
+        *--ep = VERSION_MAGIC;
 	return ep;
     }
+}
+
+byte *erts_encode_ext_dist_header_fragment(byte **hdrpp,
+                                           Uint fragment,
+                                           Eterm from)
+{
+    byte *ep = *hdrpp, *start = ep;
+    ASSERT(is_pid(from));
+    *ep++ = VERSION_MAGIC;
+    *ep++ = DIST_FRAG_CONT;
+    put_int64(from, ep);
+    ep += 8;
+    put_int64(fragment, ep);
+    ep += 8;
+    *hdrpp = ep;
+    return start;
 }
 
 
@@ -365,7 +394,8 @@ Sint erts_encode_ext_dist_header_finalize(ErtsDistOutputBuf* ob,
     int ci, sz;
     byte dist_hdr_flags;
     int long_atoms;
-    register byte *ep = ob->extp;
+    Uint64 seq_id = 0, frag_id = 0;
+    register byte *ep = ob->hdrp ? ob->hdrp : ob->extp;
     ASSERT(dflags & DFLAG_UTF8_ATOMS);
 
     /*
@@ -416,12 +446,23 @@ Sint erts_encode_ext_dist_header_finalize(ErtsDistOutputBuf* ob,
         }
         goto done;
     }
-    else if (ep[1] != DIST_HEADER) {
+    else if (ep[1] != DIST_HEADER && ep[1] != DIST_FRAG_HEADER && ep[1] != DIST_FRAG_CONT) {
         ASSERT(ep[1] == SMALL_TUPLE_EXT || ep[1] == LARGE_TUPLE_EXT);
         ASSERT(!(dflags & DFLAG_DIST_HDR_ATOM_CACHE));
         /* Node without atom cache, 'pass through' needed */
         *--ep = PASS_THROUGH;
         goto done;
+    }
+
+    if (ep[1] == DIST_FRAG_CONT) {
+        ep = ob->extp;
+        goto done;
+    } else if (ep[1] == DIST_FRAG_HEADER) {
+        /* skip the seq id and frag id */
+        seq_id = get_int64(&ep[2]);
+        ep += 8;
+        frag_id = get_int64(&ep[2]);
+        ep += 8;
     }
 
     dist_hdr_flags = ep[2];
@@ -546,11 +587,19 @@ Sint erts_encode_ext_dist_header_finalize(ErtsDistOutputBuf* ob,
     }
     --ep;
     put_int8(ci, ep);
-    *--ep = DIST_HEADER;
+    if (seq_id) {
+        ep -= 8;
+        put_int64(frag_id, ep);
+        ep -= 8;
+        put_int64(seq_id, ep);
+        *--ep = DIST_FRAG_HEADER;
+    } else {
+        *--ep = DIST_HEADER;
+    }
     *--ep = VERSION_MAGIC;
 done:
     ob->extp = ep;
-    ASSERT(&ob->data[0] <= ob->extp && ob->extp < ob->ext_endp);
+    ASSERT((byte*)ob->bin->orig_bytes <= ob->extp && ob->extp < ob->ext_endp);
     return reds < 0 ? 0 : reds;
 }
 
@@ -635,72 +684,90 @@ byte* erts_encode_ext_ets(Eterm term, byte *ep, struct erl_off_heap_header** off
 		    off_heap);
 }
 
-ErtsDistExternal *
-erts_make_dist_ext_copy(ErtsDistExternal *edep, Eterm *token)
+
+static Uint
+dist_ext_size(ErtsDistExternal *edep)
 {
-    size_t align_sz;
-    size_t dist_ext_sz;
-    size_t ext_sz = 0;
-    size_t token_sz = 0;
-    Eterm token_size;
+    Uint sz = sizeof(ErtsDistExternal);
+
+    ASSERT(edep->data->ext_endp && edep->data->extp);
+    ASSERT(edep->data->ext_endp >= edep->data->extp);
+
+    if (edep->flags & ERTS_DIST_EXT_ATOM_TRANS_TAB) {
+        ASSERT(0 <= edep->attab.size \
+               && edep->attab.size <= ERTS_ATOM_CACHE_SIZE);
+        sz -= sizeof(Eterm)*(ERTS_ATOM_CACHE_SIZE - edep->attab.size);
+    } else {
+        sz -= sizeof(ErtsAtomTranslationTable);
+    }
+    return sz;
+}
+
+Uint
+erts_dist_ext_size(ErtsDistExternal *edep)
+{
+    Uint sz = dist_ext_size(edep);
+    sz += edep->data[0].frag_id * sizeof(ErtsDistExternalData);
+    return sz + ERTS_EXTRA_DATA_ALIGN_SZ(sz);
+}
+
+Uint
+erts_dist_ext_data_size(ErtsDistExternal *edep)
+{
+    Uint sz = 0, i;
+    for (i = 0; i < edep->data->frag_id; i++)
+        sz += edep->data[i].ext_endp - edep->data[i].extp;
+    return sz;
+}
+
+void
+erts_dist_ext_frag(ErtsDistExternalData *ede_datap, ErtsDistExternal *edep)
+{
+    ErtsDistExternalData *new_ede_datap = &edep->data[edep->data->frag_id - ede_datap->frag_id];
+    sys_memcpy(new_ede_datap, ede_datap, sizeof(ErtsDistExternalData));
+
+    /* If the data is not backed by a binary, we create one here to keep
+       things simple. Only custom distribution drivers should use lists. */
+    if (new_ede_datap->binp == NULL) {
+        size_t ext_sz = ede_datap->ext_endp - ede_datap->extp;
+        new_ede_datap->binp = erts_bin_nrml_alloc(ext_sz);
+        sys_memcpy(new_ede_datap->binp->orig_bytes, (void *) ede_datap->extp, ext_sz);
+        new_ede_datap->extp = (byte*)new_ede_datap->binp->orig_bytes;
+        new_ede_datap->ext_endp = (byte*)new_ede_datap->binp->orig_bytes + ext_sz;
+    } else {
+        erts_refc_inc(&new_ede_datap->binp->intern.refc, 2);
+    }
+}
+
+void
+erts_make_dist_ext_copy(ErtsDistExternal *edep, ErtsDistExternal *new_edep)
+{
+    size_t dist_ext_sz = dist_ext_size(edep);
     byte *ep;
-    ErtsDistExternal *new_edep;
-
-    dist_ext_sz = ERTS_DIST_EXT_SIZE(edep);
-    ASSERT(edep->ext_endp && edep->extp);
-    ASSERT(edep->ext_endp >= edep->extp);
-    if (edep->binp == NULL)
-        ext_sz = edep->ext_endp - edep->extp;
-
-    align_sz = ERTS_EXTRA_DATA_ALIGN_SZ(dist_ext_sz + ext_sz);
-
-    token_size = size_object(*token);
-    if (token_size)
-        token_sz = ERTS_HEAP_FRAG_SIZE(token_size);
-
-    new_edep = erts_alloc(ERTS_ALC_T_EXT_TERM_DATA,
-			  dist_ext_sz + ext_sz + align_sz + token_sz);
 
     ep = (byte *) new_edep;
     sys_memcpy((void *) ep, (void *) edep, dist_ext_sz);
-    if (new_edep->dep)
-        erts_ref_dist_entry(new_edep->dep);
-    new_edep->heap_size = -1;
+    erts_ref_dist_entry(new_edep->dep);
 
-    if (ext_sz) {
-        ep += dist_ext_sz;
-        new_edep->extp = ep;
-        new_edep->ext_endp = ep + ext_sz;
-        sys_memcpy((void *) ep, (void *) edep->extp, ext_sz);
-    } else {
-        erts_refc_inc(&new_edep->binp->intern.refc, 2);
-    }
+    ep += dist_ext_sz;
 
-    /* Copy the seq_trace token */
-    if (is_not_nil(*token)) {
-        ErlHeapFragment *heap_frag;
-        ErlOffHeap *ohp;
-        Eterm *hp;
-        heap_frag = erts_dist_ext_trailer(new_edep);
-        ERTS_INIT_HEAP_FRAG(heap_frag, token_size, token_size);
-        hp = heap_frag->mem;
-        ohp = &heap_frag->off_heap;
-        *token = copy_struct(*token, token_size, &hp, ohp);
-    }
-    return new_edep;
+    new_edep->data = (ErtsDistExternalData*)ep;
+    sys_memzero(new_edep->data, sizeof(ErtsDistExternalData) * edep->data->frag_id);
+    new_edep->data->frag_id = edep->data->frag_id;
+    erts_dist_ext_frag(edep->data, new_edep);
 }
 
 void
 erts_free_dist_ext_copy(ErtsDistExternal *edep)
 {
-    if (edep->dep)
-	erts_deref_dist_entry(edep->dep);
-    if (edep->binp)
-        erts_bin_release(edep->binp);
-    erts_free(ERTS_ALC_T_EXT_TERM_DATA, edep);
+    int i;
+    erts_deref_dist_entry(edep->dep);
+    for (i = 0; i < edep->data->frag_id; i++)
+        if (edep->data[i].binp)
+            erts_bin_release(edep->data[i].binp);
 }
 
-int
+ErtsPrepDistExtRes
 erts_prepare_dist_ext(ErtsDistExternal *edep,
 		      byte *ext,
 		      Uint size,
@@ -710,10 +777,6 @@ erts_prepare_dist_ext(ErtsDistExternal *edep,
 		      ErtsAtomCache *cache)
 {
     register byte *ep;
-
-    edep->heap_size = -1;
-    edep->flags = 0;
-    edep->dep = dep;
 
     ASSERT(dep);
     erts_de_rlock(dep);
@@ -734,10 +797,6 @@ erts_prepare_dist_ext(ErtsDistExternal *edep,
         size--;
     }
 
-    edep->heap_size = -1;
-    edep->ext_endp = ext + size;
-    edep->binp = binp;
-
     ep = ext;
 
     if (size < 2)
@@ -753,16 +812,33 @@ erts_prepare_dist_ext(ErtsDistExternal *edep,
 	goto fail;
     }
 
+    edep->heap_size = -1;
+    edep->flags = 0;
+    edep->dep = dep;
+    edep->connection_id = conn_id;
+    edep->data->ext_endp = ext+size;
+    edep->data->binp = binp;
+    edep->data->seq_id = 0;
+    edep->data->frag_id = 1;
+
     if (dep->flags & DFLAG_DIST_HDR_ATOM_CACHE)
         edep->flags |= ERTS_DIST_EXT_DFLAG_HDR;
 
-    edep->connection_id = dep->connection_id;
-
-    if (ep[1] != DIST_HEADER) {
+    if (ep[1] != DIST_HEADER && ep[1] != DIST_FRAG_HEADER && ep[1] != DIST_FRAG_CONT) {
 	if (edep->flags & ERTS_DIST_EXT_DFLAG_HDR)
 	    goto bad_hdr;
 	edep->attab.size = 0;
-	edep->extp = ext;
+	edep->data->extp = ext;
+    }
+    else if (ep[1] == DIST_FRAG_CONT) {
+        if (!(dep->flags & DFLAG_FRAGMENTS))
+            goto bad_hdr;
+        edep->attab.size = 0;
+	edep->data->extp = ext + 1 + 1 + 8 + 8;
+        edep->data->seq_id = get_int64(&ep[2]);
+        edep->data->frag_id = get_int64(&ep[2+8]);
+        erts_de_runlock(dep);
+        return ERTS_PREP_DIST_EXT_FRAG_CONT;
     }
     else {
 	int tix;
@@ -771,9 +847,17 @@ erts_prepare_dist_ext(ErtsDistExternal *edep,
 	if (!(edep->flags & ERTS_DIST_EXT_DFLAG_HDR))
 	    goto bad_hdr;
 
+        if (ep[1] == DIST_FRAG_HEADER) {
+            if (!(dep->flags & DFLAG_FRAGMENTS))
+                goto bad_hdr;
+            edep->data->seq_id = get_int64(&ep[2]);
+            edep->data->frag_id = get_int64(&ep[2+8]);
+            ep += 16;
+        }
+
 #undef CHKSIZE
 #define CHKSIZE(SZ) \
-	do { if ((SZ) > edep->ext_endp - ep) goto bad_hdr; } while(0)
+	do { if ((SZ) > edep->data->ext_endp - ep) goto bad_hdr; } while(0)
 
 	CHKSIZE(1+1+1);
 	ep += 2;
@@ -903,7 +987,7 @@ erts_prepare_dist_ext(ErtsDistExternal *edep,
 #endif
 	    }
 	}
-	edep->extp = ep;
+	edep->data->extp = ep;
 #ifdef ERTS_DEBUG_USE_DIST_SEP
 	if (*ep != VERSION_MAGIC)
 	    goto bad_hdr;
@@ -928,7 +1012,7 @@ erts_prepare_dist_ext(ErtsDistExternal *edep,
 		      erts_this_node->sysname,
 		      edep->dep->sysname,
 		      dist_entry_channel_no(edep->dep));
-	for (ep = ext; ep < edep->ext_endp; ep++)
+	for (ep = ext; ep < edep->data->ext_endp; ep++)
 	    erts_dsprintf(dsbufp, ep != ext ? ",%b8u" : "<<%b8u", *ep);
 	erts_dsprintf(dsbufp, ">>");
 	erts_send_warning_to_logger_nogl(dsbufp);
@@ -953,9 +1037,9 @@ bad_dist_ext(ErtsDistExternal *edep)
 		      erts_this_node->sysname,
 		      dep->sysname,
 		      dist_entry_channel_no(dep));
-	for (ep = edep->extp; ep < edep->ext_endp; ep++)
+	for (ep = edep->data->extp; ep < edep->data->ext_endp; ep++)
 	    erts_dsprintf(dsbufp,
-			  ep != edep->extp ? ",%b8u" : "<<...,%b8u",
+			  ep != edep->data->extp ? ",%b8u" : "<<...,%b8u",
 			  *ep);
 	erts_dsprintf(dsbufp, ">>\n");
 	erts_dsprintf(dsbufp, "ATOM_CACHE_REF translations: ");
@@ -973,30 +1057,32 @@ bad_dist_ext(ErtsDistExternal *edep)
 }
 
 Sint
-erts_decode_dist_ext_size(ErtsDistExternal *edep)
+erts_decode_dist_ext_size(ErtsDistExternal *edep, int kill_connection)
 {
     Sint res;
     byte *ep;
-    if (edep->extp >= edep->ext_endp)
+
+    if (edep->data->extp >= edep->data->ext_endp)
 	goto fail;
 #ifndef ERTS_DEBUG_USE_DIST_SEP
     if (edep->flags & ERTS_DIST_EXT_DFLAG_HDR) {
-	if (*edep->extp == VERSION_MAGIC)
+	if (*edep->data->extp == VERSION_MAGIC)
 	    goto fail;
-	ep = edep->extp;
+	ep = edep->data->extp;
     }
     else
 #endif
     {
-	if (*edep->extp != VERSION_MAGIC)
+	if (*edep->data->extp != VERSION_MAGIC)
 	    goto fail;
-	ep = edep->extp+1;
+	ep = edep->data->extp+1;
     }
-    res = decoded_size(ep, edep->ext_endp, 0, NULL);
+    res = decoded_size(ep, edep->data->ext_endp, 0, NULL);
     if (res >= 0)
 	return res;
  fail:
-    bad_dist_ext(edep);
+    if (kill_connection)
+        bad_dist_ext(edep);
     return -1;
 }
 
@@ -1022,12 +1108,15 @@ Sint erts_decode_ext_size_ets(byte *ext, Uint size)
 */
 Eterm
 erts_decode_dist_ext(ErtsHeapFactory* factory,
-		     ErtsDistExternal *edep)
+		     ErtsDistExternal *edep,
+                     int kill_connection)
 {
     Eterm obj;
-    byte* ep = edep->extp;
+    byte* ep;
 
-    if (ep >= edep->ext_endp)
+    ep = edep->data->extp;
+
+    if (ep >= edep->data->ext_endp)
 	goto error;
 #ifndef ERTS_DEBUG_USE_DIST_SEP
     if (edep->flags & ERTS_DIST_EXT_DFLAG_HDR) {
@@ -1045,14 +1134,15 @@ erts_decode_dist_ext(ErtsHeapFactory* factory,
     if (!ep)
 	goto error;
 
-    edep->extp = ep;
+    edep->data->extp = ep;
 
     return obj;
 
  error:
     erts_factory_undo(factory);
 
-    bad_dist_ext(edep);
+    if (kill_connection)
+        bad_dist_ext(edep);
 
     return THE_NON_VALUE;
 }
@@ -1097,6 +1187,7 @@ BIF_RETTYPE erts_debug_dist_ext_to_term_2(BIF_ALIST_2)
     Eterm res;
     Sint hsz;
     ErtsDistExternal ede;
+    ErtsDistExternalData ede_data;
     Eterm *tp;
     Eterm real_bin;
     Uint offset;
@@ -1109,7 +1200,8 @@ BIF_RETTYPE erts_debug_dist_ext_to_term_2(BIF_ALIST_2)
     ede.flags = ERTS_DIST_EXT_ATOM_TRANS_TAB;
     ede.dep = NULL;
     ede.heap_size = -1;
-    
+    ede.data = &ede_data;
+
     if (is_not_tuple(BIF_ARG_1))
 	goto badarg;
     tp = tuple_val(BIF_ARG_1);
@@ -1134,15 +1226,15 @@ BIF_RETTYPE erts_debug_dist_ext_to_term_2(BIF_ALIST_2)
     if (bitsize != 0)
 	goto badarg;
 
-    ede.extp = binary_bytes(real_bin)+offset;
-    ede.ext_endp = ede.extp + size;
+    ede.data->extp = binary_bytes(real_bin)+offset;
+    ede.data->ext_endp = ede.data->extp + size;
 
-    hsz = erts_decode_dist_ext_size(&ede);
+    hsz = erts_decode_dist_ext_size(&ede, 1);
     if (hsz < 0)
 	goto badarg;
 
     erts_factory_proc_prealloc_init(&factory, BIF_P, hsz);
-    res = erts_decode_dist_ext(&factory, &ede);
+    res = erts_decode_dist_ext(&factory, &ede, 1);
     erts_factory_close(&factory);
 
     if (is_value(res))

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -620,7 +620,7 @@ int erts_encode_dist_ext_size(Eterm term, Uint32 flags, ErtsAtomCacheMap *acmp,
     }
 }
 
-int erts_encode_dist_ext_size_int(Eterm term, struct erts_dsig_send_context* ctx, Uint* szp)
+int erts_encode_dist_ext_size_int(Eterm term, ErtsDSigSendContext *ctx, Uint* szp)
 {
     Uint sz;
     if (encode_size_struct_int(&ctx->u.sc, ctx->acmp, term, ctx->flags, &ctx->reds, &sz)) {

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -2480,7 +2480,7 @@ dec_atom(ErtsDistExternal *edep, byte* ep, Eterm* objp)
     return ep;
 }
 
-static ERTS_INLINE ErlNode* dec_get_node(Eterm sysname, Uint32 creation)
+static ERTS_INLINE ErlNode* dec_get_node(Eterm sysname, Uint32 creation, Eterm book)
 {
     if (sysname == INTERNAL_LOCAL_SYSNAME)  /* && DFLAG_INTERNAL_TAGS */
 	return erts_this_node;
@@ -2489,7 +2489,7 @@ static ERTS_INLINE ErlNode* dec_get_node(Eterm sysname, Uint32 creation)
 	&& (creation == erts_this_node->creation || creation == ORIG_CREATION))
 	return erts_this_node;
 
-    return erts_find_or_insert_node(sysname,creation);
+    return erts_find_or_insert_node(sysname,creation,book);
 }
 
 static byte*
@@ -2535,7 +2535,7 @@ dec_pid(ErtsDistExternal *edep, ErtsHeapFactory* factory, byte* ep,
      * We are careful to create the node entry only after all
      * validity tests are done.
      */
-    node = dec_get_node(sysname, cre);
+    node = dec_get_node(sysname, cre, make_boxed(factory->hp));
 
     if(node == erts_this_node) {
 	*objp = make_internal_pid(data);
@@ -3529,7 +3529,7 @@ dec_term_atom_common:
                     cre = get_int32(ep);
                     ep += 4;
                 }
-		node = dec_get_node(sysname, cre);
+		node = dec_get_node(sysname, cre, make_boxed(hp));
 		if(node == erts_this_node) {
 		    *objp = make_internal_port(num);
 		}
@@ -3609,7 +3609,7 @@ dec_term_atom_common:
 		if (ref_words > ERTS_MAX_REF_NUMBERS)
 		    goto error;
 
-		node = dec_get_node(sysname, cre);
+		node = dec_get_node(sysname, cre, make_boxed(hp));
 		if(node == erts_this_node) {
 	
 		    rtp = (ErtsORefThing *) hp;

--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -122,10 +122,13 @@ typedef struct {
 
 #define ERTS_DIST_CON_ID_MASK ((Uint32) 0x00ffffff) /* also in net_kernel.erl */
 
-typedef struct {
+struct binary;
+
+typedef struct erl_dist_external {
     DistEntry *dep;
     byte *extp;
     byte *ext_endp;
+    struct binary *binp;
     Sint heap_size;
     Uint32 connection_id;
     Uint32 flags;
@@ -171,7 +174,7 @@ Uint erts_encode_ext_size_ets(Eterm);
 void erts_encode_ext(Eterm, byte **);
 byte* erts_encode_ext_ets(Eterm, byte *, struct erl_off_heap_header** ext_off_heap);
 
-ERTS_GLB_INLINE void erts_free_dist_ext_copy(ErtsDistExternal *);
+void erts_free_dist_ext_copy(ErtsDistExternal *);
 ERTS_GLB_INLINE void *erts_dist_ext_trailer(ErtsDistExternal *);
 ErtsDistExternal *erts_make_dist_ext_copy(ErtsDistExternal *, Uint);
 void *erts_dist_ext_trailer(ErtsDistExternal *);
@@ -181,8 +184,8 @@ void erts_destroy_dist_ext_copy(ErtsDistExternal *);
 #define ERTS_PREP_DIST_EXT_SUCCESS      (0)
 #define ERTS_PREP_DIST_EXT_CLOSED       (1)
 
-int erts_prepare_dist_ext(ErtsDistExternal *, byte *, Uint,
-			  DistEntry *, Uint32 conn_id, ErtsAtomCache *);
+int erts_prepare_dist_ext(ErtsDistExternal *, byte *, Uint, struct binary *,
+			  DistEntry *, Uint32, ErtsAtomCache *);
 Sint erts_decode_dist_ext_size(ErtsDistExternal *);
 Eterm erts_decode_dist_ext(ErtsHeapFactory* factory, ErtsDistExternal *);
 
@@ -201,14 +204,6 @@ int erts_debug_atom_to_out_cache_index(Eterm);
 void transcode_free_ctx(DistEntry* dep);
 
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
-
-ERTS_GLB_INLINE void
-erts_free_dist_ext_copy(ErtsDistExternal *edep)
-{
-    if (edep->dep)
-	erts_deref_dist_entry(edep->dep);
-    erts_free(ERTS_ALC_T_EXT_TERM_DATA, edep);
-}
 
 ERTS_GLB_INLINE void *
 erts_dist_ext_trailer(ErtsDistExternal *edep)

--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -176,7 +176,7 @@ byte* erts_encode_ext_ets(Eterm, byte *, struct erl_off_heap_header** ext_off_he
 
 void erts_free_dist_ext_copy(ErtsDistExternal *);
 ERTS_GLB_INLINE void *erts_dist_ext_trailer(ErtsDistExternal *);
-ErtsDistExternal *erts_make_dist_ext_copy(ErtsDistExternal *, Uint);
+ErtsDistExternal *erts_make_dist_ext_copy(ErtsDistExternal *, Eterm *);
 void *erts_dist_ext_trailer(ErtsDistExternal *);
 void erts_destroy_dist_ext_copy(ErtsDistExternal *);
 

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1093,7 +1093,7 @@ extern int distribution_info(fmtfn_t, void *);
 extern int is_node_name_atom(Eterm a);
 
 extern int erts_net_message(Port *, DistEntry *, Uint32 conn_id,
-			    byte *, ErlDrvSizeT, byte *, ErlDrvSizeT);
+			    byte *, ErlDrvSizeT, Binary *, byte *, ErlDrvSizeT);
 
 extern void init_dist(void);
 extern int stop_dist(void);

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -5104,7 +5104,7 @@ erts_port_resume_procs(Port *prt)
 
 	    erts_snprintf(port_str, sizeof(DTRACE_CHARBUF_NAME(port_str)), "%T", prt->common.id);
 	    while (plp2 != NULL) {
-		erts_snprintf(pid_str, sizeof(DTRACE_CHARBUF_NAME(pid_str)), "%T", plp2->pid);
+		erts_snprintf(pid_str, sizeof(DTRACE_CHARBUF_NAME(pid_str)), "%T", plp2->u.pid);
 		DTRACE2(process_port_unblocked, pid_str, port_str);
 	    }
 	}

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -6181,6 +6181,7 @@ int driver_output_binary(ErlDrvPort ix, char* hbuf, ErlDrvSizeT hlen,
 				dep,
                                 conn_id,
 				(byte*) hbuf, hlen,
+                                ErlDrvBinary2Binary(bin),
 				(byte*) (bin->orig_bytes+offs), len);
     }
     else
@@ -6226,12 +6227,14 @@ int driver_output2(ErlDrvPort ix, char* hbuf, ErlDrvSizeT hlen,
 				    dep,
                                     conn_id,
 				    NULL, 0,
+                                    NULL,
 				    (byte*) hbuf, hlen);
 	else
 	    return erts_net_message(prt,
 				    dep,
                                     conn_id,
 				    (byte*) hbuf, hlen,
+                                    NULL,
 				    (byte*) buf, len);
     }
     else if (state & ERTS_PORT_SFLG_LINEBUF_IO)

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -3644,20 +3644,22 @@ typedef struct {
     Eterm reason;
 } ErtsPortExitContext;
 
-static void link_port_exit(ErtsLink *lnk, void *vpectxt)
+static int link_port_exit(ErtsLink *lnk, void *vpectxt, Sint reds)
 {
     ErtsPortExitContext *pectxt = vpectxt;
     erts_proc_sig_send_link_exit(NULL, pectxt->port_id,
                                  lnk, pectxt->reason, NIL);
+    return 1;
 }
 
-static void monitor_port_exit(ErtsMonitor *mon, void *vpectxt)
+static int monitor_port_exit(ErtsMonitor *mon, void *vpectxt, Sint reds)
 {
     ErtsPortExitContext *pectxt = vpectxt;
     if (erts_monitor_is_target(mon))
         erts_proc_sig_send_monitor_down(mon, pectxt->reason);
     else
         erts_proc_sig_send_demonitor(mon);
+    return 1;
 }
 
 /* 'from' is sending 'this_port' an exit signal, (this_port must be internal).
@@ -4836,7 +4838,7 @@ typedef struct {
     void *arg;
 } prt_one_lnk_data;
 
-static void prt_one_monitor(ErtsMonitor *mon, void *vprtd)
+static int prt_one_monitor(ErtsMonitor *mon, void *vprtd, Sint reds)
 {
     ErtsMonitorData *mdp = erts_monitor_to_data(mon);
     prt_one_lnk_data *prtd = (prt_one_lnk_data *) vprtd;
@@ -4844,12 +4846,14 @@ static void prt_one_monitor(ErtsMonitor *mon, void *vprtd)
         erts_print(prtd->to, prtd->arg, "(%p,%T)", mon->other.ptr, mdp->ref);
     else
         erts_print(prtd->to, prtd->arg, "(%T,%T)", mon->other.item, mdp->ref);
+    return 1;
 }
 
-static void prt_one_lnk(ErtsLink *lnk, void *vprtd)
+static int prt_one_lnk(ErtsLink *lnk, void *vprtd, Sint reds)
 {
     prt_one_lnk_data *prtd = (prt_one_lnk_data *) vprtd;
     erts_print(prtd->to, prtd->arg, "%T", lnk->other.item);
+    return 1;
 }
 
 static void dump_port_state(fmtfn_t to, void *arg, erts_aint32_t state)

--- a/erts/emulator/beam/msg_instrs.tab
+++ b/erts/emulator/beam/msg_instrs.tab
@@ -137,8 +137,8 @@ i_loop_rec(Dest) {
 
     if (ERTS_UNLIKELY(ERTS_SIG_IS_EXTERNAL_MSG(msgp))) {
         FCALLS -= 10; /* FIXME: bump appropriate amount... */
-        SWAPOUT; /* erts_decode_dist_message() may write to heap... */
-        if (!erts_decode_dist_message(c_p, ERTS_PROC_LOCK_MAIN, msgp, 0)) {
+        SWAPOUT; /* erts_proc_sig_decode_dist() may write to heap... */
+        if (!erts_proc_sig_decode_dist(c_p, ERTS_PROC_LOCK_MAIN, msgp, 0)) {
             /*
              * A corrupt distribution message that we weren't able to decode;
              * remove it...

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -3486,7 +3486,7 @@ store_external_or_ref_(Uint **hpp, ErlOffHeap* oh, Eterm ns)
     if (is_external_header(*from_hp)) {
 	ExternalThing *etp = (ExternalThing *) from_hp;
 	ASSERT(is_external(ns));
-	erts_refc_inc(&etp->node->refc, 2);
+        erts_ref_node_entry(etp->node, 2, make_boxed(to_hp));
     }
     else if (is_ordinary_ref_thing(from_hp))
 	return make_internal_ref(to_hp);

--- a/erts/emulator/hipe/hipe_native_bif.c
+++ b/erts/emulator/hipe/hipe_native_bif.c
@@ -579,7 +579,7 @@ Eterm hipe_check_get_msg(Process *c_p)
 
     if (ERTS_SIG_IS_EXTERNAL_MSG(msgp)) {
         /* FIXME: bump appropriate amount... */
-        if (!erts_decode_dist_message(c_p, ERTS_PROC_LOCK_MAIN, msgp, 0)) {
+        if (!erts_proc_sig_decode_dist(c_p, ERTS_PROC_LOCK_MAIN, msgp, 0)) {
             /*
              * A corrupt distribution message that we weren't able to decode;
              * remove it...

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -44,7 +44,7 @@
 #include "erl_time.h"
 
 #if 0
-#define DEBUG_PRINT(FMT, ...) erts_printf(FMT "\r\n", ##__VA_ARGS__)
+#define DEBUG_PRINT(FMT, ...) do { erts_printf(FMT "\r\n", ##__VA_ARGS__); fflush(stdout); } while(0)
 #define DEBUG_PRINT_FD(FMT, STATE, ...)                                 \
     DEBUG_PRINT("%d: " FMT " (ev=%s, ac=%s, flg=%s)",                   \
                 (STATE) ? (STATE)->fd : (ErtsSysFdType)-1, ##__VA_ARGS__, \

--- a/erts/emulator/test/distribution_SUITE.erl
+++ b/erts/emulator/test/distribution_SUITE.erl
@@ -62,7 +62,8 @@
          bad_dist_ext_control/1,
          bad_dist_ext_connection_id/1,
          bad_dist_ext_size/1,
-	 start_epmd_false/1, epmd_module/1]).
+	 start_epmd_false/1, epmd_module/1,
+         bad_dist_fragments/1]).
 
 %% Internal exports.
 -export([sender/3, receiver2/2, dummy_waiter/0, dead_process/0,
@@ -90,7 +91,7 @@ all() ->
      dist_parallel_send, atom_roundtrip, unicode_atom_roundtrip,
      atom_roundtrip_r16b,
      contended_atom_cache_entry, contended_unicode_atom_cache_entry,
-     bad_dist_structure, {group, bad_dist_ext},
+     {group, bad_dist}, {group, bad_dist_ext},
      start_epmd_false, epmd_module].
 
 groups() ->
@@ -100,6 +101,8 @@ groups() ->
      {trap_bif, [], [trap_bif_1, trap_bif_2, trap_bif_3]},
      {dist_auto_connect, [],
       [dist_auto_connect_never, dist_auto_connect_once]},
+     {bad_dist, [],
+      [bad_dist_structure, bad_dist_fragments]},
      {bad_dist_ext, [],
       [bad_dist_ext_receive, bad_dist_ext_process_info,
        bad_dist_ext_size,
@@ -1382,6 +1385,15 @@ get_conflicting_unicode_atoms(CIX, N) ->
 -define(DOP_DEMONITOR_P,	20).
 -define(DOP_MONITOR_P_EXIT,	21).
 
+-define(DOP_SEND_SENDER, 22).
+-define(DOP_SEND_SENDER_TT, 23).
+
+-define(DOP_PAYLOAD_EXIT, 24).
+-define(DOP_PAYLOAD_EXIT_TT, 25).
+-define(DOP_PAYLOAD_EXIT2, 26).
+-define(DOP_PAYLOAD_EXIT2_TT, 27).
+-define(DOP_PAYLOAD_MONITOR_P_EXIT, 28).
+
 start_monitor(Offender,P) ->
     Parent = self(),
     Q = spawn(Offender,
@@ -1515,7 +1527,145 @@ bad_dist_structure(Config) when is_list(Config) ->
     stop_node(Victim),
     ok.
 
+%% Test various dist fragmentation errors
+bad_dist_fragments(Config) when is_list(Config) ->
+    ct:timetrap({seconds, 15}),
 
+    {ok, Offender} = start_node(bad_dist_fragment_offender),
+    {ok, Victim} = start_node(bad_dist_fragment_victim),
+
+    Msg = iolist_to_binary(dmsg_ext(lists:duplicate(255,255))),
+
+    start_node_monitors([Offender,Victim]),
+    Parent = self(),
+    P = spawn(Victim,
+              fun () ->
+                      process_flag(trap_exit,true),
+                      Parent ! {self(), started},
+                      receive check_msgs -> ok end,
+                      bad_dist_struct_check_msgs([one,
+                                                  two]),
+                      Parent ! {self(), messages_checked},
+                      receive done -> ok end
+              end),
+    receive {P, started} -> ok end,
+    pong = rpc:call(Victim, net_adm, ping, [Offender]),
+    verify_up(Offender, Victim),
+    true = lists:member(Offender, rpc:call(Victim, erlang, nodes, [])),
+    start_monitor(Offender,P),
+    P ! one,
+
+    start_monitor(Offender,P),
+    send_bad_fragments(Offender, Victim, P,{?DOP_SEND,?COOKIE,P},3,
+                      [{frg, 1, binary:part(Msg, 10,byte_size(Msg)-10)}]),
+
+    start_monitor(Offender,P),
+    send_bad_fragments(Offender, Victim, P,{?DOP_SEND,?COOKIE,P},3,
+                      [{hdr, 3, binary:part(Msg, 0,10)},
+                       {frg, 1, binary:part(Msg, 10,byte_size(Msg)-10)}]),
+
+    start_monitor(Offender,P),
+    send_bad_fragments(Offender, Victim, P,{?DOP_SEND,?COOKIE,P},3,
+                      [{hdr, 3, binary:part(Msg, 0,10)},
+                       {hdr, 3, binary:part(Msg, 0,10)}]),
+
+    start_monitor(Offender,P),
+    send_bad_fragments(Offender, Victim, P,{?DOP_SEND,?COOKIE,P,broken},3,
+                      [{hdr, 1, binary:part(Msg, 10,byte_size(Msg)-10)}]),
+
+    start_monitor(Offender,P),
+    send_bad_fragments(Offender, Victim, P,{?DOP_SEND,?COOKIE,P},3,
+                      [{hdr, 3, binary:part(Msg, 10,byte_size(Msg)-10)},
+                       close]),
+
+    start_monitor(Offender,P),
+    ExitVictim = spawn(Victim, fun() -> receive ok -> ok end end),
+    send_bad_fragments(Offender, Victim, P,{?DOP_PAYLOAD_EXIT,P,ExitVictim},2,
+                      [{hdr, 1, [131]}]),
+
+    start_monitor(Offender,P),
+    Exit2Victim = spawn(Victim, fun() -> receive ok -> ok end end),
+    send_bad_fragments(Offender, Victim, P,{?DOP_PAYLOAD_EXIT2,P,ExitVictim},2,
+                      [{hdr, 1, [132]}]),
+
+    start_monitor(Offender,P),
+    DownVictim = spawn(Victim, fun() -> receive ok -> ok end end),
+    DownRef = erlang:monitor(process, DownVictim),
+    send_bad_fragments(Offender, Victim, P,{?DOP_PAYLOAD_MONITOR_P_EXIT,P,DownVictim,DownRef},2,
+                      [{hdr, 1, [133]}]),
+
+    P ! two,
+    P ! check_msgs,
+    receive
+        {P, messages_checked} -> ok
+    after 5000 ->
+              exit(victim_is_dead)
+    end,
+
+    {message_queue_len, 0}
+    = rpc:call(Victim, erlang, process_info, [P, message_queue_len]),
+
+    unlink(P),
+    P ! done,
+    stop_node(Offender),
+    stop_node(Victim),
+    ok.
+
+dmsg_frag_hdr(Frag) ->
+    dmsg_frag_hdr(erlang:phash2(self()), Frag).
+dmsg_frag_hdr(Seq, Frag) ->
+    [131, $E, uint64_be(Seq), uint64_be(Frag), 0].
+
+dmsg_frag(Frag) ->
+    dmsg_frag(erlang:phash2(self()), Frag).
+dmsg_frag(Seq, Frag) ->
+    [131, $F, uint64_be(Seq), uint64_be(Frag)].
+
+send_bad_fragments(Offender,VictimNode,Victim,Ctrl,WhereToPutSelf,Fragments) ->
+    Parent = self(),
+    Done = make_ref(),
+    ct:pal("Send: ~p",[Fragments]),
+    spawn_link(Offender,
+          fun () ->
+                  Node = node(Victim),
+                  pong = net_adm:ping(Node),
+                  erlang:monitor_node(Node, true),
+                  DCtrl = dctrl(Node),
+                  Ctrl1 = case WhereToPutSelf of
+                             0 ->
+                                 Ctrl;
+                             N when N > 0 ->
+                                 setelement(N,Ctrl,self())
+                         end,
+
+                  FragData = [case Type of
+                                  hdr ->
+                                      [dmsg_frag_hdr(FragId),
+                                       dmsg_ext(Ctrl1), FragPayload];
+                                  frg ->
+                                      [dmsg_frag(FragId), FragPayload]
+                              end || {Type, FragId, FragPayload} <- Fragments],
+
+                  receive {nodedown, Node} -> exit("premature nodedown")
+                  after 10 -> ok
+                  end,
+
+                  [ dctrl_send(DCtrl, D) || D <- FragData ],
+                  [ erlang:port_close(DCtrl) || close <- Fragments],
+
+                  receive {nodedown, Node} -> ok
+                  after 5000 -> exit("missing nodedown")
+                  end,
+                  Parent ! {FragData,Done}
+          end),
+    receive
+        {WhatSent,Done} ->
+            io:format("Offender sent ~p~n",[WhatSent]),
+            verify_nc(VictimNode),
+            ok
+    after 7000 ->
+              exit(unable_to_send)
+    end.
 
 bad_dist_ext_receive(Config) when is_list(Config) ->
     {ok, Offender} = start_node(bad_dist_ext_receive_offender),
@@ -2124,7 +2274,24 @@ start_node(Config, Args, Rel) when is_list(Config), is_list(Rel) ->
     start_node(Name, Args, Rel).
 
 stop_node(Node) ->
+    verify_nc(Node),
     test_server:stop_node(Node).
+
+verify_nc(Node) ->
+    P = self(),
+    Ref = make_ref(),
+    spawn(Node,
+          fun() ->
+                  R = erts_test_utils:check_node_dist(fun(E) -> E end),
+                  P ! {Ref, R}
+          end),
+    receive
+        {Ref, ok} ->
+            ok;
+        {Ref, Error} ->
+            ct:log("~s",[Error]),
+            ct:fail(failed_nc_refc_check)
+    end.
 
 freeze_node(Node, MS) ->
     Own = 300,
@@ -2485,6 +2652,17 @@ mk_ref({NodeNameExt, Creation}, Numbers) when is_integer(Creation),
             exit({unexpected_binary_to_term_result, Other})
     end.
 
+uint64_be(Uint) when is_integer(Uint), 0 =< Uint, Uint < 1 bsl 64 ->
+    [(Uint bsr 56) band 16#ff,
+     (Uint bsr 48) band 16#ff,
+     (Uint bsr 40) band 16#ff,
+     (Uint bsr 32) band 16#ff,
+     (Uint bsr 24) band 16#ff,
+     (Uint bsr 16) band 16#ff,
+     (Uint bsr 8) band 16#ff,
+     Uint band 16#ff];
+uint64_be(Uint) ->
+    exit({badarg, uint64_be, [Uint]}).
 
 uint32_be(Uint) when is_integer(Uint), 0 =< Uint, Uint < 1 bsl 32 ->
     [(Uint bsr 24) band 16#ff,

--- a/erts/emulator/test/node_container_SUITE.erl
+++ b/erts/emulator/test/node_container_SUITE.erl
@@ -71,25 +71,10 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     erts_debug:set_internal_state(available_internal_state, true),
     erts_debug:set_internal_state(node_tab_delayed_delete, -1), %% restore original value
-    available_internal_state(false).
-
-available_internal_state(Bool) when Bool == true; Bool == false ->
-    case {Bool,
-          (catch erts_debug:get_internal_state(available_internal_state))} of
-        {true, true} ->
-            true;
-        {false, true} ->
-            erts_debug:set_internal_state(available_internal_state, false),
-            true;
-        {true, _} ->
-            erts_debug:set_internal_state(available_internal_state, true),
-            false;
-        {false, _} ->
-            false
-    end.
+    erts_test_util:available_internal_state(false).
 
 init_per_testcase(_Case, Config) when is_list(Config) ->
-    available_internal_state(true),
+    erts_test_util:available_internal_state(true),
     Config.
 
 end_per_testcase(_Case, Config) when is_list(Config) ->
@@ -928,9 +913,9 @@ id(X) ->
 -define(ND_REFS, erts_debug:get_internal_state(node_and_dist_references)).
 
 node_container_refc_check(Node) when is_atom(Node) ->
-    AIS = available_internal_state(true),
+    AIS = erts_test_util:available_internal_state(true),
     nc_refc_check(Node),
-    available_internal_state(AIS).
+    erts_test_util:available_internal_state(AIS).
 
 nc_refc_check(Node) when is_atom(Node) ->
     Ref = make_ref(),

--- a/erts/emulator/test/node_container_SUITE.erl
+++ b/erts/emulator/test/node_container_SUITE.erl
@@ -71,10 +71,10 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     erts_debug:set_internal_state(available_internal_state, true),
     erts_debug:set_internal_state(node_tab_delayed_delete, -1), %% restore original value
-    erts_test_util:available_internal_state(false).
+    erts_test_utils:available_internal_state(false).
 
 init_per_testcase(_Case, Config) when is_list(Config) ->
-    erts_test_util:available_internal_state(true),
+    erts_test_utils:available_internal_state(true),
     Config.
 
 end_per_testcase(_Case, Config) when is_list(Config) ->
@@ -913,9 +913,9 @@ id(X) ->
 -define(ND_REFS, erts_debug:get_internal_state(node_and_dist_references)).
 
 node_container_refc_check(Node) when is_atom(Node) ->
-    AIS = erts_test_util:available_internal_state(true),
+    AIS = erts_test_utils:available_internal_state(true),
     nc_refc_check(Node),
-    erts_test_util:available_internal_state(AIS).
+    erts_test_utils:available_internal_state(AIS).
 
 nc_refc_check(Node) when is_atom(Node) ->
     Ref = make_ref(),

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -2096,7 +2096,7 @@ define etp-process-info-int
     end
   end
   printf "  Current function: "
-  if ($etp_proc->current)
+  if ($etp_proc->current && !($etp_proc->state.counter & 0x800))
     etp-1 $etp_proc->current->module
     printf ":"
     etp-1 $etp_proc->current->function
@@ -2167,7 +2167,7 @@ define etp-processes-int
     set $invalid_proc = &erts_invalid_process
     set $proc_decentile = $proc_max_ix / 10
     set $proc_printile = $proc_decentile
-    while $proc_ix < $proc_max_ix && $proc_cnt > 0
+    while $proc_ix < $proc_max_ix && $proc_cnt >= 0
       set $proc = (Process *) *((UWord *) ($proc_tab + $proc_ix))
       if ($proc != ((Process *) 0) && $proc != $invalid_proc)
         printf "---\n"

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -1789,7 +1789,7 @@ define etp-pix2proc
 # Args: Eterm
 #
    set $proc = (Process *) *((UWord *) &erts_proc.r.o.tab[((int) $arg0)])
-   printf "(Process *) %p\n", $proc
+   printf "(Process*)%p\n", $proc
 end
 
 define etp-pid2proc-1
@@ -1803,7 +1803,7 @@ define etp-pid2proc
 # Args: Eterm
 #
    etp-pid2proc-1 $arg0
-   printf "(Process *) %p\n", $proc
+   printf "(Process*)%p\n", $proc
 end
 
 define etp-proc-state-int
@@ -2083,7 +2083,7 @@ define etp-process-info-int
   printf "\n  Flags: "
   etp-proc-flags $etp_proc
   if $proxy_process != 0
-    printf "  Pointer: (Process *) %p\n", $etp_proc
+    printf "  Pointer: (Process*)%p\n", $etp_proc
     printf "  *** PROXY process struct *** refer to: \n"
     etp-pid2proc-1 $etp_proc->common.id
     etp-process-info $proc
@@ -2133,7 +2133,7 @@ define etp-process-info-int
   end
   printf "  Parent: "
   etp-1 ((Eterm)($etp_proc->parent))
-  printf "\n  Pointer: (Process *) %p\n", $etp_proc
+  printf "\n  Pointer: (Process*)%p\n", $etp_proc
   end
   if ($arg1)
     etp-sigqs $etp_proc
@@ -2156,6 +2156,43 @@ document etp-process-info
 %---------------------------------------------------------------------------
 end
 
+define etp-processes-free-runq-int
+  set $runq_prio = 0
+  while $runq_prio < 3
+    set $runq_proc = ($arg0)->procs.prio[$runq_prio].first
+    while $runq_proc != 0
+      if $runq_proc->state.counter & 0x400
+        printf "---\n"
+        printf "  Pix: FREE -> run_queue %p\n", ($arg0)
+        etp-process-info-int $runq_proc ($arg1)
+      end
+      set $runq_proc = $runq_proc->next
+    end
+    set $runq_prio++
+  end
+end
+
+define etp-processes-free-de-int
+  set $de_ix = 0
+  while $de_ix < ($arg1)
+    set $de = ($arg0)+$de_ix
+    set $susp = $de->suspended
+    set $susp_curr = $susp
+    set $first_loop = 1
+    while $susp_curr != 0 && (($susp_curr != $susp) || $first_loop)
+      if ($susp_curr->u.pid & 0x3) == 0
+        printf "---\n"
+        printf "  Pix: FREE "
+        etp $de->sysname
+        etp-process-info-int $susp_curr->u.pid ($arg2)
+      end
+      set $first_loop = 0
+      set $susp_curr = $susp_curr->next
+    end
+    set $de_ix++
+  end
+end
+
 define etp-processes-int
   if (!erts_initialized)
     printf "No processes, since system isn't initialized!\n"
@@ -2167,7 +2204,7 @@ define etp-processes-int
     set $invalid_proc = &erts_invalid_process
     set $proc_decentile = $proc_max_ix / 10
     set $proc_printile = $proc_decentile
-    while $proc_ix < $proc_max_ix && $proc_cnt >= 0
+    while $proc_ix < $proc_max_ix && $proc_cnt > 0
       set $proc = (Process *) *((UWord *) ($proc_tab + $proc_ix))
       if ($proc != ((Process *) 0) && $proc != $invalid_proc)
         printf "---\n"
@@ -2176,11 +2213,36 @@ define etp-processes-int
         set $proc_cnt--
       end
       if $proc_ix == $proc_printile
-        printf "--- %d%% (%d / %d) searched\n", $proc_printile / $proc_decentile * 10, $proc_ix, $proc_max_ix
+        printf "--- %d%% (%d / %d) searched, looking for %d more\n", $proc_printile / $proc_decentile * 10, $proc_ix, $proc_max_ix, $proc_cnt
         set $proc_printile += $proc_decentile
       end
       set $proc_ix++
     end
+
+    ## We should also check for any FREE processes that are running
+    ## They can be found in esdp->current_process, dep->suspendees and
+    ## runq. Running FREE processes are processes that either are yielding
+    ## when exiting or running on a dirty scheduler while having exited.
+    set $sched_ix = 0
+    while $sched_ix < erts_no_schedulers
+      set $sched_data = &erts_aligned_scheduler_data[$sched_ix].esd
+      if $sched_data->current_process != 0
+        if $sched_data->current_process.state.counter & 0x400
+          printf "---\n"
+          printf "  Pix: FREE -> scheduler %d\n", $sched_ix+1
+          etp-process-info-int $sched_data->current_process ($arg0)
+        end
+      end
+      etp-processes-free-runq-int $sched_data->run_queue ($arg0)
+      set $sched_ix++
+    end
+    etp-processes-free-runq-int &erts_aligned_run_queues[erts_no_run_queues].runq ($arg0)
+    etp-processes-free-runq-int &erts_aligned_run_queues[erts_no_run_queues+1].runq ($arg0)
+    etp-processes-free-de-int erts_hidden_dist_entries erts_no_of_hidden_dist_entries ($arg0)
+    etp-processes-free-de-int erts_visible_dist_entries erts_no_of_visible_dist_entries ($arg0)
+    etp-processes-free-de-int erts_pending_dist_entries erts_no_of_pending_dist_entries ($arg0)
+    etp-processes-free-de-int erts_not_connected_dist_entries erts_no_of_not_connected_dist_entries ($arg0)
+    etp-processes-free-de-int erts_this_dist_entry 1 ($arg0)
     printf "---\n",
   end
 end
@@ -2237,9 +2299,9 @@ define etp-process-memory-info
   end
   printf "  "
   etp-1 $etp_pmem_proc->common.id
-  printf ": (Process *) %p ", $etp_pmem_proc
+  printf ": (Process*)%p ", $etp_pmem_proc
   if $proxy_process != 0
-    printf "(Process *) %p ", $etp_pmem_proc
+    printf "(Process*)%p ", $etp_pmem_proc
     printf "  *** PROXY process struct *** refer to next: \n"
     etp-pid2proc-1 $etp_pmem_proc->common.id
     printf " -"
@@ -2313,7 +2375,7 @@ define etp-pix2port
 # Args: Eterm
 #
    set $port = (Port *) *((UWord *) &erts_port.r.o.tab[((int) $arg0)])
-   printf "(Port *) %p\n", $port
+   printf "(Port*)%p\n", $port
 end
 
 define etp-id2port-1
@@ -2327,7 +2389,7 @@ define etp-id2port
 # Args: Eterm
 #
    etp-id2port-1 $arg0
-   printf "(Port *) %p\n", $port
+   printf "(Port*)%p\n", $port
 end
 
 define etp-port-sched-flags-int
@@ -2501,7 +2563,7 @@ define etp-port-info
   printf "  Connected: "
   set $connected = *(((Eterm *) &(((Port *) $etp_pinfo_port)->connected)))
   etp-1 $connected
-  printf "\n  Pointer: (Port *) %p\n", $etp_pinfo_port
+  printf "\n  Pointer: (Port*)%p\n", $etp_pinfo_port
 end
 
 document etp-port-info
@@ -2851,7 +2913,7 @@ define etp-scheduler-info-internal
   printf " Sleep Info Flags:"
   set $ssi_flags = *((Uint32 *) &$sched_data->ssi->flags)
   etp-ssi-flags $ssi_flags
-  printf " Pointer: (ErtsSchedulerData *) %p\n", $sched_data
+  printf " Pointer: (ErtsSchedulerData*)%p\n", $sched_data
 end
 
 define etp-run-queue-info-internal
@@ -2884,7 +2946,7 @@ define etp-run-queue-info-internal
   end
   set $rq_flags = *((Uint32 *) &($runq->flags))
   etp-rq-flags-int $rq_flags
-  printf "  Pointer: (ErtsRunQueue *) %p\n", $runq
+  printf "  Pointer: (ErtsRunQueue*)%p\n", $runq
 end
 
 define etp-fds
@@ -2961,7 +3023,7 @@ define etp-timer-wheel
         printf "\n"
         while 1
            printf "- Timeout pos: %ld\n", $tmr->timeout_pos
-	   printf "  Pointer: (ErtsTWheelTimer *) %p\n", $tmr
+	   printf "  Pointer: (ErtsTWheelTimer*)%p\n", $tmr
            set $tmr = $tmr->next
            if ($tmr == $tiw->w[$ix])
              loop_break
@@ -2991,7 +3053,7 @@ define etp-timer-wheel
         printf "\n"
         while 1
            printf "- Timeout pos: %ld\n", $tmr->timeout_pos
-	   printf "  Pointer: (ErtsTWheelTimer *) %p\n", $tmr
+	   printf "  Pointer: (ErtsTWheelTimer*)%p\n", $tmr
            set $tmr = $tmr->next
            if ($tmr == $tiw->w[$ix])
              loop_break

--- a/lib/kernel/include/dist.hrl
+++ b/lib/kernel/include/dist.hrl
@@ -44,6 +44,7 @@
 -define(DFLAG_BIG_SEQTRACE_LABELS, 16#100000).
 %% -define(DFLAG_NO_MAGIC, 16#200000). %% Used internally only
 -define(DFLAG_EXIT_PAYLOAD, 16#400000).
+-define(DFLAG_FRAGMENTS, 16#800000).
 
 %% Also update dflag2str() in ../src/dist_util.erl
 %% when adding flags...

--- a/lib/kernel/include/dist.hrl
+++ b/lib/kernel/include/dist.hrl
@@ -42,6 +42,8 @@
 -define(DFLAG_BIG_CREATION, 16#40000).
 -define(DFLAG_SEND_SENDER, 16#80000).
 -define(DFLAG_BIG_SEQTRACE_LABELS, 16#100000).
+%% -define(DFLAG_NO_MAGIC, 16#200000). %% Used internally only
+-define(DFLAG_EXIT_PAYLOAD, 16#400000).
 
 %% Also update dflag2str() in ../src/dist_util.erl
 %% when adding flags...

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -116,6 +116,8 @@ dflag2str(?DFLAG_SEND_SENDER) ->
     "SEND_SENDER";
 dflag2str(?DFLAG_BIG_SEQTRACE_LABELS) ->
     "BIG_SEQTRACE_LABELS";
+dflag2str(?DFLAG_EXIT_PAYLOAD) ->
+    "EXIT_PAYLOAD";
 dflag2str(_) ->
     "UNKNOWN".
 

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -118,6 +118,8 @@ dflag2str(?DFLAG_BIG_SEQTRACE_LABELS) ->
     "BIG_SEQTRACE_LABELS";
 dflag2str(?DFLAG_EXIT_PAYLOAD) ->
     "EXIT_PAYLOAD";
+dflag2str(?DFLAG_FRAGMENTS) ->
+    "FRAGMENTS";
 dflag2str(_) ->
     "UNKNOWN".
 

--- a/lib/kernel/src/inet_tcp_dist.erl
+++ b/lib/kernel/src/inet_tcp_dist.erl
@@ -212,6 +212,7 @@ do_accept(Driver, Kernel, AcceptPid, Socket, MyNode, Allowed, SetupTime) ->
 					   [{active, true},
 					    {deliver, port},
 					    {packet, 4},
+                                            binary,
 					    nodelay()])
 		      end,
 		      f_getll = fun(S) ->


### PR DESCRIPTION
This PR implements fragmentation of large Erlang Distribution signals in order to prevent [head-of-line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking). This PR introduces two changes to the
distribution protocol.

1. Move exit reason of EXIT, EXIT2 and MONITOR\_P\_EXIT to after the control message.
2. Introduce two new distribution headers that represent:
  1. Start of a new sequence of fragments
  2. A fragment in a sequence

The new distribution headers look like this:

| 1   |  1  |   8   |    8   |    1                    | NumberOfAtomCacheRefs/2+1 \| 0 |    N \| 0     |
|-----|-----|-------|--------|-------------------------|--------------------------------|---------------|
| 131 |  69 | SeqId | FragNo |  NumberOfAtomCacheRefs  |     Flags                      | AtomCacheRefs |

| 1   |  1  |   8   |    8   |
|-----|-----|-------|--------|
| 131 |  70 | SeqId | FragNo |

* The atom cache is the same for the entire sequence.
* The FragNo starts at the total number of fragments in the sequence and then decrements to 1, i.e. in a sequence of 2 fragments the start header has FragNo set to 2 and the following fragment has FragNo set to 1.
* The old distribution header is still used for messages that do not need to be fragmented.

The following restrictions exist when using the message fragmentation:

* Only the payload of the message may be fragmented. The control sequence may not span across several fragments.
* Only one sequence may be sent by one process at a time.
* Fragments must arrive in the correct order. i.e. if a sequence consists of 4 fragments, then the fragments have to arrive as 4, 3, 2, 1.

In addition to these changes to the Erlang Distribution protocol, this PR also fixes and optimizes many internal issues.

* Yielding during processes exit when sending many exit/down messages
* Change the distr inet driver to run in binary mode and fix dist.c to not copy the payload unneccisarily.
* Trap when sending distributed exit/1, exit/2 and monitor down messages.


NOTE: The documentation for the new distribution headers is not done yet.