### PR TITLE
Fix return from call_time traced function

### DIFF
--- a/erts/emulator/beam/beam_bp.c
+++ b/erts/emulator/beam/beam_bp.c
@@ -743,7 +743,7 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
 
     if (bp_flags & ERTS_BPF_TIME_TRACE_ACTIVE) {
 	Eterm w;
-	erts_trace_time_call(c_p, info, bp->time);
+	ErtsCodeInfo* prev_info = erts_trace_time_call(c_p, info, bp->time);
 	w = (BeamInstr) *c_p->cp;
 	if (! (BeamIsOpCode(w, op_i_return_time_trace) ||
 	       BeamIsOpCode(w, op_return_trace) ||
@@ -759,7 +759,7 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
 	    ASSERT(c_p->htop <= E && E <= c_p->hend);
 
 	    E -= 2;
-	    E[0] = make_cp(erts_codeinfo_to_code(info));
+	    E[0] = prev_info ? make_cp(erts_codeinfo_to_code(prev_info)) : NIL;
 	    E[1] = make_cp(c_p->cp);     /* original return address */
 	    c_p->cp = beam_return_time_trace;
 	    c_p->stop = E;
@@ -1048,7 +1048,7 @@ do_call_trace(Process* c_p, ErtsCodeInfo* info, Eterm* reg,
     return tracer;
 }
 
-void
+ErtsCodeInfo*
 erts_trace_time_call(Process* c_p, ErtsCodeInfo *info, BpDataTime* bdt)
 {
     ErtsMonotonicTime time;
@@ -1057,6 +1057,7 @@ erts_trace_time_call(Process* c_p, ErtsCodeInfo *info, BpDataTime* bdt)
     bp_time_hash_t *h = NULL;
     BpDataTime *pbdt = NULL;
     Uint32 six = acquire_bp_sched_ix(c_p);
+    ErtsCodeInfo* prev_info;
 
     ASSERT(c_p);
     ASSERT(erts_atomic32_read_acqb(&c_p->state) & (ERTS_PSFLG_RUNNING
@@ -1078,8 +1079,9 @@ erts_trace_time_call(Process* c_p, ErtsCodeInfo *info, BpDataTime* bdt)
 	/* First call of process to instrumented function */
 	pbt = Alloc(sizeof(process_breakpoint_time_t));
 	(void) ERTS_PROC_SET_CALL_TIME(c_p, pbt);
-    } else {
-	ASSERT(pbt->ci);
+        pbt->ci = NULL;
+    }
+    else if (pbt->ci) {
 	/* add time to previous code */
 	sitem.time = time - pbt->time;
 	sitem.pid = c_p->common.id;
@@ -1103,6 +1105,7 @@ erts_trace_time_call(Process* c_p, ErtsCodeInfo *info, BpDataTime* bdt)
 	    }
 	}
     }
+    /*else caller is not call_time traced */
 
     /* Add count to this code */
     sitem.pid     = c_p->common.id;
@@ -1123,14 +1126,16 @@ erts_trace_time_call(Process* c_p, ErtsCodeInfo *info, BpDataTime* bdt)
 	BP_TIME_ADD(item, &sitem);
     }
 
+    prev_info = pbt->ci;
     pbt->ci = info;
     pbt->time = time;
 
     release_bp_sched_ix(six);
+    return prev_info;
 }
 
 void
-erts_trace_time_return(Process *p, ErtsCodeInfo *ci)
+erts_trace_time_return(Process *p, ErtsCodeInfo *prev_info)
 {
     ErtsMonotonicTime time;
     process_breakpoint_time_t *pbt = NULL;
@@ -1188,7 +1193,7 @@ erts_trace_time_return(Process *p, ErtsCodeInfo *ci)
 
 	}
 
-	pbt->ci = ci;
+	pbt->ci = prev_info;
 	pbt->time = time;
 
     }
