### PR TITLE
Added new option to calendar:system_time_to_rfc3339/2

### DIFF
--- a/lib/stdlib/doc/src/calendar.xml
+++ b/lib/stdlib/doc/src/calendar.xml
@@ -409,6 +409,15 @@
 	    the fraction.
             </p>
 	  </item>
+      <tag><c>{fraction_format, FractionFormat}</c></tag>
+      <item><p>The second fraction part format type. The
+        default is <c>strict</c>, so trailing zeros are
+        not removed from fraction. The <c>relaxed</c> option
+        removes trailing zeros, adjusting factional second
+        to three, six, or nine digits depending on trailing
+        zeroes. If fraction part equals zero then it omitted.
+      </p>
+      </item>
 	</taglist>
         <pre>
 1> <input>calendar:system_time_to_rfc3339(erlang:system_time(second)).</input>
@@ -421,7 +430,10 @@
 "2018-04-23T10:57:05-02:00"
 4> <input>calendar:system_time_to_rfc3339(erlang:system_time(millisecond),
    [{unit, millisecond}, {time_designator, $\s}, {offset, "Z"}]).</input>
-"2018-04-23 12:57:20.482Z"</pre>
+"2018-04-23 12:57:20.482Z"
+4> <input>calendar:system_time_to_rfc3339(503640306100000000,
+   [{unit, nanosecond}, {fraction_format, relaxed}, {offset, "Z"}]).</input>
+"1985-12-17T04:05:06.100Z"</pre>
       </desc>
     </func>
 

--- a/lib/stdlib/src/calendar.erl
+++ b/lib/stdlib/src/calendar.erl
@@ -706,7 +706,7 @@ adjust_time_unit_(Time, Unit) ->
     case Time rem 1000 of
         0 ->
             NextUnit = next_time_unit(Unit),
-            NextTime = convert_time_unit(Time, Unit, NextUnit),
+            NextTime = erlang:convert_time_unit(Time, Unit, NextUnit),
             adjust_time_unit_(NextTime, NextUnit);
         _ ->
             {Time, Unit}

--- a/lib/stdlib/test/calendar_SUITE.erl
+++ b/lib/stdlib/test/calendar_SUITE.erl
@@ -307,6 +307,19 @@ rfc3339(Config) when is_list(Config) ->
     "1970-01-01T00:00:06.543210Z" = do_format_z(6543210, Mys),
     "1979-06-21T12:12:12.000000Z" = do_format_z(298815132000000, Mys),
     "1918-11-11T13:00:00.000000Z" = do_format_z(-1613818800000000, Mys),
+
+    "1985-12-17T04:05:06Z" = do_format_rz(503640306, S),
+    "1985-12-17T04:05:06.123Z" = do_format_rz(503640306123, Ms),
+    "1985-12-17T04:05:06.123456Z" = do_format_rz(503640306123456, Mys),
+    "1985-12-17T04:05:06.123456789Z" = do_format_rz(503640306123456789, Ns),
+    "1985-12-17T04:05:06.123456Z" = do_format_rz(503640306123456000, Ns),
+    "1985-12-17T04:05:06.123Z" = do_format_rz(503640306123000, Mys),
+    "1985-12-17T04:05:06Z" = do_format_rz(503640306000, Ms),
+    "1985-12-17T04:05:06.200Z" = do_format_rz(503640306200, Ms),
+    "1985-12-17T04:05:06.210Z" = do_format_rz(503640306210, Ms),
+    "1985-12-17T04:05:06Z" = do_format_rz(503640306000000000, Ns),
+    "1985-12-17T04:05:06.123Z" = do_format_rz(503640306123000000, Ns),
+    "1985-12-17T04:05:06.100Z" = do_format_rz(503640306100000000, Ns),
     ok.
 
 %%
@@ -326,6 +339,9 @@ do_parse(String, Options) ->
 test_time(Time, Options) ->
     F = calendar:system_time_to_rfc3339(Time, Options),
     Time = calendar:rfc3339_to_system_time(F, Options).
+
+do_format_rz(Time, Options) ->
+    do_format_z(Time, [{fraction_format, relaxed}|Options]).
 
 do_format_z(Time, Options) ->
     do_format(Time, [{offset, "Z"}|Options]).


### PR DESCRIPTION
Current `calendar:system_time_to_rfc3339/2` formats second fraction with trailing zeros. 
This PR adds ability to omit trailing zeros if fraction part equals zero.