### PR TITLE
Implement NSS-style keylog in ssl:connection_information/2

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -788,6 +788,16 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       </desc>
     </datatype>
 
+    <datatype>
+      <name name="keep_secrets"/>
+      <desc><p>Configures a TLS 1.3 connection for keylogging</p>
+      <p>In order to retrieve keylog information on a TLS 1.3 connection, it must be configured
+      in advance to keep the client_random and various handshake secrets.</p>
+      <p>The keep_secrets functionality is disabled (<c>false</c>) by default.</p>
+      <p>Added in OTP 23.2</p>
+      </desc>
+    </datatype>
+
     <datatype_title>TLS/DTLS OPTION DESCRIPTIONS - CLIENT</datatype_title>
     
     <datatype>
@@ -1554,7 +1564,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       </fsummary>
       <desc><p>Returns the requested information items about the connection,
       if they are defined.</p>
-      <p>Note that client_random, server_random  and master_secret are values
+      <p>Note that client_random, server_random, master_secret and keylog are values
       that affect the security of connection. Meaningful atoms, not specified
       above, are the ssl option names.</p>
 

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -310,6 +310,7 @@
                                 {signature_algs_cert, signature_schemes()} |
                                 {supported_groups, supported_groups()} |
                                 {secure_renegotiate, secure_renegotiation()} |
+                                {keep_secrets, keep_secrets()} |
                                 {depth, allowed_cert_chain_length()} |
                                 {verify_fun, custom_verify()} |
                                 {crl_check, crl_check()} |
@@ -346,6 +347,7 @@
 -type cipher_filters()            :: list({key_exchange | cipher | mac | prf,
                                         algo_filter()}). % exported
 -type algo_filter()               :: fun((kex_algo()|cipher()|hash()|aead|default_prf) -> true | false).
+-type keep_secrets()              :: boolean().
 -type secure_renegotiation()      :: boolean(). 
 -type allowed_cert_chain_length() :: integer().
 
@@ -505,6 +507,7 @@
                                 client_random |
                                 server_random |
                                 master_secret |
+                                keylog |
                                 tls_options_name().
 -type tls_options_name() :: atom().
 %% -------------------------------------------------------------------------------------------------------
@@ -2212,6 +2215,8 @@ validate_option(reuse_sessions, save = Value) ->
     Value;
 validate_option(secure_renegotiate, Value) when is_boolean(Value) ->
     Value;
+validate_option(keep_secrets, Value) when is_boolean(Value) ->
+    Value;
 validate_option(client_renegotiation, Value) when is_boolean(Value) ->
     Value;
 validate_option(renegotiate_at, Value) when is_integer(Value) ->
@@ -2762,7 +2767,7 @@ default_cb_info(dtls) ->
 include_security_info([]) ->
     false;
 include_security_info([Item | Items]) ->
-    case lists:member(Item, [client_random, server_random, master_secret]) of
+    case lists:member(Item, [client_random, server_random, master_secret, keylog]) of
         true ->
             true;
         false  ->

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -175,6 +175,7 @@
           reuse_session              => {undefined, [versions]},
           reuse_sessions             => {true,      [versions]},
           secure_renegotiate         => {true,      [versions]},
+          keep_secrets               => {false,     [versions]},
           server_name_indication     => {undefined, [versions]},
           session_tickets            => {disabled,     [versions]},
           signature_algs             => {undefined, [versions]},

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -52,6 +52,8 @@
          connection_information/1,
          secret_connection_info/0,
          secret_connection_info/1,
+         keylog_connection_info/0,
+         keylog_connection_info/1,
          versions/0,
          versions/1,
          active_n/0,
