### PR TITLE
Expliticly pass in rpo as arguments

### DIFF
--- a/lib/compiler/src/beam_ssa_bsm.erl
+++ b/lib/compiler/src/beam_ssa_bsm.erl
@@ -303,11 +303,12 @@ get_fa(#b_function{ anno = Anno }) ->
                promotions = #{} :: promotion_map() }).
 
 alias_matched_binaries(Blocks0, Counter, AliasMap) when AliasMap =/= #{} ->
-    {Dominators, _} = beam_ssa:dominators(Blocks0),
+    RPO = beam_ssa:rpo(Blocks0),
+    {Dominators, _} = beam_ssa:dominators(RPO, Blocks0),
     State0 = #amb{ dominators = Dominators,
                    match_aliases = AliasMap,
                    cnt = Counter },
-    {Blocks, State} = beam_ssa:mapfold_blocks_rpo(fun amb_1/3, [0], State0,
+    {Blocks, State} = beam_ssa:mapfold_blocks(fun amb_1/3, RPO, State0,
                                                   Blocks0),
     {amb_insert_promotions(Blocks, State), State#amb.cnt};
 alias_matched_binaries(Blocks, Counter, _AliasMap) ->
@@ -449,13 +450,15 @@ combine_matches({Fs0, ModInfo}) ->
 combine_matches(#b_function{bs=Blocks0,cnt=Counter0}=F, ModInfo) ->
     case funcinfo_get(F, has_bsm_ops, ModInfo) of
         true ->
-            {Dominators, _} = beam_ssa:dominators(Blocks0),
+            RPO = beam_ssa:rpo(Blocks0),
+            {Dominators, _} = beam_ssa:dominators(RPO, Blocks0),
             {Blocks1, State} =
-                beam_ssa:mapfold_blocks_rpo(
+                beam_ssa:mapfold_blocks(
                   fun(Lbl, #b_blk{is=Is0}=Block0, State0) ->
                           {Is, State} = cm_1(Is0, [], Lbl, State0),
                           {Block0#b_blk{is=Is}, State}
-                  end, [0],
+                  end,
+                  RPO,
                   #cm{ definitions = beam_ssa:definitions(Blocks0),
                        dominators = Dominators,
                        blocks = Blocks0 },
@@ -669,7 +672,8 @@ aca_handle_convergence(Src, State0, Last0, Blocks0) ->
                        ordsets:from_list(SuccPath),
                        ordsets:from_list(FailPath)),
 
-    case maps:is_key(Src, beam_ssa:uses(ConvergedPaths, Blocks0)) of
+    ConvergedLabels = beam_ssa:rpo(ConvergedPaths, Blocks0),
+    case maps:is_key(Src, beam_ssa:uses(ConvergedLabels, Blocks0)) of
         true ->
             case shortest(SuccPath, FailPath) of
                 left ->
@@ -792,7 +796,7 @@ aca_cs_arg(Arg, VRs) ->
 %% contexts to us.
 
 allow_context_passthrough({Fs, ModInfo0}) ->
-    FsUses = [{F, beam_ssa:uses(F#b_function.bs)} || F <- Fs],
+    FsUses = [{F, beam_ssa:uses(beam_ssa:rpo(Bs), Bs)} || #b_function{bs=Bs}=F <- Fs],
     ModInfo = acp_forward_params(FsUses, ModInfo0),
     {Fs, ModInfo}.
 
@@ -851,8 +855,9 @@ skip_outgoing_tail_extraction(#b_function{bs=Blocks0}=F, ModInfo) ->
             State0 = #sote{ definitions = beam_ssa:definitions(Blocks0),
                             mod_info = ModInfo },
 
-            {Blocks1, State} = beam_ssa:mapfold_instrs_rpo(
-                                 fun sote_rewrite_calls/2, [0], State0, Blocks0),
+            RPO = beam_ssa:rpo(Blocks0),
+            {Blocks1, State} = beam_ssa:mapfold_instrs(
+                                 fun sote_rewrite_calls/2, RPO, State0, Blocks0),
 
             {Blocks, Counter} = alias_matched_binaries(Blocks1,
                                                        F#b_function.cnt,
@@ -918,12 +923,13 @@ annotate_context_parameters(F, ModInfo) ->
 
 collect_opt_info(Fs) ->
     foldl(fun(#b_function{bs=Blocks}=F, Acc0) ->
-                  UseMap = beam_ssa:uses(Blocks),
+                  RPO = beam_ssa:rpo(Blocks),
+                  UseMap = beam_ssa:uses(RPO, Blocks),
                   Where = beam_ssa:get_anno(location, F, []),
-                  beam_ssa:fold_instrs_rpo(
+                  beam_ssa:fold_instrs(
                     fun(I, Acc) ->
                             collect_opt_info_1(I, Where, UseMap, Acc)
-                    end, [0], Acc0, Blocks)
+                    end, RPO, Acc0, Blocks)
           end, [], Fs).
 
 collect_opt_info_1(#b_set{op=Op,anno=Anno,dst=Dst}=I, Where, UseMap, Acc0) ->

--- a/lib/compiler/src/beam_ssa_recv.erl
+++ b/lib/compiler/src/beam_ssa_recv.erl
@@ -191,7 +191,8 @@ ref_in_tuple(Tuple, Blocks) ->
               when Tup =:= Tuple -> {yes,Ref};
            (_, A) -> A
         end,
-    beam_ssa:fold_instrs_rpo(F, [0], no, Blocks).
+    RPO = beam_ssa:rpo(Blocks),
+    beam_ssa:fold_instrs(F, RPO, no, Blocks).
 
 opt_ref_used(L, Ref, Blocks) ->
     Vs = #{Ref=>ref,ref=>Ref,ref_matched=>false},


### PR DESCRIPTION
Many functions in beam_ssa would receive labels
and compute the rpo from labels. This lead to
multiple calls to rpo which can be inefficient
in some scenarios.

This commit changes these functions to receive
the rpo as argument and shares them in the most
trivial cases found so far.

beam_ssa:fold_po/2 was removed as it is not used
anywhere. The remaining functions will be converted
in another PR.