### PR TITLE
Fix seq_trace named remote send trace message

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1847,7 +1847,7 @@ static Sint remote_send(Process *p, DistEntry *dep,
     case ERTS_DSIG_PREP_CONNECTED: {
 
 	if (is_atom(to))
-	    code = erts_dsig_send_reg_msg(&ctx, to, msg);
+	    code = erts_dsig_send_reg_msg(&ctx, to, full_to, msg);
 	else
 	    code = erts_dsig_send_msg(&ctx, to, msg);
 	/*

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -1109,7 +1109,8 @@ erts_dsig_send_msg(ErtsDSigSendContext* ctx, Eterm remote, Eterm message)
 }
 
 int
-erts_dsig_send_reg_msg(ErtsDSigSendContext* ctx, Eterm remote_name, Eterm message)
+erts_dsig_send_reg_msg(ErtsDSigSendContext* ctx, Eterm remote_name,
+                       Eterm full_to, Eterm message)
 {
     Eterm ctl;
     Eterm token = NIL;
@@ -1127,7 +1128,7 @@ erts_dsig_send_reg_msg(ErtsDSigSendContext* ctx, Eterm remote_name, Eterm messag
     if (have_seqtrace(SEQ_TRACE_TOKEN(sender))) {
 	seq_trace_update_send(sender);
 	token = SEQ_TRACE_TOKEN(sender);
-	seq_trace_output(token, message, SEQ_TRACE_SEND, remote_name, sender);
+	seq_trace_output(token, message, SEQ_TRACE_SEND, full_to, sender);
     }
 #ifdef USE_VM_PROBES
     *node_name = *sender_name = *receiver_name = '\0';

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -283,7 +283,7 @@ typedef struct dist_sequences DistSeqNode;
 #define ERTS_DSIG_SEND_TOO_LRG  3
 
 extern int erts_dsig_send_msg(ErtsDSigSendContext*, Eterm, Eterm);
-extern int erts_dsig_send_reg_msg(ErtsDSigSendContext*, Eterm, Eterm);
+extern int erts_dsig_send_reg_msg(ErtsDSigSendContext*, Eterm, Eterm, Eterm);
 extern int erts_dsig_send_link(ErtsDSigSendContext *, Eterm, Eterm);
 extern int erts_dsig_send_exit_tt(ErtsDSigSendContext *, Eterm, Eterm, Eterm, Eterm);
 extern int erts_dsig_send_unlink(ErtsDSigSendContext *, Eterm, Eterm);

--- a/lib/kernel/doc/src/seq_trace.xml
+++ b/lib/kernel/doc/src/seq_trace.xml
@@ -257,7 +257,7 @@ TimeStamp = {Seconds, Milliseconds, Microseconds}
       <tag><c>{send, Serial, From, To, Message}</c></tag>
       <item>
         <p>Used when a process <c>From</c> with its trace token flag
-          <c>print</c> set to <c>true</c> has sent a message.</p>
+          <c>send</c> set to <c>true</c> has sent a message.</p>
       </item>
       <tag><c>{'receive', Serial, From, To, Message}</c></tag>
       <item>

--- a/lib/kernel/test/seq_trace_SUITE.erl
+++ b/lib/kernel/test/seq_trace_SUITE.erl
@@ -28,6 +28,7 @@
 -export([token_set_get/1, tracer_set_get/1, print/1,
 	 send/1, distributed_send/1, recv/1, distributed_recv/1,
 	 trace_exit/1, distributed_exit/1, call/1, port/1,
+         port_clean_token/1,
 	 match_set_seq_token/1, gc_seq_token/1, label_capability_mismatch/1,
          send_literal/1]).
 
@@ -51,6 +52,7 @@ all() ->
     [token_set_get, tracer_set_get, print, send, send_literal,
      distributed_send, recv, distributed_recv, trace_exit,
      distributed_exit, call, port, match_set_seq_token,
+     port_clean_token,
      gc_seq_token, label_capability_mismatch].
 
 groups() -> 


### PR DESCRIPTION
Send operation
`{ToName, ToNode} ! Message`
was sequence traced as
`{seq_trace, Label, {send, Serial, From, ToName, Message}}`
and is now traced as
`{seq_trace, Label, {send, Serial, From, {ToName, ToNode}, Message}`

