### PR TITLE
Add rendering config to shell_docs

### DIFF
--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -779,8 +779,8 @@ rpc:call(Node, code, load_binary, [Module, Filename, Binary]),
           <c>{error,missing}</c>.
         </p>
         <p>For more information about the documentation chunk see
-          <seeguide marker="erl_docgen:doc_storage">Documentation Storage</seeguide>
-          in Erl_Docgen's User's Guide.</p>
+          <seeguide marker="kernel:eep48_chapter">Documentation Storage and Format</seeguide>
+          in Kernel's User's Guide.</p>
       </desc>
     </func>
     <func>

--- a/lib/kernel/doc/src/eep48_chapter.xml
+++ b/lib/kernel/doc/src/eep48_chapter.xml
@@ -38,6 +38,9 @@
   <p>To fetch the EEP-48 documentation for a module you can use
     <seemfa marker="code#get_doc/1"><c>code:get_doc/1</c></seemfa>.</p>
 
+  <p>To render the EEP-48 documentation for an Erlang module you can use
+    <seemfa marker="stdlib:shell_docs#render/2"><c>shell_docs:render/2</c></seemfa>.</p>
+
   <section>
     <title>the "Docs" storage</title>
     <p>To look for documentation for a module name example, a tool should:</p>

--- a/lib/stdlib/doc/src/shell_docs.xml
+++ b/lib/stdlib/doc/src/shell_docs.xml
@@ -46,6 +46,44 @@
   <datatypes>
     <datatype>
       <name name="docs_v1"/>
+      <desc>
+        <p>
+          The record holding EEP-48 documentation for a module.
+          You can use <seemfa marker="kernel:code#get_doc/1">code:get_doc/1</seemfa>
+          to fetch this information from a module.
+        </p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="config"/>
+      <desc>
+        <p>
+          The configuration of how the documentation should be rendered.
+        </p>
+        <taglist>
+          <tag>encoding</tag>
+          <item>
+            Configure the encoding that should be used by
+            the renderer for graphical details such as bullet-points.
+            By default <c>shell_docs</c> uses the value returned
+          by <seemfa marker="io#getopts/0"><c>io:getopts()</c></seemfa>.</item>
+          <tag>ansi</tag>
+          <item>
+            Configure whether <url href="https://en.wikipedia.org/wiki/ANSI_escape_code">
+            ansi escape codes</url> should be used to
+            render graphical details such as bold and underscore. By default
+            <c>shell_docs</c> will try to determine if the receiving shell
+            supports ansi escape codes. It is possible to override
+            the automated check by setting the kernel configuration parameter
+          <c>shell_docs_ansi</c> to a <c>boolean()</c> value.</item>
+          <tag>columns</tag>
+          <item>
+            Configure how wide the target documentation should be rendered.
+            By default <c>shell_docs</c> used the value returned by
+            <seemfa marker="io#columns/0"><c>io:columns()</c></seemfa>.
+          </item>
+        </taglist>
+      </desc>
     </datatype>
     <datatype>
       <name name="chunk_element_block_type"/>
@@ -71,29 +109,23 @@
 
     <func>
       <name name="render" arity="2" since="OTP 23.0"/>
-      <fsummary>Render the documentation for a module.</fsummary>
+      <name name="render" arity="3" clause_i="1" since="@OTP-16990@"/>
+      <name name="render" arity="3" clause_i="2" since="OTP 23.0"/>
+      <name name="render" arity="4" clause_i="1" since="@OTP-16990@"/>
+      <name name="render" arity="4" clause_i="2" since="OTP 23.0"/>
+      <name name="render" arity="5" since="@OTP-16990@"/>
+      <fsummary>Render the documentation for a module or function.</fsummary>
       <desc>
-        <p>Render the documentation for a module.</p>
-      </desc>
-    </func>
-    <func>
-      <name name="render" arity="3" since="OTP 23.0"/>
-      <name name="render" arity="4" since="OTP 23.0"/>
-      <fsummary>Render the documentation for a function.</fsummary>
-      <desc>
-        <p>Render the documentation for a function.</p>
+        <p>Render the documentation for a module or function.</p>
       </desc>
     </func>
     <func>
       <name name="render_type" arity="2" since="OTP 23.0"/>
-      <fsummary>Render a list of all available types in a module.</fsummary>
-      <desc>
-        <p>Render a list of all available types in a module.</p>
-      </desc>
-    </func>
-    <func>
-      <name name="render_type" arity="3" since="OTP 23.0"/>
-      <name name="render_type" arity="4" since="OTP 23.0"/>
+      <name name="render_type" arity="3" clause_i="1" since="@OTP-16990@"/>
+      <name name="render_type" arity="3" clause_i="2" since="OTP 23.0"/>
+      <name name="render_type" arity="4" clause_i="1" since="@OTP-16990@"/>
+      <name name="render_type" arity="4" clause_i="2" since="OTP 23.0"/>
+      <name name="render_type" arity="5" since="@OTP-16990@"/>
       <fsummary>Render the documentation of a type in a module.</fsummary>
       <desc>
         <p>Render the documentation of a type in a module.</p>
