### PR TITLE
Add a note about timeouts on gen_tcp:connect/3,4

### DIFF
--- a/lib/kernel/doc/src/gen_tcp.xml
+++ b/lib/kernel/doc/src/gen_tcp.xml
@@ -260,7 +260,7 @@ do_recv(Sock, Bs) ->
           time-out in milliseconds. Defaults to <c>infinity</c>.</p>
         <note>
           <p>Keep in mind that if the underlying OS <c>connect()</c> call returns
-            with a timeout, <c>gen_tcp:connect</c> will also return with a timeout
+            a timeout, <c>gen_tcp:connect</c> will also return a timeout
             (i.e. <c>{error, etimedout}</c>), even if a larger <c>Timeout</c> was
             specified.</p>
         </note>

--- a/lib/kernel/doc/src/gen_tcp.xml
+++ b/lib/kernel/doc/src/gen_tcp.xml
@@ -259,6 +259,12 @@ do_recv(Sock, Bs) ->
         <p>The optional <c><anno>Timeout</anno></c> parameter specifies a
           time-out in milliseconds. Defaults to <c>infinity</c>.</p>
         <note>
+          <p>Keep in mind that if the underlying OS <c>connect()</c> call returns
+            with a timeout, <c>gen_tcp:connect</c> will also return with a timeout
+            (i.e. <c>{error, etimedout}</c>), even if a larger <c>Timeout</c> was
+            specified.</p>
+        </note>
+        <note>
           <p>The default values for options specified to <c>connect</c> can
             be affected by the Kernel configuration parameter
             <c>inet_default_connect_options</c>. For details, see


### PR DESCRIPTION
Taken almost verbatim from @RaimoNiskanen's comment from [10 years ago](http://erlang.2086793.n4.nabble.com/strange-behaviour-of-gen-tcp-connect-tp2113918p2113920.html).