### PR TITLE
uri_string:normalize/2 may return error()

### DIFF
--- a/lib/stdlib/src/uri_string.erl
+++ b/lib/stdlib/src/uri_string.erl
@@ -306,7 +306,8 @@ normalize(URIMap) ->
 -spec normalize(URI, Options) -> NormalizedURI when
       URI :: uri_string() | uri_map(),
       Options :: [return_map],
-      NormalizedURI :: uri_string() | uri_map().
+      NormalizedURI :: uri_string() | uri_map()
+                     | error().
 normalize(URIMap, []) when is_map(URIMap) ->
     recompose(normalize_map(URIMap));
 normalize(URIMap, [return_map]) when is_map(URIMap) ->


### PR DESCRIPTION
~~Also remove an unnecessary try/catch in uri_string:normalize/1.~~