### PR TITLE
Fixing crash in appmon_info:format for a closed port

### DIFF
--- a/lib/runtime_tools/src/appmon_info.erl
+++ b/lib/runtime_tools/src/appmon_info.erl
@@ -713,7 +713,11 @@ format(P) when is_pid(P) ->
 	_ -> pid_to_list(P)
     end;
 format(P) when is_port(P) ->
-    "port " ++ integer_to_list(element(2, erlang:port_info(P, id)));
+    case erlang:port_info(P, id) of
+        undefined -> "port closed";
+        {_, Pid} ->
+            "port " ++ integer_to_list(element(2, Pid))
+    end;
 format(X) ->
     io:format("What: ~p~n", [X]),
     "???".

--- a/lib/runtime_tools/src/appmon_info.erl
+++ b/lib/runtime_tools/src/appmon_info.erl
@@ -716,7 +716,7 @@ format(P) when is_port(P) ->
     case erlang:port_info(P, id) of
         undefined -> "port closed";
         {_, Pid} ->
-            "port " ++ integer_to_list(element(2, Pid))
+            "port " ++ integer_to_list(Pid)
     end;
 format(X) ->
     io:format("What: ~p~n", [X]),


### PR DESCRIPTION
This PR tries to fix the following crash we observed on our verification testing VM:

`2020-05-02 11:33:33 =ERROR REPORT====

** Generic server appmon_info terminating

** Last message in was {do_it,{app,mhs,<0.2732.0>}}

** When Server state == {state,<0.7060.0>,[],#Ref<0.3033159193.3255697412.174888>,[<0.7060.0>]}

** Reason for termination ==

** {badarg,[{appmon_info,format,1,[{file,"appmon_info.erl"},{line,716}]},{appmon_info,format,1,[{file,"appmon_info.erl"},{line,706}]},{appmon_info,format,1,[{file,"appmon_info.erl"},{line,706}]},{appmon_info,calc_app_tree,2,[{file,"appmon_info.erl"},{line,454}]},{appmon_info,do_work,2,[{file,"appmon_info.erl"},{line,308}]},{appmon_info,handle_info,2,[{file,"appmon_info.erl"},{line,276}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,616}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,686}]}]}

2020-05-02 11:33:33 =CRASH REPORT====

  crasher:

    initial call: appmon_info:init/1

    pid: <0.7061.0>

    registered_name: appmon_info

    exception error: bad argument: [{appmon_info,format,1,[{file,"appmon_info.erl"},{line,716}]},{appmon_info,format,1,[{file,"appmon_info.erl"},{line,706}]},{appmon_info,format,1,[{file,"appmon_info.erl"},{line,706}]},{appmon_info,calc_app_tree,2,[{file,"appmon_info.erl"},{line,454}]},{appmon_info,do_work,2,[{file,"appmon_info.erl"},{line,308}]},{appmon_info,handle_info,2,[{file,"appmon_info.erl"},{line,276}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,616}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,686}]}]

    ancestors: [<0.7060.0>,healthmon_sup,<0.2728.0>]

    message_queue_len: 2

    messages: [{do_it,{app,butler_shared,<0.2732.0>}},{do_it,{app,hackney,<0.2732.0>}}]

    links: [<0.7060.0>]

    dictionary: []

    trap_exit: true

    status: running

    heap_size: 10958

    stack_size: 27

    reductions: 366441825

  neighbours:

    neighbour: [{pid,<0.7060.0>},{registered_name,[]},{initial_call,{appmon_watcher,init,['Argument__1']}},{current_function,{gen_statem,loop_receive,3}},{ancestors,[healthmon_sup,<0.2728.0>]},{message_queue_len,0},{links,[<0.2729.0>,<0.7061.0>]},{trap_exit,false},{status,waiting},{heap_size,233},{stack_size,12},{reductions,207},{current_stacktrace,[{gen_statem,loop_receive,3,[{file,"gen_statem.erl"},{line,880}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}]

2020-05-02 11:33:33 =SUPERVISOR REPORT====

     Supervisor: {local,healthmon_sup}

     Context:    child_terminated

     Reason:     {badarg,[{appmon_info,format,1,[{file,"appmon_info.erl"},{line,716}]},{appmon_info,format,1,[{file,"appmon_info.erl"},{line,706}]},{appmon_info,format,1,[{file,"appmon_info.erl"},{line,706}]},{appmon_info,calc_app_tree,2,[{file,"appmon_info.erl"},{line,454}]},{appmon_info,do_work,2,[{file,"appmon_info.erl"},{line,308}]},{appmon_info,handle_info,2,[{file,"appmon_info.erl"},{line,276}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,616}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,686}]}]}

     Offender:   [{pid,<0.7060.0>},{id,appmon_watcher},{mfargs,{appmon_watcher,start_link,[]}},{restart_type,{permanent,30}},{shutdown,2000},{child_type,worker}]`