### PR TITLE
fix build on alpine 3.10 musl libc 1.1.22

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3266,7 +3266,11 @@ AS_HELP_STRING([--without-javac], [don't use any Java compiler]))
 dnl
 dnl Then there are a number of apps which needs a java compiler...
 dnl
-need_java="jinterface ic/java_src"
+need_java="jinterface"
+
+if test -d $ERL_TOP/lib/ic; then
+   need_java="$need_java ic/java_src"
+fi
 
 # Remove all SKIP files from previous runs
 for a in $need_java ; do

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2723,9 +2723,25 @@ if test X${enable_hipe} != Xno; then
 	        AC_MSG_ERROR([HiPE needs mprotect() on $ARCH])
             else
 	        enable_hipe=no
-	        AC_MSG_WARN([Disable HiPE due to lack of mprotect()])
+	        AC_MSG_WARN([HiPE disabled due to lack of mprotect()])
             fi
         fi
+        AC_MSG_CHECKING([for safe signal delivery])
+        AC_TRY_COMPILE([#include <signal.h>],
+          [#if defined(__APPLE__) && defined(__MACH__) && !defined(__DARWIN__)
+           #define __DARWIN__ 1
+           #endif
+
+           #if !(defined(__GLIBC__) || defined(__DARWIN__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__sun__))
+          /*
+           * Unknown libc -- assume musl, which does not allow safe signals
+           */
+           #error "HiPE does not work without a libc that can guarantee that sigaltstack works"
+           #endif	/* !(__GLIBC__ || __DARWIN__ || __NetBSD__ || __FreeBSD__ || __sun__) */],
+        [AC_MSG_RESULT([yes])],
+        [enable_hipe=no
+         AC_MSG_RESULT([no, musl probably used. Need glibc to work properly])
+         AC_MSG_WARN([HiPE disabled due to lack of safe signal delivery])])
 fi
 
 dnl check to auto-enable hipe here...

--- a/erts/emulator/hipe/hipe_x86_signal.c
+++ b/erts/emulator/hipe/hipe_x86_signal.c
@@ -159,19 +159,9 @@
 
 #if !(defined(__GLIBC__) || defined(__DARWIN__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__sun__))
 /*
- * Unknown libc -- assume musl.  Note: musl deliberately does not provide a musl-specific
- * feature test macro, so we cannot check for it.
- *
- * sigaction is a weak alias for __sigaction, which is a wrapper for __libc_sigaction.
- * There are libc-internal calls to __libc_sigaction which install handlers, so we must
- * override __libc_sigaction rather than __sigaction.
+ * Unknown libc -- assume musl, which does not allow safe signals
  */
-#define NEXT_SIGACTION "__libc_sigaction"
-#define LIBC_SIGACTION __libc_sigaction
-#define OVERRIDE_SIGACTION
-#ifndef _NSIG
-#define _NSIG NSIG
-#endif
+#error "HiPE does not work without a libc that can guarantee that sigaltstack works"
 #endif	/* !(__GLIBC__ || __DARWIN__ || __NetBSD__ || __FreeBSD__ || __sun__) */
 
 #if defined(NEXT_SIGACTION)


### PR DESCRIPTION
From https://git.alpinelinux.org/aports/tree/community/erlang 

Without it the build fails on alpine 3.10. I can't really explain it beyond that at this time and do not know if it is a proper long term fix.