### PR TITLE
Don't keep stacktraces forever

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2120,8 +2120,9 @@ true</pre>
       <fsummary>Get the call stack back-trace of the last exception.</fsummary>
       <type name="stack_item"/>
       <desc>
-	<warning><p><c>erlang:get_stacktrace/0</c> is deprecated and will stop working
-	in a future release.</p></warning>
+	<warning><p><c>erlang:get_stacktrace/0</c> is deprecated and
+	will be removed in OTP 24. Starting from OTP 23,
+	<c>erlang:get_stacktrace/0</c> returns <c>[]</c>.</p></warning>
       <p>Instead of using <c>erlang:get_stacktrace/0</c> to retrieve
       the call stack back-trace, use the following syntax:</p>
 <pre>
@@ -2130,53 +2131,6 @@ catch
   Class:Reason:Stacktrace ->
    {Class,Reason,Stacktrace}
 end</pre>
-        <p><c>erlang:get_stacktrace/0</c> retrieves the call stack back-trace
-        (<em>stacktrace</em>) for an exception that has just been
-        caught in the calling process as a list of
-        <c>{<anno>Module</anno>,<anno>Function</anno>,<anno>Arity</anno>,<anno>Location</anno>}</c>
-        tuples. Field <c><anno>Arity</anno></c> in the first tuple can
-        be the argument list of that function call instead of an arity
-        integer, depending on the exception.</p>
-        <p>If there has not been any exceptions in a process, the
-          stacktrace is <c>[]</c>. After a code change for the process,
-          the stacktrace can also be reset to <c>[]</c>.</p>
-        <p>The stacktrace is the same data as operator <c>catch</c>
-          returns, for example:</p>
-        <pre>
-{'EXIT',{badarg,Stacktrace}} = catch abs(x)</pre>
-        <p><c><anno>Location</anno></c> is a (possibly empty) list
-          of two-tuples that
-          can indicate the location in the source code of the function.
-          The first element is an atom describing the type of
-          information in the second element. The following
-          items can occur:</p>
-        <taglist>
-          <tag><c>file</c></tag>
-          <item>The second element of the tuple is a string (list of
-            characters) representing the filename of the source file
-            of the function.
-          </item>
-          <tag><c>line</c></tag>
-          <item>The second element of the tuple is the line number
-            (an integer &gt; 0) in the source file
-            where the exception occurred or the function was called.
-          </item>
-        </taglist>
-        <warning><p>Developers should rely on stacktrace entries only for
-          debugging purposes.</p>
-          <p>The VM performs tail call optimization, which
-          does not add new entries to the stacktrace, and also limits stacktraces
-          to a certain depth. Furthermore, compiler options, optimizations and
-          future changes may add or remove stacktrace entries, causing any code
-          that expects the stacktrace to be in a certain order or contain specific
-          items to fail.</p>
-          <p>The only exception to this rule is <c>error:undef</c> which
-          guarantees to include the <anno>Module</anno>, <anno>Function</anno> and <anno>Arity</anno>
-          of the attempted function as the first stacktrace entry.</p>
-        </warning>	
-        <p>See also
-          <seealso marker="#error/1"><c>error/1</c></seealso> and
-          <seealso marker="#error/2"><c>error/2</c></seealso>.</p>
       </desc>
     </func>
 
@@ -5432,12 +5386,13 @@ RealSystem = system + MissedSystem</code>
           </item>
           <tag><c>{current_stacktrace, <anno>Stack</anno>}</c></tag>
           <item>
-            <p>Returns the current call stack back-trace (<em>stacktrace</em>)
-              of the process. The stack has the same format as returned by
-              <seealso marker="#get_stacktrace/0">
-              <c>erlang:get_stacktrace/0</c></seealso>. The depth of the
-              stacktrace is truncated according to the <c>backtrace_depth</c>
-              system flag setting.</p>
+            <p>Returns the current call stack back-trace
+            (<em>stacktrace</em>) of the process. The stack has the
+            same format as in the <c>catch</c> part of a
+            <c>try</c>. See <seealso
+            marker="doc/reference_manual:errors#stacktrace">The call-stack back trace (stacktrace)</seealso>.
+            The depth of the stacktrace is truncated according to the
+            <c>backtrace_depth</c> system flag setting.</p>
           </item>
           <tag><c>{dictionary, <anno>Dictionary</anno>}</c></tag>
           <item>

