### PR TITLE
Add s390x support in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,27 @@ matrix:
             - xsltproc
             - libxml2-utils
 
+    - env: Linux-s390x-SmokeTest
+      arch: s390x
+      script:
+        - ./scripts/build-otp
+        - ./otp_build tests
+        - ./scripts/run-smoke-tests
+      addons:
+        apt:
+          update: true
+          packages:
+            - autoconf
+            - libncurses-dev
+            - build-essential
+            - libssl-dev
+            - libwxgtk3.0-dev
+            - libglu1-mesa-dev
+            - default-jdk
+            - g++
+            - xsltproc
+            - libxml2-utils
+
     - env: Linux64Docbuild
       script:
         - ./scripts/build-otp docs

--- a/lib/kernel/test/inet_SUITE.erl
+++ b/lib/kernel/test/inet_SUITE.erl
@@ -698,6 +698,8 @@ t_gethostnative(Config) when is_list(Config) ->
 	{error,notfound} ->
 	    ok;
 	{error,no_data} ->
+	    ok;
+	{error,try_again} ->
 	    ok
     end.
 


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.