### PR TITLE
Optimize =:= when comparing maps

### DIFF
--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -2973,10 +2973,14 @@ tailrecur_ne:
 		    bb = hashmap_val(b) + 1;
 		    switch (hdr & _HEADER_MAP_SUBTAG_MASK) {
 		    case HAMT_SUBTAG_HEAD_ARRAY:
+                        if (aa[0] != bb[0])
+                            goto not_equal;
 			aa++; bb++;
 			sz = 16;
 			break;
 		    case HAMT_SUBTAG_HEAD_BITMAP:
+                        if (aa[0] != bb[0])
+                            goto not_equal;
 			aa++; bb++;
 		    case HAMT_SUBTAG_NODE_BITMAP:
 			sz = hashmap_bitcount(MAP_HEADER_VAL(hdr));


### PR DESCRIPTION
Teach `=:=` to immediately return `false` when comparing two maps
of different sizes. That can be much faster for huge maps.

Reported in the elixir forum:

https://elixirforum.com/t/erlang-2-does-not-seem-to-check-map-sizes-before-performing-the-thoroughful-comparison/28910