### PR TITLE
Add os:env/0

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -393,7 +393,6 @@ bif ets:match_spec_run_r/3
 bif os:get_env_var/1
 bif os:set_env_var/2
 bif os:unset_env_var/1
-bif os:list_env_vars/0
 bif os:getpid/0
 bif os:timestamp/0
 bif os:system_time/0
@@ -773,3 +772,4 @@ bif erts_internal:get_creation/0
 bif erts_internal:prepare_loading/2
 bif erts_internal:beamfile_chunk/2
 bif erts_internal:beamfile_module_md5/1
+bif os:env/0

--- a/erts/emulator/beam/erl_bif_os.c
+++ b/erts/emulator/beam/erl_bif_os.c
@@ -77,7 +77,7 @@ static void os_getenv_foreach(Process *process, Eterm *result, Eterm key, Eterm 
     (*result) = CONS(hp, kvp_term, (*result));
 }
 
-BIF_RETTYPE os_list_env_vars_0(BIF_ALIST_0)
+BIF_RETTYPE os_env_0(BIF_ALIST_0)
 {
     const erts_osenv_t *global_env;
     Eterm result = NIL;

--- a/lib/kernel/doc/src/os.xml
+++ b/lib/kernel/doc/src/os.xml
@@ -173,6 +173,21 @@ DirOut = os:cmd("dir"), % on Win32 platform</code>
     </func>
 
     <func>
+      <name name="env" arity="0" since="OTP @OTP-16793@"/>
+      <fsummary>List all environment variables.</fsummary>
+      <desc>
+        <p>Returns a list of all environment variables.
+          Each environment variable is expressed as a tuple
+	  <c>{VarName,Value}</c>, where <c>VarName</c> is the name of
+	  the variable and <c>Value</c> its value.</p>
+	<p>If Unicode filename encoding is in effect (see the
+          <seecom marker="erts:erl#file_name_encoding"><c>erl</c> manual
+	  page</seecom>), the strings can contain characters with
+	  codepoints &gt; 255.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="find_executable" arity="1" since=""/>
       <name name="find_executable" arity="2" since=""/>
       <fsummary>Absolute filename of a program.</fsummary>
@@ -201,6 +216,8 @@ DirOut = os:cmd("dir"), % on Win32 platform</code>
           <seecom marker="erts:erl#file_name_encoding"><c>erl</c> manual
 	  page</seecom>), the strings can contain characters with
 	  codepoints &gt; 255.</p>
+	<p>Consider using <seemfa marker="#env/0"><c>env/0</c></seemfa>
+	  for a nicer 2-tuple format.</p>
       </desc>
     </func>
 

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -31,7 +31,7 @@
 
 %%% BIFs
 
--export([get_env_var/1, getpid/0, list_env_vars/0, perf_counter/0,
+-export([get_env_var/1, getpid/0, env/0, perf_counter/0,
          perf_counter/1, set_env_var/2, set_signal/2, system_time/0,
          system_time/1, timestamp/0, unset_env_var/1]).
 
@@ -46,8 +46,8 @@
 
 -type env_var_name_value() :: nonempty_string().
 
--spec list_env_vars() -> [{env_var_name(), env_var_value()}].
-list_env_vars() ->
+-spec env() -> [{env_var_name(), env_var_value()}].
+env() ->
     erlang:nif_error(undef).
 
 -spec get_env_var(VarName) -> Value | false when
@@ -115,7 +115,7 @@ set_signal(_Signal, _Option) ->
 
 -spec getenv() -> [env_var_name_value()].
 getenv() ->
-    [lists:flatten([Key, $=, Value]) || {Key, Value} <- os:list_env_vars() ].
+    [lists:flatten([Key, $=, Value]) || {Key, Value} <- os:env() ].
 
 -spec getenv(VarName) -> Value | false when
       VarName :: env_var_name(),

--- a/lib/kernel/test/os_SUITE.erl
+++ b/lib/kernel/test/os_SUITE.erl
@@ -23,6 +23,7 @@
 	 init_per_group/2,end_per_group/2,
 	 init_per_testcase/2,end_per_testcase/2]).
 -export([space_in_cwd/1, quoting/1, cmd_unicode/1, 
+         env/1,
          null_in_command/1, space_in_name/1, bad_command/1,
 	 find_executable/1, unix_comment_in_command/1, deep_list_command/1,
          large_output_command/1, background_command/0, background_command/1,
@@ -38,6 +39,7 @@ suite() ->
 all() ->
     [space_in_cwd, quoting, cmd_unicode, null_in_command,
      space_in_name, bad_command,
+     env,
      find_executable, unix_comment_in_command, deep_list_command,
      large_output_command, background_command, message_leak,
      close_stdin, max_size_command, perf_counter_api].
@@ -69,6 +71,19 @@ init_per_testcase(_TC,Config) ->
     Config.
 
 end_per_testcase(_,_Config) ->
+    ok.
+
+env(Config) when is_list(Config) ->
+    Env0 = os:env(),
+    GetEnv0 = os:getenv(),
+    lists:foldl(fun({K,V}, [KV | T]) ->
+                        KV = K ++ "=" ++ V,
+                        V = os:getenv(K),
+                        V = os:getenv(K, default),
+                        T
+                end,
+                GetEnv0,
+                Env0),
     ok.
 
 %% Test that executing a command in a current working directory


### PR DESCRIPTION
https://bugs.erlang.org/browse/ERL-1332

`os:env/0` returns all environment variables in a tuple list `[{VarName, Value}]`

 The same as the undocumented `os:list_env_vars/0`, but with a better name.

A nicer format than the existing os:getenv/0 which returns a list of strings `"VarName=Value"`.
