### PR TITLE
Add ed25519 & ed448 support to crypto:generate_key

### DIFF
--- a/lib/crypto/c_src/atoms.c
+++ b/lib/crypto/c_src/atoms.c
@@ -89,6 +89,8 @@ ERL_NIF_TERM atom_ecdsa;
 #ifdef HAVE_ED_CURVE_DH
 ERL_NIF_TERM atom_x25519;
 ERL_NIF_TERM atom_x448;
+ERL_NIF_TERM atom_ed25519;
+ERL_NIF_TERM atom_ed448;
 #endif
 
 ERL_NIF_TERM atom_eddsa;
@@ -219,6 +221,8 @@ int init_atoms(ErlNifEnv *env, const ERL_NIF_TERM fips_mode, const ERL_NIF_TERM 
 #ifdef HAVE_ED_CURVE_DH
     atom_x25519 = enif_make_atom(env,"x25519");
     atom_x448 = enif_make_atom(env,"x448");
+    atom_ed25519 = enif_make_atom(env,"ed25519");
+    atom_ed448 = enif_make_atom(env,"ed448");
 #endif
     atom_eddsa = enif_make_atom(env,"eddsa");
 #ifdef HAVE_EDDSA

--- a/lib/crypto/c_src/atoms.h
+++ b/lib/crypto/c_src/atoms.h
@@ -93,6 +93,8 @@ extern ERL_NIF_TERM atom_ecdsa;
 #ifdef HAVE_ED_CURVE_DH
 extern ERL_NIF_TERM atom_x25519;
 extern ERL_NIF_TERM atom_x448;
+extern ERL_NIF_TERM atom_ed25519;
+extern ERL_NIF_TERM atom_ed448;
 #endif
 
 extern ERL_NIF_TERM atom_eddsa;

--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -95,7 +95,7 @@ static ErlNifFunc nif_funcs[] = {
     {"dh_generate_key_nif", 4, dh_generate_key_nif, 0},
     {"dh_compute_key_nif", 3, dh_compute_key_nif, 0},
     {"evp_compute_key_nif", 3, evp_compute_key_nif, 0},
-    {"evp_generate_key_nif", 1, evp_generate_key_nif, 0},
+    {"evp_generate_key_nif", 2, evp_generate_key_nif, 0},
     {"privkey_to_pubkey_nif", 2, privkey_to_pubkey_nif, 0},
     {"srp_value_B_nif", 5, srp_value_B_nif, 0},
     {"srp_user_secret_nif", 7, srp_user_secret_nif, 0},

--- a/lib/crypto/c_src/evp.c
+++ b/lib/crypto/c_src/evp.c
@@ -106,25 +106,34 @@ ERL_NIF_TERM evp_generate_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
     EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY *pkey = NULL;
     ERL_NIF_TERM ret_pub, ret_prv, ret;
+    ErlNifBinary prv_key;
     size_t key_len;
     unsigned char *out_pub = NULL, *out_priv = NULL;
-
-    ASSERT(argc == 1);
 
     if (argv[0] == atom_x25519)
         type = EVP_PKEY_X25519;
     else if (argv[0] == atom_x448)
         type = EVP_PKEY_X448;
+    else if (argv[0] == atom_ed25519)
+        type = EVP_PKEY_ED25519;
+    else if (argv[0] == atom_ed448)
+        type = EVP_PKEY_ED448;
     else
         goto bad_arg;
 
-    if ((ctx = EVP_PKEY_CTX_new_id(type, NULL)) == NULL)
-        goto bad_arg;
-
-    if (EVP_PKEY_keygen_init(ctx) != 1)
-        goto err;
-    if (EVP_PKEY_keygen(ctx, &pkey) != 1)
-        goto err;
+    if (argv[1] == atom_undefined) {
+        if ((ctx = EVP_PKEY_CTX_new_id(type, NULL)) == NULL)
+            goto bad_arg;
+        if (EVP_PKEY_keygen_init(ctx) != 1)
+            goto bad_arg;
+        if (EVP_PKEY_keygen(ctx, &pkey) != 1)
+            goto bad_arg;
+    } else {
+        if (!enif_inspect_binary(env, argv[1], &prv_key))
+            goto bad_arg;
+        if ((pkey = EVP_PKEY_new_raw_private_key(type, NULL, prv_key.data, prv_key.size)) == NULL)
+            goto bad_arg;
+    }
 
     if (EVP_PKEY_get_raw_public_key(pkey, NULL, &key_len) != 1)
         goto err;

--- a/lib/crypto/c_src/evp.c
+++ b/lib/crypto/c_src/evp.c
@@ -125,9 +125,9 @@ ERL_NIF_TERM evp_generate_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
         if ((ctx = EVP_PKEY_CTX_new_id(type, NULL)) == NULL)
             goto bad_arg;
         if (EVP_PKEY_keygen_init(ctx) != 1)
-            goto bad_arg;
+            goto err;
         if (EVP_PKEY_keygen(ctx, &pkey) != 1)
-            goto bad_arg;
+            goto err;
     } else {
         if (!enif_inspect_binary(env, argv[1], &prv_key))
             goto bad_arg;

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -1865,7 +1865,7 @@ group_config(srp, Config) ->
     [{generate_compute, GenerateCompute} | Config];
 group_config(ecdh, Config) ->
     Compute = ecdh(),
-    Generate = ecc() ++ ecc(x25519) ++ ecc(x448),
+    Generate = ecc(),
     [{compute, Compute}, {generate, Generate} | Config];
 group_config(dh, Config) ->
     GenerateCompute = [dh()],
@@ -3922,35 +3922,29 @@ ecc() ->
                        "782C37E372BA4520AA62E0FED121D49EF3B543660CFD05FD")},
          {ecdh,secp192r1,4,
           hexstr2point("35433907297CC378B0015703374729D7A4FE46647084E4BA",
-                       "A2649984F2135C301EA3ACB0776CD4F125389B311DB3BE32")}],
+                       "A2649984F2135C301EA3ACB0776CD4F125389B311DB3BE32")},
+         %% RFC 7748, 6.2
+         {ecdh, x448,
+          hexstr2bin("9a8f4925d1519f5775cf46b04b5800d4ee9ee8bae8bc5565d498c28d"
+                     "d9c9baf574a9419744897391006382a6f127ab1d9ac2d8c0a598726b"),
+          hexstr2bin("9b08f7cc31b7e3e67d22d5aea121074a273bd2b83de09c63faa73d2c"
+                     "22c5d9bbc836647241d953d40c5b12da88120d53177f80e532c41fa0")},
+         {ecdh, x448,
+          hexstr2bin("1c306a7ac2a0e2e0990b294470cba339e6453772b075811d8fad0d1d"
+                     "6927c120bb5ee8972b0d3e21374c9c921b09d1b0366f10b65173992d"),
+          hexstr2bin("3eb7a829b0cd20f5bcfc0b599b6feccf6da4627107bdb0d4f345b430"
+                     "27d8b972fc3e34fb4232a13ca706dcb57aec3dae07bdc1c67bf33609")},
+         %% RFC 7748, 6.1
+         {ecdh, x25519,
+          hexstr2bin("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"),
+          hexstr2bin("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a")},
+         {ecdh, x25519,
+          hexstr2bin("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"),
+          hexstr2bin("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f")}],
     lists:filter(fun ({_Type, Curve, _Priv, _Pub}) ->
                          lists:member(Curve, Curves)
                  end,
                  TestCases).
