### PR TITLE
fix deadlock during async httpc:request when request body is a function

### DIFF
--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -133,6 +133,11 @@
         The <c>iolist()</c> in <c>body_processing_result()</c> returns the next part
         of your body and the stream is ended with <c>eof</c>.
       </p>
+      <p>
+        <c>{chunkify, ...}</c> is <url href="https://tools.ietf.org/html/rfc2616#section-14.41">only
+        supported for HTTP/1.1</url>, attempts to use this function with earlier versions
+        will throw a <c>bad_body</c> exception.
+      </p>
     </note>
     <p>For more information about HTTP, see
     <url href="http://www.ietf.org/rfc/rfc2616.txt">RFC 2616</url>.</p>

--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -113,18 +113,30 @@
     <taglist>
       <tag><c>body()</c></tag>
       <item><p>= <c>string() | binary()</c></p>
-      <p>| <c>{fun(accumulator())</c></p>
-      <p><c> -> body_processing_result(), accumulator()}</c></p>
-      <p>| <c>{chunkify, fun(accumulator())</c></p>
-      <p><c> -> body_processing_result(), accumulator()}</c></p>
+            <p>| <c>body_callback()</c></p>
+            <p>| <c>{chunkify, body_callback()}</c></p>
       </item>
     </taglist>
-    <p><c>body_processing_result() = eof | {ok, iolist(), accumulator()}</c></p>
+    <p><c>body_callback() = {fun(accumulator()) -> body_processing_result() | eof, accumulator()}</c></p>
+    <p><c>body_processing_result() = {ok, iolist(), accumulator()}</c></p>
     <p><c>accumulator() = term()</c></p>
-    <p><c>filename() = string()</c></p>
- <p>For more information about HTTP, see
- <url href="http://www.ietf.org/rfc/rfc2616.txt">RFC 2616</url>.</p> 
-</section>
+    <note>
+      <p>
+        <c>body_callback()</c> is useful to handle dynamic and/or streaming
+        content which can alternatively be supplied using <c>{chunkify, ...}</c>
+        to provide automatic handling of
+        <url href="https://tools.ietf.org/html/rfc2616#section-3.6.1">chunked transfer-encoding</url>
+        where the application will handle the encoding and additionally add
+        the HTTP header <c>transfer-encoding: chunked</c> to the response.
+      </p>
+      <p>
+        The <c>iolist()</c> in <c>body_processing_result()</c> returns the next part
+        of your body and the stream is ended with <c>eof</c>.
+      </p>
+    </note>
+    <p>For more information about HTTP, see
+    <url href="http://www.ietf.org/rfc/rfc2616.txt">RFC 2616</url>.</p>
+  </section>
   
   <section>
     <title>SSL DATA TYPES</title>
@@ -309,6 +321,7 @@
                       {receiver,                receiver()} |
 	              {ipv6_host_with_brackets, boolean()}</v>
         <v>stream_to() = none | self | {self, once} | filename()</v>
