### PR TITLE
Fix performance degradation for many items in process dictionary

### DIFF
--- a/erts/emulator/beam/erl_process_dict.c
+++ b/erts/emulator/beam/erl_process_dict.c
@@ -1052,7 +1052,7 @@ static unsigned int next_array_size(unsigned int need)
 	1342177280UL,
 	2684354560UL
     };
-    int hi = sizeof(tab) / sizeof(Uint) - 1;
+    int hi = sizeof(tab) / sizeof(tab[0]) - 1;
     int lo = 1;
     int cur = 4;
 


### PR DESCRIPTION
Modern versions of Clang emit a warning that the array size calculation
in erl_process_dict.c is wrong. Only half of the array would be used.
That would lead to a performance degradation if many items were stored in
the process dictionary.