### PR TITLE
Read file rename race

### DIFF
--- a/lib/kernel/test/prim_file_SUITE.erl
+++ b/lib/kernel/test/prim_file_SUITE.erl
@@ -30,7 +30,8 @@
          file_read_file_info_opts/1, file_write_file_info_opts/1,
 	 file_write_read_file_info_opts/1]).
 -export([rename/1, access/1, truncate/1, datasync/1, sync/1,
-	 read_write/1, pread_write/1, append/1, exclusive/1]).
+	 read_write/1, pread_write/1, append/1, exclusive/1,
+	 read_file_rename_race/1]).
 -export([e_delete/1, e_rename/1, e_make_dir/1, e_del_dir/1]).
 
 -export([make_link/1, read_link_info_for_non_link/1,
@@ -67,7 +68,7 @@ groups() ->
        truncate, sync, datasync, advise, large_write, allocate]},
      {open, [],
       [open1, modes, close, access, read_write, pread_write,
-       append, exclusive]},
+       append, exclusive, read_file_rename_race]},
      {pos, [], [pos1, pos2]},
      {file_info, [],
       [file_info_basic_file,file_info_basic_directory, file_info_bad,
@@ -567,6 +568,49 @@ exclusive(Config) when is_list(Config) ->
     {error, eexist} = ?PRIM_FILE:open(Name, [write, exclusive]),
     ok = ?PRIM_FILE:close(Fd),
     ok.
+
+%% Test read_file with concurrent renames and size changes.
+
+-define(RFRR_DATA1, <<"gazonk">>).
+-define(RFRR_DATA2, <<"fubar">>). % shorter than and not a prefix of DATA1
+
+read_file_rename_race(Config) when is_list(Config) ->
+    Dir = proplists:get_value(priv_dir, Config),
+    Name = filename:join(Dir, "filename"),
+    rfrr_write_file(Name, ?RFRR_DATA2),
+    Mutator = spawn_link(fun() -> rfrr_mutator(Name, ?RFRR_DATA1, ?RFRR_DATA2) end),
+    Result = rfrr_reader(Name, 1, _N = 5000),
+    unlink(Mutator),
+    exit(Mutator, kill),
+    ok = Result.
+
+rfrr_reader(Name, I, N) when I < N ->
+    case rfrr_read_file(Name, I) of
+	ok -> rfrr_reader(Name, I + 1, N);
+	error -> error
+    end;
+rfrr_reader(_Name, _I, _N) -> ok.
+
+rfrr_read_file(Name, I) ->
+    case prim_file:read_file(Name) of
+	{ok, ?RFRR_DATA1} -> ok;
+	{ok, ?RFRR_DATA2} -> ok;
+	Other ->
+	    io:format(standard_error, "rfrr_read_file #~p got ~p\n", [I, Other]),
+	    error
+    end.
+
+%% Correctness of read_file must not depend on the mutator using the
+%% file server in the reader's Erlang VM, so we use prim_file here.
+rfrr_mutator(Name, Data1, Data2) ->
+    rfrr_write_file(Name, Data1),
+    rfrr_mutator(Name, Data2, Data1).
+
+%% Atomically replace Name with a new file containing Data.
+rfrr_write_file(Name, Data) ->
+    NameTmp = Name ++ ".tmp", % must be in same volume as Name
+    ok = prim_file:write_file(NameTmp, Data),
+    ok = prim_file:rename(NameTmp, Name).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
file:read_file/1 and prim_file:read_file/1 retrieve the file size before opening the file, and then only read as much data as that file size stated.  Between the file size retrieval (stat() on Unix) and the open, the file may get renamed to a different, larger one.  This causes read_file to return truncated data.  Fixed by retrieving the file size from the open file handle instead.

Fixes https://bugs.erlang.org/browse/ERL-1376.