### PR TITLE
systools: support creating start.boot in make_script and adding files to make_tar

### DIFF
--- a/lib/sasl/doc/src/systools.xml
+++ b/lib/sasl/doc/src/systools.xml
@@ -143,7 +143,7 @@
         <v>Name = string()</v>
         <v>Opt = src_tests | {path,[Dir]} | local | {variables,[Var]} | exref |
 	  {exref,[App]}] | silent | {outdir,Dir} | no_dot_erlang | no_warn_sasl |
-	  warnings_as_errors</v>
+	  warnings_as_errors | {script_name, Name}</v>
         <v>&nbsp;Dir = string()</v>
         <v>&nbsp;Var = {VarName,Prefix}</v>
         <v>&nbsp;&nbsp;VarName = Prefix = string()</v>
@@ -154,7 +154,9 @@
       </type>
       <desc>
         <p>Generates a boot script <c>Name.script</c> and its binary
-          version, the boot file <c>Name.boot</c>. The boot file
+          version, the boot file <c>Name.boot</c>, unless the <c>{script_name, ScriptName}</c>
+          option is given, in which case the names are <c>ScriptName.script</c>
+          and <c>ScriptName.boot</c>  The boot file
           specifies which code to be loaded and which applications
           to be started when the Erlang runtime system is started.
           See <seealso marker="script"><c>script(4)</c></seealso>.</p>
@@ -268,7 +270,7 @@
       <fsummary>Creates a release package.</fsummary>
       <type>
         <v>Name = string()</v>
-        <v>Opt = {dirs,[IncDir]} | {path,[Dir]} | {variables,[Var]} | {var_tar,VarTar} | {erts,Dir} | src_tests | exref | {exref,[App]} | silent | {outdir,Dir} | | no_warn_sasl | warnings_as_errors</v>
+        <v>Opt = {dirs,[IncDir]} | {path,[Dir]} | {variables,[Var]} | {var_tar,VarTar} | {erts,Dir} | src_tests | exref | {exref,[App]} | silent | {outdir,Dir} | | no_warn_sasl | warnings_as_errors | {extra_files, ExtraFiles}</v>
         <v>&nbsp;Dir = string()</v>
         <v>&nbsp;IncDir = src | include | atom()</v>
         <v>&nbsp;Var = {VarName,PreFix}</v>
@@ -279,6 +281,8 @@
         <v>Result = ok | error | {ok,Module,Warnings} | {error,Module,Error}</v>
         <v>&nbsp;Module = atom()</v>
         <v>&nbsp;Warning = Error = term()</v>
+        <v>&nbsp;ExtraFiles = [{NameInArchive, file:filename_all()}]</v>
+        <v>&nbsp;NameInArchive = string()</v>
       </type>
       <desc>
         <p>Creates a release package file <c>Name.tar.gz</c>.
@@ -311,6 +315,11 @@
           appended to the current path. Wildcard <c>*</c> is
           expanded to all matching directories.
           Example: <c>"lib/*/ebin"</c>.</p>
+        <p>If the <c>{extra_files, ExtraFiles}</c> option is given then the
+          <c>ExtraFiles</c> are added to the tarball after everything else to be
+          included has been added. The <c>ExtraFiles</c> list is a list of files
+          or directories in the same format as the <c>add_type()</c> tuple for
+          <seealso marker="stdlib:erl_tar#add-3">erl_tar:add/3,4</seealso></p>
         <p>Option <c>variables</c> can be used to specify an
           installation directory other than <c>lib</c> for some of
           the applications. If variable <c>{VarName,Prefix}</c> is

--- a/lib/sasl/src/systools_make.erl
+++ b/lib/sasl/src/systools_make.erl
@@ -1676,8 +1676,17 @@ mk_tar(Tar, RelName, Release, Appls, Flags, Path1) ->
     add_applications(Appls, Tar, Variables, Flags, false),
     add_variable_tars(Variables, Appls, Tar, Flags),
     add_system_files(Tar, RelName, Release, Path1),
