### PR TITLE
Use SSE/AVX to shrink code generated by the JIT

### DIFF
--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -432,12 +432,12 @@ protected:
 #endif
     }
 
-    constexpr x86::Mem getCARRef(x86::Gp Src) const {
-        return x86::qword_ptr(Src, -TAG_PRIMARY_LIST);
+    constexpr x86::Mem getCARRef(x86::Gp Src, size_t size = sizeof(UWord)) const {
+        return x86::Mem(Src, -TAG_PRIMARY_LIST, size);
     }
 
-    constexpr x86::Mem getCDRRef(x86::Gp Src) const {
-        return x86::qword_ptr(Src, -TAG_PRIMARY_LIST + sizeof(Eterm));
+    constexpr x86::Mem getCDRRef(x86::Gp Src, size_t size = sizeof(UWord)) const {
+        return x86::Mem(Src, -TAG_PRIMARY_LIST + sizeof(Eterm), size);
     }
 
     void load_x_reg_array(x86::Gp reg) {

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -1205,6 +1205,10 @@ private:
 
     void emit_is_binary(Label Fail, x86::Gp Src, Label next, Label subbin);
 
+    void emit_get_list(const x86::Gp boxed_ptr,
+                       const ArgVal &Hd,
+                       const ArgVal &Tl);
+
     void emit_div_rem(const ArgVal &Fail,
                       const ArgVal &LHS,
                       const ArgVal &RHS,

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -868,10 +868,10 @@ protected:
 #endif
     }
 
-    template<typename FieldType = UWord>
-    constexpr x86::Mem emit_boxed_val(x86::Gp Src, int32_t bytes = 0) const {
+    constexpr x86::Mem emit_boxed_val(x86::Gp Src, int32_t bytes = 0,
+                                      size_t size = sizeof(UWord)) const {
         ASSERT(bytes % sizeof(Eterm) == 0);
-        return x86::Mem(Src, bytes - TAG_PRIMARY_BOXED, sizeof(FieldType));
+        return x86::Mem(Src, bytes - TAG_PRIMARY_BOXED, size);
     }
 
     void emit_test_the_non_value(x86::Gp Reg) {

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -406,29 +406,29 @@ protected:
         return x86::Mem(registers, offset - x_reg_offset, size);
     }
 
-    constexpr x86::Mem getFRef(int index) const {
+    constexpr x86::Mem getFRef(int index, size_t size = sizeof(UWord)) const {
         int base = offsetof(ErtsSchedulerRegisters, f_reg_array.d);
         int offset = index * sizeof(FloatDef);
 
         ASSERT(index >= 0 && index <= 1023);
-        return getSchedulerRegRef(base + offset);
+        return getSchedulerRegRef(base + offset, size);
     }
 
-    constexpr x86::Mem getXRef(int index) const {
+    constexpr x86::Mem getXRef(int index, size_t size = sizeof(UWord)) const {
         int base = offsetof(ErtsSchedulerRegisters, x_reg_array.d);
         int offset = index * sizeof(Eterm);
 
         ASSERT(index >= 0 && index < ERTS_X_REGS_ALLOCATED);
-        return getSchedulerRegRef(base + offset);
+        return getSchedulerRegRef(base + offset, size);
     }
 
-    constexpr x86::Mem getYRef(int index) const {
+    constexpr x86::Mem getYRef(int index, size_t size = sizeof(UWord)) const {
         ASSERT(index >= 0 && index <= 1023);
 
 #ifdef NATIVE_ERLANG_STACK
-        return x86::qword_ptr(E, index * sizeof(Eterm));
+        return x86::Mem(E, index * sizeof(Eterm), size);
 #else
-        return x86::qword_ptr(E, (index + CP_SIZE) * sizeof(Eterm));
+        return x86::Mem(E, (index + CP_SIZE) * sizeof(Eterm), size);
 #endif
     }
 
@@ -656,14 +656,15 @@ protected:
         a.jmp(ARG6);
     }
 
-    constexpr x86::Mem getArgRef(const ArgVal &val) const {
+    constexpr x86::Mem getArgRef(const ArgVal &val,
+                                 size_t size = sizeof(UWord)) const {
         switch (val.getType()) {
         case ArgVal::TYPE::l:
-            return getFRef(val.getValue());
+            return getFRef(val.getValue(), size);
         case ArgVal::TYPE::x:
-            return getXRef(val.getValue());
+            return getXRef(val.getValue(), size);
         case ArgVal::TYPE::y:
-            return getYRef(val.getValue());
+            return getYRef(val.getValue(), size);
         default:
             ERTS_ASSERT(!"NYI");
             return x86::Mem();

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -120,6 +120,27 @@ public:
     ArgVal operator*(T val) const {
         return ArgVal(gen_op.type, val * gen_op.val);
     }
+
+    enum Relation {
+        none,
+        consecutive,
+        reverse_consecutive
+    };
+
+    static Relation register_relation(const ArgVal &arg1, const ArgVal &arg2) {
+        TYPE type = arg1.getType();
+        bool same_reg_types = type == arg2.getType() &&
+            (type == TYPE::x || type == TYPE::y);
+        if (!same_reg_types) {
+            return none;
+        } else if (arg1.getValue() + 1 == arg2.getValue()) {
+            return consecutive;
+        } else if (arg1.getValue() == arg2.getValue() + 1) {
+            return reverse_consecutive;
+        } else {
+            return none;
+        }
+    };
 };
 
 using namespace asmjit;

--- a/erts/emulator/beam/jit/instr_bs.cpp
+++ b/erts/emulator/beam/jit/instr_bs.cpp
@@ -724,7 +724,7 @@ void BeamModuleAssembler::emit_i_bs_start_match3(const ArgVal &Src,
     }
 
     x86::Gp boxed_ptr = emit_ptr_val(ARG1, ARG2);
-    a.mov(RETd, emit_boxed_val<Uint32>(boxed_ptr));
+    a.mov(RETd, emit_boxed_val(boxed_ptr, 0, sizeof(Uint32)));
 
     a.and_(RETb, imm(_HEADER_SUBTAG_MASK));
     a.cmp(RETb, imm(BIN_MATCHSTATE_SUBTAG));

--- a/erts/emulator/beam/jit/instr_common.cpp
+++ b/erts/emulator/beam/jit/instr_common.cpp
@@ -1033,7 +1033,9 @@ void BeamModuleAssembler::emit_set_tuple_element(const ArgVal &Element,
 
 void BeamModuleAssembler::emit_is_nonempty_list(const ArgVal &Fail,
                                                 const ArgVal &Src) {
-    a.test(getArgRef(Src), imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_LIST));
+    x86::Mem list_ptr = getArgRef(Src, 1);
+
+    a.test(list_ptr, imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_LIST));
     a.jne(labels[Fail.getValue()]);
 }
 

--- a/erts/emulator/beam/jit/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/instr_guard_bifs.cpp
@@ -193,7 +193,7 @@ void BeamModuleAssembler::emit_bif_element(const ArgVal &Fail,
         emit_is_boxed(error, ARG2, dShort);
 
         (void)emit_ptr_val(ARG2, ARG2);
-        a.mov(RETd, emit_boxed_val<Uint32>(ARG2));
+        a.mov(RETd, emit_boxed_val(ARG2, 0, sizeof(Uint32)));
         ERTS_CT_ASSERT(Support::isInt32(make_arityval(MAX_ARITYVAL)));
         a.cmp(RETd, imm(make_arityval((Uint)pos)));
         a.short_().jb(error);

--- a/erts/emulator/beam/jit/instr_select.cpp
+++ b/erts/emulator/beam/jit/instr_select.cpp
@@ -52,7 +52,7 @@ void BeamModuleAssembler::emit_i_select_tuple_arity(
     emit_is_boxed(labels[Fail.getValue()], ARG2);
     x86::Gp boxed_ptr = emit_ptr_val(ARG2, ARG2);
     ERTS_CT_ASSERT(Support::isInt32(make_arityval(MAX_ARITYVAL)));
-    a.mov(ARG2d, emit_boxed_val<Uint32>(boxed_ptr));
+    a.mov(ARG2d, emit_boxed_val(boxed_ptr, 0, sizeof(Uint32)));
     ERTS_CT_ASSERT(_TAG_HEADER_ARITYVAL == 0);
     a.test(ARG2.r8(), imm(_TAG_HEADER_MASK));
     a.jne(labels[Fail.getValue()]);

--- a/erts/emulator/beam/jit/ops.tab
+++ b/erts/emulator/beam/jit/ops.tab
@@ -306,16 +306,28 @@ system_limit_body
 # Optimize moves of consecutive memory addresses.
 #
 
-move S1=d D1=d | move S2=d D2=d | consecutive_words(S1, D1, S2, D2) => move_two_words S1 D1
-move_two_words s d
+move Src=c Dst => i_move Src Dst
+
+move Src SrcDst | move SrcDst Dst => i_move Src SrcDst | move SrcDst Dst
+
+# Try to move two words at once. Always arrange the source operands in
+# consecutive order; the destination operands may be in consecutive or
+# reverse consecutive order.
+
+move S1=d D1=d | move S2=d D2=d | consecutive_words(S1, D1, S2, D2) => move_two_words S1 D1 S2 D2
+move S1=d D1=d | move S2=d D2=d | consecutive_words(S1, D2, S2, D1) => move_two_words S1 D1 S2 D2
+move S1=d D1=d | move S2=d D2=d | consecutive_words(S2, D1, S1, D2) => move_two_words S2 D2 S1 D1
+move S1=d D1=d | move S2=d D2=d | consecutive_words(S2, D2, S1, D1) => move_two_words S2 D2 S1 D1
+
+move Src Dst => i_move Src Dst
 
 #
 # Move instructions.
 #
 
 swap d d
-move s d
-
+i_move s d
+move_two_words s d s d
 
 #
 # Receive operations. We conservatively align all labels before any

--- a/erts/emulator/beam/jit/ops.tab
+++ b/erts/emulator/beam/jit/ops.tab
@@ -265,7 +265,10 @@ load_tuple_ptr s
 # two words at once.
 i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple | \
    get_tuple_element Tuple Pos2 Dst2 | consecutive_words(Pos1, Dst1, Pos2, Dst2) => \
-      get_two_tuple_elements Tuple Pos1 Dst1 | current_tuple Tuple Dst2
+      get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
+i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple | \
+   get_tuple_element Tuple Pos2 Dst2 | consecutive_words(Pos1, Dst2, Pos2, Dst1) => \
+      get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
 
 # Drop the current_tuple instruction if the tuple is overwritten.
 current_tuple Tuple Tuple =>
@@ -275,7 +278,7 @@ current_tuple Tuple Dst => current_tuple Tuple
 # system to verify that the register holding the tuple pointer agrees
 # with the source tuple operand.
 i_get_tuple_element s P S
-get_two_tuple_elements s P S
+get_two_tuple_elements s P S S
 
 #
 # Expection rasing instructions. Infrequently executed.

--- a/erts/emulator/beam/jit/predicates.tab
+++ b/erts/emulator/beam/jit/predicates.tab
@@ -110,11 +110,6 @@ pred.is_ne_exact_bif(Bif) {
 }
 
 pred.consecutive_words(S1, D1, S2, D2) {
-    if (D1.type == S2.type && D1.val == S2.val) {
-	/* The moves must be performed sequentially. */
-	return 0;
-    }
-
     return S1.type == S2.type && S1.val + 1 == S2.val &&
 	D1.type == D2.type && D1.val + 1 == D2.val;
 }


### PR DESCRIPTION
When two words that are consecutive (or reverse consecutive), SSE and AVX can be used to move two words at once, shrinking the code size.