### PR TITLE
Refactor ad-hoc entropy acquisition calls

### DIFF
--- a/lib/kernel/src/auth.erl
+++ b/lib/kernel/src/auth.erl
@@ -375,9 +375,7 @@ check_cookie1([], Result) ->
 %% Creates a new, random cookie. 
    
 create_cookie(Name) ->
-    Seed = abs(erlang:monotonic_time()
-	       bxor erlang:unique_integer()),
-    Cookie = random_cookie(20, Seed, []),
+    Cookie = random_cookie(20, []),
     case file:open(Name, [write, raw]) of
 	{ok, File} ->
 	    R1 = file:write(File, Cookie),
@@ -399,12 +397,11 @@ create_cookie(Name) ->
 	       io_lib:format("Failed to create cookie file '~ts': ~p", [Name, Reason]))}
     end.
 
-random_cookie(0, _, Result) ->
+random_cookie(0, Result) ->
     Result;
-random_cookie(Count, X0, Result) ->
-    X = next_random(X0),
-    Letter = X*($Z-$A+1) div 16#1000000000 + $A,
-    random_cookie(Count-1, X, [Letter|Result]).
+random_cookie(Count, Result) ->
+    Letter = rand:uniform($Z-$A+1) - 1 + $A,
+    random_cookie(Count-1, [Letter|Result]).
 
 %% Returns suitable information for a new cookie.
 %%
@@ -422,11 +419,3 @@ make_info(Name) ->
 		{{1990, 1, 1}, {0, 0, 0}}
 	    end,
     #file_info{mode=8#400, atime=Midnight, mtime=Midnight, ctime=Midnight}.
-
-%% This RNG is from line 21 on page 102 in Knuth: The Art of Computer Programming,
-%% Volume II, Seminumerical Algorithms.
-%%
-%% Returns an integer in the range 0..(2^35-1).
-
-next_random(X) ->
-    (X*17059465+1) band 16#fffffffff.

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -504,18 +504,7 @@ gen_digest(Challenge, Cookie) when is_integer(Challenge), is_atom(Cookie) ->
 %% gen_challenge() returns a "random" number
 %% ---------------------------------------------------------------
 gen_challenge() ->
-    A = erlang:phash2([erlang:node()]),
-    B = erlang:monotonic_time(),
-    C = erlang:unique_integer(),
-    {D,_}   = erlang:statistics(reductions),
-    {E,_}   = erlang:statistics(runtime),
-    {F,_}   = erlang:statistics(wall_clock),
-    {G,H,_} = erlang:statistics(garbage_collection),
-    %% A(8) B(16) C(16)
-    %% D(16),E(8), F(16) G(8) H(16)
-    ( ((A bsl 24) + (E bsl 16) + (G bsl 8) + F) bxor
-      (B + (C bsl 16)) bxor 
-      (D + (H bsl 16)) ) band 16#ffffffff.
+    rand:uniform(16#100000000) - 1.
 
 %%
 %% Get the cookies for a node from auth

--- a/lib/kernel/src/global.erl
+++ b/lib/kernel/src/global.erl
@@ -1766,9 +1766,7 @@ update_locker_known(Upd, S) ->
     S#multi{known = Known, the_boss = TheBoss}.
 
 random_element(L) ->
-    E = abs(erlang:monotonic_time()
-		bxor erlang:unique_integer()) rem length(L),
-    lists:nth(E+1, L).
+    lists:nth(rand:uniform(length(L)), L).
 
 exclude_known(Others, Known) ->
     [N || N <- Others, not lists:member(N#him.node, Known)].

--- a/lib/kernel/src/pg2.erl
+++ b/lib/kernel/src/pg2.erl
@@ -155,9 +155,7 @@ get_closest_pid(Name) ->
     end.
 
 random_element(List) ->
-    X = abs(erlang:monotonic_time()
-		bxor erlang:unique_integer()),
-    lists:nth((X rem length(List)) + 1, List).
+    lists:nth(rand:uniform(length(List)), List).
 
 %%%
 %%% Callback functions from gen_server


### PR DESCRIPTION
This patch amends four modules in `kernel` to use `rand:uniform/1` instead of ad-hoc combinations of `erlang:monotonic_time/0` and `erlang:unique_integer/0`. This makes the codebase slightly cleaner. It also means that any future improvements in `rand` will affect these parts of the codebase.