### PR TITLE
Remove docs for specs for functions in other modules

### DIFF
--- a/system/doc/reference_manual/typespec.xml
+++ b/system/doc/reference_manual/typespec.xml
@@ -475,22 +475,22 @@
       <c>-spec</c> attribute. The general format is as follows:
     </p>
     <pre>
-  -spec Module:Function(ArgType1, ..., ArgTypeN) -> ReturnType.</pre>
+  -spec Function(ArgType1, ..., ArgTypeN) -> ReturnType.</pre>
     <p>
-      The arity of the function must match the number of arguments,
+      An implementation of the function with the same name must exist in the same module,
+      and the arity of the function must match the number of arguments,
       else a compilation error occurs.
     </p>
     <p>
-      This form can also be used in header files (.hrl) to declare type
-      information for exported functions.
-      Then these header files can be included in files that (implicitly or
-      explicitly) import these functions.
-    </p>
-    <p>
-      Within a given module, the following shorthand suffices in most cases:
+      The following longer format with module name is also valid as
+      long as Module is the same as the curent module. This can be
+      useful for example for dodumentation purposed. (For instance in
+      the erlang module this indicates that some functions are not
+      auto-improted and need to be called as fully qualified remote
+      calls.)
     </p>
     <pre>
-  -spec Function(ArgType1, ..., ArgTypeN) -> ReturnType.</pre>
+  -spec Module:Function(ArgType1, ..., ArgTypeN) -> ReturnType.</pre>
     <p>
       Also, for documentation purposes, argument names can be given:
     </p>


### PR DESCRIPTION
They are rejected by the compiler/linter since OTP 20 (commit 60e47cba).

See also https://bugs.erlang.org/browse/ERL-845.

The parser still seems to support spec with module (https://github.com/erlang/otp/blob/master/lib/stdlib/src/erl_parse.yrl#L90,
https://github.com/erlang/otp/blob/master/lib/stdlib/src/erl_parse.yrl#L681) and it is even documented in the Abstract Format (http://erlang.org/doc/apps/erts/absform.html#module-declarations-and-forms)
Should it be kept or removed?
