### PR TITLE
Change logger to use persistent_term for level checks

### DIFF
--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -257,8 +257,7 @@ log(Level, FunOrFormat, Args, Metadata) ->
       Level :: level(),
       Module :: module().
 allow(Level,Module) when is_atom(Module) ->
-    logger_config:allow(?LOGGER_TABLE,Level,Module).
-
+    logger_config:allow(Level,Module).
 
 -spec macro_log(Location,Level,StringOrReport)  -> ok when
       Location :: location(),
@@ -595,7 +594,7 @@ get_module_level(Modules) when is_list(Modules) ->
       Module :: module(),
       Level :: level() | all | none.
 get_module_level() ->
-    logger_config:get_module_level(?LOGGER_TABLE).
+    logger_config:get_module_level().
 
 %%%-----------------------------------------------------------------
 %%% Misc
@@ -1027,14 +1026,14 @@ get_logger_env(App) ->
 %%%-----------------------------------------------------------------
 %%% Internal
 do_log(Level,Msg,#{mfa:={Module,_,_}}=Meta) ->
-    case logger_config:allow(?LOGGER_TABLE,Level,Module) of
+    case logger_config:allow(Level,Module) of
         true ->
             log_allowed(#{},Level,Msg,Meta);
         false ->
             ok
     end;
 do_log(Level,Msg,Meta) ->
-    case logger_config:allow(?LOGGER_TABLE,Level) of
+    case logger_config:allow(Level) of
         true ->
             log_allowed(#{},Level,Msg,Meta);
         false ->

--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -256,7 +256,7 @@ log(Level, FunOrFormat, Args, Metadata) ->
 -spec allow(Level,Module) -> boolean() when
       Level :: level(),
       Module :: module().
-allow(Level,Module) when ?IS_LEVEL(Level), is_atom(Module) ->
+allow(Level,Module) when is_atom(Module) ->
     logger_config:allow(?LOGGER_TABLE,Level,Module).
 
 

--- a/lib/kernel/src/logger_olp.hrl
+++ b/lib/kernel/src/logger_olp.hrl
@@ -72,25 +72,8 @@
 
 -define(timestamp(), erlang:monotonic_time(microsecond)).
 
--define(get_mode(Tid),
-        case ets:lookup(Tid, mode) of
-            [{mode,M}] -> M;
-            _          -> async
-        end).
-
--define(set_mode(Tid, M),
-        begin ets:insert(Tid, {mode,M}), M end).
-
--define(change_mode(Tid, M0, M1),
-        if M0 == M1 ->
-                M0;
-           true ->
-                ets:insert(Tid, {mode,M1}),
-                M1
-        end).
-
 -define(max(X1, X2),
-        if 
+        if
             X2 == undefined -> X1;
             X2 > X1 -> X2;
             true -> X1

--- a/lib/kernel/src/logger_server.erl
+++ b/lib/kernel/src/logger_server.erl
@@ -322,11 +322,11 @@ handle_call({update_formatter_config,HandlerId,NewFConfig},_From,
             {error,{not_found,HandlerId}}
         end,
     {reply,Reply,State};
-handle_call({set_module_level,Modules,Level}, _From, #state{tid=Tid}=State) ->
-    Reply = logger_config:set_module_level(Tid,Modules,Level),
+handle_call({set_module_level,Modules,Level}, _From, State) ->
+    Reply = logger_config:set_module_level(Modules,Level),
     {reply,Reply,State};
-handle_call({unset_module_level,Modules}, _From, #state{tid=Tid}=State) ->
-    Reply = logger_config:unset_module_level(Tid,Modules),
+handle_call({unset_module_level,Modules}, _From, State) ->
+    Reply = logger_config:unset_module_level(Modules),
     {reply,Reply,State}.
 
 handle_cast({async_req_reply,_Ref,_Reply} = Reply,State) ->

--- a/lib/kernel/src/logger_server.erl
+++ b/lib/kernel/src/logger_server.erl
@@ -25,7 +25,7 @@
 -export([start_link/0, add_handler/3, remove_handler/1,
          add_filter/2, remove_filter/2,
          set_module_level/2, unset_module_level/0,
-         unset_module_level/1, cache_module_level/1,
+         unset_module_level/1,
          set_config/2, set_config/3,
          update_config/2, update_config/3,
          update_formatter_config/2]).
@@ -103,9 +103,6 @@ unset_module_level(Modules) when is_list(Modules) ->
     end;
 unset_module_level(Modules) ->
     {error,{not_a_list_of_modules,Modules}}.
-
-cache_module_level(Module) ->
-    gen_server:cast(?SERVER,{cache_module_level,Module}).
 
 set_config(Owner,Key,Value) ->
     case sanity_check(Owner,Key,Value) of
@@ -333,10 +330,7 @@ handle_call({unset_module_level,Modules}, _From, #state{tid=Tid}=State) ->
     {reply,Reply,State}.
 
 handle_cast({async_req_reply,_Ref,_Reply} = Reply,State) ->
-    call_h_reply(Reply,State);
-handle_cast({cache_module_level,Module}, #state{tid=Tid}=State) ->
-    logger_config:cache_module_level(Tid,Module),
-    {noreply, State}.
+    call_h_reply(Reply,State).
 
 %% Interface for those who can't call the API - e.g. the emulator, or
 %% places related to code loading.

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -478,14 +478,15 @@ set_application_level(cleanup,_Config) ->
     ok.
 
 cache_module_level(_Config) ->
-    ok = logger:unset_module_level(?MODULE),
-    [] = ets:lookup(?LOGGER_TABLE,?MODULE), %dirty - add API in logger_config?
+
+    %% This test does a lot of whitebox tests so be prepared for that
+    persistent_term:erase({logger_config,?MODULE}),
+
+    primary = persistent_term:get({logger_config,?MODULE}, primary),
     ?LOG_NOTICE(?map_rep),
-    %% Caching is done asynchronously, so wait a bit for the update
-    timer:sleep(100),
-    [_] = ets:lookup(?LOGGER_TABLE,?MODULE), %dirty - add API in logger_config?
-    ok = logger:unset_module_level(?MODULE),
-    [] = ets:lookup(?LOGGER_TABLE,?MODULE), %dirty - add API in logger_config?
+    5 = persistent_term:get({logger_config,?MODULE}, primary),
+    logger:set_primary_config(level, info),
+    6 = persistent_term:get({logger_config,?MODULE}, primary),
     ok.
 
 cache_module_level(cleanup,_Config) ->

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -276,7 +276,7 @@ change_config(_Config) ->
         logger:get_primary_config(),
     3 = maps:size(PC1),
     %% Check that internal 'handlers' field has not been changed
-    MS = [{{{?HANDLER_KEY,'$1'},'_','_'},[],['$1']}],
+    MS = [{{{?HANDLER_KEY,'$1'},'_'},[],['$1']}],
     HIds1 = lists:sort(ets:select(?LOGGER_TABLE,MS)), % dirty, internal data
     HIds2 = lists:sort(logger:get_handler_ids()),
     HIds1 = HIds2,
@@ -1147,7 +1147,7 @@ kernel_config(Config) ->
 
     ok.
 
-pretty_print(Config) ->
+pretty_print(_Config) ->
     ok = logger:add_handler(?FUNCTION_NAME,logger_std_h,#{}),
     ok = logger:set_module_level([module1,module2],debug),
 


### PR DESCRIPTION
Move the primary and module-level checks into `persistent_term`.

I would also like to move the handler level checks (and possibly config) into `persistent_term`, but that is not done yet.

Also did some other small improvements/bug-fixes.