### PR TITLE
httpc: do not pass error tuple to uri_string:parse/1

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -176,7 +176,7 @@ request(Method,
        (Method =:= delete) orelse 
        (Method =:= trace) andalso 
        (is_atom(Profile) orelse is_pid(Profile)) ->
-    case uri_string:parse(uri_string:normalize(Url)) of
+    case normalize_and_parse_url(Url) of
 	{error, Reason, _} ->
 	    {error, Reason};
 	ParsedUrl ->
@@ -190,7 +190,7 @@ request(Method,
     end.
 
 do_request(Method, {Url, Headers, ContentType, Body}, HTTPOptions, Options, Profile) ->
-    case uri_string:parse(uri_string:normalize(Url)) of
+    case normalize_and_parse_url(Url) of
 	{error, Reason, _} ->
 	    {error, Reason};
 	ParsedUrl ->
@@ -313,7 +313,7 @@ store_cookies(SetCookieHeaders, Url) ->
 
 store_cookies(SetCookieHeaders, Url, Profile) 
   when is_atom(Profile) orelse is_pid(Profile) ->
-    case uri_string:parse(uri_string:normalize(Url)) of
+    case normalize_and_parse_url(Url) of
         {error, Bad, _} ->
             {error, {parse_failed, Bad}};
         URI ->
@@ -500,6 +500,12 @@ service_info(Pid) ->
 %%%========================================================================
 %%% Internal functions
 %%%========================================================================
+normalize_and_parse_url(Url) ->
+    case uri_string:normalize(Url) of
+        {error, _, _} = Error -> Error;
+        UriString -> uri_string:parse(UriString)
+    end.
+
 handle_request(Method, Url, 
                URI,
 	       Headers0, ContentType, Body0,

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -107,7 +107,8 @@ real_requests()->
      inet_opts,
      invalid_headers,
      invalid_body,
-     no_scheme
+     no_scheme,
+     invalid_uri
     ].
 
 real_requests_esi() ->
@@ -1239,6 +1240,14 @@ no_scheme(_Config) ->
     {error,{bad_scheme,"ftp"}} = httpc:request("ftp://foobar"),
     {error,{no_scheme}} = httpc:request("//foobar"),
     {error,{no_scheme}} = httpc:request("foobar"),
+    ok.
+
+
+%%-------------------------------------------------------------------------
+
+invalid_uri(Config) ->
+    URL = url(group_name(Config), "/bar?x[]=a", Config),
+    {error, invalid_uri} = httpc:request(URL),
     ok.
 
 


### PR DESCRIPTION
Fixes crashing part of ERL-1083.