### PR TITLE
Add filelib:safe_relative_path/2

### DIFF
--- a/lib/stdlib/doc/src/filelib.xml
+++ b/lib/stdlib/doc/src/filelib.xml
@@ -307,5 +307,35 @@ filelib:wildcard("lib/**/*.{erl,hrl}")</code>
         marker="kernel:kernel_app#source_search_rules"><c>source_search_rules</c></seealso>.</p>
       </desc>
     </func>
+    <func>
+      <name name="safe_relative_path" arity="2" since="OTP 23.0"/>
+      <fsummary>Sanitize a relative path to avoid directory traversal attacks.</fsummary>
+      <desc>
+        <p>Sanitizes the relative path by eliminating ".." and "."
+        components to protect against directory traversal attacks.
+        Either returns the sanitized path name, or the atom
+        <c>unsafe</c> if the path is unsafe.
+        The path is considered unsafe in the following circumstances:</p>
+        <list type="bulleted">
+          <item><p>The path is not relative.</p></item>
+          <item><p>A ".." component would climb up above the root of
+          the relative path.</p></item>
+          <item><p>A symbolic link in the path points above the root
+          of the relative path.</p></item>
+        </list>
+        <p><em>Examples:</em></p>
+        <pre>
+1> <input>{ok, Cwd} = file:get_cwd().</input>
+...
+2> <input>filelib:safe_relative_path("dir/sub_dir/..", Cwd).</input>
+"dir"
+3> <input>filelib:safe_relative_path("dir/..", Cwd).</input>
+[]
+4> <input>filelib:safe_relative_path("dir/../..", Cwd).</input>
+unsafe
+5> <input>filelib:safe_relative_path("/abs/path", Cwd).</input>
+unsafe</pre>
+      </desc>
+    </func>
   </funcs>
 </erlref>

--- a/lib/stdlib/doc/src/filename.xml
+++ b/lib/stdlib/doc/src/filename.xml
@@ -570,6 +570,10 @@ true
           <item><p>A ".." component would climb up above the root of
           the relative path.</p></item>
         </list>
+        <warning>
+          <p>This function is deprecated. Use <seealso marker="filelib#safe_relative_path/2">
+          <c>filelib:safe_relative_path/2</c></seealso> instead for sanitizing paths.</p>
+        </warning>
         <p><em>Examples:</em></p>
         <pre>
 1> <input>filename:safe_relative_path("dir/sub_dir/..").</input>

--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -20,7 +20,7 @@
 -module(filename).
 
 -deprecated([{find_src,'_',"use filelib:find_source/1,3 instead"}]).
--deprecated([{safe_relative_path,'_',"use filelib:safe_relative_path/2instead"}]).
+-deprecated([{safe_relative_path,1,"use filelib:safe_relative_path/2 instead"}]).
 
 %% Purpose: Provides generic manipulation of filenames.
 %%

--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -20,6 +20,7 @@
 -module(filename).
 
 -deprecated([{find_src,'_',"use filelib:find_source/1,3 instead"}]).
+-deprecated([{safe_relative_path,'_',"use filelib:safe_relative_path/2instead"}]).
 
 %% Purpose: Provides generic manipulation of filenames.
 %%

--- a/lib/stdlib/test/filelib_SUITE.erl
+++ b/lib/stdlib/test/filelib_SUITE.erl
@@ -716,12 +716,24 @@ do_test_srp(RelPath) ->
     end.
 
 safe_relative_path_links(Config) ->
-    simple_test(Config),
-    inside_directory_test(Config),
-    nested_links_test(Config),
-    loop_test(Config),
-    loop_with_parent_test(Config),
-    revist_links_test(Config).
+    case check_symlink_support(Config) of
+        true ->
+            simple_test(Config),
+            inside_directory_test(Config),
+            nested_links_test(Config),
+            loop_test(Config),
+            loop_with_parent_test(Config),
+            revist_links_test(Config);
+        false ->
+            {skipped, "This platform/user can't create symlinks."}
+    end.
+
+check_symlink_support(Config) ->
+    BaseDir = ?config(priv_dir, Config),
+    Canary = filename:join(BaseDir, "symlink_canary"),
+    Link = filename:join(BaseDir, "symlink_canary_link"),
+    ok = file:write_file(Canary, <<"chirp">>),
+    ok =:= file:make_symlink(Canary, Link).
 
 simple_test(Config) ->
     BaseDir = ?config(priv_dir, Config),

--- a/lib/stdlib/test/filelib_SUITE.erl
+++ b/lib/stdlib/test/filelib_SUITE.erl
@@ -652,7 +652,7 @@ find_source_subdir(Config) when is_list(Config) ->
 
 safe_relative_path(Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
-    Root = filename:join(PrivDir, ?FUNCTION_NAME),
+    Root = filename:join(PrivDir, "filelib_safe_relative_path"),
     ok = file:make_dir(Root),
     ok = file:set_cwd(Root),
 

--- a/lib/stdlib/test/filename_SUITE.erl
+++ b/lib/stdlib/test/filename_SUITE.erl
@@ -886,7 +886,7 @@ t_nativename_bin(Config) when is_list(Config) ->
 
 safe_relative_path(Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
-    Root = filename:join(PrivDir, ?FUNCTION_NAME),
+    Root = filename:join(PrivDir, "filename_safe_relative_path"),
     ok = file:make_dir(Root),
     ok = file:set_cwd(Root),
 


### PR DESCRIPTION
This PR is a proposal to deprecate `filename:safe_relative_path/1` in favor of `filelib:safe_relative_path/2`.

The `filename` function does not consider symlinks so it is unsafe to use on any filesystem that supports symlinks. The new `filelib` function follows symlinks and ensures they do not escape the root of the relative path. It also detects loops in the symlinks to prevent DOS attacks.

If you want to keep the function I can amend the PR to instead add a warning about when it is dangerous to use it and point to the new `filelib` function. I wasn't sure what the appropriate module was for the new function, let me know if `filelib` is not the right place.