### PR TITLE
[ERL-588] add mnesia funcs to table of contents

### DIFF
--- a/lib/mnesia/doc/specs/.gitignore
+++ b/lib/mnesia/doc/specs/.gitignore
@@ -1,0 +1,1 @@
+specs_*.xml

--- a/lib/mnesia/doc/src/Makefile
+++ b/lib/mnesia/doc/src/Makefile
@@ -96,6 +96,9 @@ HTML_REF_MAN_FILE = $(HTMLDIR)/index.html
 
 TOP_PDF_FILE = $(PDFDIR)/$(APPLICATION)-$(VSN).pdf
 
+SPECS_FILES = $(XML_REF3_FILES:%.xml=$(SPECDIR)/specs_%.xml)
+
+TOP_SPECS_FILE = specs.xml
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
@@ -121,6 +124,7 @@ clean clean_docs:
 	rm -rf $(XMLDIR)
 	rm -f $(MAN3DIR)/*
 	rm -f $(TOP_PDF_FILE) $(TOP_PDF_FILE:%.pdf=%.fo)
+	rm -f $(SPECDIR)/*
 	rm -f errs core *~
 
 man: $(MAN3_FILES)

--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -11,7 +11,7 @@
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.
       You may obtain a copy of the License at
- 
+
           http://www.apache.org/licenses/LICENSE-2.0
 
       Unless required by applicable law or agreed to in writing, software
@@ -955,7 +955,7 @@ mnesia:create_table(person,
       <fsummary>Returns the key for the first record in a table.</fsummary>
       <desc>
       <marker id="dirty_first"></marker>
-        <p>Records in <c>set</c> or <c>bag</c> tables are not ordered. 
+        <p>Records in <c>set</c> or <c>bag</c> tables are not ordered.
           However, there is an ordering of the records that is unknown
           to the user. Therefore, a table can be traversed by this
           function with the function <c>mnesia:dirty_next/2</c>.
@@ -2589,8 +2589,8 @@ mnesia:create_table(employee,
         <code type="none">
 add_family({family, F, M, Children}) ->
     ChildOids = lists:map(fun oid/1, Children),
-    Trans = fun() ->      
-        mnesia:write(F#person{children = ChildOids}, 
+    Trans = fun() ->
+        mnesia:write(F#person{children = ChildOids},
         mnesia:write(M#person{children = ChildOids},
         Write = fun(Child) -> mnesia:write(Child) end,
         lists:foreach(Write, Children)
@@ -2687,7 +2687,7 @@ raise(Name, Amount) ->
           <c>{BackupItems,NewAcc}</c>, where <c>BackupItems</c> is
            a list of valid backup items, and <c>NewAcc</c> is a new
            accumulator value. The returned backup items are written
-           in the target backup. 
+           in the target backup.
           </item>
           <item><c>LastAcc</c> is the last accumulator value. This is
            the last <c>NewAcc</c> value that was returned by <c>Fun</c>.
@@ -2870,7 +2870,7 @@ raise(Name, Amount) ->
       <item>
         <p><c>-mnesia dc_dump_limit Number</c>. Controls how often
           <c>disc_copies</c> tables are dumped from memory.
-          Tables are dumped when 
+          Tables are dumped when
           <c>filesize(Log) > (filesize(Tab)/Dc_dump_limit)</c>.
           Lower values reduce CPU overhead but increase disk space
           and startup times. Default is 4.</p>
@@ -3033,6 +3033,6 @@ raise(Name, Amount) ->
       <seealso marker="mnesia:mnesia_registry">mnesia_registry(3)</seealso>,
       <seealso marker="stdlib:qlc">qlc(3)</seealso></p>
   </section>
-  
+
 </erlref>
 

--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -228,7 +228,7 @@
 
   <funcs>
     <func>
-      <name since="">abort(Reason) -> transaction abort</name>
+      <name name="abort" arity="1" since=""/>
       <fsummary>Terminates the current transaction.</fsummary>
       <desc>
         <p>Makes the transaction silently
@@ -240,7 +240,7 @@
       </desc>
     </func>
     <func>
-      <name since="">activate_checkpoint(Args) -> {ok,Name,Nodes} | {error,Reason}</name>
+      <name name="activate_checkpoint" arity="1" since=""/>
       <fsummary>Activates a checkpoint.</fsummary>
       <desc>
       <marker id="activate_checkpoint"></marker>
@@ -304,7 +304,8 @@
       </desc>
     </func>
     <func>
-      <name since="">activity(AccessContext, Fun [, Args]) -> ResultOfFun | exit(Reason)</name>
+      <name name="activity" arity="2" since=""/>
+        <!--<name name="activity" arity="3" since=""/>-->
       <fsummary>Executes <c>Fun</c> in <c>AccessContext</c>.</fsummary>
       <desc>
       <marker id="activity_2_3"></marker>
@@ -316,7 +317,7 @@
       </desc>
     </func>
     <func>
-      <name since="">activity(AccessContext, Fun, Args, AccessMod) -> ResultOfFun | exit(Reason)</name>
+      <name name="activity" arity="4" since=""/>
       <fsummary>Executes <c>Fun</c> in <c>AccessContext</c>.</fsummary>
       <desc>
       <marker id="activity_4"></marker>
@@ -448,7 +449,7 @@
       </desc>
     </func>
     <func>
-      <name since="">add_table_copy(Tab, Node, Type) -> {aborted, R} | {atomic, ok}</name>
+      <name name="add_table_copy" arity="3" since=""/>
       <fsummary>Copies a table to a remote node.</fsummary>
       <desc>
       <marker id="add_table_copy"></marker>
@@ -465,7 +466,7 @@ mnesia:add_table_copy(person, Node, disc_copies)</code>
       </desc>
     </func>
     <func>
-      <name since="">add_table_index(Tab, AttrName) -> {aborted, R} | {atomic, ok}</name>
+      <name name="add_table_index" arity="2" since=""/>
       <fsummary>Creates an index for a table.</fsummary>
       <desc>
       <marker id="add_table_index"></marker>
@@ -486,7 +487,7 @@ mnesia:add_table_index(person, age)</code>
       </desc>
     </func>
     <func>
-      <name since="">all_keys(Tab) -> KeyList | transaction abort</name>
+      <name name="all_keys" arity="1" since=""/>
       <fsummary>Returns all keys in a table.</fsummary>
       <desc>
       <marker id="all_keys"></marker>
@@ -498,7 +499,8 @@ mnesia:add_table_index(person, age)</code>
       </desc>
     </func>
     <func>
-      <name since="">async_dirty(Fun, [, Args]) -> ResultOfFun | exit(Reason)</name>
+      <name name="async_dirty" arity="1" since=""/>
+      <name name="async_dirty" arity="2" since=""/>
       <fsummary>Calls the <c>Fun</c> in a context that is not protected by a transaction.</fsummary>
       <desc>
       <marker id="async_dirty"></marker>
@@ -538,7 +540,8 @@ mnesia:add_table_index(person, age)</code>
       </desc>
     </func>
     <func>
-      <name since="">backup(Opaque [, BackupMod]) -> ok | {error,Reason}</name>
+      <name name="backup" arity="1" since=""/>
+      <name name="backup" arity="2" since=""/>
       <fsummary>Backs up all tables in the database.</fsummary>
       <desc>
       <marker id="backup"></marker>
@@ -550,7 +553,8 @@ mnesia:add_table_index(person, age)</code>
       </desc>
     </func>
     <func>
-      <name since="">backup_checkpoint(Name, Opaque [, BackupMod]) -> ok | {error,Reason}</name>
+      <name name="backup_checkpoint" arity="2" since=""/>
+      <name name="backup_checkpoint" arity="3" since=""/>
       <fsummary>Backs up all tables in a checkpoint.</fsummary>
       <desc>
       <marker id="backup_checkpoint"></marker>
@@ -565,7 +569,7 @@ mnesia:add_table_index(person, age)</code>
       </desc>
     </func>
     <func>
-      <name since="">change_config(Config, Value) -> {error, Reason} | {ok, ReturnValue}</name>
+      <name name="change_config" arity="2" since=""/>
       <fsummary>Changes a configuration parameter.</fsummary>
       <desc>
       <marker id="change_config"></marker>
@@ -599,7 +603,7 @@ mnesia:add_table_index(person, age)</code>
       </desc>
     </func>
     <func>
-      <name since="">change_table_access_mode(Tab, AccessMode) -> {aborted, R} | {atomic, ok}</name>
+      <name name="change_table_access_mode" arity="2" since=""/>
       <fsummary>Changes the access mode for the table.</fsummary>
       <desc>
       <marker id="change_table_access_mode"></marker>
@@ -613,7 +617,7 @@ mnesia:add_table_index(person, age)</code>
       </desc>
     </func>
     <func>
-      <name since="">change_table_copy_type(Tab, Node, To) -> {aborted, R} | {atomic, ok}</name>
+      <name name="change_table_copy_type" arity="3" since=""/>
       <fsummary>Changes the storage type of a table.</fsummary>
       <desc>
       <marker id="change_table_copy_type"></marker>
@@ -630,7 +634,7 @@ mnesia:change_table_copy_type(person, node(), disc_copies)</code>
       </desc>
     </func>
     <func>
-      <name since="">change_table_load_order(Tab, LoadOrder) -> {aborted, R} | {atomic, ok}</name>
+      <name name="change_table_load_order" arity="2" since=""/>
       <fsummary>Changes the load order priority for the table.</fsummary>
       <desc>
       <marker id="change_table_load_order"></marker>
@@ -640,7 +644,7 @@ mnesia:change_table_copy_type(person, node(), disc_copies)</code>
       </desc>
     </func>
     <func>
-      <name since="OTP R14B03">change_table_majority(Tab, Majority) -> {aborted, R} | {atomic, ok}</name>
+      <name name="change_table_majority" arity="2" since="OTP R14B03"/>
       <fsummary>Changes the majority check setting for the table.</fsummary>
       <desc>
         <p><c>Majority</c> must be a boolean. Default is <c>false</c>.
@@ -652,7 +656,7 @@ mnesia:change_table_copy_type(person, node(), disc_copies)</code>
       </desc>
     </func>
     <func>
-      <name since="">clear_table(Tab) -> {aborted, R} | {atomic, ok}</name>
+      <name name="clear_table" arity="1" since=""/>
       <fsummary>Deletes all entries in a table.</fsummary>
       <desc>
       <marker id="clear_table"></marker>
@@ -660,7 +664,7 @@ mnesia:change_table_copy_type(person, node(), disc_copies)</code>
       </desc>
     </func>
     <func>
-      <name since="">create_schema(DiscNodes) -> ok | {error,Reason}</name>
+      <name name="create_table" arity="1" since=""/>
       <fsummary>Creates a new schema on the specified nodes.</fsummary>
       <desc>
       <marker id="create_schema"></marker>
@@ -682,7 +686,7 @@ mnesia:change_table_copy_type(person, node(), disc_copies)</code>
       </desc>
     </func>
     <func>
-      <name since="">create_table(Name, TabDef) -> {atomic, ok} | {aborted, Reason}</name>
+      <name name="create_table" arity="2" since=""/>
       <fsummary>Creates a Mnesia table called <c>Name</c>with properties as described by argument <c>TabDef</c>.</fsummary>
       <desc>
       <marker id="create_table"></marker>
@@ -844,7 +848,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">deactivate_checkpoint(Name) -> ok | {error, Reason}</name>
+      <name name="deactivate_checkpoint" arity="1" since=""/>
       <fsummary>Deactivates a checkpoint.</fsummary>
       <desc>
       <marker id="deactivate_checkpoint"></marker>
@@ -856,7 +860,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">del_table_copy(Tab, Node) -> {aborted, R} | {atomic, ok}</name>
+      <name name="del_table_copy" arity="2" since=""/>
       <fsummary>Deletes the replica of table <c>Tab</c> at node <c>Node</c>.</fsummary>
       <desc>
       <marker id="del_table_copy"></marker>
@@ -870,7 +874,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">del_table_index(Tab, AttrName) -> {aborted, R} | {atomic, ok}</name>
+      <name name="del_table_index" arity="2" since=""/>
       <fsummary>Deletes an index in a table.</fsummary>
       <desc>
       <marker id="del_table_index"></marker>
@@ -879,16 +883,16 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">delete({Tab, Key}) -> transaction abort | ok</name>
+      <name name="delete" arity="1" since=""/>
       <fsummary>Deletes all records in table <c>Tab</c> with the key <c>Key</c>.</fsummary>
       <desc>
-      <marker id="delete_2"></marker>
+      <marker id="delete_1"></marker>
         <p>Calls <c>mnesia:delete(Tab, Key, write)</c>.</p>
       </desc>
     </func>
     <func>
-      <name since="">delete(Tab, Key, LockKind) -> transaction abort | ok</name>
-      <fsummary>Deletes all records in table <c>Tab</c>with the key <c>Key</c>.</fsummary>
+      <name name="delete" arity="3" since=""/>
+      <fsummary>Deletes all records in table <c>Tab</c> with the key <c>Key</c>.</fsummary>
       <desc>
       <marker id="delete_3"></marker>
         <p>Deletes all records in table <c>Tab</c> with the key
@@ -902,7 +906,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">delete_object(Record) -> transaction abort | ok</name>
+      <name name="delete_object" arity="1" since=""/>
       <fsummary>Delete a record.</fsummary>
       <desc>
       <marker id="delete_object_1"></marker>
@@ -911,7 +915,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">delete_object(Tab, Record, LockKind) -> transaction abort | ok</name>
+      <name name="delete_object" arity="3" since=""/>
       <fsummary>Deletes a record.</fsummary>
       <desc>
       <marker id="delete_object_3"></marker>
@@ -928,7 +932,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">delete_schema(DiscNodes) -> ok | {error,Reason}</name>
+      <name name="delete_schema" arity="1" since=""/>
       <fsummary>Deletes the schema on the given nodes.</fsummary>
       <desc>
       <marker id="delete_schema"></marker>
@@ -949,7 +953,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">delete_table(Tab) -> {aborted, Reason} | {atomic, ok}</name>
+      <name name="delete_table" arity="1" since=""/>
       <fsummary>Deletes permanently all replicas of table <c>Tab</c>.</fsummary>
       <desc>
       <marker id="delete_table"></marker>
@@ -957,7 +961,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_all_keys(Tab) -> KeyList | exit({aborted, Reason})</name>
+      <name name="dirty_all_keys" arity="1" since=""/>
       <fsummary>Dirty search for all record keys in table.</fsummary>
       <desc>
       <marker id="delete_all_keys"></marker>
@@ -965,7 +969,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_delete({Tab, Key}) -> ok | exit({aborted, Reason})</name>
+      <name name="dirty_delete" arity="1" since=""/>
       <fsummary>Dirty delete of a record.</fsummary>
       <desc>
       <marker id="dirty_delete"></marker>
@@ -973,14 +977,14 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_delete(Tab, Key) -> ok | exit({aborted, Reason})</name>
+      <name name="dirty_delete" arity="2" since=""/>
       <fsummary>Dirty delete of a record.</fsummary>
       <desc>
         <p>Dirty equivalent of the function <c>mnesia:delete/3</c>.</p>
       </desc>
     </func>
     <func>
-      <name since="">dirty_delete_object(Record)</name>
+      <name name="dirty_delete_object" arity="2" since=""/>
       <fsummary>Dirty delete of a record.</fsummary>
       <desc>
       <marker id="dirty_delete_object_1"></marker>
@@ -989,14 +993,14 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_delete_object(Tab, Record)</name>
+      <name name="dirty_delete_object" arity="2" since=""/>
       <fsummary>Dirty delete of a record.</fsummary>
       <desc>
         <p>Dirty equivalent of the function <c>mnesia:delete_object/3</c>.</p>
       </desc>
     </func>
     <func>
-      <name since="">dirty_first(Tab) ->  Key | exit({aborted, Reason})</name>
+      <name name="dirty_first" arity="1" since=""/>
       <fsummary>Returns the key for the first record in a table.</fsummary>
       <desc>
       <marker id="dirty_first"></marker>
@@ -1012,7 +1016,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_index_match_object(Pattern, Pos)</name>
+      <name name="dirty_index_match_object" arity="2" since=""/>
       <fsummary>Dirty pattern match using index.</fsummary>
       <desc>
       <marker id="dirty_index_match_object_2"></marker>
@@ -1022,7 +1026,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_index_match_object(Tab, Pattern, Pos)</name>
+      <name name="dirty_index_match_object" arity="3" since=""/>
       <fsummary>Dirty pattern match using index.</fsummary>
       <desc>
         <p>Dirty equivalent of the function
@@ -1030,7 +1034,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_index_read(Tab, SecondaryKey, Pos)</name>
+      <name name="dirty_index_read" arity="3" since=""/>
       <fsummary>Dirty read using index.</fsummary>
       <desc>
       <marker id="dirty_index_read"></marker>
@@ -1039,7 +1043,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_last(Tab) -> Key | exit({aborted, Reason})</name>
+      <name name="dirty_last" arity="1" since=""/>
       <fsummary>Returns the key for the last record in a table.</fsummary>
       <desc>
       <marker id="dirty_last"></marker>
@@ -1051,7 +1055,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_match_object(Pattern) -> RecordList | exit({aborted, Reason})</name>
+      <name name="dirty_match_object" arity="1" since=""/>
       <fsummary>Dirty pattern match pattern.</fsummary>
       <desc>
       <marker id="dirty_match_object_1"></marker>
@@ -1060,7 +1064,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_match_object(Tab, Pattern) -> RecordList | exit({aborted, Reason})</name>
+      <name name="dirty_match_object" arity="2" since=""/>
       <fsummary>Dirty pattern match pattern.</fsummary>
       <desc>
         <p>Dirty equivalent of the function
@@ -1068,7 +1072,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_next(Tab, Key) -> Key | exit({aborted, Reason})</name>
+      <name name="dirty_next" arity="2" since=""/>
       <fsummary>Return the next key in a table.</fsummary>
       <desc>
       <marker id="dirty_next"></marker>
@@ -1083,7 +1087,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_prev(Tab, Key) -> Key | exit({aborted, Reason})</name>
+      <name name="dirty_prev" arity="2" since=""/>
       <fsummary>Returns the previous key in a table.</fsummary>
       <desc>
       <marker id="dirty_prev"></marker>
@@ -1095,7 +1099,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_read({Tab, Key}) -> ValueList | exit({aborted, Reason}</name>
+      <name name="dirty_read" arity="1" since=""/>
       <fsummary>Dirty read of records.</fsummary>
       <desc>
       <marker id="dirty_read"></marker>
@@ -1103,14 +1107,14 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_read(Tab, Key) -> ValueList | exit({aborted, Reason}</name>
+      <name name="dirty_read" arity="2" since=""/>
       <fsummary>Dirty read of records.</fsummary>
       <desc>
         <p>Dirty equivalent of the function <c>mnesia:read/3</c>.</p>
       </desc>
     </func>
     <func>
-      <name since="">dirty_select(Tab, MatchSpec) -> ValueList | exit({aborted, Reason}</name>
+      <name name="dirty_select" arity="2" since=""/>
       <fsummary>Dirty matches the objects in <c>Tab</c> against <c>MatchSpec</c>.</fsummary>
       <desc>
       <marker id="dirty_select"></marker>
@@ -1118,7 +1122,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_update_counter({Tab, Key}, Incr) -> NewVal | exit({aborted, Reason})</name>
+      <name name="dirty_update_counter" arity="2" since=""/>
       <fsummary>Dirty update of a counter record.</fsummary>
       <desc>
       <marker id="dirty_update_counter"></marker>
@@ -1126,7 +1130,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_update_counter(Tab, Key, Incr) -> NewVal | exit({aborted, Reason})</name>
+      <name name="dirty_update_counter" arity="3" since=""/>
       <fsummary>Dirty update of a counter record.</fsummary>
       <desc>
         <p>Mnesia has no special counter records. However,
@@ -1155,7 +1159,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_write(Record) -> ok | exit({aborted, Reason})</name>
+      <name name="dirty_write" arity="1" since=""/>
       <fsummary>Dirty write of a record.</fsummary>
       <desc>
       <marker id="dirty_write_1"></marker>
@@ -1164,14 +1168,14 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_write(Tab, Record) -> ok | exit({aborted, Reason})</name>
+      <name name="dirty_write" arity="2" since=""/>
       <fsummary>Dirty write of a record.</fsummary>
       <desc>
         <p>Dirty equivalent of the function <c>mnesia:write/3</c>.</p>
       </desc>
     </func>
     <func>
-      <name since="">dump_log() -> dumped</name>
+      <name name="dump_log" arity="0" since=""/>
       <fsummary>Performs a user-initiated dump of the local log file.</fsummary>
       <desc>
       <marker id="dump_log"></marker>
@@ -1185,7 +1189,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dump_tables(TabList) -> {atomic, ok} | {aborted, Reason}</name>
+      <name name="dump_tables" arity="1" since=""/>
       <fsummary>Dumps all RAM tables to disc.</fsummary>
       <desc>
       <marker id="dump_tables"></marker>
@@ -1197,7 +1201,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dump_to_textfile(Filename)</name>
+      <name name="dump_to_textfile" arity="1" since=""/>
       <fsummary>Dumps local tables into a text file.</fsummary>
       <desc>
       <marker id="dump_to_textfile"></marker>
@@ -1210,7 +1214,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">error_description(Error) -> String</name>
+      <name name="error_description" arity="1" since=""/>
       <fsummary>Returns a string describing a particular Mnesia error.</fsummary>
       <desc>
       <marker id="error_description"></marker>
@@ -1288,7 +1292,8 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">ets(Fun, [, Args]) -> ResultOfFun | exit(Reason)</name>
+      <name name="ets" arity="1" since=""/>
+      <name name="ets" arity="2" since=""/>
       <fsummary>Calls the <c>Fun</c> in a raw context that is not protected by a transaction.</fsummary>
       <desc>
       <marker id="ets"></marker>
@@ -1307,7 +1312,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">first(Tab) ->  Key | transaction abort</name>
+      <name name="first" arity="1" since=""/>
       <fsummary>Returns the key for the first record in a table.</fsummary>
       <desc>
       <marker id="first"></marker>
@@ -1322,7 +1327,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">foldl(Function, Acc, Table) -> NewAcc | transaction abort</name>
+      <name name="foldl" arity="3" since=""/>
       <fsummary>Calls <c>Function</c> for each record in <c>Table</c>.</fsummary>
       <desc>
       <marker id="foldl"></marker>
@@ -1335,7 +1340,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">foldr(Function, Acc, Table) -> NewAcc | transaction abort</name>
+      <name name="foldr" arity="3" since=""/>
       <fsummary>Calls <c>Function</c> for each record in <c>Table</c>.</fsummary>
       <desc>
       <marker id="foldr"></marker>
@@ -1346,7 +1351,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">force_load_table(Tab) -> yes | ErrorDescription</name>
+      <name name="force_load_table" arity="1" since=""/>
       <fsummary>Forces a table to be loaded into the system.</fsummary>
       <desc>
       <marker id="force_load_table"></marker>
@@ -1364,7 +1369,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">index_match_object(Pattern, Pos) -> transaction abort | ObjList</name>
+      <name name="index_match_object" arity="2" since=""/>
       <fsummary>Matches records and uses index information.</fsummary>
       <desc>
       <marker id="index_match_object_2"></marker>
@@ -1374,7 +1379,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">index_match_object(Tab, Pattern, Pos, LockKind) -> transaction abort | ObjList</name>
+      <name name="index_match_object" arity="4" since=""/>
       <fsummary>Matches records and uses index information.</fsummary>
       <desc>
       <marker id="index_match_object_4"></marker>
@@ -1406,7 +1411,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">index_read(Tab, SecondaryKey, Pos) -> transaction abort | RecordList</name>
+      <name name="index_read" arity="3" since=""/>
       <fsummary>Reads records through index table.</fsummary>
       <desc>
       <marker id="index_read"></marker>
@@ -1426,7 +1431,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">info() -> ok</name>
+      <name name="info" arity="0" since=""/>
       <fsummary>Prints system information on the terminal.</fsummary>
       <desc>
       <marker id="info"></marker>
@@ -1437,7 +1442,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">install_fallback(Opaque) -> ok | {error,Reason}</name>
+      <name name="install_fallback" arity="1" since=""/>
       <fsummary>Installs a backup as fallback.</fsummary>
       <desc>
       <marker id="install_fallback_1"></marker>
@@ -1446,7 +1451,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">install_fallback(Opaque), BackupMod) -> ok | {error,Reason}</name>
+      <name name="install_fallback" arity="1" since=""/>
       <fsummary>Installs a backup as fallback.</fsummary>
       <desc>
         <p>Calls <c>mnesia:install_fallback(Opaque, Args)</c>, where
@@ -1454,7 +1459,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">install_fallback(Opaque, Args) -> ok | {error,Reason}</name>
+      <name name="install_fallback" arity="2" since=""/>
       <fsummary>Installs a backup as fallback.</fsummary>
       <desc>
         <p>Installs a backup as fallback. The fallback is used to
@@ -1512,7 +1517,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">is_transaction() -> boolean</name>
+      <name name="is_transaction" arity="0" since=""/>
       <fsummary>Checks if code is running in a transaction.</fsummary>
       <desc>
       <marker id="is_transaction"></marker>
@@ -1521,7 +1526,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">last(Tab) -> Key | transaction abort</name>
+      <name name="last" arity="1" since=""/>
       <fsummary>Returns the key for the last record in a table.</fsummary>
       <desc>
         <p>Works exactly like
@@ -1532,7 +1537,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">load_textfile(Filename)</name>
+      <name name="load_textfile" arity="1" since=""/>
       <fsummary>Loads tables from a text file.</fsummary>
       <desc>
       <marker id="load_textfile"></marker>
@@ -1545,7 +1550,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">lock(LockItem, LockKind) -> Nodes | ok | transaction abort</name>
+      <name name="lock" arity="2" since=""/>
       <fsummary>Explicit grab lock.</fsummary>
       <desc>
       <marker id="lock"></marker>
@@ -1634,7 +1639,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">match_object(Pattern) -> transaction abort | RecList</name>
+      <name name="match_object" arity="1" since=""/>
       <fsummary>Matches <c>Pattern</c> for records.</fsummary>
       <desc>
       <marker id="match_object_1"></marker>
@@ -1643,7 +1648,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">match_object(Tab, Pattern, LockKind) -> transaction abort | RecList</name>
+      <name name="match_object" arity="3" since=""/>
       <fsummary>Matches <c>Pattern</c> for records.</fsummary>
       <desc>
       <marker id="match_object_3"></marker>
@@ -1668,7 +1673,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">move_table_copy(Tab, From, To) -> {aborted, Reason} | {atomic, ok}</name>
+      <name name="move_table_copy" arity="3" since=""/>
       <fsummary>Moves the copy of table <c>Tab</c> from node <c>From</c> to node <c>To</c>.</fsummary>
       <desc>
       <marker id="move_table_copy"></marker>
@@ -1682,7 +1687,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">next(Tab, Key) -> Key | transaction abort</name>
+      <name name="next" arity="2" since=""/>
       <fsummary>Returns the next key in a table.</fsummary>
       <desc>
       <marker id="next"></marker>
@@ -1694,7 +1699,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">prev(Tab, Key) -> Key | transaction abort</name>
+      <name name="prev" arity="2" since=""/>
       <fsummary>Returns the previous key in a table.</fsummary>
       <desc>
         <p>Works exactly like
@@ -1705,7 +1710,8 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">read({Tab, Key}) -> transaction abort | RecordList</name>
+      <name name="read" arity="1" since=""/>
+      <name name="read" arity="2" since=""/>
       <fsummary>Reads records(s) with a given key.</fsummary>
       <desc>
       <marker id="read_2"></marker>
@@ -1713,14 +1719,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">read(Tab, Key) -> transaction abort | RecordList</name>
-      <fsummary>Reads records(s) with a given key.</fsummary>
-      <desc>
-        <p>Calls function <c>mnesia:read(Tab, Key, read)</c>.</p>
-      </desc>
-    </func>
-    <func>
-      <name since="">read(Tab, Key, LockKind) -> transaction abort | RecordList</name>
+      <name name="read" arity="3" since=""/>
       <fsummary>Reads records(s) with a given key.</fsummary>
       <desc>
       <marker id="read_3"></marker>
@@ -1745,7 +1744,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">read_lock_table(Tab) -> ok | transaction abort</name>
+      <name name="read_lock_table" arity="1" since=""/>
       <fsummary>Sets a read lock on an entire table.</fsummary>
       <desc>
       <marker id="read_lock_table"></marker>
@@ -1754,7 +1753,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">report_event(Event) -> ok</name>
+      <name name="report_event" arity="1" since=""/>
       <fsummary>Reports a user event to the Mnesia event handler.</fsummary>
       <desc>
       <marker id="report_event"></marker>
@@ -1772,7 +1771,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">restore(Opaque, Args) -> {atomic, RestoredTabs} |{aborted, Reason}</name>
+      <name name="restore" arity="2" since=""/>
       <fsummary>Online restore of backup.</fsummary>
       <desc>
       <marker id="restore"></marker>
@@ -1832,7 +1831,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">s_delete({Tab, Key}) -> ok | transaction abort</name>
+      <name name="s_delete" arity="1" since=""/>
       <fsummary>Sets sticky lock and delete records.</fsummary>
       <desc>
       <marker id="s_delete"></marker>
@@ -1841,7 +1840,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">s_delete_object(Record) -> ok | transaction abort</name>
+      <name name="s_delete_object" arity="1" since=""/>
       <fsummary>Sets sticky lock and delete record.</fsummary>
       <desc>
       <marker id="s_delete_object"></marker>
@@ -1851,7 +1850,7 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">s_write(Record) -> ok | transaction abort</name>
+      <name name="s_write" arity="1" since=""/>
       <fsummary>Writes <c>Record</c> and sets sticky lock.</fsummary>
       <desc>
       <marker id="s_write"></marker>
@@ -1861,21 +1860,22 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">schema() -> ok</name>
+      <name name="schema" arity="0" since=""/>
       <fsummary>Prints information about all table definitions on the terminal.</fsummary>
       <desc>
         <p>Prints information about all table definitions on the terminal.</p>
       </desc>
     </func>
     <func>
-      <name since="">schema(Tab) -> ok</name>
+      <name name="schema" arity="1" since=""/>
       <fsummary>Prints information about one table definition on the terminal.</fsummary>
       <desc>
         <p>Prints information about one table definition on the terminal.</p>
       </desc>
     </func>
     <func>
-      <name since="">select(Tab, MatchSpec [, Lock]) -> transaction abort | [Object]</name>
+      <name name="select" arity="2" since=""/>
+      <name name="select" arity="3" since=""/>
       <fsummary>Matches the objects in <c>Tab</c> against <c>MatchSpec</c>.</fsummary>
       <desc>
       <marker id="select_2_3"></marker>
@@ -1913,7 +1913,7 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">select(Tab, MatchSpec, NObjects, Lock) -> transaction abort | {[Object],Cont} | '$end_of_table'</name>
+      <name name="select" arity="4" since=""/>
       <fsummary>Matches the objects in <c>Tab</c> against <c>MatchSpec</c>.</fsummary>
       <desc>
       <marker id="select_4"></marker>
@@ -1936,7 +1936,7 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">select(Cont) -> transaction abort | {[Object],Cont} | '$end_of_table'</name>
+      <name name="select" arity="1" since=""/>
       <fsummary>Continues selecting objects.</fsummary>
       <desc>
         <p>Selects more objects with the match specification initiated
@@ -1948,7 +1948,7 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">set_master_nodes(MasterNodes) -> ok | {error, Reason}</name>
+      <name name="set_master_nodes" arity="1" since=""/>
       <fsummary>Sets the master nodes for all tables.</fsummary>
       <desc>
       <marker id="set_master_nodes_1"></marker>
@@ -1961,7 +1961,7 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">set_master_nodes(Tab, MasterNodes) -> ok | {error, Reason}</name>
+      <name name="set_master_nodes" arity="2" since=""/>
       <fsummary>Sets the master nodes for a table.</fsummary>
       <desc>
       <marker id="set_master_nodes_2"></marker>
@@ -1986,14 +1986,14 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">snmp_close_table(Tab) -> {aborted, R} | {atomic, ok}</name>
+      <name name="snmp_close_table" arity="1" since=""/>
       <fsummary>Removes the possibility for SNMP to manipulate the table.</fsummary>
       <desc>
         <p>Removes the possibility for SNMP to manipulate the table.</p>
       </desc>
     </func>
     <func>
-      <name since="">snmp_get_mnesia_key(Tab, RowIndex) -> {ok, Key} | undefined</name>
+      <name name="snmp_get_mnesia_key" arity="2" since=""/>
       <fsummary>Gets the corresponding Mnesia key from an SNMP index.</fsummary>
       <type>
         <v>Tab ::= atom()</v>
@@ -2008,7 +2008,7 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">snmp_get_next_index(Tab, RowIndex) -> {ok, NextIndex} | endOfTable</name>
+      <name name="snmp_get_next_index" arity="2" since=""/>
       <fsummary>Gets the index of the next lexicographical row.</fsummary>
       <type>
         <v>Tab ::= atom()</v>
@@ -2024,7 +2024,7 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">snmp_get_row(Tab, RowIndex) -> {ok, Row} | undefined</name>
+      <name name="snmp_get_row" arity="2" since=""/>
       <fsummary>Retrieves a row indexed by an SNMP index.</fsummary>
       <type>
         <v>Tab ::= atom()</v>
@@ -2037,7 +2037,7 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">snmp_open_table(Tab, SnmpStruct) -> {aborted, R} | {atomic, ok}</name>
+      <name name="snmp_open_table" arity="2" since=""/>
       <fsummary>Organizes a Mnesia table as an SNMP table.</fsummary>
       <type>
         <v>Tab ::= atom()</v>
@@ -2091,7 +2091,7 @@ mnesia:create_table(employee,
       </desc>
     </func>
     <func>
-      <name since="">start() -> ok | {error, Reason}</name>
+      <name name="start" arity="0" since=""/>
       <fsummary>Starts a local Mnesia system.</fsummary>
       <desc>
       <marker id="start"></marker>
@@ -2133,7 +2133,7 @@ mnesia:create_table(employee,
       </desc>
     </func>
     <func>
-      <name since="">stop() -> stopped</name>
+      <name name="stop" arity="0" since=""/>
       <fsummary>Stops Mnesia locally.</fsummary>
       <desc>
       <marker id="stop"></marker>
@@ -2142,7 +2142,7 @@ mnesia:create_table(employee,
       </desc>
     </func>
     <func>
-      <name since="">subscribe(EventCategory) -> {ok, Node} | {error, Reason}</name>
+      <name name="subscribe" arity="1" since=""/>
       <fsummary>Subscribes to events of type <c>EventCategory</c>.</fsummary>
       <desc>
       <marker id="subscribe"></marker>
@@ -2152,7 +2152,8 @@ mnesia:create_table(employee,
       </desc>
     </func>
     <func>
-      <name since="">sync_dirty(Fun, [, Args]) -> ResultOfFun | exit(Reason)</name>
+      <name name="sync_dirty" arity="1" since=""/>
+      <name name="sync_dirty" arity="2" since=""/>
       <fsummary>Calls the <c>Fun</c> in a context that is not protected by a transaction.</fsummary>
       <desc>
       <marker id="sync_dirty"></marker>
@@ -2168,7 +2169,7 @@ mnesia:create_table(employee,
       </desc>
     </func>
     <func>
-      <name since="OTP 17.0">sync_log() -> ok | {error, Reason}</name>
+      <name name="sync_log" arity="0" since="OTP 17.0"/>
       <fsummary>Performs a file sync of the local log file.</fsummary>
       <desc>
         <p>Ensures that the local transaction log file is synced to disk.
@@ -2191,7 +2192,7 @@ mnesia:create_table(employee,
       </desc>
     </func>
     <func>
-      <name since="">system_info(InfoKey) -> Info | exit({aborted, Reason})</name>
+      <name name="system_info" arity="1" since=""/>
       <fsummary>Returns information about the Mnesia system.</fsummary>
       <desc>
       <marker id="system_info"></marker>
@@ -2378,7 +2379,8 @@ mnesia:create_table(employee,
       </desc>
     </func>
     <func>
-      <name since="">table(Tab [,[Option]]) -> QueryHandle</name>
+      <name name="table" arity="1" since=""/>
+      <name name="table" arity="2" since=""/>
       <fsummary>Return a QLC query handle.</fsummary>
       <desc>
       <marker id="table"></marker>
@@ -2433,7 +2435,7 @@ mnesia:create_table(employee,
       </desc>
     </func>
     <func>
-      <name since="">table_info(Tab, InfoKey) -> Info | exit({aborted, Reason})</name>
+      <name name="table_info" arity="2" since=""/>
       <fsummary>Returns local information about table.</fsummary>
       <desc>
       <marker id="table_info"></marker>
@@ -2653,7 +2655,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">transform_table(Tab, Fun, NewAttributeList, NewRecordName) -> {aborted, R} | {atomic, ok}</name>
+      <name name="transform_table" arity="4" since=""/>
       <fsummary>Changes format on all records in table <c>Tab</c>.</fsummary>
       <desc>
       <marker id="transform_table_4"></marker>
@@ -2674,7 +2676,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">transform_table(Tab, Fun, NewAttributeList) -> {aborted, R} | {atomic, ok}</name>
+      <name name="transform_table" arity="3" since=""/>
       <fsummary>Changes format on all records in table <c>Tab</c>.</fsummary>
       <desc>
         <p>Calls <c>mnesia:transform_table(Tab, Fun,
@@ -2683,7 +2685,8 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">traverse_backup(Source, [SourceMod,] Target, [TargetMod,] Fun, Acc) -> {ok, LastAcc} | {error, Reason}</name>
+      <name name="traverse_backup" arity="4" since=""/>
+      <name name="traverse_backup" arity="6" since=""/>
       <fsummary>Traversal of a backup.</fsummary>
       <desc>
       <marker id="traverse_backup"></marker>
@@ -2714,7 +2717,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">uninstall_fallback() -> ok | {error,Reason}</name>
+      <name name="uninstall_fallback" arity="0" since=""/>
       <fsummary>Uninstalls a fallback.</fsummary>
       <desc>
       <marker id="uninstall_fallback_0"></marker>
@@ -2723,7 +2726,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">uninstall_fallback(Args) -> ok | {error,Reason}</name>
+      <name name="uninstall_fallback" arity="1" since=""/>
       <fsummary>Uninstalls a fallback.</fsummary>
       <desc>
         <p>Deinstalls a fallback before it
@@ -2750,7 +2753,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">unsubscribe(EventCategory) -> {ok, Node} | {error, Reason}</name>
+      <name name="unsubscribe" arity="1" since=""/>
       <fsummary>Subscribes to events of type <c>EventCategory</c>.</fsummary>
       <desc>
       <marker id="unsubscribe"></marker>
@@ -2760,7 +2763,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">wait_for_tables(TabList, Timeout) -> ok | {timeout, BadTabList} | {error, Reason}</name>
+      <name name="wait_for_tables" arity="2" since=""/>
       <fsummary>Waits for tables to be accessible.</fsummary>
       <desc>
       <marker id="wait_for_tables"></marker>
@@ -2771,7 +2774,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">wread({Tab, Key}) -> transaction abort | RecordList</name>
+      <name name="wread" arity="1" since=""/>
       <fsummary>Reads records with given key.</fsummary>
       <desc>
       <marker id="wread"></marker>
@@ -2779,7 +2782,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">write(Record) -> transaction abort | ok</name>
+      <name name="write" arity="1" since=""/>
       <fsummary>Writes a record into the database.</fsummary>
       <desc>
       <marker id="write_1"></marker>
@@ -2788,7 +2791,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">write(Tab, Record, LockKind) -> transaction abort | ok</name>
+      <name name="write" arity="3" since=""/>
       <fsummary>Writes a record into the database.</fsummary>
       <desc>
       <marker id="write_3"></marker>
@@ -2804,7 +2807,7 @@ raise(Name, Amount) ->
       </desc>
     </func>
     <func>
-      <name since="">write_lock_table(Tab) -> ok | transaction abort</name>
+      <name name="write_lock_table" arity="1" since=""/>
       <fsummary>Sets write lock on an entire table.</fsummary>
       <desc>
       <marker id="write_lock_table"></marker>

--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -1073,22 +1073,6 @@ mnesia:create_table(person,
       </desc>
     </func>
     <func>
-      <name since="">dirty_slot(Tab, Slot) -> RecordList | exit({aborted, Reason})</name>
-      <fsummary>Returns the list of records that are associated with <c>Slot</c> in a table.</fsummary>
-      <desc>
-      <marker id="dirty_slot"></marker>
-        <p>Traverses a table in a
-          manner similar to the function <c>mnesia:dirty_next/2</c>.
-          A table has a number of slots that range from 0 (zero) to
-          an unknown upper bound. The function
-          <c>mnesia:dirty_slot/2</c> returns the special atom
-          <c>'$end_of_table'</c> when the end of the table is reached.
-          The behavior of this function is undefined if a write
-          operation is performed on the table while it is being
-          traversed.</p>
-      </desc>
-    </func>
-    <func>
       <name since="">dirty_update_counter({Tab, Key}, Incr) -> NewVal | exit({aborted, Reason})</name>
       <fsummary>Dirty update of a counter record.</fsummary>
       <desc>

--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -181,6 +181,51 @@
       transaction before iterating over the table.</p>
   </description>
 
+  <datatypes>
+    <datatype>
+      <name name="table"/>
+    </datatype>
+    <datatype>
+      <name name="activity"/>
+    </datatype>
+    <datatype>
+      <name name="create_option"/>
+    </datatype>
+    <datatype>
+      <name name="storage_type"/>
+    </datatype>
+    <datatype>
+      <name name="t_result" n_vars="1"/>
+    </datatype>
+    <datatype>
+      <name name="index_attr"/>
+    </datatype>
+    <datatype>
+      <name name="write_locks"/>
+    </datatype>
+    <datatype>
+      <name name="read_locks"/>
+    </datatype>
+    <datatype>
+      <name name="lock_kind"/>
+    </datatype>
+    <datatype>
+      <name name="select_continuation"/>
+    </datatype>
+    <datatype>
+      <name name="snmp_struct"/>
+    </datatype>
+    <datatype>
+      <name name="snmp_type"/>
+    </datatype>
+    <datatype>
+      <name name="config_key"/>
+    </datatype>
+    <datatype>
+      <name name="config_result"/>
+    </datatype>
+  </datatypes>
+
   <funcs>
     <func>
       <name since="">abort(Reason) -> transaction abort</name>

--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -1903,17 +1903,6 @@ mnesia:select(Tab,[{MatchHead, [Guard], [Result]}]),</code>
       </desc>
     </func>
     <func>
-      <name since="">set_debug_level(Level) -> OldLevel</name>
-      <fsummary>Changes the internal debug level of Mnesia.</fsummary>
-      <desc>
-      <marker id="set_debug_level"></marker>
-        <p>Changes the internal debug level of Mnesia.
-          For details, see
-          <seealso marker="#configuration_parameters">Section
-          Configuration Parameters</seealso>.</p>
-      </desc>
-    </func>
-    <func>
       <name since="">set_master_nodes(MasterNodes) -> ok | {error, Reason}</name>
       <fsummary>Sets the master nodes for all tables.</fsummary>
       <desc>

--- a/lib/mnesia/doc/src/specs.xml
+++ b/lib/mnesia/doc/src/specs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<specs xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="../specs/specs_mnesia.xml"/>
+    <xi:include href="../specs/specs_mnesia_frag_hash.xml"/>
+    <xi:include href="../specs/specs_mnesia_registry.xml"/>
+</specs>


### PR DESCRIPTION
Because the mnesia docs did not have xml specs built for them, the functions were not appearing in the table of contents. This PR addresses that issue and also updates the xml documentation to use the `<name name="fun_name" arity="3" since=""/>` format instead of the older `<name since="">fun_name(A, B, C) -> :ok</name>` format.

I also removed xml documentation for `mnesia:dirty_slot/2` and `mnesia:set_debug_level/1` because they did not have specs in `mnesia.erl`.  I hope that's ok.

This is also the first time I've done this large of a documentation change, so if I've gotten wrong in some way, please let me know.