### PR TITLE
Ensure that the stack slots are initialized when matching maps

### DIFF
--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -1068,8 +1068,11 @@ verify_get_map(Fail, Src, List, Vst0) ->
 %%    {get_map_elements,{f,7},{x,1},{list,[{atom,a},{x,1},{atom,b},{x,2}]}}.
 %%
 %% If 'a' exists but not 'b', {x,1} is overwritten when we jump to {f,7}.
+%%
+%% We must be careful to preserve the uninitialized status for Y registers
+%% that have been allocated but not yet defined.
 clobber_map_vals([Key,Dst|T], Map, Vst0) ->
-    case is_reg_defined(Dst, Vst0) of
+    case is_reg_initialized(Dst, Vst0) of
         true ->
             Vst = extract_term(term, {bif,map_get}, [Key, Map], Dst, Vst0),
             clobber_map_vals(T, Map, Vst);
@@ -1078,6 +1081,17 @@ clobber_map_vals([Key,Dst|T], Map, Vst0) ->
     end;
 clobber_map_vals([], _Map, Vst) ->
     Vst.
+
+is_reg_initialized({x,_}=Reg, #vst{current=#st{xs=Xs}}) ->
+    is_map_key(Reg, Xs);
+is_reg_initialized({y,_}=Reg, #vst{current=#st{ys=Ys}}) ->
+    case Ys of
+        #{Reg:=Val} ->
+            Val =/= uninitialized;
+        #{} ->
+            false
+    end;
+is_reg_initialized(V, #vst{}) -> error({not_a_register, V}).
 
 extract_map_keys([Key,_Val|T]) ->
     [Key|extract_map_keys(T)];
@@ -1884,10 +1898,6 @@ check_try_catch_tags(Type, {y,N}=Reg, Vst) ->
         false ->
             ok
     end.
-
-is_reg_defined({x,_}=Reg, #vst{current=#st{xs=Xs}}) -> is_map_key(Reg, Xs);
-is_reg_defined({y,_}=Reg, #vst{current=#st{ys=Ys}}) -> is_map_key(Reg, Ys);
-is_reg_defined(V, #vst{}) -> error({not_a_register, V}).
 
 assert_term(Src, Vst) ->
     _ = get_term_type(Src, Vst),


### PR DESCRIPTION
When matching a map, the compiler could fail to generate code that
would initialize all stack slots (Y registers) properly. Here is a
general outline of code that *could* cause this problem:

    foo(Key, Map) ->
         Res = case Map of
                  #{Key := Val} ->
                      %% Do something with Val here.
		        .
			.
			.
                  #{} ->
		      []
              end,
	%% The stack slot for Val might not have been initialized
	%% here if the key was not present in the map.
	.
	.
	.
	%% Use Res.
	.
	.
	.

The code generator would wrongly assume that the map matching would
always initialize the stack slot, and if nothing else happened to
force that stack slot to be initialized, it would remain
uninitialized, which would likely crash the runtime system at the next
garbage collection.

`beam_validator` is supposed to find these kind of problems, but a bug
in `beam_validator` prevented it from detecting this problem.

https://bugs.erlang.org/browse/ERL-1017