### PR TITLE
Allow binaries as parts of logger_formatter template

### DIFF
--- a/lib/kernel/src/logger_formatter.erl
+++ b/lib/kernel/src/logger_formatter.erl
@@ -532,8 +532,8 @@ check_template([Str|T]) when is_list(Str) ->
         false -> error
     end;
 check_template([Bin|T]) when is_binary(Bin) ->
-    case unicode:character_to_list(Bin) of
-        Str -> check_template([Str|T]);
+    case unicode:characters_to_list(Bin) of
+        Str when is_list(Str) -> check_template([Str|T]);
         _Error -> error
     end;
 check_template([]) ->

--- a/lib/kernel/src/logger_formatter.erl
+++ b/lib/kernel/src/logger_formatter.erl
@@ -35,7 +35,7 @@
                     template        => template(),
                     time_designator => byte(),
                     time_offset     => integer() | [byte()]}.
--type template() :: [metakey() | {metakey(),template(),template()} | string() | binary()].
+-type template() :: [metakey() | {metakey(),template(),template()} | unicode:chardata()].
 -type metakey() :: atom() | [atom()].
 
 %%%-----------------------------------------------------------------

--- a/lib/kernel/src/logger_formatter.erl
+++ b/lib/kernel/src/logger_formatter.erl
@@ -532,8 +532,10 @@ check_template([Str|T]) when is_list(Str) ->
         false -> error
     end;
 check_template([Bin|T]) when is_binary(Bin) ->
-    Str = binary:bin_to_list(Bin),
-    check_template([Str|T]);
+    case unicode:character_to_list(Bin) of
+        Str -> check_template([Str|T]);
+        _Error -> error
+    end;
 check_template([]) ->
     ok;
 check_template(_) ->

--- a/lib/kernel/src/logger_formatter.erl
+++ b/lib/kernel/src/logger_formatter.erl
@@ -35,7 +35,7 @@
                     template        => template(),
                     time_designator => byte(),
                     time_offset     => integer() | [byte()]}.
--type template() :: [metakey() | {metakey(),template(),template()} | string()].
+-type template() :: [metakey() | {metakey(),template(),template()} | string() | binary()].
 -type metakey() :: atom() | [atom()].
 
 %%%-----------------------------------------------------------------
@@ -531,6 +531,9 @@ check_template([Str|T]) when is_list(Str) ->
         true -> check_template(T);
         false -> error
     end;
+check_template([Bin|T]) when is_binary(Bin) ->
+    Str = binary:bin_to_list(Bin),
+    check_template([Str|T]);
 check_template([]) ->
     ok;
 check_template(_) ->

--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -247,8 +247,13 @@ template(_Config) ->
     ct:log(String5),
     "" = String5,
 
-    Ref6 = erlang:make_ref(),
-    Meta6 = #{atom=>some_atom,
+    Template6 = [<<"binary">>],
+    String6 = format(info,{"~p",[term]},#{time=>Time},#{template=>Template5}),
+    ct:log(String6),
+    "binary" = String6,
+
+    Ref7 = erlang:make_ref(),
+    Meta7 = #{atom=>some_atom,
               integer=>632,
               list=>[list,"string",4321,#{},{tuple}],
               mfa=>{mod,func,0},
@@ -258,57 +263,57 @@ template(_Config) ->
               time=>Time,
               tuple=>{1,atom,"list"},
               nested=>#{subkey=>subvalue}},
-    Template6 = lists:join(";",lists:sort(maps:keys(maps:remove(nested,Meta6))) ++
+    Template7 = lists:join(";",lists:sort(maps:keys(maps:remove(nested,Meta6))) ++
                                [[nested,subkey]]),
-    String6 = format(info,{"~p",[term]},Meta6,#{template=>Template6,
+    String7 = format(info,{"~p",[term]},Meta6,#{template=>Template6,
                                                 single_line=>true}),
     ct:log(String6),
     SelfStr = pid_to_list(self()),
-    RefStr6 = ref_to_list(Ref6),
+    RefStr7 = ref_to_list(Ref7),
     ListStr = "[list,\"string\",4321,#{},{tuple}]",
-    ExpectedTime6 = default_time_format(Time),
+    ExpectedTime7 = default_time_format(Time),
     ["some_atom",
      "632",
      ListStr,
      "mod:func/0",
      SelfStr,
-     RefStr6,
+     RefStr7,
      "some string",
-     ExpectedTime6,
+     ExpectedTime7,
      "{1,atom,\"list\"}",
-     "subvalue"] = string:lexemes(String6,";"),
+     "subvalue"] = string:lexemes(String7,";"),
 
-    Meta7 = #{time=>Time,
+    Meta8 = #{time=>Time,
               nested=>#{key1=>#{subkey1=>value1},
                         key2=>value2}},
