### PR TITLE
Fix sscanf to use %llu instead of gnu specific %Lu

### DIFF
--- a/lib/os_mon/c_src/cpu_sup.c
+++ b/lib/os_mon/c_src/cpu_sup.c
@@ -359,7 +359,7 @@ static cpu_t *read_procstat(FILE *fp, cpu_t *cpu) {
 	memset(cpu, 0, sizeof(cpu_t));
 	return cpu;
     }
-    sscanf(buffer, "cpu%u %Lu %Lu %Lu %Lu %Lu %Lu %Lu %Lu",
+    sscanf(buffer, "cpu%u %llu %llu %llu %llu %llu %llu %llu %llu",
 	&(cpu->id),
 	&(cpu->user),
 	&(cpu->nice_user),


### PR DESCRIPTION
For instance, musl does not recognize the %L modifier.

See https://bugs.erlang.org/browse/ERL-1012