### PR TITLE
Reset inet_db timer even if file is up to date

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -1214,6 +1214,8 @@ handle_set_file(ParseFun, File, Bin, From, State) ->
 
 handle_update_file(
   Finfo, File, TagTm, TagInfo, ParseFun, From, #state{db = Db} = State) ->
+    ets:insert(Db, {TagTm, times()}),
+
     %%
     %% Update file content if file has been updated
     %%
@@ -1224,7 +1226,6 @@ handle_update_file(
         {ok, Finfo_1} ->
             %% File updated - read content
             ets:insert(Db, {TagInfo, Finfo_1}),
-            ets:insert(Db, {TagTm, times()}),
             Bin =
                 case erl_prim_loader:get_file(File) of
                     {ok, B, _} -> B;
@@ -1234,7 +1235,6 @@ handle_update_file(
         _ ->
             %% No file - clear content and reset monitor
             ets:insert(Db, {TagInfo, undefined}),
-            ets:insert(Db, {TagTm, times()}),
             handle_set_file(ParseFun, File, <<>>, From, State)
     end.
 


### PR DESCRIPTION
Prior to this patch, if 5 seconds passed and
the resolv_conf or hosts_file were up to date,
we would continue to check for the file update
on every inet_res or inet_hosts operation.

This PR makes sure that the timer is updated
even if the file is up to date, so we check
again only in the next 5 seconds.

This addresses a performance regression on
inet_res which would lookup every 5 seconds
on Erlang/OTP 22 but performs it on every
request after 5 seconds on Erlang/OTP 23.