### PR TITLE
add file:del_dir/2

### DIFF
--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -402,6 +402,28 @@ f.txt:  {person, "kalle", 25}.
       </desc>
     </func>
     <func>
+      <name name="del_dir_r" arity="1" since="OTP 23.0"/>
+      <fsummary>Delete a file or directory.</fsummary>
+      <desc>
+        <p>Deletes file or directory <c><anno>File</anno></c>.
+          If <c><anno>File</anno></c> is a directory, its contents
+          is first recursively deleted.  Returns:</p>
+        <taglist>
+          <tag><c>ok</c></tag>
+          <item>
+            <p>The operation completed without errors.</p>
+          </item>
+          <tag><c>{error, posix()}</c></tag>
+          <item>
+            <p>An error occurred when accessing or deleting <c><anno>File</anno></c>.
+             If some file or directory under <c><anno>File</anno></c> could not be
+             deleted, <c><anno>File</anno></c> cannot be deleted as it is non-empty,
+             and <c>{error, eexist}</c> is returned.</p>
+          </item>
+        </taglist>
+      </desc>
+    </func>
+    <func>
       <name name="delete" arity="1" since=""/>
       <fsummary>Delete a file.</fsummary>
       <desc>


### PR DESCRIPTION
This adds file:del_dir/2, a variant of file:del_dir/1 taking a list of options to extend its behaviour.  Available options are:
- recursive: recursively delete the contents of a directory before deleting the directory itself
- force: ignore errors when accessing or deleting files or directories
- keeptop: the top-most directory is not deleted

file:del_dir(Dir, [recursive, force]) is equivalent to "rm -rf Dir" in a Unix shell.
file:del_dir(Dir, [recursive, force, keeptop]) is similar to "rm -rf Dir/\*" in a Unix shell, but will also remove "."-files not expanded by "\*".
file:del_dir(Dir, []) is equivalent to file:del_dir(Dir).

Symbolic links are not followed.

In recursive and non-force mode, if there is an error accessing or deleting a file, the error return specifies both the error and which specific file it applies to.

Fixes ERL-1164.