### PR TITLE
erts: Do not use named no_cpuid label in asm

### DIFF
--- a/erts/lib_src/pthread/ethread.c
+++ b/erts/lib_src/pthread/ethread.c
@@ -208,9 +208,9 @@ ethr_x86_cpuid__(int *eax, int *ebx, int *ecx, int *edx)
              "popl %%eax\n\t"
              "movl $0x0, %0\n\t"
              "xorl %%ecx, %%eax\n\t"
-             "jz no_cpuid\n\t"
+             "jz 1f\n\t"
 	     "movl $0x1, %0\n\t"
-             "no_cpuid:\n\t"
+             "1:\n\t"
              : "=r"(have_cpuid)
              :
              : "%eax", "%ecx", "cc");


### PR DESCRIPTION
Ask compiler to generate unique label name. Using named label has implications
on optimizer, that may lead to the compilation errors as the following:

    pthread/ethread.c: Assembler messages:
    pthread/ethread.c:213: Error: symbol `no_cpuid' is already defined
    pthread/ethread.c:213: Error: symbol `no_cpuid' is already defined
    pthread/ethread.c:213: Error: symbol `no_cpuid' is already defined

Please, note, that I faced this build issue in a wild when tried to build Erlang for i686 platform using gcc 9.1.0 with LTO enabled. I suppose that LTO decided to inline function ethr_x86_cpuid__() in the other compilation unit.