### PR TITLE
Add gcc option -fno-common to detect name conflicts of global variables

### DIFF
--- a/erts/aclocal.m4
+++ b/erts/aclocal.m4
@@ -2935,6 +2935,12 @@ fi
 # DED_EMU_THR_DEFS=$EMU_THR_DEFS
 DED_CFLAGS="$CFLAGS $CPPFLAGS $DED_CFLAGS"
 if test "x$GCC" = xyes; then
+    # Use -fno-common for gcc, that is link error if multiple definitions of
+    # global variables are encountered. This is ISO C compliant.
+    # Until version 10, gcc has had -fcommon as default, which allows and merges
+    # such dubious duplicates.
+    LM_TRY_ENABLE_CFLAG([-fno-common], [DED_CFLAGS])
+
     DED_STATIC_CFLAGS="$DED_CFLAGS"
     DED_CFLAGS="$DED_CFLAGS -fPIC"
 fi

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -566,6 +566,12 @@ if test "x$GCC" = xyes; then
     WFLAGS="$WFLAGS -Wdeclaration-after-statement"
   fi
   CFLAGS=$saved_CFLAGS
+
+  # Use -fno-common for gcc, that is link error if multiple definitions of
+  # global variables are encountered. This is ISO C compliant.
+  # Until version 10, gcc has had -fcommon as default, which allows and merges
+  # such dubious duplicates.
+  LM_TRY_ENABLE_CFLAG([-fno-common], [CFLAGS])
 else
   WFLAGS=""
   WERRORFLAGS=""

--- a/lib/erl_interface/configure.in
+++ b/lib/erl_interface/configure.in
@@ -315,6 +315,12 @@ if test "x$GCC" = xyes; then
         WFLAGS="$WFLAGS -fno-strict-aliasing";;
   esac
   CFLAGS="$WERRORFLAGS $CFLAGS"
+
+  # Use -fno-common for gcc, that is link error if multiple definitions of
+  # global variables are encountered. This is ISO C compliant.
+  # Until version 10, gcc has had -fcommon as default, which allows and merges
+  # such dubious duplicates.
+  LM_TRY_ENABLE_CFLAG([-fno-common], [CFLAGS])
 else
   WFLAGS=""
   WERRORFLAGS=""


### PR DESCRIPTION
Use `-fno-common` for gcc, that is link error if multiple definitions of global variables are encountered. This is ISO C compliant.
Until version 10, gcc has had `-fcommon` as default, which allows and merges such dubious duplicates.
