### PR TITLE
ct: Don't hide error reasons from user

### DIFF
--- a/lib/common_test/src/ct_framework.erl
+++ b/lib/common_test/src/ct_framework.erl
@@ -946,10 +946,6 @@ error_notification(Mod,Func,_Args,{Error,Loc}) ->
 			     io_lib:format("{test_case_failed,~tp}", [Reason]);
 			 Result -> Result
 		     end;
-		 {'EXIT',_Reason} = EXIT ->
-		     io_lib:format("~tP", [EXIT,5]);
-		 {Spec,_Reason} when is_atom(Spec) ->
-		     io_lib:format("~tw", [Spec]);
 		 Other ->
 		     io_lib:format("~tP", [Other,5])
 	     end,


### PR DESCRIPTION
Depending on what was given as an argument to erlang:error(),
parts would not be printed. Specifically two-tuples of atom and
something, would cause only the atom to be printed.
Also remove now redundant clause of exempting {'ERROR', _} from this.