### PR TITLE
Fix documentation for erlang:is_map_key/2

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2553,6 +2553,7 @@ os_prompt%</pre>
 true
 > is_map_key(value,Map).
 false</code>
+        <p>Allowed in guard tests.</p>
       </desc>
     </func>
 


### PR DESCRIPTION
This function is allowed to be used in guards.