### PR TITLE
Improvements of the rpc module

### DIFF
--- a/lib/kernel/doc/src/Makefile
+++ b/lib/kernel/doc/src/Makefile
@@ -46,6 +46,7 @@ XML_REF3_FILES = application.xml \
 	erl_epmd.xml \
 	erl_prim_loader_stub.xml \
 	erlang_stub.xml \
+	erpc.xml \
 	error_handler.xml \
 	error_logger.xml \
 	file.xml \

--- a/lib/kernel/doc/src/erpc.xml
+++ b/lib/kernel/doc/src/erpc.xml
@@ -1,0 +1,513 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE erlref SYSTEM "erlref.dtd">
+
+<erlref>
+  <header>
+    <copyright>
+      <year>2020</year><year>2020</year>
+      <holder>Ericsson AB. All Rights Reserved.</holder>
+    </copyright>
+    <legalnotice>
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+ 
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+    
+    </legalnotice>
+
+    <title>erpc</title>
+    <prepared>Rickard Green</prepared>
+    <docno>1</docno>
+    <date>2020-02-20</date>
+    <rev>A</rev>
+  </header>
+  <module since="OTP @OTP-13450@">erpc</module>
+  <modulesummary>Enhanced Remote Procedure Call</modulesummary>
+  <description>
+    <p>
+      This module provide services similar to Remote Procedure Calls.
+      A remote procedure call is a method to call a function on a remote
+      node and collect the answer. It is used for collecting information
+      on a remote node, or for running a function with some specific side
+      effects on the remote node.
+    </p>
+    <p>
+      This is an enhanced subset of the operations provided by the
+      <seealso marker="rpc"><c>rpc</c></seealso> module. Enhanced in the
+      sense that it makes it possible to distinguish between returned
+      value, raised exceptions, and other errors. <c>erpc</c> also has
+      better performance and scalability than the original <c>rpc</c>
+      implementation. However, current <c>rpc</c> module will utilize
+      <c>erpc</c> in order to also provide these properties when
+      possible.
+    </p>
+    <p>
+      In order for an <c>erpc</c> operation to succeed, the remote
+      node also needs to support <c>erpc</c>. Typically only ordinary
+      Erlang nodes as of OTP 23 have <c>erpc</c> support.
+    </p>
+  </description>
+
+  <datatypes>
+    <datatype>
+      <name name="request_id"/>
+      <desc>
+        <p>
+	  An opaque type of call request identifiers. For more
+	  information see
+          <seealso marker="#send_request/4"><c>send_request/4</c></seealso>.
+	</p>
+      </desc>
+    </datatype>
+  </datatypes>
+
+  <funcs>
+
+    <func>
+      <name name="call" arity="4" since="OTP @OTP-13450@"/>
+      <name name="call" arity="5" since="OTP @OTP-13450@"/>
+      <fsummary>Evaluate a function call on a node.</fsummary>
+      <desc>
+        <p>
+	  Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
+          <anno>Args</anno>)</c> on node <c><anno>Node</anno></c> and returns
+          the corresponding value <c><anno>Result</anno></c>.
+	  <c><anno>Timeout</anno></c> is an integer representing
+	  the timeout in milliseconds or the atom <c>infinity</c>.
+	</p>
+	<p>The call <c>erpc:call(<anno>Node</anno>, <anno>Module</anno>,
+	<anno>Function</anno>, <anno>Args</anno>)</c> is equivalent
+	to the call <c>erpc:call(<anno>Node</anno>, <anno>Module</anno>,
+	<anno>Function</anno>, <anno>Args</anno>, infinity)</c></p>
+	<p>
+	  The <c>call()</c> function only returns if the applied
+	  function successfully returned without raising any uncaught
+	  exceptions, the operation did not time out, and no failures
+	  occurred. In all other cases an exception is raised. The
+	  following exceptions, listed by exception class, can
+	  currently be raised by <c>erpc:call()</c>:
+	</p>
+	<taglist>
+	  <tag><c>throw</c></tag>
+	  <item><p>
+	    The applied function called <c>throw(Value)</c>
+	    and did not catch this exception. The exception
+	    reason <c>Value</c> equals the argument passed to
+	    <c>throw/1</c>.
+	  </p></item>
+	  
+	  <tag><c>exit</c></tag>
+	  <item><p>
+	    Exception reason:
+	  </p>
+	  <taglist>
+	    <tag><c>{exception, ExitReason}</c></tag>
+	    <item><p>
+	      The applied function called <c>exit(ExitReason)</c>
+	      and did not catch this exception. The exit
+	      reason <c>ExitReason</c> equals the argument passed
+	      to <c>exit/1</c>.
+	    </p></item>
+	    <tag><c>{signal, ExitReason}</c></tag>
+	    <item><p>
+	      The process that applied the function received an
+	      exit signal and terminated due to this signal. The
+	      process terminated with exit reason <c>ExitReason</c>.
+	    </p></item>
+	  </taglist>
+	  </item>
+	  
+	  <tag><c>error</c></tag>
+	  <item><p>
+	    Exception reason:
+	  </p>
+	  <taglist>
+	    
+	    <tag><c>{exception, ErrorReason, StackTrace}</c></tag>
+	    <item><p>
+	      A runtime error occurred which raised and error
+	      exception while applying the function,
+	      and the applied function did not catch the
+	      exception. The error reason <c>ErrorReason</c>
+	      indicates the type of error that occurred.
+	      <c>StackTrace</c> is formatted as when caught in a
+	      <c>try/catch</c> construct. The <c>StackTrace</c>
+	      is limited to the applied function and functions
+	      called by it.
+	    </p></item>
+	    
+	    <tag><c>{erpc, ERpcErrorReason}</c></tag>
+	    <item><p>
+	      The <c>erpc</c> operation failed. The following
+	      <c>ERpcErrorReason</c>s are the most common ones:
+	    </p>
+	    
+	    <taglist>
+	      <tag><c>badarg</c></tag>
+	      <item>
+		<p>If any one of these are true:</p>
+		<list>
+		  <item><p><c><anno>Node</anno></c> is not a valid
+		  node name atom.</p></item>
+		  <item><p><c><anno>Module</anno></c> is not an atom.</p></item>
+		  <item><p><c><anno>Function</anno></c> is not an atom.</p></item>
+		  <item><p><c><anno>Args</anno></c> is not a proper list
+		  of terms.</p></item>
+		  <item><p><c><anno>Timeout</anno></c> is not the
+		  atom <c>infinity</c> or an integer in valid
+		  range.</p></item>
+		</list>
+	      </item>
+	      
+	      <tag><c>noconnection</c></tag>
+	      <item><p>
+		The connection to <c>Node</c> was lost or could
+		not be established. The function may or may not
+		be applied.
+	      </p></item>
+	      
+	      <tag><c>system_limit</c></tag>
+	      <item><p>
+		The <c>erpc</c> operation failed due to some system
+		limit being reached. This typically due to failure
+		to create a process on the remote node <c>Node</c>,
+		but can be other things as well.
+	      </p></item>
+	      
+	      <tag><c>timeout</c></tag>
+	      <item><p>
+		The <c>erpc</c> operation timed out. The function may
+		or may not be applied.
+	      </p></item>
+	      
+	      <tag><c>notsup</c></tag>
+	      <item><p>
+		The remote node <c>Node</c> does not support
+		this <c>erpc</c> operation.
+	      </p>
+	      </item>
+	      
+	    </taglist>
+	    </item>
+	    
+	  </taglist>
+	  </item>
+	</taglist>
+
+	<p>
+	  If the <c>erpc</c> operation fails, but it is unknown if
+	  the function is/will be applied (that is, a timeout or
+	  a connection loss), the caller will not receive any
+	  further information about the result if/when the applied
+	  function completes. If the applied function explicitly
+	  communicates with the calling process, such communication
+	  may, of course, reach the calling process.
+        </p>
+
+	<note>
+	  <p>
+	    You cannot make <em>any</em> assumptions about the
+	    process that will perform the <c>apply()</c>. It may
+	    be the calling process itself, a server, or a freshly
+	    spawned process.
+	  </p>
+	</note>
+      </desc>
+    </func>
+
+    <func>
+      <name name="cast" arity="4" since="OTP @OTP-13450@"/>
+      <fsummary>Evaluate a function call on a node ignoring the result.</fsummary>
+      <desc>
+        <p>
+	  Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
+          <anno>Args</anno>)</c> on node
+          <c><anno>Node</anno></c>. No response is delivered to the
+	  calling process. <c>erpc:cast()</c> returns immediately
+	  after the cast request has been sent. Any failures beside
+	  bad arguments are silently ignored.
+	</p>
+	<p><c>erpc:cast/4</c> fails with an <c>{erpc, badarg}</c>
+	<c>error</c> exception if:</p>
+	<list>
+	  <item><p><c><anno>Node</anno></c> is not a valid
+	  node name atom.</p></item>
+	  <item><p><c><anno>Module</anno></c> is not an atom.</p></item>
+	  <item><p><c><anno>Function</anno></c> is not an atom.</p></item>
+	  <item><p><c><anno>Args</anno></c> is not a proper list
+	  of terms.</p></item>
+	</list>
+	<note>
+	  <p>
+	    You cannot make <em>any</em> assumptions about the
+	    process that will perform the <c>apply()</c>. It may
+	    be a server, or a freshly spawned process.
+	  </p>
+	</note>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="check_response" arity="2" since="OTP @OTP-13450@"/>
+      <fsummary>Check if a message is a response corresponding to a
+      previously sent call request.</fsummary>
+      <desc>
+	<p>
+	  Check if a message is a response to a <c>call</c> request
+	  previously made by the calling process using
+	  <seealso marker="#send_request/4"><c>erpc:send_request/4</c></seealso>.
+	  <c><anno>RequestId</anno></c> should be the value returned
+	  from the previously made <c>erpc:send_request()</c> call,
+	  and the corresponding response should not already have been
+	  received and handled to completion by <c>erpc:check_response()</c>,
+	  <seealso marker="#receive_response/2"><c>erpc:receive_response()</c></seealso>, or
+	  <seealso marker="#wait_response/2"><c>erpc:wait_response()</c></seealso>.
+	  <c><anno>Message</anno></c> is the message to check.
+	</p>
+	<p>
+	  If <c><anno>Message</anno></c> does not correspond to the
+	  response, the atom <c>no_response</c> is returned. If
+	  <c><anno>Message</anno></c> corresponds to the response, the
+	  <c>call</c> operation is completed and either the result is
+	  returned as <c>{response, Result}</c> where <c>Result</c>
+	  corresponds to the value returned from the applied function
+	  or an exception is raised. The exceptions that can be raised
+	  corresponds to the same exceptions as can be raised by
+	  <seealso marker="#call/4"><c>erpc:call/4</c></seealso>.
+	  That is, no <c>{erpc, timeout}</c> <c>error</c> exception
+	  can be raised.
+	</p>
+	<p>
+	  If the <c>erpc</c> operation fails, but it is unknown if
+	  the function is/will be applied (that is, a connection loss),
+	  the caller will not receive any further information about the
+	  result if/when the applied function completes. If the applied
+	  function explicitly communicates with the calling process,
+	  such communication may, of course, reach the calling process.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="multicall" arity="4" since="OTP @OTP-13450@"/>
+      <name name="multicall" arity="5" since="OTP @OTP-13450@"/>
+      <fsummary>Evaluate a function call on a number of nodes.</fsummary>
+      <type name="caught_call_exception"/>
+      <type name="stack_item"/>
+      <desc>
+	<p>
+	  Performs multiple <c>call</c> operations in parallel
+	  on multiple nodes. The result is returned as a list where
+	  the result from each node is placed at the same position
+	  as the node name is placed in <c><anno>Nodes</anno></c>.
+	  Each item in the resulting list is formatted as either:
+	</p>
+	<taglist>
+	  <tag><c>{ok, Result}</c></tag>
+	  <item><p>
+	    The <c>call</c> operation for this specific node
+	    returned <c>Result</c>.
+	  </p></item>
+	  <tag><c>{Class, ExceptionReason}</c></tag>
+	  <item><p>
+	    The <c>call</c> operation for this specific node
+	    raised an exception of class <c>Class</c> with
+	    exception reason <c>ExceptionReason</c>. These
+	    corresponds the the exceptions that
+	    <seealso marker="#call/5"><c>erpc:call/5</c></seealso>
+	    can raise.
+	  </p></item>
+	</taglist>
+	<p>
+	  The call <c>erpc:multicall(<anno>Nodes</anno>, <anno>Module</anno>,
+	  <anno>Function</anno>, <anno>Args</anno>)</c> is equivalent
+	  to the call <c>erpc:multicall(<anno>Nodes</anno>, <anno>Module</anno>,
+	  <anno>Function</anno>, <anno>Args</anno>, infinity)</c>. These
+	  calls are also equivalent to calling <c>my_multicall(Nodes, Module,
+	  Function, Args)</c> if one disregards performance:
+	</p>
+	<pre>
+my_multicall(Nodes, Module, Function, Args) ->
+  ReqIds = lists:map(fun (Node) ->
+                       <seealso marker="#send_request/4">erpc:send_request(Node, Module, Function, Args)</seealso>
+                     end,
+                     Nodes),
+  lists:map(fun (ReqId) ->
+              try
+                {ok, <seealso marker="#receive_response/2">erpc:receive_response(ReqId, infinity)</seealso>}
+              catch
+                Class:Reason ->
+                  {Class, Reason}
+              end
+            end,
+            ReqIds).
+</pre>
+
+        <p>
+	  The <c><anno>Timeout</anno></c> value in milliseconds
+	  sets an upper time limit for all <c>call</c> operations
+	  to complete.
+	</p>
+
+	<p>
+	  If an <c>erpc</c> operation fails, but it is unknown if
+	  the function is/will be applied (that is, a timeout or
+	  connection loss), the caller will not receive any
+	  further information about the result if/when the applied
+	  function completes. If the applied function communicates
+	  with the calling process, such communication may, of
+	  course, reach the calling process.
+	</p>
+      </desc>
+      
+    </func>
+    
+    <func>
+      <name name="receive_response" arity="1" since="OTP @OTP-13450@"/>
+      <name name="receive_response" arity="2" since="OTP @OTP-13450@"/>
+      <fsummary>Receive a call response corresponding to a
+      previously sent call request.</fsummary>
+      <desc>
+	<p>
+	  Receive a response to a <c>call</c> request previously
+	  made by the calling process using
+	  <seealso marker="#send_request/4"><c>erpc:send_request/4</c></seealso>.
+	  <c><anno>RequestId</anno></c> should be the value returned from
+	  the previously made <c>erpc:send_request()</c> call, and
+	  the corresponding response should not already have been received
+	  and handled to completion by
+	  <seealso marker="#check_response/2"><c>erpc:check_response()</c></seealso>,
+	  <c>erpc:receive_response()</c>, or
+	  <seealso marker="#wait_response/2"><c>erpc:wait_response()</c></seealso>.
+	  <c><anno>Timeout</anno></c> equals the timeout time in milliseconds
+	  or the atom <c>infinity</c>. The <c>call</c> operation is completed
+	  once the <c>erpc:receive_response()</c> call returns or raise an
+	  exception.
+	</p>
+	<p>
+	  The call <c>erpc:receive_response(<anno>RequestId</anno>)</c> is
+	  equivalent to the call
+	  <c>erpc:receive_response(<anno>RequestId</anno>, infinity)</c>.
+	</p>
+	<p>
+	  A call to the function
+	  <c>my_call(Node, Module, Function, Args, Timeout)</c>
+	  below is equivalent to the call
+	  <seealso marker="#call/5"><c>erpc:call(Node, Module, Function, Args,
+	  Timeout)</c></seealso> if one disregards performance. <c>erpc:call()</c>
+	  can utilize a message queue optimization which removes the need to scan
+	  the whole message queue which the combination
+	  <c>erpc:send_request()/erpc:receive_response()</c> cannot.
+	</p>
+	<pre>
+my_call(Node, Module, Function, Args, Timeout) ->
+  RequestId = <seealso marker="#send_request/4">erpc:send_request(Node, Module, Function, Args)</seealso>,
+  erpc:receive_response(RequestId, Timeout).
+</pre>
+	<p>
+	  If the <c>erpc</c> operation fails, but it is unknown if
+	  the function is/will be applied (that is, a timeout, or
+	  a connection loss), the caller will not receive any
+	  further information about the result if/when the applied
+	  function completes. If the applied function explicitly
+	  communicates with the calling process, such communication
+	  may, of course, reach the calling process.
+        </p>
+	
+	<p>
+	  <c>erpc:receive_response()</c> will return or raise exceptions the
+	  same way as <seealso marker="#call/5"><c>erpc:call/5</c></seealso>
+	  does.
+	</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="send_request" arity="4" since="OTP @OTP-13450@"/>
+      <fsummary>Send a request to evaluate a function call on a node.</fsummary>
+      <desc>
+	<p>
+	  Send an asynchronous <c>call</c> request to the node
+	  <c><anno>Node</anno></c>. <c>erpc:send_request()</c>
+	  returns a request identifier that later is to be passed
+	  as argument to either
+	  <seealso marker="#receive_response/1"><c>erpc:receive_response()</c></seealso>,
+	  <seealso marker="#wait_response/1"><c>erpc:wait_response()</c></seealso>,
+	  or,
+	  <seealso marker="#check_response/2"><c>erpc:check_response()</c></seealso>
+	  in order to get the response of the call request.
+	</p>
+	<p><c>erpc:send_request()</c> fails with an <c>{erpc, badarg}</c>
+	<c>error</c> exception if:</p>
+	<list>
+	  <item><p><c><anno>Node</anno></c> is not a valid
+	  node name atom.</p></item>
+	  <item><p><c><anno>Module</anno></c> is not an atom.</p></item>
+	  <item><p><c><anno>Function</anno></c> is not an atom.</p></item>
+	  <item><p><c><anno>Args</anno></c> is not a proper list
+	  of terms.</p></item>
+	</list>
+      </desc>
+    </func>
+
+    <func>
+      <name name="wait_response" arity="1" since="OTP @OTP-13450@"/>
+      <name name="wait_response" arity="2" since="OTP @OTP-13450@"/>
+      <fsummary>Wait or poll for a call response corresponding to a previously
+      sent call request.</fsummary>
+      <desc>
+	<p>
+	  Wait or poll for a response message to a <c>call</c> request
+	  previously made by the calling process using
+	  <seealso marker="#send_request/4"><c>erpc:send_request/4</c></seealso>.
+	  <c><anno>RequestId</anno></c> should be the value returned from
+	  the previously made <c>erpc:send_request()</c> call, and the
+	  corresponding response should not already have been received and handled
+	  to completion by
+	  <seealso marker="#check_response/2"><c>erpc:check_response()</c></seealso>,
+	  <seealso marker="#receive_response/2"><c>erpc:receive_response()</c></seealso>,
+	  or <c>erpc:wait_response()</c>. <c><anno>WaitTime</anno></c> equals the
+	  time to wait in milliseconds (or the atom <c>infinity</c>) during the wait.
+	</p>
+	<p>
+	  The call <c>erpc:wait_response(<anno>RequestId</anno>)</c> is equivalent
+	  to the call <c>erpc:wait_response(<anno>RequestId</anno>, 0)</c>. That is,
+	  poll for a response message to a <c>call</c> request previously made by
+	  the calling process.
+	</p>
+	<p>
+	  If no response is received before <c><anno>WaitTime</anno></c> milliseconds,
+	  the atom <c>no_response</c> is returned. It is valid to continue waiting
+	  for a response as many times as needed up until a response has
+	  been received and completed by <c>erpc:check_response()</c>,
+	  <c>erpc:receive_response()</c>, or <c>erpc:wait_response()</c>. If a
+	  response is received, the <c>call</c> operation is completed and either
+	  the result is returned as <c>{response, Result}</c> where <c>Result</c>
+	  corresponds to the value returned from the applied function or an
+	  exception is raised. The exceptions that can be raised corresponds to the
+	  same exceptions as can be raised by
+	  <seealso marker="#call/4"><c>erpc:call/4</c></seealso>.
+	  That is, no <c>{erpc, timeout}</c> <c>error</c> exception can be raised.
+	</p>
+	<p>
+	  If the <c>erpc</c> operation fails, but it is unknown if
+	  the function is/will be applied (that is, a too large wait time
+	  value, or a connection loss), the caller will not receive any
+	  further information about the result if/when the applied function
+	  completes. If the applied function explicitly communicates with the
+	  calling process, such communication may, of course, reach the
+	  calling process.
+        </p>
+      </desc>
+    </func>
+
+  </funcs>
+</erlref>
+

