### PR TITLE
Improve some log events from OTP

### DIFF
--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2017-2018. All Rights Reserved.
+%% Copyright Ericsson AB 2017-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -570,8 +570,8 @@ set_application_level(App,Level) ->
             {error, {not_loaded, App}}
     end.
 
--spec unset_application_level(Application) -> ok | {error, not_loaded} when
-      Application :: atom().
+-spec unset_application_level(Application) ->
+         ok | {error, {not_loaded, Application}} when Application :: atom().
 unset_application_level(App) ->
     case application:get_key(App, modules) of
         {ok, Modules} ->

--- a/lib/kernel/src/logger_formatter.erl
+++ b/lib/kernel/src/logger_formatter.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2017-2018. All Rights Reserved.
+%% Copyright Ericsson AB 2017-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -323,7 +323,7 @@ timestamp_to_datetimemicro(SysTime,Config) when is_integer(SysTime) ->
     {Date,Time,Micro,UtcStr}.
 
 format_mfa({M,F,A},_) when is_atom(M), is_atom(F), is_integer(A) ->
-    atom_to_list(M)++":"++atom_to_list(F)++"/"++integer_to_list(A);
+    io_lib:fwrite("~tw:~tw/~w", [M, F, A]);
 format_mfa({M,F,A},Config) when is_atom(M), is_atom(F), is_list(A) ->
     format_mfa({M,F,length(A)},Config);
 format_mfa(MFA,Config) ->

--- a/lib/kernel/src/logger_handler_watcher.erl
+++ b/lib/kernel/src/logger_handler_watcher.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2018. All Rights Reserved.
+%% Copyright Ericsson AB 2018-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -51,42 +51,25 @@ register_handler(Id,Pid) ->
 %%% gen_server callbacks
 %%%===================================================================
 
