### PR TITLE
Add uri_string:resolve/2,3

### DIFF
--- a/lib/stdlib/doc/src/uri_string.xml
+++ b/lib/stdlib/doc/src/uri_string.xml
@@ -265,7 +265,7 @@
       <fsummary>Syntax-based normalization.</fsummary>
       <desc>
 	<p>Same as <c>normalize/1</c> but with an additional
-	<c><anno>Options</anno></c> parameter, that controls if the normalized URI
+	<c><anno>Options</anno></c> parameter, that controls whether the normalized URI
 	shall be returned as an uri_map().
 	There is one supported option: <c>return_map</c>.
 	</p>
@@ -328,6 +328,47 @@
 
 2> <input>uri_string:recompose(URIMap).</input>
 "foo://example.com:8042/over/there?name=ferret#nose"</pre>
+      </desc>
+    </func>
+
+    <func>
+      <name name="resolve" arity="2" since="OTP @OTP-16321@"/>
+      <fsummary>Relative resolution.</fsummary>
+      <desc>
+        <p>Convert a <c><anno>RefURI</anno></c> reference that might be relative
+	to a given base URI into the parsed components of the reference's target,
+	which can then be recomposed to form the target URI.</p>
+        <p><em>Example:</em></p>
+        <pre>
+1> <input>uri_string:resolve("/abs/ol/ute", "http://localhost/a/b/c?q").</input>
+"http://localhost/abs/ol/ute"
+2> uri_string:resolve("../relative", "http://localhost/a/b/c?q").
+"http://localhost/a/relative"
+3> uri_string:resolve("http://localhost/full", "http://localhost/a/b/c?q").
+"http://localhost/full"
+4> uri_string:resolve(#{path => "path", query => "xyz"}, "http://localhost/a/b/c?q").
+"http://localhost/a/b/path?xyz"
+	</pre>
+      </desc>
+    </func>
+
+    <func>
+      <name name="resolve" arity="3" since="OTP @OTP-16321@"/>
+      <fsummary>Relative resolution.</fsummary>
+      <desc>
+	<p>Same as <c>resolve/2</c> but with an additional
+	<c><anno>Options</anno></c> parameter, that controls whether the target URI
+	shall be returned as an uri_map().
+	There is one supported option: <c>return_map</c>.
+	</p>
+        <p><em>Example:</em></p>
+        <pre>
+1> <input>uri_string:resolve("/abs/ol/ute", "http://localhost/a/b/c?q", [return_map]).</input>
+#{host => "localhost",path => "/abs/ol/ute",scheme => "http"}
+2> uri_string:resolve(#{path => "/abs/ol/ute"}, #{scheme => "http",
+2> host => "localhost", path => "/a/b/c?q"}, [return_map]).
+#{host => "localhost",path => "/abs/ol/ute",scheme => "http"}
+	</pre>
       </desc>
     </func>
 


### PR DESCRIPTION
Please consider including them in OTP directly. For some backstory:

I was looking for this function because as part of implementing the parsing for the Link HTTP header it's necessary to resolve potentially relative URIs according to https://tools.ietf.org/html/rfc3986#section-5

After asking it turns out @darkling already needed this function in https://github.com/darkling/lagra/blob/30bba5322630382f046decb9bb83fd4ea75e058c/src/lagra_parser_turtle_parser.erl#L585

I asked him about license but I needed it before I got a response so I reimplemented it in Cowlib here: https://github.com/ninenines/cowlib/blob/master/src/cow_link.erl#L261

This is this implementation that I submit here as a PR, which is more or less the algorithm from https://tools.ietf.org/html/rfc3986#section-5.2.2

The documentation is currently missing and the whitespace/indentation is probably wrong, I'll add/fix them once I get some feedback.