### PR TITLE
Add SSH agent support

### DIFF
--- a/lib/ssh/src/Makefile
+++ b/lib/ssh/src/Makefile
@@ -100,7 +100,7 @@ APP_TARGET= $(EBIN)/$(APP_FILE)
 APPUP_SRC= $(APPUP_FILE).src
 APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 
-INTERNAL_HRL_FILES = ssh_auth.hrl ssh_connect.hrl ssh_transport.hrl ssh.hrl ssh_xfer.hrl
+INTERNAL_HRL_FILES = ssh_agent.hrl ssh_auth.hrl ssh_connect.hrl ssh_transport.hrl ssh.hrl ssh_xfer.hrl
 
 # ----------------------------------------------------
 # FLAGS
@@ -175,7 +175,7 @@ $(EBIN)/ssh_subsystem_sup.$(EMULATOR): ssh_subsystem_sup.erl
 $(EBIN)/ssh_server_channel_sup.$(EMULATOR): ssh_server_channel_sup.erl
 $(EBIN)/ssh_acceptor_sup.$(EMULATOR): ssh_acceptor_sup.erl ssh.hrl
 $(EBIN)/ssh_acceptor.$(EMULATOR): ssh_acceptor.erl ssh.hrl
-$(EBIN)/ssh_agent.$(EMULATOR): ssh_agent.erl ssh.hrl
+$(EBIN)/ssh_agent.$(EMULATOR): ssh_agent.erl ssh.hrl ssh_agent.hrl
 $(EBIN)/ssh_app.$(EMULATOR): ssh_app.erl
 $(EBIN)/ssh_auth.$(EMULATOR): ssh_auth.erl \
   ../../public_key/include/public_key.hrl \

--- a/lib/ssh/src/Makefile
+++ b/lib/ssh/src/Makefile
@@ -62,6 +62,7 @@ MODULES= \
 	ssh_connection_sup \
 	ssh_dbg \
 	ssh_file \
+	ssh_file_with_agent \
 	ssh_info \
 	ssh_io \
 	ssh_message \
@@ -189,6 +190,8 @@ $(EBIN)/ssh_file.$(EMULATOR): ssh_file.erl \
   ../../public_key/include/OTP-PUB-KEY.hrl \
   ../../public_key/include/PKCS-FRAME.hrl \
   ../../kernel/include/file.hrl ssh.hrl
+$(EBIN)/ssh_file_with_agent.$(EMULATOR): ssh_file_with_agent.erl \
+  $(EBIN)/ssh_file.$(EMULATOR) ssh.hrl ssh_agent.hrl
 $(EBIN)/ssh_io.$(EMULATOR): ssh_io.erl ssh.hrl
 $(EBIN)/ssh_info.$(EMULATOR): ssh_info.erl
 $(EBIN)/ssh_message.$(EMULATOR): ssh_message.erl \

--- a/lib/ssh/src/Makefile
+++ b/lib/ssh/src/Makefile
@@ -52,6 +52,7 @@ MODULES= \
 	ssh \
 	ssh_acceptor \
 	ssh_acceptor_sup \
+	ssh_agent \
 	ssh_app \
 	ssh_auth\
 	ssh_bits \
@@ -174,6 +175,7 @@ $(EBIN)/ssh_subsystem_sup.$(EMULATOR): ssh_subsystem_sup.erl
 $(EBIN)/ssh_server_channel_sup.$(EMULATOR): ssh_server_channel_sup.erl
 $(EBIN)/ssh_acceptor_sup.$(EMULATOR): ssh_acceptor_sup.erl ssh.hrl
 $(EBIN)/ssh_acceptor.$(EMULATOR): ssh_acceptor.erl ssh.hrl
+$(EBIN)/ssh_agent.$(EMULATOR): ssh_agent.erl ssh.hrl
 $(EBIN)/ssh_app.$(EMULATOR): ssh_app.erl
 $(EBIN)/ssh_auth.$(EMULATOR): ssh_auth.erl \
   ../../public_key/include/public_key.hrl \

--- a/lib/ssh/src/ssh.app.src
+++ b/lib/ssh/src/ssh.app.src
@@ -8,6 +8,7 @@
 	     ssh_acceptor,
 	     ssh_acceptor_sup,
              ssh_options,
+	     ssh_agent,
 	     ssh_auth,
 	     ssh_message,
 	     ssh_bits,

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -23,84 +23,11 @@
 -module(ssh_agent).
 
 -include("ssh.hrl").
+-include("ssh_agent.hrl").
 
 -export([encode/1, decode/1]).
 
