### PR TITLE
Optimise stacktrace construction using literals

### DIFF
--- a/erts/emulator/beam/beam_ranges.c
+++ b/erts/emulator/beam/beam_ranges.c
@@ -321,7 +321,6 @@ lookup_loc(FunctionInfo* fi, const BeamInstr* pc,
 	if (pc < mid[0]) {
 	    high = mid;
 	} else if (pc < mid[1]) {
-	    int file;
 	    int index = mid - lt->func_tab[0];
 
 	    if (lt->loc_size == 2) {
@@ -334,14 +333,6 @@ lookup_loc(FunctionInfo* fi, const BeamInstr* pc,
 		return;
 	    }
 	    fi->needed += 3+2+3+2;
-	    file = LOC_FILE(fi->loc);
-	    if (file == 0) {
-		/* Special case: Module name with ".erl" appended */
-		Atom* mod_atom = atom_tab(atom_val(fi->mfa->module));
-		fi->needed += 2*(mod_atom->len+4);
-	    } else {
-                fi->needed += 2*erts_atom_to_string_length((fi->fname_ptr)[file-1]);
-	    }
 	    return;
 	} else {
 	    low = mid + 1;

--- a/erts/emulator/beam/erl_unicode.c
+++ b/erts/emulator/beam/erl_unicode.c
@@ -1346,6 +1346,19 @@ Eterm erts_utf8_to_list(Process *p, Uint num, byte *bytes, Uint sz, Uint left,
     return do_utf8_to_list(p, num, bytes, sz, left, num_built, num_eaten, tail);
 }
 
+Eterm erts_utf8_to_list_x(Eterm **hpp, byte *bytes, Uint sz)
+{
+    Uint num_eaten;
+    Uint num_built;
+    Eterm ret;
+
+    ret = make_list_from_utf8_buf(hpp, sz, bytes, sz,
+                                  &num_built, &num_eaten, NIL);
+    ASSERT(num_eaten == sz);
+
+    return ret;
+}
+
 Uint erts_atom_to_string_length(Eterm atom)
 {
     Atom *ap;

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1300,6 +1300,7 @@ char* erts_convert_filename_to_wchar(byte* bytes, Uint size,
 Eterm erts_convert_native_to_filename(Process *p, size_t size, byte *bytes);
 Eterm erts_utf8_to_list(Process *p, Uint num, byte *bytes, Uint sz, Uint left,
 			Uint *num_built, Uint *num_eaten, Eterm tail);
+Eterm erts_utf8_to_list_x(Eterm **hpp, byte *bytes, Uint sz);
 int erts_utf8_to_latin1(byte* dest, const byte* source, int slen);
 #define ERTS_UTF8_OK 0
 #define ERTS_UTF8_INCOMPLETE 1


### PR DESCRIPTION
Pre-allocate all file names for each module as literals when the module is loaded. This saves on copying the file names at runtime when the stacktrace is constructed as well as copying when sending to other processes on failure - this might especially benefit supervisors that can often receive a lot of stacktraces in EXIT messages.
