### PR TITLE
Implement equal_const_time/2 as nif

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -769,3 +769,4 @@ bif erts_internal:abort_pending_connection/2
 #
 
 bif erts_internal:get_creation/0
+bif binary:secure_compare/2

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -70,6 +70,8 @@ binary_match(Process *p, Eterm arg1, Eterm arg2, Eterm arg3, Uint flags);
 static BIF_RETTYPE
 binary_split(Process *p, Eterm arg1, Eterm arg2, Eterm arg3);
 
+static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2);
+
 void erts_init_bif_binary(void)
 {
     erts_init_trap_export(&binary_find_trap_export,
@@ -2455,6 +2457,51 @@ static int cleanup_copy_bin_state(Binary *bp)
     }
     cbs->source_type =  BC_TYPE_EMPTY;
     return 1;
+}
+
+static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2)
+{
+    byte *bytes1;
+    byte *bytes2;
+    Uint bitoffs1, bitsize1;
+    Uint bitoffs2, bitsize2;
+    Uint size1, size2;
+
+    size_t i;
+    volatile unsigned char acc = 0;
+  
+    if (is_not_binary(bin1) || is_not_binary(bin2))
+        goto bad_arg;
+    
+    ERTS_GET_BINARY_BYTES(bin1, bytes1, bitoffs1, bitsize1); 
+    ERTS_GET_BINARY_BYTES(bin2, bytes2, bitoffs2, bitsize2);
+
+    size1 = binary_size(bin1);
+    
+    if (size1 != binary_size(bin2))
+      goto nomatch;
+
+
+    for (i=0; i < size1; i++) {
+        acc |= bytes1[i] ^ bytes2[i];
+    }
+
+    if (acc == 0)
+        goto match;
+
+    goto nomatch;
+
+ match:
+    BIF_RET(am_true);
+ nomatch:
+    BIF_RET(am_false);
+ bad_arg:
+    BIF_ERROR(p,BADARG);
+}
+
+BIF_RETTYPE binary_secure_compare_2(BIF_ALIST_2)
+{
+    return binary_secure_compare(BIF_P, BIF_ARG_1, BIF_ARG_2);
 }
 
 /*

--- a/lib/crypto/c_src/Makefile.in
+++ b/lib/crypto/c_src/Makefile.in
@@ -98,6 +98,7 @@ CRYPTO_OBJS = $(OBJDIR)/crypto$(TYPEMARKER).o \
 	$(OBJDIR)/pkey$(TYPEMARKER).o \
 	$(OBJDIR)/rand$(TYPEMARKER).o \
 	$(OBJDIR)/rsa$(TYPEMARKER).o \
+	$(OBJDIR)/str$(TYPEMARKER).o \
 	$(OBJDIR)/srp$(TYPEMARKER).o
 CALLBACK_OBJS = $(OBJDIR)/crypto_callback$(TYPEMARKER).o
 NIF_MAKEFILE = $(PRIVDIR)/Makefile

--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -49,6 +49,7 @@
 #include "rand.h"
 #include "rsa.h"
 #include "srp.h"
+#include "str.h"
 
 /* NIF interface declarations */
 static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info);
