### PR TITLE
Type erl_anno:anno() should not be opaque

### DIFF
--- a/lib/stdlib/src/erl_anno.erl
+++ b/lib/stdlib/src/erl_anno.erl
@@ -53,9 +53,9 @@
                     | {'text', string()}.
 
 -ifdef(DEBUG).
--opaque anno() :: [annotation(), ...].
+-type anno() :: [annotation(), ...].
 -else.
--opaque anno() :: location() | [annotation(), ...].
+-type anno() :: location() | [annotation(), ...].
 -endif.
 -type anno_term() :: term().
 


### PR DESCRIPTION
The [docs](http://erlang.org/doc/apps/erts/absform.html)
refer to the annotation simply as LINE, however, if we were
to add the lines manually and give it to erl_eval:expr/2,
Dialyzer will complain as erl_anno:anno() is listed as opaque.

This makes erl_anno:anno() as non-opaque, with the
location() as public type but the annotation() as private.