### PR TITLE
ct: Correct return value handling.

### DIFF
--- a/lib/common_test/src/ct_webtool.erl
+++ b/lib/common_test/src/ct_webtool.erl
@@ -1137,18 +1137,15 @@ get_tools2([],Data) ->
 %----------------------------------------
 get_tools3(ToolFile) ->
     case file:consult(ToolFile) of
-	{error,open} ->
-	    {error,nofile};
-	{error,read} ->
-	    {error,format};
 	{ok,[{version,"1.2"},ToolInfo]} when is_list(ToolInfo)->
 	    webdata(ToolInfo);
 	{ok,[{version,_Vsn},_Info]} ->
 	    {error,old_version};
 	{ok,_Other} ->
-	    {error,format}
+	    {error,format};
+        Error ->
+            Error
     end.
-
 
 %----------------------------------------------------------------------
 % webdata(TupleList)-> ToolTuple| nodata


### PR DESCRIPTION
Just return the error return from file:consult/1. We do not want
to hide error information and previous handling did not make any
sense as it handled non existing returns from file:consult/1.