### PR TITLE
Allow underscores in numeric literals

### DIFF
--- a/lib/stdlib/src/erl_scan.erl
+++ b/lib/stdlib/src/erl_scan.erl
@@ -940,6 +940,8 @@ escape_char(C) -> C.
 
 scan_number([C|Cs], St, Line, Col, Toks, Ncs) when ?DIGIT(C) ->
     scan_number(Cs, St, Line, Col, Toks, [C|Ncs]);
+scan_number([$_|Cs], St, Line, Col, Toks, Ncs) ->
+    scan_number(Cs, St, Line, Col, Toks, Ncs);
 scan_number([$.,C|Cs], St, Line, Col, Toks, Ncs) when ?DIGIT(C) ->
     scan_fraction(Cs, St, Line, Col, Toks, [C,$.|Ncs]);
 scan_number([$.]=Cs, _St, Line, Col, Toks, Ncs) ->
@@ -975,6 +977,8 @@ scan_based_int([C|Cs], St, Line, Col, Toks, {B,Ncs,Bcs})
 scan_based_int([C|Cs], St, Line, Col, Toks, {B,Ncs,Bcs})
     when C >= $a, B > 10, C < $a+B-10 ->
     scan_based_int(Cs, St, Line, Col, Toks, {B,[C|Ncs],Bcs});
+scan_based_int([$_|Cs], St, Line, Col, Toks, {B,Ncs,Bcs}) ->
+    scan_based_int(Cs, St, Line, Col, Toks, {B,Ncs,Bcs});
 scan_based_int([]=Cs, _St, Line, Col, Toks, State) ->
     {more,{Cs,Col,Toks,Line,State,fun scan_based_int/6}};
 scan_based_int(Cs, St, Line, Col, Toks, {B,Ncs0,Bcs}) ->
@@ -990,6 +994,8 @@ scan_based_int(Cs, St, Line, Col, Toks, {B,Ncs0,Bcs}) ->
 
 scan_fraction([C|Cs], St, Line, Col, Toks, Ncs) when ?DIGIT(C) ->
     scan_fraction(Cs, St, Line, Col, Toks, [C|Ncs]);
+scan_fraction([$_|Cs], St, Line, Col, Toks, Ncs) ->
+    scan_fraction(Cs, St, Line, Col, Toks, Ncs);
 scan_fraction([E|Cs], St, Line, Col, Toks, Ncs) when E =:= $e; E =:= $E ->
     scan_exponent_sign(Cs, St, Line, Col, Toks, [E|Ncs]);
 scan_fraction([]=Cs, _St, Line, Col, Toks, Ncs) ->
@@ -1006,6 +1012,8 @@ scan_exponent_sign(Cs, St, Line, Col, Toks, Ncs) ->
 
 scan_exponent([C|Cs], St, Line, Col, Toks, Ncs) when ?DIGIT(C) ->
     scan_exponent(Cs, St, Line, Col, Toks, [C|Ncs]);
+scan_exponent([$_|Cs], St, Line, Col, Toks, Ncs) ->
+    scan_exponent(Cs, St, Line, Col, Toks, Ncs);
 scan_exponent([]=Cs, _St, Line, Col, Toks, Ncs) ->
     {more,{Cs,Col,Toks,Line,Ncs,fun scan_exponent/6}};
 scan_exponent(Cs, St, Line, Col, Toks, Ncs) ->

--- a/lib/stdlib/src/erl_scan.erl
+++ b/lib/stdlib/src/erl_scan.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1996-2017. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2019. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -379,7 +379,7 @@ scan1([$\%|Cs], St, Line, Col, Toks) when not St#erl_scan.comment ->
 scan1([$\%=C|Cs], St, Line, Col, Toks) ->
     scan_comment(Cs, St, Line, Col, Toks, [C]);
 scan1([C|Cs], St, Line, Col, Toks) when ?DIGIT(C) ->
-    scan_number(Cs, St, Line, Col, Toks, [C]);
+    scan_number(Cs, St, Line, Col, Toks, [C], no_underscore);
 scan1("..."++Cs, St, Line, Col, Toks) ->
     tok2(Cs, St, Line, Col, Toks, "...", '...', 3);
 scan1(".."=Cs, _St, Line, Col, Toks) ->
