### PR TITLE
kernel: allow opening unbinded connections

### DIFF
--- a/lib/kernel/src/inet6_tcp.erl
+++ b/lib/kernel/src/inet6_tcp.erl
@@ -137,30 +137,42 @@ do_connect(Addr = {A,B,C,D,E,F,G,H}, Port, Opts, Time)
 	{ok, _} -> exit(badarg)
     end.
 
-%% 
+%%
 %% Listen
 %%
 listen(Port, Opts) ->
     case inet:listen_options([{port,Port} | Opts], ?MODULE) of
-	{error, Reason} -> exit(Reason);
-	{ok,
-	 #listen_opts{
-	    fd = Fd,
-	    ifaddr = BAddr = {A,B,C,D,E,F,G,H},
-	    port = BPort,
-	    opts = SockOpts} = R}
-	when ?ip6(A,B,C,D,E,F,G,H), ?port(BPort) ->
-	    case inet:open(
-		   Fd, BAddr, BPort, SockOpts,
-		   ?PROTO, ?FAMILY, ?TYPE, ?MODULE) of
-		{ok, S} ->
-		    case prim_inet:listen(S, R#listen_opts.backlog) of
-			ok -> {ok, S};
-			Error -> prim_inet:close(S), Error
-		    end;
-		Error -> Error
-	    end;
-	{ok, _} -> exit(badarg)
+        {error, Reason} -> exit(Reason);
+        {ok,
+         #listen_opts{
+            fd = Fd,
+            ifaddr = BAddr = {A,B,C,D,E,F,G,H},
+            port = BPort,
+            opts = SockOpts} = R}
+          when ?ip6(A,B,C,D,E,F,G,H), ?port(BPort) ->
+            case inet:open(
+                   Fd, BAddr, BPort, SockOpts,
+                   ?PROTO, ?FAMILY, ?TYPE, ?MODULE) of
+                {ok, S} ->
+                    case prim_inet:listen(S, R#listen_opts.backlog) of
+                        ok -> {ok, S};
+                        Error -> prim_inet:close(S), Error
+                    end;
+                Error -> Error
+            end;
+        {ok,
+         #listen_opts{
+            fd = Fd,
+            ifaddr = undefined,
+            port = BPort,
+            opts = SockOpts}}
+          when ?port(BPort) ->
+            % We assume that the port is already created, binded and ready for
+            % accepting connections, so no need for prim_inet:listen/2 there
+            inet:open(
+              Fd, BAddr, BPort, SockOpts,
+              ?PROTO, ?FAMILY, ?TYPE, ?MODULE);
+        {ok, _} -> exit(badarg)
     end.
 
 %%

--- a/lib/kernel/src/inet_udp.erl
+++ b/lib/kernel/src/inet_udp.erl
@@ -50,20 +50,23 @@ open(Port) -> open(Port, []).
 
 -spec open(_, _) -> {ok, inet:socket()} | {error, atom()}.
 open(Port, Opts) ->
-    case inet:udp_options(
-	   [{port,Port}, {recbuf, ?RECBUF} | Opts], 
-	   ?MODULE) of
-	{error, Reason} -> exit(Reason);
-	{ok,
-	 #udp_opts{
-	    fd = Fd,
-	    ifaddr = BAddr = {A,B,C,D},
-	    port = BPort,
-	    opts = SockOpts}}
-	  when ?ip(A,B,C,D), ?port(BPort) ->
-	    inet:open(
-	      Fd, BAddr, BPort, SockOpts, ?PROTO, ?FAMILY, ?TYPE, ?MODULE);
-	{ok, _} -> exit(badarg)
+    case inet:udp_options([{port,Port} | Opts], ?MODULE) of
+        {error, Reason} ->
+            exit(Reason);
+        {ok, #udp_opts{fd     = Fd,
+                       ifaddr = BAddr = {A,B,C,D},
+                       port   = BPort,
+                       opts   = SockOpts}}
+          when ?ip(A,B,C,D), ?port(BPort) ->
+            inet:open(Fd, BAddr, BPort, SockOpts,
+                      ?PROTO, ?FAMILY, ?TYPE, ?MODULE);
+        {ok, #udp_opts{fd     = Fd,
+                       ifaddr = BAddr = undefined,
+                       opts   = SockOpts}} ->
+            inet:open(Fd, BAddr, 0, SockOpts,
+                      ?PROTO, ?FAMILY, ?TYPE, ?MODULE);
+        {ok, _} ->
+            exit(badarg)
     end.
 
 send(S, {A,B,C,D} = IP, Port, Data)
@@ -81,7 +84,7 @@ send(S, {?FAMILY, {loopback, Port}} = Address, AncData, Data)
 
 send(S, Data) ->
     prim_inet:sendto(S, {any, 0}, [], Data).
-    
+
 connect(S, Addr = {A,B,C,D}, Port)
   when ?ip(A,B,C,D), ?port(Port) ->
     prim_inet:connect(S, Addr, Port).


### PR DESCRIPTION
This is useful for socket-activation features where the supervisor daemon (like `systemd`) or other daemon (like `xinitd`) pass aready opened and bounded file descriptor to the system. This allows to keep sockets opened between application restarts.

- [x] UDP
- [ ] TCP
- [ ] SCTP