### PR TITLE
syntax_tools: unwrap Node in map_field_* functions in erl_syntax

### DIFF
--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -5339,11 +5339,11 @@ revert_map_type_assoc(Node) ->
 -spec map_type_assoc_name(syntaxTree()) -> syntaxTree().
 
 map_type_assoc_name(Node) ->
-    case Node of
+    case unwrap(Node) of
         {type, _, map_field_assoc, [Name, _]} ->
             Name;
-        _ ->
-            (data(Node))#map_type_assoc.name
+        Node1 ->
+            (data(Node1))#map_type_assoc.name
     end.
 
 
@@ -5355,11 +5355,11 @@ map_type_assoc_name(Node) ->
 -spec map_type_assoc_value(syntaxTree()) -> syntaxTree().
 
 map_type_assoc_value(Node) ->
-    case Node of
+    case unwrap(Node) of
         {type, _, map_field_assoc, [_, Value]} ->
             Value;
-        _ ->
-            (data(Node))#map_type_assoc.value
+        Node1 ->
+            (data(Node1))#map_type_assoc.value
     end.
 
 
@@ -5397,11 +5397,11 @@ revert_map_type_exact(Node) ->
 -spec map_type_exact_name(syntaxTree()) -> syntaxTree().
 
 map_type_exact_name(Node) ->
-    case Node of
+    case unwrap(Node) of
         {type, _, map_field_exact, [Name, _]} ->
             Name;
-        _ ->
-            (data(Node))#map_type_exact.name
+        Node1 ->
+            (data(Node1))#map_type_exact.name
     end.
 
 
@@ -5413,11 +5413,11 @@ map_type_exact_name(Node) ->
 -spec map_type_exact_value(syntaxTree()) -> syntaxTree().
 
 map_type_exact_value(Node) ->
-    case Node of
+    case unwrap(Node) of
         {type, _, map_field_exact, [_, Value]} ->
             Value;
-        _ ->
-            (data(Node))#map_type_exact.value
+        Node1 ->
+            (data(Node1))#map_type_exact.value
     end.
 
 

--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -2192,11 +2192,11 @@ revert_map_field_assoc(Node) ->
 -spec map_field_assoc_name(syntaxTree()) -> syntaxTree().
 
 map_field_assoc_name(Node) ->
-    case Node of
+    case unwrap(Node) of
         {map_field_assoc, _, Name, _} ->
             Name;
-        _ ->
-            (data(Node))#map_field_assoc.name
+        Node1 ->
+            (data(Node1))#map_field_assoc.name
     end.
 
 
@@ -2208,11 +2208,11 @@ map_field_assoc_name(Node) ->
 -spec map_field_assoc_value(syntaxTree()) -> syntaxTree().
 
 map_field_assoc_value(Node) ->
-    case Node of
+    case unwrap(Node) of
         {map_field_assoc, _, _, Value} ->
             Value;
-        _ ->
-            (data(Node))#map_field_assoc.value
+        Node1 ->
+            (data(Node1))#map_field_assoc.value
     end.
 
 
@@ -2250,11 +2250,11 @@ revert_map_field_exact(Node) ->
 -spec map_field_exact_name(syntaxTree()) -> syntaxTree().
 
 map_field_exact_name(Node) ->
-    case Node of
+    case unwrap(Node) of
         {map_field_exact, _, Name, _} ->
             Name;
-        _ ->
-            (data(Node))#map_field_exact.name
+        Node1 ->
+            (data(Node1))#map_field_exact.name
     end.
 
 
@@ -2266,11 +2266,11 @@ map_field_exact_name(Node) ->
 -spec map_field_exact_value(syntaxTree()) -> syntaxTree().
 
 map_field_exact_value(Node) ->
-    case Node of
+    case unwrap(Node) of
         {map_field_exact, _, _, Value} ->
             Value;
-        _ ->
-            (data(Node))#map_field_exact.value
+        Node1 ->
+            (data(Node1))#map_field_exact.value
     end.
 
 

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -24,7 +24,7 @@
 
 %% Test cases
 -export([app_test/1,appup_test/1,smoke_test/1,revert/1,revert_map/1,
-         revert_map_type/1,
+         revert_map_type/1,wrapped_subtrees/1,
 	t_abstract_type/1,t_erl_parse_type/1,t_type/1, t_epp_dodger/1,
 	t_comment_scan/1,t_igor/1,t_erl_tidy/1,t_prettypr/1]).
 
@@ -32,6 +32,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
     [app_test,appup_test,smoke_test,revert,revert_map,revert_map_type,
+     wrapped_subtrees,
     t_abstract_type,t_erl_parse_type,t_type,t_epp_dodger,
     t_comment_scan,t_igor,t_erl_tidy,t_prettypr].
 
@@ -142,6 +143,41 @@ revert_map_type(Config) when is_list(Config) ->
     Mapped2 = erl_syntax_lib:map(fun(X) -> X end, Form2),
     Form2 = erl_syntax:revert(Mapped2),
     ?t:timetrap_cancel(Dog).
+
+%% Read with erl_parse, wrap each tree node with erl_syntax and check that 
+%% erl_syntax:subtrees can access the wrapped node.
+wrapped_subtrees(Config) when is_list(Config) ->
+    Dog = ?t:timetrap(?t:minutes(2)),
+    Wc = filename:join([code:lib_dir(stdlib),"src","*.erl"]),
+    Fs = filelib:wildcard(Wc) ++ test_files(Config),
+    Path = [filename:join(code:lib_dir(stdlib), "include"),
+            filename:join(code:lib_dir(kernel), "include")],
+    io:format("~p files\n", [length(Fs)]),
+    Map = fun (File) -> wrapped_subtrees_file(File, Path) end,
+    case p_run(Map, Fs) of
+        0 -> ok;
+        N -> ?t:fail({N,errors})
+    end,
+    ?t:timetrap_cancel(Dog).
+
+wrapped_subtrees_file(File, Path) ->
+    case epp:parse_file(File, Path, []) of
+        {ok,Fs0} ->
+            lists:foreach(fun wrap_each/1, Fs0)
+    end.
+
+wrap_each(Tree) ->
+    % only `wrap` top-level erl_parse node 
+    Tree1 = erl_syntax:set_pos(Tree, erl_syntax:get_pos(Tree)),
+    % assert ability to access subtrees of wrapped node with erl_syntax:subtrees/1
+    case erl_syntax:subtrees(Tree1) of 
+        [] -> ok;
+        List -> 
+            GrpsF = fun(Group) ->
+                          lists:foreach(fun wrap_each/1, Group)
+                    end,
+            lists:foreach(GrpsF, List)
+    end.
 
 %% api tests
 

--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/type_specs.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/type_specs.erl
@@ -37,6 +37,9 @@
 
 -record(par, {a :: undefined | ?MODULE}).
 
+-record(mt, {e :: #{any() := any()},
+             a :: #{any() => any()}}).
+
 -record(r0, {}).
 
 -record(r,


### PR DESCRIPTION
This adds missing calls to unwrap/1 for the map_field_* name and value functions and puts them inline with map_expr_fields/1 (and all the other accessing functions).
erl_syntax:subtrees/1 fails on wrapped map field nodes otherwise.