### PR TITLE
otp: Remove all purify support

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -10107,8 +10107,8 @@ Metadata = #{ pid => pid(),
           <item>
             <p>Returns an atom describing the build type of the runtime
               system. This is normally the atom <c>opt</c> for optimized.
-              Other possible return values are <c>debug</c>, <c>purify</c>,
-              <c>quantify</c>, <c>purecov</c>, <c>gcov</c>, <c>valgrind</c>,
+              Other possible return values are <c>debug</c>,
+              <c>gcov</c>, <c>valgrind</c>,
               <c>gprof</c>, and <c>lcnt</c>. Possible return values
               can be added or removed at any time without prior notice.</p>
           </item>

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -1,4 +1,3 @@
-
 #
 # %CopyrightBegin%
 #
@@ -121,7 +120,6 @@ endif
 DIRTY_SCHEDULER_TEST=@DIRTY_SCHEDULER_TEST@
 
 ifeq ($(TYPE),debug)
-PURIFY =
 TYPEMARKER = .debug
 TYPE_FLAGS = $(DEBUG_CFLAGS) -DDEBUG
 ENABLE_ALLOC_TYPE_VARS += debug
@@ -131,29 +129,7 @@ LDFLAGS += -g
 endif
 else
 
-ifeq ($(TYPE),purify)
-PURIFY = purify $(PURIFY_BUILD_OPTIONS)
-TYPEMARKER = .purify
-TYPE_FLAGS = $(DEBUG_CFLAGS) -DPURIFY -DNO_JUMP_TABLE
-ENABLE_ALLOC_TYPE_VARS += purify
-else
-
-ifeq ($(TYPE),quantify)
-PURIFY = quantify $(QUANTIFY_BUILD_OPTIONS)
-TYPEMARKER = .quantify
-ENABLE_ALLOC_TYPE_VARS += quantify
-  TYPE_FLAGS = @CFLAGS@ -g -O2 -DQUANTIFY -DNO_JUMP_TABLE
-else
-
-ifeq ($(TYPE),purecov)
-PURIFY = purecov --follow-child-processes=yes $(PURECOV_BUILD_OPTIONS)
-TYPEMARKER = .purecov
-TYPE_FLAGS = $(DEBUG_CFLAGS) -DPURECOV -DNO_JUMP_TABLE
-ENABLE_ALLOC_TYPE_VARS += purecov
-else
-
 ifeq ($(TYPE),gcov)
-PURIFY = 
 TYPEMARKER = .gcov
 TYPE_FLAGS = $(DEBUG_CFLAGS) -DERTS_GCOV -DNO_JUMP_TABLE -fprofile-arcs -ftest-coverage -O0 -DERTS_CAN_INLINE=0 -DERTS_INLINE=
 ifneq ($(findstring solaris,$(TARGET)),solaris)
@@ -163,14 +139,12 @@ ENABLE_ALLOC_TYPE_VARS += debug
 else
 
 ifeq ($(TYPE),valgrind)
-PURIFY = 
 TYPEMARKER = .valgrind
 TYPE_FLAGS = $(DEBUG_CFLAGS) -DVALGRIND -DNO_JUMP_TABLE
 ENABLE_ALLOC_TYPE_VARS += valgrind
 else
 
 ifeq ($(TYPE),gprof)
-PURIFY = 
 TYPEMARKER = .gprof
 TYPE_FLAGS = @CFLAGS@ -DGPROF -pg -DERTS_CAN_INLINE=0 -DERTS_INLINE=
 LDFLAGS += -pg
@@ -179,33 +153,26 @@ NO_INLINE_FUNCTIONS=true
 else
 
 ifeq ($(TYPE),lcnt)
-PURIFY =
 TYPEMARKER = .lcnt
 TYPE_FLAGS = @CFLAGS@ -DERTS_ENABLE_LOCK_COUNT
 ENABLE_ALLOC_TYPE_VARS += lcnt
 else
 
 ifeq ($(TYPE),frmptr)
-PURIFY =
 OMIT_OMIT_FP=yes
 TYPEMARKER = .frmptr
 TYPE_FLAGS = @CFLAGS@ -DERTS_FRMPTR
 else
 
 ifeq ($(TYPE),icount)