@@ -170,6 +172,7 @@
 -export([connection_information_result/1,
          connection_info_result/1,
          secret_connection_info_result/1,
+         keylog_connection_info_result/2,
          check_srp_in_connection_information/3,
          check_connection_info/2,
          prf_verify_value/4,
@@ -247,6 +250,7 @@ gen_api_tests() ->
      peercert_with_client_cert,
      connection_information,
      secret_connection_info,
+     keylog_connection_info,
      versions,
      active_n,
      dh_params,
@@ -571,6 +575,57 @@ secret_connection_info(Config) when is_list(Config) ->
     
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
+%%--------------------------------------------------------------------
+keylog_connection_info() ->
+    [{doc,"Test the API function ssl:connection_information/2"}].
+keylog_connection_info(Config) when is_list(Config) ->
+    keylog_connection_info(Config, true),
+    keylog_connection_info(Config, false).
+keylog_connection_info(Config, KeepSecrets) ->
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+
+    Server =
+        ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                                   {from, self()},
+                                   {mfa, {?MODULE, keylog_connection_info_result, [KeepSecrets]}},
+                                   {options, [{verify, verify_peer}, {keep_secrets, KeepSecrets} | ServerOpts]}]),
+
+    Port = ssl_test_lib:inet_port(Server),
+    Client =
+        ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+                                   {host, Hostname},
+                                   {from, self()},
+                                   {mfa, {?MODULE, keylog_connection_info_result, [KeepSecrets]}},
+                                   {options,  [{verify, verify_peer}, {keep_secrets, KeepSecrets} |ClientOpts]}]),
+
+    ct:log("Testcase ~p, KeepSecrets ~p Client ~p  Server ~p ~n",
+		       [self(), KeepSecrets, Client, Server]),
+
+    ServerKeylog = receive
+                       {Server, {ok, Keylog}} ->
+                           Keylog;
+                       {Server, ServerError} ->
+                           ct:fail({server, ServerError})
+                   after 5000 ->
+                           ct:fail({server, timeout})
+                   end,
+
+    receive
+        {Client, {ok, ServerKeylog}} ->
+            ok;
+        {Client, {ok, ClientKeylog}} ->
+            ct:fail({mismatch, {ServerKeylog, ClientKeylog}});
+        {Client, ClientError} ->
+            ct:fail({client, ClientError})
+    after 5000 ->
+            ct:fail({client, timeout})
+    end,
+
+    ssl_test_lib:close(Server),
+    ssl_test_lib:close(Client).
+
 %%--------------------------------------------------------------------
 prf() ->
     [{doc,"Test that ssl:prf/5 uses the negotiated PRF."}].
@@ -2335,10 +2390,27 @@ connection_information_result(Socket) ->
 	false ->
 	    ct:fail(no_ssl_options_returned)
     end.
+
 secret_connection_info_result(Socket) ->
     {ok, [{protocol, Protocol}]} = ssl:connection_information(Socket, [protocol]),
     {ok, ConnInfo} = ssl:connection_information(Socket, [client_random, server_random, master_secret]),
     check_connection_info(Protocol, ConnInfo).
+
+keylog_connection_info_result(Socket, KeepSecrets) ->
+    {ok, [{protocol, Protocol}]} = ssl:connection_information(Socket, [protocol]),
+    {ok, ConnInfo} = ssl:connection_information(Socket, [keylog]),
+    check_keylog_info(Protocol, ConnInfo, KeepSecrets).
+
+check_keylog_info('tlsv1.3', [{keylog, ["CLIENT_HANDSHAKE_TRAFFIC_SECRET"++_,_|_]=Keylog}], true) ->
+    {ok, Keylog};
+check_keylog_info('tlsv1.3', []=Keylog, false) ->
+    {ok, Keylog};
+check_keylog_info('tlsv1.2', [{keylog, ["CLIENT_RANDOM"++_]=Keylog}], _) ->
+    {ok, Keylog};
+check_keylog_info(NotSup, [], _) when NotSup == 'tlsv1.1'; NotSup == tlsv1; NotSup == 'dtlsv1.2'; NotSup == dtlsv1 ->
+    {ok, []};
+check_keylog_info(_, Unexpected, _) ->
+    {unexpected, Unexpected}.
 
 check_srp_in_connection_information(_Socket, _Username, client) ->
     ok;


### PR DESCRIPTION
This commit provides the ability to retreive keylog information that
can be used by tools (e.g. Wireshark) to decrypt TLS connections.

The information returned by the keylog connection_information item is
a list of keylog items that can be written to a file or otherwise
communicated to a tool understanding keylog.

For example:
```
{ok, [{keylog, KeylogItems}]} = ssl:connection_information(S, [keylog]).
file:write_file("/tmp/key.log", [[KeylogItem,$\n] || KeylogItem <-KeylogItems]).
```

For TLSv1.3 connections more information must be stored in the connection state. In this case the initial `ssl:listen` or `ssl:connect` call must include the option `{keylog, true}`

For TLSv1.2 connections, the required information could be obtained from the existing `master_secret` and `client_random` items and the keylog item constructed manually. However this PR provides a common method regardless of the protocol.

References:
[NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)
[Wireshark](https://wiki.wireshark.org/TLS#Using_the_.28Pre.29-Master-Secret)
