### PR TITLE
Added a fun/4 with State access for keyboard-interactive

### DIFF
--- a/lib/ssh/doc/src/ssh.xml
+++ b/lib/ssh/doc/src/ssh.xml
@@ -514,6 +514,7 @@
       <name name="prompt_texts"/>
       <name name="kb_int_tuple"/>
       <name name="kb_int_fun_3"/>
+      <name name="kb_int_fun_4"/>
       <name name="pwdfun_2"/>
       <name name="pwdfun_4"/>
       <desc>
@@ -522,7 +523,7 @@
 	  <item>
 	    <p>Sets the text strings that the daemon sends to the client for presentation to the user when
 	    using <c>keyboard-interactive</c> authentication.</p>
-	    <p>If the fun/3 is used, it is called when the actual authentication occurs and may therefore
+	    <p>If the fun/3 or fun/4 is used, it is called when the actual authentication occurs and may therefore
 	    return dynamic data like time, remote ip etc.</p>
 	    <p>The parameter <c>Echo</c> guides the client about need to hide the password.</p>
 	    <p>The default value is:

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -361,9 +361,11 @@
 -type prompt_texts() ::
         kb_int_tuple()
       | kb_int_fun_3()
+      | kb_int_fun_4()
       .
 
 -type kb_int_fun_3() :: fun((Peer::ip_port(), User::string(), Service::string()) -> kb_int_tuple()).
+-type kb_int_fun_4() :: fun((Peer::ip_port(), User::string(), Service::string(), State::any()) -> kb_int_tuple()).
 -type kb_int_tuple() :: {Name::string(), Instruction::string(), Prompt::string(), Echo::boolean()}.
 
 -type pwdfun_2() :: fun((User::string(), Password::string()) -> boolean()) .

--- a/lib/ssh/src/ssh_auth.erl
+++ b/lib/ssh/src/ssh_auth.erl
@@ -364,6 +364,9 @@ handle_userauth_request(#ssh_msg_userauth_request{user = User,
 			Default;
 		    {_,_,_,_}=V -> 
 			V;
+                    F when is_function(F, 4) ->
+			{_,PeerName} = Ssh#ssh.peer,
+			F(PeerName, User, "ssh-connection", Ssh#ssh.pwdfun_user_state);
 		    F when is_function(F) ->
 			{_,PeerName} = Ssh#ssh.peer,
 			F(PeerName, User, "ssh-connection")

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -424,7 +424,8 @@ default(server) ->
                                check_string(S3) andalso
                                is_boolean(B);
                       (F) ->
-                           check_function3(F)
+                           check_function3(F) orelse
+                               check_function4(F)
                    end,
             class => user_option
            },


### PR DESCRIPTION
Hi,

When using 'keyboard-interactive' SSH authentication we need access to the user state to be able to generate prompts. This to be able to integrate with e.g. https://duo.com/

This patch adds a (backwards compatible) 'keyboard-interactive' fun/4 that has access to the user state.