### PR TITLE
Do not try to convert already absolute path in uri_string:recompose/1

### DIFF
--- a/lib/stdlib/src/uri_string.erl
+++ b/lib/stdlib/src/uri_string.erl
@@ -1780,6 +1780,8 @@ make_path_absolute(<<"/",_/binary>> = Path) ->
     Path;
 make_path_absolute([$/|_] = Path) ->
     Path;
+make_path_absolute([<<"/">>|_] = Path) ->
+    Path;
 make_path_absolute(Path) when is_binary(Path) ->
     concat(<<$/>>, Path);
 make_path_absolute(Path) when is_list(Path) ->


### PR DESCRIPTION
According to the documentation, the `path` passed to `uri_string:recompose/1` via the `uri_map/0` is of type `unicode:chardata()`. From what I understand, a `path` expressed as `[<<"/">>, <<"tmp">>]` should be valid input, but that would be considered a relative path and therefore an extra slash would be prepended.