### PR TITLE
Operation and maintenance/snmp write usm user fix

### DIFF
--- a/lib/snmp/src/manager/snmpm_conf.erl
+++ b/lib/snmp/src/manager/snmpm_conf.erl
@@ -337,7 +337,7 @@ do_write_usm_conf(
   {EngineID, UserName, SecName,
    AuthP, AuthKey, PrivP, PrivKey}) ->
     io:format(
-      Fd, "{\"~s\", \"~s\", \"~s\", í~w, ~w, ~w, ~w}.~n",
+      Fd, "{\"~s\", \"~s\", \"~s\", ~w, ~w, ~w, ~w}.~n",
       [EngineID, UserName, SecName, AuthP, AuthKey, PrivP, PrivKey]);
 do_write_usm_conf(_Fd, Crap) ->
     error({bad_usm_conf, Crap}).


### PR DESCRIPTION
Fix a typo which caused snmpm_conf:write_usm_user/2
to add a invalid usm_entry() which contained a extra character.