### PR TITLE
mnesia_frag: Fix add and create of external_copies

### DIFF
--- a/lib/mnesia/test/Makefile
+++ b/lib/mnesia/test/Makefile
@@ -54,7 +54,8 @@ MODULES= \
 	mnesia_cost \
 	mnesia_dbn_meters \
 	ext_test \
-	mnesia_index_plugin_test
+	mnesia_index_plugin_test \
+	mnesia_ext_be_stub
 
 DocExamplesDir := ../doc/src/
 

--- a/lib/mnesia/test/mnesia_ext_be_stub.erl
+++ b/lib/mnesia/test/mnesia_ext_be_stub.erl
@@ -1,0 +1,266 @@
+-module(mnesia_ext_be_stub).
+
+
+%% ----------------------------------------------------------------------------
+%% BEHAVIOURS
+%% ----------------------------------------------------------------------------
+
+-behaviour(mnesia_backend_type).
+-behaviour(gen_server).
+
+%%
+%% BACKEND CALLBACKS
+%%
+
+%% backend management
+-export([init_backend/0,
+         add_aliases/1,
+         remove_aliases/1]).
+
+%% schema level callbacks
+-export([semantics/2,
+	 check_definition/4,
+	 create_table/3,
+	 load_table/4,
+	 close_table/2,
+	 sync_close_table/2,
+	 delete_table/2,
+	 info/3]).
+
+%% table synch calls
+-export([sender_init/4,
+         sender_handle_info/5,
+         receiver_first_message/4,
+         receive_data/5,
+         receive_done/4]).
+
+%% low-level accessor callbacks.
+-export([delete/3,
+         first/2,
+         fixtable/3,
+         insert/3,
+         last/2,
+         lookup/3,
+         match_delete/3,
+         next/3,
+         prev/3,
+         repair_continuation/2,
+         select/1,
+         select/3,
+         select/4,
+         slot/3,
+         update_counter/4]).
+
+%% Index consistency
+-export([index_is_consistent/3,
+         is_index_consistent/2]).
+
+%% record and key validation
+-export([validate_key/6,
+         validate_record/6]).
+
+%% file extension callbacks
+-export([real_suffixes/0,
+         tmp_suffixes/0]).
+
+%% Register
+-export([register/0]).
+
+%%
+%% GEN SERVER CALLBACKS AND CALLS
+%%
+
+-export([start_proc/5,
+         init/1,
+         handle_call/3,
+         handle_info/2,
+         handle_cast/2,
+         terminate/2,
+         code_change/3]).
+
+
+%%
+%% Register
+%%
+
+register() ->
+    register(default_alias()).
+
+register(Alias) ->
+    Module = ?MODULE,
+    case mnesia:add_backend_type(Alias, Module) of
+        {atomic, ok} ->
+            {ok, Alias};
+        {aborted, {backend_type_already_exists, _}} ->
+            {ok, Alias};
+        {aborted, Reason} ->
+            {error, Reason}
+    end.
+
+default_alias() ->
+    test_mnesia_be.
+
+
+%% ----------------------------------------------------------------------------
+%% BACKEND CALLBACKS
+%% ----------------------------------------------------------------------------
+
+%% backend management
+
+init_backend() ->
+    ok.
+
+add_aliases(_Aliases) ->
+    ok.
+
+remove_aliases(_Aliases) ->
+    ok.
+
+semantics(_Alias, storage) -> disc_only_copies;
+semantics(_Alias, types) -> [set, ordered_set, bag];
+semantics(_Alias, index_types) -> [ordered];
+semantics(_Alias, index_fun) -> fun index_f/4;
+semantics(_Alias, _) -> undefined.
+
+index_f(_Alias, _Tab, Pos, Obj) ->
+    [element(Pos, Obj)].
+
+is_index_consistent(_Alias, _Info) ->
+    true.
+
+index_is_consistent(_Alias, _Info, _Bool) ->
+    ok.
+
+check_definition(_Alias, _Tab, _Nodes, Props) ->
+    {ok, Props}.
+
+create_table(_Alias, _Tab, _Props) ->
+    ok.
+
+load_table(_Alias, _Tab, _LoadReason, _Opts) ->
+    ok.
+
+close_table(_Alias, _Tab) ->
+    ok.
+
+sync_close_table(_Alias, _Tab) ->
+    ok.
+
+delete_table(_Alias, _Tab) ->
+    ok.
+
+info(_Alias, _Tab, _) ->
+    0.
+
+sender_init(_Alias, _Tab, _RemoteStorage, _Pid) ->
+    {standard, fun() -> ok end, fun() -> ok end}.
+
+sender_handle_info(_Msg, _Alias, _Tab, _ReceiverPid, Cont) ->
+    {fun() -> ok end, Cont}.
+
+receiver_first_message(_Pid, _Msg, _Alias, _Tab) ->
+    {0, []}.
+
+receive_data(_Data, _Alias, _Tab, _Sender, State) ->
+    {more, State}.
+
+receive_done(_Alias, _Tab, _Sender, _State) -> 
+    ok.
+
+repair_continuation(Continuation, _MatchSpec) -> 
+    Continuation.
+
+delete(_Alias, _Tab, _Key) ->
+    ok.
+
+first(_Alias, _Tab) ->
+    '$end_of_table'.
+
+fixtable(_Alias, _Tab, _Bool) ->
+    true.
+
+insert(_Alias, _Tab, _Obj) ->
+    ok.
+
+last(_Alias, _Tab) ->
+    '$end_of_table'.
+
+lookup(_Alias, _Tab, _Key) ->
+    [].
+
+match_delete(_Alias, _Tab, _Pat) ->
+    ok.
+
+
+next(_Alias, _Tab, _Key) ->
+    '$end_of_table'.
+
+prev(_Alias, _Tab, _Key) ->
+    '$end_of_table'.
+
+select(_Cont) ->
+    '$end_of_table'.
+
+select(_Alias, _Tab, _Ms) ->
+    '$end_of_table'.
+
+select(_Alias, _Tab, _Ms, _Limit) ->
+    '$end_of_table'.
+
+slot(_Alias, _Tab, _Pos) ->
+    '$end_of_table'.
+
+update_counter(_Alias, _Tab, _Counter, _Val) -> 
+    0.
+
+
+validate_key(_Alias, _Tab, RecName, Arity, Type, _Key) ->
+    {RecName, Arity, Type}.
+
+validate_record(_Alias, _Tab, RecName, Arity, Type, _Obj) ->
+    {RecName, Arity, Type}.
+
+
+real_suffixes() ->
+    [".test"].
+
+tmp_suffixes() ->
+    [].
+
+
+
+%% ----------------------------------------------------------------------------
+%% GEN SERVER CALLBACKS AND CALLS
+%% ----------------------------------------------------------------------------
+
+start_proc(Alias, Tab, Type, LdbOpts, RecName) ->
+    ProcName = proc_name(Alias, Tab),
+    gen_server:start_link({local, ProcName}, ?MODULE,
+                          {Alias, Tab, Type, LdbOpts, RecName}, []).
+
+init({Alias, Tab, Type, LdbOpts, RecName}) ->
+    {ok, #{alias => Alias,
+	   tab => Tab,
+	   type => Type,
+	   ldbopts => LdbOpts,
+	   rec_name => RecName
+	  }}.
+
+handle_call(_, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+handle_info(_, State) ->
+    {noreply, State}.
+
+code_change(_FromVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _) ->
+    ok.
+
+
+proc_name(_Alias, Tab) ->
+    list_to_atom("mnesia_ext_proc_" ++ atom_to_list(Tab)).


### PR DESCRIPTION
The #cstruct.external_copies param is expected to
be a list of tuples:
{{Alias, Mod}, Nodes}
instead of just Nodes as in disk_copies/disk_only_copies

when mnesia_frag creates new frags with n_external_copies
it puts the Nodes directly in the #cstruct.external_copies
which results in a crash during creation and addition
of table fragments

This fix properly populates the #cstruct.external_copies
when n_external_copies is specified.

Trigger the bug:
- compile https://github.com/hazsul/mnesia-ext-frag-test/blob/master/test_mnesia_be.erl with OTP version before this fix
- Add the module test_mnesia_be to your code path
- Call `test_mnesia_be:register() ` to register Alias test_mnesia_be

- Then use it to create a normal table:
`mnesia:create_table(test_table, [{type, set}, {test_mnesia_be, [node()]}, {attributes,[key,val]}]).`
The table is created properly

- Then create a table with 4 fragments with external_copies:
`mnesia:create_table(test_table_2, [{type, set}, {test_mnesia_be, [node()]}, {attributes,[key,val]},{frag_properties, [{n_fragments, 4}, {node_pool, [node()]}, {n_external_copies, 1}]}]).`

this results in a crash below:
```
{aborted,{function_clause,[{mnesia_schema,'-verify_nodes/1-fun-2-',
                                          [mnesia_frag_crash@kingfisher],
                                          [{file,"mnesia_schema.erl"},{line,1243}]},
                           {lists,foreach,2,[{file,"lists.erl"},{line,1338}]},
                           {mnesia_schema,verify_nodes,1,
                                          [{file,"mnesia_schema.erl"},{line,1242}]},
                           {mnesia_schema,assert_correct_cstruct,1,
                                          [{file,"mnesia_schema.erl"},{line,1103}]},
                           {mnesia_schema,verify_cstruct,1,
                                          [{file,"mnesia_schema.erl"},{line,1019}]},
                           {mnesia_schema,unsafe_make_create_table,1,
                                          [{file,"mnesia_schema.erl"},{line,1552}]},
                           {mnesia_schema,do_create_table_1,1,
                                          [{file,"mnesia_schema.erl"},{line,1543}]},
                           {lists,foreach,2,[{file,"lists.erl"},{line,1338}]}]}}
```
Complete logs from local testing:
[frag_crash.log](https://github.com/erlang/otp/files/4121417/frag_crash.log)

Test the fix:
- compile https://github.com/hazsul/mnesia-ext-frag-test/blob/master/test_mnesia_be.erl with OTP version after this fix
- Repeat the tests above
- The fragmented table is created properly and the properties can be viewed using:
`rp(mnesia:table_info(test_table_2, all)).`

- Logs for fix working:
[frag_fix.log](https://github.com/erlang/otp/files/4121453/frag_fix.log)