-
-ecc(x25519) ->
-    %% RFC 7748, 6.1
-    [{ecdh, x25519,
-      hexstr2bin("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"),
-      hexstr2bin("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a")},
-     {ecdh, x25519,
-      hexstr2bin("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"),
-      hexstr2bin("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f")}
-    ];
-
-ecc(x448) ->
-    %% RFC 7748, 6.2
-    [{ecdh, x448,
-      hexstr2bin("9a8f4925d1519f5775cf46b04b5800d4ee9ee8bae8bc5565d498c28d"
-                 "d9c9baf574a9419744897391006382a6f127ab1d9ac2d8c0a598726b"),
-      hexstr2bin("9b08f7cc31b7e3e67d22d5aea121074a273bd2b83de09c63faa73d2c"
-                 "22c5d9bbc836647241d953d40c5b12da88120d53177f80e532c41fa0")},
-     {ecdh, x448,
-      hexstr2bin("1c306a7ac2a0e2e0990b294470cba339e6453772b075811d8fad0d1d"
-                 "6927c120bb5ee8972b0d3e21374c9c921b09d1b0366f10b65173992d"),
-      hexstr2bin("3eb7a829b0cd20f5bcfc0b599b6feccf6da4627107bdb0d4f345b430"
-                 "27d8b972fc3e34fb4232a13ca706dcb57aec3dae07bdc1c67bf33609")}
-    ].
 
 
 int_to_bin(X) when X < 0 -> int_to_bin_neg(X, []);


### PR DESCRIPTION
This pull request adds `ed25519` & `ed448` curve support to `crypto:generate_key/2` & `/3`.

It adds them under the `eddsa` Type:
```erlang
1> {Pub, Priv} = crypto:generate_key(eddsa, ed25519).
{<<1,...>>, <<2,...>>}
2> {Pub, Priv} = crypto:generate_key(eddsa, ed25519, Priv).
{<<1,...>>, <<2,...>>}
```

It also fixes a [bug](https://bugs.erlang.org/browse/ERL-1008) where `x25519` key generation fails for `crypto:generate_key/3`:
```erlang
1> {Pub, Priv} = crypto:generate_key(ecdh, x25519).
{<<3,...>>, <<4,...>>}
2> {Pub, Priv} = crypto:generate_key(ecdh, x25519, Priv).
{<<3,...>>, <<4,...>>}
```