### PR TITLE
Add support for default metadata to the logger

### DIFF
--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -200,6 +200,12 @@
             <c>logger:set_primary_config(level, Level)</c></seemfa>.</p>
 	<p>Defaults to <c>notice</c>.</p>
       </item>
+      <tag><marker id="logger_metadata"/><c>logger_metadata = Metadata</c></tag>
+      <item>
+	<p>Specifies primary metadata for log events.</p>
+	<p><c>Metadata = map()</c></p>
+	<p>Defaults to <c>#{}</c>.</p>
+      </item>
       <tag><marker id="logger_sasl_compatible"/>
 	<c>logger_sasl_compatible = true | false</c></tag>
       <item>

--- a/lib/kernel/doc/src/logger.xml
+++ b/lib/kernel/doc/src/logger.xml
@@ -199,17 +199,28 @@ logger:error("error happened because: ~p", [Reason]). % Without macro
 	  <item><c>file => ?FILE</c></item>
 	  <item><c>line => ?LINE</c></item>
 	</list>
-	<p>You can add custom metadata, either by specifying a map as
-	  the last parameter to any of the log macros or the API
-	  functions, or by setting process metadata
-	  with <seemfa marker="#set_process_metadata/1">
+	<p>You can add custom metadata, either by:</p>
+        <list>
+          <item>specifying a map as the last parameter to any of the
+            log macros or the logger API functions.</item>
+          <item>setting process metadata with <seemfa marker="#set_process_metadata/1">
 	    <c>set_process_metadata/1</c></seemfa>
-	  or <seemfa marker="#update_process_metadata/1">
-	    <c>update_process_metadata/1</c></seemfa>.</p>
+	    or <seemfa marker="#update_process_metadata/1">
+	  <c>update_process_metadata/1</c></seemfa>.</item>
+          <item>setting primary metadata with <seemfa marker="#set_primary_config/1">
+            <c>set_primary_config/1</c></seemfa> or through the kernel
+            configuration parameter <seeapp marker="kernel_app#logger_metadata">
+            logger_metadata</seeapp></item>
+        </list>
+        <note>
+          <p>When adding custom metadata, make sure not to use any of the keys
+            mentioned above as that may cause a lot of confusion about the log
+            events.</p>
+        </note>
 	<p>Logger merges all the metadata maps before forwarding the
 	  log event to the handlers. If the same keys occur, values
-	  from the log call overwrite process metadata, which in turn
-	  overwrite values set by Logger.</p>
+	  from the log call overwrite process metadata, which overwrites
+          the primary metadata, which in turn overwrite values set by Logger.</p>
 	<p>The following custom metadata keys have special meaning:</p>
 	<taglist>
 	  <tag><c>domain</c></tag>
@@ -816,10 +827,12 @@ start(_, []) ->
       <name name="set_primary_config" arity="2" clause_i="1" since="OTP 21.0"/>
       <name name="set_primary_config" arity="2" clause_i="2" since="OTP 21.0"/>
       <name name="set_primary_config" arity="2" clause_i="3" since="OTP 21.0"/>
+      <name name="set_primary_config" arity="2" clause_i="4" since="OTP @OTP-17181@"/>
       <fsummary>Add or update primary configuration data for Logger.</fsummary>
       <type variable="Level" name_i="1"/>
       <type variable="FilterDefault" name_i="2"/>
       <type variable="Filters" name_i="3"/>
+      <type variable="Meta" name_i="4"/>
       <desc>
         <p>Add or update primary configuration data for Logger. If the
           given <c><anno>Key</anno></c> already exists, its associated

