### PR TITLE
Copy erl_call to erts and filter tools from systools:make_tar

### DIFF
--- a/erts/Makefile
+++ b/erts/Makefile
@@ -79,6 +79,7 @@ local_setup:
 		cp $(ERL_TOP)/bin/$(TARGET)/ct_run.exe $(ERL_TOP)/bin/ct_run.exe; \
 		cp $(ERL_TOP)/bin/$(TARGET)/erlc.exe $(ERL_TOP)/bin/erlc.exe; \
 		cp $(ERL_TOP)/bin/$(TARGET)/erl.exe $(ERL_TOP)/bin/erl.exe; \
+		cp $(ERL_TOP)/bin/$(TARGET)/erl_call.exe $(ERL_TOP)/bin/erl_call.exe; \
 		cp $(ERL_TOP)/bin/$(TARGET)/werl.exe $(ERL_TOP)/bin/werl.exe; \
 		cp $(ERL_TOP)/bin/$(TARGET)/escript.exe $(ERL_TOP)/bin/escript.exe; \
 	 	chmod 755 $(ERL_TOP)/bin/erl.exe $(ERL_TOP)/bin/erlc.exe \
@@ -94,6 +95,7 @@ local_setup:
 		-e "s;%TARGET%;$(TARGET);"    \
 		-e "s;%VSN%;$(VSN);"    \
 	        $(ERL_TOP)/erts/etc/unix/cerl.src > $(ERL_TOP)/bin/cerl; \
+		cp $(ERL_TOP)/bin/$(TARGET)/erl_call $(ERL_TOP)/bin/erl_call; \
 		cp $(ERL_TOP)/bin/$(TARGET)/dialyzer $(ERL_TOP)/bin/dialyzer; \
 		cp $(ERL_TOP)/bin/$(TARGET)/typer $(ERL_TOP)/bin/typer; \
 		cp $(ERL_TOP)/bin/$(TARGET)/ct_run $(ERL_TOP)/bin/ct_run; \

--- a/erts/emulator/test/port_bif_SUITE.erl
+++ b/erts/emulator/test/port_bif_SUITE.erl
@@ -640,6 +640,3 @@ wait_until_aux(Fun, End) ->
                     end
             end
     end.
-                                   
-                                          
-                        

--- a/erts/etc/common/Makefile.in
+++ b/erts/etc/common/Makefile.in
@@ -154,7 +154,14 @@ MC_OUTPUTS=$(OBJDIR)/erlsrv_logmess.h $(OBJDIR)/erlsrv_logmess.res
 MT_FLAG="-MD"
 endif
 INET_GETHOST = $(BINDIR)/inet_gethost.exe
-INSTALL_EMBEDDED_PROGS += $(BINDIR)/typer.exe $(BINDIR)/dialyzer.exe $(BINDIR)/erlc.exe $(BINDIR)/start_erl.exe $(BINDIR)/escript.exe $(BINDIR)/ct_run.exe
+INSTALL_EMBEDDED_PROGS += \
+	$(BINDIR)/typer.exe \
+	$(BINDIR)/dialyzer.exe \
+	$(BINDIR)/erlc.exe \
+	$(BINDIR)/start_erl.exe \
+	$(BINDIR)/escript.exe \
+	$(BINDIR)/ct_run.exe \
+	$(BINDIR)/erl_call.exe
 INSTALL_SRC = $(WINETC)/start_erl.c $(WINETC)/Nmakefile.start_erl
 ERLEXECDIR=.
 INSTALL_LIBS =
@@ -165,9 +172,11 @@ INSTALL_TOP = Install.ini
 INSTALL_TOP_BIN = $(BINDIR)/Install.exe
 INSTALL_PROGS =              \
 	$(INET_GETHOST)      \