@@ -101,14 +133,11 @@
     </func>
     <func>
       <name name="render_callback" arity="2" since="OTP 23.0"/>
-      <fsummary>Render a list of all available callbacks in a module.</fsummary>
-      <desc>
-        <p>Render a list of all available callbacks in a module.</p>
-      </desc>
-    </func>
-    <func>
-      <name name="render_callback" arity="3" since="OTP 23.0"/>
-      <name name="render_callback" arity="4" since="OTP 23.0"/>
+      <name name="render_callback" arity="3" clause_i="1" since="@OTP-16990@"/>
+      <name name="render_callback" arity="3" clause_i="2" since="OTP 23.0"/>
+      <name name="render_callback" arity="4" clause_i="1" since="@OTP-16990@"/>
+      <name name="render_callback" arity="4" clause_i="2" since="OTP 23.0"/>
+      <name name="render_callback" arity="5" since="@OTP-16990@"/>
       <fsummary>Render the documentation of a callback in a module.</fsummary>
       <desc>
         <p>Render the documentation of a callback in a module.</p>

--- a/lib/stdlib/test/shell_docs_SUITE.erl
+++ b/lib/stdlib/test/shell_docs_SUITE.erl
@@ -60,35 +60,44 @@ end_per_group(_GroupName, Config) ->
 render(_Config) ->
     docsmap(
       fun(Mod, #docs_v1{ docs = Docs } = D) ->
-              try
-                  shell_docs:render(Mod, D),
-                  shell_docs:render_type(Mod, D),
-                  shell_docs:render_callback(Mod, D),
-                  [try
-                       shell_docs:render(Mod, F, A, D)
-                   catch _E:R:ST ->
-                           io:format("Failed to render ~p:~p/~p~n~p:~p~n~p~n",
-                                     [Mod,F,A,R,ST,shell_docs:get_doc(Mod,F,A)]),
-                           erlang:raise(error,R,ST)
-                   end || {F,A} <- Mod:module_info(exports)],
-                  [try
-                       shell_docs:render_type(Mod, T, A, D)
-                   catch _E:R:ST ->
-                           io:format("Failed to render type ~p:~p/~p~n~p:~p~n~p~n",
-                                     [Mod,T,A,R,ST,shell_docs:get_type_doc(Mod,T,A)]),
-                           erlang:raise(error,R,ST)
-                   end || {{type,T,A},_,_,_,_} <- Docs],
-                  [try
-                       shell_docs:render_callback(Mod, T, A, D)
-                   catch _E:R:ST ->
-                           io:format("Failed to render callback ~p:~p/~p~n~p:~p~n~p~n",
-                                     [Mod,T,A,R,ST,shell_docs:get_callback_doc(Mod,T,A)]),
-                           erlang:raise(error,R,ST)
-                   end || {{callback,T,A},_,_,_,_} <- Docs]
-              catch throw:R:ST ->
-                      io:format("Failed to render ~p~n~p:~p~n",[Mod,R,ST]),
-                      exit(R)
-              end
+              lists:foreach(
+                fun(Config) ->
+                        try
+                            shell_docs:render(Mod, D, Config),
+                            shell_docs:render_type(Mod, D, Config),
+                            shell_docs:render_callback(Mod, D, Config),
+                            [try
+                                 shell_docs:render(Mod, F, A, D, Config)
+                             catch _E:R:ST ->
+                                     io:format("Failed to render ~p:~p/~p~n~p:~p~n~p~n",
+                                               [Mod,F,A,R,ST,shell_docs:get_doc(Mod,F,A)]),
+                                     erlang:raise(error,R,ST)
+                             end || {F,A} <- Mod:module_info(exports)],
+                            [try
+                                 shell_docs:render_type(Mod, T, A, D, Config)
+                             catch _E:R:ST ->
+                                     io:format("Failed to render type ~p:~p/~p~n~p:~p~n~p~n",
+                                               [Mod,T,A,R,ST,shell_docs:get_type_doc(Mod,T,A)]),
+                                     erlang:raise(error,R,ST)
+                             end || {{type,T,A},_,_,_,_} <- Docs],
+                            [try
+                                 shell_docs:render_callback(Mod, T, A, D, Config)
+                             catch _E:R:ST ->
+                                     io:format("Failed to render callback ~p:~p/~p~n~p:~p~n~p~n",
+                                               [Mod,T,A,R,ST,shell_docs:get_callback_doc(Mod,T,A)]),
+                                     erlang:raise(error,R,ST)
+                             end || {{callback,T,A},_,_,_,_} <- Docs]
+                        catch throw:R:ST ->
+                                io:format("Failed to render ~p~n~p:~p~n",[Mod,R,ST]),
+                                exit(R)
+                        end
+                end, [#{},
+                      #{ ansi => false },
+                      #{ ansi => true },
+                      #{ columns => 5 },
+                      #{ columns => 150 },
+                      #{ encoding => unicode},
+                      #{ encoding => latin1}])
       end),
     ok.
 


### PR DESCRIPTION
In order to render documentation without the presence of a correctly configured I/O group_leader we have to be able to configure how the shell docs should be rendered.

This problem was reported in https://github.com/erlang-ls/erlang_ls/issues/754