### PR TITLE
ssl: Correct close handling for DTLS

### DIFF
--- a/lib/ssl/src/dtls_socket.erl
+++ b/lib/ssl/src/dtls_socket.erl
@@ -81,6 +81,8 @@ connect(Address, Port, #config{transport_info = {Transport, _, _, _, _} = CbInfo
 	    Error
     end.
 
+close(_, dtls) ->
+    ok;
 close(gen_udp, {_Client, _Socket}) ->
     ok;
 close(Transport, {_Client, Socket}) ->

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -797,8 +797,10 @@ close(#sslsocket{pid = [TLSPid|_]},
 close(#sslsocket{pid = [TLSPid|_]}, Timeout) when is_pid(TLSPid),
 					      (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
     ssl_connection:close(TLSPid, {close, Timeout});
+close(#sslsocket{pid = {dtls = ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}, _) ->
+    dtls_socket:close(Transport, ListenSocket);    
 close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}, _) ->
-    Transport:close(ListenSocket).
+    tls_socket:close(Transport, ListenSocket).
 
 %%--------------------------------------------------------------------
 -spec send(SslSocket, Data) -> ok | {error, reason()} when

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -509,7 +509,7 @@ close(downgrade, _,_,_,_) ->
     ok;
 %% Other
 close(_, Socket, Transport, _,_) -> 
-    Transport:close(Socket).
+    tls_socket:close(Transport, Socket).
 protocol_name() ->
     "TLS".
 

--- a/lib/ssl/src/tls_socket.erl
+++ b/lib/ssl/src/tls_socket.erl
@@ -35,7 +35,8 @@
          getstat/3, 
          peername/2, 
          sockname/2, 
-         port/2]).
+         port/2,
+         close/2]).
 
 -export([split_options/1, 
          get_socket_opts/3]).
@@ -231,6 +232,11 @@ port(gen_tcp, Socket) ->
     inet:port(Socket);
 port(Transport, Socket) ->
     Transport:port(Socket).
+
+close(gen_tcp, Socket) ->
+    inet:close(Socket);
+close(Transport, Socket) ->
+    Transport:close(Socket).
 
 emulated_options() ->
     [mode, packet, active, header, packet_size].

--- a/lib/ssl/test/dtls_api_SUITE.erl
+++ b/lib/ssl/test/dtls_api_SUITE.erl
@@ -38,7 +38,8 @@ groups() ->
 
 api_tests() ->
     [
-     dtls_listen_owner_dies
+     dtls_listen_owner_dies,
+     dtls_listen_close
     ].
 
 init_per_suite(Config0) ->
@@ -129,3 +130,13 @@ dtls_listen_owner_dies(Config) when is_list(Config) ->
     end.
 
 
+dtls_listen_close() ->
+    [{doc, "Test that you close a DTLS 'listner' socket"}].
+
+dtls_listen_close(Config) when is_list(Config) ->    
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    {_, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
+
+    Port = ssl_test_lib:inet_port(ServerNode),
+    {ok, ListenSocket} = ssl:listen(Port, [{protocol, dtls} | ServerOpts]),
+    ok = ssl:close(ListenSocket).


### PR DESCRIPTION
Solve ERL-1110

Closing a DTLS listen socket using UDP will not actually do much
as the connection is emulated and there is no low level socket
to close.

Also better follow tls/dtls-socket abstraction