### PR TITLE
Allow changing the -mode when the system restarts

### DIFF
--- a/erts/doc/src/init.xml
+++ b/erts/doc/src/init.xml
@@ -165,12 +165,24 @@
       <name name="restart" arity="0" since=""/>
       <fsummary>Restart the running Erlang node.</fsummary>
       <desc>
+        <p>The same as
+    <seealso marker="#restart/1"><c>restart([])</c></seealso>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="restart" arity="1" since="OTP 23.0"/>
+      <fsummary>Restart the running Erlang node.</fsummary>
+      <desc>
         <p>The system is restarted <em>inside</em> the running Erlang
           node, which means that the emulator is not restarted. All
           applications are taken down smoothly, all code is unloaded,
           and all ports are closed before the system is booted again in
-          the same way as initially started. The same <c>BootArgs</c>
-          are used again.</p>
+          the same way as initially started.</p>
+        <p>The same <c>BootArgs</c> are used when restarting the
+          system unless the <c>mode</c> option is given, allowing the
+          code loading mode to be set to either <c>embedded</c> or
+          <c>interactive</c>. All other <c>BootArgs</c> remain the same.</p>
         <p>To limit the shutdown time, the time <c>init</c> is allowed
           to spend taking down applications, command-line flag
           <c>-shutdown_time</c> is to be used.</p>


### PR DESCRIPTION
In order for Elixir developers to configure their
systems using Elixir syntax, the Elixir application
must be started. However, in order to start the
Elixir application, kernel and stdlib need to be
started, which means we can't configure those
applications.

Elixir addresses this by booting twice. First, the
system boots with a minimal set of apps started, then
it executes the configuration files, writes them to
disk and restarts the system, which will pick up the
new configuration.

The problem with such approach is that, when running
in embedded mode, starting and shutting down the system
takes a long period of time, due to the loading and
purging of all modules.

This PR addresses the problem by allowing the mode to
be changed to embedded on init:restart/1. This allows
Elixir to first boot in interactive mode, load the
configuration, and then start the system in embedded
mode.

This reduces the boot time in the sample application
that reproduces the problem from 5s to 1s.