### PR TITLE
Add hostname to -remsh if none is given

### DIFF
--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -460,7 +460,10 @@
       <tag><c><![CDATA[-remsh Node]]></c></tag>
       <item>
         <p>Starts Erlang with a remote shell connected to
-          <c><![CDATA[Node]]></c>.</p>
+          <c><![CDATA[Node]]></c>. Requires either <c><![CDATA[-name]]></c>
+          or <c><![CDATA[-sname]]></c> to be given. If <c><![CDATA[Node]]></c>
+          does not contain a hostname, one is automatically taken from
+          <c><![CDATA[-name]]></c> or <c><![CDATA[-sname]]></c></p>
       </item>
       <tag><c><![CDATA[-rsh Program]]></c></tag>
       <item>

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -120,7 +120,7 @@ server1(Iport, Oport, Shell) ->
     {Curr,Shell1} =
 	case init:get_argument(remsh) of
 	    {ok,[[Node]]} ->
-		ANode = list_to_atom(Node),
+		ANode = list_to_atom(append_hostname(Node)),
 		RShell = {ANode,shell,start,[]},
 		RGr = group:start(self(), RShell, rem_sh_opts(ANode)),
 		{RGr,RShell};
@@ -138,6 +138,12 @@ server1(Iport, Oport, Shell) ->
 
     %% Enter the server loop.
     server_loop(Iport, Oport, Curr, User, Gr, {false, queue:new()}).
+
+append_hostname(Node) ->
+    case string:find(Node, "@") of
+	nomatch -> Node ++ string:find(atom_to_list(node()), "@");
+	_ -> Node
+    end.
 
 rem_sh_opts(Node) ->
     [{expand_fun,fun(B)-> rpc:call(Node,edlin_expand,expand,[B]) end}].


### PR DESCRIPTION
The -name option already computes a default
hostname if none is given. This PR adds the
same behaviour to -remsh. Now we can run:

    erl -name foo -remsh bar
    erl -sname foo -remsh bar

This simplifies deployment scripts as otherwise
they have to compute the hostname by hand or
start an Erlang VM instance only to do so.