### PR TITLE
Add format checks to CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -106,6 +106,10 @@ jobs:
           name: otp_doc_man
           path: otp_doc_man.tar.gz
 
+        ## Check formatting of cpp code
+      - if: matrix.type == '64-bit'
+        name: Check format
+        run: docker run -v $PWD/scripts:/scripts otp "make format-check"
         ## Run dialyzer
       - if: matrix.type == '64-bit'
         name: Run dialyzer

--- a/Makefile.in
+++ b/Makefile.in
@@ -533,8 +533,10 @@ compdb:
 	(cd erts/emulator && ERL_TOP=$(ERL_TOP) TYPE=$(TYPE) $(MAKE) compdb)
 	sed -i -e '1s/^/[\n/' -e '$$s/,$$/\n]/' $(ERL_TOP)/compile_commands.json
 
-clang_format:
-	(cd erts/emulator && ERL_TOP=$(ERL_TOP) $(MAKE) clang_format)
+format-check:
+	(cd erts/emulator && ERL_TOP=$(ERL_TOP) $(MAKE) format-check)
+format:
+	(cd erts/emulator && ERL_TOP=$(ERL_TOP) $(MAKE) format)
 
 dep depend:
 	$(make_verbose)

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -1509,7 +1509,9 @@ compdb:
 	clang -MJ $(TTF_DIR)/zlib.json $(COMPDB_CFLAGS) $(ZLIB_SRC) > /dev/null
 	cat $(TTF_DIR)/*.json > $(ERL_TOP)/compile_commands.json
 
-clang_format:
+format-check:
+	clang-format --Werror --dry-run -i beam/jit/*.cpp beam/jit/*.hpp beam/jit/*.c beam/jit/*.h
+format:
 	clang-format -i beam/jit/*.cpp beam/jit/*.hpp beam/jit/*.c beam/jit/*.h
 
 ifneq ($(ERTS_SKIP_DEPEND),true)

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -121,16 +121,12 @@ public:
         return ArgVal(gen_op.type, val * gen_op.val);
     }
 
-    enum Relation {
-        none,
-        consecutive,
-        reverse_consecutive
-    };
+    enum Relation { none, consecutive, reverse_consecutive };
 
     static Relation register_relation(const ArgVal &arg1, const ArgVal &arg2) {
         TYPE type = arg1.getType();
-        bool same_reg_types = type == arg2.getType() &&
-            (type == TYPE::x || type == TYPE::y);
+        bool same_reg_types =
+                type == arg2.getType() && (type == TYPE::x || type == TYPE::y);
         if (!same_reg_types) {
             return none;
         } else if (arg1.getValue() + 1 == arg2.getValue()) {
@@ -453,11 +449,13 @@ protected:
 #endif
     }
 
-    constexpr x86::Mem getCARRef(x86::Gp Src, size_t size = sizeof(UWord)) const {
+    constexpr x86::Mem getCARRef(x86::Gp Src,
+                                 size_t size = sizeof(UWord)) const {
         return x86::Mem(Src, -TAG_PRIMARY_LIST, size);
     }
 
-    constexpr x86::Mem getCDRRef(x86::Gp Src, size_t size = sizeof(UWord)) const {
+    constexpr x86::Mem getCDRRef(x86::Gp Src,
+                                 size_t size = sizeof(UWord)) const {
         return x86::Mem(Src, -TAG_PRIMARY_LIST + sizeof(Eterm), size);
     }
 
@@ -890,7 +888,8 @@ protected:
 #endif
     }
 
-    constexpr x86::Mem emit_boxed_val(x86::Gp Src, int32_t bytes = 0,
+    constexpr x86::Mem emit_boxed_val(x86::Gp Src,
+                                      int32_t bytes = 0,
                                       size_t size = sizeof(UWord)) const {
         ASSERT(bytes % sizeof(Eterm) == 0);
         return x86::Mem(Src, bytes - TAG_PRIMARY_BOXED, size);

--- a/erts/emulator/beam/jit/instr_common.cpp
+++ b/erts/emulator/beam/jit/instr_common.cpp
@@ -632,7 +632,7 @@ void BeamModuleAssembler::emit_get_list(const x86::Gp src,
         break;
     }
     case ArgVal::Relation::reverse_consecutive: {
-        if (! hasCpuFeature(x86::Features::kAVX)) {
+        if (!hasCpuFeature(x86::Features::kAVX)) {
             goto fallback;
         }
 
@@ -644,7 +644,7 @@ void BeamModuleAssembler::emit_get_list(const x86::Gp src,
         break;
     }
     case ArgVal::Relation::none:
-        fallback:
+    fallback:
         a.mov(ARG2, getCARRef(boxed_ptr));
         a.mov(ARG3, getCDRRef(boxed_ptr));
         mov_arg(Hd, ARG2);
@@ -795,7 +795,8 @@ void BeamModuleAssembler::emit_get_two_tuple_elements(const ArgVal &Src,
     emit_tuple_assertion(Src, ARG2);
 #endif
 
-    x86::Mem element_ptr = emit_boxed_val(ARG2, Element.getValue(), 2*sizeof(Eterm));
+    x86::Mem element_ptr =
+            emit_boxed_val(ARG2, Element.getValue(), 2 * sizeof(Eterm));
 
     switch (ArgVal::register_relation(Dst1, Dst2)) {
     case ArgVal::Relation::consecutive: {
@@ -805,7 +806,7 @@ void BeamModuleAssembler::emit_get_two_tuple_elements(const ArgVal &Src,
         break;
     }
     case ArgVal::Relation::reverse_consecutive: {
-        if (! hasCpuFeature(x86::Features::kAVX)) {
+        if (!hasCpuFeature(x86::Features::kAVX)) {
             goto fallback;
         } else {
             x86::Mem dst_ptr = getArgRef(Dst2, 16);
@@ -815,9 +816,9 @@ void BeamModuleAssembler::emit_get_two_tuple_elements(const ArgVal &Src,
         }
     }
     case ArgVal::Relation::none:
-        fallback:
+    fallback:
         a.mov(ARG1, emit_boxed_val(ARG2, Element.getValue()));
-        a.mov(ARG3, emit_boxed_val(ARG2, (Element+sizeof(Eterm)).getValue()));
+        a.mov(ARG3, emit_boxed_val(ARG2, (Element + sizeof(Eterm)).getValue()));
         mov_arg(Dst1, ARG1);
         mov_arg(Dst2, ARG3);
         break;
@@ -849,7 +850,8 @@ void BeamModuleAssembler::emit_move_two_words(const ArgVal &Src1,
                                               const ArgVal &Dst2) {
     x86::Mem src_ptr = getArgRef(Src1, 16);
 
-    ASSERT(ArgVal::register_relation(Src1, Src2) == ArgVal::Relation::consecutive);
+    ASSERT(ArgVal::register_relation(Src1, Src2) ==
+           ArgVal::Relation::consecutive);
 
     switch (ArgVal::register_relation(Dst1, Dst2)) {
     case ArgVal::Relation::consecutive: {
@@ -876,11 +878,10 @@ void BeamModuleAssembler::emit_move_two_words(const ArgVal &Src1,
         ASSERT(0);
         break;
     }
-
 }
 
 void BeamModuleAssembler::emit_swap(const ArgVal &R1, const ArgVal &R2) {
-    if (! hasCpuFeature(x86::Features::kAVX)) {
+    if (!hasCpuFeature(x86::Features::kAVX)) {
         goto fallback;
     }
 
@@ -900,7 +901,7 @@ void BeamModuleAssembler::emit_swap(const ArgVal &R1, const ArgVal &R2) {
         break;
     }
     case ArgVal::Relation::none:
-        fallback:
+    fallback:
         mov_arg(ARG1, R1);
         mov_arg(ARG2, R2);
         mov_arg(R2, ARG1);
@@ -927,7 +928,7 @@ void BeamModuleAssembler::emit_put_cons(const ArgVal &Hd, const ArgVal &Tl) {
         break;
     }
     case ArgVal::Relation::reverse_consecutive: {
-        if (! hasCpuFeature(x86::Features::kAVX)) {
+        if (!hasCpuFeature(x86::Features::kAVX)) {
             goto fallback;
         }
 
@@ -939,7 +940,7 @@ void BeamModuleAssembler::emit_put_cons(const ArgVal &Hd, const ArgVal &Tl) {
         break;
     }
     case ArgVal::Relation::none:
-        fallback:
+    fallback:
         mov_arg(x86::qword_ptr(HTOP, 0), Hd);
         mov_arg(x86::qword_ptr(HTOP, 1 * sizeof(Eterm)), Tl);
         break;
@@ -977,7 +978,7 @@ void BeamModuleAssembler::emit_put_tuple2(const ArgVal &Dst,
         if (i + 1 == size) {
             mov_arg(dst_ptr, args[i]);
         } else {
-            switch (ArgVal::register_relation(args[i], args[i+1])) {
+            switch (ArgVal::register_relation(args[i], args[i + 1])) {
             case ArgVal::consecutive: {
                 x86::Mem src_ptr = getArgRef(args[i], 16);
 
@@ -989,10 +990,10 @@ void BeamModuleAssembler::emit_put_tuple2(const ArgVal &Dst,
                 break;
             }
             case ArgVal::reverse_consecutive: {
-                if (! hasCpuFeature(x86::Features::kAVX)) {
+                if (!hasCpuFeature(x86::Features::kAVX)) {
                     mov_arg(dst_ptr, args[i]);
                 } else {
-                    x86::Mem src_ptr = getArgRef(args[i+1], 16);
+                    x86::Mem src_ptr = getArgRef(args[i + 1], 16);
 
                     comment("(moving and swapping two elements at once)");
                     dst_ptr.setSize(16);
@@ -1098,7 +1099,8 @@ void BeamModuleAssembler::emit_is_binary(const ArgVal &Fail,
     {
         /* emit_is_binary has already removed the literal tag from Src, if
          * applicable. */
-        a.cmp(emit_boxed_val(ARG1, offsetof(ErlSubBin, bitsize), sizeof(byte)), imm(0));
+        a.cmp(emit_boxed_val(ARG1, offsetof(ErlSubBin, bitsize), sizeof(byte)),
+              imm(0));
         a.jne(labels[Fail.getValue()]);
     }
 

--- a/make/run_make.mk
+++ b/make/run_make.mk
@@ -38,5 +38,5 @@ emu jit:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile FLAVOR=$@
 
 clean generate depend docs release release_spec release_docs release_docs_spec \
-  tests release_tests release_tests_spec static_lib xmllint clang_format compdb:
+  tests release_tests release_tests_spec static_lib xmllint format format-check compdb:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile $@


### PR DESCRIPTION
Rename the `clang_format` make target to `format` and add a makefile target called `format-check` that can be used to only check the format without changing anything.

Added call to `make format-check` as part of the github actions workflow.

Ran and committed the changes after running `make format`.