### PR TITLE
alt_dist docs: Correct the mf_getstat description

### DIFF
--- a/erts/doc/src/alt_dist.xml
+++ b/erts/doc/src/alt_dist.xml
@@ -680,7 +680,10 @@
 	    of the distribution controller, <c>Received</c>
 	    is received packets, <c>Sent</c> is
 	    sent packets, and <c>PendSend</c> is
-	    amount of packets in queue to be sent
+	    amount of data in queue to be sent
+	    (typically in bytes, but <c>dist_util</c>
+	    only checks whether the value is non-zero
+	    to know there is data in queue)
 	    or a <c>boolean()</c> indicating whether
 	    there are packets in queue to be sent.
 	  </p>


### PR DESCRIPTION
See https://github.com/erlang/otp/pull/2259#issuecomment-498305226 

I resorted to `amount of data` because that doesn't put too much intent on what the function should do compared to what `dist_util` uses this value for, so that the patch I sent at https://github.com/erlang/otp/pull/2270 is still in line with the documentation.