### PR TITLE
Use cerl_sets where appropriate in beam_ssa_bool

### DIFF
--- a/lib/compiler/src/beam_ssa_bool.erl
+++ b/lib/compiler/src/beam_ssa_bool.erl
@@ -185,7 +185,7 @@ pre_opt(Blocks, Count) ->
     Sub = maps:remove(uses, Sub1),
 
     %% Now do the actual optimizations.
-    Reached = gb_sets:singleton(hd(Top)),
+    Reached = cerl_sets:from_list([hd(Top)]),
     pre_opt(Top, Sub, Reached, Count, Blocks).
 
 -spec get_phi_info(Ls, Blocks, Sub0) -> Sub when
@@ -265,7 +265,7 @@ get_phi_info_single_use(Var, Sub) ->
 
 -spec pre_opt(Ls, Sub, Reached, Count0, Blocks0) -> {Blocks,Count} when
       Ls :: [beam_ssa:label()],
-      Reached :: gb_sets:set(beam_ssa:label()),
+      Reached :: cerl_sets:set(beam_ssa:label()),
       Count0 :: beam_ssa:label(),
       Blocks0 :: beam_ssa:block_map(),
       Sub :: pre_sub_map(),
@@ -273,7 +273,7 @@ get_phi_info_single_use(Var, Sub) ->
       Blocks :: beam_ssa:block_map().
 
 pre_opt([L|Ls], Sub0, Reached0, Count0, Blocks) ->
-    case gb_sets:is_member(L, Reached0) of
+    case cerl_sets:is_element(L, Reached0) of
         false ->
             %% This block will never be reached.
             pre_opt(Ls, Sub0, Reached0, Count0, maps:remove(L, Blocks));
@@ -290,14 +290,14 @@ pre_opt([L|Ls], Sub0, Reached0, Count0, Blocks) ->
                     Br = Br0#b_br{bool=Bool},
                     Blk = Blk0#b_blk{is=Is++[Test],last=Br},
                     Successors = beam_ssa:successors(Blk),
