### PR TITLE
stdlib: accept all types of ServerRef returned by alternative process registry

### DIFF
--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -233,17 +233,19 @@ do_for_proc(Process, Fun)
 	orelse
 	  (tuple_size(Process) == 3 andalso element(1, Process) == via)) ->
     case where(Process) of
-	Pid when is_pid(Pid) ->
-	    Node = node(Pid),
-	    try Fun(Pid)
+	undefined ->
+	    exit(noproc);
+	Proc when is_atom(Proc) ->
+	    do_for_proc(Proc, Fun);
+	Proc ->
+	    Node = get_node(Proc),
+	    try do_for_proc(Proc, Fun)
 	    catch
 		exit:{nodedown, Node} ->
 		    %% A nodedown not yet detected by global,
 		    %% pretend that it was.
 		    exit(noproc)
-	    end;
-	undefined ->
-	    exit(noproc)
+	    end
     end;
 %% Local by name in disguise
 do_for_proc({Name, Node}, Fun) when Node =:= node() ->


### PR DESCRIPTION
Besides pid, gen_server:call accepts locally registered name and locally registered name at another node. However, it accepts only pid, if that is returned by an alternative process registry. And this is also inconsistent with gen_server:cast.