### PR TITLE
Propagate seq_trace tokens to spawned processes

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1987,7 +1987,7 @@ do_send(Process *p, Eterm to, Eterm msg, Eterm return_term, Eterm *refp,
                 trace_send(p, portid, msg);
 
             if (have_seqtrace(SEQ_TRACE_TOKEN(p))) {
-                seq_trace_update_send(p);
+                seq_trace_update_serial(p);
                 seq_trace_output(SEQ_TRACE_TOKEN(p), msg,
                                  SEQ_TRACE_SEND, portid, p);
             }

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -1100,7 +1100,7 @@ erts_dsig_send_msg(ErtsDSigSendContext* ctx, Eterm remote, Eterm message)
 #endif
 
     if (have_seqtrace(SEQ_TRACE_TOKEN(sender))) {
-	seq_trace_update_send(sender);
+	seq_trace_update_serial(sender);
 	token = SEQ_TRACE_TOKEN(sender);
 	seq_trace_output(token, message, SEQ_TRACE_SEND, remote, sender);
     }
@@ -1174,7 +1174,7 @@ erts_dsig_send_reg_msg(ErtsDSigSendContext* ctx, Eterm remote_name, Eterm messag
 #endif
 
     if (have_seqtrace(SEQ_TRACE_TOKEN(sender))) {
-	seq_trace_update_send(sender);
+	seq_trace_update_serial(sender);
 	token = SEQ_TRACE_TOKEN(sender);
 	seq_trace_output(token, message, SEQ_TRACE_SEND, remote_name, sender);
     }
@@ -1233,7 +1233,7 @@ erts_dsig_send_exit_tt(ErtsDSigSendContext *ctx, Eterm local, Eterm remote,
         msg = reason;
 
     if (have_seqtrace(token)) {
-	seq_trace_update_send(ctx->c_p);
+	seq_trace_update_serial(ctx->c_p);
 	seq_trace_output_exit(token, reason, SEQ_TRACE_SEND, remote, local);
         if (ctx->dep->flags & DFLAG_EXIT_PAYLOAD) {
             ctl = TUPLE4(&ctx->ctl_heap[0],

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -1858,6 +1858,8 @@ Eterm erts_seq_trace(Process *p, Eterm arg1, Eterm arg2,
 
     if (arg1 == am_send) {
 	current_flag = SEQ_TRACE_SEND;
+    } else if (arg1 == am_spawn) {
+	current_flag = SEQ_TRACE_SPAWN;
     } else if (arg1 == am_receive) {
 	current_flag = SEQ_TRACE_RECEIVE; 
     } else if (arg1 == am_print) {
@@ -1966,8 +1968,9 @@ BIF_RETTYPE erl_seq_trace_info(Process *p, Eterm item)
     }
 
     if (have_no_seqtrace(SEQ_TRACE_TOKEN(p))) {
-	if ((item == am_send)  || (item == am_receive) || 
-	    (item == am_print) || (item == am_timestamp)
+	if ((item == am_send) || (item == am_spawn) ||
+        (item == am_receive) || (item == am_print)
+        || (item == am_timestamp)
 	    || (item == am_monotonic_timestamp)
 	    || (item == am_strict_monotonic_timestamp)) {
 	    hp = HAlloc(p,3);
@@ -1982,6 +1985,8 @@ BIF_RETTYPE erl_seq_trace_info(Process *p, Eterm item)
 
     if (item == am_send) {
 	current_flag = SEQ_TRACE_SEND;
+    } else if (item == am_spawn) {
+	current_flag = SEQ_TRACE_SPAWN;
     } else if (item == am_receive) {
 	current_flag = SEQ_TRACE_RECEIVE; 
     } else if (item == am_print) {
@@ -2031,7 +2036,7 @@ BIF_RETTYPE seq_trace_print_1(BIF_ALIST_1)
     if (have_no_seqtrace(SEQ_TRACE_TOKEN(BIF_P))) {
 	BIF_RET(am_false);
     }
-    seq_trace_update_send(BIF_P);
+    seq_trace_update_serial(BIF_P);
     seq_trace_output(SEQ_TRACE_TOKEN(BIF_P), BIF_ARG_1, 
 		     SEQ_TRACE_PRINT, NIL, BIF_P);
     BIF_RET(am_true);
@@ -2055,7 +2060,7 @@ BIF_RETTYPE seq_trace_print_2(BIF_ALIST_2)
     }
     if (SEQ_TRACE_TOKEN_LABEL(BIF_P) != BIF_ARG_1)
 	BIF_RET(am_false);
-    seq_trace_update_send(BIF_P);
+    seq_trace_update_serial(BIF_P);
     seq_trace_output(SEQ_TRACE_TOKEN(BIF_P), BIF_ARG_2, 
 		     SEQ_TRACE_PRINT, NIL, BIF_P);
     BIF_RET(am_true);

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -674,7 +674,7 @@ erts_send_message(Process* sender,
          * Make sure we don't use the heap between those instances.
          */
         if (have_seqtrace(stoken)) {
-	    seq_trace_update_send(sender);
+	    seq_trace_update_serial(sender);
 	    seq_trace_output(stoken, message, SEQ_TRACE_SEND,
 			     receiver->common.id, sender);
 

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -815,7 +815,7 @@ int enif_send(ErlNifEnv* env, const ErlNifPid* to_pid,
             }
 #endif
             if (have_seqtrace(stoken)) {
-                seq_trace_update_send(c_p);
+                seq_trace_update_serial(c_p);
                 seq_trace_output(stoken, msg, SEQ_TRACE_SEND,
                                  rp->common.id, c_p);
             }

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -994,7 +994,7 @@ send_gen_exit_signal(Process *c_p, Eterm from_tag,
 
     seq_trace = c_p && have_seqtrace(token);
     if (seq_trace)
-        seq_trace_update_send(c_p);
+        seq_trace_update_serial(c_p);
 
 #ifdef USE_VM_PROBES
     utag_sz = 0;

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1483,6 +1483,8 @@ extern int erts_system_profile_ts_type;
 #define SEQ_TRACE_SEND     (1 << 0)
 #define SEQ_TRACE_RECEIVE  (1 << 1)
 #define SEQ_TRACE_PRINT    (1 << 2)
+/* (This three-bit gap contains the timestamp.) */
+#define SEQ_TRACE_SPAWN    (1 << 6)
 
 #define ERTS_SEQ_TRACE_FLAGS_TS_TYPE_SHIFT 3
 

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -824,7 +824,7 @@ trace_receive(Process* receiver,
 }
 
 int
-seq_trace_update_send(Process *p)
+seq_trace_update_serial(Process *p)
 {
     ErtsTracer seq_tracer = erts_get_system_seq_tracer();
     ASSERT((is_tuple(SEQ_TRACE_TOKEN(p)) || is_nil(SEQ_TRACE_TOKEN(p))));
@@ -892,6 +892,7 @@ seq_trace_output_generic(Eterm token, Eterm msg, Uint type,
 
     switch (type) {
     case SEQ_TRACE_SEND:    type_atom = am_send; break;
+    case SEQ_TRACE_SPAWN:   type_atom = am_spawn; break;
     case SEQ_TRACE_PRINT:   type_atom = am_print; break;
     case SEQ_TRACE_RECEIVE: type_atom = am_receive; break;
     default:

--- a/erts/emulator/beam/erl_trace.h
+++ b/erts/emulator/beam/erl_trace.h
@@ -163,7 +163,9 @@ seq_trace_output_generic((token), (msg), (type), (receiver), NULL, (exitfrom))
 void seq_trace_output_generic(Eterm token, Eterm msg, Uint type, 
 			      Eterm receiver, Process *process, Eterm exitfrom);
 
-int seq_trace_update_send(Process *process);
+/* Bump the sequence number if tracing is enabled; must be used before sending
+ * send/spawn trace messages. */
+int seq_trace_update_serial(Process *process);
 
 Eterm erts_seq_trace(Process *process, 
 		     Eterm atom_type, Eterm atom_true_or_false, 

--- a/lib/kernel/doc/src/seq_trace.xml
+++ b/lib/kernel/doc/src/seq_trace.xml
@@ -107,6 +107,12 @@ seq_trace:set_token(OldToken), % activate the trace token again
               enables/disables tracing on message sending. Default is
               <c>false</c>.</p>
           </item>
+          <tag><c>set_token('spawn', <anno>Bool</anno>)</c></tag>
+          <item>
+            <p>A trace token flag (<c>true | false</c>) which
+              enables/disables tracing on process spawning. Default is
+              <c>false</c>.</p>
+          </item>
           <tag><c>set_token('receive', <anno>Bool</anno>)</c></tag>
           <item>
             <p>A trace token flag (<c>true | false</c>) which
@@ -259,6 +265,11 @@ TimeStamp = {Seconds, Milliseconds, Microseconds}
         <p>Used when a process <c>From</c> with its trace token flag
           <c>send</c> set to <c>true</c> has sent a message.</p>
       </item>
+      <tag><c>{spawn, Serial, Parent, Child, _}</c></tag>
+      <item>
+        <p>Used when a process <c>Parent</c> with its trace token flag
+          <c>spawn</c> set to <c>true</c> has spawned a process.</p>
+      </item>
       <tag><c>{'receive', Serial, From, To, Message}</c></tag>
       <item>
         <p>Used when a process <c>To</c> receives a message with a
@@ -295,8 +306,8 @@ TimeStamp = {Seconds, Milliseconds, Microseconds}
       is initiated by a single message. In short, it works as follows:</p>
     <p>Each process has a <em>trace token</em>, which can be empty or
       not empty. When not empty, the trace token can be seen as
-      the tuple <c>{Label, Flags, Serial, From}</c>. The trace token is
-      passed invisibly with each message.</p>
+      the tuple <c>{Label, Flags, Serial, From}</c>. The trace token is passed
+      invisibly to spawned processes and with each message sent.</p>
     <p>To start a sequential trace, the user must explicitly set
       the trace token in the process that will send the first message
       in a sequence.</p>
@@ -306,9 +317,10 @@ TimeStamp = {Seconds, Milliseconds, Microseconds}
     <p>On each Erlang node, a process can be set as the <em>system tracer</em>.
       This process will receive trace messages each time
       a message with a trace token is sent or received (if the trace
-      token flag <c>send</c> or <c>'receive'</c> is set). The system
-      tracer can then print each trace event, write it to a file, or
-      whatever suitable.</p>
+      token flag <c>send</c> or <c>'receive'</c> is set), and when a process
+      with a non-empty trace token spawns another (if the trace token flag
+      <c>spawn</c> is set). The system tracer can then print each trace event,
+      write it to a file, or whatever suitable.</p>
     <note>
       <p>The system tracer only receives those trace events that
         occur locally within the Erlang node. To get the whole picture
@@ -322,10 +334,9 @@ TimeStamp = {Seconds, Milliseconds, Microseconds}
 
   <section>
     <title>Trace Token</title>
-    <p>Each process has a current trace token. Initially, the token is
-      empty. When the process sends a message to another process, a
-      copy of the current token is sent "invisibly" along with
-      the message.</p>
+    <p>Each process has a current trace token, which is copied from the process
+      that spawned it. When a process sends a message to another process, a
+      copy of the current token is sent "invisibly" along with the message.</p>
     <p>The current token of a process is set in one of the following two
       ways:</p>
     <list type="bulleted">
@@ -354,8 +365,9 @@ TimeStamp = {Seconds, Milliseconds, Microseconds}
     <p>The algorithm for updating <c>Serial</c> can be described as
       follows:</p>
     <p>Let each process have two counters, <c>prev_cnt</c> and
-      <c>curr_cnt</c>, both are set to <c>0</c> when a process is created.
-      The counters are updated at the following occasions:</p>
+      <c>curr_cnt</c>, both are set to <c>0</c> when a process is created
+      outside of a trace sequence. The counters are updated at the following
+      occasions:</p>
     <list type="bulleted">
       <item>
         <p><em>When the process is about to send a message and the trace token
@@ -368,6 +380,16 @@ tprev := prev_cnt
 tcurr := curr_cnt</pre>
         <p>The trace token with <c>tprev</c> and <c>tcurr</c> is then
           passed along with the message.</p>
+      </item>
+      <item>
+        <p><em>When the process is about to spawn another process and the trace
+          token is not empty.</em></p>
+        <p>The counters of the parent process are updated in the same way as
+          for send above. The trace token is then passed to the child process,
+          whose counters will be set as follows:</p>
+        <code>
+curr_cnt := tcurr
+prev_cnt := tcurr</code>
       </item>
       <item>
         <p><em>When the process calls</em> <c>seq_trace:print(Label, Info)</c>,
@@ -487,9 +509,9 @@ tracer() ->
            print_trace(Label,TraceInfo,false);
         {seq_trace,Label,TraceInfo,Ts} ->
            print_trace(Label,TraceInfo,Ts);
-        Other -> ignore
+        _Other -> ignore
     end,
-    tracer().        
+    tracer().
 
 print_trace(Label,TraceInfo,false) ->
     io:format("~p:",[Label]),
@@ -504,8 +526,11 @@ print_trace({'receive',Serial,From,To,Message}) ->
     io:format("~p Received ~p FROM ~p WITH~n~p~n", 
               [To,Serial,From,Message]);
 print_trace({send,Serial,From,To,Message}) ->
-    io:format("~p Sent ~p TO ~p WITH~n~p~n", 
-              [From,Serial,To,Message]).</code>
+    io:format("~p Sent ~p TO ~p WITH~n~p~n",
+              [From,Serial,To,Message]);
+print_trace({spawn,Serial,Parent,Child,_}) ->
+    io:format("~p Spawned ~p AT ~p~n",
+              [Parent,Child,Serial]).</code>
     <p>The code that creates a process that runs this tracer function
       and sets that process as the system tracer can look like this:</p>
     <code type="none">

--- a/lib/kernel/doc/src/seq_trace.xml
+++ b/lib/kernel/doc/src/seq_trace.xml
@@ -257,7 +257,7 @@ TimeStamp = {Seconds, Milliseconds, Microseconds}
       <tag><c>{send, Serial, From, To, Message}</c></tag>
       <item>
         <p>Used when a process <c>From</c> with its trace token flag
-          <c>print</c> set to <c>true</c> has sent a message.</p>
+          <c>send</c> set to <c>true</c> has sent a message.</p>
       </item>
       <tag><c>{'receive', Serial, From, To, Message}</c></tag>
       <item>

--- a/lib/kernel/src/seq_trace.erl
+++ b/lib/kernel/src/seq_trace.erl
@@ -20,12 +20,14 @@
 
 -module(seq_trace).
 
--define(SEQ_TRACE_SEND, 1).       %(1 << 0)
--define(SEQ_TRACE_RECEIVE, 2).    %(1 << 1)
--define(SEQ_TRACE_PRINT, 4).      %(1 << 2)
--define(SEQ_TRACE_NOW_TIMESTAMP, 8). %(1 << 3)
--define(SEQ_TRACE_STRICT_MON_TIMESTAMP, 16). %(1 << 4)
--define(SEQ_TRACE_MON_TIMESTAMP, 32). %(1 << 5)
+%% Don't forget to update seq_trace_SUITE after changing these.
+-define(SEQ_TRACE_SEND, 1).                     %(1 << 0)
+-define(SEQ_TRACE_RECEIVE, 2).                  %(1 << 1)
+-define(SEQ_TRACE_PRINT, 4).                    %(1 << 2)
+-define(SEQ_TRACE_NOW_TIMESTAMP, 8).            %(1 << 3)
+-define(SEQ_TRACE_STRICT_MON_TIMESTAMP, 16).    %(1 << 4)
+-define(SEQ_TRACE_MON_TIMESTAMP, 32).           %(1 << 5)
+-define(SEQ_TRACE_SPAWN, 64).                   %(1 << 6)
 
 -export([set_token/1,
 	 set_token/2,
@@ -39,7 +41,8 @@
 
 %%---------------------------------------------------------------------------
 
--type flag()       :: 'send' | 'receive' | 'print' | 'timestamp' | 'monotonic_timestamp' | 'strict_monotonic_timestamp'.
+-type flag()       :: 'send' | 'spawn' | 'receive' | 'print' | 'timestamp' |
+                      'monotonic_timestamp' | 'strict_monotonic_timestamp'.
 -type component()  :: 'label' | 'serial' | flag().
 -type value()      :: (Label :: term())
                     | {Previous :: non_neg_integer(),
@@ -142,10 +145,11 @@ set_token2([]) ->
 decode_flags(Flags) ->
     Print = (Flags band ?SEQ_TRACE_PRINT) > 0,
     Send = (Flags band ?SEQ_TRACE_SEND) > 0,
+    Spawn = (Flags band ?SEQ_TRACE_SPAWN) > 0,
     Rec = (Flags band ?SEQ_TRACE_RECEIVE) > 0,
     NowTs = (Flags band ?SEQ_TRACE_NOW_TIMESTAMP) > 0,
     StrictMonTs = (Flags band ?SEQ_TRACE_STRICT_MON_TIMESTAMP) > 0,
     MonTs = (Flags band ?SEQ_TRACE_MON_TIMESTAMP) > 0,
-    [{print,Print},{send,Send},{'receive',Rec},{timestamp,NowTs},
+    [{print,Print},{send,Send},{spawn,Spawn},{'receive',Rec},{timestamp,NowTs},
      {strict_monotonic_timestamp, StrictMonTs},
      {monotonic_timestamp, MonTs}].

--- a/lib/kernel/test/seq_trace_SUITE.erl
+++ b/lib/kernel/test/seq_trace_SUITE.erl
@@ -994,7 +994,7 @@ stop_tracer(N) when is_integer(N) ->
 	    receive
 		{tracerlog,Data} ->
 		    Data
-	    after 1000 ->
+	    after 5000 ->
 		    {error,timeout}
 	    end
     end.

--- a/lib/observer/test/ttb_SUITE.erl
+++ b/lib/observer/test/ttb_SUITE.erl
@@ -658,11 +658,13 @@ seq_trace(Config) when is_list(Config) ->
     ?line ok = ttb:format(
 		 [filename:join(Privdir,atom_to_list(Node)++"-seq_trace")]),
     ?line [{trace_ts,StartProc,call,{?MODULE,seq,[]},{_,_,_}},
-	   {seq_trace,0,{send,{0,1},StartProc,P1Proc,{Start,P2}}},
-	   {seq_trace,0,{send,{1,2},P1Proc,P2Proc,{P1,Start}}},
-	   {seq_trace,0,{send,{2,3},P2Proc,StartProc,{P2,P1}}},
+	   {seq_trace,0,{send,{First, Seq0},StartProc,P1Proc,{Start,P2}}},
+	   {seq_trace,0,{send,{Seq0,  Seq1},P1Proc,P2Proc,{P1,Start}}},
+	   {seq_trace,0,{send,{Seq1,  Last},P2Proc,StartProc,{P2,P1}}},
 	   end_of_trace] = flush(),
-
+    true = First < Seq0,
+    true = Seq0 < Seq1,
+    true = Seq1 < Last,
    %% Additional test for metatrace
     case StartProc of
 	{Start,_,_} -> ok;


### PR DESCRIPTION
Trace tokens can be lost when a process delegates message sending to a child process, which can be pretty surprising and limits the usefulness of seq tracing. One example of this is `gen_statem:call/4` which uses a child process to implement timeouts without the risk of a late reply arriving to the caller.

This PR attempts to fix this by propagating the trace token to spawned processes, and adds optional tracing for process spawning as well.

https://bugs.erlang.org/browse/ERL-700