### PR TITLE
Add "make test" command for root and application directories

### DIFF
--- a/HOWTO/TESTING.md
+++ b/HOWTO/TESTING.md
@@ -130,6 +130,52 @@ i.e.
 Running [ct_run][] from the command line still requires you to do the
 `ts:install()` step above.
 
+### Convenience for running tests without the release and configuration steps
+
+It can be convenient to run tests with a single command. This way, one
+do not need to worry about missing to run `make release_tests` after
+changing a test suite. The `make test` command can be used for this
+purpose. The `make test` command works when the current directory
+contains a directory called test and in the root directory of the
+source code tree.
+
+*(Waring)* Some test cases do not run correctly or cannot be run at
+all through the `make test` command (typically test cases that require
+test specific C code to be compiled) because `make test` runs tests
+directly by invoking the `ct_run` command instead of using the `ts`
+wrapper. One has to follow the procedure described above to run test
+cases that do not work with `make test`.
+
+Below are some examples that illustrate how `make test` can be
+used:
+
+    # ERL_TOP needs to be set correctly
+    cd /path/to/otp
+    export ERL_TOP=`pwd`
+
+    # Build Erlang/OTP
+    #
+    # Note that make test will only compile test code except when
+    # make test is executed from $ERL_TOP.
+    ./otp_build setup -a
+
+    # Run a test case (The ARGS variable is passed to ct_run)
+    (cd $ERL_TOP/erts/emulator && make ARGS="-suite binary_SUITE -case deep_bitstr_lists" test)
+
+    # Run a test suite
+    (cd $ERL_TOP/lib/stdlib && make ARGS="-suite ets_SUITE" test)
+
+    # Run all test suites for an application
+    (cd $ERL_TOP/lib/asn1 && make test)
+
+    # Run all tests
+    #
+    # When executed from $ERL_TOP, "make test" will first release and
+    # configure all tests and then attempt to run all tests with `ts:run`.
+    # This will take several hours.
+    (cd $ERL_TOP && make test)
+
+
 Examining the results
 ---------------------
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -1142,5 +1142,6 @@ bootstrap_clean:
 
 # ----------------------------------------------------------------------
 
-test: all release_tests
-	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)
+test: all release_tests release
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/Makefile.in
+++ b/Makefile.in
@@ -1090,7 +1090,7 @@ $(IBIN_DIR):
 
 # ----------------------------------------------------------------------
 
-.PHONY: clean eclean bootstrap_root_clean bootstrap_clean test
+.PHONY: clean eclean bootstrap_root_clean bootstrap_clean
 
 #
 # Clean targets
@@ -1142,6 +1142,7 @@ bootstrap_clean:
 
 # ----------------------------------------------------------------------
 
-test: all release_tests release
+.PHONY: test
 
-include $(ERL_TOP)/make/app_targets.mk
+test: all release release_tests
+	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)

--- a/Makefile.in
+++ b/Makefile.in
@@ -1090,7 +1090,7 @@ $(IBIN_DIR):
 
 # ----------------------------------------------------------------------
 
-.PHONY: clean eclean bootstrap_root_clean bootstrap_clean
+.PHONY: clean eclean bootstrap_root_clean bootstrap_clean test
 
 #
 # Clean targets
@@ -1141,3 +1141,6 @@ bootstrap_clean:
 		|| $(MAKE) BOOTSTRAP_ROOT=$(BOOTSTRAP_ROOT) bootstrap_root_clean
 
 # ----------------------------------------------------------------------
+
+test: all release_tests
+	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)

