### PR TITLE
Make erlang:get_stacktrace/0 a regular function

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1032,13 +1032,6 @@ BIF_RETTYPE hibernate_3(BIF_ALIST_3)
 }
 
 /**********************************************************************/
-
-BIF_RETTYPE get_stacktrace_0(BIF_ALIST_0)
-{
-    BIF_RET(NIL);
-}
-
-/**********************************************************************/
 /*
  * This is like exit/1, except that errors are logged if they terminate
  * the process, and the final error value will be {Term,StackTrace}.

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -283,7 +283,6 @@ bif erts_internal:is_process_alive/2
 bif erlang:error/1		error_1
 bif erlang:error/2		error_2
 bif erlang:raise/3		raise_3
-bif erlang:get_stacktrace/0
 
 bif erlang:is_builtin/3
 

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -1064,9 +1064,9 @@ get_module_info(_Module) ->
     erlang:nif_error(undefined).
 
 %% get_stacktrace/0
--spec erlang:get_stacktrace() -> [stack_item()].
+-spec erlang:get_stacktrace() -> [].
 get_stacktrace() ->
-    erlang:nif_error(undefined).
+    [].
 
 %% group_leader/0
 -spec group_leader() -> pid().


### PR DESCRIPTION
Since the function now always returns an empty list, it does not
need to be implemented as a BIF, a regular function will work
just fine.
Additionally changing the spec should give some additional signal
forcing people to migrate.

---

This probably needs to update the preloaded modules as well, but I'll leave that to the maintainers