### PR TITLE
stdlib: fix lists:sublist/3 if Start>length(L)+1 

### DIFF
--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -341,8 +341,12 @@ max([],    Max)              -> Max.
       Len :: non_neg_integer(),
       T :: term().
 
-sublist(List, S, L) when is_integer(L), L >= 0 ->
-    sublist(nthtail(S-1, List), L).
+sublist(List, 1, L) when is_list(List), is_integer(L), L >= 0 ->
+    sublist(List, L);
+sublist([], S, _L) when is_integer(S), S >= 2 ->
+    [];
+sublist([_H|T], S, L) when is_integer(S), S >= 2 ->
+    sublist(T, S-1, L).
 
 -spec sublist(List1, Len) -> List2 when
       List1 :: [T],

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -2215,6 +2215,7 @@ sublist_2_e(Config) when is_list(Config) ->
 sublist_3(Config) when is_list(Config) ->
     [] = lists:sublist([], 1, 0),
     [] = lists:sublist([], 1, 1),
+    [] = lists:sublist([], 2, 0),
     [] = lists:sublist([a], 1, 0),
     [a] = lists:sublist([a], 1, 1),
     [a] = lists:sublist([a], 1, 2),
@@ -2228,6 +2229,7 @@ sublist_3(Config) when is_list(Config) ->
     [] = lists:sublist([a], 2, 1),
     [] = lists:sublist([a], 2, 2),
     [] = lists:sublist([a], 2, 79),
+    [] = lists:sublist([a], 3, 1),
     [] = lists:sublist([a,b|c], 1, 0),
     [] = lists:sublist([a,b|c], 2, 0),
     [a] = lists:sublist([a,b|c], 1, 1),


### PR DESCRIPTION
lists:sublist/3 fails when Start (the 2nd argument) was greater than
len(List)+1, due to nthtail/2 throwing an exception. This change
replaces the use of nthtail/2 with a recursive function definition.

This fixes [ERL-1334](https://bugs.erlang.org/browse/ERL-1334).