### PR TITLE
Replace CAR, CDR and CONS macros to inline functions 

### DIFF
--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -309,7 +309,7 @@ finish_loading_1(BIF_ALIST_1)
 
     for (i = 0; i < n; i++) {
 	Eterm* cons = list_val(BIF_ARG_1);
-	Eterm term = CAR(cons);
+	Eterm term = cell_head(cons);
 
 	if (!is_internal_magic_ref(term)) {
 	    goto badarg;
@@ -319,7 +319,7 @@ finish_loading_1(BIF_ALIST_1)
 	if (p[i].module == NIL) {
 	    goto badarg;
 	}
-	BIF_ARG_1 = CDR(cons);
+	BIF_ARG_1 = cell_tail(cons);
     }
 
     /*
@@ -1165,7 +1165,7 @@ check_process_code(Process* rp, Module* modp, int *redsp, int fcalls)
     if (rp->ftrace != NIL) {
 	struct StackTrace *s;
 	ASSERT(is_list(rp->ftrace));
-	s = (struct StackTrace *) big_val(CDR(list_val(rp->ftrace)));
+	s = (struct StackTrace *) big_val(cell_tail(list_val(rp->ftrace)));
 	if ((s->pc && ErtsInArea(s->pc, mod_start, mod_size)) ||
 	    (s->current && ErtsInArea(s->current, mod_start, mod_size))) {
 	    rp->freason = EXC_NULL;

--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -1717,7 +1717,7 @@ save_stacktrace(Process* c_p, BeamInstr* pc, Eterm* reg,
 	    depth--;
 	}
 	s->pc = NULL;
-	args = make_arglist(c_p, reg, bif_mfa->arity); /* Overwrite CAR(c_p->ftrace) */
+	args = make_arglist(c_p, reg, bif_mfa->arity); /* Overwrite cell_head(c_p->ftrace) */
     } else {
 
     non_bif_stacktrace:
@@ -1732,7 +1732,7 @@ save_stacktrace(Process* c_p, BeamInstr* pc, Eterm* reg,
 	    int a;
 	    ASSERT(s->current);
 	    a = s->current->arity;
-	    args = make_arglist(c_p, reg, a); /* Overwrite CAR(c_p->ftrace) */
+	    args = make_arglist(c_p, reg, a); /* Overwrite cell_head(c_p->ftrace) */
 	    s->pc = NULL; /* Ignore pc */
 	} else {
 	    s->pc = pc;
@@ -1765,7 +1765,7 @@ static struct StackTrace *get_trace_from_exc(Eterm exc) {
 	return NULL;
     } else {
 	ASSERT(is_list(exc));
-	return (struct StackTrace *) big_val(CDR(list_val(exc)));
+	return (struct StackTrace *) big_val(cell_tail(list_val(exc)));
     }
 }
 
@@ -1774,7 +1774,7 @@ static Eterm get_args_from_exc(Eterm exc) {
 	return NIL;
     } else {
 	ASSERT(is_list(exc));
-	return CAR(list_val(exc));
+	return cell_head(list_val(exc));
     }
 }
 
@@ -1783,7 +1783,7 @@ static int is_raised_exc(Eterm exc) {
         return 0;
     } else {
         ASSERT(is_list(exc));
-        return bignum_header_is_neg(*big_val(CDR(list_val(exc))));
+        return bignum_header_is_neg(*big_val(cell_tail(list_val(exc))));
     }
 }
 
@@ -1801,7 +1801,7 @@ static Eterm *get_freason_ptr_from_exc(Eterm exc) {
 	return &dummy_freason;
     } else {
 	ASSERT(is_list(exc));
-        s = (struct StackTrace *) big_val(CDR(list_val(exc)));
+        s = (struct StackTrace *) big_val(cell_tail(list_val(exc)));
         return &s->freason;
     }
 }
