### PR TITLE
Fixed using unitialized variable when environment var is too big

### DIFF
--- a/lib/wx/c_src/wxe_ps_init.c
+++ b/lib/wx/c_src/wxe_ps_init.c
@@ -74,7 +74,7 @@ void * wxe_ps_init2() {
    if( !is_packaged_app() ) {
       // Undocumented function (but no documented way of doing this exists)
       int res = erl_drv_getenv("WX_APP_TITLE", app_title_buf, &app_len);
-      if (res >= 0) {
+      if (res == 0) {
           app_title = app_title_buf;
       } else {
           app_title = NULL;


### PR DESCRIPTION
While implementing #2808  I've adapted the same process used in wxe_ps_init.c for macos but there is a bug in that macos code:

```
      int res = erl_drv_getenv("WX_APP_TITLE", app_title_buf, &app_len);
      if (res >= 0) {
          app_title = app_title_buf;
      } else {
          app_title = NULL;
      }
```

and it should just be `if (res == 0)` because when res > 0 the `app_title_buf` variable is being used uninitialized. According to this impl of `erts_osenv_get_native()` in erl_osenv.c

```
int erts_osenv_get_native(const erts_osenv_t *env,
        const erts_osenv_data_t *key,
        erts_osenv_data_t *value) {
    env_rbtnode_t *node = env_rbt_lookup(env->tree, *key);

    if(node != NULL) {
        if(value != NULL) {
            if(node->value.length > value->length) {
                return -1;
            }

            sys_memcpy(value->data, node->value.data, node->value.length);
            value->length = node->value.length;
        }

        return 1;
    }

    return 0;
}
```

So when the destination buffer is not large enough the output buffer is never touched. The sys_memcpy call is skipped and the destination stays uninitialized. Note this is called from io.c - which does invert the result of -1 and +1:

```
int
erl_drv_getenv(const char *key, char *value, size_t *value_size)
{
    switch (erts_sys_explicit_8bit_getenv((char*)key, value, value_size)) {
    case -1: /* Insufficient buffer space */
        return 1;
    case 1: /* Success */
        return 0;
    default: /* Not found */
        return -1;
    }
}
```
