### PR TITLE
eunit: Allow test cases to retrieve output captured by EUnit

### DIFF
--- a/lib/eunit/doc/overview.edoc
+++ b/lib/eunit/doc/overview.edoc
@@ -277,6 +277,9 @@ while testing, you can write to the `user' output stream, as in
 `io:format(user, "~w", [Term])'. The recommended way of doing this is to
 use the EUnit {@section Debugging macros}, which make it much simpler.
 
+For checking the output produced by the unit under test, see
+{@section Macros for checking output}.
+
 === Writing test generating functions ===
 
 A drawback of simple test functions is that you must write a separate
@@ -415,6 +418,7 @@ your code is compiled with testing enabled or disabled.
 <li>{@section Compilation control macros}</li>
 <li>{@section Utility macros}</li>
 <li>{@section Assert macros}</li>
+<li>{@section Macros for checking output}</li>
 <li>{@section Macros for running external commands}</li>
 <li>{@section Debugging macros}</li>
 </ul>
@@ -605,6 +609,22 @@ Examples:
 ```?assertError(badarith, X/0)'''
 ```?assertExit(normal, exit(normal))'''
 ```?assertException(throw, {not_found,_}, throw({not_found,42}))'''
+</dd>
+</dl>
+
+=== Macros for checking output ===
+
+The following macro can be used within a test case to retreive the
+output written to standard output.
+
+<dl>
+<dt>`capturedOutput'</dt>
+<dd>The output captured by EUnit in the current test case, as a string.
+
+Examples:
+
+```io:format("Hello~n"),
+   ?assertEqual("Hello\n", ?capturedOutput)'''
 </dd>
 </dl>
 

--- a/lib/eunit/include/eunit.hrl
+++ b/lib/eunit/include/eunit.hrl
@@ -147,6 +147,16 @@
 -define(_assertNotException(Class, Term, Expr),
 	?_test(?assertNotException(Class, Term, Expr))).
 
+%% Macros for retrieving the output of a test case
+
+-ifndef(capturedOutput).
+-define(capturedOutput,
+    case ?UNDER_EUNIT of
+        true  -> eunit_proc:get_output();
+        false -> ""
+    end).
+-endif.
+
 %% Macros for running operating system commands. (Note that these
 %% require EUnit to be present at runtime, or at least eunit_lib.)
 

--- a/lib/eunit/src/eunit_tests.erl
+++ b/lib/eunit/src/eunit_tests.erl
@@ -45,3 +45,10 @@ if_test_() ->
 matches_test_() ->
     [?_assert(?MATCHES("hel"++_, "hello")),
      ?_assertNot(?MATCHES("hal"++_, "hello"))].
+
+get_output_test() ->
+    io:format(<<"Hello ~p!~n">>, [eunit]),
+    ?assertEqual("Hello eunit!\n", ?capturedOutput),
+    io:format("System working?~n~s~n", ["Seems to be."]),
+    ?assertEqual("Hello eunit!\nSystem working?\nSeems to be.\n",
+                 ?capturedOutput).


### PR DESCRIPTION
To be able to test programs or functions producing output on
standard output and to verify this output in an EUnit test
case, a new macro ?capturedOutput is defined in eunit.hrl.