### PR TITLE
pg: fix doubling for local processes with dynamic distribution

### DIFF
--- a/lib/kernel/src/pg.erl
+++ b/lib/kernel/src/pg.erl
@@ -342,6 +342,8 @@ handle_info({nodedown, _Node}, State) ->
     {noreply, State};
 
 %% nodeup: discover if remote node participates in the overlay network
+handle_info({nodeup, Node}, State) when Node =:= node() ->
+    {noreply, State};
 handle_info({nodeup, Node}, #state{scope = Scope} = State) ->
     {Scope, Node} ! {discover, self()},
     {noreply, State};


### PR DESCRIPTION
When distribution is started dynamically (via net_kernel:start/1),
pg incorrectly forms an overlay network with local node. Then,
every local process is counted twice (once as local, once as
remote).
This commit also contains tests for the case above, and test
case for local process check.