### PR TITLE
Return real pend value in erlang:dist_get_stat/1

### DIFF
--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -3368,7 +3368,7 @@ dist_get_stat_1(BIF_ALIST_1)
                              am_ok,
                              erts_bld_sint64(hpp, szp, read),
                              erts_bld_sint64(hpp, szp, write),
-                             pend ? am_true : am_false);
+                             erts_bld_sint64(hpp, szp, pend));
         if (hpp)
             break;
         hp = HAlloc(BIF_P, sz);

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -3361,7 +3361,7 @@ dist_ctrl_get_opt(_DHandle, _Opt) ->
       DHandle :: dist_handle(),
       InputPackets :: non_neg_integer(),
       OutputPackets :: non_neg_integer(),
-      PendingOutputPackets :: boolean(),
+      PendingOutputPackets :: non_neg_integer(),
       Res :: {'ok', InputPackets, OutputPackets, PendingOutputPackets}.
 
 dist_get_stat(_DHandle) ->


### PR DESCRIPTION
Only the dist_util code is using this function and it already
is compatible with a non-boolean value.

We are interested in using this value as a metric to know
how large the distribution output queue is when we encounter
distribution-related issues.

/cc @gerhard 