### PR TITLE
Optimize the beam_ssa_dead sub pass

### DIFF
--- a/lib/compiler/src/beam_ssa_dead.erl
+++ b/lib/compiler/src/beam_ssa_dead.erl
@@ -88,6 +88,16 @@ shortcut_opt(#st{bs=Blocks}=St) ->
     %% opportunities for optimizations compared to post order. (Based on
     %% running scripts/diffable with both PO and RPO and looking at
     %% the diff.)
+    %%
+    %% Unfortunately, processing the blocks in reverse post order
+    %% potentially makes the time complexity quadratic or even cubic if
+    %% the ordset of unset variables grows large, instead of
+    %% linear for post order processing. We try to still get reasonable
+    %% compilation times by optimizations that will keep the constant
+    %% factor as low as possible, and we try to avoid the cubic time
+    %% complexity by trying to keep the set of unset variables as small
+    %% as possible.
+
     Ls = beam_ssa:rpo(Blocks),
     shortcut_opt(Ls, #{}, St).
 


### PR DESCRIPTION
@josevalim pointed out that the `beam_ssa_dead` sub pass took almost all of the time in `beam_ssa_opt` when compiling `lib/elixir/unicode/tokenizer.ex`.

This pull request reduces the time approximately by half, down from almost 2 seconds to under 1 second on my computer.

There are more details in the individual commit messages.