### PR TITLE
Fix css problem with leftnav

### DIFF
--- a/lib/erl_docgen/priv/css/otp_doc.css
+++ b/lib/erl_docgen/priv/css/otp_doc.css
@@ -37,6 +37,7 @@ a:visited      { color: #1b6ec2; text-decoration: none }
 }
 
 #leftnav {
+  background: #fefefe;
   position: fixed;
   float: left;
   top: 0;


### PR DESCRIPTION
Avoid documentation overlapping strange behavior

*Old behavior*
![image](https://user-images.githubusercontent.com/22854243/88643232-bc060c80-d0c1-11ea-9eaf-1461d6c06edb.png)

*New behavior*
![image](https://user-images.githubusercontent.com/22854243/88643392-f1125f00-d0c1-11ea-9557-9f60acaeceb3.png)
