### PR TITLE
Remove asn1/test items from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,12 +230,6 @@ JAVADOC-GENERATED
 /erts/test/install_SUITE_data/install_bin
 /erts/test/autoimport_SUITE_data/erlang.xml
 
-# asn1
-
-/lib/asn1/test/asn1_SUITE.erl
-/lib/asn1/test/asn1_bin_SUITE.erl
-/lib/asn1/test/asn1_bin_v2_SUITE.erl
-
 # common_test
 
 /lib/common_test/priv/install.sh


### PR DESCRIPTION
This file shouldn't be ignored:
```
/lib/asn1/test/asn1_SUITE.erl
```

These files don't exist any longer:
```
/lib/asn1/test/asn1_bin_SUITE.erl
/lib/asn1/test/asn1_bin_v2_SUITE.erl
```