### PR TITLE
Fix configuration procedure log

### DIFF
--- a/configure.src
+++ b/configure.src
@@ -323,7 +323,9 @@ for app_dir in make $check_conf_dirs erts; do
        rm -f $app_dir/configure.result.command
        rm -f $app_dir/configure.result.stdout
        rm -f $app_dir/configure.result.stderr
-       app_dirs="$app_dirs $app_dir"
+       if ! echo "$skip_applications" | grep $(basename $app_dir) > /dev/null 2> /dev/null; then
+           app_dirs="$app_dirs $app_dir"
+       fi
     fi
 done
 

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -985,8 +985,7 @@ case $host_os in
 		LDFLAGS=-Wl,-export-dynamic
 		AC_TRY_LINK(,,[DEXPORT=-Wl,-export-dynamic], [
 			LDFLAGS=-Wl,-Bexport
-			AC_TRY_LINK(,,[DEXPORT=-Wl,-Bexport],
-				AC_MSG_RESULT(none))])
+			AC_TRY_LINK(,,[DEXPORT=-Wl,-Bexport],)])
 		LDFLAGS="$save_ldflags"
 	;;
 esac

--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1348,7 +1348,6 @@ error
 ])
 
 if test "$Z_LIB" != ""; then
-  AC_MSG_CHECKING(for zlib inflateGetDictionary presence)
   AC_SEARCH_LIBS(inflateGetDictionary, [z],
                  AC_DEFINE(HAVE_ZLIB_INFLATEGETDICTIONARY, 1,
                            [Define if your zlib version defines inflateGetDictionary.]))

--- a/lib/crypto/configure.in
+++ b/lib/crypto/configure.in
@@ -211,9 +211,7 @@ case "$erl_xcomp_without_sysroot-$with_ssl" in
     SSL_APP=
     CRYPTO_APP=
     SSH_APP=
-    if test "$with_ssl" = "no"; then
-	skip="User gave --without-ssl option"
-    else
+    if test "$with_ssl" != "no"; then
 	skip="Cannot search for ssl; missing cross system root (erl_xcomp_sysroot)."
     fi
     for a in ssl crypto ssh; do

--- a/lib/odbc/configure.in
+++ b/lib/odbc/configure.in
@@ -46,7 +46,6 @@ AC_ARG_WITH(odbc,
 if test "$with_odbc" = "no"; then
 
    rm -f "$ERL_TOP/lib/odbc/SKIP"
-   echo "odbc disabled by user." > "$ERL_TOP/lib/odbc/SKIP"
 
 else dnl "$with_odbc" != "no"
 

--- a/lib/wx/configure.in
+++ b/lib/wx/configure.in
@@ -335,9 +335,15 @@ elif test  X"$MIXED_VC" = X"no"; then
     # Try to find debug libs first 
     # wxelibs=core,base,gl,aui,adv
 
-    AC_MSG_CHECKING(for debug build of wxWidgets)
-
     AM_PATH_WXCONFIG($reqwx, wxWinWithGLDBG=1, wxWinWithGLDBG=0, [stc,xrc,html,adv,xml,core,base,gl,aui], [--unicode --debug=yes])
+
+    AC_MSG_CHECKING(for debug build of wxWidgets)
+    if test "$wxWinWithGLDBG" = 1; then
+      AC_MSG_RESULT(yes);
+    else
+      AC_MSG_RESULT(no);
+    fi
+
     DEBUG_WX_CFLAGS=$WX_CFLAGS
     DEBUG_WX_CXXFLAGS=$WX_CXXFLAGS
     DEBUG_WX_LIBS=$WX_LIBS
@@ -347,8 +353,14 @@ elif test  X"$MIXED_VC" = X"no"; then
     AC_SUBST(DEBUG_WX_LIBS)
     AC_SUBST(DEBUG_WX_LIBS_STATIC)
     
-    AC_MSG_CHECKING(for standard build of wxWidgets)
     AM_PATH_WXCONFIG($reqwx, wxWinWithGL=1, wxWinWithGL=0, [stc,xrc,html,adv,xml,core,base,gl,aui], [--unicode --debug=no])
+
+    AC_MSG_CHECKING(for standard build of wxWidgets)
+    if test "$wxWinWithGL" = 1; then
+      AC_MSG_RESULT(yes);
+    else
+      AC_MSG_RESULT(no);
+    fi
 
     if test "x$WX_LIBS_STATIC" = "x"; then
        WX_HAVE_STATIC_LIBS=false


### PR DESCRIPTION
As discussed in [ERL-1173](https://bugs.erlang.org/browse/ERL-1173).

I'm sure I skipped some duplicates but don't have a consistent way to figure out which ones, so this is on a trial-and-error basis.

---

I did try to skip, for example, the whole `wx` configuration step, but am unable to obtain `--without-wx`. My trial meant I'd skip the whole file since if you don't want `wx` there's no need to configure it (this is my very limited world view of the configuration process, though). Is this a valid approach?