### PR TITLE
Document the allowed float sizes for the bit syntax

### DIFF
--- a/system/doc/programming_examples/bit_syntax.xml
+++ b/system/doc/programming_examples/bit_syntax.xml
@@ -285,7 +285,8 @@ X:4/little-signed-integer-unit:8</code>
     <p>Each segment in a binary can consist of zero or more bits.
        A segment of type <c>binary</c> must have a size evenly divisible by 8
     (or divisible by the unit size, if the unit size has been changed).
-    A segment of type <c>bitstring</c> has no restrictions on the size.</p>
+    A segment of type <c>bitstring</c> has no restrictions on the size.
+    A segment of type <c>float</c> must have size 64 or 32.</p>
     <p>As mentioned earlier, segments have the following general syntax:</p>
     <p><c>Value:Size/TypeSpecifierList</c></p>
     <p>When matching <c>Value</c>, value must be either a variable or

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -1153,7 +1153,8 @@ Ei = Value |
     </taglist>
     <p>The value of <c>Size</c> multiplied with the unit gives
       the number of bits. A segment of type <c>binary</c> must have 
-      a size that is evenly divisible by 8.</p>
+      a size that is evenly divisible by 8. For a segment of type <c>float</c>
+      the size must be either 64 or 32.</p>
 
     <note><p>When constructing binaries, if the size <c>N</c> of an integer
     segment is too small to contain the given integer, the most significant


### PR DESCRIPTION
The current implementation of the bit syntax only allows floating point
fields of size 64 or 32. Make this clear in the Erlang Reference Manual.