--spec init(Args :: term()) -> {ok, State :: term()} |
-                              {ok, State :: term(), Timeout :: timeout()} |
-                              {ok, State :: term(), hibernate} |
-                              {stop, Reason :: term()} |
-                              ignore.
+-spec init(Args :: term()) -> {ok, State :: term()}.
 init([]) ->
     process_flag(trap_exit, true),
     {ok, #state{handlers=[]}}.
 
 -spec handle_call(Request :: term(), From :: {pid(), term()}, State :: term()) ->
-                         {reply, Reply :: term(), NewState :: term()} |
-                         {reply, Reply :: term(), NewState :: term(), Timeout :: timeout()} |
-                         {reply, Reply :: term(), NewState :: term(), hibernate} |
-                         {noreply, NewState :: term()} |
-                         {noreply, NewState :: term(), Timeout :: timeout()} |
-                         {noreply, NewState :: term(), hibernate} |
-                         {stop, Reason :: term(), Reply :: term(), NewState :: term()} |
-                         {stop, Reason :: term(), NewState :: term()}.
+                         {reply, ok, NewState :: term()}.
 handle_call({register,Id,Pid}, _From, #state{handlers=Hs}=State) ->
     Ref = erlang:monitor(process,Pid),
     Hs1 = lists:keystore(Id,1,Hs,{Id,Ref}),
     {reply, ok, State#state{handlers=Hs1}}.
 
 -spec handle_cast(Request :: term(), State :: term()) ->
-                         {noreply, NewState :: term()} |
-                         {noreply, NewState :: term(), Timeout :: timeout()} |
-                         {noreply, NewState :: term(), hibernate} |
-                         {stop, Reason :: term(), NewState :: term()}.
+                         {noreply, NewState :: term()}.
 handle_cast(_Request, State) ->
     {noreply, State}.
 
 -spec handle_info(Info :: timeout() | term(), State :: term()) ->
-                         {noreply, NewState :: term()} |
-                         {noreply, NewState :: term(), Timeout :: timeout()} |
-                         {noreply, NewState :: term(), hibernate} |
-                         {stop, Reason :: normal | term(), NewState :: term()}.
+                         {noreply, NewState :: term()}.
 handle_info({'DOWN',Ref,process,_,shutdown}, #state{handlers=Hs}=State) ->
     case lists:keytake(Ref,2,Hs) of
         {value,{Id,Ref},Hs1} ->
@@ -108,6 +91,6 @@ handle_info(_Other,State) ->
     {noreply,State}.
 
 -spec terminate(Reason :: normal | shutdown | {shutdown, term()} | term(),
-                State :: term()) -> any().
+                State :: term()) -> ok.
 terminate(_Reason, _State) ->
     ok.

--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2018. All Rights Reserved.
+%% Copyright Ericsson AB 2018-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -567,6 +567,11 @@ format_mfa(_Config) ->
     String4 = format(info,{"~p",[term]},Meta4,#{template=>Template}),
     ct:log(String4),
     "othermfa" = String4,
+
+    Meta5 = #{mfa=>{'m o d','a\x{281}b',['  ']}},
+    String5 = format(info,{"~p",[term]},Meta5,#{template=>Template}),
+    ct:log(String5),
+    "'m o d':'a\x{281}b'/1" = String5,
 
     ok.
     

--- a/lib/kernel/test/logger_legacy_SUITE.erl
+++ b/lib/kernel/test/logger_legacy_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2018. All Rights Reserved.
+%% Copyright Ericsson AB 2018-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -137,9 +137,9 @@ gen_event(_Config) ->
     ok = gen_event:add_handler(Pid,?MODULE,gen_event),
     Msg = fun() -> erlang:error({badmatch,b}) end,
     Pid ! Msg,
-    ?check({warning_msg,"** Undefined handle_info in ~tp"++_,[?MODULE,Msg]}),
+    ?check({warning_msg,"** Undefined handle_info in ~p"++_,[?MODULE,Msg]}),
     gen_event:notify(Pid,Msg),
-    ?check({error,"** gen_event handler ~p crashed."++_,
+    ?check({error,"** gen_event handler ~tp crashed."++_,
             [?MODULE,Pid,Msg,gen_event,{{badmatch,b},_}]}).
 
 gen_fsm(_Config) ->

--- a/lib/sasl/test/sasl_report_SUITE.erl
+++ b/lib/sasl/test/sasl_report_SUITE.erl
@@ -98,7 +98,7 @@ gen_server_crash(Config, Encoding) ->
                                               (_,_) -> ignore
                                            end,[]}),
     ct:log("Local node Logger config:~n~p",
-           [rpc:call(Node,logger,get_config,[])]),
+           [logger:get_config()]),
     ct:log("Remote node Logger config:~n~p",
            [rpc:call(Node,logger,get_config,[])]),
     ct:log("Remote node error_logger handlers: ~p",

--- a/lib/sasl/test/sasl_report_SUITE.erl
+++ b/lib/sasl/test/sasl_report_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2015-2018. All Rights Reserved.
+%% Copyright Ericsson AB 2015-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2]).
 -export([gen_server_crash/1, gen_server_crash_unicode/1]).
+-export([gen_server_crash_chars_limit/1,
+         gen_server_crash_chars_limit_unicode/1]).
 -export([legacy_gen_server_crash/1, legacy_gen_server_crash_unicode/1]).
 
 -export([crash_me/0,start_link/0,init/1,handle_cast/2,terminate/2]).
@@ -32,6 +34,8 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 all() ->
     [gen_server_crash,
      gen_server_crash_unicode,
+     gen_server_crash_chars_limit,
+     gen_server_crash_chars_limit_unicode,
      legacy_gen_server_crash,
      legacy_gen_server_crash_unicode].
 
@@ -51,18 +55,31 @@ end_per_group(_GroupName, Config) ->
     Config.
 
 gen_server_crash(Config) ->
-    gen_server_crash(Config, latin1).
+    gen_server_crash(Config, latin1, depth).
 
 gen_server_crash_unicode(Config) ->
-    gen_server_crash(Config, unicode).
+    gen_server_crash(Config, unicode, depth).
+
+gen_server_crash_chars_limit(Config) ->
+    gen_server_crash(Config, latin1, chars_limit).
+
+gen_server_crash_chars_limit_unicode(Config) ->
+    gen_server_crash(Config, unicode, chars_limit).
 
 legacy_gen_server_crash(Config) ->
-    legacy_gen_server_crash(Config,latin1).
+    legacy_gen_server_crash(Config, latin1).
 
 legacy_gen_server_crash_unicode(Config) ->
-    legacy_gen_server_crash(Config,unicode).
+    legacy_gen_server_crash(Config, unicode).
 
-gen_server_crash(Config, Encoding) ->
+gen_server_crash(Config, Encoding, depth) ->
+    FormatterOpts = #{depth=>30},
+    gen_server_crash(Config, Encoding, FormatterOpts, 70000, 150000);
+gen_server_crash(Config, Encoding, chars_limit) ->
+    FormatterOpts = #{chars_limit=>50000, single_line=>true},
+    gen_server_crash(Config, Encoding, FormatterOpts, 50000, 100000).
+
+gen_server_crash(Config, Encoding, FormatterOpts, Min, Max) ->
     TC = list_to_atom(lists:concat([?FUNCTION_NAME,"_",Encoding])),
     PrivDir = filename:join(?config(priv_dir,Config),?MODULE),
     ConfigFileName = filename:join(PrivDir,TC),
@@ -85,9 +102,9 @@ gen_server_crash(Config, Encoding) ->
                    " -boot start_sasl -kernel start_timer true "
                    "-config ",ConfigFileName]}]),
 
-    %% Set depth
-    ok = rpc:call(Node,logger,update_formatter_config,[default,depth,30]),
-    ok = rpc:call(Node,logger,update_formatter_config,[sasl,depth,30]),
+    %% Set depth or chars_limit.
+    ok = rpc:call(Node,logger,update_formatter_config,[default,FormatterOpts]),
+    ok = rpc:call(Node,logger,update_formatter_config,[sasl,FormatterOpts]),
 
     %% Make sure remote node logs it's own logs, and current node does
     %% not log them.
@@ -112,8 +129,8 @@ gen_server_crash(Config, Encoding) ->
     test_server:stop_node(Node),
     ok = logger:remove_primary_filter(no_remote),
 
-    check_file(KernelLog, utf8, 70000, 150000),
-    check_file(SaslLog, Encoding, 70000, 150000),
+    check_file(KernelLog, utf8, Min, Max),
+    check_file(SaslLog, Encoding, Min, Max),
 
     ok = file:delete(KernelLog),
     ok = file:delete(SaslLog),