-PURIFY =
 TYPEMARKER = .icount
 TYPE_FLAGS = @CFLAGS@ -DERTS_OPCODE_COUNTER_SUPPORT
 else
 
 # If type isn't one of the above, it *is* opt type...
 override TYPE=opt
-PURIFY =
 TYPEMARKER =
 TYPE_FLAGS = @CFLAGS@
-endif
-endif
-endif
 endif
 endif
 endif
@@ -356,16 +323,7 @@ RC=false
 endif
 endif
 
-
-ifdef PURIFY_CHILD_SETUP
-CS_PURIFY = $(PURIFY)
-CS_TYPE_FLAGS = $(TYPE_FLAGS)
-else
-CS_PURIFY = 
-CS_TYPE_FLAGS = $(subst QUANTIFY,FAKE_QUANTIFY, \
-		$(subst PURIFY,FAKE_PURIFY, $(TYPE_FLAGS)))
-endif
-CS_CFLAGS_ = $(CS_TYPE_FLAGS) $(DEFS) $(WFLAGS)
+CS_CFLAGS_ = $(TYPE_FLAGS) $(DEFS) $(WFLAGS)
 ifeq ($(GCC),yes)
 CS_CFLAGS = $(subst -O2, $(GEN_OPT_FLGS) $(UNROLL_FLG), $(CS_CFLAGS_))
 else
@@ -917,7 +875,7 @@ update_asmjit:
 CS_OBJ = $(OBJDIR)/erl_child_setup.o $(OBJDIR)/sys_uds.o $(OBJDIR)/hash.o
 
 $(BINDIR)/$(CS_EXECUTABLE): $(TTF_DIR)/GENERATED $(PRELOAD_SRC) $(CS_OBJ) $(ERTS_LIB)
-	$(ld_verbose)$(CS_PURIFY) $(LD) $(CS_LDFLAGS) -o $(BINDIR)/$(CS_EXECUTABLE) \
+	$(ld_verbose) $(LD) $(CS_LDFLAGS) -o $(BINDIR)/$(CS_EXECUTABLE) \
                $(CS_CFLAGS) $(COMMON_INCLUDES) $(CS_OBJ) $(CS_LIBS)
 
 ifeq ($(GCC),yes)
@@ -1183,7 +1141,7 @@ $(OBJS): $(TTF_DIR)/GENERATED
 ifeq ($(TARGET), win32)
 # Only the basic erlang to begin with eh?
 $(BINDIR)/$(FLAVOR_EXECUTABLE): $(INIT_OBJS) $(OBJS) $(DEPLIBS)
-	$(ld_verbose)$(PURIFY) $(LD) -dll -def:sys/$(ERLANG_OSTYPE)/erl.def \
+	$(ld_verbose) $(LD) -dll -def:sys/$(ERLANG_OSTYPE)/erl.def \
 	-implib:$(BINDIR)/erl_dll.lib -o $@ \
 	$(LDFLAGS) $(DEXPORT) $(INIT_OBJS) $(OBJS) $(STATIC_NIF_LIBS) \
 	$(STATIC_DRIVER_LIBS) $(LIBS)
@@ -1195,7 +1153,7 @@ else
 EMU_LD=$(CC)
 endif
 $(BINDIR)/$(FLAVOR_EXECUTABLE): $(INIT_OBJS) $(OBJS) $(DEPLIBS)
-	$(ld_verbose)$(PURIFY) $(EMU_LD) -o $@ \
+	$(ld_verbose) $(EMU_LD) -o $@ \
 	$(PROFILE_LDFLAGS) $(LDFLAGS) $(DEXPORT) $(INIT_OBJS) $(OBJS) \
 	$(STATIC_NIF_LIBS) $(STATIC_DRIVER_LIBS) $(LIBS)
 

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -545,8 +545,6 @@ atom protected
 atom protection
 atom ptab_list_continue
 atom public
