### PR TITLE
Fix unsafe optimization of receives

### DIFF
--- a/lib/compiler/src/beam_a.erl
+++ b/lib/compiler/src/beam_a.erl
@@ -59,6 +59,13 @@ rename_instrs([{test,is_eq_exact,_,[Dst,Src]}=Test,
 rename_instrs([{test,is_eq_exact,_,[Same,Same]}|Is]) ->
     %% Same literal or same register. Will always succeed.
     rename_instrs(Is);
+rename_instrs([{recv_set,_},
+               {label,Lbl},
+               {loop_rec,{f,Fail},{x,0}},
+               {loop_rec_end,_},{label,Fail}|Is]) ->
+    %% This instruction sequence does nothing. All we need to
+    %% keep is the first label.
+    [{label,Lbl}|rename_instrs(Is)];
 rename_instrs([{loop_rec,{f,Fail},{x,0}},{loop_rec_end,_},{label,Fail}|Is]) ->
     %% This instruction sequence does nothing.
     rename_instrs(Is);

--- a/lib/compiler/test/receive_SUITE.erl
+++ b/lib/compiler/test/receive_SUITE.erl
@@ -26,7 +26,8 @@
 	 init_per_testcase/2,end_per_testcase/2,
 	 export/1,recv/1,coverage/1,otp_7980/1,ref_opt/1,
 	 wait/1,recv_in_try/1,double_recv/1,receive_var_zero/1,
-         match_built_terms/1,elusive_common_exit/1]).
+         match_built_terms/1,elusive_common_exit/1,
+         return_before_receive/1,trapping/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -47,7 +48,8 @@ groups() ->
     [{p,test_lib:parallel(),
       [recv,coverage,otp_7980,ref_opt,export,wait,
        recv_in_try,double_recv,receive_var_zero,
-       match_built_terms,elusive_common_exit]}].
+       match_built_terms,elusive_common_exit,
+       return_before_receive,trapping]}].
 
 
 init_per_suite(Config) ->
@@ -483,5 +485,56 @@ elusive2(Acc) ->
     end,
     %% Common code.
     elusive2([Pid | Acc]).
+
+return_before_receive(_Config) ->
+    ref_received = do_return_before_receive(),
+    ok.
+
+do_return_before_receive() ->
+    Ref = make_ref(),
+    self() ! {ref,Ref},
+    maybe_receive(id(false)),
+    receive
+        {ref,Ref} ->
+            ref_received
+    after 1 ->
+            %% Can only be reached if maybe_receive/1 returned
+            %% with the receive marker set.
+            timeout
+    end.
+
+maybe_receive(Bool) ->
+    NewRef = make_ref(),
+    case Bool of
+        true ->
+            receive
+                NewRef ->
+                    ok
+            end;
+        false ->
+            %% The receive marker must not be set when
+            %% leaving this function.
+            ok
+    end.
+
+trapping(_Config) ->
+    ok = do_trapping(0),
+    ok = do_trapping(1),
+    ok.
+
+%% Simplified from emulator's binary_SUITE:trapping/1.
+do_trapping(N) ->
+    Ref = make_ref(),
+    self() ! Ref,
+    case N rem 2 of
+	0 ->
+            %% Would generate recv_set _, label _, wait_timeout _ _,
+            %% which the loader can't handle.
+            receive after 1 -> ok end;
+	1 ->
+            void
+    end,
+    receive Ref -> ok end,
+    receive after 1 -> ok end.
 
 id(I) -> I.

--- a/lib/compiler/test/receive_SUITE_data/ref_opt/no_6.erl
+++ b/lib/compiler/test/receive_SUITE_data/ref_opt/no_6.erl
@@ -1,0 +1,26 @@
+-module(no_6).
+-export([?MODULE/0]).
+
+?MODULE() ->
+    ok = return_before_receive(ok),
+    ok = return_before_receive(ok),
+    {error, whatever} = return_before_receive(error),
+    ok.
+
+return_before_receive(Cmd)  ->
+    RecvRef = make_ref(),
+    case value(Cmd, RecvRef) of
+        ok ->
+            ok;
+        {error, eagain} ->
+            receive
+                {abort, {RecvRef, Reason}} ->
+                    {error, Reason}
+            end
+    end.
+
+value(error, Ref) ->
+    self() ! {abort, {Ref, whatever}},
+    {error, eagain};
+value(ok, _Ref) ->
+    ok.

--- a/lib/compiler/test/receive_SUITE_data/ref_opt/yes_15.erl
+++ b/lib/compiler/test/receive_SUITE_data/ref_opt/yes_15.erl
@@ -1,0 +1,19 @@
+-module(yes_15).
+-export([?MODULE/0,do_multi_call/0]).
+
+?MODULE() ->
+    ok.
+
+do_multi_call() ->
+    %% The calls to make_ref/0 and erlang:monitor/2 will be
+    %% in the same block.
+    Tag = make_ref(),
+    Receiver = spawn(fun() -> ok end),
+    Mref = erlang:monitor(process, Receiver),
+    Receiver ! {self(),Tag},
+    receive
+	{'DOWN',Mref,_,_,{_Receiver,Tag,Result}} ->
+	    Result;
+	{'DOWN',Mref,_,_,Reason} ->
+	    exit(Reason)
+    end.

--- a/lib/compiler/test/receive_SUITE_data/ref_opt/yes_16.erl
+++ b/lib/compiler/test/receive_SUITE_data/ref_opt/yes_16.erl
@@ -1,0 +1,17 @@
+-module(yes_16).
+-export([?MODULE/0,ttb_stop/1]).
+
+?MODULE() ->
+    ok.
+
+ttb_stop(MetaPid) ->
+    Delivered = erlang:trace_delivered(all),
+    receive
+	{trace_delivered,all,Delivered} -> ok
+    end,
+    %% The erlang:monitor/2 call will be in the same block
+    %% as the remove message instruction for the previous
+    %% receive.
+    Ref = erlang:monitor(process,MetaPid),
+    MetaPid ! stop,
+    receive {'DOWN', Ref, process, MetaPid, _Info} -> ok end.


### PR DESCRIPTION
Fix a problem where a receive marker would be set even if it
was not guaranteed that execution would reach a receive statement.

This optimization bug caused the problem for the `socket` module
reported here:

http://erlang.org/pipermail/erlang-questions/2019-October/098591.html

https://bugs.erlang.org/browse/ERL-1076