### PR TITLE
fun2ms: accept ++ in function head when called from shell

### DIFF
--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -1100,6 +1100,8 @@ normalise({bin,_,Fs}) ->
     B;
 normalise({cons,_,Head,Tail}) ->
     [normalise(Head)|normalise(Tail)];
+normalise({op,_,'++',A,B}) ->
+    normalise(A) ++ normalise(B);
 normalise({tuple,_,Args}) ->
     list_to_tuple(normalise_list(Args));
 normalise({map,_,Pairs0}) ->

--- a/lib/stdlib/test/ms_transform_SUITE.erl
+++ b/lib/stdlib/test/ms_transform_SUITE.erl
@@ -281,6 +281,8 @@ basic_ets(Config) when is_list(Config) ->
 	compile_and_run(<<"ets:fun2ms(fun({A,B}) -> {B,A} end)">>),
     [{{'$1','$2'},[],[['$2','$1']]}] =
 	compile_and_run(<<"ets:fun2ms(fun({A,B}) -> [B,A] end)">>),
+    [{{"foo" ++ '_','$1'},[],['$1']}] =
+        compile_and_run(<<"ets:fun2ms(fun({\"foo\" ++ _, X}) -> X end)">>),
     ok.
 
 %% Tests basic ets:fun2ms.
@@ -313,6 +315,8 @@ from_shell(Config) when is_list(Config) ->
     [{[a,b],[],[{message,banan},{return_trace}]}] =
 	do_eval(
 	  "dbg:fun2ms(fun([a,b]) -> message(banan), return_trace() end)"),
+    [{{"foo" ++ '_','$1'},[],['$1']}] =
+        do_eval("ets:fun2ms(fun({\"foo\" ++ _, X}) -> X end)"),
     ok.
 
 %% Tests expansion of records in fun2ms.


### PR DESCRIPTION
Code such as `ets:fun2ms(fun({"foo" ++ X}) -> X end)` works fine in
compiled code.  Let's make it work when fun2ms is invoked from the
shell as well.