### PR TITLE
Drop remnants of elib_malloc (removed in R15)

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -8269,7 +8269,7 @@ Metadata = #{ pid => pid(),
     </func>
 
     <func>
-      <name name="system_info" arity="1" clause_i="77" since=""/>
+      <name name="system_info" arity="1" clause_i="76" since=""/>
       <fsummary>System info overview.</fsummary>
       <desc>
         <p>Returns information about the current system.
@@ -8283,8 +8283,7 @@ Metadata = #{ pid => pid(),
               <seeerl marker="#system_info_allocated_areas"><c>allocated_areas</c></seeerl>,
               <seeerl marker="#system_info_allocator"><c>allocator</c></seeerl>,
               <seeerl marker="#system_info_alloc_util_allocators"><c>alloc_util_allocators</c></seeerl>,
-              <seeerl marker="#system_info_allocator_sizes"><c>allocator_sizes</c></seeerl>,
-              <seeerl marker="#system_info_elib_malloc"><c>elib_malloc</c></seeerl>
+              <seeerl marker="#system_info_allocator_sizes"><c>allocator_sizes</c></seeerl>
             </p>
           </item>
           <tag><seeerl marker="#system_info_cpu_topology">
@@ -8408,7 +8407,6 @@ Metadata = #{ pid => pid(),
       <name name="system_info" arity="1" clause_i="3" since=""/>   <!-- {allocator, _} -->
       <name name="system_info" arity="1" clause_i="4" since=""/>   <!-- alloc_util_allocators -->
       <name name="system_info" arity="1" clause_i="5" since=""/>   <!-- {allocator_sizes, _} -->
-      <name name="system_info" arity="1" clause_i="27" since=""/>  <!-- elib_malloc -->
       <fsummary>Information about the system allocators.</fsummary>
       <type variable="Allocator" name_i="2"/>
       <type variable="Version" name_i="2"/>
@@ -8547,13 +8545,6 @@ Metadata = #{ pid => pid(),
               <c>erlang:system_info({allocator,
               <anno>Alloc</anno>})</c></seeerl>.</p>
           </item>
-          <tag><marker id="system_info_elib_malloc"/>
-            <c>elib_malloc</c></tag>
-          <item>
-            <p>This option will be removed in a future release.
-              The return value will always be <c>false</c>, as the
-              <c>elib_malloc</c> allocator has been removed.</p>
-          </item>
         </taglist>
       </desc>
     </func>
@@ -8562,8 +8553,8 @@ Metadata = #{ pid => pid(),
       <name name="system_info" arity="1" clause_i="12"
 	    anchor="system_info_cpu_topology" since=""/>           <!-- cpu_topology -->
       <name name="system_info" arity="1" clause_i="13" since=""/>  <!-- {cpu_topology, _} -->
-      <name name="system_info" arity="1" clause_i="38" since=""/>  <!-- logical_processors -->
-      <name name="system_info" arity="1" clause_i="74" since="OTP R14B"/>  <!-- update_cpu_info -->
+      <name name="system_info" arity="1" clause_i="37" since=""/>  <!-- logical_processors -->
+      <name name="system_info" arity="1" clause_i="73" since="OTP R14B"/>  <!-- update_cpu_info -->
       <fsummary>Information about the CPU topology of the system.</fsummary>
       <type name="cpu_topology"/>
       <type name="level_entry"/>
@@ -8724,16 +8715,16 @@ Metadata = #{ pid => pid(),
     </func>
 
     <func>
-      <name name="system_info" arity="1" clause_i="31"
+      <name name="system_info" arity="1" clause_i="30"
 	    anchor="system_info_process" since=""/>  <!-- fullsweep_after -->
