### PR TITLE
logger.hrl: use fully qualifier call to erlang:apply

### DIFF
--- a/lib/kernel/include/logger.hrl
+++ b/lib/kernel/include/logger.hrl
@@ -46,7 +46,7 @@
 -define(DO_LOG(Level,Args),
         case logger:allow(Level,?MODULE) of
             true ->
-                apply(logger,macro_log,[?LOCATION,Level|Args]);
+                erlang:apply(logger,macro_log,[?LOCATION,Level|Args]);
             false ->
                 ok
         end).

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -68,7 +68,7 @@ init_per_testcase(_TestCase, Config) ->
     [{logger_config,PC}|Config].
 
 end_per_testcase(Case, Config) ->
-    try apply(?MODULE,Case,[cleanup,Config])
+    try erlang:apply(?MODULE,Case,[cleanup,Config])
     catch error:undef -> ok
     end,
     ok.
@@ -1407,4 +1407,10 @@ my_try(Fun) ->
 check_config(crash) ->
     erlang:error({badmatch,3});
 check_config(_) ->
+    ok.
+
+%% this function is also a test. When logger.hrl used non-qualified
+%%  apply/3 call, any module that was implementing apply/3 could
+%%  not use any logging macro
+apply(_Any, _Any, _Any) ->
     ok.


### PR DESCRIPTION
When a module has local apply/3 function, logging macros
do not work correctly due to "ambiguous call of overridden pre
R14 auto-imported BIF apply/3"