--- a/lib/kernel/doc/src/ref_man.xml
+++ b/lib/kernel/doc/src/ref_man.xml
@@ -43,6 +43,7 @@
   <xi:include href="erl_epmd.xml"/>
   <xi:include href="erl_prim_loader_stub.xml"/>
   <xi:include href="erlang_stub.xml"/>
+  <xi:include href="erpc.xml"/>
   <xi:include href="error_handler.xml"/>
   <xi:include href="error_logger.xml"/>
   <xi:include href="file.xml"/>

--- a/lib/kernel/doc/src/rpc.xml
+++ b/lib/kernel/doc/src/rpc.xml
@@ -37,13 +37,29 @@
       a function on a remote node and collect the answer. It is used
       for collecting information on a remote node, or for running a
       function with some specific side effects on the remote node.</p>
+      <note><p>
+	<c>rpc:call()</c> and friends makes it quite hard to distinguish
+	between successful results, raised exceptions, and other errors.
+	This cannot be changed due to compatibility reasons. As of OTP 23,
+	a new module <seealso marker="erpc"><c>erpc</c></seealso> was
+	introduced in order to provide an API that makes it possible
+	to distingush between the different results. The <c>erpc</c>
+	module provides a subset (however, the central subset) of the
+	functionality available in the <c>rpc</c> module. The <c>erpc</c>
+	implementation also provides a more scalable implementation with
+	better performance than the original <c>rpc</c> implementation.
+	However, since the introduction of <c>erpc</c>, the <c>rpc</c>
+	module implements large parts of its central functionality using
+	<c>erpc</c>, so the <c>rpc</c> module wont not suffer scalability
+	wise and performance wise compared to <c>erpc</c>.
+      </p></note>
   </description>
 
   <datatypes>
     <datatype>
       <name name="key"/>
       <desc>
