### PR TITLE
Name cipher suites consistently across ssl docs

### DIFF
--- a/lib/ssl/doc/src/notes.xml
+++ b/lib/ssl/doc/src/notes.xml
@@ -3578,7 +3578,7 @@
         <item>
           <p>
 	    Add support for PSK (Pre Shared Key) and SRP (Secure
-	    Remote Password) chipher suits, thanks to Andreas
+	    Remote Password) cipher suites, thanks to Andreas
 	    Schultz.</p>
           <p>
 	    Own Id: OTP-10450 Aux Id: kunagi-269 [180] </p>

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1354,7 +1354,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       <desc><p>Make <c>Deferred</c> suites become the least preferred
       suites, that is put them at the end of the cipher suite list
       <c>Suites</c> after removing them from <c>Suites</c> if
-      present. <c>Deferred</c> may be a list of cipher suits or a
+      present. <c>Deferred</c> may be a list of cipher suites or a
       list of filters in which case the filters are use on  <c>Suites</c> to
       extract the Deferred cipher list.</p> 
       </desc>
@@ -1566,7 +1566,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       returns false for any part of the cipher suite. If no filter function is supplied for some
       part the default behaviour regards it as if there was a filter function that returned true.
       
-      For examples see <seeguide marker="ssl:using_ssl#customizing-cipher-suits"> Customizing cipher suits </seeguide> 
+      For examples see <seeguide marker="ssl:using_ssl#customizing-cipher-suites"> Customizing cipher suites </seeguide> 
       
       Additionaly this function also filters the cipher suites to
       exclude cipher suites not supported by the cryptolib used by the
@@ -1717,7 +1717,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       <desc><p>Make <c>Preferred</c> suites become the most preferred
       suites that is put them at the head of the cipher suite list
       <c>Suites</c> after removing them from <c>Suites</c> if
-      present. <c>Preferred</c> may be a list of cipher suits or a
+      present. <c>Preferred</c> may be a list of cipher suites or a
       list of filters in which case the filters are use on <c>Suites</c> to
       extract the preferred cipher list. </p>
       </desc>

--- a/lib/ssl/doc/src/using_ssl.xml
+++ b/lib/ssl/doc/src/using_ssl.xml
@@ -154,7 +154,7 @@ ok</code>
   </section>
 
   <section>
-    <title>Customizing cipher suits</title>
+    <title>Customizing cipher suites</title>
 
     <p>Fetch default cipher suite list for a TLS/DTLS version. Change default
     to all to get all possible cipher suites.</p>

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -1122,7 +1122,7 @@ filter_cipher_suites(Suites, Filters0) ->
 %% Description: Make <Preferred> suites become the most prefered
 %%      suites that is put them at the head of the cipher suite list
 %%      and remove them from <Suites> if present. <Preferred> may be a
-%%      list of cipher suits or a list of filters in which case the
+%%      list of cipher suites or a list of filters in which case the
 %%      filters are use on Suites to extract the the preferred
 %%      cipher list.
 %% --------------------------------------------------------------------

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -157,10 +157,10 @@ nonce_seed(Seed, CipherState) ->
 -spec cipher(cipher_enum(), #cipher_state{}, binary(), iodata(), ssl_record:ssl_version()) ->
 		    {binary(), #cipher_state{}}. 
 %%
-%% Description: Encrypts the data and the MAC using chipher described
+%% Description: Encrypts the data and the MAC using cipher described
 %% by cipher_enum() and updating the cipher state
 %% Used for "MAC then Cipher" suites where first an HMAC of the
-%% data is calculated and the data plus the HMAC is ecncrypted.
+%% data is calculated and the data plus the HMAC is encrypted.
 %%-------------------------------------------------------------------
 cipher(?NULL, CipherState, <<>>, Fragment, _Version) ->
     {iolist_to_binary(Fragment), CipherState};

--- a/lib/ssl/src/tls_record.erl
+++ b/lib/ssl/src/tls_record.erl
@@ -686,7 +686,7 @@ encode_fragments(_Type, _Version, _Data, CS, _CompS, _CipherS, _Seq, _CipherFrag
     exit({cs, CS}).
 %%--------------------------------------------------------------------
 
-%% 1/n-1 splitting countermeasure Rizzo/Duong-Beast, RC4 chiphers are
+%% 1/n-1 splitting countermeasure Rizzo/Duong-Beast, RC4 ciphers are
 %% not vulnerable to this attack.
 split_iovec(Data, Version, BCA, one_n_minus_one, MaxLength)
   when (BCA =/= ?RC4) andalso ({3, 1} == Version orelse

--- a/lib/ssl/test/ssl_ECC.erl
+++ b/lib/ssl/test/ssl_ECC.erl
@@ -30,7 +30,7 @@
 -include_lib("public_key/include/public_key.hrl").
 
 %% Test diffrent certificate chain types, note that it is the servers
-%% chain that affect what cipher suit that will be choosen
+%% chain that affect what cipher suite that will be choosen
 
 %% ECDH_RSA 
 client_ecdh_rsa_server_ecdh_rsa(Config) when is_list(Config) ->

--- a/lib/ssl/test/ssl_ECC_SUITE.erl
+++ b/lib/ssl/test/ssl_ECC_SUITE.erl
@@ -125,7 +125,7 @@ end_per_testcase(_TestCase, Config) ->
 %% Test Cases --------------------------------------------------------
 %%--------------------------------------------------------------------
 %% Test diffrent certificate chain types, note that it is the servers
-%% chain that affect what cipher suit that will be choosen
+%% chain that affect what cipher suite that will be choosen
 
 client_ecdsa_server_ecdsa_with_raw_key(Config)  when is_list(Config) ->
      Default = ssl_test_lib:default_cert_chain_conf(),


### PR DESCRIPTION
They are referenced as "cipher suites" most of the time, but as "cipher suits" in a few places. This change turns these remaining occurences into "cipher suites". Also fixes typo: chipher -> cipher.