### PR TITLE
Correct an unsafe optimization of nested map matching

### DIFF
--- a/lib/compiler/src/beam_peep.erl
+++ b/lib/compiler/src/beam_peep.erl
@@ -184,7 +184,8 @@ prune_redundant_values([], _) -> [].
 
 simplify_get_map_elements(Fail, Src, {list,[Key,Dst]},
                           [{get_map_elements,Fail,Src,{list,List1}}|Acc]) ->
-    case are_keys_literals([Key]) andalso are_keys_literals(List1) of
+    case are_keys_literals([Key]) andalso are_keys_literals(List1) andalso
+        not is_source_overwritten(Src, List1) of
         true ->
             case member(Key, List1) of
                 true ->
@@ -217,3 +218,6 @@ simplify_has_map_fields(_, _, _) -> error.
 are_keys_literals([{x,_}|_]) -> false;
 are_keys_literals([{y,_}|_]) -> false;
 are_keys_literals([_|_]) -> true.
+
+is_source_overwritten(Src, [_Key,Src]) -> true;
+is_source_overwritten(_, _) -> false.

--- a/lib/compiler/test/map_SUITE.erl
+++ b/lib/compiler/test/map_SUITE.erl
@@ -1995,6 +1995,15 @@ t_nested_pattern_expressions(Config) when is_list(Config) ->
     F1 = F0(wat),
     F2 = F1(watzor),
     {yep,ok} = F2(M0),
+
+    %% Test matching of nested maps. There used to be an unsafe optimization in beam_peep.
+    #{ <<"result">> := #{<<"foo">> := <<"6">> } } =
+        nested_map(),
+
+    InnerMap = #{a => id({a,value})},
+    OuterMap = #{inner_map => InnerMap},
+    #{inner_map := #{a := {a,value}}} = OuterMap,
+
     ok.
 
 map_nested_pattern_funs(M) ->
@@ -2013,6 +2022,10 @@ map_nested_pattern_funs(M) ->
 		    end
 	    end
     end.
+
+nested_map() ->
+    #{ <<"result">> := #{<<"foo">> := <<"6">> } } =
+        #{ <<"result">> => #{<<"foo">> => <<"6">> } }.
 
 t_guard_update_variables(Config) when is_list(Config) ->
     error  = map_guard_update_variables(n,#{},#{}),


### PR DESCRIPTION
Because of an unsafe optimization, the following expression would
fail to match:

    #{ <<"result">> := #{<<"foo">> := <<"6">> } } =
        #{ <<"result">> => #{<<"foo">> => <<"6">> } }