### PR TITLE
erl_bits.hrl cleanup

### DIFF
--- a/bootstrap/lib/stdlib/include/erl_bits.hrl
+++ b/bootstrap/lib/stdlib/include/erl_bits.hrl
@@ -31,19 +31,3 @@
           sign   :: bt_sign() | 'undefined',
           endian :: bt_endian() | 'undefined'
          }).
-
--record(bitdefault, {
-	  integer,    %% default type for integer
-	  float,      %% default type for float
-	  binary      %% default type for binary
-	 }).
-
-%%% (From config.hrl in the bitsyntax branch.)
--define(SYS_ENDIAN, big).
--define(SIZEOF_CHAR, 1).
--define(SIZEOF_DOUBLE, 8).
--define(SIZEOF_FLOAT, 4).
--define(SIZEOF_INT, 4).
--define(SIZEOF_LONG, 4).
--define(SIZEOF_LONG_LONG, 8).
--define(SIZEOF_SHORT, 2).

--- a/lib/stdlib/include/erl_bits.hrl
+++ b/lib/stdlib/include/erl_bits.hrl
@@ -31,19 +31,3 @@
           sign   :: bt_sign() | 'undefined',
           endian :: bt_endian() | 'undefined'
          }).
-
--record(bitdefault, {
-	  integer,    %% default type for integer
-	  float,      %% default type for float
-	  binary      %% default type for binary
-	 }).
-
-%%% (From config.hrl in the bitsyntax branch.)
--define(SYS_ENDIAN, big).
--define(SIZEOF_CHAR, 1).
--define(SIZEOF_DOUBLE, 8).
--define(SIZEOF_FLOAT, 4).
--define(SIZEOF_INT, 4).
--define(SIZEOF_LONG, 4).
--define(SIZEOF_LONG_LONG, 8).
--define(SIZEOF_SHORT, 2).


### PR DESCRIPTION
Removing macros and the record bitdefault - they are never used.