### PR TITLE
Fixup erl_lint:format_error/1 deprecation clause

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -249,7 +249,7 @@ format_error({redefine_bif_import,{F,A}}) ->
     io_lib:format("import directive overrides auto-imported BIF ~w/~w~n"
 		  " - use \"-compile({no_auto_import,[~w/~w]}).\" to resolve name clash", [F,A,F,A]);
 format_error({deprecated, MFA, String, Rel}) ->
-    io_lib:format("~s is deprecated and will be removed in ~s; use ~s",
+    io_lib:format("~s is deprecated and will be removed in ~s; ~s",
 		  [format_mfa(MFA), Rel, String]);
 format_error({deprecated, MFA, String}) when is_list(String) ->
     io_lib:format("~s is deprecated; ~s", [format_mfa(MFA), String]);

--- a/lib/stdlib/src/erl_scan.erl
+++ b/lib/stdlib/src/erl_scan.erl
@@ -69,9 +69,9 @@
 %% Removed functions and types
 -removed([{set_attribute,3,"use erl_anno:set_line/2 instead"},
           {attributes_info,'_',
-           "erl_anno:{column,line,location,text}/1 instead"},
+           "use erl_anno:{column,line,location,text}/1 instead"},
           {token_info,'_',
-           "erl_scan:{category,column,line,location,symbol,text}/1 instead"}]).
+           "use erl_scan:{category,column,line,location,symbol,text}/1 instead"}]).
 
 -removed_type([{column,0,"use erl_anno:column() instead"},
                {line,0,"use erl_anno:line() instead"},


### PR DESCRIPTION
In the case of deprecation warnings erl_lint:format_error/1 would include the word `use` while all `-deprecated/1` calls included the word `use` resulting in `use use` in the warning message.


I'd be happy to write a test but it didn't look like there were any tests concerned with this level of detail and assumed it's probably unwanted.

Before : 

```
src/mod.erl:line_no: Warning: crypto:block_encrypt/4 is deprecated and will be removed in OTP 24; use use crypto:crypto_one_time/5, crypto:crypto_one_time_aead/6,7 or crypto:crypto_(dyn_iv)?_init + crypto:crypto_(dyn_iv)?_update + crypto:crypto_final instead
```

After:

```
src/mod.erl:line_no:  Warning: crypto:block_encrypt/4 is deprecated and will be removed in OTP 24; use crypto:crypto_one_time/5, crypto:crypto_one_time_aead/6,7 or crypto:crypto_(dyn_iv)?_init + crypto:crypto_(dyn_iv)?_update + crypto:crypto_final instead
```

The other way to tackle this is to keep `use` in the `format_error/1` clause and remove `use` from all the string elements in the `-deprecated/1` clause. 