### PR TITLE
erts: Add enif_term_type

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -3369,6 +3369,48 @@ if (retval &amp; ERL_NIF_SELECT_STOP_CALLED) {
     </func>
 
     <func>
+      <name since="OTP @OTP-15640@"><ret>ErlNifTermType</ret>
+        <nametext>enif_term_type(ErlNifEnv *env, ERL_NIF_TERM term)</nametext>
+      </name>
+      <fsummary>Determine the type of a term.</fsummary>
+      <desc>
+        <p>Determines the type of the given term. The term must be an ordinary
+          Erlang term and not one of the special terms returned by
+          <seealso marker="#enif_raise_exception">
+          <c>enif_raise_exception</c></seealso>,
+          <seealso marker="#enif_schedule_nif">
+          <c>enif_schedule_nif</c></seealso>, or similar.</p>
+        <p>The following types are defined at the moment:</p>
+        <taglist>
+          <tag><c>ERL_NIF_TERM_TYPE_ATOM</c></tag>
+          <item/>
+          <tag><c>ERL_NIF_TERM_TYPE_BITSTRING</c></tag>
+          <item><p>A bitstring or binary</p></item>
+          <tag><c>ERL_NIF_TERM_TYPE_FLOAT</c></tag>
+          <item/>
+          <tag><c>ERL_NIF_TERM_TYPE_FUN</c></tag>
+          <item/>
+          <tag><c>ERL_NIF_TERM_TYPE_INTEGER</c></tag>
+          <item/>
+          <tag><c>ERL_NIF_TERM_TYPE_LIST</c></tag>
+          <item><p>A list, empty or not</p></item>
+          <tag><c>ERL_NIF_TERM_TYPE_MAP</c></tag>
+          <item/>
+          <tag><c>ERL_NIF_TERM_TYPE_PID</c></tag>
+          <item/>
+          <tag><c>ERL_NIF_TERM_TYPE_PORT</c></tag>
+          <item/>
+          <tag><c>ERL_NIF_TERM_TYPE_REFERENCE</c></tag>
+          <item/>
+          <tag><c>ERL_NIF_TERM_TYPE_TUPLE</c></tag>
+          <item/>
+        </taglist>
+        <p>Note that new types may be added in the future, so the caller must
+          be prepared to handle unknown types.</p>
+      </desc>
+    </func>
+
+    <func>
       <name since="OTP R13B04"><ret>int</ret>
         <nametext>enif_thread_create(char *name,ErlNifTid
         *tid,void * (*func)(void *),void *args,ErlNifThreadOpts

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1158,6 +1158,47 @@ int enif_is_number(ErlNifEnv* env, ERL_NIF_TERM term)
     return is_number(term);
 }
 
+ErlNifTermType enif_term_type(ErlNifEnv* env, ERL_NIF_TERM term) {
+    (void)env;
+
+    switch (tag_val_def(term)) {
+    case ATOM_DEF:
+        return ERL_NIF_TERM_TYPE_ATOM;
+    case BINARY_DEF:
+        return ERL_NIF_TERM_TYPE_BITSTRING;
+    case FLOAT_DEF:
+        return ERL_NIF_TERM_TYPE_FLOAT;
+    case EXPORT_DEF:
+    case FUN_DEF:
+        return ERL_NIF_TERM_TYPE_FUN;
+    case BIG_DEF:
+    case SMALL_DEF:
+        return ERL_NIF_TERM_TYPE_INTEGER;
+    case LIST_DEF:
+    case NIL_DEF:
+        return ERL_NIF_TERM_TYPE_LIST;
+    case MAP_DEF:
+        return ERL_NIF_TERM_TYPE_MAP;
+    case EXTERNAL_PID_DEF:
+    case PID_DEF:
+        return ERL_NIF_TERM_TYPE_PID;
+    case EXTERNAL_PORT_DEF:
+    case PORT_DEF:
+        return ERL_NIF_TERM_TYPE_PORT;
+    case EXTERNAL_REF_DEF:
+    case REF_DEF:
+        return ERL_NIF_TERM_TYPE_REFERENCE;
+    case TUPLE_DEF:
+        return ERL_NIF_TERM_TYPE_TUPLE;
+    default:
+        /* tag_val_def() aborts on its own when passed complete garbage, but
+         * it's possible that the user has given us garbage that just happens
+         * to match something that tag_val_def() accepts but we don't, like
+         * binary match contexts. */
+        ERTS_INTERNAL_ERROR("Invalid term passed to enif_term_type");
+    }
+}
+
 static void aligned_binary_dtor(struct enif_tmp_obj_t* obj)
 {
     erts_free_aligned_binary_bytes_extra((byte*)obj, obj->allocator);

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -55,6 +55,7 @@
 ** 2.14: 21.0 add enif_ioq_peek_head, enif_(mutex|cond|rwlock|thread)_name
 **                enif_vfprintf, enif_vsnprintf, enif_make_map_from_arrays
 ** 2.15: 22.0 ERL_NIF_SELECT_CANCEL, enif_select_(read|write)
+**            enif_term_type
 */
 #define ERL_NIF_MAJOR_VERSION 2
 #define ERL_NIF_MINOR_VERSION 15
@@ -63,7 +64,7 @@
  * with ticket syntax like "erts-@OTP-12345@", or a temporary placeholder
  * between two @ like "erts-@MyName@", if you don't know what a ticket is.
  */
-#define ERL_NIF_MIN_ERTS_VERSION "erts-@OTP-15095@ (OTP-22)"
+#define ERL_NIF_MIN_ERTS_VERSION "erts-@OTP-15095 OTP-15640@ (OTP-22)"
 
 /*
  * The emulator will refuse to load a nif-lib with a major version
@@ -281,6 +282,26 @@ typedef struct erts_io_queue ErlNifIOQueue;
 typedef enum {
     ERL_NIF_IOQ_NORMAL = 1
 } ErlNifIOQueueOpts;
+
+typedef enum {
+    ERL_NIF_TERM_TYPE_ATOM = 1,
+    ERL_NIF_TERM_TYPE_BITSTRING = 2,
+    ERL_NIF_TERM_TYPE_FLOAT = 3,
+    ERL_NIF_TERM_TYPE_FUN = 4,
+    ERL_NIF_TERM_TYPE_INTEGER = 5,
+    ERL_NIF_TERM_TYPE_LIST = 6,
+    ERL_NIF_TERM_TYPE_MAP = 7,
+    ERL_NIF_TERM_TYPE_PID = 8,
+    ERL_NIF_TERM_TYPE_PORT = 9,
+    ERL_NIF_TERM_TYPE_REFERENCE = 10,
+    ERL_NIF_TERM_TYPE_TUPLE = 11,
+
+    /* This is a dummy value intended to coax the compiler into warning about
+     * unhandled values in a switch even if all the above values have been
+     * handled. We can add new entries at any time so the user must always
+     * have a default case. */
+    ERL_NIF_TERM_TYPE__MISSING_DEFAULT_CASE__READ_THE_MANUAL = -1
+} ErlNifTermType;
 
 /*
  * Return values from enif_thread_type(). Negative values

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -215,6 +215,8 @@ ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM,enif_make_monitor_term,(ErlNifEnv* env, const
 ERL_NIF_API_FUNC_DECL(void,enif_set_pid_undefined,(ErlNifPid* pid));
 ERL_NIF_API_FUNC_DECL(int,enif_is_pid_undefined,(const ErlNifPid* pid));
 
+ERL_NIF_API_FUNC_DECL(ErlNifTermType,enif_term_type,(ErlNifEnv* env, ERL_NIF_TERM term));
+
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
 */
@@ -401,6 +403,7 @@ ERL_NIF_API_FUNC_DECL(int,enif_is_pid_undefined,(const ErlNifPid* pid));
 #  define enif_make_monitor_term ERL_NIF_API_FUNC_MACRO(enif_make_monitor_term)
 #  define enif_set_pid_undefined ERL_NIF_API_FUNC_MACRO(enif_set_pid_undefined)
 #  define enif_is_pid_undefined ERL_NIF_API_FUNC_MACRO(enif_is_pid_undefined)
+#  define enif_term_type ERL_NIF_API_FUNC_MACRO(enif_term_type)
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment)

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -3583,6 +3583,36 @@ static ERL_NIF_TERM compare_pids_nif(ErlNifEnv* env, int argc, const ERL_NIF_TER
     return enif_make_int(env, enif_compare_pids(&a, &b));
 }
 
