### PR TITLE
Fix ei_get_type to set *size to zero for floats, pids, ports and refs

### DIFF
--- a/lib/erl_interface/doc/src/ei.xml
+++ b/lib/erl_interface/doc/src/ei.xml
@@ -1020,8 +1020,10 @@ ei_encode_tuple_header(buf, &amp;i, 0);</pre>
           size is the number of characters <em>not</em> including the
           terminating <c>NULL</c>. For binaries and bitstrings, <c>*size</c> is
 	  the number of bytes. For lists, tuples and maps, <c>*size</c> is the
-	  arity of the object. For other types, <c>*size</c> is 0. In all
-          cases, <c>index</c> is left unchanged.</p>
+	  arity of the object. For bignum integers, <c>*size</c> is
+	  the number of bytes for the absolute value of the bignum.
+	  For other types, <c>*size</c> is 0.
+	  In all cases, <c>index</c> is left unchanged.</p>
 	<p>Currently <c>*type</c> is one of:</p>
 	<taglist>  
 	  <tag>ERL_ATOM_EXT</tag>

--- a/lib/erl_interface/src/misc/get_type.c
+++ b/lib/erl_interface/src/misc/get_type.c
@@ -32,6 +32,7 @@ int ei_get_type(const char *buf, const int *index, int *type, int *len)
   const char *s = buf + *index;
 
   *type = get8(s);
+  *len = 0;
   
   switch (*type) {
   case ERL_SMALL_ATOM_EXT:
@@ -60,7 +61,7 @@ int ei_get_type(const char *buf, const int *index, int *type, int *len)
   case ERL_BIT_BINARY_EXT:
     *len = get32be(s);
     break;
-    
+
   case ERL_SMALL_BIG_EXT:
     *len = get8(s); /* #digit_bytes */
     break;
@@ -78,9 +79,6 @@ int ei_get_type(const char *buf, const int *index, int *type, int *len)
   case ERL_NEWER_REFERENCE_EXT:
       *type = ERL_NEW_REFERENCE_EXT;
       break;
-  default:
-    *len = 0;
-    break;
   }
 
   /* leave index unchanged */

--- a/lib/erl_interface/test/ei_decode_encode_SUITE_data/ei_decode_encode_test.c
+++ b/lib/erl_interface/test/ei_decode_encode_SUITE_data/ei_decode_encode_test.c
@@ -79,15 +79,51 @@ struct Type fun_type = {
     (encodeFT*)ei_encode_fun, (x_encodeFT*)ei_x_encode_fun
 };
 
+int ei_decode_my_pid(const char *buf, int *index, struct my_obj* obj)
+{
+    int ix = *index;
+    int type = -1;
+    int size = -2;
+    if (ei_get_type(buf, &ix, &type, &size) != 0
+        || ix != *index || type != ERL_PID_EXT || size != 0) {
+        fail2("ei_get_type failed for pid, type=%d size=%d", type, size);
+    }
+    return ei_decode_pid(buf, index, (erlang_pid*)obj);
+}
+
 struct Type pid_type = {
-    "pid", "erlang_pid", (decodeFT*)ei_decode_pid,
+    "pid", "erlang_pid", ei_decode_my_pid,
     (encodeFT*)ei_encode_pid, (x_encodeFT*)ei_x_encode_pid
 };
 
+int ei_decode_my_port(const char *buf, int *index, struct my_obj* obj)
+{
+    int ix = *index;
+    int type = -1;
+    int size = -2;
+    if (ei_get_type(buf, &ix, &type, &size) != 0
+        || ix != *index || type != ERL_PORT_EXT || size != 0) {
+        fail2("ei_get_type failed for port, type=%d size=%d", type, size);
+    }
+    return ei_decode_port(buf, index, (erlang_port*)obj);
+}
+
 struct Type port_type = {
-    "port", "erlang_port", (decodeFT*)ei_decode_port,
+    "port", "erlang_port", ei_decode_my_port,
     (encodeFT*)ei_encode_port, (x_encodeFT*)ei_x_encode_port
 };
+
+int ei_decode_my_ref(const char *buf, int *index, struct my_obj* obj)
+{
+    int ix = *index;
+    int type = -1;
+    int size = -2;
+    if (ei_get_type(buf, &ix, &type, &size) != 0
+        || ix != *index || type != ERL_NEW_REFERENCE_EXT || size != 0) {
+        fail2("ei_get_type failed for ref, type=%d size=%d", type, size);
+    }
+    return ei_decode_ref(buf, index, (erlang_ref*)obj);
+}
 
 struct Type ref_type = {
     "ref", "erlang_ref", (decodeFT*)ei_decode_ref,


### PR DESCRIPTION
as documented.

Proposed fix for https://bugs.erlang.org/projects/ERL/issues/ERL-1288
