### PR TITLE
Add openssh vendor extension to sftp rename.

### DIFF
--- a/lib/ssh/src/ssh_xfer.erl
+++ b/lib/ssh/src/ssh_xfer.erl
@@ -156,13 +156,20 @@ rename(XF, ReqID, OldPath, NewPath, Flags) ->
 	     true ->
 		  (<<>>)
 	  end,
-    xf_request(XF, ?SSH_FXP_RENAME, 
-	       [?uint32(ReqID),
-		?string_utf8(OldPath),
-		?string_utf8(NewPath),
-		FlagBits]).
-
-
+    Ext = XF#ssh_xfer.ext,
+    ExtRename = "posix-rename@openssh.com",
+    case lists:member({ExtRename, "1"}, Ext) of
+	true ->
+	    extended(XF, ReqID, ExtRename,
+		     [?string_utf8(OldPath),
+		      ?string_utf8(NewPath)]);
+	false ->
+	    xf_request(XF, ?SSH_FXP_RENAME,
+		       [?uint32(ReqID),
+			?string_utf8(OldPath),
+			?string_utf8(NewPath),
+			FlagBits])
+    end.
 
 %% Create directory
 mkdir(XF, ReqID, Path, Attrs) ->
@@ -261,7 +268,7 @@ extended(XF, ReqID, Request, Data) ->
     xf_request(XF, ?SSH_FXP_EXTENDED,
 	       [?uint32(ReqID),
 		?string(Request),
-		?binary(Data)]).
+		Data]).
 
 
 %% Send xfer request to connection manager


### PR DESCRIPTION
To use openssh rename extension it use the same logic as openssh scp client and verify if extension exists and choose that first. 