### PR TITLE
Ensure create_table aborted reason is expected format

### DIFF
--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -2731,7 +2731,7 @@ create_table(Arg) ->
 create_table(Name, Arg) when is_list(Arg) ->
     mnesia_schema:create_table([{name, Name}| Arg]);
 create_table(Name, Arg) ->
-    {aborted, badarg, Name, Arg}.
+    {aborted, {badarg, Name, Arg}}.
 
 -spec delete_table(Tab::table()) -> t_result('ok').
 delete_table(Tab) ->


### PR DESCRIPTION
According to the docs and other `{aborted, _}` return values, the form should be `{aborted, Reason}`, where `Reason` is a single term.

This fix makes `mnesia:create_table/2` consistent with that expectation.

For instance, `mnesia:error_description` would work with this change:

```
Erlang/OTP 22 [erts-10.4.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]

Eshell V10.4.4  (abort with ^G)
1> mnesia:error_description(badarg).
"Bad or invalid argument, possibly bad type"
2> mnesia:error_description({aborted,badarg,foo,bag}).
{aborted,badarg,foo,bag}
3> mnesia:error_description({aborted,{badarg,foo,bag}}).
{"Bad or invalid argument, possibly bad type",foo,bag}
```