### PR TITLE
[Proposal] Add new erl_epmd:names/2 function

### DIFF
--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -41,7 +41,7 @@
 
 %% External exports
 -export([start/0, start_link/0, stop/0, port_please/2, 
-	 port_please/3, names/0, names/1,
+	 port_please/3, names/0, names/1, names/2,
 	 register_node/2, register_node/3, address_please/3, open/0, open/1, open/2]).
 
 %% gen_server callbacks
@@ -131,14 +131,29 @@ names() ->
       Reason :: address | file:posix().
 
 names(HostName) when is_atom(HostName); is_list(HostName) ->
-  case inet:gethostbyname(HostName) of
-    {ok,{hostent, _Name, _ , _Af, _Size, [EpmdAddr | _]}} ->
-      get_names(EpmdAddr);
-    Else ->
-      Else
-  end;
+    case inet:gethostbyname(HostName) of
+        {ok,{hostent, _Name, _ , _Af, _Size, [EpmdAddr | _]}} ->
+            get_names(EpmdAddr);
+        Else ->
+            Else
+    end;
 names(EpmdAddr) ->
-  get_names(EpmdAddr).
+    get_names(EpmdAddr).
+
+-spec names(Host, Family) -> {ok, [{Name, Port}]} | {error, Reason} when
+      Host :: atom() | string() | inet:ip_address(),
+      Family :: inet:address_family(),
+      Name :: string(),
+      Port :: non_neg_integer(),
+      Reason :: address | file:posix().
+
+names(HostName, Family) when is_atom(HostName); is_list(HostName) ->
+    case inet:gethostbyname(HostName, Family) of
+        {ok,{hostent, _Name, _ , _Af, _Size, [EpmdAddr | _]}} ->
+            get_names(EpmdAddr);
+        Else ->
+            Else
+    end.
 
 -spec register_node(Name, Port) -> Result when
 	  Name :: string(),

--- a/lib/kernel/src/net_adm.erl
+++ b/lib/kernel/src/net_adm.erl
@@ -20,7 +20,7 @@
 -module(net_adm).
 -export([host_file/0,
 	 localhost/0,
-	 names/0, names/1,
+	 names/0, names/1, names/2,
 	 ping_list/1,
 	 world/0,world/1,
 	 world_list/1, world_list/2,
@@ -98,6 +98,18 @@ names() ->
 names(Hostname) ->
     ErlEpmd = net_kernel:epmd_module(),
     ErlEpmd:names(Hostname).
+
+-spec names(Host, Family) -> {ok, [{Name, Port}]} | {error, Reason} when
+  Host :: atom() | string() | inet:ip_address(),
+  Family :: inet:address_family(),
+  Name :: string(),
+  Port :: non_neg_integer(),
+  Reason :: address | file:posix().
+
+names(Hostname, Family) ->
+  ErlEpmd = net_kernel:epmd_module(),
+  ErlEpmd:names(Hostname, Family).
+
 
 -spec dns_hostname(Host) -> {ok, Name} | {error, Host} when
       Host :: atom() | string(),


### PR DESCRIPTION
With `erl_epmd:names/2`  it is possible to specify the Family address
as:  `net_adm:names(localhost,inet6).`.
It would help to handle the nodes name resolution when the EPMD is bound
to IPV6 port: 
See  https://github.com/erlang/otp/pull/602#issuecomment-482561996.

for example:
```bash
bin/erl -sname hello -proto_dist inet6_tcp

(hello@linux-s1)5> net_adm:names(localhost).
{error,address}
``` 

with the new function, it is possible to specify the Family address, it would be:
```bash
bin/erl -sname hello -proto_dist inet6_tcp

(hello@linux-s1)4> net_adm:names(localhost,inet6).
{ok,[{"hello",33353}]}
```

**Note:**
This is just a proposal, please let me know what you think about if it makes sense I will add the documentation.

Thank you for your attention. 

