### PR TITLE
Cache crypto:supports(curves) on application start

### DIFF
--- a/lib/crypto/src/Makefile
+++ b/lib/crypto/src/Makefile
@@ -37,6 +37,7 @@ RELSYSDIR = $(RELEASE_PATH)/lib/crypto-$(VSN)
 
 MODULES= \
 	crypto \
+	crypto_app \
 	crypto_ec_curves
 
 HRL_FILES=

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -646,13 +646,7 @@ version() -> ?CRYPTO_VSN.
 
 -spec start() -> ok | {error, Reason::term()}.
 start() ->
-    case application:start(crypto) of
-        ok ->
-            _ = supports(curves), % Build curves cache if needed
-            ok;
-        Error ->
-            Error
-    end.
+    application:start(crypto).
 
 -spec stop() -> ok | {error, Reason::term()}.
 stop() ->

--- a/lib/crypto/src/crypto_app.erl
+++ b/lib/crypto/src/crypto_app.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1999-2017. All Rights Reserved.
+%% Copyright Ericsson AB 2010-2020. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -17,16 +17,22 @@
 %%
 %% %CopyrightEnd%
 %%
-{application, crypto,
-   [{description, "CRYPTO"},
-    {vsn, "%VSN%"},
-    {modules, [crypto,
-	       crypto_app]},
-	       crypto_ec_curves]},
-    {registered, []},
-    {mod, {crypto_app, []}},
-    {applications, [kernel, stdlib]},
-    {env, [{fips_mode, false}, {rand_cache_size, 896}]},
-    {runtime_dependencies, ["erts-9.0","stdlib-3.4","kernel-5.3"]}]}.
 
+-module(crypto_app).
 
+-behaviour(application).
+-export([start/2, stop/1]).
+
+-behaviour(supervisor).
+-export([init/1]).
+
+start(_Type, _Args) ->
+    % Build curves cache if needed
+    _ = crypto:supports(curves),
+    supervisor:start_link(?MODULE, ok).
+
+stop(_) ->
+    ok.
+
+init(ok) ->
+    {ok, {#{}, []}}.


### PR DESCRIPTION
Otherwise the ssl app may start the crypto app indirectly
as part of its dependencies without a curves cache, which
can lead to crypto:supports/0 being called concurrently,
considerably slowing down the machine performance.