### PR TITLE
Optimize the transformation engine in the BEAM loader

### DIFF
--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -2716,36 +2716,30 @@ load_code(LoaderState* stp)
                 num_trailing_f = 0;
             }
 #endif
+            CodeNeed(1);
 	    switch (tmp_op->a[arg].type) {
 	    case TAG_i:
-		CodeNeed(1);
 		code[ci++] = make_small(tmp_op->a[arg].val);
 		break;
 	    case TAG_u:
 	    case TAG_a:
 	    case TAG_v:
-		CodeNeed(1);
 		code[ci++] = tmp_op->a[arg].val;
 		break;
 	    case TAG_f:
-		CodeNeed(1);
                 register_label_patch(stp, tmp_op->a[arg].val, ci, -last_instr_start);
 		ci++;
 		break;
 	    case TAG_x:
-		CodeNeed(1);
 		code[ci++] = make_loader_x_reg(tmp_op->a[arg].val);
 		break;
 	    case TAG_y:
-		CodeNeed(1);
 		code[ci++] = make_loader_y_reg(tmp_op->a[arg].val);
 		break;
 	    case TAG_n:
-		CodeNeed(1);
 		code[ci++] = NIL;
 		break;
 	    case TAG_q:
-		CodeNeed(1);
 		new_literal_patch(stp, ci);
 		code[ci++] = tmp_op->a[arg].val;
 		break;

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -2986,6 +2986,7 @@ load_code(LoaderState* stp)
 #define succ3(St, X, Y) ((X).type == (Y).type && (X).val + 3 == (Y).val)
 #define succ4(St, X, Y) ((X).type == (Y).type && (X).val + 4 == (Y).val)
 
+#define offset(St, X, Y, Offset) ((X).type == (Y).type && (X).val + Offset == (Y).val)
 
 #ifdef NO_FPE_SIGNALS 
 #define no_fpe_signals(St) 1

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -5689,6 +5689,23 @@ transform_engine(LoaderState* st)
 	    break;
 	case TOP_fail:
 	    return TE_FAIL;
+#if defined(TOP_skip_unless)
+	case TOP_skip_unless:
+            /*
+             * Note that the caller of transform_engine() guarantees that
+             * there is always a second instruction available.
+             */
+            ASSERT(instr);
+            if (instr->next->op != pc[0]) {
+                /* The second instruction is wrong. Skip ahead. */
+                pc += pc[1] + 2;
+                ASSERT(*pc < NUM_TOPS); /* Valid instruction? */
+            } else {
+                /* Correct second instruction. */
+                pc += 2;
+            }
+	    break;
+#endif
 	default:
 	    ASSERT(0);
 	}

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -389,16 +389,6 @@ move2_par X1=x X2=x X3=x X4=x | move X5=x X6=x => move3 X1 X2 X3 X4 X5 X6
 move3 y x y x y x
 move3 x x x x x x
 
-# move_x1, move_x2
-
-move C=aiq X=x==1 => move_x1 C
-move C=aiq X=x==2 => move_x2 C
-
-move n D=y => init D
-
-move_x1 c
-move_x2 c
-
 move xy xy
 move c xy
 move n x
@@ -1718,3 +1708,21 @@ i_recv_set
 
 build_stacktrace
 raw_raise
+
+#
+# Specialized move instructions. Since they don't require a second
+# instruction, we have intentionally placed them after any other
+# transformation rules that starts with a move instruction in order to
+# produce better code for the transformation engine.
+#
+
+# move_x1, move_x2
+
+move C=aiq X=x==1 => move_x1 C
+move C=aiq X=x==2 => move_x2 C
+
+move n D=y => init D
+
+move_x1 c
+move_x2 c
+

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -280,26 +280,19 @@ move_jump f c r
 # Movement to and from the stack is common.
 # Try to pack as much as we can into one instruction.
 
-# Window move
-move_window/5
-move_window/6
-
 # x -> y
 
-move X1=x Y1=y | move X2=x Y2=y | move X3=x Y3=y | succ(Y1,Y2) | succ(Y2,Y3) => \
-    move_window X1 X2 X3 Y1 Y3
-
-move X1=x Y1=y | move X2=x Y2=y | succ(Y1,Y2) => \
+move X1=x Y1=y | move X2=x Y2=y | succ(Y1, Y2) => \
     move_window2 X1 X2 Y1
 
