### PR TITLE
erts: Fix exception handling during tracing

### DIFF
--- a/erts/emulator/beam/beam_emu.c
+++ b/erts/emulator/beam/beam_emu.c
@@ -1425,32 +1425,22 @@ next_catch(Process* c_p, Eterm *reg) {
 	else if (is_CP(*ptr)) {
 	    prev = ptr;
 	    if (*cp_val(*prev) == i_return_trace) {
-		/* Skip stack frame variables */
-		while (++ptr, ptr < STACK_START(c_p) && is_not_CP(*ptr)) {
-		    if (is_catch(*ptr) && active_catches) goto found_catch;
-		}
 		if (cp_val(*prev) == beam_exception_trace) {
-                    ErtsCodeMFA *mfa = (ErtsCodeMFA*)cp_val(ptr[0]);
+                    ErtsCodeMFA *mfa = (ErtsCodeMFA*)cp_val(ptr[1]);
 		    erts_trace_exception(c_p, mfa,
 					 reg[1], reg[2],
-                                         ERTS_TRACER_FROM_ETERM(ptr+1));
+                                         ERTS_TRACER_FROM_ETERM(ptr+2));
 		}
-		/* Skip return_trace parameters */
-		ptr += 2;
+		/* Skip MFA, tracer, and CP. */
+		ptr += 3;
 	    } else if (*cp_val(*prev) == i_return_to_trace) {
-		/* Skip stack frame variables */
-		while (++ptr, ptr < STACK_START(c_p) && is_not_CP(*ptr)) {
-		    if (is_catch(*ptr) && active_catches) goto found_catch;
-		}
 		have_return_to_trace = !0; /* Record next cp */
 		return_to_trace_ptr = NULL;
-	    } else if (*cp_val(*prev) == i_return_time_trace) {
-		/* Skip stack frame variables */
-		while (++ptr, ptr < STACK_START(c_p) && is_not_CP(*ptr)) {
-		    if (is_catch(*ptr) && active_catches) goto found_catch;
-		}
-		/* Skip return_trace parameters */
+		/* Skip CP. */
 		ptr += 1;
+	    } else if (*cp_val(*prev) == i_return_time_trace) {
+		/* Skip prev_info and CP. */
+		ptr += 2;
 	    } else {
 		if (have_return_to_trace) {
 		    /* Record this cp as possible return_to trace cp */

--- a/erts/emulator/test/trace_call_time_SUITE.erl
+++ b/erts/emulator/test/trace_call_time_SUITE.erl
@@ -35,7 +35,7 @@
 
 -export([seq/3, seq_r/3]).
 -export([loaded/1, a_function/1, a_called_function/1, dec/1, nif_dec/1, dead_tracer/1,
-        return_stop/1]).
+        return_stop/1,catch_crash/1]).
 
 -define(US_ERROR, 10000).
 -define(R_ERROR, 0.8).
@@ -91,7 +91,8 @@ all() ->
 	false ->
 	    [basic, on_and_off, info, pause_and_restart, scheduling,
              disable_ongoing,
-	     combo, bif, nif, called_function, dead_tracer, return_stop]
+	     combo, bif, nif, called_function, dead_tracer, return_stop,
+             catch_crash]
     end.
 
 not_run(Config) when is_list(Config) ->
@@ -634,6 +635,25 @@ spinner(N) ->
 quicky() ->
     done.
 
+%% OTP-16994: next_catch returned a bogus stack pointer when call_time tracing
+%% was enabled, crashing the emulator.
+catch_crash(_Config) ->
+    Fun = id(fun() -> catch_crash_1() end),
+
+    _ = erlang:trace_pattern({?MODULE,'_','_'}, true, [call_time]),
+    _ = erlang:trace(self(), true, [call]),
+
+    Res = (catch Fun()),
+
+    _ = erlang:trace_pattern({'_','_','_'}, false, [call_time]),
+    _ = erlang:trace(self(), false, [call]),
+
+    id(Res),
+
+    ok.
+
+catch_crash_1() ->
+    error(crash).
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Since 25fe3fb23c594d735cb6ebae120910e44f0cdae4, trace parameters always live next to their CP so we don't need to skip any "stack frame variables." This was generally harmless since the first argument was usually a CP anyway, but we'd skip too much when it wasn't. For example when return time tracing was used, and we didn't have any prev_info:

```
E -= 2;
E[1] = prev_info ? make_cp(erts_codeinfo_to_code(prev_info)) : NIL;
E[0] = (Eterm) beam_return_time_trace;
c_p->stop = E;
```

The loop to skip stack frame variables would thus skip the trace CP (which is OK) and then skip the `prev_info` (which is `[]`), and then we'd add one to skip what we thought was `prev_info`, ruining the scan.