### PR TITLE
	Better shell tab completion for modules

### DIFF
--- a/lib/stdlib/src/edlin_expand.erl
+++ b/lib/stdlib/src/edlin_expand.erl
@@ -49,9 +49,9 @@ expand_module_name(Prefix) ->
 expand_function_name(ModStr, FuncPrefix) ->
     case to_atom(ModStr) of
 	{ok, Mod} ->
+		L = Mod:module_info(),
 	    case erlang:module_loaded(Mod) of
 		true ->
-		    L = Mod:module_info(),
 		    case lists:keyfind(exports, 1, L) of
 			{_, Exports} ->
 			    match(FuncPrefix, Exports, "(");


### PR DESCRIPTION
Call `Mod:module_info()` before testing if module is loaded, for interactive mode, so that shell completion work for modules not already loaded.

Before :
```
Eshell V10.4  (abort with ^G)
1> mymodule:<Tab>
```

After : 
```
Eshell V10.4  (abort with ^G)
1> mymodule:<Tab>
module_info/0  module_info/1  myfunction/1 
```