### PR TITLE
ssl: fix documentation of option verify_fun

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -449,8 +449,8 @@
 	<code>
 fun(OtpCert :: #'OTPCertificate'{}, Event :: {bad_cert, Reason :: atom() |
              {revoked, atom()}} |
-	     {extension, #'Extension'{}}, InitialUserState :: term()) ->
-	{valid, UserState :: term()} | {valid_peer, UserState :: term()} |
+	     {extension, #'Extension'{}} | valid | valid_peer, InitialUserState :: term()) ->
+	{valid, UserState :: term()} |
 	{fail, Reason :: term()} | {unknown, UserState :: term()}.
 	</code>
 


### PR DESCRIPTION
Relevant past commits:
- [Code re `valid`](https://github.com/erlang/otp/commit/6cced538abd4f8053c009b163efa8c6d568b9580?diff=split&w=1#diff-79b520311347e34fac9cffbc4ea373f9R539)
- [Code (and doc) re `valid_peer`](https://github.com/erlang/otp/commit/e501709bec61bf8813cab741b0e39c211c73c89e?diff=split&w=1#diff-79b520311347e34fac9cffbc4ea373f9R541).

----

This is similar to #2592 though I kept it as separate PR as I see some ongoing testing effort on that.