### PR TITLE
erts: don't loop indefinitely on --enable-pgo

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -676,7 +676,7 @@ elif test "X$PROFILE_INSTR_GENERATE" = "Xtrue" -a "X$PROFILE_INSTR_USE" = "Xtrue
   PROFILE_COMPILER=clang
   AC_MSG_RESULT([yes, using -fprofile-instr-generate])
 else
-  if $enable_pgo = yes; then
+  if test $enable_pgo = yes; then
     AC_MSG_ERROR(cannot use PGO with this compiler)
   else
     AC_MSG_RESULT([no])


### PR DESCRIPTION
In https://bugs.gentoo.org/686786 gcc-9.1.0 exposed
a bug in erts/configure: if compiler does not support
PGO flags the configure process calls 'yes = yes'
(indefinite loop) instead of 'test yes = yes'.

The change does not fix gcc-9.1.0 PGO detection but
fixes ./configure termination.

Reported-by: Dennis Schridde
Bug: https://bugs.gentoo.org/686786