### PR TITLE
Add tty_exception_print_depth option to eunit:test

### DIFF
--- a/lib/eunit/src/eunit.erl
+++ b/lib/eunit/src/eunit.erl
@@ -133,6 +133,8 @@ test(Tests) ->
 %% <dl>
 %% <dt>`verbose'</dt>
 %% <dd>Displays more details about the running tests.</dd>
+%% <dt>`print_depth'</dt>
+%% <dd>Maximum depth to which terms are printed in case of error.</dd>
 %% </dl>
 %%
 %% Options in the environment variable EUNIT are also included last in


### PR DESCRIPTION
It can be set to change the max print depth of exceptions generated by eunit test suites. Current hardcoded limit of 20 can be considered too small in many cases and for some situations (like `?assertEqual` macro) this truncation can just easily hide the difference that we are trying to find with unit tests.

Example of such frustration: https://stackoverflow.com/questions/10952767/showing-full-expected-and-value-information-when-assertequal-fails

How it looks now:
I added `?_assertEqual(#{}, lists:seq(1, 5000))` to `eunit/examples/fib.erl`
```erlang
> cd("lib/eunit/examples").
> c("fib.erl").
> eunit:test(fib).
fib:19: fib_test_...*failed*
in function fib:'-fib_test_/0-fun-16-'/0 (fib.erl, line 19)
<..>
in call from eunit_proc:run_group/2 (eunit_proc.erl, line 561)
**error:{assertEqual,[{module,fib},
              {line,19},
              {expression,"lists : seq ( 1 , 5000 )"},
              {expected,#{}},
              {value,[1,2,3,4,5,6,7,8,9,10|...]}]}
  output:<<"">>

=======================================================
  Failed: 1.  Skipped: 0.  Passed: 8.
> eunit:test(fib, [{tty_exception_print_depth, 200}]).
fib:19: fib_test_...*failed*
in function fib:'-fib_test_/0-fun-16-'/0 (fib.erl, line 19)
<..>
in call from eunit_proc:run_group/2 (eunit_proc.erl, line 561)
**error:{assertEqual,[{module,fib},
              {line,19},
              {expression,"lists : seq ( 1 , 5000 )"},
              {expected,#{}},
              {value,[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,
                      22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,
                      40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,
                      58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,
                      76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,
                      94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,
                      109,110,111,112,113,114,115,116,117,118,119,120,121,122,
                      123,124,125,126,127,128,129,130,131,132,133,134,135,136,
                      137,138,139,140,141,142,143,144,145,146,147,148,149,150,
                      151,152,153,154,155,156,157,158,159,160,161,162,163,164,
                      165,166,167,168,169,170,171,172,173,174,175,176,177,178,
                      179,180,181,182,183,184,185,186,187,188,189,190|...]}]}
  output:<<"">>

=======================================================
  Failed: 1.  Skipped: 0.  Passed: 8.
```
So, the term truncation is less aggressive now. By setting it to a bigger number we can achieve even less truncation.

Now with rebar3 and https://github.com/seancribbs/eunit_formatters it's less of a problem, but still nice option to have in OTP.

Usage:

```
eunit:test(my_suite, [{tty_exception_print_depth, 50}]).
```

Better option name suggestions are highly appreciated.