### PR TITLE
Fold over queues

### DIFF
--- a/lib/stdlib/doc/src/queue.xml
+++ b/lib/stdlib/doc/src/queue.xml
@@ -54,6 +54,7 @@
 
     <p>All operations have an amortized O(1) running time, except
       <seemfa marker="#filter/2"><c>filter/2</c></seemfa>,
+      <seemfa marker="#fold/3"><c>fold/3</c></seemfa>,
       <seemfa marker="#join/2"><c>join/2</c></seemfa>,
       <seemfa marker="#len/1"><c>len/1</c></seemfa>,
       <seemfa marker="#member/2"><c>member/2</c></seemfa>,
@@ -131,6 +132,27 @@
           as returning <c>[]</c> is semantically equivalent to
           returning <c>false</c>. But returning a list builds
           more garbage than returning an atom.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="fold" arity="3" since=""/>
+      <fsummary>Fold a function over a queue.</fsummary>
+      <desc>
+        <p>Calls <c><anno>Fun</anno>(<anno>Item</anno>, <anno>AccIn</anno>)</c>
+          on successive items <c>Item</c> of <c>Queue</c>, starting
+          with <c><anno>AccIn</anno> == <anno>Acc0</anno></c>. The queue is
+          traversed in queue order, that is, from front to rear.
+          <c><anno>Fun</anno>/2</c> must return a new accumulator, which is
+          passed to the next call. The function returns the final value of
+          the accumulator. <c><anno>Acc0</anno></c> is returned if the queue is
+          empty.</p>
+        <p><em>Example:</em></p>
+        <pre>
+> <input>queue:fold(fun(X, Sum) -> X + Sum end, 0, queue:from_list([1,2,3,4,5])).</input>
+15
+> <input>queue:fold(fun(X, Prod) -> X * Prod end, 1, queue:from_list([1,2,3,4,5])).</input>
+120</pre>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/queue.xml
+++ b/lib/stdlib/doc/src/queue.xml
@@ -54,6 +54,7 @@
 
     <p>All operations have an amortized O(1) running time, except
       <seemfa marker="#filter/2"><c>filter/2</c></seemfa>,
+      <seemfa marker="#filtermap/2"><c>filtermap/2</c></seemfa>,
       <seemfa marker="#fold/3"><c>fold/3</c></seemfa>,
       <seemfa marker="#join/2"><c>join/2</c></seemfa>,
       <seemfa marker="#len/1"><c>len/1</c></seemfa>,
@@ -132,6 +133,21 @@
           as returning <c>[]</c> is semantically equivalent to
           returning <c>false</c>. But returning a list builds
           more garbage than returning an atom.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="filtermap" arity="2" since=""/>
+      <fsummary>Filter and map a queue.</fsummary>
+      <desc>
+        <p>Returns a queue <c><anno>Q2</anno></c> that is the result of calling
+          <c><anno>Fun</anno>(<anno>Item</anno>)</c> on all items in
+          <c><anno>Q1</anno></c>, in order from front to rear.</p>
+        <p>If <c><anno>Fun</anno>(<anno>Item</anno>)</c> returns <c>true</c>,
+          <c>Item</c> is copied to the result queue. If it returns <c>false</c>,
+          <c><anno>Item</anno></c> is not copied. If it returns
+          <c>{true, NewItem}</c>, the queue element at this position is replaced
+          with <c>NewItem</c> in the result queue.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/queue.erl
+++ b/lib/stdlib/src/queue.erl
@@ -27,7 +27,7 @@
 -export([get/1,get_r/1,peek/1,peek_r/1,drop/1,drop_r/1]).
 
 %% Higher level API
