### PR TITLE
ERL-1030 SSL failing to handle a 'cRLIssuer' entry in a CRL distribution point extension

### DIFF
--- a/lib/public_key/src/pubkey_crl.erl
+++ b/lib/public_key/src/pubkey_crl.erl
@@ -340,6 +340,7 @@ verify_issuer_and_scope(#'OTPCertificate'{tbsCertificate = TBSCert}= Cert,
     end.
 
 dp_crlissuer_to_issuer(DPCRLIssuer) ->
+     %% Assume the cRLIssuer SEQUENCE is of length exactly 1
      [{directoryName, Issuer}] = pubkey_cert_records:transform(DPCRLIssuer, decode),
      Issuer.
 

--- a/lib/ssl/src/ssl_crl_cache.erl
+++ b/lib/ssl/src/ssl_crl_cache.erl
@@ -46,6 +46,12 @@ lookup(#'DistributionPoint'{distributionPoint = {fullName, Names}},
 lookup(_,_,_) ->
     not_available.
 
+select(GenNames, CRLDbHandle) when is_list(GenNames) ->
+    lists:flatmap(fun({directoryName, Issuer}) ->
+                          select(Issuer, CRLDbHandle);
+                     (_) ->
+                          []
+                  end, GenNames);
 select(Issuer, {{_Cache, Mapping},_}) ->
     case ssl_pkix_db:lookup(Issuer, Mapping) of
 	undefined ->

--- a/lib/ssl/src/ssl_crl_cache_api.erl
+++ b/lib/ssl/src/ssl_crl_cache_api.erl
@@ -31,5 +31,5 @@
 
   
 -callback lookup(dist_point(), issuer_name(), crl_cache_ref()) -> not_available | [public_key:der_encoded()].
--callback select(issuer_name(), crl_cache_ref()) ->  [public_key:der_encoded()].
+-callback select(issuer_name() | list(), crl_cache_ref()) ->  [public_key:der_encoded()].
 -callback fresh_crl(dist_point(), public_key:der_encoded()) -> public_key:der_encoded().

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1792,11 +1792,7 @@ dps_and_crls(OtpCert, Callback, CRLDbHandle, ext) ->
 dps_and_crls(OtpCert, Callback, CRLDbHandle, same_issuer) ->    
     DP = #'DistributionPoint'{distributionPoint = {fullName, GenNames}} = 
 	public_key:pkix_dist_point(OtpCert),
-    CRLs = lists:flatmap(fun({directoryName, Issuer}) -> 
-				 Callback:select(Issuer, CRLDbHandle);
-			    (_) ->
-				 []
-			 end, GenNames),
+    CRLs = Callback:select(GenNames, CRLDbHandle),
     [{DP, {CRL, public_key:der_decode('CertificateList', CRL)}} ||  CRL <- CRLs].
 
 dps_and_crls([], _, Acc) ->

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1792,7 +1792,11 @@ dps_and_crls(OtpCert, Callback, CRLDbHandle, ext) ->
 dps_and_crls(OtpCert, Callback, CRLDbHandle, same_issuer) ->    
     DP = #'DistributionPoint'{distributionPoint = {fullName, GenNames}} = 
 	public_key:pkix_dist_point(OtpCert),
-    CRLs = Callback:select(GenNames, CRLDbHandle),
+    CRLs = lists:flatmap(fun({directoryName, Issuer}) ->
+                                 Callback:select(Issuer, CRLDbHandle);
+                            (_) ->
+                                 []
+                         end, GenNames),
     [{DP, {CRL, public_key:der_decode('CertificateList', CRL)}} ||  CRL <- CRLs].
 
 dps_and_crls([], _, Acc) ->


### PR DESCRIPTION
SSL is failing to handle a populated 'cRLIssuer' entry in a CRL distribution point extension in a certificate.

Specifically, ssl_crl_hash_dir:lookup/3 confuses the structure of 'CertIssuer' with 'CRLIssuer' which is potentially a list.

Fix by using the existing pubkey_crl:dp_crlissuer_to_issuer/1 to unwrap the CRLIssuer.

Added test to repro the problem.