### PR TITLE
Implement binary:linear_compare/2

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3496,6 +3496,19 @@ if test "$enable_lttng_test" = "yes" ; then
 fi
 
 
+AC_MSG_CHECKING(if weak symbols are supported)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#if !defined(__ELF__) && !defined(__APPLE_CC__)
+# error Support for weak symbols may not be available
+#endif
+__attribute__((weak)) void __dummy(void *x) { }
+void f(void *x) { __dummy(x); }
+]], [[ ]]
+)],
+[AC_MSG_RESULT(yes)
+ AC_DEFINE([HAVE_WEAK_SYMBOLS], [1], [weak symbols are supported])],
+[AC_MSG_RESULT(no)])
+
 #--------------------------------------------------------------------
 # Os mon stuff.
 #--------------------------------------------------------------------

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -773,3 +773,4 @@ bif erts_internal:get_creation/0
 bif erts_internal:prepare_loading/2
 bif erts_internal:beamfile_chunk/2
 bif erts_internal:beamfile_module_md5/1
+bif binary:secure_compare/2

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -773,4 +773,4 @@ bif erts_internal:get_creation/0
 bif erts_internal:prepare_loading/2
 bif erts_internal:beamfile_chunk/2
 bif erts_internal:beamfile_module_md5/1
-bif binary:secure_compare/2
+bif binary:linear_compare/2

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -2513,7 +2513,7 @@ static BIF_RETTYPE binary_linear_compare(Process *p, Eterm bin1, Eterm bin2)
         x |= b1[i] ^ b2[i];
     }
 
-    if (x == 0U)
+    if ((1 & ((x - 1) >> 8)) - 1 == 0)
         goto match;
 
     goto nomatch;

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -2484,11 +2484,11 @@ static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2)
         if (i <= (size1 - 1) && i <= (size2 - 1))
             acc |= bytes1[i] ^ bytes2[i];
 
-        if ((i > (size1 - 1) && i <= (size2 - 1)))
-            acc |= bytes1[size1 - i] ^ bytes2[i];
-
         if ((i <= (size1 - 1) && i > (size2 - 1)))
             acc |= bytes1[i] ^ bytes2[size2 - 1];
+        
+        if ((i > (size1 - 1) && i <= (size2 - 1)))
+            acc |= bytes1[size1 - 1] ^ bytes2[i];
     }
 
     if (acc == 0)

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -2481,7 +2481,7 @@ static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2)
     max_size = size1 > size2 ? size1 : size2;
 
     for (i=0; i < max_size; i++) {
-        if (i <= (size1 - 1) && i <= (size2 - 1)) { 
+        if (i < size1 && i < size2) {
             acc |= bytes1[i] ^ bytes2[i];
         } else {
             acc |= 'a' ^ 'b';

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -2513,7 +2513,7 @@ static BIF_RETTYPE binary_linear_compare(Process *p, Eterm bin1, Eterm bin2)
         x |= b1[i] ^ b2[i];
     }
 
-    if ((1 & ((x - 1) >> 8)) - 1 == 0)
+    if (x == 0U)
         goto match;
 
     goto nomatch;

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -2481,11 +2481,14 @@ static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2)
     max_size = size1 > size2 ? size1 : size2;
 
     for (i=0; i < max_size; i++) {
-        if (i <= (size1 - 1) && i < (size2 - 1))
+        if (i <= (size1 - 1) && i <= (size2 - 1))
             acc |= bytes1[i] ^ bytes2[i];
 
-        if ((i > (size1 - 1) || i > (size2 - 1)) && acc == 0)
-            acc = 1;
+        if ((i > (size1 - 1) && i <= (size2 - 1)))
+            acc |= bytes1[size1 - i] ^ bytes2[i];
+
+        if ((i <= (size1 - 1) && i > (size2 - 1)))
+            acc |= bytes1[i] ^ bytes2[size2 - 1];
     }
 
     if (acc == 0)

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -2467,8 +2467,10 @@ static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2)
     Uint bitoffs2, bitsize2;
     Uint size1, size2, max_size;
     size_t i;
-    volatile unsigned char acc = 0;
-  
+    volatile unsigned char acc = 0; 
+    const volatile char A = 'a';
+    const volatile char B = 'b';
+
     if (is_not_binary(bin1) || is_not_binary(bin2))
         goto bad_arg;
     
