### PR TITLE
Emacs erlang-mode: Improve functionality for displaying an Erlang/OTP function's documenation

### DIFF
--- a/lib/tools/emacs/erlang-eunit.el
+++ b/lib/tools/emacs/erlang-eunit.el
@@ -22,7 +22,7 @@
 ;;; Author: Klas Johansson
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 (require 'erlang)
 
 (defvar erlang-eunit-src-candidate-dirs '("../src" ".")
@@ -319,7 +319,7 @@ With prefix arg, compiles for debug and runs tests with the verbose flag set."
     ;; instead of possibly several: one for each file to compile,
     ;; for instance for both x.erl and x_tests.erl.
     (save-some-buffers erlang-eunit-autosave)
-    (flet ((save-some-buffers (&optional any) nil))
+    (cl-letf (((symbol-function 'save-some-buffers) #'ignore))
 
       ;; Compilation of the source file is mandatory (the file must
       ;; exist, otherwise the procedure is aborted).  Compilation of the

--- a/lib/tools/emacs/erlang-flymake.el
+++ b/lib/tools/emacs/erlang-flymake.el
@@ -22,7 +22,7 @@
 
 (require 'flymake)
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (defvar erlang-flymake-command
   "erlc"
@@ -68,7 +68,7 @@ check on newline and when there are no changes)."
 
 (defun erlang-flymake-init ()
   (let* ((temp-file
-          (flet ((flymake-get-temp-dir () (erlang-flymake-temp-dir)))
+          (cl-letf (((symbol-function 'flymake-get-temp-dir) #'erlang-flymake-temp-dir))
             (flymake-init-create-temp-buffer-copy
              'flymake-create-temp-with-folder-structure)))
          (code-dir-opts

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -1934,7 +1934,15 @@ The format is described in the documentation of `erlang-man-dirs'."
          (("Error! Why?" erlang-man-describe-error)))))))
 
 (defun erlang-man-dir (subdir)
-  (concat erlang-root-dir "/lib/erlang/" subdir))
+  (let ((default_man_dir (concat (file-name-as-directory erlang-root-dir)
+                                 (file-name-as-directory "lib")
+                                 (file-name-as-directory "erlang") subdir)))
+    (if (or (equal erlang-root-dir nil) (file-directory-p default_man_dir))
+        default_man_dir
+      (concat (file-name-as-directory erlang-root-dir) subdir)
+      )
+    )
+  )
 
 ;; Should the menu be to long, let's split it into a number of
 ;; smaller menus.  Warning, this code contains beautiful

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -2006,12 +2006,11 @@ erlang-man-download downloads the man pages without prompting the
 user."
   (interactive)
   (if (y-or-n-p "Could not find Erlang man pages on your system. Do you want to download them?")
-      (let ((download-url (read-string "URL to download man pages from:" erlang-man-download-url)))
+      (let ((download-url (read-string "URL to download man pages from: " erlang-man-download-url)))
         (concat (directory-file-name (erlang-man-download download-url)) (or subdir "")))))
 
 
-(defun erlang-man-dir (subdir &optional no_download)
-  (message subdir)
+(defun erlang-man-dir (subdir &optional no-download)
   (let ((default-man-dir (if erlang-root-dir
                              (concat (directory-file-name (concat
                                                            (file-name-as-directory erlang-root-dir)
@@ -2027,7 +2026,7 @@ user."
           alt-man-dir
         (if (file-directory-p downloaded-man-dir)
             (concat (directory-file-name downloaded-man-dir) subdir)
-          (and (not no_download) (erlang-man-download-ask subdir)))))))
+          (and (not no-download) (erlang-man-download-ask subdir)))))))
 
 ;; Should the menu be to long, let's split it into a number of
 ;; smaller menus.  Warning, this code contains beautiful

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -2161,12 +2161,18 @@ command is executed asynchronously."
               (set-buffer buf)
               (goto-char (point-min))
               (if (re-search-forward
-                   (concat "^[ \t]+" func " ?(")
+                   (concat "^[ \t]*\\([a-z0-9_]*[ \t]*:\\)?[ \t]*" func "[ \t]*([A-Za-z0-9 \t:,_()]*)[ \t]*->")
                    (point-max) t)
                   (progn
                     (forward-word -1)
                     (set-window-point win (point)))
-                (message "Could not find function `%s'" func)))))))
+                (if (re-search-forward
+                     (concat "^[ \t]*\\([a-z0-9_]*[ \t]*:\\)?[ \t]*" func "[ \t]*\(")
+                     (point-max) t)
+                    (progn
+                      (forward-word -1)
+                      (set-window-point win (point)))
+                  (message "Could not find function `%s'" func))))))))
 
 (defvar erlang-man-file-regexp
   "\\(.*\\)/man[^/]*/\\([^.]+\\)\\.\\([124-9]\\|3\\(erl\\)?\\)\\(\\.gz\\)?$")

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -4,8 +4,8 @@
 ;; Author:   Anders Lindgren
 ;; Keywords: erlang, languages, processes
 ;; Date:     2011-12-11
-;; Version:  2.8.2
-;; Package-Requires: ((emacs "24.1"))
+;; Version:  2.8.3
+;; Package-Requires: ((emacs "24.3"))
 
 ;; %CopyrightBegin%
 ;;
@@ -87,7 +87,7 @@
   "The Erlang programming language."
   :group 'languages)
 
-(defconst erlang-version "2.8.2"
+(defconst erlang-version "2.8.3"
   "The version number of Erlang mode.")
 
 (defcustom erlang-root-dir nil

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -2104,6 +2104,22 @@ This function is aware of imported functions."
              (erlang-man-find-function (current-buffer) funcname))))))
 
 
+(defun erlang-man-function-no-prompt ()
+    "Find manual page for the function under the cursor.
+The man entry for `function' is displayed.  This function
+provides the same functionality as erlang-man-function except for
+that it does not ask the user to confirm the function name before
+opening the man page for the function."
+  (interactive)
+  (progn
+    (erlang-man-function (erlang-default-function-or-module))
+    (sleep-for 0 800) ; A hack to make sure that the function scrolls
+                      ; to the description of the function when it is
+                      ; the first time that the man page for a module
+                      ; is opened
+    (erlang-man-function (erlang-default-function-or-module))
+    ))
+
 ;; Should the defadvice be at the top level, the package `advice' would
 ;; be required.  Now it is only required when this functionality
 ;; is used.  (Emacs 19 specific.)


### PR DESCRIPTION
The Emacs erlang-mode has a feature that lets the user open the documentation for an Erlang/OTP function in an Emacs buffer. This functionality has not worked correctly with recent versions of Emacs and Erlang. The wrong path was searched for man pages, and the Emacs buffer with the man page would often not scroll to the description of the function automatically. This change fixes these issues and makes this functionality more convenient by asking the user if the man pages should be downloaded automatically by Emacs when they can't be found on the system. To try out this functionality, put the cursor over the function name in a call to an Erlang/OTP function (e.g., "io:format("arg")") and type C-c C-d (i.e., Ctrl-key and c-key and then Ctrl-key and d-key). There is also a new menu item under the Erlang menu (labeled "Man - Function Under Cursor") that should make this functionality more visible.