### PR TITLE
erts: Fix missing persistent_term from erts.app

### DIFF
--- a/erts/preloaded/src/erts.app.src
+++ b/erts/preloaded/src/erts.app.src
@@ -35,6 +35,7 @@
 		prim_zip,
                 atomics,
                 counters,
+                persistent_term,
 		zlib,
 		%ESOCK_MODS%
 	    ]},


### PR DESCRIPTION
Some tools rely on the fact that the `modules` section of the .app file contains all modules. For example Elixir's `dialyxir`. Let's add the missing `persistent_term` to `erts.app.src`.