### PR TITLE
Add missing line feed in crash dump

### DIFF
--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -595,7 +595,7 @@ do_break(void)
 		   */
 	    erts_exit(0, "");
 	case 'A':		/* Halt generating crash dump */
-	    erts_exit(ERTS_ERROR_EXIT, "Crash dump requested by user");
+	    erts_exit(ERTS_ERROR_EXIT, "Crash dump requested by user\n");
 	case 'c':
 	    return;
 	case 'p':


### PR DESCRIPTION
When a crash dump is triggered by user request, there is a line feed missing between the "Slogan" and "System version" entries.

Before:

```
=erl_crash_dump:0.5
Tue Sep 22 11:40:11 2020
Slogan: Crash dump requested by userSystem version: Erlang/OTP 23 [erts-11.0.4] [source-b615489276] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]
Compiled: Tue Sep 22 10:33:17 2020
```

After:

```
=erl_crash_dump:0.5
Tue Sep 22 12:04:34 2020
Slogan: Crash dump requested by user
System version: Erlang/OTP 23 [erts-11.0.4] [source-51451ea635] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]
Compiled: Tue Sep 22 10:33:17 2020
```

To reproduce:

```
Eshell V11.0.4  (abort with ^G)
1>
BREAK: (a)bort (A)bort with dump (c)ontinue (p)roc info (i)nfo
       (l)oaded (v)ersion (k)ill (D)b-tables (d)istribution
A
Crash dump requested by user
Crash dump is being written to: erl_crash.dump...done
```