### PR TITLE
Fix: ERL-1307 - dialyzer handling of letrec nested in values

### DIFF
--- a/lib/dialyzer/src/dialyzer_dep.erl
+++ b/lib/dialyzer/src/dialyzer_dep.erl
@@ -208,8 +208,12 @@ traverse(Tree, Out, State, CurrentFun) ->
       Val = cerl:map_pair_val(Tree),
       {List, State1} = traverse_list([Key,Val], Out, State, CurrentFun),
       {merge_outs(List), State1};
-    values ->      
-      traverse_list(cerl:values_es(Tree), Out, State, CurrentFun);
+    values ->
+      OldNumRvals = state__num_rvals(State),
+      State1 = state__store_num_rvals(1, State),
+      {List, State2} = traverse_list(cerl:values_es(Tree), Out, State1, CurrentFun),
+      State3 = state__store_num_rvals(OldNumRvals, State2),
+      {List, State3};
     var ->
       case map__lookup(cerl_trees:get_label(Tree), Out) of
 	none -> {output(none), State};


### PR DESCRIPTION
Fixed dialyzer plt build breaking on code that compiles to letrec nested within a multi-value values node.

The code sample in plt_SUITE: letrec_rvals contains the following (cleaned up) extract:

```
<(letrec('lc$^0'/1 ) =
    (...(let (_6) = (apply('lc$^0'/1)((_3))) in ([('ok') | (_6)]))...) in (...)),
 (_Res)>
```

While traversing the tree:

1. letrec node would (incorrectly) inherit num_rvals from values (here: 2)
2. then apply would incorrectly duplicate output
3. then let would call bind_list on two lists of differing length (list of 1 corresponding to _6; list of 2 returned by apply)
4. resulting in function_clause error for bind_list1

The fix updates values handler to recurse into children with num_rvals = 1 (as each child corresponds to a single slot of a values node)