-move_window X1=x X2=x X3=x Y1=y Y3=y | move X4=x Y4=y | succ(Y3,Y4) => \
-    move_window X1 X2 X3 X4 Y1 Y4
+move_window2 X1 X2 Y1 | move X3=x Y3=y | offset(Y1, Y3, 2) => \
+    move_window3 X1 X2 X3 Y1
 
-move_window X1=x X2=x X3=x X4=x Y1=y Y4=y | move X5=x Y5=y | succ(Y4,Y5) => \
+move_window3 X1 X2 X3 Y1 | move X4=x Y4=y | offset(Y1, Y4, 3) => \
+    move_window4 X1 X2 X3 X4 Y1
+
+move_window4 X1 X2 X3 X4 Y1=y | move X5=x Y5=y | offset(Y1, Y5, 4) => \
     move_window5 X1 X2 X3 X4 X5 Y1
-
-move_window X1=x X2=x X3=x Y1=y Y3=y => move_window3 X1 X2 X3 Y1
-move_window X1=x X2=x X3=x X4=x Y1=y Y4=y => move_window4 X1 X2 X3 X4 Y1
 
 move_window2 x x y
 move_window3 x x x y

--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -74,35 +74,29 @@ trace_jump W
 
 return
 
-# To ensure that a "move Src x(0)" instruction can be combined with
-# the following call instruction, we need to make sure that there is
-# no line/1 instruction between the move and the call.
-
-move S X0=x==0 | line Loc | call Ar Func => \
-     line Loc | move S X0 | call Ar Func
-
-move S X0=x==0 | line Loc | call_ext Ar Func => \
-     line Loc | move S X0 | call_ext Ar Func
-
 #
 # A tail call will not refer to the current function on error unless it's a
 # BIF, so we can omit the line instruction for non-BIFs.
 #
 
-move S X0=x==0 | line Loc | call_ext_last Ar Func=u$is_bif D => \
-     line Loc | move S X0 | call_ext_last Ar Func D
-move S X0=x==0 | line Loc | call_ext_only Ar Func=u$is_bif => \
-     line Loc | move S X0 | call_ext_only Ar Func
-
-move S X0=x==0 | line Loc | call_ext_last Ar Func D => \
+move S X0=x==0 | line Loc | call_ext_last Ar Func=u$is_not_bif D => \
      move S X0 | call_ext_last Ar Func D
-move S X0=x==0 | line Loc | call_ext_only Ar Func => \
+move S X0=x==0 | line Loc | call_ext_only Ar Func=u$is_not_bif => \
      move S X0 | call_ext_only Ar Func
 
 move S X0=x==0 | line Loc | call_last Ar Func D => \
      move S X0 | call_last Ar Func D
 move S X0=x==0 | line Loc | call_only Ar Func => \
      move S X0 | call_only Ar Func
+
+# To ensure that a "move Src x(0)" instruction can be combined with
+# the following call instruction, we need to make sure that there is
+# no line/1 instruction between the move and the call. (We don't
+# need to match the call instruction, because reordering the move
+# and line instructions would be harmless even if no call instruction
+# follows.)
+
+move S X0=x==0 | line Loc => line Loc | move S X0
 
 line Loc | func_info M F A => func_info M F A | line Loc
 

