### PR TITLE
Handle paths with spaces

### DIFF
--- a/erts/etc/win32/wsl_tools/w32_path.sh
+++ b/erts/etc/win32/wsl_tools/w32_path.sh
@@ -100,8 +100,8 @@ else
         esac
         exit 0
     else
-        dir=`dirname $1`
-        file=`basename $1`
+        dir=`dirname "$1"`
+        file=`basename "$1"`
 
         case "$SEPARATOR" in
 	    slash)


### PR DESCRIPTION
Add missing quotes.

Caused redist files to not be included in the win32 installers.