### PR TITLE
Emacs: Refine xref etags matches

### DIFF
--- a/lib/tools/emacs/erlang-test.el
+++ b/lib/tools/emacs/erlang-test.el
@@ -50,8 +50,15 @@
 ;; The -L option adds a directory to the load-path.  It should be the
 ;; directory containing erlang.el and erlang-test.el.
 ;;
-;; 3. Call the script test-erlang-mode in this directory.  This script
-;; use the second method.
+;; 3. Run the emacs_SUITE.  The testcases tests_interpreted/1 and
+;; tests_compiled/1 in this suite are using the second method.  One
+;; way to run this suite is with the ct_run tool, for example like the
+;; following when standing at the OTP repo top directory:
+;;
+;; ct_run -suite lib/tools/test/emacs_SUITE
+;;
+;; Note that this creates a lot of html log files in the current
+;; directory.
 
 ;;; Code:
 

--- a/lib/tools/test/emacs_SUITE.erl
+++ b/lib/tools/test/emacs_SUITE.erl
@@ -70,19 +70,20 @@ bif_highlight(Config) ->
 
 
 check_bif_highlight(Bin, Tag, Compare) ->
-    [_H,IntMatch,_T] =
+    [_H,Match,_T] =
         re:split(Bin,<<"defvar ",Tag/binary,
                        "[^(]*\\(([^)]*)">>,[]),
-    EmacsIntBifs = [list_to_atom(S) ||
-                  S <- string:tokens(binary_to_list(IntMatch)," '\"\n")],
+    EmacsBifs = [list_to_atom(S) ||
+                  S <- string:tokens(binary_to_list(Match)," '\"\n")],
 
-    ct:log("Emacs ~p",[EmacsIntBifs]),
-    ct:log("Int ~p",[Compare]),
+    ct:log("Comparing ~s", [Tag]),
+    ct:log("Emacs ~p",[EmacsBifs]),
+    ct:log("Erlang ~p",[Compare]),
 
-    ct:log("Diff1 ~p",[Compare -- EmacsIntBifs]),
-    ct:log("Diff2 ~p",[EmacsIntBifs -- Compare]),
-    [] = Compare -- EmacsIntBifs,
-    [] = EmacsIntBifs -- Compare.
+    ct:log("Only in Erlang ~p",[Compare -- EmacsBifs]),
+    ct:log("Only in Emacs ~p",[EmacsBifs -- Compare]),
+    [] = Compare -- EmacsBifs,
+    [] = EmacsBifs -- Compare.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -188,7 +189,9 @@ diff(Orig, File) ->
     end.
 
 emacs_version_ok(AcceptVer) ->
-    case os:cmd("emacs --version | head -1") of
+    VersionLine = os:cmd("emacs --version | head -1"),
+    io:format("~s~n", [VersionLine]),
+    case VersionLine of
         "GNU Emacs " ++ Ver ->
             case string:to_float(Ver) of
                 {Vsn, _} when Vsn >= AcceptVer ->


### PR DESCRIPTION
Fetch and present arity in the *xref* window (unless too many hits).

If we are reasonably sure which definition the user wants to go to
then jump there directly instead of popping to the *xref* window.