### PR TITLE
Fix ssl:peername/1 (DTLS client sockets)

### DIFF
--- a/lib/ssl/src/dtls_socket.erl
+++ b/lib/ssl/src/dtls_socket.erl
@@ -111,10 +111,11 @@ close(gen_udp, {_Client, _Socket}) ->
 close(Transport, {_Client, Socket}) ->
     Transport:close(Socket).
 
-socket(Pids, gen_udp = Transport, {{_, _}, Socket}, ConnectionCb) ->
+socket(Pids, gen_udp = Transport,
+       PeerAndSock = {{_Host, _Port}, _Socket}, ConnectionCb) ->
     #sslsocket{pid = Pids, 
 	       %% "The name "fd" is keept for backwards compatibility
-	       fd = {Transport, Socket, ConnectionCb}};
+	       fd = {Transport, PeerAndSock, ConnectionCb}};
 socket(Pids, Transport, Socket, ConnectionCb) ->
     #sslsocket{pid = Pids, 
 	       %% "The name "fd" is keept for backwards compatibility
@@ -179,13 +180,18 @@ getstat(gen_udp, Pid, Options) when is_pid(Pid) ->
     dtls_packet_demux:getstat(Pid, Options);
 getstat(gen_udp, {_,{_, Socket}}, Options) ->
     inet:getstat(Socket, Options);
+getstat(gen_udp, {_, Socket}, Options) ->
+    inet:getstat(Socket, Options);
 getstat(gen_udp, Socket, Options) ->
     inet:getstat(Socket, Options);
 getstat(Transport, Socket, Options) ->
 	Transport:getstat(Socket, Options).
+
 peername(_, undefined) ->
     {error, enotconn};
 peername(gen_udp, {_, {Client, _Socket}}) ->
+    {ok, Client};
+peername(gen_udp, {Client, _Socket}) ->
     {ok, Client};
 peername(Transport, Socket) ->
     Transport:peername(Socket).

--- a/lib/ssl/src/ssl_connection.erl
+++ b/lib/ssl/src/ssl_connection.erl
@@ -193,10 +193,10 @@ socket_control(tls_connection = Connection, Socket, [Pid|_] = Pids, Transport, T
 	{error, Reason}	->
 	    {error, Reason}
     end;
-socket_control(dtls_connection = Connection, {_, Socket}, [Pid|_] = Pids, Transport, Trackers) ->
+socket_control(dtls_connection = Connection, {PeerAddrPort, Socket}, [Pid|_] = Pids, Transport, Trackers) ->
     case Transport:controlling_process(Socket, Pid) of
 	ok ->
-	    {ok, Connection:socket(Pids, Transport, Socket, Trackers)};
+	    {ok, Connection:socket(Pids, Transport, {PeerAddrPort, Socket}, Trackers)};
 	{error, Reason}	->
 	    {error, Reason}
     end.


### PR DESCRIPTION
Fix for [ERL-1341](https://bugs.erlang.org/browse/ERL-1341).