### PR TITLE
Error on duplicated config apps/keys in -config

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -537,14 +537,12 @@ check_conf_data(ConfData) when is_list(ConfData) ->
 	{AppName, List} when is_atom(AppName), is_list(List) ->
 	    case lists:keymember(AppName, 1, ConfDataRem) of
 		true ->
-		    ?LOG_WARNING("duplicate application config: " ++ atom_to_list(AppName));
+		    {error, "duplicate application config: " ++ atom_to_list(AppName)};
 		false ->
-		    ok
-	    end,
-
-	    case check_para(List, AppName) of
-		ok -> check_conf_data(ConfDataRem);
-		Error -> Error
+		    case check_para(List, AppName) of
+			ok -> check_conf_data(ConfDataRem);
+			Error -> Error
+		    end
 	    end;
 	{AppName, List} when is_list(List)  ->
 	    ErrMsg = "application: "
@@ -570,15 +568,14 @@ check_para([], _AppName) ->
 check_para([{Para, Val} | ParaList], AppName) when is_atom(Para) ->
     case lists:keymember(Para, 1, ParaList) of
 	true ->
-	    ?LOG_WARNING("application: " ++ atom_to_list(AppName) ++
-                             "; duplicate parameter: " ++ atom_to_list(Para));
+	    ErrMsg =  "application: " ++ atom_to_list(AppName)
+		++ "; duplicate parameter: " ++ atom_to_list(Para),
+	    {error, ErrMsg};
 	false ->
-	    ok
-    end,
-
-    case check_para_value(Para, Val, AppName) of
-	ok -> check_para(ParaList, AppName);
-	{error, _} = Error -> Error
+	    case check_para_value(Para, Val, AppName) of
+		ok -> check_para(ParaList, AppName);
+		{error, _} = Error -> Error
+	    end
     end;
 check_para([{Para, _Val} | _ParaList], AppName) ->
     {error, "application: " ++ atom_to_list(AppName) ++ "; invalid parameter name: " ++

--- a/lib/kernel/test/application_SUITE.erl
+++ b/lib/kernel/test/application_SUITE.erl
@@ -2020,18 +2020,11 @@ set_env_errors(Conf) when is_list(Conf) ->
     "application: kernel; erroneous parameter: distributed" =
 	badarg_msg(fun() -> application:set_env([{kernel, [{distributed, config}]}]) end),
 
-    %% This will raise in the future
-    ct:capture_start(),
-    _ = application:set_env([{foo, []}, {foo, []}]),
-    timer:sleep(100),
-    ct:capture_stop(),
-    [_ | _] = string:find(ct:capture_get(), "duplicate application config: foo"),
+    "duplicate application config: foo" =
+	badarg_msg(fun() -> application:set_env([{foo, []}, {foo, []}]) end),
 
-    ct:capture_start(),
-    _ = application:set_env([{foo, [{bar, baz}, {bar, bat}]}]),
-    timer:sleep(100),
-    ct:capture_stop(),
-    [_ | _] = string:find(ct:capture_get(), "application: foo; duplicate parameter: bar"),
+    "application: foo; duplicate parameter: bar" =
+	badarg_msg(fun() -> application:set_env([{foo, [{bar, baz}, {bar, bat}]}]) end),
 
     ok.
 


### PR DESCRIPTION
Erlang/OTP 21.3 warned on those cases and now we will
raise on Erlang/OTP 22.0.