@@ -169,6 +186,7 @@ check_file(File, Encoding, Min, Max) ->
         _ -> io:format("~ts\n", [Bin])
     end,
     Sz = byte_size(Bin),
+    %% Sz = string:length(string:replace(Bin, " ", "", all)),
     io:format("Size: ~p (allowed range is ~p..~p)\n",
 	      [Sz,Min,Max]),
     if

--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -901,7 +901,7 @@ format_mfa(Indent0, {M,F,Args}=StartF, #{encoding:=Enc,single_line:=Single}=Extr
              end,
     try
 	A = length(Args),
-	[Indent,"initial call: ",atom_to_list(M),$:,to_string(F, Enc),$/,
+	[Indent,"initial call: ",to_string(M, Enc),$:,to_string(F, Enc),$/,
 	 integer_to_list(A)]
     catch
 	error:_ ->

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1996-2018. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -32,6 +32,9 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3, format_status/2]).
 
+%% logger callback
+-export([format_log/1, format_log/2]).
+
 %% For release_handler only
 -export([get_callback_module/1]).
 
@@ -44,10 +47,11 @@
                               {reason,Reason},
                               {offender,extract_child(Child)}]},
                    #{domain=>[otp,sasl],
-                     report_cb=>fun logger:format_otp_report/1,
+                     report_cb=>fun supervisor:format_log/2,
                      logger_formatter=>#{title=>"SUPERVISOR REPORT"},
                      error_logger=>#{tag=>error_report,
-                                     type=>supervisor_report}})).
+                                     type=>supervisor_report,
+                                     report_cb=>fun supervisor:format_log/1}})).
 
 %%--------------------------------------------------------------------------
 
@@ -1428,9 +1432,159 @@ report_progress(Child, SupName) ->
                 report=>[{supervisor,SupName},
                          {started,extract_child(Child)}]},
               #{domain=>[otp,sasl],
-                report_cb=>fun logger:format_otp_report/1,
+                report_cb=>fun supervisor:format_log/2,
                 logger_formatter=>#{title=>"PROGRESS REPORT"},