-        <p>As returned by
+        <p>Opaque value returned by
           <seealso marker="#async_call/4"><c>async_call/4</c></seealso>.</p>
       </desc>
     </datatype>
@@ -87,7 +103,17 @@
           <seealso marker="#nb_yield/1"><c>nb_yield/1,2</c></seealso>
           to retrieve the value of evaluating <c>apply(<anno>Module</anno>,
           <anno>Function</anno>, <anno>Args</anno>)</c> on node
-          <c><anno>Node</anno></c>.</p>
+        <c><anno>Node</anno></c>.</p>
+	<note>
+	  <p>
+	    If you want the ability to distinguish between results,
+	    you may want to consider using the
+	    <seealso marker="erpc#send_request/4"><c>erpc:send_request()</c></seealso>
+	    function from the <c>erpc</c> module instead. This also
+	    gives you the ability retrieve the results in other useful
+	    ways.
+	  </p>
+	</note>
         <note>
           <p><seealso marker="#yield/1"><c>yield/1</c></seealso> and
             <seealso marker="#nb_yield/1"><c>nb_yield/1,2</c></seealso>
@@ -99,34 +125,34 @@
 
     <func>
       <name name="block_call" arity="4" since=""/>
-      <fsummary>Evaluate a function call on a node in the RPC server's
-        context.</fsummary>
-      <desc>
-        <p>Same as <seealso marker="#call/4"><c>call/4</c></seealso>,
-          but the RPC server at <c><anno>Node</anno></c> does
-          not create a separate process to handle the call. Thus,
-          this function can be used if the intention of the call is to
-          block the RPC server from any other incoming requests until
-          the request has been handled. The function can also be used
-          for efficiency reasons when very small fast functions are
-          evaluated, for example, BIFs that are guaranteed not to
-          suspend.</p>
-	  <p>See the note in <seealso marker="#call/4"><c>call/4</c></seealso>
-	  for more details of the return value.</p>
+      <fsummary>Evaluate a function call on a node.</fsummary>
+	<desc>
+	<p>
+	  The same as calling
+	  <seealso marker="#block_call/5"><c>rpc:block_call(<anno>Node</anno>,
+	  <anno>Module</anno>, <anno>Function</anno>,
+	  <anno>Args</anno>, infinity)</c></seealso>.
+	</p>
       </desc>
     </func>
 
     <func>
       <name name="block_call" arity="5" since=""/>
-      <fsummary>Evaluate a function call on a node in the RPC server's
-        context.</fsummary>
+      <fsummary>Evaluate a function call on a node.</fsummary>
       <desc>
-        <p>Same as
-          <seealso marker="#block_call/4"><c>block_call/4</c></seealso>,
-          but with a time-out value in the same manner as
-          <seealso marker="#call/5"><c>call/5</c></seealso>.</p>
-	  <p>See the note in <seealso marker="#call/4"><c>call/4</c></seealso>
-	  for more details of the return value.</p>
+	  <p>
+	    The same as calling
+	    <seealso marker="#call/5"><c>rpc:call(<anno>Node</anno>,
+	    <anno>Module</anno>, <anno>Function</anno>,
+	    <anno>Args</anno>, <anno>Timeout</anno>)</c></seealso> with
+	    the exception that it also blocks other <c>rpc:block_call()</c>
+	    operations from executing concurrently on the node
+	    <c><anno>Node</anno></c>.
+	  </p>
+	  <warning><p>
+	    Note that it also blocks other operations than just
+	    <c>rpc:block_call()</c> operations, so use it with care.
+	  </p></warning>
       </desc>
     </func>
 
@@ -135,9 +161,38 @@
       <fsummary>Evaluate a function call on a node.</fsummary>
       <desc>
         <p>Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
+        <anno>Args</anno>)</c> on node <c><anno>Node</anno></c> and returns
+          the corresponding value <c><anno>Res</anno></c>, or
+          <c>{badrpc, <anno>Reason</anno>}</c> if the call fails.
+	  The same as calling
+	  <seealso marker="#call/5"><c>rpc:call(<anno>Node</anno>,
+	  <anno>Module</anno>, <anno>Function</anno>,
+	  <anno>Args</anno>, infinity)</c></seealso>.
+	</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="call" arity="5" since=""/>
+      <fsummary>Evaluate a function call on a node.</fsummary>
+      <desc>
+        <p>Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
           <anno>Args</anno>)</c> on node <c><anno>Node</anno></c> and returns
           the corresponding value <c><anno>Res</anno></c>, or
-        <c>{badrpc, <anno>Reason</anno>}</c> if the call fails.</p>
+          <c>{badrpc, <anno>Reason</anno>}</c> if the call fails.
+          <c><anno>Timeout</anno></c> is
+          a time-out value in milliseconds. If the call times out,
+          <c><anno>Reason</anno></c> is <c>timeout</c>.</p>
+        <p>If the reply arrives after the call times out, no message
+          contaminates the caller's message queue.</p>
+	<note>
+	  <p>
+	    If you want the ability to distinguish between results,
+	    you may want to consider using the
+	    <seealso marker="erpc#call/4"><c>erpc:call()</c></seealso>
+	    function from the <c>erpc</c> module instead.
+	  </p>
+	</note>
 	<note>
 	  <p>Here follows the details of what exactly is returned.</p>
 	  <p><c>{badrpc, <anno>Reason</anno>}</c> will be returned in the
@@ -159,28 +214,14 @@
 	    <strong>not</strong> match <c>{'EXIT',_}</c>.</item>
           </list>
 	</note>
-      </desc>
-    </func>
-
-    <func>
-      <name name="call" arity="5" since=""/>
-      <fsummary>Evaluate a function call on a node.</fsummary>
-      <desc>
-        <p>Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
-          <anno>Args</anno>)</c> on node <c><anno>Node</anno></c> and returns
-          the corresponding value <c><anno>Res</anno></c>, or
-          <c>{badrpc, <anno>Reason</anno>}</c> if the call fails.
-          <c><anno>Timeout</anno></c> is
-          a time-out value in milliseconds. If the call times out,
-          <c><anno>Reason</anno></c> is <c>timeout</c>.
-	  See the note in <seealso marker="#call/4"><c>call/4</c></seealso>
-	  for more details of the return value.</p>
-        <p>If the reply arrives after the call times out, no message
-          contaminates the caller's message queue, as this
-          function spawns off a middleman process to act as (a void)
-          destination for such an orphan reply. This feature also makes
-          this function more expensive than <c>call/4</c> at
-          the caller's end.</p>
+	<note>
+	  <p>
+	    You cannot make <em>any</em> assumptions about the
+	    process that will perform the <c>apply()</c>. It may
+	    be the calling process itself, an <c>rpc</c> server,
+	    another server, or a freshly spawned process.
+	  </p>
+	</note>
       </desc>
     </func>
 
@@ -194,6 +235,14 @@
           process is not suspended until the evaluation is complete, as
           is the case with
           <seealso marker="#call/4"><c>call/4,5</c></seealso>.</p>
+	<note>
+	  <p>
+	    You cannot make <em>any</em> assumptions about the
+	    process that will perform the <c>apply()</c>. It may
+	    be an <c>rpc</c> server, another server, or a
+	    freshly spawned process.
+	  </p>
+	</note>
       </desc>
     </func>
 
@@ -226,7 +275,7 @@
           <anno>Name</anno>, <anno>Msg</anno>)</c>.</p>
       </desc>
     </func>
