### PR TITLE
EDoc: Allow user defined macros to be functions

### DIFF
--- a/lib/edoc/src/edoc_macros.erl
+++ b/lib/edoc/src/edoc_macros.erl
@@ -58,6 +58,8 @@ std_macros(Env) ->
 
 check_defs([{K, D} | Ds]) when is_atom(K), is_list(D) ->
     check_defs(Ds);
+check_defs([{K, D} | Ds]) when is_atom(K), is_function(D, 3) ->
+    check_defs(Ds);
 check_defs([X | _Ds]) ->
     report("bad macro definition: ~P.", [X, 10]),
     exit(error);


### PR DESCRIPTION
This makes them equal to the builtin ones, and allows for neat things
like linking to the offical docs page:

```erlang
man_doc_macro(MacroArg, _Line, _Env) ->
    {ok, Pattern} = re:compile("([^:]+):([^/]+)/(\\d+)"),
    {match, [Module, Function, Arity]} = re:run(
        MacroArg, Pattern, [{capture, all_but_first, binary}]
    ),
    lists:flatten(io_lib:format(
        "<a href=\"https://erlang.org/man/~ts.html#~ts-~ts\"><code>~ts</code></a>",
        [Module, Function, Arity, MacroArg]
    )).
```

---

Which allows for:

```erlang
%%% {@man maps:merge/2}
```

To output:

```html
<a href="https://erlang.org/man/maps.html#merge-2"><code>maps:merge/2</code></a>
```