### PR TITLE
erts: release dirty runqueue lock before entering endless loop

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -9474,6 +9474,7 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 
 	if (!is_normal_sched & !!(flags & ERTS_RUNQ_FLG_HALTING)) {
 	    /* Wait for emulator to terminate... */
+	    erts_runq_unlock(rq);
 	    while (1)
 		erts_milli_sleep(1000*1000);
 	}
@@ -13081,10 +13082,10 @@ void erts_halt(int code)
     if (-1 == erts_atomic32_cmpxchg_acqb(&erts_halt_progress,
 					     erts_no_schedulers,
 					     -1)) {
+        notify_reap_ports_relb();
         ERTS_RUNQ_FLGS_SET(ERTS_DIRTY_CPU_RUNQ, ERTS_RUNQ_FLG_HALTING);
         ERTS_RUNQ_FLGS_SET(ERTS_DIRTY_IO_RUNQ, ERTS_RUNQ_FLG_HALTING);
 	erts_halt_code = code;
-	notify_reap_ports_relb();
     }
 }
 


### PR DESCRIPTION
This patch fixes a problem happening when BEAM is shutting down. It is possible for a dirty scheduler to take the lock, and keep it, when the system is shutting down. It may also happen that a normal scheduler decides to schedule some dirty job (example is major garbage collection that results in migrating the process into dirty CPU queue), and hangs trying to take the lock that will never be released.

To fix the problem, either release the lock before entering endless wait loop, or reverse the order in which schedulers are stopped. Either fix works, and, of course, it works even better to apply both.