### PR TITLE
`init:get_argument(home).` uses `$HOME`

### DIFF
--- a/erts/doc/src/init.xml
+++ b/erts/doc/src/init.xml
@@ -101,7 +101,7 @@
           </item>
           <tag><c>home</c></tag>
           <item>
-            <p>The home directory:</p>
+            <p>The home directory (on Unix, the value of $HOME):</p>
             <pre>
 4> <input>init:get_argument(home).</input>
 {ok,[["/home/harry"]]}</pre>


### PR DESCRIPTION
Demo:

```
HOME="silly_value" /path/to/erl
> init:get_argument(home).
{ok,[["silly_value"]]}
```