### PR TITLE
Add queue:all/2, queue:any/2, queue:delete/2, and queue:delete_r/2

### DIFF
--- a/lib/stdlib/doc/src/queue.xml
+++ b/lib/stdlib/doc/src/queue.xml
@@ -53,6 +53,8 @@
       assuming knowledge of the format is running on thin ice.</p>
 
     <p>All operations have an amortized O(1) running time, except
+      <seemfa marker="#all/2"><c>all/2</c></seemfa>,
+      <seemfa marker="#any/2"><c>any/2</c></seemfa>,
       <seemfa marker="#filter/2"><c>filter/2</c></seemfa>,
       <seemfa marker="#filtermap/2"><c>filtermap/2</c></seemfa>,
       <seemfa marker="#fold/3"><c>fold/3</c></seemfa>,
@@ -115,6 +117,28 @@
     <fsdescription>
       <title>Original API</title>
     </fsdescription>
+    <func>
+      <name name="all" arity="2" since=""/>
+      <fsummary>Return <c>true</c> if all items in a queue satisfy
+        <c>Pred</c>.</fsummary>
+      <desc>
+        <p>Returns <c>true</c> if <c><anno>Pred</anno>(<anno>Item</anno>)</c>
+          returns <c>true</c> for all items <c><anno>Item</anno></c> in
+          <c><anno>Q</anno></c>, otherwise <c>false</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="any" arity="2" since=""/>
+      <fsummary>Return <c>true</c> if any of the items in a queue satisfy
+        <c>Pred</c>.</fsummary>
+      <desc>
+        <p>Returns <c>true</c> if <c><anno>Pred</anno>(<anno>Item</anno>)</c>
+          returns <c>true</c> for at least one item <c><anno>Item</anno></c>
+          in <c><anno>Q</anno></c>, otherwise <c>false</c>.</p>
+      </desc>
+    </func>
+
     <func>
       <name name="filter" arity="2" since=""/>
       <fsummary>Filter a queue.</fsummary>

--- a/lib/stdlib/doc/src/queue.xml
+++ b/lib/stdlib/doc/src/queue.xml
@@ -57,6 +57,8 @@
       <seemfa marker="#any/2"><c>any/2</c></seemfa>,
       <seemfa marker="#delete/2"><c>delete/2</c></seemfa>,
       <seemfa marker="#delete_r/2"><c>delete_r/2</c></seemfa>,
+      <seemfa marker="#delete_with/2"><c>delete_with/2</c></seemfa>,
+      <seemfa marker="#delete_with_r/2"><c>delete_with_r/2</c></seemfa>,
       <seemfa marker="#filter/2"><c>filter/2</c></seemfa>,
       <seemfa marker="#filtermap/2"><c>filtermap/2</c></seemfa>,
       <seemfa marker="#fold/3"><c>fold/3</c></seemfa>,
@@ -147,7 +149,7 @@
       <desc>
         <p>Returns a copy of <c><anno>Q1</anno></c> where the first item
           matching <c><anno>Item</anno></c> is deleted, if there is such an
-          element.</p>
+          item.</p>
       </desc>
     </func>
 
@@ -157,7 +159,29 @@
       <desc>
         <p>Returns a copy of <c><anno>Q1</anno></c> where the last item
           matching <c><anno>Item</anno></c> is deleted, if there is such an
-          element.</p>
+          item.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="delete_with" arity="2" since=""/>
+      <fsummary>Delete an item matching a predicate from the front of a
+        queue.</fsummary>
+      <desc>
+        <p>Returns a copy of <c><anno>Q1</anno></c> where the first item
+          for which <c><anno>Pred</anno></c> returns <c>true</c> is deleted,
+          if there is such an item.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="delete_with_r" arity="2" since=""/>
+      <fsummary>Delete an item matching a predicate from the rear of a
+        queue.</fsummary>
+      <desc>
+        <p>Returns a copy of <c><anno>Q1</anno></c> where the last item
+          for which <c><anno>Pred</anno></c> returns <c>true</c> is deleted,
+          if there is such an item.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/queue.xml
+++ b/lib/stdlib/doc/src/queue.xml
@@ -188,7 +188,7 @@
       <desc>
         <p>Returns a queue <c><anno>Q2</anno></c> that is the result of calling
           <c><anno>Fun</anno>(<anno>Item</anno>)</c> on all items in
-          <c><anno>Q1</anno></c>, in order from front to rear.</p>
+          <c><anno>Q1</anno></c>.</p>
         <p>If <c><anno>Fun</anno>(<anno>Item</anno>)</c> returns <c>true</c>,
           <c>Item</c> is copied to the result queue. If it returns <c>false</c>,
           <c><anno>Item</anno></c> is not copied. If it returns

--- a/lib/stdlib/doc/src/queue.xml
+++ b/lib/stdlib/doc/src/queue.xml
@@ -55,6 +55,8 @@
     <p>All operations have an amortized O(1) running time, except
       <seemfa marker="#all/2"><c>all/2</c></seemfa>,
       <seemfa marker="#any/2"><c>any/2</c></seemfa>,
