### PR TITLE
Explicit pass RPO to beam_ssa functions (cont)

### DIFF
--- a/lib/compiler/src/beam_ssa_bool.erl
+++ b/lib/compiler/src/beam_ssa_bool.erl
@@ -160,7 +160,7 @@ opt_function(#b_function{bs=Blocks0,cnt=Count0}=F) ->
             %% To ensure that, trim before merging.
 
             Blocks3 = beam_ssa:trim_unreachable(Blocks2),
-            Blocks = beam_ssa:merge_blocks(Blocks3),
+            Blocks = beam_ssa:merge_blocks(beam_ssa:rpo(Blocks3), Blocks3),
             F#b_function{bs=Blocks,cnt=Count};
         true ->
             %% There are no boolean operators that can be optimized in
@@ -1504,7 +1504,7 @@ join_inits_1([], VarMap) ->
 %%%
 %%% We don't try merge blocks during the conversion because it would
 %%% be difficult to keep phi nodes up to date. We will call
-%%% beam_ssa:merge_blocks/1 before returning from this pass to do all
+%%% beam_ssa:merge_blocks/2 before returning from this pass to do all
 %%% block merging.
 %%%
 

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -454,7 +454,8 @@ ssa_opt_trim_unreachable({#opt_st{ssa=Blocks}=St, FuncDb}) ->
     {St#opt_st{ssa=beam_ssa:trim_unreachable(Blocks)}, FuncDb}.
 
 ssa_opt_merge_blocks({#opt_st{ssa=Blocks0}=St, FuncDb}) ->
-    Blocks = beam_ssa:merge_blocks(Blocks0),
+    RPO = beam_ssa:rpo(Blocks0),
+    Blocks = beam_ssa:merge_blocks(RPO, Blocks0),
     {St#opt_st{ssa=Blocks}, FuncDb}.
 
 %%%
@@ -474,7 +475,8 @@ ssa_opt_split_blocks({#opt_st{ssa=Blocks0,cnt=Count0}=St, FuncDb}) ->
            (#b_set{op=old_make_fun}) -> true;
            (_) -> false
         end,
-    {Blocks,Count} = beam_ssa:split_blocks(P, Blocks0, Count0),
+    RPO = beam_ssa:rpo(Blocks0),
+    {Blocks,Count} = beam_ssa:split_blocks(RPO, P, Blocks0, Count0),
     {St#opt_st{ssa=Blocks,cnt=Count}, FuncDb}.
 
 %%%


### PR DESCRIPTION
This patch finishes the work started on 0ce3fb91
by explicitly passing RPO to the remaining functions
in beam_ssa. This commit avoids the double RPO
computation in 4 other occasions.