@@ -1451,24 +1456,26 @@ void erts_schedule_time_break(Process *p, Uint schedule) {
 	     * the previous breakpoint.
 	     */
 
-	    pbdt = get_time_break(pbt->ci);
-	    if (pbdt) {
-		sitem.time = get_mtime(p) - pbt->time;
-		sitem.pid   = p->common.id;
-		sitem.count = 0;
+            if (pbt->ci) {
+                pbdt = get_time_break(pbt->ci);
+                if (pbdt) {
+                    sitem.time = get_mtime(p) - pbt->time;
+                    sitem.pid   = p->common.id;
+                    sitem.count = 0;
 
-		h = &(pbdt->hash[six]);
+                    h = &(pbdt->hash[six]);
 
-		ASSERT(h);
-		ASSERT(h->item);
+                    ASSERT(h);
+                    ASSERT(h->item);
 
-		item = bp_hash_get(h, &sitem);
-		if (!item) {
-		    item = bp_hash_put(h, &sitem);
-		} else {
-		    BP_TIME_ADD(item, &sitem);
-		}
-	    }
+                    item = bp_hash_get(h, &sitem);
+                    if (!item) {
+                        item = bp_hash_put(h, &sitem);
+                    } else {
+                        BP_TIME_ADD(item, &sitem);
+                    }
+                }
+            }
 	    break;
 	case ERTS_BP_CALL_TIME_SCHEDULE_IN :
 	    /* When a process is scheduled _in_,
@@ -1686,33 +1693,8 @@ bp_time_unref(BpDataTime* bdt)
 {
     if (erts_refc_dectest(&bdt->refc, 0) <= 0) {
 	Uint i = 0;
-	Uint j = 0;
-	Process *h_p = NULL;
-	bp_data_time_item_t* item = NULL;
-	process_breakpoint_time_t* pbt = NULL;
-
-	/* remove all psd associated with the hash
-	 * and then delete the hash.
-	 * ... sigh ...
-	 */
 
 	for (i = 0; i < bdt->n; ++i) {
-	    if (bdt->hash[i].used) {
-		for (j = 0; j < bdt->hash[i].n; ++j) {
-		    item = &(bdt->hash[i].item[j]);
-		    if (item->pid != NIL) {
-			h_p = erts_pid2proc(NULL, 0, item->pid,
-					    ERTS_PROC_LOCK_MAIN);
-			if (h_p) {
-			    pbt = ERTS_PROC_SET_CALL_TIME(h_p, NULL);
-			    if (pbt) {
-				Free(pbt);
-			    }
-			    erts_proc_unlock(h_p, ERTS_PROC_LOCK_MAIN);
-			}
-		    }
-		}
-	    }
 	    bp_hash_delete(&(bdt->hash[i]));
 	}
 	Free(bdt->hash);

--- a/erts/emulator/beam/beam_bp.h
+++ b/erts/emulator/beam/beam_bp.h
@@ -157,7 +157,7 @@ int erts_is_native_break(ErtsCodeInfo *ci);
 int erts_is_count_break(ErtsCodeInfo *ci, Uint *count_ret);
 int erts_is_time_break(Process *p, ErtsCodeInfo *ci, Eterm *call_time);
 
-void erts_trace_time_call(Process* c_p, ErtsCodeInfo *ci, BpDataTime* bdt);
+ErtsCodeInfo* erts_trace_time_call(Process* c_p, ErtsCodeInfo *ci, BpDataTime* bdt);
 void erts_trace_time_return(Process* c_p, ErtsCodeInfo *ci);
 void erts_schedule_time_break(Process *p, Uint out);
 void erts_set_time_break(BpFunctions *f, enum erts_break_op);

--- a/erts/emulator/beam/trace_instrs.tab
+++ b/erts/emulator/beam/trace_instrs.tab
@@ -45,9 +45,10 @@ i_generic_breakpoint() {
 }
 
 i_return_time_trace() {
-    BeamInstr *pc = (BeamInstr *) (UWord) E[0];
+    ErtsCodeInfo *cinfo = (!is_CP(E[0]) ? NULL
+                           : erts_code_to_codeinfo((BeamInstr*)E[0]));
     SWAPOUT;
-    erts_trace_time_return(c_p, erts_code_to_codeinfo(pc));
+    erts_trace_time_return(c_p, cinfo);
     SWAPIN;
     c_p->cp = NULL;
     SET_I((BeamInstr *) cp_val(E[1]));

--- a/erts/emulator/test/trace_call_time_SUITE.erl
+++ b/erts/emulator/test/trace_call_time_SUITE.erl
@@ -34,7 +34,8 @@
 %% Exported end user tests
 
 -export([seq/3, seq_r/3]).
--export([loaded/1, a_function/1, a_called_function/1, dec/1, nif_dec/1, dead_tracer/1]).
+-export([loaded/1, a_function/1, a_called_function/1, dec/1, nif_dec/1, dead_tracer/1,
+        return_stop/1]).
 
 -define(US_ERROR, 10000).
 -define(R_ERROR, 0.8).
@@ -64,6 +65,7 @@
 -export([all/0, suite/0,
 	 init_per_testcase/2, end_per_testcase/2, not_run/1]).
 -export([basic/1, on_and_off/1, info/1,
+         disable_ongoing/1,
 	 pause_and_restart/1, scheduling/1, called_function/1, combo/1, 
 	 bif/1, nif/1]).
 
@@ -88,7 +90,8 @@ all() ->
 	true -> [not_run];
 	false ->
 	    [basic, on_and_off, info, pause_and_restart, scheduling,
-	     combo, bif, nif, called_function, dead_tracer]
+             disable_ongoing,
+	     combo, bif, nif, called_function, dead_tracer, return_stop]
     end.
 
 not_run(Config) when is_list(Config) ->
@@ -116,6 +119,56 @@ basic(Config) when is_list(Config) ->
     P = erlang:trace_pattern({'_','_','_'}, false, [call_time]),
     Pid ! quit,
     ok.
+
+%% Tests disable ongoing call_time traced function
+disable_ongoing(Config) when is_list(Config) ->
+    P = erlang:trace_pattern({'_','_','_'}, false, [call_time]),
+    %%
+    1 = erlang:trace_pattern({?MODULE,disong_a, 1}, true, [call_time]),
+    1 = erlang:trace_pattern({?MODULE,disong_b, 1}, true, [call_time]),
+    1 = erlang:trace_pattern({?MODULE,disong_c, 1}, true, [call_time]),
+    1 = erlang:trace_pattern({?MODULE,disong_d, 0}, true, [call_time]),
+
+    Pid = setup(),
+
+    Self = self(),
+    Pid  ! {self(), execute, fun() -> disong_a(Self) end},
+
+    c_ready = receive M1 -> M1 end,
+
+    1 = erlang:trace_pattern({?MODULE,disong_b,1}, false, [call_time]),
+
+    Pid ! go_on,
+
+    {Pid, answer, _} = receive M2 -> M2
+                       after 1000 -> timeout end,
+
+    P = erlang:trace_pattern({'_','_','_'}, false, [call_time]),
+    Pid ! quit,
+    ok.
+
+disong_a(Pid) ->
+    ForceStack = id(a),
+    disong_b(Pid),
+    disong_d(),
+    ForceStack.
+
+disong_b(Pid) ->
+    ForceStack = id(b),
+    disong_c(Pid),
+    ForceStack.
+
+disong_c(Pid) ->
+    Pid ! c_ready,
+    receive
+        go_on -> ok
+    end.
+
+disong_d() ->
+    ok.
+
+id(I) ->
+    I.
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -390,8 +443,8 @@ nif(Config) when is_list(Config) ->
 
     % the nif is called M - 1 times, the last time the function with 'with_nif'
     % returns ok and does not call the nif.
-    ok = check_trace_info({?MODULE, nif_dec,  1}, [{Pid, M-1, 0, 0}], T1/5*4),
-    ok = check_trace_info({?MODULE, with_nif, 1}, [{Pid, M, 0, 0}], T1/5),
+    ok = check_trace_info({?MODULE, nif_dec,  1}, [{Pid, M-1, 0, 0}], T1/2),
+    ok = check_trace_info({?MODULE, with_nif, 1}, [{Pid, M, 0, 0}], T1/2),
 
     %%
     P = erlang:trace_pattern({'_','_','_'}, false, [call_time]),
@@ -512,9 +565,58 @@ collect_all_info([MFA|T]) ->
     end;
 collect_all_info([]) -> [].
 
-%%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%% The Tests
-%%%
+
+%% OTP-16111: Verify call_time does not increase after traced function returns.
+return_stop(_Config) ->
+    P = erlang:trace_pattern({'_','_','_'}, false, [call_time]),
+    %%
+    1 = erlang:trace_pattern({?MODULE,aaa,  '_'}, true, [call_time]),
+    1 = erlang:trace_pattern({?MODULE,bbb,  '_'}, true, [call_time]),
+    Pid = setup(),
+    {aaa, T1} = execute(Pid, fun() -> aaa()  end),
+    {call_time, [{Pid, 1, 0, US1}]} = erlang:trace_info({?MODULE,aaa,0}, call_time),
+    io:format("T1=~p us, US1=~p us\n", [T1, US1]),
+    true = (US1 =< T1),
+
+    {call_time, [{Pid, 1, 0, US1}]} = erlang:trace_info({?MODULE,aaa,0}, call_time),
+
+    execute(Pid, fun() -> loaded(1000000)  end),
+    {call_time, [{Pid, 1, 0, US1}]} = erlang:trace_info({?MODULE,aaa,0}, call_time),
+
+    {bbb,  _} = execute(Pid, fun() -> bbb()  end),
+    {call_time, [{Pid, 1, 0, US1}]} = erlang:trace_info({?MODULE,aaa,0}, call_time),
+
+    1 = erlang:trace_pattern({?MODULE,spinner,  1}, true, [call_time]),
+    1 = erlang:trace_pattern({?MODULE,quicky,  0}, true, [call_time]),
+    {spinner,  T2} = execute(Pid, fun() -> spinner(1000000)  end),
+    {call_time, [{Pid, 1, SpS, SpUS}]} = erlang:trace_info({?MODULE,spinner,1}, call_time),
+    Spinner = SpS*1000000 + SpUS,
+    {call_time, [{Pid, 1, 0, Quicky}]} = erlang:trace_info({?MODULE,quicky,0}, call_time),
+    io:format("T2=~p us, Spinner=~p us, Quicky=~p us\n", [T2, Spinner, Quicky]),
+
+    %% Before fix: quicky() got attributed the call_time of its caller spinner().
+    true = (Quicky =< Spinner),
+    true = (Spinner =< T2),
+
+    %%
+    P = erlang:trace_pattern({'_','_','_'}, false, [call_time]),
+    Pid ! quit,
+    ok.
+
+
+aaa() ->
+    aaa.
+bbb() ->
+   bbb.
+
+spinner(N) ->
+    quicky(),
+    loaded(N),
+    spinner.
+
+quicky() ->
+    done.
+
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
https://bugs.erlang.org/browse/ERL-1027

The active call_time traced function for a process
was not reset correctly when returning from a call_time traced function.


