### PR TITLE
Use wxBG_STYLE_PAINT instead of STYLE_SYSTEM

### DIFF
--- a/lib/observer/src/observer_app_wx.erl
+++ b/lib/observer/src/observer_app_wx.erl
@@ -93,7 +93,7 @@ init([Notebook, Parent, _Config]) ->
     DrawingArea = wxScrolledWindow:new(P2, [{winid, ?DRAWAREA},
 					    {style,?wxFULL_REPAINT_ON_RESIZE}]),
     BG = wxWindow:getBackgroundColour(Apps),
-    wxWindow:setBackgroundStyle(DrawingArea, ?wxBG_STYLE_SYSTEM),
+    wxWindow:setBackgroundStyle(DrawingArea, ?wxBG_STYLE_PAINT),
     wxWindow:setVirtualSize(DrawingArea, 800, 800),
     wxSplitterWindow:setMinimumPaneSize(Splitter,50),
     wxSizer:add(Extra, DrawingArea, [{flag, ?wxEXPAND},{proportion, 1}]),

--- a/lib/observer/src/observer_perf_wx.erl
+++ b/lib/observer/src/observer_perf_wx.erl
@@ -99,13 +99,9 @@ make_win(Name, Parent, Sizer, Border) ->
     #win{name=Name, panel=Panel}.
 
 setup_graph_drawing(Panels) ->
-    IsWindows = element(1, os:type()) =:= win32,
-    IgnoreCB = {callback, fun(_,_) -> ok end},
     Do = fun(#win{panel=Panel}) ->
-		 wxWindow:setBackgroundStyle(Panel, ?wxBG_STYLE_SYSTEM),
-		 wxPanel:connect(Panel, paint, [callback]),
-		 IsWindows andalso
-		     wxPanel:connect(Panel, erase_background, [IgnoreCB])
+		 wxWindow:setBackgroundStyle(Panel, ?wxBG_STYLE_PAINT),
+		 wxPanel:connect(Panel, paint, [callback])
 	 end,
     _ = [Do(Panel) || Panel <- Panels],
     UseGC = haveGC(),


### PR DESCRIPTION
Avoid flickering graphs (on windows) by using wxBG_STYLE_PAINT,
i.e. telling wx that observer code handles the drawing the window.