### PR TITLE
Allow "underscore variables" to suppress all warnings

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -711,10 +711,7 @@ expr({call,L,FunExp,As0}, St0) ->
 expr({match,L,P0,E0}, St0) ->
     %% First fold matches together to create aliases.
     {P1,E1} = fold_match(E0, P0),
-    St1 = case P1 of
-	      {var,_,'_'} -> St0#core{wanted=false};
-	      _ -> St0
-	  end,
+    St1 = set_wanted(P1, St0),
     {E2,Eps1,St2} = novars(E1, St1),
     St3 = St2#core{wanted=St0#core.wanted},
     {P2,St4} = try
@@ -830,6 +827,20 @@ expr({op,L,Op,L0,R0}, St0) ->
     {#icall{anno=#a{anno=LineAnno},		%Must have an #a{}
 	    module=#c_literal{anno=LineAnno,val=erlang},
 	    name=#c_literal{anno=LineAnno,val=Op},args=As},Aps,St1}.
+
+%% set_wanted(Pattern, St) -> St'.
+%%  Suppress warnings for expressions that are bound to the '_'
+%%  variable and variables that begin with '_'.
+set_wanted({var,_,'_'}, St) ->
+    St#core{wanted=false};
+set_wanted({var,_,Var}, St) ->
+    case atom_to_list(Var) of
+        "_" ++ _ ->
+            St#core{wanted=false};
+        _ ->
+            St
+    end;
+set_wanted(_, St) -> St.
 
 letify_aliases(#c_alias{var=V,pat=P0}, E0) ->
     {P1,E1,Eps0} = letify_aliases(P0, V),

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -92,9 +92,9 @@ _Height</pre>
     <pre>
 [H|_] = [1,2,3]</pre>
     <p>Variables starting with underscore (_), for example,
-      <c>_Height</c>, are normal variables, not anonymous. They are
-      however ignored by the compiler in the sense that they do not
-      generate any warnings for unused variables.</p>
+      <c>_Height</c>, are normal variables, not anonymous. However,
+      they are ignored by the compiler in the sense that they do not
+      generate warnings.</p>
       <p><em>Example:</em></p>
       <p>The following code:</p>
     <pre>


### PR DESCRIPTION
Compiler warnings for unused variables can be suppressed by prefixing
the variable name with an underscore (`_`). Other kind of warnings
(such as ignoring the result of an expression without side effects)
can only be ignored by assigning (or, strictly speaking, matching) the
result of the expression to the anonymous variable (`_`). This
distinction can be confusing, so this commit teaches the compiler to
suppress all warnings when an expression is assigned to a variable
that begins with an underscore.

Specification
-------------

Consider this function:

    foobar(A, B, C) ->
        {ignore,A},
        element(1, B),
        ok.

There will be three compiler warnings:

    module.erl:4: Warning: variable 'C' is unused
    module.erl:5: Warning: a term is constructed, but never used
    module.erl:6: Warning: the result of the expression is ignored (suppress the warning by assigning the expression to the _ variable)

The warning for the unused variable `C` can be suppressed by prefixing
the name with `_`. However, trying to suppress the other two warnings
this way:

    foobar(A, B, _C) ->
        _ignored_term = {ignore,A},
        _ignored_result = element(1, B),
        ok.

does not work:

module.erl:5: Warning: a term is constructed, but never used
module.erl:6: Warning: the result of the expression is ignored (suppress the warning by assigning the expression to the _ variable)

Currently, the only way to suppress the warnings is to assign the
expressions to the anonymous variable:

    foobar(A, B, _C) ->
        _ = {ignore,A},
        _ = element(1, B),
        ok.

This commit teaches the compiler to suppress all warnings when the
result is assigned to a variable that begins with `_`.

Motivation
----------

It is confusing that a variable beginning with underscore can suppress only some warnings.

The inability to suppress warnings assigned to a term disallows some
legitimate use cases, such as:

    bar(A, B, C) ->
        _Term = {very_complex_term, {A, B, C}},
        %%io:format("~p\n", [_Term]),
        do_something(A, B, C).

Here the intention is that the comment markers before the
`io:format/2` call can be removed during debugging. Currently, there
will be a warning for the line that binds a term to `_Term` (and a
compilation error if `warnings_as_errors` is enabled).

Another example is that the following code (which currently produces a warning):

    _Assertion = map_get(Key, Map)

will raise a `{badkey,Key}` exception which is more informative than
the `{badmatch,false}` exception raised by:

    true = is_map_key(Key, Map)   %Assertion

Backwards Compatibility
-----------------------

Since the compiler with this change will produce fewer warnings than
before, this change is backwards compatible.