### PR TITLE
Update and fix Android cross compilation to support newer Android NDK versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ autom4te.cache
 # Do not use too creative wildcards.
 # Those might ignore files that should not be ignored.
 
+aarch64-unknown-linux-android
+arm-unknown-linux-androideabi
 armv7l-unknown-linux-gnueabihf
 i686-pc-linux-gnu
 x86_64-unknown-linux-gnu

--- a/xcomp/erl-xcomp-arm64-android.conf
+++ b/xcomp/erl-xcomp-arm64-android.conf
@@ -2,7 +2,7 @@
 ##
 ## %CopyrightBegin%
 ##
-## Copyright Ericsson AB 2009-2019. All Rights Reserved.
+## Copyright Ericsson AB 2019. All Rights Reserved.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@
 ##
 ## %CopyrightEnd%
 ##
-## File: erl-xcomp-arm-android.conf
-## Author: Dmitry Kolesnikov
+## File: erl-xcomp-arm64-android.conf
+## Author: Jérôme de Bretagne
 ##
 ## -----------------------------------------------------------------------------
 ## When cross compiling Erlang/OTP using `otp_build', copy this file and set
@@ -56,7 +56,7 @@ erl_xcomp_build=guess
 #   It does not have to be a full `CPU-VENDOR-OS' triplet, but can be. The
 #   full `CPU-VENDOR-OS' triplet will be created by
 #   `$ERL_TOP/erts/autoconf/config.sub $erl_xcomp_host'.
-erl_xcomp_host=arm-linux-androideabi
+erl_xcomp_host=aarch64-linux-android
 
 # * `erl_xcomp_configure_flags' - Extra configure flags to pass to the
 #   `configure' script.
@@ -84,14 +84,12 @@ NDK_SYSROOT=$NDK_ROOT/sysroot
 
 # * `CC' - C compiler.
 #
-#   For older Android NDK versions still supporting GCC.
-#CC="arm-linux-androideabi-gcc --sysroot=$NDK_SYSROOT"
-#   For more recent Android NDK versions only supporting Clang/LLVM.
-#NDK_ABI_PLAT=androideabi24  # when targeting Android 7.0 Nougat
-CC="armv7a-linux-$NDK_ABI_PLAT-clang"
+#   For recent Android NDK versions only supporting Clang/LLVM.
+#NDK_ABI_PLAT=android24  # when targeting Android 7.0 Nougat
+CC="aarch64-linux-$NDK_ABI_PLAT-clang"
 
 # * `CFLAGS' - C compiler flags.
-CFLAGS="-g -O2 -march=armv7-a -mfloat-abi=softfp -mthumb"
+CFLAGS="-g -O2"
 
 # * `STATIC_CFLAGS' - Static C compiler flags.
 #STATIC_CFLAGS=
@@ -103,37 +101,29 @@ CFLAGS="-g -O2 -march=armv7-a -mfloat-abi=softfp -mthumb"
 
 # * `CPP' - C pre-processor.
 #
-#   For older Android NDK versions still supporting GCC.
-#CPP="arm-linux-androideabi-cpp --sysroot=$NDK_SYSROOT"
 #   Not needed when using Clang/LLVM.
 #CPP=
 
 # * `CPPFLAGS' - C pre-processor flags.
 #
-#   For older Android NDK versions still supporting GCC.
-#CPPFLAGS="-static -march=armv7-a -msoft-float -mthumb"
 #   Not needed when using Clang/LLVM.
 #CPPFLAGS=
 
 # * `CXX' - C++ compiler.
 #
-#   For older Android NDK versions still supporting GCC.
-#CXX="arm-linux-androideabi-c++ --sysroot=$NDK_SYSROOT
-#   For more recent Android NDK versions only supporting Clang/LLVM.
-CXX="armv7a-linux-$NDK_ABI_PLAT-clang++"
+#   For recent Android NDK versions only supporting Clang/LLVM.
+CXX="aarch64-linux-$NDK_ABI_PLAT-clang++"
 
 # * `CXXFLAGS' - C++ compiler flags.
-CXXFLAGS="-march=armv7-a -mfloat-abi=softfp -mthumb"
+#CXXFLAGS=
 
 # * `LD' - Linker.
 #
-#   Not needed when using GCC.
-#LD=
-#   For more recent Android NDK versions only supporting Clang/LLVM.
-LD="arm-linux-androideabi-ld"
+#   For recent Android NDK versions only supporting Clang/LLVM.
+LD="aarch64-linux-android-ld"
 
 # * `LDFLAGS' - Linker flags.
-LDFLAGS="-march=armv7-a -mfloat-abi=softfp -mthumb"
+#LDFLAGS=
 
 # * `LIBS' - Libraries.
 #LIBS=


### PR DESCRIPTION
Here is a branch refreshing the Android cross compilation with:
- an updated configuration supporting newer Android NDK toolsets
- corresponding modifications to the documentation, now detailed in a more step-by-step way

These changes have been tested with the current stable Android NDK: 20.0.5594570 on Linux x86_64.

Thanks,
Jérôme