--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -237,8 +237,21 @@ logger:debug(#{got => connection_request, id => Id, state => State},
       <title>Metadata</title>
       <p>Metadata contains additional data associated with a log
 	message. Logger inserts some metadata fields by default, and
-	the client can add custom metadata in two different ways:</p>
+	the client can add custom metadata in three different ways:</p>
       <taglist>
+        <tag>Set primary metadata</tag>
+        <item>
+          <p>Primary metadata applies is the base metadata given to
+            all log events. At startup it can be set using
+            the kernel configuration parameter
+            <seeapp marker="kernel_app#logger_metadata">logger_metadata</seeapp>.
+            At run-time it can be set and updated using
+            <seemfa marker="logger#set_primary_config/1">
+              <c>logger:set_primary_config/1</c></seemfa> and
+            <seemfa marker="logger#update_primary_config/1">
+              <c>logger:update_primary_config/1</c></seemfa> respectively.
+          </p>
+        </item>
 	<tag>Set process metadata</tag>
 	<item>
 	  <p>Process metadata is set and updated
@@ -544,6 +557,13 @@ logger:debug(#{got => connection_request, id => Id, state => State},
 	    for more information about how this option is used.</p>
 	  <p>Defaults to <c>log</c>.</p>
 	</item>
+        <tag><c>metadata = </c><seetype marker="logger#metadata"><c>metadata()</c></seetype></tag>
+	<item>
+	  <p>The primary metadata to be used for all log calls.</p>
+          <p>See section <seeguide marker="#metadata">Metadata</seeguide>
+	    for more information about how this option is used.</p>
+	  <p>Defaults to <c>#{}</c>.</p>
+	</item>
       </taglist>
     </section>
 
@@ -761,6 +781,13 @@ logger:debug(#{got => connection_request, id => Id, state => State},
 	  section <seeguide marker="#config_examples">Configuration
 	  Examples</seeguide> for examples using the <c>logger</c>
 	  parameter for system configuration.</p>
+      </item>
+      <tag><marker id="logger_metadata"/>
+	<c>logger_metadata = map()</c></tag>
+      <item>
+	<p>Specifies the primary metadata. See
+	  the <seeapp marker="kernel_app#logger_metadata"><c>kernel(6)</c></seeapp>
+	  manual page for more information about this parameter.</p>
       </item>
       <tag><marker id="logger_level"/>
 	<c>logger_level = Level</c></tag>

--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -108,6 +108,7 @@
 -type filter_arg() :: term().
 -type filter_return() :: stop | ignore | log_event().
 -type primary_config() :: #{level => level() | all | none,
+                            metadata => metadata(),
                             filter_default => log | stop,
                             filters => [{filter_id(),filter()}]}.
 -type handler_config() :: #{id => handler_id(),
@@ -403,7 +404,9 @@ remove_handler(HandlerId) ->
                         (filter_default,FilterDefault) -> ok | {error,term()} when
       FilterDefault :: log | stop;
                         (filters,Filters) -> ok | {error,term()} when
-      Filters :: [{filter_id(),filter()}].
+      Filters :: [{filter_id(),filter()}];
+                        (metadata,Meta) -> ok | {error,term()} when
+      Meta :: metadata().
 set_primary_config(Key,Value) ->
     logger_server:set_config(primary,Key,Value).
 
@@ -799,6 +802,7 @@ internal_init_logger() ->
         Env = get_logger_env(kernel),
         check_logger_config(kernel,Env),
         ok = logger:set_primary_config(level, get_logger_level()),
+        ok = logger:set_primary_config(metadata, get_primary_metadata()),
         ok = logger:set_primary_config(filter_default,
                                        get_primary_filter_default(Env)),
 
@@ -955,6 +959,14 @@ get_logger_level() ->
             throw({logger_level, Level})
     end.
 
+get_primary_metadata() ->
+    case application:get_env(kernel,logger_default_metadata,#{}) of
+        Meta when is_map(Meta) ->
+            Meta;
+        Meta ->
+            throw({logger_metadata, Meta})
+    end.
+
 get_primary_filter_default(Env) ->
     case lists:keyfind(filters,1,Env) of
         {filters,Default,_} ->
@@ -1067,40 +1079,52 @@ log_allowed(Location,Level,{Fun,FunArgs},Meta) when is_function(Fun,1) ->
                          [{Fun,FunArgs},{C,R}]},
                         Meta)
     end;
-log_allowed(Location,Level,Msg,Meta0) when is_map(Meta0) ->
+log_allowed(Location,Level,Msg,LogCallMeta) when is_map(LogCallMeta) ->
+
+    Tid = tid(),
+
+    {ok,PrimaryConfig} = logger_config:get(Tid,primary),
+
     %% Metadata priorities are:
-    %% Location (added in API macros) - will be overwritten by process
-    %% metadata (set by set_process_metadata/1), which in turn will be
+    %% Location (added in API macros) - will be overwritten by
+    %% Default Metadata (added by logger:primary_config/1) - will be overwritten by
+    %% process metadata (set by set_process_metadata/1), which in turn will be
     %% overwritten by the metadata given as argument in the log call
     %% (function or macro).
+
     Meta = add_default_metadata(
-             maps:merge(Location,maps:merge(proc_meta(),Meta0))),
+             maps:merge(
+               Location,
+               maps:merge(
+                 maps:get(metadata,PrimaryConfig),
+                 maps:merge(proc_meta(),LogCallMeta)))),
+
     case node(maps:get(gl,Meta)) of
         Node when Node=/=node() ->
             log_remote(Node,Level,Msg,Meta);
         _ ->
             ok
     end,
