### PR TITLE
Add missing attribute to debug variable

### DIFF
--- a/erts/emulator/beam/erl_sched_spec_pre_alloc.h
+++ b/erts/emulator/beam/erl_sched_spec_pre_alloc.h
@@ -49,7 +49,7 @@ do {									\
 #endif
 
 #ifdef DEBUG
-extern Uint erts_no_schedulers;
+extern Uint ERTS_WRITE_UNLIKELY(erts_no_schedulers);
 #endif
 
 #define ERTS_SSPA_FORCE_THR_CHECK_PROGRESS 10


### PR DESCRIPTION
Without this I wasn't able to compile the debug emulator, the compilation
would fail with "section attribute is specified on redeclared variable" errors.