### PR TITLE
Remove duplication of SSH encoding macros

### DIFF
--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -68,6 +68,25 @@
 -define(string(X), ?string_utf8(X)).
 -define(binary(X), << ?STRING(X) >>).
 
+-define('2bin'(X), (if is_binary(X) -> X;
+		       is_list(X) -> list_to_binary(X);
+		       X==undefined -> <<>>
+		    end) ).
+
+%% encoding macros
+-define('E...'(X),    ?'2bin'(X)/binary ).
+-define(Eboolean(X),  ?BOOLEAN(case X of
+				   true -> ?TRUE;
+				   false -> ?FALSE
+			       end) ).
+-define(Ebyte(X),        ?BYTE(X) ).
+-define(Euint32(X),      ?UINT32(X) ).
+-define(Estring(X),      ?STRING(?'2bin'(X)) ).
+-define(Estring_utf8(X), ?string_utf8(X)/binary ).
+-define(Ename_list(X),   ?STRING(ssh_bits:name_list(X)) ).
+-define(Empint(X),       (ssh_bits:mpint(X))/binary ).
+-define(Ebinary(X),      ?STRING(X) ).
+
 %% Cipher details
 -define(SSH_CIPHER_NONE, 0).
 -define(SSH_CIPHER_3DES, 3).

--- a/lib/ssh/src/ssh_message.erl
+++ b/lib/ssh/src/ssh_message.erl
@@ -34,24 +34,6 @@
 
 -export([dbg_trace/3]).
 
--define('2bin'(X), (if is_binary(X) -> X;
-		       is_list(X) -> list_to_binary(X);
-		       X==undefined -> <<>>
-		    end) ).
-
--define('E...'(X),    ?'2bin'(X)/binary ).
--define(Eboolean(X),  ?BOOLEAN(case X of
-				   true -> ?TRUE;
-				   false -> ?FALSE
-			       end) ).
--define(Ebyte(X),        ?BYTE(X) ).
--define(Euint32(X),      ?UINT32(X) ).
--define(Estring(X),      ?STRING(?'2bin'(X)) ).
--define(Estring_utf8(X), ?string_utf8(X)/binary ).
--define(Ename_list(X),   ?STRING(ssh_bits:name_list(X)) ).
--define(Empint(X),       (ssh_bits:mpint(X))/binary ).
--define(Ebinary(X),      ?STRING(X) ).
-
 ucl(B) ->
     try unicode:characters_to_list(B) of
 	L when is_list(L) -> L;

--- a/lib/ssh/src/ssh_transport.erl
+++ b/lib/ssh/src/ssh_transport.erl
@@ -61,14 +61,6 @@
 -export([pack/3, adjust_algs_for_peer_version/2]).
 -export([decompress/2,  decrypt_blocks/3, is_valid_mac/3 ]). % FIXME: remove
 
--define(Estring(X), ?STRING((if is_binary(X) -> X;
-				is_list(X) -> list_to_binary(X);
-				X==undefined -> <<>>
-			     end))).
--define(Empint(X),     (ssh_bits:mpint(X))/binary ).
--define(Ebinary(X),    ?STRING(X) ).
--define(Euint32(X),   ?UINT32(X) ).
-
 %%%----------------------------------------------------------------------------
 %%%
 %%% There is a difference between supported and default algorithms. The


### PR DESCRIPTION
I noticed some duplication of macros within the `ssh` modules and did a tiny refactoring.