-atom purify
-atom quantify
 atom queue_size
 atom raw
 atom re

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -163,13 +163,11 @@ static char *erts_dop_to_string(enum dop dop) {
 #endif
 
 #if defined(VALGRIND)
-#include <valgrind/valgrind.h>
-#include <valgrind/memcheck.h>
-
-#  define PURIFY_MSG(msg)                                                    \
-    VALGRIND_PRINTF("%s, line %d: %s", __FILE__, __LINE__, msg)
+#  include <valgrind/valgrind.h>
+#  include <valgrind/memcheck.h>
+#  define VALGRIND_MSG(msg) VALGRIND_PRINTF("%s, line %d: %s", __FILE__, __LINE__, msg)
 #else
-#  define PURIFY_MSG(msg)
+#  define VALGRIND_MSG(msg)
 #endif
 
 int erts_is_alive; /* System must be blocked on change */
@@ -1874,7 +1872,7 @@ int erts_net_message(Port *prt,
             erts_fprintf(dbg_file, "DIST MSG DEBUG: erts_decode_dist_ext_size(CTL) failed:\n");
             bw(buf, orig_len);
 #endif
-            PURIFY_MSG("data error");
+            VALGRIND_MSG("data error");
             goto data_error;
         }
 
@@ -1962,7 +1960,7 @@ int erts_net_message(Port *prt,
 	erts_fprintf(dbg_file, "DIST MSG DEBUG: erts_decode_dist_ext(CTL) failed:\n");
 	bw(buf, orig_len);
 #endif
-	PURIFY_MSG("data error");
+	VALGRIND_MSG("data error");
 	goto decode_error;
     }
 
@@ -2747,7 +2745,7 @@ int erts_net_message(Port *prt,
 	erts_send_error_to_logger_nogl(dsbufp);
     }
 decode_error:
-    PURIFY_MSG("data error");
+    VALGRIND_MSG("data error");
     if (ede_hfrag == NULL) {
         erts_factory_close(&factory);
         if (ctl != ctl_default) {

--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -66,7 +66,7 @@
 
 #define ERTS_ALC_DEFAULT_MAX_THR_PREF ERTS_MAX_NO_OF_SCHEDULERS
 
-#if defined(SMALL_MEMORY) || defined(PURIFY) || defined(VALGRIND)
+#if defined(SMALL_MEMORY) || defined(VALGRIND)
 #define AU_ALLOC_DEFAULT_ENABLE(X)	0
 #else
 #define AU_ALLOC_DEFAULT_ENABLE(X)	(X)

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -2684,7 +2684,7 @@ shrink_new_heap(Process *p, Uint new_sz, Eterm *objv, int nobj)
 
         /*
          * Normally, we don't expect a shrunk heap to move, but you never
-         * know on some strange embedded systems...  Or when using purify.
+         * know on some strange embedded systems...
          */
 
         offset_heap(new_heap, heap_size, offs, area, area_size);

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -3385,9 +3385,7 @@ enc_term_int(TTBEncodeContext* ctx, ErtsAtomCacheMap *acmp, Eterm obj, byte* ep,
 		/* now the erts_snprintf which does the work */
 		i = sys_double_to_chars(f.fd, (char*) ep, (size_t)31);
 
-		/* Don't leave garbage after the float!  (Bad practice in general,
-		 * and Purify complains.)
-		 */
+		/* Don't leave garbage after the float */
 		sys_memset(ep+i, 0, 31-i);
 		ep += 31;
 	    }

--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -128,12 +128,6 @@ typedef struct driver_data {
 
 #if defined(DEBUG)
 #define ERL_BUILD_TYPE_MARKER ".debug"
-#elif defined(PURIFY)
-#define ERL_BUILD_TYPE_MARKER ".purify"
-#elif defined(QUANTIFY)
-#define ERL_BUILD_TYPE_MARKER ".quantify"
-#elif defined(PURECOV)
-#define ERL_BUILD_TYPE_MARKER ".purecov"
 #elif defined(VALGRIND)
 #define ERL_BUILD_TYPE_MARKER ".valgrind"
 #else /* opt */

--- a/erts/emulator/test/mtx_SUITE.erl
+++ b/erts/emulator/test/mtx_SUITE.erl
@@ -477,8 +477,7 @@ handicap() ->
         opt ->
             X0;
         ReallySlow when ReallySlow == debug;
-                        ReallySlow == valgrind;
-                        ReallySlow == purify ->
+                        ReallySlow == valgrind ->
             X0*3;
         _Slow ->
             X0*2

--- a/erts/epmd/src/Makefile.in
+++ b/erts/epmd/src/Makefile.in
@@ -20,22 +20,13 @@
 include $(ERL_TOP)/make/target.mk
 
 ifeq ($(TYPE),debug)
-PURIFY     =
 TYPEMARKER = .debug
 TYPE_FLAGS = -DDEBUG @DEBUG_FLAGS@
 else
 
-ifeq ($(TYPE),purify)
-PURIFY     = purify
-TYPEMARKER =
-TYPE_FLAGS = -O2 -DPURIFY
-else
-
 override TYPE = opt
-PURIFY     =
 TYPEMARKER =
 TYPE_FLAGS = -O2
-endif
 endif
 
 include $(ERL_TOP)/make/$(TARGET)/otp.mk
@@ -116,7 +107,7 @@ clean:
 #
 
 $(BINDIR)/$(EPMD): $(EPMD_OBJS) $(ERTS_LIB)
-	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $(EPMD_OBJS) $(LIBS)
+	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(EPMD_OBJS) $(LIBS)
 
 $(OBJDIR)/%.o: %.c epmd.h epmd_int.h
 	$(V_CC) $(CFLAGS) $(EPMD_FLAGS) -o $@ -c $<

--- a/erts/etc/common/Makefile.in
+++ b/erts/etc/common/Makefile.in
@@ -26,23 +26,14 @@ ERTS_LIB_TYPEMARKER=.$(TYPE)
 USING_VC=@MIXED_VC@
 
 ifeq ($(TYPE),debug)
-PURIFY =
 TYPEMARKER = .debug
 TYPE_FLAGS = -DDEBUG @DEBUG_FLAGS@
 else
 
-ifeq ($(TYPE),purify)
-PURIFY = purify
-TYPEMARKER =
-TYPE_FLAGS = -g -O2 -DPURIFY
-else
-
 override TYPE=opt
-PURIFY =
 TYPEMARKER =
 ERTS_LIB_TYPEMARKER=
 TYPE_FLAGS =
-endif
 endif
 
 include $(ERL_TOP)/make/$(TARGET)/otp.mk
@@ -413,14 +404,14 @@ $(OBJDIR)/heart.o: heart.c $(RC_GENERATED)
 #	$(V_CC) $(CFLAGS) -o $@ -c $<
 #
 #$(BINDIR)/%: $(OBJDIR)/%.o
-#	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $< $(LIBS)
+#	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $< $(LIBS)
 
 $(OBJDIR)/inet_gethost.o: inet_gethost.c $(RC_GENERATED)
 	$(V_CC) $(CFLAGS) -o $@ -c inet_gethost.c
 
 # inet_gethost
 $(BINDIR)/inet_gethost@EXEEXT@: $(OBJDIR)/inet_gethost.o $(ENTRY_OBJ) $(ERTS_LIB)
-	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) $(ENTRY_LDFLAGS) -o $@ $(OBJDIR)/inet_gethost.o $(ENTRY_OBJ) $(LIBS) $(ERTS_INTERNAL_LIBS)
+	$(ld_verbose) $(LD) $(LDFLAGS) $(ENTRY_LDFLAGS) -o $@ $(OBJDIR)/inet_gethost.o $(ENTRY_OBJ) $(LIBS) $(ERTS_INTERNAL_LIBS)
 
 # run_erl
 $(BINDIR)/run_erl: $(OBJDIR)/safe_string.o $(OBJDIR)/run_erl.o
@@ -448,38 +439,38 @@ $(BINDIR)/erl_call@EXEEXT@: $(ERL_TOP)/lib/erl_interface/bin/$(TARGET)/erl_call@
 
 ifneq ($(TARGET),win32)
 $(BINDIR)/$(ERLEXEC): $(OBJDIR)/$(ERLEXEC).o $(ERTS_LIB)
-	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/$(ERLEXEC).o $(ERTS_INTERNAL_LIBS)
+	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/$(ERLEXEC).o $(ERTS_INTERNAL_LIBS)
 
 $(OBJDIR)/$(ERLEXEC).o: $(ERLEXECDIR)/$(ERLEXEC).c $(RC_GENERATED)
 	$(V_CC) -I$(EMUDIR) $(CFLAGS) -o $@ -c $(ERLEXECDIR)/$(ERLEXEC).c
 endif
 
 $(BINDIR)/erlc@EXEEXT@: $(OBJDIR)/erlc.o $(ERTS_LIB)
-	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/erlc.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS) $(EI_LIB)
+	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/erlc.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS) $(EI_LIB)
 
 $(OBJDIR)/erlc.o: erlc.c $(RC_GENERATED)
 	$(V_CC) $(CFLAGS) $(THR_DEFS) $(EI_INCL) $(MT_FLAG) -o $@ -c erlc.c
 
 $(BINDIR)/dialyzer@EXEEXT@: $(OBJDIR)/dialyzer.o $(ERTS_LIB)
-	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/dialyzer.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
+	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/dialyzer.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
 
 $(OBJDIR)/dialyzer.o: dialyzer.c $(RC_GENERATED)
 	$(V_CC) $(CFLAGS) -o $@ -c dialyzer.c
 
 $(BINDIR)/typer@EXEEXT@: $(OBJDIR)/typer.o $(ERTS_LIB)
-	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/typer.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
+	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/typer.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
 
 $(OBJDIR)/typer.o: typer.c $(RC_GENERATED)
 	$(V_CC) $(CFLAGS) -o $@ -c typer.c
 
 $(BINDIR)/escript@EXEEXT@: $(OBJDIR)/escript.o $(ERTS_LIB)
-	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/escript.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
+	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/escript.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
 
 $(OBJDIR)/escript.o: escript.c $(RC_GENERATED)
 	$(V_CC) $(CFLAGS) -o $@ -c escript.c
 
 $(BINDIR)/ct_run@EXEEXT@: $(OBJDIR)/ct_run.o $(ERTS_LIB)
-	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/ct_run.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
+	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/ct_run.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
 
 $(OBJDIR)/ct_run.o: ct_run.c $(RC_GENERATED)
 	$(V_CC) $(CFLAGS) -o $@ -c ct_run.c

--- a/erts/etc/unix/cerl.src
+++ b/erts/etc/unix/cerl.src
@@ -38,9 +38,6 @@
 #   -break F    Run the debug compiled emulator in emacs and gdb and set break.
 #               The session is started, i.e. "run" is already don for you.
 #   -xxgdb      FIXME currently disabled
-#   -purify     Run emulator compiled for purify
-#   -quantify   Run emulator compiled for quantify
-#   -purecov    Run emulator compiled for purecov
 #   -gcov       Run emulator compiled for gcov
 #   -valgrind   Run emulator compiled for valgrind
 #   -lcnt	Run emulator compiled for lock counting
@@ -194,21 +191,6 @@ while [ $# -gt 0 ]; do
 #	    shift
 #	    GDB=xxgdb
 #	    ;;
-	"-purify")
-	    shift
-	    cargs="$cargs -purify"
-	    TYPE=.purify
-	    ;;
-	"-quantify")
-	    shift
-	    cargs="$cargs -quantify"
-	    TYPE=.quantify
-	    ;;
-	"-purecov")
-	    shift
-	    cargs="$cargs -purecov"
-	    TYPE=.purecov
-	    ;;
 	"-gcov")
 	    shift
 	    cargs="$cargs -gcov"

