### PR TITLE
filter makedep_side_effect

### DIFF
--- a/lib/stdlib/src/erl_abstract_code.erl
+++ b/lib/stdlib/src/erl_abstract_code.erl
@@ -22,6 +22,7 @@ delete_reports(Opts) ->
 is_report_option(report) -> true;
 is_report_option(report_errors) -> true;
 is_report_option(report_warnings) -> true;
+is_report_option(makedep_side_effect) -> true;
 is_report_option(_) -> false.
 
 add_core_returns(Opts) ->


### PR DESCRIPTION
Avoid dialyzer (and other) crash when using -MMD -MF dir/file.d options to generate beam file. Otherwise makedep_side_effect is passed to compiler that tries to create dir/file.d out-of context.

