### PR TITLE
Fix line number for failing map update

### DIFF
--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -746,6 +746,13 @@ line_numbers(Config) when is_list(Config) ->
               {?MODULE,line_numbers,1,_}|_]}} =
         (catch increment2(x)),
 
+    {'EXIT',{{badmap,not_a_map},
+             [{?MODULE,update_map,1,[{file,"map.erl"},{line,3}]}|_]}} =
+        (catch update_map(not_a_map)),
+    {'EXIT',{{badkey,a},
+             [{?MODULE,update_map,1,[{file,"map.erl"},{line,4}]}|_]}} =
+        (catch update_map(#{})),
+
     ok.
 
 id(I) -> I.
@@ -858,3 +865,8 @@ increment1(Arg) ->                              %Line 43
 increment2(Arg) ->                              %Line 46
     _ = id(Arg),                                %Line 47
     Arg + 1.                                    %Line 48
+
+-file("map.erl", 1).
+update_map(M0) ->                               %Line 2
+    M = M0#{new => value},                      %Line 3
+    M#{a := b}.                                 %Line 4

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -1719,9 +1719,9 @@ cg_test({float,Op0}, Fail, Args, Dst, #cg_set{anno=Anno}) ->
     [line(Anno),{bif,Op,Fail,Args,Dst}];
 cg_test(peek_message, Fail, [], Dst, _I) ->
     [{loop_rec,Fail,{x,0}}|copy({x,0}, Dst)];
-cg_test(put_map, Fail, [{atom,exact},SrcMap|Ss], Dst, Set) ->
+cg_test(put_map, Fail, [{atom,exact},SrcMap|Ss], Dst, #cg_set{anno=Anno}=Set) ->
     Live = get_live(Set),
-    [{put_map_exact,Fail,SrcMap,Dst,Live,{list,Ss}}].
+    [line(Anno),{put_map_exact,Fail,SrcMap,Dst,Live,{list,Ss}}].
 
 cg_bs_get(Fail, #cg_set{dst=Dst0,args=[#b_literal{val=Type}|Ss0]}=Set, St) ->
     Op = case Type of


### PR DESCRIPTION
If the update of a map using the syntax `Map#{Key := Value}` failed,
the line number in the stack backtrace could be wrong.

https://bugs.erlang.org/browse/ERL-1271