### PR TITLE
Handle uncompressed binaries given as compressed to erl_tar

### DIFF
--- a/lib/stdlib/src/erl_tar.erl
+++ b/lib/stdlib/src/erl_tar.erl
@@ -323,9 +323,16 @@ do_open(Name, Mode) when is_list(Mode) ->
 
 open1({binary,Bin0}=Handle, read, _Raw, Opts) when is_binary(Bin0) ->
     Bin = case lists:member(compressed, Opts) of
-        true -> zlib:gunzip(Bin0);
-        false -> Bin0
+        true ->
+            try
+                zlib:gunzip(Bin0)
+            catch
+                _:_ -> Bin0
+            end;
+        false ->
+            Bin0
     end,
+
     case file:open(Bin, [ram,binary,read]) of
         {ok,File} ->
             {ok, #reader{handle=File,access=read,func=fun file_op/2}};

--- a/lib/stdlib/test/tar_SUITE.erl
+++ b/lib/stdlib/test/tar_SUITE.erl
@@ -510,6 +510,11 @@ extract_from_binary_compressed(Config) when is_list(Config) ->
     io:format("~p\n", [Files]),
     19 = length(Files),
 
+    %% Try taking contents when already uncompressed.
+    {ok,Files} = erl_tar:table({binary,zlib:gunzip(Bin)}, [compressed]),
+    io:format("~p\n", [Files]),
+    19 = length(Files),
+
     %% Trying extracting from a binary.
     ok = erl_tar:extract({binary,Bin}, [compressed,{cwd,ExtractDir}]),
     {ok,List} = file:list_dir(filename:join(ExtractDir, "ddll_SUITE_data")),


### PR DESCRIPTION
While one could argue that given an uncompressed binary with the compressed flag should fail, earlier OTP versions implicitly supported this behaviour, so this commit adds it back.

This fixes a regression from #2802. /cc @jhogberg 

Thanks @wojtekmach for the report.
