### PR TITLE
[trivial] specs_gen script fix error message

### DIFF
--- a/lib/erl_docgen/priv/bin/specs_gen.escript
+++ b/lib/erl_docgen/priv/bin/specs_gen.escript
@@ -131,7 +131,7 @@ write_text(Text, File, Dir) ->
             ok;
         {error, R} ->
             R1 = file:format_error(R),
-            io:format("could not write file '~s': ~s\n", [File, R1]),
+            io:format("could not write file '~s': ~s\n", [OutFile, R1]),
             halt(2)
     end.
 


### PR DESCRIPTION
The warning message was using input file, not output file:

Example:
could not write file '../src/alarm_handler.erl': no such file or directory

Which is the input file, the correct message is:

could not write file '../specs/alarm_handler.specs': no such file or directory