--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -2471,11 +2471,17 @@ sub tr_gen_from {
 	    $name = $1;
 	    $may_fail = 1;
 	    my $var;
-	    my(@args);
+	    my @args;
+            my @vars;
 
 	    foreach $var (@ops) {
-		error($where, "variable '$var' unbound")
+                if ($var =~ /^-?\d+$/) {
+                    push @args, $var;
+                    next;
+                }
+		error($where, "'$var' unbound")
 		    unless defined $var{$var};
+                push @vars, $var;
 		if ($var_type{$var} eq 'scalar') {
 		    push(@args, "var[$var{$var}]");
 		} else {
@@ -2483,8 +2489,8 @@ sub tr_gen_from {
 		}
 	    }
 	    my $pi = tr_next_index(\@pred_table, \%pred_table, $name, @args);
-	    my $op = make_op("$name()", 'pred', $pi);
-	    my @slots = grep(/^\d+/, map { $var{$_} } @ops);
+            my $op = make_op("$name()", 'pred', $pi);
+            my @slots = grep(/^\d+/, map { $var{$_} } @vars);
 	    op_slot_usage($op, @slots);
 	    push(@code, $op);
 	    next;

--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -2595,6 +2595,39 @@ sub tr_gen_from {
     #
     push(@code, make_op($may_fail ? '' : 'always reached', 'commit'));
 
+    #
+    # Peephole optimization: combine instructions.
+    #
+    for (my $i = 0; $i < @code; $i++) {
+        if (is_instr($code[$i], 'is_type')) {
+            my(undef, $is_type_ref, $type_comment) = @{$code[$i]};
+            if (is_instr($code[$i+1], 'set_var_next_arg')) {
+                my(undef, $next_ref, $next_comment) = @{$code[$i+1]};
+                my $comment = "$type_comment $next_comment";
+                my $op = make_op($comment, 'is_type_set_var_next_arg',
+                                 $is_type_ref->[1], $next_ref->[1]);
+                splice @code, $i, 2, ($op);
+            } elsif (is_instr($code[$i+1], 'next_arg')) {
+                my $op = make_op($type_comment, 'is_type_next_arg', $is_type_ref->[1]);
+                splice @code, $i, 2, ($op);
+            }
+        } elsif (is_instr($code[$i], 'is_type_eq')) {
+            my(undef, $is_type_ref, $type_comment) = @{$code[$i]};
+            if (is_instr($code[$i+1], 'set_var_next_arg')) {
+                my(undef, $next_ref, $next_comment) = @{$code[$i+1]};
+                my $comment = "$type_comment $next_comment";
+                my $op = make_op($comment, 'is_type_eq_set_var_next_arg',
+                                 $is_type_ref->[1], $is_type_ref->[2],
+                                 $next_ref->[1]);
+                splice @code, $i, 2, ($op);
+            } elsif (is_instr($code[$i+1], 'next_arg')) {
+                my $op = make_op($type_comment, 'is_type_eq_next_arg',
+                                 $is_type_ref->[1], $is_type_ref->[2]);
+                splice @code, $i, 2, ($op);
+            }
+        }
+    }
+
     $te_max_vars = $var_num
 	if $te_max_vars < $var_num;
     [\%var, \%var_type, \@code];
@@ -2670,11 +2703,10 @@ sub tr_gen_to {
 		op_slot_usage($op, $var{$var});
 		push(@code, $op);
 	    } elsif ($type ne '') {
-		push(@code, make_op('', 'store_type', "TAG_$type"));
-		if ($type_val) {
-		    push(@code, make_op('', 'store_val', $type_val));
-		}
-		push(@code, make_op('', 'next_arg'));
+                my $val = $type_val || 0;
+                my $comment = "$type=$val";
+                my $op = make_op($comment, 'store_val_next_arg', "TAG_$type", $val);
+                push @code, $op;
 	    }
 	}
 	pop(@code) if is_instr($code[$#code], 'next_arg');
@@ -2685,6 +2717,7 @@ sub tr_gen_to {
 
     tr_maybe_keep(\@code);
     tr_maybe_rename(\@code);
+    combine_commit(\@code);
     tr_remove_unused(\@code);
 
     #
@@ -2726,6 +2759,10 @@ sub tr_maybe_keep {
 	    @last_instr = ($args[0]);
 	} elsif ($op eq 'set_var_next_arg') {
 	    push @last_instr, $args[0];
+	} elsif ($op eq 'is_type_set_var_next_arg') {
+	    push @last_instr, $args[1];
+	} elsif ($op eq 'is_type_eq_set_var_next_arg') {
+	    push @last_instr, $args[2];
 	} elsif ($op eq 'next_arg') {
 	    push @last_instr, 'ignored';
 	} elsif ($op eq 'new_instr') {
@@ -2752,6 +2789,22 @@ sub tr_maybe_keep {
     }
 }
 
+sub combine_commit {
+    my($ref) = @_;
+
+    for (my $i = 1; $i < @$ref; $i++) {
+        my $instr = $$ref[$i];
+	my($size, $instr_ref, $comment) = @$instr;
+	my($op, @args) = @$instr_ref;
+        if ($op eq 'rest_args') {
+            return;
+        } elsif ($op eq 'new_instr' and is_instr($$ref[$i-1], 'commit')) {
+            my $op = make_op($comment, 'commit_new_instr', @args);
+            splice @$ref, $i - 1, 2, ($op);
+        }
+    }
+}
+
 sub tr_maybe_rename {
     my($ref) = @_;
     my $s = 'left';
@@ -2772,7 +2825,21 @@ sub tr_maybe_rename {
 		    $num_args++;
 		}
 		$a++;
+            } elsif ($op eq 'is_type_set_var_next_arg') {
+	        if ($num_args == $a and $args[1] == $a) {
+	            $num_args++;
+	        }
+	        $a++;
+            } elsif ($op eq 'is_type_eq_set_var_next_arg') {
+	        if ($num_args == $a and $args[2] == $a) {
+	            $num_args++;
+	        }
+	        $a++;
 	    } elsif ($op eq 'next_arg') {
+		$a++;
+	    } elsif ($op eq 'is_type_next_arg') {
+		$a++;
+	    } elsif ($op eq 'is_type_eq_next_arg') {
 		$a++;
 	    } elsif ($op eq 'commit') {
 		$a = 0;
@@ -2817,8 +2884,7 @@ sub tr_remove_unused {
 	}
     }
 
-    # Replace 'set_var_next_arg' with 'next_arg' if the variable
-    # is never used.
+    # If a variable is not used, don't store the variable.
     for my $instr (@$ref) {
 	my($size, $instr_ref, $comment) = @$instr;
 	my($op, @args) = @$instr_ref;
@@ -2826,7 +2892,16 @@ sub tr_remove_unused {
 	    my $var = $args[0];
 	    next if $used{$var};
 	    $instr = make_op("$comment (ignored)", 'next_arg');
-	}
+	} elsif ($op eq 'is_type_set_var_next_arg') {
+            my($type,$var) = @args;
+            next if $used{$var};
+	    $instr = make_op("$comment (ignored)", 'is_type_next_arg', $type);
+	} elsif ($op eq 'is_type_eq_set_var_next_arg') {
+            my($type,$val,$var) = @args;
+            next if $used{$var};
+            $instr = make_op("$comment (ignored)", 'is_type_eq_next_arg',
+                             $type, $val);
+        }
     }
 
     # Delete a sequence of 'next_arg' instructions when they are

--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -719,7 +719,7 @@ sub emulator_output {
     print "const GenOpEntry gen_opc[] = {\n";
     for ($i = 0; $i < @gen_opname; $i++) {
 	if ($i == $num_file_opcodes) {
-	    print "\n/*\n * Internal generic instructions.\n */\n\n";
+            print starred_comment("Internal generic instructions.");
 	}
 	my($name) = $gen_opname[$i];
 	my($arity) = $gen_arity[$i];
@@ -2240,6 +2240,7 @@ sub parse_transformation {
 	    (undef,$_) = compile_transform(0, $rest_var, @op);
 	}
     }
+    $orig =~ tr/ \t/ /s;
     push(@transformations, [$., $orig, [@from], [reverse @to]]);
 }
 
@@ -2398,6 +2399,13 @@ sub tr_gen {
     }
 
     #
+    # Group instructions.
+    #
+    foreach $key (sort keys %gen_transform) {
+        $gen_transform{$key} = group_tr($gen_transform{$key});
+    }
+
+    #
     # Print the generated transformation engine.
     #
     my($offset) = 0;
@@ -2406,29 +2414,18 @@ sub tr_gen {
 	$gen_transform_offset{$key} = $offset;
 	my @instr = @{$gen_transform{$key}};
 
-	#
-	# If the last instruction is 'fail', remove it and
-	# convert the previous 'try_me_else' to 'try_me_else_fail'.
-	#
-	if (is_instr($instr[$#instr], 'fail')) {
-	    pop(@instr);
-	    my $i = $#instr;
-	    $i-- while !is_instr($instr[$i], 'try_me_else');
-	    $instr[$i] = make_op('', 'try_me_else_fail');
-	}
-
 	foreach $instr (@instr) {
 	    my($size, $instr_ref, $comment) = @$instr;
 	    my($op, @args) = @$instr_ref;
-	    print "    ";
 	    if (!defined $op) {
 		$comment =~ s/\n(.)/\n    $1/g;
-		print "\n", $comment;
+		print $comment;
 	    } else {
+                print "    ";
 		$op = "TOP_$op";
 		$match_engine_ops{$op} = 1;
 		if ($comment ne '') {
-		    printf "%-24s /* %s */\n", (join(", ", ($op, @args)) . ","),
+		    printf "%-30s /* %s */\n", (join(", ", ($op, @args)) . ","),
 		    $comment;
 		} else {
 		    print join(", ", ($op, @args)), ",\n";
@@ -2438,9 +2435,7 @@ sub tr_gen {
 	}
 	print "\n";
     }
-    print "/*\n";
-    print " * Total number of words: $offset\n";
-    print " */\n";
+    print starred_comment("Total number of words: $offset");
     print "};\n\n";
 }
 
@@ -2454,6 +2449,7 @@ sub tr_gen_from {
     my $where = "left side of transformation in line $line: ";
     my $may_fail = 0;
     my $is_first = 1;
+    my @instrs;
 
     foreach $ref (@tr) {
 	my($name, $arity, @ops) = @$ref;
@@ -2488,7 +2484,7 @@ sub tr_gen_from {
 		    push(@args, "rest_args");
 		}
 	    }
-	    my $pi = tr_next_index(\@pred_table, \%pred_table, $name, @args);
+	    my $pi = tr_next_index(\@{pred_table}, \%pred_table, $name, @args);
             my $op = make_op("$name()", 'pred', $pi);
             my @slots = grep(/^\d+/, map { $var{$_} } @vars);
 	    op_slot_usage($op, @slots);
@@ -2505,6 +2501,7 @@ sub tr_gen_from {
 	$opnum = $gen_opnum{$name,$arity};
 
 	push(@code, make_op("$name/$arity", 'next_instr', $opnum));
+        push @instrs, "$name/$arity";
 	foreach $op (@ops) {
 	    my($var, $type, $type_val, $cond, $val) = @$op;
 	    my $ignored_var = "$var (ignored)";
@@ -2630,12 +2627,12 @@ sub tr_gen_from {
 
     $te_max_vars = $var_num
 	if $te_max_vars < $var_num;
-    [\%var, \%var_type, \@code];
+    [\%var, \%var_type, \@instrs, \@code];
 }
 
 sub tr_gen_to {
     my($line, $orig_transform, $so_far, @tr) = @_;
-    my($var_ref, $var_type_ref, $code_ref) = @$so_far;
+    my($var_ref, $var_type_ref, $instrs_ref, $code_ref) = @$so_far;
     my(%var) = %$var_ref;
     my(%var_type) = %$var_type_ref;
     my(@code) = @$code_ref;
@@ -2720,29 +2717,130 @@ sub tr_gen_to {
     combine_commit(\@code);
     tr_remove_unused(\@code);
 
-    #
-    # Chain together all codes segments having the same first operation.
-    #
-    my($first_ref) = shift(@code);
-    my($size, $first, $key) = @$first_ref;
-    my($dummy, $arity);
-    ($dummy, $op, $arity) = @$first;
-    my($comment) = "\n/*\n * Line $line:\n *   $orig_transform\n */\n\n";
+    chain_instructions($instrs_ref, $line, $orig_transform,
+                       $cannot_fail, @code);
+}
 
-    my $prev_last;
-    $prev_last = pop(@{$gen_transform{$key}})
-	if defined $gen_transform{$key}; # Fail
+#
+# Chain together all codes segments having the same first instruction.
+#
+sub chain_instructions() {
+    my($instrs_ref, $line, $orig_transform, $cannot_fail, @code) = @_;
+    my($first,$second) = @$instrs_ref;
 
-    if ($prev_last && !is_instr($prev_last, 'fail')) {
-	error("Line $line: A previous transformation shadows '$orig_transform'");
+    my $tr_ref = $gen_transform{$first};
+
+    if ($tr_ref) {
+        my (undef, $cant_fail) = $$tr_ref[$#{$tr_ref}];
+        if ($cant_fail) {
+            error("Line $line: A previous transformation shadows '$orig_transform'");
+        }
     }
-    unless ($cannot_fail) {
-	unshift(@code, make_op('', 'try_me_else',
-			       tr_code_len(@code)));
-	push(@code, make_op("$key", 'fail'));
+    shift @code;
+    my $comment = starred_comment("Line $line:", "  $orig_transform");
+    push @$tr_ref, [$first,$second,$cannot_fail,$comment,@code];
+
+    $gen_transform{$first} = $tr_ref;
+}
+
+#
+# Optimize the code for transformations matching the same first
+# instruction.
+#
+
+sub group_tr {
+    my($lref) = @_;
+
+    #
+    # Group tranformations (while keeping the order) that all match the same
+    # second instruction.
+    #
+    for (my $i = 0; $i < @$lref; $i++) {
+        my(undef,$current) = @{${$lref}[$i]};
+        next unless defined $current;
+
+        # Find the next instruction that as the same second instruction.
+        for (my $j = $i + 1; $j < @$lref; $j++) {
+            my(undef,$other) = @{${$lref}[$j]};
+
+            # If this instruction does not match a second instruction,
+            # we must not continue the search.
+            last unless defined $other;
+
+            if ($other eq $current) {
+                # Found an instruction. If it is already the very next
+                # instruction, place it directly after the current instruction.
+                if ($j > $i + 1) {
+                    my($el) = splice @$lref, $j, 1;
+                    splice @$lref, $i, 0, ($el);
+                }
+                last;
+            }
+        }
     }
-    unshift(@code, make_op($comment));
-    push(@{$gen_transform{$key}}, @code),
+
+    #
+    # Add 'try_me_else' instructions to try the next transformation
+    # when the current transformation fails.
+    #
+    for (my $i = 0; $i < @$lref; $i++) {
+        my($first,$second,$cannot_fail,$comment,@c) = @{${$lref}[$i]};
+        unless ($cannot_fail) {
+            if ($i == $#{$lref}) {
+                unshift @c, make_op('', 'try_me_else_fail');
+            } else {
+                unshift @c, make_op('', 'try_me_else', code_len(@c));
+            }
+        }
+        ${$lref}[$i] = [$first,$second,$cannot_fail,$comment,@c];
+    }
+
+    #
+    # Find consecutive runs of at least two transformation matching
+    # the same second instruction. When a run is found, add a
+    # 'skip_unless' instruction that will skip all of the instructions in the run
+    # when the second instruction is wrong.
+    #
+    for (my $i = 0; $i < @$lref; $i++) {
+        my(undef,$current) = @{${$lref}[$i]};
+        next unless defined $current;
+        my $j;
+        my $skip_len = 0;
+
+        for ($j = $i; $j < @$lref; $j++) {
+            my(undef,$other,undef,undef,@c) = @{${$lref}[$j]};
+            last unless defined $other and $other eq $current;
+            $skip_len += code_len(@c);
+        }
+
+        if ($j > $i + 1) {
+            my $num_rules_skipped = $j - $i;
+            my $comment = "Skip $num_rules_skipped rules" .
+                " unless the second instruction is $current.";
+            $comment = starred_comment($comment);
+            my($name, $arity) = split('/', $current);
+            my $op = make_op('', 'skip_unless',
+                             $gen_opnum{$name,$arity}, $skip_len);
+            splice @$lref, $i, 0, (['','',1,$comment,$op]);
+            $i = $j + 1;
+            if ($j == $#{$lref}) {
+                my($first,$second,$cannot_fail,$comment,@c) = @{${$lref}[$j]};
+                push @c, make_op('wrong second instruction', 'fail');
+                ${$lref}[$j] = [$first,$second,$cannot_fail,$comment,@c];
+            }
+        }
+    }
+
+    #
+    # Flatten the code to a one-dimensional sequence of instructions.
+    #
+    my @code;
+    for (my $i = 0; $i < @$lref; $i++) {
+        my($first,$second,$cannot_fail,$comment,@c) = @{${$lref}[$i]};
+        push @code, make_op($comment);
+        push @code, @c;
+    }
+    \@code;
 }
 
 sub tr_maybe_keep {
@@ -2929,7 +3027,7 @@ sub tr_remove_unused {
     }
 }
 
-sub tr_code_len {
+sub code_len {
     my($sum) = 0;
     my($ref);
 
@@ -2959,6 +3057,10 @@ sub get_comment {
     my($ref,$op) = @_;
     return '' unless ref($ref) eq 'ARRAY';
     $ref->[2];
+}
+
+sub starred_comment {
+    "\n/*" . join("\n * ", '', @_) . "\n */\n\n";
 }
 
 sub tr_next_index {


### PR DESCRIPTION
The BEAM loader has a transformation engine that can do peephole optimizations while loading code: combining, splitting, and deleting instructions.

This pull request optimizes the transformation engine.

When loading a huge BEAM module (`NBAP-PDU-Contents` from the asn1 test suite) from a binary, the loading time is about 90 per cent of the loading time before this pull request.
