### PR TITLE
Decentralized counters for all ETS table types and an option to disable decentralized counters

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -193,6 +193,7 @@ atom current_location
 atom current_stacktrace
 atom data
 atom debug_flags
+atom decentralized_counters
 atom decimals
 atom default
 atom delay_trap

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -195,6 +195,7 @@ type	DB_DMC_ERR_INFO	ETS		ETS		db_dmc_error_info
 type	DB_TERM		ETS		ETS		db_term
 type	DB_PROC_CLEANUP SHORT_LIVED	ETS		db_proc_cleanup_state
 type	ETS_ALL_REQ	SHORT_LIVED	ETS		ets_all_request
+type	ETS_CTRS	ETS             ETS		ets_decentralized_ctrs
 type	LOGGER_DSBUF	TEMPORARY	SYSTEM		logger_dsbuf
 type	TMP_DSBUF	TEMPORARY	SYSTEM		tmp_dsbuf
 type	INFO_DSBUF	SYSTEM		SYSTEM		info_dsbuf

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -4053,7 +4053,16 @@ BIF_RETTYPE erts_debug_get_internal_state_1(BIF_ALIST_1)
             BIF_RET(am_notsup);
 #endif
         }
-
+        else if (ERTS_IS_ATOM_STR("flxctr_memory_usage", BIF_ARG_1)) {
+            Sint mem = erts_flxctr_debug_memory_usage();
+            if (mem == -1) {
+                BIF_RET(am_notsup);
+            } else {
+		Uint hsz = BIG_UWORD_HEAP_SIZE((UWord)mem);
+		Eterm *hp = HAlloc(BIF_P, hsz);
+		BIF_RET(uword_to_big((UWord)mem, hp));
+            }
+        }
     }
     else if (is_tuple(BIF_ARG_1)) {
 	Eterm* tp = tuple_val(BIF_ARG_1);
@@ -4642,6 +4651,8 @@ BIF_RETTYPE erts_debug_set_internal_state_2(BIF_ALIST_2)
 		flag = ERTS_DEBUG_WAIT_COMPLETED_TIMER_CANCELLATIONS;
             else if (ERTS_IS_ATOM_STR("aux_work", BIF_ARG_2))
                 flag = ERTS_DEBUG_WAIT_COMPLETED_AUX_WORK;
+            else if (ERTS_IS_ATOM_STR("thread_progress", BIF_ARG_2))
+                flag = ERTS_DEBUG_WAIT_COMPLETED_THREAD_PROGRESS;
 
             if (flag && erts_debug_wait_completed(BIF_P, flag)) {
                 ERTS_BIF_YIELD_RETURN(BIF_P, am_ok);
@@ -4723,7 +4734,6 @@ BIF_RETTYPE erts_debug_set_internal_state_2(BIF_ALIST_2)
         else if (ERTS_IS_ATOM_STR("ets_debug_random_split_join", BIF_ARG_1)) {
             if (is_tuple(BIF_ARG_2)) {
                 Eterm* tpl = tuple_val(BIF_ARG_2);
-
                 if (erts_ets_debug_random_split_join(tpl[1], tpl[2] == am_true))
                     BIF_RET(am_ok);
             }

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -1624,6 +1624,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
     int is_named, is_compressed;
     int is_fine_locked, frequent_read;
     int is_decentralized_counters;
+    int is_decentralized_counters_option;
     int cret;
     DbTableMethod* meth;
 
@@ -1639,7 +1640,8 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
     is_named = 0;
     is_fine_locked = 0;
     frequent_read = 0;
-    is_decentralized_counters = 1;
+    is_decentralized_counters = 0;
+    is_decentralized_counters_option = -1;
     heir = am_none;
     heir_data = (UWord) am_undefined;
     is_compressed = erts_ets_always_compress;
@@ -1656,6 +1658,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
 	    status &= ~(DB_SET | DB_BAG | DB_ORDERED_SET | DB_CA_ORDERED_SET);
 	}
 	else if (val == am_ordered_set) {
+            is_decentralized_counters = 1;
 	    status |= DB_ORDERED_SET;
 	    status &= ~(DB_SET | DB_BAG | DB_DUPLICATE_BAG | DB_CA_ORDERED_SET);
 	}
@@ -1686,9 +1689,9 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
 		}
                 else if (tp[1] == am_decentralized_counters) {
 		    if (tp[2] == am_true) {
-			is_decentralized_counters = 1;
+			is_decentralized_counters_option = 1;
 		    } else if (tp[2] == am_false) {
-			is_decentralized_counters = 0;
+			is_decentralized_counters_option = 0;
 		    } else break;
                 }
 		else break;
@@ -1723,6 +1726,9 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
     }
     if (is_not_nil(list)) { /* bad opt or not a well formed list */
 	BIF_ERROR(BIF_P, BADARG);
+    }
+    if (-1 != is_decentralized_counters_option) {
+        is_decentralized_counters = is_decentralized_counters_option;
     }
     if (IS_TREE_TABLE(status) && is_fine_locked && !(status & DB_PRIVATE)) {
         meth = &db_catree;

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -1623,6 +1623,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
     Sint keypos;
     int is_named, is_compressed;
     int is_fine_locked, frequent_read;
+    int is_decentralized_counters;
     int cret;
     DbTableMethod* meth;
 
@@ -1638,6 +1639,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
     is_named = 0;
     is_fine_locked = 0;
     frequent_read = 0;
+    is_decentralized_counters = 1;
     heir = am_none;
     heir_data = (UWord) am_undefined;
     is_compressed = erts_ets_always_compress;
@@ -1663,7 +1665,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
 		if (tp[1] == am_keypos
 		    && is_small(tp[2]) && (signed_val(tp[2]) > 0)) {
 		    keypos = signed_val(tp[2]);
-		}		
+		}
 		else if (tp[1] == am_write_concurrency) {
 		    if (tp[2] == am_true) {
 			is_fine_locked = 1;
@@ -1677,12 +1679,18 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
 		    } else if (tp[2] == am_false) {
 			frequent_read = 0;
 		    } else break;
-		    
 		}
 		else if (tp[1] == am_heir && tp[2] == am_none) {
 		    heir = am_none;
 		    heir_data = am_undefined;
 		}
