### PR TITLE
Fix stateless ticket window check. ERL-1316

### DIFF
--- a/lib/ssl/doc/src/using_ssl.xml
+++ b/lib/ssl/doc/src/using_ssl.xml
@@ -424,12 +424,12 @@ ssl:connect("localhost", 9999,
     is set as <em>current</em>.
     </p>
 
-    <p>The Anti-Replay protection feature in statless servers executes in the following steps
+    <p>The Anti-Replay protection feature in stateless servers executes in the following steps
     when a new ClientHello is received:</p>
     <list type="bulleted">
       <item><p>Reported ticket age (obfuscated ticket age) shall be
       less than ticket lifetime.</p></item>
-      <item><p>Actual ticket age shall be less than the ticket lifetime (statless session
+      <item><p>Actual ticket age shall be less than the ticket lifetime (stateless session
       tickets contain the servers timestamp when the ticket was issued).</p></item>
       <item><p>Ticket shall be used within specified time window (freshness checks).</p></item>
       <item><p>If all above checks passed both <em>current</em> and <em>old</em> Bloom filters

--- a/lib/ssl/src/tls_server_session_ticket.erl
+++ b/lib/ssl/src/tls_server_session_ticket.erl
@@ -91,8 +91,8 @@ handle_call({new_session_ticket, Prf, MasterSecret}, _From,
             #state{nonce = Nonce, 
                    stateless = #{}} = State) -> 
     BaseSessionTicket = new_session_ticket_base(State),
-    SessionTicket = generate_statless_ticket(BaseSessionTicket, Prf, 
-                                             MasterSecret, State),
+    SessionTicket = generate_stateless_ticket(BaseSessionTicket, Prf, 
+                                              MasterSecret, State),
     {reply, SessionTicket, State#state{nonce = Nonce+1}};
 handle_call({use_ticket, Identifiers, Prf, HandshakeHist}, _From, 
             #state{stateful = #{}} = State0) -> 
@@ -307,9 +307,9 @@ stateful_psk_ticket_id(Key) ->
 %%%===================================================================
 %%% Stateless ticket 
 %%%===================================================================
-generate_statless_ticket(#new_session_ticket{ticket_nonce = Nonce, 
-                                             ticket_age_add = TicketAgeAdd,
-                                             ticket_lifetime = Lifetime} 
+generate_stateless_ticket(#new_session_ticket{ticket_nonce = Nonce, 
+                                              ticket_age_add = TicketAgeAdd,
+                                              ticket_lifetime = Lifetime} 
                          = Ticket, Prf, MasterSecret, 
                          #state{stateless = #{seed := {IV, Shard}}}) ->
     PSK = tls_v1:pre_shared_key(MasterSecret, Nonce, Prf),
@@ -339,7 +339,7 @@ stateless_use([#psk_identity{identity = Encrypted,
     case ssl_cipher:decrypt_ticket(Encrypted, Shard, IV) of
         #stateless_ticket{hash = Prf,
                           pre_shared_key = PSK} = Ticket ->
-            case statless_usable_ticket(Ticket, ObfAge, Binder,
+            case stateless_usable_ticket(Ticket, ObfAge, Binder,
                                         HandshakeHist, Window) of
                 true ->
                     stateless_anti_replay(Index, PSK, Binder, State);
@@ -353,11 +353,11 @@ stateless_use([#psk_identity{identity = Encrypted,
             stateless_use(Ids, Binders, Prf, HandshakeHist, Index+1, State)
     end.
 
-statless_usable_ticket(#stateless_ticket{hash = Prf,
-                                         ticket_age_add = TicketAgeAdd,
-                                         lifetime = Lifetime,
-                                         timestamp = Timestamp,
-                                         pre_shared_key = PSK}, ObfAge, 
+stateless_usable_ticket(#stateless_ticket{hash = Prf,
+                                          ticket_age_add = TicketAgeAdd,
+                                          lifetime = Lifetime,
+                                          timestamp = Timestamp,
+                                          pre_shared_key = PSK}, ObfAge, 
                        Binder, HandshakeHist, Window) ->
     case stateless_living_ticket(ObfAge, TicketAgeAdd, Lifetime, 
                                  Timestamp, Window) of
@@ -378,7 +378,7 @@ stateless_living_ticket(ObfAge, TicketAgeAdd, Lifetime, Timestamp, Window) ->
         
 in_window(_, undefined) ->
     true;
-in_window(Age, {Window, _, _}) ->
+in_window(Age, Window) when is_integer(Window) ->
     Age =< Window.
 
 stateless_anti_replay(Index, PSK, Binder, 


### PR DESCRIPTION
The window is passed as an integer, not as tuple.

Sorry I did not include a test with this PR. There are so many moving parts in ssl. I checked this PR by using Chrome and Firefox and connect it to an erlang web server using TLS 1.3 with stateless tickets with bloomfilter replay detection.