-    Template7 = lists:join(";",[nested,
+    Template8 = lists:join(";",[nested,
                                 [nested,key1],
                                 [nested,key1,subkey1],
                                 [nested,key2],
                                 [nested,key2,subkey2],
                                 [nested,key3],
                                 [nested,key3,subkey3]]),
-    String7 = format(info,{"~p",[term]},Meta7,#{template=>Template7,
+    String8 = format(info,{"~p",[term]},Meta7,#{template=>Template7,
                                                 single_line=>true}),
-    ct:log(String7),
-    [MultipleKeysStr7,
+    ct:log(String8),
+    [MultipleKeysStr8,
      "#{subkey1 => value1}",
      "value1",
      "value2",
      "",
      "",
-     ""] = string:split(String7,";",all),
+     ""] = string:split(String8,";",all),
     %% Order of keys is not fixed
-    case MultipleKeysStr7 of
+    case MultipleKeysStr8 of
         "#{key2 => value2,key1 => #{subkey1 => value1}}" -> ok;
         "#{key1 => #{subkey1 => value1},key2 => value2}" -> ok;
-        _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr7})
+        _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr8})
     end,
 
-    Meta8 = #{time=>Time,
+    Meta9 = #{time=>Time,
               nested=>#{key1=>#{subkey1=>value1},
                         key2=>value2}},
-    Template8 =
+    Template9 =
         lists:join(
           ";",
           [{nested,["exist:",nested],["noexist"]},
@@ -318,21 +323,21 @@ template(_Config) ->
            {[nested,key2,subkey2],["exist:",[nested,key2,subkey2]],["noexist"]},
            {[nested,key3],["exist:",[nested,key3]],["noexist"]},
            {[nested,key3,subkey3],["exist:",[nested,key3,subkey3]],["noexist"]}]),
-    String8 = format(info,{"~p",[term]},Meta8,#{template=>Template8,
+    String9 = format(info,{"~p",[term]},Meta8,#{template=>Template8,
                                                 single_line=>true}),
-    ct:log(String8),
-    [MultipleKeysStr8,
+    ct:log(String9),
+    [MultipleKeysStr9,
      "exist:#{subkey1 => value1}",
      "exist:value1",
      "exist:value2",
      "noexist",
      "noexist",
-     "noexist"] = string:split(String8,";",all),
+     "noexist"] = string:split(String9,";",all),
     %% Order of keys is not fixed
-    case MultipleKeysStr8 of
+    case MultipleKeysStr9 of
         "exist:#{key2 => value2,key1 => #{subkey1 => value1}}" -> ok;
         "exist:#{key1 => #{subkey1 => value1},key2 => value2}" -> ok;
-        _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr8})
+        _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr9})
     end,
 
     ok.
