### PR TITLE
ssh: fix typespec in ssh_sftpd

### DIFF
--- a/lib/ssh/src/ssh_sftpd.erl
+++ b/lib/ssh/src/ssh_sftpd.erl
@@ -60,14 +60,15 @@
 %%====================================================================
 -spec subsystem_spec(Options) -> Spec when
       Options :: [ {cwd, string()} |
-                   {file_handler, CallbackModule::string()} |
+                   {file_handler, CbMod | {CbMod, FileState}} |
                    {max_files, integer()} |
                    {root, string()} |
                    {sftpd_vsn, integer()}
                  ],
       Spec :: {Name, {CbMod,Options}},
       Name :: string(),
-      CbMod :: atom() .
+      CbMod :: atom(),
+      FileState :: term().
 
 
 subsystem_spec(Options) ->


### PR DESCRIPTION
file_handler is a callback module, tupled optionally with a state.
Fix that modules tend to be atoms.
Introduce ssh_sftpd_file_api:state() :: term() and use that,
but let the default state remain an empty list for compatibility.