### PR TITLE
ssl: fix documentation of option `crl_cache`

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -340,7 +340,9 @@
 
 -type custom_verify()               ::  {Verifyfun :: fun(), InitialUserState :: any()}.
 -type crl_check()                :: boolean() | peer | best_effort.
--type crl_cache_opts()           :: [any()].
+-type crl_cache_opts()           :: {Module :: atom(),
+                                     {DbHandle :: internal | term(),
+                                      Args :: list()}}.
 -type handshake_size()           :: integer().
 -type hibernate_after()          :: timeout().
 -type root_fun()                 ::  fun().


### PR DESCRIPTION
... restoring it to its intended value before e042afe547 that planted
the type for using it in the doc.