### PR TITLE
monitor_node/2: Raise 'notalive' instead of 'badarg'

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -4031,7 +4031,7 @@ RealSystem = system + MissedSystem</code>
           If this fails, a <c>nodedown</c> message is delivered.</p>
         <p>Nodes connected through hidden connections can be monitored
           as any other nodes.</p>
-        <p>Failure: <c>badarg</c> if the local node is not alive.</p>
+        <p>Failure: <c>notalive</c> if the local node is not alive.</p>
       </desc>
     </func>
 

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -5801,8 +5801,10 @@ monitor_node(Process* p, Eterm Node, Eterm Bool, Eterm Options)
     if (is_not_atom(Node))
         goto badarg;
 
-    if (erts_this_node->sysname == am_Noname && Node != am_Noname)
-	goto badarg;
+    if (erts_this_node->sysname == am_Noname && Node != am_Noname) {
+        ERTS_BIF_PREP_ERROR(ret, p, EXC_NOTALIVE);
+        goto do_return;
+    }
 
     switch (Bool) {
 


### PR DESCRIPTION
The `monitor_node/2` BIF raises a `badarg` exception when the
node is not alive. This commit changes `monitor_node/2` to
instead raise a `notalive` exception in that situation.

Specification
-------------

Currently, `monitor_node/2` raises a `badarg` exception when
the node is not distributed (not alive):

    1> monitor_node(node@host, true).
    ** exception error: bad argument
         in function  monitor_node/2
            called as monitor_node(node@host,true)

Change that to raise a `notalive` exception:

    1> monitor_node(node@host, true).
    ** exception error: the node cannot be part of a distributed system
         in function  monitor_node/2
            called as monitor_node(node@host,true)
    2> catch monitor_node(node@host, true).
    {'EXIT',{notalive,[{erlang,monitor_node,[node@host,true],[]},
                       {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,684}]},
                       {erl_eval,expr,5,[{file,"erl_eval.erl"},{line,437}]},
                       {shell,exprs,7,[{file,"shell.erl"},{line,686}]},
                       {shell,eval_exprs,7,[{file,"shell.erl"},{line,642}]},
                       {shell,eval_loop,3,[{file,"shell.erl"},{line,627}]}]}}

Motivation
----------

`badarg` is illogical if there is nothing wrong with the arguments. To
avoid confusion, it is better to only raise a `badarg` exception if
the arguments are bad.

Backwards Compatibility
-----------------------

Applications or libraries that catch the exception from
`monitor_nodes/2` and expect the exception reason to always be
`badarg` will need to be updated. However, in practice, there is
probably little or no code that does that. If an application uses
`monitor_node/2`, it probably expects that the distribution is
enabled.