### PR TITLE
Fix os_mon application (disksup). replace hardcoded path for 'df' command in linux environment

### DIFF
--- a/lib/os_mon/src/disksup.erl
+++ b/lib/os_mon/src/disksup.erl
@@ -240,7 +240,7 @@ check_disk_space({unix, irix}, Port, Threshold) ->
     Result = my_cmd("/usr/sbin/df -lk",Port),
     check_disks_irix(skip_to_eol(Result), Threshold);
 check_disk_space({unix, linux}, Port, Threshold) ->
-    Result = my_cmd("/bin/df -lk -x squashfs", Port),
+    Result = my_cmd("/usr/bin/env df -lk -x squashfs", Port),
     check_disks_solaris(skip_to_eol(Result), Threshold);
 check_disk_space({unix, posix}, Port, Threshold) ->
     Result = my_cmd("df -k -P", Port),

--- a/lib/os_mon/src/disksup.erl
+++ b/lib/os_mon/src/disksup.erl
@@ -228,6 +228,19 @@ newline([13|_], B) -> {ok, lists:reverse(B)};
 newline([H|T], B) -> newline(T, [H|B]);
 newline([], B) -> {more, B}.
 
+%%-- Looking for Cmd location ------------------------------------------
+find_cmd(Cmd) ->
+    os:find_executable(Cmd).
+
+find_cmd(Cmd, Path) ->
+    %% try to find it at the specific location
+    case os:find_executable(Cmd, Path) of
+        false ->
+            find_cmd(Cmd);
+        Found ->
+            Found
+    end.
+
 %%--Check disk space----------------------------------------------------
 
 check_disk_space({win32,_}, not_used, Threshold) ->
@@ -240,7 +253,8 @@ check_disk_space({unix, irix}, Port, Threshold) ->
     Result = my_cmd("/usr/sbin/df -lk",Port),
     check_disks_irix(skip_to_eol(Result), Threshold);
 check_disk_space({unix, linux}, Port, Threshold) ->
-    Result = my_cmd("/usr/bin/env df -lk -x squashfs", Port),
+    Df = find_cmd("df", "/bin"),
+    Result = my_cmd(Df ++ " -lk -x squashfs", Port),
     check_disks_solaris(skip_to_eol(Result), Threshold);
 check_disk_space({unix, posix}, Port, Threshold) ->
     Result = my_cmd("df -k -P", Port),


### PR DESCRIPTION
This PR is resolving issue https://bugs.erlang.org/browse/ERL-1370 and related to https://github.com/NixOS/nixpkgs/issues/99387

Retrieving some details of available disks is implemented via regular `df` command with a hardcoded path to it for all the OSs the Erlang does support.
https://github.com/erlang/otp/blob/master/lib/os_mon/src/disksup.erl#L242

In NixOS the location of `df` command differs from the defined location in [FHL](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard). 

Solution: replace the hardcoded path to `df`command with a more flexible way via `env`. 


