### PR TITLE
Rename Service Discovery into Node Discovery in documentation

### DIFF
--- a/erts/doc/src/alt_disco.xml
+++ b/erts/doc/src/alt_disco.xml
@@ -4,7 +4,7 @@
 <chapter>
   <header>
     <copyright>
-      <year>2018</year><year>2018</year>
+      <year>2018</year><year>2019</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -22,7 +22,7 @@
 
     </legalnotice>
 
-    <title>How to Implement an Alternative Service Discovery for Erlang Distribution
+    <title>How to Implement an Alternative Node Discovery for Erlang Distribution
     </title>
     <prepared>Timmo Verlaan</prepared>
     <responsible></responsible>
@@ -34,20 +34,20 @@
     <file>alt_disco.xml</file>
   </header>
   <p>
-    This section describes how to implement an alternative discovery mechanism
-    for Erlang distribution. Discovery is normally done using DNS and the
-    Erlang Port Mapper Daemon (EPMD) for port discovery.
+    This section describes how to implement an alternative node discovery
+    mechanism for Erlang distribution. Node discovery is normally done using DNS
+    and the Erlang Port Mapper Daemon (EPMD) for port registration and lookup.
   </p>
 
   <note><p>
-    Support for alternative service discovery mechanisms was added in Erlang/OTP
+    Support for alternative node discovery mechanisms was added in Erlang/OTP
     21.
   </p></note>
 
 
   <section>
     <title>Introduction</title>
-    <p>To implement your own service discovery module you have to write your own
+    <p>To implement your own node discovery module you have to write your own
     EPMD module. The <seealso marker="kernel:erl_epmd">EPMD module</seealso> is
     responsible for providing the location of another node. The distribution
     modules (<c>inet_tcp_dist</c>/<c>inet_tls_dist</c>) call the EPMD module to

--- a/erts/doc/src/notes.xml
+++ b/erts/doc/src/notes.xml
@@ -4,7 +4,7 @@
 <chapter>
   <header>
     <copyright>
-      <year>2004</year><year>2018</year>
+      <year>2004</year><year>2019</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -2786,7 +2786,7 @@
 	    marker="kernel:erl_epmd"><c>erl_epmd</c></seealso>
 	    reference manual and ERTS User's Guide <seealso
 	    marker="erts:alt_disco">How to Implement an Alternative
-	    Service Discovery for Erlang Distribution</seealso>.</p>
+	    Node Discovery for Erlang Distribution</seealso>.</p>
           <p>
 	    Own Id: OTP-15086 Aux Id: PR-1694 </p>
         </item>

--- a/lib/kernel/doc/src/erl_epmd.xml
+++ b/lib/kernel/doc/src/erl_epmd.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>2018</year><year>2018</year>
+      <year>2018</year><year>2019</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -36,7 +36,7 @@
     <p>This module communicates with the EPMD daemon, see <seealso
     marker="erts:epmd">epmd</seealso>. To implement your own epmd module please
     see <seealso marker="erts:alt_disco">ERTS User's Guide: How to Implement an
-    Alternative Service Discovery for Erlang Distribution</seealso></p>
+    Alternative Node Discovery for Erlang Distribution</seealso></p>
   </description>
 
   <funcs>

--- a/lib/kernel/doc/src/notes.xml
+++ b/lib/kernel/doc/src/notes.xml
@@ -4,7 +4,7 @@
 <chapter>
   <header>
     <copyright>
-      <year>2004</year><year>2018</year>
+      <year>2004</year><year>2019</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -894,7 +894,7 @@
 	    marker="kernel:erl_epmd"><c>erl_epmd</c></seealso>
 	    reference manual and ERTS User's Guide <seealso
 	    marker="erts:alt_disco">How to Implement an Alternative
-	    Service Discovery for Erlang Distribution</seealso>.</p>
+	    Node Discovery for Erlang Distribution</seealso>.</p>
           <p>
 	    Own Id: OTP-15086 Aux Id: PR-1694 </p>
         </item>


### PR DESCRIPTION
Discovery of "nodes" instead of "services" seems a more common description for Erlang distribution