### PR TITLE
pg: ensure argument is expected local pid(s)

### DIFF
--- a/lib/kernel/src/pg.erl
+++ b/lib/kernel/src/pg.erl
@@ -117,31 +117,29 @@ start_link(Scope) when is_atom(Scope) ->
 
 %%--------------------------------------------------------------------
 %% @doc
-%% Joins a single process
+%% Joins a single or a list of processes.
 %% Group is created automatically.
-%% Process must be local to this node.
+%% Processes must be local to this node.
 -spec join(Group :: group(), PidOrPids :: pid() | [pid()]) -> ok.
 join(Group, PidOrPids) ->
     join(?DEFAULT_SCOPE, Group, PidOrPids).
 
 -spec join(Scope :: atom(), Group :: group(), PidOrPids :: pid() | [pid()]) -> ok.
-join(Scope, Group, PidOrPids) ->
-    Node = node(),
-    is_list(PidOrPids) andalso [error({nolocal, Pid}) || Pid <- PidOrPids, node(Pid) =/= Node orelse not is_pid(Pid)],
+join(Scope, Group, PidOrPids) when is_pid(PidOrPids); is_list(PidOrPids) ->
+    ok = ensure_local(PidOrPids),
     gen_server:call(Scope, {join_local, Group, PidOrPids}, infinity).
 
 %%--------------------------------------------------------------------
 %% @doc
-%% Single process leaving the group.
-%% Process must be local to this node.
+%% Single or list of processes leaving the group.
+%% Processes must be local to this node.
 -spec leave(Group :: group(), PidOrPids :: pid() | [pid()]) -> ok.
 leave(Group, PidOrPids) ->
     leave(?DEFAULT_SCOPE, Group, PidOrPids).
 
--spec leave(Scope :: atom(), Group :: group(), Pid :: pid() | [pid()]) -> ok | not_joined.
-leave(Scope, Group, PidOrPids) ->
-    Node = node(),
-    is_list(PidOrPids) andalso [error({nolocal, Pid}) || Pid <- PidOrPids, node(Pid) =/= Node orelse not is_pid(Pid)],
+-spec leave(Scope :: atom(), Group :: group(), PidOrPids :: pid() | [pid()]) -> ok | not_joined.
+leave(Scope, Group, PidOrPids) when is_pid(PidOrPids); is_list(PidOrPids) ->
+    ok = ensure_local(PidOrPids),
     gen_server:call(Scope, {leave_local, Group, PidOrPids}, infinity).
 
 %%--------------------------------------------------------------------
@@ -339,6 +337,20 @@ terminate(_Reason, #state{scope = Scope}) ->
 
 %%--------------------------------------------------------------------
 %% Internal implementation
+
+%% Ensures argument is either a node-local pid or a list of such, or it throws an error
+ensure_local(Pid) when is_pid(Pid), node(Pid) =:= node() ->
+    ok;
+ensure_local(Pids) when is_list(Pids) ->
+    lists:foreach(
+        fun
+            (Pid) when is_pid(Pid), node(Pid) =:= node() ->
+                ok;
+            (Bad) ->
+                error({nolocal, Bad})
+        end, Pids);
+ensure_local(Bad) ->
+    error({nolocal, Bad}).
 
 %% Override all knowledge of the remote node with information it sends
 %%  to local node. Current implementation must do the full table scan


### PR DESCRIPTION
Hi,

Looking through the new pg module that was recently merged in (https://github.com/erlang/otp/pull/2524), I came across something that might be unintended.

https://github.com/erlang/otp/blob/8eefeda8d81996bfe8249017fa0be2595eb64cff/lib/kernel/src/pg.erl#L130

There appear to be two issues here. One is that in the list case the (in)comprehension deals in dark arts, and two, that in the pid case, it is never ensured in the caller to be a pid.

#### List Case

The intent in join/3 when PidOrPids is a list seems to be to ensure that each entry is a pid and that it is local to the node, otherwise throw an error.

Unfortunately, the filters in comprehensions treat functions that can be guards as guards would be treated in clause heads ([read more](http://erlang.org/pipermail/erlang-questions/2010-October/053649.html)), and unless wrapped in for instance a block expression or a fun, exceptions are devoured and the entire filter is treated as false -- in this case, sidestepping the intended protection mechanism.

As such:
```erlang
1> Node = node().
pgfixes@something
2> PidOrPids = [123, 456, 789].
[123,456,789]
3> is_list(PidOrPids) andalso [error({nolocal, Pid}) || Pid <- PidOrPids, node(Pid) =/= Node orelse not is_pid(Pid)].
[]
```
the is_pid/1 call never gets a chance as node/1 throws a badarg which magically turns the entire filter into a 'false'.

A wrapping in a block expression seems to dispel the magic:
```erlang
4> is_list(PidOrPids) andalso [error({nolocal, Pid}) || Pid <- PidOrPids, begin node(Pid) =/= Node orelse not is_pid(Pid) end].
** exception error: bad argument
     in function  node/1
        called as node(123)
```

#### Pid Case

However, when PidOrPids is a pid instead of a list, the checks aren't afforded at all. As such, pg:join(group, 123) for instance passes through into the process and it eventually crashes with a no function clause in join_monitors/3 as it has an is_pid guard for the only non-list clause.

The same thing occurs for leave/3 where it crashes with a no function clause in leave_monitors/3.

While raising these issues was my main concern, I took some liberties in rewriting this handling.

I kept the semantics intact where {nolocal, Pid} is thrown as an error. Perhaps this should do something else in case a list element isn't a pid at all.

Minor spec and doc adjustments in the related parts to reflect current state.

While at a glance there are a few other bits that could be improved in this module, this is what I could do for now.

Thanks.