-%% SSH Agent message numbers
-%%
-%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-5.1
-
-%% The following numbers are used for requests from the client to the agent.
-
--define(SSH_AGENTC_REQUEST_IDENTITIES,            11).
--define(SSH_AGENTC_SIGN_REQUEST,                  13).
--define(SSH_AGENTC_ADD_IDENTITY,                  17).
--define(SSH_AGENTC_REMOVE_IDENTITY,               18).
--define(SSH_AGENTC_REMOVE_ALL_IDENTITIES,         19).
--define(SSH_AGENTC_ADD_ID_CONSTRAINED,            25).
--define(SSH_AGENTC_ADD_SMARTCARD_KEY,             20).
--define(SSH_AGENTC_REMOVE_SMARTCARD_KEY,          21).
--define(SSH_AGENTC_LOCK,                          22).
--define(SSH_AGENTC_UNLOCK,                        23).
--define(SSH_AGENTC_ADD_SMARTCARD_KEY_CONSTRAINED, 26).
--define(SSH_AGENTC_EXTENSION,                     27).
-
-%% The following numbers are used for replies from the agent to the client.
-
--define(SSH_AGENT_FAILURE,                        5).
--define(SSH_AGENT_SUCCESS,                        6).
--define(SSH_AGENT_EXTENSION_FAILURE,              28).
--define(SSH_AGENT_IDENTITIES_ANSWER,              12).
--define(SSH_AGENT_SIGN_RESPONSE,                  14).
-
-%% SSH Agent messages
-%%
-%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-4
-
-%% 4.1 Generic server responses
-
--record(ssh_agent_success,
-	{
-	 }).
-
--record(ssh_agent_failure,
-	{
-	 }).
-
-%% 4.4 Requesting a list of keys
-
--record(ssh_agent_identities_request,
-	{
-	 }).
-
--record(ssh_agent_identity,
-    {
-      key_blob, % string
-      comment   % string
-     }).
-
--record(ssh_agent_identities_response,
-    {
-      nkeys, % integer
-      keys   % list of ssh_agent_identity records
-     }).
-
-%% 4.5 Private key operations
-
--record(ssh_agent_sign_request,
-	{
-	  key_blob, % string
-	  data,		% string
-	  flags		% integer
-	 }).
-
--record(ssh_agent_sign_response,
-	{
-	  signature % string
-  	 }).
-
 %% SSH Agent message encoding
