### PR TITLE
sctp_assoc_change record have incorrect type in documentation

### DIFF
--- a/lib/kernel/doc/src/gen_sctp.xml
+++ b/lib/kernel/doc/src/gen_sctp.xml
@@ -165,7 +165,7 @@
         <pre>
 #sctp_assoc_change{
       state             = atom(),
-      error             = atom(),
+      error             = integer(),
       outbound_streams  = integer(),
       inbound_streams   = integer(),
       assoc_id          = assoc_id()
@@ -208,7 +208,9 @@ connect(Socket, Ip, Port>,
           <tag><c>shutdown_comp</c></tag>
           <item></item>
         </taglist>
-        <p>Field <c>error</c> can provide more detailed diagnostics.</p>
+        <p>Field <c>error</c> can provide more detailed diagnostics.
+        The <c>error</c> field value can be converted into a string using
+        <seealso marker="#error_string/1"><c>error_string/1</c></seealso>.</p>
       </desc>
     </func>
 


### PR DESCRIPTION
Everywhere else the error field in the SCTP record is an integer.
The default value for this field is '0'.