### PR TITLE
Support local sockets with inet:i/0

### DIFF
--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -1645,6 +1645,7 @@ fmt_addr({ok,Addr}, Proto) ->
 	{{0,0,0,0,0,0,0,0},Port} -> "*:" ++ fmt_port(Port, Proto);
 	{{127,0,0,1},Port} -> "localhost:" ++ fmt_port(Port, Proto);
 	{{0,0,0,0,0,0,0,1},Port} -> "localhost:" ++ fmt_port(Port, Proto);
+	{local, Path} -> "local:" ++ binary_to_list(Path);
 	{IP,Port} -> inet_parse:ntoa(IP) ++ ":" ++ fmt_port(Port, Proto)
     end.
 


### PR DESCRIPTION
Before:

```erlang
1> gen_udp:open(0, [local, {ip, {local, "unixdomainfile"}}]).
{ok,#Port<0.6>}
2> inet:i().
** exception error: bad argument
     in function  integer_to_list/1
        called as integer_to_list(<<"unixdomainfile">>)
     in call from inet:fmt_port/2 (inet.erl, line 1646)
     in call from inet:fmt_addr/2 (inet.erl, line 1642)
     in call from inet:'-i_line/3-lc$^0/1-0-'/3 (inet.erl, line 1547)
     in call from inet:'-i_line/3-lc$^0/1-0-'/3 (inet.erl, line 1547)
     in call from inet:'-info_lines/3-lc$^0/1-0-'/3 (inet.erl, line 1546)
     in call from inet:ii/3 (inet.erl, line 1531)
     in call from inet:i/0 (inet.erl, line 1515)
```

After:

```erlang
2> inet:i().
Port Module    Recv Sent Owner      Local Address           Foreign Address State Type
4160 local_udp 0    0    <0.1747.0> local:unixdomainfile    *:*             IDLE  DGRAM
```