-    add_erts_bin(Tar, Release, Flags).
-    
+    add_erts_bin(Tar, Release, Flags),
+    add_additional_files(Tar, Flags).
+
+add_additional_files(Tar, Flags) ->
+    case get_flag(extra_files, Flags) of
+        {extra_files, ToAdd} ->
+            [add_to_tar(Tar, From, To) || {From, To} <- ToAdd];
+        _ ->
+            ok
+    end.
+
 add_applications(Appls, Tar, Variables, Flags, Var) ->
     Res = foldl(fun({{Name,Vsn},App}, Errs) ->
 		  case catch add_appl(to_list(Name), Vsn, App,

--- a/lib/sasl/src/systools_make.erl
+++ b/lib/sasl/src/systools_make.erl
@@ -2210,6 +2210,9 @@ cas([no_module_tests | Args], X) ->
     cas(Args, X);
 cas([no_dot_erlang | Args], X) ->
     cas(Args, X);
+%% set the name of the script and boot file to create
+cas([{script_name, Name} | Args], X) when is_list(Name) ->
+    cas(Args, X);
 
 %%% ERROR --------------------------------------------------------------
 cas([Y | Args], X) ->
@@ -2290,6 +2293,9 @@ cat([no_warn_sasl | Args], X) ->
 %%% no_module_tests (kept for backwards compatibility, but ignored) ----
 cat([no_module_tests | Args], X) ->
     cat(Args, X);
+cat([{extra_files, ExtraFiles} | Args], X) when is_list(ExtraFiles) ->
+    cat(Args, X);
+
 %%% ERROR --------------------------------------------------------------
 cat([Y | Args], X) ->
     cat(Args, X++[Y]).

--- a/lib/sasl/test/systools_SUITE.erl
+++ b/lib/sasl/test/systools_SUITE.erl
@@ -57,7 +57,7 @@ all() ->
 
 groups() -> 
     [{script, [],
-      [script_options, normal_script, unicode_script, no_mod_vsn_script,
+      [script_options, normal_script, start_script, unicode_script, no_mod_vsn_script,
        wildcard_script, variable_script, abnormal_script,
        no_sasl_script, no_dot_erlang_script,
        src_tests_script, crazy_script,
@@ -66,10 +66,10 @@ groups() ->
        duplicate_modules_script,
        otp_3065_circular_dependenies, included_and_used_sort_script]},
      {tar, [],
-      [tar_options, normal_tar, no_mod_vsn_tar, system_files_tar,
+      [tar_options, relname_tar, normal_tar, no_mod_vsn_tar, system_files_tar,
        system_src_file_tar, invalid_system_files_tar, variable_tar,
        src_tests_tar, var_tar, exref_tar, link_tar, no_sasl_tar,
-       otp_9507_path_ebin]},
+       otp_9507_path_ebin, additional_files_tar]},
      {relup, [],
       [normal_relup, restart_relup, abnormal_relup, no_sasl_relup,
        no_appup_relup, bad_appup_relup, app_start_type_relup, regexp_relup
@@ -252,7 +252,7 @@ start_script(Config) when is_list(Config) ->
 
     ok = file:set_cwd(LatestDir),
 
-    ok = systools:make_script(filename:basename(LatestName), [{script_name, start}]),
+    ok = systools:make_script(filename:basename(LatestName), [{script_name, "start"}]),
     {ok, _} = read_script_file("start"),	% Check readabillity
 
     ok = file:set_cwd(OldDir),
@@ -892,7 +892,7 @@ tar_options(Config) when is_list(Config) ->
     ok.
 
 
-%% make_tar: Check normal case
+%% make_tar: Check case of start.boot
 normal_tar(Config) when is_list(Config) ->
     {ok, OldDir} = file:get_cwd(),
 
@@ -905,7 +905,7 @@ normal_tar(Config) when is_list(Config) ->
 
     ok = file:set_cwd(LatestDir),
 
-    {ok, _, []} = systools:make_script(LatestName, [silent, {path, P}]),
+    {ok, _, []} = systools:make_script(LatestName, [silent, {path, P}, {script_name, "start"}]),
     ok = systools:make_tar(LatestName, [{path, P}]),
     ok = check_tar(fname([lib,'db-2.1',ebin,'db.app']), LatestName),
     {ok, _, []} = systools:make_tar(LatestName, [{path, P}, silent]),
@@ -914,8 +914,8 @@ normal_tar(Config) when is_list(Config) ->
     ok = file:set_cwd(OldDir),
     ok.
 
-%% make_tar: Check legacy case of relname.boot
-legacy_tar(Config) when is_list(Config) ->
+%% make_tar: Check case of relname.boot
+relname_tar(Config) when is_list(Config) ->
     {ok, OldDir} = file:get_cwd(),
 
     {LatestDir, LatestName} = create_script(latest,Config),
@@ -985,6 +985,48 @@ system_files_tar(Config) ->
     {ok, _, []} = systools:make_tar(LatestName, [{path, P}, silent]),
     ok = check_tar(fname(["releases","LATEST","sys.config"]), LatestName),
     ok = check_tar(fname(["releases","LATEST","relup"]), LatestName),
+
+    ok = file:set_cwd(OldDir),
+
+    ok.
+
+%% make_tar: Check that extra_files are included in the tarball
+additional_files_tar(Config) ->
+    {ok, OldDir} = file:get_cwd(),
+
+    {LatestDir, LatestName} = create_script(latest,Config),
+
+    DataDir = filename:absname(?copydir),
+    LibDir = fname([DataDir, d_normal, lib]),
+    P = [fname([LibDir, 'db-2.1', ebin]),
+	 fname([LibDir, 'fe-3.1', ebin])],
+
+    ok = file:set_cwd(LatestDir),
+
+    %% Add dummy relup and sys.config
+    ok = file:write_file("sys.config","[].\n"),
+    ok = file:write_file("relup","{\"LATEST\",[],[]}.\n"),
+
+    %% unrelated files that must be included explicitly
+    RandomFile = "somefile",
+    ok = file:write_file(RandomFile,"hello\n"),
+
+    {ok, _, []} = systools:make_script(LatestName, [silent, {path, P}]),
+    ok = systools:make_tar(LatestName, [{path, P}]),
+    ok = check_tar(fname(["releases","LATEST","sys.config"]), LatestName),
+    ok = check_tar(fname(["releases","LATEST","relup"]), LatestName),
+    %% random file should not be in this tarball
+    {error, _} = check_tar(fname(["releases","LATEST",RandomFile]), LatestName),
+
+    RandomFilePathInTar = filename:join("releases", "LATEST", RandomFile),
+    {ok, _, []} = systools:make_tar(LatestName,
+                                    [{path, P}, silent,
+                                     {extra_files, [{RandomFile, RandomFilePathInTar}]}]),
+    ok = check_tar(fname(["releases","LATEST","sys.config"]), LatestName),
+    ok = check_tar(fname(["releases","LATEST","relup"]), LatestName),
+
+    %% random file should be in this tarball
+    ok = check_tar(fname(["releases","LATEST",RandomFile]), LatestName),
 
     ok = file:set_cwd(OldDir),
 

--- a/lib/sasl/test/systools_SUITE.erl
+++ b/lib/sasl/test/systools_SUITE.erl
@@ -1018,7 +1018,7 @@ additional_files_tar(Config) ->
     %% random file should not be in this tarball
     {error, _} = check_tar(fname(["releases","LATEST",RandomFile]), LatestName),
 
-    RandomFilePathInTar = filename:join("releases", "LATEST", RandomFile),
+    RandomFilePathInTar = filename:join(["releases", "LATEST", RandomFile]),
     {ok, _, []} = systools:make_tar(LatestName,
                                     [{path, P}, silent,
                                      {extra_files, [{RandomFile, RandomFilePathInTar}]}]),

--- a/lib/sasl/test/systools_SUITE.erl
+++ b/lib/sasl/test/systools_SUITE.erl
@@ -1011,6 +1011,12 @@ additional_files_tar(Config) ->
     RandomFile = "somefile",
     ok = file:write_file(RandomFile,"hello\n"),
 
+    TopLevelDir = "some_dir",
+    TopLevelFile = filename:join(TopLevelDir, "top_level_file"),
+
+    filelib:ensure_dir(TopLevelFile),
+    ok = file:write_file(TopLevelFile, "hello there\n"),
+
     {ok, _, []} = systools:make_script(LatestName, [silent, {path, P}]),
     ok = systools:make_tar(LatestName, [{path, P}]),
     ok = check_tar(fname(["releases","LATEST","sys.config"]), LatestName),
@@ -1019,14 +1025,17 @@ additional_files_tar(Config) ->
     {error, _} = check_tar(fname(["releases","LATEST",RandomFile]), LatestName),
 
     RandomFilePathInTar = filename:join(["releases", "LATEST", RandomFile]),
+
     {ok, _, []} = systools:make_tar(LatestName,
                                     [{path, P}, silent,
-                                     {extra_files, [{RandomFile, RandomFilePathInTar}]}]),
+                                     {extra_files, [{RandomFile, RandomFilePathInTar},
+                                                    {TopLevelDir, TopLevelDir}]}]),
     ok = check_tar(fname(["releases","LATEST","sys.config"]), LatestName),
     ok = check_tar(fname(["releases","LATEST","relup"]), LatestName),
 
-    %% random file should be in this tarball
+    %% random file and dir should be in this tarball
     ok = check_tar(fname(["releases","LATEST",RandomFile]), LatestName),
+    ok = check_tar(fname([TopLevelFile]), LatestName),
 
     ok = file:set_cwd(OldDir),
 


### PR DESCRIPTION
I'm unable to compile OTP in order to run tests so I have not confirmed these changes yet. But because that has been taking so long to figure out I'm opening this as a draft for comment. I know that documentation still needs to be updated.

`make_script` now accepts the name of the boot file to create, it is not restricted to only `RelName.boot` or `start.boot`. This is because after talking to @josevalim he pointed out that Elixir releases need to create a `start_clean.boot`. With relx we just copy the one that is found in the Erlang install but they can't do that because it needs to include iex and elixir libs.

`make_tar` will take a list the same as the list of tuples you can pass to `erl_tar`, `{From, To}`.