### PR TITLE
Eliminate warnings for undeclared functions in C code in test suites

### DIFF
--- a/erts/emulator/test/driver_SUITE_data/peek_non_existing_queue_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/peek_non_existing_queue_drv.c
@@ -47,6 +47,10 @@
 #include <windows.h>
 #endif
 
+#ifdef HAVE_UNISTD_H
+#   include <unistd.h>
+#endif
+
 #include <errno.h>
 
 #include "erl_driver.h"

--- a/erts/emulator/test/driver_SUITE_data/thr_msg_blast_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/thr_msg_blast_drv.c
@@ -18,6 +18,10 @@
  * %CopyrightEnd%
  */
 
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
 #include "erl_driver.h"
 
 #define THR_MSG_BLAST_NO_PROCS 10

--- a/erts/emulator/test/estone_SUITE_data/estone_cat.c
+++ b/erts/emulator/test/estone_SUITE_data/estone_cat.c
@@ -12,9 +12,11 @@
 #include <fcntl.h>
 #include <errno.h>
 
-main(argc, argv)
-int argc;
-char *argv[];
+#ifdef HAVE_UNISTD_H
+#   include <unistd.h>
+#endif
+
+int main(int argc, char* argv[])
 {
     char buf[16384];
     int n;

--- a/erts/emulator/test/mtx_SUITE_data/mtx_SUITE.c
+++ b/erts/emulator/test/mtx_SUITE_data/mtx_SUITE.c
@@ -39,6 +39,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
 
 static int
 fail(const char *file, int line, const char *function, const char *assertion);

--- a/erts/emulator/test/port_bif_SUITE_data/port_test.c
+++ b/erts/emulator/test/port_bif_SUITE_data/port_test.c
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <ctype.h>
 
 #ifndef __WIN32__
 #include <unistd.h>
@@ -32,7 +33,7 @@
     exit(1); \
 }
 
-#define MAIN(argc, argv) main(argc, argv)
+#define MAIN(argc, argv) int main(argc, argv)
 
 extern int errno;
 

--- a/erts/emulator/test/trace_SUITE_data/slow_drv.c
+++ b/erts/emulator/test/trace_SUITE_data/slow_drv.c
@@ -3,6 +3,12 @@
 #endif
 
 #include <stdio.h>
+#include <string.h>
+
+#ifdef HAVE_UNISTD_H
+#   include <unistd.h>
+#endif
+
 #include "erl_driver.h"
 
 typedef struct _erl_drv_data {

--- a/lib/erl_interface/test/all_SUITE_data/ei_runner.c
+++ b/lib/erl_interface/test/all_SUITE_data/ei_runner.c
@@ -18,11 +18,13 @@
  * %CopyrightEnd%
  */
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <ctype.h>
 #ifndef __WIN32__
 #include <unistd.h>
 #endif

--- a/lib/erl_interface/test/ei_connect_SUITE_data/einode.c
+++ b/lib/erl_interface/test/ei_connect_SUITE_data/einode.c
@@ -21,6 +21,7 @@
 /* to test multiple threads in ei */
 
 #include <stdlib.h>
+#include <string.h>
 #include <stdio.h>
 
 #ifdef __WIN32__
@@ -30,11 +31,10 @@
 #else
 #include <pthread.h>
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 
 #include "ei.h"
-
-#define MAIN main
 
 /*
    A small einode.
@@ -95,7 +95,7 @@ static void*
     return 0;
 }
 
-MAIN(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
     int i, n, no_threads;
 #ifdef __WIN32__

--- a/lib/erl_interface/test/ei_format_SUITE_data/ei_format_test.c
+++ b/lib/erl_interface/test/ei_format_SUITE_data/ei_format_test.c
@@ -18,6 +18,7 @@
  * %CopyrightEnd%
  */
 
+#include <stdlib.h>
 #include "ei_runner.h"
 #include <string.h>
 

--- a/lib/erl_interface/test/ei_tmo_SUITE_data/ei_tmo_test.c
+++ b/lib/erl_interface/test/ei_tmo_SUITE_data/ei_tmo_test.c
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <unistd.h>
 #endif
 
 #include "ei_runner.h"

--- a/lib/inets/test/httpd_SUITE_data/cgi_echo.c
+++ b/lib/inets/test/httpd_SUITE_data/cgi_echo.c
@@ -4,6 +4,8 @@
 #if defined __WIN32__
 #include <windows.h> 
 #include <fcntl.h>
+#else
+#include <unistd.h>
 #endif
 
 static int read_exact(char *buffer, int len);

--- a/lib/kernel/test/os_SUITE_data/my_fds.c
+++ b/lib/kernel/test/os_SUITE_data/my_fds.c
@@ -1,5 +1,9 @@
 #include <stdio.h>
 
+#ifdef HAVE_UNISTD_H
+#   include <unistd.h>
+#endif
+
 int
 main(int argc, char** argv)
 {


### PR DESCRIPTION
Apple Clang 12 in Xcode 12 reports an error for the use of a function without a declaration. This pull request updates C code in test suites to ensure that all functions are declared.
