### PR TITLE
Use file:name_all() on spawn_executable

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2186,7 +2186,7 @@ nodes(_Arg) ->
 -spec open_port(PortName, PortSettings) -> port() when
       PortName :: {spawn, Command :: string() | binary()} |
                   {spawn_driver, Command :: string() | binary()} |
-                  {spawn_executable, FileName :: file:name() } |
+                  {spawn_executable, FileName :: file:name_all() } |
                   {fd, In :: non_neg_integer(), Out :: non_neg_integer()},
       PortSettings :: [Opt],
       Opt :: {packet, N :: 1 | 2 | 4}


### PR DESCRIPTION
The spawn_executable option in open_port supports
binaries so we update its typespec accordingly.