@@ -2479,12 +2481,12 @@ static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2)
     size2 = binary_size(bin2);
 
     max_size = size1 > size2 ? size1 : size2;
-
+   
     for (i=0; i < max_size; i++) {
         if (i < size1 && i < size2) {
             acc |= bytes1[i] ^ bytes2[i];
         } else {
-            acc |= 'a' ^ 'b';
+            acc |= A ^ B;
         }
     }
 

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -2486,7 +2486,7 @@ static BIF_RETTYPE binary_linear_compare(Process *p, Eterm bin1, Eterm bin2)
     const volatile unsigned char *volatile b2 =
         (const volatile unsigned char *volatile) bytes2;
 
-    for (i=0; i < size; i++) {
+    for (i=0U; i < size; i++) {
         x |= b1[i] ^ b2[i];
     }
 

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -2481,14 +2481,11 @@ static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2)
     max_size = size1 > size2 ? size1 : size2;
 
     for (i=0; i < max_size; i++) {
-        if (i <= (size1 - 1) && i <= (size2 - 1))
+        if (i <= (size1 - 1) && i <= (size2 - 1)) { 
             acc |= bytes1[i] ^ bytes2[i];
-
-        if ((i <= (size1 - 1) && i > (size2 - 1)))
-            acc |= bytes1[i] ^ bytes2[size2 - 1];
-        
-        if ((i > (size1 - 1) && i <= (size2 - 1)))
-            acc |= bytes1[size1 - 1] ^ bytes2[i];
+        } else {
+            acc |= 'a' ^ 'b';
+        }
     }
 
     if (acc == 0)

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -70,6 +70,8 @@ binary_match(Process *p, Eterm arg1, Eterm arg2, Eterm arg3, Uint flags);
 static BIF_RETTYPE
 binary_split(Process *p, Eterm arg1, Eterm arg2, Eterm arg3);
 
