### PR TITLE
Eliminate compiler crash for repeated is_map_key/2 calls

### DIFF
--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -1197,10 +1197,17 @@ cg_block([#cg_set{op=is_tagged_tuple,dst=Bool,args=Args0}], {Bool,Fail}, St) ->
 cg_block([#cg_set{op=is_nonempty_list,dst=Bool,args=Args0}], {Bool,Fail}, St) ->
     Args = beam_args(Args0, St),
     {[{test,is_nonempty_list,ensure_label(Fail, St),Args}],St};
-cg_block([#cg_set{op=has_map_field,dst=Bool,args=Args0}], {Bool,Fail0}, St) ->
-    [Src,Key] = beam_args(Args0, St),
+cg_block([#cg_set{op=has_map_field,dst=Dst0,args=Args0}], {Dst0,Fail0}, St) ->
     Fail = ensure_label(Fail0, St),
-    {[{test,has_map_fields,Fail,Src,{list,[Key]}}],St};
+    case beam_args([Dst0|Args0], St) of
+        [{z,0},Src,Key] ->
+            {[{test,has_map_fields,Fail,Src,{list,[Key]}}],St};
+        [Dst,Src,Key] ->
+            %% The result is used more than once. Must rewrite to bif:is_map_key
+            %% to set the destination register.
+            {[{bif,is_map_key,Fail0,[Key,Src],Dst},
+              {test,is_eq_exact,Fail,[Dst,{atom,true}]}],St}
+    end;
 cg_block([#cg_set{op=call}=Call], {_Bool,_Fail}=Context, St0) ->
     {Is0,St1} = cg_call(Call, body, none, St0),
     {Is1,St} = cg_block([], Context, St1),

--- a/lib/compiler/test/beam_ssa_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_SUITE.erl
@@ -440,12 +440,85 @@ recv_coverage_2() ->
 
 maps(_Config) ->
     {'EXIT',{{badmatch,#{}},_}} = (catch maps_1(any)),
+
+    {jkl,nil,nil} = maps_2(#{abc => 0, jkl => 0}),
+    {def,ghi,abc} = maps_2(#{abc => 0, def => 0}),
+    {def,ghi,jkl} = maps_2(#{def => 0, jkl => 0}),
+    {mno,nil,abc} = maps_2(#{abc => 0, mno => 0, jkl => 0}),
+    {jkl,nil,nil} = maps_2(#{jkl => 0}),
+    error = maps_2(#{}),
+
     ok.
 
 maps_1(K) ->
     _ = id(42),
     #{K:=V} = #{},
     V.
+
+maps_2(Map) ->
+    Res = maps_2a(Map),
+    Res = maps_2b(Map),
+    Res.
+
+maps_2a(#{} = Map) ->
+    case case Abc = is_map_key(abc, Map) of
+             false -> false;
+             _ -> is_map_key(def, Map)
+         end of
+        true ->
+            {def, ghi, abc};
+        false ->
+            case case Jkl = is_map_key(jkl, Map) of
+                     false -> false;
+                     _ -> is_map_key(def, Map)
+                 end of
+                true ->
+                    {def, ghi, jkl};
+                false ->
+                    case case Abc of
+                             false -> false;
+                             _ -> is_map_key(mno, Map)
+                         end of
+                        true ->
+                            {mno, nil, abc};
+                        false ->
+                            case Jkl of
+                                true -> {jkl, nil, nil};
+                                false -> error
+                            end
+                    end
+            end
+    end.
+
+maps_2b(#{}=Map) ->
+    case case is_map_key(abc, Map) of
+             false -> false;
+             _ -> is_map_key(def, Map)
+         end of
+        true ->
+            {def, ghi, abc};
+        false ->
+            case case is_map_key(jkl, Map) of
+                     false -> false;
+                     _ -> is_map_key(def, Map)
+                 end of
+                true ->
+                    {def, ghi, jkl};
+                false ->
+                    case case is_map_key(abc, Map) of
+                             false -> false;
+                             _ -> is_map_key(mno, Map)
+                         end of
+                        true ->
+                            {mno, nil, abc};
+                        false ->
+                            case is_map_key(jkl, Map) of
+                                true -> {jkl, nil, nil};
+                                false -> error
+                            end
+                    end
+            end
+    end.
 
 -record(wx_ref, {type=any_type,ref=any_ref}).
 


### PR DESCRIPTION
Eliminate a compiler crash when there are repeated calls to `is_map_key/2`
with the same arguments.

https://bugs.erlang.org/browse/ERL-1276