### PR TITLE
Remove unused SSH definitions

### DIFF
--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -478,14 +478,6 @@
           recv_ext_info
 	 }).
 
--record(ssh_key,
-	{
-	  type,
-	  public,
-	  private,
-	  comment = ""
-	 }).
-
 -record(ssh_pty, {term = "", % e.g. "xterm"
 		  width = 80,
 		  height = 25,

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -485,13 +485,6 @@
 		  pixel_height = 768,
 		  modes = <<>>}).
 
-%% assertion macro
--define(ssh_assert(Expr, Reason),
-	case Expr of
-	    true -> ok;
-	    _ -> exit(Reason)
-	end).
-
 
 %% dbg help macros
 -define(wr_record(N,BlackList),


### PR DESCRIPTION
While working on the `ssh` application I noticed one record and one macro definition that apparently are not used anywhere in the codebase.

Should this be based on top of the `master` or the `maint` branch?
Just let me know and I can rebase if needed and update the PR to point to the correct one 🙂 

Cheers