### PR TITLE
Make persistent_term:put/2 and persistent_term:erase/1 yield

### DIFF
--- a/erts/doc/src/persistent_term.xml
+++ b/erts/doc/src/persistent_term.xml
@@ -121,19 +121,6 @@
   </section>
 
   <section>
-    <title>Warning For Many Persistent Terms</title>
-    <p>The runtime system will send a warning report to the
-    error logger if more than 20000 persistent terms have been
-    created. It will look like this:</p>
-
-<pre>
-More than 20000 persistent terms have been created.
-It is recommended to avoid creating an excessive number of
-persistent terms, as creation and deletion of persistent terms
-will be slower as the number of persistent terms increases.</pre>
-  </section>
-
-  <section>
     <title>Best Practices for Using Persistent Terms</title>
 
     <p>It is recommended to use keys like <c>?MODULE</c> or

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -282,6 +282,7 @@ type	ENVIRONMENT	SYSTEM		SYSTEM		environment
 
 type	PERSISTENT_TERM	LONG_LIVED	CODE		persisten_term
 type	PERSISTENT_LOCK_Q SHORT_LIVED	SYSTEM		persistent_lock_q
+type	PERSISTENT_TERM_TMP SHORT_LIVED	SYSTEM		persistent_term_tmp_table
 
 #
 # Types used for special emulators

--- a/erts/emulator/beam/erl_bif_persistent.c
+++ b/erts/emulator/beam/erl_bif_persistent.c
@@ -583,7 +583,7 @@ BIF_RETTYPE persistent_term_erase_1(BIF_ALIST_1)
         TRAPPING_COPY_TABLE_ERASE(ctx->new_table,
                                   ctx->tmp_table,
                                   new_size,
-                                  1,
+                                  ERTS_PERSISTENT_TERM_CPY_REHASH,
                                   ERASE1_TRAP_LOCATION_FINAL_COPY);
         erts_free(ERTS_ALC_T_PERSISTENT_TERM_TMP, ctx->tmp_table);
         /*
@@ -966,7 +966,7 @@ copy_table(ErtsPersistentTermCpyTableCtx* ctx)
          */
         *ctx->new_table = *ctx->old_table;
     L_copy_table_place_1:
-        for (i = MAX(0, ctx->iterations_done);
+        for (i = ctx->iterations_done;
              i < MIN(ctx->iterations_done + ctx->max_iterations,
                      ctx->new_size);
              i++) {
@@ -989,7 +989,7 @@ copy_table(ErtsPersistentTermCpyTableCtx* ctx)
         ctx->new_table->num_entries = ctx->old_table->num_entries;
         ctx->new_table->mask = ctx->new_size - 1;
     L_copy_table_place_2:
-        for (i = MAX(0, ctx->iterations_done);
+        for (i = ctx->iterations_done;
              i < MIN(ctx->iterations_done + ctx->max_iterations,
                      ctx->new_size);
              i++) {
@@ -1004,7 +1004,7 @@ copy_table(ErtsPersistentTermCpyTableCtx* ctx)
         }
         ctx->iterations_done = 0;
     L_copy_table_place_3:
-        for (i = MAX(0, ctx->iterations_done);
+        for (i = ctx->iterations_done;
              i < MIN(ctx->iterations_done + ctx->max_iterations,
                      old_size);
              i++) {

--- a/erts/emulator/test/persistent_term_SUITE.erl
+++ b/erts/emulator/test/persistent_term_SUITE.erl
@@ -633,11 +633,12 @@ pget({_, Initial}) ->
 
 
 killed_while_trapping_put(_Config) ->
+    erts_debug:set_internal_state(available_internal_state, true),
     repeat(
       fun() ->
               NrOfPutsInChild = 10000,
               do_puts(2500, my_value),
-              Pid = 
+              Pid =
                   spawn(fun() ->
                                 do_puts(NrOfPutsInChild, my_value2)
                         end),
@@ -645,14 +646,16 @@ killed_while_trapping_put(_Config) ->
               erlang:exit(Pid, kill),
               do_erases(NrOfPutsInChild)
       end,
-      5).
+      10),
+    erts_debug:set_internal_state(available_internal_state, false).
 
 killed_while_trapping_erase(_Config) ->
+    erts_debug:set_internal_state(available_internal_state, true),
     repeat(
       fun() ->
               NrOfErases = 2500,
               do_puts(NrOfErases, my_value),
-              Pid = 
+              Pid =
                   spawn(fun() ->
                                 do_erases(NrOfErases)
                         end),
@@ -660,28 +663,31 @@ killed_while_trapping_erase(_Config) ->
               erlang:exit(Pid, kill),
               do_erases(NrOfErases)
       end,
-      10).
+      10),
+    erts_debug:set_internal_state(available_internal_state, false).
 
 put_erase_trapping(_Config) ->
     NrOfItems = 5000,
+    erts_debug:set_internal_state(available_internal_state, true),
     do_puts(NrOfItems, first),
     do_puts(NrOfItems, second),
-    do_erases(NrOfItems).
+    do_erases(NrOfItems),
+    erts_debug:set_internal_state(available_internal_state, false).
 
 do_puts(0, _) -> ok;
 do_puts(NrOfPuts, ValuePrefix) ->
     Key = {?MODULE, NrOfPuts},
     Value = {ValuePrefix, NrOfPuts},
+    erts_debug:set_internal_state(reds_left, rand:uniform(250)),
     persistent_term:put(Key, Value),
-    _Hej = persistent_term:get(),
     Value = persistent_term:get(Key),
     do_puts(NrOfPuts - 1, ValuePrefix).
 
 do_erases(0) -> ok;
 do_erases(NrOfErases) ->
     Key = {?MODULE,NrOfErases},
+    erts_debug:set_internal_state(reds_left, rand:uniform(500)),
     persistent_term:erase(Key),
-    _Hej = persistent_term:get(),
     not_found = persistent_term:get(Key, not_found),
     do_erases(NrOfErases - 1).
 

--- a/erts/emulator/test/persistent_term_SUITE.erl
+++ b/erts/emulator/test/persistent_term_SUITE.erl
@@ -25,7 +25,9 @@
 	 basic/1,purging/1,sharing/1,get_trapping/1,
          info/1,info_trapping/1,killed_while_trapping/1,
          off_heap_values/1,keys/1,collisions/1,
-         init_restart/1]).
+         init_restart/1, put_erase_trapping/1,
+         killed_while_trapping_put/1,
+         killed_while_trapping_erase/1]).
 
 %%
 -export([test_init_restart_cmd/1]).