@@ -2117,16 +2117,16 @@ apply(Process* p, Eterm* reg, BeamInstr *I, Uint stack_offset)
 	a = args;
 	if (is_list(a)) {
 	    Eterm *consp = list_val(a);
-	    m = CAR(consp);
-	    a = CDR(consp);
+	    m = cell_head(consp);
+	    a = cell_tail(consp);
 	    if (is_list(a)) {
 		consp = list_val(a);
-		f = CAR(consp);
-		a = CDR(consp);
+		f = cell_head(consp);
+		a = cell_tail(consp);
 		if (is_list(a)) {
 		    consp = list_val(a);
-		    a = CAR(consp);
-		    if (is_nil(CDR(consp))) {
+		    a = cell_head(consp);
+		    if (is_nil(cell_tail(consp))) {
 			/* erlang:apply/3 */
 			module = m;
 			function = f;
@@ -2149,8 +2149,8 @@ apply(Process* p, Eterm* reg, BeamInstr *I, Uint stack_offset)
     arity = 0;
     while (is_list(tmp)) {
 	if (arity < (MAX_REG - 1)) {
-	    reg[arity++] = CAR(list_val(tmp));
-	    tmp = CDR(list_val(tmp));
+	    reg[arity++] = cell_head(list_val(tmp));
+	    tmp = cell_tail(list_val(tmp));
 	} else {
 	    p->freason = SYSTEM_LIMIT;
 	    goto error2;
@@ -2253,7 +2253,7 @@ erts_hibernate(Process* c_p, Eterm* reg)
     tmp = args;
     while (is_list(tmp)) {
 	if (arity < MAX_REG) {
-	    tmp = CDR(list_val(tmp));
+	    tmp = cell_tail(list_val(tmp));
 	    arity++;
 	} else {
 	    c_p->freason = SYSTEM_LIMIT;
@@ -2499,8 +2499,8 @@ apply_fun(Process* p, Eterm fun, Eterm args, Eterm* reg)
     arity = 0;
     while (is_list(tmp)) {
 	if (arity < MAX_REG-1) {
-	    reg[arity++] = CAR(list_val(tmp));
-	    tmp = CDR(list_val(tmp));
+	    reg[arity++] = cell_head(list_val(tmp));
+	    tmp = cell_tail(list_val(tmp));
 	} else {
 	    p->freason = SYSTEM_LIMIT;
 	    return NULL;

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -3969,8 +3969,8 @@ code_get_chunk_2(BIF_ALIST_2)
 	    goto error;
 	}
 	chunkp = list_val(Chunk);
-	num = CAR(chunkp);
-	Chunk = CDR(chunkp);
+	num = cell_head(chunkp);
+	Chunk = cell_tail(chunkp);
 	if (!is_byte(num)) {
 	    goto error;
 	}
@@ -4179,7 +4179,7 @@ patch(Eterm Addresses, Uint fe)
   while (!is_nil(Addresses)) {
     listp = list_val(Addresses);
 
-    tuple = CAR(listp);
+    tuple = cell_head(listp);
     if (is_not_tuple(tuple)) {
       return 0; /* Signal error */
     }
@@ -4200,7 +4200,7 @@ patch(Eterm Addresses, Uint fe)
     
     hipe_patch_address((Uint *)AddressToPatch, patchtype, fe);
 
-    Addresses = CDR(listp);
+    Addresses = cell_tail(listp);
 
 
   }
@@ -4226,8 +4226,8 @@ patch_funentries(Eterm Patchlist)
     Uint native_address;
      
     listp = list_val(Patchlist);
-    tuple = CAR(listp);
-    Patchlist = CDR(listp);
+    tuple = cell_head(listp);
+    Patchlist = cell_tail(listp);
 
     if (is_not_tuple(tuple)) {
       return 0; /* Signal error */
@@ -4450,8 +4450,8 @@ erts_make_stub_module(Process* p, Eterm hipe_magic_bin, Eterm Beam, Eterm Info)
 	    break;
 	}
 	listp = list_val(Funcs);
-	tuple = CAR(listp);
-	Funcs = CDR(listp);
+	tuple = cell_head(listp);
+	Funcs = cell_tail(listp);
 
 	/* Error checking */
 	if (is_not_tuple(tuple)) {

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -412,7 +412,7 @@ BIF_RETTYPE demonitor_2(BIF_ALIST_2)
 
     while (is_list(list)) {
 	Eterm* consp = list_val(list);
-	switch (CAR(consp)) {
+	switch (cell_head(consp)) {
 	case am_flush:
 	    flush = 1;
 	    break;
@@ -422,7 +422,7 @@ BIF_RETTYPE demonitor_2(BIF_ALIST_2)
 	default:
 	    goto badarg;
 	}
-	list = CDR(consp);	
+	list = cell_tail(consp);
     }
 
     if (is_not_nil(list))
@@ -1133,8 +1133,8 @@ BIF_RETTYPE raise_3(BIF_ALIST_3)
      */
     for (l = stacktrace, depth = 0;  
 	 is_list(l);  
-	 l = CDR(list_val(l)), depth++) {
-	Eterm t = CAR(list_val(l));
+	 l = cell_tail(list_val(l)), depth++) {
+	Eterm t = cell_head(list_val(l));
 	Eterm location = NIL;
 
 	if (is_not_tuple(t)) goto error;
@@ -1216,13 +1216,13 @@ BIF_RETTYPE raise_3(BIF_ALIST_3)
 	/* Copy list up to depth */
 	for (cnt = 0, l = stacktrace;
 	     cnt < depth;
-	     cnt++, l = CDR(list_val(l))) {
+	     cnt++, l = cell_tail(list_val(l))) {
 	    Eterm t;
 	    Eterm *tpp;
 	    int arity;
 
 	    ASSERT(*tp == NIL);
-	    t = CAR(list_val(l));
+	    t = cell_head(list_val(l));
 	    tpp = tuple_val(t);
 	    arity = arityval(tpp[0]);
 	    if (arity == 2) {
@@ -1233,7 +1233,7 @@ BIF_RETTYPE raise_3(BIF_ALIST_3)
 		hp += 5;
 	    }
 	    *tp = CONS(hp, t, *tp);
-	    tp = &CDR(list_val(*tp));
+	    tp = cell_tail_ptr(list_val(*tp));
 	    hp += 2;
 	}
     }
@@ -2155,15 +2155,15 @@ BIF_RETTYPE send_3(BIF_ALIST_3)
     ERTS_MSACC_PUSH_STATE_M_X();
 
     while (is_list(l)) {
-	if (CAR(list_val(l)) == am_noconnect) {
+	if (cell_head(list_val(l)) == am_noconnect) {
 	    connect = 0;
-	} else if (CAR(list_val(l)) == am_nosuspend) {
+	} else if (cell_head(list_val(l)) == am_nosuspend) {
 	    suspend = 0;
 	} else {
 	    ERTS_BIF_PREP_ERROR(retval, p, BADARG);
 	    goto done;
 	}
-	l = CDR(list_val(l));
+	l = cell_tail(list_val(l));
     }
     if(!is_nil(l)) {
 	ERTS_BIF_PREP_ERROR(retval, p, BADARG);
@@ -2362,7 +2362,7 @@ BIF_RETTYPE hd_1(BIF_ALIST_1)
      if (is_not_list(BIF_ARG_1)) {
 	 BIF_ERROR(BIF_P, BADARG);
      }
-     BIF_RET(CAR(list_val(BIF_ARG_1)));
+     BIF_RET(cell_head(list_val(BIF_ARG_1)));
 }
 
 /**********************************************************************/
@@ -2374,7 +2374,7 @@ BIF_RETTYPE tl_1(BIF_ALIST_1)
     if (is_not_list(BIF_ARG_1)) {
 	BIF_ERROR(BIF_P, BADARG);
     }
-    BIF_RET(CDR(list_val(BIF_ARG_1)));
+    BIF_RET(cell_tail(list_val(BIF_ARG_1)));
 }
 
 
@@ -2520,8 +2520,8 @@ BIF_RETTYPE iolist_size_1(BIF_ALIST_1)
                 goto L_save_state_and_trap;
             }
 	    objp = list_val(obj);
-	    hd = CAR(objp);
-	    obj = CDR(objp);
+	    hd = cell_head(objp);
+	    obj = cell_tail(objp);
 	    /* Head */
 	    if (is_byte(hd)) {
 		size++;
@@ -2734,8 +2734,8 @@ BIF_RETTYPE make_tuple_3(BIF_ALIST_3)
 	Uint index_val;
 
 	cons = list_val(list);
-	hd = CAR(cons);
-	list = CDR(cons);
+	hd = cell_head(cons);
+	list = cell_tail(cons);
 	if (is_not_tuple_arity(hd, 2)) {
 	    goto error;
 	}
@@ -3132,8 +3132,8 @@ static int do_float_to_charbuf(Process *p, Eterm efloat, Eterm list,
     if (is_not_float(efloat))
         goto badarg;
 
-    for(; is_list(list); list = CDR(list_val(list))) {
-        arg = CAR(list_val(list));
+    for(; is_list(list); list = cell_tail(list_val(list))) {
+        arg = cell_head(list_val(list));
         if (arg == am_compact) {
             compact = 1;
             continue;
@@ -3281,9 +3281,9 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
        restore the position (end of the float) with LOAD_E.
     */
     while(1) {
-	if (is_not_small(CAR(list_val(list)))) 
+	if (is_not_small(cell_head(list_val(list))))
 	    goto back_to_e;
-	if (CAR(list_val(list)) == make_small('-')) {
+	if (cell_head(list_val(list)) == make_small('-')) {
 	    switch (part) {
 	    case SIGN:		/* expect integer part next */
 		part = INT;		
@@ -3296,7 +3296,7 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 	    default:		/* unexpected - done */
 		part = END;
 	    }
-	} else if (CAR(list_val(list)) == make_small('+')) {
+	} else if (cell_head(list_val(list)) == make_small('+')) {
 	    switch (part) {
 	    case SIGN:		/* expect integer part next */
 		part = INT;
@@ -3309,7 +3309,7 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 	    default:		/* unexpected - done */
 		part = END;
 	    }
-	} else if (IS_DOT(CAR(list_val(list)))) { /* . or , */
+	} else if (IS_DOT(cell_head(list_val(list)))) { /* . or , */
 	    switch (part) {
 	    case INT:		/* expect fractional part next */
 		part = FRAC;
@@ -3321,7 +3321,7 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 	    default:		/* unexpected - done */
 		part = END;
 	    }
-	} else if (IS_E(CAR(list_val(list)))) {	/* e or E */
+	} else if (IS_E(cell_head(list_val(list)))) {	/* e or E */
 	    switch (part) {
 	    case FRAC:		/* expect a + or - (or a digit) next */
 		/* 
@@ -3339,7 +3339,7 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 	    default:		/* unexpected - done */
 		part = END;
 	    }
-	} else if (IS_DIGIT(CAR(list_val(list)))) { /* digit */
+	} else if (IS_DIGIT(cell_head(list_val(list)))) { /* digit */
 	    switch (part) {
 	    case SIGN:		/* got initial digit in integer part */
 		part = INT;	/* expect more digits to follow */
@@ -3360,14 +3360,14 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 	    break;
 	}
 
-	buf[i++] = unsigned_val(CAR(list_val(list)));
+	buf[i++] = unsigned_val(cell_head(list_val(list)));
 
 	if (i == bufsz - 1)
 	    buf = (byte *) erts_realloc(ERTS_ALC_T_TMP,
 					(void *) buf,
 					bufsz += STRING_TO_FLOAT_BUF_INC_SZ);
     skip:
-	list = CDR(list_val(list)); /* next element */
+	list = cell_tail(list_val(list)); /* next element */
 
 	if (is_nil(list))
 	    goto back_to_e;
@@ -3544,8 +3544,8 @@ BIF_RETTYPE list_to_tuple_1(BIF_ALIST_1)
     *hp++ = make_arityval(len);
     while(is_list(list)) {
 	cons = list_val(list);
-	*hp++ = CAR(cons);
-	list = CDR(cons);
+	*hp++ = cell_head(cons);
+	list = cell_tail(cons);
     }
     BIF_RET(res);
 }
@@ -3930,8 +3930,8 @@ BIF_RETTYPE halt_2(BIF_ALIST_2)
 
     for (optlist = BIF_ARG_2;
 	 is_list(optlist);
-	 optlist = CDR(list_val(optlist))) {
-	Eterm *tp, opt = CAR(list_val(optlist));
+	 optlist = cell_tail(list_val(optlist))) {
+	Eterm *tp, opt = cell_head(list_val(optlist));
 	if (is_not_tuple(opt))
 	    goto error;
 	tp = tuple_val(opt);

--- a/erts/emulator/beam/big.c
+++ b/erts/emulator/beam/big.c
@@ -2893,19 +2893,19 @@ LTI_result_t erts_list_to_integer(Process *BIF_P, Eterm orig_list,
        goto error;
 
      /* if first char is a '-' then it is a negative integer */
-     if (CAR(list_val(lst)) == make_small('-')) {
+     if (cell_head(list_val(lst)) == make_small('-')) {
           neg = 1;
           skip = 1;
-          lst = CDR(list_val(lst));
+          lst = cell_tail(list_val(lst));
           if (is_not_list(lst)) {
               tail = lst;
               error_res = LTI_NO_INTEGER;
               goto error;
           }
-     } else if (CAR(list_val(lst)) == make_small('+')) {
+     } else if (cell_head(list_val(lst)) == make_small('+')) {
          /* ignore plus */
          skip = 1;
-         lst = CDR(list_val(lst));
+         lst = cell_tail(list_val(lst));
          if (is_not_list(lst)) {
              tail = lst;
              error_res = LTI_NO_INTEGER;
@@ -2917,17 +2917,17 @@ LTI_result_t erts_list_to_integer(Process *BIF_P, Eterm orig_list,
 
      while(1) {
          byte ch;
-         if (is_not_small(CAR(list_val(lst)))) {
+         if (is_not_small(cell_head(list_val(lst)))) {
              break;
          }
-         ch = unsigned_val(CAR(list_val(lst)));
+         ch = unsigned_val(cell_head(list_val(lst)));
          if (c2int_is_invalid_char(ch, base)) {
              break;
          }
          ui = ui * base;
          ui = ui + c2int_digit_from_base(ch);
          n++;
-         lst = CDR(list_val(lst));
+         lst = cell_tail(list_val(lst));
          if (is_nil(lst)) {
              break;
          }
@@ -2965,7 +2965,7 @@ LTI_result_t erts_list_to_integer(Process *BIF_P, Eterm orig_list,
 
          lst = orig_list;
          if (skip)
-             lst = CDR(list_val(lst));
+             lst = cell_tail(list_val(lst));
 
          /* load first digits (at least one digit) */
          if ((i = (n % digits_per_Sint)) == 0)
@@ -2974,8 +2974,8 @@ LTI_result_t erts_list_to_integer(Process *BIF_P, Eterm orig_list,
          m = 0;
          while(i--) {
              m *= base;
-             m += c2int_digit_from_base(unsigned_val(CAR(list_val(lst))));
-             lst = CDR(list_val(lst));
+             m += c2int_digit_from_base(unsigned_val(cell_head(list_val(lst))));
+             lst = cell_tail(list_val(lst));
          }
          res = small_to_big(m, hp);  /* load first digits */
 
@@ -2985,8 +2985,8 @@ LTI_result_t erts_list_to_integer(Process *BIF_P, Eterm orig_list,
              m = 0;
              while(i--) {
                  m *= base;
-                 m += c2int_digit_from_base(unsigned_val(CAR(list_val(lst))));
-                 lst = CDR(list_val(lst));
+                 m += c2int_digit_from_base(unsigned_val(cell_head(list_val(lst))));
+                 lst = cell_tail(list_val(lst));
              }
              if (is_small(res))
                  res = small_to_big(signed_val(res), hp);

--- a/erts/emulator/beam/binary.c
+++ b/erts/emulator/beam/binary.c
@@ -950,8 +950,8 @@ BIF_RETTYPE erts_list_to_binary_bif(Process *c_p, Eterm arg, Export *bif)
 	ERTS_BIF_PREP_ERROR(ret, c_p, BADARG);
     else {
 	/* check for [binary()] case */
-	Eterm h = CAR(list_val(arg));
-	Eterm t = CDR(list_val(arg));
+	Eterm h = cell_head(list_val(arg));
+	Eterm t = cell_tail(list_val(arg));
 	if (is_binary(h)
 	    && is_nil(t)
 	    && !(HEADER_SUB_BIN == *(binary_val(h))
@@ -1073,8 +1073,8 @@ BIF_RETTYPE list_to_bitstring_1(BIF_ALIST_1)
 	ERTS_BIF_PREP_ERROR(ret, BIF_P, BADARG);
     else {
 	/* check for [bitstring()] case */
-	Eterm h = CAR(list_val(BIF_ARG_1));
-	Eterm t = CDR(list_val(BIF_ARG_1));
+	Eterm h = cell_head(list_val(BIF_ARG_1));
+	Eterm t = cell_tail(list_val(BIF_ARG_1));
 	if (is_binary(h) && is_nil(t)) {
 	    ERTS_BIF_PREP_RET(ret, h);
 	}
@@ -1328,7 +1328,7 @@ list_to_bitstr_buf(int yield_support, ErtsIOList2BufState *state)
 		    if (yield_support && --yield_count <= 0)
 			goto L_yield;
 		    objp = list_val(obj);
-		    obj = CAR(objp);
+		    obj = cell_head(objp);
 		    if (is_byte(obj)) {
 			ASSERT(len > 0);
 			if (offset == 0) {
@@ -1345,7 +1345,7 @@ list_to_bitstr_buf(int yield_support, ErtsIOList2BufState *state)
 		    } else if (is_binary(obj)) {
 			LIST_TO_BITSTR_BUF_BCOPY(objp);
 		    } else if (is_list(obj)) {
-			ESTACK_PUSH(s, CDR(objp));
+			ESTACK_PUSH(s, cell_tail(objp));
 			continue; /* Head loop */
 		    } else {
 			ASSERT(is_nil(obj));
@@ -1355,7 +1355,7 @@ list_to_bitstr_buf(int yield_support, ErtsIOList2BufState *state)
 
 	    L_tail:
 
-		obj = CDR(objp);
+		obj = cell_tail(objp);
 		if (is_list(obj)) {
 		    continue; /* Tail loop */
 		} else if (is_binary(obj)) {
@@ -1580,7 +1580,7 @@ bitstr_list_len(ErtsIOListState *state)
 			goto L_yield;
 		    objp = list_val(obj);
 		    /* Head */
-		    obj = CAR(objp);
+		    obj = cell_head(objp);
 		    if (is_byte(obj)) {
 			len++;
 			if (len == 0) {
@@ -1590,7 +1590,7 @@ bitstr_list_len(ErtsIOListState *state)
 			SAFE_ADD(len, binary_size(obj));
 			SAFE_ADD_BITSIZE(offs, obj);
 		    } else if (is_list(obj)) {
-			ESTACK_PUSH(s, CDR(objp));
+			ESTACK_PUSH(s, cell_tail(objp));
 			continue; /* Head loop */
 		    } else if (is_not_nil(obj)) {
 			goto L_type_error;
@@ -1598,7 +1598,7 @@ bitstr_list_len(ErtsIOListState *state)
 		    break;
 		}
 		/* Tail */
-		obj = CDR(objp);
+		obj = cell_tail(objp);
 		if (is_list(obj))
 		    continue; /* Tail loop */
 		else if (is_binary(obj)) {

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -5320,7 +5320,7 @@ BIF_RETTYPE erts_internal_dist_spawn_request_4(BIF_ALIST_4)
         list = alist;
         while (is_list(list)) {
             Eterm *cp = list_val(list);
-            list = CDR(cp);
+            list = cell_tail(cp);
             nargs++;
         }
         if (!is_nil(list))
@@ -5334,8 +5334,8 @@ BIF_RETTYPE erts_internal_dist_spawn_request_4(BIF_ALIST_4)
     
     while (is_list(list)) {
         Eterm *cp = list_val(list);
-        Eterm car = CAR(cp);
-        list = CDR(cp);
+        Eterm car = cell_head(cp);
+        list = cell_tail(cp);
         nopts++;
         switch (car) {
         case am_link:
@@ -5430,8 +5430,8 @@ BIF_RETTYPE erts_internal_dist_spawn_request_4(BIF_ALIST_4)
             
             while (is_list(list)) {
                 Eterm *cp = list_val(list);
-                Eterm car = CAR(cp);
-                list = CDR(cp);
+                Eterm car = cell_head(cp);
+                list = cell_tail(cp);
                 if (is_tuple_arity(car, 2)) {
                     Eterm *tp = tuple_val(car);
                     if (am_reply_tag == tp[1]
@@ -5441,7 +5441,7 @@ BIF_RETTYPE erts_internal_dist_spawn_request_4(BIF_ALIST_4)
                         if (rm_cnt == rm_opts) {
                             ASSERT(prev_cp);
                             ASSERT(list == reusable_tail);
-                            CDR(prev_cp) = list;
+                            set_cell_tail(prev_cp, list);
                             break; /* last option to skip */
                         }
                         continue;
@@ -5450,10 +5450,10 @@ BIF_RETTYPE erts_internal_dist_spawn_request_4(BIF_ALIST_4)
 #ifdef DEBUG
                 rebuild_opts--;
 #endif
-                CAR(hp) = car;
+                set_cell_head(hp, car);
                 prev_cp = hp;
                 hp -= 2;
-                CDR(prev_cp) = make_list(hp);
+                set_cell_tail(prev_cp, make_list(hp));
             }
             ASSERT(hp == hp_start - 2);
             ASSERT(rebuild_opts == 0);
@@ -5661,7 +5661,7 @@ BIF_RETTYPE nodes_1(BIF_ALIST_1)
       arg_list = CONS(buf, BIF_ARG_1, NIL);
 
     while (is_list(arg_list)) {
-      switch(CAR(list_val(arg_list))) {
+      switch(cell_head(list_val(arg_list))) {
       case am_visible:   visible = 1;                                 break;
       case am_hidden:    hidden = 1;                                  break;
       case am_known:     visible = hidden = not_connected = this = 1; break;
@@ -5669,7 +5669,7 @@ BIF_RETTYPE nodes_1(BIF_ALIST_1)
       case am_connected: visible = hidden = 1;                        break;
       default:           goto error;                                  break;
       }
-      arg_list = CDR(list_val(arg_list));
+      arg_list = cell_tail(list_val(arg_list));
     }
 
     if (is_not_nil(arg_list)) {
@@ -5764,8 +5764,8 @@ monitor_node(Process* p, Eterm Node, Eterm Bool, Eterm Options)
     Eterm l;
     int async_connect = 1;
 
-    for (l = Options; l != NIL && is_list(l); l = CDR(list_val(l))) {
-	Eterm t = CAR(list_val(l));
+    for (l = Options; l != NIL && is_list(l); l = cell_tail(list_val(l))) {
+	Eterm t = cell_head(list_val(l));
 	if (t == am_allow_passive_connect) {
 	    /*
 	     * Handle this horrible feature by falling back on old synchronous
@@ -6017,8 +6017,8 @@ erts_monitor_nodes(Process *c_p, Eterm on, Eterm olist)
 
 	while (is_list(opts_list)) {
 	    Eterm *cp = list_val(opts_list);
-	    Eterm opt = CAR(cp);
-	    opts_list = CDR(cp);
+	    Eterm opt = cell_head(cp);
+	    opts_list = cell_tail(cp);
 	    if (opt == am_nodedown_reason)
 		opts |= ERTS_NODES_MON_OPT_DOWN_REASON;
 	    else if (is_tuple(opt)) {

--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -2197,7 +2197,7 @@ erts_memory(fmtfn_t *print_to_p, void *print_to_arg, void *proc, Eterm earg)
 	}
 	    
 	while (is_list(wanted_list)) {
-	    switch (CAR(list_val(wanted_list))) {
+	    switch (cell_head(list_val(wanted_list))) {
 	    case am_total:
 		if (!want.total) {
 		    want.total = 1;
@@ -2265,7 +2265,7 @@ erts_memory(fmtfn_t *print_to_p, void *print_to_arg, void *proc, Eterm earg)
 		UnUseTmpHeapNoproc(2);
 		return am_badarg;
 	    }
-	    wanted_list = CDR(list_val(wanted_list));
+	    wanted_list = cell_tail(list_val(wanted_list));
 	}
 	UnUseTmpHeapNoproc(2);
 	if (is_not_nil(wanted_list))
@@ -3299,7 +3299,7 @@ erts_request_alloc_info(struct process *c_p,
     while (is_list(alist)) {
 	int saved = 0;
 	Eterm* consp = list_val(alist);
-	Eterm alloc = CAR(consp);
+	Eterm alloc = cell_head(consp);
 
 	for (ai = ERTS_ALC_A_MIN; ai <= ERTS_ALC_A_MAX; ai++)
 	    if (erts_is_atom_str(erts_alc_a2ad[ai], alloc, 0))
@@ -3331,7 +3331,7 @@ erts_request_alloc_info(struct process *c_p,
 	if (!saved)
 	    return 0;
 
-	alist = CDR(consp);
+	alist = cell_tail(consp);
     }
 
     if (is_not_nil(alist))

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -1009,8 +1009,8 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
     if (is_list(argument)) {
 	t = argument;
 	while (is_list(t)) {
-	    b = CAR(list_val(t));
-	    t = CDR(list_val(t));
+	    b = cell_head(list_val(t));
+	    t = cell_tail(list_val(t));
 	    if (!is_binary(b)) {
 		goto badarg;
 	    }
@@ -1030,7 +1030,7 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
 	if (words > 1) {
 	    comp_term = argument;
 	} else {
-	    comp_term = CAR(list_val(argument));
+	    comp_term = cell_head(list_val(argument));
 	}
     } else if (is_binary(argument)) {
 	if (binary_bitsize(argument) != 0) {
@@ -1075,8 +1075,8 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
 	    byte *bytes;
 	    Uint bitoffs, bitsize;
 	    byte *temp_alloc = NULL;
-	    b = CAR(list_val(t));
-	    t = CDR(list_val(t));
+	    b = cell_head(list_val(t));
+	    t = cell_tail(list_val(t));
 	    ERTS_GET_BINARY_BYTES(b, bytes, bitoffs, bitsize);
 	    if (bitoffs != 0) {
 		bytes = erts_get_aligned_binary_bytes(b, &temp_alloc);
@@ -1278,7 +1278,7 @@ static int parse_match_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp)
 	return 0;
     } else if (is_list(l)) {
 	while(is_list(l)) {
-	    Eterm t = CAR(list_val(l));
+	    Eterm t = cell_head(list_val(l));
 	    Uint orig_size;
 	    if (!is_tuple(t)) {
 		goto badarg;
@@ -1319,7 +1319,7 @@ static int parse_match_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp)
 		orig_size < (*endp)) {
 		goto badarg;
 	    }
-	    l = CDR(list_val(l));
+	    l = cell_tail(list_val(l));
 	}
 	return 0;
     } else {
@@ -1340,22 +1340,22 @@ static int parse_split_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp, Uin
 	return 0;
     } else if (is_list(l)) {
 	while(is_list(l)) {
-	    Eterm t = CAR(list_val(l));
+	    Eterm t = cell_head(list_val(l));
 	    Uint orig_size;
 	    if (is_atom(t)) {
 		if (t == am_global) {
 		    *optp |= BF_FLAG_GLOBAL;
-		    l = CDR(list_val(l));
+		    l = cell_tail(list_val(l));
 		    continue;
 		}
 		if (t == am_trim) {
 		    *optp |= BF_FLAG_SPLIT_TRIM;
-		    l = CDR(list_val(l));
+		    l = cell_tail(list_val(l));
 		    continue;
 		}
 		if (t == am_trim_all) {
 		    *optp |= BF_FLAG_SPLIT_TRIM_ALL;
-		    l = CDR(list_val(l));
+		    l = cell_tail(list_val(l));
 		    continue;
 		}
 	    }
@@ -1398,7 +1398,7 @@ static int parse_split_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp, Uin
 		orig_size < (*endp)) {
 		goto badarg;
 	    }
-	    l = CDR(list_val(l));
+	    l = cell_tail(list_val(l));
 	}
 	return 0;
     } else {
@@ -2162,12 +2162,12 @@ static BIF_RETTYPE do_longest_common(Process *p, Eterm list, int direction)
 
     /* First just count the number of binaries */
     while (is_list(l)) {
-	b = CAR(list_val(l));
+	b = cell_head(list_val(l));
 	if (!is_binary(b)) {
 	    goto badarg;
 	}
 	++n;
-	l = CDR(list_val(l));
+	l = cell_tail(list_val(l));
     }
     if (l != NIL || n == 0) {
 	goto badarg;
@@ -2186,7 +2186,7 @@ static BIF_RETTYPE do_longest_common(Process *p, Eterm list, int direction)
 	ProcBin* pb;
 
 	cd[i].type = CL_TYPE_EMPTY;
-	b = CAR(list_val(l));
+	b = cell_head(list_val(l));
 	ERTS_GET_REAL_BIN(b, real_bin, offset, bitoffs, bitsize);
 	if (bitsize != 0) {
 	    erts_bin_free(mb);
@@ -2209,7 +2209,7 @@ static BIF_RETTYPE do_longest_common(Process *p, Eterm list, int direction)
 	    cd[i].type = (cd[i].temp_alloc != NULL) ? CL_TYPE_ALIGNED : CL_TYPE_HEAP_NOALLOC;
 	}
 	++i;
-	l = CDR(list_val(l));
+	l = cell_tail(list_val(l));
     }
     cd[i].type = CL_TYPE_EMPTY;
 #if defined(DEBUG) || defined(VALGRIND)

--- a/erts/emulator/beam/erl_bif_chksum.c
+++ b/erts/emulator/beam/erl_bif_chksum.c
@@ -136,7 +136,7 @@ static Eterm do_chksum(ChksumFun sumfun, Process *p, Eterm ioterm, int left,
 	if(is_list(ioterm)) {
 L_Again:   /* Restart with sublist, old listend was pushed on stack */
 	    objp = list_val(ioterm);
-	    obj = CAR(objp);
+	    obj = cell_head(objp);
 	    for(;;) { /* loop over one flat list of bytes and binaries
 		         until sublist or list end is encountered */
 		if (is_byte(obj)) {
@@ -158,12 +158,12 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 			}  
 			bytes[bsize++] = (unsigned char) unsigned_val(obj);
 			--left;
-			ioterm = CDR(objp);
+			ioterm = cell_tail(objp);
 			if (!is_list(ioterm)) {
 			    break;
 			}
 			objp = list_val(ioterm);
-			obj = CAR(objp);
+			obj = cell_head(objp);
 			if (!is_byte(obj))
 			    break;
 			if (!left) {
@@ -173,16 +173,16 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		    (*sumfun)(sum, bytes, bsize);
 		    *res += bsize;
 		} else if (is_nil(obj)) {
-		    ioterm = CDR(objp);
+		    ioterm = cell_tail(objp);
 		    if (!is_list(ioterm)) {
 			break;
 		    }
 		    objp = list_val(ioterm);
-		    obj = CAR(objp);
+		    obj = cell_head(objp);
 		} else if (is_list(obj)) {
 		    /* push rest of list for later processing, start 
 		       again with sublist */
-		    ESTACK_PUSH(stack,CDR(objp));
+		    ESTACK_PUSH(stack,cell_tail(objp));
 		    ioterm = obj;
 		    goto L_Again;
 		} else if (is_binary(obj)) {
@@ -202,17 +202,17 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		    if (rest_term != NIL) {
 			Eterm *hp;
 			hp = HAlloc(p, 2);
-			obj = CDR(objp);
+			obj = cell_tail(objp);
 			ioterm = CONS(hp, rest_term, obj);
 			left = 0;
 			break;
 		    }
-		    ioterm = CDR(objp);
+		    ioterm = cell_tail(objp);
 		    if (is_list(ioterm)) {
 			/* objp and obj need to be updated if 
 			   loop is to continue */
 			objp = list_val(ioterm);
-			obj = CAR(objp);
+			obj = cell_head(objp);
 		    }
 		} else {
 		    *err = 1;

--- a/erts/emulator/beam/erl_bif_ddll.c
+++ b/erts/emulator/beam/erl_bif_ddll.c
@@ -196,8 +196,8 @@ BIF_RETTYPE erl_ddll_try_load_3(BIF_ALIST_3)
     int build_this_load_error = 0;
     int encoding;
 
-    for(l = options; is_list(l); l =  CDR(list_val(l))) {
-	Eterm opt = CAR(list_val(l));
+        for(l = options; is_list(l); l =  cell_tail(list_val(l))) {
+	Eterm opt = cell_head(list_val(l));
 	Eterm *tp;
 	if (is_not_tuple(opt)) {
 	    goto error;
@@ -210,8 +210,8 @@ BIF_RETTYPE erl_ddll_try_load_3(BIF_ALIST_3)
 	case am_driver_options:
 	    {
 		Eterm ll;
-		for(ll = tp[2]; is_list(ll); ll = CDR(list_val(ll))) {
-		    Eterm dopt = CAR(list_val(ll));
+		for(ll = tp[2]; is_list(ll); ll = cell_tail(list_val(ll))) {
+		    Eterm dopt = cell_head(list_val(ll));
 		    if (dopt == am_kill_ports) {
 			flags |= ERL_DE_FL_KILL_PORTS;
 		    } else {
@@ -501,8 +501,8 @@ Eterm erl_ddll_try_unload_2(BIF_ALIST_2)
 
     erts_proc_unlock(BIF_P, ERTS_PROC_LOCK_MAIN);
 
-    for(l = options; is_list(l); l =  CDR(list_val(l))) {
-	Eterm opt = CAR(list_val(l));
+    for(l = options; is_list(l); l =  cell_tail(list_val(l))) {
+	Eterm opt = cell_head(list_val(l));
 	Eterm *tp;
 	if (is_not_tuple(opt)) {
 	    if (opt == am_kill_ports) {

--- a/erts/emulator/beam/erl_bif_guard.c
+++ b/erts/emulator/beam/erl_bif_guard.c
@@ -283,7 +283,7 @@ Eterm erts_trapping_length_1(Process* p, Eterm* args)
     list = args[0];
     i = unsigned_val(args[1]);
     while (is_list(list) && max_iter != 0) {
-	list = CDR(list_val(list));
+	list = cell_tail(list_val(list));
 	i++, max_iter--;
     }
 

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -1126,7 +1126,7 @@ process_info_bif(Process *c_p, Eterm pid, Eterm opt, int always_wrap, int pi2)
 
         while (is_list(list)) {
             Eterm *consp = list_val(list);
-            Eterm arg = CAR(consp);
+            Eterm arg = cell_head(consp);
             int ix = pi_arg2ix(arg);
             if (ix < 0)
                 goto badarg;
@@ -1142,7 +1142,7 @@ process_info_bif(Process *c_p, Eterm pid, Eterm opt, int always_wrap, int pi2)
             reserve_size += 3; /* 2-tuple */
             reserve_size += 2; /* cons */
 
-            list = CDR(consp);
+            list = cell_tail(consp);
         }
 
         if (is_not_nil(list))
@@ -5455,16 +5455,16 @@ BIF_RETTYPE erts_debug_lcnt_control_2(BIF_ALIST_2)
             Eterm *cell = list_val(categories);
             erts_lock_flags_t category;
 
-            category = lcnt_atom_to_lock_category(CAR(cell));
+            category = lcnt_atom_to_lock_category(cell_head(cell));
 
             if(!category) {
                 Eterm *hp = HAlloc(BIF_P, 4);
 
-                BIF_RET(TUPLE3(hp, am_error, am_badarg, CAR(cell)));
+                BIF_RET(TUPLE3(hp, am_error, am_badarg, cell_head(cell)));
             }
 
             category_mask |= category;
-            categories = CDR(cell);
+            categories = cell_tail(cell);
         }
 
         erts_lcnt_set_category_mask(category_mask);

--- a/erts/emulator/beam/erl_bif_port.c
+++ b/erts/emulator/beam/erl_bif_port.c
@@ -174,14 +174,14 @@ BIF_RETTYPE erts_internal_port_command_3(BIF_ALIST_3)
 	Eterm l = BIF_ARG_3;
 	while (is_list(l)) {
 	    Eterm* cons = list_val(l);
-	    Eterm car = CAR(cons);
+	    Eterm car = cell_head(cons);
 	    if (car == am_force)
 		flags |= ERTS_PORT_SIG_FLG_FORCE;
 	    else if (car == am_nosuspend)
 		flags |= ERTS_PORT_SIG_FLG_NOSUSPEND;
 	    else
 		BIF_RET(am_badarg);
-	    l = CDR(cons);
+	    l = cell_tail(cons);
 	}
 	if (!is_nil(l))
 	    BIF_RET(am_badarg);
@@ -1068,12 +1068,12 @@ static int merge_global_environment(erts_osenv_t *env, Eterm key_value_pairs) {
 
         cell = list_val(key_value_pairs);
 
-        if(!is_tuple_arity(CAR(cell), 2)) {
+        if(!is_tuple_arity(cell_head(cell), 2)) {
             return -1;
         }
 
-        tuple = tuple_val(CAR(cell));
-        key_value_pairs = CDR(cell);
+        tuple = tuple_val(cell_head(cell));
+        key_value_pairs = cell_tail(cell);
 
         if(is_nil(tuple[2]) || tuple[2] == am_false) {
             if(erts_osenv_unset_term(env, tuple[1]) < 0) {
@@ -1112,7 +1112,7 @@ static char **convert_args(Eterm l)
     pp = erts_alloc(ERTS_ALC_T_TMP, (n + 2) * sizeof(char **));
     pp[i++] = erts_default_arg0;
     while (is_list(l)) {
-	str = CAR(list_val(l));
+	str = cell_head(list_val(l));
 	if ((b = erts_convert_filename_to_native(str,NULL,0,ERTS_ALC_T_TMP,1,1,NULL)) == NULL) {
 	    int j;
 	    for (j = 1; j < i; ++j)
@@ -1121,7 +1121,7 @@ static char **convert_args(Eterm l)
 	    return NULL;
 	}	    
 	pp[i++] = b;
-	l = CDR(list_val(l));
+	l = cell_tail(list_val(l));
     }
     pp[i] = NULL;
     return pp;
@@ -1449,8 +1449,8 @@ BIF_RETTYPE decode_packet_3(BIF_ALIST_3)
     options = BIF_ARG_3;
     while (!is_nil(options)) {
         Eterm* cons = list_val(options);
-        if (is_tuple(CAR(cons))) {
-            Eterm* tpl = tuple_val(CAR(cons));
+        if (is_tuple(cell_head(cons))) {
+            Eterm* tpl = tuple_val(cell_head(cons));
             Uint val;
             if (tpl[0] == make_arityval(2) &&
 		term_to_Uint(tpl[2],&val) && val <= UINT_MAX) {
@@ -1472,7 +1472,7 @@ BIF_RETTYPE decode_packet_3(BIF_ALIST_3)
         BIF_ERROR(BIF_P, BADARG);
 
     next_option:       
-        options = CDR(cons);
+        options = cell_tail(cons);
     }
 
 

--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -242,8 +242,8 @@ parse_options(Eterm listp, /* in */
 	copt = 0;
 	eopt = 0;
 	fl = 0;
-	for (;is_list(listp); listp = CDR(list_val(listp))) {
-	    item = CAR(list_val(listp));
+	for (;is_list(listp); listp = cell_tail(list_val(listp))) {
+	    item = cell_head(list_val(listp));
 	    if (is_tuple(item)) {
 		Eterm *tp = tuple_val(item);
 		if (arityval(*tp) != 2 || is_not_atom(tp[1])) {
@@ -1014,9 +1014,9 @@ build_capture(Eterm capture_spec[CAPSPEC_SIZE], const pcre *code)
 	}
     default:
 	if (is_list(capture_spec[CAPSPEC_VALUES])) {
-	    for(l=capture_spec[CAPSPEC_VALUES];is_list(l);l = CDR(list_val(l))) {
+	    for(l=capture_spec[CAPSPEC_VALUES];is_list(l);l = cell_tail(list_val(l))) {
 		int x;
-		Eterm val = CAR(list_val(l));
+		Eterm val = cell_head(list_val(l));
 		ASSERT(ri->num_spec >= 0);
 		++(ri->num_spec);
 		if(ri->num_spec > sallocated) {

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -163,9 +163,9 @@ trace_pattern(Process* p, Eterm MFA, Eterm Pattern, Eterm flaglist)
     }
     
     is_global = 0;
-    for(l = flaglist; is_list(l); l = CDR(list_val(l))) {
-	if (is_tuple(CAR(list_val(l)))) {
-            meta_tracer = erts_term_to_tracer(am_meta, CAR(list_val(l)));
+    for(l = flaglist; is_list(l); l = cell_tail(list_val(l))) {
+	if (is_tuple(cell_head(list_val(l)))) {
+            meta_tracer = erts_term_to_tracer(am_meta, cell_head(list_val(l)));
             if (meta_tracer == THE_NON_VALUE) {
                 meta_tracer = erts_tracer_nil;
                 goto error;
@@ -173,7 +173,7 @@ trace_pattern(Process* p, Eterm MFA, Eterm Pattern, Eterm flaglist)
 	    flags.breakpoint = 1;
 	    flags.meta       = 1;
 	} else {
-	    switch (CAR(list_val(l))) {
+	    switch (cell_head(list_val(l))) {
 	    case am_local:
 		if (is_global) {
 		    goto error;
@@ -457,7 +457,7 @@ erts_trace_flags(Eterm List,
     
     while (is_list(list)) {
 	Uint bit;
-	Eterm item = CAR(list_val(list));
+	Eterm item = cell_head(list_val(list));
 	if (is_atom(item) && (bit = erts_trace_flag2bit(item))) {
 	    mask |= bit;
 #ifdef HAVE_ERTS_NOW_CPU
@@ -469,7 +469,7 @@ erts_trace_flags(Eterm List,
             if (tracer == THE_NON_VALUE)
                 goto error;
 	} else goto error;
-	list = CDR(list_val(list));
+	list = cell_tail(list_val(list));
     }
     if (is_not_nil(list)) goto error;
     
@@ -2090,8 +2090,8 @@ system_monitor(Process *p, Eterm monitor_pid, Eterm list)
 	for (long_gc = 0, long_schedule = 0, large_heap = 0, 
 		 busy_port = 0, busy_dist_port = 0;
 	     is_list(list);
-	     list = CDR(list_val(list))) {
-	    Eterm t = CAR(list_val(list));
+	     list = cell_tail(list_val(list))) {
+	    Eterm t = cell_head(list_val(list));
 	    if (is_tuple(t)) {
 		Eterm *tp = tuple_val(t);
 		if (arityval(tp[0]) != 2) goto error;
@@ -2233,9 +2233,9 @@ BIF_RETTYPE system_profile_2(BIF_ALIST_2)
 	for (ts = ERTS_TRACE_FLG_NOW_TIMESTAMP, scheduler = 0,
 		 runnable_ports = 0, runnable_procs = 0, exclusive = 0;
 	    is_list(list);
-	    list = CDR(list_val(list))) {
+	    list = cell_tail(list_val(list))) {
 	    
-	    Eterm t = CAR(list_val(list));
+	    Eterm t = cell_head(list_val(list));
 	    if (t == am_runnable_procs) {
 	   	 runnable_procs = !0;
 	    } else if (t == am_runnable_ports) {

--- a/erts/emulator/beam/erl_bif_unique.c
+++ b/erts/emulator/beam/erl_bif_unique.c
@@ -822,7 +822,7 @@ BIF_RETTYPE unique_integer_1(BIF_ALIST_1)
 
     while (is_list(modlist)) {
 	Eterm *consp = list_val(modlist);
-	switch (CAR(consp)) {
+	switch (cell_head(consp)) {
 	case am_monotonic:
 	    monotonic = 1;
 	    break;
@@ -832,7 +832,7 @@ BIF_RETTYPE unique_integer_1(BIF_ALIST_1)
 	default:
 	    BIF_ERROR(BIF_P, BADARG);
 	}
-	modlist = CDR(consp);
+	modlist = cell_tail(consp);
     }
 
     if (is_not_nil(modlist))

--- a/erts/emulator/beam/erl_cpu_topology.c
+++ b/erts/emulator/beam/erl_cpu_topology.c
@@ -1381,7 +1381,7 @@ erts_set_cpu_topology(Process *c_p, Eterm term)
 
 	while (is_list(list)) {
 	    Eterm *lp = list_val(list);
-	    Eterm cpu = CAR(lp);
+	    Eterm cpu = cell_head(lp);
 	    Eterm* tp;
 	    Sint id;
 		
@@ -1431,7 +1431,7 @@ erts_set_cpu_topology(Process *c_p, Eterm term)
 		goto error;
 	    cpudata[ix].logical = (int) id;
 
-	    list = CDR(lp);
+	    list = cell_tail(lp);
 	    ix++;
 	}
 

--- a/erts/emulator/beam/erl_db_hash.c
+++ b/erts/emulator/beam/erl_db_hash.c
@@ -1907,13 +1907,13 @@ static int select_chunk_on_loop_ended(traverse_context_t* ctx_base,
                 Eterm tmp = ctx->match_list;
                 rest = ctx->match_list;
                 while (got-- > ctx->chunk_size + 1) {
-                    tmp = CDR(list_val(tmp));
+                    tmp = cell_tail(list_val(tmp));
                     ++rest_size;
                 }
                 ++rest_size;
-                ctx->match_list = CDR(list_val(tmp));
-                CDR(list_val(tmp)) = NIL; /* Destructive, the list has never
-                                             been in 'user space' */
+                ctx->match_list = cell_tail(list_val(tmp));
+                set_cell_tail(list_val(tmp), NIL); /* Destructive, the list has never
+                                                      been in 'user space' */
             }
             if (rest != NIL || slot_ix >= 0) { /* Need more calls */
                 Eterm tid = ctx->base.tid;
@@ -2061,9 +2061,9 @@ int select_chunk_continue_on_loop_ended(traverse_context_t* ctx_base,
                been in user space */
             hp = HAlloc(ctx->base.p, (got - ctx->chunk_size) * 2);
             while (got-- > ctx->chunk_size) {
-                rest = CONS(hp, CAR(list_val(ctx->match_list)), rest);
+                rest = CONS(hp, cell_head(list_val(ctx->match_list)), rest);
                 hp += 2;
-                ctx->match_list = CDR(list_val(ctx->match_list));
+                ctx->match_list = cell_tail(list_val(ctx->match_list));
                 ++rest_size;
             }
         }
@@ -2847,7 +2847,7 @@ static int analyze_pattern(DbTableHash *tb, Eterm pattern,
     mpi->something_can_match = 0;
     mpi->mp = NULL;
 
-    for (lst = pattern; is_list(lst); lst = CDR(list_val(lst)))
+    for (lst = pattern; is_list(lst); lst = cell_tail(list_val(lst)))
 	++num_heads;
 
     if (lst != NIL) {/* proper list... */
@@ -2865,12 +2865,12 @@ static int analyze_pattern(DbTableHash *tb, Eterm pattern,
     bodies = buff + (num_heads * 2);
 
     i = 0;
-    for(lst = pattern; is_list(lst); lst = CDR(list_val(lst))) {
+    for(lst = pattern; is_list(lst); lst = cell_tail(list_val(lst))) {
         Eterm match;
         Eterm guard;
         Eterm body;
 
-	ttpl = CAR(list_val(lst));
+	ttpl = cell_head(list_val(lst));
 	if (!is_tuple(ttpl)) {
 	    if (buff != sbuff) { 
 		erts_free(ERTS_ALC_T_DB_TMP, buff);
@@ -2895,8 +2895,8 @@ static int analyze_pattern(DbTableHash *tb, Eterm pattern,
             return DB_ERROR_BADPARAM;
         }
 
-	if (!is_list(body) || CDR(list_val(body)) != NIL ||
-	    CAR(list_val(body)) != am_DollarUnderscore) {
+	if (!is_list(body) || cell_tail(list_val(body)) != NIL ||
+	    cell_head(list_val(body)) != am_DollarUnderscore) {
 	}
 	++i;
 	if (!(mpi->key_given)) {

--- a/erts/emulator/beam/erl_db_tree.c
+++ b/erts/emulator/beam/erl_db_tree.c
@@ -1148,9 +1148,9 @@ static BIF_RETTYPE ets_select_reverse(BIF_ALIST_3)
 	    hp = HAlloc(p, 64);
 	    hend = hp + 64;
 	}
-	result = CONS(hp, CAR(pair), result);
+	result = CONS(hp, cell_head(pair), result);
 	hp += 2;
-	list = CDR(pair);
+	list = cell_tail(pair);
     }
     if (is_not_nil(list))  {
 	goto error;
@@ -2687,7 +2687,7 @@ static int analyze_pattern(DbTableCommon *tb, Eterm pattern,
     mpi->key_boundness = MS_KEY_IMPOSSIBLE;
     mpi->mp = NULL;
 
-    for (lst = pattern; is_list(lst); lst = CDR(list_val(lst)))
+    for (lst = pattern; is_list(lst); lst = cell_tail(list_val(lst)))
 	++num_heads;
 
     if (lst != NIL) {/* proper list... */
@@ -2702,13 +2702,13 @@ static int analyze_pattern(DbTableCommon *tb, Eterm pattern,
     bodies = buff + (num_heads * 2);
 
     i = 0;
-    for(lst = pattern; is_list(lst); lst = CDR(list_val(lst))) {
+    for(lst = pattern; is_list(lst); lst = cell_tail(list_val(lst))) {
         Eterm match;
         Eterm guard;
         Eterm body;
         Eterm key;
 
-	ttpl = CAR(list_val(lst));
+	ttpl = cell_head(list_val(lst));
 	if (!is_tuple(ttpl)) {
 	    if (buff != sbuff) { 
 		erts_free(ERTS_ALC_T_DB_TMP, buff);
@@ -2733,8 +2733,8 @@ static int analyze_pattern(DbTableCommon *tb, Eterm pattern,
             return DB_ERROR_BADPARAM;
         }
 
-	if (!is_list(body) || CDR(list_val(body)) != NIL ||
-	    CAR(list_val(body)) != am_DollarUnderscore) {
+	if (!is_list(body) || cell_tail(list_val(body)) != NIL ||
+	    cell_head(list_val(body)) != am_DollarUnderscore) {
 	}
 	++i;
 

--- a/erts/emulator/beam/erl_hl_timer.c
+++ b/erts/emulator/beam/erl_hl_timer.c
@@ -2230,7 +2230,7 @@ parse_bif_timer_options(Eterm option_list, int *async,
 	Eterm *consp, *tp, opt;
 
 	consp = list_val(list);
-	opt = CAR(consp);
+	opt = cell_head(consp);
 	if (is_not_tuple(opt))
 	    return 0;
 
@@ -2255,7 +2255,7 @@ parse_bif_timer_options(Eterm option_list, int *async,
 	    return 0;
 	}
 
-	list = CDR(consp);	
+	list = cell_tail(consp);
     }
 
     if (is_not_nil(list))

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1498,7 +1498,7 @@ int enif_get_string(ErlNifEnv *env, ERL_NIF_TERM list, char* buf, unsigned len,
 	    buf[n-1] = '\0'; /* truncate */
 	    return -len;
 	}
-	list = CDR(listptr);
+	list = cell_tail(listptr);
     }
     buf[n] = '\0';
     return n + 1;
@@ -1735,8 +1735,8 @@ int enif_get_list_cell(ErlNifEnv* env, Eterm term, Eterm* head, Eterm* tail)
     Eterm* val;
     if (is_not_list(term)) return 0;
     val = list_val(term);
-    *head = CAR(val);
-    *tail = CDR(val);
+    *head = cell_head(val);
+    *tail = cell_tail(val);
     return 1;
 }
 
@@ -1910,8 +1910,8 @@ ERL_NIF_TERM enif_make_list_cell(ErlNifEnv* env, Eterm car, Eterm cdr)
 
     ASSERT_IN_ENV(env, car, 0, "head of list cell");
     ASSERT_IN_ENV(env, cdr, 0, "tail of list cell");
-    CAR(hp) = car;
-    CDR(hp) = cdr;
+    set_cell_head(hp, car);
+    set_cell_tail(hp, cdr);
     return ret;
 }
 
@@ -2003,8 +2003,8 @@ int enif_make_reverse_list(ErlNifEnv* env, ERL_NIF_TERM term, ERL_NIF_TERM *list
 	}
 	hp = alloc_heap(env, 2);
 	listptr = list_val(term);
-	ret = CONS(hp, CAR(listptr), ret);
-	term = CDR(listptr);
+	ret = CONS(hp, cell_head(listptr), ret);
+	term = cell_tail(listptr);
     }
     *list = ret;
     return 1;
@@ -3519,8 +3519,8 @@ int enif_map_iterator_get_pair(ErlNifEnv *env,
     else {
         ASSERT(is_hashmap(iter->map));
         if (iter->idx > 0 && iter->idx <= iter->size) {
-            *key   = CAR(iter->u.hash.kv);
-            *value = CDR(iter->u.hash.kv);
+            *key   = cell_head(iter->u.hash.kv);
+            *value = cell_tail(iter->u.hash.kv);
             return 1;
         }
     }
@@ -3701,7 +3701,7 @@ static int examine_iovec_term(Eterm list, UWord max_length, iovec_slice_t *resul
         Eterm *cell;
 
         cell = list_val(lookahead);
-        binary = CAR(cell);
+        binary = cell_head(cell);
 
         if (!is_binary(binary)) {
             return 0;
@@ -3740,7 +3740,7 @@ static int examine_iovec_term(Eterm list, UWord max_length, iovec_slice_t *resul
         }
 
         result->sublist_length += 1;
-        lookahead = CDR(cell);
+        lookahead = cell_tail(cell);
 
         if (result->sublist_length >= max_length) {
             break;
@@ -3845,7 +3845,7 @@ static int fill_iovec_with_slice(ErlNifEnv *env,
         Eterm *cell;
 
         cell = list_val(sublist_iterator);
-        marshal_iovec_binary(CAR(cell), &copy_buffer, &copy_offset, &raw_data);
+        marshal_iovec_binary(cell_head(cell), &copy_buffer, &copy_offset, &raw_data);
 
         while (raw_data.size > 0) {
             UWord chunk_len = MIN(raw_data.size, MAX_SYSIOVEC_IOVLEN);
@@ -3864,7 +3864,7 @@ static int fill_iovec_with_slice(ErlNifEnv *env,
             iovec_idx += 1;
         }
 
-        sublist_iterator = CDR(cell);
+        sublist_iterator = cell_tail(cell);
     }
 
     ASSERT(iovec_idx == iovec->iovcnt);

--- a/erts/emulator/beam/erl_printf_term.c
+++ b/erts/emulator/beam/erl_printf_term.c
@@ -123,7 +123,7 @@ is_printable_string(Eterm list) {
 
     while(is_list(list)) {
 	Eterm* consp = list_val(list);
-	Eterm hd = CAR(consp);
+	Eterm hd = cell_head(consp);
 
 	if (!is_byte(hd))
 	    return 0;
@@ -132,7 +132,7 @@ is_printable_string(Eterm list) {
 	if (IS_CNTRL(c) && !IS_SPACE(c))
 	   return 0;
 	len++;
-	list = CDR(consp);
+	list = cell_tail(consp);
     }
     if (is_nil(list))
 	return len;
@@ -308,8 +308,8 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
 		    Eterm* cons = list_val(obj);
 		    Eterm tl;
 		    
-		    obj = CAR(cons);
-		    tl = CDR(cons);
+		    obj = cell_head(cons);
+		    tl = cell_tail(cons);
 		    if (is_not_nil(tl)) {
 			if (is_list(tl)) {
 			    WSTACK_PUSH3(s, tl, PRT_ONE_CONS, PRT_COMMA);

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -8702,7 +8702,7 @@ erts_internal_suspend_process_2(BIF_ALIST_2)
 
 	while (is_list(arg)) {
 	    Eterm *lp = list_val(arg);
-	    arg = CAR(lp);
+	    arg = cell_head(lp);
 	    switch (arg) {
 	    case am_unless_suspending:
 		unless_suspending = 1;
@@ -8722,7 +8722,7 @@ erts_internal_suspend_process_2(BIF_ALIST_2)
                 BIF_RET(am_badarg);
 	    }
             }
-	    arg = CDR(lp);
+	    arg = cell_tail(lp);
         }
 	if (is_not_nil(arg))
             BIF_RET(am_badarg);
@@ -11527,8 +11527,8 @@ erts_parse_spawn_opts(ErlSpawnOpts *sop, Eterm opts_list, Eterm *tag,
      * Walk through the option list.
      */
     while (is_list(ap)) {
-	Eterm arg = CAR(list_val(ap));
-	ap = CDR(list_val(ap));
+	Eterm arg = cell_head(list_val(ap));
+	ap = cell_tail(list_val(ap));
 	if (arg == am_link) {
             if (sop->flags & SPO_LINK)
                 sop->multi_set = !0;

--- a/erts/emulator/beam/erl_process_dict.c
+++ b/erts/emulator/beam/erl_process_dict.c
@@ -73,8 +73,11 @@
      erts_realloc(ERTS_ALC_T_PROC_DICT, (P), (NSz))
 
 
-#define TCAR(Term) CAR(list_val(Term))
-#define TCDR(Term) CDR(list_val(Term))
+#define TCAR(Term) cell_head(list_val(Term))
+#define TCAR_ptr(Term) cell_head_ptr(list_val(Term))
+
+#define TCDR(Term) cell_tail(list_val(Term))
+#define TCDR_ptr(Term) cell_tail_ptr(list_val(Term))
 
 /* Array access macro */ 
 #define ARRAY_GET(PDict, Index) (ASSERT((Index) < (PDict)->arraySize), \
@@ -404,7 +407,7 @@ static void pd_hash_erase(Process *p, Eterm id, Eterm *ret)
 	/* Find cons cell for identical value */
 	Eterm* prev = &p->dictionary->data[hval];
 
-	for (tmp = *prev; tmp != NIL; prev = &TCDR(tmp), tmp = *prev) {
+	for (tmp = *prev; tmp != NIL; prev = TCDR_ptr(tmp), tmp = *prev) {
 	    if (EQ(tuple_val(TCAR(tmp))[1], id)) {
 		*prev = TCDR(tmp);
 		*ret = tuple_val(TCAR(tmp))[2];
@@ -674,7 +677,7 @@ static Eterm pd_hash_put(Process *p, Eterm id, Eterm value)
         Eterm* prev_cdr = bucket;
 
         needed += 2;
-	for (tmp = old; tmp != NIL; prev_cdr = &TCDR(tmp), tmp = *prev_cdr) {
+	for (tmp = old; tmp != NIL; prev_cdr = TCDR_ptr(tmp), tmp = *prev_cdr) {
             tp = tuple_val(TCAR(tmp));
             if (EQ(tp[1], id)) {
                 old_val = tp[2];

--- a/erts/emulator/beam/erl_ptab.h
+++ b/erts/emulator/beam/erl_ptab.h
@@ -38,8 +38,8 @@
 #include "erl_monitor_link.h"
 
 #define ERTS_TRACER(P)          ((P)->common.tracer)
-#define ERTS_TRACER_MODULE(T) 	(CAR(list_val(T)))
-#define ERTS_TRACER_STATE(T) 	(CDR(list_val(T)))
+#define ERTS_TRACER_MODULE(T) 	(cell_head(list_val(T)))
+#define ERTS_TRACER_STATE(T) 	(cell_tail(list_val(T)))
 #define ERTS_TRACE_FLAGS(P)	((P)->common.trace_flags)
 
 #define ERTS_P_LINKS(P)		((P)->common.u.alive.links)

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -230,11 +230,32 @@ _ET_DECLARE_CHECKED(int,is_not_list,Eterm)
 _ET_DECLARE_CHECKED(Eterm*,list_val,Wterm)
 #define list_val(x)		_ET_APPLY(list_val,(x))
 
-#define CONS(hp, car, cdr) \
-        (CAR(hp)=(car), CDR(hp)=(cdr), make_list(hp))
+// CAR(x) return list cell head element
+ERTS_INLINE Eterm cell_head(const Eterm *x) { return x[0]; }
 
-#define CAR(x)  ((x)[0])
-#define CDR(x)  ((x)[1])
+// CAR(x) as lvalue
+// Return pointer to the first element in a list cell (head)
+ERTS_INLINE Eterm* cell_head_ptr(Eterm *x) { return x; }
+
+// Set value of the list cell head
+ERTS_INLINE void set_cell_head(Eterm *x, Eterm val) { x[0] = val; }
+
+// CDR(x) return list cell tail element
+ERTS_INLINE Eterm cell_tail(const Eterm *x) { return x[1]; }
+
+// CDR(x) as lvalue
+// Return pointer to second element in a list cell, usable for assignments/as a pointer
+ERTS_INLINE Eterm* cell_tail_ptr(Eterm *x) { return &x[1]; }
+
+// Set value of the list cell tail
+ERTS_INLINE void set_cell_tail(Eterm *x, Eterm val) { x[1] = val; }
+
+// Create a list cell on heap hp with head and tail components. The hp is not incremented.
+ERTS_INLINE Eterm CONS(Eterm *hp, Eterm head, Eterm tail) {
+    set_cell_head(hp, head);
+    set_cell_tail(hp, tail);
+    return make_list(hp);
+}
 
 /* generic tagged pointer (boxed or list) access methods */
 #define _unchecked_ptr_val(x)	((Eterm*) ((x) & ~((Uint) TAG_PTR_MASK__)))

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -2166,7 +2166,7 @@ sys_msg_disp_failure(ErtsSysMsgQ *smqp, Eterm receiver)
             static const char *no_logger = "(no logger present)";
         /* no_error_logger: */
             erts_fprintf(stderr, "%s %T: %T\n",
-                         no_logger, tag, CAR(list_val(tp[3])));
+                         no_logger, tag, cell_head(list_val(tp[3])));
             break;
         unexpected_error_msg:
             erts_fprintf(stderr,

--- a/erts/emulator/beam/instrs.tab
+++ b/erts/emulator/beam/instrs.tab
@@ -387,20 +387,20 @@ return() {
 get_list(Src, Hd, Tl) {
     Eterm* tmp_ptr = list_val($Src);
     Eterm hd, tl;
-    hd = CAR(tmp_ptr);
-    tl = CDR(tmp_ptr);
+    hd = cell_head(tmp_ptr);
+    tl = cell_tail(tmp_ptr);
     $Hd = hd;
     $Tl = tl;
 }
 
 get_hd(Src, Hd) {
     Eterm* tmp_ptr = list_val($Src);
-    $Hd = CAR(tmp_ptr);
+    $Hd = cell_head(tmp_ptr);
 }
 
 get_tl(Src, Tl) {
     Eterm* tmp_ptr = list_val($Src);
-    $Tl = CDR(tmp_ptr);
+    $Tl = cell_tail(tmp_ptr);
 }
 
 i_get(Src, Dst) {

--- a/erts/emulator/hipe/hipe_mode_switch.c
+++ b/erts/emulator/hipe/hipe_mode_switch.c
@@ -580,8 +580,8 @@ Process *hipe_mode_switch(Process *p, unsigned cmd, Eterm reg[])
 	  arity = 0;
 	  while (is_list(args)) {
 	      if (arity < 255) {
-		  reg[arity++] = CAR(list_val(args));
-		  args = CDR(list_val(args));
+		  reg[arity++] = cell_head(list_val(args));
+		  args = cell_tail(list_val(args));
 	      } else
 		  goto do_apply_fail;
 	  }
@@ -724,7 +724,7 @@ Eterm hipe_build_stacktrace(Process *p, struct StackTrace *s)
 	hp += 5;
 	next = CONS(hp, mfa, NIL);
 	*next_p = next;
-	next_p = &CDR(list_val(next));
+	next_p = cell_tail_ptr(list_val(next));
 	hp += 2;
     }
     HRelease(p, hp_end, hp);

--- a/erts/emulator/hipe/hipe_native_bif.c
+++ b/erts/emulator/hipe/hipe_native_bif.c
@@ -266,7 +266,7 @@ static struct StackTrace *get_trace_from_exc(Eterm exc)
     if (exc == NIL)
 	return NULL;
     else
-	return (struct StackTrace *) big_val(CDR(list_val(exc)));
+	return (struct StackTrace *) big_val(cell_tail(list_val(exc)));
 }
 
 /*


### PR DESCRIPTION
Replaces 3 macros: CAR, CDR and CONS with better more typesafe and read/write const-safe inlines.
Gathering OTP team opinion whether this is a good idea, and whether I should do more like this.
If the idea is liked, this opens way for more similar changes:

* Cleaner `Eterm` API: list ops, binary ops, small int ops, atom ops...
* Abstract away bit ops on terms, hiding bit ops from the logic and making the logic cleaner and safer.
* Prevent bugs when an integer is passed/received unintentionally, which is not an Eterm

![](https://user-images.githubusercontent.com/288724/92940800-d6b4fa80-f44f-11ea-95e8-43ae63e88fb0.png)


## Pros

* Renames old style `CAR`, `CDR` to `cell_head` and `cell_tail` which reads easier.
* Ensures that `Eterm*` and `Eterm` goes in/returns `Eterm` and `Eterm*`. Some compile time checks on types, and sizes.
* Has some `const` safety (more in the future changes). The user has to choose whether the `list_cell` will be writable or not.
* Debugging separate functions is also more pleasant (more debug info, stepping in, seeing locals), than macros.
* Should not affect the performance, but could (see Cons below).

## Cons (not CONS)

* While `Eterm` is identical to an integer, the type safety is not yet enforced. But it is possible also to replace `Eterm` with a single field struct. This can give it strong type and prevents confusing it with integers.
* This potentially could affect the performance, should be investigated. On small code examples in Godbolt's Compiler Explorer the assembly coming from the inline code looks identical to macros.