--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -1491,6 +1491,8 @@ terminate_proc(Process* c_p, Eterm Value)
     if (GET_EXC_CLASS(c_p->freason) == EXTAG_ERROR) {
         Value = add_stacktrace(c_p, Value, c_p->ftrace);
     }
+    c_p->ftrace = NIL;
+
     /* EXF_LOG is a primary exception flag */
     if (c_p->freason & EXF_LOG) {
 	int alive = erts_is_alive;

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1006,8 +1006,7 @@ BIF_RETTYPE hibernate_3(BIF_ALIST_3)
 
 BIF_RETTYPE get_stacktrace_0(BIF_ALIST_0)
 {
-    Eterm t = build_stacktrace(BIF_P, BIF_P->ftrace);
-    BIF_RET(t);
+    BIF_RET(NIL);
 }
 
 /**********************************************************************/

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -2575,13 +2575,17 @@ setup_rootset(Process *p, Eterm *objv, int nobj, Rootset *rootset)
 
     /*
      * The process may be garbage-collected while it is terminating.
-     * (fvalue contains the EXIT reason and ftrace the saved stack trace.)
+     * fvalue contains the EXIT reason.
      */
     if (is_not_immed(p->fvalue)) {
 	roots[n].v  = &p->fvalue;
 	roots[n].sz = 1;
 	n++;
     }
+
+    /*
+     * The raise/3 BIF will store the stacktrace in ftrace.
+     */
     if (is_not_immed(p->ftrace)) {
 	roots[n].v  = &p->ftrace;
 	roots[n].sz = 1;

--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -1073,6 +1073,7 @@ catch_end(Y) {
     $try_end($Y);
     if (is_non_value(r(0))) {
         c_p->fvalue = NIL;
+        c_p->ftrace = NIL;
         if (x(1) == am_throw) {
             r(0) = x(2);
         } else {
@@ -1106,6 +1107,7 @@ try_case(Y) {
     $try_end($Y);
     ASSERT(is_non_value(r(0)));
     c_p->fvalue = NIL;
+    c_p->ftrace = NIL;
     r(0) = x(1);
     x(1) = x(2);
     x(2) = x(3);

--- a/erts/emulator/hipe/hipe_bif2.c
+++ b/erts/emulator/hipe/hipe_bif2.c
@@ -193,5 +193,6 @@ BIF_RETTYPE hipe_bifs_llvm_fix_pinned_regs_0(BIF_ALIST_0)
 
 BIF_RETTYPE hipe_bifs_build_stacktrace_1(BIF_ALIST_1)
 {
+    BIF_P->ftrace = NIL;
     BIF_RET(build_stacktrace(BIF_P, BIF_ARG_1));
 }

--- a/erts/emulator/test/code_SUITE_data/call_purged_fun_tester.erl
+++ b/erts/emulator/test/code_SUITE_data/call_purged_fun_tester.erl
@@ -8,8 +8,7 @@
 do(Priv, Data, Type, Opts) ->
     try do_it(Priv, Data, Type, Opts)
     catch
-        C:E ->
-            ST = erlang:get_stacktrace(),
+        C:E:ST ->
             io:format("Caught exception from line ~p:\n~p\n",
                       [get(the_line), ST]),
             io:format("Message queue: ~p\n", [process_info(self(), messages)]),

--- a/erts/emulator/test/hipe_SUITE_data/trycatch_1.erl
+++ b/erts/emulator/test/hipe_SUITE_data/trycatch_1.erl
@@ -5,10 +5,9 @@ one_try_catch(Term) ->
     try
         trycatch_2:two(Term)
     catch
-        C:R ->
-            Stk = erlang:get_stacktrace(),
+        C:R:Stk ->
             {C,R,Stk}
     end.
 
 one_plain_catch(Term) ->
-    {catch trycatch_2:two(Term),erlang:get_stacktrace()}.
+    catch trycatch_2:two(Term).

--- a/erts/emulator/test/trace_local_SUITE.erl
+++ b/erts/emulator/test/trace_local_SUITE.erl
@@ -1111,12 +1111,14 @@ x_exc_body(ExcOpts, {M,F}=Func, Args, Apply) ->
             end,
             {value,Value}
     catch
-        Thrown when Nocatch ->
+        throw:Thrown:Stk when Nocatch ->
+            put(get_stacktrace, Stk),
             CR = {error,{nocatch,Thrown}},
             x_exc_exception(Rtt, M, F, Args, Arity, CR),
             expect({eft,{?MODULE,exc,2},CR}),
             CR;
-        Class:Reason ->
+        Class:Reason:Stk ->
+            put(get_stacktrace, Stk),
             CR = {Class,Reason},
             x_exc_exception(Rtt, M, F, Args, Arity, CR),
             expect({eft,{?MODULE,exc,2},CR}),
@@ -1157,7 +1159,8 @@ x_exc_exception(_Rtt, M, F, _, Arity, CR) ->
     expect({eft,{M,F,Arity},CR}).
 
 x_exc_stacktrace() ->
-    x_exc_stacktrace(erlang:get_stacktrace()).
+    x_exc_stacktrace(get(get_stacktrace)).
+
 %% Truncate stacktrace to below exc/2
 x_exc_stacktrace([{?MODULE,x_exc,4,_}|_]) -> [];
 x_exc_stacktrace([{?MODULE,x_exc_func,4,_}|_]) -> [];

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -469,20 +469,8 @@ expr(#c_try{anno=A,arg=E0,vars=Vs0,body=B0,evars=Evs0,handler=H0}=Try, _, Sub0) 
 	false ->
 	    {Evs1,Sub2} = var_list(Evs0, Sub0),
 	    H1 = body(H0, value, Sub2),
-	    H2 = opt_try_handler(H1, lists:last(Evs1)),
-	    Try#c_try{arg=E1,vars=Vs1,body=B1,evars=Evs1,handler=H2}
+	    Try#c_try{arg=E1,vars=Vs1,body=B1,evars=Evs1,handler=H1}
     end.
-
-%% Attempts to convert old erlang:get_stacktrace/0 calls into the new
-%% three-argument catch, with possibility of further optimisations.
-opt_try_handler(#c_call{anno=A,module=#c_literal{val=erlang},name=#c_literal{val=get_stacktrace},args=[]}, Var) ->
-    #c_primop{anno=A,name=#c_literal{val=build_stacktrace},args=[Var]};
-opt_try_handler(#c_case{clauses=Cs0} = Case, Var) ->
-    Cs = [C#c_clause{body=opt_try_handler(B, Var)} || #c_clause{body=B} = C <- Cs0],
-    Case#c_case{clauses=Cs};
-opt_try_handler(#c_let{arg=Arg} = Let, Var) ->
-    Let#c_let{arg=opt_try_handler(Arg, Var)};
-opt_try_handler(X, _) -> X.
 
 %% If a fun or its application is used as an argument, then it's unsafe to
 %% handle it in effect context as the side-effects may rely on its return

--- a/lib/compiler/test/trycatch_SUITE.erl
+++ b/lib/compiler/test/trycatch_SUITE.erl
@@ -1079,7 +1079,7 @@ stacktrace(_Config) ->
         error:{badmatch,_}:Stk2 ->
             [{?MODULE,stacktrace_2,0,_},
              {?MODULE,stacktrace,1,_}|_] = Stk2,
-            Stk2 = erlang:get_stacktrace(),
+            [] = erlang:get_stacktrace(),
             ok
     end,
 
@@ -1087,7 +1087,7 @@ stacktrace(_Config) ->
         stacktrace_3(a, b)
     catch
         error:function_clause:Stk3 ->
-            Stk3 = erlang:get_stacktrace(),
+            [] = erlang:get_stacktrace(),
             case lists:module_info(native) of
                 false ->
                     [{lists,prefix,[a,b],_}|_] = Stk3;
@@ -1108,14 +1108,16 @@ stacktrace_1(X, C1, Y) ->
             C1 -> value1
         catch
             C1:D1:Stk1 ->
-                Stk1 = erlang:get_stacktrace(),
+                [] = erlang:get_stacktrace(),
                 {caught1,D1,Stk1}
         after
             foo(Y)
         end of
         V2 -> {value2,V2}
     catch
-        C2:D2:Stk2 -> {caught2,{C2,D2},Stk2=erlang:get_stacktrace()}
+        C2:D2:Stk2 ->
+            [] = erlang:get_stacktrace(),
+            {caught2,{C2,D2},Stk2}
     end.
 
 stacktrace_2() ->
@@ -1160,12 +1162,10 @@ nested_stacktrace_1({X1,C1,V1}, {X2,C2,V2}) ->
         V1 -> value1
     catch
         C1:V1:S1 ->
-            S1 = erlang:get_stacktrace(),
             T2 = try foo(X2) of
                      V2 -> value2
                  catch
                      C2:V2:S2 ->
-                         S2 = erlang:get_stacktrace(),
                          {caught2,S2}
                  end,
             {caught1,S1,T2}

--- a/lib/debugger/src/dbg_iload.erl
+++ b/lib/debugger/src/dbg_iload.erl
@@ -438,8 +438,6 @@ expr({'fun',Anno,{function,M,F,A}}, _Lc) ->
     {make_ext_fun,ln(Anno),MFA};
 expr({call,Anno,{remote,_,{atom,_,erlang},{atom,_,self}},[]}, _Lc) ->
     {dbg,ln(Anno),self,[]};
-expr({call,Anno,{remote,_,{atom,_,erlang},{atom,_,get_stacktrace}},[]}, _Lc) ->
-    {dbg,ln(Anno),get_stacktrace,[]};
 expr({call,Anno,{remote,_,{atom,_,erlang},{atom,_,throw}},[_]=As}, _Lc) ->
     {dbg,ln(Anno),throw,expr_list(As)};
 expr({call,Anno,{remote,_,{atom,_,erlang},{atom,_,error}},[_]=As}, _Lc) ->

--- a/lib/debugger/test/int_eval_SUITE_data/stacktrace.erl
+++ b/lib/debugger/test/int_eval_SUITE_data/stacktrace.erl
@@ -3,10 +3,15 @@
 
 ?MODULE() ->
     OldDepth = erlang:system_flag(backtrace_depth, 32),
-    done = (catch do_try()),
-    Stk = trim(erlang:get_stacktrace()),
-    erlang:system_flag(backtrace_depth, OldDepth),
-    {done,Stk}.
+    try
+        do_try()
+    catch
+        throw:done:Stk0 ->
+            Stk = trim(Stk0),
+            {done,Stk}
+    after
+        erlang:system_flag(backtrace_depth, OldDepth)
+    end.
 
 trim([{int_eval_SUITE,_,_,_}|_]) ->
     [];

--- a/lib/debugger/test/line_number_SUITE.erl
+++ b/lib/debugger/test/line_number_SUITE.erl
@@ -90,8 +90,8 @@ close_calls(Where) ->				%Line 86
 	call2(),				%Line 90
 	call3(),				%Line 91
 	no_crash				%Line 92
-    catch error:crash ->
-	    erlang:get_stacktrace()		%Line 94
+    catch error:crash:Stk ->
+	    Stk                                 %Line 94
     end.					%Line 95
 
 call1() ->					%Line 97

--- a/lib/dialyzer/test/small_SUITE_data/results/stacktrace
+++ b/lib/dialyzer/test/small_SUITE_data/results/stacktrace
@@ -1,5 +1,5 @@
 
 stacktrace.erl:11: The pattern {'a', 'b'} can never match the type [{atom(),atom(),[any()] | byte(),[{'file',string()} | {'line',pos_integer()}]}]
 stacktrace.erl:19: The pattern ['a', 'b'] can never match the type [{atom(),atom(),[any()] | byte(),[{'file',string()} | {'line',pos_integer()}]}]
-stacktrace.erl:44: The pattern {'a', 'b'} can never match the type [{atom(),atom(),[any()] | byte(),[{'file',string()} | {'line',pos_integer()}]}]
-stacktrace.erl:53: The pattern ['a', 'b'] can never match the type [{atom(),atom(),[any()] | byte(),[{'file',string()} | {'line',pos_integer()}]}]
+stacktrace.erl:43: The pattern {'a', 'b'} can never match the type [{atom(),atom(),[any()] | byte(),[{'file',string()} | {'line',pos_integer()}]}]
+stacktrace.erl:51: The pattern ['a', 'b'] can never match the type [{atom(),atom(),[any()] | byte(),[{'file',string()} | {'line',pos_integer()}]}]

--- a/lib/dialyzer/test/small_SUITE_data/src/stacktrace.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/stacktrace.erl
@@ -39,8 +39,7 @@ t4() ->
 s1() ->
     try foo:bar()
     catch
-        E:P ->
-            S = erlang:get_stacktrace(),
+        E:P:S ->
             {a,b} = S, % can never match
             {E, P}
     end.
@@ -48,8 +47,7 @@ s1() ->
 s2() ->
     try foo:bar()
     catch
-        E:P ->
-            S = erlang:get_stacktrace(),
+        E:P:S ->
             [a,b] = S, % can never match
             {E, P}
     end.
@@ -57,8 +55,7 @@ s2() ->
 s3() ->
     try foo:bar()
     catch
-        E:P ->
-            S = erlang:get_stacktrace(),
+        E:P:S ->
             [{m,f,[],[]}] = S,
             {E, P}
     end.
@@ -66,8 +63,7 @@ s3() ->
 s4() ->
     try foo:bar()
     catch
-        E:P ->
-            S = erlang:get_stacktrace(),
+        E:P:S ->
             [{m,f,1,[{file,"tjo"},{line,95}]}] = S,
             {E, P}
     end.

--- a/lib/hipe/icode/hipe_beam_to_icode.erl
+++ b/lib/hipe/icode/hipe_beam_to_icode.erl
@@ -2336,9 +2336,8 @@ catch_handler('catch', [TagVar,ValueVar,TraceVar], OldCatchLbl) ->
 				       ValueVar]),
    hipe_icode:mk_goto(Cont),
    ErrorLbl,
-   %% We use the trace variable to hold the symbolic trace. Its previous
-   %% value is just that in p->ftrace, so get_stacktrace() works fine.
-   hipe_icode:mk_call([TraceVar],erlang,get_stacktrace,[],remote),
+   %% We use the trace variable to hold the symbolic trace.
+   hipe_icode:mk_primop([TraceVar],build_stacktrace,[TraceVar]),
    hipe_icode:mk_primop([ValueVar],mktuple, [ValueVar, TraceVar]),
    hipe_icode:mk_goto(hipe_icode:label_name(ExitLbl)),
    OldCatchLbl,  % normal execution paths must go through end_try

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -773,11 +773,11 @@ post_204(Config) ->
 	    ct:fail({connect_error, ConnectError,
 		     [SockType, Host, Port, TranspOpts]})
     catch
-	T:E ->
+	T:E:Stk ->
 	    ct:fail({connect_failure,
 		     [{type,       T},
 		      {error,      E},
-		      {stacktrace, erlang:get_stacktrace()},
+		      {stacktrace, Stk},
 		      {args,       [SockType, Host, Port, TranspOpts]}]})
     end.
 

--- a/lib/inets/test/httpd_test_lib.erl
+++ b/lib/inets/test/httpd_test_lib.erl
@@ -119,11 +119,11 @@ verify_request(SocketType, Host, Port, TranspOpts, Node, RequestStr, Options, Ti
 	    ct:fail({connect_error, ConnectError, 
 		     [SocketType, Host, Port, TranspOpts]})
     catch
-	T:E ->
+	T:E:Stk ->
 	    ct:fail({connect_failure, 
 		     [{type,       T}, 
 		      {error,      E}, 
-		      {stacktrace, erlang:get_stacktrace()}, 
+		      {stacktrace, Stk},
 		      {args,       [SocketType, Host, Port, TranspOpts]}]}) 
     end.
 
@@ -136,11 +136,11 @@ verify_request_N(SocketType, Host, Port, TranspOpts, Node, RequestStr, Options, 
 	    ct:fail({connect_error, ConnectError, 
 		     [SocketType, Host, Port, TranspOpts]})
     catch
-	T:E ->
+	T:E:Stk ->
 	    ct:fail({connect_failure, 
 		     [{type,       T}, 
 		      {error,      E}, 
-		      {stacktrace, erlang:get_stacktrace()}, 
+		      {stacktrace, Stk},
 		      {args,       [SocketType, Host, Port, TranspOpts]}]}) 
     end.
 

--- a/system/doc/reference_manual/errors.xml
+++ b/system/doc/reference_manual/errors.xml
@@ -115,6 +115,7 @@
       error.</p>
 
       <section>
+	<marker id="stacktrace"></marker>
 	<title>The call-stack back trace (stacktrace)</title>
         <p>The stack back-trace (<em>stacktrace</em>) is a list of
           <c>{Module,Function,Arity,Location}</c>


### PR DESCRIPTION
The `erlang:get_stacktrace/0` BIF retrieves the stacktrace from
the previous error in the process. The problem is that the very
existence of `erlang:get_stacktrace/0` means that the stacktrace
and potentially function arguments must be kept indefinitely.

Therefore, in OTP 21, the `erlang:get_stacktrace/0` BIF was deprecated
and the syntax of try/catch extended to allow matching out the
stacktrace directly.

This commit changes `erlang:get_stacktrace/0` for OTP 23 to always
return an empty list (`[]`) and eliminates the need to keep the
stacktrace forever.

`erlang:get_stacktrace/0` is scheduled for removal in OTP 24.