### PR TITLE
gen_statem: change callback module

### DIFF
--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>2016</year><year>2019</year>
+      <year>2016</year><year>2020</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -99,6 +99,14 @@
 	  </seealso>
 	  were added.
 	</item>
+	<item>
+	  In OTP 22.3 the possibility to change the callback module
+	  with action
+	  <seealso marker="#type-action">
+	    <c>change_callback_module</c>
+	  </seealso>
+	  was added.
+	</item>
       </list>
     </note>
     <p>
@@ -119,6 +127,7 @@
 	Reply from other state than the request, <c>sys</c> traceable
       </item>
       <item>Multiple <c>sys</c> traceable replies</item>
+      <item>Changing the callback module</item>
     </list>
 
 
@@ -129,15 +138,17 @@
     </p>
     <list type="bulleted">
       <item>
-        <p>One for finite-state machines
+        <p>
+	  One for finite-state machines
           (<seealso marker="gen_fsm"><c>gen_fsm</c></seealso> like),
           which requires the state to be an atom and uses that state as
-          the name of the current callback function
+          the name of the current callback function.
         </p>
       </item>
       <item>
-        <p>One without restriction on the state data type
-          that uses one callback function for all states
+        <p>
+	  One that allows the state to be any term and
+          that uses one callback function for all states.
         </p>
       </item>
     </list>
@@ -150,7 +161,7 @@
       </seealso> <c>gen_fsm</c> to <c>gen_statem</c>.
     </p>
     <p>
-      A generic state machine process (<c>gen_statem</c>) implemented
+      A generic state machine server process (<c>gen_statem</c>) implemented
       using this module has a standard set of interface functions
       and includes functionality for tracing and error reporting.
       It also fits into an OTP supervision tree. For more information, see
@@ -626,9 +637,12 @@ handle_event(_, _, State, Data) ->
 	  If the
 	  <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
 	  is <c>state_functions</c>,
-	  the state must be of this type.
+	  the state must be an atom.
 	  After a <em>state change</em> (<c>NextState =/= State</c>),
 	  all postponed events are retried.
+	  Note that the state <c>terminate</c> is not possible
+	  to use since it would collide with the optional callback function
+	  <seealso marker="#Module:terminate/3"><c>Module:terminate/3</c></seealso>.
 	</p>
       </desc>
     </datatype>
@@ -707,10 +721,9 @@ handle_event(_, _, State, Data) ->
       <name name="callback_mode"/>
       <desc>
 	<p>
-	  The <em>callback mode</em> is selected when starting the
-	  <c>gen_statem</c> and after code change
-	  using the return value from
-	  <seealso marker="#Module:callback_mode/0"><c>Module:callback_mode/0</c></seealso>.
+	  The <em>callback mode</em> is selected
+	  with the return value from
+	  <seealso marker="#Module:callback_mode/0"><c>Module:callback_mode/0</c></seealso>:
 	</p>
 	<taglist>
 	  <tag><c>state_functions</c></tag>
@@ -732,6 +745,16 @@ handle_event(_, _, State, Data) ->
 	    </p>
 	  </item>
 	</taglist>
+	<p>
+	  The function
+	  <seealso marker="#Module:callback_mode/0"><c>Module:callback_mode/0</c></seealso>
+	  is called when starting the <c>gen_statem</c>,
+	  after code change
+	  and after changing the callback module with action
+	  <seealso marker="#type-action"><c>change_callback_module</c></seealso>.
+	  The result is cached for subsequent calls to
+	  <seealso marker="#state callback">state callbacks</seealso>.
+	</p>
       </desc>
     </datatype>
     <datatype>
@@ -1166,6 +1189,46 @@ handle_event(_, _, State, Data) ->
 	      <seealso marker="#type-event_type"><c>internal</c></seealso>
 	      is to be used when you want to reliably distinguish
 	      an event inserted this way from any external event.
+	    </p>
+	  </item>
+	  <tag><c>change_callback_module</c></tag>
+	  <item>
+	    <p>
+	      Changes the callback module to
+	      <c><anno>NewModule</anno></c>
+	      which will be used when calling all subsequent
+	      <seealso marker="#state callback">state callbacks</seealso>.
+	    </p>
+	    <p>
+	      The <c>gen_statem</c> engine will find out the
+	      <seealso marker="#type-callback_mode">
+		<em>callback mode</em>
+	      </seealso>
+	      of <c><anno>NewModule</anno></c> by calling
+	      <seealso marker="#Module:callback_mode/0">
+		<c>NewModule:callback_mode/0</c>
+	      </seealso>
+	      before the next
+	      <seealso marker="#state callback">state callback</seealso>.
+	    </p>
+	    <p>
+	      Changing the callback module does not affect the
+	      <em>state transition</em> in any way,
+	      it only changes which module that handles the events.
+	      Be aware that all relevant callback functions in
+	      <c><anno>NewModule</anno></c>
+	      such as the
+	      <seealso marker="#state callback">state callback</seealso>,
+	      <seealso marker="#Module:code_change/4"><c><anno>NewModule</anno>:code_change/4</c></seealso>,
+	      <seealso marker="#Module:format_status/2">
+		<c><anno>NewModule</anno>:format_status/2</c>
+	      </seealso>
+	      and
+	      <seealso marker="#Module:terminate/3">
+		<c><anno>NewModule</anno>:terminate/3</c>
+	      </seealso>
+	      must be able to handle the state and data
+	      from the old module.
 	    </p>
 	  </item>
 	</taglist>
