### PR TITLE
cover: Suppress compilation warnings when instrumenting andalso/orelse

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -1722,7 +1722,10 @@ bool_switch(E, T, F, AllVars, AuxVarN) ->
     {'case',Line,E,
      [{clause,Line,[{atom,Line,true}],[],[T]},
       {clause,Line,[{atom,Line,false}],[],[F]},
-      {clause,Line,[AuxVar],[],
+      %% Mark the next clause as compiler-generated to suppress
+      %% a warning if the case expression is an obvious boolean
+      %% value.
+      {clause,erl_anno:set_generated(true, Line),[AuxVar],[],
        [{call,Line,
          {remote,Line,{atom,Line,erlang},{atom,Line,error}},
          [{tuple,Line,[{atom,Line,badarg},AuxVar]}]}]}]}.

--- a/lib/tools/test/cover_SUITE.erl
+++ b/lib/tools/test/cover_SUITE.erl
@@ -37,7 +37,7 @@ all() ->
                  dont_reconnect_after_stop, stop_node_after_disconnect,
                  export_import, otp_5031, otp_6115,
                  otp_8270, otp_10979_hanging_node, otp_14817,
-                 local_only, startup_race],
+                 local_only, startup_race, otp_16476],
     case whereis(cover_server) of
         undefined ->
             [coverage,StartStop ++ NoStartStop];
@@ -1801,6 +1801,17 @@ startup_race_1([{Pid, Ref} | PidRefs]) ->
     end;
 startup_race_1([]) ->
     cover:stop(),
+    ok.
+
+otp_16476(Config) when is_list(Config) ->
+    Mod = obvious_booleans,
+    Dir = filename:join(proplists:get_value(data_dir, Config),
+                        ?FUNCTION_NAME),
+    ok = file:set_cwd(Dir),
+    {ok, Mod} = compile:file(Mod, [debug_info]),
+    {ok, Mod} = cover:compile(Mod),
+    ok = Mod:Mod(),
+    ok = cover:stop(),
     ok.
 
 %%--Auxiliary------------------------------------------------------------

--- a/lib/tools/test/cover_SUITE_data/otp_16476/obvious_booleans.erl
+++ b/lib/tools/test/cover_SUITE_data/otp_16476/obvious_booleans.erl
@@ -1,0 +1,17 @@
+-module(obvious_booleans).
+-export([?MODULE/0]).
+-compile([warnings_as_errors]).
+
+?MODULE() ->
+    true = both_ok(ok, ok),
+    false = both_ok(ok, nok),
+    true = one_ok(ok, nok),
+    true = one_ok(nok, ok),
+    false = one_ok(nok, nok),
+    ok.
+
+both_ok(A, B) ->
+    A =:= ok andalso B =:= ok.
+
+one_ok(A, B) ->
+    A =:= ok orelse B =:= ok.


### PR DESCRIPTION
The cover tool translates andalso/orelse to a case in the instrumented
code. For example:

    both_ok(A, B) ->
	A =:= ok andalso B =:= ok.

Is translated to:

    both_ok(A, B) ->
	case A =:= ok of
	    true  -> B =:= ok;
	    false -> false;
	    _1    -> error({badarg, _1})
	end.

Since the expression `A =:= ok` clearly is a boolean expression, the
final clause can't possibly match, so the compiler issues a
warning. If the `warnings_as_errors` option is set in the environment
or in the module itself, compilation will fail.

Eliminate the warning by letting cover mark the final clause as compiler
generated to suppress the warning.

https://bugs.erlang.org/browse/ERL-1147