### PR TITLE
Suppress `xref` output for "unused export" on behaviour module's `behaviour_info/1`

### DIFF
--- a/lib/tools/src/xref_reader.erl
+++ b/lib/tools/src/xref_reader.erl
@@ -95,6 +95,8 @@ form({function, _, module_info, 0, _Clauses}, S) ->
     S;
 form({function, _, module_info, 1, _Clauses}, S) ->
     S;
+form({function, 0 = _Line, behaviour_info, 1, _Clauses}, S) ->
+    S;
 form({function, Anno, Name, Arity, Clauses}, S) ->
     MFA0 = {S#xrefr.module, Name, Arity},
     MFA = adjust_arity(S, MFA0),

--- a/lib/tools/test/xref_SUITE_data/lib_test/bi.erl
+++ b/lib/tools/test/xref_SUITE_data/lib_test/bi.erl
@@ -1,0 +1,3 @@
+-module(bi).
+
+-callback a() -> ok.

--- a/lib/tools/test/xref_SUITE_data/lib_test/no_bi.erl
+++ b/lib/tools/test/xref_SUITE_data/lib_test/no_bi.erl
@@ -1,0 +1,6 @@
+-module(no_bi).
+
+-export([behaviour_info/1]).
+
+behaviour_info(_) ->
+    ok.


### PR DESCRIPTION
This is a special (albeit optional) case - `behaviour_info`, generated internally by Erlang, so should not be part of the analysis' output.
Tools depending on the analysis output (like e.g. `rebar3 xref`) will force the consumer to add exceptions to them, when otherwise not required.