### PR TITLE
add Hygon Dhyana support to enable cmpxchg and sse2 support.

### DIFF
--- a/erts/lib_src/common/ethr_aux.c
+++ b/erts/lib_src/common/ethr_aux.c
@@ -109,7 +109,8 @@ x86_init(void)
 
     if (eax > 0
 	&& (ETHR_IS_X86_VENDOR("GenuineIntel", ebx, ecx, edx)
-	    || ETHR_IS_X86_VENDOR("AuthenticAMD", ebx, ecx, edx))) {
+	    || ETHR_IS_X86_VENDOR("AuthenticAMD", ebx, ecx, edx)
+	    || ETHR_IS_X86_VENDOR("HygonGenuine", ebx, ecx, edx))) {
 	eax = 1;
 	ethr_x86_cpuid__(&eax, &ebx, &ecx, &edx);
     }


### PR DESCRIPTION
As Hygon Dhyana(Family 18h) share similar arch with AMD Family 17h,
add Hygon Dhyana support  to enable cmpxchg and sse2 support for erlang