### PR TITLE
epp: Fix error return for an incorrect preprocessor -if directive

### DIFF
--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -1106,6 +1106,8 @@ scan_if([{'(',_}|_]=Toks, If, From, St) ->
 	    Error = case Error0 of
 			{_,erl_parse,_} ->
 			    {error,Error0};
+                        {error,ErrL,What} ->
+                            {error,{ErrL,epp,What}};
 			_ ->
 			    {error,{loc(If),epp,Error0}}
 		    end,


### PR DESCRIPTION
Referencing an undefined preprocessor symbol in an `-if` directive
would return an invalid error term not recognized by
`epp:format_error/1`.

https://bugs.erlang.org/browse/ERL-1310