### PR TITLE
Drop commented-out code for the experimental "structs"

### DIFF
--- a/lib/stdlib/examples/erl_id_trans.erl
+++ b/lib/stdlib/examples/erl_id_trans.erl
@@ -193,9 +193,6 @@ pattern({map_field_exact,Line,K,V}) ->
     Ke = expr(K),
     Ve = pattern(V),
     {map_field_exact,Line,Ke,Ve};
-%%pattern({struct,Line,Tag,Ps0}) ->
-%%    Ps1 = pattern_list(Ps0),
-%%    {struct,Line,Tag,Ps1};
 pattern({record,Line,Name,Pfs0}) ->
     Pfs1 = pattern_fields(Pfs0),
     {record,Line,Name,Pfs1};
@@ -433,9 +430,6 @@ expr({map_field_exact,Line,K,V}) ->
     Ke = expr(K),
     Ve = expr(V),
     {map_field_exact,Line,Ke,Ve};
-%%expr({struct,Line,Tag,Es0}) ->
-%%    Es1 = pattern_list(Es0),
-%%    {struct,Line,Tag,Es1};
 expr({record_index,Line,Name,Field0}) ->
     Field1 = expr(Field0),
     {record_index,Line,Name,Field1};

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -20,10 +20,6 @@
 %% Purpose: Expand records into tuples. Also add explicit module
 %% names to calls to imported functions and BIFs.
 
-%% N.B. Although structs (tagged tuples) are not yet allowed in the
-%% language there is code included in pattern/2 and expr/3 (commented out)
-%% that handles them.
-
 -module(erl_expand_records).
 
 -export([module/2]).
@@ -125,9 +121,6 @@ pattern({map_field_exact,Line,K0,V0}, St0) ->
     {K,St1} = expr(K0, St0),
     {V,St2} = pattern(V0, St1),
     {{map_field_exact,Line,K,V},St2};
-%%pattern({struct,Line,Tag,Ps}, St0) ->
-%%    {TPs,TPsvs,St1} = pattern_list(Ps, St0),
-%%    {{struct,Line,Tag,TPs},TPsvs,St1};
 pattern({record_index,Line,Name,Field}, St) ->
     {index_expr(Line, Field, Name, record_fields(Name, St)),St};
 pattern({record,Line0,Name,Pfs}, St0) ->
@@ -310,9 +303,6 @@ expr({map_field_exact,Line,K0,V0}, St0) ->
     {K,St1} = expr(K0, St0),
     {V,St2} = expr(V0, St1),
     {{map_field_exact,Line,K,V},St2};
-%%expr({struct,Line,Tag,Es0}, Vs, St0) ->
-%%    {Es1,Esvs,Esus,St1} = expr_list(Es0, Vs, St0),
-%%    {{struct,Line,Tag,Es1},Esvs,Esus,St1};
 expr({record_index,Line,Name,F}, St) ->
     I = index_expr(Line, F, Name, record_fields(Name, St)),
     expr(I, St);

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -20,9 +20,6 @@
 %%
 %% Do necessary checking of Erlang code.
 
-%% N.B. All the code necessary for checking structs (tagged tuples) is
-%% here. Just comment out the lines in pattern/2, gexpr/3 and expr/3.
-
 -module(erl_lint).
 
 -export([module/1,module/2,module/3,format_error/1]).
@@ -1646,8 +1643,6 @@ pattern({tuple,_Line,Ps}, Vt, Old, Bvt, St) ->
     pattern_list(Ps, Vt, Old, Bvt, St);
 pattern({map,_Line,Ps}, Vt, Old, Bvt, St) ->
     pattern_map(Ps, Vt, Old, Bvt, St);
-%%pattern({struct,_Line,_Tag,Ps}, Vt, Old, Bvt, St) ->
-%%    pattern_list(Ps, Vt, Old, Bvt, St);
 pattern({record_index,Line,Name,Field}, _Vt, _Old, _Bvt, St) ->
     {Vt1,St1} =
         check_record(Line, Name, St,
@@ -2266,8 +2261,6 @@ is_gexpr({string,_L,_S}, _Info) -> true;
 is_gexpr({nil,_L}, _Info) -> true;
 is_gexpr({cons,_L,H,T}, Info) -> is_gexpr_list([H,T], Info);
 is_gexpr({tuple,_L,Es}, Info) -> is_gexpr_list(Es, Info);
-%%is_gexpr({struct,_L,_Tag,Es}, Info) ->
-%%    is_gexpr_list(Es, Info);
 is_gexpr({map,_L,Es}, Info) ->
     is_map_fields(Es, Info);
 is_gexpr({map,_L,Src,Es}, Info) ->

--- a/lib/stdlib/src/erl_pp.erl
+++ b/lib/stdlib/src/erl_pp.erl
@@ -560,8 +560,6 @@ lexpr({bc,_,E,Qs}, _Prec, Opts) ->
     %% {list,[{step,'<<',Lcl},'>>']};
 lexpr({tuple,_,Elts}, _, Opts) ->
     tuple(Elts, Opts);
-%%lexpr({struct,_,Tag,Elts}, _, Opts) ->
-%%  {first,format("~w", [Tag]),tuple(Elts, Opts)};
 lexpr({record_index, _, Name, F}, Prec, Opts) ->
     {P,R} = preop_prec('#'),
     Nl = record_name(Name),


### PR DESCRIPTION
This removes remnants of Joe Armstrong's experiment with "proper structs".