+                else if (tp[1] == am_decentralized_counters) {
+		    if (tp[2] == am_true) {
+			is_decentralized_counters = 1;
+		    } else if (tp[2] == am_false) {
+			is_decentralized_counters = 0;
+		    } else break;
+                }
 		else break;
 	    }
 	    else if (arityval(tp[0]) == 3 && tp[1] == am_heir
@@ -1740,7 +1748,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
 
     /* we create table outside any table lock
      * and take the unusal cost of destroy table if it
-     * fails to find a slot 
+     * fails to find a slot
      */
     {
         DbTable init_tb;
@@ -1748,7 +1756,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
 	tb = (DbTable*) erts_db_alloc(ERTS_ALC_T_DB_TABLE,
 				      &init_tb, sizeof(DbTable));
         erts_flxctr_init(&tb->common.counters,
-                         status & DB_FINE_LOCKED,
+                         (status & DB_FINE_LOCKED) && is_decentralized_counters,
                          2,
                          ERTS_ALC_T_ETS_CTRS);
         erts_flxctr_add(&tb->common.counters,
@@ -1759,7 +1767,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
 
     tb->common.meth = meth;
     tb->common.the_name = BIF_ARG_1;
-    tb->common.status = status;    
+    tb->common.status = status;
     tb->common.type = status;
     /* Note, 'type' is *read only* from now on... */
     erts_refc_init(&tb->common.fix_count, 0);
@@ -1798,7 +1806,7 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
         table_dec_refc(tb, 0);
 	BIF_ERROR(BIF_P, BADARG);
     }
-    
+
     BIF_P->flags |= F_USING_DB; /* So we can remove tb if p dies */
 
 #ifdef HARDDEBUG
@@ -3289,6 +3297,7 @@ BIF_RETTYPE ets_info_1(BIF_ALIST_1)
                              am_node, am_size, am_name, am_heir, am_owner, am_memory, am_compressed,
                              am_write_concurrency,
                              am_read_concurrency,
+                             am_decentralized_counters,
                              am_id};
     Eterm results[sizeof(fields)/sizeof(Eterm)];
     DbTable* tb;
@@ -4322,7 +4331,7 @@ static Eterm table_info(Process* p, DbTable* tb, Eterm What)
     } else if (What == am_heir) {
 	ret = tb->common.heir;
     } else if (What == am_protection) {
-	if (tb->common.status & DB_PRIVATE) 
+	if (tb->common.status & DB_PRIVATE)
 	    ret = am_private;
 	else if (tb->common.status & DB_PROTECTED)
 	    ret = am_protected;
@@ -4344,6 +4353,8 @@ static Eterm table_info(Process* p, DbTable* tb, Eterm What)
 	ret = tb->common.compress ? am_true : am_false;
     } else if (What == am_id) {
         ret = make_tid(p, tb);
+    } else if (What == am_decentralized_counters) {
+        ret = tb->common.counters.is_decentralized ? am_true : am_false;
     }
 
     /*

--- a/erts/emulator/beam/erl_db_hash.c
+++ b/erts/emulator/beam/erl_db_hash.c
@@ -3632,7 +3632,7 @@ void erts_lcnt_enable_db_hash_lock_count(DbTableHash *tb, int enable) {
     }
 
     for(i = 0; i < DB_HASH_LOCK_CNT; i++) {
-        erts_lcnt_ref_t *ref = &tb->locks->lck_vec[i].lck.lcnt;
+        erts_lcnt_ref_t *ref = &tb->locks->lck_vec[i].lck_ctr.lck.lcnt;
 
         if(enable) {
             erts_lcnt_install_new_lock_info(ref, "db_hash_slot", tb->common.the_name,

--- a/erts/emulator/beam/erl_db_hash.h
+++ b/erts/emulator/beam/erl_db_hash.h
@@ -53,9 +53,14 @@ typedef struct hash_db_term {
 #define DB_HASH_LOCK_CNT 64
 #endif
 
+typedef struct DbTableHashLockAndCounter {
+    Uint nitems;
+    erts_rwmtx_t lck;
+} DbTableHashLockAndCounter;
+
 typedef struct db_table_hash_fine_locks {
     union {
-	erts_rwmtx_t lck;
+	DbTableHashLockAndCounter lck_ctr;
 	byte _cache_line_alignment[ERTS_ALC_CACHE_LINE_ALIGN_SIZE(sizeof(erts_rwmtx_t))];
     }lck_vec[DB_HASH_LOCK_CNT];
 } DbTableHashFineLocks;

--- a/erts/emulator/beam/erl_db_hash.h
+++ b/erts/emulator/beam/erl_db_hash.h
@@ -54,7 +54,7 @@ typedef struct hash_db_term {
 #endif
 
 typedef struct DbTableHashLockAndCounter {
-    Uint nitems;
+    Sint nitems;
     erts_rwmtx_t lck;
 } DbTableHashLockAndCounter;
 

--- a/erts/emulator/beam/erl_db_tree.c
+++ b/erts/emulator/beam/erl_db_tree.c
@@ -2307,9 +2307,12 @@ static SWord db_free_table_continue_tree(DbTable *tbl, SWord reds)
 		     sizeof(TreeDbTerm *) * STACK_NEED);
 	ASSERT(erts_flxctr_is_snapshot_ongoing(&tb->common.counters) ||
                ((APPROX_MEM_CONSUMED(tb)
-                 == sizeof(DbTable)) ||
+                 == (sizeof(DbTable) +
+                     erts_flxctr_nr_of_allocated_bytes(&tb->common.counters))) ||
                 (APPROX_MEM_CONSUMED(tb)
-                 == (sizeof(DbTable) + sizeof(DbFixation)))));
+                 == (sizeof(DbTable) +
+                     sizeof(DbFixation) +
+                     erts_flxctr_nr_of_allocated_bytes(&tb->common.counters)))));
     }
     return reds;
 }

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -92,7 +92,7 @@ typedef struct {
     int flags;
     union {
         struct {
-            erts_rwmtx_t* lck;
+            struct DbTableHashLockAndCounter* lck_ctr;
         } hash;
         struct {
             struct DbTableCATreeNode* base_node;

--- a/erts/emulator/beam/erl_flxctr.h
+++ b/erts/emulator/beam/erl_flxctr.h
@@ -288,6 +288,24 @@ int erts_flxctr_is_snapshot_ongoing(ErtsFlxCtr* c);
  */
 int erts_flxctr_suspend_until_thr_prg_if_snapshot_ongoing(ErtsFlxCtr* c, Process* p);
 
