### PR TITLE
Adjust the shell path in installation scripts for Android

### DIFF
--- a/HOWTO/INSTALL-ANDROID.md
+++ b/HOWTO/INSTALL-ANDROID.md
@@ -45,7 +45,8 @@ Use the following instead when compiling a 32-bit version.
 
 ### Compile Erlang/OTP ###
 
-    $ # make noboot [-j4] # noboot doesn't work, is it a recent regression?
+    $ make noboot [-j4]
+      or
     $ make [-j4]
 
 
@@ -77,19 +78,6 @@ from other local applications due to Android sandbox security model.
 To properly integrate into an Android application, the installation would have
 to target /data/data/[your/app/package/name]/files/[erlang/dir/once/unpacked]
 as shown in https://github.com/JeromeDeBretagne/erlanglauncher as an example.
-
-TODO: Propose a permanent fix for the following issue.
-Adapt the installation specifically for Android, by replacing manually /bin/sh
-into /system/bin/sh in the various Erlang/OTP release scripts, such as:
-   - bin/erl
-   - bin/start
-   - bin/start_erl
-   - erts-X.Y.Z/bin/erl
-   - erts-X.Y.Z/bin/erl.src
-   - erts-X.Y.Z/bin/start
-   - erts-X.Y.Z/bin/start_erl.src
-   - erts-X.Y.Z/bin/start.src
-   - etc.
 
 WARNING: adb has issues with symlinks (and java.util.zip too). There is only
 one symlink for epmd in recent Erlang/OTP releases (20 to master-based 23) so

--- a/erts/Makefile
+++ b/erts/Makefile
@@ -108,6 +108,15 @@ local_setup:
 		$(ERL_TOP)/bin/start_sasl.script \
 		$(ERL_TOP)/bin/start_clean.script \
 		$(ERL_TOP)/bin/no_dot_erlang.script
+# On Android, the shell is found in /system/bin/sh instead of /bin/sh
+	@case "$(TARGET)" in \
+		*-android*) \
+		sed -i'' -e "s;/bin/sh;/system/bin/sh;" \
+			$(ERL_TOP)/bin/erl; \
+		sed -i'' -e "s;/bin/sh;/system/bin/sh;" \
+			$(ERL_TOP)/bin/cerl; \
+		;; \
+	esac
 
 # ----------------------------------------------------------------------
 # These are "convenience targets", provided as shortcuts for developers

--- a/erts/etc/common/Makefile.in
+++ b/erts/etc/common/Makefile.in
@@ -511,6 +511,13 @@ endif
 	$(INSTALL_DIR) "$(RELEASE_PATH)/erts-$(VSN)/bin"
 ifneq ($(TARGET), win32)
 	$(INSTALL_SCRIPT) erl.src "$(RELEASE_PATH)/erts-$(VSN)/bin"
+# On Android, the shell is found in /system/bin/sh instead of /bin/sh
+	case "$(TARGET)" in \
+		*-android*) \
+		sed -i'' -e "s;/bin/sh;/system/bin/sh;" \
+			"$(RELEASE_PATH)/erts-$(VSN)/bin/erl.src" \
+		;; \
+	esac
 endif
 ifneq ($(INSTALL_PROGS),)
 	$(INSTALL_PROGRAM) $(INSTALL_PROGS) "$(RELEASE_PATH)/erts-$(VSN)/bin"
@@ -531,6 +538,15 @@ ifneq ($(INSTALL_SRC),)
 endif
 ifneq ($(INSTALL_EMBEDDED_DATA),)
 	$(INSTALL_SCRIPT) $(INSTALL_EMBEDDED_DATA) "$(RELEASE_PATH)/erts-$(VSN)/bin"
+# On Android, the shell is found in /system/bin/sh instead of /bin/sh
+	case "$(TARGET)" in \
+		*-android*) \
+		sed -i'' -e "s;/bin/sh;/system/bin/sh;" \
+			"$(RELEASE_PATH)/erts-$(VSN)/bin/start_erl.src"; \
+		sed -i'' -e "s;/bin/sh;/system/bin/sh;" \
+			"$(RELEASE_PATH)/erts-$(VSN)/bin/start.src"; \
+		;; \
+	esac
 endif
 ifneq ($(INSTALL_LIBS),)
 	$(INSTALL_DATA) $(INSTALL_LIBS) "$(RELEASE_PATH)/erts-$(VSN)/bin"


### PR DESCRIPTION
This patch replaces /bin/sh into /system/bin/sh in the Release target for Android to adjust the various Erlang/OTP release scripts. I've updated the Android documentation accordingly.

I'm not totally sure to see the purpose of the local_setup target in erts/Makefile when cross compiling for Android but I've adjusted it as well.

Cheers, Jérôme