-                error_logger=>#{tag=>info_report,type=>progress}}).
+                error_logger=>#{tag=>info_report,
+                                type=>progress,
+                                report_cb=>fun supervisor:format_log/1}}).
+
+%% format_log/1 is the report callback used by Logger handler
+%% error_logger only. It is kept for backwards compatibility with
+%% legacy error_logger event handlers. This function must always
+%% return {Format,Args} compatible with the arguments in this module's
+%% calls to error_logger prior to OTP-21.0.
+format_log(LogReport) ->
+    Depth = error_logger:get_format_depth(),
+    FormatOpts = #{chars_limit => unlimited,
+                   depth => Depth,
+                   single_line => false,
+                   encoding => utf8},
+    format_log_multi(limit_report(LogReport, Depth), FormatOpts).
+
+limit_report(LogReport, unlimited) ->
+    LogReport;
+limit_report(#{label:={supervisor,progress},
+               report:=[{supervisor,_}=Supervisor,{started,Child}]}=LogReport,
+             Depth) ->
+    LogReport#{report=>[Supervisor,
+                        {started,limit_child_report(Child, Depth)}]};
+limit_report(#{label:={supervisor,_Error},
+               report:=[{supervisor,_}=Supervisor,{errorContext,Ctxt},
+                        {reason,Reason},{offender,Child}]}=LogReport,
+             Depth) ->
+    LogReport#{report=>[Supervisor,
+                        {errorContext,io_lib:limit_term(Ctxt, Depth)},
+                        {reason,io_lib:limit_term(Reason, Depth)},
+                        {offender,limit_child_report(Child, Depth)}]}.
+
+limit_child_report(Report, Depth) ->
+    io_lib:limit_term(Report, Depth).
+
+%% format_log/2 is the report callback for any Logger handler, except
+%% error_logger.
+format_log(Report, FormatOpts0) ->
+    Default = #{chars_limit => unlimited,
+                depth => unlimited,
+                single_line => false,
+                encoding => utf8},
+    FormatOpts = maps:merge(Default, FormatOpts0),
+    IoOpts =
+        case FormatOpts of
+            #{chars_limit:=unlimited} ->
+                [];
+            #{chars_limit:=Limit} ->
+                [{chars_limit,Limit}]
+        end,
+    {Format,Args} = format_log_single(Report, FormatOpts),
+    io_lib:format(Format, Args, IoOpts).
+
+format_log_single(#{label:={supervisor,progress},
+                    report:=[{supervisor,SupName},{started,Child}]},
+                  #{single_line:=true,depth:=Depth}=FormatOpts) ->
+    P = p(FormatOpts),
+    {ChildFormat,ChildArgs} = format_child_log_single(Child, "Started:"),
+    Format = "Supervisor: "++P++".",
+    Args =
+        case Depth of
+            unlimited ->
+                [SupName];
+            _ ->
+                [SupName,Depth]
+        end,
+    {Format++ChildFormat,Args++ChildArgs};
+format_log_single(#{label:={supervisor,_Error},
+                    report:=[{supervisor,SupName},
+                             {errorContext,Ctxt},
+                             {reason,Reason},
+                             {offender,Child}]},
+                  #{single_line:=true,depth:=Depth}=FormatOpts) ->
+    P = p(FormatOpts),
+    Format = lists:append(["Supervisor: ",P,". Context: ",P,
+                            ". Reason: ",P,"."]),
+    {ChildFormat,ChildArgs} = format_child_log_single(Child, "Offender:"),
+    Args =
+        case Depth of
+            unlimited ->
+                [SupName,Ctxt,Reason];
+            _ ->
+                [SupName,Depth,Ctxt,Depth,Reason,Depth]
+        end,
+    {Format++ChildFormat,Args++ChildArgs};
+format_log_single(Report,FormatOpts) ->
+    format_log_multi(Report,FormatOpts).
+
+format_log_multi(#{label:={supervisor,progress},
+                   report:=[{supervisor,SupName},
+                            {started,Child}]},
+                 #{depth:=Depth}=FormatOpts) ->
+    P = p(FormatOpts),
+    Format =
+        lists:append(
+          ["    supervisor: ",P,"~n",
+           "    started: ",P,"~n"]),
+    Args =
+        case Depth of
+            unlimited ->
+                [SupName,Child];
+            _ ->
+                [SupName,Depth,Child,Depth]
+        end,
+    {Format,Args};
+format_log_multi(#{label:={supervisor,_Error},
+                   report:=[{supervisor,SupName},
+                            {errorContext,Ctxt},
+                            {reason,Reason},
+                            {offender,Child}]},
+                 #{depth:=Depth}=FormatOpts) ->
+    P = p(FormatOpts),
+    Format =
+        lists:append(
+          ["    supervisor: ",P,"~n",
+           "    errorContext: ",P,"~n",
+           "    reason: ",P,"~n",
+           "    offender: ",P,"~n"]),
+    Args =
+        case Depth of
+            unlimited ->
+                [SupName,Ctxt,Reason,Child];
+            _ ->
+                [SupName,Depth,Ctxt,Depth,Reason,Depth,Child,Depth]
+        end,
+    {Format,Args}.
+
+format_child_log_single(Child, Tag) ->
+    {id,Id} = lists:keyfind(id, 1, Child),
+    case lists:keyfind(pid, 1, Child) of
+        false ->
+            {nb_children,NumCh} = lists:keyfind(nb_children, 1, Child),
+            {" ~s id=~w,nb_children=~w.", [Tag,Id,NumCh]};
+        T when is_tuple(T) ->
+            {pid,Pid} = lists:keyfind(pid, 1, Child),
+            {" ~s id=~w,pid=~w.", [Tag,Id,Pid]}
+    end.
+
+p(#{single_line:=Single,depth:=Depth,encoding:=Enc}) ->
+    "~"++single(Single)++mod(Enc)++p(Depth);
+p(unlimited) ->
+    "p";
+p(_Depth) ->
+    "P".
+
+single(true) -> "0";
+single(false) -> "".
+
+mod(latin1) -> "";
+mod(_) -> "t".
 
 format_status(terminate, [_PDict, State]) ->
     State;

--- a/lib/stdlib/src/supervisor_bridge.erl
+++ b/lib/stdlib/src/supervisor_bridge.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %% 
-%% Copyright Ericsson AB 1996-2018. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2019. All Rights Reserved.
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@
 %% Internal exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 -export([code_change/3]).
+%% logger callback
+-export([format_log/1, format_log/2]).
 
 -callback init(Args :: term()) ->
     {ok, Pid :: pid(), State :: term()} | ignore | {error, Error :: term()}.
@@ -136,9 +138,12 @@ report_progress(Pid, Mod, StartArgs, SupName) ->
                          {started, [{pid, Pid},
                                     {mfa, {Mod, init, [StartArgs]}}]}]},
               #{domain=>[otp,sasl],
-                report_cb=>fun logger:format_otp_report/1,
+                report_cb=>fun supervisor_bridge:format_log/2,
                 logger_formatter=>#{title=>"PROGRESS REPORT"},