-                    Reached = gb_sets:union(Reached0,
-                                            gb_sets:from_list(Successors)),
+                    Reached = cerl_sets:union(Reached0,
+                                              cerl_sets:from_list(Successors)),
                     pre_opt(Ls, Sub, Reached, Count, Blocks#{L:=Blk});
                 Last ->
                     Blk = Blk0#b_blk{is=Is,last=Last},
                     Successors = beam_ssa:successors(Blk),
-                    Reached = gb_sets:union(Reached0,
-                                            gb_sets:from_list(Successors)),
+                    Reached = cerl_sets:union(Reached0,
+                                              cerl_sets:from_list(Successors)),
                     pre_opt(Ls, Sub, Reached, Count0, Blocks#{L:=Blk})
             end
     end;
@@ -306,7 +306,7 @@ pre_opt([], _, _, Count, Blocks) ->
 
 pre_opt_is([#b_set{op=phi,dst=Dst,args=Args0}=I0|Is], Reached, Sub0, Acc) ->
     Args1 = [{Val,From} || {Val,From} <- Args0,
-                           gb_sets:is_member(From, Reached)],
+                           cerl_sets:is_element(From, Reached)],
     Args = sub_args(Args1, Sub0),
     case all_same(Args) of
         true ->
@@ -1538,16 +1538,16 @@ del_out_edges(V, G) ->
     beam_digraph:del_edges(G, beam_digraph:out_edges(G, V)).
 
 covered(From, To, G) ->
-    Seen0 = gb_sets:empty(),
+    Seen0 = cerl_sets:new(),
     {yes,Seen} = covered_1(From, To, G, Seen0),
-    gb_sets:to_list(Seen).
+    cerl_sets:to_list(Seen).
 
 covered_1(To, To, _G, Seen) ->
     {yes,Seen};
 covered_1(From, To, G, Seen0) ->
     Vs0 = beam_digraph:out_neighbours(G, From),
-    Vs = [V || V <- Vs0, not gb_sets:is_member(V, Seen0)],
-    Seen = gb_sets:union(gb_sets:from_list(Vs), Seen0),
+    Vs = [V || V <- Vs0, not cerl_sets:is_element(V, Seen0)],
+    Seen = cerl_sets:union(cerl_sets:from_list(Vs), Seen0),
     case Vs of
         [] ->
             no;


### PR DESCRIPTION
This speeds up the pass in roughly 20%.

Before:

    FUNCTION                                         CALLS        %     TIME  [uS / CALLS]
    --------                                         -----  -------     ----  [----------]
    gen:'-call/4-fun-0-'/4                               1     0.00        0  [      0.00]
    gen:call/4                                           1     0.00        1  [      1.00]
    gen:do_for_proc/2                                    1     0.00        1  [      1.00]
    beam_ssa_bool:module/2                               1     0.00        1  [      1.00]
    beam_ssa:uses/1                                      9     0.00        1  [      0.11]
    erlang:whereis/1                                     1     0.00        1  [      1.00]
    erlang:make_tuple/2                                  9     0.00        1  [      0.11]
    gen_server:call/3                                    1     0.00        1  [      1.00]
    erlang:make_tuple/2                                  9     0.00        1  [      0.11]
    erlang:whereis/1                                     1     0.00        1  [      1.00]
    gen:do_call/4                                        1     0.00        2  [      2.00]
    c:appcall/4                                          1     0.00        2  [      2.00]
    compile:'-select_passes/2-anonymous-2-'/3            1     0.00        2  [      2.00]
    lists:usplit_2_1/6                                   9     0.00        3  [      0.33]
    erlang:send/3                                        1     0.00        3  [      3.00]
    erlang:send/3                                        1     0.00        3  [      3.00]
    lists:usplit_2/5                                    22     0.00        4  [      0.18]
    sofs:rel/3                                           9     0.00        4  [      0.44]
    erlang:monitor/2                                     1     0.00        4  [      4.00]
    erlang:monitor/2                                     1     0.00        4  [      4.00]
    sofs:to_external/1                                   9     0.00        5  [      0.56]
    sofs:rel2family/1                                    9     0.00        5  [      0.56]
    beam_ssa:fold_rpo/4                                  9     0.00        5  [      0.56]
    erlang:demonitor/2                                   1     0.00        5  [      5.00]
    erlang:demonitor/2                                   1     0.00        5  [      5.00]
    beam_ssa_bool:pre_is_arg_bool/2                     33     0.00        6  [      0.18]
    gb_sets:singleton/1                                 23     0.00        6  [      0.26]
    beam_ssa:uses/2                                      9     0.00        6  [      0.67]
    sofs:rel2fam/1                                       9     0.00        7  [      0.78]
    lists:rmerge3_21_3/6                                51     0.00       11  [      0.22]
    beam_ssa:rpo/1                                      41     0.00       11  [      0.27]
    beam_ssa_bool:function/1                            23     0.00       12  [      0.52]
    beam_ssa_bool:pre_are_args_bool/2                   33     0.00       12  [      0.36]
    cerl_sets:new/0                                     50     0.00       14  [      0.28]
    lists:rmerge3_12_3/6                                67     0.00       14  [      0.21]
    beam_ssa_bool:pre_eval_op/2                         33     0.00       14  [      0.42]
    sofs:relation/1                                      9     0.00       14  [      1.56]
    maps:remove/2                                       23     0.00       15  [      0.65]
    maps:to_list/1                                      32     0.00       15  [      0.47]
    maps:remove/2                                       23     0.00       15  [      0.65]
    beam_ssa_bool:'-module/2-lc$^0/1-0-'/1              24     0.00       20  [      0.83]
    gb_sets:union_2/3                                  119     0.00       21  [      0.18]
    beam_ssa:predecessors/1                              9     0.00       27  [      3.00]
    beam_ssa:dominators/1                                9     0.00       27  [      3.00]
    beam_ssa:rpo/2                                      41     0.00       31  [      0.76]
    beam_ssa_bool:pre_opt/2                             23     0.00       40  [      1.74]
    gb_sets:balance_revlist/2                          119     0.00       44  [      0.37]
    lists:merge3_2/6                                   252     0.00       61  [      0.24]
    beam_ssa_bool:opt_function/1                        23     0.00       62  [      2.70]
    lists:merge3_1/6                                   211     0.00       64  [      0.30]
    lists:rmerge3_2/6                                  371     0.00      101  [      0.27]
    maps:to_list_internal/1                            211     0.00      118  [      0.56]
    lists:merge3_21_3/6                                710     0.00      132  [      0.19]
    lists:split_2_1/6                                  392     0.00      148  [      0.38]
    gb_sets:push/2                                    1795     0.00      274  [      0.15]
    lists:rmerge2_2/5                                  710     0.00      281  [      0.40]
    lists:split_2/5                                   1263     0.00      400  [      0.32]
    lists:merge2_1/4                                  1967     0.00      401  [      0.20]
    lists:mergel/2                                    1181     0.01      440  [      0.37]
    lists:split_1_1/6                                 1339     0.01      619  [      0.46]
    gb_sets:union_2/4                                 4765     0.01      822  [      0.17]
    lists:rmergel/2                                   1483     0.01      886  [      0.60]
    lists:sort/1                                       849     0.01     1046  [      1.23]
    lists:merge2_2/5                                  6396     0.01     1227  [      0.19]
    lists:rmerge3_1/6                                 9044     0.03     2172  [      0.24]
    lists:rmerge2_1/4                                11166     0.03     2173  [      0.19]
    lists:umerge2_1/5                                10821     0.03     2220  [      0.21]
    lists:umergel/3                                   5784     0.03     2307  [      0.40]
    gb_sets:balance_revlist_1/2                       7355     0.03     2459  [      0.33]
    lists:last/1                                     23673     0.05     3769  [      0.16]
    lists:rumergel/3                                 13631     0.06     4908  [      0.36]
    lists:rumerge2_2/5                               26367     0.07     5438  [      0.21]
    erl_internal:bool_op/2                           35460     0.07     5498  [      0.16]
    erl_internal:new_type_test/2                     35482     0.07     5782  [      0.16]
    erl_internal:comp_op/2                           35526     0.07     5839  [      0.16]
    lists:umerge2_2/4                                34607     0.08     6615  [      0.19]
    lists:umerge3_12_3/6                             34623     0.08     6933  [      0.20]
    beam_ssa:dom_intersection/3                      24081     0.08     6980  [      0.29]
    gb_sets:balance/2                                21183     0.09     7125  [      0.34]
    beam_ssa:'-uses/2-anonymous-0-'/3                47341     0.09     7346  [      0.16]
    beam_ssa:dom_intersection/2                      47332     0.09     7483  [      0.16]
    lists:rumerge2_1/4                               36990     0.09     7795  [      0.21]
    lists:reverse/2                                  36328     0.10     8443  [      0.23]
    lists:reverse/2                                  36328     0.10     8443  [      0.23]
    lists:rumerge3_21_3/7                            38755     0.10     8477  [      0.22]
    lists:rumerge3_12_3/7                            40238     0.10     8590  [      0.21]
    erts_internal:map_next/3                           297     0.11     8933  [     30.08]
    erts_internal:map_next/3                           297     0.11     8933  [     30.08]
    lists:last/2                                     47364     0.11     9109  [      0.19]
    lists:usplit_1_1/6                               40574     0.12     9507  [      0.23]
    beam_ssa_bool:pre_is_safe_bool/2                 61459     0.13    10472  [      0.17]
    beam_ssa:normalize/1                             61496     0.14    11160  [      0.18]
    lists:split_1/5                                  37819     0.14    11221  [      0.30]
    lists:umerge3_21_3/6                             61052     0.15    12416  [      0.20]
    sofs:rel/4                                       71401     0.15    12731  [      0.18]
    maps:from_list/1                                    41     0.17    13642  [    332.73]
    maps:from_list/1                                    41     0.17    13642  [    332.73]
    lists:usplit_1/5                                 72451     0.17    14263  [      0.20]
    beam_ssa:'-predecessors/1-lc$^0/1-0-'/1          47351     0.17    14350  [      0.30]
    sofs:rel2fam/4                                   71392     0.19    15689  [      0.22]
    beam_ssa:number/2                                47350     0.20    16152  [      0.34]
    lists:umerge3_2/7                                78928     0.22    18033  [      0.23]
    lists:umerge3_1/7                                81359     0.23    19290  [      0.24]
    beam_ssa:'-dominators/1-lc$^0/1-0-'/2            47350     0.25    20981  [      0.44]
    gb_sets:mk_set/2                                122875     0.25    21065  [      0.17]
    beam_ssa:fold_uses_block/3                       47341     0.26    21644  [      0.46]
    gb_sets:to_list_1/1                             144296     0.28    22767  [      0.16]
    lists:reverse/1                                 123012     0.32    26309  [      0.21]
    lists:rumerge3_2/7                              119231     0.33    26911  [      0.23]
    beam_ssa:'-predecessors/1-lc$^1/1-1-'/3         118734     0.36    29962  [      0.25]
    lists:rumerge3_1/6                              147275     0.38    31377  [      0.21]
    beam_ssa:fold_rpo_1/4                            47350     0.40    32682  [      0.69]
    ordsets:from_list/1                             217185     0.42    34780  [      0.16]
    lists:usort/1                                   217194     0.45    36878  [      0.17]
    beam_ssa_bool:bool_opt/3                         47350     0.45    37230  [      0.79]
    beam_ssa:dom_intersection_1/3                   165489     0.47    38899  [      0.24]
    gb_sets:from_list/1                             122994     0.47    39096  [      0.32]
    beam_ssa:'-dominators_1/3-lc$^0/1-0-'/2         118724     0.48    39881  [      0.34]
    gb_sets:insert/2                                121586     0.49    40337  [      0.33]
    gb_sets:union/2                                 122994     0.49    40735  [      0.33]
    gb_sets:from_ordset/1                           122994     0.51    41930  [      0.34]
    beam_ssa_bool:interesting_defs/2                123024     0.52    43075  [      0.35]
    gb_sets:balance_list/2                          144177     0.54    44284  [      0.31]
    beam_ssa:dominators_1/3                          47341     0.55    45672  [      0.96]
    gb_sets:union/4                                 122994     0.58    48318  [      0.39]
    gb_sets:is_member/2                             306833     0.59    48412  [      0.16]
    beam_ssa:used/1                                 141532     0.60    49221  [      0.35]
    beam_ssa_bool:get_phi_info_instr/3              225353     0.61    50636  [      0.22]
    maps:get/3                                      145427     0.68    56239  [      0.39]
    beam_ssa_bool:is_bool_expr/1                    181657     0.69    57157  [      0.31]
    gb_sets:add/2                                   183839     0.71    58414  [      0.32]
    beam_ssa_bool:do_sub_arg/2                      352291     0.77    63492  [      0.18]
    beam_ssa_bool:interesting_defs_is/3             348361     0.81    66539  [      0.19]
    beam_ssa:'-fold_uses_block/3-anonymous-1-'/3    141532     0.88    72661  [      0.51]
    beam_ssa_bool:pre_opt_terminator/3              122994     0.89    73596  [      0.60]
    beam_ssa_bool:get_phi_info/3                    123017     0.94    77721  [      0.63]
    gb_sets:union_1/2                               306714     0.95    78274  [      0.26]
    erlang:setelement/3                             328744     0.95    78663  [      0.24]
    erlang:setelement/3                             328744     0.95    78663  [      0.24]
    beam_ssa:'-successors/1-lc$^0/1-0-'/1           177784     1.00    82767  [      0.47]
    beam_ssa:'-fold_uses_block/3-anonymous-0-'/4    145427     1.03    85503  [      0.59]
    maps:put/3                                      145449     1.07    88167  [      0.61]
    maps:put/3                                      145449     1.07    88167  [      0.61]
    beam_ssa_bool:get_phi_info_is/3                 348347     1.22   100639  [      0.29]
    beam_ssa:used_args/1                            325321     1.22   101136  [      0.31]
    erlang:max/2                                    670656     1.24   102468  [      0.15]
    lists:foldl/3                                   428491     1.29   106661  [      0.25]
    cerl_sets:is_element/2                          399489     1.40   116097  [      0.29]
    beam_ssa_bool:sub_args/2                        225353     1.45   119583  [      0.53]
    beam_ssa_bool:sub_arg/2                         599367     1.53   126517  [      0.21]
    cerl_sets:add_element/2                         265017     1.72   142411  [      0.54]
    beam_ssa:successors/1                           435353     1.75   144641  [      0.33]
    beam_ssa_bool:'-sub_args/2-lc$^0/1-0-'/2        496081     2.03   167717  [      0.34]
    beam_ssa_bool:pre_opt_is/4                      348347     2.99   246736  [      0.71]
    beam_ssa_bool:pre_opt/5                         123017     3.44   284330  [      2.31]
    beam_ssa:rpo_1/4                                664556     4.89   404437  [      0.61]
    gb_sets:count/1                                1164841     5.09   420674  [      0.36]
    gb_sets:balance_list_1/2                       1559839     6.47   534866  [      0.34]
    gb_sets:to_list/2                              2725254     7.61   629038  [      0.23]
    gb_sets:is_member_1/2                          6662288    12.48  1031726  [      0.15]
    gb_sets:insert_1/3                             3143270    13.47  1113025  [      0.35]
    --------------------------------------------  --------  -------  -------  [----------]
    Total:                                        28465162  100.00%  8265674  [      0.29]

After:

    FUNCTION                                         CALLS        %     TIME  [uS / CALLS]
    --------                                         -----  -------     ----  [----------]
    gen:do_for_proc/2                                    1     0.00        0  [      0.00]
    lists:usplit_2_1/6                                   9     0.00        0  [      0.00]
    gen:call/4                                           1     0.00        1  [      1.00]
    gen:'-call/4-fun-0-'/4                               1     0.00        1  [      1.00]
    beam_ssa_bool:module/2                               1     0.00        1  [      1.00]
    erlang:whereis/1                                     1     0.00        1  [      1.00]
    gen_server:call/3                                    1     0.00        1  [      1.00]
    erlang:whereis/1                                     1     0.00        1  [      1.00]
    c:appcall/4                                          1     0.00        2  [      2.00]
    erlang:monitor/2                                     1     0.00        2  [      2.00]
    erlang:make_tuple/2                                  9     0.00        2  [      0.22]
    compile:'-select_passes/2-anonymous-2-'/3            1     0.00        2  [      2.00]
    erlang:monitor/2                                     1     0.00        2  [      2.00]
    erlang:make_tuple/2                                  9     0.00        2  [      0.22]
    gen:do_call/4                                        1     0.00        3  [      3.00]
    sofs:to_external/1                                   9     0.00        3  [      0.33]
    erlang:send/3                                        1     0.00        3  [      3.00]
    erlang:send/3                                        1     0.00        3  [      3.00]
    sofs:rel2family/1                                    9     0.00        4  [      0.44]
    beam_ssa:uses/1                                      9     0.00        4  [      0.44]
    erlang:demonitor/2                                   1     0.00        4  [      4.00]
    erlang:demonitor/2                                   1     0.00        4  [      4.00]
    beam_ssa_bool:pre_is_arg_bool/2                     33     0.00        5  [      0.15]
    beam_ssa:uses/2                                      9     0.00        5  [      0.56]
    sofs:rel2fam/1                                       9     0.00        6  [      0.67]
    beam_ssa_bool:function/1                            23     0.00        7  [      0.30]
    beam_ssa:fold_rpo/4                                  9     0.00        7  [      0.78]
    lists:usplit_2/5                                    22     0.00        8  [      0.36]
    sofs:rel/3                                           9     0.00        8  [      0.89]
    maps:remove/2                                       23     0.00       10  [      0.43]
    maps:remove/2                                       23     0.00       10  [      0.43]
    beam_ssa:rpo/1                                      41     0.00       11  [      0.27]
    cerl_sets:new/0                                     50     0.00       12  [      0.24]
    lists:rmerge3_12_3/6                                67     0.00       12  [      0.18]
    sofs:relation/1                                      9     0.00       13  [      1.44]
    lists:rmerge3_21_3/6                                51     0.00       14  [      0.27]
    beam_ssa_bool:pre_are_args_bool/2                   33     0.00       15  [      0.45]
    beam_ssa_bool:pre_eval_op/2                         33     0.00       18  [      0.55]
    beam_ssa_bool:'-module/2-lc$^0/1-0-'/1              24     0.00       18  [      0.75]
    beam_ssa:predecessors/1                              9     0.00       21  [      2.33]
    maps:to_list/1                                      32     0.00       24  [      0.75]
    beam_ssa:rpo/2                                      41     0.00       36  [      0.88]
    beam_ssa_bool:opt_function/1                        23     0.00       48  [      2.09]
    beam_ssa_bool:pre_opt/2                             23     0.00       48  [      2.09]
    lists:merge3_1/6                                   211     0.00       58  [      0.27]
    lists:merge3_2/6                                   252     0.00       59  [      0.23]
    lists:rmerge3_2/6                                  371     0.00       88  [      0.24]
    lists:merge3_21_3/6                                710     0.00      126  [      0.18]
    lists:split_2_1/6                                  392     0.00      148  [      0.38]
    lists:rmerge2_2/5                                  710     0.01      268  [      0.38]
    lists:mergel/2                                    1181     0.01      383  [      0.32]
    lists:split_2/5                                   1263     0.01      404  [      0.32]
    lists:merge2_1/4                                  1967     0.01      409  [      0.21]
    lists:split_1_1/6                                 1339     0.01      521  [      0.39]
    lists:sort/1                                       849     0.01      591  [      0.70]
    lists:rmergel/2                                   1483     0.02      747  [      0.50]
    lists:umergel/3                                   2287     0.02      852  [      0.37]
    lists:merge2_2/5                                  6396     0.03     1170  [      0.18]
    lists:rmerge3_1/6                                 9044     0.05     2034  [      0.22]
    lists:rmerge2_1/4                                11166     0.05     2138  [      0.19]
    lists:umerge2_1/5                                10741     0.05     2164  [      0.20]
    lists:rumergel/3                                  6788     0.05     2323  [      0.34]
    lists:umerge2_2/4                                17217     0.07     3255  [      0.19]
    lists:rumerge2_2/5                               15301     0.07     3273  [      0.21]
    lists:last/1                                     23673     0.08     3570  [      0.15]
    lists:rumerge2_1/4                               22482     0.10     4588  [      0.20]
    erl_internal:bool_op/2                           35460     0.12     5497  [      0.16]
    erl_internal:new_type_test/2                     35482     0.12     5531  [      0.16]
    erl_internal:comp_op/2                           35526     0.12     5564  [      0.16]
    lists:reverse/2                                  28351     0.14     6418  [      0.23]
    lists:reverse/2                                  28351     0.14     6418  [      0.23]
    lists:umerge3_12_3/6                             34623     0.14     6495  [      0.19]
    lists:usplit_1_1/6                               26962     0.15     6866  [      0.25]
    beam_ssa:'-uses/2-anonymous-0-'/3                47341     0.16     6992  [      0.15]
    beam_ssa:dom_intersection/2                      47332     0.16     7079  [      0.15]
    beam_ssa:dom_intersection/3                      24081     0.16     7223  [      0.30]
    erts_internal:map_next/3                           294     0.17     7668  [     26.08]
    erts_internal:map_next/3                           294     0.17     7668  [     26.08]
    lists:rumerge3_12_3/7                            40237     0.18     8050  [      0.20]
    lists:rumerge3_21_3/7                            38755     0.18     8081  [      0.21]
    lists:umerge3_21_3/6                             49695     0.21     9216  [      0.19]
    lists:usplit_1/5                                 44393     0.21     9299  [      0.21]
    lists:last/2                                     47364     0.22     9704  [      0.20]
    beam_ssa_bool:pre_is_safe_bool/2                 61459     0.23    10313  [      0.17]
    lists:split_1/5                                  37819     0.24    10569  [      0.28]
    beam_ssa:normalize/1                             61496     0.25    11025  [      0.18]
    sofs:rel/4                                       71401     0.26    11771  [      0.16]
    ordsets:from_list/1                              94191     0.32    14408  [      0.15]
    lists:usort/1                                    94200     0.33    14697  [      0.16]
    sofs:rel2fam/4                                   71392     0.33    14725  [      0.21]
    beam_ssa:'-predecessors/1-lc$^0/1-0-'/1          47351     0.34    15133  [      0.32]
    lists:umerge3_2/7                                78928     0.37    16414  [      0.21]
    beam_ssa:number/2                                47350     0.38    16896  [      0.36]
    lists:umerge3_1/7                                79435     0.39    17519  [      0.22]
    beam_ssa:'-dominators/1-lc$^0/1-0-'/2            47350     0.47    21163  [      0.45]
    lists:rumerge3_2/7                              102746     0.51    22702  [      0.22]
    lists:rumerge3_1/6                              116574     0.55    24666  [      0.21]
    lists:reverse/1                                 123012     0.56    24934  [      0.20]
    maps:to_list_internal/1                            209     0.58    25937  [    124.10]
    beam_ssa:fold_uses_block/3                       47341     0.60    27059  [      0.57]
    beam_ssa:dominators/1                                9     0.67    29804  [   3311.56]
    beam_ssa:fold_rpo_1/4                            47350     0.79    35452  [      0.75]
    cerl_sets:union/2                               123050     0.83    36975  [      0.30]
    beam_ssa_bool:bool_opt/3                         47350     0.84    37806  [      0.80]
    beam_ssa:dom_intersection_1/3                   165489     0.89    40097  [      0.24]
    beam_ssa_bool:is_bool_expr/1                    181657     0.94    41966  [      0.23]
    beam_ssa:'-dominators_1/3-lc$^0/1-0-'/2         118724     0.94    42181  [      0.36]
    maps:from_list/1                                123093     0.95    42688  [      0.35]
    maps:from_list/1                                123093     0.95    42688  [      0.35]
    beam_ssa:dominators_1/3                          47341     1.00    44831  [      0.95]
    beam_ssa_bool:interesting_defs/2                123024     1.06    47529  [      0.39]
    beam_ssa:used/1                                 141532     1.22    54704  [      0.39]
    beam_ssa:'-predecessors/1-lc$^1/1-1-'/3         118734     1.26    56457  [      0.48]
    beam_ssa:'-fold_uses_block/3-anonymous-1-'/3    141532     1.34    59987  [      0.42]
    maps:get/3                                      145427     1.34    60069  [      0.41]
    beam_ssa_bool:get_phi_info_instr/3              225353     1.36    61161  [      0.27]
    beam_ssa_bool:do_sub_arg/2                      352291     1.37    61435  [      0.17]
    beam_ssa_bool:interesting_defs_is/3             348361     1.43    63939  [      0.18]
    beam_ssa:'-successors/1-lc$^0/1-0-'/1           177784     1.43    64231  [      0.36]
    cerl_sets:from_list/1                           123017     1.67    74830  [      0.61]
    beam_ssa_bool:get_phi_info/3                    123017     1.71    76697  [      0.62]
    erlang:setelement/3                             328731     1.73    77594  [      0.24]
    erlang:setelement/3                             328731     1.73    77594  [      0.24]
    cerl_sets:'-from_list/1-lc$^0/1-0-'/1           308303     1.74    77793  [      0.25]
    maps:put/3                                      145448     1.94    86791  [      0.60]
    maps:put/3                                      145448     1.94    86791  [      0.60]
    beam_ssa_bool:pre_opt_terminator/3              122994     2.01    90153  [      0.73]
    beam_ssa:used_args/1                            325321     2.19    97909  [      0.30]
    beam_ssa_bool:get_phi_info_is/3                 348347     2.23   100136  [      0.29]
    beam_ssa:'-fold_uses_block/3-anonymous-0-'/4    145427     2.32   103854  [      0.71]
    lists:foldl/3                                   428491     2.34   104626  [      0.24]
    beam_ssa_bool:sub_args/2                        225353     2.53   113570  [      0.50]
    beam_ssa_bool:sub_arg/2                         599367     2.85   127919  [      0.21]
    maps:merge/2                                    123020     3.06   137201  [      1.12]
    maps:merge/2                                    123020     3.06   137201  [      1.12]
    cerl_sets:is_element/2                          522483     3.13   140433  [      0.27]
    cerl_sets:add_element/2                         265017     3.18   142595  [      0.54]
    beam_ssa_bool:'-sub_args/2-lc$^0/1-0-'/2        496081     3.84   171898  [      0.35]
    beam_ssa:successors/1                           435353     4.25   190499  [      0.44]
    beam_ssa_bool:pre_opt_is/4                      348347     5.47   245169  [      0.70]
    beam_ssa_bool:pre_opt/5                         123017     6.44   288605  [      2.35]
    beam_ssa:rpo_1/4                                664556     7.89   353551  [      0.53]
    --------------------------------------------  --------  -------  -------  [----------]
    Total:                                        11433367  100.00%  4480680  [      0.39]