--- a/erts/Makefile
+++ b/erts/Makefile
@@ -153,3 +153,5 @@ release_docs:
 .PHONY: xmllint
 xmllint:
 	$(MAKE) -C doc/src $@
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -1291,3 +1291,5 @@ ifndef VOID_EMULATOR
 endif
 endif
 endif
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/erts/epmd/Makefile
+++ b/erts/epmd/Makefile
@@ -31,3 +31,5 @@ SPECIAL_TARGETS =
 # Default Subdir Targets
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/asn1/Makefile
+++ b/lib/asn1/Makefile
@@ -100,3 +100,5 @@ tar: $(APP_TAR_FILE)
 $(APP_TAR_FILE): $(APP_DIR)
 	(cd $(APP_RELEASE_DIR); gtar zcf $(APP_TAR_FILE) $(DIR_NAME))
 
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/common_test/Makefile
+++ b/lib/common_test/Makefile
@@ -45,3 +45,4 @@ SPECIAL_TARGETS =
 #
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/compiler/Makefile
+++ b/lib/compiler/Makefile
@@ -36,3 +36,4 @@ SPECIAL_TARGETS =
 #
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/crypto/Makefile
+++ b/lib/crypto/Makefile
@@ -38,3 +38,4 @@ SPECIAL_TARGETS =
 include $(ERL_TOP)/make/otp_subdir.mk
 
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/debugger/Makefile
+++ b/lib/debugger/Makefile
@@ -34,3 +34,5 @@ SPECIAL_TARGETS =
 # Default Subdir Targets
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/dialyzer/Makefile
+++ b/lib/dialyzer/Makefile
@@ -42,3 +42,4 @@ SPECIAL_TARGETS =
 #
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/diameter/Makefile
+++ b/lib/diameter/Makefile
@@ -31,3 +31,5 @@ info:
 	@echo "APP_VSN = $(APP_VSN)"
 
 .PHONY: info
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/edoc/Makefile
+++ b/lib/edoc/Makefile
@@ -124,3 +124,6 @@ tar: $(APP_TAR_FILE)
 
 $(APP_TAR_FILE): $(APP_DIR)
 	(cd $(APP_RELEASE_DIR); gtar zcf $(APP_TAR_FILE) $(DIR_NAME))
+
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/eldap/Makefile
+++ b/lib/eldap/Makefile
@@ -38,3 +38,4 @@ SPECIAL_TARGETS =
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/erl_docgen/Makefile
+++ b/lib/erl_docgen/Makefile
@@ -37,3 +37,4 @@ SPECIAL_TARGETS =
 include $(ERL_TOP)/make/otp_subdir.mk
 
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/erl_interface/Makefile
+++ b/lib/erl_interface/Makefile
@@ -31,3 +31,5 @@ SPECIAL_TARGETS =
 # Default Subdir Targets
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/et/Makefile
+++ b/lib/et/Makefile
@@ -35,3 +35,4 @@ SPECIAL_TARGETS =
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/eunit/Makefile
+++ b/lib/eunit/Makefile
@@ -94,3 +94,5 @@ tar: $(APP_TAR_FILE)
 
 $(APP_TAR_FILE): $(APP_DIR)
 	(cd $(APP_RELEASE_DIR); gtar zcf $(APP_TAR_FILE) $(DIR_NAME))
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/ftp/Makefile
+++ b/lib/ftp/Makefile
@@ -76,3 +76,5 @@ dialyzer: $(DIA_PLT)
 	@dialyzer --plt $< \
                   ../$(APPLICATION)/ebin \
                   --verbose
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/hipe/Makefile
+++ b/lib/hipe/Makefile
@@ -75,3 +75,4 @@ distclean:
 realclean:
 	$(V_at)$(MAKE) MAKETARGET="realclean" all-subdirs all-subdirs-x
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/inets/Makefile
+++ b/lib/inets/Makefile
@@ -76,3 +76,5 @@ dialyzer: $(DIA_PLT)
 	@dialyzer --plt $< \
                   ../$(APPLICATION)/ebin \
                   --verbose
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/jinterface/Makefile
+++ b/lib/jinterface/Makefile
@@ -39,3 +39,4 @@ SPECIAL_TARGETS =
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/kernel/Makefile
+++ b/lib/kernel/Makefile
@@ -34,3 +34,5 @@ SPECIAL_TARGETS =
 # Default Subdir Targets
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/megaco/Makefile
+++ b/lib/megaco/Makefile
@@ -219,3 +219,5 @@ dialyzer: $(DIA_PLT)
 	@dialyzer --plt $< \
                   ../$(APPLICATION)/ebin \
                   --verbose
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/mnesia/Makefile
+++ b/lib/mnesia/Makefile
@@ -38,3 +38,4 @@ SPECIAL_TARGETS =
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/observer/Makefile
+++ b/lib/observer/Makefile
@@ -37,3 +37,4 @@ SPECIAL_TARGETS =
 include $(ERL_TOP)/make/otp_subdir.mk
 
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/odbc/Makefile
+++ b/lib/odbc/Makefile
@@ -114,3 +114,5 @@ tar: $(APP_TAR_FILE)
 
 $(APP_TAR_FILE): $(APP_DIR)
 	(cd $(APP_RELEASE_DIR); gtar zcf $(APP_TAR_FILE) $(DIR_NAME))
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/os_mon/Makefile
+++ b/lib/os_mon/Makefile
@@ -35,3 +35,4 @@ SPECIAL_TARGETS =
 #
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/parsetools/Makefile
+++ b/lib/parsetools/Makefile
@@ -37,3 +37,4 @@ SPECIAL_TARGETS =
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/public_key/Makefile
+++ b/lib/public_key/Makefile
@@ -38,3 +38,4 @@ SPECIAL_TARGETS =
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/reltool/Makefile
+++ b/lib/reltool/Makefile
@@ -36,3 +36,4 @@ SPECIAL_TARGETS =
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/runtime_tools/Makefile
+++ b/lib/runtime_tools/Makefile
@@ -37,3 +37,4 @@ SPECIAL_TARGETS =
 include $(ERL_TOP)/make/otp_subdir.mk
 
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/sasl/Makefile
+++ b/lib/sasl/Makefile
@@ -36,3 +36,4 @@ SPECIAL_TARGETS =
 #
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/snmp/Makefile
+++ b/lib/snmp/Makefile
@@ -149,3 +149,5 @@ dialyzer: $(DIA_PLT)
 	@dialyzer --plt $< \
                   ../$(APPLICATION)/ebin \
                   --verbose
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/ssh/Makefile
+++ b/lib/ssh/Makefile
@@ -38,3 +38,4 @@ SPECIAL_TARGETS =
 include $(ERL_TOP)/make/otp_subdir.mk
 
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/ssl/Makefile
+++ b/lib/ssl/Makefile
@@ -38,4 +38,4 @@ SPECIAL_TARGETS =
 #
 include $(ERL_TOP)/make/otp_subdir.mk
 