-      <name name="system_info" arity="1" clause_i="32" since=""/>  <!-- garbage_collection -->
-      <name name="system_info" arity="1" clause_i="33" since=""/>  <!-- heap_sizes -->
-      <name name="system_info" arity="1" clause_i="34" since=""/>  <!-- heap_type -->
-      <name name="system_info" arity="1" clause_i="40" since="OTP 19.0"/>  <!-- max_heap_size -->
-      <name name="system_info" arity="1" clause_i="41" since="OTP 19.0"/>  <!-- message_queue_data -->
-      <name name="system_info" arity="1" clause_i="42" since="OTP R13B04"/>  <!-- min_heap_size -->
-      <name name="system_info" arity="1" clause_i="43" since="OTP R13B04"/>  <!-- min_bin_vheap_size -->
-      <name name="system_info" arity="1" clause_i="57" since=""/>  <!-- procs -->
+      <name name="system_info" arity="1" clause_i="31" since=""/>  <!-- garbage_collection -->
+      <name name="system_info" arity="1" clause_i="32" since=""/>  <!-- heap_sizes -->
+      <name name="system_info" arity="1" clause_i="33" since=""/>  <!-- heap_type -->
+      <name name="system_info" arity="1" clause_i="39" since="OTP 19.0"/>  <!-- max_heap_size -->
+      <name name="system_info" arity="1" clause_i="40" since="OTP 19.0"/>  <!-- message_queue_data -->
+      <name name="system_info" arity="1" clause_i="41" since="OTP R13B04"/>  <!-- min_heap_size -->
+      <name name="system_info" arity="1" clause_i="42" since="OTP R13B04"/>  <!-- min_bin_vheap_size -->
+      <name name="system_info" arity="1" clause_i="56" since=""/>  <!-- procs -->
       <fsummary>Information about the default process heap settings.</fsummary>
       <type name="message_queue_data"/>
       <type name="max_heap_size"/>
@@ -8845,12 +8836,12 @@ Metadata = #{ pid => pid(),
     <func>
       <name name="system_info" arity="1" clause_i="6" anchor="system_info_limits" since="OTP 20.0"/>   <!-- atom_count -->
       <name name="system_info" arity="1" clause_i="7" since="OTP 20.0"/>   <!-- atom_limit -->
-      <name name="system_info" arity="1" clause_i="29" since="OTP 21.1"/>  <!-- ets_count -->
-      <name name="system_info" arity="1" clause_i="30" since="OTP R16B03"/>  <!-- ets_limit -->
-      <name name="system_info" arity="1" clause_i="53" since="OTP R16B"/>  <!-- port_count -->
-      <name name="system_info" arity="1" clause_i="54" since="OTP R16B"/>  <!-- port_limit -->
-      <name name="system_info" arity="1" clause_i="55" since=""/>  <!-- process_count -->
-      <name name="system_info" arity="1" clause_i="56" since=""/>  <!-- process_limit -->
+      <name name="system_info" arity="1" clause_i="28" since="OTP 21.1"/>  <!-- ets_count -->
+      <name name="system_info" arity="1" clause_i="29" since="OTP R16B03"/>  <!-- ets_limit -->
+      <name name="system_info" arity="1" clause_i="52" since="OTP R16B"/>  <!-- port_count -->
+      <name name="system_info" arity="1" clause_i="53" since="OTP R16B"/>  <!-- port_limit -->
+      <name name="system_info" arity="1" clause_i="54" since=""/>  <!-- process_count -->
+      <name name="system_info" arity="1" clause_i="55" since=""/>  <!-- process_limit -->
       <fsummary>Information about various system limits.</fsummary>
       <desc>
         <marker id="system_info_limits"/>
@@ -8925,13 +8916,13 @@ Metadata = #{ pid => pid(),
     <func>
       <name name="system_info" arity="1" clause_i="26"
 	    anchor="system_info_time" since="OTP 18.0"/>  <!-- end_time -->
