### PR TITLE
Allow file:read_file_info() to be called on I/O devices

### DIFF
--- a/erts/emulator/nifs/common/prim_file_nif.c
+++ b/erts/emulator/nifs/common/prim_file_nif.c
@@ -162,6 +162,7 @@ WRAP_FILE_HANDLE_EXPORT(allocate_nif)
 WRAP_FILE_HANDLE_EXPORT(advise_nif)
 WRAP_FILE_HANDLE_EXPORT(get_handle_nif)
 WRAP_FILE_HANDLE_EXPORT(ipread_s32bu_p32bu_nif)
+WRAP_FILE_HANDLE_EXPORT(read_handle_info_nif)
 
 static ErlNifFunc nif_funcs[] = {
     /* File handle ops */
@@ -176,6 +177,7 @@ static ErlNifFunc nif_funcs[] = {
     {"truncate_nif", 1, truncate_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"allocate_nif", 3, allocate_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"advise_nif", 4, advise_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"read_handle_info_nif", 1, read_handle_info_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
 
     /* Filesystem ops */
     {"make_hard_link_nif", 2, make_hard_link_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
@@ -896,6 +898,26 @@ static ERL_NIF_TERM get_handle_nif_impl(efile_data_t *d, ErlNifEnv *env, int arg
     return efile_get_handle(env, d);
 }
 
+static ERL_NIF_TERM build_file_info(ErlNifEnv *env, efile_fileinfo_t *info) {
+    /* #file_info as declared in file.hrl */
+    return enif_make_tuple(env, 14,
+        am_file_info,
+        enif_make_uint64(env, info->size),
+        efile_filetype_to_atom(info->type),
+        efile_access_to_atom(info->access),
+        enif_make_int64(env, MAX(EFILE_MIN_FILETIME, info->a_time)),
+        enif_make_int64(env, MAX(EFILE_MIN_FILETIME, info->m_time)),
+        enif_make_int64(env, MAX(EFILE_MIN_FILETIME, info->c_time)),
+        enif_make_uint(env, info->mode),
+        enif_make_uint(env, info->links),
+        enif_make_uint(env, info->major_device),
+        enif_make_uint(env, info->minor_device),
+        enif_make_uint(env, info->inode),
+        enif_make_uint(env, info->uid),
+        enif_make_uint(env, info->gid)
+    );
+}
+
 static ERL_NIF_TERM read_info_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     posix_errno_t posix_errno;
 
@@ -914,23 +936,20 @@ static ERL_NIF_TERM read_info_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
         return posix_error_to_tuple(env, posix_errno);
     }
 
-    /* #file_info as declared in file.hrl */
-    return enif_make_tuple(env, 14,
-        am_file_info,
-        enif_make_uint64(env, info.size),
-        efile_filetype_to_atom(info.type),
-        efile_access_to_atom(info.access),
-        enif_make_int64(env, MAX(EFILE_MIN_FILETIME, info.a_time)),
-        enif_make_int64(env, MAX(EFILE_MIN_FILETIME, info.m_time)),
-        enif_make_int64(env, MAX(EFILE_MIN_FILETIME, info.c_time)),
-        enif_make_uint(env, info.mode),
-        enif_make_uint(env, info.links),
-        enif_make_uint(env, info.major_device),
-        enif_make_uint(env, info.minor_device),
-        enif_make_uint(env, info.inode),
-        enif_make_uint(env, info.uid),
-        enif_make_uint(env, info.gid)
-    );
+    return build_file_info(env, &info);
+}
+
+static ERL_NIF_TERM read_handle_info_nif_impl(efile_data_t *d, ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    posix_errno_t posix_errno;
+    efile_fileinfo_t info = {0};
+
+    ASSERT(argc == 0);
+
+    if((posix_errno = efile_read_handle_info(d, &info))) {
+        return posix_error_to_tuple(env, posix_errno);
+    }
+
+    return build_file_info(env, &info);
 }
 
 static ERL_NIF_TERM set_permissions_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {

--- a/erts/emulator/nifs/common/prim_file_nif.h
+++ b/erts/emulator/nifs/common/prim_file_nif.h
@@ -170,6 +170,7 @@ int efile_close(efile_data_t *d, posix_errno_t *error);
 /* **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** */
 
 posix_errno_t efile_read_info(const efile_path_t *path, int follow_link, efile_fileinfo_t *result);
+posix_errno_t efile_read_handle_info(efile_data_t *d, efile_fileinfo_t *result);
 
 /** @brief Sets the file times to the given values. Refer to efile_fileinfo_t
  * for a description of each. */

--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -1444,7 +1444,11 @@ f.txt:  {person, "kalle", 25}.
            break this module's atomicity guarantees as it can race with a
            concurrent call to
            <seealso marker="#write_file_info/2"><c>write_file_info/1,2</c>
-           </seealso></p>
+           </seealso>.</p>
+        <p>This option has no effect when the function is
+           given an I/O device instead of a file name. Use
+           <seealso marker="#open/2"><c>open/2</c></seealso> with the
+           <c>raw</c> mode to obtain a file descriptor first.</p>
 	  <note>
           <p>As file times are stored in POSIX time on most OS, it is faster to
 	  query file information with option <c>posix</c>.</p>

--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -239,19 +239,29 @@ make_dir(Name) ->
 del_dir(Name) ->
     check_and_call(del_dir, [file_name(Name)]).
 
--spec read_file_info(Filename) -> {ok, FileInfo} | {error, Reason} when
-      Filename :: name_all(),
+-spec read_file_info(File) -> {ok, FileInfo} | {error, Reason} when
+      File :: name_all() | io_device(),
       FileInfo :: file_info(),
       Reason :: posix() | badarg.
+
+read_file_info(IoDevice)
+  when is_pid(IoDevice); is_record(IoDevice, file_descriptor) ->
+    read_file_info(IoDevice, []);
 
 read_file_info(Name) ->
     check_and_call(read_file_info, [file_name(Name)]).
 
--spec read_file_info(Filename, Opts) -> {ok, FileInfo} | {error, Reason} when
-      Filename :: name_all(),
+-spec read_file_info(File, Opts) -> {ok, FileInfo} | {error, Reason} when
+      File :: name_all() | io_device(),
       Opts :: [file_info_option()],
       FileInfo :: file_info(),
       Reason :: posix() | badarg.
+
+read_file_info(IoDevice, Opts) when is_pid(IoDevice), is_list(Opts) ->
+    file_request(IoDevice, {read_handle_info, Opts});
+
+read_file_info(#file_descriptor{module = Module} = Handle, Opts) when is_list(Opts) ->
+    Module:read_handle_info(Handle, Opts);
 
 read_file_info(Name, Opts) when is_list(Opts) ->
     Args = [file_name(Name), Opts],

--- a/lib/kernel/src/file_io_server.erl
+++ b/lib/kernel/src/file_io_server.erl
@@ -314,6 +314,14 @@ file_request(truncate,
 	Reply ->
 	    std_reply(Reply, State)
     end;
+file_request({read_handle_info, Opts},
+             #state{handle=Handle}=State) ->
+    case ?CALL_FD(Handle, read_handle_info, [Opts]) of
+        {error,Reason}=Reply ->
+            {stop,Reason,Reply,State};
+        Reply ->
+            {reply,Reply,State}
+    end;
 file_request(Unknown, 
 	     #state{}=State) ->
     Reason = {request, Unknown},

--- a/lib/kernel/src/raw_file_io_compressed.erl
+++ b/lib/kernel/src/raw_file_io_compressed.erl
@@ -21,7 +21,8 @@
 
 -export([close/1, sync/1, datasync/1, truncate/1, advise/4, allocate/3,
          position/2, write/2, pwrite/2, pwrite/3,
-         read_line/1, read/2, pread/2, pread/3]).
+         read_line/1, read/2, pread/2, pread/3,
+         read_handle_info/2]).
 
 %% OTP internal.
 -export([ipread_s32bu_p32bu/3, sendfile/8]).
@@ -117,6 +118,9 @@ ipread_s32bu_p32bu(Fd, Offset, MaxSize) ->
 
 sendfile(_,_,_,_,_,_,_,_) ->
     {error, enotsup}.
+
+read_handle_info(Fd, Opts) ->
+    wrap_call(Fd, [Opts]).
 
 wrap_call(Fd, Command) ->
     {_Owner, Pid} = get_fd_data(Fd),

--- a/lib/kernel/src/raw_file_io_delayed.erl
+++ b/lib/kernel/src/raw_file_io_delayed.erl
@@ -23,7 +23,8 @@
 
 -export([close/1, sync/1, datasync/1, truncate/1, advise/4, allocate/3,
          position/2, write/2, pwrite/2, pwrite/3,
-         read_line/1, read/2, pread/2, pread/3]).
+         read_line/1, read/2, pread/2, pread/3,
+         read_handle_info/2]).
 
 %% OTP internal.
 -export([ipread_s32bu_p32bu/3, sendfile/8]).
@@ -303,6 +304,9 @@ ipread_s32bu_p32bu(Fd, Offset, MaxSize) ->
 
 sendfile(_,_,_,_,_,_,_,_) ->
     {error, enotsup}.
+
+read_handle_info(Fd, Opts) ->
+    wrap_call(Fd, [Opts]).
 
 wrap_call(Fd, Command) ->
     #{ pid := Pid } = get_fd_data(Fd),

--- a/lib/kernel/src/raw_file_io_list.erl
+++ b/lib/kernel/src/raw_file_io_list.erl
@@ -21,7 +21,8 @@
 
 -export([close/1, sync/1, datasync/1, truncate/1, advise/4, allocate/3,
          position/2, write/2, pwrite/2, pwrite/3,
-         read_line/1, read/2, pread/2, pread/3]).
+         read_line/1, read/2, pread/2, pread/3,
+         read_handle_info/2]).
 
 %% OTP internal.
 -export([ipread_s32bu_p32bu/3, sendfile/8]).
@@ -126,3 +127,7 @@ sendfile(Fd, Dest, Offset, Bytes, ChunkSize, Headers, Trailers, Flags) ->
     Args = [Dest, Offset, Bytes, ChunkSize, Headers, Trailers, Flags],
     PrivateFd = Fd#file_descriptor.data,
     ?CALL_FD(PrivateFd, sendfile, Args).
+
+read_handle_info(Fd, Opts) ->
+    PrivateFd = Fd#file_descriptor.data,
+    ?CALL_FD(PrivateFd, read_handle_info, [Opts]).


### PR DESCRIPTION
This gives us the equivalent of `fstat(2)`. I've tested on Linux and Windows. On the latter I had to use the `GetFinalPathNameByHandleW()` function, which requires `_WIN32_WINNT > = 0x600`. In the PR, I'm simply returning `ENOTSUP` for lower values.

I was unsure if I should include the preloaded beam files in the PR.

Finally, this PR depends on #2212, but only for the tests on directories. The test can be removed and added back when/if that PR is merged.