### PR TITLE
Change application set/unset env timeouts to infinity

### DIFF
--- a/lib/kernel/doc/src/application.xml
+++ b/lib/kernel/doc/src/application.xml
@@ -247,10 +247,10 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
           each application individually, except it is more efficient.
           The given <c><anno>Config</anno></c> is validated before the
           configuration is set.</p>
-        <p><c>set_env/2</c> uses the standard <c>gen_server</c> time-out
-          value (5000 ms). Option <c>timeout</c> can be specified
-          if another time-out value is useful, for example, in situations
-          where the application controller is heavily loaded.</p>
+        <p><c>set_env/2</c> uses the default <c>timeout</c> of <c>infinity</c>.
+          Option <c>timeout</c> can be specified if another time-out value
+          is useful, for example, in situations where the application controller
+          is heavily loaded.</p>
         <p>Option <c>persistent</c> can be set to <c>true</c>
           to guarantee that parameters set with <c>set_env/2</c>
           are not overridden by those defined in the application resource
@@ -312,10 +312,10 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
       <desc>
         <p>Sets the value of configuration parameter <c><anno>Par</anno></c> for
           <c><anno>Application</anno></c>.</p>
-        <p><c>set_env/4</c> uses the standard <c>gen_server</c> time-out
-          value (5000 ms). Option <c>timeout</c> can be specified
-          if another time-out value is useful, for example, in situations
-          where the application controller is heavily loaded.</p>
+        <p><c>set_env/4</c> uses the default <c>timeout</c> of <c>infinity</c>.
+          Option <c>timeout</c> can be specified if another time-out value
+          is useful, for example, in situations where the application controller
+          is heavily loaded.</p>
         <p>If <c>set_env/4</c> is called before the application is loaded,
           the application environment values specified in file <c>Application.app</c>
           override the ones previously set. This is also true for application
@@ -476,10 +476,10 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
       <desc>
         <p>Removes the configuration parameter <c><anno>Par</anno></c> and its value
           for <c><anno>Application</anno></c>.</p>
-        <p><c>unset_env/2</c> uses the standard <c>gen_server</c>
-          time-out value (5000 ms). Option <c>timeout</c> can be
-          specified if another time-out value is useful, for example, in
-          situations where the application controller is heavily loaded.</p>
+        <p><c>unset_env/2</c> uses the default <c>timeout</c> of <c>infinity</c>.
+          Option <c>timeout</c> can be specified if another time-out value
+          is useful, for example, in situations where the application controller
+          is heavily loaded.</p>
         <p><c>unset_env/3</c> also allows the persistent option to be passed
           (see <seemfa marker="#set_env/4"><c>set_env/4</c></seemfa>).</p>
 	<warning>

--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -463,7 +463,7 @@ permit_application(ApplName, Flag) ->
 set_env(Config, Opts) ->
     case check_conf_data(Config) of
 	ok ->
-	    Timeout = proplists:get_value(timeout, Opts, 5000),
+	    Timeout = proplists:get_value(timeout, Opts, infinity),
 	    gen_server:call(?AC, {set_env, Config, Opts}, Timeout);
 
 	{error, _} = Error ->
@@ -471,15 +471,15 @@ set_env(Config, Opts) ->
     end.
 
 set_env(AppName, Key, Val) ->
-    gen_server:call(?AC, {set_env, AppName, Key, Val, []}).
+    gen_server:call(?AC, {set_env, AppName, Key, Val, []}, infinity).
 set_env(AppName, Key, Val, Opts) ->
-    Timeout = proplists:get_value(timeout, Opts, 5000),
+    Timeout = proplists:get_value(timeout, Opts, infinity),
     gen_server:call(?AC, {set_env, AppName, Key, Val, Opts}, Timeout).
 
 unset_env(AppName, Key) ->
-    gen_server:call(?AC, {unset_env, AppName, Key, []}).
+    gen_server:call(?AC, {unset_env, AppName, Key, []}, infinity).
 unset_env(AppName, Key, Opts) ->
-    Timeout = proplists:get_value(timeout, Opts, 5000),
+    Timeout = proplists:get_value(timeout, Opts, infinity),
     gen_server:call(?AC, {unset_env, AppName, Key, Opts}, Timeout).
 
 %%%-----------------------------------------------------------------


### PR DESCRIPTION
There has been a recent report where starting multiple
processes (8) to perform concurrent httpc requests in
a Raspberry Pi Zero would trigger set_env timeouts.

That's because httpc would call crypto which would call
application:set_env with a cache of the existing curvers
and that would make the aplication_controller unable to
reply in time.

One option to address this issue would be to pass the
timeout option when calling set_env from crypto but
reallistically speaking we would most likely just move
the error to next set_env call that may happen.

Given all functions in application already default to
a timeout of infinity, I chose to fix the problem at
the source and set the default timeout to infinity.

This also aligns with more recent trends in Erlang/OTP
that use an infinity timeout as default.