### PR TITLE
Fixes ERL-1335

### DIFF
--- a/lib/common_test/src/ct_run.erl
+++ b/lib/common_test/src/ct_run.erl
@@ -1148,7 +1148,8 @@ run_all_specs([], _, _, TotResult) ->
 				    {Ok1,Fail1,{UserSkip1,AutoSkip1}}) ->
 					{Ok1+Ok,Fail1+Fail,
 					 {UserSkip1+UserSkip,
-					  AutoSkip1+AutoSkip}}
+					  AutoSkip1+AutoSkip}};
+				(Pid, Acc) when is_pid(Pid) -> Acc
 				end, {0,0,{0,0}}, TotResult1)
 	    end
     end;


### PR DESCRIPTION
* When using `release_shell` option, the return is a pid, instead of the usual test return.
* For those cases, just skip that entry and continue result accumulation as usual

As requested in https://bugs.erlang.org/browse/ERL-1335