### PR TITLE
Correct uri_string:normalize/2 wrt RFC 3986 for percent encoding

### DIFF
--- a/lib/stdlib/src/uri_string.erl
+++ b/lib/stdlib/src/uri_string.erl
@@ -1390,17 +1390,7 @@ normalize_percent_encoding(<<$%,C0,C1,Cs/binary>>, Acc) ->
 normalize_percent_encoding(<<C,Cs/binary>>, Acc) ->
     normalize_percent_encoding(Cs, <<Acc/binary, C>>);
 normalize_percent_encoding(<<>>, Acc) ->
-    check_utf8(Acc).
-
-%% Returns Cs if it is utf8 encoded.
-check_utf8(Cs) ->
-    case unicode:characters_to_list(Cs) of
-        {incomplete,_,_} ->
-            throw({error,invalid_utf8,Cs});
-        {error,_,_} ->
-            throw({error,invalid_utf8,Cs});
-        _ -> Cs
-    end.
+    Acc.
 
 %% Convert hex digit to uppercase form
 hex_to_upper(H) when $a =< H, H =< $f ->


### PR DESCRIPTION
The previous implementation was ass-backwards. The normalization of percent encoding was decoding all characters except the reserved ones, instead of only the unreserved ones (a big difference).
If your URL contained a percent-encoded sequence representing some arbitrary bytes (or Latin-1), they got expanded to the actual bytes, which then crashed in the (now redundant) check for utf8-ness.