-%%
 
 encode(#ssh_agent_identities_request{}) ->
     <<?Ebyte(?SSH_AGENTC_REQUEST_IDENTITIES)>>;
@@ -112,7 +39,6 @@ encode(#ssh_agent_sign_request{
     <<?Ebyte(?SSH_AGENTC_SIGN_REQUEST), ?Ebinary(KeyBlob), ?Ebinary(Data), ?Euint32(Flags)>>.
 
 %% SSH Agent message decoding
-%%
 
 decode_identities(<<>>, Acc, 0) ->
     lists:reverse(Acc);

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -72,8 +72,8 @@ decode_keys(<<>>, Acc, 0) ->
     lists:reverse(Acc);
 
 decode_keys(<<?DEC_BIN(KeyBlob, _KeyBlobLen), ?DEC_BIN(Comment, _CommentLen), Rest/binary>>, Acc, N) ->
-    Identity = #ssh_agent_identity{key_blob = KeyBlob, comment = Comment},
-    decode_keys(Rest, [Identity | Acc], N - 1).
+    Key = #ssh_agent_key{blob = KeyBlob, comment = Comment},
+    decode_keys(Rest, [Key | Acc], N - 1).
 
 decode_signature(<<?DEC_BIN(Format, _FormatLen), Blob/binary>>) ->
     % Decode signature according to https://tools.ietf.org/html/rfc4253#section-6.6

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -29,8 +29,6 @@
 
 %% Agent communication
 
-% TODO: Is it safe to issue multiple requests in parallel?
-% Do we need a dedicated process to handle agent access?
 send(Request) ->
     SocketPath = os:getenv("SSH_AUTH_SOCK"),
 

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -1,0 +1,50 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2008-2018. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+
+-module(ssh_agent).
+
+%% SSH Agent message numbers
+%%
+%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-5.1
+
+%% The following numbers are used for requests from the client to the agent.
+
+-define(SSH_AGENTC_REQUEST_IDENTITIES,            11).
+-define(SSH_AGENTC_SIGN_REQUEST,                  13).
+-define(SSH_AGENTC_ADD_IDENTITY,                  17).
+-define(SSH_AGENTC_REMOVE_IDENTITY,               18).
+-define(SSH_AGENTC_REMOVE_ALL_IDENTITIES,         19).
+-define(SSH_AGENTC_ADD_ID_CONSTRAINED,            25).
+-define(SSH_AGENTC_ADD_SMARTCARD_KEY,             20).
+-define(SSH_AGENTC_REMOVE_SMARTCARD_KEY,          21).
+-define(SSH_AGENTC_LOCK,                          22).
+-define(SSH_AGENTC_UNLOCK,                        23).
+-define(SSH_AGENTC_ADD_SMARTCARD_KEY_CONSTRAINED, 26).
+-define(SSH_AGENTC_EXTENSION,                     27).
+
+%% The following numbers are used for replies from the agent to the client.
+
+-define(SSH_AGENT_FAILURE,                        5).
+-define(SSH_AGENT_SUCCESS,                        6).
+-define(SSH_AGENT_EXTENSION_FAILURE,              28).
+-define(SSH_AGENT_IDENTITIES_ANSWER,              12).
+-define(SSH_AGENT_SIGN_RESPONSE,                  14).

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -48,3 +48,55 @@
 -define(SSH_AGENT_EXTENSION_FAILURE,              28).
 -define(SSH_AGENT_IDENTITIES_ANSWER,              12).
 -define(SSH_AGENT_SIGN_RESPONSE,                  14).
+
+%% SSH Agent messages
+%%
+%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-4
+
+%% 4.1 Generic server responses
+
+-record(ssh_agent_success,
+	{
+	 }).
+
+-record(ssh_agent_failure,
+	{
+	 }).
+
+%% 4.4 Requesting a list of keys
+
+-record(ssh_agent_identities_request,
+	{
+	 }).
+
+-record(ssh_agent_identity,
+    {
+      key_blob, % string
+      comment   % string
+     }).
+
+-record(ssh_agent_identities_response,
+    {
+      nkeys, % integer
+      keys   % list of ssh_agent_identity records
+     }).
+
+%% 4.5 Private key operations
+
+-record(ssh_agent_sign_request,
+	{
+	  key_blob, % string
+	  data,		% string
+	  flags		% integer
+	 }).
+
+-record(ssh_agent_sign_response,
+	{
+	  signature % string
+  	 }).
+
+%% SSH Agent message encoding
+%%
+
+%% SSH Agent message decoding
+%%

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -18,7 +18,7 @@
 %% %CopyrightEnd%
 %%
 
-%%
+%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02
 
 -module(ssh_agent).
 

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -25,11 +25,14 @@
 -include("ssh.hrl").
 -include("ssh_agent.hrl").
 
--export([send/1]).
+-export([send/1, send/2]).
 
 %% Agent communication
 
 send(Request) ->
+    send(Request, infinity).
+
+send(Request, Timeout) ->
     SocketPath = os:getenv("SSH_AUTH_SOCK"),
 
     ConnectOpts = [binary, {packet, 0}, {active, false}],
@@ -38,7 +41,6 @@ send(Request) ->
     BinRequest = pack(encode(Request)),
     ok = gen_tcp:send(Socket, BinRequest),
 
-    Timeout = 1000, % TODO: Make this a parameter? What is a sensible default value?
     {ok, BinResponse} = gen_tcp:recv(Socket, 0, Timeout),
 
     ok = gen_tcp:close(Socket),

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2008-2018. All Rights Reserved.
+%% Copyright Ericsson AB 2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -25,7 +25,7 @@
 -include("ssh.hrl").
 -include("ssh_agent.hrl").
 
--export([send/1, send/2]).
+-export([send/1, send/2, send/3]).
 
 %% Agent communication
 
@@ -33,10 +33,12 @@ send(Request) ->
     send(Request, infinity).
 
 send(Request, Timeout) ->
-    SocketPath = os:getenv("SSH_AUTH_SOCK"),
+    send(Request, os:getenv("SSH_AUTH_SOCK"), Timeout).
 
+
+send(Request, SocketPath, Timeout) ->
     ConnectOpts = [binary, {packet, 0}, {active, false}],
-    {ok, Socket} = gen_tcp:connect({local, SocketPath}, 0, ConnectOpts),
+    {ok, Socket} = gen_tcp:connect({local, SocketPath}, 0, ConnectOpts, Timeout),
 
     BinRequest = pack(encode(Request)),
     ok = gen_tcp:send(Socket, BinRequest),

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -78,13 +78,9 @@ decode_keys(<<?DEC_BIN(KeyBlob, _KeyBlobLen), ?DEC_BIN(Comment, _CommentLen), Re
     decode_keys(Rest, [Identity | Acc], N - 1).
 
 decode_signature(<<?DEC_BIN(Format, _FormatLen), Blob/binary>>) ->
-    % TODO: Decode signature depending on signature format as per
-    % https://tools.ietf.org/html/rfc4253#section-6.6
-    %
-    % Currently this just decodes RSA signatures correctly.
-    io:fwrite("Signature format: ~p~n~n", [Format]),
-    <<?DEC_BIN(RSASignBlob, _RSASignBlobLen)>> = Blob,
-    #ssh_agent_signature{format = Format, blob = RSASignBlob}.
+    % Decode signature according to https://tools.ietf.org/html/rfc4253#section-6.6
+    <<?DEC_BIN(SignatureBlob, _SignatureBlobLen)>> = Blob,
+    #ssh_agent_signature{format = Format, blob = SignatureBlob}.
 
 decode(<<?BYTE(?SSH_AGENT_SUCCESS)>>) ->
     #ssh_agent_success{};

--- a/lib/ssh/src/ssh_agent.hrl
+++ b/lib/ssh/src/ssh_agent.hrl
@@ -88,7 +88,13 @@
       flags     % integer
     }).
 
+-record(ssh_agent_signature,
+    {
+      format, % string
+      blob    % binary
+    }).
+
 -record(ssh_agent_sign_response,
     {
-      signature % string
+      signature % ssh_agent_signature
     }).

--- a/lib/ssh/src/ssh_agent.hrl
+++ b/lib/ssh/src/ssh_agent.hrl
@@ -1,0 +1,94 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2019. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+
+%% SSH Agent message numbers
+%%
+%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-5.1
+
+%% The following numbers are used for requests from the client to the agent.
+
+-define(SSH_AGENTC_REQUEST_IDENTITIES,            11).
+-define(SSH_AGENTC_SIGN_REQUEST,                  13).
+-define(SSH_AGENTC_ADD_IDENTITY,                  17).
+-define(SSH_AGENTC_REMOVE_IDENTITY,               18).
+-define(SSH_AGENTC_REMOVE_ALL_IDENTITIES,         19).
+-define(SSH_AGENTC_ADD_ID_CONSTRAINED,            25).
+-define(SSH_AGENTC_ADD_SMARTCARD_KEY,             20).
+-define(SSH_AGENTC_REMOVE_SMARTCARD_KEY,          21).
+-define(SSH_AGENTC_LOCK,                          22).
+-define(SSH_AGENTC_UNLOCK,                        23).
+-define(SSH_AGENTC_ADD_SMARTCARD_KEY_CONSTRAINED, 26).
+-define(SSH_AGENTC_EXTENSION,                     27).
+
+%% The following numbers are used for replies from the agent to the client.
+
+-define(SSH_AGENT_FAILURE,                        5).
+-define(SSH_AGENT_SUCCESS,                        6).
+-define(SSH_AGENT_EXTENSION_FAILURE,              28).
+-define(SSH_AGENT_IDENTITIES_ANSWER,              12).
+-define(SSH_AGENT_SIGN_RESPONSE,                  14).
+
+%% SSH Agent messages
+%%
+%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-4
+
+%% 4.1 Generic server responses
+
+-record(ssh_agent_success,
+	{
+	 }).
+
+-record(ssh_agent_failure,
+	{
+	 }).
+
+%% 4.4 Requesting a list of keys
+
+-record(ssh_agent_identities_request,
+	{
+	 }).
+
+-record(ssh_agent_identity,
+    {
+      key_blob, % string
+      comment   % string
+     }).
+
+-record(ssh_agent_identities_response,
+    {
+      nkeys, % integer
+      keys   % list of ssh_agent_identity records
+     }).
+
+%% 4.5 Private key operations
+
+-record(ssh_agent_sign_request,
+	{
+	  key_blob, % string
+	  data,		% string
+	  flags		% integer
+	 }).
+
+-record(ssh_agent_sign_response,
+	{
+	  signature % string
+  	 }).

--- a/lib/ssh/src/ssh_agent.hrl
+++ b/lib/ssh/src/ssh_agent.hrl
@@ -74,15 +74,15 @@
     {
     }).
 
