### PR TITLE
Fix `since` field being hidden

### DIFF
--- a/lib/erl_docgen/priv/css/otp_doc.css
+++ b/lib/erl_docgen/priv/css/otp_doc.css
@@ -76,7 +76,7 @@ a:visited      { color: #1b6ec2; text-decoration: none }
 /* Invisible table for function specs,
  * just to get since-version out in right margin */
 .func-table, .func-tr, .func-td, .cfunc-td, .func-since-td {
-    width: 200%;
+    width: 100%;
     border: 0;
     padding: 0;
     margin: 0;
@@ -86,10 +86,6 @@ a:visited      { color: #1b6ec2; text-decoration: none }
     background: inherit  /* turn off zebra striped rows */
 }
 
-.func-td {
-    width: 50%;
-}
-
 .cfunc-td {
     width: 50%;
     padding-left: 100px;
@@ -97,7 +93,7 @@ a:visited      { color: #1b6ec2; text-decoration: none }
 }
 
 .func-since-td {
-    width: 50%;
+    width: 6em;
     padding-left: 1em
 }
 


### PR DESCRIPTION
See comments in https://github.com/erlang/otp/pull/2571

---

Putting it up here so it's easier for people to test locally.