--- a/erts/include/internal/ethread.h
+++ b/erts/include/internal/ethread.h
@@ -131,7 +131,7 @@ typedef pthread_key_t ethr_tsd_key;
 
 #define ETHR_HAVE_ETHR_SIG_FUNCS 1
 
-#if defined(PURIFY) || defined(VALGRIND)
+#if defined(VALGRIND)
 #  define ETHR_FORCE_PTHREAD_RWLOCK
 #  define ETHR_FORCE_PTHREAD_MUTEX
 #endif

--- a/erts/include/internal/i386/ethr_dw_atomic.h
+++ b/erts/include/internal/i386/ethr_dw_atomic.h
@@ -137,7 +137,7 @@ ethr_native_dw_atomic_addr(ethr_native_dw_atomic_t *var)
 #if ETHR_NO_CLOBBER_EBX__ && !defined(ETHR_CMPXCHG8B_REGISTER_SHORTAGE)
 /* When no optimization is on, we'll run into a register shortage */
 #  if defined(ETHR_DEBUG) || defined(DEBUG) || defined(VALGRIND) \
-      || defined(GCOV) || defined(PURIFY) || defined(PURECOV)
+      || defined(GCOV)
 #    define ETHR_CMPXCHG8B_REGISTER_SHORTAGE 1
 #  else
 #    define ETHR_CMPXCHG8B_REGISTER_SHORTAGE 0

