### PR TITLE
Remove long-ago commented code

### DIFF
--- a/lib/stdlib/src/io.erl
+++ b/lib/stdlib/src/io.erl
@@ -255,8 +255,6 @@ read(Io, Prompt) ->
     case request(Io, {get_until,unicode,Prompt,erl_scan,tokens,[1]}) of
 	{ok,Toks,_EndLine} ->
 	    erl_parse:parse_term(Toks);
-%	{error, Reason} when atom(Reason) ->
-%	    erlang:error(conv_reason(read, Reason), [Io, Prompt]);
 	{error,E,_EndLine} ->
 	    {error,E};
 	{eof,_EndLine} ->


### PR DESCRIPTION
It seems to be commented out 10 years ago from https://github.com/erlang/otp/commit/84adefa331c4159d432d22840663c38f155cd4c1, would there be a special reason to keep it?