-                error_logger=>#{tag=>info_report,type=>progress}}).
+                error_logger=>#{tag=>info_report,
+                                type=>progress,
+                                report_cb=>
+                                    fun supervisor_bridge:format_log/1}}).
 
 report_error(Error, Reason, #state{name = Name, pid = Pid, mod = Mod}) ->
     ?LOG_ERROR(#{label=>{supervisor,error},
@@ -147,6 +152,167 @@ report_error(Error, Reason, #state{name = Name, pid = Pid, mod = Mod}) ->
                           {reason, Reason},
                           {offender, [{pid, Pid}, {mod, Mod}]}]},
                #{domain=>[otp,sasl],
-                 report_cb=>fun logger:format_otp_report/1,
+                 report_cb=>fun supervisor_bridge:format_log/2,
                  logger_formatter=>#{title=>"SUPERVISOR REPORT"},
-                 error_logger=>#{tag=>error_report,type=>supervisor_report}}).
+                 error_logger=>#{tag=>error_report,
+                                 type=>supervisor_report,
+                                 report_cb=>
+                                     fun supervisor_bridge:format_log/1}}).
+
+%% format_log/1 is the report callback used by Logger handler
+%% error_logger only. It is kept for backwards compatibility with
+%% legacy error_logger event handlers. This function must always
+%% return {Format,Args} compatible with the arguments in this module's
+%% calls to error_logger prior to OTP-21.0.
+format_log(LogReport) ->
+    Depth = error_logger:get_format_depth(),
+    FormatOpts = #{chars_limit => unlimited,
+                   depth => Depth,
+                   single_line => false,
+                   encoding => utf8},
+    format_log_multi(limit_report(LogReport, Depth), FormatOpts).
+
+limit_report(LogReport, unlimited) ->
+    LogReport;
+limit_report(#{label:={supervisor,progress},
+               report:=[{supervisor,_}=Supervisor,{started,Child}]}=LogReport,
+             Depth) ->
+    LogReport#{report=>[Supervisor,
+                        {started,limit_child_report(Child, Depth)}]};
+limit_report(#{label:={supervisor,error},
+               report:=[{supervisor,_}=Supervisor,{errorContext,Ctxt},
+                        {reason,Reason},{offender,Child}]}=LogReport,
+             Depth) ->
+    LogReport#{report=>[Supervisor,
+                        {errorContext,io_lib:limit_term(Ctxt, Depth)},
+                        {reason,io_lib:limit_term(Reason, Depth)},
+                        {offender,io_lib:limit_term(Child, Depth)}]}.
+
+limit_child_report(ChildReport, Depth) ->
+    {mfa,{M,F,[As]}} = lists:keyfind(mfa, 1, ChildReport),
+    NewMFAs = {M,F,[io_lib:limit_term(As, Depth)]},
+    lists:keyreplace(mfa, 1, ChildReport, {mfa,NewMFAs}).
+
+%% format_log/2 is the report callback for any Logger handler, except
+%% error_logger.
+format_log(Report, FormatOpts0) ->
+    Default = #{chars_limit => unlimited,
+                depth => unlimited,
+                single_line => false,
+                encoding => utf8},
+    FormatOpts = maps:merge(Default, FormatOpts0),
+    IoOpts =
+        case FormatOpts of
+            #{chars_limit:=unlimited} ->
+                [];
+            #{chars_limit:=Limit} ->
+                [{chars_limit,Limit}]
+        end,
+    {Format,Args} = format_log_single(Report, FormatOpts),
+    io_lib:format(Format, Args, IoOpts).
+
+format_log_single(#{label:={supervisor,progress},
+                    report:=[{supervisor,SupName},{started,Child}]},
+                  #{single_line:=true,depth:=Depth}=FormatOpts) ->
+    P = p(FormatOpts),
+    {ChildFormat,ChildArgs} =
+        format_child_log_progress_single(Child, "Started:", FormatOpts),
+    Format = "Supervisor: "++P++".",
+    Args =
+        case Depth of
+            unlimited ->
+                [SupName];
+            _ ->
+                [SupName,Depth]
+        end,
+    {Format++ChildFormat,Args++ChildArgs};
+format_log_single(#{label:={supervisor,_Error},
+                    report:=[{supervisor,SupName},
+                             {errorContext,Ctxt},
+                             {reason,Reason},
+                             {offender,Child}]},
+                  #{single_line:=true,depth:=Depth}=FormatOpts) ->
+    P = p(FormatOpts),
+    Format = lists:append(["Supervisor: ",P,". Context: ",P,
+                            ". Reason: ",P,"."]),
+    {ChildFormat,ChildArgs} =
+        format_child_log_error_single(Child, "Offender:"),
+    Args =
+        case Depth of
+            unlimited ->
+                [SupName,Ctxt,Reason];
+            _ ->
+                [SupName,Depth,Ctxt,Depth,Reason,Depth]
+        end,
+    {Format++ChildFormat,Args++ChildArgs};
+format_log_single(Report, FormatOpts) ->
+    format_log_multi(Report, FormatOpts).
+
+format_log_multi(#{label:={supervisor,progress},
+                   report:=[{supervisor,SupName},
+                            {started,Child}]},
+                 #{depth:=Depth}=FormatOpts) ->
+    P = p(FormatOpts),
+    Format =
+        lists:append(
+          ["    supervisor: ",P,"~n",
+           "    started: ",P,"~n"]),
+    Args =
+        case Depth of
+            unlimited ->
+                [SupName,Child];
+            _ ->
+                [SupName,Depth,Child,Depth]
+        end,
+    {Format,Args};
+format_log_multi(#{label:={supervisor,_Error},
+                   report:=[{supervisor,SupName},
+                            {errorContext,Ctxt},
+                            {reason,Reason},
+                            {offender,Child}]},
+                 #{depth:=Depth}=FormatOpts) ->
+    P = p(FormatOpts),
+    Format =
+        lists:append(
+          ["    supervisor: ",P,"~n",
+           "    errorContext: ",P,"~n",
+           "    reason: ",P,"~n",
+           "    offender: ",P,"~n"]),
+    Args =
+        case Depth of
+            unlimited ->
+                [SupName,Ctxt,Reason,Child];
+            _ ->
+                [SupName,Depth,Ctxt,Depth,Reason,Depth,Child,Depth]
+        end,
+    {Format,Args}.
+
+format_child_log_progress_single(Child, Tag, FormatOpts) ->
+    {pid,Pid} = lists:keyfind(pid, 1, Child),
+    {mfa,MFAs} = lists:keyfind(mfa, 1, Child),
+    Args =
+        case maps:get(depth, FormatOpts) of
+            unlimited ->
+                [MFAs];
+            Depth ->
+                [MFAs, Depth]
+        end,
+    {" ~s pid=~w,mfa="++p(FormatOpts)++".",[Tag,Pid]++Args}.
+
+format_child_log_error_single(Child, Tag) ->
+    {pid,Pid} = lists:keyfind(pid, 1, Child),
+    {mod,Mod} = lists:keyfind(mod, 1, Child),
+    {" ~s pid=~w,mod=~w.",[Tag,Pid,Mod]}.
+
+p(#{single_line:=Single,depth:=Depth,encoding:=Enc}) ->
+    "~"++single(Single)++mod(Enc)++p(Depth);
+p(unlimited) ->
+    "p";
+p(_Depth) ->
+    "P".
+
+single(true) -> "0";
+single(false) -> "".
+
+mod(latin1) -> "";
+mod(_) -> "t".

--- a/lib/stdlib/test/gen_event_SUITE.erl
+++ b/lib/stdlib/test/gen_event_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1996-2017. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
          start_opt/1,
          undef_init/1, undef_handle_call/1, undef_handle_event/1,
          undef_handle_info/1, undef_code_change/1, undef_terminate/1,
-         undef_in_terminate/1]).
+         undef_in_terminate/1, format_log_1/1, format_log_2/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -40,7 +40,8 @@ all() ->
     [start, {group, test_all}, hibernate, auto_hibernate,
      call_format_status, call_format_status_anon, error_format_status,
      get_state, replace_state,
-     start_opt, {group, undef_callbacks}, undef_in_terminate].
+     start_opt, {group, undef_callbacks}, undef_in_terminate,
+     format_log_1, format_log_2].
 
 groups() ->
     [{test_all, [],
@@ -1221,3 +1222,209 @@ fake_upgrade(Pid, Mod) ->
     Ret = sys:change_code(Pid, Mod, old_vsn, []),
     ok = sys:resume(Pid),
     Ret.
+
+%% Test report callback for Logger handler error_logger
+format_log_1(_Config) ->
+    FD = application:get_env(kernel, error_logger_format_depth),
+    application:unset_env(kernel, error_logger_format_depth),
+    Term = lists:seq(1, 15),
+    Handler = my_handler,
+    Name = self(),
+    Report = #{label=>{gen_event,terminate},
+               handler=>Handler,
+               name=>Name,
+               last_message=>Term,
+               state=>Term,
+               reason=>Term},
+    {F1, A1} = gen_event:format_log(Report),
+    FExpected1 = "** gen_event handler ~tp crashed.\n"
+        "** Was installed in ~tp\n"
+        "** Last event was: ~tp\n"
+        "** When handler state == ~tp\n"
+        "** Reason == ~tp\n",
+    ct:log("F1: ~ts~nA1: ~tp", [F1,A1]),
+    FExpected1 = F1,
+    [Handler,Name,Term,Term,Term] = A1,
+
+    Warning = #{label=>{gen_event,no_handle_info},
+                module=>?MODULE,
+                message=>Term},
+    {WF1,WA1} = gen_event:format_log(Warning),
+    WFExpected1 = "** Undefined handle_info in ~p\n"
+                  "** Unhandled message: ~tp\n",
+    ct:log("WF1: ~ts~nWA1: ~tp", [WF1,WA1]),
+    WFExpected1 = WF1,
+    [?MODULE,Term] = WA1,
+
+    Depth = 10,
+    ok = application:set_env(kernel, error_logger_format_depth, Depth),
+    Limited = [1,2,3,4,5,6,7,8,9,'...'],
+    {F2,A2} = gen_event:format_log(#{label=>{gen_event,terminate},
+                                     handler=>Handler,
+                                     name=>Name,
+                                     last_message=>Term,
+                                     state=>Term,
+                                     reason=>Term}),
+    FExpected2 = "** gen_event handler ~tP crashed.\n"
+        "** Was installed in ~tP\n"
+        "** Last event was: ~tP\n"
+        "** When handler state == ~tP\n"
+        "** Reason == ~tP\n",
+    ct:log("F2: ~ts~nA2: ~tp", [F2,A2]),
+    FExpected2 = F2,
+    [Handler,Depth,Name,Depth,Limited,Depth,Limited,Depth,Limited,Depth] = A2,
+
+    {WF2,WA2} = gen_event:format_log(Warning),
+    WFExpected2 = "** Undefined handle_info in ~p\n"
+                  "** Unhandled message: ~tP\n",
+    ct:log("WF2: ~ts~nWA2: ~tp", [WF2,WA2]),
+    WFExpected2 = WF2,
+    [?MODULE,Limited,Depth] = WA2,
+
+    case FD of
+        undefined ->
+            application:unset_env(kernel, error_logger_format_depth);
+        _ ->
+            application:set_env(kernel, error_logger_format_depth, FD)
+    end,
+    ok.
+
+%% Test report callback for any Logger handler
+format_log_2(_Config) ->
+    Term = lists:seq(1, 15),
+    Handler = my_handler,
+    Name = self(),
+    NameStr = pid_to_list(Name),
+    Report = #{label=>{gen_event,terminate},
+               handler=>Handler,
+               name=>Name,
+               last_message=>Term,
+               state=>Term,
+               reason=>Term},
+    FormatOpts1 = #{},
+    Str1 = flatten_format_log(Report, FormatOpts1),
+    L1 = length(Str1),
+    Expected1 = "** gen_event handler my_handler crashed.\n"
+        "** Was installed in "++NameStr++"\n"
+        "** Last event was: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]\n"
+        "** When handler state == [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]\n"
+        "** Reason == [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]\n",
+    ct:log("Str1: ~ts", [Str1]),
+    ct:log("length(Str1): ~p", [L1]),
+    true = Expected1 =:= Str1,
+
+    Warning = #{label=>{gen_event,no_handle_info},
+                module=>?MODULE,
+                message=>Term},
+    WStr1 = flatten_format_log(Warning, FormatOpts1),
+    WL1 = length(WStr1),
+    WExpected1 = "** Undefined handle_info in gen_event_SUITE\n"
+        "** Unhandled message: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]\n",
+    ct:log("WStr1: ~ts", [WStr1]),
+    ct:log("length(WStr1): ~p", [WL1]),
+    true = WExpected1 =:= WStr1,
+
+    Depth = 10,
+    FormatOpts2 = #{depth=>Depth},
+    Str2 = flatten_format_log(Report, FormatOpts2),
+    L2 = length(Str2),
+    Expected2 = "** gen_event handler my_handler crashed.\n"
+        "** Was installed in " ++ NameStr ++ "\n"
+        "** Last event was: [1,2,3,4,5,6,7,8,9|...]\n"
+        "** When handler state == [1,2,3,4,5,6,7,8,9|...]\n"
+        "** Reason == [1,2,3,4,5,6,7,8,9|...]\n",
+    ct:log("Str2: ~ts", [Str2]),
+    ct:log("length(Str2): ~p", [L2]),
+    true = Expected2 =:= Str2,
+
+    WStr2 = flatten_format_log(Warning, FormatOpts2),
+    WL2 = length(WStr2),
+    WExpected2 = "** Undefined handle_info in gen_event_SUITE\n"
+        "** Unhandled message: [1,2,3,4,5,6,7,8,9|...]\n",
+    ct:log("WStr2: ~ts", [WStr2]),
+    ct:log("length(WStr2): ~p", [WL2]),
+    true = WExpected2 =:= WStr2,
+
+    FormatOpts3 = #{chars_limit=>200},
+    Str3 = flatten_format_log(Report, FormatOpts3),
+    L3 = length(Str3),
+    Expected3 = "** gen_event handler my_handler crashed.\n"
+                "** Was installed",
+    ct:log("Str3: ~ts", [Str3]),
+    ct:log("length(Str3): ~p", [L3]),
+    true = lists:prefix(Expected3, Str3),
+    true = L3 < L1,
+
+    WFormatOpts3 = #{chars_limit=>80},
+    WStr3 = flatten_format_log(Warning, WFormatOpts3),
+    WL3 = length(WStr3),
+    WExpected3 = "** Undefined handle_info in gen_event_SUITE\n"
+        "** Unhandled message: ",
+    ct:log("WStr3: ~ts", [WStr3]),
+    ct:log("length(WStr3): ~p", [WL3]),
+    true = lists:prefix(WExpected3, WStr3),
+    true = WL3 < WL1,
+
+    FormatOpts4 = #{single_line=>true},
+    Str4 = flatten_format_log(Report, FormatOpts4),
+    L4 = length(Str4),
+
+    Expected4 = "Generic event handler my_handler crashed. "
+        "Installed: "++NameStr++". "
+        "Last event: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]. "
+        "State: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]. "
+        "Reason: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15].",
+    ct:log("Str4: ~ts", [Str4]),
+    ct:log("length(Str4): ~p", [L4]),
+    true = Expected4 =:= Str4,
+
+    WStr4 = flatten_format_log(Warning, FormatOpts4),
+    WL4 = length(WStr4),
+    WExpected4 = "Undefined handle_info in gen_event_SUITE. "
+        "Unhandled message: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15].",
+    ct:log("WStr4: ~ts", [WStr4]),
+    ct:log("length(WStr4): ~p", [WL4]),
+    true = WExpected4 =:= WStr4,
+
+    FormatOpts5 = #{single_line=>true, depth=>Depth},
+    Str5 = flatten_format_log(Report, FormatOpts5),
+    L5 = length(Str5),
+    Expected5 = "Generic event handler my_handler crashed. "
+        "Installed: "++NameStr++". "
+        "Last event: [1,2,3,4,5,6,7,8,9|...]. "
+        "State: [1,2,3,4,5,6,7,8,9|...]. "
+        "Reason: [1,2,3,4,5,6,7,8,9|...].",
+    ct:log("Str5: ~ts", [Str5]),
+    ct:log("length(Str5): ~p", [L5]),
+    true = Expected5 =:= Str5,
+
+    WStr5 = flatten_format_log(Warning, FormatOpts5),
+    WL5 = length(WStr5),
+    WExpected5 = "Undefined handle_info in gen_event_SUITE. "
+        "Unhandled message: [1,2,3,4,5,6,7,8,9|...].",
+    ct:log("WStr5: ~ts", [WStr5]),
+    ct:log("length(WStr5): ~p", [WL5]),
+    true = WExpected5 =:= WStr5,
+
+    FormatOpts6 = #{single_line=>true, chars_limit=>200},
+    Str6 = flatten_format_log(Report, FormatOpts6),
+    L6 = length(Str6),
+    Expected6 = "Generic event handler my_handler crashed. Installed: ",
+    ct:log("Str6: ~ts", [Str6]),
+    ct:log("length(Str6): ~p", [L6]),
+    true = lists:prefix(Expected6, Str6),
+    true = L6 < L4,
+
+    WFormatOpts6 = #{single_line=>true, chars_limit=>80},
+    WStr6 = flatten_format_log(Warning, WFormatOpts6),
+    WL6 = length(WStr6),
+    WExpected6 = "Undefined handle_info in gen_event_SUITE. ",
+    ct:log("WStr6: ~ts", [WStr6]),
+    ct:log("length(WStr6): ~p", [WL6]),
+    true = lists:prefix(WExpected6, WStr6),
+    true = WL6 < WL4,
+
+    ok.
+
+flatten_format_log(Report, Format) ->
+    lists:flatten(gen_event:format_log(Report, Format)).

