### PR TITLE
Correct the documentation for proplists:substitute_negations/2

### DIFF
--- a/lib/stdlib/doc/src/proplists.xml
+++ b/lib/stdlib/doc/src/proplists.xml
@@ -346,7 +346,7 @@ split([{c, 2}, {e, 1}, a, {c, 3, 4}, d, {b, 5}, b], [a, b, c])</code>
           <c>K1</c> such that <c>{K1, K2}</c> occurs in
           <c><anno>Negations</anno></c>: if the entry was
           <c>{K1, true}</c>, it is replaced with <c>{K2, false}</c>, otherwise
-          with <c>{K2, true}</c>, thus changing the name of the option and
+          with <c>K2</c>, thus changing the name of the option and
           simultaneously negating the value specified by
           <seealso marker="#get_bool/2">
           <c>get_bool(Key, <anno>ListIn</anno>)</c></seealso>.
@@ -355,7 +355,7 @@ split([{c, 2}, {e, 1}, a, {c, 3, 4}, d, {b, 5}, b], [a, b, c])</code>
         <p>For example, <c>substitute_negations([{no_foo, foo}], L)</c>
           replaces any atom <c>no_foo</c> or tuple
           <c>{no_foo, true}</c> in <c>L</c> with <c>{foo, false}</c>,
-          and any other tuple <c>{no_foo, ...}</c> with <c>{foo, true}</c>.</p>
+          and any other tuple <c>{no_foo, ...}</c> with <c>foo</c>.</p>
         <p>See also
           <seealso marker="#get_bool/2"><c>get_bool/2</c></seealso>,
           <seealso marker="#normalize/2"><c>normalize/2</c></seealso>,

--- a/lib/stdlib/src/proplists.erl
+++ b/lib/stdlib/src/proplists.erl
@@ -410,8 +410,8 @@ substitute_aliases_1([], P) ->
 %% associated with some key <code>K1</code> such that <code>{K1,
 %% K2}</code> occurs in <code>Negations</code>, then if the entry was
 %% <code>{K1, true}</code> it will be replaced with <code>{K2,
-%% false}</code>, otherwise it will be replaced with <code>{K2,
-%% true}</code>, thus changing the name of the option and simultaneously
+%% false}</code>, otherwise it will be replaced with <code>K2</code>,
+%% thus changing the name of the option and simultaneously
 %% negating the value given by <code>get_bool(ListIn)</code>. If the same
 %% <code>K1</code> occurs more than once in <code>Negations</code>, only
 %% the first occurrence is used.
@@ -419,8 +419,7 @@ substitute_aliases_1([], P) ->
 %% <p>Example: <code>substitute_negations([{no_foo, foo}], L)</code>
 %% will replace any atom <code>no_foo</code> or tuple <code>{no_foo,
 %% true}</code> in <code>L</code> with <code>{foo, false}</code>, and
-%% any other tuple <code>{no_foo, ...}</code> with <code>{foo,
-%% true}</code>.</p>
+%% any other tuple <code>{no_foo, ...}</code> with <code>foo</code.</p>
 %%
 %% @see get_bool/2
 %% @see substitute_aliases/2

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -56,6 +56,7 @@ MODULES= \
 	math_SUITE \
 	ms_transform_SUITE \
 	proc_lib_SUITE \
+	proplists_SUITE \
 	qlc_SUITE \
 	queue_SUITE \
 	rand_SUITE \

--- a/lib/stdlib/test/proplists_SUITE.erl
+++ b/lib/stdlib/test/proplists_SUITE.erl
@@ -1,0 +1,80 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2019. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(proplists_SUITE).
+
+-export([all/0, suite/0,groups/0, init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+	 init_per_testcase/2, end_per_testcase/2,
+         examples/1]).
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok.
+
+suite() ->
+    [{ct_hooks,[ts_install_cth]},
+     {timetrap,{minutes,5}}].
+
+all() ->
+    [examples].
+
+groups() ->
+    [].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+%% Test all examples in the documentation.
+
+examples(_Config) ->
+    [1,2,3,4] = proplists:append_values(a, [{a, [1,2]}, {b, 0}, {a, 3}, {c, -1}, {a, [4]}]),
+
+    ExpandRes = [fie, bar, baz, fum],
+    ExpandRes = proplists:expand([{foo, [bar, baz]}], [fie, foo, fum]),
+    ExpandRes = proplists:expand([{{foo, true}, [bar, baz]}], [fie, foo, fum]),
+    ExpandRes = proplists:expand([{{foo, false}, [bar, baz]}], [fie, {foo, false}, fum]),
+
+    [{foo, false}, fie, foo, fum] = proplists:expand([{{foo, true}, [bar, baz]}],
+                                                     [{foo, false}, fie, foo, fum]),
+
+    {[[a], [{b, 5}, b],[{c, 2}, {c, 3, 4}]], [{e, 1}, d]} =
+        proplists:split([{c, 2}, {e, 1}, a, {c, 3, 4}, d, {b, 5}, b], [a, b, c]),
+
+    ColorList = [{color, red}, {colour, green}, color, colour],
+    ColorListRes = [{colour, red}, {colour, green}, colour, colour],
+    ColorListRes = proplists:substitute_aliases([{color, colour}], ColorList),
+
+    NegList = [no_foo, {no_foo, true}, {no_foo, false}, {no_foo, any}, foo],
+    NegListRes = [{foo, false}, {foo, false}, foo, foo, foo],
+    NegListRes = proplists:substitute_negations([{no_foo, foo}], NegList),
+
+    ok.


### PR DESCRIPTION
According to the documentation, the following call:

    proplists:substitute_negations([{no_foo, foo}], [{no_foo, false}]).

should return `[{foo, true}]`. The actual return value is `[foo]`.

The implementation of `proplists:substitute_negations/2` calls
`proplists:property/2` to reduce the substituted items to their
minimal representation. That seems to be the intention of the
author and it makes sense.

Therefore, the documentation should be corrected.

While at it, add a minimal `proplists_SUITE` that tests all examples
in the documentation.