### PR TITLE
mnesia: Fix deadlock caused by add_table_copy

### DIFF
--- a/lib/mnesia/src/mnesia_schema.erl
+++ b/lib/mnesia/src/mnesia_schema.erl
@@ -697,7 +697,7 @@ schema_coordinator(Client, _Fun, undefined) ->
 schema_coordinator(Client, Fun, Controller) when is_pid(Controller) ->
     %% Do not trap exit in order to automatically die
     %% when the controller dies
-
+    put(transaction_client, Client), %% debug
     link(Controller),
     unlink(Client),
 


### PR DESCRIPTION
If add_table_copy was called when a node was starting it could deadlock
waiting for mnesia_controller, when schema was not merged.

Abort if that is the case.