### PR TITLE
Fix loading of Core Erlang code for extracting a map element

### DIFF
--- a/lib/compiler/test/core_SUITE.erl
+++ b/lib/compiler/test/core_SUITE.erl
@@ -29,7 +29,8 @@
 	 bs_shadowed_size_var/1,
 	 cover_v3_kernel_1/1,cover_v3_kernel_2/1,cover_v3_kernel_3/1,
 	 cover_v3_kernel_4/1,cover_v3_kernel_5/1,
-         non_variable_apply/1,name_capture/1,fun_letrec_effect/1]).
+         non_variable_apply/1,name_capture/1,fun_letrec_effect/1,
+         get_map_element/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -57,7 +58,8 @@ groups() ->
        bs_shadowed_size_var,
        cover_v3_kernel_1,cover_v3_kernel_2,cover_v3_kernel_3,
        cover_v3_kernel_4,cover_v3_kernel_5,
-       non_variable_apply,name_capture,fun_letrec_effect
+       non_variable_apply,name_capture,fun_letrec_effect,
+       get_map_element
       ]}].
 
 
@@ -95,6 +97,7 @@ end_per_group(_GroupName, Config) ->
 ?comp(non_variable_apply).
 ?comp(name_capture).
 ?comp(fun_letrec_effect).
+?comp(get_map_element).
 
 try_it(Mod, Conf) ->
     Src = filename:join(proplists:get_value(data_dir, Conf),

--- a/lib/compiler/test/core_SUITE_data/get_map_element.core
+++ b/lib/compiler/test/core_SUITE_data/get_map_element.core
@@ -1,0 +1,18 @@
+module 'get_map_element' ['get_map_element'/0]
+attributes []
+
+'get_map_element'/0 =
+    fun () ->
+      apply 'match_map'/1(~{'foo'=>'bar'}~)
+
+'match_map'/1 =
+    fun (_0) ->
+	case _0 of
+	  <~{'foo':='bar'}~> when 'true' ->
+	    'ok'
+	  %% It will be undefined behaviour at runtime if no
+	  %% clause of the case can be selected. That can't
+	  %% happen for this module, because match_map/1 is
+	  %% always called with a matching map argument.
+    end
+end


### PR DESCRIPTION
The following Core Erlang code could not be loaded:

    'f'/1 = fun (_1) ->
                case <_1> of
                  <~{'foo':='foo'}~> when 'true' ->
                    _1
                end

Loading would fail with the following message:

     beam/beam_load.c(2314): Error loading function example:f/1: op i_get_map_element_hash p x a u x:
       no specific operation found

https://bugs.erlang.org/browse/ERL-955