--- a/erts/lib_src/Makefile.in
+++ b/erts/lib_src/Makefile.in
@@ -56,21 +56,6 @@ PRE_LD=
 
 else
 
-ifeq ($(TYPE),purify)
-CFLAGS=@DEBUG_CFLAGS@ -DPURIFY
-TYPE_SUFFIX=.purify
-PRE_LD=purify $(PURIFY_BUILD_OPTIONS)
-else
-ifeq ($(TYPE),quantify)
-CFLAGS += -DQUANTIFY
-TYPE_SUFFIX=.quantify
-PRE_LD=quantify $(QUANTIFY_BUILD_OPTIONS)
-else
-ifeq ($(TYPE),purecov)
-CFLAGS=@DEBUG_CFLAGS@ -DPURECOV
-TYPE_SUFFIX=.purecov
-PRE_LD=purecov $(PURECOV_BUILD_OPTIONS)
-else
 ifeq ($(TYPE),gcov)
 CFLAGS=@DEBUG_CFLAGS@ -DGCOV -fprofile-arcs -ftest-coverage -O0
 TYPE_SUFFIX=.gcov
@@ -107,9 +92,6 @@ override TYPE=opt
 OMIT_FP=true
 TYPE_SUFFIX=
 PRE_LD=
-endif
-endif
-endif
 endif
 endif
 endif

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2730,7 +2730,7 @@ tuple_to_list(_Tuple) ->
       Alloc :: atom();
          (atom_count) -> pos_integer();
          (atom_limit) -> pos_integer();
