### PR TITLE
supervisor: Eliminate a subtle internal state corruption

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1605,8 +1605,8 @@ format_status(_, [_PDict, State]) ->
 dyn_size(#state{dynamics = {_Kind,Db}}) ->
     map_size(Db).
 
-dyn_erase(Pid,#state{dynamics={_Kind,Db}}=State) ->
-    State#state{dynamics={maps,maps:remove(Pid,Db)}}.
+dyn_erase(Pid,#state{dynamics={Kind,Db}}=State) ->
+    State#state{dynamics={Kind,maps:remove(Pid,Db)}}.
 
 dyn_store(Pid,Args,#state{dynamics={Kind,Db}}=State) ->
     case Kind of


### PR DESCRIPTION
When a temporary child of a `simple_one_for_one` supervisor died, the  internal state of the supervisor would be corrupted in a way that would cause the supervisor to retain the start arguments for subsequent children started by the supervisor, causing unnecessary growth of the supervisor's heap.
    
This bug was introduced in 59d418205486.
    
Thanks to Zeyu Zhang (@zzydxm) for noticing this bug and to Maxim Fedorov for making it known to me.