-
+    
     <func>
       <name name="multi_server_call" arity="3" since=""/>
       <fsummary>Interact with the servers on a number of nodes.</fsummary>
@@ -311,6 +360,14 @@
 {ResL, _} = rpc:multicall(code, load_binary, [Mod, File, Bin]),
 
 %% and then maybe check the ResL list.</code>
+	<note>
+	  <p>
+	    If you want the ability to distinguish between results,
+	    you may want to consider using the
+	    <seealso marker="erpc#multicall/4"><c>erpc:multicall()</c></seealso>
+	    function from the <c>erpc</c> module instead.
+	  </p>
+	</note>
       </desc>
     </func>
 

--- a/lib/kernel/doc/src/specs.xml
+++ b/lib/kernel/doc/src/specs.xml
@@ -9,6 +9,7 @@
   <xi:include href="../specs/specs_erl_epmd.xml"/>
   <xi:include href="../specs/specs_erl_prim_loader_stub.xml"/>
   <xi:include href="../specs/specs_erlang_stub.xml"/>
+  <xi:include href="../specs/specs_erpc.xml"/>
   <xi:include href="../specs/specs_error_handler.xml"/>
   <xi:include href="../specs/specs_error_logger.xml"/>
   <xi:include href="../specs/specs_file.xml"/>

--- a/lib/kernel/src/Makefile
+++ b/lib/kernel/src/Makefile
@@ -73,6 +73,7 @@ MODULES = \
 	erl_epmd \
 	erl_reply \
 	erl_signal_handler \
+	erpc \
 	erts_debug \
 	error_handler \
 	error_logger \

--- a/lib/kernel/src/erpc.erl
+++ b/lib/kernel/src/erpc.erl
@@ -1,0 +1,473 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2020. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% Author: Rickard Green
+%%
+
+-module(erpc).
+
+%% Exported API
+
+-export([call/4,
+         call/5,
+	 cast/4,
+         send_request/4,
+         receive_response/1,
+         receive_response/2,
+         wait_response/1,
+         wait_response/2,
+         check_response/2,
+         multicall/4,
+	 multicall/5]).
+
+-export_type([request_id/0]).
+
+%% Internal exports (also used by the 'rpc' module)
+
+-export([execute_call/4,
+         execute_call/3,
+         is_arg_error/4,
+         trim_stack/4,
+         call_result/4]).
+
+%%------------------------------------------------------------------------
+
+-compile({inline,[{result,4}]}). %% Nicer error stack trace...
+
+-define(MAX_INT_TIMEOUT, 4294967295).
+-define(TIMEOUT_TYPE, 0..?MAX_INT_TIMEOUT | 'infinity').
+-define(IS_VALID_TMO_INT(TI_), (is_integer(TI_)
+                                andalso (0 =< TI_)
+                                andalso (TI_ =< ?MAX_INT_TIMEOUT))).
+-define(IS_VALID_TMO(T_), ((T_ == infinity) orelse ?IS_VALID_TMO_INT(T_))).
+
+%%------------------------------------------------------------------------
+%% Exported API
+%%------------------------------------------------------------------------
+
+-spec call(Node, Module, Function, Args) -> Result when
+      Node :: node(),
+      Module :: atom(),
+      Function :: atom(),
+      Args :: [term()],
+      Result :: term().
+
+call(N, M, F, A) ->
+    call(N, M, F, A, infinity).
+
+-dialyzer([{nowarn_function, call/5}, no_return]).
+
+-spec call(Node, Module, Function, Args, Timeout) -> Result when
+      Node :: node(),
+      Module :: atom(),
+      Function :: atom(),
+      Args :: [term()],
+      Timeout :: ?TIMEOUT_TYPE,
+      Result :: term().
+
+call(N, M, F, A, infinity) when node() =:= N,  %% Optimize local call
+                                is_atom(M),
+                                is_atom(F),
+                                is_list(A) ->
+    try
+        {return, Return} = execute_call(M,F,A),
+        Return
+    catch
+        exit:Reason ->
+            exit({exception, Reason});
+        error:Reason:Stack ->
+            case is_arg_error(Reason, M, F, A) of
+                true ->
+                    error({?MODULE, Reason});
+                false ->
+                    ErpcStack = trim_stack(Stack, M, F, A),
+                    error({exception, Reason, ErpcStack})
+            end
+    end;
+call(N, _M, _F, _A, infinity) when node() =:= N ->
+    error({?MODULE, badarg});
+call(N, M, F, A, T) when ?IS_VALID_TMO(T) ->
+    try
+        Res = make_ref(),
+        ReqId = erlang:spawn_request(N, ?MODULE, execute_call,
+                                     [Res, M, F, A],
+                                     [{reply, error_only},
+                                      monitor]),
+        receive
+            {spawn_reply, ReqId, error, Reason} ->
+                result(spawn_reply, ReqId, Res, Reason);
+            {'DOWN', ReqId, process, _Pid, Reason} ->
+                result(down, ReqId, Res, Reason)
+        after T ->
+                result(timeout, ReqId, Res, undefined)
+        end
+    catch
+        error:badarg ->
+            error({?MODULE, badarg})
+    end;
+call(_N, _M, _F, _A, _T) ->
+    error({?MODULE, badarg}).
+
+%% Asynchronous call
+
+-opaque request_id() :: {reference(), reference()}.
+
+-spec send_request(Node, Module, Function, Args) -> RequestId when
+      Node :: node(),
+      Module :: module(),
+      Function :: atom(),
+      Args :: [term()],
+      RequestId :: request_id().
+
+send_request(N, M, F, A) ->
+    try
+        Res = make_ref(),
+        ReqId = erlang:spawn_request(N, ?MODULE, execute_call,
+                                     [Res, M, F, A],
+                                     [{reply, error_only},
+                                      monitor]),
+        {Res, ReqId}
+    catch
+        error:badarg ->
+            error({?MODULE, badarg})
+    end.
+
+-spec receive_response(RequestId) -> Result when
+      RequestId :: request_id(),
+      Result :: term().
+
+receive_response({Res, ReqId} = RId) when is_reference(Res),
+                                          is_reference(ReqId) ->
+    receive_response(RId, infinity);
+receive_response(_) ->
+    error({?MODULE, badarg}).
+
+-dialyzer([{nowarn_function, receive_response/2}, no_return]).
+
+-spec receive_response(RequestId, Timeout) -> Result when
+      RequestId :: request_id(),
+      Timeout :: ?TIMEOUT_TYPE,
+      Result :: term().
+
+receive_response({Res, ReqId}, Tmo) when is_reference(Res),
+                                         is_reference(ReqId),
+                                         ?IS_VALID_TMO(Tmo) ->
+    receive
+        {spawn_reply, ReqId, error, Reason} ->
+            result(spawn_reply, ReqId, Res, Reason);
+        {'DOWN', ReqId, process, _Pid, Reason} ->
+            result(down, ReqId, Res, Reason)
+    after Tmo ->
+            result(timeout, ReqId, Res, undefined)
+    end;
+receive_response(_, _) ->
+    error({?MODULE, badarg}).
+
+-spec wait_response(RequestId) -> {'response', Result} | 'no_response' when
+      RequestId :: request_id(),
+      Result :: term().
+
+wait_response({Res, ReqId} = RId) when is_reference(Res),
+                                       is_reference(ReqId) ->
+    wait_response(RId, 0).
+    
+-dialyzer([{nowarn_function, wait_response/2}, no_return]).
+
+-spec wait_response(RequestId, WaitTime) ->
+          {'response', Result} | 'no_response' when
+      RequestId :: request_id(),
+      WaitTime :: ?TIMEOUT_TYPE,
+      Result :: term().
+
+wait_response({Res, ReqId}, WT) when is_reference(Res),
+                                     is_reference(ReqId),
+                                     ?IS_VALID_TMO(WT) ->
+    receive
+        {spawn_reply, ReqId, error, Reason} ->
+            result(spawn_reply, ReqId, Res, Reason);
+        {'DOWN', ReqId, process, _Pid, Reason} ->
+            {response, result(down, ReqId, Res, Reason)}
+    after WT ->
+            no_response
+    end;
+wait_response(_, _) ->
+    error({?MODULE, badarg}).
+
+-dialyzer([{nowarn_function, check_response/2}, no_return]).
+
+-spec check_response(Message, RequestId) ->
+          {'response', Result} | 'no_response' when
+      Message :: term(),
+      RequestId :: request_id(),
+      Result :: term().
+
+check_response({spawn_reply, ReqId, error, Reason},
+               {Res, ReqId}) when is_reference(Res),
+                                  is_reference(ReqId) ->
+    result(spawn_reply, ReqId, Res, Reason);
+check_response({'DOWN', ReqId, process, _Pid, Reason},
+               {Res, ReqId}) when is_reference(Res),
+                                  is_reference(ReqId) ->
+    {response, result(down, ReqId, Res, Reason)};
+check_response(_Msg, {Res, ReqId}) when is_reference(Res),
+                                        is_reference(ReqId) ->
+    no_response;
+check_response(_, _) ->
+    error({?MODULE, badarg}).
+
+-type stack_item() ::
+        {Module :: atom(),
+         Function :: atom(),
+         Arity :: arity() | (Args :: [term()]),
+         Location :: [{file, Filename :: string()} |
+                      {line, Line :: pos_integer()}]}.
+
+-type caught_call_exception() ::
+        {throw, Throw :: term()}
+      | {exit, {exception, Reason :: term()}}
+      | {error, {exception, Reason :: term(), StackTrace :: [stack_item()]}}
+      | {exit, {signal, Reason :: term()}}
+      | {error, {?MODULE, Reason :: term()}}.
+
+
+-spec multicall(Nodes, Module, Function, Args) -> Result when
+      Nodes :: [atom()],
+      Module :: atom(),
+      Function :: atom(),
+      Args :: [term()],
+      Result :: [{ok, ReturnValue :: term()} | caught_call_exception()].
+
+multicall(Ns, M, F, A) ->
+    multicall(Ns, M, F, A, infinity).
+
+-spec multicall(Nodes, Module, Function, Args, Timeout) -> Result when
+      Nodes :: [atom()],
+      Module :: atom(),
+      Function :: atom(),
+      Args :: [term()],
+      Timeout :: ?TIMEOUT_TYPE,
+      Result :: [{ok, ReturnValue :: term()} | caught_call_exception()].
+
+multicall(Ns, M, F, A, T) when ?IS_VALID_TMO(T) ->
+    EndTime = if T == infinity ->
+                      infinity;
+                 T == 0 ->
+                      erlang:monotonic_time(millisecond);
+                 T == ?MAX_INT_TIMEOUT ->
+                      erlang:monotonic_time(millisecond)
+                          + ?MAX_INT_TIMEOUT;
+                 true ->
+                      Start = erlang:monotonic_time(),
+                      NTmo = erlang:convert_time_unit(T,
+                                                      millisecond,
+                                                      native),
+                      erlang:convert_time_unit(Start + NTmo - 1,
+                                               native,
+                                               millisecond) + 1
+              end,
+    try
+        ReqIds = mcall_send_requests(Ns, M, F, A, []),
+        mcall_wait_replies(ReqIds, [], EndTime)
+    catch
+        error:{?MODULE, badarg} = Reason ->
+            error(Reason)
+    end;
+multicall(_Ns, _M, _F, _A, _T) ->
+    error({?MODULE, badarg}).
+
+-spec cast(Node, Module, Function, Args) -> ok when
+      Node :: node(),
+      Module :: module(),
+      Function :: atom(),
+      Args :: [term()].
+
+cast(Node, Mod, Fun, Args) ->
+    %% Fire and forget...
+    try
+        _ = erlang:spawn_request(Node, Mod, Fun, Args, [{reply, no}]),
+        ok
+    catch
+        error:badarg ->
+            error({?MODULE, badarg})
+    end.
+
+%%------------------------------------------------------------------------
+%% Exported internals
+%%------------------------------------------------------------------------
+
+%% Note that most of these are used by 'rpc' as well...
+
+execute_call(Ref, M, F, A) ->
+    Reply = try
+                {Ref, return, apply(M, F, A)}
+            catch
+                throw:Reason ->
+                    {Ref, throw, Reason};
+                exit:Reason ->
+                    {Ref, exit, Reason};
+                error:Reason:Stack ->
+                    case is_arg_error(Reason, M, F, A) of
+                        true ->
+                            {Ref, error, {?MODULE, Reason}};
+                        false ->
+                            ErpcStack = trim_stack(Stack, M, F, A),
+                            {Ref, error, Reason, ErpcStack}
+                    end
+            end,
+    exit(Reply).
+
+execute_call(M,F,A) ->
+    {return, apply(M, F, A)}.
+
+call_result(Type, ReqId, Res, Reason) ->
+    result(Type, ReqId, Res, Reason).
+
+is_arg_error(badarg, M, F, A) ->
+    try
+        true = is_atom(M),
+        true = is_atom(F),
+        true = is_integer(length(A)),
+        false
+    catch
+        error:badarg ->
+            true
+    end;
+is_arg_error(system_limit, _M, _F, A) ->
+    try
+        apply(?MODULE, nonexisting, A),
+        false
+    catch
+        error:system_limit -> true;
+        _:_ -> false
+    end;
+is_arg_error(_R, _M, _F, _A) ->
+    false.
+
+trim_stack([{?MODULE, execute_call, _, _} | _], M, F, A) ->
+    [{M, F, A, []}];
+trim_stack([{M, F, A, _} = SF, {?MODULE, execute_call, _, _} | _], M, F, A) ->
+    [SF];
+trim_stack(S, M, F, A) ->
+    try
+        trim_stack_aux(S, M, F, A)
+    catch
+        throw:use_all -> S
+    end.
+
+%%------------------------------------------------------------------------
+%% Internals
+%%------------------------------------------------------------------------
+
+trim_stack_aux([], _M, _F, _A) ->
+    throw(use_all);
+trim_stack_aux([{M, F, AL, _} = SF, {?MODULE, execute_call, _, _} | _],
+               M, F, A) when AL == length(A) ->
+    [SF];
+trim_stack_aux([{?MODULE, execute_call, _, _} | _], M, F, A) ->
+    [{M, F, length(A), []}];
+trim_stack_aux([SF|SFs], M, F, A) ->
+    [SF|trim_stack_aux(SFs, M, F, A)].
+
+call_abandon(ReqId) ->
+    case erlang:spawn_request_abandon(ReqId) of
+        true -> true;
+        false -> erlang:demonitor(ReqId, [info])
+    end.
+
+-dialyzer([{nowarn_function, result/4}, no_return]).
+
+-spec result('down', ReqId, Res, Reason) -> term() when
+      ReqId :: reference(),
+      Res :: reference(),
+      Reason :: term();
+                  ('spawn_reply', ReqId, Res, Reason) -> no_return() when
+      ReqId :: reference(),
+      Res :: reference(),
+      Reason :: term();
+                  ('timeout', ReqId, Res, Reason) -> term() when
+      ReqId :: reference(),
+      Res :: reference(),
+      Reason :: term().
+
+result(down, _ReqId, Res, {Res, return, Return}) ->
+    Return;
+result(down, _ReqId, Res, {Res, throw, Throw}) ->
+    throw(Throw);
+result(down, _ReqId, Res, {Res, exit, Exit}) ->
+    exit({exception, Exit});
+result(down, _ReqId, Res, {Res, error, Error, Stack}) ->
+    error({exception, Error, Stack});
+result(down, _ReqId, Res, {Res, error, {?MODULE, _} = ErpcErr}) ->
+    error(ErpcErr);
+result(down, _ReqId, _Res, noconnection) ->
+    error({?MODULE, noconnection});
+result(down, _ReqId, _Res, Reason) ->
+    exit({signal, Reason});
+result(spawn_reply, _ReqId, _Res, Reason) ->
+    error({?MODULE, Reason});
+result(timeout, ReqId, Res, _Reason) ->
+    case call_abandon(ReqId) of
+        true ->
+            error({?MODULE, timeout});
+        false ->
+            %% Spawn error or DOWN has arrived. Return
+            %% a result instead of a timeout since we
+            %% just got the result...
+            receive
+                {spawn_reply, ReqId, error, Reason} ->
+                    result(spawn_reply, ReqId, Res, Reason);
+                {'DOWN', ReqId, process, _Pid, Reason} ->
+                    result(down, ReqId, Res, Reason)
+            after
+                0 ->
+                    %% Invalid request id...
+                    error({?MODULE, badarg})
+            end
+    end.
+
+mcall_send_requests([], _M, _F, _A, RIDs) ->
+    RIDs;
+mcall_send_requests([N|Ns], M, F, A, RIDs) ->
+    RID = send_request(N, M, F, A),
+    mcall_send_requests(Ns, M, F, A, [RID|RIDs]);
+mcall_send_requests(_, _M, _F, _A, _RIDs) ->
+    error({?MODULE, badarg}).
+
+mcall_wait_replies([], Replies, _Tmo) ->
+    Replies;
+mcall_wait_replies([RID|RIDs], Replies, infinity) ->
+    Reply = mcall_wait_reply(RID, infinity),
+    mcall_wait_replies(RIDs, [Reply|Replies], infinity);
+mcall_wait_replies([RID|RIDs], Replies, EndTime) ->
+    Now = erlang:monotonic_time(millisecond),
+    Tmo = case EndTime - Now of
+              T when T =< 0 -> 0;
+              T -> T
+          end,
+    Reply = mcall_wait_reply(RID, Tmo),
+    mcall_wait_replies(RIDs, [Reply|Replies], EndTime).
+
+mcall_wait_reply(RID, Tmo) ->
+    try
+        {ok, receive_response(RID, Tmo)}
+    catch
+        Class:Reason ->
+            {Class, Reason}
+    end.
+    

