### PR TITLE
seq_trace: fix label spec missed in PR #1760

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -248,20 +248,10 @@
       type |
       uniq.
 
--type seq_trace_info() ::
-      'send' |
-      'receive' |
-      'print' |
-      'timestamp' |
-      'monotonic_timestamp' |
-      'strict_monotonic_timestamp' |
-      'label' |
-      'serial'.
-
 -type seq_trace_info_returns() ::
-      { seq_trace_info(), non_neg_integer() |
-                          boolean() |
-			  { non_neg_integer(), non_neg_integer() } } |
+      { 'send' | 'receive' | 'print' | 'timestamp' | 'monotonic_timestamp' | 'strict_monotonic_timestamp', boolean() } |
+      { 'label', term() } |
+      { 'serial', { non_neg_integer(), non_neg_integer() } } |
       [].
 
 -type system_profile_option() ::
@@ -2436,7 +2426,7 @@ send(_Dest,_Msg,_Options) ->
                     (timestamp) -> {timestamp, boolean()};
                     (monotonic_timestamp) -> {timestamp, boolean()};
                     (strict_monotonic_timestamp) -> {strict_monotonic_timestamp, boolean()};
-                    (label) -> [] | {label, non_neg_integer()};
+                    (label) -> [] | {label, term()};
                     (serial) -> [] | {serial, {non_neg_integer(), non_neg_integer()}}.
 seq_trace_info(_What) ->
     erlang:nif_error(undefined).


### PR DESCRIPTION
`dialyzer` grumbles that `label` needs to be `non_neg_integer()` but since 06ed628dfd013010dd6e182508c1137b9f4ba09b (PR #1760) this constraint has been lifted and is now `term()`.

As things are at the moment the following:
```
ok = case seq_trace:get_token(label) of
        {label,{_TraceId,_Bag,undefined}} ->
                ok;
        {label,{_TraceId,_Bag,_SpanExportable}} ->
                span_orphan;
        [] ->
                ok
end
```

Causes `dialyzer` to grumble with:
```
  27: The pattern {'label', {_TraceId, _Bag, 'undefined'}} can never match the type {'label' | 'print' | 'receive' | 'send' | 'serial' | 'strict_monotonic_timestamp' | 'timestamp',boolean() | non_neg_integer() | {non_neg_integer(),non_neg_integer()}}
```

This (untested!) commit should hopefully fix this, though only changing spec's it is not 100% clear to me as we are in 'preloaded'-land what other steps I need to take to get his PR into shape?

Does the fix otherwise look right? What other work do I need to do so I can remove the `-dialyzer({no_match, ...}).` blemishings from my codebase? :)