### PR TITLE
erts/socket: [ERL-1061]  Fix a bug which segfault in nif_open

### DIFF
--- a/erts/emulator/nifs/common/socket_nif.c
+++ b/erts/emulator/nifs/common/socket_nif.c
@@ -4766,9 +4766,10 @@ ERL_NIF_TERM nif_open(ErlNifEnv*         env,
 #if defined(__WIN32__)
     return enif_raise_exception(env, MKA(env, "notsup"));
 #else
-    int          edomain, etype, eproto;
+    int          edomain, etype;
     int          domain, type, proto;
     char*        netns;
+    ERL_NIF_TERM eproto;
     ERL_NIF_TERM emap;
     ERL_NIF_TERM result;
 


### PR DESCRIPTION
If specified `raw` and `{raw, integer}` as arguments in open/3, segfault occurs in nif_open. This PR is in order to can be avoided this issue.

This is a proposed fix for [ERL-1061](https://bugs.erlang.org/browse/ERL-1061).
