### PR TITLE
Extend the compiler's type representation

### DIFF
--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -198,7 +198,7 @@ types(erlang, element, [PosType, TupleType]) ->
 types(erlang, setelement, [PosType, TupleType, ArgType]) ->
     RetType = case {PosType,TupleType} of
                   {#t_integer{elements={Index,Index}},
-                   #t_tuple{elements=Es0,size=Size}=T} ->
+                   #t_tuple{elements=Es0,size=Size}=T} when Index >= 1 ->
                       %% This is an exact index, update the type of said
                       %% element or return 'none' if it's known to be out of
                       %% bounds.
@@ -212,7 +212,7 @@ types(erlang, setelement, [PosType, TupleType, ArgType]) ->
                               none
                       end;
                   {#t_integer{elements={Min,Max}},
-                   #t_tuple{elements=Es0,size=Size}=T} ->
+                   #t_tuple{elements=Es0,size=Size}=T} when Min >= 1 ->
                       %% We know this will land between Min and Max, so kill
                       %% the types for those indexes.
                       Es = discard_tuple_element_info(Min, Max, Es0),

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -37,7 +37,7 @@
 -spec types(Mod, Func, ArgTypes) -> {RetType, ArgTypes, CanSubtract} when
       Mod :: atom(),
       Func :: atom(),
-      ArgTypes :: [type()],
+      ArgTypes :: [normal_type()],
       RetType :: type(),
       CanSubtract :: boolean().
 

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -24,39 +24,7 @@
 
 -import(lists, [duplicate/2,foldl/3]).
 
--export([never_throws/3, types/3]).
-
--spec never_throws(Mod, Func, Arity) -> boolean() when
-      Mod :: atom(),
-      Func :: atom(),
-      Arity :: non_neg_integer().
-
-never_throws(erlang, '/=', 2) -> true;
-never_throws(erlang, '<', 2) -> true;
-never_throws(erlang, '=/=', 2) -> true;
-never_throws(erlang, '=:=', 2) -> true;
-never_throws(erlang, '=<', 2) -> true;
-never_throws(erlang, '==', 2) -> true;
-never_throws(erlang, '>', 2) -> true;
-never_throws(erlang, '>=', 2) -> true;
-never_throws(erlang, is_atom, 1) -> true;
-never_throws(erlang, is_boolean, 1) -> true;
-never_throws(erlang, is_binary, 1) -> true;
-never_throws(erlang, is_bitstring, 1) -> true;
-never_throws(erlang, is_float, 1) -> true;
-never_throws(erlang, is_function, 1) -> true;
-never_throws(erlang, is_integer, 1) -> true;
-never_throws(erlang, is_list, 1) -> true;
-never_throws(erlang, is_map, 1) -> true;
-never_throws(erlang, is_number, 1) -> true;
-never_throws(erlang, is_pid, 1) -> true;
-never_throws(erlang, is_port, 1) -> true;
-never_throws(erlang, is_reference, 1) -> true;
-never_throws(erlang, is_tuple, 1) -> true;
-never_throws(erlang, get, 1) -> true;
-never_throws(erlang, self, 0) -> true;
-never_throws(erlang, node, 0) -> true;
-never_throws(_, _, _) -> false.
+-export([types/3]).
 
 %%
 %% Returns the inferred return and argument types for known functions, and

--- a/lib/compiler/src/beam_kernel_to_ssa.erl
+++ b/lib/compiler/src/beam_kernel_to_ssa.erl
@@ -34,7 +34,7 @@
 -type label() :: beam_ssa:label().
 
 %% Main codegen structure.
--record(cg, {lcount=1 :: label(),               %Label counter
+-record(cg, {lcount=1 :: label(),   %Label counter
              bfail=1 :: label(),
              catch_label=none :: 'none' | label(),
              vars=#{} :: map(),     %Defined variables.
@@ -83,6 +83,7 @@ function(#k_fdef{anno=Anno0,func=Name,arity=Arity,
 
 cg_fun(Ke, St0) ->
     {UltimateFail,FailIs,St1} = make_failure(badarg, St0),
+    ?EXCEPTION_BLOCK = UltimateFail,            %Assertion.
     St2 = St1#cg{bfail=UltimateFail,ultimate_failure=UltimateFail},
     {B,St} = cg(Ke, St2),
     Asm = [{label,0}|B++FailIs],

--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -101,7 +101,7 @@
                    'bs_match' | 'bs_put' | 'bs_start_match' | 'bs_test_tail' |
                    'bs_utf16_size' | 'bs_utf8_size' | 'build_stacktrace' |
                    'call' | 'catch_end' |
-                   'extract' |
+                   'extract' | 'exception_trampoline' |
                    'get_hd' | 'get_map_element' | 'get_tl' | 'get_tuple_element' |
                    'has_map_field' |
                    'is_nonempty_list' | 'is_tagged_tuple' |

--- a/lib/compiler/src/beam_ssa.hrl
+++ b/lib/compiler/src/beam_ssa.hrl
@@ -62,5 +62,13 @@
 -record(b_local, {name  :: beam_ssa:b_literal(),
                   arity :: non_neg_integer()}).
 
-%% If this block exists, it calls erlang:error(badarg).
--define(BADARG_BLOCK, 1).
+%% This is a psuedo-block used to express that certain instructions and BIFs
+%% throw exceptions on failure. The code generator rewrites all branches to
+%% this block to {f,0} which causes the instruction to throw an exception
+%% instead of branching.
+%%
+%% Since this is not an ordinary block, it's illegal to merge it with other
+%% blocks, and jumps are only valid when we know that an exception will be
+%% thrown by the operation that branches here; the *block itself* does not
+%% throw an exception.
+-define(EXCEPTION_BLOCK, 1).

--- a/lib/compiler/src/beam_ssa_bsm.erl
+++ b/lib/compiler/src/beam_ssa_bsm.erl
@@ -684,9 +684,9 @@ aca_copy_successors(Lbl0, Blocks0, Counter0) ->
     Lbl = maps:get(Lbl0, BRs),
     {Lbl, Blocks, Counter}.
 
-aca_cs_build_brs([?BADARG_BLOCK=Lbl | Path], Counter, Acc) ->
-    %% ?BADARG_BLOCK is a marker and not an actual block, so renaming it will
-    %% break exception handling.
+aca_cs_build_brs([?EXCEPTION_BLOCK=Lbl | Path], Counter, Acc) ->
+    %% ?EXCEPTION_BLOCK is a marker and not an actual block, so renaming it
+    %% will break exception handling.
     aca_cs_build_brs(Path, Counter, Acc#{ Lbl => Lbl });
 aca_cs_build_brs([Lbl | Path], Counter0, Acc) ->
     aca_cs_build_brs(Path, Counter0 + 1, Acc#{ Lbl => Counter0 });

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -965,6 +965,12 @@ cg_block(Is0, Last, Next, St0) ->
     case Last of
         #cg_br{succ=Next,fail=Next} ->
             cg_block(Is0, none, St0);
+        #cg_br{succ=Same,fail=Same} when Same =:= ?BADARG_BLOCK ->
+            %% An expression in this block *always* throws an exception, so we
+            %% terminate it with an 'if_end' to make sure the validator knows
+            %% that the following instructions won't actually be reached.
+            {Is,St} = cg_block(Is0, none, St0),
+            {Is++[if_end],St};
         #cg_br{succ=Same,fail=Same} ->
             {Fail,St1} = use_block_label(Same, St0),
             {Is,St} = cg_block(Is0, none, St1),

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -2274,7 +2274,7 @@ non_guards_1([{L,#b_blk{is=Is}}|Bs]) ->
             non_guards_1(Bs)
     end;
 non_guards_1([]) ->
-    [?BADARG_BLOCK].
+    [?EXCEPTION_BLOCK].
 
 rel2fam(S0) ->
     S1 = sofs:relation(S0),

--- a/lib/compiler/src/beam_ssa_share.erl
+++ b/lib/compiler/src/beam_ssa_share.erl
@@ -117,8 +117,8 @@ share_terminator(_Last, _Blocks) -> none.
 %% possible if the blocks are not equivalent, as that is the common
 %% case.
 
-are_equivalent(_Succ, _, ?BADARG_BLOCK, _, _Blocks) ->
-    %% ?BADARG_BLOCK is special. Sharing could be incorrect.
+are_equivalent(_Succ, _, ?EXCEPTION_BLOCK, _, _Blocks) ->
+    %% ?EXCEPTION_BLOCK is special. Sharing could be incorrect.
     false;
 are_equivalent(_Succ, #b_blk{is=Is1,last=#b_ret{arg=RetVal1}=Ret1},
          _Fail, #b_blk{is=Is2,last=#b_ret{arg=RetVal2}=Ret2}, _Blocks) ->

--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -108,7 +108,7 @@ opt_continue_1(Linear0, Args, Id, Ts, FuncDb0) ->
     D = #d{ func_db=FuncDb0,
             func_id=Id,
             ds=Defs,
-            ls=#{0=>Ts,?BADARG_BLOCK=>#{}},
+            ls=#{0=>Ts,?EXCEPTION_BLOCK=>#{}},
             once=UsedOnce },
 
     {Linear, FuncDb, NewRet} = opt(Linear0, D, []),
@@ -892,8 +892,8 @@ sub_sw_list_1(Type, [{Val,_}|T], Ts) ->
 sub_sw_list_1(Type, [], _Ts) ->
     Type.
 
-update_successor(?BADARG_BLOCK, _Ts, #d{}=D) ->
-    %% We KNOW that no variables are used in the ?BADARG_BLOCK,
+update_successor(?EXCEPTION_BLOCK, _Ts, #d{}=D) ->
+    %% We KNOW that no variables are used in the ?EXCEPTION_BLOCK,
     %% so there is no need to update the type information. That
     %% can be a huge timesaver for huge functions.
     D;

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -180,8 +180,9 @@ meet(#t_integer{elements={_,_}}=T, #t_integer{elements=any}) ->
 meet(#t_integer{elements=any}, #t_integer{elements={_,_}}=T) ->
     T;
 meet(#t_integer{elements={MinA,MaxA}}, #t_integer{elements={MinB,MaxB}})
-  when MinA >= MinB, MaxA =< MaxB;
-       MinB >= MinA, MaxB =< MaxA ->
+  when MinA >= MinB, MinA =< MaxB;
+       MinB >= MinA, MinB =< MaxA ->
+    true = MinA =< MaxA andalso MinB =< MaxB,   %Assertion.
     #t_integer{elements={max(MinA, MinB),min(MaxA, MaxB)}};
 meet(#t_integer{}=T, number) -> T;
 meet(float=T, number) -> T;

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -171,6 +171,18 @@ meet(#t_atom{elements=[_|_]}=T, #t_atom{elements=any}) ->
     T;
 meet(#t_atom{elements=any}, #t_atom{elements=[_|_]}=T) ->
     T;
+meet(#t_bs_context{slots=SlotCountA,valid=ValidSlotsA},
+     #t_bs_context{slots=SlotCountB,valid=ValidSlotsB}) ->
+    CommonSlotMask = (1 bsl min(SlotCountA, SlotCountB)) - 1,
+    CommonSlotsA = ValidSlotsA band CommonSlotMask,
+    CommonSlotsB = ValidSlotsB band CommonSlotMask,
+    if
+        CommonSlotsA =:= CommonSlotsB ->
+            #t_bs_context{slots=max(SlotCountA, SlotCountB),
+                          valid=ValidSlotsA bor ValidSlotsB};
+        CommonSlotsA =/= CommonSlotsB ->
+            none
+    end;
 meet(#t_fun{arity=any}, #t_fun{}=T) ->
     T;
 meet(#t_fun{}=T, #t_fun{arity=any}) ->

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -37,8 +37,6 @@
 %%       -- cons         Cons (nonempty list).
 %%       -- nil          The empty list.
 %%    - #t_tuple{}       Tuple.
-%%    - #t_abstract{}    Psuedo-type used in the validator to track tuples
-%                        under construction, match context positions, etc.
 %%
 %%  none                 No type (bottom element).
 
@@ -54,7 +52,6 @@
 -record(t_tuple, {size=0 :: integer(),
                   exact=false :: boolean(),
                   elements=#{} :: tuple_elements()}).
--record(t_abstract, {kind :: atom()}).
 
 %% Known element types, unknown elements are assumed to be 'any'. The key is
 %% a 1-based integer index for tuples, and a plain literal for maps (that is,
@@ -67,6 +64,6 @@
 
 -type type() :: any | none |
                 list | number |
-                #t_atom{} | #t_bitstring{} | #t_bs_context{} | #t_fun{} |
-                #t_integer{} | #t_map{} | #t_tuple{} | #t_abstract{} |
+                #t_atom{} | #t_bitstring{} | #t_bs_context{} |
+                #t_fun{} | #t_integer{} | #t_map{} | #t_tuple{} |
                 'cons' | 'float' | 'nil'.

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -39,6 +39,13 @@
 %%    - #t_tuple{}       Tuple.
 %%
 %%  none                 No type (bottom element).
+%%
+%% We also use #t_union{} to represent conflicting types produced by certain
+%% expressions, e.g. the "#t_atom{} or #t_tuple{}" of lists:keyfind/3, which is
+%% very useful for preserving type information when we would otherwise have
+%% reduced it to 'any'. Since few operations can make direct use of this extra
+%% type information, types should generally be normalized to one of the above
+%% before use.
 
 -define(ATOM_SET_SIZE, 5).
 
@@ -62,8 +69,20 @@
 
 -type elements() :: tuple_elements() | map_elements().
 
--type type() :: any | none |
-                list | number |
-                #t_atom{} | #t_bitstring{} | #t_bs_context{} |
-                #t_fun{} | #t_integer{} | #t_map{} | #t_tuple{} |
-                'cons' | 'float' | 'nil'.
+-type normal_type() :: any | none |
+                       list | number |
+                       #t_atom{} | #t_bitstring{} | #t_bs_context{} |
+                       #t_fun{} | #t_integer{} | #t_map{} | #t_tuple{} |
+                       'cons' | 'float' | 'nil'.
+
+-type record_key() :: {Arity :: integer(), Tag :: normal_type() }.
+-type record_set() :: ordsets:ordset({record_key(), #t_tuple{}}).
+-type tuple_set() :: #t_tuple{} | record_set().
+
+-record(t_union, {atom=none :: none | #t_atom{},
+                  list=none :: none | list | cons | nil,
+                  number=none :: none | number | float | #t_integer{},
+                  tuple_set=none :: none | tuple_set(),
+                  other=none :: normal_type()}).
+
+-type type() :: #t_union{} | normal_type().

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -396,7 +396,7 @@ valfun_1({init,Reg}, Vst) ->
 valfun_1({test_heap,Heap,Live}, Vst) ->
     test_heap(Heap, Live, Vst);
 valfun_1({bif,Op,{f,_},Ss,Dst}=I, Vst) ->
-    case beam_call_types:never_throws(erlang, Op, length(Ss)) of
+    case erl_bifs:is_safe(erlang, Op, length(Ss)) of
         true ->
             %% It can't fail, so we finish handling it here (not updating
             %% catch state).

--- a/lib/compiler/test/beam_types_SUITE.erl
+++ b/lib/compiler/test/beam_types_SUITE.erl
@@ -25,18 +25,30 @@
 -export([all/0, suite/0, groups/0,
          init_per_suite/1, end_per_suite/1]).
 
--export([consistency/1, commutativity/1,
-         binary_consistency/1, integer_consistency/1]).
+-export([absorption/1,
+         associativity/1,
+         commutativity/1,
+         idempotence/1,
+         identity/1]).
+
+-export([binary_absorption/1,
+         integer_absorption/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]}].
 
 all() ->
-    [{group,property_tests}].
+    [{group,property_tests},
+     binary_absorption,
+     integer_absorption].
 
 groups() ->
-    [{property_tests,[], [consistency, commutativity,
-                          binary_consistency, integer_consistency]}].
+    [{property_tests,[parallel],
+      [absorption,
+       associativity,
+       commutativity,
+       idempotence,
+       identity]}].
 
 init_per_suite(Config) ->
     ct_property_test:init_per_suite(Config).
@@ -44,15 +56,27 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     Config.
 
-consistency(Config) when is_list(Config) ->
-    %% manual test: proper:quickcheck(beam_types_prop:consistency()).
-    true = ct_property_test:quickcheck(beam_types_prop:consistency(), Config).
+absorption(Config) when is_list(Config) ->
+    %% manual test: proper:quickcheck(beam_types_prop:absorption()).
+    true = ct_property_test:quickcheck(beam_types_prop:absorption(), Config).
+
+associativity(Config) when is_list(Config) ->
+    %% manual test: proper:quickcheck(beam_types_prop:associativity()).
+    true = ct_property_test:quickcheck(beam_types_prop:associativity(), Config).
 
 commutativity(Config) when is_list(Config) ->
     %% manual test: proper:quickcheck(beam_types_prop:commutativity()).
     true = ct_property_test:quickcheck(beam_types_prop:commutativity(), Config).
 
-binary_consistency(Config) when is_list(Config) ->
+idempotence(Config) when is_list(Config) ->
+    %% manual test: proper:quickcheck(beam_types_prop:idempotence()).
+    true = ct_property_test:quickcheck(beam_types_prop:idempotence(), Config).
+
+identity(Config) when is_list(Config) ->
+    %% manual test: proper:quickcheck(beam_types_prop:identity()).
+    true = ct_property_test:quickcheck(beam_types_prop:identity(), Config).
+
+binary_absorption(Config) when is_list(Config) ->
     %% These binaries should meet into {binary,12} as that's the best common
     %% unit for both types.
     A = #t_bitstring{unit=4},
@@ -66,7 +90,7 @@ binary_consistency(Config) when is_list(Config) ->
 
     ok.
 
-integer_consistency(Config) when is_list(Config) ->
+integer_absorption(Config) when is_list(Config) ->
     %% Integers that don't overlap fully should never meet.
     A = #t_integer{elements={3,5}},
     B = #t_integer{elements={4,6}},
@@ -78,3 +102,4 @@ integer_consistency(Config) when is_list(Config) ->
     A = beam_types:join(A, beam_types:meet(A, B)),
 
     ok.
+

--- a/lib/compiler/test/beam_types_SUITE.erl
+++ b/lib/compiler/test/beam_types_SUITE.erl
@@ -32,7 +32,8 @@
          identity/1]).
 
 -export([binary_absorption/1,
-         integer_absorption/1]).
+         integer_absorption/1,
+         integer_associativity/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]}].
@@ -40,7 +41,8 @@ suite() ->
 all() ->
     [{group,property_tests},
      binary_absorption,
-     integer_absorption].
+     integer_absorption,
+     integer_associativity].
 
 groups() ->
     [{property_tests,[parallel],
@@ -91,15 +93,32 @@ binary_absorption(Config) when is_list(Config) ->
     ok.
 
 integer_absorption(Config) when is_list(Config) ->
-    %% Integers that don't overlap fully should never meet.
-    A = #t_integer{elements={3,5}},
-    B = #t_integer{elements={4,6}},
+    %% Integers that don't overlap at all should never meet.
+    A = #t_integer{elements={2,3}},
+    B = #t_integer{elements={4,5}},
 
     none = beam_types:meet(A, B),
-    #t_integer{elements={3,6}} = beam_types:join(A, B),
+    #t_integer{elements={2,5}} = beam_types:join(A, B),
 
     A = beam_types:meet(A, beam_types:join(A, B)),
     A = beam_types:join(A, beam_types:meet(A, B)),
+
+    ok.
+
+integer_associativity(Config) when is_list(Config) ->
+    A = #t_integer{elements={3,5}},
+    B = #t_integer{elements={4,6}},
+    C = #t_integer{elements={5,5}},
+
+    %% a ∨ (b ∨ c) = (a ∨ b) ∨ c,
+    LHS_Join = beam_types:join(A, beam_types:join(B, C)),
+    RHS_Join = beam_types:join(beam_types:join(A, B), C),
+    #t_integer{elements={3,6}} = LHS_Join = RHS_Join,
+
+    %% a ∧ (b ∧ c) = (a ∧ b) ∧ c.
+    LHS_Meet = beam_types:meet(A, beam_types:meet(B, C)),
+    RHS_Meet = beam_types:meet(beam_types:meet(A, B), C),
+    #t_integer{elements={5,5}} = LHS_Meet = RHS_Meet,
 
     ok.
 

--- a/lib/compiler/test/beam_validator_SUITE.erl
+++ b/lib/compiler/test/beam_validator_SUITE.erl
@@ -520,9 +520,9 @@ bad_tuples(Config) ->
      {{bad_tuples,long,2},
       {{put,{atom,too_long}},8,not_building_a_tuple}},
      {{bad_tuples,self_referential,1},
-      {{put,{x,1}},7,{tuple_in_progress,{x,1}}}},
+      {{put,{x,1}},7,{unfinished_tuple,{x,1}}}},
      {{bad_tuples,short,1},
-      {{move,{x,1},{x,0}},7,{tuple_in_progress,{x,1}}}}] = Errors,
+      {{move,{x,1},{x,0}},7,{unfinished_tuple,{x,1}}}}] = Errors,
 
     ok.
 

--- a/lib/compiler/test/property_test/beam_types_prop.erl
+++ b/lib/compiler/test/property_test/beam_types_prop.erl
@@ -165,8 +165,7 @@ gen_atom() ->
          end).
 
 gen_binary() ->
-    ?SHRINK(#t_bitstring{unit=range(1, 128)},
-            [#t_bitstring{unit=[1, 2, 3, 5, 7, 8, 16, 32, 64]}]).
+    ?SHRINK(#t_bitstring{unit=range(1, 128)}, [#t_bitstring{unit=1}]).
 
 gen_integer() ->
     oneof([gen_integer_bounded(), #t_integer{}]).


### PR DESCRIPTION
While reasonably effective, our current type representation doesn't allow us to express union types such as `atom() | integer()`; they're reduced to their lowest upper bound which turns out to be `term()` more often than not. This is especially annoying for functions following the `{ok, Value} | {error, Reason}` idiom, as they will be flattened down to `{ok | error, term()}` making it next to impossible to propagate types on the happy path.

This PR solves that problem by introducing union types, letting us express types like `{ok, Value} | {error, Reason}` directly, and adds a few minor optimizations to take better advantage of them.

Having better type information uncovered a bunch of crashes when optimizing unreachable code, necessitating the removal of impossible branches (ec35aa9), which in turn required the addition of exception trampolines to prevent known-failing instructions from being optimized out (02c74c8). The latter adds a lot of extra blocks which makes the compiler noticeably slower on large modules (`Elixir.String.Unicode` went from 20s to 40s on my machine), but I'll optimize that in a later PR.