-
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/syntax_tools/Makefile
+++ b/lib/syntax_tools/Makefile
@@ -91,3 +91,5 @@ tar: $(APP_TAR_FILE)
 
 $(APP_TAR_FILE): $(APP_DIR)
 	(cd $(APP_RELEASE_DIR); gtar zcf $(APP_TAR_FILE) $(DIR_NAME))
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/tftp/Makefile
+++ b/lib/tftp/Makefile
@@ -76,3 +76,5 @@ dialyzer: $(DIA_PLT)
 	@dialyzer --plt $< \
                   ../$(APPLICATION)/ebin \
                   --verbose
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/tools/Makefile
+++ b/lib/tools/Makefile
@@ -36,3 +36,4 @@ SPECIAL_TARGETS =
 # ----------------------------------------------------
 include $(ERL_TOP)/make/otp_subdir.mk
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/wx/Makefile
+++ b/lib/wx/Makefile
@@ -40,3 +40,5 @@ CLEANDIRS = $(SUBDIRS) api_gen
 SUB_DIRECTORIES=$(SUBDIRS)
 
 include $(ERL_TOP)/make/otp_subdir.mk
+
+include $(ERL_TOP)/make/app_targets.mk

--- a/lib/xmerl/Makefile
+++ b/lib/xmerl/Makefile
@@ -97,3 +97,4 @@ tar: $(APP_TAR_FILE)
 $(APP_TAR_FILE): $(APP_DIR)
 	(cd $(APP_RELEASE_DIR); gtar zcf $(APP_TAR_FILE) $(DIR_NAME))
 
+include $(ERL_TOP)/make/app_targets.mk

--- a/make/app_targets.mk
+++ b/make/app_targets.mk
@@ -1,7 +1,7 @@
-#
+# 
 # %CopyrightBegin%
 # 
-# Copyright Ericsson AB 1996-2016. All Rights Reserved.
+# Copyright Ericsson AB 1997-2019. All Rights Reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,23 +17,9 @@
 # 
 # %CopyrightEnd%
 #
-include $(ERL_TOP)/make/target.mk
-include $(ERL_TOP)/make/$(TARGET)/otp.mk
 
-#
-# Macros
-#
 
-SUB_DIRECTORIES = src doc/src examples
+.PHONY: test
 
-include vsn.mk
-VSN = $(STDLIB_VSN)
-
-SPECIAL_TARGETS = 
-
-#
-# Default Subdir Targets
-#
-include $(ERL_TOP)/make/otp_subdir.mk
-
-include $(ERL_TOP)/make/app_targets.mk
+test:
+	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)