--- a/lib/stdlib/test/proc_lib_SUITE.erl
+++ b/lib/stdlib/test/proc_lib_SUITE.erl
@@ -726,8 +726,9 @@ report_cb_chars_limit(_Config) ->
     %% according to the chars_limit setting.
     %%
     %% Currently, multi-line formatting with chars_limit=1024 gives
-    %% a final report of 1845 character. The excess is due to a
-    %% deficiency of erl_error:format_exception().
+    %% a final report of 1696 character. The excess is due to the fact
+    %% that io_lib_pretty counts non-white characters--the indentation
+    %% of the formatted exception is not counted.
     %%
     %% Single-line formatting with chars_limit=1024 gives a final
     %% report of 1104 characters.


### PR DESCRIPTION
The `report_cb` used for `gen_server` terminate reports is originally written for multi-line logging. Setting `single_line=>true` in the `logger_formatter` configuration causes newlines to be replaced by ", " and the result of this is not very good for `gen_server` terminate reports.

This pull request changes this `report_cb` to behave differently for multi-line vs single-line logging. See examples:

Multi-line:
```
=ERROR REPORT==== 28-May-2019::16:37:48.922225 ===
** Generic server <0.87.0> terminating 
** Last message in was {a,message,which,is_not,handled}
** When Server state == {state,<0.85.0>,
                               [some,data,in,stored,in,my,state],
                               <<"and a binary as well">>}
** Reason for termination ==
** {{badmatch,{a,message,which,is_not,handled}},
    [{gs,handle_call,3,[{file,"gs.erl"},{line,32}]},
     {gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,663}]},
     {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,692}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}
** Client <0.85.0> stacktrace
** [{gen,do_call,4,[{file,"gen.erl"},{line,167}]},
    {gen_server,call,2,[{file,"gen_server.erl"},{line,211}]},
    {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,684}]},
    {shell,exprs,7,[{file,"shell.erl"},{line,686}]},
    {shell,eval_exprs,7,[{file,"shell.erl"},{line,642}]},
    {shell,eval_loop,3,[{file,"shell.erl"},{line,627}]}]
```

