### PR TITLE
ERL-991 Strip control codes from eunit_surefire output

### DIFF
--- a/lib/eunit/src/eunit_surefire.erl
+++ b/lib/eunit/src/eunit_surefire.erl
@@ -451,6 +451,11 @@ escape_xml([$< | Tail], Acc, ForAttr) -> escape_xml(Tail, [$;, $t, $l, $& | Acc]
 escape_xml([$> | Tail], Acc, ForAttr) -> escape_xml(Tail, [$;, $t, $g, $& | Acc], ForAttr);
 escape_xml([$& | Tail], Acc, ForAttr) -> escape_xml(Tail, [$;, $p, $m, $a, $& | Acc], ForAttr);
 escape_xml([$" | Tail], Acc, true) -> escape_xml(Tail, [$;, $t, $o, $u, $q, $& | Acc], true); % "
+escape_xml([Char | Tail], Acc, ForAttr) when
+	  Char == $\n; Char == $\r; Char == $\t -> escape_xml(Tail, [Char | Acc], ForAttr);
+%% Strip C0 control codes which are not allowed in XML 1.0
+escape_xml([Char | Tail], Acc, ForAttr) when
+	  0 =< Char, Char =< 31 -> escape_xml(Tail, Acc, ForAttr);
 escape_xml([Char | Tail], Acc, ForAttr) when is_integer(Char) -> escape_xml(Tail, [Char | Acc], ForAttr).
 
 %% the input may be utf8 or latin1; the resulting list is unicode

--- a/lib/eunit/test/Makefile
+++ b/lib/eunit/test/Makefile
@@ -22,6 +22,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 
 MODULES =  \
 	eunit_SUITE \
+	tc0 \
 	tlatin \
 	tutf8
 

--- a/lib/eunit/test/tc0.erl
+++ b/lib/eunit/test/tc0.erl
@@ -1,0 +1,14 @@
+-module(tc0).
+
+-include_lib("eunit/include/eunit.hrl").
+
+'c0_bad_output_test_'() ->
+    [{integer_to_list(C), fun() -> io:format("'~c'", [C]) end}
+     || C <- lists:seq(0, 31)].
+
+'c0_bad_description_test_'() ->
+    [{[C], fun() -> ok end}
+     || C <- lists:seq(0, 31)].
+
+'c0_bad_name__test'() ->
+    ok.


### PR DESCRIPTION
Without this, test cases which output control codes, or with names or
descriptions containing control codes, would cause the generated XML files to be
invalid.

Backport from master.