### PR TITLE
Add support for utf8 atoms in enif_get_atom/enif_get_atom_length

### DIFF
--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -183,7 +183,8 @@ typedef enum
 
 typedef enum
 {
-    ERL_NIF_LATIN1 = 1
+    ERL_NIF_LATIN1 = 1,
+    ERL_NIF_UTF8 = 2
 }ErlNifCharEncoding;
 
 typedef struct

--- a/erts/emulator/beam/erl_unicode.c
+++ b/erts/emulator/beam/erl_unicode.c
@@ -2970,6 +2970,29 @@ int erts_utf8_to_latin1(byte* dest, const byte* source, int slen)
     return dp - dest;
 }
 
+int erts_utf8_to_latin1_length(const byte* source, int slen)
+{
+    /*
+     * Assumes source contains valid utf8 that can be encoded as latin1
+     */
+    int dlen = 0;
+    while (slen > 0) {
+        if ((source[0] & 0x80) == 0) {
+            source++;
+            --slen;
+        }
+        else {
+            ASSERT(slen > 1);
+            ASSERT((source[0] & 0xFE) == 0xC2);
+            ASSERT((source[1] & 0xC0) == 0x80);
+            source += 2;
+            slen -= 2;
+        }
+        dlen++;
+    }
+    return dlen;
+}
+
 BIF_RETTYPE io_printable_range_0(BIF_ALIST_0)
 {
     if (erts_get_printable_characters() == ERL_PRINTABLE_CHARACTERS_UNICODE) {

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1357,6 +1357,7 @@ Eterm erts_convert_native_to_filename(Process *p, size_t size, byte *bytes);
 Eterm erts_utf8_to_list(Process *p, Uint num, byte *bytes, Uint sz, Uint left,
 			Uint *num_built, Uint *num_eaten, Eterm tail);
 int erts_utf8_to_latin1(byte* dest, const byte* source, int slen);
+int erts_utf8_to_latin1_length(const byte* source, int slen);
 #define ERTS_UTF8_OK 0
 #define ERTS_UTF8_INCOMPLETE 1
 #define ERTS_UTF8_ERROR 2

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -1176,6 +1176,13 @@ get_atom(Config) when is_list(Config) ->
     {0, <<>>} = atom_to_bin(hejsan,0),
     {1, <<0>>} = atom_to_bin('',1),
     {0, <<>>} = atom_to_bin('',0),
+
+    Uatom = 'чзöÄ',
+    UBin = erlang:atom_to_binary(Uatom),
+    UBsize = size(UBin),
+    {9, <<UBin:UBsize/binary,0,_>>} = atom_to_bin(Uatom,UBsize + 2),
+    {9, <<UBin:UBsize/binary,0>>} = atom_to_bin(Uatom,UBsize + 1),
+    {0, <<_:UBsize/binary>>} = atom_to_bin(Uatom,UBsize),
     ok.
 
 %% Test NIF maps handling.
@@ -2215,7 +2222,7 @@ is_checks(Config) when is_list(Config) ->
 %% Test all enif_get_length functions
 get_length(Config) when is_list(Config) ->
     ensure_lib_loaded(Config, 1),
-    ok = length_test(hejsan, "hejsan", [], [], not_a_list, [1,2|3]).
+    ok = length_test(hejsan, "hejsan", [], [], not_a_list, [1,2|3], 'чзöÄ').
 
 ensure_lib_loaded(Config) ->
     ensure_lib_loaded(Config, 1).

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -804,6 +804,9 @@ static ERL_NIF_TERM atom_to_bin(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
 	return enif_make_badarg(env);
     }
     n = enif_get_atom(env, argv[0], (char*)obin.data, size, ERL_NIF_LATIN1);
+    if (n == 0) {
+        n = enif_get_atom(env, argv[0], (char*)obin.data, size, ERL_NIF_UTF8);
+    }
     return enif_make_tuple(env, 2, enif_make_int(env,n),
 			   enif_make_binary(env,&obin));
 }
@@ -1088,6 +1091,7 @@ static ERL_NIF_TERM check_is_exception(ErlNifEnv* env, int argc, const ERL_NIF_T
  * argv[3] not an atom
  * argv[4] not a list
  * argv[5] improper list
+ * argv[6] utf-8 atom with length of 8
  */
 static ERL_NIF_TERM length_test(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -1110,6 +1114,9 @@ static ERL_NIF_TERM length_test(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
 
     if (enif_get_list_length(env, argv[5], &len))
 	return enif_make_badarg(env);
+
+    if (!enif_get_atom_length(env, argv[6], &len, ERL_NIF_UTF8) || len != 8)
+        return enif_make_badarg(env);
 
     return enif_make_atom(env, "ok");
 }


### PR DESCRIPTION
Hi this little PR adds support for utf8 atoms in enif_get_atom/enif_get_atom_length functions.