@@ -1917,7 +1980,9 @@ handle_event(_, _, State, Data) ->
   <funcs>
     <func>
       <name since="OTP 19.1">Module:callback_mode() -> CallbackMode</name>
-      <fsummary>Update the internal state during upgrade/downgrade.</fsummary>
+      <fsummary>
+	Define the callback mode for the callback module.
+      </fsummary>
       <type>
 	<v>
 	  CallbackMode =
@@ -1933,10 +1998,11 @@ handle_event(_, _, State, Data) ->
 	  <seealso marker="#type-callback_mode"><em>callback mode</em></seealso>
 	  of the callback module.  The value is cached by <c>gen_statem</c>
 	  for efficiency reasons, so this function is only called
-	  once after server start and after code change,
+	  once after server start, after code change,
+	  and after changing the callback module,
 	  but before the first
 	  <seealso marker="#state callback"><em>state callback</em></seealso>
-	  in the current code version is called.
+	  in the current callback module's code version is called.
 	  More occasions may be added in future versions
 	  of <c>gen_statem</c>.
 	</p>
@@ -1945,9 +2011,14 @@ handle_event(_, _, State, Data) ->
 	  <seealso marker="#Module:init/1"><c>Module:init/1</c></seealso>
 	  returns or when
 	  <seealso marker="#enter_loop/4"><c>enter_loop/4-6</c></seealso>
-	  is called.  Code change happens when
+	  is called.
+	  Code change happens when
 	  <seealso marker="#Module:code_change/4"><c>Module:code_change/4</c></seealso>
 	  returns.
+	  A change of the callback module happens when a
+	  <seealso marker="#state callback"><em>state callback</em></seealso>
+	  returns the action
+	  <seealso marker="#type-action"><c>change_callback_module</c></seealso>.
 	</p>
 	<p>
 	  The <c>CallbackMode</c> is either just
@@ -1970,7 +2041,9 @@ handle_event(_, _, State, Data) ->
       <name since="OTP 19.0">Module:code_change(OldVsn, OldState, OldData, Extra) ->
         Result
       </name>
-      <fsummary>Update the internal state during upgrade/downgrade.</fsummary>
+      <fsummary>
+	Update the internal state during upgrade/downgrade.
+      </fsummary>
       <type>
         <v>OldVsn = Vsn | {down,Vsn}</v>
         <v>&nbsp;&nbsp;Vsn = term()</v>
@@ -2058,7 +2131,7 @@ handle_event(_, _, State, Data) ->
     <func>
       <name since="OTP 19.0">Module:init(Args) -> Result(StateType)</name>
       <fsummary>
-	Initializing process and internal state.
+	Initialize process and internal state.
       </fsummary>
       <type>
         <v>Args = term()</v>
@@ -2101,8 +2174,9 @@ init(Args) -> erlang:error(not_implemented, [Args]).</pre>
       <name since="OTP 19.0">Module:format_status(Opt, [PDict,State,Data]) ->
         Status
       </name>
-      <fsummary>Optional function for providing a term describing the
-        current <c>gen_statem</c> status.</fsummary>
+      <fsummary>
+	Describe the current <c>gen_statem</c> status (optional).
+      </fsummary>
       <type>
         <v>Opt = normal | terminate</v>
         <v>PDict = [{Key, Value}]</v>

--- a/lib/stdlib/test/gen_statem_SUITE_data/oc_statem.erl
+++ b/lib/stdlib/test/gen_statem_SUITE_data/oc_statem.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2017. All Rights Reserved.
+%% Copyright Ericsson AB 2017-2020. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,16 +22,19 @@
 -behaviour(gen_statem).
 
 %% API
--export([start/0]).
+-export([start/1]).
 
 %% gen_statem callbacks
--export([init/1, callback_mode/0]).
+-export([init/1, callback_mode/0, handle_event/4]).
 
-start() ->
-    gen_statem:start({local, ?MODULE}, ?MODULE, [], []).
+start(Opts) ->
+    gen_statem:start({local, ?MODULE}, ?MODULE, [], Opts).
 
 init([]) ->
