### PR TITLE
Update config scripts to compile for Apple Silicon (arm64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ armv7l-unknown-linux-gnueabihf
 i686-pc-linux-gnu
 x86_64-unknown-linux-gnu
 i386-apple-darwin[0-9]*.[0-9]*.[0-9]*
+arm-apple-darwin[0-9]*.[0-9]*.[0-9]*
 x86_64-apple-darwin[0-9]*.[0-9]*.[0-9]*
 x86_64-unknown-freebsd[0-9]*.[0-9]*
 sparc-sun-solaris[0-9]*.[0-9]*

--- a/erts/aclocal.m4
+++ b/erts/aclocal.m4
@@ -2822,6 +2822,7 @@ AC_DEFUN([LM_HARDWARE_ARCH], [
     ppc64)	ARCH=ppc64;;
     ppc64le)	ARCH=ppc64le;;
     "Power Macintosh")	ARCH=ppc;;
+    arm64)	ARCH=arm64;;
     armv5b)	ARCH=arm;;
     armv5teb)	ARCH=arm;;
     armv5tel)	ARCH=arm;;

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -750,7 +750,7 @@ dnl First remove common_tests skip file.
 
 dnl Adjust LDFLAGS to allow 64bit linkage on DARWIN
 case $ARCH-$OPSYS in
-	amd64-darwin*)
+	amd64-darwin*|arm64-darwin*)
 		AC_MSG_NOTICE([Adjusting LDFLAGS to cope with 64bit Darwin])
 		case $LDFLAGS in
 			*-m64*)

--- a/make/configure.in
+++ b/make/configure.in
@@ -396,7 +396,7 @@ if test $CROSS_COMPILING = no; then
 	   }
 	   [case "$macosx_version" in
 	       [1-9][0-9].[0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\1\2|'`;;
+	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\10\200|'`;;
 	       [1-9][0-9].[0-9].[0-9])
 	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
 	       [1-9][0-9].[1-9][0-9])


### PR DESCRIPTION
Detect Apple Silicon (arm64) during configuration for compilation on macOS 11.0 (beta at this time). Fixes ERL-1305.

Main changes:
- Fix the integer macOS version correctly for the build version check
- Map correctly to 64bit builds (-m64)

Verified via `./otp_build tests`

Note: the current config.guess uses "arm-apple-darwin*" for the build/host system type while a newer version uses "aarch64-apple-darwin*". However, the diffs between 2015-03-04 to 2020-07-12 were outside the scope of being able to test for this PR.