### PR TITLE
Start up of SASl when compared log level is all

### DIFF
--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -600,11 +600,11 @@ get_module_level() ->
 %%%-----------------------------------------------------------------
 %%% Misc
 -spec compare_levels(Level1,Level2) -> eq | gt | lt when
-      Level1 :: level(),
-      Level2 :: level().
-compare_levels(Level,Level) when ?IS_LEVEL(Level) ->
+      Level1 :: level() | all | none,
+      Level2 :: level() | all | none.
+compare_levels(Level,Level) when ?IS_LEVEL_ALL(Level) ->
     eq;
-compare_levels(Level1,Level2) when ?IS_LEVEL(Level1), ?IS_LEVEL(Level2) ->
+compare_levels(Level1,Level2) when ?IS_LEVEL_ALL(Level1), ?IS_LEVEL_ALL(Level2) ->
     Int1 = logger_config:level_to_int(Level1),
     Int2 = logger_config:level_to_int(Level2),
     if Int1 < Int2 -> gt;
@@ -950,7 +950,7 @@ get_logger_type(Env) ->
 
 get_logger_level() ->
     case application:get_env(kernel,logger_level,info) of
-        Level when ?IS_LEVEL(Level); Level=:=all; Level=:=none ->
+        Level when ?IS_LEVEL_ALL(Level) ->
             Level;
         Level ->
             throw({logger_level, Level})

--- a/lib/kernel/src/logger_internal.hrl
+++ b/lib/kernel/src/logger_internal.hrl
@@ -86,7 +86,12 @@
             L=:=warning orelse
             L=:=notice orelse
             L=:=info orelse
-            L=:=debug)).
+            L=:=debug )).
+
+-define(IS_LEVEL_ALL(L),
+        ?IS_LEVEL(L) orelse
+            L=:=all orelse
+			L=:=none ).
 
 -define(IS_MSG(Msg),
         ((is_tuple(Msg) andalso tuple_size(Msg)==2)

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -880,7 +880,7 @@ other_node(cleanup,_Config) ->
     ok.
 
 compare_levels(_Config) ->
-    Levels = [emergency,alert,critical,error,warning,notice,info,debug],
+    Levels = [none,emergency,alert,critical,error,warning,notice,info,debug,all],
     ok = compare(Levels),
     {error,badarg} = ?TRY(logger:compare_levels(bad,bad)),
     {error,badarg} = ?TRY(logger:compare_levels({bad},notice)),


### PR DESCRIPTION
SASL won;'t boot when it compares log level (when one is all); it seems like a mistake as all is a valid log level as defined by the all levels macro. 

**Example:**
```
logger:compare_levels(info,all). 
** exception error: bad argument
     in function  logger:compare_levels/2
        called as logger:compare_levels(info,all)

```
Example of SASL not starting. 
```=INFO REPORT==== 25-Jun-2019::10:53:19.643029 ===
    application: sasl
    exited: {bad_return,
                {{sasl,start,[normal,[]]},
                 {'EXIT',
                     {badarg,
                         [{logger,compare_levels,
                              [info,all],
                              [{file,"logger.erl"},{line,614}]},
                          {sasl,allow_progress,0,
                              [{file,"sasl.erl"},{line,171}]},
                          {sasl,add_error_logger_mf,1,
                              [{file,"sasl.erl"},{line,158}]},
                          {sasl,start,2,[{file,"sasl.erl"},{line,40}]},
                          {application_master,start_it_old,4,
                              [{file,"application_master.erl"},
                               {line,277}]}]}}}}
```