### PR TITLE
socket_nif: improve support for sendmsg ctrl types

### DIFF
--- a/erts/emulator/nifs/common/socket_nif.c
+++ b/erts/emulator/nifs/common/socket_nif.c
@@ -16516,8 +16516,8 @@ char* encode_cmsghdr_type(ErlNifEnv*    env,
     switch (level) {
     case SOL_SOCKET:
         switch (type) {
-#if defined(SO_TIMESTAMP)
-        case SO_TIMESTAMP:
+#if defined(SCM_TIMESTAMP)
+        case SCM_TIMESTAMP:
             *eType = esock_atom_timestamp;
             break;
 #endif
@@ -16532,10 +16532,14 @@ char* encode_cmsghdr_type(ErlNifEnv*    env,
         case SCM_CREDENTIALS:
             *eType = esock_atom_credentials;
             break;
+#elif defined(SCM_CREDS)
+        case SCM_CREDS:
+            *eType = esock_atom_credentials;
+            break;
 #endif
 
         default:
-            xres = ESOCK_STR_EINVAL;
+            *eType = MKI(env, type);
             break;
         }        
         break;
@@ -16648,7 +16652,29 @@ char* decode_cmsghdr_type(ErlNifEnv*   env,
 
     switch (level) {
     case SOL_SOCKET:
-        if (IS_NUM(env, eType)) {
+        if (IS_ATOM(env, eType)) {
+            if (COMPARE(eType, esock_atom_timestamp) == 0) {
+#if defined(SCM_TIMESTAMP)
+                *type = SCM_TIMESTAMP;
+#else
+                xres  = ESOCK_STR_EINVAL;
+#endif
+            } else if (COMPARE(eType, esock_atom_rights) == 0) {
+#if defined(SCM_RIGHTS)
+                *type = SCM_RIGHTS;
+#else
+                xres  = ESOCK_STR_EINVAL;
+#endif
+            } else if (COMPARE(eType, esock_atom_credentials) == 0) {
+#if defined(SCM_CREDENTIALS)
+                *type = SCM_CREDENTIALS;
+#elif defined(SCM_CREDS)
+                *type = SCM_CREDS;
+#else
+                xres  = ESOCK_STR_EINVAL;
+#endif
+            }
+        } else if (IS_NUM(env, eType)) {
             if (!GET_INT(env, eType, type)) {
                 *type = -1;
                 xres  = ESOCK_STR_EINVAL;
@@ -16831,8 +16857,8 @@ char* encode_cmsghdr_data_socket(ErlNifEnv*     env,
     // char* xres;
 
     switch (type) {
-#if defined(SO_TIMESTAMP)
-    case SO_TIMESTAMP:
+#if defined(SCM_TIMESTAMP)
+    case SCM_TIMESTAMP:
         {
             struct timeval* timeP = (struct timeval*) dataP;
 

--- a/erts/preloaded/src/socket.erl
+++ b/erts/preloaded/src/socket.erl
@@ -615,13 +615,16 @@
         #{level := ipv6,      type := integer(),   data := binary()}       |
         #{level := integer(), type := integer(),   data := binary()}.
 -type cmsghdr_send() :: 
-        #{level := socket,    type := integer(), data := binary()} |
-        #{level := ip,        type := tos,       data := ip_tos()  | binary()} |
-        #{level := ip,        type := ttl,       data := integer() | binary()} |
-        #{level := ip,        type := integer(), data := binary()} |
-        #{level := ipv6,      type := integer(), data := binary()} |
-        #{level := udp,       type := integer(), data := binary()} |
-        #{level := integer(), type := integer(), data := binary()}.
+        #{level := socket,    type := timestamp,   data := binary()} |
+        #{level := socket,    type := rights,      data := binary()} |
+        #{level := socket,    type := credentials, data := binary()} |
+        #{level := socket,    type := integer(),   data := binary()} |
+        #{level := ip,        type := tos,         data := ip_tos()  | binary()} |
+        #{level := ip,        type := ttl,         data := integer() | binary()} |
+        #{level := ip,        type := integer(),   data := binary()} |
+        #{level := ipv6,      type := integer(),   data := binary()} |
+        #{level := udp,       type := integer(),   data := binary()} |
+        #{level := integer(), type := integer(),   data := binary()}.
 
 
 -opaque select_tag() :: atom().


### PR DESCRIPTION
fix handling some UNIX socket cmsg_type values from erlang code:
  * timestamp <-> SCM_TIMESTAMP
  * rights <-> SCM_RIGHTS
  * credentials <-> SCM_CREDENTIALS or SCM_CREDS

'rigths' type allows passing file descriptors to another process,
which allows passing TCP sockets too, E.g.:

```
% Sender code, FD is an integer file descriptor
Ctrl = [#{level => socket, type => rights, data => <<FD:32/native>>}],
ok = socket:sendmsg(USock, #{iov => [<<"hello">>], ctrl => Ctrl}),
```

```
% Receiver side (other process)
{ok, Msg} = socket:recvmsg(U),
{ctrl := [#{level := socket, type := rights, data := Data}]} = Msg,
<<FD:32/native, Rest/binary>> = Data, % On MacOS Rest contains garbage
```