### PR TITLE
erl_call: Assume localhost if own hostname resolution fails

### DIFF
--- a/lib/erl_interface/doc/src/erl_call_cmd.xml
+++ b/lib/erl_interface/doc/src/erl_call_cmd.xml
@@ -183,6 +183,13 @@
               specified, an Erlang node is started (if necessary) with
               <c>erl -sname</c>.</p>
           </item>
+          <tag><c>-timeout Seconds</c></tag>
+          <item>
+            <p>(<em>Optional.</em>) Aborts the <c>erl_call</c> process after
+              the timeout expires. Note that this does not abort commands that
+              have already been started with <c>-a</c>, <c>-e</c>, or similar.
+            </p>
+          </item>
           <tag><c>-v</c></tag>
           <item>
             <p>(<em>Optional.</em>) Prints a lot of <c>verbose</c>

--- a/lib/erl_interface/test/erl_call_SUITE.erl
+++ b/lib/erl_interface/test/erl_call_SUITE.erl
@@ -26,13 +26,15 @@
 -export([all/0, smoke/1,
          random_cnode_name/1,
          test_connect_to_host_port/1,
-         unresolvable_hostname/1]).
+         unresolvable_hostname/1,
+         timeout/1]).
 
 all() ->
     [smoke,
      random_cnode_name,
      test_connect_to_host_port,
-     unresolvable_hostname].
+     unresolvable_hostname,
+     timeout].
 
 smoke(Config) when is_list(Config) ->
     Name = atom_to_list(?MODULE)
@@ -130,6 +132,21 @@ unresolvable_hostname(_Config) ->
         [_, Hostname] = string:lexemes(atom_to_list(node()), "@"),
         DefaultName = list_to_atom("c17@" ++ Hostname),
         check_eq(CNodeName, DefaultName)
+    after
+        halt_node(Name)
+    end,
+
+    ok.
+
+%% OTP-16604: Test the -timeout option
+timeout(_Config) ->
+    Name = atom_to_list(?MODULE)
+        ++ "-"
+        ++ integer_to_list(erlang:system_time(microsecond)),
+    Opts = ["-timeout", "3"],
+
+    try
+        [] = start_node_and_apply(Name, "timer sleep [10000]", Opts)
     after
         halt_node(Name)
     end,

--- a/lib/erl_interface/test/erl_call_SUITE.erl
+++ b/lib/erl_interface/test/erl_call_SUITE.erl
@@ -25,12 +25,14 @@
 
 -export([all/0, smoke/1,
          random_cnode_name/1,
-         test_connect_to_host_port/1]).
+         test_connect_to_host_port/1,
+         unresolvable_hostname/1]).
 
 all() ->
     [smoke,
      random_cnode_name,
-     test_connect_to_host_port].
+     test_connect_to_host_port,
+     unresolvable_hostname].
 
 smoke(Config) when is_list(Config) ->
     Name = atom_to_list(?MODULE)
@@ -113,6 +115,25 @@ test_connect_to_host_port_do(Name) ->
         nomatch -> ct:fail("Incorrect error message");
         _ -> ok
     end,
+    ok.
+
+%% OTP-16604: Tests that erl_call works even when the local hostname cannot be
+%% resolved.
+unresolvable_hostname(_Config) ->
+    Name = atom_to_list(?MODULE)
+        ++ "-"
+        ++ integer_to_list(erlang:system_time(microsecond)),
+    Opt = "-__uh_test__",
+
+    try
+        CNodeName = start_node_and_get_c_node_name(Name, [Opt]),
+        [_, Hostname] = string:lexemes(atom_to_list(node()), "@"),
+        DefaultName = list_to_atom("c17@" ++ Hostname),
+        check_eq(CNodeName, DefaultName)
+    after
+        halt_node(Name)
+    end,
+
     ok.
 
 %


### PR DESCRIPTION
This PR makes erl_call work out of the box on systems like OS X where the computer's hostname can't always be resolved.