-      <name name="system_info" arity="1" clause_i="50" since="OTP 18.0"/>  <!-- os_monotonic_time_source -->
-      <name name="system_info" arity="1" clause_i="51" since="OTP 18.0"/>  <!-- os_system_time_source -->
-      <name name="system_info" arity="1" clause_i="63" since="OTP 18.0"/>  <!-- start_time -->
-      <name name="system_info" arity="1" clause_i="69" since="OTP 18.0"/>  <!-- time_correction -->
-      <name name="system_info" arity="1" clause_i="70" since="OTP 18.0"/>  <!-- time_offset -->
-      <name name="system_info" arity="1" clause_i="71" since="OTP 18.0"/>  <!-- time_warp_mode -->
-      <name name="system_info" arity="1" clause_i="72" since="OTP 17.1"/>  <!-- tolerant_timeofday -->
+      <name name="system_info" arity="1" clause_i="49" since="OTP 18.0"/>  <!-- os_monotonic_time_source -->
+      <name name="system_info" arity="1" clause_i="50" since="OTP 18.0"/>  <!-- os_system_time_source -->
+      <name name="system_info" arity="1" clause_i="62" since="OTP 18.0"/>  <!-- start_time -->
+      <name name="system_info" arity="1" clause_i="68" since="OTP 18.0"/>  <!-- time_correction -->
+      <name name="system_info" arity="1" clause_i="69" since="OTP 18.0"/>  <!-- time_offset -->
+      <name name="system_info" arity="1" clause_i="70" since="OTP 18.0"/>  <!-- time_warp_mode -->
+      <name name="system_info" arity="1" clause_i="71" since="OTP 17.1"/>  <!-- tolerant_timeofday -->
       <fsummary>Information about system time.</fsummary>
       <desc>
         <marker id="system_info_time_tags"/>
@@ -9155,16 +9146,16 @@ Metadata = #{ pid => pid(),
 	    anchor="system_info_scheduler" since="OTP 17.0"/>  <!-- dirty_cpu_schedulers -->
       <name name="system_info" arity="1" clause_i="18" since="OTP 17.0"/>  <!-- dirty_cpu_schedulers_online -->
       <name name="system_info" arity="1" clause_i="19" since="OTP 17.0"/>  <!-- dirty_io_schedulers -->
-      <name name="system_info" arity="1" clause_i="45" since=""/>  <!-- multi_scheduling -->
-      <name name="system_info" arity="1" clause_i="46" since=""/>  <!-- multi_scheduling_blockers -->
-      <name name="system_info" arity="1" clause_i="49" since="OTP 19.0"/>  <!-- normal_multi_scheduling_blockers -->
-      <name name="system_info" arity="1" clause_i="58" since=""/>  <!-- scheduler_bind_type -->
-      <name name="system_info" arity="1" clause_i="59" since=""/>  <!-- scheduler_bindings -->
-      <name name="system_info" arity="1" clause_i="60" since=""/>  <!-- scheduler_id -->
-      <name name="system_info" arity="1" clause_i="61" since=""/>  <!-- schedulers -->
-      <name name="system_info" arity="1" clause_i="62" since=""/>  <!-- smp_support -->
-      <name name="system_info" arity="1" clause_i="67" since=""/>  <!-- threads -->
-      <name name="system_info" arity="1" clause_i="68" since=""/>  <!-- thread_pool_size -->
+      <name name="system_info" arity="1" clause_i="44" since=""/>  <!-- multi_scheduling -->
+      <name name="system_info" arity="1" clause_i="45" since=""/>  <!-- multi_scheduling_blockers -->
+      <name name="system_info" arity="1" clause_i="47" since="OTP 19.0"/>  <!-- normal_multi_scheduling_blockers -->
+      <name name="system_info" arity="1" clause_i="57" since=""/>  <!-- scheduler_bind_type -->
+      <name name="system_info" arity="1" clause_i="58" since=""/>  <!-- scheduler_bindings -->
+      <name name="system_info" arity="1" clause_i="59" since=""/>  <!-- scheduler_id -->
+      <name name="system_info" arity="1" clause_i="60" since=""/>  <!-- schedulers -->
+      <name name="system_info" arity="1" clause_i="61" since=""/>  <!-- smp_support -->
+      <name name="system_info" arity="1" clause_i="66" since=""/>  <!-- threads -->
+      <name name="system_info" arity="1" clause_i="67" since=""/>  <!-- thread_pool_size -->
       <fsummary>Information about system schedulers.</fsummary>
       <desc>
         <marker id="system_info_scheduler_tags"/>
