### PR TITLE
[ERL-1078] Validate auth tag when using chacha20_poly1305 cipher

### DIFF
--- a/lib/crypto/c_src/aead.c
+++ b/lib/crypto/c_src/aead.c
@@ -154,8 +154,8 @@ ERL_NIF_TERM aead_cipher(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         }
     else
         {
-#if defined(HAVE_GCM)
-            if (cipherp->flags & GCM_MODE) {
+#if defined(HAVE_GCM) || defined(HAVE_CHACHA20_POLY1305)
+            if (cipherp->flags & (GCM_MODE | POLY1305_MODE)) {
                 if (EVP_CIPHER_CTX_ctrl(ctx, cipherp->extra.aead.ctx_ctrl_set_tag, (int)tag_len, tag.data) != 1)
                     /* Decrypt error */
                     {ret = atom_error; goto done;}

--- a/lib/crypto/c_src/cipher.c
+++ b/lib/crypto/c_src/cipher.c
@@ -96,9 +96,9 @@ static struct cipher_type_t cipher_types[] =
 
     /*==== AEAD ciphers ====*/
 #if defined(HAVE_CHACHA20_POLY1305)
-    {{"chacha20_poly1305"}, {&EVP_chacha20_poly1305}, 0, NO_FIPS_CIPHER | AEAD_CIPHER, {{EVP_CTRL_AEAD_SET_IVLEN,EVP_CTRL_AEAD_GET_TAG,EVP_CTRL_AEAD_SET_TAG}}},
+    {{"chacha20_poly1305"}, {&EVP_chacha20_poly1305}, 0, NO_FIPS_CIPHER|AEAD_CIPHER|POLY1305_MODE, {{EVP_CTRL_AEAD_SET_IVLEN,EVP_CTRL_AEAD_GET_TAG,EVP_CTRL_AEAD_SET_TAG}}},
 #else
-    {{"chacha20_poly1305"}, {NULL}, 0, NO_FIPS_CIPHER | AEAD_CIPHER, {{0,0,0}}},
+    {{"chacha20_poly1305"}, {NULL}, 0, NO_FIPS_CIPHER|AEAD_CIPHER, {{0,0,0}}},
 #endif
 
 #if defined(HAVE_GCM)

--- a/lib/crypto/c_src/cipher.h
+++ b/lib/crypto/c_src/cipher.h
@@ -48,6 +48,7 @@ struct cipher_type_t {
 #define AES_CTR_COMPAT 32
 #define CCM_MODE 64
 #define GCM_MODE 128
+#define POLY1305_MODE 256
 
 
 #ifdef FIPS_SUPPORT


### PR DESCRIPTION
Adds support for validating auth tag when using `chacha20_poly1305` cipher with `crypto_one_time_aead`

Details at https://bugs.erlang.org/browse/ERL-1078