### PR TITLE
Add optional_applications to .app resource files

### DIFF
--- a/lib/kernel/doc/src/app.xml
+++ b/lib/kernel/doc/src/app.xml
@@ -59,6 +59,7 @@
    {maxT,         MaxT},
    {registered,   Names},
    {included_applications, Apps},
+   {optional_applications, Apps},
    {applications, Apps},
    {env,          Env},
    {mod,          Start},
@@ -148,10 +149,21 @@ ApplicationVersion = string()</code>
       <tag><c>applications</c></tag>
       <item>
         <p>All applications that must be started before this
-          application is allowed to be started. <c>systools</c> uses
-          this list to generate correct start scripts. Defaults to
-          the empty list, but notice that all applications have
-          dependencies to (at least) Kernel and STDLIB.</p>
+          application. If an application is also listed in
+          <c>optional_applications</c>, then the application
+          is not required to exist (but if it exists, it is
+          also guaranteed to be started before this one).</p>
+        <p><c>systools</c> uses this list to generate correct start
+          scripts. Defaults to the empty list, but notice that all
+          applications have dependencies to (at least) Kernel and STDLIB.</p>
+      </item>
+      <tag><c>optional_applications</c></tag>
+      <item>
+        <p>A list of <c>applications</c> that are optional.
+          Note if you want an optional dependency to be
+          automatically started before the current application
+          whenever it is available, it must be listed on both
+          <c>applications</c> and <c>optional_applications</c>.</p>
       </item>
       <tag><c>env</c></tag>
       <item>
@@ -239,4 +251,3 @@ ApplicationVersion = string()</code>
       <seeerl marker="sasl:systools"><c>systools(3)</c></seeerl></p>
   </section>
 </fileref>
-

--- a/lib/kernel/doc/src/application.xml
+++ b/lib/kernel/doc/src/application.xml
@@ -73,18 +73,16 @@
       <desc>
         <p>Equivalent to calling
         <seemfa marker="#start/1"><c>start/1,2</c></seemfa>
-            repeatedly on all dependencies that are not yet started for an
-            application that is not yet started.</p>
-        <p>Returns <c>{ok, AppNames}</c>, where <c>AppNames</c> is a list of the application names
-            that was actually started by this call.
-            The list might be empty, or not contain all dependencies if the application
-            or some of its dependencies are already started.</p>
+            repeatedly on all dependencies that are not yet started for an application.
+            Optional dependencies will also be loaded and started if they are available.</p>
+        <p>Returns <c>{ok, AppNames}</c> for a successful start or for an already started
+            application (which is, however, omitted from the <c>AppNames</c> list).</p>
         <p>The function reports <c>{error, {AppName,Reason}}</c> for errors, where
         <c>Reason</c> is any possible reason returned by
         <seemfa marker="#start/1"><c>start/1,2</c></seemfa>
             when starting a specific dependency.</p>
-        <p>If an error occurs, the applications started by the function are stopped
-            to bring the set of running applications back to its initial state.</p>
+	<p>If an error occurs, the applications started by the function are stopped
+	    to bring the set of running applications back to its initial state.</p>
       </desc>
     </func>
     <func>
@@ -352,16 +350,22 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
         <p>The application controller checks the value of
           the application specification key <c>applications</c>, to
           ensure that all applications needed to be started before
-          this application are running. Otherwise,
+          this application are running. If an application is missing
+          and the application is not marked as optional,
           <c>{error,{not_started,App}}</c> is returned, where <c>App</c>
-          is the name of the missing application.</p>
-        <p>The application controller then creates an <em>application master</em>
-          for the application. The application master becomes the
-          group leader of all the processes in the application. I/O is
-          forwarded to the previous group leader, though, this is just
-          a way to identify processes that belong to the application.
-          Used for example to find itself from any process, or,
-          reciprocally, to kill them all when it terminates.</p>
+          is the name of the missing application. Note this function
+          makes no attempt to start any of the applications listed in
+          <c>applications</c>, not even optional ones. See
+          <seemfa marker="#ensure_all_started/1"><c>ensure_all_started/1,2</c></seemfa>
+          for recursively starting the current application and its
+          dependencies.</p>
+        <p>Once validated, the application controller then creates an
+          <em>application master</em> for the application. The application
+          master becomes the group leader of all the processes in the
+          application. I/O is forwarded to the previous group leader,
+          though, this is just a way to identify processes that belong
+          to the application. Used for example to find itself from any
+          process, or, reciprocally, to kill them all when it terminates.</p>
         <p>
           The application master starts the application by calling
           the application callback function <c>Module:start/2</c> as

--- a/lib/reltool/src/reltool.hrl
+++ b/lib/reltool/src/reltool.hrl
@@ -164,6 +164,7 @@
           maxP         = infinity  :: '_' | integer() | infinity,
           maxT         = infinity  :: '_' | integer() | infinity,
           registered   = []        :: '_' | [atom()],