@@ -9549,57 +9540,56 @@ Metadata = #{ pid => pid(),
       <name name="system_info" arity="1" clause_i="24" since="OTP R15B01"/>  <!-- dynamic_trace -->
       <name name="system_info" arity="1" clause_i="25" since="OTP R15B01"/>  <!-- dynamic_trace_probes -->
       <!-- <name name="system_info" arity="1" clause_i="26"/>  end_time -->
-      <!-- <name name="system_info" arity="1" clause_i="27"/>  elib_malloc -->
-      <!-- <name name="system_info" arity="1" clause_i="28"/>  eager_check_io, removed -->
-      <!-- <name name="system_info" arity="1" clause_i="29"/>  ets_count -->
-      <!-- <name name="system_info" arity="1" clause_i="30"/>  ets_limit -->
-      <!-- <name name="system_info" arity="1" clause_i="31"/>  fullsweep_after -->
-      <!-- <name name="system_info" arity="1" clause_i="32"/>  garbage_collection -->
-      <!-- <name name="system_info" arity="1" clause_i="33"/>  heap_sizes -->
-      <!-- <name name="system_info" arity="1" clause_i="34"/>  heap_type -->
-      <name name="system_info" arity="1" clause_i="35" since=""/>  <!-- info -->
-      <name name="system_info" arity="1" clause_i="36" since=""/>  <!-- kernel_poll -->
-      <name name="system_info" arity="1" clause_i="37" since=""/>  <!-- loaded -->
-      <!-- <name name="system_info" arity="1" clause_i="38"/>  logical_processors -->
-      <name name="system_info" arity="1" clause_i="39" since=""/>  <!-- machine -->
-      <!-- <name name="system_info" arity="1" clause_i="40"/>  max_heap_size -->
-      <!-- <name name="system_info" arity="1" clause_i="41"/>  message_queue_data -->
-      <!-- <name name="system_info" arity="1" clause_i="42"/>  min_heap_size -->
-      <!-- <name name="system_info" arity="1" clause_i="43"/>  min_bin_vheap_size -->
-      <name name="system_info" arity="1" clause_i="44" since=""/>  <!-- modified_timing_level -->
-      <!-- <name name="system_info" arity="1" clause_i="45"/>  multi_scheduling -->
-      <!-- <name name="system_info" arity="1" clause_i="46"/>  multi_scheduling_blockers -->
-      <name name="system_info" arity="1" clause_i="47" since="OTP 17.4"/>  <!-- nif_version -->
-      <!-- n<name name="system_info" arity="1" clause_i="48"/>  ormal_multi_scheduling_blockers -->
-      <name name="system_info" arity="1" clause_i="49" since=""/>  <!-- otp_release -->
-      <!-- <name name="system_info" arity="1" clause_i="50"/>  os_monotonic_time_source -->
-      <!-- <name name="system_info" arity="1" clause_i="51"/>  os_system_time_source -->
-      <name name="system_info" arity="1" clause_i="52" since="OTP R16B"/>  <!-- port_parallelism -->
-      <!-- <name name="system_info" arity="1" clause_i="53"/>  port_count -->
-      <!-- <name name="system_info" arity="1" clause_i="54"/>  port_limit -->
-      <!-- <name name="system_info" arity="1" clause_i="55"/>  process_count -->
-      <!-- <name name="system_info" arity="1" clause_i="56"/>  process_limit -->
-      <!-- <name name="system_info" arity="1" clause_i="57"/>  procs -->
-      <!-- <name name="system_info" arity="1" clause_i="58"/>  scheduler_bind_type -->
-      <!-- <name name="system_info" arity="1" clause_i="59"/>  scheduler_bindings -->
-      <!-- <name name="system_info" arity="1" clause_i="60"/>  scheduler_id -->
-      <!-- <name name="system_info" arity="1" clause_i="61"/>  schedulers -->
-      <!-- <name name="system_info" arity="1" clause_i="62"/>  smp_support -->
-      <!-- <name name="system_info" arity="1" clause_i="63"/>  start_time -->
-      <name name="system_info" arity="1" clause_i="64" since=""/>  <!-- system_architecture -->
-      <name name="system_info" arity="1" clause_i="65" since="OTP 21.3"/>  <!-- system_logger -->
-      <name name="system_info" arity="1" clause_i="66" since=""/>  <!-- system_version -->
-      <!-- <name name="system_info" arity="1" clause_i="67"/>  threads -->
-      <!-- <name name="system_info" arity="1" clause_i="68"/>  thread_pool_size -->
-      <!-- <name name="system_info" arity="1" clause_i="69"/>  time_correction -->
-      <!-- <name name="system_info" arity="1" clause_i="70"/>  time_offset -->
-      <!-- <name name="system_info" arity="1" clause_i="71"/>  time_warp_mode -->
-      <!-- <name name="system_info" arity="1" clause_i="72"/>  tolerant_timeofday -->
-      <name name="system_info" arity="1" clause_i="73" since=""/>  <!-- trace_control_word -->
-      <!-- <name name="system_info" arity="1" clause_i="74"/>  update_cpu_info -->
-      <name name="system_info" arity="1" clause_i="75" since=""/>  <!-- version -->
-      <name name="system_info" arity="1" clause_i="76" since=""/>  <!-- wordsize -->
-      <!-- <name name="system_info" arity="1" clause_i="77"/>  overview -->
+      <!-- <name name="system_info" arity="1" clause_i="27"/>  eager_check_io, removed -->
+      <!-- <name name="system_info" arity="1" clause_i="28"/>  ets_count -->
+      <!-- <name name="system_info" arity="1" clause_i="29"/>  ets_limit -->
+      <!-- <name name="system_info" arity="1" clause_i="30"/>  fullsweep_after -->
+      <!-- <name name="system_info" arity="1" clause_i="31"/>  garbage_collection -->
+      <!-- <name name="system_info" arity="1" clause_i="32"/>  heap_sizes -->
+      <!-- <name name="system_info" arity="1" clause_i="33"/>  heap_type -->
+      <name name="system_info" arity="1" clause_i="34" since=""/>  <!-- info -->
+      <name name="system_info" arity="1" clause_i="35" since=""/>  <!-- kernel_poll -->
+      <name name="system_info" arity="1" clause_i="36" since=""/>  <!-- loaded -->
+      <!-- <name name="system_info" arity="1" clause_i="37"/>  logical_processors -->
+      <name name="system_info" arity="1" clause_i="38" since=""/>  <!-- machine -->
+      <!-- <name name="system_info" arity="1" clause_i="39"/>  max_heap_size -->
+      <!-- <name name="system_info" arity="1" clause_i="40"/>  message_queue_data -->
+      <!-- <name name="system_info" arity="1" clause_i="41"/>  min_heap_size -->
+      <!-- <name name="system_info" arity="1" clause_i="42"/>  min_bin_vheap_size -->
+      <name name="system_info" arity="1" clause_i="43" since=""/>  <!-- modified_timing_level -->
+      <!-- <name name="system_info" arity="1" clause_i="44"/>  multi_scheduling -->
+      <!-- <name name="system_info" arity="1" clause_i="45"/>  multi_scheduling_blockers -->
+      <name name="system_info" arity="1" clause_i="46" since="OTP 17.4"/>  <!-- nif_version -->
+      <!-- n<name name="system_info" arity="1" clause_i="47"/> normal_multi_scheduling_blockers -->
+      <name name="system_info" arity="1" clause_i="48" since=""/>  <!-- otp_release -->
+      <!-- <name name="system_info" arity="1" clause_i="49"/>  os_monotonic_time_source -->
+      <!-- <name name="system_info" arity="1" clause_i="50"/>  os_system_time_source -->
+      <name name="system_info" arity="1" clause_i="51" since="OTP R16B"/>  <!-- port_parallelism -->
+      <!-- <name name="system_info" arity="1" clause_i="52"/>  port_count -->
+      <!-- <name name="system_info" arity="1" clause_i="53"/>  port_limit -->
+      <!-- <name name="system_info" arity="1" clause_i="54"/>  process_count -->
+      <!-- <name name="system_info" arity="1" clause_i="55"/>  process_limit -->
+      <!-- <name name="system_info" arity="1" clause_i="56"/>  procs -->
+      <!-- <name name="system_info" arity="1" clause_i="57"/>  scheduler_bind_type -->
+      <!-- <name name="system_info" arity="1" clause_i="58"/>  scheduler_bindings -->
+      <!-- <name name="system_info" arity="1" clause_i="59"/>  scheduler_id -->
+      <!-- <name name="system_info" arity="1" clause_i="60"/>  schedulers -->
+      <!-- <name name="system_info" arity="1" clause_i="61"/>  smp_support -->
+      <!-- <name name="system_info" arity="1" clause_i="62"/>  start_time -->
+      <name name="system_info" arity="1" clause_i="63" since=""/>  <!-- system_architecture -->
+      <name name="system_info" arity="1" clause_i="64" since="OTP 21.3"/>  <!-- system_logger -->
+      <name name="system_info" arity="1" clause_i="65" since=""/>  <!-- system_version -->
+      <!-- <name name="system_info" arity="1" clause_i="66"/>  threads -->
+      <!-- <name name="system_info" arity="1" clause_i="67"/>  thread_pool_size -->
+      <!-- <name name="system_info" arity="1" clause_i="68"/>  time_correction -->
+      <!-- <name name="system_info" arity="1" clause_i="69"/>  time_offset -->
+      <!-- <name name="system_info" arity="1" clause_i="70"/>  time_warp_mode -->
+      <!-- <name name="system_info" arity="1" clause_i="71"/>  tolerant_timeofday -->
+      <name name="system_info" arity="1" clause_i="72" since=""/>  <!-- trace_control_word -->
+      <!-- <name name="system_info" arity="1" clause_i="73"/>  update_cpu_info -->
+      <name name="system_info" arity="1" clause_i="74" since=""/>  <!-- version -->
+      <name name="system_info" arity="1" clause_i="75" since=""/>  <!-- wordsize -->
+      <!-- <name name="system_info" arity="1" clause_i="76"/>  overview -->
       <!--    When adding any entry, make sure to update the overview clause_i -->
       <fsummary>Information about the system.</fsummary>
       <desc>

