### PR TITLE
Prevent left nav overlapping content during scroll

### DIFF
--- a/lib/erl_docgen/priv/css/otp_doc.css
+++ b/lib/erl_docgen/priv/css/otp_doc.css
@@ -52,6 +52,7 @@ a:visited      { color: #1b6ec2; text-decoration: none }
 #content {
   margin-left: 340px; /* set left value to WidthOfFrameDiv */
   max-width: 42em;
+  overflow-x: hidden;
 }
 
 .frontpage 


### PR DESCRIPTION
When viewed on a smaller screen the content can be scrolled not only up
and down, but also left and right. More specifically it can be scrolled
back over the navigation menu to the left.

This prevents that, and as an bonus it fixes the scrolling to the right
where there is no content.

---

Compare:

![image](https://user-images.githubusercontent.com/664779/77236487-50fe7380-6bbf-11ea-815a-1eae5e4ac6a2.png)

With:

![image](https://user-images.githubusercontent.com/664779/77236481-43e18480-6bbf-11ea-83d3-99345ca5d831.png)

---

I wasn't sure if this is to be merged to master or maint. I mean the bug is in master, but the file hasn't been touched since 2015.

I can easily rebase on maint and update the PR if needed.