### PR TITLE
Correct documentation on dump_log_write_threshold default value

### DIFF
--- a/lib/mnesia/doc/src/Mnesia_chap7.xmlsrc
+++ b/lib/mnesia/doc/src/Mnesia_chap7.xmlsrc
@@ -295,7 +295,7 @@ ok</pre>
         if the log is large. Notice that the <c>Mnesia</c> system
         continues to operate during log dumps.</p>
       <p>By default <c>Mnesia</c> either dumps the log whenever
-        100 records have
+        1000 records have
         been written in the log or when three minutes have passed.
         This is controlled by the two application parameters
         <c>-mnesia dump_log_write_threshold WriteOperations</c> and


### PR DESCRIPTION
I see in OTP 20 & 21 in the eshell:

```erl
Eshell V10.0  (abort with ^G)
1> mnesia:system_info(dump_log_write_threshold).
1000
```

But the documentation says that the default log wirte threshold is 100.

Looks like a missing `0`!