### PR TITLE
Extend erl_call with a new flag to access a node at HOSTNAME:PORT

### DIFF
--- a/lib/erl_interface/doc/src/ei_connect.xml
+++ b/lib/erl_interface/doc/src/ei_connect.xml
@@ -422,6 +422,8 @@ typedef struct {
     <func>
       <name since=""><ret>int</ret><nametext>ei_connect(ei_cnode* ec, char *nodename)</nametext></name>
       <name since=""><ret>int</ret><nametext>ei_xconnect(ei_cnode* ec, Erl_IpAddr adr, char *alivename)</nametext></name>
+      <name since="OTP @OTP-16251@"><ret>int</ret><nametext>ei_connect_host_port(ei_cnode* ec, char *hostname, int port)</nametext></name>
+      <name since="OTP @OTP-16251@"><ret>int</ret><nametext>ei_xconnect_host_port(ei_cnode* ec, Erl_IpAddr adr, int port)</nametext></name>
       <fsummary>Establish a connection to an Erlang node.</fsummary>
       <desc>
         <p>Sets up a connection to an Erlang node.</p>
@@ -429,13 +431,21 @@ typedef struct {
           remote host and the alive name of the remote node to be
           specified. <c>ei_connect()</c> provides an alternative
           interface and determines the information from the node name
-          provided.</p>
+          provided. The <c>ei_xconnect_host_port()</c> function provides
+          yet another alternative that will work even if there is no
+          EPMD instance on the host where the remote node is running. The
+          <c>ei_xconnect_host_port()</c> function requires the IP
+          address and port of the remote node to be specified.
+          The <c>ei_connect_host_port()</c> function is an alternative
+          to <c>ei_xconnect_host_port()</c> that lets the user specify
+          a hostname instead of an IP address.</p>
         <list type="bulleted">
-          <item><c>addr</c> is the 32-bit IP address of the remote
+          <item><c>adr</c> is the 32-bit IP address of the remote
             host.</item>
           <item><c>alive</c> is the alivename of the remote node.
           </item>
           <item><c>node</c> is the name of the remote node.</item>
+          <item><c>port</c> is the port number of the remote node.</item>
         </list>
         <p>These functions return an open file descriptor on success, or
           a negative value indicating that an error occurred. In the latter
@@ -571,13 +581,16 @@ if (ei_connect_init(&ec, "madonna", "cookie...", n++) < 0) {
     <func>
       <name since=""><ret>int</ret><nametext>ei_connect_tmo(ei_cnode* ec, char *nodename, unsigned timeout_ms)</nametext></name>
       <name since=""><ret>int</ret><nametext>ei_xconnect_tmo(ei_cnode* ec, Erl_IpAddr adr, char *alivename, unsigned timeout_ms)</nametext></name>
+      <name since="OTP @OTP-16251@"><ret>int</ret><nametext>ei_connect_host_port_tmo(ei_cnode* ec, char *hostname, int port, unsigned ms)</nametext></name>
+      <name since="OTP @OTP-16251@"><ret>int</ret><nametext>ei_xconnect_host_port_tmo(ei_cnode* ec, Erl_IpAddr adr, int port, unsigned ms)</nametext></name>
       <fsummary>Establish a connection to an Erlang node with optional
         time-out.</fsummary>
       <desc>
-        <p>Equivalent to
-          <c>ei_connect</c> and <c>ei_xconnect</c> with an optional time-out
-          argument, see the description at the beginning of this manual
-          page.</p>
+        <p>Equivalent to <c>ei_connect</c>, <c>ei_xconnect</c>,
+        <c>ei_connect_host_port</c> and
+        <c>ei_xconnect_host_port</c> with an optional time-out
+        argument, see the description at the beginning of this manual
+        page.</p>
       </desc>
     </func>
 

--- a/lib/erl_interface/doc/src/erl_call.xml
+++ b/lib/erl_interface/doc/src/erl_call.xml
@@ -78,6 +78,22 @@
               <c>Fun</c>, and <c>Args</c> in a manner
               dependent on the behavior of your command shell.</p>
           </item>
+          <tag><c>-address [Hostname:]Port</c></tag>
+          <item>
+            <p>(One of <c>-n</c>, <c>-name</c>, <c>-sname</c> or
+            <c>-address</c> is required.) <c>Hostname</c> is the
+            hostname of the machine that is running the node that
+            <c>erl_call</c> shall communicate with. The default
+            hostname is the hostname of the local machine. <c>Port</c>
+            is the port number of the node that <c>erl_call</c> shall
+            communicate with. The <c>-address</c> flag cannot be
+            combined with any of the flags <c>-n</c>, <c>-name</c>,
+            <c>-sname</c> or <c>-s</c>.</p>
+            <p>The <c>-address</c> flag is typically useful when one
+            wants to call a node that is running on machine without an
+            accessible <seealso marker="epmd">epmd</seealso>
+            instance.</p>
+          </item>
           <tag><c>-c Cookie</c></tag>
           <item>
             <p>(<em>Optional.</em>) Use this option to specify a certain cookie.
@@ -112,13 +128,15 @@
           </item>
           <tag><c>-n Node</c></tag>
           <item>
-            <p>(One of <c>-n, -name, -sname</c> is required.)
+            <p>(One of <c>-n</c>, <c>-name</c>, <c>-sname</c> or
+            <c>-address</c> is required.)
               Has the same meaning as <c>-name</c> and can still be
               used for backward compatibility reasons.</p>
           </item>
           <tag><c>-name Node</c></tag>
           <item>
-            <p>(One of <c>-n, -name, -sname</c> is required.)
+            <p>(One of <c>-n</c>, <c>-name</c>, <c>-sname</c> or
+            <c>-address</c> is required.)
               <c>Node</c> is the name of the node to be
               started or communicated with. It is assumed that
               <c>Node</c> is started with
@@ -149,7 +167,8 @@
           </item>
           <tag><c>-sname Node</c></tag>
           <item>
-            <p>(One of <c>-n, -name, -sname</c> is required.)
+            <p>(One of <c>-n</c>, <c>-name</c>, <c>-sname</c> or
+            <c>-address</c> is required.)
               <c>Node</c> is the name of the node to be started
               or communicated with. It is assumed that <c>Node</c>
               is started with <c>erl -sname</c>, which means that

--- a/lib/erl_interface/include/ei.h
+++ b/lib/erl_interface/include/ei.h
@@ -404,8 +404,12 @@ int ei_connect_xinit_ussi(ei_cnode* ec, const char *thishostname,
 
 int ei_connect(ei_cnode* ec, char *nodename);
 int ei_connect_tmo(ei_cnode* ec, char *nodename, unsigned ms);
+int ei_connect_host_port(ei_cnode* ec, char *hostname, int port);
+int ei_connect_host_port_tmo(ei_cnode* ec, char *hostname, int port, unsigned ms);
 int ei_xconnect(ei_cnode* ec, Erl_IpAddr adr, char *alivename);
 int ei_xconnect_tmo(ei_cnode* ec, Erl_IpAddr adr, char *alivename, unsigned ms);
+int ei_xconnect_host_port(ei_cnode* ec, Erl_IpAddr adr, int port);
+int ei_xconnect_host_port_tmo(ei_cnode* ec, Erl_IpAddr adr, int port, unsigned ms);
 
 int ei_receive(int fd, unsigned char *bufp, int bufsize);
 int ei_receive_tmo(int fd, unsigned char *bufp, int bufsize, unsigned ms);

--- a/lib/erl_interface/test/ei_connect_SUITE_data/ei_connect_test.c
+++ b/lib/erl_interface/test/ei_connect_SUITE_data/ei_connect_test.c
@@ -36,6 +36,7 @@
 
 static void cmd_ei_connect_init(char* buf, int len);
 static void cmd_ei_connect(char* buf, int len);
+static void cmd_ei_connect_host_port(char* buf, int len);
 static void cmd_ei_send(char* buf, int len);
 static void cmd_ei_format_pid(char* buf, int len);
 static void cmd_ei_send_funs(char* buf, int len);
@@ -55,6 +56,7 @@ static struct {
 } commands[] = {
     "ei_connect_init",       4, cmd_ei_connect_init,
     "ei_connect", 	     1, cmd_ei_connect,
+    "ei_connect_host_port",  2, cmd_ei_connect_host_port,
     "ei_send",  	     3, cmd_ei_send,
     "ei_send_funs",  	     3, cmd_ei_send_funs,
     "ei_reg_send", 	     3, cmd_ei_reg_send,
@@ -152,6 +154,25 @@ static void cmd_ei_connect(char* buf, int len)
     if (ei_decode_atom(buf, &index, node) < 0)
 	fail("expected atom");
     i=ei_connect(&ec, node);
+#ifdef VXWORKS
+    if(i >= 0) {
+	save_fd(i);
+    }
+#endif
+    send_errno_result(i);
+}
+
+static void cmd_ei_connect_host_port(char* buf, int len)
+{
+    int index = 0;
+    char hostname[256];
+    int i;
+    long port;
+    if (ei_decode_atom(buf, &index, hostname) < 0)
+	fail("expected atom");
+    if (ei_decode_long(buf, &index, &port) < 0)
+	fail("expected int");
+    i = ei_connect_host_port(&ec, hostname, (int)port);
 #ifdef VXWORKS
     if(i >= 0) {
 	save_fd(i);

--- a/lib/erl_interface/test/erl_call_SUITE.erl
+++ b/lib/erl_interface/test/erl_call_SUITE.erl
@@ -23,41 +23,87 @@
 
 -include_lib("common_test/include/ct.hrl").
 
--export([all/0, smoke/1]).
+-export([all/0, smoke/1, test_connect_to_host_port/1]).
 
-all() -> 
-    [smoke].
+all() ->
+    [smoke,
+     test_connect_to_host_port].
 
 smoke(Config) when is_list(Config) ->
-    ErlCall = find_erl_call(),
+    Name = atom_to_list(?MODULE)
+        ++ "-"
+        ++ integer_to_list(erlang:system_time(microsecond)),
+
+    RetNodeName = start_node_and_get_node_name(Name),
+
+    halt_node(Name),
+
+    [_, Hostname] = string:lexemes(atom_to_list(node()), "@"),
+    NodeName = list_to_atom(Name ++ "@" ++ Hostname),
+    NodeName = list_to_atom(RetNodeName),
+    ok.
+
+
+test_connect_to_host_port(Config) when is_list(Config) ->
+    Name = atom_to_list(?MODULE)
+        ++ "-"
+        ++ integer_to_list(erlang:system_time(microsecond)),
+    Port = start_node_and_get_port(Name),
+    AddressCaller =
+        fun(Address) ->
+                  get_erl_call_result(["-address",
+                                       Address,
+                                       "-a",
+                                       "erlang length [[1,2,3,4,5,6,7,8,9]]"])
+        end,
+    "9" = AddressCaller(erlang:integer_to_list(Port)),
+    "9" = AddressCaller(":" ++ erlang:integer_to_list(Port)),
+    [_, Hostname] = string:lexemes(atom_to_list(node()), "@"),
+    "9" = AddressCaller(Hostname ++ ":" ++ erlang:integer_to_list(Port)),
+    FailedRes = AddressCaller("80"),
+    case string:find(FailedRes, "80") of
+        nomatch -> ct:fail("Incorrect error message");
+        _ -> ok
+    end,
+    halt_node(Name),
+    ok.
+
+%
+% Utility functions...
+%
+
+
+halt_node(Name) ->
+    [_, Hostname] = string:lexemes(atom_to_list(node()), "@"),
+    NodeName = list_to_atom(Name ++ "@" ++ Hostname),
+    io:format("NodeName: ~p~n~n", [NodeName]),
+
+    pong = net_adm:ping(NodeName),
+    rpc:cast(NodeName, erlang, halt, []).
+
+start_node_and_get_node_name(Name) ->
     NameSwitch = case net_kernel:longnames() of
                      true ->
                          "-name";
                      false ->
                          "-sname"
                  end,
-    Name = atom_to_list(?MODULE)
-        ++ "-"
-        ++ integer_to_list(erlang:system_time(microsecond)),
+    string:trim(get_erl_call_result(["-s",
+                                     NameSwitch,
+                                     Name, "-a",
+                                     "erlang node"]),
+                both,
+                "'").
 
-    ArgsList = ["-s", "-a", "erlang node", NameSwitch, Name],
-    io:format("erl_call: \"~ts\"\n~nargs list: ~p~n", [ErlCall, ArgsList]),
-    CmdRes = get_smoke_port_res(open_port({spawn_executable, ErlCall},
-                                          [{args, ArgsList}, eof]), []),
-    io:format("CmdRes: ~p~n", [CmdRes]),
-
-    [_, Hostname] = string:lexemes(atom_to_list(node()), "@"),
-    NodeName = list_to_atom(Name ++ "@" ++ Hostname),
-    io:format("NodeName: ~p~n~n", [NodeName]),
-
-    pong = net_adm:ping(NodeName),
-    rpc:cast(NodeName, erlang, halt, []),
-    NodeName = list_to_atom(string:trim(CmdRes, both, "'")),
-    ok.
-
-%
-% Utility functions...
-%
+start_node_and_get_port(Name) ->
+    start_node_and_get_node_name(Name),
+    {ok, NamePortList} = net_adm:names(),
+    {value, {_, Port}}
+        = lists:search(fun({N, _}) ->
+                               string:equal(N, Name)
+                       end,
+                       NamePortList),
+    Port.
 
 find_erl_call() ->
     ErlCallName = case os:type() of
@@ -86,10 +132,19 @@ find_erl_call() ->
             ErlCall
     end.
 
-get_smoke_port_res(Port, Acc) when is_port(Port) ->
+
+get_erl_call_result(ArgsList) ->
+    ErlCall = find_erl_call(),
+    io:format("erl_call: \"~ts\"\n~nargs list: ~p~n", [ErlCall, ArgsList]),
+    CmdRes = get_port_res(open_port({spawn_executable, ErlCall},
+                                    [{args, ArgsList}, eof, stderr_to_stdout]), []),
+    io:format("CmdRes: ~p~n", [CmdRes]),
+    CmdRes.
+
+get_port_res(Port, Acc) when is_port(Port) ->
     receive
         {Port, {data, Data}} ->
-            get_smoke_port_res(Port, [Acc|Data]);
+            get_port_res(Port, [Acc|Data]);
         {Port, eof} ->
             lists:flatten(Acc)
     end.


### PR DESCRIPTION
This pull request adds the flag `-address` to the `erl_call` program. This flag makes it possible for the user to use `erl_call` to interact with a node even if no EPMD instance is running on the node's host.

This pull request also adds a family of new functions to the `erl_interface` API (that are needed implement the new `erl_call` flag and similar types of functionality) and extends the documentation of `erl_call` and `erl_interface` with descriptions of the new flag and functions.