-    do_log_allowed(Level,Msg,Meta,tid()).
+    do_log_allowed(Level,Msg,Meta,Tid,PrimaryConfig).
 
-do_log_allowed(Level,{Format,Args}=Msg,Meta,Tid)
+do_log_allowed(Level,{Format,Args}=Msg,Meta,Tid,Config)
   when ?IS_LEVEL(Level),
        ?IS_FORMAT(Format),
        is_list(Args),
        is_map(Meta) ->
-    logger_backend:log_allowed(#{level=>Level,msg=>Msg,meta=>Meta},Tid);
-do_log_allowed(Level,Report,Meta,Tid)
+    logger_backend:log_allowed(#{level=>Level,msg=>Msg,meta=>Meta},Tid,Config);
+do_log_allowed(Level,Report,Meta,Tid,Config)
   when ?IS_LEVEL(Level),
        ?IS_REPORT(Report),
        is_map(Meta) ->
     logger_backend:log_allowed(#{level=>Level,msg=>{report,Report},meta=>Meta},
-                               Tid);
-do_log_allowed(Level,String,Meta,Tid)
+                               Tid,Config);
+do_log_allowed(Level,String,Meta,Tid,Config)
   when ?IS_LEVEL(Level),
        ?IS_STRING(String),
        is_map(Meta) ->
     logger_backend:log_allowed(#{level=>Level,msg=>{string,String},meta=>Meta},
-                               Tid).
+                               Tid,Config).
 tid() ->
     ets:whereis(?LOGGER_TABLE).
 

--- a/lib/kernel/src/logger_config.erl
+++ b/lib/kernel/src/logger_config.erl
@@ -122,9 +122,12 @@ set(Tid,proxy,Config) ->
     ok;
 set(Tid,What,Config) ->
     LevelInt = level_to_int(maps:get(level,Config)),
+    %% Put either primary or handler level in pt cache
     ok = persistent_term:put({?MODULE,table_key(What)}, LevelInt),
     case What of
         primary ->
+            %% If we change primary level, then we need to flush
+            %% the module level cache.
             [persistent_term:put(Key,?PRIMARY_TO_CACHE(LevelInt))
              || {{?MODULE,Module} = Key,Level} <- persistent_term:get(),
                 ?IS_MODULE(Module), ?IS_CACHED(Level)],

--- a/lib/kernel/src/logger_server.erl
+++ b/lib/kernel/src/logger_server.erl
@@ -415,6 +415,7 @@ do_remove_filter(Tid,Id,FilterId) ->
 
 default_config(primary) ->
     #{level=>notice,
+      metadata=>#{},
       filters=>[],
       filter_default=>log};
 default_config(Id) ->
@@ -461,6 +462,8 @@ check_config(Owner,[{filter_default,FD}|Config]) ->
 check_config(handler,[{formatter,Formatter}|Config]) ->
     check_formatter(Formatter),
     check_config(handler,Config);
+check_config(primary,[{metadata,Meta}|Config]) when is_map(Meta) ->
+    check_config(primary,Config);
 check_config(primary,[C|_]) ->
     throw({invalid_primary_config,C});
 check_config(handler,[{_,_}|Config]) ->


### PR DESCRIPTION
This adds new `kernel` configuration option `logger_default_metadata` that will contain default metadata for processes.  It can be overriden via `logger:set_process_metadata/1`, so if someone is using that form of setting metadata it will remove the defaults.  Changing the defaults after the local process metadata were set will not be reflected in the metadata

Close ERL-1904