### PR TITLE
Default to Unicode for filename encoding on Android

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -732,7 +732,7 @@
         <p>The virtual machine works with filenames as if they are encoded
           using UTF-8 (or some other system-specific Unicode encoding). This is
           the default on operating systems that enforce Unicode encoding, that
-          is, Windows and MacOS X.</p>
+          is, Windows MacOS X and Android.</p>
         <p>The <c>+fnu</c> switch can be followed by <c>w</c>, <c>i</c>, or
           <c>e</c> to control how wrongly encoded filenames are to be
           reported:</p>
@@ -768,8 +768,8 @@
         <p>Selection between <c>+fnl</c> and <c>+fnu</c> is done based
           on the current locale settings in the OS. This means that if you
           have set your terminal for UTF-8 encoding, the filesystem is
-          expected to use the same encoding for filenames. This is
-          default on all operating systems, except MacOS X and Windows.</p>
+          expected to use the same encoding for filenames. This is the default
+          on all operating systems, except Android, MacOS X and Windows.</p>
         <p>The <c>+fna</c> switch can be followed by <c>w</c>, <c>i</c>, or
           <c>e</c>. This has effect if the locale settings cause the behavior
           of <c>+fnu</c> to be selected; see the description of <c>+fnu</c>

--- a/erts/emulator/sys/common/erl_sys_common_misc.c
+++ b/erts/emulator/sys/common/erl_sys_common_misc.c
@@ -1,8 +1,8 @@
 /*
  * %CopyrightBegin%
- * 
- * Copyright Ericsson AB 2006-2018. All Rights Reserved.
- * 
+ *
+ * Copyright Ericsson AB 2006-2020. All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -49,9 +49,9 @@
 
 static int filename_encoding = ERL_FILENAME_UNKNOWN;
 static int filename_warning = ERL_FILENAME_WARNING_WARNING;
-#if defined(__WIN32__) || defined(__DARWIN__)
-/* Default unicode on windows and MacOS X */
-static int user_filename_encoding = ERL_FILENAME_UTF8; 
+#if defined(__WIN32__) || defined(__DARWIN__) || defined(__ANDROID__)
+/* Default to Unicode on Windows, MacOS X and Android */
+static int user_filename_encoding = ERL_FILENAME_UTF8;
 #else
 static int user_filename_encoding = ERL_FILENAME_UNKNOWN;
 #endif

--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>1996</year><year>2018</year>
+      <year>1996</year><year>2020</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -53,8 +53,8 @@
     converts filenames back and forth to the native filename encoding
     (usually UTF-8, but UTF-16 on Windows).</p>
 
-    <p>The default mode depends on the operating system. Windows and
-    MacOS X enforce consistent filename encoding and therefore the
+    <p>The default mode depends on the operating system. Windows, MacOS X
+    and Android enforce consistent filename encoding and therefore the
     VM uses <c>utf8</c> mode.</p>
 
     <p>On operating systems with transparent naming (for example, all Unix

--- a/lib/stdlib/doc/src/unicode_usage.xml
+++ b/lib/stdlib/doc/src/unicode_usage.xml
@@ -5,7 +5,7 @@
   <header>
     <copyright>
       <year>1999</year>
-      <year>2017</year>
+      <year>2020</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -728,9 +728,9 @@ Eshell V5.10.1  (abort with ^G)
     <taglist>
       <tag>Mandatory Unicode file naming</tag>
       <item>
-        <p>Windows and, for most common uses, MacOS X enforce Unicode support
-          for filenames. All files created in the file system have names that
-          can consistently be interpreted. In MacOS X, all filenames are
+        <p>Windows, Android and, for most cases, MacOS X enforce Unicode support
+          for filenames. All files created in the file system have names that can
+          consistently be interpreted. In MacOS X and Android, all filenames are
           retrieved in UTF-8 encoding. In Windows, each system call handling
           filenames has a special Unicode-aware variant, giving much the same
           effect. There are no filenames on these systems that are not Unicode
@@ -802,8 +802,8 @@ Eshell V5.10.1  (abort with ^G)
     <p>Unicode filename translation is turned on with switch <c>+fnu</c>. On
       Linux, a VM started without explicitly stating the filename translation
       mode defaults to <c>latin1</c> as the native filename encoding. On
-      Windows and MacOS X, the default behavior is that of Unicode filename
-      translation. Therefore
+      Windows, MacOS X and Android, the default behavior is that of Unicode
+      filename translation. Therefore
       <seemfa marker="kernel:file#native_name_encoding/0"><c>file:native_name_encoding/0</c></seemfa>
       by default returns <c>utf8</c> on those systems (Windows does not use
       UTF-8 on the file system level, but this can safely be ignored by the


### PR DESCRIPTION
UTF-8 is used for filename encoding on Android, for reference from the official documentation:

https://developer.android.com/reference/java/io/File#interoperability-with-java.nio.file-package
> On Android strings are converted to UTF-8 byte sequences when sending filenames to the operating system, and byte sequences returned by the operating system (from the various list methods) are converted to strings by decoding them as UTF-8 byte sequences.

Cheers,
Jérôme