### PR TITLE
Optimize dist data shuffling

### DIFF
--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -527,7 +527,7 @@ erts_msg_attached_data_size_aux(ErtsMessage *msg)
 
     if (edep->heap_size < 0) {
 
-        sz = erts_decode_dist_ext_size(edep, 1);
+        sz = erts_decode_dist_ext_size(edep, 1, 1);
         if (sz < 0) {
             /* Bad external
              * We leave the message intact in this case as it's not worth the trouble

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -3028,7 +3028,7 @@ erts_proc_sig_decode_dist(Process *proc, ErtsProcLocks proc_locks,
     if (edep->heap_size >= 0)
 	need = edep->heap_size;
     else {
-	need = erts_decode_dist_ext_size(edep, 1);
+	need = erts_decode_dist_ext_size(edep, 1, 1);
 	if (need < 0) {
 	    /* bad signal; remove it... */
 	    return 0;

--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -199,7 +199,7 @@ typedef enum {
 
 ErtsPrepDistExtRes erts_prepare_dist_ext(ErtsDistExternal *, byte *, Uint, struct binary *,
                                          DistEntry *, Uint32, ErtsAtomCache *);
-Sint erts_decode_dist_ext_size(ErtsDistExternal *, int);
+Sint erts_decode_dist_ext_size(ErtsDistExternal *, int, int);
 Eterm erts_decode_dist_ext(ErtsHeapFactory*, ErtsDistExternal *, int);
 
 Sint erts_decode_ext_size(byte*, Uint);


### PR DESCRIPTION
* Move the copy of fragmented payload to the receiving process in order for the copying of multiple messages to be done in parallel.
* Don't copy large binary data when doing decode of an external term from the distribution.