### PR TITLE
Update types of which_sessions

### DIFF
--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -702,8 +702,8 @@
 	<v>Profile = profile() | pid()</v>
 	<d>When started <c>stand_alone</c> only the pid can be used.</d>
 	<v>session_info() = {GoodSessions, BadSessions, NonSessions}</v>
-	<v>GoodSessions = session()</v>
-	<v>BadSessions = tuple()</v>
+	<v>GoodSessions = [session()]</v>
+	<v>BadSessions = [tuple()]</v>
 	<v>NonSessions = term()</v>
       </type>
       <desc>


### PR DESCRIPTION
I don't think the previous types make sense in OTP 19.

When I open an erlang shell and (with a live session) run `which_sessions`:

```
(srvr@home)429> httpc:which_sessions(proxy).
{[{session,{{"remote_host",10001},
            <0.12529.112>},
           false,https,
           #sslsocket{fd = {gen_tcp,#Port<0.85648>,tls_connection,
                                    undefined},
                      pid = <0.12642.112>},
           {essl,[{cert,<<48,130,2,223,48,130,1,199,160,3,2,1,2,2,8,
                          104,...>>},
                  {key,{'RSAPrivateKey',<<48,130,4,164,2,1,0,2,130,1,1,
                                          0,186,...>>}}]},
           2,keep_alive,true}],
 [],[]}
```

To format this a little...

```erl
{
    [
        {
            session,
            {{"remote_host",10001},<0.12529.112>},
            false,
            https,
            #sslsocket{fd = {gen_tcp,#Port<0.85648>,tls_connection,undefined},pid = <0.12642.112>},
            {
                essl,
                [
                    {cert,<<48,130,2,223,48,130,1,199,160,3,2,1,2,2,8,104,...>>},
                    {key,{'RSAPrivateKey',<<48,130,4,164,2,1,0,2,130,1,1,0,186,...>>}}
                ]
            },
            2,
            keep_alive,
            true
        }
    ],
    [],
    []
}
```

So from the second, we can see that
* The return from `which_sessions` is a 3-tuple.
* `element(1, https:which_sessions())` is _a list of tuples_ whose first element is (probably) the atom `session`. There should also be a direct reference to the type `session()` somewhere in the document. Presently there is not.
* `element(2, https:which_sessions())` is _a list_ which *directly contradicts* the documentation. This is frustrating.
* `element(3, https:which_sessions())` is a list, which I think is a valid term in erlang?

I'm nonplussed by this documentation. I think my changes make it better, but I'm not sure.