### PR TITLE
Allow native compilation when calling Dialyzer from Erlang

### DIFF
--- a/lib/dialyzer/doc/src/dialyzer.xml
+++ b/lib/dialyzer/doc/src/dialyzer.xml
@@ -537,7 +537,10 @@ Option   :: {files,          [Filename :: string()]}
                              'plt_check' |
                              'plt_remove'}
           | {warnings,       [WarnOpts]}
-          | {get_warnings,   bool()}
+          | {get_warnings,   boolean()}
+          | {native,         boolean()}
+                               %% Defaults to false when invoked from Erlang
+          | {native_cache,   boolean()}
 
 WarnOpts :: error_handling
           | no_behaviours

--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -160,7 +160,9 @@
                   indent_opt      = ?INDENT_OPT    :: iopt(),
 		  callgraph_file  = ""             :: file:filename(),
 		  check_plt       = true           :: boolean(),
-                  solvers         = []             :: [solver()]}).
+                  solvers         = []             :: [solver()],
+                  native          = maybe          :: boolean() | 'maybe',
+                  native_cache    = true           :: boolean()}).
 
 -record(contract, {contracts	  = []		   :: [contract_pair()],
 		   args		  = []		   :: [erl_types:erl_type()],

--- a/lib/dialyzer/src/dialyzer_cl_parse.erl
+++ b/lib/dialyzer/src/dialyzer_cl_parse.erl
@@ -316,7 +316,9 @@ common_options() ->
    {use_spec, get(dialyzer_options_use_contracts)},
    {warnings, get(dialyzer_warnings)},
    {check_plt, get(dialyzer_options_check_plt)},
-   {solvers, get(dialyzer_solvers)}].
+   {solvers, get(dialyzer_solvers)},
+   {native, get(dialyzer_options_native)},
+   {native_cache, get(dialyzer_options_native_cache)}].
 
 %%-----------------------------------------------------------------------
 

--- a/lib/dialyzer/src/dialyzer_options.erl
+++ b/lib/dialyzer/src/dialyzer_options.erl
@@ -197,6 +197,10 @@ build_options([{OptionName, Value} = Term|Rest], Options) ->
     solvers ->
       assert_solvers(Value),
       build_options(Rest, Options#options{solvers = Value});
+    native ->
+      build_options(Rest, Options#options{native = Value});
+    native_cache ->
+      build_options(Rest, Options#options{native_cache = Value});
     _ ->
       bad_option("Unknown dialyzer command line option", Term)
   end;


### PR DESCRIPTION
Invoking Dialyzer through the function dialyzer:run/1 instead of from
the command line activates "Erlang mode", meaning that warnings are
returned instead of printed, and that HiPE compilation of modules does
not take place.  With this change, HiPE compilation can optionally be
enabled in this situation by passing the option {native, true}.
Caching of natively compiled modules is enabled by default, but can be
turned off using the option {native_cache, false}.