### PR TITLE
Use a more reasonable scratch register in the compiler

### DIFF
--- a/lib/compiler/src/beam_ssa_pre_codegen.erl
+++ b/lib/compiler/src/beam_ssa_pre_codegen.erl
@@ -2569,8 +2569,8 @@ linear_scan(#st{intervals=Intervals0,res=Res}=St0) ->
     {UnhandledRes,Unhandled} = partition(IsReserved, Intervals),
     L = #l{unhandled_res=UnhandledRes,
            unhandled_any=Unhandled,free=Free},
-    #l{regs=Regs} = do_linear(L),
-    St#st{regs=maps:from_list(Regs)}.
+    #l{regs=Regs,free=#{{next,x}:=Scratch}} = do_linear(L),
+    St#st{regs=maps:from_list([{scratch,{x,Scratch}}|Regs])}.
 
 init_interval({V,[{Start,_}|_]=Rs}, Res) ->
     Info = map_get(V, Res),


### PR DESCRIPTION
This uses an X register larger than any used normally in the function for the scratch register when shuffling registers. In many cases, there's probably an even lower register that could be used, but this is a simple measure that avoids using the 1022 register. The high register was both alarming when analysing the produced code and might possibly lower runtime performance by significantly inflating the number of used registers.

Additionally, simplify the algorithm for finding scratch register when shuffling call arguments.