### PR TITLE
Fix failure to build OTP on macOS Catalina (10.15)

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1005,6 +1005,18 @@ case "${host}:${GCC}" in
 esac
 
 
+case $host_os in
+        darwin19*)
+	    # Disable stack checking to avoid crashing with a segment fault
+	    # in macOS Catalina.
+	    AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)])
+	    CFLAGS="-fno-stack-check $CFLAGS"
+	    ;;
+        *)
+	    ;;
+esac
+
+
 dnl ----------------------------------------------------------------------
 dnl Checks for libraries.
 dnl ----------------------------------------------------------------------


### PR DESCRIPTION
The build of Erlang/OTP crashes on macOS Catalina (10.15).

The reason is that the default for stack checks have changed. Stack
checks are now on by default (when the target is macOS 10.15 or
later). They used to be off by default. There seems to be some
pre-existing bug in Clang so that it could generate code that crashes
when stack checks are turned on. If stack checks are turned on when
compiling for macOS 10.14 (Mojave), the build will crash in the same
way.

This commit turns off stack checks when building Erlang/OTP on
macOS Catalina.

Here are some useful links I found while investigating this issue:

https://forums.developer.apple.com/thread/121887
https://code.videolan.org/videolan/libbluray/issues/20

https://bugs.erlang.org/browse/ERL-1063