### PR TITLE
compiler: Fix instruction order reversal in ssa_opt_try

### DIFF
--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -1472,7 +1472,7 @@ is_safe_without_try([#b_set{op=kill_try_tag}|Is], Acc) ->
     %% Remove this kill_try_tag instruction. If there was a landingpad
     %% instruction in this block, it has already been removed. Preserve
     %% all other instructions in the block.
-    {done,reverse(Is, Acc)};
+    {done,reverse(Acc, Is)};
 is_safe_without_try([#b_set{op=extract}|_], _Acc) ->
     %% The error reason is accessed.
     unsafe;


### PR DESCRIPTION
This patch fixes a bug in which beam_ssa_opt:is_safe_without_try/2 in
some cases reverses the order of the instructions in a basic block.

beam_ssa_opt:is_safe_without_try/2 is called from
beam_ssa_opt:do_opt_try/2 to traverse the instructions of a basic
block. During its in-order traversal, it accumulates the visited (and
kept) instructions in an accumulator. When the traversal encounters a
kill_try_tag instruction, the instruction is removed, traversal is
halted, and the modified list of instructions is returned. To preserve
the order among the instructions, the not yet traversed instructions
should be appended to the reversed accumulator. This patch fixes a
mixup of the arguments to lists:reverse/2 which resulted in a reversal
of the instruction order.

Unfortunately this patch comes without a regression test as I have
only been able to trigger the error with an experimental compiler
branch.