+/**
+ * @brief This function returns the number of bytes that are allocated
+ * for for the given FlxCtr.
+ *
+ * @return nr of bytes allocated for the FlxCtr
+ */
+size_t erts_flxctr_nr_of_allocated_bytes(ErtsFlxCtr* c);
+
+/**
+ * @brief This debug function returns the amount of memory allocated
+ * for decentralized counter arrays when compiled with the DEBUG
+ * macro. The function returns -1 if the DEBUG macro is undefined.
+ *
+ * @return number of bytes allocated for decentralized counter arrays
+ * if in debug mode and otherwise -1
+ */
+Sint erts_flxctr_debug_memory_usage(void);
+
 /* End: Public Interface */
 
 /* Internal Declarations */

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1866,6 +1866,7 @@ Uint erts_debug_nbalance(void);
 #define ERTS_DEBUG_WAIT_COMPLETED_DEALLOCATIONS		(1 << 0)
 #define ERTS_DEBUG_WAIT_COMPLETED_TIMER_CANCELLATIONS	(1 << 1)
 #define ERTS_DEBUG_WAIT_COMPLETED_AUX_WORK		(1 << 2)
+#define ERTS_DEBUG_WAIT_COMPLETED_THREAD_PROGRESS       (1 << 3)
 
 int erts_debug_wait_completed(Process *c_p, int flags);
 

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -552,13 +552,6 @@ Error: fun containing local Erlang function calls
           for a table identifier, but does not refer to an existing ETS
           table, <c>undefined</c> is returned. If <c><anno>Tab</anno></c> is
           not of the correct type, a <c>badarg</c> exception is raised.</p>
