### PR TITLE
Make C function documentation more readable

### DIFF
--- a/lib/erl_docgen/priv/css/otp_doc.css
+++ b/lib/erl_docgen/priv/css/otp_doc.css
@@ -74,7 +74,7 @@ a:visited      { color: #1b6ec2; text-decoration: none }
 
 /* Invisible table for function specs,
  * just to get since-version out in right margin */
-.func-table, .func-tr, .func-td, .func-since-td {
+.func-table, .func-tr, .func-td, .cfunc-td, .func-since-td {
     width: 200%;
     border: 0;
     padding: 0;
@@ -86,7 +86,13 @@ a:visited      { color: #1b6ec2; text-decoration: none }
 }
 
 .func-td {
-    width: 50%
+    width: 50%;
+}
+
+.cfunc-td {
+    width: 50%;
+    padding-left: 100px;
+    text-indent: -100px;
 }
 
 .func-since-td {

--- a/lib/erl_docgen/priv/xsl/db_html.xsl
+++ b/lib/erl_docgen/priv/xsl/db_html.xsl
@@ -2119,7 +2119,7 @@
       <xsl:when test="ancestor::cref">
 	<table class="func-table">
 	  <tr class="func-tr">
-	    <td class="func-td">
+	    <td class="cfunc-td">
               <span class="bold_code bc-7">
 		<xsl:call-template name="title_link">
 		  <xsl:with-param name="link" select="substring-before(nametext, '(')"/>


### PR DESCRIPTION
with indentation and one function argument per line.

Example
Before: http://erlang.org/doc/man/erl_nif.html#enif_open_resource_type
After: http://erlang.org/~sverker/prettify_cfunc_doc/html/erl_nif.html#enif_open_resource_type

