### PR TITLE
erts: set quota to 1 if cpu quota is less than 1

### DIFF
--- a/erts/lib_src/common/erl_misc_utils.c
+++ b/erts/lib_src/common/erl_misc_utils.c
@@ -1216,6 +1216,9 @@ read_cpu_quota(int limit)
             if (cfs_period_us > 0 && cfs_quota_us > 0) {
                 size_t quota = cfs_quota_us / cfs_period_us;
 
+                if (quota == 0) {
+                    quota = 1;
+                }
                 if (quota > 0 && quota <= (size_t)limit) {
                     return quota;
                 }


### PR DESCRIPTION
Fixes https://bugs.erlang.org/browse/ERL-1280

With this, if CPU quota is less than 1, we will try to use `1` as the quota. Without this, cores number will be used.