### PR TITLE
Clarify how add_sup_handler establishes links

### DIFF
--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -209,6 +209,10 @@ gen_event:stop             ----->  Module:terminate/2
           <seemfa marker="#add_handler/3"><c>add_handler/3</c></seemfa>,
           but also supervises the connection between the event handler
           and the calling process.</p>
+	<p>This call will also set up a link between the event handler and
+	  the calling process, which will <em>not</em> be removed if the
+	  handler is removed, in case another supervised handler also links
+	  to the same process.</p>
         <list type="bulleted">
           <item>If the calling process later terminates with <c>Reason</c>,
            the event manager deletes the event handler by calling


### PR DESCRIPTION
Make the following comment visible in the docs: 
https://github.com/erlang/otp/blame/maint/lib/stdlib/src/gen_event.erl#L525