### PR TITLE
port_please/2 and port_please/3 can return closed

### DIFF
--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -79,7 +79,7 @@ stop() ->
 %% return {port, P, Version} | noport
 %%
 
--spec port_please(Name, Host) -> {ok, Port, Version} | noport when
+-spec port_please(Name, Host) -> {ok, Port, Version} | noport | closed | {error, term()} when
 	  Name :: atom() | string(),
 	  Host :: atom() | string() | inet:ip_address(),
 	  Port :: non_neg_integer(),
@@ -88,7 +88,7 @@ stop() ->
 port_please(Node, Host) ->
   port_please(Node, Host, infinity).
 
--spec port_please(Name, Host, Timeout) -> {port, Port, Version} | noport when
+-spec port_please(Name, Host, Timeout) -> {port, Port, Version} | noport | closed | {error, term()} when
 	  Name :: atom() | string(),
 	  Host :: atom() | string() | inet:ip_address(),
 	  Timeout :: non_neg_integer() | infinity,


### PR DESCRIPTION
`wait_for_port_reply/2` will return `closed` in the `tcp_closed` case, and this is propagated as the return value of port_please

Reported in the RabbitMQ public slack channel:

https://rabbitmq.slack.com/archives/C1EDN83PA/p1588166195464400