### PR TITLE
dbg improvments

### DIFF
--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -926,6 +926,13 @@ int enif_send(ErlNifEnv* env, const ErlNifPid* to_pid,
             msgq = msgq->next;
         }
 
+        if (t_p && scheduler > 0 && copy_sz > ERTS_MSG_COPY_WORDS_PER_REDUCTION) {
+            Uint reds = copy_sz / ERTS_MSG_COPY_WORDS_PER_REDUCTION;
+            if (reds > CONTEXT_REDS)
+                reds = CONTEXT_REDS;
+            BUMP_REDS(t_p, (int) reds);
+        }
+
 #ifdef ERTS_ENABLE_LOCK_CHECK
         lc_locks = erts_proc_lc_my_proc_locks(rp);
         rp_locks |= lc_locks;

--- a/lib/kernel/src/logger_olp.erl
+++ b/lib/kernel/src/logger_olp.erl
@@ -517,9 +517,8 @@ check_load(State = #{id:=_Name, mode_ref := ModeRef, mode := Mode,
                      sync_mode_qlen := SyncModeQLen,
                      drop_mode_qlen := DropModeQLen,
                      flush_qlen := FlushQLen}) ->
-    {_,Mem} = process_info(self(), memory),
+    [{_,Mem},{_,QLen}] = process_info(self(), [memory,message_queue_len]),
     ?observe(_Name,{max_mem,Mem}),
-    {_,QLen} = process_info(self(), message_queue_len),
     ?observe(_Name,{max_qlen,QLen}),
     %% When the handler process gets scheduled in, it's impossible
     %% to predict the QLen. We could jump "up" arbitrarily from say

--- a/lib/kernel/src/logger_olp.erl
+++ b/lib/kernel/src/logger_olp.erl
@@ -57,7 +57,7 @@
       Module :: module(),
       Args :: term(),
       OLPOptions :: options(),
-      Options :: proc_lib:spawn_options(),
+      Options :: [proc_lib:spawn_option()],
       Pid :: pid(),
       Olp :: olp_ref(),
       Reason :: term().
@@ -69,7 +69,7 @@ start(Module,Args,OLPOptions,Options) when is_map(OLPOptions) ->
       Module :: module(),
       Args :: term(),
       OLPOptions :: options(),
-      Options :: proc_lib:spawn_options(),
+      Options :: [proc_lib:spawn_option()],
       Pid :: pid(),
       Olp :: olp_ref(),
       Reason :: term().

--- a/lib/runtime_tools/doc/src/dbg.xml
+++ b/lib/runtime_tools/doc/src/dbg.xml
@@ -808,7 +808,7 @@ Error: fun containing local erlang function calls ('is_atomm' called in guard)\
       <name since="">tracer(Type, Data) -> {ok, pid()} | {error, Error}</name>
       <fsummary>Start a tracer server with additional parameters</fsummary>
       <type>
-        <v>Type = port | process | module</v>
+        <v>Type = port | process | module | logger</v>
         <v>Data = PortGenerator | HandlerSpec | ModuleSpec</v>
         <v>PortGenerator = fun() (no arguments)</v>
         <v>Error = term()</v>
@@ -823,8 +823,10 @@ Error: fun containing local erlang function calls ('is_atomm' called in guard)\
           parameters on the local node. The first parameter, the
           <c>Type</c>, indicates if trace messages should be handled
           by a receiving process (<c>process</c>), by a tracer port
-          (<c>port</c>) or by a tracer module
-          (<c>module</c>). For a description about tracer ports see
+          (<c>port</c>), by a tracer module
+          (<c>module</c>) or by creating a
+          <seemod marker="kernel:logger">logger</seemod> event.
+          For a description about tracer ports see
           <seemfa marker="#trace_port/2"><c>trace_port/2</c></seemfa>
           and for a tracer modules see
           <seeerl marker="erts:erl_tracer"><c>erl_tracer</c></seeerl>.
@@ -849,6 +851,9 @@ Error: fun containing local erlang function calls ('is_atomm' called in guard)\
             be either a tuple describing the <seeerl marker="erts:erl_tracer"><c>erl_tracer</c></seeerl>
           module to be used for tracing and the state to be used for
           that tracer module or a fun returning the same tuple.</p>
+        <p>if <c>Type</c> is <c>logger</c>, then the second parameter
+          is the logger level that the trace event should be emitted as.
+          If not level is given it defaults to DEBUG level.</p>
         <p>If an error is returned, it can either be due to a tracer
           server already running (<c>{error,already_started}</c>) or
           due to the <c>HandlerFun</c> throwing an exception.

--- a/lib/runtime_tools/doc/src/dbg.xml
+++ b/lib/runtime_tools/doc/src/dbg.xml
@@ -825,7 +825,7 @@ Error: fun containing local erlang function calls ('is_atomm' called in guard)\
           by a receiving process (<c>process</c>), by a tracer port
           (<c>port</c>), by a tracer module
           (<c>module</c>) or by creating a
-          <seemod marker="kernel:logger">logger</seemod> event.
+          <seeerl marker="kernel:logger">logger</seeerl> event.
           For a description about tracer ports see
           <seemfa marker="#trace_port/2"><c>trace_port/2</c></seemfa>
           and for a tracer modules see

--- a/lib/runtime_tools/src/dbg.erl
+++ b/lib/runtime_tools/src/dbg.erl
@@ -839,9 +839,9 @@ start_tracer_process(Handler, HandlerData, OLPOpts) ->
                      overload_kill_enable => true,
                      burst_limit_enable => false},
 
