### PR TITLE
inets: httpd_request - honor RFC2616 LF only as header line terminator

### DIFF
--- a/lib/inets/src/http_server/httpd_request.erl
+++ b/lib/inets/src/http_server/httpd_request.erl
@@ -196,9 +196,9 @@ parse_headers(<<?CR,?LF,?LF,Body/binary>>, [], [], Current, Max, Options, Result
     parse_headers(<<?CR,?LF,?CR,?LF,Body/binary>>, [], [], Current, Max,  
 		  Options, Result);
 
-parse_headers(<<?LF,?LF,Body/binary>>, [], [], Current, Max,  Options, Result) ->
+parse_headers(<<?LF,?LF,Body/binary>>, Header, Headers, Current, Max,  Options, Result) ->
     %% If ?CR is is missing RFC2616 section-19.3 
-    parse_headers(<<?CR,?LF,?CR,?LF,Body/binary>>, [], [], Current, Max, 
+    parse_headers(<<?CR,?LF,?CR,?LF,Body/binary>>, Header, Headers, Current, Max, 
 		  Options, Result);
 
 parse_headers(<<?CR,?LF,?CR,?LF,Body/binary>>, [], [], _, _,  _, Result) ->

--- a/lib/inets/test/http_format_SUITE.erl
+++ b/lib/inets/test/http_format_SUITE.erl
@@ -414,6 +414,19 @@ http_request(Config) when is_list(Config) ->
 				      {max_content_length, ?HTTP_MAX_CONTENT_LENGTH}
 				     ]], HttpHead2),
 
+    %% If ?CR is is missing RFC2616 section-19.3
+    HttpHead3 = ["GET http://www.erlang.org HTTP/1.1", [?LF],
+                 "Accept: text/html", [?LF, ?LF]],
+    {"GET",
+     "http://www.erlang.org",
+     "HTTP/1.1",
+     {#http_request_h{}, [{"accept","text/html"}]}, <<>>} =
+	parse(httpd_request, parse, [[{max_header, ?HTTP_MAX_HEADER_SIZE},
+				      {max_version, ?HTTP_MAX_VERSION_STRING},
+				      {max_method, ?HTTP_MAX_METHOD_STRING},
+				      {max_content_length, ?HTTP_MAX_CONTENT_LENGTH}
+				     ]], HttpHead3),
+
     %% Note the following body is not related to the headers above
     HttpBody = ["<HTML>\n<HEAD>\n<TITLE> dummy </TITLE>\n</HEAD>\n<BODY>\n",
 		"<H1>dummy</H1>\n</BODY>\n</HTML>\n"],


### PR DESCRIPTION
RFC2616 section 19.3 specifies that LF only can be used as terminator.

The line terminator for message-header fields is the sequence CRLF.
However, we recommend that applications, when parsing such headers,
recognize a single LF as a line terminator and ignore the leading CR.

httpd_request:parse_headers(...) only partly honored this.
The parse_headers function clause matching two LF as end of headers did not allow any previously parsed headers.