+        <v>filename() = string()</v>
         <v>socket_opts() = [socket_opt()]</v>
         <v>receiver() = pid() | function()/1 | {Module, Function, Args}</v>
         <v>Module = atom()</v>

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -176,6 +176,9 @@ request(Method,
        (Method =:= delete) orelse 
        (Method =:= trace) andalso 
        (is_atom(Profile) orelse is_pid(Profile)) ->
+    do_request(Method, {Url, Headers, [], []}, HTTPOptions, Options, Profile).
+
+do_request(Method, {Url, Headers, ContentType, Body}, HTTPOptions, Options, Profile) ->
     case normalize_and_parse_url(Url) of
 	{error, Reason, _} ->
 	    {error, Reason};
@@ -184,19 +187,9 @@ request(Method,
 		{error, Reason} ->
 		    {error, Reason};
 		_ ->
-		    handle_request(Method, Url, ParsedUrl, Headers, [], [], 
+		    handle_request(Method, Url, ParsedUrl, Headers, ContentType, Body,
 				   HTTPOptions, Options, Profile)
 	    end
-    end.
-
-do_request(Method, {Url, Headers, ContentType, Body}, HTTPOptions, Options, Profile) ->
-    case normalize_and_parse_url(Url) of
-	{error, Reason, _} ->
-	    {error, Reason};
-	ParsedUrl ->
-	    handle_request(Method, Url, 
-			   ParsedUrl, Headers, ContentType, Body, 
-			   HTTPOptions, Options, Profile)
     end.
 
 %%--------------------------------------------------------------------------

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -516,10 +516,12 @@ handle_request(Method, Url,
 
     try
 	begin
+            HTTPOptions   = http_options(HTTPOptions0),
+
 	    {NewHeaders, Body} = 
 		case Body0 of
 		    {chunkify, ProcessBody, Acc} 
-		      when is_function(ProcessBody, 1) ->
+		      when is_function(ProcessBody, 1), HTTPOptions#http_options.version == "HTTP/1.1" ->
 			NewHeaders1 = ensure_chunked_encoding(NewHeaders0), 
 			Body1       = {mk_chunkify_fun(ProcessBody), Acc}, 
 			{NewHeaders1, Body1};
@@ -532,7 +534,6 @@ handle_request(Method, Url,
 			throw({error, {bad_body, Body0}})
 		end,
 
-            HTTPOptions   = http_options(HTTPOptions0),
             Options       = request_options(Options0),
             Sync          = proplists:get_value(sync,   Options),
             Stream        = proplists:get_value(stream, Options),

--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -397,7 +397,7 @@ do_handle_call(#request{address = Addr} = Request, From,
                                         queue:len(NewPipeline) + 1,
                                         client_close = ClientClose},
                     insert_session(NewSession, ProfileName),
-                    {reply, ok, State1#state{
+                    {noreply, State1#state{
 				  request = OldRequest,
 				  pipeline = NewPipeline,
 				  session  = NewSession,

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -580,9 +580,7 @@ connect(Socket, SslOptions0, Timeout) when is_list(SslOptions0) andalso
     
     CbInfo = handle_option_cb_info(SslOptions0, tls),
     Transport = element(1, CbInfo),
-    EmulatedOptions = tls_socket:emulated_options(),
-    {ok, SocketValues} = tls_socket:getopts(Transport, Socket, EmulatedOptions),
-    try handle_options(SslOptions0 ++ SocketValues, client) of
+    try handle_options(Transport, Socket, SslOptions0, client, undefined) of
         {ok, Config} ->
             tls_socket:upgrade(Socket, Config, Timeout)
     catch
@@ -784,10 +782,8 @@ handshake(#sslsocket{pid = [Pid|_], fd = {_, _, _}} = Socket, SslOpts, Timeout) 
 handshake(Socket, SslOptions, Timeout) when (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
     CbInfo = handle_option_cb_info(SslOptions, tls),
     Transport = element(1, CbInfo),
-    EmulatedOptions = tls_socket:emulated_options(),
-    {ok, SocketValues} = tls_socket:getopts(Transport, Socket, EmulatedOptions),
     ConnetionCb = connection_cb(SslOptions),
-    try handle_options(SslOptions ++ SocketValues, server) of
+    try handle_options(Transport, Socket, SslOptions, server, undefined) of
         {ok, #config{transport_info = CbInfo, ssl = SslOpts, emulated = EmOpts}} ->
             ok = tls_socket:setopts(Transport, Socket, tls_socket:internal_inet_values()),
             {ok, Port} = tls_socket:port(Transport, Socket),
@@ -1577,24 +1573,24 @@ do_listen(Port, #config{transport_info = {Transport, _, _, _,_}} = Config, tls_g
 do_listen(Port,  Config, dtls_gen_connection) ->
     dtls_socket:listen(Port, Config).
 	
-
-
 -spec handle_options([any()], client | server) -> {ok, #config{}};
                     ([any()], ssl_options()) -> ssl_options().
 
 handle_options(Opts, Role) ->
-    handle_options(Opts, Role, undefined).   
+    handle_options(undefined, undefined, Opts, Role, undefined).   
 
+handle_options(Opts, Role, InheritedSslOpts) ->
+    handle_options(undefined, undefined, Opts, Role, InheritedSslOpts).   
 
 %% Handle ssl options at handshake, handshake_continue
-handle_options(Opts0, Role, InheritedSslOpts) when is_map(InheritedSslOpts) ->
+handle_options(_, _, Opts0, Role, InheritedSslOpts) when is_map(InheritedSslOpts) ->
     {SslOpts, _} = expand_options(Opts0, ?RULES),
     process_options(SslOpts, InheritedSslOpts, #{role => Role,
                                                  rules => ?RULES});
 %% Handle all options in listen, connect and handshake
-handle_options(Opts0, Role, Host) ->
-    {SslOpts0, SockOpts} = expand_options(Opts0, ?RULES),
-
+handle_options(Transport, Socket, Opts0, Role, Host) ->
+    {SslOpts0, SockOpts0} = expand_options(Opts0, ?RULES),
+    
     %% Ensure all options are evaluated at startup
     SslOpts1 = add_missing_options(SslOpts0, ?RULES),
     SslOpts = #{protocol := Protocol}
@@ -1605,7 +1601,7 @@ handle_options(Opts0, Role, Host) ->
                             rules => ?RULES}),
     
     %% Handle special options
-    {Sock, Emulated} = emulated_options(Protocol, SockOpts),
+    {Sock, Emulated} = emulated_options(Transport, Socket, Protocol, SockOpts0),
     ConnetionCb = connection_cb(Protocol),
     CbInfo = handle_option_cb_info(Opts0, Protocol),
 
@@ -2033,8 +2029,9 @@ expand_options(Opts0, Rules) ->
                                 cb_info,
                                 client_preferred_next_protocols,  %% next_protocol_selector
                                 log_alert]),                      %% obsoleted by log_level
-
-    SslOpts = {Opts -- SockOpts, [], length(Opts -- SockOpts)},
+    
+    SslOpts0 = Opts -- SockOpts,
+    SslOpts = {SslOpts0, [], length(SslOpts0)},
     {SslOpts, SockOpts}.
 
 
@@ -2619,13 +2616,18 @@ ca_cert_default(verify_peer, {Fun,_}, _) when is_function(Fun) ->
 %% some trusted certs.
 ca_cert_default(verify_peer, undefined, _) ->
     "".
-emulated_options(Protocol, Opts) ->
+emulated_options(undefined, undefined, Protocol, Opts) ->
     case Protocol of
 	tls ->
 	    tls_socket:emulated_options(Opts);
 	dtls ->
 	    dtls_socket:emulated_options(Opts)
-    end.
+    end;
+emulated_options(Transport, Socket, Protocol, Opts) ->
+    EmulatedOptions = tls_socket:emulated_options(),
+    {ok, Original} = tls_socket:getopts(Transport, Socket, EmulatedOptions),
+    {Inet, Emulated0} = emulated_options(undefined, undefined, Protocol, Opts),
+    {Inet, lists:ukeymerge(1, Emulated0, Original)}.
 
 handle_cipher_option(Value, Versions)  when is_list(Value) ->       
     try binary_cipher_suites(Versions, Value) of

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2798,7 +2798,7 @@ binary_filename(FileName) ->
 %% Assert that basic options are on the format {Key, Value}
 %% with a few exceptions and phase out log_alert 
 handle_option_format([], Acc) ->
-    Acc;
+    lists:reverse(Acc);
 handle_option_format([{log_alert, Bool} | Rest], Acc) when is_boolean(Bool) ->
     case proplists:get_value(log_level, Acc ++ Rest, undefined) of
         undefined -> 

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -39,6 +39,8 @@
 %% Test cases
 -export([tls_upgrade/0,
          tls_upgrade/1,
+         tls_upgrade_new_opts/0,
+         tls_upgrade_new_opts/1,         
          tls_upgrade_with_timeout/0,
          tls_upgrade_with_timeout/1,
          tls_downgrade/0,
@@ -83,6 +85,7 @@
 
 %% Apply export
 -export([upgrade_result/1,
+         upgrade_result_new_opts/1,
          tls_downgrade_result/2,
          tls_shutdown_result/2,
          tls_shutdown_write_result/2,
@@ -117,6 +120,7 @@ groups() ->
 api_tests() ->
     [
      tls_upgrade,
+     tls_upgrade_new_opts,
      tls_upgrade_with_timeout,
      tls_downgrade,
      tls_shutdown,
@@ -199,6 +203,44 @@ tls_upgrade(Config) when is_list(Config) ->
     
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
+
+%%--------------------------------------------------------------------
+tls_upgrade_new_opts() ->
+    [{doc,"Test that you can upgrade an tcp connection to an ssl connection and give new socket opts"}].
+
+tls_upgrade_new_opts(Config) when is_list(Config) ->
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    TcpOpts = [binary, {reuseaddr, true}],
+
+    Server = ssl_test_lib:start_upgrade_server([{node, ServerNode}, {port, 0}, 
+						{from, self()}, 
+						{mfa, {?MODULE, 
+						       upgrade_result_new_opts, []}},
+						{tcp_options, 
+						 [{active, false} | TcpOpts]},
+						{ssl_options, [{verify, verify_peer},
+                                                               {mode, list} | ServerOpts]}]),
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_upgrade_client([{node, ClientNode}, 
+						{port, Port}, 
+				   {host, Hostname},
+				   {from, self()}, 
+				   {mfa, {?MODULE, upgrade_result_new_opts, []}},
+				   {tcp_options, [binary]},
+				   {ssl_options,  [{verify, verify_peer},
+                                                   {mode, list},
+                                                   {server_name_indication, Hostname} | ClientOpts]}]),
+    
+    ct:log("Testcase ~p, Client ~p  Server ~p ~n",
+		       [self(), Client, Server]),
+    
+    ssl_test_lib:check_result(Server, ok, Client, ok),
+    
+    ssl_test_lib:close(Server),
+    ssl_test_lib:close(Client).
+
 %%--------------------------------------------------------------------
 tls_upgrade_with_timeout() ->
     [{doc,"Test ssl_accept/3"}].
@@ -815,6 +857,14 @@ upgrade_result(Socket) ->
     %% Make sure binary is inherited from tcp socket and that we do
     %% not get the list default!
     <<"Hello world">> =  ssl_test_lib:active_recv(Socket, length("Hello world")),
+    ok.
+
+upgrade_result_new_opts(Socket) ->
+    ssl:setopts(Socket, [{active, true}]),
+    ok = ssl:send(Socket, "Hello world"),
+    %% Make sure list option set in ssl:connect/handskae overrides 
+    %% previous gen_tcp socket option that was set to binary.
+    "Hello world" =  ssl_test_lib:active_recv(Socket, length("Hello world")),
     ok.
 
 tls_downgrade_result(Socket, Pid) ->


### PR DESCRIPTION
This is resolves the async calling of `httpc:request/4` deadlock bug described in https://github.com/erlang/otp/issues/4329 (was https://bugs.erlang.org/browse/ERL-1321)

Unit tests pass locally for me as much as they usually do for `maint`; `https_sim` seems to flip flop on `stream_no_length` and `stream_large_not_200_or_206` and the IPv6 ones skip for some reason claiming I do not have host support for IPv6.