### PR TITLE
Add a cost for copying binaries with the binary syntax

### DIFF
--- a/erts/emulator/beam/bs_instrs.tab
+++ b/erts/emulator/beam/bs_instrs.tab
@@ -294,10 +294,13 @@ i_new_bs_put_binary(Fail, Sz, Flags, Src) {
     Eterm sz = $Sz;
     Sint _size;
     $BS_GET_UNCHECKED_FIELD_SIZE(sz, (($Flags) >> 3), $BADARG($Fail), _size);
-    if (!erts_new_bs_put_binary(ERL_BITS_ARGS_2(($Src), _size))) {
+    c_p->fcalls = FCALLS;
+    if (!erts_new_bs_put_binary(c_p, $Src, _size)) {
         $BADARG($Fail);
     }
+    FCALLS = c_p->fcalls;
 }
+
 i_new_bs_put_binary_all := i_new_bs_put_binary_all.fetch.execute;
 
 i_new_bs_put_binary_all.head() {
@@ -309,15 +312,19 @@ i_new_bs_put_binary_all.fetch(Src) {
 }
 
 i_new_bs_put_binary_all.execute(Fail, Unit) {
-    if (!erts_new_bs_put_binary_all(ERL_BITS_ARGS_2(src, ($Unit)))) {
+    c_p->fcalls = FCALLS;
+    if (!erts_new_bs_put_binary_all(c_p, src, ($Unit))) {
         $BADARG($Fail);
     }
+    FCALLS = c_p->fcalls;
 }
 
 i_new_bs_put_binary_imm(Fail, Sz, Src) {
-    if (!erts_new_bs_put_binary(ERL_BITS_ARGS_2(($Src), ($Sz)))) {
+    c_p->fcalls = FCALLS;
+    if (!erts_new_bs_put_binary(c_p, ($Src), ($Sz))) {
         $BADARG($Fail);
     }
+    FCALLS = c_p->fcalls;
 }
 
 i_new_bs_put_float(Fail, Sz, Flags, Src) {
@@ -707,11 +714,13 @@ i_bs_append(Fail, ExtraHeap, Live, Unit, Size, Dst) {
 i_bs_private_append(Fail, Unit, Size, Src, Dst) {
     Eterm res;
 
+    c_p->fcalls = FCALLS;
     res = erts_bs_private_append(c_p, $Src, $Size, $Unit);
     if (is_non_value(res)) {
         /* c_p->freason is already set (to BADARG or SYSTEM_LIMIT). */
         $FAIL_HEAD_OR_BODY($Fail);
     }
+    FCALLS = c_p->fcalls;
     $Dst = res;
 }
 

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -164,8 +164,8 @@ Eterm erts_bs_get_binary_all_2(Process *p, ErlBinMatchBuffer* mb);
 int erts_new_bs_put_integer(ERL_BITS_PROTO_3(Eterm Integer, Uint num_bits, unsigned flags));
 int erts_bs_put_utf8(ERL_BITS_PROTO_1(Eterm Integer));
 int erts_bs_put_utf16(ERL_BITS_PROTO_2(Eterm Integer, Uint flags));
-int erts_new_bs_put_binary(ERL_BITS_PROTO_2(Eterm Bin, Uint num_bits));
-int erts_new_bs_put_binary_all(ERL_BITS_PROTO_2(Eterm Bin, Uint unit));
+int erts_new_bs_put_binary(Process *c_p, Eterm Bin, Uint num_bits);
+int erts_new_bs_put_binary_all(Process *c_p, Eterm Bin, Uint unit);
 int erts_new_bs_put_float(Process *c_p, Eterm Float, Uint num_bits, int flags);
 void erts_new_bs_put_string(ERL_BITS_PROTO_2(byte* iptr, Uint num_bytes));
 


### PR DESCRIPTION
When constructing binaries using the binary syntax, there would
not be any cost in terms of reductions for copying large binaries,
and a process could copy many large binaries before being scheduled
out.

Add a cost of 1 reduction per 1 KiB of binary data copied in
binary construction.