-	$(BINDIR)/heart.exe   $(BINDIR)/erlsrv.exe   \
-	$(BINDIR)/erl.exe $(BINDIR)/erl_log.exe \
-	$(BINDIR)/werl.exe \
+	$(BINDIR)/heart.exe  \
+	$(BINDIR)/erlsrv.exe \
+	$(BINDIR)/erl.exe    \
+	$(BINDIR)/erl_log.exe\
+	$(BINDIR)/werl.exe   \
 	$(BINDIR)/$(ERLEXEC) \
 	$(INSTALL_EMBEDDED_PROGS)
 
@@ -187,9 +196,16 @@ ENTRY_OBJ=
 ERLSRV_OBJECTS= 
 MC_OUTPUTS=
 INET_GETHOST = $(BINDIR)/inet_gethost@EXEEXT@
-INSTALL_EMBEDDED_PROGS += $(BINDIR)/typer@EXEEXT@ $(BINDIR)/dialyzer@EXEEXT@ \
- $(BINDIR)/erlc@EXEEXT@ $(BINDIR)/escript@EXEEXT@ $(BINDIR)/ct_run@EXEEXT@ \
- $(BINDIR)/run_erl $(BINDIR)/to_erl $(BINDIR)/dyn_erl
+INSTALL_EMBEDDED_PROGS += \
+	$(BINDIR)/typer@EXEEXT@ \
+	$(BINDIR)/dialyzer@EXEEXT@ \
+	$(BINDIR)/erlc@EXEEXT@ \
+	$(BINDIR)/escript@EXEEXT@ \
+	$(BINDIR)/ct_run@EXEEXT@ \
+	$(BINDIR)/run_erl@EXEEXT@ \
+	$(BINDIR)/to_erl@EXEEXT@ \
+	$(BINDIR)/dyn_erl@EXEEXT@ \
+	$(BINDIR)/erl_call@EXEEXT@
 INSTALL_EMBEDDED_DATA = $(UXETC)/start.src $(UXETC)/start_erl.src
 INSTALL_TOP = Install
 INSTALL_TOP_BIN = 
@@ -423,6 +439,10 @@ $(OBJDIR)/dyn_erl.o: $(UXETC)/dyn_erl.c $(RC_GENERATED)
 	$(V_CC) $(CFLAGS) -o $@ -c $(UXETC)/dyn_erl.c
 $(OBJDIR)/safe_string.o: $(ETC)/safe_string.c $(RC_GENERATED)
 	$(V_CC) $(CFLAGS) -o $@ -c $(ETC)/safe_string.c
+
+# erl_call
+$(BINDIR)/erl_call@EXEEXT@: $(ERL_TOP)/lib/erl_interface/bin/$(TARGET)/erl_call@EXEEXT@
+	$(ld_verbose)cp $< $@
 
 ifneq ($(TARGET),win32)
 $(BINDIR)/$(ERLEXEC): $(OBJDIR)/$(ERLEXEC).o $(ERTS_LIB)

--- a/erts/etc/unix/Install.src
+++ b/erts/etc/unix/Install.src
@@ -88,6 +88,7 @@ cd "$ERL_ROOT/bin"
 
 cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erl" .
 cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erlc" .
+cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erl_call" .
 cp -p "$ERL_ROOT/erts-%I_VSN%/bin/dialyzer" .
 cp -p "$ERL_ROOT/erts-%I_VSN%/bin/typer" .
 cp -p "$ERL_ROOT/erts-%I_VSN%/bin/ct_run" .

--- a/erts/etc/win32/Install.c
+++ b/erts/etc/win32/Install.c
@@ -47,7 +47,7 @@ int wmain(int argc, wchar_t **argv)
     InitFile *ini_file;
     InitSection *ini_section;
     HANDLE module = GetModuleHandle(NULL);
