### PR TITLE
Remove inets dependency from edoc

### DIFF
--- a/lib/edoc/src/edoc.app.src
+++ b/lib/edoc/src/edoc.app.src
@@ -23,4 +23,4 @@
   {applications, [compiler,kernel,stdlib,syntax_tools]},
   {env, []},
   {runtime_dependencies, ["xmerl-1.3.7","syntax_tools-1.6.14","stdlib-2.5",
-			  "kernel-3.0","inets-5.10","erts-6.0"]}]}.
+			  "kernel-3.0","erts-6.0"]}]}.

--- a/lib/edoc/src/edoc.erl
+++ b/lib/edoc/src/edoc.erl
@@ -259,10 +259,9 @@ opt_negations() ->
 %%  </dd>
 %%  <dt>{@type {doc_path, [string()]@}}
 %%  </dt>
-%%  <dd>Specifies a list of URI:s pointing to directories that contain
-%%      EDoc-generated documentation. URI without a `scheme://' part are
-%%      taken as relative to `file://'. (Note that such paths must use
-%%      `/' as separator, regardless of the host operating system.)
+%%  <dd>Specifies a list of file system paths pointing to directories that
+%%      contain EDoc-generated documentation. All paths for applications
+%%      in the code path are automatically added.
 %%  </dd>
 %%  <dt>{@type {doclet, Module::atom()@}}
 %%  </dt>


### PR DESCRIPTION
The feature that depended on inets was not used
in practice since Edoc automatically includes all
references to projects in your code path. Plus
you can always link to an external document
directly.

Finally, as we move towards EEP 48, we will likely
rely more on the chunk information rather than
precompiled edoc-info.

/cc @richcarl 