### PR TITLE
Optimize proc_lib:raw_initial_call(Pid)

### DIFF
--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -190,7 +190,7 @@ typedef struct {
     Uint reserve_size;
     Uint len;
     int flags;
-    int item_ix[1]; /* of len size in reality... */
+    ErtsPiItem item[1]; /* of len size in reality... */
 } ErtsProcessInfoSig;
 
 #define ERTS_PROC_SIG_PI_MSGQ_LEN_IGNORE        ((Sint) -1)
@@ -1645,7 +1645,7 @@ erts_proc_sig_send_is_alive_request(Process *c_p, Eterm to, Eterm ref)
 int
 erts_proc_sig_send_process_info_request(Process *c_p,
                                         Eterm to,
-                                        int *item_ix,
+                                        ErtsPiItem *item,
                                         int len,
                                         int need_msgq_len,
                                         int flags,
@@ -1657,7 +1657,7 @@ erts_proc_sig_send_process_info_request(Process *c_p,
     int res;
 
     ASSERT(c_p);
-    ASSERT(item_ix);
+    ASSERT(item);
     ASSERT(len > 0);
     ASSERT(is_internal_ordinary_ref(ref));
 
@@ -1683,9 +1683,10 @@ erts_proc_sig_send_process_info_request(Process *c_p,
     pis->reserve_size = reserve_size;
     pis->len = len;
     pis->flags = flags;
-    sys_memcpy((void *) &pis->item_ix[0],
-               (void *) item_ix,
-               sizeof(int)*len);
+    /* FIXME: permit boxed values for item[].arg */
+    sys_memcpy((void *) &pis->item[0],
+               (void *) item,
+               sizeof(item[0]) * len);
     res = proc_queue_signal(c_p, to, (ErtsSignal *) pis,
                             ERTS_SIG_Q_OP_PROCESS_INFO);
     if (res)
@@ -2871,7 +2872,7 @@ handle_process_info(Process *c_p, ErtsSigRecvTracing *tracing,
             erts_factory_selfcontained_message_init(&hfact, mp, &hfrag->mem[0]);
 
             res = erts_process_info(c_p, &hfact, c_p, ERTS_PROC_LOCK_MAIN,
-                                    pisig->item_ix, pisig->len,
+                                    pisig->item, pisig->len,
                                     pisig->flags, reserve_size, &reds);
 
             hp = erts_produce_heap(&hfact,

--- a/erts/emulator/beam/erl_proc_sig_queue.h
+++ b/erts/emulator/beam/erl_proc_sig_queue.h
@@ -602,7 +602,7 @@ erts_proc_sig_send_is_alive_request(Process *c_p, Eterm to,
 int
 erts_proc_sig_send_process_info_request(Process *c_p,
                                         Eterm to,
-                                        int *item_ix,
+                                        ErtsPiItem *item,
                                         int len,
                                         int need_msgq_len,
                                         int flags,

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1813,9 +1813,13 @@ void erts_print_scheduler_info(fmtfn_t to, void *to_arg, ErtsSchedulerData *esdp
 void erts_print_run_queue_info(fmtfn_t, void *to_arg, ErtsRunQueue*);
 void erts_dump_extended_process_state(fmtfn_t to, void *to_arg, erts_aint32_t psflg);
 void erts_dump_process_state(fmtfn_t to, void *to_arg, erts_aint32_t psflg);
+typedef struct {
+    int ix;
+    Eterm arg;
+} ErtsPiItem;
 Eterm erts_process_info(Process *c_p, ErtsHeapFactory *hfact,
                         Process *rp, ErtsProcLocks rp_locks,
-                        int *item_ix, int item_ix_len,
+                        ErtsPiItem *item, int item_ix_len,
                         int flags, Uint reserve_size, Uint *reds);
 
 typedef struct {

--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -454,9 +454,9 @@ translate_initial_call(DictOrPid) ->
 raw_initial_call({X,Y,Z}) when is_integer(X), is_integer(Y), is_integer(Z) ->
     raw_initial_call(c:pid(X,Y,Z));
 raw_initial_call(Pid) when is_pid(Pid) ->
-    case get_process_info(Pid, dictionary) of
-	{dictionary,Dict} ->
-	    raw_init_call(Dict);
+    case process_info(Pid, {dictionary, '$initial_call'}) of
+	{_, {_, _, _} = MFA} ->
+	    MFA;
 	_ ->
 	    false
     end;
@@ -598,14 +598,9 @@ clean_dict([]) ->
     [].
 
 get_dictionary(Pid,Tag) ->
-    case get_process_info(Pid,dictionary) of
-	{dictionary,Dict} ->
-	    case lists:keysearch(Tag,1,Dict) of
-		{value,Value} -> Value;
-		_             -> undefined
-	    end;
-	_ ->
-	    undefined
+    case get_process_info(Pid, {dictionary, Tag}) of
+	{_, undefined} -> undefined;
+	{_, Value} -> {Tag, Value}
     end.
 
 linked_info(Pid) ->


### PR DESCRIPTION
Monitoring tools sometimes need to call proc_lib:translate_initial_call/1 to get a more useful version of the initial_call of a process.  Currently that requires retrieving the _entire_ dictionary of the target process, even though only a single usually small entry is needed.  This updates the VM to support retrieving that one entry directly, and then updates proc_lib to do so instead of retrieving the entire dictionary.

At the moment this is an RFC because:

1. Ideally the VM should support process_info(Pid, {dictionary,Key}) queries, but the implementation of process_info/2 really wants info keys to be plain atoms not composite terms.

2. Alternatively one could add erlang:get/2, taking Pid and Key.  This is nicely general, but unfortunately requires copying much of the process_info/2 implementation.

3. For this RFC I opted for a simple solution, namely to add '$initial_call' as an info item key to process_info/2.  It's however entirely specific to the proc_lib use case.

So this is an RFC to highlight the use-case and solicit opinions on how to solve it properly.