### PR TITLE
Make crypto:cipher_info work for all ciphers and aliases

### DIFF
--- a/lib/crypto/c_src/atoms.c
+++ b/lib/crypto/c_src/atoms.c
@@ -51,6 +51,12 @@ ERL_NIF_TERM atom_ecb_mode;
 ERL_NIF_TERM atom_cbc_mode;
 ERL_NIF_TERM atom_cfb_mode;
 ERL_NIF_TERM atom_ofb_mode;
+ERL_NIF_TERM atom_ctr_mode;
+ERL_NIF_TERM atom_gcm_mode;
+ERL_NIF_TERM atom_ccm_mode;
+ERL_NIF_TERM atom_xts_mode;
+ERL_NIF_TERM atom_wrap_mode;
+ERL_NIF_TERM atom_ocb_mode;
 ERL_NIF_TERM atom_stream_cipher;
 
 #if defined(HAVE_EC)
@@ -162,6 +168,12 @@ int init_atoms(ErlNifEnv *env, const ERL_NIF_TERM fips_mode, const ERL_NIF_TERM 
     atom_cbc_mode = enif_make_atom(env,"cbc_mode");
     atom_cfb_mode = enif_make_atom(env,"cfb_mode");
     atom_ofb_mode = enif_make_atom(env,"ofb_mode");
+    atom_ctr_mode = enif_make_atom(env,"ctr_mode");
+    atom_gcm_mode = enif_make_atom(env,"gcm_mode");
+    atom_ccm_mode = enif_make_atom(env,"ccm_mode");
+    atom_xts_mode = enif_make_atom(env,"xts_mode");
+    atom_wrap_mode = enif_make_atom(env,"wrap_mode");
+    atom_ocb_mode = enif_make_atom(env,"ocb_mode");
     atom_stream_cipher = enif_make_atom(env,"stream_cipher");
 
 #if defined(HAVE_EC)

--- a/lib/crypto/c_src/atoms.h
+++ b/lib/crypto/c_src/atoms.h
@@ -55,6 +55,12 @@ extern ERL_NIF_TERM atom_ecb_mode;
 extern ERL_NIF_TERM atom_cbc_mode;
 extern ERL_NIF_TERM atom_cfb_mode;
 extern ERL_NIF_TERM atom_ofb_mode;
+extern ERL_NIF_TERM atom_ctr_mode;
+extern ERL_NIF_TERM atom_gcm_mode;
+extern ERL_NIF_TERM atom_ccm_mode;
+extern ERL_NIF_TERM atom_xts_mode;
+extern ERL_NIF_TERM atom_wrap_mode;
+extern ERL_NIF_TERM atom_ocb_mode;
 extern ERL_NIF_TERM atom_stream_cipher;
 
 #if defined(HAVE_EC)

--- a/lib/crypto/c_src/cipher.c
+++ b/lib/crypto/c_src/cipher.c
@@ -267,6 +267,42 @@ ERL_NIF_TERM cipher_info_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
             ret_mode = atom_ofb_mode;
             break;
 
+#ifdef EVP_CIPH_CTR_MODE
+        case EVP_CIPH_CTR_MODE:
+            ret_mode = atom_ctr_mode;
+            break;
+#endif
+
+#ifdef EVP_CIPH_GCM_MODE
+        case EVP_CIPH_GCM_MODE:
+            ret_mode = atom_gcm_mode;
+            break;
+#endif
+
+#ifdef EVP_CIPH_CCM_MODE
+        case EVP_CIPH_CCM_MODE:
+            ret_mode = atom_ccm_mode;
+            break;
+#endif
+
+#ifdef EVP_CIPH_XTS_MODE
+        case EVP_CIPH_XTS_MODE:
+            ret_mode = atom_xts_mode;
+            break;
+#endif
+
+#ifdef EVP_CIPH_WRAP_MODE
+        case EVP_CIPH_WRAP_MODE:
+            ret_mode = atom_wrap_mode;
+            break;
+#endif
+
+#ifdef EVP_CIPH_OCB_MODE
+        case EVP_CIPH_OCB_MODE:
+            ret_mode = atom_ocb_mode;
+            break;
+#endif
+
         case EVP_CIPH_STREAM_CIPHER:
             ret_mode = atom_stream_cipher;
             break;

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -540,6 +540,16 @@ poly1305(Key, Data) ->
 -spec cipher_info(Type) -> map() when Type :: block_cipher_with_iv()
                                            | aead_cipher()
                                            | block_cipher_without_iv().
+%% These ciphers are not available via the EVP interface on older cryptolibs.
+cipher_info(aes_ctr) ->
+    #{block_size => 1,iv_length => 16,key_length => 32,mode => ctr_mode,type => undefined};
+cipher_info(aes_128_ctr) ->
+    #{block_size => 1,iv_length => 16,key_length => 16,mode => ctr_mode,type => undefined};
+cipher_info(aes_192_ctr) ->
+    #{block_size => 1,iv_length => 16,key_length => 24,mode => ctr_mode,type => undefined};
+cipher_info(aes_256_ctr) ->
+    #{block_size => 1,iv_length => 16,key_length => 32,mode => ctr_mode,type => undefined};
+%% This cipher is handled specialy.
 cipher_info(aes_ige256) ->
     #{block_size => 16,iv_length => 32,key_length => 16,mode => ige_mode,type => undefined};
 cipher_info(Type) ->

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -540,8 +540,10 @@ poly1305(Key, Data) ->
 -spec cipher_info(Type) -> map() when Type :: block_cipher_with_iv()
                                            | aead_cipher()
                                            | block_cipher_without_iv().
+cipher_info(aes_ige256) ->
+    #{block_size => 16,iv_length => 32,key_length => 16,mode => ige_mode,type => undefined};
 cipher_info(Type) ->
-    cipher_info_nif(Type).
+    cipher_info_nif(alias(Type)).
 
 %%%---- Block ciphers
 

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -674,7 +674,8 @@ cipher_info(Config) when is_list(Config) ->
     #{type := _,key_length := _,iv_length := _,
         block_size := _,mode := _} = crypto:cipher_info(aes_128_cbc),
     {'EXIT',_} = (catch crypto:cipher_info(not_a_cipher)),
-    ok.
+    lists:foreach(fun(C) -> crypto:cipher_info(C) end,
+        proplists:get_value(ciphers, crypto:supports())).
 
 %%--------------------------------------------------------------------
 hash_info() ->
@@ -682,7 +683,8 @@ hash_info() ->
 hash_info(Config) when is_list(Config) ->
     #{type := _,size := _,block_size := _} = crypto:hash_info(sha256),
     {'EXIT',_} = (catch crypto:hash_info(not_a_hash)),
-    ok.
+    lists:foreach(fun(H) -> crypto:hash_info(H) end,
+        proplists:get_value(hashs, crypto:supports())).
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------


### PR DESCRIPTION
Fix for https://bugs.erlang.org/browse/ERL-890

I'm not sure about the ASN1 type set to `undefined` for `aes_ige256`. It may have a type defined  in OpenSSL but I'm not sure where to find this information. Though I'm fine with `undefined` for now personally.

I'm also not sure about returning `ige_mode` for the cipher mode.