### PR TITLE
Fix getting data from ssh-agent

### DIFF
--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -161,21 +161,19 @@ send(Request, Opts) ->
     BinRequest = pack(encode(Request)),
     ok = gen_tcp:send(Socket, BinRequest),
 
-    {ok, BinResponse} = gen_tcp:recv(Socket, 0, Timeout),
+    {ok, <<Len:32/unsigned-big-integer>>} = gen_tcp:recv(Socket, 4, Timeout),
+    {ok, BinResponse} = gen_tcp:recv(Socket, Len, Timeout),
 
     ok = gen_tcp:close(Socket),
 
-    Response = decode(unpack(BinResponse)),
+    Response = decode(BinResponse),
 
     Response.
 
-%% Message packing and unpacking
+%% Message packing
 
 pack(Data) ->
     <<(size(Data)):32/unsigned-big-integer, Data/binary>>.
-
-unpack(<<Len:32/unsigned-big-integer, Data:Len/binary>>) ->
-    Data.
 
 %% SSH Agent message encoding
 


### PR DESCRIPTION
Attempting to request a user key from the ssh agent may fail because `unpack/1` assumes
that the received packet contains the full response, but in some cases it doesn't and one might
get a match error as seen below:

```erlang
> Options = [{key_cb, ssh_agent}, {key_cb_private, []}, {user_dir, '/home/jonjon/.ssh'}].
[{key_cb,ssh_agent},
 {key_cb_private,[]},
 {user_dir,'/home/jonjon/.ssh'}]
> ssh_agent:user_key("ssh-rsa", Options).
** exception error: no function clause matching ssh_agent:unpack(<<0,0,9,249,12,0,0,0,5,0,0,2,23,0,0,0,7,
                                                                   115,115,104,45,114,115,97,0,0,0,3,...>>) (ssh_agent.erl, line 177)
     in function  ssh_agent:send/2 (ssh_agent.erl, line 168)
     in call from ssh_agent:user_key/2 (ssh_agent.erl, line 110)
```

`unpack/1` uses the first 4 bytes of the message to determine how much binary data to match
out. When manually implemented, you can see that this case shows that the expected length of
binary data doesn't match what was returned which causes the failure above:

```erlang
> SocketPath = os:getenv("SSH_AUTH_SOCK").
"/run/user/1000/vscode-ssh-auth-sock-441264969"
> ConnectOpts = [binary, {packet, 0}, {active, false}].
[binary,{packet,0},{active,false}]
> {ok, Socket} = gen_tcp:connect({local, SocketPath}, 0, ConnectOpts, 1000).
{ok,#Port<0.9>}
12> ok = gen_tcp:send(Socket, <<1:32/unsigned-big-integer, 11>>).
ok
> {ok, Res1} = gen_tcp:recv(Socket, 0, 1000).
{ok,<<0,0,9,249,12,0,0,0,5,0,0,2,23,0,0,0,7,115,115,104,
      45,114,115,97,0,0,0,...>>}
> <<Len:32/unsigned-big-integer, Data/binary>> = Res1.
<<0,0,9,249,12,0,0,0,5,0,0,2,23,0,0,0,7,115,115,104,45,
  114,115,97,0,0,0,3,1,...>>
> Len.
2553
> byte_size(Data).
1456
```

Calling `gen_tcp:recv/3` again would fetch the remaining packet data and matches
the expected byte size of the response to be parsed:

```erlang
> {ok, Res2} = gen_tcp:recv(Socket, 0, 1000).
{ok,<<57,70,147,93,255,182,95,140,25,113,13,241,132,198,
      6,125,160,12,188,225,248,173,232,76,147,107,200,...>>}
> byte_size(Data) + byte_size(Res2).
2553
```

This fixes that case by making 2 `gen_tcp:recv/3` calls - First, fetch 4 bytes for
the expected length of the data response. Then request that expected length to get
the full response before decoding.

/cc @fhunleth 