### PR TITLE
Undo perform degradation on macOS

### DIFF
--- a/erts/aclocal.m4
+++ b/erts/aclocal.m4
@@ -243,6 +243,7 @@ AC_TRY_COMPILE([],[
 #endif
     __label__ lbl1;
     __label__ lbl2;
+    extern int magic(void);
     int x = magic();
     static void *jtab[2];
 
@@ -288,6 +289,7 @@ if test "$ac_cv_prog_emu_cc" != no; then
 #endif
     	__label__ lbl1;
     	__label__ lbl2;
+	extern int magic(void);
     	int x = magic();
     	static void *jtab[2];
 


### PR DESCRIPTION
Apple Clang 12 included in Xcode 12 reports an error when a
function without a declaration is used. That change causes
the configure test for jump table support to wrongly assume
that jump table support is missing, and therefore a `switch`
would be used, degrading the performance of BEAM.