--- a/lib/kernel/src/kernel.app.src
+++ b/lib/kernel/src/kernel.app.src
@@ -36,6 +36,7 @@
 	     erl_distribution,
 	     erl_reply,
              erl_signal_handler,
+	     erpc,
 	     error_handler,
 	     error_logger,
 	     file,

--- a/lib/kernel/test/Makefile
+++ b/lib/kernel/test/Makefile
@@ -25,6 +25,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 # ----------------------------------------------------
 
 MODULES= \
+	erpc_SUITE \
 	rpc_SUITE \
 	pdict_SUITE \
 	bif_SUITE \

--- a/lib/kernel/test/erpc_SUITE.erl
+++ b/lib/kernel/test/erpc_SUITE.erl
@@ -1,0 +1,796 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2020. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(erpc_SUITE).
+
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
+	 init_per_group/2,end_per_group/2]).
+-export([call/1, call_reqtmo/1, call_against_old_node/1, cast/1,
+         send_request/1, send_request_receive_reqtmo/1,
+         send_request_wait_reqtmo/1,
+         send_request_check_reqtmo/1,
+         send_request_against_old_node/1,
+         multicall/1, multicall_reqtmo/1,
+         timeout_limit/1]).
+-export([init_per_testcase/2, end_per_testcase/2]).
+
+-export([call_func1/1, call_func2/1, call_func4/4]).
+
+-export([f/0, f2/0]).
+
+-include_lib("common_test/include/ct.hrl").
+
+suite() ->
+    [{ct_hooks,[ts_install_cth]},
+     {timetrap,{minutes,2}}].
+
+all() -> 
+    [call, call_reqtmo, call_against_old_node, cast,
+     send_request, send_request_receive_reqtmo,
+     send_request_wait_reqtmo, send_request_check_reqtmo,
+     send_request_against_old_node,
+     multicall, multicall_reqtmo,
+     timeout_limit].
+
+groups() -> 
+    [].
+
+init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
+    [{testcase, Func}|Config].
+
+end_per_testcase(_Func, _Config) ->
+    ok.
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+call(Config) when is_list(Config) ->
+    call_test(Config).
+
+call_test(Config) ->
+    call_test(node(), 10000),
+    call_test(node(), infinity),
+    try
+        erpc:call(node(), erlang, node, [], 0),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, timeout} ->
+            ok
+    end,
+    {ok, Node} = start_node(Config),
+    call_test(Node, 10000),
+    call_test(Node, infinity),
+    try
+        erpc:call(Node, erlang, node, [], 0),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, timeout} ->
+            ok
+    end,
+    try
+        erpc:call(Node, erlang, halt, []),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, noconnection} ->
+            ok
+    end,
+    try
+        erpc:call(Node, erlang, node, []),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, noconnection} ->
+            ok
+    end.
+
+call_test(Node, Timeout) ->
+    io:format("call_test(~p, ~p)~n", [Node, Timeout]),
+    Node = erpc:call(Node, erlang, node, [], Timeout),
+    try
+        erpc:call(Node, erlang, error, [oops|invalid], Timeout),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} ->
+            ok
+    end,
+    try
+        erpc:call(Node, erlang, error, [oops|invalid], Timeout),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} ->
+            ok
+    end,
+    try
+        erpc:call(Node, erlang, error, [oops], Timeout),
+        ct:fail(unexpected)
+    catch
+        error:{exception, oops, [{erlang,error,[oops],_}]} ->
+            ok
+    end,
+    try
+        erpc:call(Node, erlang, exit, [oops], Timeout),
+        ct:fail(unexpected)
+    catch
+        exit:{exception, oops} ->
+            ok
+    end,
+    try
+        erpc:call(Node, erlang, throw, [oops], Timeout),
+        ct:fail(unexpected)
+    catch
+        throw:oops ->
+            ok
+    end,
+    case {node() == Node, Timeout == infinity} of
+        {true, true} ->
+            %% This would kill the test since local calls
+            %% without timeout is optimized to execute in
+            %% calling process itself...
+            ok;
+        _ ->
+            ExitSignal = fun () ->
+                                 exit(self(), oops),
+                                 receive after infinity -> ok end
+                         end,
+            try
+                erpc:call(Node, erlang, apply, [ExitSignal, []], Timeout),
+                ct:fail(unexpected)
+            catch
+                exit:{signal, oops} ->
+                    ok
+            end
+    end,
+    try
+        erpc:call(Node, ?MODULE, call_func1, [boom], Timeout),
+        ct:fail(unexpected)
+    catch
+        error:{exception,
+               {exception,
+                boom,
+                [{?MODULE, call_func3, A2, _},
+                 {?MODULE, call_func2, 1, _}]},
+               [{erpc, call, A1, _},
+                {?MODULE, call_func1, 1, _}]}
+          when ((A1 == 5)
+                orelse (A1 == [Node, ?MODULE, call_func2, [boom]]))
+               andalso ((A2 == 1)
+                        orelse (A2 == [boom])) ->
+            ok
+    end,
+    try
+        call_func4(Node, node(), 10, Timeout),
+        ct:fail(unexpected)
+    catch
+        error:Error1 ->
+%%%            io:format("Error1=~p~n", [Error1]),
+            check_call_func4_error(Error1, 10)
+    end,
+    try
+        call_func4(node(), Node, 5, Timeout),
+        ct:fail(unexpected)
+    catch
+        error:Error2 ->
+%%%            io:format("Error2=~p~n", [Error2]),
+            check_call_func4_error(Error2, 5)
+    end,
+    ok.
+
+check_call_func4_error({exception,
+                         badarg,
+                         [{?MODULE, call_func5, _, _},
+                          {?MODULE, call_func4, _, _}]},
+                         0) ->
+    ok;
+check_call_func4_error({exception,
+                        Exception,
+                        [{erpc, call, _, _},
+                         {?MODULE, call_func5, _, _},
+                         {?MODULE, call_func4, _, _}]},
+                       N) ->
+    check_call_func4_error(Exception, N-1).
+    
+call_func1(X) ->
+    erpc:call(node(), ?MODULE, call_func2, [X]),
+    ok.
+
+call_func2(X) ->
+    call_func3(X),
+    ok.
+
+call_func3(X) ->
+    erlang:error(X, [X]).
+    
+call_func4(A, B, N, T) ->
+    call_func5(A, B, N, T),
+    ok.
+
+call_func5(A, B, N, T) when N >= 0 ->
+    erpc:call(A, ?MODULE, call_func4, [B, A, N-1, T], T),
+    ok;
+call_func5(_A, _B, _N, _T) ->
+    erlang:error(badarg).
+
+call_against_old_node(Config) ->
+    case start_22_node(Config) of
+        {ok, Node22} ->
+            try
+                erpc:call(Node22, erlang, node, []),
+                ct:fail(unexpected)
+            catch
+                error:{erpc, notsup} ->
+                    ok
+            end,
+            stop_node(Node22),
+            ok;
+        _ ->
+	    {skipped, "No OTP 22 available"}
+    end.
+
+call_reqtmo(Config) when is_list(Config) ->
+    Fun = fun (Node, SendMe, Timeout) ->
+                  try
+                      erpc:call(Node, erlang, send,
+                                [self(), SendMe], Timeout),
+                      ct:fail(unexpected)
+                  catch
+                      error:{erpc, timeout} -> ok
+                  end
+          end,
+    reqtmo_test(Config, Fun).
+
+reqtmo_test(Config, Test) ->
+    %% Tests that we time out in time also when the request itself
+    %% does not get through. A typical issue we have had
+    %% in the past, is that the timeout has not triggered until
+    %% the request has gotten through...
+    
+    Timeout = 500,
+    WaitBlock = 100,
+    BlockTime = 1000,
+
+    {ok, Node} = start_node(Config),
+
+    erpc:call(Node, erts_debug, set_internal_state, [available_internal_state,
+                                                     true]),
+    
+    SendMe = make_ref(),
+
+    erpc:cast(Node, erts_debug, set_internal_state, [block, BlockTime]),
+    receive after WaitBlock -> ok end,
+    
+    Start = erlang:monotonic_time(),
+
+    Test(Node, SendMe, Timeout),
+
+    Stop = erlang:monotonic_time(),
+    Time = erlang:convert_time_unit(Stop-Start, native, millisecond),
+    io:format("Actual time: ~p ms~n", [Time]),
+    true = Time >= Timeout,
+    true = Time =< Timeout + 200,
+    
+    receive SendMe -> ok end,
+    
+    receive UnexpectedMsg -> ct:fail({unexpected_message, UnexpectedMsg})
+    after 0 -> ok
+    end,
+    
+    stop_node(Node),
+    
+    {comment,
+     "Timeout = " ++ integer_to_list(Timeout)
+     ++ " Actual = " ++ integer_to_list(Time)}.
+
+cast(Config) when is_list(Config) ->
+    try
+        erpc:cast(node, erlang, send, [hej]),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} -> ok
+    end,
+    try
+        erpc:cast(node(), "erlang", send, [hej]),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} -> ok
+    end,
+    try
+        erpc:cast(node(), erlang, make_ref(), [hej]),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} -> ok
+    end,
+    try
+        erpc:cast(node(), erlang, send, [hej|hopp]),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} -> ok
+    end,
+    Me = self(),
+    Ok1 = make_ref(),
+    ok = erpc:cast(node(), erlang, send, [Me, Ok1]),
+    receive
+        Ok1 -> ok
+    end,
+    {ok, Node} = start_node(Config),
+    Ok2 = make_ref(),
+    ok = erpc:cast(Node, erlang, send, [Me, Ok2]),
+    receive
+        Ok2 -> ok
+    end,
+    stop_node(Node),
+    case start_22_node(Config) of
+        {ok, Node22} ->
+            ok = erpc:cast(Node, erlang, send, [Me, wont_reach_me]),
+            receive
+                Msg -> ct:fail({unexpected_message, Msg})
+            after
+                2000 -> ok
+            end,
+            stop_node(Node22),
+            {comment, "Tested against OTP 22 as well"};
+        _ ->
+            {comment, "No tested against OTP 22"}
+    end.
+
+send_request(Config) when is_list(Config) ->
+    %% Note: First part of nodename sets response delay in seconds.
+    PA = filename:dirname(code:which(?MODULE)),
+    NodeArgs = [{args,"-pa "++ PA}],
+    {ok,Node1} = test_server:start_node('1_erpc_SUITE_call', slave, NodeArgs),
+    {ok,Node2} = test_server:start_node('10_erpc_SUITE_call', slave, NodeArgs),
+    {ok,Node3} = test_server:start_node('20_erpc_SUITE_call', slave, NodeArgs),
+    ReqId1 = erpc:send_request(Node1, ?MODULE, f, []),
+    ReqId2 = erpc:send_request(Node2, ?MODULE, f, []),
+    ReqId3 = erpc:send_request(Node3, ?MODULE, f, []),
+    ReqId4 = erpc:send_request(Node1, erlang, error, [bang]),
+    ReqId5 = erpc:send_request(Node1, ?MODULE, f, []),
+
+    try
+        erpc:receive_response(ReqId4, 10)
+    catch
+        error:{exception, bang, [{erlang,error,[bang],_}]} ->
+            ok
+    end,
+    try
+        erpc:receive_response(ReqId5, 10)
+    catch
+        error:{erpc, timeout} ->
+            ok
+    end,
+
+    %% Test fast timeouts.
+    no_response = erpc:wait_response(ReqId2),
+    no_response = erpc:wait_response(ReqId2, 10),
+
+    %% Let Node1 finish its work before yielding.
+    ct:sleep({seconds,2}),
+    {hej,_,Node1} = erpc:receive_response(ReqId1),
+
+    %% Wait for the Node2 and Node3.
+    {response,{hej,_,Node2}} = erpc:wait_response(ReqId2, infinity),
+    {hej,_,Node3} = erpc:receive_response(ReqId3),
+
+    try
+        erpc:receive_response(ReqId5, 10),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} ->
+            ok
+    end,
+
+    receive
+        Msg0 -> ct:fail(Msg0)
+    after 0 -> ok
+    end,
+
+    {ok, Node4} = start_node(Config),
+
+    ReqId6 = erpc:send_request(Node4, erlang, node, []),
+    
+    no_response = erpc:check_response({response, Node1}, ReqId6),
+    no_response = erpc:check_response(ReqId6, ReqId6),
+    receive
+        Msg1 ->
+            {response, Node4} = erpc:check_response(Msg1, ReqId6)
+    end,
+
+    ReqId7 = erpc:send_request(Node4, erlang, halt, []),
+    try
+        erpc:receive_response(ReqId7),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, noconnection} -> ok
+    end,
+
+    ReqId8 = erpc:send_request(Node4, erlang, node, []),
+    receive
+        Msg2 ->
+            try
+                erpc:check_response(Msg2, ReqId8),
+                ct:fail(unexpected)
+            catch
+                error:{erpc, noconnection} ->
+                    ok
+            end
+    end,
+
+    case start_22_node(Config) of
+        {ok, Node5} ->
+            ReqId9 = erpc:send_request(Node5, erlang, node, []),
+            try
+                erpc:receive_response(ReqId9),
+                ct:fail(unexpected)
+            catch
+                error:{erpc, notsup} -> ok
+            end,
+
+            stop_node(Node5),
+            ok;
+        _ ->
+            {comment, "No test against OTP 22 node performed"}
+    end.
+
+send_request_receive_reqtmo(Config) when is_list(Config) ->
+    Fun = fun (Node, SendMe, Timeout) ->
+                  RID = erpc:send_request(Node, erlang, send,
+                                          [self(), SendMe]),
+                  try
+                      erpc:receive_response(RID, Timeout),
+                      ct:fail(unexpected)
+                  catch
+                      error:{erpc, timeout} -> ok
+                  end
+          end,
+    reqtmo_test(Config, Fun).
+
+send_request_wait_reqtmo(Config) when is_list(Config) ->
+    Fun = fun (Node, SendMe, Timeout) ->
+                  RID = erpc:send_request(Node, erlang, send,
+                                          [self(), SendMe]),
+                  no_response = erpc:wait_response(RID, 0),
+                  no_response = erpc:wait_response(RID, Timeout),
+                  %% Cleanup...
+                  try
+                      erpc:receive_response(RID, 0),
+                      ct:fail(unexpected)
+                  catch
+                      error:{erpc, timeout} -> ok
+                  end
+          end,
+    reqtmo_test(Config, Fun).
+
+send_request_check_reqtmo(Config) when is_list(Config) ->
+    Fun = fun (Node, SendMe, Timeout) ->
+                  RID = erpc:send_request(Node, erlang, send,
+                                          [self(), SendMe]),
+                  receive Msg -> erpc:check_response(Msg, RID)
+                  after Timeout -> ok
+                  end,
+                  %% Cleanup...
+                  try
+                      erpc:receive_response(RID, 0),
+                      ct:fail(unexpected)
+                  catch
+                      error:{erpc, timeout} -> ok
+                  end
+          end,
+    reqtmo_test(Config, Fun).
+
+send_request_against_old_node(Config) when is_list(Config) ->
+    case start_22_node(Config) of
+        {ok, Node22} ->
+            RID1 = erpc:send_request(Node22, erlang, node, []),
+            RID2 = erpc:send_request(Node22, erlang, node, []),
+            RID3 = erpc:send_request(Node22, erlang, node, []),
+            try
+                erpc:receive_response(RID1),
+                ct:fail(unexpected)
+            catch
+                error:{erpc, notsup} ->
+                    ok
+            end,
+            try
+                erpc:wait_response(RID2, infinity),
+                ct:fail(unexpected)
+            catch
+                error:{erpc, notsup} ->
+                    ok
+            end,
+            try
+                receive
+                    Msg ->
+                        erpc:check_response(Msg, RID3),
+                        ct:fail(unexpected)
+                end
+            catch
+                error:{erpc, notsup} ->
+                    ok
+            end,
+            stop_node(Node22),
+            ok;
+        _ ->
+	    {skipped, "No OTP 22 available"}
+    end.
+
+multicall(Config) ->
+    {ok, Node1} = start_node(Config),
+    {ok, Node2} = start_node(Config),
+    {Node3, Node3Res} = case start_22_node(Config) of
+                            {ok, N3} ->
+                                {N3, {error, {erpc, notsup}}};
+                            _ ->
+                                {ok, N3} = start_node(Config),
+                                stop_node(N3),
+                                {N3, {error, {erpc, noconnection}}}
+                        end,
+    {ok, Node4} = start_node(Config),
+    {ok, Node5} = start_node(Config),
+    stop_node(Node2),
+    
+    ThisNode = node(),
+    Nodes = [ThisNode, Node1, Node2, Node3, Node4, Node5],
+    
+    [{ok, ThisNode},
+     {ok, Node1},
+     {error, {erpc, noconnection}},
+     Node3Res,
+     {ok, Node4},
+     {ok, Node5}]
+        = erpc:multicall(Nodes, erlang, node, []),
+    
+    [BlingError,
+     BlingError,
+     {error, {erpc, noconnection}},
+     Node3Res,
+     BlingError,
+     BlingError]
+        = erpc:multicall(Nodes, ?MODULE, call_func2, [bling]),
+
+    {error, {exception,
+             bling,
+             [{?MODULE, call_func3, A, _},
+              {?MODULE, call_func2, 1, _}]}} = BlingError,
+    true = (A == 1) orelse (A == [bling]),
+
+    [{error, {exception, blong, [{erlang, error, [blong], _}]}},
+     {error, {exception, blong, [{erlang, error, [blong], _}]}},
+     {error, {erpc, noconnection}},
+     Node3Res,
+     {error, {exception, blong, [{erlang, error, [blong], _}]}},
+     {error, {exception, blong, [{erlang, error, [blong], _}]}}]
+        = erpc:multicall(Nodes, erlang, error, [blong]),
+
+    SlowNode4 = fun () ->
+                        case node() of
+                            Node4 ->
+                                receive after 1000 -> ok end,
+                                slow;
+                            ThisNode ->
+                                throw(fast);
+                            _ ->
+                                fast
+                           end
+                end,
+
+    Start1 = erlang:monotonic_time(),
+    [{throw, fast},
+     {ok, fast},
+     {error, {erpc, noconnection}},
+     Node3Res,
+     {error, {erpc, timeout}},
+     {ok, fast}]
+        = erpc:multicall(Nodes, erlang, apply, [SlowNode4, []], 500),
+
+    End1 = erlang:monotonic_time(),
+
+    Time1 = erlang:convert_time_unit(End1-Start1, native, millisecond),
+    io:format("Time1 = ~p~n",[Time1]),
+    true = Time1 >= 500,
+    true = Time1 =< 1000,
+
+    SlowThisNode = fun () ->
+                           case node() of
+                               ThisNode ->
+                                   receive after 1000 -> ok end,
+                                   slow;
+                               Node4 ->
+                                   throw(fast);
+                               Node5 ->
+                                   exit(fast);
+                               _ ->
+                                   fast
+                           end
+                   end,
+
+    Start2 = erlang:monotonic_time(),
+    [{error, {erpc, timeout}},
+     {ok, fast},
+     {error, {erpc, noconnection}},
+     Node3Res,
+     {throw, fast},
+     {exit, {exception, fast}}]
+        = erpc:multicall(Nodes, erlang, apply, [SlowThisNode, []], 500),
+
+    End2 = erlang:monotonic_time(),
+
+    Time2 = erlang:convert_time_unit(End2-Start2, native, millisecond),
+    io:format("Time2 = ~p~n",[Time2]),
+    true = Time2 >= 500,
+    true = Time2 =< 1000,
+
+    %% We should not get any stray messages due to timed out operations...
+    receive Msg -> ct:fail({unexpected, Msg})
+    after 1000 -> ok
+    end,
+
+    [{error, {erpc, noconnection}},
+     Node3Res,
+     {error, {erpc, noconnection}},
+     {error, {erpc, noconnection}}]
+        = erpc:multicall([Node2, Node3, Node4, Node5], erlang, halt, []),
+
+    stop_node(Node3),
+    case Node3Res of
+        {error, {erpc, notsup}} ->
+            {comment, "Tested against an OTP 22 node as well"};
+        _ ->
+            {comment, "No OTP 22 node available; i.e., only testing against current release"}
+    end.
+
+multicall_reqtmo(Config) when is_list(Config) ->
+    {ok, QuickNode1} = start_node(Config),
+    {ok, QuickNode2} = start_node(Config),
+    Fun = fun (Node, SendMe, Timeout) ->
+                  Me = self(),
+                  SlowSend = fun () ->
+                                     if node() == Node ->
+                                             Me ! SendMe,
+                                             done;
+                                        true ->
+                                             done
+                                     end
+                             end,
+                  [{ok, done},{error,{erpc,timeout}},{ok, done}]
+                      = erpc:multicall([QuickNode1, Node, QuickNode2],
+                                        erlang, apply, [SlowSend, []],
+                                        Timeout)
+          end,
+    Res = reqtmo_test(Config, Fun),
+    stop_node(QuickNode1),
+    stop_node(QuickNode2),
+    Res.
+
+timeout_limit(Config) when is_list(Config) ->
+    Node = node(),
+    MaxTmo = (1 bsl 32) - 1,
+    erlang:send_after(100, self(), dummy_message),
+    try
+        receive
+            M ->
+                M
+        after MaxTmo + 1 ->
+                ok
+        end,
+        ct:fail("The ?MAX_INT_TIMEOUT define in erpc.erl needs "
+                "to be updated to reflect max timeout value "
+                "in a receive/after...")
+    catch
+        error:timeout_value ->
+            ok
+    end,
+    Node = erpc:call(Node, erlang, node, [], MaxTmo),
+    try
+        erpc:call(node(), erlang, node, [], MaxTmo+1),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} ->
+            ok
+    end,
+    [{ok,Node}] = erpc:multicall([Node], erlang, node, [], MaxTmo),
+    try
+        erpc:multicall([Node], erlang, node, [], MaxTmo+1),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} ->
+            ok
+    end,
+    ReqId1 = erpc:send_request(Node, erlang, node, []),
+    Node = erpc:receive_response(ReqId1, MaxTmo),
+    ReqId2 = erpc:send_request(Node, erlang, node, []),
+    try
+        erpc:receive_response(ReqId2, MaxTmo+1),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} ->
+            ok
+    end,
+    ReqId3 = erpc:send_request(Node, erlang, node, []),
+    Node = erpc:receive_response(ReqId3, MaxTmo),
+    ReqId4 = erpc:send_request(Node, erlang, node, []),
+    try
+        erpc:receive_response(ReqId4, MaxTmo+1),
+        ct:fail(unexpected)
+    catch
+        error:{erpc, badarg} ->
+            ok
+    end,
+    ok.
+    
+
+%%%
+%%% Utility functions.
+%%%
+
+start_node(Config) ->
+    Name = list_to_atom(atom_to_list(?MODULE)
+			++ "-" ++ atom_to_list(proplists:get_value(testcase, Config))
+			++ "-" ++ integer_to_list(erlang:system_time(second))
+			++ "-" ++ integer_to_list(erlang:unique_integer([positive]))),
+    Pa = filename:dirname(code:which(?MODULE)),
+    test_server:start_node(Name, slave, [{args,  "-pa " ++ Pa}]).
+
+start_22_node(Config) ->
+    Rel = "22_latest",
+    case test_server:is_release_available(Rel) of
+	false ->
+            notsup;
+        true ->
+            Cookie = atom_to_list(erlang:get_cookie()),
+            Name = list_to_atom(atom_to_list(?MODULE)
+                                ++ "-" ++ atom_to_list(proplists:get_value(testcase, Config))
+                                ++ "-" ++ integer_to_list(erlang:system_time(second))
+                                ++ "-" ++ integer_to_list(erlang:unique_integer([positive]))),
+            Pa = filename:dirname(code:which(?MODULE)),
+	    test_server:start_node(Name,
+                                   peer,
+                                   [{args, "-pa " ++ Pa ++ " -setcookie "++Cookie},
+                                    {erl, [{release, Rel}]}])
+    end.
+
+stop_node(Node) ->
+    test_server:stop_node(Node).
+
+flush(L) ->
+    receive
+	M ->
+	    flush([M|L])
+    after 0 ->
+	    L
+    end.
+
+t() ->
+    [N | _] = string:tokens(atom_to_list(node()), "_"),
+    1000*list_to_integer(N).
+
+f() ->
+    timer:sleep(T=t()),
+    spawn(?MODULE, f2, []),
+    {hej,T,node()}.
+
+f2() ->
+    timer:sleep(500),
+    halt().

