### PR TITLE
escript: Allow the user to request a particular emulator flavor

### DIFF
--- a/erts/doc/src/escript_cmd.xml
+++ b/erts/doc/src/escript_cmd.xml
@@ -446,5 +446,11 @@ ok
       <item>Compiles the escript using flag <c>+native</c>.
       </item>
     </taglist>
+    <note>
+      <p>The configuration of the Erlang emulator invoked by
+        <c>escript</c> can be controlled using the <seecom
+        marker="erl#environment_variables"> environment variables
+        understood by <c>erl</c></seecom>.</p>
+    </note>
   </section>
 </comref>


### PR DESCRIPTION
Escript allows the user to use the (undocumented) `ESCRIPT_EMULATOR`
environment variable to specify which emulator binary to use, but
there is no corresponding way to select the emulator flavor. This
patch adds support for selecting the flavor by setting the
`ESCRIPT_FLAVOR` environment variable. Setting `ESCRIPT_FLAVOR` to
`<flavor>` will add `-emu_flavor <flavor>` to the emulator command
line when running escripts.