### PR TITLE
Expand Android cross compilation compatibility

### DIFF
--- a/HOWTO/INSTALL-ANDROID.md
+++ b/HOWTO/INSTALL-ANDROID.md
@@ -29,7 +29,7 @@ to generate the configure scripts.
 
 Use the following when compiling a 64-bit version.
 
-    $ export NDK_ABI_PLAT=android24      # When targeting Android 7.0 Nougat
+    $ export NDK_ABI_PLAT=android21      # When targeting Android 5.0 Lollipop
     $ ./otp_build configure \
          --xcomp-conf=./xcomp/erl-xcomp-arm64-android.conf  \
          --without-ssl
@@ -37,7 +37,7 @@ Use the following when compiling a 64-bit version.
 
 Use the following instead when compiling a 32-bit version.
 
-    $ export NDK_ABI_PLAT=androideabi24  # When targeting Android 7.0 Nougat
+    $ export NDK_ABI_PLAT=androideabi21  # When targeting Android 5.0 Lollipop
     $ ./otp_build configure \
          --xcomp-conf=./xcomp/erl-xcomp-arm-android.conf  \
          --without-ssl

--- a/HOWTO/INSTALL-ANDROID.md
+++ b/HOWTO/INSTALL-ANDROID.md
@@ -37,7 +37,7 @@ Use the following when compiling a 64-bit version.
 
 Use the following instead when compiling a 32-bit version.
 
-    $ export NDK_ABI_PLAT=androideabi21  # When targeting Android 5.0 Lollipop
+    $ export NDK_ABI_PLAT=androideabi16  # When targeting Android 4.1 Jelly Bean
     $ ./otp_build configure \
          --xcomp-conf=./xcomp/erl-xcomp-arm-android.conf  \
          --without-ssl

--- a/erts/emulator/nifs/common/prim_net_nif.c
+++ b/erts/emulator/nifs/common/prim_net_nif.c
@@ -1109,7 +1109,7 @@ ERL_NIF_TERM nif_if_names(ErlNifEnv*         env,
                           int                argc,
                           const ERL_NIF_TERM argv[])
 {
-#if defined(__WIN32__)
+#if defined(__WIN32__) || (defined(__ANDROID__) && (__ANDROID_API__ < 24))
     return enif_raise_exception(env, MKA(env, "notsup"));
 #else
     ERL_NIF_TERM result;
@@ -1130,7 +1130,10 @@ ERL_NIF_TERM nif_if_names(ErlNifEnv*         env,
 
 
 
-#if !defined(__WIN32__)
+/* if_nameindex and if_freenameindex were added in Android 7.0 Nougat. With
+the Android NDK Unified Headers, check that the build is targeting at least
+the corresponding API level 24. */
+#if !defined(__WIN32__) && !(defined(__ANDROID__) && (__ANDROID_API__ < 24))
 static
 ERL_NIF_TERM nif_names(ErlNifEnv* env)
 {

--- a/erts/emulator/sys/common/erl_poll.h
+++ b/erts/emulator/sys/common/erl_poll.h
@@ -1,8 +1,8 @@
 /*
  * %CopyrightBegin%
- * 
- * Copyright Ericsson AB 2006-2018. All Rights Reserved.
- * 
+ *
+ * Copyright Ericsson AB 2006-2019. All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -161,7 +161,10 @@ typedef enum {
 #include <sys/epoll.h>
 
 #if ERTS_POLL_USE_EPOLL
-#ifdef HAVE_SYS_TIMERFD_H
+/* sys/timerfd.h was added in Android 4.4 KitKat. With the Android NDK
+Unified Headers, check that the build is targeting at least the
+corresponding API level 19. */
+#if defined(HAVE_SYS_TIMERFD_H) && !(defined(__ANDROID__) && (__ANDROID_API__ < 19))
 #include <sys/timerfd.h>
 #undef ERTS_POLL_USE_TIMERFD
 #define ERTS_POLL_USE_TIMERFD 1

--- a/xcomp/erl-xcomp-arm-android.conf
+++ b/xcomp/erl-xcomp-arm-android.conf
@@ -87,7 +87,7 @@ NDK_SYSROOT=$NDK_ROOT/sysroot
 #   For older Android NDK versions still supporting GCC.
 #CC="arm-linux-androideabi-gcc --sysroot=$NDK_SYSROOT"
 #   For more recent Android NDK versions only supporting Clang/LLVM.
-#NDK_ABI_PLAT=androideabi21  # when targeting Android 5.0 Lollipop
+#NDK_ABI_PLAT=androideabi16  # when targeting Android 4.1 Jelly Bean
 CC="armv7a-linux-$NDK_ABI_PLAT-clang"
 
 # * `CFLAGS' - C compiler flags.

--- a/xcomp/erl-xcomp-arm-android.conf
+++ b/xcomp/erl-xcomp-arm-android.conf
@@ -87,7 +87,7 @@ NDK_SYSROOT=$NDK_ROOT/sysroot
 #   For older Android NDK versions still supporting GCC.
 #CC="arm-linux-androideabi-gcc --sysroot=$NDK_SYSROOT"
 #   For more recent Android NDK versions only supporting Clang/LLVM.
-#NDK_ABI_PLAT=androideabi24  # when targeting Android 7.0 Nougat
+#NDK_ABI_PLAT=androideabi21  # when targeting Android 5.0 Lollipop
 CC="armv7a-linux-$NDK_ABI_PLAT-clang"
 
 # * `CFLAGS' - C compiler flags.

--- a/xcomp/erl-xcomp-arm64-android.conf
+++ b/xcomp/erl-xcomp-arm64-android.conf
@@ -85,7 +85,7 @@ NDK_SYSROOT=$NDK_ROOT/sysroot
 # * `CC' - C compiler.
 #
 #   For recent Android NDK versions only supporting Clang/LLVM.
-#NDK_ABI_PLAT=android24  # when targeting Android 7.0 Nougat
+#NDK_ABI_PLAT=android21  # when targeting Android 5.0 Lollipop
 CC="aarch64-linux-$NDK_ABI_PLAT-clang"
 
 # * `CFLAGS' - C compiler flags.


### PR DESCRIPTION
This pull request fixes Android cross compilation to make it work across all versions currently supported by the Android NDK, which are:
- API level 21 (Android 5.0 Lollipop) for 64-bit ARM
- API level 16 (Android 4.1 Jelly Bean) for 32-bit ARM

Thanks,
Jérôme