### PR TITLE
Fix bug in erlang:load_nif/2 sometimes throwing badarg

### DIFF
--- a/erts/emulator/beam/bif_instrs.tab
+++ b/erts/emulator/beam/bif_instrs.tab
@@ -648,6 +648,6 @@ i_load_nif() {
         SWAPOUT;
         c_p->current = NULL;
         c_p->arity = 2;
-        goto do_schedule;
+        goto context_switch3;
     }
 }


### PR DESCRIPTION
Preliminary proposed fix for https://bugs.erlang.org/browse/ERL-1273.

Bug only exists since OTP 23.0.


The problem is in instruction i_load_nif when it fails to seize code_write_permission. When yielding it does not save the arguments reg[0] and reg[1].