### PR TITLE
Check only #k_var{} when checking for var clauses

### DIFF
--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -2166,7 +2166,11 @@ clause_con(C) -> arg_con(clause_arg(C)).
 
 clause_val(C) -> arg_val(clause_arg(C), C).
 
-is_var_clause(C) -> clause_con(C) =:= k_var.
+is_var_clause(C) ->
+    case arg_arg(clause_arg(C)) of
+        #k_var{} -> true;
+        _ -> false
+    end.
 
 %% arg_arg(Arg) -> Arg.
 %% arg_alias(Arg) -> Aliases.


### PR DESCRIPTION
This patch makes v3_kernel roughly 15% faster when
compiling functions with many binary clauses.

The speed up is achieved by only matching on the
record we care about, instead of all possible ones.
Although the new code is less strict, checking of
all possible clauses happens in other occasions.