### PR TITLE
Allow using custom IO devices in logger_std_h

### DIFF
--- a/lib/kernel/doc/src/logger_std_h.xml
+++ b/lib/kernel/doc/src/logger_std_h.xml
@@ -55,7 +55,7 @@
        is stored in a sub map with the key <c>config</c>, and can contain the
        following parameters:</p>
     <taglist>
-      <tag><marker id="type"/><c>type = standard_io | standard_error | file | {device, atom() | file:io_device()}</c></tag>
+      <tag><marker id="type"/><c>type = standard_io | standard_error | file | {device, io:device()}</c></tag>
       <item>
 	<p>Specifies the log destination.</p>
 	<p>The value is set when the handler is added, and it cannot

--- a/lib/kernel/doc/src/logger_std_h.xml
+++ b/lib/kernel/doc/src/logger_std_h.xml
@@ -55,7 +55,7 @@
        is stored in a sub map with the key <c>config</c>, and can contain the
        following parameters:</p>
     <taglist>
-      <tag><marker id="type"/><c>type = standard_io | standard_error | file</c></tag>
+      <tag><marker id="type"/><c>type = standard_io | standard_error | file | {device, atom() | file:io_device()}</c></tag>
       <item>
 	<p>Specifies the log destination.</p>
 	<p>The value is set when the handler is added, and it cannot

--- a/lib/kernel/src/logger_std_h.erl
+++ b/lib/kernel/src/logger_std_h.erl
@@ -150,6 +150,8 @@ check_h_config(Type,[{type,Type} | Config]) when Type =:= standard_io;
                                                  Type =:= standard_error;
                                                  Type =:= file ->
     check_h_config(Type,Config);
+check_h_config({device,Device},[{type,{device,Device}} | Config]) ->
+    check_h_config({device,Device},Config);
 check_h_config(file,[{file,File} | Config]) when is_list(File) ->
     check_h_config(file,Config);
 check_h_config(file,[{modes,Modes} | Config]) when is_list(Modes) ->
@@ -419,6 +421,9 @@ file_ctrl_init(HandlerName,
         {error,Reason} ->
             Starter ! {self(),{error,{open_failed,FileName,Reason}}}
     end;
+file_ctrl_init(HandlerName, #{type:={device,Dev}}, Starter) ->
+    Starter ! {self(),ok},
+    file_ctrl_loop(#{handler_name=>HandlerName,dev=>Dev});
 file_ctrl_init(HandlerName, #{type:=StdDev}, Starter) ->
     Starter ! {self(),ok},
     file_ctrl_loop(#{handler_name=>HandlerName,dev=>StdDev}).

--- a/lib/kernel/test/logger_std_h_SUITE.erl
+++ b/lib/kernel/test/logger_std_h_SUITE.erl
@@ -118,6 +118,7 @@ all() ->
     [add_remove_instance_tty,
      add_remove_instance_standard_io,
      add_remove_instance_standard_error,
+     add_remove_instance_custom_device,
      add_remove_instance_file1,
      add_remove_instance_file2,
      add_remove_instance_file3,
@@ -173,6 +174,11 @@ add_remove_instance_tty(_Config) ->
 add_remove_instance_standard_io(_Config) ->
     add_remove_instance_nofile(standard_io).
 add_remove_instance_standard_io(cleanup,_Config) ->
+    logger_std_h_remove().
+
+add_remove_instance_custom_device(_Config) ->
+    add_remove_instance_nofile({device,user}).
+add_remove_instance_custom_device(cleanup,_Config) ->
     logger_std_h_remove().
 
 add_remove_instance_standard_error(_Config) ->


### PR DESCRIPTION
This is needed for simpler integration with Elixir logger which allows any device to be set as an output device. It also provides greater flexibility when needed to integrate with log catchers.