### PR TITLE
ERL-989: Fix typo in httpc_SUITE:content_length/1

### DIFF
--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -2180,7 +2180,7 @@ check_cookie([_Head | Tail]) ->
 
 content_length([]) ->
     0;
-content_length(["content-length:" ++ Value | _]) ->
+content_length([{"content-length", Value}|_]) ->
     list_to_integer(string:strip(Value));
 content_length([_Head | Tail]) ->
    content_length(Tail).


### PR DESCRIPTION
[https://bugs.erlang.org/browse/ERL-989](https://bugs.erlang.org/browse/ERL-989)