### PR TITLE
Fix a particular sed invocation in otp_build

### DIFF
--- a/lib/common_test/test_server/configure.in
+++ b/lib/common_test/test_server/configure.in
@@ -459,11 +459,11 @@ dnl Freely inspired by AC_TRY_LINK. (Maybe better to create a
 dnl AC_LANG_JAVA instead...)
 AC_DEFUN(ERL_TRY_LINK_JAVA,
 [java_link='$JAVAC conftest.java 1>&AC_FD_CC'
-changequote(«, »)dnl
+changequote(, )dnl
 cat > conftest.java <<EOF
-«$1»
+$1
 class conftest { public static void main(String[] args) {
-   «$2»
+   $2
    ; return; }}
 EOF
 changequote([, ])dnl

--- a/otp_build
+++ b/otp_build
@@ -317,7 +317,7 @@ do_autoconf ()
 
 	    echo "=== running autoconf in $d"
 	    ( cd "$d" && autoconf ) || exit 1
-	    chdr=`cat "$file" | LC_CTYPE=C sed -n "s|.*\(AC_CONFIG_HEADER\).*|\1|p"`
+	    chdr=`cat "$file" | sed -n "s|.*\(AC_CONFIG_HEADER\).*|\1|p"`
 	    [ "$chdr" = "AC_CONFIG_HEADER" ] || continue
 	    echo "=== running autoheader in $d"
 	    ( cd "$d" && autoheader ) || exit 1

--- a/otp_build
+++ b/otp_build
@@ -317,7 +317,7 @@ do_autoconf ()
 
 	    echo "=== running autoconf in $d"
 	    ( cd "$d" && autoconf ) || exit 1
-	    chdr=`cat "$file" | sed -n "s|.*\(AC_CONFIG_HEADER\).*|\1|p"`
+	    chdr=`cat "$file" | LC_CTYPE=C sed -n "s|.*\(AC_CONFIG_HEADER\).*|\1|p"`
 	    [ "$chdr" = "AC_CONFIG_HEADER" ] || continue
 	    echo "=== running autoheader in $d"
 	    ( cd "$d" && autoheader ) || exit 1


### PR DESCRIPTION
Otherwise sed cannot process `lib/common_test/test_server/configure.in`
when run under UTF-8 locale.  That file uses m4’s `changequote(«, »)`, in latin-1.