### PR TITLE
Add function/arity to shadow clauses warnings when possible

### DIFF
--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -121,7 +121,7 @@ pattern2(Config) when is_list(Config) ->
     Ts = [{pattern2,
 	   Source,
 	   [nowarn_unused_vars],
-	   {warnings,[{2,sys_core_fold,{nomatch_shadow,1}},
+	   {warnings,[{2,sys_core_fold,{nomatch_shadow,1,{f,1}}},
 		      {4,sys_core_fold,no_clause_match},
 		      {5,sys_core_fold,nomatch_clause_type},
 		      {6,sys_core_fold,nomatch_clause_type}]}}],
@@ -786,7 +786,7 @@ latin1_fallback(Conf) when is_list(Conf) ->
               ">>,
 	    [],
 	    {warnings,[{1,compile,reparsing_invalid_unicode},
-		       {3,sys_core_fold,{nomatch_shadow,2}}]}}],
+		       {3,sys_core_fold,{nomatch_shadow,2,{t,1}}}]}}],
     [] = run(Conf, Ts1),
 
     Ts2 = [{latin1_fallback2,


### PR DESCRIPTION
When functions can be generated dynamically, we may
have multiple functions defined in the same line, which
makes the shadow clause warning a bit hard to debug.

This patch addresses this by using the a function
annotation, if available, and including that in the
printed message.