+static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2);
+
 void erts_init_bif_binary(void)
 {
     erts_init_trap_export(&binary_find_trap_export,
@@ -2455,6 +2457,53 @@ static int cleanup_copy_bin_state(Binary *bp)
     }
     cbs->source_type =  BC_TYPE_EMPTY;
     return 1;
+}
+
+static BIF_RETTYPE binary_secure_compare(Process *p, Eterm bin1, Eterm bin2)
+{
+    byte *bytes1;
+    byte *bytes2;
+    Uint bitoffs1, bitsize1;
+    Uint bitoffs2, bitsize2;
+    Uint size1, size2, max_size;
+    size_t i;
+    volatile unsigned char acc = 0;
+  
+    if (is_not_binary(bin1) || is_not_binary(bin2))
+        goto bad_arg;
+    
+    ERTS_GET_BINARY_BYTES(bin1, bytes1, bitoffs1, bitsize1); 
+    ERTS_GET_BINARY_BYTES(bin2, bytes2, bitoffs2, bitsize2);
+
+    size1 = binary_size(bin1);
+    size2 = binary_size(bin2);
+
+    max_size = size1 > size2 ? size1 : size2;
+
+    for (i=0; i < max_size; i++) {
+        if (i <= (size1 - 1) && i < (size2 - 1))
+            acc |= bytes1[i] ^ bytes2[i];
+
+        if ((i > (size1 - 1) || i > (size2 - 1)) && acc == 0)
+            acc = 1;
+    }
+
+    if (acc == 0)
+        goto match;
+
+    goto nomatch;
+
+ match:
+    BIF_RET(am_true);
+ nomatch:
+    BIF_RET(am_false);
+ bad_arg:
+    BIF_ERROR(p,BADARG);
+}
+
+BIF_RETTYPE binary_secure_compare_2(BIF_ALIST_2)
+{
+    return binary_secure_compare(BIF_P, BIF_ARG_1, BIF_ARG_2);
 }
 
 /*

--- a/lib/stdlib/doc/src/binary.xml
+++ b/lib/stdlib/doc/src/binary.xml
@@ -576,12 +576,11 @@ store(Binary, GBSet) ->
     </func>
 
     <func>
-      <name name="secure_compare" arity="2" since="OTP R24"/>
-      <fsummary>Compares two binaries in constant time.</fsummary>
+      <name name="linear_compare" arity="2" since="OTP R24"/>
+      <fsummary>Compares two binaries in linear time.</fsummary>
       <desc>
-          <p>Given two binaries this function will iterate and compare each byte of both binaries in constant time 
-              in order to mitigate timing attacks. The size of the largest binary is used as the upper bounds 
-              (i.e., how many iterations will occur).</p>
+          <p>Given two binaries of equal size this function will compare each byte in linear time.
+              This function will raise a badargument error if both binaries are not of equal size.</p>
           <p>Returns true if both binaries match exactly, otherwise returns false.</p>
       </desc>
     </func>

--- a/lib/stdlib/doc/src/binary.xml
+++ b/lib/stdlib/doc/src/binary.xml
@@ -580,7 +580,7 @@ store(Binary, GBSet) ->
       <fsummary>Compares two binaries in linear time.</fsummary>
       <desc>
           <p>Given two binaries of equal size this function will compare each byte in linear time.
-              This function will raise a badargument error if both binaries are not of equal size.</p>
+              This function will raise a badarg error if both binaries are not of equal size.</p>
           <p>Returns true if both binaries match exactly, otherwise returns false.</p>
       </desc>
     </func>

--- a/lib/stdlib/doc/src/binary.xml
+++ b/lib/stdlib/doc/src/binary.xml
@@ -579,8 +579,12 @@ store(Binary, GBSet) ->
       <name name="linear_compare" arity="2" since="OTP R24"/>
       <fsummary>Compares two binaries in linear time.</fsummary>
       <desc>
-          <p>Given two binaries of equal size this function will compare each byte in linear time.
-              This function will raise a badarg error if both binaries are not of equal size.</p>
+          <p>Given two binaries of equal size this function will compare each byte of both binaries 
+              in linear time. The time this function takes to complete will always be proportional to the 
+              size of the data given, regardless of the differences between the two arguments.</p>
+
+          <p>This function will raise a badarg error if both binaries are not of equal size.</p>
+          
           <p>Returns true if both binaries match exactly, otherwise returns false.</p>
       </desc>
     </func>

--- a/lib/stdlib/doc/src/binary.xml
+++ b/lib/stdlib/doc/src/binary.xml
@@ -576,6 +576,17 @@ store(Binary, GBSet) ->
     </func>
 
     <func>
+      <name name="secure_compare" arity="2" since="OTP R24"/>
+      <fsummary>Compares two binaries in constant time.</fsummary>
+      <desc>
+          <p>Given two binaries this function will iterate and compare each byte of both binaries in constant time 
+              in order to mitigate timing attacks. The size of the largest binary is used as the upper bounds 
+              (i.e., how many iterations will occur).</p>
+          <p>Returns true if both binaries match exactly, otherwise returns false.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="split" arity="2" since="OTP R14B"/>
       <fsummary>Split a binary according to a pattern.</fsummary>
       <desc>

--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -35,7 +35,10 @@
          first/1, last/1, list_to_bin/1, longest_common_prefix/1,
          longest_common_suffix/1, match/2, match/3, matches/2,
          matches/3, part/2, part/3, referenced_byte_size/1,
-         split/2, split/3]).
+         split/2, split/3, secure_compare/2]).
+
+secure_compare(_, _) ->
+    erlang:nif_error(undef).
 
 -spec at(Subject, Pos) -> byte() when
       Subject :: binary(),

--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -35,14 +35,14 @@
          first/1, last/1, list_to_bin/1, longest_common_prefix/1,
          longest_common_suffix/1, match/2, match/3, matches/2,
          matches/3, part/2, part/3, referenced_byte_size/1,
-         split/2, split/3, secure_compare/2]).
+         split/2, split/3, linear_compare/2]).
 
 
--spec secure_compare(Bin1, Bin2) -> boolean() when 
+-spec linear_compare(Bin1, Bin2) -> boolean() when 
       Bin1 :: binary(),
       Bin2 :: binary().
 
-secure_compare(_, _) ->
+linear_compare(_, _) ->
     erlang:nif_error(undef).
 
 -spec at(Subject, Pos) -> byte() when

--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -37,6 +37,11 @@
          matches/3, part/2, part/3, referenced_byte_size/1,
          split/2, split/3, secure_compare/2]).
 
+
+-spec secure_compare(Bin1, Bin2) -> boolean() when 
+      Bin1 :: binary(),
+      Bin2 :: binary().
+
 secure_compare(_, _) ->
     erlang:nif_error(undef).
 

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -1385,6 +1385,9 @@ secure_compare(Config) when is_list(Config) ->
     false = binary:secure_compare(<<"eh?">>, <<"Hello Joe">>),
     false = binary:secure_compare(<<"one">>, <<"two">>),
     false = binary:secure_compare(<<"two">>, <<"one">>),
+    false = binary:secure_compare(<<"xtest">>, <<"xtestx">>),
+    false = binary:secure_compare(<<"xtestxx">>, <<"xtestx">>),
+    false = binary:secure_compare(<<"xtestxx">>, <<"xtestxxx">>),
     ok.
 
 secure_compare_time(Config) when is_list(Config) -> 

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -27,7 +27,7 @@
 
 -export([random_number/1, make_unaligned/1]).
 
--export([secure_compare/1, secure_compare_time/1]).
+-export([linear_compare/1, linear_compare_time/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -40,7 +40,7 @@ all() ->
      random_ref_comp, parts, bin_to_list, list_to_bin, copy,
      referenced, guard, encode_decode, badargs,
      longest_common_trap, check_no_invalid_read_bug, 
-     secure_compare, secure_compare_time].
+     linear_compare, linear_compare_time].
 
 
 -define(MASK_ERROR(EXPR),mask_error((catch (EXPR)))).
@@ -1377,20 +1377,20 @@ check_no_invalid_read_bug(I) ->
     binary:encode_unsigned(N+N, little),
     check_no_invalid_read_bug(I+1).
 
-secure_compare(Config) when is_list(Config) ->
-    true  = binary:secure_compare(<<"">>, <<"">>),
-    true  = binary:secure_compare(<<"good">>, <<"good">>),
+linear_compare(Config) when is_list(Config) ->
+    true  = binary:linear_compare(<<"">>, <<"">>),
+    true  = binary:linear_compare(<<"good">>, <<"good">>),
 
-    false = binary:secure_compare(<<"good">>, <<"bad">>),
-    false = binary:secure_compare(<<"eh?">>, <<"Hello Joe">>),
-    false = binary:secure_compare(<<"one">>, <<"two">>),
-    false = binary:secure_compare(<<"two">>, <<"one">>),
-    false = binary:secure_compare(<<"xtest">>, <<"xtestx">>),
-    false = binary:secure_compare(<<"xtestxx">>, <<"xtestx">>),
-    false = binary:secure_compare(<<"xtestxx">>, <<"xtestxxx">>),
+    false = binary:linear_compare(<<"good">>, <<"bad">>),
+    false = binary:linear_compare(<<"eh?">>, <<"Hello Joe">>),
+    false = binary:linear_compare(<<"one">>, <<"two">>),
+    false = binary:linear_compare(<<"two">>, <<"one">>),
+    false = binary:linear_compare(<<"xtest">>, <<"xtestx">>),
+    false = binary:linear_compare(<<"xtestxx">>, <<"xtestx">>),
+    false = binary:linear_compare(<<"xtestxx">>, <<"xtestxxx">>),
     ok.
 
-secure_compare_time(Config) when is_list(Config) -> 
+linear_compare_time(Config) when is_list(Config) -> 
     A = <<"A">>,
     B = <<"B">>,
     
@@ -1403,12 +1403,12 @@ secure_compare_time(Config) when is_list(Config) ->
 
     T1 =  erlang:convert_time_unit(erlang:monotonic_time(), native, microsecond),
 
-    binary:secure_compare(Arg1, Arg2),   
+    binary:linear_compare(Arg1, Arg2),   
     
     T2 =  erlang:convert_time_unit(erlang:monotonic_time(), native, microsecond),
 
     %% Given a 10 megabyte binary we can say with a fair amount of certainty 
-    %% that to perform the secure_compare/2 operation will always take over 
+    %% that to perform the linear_compare/2 operation will always take over 
     %% 1ms, anything equal to or less means we returned early per the differnce
     %% on the first byte of each argument and ergo we can say :
     %% "Houston, we have a problem". 


### PR DESCRIPTION
- added linear_compare/2 to binary via erl_bif_binary
- added tests for main functionality
- added smoke test to check if a compiler optimization has caused the
  function to return early.
- updated binary docs