### PR TITLE
add 'ia' and 'iz' options in addition to 'i'

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1033,7 +1033,8 @@ do_parse_module(DefEncoding, #compile{ifile=File,options=Opts,dir=Dir}=St) ->
                      false -> SourceName0
                  end,
     R = epp:parse_file(File,
-                       [{includes,[".",Dir|inc_paths(Opts)]},
+                       [{includes,inc_paths(ia, Opts) ++
+                             [".", Dir| inc_paths(i, Opts)] ++ inc_paths(iz, Opts)},
                         {source_name, SourceName},
                         {macros,pre_defs(Opts)},
                         {default_encoding,DefEncoding},
@@ -1874,8 +1875,8 @@ pre_defs([_|Opts]) ->
     pre_defs(Opts);
 pre_defs([]) -> [].
 
-inc_paths(Opts) ->
-    [ P || {i,P} <- Opts, is_list(P) ].
+inc_paths(Key, Opts) ->
+    [ P || {K,P} <- Opts, K =:= Key, is_list(P) ].
 
 src_listing(Ext, Code, St) ->
     listing(fun (Lf, {_Mod,_Exp,Fs}) -> do_src_listing(Lf, Fs);


### PR DESCRIPTION
I'm opening this before adding tests (still have to find where `i` and includes are tested) and the command line argument for `erlc` to get feedback and make sure this is an acceptable direction.

`ia` and `iz` are meant to act like `pa` and `pz` but instead of or code path they prepend or append include paths. The issue with `i` is it only allows appending (so acts the same as `iz` but I added `iz` to be consistent with `pa`/`pz` and didn't remove `i` to stay backwards compatible). This leaves `.` as always the first directory that includes are looked for from.

Rebar3 does not change the working directory when building dependencies, or for applications if they live in `apps/<appname>` instead of at the top level, and this causes issues when a dependency and the root have includes with the same name. The dependency ends up using the root header instead of its own and there appears to be nothing we can do to stop that besides changing the working directory.

Issue in rebar3 that was recently opened about this: https://github.com/erlang/rebar3/issues/2145

A related jira ticket about having a functional interface to the compiler's path handling: https://bugs.erlang.org/browse/ERL-711