### PR TITLE
ssl: Correct DTLS listen emulation

### DIFF
--- a/lib/ssl/src/dtls_listener_sup.erl
+++ b/lib/ssl/src/dtls_listener_sup.erl
@@ -52,7 +52,7 @@ lookup_listner(Port) ->
         [{Port, {Owner, Handler}}] ->
             case erlang:is_process_alive(Handler) of 
                 true ->
-                    case erlang:is_process_alive(Owner) of
+                    case (Owner =/= undefined) andalso erlang:is_process_alive(Owner) of
                         true ->
                             {error, already_listening};
                         false ->
@@ -75,7 +75,7 @@ register_listner(OwnerAndListner, Port) ->
 %%%  Supervisor callback
 %%%=========================================================================
 init(_O) ->
-    ets:new(dtls_listener_sup, [named_table, public]),
+    ets:new(dtls_listener_sup, [named_table, public, set]),
     RestartStrategy = simple_one_for_one,
     MaxR = 0,
     MaxT = 3600,

--- a/lib/ssl/src/dtls_packet_demux.erl
+++ b/lib/ssl/src/dtls_packet_demux.erl
@@ -32,6 +32,7 @@
          accept/2,
          sockname/1,
          close/1,
+         new_owner/1,
          get_all_opts/1,
          set_all_opts/2,
          get_sock_opts/2,
@@ -76,16 +77,23 @@ accept(PacketSocket, Accepter) ->
 
 sockname(PacketSocket) ->
     call(PacketSocket, sockname).
+
 close(PacketSocket) ->
     call(PacketSocket, close).
+
+new_owner(PacketSocket) ->
+    call(PacketSocket, new_owner).
+
 get_sock_opts(PacketSocket, SplitSockOpts) ->
     call(PacketSocket,  {get_sock_opts, SplitSockOpts}).
 get_all_opts(PacketSocket) ->
     call(PacketSocket, get_all_opts).
+
 set_sock_opts(PacketSocket, Opts) ->
     call(PacketSocket, {set_sock_opts, Opts}).
 set_all_opts(PacketSocket, Opts) ->
     call(PacketSocket, {set_all_opts, Opts}).
+
 getstat(PacketSocket, Opts) ->
     call(PacketSocket, {getstat, Opts}).
 
@@ -143,6 +151,8 @@ handle_call(close, _, #state{dtls_processes = Processes,
                           end, queue:to_list(Accepters)),
             {reply, ok,  State#state{close = true, accepters = queue:new()}}
     end;
+handle_call(new_owner, _, State) ->
+    {reply, ok,  State#state{close = false, first = true}};
 handle_call({get_sock_opts, {SocketOptNames, EmOptNames}}, _, #state{listener = Socket,
                                                                emulated_options = EmOpts} = State) ->
     case get_socket_opts(Socket, SocketOptNames) of

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -786,8 +786,8 @@ handshake_cancel(Socket) ->
 %%--------------------------------------------------------------------
 close(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) ->
     ssl_connection:close(Pid, {close, ?DEFAULT_TIMEOUT});
-close(#sslsocket{pid = {dtls, #config{dtls_handler = {Pid, _}}}}) ->
-   dtls_packet_demux:close(Pid);
+close(#sslsocket{pid = {dtls, #config{dtls_handler = {_, _}}}} = DTLSListen) ->
+    dtls_socket:close(DTLSListen);
 close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}) ->
     Transport:close(ListenSocket).
 

--- a/lib/ssl/test/dtls_api_SUITE.erl
+++ b/lib/ssl/test/dtls_api_SUITE.erl
@@ -39,7 +39,8 @@ groups() ->
 api_tests() ->
     [
      dtls_listen_owner_dies,
-     dtls_listen_close
+     dtls_listen_close,
+     dtls_listen_reopen
     ].
 
 init_per_suite(Config0) ->
@@ -114,7 +115,7 @@ dtls_listen_owner_dies(Config) when is_list(Config) ->
     {ok, LSocket} = ssl:listen(Port, [{protocol, dtls} | ServerOpts]),
     spawn(fun() -> 
                   {ok, ASocket} = ssl:transport_accept(LSocket),
-                  _ = ssl:handshake(ASocket),
+                  {ok, Socket} = ssl:handshake(ASocket),
                    receive 
                        {ssl, Socket, "from client"} ->
                            ssl:send(Socket, "from server"),
@@ -141,6 +142,49 @@ dtls_listen_close(Config) when is_list(Config) ->
     {ok, ListenSocket} = ssl:listen(Port, [{protocol, dtls} | ServerOpts]),
     ok = ssl:close(ListenSocket).
 
+
+dtls_listen_reopen() ->
+    [{doc, "Test that you close a DTLS 'listner' socket and open a new one for the same port"}].
+
+dtls_listen_reopen(Config) when is_list(Config) -> 
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    {_, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+
+    Port = ssl_test_lib:inet_port(ServerNode),
+    {ok, LSocket0} = ssl:listen(Port, [{protocol, dtls} | ServerOpts]),
+     spawn(fun() ->
+                  {ok, ASocket} = ssl:transport_accept(LSocket0),
+                   {ok, Socket} = ssl:handshake(ASocket),
+                   receive
+                       {ssl, Socket, "from client"} ->
+                           ssl:send(Socket, "from server 1"),
+                           ssl:close(Socket)
+                   end
+           end),
+    {ok, Client1} = ssl:connect(Hostname, Port, ClientOpts),
+    ok = ssl:close(LSocket0),
+    {ok, LSocket1} = ssl:listen(Port, [{protocol, dtls} | ServerOpts]),
+    spawn(fun() ->
+                  {ok, ASocket} = ssl:transport_accept(LSocket1),
+                  {ok, Socket} = ssl:handshake(ASocket),
+                  receive
+                      {ssl, Socket, "from client"} ->
+                          ssl:send(Socket, "from server 2"),
+                          ssl:close(Socket)
+                   end
+          end),
+    {ok, Client2} = ssl:connect(Hostname, Port, [{protocol, dtls} | ClientOpts]),
+    ssl:send(Client2, "from client"),
+    ssl:send(Client1, "from client"),
+    receive
+        {ssl, Client1, "from server 1"} ->
+            ssl:close(Client1)
+    end,
+    receive
+        {ssl, Client2, "from server 2"} ->
+            ssl:close(Client2)
+    end.
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------
 %%--------------------------------------------------------------------


### PR DESCRIPTION
When a DTLS "listen socket" is closed the owner shall be
deassociated with the packet multiplexor process if it should be keept alive.
The packet multiplexor may still have ongoing connections. When a new
listen socket is opened for the same port it shall be associated with the
existing packet multiplexor if it is still alive.