### PR TITLE
Clean up and simplify the v3_kernel compiler pass

### DIFF
--- a/lib/compiler/src/beam_kernel_to_ssa.erl
+++ b/lib/compiler/src/beam_kernel_to_ssa.erl
@@ -106,8 +106,6 @@ make_failure(Reason, St0) ->
 
 cg(#k_match{body=M,ret=Rs}, St) ->
     do_match_cg(M, Rs, St);
-cg(#k_guard_match{body=M,ret=Rs}, St) ->
-    do_match_cg(M, Rs, St);
 cg(#k_seq{arg=Arg,body=Body}, St0) ->
     {ArgIs,St1} = cg(Arg, St0),
     {BodyIs,St} = cg(Body, St1),
@@ -139,9 +137,7 @@ cg(#k_return{args=[Ret0]}, St) ->
     {[#b_ret{arg=Ret}],St};
 cg(#k_break{args=Bs}, #cg{break=Br}=St) ->
     Args = ssa_args(Bs, St),
-    {[#cg_break{args=Args,phi=Br}],St};
-cg(#k_guard_break{args=Bs}, St) ->
-    cg(#k_break{args=Bs}, St).
+    {[#cg_break{args=Args,phi=Br}],St}.
 
 %% match_cg(Matc, [Ret], State) -> {[Ainstr],State}.
 %%  Generate code for a match.

--- a/lib/compiler/src/cerl_sets.erl
+++ b/lib/compiler/src/cerl_sets.erl
@@ -130,8 +130,10 @@ union1(S1, []) -> S1.
       Set2 :: set(Element),
       Set3 :: set(Element).
 
+intersection(S1, S2) when map_size(S1) >= map_size(S2) ->
+    filter(fun (E) -> is_element(E, S1) end, S2);
 intersection(S1, S2) ->
-    filter(fun (E) -> is_element(E, S1) end, S2).
+    intersection(S2, S1).
 
 %% intersection([Set]) -> Set.
 %%  Return the intersection of the list of sets.

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -419,6 +419,15 @@ gexpr_test(E0, Bools0, St0) ->
     {E1,Eps0,St1} = expr(E0, St0),
     %% Generate "top-level" test and argument calls.
     case E1 of
+        #icall{anno=Anno,module=#c_literal{val=erlang},
+               name=#c_literal{val=is_function},
+               args=[_,_]} ->
+            %% is_function/2 is not a safe type test. We must force
+            %% it to be protected.
+            Lanno = Anno#a.anno,
+            {New,St2} = new_var(Lanno, St1),
+            {icall_eq_true(New),
+             Eps0 ++ [#iset{anno=Anno,var=New,arg=E1}],Bools0,St2};
 	#icall{anno=Anno,module=#c_literal{val=erlang},name=#c_literal{val=N},args=As} ->
             %% Note that erl_expand_records has renamed type
             %% tests to the new names; thus, float/1 as a type

--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -2016,9 +2016,10 @@ uexpr(#ifun{anno=A,vars=Vs,body=B0}, {break,Rs}, St0) ->
 		new_fun_name(St1)
 	end,
     Fun = make_fdef(A, Fname, Arity, Vs++Fvs, B1),
+    Local = #k_local{name=Fname,arity=Arity},
     {#k_bif{anno=A,
 	    op=#k_internal{name=make_fun,arity=length(Free)+2},
-	    args=[#k_literal{val=Fname},#k_literal{val=Arity}|Fvs],
+	    args=[Local|Fvs],
  	    ret=Rs},
      Free,add_local_function(Fun, St)};
 uexpr(Lit, {break,Rs0}, St0) ->

--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -194,26 +194,12 @@ body(Ce, Sub, St0) ->
 %% guard(Cexpr, Sub, State) -> {Kexpr,State}.
 %%  We handle guards almost as bodies. The only special thing we
 %%  must do is to make the final Kexpr a #k_test{}.
-%%  Also, we wrap the entire guard in a try/catch which is
-%%  not strictly needed, but makes sure that every 'bif' instruction
-%%  will get a proper failure label.
 
 guard(G0, Sub, St0) ->
-    {G1,St1} = wrap_guard(G0, St0),
-    {Ge0,Pre,St2} = expr(G1, Sub, St1),
-    {Ge1,St3} = gexpr_test(Ge0, St2),
-    {Ge,St} = {Ge1,St3},
+    {Ge0,Pre,St1} = expr(G0, Sub, St0),
+    {Ge,St} = gexpr_test(Ge0, St1),
     {pre_seq(Pre, Ge),St}.
 
-%% Wrap the entire guard in a try/catch if needed.
-
-wrap_guard(#c_try{}=Try, St) -> {Try,St};
-wrap_guard(Core, St0) ->
-    {VarName,St} = new_var_name(St0),
-    Var = #c_var{name=VarName},
-    Try = #c_try{arg=Core,vars=[Var],body=Var,evars=[],handler=#c_literal{val=false}},
-    {Try,St}.
-    
 %% gexpr_test(Kexpr, State) -> {Kexpr,State}.
 %%  Builds the final boolean test from the last Kexpr in a guard test.
 %%  Must enter try blocks and isets and find the last Kexpr in them.

--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -183,7 +183,6 @@ function({#c_var{name={F,Arity}=FA},Body}, St0) ->
 body(#c_values{anno=A,es=Ces}, Sub, St0) ->
     %% Do this here even if only in bodies.
     {Kes,Pe,St1} = atomic_list(Ces, Sub, St0),
-    %%{Kes,Pe,St1} = expr_list(Ces, Sub, St0),
     {#ivalues{anno=A,args=Kes},Pe,St1};
 body(#ireceive_next{anno=A}, _, St) ->
     {#k_receive_next{anno=A},[],St};
@@ -603,12 +602,6 @@ force_atomic(Ke, St0) ->
 	    {V,[#iset{vars=[V],arg=Ke}],St1}
     end.
 
-% force_atomic_list(Kes, St) ->
-%     foldr(fun (Ka, {As,Asp,St0}) ->
-% 		  {A,Ap,St1} = force_atomic(Ka, St0),
-% 		  {[A|As],Ap ++ Asp,St1}
-% 	  end, {[],[],St}, Kes).
-
 atomic_bin([#c_bitstr{anno=A,val=E0,size=S0,unit=U0,type=T,flags=Fs0}|Es0],
 	   Sub, St0) ->
     {E,Ap1,St1} = atomic(E0, Sub, St0),
@@ -908,11 +901,6 @@ make_vars(Vs) -> [ #k_var{name=V} || V <- Vs ].
 
 add_var_def(V, St) ->
     St#kern{ds=cerl_sets:add_element(V#k_var.name, St#kern.ds)}.
-
-%%add_vars_def(Vs, St) ->
-%%    Ds = foldl(fun (#k_var{name=V}, Ds) -> add_element(V, Ds) end,
-%%	       St#kern.ds, Vs),
-%%    St#kern{ds=Ds}.
 
 %% is_remote_bif(Mod, Name, Arity) -> true | false.
 %%  Test if function is really a BIF.
@@ -1495,15 +1483,6 @@ group_keeping_order(Us, [C1|Cs]) ->
     {More,Rest} = splitwith(fun (C) -> clause_val(C) =:= V1 end, Cs),
     [{Us,[C1|More]}|group_keeping_order(Us, Rest)];
 group_keeping_order(_, []) -> [].
-
-%% Profiling shows that this quadratic implementation account for a big amount
-%% of the execution time if there are many values.
-% group_value([C|Cs]) ->
-%     V = clause_val(C),
-%     Same = [ Cv || Cv <- Cs, clause_val(Cv) == V ], %Same value
-%     Rest = [ Cv || Cv <- Cs, clause_val(Cv) /= V ], % and all the rest
-%     [[C|Same]|group_value(Rest)];
-% group_value([]) -> [].
 
 %% match_clause([Var], [Clause], Default, State) -> {Clause,State}.
 %%  At this point all the clauses have the same "value".  Build one

--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -1869,12 +1869,7 @@ ubody(#ivalues{anno=A,args=As}, return, St) ->
     {#k_return{anno=A,args=As},Au,St};
 ubody(#ivalues{anno=A,args=As}, {break,_Vbs}, St) ->
     Au = lit_list_vars(As),
-    case is_in_guard(St) of
-	true ->
-	    {#k_guard_break{anno=A,args=As},Au,St};
-	false ->
-	    {#k_break{anno=A,args=As},Au,St}
-    end;
+    {#k_break{anno=A,args=As},Au,St};
 ubody(E, return, St0) ->
     %% Enterable expressions need no trailing return.
     case is_enter_expr(E) of
@@ -1992,14 +1987,7 @@ uexpr(#k_bif{anno=A,op=Op,args=As}=Bif, {break,Rs}, St0) ->
 uexpr(#k_match{anno=A,vars=Vs,body=B0}, Br, St0) ->
     Rs = break_rets(Br),
     {B1,Bu,St1} = umatch(B0, Br, St0),
-    case is_in_guard(St1) of
-	true ->
-	    {#k_guard_match{anno=A,
-			    vars=Vs,body=B1,ret=Rs},Bu,St1};
-	false ->
-	    {#k_match{anno=A,
-		      vars=Vs,body=B1,ret=Rs},Bu,St1}
-    end;
+    {#k_match{anno=A,vars=Vs,body=B1,ret=Rs},Bu,St1};
 uexpr(#k_receive{anno=A,var=V,body=B0,timeout=T,action=A0}, Br, St0) ->
     Rs = break_rets(Br),
     Tu = lit_vars(T),				%Timeout is atomic

--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -84,7 +84,6 @@
                 splitwith/2]).
 -import(ordsets, [add_element/2,del_element/2,intersection/2,
                   subtract/2,union/2,union/1]).
--import(cerl, [c_tuple/1]).
 
 -include("core_parse.hrl").
 -include("v3_kernel.hrl").
@@ -389,14 +388,8 @@ expr(#c_call{anno=A,module=M0,name=F0,args=Cargs}, Sub, St0) ->
 			   args=[M0,F0,cerl:make_list(Cargs)]},
 	    expr(Call, Sub, St)
     end;
-expr(#c_primop{anno=A,name=#c_literal{val=match_fail},args=Cargs0}, Sub, St0) ->
-    Cargs = translate_match_fail(Cargs0, Sub, A, St0),
-    {Kargs,Ap,St} = atomic_list(Cargs, Sub, St0),
-    Ar = length(Cargs),
-    Call = #k_call{anno=A,op=#k_remote{mod=#k_literal{val=erlang},
-				       name=#k_literal{val=error},
-				       arity=Ar},args=Kargs},
-    {Call,Ap,St};
+expr(#c_primop{anno=A,name=#c_literal{val=match_fail},args=Cargs0}, Sub, St) ->
+    translate_match_fail(Cargs0, Sub, A, St);
 expr(#c_primop{anno=A,name=#c_literal{val=N},args=Cargs}, Sub, St0) ->
     {Kargs,Ap,St1} = atomic_list(Cargs, Sub, St0),
     Ar = length(Cargs),
@@ -419,29 +412,23 @@ expr(#c_catch{anno=A,body=Cb}, Sub, St0) ->
 expr(#ireceive_accept{anno=A}, _Sub, St) -> {#k_receive_accept{anno=A},[],St}.
 
 %% Translate a function_clause exception to a case_clause exception if
-%% it has been moved into another function. (A function_clause exception
-%% will not work correctly if it is moved into another function, or
-%% even if it is invoked not from the top level in the correct function.)
-translate_match_fail(Args, Sub, Anno, St) ->
-    case Args of
-	[#c_tuple{es=[#c_literal{val=function_clause}|As]}] ->
-	    translate_match_fail_1(Anno, As, Sub, St);
-	[#c_literal{val=Tuple}] when is_tuple(Tuple) ->
-	    %% The inliner may have created a literal out of
-	    %% the original #c_tuple{}.
-	    case tuple_to_list(Tuple) of
-		[function_clause|As0] ->
-		    As = [#c_literal{val=E} || E <- As0],
-		    translate_match_fail_1(Anno, As, Sub, St);
-		_ ->
-		    Args
-	    end;
-	_ ->
-	    %% Not a function_clause exception.
-	    Args
-    end.
+%% it has been moved into another function.
+translate_match_fail([Arg], Sub, Anno, St0) ->
+    Cargs = case {cerl:data_type(Arg),cerl:data_es(Arg)} of
+                {tuple,[#c_literal{val=function_clause}|As]} ->
+                    translate_fc_args(Anno, As, Sub, St0);
+                {_,_} ->
+                    [Arg]
+            end,
+    {Kargs,Ap,St} = atomic_list(Cargs, Sub, St0),
+    Ar = length(Cargs),
+    Call = #k_call{anno=Anno,
+                   op=#k_remote{mod=#k_literal{val=erlang},
+                                name=#k_literal{val=error},
+                                arity=Ar},args=Kargs},
+    {Call,Ap,St}.
 
-translate_match_fail_1(Anno, As, Sub, #kern{ff=FF}) ->
+translate_fc_args(Anno, As, Sub, #kern{ff=FF}) ->
     AnnoFunc = case keyfind(function_name, 1, Anno) of
 		   false ->
 		       none;			%Force rewrite.
@@ -459,11 +446,11 @@ translate_match_fail_1(Anno, As, Sub, #kern{ff=FF}) ->
 	    %% Wrong function or no function_name annotation.
 	    %%
 	    %% The inliner has copied the match_fail(function_clause)
-	    %% primop from another function (or from another instance of
-	    %% the current function). match_fail(function_clause) will
-	    %% only work at the top level of the function it was originally
-	    %% defined in, so we will need to rewrite it to a case_clause.
-	    [c_tuple([#c_literal{val=case_clause},c_tuple(As)])]
+	    %% primop from another function (or from another instance
+	    %% of the current function). Keeping the function_clause
+            %% exception reason would be confusing.
+	    [cerl:c_tuple([#c_literal{val=case_clause},
+                           cerl:c_tuple(As)])]
     end.
 
 translate_fc(Args) ->

--- a/lib/compiler/src/v3_kernel.hrl
+++ b/lib/compiler/src/v3_kernel.hrl
@@ -24,11 +24,6 @@
 %% this could make including this file difficult.
 %% N.B. the annotation field is ALWAYS the first field!
 
-%% Kernel annotation record.
--record(k, {us,					%Used variables
-	    ns,					%New variables
-	    a}).				%Core annotation
-
 %% Literals
 %% NO CHARACTERS YET.
 %%-record(k_char, {anno=[],val}).

--- a/lib/compiler/src/v3_kernel.hrl
+++ b/lib/compiler/src/v3_kernel.hrl
@@ -57,7 +57,6 @@
 -record(k_receive_next, {anno=[]}).
 -record(k_try, {anno=[],arg,vars,body,evars,handler,ret=[]}).
 -record(k_try_enter, {anno=[],arg,vars,body,evars,handler}).
--record(k_protected, {anno=[],arg,ret=[],inner}).
 -record(k_catch, {anno=[],body,ret=[]}).
 
 -record(k_match, {anno=[],body,ret=[]}).
@@ -67,6 +66,8 @@
 -record(k_val_clause, {anno=[],val,body}).
 -record(k_guard, {anno=[],clauses}).
 -record(k_guard_clause, {anno=[],guard,body}).
+-record(k_protected, {anno=[],arg}).
+-record(k_protected_value, {anno=[],arg,ret,body_ret}).
 
 -record(k_break, {anno=[],args=[]}).
 -record(k_return, {anno=[],args=[]}).

--- a/lib/compiler/src/v3_kernel.hrl
+++ b/lib/compiler/src/v3_kernel.hrl
@@ -60,7 +60,7 @@
 -record(k_protected, {anno=[],arg,ret=[],inner}).
 -record(k_catch, {anno=[],body,ret=[]}).
 
--record(k_match, {anno=[],vars,body,ret=[]}).
+-record(k_match, {anno=[],body,ret=[]}).
 -record(k_alt, {anno=[],first,then}).
 -record(k_select, {anno=[],var,types}).
 -record(k_type_clause, {anno=[],type,values}).

--- a/lib/compiler/src/v3_kernel.hrl
+++ b/lib/compiler/src/v3_kernel.hrl
@@ -64,7 +64,6 @@
 -record(k_protected, {anno=[],arg,ret=[],inner}).
 -record(k_catch, {anno=[],body,ret=[]}).
 
--record(k_guard_match, {anno=[],vars,body,ret=[]}).
 -record(k_match, {anno=[],vars,body,ret=[]}).
 -record(k_alt, {anno=[],first,then}).
 -record(k_select, {anno=[],var,types}).
@@ -74,7 +73,6 @@
 -record(k_guard_clause, {anno=[],guard,body}).
 
 -record(k_break, {anno=[],args=[]}).
--record(k_guard_break, {anno=[],args=[]}).
 -record(k_return, {anno=[],args=[]}).
 
 %%k_get_anno(Thing) -> element(2, Thing).

--- a/lib/compiler/src/v3_kernel.hrl
+++ b/lib/compiler/src/v3_kernel.hrl
@@ -27,11 +27,7 @@
 %% Literals
 %% NO CHARACTERS YET.
 %%-record(k_char, {anno=[],val}).
--record(k_literal, {anno=[],val}).		%Only used for complex literals.
--record(k_int, {anno=[],val}).
--record(k_float, {anno=[],val}).
--record(k_atom, {anno=[],val}).
--record(k_nil, {anno=[]}).
+-record(k_literal, {anno=[],val}).
 
 -record(k_tuple, {anno=[],es}).
 -record(k_map, {anno=[],var=#k_literal{val=#{}},op,es}).

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -57,8 +57,6 @@ format(Node, Ctxt) ->
 	    format_1(Node, Ctxt);
 	[L,{file,_}] when is_integer(L) ->
 	    format_1(Node, Ctxt);
-	#k{a=Anno}=K when Anno =/= [] ->
-	    format(setelement(2, Node, K#k{a=[]}), Ctxt);
 	List ->
 	    format_anno(List, Ctxt, fun (Ctxt1) ->
 					    format_1(Node, Ctxt1)

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -166,16 +166,6 @@ format_1(#k_match{vars=Vs,body=Bs,ret=Rs}, Ctxt) ->
      "end",
      format_ret(Rs, Ctxt1)
     ];
-format_1(#k_guard_match{vars=Vs,body=Bs,ret=Rs}, Ctxt) ->
-    Ctxt1 = ctxt_bump_indent(Ctxt, Ctxt#ctxt.item_indent),
-    ["guard_match ",
-     format_hseq(Vs, ",", ctxt_bump_indent(Ctxt, 6), fun format/2),
-     nl_indent(Ctxt1),
-     format(Bs, Ctxt1),
-     nl_indent(Ctxt),
-     "end",
-     format_ret(Rs, Ctxt1)
-    ];
 format_1(#k_alt{first=O,then=T}, Ctxt) ->
     Ctxt1 = ctxt_bump_indent(Ctxt, Ctxt#ctxt.item_indent),
     ["alt",
@@ -318,11 +308,6 @@ format_1(#k_break{args=As}, Ctxt) ->
     ["<",
      format_hseq(As, ",", ctxt_bump_indent(Ctxt, 1), fun format/2),
      ">"
-    ];
-format_1(#k_guard_break{args=As}, Ctxt) ->
-    [":<",
-     format_hseq(As, ",", ctxt_bump_indent(Ctxt, 1), fun format/2),
-     ">:"
     ];
 format_1(#k_return{args=As}, Ctxt) ->
     ["<<",

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -266,14 +266,22 @@ format_1(#k_try_enter{arg=A,vars=Vs,body=B,evars=Evs,handler=H}, Ctxt) ->
      nl_indent(Ctxt),
      "end"
     ];
-format_1(#k_protected{arg=A,ret=Rs}, Ctxt) ->
+format_1(#k_protected{arg=A}, Ctxt) ->
     Ctxt1 = ctxt_bump_indent(Ctxt, Ctxt#ctxt.body_indent),
     ["protected",
      nl_indent(Ctxt1),
      format(A, Ctxt1),
      nl_indent(Ctxt),
+     "end"
+    ];
+format_1(#k_protected_value{arg=A,ret=Ret}, Ctxt) ->
+    Ctxt1 = ctxt_bump_indent(Ctxt, Ctxt#ctxt.body_indent),
+    ["protected_value",
+     nl_indent(Ctxt1),
+     format(A, Ctxt1),
+     nl_indent(Ctxt),
      "end",
-     format_ret(Rs, ctxt_bump_indent(Ctxt, 1))
+     format_ret([Ret], ctxt_bump_indent(Ctxt, 1))
     ];
 format_1(#k_catch{body=B,ret=Rs}, Ctxt) ->
     Ctxt1 = ctxt_bump_indent(Ctxt, Ctxt#ctxt.body_indent),

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -155,10 +155,9 @@ format_1(#k_seq{arg=A,body=B}, Ctxt) ->
      nl_indent(Ctxt)
      | format(B, Ctxt)
     ];
-format_1(#k_match{vars=Vs,body=Bs,ret=Rs}, Ctxt) ->
+format_1(#k_match{body=Bs,ret=Rs}, Ctxt) ->
     Ctxt1 = ctxt_bump_indent(Ctxt, Ctxt#ctxt.item_indent),
-    ["match ",
-     format_hseq(Vs, ",", ctxt_bump_indent(Ctxt, 6), fun format/2),
+    ["match",
      nl_indent(Ctxt1),
      format(Bs, Ctxt1),
      nl_indent(Ctxt),


### PR DESCRIPTION
The main purpose of this pull request it to clean up and simplify the `v3_kernel` pass. Details are described in the individual commit messages.

A few inefficiencies were fixed along the way. For example, when compiling a version of elixir's `String.Unicode` module, the time for running the `v3_kernel` pass was reduced from about 1.5 seconds down to less than a second on my computer.