@@ -347,7 +352,7 @@ format_msg(_Config) ->
     String2 = format(info,{"list",[term]},#{},#{template=>Template}),
     ct:log(String2),
     "FORMAT ERROR: \"list\" - [term]" = String2,
-    
+
     String3 = format(info,{report,term},#{},#{template=>Template}),
     ct:log(String3),
     "term" = String3,

--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -248,72 +248,77 @@ template(_Config) ->
     "" = String5,
 
     Template6 = [<<"binary">>],
-    String6 = format(info,{"~p",[term]},#{time=>Time},#{template=>Template5}),
+    String6 = format(info,{"~p",[term]},#{time=>Time},#{template=>Template6}),
     ct:log(String6),
     "binary" = String6,
 
-    Ref7 = erlang:make_ref(),
-    Meta7 = #{atom=>some_atom,
+    Template7 = [{metakey,[[$e,<<"x">>,$i,[<<"s">>],":"],metakey],[[[[[[[[["does ",<<"not">>," exist"]]]]]]]]]},[[[<<" more ">>]],"deep"]],
+    String7 = format(info,{"~p",[term]},#{time=>Time},#{template=>Template7}),
+    ct:log(String7),
+    "does not exist more deep" = String7,
+
+    Ref8 = erlang:make_ref(),
+    Meta8 = #{atom=>some_atom,
               integer=>632,
               list=>[list,"string",4321,#{},{tuple}],
               mfa=>{mod,func,0},
               pid=>self(),
-              ref=>Ref6,
+              ref=>Ref8,
               string=>"some string",
               time=>Time,
               tuple=>{1,atom,"list"},
               nested=>#{subkey=>subvalue}},
-    Template7 = lists:join(";",lists:sort(maps:keys(maps:remove(nested,Meta6))) ++
+    Template8 = lists:join(";",lists:sort(maps:keys(maps:remove(nested,Meta8))) ++
                                [[nested,subkey]]),
-    String7 = format(info,{"~p",[term]},Meta6,#{template=>Template6,
+    String8 = format(info,{"~p",[term]},Meta8,#{template=>Template8,
                                                 single_line=>true}),
     ct:log(String6),
     SelfStr = pid_to_list(self()),
-    RefStr7 = ref_to_list(Ref7),
+    RefStr8 = ref_to_list(Ref8),
     ListStr = "[list,\"string\",4321,#{},{tuple}]",
-    ExpectedTime7 = default_time_format(Time),
+    ExpectedTime8 = default_time_format(Time),
     ["some_atom",
      "632",
      ListStr,
      "mod:func/0",
      SelfStr,
-     RefStr7,
+     RefStr8,
      "some string",
-     ExpectedTime7,
+     ExpectedTime8,
      "{1,atom,\"list\"}",
-     "subvalue"] = string:lexemes(String7,";"),
+     "subvalue"] = string:lexemes(String8,";"),
 
-    Meta8 = #{time=>Time,
+    Meta9 = #{time=>Time,
               nested=>#{key1=>#{subkey1=>value1},
                         key2=>value2}},
-    Template8 = lists:join(";",[nested,
+    Template9 = lists:join(";",[nested,
                                 [nested,key1],
                                 [nested,key1,subkey1],
                                 [nested,key2],
                                 [nested,key2,subkey2],
                                 [nested,key3],
                                 [nested,key3,subkey3]]),
-    String8 = format(info,{"~p",[term]},Meta7,#{template=>Template7,
+    String9 = format(info,{"~p",[term]},Meta9,#{template=>Template9,
                                                 single_line=>true}),
-    ct:log(String8),
-    [MultipleKeysStr8,
+    ct:log(String9),
+    [MultipleKeysStr9,
      "#{subkey1 => value1}",
      "value1",
      "value2",
      "",
      "",
-     ""] = string:split(String8,";",all),
+     ""] = string:split(String9,";",all),
     %% Order of keys is not fixed
-    case MultipleKeysStr8 of
+    case MultipleKeysStr9 of
         "#{key2 => value2,key1 => #{subkey1 => value1}}" -> ok;
         "#{key1 => #{subkey1 => value1},key2 => value2}" -> ok;
-        _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr8})
+        _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr9})
     end,
 
-    Meta9 = #{time=>Time,
+    Meta10 = #{time=>Time,
               nested=>#{key1=>#{subkey1=>value1},
                         key2=>value2}},
-    Template9 =
+    Template10 =
         lists:join(
           ";",
           [{nested,["exist:",nested],["noexist"]},
@@ -323,21 +328,21 @@ template(_Config) ->
            {[nested,key2,subkey2],["exist:",[nested,key2,subkey2]],["noexist"]},
            {[nested,key3],["exist:",[nested,key3]],["noexist"]},
            {[nested,key3,subkey3],["exist:",[nested,key3,subkey3]],["noexist"]}]),
-    String9 = format(info,{"~p",[term]},Meta8,#{template=>Template8,
-                                                single_line=>true}),
-    ct:log(String9),
-    [MultipleKeysStr9,
+    String10 = format(info,{"~p",[term]},Meta10,#{template=>Template10,
+                                                 single_line=>true}),
+    ct:log(String10),
+    [MultipleKeysStr10,
      "exist:#{subkey1 => value1}",
      "exist:value1",
      "exist:value2",
      "noexist",
      "noexist",
-     "noexist"] = string:split(String9,";",all),
+     "noexist"] = string:split(String10,";",all),
     %% Order of keys is not fixed
-    case MultipleKeysStr9 of
+    case MultipleKeysStr10 of
         "exist:#{key2 => value2,key1 => #{subkey1 => value1}}" -> ok;
         "exist:#{key1 => #{subkey1 => value1},key2 => value2}" -> ok;
-        _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr9})
+        _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr10})
     end,
 
     ok.
@@ -847,7 +852,7 @@ format(Level,Msg,Meta,Config) ->
     format(#{level=>Level,msg=>Msg,meta=>add_time(Meta)},Config).
 
 format(Log,Config) ->
-    lists:flatten(logger_formatter:format(Log,Config)).
+    unicode:characters_to_list(logger_formatter:format(Log,Config)).
 
 default_time_format(Timestamp) ->
     default_time_format(Timestamp,false).


### PR DESCRIPTION
This small change will simplify integration of Erlang's logger with
Elixir applications where users are more accustomed to usage of binaries
instead of char lists as a "string" type.