### PR TITLE
Optimize handling of empty_list in ping_list()

### DIFF
--- a/lib/kernel/src/net_adm.erl
+++ b/lib/kernel/src/net_adm.erl
@@ -129,6 +129,9 @@ dns_hostname(Hostname) ->
 
 -spec ping_list([atom()]) -> [atom()].
 
+ping_list([]) ->
+    [];
+
 ping_list(Nodelist) ->
     ok = net_kernel:monitor_nodes(true),
     Sofar = ping_first(Nodelist, nodes()),


### PR DESCRIPTION
Currently, calling this method with an empty list can take several seconds for the function to return. For system that can be run in both single and multiple instance mode, this add unnecessary delays for the single instance scenario.