### PR TITLE
Since the string from strerror should never be modified, use const.

### DIFF
--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -710,7 +710,7 @@ erts_alloc_init(int *argc, char **argv, ErtsAllocInitOpts *eaiop)
 	errno = 0;
 	if (mlockall(MCL_CURRENT|MCL_FUTURE) != 0) {
 	    int err = errno;
-	    char *errstr = err ? strerror(err) : "unknown";
+	    const char *errstr = err ? strerror(err) : "unknown";
 	    erts_exit(1, "Failed to lock physical memory: %s (%d)\n",
 		     errstr, err);
 	}

--- a/erts/emulator/beam/erl_drv_thread.c
+++ b/erts/emulator/beam/erl_drv_thread.c
@@ -35,9 +35,9 @@
    + sizeof(((ErlDrvThreadOpts *) 0)->LAST_FIELD))
 
 static void
-fatal_error(int err, char *func)
+fatal_error(int err, const char *func)
 {
-    char *estr = strerror(err);
+    const char *estr = strerror(err);
     if (!estr) {
 	if (err == ENOTSUP)
 	    estr = "Not supported";

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -2445,7 +2445,7 @@ erl_start(int argc, char **argv)
 
 __decl_noreturn void erts_thr_fatal_error(int err, const char *what)
 {
-    char *errstr = err ? strerror(err) : NULL;
+    const char *errstr = err ? strerror(err) : NULL;
     erts_fprintf(stderr,
 		 "Failed to %s: %s%s(%d)\n",
 		 what,

--- a/erts/emulator/sys/unix/sys_time.c
+++ b/erts/emulator/sys/unix/sys_time.c
@@ -453,7 +453,7 @@ posix_clock_gettime(clockid_t id, char *name)
 
     if (clock_gettime(id, &ts) != 0) {
 	int err = errno;
-	char *errstr = err ? strerror(err) : "unknown";
+	const char *errstr = err ? strerror(err) : "unknown";
 	erts_exit(ERTS_ABORT_EXIT,
 		 "clock_gettime(%s, _) failed: %s (%d)\n",
 		 name, errstr, err);
@@ -498,13 +498,13 @@ posix_clock_gettime_times(clockid_t mid, char *mname,
     serr = errno;
     
     if (mres != 0) {
-	char *errstr = merr ? strerror(merr) : "unknown";
+	const char *errstr = merr ? strerror(merr) : "unknown";
 	erts_exit(ERTS_ABORT_EXIT,
 		 "clock_gettime(%s, _) failed: %s (%d)\n",
 		 mname, errstr, merr);
     }
     if (sres != 0) {
-	char *errstr = serr ? strerror(serr) : "unknown";
+	const char *errstr = serr ? strerror(serr) : "unknown";
 	erts_exit(ERTS_ABORT_EXIT,
 		 "clock_gettime(%s, _) failed: %s (%d)\n",
 		 sname, errstr, serr);
@@ -698,7 +698,7 @@ mach_clocks_init(void)
 
     if (atexit(mach_clocks_fini) != 0) {
 	int err = errno;
-	char *errstr = err ? strerror(err) : "unknown";
+	const char *errstr = err ? strerror(err) : "unknown";
 	erts_exit(ERTS_ABORT_EXIT,
 		 "Failed to register mach_clocks_fini() "
 		 "for call at exit: %s (%d)\n",
@@ -853,7 +853,7 @@ erts_os_system_time(void)
 
     if (gettimeofday(&tv, NULL) != 0) {
 	int err = errno;
-	char *errstr = err ? strerror(err) : "unknown";
+	const char *errstr = err ? strerror(err) : "unknown";
 	erts_exit(ERTS_ABORT_EXIT,
 		 "gettimeofday(_, NULL) failed: %s (%d)\n",
 		 errstr, err);

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -1854,10 +1854,10 @@ done:
 #undef ENSURE
 }
 
-static char *
+static const char *
 errno_string(void)
 {
-    char *str = strerror(errno);
+    const char *str = strerror(errno);
     if (!str)
 	return "unknown error";
     return str;

--- a/erts/lib_src/common/ethr_aux.c
+++ b/erts/lib_src/common/ethr_aux.c
@@ -738,7 +738,7 @@ ETHR_IMPL_NORETURN__ ethr_fatal_error__(const char *file,
 					const char *func,
 					int err)
 {
-    char *errstr;
+    const char *errstr;
     if (err == ENOTSUP)
 	errstr = "Operation not supported";
     else {

--- a/lib/erl_interface/src/connect/ei_connect.c
+++ b/lib/erl_interface/src/connect/ei_connect.c
@@ -143,10 +143,10 @@ dyn_gethostbyname_r(const char *name, struct hostent *hostp, char **buffer_p,
 static void abort_connection(ei_socket_callbacks *cbs, void *ctx);
 static int close_connection(ei_socket_callbacks *cbs, void *ctx, int fd);
 
-static char *
+static const char *
 estr(int e)
 {
-    char *str = strerror(e);
+    const char *str = strerror(e);
     if (!str)
         return "unknown error";
     return str;

--- a/lib/tools/c_src/erl_memory.c
+++ b/lib/tools/c_src/erl_memory.c
@@ -1859,7 +1859,7 @@ error_string(int error)
     error_str = unknown_error;
 
     if (error > 0) {
-	char *str = strerror(error);
+	const char *str = strerror(error);
 	if (str)
 	    error_str = str;
     }


### PR DESCRIPTION
This is just a very minor issue.

erlang contains some calls to strerror where the result is assigned to a char *. However, according to the strerror specification, the
string returned by strerror should never be changed, so I think it would be better to use const char * instead.

Philipp
