### PR TITLE
Unfold literals to avoid unnecessary move instructions

### DIFF
--- a/lib/compiler/test/beam_except_SUITE.erl
+++ b/lib/compiler/test/beam_except_SUITE.erl
@@ -127,13 +127,19 @@ coverage(_) ->
     {'EXIT',{function_clause,[{?MODULE,foobar,[[fail],1,2],
                                [{file,"fake.erl"},{line,16}]}|_]}} =
         (catch foobar([fail], 1, 2)),
-    {'EXIT',{function_clause,[{?MODULE,fake_function_clause,[{a,b},42.0],_}|_]}} =
-        (catch fake_function_clause({a,b})),
+    {'EXIT',{function_clause,[{?MODULE,fake_function_clause1,[{a,b},42.0],_}|_]}} =
+        (catch fake_function_clause1({a,b})),
+
+    {'EXIT',{function_clause,[{?MODULE,fake_function_clause2,[42|bad_tl],_}|_]}} =
+        (catch fake_function_clause2(42, bad_tl)),
+    {'EXIT',{function_clause,[{?MODULE,fake_function_clause3,[x,y],_}|_]}} =
+        (catch fake_function_clause3(42, id([x,y]))),
 
     ok.
 
-fake_function_clause(A) -> error(function_clause, [A,42.0]).
-
+fake_function_clause1(A) -> error(function_clause, [A,42.0]).
+fake_function_clause2(A, Tl) -> error(function_clause, [A|Tl]).
+fake_function_clause3(_, Stk) -> error(function_clause, Stk).
 
 binary_construction_allocation(_Config) ->
     ok = do_binary_construction_allocation("PUT"),


### PR DESCRIPTION
Consider the following example:

    -module(whatever).
    -export([foo/0]).

    foo() ->
        foobar(1, 2, 3).

    foobar(A, B, C) ->
        foobar(A, B, C, []).

    foobar(A, B, C, D) -> ...

The type optimization pass will find out that `A`, `B`, and `C` have constant
values and do constant folding, rewriting `foobar/3` to:

    foobar(A, B, C) ->
        foobar(1, 2, 3, []).

That will result in three unecessary `move` instructions.

This was an issue already in OTP 22, but it has got worse in the
upcoming OTP 23 release because of the improved type optimizations.

This commit adds an `unfold_literals` sub pass in `beam_ssa_opt` that
undoes the constant folding optimization, rewriting code to use the
original variable instead of the constant if the original variable is
known to be in an x register.

This optimization sub pass also undoes constant folding of the
list of arguments in the call to error/2 in the last clause of a
function. For example:

    bar(X, Y) ->
        error(function_clause, [X,42]).

will be rewritten to:

    bar(X, Y) ->
        error(function_clause, [X,Y]).