### PR TITLE
Add missing include statements in in6addr tests

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2240,6 +2240,7 @@ AC_CACHE_CHECK(
 		#include <sys/types.h>
 		#include <sys/socket.h>
 		#include <netinet/in.h>
+		#include <stdio.h>
 	    ]],
 	    [[printf("%d", in6addr_any.s6_addr[16]);]]
 	)],
@@ -2263,6 +2264,7 @@ AC_CACHE_CHECK(
 		#include <sys/types.h>
 		#include <sys/socket.h>
 		#include <netinet/in.h>
+		#include <stdio.h>
 	    ]],
 	    [[printf("%d", in6addr_loopback.s6_addr[16]);]]
 	)],


### PR DESCRIPTION
Compilation is failing on macOS Big Sur due to `in6addr_any` and `in6addr_loopback` being redeclared. The underlying issue is that the tests for these are failing due to missing include statements:

```sh
conftest.c:197:1: error: implicitly declaring library function 'printf' with type 'int (const char *, ...)' [-Werror,-Wimplicit-function-declaration]
printf("%d", in6addr_any.s6_addr[16]);
^
conftest.c:197:1: note: include the header <stdio.h> or explicitly provide a declaration for 'printf'
```

ERL-1306