--- a/lib/kernel/test/seq_trace_SUITE.erl
+++ b/lib/kernel/test/seq_trace_SUITE.erl
@@ -1361,7 +1361,11 @@ start_tracer(Node) ->
                              Me ! Ref,
                              simple_tracer([], 0)
                      end),
-    receive Ref -> Pid end.
+    receive
+        Ref ->
+            unlink(Pid),
+            Pid
+    end.
            
 
 set_token_flags([]) ->

--- a/lib/observer/test/crashdump_helper.erl
+++ b/lib/observer/test/crashdump_helper.erl
@@ -152,6 +152,7 @@ dump_maps() ->
     Pid = spawn_link(F),
     receive
         {Pid,done} ->
+            unlink(Pid),
             {ok,Pid}
     end.
 
@@ -198,6 +199,7 @@ dump_persistent_terms() ->
     Pid = spawn_link(F),
     receive
         {Pid,done} ->
+            unlink(Pid),
             {ok,Pid}
     end.
 

--- a/lib/sasl/test/release_handler_SUITE_data/lib/many_mods-1.0/src/m.erl
+++ b/lib/sasl/test/release_handler_SUITE_data/lib/many_mods-1.0/src/m.erl
@@ -8,4 +8,5 @@ start(NProcs) ->
 			       receive stop -> Cs end
 		       end) ||
 	       _ <- lists:seq(1,NProcs)],
