### PR TITLE
Document epp:scan_erl_form/1 and add epp:scan_file/2

### DIFF
--- a/lib/stdlib/doc/src/epp.xml
+++ b/lib/stdlib/doc/src/epp.xml
@@ -72,6 +72,9 @@
     <datatype>
       <name name="source_encoding"></name>
     </datatype>
+    <datatype>
+      <name name="warning_info"></name>
+    </datatype>
   </datatypes>
 
   <funcs>
@@ -160,7 +163,6 @@
       <name name="parse_erl_form" arity="1" since=""/>
       <fsummary>Return the next Erlang form from the opened Erlang source file.
       </fsummary>
-      <type name="warning_info"/>
       <desc>
         <p>Returns the next Erlang form from the opened Erlang source file.
         Tuple <c>{eof, <anno>Location</anno>}</c> is returned at the end
@@ -226,6 +228,32 @@
           default, which is correct for Erlang source files. If set to
           <c>false</c>, the encoding string does not necessarily have to
           occur in a comment.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="scan_erl_form" arity="1" since="OTP R13B03"/>
+      <fsummary>Return the raw tokens of the next Erlang form from the opened
+      Erlang source file.</fsummary>
+      <desc>
+        <p>Returns the raw tokens of the next Erlang form from the opened
+        Erlang source file. A tuple <c>{eof, Line}</c> is
+        returned at the end of the file. The first form corresponds to an
+        implicit attribute <c>-file(File,1).</c>, where <c>File</c> is the
+        file name.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="scan_file" arity="2" since="OTP 24.0"/>
+      <fsummary>Preprocess an Erlang source file, returning raw tokens.</fsummary>
+      <desc>
+        <p>Preprocesses an Erlang source file returning a list of the lists
+        of raw tokens of each form.
+        Notice that the tuple <c>{eof, Line}</c> returned at the
+        end of the file is included as a "form", and any failures to scan a
+        form are included in the list as tuples <c>{error,
+        <anno>ErrorInfo</anno>}</c>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/erl_scan.erl
+++ b/lib/stdlib/src/erl_scan.erl
@@ -63,7 +63,7 @@
 -export_type([error_info/0,
               options/0,
               return_cont/0,
-              token/0,
+              token/0, tokens/0,
               tokens_result/0]).
 
 %% Removed functions and types

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -29,7 +29,7 @@
          otp_8562/1, otp_8665/1, otp_8911/1, otp_10302/1, otp_10820/1,
          otp_11728/1, encoding/1, extends/1,  function_macro/1,
 	 test_error/1, test_warning/1, otp_14285/1,
-	 test_if/1,source_name/1,otp_16978/1,otp_16824/1]).
+	 test_if/1,source_name/1,otp_16978/1,otp_16824/1,scan_file/1]).
 
 -export([epp_parse_erl_form/2]).
 
@@ -70,7 +70,7 @@ all() ->
      overload_mac, otp_8388, otp_8470, otp_8562,
      otp_8665, otp_8911, otp_10302, otp_10820, otp_11728,
      encoding, extends, function_macro, test_error, test_warning,
-     otp_14285, test_if, source_name, otp_16978,otp_16824].
+     otp_14285, test_if, source_name, otp_16978, otp_16824, scan_file].
 
 groups() -> 
     [{upcase_mac, [], [upcase_mac_1, upcase_mac_2]},
@@ -840,6 +840,21 @@ otp_8130(Config) when is_list(Config) ->
 
     _ = ifdef(Config),
 
+    ok.
+
+scan_file(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    File = filename:join(DataDir, "source_name.erl"),
+
+    {ok, Toks, [{encoding, _}]} = epp:scan_file(File, []),
+    [FileForm1, ModuleForm, ExportForm,
+     FileForm2, FileForm3, FunctionForm,
+     {eof,_}] = Toks,
+    [{'-',_}, {atom,_,file}, {'(',_} | _ ] = FileForm1,
+    [{'-',_}, {atom,_,module}, {'(',_} | _ ] = ModuleForm,
+    [{'-',_}, {atom,_,export}, {'(',_} | _ ] = ExportForm,
+    [{'-',_}, {atom,_,file}, {'(',_} | _ ] = FileForm2,
+    [{'-',_}, {atom,_,file}, {'(',_} | _ ] = FileForm3,
     ok.
 
 macs(Epp) ->


### PR DESCRIPTION
epp:scan_erl_form/1 was undocumented, but in use by edoc and there were tests for it.
epp:scan_file/2 can be used to implement e.g. a standalone token level preprocessor pass, like gcc -E.