### PR TITLE
Export ssl:named_curve/0 and ssl:sign_scheme/0 types

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -125,7 +125,9 @@
               protocol_extensions/0,
               session_id/0,
               error_alert/0,
-              srp_param_type/0]).
+              srp_param_type/0,
+              named_curve/0,
+              sign_scheme/0]).
 
 %% -------------------------------------------------------------------------------------------------------
 
@@ -191,7 +193,7 @@
                                  | rsa_pss_pss_sha384
                                  | rsa_pss_pss_sha512
                                  | rsa_pkcs1_sha1
-                                 | ecdsa_sha1.
+                                 | ecdsa_sha1. % exported
 -type kex_algo()                :: rsa |
                                    dhe_rsa | dhe_dss |
                                    ecdhe_ecdsa | ecdh_ecdsa | ecdh_rsa |
@@ -236,7 +238,7 @@
                                  sect163r2 |
                                  secp160k1 |
                                  secp160r1 |
-                                 secp160r2.
+                                 secp160r2. % exported
 
 -type group() :: secp256r1 | secp384r1 | secp521r1 | ffdhe2048 |
                  ffdhe3072 | ffdhe4096 | ffdhe6144 | ffdhe8192.


### PR DESCRIPTION
The types `ssl:named_curve/0` and `ssl:sign_scheme/0` consist of many options and may also change with time. Since they are not exported, users must either repeat and forthwith maintain their specs, or use a general type like `any()` or `atom()` if they want to refer to them.