### PR TITLE
[Fix] ERL-1227: mnesia_recover

### DIFF
--- a/lib/mnesia/src/mnesia_recover.erl
+++ b/lib/mnesia/src/mnesia_recover.erl
@@ -449,6 +449,9 @@ wait_for_decision(D, InitBy, N) ->
     if 
 	Outcome =:= committed -> {Tid, committed};
 	Outcome =:= aborted   -> {Tid, aborted};
+	InitBy == startup ->
+	    {ok, Res} = call({wait_for_decision, D}),
+	    {Tid, Res};
 	Outcome =:= presume_abort -> 
 	    case N > Max of
 		true -> {Tid, aborted};
@@ -460,10 +463,10 @@ wait_for_decision(D, InitBy, N) ->
 	    %% Wait a while for active transactions
 	    %% to end and try again
 	    timer:sleep(100), 
-	    wait_for_decision(D, InitBy, N);
-	InitBy == startup ->
-	    {ok, Res} = call({wait_for_decision, D}),
-	    {Tid, Res}
+	    wait_for_decision(D, InitBy, N)
+	%%InitBy == startup ->
+	%%    {ok, Res} = call({wait_for_decision, D}),
+	%%    {Tid, Res}
     end.
 
 still_pending([Tid | Pending]) ->

--- a/lib/mnesia/src/mnesia_recover.erl
+++ b/lib/mnesia/src/mnesia_recover.erl
@@ -464,9 +464,6 @@ wait_for_decision(D, InitBy, N) ->
 	    %% to end and try again
 	    timer:sleep(100), 
 	    wait_for_decision(D, InitBy, N)
-	%%InitBy == startup ->
-	%%    {ok, Res} = call({wait_for_decision, D}),
-	%%    {Tid, Res}
     end.
 
 still_pending([Tid | Pending]) ->


### PR DESCRIPTION
https://bugs.erlang.org/browse/ERL-1227?jql=text%20~%20%22mnesia%22

When a Mnesia node startup, it could not execute the transaction recovery process. 
The transaction recovery process entry is in mnesia_recover.erl file, but never called 
when a Mnesia node startup. This commit fix the bug.