### PR TITLE
lib/asn1: add missing build dependency to 'asn1ct_eval_ext.erl'

### DIFF
--- a/lib/asn1/src/Makefile
+++ b/lib/asn1/src/Makefile
@@ -190,7 +190,8 @@ asn1rtt_%.$(EMULATOR): asn1rtt_%.erl
 	$(V_ERLC) +debug_info $<
 
 $(EVAL_CT_MODULES:%=%.erl): prepare_templates.$(EMULATOR) \
-			    $(EBIN)/asn1ct_rtt.$(EMULATOR)
+			    $(EBIN)/asn1ct_rtt.$(EMULATOR) \
+			    $(EBIN)/asn1ct_func.$(EMULATOR) \
 
 #
 # Dependencies


### PR DESCRIPTION
The build failure is reproducible on a 4-core CPU when using
massive parallelism:

```
$ make -j21 -l4
...
 GEN    asn1ct_eval_ext.erl
{"init terminating in do_boot",
  {undef,[{asn1ct_func,start_link,[],[]},
          {prepare_templates,gen_asn1ct_eval,1,
           [{file,"prepare_templates.erl"},{line,58}]},
            {init,start_it,1,[]},{init,start_em,1,[]}]}}
init terminating in do_boot ()

Crash dump is being written to: erl_crash.dump...done
make[2]: *** [Makefile:139: asn1ct_eval_ext.erl] Error 1
```

Here `asn1ct_eval_ext.erl` attempts to load `asn1ct_func.beam`
via `prepare_templates.erl` before it's compiled into `.beam` file.

The change pulls in a dependency on `asn1ct_func.beam`.

Reported-by: WGH
Bug: https://github.com/NixOS/nixpkgs/pull/51644
Bug: https://bugs.gentoo.org/705500
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>