### PR TITLE
add Linux sock_extended_err support to socket

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1719,6 +1719,9 @@ dnl Check for setns
 AC_CHECK_HEADERS(sched.h setns.h)
 AC_CHECK_FUNCS([setns])
 
+dnl Check for linux/errqueue
+AC_CHECK_HEADERS(linux/errqueue.h)
+
 HAVE_VALGRIND=no
 AC_CHECK_HEADER(valgrind/valgrind.h, HAVE_VALGRIND=yes)
 AC_SUBST(HAVE_VALGRIND)

--- a/erts/doc/src/socket.xml
+++ b/erts/doc/src/socket.xml
@@ -269,6 +269,12 @@
       <name name="cmsghdr_send"/>
     </datatype>
     <datatype>
+      <name name="ee_origin"/>
+    </datatype>
+    <datatype>
+      <name name="sock_extended_err"/>
+    </datatype>
+    <datatype>
       <name name="uint8"/>
     </datatype>
     <datatype>

--- a/erts/emulator/nifs/common/socket_int.h
+++ b/erts/emulator/nifs/common/socket_int.h
@@ -177,6 +177,7 @@ typedef unsigned int BOOLEAN_T;
     GLOBAL_ATOM_DEF(hoplimit);                 \
     GLOBAL_ATOM_DEF(hopopts);                  \
     GLOBAL_ATOM_DEF(icmp);                     \
+    GLOBAL_ATOM_DEF(icmp6);                    \
     GLOBAL_ATOM_DEF(ifindex);                  \
     GLOBAL_ATOM_DEF(igmp);                     \
     GLOBAL_ATOM_DEF(inet);                     \

--- a/erts/preloaded/src/socket.erl
+++ b/erts/preloaded/src/socket.erl
@@ -134,6 +134,9 @@
               %% cmsghdr_data/0,
               cmsghdr_recv/0, cmsghdr_send/0,
 
+              ee_origin/0,
+              sock_extended_err/0,
+
               uint8/0,
               uint16/0,
               uint20/0,
@@ -601,9 +604,11 @@
         #{level := ip,        type := recvttl,     data := integer()}      |
         #{level := ip,        type := pktinfo,     data := ip_pktinfo()}   |
         #{level := ip,        type := origdstaddr, data := sockaddr_in4()} |
+        #{level := ip,        type := recverr,     data := sock_extended_err() | binary()} |
         #{level := ip,        type := integer(),   data := binary()}       |
         #{level := ipv6,      type := hoplevel,    data := integer()}      |
         #{level := ipv6,      type := pktinfo,     data := ipv6_pktinfo()} |
+        #{level := ipv6,      type := recverr,     data := sock_extended_err() | binary()} |
         #{level := ipv6,      type := tclass,      data := integer()}      |
         #{level := ipv6,      type := integer(),   data := binary()}       |
         #{level := integer(), type := integer(),   data := binary()}.
@@ -620,6 +625,14 @@
         #{level := udp,       type := integer(),   data := binary()} |
         #{level := integer(), type := integer(),   data := binary()}.
 
+-type ee_origin() :: none | local | icmp | icmp6 | uint8().
+-type sock_extended_err() :: #{error := term(),
+                               origin := ee_origin(),
+                               type := uint8(),
+                               code := uint8(),
+                               info := uint32(),
+                               data := uint32(),
+                               offender := undefined | sockaddr()}.
 
 -opaque select_tag() :: atom().
 -opaque select_ref() :: reference().

--- a/erts/preloaded/src/socket.erl
+++ b/erts/preloaded/src/socket.erl
@@ -135,6 +135,8 @@
               cmsghdr_recv/0, cmsghdr_send/0,
 
               ee_origin/0,
+              icmp_dest_unreach/0,
+              icmpv6_dest_unreach/0,
               sock_extended_err/0,
 
               uint8/0,
@@ -626,13 +628,29 @@
         #{level := integer(), type := integer(),   data := binary()}.
 
 -type ee_origin() :: none | local | icmp | icmp6 | uint8().
--type sock_extended_err() :: #{error := term(),
-                               origin := ee_origin(),
-                               type := uint8(),
-                               code := uint8(),
-                               info := uint32(),
-                               data := uint32(),
-                               offender := undefined | sockaddr()}.
+-type icmp_dest_unreach() :: net_unreach | host_unreach | port_unreach | frag_needed |
+                             net_unknown | host_unknown | uint8().
+-type icmpv6_dest_unreach() :: noroute | adm_prohibited | not_neighbour | addr_unreach |
+                               port_unreach | policy_fail | reject_route | uint8().
+-type sock_extended_err() ::
+        #{error := term(), origin := icmp, type := dest_unreach,
+          code := icmp_dest_unreach(),     info := uint32(),
+          data := uint32(), offender := undefined | sockaddr()} |
+        #{error := term(), origin := icmp, type := time_exceeded | uint8(),
+          code := uint8(), info := uint32(), data := uint32(),
+          offender := undefined | sockaddr()} |
+        #{error := term(), origin := icmp, type := uint8(),
+          code := uint8(), info := uint32(), data := uint32(),
+          offender := undefined | sockaddr()} |
+        #{error := term(), origin := icmp6, type := dest_unreach,
+          code := icmpv6_dest_unreach(),     info := uint32(),
+          data := uint32(), offender := undefined | sockaddr()} |
+        #{error := term(), origin := ee_origin(), type := pkt_toobig | time_xceeded | uint8(),
+          code := uint8(), info := uint32(),      data := uint32(),
+          offender := undefined | sockaddr()} |
+        #{error := term(), origin := ee_origin(), type := uint8(),
+          code := uint8(), info := uint32(),      data := uint32(),
+          offender := undefined | sockaddr()}.
 
 -opaque select_tag() :: atom().
 -opaque select_ref() :: reference().


### PR DESCRIPTION
Linux defines a sock_extended_err structure for message
received from the error queue when the recverr option is
in effect.
Decode that structure and pass it to the caller.