### PR TITLE
ERL-991 Strip control codes from eunit_surefire output

### DIFF
--- a/lib/eunit/src/eunit_surefire.erl
+++ b/lib/eunit/src/eunit_surefire.erl
@@ -451,6 +451,9 @@ escape_xml([$< | Tail], Acc, ForAttr) -> escape_xml(Tail, [$;, $t, $l, $& | Acc]
 escape_xml([$> | Tail], Acc, ForAttr) -> escape_xml(Tail, [$;, $t, $g, $& | Acc], ForAttr);
 escape_xml([$& | Tail], Acc, ForAttr) -> escape_xml(Tail, [$;, $p, $m, $a, $& | Acc], ForAttr);
 escape_xml([$" | Tail], Acc, true) -> escape_xml(Tail, [$;, $t, $o, $u, $q, $& | Acc], true); % "
+%% Strip C0 control codes, which are not allowed in XML 1.0
+escape_xml([Char | Tail], Acc, ForAttr) when
+      is_integer(Char), 0 =< Char, Char =< 31 -> escape_xml(Tail, Acc, ForAttr);
 escape_xml([Char | Tail], Acc, ForAttr) when is_integer(Char) -> escape_xml(Tail, [Char | Acc], ForAttr).
 
 %% the input may be utf8 or latin1; the resulting list is unicode

--- a/lib/eunit/test/Makefile
+++ b/lib/eunit/test/Makefile
@@ -22,6 +22,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 
 MODULES =  \
 	eunit_SUITE \
+	tc0 \
 	tlatin \
 	tutf8
 

--- a/lib/eunit/test/eunit_SUITE.erl
+++ b/lib/eunit/test/eunit_SUITE.erl
@@ -21,14 +21,16 @@
 
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
-	 app_test/1,appup_test/1,eunit_test/1,surefire_utf8_test/1,surefire_latin_test/1]).
+	 app_test/1,appup_test/1,eunit_test/1,surefire_utf8_test/1,surefire_latin_test/1,
+	 surefire_c0_test/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
-    [app_test, appup_test, eunit_test, surefire_utf8_test, surefire_latin_test].
+    [app_test, appup_test, eunit_test, surefire_utf8_test, surefire_latin_test,
+     surefire_c0_test].
 
 groups() ->
     [].
@@ -65,6 +67,11 @@ surefire_utf8_test(Config) when is_list(Config) ->
 	check_surefire(tutf8),
 	ok.
 
+surefire_c0_test(Config) when is_list(Config) ->
+    ok = file:set_cwd(proplists:get_value(priv_dir, Config, ".")),
+    check_surefire(tc0),
+    ok.
+
 check_surefire(Module) ->
 	File = "TEST-"++atom_to_list(Module)++".xml",
 	file:delete(File),
@@ -72,4 +79,5 @@ check_surefire(Module) ->
 	eunit:test(Module, [{report,{eunit_surefire,[{dir,"."}]}}]),
 	{ok, Bin} = file:read_file(File),
 	[_|_] = unicode:characters_to_list(Bin, unicode),
+	xmerl_scan:file(File),
 	ok.

--- a/lib/eunit/test/tc0.erl
+++ b/lib/eunit/test/tc0.erl
@@ -1,0 +1,14 @@
+-module(tc0).
+
+-include_lib("eunit/include/eunit.hrl").
+
+'c0_bad_output_test_'() ->
+    [{integer_to_list(C), fun() -> io:format("'~c'", [C]) end}
+     || C <- lists:seq(0, 31)].
+
+'c0_bad_description_test_'() ->
+    [{[C], fun() -> ok end}
+     || C <- lists:seq(0, 31)].
+
+'c0_bad_name__test'() ->
+    ok.


### PR DESCRIPTION
Without this, test cases which output control codes, or with names or
descriptions containing control codes, would cause the generated XML files to be
invalid.