### PR TITLE
Optimize continuation pointer management

### DIFF
--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -1125,13 +1125,12 @@ check_process_code(Process* rp, Module* modp, int *redsp, int fcalls)
     mod_size = modp->old.code_length;
 
     /*
-     * Check if current instruction or continuation pointer points into module.
+     * Check if the instruction pointer points into module.
      */
-    if (ErtsInArea(rp->i, mod_start, mod_size)
-	|| ErtsInArea(rp->cp, mod_start, mod_size)) {
+    if (ErtsInArea(rp->i, mod_start, mod_size)) {
 	return am_true;
     }
- 
+
     *redsp += 1;
 
     if (erts_check_nif_export_in_area(rp, mod_start, mod_size))

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -5164,7 +5164,7 @@ erts_schedule_bif(Process *proc,
 	else if (proc->flags & F_HIPE_MODE) {
 	    /* Pointer to bif export in i */
 	    exp = (Export *) i;
-	    pc = c_p->cp;
+            pc = cp_val(c_p->stop[0]);
 	    mfa = &exp->info.mfa;
 	}
 #endif
@@ -5181,8 +5181,7 @@ erts_schedule_bif(Process *proc,
 	    mfa = &exp->info.mfa;
 	}
 	else if (BeamIsOpCode(*i, op_apply_bif)) {
-	    /* Pointer to bif in i+1, and mfa in i-3 */	    
-	    pc = c_p->cp;
+            pc = cp_val(c_p->stop[0]);
 	    mfa = erts_code_to_codemfa(i);
 	}
 	else {
@@ -5273,7 +5272,6 @@ erts_call_dirty_bif(ErtsSchedulerData *esdp, Process *c_p, BeamInstr *I, Eterm *
     dirty_shadow_proc->freason = c_p->freason;
     dirty_shadow_proc->fvalue = c_p->fvalue;
     dirty_shadow_proc->ftrace = c_p->ftrace;
-    dirty_shadow_proc->cp = c_p->cp;
     dirty_shadow_proc->i = c_p->i;
 
 #ifdef DEBUG
@@ -5320,7 +5318,6 @@ erts_call_dirty_bif(ErtsSchedulerData *esdp, Process *c_p, BeamInstr *I, Eterm *
 	c_p->freason = dirty_shadow_proc->freason;
 	c_p->fvalue = dirty_shadow_proc->fvalue;
 	c_p->ftrace = dirty_shadow_proc->ftrace;
-	c_p->cp = dirty_shadow_proc->cp;
 	c_p->i = dirty_shadow_proc->i;
 	c_p->arity = dirty_shadow_proc->arity;
     }

--- a/erts/emulator/beam/bif_instrs.tab
+++ b/erts/emulator/beam/bif_instrs.tab
@@ -280,7 +280,7 @@ call_bif(Exp) {
          * erlang code or by nif_bif.epilogue() when the BIF
          * is done).
          */
-        SET_CP(c_p, $NEXT_INSTRUCTION);
+        $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
         SET_I(c_p->i);
         SWAPIN;
         Dispatch();
@@ -297,7 +297,7 @@ call_bif(Exp) {
 
 //
 // Call a BIF tail-recursively, storing the result in x(0) and doing
-// a return to the continuation poiner (c_p->cp).
+// a return to the continuation poiner.
 //
 
 call_bif_only(Exp) {
@@ -367,7 +367,7 @@ call_bif_only(Exp) {
     } else if (c_p->freason == TRAP) {
         /*
          * Dispatch to a trap. When the trap is done, a jump
-         * to the continuation pointer (c_p->cp) will be done.
+         * to the continuation pointer on the stack will be done.
          */
         SET_I(c_p->i);
         SWAPIN;
@@ -413,7 +413,7 @@ send() {
         r(0) = result;
         CHECK_TERM(r(0));
     } else if (c_p->freason == TRAP) {
-        SET_CP(c_p, $NEXT_INSTRUCTION);
+        $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
         SET_I(c_p->i);
         SWAPIN;
         Dispatch();
@@ -570,8 +570,7 @@ nif_bif.epilogue() {
     if (ERTS_LIKELY(is_value(nif_bif_result))) {
         r(0) = nif_bif_result;
         CHECK_TERM(r(0));
-        SET_I(c_p->cp);
-        c_p->cp = 0;
+        $RETURN();
         Goto(*I);
     } else if (c_p->freason == TRAP) {
         SET_I(c_p->i);
@@ -581,6 +580,10 @@ nif_bif.epilogue() {
         }
         Dispatch();
     }
-    I = handle_error(c_p, c_p->cp, reg, c_p->current);
+    {
+        BeamInstr *cp = cp_val(*E);
+        ASSERT(VALID_INSTR(*cp));
+        I = handle_error(c_p, cp, reg, c_p->current);
+    }
     goto post_error_handling;
 }

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2008,14 +2008,16 @@ current_function(Process *c_p, ErtsHeapFactory *hfact, Process* rp,
 
     if (c_p == rp && !(flags & ERTS_PI_FLAG_REQUEST_FOR_OTHER)) {
 	FunctionInfo fi2;
+        BeamInstr* continuation_ptr;
 
 	/*
 	 * The current function is erlang:process_info/{1,2},
 	 * which is not the answer that the application want.
-	 * We will use the function pointed into by rp->cp
-	 * instead if it can be looked up.
+         * We will use the continuation pointer stored at the
+         * top of the stack instead.
 	 */
-	erts_lookup_function_info(&fi2, rp->cp, full_info);
+        continuation_ptr = (BeamInstr *) rp->stop[0];
+        erts_lookup_function_info(&fi2, continuation_ptr, full_info);
 	if (fi2.mfa) {
 	    fi = fi2;
 	    rp->current = fi2.mfa;
@@ -2060,10 +2062,6 @@ current_stacktrace(ErtsHeapFactory *hfact, Process* rp,
     s->depth = 0;
     if (depth > 0 && rp->i) {
 	s->trace[s->depth++] = rp->i;
-	depth--;
-    }
-    if (depth > 0 && rp->cp != 0) {
-	s->trace[s->depth++] = rp->cp - 1;
 	depth--;
     }
     erts_save_stacktrace(rp, s, depth);

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -2612,7 +2612,10 @@ restart:
 	    break;
         case matchCaller:
             ASSERT(c_p == self);
-	    if (!(c_p->cp) || !(cp = find_function_from_pc(c_p->cp))) {
+            t = c_p->stop[0];
+            if (is_not_CP(t)) {
+                *esp++ = am_undefined;
+            } else if (!(cp = find_function_from_pc(cp_val(t)))) {
  		*esp++ = am_undefined;
  	    } else {
 		ehp = HAllocX(build_proc, 4, HEAP_XTRA);
@@ -5226,7 +5229,7 @@ static Eterm match_spec_test(Process *p, Eterm against, Eterm spec, int trace)
     Eterm l;
     Uint32 ret_flags;
     Uint sz;
-    BeamInstr *save_cp;
+    Eterm save_cp;
 
     if (trace && !(is_list(against) || against == NIL)) {
 	return THE_NON_VALUE;
@@ -5270,13 +5273,13 @@ static Eterm match_spec_test(Process *p, Eterm against, Eterm spec, int trace)
 		++n;
 		l = CDR(list_val(l));
 	    }
-	    save_cp = p->cp;
-	    p->cp = NULL;
+	    save_cp = p->stop[0];
+	    p->stop[0] = NIL;
 	    res = erts_match_set_run_trace(p, p,
                       mps, arr, n,
 		      ERTS_PAM_COPY_RESULT|ERTS_PAM_IGNORE_TRACE_SILENT,
 		      &ret_flags);
-	    p->cp = save_cp;
+	    p->stop[0] = save_cp;
 	} else {
 	    n = 0;
 	    arr = NULL;

--- a/erts/emulator/beam/erl_nfunc_sched.c
+++ b/erts/emulator/beam/erl_nfunc_sched.c
@@ -67,7 +67,7 @@ erts_destroy_nif_export(Process *p)
 
 void
 erts_nif_export_save_trace(Process *c_p, NifExport *nep, int applying,
-			   Export* ep, BeamInstr *cp, Uint32 flags,
+			   Export* ep, Uint32 flags,
 			   Uint32 flags_meta, BeamInstr* I,
 			   ErtsTracer meta_tracer)
 {
@@ -78,7 +78,6 @@ erts_nif_export_save_trace(Process *c_p, NifExport *nep, int applying,
 		      sizeof(NifExportTrace));
     netp->applying = applying;
     netp->ep = ep;
-    netp->cp = cp;
     netp->flags = flags;
     netp->flags_meta = flags_meta;
     netp->I = I;
@@ -93,7 +92,7 @@ erts_nif_export_restore_trace(Process *c_p, Eterm result, NifExport *nep)
     NifExportTrace *netp = nep->trace;
     nep->trace = NULL;
     erts_bif_trace_epilogue(c_p, result, netp->applying, netp->ep,
-			    netp->cp, netp->flags, netp->flags_meta,
+			    netp->flags, netp->flags_meta,
 			    netp->I, netp->meta_tracer);
     erts_tracer_update(&netp->meta_tracer, NIL);
     erts_free(ERTS_ALC_T_NIF_EXP_TRACE, netp);
@@ -148,7 +147,6 @@ erts_nif_export_schedule(Process *c_p, Process *dirty_shadow_proc,
 	for (i = 0; i < (int) mfa->arity; i++)
 	    nep->argv[i] = reg[i];
 	nep->pc = pc;
-	nep->cp = c_p->cp;
 	nep->mfa = mfa;
 	nep->current = c_p->current;
 	ASSERT(argc >= 0);

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -334,7 +334,7 @@ schedule(ErlNifEnv* env, NativeFunPtr direct_fp, NativeFunPtr indirect_fp,
 
     ep = erts_nif_export_schedule(c_p, dirty_shadow_proc,
 				  c_p->current,
-				  c_p->cp,
+                                  cp_val(c_p->stop[0]),
 				  BeamOpCodeAddr(op_call_nif),
 				  direct_fp, indirect_fp,
 				  mod, func_name,
@@ -4117,7 +4117,6 @@ static struct erl_module_nif* create_lib(const ErlNifEntry* src)
     return lib;
 };
 
-
 BIF_RETTYPE load_nif_2(BIF_ALIST_2)
 {
     static const char bad_lib[] = "bad_lib";
@@ -4140,6 +4139,7 @@ BIF_RETTYPE load_nif_2(BIF_ALIST_2)
     struct erl_module_nif* lib = NULL;
     struct erl_module_instance* this_mi;
     struct erl_module_instance* prev_mi;
+    BeamInstr* caller_cp;
 
     if (BIF_P->flags & F_HIPE_MODE) {
 	ret = load_nif_error(BIF_P, "notsup", "Calling load_nif from HiPE compiled "
@@ -4175,7 +4175,8 @@ BIF_RETTYPE load_nif_2(BIF_ALIST_2)
     ASSERT(BIF_P->current->module == am_erlang
 	   && BIF_P->current->function == am_load_nif 
 	   && BIF_P->current->arity == 2);
-    caller = find_function_from_pc(BIF_P->cp);
+    caller_cp = cp_val(BIF_P->stop[0]);
+    caller = find_function_from_pc(caller_cp);
     ASSERT(caller != NULL);
     mod_atom = caller->module;
     ASSERT(is_atom(mod_atom));

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -975,7 +975,6 @@ struct process {
     unsigned max_arg_reg;	/* Maximum number of argument registers available. */
     Eterm def_arg_reg[6];	/* Default array for argument registers. */
 
-    BeamInstr* cp;		/* (untagged) Continuation pointer (for threaded code). */
     BeamInstr* i;		/* Program counter for threaded code. */
     Sint catches;		/* Number of catches on stack */
     Sint fcalls;		/* 

--- a/erts/emulator/beam/erl_trace.h
+++ b/erts/emulator/beam/erl_trace.h
@@ -145,7 +145,7 @@ int erts_trace_flags(Eterm List,
 Eterm erts_bif_trace(int bif_index, Process* p, Eterm* args, BeamInstr *I);
 Eterm
 erts_bif_trace_epilogue(Process *p, Eterm result, int applying,
-			Export* ep, BeamInstr *cp, Uint32 flags,
+			Export* ep, Uint32 flags,
 			Uint32 flags_meta, BeamInstr* I,
 			ErtsTracer meta_tracer);
 

--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -165,9 +165,11 @@ i_call(CallDest) {
 }
 
 move_call(Src, CallDest) {
-    x(0) = $Src;
+    Eterm call_dest = $CallDest;
+    Eterm src = $Src;
     $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
-    $DISPATCH_REL($CallDest);
+    x(0) = src;
+    $DISPATCH_REL(call_dest);
 }
 
 i_call_last(CallDest, Deallocate) {
@@ -176,8 +178,11 @@ i_call_last(CallDest, Deallocate) {
 }
 
 move_call_last(Src, CallDest, Deallocate) {
-    x(0) = $Src;
-    $i_call_last($CallDest, $Deallocate);
+    Eterm call_dest = $CallDest;
+    Eterm src = $Src;
+    $deallocate($Deallocate);
+    x(0) = src;
+    $DISPATCH_REL(call_dest);
 }
 
 i_call_only(CallDest) {
@@ -185,8 +190,10 @@ i_call_only(CallDest) {
 }
 
 move_call_only(Src, CallDest) {
-    x(0) = $Src;
-    $i_call_only($CallDest);
+    Eterm call_dest = $CallDest;
+    Eterm src = $Src;
+    x(0) = src;
+    $DISPATCH_REL(call_dest);
 }
 
 DISPATCHX(Dest) {
@@ -202,18 +209,23 @@ i_call_ext(Dest) {
     $DISPATCHX($Dest);
 }
 
-i_move_call_ext(Src, Dest) {
-    x(0) = $Src;
-    $i_call_ext($Dest);
+i_move_call_ext(Src, CallDest) {
+    Eterm call_dest = $CallDest;
+    Eterm src = $Src;
+    $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
+    x(0) = src;
+    $DISPATCHX(call_dest);
 }
 
 i_call_ext_only(Dest) {
     $DISPATCHX($Dest);
 }
 
-i_move_call_ext_only(Dest, Src) {
-    x(0) = $Src;
-    $i_call_ext_only($Dest);
+i_move_call_ext_only(CallDest, Src) {
+    Eterm call_dest = $CallDest;
+    Eterm src = $Src;
+    x(0) = src;
+    $DISPATCHX(call_dest);
 }
 
 i_call_ext_last(Dest, Deallocate) {
@@ -221,9 +233,12 @@ i_call_ext_last(Dest, Deallocate) {
     $DISPATCHX($Dest);
 }
 
-i_move_call_ext_last(Dest, StackOffset, Src) {
-    x(0) = $Src;
-    $i_call_ext_last($Dest, $StackOffset);
+i_move_call_ext_last(CallDest, Deallocate, Src) {
+    Eterm call_dest = $CallDest;
+    Eterm src = $Src;
+    $deallocate($Deallocate);
+    x(0) = src;
+    $DISPATCHX(call_dest);
 }
 
 APPLY(I, Deallocate, Next) {

--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -19,7 +19,12 @@
 // %CopyrightEnd%
 //
 
-// Stack manipulation instructions
+//
+// Stack manipulation instructions follow.
+//
+// See the comment for AH() in macros.tab for information about
+// the layout of stack frames.
+//
 
 allocate(NeedStack, Live) {
     $AH($NeedStack, 0, $Live);
@@ -58,15 +63,14 @@ allocate_heap_zero(NeedStack, NeedHeap, Live) {
 
 deallocate(Deallocate) {
     //| -no_prefetch
-    SET_CP(c_p, (BeamInstr *) cp_val(*E));
     E = ADD_BYTE_OFFSET(E, $Deallocate);
 }
 
 deallocate_return(Deallocate) {
     //| -no_next
     int words_to_pop = $Deallocate;
-    SET_I((BeamInstr *) cp_val(*E));
     E = ADD_BYTE_OFFSET(E, words_to_pop);
+    $RETURN();
     CHECK_TERM(x(0));
     DispatchReturn;
 }
@@ -93,13 +97,13 @@ DISPATCH_ABS(CallDest) {
 }
 
 i_call(CallDest) {
-    SET_CP(c_p, $NEXT_INSTRUCTION);
+    $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
     $DISPATCH_REL($CallDest);
 }
 
 move_call(Src, CallDest) {
     x(0) = $Src;
-    SET_CP(c_p, $NEXT_INSTRUCTION);
+    $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
     $DISPATCH_REL($CallDest);
 }
 
@@ -131,7 +135,7 @@ DISPATCHX(Dest) {
 }
 
 i_call_ext(Dest) {
-    SET_CP(c_p, $NEXT_INSTRUCTION);
+    $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
     $DISPATCHX($Dest);
 }
 
@@ -175,7 +179,7 @@ i_apply() {
     BeamInstr *next;
     $APPLY(NULL, 0, next);
     if (ERTS_LIKELY(next != NULL)) {
-        SET_CP(c_p, $NEXT_INSTRUCTION);
+        $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
         $DISPATCH_ABS(next);
     }
     $HANDLE_APPLY_ERROR();
@@ -211,7 +215,7 @@ apply(Arity) {
     BeamInstr *next;
     $FIXED_APPLY($Arity, NULL, 0, next);
     if (ERTS_LIKELY(next != NULL)) {
-        SET_CP(c_p, $NEXT_INSTRUCTION);
+        $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
         $DISPATCH_ABS(next);
     }
     $HANDLE_APPLY_ERROR();
@@ -247,7 +251,7 @@ i_apply_fun() {
     BeamInstr *next;
     $APPLY_FUN(next);
     if (ERTS_LIKELY(next != NULL)) {
-        SET_CP(c_p, $NEXT_INSTRUCTION);
+        $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
         $DISPATCH_FUN(next);
     }
     $HANDLE_APPLY_FUN_ERROR();
@@ -283,7 +287,7 @@ i_call_fun(Fun) {
     BeamInstr *next;
     $CALL_FUN($Fun, next);
     if (ERTS_LIKELY(next != NULL)) {
-        SET_CP(c_p, $NEXT_INSTRUCTION);
+        $SAVE_CONTINUATION_POINTER($NEXT_INSTRUCTION);
         $DISPATCH_FUN(next);
     }
     $HANDLE_APPLY_FUN_ERROR();
@@ -301,15 +305,8 @@ i_call_fun_last(Fun, Deallocate) {
 
 return() {
     //| -no_next
-    SET_I(c_p->cp);
+    $RETURN();
     DTRACE_RETURN_FROM_PC(c_p);
-
-    /*
-     * We must clear the CP to make sure that a stale value do not
-     * create a false module dependcy preventing code upgrading.
-     * It also means that we can use the CP in stack backtraces.
-     */
-    c_p->cp = 0;
     CHECK_TERM(r(0));
     HEAP_SPACE_VERIFIED(0);
     DispatchReturn;
@@ -478,16 +475,21 @@ i_make_fun(FunP, NumFree) {
 }
 
 move_trim(Src, Dst, Words) {
-    Uint cp = E[0];
     $Dst = $Src;
-    E += $Words;
-    E[0] = cp;
+    $i_trim($Words);
 }
 
 i_trim(Words) {
-    Uint cp = E[0];
     E += $Words;
-    E[0] = cp;
+
+    /*
+     * Clear the reserved location for the continuation pointer at
+     * E[0]. This is not strictly necessary for correctness, but if a
+     * GC is triggered before E[0] is overwritten by another
+     * continuation pointer the now dead term at E[0] would be
+     * retained by the GC.
+     */
+    E[0] = NIL;
 }
 
 move(Src, Dst) {
@@ -599,8 +601,7 @@ move_window5(S1, S2, S3, S4, S5, D) {
 move_return(Src) {
     //| -no_next
     x(0) = $Src;
-    SET_I(c_p->cp);
-    c_p->cp = 0;
+    $RETURN();
     DispatchReturn;
 }
 

--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -66,18 +66,81 @@ deallocate(Deallocate) {
     E = ADD_BYTE_OFFSET(E, $Deallocate);
 }
 
+deallocate_return0 := dealloc_ret.n0.execute;
+deallocate_return1 := dealloc_ret.n1.execute;
+deallocate_return2 := dealloc_ret.n2.execute;
+deallocate_return3 := dealloc_ret.n3.execute;
+deallocate_return4 := dealloc_ret.n4.execute;
+
+dealloc_ret.head() {
+    Uint num_bytes;
+}
+
+dealloc_ret.n0() {
+    num_bytes = (0+1) * sizeof(Eterm);
+}
+
+dealloc_ret.n1() {
+    num_bytes = (1+1) * sizeof(Eterm);
+}
+
+dealloc_ret.n2() {
+    num_bytes = (2+1) * sizeof(Eterm);
+}
+
+dealloc_ret.n3() {
+    num_bytes = (3+1) * sizeof(Eterm);
+}
+
+dealloc_ret.n4() {
+    num_bytes = (4+1) * sizeof(Eterm);
+}
+
+dealloc_ret.execute() {
+    //| -no_next
+
+    /*
+     * Micro-benchmarks showed that the deallocate_return instruction
+     * became slower when the continuation pointer was moved from
+     * the process struct to the stack. The reason seems to be read
+     * dependencies, i.e. that the CPU cannot figure out beforehand
+     * from which position on the stack the continuation pointer
+     * should be fetched.
+     *
+     * Making sure that num_bytes is always initialized with a
+     * constant value seems to restore the lost speed.
+     */
+
+    E = ADD_BYTE_OFFSET(E, num_bytes);
+    $RETURN();
+    CHECK_TERM(x(0));
+    DispatchReturn;
+}
+
 deallocate_return(Deallocate) {
     //| -no_next
-    int words_to_pop = $Deallocate;
-    E = ADD_BYTE_OFFSET(E, words_to_pop);
+    Uint bytes_to_pop = $Deallocate;
+    E = ADD_BYTE_OFFSET(E, bytes_to_pop);
     $RETURN();
     CHECK_TERM(x(0));
     DispatchReturn;
 }
 
 move_deallocate_return(Src, Deallocate) {
-    x(0) = $Src;
-    $deallocate_return($Deallocate);
+    //| -no_next
+
+    /*
+     * Explicitly do reads first to mitigate the impact of read
+     * dependencies.
+     */
+
+    Uint bytes_to_pop = $Deallocate;
+    Eterm src = $Src;
+    E = ADD_BYTE_OFFSET(E, bytes_to_pop);
+    x(0) = src;
+    $RETURN();
+    CHECK_TERM(x(0));
+    DispatchReturn;
 }
 
 // Call instructions

--- a/erts/emulator/beam/macros.tab
+++ b/erts/emulator/beam/macros.tab
@@ -104,14 +104,52 @@ GC_TEST_PRESERVE(NeedHeap, Live, PreserveTerm) {
 
 
 // Make sure that there are NeedStack + NeedHeap + 1 words available
-// on the combined heap/stack segment, then allocates NeedHeap + 1
-// words on the stack and saves CP.
+// on the combined heap/stack segment, then decrement the stack
+// pointer by (NeedStack + 1) words. Finally clear the word reserved
+// for the continuation pointer at the top of the stack.
+//
+// Stack frame layout:
+//
+//       +-----------+
+// y(N)  | Term      |
+//       +-----------+
+//            .
+//            .
+//            .
+//       +-----------+
+// y(0)  | Term      |
+//       +-----------+
+// E ==> | NIL or CP |
+//       +-----------+
+//
+// When the function owning the stack frame is the currently executing
+// function, the word at the top of the stack is NIL. When calling
+// another function, the continuation pointer will be stored in the
+// word at the top of the stack. When returning to the function
+// owning the stack frame, the word at the stack top will again be set
+// to NIL.
+
 AH(NeedStack, NeedHeap, Live) {
     unsigned needed = $NeedStack + 1;
     $GC_TEST(needed, $NeedHeap, $Live);
     E -= needed;
-    *E = make_cp(c_p->cp);
-    c_p->cp = 0;
+    *E = NIL;
+}
+
+// Save the continuation pointer in the reserved slot at the
+// top of the stack as preparation for doing a function call.
+
+SAVE_CONTINUATION_POINTER(IP) {
+    ASSERT(VALID_INSTR(*($IP)));
+    *E = (BeamInstr) ($IP);
+}
+
+// Return to the function whose continuation pointer is stored
+// at the top of the stack and set that word to NIL.
+
+RETURN() {
+    SET_I(cp_val(*E));
+    *E = NIL;
 }
 
 NEXT0() {

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -596,7 +596,19 @@ move S x==0 | deallocate D | return => move_deallocate_return S D
 
 move_deallocate_return xycn Q
 
+deallocate u==0 | return => deallocate_return0
+deallocate u==1 | return => deallocate_return1
+deallocate u==2 | return => deallocate_return2
+deallocate u==3 | return => deallocate_return3
+deallocate u==4 | return => deallocate_return4
+
 deallocate D | return => deallocate_return D
+
+deallocate_return0
+deallocate_return1
+deallocate_return2
+deallocate_return3
+deallocate_return4
 
 deallocate_return Q
 

--- a/erts/emulator/beam/trace_instrs.tab
+++ b/erts/emulator/beam/trace_instrs.tab
@@ -20,16 +20,15 @@
 //
 
 return_trace() {
-    ErtsCodeMFA* mfa = (ErtsCodeMFA *)(E[0]);
+    ErtsCodeMFA* mfa = (ErtsCodeMFA *)(E[1]);
 
     SWAPOUT;		/* Needed for shared heap */
     ERTS_UNREQ_PROC_MAIN_LOCK(c_p);
-    erts_trace_return(c_p, mfa, r(0), ERTS_TRACER_FROM_ETERM(E+1)/* tracer */);
+    erts_trace_return(c_p, mfa, r(0), ERTS_TRACER_FROM_ETERM(E+2)/* tracer */);
     ERTS_REQ_PROC_MAIN_LOCK(c_p);
     SWAPIN;
-    c_p->cp = NULL;
-    SET_I((BeamInstr *) cp_val(E[2]));
     E += 3;
+    $RETURN();
     Goto(*I);
     //| -no_next
 }
@@ -45,13 +44,12 @@ i_generic_breakpoint() {
 }
 
 i_return_time_trace() {
-    BeamInstr *pc = (BeamInstr *) (UWord) E[0];
+    BeamInstr *pc = (BeamInstr *) (UWord) E[1];
     SWAPOUT;
     erts_trace_time_return(c_p, erts_code_to_codeinfo(pc));
     SWAPIN;
-    c_p->cp = NULL;
-    SET_I((BeamInstr *) cp_val(E[1]));
     E += 2;
+    $RETURN();
     Goto(*I);
     //| -no_next
 }
@@ -59,8 +57,10 @@ i_return_time_trace() {
 i_return_to_trace() {
     if (IS_TRACED_FL(c_p, F_TRACE_RETURN_TO)) {
         Uint *cpp = (Uint*) E;
+        while (is_not_CP(*cpp)) {
+            cpp++;
+        }
         for(;;) {
-            ASSERT(is_CP(*cpp));
             if (IsOpCode(*cp_val(*cpp), return_trace)) {
                 do
                     ++cpp;
@@ -80,9 +80,8 @@ i_return_to_trace() {
         ERTS_REQ_PROC_MAIN_LOCK(c_p);
         SWAPIN;
     }
-    c_p->cp = NULL;
-    SET_I((BeamInstr *) cp_val(E[0]));
     E += 1;
+    $RETURN();
     Goto(*I);
     //| -no_next
 }

--- a/erts/emulator/hipe/hipe_debug.c
+++ b/erts/emulator/hipe/hipe_debug.c
@@ -232,7 +232,6 @@ void hipe_print_pcb(Process *p)
     U("intial.fun ", u.initial.function);
     U("intial.ari ", u.initial.arity);
     U("current    ", current);
-    P("cp         ", cp);
     P("i          ", i);
     U("catches    ", catches);
     U("arity      ", arity);

--- a/erts/emulator/hipe/hipe_instrs.tab
+++ b/erts/emulator/hipe/hipe_instrs.tab
@@ -86,8 +86,7 @@ hipe_trap.post() {
     switch( c_p->def_arg_reg[3] ) {
     case HIPE_MODE_SWITCH_RES_RETURN:
         ASSERT(is_value(reg[0]));
-        SET_I(c_p->cp);
-        c_p->cp = 0;
+        $RETURN();
         Goto(*I);
     case HIPE_MODE_SWITCH_RES_CALL_EXPORTED:
         c_p->i = c_p->hipe.u.callee_exp->addressv[erts_active_code_ix()];
@@ -111,7 +110,6 @@ hipe_trap.post() {
             goto find_func_info;
         }
     case HIPE_MODE_SWITCH_RES_THROW:
-        c_p->cp = NULL;
         I = handle_error(c_p, I, reg, NULL);
         goto post_error_handling;
     default:

--- a/erts/emulator/hipe/hipe_mode_switch.c
+++ b/erts/emulator/hipe/hipe_mode_switch.c
@@ -202,15 +202,13 @@ hipe_push_beam_trap_frame(Process *p, Eterm reg[], unsigned arity)
 	p->stop -= 2;
 	p->stop[1] = hipe_beam_catch_throw;
     }
-    p->stop[0] = make_cp(p->cp);
+    p->stop[0] = (BeamInstr) hipe_beam_pc_return;
     ++p->catches;
-    p->cp = hipe_beam_pc_return;
 }
 
 static __inline__ void hipe_pop_beam_trap_frame(Process *p)
 {
     ASSERT(p->stop[1] == hipe_beam_catch_throw);
-    p->cp = cp_val(p->stop[0]);
     --p->catches;
     p->stop += 2;
 }
@@ -263,7 +261,7 @@ Process *hipe_mode_switch(Process *p, unsigned cmd, Eterm reg[])
 	  unsigned arity = cmd >> 8;
 
 	  /* p->hipe.u.ncallee set in beam_emu */
-	  if (p->cp == hipe_beam_pc_return) {
+	  if (cp_val(p->stop[0]) == hipe_beam_pc_return) {
 	    /* Native called BEAM, which now tailcalls native. */
 	    hipe_pop_beam_trap_frame(p);
 	    result = hipe_tailcall_to_native(p, arity, reg);
@@ -292,7 +290,7 @@ Process *hipe_mode_switch(Process *p, unsigned cmd, Eterm reg[])
 	  /* just like a normal call from now on */
 
 	  /* p->hipe.u.ncallee set in beam_emu */
-	  if (p->cp == hipe_beam_pc_return) {
+	  if (cp_val(p->stop[0]) == hipe_beam_pc_return) {
 	      /* Native called BEAM, which now tailcalls native. */
 	      hipe_pop_beam_trap_frame(p);
 	      result = hipe_tailcall_to_native(p, arity, reg);

--- a/erts/emulator/test/bif_SUITE.erl
+++ b/erts/emulator/test/bif_SUITE.erl
@@ -860,6 +860,7 @@ error_stacktrace_test() ->
     Types = [apply_const_last, apply_const, apply_last,
 	     apply, double_apply_const_last, double_apply_const,
 	     double_apply_last, double_apply, multi_apply_const_last,
+             apply_const_only, apply_only,
 	     multi_apply_const, multi_apply_last, multi_apply,
 	     call_const_last, call_last, call_const, call],
     lists:foreach(fun (Type) ->
@@ -897,6 +898,8 @@ error_stacktrace_test() ->
     ok.
 
 stk([], Type, Func) ->
+    put(erlang, erlang),
+    put(tail, []),
     tail(Type, Func, jump),
     ok;
 stk([_|L], Type, Func) ->
@@ -910,6 +913,12 @@ tail(Type, error_1, do) ->
 tail(Type, error_2, do) ->
     do_error_2(Type).
 
+do_error_2(apply_const_only) ->
+    apply(erlang, error, [oops, [apply_const_only]]);
+do_error_2(apply_only) ->
+    Erlang = get(erlang),
+    Tail = get(tail),
+    apply(Erlang, error, [oops, [apply_only|Tail]]);
 do_error_2(apply_const_last) ->
     erlang:apply(erlang, error, [oops, [apply_const_last]]);
 do_error_2(apply_const) ->
@@ -951,6 +960,12 @@ do_error_2(call) ->
     erlang:error(id(oops), id([call])).
 
 
+do_error_1(apply_const_only) ->
+    apply(erlang, error, [oops]);
+do_error_1(apply_only) ->
+    Erlang = get(erlang),
+    Tail = get(tail),
+    apply(Erlang, error, [oops|Tail]);
 do_error_1(apply_const_last) ->
     erlang:apply(erlang, error, [oops]);
 do_error_1(apply_const) ->

--- a/erts/emulator/test/hibernate_SUITE.erl
+++ b/erts/emulator/test/hibernate_SUITE.erl
@@ -46,11 +46,16 @@ all() ->
 basic(Config) when is_list(Config) ->
     Ref = make_ref(),
     Info = {self(),Ref},
-    ExpectedHeapSz = erts_debug:size([Info]),
+    ExpectedHeapSz = expected_heap_size([Info]),
     Child = spawn_link(fun() -> basic_hibernator(Info) end),
     hibernate_wake_up(100, ExpectedHeapSz, Child),
     Child ! please_quit_now,
     ok.
+
+expected_heap_size(Term) ->
+    %% When hibernating, an extra word will be allocated on the stack
+    %% for a continuation pointer.
+    erts_debug:size(Term) + 1.
 
 hibernate_wake_up(0, _, _) -> ok;
 hibernate_wake_up(N, ExpectedHeapSz, Child) ->
@@ -142,7 +147,7 @@ whats_up_calc(A1, A2, A3, A4, A5, A6, A7, A8, A9, Acc) ->
 dynamic_call(Config) when is_list(Config) ->
     Ref = make_ref(),
     Info = {self(),Ref},
-    ExpectedHeapSz = erts_debug:size([Info]),
+    ExpectedHeapSz = expected_heap_size([Info]),
     Child = spawn_link(fun() -> ?MODULE:dynamic_call_hibernator(Info, hibernate) end),
     hibernate_wake_up(100, ExpectedHeapSz, Child),
     Child ! please_quit_now,

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -1187,12 +1187,14 @@ document etp-cp
 %---------------------------------------------------------------------------
 % etp-cp Eterm
 % 
-% Take a code continuation pointer and print 
+% Take a code continuation pointer or instruction pointer and print 
 % module, function, arity and offset. 
 % 
-% Code continuation pointers can be found in the process structure e.g
-% process_tab[i]->cp and process_tab[i]->i, the second is the
-% program counter, which is the same thing as a continuation pointer.
+% Code continuation pointers can be found on the stack. The instruction
+% pointer is found in the process struct. For example:
+%
+%    c_p->i
+%    process_tab[i]->i
 %---------------------------------------------------------------------------
 end
 
@@ -1462,10 +1464,6 @@ define etp-stack-preamble
     printf "I: "
     etp ((Eterm)($arg0)->i)
   end
-  if ($arg0)->cp != 0
-    printf "cp:"
-    etp ((Eterm)($arg0)->cp)
-  end
 end
 
 define etp-stack-preamble-emu
@@ -1474,10 +1472,6 @@ define etp-stack-preamble-emu
   printf "%% Stacktrace (%u)\n", $etp_stack_end-$etp_stack_p
   printf "I: "
   etp ((BeamInstr)I)
-  if ($arg0)->cp != 0
-    printf "cp: "
-    etp ((Eterm)($arg0)->cp)
-  end
 end
 
 define etp-stacktrace-1
@@ -2183,13 +2177,6 @@ define etp-process-info-int
   else
     printf "unknown\n"
   end
-  printf "  CP: "
-  if ($etp_proc->cp)
-    etp-cp-1 $etp_proc->cp
-    printf "\n"
-  else
-    printf "unknown\n"
-  end
   printf "  I: "
   if ($etp_proc->i)
     etp-cp-1 $etp_proc->i
@@ -2419,11 +2406,6 @@ define etp-process-memory-info
       end
     end
 
-    if ($etp_pmem_proc->cp)
-      printf " CP: "
-      etp-cp-1 $etp_pmem_proc->cp
-      printf " "
-    end
     printf "\n"
   end
 end


### PR DESCRIPTION
The BEAM instructions for calling a function don't save the
continuation pointer (return address) on the stack, but to a special
BEAM register called CP. It is the responsibility of the called
function to save CP to the stack frame before calling other functions.

In the earlier implementations of BEAM on Sparc, CP was located in a
CPU register. That meant that the continuation pointer was never
written to memory when calling simple functions that didn't call
other functions at all or ended in a tail-call to another function.

The modern BEAM no longer keeps CP in CPU register. Instead, it is
kept in the `process` struct (in `p->cp`). That means the continuation
pointer must be written to the memory on every call, and if the called
function will call other functions, it will must read the continuation
pointer from `p->cp` and store it on the stack.

This commit eliminates the concept of the CP register and modifies
the call instructions to directly store the continuation pointer on
the stack. That makes allocation and trimming of stack frames slightly
faster. A more important benefit is simplification of code that handles
continuation pointers. Because all continuation pointers are now stored
on the stack, the special case of handling `p->cp` disappears.

Co-authored-by: John Högberg <john@erlang.org>