### PR TITLE
ssl: Prioritise rsa_suites above rc4 and des

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -290,8 +290,8 @@ all_suites({3, _} = Version) ->
 	++ psk_suites(Version)
 	++ srp_suites(Version)
         ++ rsa_suites(Version)
-        ++ rc4_suites(Version)
-        ++ des_suites(Version);
+        ++ des_suites(Version)
+        ++ rc4_suites(Version);
 
 all_suites(Version) ->
     dtls_v1:all_suites(Version).

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -289,9 +289,9 @@ all_suites({3, _} = Version) ->
         ++ chacha_suites(Version)
 	++ psk_suites(Version)
 	++ srp_suites(Version)
+        ++ rsa_suites(Version)
         ++ rc4_suites(Version)
-        ++ des_suites(Version)
-        ++ rsa_suites(Version);
+        ++ des_suites(Version);
 
 all_suites(Version) ->
     dtls_v1:all_suites(Version).


### PR DESCRIPTION
https://bugs.erlang.org/browse/ERL-1145

> @IngelaAndin: OpenSSL considers  RC4 and DES legacy and not default supported. They still support RSA. The not anonymous  PSK and SRP are prioritized over RSA.   So  you are welcome to make a PR that prioritizes  RSA over DES and RC4  in "all-list" and we will accept it.