### PR TITLE
Move type-based optimizations from Core Erlang passes to SSA passes

### DIFF
--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -79,7 +79,7 @@
 -type var_base()   :: atom() | non_neg_integer().
 
 -type literal_value() :: atom() | integer() | float() | list() |
-                         nil() | tuple() | map() | binary().
+                         nil() | tuple() | map() | binary() | fun().
 
 -type op()   :: {'bif',atom()} | {'float',float_op()} | prim_op() | cg_prim_op().
 -type anno() :: #{atom() := any()}.

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -157,6 +157,8 @@ repeated_passes(Opts) ->
           ?PASS(ssa_opt_dead),
           ?PASS(ssa_opt_cse),
           ?PASS(ssa_opt_tail_phis),
+          ?PASS(ssa_opt_tuple_size),
+          ?PASS(ssa_opt_record),
           ?PASS(ssa_opt_type_continue)],        %Must run after ssa_opt_dead to
                                                 %clean up phi nodes.
     passes_1(Ps, Opts).

--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -552,6 +552,17 @@ simplify(#b_set{op={bif,'=:='},args=[A1,_A2]=Args}=I, Ts) ->
                 {true,#t_atom{elements=[true]}} ->
                     %% Bool =:= true  ==>  Bool
                     A1;
+                {true,#t_atom{elements=[false]}} ->
+                    %% Bool =:= false ==> not Bool
+                    %%
+                    %% This will be further optimized to eliminate the
+                    %% 'not', swapping the success and failure
+                    %% branches in the br instruction. If A1 comes
+                    %% from a type test (such as is_atom/1) or a
+                    %% comparison operator (such as >=) that can be
+                    %% translated to test instruction, this
+                    %% optimization will eliminate one instruction.
+                    simplify(I#b_set{op={bif,'not'},args=[A1]}, Ts);
                 {_,_} ->
                     eval_bif(I, Ts)
             end


### PR DESCRIPTION
This pull request simplifies the `sys_core_fold` pass by moving a few optimizations that `beam_ssa_type` didn't do to `beam_ssa_type`, but some optimizations will also be more effective because `beam_ssa_type` has better type information.
