### PR TITLE
Exporting useful gen_server types

### DIFF
--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -117,12 +117,19 @@
 %% Internal exports
 -export([init_it/6]).
 
+%% Type exports
+-export_type([server_name/0]).
+
 -include("logger.hrl").
 
 -define(
    STACKTRACE(),
    element(2, erlang:process_info(self(), current_stacktrace))).
 
+-type server_name() ::
+        {'local', atom()}
+      | {'global', term()}
+      | {'via', Module :: module(), Name :: term()}.
 
 -type server_ref() ::
         pid()

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -118,7 +118,7 @@
 -export([init_it/6]).
 
 %% Type exports
--export_type([server_name/0]).
+-export_type([server_name/0, server_ref/0]).
 
 -include("logger.hrl").
 

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -118,7 +118,7 @@
 -export([init_it/6]).
 
 %% Type exports
--export_type([server_name/0, server_ref/0]).
+-export_type([server_name/0, server_ref/0, request_id/0]).
 
 -include("logger.hrl").
 


### PR DESCRIPTION
Following an [email on the erlang-questions mailing list](https://erlang.org/pipermail/erlang-questions/2020-July/099773.html), I'm opening this PR to discuss the possibility of exporting these types.

I believe adding these will avoid duplicate and error prone copy/pasting when writing type specifications for functions which spawn gen_server processes, or refer to them.