### PR TITLE
Implement a separate test for stack direction for the re module

### DIFF
--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -90,6 +90,16 @@ stack_guard_upwards(void)
     return erts_check_above_limit(&c, limit - ERTS_PCRE_STACK_MARGIN);
 }
 
+static ERTS_NOINLINE
+int stack_grows_downwards(char *prev_c)
+{
+    char c;
+    if (&c < prev_c)
+        return 1;
+    else
+        return 0;
+}
+
 void erts_init_bif_re(void)
 {
     char c;
@@ -97,7 +107,7 @@ void erts_init_bif_re(void)
     erts_pcre_free = &erts_erts_pcre_free;
     erts_pcre_stack_malloc = &erts_erts_pcre_stack_malloc;
     erts_pcre_stack_free = &erts_erts_pcre_stack_free;
-    if ((char *) erts_ptr_id(&c) > ERTS_STACK_LIMIT)
+    if (stack_grows_downwards(&c))
         erts_pcre_stack_guard = stack_guard_downwards;
     else
         erts_pcre_stack_guard = stack_guard_upwards;

--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -90,16 +90,6 @@ stack_guard_upwards(void)
     return erts_check_above_limit(&c, limit - ERTS_PCRE_STACK_MARGIN);
 }
 
-static ERTS_NOINLINE
-int stack_grows_downwards(char *prev_c)
-{
-    char c;
-    if (erts_check_below_limit(&c, prev_c))
-        return 1;
-    else
-        return 0;
-}
-
 void erts_init_bif_re(void)
 {
     char c;
@@ -107,7 +97,7 @@ void erts_init_bif_re(void)
     erts_pcre_free = &erts_erts_pcre_free;
     erts_pcre_stack_malloc = &erts_erts_pcre_stack_malloc;
     erts_pcre_stack_free = &erts_erts_pcre_stack_free;
-    if (stack_grows_downwards(&c))
+    if (erts_check_if_stack_grows_downwards(&c))
         erts_pcre_stack_guard = stack_guard_downwards;
     else
         erts_pcre_stack_guard = stack_guard_upwards;

--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -94,7 +94,7 @@ static ERTS_NOINLINE
 int stack_grows_downwards(char *prev_c)
 {
     char c;
-    if erts_check_below_limit(&c, prev_c)
+    if (erts_check_below_limit(&c, prev_c))
         return 1;
     else
         return 0;

--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -94,7 +94,7 @@ static ERTS_NOINLINE
 int stack_grows_downwards(char *prev_c)
 {
     char c;
-    if (&c < prev_c)
+    if erts_check_below_limit(&c, prev_c)
         return 1;
     else
         return 0;

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1253,6 +1253,7 @@ void *erts_calc_stacklimit(char *prev_c, UWord stacksize) ERTS_NOINLINE;
 int erts_check_below_limit(char *ptr, char *limit) ERTS_NOINLINE;
 int erts_check_above_limit(char *ptr, char *limit) ERTS_NOINLINE;
 void *erts_ptr_id(void *ptr) ERTS_NOINLINE;
+int erts_check_if_stack_grows_downwards(char *ptr) ERTS_NOINLINE;
 
 Eterm store_external_or_ref_in_proc_(Process *, Eterm);
 Eterm store_external_or_ref_(Uint **, ErlOffHeap*, Eterm);

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -4789,3 +4789,11 @@ erts_ptr_id(void *ptr)
     return ptr;
 }
 
+int erts_check_if_stack_grows_downwards(char *ptr)
+{
+    char c;
+    if (erts_check_below_limit(&c, ptr))
+        return 1;
+    else
+        return 0;
+}


### PR DESCRIPTION
Fix the bug with failure to build from the source on HP PA-RISC
architecture where stack grows upwards. See
https://bugs.erlang.org/browse/ERL-1043 for details.