-         (build_type) -> opt | debug | purify | quantify | purecov |
+         (build_type) -> opt | debug |
                          gcov | valgrind | gprof | lcnt | frmptr;
          (c_compiler_used) -> {atom(), term()};
          (check_io) -> [_];

--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -824,10 +824,6 @@ do_boot(Init,Flags,Start) ->
 	     vars=BootVars},
     eval_script(BootList, Es),
 
-    %% To help identifying Purify windows that pop up,
-    %% print the node name into the Purify log.
-    (catch erlang:system_info({purify, "Node: " ++ atom_to_list(node())})),
-
     start_em(Start),
     case b2a(get_flag(profile_boot,Flags,false)) of
         false -> ok;

--- a/erts/test/utils/gccifier.c
+++ b/erts/test/utils/gccifier.c
@@ -138,9 +138,6 @@ main(int argc, char *argv[])
     char *cc = NULL;
     args_t args = {0};
     int is_debug = 0;
-    int is_purify = 0;
-    int is_quantify = 0;
-    int is_purecov = 0;
 #ifdef __WIN32__
     int is_shared = 0;
     stdlib_t stdlib = STDLIB_NONE;
@@ -191,18 +188,6 @@ main(int argc, char *argv[])
 		}
 	    }
 	}
-	else if (strcmp("-DPURIFY", arg) == 0) {
-	    save_arg(&args, arg, NULL);
-	    is_purify = 1;
-	}
-	else if (strcmp("-DQUANTIFY", arg) == 0) {
-	    save_arg(&args, arg, NULL);
-	    is_quantify = 1;
-	}
-	else if (strcmp("-DPURECOV", arg) == 0) {
-	    save_arg(&args, arg, NULL);
-	    is_purecov = 1;
-	}
 #ifdef __WIN32__
 	else if (strcmp("-g", arg) == 0) {
 	    goto set_debug;
@@ -246,12 +231,6 @@ main(int argc, char *argv[])
 	    CHECK_FIRST_LINK_ARG;
 	    if (is_debug && strcmp("ethread", arg) == 0)
 		arg = "ethread.debug";
-	    else if (is_purify && strcmp("ethread", arg) == 0)
-		arg = "ethread.purify";
-	    else if (is_quantify && strcmp("ethread", arg) == 0)
-		arg = "ethread.quantify";
-	    else if (is_purecov && strcmp("ethread", arg) == 0)
-		arg = "ethread.purecov";
 #ifdef __WIN32__
 	    else if (strcmp("socket", arg) == 0)
 		arg = "ws2_32";

--- a/lib/erl_interface/src/Makefile
+++ b/lib/erl_interface/src/Makefile
@@ -26,7 +26,7 @@
 include $(ERL_TOP)/make/output.mk
 include $(ERL_TOP)/make/target.mk
 
-debug opt shared purify quantify purecov gcov:
+debug opt shared gcov:
 ifndef TERTIARY_BOOTSTRAP
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile TYPE=$@
 endif

--- a/lib/erl_interface/src/Makefile.in
+++ b/lib/erl_interface/src/Makefile.in
@@ -66,42 +66,21 @@ LDFLAGS = @LDFLAGS@
 LIBS = @LIBS@
 
 ifeq ($(TYPE),debug)
-PURIFY =
 TYPEMARKER = .debug
 TYPE_FLAGS = -g -DDEBUG
 ifeq ($(TARGET),win32)
 LDFLAGS += -g
 endif
 else
-ifeq ($(TYPE),purify)
-PURIFY = purify
-TYPEMARKER = .purify
-TYPE_FLAGS = -DPURIFY -DNO_JUMP_TABLE
-else
-ifeq ($(TYPE),quantify)
-PURIFY = quantify
-TYPEMARKER = .quantify
-TYPE_FLAGS = -g -O2 -DQUANTIFY
-else
-ifeq ($(TYPE),purecov)
-PURIFY = purecov --follow-child-processes=yes
-TYPEMARKER = .purecov
-TYPE_FLAGS = -g -DPURECOV -DNO_JUMP_TABLE
-else
 ifeq ($(TYPE),gcov)
-PURIFY =
 TYPEMARKER =
 TYPE_FLAGS = -DNO_JUMP_TABLE -fprofile-arcs -ftest-coverage
 ifeq ($(TARGET),linux)
 LIBS += -lgcov
 endif
 else
-PURIFY =
 TYPEMARKER =
 TYPE_FLAGS =
-endif
-endif
-endif
 endif
 endif
 
@@ -566,16 +545,16 @@ endif
 
 ifeq ($(TARGET),win32)
 $(ERL_CALL): $(ERLCALL) ../include/ei.h $(MD_EILIB)
-	$(ld_verbose)$(PURIFY) $(CC) -MD $(PROG_CFLAGS) $(THR_DEFS) -o $@ $(ERLCALL) \
+	$(ld_verbose) $(CC) -MD $(PROG_CFLAGS) $(THR_DEFS) -o $@ $(ERLCALL) \
 		-L$(OBJDIR) -lei_md $(THR_LIBS) $(LIBS) -lsocket
 else
 ifdef THR_DEFS
 $(ERL_CALL): $(ERLCALL) ../include/ei.h $(MT_EILIB)
-	$(ld_verbose)$(PURIFY) $(CC) $(PROG_CFLAGS) $(THR_DEFS) $(LDFLAGS) -o $@ $(ERLCALL) \
+	$(ld_verbose) $(CC) $(PROG_CFLAGS) $(THR_DEFS) $(LDFLAGS) -o $@ $(ERLCALL) \
 		-L$(OBJDIR) -lei $(THR_LIBS) $(LIBS)
 else
 $(ERL_CALL): $(ERLCALL) ../include/ei.h $(ST_EILIB)
-	$(ld_verbose)$(PURIFY) $(CC) $(PROG_CFLAGS) $(LDFLAGS) -o $@ $(ERLCALL) \
+	$(ld_verbose) $(CC) $(PROG_CFLAGS) $(LDFLAGS) -o $@ $(ERLCALL) \
 		-L$(OBJDIR) -lei $(LIBS)
 endif
 endif

--- a/lib/erl_interface/test/all_SUITE_data/gccifier.c
+++ b/lib/erl_interface/test/all_SUITE_data/gccifier.c
@@ -138,9 +138,6 @@ main(int argc, char *argv[])
     char *cc = NULL;
     args_t args = {0};
     int is_debug = 0;
-    int is_purify = 0;
-    int is_quantify = 0;
-    int is_purecov = 0;
 #ifdef __WIN32__
     int is_shared = 0;
     stdlib_t stdlib = STDLIB_NONE;
@@ -191,18 +188,6 @@ main(int argc, char *argv[])
 		}
 	    }
 	}