--record(ssh_agent_identity,
+-record(ssh_agent_key,
     {
-      key_blob, % string
-      comment   % string
+      blob,   % string
+      comment % string
     }).
 
 -record(ssh_agent_identities_response,
     {
-      keys % list of ssh_agent_identity records
+      keys % list of ssh_agent_key records
     }).
 
 %% 4.5 Private key operations

--- a/lib/ssh/src/ssh_agent.hrl
+++ b/lib/ssh/src/ssh_agent.hrl
@@ -82,8 +82,7 @@
 
 -record(ssh_agent_identities_response,
     {
-      nkeys, % integer
-      keys   % list of ssh_agent_identity records
+      keys % list of ssh_agent_identity records
     }).
 
 %% 4.5 Private key operations

--- a/lib/ssh/src/ssh_agent.hrl
+++ b/lib/ssh/src/ssh_agent.hrl
@@ -47,6 +47,13 @@
 -define(SSH_AGENT_IDENTITIES_ANSWER,              12).
 -define(SSH_AGENT_SIGN_RESPONSE,                  14).
 
+%% SSH Agent signature flags
+%%
+%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-5.3
+
+-define(SSH_AGENT_RSA_SHA2_256,                   2).
+-define(SSH_AGENT_RSA_SHA2_512,                   4).
+
 %% SSH Agent messages
 %%
 %% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-4

--- a/lib/ssh/src/ssh_agent.hrl
+++ b/lib/ssh/src/ssh_agent.hrl
@@ -54,41 +54,41 @@
 %% 4.1 Generic server responses
 
 -record(ssh_agent_success,
-	{
-	 }).
+    {
+    }).
 
 -record(ssh_agent_failure,
-	{
-	 }).
+    {
+    }).
 
 %% 4.4 Requesting a list of keys
 
 -record(ssh_agent_identities_request,
-	{
-	 }).
+    {
+    }).
 
 -record(ssh_agent_identity,
     {
       key_blob, % string
       comment   % string
-     }).
+    }).
 
 -record(ssh_agent_identities_response,
     {
       nkeys, % integer
       keys   % list of ssh_agent_identity records
-     }).
+    }).
 
 %% 4.5 Private key operations
 
 -record(ssh_agent_sign_request,
-	{
-	  key_blob, % string
-	  data,		% string
-	  flags		% integer
-	 }).
+    {
+      key_blob, % string
+      data,     % string
+      flags     % integer
+    }).
 
 -record(ssh_agent_sign_response,
-	{
-	  signature % string
-  	 }).
+    {
+      signature % string
+    }).

--- a/lib/ssh/src/ssh_agent.hrl
+++ b/lib/ssh/src/ssh_agent.hrl
@@ -18,7 +18,7 @@
 %% %CopyrightEnd%
 %%
 
-%%
+%% Reference: https://tools.ietf.org/html/draft-miller-ssh-agent-02
 
 %% SSH Agent message numbers
 %%

