### PR TITLE
Fix invalid xml closing tag in proplists.erl edoc

### DIFF
--- a/lib/stdlib/src/proplists.erl
+++ b/lib/stdlib/src/proplists.erl
@@ -419,7 +419,7 @@ substitute_aliases_1([], P) ->
 %% <p>Example: <code>substitute_negations([{no_foo, foo}], L)</code>
 %% will replace any atom <code>no_foo</code> or tuple <code>{no_foo,
 %% true}</code> in <code>L</code> with <code>{foo, false}</code>, and
-%% any other tuple <code>{no_foo, ...}</code> with <code>foo</code.</p>
+%% any other tuple <code>{no_foo, ...}</code> with <code>foo</code>.</p>
 %%
 %% @see get_bool/2
 %% @see substitute_aliases/2


### PR DESCRIPTION
Current edoc crashes xmerl parser with
```
14:49:01.064 [error] 2557- fatal: {:endtag_does_not_match, {:was, :"code.", :should_have_been, :code}}

/Users/lukaszsamson/.asdf/installs/erlang/22.2.6/lib/stdlib-3.11.2/src/proplists.erl, function substitute_negations/2: at line 408: error in XML parser: {fatal,
                         {{endtag_does_not_match,
                              {was,'code.',should_have_been,code}},
                          {file,file_name_unknown},
                          {line,422},
                          {col,64}}}.
```