### PR TITLE
crypto: fix ng mem leak

### DIFF
--- a/lib/crypto/c_src/api_ng.c
+++ b/lib/crypto/c_src/api_ng.c
@@ -261,7 +261,7 @@ static int get_update_args(ErlNifEnv* env,
     if (!enif_inspect_binary(env, indata_arg, &in_data_bin) )
         {
             *return_term = EXCP_BADARG(env, "Bad 2:nd arg");
-            goto err;
+            goto err0;
         }
 
     ASSERT(in_data_bin.size <= INT_MAX);
@@ -294,7 +294,7 @@ static int get_update_args(ErlNifEnv* env,
         if (!enif_alloc_binary((size_t)in_data_bin.size+block_size, &out_data_bin))
             {
                 *return_term = EXCP_ERROR(env, "Can't allocate outdata");
-                goto err;
+                goto err0;
             }
 
         if (!EVP_CipherUpdate(ctx_res->ctx, out_data_bin.data, &out_len, in_data_bin.data, in_data_bin.size))
@@ -318,6 +318,8 @@ static int get_update_args(ErlNifEnv* env,
     return 1;
 
  err:
+    enif_release_binary(&out_data_bin);
+ err0:
     return 0;
 }
 


### PR DESCRIPTION
This PR fixes potential memory leaks involving calls to the ng nifs.
Following along with the original PR in this file: https://github.com/erlang/otp/commit/98feb2577dc64a622f51dac6562135aa4c60274c