-	else if (strcmp("-DPURIFY", arg) == 0) {
-	    save_arg(&args, arg, NULL);
-	    is_purify = 1;
-	}
-	else if (strcmp("-DQUANTIFY", arg) == 0) {
-	    save_arg(&args, arg, NULL);
-	    is_quantify = 1;
-	}
-	else if (strcmp("-DPURECOV", arg) == 0) {
-	    save_arg(&args, arg, NULL);
-	    is_purecov = 1;
-	}
 #ifdef __WIN32__
 	else if (strcmp("-g", arg) == 0) {
 	    goto set_debug;
@@ -246,12 +231,6 @@ main(int argc, char *argv[])
 	    CHECK_FIRST_LINK_ARG;
 	    if (is_debug && strcmp("ethread", arg) == 0)
 		arg = "ethread.debug";
-	    else if (is_purify && strcmp("ethread", arg) == 0)
-		arg = "ethread.purify";
-	    else if (is_quantify && strcmp("ethread", arg) == 0)
-		arg = "ethread.quantify";
-	    else if (is_purecov && strcmp("ethread", arg) == 0)
-		arg = "ethread.purecov";
 #ifdef __WIN32__
 	    else if (strcmp("socket", arg) == 0)
 		arg = "ws2_32";

--- a/lib/tools/c_src/Makefile.in
+++ b/lib/tools/c_src/Makefile.in
@@ -43,28 +43,10 @@ ifeq ($(TARGET),win32)
 LDFLAGS += -g
 endif
 else
-ifeq ($(TYPE),purify)
-CFLAGS = @CFLAGS@ -DPURIFY
-TYPEMARKER=.purify
-PRE_LD = purify $(PURIFY_BUILD_OPTIONS)
-else
-ifeq ($(TYPE),quantify)
-CFLAGS = @CFLAGS@ -DQUANTIFY
-TYPEMARKER=.quantify
-PRE_LD = quantify $(QUANTIFY_BUILD_OPTIONS)
-else
-ifeq ($(TYPE),purecov)
-CFLAGS = @DEBUG_CFLAGS@ -DPURECOV
-TYPEMARKER=.purecov
-PRE_LD = purecov $(PURECOV_BUILD_OPTIONS)
-else
 override TYPE=opt
 CFLAGS = @CFLAGS@
 PRE_LD =
 TYPEMARKER =
-endif
-endif
-endif
 endif
 
 ifeq ($(findstring -D_GNU_SOURCE,$(CFLAGS)),)

--- a/lib/tools/c_src/erl_memory.c
+++ b/lib/tools/c_src/erl_memory.c
@@ -2790,15 +2790,6 @@ main(int argc, char *argv[])
 #ifdef DEBUG
     print_string(state, "> [debug]\n");
 #endif
-#ifdef PURIFY
-    print_string(state, "> [purify]\n");
-#endif
-#ifdef QUANTIFY
-    print_string(state, "> [quantify]\n");
-#endif
-#ifdef PURECOV
-    print_string(state, "> [purecov]\n");
-#endif
 
     res = init_connection(state);
     if (res != 0)

--- a/lib/tools/test/emem_SUITE.erl
+++ b/lib/tools/test/emem_SUITE.erl
@@ -117,8 +117,6 @@ init_per_suite(Config) when is_list(Config) ->
 		     case check_dir(filename:join([BinDir, Target])) of
 			 not_found -> ok;
 			 TDir ->
-			     check_emem(TDir, purecov),
-			     check_emem(TDir, purify),
 			     check_emem(TDir, debug),
 			     check_emem(TDir, opt)
 		     end,

--- a/make/run_make.mk
+++ b/make/run_make.mk
@@ -31,7 +31,7 @@ include $(ERL_TOP)/make/target.mk
 
 .PHONY: valgrind
 
-opt debug purify quantify purecov valgrind gcov gprof lcnt frmptr icount:
+opt debug valgrind gcov gprof lcnt frmptr icount:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile TYPE=$@
 
 emu jit:


### PR DESCRIPTION
Purify has not been used on the emulator for a decade and is now just cluttering make files and some source code.

Build targets removed: purify, quantify and purecov.