+    [unlink(Pid) || Pid <- Pids],
     {Modules,Pids}.

--- a/lib/sasl/test/release_handler_SUITE_data/lib/many_mods-1.1/src/m.erl
+++ b/lib/sasl/test/release_handler_SUITE_data/lib/many_mods-1.1/src/m.erl
@@ -8,4 +8,5 @@ start(NProcs) ->
 			       receive stop -> Cs end
 		       end) ||
 	       _ <- lists:seq(1,NProcs)],
+    [unlink(Pid) || Pid <- Pids],
     {Modules,Pids}.

--- a/lib/sasl/test/release_handler_SUITE_data/lib/many_mods-2.0/src/m.erl
+++ b/lib/sasl/test/release_handler_SUITE_data/lib/many_mods-2.0/src/m.erl
@@ -8,4 +8,5 @@ start(NProcs) ->
 			       receive stop -> Cs end
 		       end) ||
 	       _ <- lists:seq(1,NProcs)],
+    [unlink(Pid) || Pid <- Pids],
     {Modules,Pids}.


### PR DESCRIPTION
Rpc calls (and friends) utilizing the newly introduced distributed `spawn_request()` BIF when possible instead of communicating via the `rex` server. This removes `rex` as a scalability bottleneck for calls. It also removes the extra copying of the (potentially large) argument list via `rex` to the (by `rex` spawned) process actually executing the call.

