### PR TITLE
Allow any element subpatterns in LHS of ++-patterns

### DIFF
--- a/lib/stdlib/src/erl_eval.erl
+++ b/lib/stdlib/src/erl_eval.erl
@@ -1185,10 +1185,8 @@ match1({bin,_,_}, _, _Bs, _BBs) ->
     throw(nomatch);
 match1({op,_,'++',{nil,_},R}, Term, Bs, BBs) ->
     match1(R, Term, Bs, BBs);
-match1({op,_,'++',{cons,Ai,{integer,A2,I},T},R}, Term, Bs, BBs) ->
-    match1({cons,Ai,{integer,A2,I},{op,Ai,'++',T,R}}, Term, Bs, BBs);
-match1({op,_,'++',{cons,Ai,{char,A2,C},T},R}, Term, Bs, BBs) ->
-    match1({cons,Ai,{char,A2,C},{op,Ai,'++',T,R}}, Term, Bs, BBs);
+match1({op,_,'++',{cons,Ai,H,T},R}, Term, Bs, BBs) ->
+    match1({cons,Ai,H,{op,Ai,'++',T,R}}, Term, Bs, BBs);
 match1({op,_,'++',{string,Ai,L},R}, Term, Bs, BBs) ->
     match1(string_to_conses(L, Ai, R), Term, Bs, BBs);
 match1({op,Anno,Op,A}, Term, Bs, BBs) ->

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -1665,10 +1665,8 @@ pattern({bin,_,Fs}, Vt, Old, St) ->
     pattern_bin(Fs, Vt, Old, St);
 pattern({op,_Anno,'++',{nil,_},R}, Vt, Old, St) ->
     pattern(R, Vt, Old, St);
-pattern({op,_Anno,'++',{cons,Ai,{char,_A2,_C},T},R}, Vt, Old, St) ->
-    pattern({op,Ai,'++',T,R}, Vt, Old, St);    %Char unimportant here
-pattern({op,_Anno,'++',{cons,Ai,{integer,_A2,_I},T},R}, Vt, Old, St) ->
-    pattern({op,Ai,'++',T,R}, Vt, Old, St);    %Weird, but compatible!
+pattern({op,_Line,'++',{cons,Li,H,T},R}, Vt, Old, St) ->
+    pattern_list([H,{op,Li,'++',T,R}], Vt, Old, St);
 pattern({op,_Anno,'++',{string,_Ai,_S},R}, Vt, Old, St) ->
     pattern(R, Vt, Old, St);                   %String unimportant here
 pattern({match,_Anno,Pat1,Pat2}, Vt, Old, St0) ->

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -166,8 +166,15 @@ f(Signal, To) ->
     </section>
 
     <section>
-      <title>String Prefix in Patterns</title>
-      <p>When matching strings, the following is a valid pattern:</p>
+      <title>List and String Prefix in Patterns</title>
+      <p>For a fixed-length list prefix, the <c>++</c> operator is allowed
+      in a pattern to match on the prefix and extract the suffix:</p>
+      <pre>
+f([{a,A},{b,B}] ++ Rest) -> ...</pre>
+      <p>which is just a different way of writing a list pattern with a tail:</p>
+      <pre>
+f([{a,A},{b,B} | Rest]) -> ...</pre>
+      <p>Strings are lists of characters, so the following is also a valid pattern:</p>
       <pre>
 f("prefix" ++ Str) -> ...</pre>
       <p>This is syntactic sugar for the equivalent, but harder to


### PR DESCRIPTION
There is no actual need to restrict the elements of the LHS list
of a ++-pattern to be characters like $x or integers like 65. The
rewriting by the compiler is the same even if patterns like
`[foo,bar,baz] ++ Rest` or `[{x,42},{y,Y}]++Rest` are allowed.
Dropping this restriction removes any real need to use the traditional
list syntax [...|...].