### PR TITLE
Fix wxe_driver improper realloc call

### DIFF
--- a/lib/wx/c_src/wxe_driver.c
+++ b/lib/wx/c_src/wxe_driver.c
@@ -214,7 +214,7 @@ standard_outputv(ErlDrvData drv_data, ErlIOVec* ev)
 
    if(binref == NULL) { /* realloc */
      max = sd->max_bins + DEF_BINS;
-     driver_realloc(sd->bin, sizeof(WXEBinRef)*max);
+     sd->bin = driver_realloc(sd->bin, sizeof(WXEBinRef)*max);
      for(i=sd->max_bins; i < max; i++) {
        sd->bin[i].from = 0;
      }


### PR DESCRIPTION
Looks like I accidentally deleted my last PR. Anyways, driver_realloc works just like regular realloc and expects the caller to match pointers to the allocation with the return value, otherwise undefined behaviour ensues.