### PR TITLE
User defined tls alert for selfsigned cert

### DIFF
--- a/lib/public_key/doc/src/public_key.xml
+++ b/lib/public_key/doc/src/public_key.xml
@@ -448,6 +448,10 @@ fun(OtpCert :: #'OTPCertificate'{},
 	verifying application-specific extensions. If called with an
 	extension unknown to the user application, the return value
 	<c>{unknown, UserState}</c> is to be used.</p>
+  <note><p>
+  Note that user defined custom verify_fun may alter original 
+  path validation error (e.g <c>selfsigned_peer</c>). Use with caution.
+  </p></note>
 
 	</item>
 	<tag>{max_path_length, integer()}</tag>

--- a/lib/public_key/doc/src/public_key.xml
+++ b/lib/public_key/doc/src/public_key.xml
@@ -448,10 +448,10 @@ fun(OtpCert :: #'OTPCertificate'{},
 	verifying application-specific extensions. If called with an
 	extension unknown to the user application, the return value
 	<c>{unknown, UserState}</c> is to be used.</p>
-  <note><p>
-  Note that user defined custom verify_fun may alter original 
+  <warning><p>
+  Note that user defined custom <c>verify_fun</c> may alter original
   path validation error (e.g <c>selfsigned_peer</c>). Use with caution.
-  </p></note>
+  </p></warning>
 
 	</item>
 	<tag>{max_path_length, integer()}</tag>

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -928,8 +928,8 @@ pkix_path_validation(PathErr, [Cert | Chain], Options0) when is_atom(PathErr)->
 	    Options = proplists:delete(verify_fun, Options0),
 	    pkix_path_validation(Otpcert, Chain, [{verify_fun,
 						   {VerifyFun, Userstate}}| Options]);
-	{fail, _} ->
-	    {error, Reason}
+	{fail, UserReason} ->
+	    {error, UserReason}
     catch
 	_:_ ->
 	    {error, Reason}

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -586,6 +586,19 @@ pkix_path_validation(Config) when is_list(Config) ->
     {ok, _} =
 	public_key:pkix_path_validation(unknown_ca, [Cert1], [{verify_fun,
 							      VerifyFunAndState1}]),
+
+    VerifyFunAndState2 =
+        {fun(_, {bad_cert, selfsigned_peer}, _UserState) ->
+                  {fail, custom_reason};
+            (_,{extension, _}, UserState) ->
+		          {unknown, UserState};
+	        (_, valid, UserState) ->
+		          {valid, UserState}
+        end, []},
+
+    {error, custom_reason} =
+        public_key:pkix_path_validation(selfsigned_peer, [Trusted], [{verify_fun,
+                                                                     VerifyFunAndState2}]),
     ok.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This PR aims at giving user possibility to generate custom TLS alert for path validation errors.
Previously, no matter what user defined verify_fun returned, the alert was always Bad Certificate.
The changes allow user to control TLS alert in similar way that is done for certificates with valid paths.