--- a/lib/ssh/src/ssh_auth.erl
+++ b/lib/ssh/src/ssh_auth.erl
@@ -172,10 +172,10 @@ publickey_msg([SigAlg, #ssh{user = User,
             SigAlgStr = atom_to_list(SigAlg),
             SigData = build_sig_data(SessionId, User, Service, PubKeyBlob, SigAlgStr),
 
-            SignRequest = #ssh_agent_sign_request{
-                key_blob = PubKeyBlob,
-                data = SigData,
-                flags = ?SSH_AGENT_RSA_SHA2_256 bor ?SSH_AGENT_RSA_SHA2_512},
+            % OpenSSH does not seem to care when these flags are set for
+            % signature algorithms other than RSA, so we always send them.
+            SignFlags = ?SSH_AGENT_RSA_SHA2_256 bor ?SSH_AGENT_RSA_SHA2_512,
+            SignRequest = #ssh_agent_sign_request{key_blob = PubKeyBlob, data = SigData, flags = SignFlags},
             SignResponse = ssh_agent:send(SignRequest),
 
             #ssh_agent_sign_response{signature = #ssh_agent_signature{blob = Sig}} = SignResponse,

--- a/lib/ssh/src/ssh_auth.erl
+++ b/lib/ssh/src/ssh_auth.erl
@@ -169,12 +169,12 @@ publickey_msg([SigAlg, #ssh{user = User,
     case get_public_key(SigAlg, Ssh) of
         % TODO: Integrate agent support (explicitly mark agent keys)
         {ok, {nil, PubKeyBlob}} ->
-            SigAlgStr = "rsa-sha2-256",
-            Data = build_sig_data(SessionId, User, Service, PubKeyBlob, SigAlgStr),
+            SigAlgStr = atom_to_list(SigAlg),
+            SigData = build_sig_data(SessionId, User, Service, PubKeyBlob, SigAlgStr),
 
             SignRequest = #ssh_agent_sign_request{
                 key_blob = PubKeyBlob,
-                data = Data,
+                data = SigData,
                 flags = ?SSH_AGENT_RSA_SHA2_256 bor ?SSH_AGENT_RSA_SHA2_512},
             SignResponse = ssh_agent:send(SignRequest),
 

--- a/lib/ssh/src/ssh_auth.erl
+++ b/lib/ssh/src/ssh_auth.erl
@@ -178,15 +178,13 @@ publickey_msg([SigAlg, #ssh{user = User,
     SignRequest = #ssh_agent_sign_request{
       key_blob = PubKeyBlob,
       data = Data,
-      flags = 2}, % SSH_AGENT_RSA_SHA2_256
+      flags = ?SSH_AGENT_RSA_SHA2_256 bor ?SSH_AGENT_RSA_SHA2_512},
     SignResponse = ssh_agent:send(SignRequest),
 
     #ssh_agent_sign_response{signature = #ssh_agent_signature{blob = Sig}} = SignResponse,
 
     SigBlob = list_to_binary([?string(SigAlgStr),
                               ?binary(Sig)]),
-    % SigBlob = Sig,
-
     io:fwrite("Sig:~n~p~n~nSigBlob:~n~p~n~nPubKeyBlob:~n~p~n~n", [Sig, SigBlob, PubKeyBlob]),
 
     ssh_transport:ssh_packet(

--- a/lib/ssh/src/ssh_auth.erl
+++ b/lib/ssh/src/ssh_auth.erl
@@ -168,7 +168,7 @@ publickey_msg([SigAlg, #ssh{user = User,
     Response = ssh_agent:send(Request),
 
     #ssh_agent_identities_response{keys = Keys} = Response,
-    [#ssh_agent_identity{key_blob = PubKeyBlob} | _Rest] = Keys,
+    [#ssh_agent_key{blob = PubKeyBlob} | _Rest] = Keys,
 
     % Sign data
 

--- a/lib/ssh/src/ssh_client_key_api.erl
+++ b/lib/ssh/src/ssh_client_key_api.erl
@@ -25,11 +25,11 @@
 
 -export_type([client_key_cb_options/0]).
 
--type client_key_cb_options() :: [{key_cb_private,term()} | ssh:client_option()].
+-type client_key_cb_options() :: [{key_cb_private, term()} | ssh:client_option()].
 
 -callback is_host_key(Key :: public_key:public_key(),
                       Host :: string(),
-		      Algorithm :: ssh:pubkey_alg(),
+                      Algorithm :: ssh:pubkey_alg(),
                       Options :: client_key_cb_options()
                      ) ->
     boolean().
@@ -37,11 +37,13 @@
 -callback user_key(Algorithm :: ssh:pubkey_alg(),
                    Options :: client_key_cb_options()
                   ) ->
-    {ok,  PrivateKey :: public_key:private_key()} | {error, string()}.
+    {ok, PrivateKey :: public_key:private_key()} |
+    {ok, PrivKeyBlob :: binary()} |
+    {error, string()}.
 
 
 -callback add_host_key(Host :: string(),
                        PublicKey :: public_key:public_key(),
                        Options :: client_key_cb_options()
                       ) ->
-    ok | {error, Error::term()}.
+    ok | {error, Error :: term()}.

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1832,17 +1832,13 @@ ext_info(_, D0) ->
     D0.
 
 %%%----------------------------------------------------------------
-is_usable_user_pubkey(_Alg, _Ssh) ->
-    true.
-
-% TODO: Re-enable once ssh_auth:get_public_key supports ssh-agent
-% is_usable_user_pubkey(Alg, Ssh) ->
-%     try ssh_auth:get_public_key(Alg, Ssh) of
-%         {ok,_} -> true;
-%         _ -> false
-%     catch
-%         _:_ -> false
-%     end.
+is_usable_user_pubkey(Alg, Ssh) ->
+    try ssh_auth:get_public_key(Alg, Ssh) of
+        {ok,_} -> true;
+        _ -> false
+    catch
+        _:_ -> false
+    end.
 
 %%%----------------------------------------------------------------
 is_usable_host_key(Alg, Opts) ->

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1832,13 +1832,17 @@ ext_info(_, D0) ->
     D0.
 
 %%%----------------------------------------------------------------
-is_usable_user_pubkey(Alg, Ssh) ->
-    try ssh_auth:get_public_key(Alg, Ssh) of
-        {ok,_} -> true;
-        _ -> false
-    catch
-        _:_ -> false
-    end.
+is_usable_user_pubkey(_Alg, _Ssh) ->
+    true.
+
+% TODO: Re-enable once ssh_auth:get_public_key supports ssh-agent
+% is_usable_user_pubkey(Alg, Ssh) ->
+%     try ssh_auth:get_public_key(Alg, Ssh) of
+%         {ok,_} -> true;
+%         _ -> false
+%     catch
+%         _:_ -> false
+%     end.
 
 %%%----------------------------------------------------------------
 is_usable_host_key(Alg, Opts) ->

--- a/lib/ssh/src/ssh_file_with_agent.erl
+++ b/lib/ssh/src/ssh_file_with_agent.erl
@@ -35,9 +35,12 @@ add_host_key(Host, Key, Opts) ->
 is_host_key(Key, PeerName, Algorithm, Opts) ->
     ssh_file:is_host_key(Key, PeerName, Algorithm, Opts).
 
-user_key(Algorithm, _Opts) ->
+user_key(Algorithm, Opts) ->
+    KeyCbOpts = proplists:get_value(key_cb_private, Opts, []),
+    Timeout = proplists:get_value(timeout, KeyCbOpts, 1000),
+
     Request = #ssh_agent_identities_request{},
-    Response = ssh_agent:send(Request),
+    Response = ssh_agent:send(Request, Timeout),
 
     #ssh_agent_identities_response{keys = Keys} = Response,
 

--- a/lib/ssh/src/ssh_file_with_agent.erl
+++ b/lib/ssh/src/ssh_file_with_agent.erl
@@ -1,0 +1,62 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2019. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%% Description: SSH file handling with SSH Agent support
+
+-module(ssh_file_with_agent).
+
+-behaviour(ssh_client_key_api).
+
+-include("ssh.hrl").
+-include("ssh_agent.hrl").
+
+-export([add_host_key/3, is_host_key/4, user_key/2]).
+
+add_host_key(Host, Key, Opts) ->
+    ssh_file:add_host_key(Host, Key, Opts).
+
+is_host_key(Key, PeerName, Algorithm, Opts) ->
+    ssh_file:is_host_key(Key, PeerName, Algorithm, Opts).
+
+user_key(Algorithm, _Opts) ->
+    Request = #ssh_agent_identities_request{},
+    Response = ssh_agent:send(Request),
+
+    #ssh_agent_identities_response{keys = Keys} = Response,
+
+    AlgorithmStr = atom_to_list(Algorithm),
+    MatchingKeys = lists:filter(fun(Key) -> has_key_type(Key, AlgorithmStr) end, Keys),
+
+    % The "client_key_api" behaviour only allows returning a single user key,
+    % so we simply select the first one returned from the SSH agent here. This
+    % means that if a user adds multiple keys for the same algorithm, only the
+    % first one added will be used.
+    [#ssh_agent_key{blob = PubKeyBlob} | _OtherKeys] = MatchingKeys,
+
+    % TODO:
+    % Mark the returned key so we can identify agent keys as they do not
+    % contain the private key.
+    {ok, PubKeyBlob}.
+
+%% Utility functions
+
+has_key_type(#ssh_agent_key{blob = KeyBlob}, Type) ->
+  <<?DEC_BIN(KeyType, _KeyTypeLen), _KeyBlobRest/binary>> = KeyBlob,
+  binary_to_list(KeyType) == Type.

--- a/lib/ssh/test/Makefile
+++ b/lib/ssh/test/Makefile
@@ -39,6 +39,7 @@ MODULES= \
 	ssh_chan_behaviours_SUITE \
 	ssh_compat_SUITE \
 	ssh_connection_SUITE \
+	ssh_agent_SUITE \
 	ssh_dbg_SUITE \
 	ssh_engine_SUITE \
 	ssh_protocol_SUITE \

--- a/lib/ssh/test/ssh_agent_SUITE.erl
+++ b/lib/ssh/test/ssh_agent_SUITE.erl
@@ -39,18 +39,14 @@ all() ->
 
 init_per_suite(Config) ->
     ok = ssh:start(),
-    TempDir = filename:join(["", "tmp", ?MODULE_STRING]),
-    ok = file:make_dir(TempDir),
-    put_temp_dir(Config, TempDir).
+    Config.
 
-end_per_suite(Config) ->
-    TempDir = get_temp_dir(Config),
-    ok = file:del_dir(TempDir),
+end_per_suite(_Config) ->
     ok = ssh:stop().
 
 init_per_testcase(_TestCase, Config) ->
-    TempDir = get_temp_dir(Config),
-    PathPrefix = filename:join(TempDir, "agent."),
+    PrivDir = proplists:get_value(priv_dir, Config),
+    PathPrefix = filename:join(PrivDir, "agent."),
     SocketPath = test_server:temp_name(PathPrefix),
     put_socket_path(Config, SocketPath).
 
@@ -85,12 +81,6 @@ request_identities(Config) ->
     ok.
 
 %% Utility functions
-
-put_temp_dir(Config, TempDir) ->
-    [{temp_dir, TempDir} | Config].
-
-get_temp_dir(Config) ->
-    proplists:get_value(temp_dir, Config).
 
 put_socket_path(Config, SocketPath) ->
     [{socket_path, SocketPath} | Config].

--- a/lib/ssh/test/ssh_agent_SUITE.erl
+++ b/lib/ssh/test/ssh_agent_SUITE.erl
@@ -1,0 +1,121 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2019. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+
+-module(ssh_agent_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("ssh/src/ssh_agent.hrl").
+-include("ssh_test_lib.hrl").
+-include("ssh.hrl").
+
+-compile(export_all).
+
+%% Test configuration
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    [request_identities].
+
+init_per_suite(Config) ->
+    ok = ssh:start(),
+    TempDir = filename:join(["", "tmp", ?MODULE_STRING]),
+    ok = file:make_dir(TempDir),
+    put_temp_dir(Config, TempDir).
+
+end_per_suite(Config) ->
+    TempDir = get_temp_dir(Config),
+    ok = file:del_dir(TempDir),
+    ok = ssh:stop().
+
+init_per_testcase(_TestCase, Config) ->
+    TempDir = get_temp_dir(Config),
+    PathPrefix = filename:join(TempDir, "agent."),
+    SocketPath = test_server:temp_name(PathPrefix),
+    put_socket_path(Config, SocketPath).
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%% Test cases
+
+request_identities() ->
+    [{doc, "Request a list of identities"}].
+
+request_identities(Config) ->
+    Request = #ssh_agent_identities_request{},
+    SocketPath = get_socket_path(Config),
+
+    agent(Config, <<?UINT32(41),            % message length
+                    ?BYTE(12),              % message type   (1 byte)
+                    ?UINT32(2),             % number of keys (4 bytes)
+                    ?STRING(<<"lorem">>),   % key 1 comment  (4 + 5 bytes)
+                    ?STRING(<<"key-1">>),   % key 1 blob     (4 + 5 bytes)
+                    ?STRING(<<"ipsum">>),   % key 2 comment  (4 + 5 bytes)
+                    ?STRING(<<"key-2">>)    % key 2 blob     (4 + 5 bytes)
+                  >>),
+
+    Response = ssh_agent:send(Request, SocketPath, infinity),
+
+    #ssh_agent_identities_response{keys = Keys} = Response,
+
+    [{ssh_agent_key,<<"lorem">>,<<"key-1">>},
+     {ssh_agent_key,<<"ipsum">>,<<"key-2">>}] = Keys,
+
+    ok.
+
+%% Utility functions
+
+put_temp_dir(Config, TempDir) ->
+    [{temp_dir, TempDir} | Config].
+
+get_temp_dir(Config) ->
+    proplists:get_value(temp_dir, Config).
+
+put_socket_path(Config, SocketPath) ->
+    [{socket_path, SocketPath} | Config].
+
+get_socket_path(Config) ->
+    proplists:get_value(socket_path, Config).
+
+%% Mock agent
+
+agent(Config, BinResponse) ->
+    SocketPath = get_socket_path(Config),
+    Parent = self(),
+
+    spawn(fun() ->
+              Address = {local, SocketPath},
+              ConnectOpts = [local, binary, {ip, Address}, {packet, 0}, {active, false}],
+
+              {ok, ListenSocket} = gen_tcp:listen(0, ConnectOpts),
+              {ok, Socket} = gen_tcp:accept(ListenSocket),
+              {ok, BinRequest} = gen_tcp:recv(Socket, 0),
+
+              Parent ! {request, BinRequest},
+
+              ok = gen_tcp:send(Socket, BinResponse),
+
+              ok = gen_tcp:close(Socket),
+              ok = file:delete(SocketPath)
+          end).

--- a/scripts/Dockerfile.develop
+++ b/scripts/Dockerfile.develop
@@ -1,6 +1,8 @@
 FROM erlang/ubuntu-build:64bit
 
-RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+      && apt-get install -y libssl-dev sudo \
+      && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user to use for development -
 # test for applications like `ssh` fail when executed as root

--- a/scripts/Dockerfile.develop
+++ b/scripts/Dockerfile.develop
@@ -1,7 +1,7 @@
 FROM erlang/ubuntu-build:64bit
 
 RUN apt-get update \
-      && apt-get install -y libssl-dev sudo \
+      && apt-get install -y libssl-dev sudo wget \
       && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user to use for development -
@@ -34,7 +34,7 @@ COPY --chown=dev ./otp $ERL_TOP
 RUN $ERL_TOP/otp_build setup -a --prefix=$PREFIX && $ERL_TOP/otp_build release
 RUN sudo make --directory=$ERL_TOP install
 
-# Set up PropEr for property-based testing which used in some OTP tests
+# Set up PropEr for property-based testing which is used in some OTP tests
 RUN git clone git://github.com/proper-testing/proper.git /buildroot/proper
 RUN make --directory=/buildroot/proper
 ENV ERL_LIBS /buildroot/proper:$ERL_LIBS

--- a/scripts/Dockerfile.develop
+++ b/scripts/Dockerfile.develop
@@ -21,6 +21,7 @@ RUN mkdir -p $ERL_TOP && chown -R dev:dev $ERL_TOP
 
 # Switch to the development user and directory
 USER dev
+ENV USER dev
 WORKDIR $ERL_TOP
 
 # Copy sources from the Docker build context

--- a/scripts/Dockerfile.develop
+++ b/scripts/Dockerfile.develop
@@ -1,0 +1,43 @@
+FROM erlang/ubuntu-build:64bit
+
+RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user to use for development -
+# test for applications like `ssh` fail when executed as root
+RUN useradd --create-home --user-group --groups sudo dev
+RUN echo 'dev ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers.d/dev
+
+# Create the root directory for development
+RUN mkdir -p /buildroot && chown -R dev:dev /buildroot
+
+# Set up the environment
+ENV ERL_TOP /buildroot/otp
+ENV PATH $ERL_TOP/bin:$PATH
+ENV PREFIX /usr/local
+ENV MAKEFLAGS -j4
+
+# Create top-level OTP directory and own it!
+RUN mkdir -p $ERL_TOP && chown -R dev:dev $ERL_TOP
+
+# Switch to the development user and directory
+USER dev
+WORKDIR $ERL_TOP
+
+# Copy sources from the Docker build context
+COPY --chown=dev ./otp $ERL_TOP
+
+# Install a release required for a number of tests to execute successfully -
+# https://github.com/erlang/otp/wiki/Running-tests
+RUN $ERL_TOP/otp_build setup -a --prefix=$PREFIX && $ERL_TOP/otp_build release
+RUN sudo make --directory=$ERL_TOP install
+
+# Set up PropEr for property-based testing which used in some OTP tests
+RUN git clone git://github.com/proper-testing/proper.git /buildroot/proper
+RUN make --directory=/buildroot/proper
+ENV ERL_LIBS /buildroot/proper:$ERL_LIBS
+
+# Enable erl shell history
+ENV ERL_AFLAGS -kernel shell_history enabled
+
+# Run an Erlang session by default
+CMD ["/usr/local/bin/erl"]

--- a/scripts/build-docker-image
+++ b/scripts/build-docker-image
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Create a Docker image for development:
+#
+# 1. Create an archive from the master branch
+# 2. Inject Dockerfile.develop
+# 3. Send these to Docker as the build context
+# 4. Build the development image according to Dockerfile.develop
+
+HERE=$(realpath "$(dirname "$0")")
+DOCKERFILE="Dockerfile.develop"
+
+git archive --format=tar --prefix=otp/ master | tar -C $HERE -c -f - $DOCKERFILE @- | gzip | docker build --file $DOCKERFILE --tag otp-dev -

--- a/scripts/drop-into-docker
+++ b/scripts/drop-into-docker
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Start a container from the OTP development Docker image
+#
+# The image is built with `scripts/build-docker-image`.
+#
+# Mount the local repo on the host machine as the build root so you can develop
+# with your own editor and setup, but run builds and tests inside the container.
+
+ROOT=$(realpath "$(dirname "$0")/..")
+
+IMAGE=otp-dev
+
+exec docker run \
+  --interactive \
+  --tty \
+  --rm \
+  --hostname otp-dev \
+  --volume $ROOT:/buildroot/otp \
+  $IMAGE \
+  bash

--- a/scripts/open-test-results
+++ b/scripts/open-test-results
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ROOT=$(realpath "$(dirname "$0")/..")
+
+open $ROOT/release/tests/test_server/index.html


### PR DESCRIPTION
Hey 👋 This is a take on adding `ssh-agent` support to OTP.

_Note: This is an early draft intended to collect feedback and iterate on the solution. ✌️_

_Note 2: There are a few helper files (`scripts/*` and `Dockerfile`) which I intend to remove but kept around for now, because they make development a bit more convenient._

**Overview of changes**

1. Add an `ssh_agent` module handling communication with `ssh-agent` processes
    - determines the agent socket from the process environment
    - handles encoding and decoding of agent messages into records
2. Add `ssh_file_with_agent` module (loosely) implementing the [`ssh_client_key_api`](http://erlang.org/doc/man/ssh_client_key_api.html) `behaviour`
    - handles calls to the `user_key/2` callback by fetching a list of keys from an agent
    - delegates calls to the host key callbacks to the default [`ssh_file`](http://erlang.org/doc/man/ssh_file.html) module (agents do not handle host keys)
3. Update the `ssh_auth` module to handle keys returned from an agent
    - keys returned from an agent never include the private key part
    - delegate "signing" to the agent for agent keys to prove the client identity

**Test-drive**

If you would like to test-drive these changes, here is an escript I used to try them out:
https://gist.github.com/pmeinhardt/a39494d43f6acf606fc7249a3fe2cb50

This also illustrates how these changes would be used in code.

**Discussion**

The current approach taken tries to fit into the existing code structure and APIs without breaking backwards-compatibility. However, there are some limitations because of this which may be worth addressing in the future (not part of this PR).

In particular, while working on this I noticed that the `ssh_client_key_cb` behavior:

1. makes the assumption that there is only ever one key for a given algorithm (`user_key/2` is expected to only ever return one key).

    This means that even though you can add multiple RSA keys to an agent for instance (or you may have multiple key files for this algorithm), the OTP `ssh` application will only try one.

2. does not include "signing" to verify the client identity.

    This makes it rather odd to integrate the agent behavior, as the agent-specific keys and handling of data signing "bleeds" into the `ssh_auth` module.

In the long run ("future work"), it might therefore be desirable to potentially replace/extend the `ssh_client_key_api` to address these issues.

**References**

The relevant RFCs and specific sections are also referenced in the code, but I will also list them here for easy access:

- https://tools.ietf.org/html/draft-miller-ssh-agent-02
- https://tools.ietf.org/html/rfc4251
- https://tools.ietf.org/html/rfc4252
- https://tools.ietf.org/html/rfc4253

**To-Dos**

- [ ] Add unit-tests
- [ ] Add system tests?
- [ ] Finalize `ssh_client_key_api` behaviour changes
- [ ] Update documentation