### PR TITLE
dialyzer: Remove GNU licence from test data

### DIFF
--- a/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_common.hrl
+++ b/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_common.hrl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2013 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_gen.erl
+++ b/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_gen.erl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2015 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_internal.hrl
+++ b/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_internal.hrl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2016 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_types.erl
+++ b/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_types.erl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2013 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_typeserver.erl
+++ b/lib/dialyzer/test/behaviour_SUITE_data/src/proper/proper_typeserver.erl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2016 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_common.hrl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_common.hrl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2013 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_gen.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_gen.erl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2013 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_internal.hrl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_internal.hrl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2013 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_types.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_types.erl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2013 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_typeserver.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/proper/proper_typeserver.erl
@@ -4,18 +4,18 @@
 %%%
 %%% This file is part of PropEr.
 %%%
-%%% PropEr is free software: you can redistribute it and/or modify
-%%% it under the terms of the GNU General Public License as published by
-%%% the Free Software Foundation, either version 3 of the License, or
-%%% (at your option) any later version.
 %%%
-%%% PropEr is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-%%% GNU General Public License for more details.
 %%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
+%%%
 
 %%% @copyright 2010-2015 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}

--- a/lib/dialyzer/test/options1_SUITE_data/src/compiler/rec_env.erl
+++ b/lib/dialyzer/test/options1_SUITE_data/src/compiler/rec_env.erl
@@ -1,18 +1,18 @@
 %% =====================================================================
-%% This library is free software; you can redistribute it and/or modify
-%% it under the terms of the GNU Lesser General Public License as
-%% published by the Free Software Foundation; either version 2 of the
-%% License, or (at your option) any later version.
 %%
-%% This library is distributed in the hope that it will be useful, but
-%% WITHOUT ANY WARRANTY; without even the implied warranty of
-%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-%% Lesser General Public License for more details.
 %%
-%% You should have received a copy of the GNU Lesser General Public
-%% License along with this library; if not, write to the Free Software
-%% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-%% USA
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
 %%
 %% $Id: rec_env.erl,v 1.2 2009/09/17 09:46:19 kostis Exp $
 %%

--- a/lib/dialyzer/test/small_SUITE_data/src/cerl_hipeify.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/cerl_hipeify.erl
@@ -1,18 +1,18 @@
 %% =====================================================================
-%% This library is free software; you can redistribute it and/or modify
-%% it under the terms of the GNU Lesser General Public License as
-%% published by the Free Software Foundation; either version 2 of the
-%% License, or (at your option) any later version.
 %%
-%% This library is distributed in the hope that it will be useful, but
-%% WITHOUT ANY WARRANTY; without even the implied warranty of
-%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-%% Lesser General Public License for more details.
 %%
-%% You should have received a copy of the GNU Lesser General Public
-%% License along with this library; if not, write to the Free Software
-%% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-%% USA
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
+%%
 %%
 %% $Id: cerl_hipeify.erl,v 1.1 2008/12/17 09:53:49 mikpe Exp $
 %%


### PR DESCRIPTION
We're doing this as to simplify some administration.