### PR TITLE
Xref: Fix local calls from on_load being reported as unused

### DIFF
--- a/lib/tools/src/xref_base.erl
+++ b/lib/tools/src/xref_base.erl
@@ -401,8 +401,8 @@ analysis(locals_not_used, functions) ->
     %% But then we only get locals that make some calls, so we add
     %% locals that are not used at all: "L * (UU + XU - LU)".
     %% We also need to exclude functions with the -on_load() attribute:
-    %% (L - OL) is used rather than just L.
-    "(L - OL) * ((UU + XU - LU) + domain EE + range EE)";
+    %% (L - (OL + range (closure LC | OL))) is used rather than just L.
+    "(L - (OL + range (closure LC | OL))) * ((UU + XU - LU) + domain EE + range EE)";
 analysis(exports_not_used, _) ->
     %% Local calls are not considered here. "X * UU" would do otherwise.
     "X - XU";

--- a/lib/tools/test/xref_SUITE.erl
+++ b/lib/tools/test/xref_SUITE.erl
@@ -2454,8 +2454,9 @@ otp_14344(Conf) when is_list(Conf) ->
     MFile1 = fname(Dir, "a"),
     Beam1 = fname(Dir, "a.beam"),
     Test1 = <<"-module(a).
-               -on_load(doit/0).
-               doit() -> ok.
+               -on_load(init/0).
+               init() -> do_init().
+               do_init() -> ok.
               ">>,
     ok = file:write_file(File1, Test1),
     {ok, a} = compile:file(File1, [debug_info,{outdir,Dir}]),
@@ -2463,7 +2464,7 @@ otp_14344(Conf) when is_list(Conf) ->
     {ok, _} = xref:start(s),
     {ok, a} = xref:add_module(s, MFile1),
 
-    {ok, [{a,doit,0}]} = xref:q(s, "OL"),
+    {ok, [{a,init,0}]} = xref:q(s, "OL"),
     {ok, []} = xref:analyze(s, locals_not_used),
 
     xref:stop(s),


### PR DESCRIPTION
Xref incorrectly reported functions called exclusively from an on_load
function as being unused.