### PR TITLE
Expand the spec for erl_epmd:listen_port_please/2

### DIFF
--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -130,8 +130,8 @@ getepmdbyname(HostName, _Timeout) ->
     {ok, HostName}.
 
 -spec listen_port_please(Name, Host) -> {ok, Port} when
-      Name :: atom(),
-      Host :: string() | inet:ip_address(),
+      Name :: atom() | string(),
+      Host :: atom() | string() | inet:ip_address(),
       Port :: non_neg_integer().
 listen_port_please(_Name, _Host) ->
     try


### PR DESCRIPTION
The spec for erl_epmd:listen_port_please/2 is overly strict, resulting in
dialyzer errors for the valid snippet:

[Name, Host] = string:split(atom_to_list(node()), "@"),
R = erl_epmd:port_please(Name, Host),

This commit relaxes the spec for listen_port_please to match that of port_please