### PR TITLE
Remove 7-bit ASCII limitation in to_erl

### DIFF
--- a/erts/etc/unix/to_erl.c
+++ b/erts/etc/unix/to_erl.c
@@ -245,7 +245,6 @@ int main(int argc, char **argv)
     tty_smode.c_iflag =
 	1*BRKINT |/*Signal interrupt on break.*/
 	    1*IGNPAR |/*Ignore characters with parity errors.*/
-		1*ISTRIP |/*Strip character.*/
 		    0;
     
 #if 0


### PR DESCRIPTION
Symptom: to_erl garbles anything beyond 7-bit ASCII received on STDIN

Solution: Remove setting of ISTRIP flag on input terminal which strips off the eighth bit.

