### PR TITLE
gen_tcp, gen_udp: Update specs

### DIFF
--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -156,7 +156,7 @@ connect(Address, Port, Opts) ->
       Options :: [connect_option()],
       Timeout :: timeout(),
       Socket :: socket(),
-      Reason :: inet:posix().
+      Reason :: timeout | inet:posix().
 
 connect(Address, Port, Opts, Time) ->
     Timer = inet:start_timer(Time),
@@ -220,7 +220,7 @@ listen(Port, Opts0) ->
 -spec accept(ListenSocket) -> {ok, Socket} | {error, Reason} when
       ListenSocket :: socket(),
       Socket :: socket(),
-      Reason :: closed | timeout | system_limit | inet:posix().
+      Reason :: closed | system_limit | inet:posix().
 
 accept(S) ->
     case inet_db:lookup_socket(S) of
@@ -312,7 +312,7 @@ recv(S, Length) when is_port(S) ->
       Length :: non_neg_integer(),
       Timeout :: timeout(),
       Packet :: string() | binary() | HttpPacket,
-      Reason :: closed | inet:posix(),
+      Reason :: closed | timeout | inet:posix(),
       HttpPacket :: term().
 
 recv(S, Length, Time) when is_port(S) ->

--- a/lib/kernel/src/gen_udp.erl
+++ b/lib/kernel/src/gen_udp.erl
@@ -95,7 +95,7 @@
 -spec open(Port) -> {ok, Socket} | {error, Reason} when
       Port :: inet:port_number(),
       Socket :: socket(),
-      Reason :: inet:posix().
+      Reason :: system_limit | inet:posix().
 
 open(Port) -> 
     open(Port, []).
@@ -112,7 +112,7 @@ open(Port) ->
               | {bind_to_device, binary()}
               | option(),
       Socket :: socket(),
-      Reason :: inet:posix().
+      Reason :: system_limit | inet:posix().
 
 open(Port, Opts0) ->
     {Mod, Opts} = inet:udp_module(Opts0),
@@ -186,7 +186,7 @@ recv(S,Len) when is_port(S), is_integer(Len) ->
       Port :: inet:port_number(),
       AncData :: inet:ancillary_data(),
       Packet :: string() | binary(),
-      Reason :: not_owner | inet:posix().
+      Reason :: not_owner | timeout | inet:posix().
 
 recv(S,Len,Time) when is_port(S) ->
     case inet_db:lookup_socket(S) of


### PR DESCRIPTION
gen_tcp: Update connect/3, accept/1, and recv/3 specs
* `connect/3` can return `{error, timeout}`
* `accept/1` cannot return `{error, timeout}`
* `recv/3` can return `{error, timeout}`

 gen_udp: Update open/1-2 and recv/3 specs
* `open/1-2` can return `{error, system_limit}`
* `recv/3` can return `{error, timeout}`