### PR TITLE
Handle clicking links more than once in Observer's "Expanded term"

### DIFF
--- a/lib/observer/src/cdv_html_wx.erl
+++ b/lib/observer/src/cdv_html_wx.erl
@@ -138,7 +138,8 @@ handle_event(#wx{event=#wxHtmlLink{type=command_html_link_clicked,
 				 list_to_integer(Key3)}}},
 		expand(Id,cdv_term_cb,State);
 	    _ when App =:= obs ->
-		observer ! {open_link, Target};
+		observer ! {open_link, Target},
+                State;
 	    _ ->
 		cdv_virtual_list_wx:start_detail_win(Target),
 		State


### PR DESCRIPTION
When looking at an "expanded term" in Observer, such as the state term
of a supervisor process, all pids are turned into clickable links.
However, without this change, you could only follow one such link; any
further clicks would be ignored.  Fix that by ensuring that the
cdv_html_wx process holds on to its state.