### PR TITLE
Issue an error for improper use of record_info/2 in a fun

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2276,6 +2276,9 @@ expr({'fun',Line,Body}, Vt, St) ->
     case Body of
         {clauses,Cs} ->
             fun_clauses(Cs, Vt, St);
+        {function,record_info,2} ->
+            %% It is illegal to call record_info/2 with unknown arguments.
+            {[],add_error(Line, illegal_record_info, St)};
         {function,F,A} ->
 	    %% BifClash - Fun expression
             %% N.B. Only allows BIFs here as well, NO IMPORTS!!

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -3576,10 +3576,12 @@ basic_errors(Config) ->
 
 	  {illegal_record_info,
 	   <<"f1() -> record_info(42, record).
-	      f2() -> record_info(shoe_size, record).">>,
+	      f2() -> record_info(shoe_size, record).
+              f3() -> fun record_info/2.">>,
 	   [],
 	   {errors,[{1,erl_lint,illegal_record_info},
-		    {2,erl_lint,illegal_record_info}],[]}},
+		    {2,erl_lint,illegal_record_info},
+                    {3,erl_lint,illegal_record_info}],[]}},
 
 	  {illegal_expr,
 	   <<"f() -> a:b.">>,


### PR DESCRIPTION
`record_info/2` is a pseudo-function that requires literal arguments
known at compile time. Therefore, the following usage is illegal:

    f() -> fun record_info/2.

However, `erl_lint` did not issue a compilation error for this usage,
and the compiler would crash in a later pass.

https://bugs.erlang.org/browse/ERL-907