### PR TITLE
Also collapse strings in patterns

### DIFF
--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -87,6 +87,8 @@
 
 -include("core_parse.hrl").
 -include("v3_kernel.hrl").
+
+%% Matches collapse max segment in v3_core.
 -define(EXPAND_MAX_SIZE_SEGMENT, 1024).
 
 %% These are not defined in v3_kernel.hrl.


### PR DESCRIPTION
Prior to this patch, v3_core would expand each
character in a string to an integer. This made
patterns with large strings to become large and
expensive ASTs. For example, this file:

https://gist.github.com/josevalim/694c1799143fcf25e43aa27e3e11e4c1

would grow its representation in more than 10x!

This commit makes it so we squeeze strings into
large integers also when building patterns,
mimicking an optimization that we already did for
strings outside of patterns.

Before this patch:

    expand_records   :  0.077 s   19988.7 kB
    core             :  2.552 s  373294.0 kB
    sys_core_fold    :  0.868 s  370212.9 kB
    sys_core_alias   :  0.237 s  370212.9 kB
    core_transforms  :  0.000 s  370212.9 kB
    sys_core_bsm     :  0.677 s  370212.9 kB
    v3_kernel        :  2.662 s  169439.0 kB

After this patch:

    core             :  0.653 s   72136.4 kB
    sys_core_fold    :  0.482 s   69055.3 kB
    sys_core_alias   :  0.146 s   69055.3 kB
    core_transforms  :  0.000 s   69055.3 kB
    sys_core_bsm     :  0.098 s   69055.3 kB
    v3_kernel        :  2.250 s  169439.0 kB

This commit also changes the maximum collapse size
from 2048 to 1024 in order to mirror the expansion
value in v3_kernel. Making sure that collapses made
in v3_core are expanded in v3_kernel.