### PR TITLE
Clarify beam_load error message on file/module mismatch

### DIFF
--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -1425,7 +1425,7 @@ load_atom_table(LoaderState* stp, ErtsAtomEncoding enc)
 	ap = atom_tab(atom_val(stp->atom[1]));
 	sys_memcpy(sbuf, ap->name, ap->len);
 	sbuf[ap->len] = '\0';
-	LoadError1(stp, "module name in object code is %s", sbuf);
+	LoadError1(stp, "BEAM file exists but it defines a module named %s", sbuf);
     }
 
     return 1;


### PR DESCRIPTION
This is particularly important in case insensitive filesystems,
where attempting to invoke a module with the wrong case leads
to confusing error messages:

    1> erlpress_core:foo().
    beam/beam_load.c(1428): Error loading module 'erlpress_core':
      module name in object code is erlPress_core

    Loading of erlPress_core.beam failed: :badfile

This commit replaces object code by BEAM file and improves
the readability of the message.