<s>A number of new call functions (identified by the name ecall) has been added. The main purpose of this is making it easier to differentiate between returned result, uncaught exceptions, none-trapped exit signals, and rpc failures. The `rpc:ecall_send_request()`/`rpc:ecall_*_response()` functions also makes it possible to asynchronously handle call request/reply in situations which are not possible with the `rpc:async_call()`/`rpc:*yield()` functions. The `rpc:ecall_receive_response()` makes it possible to make asynchronous calls without getting stale messages in the message box in case of a timeout. No counterpart for receiving replies of `rpc:async_call()` exist for this. `rpc:ecall_wait_response()` polls and wait on the message queue for a reply which is similar to what `rpc:nb_yield()`/`rpc:yield()` does. `rpc:ecall_check_response()` checks if a user provided message is the reply. No counterpart for this for `rpc:async_call()` exist either.

`rpc:ecall()` similiar to `rpc:call()`:

* `rpc:ecall/4`
* `rpc:ecall/5`

`rpc:ecall_send_request()`, `rpc:ecall_wait_response/1`, ...  similiar to `rpc:async_call()`, `rpc:yield()`, ...:

* `rpc:ecall_send_request/4`
* `rpc:ecall_receive_response/1` <s>`ecall_wait_reply/1`</s>
* `rpc:ecall_receive_response/2` <s>`ecall_wait_reply/2`</s>
* `rpc:ecall_wait_response/1`<s>`ecall_poll_reply/1`</s>
* `rpc:ecall_wait_response/2`<s>`ecall_poll_reply/2`</s>
* `rpc:ecall_check_response/2`<s>`ecall_check_reply/2`</s>

`rpc:multi_ecall()` similiar to `rpc:multicall()`:
* `rpc:multi_ecall/4`
* `rpc:multi_ecall/5`

`rpc:block_ecall()` similiar to `rpc:block_call()`:
* `rpc:block_ecall/4`
* `rpc:block_ecall/5`</s>

A new module [`erpc`](http://erlang.org/~rickard/OTP-13450_OTP-15251/lib/kernel-6.5.1/doc/html/erpc.html) has been added. The main purpose of this is making it easier to differentiate between returned result, uncaught exceptions, none-trapped exit signals, and rpc failures. The `erpc:send_request()`/`erpc:*_response()` functions also makes it possible to asynchronously handle call request/reply in situations which are not possible with the `rpc:async_call()`/`rpc:*yield()` functions. The `erpc:receive_response()` makes it possible to make asynchronous calls without getting stale messages in the message box in case of a timeout. No counterpart for receiving replies of `rpc:async_call()` exist for this. `erpc:wait_response()` polls and wait on the message queue for a reply which is similar to what `rpc:nb_yield()`/`rpc:yield()` does. `erpc:check_response()` checks if a user provided message is the reply. No counterpart for this for `rpc:async_call()` exist either.

`erpc:call()` similiar to `rpc:call()`:

* [`erpc:call()`](http://erlang.org/~rickard/OTP-13450_OTP-15251/lib/kernel-6.5.1/doc/html/erpc.html#call-4)

`erpc:cast()` similiar to `rpc:cast()`:
* [`erpc:cast()`](http://erlang.org/~rickard/OTP-13450_OTP-15251/lib/kernel-6.5.1/doc/html/erpc.html#cast-4)

`erpc:send_request()`, `erpc:wait_response/1`, ...  similiar to `rpc:async_call()`, `rpc:yield()`, ...:

* [`erpc:send_request()`](http://erlang.org/~rickard/OTP-13450_OTP-15251/lib/kernel-6.5.1/doc/html/erpc.html#send_request-4)
* [`erpc:receive_response()`](http://erlang.org/~rickard/OTP-13450_OTP-15251/lib/kernel-6.5.1/doc/html/erpc.html#receive_response-1)
* [`erpc:wait_response()`](http://erlang.org/~rickard/OTP-13450_OTP-15251/lib/kernel-6.5.1/doc/html/erpc.html#wait_response-1)
* [`erpc:check_response()`](http://erlang.org/~rickard/OTP-13450_OTP-15251/lib/kernel-6.5.1/doc/html/erpc.html#check_response-2)

`erpc:multicall()` similiar to `rpc:multicall()`:
* [`erpc:multicall()`](http://erlang.org/~rickard/OTP-13450_OTP-15251/lib/kernel-6.5.1/doc/html/erpc.html#multicall-4)

EDIT 2020-02-19: renamed <s>`ecall_wait_reply/1`</s>, <s>`ecall_wait_reply/2`</s>, <s>`ecall_poll_reply/1`</s>, <s>`ecall_poll_reply/2`</s>, and <s>`ecall_check_reply/2`</s> as above.

EDIT 2020-02-20: Technical bord decided: Introduction of a new module `erpc` instead of new functions in `rpc`.