### PR TITLE
Move size=all binary clause pruning to v3_kernel

### DIFF
--- a/lib/compiler/src/beam_kernel_to_ssa.erl
+++ b/lib/compiler/src/beam_kernel_to_ssa.erl
@@ -327,7 +327,7 @@ select_bin_seg(#k_val_clause{val=#k_bin_seg{size=Size,unit=U,type=T,
     {Mis,St1} = select_extract_bin(Next, Size, U, T, Fs, Fail,
                                    Ctx, LineAnno, St0),
     {Extracted,St2} = new_ssa_var(Seg#k_var.name, St1),
-    {Bis,St} = bin_match_cg(Size, B, Fail, St2),
+    {Bis,St} = match_cg(B, Fail, St2),
     BsGet = #b_set{op=bs_extract,dst=Extracted,args=[ssa_arg(Next, St)]},
     Is = Mis ++ [BsGet] ++ Bis,
     {Is,St};
@@ -361,14 +361,6 @@ select_bin_seg(#k_val_clause{val=#k_bin_int{size=Sz,unit=U,flags=Fs,
                  Is0
          end,
     {Is,St}.
-
-bin_match_cg(#k_atom{val=all}, B0, Fail, St) ->
-    #k_select{types=Types} = B0,
-    [#k_type_clause{type=k_bin_end,values=Values}] = Types,
-    [#k_val_clause{val=#k_bin_end{},body=B}] = Values,
-    match_cg(B, Fail, St);
-bin_match_cg(_, B, Fail, St) ->
-    match_cg(B, Fail, St).
 
 get_context(#k_var{}=Var, St) ->
     ssa_arg(Var, St).

--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -2040,6 +2040,10 @@ get_match(#k_cons{}, St0) ->
 get_match(#k_binary{}, St0) ->
     {[V]=Mes,St1} = new_vars(1, St0),
     {#k_binary{segs=V},Mes,St1};
+get_match(#k_bin_seg{size=#k_atom{val=all},next={k_bin_end,[]}}=Seg, St0) ->
+    {[S,N0],St1} = new_vars(2, St0),
+    N = set_kanno(N0, [no_usage]),
+    {Seg#k_bin_seg{seg=S,next=N},[S],St1};
 get_match(#k_bin_seg{}=Seg, St0) ->
     {[S,N0],St1} = new_vars(2, St0),
     N = set_kanno(N0, [no_usage]),
@@ -2067,6 +2071,9 @@ new_clauses(Cs0, U, St) ->
 				 #k_cons{hd=H,tl=T} -> [H,T|As];
 				 #k_tuple{es=Es} -> Es ++ As;
 				 #k_binary{segs=E}  -> [E|As];
+				 #k_bin_seg{size=#k_atom{val=all},
+					    seg=S,next={k_bin_end,[]}} ->
+				     [S|As];
 				 #k_bin_seg{seg=S,next=N} ->
 				     [S,N|As];
 				 #k_bin_int{next=N} ->


### PR DESCRIPTION
The advantage of moving it up is that it reduces the
size of the code emitted by v3_kernel, speeding
v3_kernel itself and beam_kernel_to_ssa pass.