### PR TITLE
erts: Revert small doc change

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -7772,7 +7772,7 @@ ok
             has been suspended
             more times by the calling process than can be represented by the
             currently used internal data structures. The system limit is
-            greater than 2 billion suspends and will never be lower.
+            greater than 2,000,000,000 suspends and will never be lower.
           </item>
         </taglist>
       </desc>


### PR DESCRIPTION
Avoid "billion" as it can be ambiguous depending on language.