### PR TITLE
crypto: Used EVP_aes_192_cfb8, EVP_aes_256_cfb8, EVP_aes_192_cfb128 and

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -475,8 +475,6 @@ static ERL_NIF_TERM hmac_update_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM
 static ERL_NIF_TERM hmac_final_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM cmac_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM block_crypt_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
-static ERL_NIF_TERM aes_cfb_8_crypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
-static ERL_NIF_TERM aes_cfb_128_crypt_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM aes_ige_crypt_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM aes_ctr_stream_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM aes_ctr_stream_encrypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
@@ -832,8 +830,12 @@ static struct cipher_type_t cipher_types[] =
     {{"aes_cbc"}, {&EVP_aes_256_cbc}, 32},
     {{"aes_cbc128"}, {&EVP_aes_128_cbc}},
     {{"aes_cbc256"}, {&EVP_aes_256_cbc}},
-    {{"aes_cfb8"}, {&EVP_aes_128_cfb8}},
-    {{"aes_cfb128"}, {&EVP_aes_128_cfb128}},
+    {{"aes_cfb8"}, {&EVP_aes_128_cfb8}, 16},
+    {{"aes_cfb8"}, {&EVP_aes_192_cfb8}, 24},
+    {{"aes_cfb8"}, {&EVP_aes_256_cfb8}, 32},
+    {{"aes_cfb128"}, {&EVP_aes_128_cfb128}, 16},
+    {{"aes_cfb128"}, {&EVP_aes_192_cfb128}, 24},
+    {{"aes_cfb128"}, {&EVP_aes_256_cfb128}, 32},
     {{"aes_ecb"}, {&EVP_aes_128_ecb}, 16},
     {{"aes_ecb"}, {&EVP_aes_192_ecb}, 24},
     {{"aes_ecb"}, {&EVP_aes_256_ecb}, 32},
@@ -1963,21 +1965,6 @@ static ERL_NIF_TERM block_crypt_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM
         return enif_raise_exception(env, atom_notsup);
     }
 
-    if (argv[0] == atom_aes_cfb8
-        && (key.size == 24 || key.size == 32)) {
-        /* Why do EVP_CIPHER_CTX_set_key_length() fail on these key sizes?
-         * Fall back on low level API
-         */
-        return aes_cfb_8_crypt(env, argc-1, argv+1);
-    }
-    else if (argv[0] == atom_aes_cfb128
-        && (key.size == 24 || key.size == 32)) {
-        /* Why do EVP_CIPHER_CTX_set_key_length() fail on these key sizes?
-         * Fall back on low level API
-         */
-        return aes_cfb_128_crypt_nif(env, argc-1, argv+1);
-   }
-
     ivec_size  = EVP_CIPHER_iv_length(cipher);
 
 #ifdef HAVE_ECB_IVEC_BUG
@@ -2022,58 +2009,6 @@ static ERL_NIF_TERM block_crypt_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM
     EVP_CIPHER_CTX_free(ctx);
     CONSUME_REDS(env, text);
 
-    return ret;
-}
-
-static ERL_NIF_TERM aes_cfb_8_crypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{/* (Key, IVec, Data, IsEncrypt) */
-     ErlNifBinary key, ivec, text;
-     AES_KEY aes_key;
-     unsigned char ivec_clone[16]; /* writable copy */
-     int new_ivlen = 0;
-     ERL_NIF_TERM ret;
-
-     CHECK_NO_FIPS_MODE();
-
-     if (!enif_inspect_iolist_as_binary(env, argv[0], &key)
-         || !(key.size == 16 || key.size == 24 || key.size == 32)
-         || !enif_inspect_binary(env, argv[1], &ivec) || ivec.size != 16
-         || !enif_inspect_iolist_as_binary(env, argv[2], &text)) {
-         return enif_make_badarg(env);
-     }
-
-     memcpy(ivec_clone, ivec.data, 16);
-     AES_set_encrypt_key(key.data, key.size * 8, &aes_key);
-     AES_cfb8_encrypt((unsigned char *) text.data,
-                      enif_make_new_binary(env, text.size, &ret),
-                      text.size, &aes_key, ivec_clone, &new_ivlen,
-                      (argv[3] == atom_true));
-     CONSUME_REDS(env,text);
-     return ret;
-}
-
-static ERL_NIF_TERM aes_cfb_128_crypt_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{/* (Key, IVec, Data, IsEncrypt) */
-    ErlNifBinary key, ivec, text;
-    AES_KEY aes_key;
-    unsigned char ivec_clone[16]; /* writable copy */
-    int new_ivlen = 0;
-    ERL_NIF_TERM ret;
-
-    if (!enif_inspect_iolist_as_binary(env, argv[0], &key)
-        || !(key.size == 16 || key.size == 24 || key.size == 32)
-        || !enif_inspect_binary(env, argv[1], &ivec) || ivec.size != 16
-        || !enif_inspect_iolist_as_binary(env, argv[2], &text)) {
-        return enif_make_badarg(env);
-    }
-
-    memcpy(ivec_clone, ivec.data, 16);
-    AES_set_encrypt_key(key.data, key.size * 8, &aes_key);
-    AES_cfb128_encrypt((unsigned char *) text.data,
-                       enif_make_new_binary(env, text.size, &ret),
-                       text.size, &aes_key, ivec_clone, &new_ivlen,
-                       (argv[3] == atom_true));
-    CONSUME_REDS(env,text);
     return ret;
 }
 


### PR DESCRIPTION
Cisco's latest version of the ConfD product (7.2) has support for using the FIPS crypto mode of OTP 20. Among other crypto functions, we use the AES CFB128 crypto with 128 and 256 bit keys.
There is a FIPS related bug in how you handle 192 and 256 bit keys, where you implement those with the lower level API, which is not FIPS compliant.

Instead, I believe that you should use the EVP level API for those key sizes as well, for the sake of FIPS compliance as demonstrated by this patch.

In later versions of crypto - e.g. 
https://github.com/erlang/otp/commit/a4cff5acd6045cc6022b0b1cf017a0a2a0c40965?diff=split
and https://github.com/erlang/otp/blob/master/lib/crypto/c_src/cipher.c 

you removed FIPS support for all AES cfb cryptos (all shifts and all key sizes). I do not know why you did so, but reading https://www.openssl.org/docs/fips/UserGuide-2.0.pdf  - e.g. "OVERVIEW
The OpenSSL FIPS Object Module must be built with the fips config option. The application must call FIPS_mode_set() to enable FIPS mode. When in FIPS mode only the FIPS approved encryption algorithms are usable: +RSA +DSA +3DES in CBC, (CFB1), CFB8, CFB64, ECB, OFB modes +DH +AES in CBC, (CFB1), CFB8, CFB128, ECB, OFB modes with 128/192/256 bit keys +SHA-1, SHA-2 +HMAC Other non-FIPS approved algorithms such a Blowfish, MD5, IDEA, RC4, etc. are disabled in FIPS mode."

I believe that the AES cfb cryptos should be available with FIPS mode enabled.