### PR TITLE
Always run the core_lint pass when compiling from Core Erlang

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -597,7 +597,7 @@ passes_1([]) ->
     {".erl",[?pass(parse_module)|standard_passes()]}.
 
 pass(from_core) ->
-    {".core",[?pass(parse_core)|core_passes()]};
+    {".core",[?pass(parse_core)|core_passes(mandatory_core_lint)]};
 pass(from_asm) ->
     {".S",[?pass(beam_consult_asm)|asm_passes()]};
 pass(from_beam) ->
@@ -795,11 +795,17 @@ standard_passes() ->
      ?pass(core),
      {iff,'dcore',{listing,"core"}},
      {iff,'to_core0',{done,"core"}}
-     | core_passes()].
+     | core_passes(optional_core_lint)].
 
-core_passes() ->
+core_passes(LintOpt) ->
     %% Optimization and transforms of Core Erlang code.
-    [{iff,clint0,?pass(core_lint_module)},
+    CoreLint = case LintOpt of
+                   mandatory_core_lint ->
+                       ?pass(core_lint_module);
+                   optional_core_lint ->
+                       {iff,clint0,?pass(core_lint_module)}
+               end,
+    [CoreLint,
      {delay,
       [{unless,no_copt,
        [{core_old_inliner,fun test_old_inliner/1,fun core_old_inliner/2},

--- a/lib/compiler/test/core_SUITE_data/fun_letrec_effect.core
+++ b/lib/compiler/test/core_SUITE_data/fun_letrec_effect.core
@@ -1,4 +1,4 @@
-module 'fun_letrec_effect' ['fun_letrec_effect'/0, 'ok'/0, 'wat'/0]
+module 'fun_letrec_effect' ['fun_letrec_effect'/0, 'wat'/0]
 attributes []
 
 'fun_letrec_effect'/0 =


### PR DESCRIPTION
When compiling directly from Core Erlang code, run the `core_lint`
pass and abort if errors are found in the Core Erlang code.

https://bugs.erlang.org/browse/ERL-1065