+static ERL_NIF_TERM term_type_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    switch (enif_term_type(env, argv[0])) {
+    case ERL_NIF_TERM_TYPE_ATOM:
+        return enif_make_atom(env, "atom");
+    case ERL_NIF_TERM_TYPE_BITSTRING:
+        return enif_make_atom(env, "bitstring");
+    case ERL_NIF_TERM_TYPE_FLOAT:
+        return enif_make_atom(env, "float");
+    case ERL_NIF_TERM_TYPE_FUN:
+        return enif_make_atom(env, "fun");
+    case ERL_NIF_TERM_TYPE_INTEGER:
+        return enif_make_atom(env, "integer");
+    case ERL_NIF_TERM_TYPE_LIST:
+        return enif_make_atom(env, "list");
+    case ERL_NIF_TERM_TYPE_MAP:
+        return enif_make_atom(env, "map");
+    case ERL_NIF_TERM_TYPE_PID:
+        return enif_make_atom(env, "pid");
+    case ERL_NIF_TERM_TYPE_PORT:
+        return enif_make_atom(env, "port");
+    case ERL_NIF_TERM_TYPE_REFERENCE:
+        return enif_make_atom(env, "reference");
+    case ERL_NIF_TERM_TYPE_TUPLE:
+        return enif_make_atom(env, "tuple");
+    default:
+        return enif_make_badarg(env);
+    }
+}
+
 static ErlNifFunc nif_funcs[] =
 {
     {"lib_version", 0, lib_version},
@@ -3690,7 +3720,8 @@ static ErlNifFunc nif_funcs[] =
     {"make_pid_nif", 1, make_pid_nif},
     {"set_pid_undefined_nif", 0, set_pid_undefined_nif},
     {"is_pid_undefined_nif", 1, is_pid_undefined_nif},
-    {"compare_pids_nif", 2, compare_pids_nif}
+    {"compare_pids_nif", 2, compare_pids_nif},
+    {"term_type_nif", 1, term_type_nif}
 };
 
 ERL_NIF_INIT(nif_SUITE,nif_funcs,load,NULL,upgrade,unload)


### PR DESCRIPTION
This helps avoid long sequences of `enif_is_xxx` in code that serializes terms (such as JSON encoders) by letting the user switch on the type.

Thanks to @dhull for pointing out the need for this!
https://github.com/erlang/otp/pull/2143#issuecomment-464379596