### PR TITLE
jit: Allocate code within 2GB of the emulator when possible

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -2997,6 +2997,29 @@ EOF
    fi
 fi
 
+AC_ARG_WITH(jit-reserved-code-size,
+AS_HELP_STRING([--with-jit-reserved-code-size=SIZE],
+               [reserved size for jitted code in MiB (default is 512)]))
+
+case "$with_jit_reserved_code_size" in
+    '')
+      case "$ARCH-$OPSYS" in
+        amd64-linux|amd64-darwin*|amd64-freebsd|amd64-sol2)
+          with_jit_reserved_code_size=512;;
+        *)
+          with_jit_reserved_code_size=0;;
+      esac
+      ;;
+    *)
+      ;;
+esac
+
+if test "X$with_jit_reserved_code_size" != "X0"; then
+  AC_DEFINE_UNQUOTED(ERTS_JIT_RESERVED_CODE_SIZE,
+                    $with_jit_reserved_code_size,
+                    [Reserved size for jitted code (in megabytes)])
+fi
+
 if test "$cross_compiling" != "yes" && test X${enable_hipe} != Xno; then
   if test -z "$M4"; then
     enable_hipe=no

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3003,7 +3003,7 @@ AS_HELP_STRING([--with-jit-reserved-code-size=SIZE],
 
 if test "X$with_jit_reserved_code_size" = "X"; then
   case "$OPSYS" in
-    win32)
+    win32|darwin)
       with_jit_reserved_code_size=0;;
     *)
       with_jit_reserved_code_size=512;;

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3001,23 +3001,20 @@ AC_ARG_WITH(jit-reserved-code-size,
 AS_HELP_STRING([--with-jit-reserved-code-size=SIZE],
                [reserved size for jitted code in MiB (default is 512)]))
 
-case "$with_jit_reserved_code_size" in
-    '')
-      case "$ARCH-$OPSYS" in
-        amd64-linux|amd64-darwin*|amd64-freebsd|amd64-sol2)
-          with_jit_reserved_code_size=512;;
-        *)
-          with_jit_reserved_code_size=0;;
-      esac
-      ;;
+if test "X$with_jit_reserved_code_size" = "X"; then
+  case "$OPSYS" in
+    win32)
+      with_jit_reserved_code_size=0;;
     *)
-      ;;
-esac
+      with_jit_reserved_code_size=512;;
+  esac
+fi
 
-if test "X$with_jit_reserved_code_size" != "X0"; then
+if test "X$enable_jit" = "Xyes" &&
+   test "X$with_jit_reserved_code_size" != "X0"; then
   AC_DEFINE_UNQUOTED(ERTS_JIT_RESERVED_CODE_SIZE,
-                    $with_jit_reserved_code_size,
-                    [Reserved size for jitted code (in megabytes)])
+                     $with_jit_reserved_code_size,
+                     [Reserved size for jitted code (in megabytes)])
 fi
 
 if test "$cross_compiling" != "yes" && test X${enable_hipe} != Xno; then

--- a/erts/emulator/sys/common/erl_mmap.c
+++ b/erts/emulator/sys/common/erl_mmap.c
@@ -380,6 +380,9 @@ char* erts_literals_start;
 UWord erts_literals_size;
 #endif
 
+#if defined(ERTS_ALC_A_EXEC)
+ErtsMemMapper erts_exec_mmapper;
+#endif
 
 #define ERTS_MMAP_SIZE_SC_SA_INC(SZ) 						\
     do {									\

--- a/erts/emulator/sys/common/erl_mmap.h
+++ b/erts/emulator/sys/common/erl_mmap.h
@@ -163,6 +163,10 @@ extern ErtsMemMapper erts_literal_mmapper;
 # endif /* ERTS_HAVE_OS_PHYSICAL_MEMORY_RESERVATION */
 #endif /* ERTS_WANT_MEM_MAPPERS */
 
+#if defined(ERTS_ALC_A_EXEC)
+extern ErtsMemMapper erts_exec_mmapper;
+#endif
+
 /*#define HARD_DEBUG_MSEG*/
 #ifdef HARD_DEBUG_MSEG
 #  define HARD_DBG_INSERT_MSEG hard_dbg_insert_mseg


### PR DESCRIPTION
This lets us make relative jumps and calls into the emulator, fixing a performance issue [mentioned in the JIT PR](https://github.com/erlang/otp/pull/2745#issuecomment-693696619).

@dominicletz