-         <p><em>Performance Information</em></p>
-         <p>The execution time of this function is affected by
-          the <seealso marker="#new_2_decentralized_counters">
-          <c>decentralized_counters</c></seealso> table option.
-          The execution time is much longer when the <c>decentralized_counters</c>
-          option is set to <c>true</c> than when the <c>decentralized_counters</c>
-          option is set to <c>false</c>.</p>
         <taglist>
           <tag><c>{compressed, boolean()}</c></tag>
           <item>
@@ -627,6 +620,13 @@ Error: fun containing local Erlang function calls
             <p>Indicates whether the table uses <c>write_concurrency</c>.</p>
           </item>
         </taglist>
+	<note><p>The execution time of this function is affected by
+          the <seealso marker="#new_2_decentralized_counters">
+          <c>decentralized_counters</c></seealso> table option.
+          The execution time is much longer when the <c>decentralized_counters</c>
+          option is set to <c>true</c> than when the <c>decentralized_counters</c>
+          option is set to <c>false</c>.</p>
+	</note>
       </desc>
     </func>
 
@@ -712,7 +712,7 @@ Error: fun containing local Erlang function calls
             <p>Returns internal statistics about tables on an internal format
 	    used by OTP test suites. Not for production use.</p></item>
         </list>
-         <p><em>Performance Information</em></p>
+        <note>
          <p>The execution time of this function is affected by
           the <seealso marker="#new_2_decentralized_counters">
           <c>decentralized_counters</c></seealso> table option when the second
@@ -720,6 +720,7 @@ Error: fun containing local Erlang function calls
           The execution time is much longer when the <c>decentralized_counters</c>
           option is set to <c>true</c> than when the <c>decentralized_counters</c>
           option is set to <c>false</c>.</p>
+	</note>
       </desc>
     </func>
 
@@ -1294,24 +1295,20 @@ ets:select(Table, MatchSpec),</code>
               Performance tuning. Defaults to <c>true</c> for tables
               of type <c>ordered_set</c> with the
               <seealso marker="#new_2_write_concurrency">
