### PR TITLE
Allow ignoring log message from function

### DIFF
--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -88,7 +88,8 @@
                               single_line := boolean()}.
 -type msg_fun() :: fun((term()) -> {io:format(),[term()]} |
                                    report() |
-                                   unicode:chardata()).
+                                   unicode:chardata() |
+                                   ignore).
 -type metadata() :: #{pid    => pid(),
                       gl     => pid(),
                       time   => timestamp(),
@@ -1050,6 +1051,7 @@ do_log(Level,Msg,Meta) ->
       Meta :: metadata().
 log_allowed(Location,Level,{Fun,FunArgs},Meta) when is_function(Fun,1) ->
     try Fun(FunArgs) of
+        ignore -> ok;
         Msg={Format,Args} when is_list(Format), is_list(Args) ->
             log_allowed(Location,Level,Msg,Meta);
         Report when ?IS_REPORT(Report) ->


### PR DESCRIPTION
This introduces ~~2~~ 1 change:

- `msg_fun/0` can now return `ignore` to ignore logging message at all
- ~~`Metadata` argument can accept 0-ary function that is supposed to
  return computed map with metadata~~