### PR TITLE
Fix incorrect compilation of guard expressions with 'not'

### DIFF
--- a/lib/compiler/src/beam_ssa_bool.erl
+++ b/lib/compiler/src/beam_ssa_bool.erl
@@ -922,9 +922,11 @@ opt_digraph_instr(#b_set{dst=Dst}=I, G0, St) ->
             %% Rewriting 'xor' is not practical. Fortunately,
             %% 'xor' is almost never used in practice.
             not_possible();
-        #b_set{op={bif,'not'},args=[#b_var{}=Bool]} ->
-            G = convert_to_br_node(I, Fail, G1, St),
-            redirect_test(Bool, {fail,Succ}, G, St);
+        #b_set{op={bif,'not'}} ->
+            %% This is suprisingly rare. The previous attempt to
+            %% optimize it was broken, which wasn't noticed because
+            %% very few test cases triggered this code.
+            not_possible();
         #b_set{op=phi,dst=Bool} ->
             Vtx = get_vertex(Bool, St),
             G2 = del_out_edges(Vtx, G1),

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -2300,6 +2300,7 @@ beam_bool_SUITE(_Config) ->
     in_catch(),
     recv_semi(),
     andalso_repeated_var(),
+    erl1246(),
     ok.
 
 before_and_inside_if() ->
@@ -2596,6 +2597,30 @@ andalso_repeated_var() ->
 
 andalso_repeated_var(B) when B andalso B -> ok;
 andalso_repeated_var(_) -> error.
+
+-record(erl1246, {tran_stat = 0}).
+
+erl1246() ->
+    false = erl1246(#erl1246{tran_stat = 0}, #{cid => 1131}),
+    false = erl1246(#erl1246{tran_stat = 12}, #{cid => 1131}),
+    false = erl1246(#erl1246{tran_stat = 12}, #{cid => 9502}),
+    true = erl1246(#erl1246{tran_stat = 0}, #{cid => 9502}),
+    ok.
+
+erl1246(Rec, #{cid := CollID}) ->
+    {GiftCollID, _} = erl1246_conf(gift_coll),
+    IsTranStat = Rec#erl1246.tran_stat =:= erl1246_conf(transform_id),
+    if
+        %% Optimization of 'not' in a guard was broken.
+        CollID =:= GiftCollID andalso not IsTranStat ->
+            true;
+        true ->
+            false
+    end.
+
+erl1246_conf(gift_coll) -> {9502, {112, 45}};
+erl1246_conf(transform_id) -> 12;
+erl1246_conf(_) -> undefined.
 
 %%%
 %%% End of beam_bool_SUITE tests.


### PR DESCRIPTION
The optimization of 'not' in a guard by the beam_ssa_bool pass was
broken. It turns out that this optimization was very seldom triggered
and therefore was not well-tested. Fix the problem by removing the
optimization of 'not'.

https://bugs.erlang.org/browse/ERL-1246