+      <seemfa marker="#delete/2"><c>delete/2</c></seemfa>,
+      <seemfa marker="#delete_r/2"><c>delete_r/2</c></seemfa>,
       <seemfa marker="#filter/2"><c>filter/2</c></seemfa>,
       <seemfa marker="#filtermap/2"><c>filtermap/2</c></seemfa>,
       <seemfa marker="#fold/3"><c>fold/3</c></seemfa>,
@@ -136,6 +138,26 @@
         <p>Returns <c>true</c> if <c><anno>Pred</anno>(<anno>Item</anno>)</c>
           returns <c>true</c> for at least one item <c><anno>Item</anno></c>
           in <c><anno>Q</anno></c>, otherwise <c>false</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="delete" arity="2" since=""/>
+      <fsummary>Delete an item from the front of a queue.</fsummary>
+      <desc>
+        <p>Returns a copy of <c><anno>Q1</anno></c> where the first item
+          matching <c><anno>Item</anno></c> is deleted, if there is such an
+          element.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="delete_r" arity="2" since=""/>
+      <fsummary>Delete an item from the rear of a queue.</fsummary>
+      <desc>
+        <p>Returns a copy of <c><anno>Q1</anno></c> where the last item
+          matching <c><anno>Item</anno></c> is deleted, if there is such an
+          element.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/queue.xml
+++ b/lib/stdlib/doc/src/queue.xml
@@ -167,7 +167,7 @@
       <desc>
         <p>Returns a queue <c><anno>Q2</anno></c> that is the result of calling
           <c><anno>Fun</anno>(<anno>Item</anno>)</c> on all items in
-          <c><anno>Q1</anno></c>, in order from front to rear.</p>
+          <c><anno>Q1</anno></c>.</p>
         <p>If <c><anno>Fun</anno>(<anno>Item</anno>)</c> returns <c>true</c>,
           <c>Item</c> is copied to the result queue. If it returns <c>false</c>,
           <c><anno>Item</anno></c> is not copied. If it returns a list,

--- a/lib/stdlib/src/queue.erl
+++ b/lib/stdlib/src/queue.erl
@@ -27,7 +27,7 @@
 -export([get/1,get_r/1,peek/1,peek_r/1,drop/1,drop_r/1]).
 
 %% Higher level API
