### PR TITLE
Fix syntax error in logger_disk_log_h.xml

### DIFF
--- a/lib/kernel/doc/src/logger_disk_log_h.xml
+++ b/lib/kernel/doc/src/logger_disk_log_h.xml
@@ -133,7 +133,7 @@ logger:add_handler(my_disk_log_h, logger_disk_log_h,
                    #{config => #{file => "./my_disk_log",
                                  type => wrap,
                                  max_no_files => 4,
-                                 max_no_bytes => 10000},
+                                 max_no_bytes => 10000,
                                  filesync_repeat_interval => 1000}}).
     </code>
     <p>To use the disk_log handler instead of the default standard


### PR DESCRIPTION
Fix syntax error in logger_disk_log_h.xml

```erl
logger:add_handler(my_disk_log_h, logger_disk_log_h,
                   #{config => #{file => "./my_disk_log",
                                 type => wrap,
                                 max_no_files => 4,
                                 max_no_bytes => 10000},
                                 filesync_repeat_interval => 1000}}).
```
should be
```erl
logger:add_handler(my_disk_log_h, logger_disk_log_h,
                   #{config => #{file => "./my_disk_log",
                                 type => wrap,
                                 max_no_files => 4,
                                 max_no_bytes => 10000,
                                 filesync_repeat_interval => 1000}}).
```