+          opt_apps     = []        :: '_' | [app_name()],
           incl_apps    = []        :: '_' | '$3' | [app_name()],
           applications = []        :: '_' | '$2' | [app_name()],
           env          = []        :: '_' | [{atom(), term()}],

--- a/lib/reltool/test/reltool_server_SUITE.erl
+++ b/lib/reltool/test/reltool_server_SUITE.erl
@@ -401,7 +401,8 @@ create_release_sort(Config) ->
     RelVsn = "1.0",
     %% Application z (.app file):
     %%     includes [tools, mnesia]
-    %%     uses [kernel, stdlib, sasl, inets]
+    %%     uses [kernel, stdlib, sasl, inets, unknown]
+    %% where unknown is optional dependency
     Sys =
         {sys,
          [
@@ -623,7 +624,8 @@ create_script_sort(Config) ->
     LibDir = filename:join(DataDir,"sort_apps"),
     %% Application z (.app file):
     %%     includes [tools, mnesia]
-    %%     uses [kernel, stdlib, sasl, inets]
+    %%     uses [kernel, stdlib, sasl, inets, unknown]
+    %% where unknown is optional dependency
     Sys =
         {sys,
          [

--- a/lib/reltool/test/reltool_server_SUITE_data/sort_apps/z-1.0/ebin/z.app
+++ b/lib/reltool/test/reltool_server_SUITE_data/sort_apps/z-1.0/ebin/z.app
@@ -4,5 +4,6 @@
   {vsn, "1.0"},
   {modules,[]},
   {registered, []},
-  {applications, [kernel, stdlib, sasl, inets]},
+  {applications, [kernel, stdlib, sasl, inets, unknown]},
+  {optional_applications, [unknown]},
   {included_applications, [tools, mnesia]}]}.

--- a/lib/sasl/src/systools.hrl
+++ b/lib/sasl/src/systools.hrl
@@ -48,6 +48,8 @@
 				%% Module = atom(), Vsn = string().
 	 uses = [],		%% [Application] list of applications required
 	 			%% by the application, Application = atom().
+	 optional = [],		%% [Application] list of applications in uses
+	 			%% that are optional, Application = atom().
 	 includes = [],		%% [Application] list of applications included
 	 			%% by the application, Application = atom().
 	 regs = [],		%% [RegNames] a list of registered process 

--- a/lib/sasl/test/systools_SUITE_data/d_opt_apps/lib/app1-1.0/ebin/app1.app
+++ b/lib/sasl/test/systools_SUITE_data/d_opt_apps/lib/app1-1.0/ebin/app1.app
@@ -1,0 +1,8 @@
+{application, app1,
+   [{description, "Application 1"},
+    {vsn, "1.0"},
+    {modules, [myapp1]},
+    {registered, []},
+    {applications, [app2]},
+    {optional_applications, [app2]},
+    {env, []}]}.

--- a/lib/sasl/test/systools_SUITE_data/d_opt_apps/lib/app1-1.0/src/myapp1.erl
+++ b/lib/sasl/test/systools_SUITE_data/d_opt_apps/lib/app1-1.0/src/myapp1.erl
@@ -1,0 +1,1 @@
+-module(myapp1).

--- a/lib/sasl/test/systools_SUITE_data/d_opt_apps/lib/app2-1.0/ebin/app2.app
+++ b/lib/sasl/test/systools_SUITE_data/d_opt_apps/lib/app2-1.0/ebin/app2.app
@@ -1,0 +1,7 @@
+{application, app2,
+   [{description, "Application 2"},
+    {vsn, "1.0"},
+    {modules, [myapp2]},
+    {registered, []},
+    {applications, []},
+    {env, []}]}.

--- a/lib/sasl/test/systools_SUITE_data/d_opt_apps/lib/app2-1.0/src/myapp2.erl
+++ b/lib/sasl/test/systools_SUITE_data/d_opt_apps/lib/app2-1.0/src/myapp2.erl
@@ -1,0 +1,1 @@
+-module(myapp2).


### PR DESCRIPTION
Both Mix and Rebar allow some applications to be absent
at runtime - sometimes also known as optional dependencies.

However, given optional applications are not stored in .app
resource files, releases do not consider optional applications
in its boot order, leaving it up to chance if an optional app
will be started before its parent.

Users can try to explicitly list optional applications on their
release definition files, but given the order is not enforced,
this manual specification may be reordered when new apps
are added, leaving developers with broken releases.

This PR introduces the "optional_applications" field to .app
resource files. This field must be a subset of the "applications"
field. The reason why it is a subset rather than its own list
of applications is exactly to keep application start order
on "application:start/2" and during releases.

If application "b" is an optional application for application "a",
and application "b" is missing, "application:start(a)" will still
succeed.

If application "b" is an optional application for application "a",
and application "b" is available, "application:ensure_all_started(a)"
will automatically start application "b" before "a".