### PR TITLE
erlexec: Improve error message when unable to open included args_file

### DIFF
--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -1879,8 +1879,18 @@ read_args_file(char *filename)
 	file = fopen(filename, "r");
     } while (!file && errno == EINTR);
     if (!file) {
-	usage_format("Failed to open arguments file \"%s\": %s\n",
+#ifdef __WIN32__
+        char cwd[MAX_PATH];
+        if (_getcwd(cwd, sizeof(cwd)) == NULL) {
+#else
+        char cwd[PATH_MAX];
+        if (getcwd(cwd, sizeof(cwd)) == NULL) {
+#endif
+            cwd[0] = '\0';
+        }
+	usage_format("Failed to open arguments file \"%s\" at \"%s\": %s\n",
 		     filename,
+             cwd,
 		     errno_string());
     }
 


### PR DESCRIPTION
By specifying `-args_file` in a supplied `vm.args` it is possible to
extend the VM options, the path supplied is relative to the current
working directory. Improve the error message when unable to open such
a file to ease the process.