@@ -89,6 +90,7 @@ static ErlNifFunc nif_funcs[] = {
     {"strong_rand_range_nif", 1, strong_rand_range_nif, 0},
     {"rand_uniform_nif", 2, rand_uniform_nif, 0},
     {"mod_exp_nif", 4, mod_exp_nif, 0},
+    {"do_equal_const_time", 2, do_equal_const_time, 0},
     {"do_exor", 2, do_exor, 0},
     {"pkey_sign_nif", 5, pkey_sign_nif, 0},
     {"pkey_verify_nif", 6, pkey_verify_nif, 0},

--- a/lib/crypto/c_src/str.c
+++ b/lib/crypto/c_src/str.c
@@ -1,0 +1,50 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2010-2020. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+#include "str.h"
+
+ERL_NIF_TERM do_equal_const_time(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    
+    ErlNifBinary s1, s2;
+    
+    ASSERT(argc == 2);
+    
+    if (!enif_inspect_binary(env, argv[0], &s1)) 
+        goto bad_arg;
+    if (!enif_inspect_binary(env, argv[1], &s2))
+        goto bad_arg;
+
+    if (s1.size != s2.size)
+      goto nomatch;
+
+    if (CRYPTO_memcmp(s1.data, s2.data, s1.size) == 0)
+        goto match;
+
+    goto nomatch;
+
+ match: 
+    return  enif_make_atom(env,"true");
+ nomatch: 
+     return  enif_make_atom(env,"false");
+ bad_arg:
+    return enif_make_badarg(env);
+}
+

--- a/lib/crypto/c_src/str.h
+++ b/lib/crypto/c_src/str.h
@@ -1,0 +1,29 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2010-2020. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+
+#ifndef E_STR_H__
+#define E_STR_H__ 1
+
+#include "common.h"
+
+ERL_NIF_TERM do_equal_const_time(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+
+#endif /* E_STR_H__ */

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -774,7 +774,7 @@ enable_fips_mode_nif(_) -> ?nif_stub.
 %%%
 %%%================================================================
 
-equal_const_time(X1, X2) when is_binary(X1) andalso is_binary(X2) ->
+equal_const_time(X1, X2) when is_binary(X1), is_binary(X2) ->
     do_equal_const_time(X1, X2);
 
 equal_const_time(X1, X2) ->
@@ -3058,5 +3058,4 @@ check_otp_test_engine(LibDir) ->
                     {error, notexist}
             end
     end.
-
 

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -774,18 +774,11 @@ enable_fips_mode_nif(_) -> ?nif_stub.
 %%%
 %%%================================================================
 
-%%% Candidate for a NIF
+equal_const_time(X1, X2) when is_binary(X1) andalso is_binary(X2) ->
+    do_equal_const_time(X1, X2);
 
 equal_const_time(X1, X2) ->
     equal_const_time(X1, X2, true).
-
-
-equal_const_time(<<B1,R1/binary>>, <<B2,R2/binary>>, Truth) ->
-    equal_const_time(R1, R2, Truth and (B1 == B2));
-equal_const_time(<<_,R1/binary>>, <<>>, Truth) ->
-    equal_const_time(R1, <<>>, Truth and false);
-equal_const_time(<<>>, <<>>, Truth) ->
-    Truth;
 
 equal_const_time([H1|T1], [H2|T2], Truth) ->
     equal_const_time(T1, T2, Truth and (H1 == H2));
@@ -796,6 +789,8 @@ equal_const_time([], [], Truth) ->
 
 equal_const_time(_, _, _) ->
     false.
+
+do_equal_const_time(_X1, _X2) -> ?nif_stub.
 
 %%%================================================================
 %%%

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -67,6 +67,8 @@
          compute/1,
          compute_bug/0,
          compute_bug/1,
+         equal_const_time/0,
+         equal_const_time/1,
          exor/0,
          exor/1,
          generate/0,
@@ -218,6 +220,7 @@ all() ->
      {group, non_fips},
      cipher_padding,
      mod_pow,
+     equal_const_time,
      exor,
      rand_uniform,
      rand_threads,
@@ -1227,6 +1230,24 @@ mod_pow() ->
     [{doc, "mod_pow testing (A ^ M % P with bignums)"}].
 mod_pow(Config) when is_list(Config) ->
     mod_pow_aux_test(2, 5, 10, 8).
+%%--------------------------------------------------------------------
+equal_const_time() ->
+    [{doc, "Test equal_const_time"}].
+equal_const_time(Config) when is_list(Config) ->
+    true  = crypto:equal_const_time(<<"">>, <<"">>),
+    true  = crypto:equal_const_time(<<"good">>, <<"good">>),
+    
+    false  = crypto:equal_const_time(<<"good">>, <<"good1">>),
+    false = crypto:equal_const_time(<<"good">>, <<"bad">>),
+    false = crypto:equal_const_time(<<"eh?">>, <<"abcdefg">>),
+
+    true  = crypto:equal_const_time("", ""),
+    true  = crypto:equal_const_time("good", "good"),
+
+    false = crypto:equal_const_time("good", "bad"),
+    false = crypto:equal_const_time("good", "bad1"),
+    false = crypto:equal_const_time("eh?", "abcdefg"),
+    ok.
 %%--------------------------------------------------------------------
 exor() ->
     [{doc, "Test the exor function"}].

--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -35,7 +35,10 @@
          first/1, last/1, list_to_bin/1, longest_common_prefix/1,
          longest_common_suffix/1, match/2, match/3, matches/2,
          matches/3, part/2, part/3, referenced_byte_size/1,
-         split/2, split/3]).
+         split/2, split/3, secure_compare/2]).
+
+secure_compare(_, _) ->
+    erlang:nif_error(undef).
 
 -spec at(Subject, Pos) -> byte() when
       Subject :: binary(),

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -27,6 +27,8 @@
 
 -export([random_number/1, make_unaligned/1]).
 
+-export([secure_compare/1, secure_compare_time/1]).
+
 -include_lib("common_test/include/ct.hrl").
 
 suite() ->
@@ -37,7 +39,8 @@ all() ->
     [scope_return,interesting, random_ref_fla_comp, random_ref_sr_comp,
      random_ref_comp, parts, bin_to_list, list_to_bin, copy,
      referenced, guard, encode_decode, badargs,
-     longest_common_trap, check_no_invalid_read_bug].
+     longest_common_trap, check_no_invalid_read_bug, 
+     secure_compare, secure_compare_time].
 
 
 -define(MASK_ERROR(EXPR),mask_error((catch (EXPR)))).
@@ -1373,3 +1376,37 @@ check_no_invalid_read_bug(I) ->
     binary:encode_unsigned(N+N),
     binary:encode_unsigned(N+N, little),
     check_no_invalid_read_bug(I+1).
