### PR TITLE
compiler: Improve type inference

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -52,6 +52,7 @@ MODULES =  \
 	beam_call_types \
 	beam_clean \
 	beam_dict \
+	beam_digraph \
 	beam_disasm \
 	beam_flatten \
 	beam_jump \

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -210,6 +210,7 @@ $(EBIN)/beam_ssa_recv.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_share.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_type.beam: beam_ssa.hrl beam_types.hrl
 $(EBIN)/beam_types.beam: beam_types.hrl
+$(EBIN)/beam_validator.beam: beam_types.hrl
 $(EBIN)/cerl.beam: core_parse.hrl
 $(EBIN)/compile.beam: core_parse.hrl ../../stdlib/include/erl_compile.hrl
 $(EBIN)/core_lib.beam: core_parse.hrl

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -136,7 +136,7 @@ types(erlang, 'xor', [_,_]) ->
 
 %% Bitwise ops
 types(erlang, 'band', [_,_]=Args) ->
-    sub_unsafe(band_return_type(Args), [#t_integer{}, #t_integer{}]);
+    sub_unsafe(erlang_band_type(Args), [#t_integer{}, #t_integer{}]);
 types(erlang, 'bor', [_,_]) ->
     sub_unsafe(#t_integer{}, [#t_integer{}, #t_integer{}]);
 types(erlang, 'bxor', [_,_]) ->
@@ -483,14 +483,14 @@ mixed_arith_types([FirstType | _]=Args0) ->
                     end, FirstType, Args0),
     sub_unsafe(RetType, [number || _ <- Args0]).
 
-band_return_type([#t_integer{elements={Int,Int}}, RHS]) when is_integer(Int) ->
-    band_return_type_1(RHS, Int);
-band_return_type([LHS, #t_integer{elements={Int,Int}}]) when is_integer(Int) ->
-    band_return_type_1(LHS, Int);
-band_return_type(_) ->
+erlang_band_type([#t_integer{elements={Int,Int}}, RHS]) when is_integer(Int) ->
+    erlang_band_type_1(RHS, Int);
+erlang_band_type([LHS, #t_integer{elements={Int,Int}}]) when is_integer(Int) ->
+    erlang_band_type_1(LHS, Int);
+erlang_band_type(_) ->
     #t_integer{}.
 
-band_return_type_1(LHS, Int) ->
+erlang_band_type_1(LHS, Int) ->
     case LHS of
         #t_integer{elements={Min0,Max0}} when Max0 - Min0 < 1 bsl 256 ->
             {Intersection, Union} = range_masks(Min0, Max0),

--- a/lib/compiler/src/beam_digraph.erl
+++ b/lib/compiler/src/beam_digraph.erl
@@ -1,0 +1,308 @@
+
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2019. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% Digraph data type. Similar to the digraph module, but provides a
+%% functional API. The functional API allows us to revert to a
+%% previous version of the digraph when an optimization that may have
+%% damaged the digraph has failed.
+%%
+
+-module(beam_digraph).
+
+-export([new/0,
+         add_vertex/2, add_vertex/3, add_edge/3, add_edge/4,
+         del_edge/2, del_edges/2,
+         has_vertex/2,
+         is_path/3,
+         in_degree/2, in_edges/2, in_neighbours/2,
+         out_degree/2, out_edges/2, out_neighbours/2,
+         vertex/2, vertices/1,
+         reverse_postorder/2,
+         roots/1,
+         topsort/1,
+         strong_components/2]).
+
+%% Debugging.
+-define(DEBUG, true).
+-if(?DEBUG).
+-export([dump/1,dump/2,dump/3]).
+-endif.
+
+-import(lists, [foldl/3, reverse/1]).
+
+-type edge_map() :: #{ vertex() => ordsets:ordset(vertex()) }.
+-type vertice_map() :: #{ vertex() => label() }.
+
+-record(dg, {vs = #{} :: vertice_map(),
+             in_es = #{} :: edge_map(),
+             out_es = #{} :: edge_map()}).
+
+-type graph() :: #dg{}.
+
+-type vertex() :: term().
+-type label() :: term().
+-type edge() :: {vertex(), vertex(), label()}.
+
+-spec new() -> graph().
+new() -> #dg{}.
+
+-spec add_vertex(graph(), vertex()) -> graph().
+add_vertex(Dg, V) ->
+    add_vertex(Dg, V, vertex).
+
+-spec add_vertex(graph(), vertex(), label()) -> graph().
+add_vertex(Dg, V, Label) ->
+    #dg{in_es=InEsMap0,out_es=OutEsMap0,vs=Vs0} = Dg,
+    InEsMap = init_edge_map(V, InEsMap0),
+    OutEsMap = init_edge_map(V, OutEsMap0),
+    Vs = Vs0#{V=>Label},
+    Dg#dg{vs=Vs,in_es=InEsMap,out_es=OutEsMap}.
+
+init_edge_map(V, EsMap) ->
+    case is_map_key(V, EsMap) of
+        true ->
+            EsMap;
+        false ->
+            EsMap#{V=>ordsets:new()}
+    end.
+
+-spec add_edge(graph(), vertex(), vertex()) -> graph().
+add_edge(Dg, From, To) ->
+    add_edge(Dg, From, To, edge).
+
+-spec add_edge(graph(), vertex(), vertex(), label()) -> graph().
+add_edge(Dg, From, To, Label) ->
+    #dg{in_es=InEsMap0,out_es=OutEsMap0} = Dg,
+    Name = {From,To,Label},
+    InEsMap = edge_map_add(To, Name, InEsMap0),
+    OutEsMap = edge_map_add(From, Name, OutEsMap0),
+    Dg#dg{in_es=InEsMap,out_es=OutEsMap}.
+
+edge_map_add(V, E, EsMap) ->
+    Es0 = map_get(V, EsMap),
+    Es = ordsets:add_element(E, Es0),
+    EsMap#{V:=Es}.
+
+-spec del_edge(graph(), edge()) -> graph().
+del_edge(Dg, {From,To,_}=E) ->
+    #dg{in_es=InEsMap0,out_es=OutEsMap0} = Dg,
+    InEsMap = edge_map_del(To, E, InEsMap0),
+    OutEsMap = edge_map_del(From, E, OutEsMap0),
+    Dg#dg{in_es=InEsMap,out_es=OutEsMap}.
+
+edge_map_del(V, E, EsMap) ->
+    Es0 = map_get(V, EsMap),
+    Es = Es0 -- [E],
+    EsMap#{V:=Es}.
+
+-spec del_edges(graph(), [edge()]) -> graph().
+del_edges(G, Es) when is_list(Es) ->
+    foldl(fun(E, A) -> del_edge(A, E) end, G, Es).
+
+-spec has_vertex(graph(), vertex()) -> boolean().
+has_vertex(#dg{vs=Vs}, V) ->
+    is_map_key(V, Vs).
+
+-spec in_degree(graph(), vertex()) -> non_neg_integer().
+in_degree(#dg{in_es=InEsMap}, V) ->
+    length(map_get(V, InEsMap)).
+
+-spec in_edges(graph(), vertex()) -> [edge()].
+in_edges(#dg{in_es=InEsMap}, V) ->
+    map_get(V, InEsMap).
+
+-spec in_neighbours(graph(), vertex()) -> [vertex()].
+in_neighbours(#dg{in_es=InEsMap}, V) ->
+    [From || {From,_,_} <- map_get(V, InEsMap)].
+
+-spec is_path(graph(), vertex(), vertex()) -> boolean().
+is_path(G, From, To) ->
+    Seen = cerl_sets:new(),
+    try
+        _ = is_path_1([From], To, G, Seen),
+        false
+    catch
+        throw:true ->
+            true
+    end.
+
+is_path_1([To|_], To, _G, _Seen) ->
+    throw(true);
+is_path_1([V|Vs], To, G, Seen0) ->
+    case cerl_sets:is_element(V, Seen0) of
+        true ->
+            is_path_1(Vs, To, G, Seen0);
+        false ->
+            Seen1 = cerl_sets:add_element(V, Seen0),
+            Successors = out_neighbours(G, V),
+            Seen = is_path_1(Successors, To, G, Seen1),
+            is_path_1(Vs, To, G, Seen)
+    end;
+is_path_1([], _To, _G, Seen) ->
+    Seen.
+
+-spec out_degree(graph(), vertex()) -> non_neg_integer().
+out_degree(#dg{out_es=OutEsMap}, V) ->
+    length(map_get(V, OutEsMap)).
+
+-spec out_edges(graph(), vertex()) -> [edge()].
+out_edges(#dg{out_es=OutEsMap}, V) ->
+    map_get(V, OutEsMap).
+
+-spec out_neighbours(graph(), vertex()) -> [vertex()].
+out_neighbours(#dg{out_es=OutEsMap}, V) ->
+    [To || {_,To,_} <- map_get(V, OutEsMap)].
+
+-spec vertex(graph(), vertex()) -> label().
+vertex(#dg{vs=Vs}, V) ->
+    map_get(V, Vs).
+
+-spec vertices(graph()) -> [{vertex(), label()}].
+vertices(#dg{vs=Vs}) ->
+    maps:to_list(Vs).
+
+-spec reverse_postorder(graph(), [vertex()]) -> [vertex()].
+reverse_postorder(G, Vs) ->
+    Seen = cerl_sets:new(),
+    {RPO, _} = reverse_postorder_1(Vs, G, Seen, []),
+    RPO.
+
+reverse_postorder_1([V|Vs], G, Seen0, Acc0) ->
+    case cerl_sets:is_element(V, Seen0) of
+        true ->
+            reverse_postorder_1(Vs, G, Seen0, Acc0);
+        false ->
+            Seen1 = cerl_sets:add_element(V, Seen0),
+            Successors = out_neighbours(G, V),
+            {Acc,Seen} = reverse_postorder_1(Successors, G, Seen1, Acc0),
+            reverse_postorder_1(Vs, G, Seen, [V|Acc])
+    end;
+reverse_postorder_1([], _, Seen, Acc) ->
+    {Acc, Seen}.
+
+-spec roots(graph()) -> [vertex()].
+roots(G) ->
+    roots_1(vertices(G), G).
+
+roots_1([{V,_}|Vs], G) ->
+    case in_degree(G, V) of
+        0 ->
+            [V|roots_1(Vs, G)];
+        _ ->
+            roots_1(Vs, G)
+    end;
+roots_1([], _G) -> [].
+
+-spec topsort(graph()) -> [vertex()].
+topsort(G) ->
+    Seen = roots(G),
+    reverse_postorder(G, Seen).
+
+%%
+%% Kosaraju's algorithm
+%%
+%% Visit each node in reverse post order. If the node has not been assigned to
+%% a component yet, start a new component and add all of its in-neighbors to it
+%% if they don't yet belong to one. Keep going until all nodes have been
+%% visited.
+%%
+%% https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
+%%
+
+-spec strong_components(graph(), [vertex()]) -> ComponentMap when
+      %% Vertices together with their components.
+      ComponentMap :: #{ vertex() => [vertex()] }.
+strong_components(G, Vs) ->
+    sc_1(Vs, G, #{}, #{}).
+
+sc_1([V | Vs], G, Roots0, Components) when not is_map_key(V, Roots0) ->
+    %% V has not been assigned to a component, start a new one with this one as
+    %% the root.
+    {Roots, Component} = sc_2([V], G, V, Roots0, []),
+    sc_1(Vs, G, Roots, Components#{ V => Component });
+sc_1([V | Vs], G, Roots, Components0) ->
+    %% V is already part of a component, copy it over.
+    Root = map_get(V, Roots),
+    Components = Components0#{ V => map_get(Root, Components0) },
+
+    sc_1(Vs, G, Roots, Components);
+sc_1([], _G, _Roots, Components) ->
+    Components.
+
+sc_2([V | Vs], G, Root, Roots, Acc) when not is_map_key(V, Roots) ->
+    %% V has not been assigned to a component, so assign it to the current one.
+    sc_2(in_neighbours(G, V) ++ Vs, G, Root, Roots#{ V => Root }, [V | Acc]);
+sc_2([_V | Vs], G, Root, Roots, Acc) ->
+    %% V is already part of a component, skip it.
+    sc_2(Vs, G, Root, Roots, Acc);
+sc_2([], _G, _Root, Roots, Acc) ->
+    {Roots, reverse(Acc)}.
+
+-if(?DEBUG).
+
+%%
+%% Dumps the graph as a string in dot (graphviz) format.
+%%
+%% Use dot(1) to convert to an image:
+%%
+%%    dot [input] -T[format]
+%%    dot graph_file -Tsvg > graph.svg
+
+-spec dump(any()) -> any().
+dump(G) ->
+    Formatter = fun(Node) -> io_lib:format("~p", [Node]) end,
+    io:format("~s", [dump_1(G, Formatter)]).
+
+-spec dump(any(), any()) -> any().
+dump(G, FileName) ->
+    Formatter = fun(Node) -> io_lib:format("~p", [Node]) end,
+    dump(G, FileName, Formatter).
+
+-spec dump(any(), any(), any()) -> any().
+dump(G, FileName, Formatter) ->
+    {ok, Fd} = file:open(FileName, [write]),
+    io:fwrite(Fd, "~s", [dump_1(G, Formatter)]),
+    file:close(Fd).
+
+dump_1(G, Formatter) ->
+    Vs = maps:keys(G#dg.vs),
+
+    {Map, Vertices} = dump_vertices(Vs, 0, Formatter,#{}, []),
+    Edges = dump_edges(Vs, G, Map, []),
+
+    io_lib:format("digraph g {~n~s~n~s~n}~n", [Vertices, Edges]).
+
+dump_vertices([V | Vs], Counter, Formatter, Map, Acc) ->
+    VerticeSlug = io_lib:format("    ~p [label=\"~s\"]~n",
+                                [Counter, Formatter(V)]),
+    dump_vertices(Vs, Counter + 1, Formatter,
+                  Map#{ V => Counter }, [VerticeSlug | Acc]);
+dump_vertices([], _Counter, _Formatter, Map, Acc) ->
+    {Map, Acc}.
+
+dump_edges([V | Vs], G, Map, Acc) ->
+    SelfId = map_get(V, Map),
+    EdgeSlug = [io_lib:format("    ~p -> ~p~n", [SelfId, map_get(To, Map)]) ||
+                {_, To, _} <- out_edges(G, V)],
+    dump_edges(Vs, G, Map, [EdgeSlug | Acc]);
+dump_edges([], _G, _Map, Acc) ->
+    Acc.
+
+-endif.

--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -125,7 +125,7 @@
                       'put_tuple_element' | 'put_tuple_elements' |
                       'set_tuple_element'.
 
--import(lists, [foldl/3,keyfind/3,mapfoldl/3,member/2,reverse/1]).
+-import(lists, [foldl/3,keyfind/3,mapfoldl/3,member/2,reverse/1,sort/1]).
 
 -spec add_anno(Key, Value, Construct) -> Construct when
       Key :: atom(),
@@ -315,7 +315,7 @@ normalize(#b_switch{arg=Arg,fail=Fail,list=List}=Sw) ->
         #b_var{} when List =:= [] ->
             #b_br{bool=#b_literal{val=true},succ=Fail,fail=Fail};
         #b_var{} ->
-            Sw
+            Sw#b_switch{list=sort(List)}
     end;
 normalize(#b_ret{}=Ret) ->
     Ret.

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -257,12 +257,14 @@ prologue_passes(Opts) ->
           ?PASS(ssa_opt_tuple_size),
           ?PASS(ssa_opt_record),
           ?PASS(ssa_opt_cse),                   % Helps the first type pass.
-          ?PASS(ssa_opt_live),                  % ...
-          ?PASS(ssa_opt_type_start)],
+          ?PASS(ssa_opt_live)],                 % ...
     passes_1(Ps, Opts).
 
 module_passes(Opts) ->
-    Ps0 = [],
+    Ps0 = [{ssa_opt_type_start,
+            fun({StMap, FuncDb}) ->
+                    beam_ssa_type:opt_start(StMap, FuncDb)
+            end}],
     passes_1(Ps0, Opts).
 
 %% These passes all benefit from each other (in roughly this order), so they
@@ -428,10 +430,6 @@ ssa_opt_dead({#opt_st{ssa=Linear}=St, FuncDb}) ->
 
 ssa_opt_linearize({#opt_st{ssa=Blocks}=St, FuncDb}) ->
     {St#opt_st{ssa=beam_ssa:linearize(Blocks)}, FuncDb}.
-
-ssa_opt_type_start({#opt_st{ssa=Linear0,args=Args,anno=Anno}=St0, FuncDb0}) ->
-    {Linear, FuncDb} = beam_ssa_type:opt_start(Linear0, Args, Anno, FuncDb0),
-    {St0#opt_st{ssa=Linear}, FuncDb}.
 
 ssa_opt_type_continue({#opt_st{ssa=Linear0,args=Args,anno=Anno}=St0, FuncDb0}) ->
     {Linear, FuncDb} = beam_ssa_type:opt_continue(Linear0, Args, Anno, FuncDb0),

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -340,6 +340,12 @@ fdb_is([#b_set{op=call,
                                name=#b_literal{val=load_nif}},
                      _Path, _LoadInfo]} | _Is], _Caller, _FuncDb) ->
     throw(load_nif);
+fdb_is([#b_set{op=make_fun,
+               args=[#b_local{}=Callee | _]} | Is],
+       Caller, FuncDb) ->
+    %% The make_fun instruction's type depends on the return type of the
+    %% function in question, so we treat this as a function call.
+    fdb_is(Is, Caller, fdb_update(Caller, Callee, FuncDb));
 fdb_is([_ | Is], Caller, FuncDb) ->
     fdb_is(Is, Caller, FuncDb);
 fdb_is([], _Caller, FuncDb) ->

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -134,8 +134,8 @@ changed(PrevIds, FuncDb0, FuncDb, StMap0, StMap) ->
                     true ->
                         A;
                     false ->
-                        {#func_info{arg_types=ATs0,ret_types=RT0},
-                         #func_info{arg_types=ATs1,ret_types=RT1}} =
+                        {#func_info{arg_types=ATs0,succ_types=ST0},
+                         #func_info{arg_types=ATs1,succ_types=ST1}} =
                             {map_get(Id, FuncDb0),map_get(Id, FuncDb)},
 
                         %% If the argument types have changed for this
@@ -149,7 +149,7 @@ changed(PrevIds, FuncDb0, FuncDb, StMap0, StMap) ->
                                     true -> [];
                                     false -> [called]
                                 end ++
-                            case RT0 =:= RT1 of
+                            case ST0 =:= ST1 of
                                 true -> [];
                                 false -> [callers]
                             end,

--- a/lib/compiler/src/beam_ssa_opt.hrl
+++ b/lib/compiler/src/beam_ssa_opt.hrl
@@ -38,21 +38,24 @@
          %% when dealing with co-recursive functions.
          arg_types = [] :: list(arg_type_map()),
 
-         %% The inferred return types of this function, grouped by the inferred
+         %% The success types of this function, grouping return values by their
          %% argument types at the time of return.
          %%
          %% This gives us more precise types than a naive join of all returned
          %% values, as we can rule out the cases where the arguments are
          %% incompatible with the ones we're passing.
-         ret_types = ordsets:new() :: return_type_set()}).
+         %%
+         %% Note that the argument types are those seen on successful return,
+         %% they do not cover all types that are provided to the function.
+         succ_types = ordsets:new() :: success_type_set()}).
 
 -type arg_key() :: {CallerId :: func_id(),
                     CallDst :: beam_ssa:b_var()}.
 -type arg_type_map() :: #{ arg_key() => term() }.
 
 -type call_self() :: {call_self, ArgTypes :: [term()]}.
--type return_type_set() :: ordsets:ordset({ArgTypes :: [term()],
-                                           RetType :: call_self() | term()}).
+-type success_type_set() :: ordsets:ordset({ArgTypes :: [term()],
+                                            RetType :: call_self() | term()}).
 
 %% Per-function metadata used by various optimization passes to perform
 %% module-level optimization. If a function is absent it means that

--- a/lib/compiler/src/beam_ssa_opt.hrl
+++ b/lib/compiler/src/beam_ssa_opt.hrl
@@ -47,15 +47,15 @@
          %%
          %% Note that the argument types are those seen on successful return,
          %% they do not cover all types that are provided to the function.
-         succ_types = ordsets:new() :: success_type_set()}).
+         succ_types = [] :: success_type_set()}).
 
 -type arg_key() :: {CallerId :: func_id(),
                     CallDst :: beam_ssa:b_var()}.
 -type arg_type_map() :: #{ arg_key() => term() }.
 
 -type call_self() :: {call_self, ArgTypes :: [term()]}.
--type success_type_set() :: ordsets:ordset({ArgTypes :: [term()],
-                                            RetType :: call_self() | term()}).
+-type success_type_set() :: [{ArgTypes :: [term()],
+                              RetType :: call_self() | term()}].
 
 %% Per-function metadata used by various optimization passes to perform
 %% module-level optimization. If a function is absent it means that

--- a/lib/compiler/src/beam_ssa_opt.hrl
+++ b/lib/compiler/src/beam_ssa_opt.hrl
@@ -62,3 +62,10 @@
 %% module-level optimization has been turned off for said function.
 -type func_id() :: beam_ssa:b_local().
 -type func_info_db() :: #{ func_id() => #func_info{} }.
+
+-record(opt_st, {ssa :: [{beam_ssa:label(),beam_ssa:b_blk()}] |
+                        beam_ssa:block_map(),
+                 args :: [beam_ssa:b_var()],
+                 cnt :: beam_ssa:label(),
+                 anno :: beam_ssa:anno()}).
+-type st_map() :: #{ func_id() => #opt_st{} }.

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -39,6 +39,7 @@
 
 -export([make_atom/1,
          make_boolean/0,
+         make_cons/2,
          make_float/1,
          make_float/2,
          make_integer/1,
@@ -47,8 +48,8 @@
 -export([limit_depth/1]).
 
 -define(IS_LIST_TYPE(N),
-        N =:= list orelse
-        N =:= cons orelse
+        is_record(N, t_list) orelse
+        is_record(N, t_cons) orelse
         N =:= nil).
 
 -define(IS_NUMBER_TYPE(N),
@@ -347,8 +348,17 @@ subtract(#t_integer{elements={Min, Max}}, #t_integer{elements={N,N}}) ->
     end;
 subtract(number, #t_float{elements=any}) -> #t_integer{};
 subtract(number, #t_integer{elements=any}) -> #t_float{};
-subtract(list, cons) -> nil;
-subtract(list, nil) -> cons;
+
+%% A list is essentially `#t_cons{} | nil`, so we're left with nil if we
+%% subtract a cons cell that is more general than the one in the list.
+subtract(#t_list{type=TypeA,terminator=TermA}=T,
+         #t_cons{type=TypeB,terminator=TermB}) ->
+    case {meet(TypeA, TypeB), meet(TermA, TermB)} of
+        {TypeA, TermA} -> nil;
+        _ -> T
+    end;
+subtract(#t_list{type=Type,terminator=Term}, nil) ->
+    #t_cons{type=Type,terminator=Term};
 
 subtract(#t_union{atom=Atom}=A, #t_atom{}=B)->
     shrink_union(A#t_union{atom=subtract(Atom, B)});
@@ -473,8 +483,6 @@ normalize_tuple_set(A, B) ->
 make_type_from_value(Value) ->
     mtfv_1(Value).
 
-mtfv_1([]) -> nil;
-mtfv_1([_|_]) -> cons;
 mtfv_1(A) when is_atom(A) -> #t_atom{elements=[A]};
 mtfv_1(B) when is_binary(B) -> #t_bitstring{size_unit=8};
 mtfv_1(B) when is_bitstring(B) -> #t_bitstring{};
@@ -483,6 +491,11 @@ mtfv_1(F) when is_function(F) ->
     {arity, Arity} = erlang:fun_info(F, arity),
     #t_fun{arity=Arity};
 mtfv_1(I) when is_integer(I) -> make_integer(I);
+mtfv_1(L) when is_list(L)->
+    case L of
+        [_|_] -> mtfv_cons(L, none);
+        [] -> nil
+    end;
 mtfv_1(M) when is_map(M) -> #t_map{};
 mtfv_1(T) when is_tuple(T) ->
     {Es,_} = foldl(fun(Val, {Es0, Index}) ->
@@ -494,6 +507,11 @@ mtfv_1(T) when is_tuple(T) ->
 mtfv_1(_Term) ->
     any.
 
+mtfv_cons([Head | Tail], Type) ->
+    mtfv_cons(Tail, join(mtfv_1(Head), Type));
+mtfv_cons(Terminator, Type) ->
+    #t_cons{type=Type,terminator=mtfv_1(Terminator)}.
+
 -spec make_atom(atom()) -> type().
 make_atom(Atom) when is_atom(Atom) ->
     #t_atom{elements=[Atom]}.
@@ -501,6 +519,21 @@ make_atom(Atom) when is_atom(Atom) ->
 -spec make_boolean() -> type().
 make_boolean() ->
     #t_atom{elements=[false,true]}.
+
+-spec make_cons(type(), type()) -> type().
+make_cons(Head0, Tail) ->
+    case meet(Tail, #t_cons{}) of
+        #t_cons{type=Type0,terminator=Term0} ->
+            %% Propagate element and terminator types. Note that if the tail is
+            %% the union of a list and something else, the new list could be
+            %% terminated by the other types in the union.
+            Type = join(Head0, Type0),
+            Term = join(subtract(Tail, #t_cons{}), Term0),
+            #t_cons{type=Type,terminator=Term};
+        _ ->
+            %% Tail can't be a cons cell, so we know it terminates the list.
+            #t_cons{type=Head0,terminator=Tail}
+    end.
 
 -spec make_float(float()) -> type().
 make_float(Float) when is_float(Float) ->
@@ -525,43 +558,54 @@ make_integer(Min, Max) when is_integer(Min), is_integer(Max), Min =< Max ->
 limit_depth(Type) ->
     limit_depth(Type, ?MAX_TYPE_DEPTH).
 
-limit_depth(#t_tuple{elements=Es0}=T, Depth) ->
-    if Depth =< 0 ->
-            #t_tuple{elements=#{}};
-       true ->
-            Es = limit_depth_elements(Es0, Depth - 1),
-            T#t_tuple{elements=Es}
-    end;
-limit_depth(#t_union{tuple_set=TupleSet}=U, Depth) ->
-    case TupleSet of
-        none ->
-            U;
-        #t_tuple{}=Tup ->
-            U#t_union{tuple_set=limit_depth(Tup, Depth)};
-        [_|_] ->
-            if Depth =< 0 ->
-                    %% Preserve the minimum size of the tuple.
-                    [{{MinSize,_},_}|_] = TupleSet,
-                    T = #t_tuple{exact=false,size=MinSize},
-
-                    %% We must take care to get rid of the union
-                    %% wrapper if the union does not hold any other
-                    %% types than tuples.
-                    shrink_union(U#t_union{tuple_set=T});
-               true ->
-                    U#t_union{tuple_set=limit_depth_tuple_set(TupleSet, Depth)}
-            end
-    end;
+limit_depth(#t_cons{}=T, Depth) ->
+    limit_depth_list(T, Depth);
+limit_depth(#t_list{}=T, Depth) ->
+    limit_depth_list(T, Depth);
+limit_depth(#t_tuple{}=T, Depth) ->
+    limit_depth_tuple(T, Depth);
+limit_depth(#t_union{list=List0,tuple_set=TupleSet0}=U, Depth) ->
+    TupleSet = limit_depth_tuple(TupleSet0, Depth),
+    List = limit_depth_list(List0, Depth),
+    shrink_union(U#t_union{list=List,tuple_set=TupleSet});
 limit_depth(Type, _Depth) ->
     Type.
 
-limit_depth_elements(Es, Depth) ->
-    maps:map(fun(_, E) -> limit_depth(E, Depth) end, Es).
+limit_depth_list(#t_cons{type=Type0,terminator=Term0}=T, Depth) ->
+    {Type, Term} = limit_depth_list_1(Type0, Term0, Depth),
+    T#t_cons{type=Type,terminator=Term};
+limit_depth_list(#t_list{type=Type0,terminator=Term0}=T, Depth) ->
+    {Type, Term} = limit_depth_list_1(Type0, Term0, Depth),
+    T#t_list{type=Type,terminator=Term};
+limit_depth_list(nil, _Depth) ->
+    nil;
+limit_depth_list(none, _Depth) ->
+    none.
 
-limit_depth_tuple_set([{SzTag,Tuple}|Ts], Depth) ->
-    [{SzTag,limit_depth(Tuple, Depth)}|limit_depth_tuple_set(Ts, Depth)];
-limit_depth_tuple_set([], _Depth) ->
-    [].
+limit_depth_list_1(Type0, Terminator0, Depth) when Depth > 0 ->
+    Type = limit_depth(Type0, Depth - 1),
+    Terminator = limit_depth(Terminator0, Depth - 1),
+    {Type, Terminator};
+limit_depth_list_1(_Type, _Terminator, Depth) when Depth =< 0 ->
+    {any, any}.
+
+limit_depth_tuple(#t_tuple{elements=Es0}=T, Depth) ->
+    if
+        Depth > 0 ->
+            Es = maps:map(fun(_, E) -> limit_depth(E, Depth - 1) end, Es0),
+            T#t_tuple{elements=Es};
+        Depth =< 0 ->
+            #t_tuple{elements=#{}}
+    end;
+limit_depth_tuple([{{MinSize,_},_}|_], Depth) when Depth =< 0 ->
+    %% Preserve the minimum size of the tuple set.
+    #t_tuple{exact=false,size=MinSize};
+limit_depth_tuple([{SzTag,Tuple}|Ts], Depth) ->
+    [{SzTag, limit_depth_tuple(Tuple, Depth)} | limit_depth_tuple(Ts, Depth)];
+limit_depth_tuple([], _Depth) ->
+    [];
+limit_depth_tuple(none, _Depth) ->
+    none.
 
 %%%
 %%% Helpers
@@ -628,6 +672,21 @@ glb(#t_bs_matchable{tail_unit=UnitA}, #t_bitstring{size_unit=UnitB}=T) ->
 glb(#t_bs_matchable{tail_unit=UnitA}, #t_bs_context{tail_unit=UnitB}=T) ->
     Unit = UnitA * UnitB div gcd(UnitA, UnitB),
     T#t_bs_context{tail_unit=Unit};
+glb(#t_cons{type=TypeA,terminator=TermA},
+    #t_cons{type=TypeB,terminator=TermB}) ->
+    %% Note the use of meet/2; elements don't need to be normal types.
+    case {meet(TypeA, TypeB), meet(TermA, TermB)} of
+        {none, _} -> none;
+        {_, none} -> none;
+        {Type, Term} -> #t_cons{type=Type,terminator=Term}
+    end;
+glb(#t_cons{type=TypeA,terminator=TermA},
+    #t_list{type=TypeB,terminator=TermB}) ->
+    case {meet(TypeA, TypeB), meet(TermA, TermB)} of
+        {none, _} -> none;
+        {_, none} -> none;
+        {Type, Term} -> #t_cons{type=Type,terminator=Term}
+    end;
 glb(#t_float{}=T, #t_float{elements=any}) ->
     T;
 glb(#t_float{elements=any}, #t_float{}=T) ->
@@ -650,14 +709,29 @@ glb(#t_integer{elements={MinA,MaxA}}, #t_integer{elements={MinB,MaxB}})
        MinB >= MinA, MinB =< MaxA ->
     true = MinA =< MaxA andalso MinB =< MaxB,   %Assertion.
     #t_integer{elements={max(MinA, MinB),min(MaxA, MaxB)}};
-glb(#t_integer{}=T, number) -> T;
-glb(#t_float{}=T, number) -> T;
-glb(number, #t_integer{}=T) -> T;
-glb(number, #t_float{}=T) -> T;
-glb(list, cons) -> cons;
-glb(list, nil) -> nil;
-glb(cons, list) -> cons;
-glb(nil, list) -> nil;
+glb(#t_integer{}=T, number) ->
+    T;
+glb(#t_float{}=T, number) ->
+    T;
+glb(#t_list{type=TypeA,terminator=TermA},
+    #t_list{type=TypeB,terminator=TermB}) ->
+    %% A list is a union of `[type() | _]` and `[]`, so we're left with
+    %% nil when the element types are incompatible.
+    case {meet(TypeA, TypeB), meet(TermA, TermB)} of
+        {none, _} -> nil;
+        {_, none} -> nil;
+        {Type, Term} -> #t_list{type=Type,terminator=Term}
+    end;
+glb(#t_list{}=A, #t_cons{}=B) ->
+    glb(B, A);
+glb(#t_list{}, nil) ->
+    nil;
+glb(nil, #t_list{}) ->
+    nil;
+glb(number, #t_integer{}=T) ->
+    T;
+glb(number, #t_float{}=T) ->
+    T;
 glb(#t_tuple{}=T1, #t_tuple{}=T2) ->
     glb_tuples(T1, T2);
 glb(_, _) ->
@@ -754,29 +828,50 @@ lub(#t_bs_matchable{tail_unit=UnitA}, #t_bitstring{size_unit=UnitB}) ->
     lub_bs_matchable(UnitA, UnitB);
 lub(#t_bs_matchable{tail_unit=UnitA}, #t_bs_context{tail_unit=UnitB}) ->
     lub_bs_matchable(UnitA, UnitB);
+lub(#t_cons{type=TypeA,terminator=TermA},
+    #t_cons{type=TypeB,terminator=TermB}) ->
+    %% Note the use of join/2; elements don't need to be normal types.
+    #t_cons{type=join(TypeA,TypeB),terminator=join(TermA, TermB)};
+lub(#t_cons{type=TypeA,terminator=TermA},
+    #t_list{type=TypeB,terminator=TermB}) ->
+    #t_list{type=join(TypeA,TypeB),terminator=join(TermA, TermB)};
+lub(#t_cons{type=Type,terminator=Term}, nil) ->
+    #t_list{type=Type,terminator=Term};
 lub(#t_float{elements={MinA,MaxA}},
     #t_float{elements={MinB,MaxB}}) ->
     #t_float{elements={min(MinA,MinB),max(MaxA,MaxB)}};
 lub(#t_float{}, #t_float{}) ->
     #t_float{};
+lub(#t_float{}, #t_integer{}) ->
+    number;
+lub(#t_float{}, number) ->
+    number;
 lub(#t_fun{}, #t_fun{}) ->
     #t_fun{};
 lub(#t_integer{elements={MinA,MaxA}},
     #t_integer{elements={MinB,MaxB}}) ->
     #t_integer{elements={min(MinA,MinB),max(MaxA,MaxB)}};
-lub(#t_integer{}, #t_integer{}) -> #t_integer{};
-lub(list, cons) -> list;
-lub(cons, list) -> list;
-lub(nil, cons) -> list;
-lub(cons, nil) -> list;
-lub(nil, list) -> list;
-lub(list, nil) -> list;
-lub(#t_integer{}, #t_float{}) -> number;
-lub(#t_float{}, #t_integer{}) -> number;
-lub(#t_integer{}, number) -> number;
-lub(number, #t_integer{}) -> number;
-lub(#t_float{}, number) -> number;
-lub(number, #t_float{}) -> number;
+lub(#t_integer{}, #t_integer{}) ->
+    #t_integer{};
+lub(#t_integer{}, #t_float{}) ->
+    number;
+lub(#t_integer{}, number) ->
+    number;
+lub(#t_list{type=TypeA,terminator=TermA},
+    #t_list{type=TypeB,terminator=TermB}) ->
+    #t_list{type=join(TypeA, TypeB),terminator=join(TermA, TermB)};
+lub(#t_list{}=A, #t_cons{}=B) ->
+    lub(B, A);
+lub(nil=A, #t_cons{}=B) ->
+    lub(B, A);
+lub(nil, #t_list{}=T) ->
+    T;
+lub(#t_list{}=T, nil) ->
+    T;
+lub(number, #t_integer{}) ->
+    number;
+lub(number, #t_float{}) ->
+    number;
 lub(#t_tuple{size=Sz,exact=ExactA,elements=EsA},
     #t_tuple{size=Sz,exact=ExactB,elements=EsB}) ->
     Exact = ExactA and ExactB,
@@ -909,6 +1004,10 @@ verified_normal_type(#t_bs_context{tail_unit=U}=T)
 verified_normal_type(#t_bs_matchable{tail_unit=U}=T)
   when is_integer(U), U >= 1 ->
     T;
+verified_normal_type(#t_cons{type=Type,terminator=Term}=T) ->
+    _ = verified_type(Type),
+    _ = verified_type(Term),
+    T;
 verified_normal_type(#t_fun{arity=Arity}=T)
   when Arity =:= any; is_integer(Arity) ->
     T;
@@ -917,10 +1016,12 @@ verified_normal_type(#t_integer{elements=any}=T) -> T;
 verified_normal_type(#t_integer{elements={Min,Max}}=T)
   when is_integer(Min), is_integer(Max), Min =< Max ->
     T;
-verified_normal_type(list=T) -> T;
+verified_normal_type(#t_list{type=Type,terminator=Term}=T) ->
+    _ = verified_type(Type),
+    _ = verified_type(Term),
+    T;
 verified_normal_type(#t_map{}=T) -> T;
 verified_normal_type(nil=T) -> T;
-verified_normal_type(cons=T) -> T;
 verified_normal_type(number=T) -> T;
 verified_normal_type(#t_tuple{size=Size,elements=Es}=T) ->
     %% All known elements must have a valid index and type (which may be a

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -57,7 +57,8 @@
                        valid=0 :: non_neg_integer()}).
 -record(t_bs_matchable, {tail_unit=1}).
 -record(t_float, {elements=any :: 'any' | {float(),float()}}).
--record(t_fun, {arity=any :: arity() | 'any'}).
+-record(t_fun, {arity=any :: arity() | 'any',
+                type=any :: type() }).
 -record(t_integer, {elements=any :: 'any' | {integer(),integer()}}).
 -record(t_map, {}).
 

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -34,8 +34,8 @@
 %%    - number               Any number.
 %%       -- #t_float{}       Floating point number.
 %%       -- #t_integer{}     Integer.
-%%    - list                 Any list.
-%%       -- cons             Cons (nonempty list).
+%%    - #t_list{}            Any list.
+%%       -- #t_cons{}        Cons (nonempty list).
 %%       -- nil              The empty list.
 %%    - #t_tuple{}           Tuple.
 %%
@@ -51,15 +51,25 @@
 -define(ATOM_SET_SIZE, 5).
 
 -record(t_atom, {elements=any :: 'any' | ordsets:ordset(atom())}).
--record(t_float, {elements=any :: 'any' | {float(),float()}}).
--record(t_fun, {arity=any :: arity() | 'any'}).
--record(t_integer, {elements=any :: 'any' | {integer(),integer()}}).
 -record(t_bitstring, {size_unit=1 :: pos_integer()}).
 -record(t_bs_context, {tail_unit=1 :: pos_integer(),
                        slots=0 :: non_neg_integer(),
                        valid=0 :: non_neg_integer()}).
 -record(t_bs_matchable, {tail_unit=1}).
+-record(t_float, {elements=any :: 'any' | {float(),float()}}).
+-record(t_fun, {arity=any :: arity() | 'any'}).
+-record(t_integer, {elements=any :: 'any' | {integer(),integer()}}).
 -record(t_map, {}).
+
+%% `type` is the join of all list elements, and `terminator` is the tail of the
+%% last cons cell ('nil' for proper lists).
+%%
+%% Note that `type` may not be updated unless the entire list is known, and
+%% that the terminator being known is not a guarantee that the rest of the list
+%% is.
+-record(t_cons, {type=any :: type(), terminator=any :: type()}).
+-record(t_list, {type=any :: type(), terminator=any :: type()}).
+
 -record(t_tuple, {size=0 :: integer(),
                   exact=false :: boolean(),
                   elements=#{} :: tuple_elements()}).
@@ -72,11 +82,11 @@
 -type tuple_elements() :: #{ Key :: pos_integer() => type() }.
 
 -type normal_type() :: any | none |
-                       list | cons | nil |
                        number | #t_float{} | #t_integer{} |
                        #t_atom{} |
                        #t_bitstring{} | #t_bs_context{} | #t_bs_matchable{} |
                        #t_fun{} |
+                       #t_list{} | #t_cons{} | nil |
                        #t_map{} |
                        #t_tuple{}.
 
@@ -85,7 +95,7 @@
 -type tuple_set() :: #t_tuple{} | record_set().
 
 -record(t_union, {atom=none :: none | #t_atom{},
-                  list=none :: none | list | cons | nil,
+                  list=none :: none | #t_list{} | #t_cons{} | nil,
                   number=none :: none | number | #t_float{} | #t_integer{},
                   tuple_set=none :: none | tuple_set(),
                   other=none :: normal_type()}).

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -50,7 +50,7 @@
 
 -define(ATOM_SET_SIZE, 5).
 
--record(t_atom, {elements=any :: 'any' | [atom()]}).
+-record(t_atom, {elements=any :: 'any' | ordsets:ordset(atom())}).
 -record(t_float, {elements=any :: 'any' | {float(),float()}}).
 -record(t_fun, {arity=any :: arity() | 'any'}).
 -record(t_integer, {elements=any :: 'any' | {integer(),integer()}}).

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -437,10 +437,12 @@ valfun_1({gc_bif,Op,{f,0},Live,Ss,Dst}=I, Vst0) ->
     end;
 %% Put instructions.
 valfun_1({put_list,A,B,Dst}, Vst0) ->
-    assert_term(A, Vst0),
-    assert_term(B, Vst0),
     Vst = eat_heap(2, Vst0),
-    create_term(cons, put_list, [A, B], Dst, Vst);
+
+    Head = get_term_type(A, Vst),
+    Tail = get_term_type(B, Vst),
+
+    create_term(beam_types:make_cons(Head, Tail), put_list, [A, B], Dst, Vst);
 valfun_1({put_tuple2,Dst,{list,Elements}}, Vst0) ->
     _ = [assert_term(El, Vst0) || El <- Elements],
     Size = length(Elements),
@@ -631,17 +633,30 @@ valfun_1({try_case,Reg}, #vst{current=#st{ct=[Tag|_]}}=Vst0) ->
 %% Simple getters that can't fail.
 valfun_1({get_list,Src,D1,D2}, Vst0) ->
     assert_not_literal(Src),
-    assert_type(cons, Src, Vst0),
-    Vst = extract_term(any, get_hd, [Src], D1, Vst0),
-    extract_term(any, get_tl, [Src], D2, Vst);
+    assert_type(#t_cons{}, Src, Vst0),
+
+    SrcType = get_term_type(Src, Vst0),
+    {HeadType, _, _} = beam_call_types:types(erlang, hd, [SrcType]),
+    {TailType, _, _} = beam_call_types:types(erlang, tl, [SrcType]),
+
+    Vst = extract_term(HeadType, get_hd, [Src], D1, Vst0),
+    extract_term(TailType, get_tl, [Src], D2, Vst, Vst0);
 valfun_1({get_hd,Src,Dst}, Vst) ->
     assert_not_literal(Src),
-    assert_type(cons, Src, Vst),
-    extract_term(any, get_hd, [Src], Dst, Vst);
+    assert_type(#t_cons{}, Src, Vst),
+
+    SrcType = get_term_type(Src, Vst),
+    {HeadType, _, _} = beam_call_types:types(erlang, hd, [SrcType]),
+
+    extract_term(HeadType, get_hd, [Src], Dst, Vst);
 valfun_1({get_tl,Src,Dst}, Vst) ->
     assert_not_literal(Src),
-    assert_type(cons, Src, Vst),
-    extract_term(any, get_tl, [Src], Dst, Vst);
+    assert_type(#t_cons{}, Src, Vst),
+
+    SrcType = get_term_type(Src, Vst),
+    {TailType, _, _} = beam_call_types:types(erlang, tl, [SrcType]),
+
+    extract_term(TailType, get_tl, [Src], Dst, Vst);
 valfun_1({get_tuple_element,Src,N,Dst}, Vst) ->
     Index = N+1,
     assert_not_literal(Src),
@@ -949,11 +964,11 @@ valfun_3({test,is_tuple,{f,Lbl},[Src]}, Vst) ->
 valfun_3({test,is_integer,{f,Lbl},[Src]}, Vst) ->
     type_test(Lbl, #t_integer{}, Src, Vst);
 valfun_3({test,is_nonempty_list,{f,Lbl},[Src]}, Vst) ->
-    type_test(Lbl, cons, Src, Vst);
+    type_test(Lbl, #t_cons{}, Src, Vst);
 valfun_3({test,is_number,{f,Lbl},[Src]}, Vst) ->
     type_test(Lbl, number, Src, Vst);
 valfun_3({test,is_list,{f,Lbl},[Src]}, Vst) ->
-    type_test(Lbl, list, Src, Vst);
+    type_test(Lbl, #t_list{}, Src, Vst);
 valfun_3({test,is_map,{f,Lbl},[Src]}, Vst) ->
     type_test(Lbl, #t_map{}, Src, Vst);
 valfun_3({test,is_nil,{f,Lbl},[Src]}, Vst) ->
@@ -1812,7 +1827,7 @@ infer_types_1(#value{op={bif,is_float},args=[Src]}, Val, Op, Vst) ->
 infer_types_1(#value{op={bif,is_integer},args=[Src]}, Val, Op, Vst) ->
     infer_type_test_bif(#t_integer{}, Src, Val, Op, Vst);
 infer_types_1(#value{op={bif,is_list},args=[Src]}, Val, Op, Vst) ->
-    infer_type_test_bif(list, Src, Val, Op, Vst);
+    infer_type_test_bif(#t_list{}, Src, Val, Op, Vst);
 infer_types_1(#value{op={bif,is_map},args=[Src]}, Val, Op, Vst) ->
     infer_type_test_bif(#t_map{}, Src, Val, Op, Vst);
 infer_types_1(#value{op={bif,is_number},args=[Src]}, Val, Op, Vst) ->

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -2114,6 +2114,7 @@ pre_load() ->
 	 beam_call_types,
 	 beam_clean,
 	 beam_dict,
+	 beam_digraph,
 	 beam_flatten,
 	 beam_jump,
 	 beam_kernel_to_ssa,

--- a/lib/compiler/src/compiler.app.src
+++ b/lib/compiler/src/compiler.app.src
@@ -27,6 +27,7 @@
              beam_call_types,
 	     beam_clean,
 	     beam_dict,
+	     beam_digraph,
 	     beam_disasm,
 	     beam_flatten,
 	     beam_jump,

--- a/lib/compiler/test/beam_types_SUITE.erl
+++ b/lib/compiler/test/beam_types_SUITE.erl
@@ -29,7 +29,8 @@
          associativity/1,
          commutativity/1,
          idempotence/1,
-         identity/1]).
+         identity/1,
+         subtraction/1]).
 
 -export([binary_absorption/1,
          integer_absorption/1,
@@ -50,7 +51,8 @@ groups() ->
        associativity,
        commutativity,
        idempotence,
-       identity]}].
+       identity,
+       subtraction]}].
 
 init_per_suite(Config) ->
     ct_property_test:init_per_suite(Config).
@@ -77,6 +79,10 @@ idempotence(Config) when is_list(Config) ->
 identity(Config) when is_list(Config) ->
     %% manual test: proper:quickcheck(beam_types_prop:identity()).
     true = ct_property_test:quickcheck(beam_types_prop:identity(), Config).
+
+subtraction(Config) when is_list(Config) ->
+    %% manual test: proper:quickcheck(beam_types_prop:subtraction()).
+    true = ct_property_test:quickcheck(beam_types_prop:subtraction(), Config).
 
 binary_absorption(Config) when is_list(Config) ->
     %% These binaries should meet into {binary,12} as that's the best common

--- a/lib/compiler/test/beam_validator_SUITE.erl
+++ b/lib/compiler/test/beam_validator_SUITE.erl
@@ -251,7 +251,7 @@ cons_guard(Config) when is_list(Config) ->
     [{{cons,foo,1},
       {{get_list,{x,0},{x,1},{x,2}},
        5,
-       {bad_type,{needed,cons},{actual,any}}}}] = Errors,
+       {bad_type,{needed,{t_cons,any,any}},{actual,any}}}}] = Errors,
     ok.
 
 freg_range(Config) when is_list(Config) ->

--- a/lib/compiler/test/property_test/beam_types_prop.erl
+++ b/lib/compiler/test/property_test/beam_types_prop.erl
@@ -163,22 +163,22 @@ other_types() ->
     [any,
      gen_atom(),
      gen_bs_matchable(),
-     gen_fun(),
      none].
 
 numerical_types() ->
     [gen_integer(), gen_float(), number].
 
 nested_types(Depth) when Depth >= 3 -> [none];
-nested_types(Depth) -> list_types(Depth) ++
+nested_types(Depth) -> list_types(Depth + 1) ++
                            [#t_map{},
+                            gen_fun(Depth + 1),
                             gen_union(Depth + 1),
                             gen_tuple(Depth + 1)].
 
 list_types(Depth) when Depth >= 3 ->
     [nil];
 list_types(Depth) ->
-    [gen_list(Depth + 1), gen_cons(Depth + 1), nil].
+    [gen_list(Depth), gen_cons(Depth), nil].
 
 gen_atom() ->
     ?LET(Size, range(0, ?ATOM_SET_SIZE),
@@ -200,8 +200,10 @@ gen_bs_matchable() ->
            ?LET(Unit, range(1, 128), #t_bs_context{tail_unit=Unit}),
            ?LET(Unit, range(1, 128), #t_bitstring{size_unit=Unit})]).
 
-gen_fun() ->
-    oneof([?LET(Arity, range(1, 8), #t_fun{arity=Arity}), #t_fun{arity=any}]).
+gen_fun(Depth) ->
+    oneof([?LET(Arity, range(1, 8),
+                #t_fun{type=type(Depth),arity=Arity}),
+                #t_fun{type=type(Depth),arity=any}]).
 
 gen_integer() ->
     oneof([gen_integer_bounded(), #t_integer{}]).

--- a/lib/compiler/test/property_test/beam_types_prop.erl
+++ b/lib/compiler/test/property_test/beam_types_prop.erl
@@ -88,7 +88,7 @@ commutativity_1() ->
     ?FORALL({TypeA, TypeB},
             ?LET(TypeA, type(),
                  ?LET(TypeB, type(), {TypeA, TypeB})),
-             commutativity_check(TypeA, TypeB)).
+            commutativity_check(TypeA, TypeB)).
 
 commutativity_check(A, B) ->
     %% a ∨ b = b ∨ a,
@@ -126,8 +126,26 @@ identity_check(Type) ->
 
     true.
 
+subtraction() ->
+    numtests(?REPETITIONS, subtraction_1()).
+
+subtraction_1() ->
+    ?FORALL({TypeA, TypeB},
+            ?LET(TypeA, type(),
+                 ?LET(TypeB, type(), {TypeA, TypeB})),
+            subtraction_check(TypeA, TypeB)).
+
+subtraction_check(A, B) ->
+    %% Subtraction can be thought of as `a ∧ ¬b`, so the result must be at
+    %% least as specific as `a`.
+    Res = subtract(A, B),
+    Res = meet(A, Res),
+
+    true.
+
 meet(A, B) -> beam_types:meet(A, B).
 join(A, B) -> beam_types:join(A, B).
+subtract(A, B) -> beam_types:subtract(A, B).
 
 %%%
 %%% Generators
@@ -139,7 +157,6 @@ type() ->
 type(Depth) ->
     oneof(nested_types(Depth) ++
               numerical_types() ++
-              list_types() ++
               other_types()).
 
 other_types() ->
@@ -149,14 +166,19 @@ other_types() ->
      gen_fun(),
      none].
 
-list_types() ->
-    [cons, list, nil].
-
 numerical_types() ->
     [gen_integer(), gen_float(), number].
 
 nested_types(Depth) when Depth >= 3 -> [none];
-nested_types(Depth) -> [#t_map{}, gen_union(Depth + 1), gen_tuple(Depth + 1)].
+nested_types(Depth) -> list_types(Depth) ++
+                           [#t_map{},
+                            gen_union(Depth + 1),
+                            gen_tuple(Depth + 1)].
+
+list_types(Depth) when Depth >= 3 ->
+    [nil];
+list_types(Depth) ->
+    [gen_list(Depth + 1), gen_cons(Depth + 1), nil].
 
 gen_atom() ->
     ?LET(Size, range(0, ?ATOM_SET_SIZE),
@@ -190,6 +212,14 @@ gen_integer_bounded() ->
              #t_integer{elements={min(A,B), max(A,B)}}
          end).
 
+gen_cons(Depth) ->
+    ?LET({Type, Term}, {gen_element(Depth), gen_element(Depth)},
+         #t_cons{type=Type,terminator=Term}).
+
+gen_list(Depth) ->
+    ?LET({Type, Term}, {gen_element(Depth), gen_element(Depth)},
+         #t_list{type=Type,terminator=Term}).
+
 gen_float() ->
     oneof([gen_float_bounded(), #t_float{}]).
 
@@ -216,13 +246,13 @@ gen_union(Depth) ->
 gen_wide_union(Depth) ->
     ?LET({A, B, C, D}, {oneof(nested_types(Depth)),
                         oneof(numerical_types()),
-                        oneof(list_types()),
+                        oneof(list_types(Depth)),
                         oneof(other_types())},
-          begin
-              T0 = join(A, B),
-              T1 = join(T0, C),
-              join(T1, D)
-          end).
+         begin
+             T0 = join(A, B),
+             T1 = join(T0, C),
+             join(T1, D)
+         end).
 
 gen_tuple_union(Depth) ->
     ?SIZED(Size,


### PR DESCRIPTION
The cross-function type optimization introduced in PR #2100 removed a lot of redundant type checks, but the implementation was very naive and often lost type information in recursive functions which greatly limited its effectiveness. For example, it couldn't figure out that the following always produced a proper list:

```erlang
foo([A | As]) -> [A | foo(As)];
foo([]) -> [].
```

This PR improves the compiler's understanding of recursive functions and leverages that to keep track of types inside lists, allowing us to remove more type tests in loops.

I'm still waiting for the benchmarks to finish running, but until then [here's an assembly diff](https://github.com/erlang/otp/files/3858858/improved_type_inference_diff.txt) showing the impact this PR has on OTP and parts of Elixir.