### PR TITLE
Stop mangling FQDNs in inet:gethostname()

### DIFF
--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -484,8 +484,7 @@ gethostname() ->
 	{ok,U} ->
 	    {ok,Res} = gethostname(U),
 	    inet_udp:close(U),
-	    {Res2,_} = lists:splitwith(fun($.)->false;(_)->true end,Res),
-	    {ok, Res2};
+	    {ok, Res};
 	_ ->
 	    {ok, "nohost.nodomain"}
     end.


### PR DESCRIPTION
Dear Ericsson team! Hallå från Ukraina! :)

I'm well aware that touching code which hasn't seen any change in 10+ years is a bold move. But please consider. Someone on #erlang IRC told me you're working on switching to the *'socket' NIF interface* (honestly, no idea what's that), so things are going to break anyway — thus more documented inet defects & more patches wouldn't harm.

### Bug description ###

We've stumbled into the OTP's implementation for `inet:gethostname()` while solving a 5-second delay during login to RabbitMQ, from any client. RabbitMQ server needs to compute its hostname during AMQP connection opening — and while doing that it [tries to resolve][1] the result of `inet:gethostname()`.

Two factors come together and materialize the bug for us.
1. Our system is using `foobar.cluster-eu3` FQDN-like hostname (uname -n, /proc/sys/kernel/hostname).
2. Hostname **is not** aliased to 127.0.0.1 in /etc/hosts (which is [rather popular][2], but wrong thing to do). Neither is the "short" (stripped) hostname, `foobar`, valid or resolvable.

Now, the bug is in the line I'm proposing to remove in this patch. The line causes `inet:gethostname()` to return `foobar` where it should return `foobar.cluster-eu3`.

As a consequence, RabbitMQ spends 5 seconds trying to resolve `foobar` via the system (Erlang "native") resolver — times out, then immediately succeeds thanks to `search cluster-eu3` in /etc/resolv.conf. Still, 5 second delay has passed, and it's a big deal here.

Furthermore, on the same system we're getting `foobar.cluster-eu3` from `net_adm:localhost()` function — while `inet:gethostname()` returns `foobar`. Observe the inconsistency.

[1]: https://github.com/rabbitmq/rabbitmq-common/blob/v3.8.0/src/rabbit_net.erl#L269-L275
[2]: https://github.com/hashicorp/vagrant/issues/7263#issuecomment-567983125

### Workarounds ###

Everyone's immediate knee-jerk reaction is to suggest putting `foobar` (the "short" hostname) into /etc/hosts. Well, we cannot go this way, since it [breaks other tools][2] we use.

A viable workaround is to plumb together an `erl_hosts` file via ERL_INETRC. Not fun at all, neither reliable — but doable if you control *all of* hostname-changing code on the system.

Another viable workaround is to *vendor* the OTP — patch it, and use a "shop-local" build.

### Change analysis ###

Obviously, this change has the potential to break *bug-compatibility*: it's somewhat likely that there's software which worked by chance (relying on the bug), and it will stop working.

However, this change **cannot affect** any systems which use "short" (non-FQDN) hostnames.

On the other hand — for systems which do use multiple-dotted-component FQDN-like hostnames,
this mangling I'm removing causes a lot of grief, unnecessary /etc/hosts manipulation,
broken `libnss_myhostname` /etc/nsswitch.conf plugin, spurious resolution timeouts, etc etc etc.

The "nohost.nodomain" fallback winks extra irony: we'll mangle your hostname, remove components,
and ALWAYS return you a single short name without dots. Oh, except not always; be ready for "nohost.nodomain".

This splitting & stripping just shouldn't be here, as I see it.

With sincere regards for your Open-Source work
Max, Senior DevOps, Ukraine