### PR TITLE
ssl: Correct certificate handling

### DIFF
--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -364,7 +364,7 @@ certify(#certificate{asn1_certificates = ASN1Certs}, CertDbHandle, CertDbRef,
                                              CertDbHandle, CertDbRef)
 	end
     catch
-	error:{badmatch,{asn1, Asn1Reason}} ->
+	error:{badmatch,{error, {asn1, Asn1Reason}}} ->
 	    %% ASN-1 decode of certificate somehow failed
             ?ALERT_REC(?FATAL, ?CERTIFICATE_UNKNOWN, {failed_to_decode_certificate, Asn1Reason});
         error:OtherReason ->

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -317,8 +317,7 @@ handle_protocol_record(#ssl_tls{type = ?HANDSHAKE, fragment = Data},
                     _ ->
                         HsEnv = State#state.handshake_env,
                         {next_state, StateName, 
-                         State#state{protocol_buffers = Buffers,
-                                     handshake_env = 
+                         State#state{handshake_env = 
                                          HsEnv#handshake_env{unprocessed_handshake_events 
                                                              = unprocessed_events(Events)}}, Events}
                 end

--- a/lib/ssl/test/ssl_certificate_verify_SUITE.erl
+++ b/lib/ssl/test/ssl_certificate_verify_SUITE.erl
@@ -91,7 +91,8 @@ tests() ->
      critical_extension_verify_server,
      critical_extension_verify_none,
      customize_hostname_check,
-     incomplete_chain
+     incomplete_chain,
+     long_chain
     ].
 
 error_handling_tests()->
@@ -1160,6 +1161,44 @@ incomplete_chain(Config) when is_list(Config) ->
                                         {mfa, {ssl_test_lib, ReceiveFunction, []}},
                                         {options, [{active, Active}, 
                                                    {verify, verify_peer},
+                                                   {cacerts,  ServerCas ++ ClientCas} | 
+                                                   proplists:delete(cacerts, ClientConf)]}]),
+    ssl_test_lib:check_result(Server, ok, Client, ok),
+    ssl_test_lib:close(Server),
+    ssl_test_lib:close(Client).
+
+long_chain() ->
+    [{doc,"Test option verify_peer"}].
+long_chain(Config) when is_list(Config) ->      
+    #{server_config := ServerConf,
+      client_config := ClientConf} = public_key:pkix_test_data(#{server_chain => #{root => [{key, ssl_test_lib:hardcode_rsa_key(1)}],
+                                                                                  intermediates => [[{key, ssl_test_lib:hardcode_rsa_key(2)}], 
+                                                                                                    [{key, ssl_test_lib:hardcode_rsa_key(3)}],
+                                                                                                    [{key, ssl_test_lib:hardcode_rsa_key(4)}]],
+                                                                                  peer => [{key, ssl_test_lib:hardcode_rsa_key(5)}]},
+                                                                 client_chain => #{root => [{key, ssl_test_lib:hardcode_rsa_key(3)}], 
+                                                                                  intermediates => [[{key, ssl_test_lib:hardcode_rsa_key(2)}]],
+                                                                                  peer => [{key, ssl_test_lib:hardcode_rsa_key(1)}]}}), 
+    [ServerRoot| _] = ServerCas = proplists:get_value(cacerts, ServerConf),
+    ClientCas = proplists:get_value(cacerts, ClientConf),
+    
+    Active = proplists:get_value(active, Config),
+    ReceiveFunction =  proplists:get_value(receive_function, Config),
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+					{from, self()},
+                                        {mfa, {ssl_test_lib, ReceiveFunction, []}},
+                                        {options, [{active, Active}, {verify, verify_peer},
+                                                   {cacerts, [ServerRoot]} |  
+                                                   proplists:delete(cacerts, ServerConf)]}]),
+    Port  = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+					{host, Hostname},
+                                        {from, self()},
+                                        {mfa, {ssl_test_lib, ReceiveFunction, []}},
+                                        {options, [{active, Active}, 
+                                                   {verify, verify_peer},
+                                                   {depth, 5},
                                                    {cacerts,  ServerCas ++ ClientCas} | 
                                                    proplists:delete(cacerts, ClientConf)]}]),
     ssl_test_lib:check_result(Server, ok, Client, ok),


### PR DESCRIPTION
Solves ERL-968, a refactoring bug could cause part of a server key exchange message to
be appended, to an incorrectly duplicated, certificate handshake message. In the end
causing an ASN1 decoding error. That in turn did not end up the correct error handling branch.