### PR TITLE
Fix slow lists:mapfoldl/3

### DIFF
--- a/erts/emulator/beam/ops.tab
+++ b/erts/emulator/beam/ops.tab
@@ -390,6 +390,12 @@ move S1=x D1=x | move Y1=y X1=x | independent_moves(Y1, X1, S1, D1) => \
      move2_par Y1 X1 S1 D1
 move2_par y x x x
 
+# move2_par y y y y
+
+move Y1=y Y2=y | move Y3=y Y4=y | independent_moves(Y1, Y2, Y3, Y4) => \
+     move2_par Y1 Y2 Y3 Y4
+move2_par y y y y
+
 # move3
 
 move2_par Y1=y X1=x Y2=y X2=x | move Y3=y X3=x => move3 Y1 X1 Y2 X2 Y3 X3


### PR DESCRIPTION
This PR fixes two issues in the compiler that made `lists:mapfoldl/3` slow. See the commit messages for further details.

https://bugs.erlang.org/browse/ERL-1216
