### PR TITLE
Remove package support from ms_transform

### DIFF
--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -356,11 +356,6 @@ clause({clause,Line,H0,G0,B0},Bound) ->
 copy({call,Line,{remote,_Line2,{atom,_Line3,ets},{atom,_Line4,fun2ms}},
       As0},Bound) ->
     {transform_call(ets,Line,As0,Bound),Bound};
-copy({call,Line,{remote,_Line2,{record_field,_Line3,
-                                {atom,_Line4,''},{atom,_Line5,ets}},
-                 {atom,_Line6,fun2ms}}, As0},Bound) ->
-    %% Packages...
-    {transform_call(ets,Line,As0,Bound),Bound};
 copy({call,Line,{remote,_Line2,{atom,_Line3,dbg},{atom,_Line4,fun2ms}},
       As0},Bound) ->
     {transform_call(dbg,Line,As0,Bound),Bound};


### PR DESCRIPTION
Although historically interesting, I think it's ok to remove this code snippet as package support was removed in OTP R16.