### PR TITLE
ssl: Fix broken return value

### DIFF
--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -124,7 +124,7 @@ handshake(#sslsocket{pid = [Pid|_]} = Socket, Timeout) ->
 	connected ->
 	    {ok, Socket};
         {ok, Ext} ->
-            {ok, Socket, Ext};
+            {ok, Socket, no_records(Ext)};
  	Error ->
 	    Error
     end.
@@ -709,6 +709,7 @@ handle_session(#server_hello{cipher_suite = CipherSuite,
 
     {ExpectNPN, Protocol} = case Protocol0 of
 				undefined -> 
+
 				    {false, CurrentProtocol};
 				_ -> 
 				    {ProtoExt =:= npn, Protocol0}
@@ -3000,3 +3001,8 @@ new_emulated([], EmOpts) ->
     EmOpts;
 new_emulated(NewEmOpts, _) ->
     NewEmOpts.
+
+no_records(Extensions) ->
+    maps:map(fun(_, Value) ->
+                     ssl_handshake:extension_value(Value)
+             end, Extensions).  

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -159,6 +159,7 @@ connect(ListenSocket, Node, N, _, Timeout, SslOpts, [_|_] =ContOpts) ->
 
     case ssl:handshake(AcceptSocket, SslOpts, Timeout) of
 	{ok, Socket0, Ext} ->
+            [_|_] = maps:get(sni, Ext),
             ct:log("Ext ~p:~n", [Ext]),            
             ct:log("~p:~p~nssl:handshake_continue(~p,~p,~p)~n", [?MODULE,?LINE, Socket0, ContOpts,Timeout]),            
             case ssl:handshake_continue(Socket0, ContOpts, Timeout) of


### PR DESCRIPTION
Internal data was accidental leaked by refactorization. Fix the return value to be as documented.