--export([reverse/1,join/2,split/2,filter/2,fold/3]).
+-export([reverse/1,join/2,split/2,filter/2,filtermap/2,fold/3]).
 
 %% Okasaki API from klacke
 -export([cons/2,head/1,tail/1,
@@ -400,6 +400,42 @@ filter_r(Fun, [X|R0]) ->
 	    R;
 	L when is_list(L) ->
 	    lists:reverse(L, R)
+    end.
+
+%% Filter and map a queue, traverses in queue order.
+%%
+%% O(len(Q1))
+-spec filtermap(Fun, Q1) -> Q2 when
+      Fun :: fun((Item) -> boolean() | {'true', Value}),
+      Q1 :: queue(Item),
+      Q2 :: queue(Item | Value),
+      Item :: term(),
+      Value :: term().
+filtermap(Fun, {R0, F0}) when is_function(Fun, 1), is_list(R0), is_list(F0) ->
+    F = lists:filtermap(Fun, F0),
+    R = filtermap_r(Fun, R0),
+    if R =:= [] ->
+	    f2r(F);
+       F =:= [] ->
+	    r2f(R);
+       true ->
+	    {R,F}
+    end;
+filtermap(Fun, Q) ->
+    erlang:error(badarg, [Fun,Q]).
+
+%% Call Fun in reverse order, i.e tail to head
+filtermap_r(_, []) ->
+    [];
+filtermap_r(Fun, [X|R0]) ->
+    R = filtermap_r(Fun, R0),
+    case Fun(X) of
+	true ->
+	    [X|R];
+	{true, Y} ->
+	    [Y|R];
+	false ->
+	    R
     end.
 
 %% Fold a function over a queue, in queue order.

--- a/lib/stdlib/src/queue.erl
+++ b/lib/stdlib/src/queue.erl
@@ -373,7 +373,11 @@ filter_f(Fun, [X|F]) ->
     case Fun(X) of
 	true ->
 	    [X|filter_f(Fun, F)];
+	[Y] ->
+	    [Y|filter_f(Fun, F)];
 	false ->
+	    filter_f(Fun, F);
+	[] ->
 	    filter_f(Fun, F);
 	L when is_list(L) ->
 	    L++filter_f(Fun, F)
@@ -388,7 +392,11 @@ filter_r(Fun, [X|R0]) ->
     case Fun(X) of
 	true ->
 	    [X|R];
+	[Y] ->
+	    [Y|R];
 	false ->
+	    R;
+	[] ->
 	    R;
 	L when is_list(L) ->
 	    lists:reverse(L, R)

--- a/lib/stdlib/src/queue.erl
+++ b/lib/stdlib/src/queue.erl
@@ -27,7 +27,7 @@
 -export([get/1,get_r/1,peek/1,peek_r/1,drop/1,drop_r/1]).
 
 %% Higher level API
--export([reverse/1,join/2,split/2,filter/2]).
+-export([reverse/1,join/2,split/2,filter/2,fold/3]).
 
 %% Okasaki API from klacke
 -export([cons/2,head/1,tail/1,
@@ -401,6 +401,21 @@ filter_r(Fun, [X|R0]) ->
 	L when is_list(L) ->
 	    lists:reverse(L, R)
     end.
+
+%% Fold a function over a queue, in queue order.
+%%
+%% O(len(Q))
+-spec fold(Fun, Acc0, Q :: queue(Item)) -> Acc1 when
+      Fun :: fun((Item, AccIn) -> AccOut),
+      Acc0 :: term(),
+      Acc1 :: term(),
+      AccIn :: term(),
+      AccOut :: term().
+fold(Fun, Acc0, {R, F}) when is_function(Fun, 2), is_list(R), is_list(F) ->
+    Acc1 = lists:foldl(Fun, Acc0, F),
+    lists:foldr(Fun, Acc1, R);
+fold(Fun, Acc0, Q) ->
+    erlang:error(badarg, [Fun, Acc0, Q]).
 
 %%--------------------------------------------------------------------------
 %% Okasaki API inspired by an Erlang user contribution "deque.erl" 

--- a/lib/stdlib/test/queue_SUITE.erl
+++ b/lib/stdlib/test/queue_SUITE.erl
@@ -373,6 +373,14 @@ do_op_test(F) ->
 					    (_) -> [] end, MyQ4)),
     [33,44] = queue:to_list(queue:filter(fun(X) when X < 27 -> false;
 					    (X) -> [X] end, MyQ4)),
+    [11,22*22,33*33] = queue:to_list(queue:filtermap(fun(X) when X < 17 -> true;
+							(X) when X > 37 -> false;
+							(X) -> {true, X*X}
+						     end, MyQ4)),
+    [22*22,33*33,44] = queue:to_list(queue:filtermap(fun(X) when X < 17 -> false;
+							(X) when X > 37 -> true;
+							(X) -> {true, X*X}
+						     end, MyQ4)),
     FoldQ = queue:from_list(L1),
     FoldExp1 = lists:sum(L1),
     FoldAct1 = queue:fold(fun(X,A) -> X+A end, 0, FoldQ),

--- a/lib/stdlib/test/queue_SUITE.erl
+++ b/lib/stdlib/test/queue_SUITE.erl
@@ -373,6 +373,13 @@ do_op_test(F) ->
 					    (_) -> [] end, MyQ4)),
     [33,44] = queue:to_list(queue:filter(fun(X) when X < 27 -> false;
 					    (X) -> [X] end, MyQ4)),
+    FoldQ = queue:from_list(L1),
+    FoldExp1 = lists:sum(L1),
+    FoldAct1 = queue:fold(fun(X,A) -> X+A end, 0, FoldQ),
+    FoldExp1 = FoldAct1,
+    FoldExp2 = [X*X || X <- L1],
+    FoldAct2 = queue:fold(fun(X,A) -> [X*X|A] end, [], FoldQ),
+    FoldExp2 = lists:reverse(FoldAct2),
     %%
     ok.
 


### PR DESCRIPTION
The first commit in this PR introduces a `fold/3` function for the `queue` module. Up to now, this had to be done by converting a queue to a list and folding over that, which is both cumbersome and more performance-intensive (`O(length(Rear))` for the conversion, and `O(length(List))` for the fold over that list) than a fold over the internal lists making up the `Rear` and `Front`, inside the `queue` module (`O(len(Queue))`, roughly equivalent to only `O(length(List))`). The queue is traversed in queue order (front to rear), which is what would be expected.

<hr />

The second commit in this PR addresses a "glitch" in the `filter/2` function, namely that while returning `true` or `false` from the filter function is semantically equivalent to returning `[Item]` or `[]` respectively, the latter generates more garbage. By handling the two special cases "single-element list" and "empty list" the same as `true` and `false` respectively, this is no longer the case, and the paragraph in the function documentation has been removed accordingly.

Also, to align `queue:filter/2` more closely with `lists:filtermap/2` (`queue:filter/2` is really a filtermap with insert capability), the filter function may return `{true, NewItem}` to signal that the current item should be replaced with `NewItem` in the result queue.