### PR TITLE
net_kernel: improve performance of debugging functions, and fix race

### DIFF
--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -344,21 +344,10 @@ shutdown(_Module, _Line, _Data, Reason) ->
     ?shutdown_trace("Net Kernel 2: shutting down connection "
 		    "~p:~p, data ~p,reason ~p~n",
 		    [_Module,_Line, _Data, Reason]),
-    flush_down(),
     exit(Reason).
 %% Use this line to debug connection.  
 %% Set net_kernel verbose = 1 as well.
 %%    exit({Reason, ?MODULE, _Line, _Data, erlang:timestamp()}).
-
-
-flush_down() ->
-    receive
-	{From, get_status} ->
-	    From ! {self(), get_status, error},
-	    flush_down()
-    after 0 ->
-	    ok
-    end.
 
 handshake_we_started(#hs_data{request_type=ReqType,
 			      other_node=Node,


### PR DESCRIPTION
net_kernel contains several function intended only for debugging. For example,
node_info/1,2 and nodes_info(). While undocumented, these functions provide
extremely valuable monitoring information.
This patch fixes several issues. First, get_status call was monitoring node,
and not distribution process. It was a subject to race condition, when
'nodedown' message was never delivered. With erlang:monitor/2, race does
not happen. Also it allowed to remove unneeded flush_down from dist_util.
Second, nodes_info/0 was implemented sequentially, being quite slow. Now
it is concurrent enough to complete within a second even with thousands
nodes in a cluster.
Third, nodes_info/0 was traversing the same sys_dist table two times,
where one was enough.
Fourth, dialyzer specs are somewhat helpful too (relaxed for ets:select)