--- a/make/otp_subdir.mk
+++ b/make/otp_subdir.mk
@@ -20,7 +20,7 @@
 # Make include file for otp
 
 .PHONY: debug opt lcnt release docs release_docs tests release_tests \
-	clean depend valgrind static_lib
+	clean depend valgrind static_lib test
 
 #
 # Targets that don't affect documentation directories
@@ -56,3 +56,6 @@ opt debug lcnt release docs release_docs tests release_tests clean depend valgri
 	    fi	;							\
 	    echo "=== Leaving application" `basename $$app_pwd` ;	\
 	fi
+
+test:
+	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)

--- a/make/otp_subdir.mk
+++ b/make/otp_subdir.mk
@@ -20,7 +20,7 @@
 # Make include file for otp
 
 .PHONY: debug opt lcnt release docs release_docs tests release_tests \
-	clean depend valgrind static_lib test
+	clean depend valgrind static_lib
 
 #
 # Targets that don't affect documentation directories
@@ -57,5 +57,3 @@ opt debug lcnt release docs release_docs tests release_tests clean depend valgri
 	    echo "=== Leaving application" `basename $$app_pwd` ;	\
 	fi
 
-test:
-	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)

--- a/make/run_make.mk
+++ b/make/run_make.mk
@@ -29,7 +29,7 @@
 include $(ERL_TOP)/make/output.mk
 include $(ERL_TOP)/make/target.mk
 
-.PHONY: valgrind test
+.PHONY: valgrind
 
 opt debug purify quantify purecov valgrind gcov gprof lcnt frmptr icount:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile TYPE=$@
@@ -40,6 +40,3 @@ plain smp frag smp_frag:
 clean generate depend docs release release_spec release_docs release_docs_spec \
   tests release_tests release_tests_spec static_lib xmllint:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile $@
-
-test:
-	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)

--- a/make/run_make.mk
+++ b/make/run_make.mk
@@ -29,7 +29,7 @@
 include $(ERL_TOP)/make/output.mk
 include $(ERL_TOP)/make/target.mk
 
-.PHONY: valgrind
+.PHONY: valgrind test
 
 opt debug purify quantify purecov valgrind gcov gprof lcnt frmptr icount:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile TYPE=$@
@@ -40,3 +40,6 @@ plain smp frag smp_frag:
 clean generate depend docs release release_spec release_docs release_docs_spec \
   tests release_tests release_tests_spec static_lib xmllint:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile $@
+
+test:
+	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -146,7 +146,7 @@ then
     echo "The tests will start in a few seconds..."
     sleep 60
     "$ERL_TOP"/bin/erl -eval "ts:install(),erlang:halt()"
-    "$ERL_TOP"/bin/erl -eval "ts:run(),erlang:halt()"
+    "$ERL_TOP"/bin/erl -noinput -eval "ts:run([all_tests|batch]),erlang:halt()"
     exit $?
 fi
 
@@ -155,7 +155,6 @@ if [ -d test ]
 then
     APPLICATION=`basename $DIR`
     cd test
-    echo
     echo "The tests in test directory for $APPLICATION will be executed with ct_run"
     if [ -z "${ARGS}" ]
     then
@@ -191,7 +190,6 @@ then
     # Compile test server
     echo "BEFORE COMPILE TEST SERVER"
     (cd "$ERL_TOP/lib/common_test/test_server" && make)
-    echo "AFTER COMPILE TEST SERVER"
     # Run ct_run
     cd $MAKE_TEST_REL_DIR
     $CT_RUN -logdir $MAKE_TEST_CT_LOGS\

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -1,5 +1,25 @@
 #!/bin/sh
 
+# 
+# %CopyrightBegin%
+# 
+# Copyright Ericsson AB 1997-2019. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# %CopyrightEnd%
+#
+
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -66,7 +86,6 @@ errors:
 
 EOM
         echo "$ERL_TOP/HOWTO/TESTING.md"
-        echo
     }
     print_highlighted_msg_with_printer $LIGHT_CYAN print_msg
 }
@@ -141,12 +160,18 @@ fi
 DIR=`pwd`
 if [ "$DIR" -ef "$ERL_TOP" ]
 then
