### PR TITLE
Fix system restart when installing in silent mode

### DIFF
--- a/erts/etc/win32/nsis/erlang20.nsi
+++ b/erts/etc/win32/nsis/erlang20.nsi
@@ -134,7 +134,7 @@ Section "Microsoft redistributable libraries." SecMSRedist
 	IfSilent +3
 	    ExecWait '"$INSTDIR\${REDIST_EXECUTABLE}"'
 	Goto +2
-	    ExecWait '"$INSTDIR\${REDIST_EXECUTABLE}" /q'
+	    ExecWait '"$INSTDIR\${REDIST_EXECUTABLE}" /q /norestart'
 
   	!verbose 1
 SectionEnd ; MSRedist


### PR DESCRIPTION
Prevent redist from restarting the system and thus aborting the
installation when installing in silent mode.