### PR TITLE
fix: gen_server:reply/2

### DIFF
--- a/lib/kernel/src/global.erl
+++ b/lib/kernel/src/global.erl
@@ -909,7 +909,7 @@ handle_info({nodeup, Node}, S0) when S0#state.connect_all ->
     end;
 
 handle_info({whereis, Name, From}, S) ->
-    do_whereis(Name, From),
+    _ = do_whereis(Name, From),
     {noreply, S};
 
 handle_info(known, S) ->

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -307,12 +307,11 @@ gen_server:abcast     -----> Module:handle_cast/2
     </func>
 
     <func>
-      <name since="">reply(Client, Reply) -> Result</name>
+      <name since="">reply(Client, Reply) -> ok</name>
       <fsummary>Send a reply to a client.</fsummary>
       <type>
         <v>Client - see below</v>
         <v>Reply = term()</v>
-        <v>Result = term()</v>
       </type>
       <desc>
         <p>This function can be used by a <c>gen_server</c> process to
@@ -326,8 +325,6 @@ gen_server:abcast     -----> Module:handle_cast/2
           the callback function. <c>Reply</c> is any term
           given back to the client as the return value of
           <c>call/2,3</c> or <c>multi_call/2,3,4</c>.</p>
-        <p>The return value <c>Result</c> is not further defined, and
-          is always to be ignored.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -249,7 +249,8 @@ cast_msg(Request) -> {'$gen_cast',Request}.
 %% Send a reply to the client.
 %% -----------------------------------------------------------------
 reply({To, Tag}, Reply) ->
-    catch To ! {Tag, Reply}.
+    catch To ! {Tag, Reply},
+    ok.
 
 %% ----------------------------------------------------------------- 
 %% Asynchronous broadcast, returns nothing, it's just send 'n' pray


### PR DESCRIPTION
Related to  [discussion](https://github.com/erlang/otp/pull/2375#issuecomment-539514080) we had about adding type specs to `gen_server`.