--- a/erts/doc/src/erts_alloc.xml
+++ b/erts/doc/src/erts_alloc.xml
@@ -423,13 +423,6 @@
             <p><c>sys_alloc</c> cannot be disabled.</p>
           </note>
         </item>
-        <tag><marker id="MYm"/><c>+MYm libc</c></tag>
-        <item>
-          <p><c>malloc</c> library to use. Only
-            <c>libc</c> is available. <c>libc</c> enables the standard
-            <c>libc</c> <c>malloc</c> implementation. By default <c>libc</c>
-            is used.</p>
-        </item>
         <tag><marker id="MYtt"/><c><![CDATA[+MYtt <size>]]></c></tag>
         <item>
           <p>Trim threshold size (in kilobytes). This is the maximum amount

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -234,7 +234,6 @@ atom duplicate_bag
 atom duplicated
 atom dupnames
 atom einval
-atom elib_malloc
 atom emulator
 atom enable_trace
 atom enabled

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2680,10 +2680,6 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
     else if (BIF_ARG_1 == am_alloc_util_allocators) {
 	BIF_RET(erts_alloc_util_allocators((void *) BIF_P));
     }
-    else if (BIF_ARG_1 == am_elib_malloc) {
-	/* To be removed in R15 */
-        BIF_RET(am_false);
-    }
     else if (BIF_ARG_1 == am_os_version) {
 	BIF_RET(os_version_tuple);
     }

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -422,7 +422,6 @@ int main(int argc, char **argv)
     int i;
     char* s;
     char *epmd_prog = NULL;