--export([reverse/1,join/2,split/2,filter/2,filtermap/2,fold/3]).
+-export([reverse/1,join/2,split/2,filter/2,filtermap/2,fold/3,any/2,all/2]).
 
 %% Okasaki API from klacke
 -export([cons/2,head/1,tail/1,
@@ -452,6 +452,28 @@ fold(Fun, Acc0, {R, F}) when is_function(Fun, 2), is_list(R), is_list(F) ->
     lists:foldr(Fun, Acc1, R);
 fold(Fun, Acc0, Q) ->
     erlang:error(badarg, [Fun, Acc0, Q]).
+
+%% Check if any item satisfies the predicate, traverse in queue order.
+%%
+%% O(len(Q)) worst case
+-spec any(Pred, Q :: queue(Item)) -> boolean() when
+      Pred :: fun((Item) -> boolean()).
+any(Pred, {R, F}) when is_function(Pred, 1), is_list(R), is_list(F) ->
+    lists:any(Pred, F) orelse
+    lists:any(Pred, R);
+any(Pred, Q) ->
+    erlang:error(badarg, [Pred, Q]).
+
+%% Check if all items satisfy the predicate, traverse in queue order.
+%%
+%% O(len(Q)) worst case
+-spec all(Pred, Q :: queue(Item)) -> boolean() when
+      Pred :: fun((Item) -> boolean()).
+all(Pred, {R, F}) when is_function(Pred, 1), is_list(R), is_list(F) ->
+    lists:all(Pred, F) andalso
+    lists:all(Pred, R);
+all(Pred, Q) ->
+    erlang:error(badarg, [Pred, Q]).
 
 %%--------------------------------------------------------------------------
 %% Okasaki API inspired by an Erlang user contribution "deque.erl" 

--- a/lib/stdlib/test/queue_SUITE.erl
+++ b/lib/stdlib/test/queue_SUITE.erl
@@ -400,6 +400,18 @@ do_op_test(F) ->
     false = queue:all(fun(X) -> X>1 end, AllQ),
     true = queue:all(fun(X) -> X=<3 end, AllQ),
     false = queue:all(fun(X) -> X<3 end, AllQ),
+    [] = queue:to_list(queue:delete(x, queue:new())),
+    [1,2,3] = queue:to_list(queue:delete(x, queue:from_list([1,2,3]))),
+    [2,3] = queue:to_list(queue:delete(x, queue:from_list([x,2,3]))),
+    [1,3] = queue:to_list(queue:delete(x, queue:from_list([1,x,3]))),
+    [1,2] = queue:to_list(queue:delete(x, queue:from_list([1,2,x]))),
+    [1,2,x] = queue:to_list(queue:delete(x, queue:from_list([x,1,2,x]))),
+    [] = queue:to_list(queue:delete_r(x, queue:new())),
+    [1,2,3] = queue:to_list(queue:delete_r(x, queue:from_list([1,2,3]))),
+    [2,3] = queue:to_list(queue:delete_r(x, queue:from_list([x,2,3]))),
+    [1,3] = queue:to_list(queue:delete_r(x, queue:from_list([1,x,3]))),
+    [1,2] = queue:to_list(queue:delete_r(x, queue:from_list([1,2,x]))),
+    [x,1,2] = queue:to_list(queue:delete_r(x, queue:from_list([x,1,2,x]))),
     %%
     ok.
 

--- a/lib/stdlib/test/queue_SUITE.erl
+++ b/lib/stdlib/test/queue_SUITE.erl
@@ -412,6 +412,18 @@ do_op_test(F) ->
     [1,3] = queue:to_list(queue:delete_r(x, queue:from_list([1,x,3]))),
     [1,2] = queue:to_list(queue:delete_r(x, queue:from_list([1,2,x]))),
     [x,1,2] = queue:to_list(queue:delete_r(x, queue:from_list([x,1,2,x]))),
+    [] = queue:to_list(queue:delete_with(fun(_) -> false end, queue:new())),
+    [1,2,3] = queue:to_list(queue:delete_with(fun(X) -> X<0 end, queue:from_list([1,2,3]))),
+    [2,3] = queue:to_list(queue:delete_with(fun(X) -> X>0 end, queue:from_list([1,2,3]))),
+    [1,3] = queue:to_list(queue:delete_with(fun(X) -> X>1 end, queue:from_list([1,2,3]))),
+    [1,2] = queue:to_list(queue:delete_with(fun(X) -> X>2 end, queue:from_list([1,2,3]))),
+    [1,2,3] = queue:to_list(queue:delete_with(fun(X) -> X>1 end, queue:from_list([1,2,2,3]))),
+    [] = queue:to_list(queue:delete_with_r(fun(_) -> false end, queue:new())),
+    [1,2,3] = queue:to_list(queue:delete_with_r(fun(X) -> X>9 end, queue:from_list([1,2,3]))),
+    [1,2] = queue:to_list(queue:delete_with_r(fun(X) -> X<9 end, queue:from_list([1,2,3]))),
+    [1,3] = queue:to_list(queue:delete_with_r(fun(X) -> X<3 end, queue:from_list([1,2,3]))),
+    [2,3] = queue:to_list(queue:delete_with_r(fun(X) -> X<2 end, queue:from_list([1,2,3]))),
+    [1,2,3] = queue:to_list(queue:delete_with_r(fun(X) -> X<3 end, queue:from_list([1,2,2,3]))),
     %%
     ok.
 

--- a/lib/stdlib/test/queue_SUITE.erl
+++ b/lib/stdlib/test/queue_SUITE.erl
@@ -388,6 +388,18 @@ do_op_test(F) ->
     FoldExp2 = [X*X || X <- L1],
     FoldAct2 = queue:fold(fun(X,A) -> [X*X|A] end, [], FoldQ),
     FoldExp2 = lists:reverse(FoldAct2),
+    false = queue:any(fun(X) -> X>9 end, queue:from_list([])),
+    AnyQ = queue:from_list([1,2,3]),
+    true = queue:any(fun(X) -> X>1 end, AnyQ),
+    false = queue:any(fun(X) -> X<1 end, AnyQ),
+    true = queue:any(fun(X) -> X<3 end, AnyQ),
+    false = queue:any(fun(X) -> X>3 end, AnyQ),
+    true = queue:all(fun(X) -> X>9 end, queue:from_list([])),
+    AllQ = queue:from_list([1,2,3]),
+    true = queue:all(fun(X) -> X>=1 end, AllQ),
+    false = queue:all(fun(X) -> X>1 end, AllQ),
+    true = queue:all(fun(X) -> X=<3 end, AllQ),
+    false = queue:all(fun(X) -> X<3 end, AllQ),
     %%
     ok.
 


### PR DESCRIPTION
This PR is a follow-up to #2791 which adds 4 new functions to the `queue` module. The new functions perform the same tasks as their counterparts in the `lists` module, but avoid the need to convert queues to lists first, which is both inconvenient and inefficient.

* `queue:all/2`: like `lists:all/2`, checks if all items in a queue satisfy a predicate; processed in queue order to retain the order of side effects of the predicate function
* `any/2`: like `lists:any/2`, checks if at least one item in a queue satisfies a predicate; procesed in queue order to retain the order of side effects of the predicate function
* `delete/2`: like `lists:delete/2`, removes the _first_ occurence of an item from a queue, according to queue order
* `delete_r/2`: there is no counterpart for this in the `lists` module, but I believe this function is still handy in a queue context; it removes the _last_ occurence of an item from a queue, according to queue order; the naming `..._r` has been chosen to follow the naming convention of other "from the rear" functions of the module, namely `in_r` and `out_r`

In #2791, @okeuday requested another function that removes the first/last item from a queue matching a predicate. Suggested naming was `remove/2`, IIRC. While this may be handy and could be added to this PR, I'm not sure what the consensus was, as such a function is not present in the `lists` module. What do you think?