-    {ok, state_name, #{}}.
+    {ok, start, #{}}.
 
 callback_mode() ->
-    handle_event_function.
+    [handle_event_function, state_enter].
+
+handle_event(enter, start, start, _Data) ->
+    keep_state_and_data.

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -4,7 +4,7 @@
 <chapter>
   <header>
     <copyright>
-      <year>2016</year><year>2019</year>
+      <year>2016</year><year>2020</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -183,6 +183,21 @@ State(S) x Event(E) -> Actions(A), State(S')</pre>
       handles the system messages, and calls the <em>callback module</em>
       with machine specific events.
     </p>
+    <p>
+      The <em>callback module</em> can be changed for a running server
+      using the
+      <seealso marker="#Transition Actions">transition action</seealso>
+      <seealso marker="stdlib:gen_statem#type-action"><c>{change_callback_module, NewModule}</c></seealso>.
+      Note that this is a pretty esotheric thing to do...
+      The origin for this feature is a protocol that after
+      version negotiation branches off into quite different
+      state machines depending on the protocol version.
+      There <i>might</i> be other use cases.
+      <i>Beware</i> that the <c>NewModule</c>
+      completely replaces the previous behaviour module,
+      so all relevant callback functions has to handle
+      the state and data from the previous callback module.
+    </p>
   </section>
 
 <!-- =================================================================== -->
@@ -216,8 +231,10 @@ State(S) x Event(E) -> Actions(A), State(S')</pre>
       </item>
     </taglist>
     <p>
-      The <em>callback mode</em> is selected at server start
-      and may be changed with a code upgrade/downgrade.
+      The <em>callback mode</em> is a property of
+      the <em>callback module</em> and is set at server start.
+      It may be changed due to a code upgrade/downgrade,
+      or when changing the <em>callback module</em>.
     </p>
     <p>
       See the section
@@ -631,6 +648,22 @@ State(S) x Event(E) -> Actions(A), State(S')</pre>
 	Generate the next event to handle, see section 
 	<seealso marker="#Inserted Events">Inserted Events</seealso>.
       </item>
+      <tag>
+	<seealso marker="stdlib:gen_statem#type-action">
+	  <c>{change_callback_module, NewModule}</c>
+	</seealso>
+      </tag>
+      <item>
+	Change the
+	<seealso marker="#Callback Module">
+	  <em>callback module</em>
+	</seealso>
+	for the running server.
+	This can be done during any <em>state transition</em>,
+	whether it is a <em>state change</em> or not,
+	but it can <i>not</i> be done from a
+	<seealso marker="#State Enter Calls"><em>state enter call</em></seealso>.
+      </item>
     </taglist>
     <p>
       For details, see the <c>gen_statem(3)</c>
@@ -812,8 +845,10 @@ StateName(EventType, EventContent, Data) ->
       <seealso marker="#Transition Actions">State Transition Actions</seealso>.
       You may not change the state,
       <seealso marker="#Postponing Events">postpone</seealso>
-      this non-event, or
-      <seealso marker="#Inserted Events">insert any events</seealso>.
+      this non-event,
+      <seealso marker="#Inserted Events">insert any events</seealso>,
+      or change the
+      <seealso marker="#Callback Module"><em>callback module</em></seealso>.
     </p>
     <p>
       The first state that is entered


### PR DESCRIPTION
#### Changing the callback module
This is a new feature, proposed for `gen_statem`, that does not exist in e.g `gen_server`.

By returning the action `{change_callback_module, NewModule}` the `gen_statem` engine changes the callback module.  Simple as that!

We have not figured out any hairy implications other than that the *callback mode* has to be read for `NewModule` before calling any callback function in it, which was not very hairy.  Also, changing the callback module has to be regarded as orthogonal to changing the state.  I have furthermore made it not possible to change callback module from a *state enter call* since that would be just too weird.

#### Why, indeed?
The inception is our work on TLS 1.3.  This protocol has evolved so much that the state machines for TLS 1.3 has so little in common with the one for TLS 1.2, so it makes much sense to have a common state machine for the version negotiation, and when that is done switch to a version specific state machine.

This feature makes the code clearer to read since the version specific state machines can be cleansed from irrelevant code.

There might be other applications, but I foresee mostly state machines for protocols with similar properties.

Sure, it is yet another knob, which increases the possibility for confusion, but it is well contained and suited for specific use cases.

#### Alternatives?
I prototyped a state machine wrapper doing the same thing that became 500 lines of mostly boilerplate code and around 80 lines in the dispatch function.

The worst bit with this solution is that it turned out to not be possible to write a generic variant suitable for `stdlib`. It has to be adapted to the *callback mode* of the target callback module, so there needs to be 4 variants: `state_functions`, `handle_event_function,` `[state_functions,state_enter]` and `[handle_event_function,state_enter]`.

And for the SSL application it meant that two wrapper modules would have to be written since one of its state machines use `state_enter` and the other does not.

#### The implementation

Most of the diff is documentation changes, and a test case.  The first commit is preparation that moves reading the *callback mode* to a little bit later in the engine loop, so it happens in the right place for the feature addition.

The actual change is in `gen_statem.erl`, in the second commit (095cd40) and is quite straightforward and small.