### PR TITLE
use ets:select instead of ets:filter in application:loaded_applications/0

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -268,13 +268,12 @@ which_applications(Timeout) ->
     gen_server:call(?AC, which_applications, Timeout).
 
 loaded_applications() ->
-    ets:filter(ac_tab,
-	       fun([{{loaded, AppName}, #appl{descr = Descr, vsn = Vsn}}]) ->
-		       {true, {AppName, Descr, Vsn}};
-		  (_) ->
-		       false
-	       end,
-	       []).
+    ets:select(ac_tab,
+               [{
+                  {{loaded, '$1'}, #appl{descr = '$2', vsn = '$3', _ = '_'}},
+                  [],
+                  [{{'$1', '$2', '$3'}}]
+                }]).
 
 %% Returns some debug info
 info() ->


### PR DESCRIPTION
ets:filter dies with badarg if there is a delete, while it is walking through the table

I've found that if an application uses `application:loaded_applications()` while live upgrade/downgrade is running, it throws badarg errors

it is fairly easy to reproduce:

```
2> [spawn(fun() -> application:loaded_applications(),application:unset_env(kernel,shell_history),application:set_env(kernel,shell_history,enabled) end) || _<-lists:seq(1,10000)].
=ERROR REPORT==== 21-Apr-2020::10:31:10.959539 ===
Error in process <0.732.0> with exit value:
{badarg,[{ets,next,[ac_tab,{env,kernel,shell_history}],[]},
         {ets,do_filter,5,[{file,"ets.erl"},{line,775}]},
         {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,684}]},
         {erl_eval,exprs,5,[{file,"erl_eval.erl"},{line,126}]}]}

=ERROR REPORT==== 21-Apr-2020::10:31:11.064337 ===
Error in process <0.2606.0> with exit value:
{badarg,[{ets,next,[ac_tab,{env,kernel,shell_history}],[]},
         {ets,do_filter,5,[{file,"ets.erl"},{line,775}]},
         {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,684}]},
         {erl_eval,exprs,5,[{file,"erl_eval.erl"},{line,126}]}]}
...
```