-    cd release/tests/test_server
+    TARGET_SYS=`$ERL_TOP/erts/autoconf/config.guess`
+    REL_DIR="$ERL_TOP/release/$TARGET_SYS"
+    cd "$REL_DIR"
+    ./Install -sasl `pwd`
+    export PATH="$REL_DIR/bin:$PATH"
+    cd "$ERL_TOP/release/tests/test_server"
     print_all_tests_takes_long_time_warning
     echo "The tests will start in a few seconds..."
-    sleep 60
-    "$ERL_TOP"/bin/erl -eval "ts:install(),erlang:halt()"
-    "$ERL_TOP"/bin/erl -noinput -eval "ts:run([all_tests|batch]),erlang:halt()"
+    sleep 45
+    cd "$ERL_TOP/release/tests/test_server"
+    erl -eval "ts:install(),erlang:halt()"
+    erl -noinput -eval "ts:run([all_tests,batch]),erlang:halt()"
     exit $?
 fi
 
@@ -188,7 +213,6 @@ then
         ARGS="$SPEC_FLAG $SPEC_FILE"
     fi
     # Compile test server
-    echo "BEFORE COMPILE TEST SERVER"
     (cd "$ERL_TOP/lib/common_test/test_server" && make)
     # Run ct_run
     cd $MAKE_TEST_REL_DIR

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+LIGHT_CYAN='\033[1;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+
+print_highlighted_msg_with_printer () {
+    COLOR=$1
+    MSG_PRINTER=$2
+    printf "\n${COLOR}======================================================================${NC}\n"
+    echo
+    $MSG_PRINTER
+    echo
+    printf "${COLOR}======================================================================${NC}\n"
+}
+
+print_highlighted_msg () {
+    COLOR=$1
+    MSG=$2
+    print_msg () {
+        echo "$MSG"
+    }
+    print_highlighted_msg_with_printer $COLOR print_msg
+}
+
+print_all_tests_takes_long_time_warning () {
+    print_msg () {
+        cat << EOM
+
+WARNING
+
+All tests will require several hours to run. You may want to check the
+following text file that describes how to run tests for a specific
+application.
+
+EOM
+        echo $ERL_TOP/HOWTO/TESTING.md
+    }
+    print_highlighted_msg_with_printer $YELLOW print_msg
+}
+
+print_all_tests_for_application_notes () {
+    print_msg () {
+        cat << EOM
+
+NOTE 1
+
+ct_run will now attempt to execute tests in the test directory, which
+may take a long time to do. One can pass arguments to ct_run by
+setting the ARGS variable when invoking "make test".
+
+Example:
+
+make ARGS="-suite asn1_SUITE -case ticket_7407" test
+
+NOTE 2
+
+You may want to look at the more established way of running tests that
+is described in the following text file if you encounter strange
+errors:
+
+EOM
+        echo "$ERL_TOP/HOWTO/TESTING.md"
+        echo
+    }
+    print_highlighted_msg_with_printer $LIGHT_CYAN print_msg
+}
+
+print_c_files_warning () {
+    print_msg () {
+        cat << EOM
+
+WARNING
+
+The test directory contains .c files which means that some test cases
+will probably not work correctly when run through "make test". The
+text file at the following location describes how one can compile and
+run all test cases:
+
+
+EOM
+        echo $ERL_TOP/HOWTO/TESTING.md
+    }
+    print_highlighted_msg_with_printer $YELLOW print_msg
+}
+
+
+print_on_error_note () {
+    print_msg () {
+        cat << EOM
+NOTE:
+
+Some test cases do not work correctly when run through "make test" as
+they are designed to be run through the method that is described in
+the "$ERL_TOP/HOWTO/TESTING.md" text file. You may want to check this
+text file if you encounter strange errors. Note also that you can
+rerun a specific test case by passing parameters to ct_run as in the
+example below:
+
+make ARGS="-suite asn1_SUITE -case ticket_7407" test
+
+EOM
+    }
+    print_highlighted_msg_with_printer $NC print_msg
+}
+
+# Check ERL_TOP
+
+if [ -d "$1" ]
+then
+    ERL_TOP="$1"
+    shift
+fi
+
+if [ -z $ERL_TOP ]
+then
+    ERL_TOP=`git rev-parse --show-toplevel`
+    if [ $? = 0 ]
+    then
+        print_highlighted_msg $LIGHT_CYAN "The environment variable ERL_TOP has been set to the git root"
+    else
+        echo "The ERL_TOP environment variable need to be set before this script is executed."
+        exit 1
+    fi
+fi
+
+export ERL_TOP=$ERL_TOP
+
+
+if [ -z "${ARGS}" ]
+then
+   ARGS="$@"
+fi
+
+# make test in root
+DIR=`pwd`
+if [ "$DIR" -ef "$ERL_TOP" ]
+then
+    cd release/tests/test_server
+    print_all_tests_takes_long_time_warning
+    echo "The tests will start in a few seconds..."
+    sleep 60
+    "$ERL_TOP"/bin/erl -eval "ts:install(),erlang:halt()"
+    "$ERL_TOP"/bin/erl -eval "ts:run(),erlang:halt()"
+    exit $?
+fi
+
+# make test in application directory
+if [ -d test ]
+then
+    APPLICATION=`basename $DIR`
+    cd test
+    echo
+    echo "The tests in test directory for $APPLICATION will be executed with ct_run"
+    if [ -z "${ARGS}" ]
+    then
+        print_all_tests_for_application_notes
+        if find . -type f -name '*.c' | grep -q "."
+        then
+            print_c_files_warning
+        fi
+    fi
+    CT_RUN="$ERL_TOP/bin/ct_run"
+    MAKE_TEST_DIR="`pwd`/make_test_dir"
+    MAKE_TEST_REL_DIR="$MAKE_TEST_DIR/${APPLICATION}_test"
+    MAKE_TEST_CT_LOGS="$MAKE_TEST_DIR/ct_logs"
+    RELEASE_TEST_SPEC_LOG="$MAKE_TEST_CT_LOGS/release_tests_spec_log"
+    mkdir -p $MAKE_TEST_DIR
+    mkdir -p $MAKE_TEST_REL_DIR
+    mkdir -p $MAKE_TEST_CT_LOGS
+    make RELSYSDIR=$MAKE_TEST_REL_DIR release_tests_spec > $RELEASE_TEST_SPEC_LOG 2>&1
+    if [ $? != 0 ]
+    then
+        cat $RELEASE_TEST_SPEC_LOG
+        print_highlighted_msg $RED "\"make RELSYSDIR=$MAKE_TEST_REL_DIR release_tests_spec\" failed."
+        exit 1
+    fi
+    SPEC_FLAG=""
+    SPEC_FILE=""
+    if [ -z "${ARGS}" ]
+    then
+        SPEC_FLAG="-spec"
+        SPEC_FILE="$MAKE_TEST_REL_DIR/$APPLICATION.spec"
+        ARGS="$SPEC_FLAG $SPEC_FILE"
+    fi
+    # Compile test server
+    echo "BEFORE COMPILE TEST SERVER"
+    (cd "$ERL_TOP/lib/common_test/test_server" && make)
+    echo "AFTER COMPILE TEST SERVER"
+    # Run ct_run
+    cd $MAKE_TEST_REL_DIR
+    $CT_RUN -logdir $MAKE_TEST_CT_LOGS\
+           -pa "$ERL_TOP/lib/common_test/test_server"\
+           ${ARGS}\
+           -erl_args\
+           -env "$PATH"\
+           -env ERL_CRASH_DUMP "$MAKE_TEST_DIR/${APPLICATION}_erl_crash.dump"\
+           -boot start_sasl\
+           -sasl errlog_type error\
+           -pz "$ERL_TOP/lib/common_test/test_server"\
+           -pz "."\
+           -ct_test_vars "{net_dir,\"\"}"\
+           -noshell\
+           -sname test_server\
+           -rsh ssh\
+           ${ERL_ARGS}
+    CT_RUN_STATUS=$?
+    if [ $CT_RUN_STATUS = "0" ]
+    then
+        print_highlighted_msg $GREEN "The test(s) ran successfully (ct_run returned a success code)"
+        exit 0
+    else
+        print_on_error_note
+        print_highlighted_msg $RED "ct_run returned an error code"
+        exit 1
+    fi
+else
+    print_highlighted_msg $RED "This target only works in directories containing a test directory or\nin the root directory."
+    exit 1
+fi
+


### PR DESCRIPTION
This pull request adds a new make target to the makefiles in the root directory and sub-directories that contain a test folder. The purpose of this target is to make it more convenient to run tests while developing. The added make target is described in `HOWTO/TESTING.md`.