-    char *malloc_lib;
     int process_args = 1;
     int print_args_exit = 0;
     int print_qouted_cmd_exit = 0;
@@ -489,21 +488,8 @@ int main(int argc, char **argv)
 #endif
 
     /* We need to do this before the ordinary processing. */
-    malloc_lib = get_env("ERL_MALLOC_LIB");
     while (i < argc) {
-	if (argv[i][0] == '+') {
-	    if (argv[i][1] == 'M' && argv[i][2] == 'Y' && argv[i][3] == 'm') {
-		if (argv[i][4] == '\0') {
-		    if (++i < argc)
-			malloc_lib = argv[i];
-		    else
-			usage("+MYm");
-		}
-		else
-		    malloc_lib = &argv[i][4];
-	    }
-	}
-	else if (argv[i][0] == '-') {
+	if (argv[i][0] == '-') {
 	    if (strcmp(argv[i], "-smp") == 0) {
 		if (i + 1 >= argc)
 		    goto smp;
@@ -541,10 +527,6 @@ int main(int argc, char **argv)
 	i++;
     }
 
-    if (malloc_lib) {
-	if (strcmp(malloc_lib, "libc") != 0)
-	    usage("+MYm");
-    }
     emu = add_extra_suffixes(emu);
     emu_name = strsave(emu);
     erts_snprintf(tmpStr, sizeof(tmpStr), "%s" DIRSEP "%s" BINARY_EXT, bindir, emu);

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2747,7 +2747,6 @@ tuple_to_list(_Tuple) ->
          (dynamic_trace) -> none | dtrace | systemtap;
          (dynamic_trace_probes) -> boolean();
          (end_time) -> non_neg_integer();
-         (elib_malloc) -> false;
          (eager_check_io) -> boolean();
          (ets_count) -> pos_integer();
          (ets_limit) -> pos_integer();

--- a/lib/hipe/cerl/erl_bif_types.erl
+++ b/lib/hipe/cerl/erl_bif_types.erl
@@ -887,8 +887,6 @@ type(erlang, system_info, 1, Xs, Opaques) ->
 		     t_binary();
 		   ['dist_ctrl'] ->
 		     t_list(t_tuple([t_atom(), t_sup([t_pid(), t_port()])]));
-		   %% elib_malloc is intentionally not included,
-		   %% because it scheduled for removal in R15.
 		   ['endian'] ->
 		     t_endian();
 		   ['fullsweep_after'] ->

--- a/lib/observer/test/crashdump_viewer_SUITE_data/old_format.dump
+++ b/lib/observer/test/crashdump_viewer_SUITE_data/old_format.dump
@@ -793,7 +793,6 @@ dsend
 dsend_nosuspend
 dunlink
 duplicate_bag
-elib_malloc
 emulator
 enable_trace
 env

--- a/lib/runtime_tools/src/system_information.erl
+++ b/lib/runtime_tools/src/system_information.erl
@@ -397,7 +397,6 @@ os_getenv_erts_specific() ->
 	    "ERL_EMULATOR_DLL",
 	    "ERL_FULLSWEEP_AFTER",
 	    "ERL_LIBS",
-	    "ERL_MALLOC_LIB",
 	    "ERL_MAX_PORTS",
 	    "ERL_MAX_ETS_TABLES",
 	    "ERL_NO_KERNEL_POLL",

--- a/lib/runtime_tools/test/system_information_SUITE_data/information_test_report.dat
+++ b/lib/runtime_tools/test/system_information_SUITE_data/information_test_report.dat
@@ -9739,7 +9739,6 @@
                  {"ERL_EMULATOR_DLL",false},
                  {"ERL_FULLSWEEP_AFTER",false},
                  {"ERL_LIBS",false},
-                 {"ERL_MALLOC_LIB",false},
                  {"ERL_MAX_PORTS",false},
                  {"ERL_MAX_ETS_TABLES",false},
                  {"ERL_NO_VFORK",false},


### PR DESCRIPTION
While working on https://github.com/erlang/otp/pull/2627, I found that this elib_malloc stuff was still in there even though the docs said it was to be removed in R15. See https://github.com/erlang/otp/blob/master/erts/doc/src/notes.xml#L16543