### PR TITLE
Introduce file:delete/2 supporting 'raw' option

### DIFF
--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -425,10 +425,16 @@ f.txt:  {person, "kalle", 25}.
     </func>
     <func>
       <name name="delete" arity="1" since=""/>
+      <name name="delete" arity="2" since=""/>
       <fsummary>Delete a file.</fsummary>
+      <type name="delete_option"/>
       <desc>
         <p>Tries to delete file <c><anno>Filename</anno></c>.
           Returns <c>ok</c> if successful.</p>
+        <p>If the option <c>raw</c> is set, the file server is not called.
+           This can be useful in particular during the early boot stage when
+           the file server is not yet registered, to still be able to delete
+           local files.</p>
         <p>Typical error reasons:</p>
         <taglist>
           <tag><c>enoent</c></tag>

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -2313,6 +2313,21 @@ delete(Config) when is_list(Config) ->
     {error, _} = ?FILE_MODULE:open(Name, read),
     %% Try deleting a nonexistent file
     {error, enoent} = ?FILE_MODULE:delete(Name),
+    Name2 = filename:join(RootDir,
+                          atom_to_list(?MODULE)
+                          ++"_delete_2.fil"),
+    {ok, Fd3} = ?FILE_MODULE:open(Name2, write),
+    io:format(Fd3,"ok.\n",[]),
+    ok = ?FILE_MODULE:close(Fd3),
+    %% Check that the file is readable
+    {ok, Fd4} = ?FILE_MODULE:open(Name2, read),
+    ok = ?FILE_MODULE:close(Fd4),
+    %% Try deleting with the raw option
+    ok = ?FILE_MODULE:delete(Name2, [raw]),
+    %% Check that the file is not readable anymore
+    {error, _} = ?FILE_MODULE:open(Name2, read),
+    %% Try deleting a nonexistent file with the raw option
+    {error, enoent} = ?FILE_MODULE:delete(Name2, [raw]),
     [] = flush(),
     ok.
 


### PR DESCRIPTION
As dicussed in [ERL-1244](https://bugs.erlang.org/browse/ERL-1244), here is a PR implementing  file:delete/2 supporting the 'raw' option.

Let me know if this is going in the right direction, then I'll add a corresponding documentation update in a second commit.

Thanks, Jérôme