+
+secure_compare(Config) when is_list(Config) ->
+    true  = binary:secure_compare(<<"">>, <<"">>),
+    true  = binary:secure_compare(<<"good">>, <<"good">>),
+
+    false = binary:secure_compare(<<"good">>, <<"bad">>),
+    false = binary:secure_compare(<<"eh?">>, <<"Hello Joe">>),
+    false = binary:secure_compare(<<"one">>, <<"two">>),
+    false = binary:secure_compare(<<"two">>, <<"one">>),
+    ok.
+
+secure_compare_time(Config) when is_list(Config) -> 
+    A = <<"A">>,
+    B = <<"B">>,
+    
+    %% 9.9 Megabyte base binary
+    Base = binary:copy(<<"X">>, 9999999),
+
+    %% 10 Megabyte arg1 and arg2 with a one byte difference at the start of each. 
+    Arg1 = <<A/binary, Base/binary>>,
+    Arg2 = <<B/binary, Base/binary>>,
+
+    T1 =  erlang:convert_time_unit(erlang:monotonic_time(), native, microsecond),
+
+    binary:secure_compare(Arg1, Arg2),   
+    
+    T2 =  erlang:convert_time_unit(erlang:monotonic_time(), native, microsecond),
+
+    %% Given a 10 megabyte binary we can say with a fair amount of certainty that
+    %% to perform the secure_compare/2 operation will always take over 1ms, anything equal to
+    %% or less means we returned early per the differnce on the first byte of each argument and ergo can say
+    %% "Houston, we have a problem". 
+    false = (T2 - T1) =< 1000,
+    ok.


### PR DESCRIPTION
This PR implements equal_const_time/2 as a nif via delegation to [CRYPTO_memcmp](https://github.com/openssl/openssl/blob/08073700cc50bcd0df5c0ee68c100e300a320d03/crypto/cryptlib.c#L443) and intends to expose this function as part of the public api via documentation. If this PR is approved I will gladly document the function as part of the public API.

Discussions around this PR were had with @josevalim , @voltone , and @peerst  of the erlef security working group.

One particular topic that I feel is worth discussing and possibly adjusting this PR for is around having either a pure erlang implementation of a constant time comparisson function on `binary` as `secure_compare/2` or as BIF on binary of the same name and arity. The idea for having this in addition to `crypto:equal_const_time/2` is prompted by the case where one does not have crypto (openssl) available. This option may even be more advantageous with BeamAsm on the horizon, such that the nif implementation is not desired at all. However, no benchmarks were done using BeasmAsm against the NIF or BIF implementations. 

I have implemented the BIF but did not include it in this PR initially but am happy to do so either in this PR or a subsequent PR. Likewise, if a BIF is undesirable I'm also happy to add an erlang implementation on `binary` either as part of this PR or a subsequent PR. 

It should be noted that the BIF implementation was found to be twice as fast as the NIF implementation at a cursory glance, however, there is concern around maintaining the implementation, specifically around keeping up with compilers not respecting the`volatile` qualifier (see https://github.com/openssl/openssl/pull/102  for more details around this subject). 

## Benchmarks for the NIF implementation

Benchmarks were performed with erlperf and as with all benchmarks take the ones below with a grain of salt, but they give a good idea of the improvements.For brevity I did not include all my runs which measured function calls with more samples and in parallel (i.e., new nif impl vs old erlang impl). I'm happy to provide these if desired, but the quick benchmarks below show the same findings.

### Findings for binaries

The performance improvement was found to be significant.

#### Original erl implementation:
```
$ erlperf 'crypto:old_equal_const_time(<<"onexxxxx">>, <<"twoxxxxx">>).'
Code                                                               ||        QPS     Rel
crypto:old_equal_const_time(<<"onexxxxx">>, <<"twoxxxxx">>).        1    1522 Ki    100%
```

#### New NIF implementation:

```
$erlperf 'crypto:equal_const_time(<<"onexxxxx">>, <<"twoxxxxx">>).'
Code                                                             ||        QPS     Rel
crypto:equal_const_time(<<"onexxxxx">>, <<"twoxxxxx">>).          1    5909 Ki    100%
```

### Findings for strings

A performance decrease was observed for small strings, only at 64 byte strings was performance roughly the same. As such
equal_const_time/2 as part of this PR will only delegate to the nif for binaries.

#### Original erl implementation:

```
$ erlperf 'crypto:old_equal_const_time("onexxxxx", "twoxxxxx").'
Code                                                         ||        QPS     Rel
crypto:old_equal_const_time("onexxxxx", "twoxxxxx").          1    5267 Ki    100%
```

#### New NIF Implementation

```
$ erlperf 'crypto:equal_const_time("onexxxxx", "twoxxxxx").'
Code                                                     ||        QPS     Rel
crypto:equal_const_time("onexxxxx", "twoxxxxx").          1    2644 Ki    100%
```