### PR TITLE
ETS Optimizations (for +S 1)

### DIFF
--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -344,6 +344,8 @@ typedef struct db_table_common {
 #define NFIXED(T) (erts_refc_read(&(T)->common.fix_count,0))
 #define IS_FIXED(T) (NFIXED(T) != 0) 
 
+#define DB_LOCK_FREE() (erts_no_schedulers == 1)
+
 /*
  * tplp is an untagged pointer to a tuple we know is large enough
  * and dth is a pointer to a DbTableHash.

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -344,7 +344,8 @@ typedef struct db_table_common {
 #define NFIXED(T) (erts_refc_read(&(T)->common.fix_count,0))
 #define IS_FIXED(T) (NFIXED(T) != 0) 
 
-#define DB_LOCK_FREE() (erts_no_schedulers == 1)
+#define META_DB_LOCK_FREE() (erts_no_schedulers == 1)
+#define DB_LOCK_FREE(T) META_DB_LOCK_FREE()
 
 /*
  * tplp is an untagged pointer to a tuple we know is large enough


### PR DESCRIPTION
* Remove table locking when using +S 1
* Optimize meta table lock to not be taken when using +S 1
* Optimize dec_term for atoms when used by ets compressed

Together these changes can significantly reduce the CPU usage of applications using only one scheduler.