### PR TITLE
Report stacktrace in non-transactions activity function errors.

### DIFF
--- a/lib/mnesia/src/mnesia_tm.erl
+++ b/lib/mnesia/src/mnesia_tm.erl
@@ -743,8 +743,9 @@ non_transaction(OldState, Fun, Args, ActivityKind, Mod) ->
 	{aborted, Reason} -> mnesia:abort(Reason);
 	Res -> Res
     catch
-	throw:Throw -> throw(Throw);
-	_:Reason    -> exit(Reason)
+    throw:Throw     -> throw(Throw);
+    error:Reason:ST -> exit({Reason, ST});
+    exit:Reason     -> exit(Reason)
     after
 	case OldState of
 	    undefined -> erase(mnesia_activity_state);

--- a/lib/mnesia/test/mnesia_dirty_access_test.erl
+++ b/lib/mnesia/test/mnesia_dirty_access_test.erl
@@ -142,7 +142,7 @@ dirty_error_stacktrace(Config) ->
     try
         mnesia:async_dirty(fun() -> mnesia:abort(custom_abort) end)
     catch
-        exit:{aborted, custom_error} -> ok
+        exit:{aborted, custom_abort} -> ok
     end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/mnesia/test/mnesia_dirty_access_test.erl
+++ b/lib/mnesia/test/mnesia_dirty_access_test.erl
@@ -48,7 +48,7 @@
          del_table_copy_1/1, del_table_copy_2/1, del_table_copy_3/1,
          add_table_copy_1/1, add_table_copy_2/1, add_table_copy_3/1,
          add_table_copy_4/1, move_table_copy_1/1, move_table_copy_2/1,
-         move_table_copy_3/1, move_table_copy_4/1]).
+         move_table_copy_3/1, move_table_copy_4/1, dirty_error_stacktrace/1]).
 
 -export([update_trans/3]).
 
@@ -64,7 +64,7 @@ all() ->
      {group, dirty_update_counter}, {group, dirty_delete},
      {group, dirty_delete_object},
      {group, dirty_match_object}, {group, dirty_index},
-     {group, dirty_iter}, {group, admin_tests}].
+     {group, dirty_iter}, {group, admin_tests}, dirty_error_stacktrace].
 
 groups() -> 
     [{dirty_write, [],
@@ -114,6 +114,36 @@ init_per_group(_GroupName, Config) ->
 end_per_group(_GroupName, Config) ->
     Config.
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Errors in dirty activity should have stacktrace
+dirty_error_stacktrace(Config) ->
+    %% Custom errors should have stacktrace
+    try
+        mnesia:async_dirty(fun() -> error(custom_error) end)
+    catch
+        exit:{custom_error, _} -> ok
+    end,
+
+    %% Undef error should have unknown module and function in the stacktrace
+    try
+        mnesia:async_dirty(fun() -> unknown_module:unknown_fun(arg) end)
+    catch
+        exit:{undef, [{unknown_module, unknown_fun, [arg], []} | _]} -> ok
+    end,
+
+    %% Exists don't have stacktrace
+    try
+        mnesia:async_dirty(fun() -> exit(custom_error) end)
+    catch
+        exit:custom_error -> ok
+    end,
+
+    %% Aborts don't have a stacktrace (unfortunately)
+    try
+        mnesia:async_dirty(fun() -> mnesia:abort(custom_abort) end)
+    catch
+        exit:{aborted, custom_error} -> ok
+    end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Write records dirty


### PR DESCRIPTION
If an activity function fails with an error, the stacktrace is
dropped in non_transaction function try/catch clause.
This makes debuging of errors inside a transaction really hard.

Transaction activities handle errors and exits differently, non-transaction
activities should do the same.

Adding the stacktrace to the exit reason when translating errors to exits.