### PR TITLE
Allow metadata and ignore to be computed in logger funs

### DIFF
--- a/lib/kernel/doc/src/logger.xml
+++ b/lib/kernel/doc/src/logger.xml
@@ -450,12 +450,44 @@ logger:error("error happened because: ~p", [Reason]). % Without macro
       <type variable="FunArgs" name_i="4"/>
       <type variable="Metadata"/>
       <desc>
-        <p>Log the given message.</p>
+        <p>Create a log event at the given
+          <seeguide marker="logger_chapter#log_level">log level</seeguide>,
+          with the given <seeguide marker="logger_chapter#log_message">message</seeguide>
+          to be logged and
+          <seeguide marker="logger_chapter#metadata"><em>metadata</em></seeguide>.
+        Examples:</p>
+        <code>
+%% A plain string
+logger:log(info, "Hello World").
+%% A plain string with metadata
+logger:log(debug, "Hello World", #{ meta => data }).
+%% A format string with arguments
+logger:log(warning, "The roof is on ~ts",[Cause]).
+%% A report
+logger:log(warning, #{ what => roof, cause => Cause }).
+        </code>
+        <p>The message and metadata can either be given directly in the arguments,
+          or returned from a fun. Passing a fun instead of the message/metadata directly is
+          useful in scenarios when the message/metadata is very expensive to compute.
+          This is because the fun is only evaluted when the message/metadata is
+          actually needed, which may be not at all if the log event is not
+          to be logged. Examples:</p>
+        <code>
+%% A plain string with expensive metadata
+logger:info(fun([]) -> {"Hello World", #{ meta => expensive() }} end,[]).
+%% An expensive report
+logger:debug(fun(What) -> #{ what => What, cause => expensive() } end,roof).
+%% A plain string with expensive metadata and normal metadata
+logger:debug(fun([]) -> {"Hello World", #{ meta => expensive() }} end,[],
+             #{ meta => data }).
+        </code>
+        <p>When metadata is given both as an argument and returned from the fun they
+          are merged. If equal keys exists the values are taken from the metadata
+          returned by the fun.</p>
       </desc>
     </func>
   </funcs>
 
- 
   <funcs>
     <fsdescription>
       <marker id="configuration_API"/>

--- a/lib/kernel/doc/src/logger.xml
+++ b/lib/kernel/doc/src/logger.xml
@@ -245,6 +245,12 @@ logger:error("error happened because: ~p", [Reason]). % Without macro
       </desc>
     </datatype>
     <datatype>
+      <name name="msg_fun_return"/>
+      <desc>
+        <p></p>
+      </desc>
+    </datatype>
+    <datatype>
       <name name="olp_config"/>
       <desc>
 	<p></p>

--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -192,8 +192,18 @@
       <p>The log message contains the information to be logged. The
 	message can consist of a format string and arguments (given as
 	two separate parameters in the Logger API), a string or a
-	report. The latter, which is either a map or a key-value list,
-	can be accompanied by a <em>report callback</em> specified in
+        report.</p>
+      <p>Example, format string and arguments:</p>
+      <code>logger:error("The file does not exist: ~ts",[Filename])</code>
+      <p>Example, string:</p>
+      <code>logger:notice("Something strange happened!")</code>
+      <p>A report, which is either a map or a key-value list, is
+        the preferred way to log using Logger as it makes it possible
+        for different backends to filter and format the log event as it
+        needs to.</p>
+      <p>Example, report:</p>
+      <code>?LOG_ERROR(#{ user => joe, filename => Filename, reason => enoent })</code>
+      <p>Reports can be accompanied by a <em>report callback</em> specified in
 	the log event's <seeguide marker="#metadata">metadata</seeguide>.
 	The report callback is a convenience function that
 	the <seeguide marker="#formatters">formatter</seeguide> can use
@@ -219,10 +229,6 @@
 	contain line breaks or not. This variant is used when the
 	formatting of the report depends on the size or single line
 	parameters.</p>
-      <p>Example, format string and arguments:</p>
-      <code>logger:error("The file does not exist: ~ts",[Filename])</code>
-      <p>Example, string:</p>
-      <code>logger:notice("Something strange happened!")</code>
       <p>Example, report, and metadata with report callback:</p>
       <code>
 logger:debug(#{got => connection_request, id => Id, state => State},

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -1341,6 +1341,16 @@ test_log_function(Level) ->
     logger:log(Level,F2=fun(x) -> erlang:error(fun_that_crashes) end,x,#{}),
     ok = check_logged(Level,"LAZY_FUN CRASH: ~tp; Reason: ~tp",
                       [{F2,x},{error,fun_that_crashes}],#{}),
+    logger:log(Level,fun(x) -> {{"~w: ~w ~w",[Level,fun_to_fa,meta]}, #{my=>override}} end,
+               x, #{my=>meta}),
+    ok = check_logged(Level,"~w: ~w ~w",[Level,fun_to_fa,meta],#{my=>override}),
+    logger:log(Level,fun(x) -> {#{Level=>fun_to_r,meta=>true}, #{my=>override}} end,
+               x, #{my=>meta}),
+    ok = check_logged(Level,#{Level=>fun_to_r,meta=>true},#{my=>override}),
+    logger:log(Level,fun(x) -> {<<"fun_to_s">>,#{my=>override}} end,x,#{my=>meta}),
+    ok = check_logged(Level,<<"fun_to_s">>,#{my=>override}),
+    logger:log(Level, fun(x) -> ignore end, x, #{}),
+    ok = check_no_log(),
     ok.
 
 test_macros(emergency=Level) ->


### PR DESCRIPTION
This commit allows the logger metadata to be
computed lazily via the logger `msg_fun`.
The `msg_fun` itself can also return `ignore`.

These features are useful when computing the
metadata or if the message should be logged or
not is expensive and you want to do so only
after the log level match.
