### PR TITLE
Preserve http headers original case while erlang:decode_packet/3

### DIFF
--- a/erts/emulator/beam/packet_parser.c
+++ b/erts/emulator/beam/packet_parser.c
@@ -780,7 +780,6 @@ int packet_parse_http(const char* buf, int len, int* statep,
         }
     }
     else {
-        int up = 1;      /* make next char uppercase */
         http_atom_t* name;
         char name_buf[HTTP_MAX_NAME_LEN];
         const char* name_ptr = name_buf;
@@ -797,18 +796,6 @@ int packet_parse_http(const char* buf, int len, int* statep,
         while (!is_tspecial((unsigned char)*ptr)) {
             if (name_len < HTTP_MAX_NAME_LEN) {
                 int c = *ptr;
-                if (up) {
-                    if (islower(c)) {
-                        c = toupper(c);
-                    }
-                    up = 0;
-                }
-                else {
-                    if (isupper(c))
-                        c = tolower(c);
-                    else if (c == '-')
-                        up = 1;
-                }                            
                 name_buf[name_len] = c;
                 hash_update(h, c);
             }


### PR DESCRIPTION
Function `erlang:decode_packet/3` titleizes header names (convert the case to `X-Awesome-Header` shape) for some reason. By [RFC](https://tools.ietf.org/html/rfc2616#section-4.2) headers are case-insensitive. But in some cases in can be important to keep the original case of the header name. For example for testing purposes. bookish_spork library tries to give a user the most precise means for http request introspection as possible. Preserving headers case will allow to check how http-clients and some api libraries manage headers

See: https://github.com/tank-bohr/bookish_spork/issues/44