### PR TITLE
edoc: support multiple clauses in -spec

### DIFF
--- a/lib/edoc/src/edoc_data.erl
+++ b/lib/edoc/src/edoc_data.erl
@@ -230,9 +230,11 @@ callback({N, A}, _Env, _Opts) ->
 %% <!ELEMENT throws (type, localdef*)>
 %% <!ELEMENT equiv (expr, see?)>
 %% <!ELEMENT expr (#PCDATA)>
-
-function({N, A}, As, Export, Ts, Env, Opts) ->
-    {Args, Ret, Spec} = signature(Ts, As, Env),
+function({N, A}, []=As, Export, Ts, Env, Opts)->
+    function({N, A}, [As], Export, Ts, Env, Opts);
+function({N, A}, [HAs | _]=As, Export, Ts, Env, Opts) when not is_list(HAs) ->
+    function({N, A}, [As], Export, Ts, Env, Opts);
+function({N, A}, As0, Export, Ts, Env, Opts) ->
     {function, [{name, atom_to_list(N)},
 		{arity, integer_to_list(A)},
       		{exported, case Export of
@@ -240,13 +242,8 @@ function({N, A}, As, Export, Ts, Env, Opts) ->
 			       false -> "no"
 			   end},
 		{label, edoc_refs:to_label(edoc_refs:function(N, A))}],
-     [{args, [{arg, [{argName, [atom_to_list(A)]}] ++ description(D)}
-	      || {A, D} <- Args]}]
-     ++ Spec
-     ++ case Ret of
-	    [] -> [];
-	    _ -> [{returns, description(Ret)}]
-	end
+     lists:append([get_args(lists:nth(Clause, As0), Ts, Clause, Env)
+                   || Clause <- lists:seq(1, length(As0))])
      ++ get_throws(Ts, Env)
      ++ get_equiv(Ts, Env)
      ++ get_doc(Ts)
@@ -255,6 +252,16 @@ function({N, A}, As, Export, Ts, Env, Opts) ->
      ++ sees(Ts, Env)
      ++ todos(Ts, Opts)
     }.
+
+get_args(As, Ts, Clause, Env) ->
+    {Args, Ret, Spec} = signature(Ts, As, Clause, Env),
+    [{args, [{arg, [{argName, [atom_to_list(A)]}] ++ description(D)}
+     || {A, D} <- Args]}]
+    ++ Spec
+    ++ case Ret of
+           [] -> [];
+           _ -> [{returns, description(Ret)}]
+       end.
 
 get_throws(Ts, Env) ->
     case get_tags(throws, Ts) of
@@ -406,10 +413,10 @@ todos(Tags, Opts) ->
 	    []
     end.
 
-signature(Ts, As, Env) ->
+signature(Ts, As, Clause, Env) ->
     case get_tags(spec, Ts) of
 	[T] ->
-	    Spec = T#tag.data,
+            Spec = maybe_nth(Clause, T#tag.data),
 	    R = merge_returns(Spec, Ts),
 	    As0 = edoc_types:arg_names(Spec),
 	    Ds0 = edoc_types:arg_descs(Spec),
@@ -423,6 +430,11 @@ signature(Ts, As, Env) ->
 	    S = sets:new(),
 	    {[{A, ""} || A <- fix_argnames(As, S, 1)], [], []}
     end.
+
+maybe_nth(N, List) when is_list(List) ->
+    lists:nth(N, List);
+maybe_nth(1, Other) ->
+    Other.
 
 params(Ts) ->
     [T#tag.data || T <- get_tags(param, Ts)].

--- a/lib/edoc/src/edoc_extract.erl
+++ b/lib/edoc/src/edoc_extract.erl
@@ -634,7 +634,7 @@ select_spec(Ts, _Where, _Specs) ->
 selected_specs([], Ts) ->
     Ts;
 selected_specs([F], [_ | Ts]) ->
-    [edoc_specs:spec(F, _Clause=1) | Ts].
+    [edoc_specs:spec(F) | Ts].
 
 %% Macros for modules
 

--- a/lib/erl_docgen/src/docgen_edoc_xml_cb.erl
+++ b/lib/erl_docgen/src/docgen_edoc_xml_cb.erl
@@ -780,23 +780,21 @@ functions(Fs) ->
 
 function(_Name, E=#xmlElement{content = Es}) ->
     TypeSpec = get_content(typespec, Es),
-    [?NL,{func, [ ?NL,
-		  {name, [{since,""}],
-			  case funcheader(TypeSpec) of
-			      [] ->
-				  signature(get_content(args, Es),
-					    get_attrval(name, E));
-			      Spec -> Spec
-			  end
-			 },
-		  ?NL,{fsummary, fsummary(Es)},
-		  ?NL,local_types(TypeSpec),
-		  ?NL,{desc,
-		       label_anchor(E)++
-		       deprecated(Es)++
-		       fulldesc(Es)++
-		       seealso_function(Es)}
-	   ]}].
+    FuncHeaders =
+        case funcheader(TypeSpec) of
+            [] ->
+                [signature(get_content(args, Es), get_attrval(name, E))];
+            Specs ->
+                Specs
+        end,
+    [?NL, {func, [?NL]++
+		 [{name, [{since,""}], Spec} || Spec <- FuncHeaders]++
+		 [?NL, {fsummary, fsummary(Es)},
+		  ?NL, local_types(TypeSpec),
+		  ?NL, {desc, label_anchor(E)++
+		              deprecated(Es)++
+		              fulldesc(Es)++
+		              seealso_function(Es)}]}].
 
 fsummary([]) -> ["\s"];
 fsummary(Es) ->
@@ -840,7 +838,9 @@ arg(#xmlElement{content = Es}) ->
 
 funcheader([]) -> [];
 funcheader(Es) ->
-    [t_name(get_elem(erlangName, Es))] ++ t_utype(get_elem(type, Es)).
+    Name = t_name(get_elem(erlangName, Es)),
+    [ [Name] ++ t_utype([E]) || E <- get_elem(type, Es)].
+
 
 local_types([]) -> [];
 local_types(Es) ->
@@ -1020,7 +1020,7 @@ author(E=#xmlElement{}) ->
 	   end,
     [?NL,{aname,[Name]},?NL,{email,[Mail]}].
 
-t_name([E]) ->
+t_name([E | _]) ->
     N = get_attrval(name, E),
     case get_attrval(module, E) of
 	"" -> N;
@@ -1231,12 +1231,15 @@ get_attrval(Name, #xmlElement{attributes = As}) ->
 
 %% get_content(Tag, Es1) -> Es2
 %% If there is one element in Es1 with name Tag, returns its contents,
-%% otherwise []
+%% if there are no tags, return [],
+%% if there are multiple, merge their contents.
 get_content(Name, Es) ->
     case get_elem(Name, Es) of
-	[#xmlElement{content = Es1}] ->
-	    Es1;
-	[] -> []
+        [#xmlElement{content = Es1}] ->
+            Es1;
+        [] -> [];
+        Elems ->
+            lists:append([Es1 || #xmlElement{content = Es1} <- Elems])
     end.
 
 %% get_text(Tag, Es) -> string()


### PR DESCRIPTION
Putting this up again...
I'm getting nowhere fast in cleaning this up (and starting to question how much that is needed).
As we all know, the best way to know what the proper solution would be is being wrong on the internet.

Purpose: render specs with multiple clauses in edoc.