-              <c>write_concurrency</c></seealso> option enabled,
-              and defaults to false for all other
-              table types. This option has no effect if the
-              <c>write_concurrency</c> option is set to
-              <c>false</c>. When this option is set to <c>true</c>,
-              the table is optimized for few calls to <seealso
-              marker="#info/1"><c>info/1</c></seealso> or <seealso
-              marker="#info/2"><c>info/2</c></seealso> with
-              <c>size</c> or <c>memory</c> as the second argument and
-              frequent calls to operations that modify the table
-              (e.g., <seealso
+              <c>write_concurrency</c></seealso> option enabled, and defaults to
+	      false for all other   table types. This option has no effect if
+	      the <c>write_concurrency</c> option is set to <c>false</c>.</p>
+	    <p>
+	      When this option is set to <c>true</c>, the table is optimized for
+	      frequent concurrent calls to operations that modify the tables
+	      size and/or its memory consumption (e.g., <seealso
               marker="#insert/2"><c>insert/2</c></seealso> and <seealso
               marker="#delete/2"><c>delete/2</c></seealso>).
-              Calls to <seealso marker="#info/1"><c>info/1</c></seealso> and
-              <seealso marker="#info/2"><c>info/2</c></seealso> with <c>size</c> or
-              <c>memory</c> as the second argument get much slower when the
-              <c>decentralized_counters</c> option is turned on.
-            </p>
+	      The drawback is that calls to
+	      <seealso marker="#info/1"><c>info/1</c></seealso> and
+	      <seealso marker="#info/2"><c>info/2</c></seealso> with <c>size</c> or
+              <c>memory</c> as the second argument can get much slower when the
+              <c>decentralized_counters</c> option is turned on.</p>
             <p>
               When this option is enabled the counters for the
               table size and memory consumption are distributed over

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -552,6 +552,13 @@ Error: fun containing local Erlang function calls
           for a table identifier, but does not refer to an existing ETS
           table, <c>undefined</c> is returned. If <c><anno>Tab</anno></c> is
           not of the correct type, a <c>badarg</c> exception is raised.</p>
+         <p><em>Performance Information</em></p>
+         <p>The execution time of this function is affected by
+          the <seealso marker="#new_2_decentralized_counters">
+          <c>decentralized_counters</c></seealso> table option.
+          The execution time is much longer when the <c>decentralized_counters</c>
+          option is set to <c>true</c> than when the <c>decentralized_counters</c>
+          option is set to <c>false</c>.</p>
         <taglist>
           <tag><c>{compressed, boolean()}</c></tag>
           <item>
@@ -705,6 +712,14 @@ Error: fun containing local Erlang function calls
             <p>Returns internal statistics about tables on an internal format
 	    used by OTP test suites. Not for production use.</p></item>
         </list>
+         <p><em>Performance Information</em></p>
+         <p>The execution time of this function is affected by
+          the <seealso marker="#new_2_decentralized_counters">
+          <c>decentralized_counters</c></seealso> table option when the second
+          argument of the function is <c>size</c> or <c>memory</c>.
+          The execution time is much longer when the <c>decentralized_counters</c>
+          option is set to <c>true</c> than when the <c>decentralized_counters</c>
+          option is set to <c>false</c>.</p>
       </desc>
     </func>
 
@@ -1223,11 +1238,13 @@ ets:select(Table, MatchSpec),</code>
               write bursts are common; for more information, see option
               <seealso marker="#new_2_read_concurrency">
               <c>read_concurrency</c></seealso>. The <c>decentralized_counters</c>
-              option is turned on by default when <c>write_concurrency</c> is enabled.
-              One may benefit from turning the <c>decentralized_counters</c> off if
-              calls to <seealso marker="#info/1"><c>info/1</c></seealso> or
-              <seealso marker="#info/2"><c>info/2</c></seealso> with <c>size</c> or
-              <c>memory</c> as parameter are frequent.</p>
+              option is turned on by default for tables of type <c>ordered_set</c>
+              with the <c>write_concurrency</c> option enabled, and the
+              <c>decentralized_counters</c> option is turned off by default for
+              all other table types.
+              For more information, see the documentation for the
+              <seealso marker="#new_2_decentralized_counters">
+              <c>decentralized_counters</c></seealso> option.</p>
             <p>Notice that this option does not change any guarantees about
               <seealso marker="#concurrency">atomicity and isolation</seealso>.
               Functions that makes such promises over many objects (like
@@ -1274,20 +1291,26 @@ ets:select(Table, MatchSpec),</code>
           <tag><c>{decentralized_counters,boolean()}</c></tag>
           <item>
             <p>
-              Performance tuning. Defaults to <c>true</c> when the
+              Performance tuning. Defaults to <c>true</c> for tables
+              of type <c>ordered_set</c> with the
               <seealso marker="#new_2_write_concurrency">
-              <c>write_concurrency</c></seealso> option is set to
-              <c>true</c>. This option has no effect if the
+              <c>write_concurrency</c></seealso> option enabled,
+              and defaults to false for all other
+              table types. This option has no effect if the
               <c>write_concurrency</c> option is set to
               <c>false</c>. When this option is set to <c>true</c>,
               the table is optimized for few calls to <seealso
               marker="#info/1"><c>info/1</c></seealso> or <seealso
               marker="#info/2"><c>info/2</c></seealso> with
-              <c>size</c> or <c>memory</c> as the second parameter and
+              <c>size</c> or <c>memory</c> as the second argument and
               frequent calls to operations that modify the table
               (e.g., <seealso
-              marker="#insert/2"><c>insert/2</c></seealso>, <seealso
-              marker="#delete/2"><c>delete/2</c></seealso>)
+              marker="#insert/2"><c>insert/2</c></seealso> and <seealso
+              marker="#delete/2"><c>delete/2</c></seealso>).
+              Calls to <seealso marker="#info/1"><c>info/1</c></seealso> and
+              <seealso marker="#info/2"><c>info/2</c></seealso> with <c>size</c> or
+              <c>memory</c> as the second argument get much slower when the
+              <c>decentralized_counters</c> option is turned on.
             </p>
             <p>
               When this option is enabled the counters for the

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -557,6 +557,10 @@ Error: fun containing local Erlang function calls
           <item>
             <p>Indicates if the table is compressed.</p>
           </item>
+          <tag><c>{decentralized_counters, boolean()}</c></tag>
+          <item>
+            <p>Indicates whether the table uses <c>decentralized_counters</c>.</p>
+          </item>
           <tag><c>{heir, pid() | none}</c></tag>
           <item>
             <p>The pid of the heir of the table, or <c>none</c> if no heir
@@ -1113,7 +1117,8 @@ ets:select(Table, MatchSpec),</code>
           table is named. Default values are used for omitted options.
           This means that not specifying any options (<c>[]</c>) is the same
           as specifying <c>[set, protected, {keypos,1}, {heir,none},
-          {write_concurrency,false}, {read_concurrency,false}]</c>.</p>
+          {write_concurrency,false}, {read_concurrency,false},
+          {decentralized_counters,false}]</c>.</p>
         <taglist>
           <tag><c>set</c></tag>
           <item>
