### PR TITLE
Fix handling of deep lists in path component (uri_string:recompose/1)

### DIFF
--- a/lib/stdlib/src/uri_string.erl
+++ b/lib/stdlib/src/uri_string.erl
@@ -1681,7 +1681,8 @@ update_path(#{path := Path}, empty) ->
     encode_path(Path);
 update_path(#{host := _, path := Path0}, URI) ->
     %% When host is present in a URI the path must begin with "/" or be empty.
-    Path = make_path_absolute(Path0),
+    Path1 = maybe_flatten_list(Path0),
+    Path = make_path_absolute(Path1),
     concat(URI,encode_path(Path));
 update_path(#{path := Path}, URI) ->
     concat(URI,encode_path(Path));
@@ -1784,6 +1785,11 @@ make_path_absolute(Path) when is_binary(Path) ->
     concat(<<$/>>, Path);
 make_path_absolute(Path) when is_list(Path) ->
     concat("/", Path).
+
+maybe_flatten_list(Path) when is_binary(Path) ->
+    Path;
+maybe_flatten_list(Path) ->
+    unicode:characters_to_list(Path).
 
 %%-------------------------------------------------------------------------
 %% Helper functions for resolve

--- a/lib/stdlib/test/uri_string_SUITE.erl
+++ b/lib/stdlib/test/uri_string_SUITE.erl
@@ -52,7 +52,8 @@
          dissect_query/1, dissect_query_negative/1,
          interop_query_latin1/1, interop_query_utf8/1,
          regression_parse/1, regression_recompose/1, regression_normalize/1,
-         recompose_host_relative_path/1
+         recompose_host_relative_path/1,
+         recompose_host_absolute_path/1
         ]).
 
 
@@ -146,7 +147,8 @@ all() ->
      regression_parse,
      regression_recompose,
      regression_normalize,
-     recompose_host_relative_path
+     recompose_host_relative_path,
+     recompose_host_absolute_path
     ].
 
 groups() ->
@@ -1254,5 +1256,20 @@ recompose_host_relative_path(_Config) ->
         uri_string:recompose(#{host => "example.com", path => ".foo"}),
     <<"//example.com/foo">> =
         uri_string:recompose(#{host => <<"example.com">>, path => <<"foo">>}),
+    ok.
+
+recompose_host_absolute_path(_Config) ->
+    "//example.com/foo" =
+        uri_string:recompose(#{host => "example.com",
+                               path => ["/", "foo"]}),
+    "//example.com/foo" =
+        uri_string:recompose(#{host => <<"example.com">>,
+                               path => [<<"/">>,<<"foo">>]}),
+    "//example.com/foo" =
+        uri_string:recompose(#{host => "example.com",
+                               path => ["/f", "oo"]}),
+    "//example.com/foo" =
+        uri_string:recompose(#{host => <<"example.com">>,
+                               path => [<<"/f">>,<<"oo">>]}),
     ok.
 


### PR DESCRIPTION
This change fixes the handling of deep lists in the path component when using ```uri_string:recompose/1```.
```erlang
 "//example.com/foo" =
        uri_string:recompose(#{host => "example.com",
                               path => ["/", "foo"]}),
```