### PR TITLE
rpc do not hide throw class failures

### DIFF
--- a/lib/kernel/doc/src/rpc.xml
+++ b/lib/kernel/doc/src/rpc.xml
@@ -134,6 +134,12 @@
           <anno>Args</anno>)</c> on node <c><anno>Node</anno></c> and returns
           the corresponding value <c><anno>Res</anno></c>, or
           <c>{badrpc, <anno>Reason</anno>}</c> if the call fails.</p>
+        <p>A call that evaluates to <c>{'EXIT', _} = <anno>Reason</anno></c> is
+          considered to have failed, causing <c>{badrpc, <anno>Reason</anno>}</c>
+          to be returned.</p>
+        <p>Prior to OTP-23, if a call failed by throwing <c><anno>Reason</anno></c>,
+          <c><anno>Reason</anno></c> would be returned. In OTP-23 and later,
+          <c>{badrpc, <anno>Reason</anno>}</c> is returned.</p>
       </desc>
     </func>
 
@@ -145,6 +151,8 @@
           <anno>Args</anno>)</c> on node <c><anno>Node</anno></c> and returns
           the corresponding value <c><anno>Res</anno></c>, or
           <c>{badrpc, <anno>Reason</anno>}</c> if the call fails.
+          (See <seealso marker="#call/4"><c>call/4</c></seealso> for details
+          about failure handling.)
           <c><anno>Timeout</anno></c> is
           a time-out value in milliseconds. If the call times out,
           <c><anno>Reason</anno></c> is <c>timeout</c>.</p>

--- a/lib/kernel/test/rpc_SUITE.erl
+++ b/lib/kernel/test/rpc_SUITE.erl
@@ -408,7 +408,7 @@ called_throws(Config) when is_list(Config) ->
 				     [{args, "-pa " ++ PA}]),
     %%
     rep(fun (Tag, Call, Args) ->
-		{Tag,up} =
+		{Tag,{badrpc,up}} =
 		    {Tag,apply(rpc, Call, Args)}
 	end, N, erlang, throw, [up]),
     rep(fun (Tag, Call, Args) ->


### PR DESCRIPTION
Factor out duplicated code for evaluating user-specified function
call to new helper function.  Replace old-style catch with try-catch,
and map thrown exceptions to badrpcs.

Adjust rpc_SUITE to match the new behaviour.

Fixes ERL-1066.