Single-line original:
```
2019-05-28T16:40:17.356553+02:00 error: ** Generic server <0.87.0> terminating , ** Last message in was {a,message,which,is_not,handled}, ** When Server state == {state,<0.85.0>,[some,data,in,stored,in,my,state],<<"and a binary as well">>}, ** Reason for termination ==, ** {{badmatch,{a,message,which,is_not,handled}},[{gs,handle_call,3,[{file,"gs.erl"},{line,32}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,661}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,690}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}, ** Client <0.85.0> stacktrace, ** [{gen,do_call,4,[{file,"gen.erl"},{line,167}]},{gen_server,call,2,[{file,"gen_server.erl"},{line,211}]},{erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,684}]},{shell,exprs,7,[{file,"shell.erl"},{line,686}]},{shell,eval_exprs,7,[{file,"shell.erl"},{line,642}]},{shell,eval_loop,3,[{file,"shell.erl"},{line,627}]}]

```

Single-line modified:
```
2019-05-28T16:37:48.922225+02:00 error: gen_server <0.87.0> terminating, last message: {a,message,which,is_not,handled}, state: {state,<0.85.0>,[some,data,in,stored,in,my,state],<<"and a binary as well">>}, reason: {{badmatch,{a,message,which,is_not,handled}},[{gs,handle_call,3,[{file,"gs.erl"},{line,32}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,663}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,692}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}, client <0.85.0> stacktrace: [{gen,do_call,4,[{file,"gen.erl"},{line,167}]},{gen_server,call,2,[{file,"gen_server.erl"},{line,211}]},{erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,684}]},{shell,exprs,7,[{file,"shell.erl"},{line,686}]},{shell,eval_exprs,7,[{file,"shell.erl"},{line,642}]},{shell,eval_loop,3,[{file,"shell.erl"},{line,627}]}]
```

Crash reports from `proc_lib` were earlier not much limited in size by the `chars_limit` option in `logger_formatter`. This is also improved with this PR.