@@ -938,30 +938,33 @@ escape_char($s) -> $\s;                         % \s = SPC
 escape_char($d) -> $\d;                         % \d = DEL
 escape_char(C) -> C.
 
-scan_number([C|Cs], St, Line, Col, Toks, Ncs) when ?DIGIT(C) ->
-    scan_number(Cs, St, Line, Col, Toks, [C|Ncs]);
-scan_number([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs) when
+scan_number(Cs, St, Line, Col, Toks, {Ncs, Us}) ->
+    scan_number(Cs, St, Line, Col, Toks, Ncs, Us).
+
+scan_number([C|Cs], St, Line, Col, Toks, Ncs, Us) when ?DIGIT(C) ->
+    scan_number(Cs, St, Line, Col, Toks, [C|Ncs], Us);
+scan_number([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs, _Us) when
       ?DIGIT(Next) andalso ?DIGIT(Prev) ->
-    scan_number(Cs, St, Line, Col, Toks, [Next,$_|Ncs]);
-scan_number([$.,C|Cs], St, Line, Col, Toks, Ncs) when ?DIGIT(C) ->
-    scan_fraction(Cs, St, Line, Col, Toks, [C,$.|Ncs]);
-scan_number([$.]=Cs, _St, Line, Col, Toks, Ncs) ->
-    {more,{Cs,Col,Toks,Line,Ncs,fun scan_number/6}};
-scan_number([$#|Cs]=Cs0, St, Line, Col, Toks, Ncs0) ->
+    scan_number(Cs, St, Line, Col, Toks, [Next,$_|Ncs], with_underscore);
+scan_number([$.,C|Cs], St, Line, Col, Toks, Ncs, Us) when ?DIGIT(C) ->
+    scan_fraction(Cs, St, Line, Col, Toks, [C,$.|Ncs], Us);
+scan_number([$.]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
+    {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_number/6}};
+scan_number([$#|Cs]=Cs0, St, Line, Col, Toks, Ncs0, Us) ->
     Ncs = lists:reverse(Ncs0),
-    case catch list_to_integer(remove_digit_separators(Ncs)) of
+    case catch list_to_integer(remove_digit_separators(Ncs, Us)) of
         B when B >= 2, B =< 1+$Z-$A+10 ->
             Bcs = Ncs++[$#],
-            scan_based_int(Cs, St, Line, Col, Toks, {B,[],Bcs});
+            scan_based_int(Cs, St, Line, Col, Toks, {B,[],Bcs}, no_underscore);
         B ->
             Len = length(Ncs),
             scan_error({base,B}, Line, Col, Line, incr_column(Col, Len), Cs0)
     end;
-scan_number([]=Cs, _St, Line, Col, Toks, Ncs) ->
-    {more,{Cs,Col,Toks,Line,Ncs,fun scan_number/6}};
-scan_number(Cs, St, Line, Col, Toks, Ncs0) ->
+scan_number([]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
+    {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_number/6}};
+scan_number(Cs, St, Line, Col, Toks, Ncs0, Us) ->
     Ncs = lists:reverse(Ncs0),
-    case catch list_to_integer(remove_digit_separators(Ncs)) of
+    case catch list_to_integer(remove_digit_separators(Ncs, Us)) of
         N when is_integer(N) ->
             tok3(Cs, St, Line, Col, Toks, integer, Ncs, N);
         _ ->
@@ -969,7 +972,9 @@ scan_number(Cs, St, Line, Col, Toks, Ncs0) ->
             scan_error({illegal,integer}, Line, Col, Line, Ncol, Cs)
     end.
 
-remove_digit_separators(Number) ->
+remove_digit_separators(Number, no_underscore) ->
+    Number;
+remove_digit_separators(Number, with_underscore) ->
     [C || C <- Number, C =/= $_].
 
 -define(BASED_DIGIT(C, B),
@@ -977,17 +982,20 @@ remove_digit_separators(Number) ->
          orelse (C >= $A andalso B > 10 andalso C < $A + B - 10)
          orelse (C >= $a andalso B > 10 andalso C < $a + B - 10))).
 
-scan_based_int([C|Cs], St, Line, Col, Toks, {B,Ncs,Bcs}) when
+scan_based_int(Cs, St, Line, Col, Toks, {State,Us}) ->
+    scan_based_int(Cs, St, Line, Col, Toks, State, Us).
+
+scan_based_int([C|Cs], St, Line, Col, Toks, {B,Ncs,Bcs}, Us) when
       ?BASED_DIGIT(C, B) ->
-    scan_based_int(Cs, St, Line, Col, Toks, {B,[C|Ncs],Bcs});
-scan_based_int([$_,Next|Cs], St, Line, Col, Toks, {B,[Prev|_]=Ncs,Bcs}) when
+    scan_based_int(Cs, St, Line, Col, Toks, {B,[C|Ncs],Bcs}, Us);
+scan_based_int([$_,Next|Cs], St, Line, Col, Toks, {B,[Prev|_]=Ncs,Bcs}, _Us) when
       ?BASED_DIGIT(Next, B) andalso ?BASED_DIGIT(Prev, B) ->
-    scan_based_int(Cs, St, Line, Col, Toks, {B,[Next,$_|Ncs],Bcs});
-scan_based_int([]=Cs, _St, Line, Col, Toks, State) ->
-    {more,{Cs,Col,Toks,Line,State,fun scan_based_int/6}};
-scan_based_int(Cs, St, Line, Col, Toks, {B,Ncs0,Bcs}) ->
+    scan_based_int(Cs, St, Line, Col, Toks, {B,[Next,$_|Ncs],Bcs}, with_underscore);
+scan_based_int([]=Cs, _St, Line, Col, Toks, State, Us) ->
+    {more,{Cs,Col,Toks,Line,{State,Us},fun scan_based_int/6}};
+scan_based_int(Cs, St, Line, Col, Toks, {B,Ncs0,Bcs}, Us) ->
     Ncs = lists:reverse(Ncs0),
-    case catch erlang:list_to_integer(remove_digit_separators(Ncs), B) of
+    case catch erlang:list_to_integer(remove_digit_separators(Ncs, Us), B) of
         N when is_integer(N) ->
             tok3(Cs, St, Line, Col, Toks, integer, Bcs++Ncs, N);
         _ ->
@@ -996,38 +1004,48 @@ scan_based_int(Cs, St, Line, Col, Toks, {B,Ncs0,Bcs}) ->
             scan_error({illegal,integer}, Line, Col, Line, Ncol, Cs)
     end.
 
-scan_fraction([C|Cs], St, Line, Col, Toks, Ncs) when ?DIGIT(C) ->
-    scan_fraction(Cs, St, Line, Col, Toks, [C|Ncs]);
-scan_fraction([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs) when
+scan_fraction(Cs, St, Line, Col, Toks, {Ncs,Us}) ->
+    scan_fraction(Cs, St, Line, Col, Toks, Ncs, Us).
+
+scan_fraction([C|Cs], St, Line, Col, Toks, Ncs, Us) when ?DIGIT(C) ->
+    scan_fraction(Cs, St, Line, Col, Toks, [C|Ncs], Us);
+scan_fraction([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs, _Us) when
       ?DIGIT(Next) andalso ?DIGIT(Prev) ->
-    scan_fraction(Cs, St, Line, Col, Toks, [Next,$_|Ncs]);
-scan_fraction([E|Cs], St, Line, Col, Toks, Ncs) when E =:= $e; E =:= $E ->
-    scan_exponent_sign(Cs, St, Line, Col, Toks, [E|Ncs]);
-scan_fraction([]=Cs, _St, Line, Col, Toks, Ncs) ->
-    {more,{Cs,Col,Toks,Line,Ncs,fun scan_fraction/6}};
-scan_fraction(Cs, St, Line, Col, Toks, Ncs) ->
-    float_end(Cs, St, Line, Col, Toks, Ncs).
+    scan_fraction(Cs, St, Line, Col, Toks, [Next,$_|Ncs], with_underscore);
+scan_fraction([E|Cs], St, Line, Col, Toks, Ncs, Us) when E =:= $e; E =:= $E ->
+    scan_exponent_sign(Cs, St, Line, Col, Toks, [E|Ncs], Us);
+scan_fraction([]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
+    {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_fraction/6}};
+scan_fraction(Cs, St, Line, Col, Toks, Ncs, Us) ->
+    float_end(Cs, St, Line, Col, Toks, Ncs, Us).
 
-scan_exponent_sign([C|Cs], St, Line, Col, Toks, Ncs) when C =:= $+; C =:= $- ->
-    scan_exponent(Cs, St, Line, Col, Toks, [C|Ncs]);
-scan_exponent_sign([]=Cs, _St, Line, Col, Toks, Ncs) ->
-    {more,{Cs,Col,Toks,Line,Ncs,fun scan_exponent_sign/6}};
-scan_exponent_sign(Cs, St, Line, Col, Toks, Ncs) ->
-    scan_exponent(Cs, St, Line, Col, Toks, Ncs).
+scan_exponent_sign(Cs, St, Line, Col, Toks, {Ncs, Us}) ->
+    scan_exponent_sign(Cs, St, Line, Col, Toks, Ncs, Us).
 
-scan_exponent([C|Cs], St, Line, Col, Toks, Ncs) when ?DIGIT(C) ->
-    scan_exponent(Cs, St, Line, Col, Toks, [C|Ncs]);
-scan_exponent([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs) when
+scan_exponent_sign([C|Cs], St, Line, Col, Toks, Ncs, Us) when
+      C =:= $+; C =:= $- ->
+    scan_exponent(Cs, St, Line, Col, Toks, [C|Ncs], Us);
+scan_exponent_sign([]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
+    {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_exponent_sign/6}};
+scan_exponent_sign(Cs, St, Line, Col, Toks, Ncs, Us) ->
+    scan_exponent(Cs, St, Line, Col, Toks, Ncs, Us).
+
+scan_exponent(Cs, St, Line, Col, Toks, {Ncs, Us}) ->
+    scan_exponent(Cs, St, Line, Col, Toks, Ncs, Us).
+
+scan_exponent([C|Cs], St, Line, Col, Toks, Ncs, Us) when ?DIGIT(C) ->
+    scan_exponent(Cs, St, Line, Col, Toks, [C|Ncs], Us);
+scan_exponent([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs, _) when
       ?DIGIT(Next) andalso ?DIGIT(Prev) ->
-    scan_exponent(Cs, St, Line, Col, Toks, [Next,$_|Ncs]);
-scan_exponent([]=Cs, _St, Line, Col, Toks, Ncs) ->
-    {more,{Cs,Col,Toks,Line,Ncs,fun scan_exponent/6}};
-scan_exponent(Cs, St, Line, Col, Toks, Ncs) ->
-    float_end(Cs, St, Line, Col, Toks, Ncs).
+    scan_exponent(Cs, St, Line, Col, Toks, [Next,$_|Ncs], with_underscore);
+scan_exponent([]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
+    {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_exponent/6}};
+scan_exponent(Cs, St, Line, Col, Toks, Ncs, Us) ->
+    float_end(Cs, St, Line, Col, Toks, Ncs, Us).
 
-float_end(Cs, St, Line, Col, Toks, Ncs0) ->
+float_end(Cs, St, Line, Col, Toks, Ncs0, Us) ->
     Ncs = lists:reverse(Ncs0),
-    case catch list_to_float(remove_digit_separators(Ncs)) of
+    case catch list_to_float(remove_digit_separators(Ncs, Us)) of
         F when is_float(F) ->
             tok3(Cs, St, Line, Col, Toks, float, Ncs, F);
         _ ->

--- a/lib/stdlib/src/erl_scan.erl
+++ b/lib/stdlib/src/erl_scan.erl
@@ -946,6 +946,8 @@ scan_number([C|Cs], St, Line, Col, Toks, Ncs, Us) when ?DIGIT(C) ->
 scan_number([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs, _Us) when
       ?DIGIT(Next) andalso ?DIGIT(Prev) ->
     scan_number(Cs, St, Line, Col, Toks, [Next,$_|Ncs], with_underscore);
+scan_number([$_]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
+    {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_number/6}};
 scan_number([$.,C|Cs], St, Line, Col, Toks, Ncs, Us) when ?DIGIT(C) ->
     scan_fraction(Cs, St, Line, Col, Toks, [C,$.|Ncs], Us);
 scan_number([$.]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
@@ -992,6 +994,8 @@ scan_based_int([$_,Next|Cs], St, Line, Col, Toks, B, [Prev|_]=Ncs, Bcs, _Us)
       when ?BASED_DIGIT(Next, B) andalso ?BASED_DIGIT(Prev, B) ->
     scan_based_int(Cs, St, Line, Col, Toks, B, [Next,$_|Ncs], Bcs,
                    with_underscore);
+scan_based_int([$_]=Cs, _St, Line, Col, Toks, B, NCs, BCs, Us) ->
+    {more,{Cs,Col,Toks,Line,{B,NCs,BCs,Us},fun scan_based_int/6}};
 scan_based_int([]=Cs, _St, Line, Col, Toks, B, NCs, BCs, Us) ->
     {more,{Cs,Col,Toks,Line,{B,NCs,BCs,Us},fun scan_based_int/6}};
 scan_based_int(Cs, St, Line, Col, Toks, B, Ncs0, Bcs, Us) ->
@@ -1013,6 +1017,8 @@ scan_fraction([C|Cs], St, Line, Col, Toks, Ncs, Us) when ?DIGIT(C) ->
 scan_fraction([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs, _Us) when
       ?DIGIT(Next) andalso ?DIGIT(Prev) ->
     scan_fraction(Cs, St, Line, Col, Toks, [Next,$_|Ncs], with_underscore);
+scan_fraction([$_]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
+    {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_fraction/6}};
 scan_fraction([E|Cs], St, Line, Col, Toks, Ncs, Us) when E =:= $e; E =:= $E ->
     scan_exponent_sign(Cs, St, Line, Col, Toks, [E|Ncs], Us);
 scan_fraction([]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
@@ -1039,6 +1045,8 @@ scan_exponent([C|Cs], St, Line, Col, Toks, Ncs, Us) when ?DIGIT(C) ->
 scan_exponent([$_,Next|Cs], St, Line, Col, Toks, [Prev|_]=Ncs, _) when
       ?DIGIT(Next) andalso ?DIGIT(Prev) ->
     scan_exponent(Cs, St, Line, Col, Toks, [Next,$_|Ncs], with_underscore);
+scan_exponent([$_]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
+    {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_exponent/6}};
 scan_exponent([]=Cs, _St, Line, Col, Toks, Ncs, Us) ->
     {more,{Cs,Col,Toks,Line,{Ncs,Us},fun scan_exponent/6}};
 scan_exponent(Cs, St, Line, Col, Toks, Ncs, Us) ->

--- a/lib/stdlib/test/erl_scan_SUITE.erl
+++ b/lib/stdlib/test/erl_scan_SUITE.erl
@@ -300,6 +300,30 @@ integers() ->
          Ts = [{integer,{1,1},I}],
          test_string(S, Ts)
      end || S <- [[N] || N <- lists:seq($0, $9)] ++ ["2323","000"] ],
+    UnderscoreSamples =
+        [{"123_456", 123456},
+         {"123_456_789", 123456789},
+         {"1_2", 12}],
+    lists:foreach(
+         fun({S, I}) ->
+                 {ok, [{integer, 1, I}], _} = erl_scan_string(S)
+         end, UnderscoreSamples),
+    UnderscoreErrors =
+        ["123_",
+         "123__",
+         "123_456_",
+         "123__456",
+         "_123",
+         "__123"],
+    lists:foreach(
+      fun(S) ->
+              case erl_scan:string(S) of
+                  {ok, [{integer, _, _}], _} ->
+                      error({unexpected_integer, S});
+                  _ ->
+                      ok
+              end
+      end, UnderscoreErrors),
     ok.
 
 base_integers() ->
@@ -329,6 +353,34 @@ base_integers() ->
     {ok,[{integer,{1,1},14},{atom,{1,5},g@}],{1,7}} =
         erl_scan_string("16#eg@", {1,1}, []),
 
+    UnderscoreSamples =
+        [{"16#1234_ABCD_EF56", 16#1234abcdef56},
+         {"2#0011_0101_0011", 2#001101010011},
+         {"1_6#123ABC", 16#123abc},
+         {"1_6#123_ABC", 16#123abc},
+         {"16#abcdef", 16#ABCDEF}],
+    lists:foreach(
+         fun({S, I}) ->
+                 {ok, [{integer, 1, I}], _} = erl_scan_string(S)
+         end, UnderscoreSamples),
+    UnderscoreErrors =
+        ["16_#123ABC",
+         "16#123_",
+         "16#_123",
+         "16#ABC_",
+         "16#_ABC",
+         "2#_0101",
+         "1__6#ABC",
+         "16#AB__CD"],
+    lists:foreach(
+      fun(S) ->
+              case erl_scan:string(S) of
+                  {ok, [{integer, _, _}], _} ->
+                      error({unexpected_integer, S});
+                  _ ->
+                      ok
+              end
+      end, UnderscoreErrors),
     ok.
 
 floats() ->
@@ -350,6 +402,34 @@ floats() ->
              erl_scan:string(S, {1,1}, [])
      end || S <- ["1.14Ea"]],
 
+    UnderscoreSamples =
+        [{"123_456.789", 123456.789},
+         {"123.456_789", 123.456789},
+         {"1.2_345e10", 1.2345e10},
+         {"1.234e1_06", 1.234e106},
+         {"12_34.56_78e1_6", 1234.5678e16},
+         {"12_34.56_78e-1_8", 1234.5678e-18}],
+    lists:foreach(
+         fun({S, I}) ->
+                 {ok, [{float, 1, I}], _} = erl_scan_string(S)
+         end, UnderscoreSamples),
+    UnderscoreErrors =
+        ["123_.456",
+         "123._456",
+         "123.456_",
+         "123._",
+         "1._23e10",
+         "1.23e_10",
+         "1.23e10_"],
+    lists:foreach(
+      fun(S) ->
+              case erl_scan:string(S) of
+                  {ok, [{float, _, _}], _} ->
+                      error({unexpected_float, S});
+                  _ ->
+                      ok
+              end
+      end, UnderscoreErrors),
     ok.
 
 dots() ->

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -1224,8 +1224,8 @@ This must be placed in front of `erlang-font-lock-keywords-vars'.")
          1 'font-lock-type-face)
    ;; Don't highlight numerical constants.
    (list (if erlang-regexp-modern-p
-             "\\_<[0-9]+#\\([0-9a-zA-Z]+\\)"
-           "\\<[0-9]+#\\([0-9a-zA-Z]+\\)")
+             "\\_<\\([0-9]+\\(_[0-9]+\\)*#[0-9a-zA-Z]+\\(_[0-9a-zA-Z]+\\)*\\)"
+              "\\<\\([0-9]+\\(_[0-9]+\\)*#[0-9a-zA-Z]+\\(_[0-9a-zA-Z]+\\)*\\)")
          1 nil t)
    (list (concat "^-record\\s-*(\\s-*" erlang-atom-regexp)
          1 'font-lock-type-face))

--- a/system/doc/reference_manual/data_types.xml
+++ b/system/doc/reference_manual/data_types.xml
@@ -52,24 +52,33 @@
        Integer with the base <em><c>base</c></em>, that must be an
        integer in the range 2..36.</item>
     </list>
+    <p>Leading zeroes are ignored. Single underscore <c>_</c> can be inserted
+    between digits as a visual separator.</p>
     <p><em>Examples:</em></p>
     <pre>
 1> <input>42.</input>
 42
-2> <input>$A.</input>
+2> <input>-1_234_567_890.</input>
+-1234567890
+3> <input>$A.</input>
 65
-3> <input>$\n.</input>
+4> <input>$\n.</input>
 10
-4> <input>2#101.</input>
+5> <input>2#101.</input>
 5
-5> <input>16#1f.</input>
+6> <input>16#1f.</input>
 31
-6> <input>2.3.</input>
+7> <input>16#4865_316F_774F_6C64.</input>
+5216630098191412324
+8> <input>2.3.</input>
 2.3
-7> <input>2.3e3.</input>
+9> <input>2.3e3.</input>
 2.3e3
-8> <input>2.3e-3.</input>
-0.0023</pre>
+10> <input>2.3e-3.</input>
+0.0023
+11> <input>1_234.333_333</input>
+1234.333333
+</pre>
   </section>
 
   <section>


### PR DESCRIPTION
Just draft to get some feedback. Can update docs, erlang-mode.el and tests if we are ok to proceed.

This is to make long numeric literals more readable. The idea is [borrowed from Rust language](https://doc.rust-lang.org/rust-by-example/primitives/literals.html) ([rust spec](https://doc.rust-lang.org/reference/tokens.html#numbers))

Examples:
* `123_456_789` vs `123456789`
* `123_456.789_123` vs `123456.789123`
* `16#123_ABC` vs `16#123ABC`
* `2#1100_0011_0101` vs `2#110000110101`

<del>One minor problem with current implementation is that `erl_scan:string("123_456", text)` will return `{integer,[{text,"123456"},<..>],123456}` - so, text will be "123456" and not original "123_456", but this can be fixed, if it's important.</del>