### PR TITLE
export uri_string:decode/1

### DIFF
--- a/lib/stdlib/doc/src/uri_string.xml
+++ b/lib/stdlib/doc/src/uri_string.xml
@@ -84,6 +84,9 @@
       <item>Dissecting form-urlencoded query strings into a list of key-value pairs<br></br>
       <seealso marker="#dissect_query/1"><c>dissect_query/1</c></seealso>
       </item>
+      <item>Decoding percent-encoded strings or binaries.<br></br>
+      <seealso marker="#decode/1"><c>decode/1</c></seealso>
+      </item>
     </list>
     <p>There are four different encodings present during the handling of URIs:</p>
     <list type="bulleted">
@@ -206,6 +209,21 @@
 2> {<<"city">>,<<"東京"/utf8>>}], [{encoding, latin1}]).]]>
 <![CDATA[<<"foo+bar=1&city=%26%2326481%3B%26%2320140%3B">>]]>
 	</pre>
+      </desc>
+    </func>
+
+    <func>
+      <name name="decode" arity="1" />
+      <fsummary>Percent-encoding string or binary decoding.</fsummary>
+      <desc>
+        <p>Decodes a percent-encoded string or binary as defined in section
+        2.1 of <url href="https://www.ietf.org/rfc/rfc3986.txt">RFC
+        3986</url>.</p>
+        <p><em>Example:</em></p>
+        <pre>
+          1> <input><![CDATA[uri_string:decode(<<"hello%20world">>).]]></input>
+          <![CDATA[<<"hello world">>]]>
+	    </pre>
       </desc>
     </func>
 

--- a/lib/stdlib/src/uri_string.erl
+++ b/lib/stdlib/src/uri_string.erl
@@ -226,7 +226,7 @@
 %%-------------------------------------------------------------------------
 %% External API
 %%-------------------------------------------------------------------------
--export([compose_query/1, compose_query/2,
+-export([compose_query/1, compose_query/2, decode/1,
          dissect_query/1, normalize/1, normalize/2, parse/1,
          recompose/1, resolve/2, resolve/3, transcode/2]).
 -export_type([error/0, uri_map/0, uri_string/0]).


### PR DESCRIPTION
In the current state, the uri_string module parses URIs to maps of components
but does not decode those which can be percent-encoded such as the
fragment. It is not a problem with the query since `uri_string:dissect_query/1`
will decode it, but other components need decoding.

Exporting `uri_string:decode/1` solves this problem and lets users decode
components when they need it.

In the future, it could be nice to add `uri_string:parse/2`, the second
argument being a list of options which could include `decode_components`.