### PR TITLE
Allow specifying start location for epp:parse_file/2 and open/1 

### DIFF
--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -164,10 +164,10 @@ scan_erl_form(Epp) ->
 
 -spec parse_erl_form(Epp) ->
     {'ok', AbsForm} | {error, ErrorInfo} |
-    {'warning',WarningInfo} | {'eof',Line} when
+    {'warning',WarningInfo} | {'eof',Loc} when
       Epp :: epp_handle(),
       AbsForm :: erl_parse:abstract_form(),
-      Line :: erl_anno:line(),
+      Loc :: erl_anno:location(),
       ErrorInfo :: erl_scan:error_info() | erl_parse:error_info(),
       WarningInfo :: warning_info().
 
@@ -238,9 +238,9 @@ format_error(E) -> file:format_error(E).
                 {'ok', [Form]} | {error, OpenError} when
       FileName :: file:name(),
       IncludePath :: [DirectoryName :: file:name()],
-      Form :: erl_parse:abstract_form() | {'error', ErrorInfo} | {'eof',Line},
+      Form :: erl_parse:abstract_form() | {'error', ErrorInfo} | {'eof',Loc},
       PredefMacros :: macros(),
-      Line :: erl_anno:line(),
+      Loc :: erl_anno:location(),
       ErrorInfo :: erl_scan:error_info() | erl_parse:error_info(),
       OpenError :: file:posix() | badarg | system_limit.
 
@@ -256,8 +256,8 @@ parse_file(Ifile, Path, Predefs) ->
 		  {'default_encoding', DefEncoding :: source_encoding()} |
                   {'start_location', StartLocation :: erl_anno:location()} |
 		  'extra'],
-      Form :: erl_parse:abstract_form() | {'error', ErrorInfo} | {'eof',Line},
-      Line :: erl_anno:line(),
+      Form :: erl_parse:abstract_form() | {'error', ErrorInfo} | {'eof',Loc},
+      Loc :: erl_anno:location(),
       ErrorInfo :: erl_scan:error_info() | erl_parse:error_info(),
       Extra :: [{'encoding', source_encoding() | 'none'}],
       OpenError :: file:posix() | badarg | system_limit.
@@ -279,8 +279,8 @@ parse_file(Ifile, Options) ->
 -spec parse_file(Epp) -> [Form] when
       Epp :: epp_handle(),
       Form :: erl_parse:abstract_form() | {'error', ErrorInfo} |
-	      {'warning',WarningInfo} | {'eof',Line},
-      Line :: erl_anno:line(),
+	      {'warning',WarningInfo} | {'eof',Loc},
+      Loc :: erl_anno:location(),
       ErrorInfo :: erl_scan:error_info() | erl_parse:error_info(),
       WarningInfo :: warning_info().
 
@@ -929,8 +929,8 @@ scan_define_cont(F, #epp{macs=Ms0}=St, M, Defs, Arity, Def) ->
 	    Uses = Uses0#{M=>Val},
             scan_toks(F, St#epp{uses=Uses,macs=Ms})
     catch
-        {error, Line, Reason} ->
-            epp_reply(F, {error,{Line,epp,Reason}}),
+        {error, Loc, Reason} ->
+            epp_reply(F, {error,{Loc,epp,Reason}}),
             wait_req_scan(St)
     end.
 

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -29,7 +29,7 @@
          otp_8562/1, otp_8665/1, otp_8911/1, otp_10302/1, otp_10820/1,
          otp_11728/1, encoding/1, extends/1,  function_macro/1,
 	 test_error/1, test_warning/1, otp_14285/1,
-	 test_if/1,source_name/1]).
+	 test_if/1,source_name/1,column_numbers/1]).
 
 -export([epp_parse_erl_form/2]).
 
@@ -1714,6 +1714,15 @@ source_name(Config) when is_list(Config) ->
 source_name_1(File, Expected) ->
     Res = epp:parse_file(File, [{source_name, Expected}]),
     {ok, [{attribute,_,file,{Expected,_}} | _Forms]} = Res.
+
+column_numbers(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    File = filename:join(DataDir, "source_name.erl"),
+    Res = epp:parse_file(File, [{start_location, {1, 1}}]),
+    {ok, Forms} = Res,
+    %% all forms should have column numbers
+    {attribute, {_, 2}, module, _} = lists:keyfind(module, 3, Forms),
+    {eof, {_, 1}} = lists:last(Forms).
 
 check(Config, Tests) ->
     eval_tests(Config, fun check_test/2, Tests).


### PR DESCRIPTION
The primary goal is to get column numbers by setting start_location to {1,1}.

Specifying start location is already supported internally by epp via the
undocumented open/5 function (used by escript).

If it is not desirable to allow any start location, an alternative would
be a `{column, boolean()}` option.

(TODO: update docs)