@@ -1208,13 +1213,21 @@ ets:select(Table, MatchSpec),</code>
               (and read) by concurrent processes. This is achieved to some
               degree at the expense of memory consumption and the performance
               of sequential access and concurrent reading.</p>
-            <p>Option <c>write_concurrency</c> can be combined with option
+              <p>The <c>write_concurrency</c> option can be combined with the options
               <seealso marker="#new_2_read_concurrency">
-              <c>read_concurrency</c></seealso>. You typically want to combine
-              these when large concurrent read bursts and large concurrent
+              <c>read_concurrency</c></seealso> and
+              <seealso marker="#new_2_decentralized_counters">
+              <c>decentralized_counters</c></seealso>. You typically want to combine
+              <c>write_concurrency</c> with <c>read_concurrency</c> when large
+              concurrent read bursts and large concurrent
               write bursts are common; for more information, see option
               <seealso marker="#new_2_read_concurrency">
-              <c>read_concurrency</c></seealso>.</p>
+              <c>read_concurrency</c></seealso>. The <c>decentralized_counters</c>
+              option is turned on by default when <c>write_concurrency</c> is enabled.
+              One may benefit from turning the <c>decentralized_counters</c> off if
+              calls to <seealso marker="#info/1"><c>info/1</c></seealso> or
+              <seealso marker="#info/2"><c>info/2</c></seealso> with <c>size</c> or
+              <c>memory</c> as parameter are frequent.</p>
             <p>Notice that this option does not change any guarantees about
               <seealso marker="#concurrency">atomicity and isolation</seealso>.
               Functions that makes such promises over many objects (like
@@ -1256,7 +1269,37 @@ ets:select(Table, MatchSpec),</code>
               <c>write_concurrency</c></seealso>.
               You typically want to combine these when large concurrent
               read bursts and large concurrent write bursts are common.</p>
-            <marker id="new_2_compressed"></marker>
+            <marker id="new_2_decentralized_counters"></marker>
+          </item>
+          <tag><c>{decentralized_counters,boolean()}</c></tag>
+          <item>
+            <p>
+              Performance tuning. Defaults to <c>true</c> when the
+              <seealso marker="#new_2_write_concurrency">
+              <c>write_concurrency</c></seealso> option is set to
+              <c>true</c>. This option has no effect if the
+              <c>write_concurrency</c> option is set to
+              <c>false</c>. When this option is set to <c>true</c>,
+              the table is optimized for few calls to <seealso
+              marker="#info/1"><c>info/1</c></seealso> or <seealso
+              marker="#info/2"><c>info/2</c></seealso> with
+              <c>size</c> or <c>memory</c> as the second parameter and
+              frequent calls to operations that modify the table
+              (e.g., <seealso
+              marker="#insert/2"><c>insert/2</c></seealso>, <seealso
+              marker="#delete/2"><c>delete/2</c></seealso>)
+            </p>
+            <p>
+              When this option is enabled the counters for the
+              table size and memory consumption are distributed over
+              several cache lines and the scheduling threads are
+              mapped to one of those cache lines. The <c>erl</c>
+              option <seealso
+              marker="erts:erl#+dcg"><c>+dcg</c></seealso> can be used
+              to control the number of cache lines that the counters
+              are distributed over.
+            </p>
+              <marker id="new_2_compressed"></marker>
           </item>
           <tag><c>compressed</c></tag>
           <item>

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -155,6 +155,7 @@ give_away(_, _, _) ->
       Tab :: tab(),
       InfoList :: [InfoTuple],
       InfoTuple :: {compressed, boolean()}
+                 | {decentralized_counters, boolean()}
                  | {heir, pid() | none}
                  | {id, tid()}
                  | {keypos, pos_integer()}
@@ -174,7 +175,7 @@ info(_) ->
 
 -spec info(Tab, Item) -> Value | undefined when
       Tab :: tab(),
-      Item :: binary | compressed | fixed | heir | id | keypos | memory
+      Item :: binary | compressed | decentralized_counters | fixed | heir | id | keypos | memory
             | name | named_table | node | owner | protection
             | safe_fixed | safe_fixed_monotonic_time | size | stats | type
 	    | write_concurrency | read_concurrency,
@@ -311,6 +312,7 @@ member(_, _) ->
       Access :: access(),
       Tweaks :: {write_concurrency, boolean()}
               | {read_concurrency, boolean()}
+              | {decentralized_counters, boolean()}
               | compressed,
       Pos :: pos_integer(),
       HeirData :: term().


### PR DESCRIPTION
This pull request contains two commits. The first commit (ad2ce60) adds support for using decentralized counters to count the number of items and the memory consumption in the ETS table types that are implemented with hashing (`set`, `bag` and `duplicate_bag`). All tables with the `write_concurrency` option activated use decentralized counters by default after this commit has been applied. The second commit (efe06e4) in this pull request adds an ETS table option that can be used to turn off decentralized counters in tables. Such an option can be useful in applications that frequently call `ets:info(T)`, `ets:info(T,size)` or `ets:info(T,memory)` because such calls are substantially slower with decentralized counters compared to with centralized counters.

[This pull request has been experimentally evaluated][1] on a machine with 64 hardware threads and a machine with 8 hardware threads.  The results from the machine with 64 hardware threads indicate that decentralized counters give ETS tables a major scalability improvement in scenarios with many write operations (i.e., `insert/2` and `delete/2`) when many cores are being utilized. Furthermore, decentralized counters do not cause a major performance penalty in any of the scenarios that are included in the benchmarks.

[1]:  http://winsh.me/ets_catree_benchmark/decent_ctrs_hash.html