-    wchar_t *binaries[] = { L"erl.exe", L"werl.exe", L"erlc.exe",
+    wchar_t *binaries[] = { L"erl.exe", L"werl.exe", L"erlc.exe", L"erl_call.exe",
 			    L"dialyzer.exe",
 			    L"typer.exe",
 			    L"escript.exe", L"ct_run.exe", NULL };

--- a/lib/erl_interface/src/Makefile.in
+++ b/lib/erl_interface/src/Makefile.in
@@ -745,9 +745,7 @@ release: opt
 	$(INSTALL_DATA) $(HEADERS)     "$(RELEASE_PATH)/usr/include"
 	$(INSTALL_DATA) $(OBJ_TARGETS) "$(RELSYSDIR)/lib"
 	$(INSTALL_DATA) $(OBJ_TARGETS) "$(RELEASE_PATH)/usr/lib"
-ifneq ($(EXE_TARGETS),)
 	$(INSTALL_PROGRAM) $(EXE_TARGETS) "$(RELSYSDIR)/bin"
-endif
 	$(INSTALL_DATA) $(EXTRA)        "$(RELSYSDIR)/src"
 	$(INSTALL_DATA) connect/*.[ch]  "$(RELSYSDIR)/src/connect"
 	$(INSTALL_DATA) decode/*.[ch]   "$(RELSYSDIR)/src/decode"

--- a/lib/sasl/doc/specs/.gitignore
+++ b/lib/sasl/doc/specs/.gitignore
@@ -1,0 +1,1 @@
+specs_*.xml

--- a/lib/sasl/doc/src/Makefile
+++ b/lib/sasl/doc/src/Makefile
@@ -53,6 +53,8 @@ XML_FILES = \
 	$(XML_PART_FILES) $(XML_REF3_FILES) $(XML_REF4_FILES) \
 	$(XML_REF6_FILES) $(XML_APPLICATION_FILES)
 
+TOP_SPECS_FILE = specs.xml
+
 # ----------------------------------------------------
 
 include $(ERL_TOP)/make/doc.mk

--- a/lib/sasl/doc/src/specs.xml
+++ b/lib/sasl/doc/src/specs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<specs xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="../specs/specs_systools.xml"/>
+</specs>

--- a/lib/sasl/doc/src/systools.xml
+++ b/lib/sasl/doc/src/systools.xml
@@ -251,8 +251,8 @@
           warnings are issued for calls to undefined functions.</p>
         <p>By default, errors and warnings are printed to tty and
           the function returns <c>ok</c> or <c>error</c>. If option
-          <c>silent</c> is specified, the function instead returns
           <c>{ok,Module,Warnings}</c> or <c>{error,Module,Error}</c>.
+          <c>silent</c> is specified, the function instead returns
           Warnings and errors can be converted to strings by calling
           <c>Module:format_warning(Warnings)</c> or
           <c>Module:format_error(Error)</c>.</p>
@@ -265,25 +265,9 @@
     </func>
 
     <func>
-      <name since="">make_tar(Name) -> Result</name>
-      <name since="">make_tar(Name, [Opt]) -> Result</name>
+      <name name="make_tar" arity="1" since=""/>
+      <name name="make_tar" arity="2" since=""/>
       <fsummary>Creates a release package.</fsummary>
-      <type>
-        <v>Name = string()</v>
-        <v>Opt = {dirs,[IncDir]} | {path,[Dir]} | {variables,[Var]} | {var_tar,VarTar} | {erts,Dir} | src_tests | exref | {exref,[App]} | silent | {outdir,Dir} | | no_warn_sasl | warnings_as_errors | {extra_files, ExtraFiles}</v>
-        <v>&nbsp;Dir = string()</v>
-        <v>&nbsp;IncDir = src | include | atom()</v>
-        <v>&nbsp;Var = {VarName,PreFix}</v>
-        <v>&nbsp;&nbsp;VarName = Prefix = string()</v>
-        <v>&nbsp;VarTar = include | ownfile | omit</v>
-        <v>&nbsp;Machine = atom()</v>
-        <v>&nbsp;App = atom()</v>
-        <v>Result = ok | error | {ok,Module,Warnings} | {error,Module,Error}</v>
-        <v>&nbsp;Module = atom()</v>
-        <v>&nbsp;Warning = Error = term()</v>
-        <v>&nbsp;ExtraFiles = [{NameInArchive, file:filename_all()}]</v>
-        <v>&nbsp;NameInArchive = string()</v>
-      </type>
       <desc>
         <p>Creates a release package file <c>Name.tar.gz</c>.
           This file must be uncompressed and unpacked on the target
@@ -364,8 +348,10 @@ myapp-1/ebin/myapp.app
           specified using option <c>path</c>. In the case of <c>sys.config</c>
           it is not included if <c>sys.config.src</c> is found.</p>
         <p>If the release package is to contain a new Erlang runtime
-          system, the <c>bin</c> directory of the specified runtime
-          system <c>{erts,Dir}</c> is copied to <c>erts-ErtsVsn/bin</c>.</p>
+          system, the <c>erts-ErtsVsn/bin</c> directory of the specified runtime
+          system <c>{erts,Dir}</c> is copied to <c>erts-ErtsVsn/bin</c>. Some
+          erts executables are not copied by default, if you want to include all
+          executables you can give the <c>erts_all</c> option.</p>
         <p>All checks with function 
 	<seemfa marker="#make_script/1"><c>make_script</c></seemfa>
           are performed before the release package is created.

--- a/lib/sasl/src/systools.erl
+++ b/lib/sasl/src/systools.erl
@@ -62,8 +62,32 @@ make_script(RelName, Opt) ->
 %% release package and erts specifies that the erts-Vsn/bin directory
 %% should be included in the release package and there it can be found.
 %%-----------------------------------------------------------------
+-spec make_tar(Name) -> Result when
+      Name :: string(),
+      Result :: ok | error | {ok, Module :: module(), Warnings :: term()} |
+                {error, Module :: module(), Error :: term()}.
 make_tar(RelName) -> make_tar(RelName, []).
 
+-spec make_tar(Name, Opts) -> Result when
+      Name :: string(),
+      Opts :: [Opt],
+      Opt :: {dirs,[IncDir]} | {path,[Dir]} |
+             {variables,[Var]} | {var_tar,VarTar} |
+             {erts,Dir} | erts_all | src_tests | exref |
+             {exref,[App]} | silent | {outdir,Dir} |
+             no_warn_sasl | warnings_as_errors |
+             {extra_files, ExtraFiles},
+      Dir :: file:filename_all(),
+      IncDir :: src | include | atom(),
+      Var :: {VarName,PreFix},
+      VarName :: string(),
+      PreFix :: string(),
+      VarTar :: include | ownfile | omit,
+      App :: atom(),
+      Result :: ok | error | {ok, Module :: module(), Warnings :: term()} |
+                {error, Module :: module(), Error :: term()},
+      ExtraFiles :: [{NameInArchive, file:filename_all()}],
+      NameInArchive :: string().
 make_tar(RelName, Opt) ->
     systools_make:make_tar(RelName, Opt).
 

--- a/lib/sasl/src/systools_make.erl
+++ b/lib/sasl/src/systools_make.erl
@@ -27,8 +27,7 @@
 
 -export([format_error/1, format_warning/1]).
 
--export([read_release/2, get_release/2, get_release/3,
-	 get_release/4, pack_app/1]).
+-export([read_release/2, get_release/2, get_release/3, pack_app/1]).
 
 -export([read_application/4]).
 
@@ -65,7 +64,6 @@
 %% New options: {path,Path} can contain wildcards
 %%              src_tests
 %%              {variables,[{Name,AbsString}]}
-%%              {machine, jam | beam | vee}
 %%              exref | {exref, [AppName]}
 %%              no_warn_sasl
 %%-----------------------------------------------------------------
@@ -98,7 +96,7 @@ make_script(RelName, Output, Flags) when is_list(RelName),
 	    Path1 = mk_path(Path0), % expand wildcards etc.
 	    Path  = make_set(Path1 ++ code:get_path()),
 	    ModTestP = {member(src_tests, Flags),xref_p(Flags)},
-	    case get_release(RelName, Path, ModTestP, machine(Flags)) of
+	    case get_release(RelName, Path, ModTestP) of
 		{ok, Release, Appls, Warnings0} ->
 		    Warnings = wsasl(Flags, Warnings0),
 		    case systools_lib:werror(Flags, Warnings) of
@@ -136,12 +134,6 @@ wsasl(Options, Warnings) ->
 
 badarg(BadArg, Args) ->
     erlang:error({badarg,BadArg}, Args).
-
-machine(Flags) ->
-    case get_flag(machine,Flags) of
-	{machine, Machine} when is_atom(Machine) -> Machine;
-	_                                        -> false
-    end.
 
 get_script_name(RelName, Flags) ->
     case get_flag(script_name,Flags) of
@@ -362,7 +354,6 @@ add_apply_upgrade(Script,Args) ->
 %%              src_tests
 %%              exref | {exref, [AppName]}
 %%              {variables,[{Name,AbsString}]}
-%%              {machine, jam | beam | vee}
 %%              {var_tar, include | ownfile | omit}
 %%              no_warn_sasl
 %%              warnings_as_errors
@@ -398,7 +389,7 @@ make_tar(RelName, Flags) when is_list(RelName), is_list(Flags) ->
 	    Path1 = mk_path(Path0),
 	    Path  = make_set(Path1 ++ code:get_path()),
 	    ModTestP = {member(src_tests, Flags),xref_p(Flags)},
-	    case get_release(RelName, Path, ModTestP, machine(Flags)) of
+	    case get_release(RelName, Path, ModTestP) of
 		{ok, Release, Appls, Warnings0} ->
 		    Warnings = wsasl(Flags, Warnings0),
 		    case systools_lib:werror(Flags, Warnings) of
@@ -430,17 +421,13 @@ make_tar(RelName, Flags) ->
 %%______________________________________________________________________
 %% get_release(File, Path) ->
 %% get_release(File, Path, ModTestP) ->
-%% get_release(File, Path, ModTestP, Machine) ->
 %%     {ok, #release, [{{Name,Vsn},#application}], Warnings} | {error, What}
 
 get_release(File, Path) ->
-    get_release(File, Path, {false,false}, false).
+    get_release(File, Path, {false,false}).
 
 get_release(File, Path, ModTestP) ->
-    get_release(File, Path, ModTestP, false).
-
-get_release(File, Path, ModTestP, Machine) ->
-    case catch get_release1(File, Path, ModTestP, Machine) of
+    case catch get_release1(File, Path, ModTestP) of
 	{error, Error} ->
 	    {error, ?MODULE, Error};
 	{'EXIT', Why} ->
@@ -449,12 +436,12 @@ get_release(File, Path, ModTestP, Machine) ->
 	    Answer
     end.
 	
-get_release1(File, Path, ModTestP, Machine) ->
+get_release1(File, Path, ModTestP) ->
     {ok, Release, Warnings1} = read_release(File, Path),
     {ok, Appls0} = collect_applications(Release, Path),
     {ok, Appls1} = check_applications(Appls0),
     {ok, Appls2} = sort_used_and_incl_appls(Appls1, Release), % OTP-4121, OTP-9984
-    {ok, Warnings2} = check_modules(Appls2, Path, ModTestP, Machine),
+    {ok, Warnings2} = check_modules(Appls2, Path, ModTestP),
     {ok, Appls} = sort_appls(Appls2),
     {ok, Release, Appls, Warnings1 ++ Warnings2}.
 
@@ -974,13 +961,13 @@ find_pos(N, Name, [_OtherAppl|OrderedAppls]) ->
     find_pos(N+1, Name, OrderedAppls).
 
 %%______________________________________________________________________
-%% check_modules(Appls, Path, TestP, Machine) ->
+%% check_modules(Appls, Path, TestP) ->
 %%  {ok, Warnings} | throw({error, What})
 %%   where Appls = [{App,Vsn}, #application}]
 %%   performs logical checking that we can find all the modules
 %%   etc.
 
-check_modules(Appls, Path, TestP, Machine) ->
+check_modules(Appls, Path, TestP) ->
     %% first check that all the module names are unique
     %% Make a list M1 = [{Mod,App,Dir}]
     M1 = [{Mod,App,A#application.dir} ||
@@ -988,7 +975,7 @@ check_modules(Appls, Path, TestP, Machine) ->
 	     Mod <- A#application.modules],
     case duplicates(M1) of
 	[] ->
-	    case check_mods(M1, Appls, Path, TestP, Machine) of
+	    case check_mods(M1, Appls, Path, TestP) of
 		{error, Errors} ->
 		    throw({error, {modules, Errors}});
 		Return ->
@@ -1004,8 +991,8 @@ check_modules(Appls, Path, TestP, Machine) ->
 %% Use the module extension of the running machine as extension for
 %% the checked modules.
 
-check_mods(Modules, Appls, Path, {SrcTestP, XrefP}, Machine) ->
-    SrcTestRes = check_src(Modules, Appls, Path, SrcTestP, Machine),
+check_mods(Modules, Appls, Path, {SrcTestP, XrefP}) ->
+    SrcTestRes = check_src(Modules, Appls, Path, SrcTestP),
     XrefRes = check_xref(Appls, Path, XrefP),
     Res = SrcTestRes ++ XrefRes,
     case filter(fun({error, _}) -> true;
@@ -1021,8 +1008,8 @@ check_mods(Modules, Appls, Path, {SrcTestP, XrefP}, Machine) ->
 	    {error, Errors}
     end.
 
-check_src(Modules, Appls, Path, true, Machine) ->
-    Ext = objfile_extension(Machine),
+check_src(Modules, Appls, Path, true) ->
+    Ext = code:objfile_extension(),
     IncPath = create_include_path(Appls, Path),
     append(map(fun(ModT) ->
 		       {Mod,App,Dir} = ModT,
@@ -1036,7 +1023,7 @@ check_src(Modules, Appls, Path, true, Machine) ->
 		       end
 	       end,
 	       Modules));
-check_src(_, _, _, _, _) ->
+check_src(_, _, _, _) ->
     [].
 
 check_xref(_Appls, _Path, false) ->
@@ -1133,11 +1120,6 @@ exists_xref(Flag) ->
 	{error, _} -> false;
 	_          -> Flag
     end.
-
-objfile_extension(false) ->
-    code:objfile_extension();
-objfile_extension(Machine) ->
-    "." ++ atom_to_list(Machine).
 
 check_mod(Mod,App,Dir,Ext,IncPath) ->
     ObjFile = mod_to_filename(Dir, Mod, Ext),
@@ -1904,7 +1886,7 @@ add_appl(Name, Vsn, App, Tar, Variables, Flags, Var) ->
 			Tar,
 			AppDir,
 			BinDir,
-			objfile_extension(machine(Flags)))
+			code:objfile_extension())
     end.
 
 %%______________________________________________________________________
@@ -2196,9 +2178,6 @@ cas([{variables, V} | Args], X) when is_list(V) ->
 	error ->
 	    cas(Args, X++[{variables, V}])
     end;
-%%% machine ------------------------------------------------------------
-cas([{machine, M} | Args], X) when is_atom(M) ->
-    cas(Args, X);
 %%% exref --------------------------------------------------------------
 cas([exref | Args], X)  ->
     cas(Args, X);
@@ -2282,9 +2261,6 @@ cat([{variables, V} | Args], X) when is_list(V) ->
 cat([{var_tar, VT} | Args], X) when VT == include;
                                     VT == ownfile;
                                     VT == omit ->
-    cat(Args, X);
-%%% machine ------------------------------------------------------------
-cat([{machine, M} | Args], X) when is_atom(M) ->
     cat(Args, X);
 %%% exref --------------------------------------------------------------
 cat([exref | Args], X)  ->


### PR DESCRIPTION
This PR makes the executable `erl_call` to be part of erts when building Erlang so that tools can rely on it being present and not have to include all of `erl_interface`.

Also, any tool binaries in erts are now filtered away when creating the release tar using `systools:make_tar/1,2`.