### PR TITLE
Eliminate crash in compilation of native code

### DIFF
--- a/lib/hipe/icode/hipe_icode_primops.erl
+++ b/lib/hipe/icode/hipe_icode_primops.erl
@@ -133,6 +133,7 @@ is_safe({hipe_bs_primop, {bs_append, _, _, _, _}}) -> false;
 is_safe({hipe_bs_primop, {bs_private_append, _, _}}) -> false;
 is_safe({hipe_bs_primop, bs_init_writable}) -> true;
 is_safe(build_stacktrace) -> true;
+is_safe(raw_raise) -> false;
 is_safe(#mkfun{}) -> true;
 is_safe(#unsafe_element{}) -> true;
 is_safe(#unsafe_update_element{}) -> true;

--- a/lib/hipe/test/basic_SUITE_data/basic_exceptions.erl
+++ b/lib/hipe/test/basic_SUITE_data/basic_exceptions.erl
@@ -25,6 +25,7 @@ test() ->
   ok = test_guard_bif(),
   ok = test_eclectic(),
   ok = test_raise(),
+  ok = test_effect(),
   ok.
 
 %%--------------------------------------------------------------------
@@ -674,5 +675,19 @@ do_test_raise_3(Expr) ->
       %% not actually used.
       erlang:raise(exit, {exception,C,E}, Stk)
   end.
+
+test_effect() ->
+  ok = effect_try(2),
+  {'EXIT',{badarith,_}} = (catch effect_try(bad)),
+  ok.
+
+effect_try(X) ->
+  try
+    X + 1
+  catch
+    C:E:Stk ->
+      erlang:raise(C, E, Stk)
+  end,
+  ok.
 
 id(I) -> I.


### PR DESCRIPTION
The native code compiler would crash when attempting to compile
code such as the following:

    ignore_value_of_try_catch(X) ->
        try
            X + 1
        catch
            C:E:Stk ->
                erlang:raise(C, E, Stk)
        end,
        ok.

https://bugs.erlang.org/browse/ERL-1175