-    {ok,_,_} = OLP = logger_olp:start(?MODULE,{Handler,HandlerData},
-                                      maps:merge(OLPOpts, DefaultOpts),
-                                      [link, {priority,max}]),
+    {ok,_,OLP} = logger_olp:start(?MODULE,{Handler,HandlerData},
+                                  maps:merge(OLPOpts, DefaultOpts),
+                                  [link, {priority,max}]),
 
     %% This is a small monitor process that makes sure that the
     %% traces dies when the parent process exits.

--- a/lib/runtime_tools/src/dbg.erl
+++ b/lib/runtime_tools/src/dbg.erl
@@ -1216,16 +1216,19 @@ ffunc({M,F,Arity},#{ modifier := Modifier }) ->
 ffunc(X,#{ modifier := Modifier }) -> io_lib:format("~"++Modifier++"p", [X]).
 
 out(Device) ->
-    C = try
-            {ok, Cols} = io:columns(Device),
-            Cols
-        catch error:_ ->
-                80
-        end,
-
-    Encoding = encoding(Device),
+    Cols = try
+               {ok,C} = io:columns(Device),
+               C
+           catch error:_ ->
+                   80
+           end,
+    Encoding = try
+                   encoding(Device)
+               catch error:_ ->
+                       io:printable_range()
+               end,
                 
-    #{ device => Device, columns => C, depth => -1,
+    #{ device => Device, columns => Cols, depth => -1,
        encoding => Encoding, modifier => encoding_to_modifier(Encoding) }.
 
 encoding(Device) ->

--- a/lib/runtime_tools/src/runtime_tools.app.src
+++ b/lib/runtime_tools/src/runtime_tools.app.src
@@ -29,5 +29,5 @@
     {applications, [kernel, stdlib]},
     {env,          []},
     {mod,          {runtime_tools, []}},
-    {runtime_dependencies, ["stdlib-3.13","mnesia-4.12","kernel-7.0",
+    {runtime_dependencies, ["stdlib-3.13","mnesia-4.12","@kernel-16057@",
 			    "erts-11.0"]}]}.

--- a/lib/runtime_tools/test/dbg_SUITE.erl
+++ b/lib/runtime_tools/test/dbg_SUITE.erl
@@ -839,7 +839,7 @@ tracer_exit_on_stop(_) ->
     {ok, _} = dbg:p(new, [call]),
     {ok, _} = dbg:tp(?MODULE, dummy, []),
     ?MODULE:dummy(),
-    receive {'DOWN', MRef, _, _, normal} -> ok end,
+    receive {'DOWN', MRef, _, _, _} -> ok end,
     [{trace,_,call,{?MODULE, dummy,[]}},
      {trace,_,call,{?MODULE, dummy,[]}}] = flush(),
     ok.
@@ -1036,7 +1036,7 @@ start() ->
     dbg:tracer(process, {fun myhandler/2, self()}).
 
 stop() ->
-    dbg:stop().
+    dbg:stop_clear().
 
 
 

--- a/lib/runtime_tools/test/dbg_SUITE_data/dbg_SUITE.c
+++ b/lib/runtime_tools/test/dbg_SUITE_data/dbg_SUITE.c
@@ -42,6 +42,7 @@ static ErlNifFunc nif_funcs[] = {
 ERL_NIF_INIT(dbg_SUITE, nif_funcs, load, NULL, upgrade, unload)
 
 static ERL_NIF_TERM atom_trace;
+static ERL_NIF_TERM atom_remove;
 static ERL_NIF_TERM atom_ok;
 
 #define ASSERT(expr) assert(expr)
@@ -50,6 +51,7 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 {
 
     atom_trace = enif_make_atom(env, "trace");
+    atom_remove = enif_make_atom(env, "remove");
     atom_ok = enif_make_atom(env, "ok");
 
     *priv_data = NULL;
@@ -82,10 +84,12 @@ static ERL_NIF_TERM enabled(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     int state_arity;
     const ERL_NIF_TERM *state_tuple;
     ERL_NIF_TERM value;
+    ErlNifPid pid;
     ASSERT(argc == 3);
 
-
-    return atom_trace;
+    if (enif_get_local_pid(env, argv[1], &pid) && enif_is_process_alive(env, &pid))
+        return atom_trace;
+    return atom_remove;
 }
 
 static ERL_NIF_TERM trace(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/lib/runtime_tools/test/dbg_SUITE_data/dbg_test.erl
+++ b/lib/runtime_tools/test/dbg_SUITE_data/dbg_test.erl
@@ -42,11 +42,11 @@
 -export([new/0, push/3, pop/1]).
 
 loop(Config) ->
-    test(Config),
     receive
 	{dbg_test, stop} ->
 	    ok;
 	Other ->
+            test(Config),
 	    loop(Config)
     end,
     ok.


### PR DESCRIPTION
This PR does a couple of things to `dbg`:

* It adds a new tracer sink for `logger`. So it is now possible to do `dbg:tracer(logger)` to start tracing to logger instead. These log events have the domain `[otp,runtime_tools,dbg]` which means that they will not show up in the default log unless the default filters are modified.
* Printing of terms using the device sink (i.e. the one for stdout) has been modified to take the width of the terminal into consideration. Also "smart" new-lines are added to avoid printouts that were terrible to read.
* The default `dbg` process sink has been re-written to use the `logger_olp` module instead of relying on suspending processes. This will make the `dbg` sink kill itself if it is overloaded.

Things left to do:

- [ ] documentation about `logger` integration and options to `logger_olp`
- [ ] testcases for `logger` and `logger_olp` integrations
- [ ] testcases for the printing of terms

I'm publishing this PR before completely done in order to get feedback before finishing the work.