@@ -37,7 +39,8 @@ suite() ->
 all() ->
     [basic,purging,sharing,get_trapping,info,info_trapping,
      killed_while_trapping,off_heap_values,keys,collisions,
-     init_restart].
+     init_restart, put_erase_trapping, killed_while_trapping_put,
+     killed_while_trapping_erase].
 
 init_per_suite(Config) ->
     %% Put a term in the dict so that we know that the testcases handle
@@ -627,3 +630,63 @@ chk_not_stuck(Term) ->
 
 pget({_, Initial}) ->
     persistent_term:get() -- Initial.
+
+
+killed_while_trapping_put(_Config) ->
+    repeat(
+      fun() ->
+              NrOfPutsInChild = 10000,
+              do_puts(2500, my_value),
+              Pid = 
+                  spawn(fun() ->
+                                do_puts(NrOfPutsInChild, my_value2)
+                        end),
+              timer:sleep(1),
+              erlang:exit(Pid, kill),
+              do_erases(NrOfPutsInChild)
+      end,
+      5).
+
+killed_while_trapping_erase(_Config) ->
+    repeat(
+      fun() ->
+              NrOfErases = 2500,
+              do_puts(NrOfErases, my_value),
+              Pid = 
+                  spawn(fun() ->
+                                do_erases(NrOfErases)
+                        end),
+              timer:sleep(1),
+              erlang:exit(Pid, kill),
+              do_erases(NrOfErases)
+      end,
+      10).
+
+put_erase_trapping(_Config) ->
+    NrOfItems = 5000,
+    do_puts(NrOfItems, first),
+    do_puts(NrOfItems, second),
+    do_erases(NrOfItems).
+
+do_puts(0, _) -> ok;
+do_puts(NrOfPuts, ValuePrefix) ->
+    Key = {?MODULE, NrOfPuts},
+    Value = {ValuePrefix, NrOfPuts},
+    persistent_term:put(Key, Value),
+    _Hej = persistent_term:get(),
+    Value = persistent_term:get(Key),
+    do_puts(NrOfPuts - 1, ValuePrefix).
+
+do_erases(0) -> ok;
+do_erases(NrOfErases) ->
+    Key = {?MODULE,NrOfErases},
+    persistent_term:erase(Key),
+    _Hej = persistent_term:get(),
+    not_found = persistent_term:get(Key, not_found),
+    do_erases(NrOfErases - 1).
+
+repeat(_Fun, 0) ->
+    ok;
+repeat(Fun, N) ->
+    Fun(),
+    repeat(Fun, N-1).


### PR DESCRIPTION
Prior to this commit, the functions put/2 and erase/1 in the
persistent_term module did not yield even if the persistent term table
was large (the persistent term table is copied every time put/2 or
erase/1 is called). Furthermore, a call to put/2 or erase/1 did only
consume a single reduction. This commit fixes these problems.