### PR TITLE
erts: Refactor code pointers

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -544,7 +544,7 @@ if test "x$GCC" = xyes; then
 
   # until the emulator can handle this, I suggest we turn it off!
   #WFLAGS="-Wall -Wshadow -Wcast-qual -Wmissing-declarations"
-  WFLAGS="-Wall -Wstrict-prototypes"
+  WFLAGS="-Wall -Wstrict-prototypes -Wpointer-arith"
 
   case "$host_cpu" in
     tile*)

--- a/erts/emulator/beam/beam_catches.h
+++ b/erts/emulator/beam/beam_catches.h
@@ -26,17 +26,20 @@
 #endif
 #include "sys.h"
 #include "code_ix.h"
+#include "beam_code.h"
 
 #define BEAM_CATCHES_NIL	(-1)
 
 void beam_catches_init(void);
 void beam_catches_start_staging(void);
 void beam_catches_end_staging(int commit);
-unsigned beam_catches_cons(BeamInstr* cp, unsigned cdr, BeamInstr ***);
-BeamInstr *beam_catches_car(unsigned i);
-void beam_catches_delmod(unsigned head, BeamInstr* code, unsigned code_bytes,
-			 ErtsCodeIndex);
-BeamInstr *beam_catches_car_staging(unsigned i);
+unsigned beam_catches_cons(ErtsCodePtr cp, unsigned cdr, ErtsCodePtr **);
+ErtsCodePtr beam_catches_car(unsigned i);
+void beam_catches_delmod(unsigned head,
+                         const BeamCodeHeader *hdr,
+                         unsigned code_bytes,
+                         ErtsCodeIndex code_ix);
+ErtsCodePtr beam_catches_car_staging(unsigned i);
 #define catch_pc(x)	beam_catches_car(catch_val((x)))
 
 #endif	/* __BEAM_CATCHES_H */

--- a/erts/emulator/beam/beam_code.h
+++ b/erts/emulator/beam/beam_code.h
@@ -76,7 +76,7 @@ typedef struct beam_code_header {
     /*
      * Pointer to the on_load function (or NULL if none).
      */
-    const BeamInstr *on_load_function_ptr;
+    const ErtsCodeInfo *on_load;
 
     /*
      * Pointer to the line table (or NULL if none).

--- a/erts/emulator/beam/beam_common.h
+++ b/erts/emulator/beam/beam_common.h
@@ -212,20 +212,20 @@ do {						\
         DTRACE2(nif_return, process_name, mfa_buf);                     \
     }
 
-#define DTRACE_GLOBAL_CALL_FROM_EXPORT(p,e)                                                    \
-    do {                                                                                       \
-        if (DTRACE_ENABLED(global_function_entry)) {                                           \
-            BeamInstr* fp = (BeamInstr *) (((Export *) (e))->addresses[erts_active_code_ix()]); \
-            DTRACE_GLOBAL_CALL((p), erts_code_to_codemfa(fp));          \
-        }                                                                                      \
+#define DTRACE_GLOBAL_CALL_FROM_EXPORT(p,e)                                        \
+    do {                                                                           \
+        if (DTRACE_ENABLED(global_function_entry)) {                               \
+            ErtsCodePtr fp__ (((Export *) (e))->addresses[erts_active_code_ix()]); \
+            DTRACE_GLOBAL_CALL((p), erts_code_to_codemfa(fp__));                   \
+        }                                                                          \
     } while(0)
 
-#define DTRACE_RETURN_FROM_PC(p, i)                                                        \
-    do {                                                                                \
-        ErtsCodeMFA* cmfa;                                                                  \
+#define DTRACE_RETURN_FROM_PC(p, i)                                                      \
+    do {                                                                                 \
+        const ErtsCodeMFA* cmfa;                                                         \
         if (DTRACE_ENABLED(function_return) && (cmfa = erts_find_function_from_pc(i))) { \
-            DTRACE_RETURN((p), cmfa);                               \
-        }                                                                               \
+            DTRACE_RETURN((p), cmfa);                                                    \
+        }                                                                                \
     } while(0)
 
 #else /* USE_VM_PROBES */
@@ -248,29 +248,29 @@ do {						\
 #define REDS_IN(p)  ((p)->def_arg_reg[5])
 
 ErtsCodeMFA *ubif2mfa(void* uf);
-const BeamInstr* handle_error(Process* c_p, const BeamInstr* pc,
-                              Eterm* reg, const ErtsCodeMFA* bif_mfa);
+ErtsCodePtr handle_error(Process* c_p, ErtsCodePtr pc,
+                         Eterm* reg, const ErtsCodeMFA* bif_mfa);
 Export* call_error_handler(Process* p, const ErtsCodeMFA* mfa,
                            Eterm* reg, Eterm func);
 Export* fixed_apply(Process* p, Eterm* reg, Uint arity,
-                    const BeamInstr *I, Uint offs);
-Export* apply(Process* p, Eterm* reg, const BeamInstr *I, Uint offs);
-const BeamInstr* call_fun(Process* p, int arity,
-                          Eterm* reg, Eterm args, Export **epp);
-const BeamInstr* apply_fun(Process* p, Eterm fun,
-                           Eterm args, Eterm* reg, Export **epp);
+                    ErtsCodePtr I, Uint offs);
+Export* apply(Process* p, Eterm* reg, ErtsCodePtr I, Uint offs);
+ErtsCodePtr call_fun(Process* p, int arity, Eterm* reg,
+                     Eterm args, Export **epp);
+ErtsCodePtr apply_fun(Process* p, Eterm fun, Eterm args,
+                      Eterm* reg, Export **epp);
 Eterm new_fun(Process* p, Eterm* reg,
 		     ErlFunEntry* fe, int num_free);
 ErlFunThing* new_fun_thing(Process* p, ErlFunEntry* fe, int num_free);
 int is_function2(Eterm Term, Uint arity);
 Eterm erts_gc_new_map(Process* p, Eterm* reg, Uint live,
-                             Uint n, const BeamInstr* ptr);
+                      Uint n, const Eterm* data);
 Eterm erts_gc_new_small_map_lit(Process* p, Eterm* reg, Eterm keys_literal,
-                               Uint live, const BeamInstr* ptr);
+                                Uint live, const Eterm* data);
 Eterm erts_gc_update_map_assoc(Process* p, Eterm* reg, Uint live,
-                              Uint n, const BeamInstr* new_p);
+                               Uint n, const Eterm* data);
 Eterm erts_gc_update_map_exact(Process* p, Eterm* reg, Uint live,
-                              Uint n, const Eterm* new_p);
+                               Uint n, const Eterm* data);
 Eterm get_map_element(Eterm map, Eterm key);
 Eterm get_map_element_hash(Eterm map, Eterm key, Uint32 hx);
 int raw_raise(Eterm stacktrace, Eterm exc_class, Eterm value, Process *c_p);
@@ -279,33 +279,19 @@ Eterm add_stacktrace(Process* c_p, Eterm Value, Eterm exc);
 void copy_out_registers(Process *c_p, Eterm *reg);
 void copy_in_registers(Process *c_p, Eterm *reg);
 void check_monitor_long_schedule(Process *c_p, Uint64 start_time,
-                                 const BeamInstr* start_time_i);
+                                 ErtsCodePtr start_time_i);
 
 
-#define BeamCodeApply() beam_apply
-
-#ifdef BEAMASM
-#define BeamCodeNormalExit() beam_normal_exit
-extern BeamInstr *beam_apply;
-extern BeamInstr *beam_normal_exit;
-extern BeamInstr *beam_exit;
-extern BeamInstr *beam_save_calls;
-extern BeamInstr *beam_bif_export_trap;
-extern BeamInstr *beam_export_trampoline;
-extern BeamInstr *beam_continue_exit;
-extern BeamInstr *beam_return_to_trace;   /* OpCode(i_return_to_trace) */
-extern BeamInstr *beam_return_trace;      /* OpCode(i_return_trace) */
-extern BeamInstr *beam_exception_trace;   /* OpCode(i_exception_trace) */
-extern BeamInstr *beam_return_time_trace; /* OpCode(i_return_time_trace) */
-#else
-#define BeamCodeNormalExit() (beam_apply + 1)
-extern BeamInstr beam_apply[2];
-extern BeamInstr beam_exit[1];
-extern BeamInstr beam_continue_exit[1];
-extern BeamInstr beam_return_to_trace[1];   /* OpCode(i_return_to_trace) */
-extern BeamInstr beam_return_trace[1];      /* OpCode(i_return_trace) */
-extern BeamInstr beam_exception_trace[1];   /* OpCode(i_exception_trace) */
-extern BeamInstr beam_return_time_trace[1]; /* OpCode(i_return_time_trace) */
-#endif
+extern ErtsCodePtr beam_apply;
+extern ErtsCodePtr beam_normal_exit;
+extern ErtsCodePtr beam_exit;
+extern ErtsCodePtr beam_save_calls;
+extern ErtsCodePtr beam_bif_export_trap;
+extern ErtsCodePtr beam_export_trampoline;
+extern ErtsCodePtr beam_continue_exit;
+extern ErtsCodePtr beam_return_to_trace;   /* OpCode(i_return_to_trace) */
+extern ErtsCodePtr beam_return_trace;      /* OpCode(i_return_trace) */
+extern ErtsCodePtr beam_exception_trace;   /* OpCode(i_exception_trace) */
+extern ErtsCodePtr beam_return_time_trace; /* OpCode(i_return_time_trace) */
 
 #endif /* _BEAM_COMMON_H_ */

--- a/erts/emulator/beam/beam_debug.c
+++ b/erts/emulator/beam/beam_debug.c
@@ -49,7 +49,7 @@
 #endif
 
 void dbg_bt(Process* p, Eterm* sp);
-void dbg_where(BeamInstr* addr, Eterm x0, Eterm* reg);
+void dbg_where(ErtsCodePtr addr, Eterm x0, Eterm* reg);
 
 #ifndef BEAMASM
 static int print_op(fmtfn_t to, void *to_arg, int op, int size, BeamInstr* addr);
@@ -399,7 +399,7 @@ dbg_bt(Process* p, Eterm* sp)
 }
 
 void
-dbg_where(BeamInstr* addr, Eterm x0, Eterm* reg)
+dbg_where(ErtsCodePtr addr, Eterm x0, Eterm* reg)
 {
     const ErtsCodeMFA* cmfa = erts_find_function_from_pc(addr);
 
@@ -957,7 +957,7 @@ static BIF_RETTYPE dirty_test(Process *c_p,
                               Eterm type,
                               Eterm arg1,
                               Eterm arg2,
-                              const BeamInstr *I);
+                              ErtsCodePtr I);
 
 /*
  * erts_debug:dirty_cpu/2 is statically determined to execute on
@@ -1021,7 +1021,7 @@ erts_debug_dirty_3(BIF_ALIST_3)
 
 
 static BIF_RETTYPE
-dirty_test(Process *c_p, Eterm type, Eterm arg1, Eterm arg2, const BeamInstr *I)
+dirty_test(Process *c_p, Eterm type, Eterm arg1, Eterm arg2, ErtsCodePtr I)
 {
     BIF_RETTYPE ret;
     if (am_scheduler == arg1) {

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -234,7 +234,7 @@ erts_finish_loading(Binary* magic, Process* c_p,
                     erts_clear_export_break(mod_tab_p, ep);
 
                     ep->addresses[code_ix] =
-                        (BeamInstr*)ep->trampoline.breakpoint.address;
+                        (ErtsCodePtr)ep->trampoline.breakpoint.address;
                     ep->trampoline.breakpoint.address = 0;
 
                     ASSERT(!erts_is_export_trampoline_active(ep, code_ix));

--- a/erts/emulator/beam/bif.h
+++ b/erts/emulator/beam/bif.h
@@ -32,7 +32,7 @@ extern Export *erts_convert_time_unit_trap;
 
 #define BIF_P A__p
 
-#define BIF_ALIST Process* A__p, Eterm* BIF__ARGS, const BeamInstr *A__I
+#define BIF_ALIST Process* A__p, Eterm* BIF__ARGS, ErtsCodePtr A__I
 #define BIF_CALL_ARGS A__p, BIF__ARGS, A__I
 
 #define BIF_ALIST_0 BIF_ALIST
@@ -314,7 +314,7 @@ do {								\
 #ifdef BEAMASM
 
 /* See `emit_bif_export_trap` for details. */
-extern BeamInstr *beam_bif_export_trap;
+extern ErtsCodePtr beam_bif_export_trap;
 #define ERTS_BIF_PREP_TRAP(Export, Proc, Arity)                               \
     do {                                                                      \
         (Proc)->i = beam_bif_export_trap;                                     \
@@ -327,7 +327,7 @@ extern BeamInstr *beam_bif_export_trap;
 
 #define ERTS_BIF_PREP_TRAP(Export, Proc, Arity)                               \
     do {                                                                      \
-        (Proc)->i = (BeamInstr*)((Export)->addresses[erts_active_code_ix()]);  \
+        (Proc)->i = (Export)->addresses[erts_active_code_ix()];               \
         (Proc)->arity = (Arity);                                              \
         (Proc)->freason = TRAP;                                               \
     } while(0);
@@ -434,7 +434,7 @@ extern BeamInstr *beam_bif_export_trap;
 #define BIF_TRAP_CODE_PTR(p, Code_, Arity_)                                   \
     do {                                                                      \
         (p)->arity = (Arity_);                                                \
-        (p)->i = (BeamInstr*)(Code_);                                         \
+        (p)->i = (Code_);                                                     \
         (p)->freason = TRAP;                                                  \
         return THE_NON_VALUE;                                                 \
     } while(0)
@@ -539,12 +539,12 @@ do {					\
 } while (0)
 
 int erts_call_dirty_bif(ErtsSchedulerData *esdp, Process *c_p,
-                        const BeamInstr *I, Eterm *reg);
+                        ErtsCodePtr I, Eterm *reg);
 
 BIF_RETTYPE
 erts_schedule_bif(Process *proc,
 		  Eterm *argv,
-		  const BeamInstr *i,
+		  ErtsCodePtr i,
 		  const ErtsCodeMFA *mfa,
 		  ErtsBifFunc dbf,
 		  ErtsSchedType sched_type,
@@ -555,7 +555,7 @@ erts_schedule_bif(Process *proc,
 ERTS_GLB_INLINE BIF_RETTYPE
 erts_reschedule_bif(Process *proc,
 		    Eterm *argv,
-		    const BeamInstr *i,
+		    ErtsCodePtr i,
 		    const ErtsCodeMFA *mfa,
 		    ErtsBifFunc dbf,
 		    ErtsSchedType sched_type);
@@ -565,7 +565,7 @@ erts_reschedule_bif(Process *proc,
 ERTS_GLB_INLINE BIF_RETTYPE
 erts_reschedule_bif(Process *proc,
 		    Eterm *argv,
-		    const BeamInstr *i,
+		    ErtsCodePtr i,
 		    const ErtsCodeMFA *mfa,
 		    ErtsBifFunc dbf,
 		    ErtsSchedType sched_type)

--- a/erts/emulator/beam/code_ix.h
+++ b/erts/emulator/beam/code_ix.h
@@ -88,19 +88,19 @@ typedef struct ErtsCodeInfo_ {
 
 /* Get the code associated with a ErtsCodeInfo ptr. */
 ERTS_GLB_INLINE
-const BeamInstr *erts_codeinfo_to_code(const ErtsCodeInfo *ci);
+ErtsCodePtr erts_codeinfo_to_code(const ErtsCodeInfo *ci);
 
 /* Get the ErtsCodeInfo for from a code ptr. */
 ERTS_GLB_INLINE
-const ErtsCodeInfo *erts_code_to_codeinfo(const BeamInstr *I);
+const ErtsCodeInfo *erts_code_to_codeinfo(ErtsCodePtr I);
 
 /* Get the code associated with a ErtsCodeMFA ptr. */
 ERTS_GLB_INLINE
-const BeamInstr *erts_codemfa_to_code(const ErtsCodeMFA *mfa);
+ErtsCodePtr erts_codemfa_to_code(const ErtsCodeMFA *mfa);
 
 /* Get the ErtsCodeMFA from a code ptr. */
 ERTS_GLB_INLINE
-const ErtsCodeMFA *erts_code_to_codemfa(const BeamInstr *I);
+const ErtsCodeMFA *erts_code_to_codemfa(ErtsCodePtr I);
 
 /* Called once at emulator initialization.
  */
@@ -182,39 +182,40 @@ extern erts_atomic32_t the_staging_code_index;
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 
 ERTS_GLB_INLINE
-const BeamInstr *erts_codeinfo_to_code(const ErtsCodeInfo *ci)
+ErtsCodePtr erts_codeinfo_to_code(const ErtsCodeInfo *ci)
 {
 #ifndef BEAMASM
     ASSERT(BeamIsOpCode(ci->op, op_i_func_info_IaaI) || !ci->op);
 #endif
     ASSERT_MFA(&ci->mfa);
-    return (const BeamInstr*)(ci + 1);
+    return (ErtsCodePtr)&ci[1];
 }
 
 ERTS_GLB_INLINE
-const ErtsCodeInfo *erts_code_to_codeinfo(const BeamInstr *I)
+const ErtsCodeInfo *erts_code_to_codeinfo(ErtsCodePtr I)
 {
-    ErtsCodeInfo *ci = ((ErtsCodeInfo *)(((char *)(I)) - sizeof(ErtsCodeInfo)));
+    const ErtsCodeInfo *ci = &((const ErtsCodeInfo *)I)[-1];
+
 #ifndef BEAMASM
     ASSERT(BeamIsOpCode(ci->op, op_i_func_info_IaaI) || !ci->op);
 #endif
     ASSERT_MFA(&ci->mfa);
+
     return ci;
 }
 
 ERTS_GLB_INLINE
-const BeamInstr *erts_codemfa_to_code(const ErtsCodeMFA *mfa)
+ErtsCodePtr erts_codemfa_to_code(const ErtsCodeMFA *mfa)
 {
     ASSERT_MFA(mfa);
-    return (const BeamInstr*)(mfa + 1);
+    return (ErtsCodePtr)&mfa[1];
 }
 
 ERTS_GLB_INLINE
-const ErtsCodeMFA *erts_code_to_codemfa(const BeamInstr *I)
+const ErtsCodeMFA *erts_code_to_codemfa(ErtsCodePtr I)
 {
-    const ErtsCodeMFA *mfa;
+    const ErtsCodeMFA *mfa = &((const ErtsCodeMFA *)I)[-1];
 
-    mfa = ((const ErtsCodeMFA *)(((const char *)(I)) - sizeof(ErtsCodeMFA)));
     ASSERT_MFA(mfa);
 
     return mfa;

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -3244,7 +3244,7 @@ erts_dsig_send(ErtsDSigSendContext *ctx)
 		}
 
                 ASSERT(fragments < 2
-                       || (get_int64(ctx->obuf->eiov->iov[1].iov_base + 10)
+                       || (get_int64(&((char*)ctx->obuf->eiov->iov[1].iov_base)[10])
                            == ctx->fragments));
 
                 if (fragments) {

--- a/erts/emulator/beam/emu/beam_emu.c
+++ b/erts/emulator/beam/emu/beam_emu.c
@@ -107,9 +107,15 @@
  * Special Beam instructions.
  */
 
-BeamInstr beam_apply[2];
-BeamInstr beam_exit[1];
-BeamInstr beam_continue_exit[1];
+static BeamInstr beam_apply_[2];
+ErtsCodePtr beam_apply;             /* beam_apply_[0]; */
+ErtsCodePtr beam_normal_exit;       /* beam_apply_[1]; */
+
+static BeamInstr beam_exit_[1];
+ErtsCodePtr beam_exit;
+
+static BeamInstr beam_continue_exit_[1];
+ErtsCodePtr beam_continue_exit;
 
 
 /* NOTE These should be the only variables containing trace instructions.
@@ -117,11 +123,22 @@ BeamInstr beam_continue_exit[1];
 **      for the referring variable (one of these), and rouge references
 **      will most likely cause chaos.
 */
-BeamInstr beam_return_to_trace[1];   /* OpCode(i_return_to_trace) */
-BeamInstr beam_return_trace[1];      /* OpCode(i_return_trace) */
-BeamInstr beam_exception_trace[1];   /* UGLY also OpCode(i_return_trace) */
-BeamInstr beam_return_time_trace[1]; /* OpCode(i_return_time_trace) */
 
+/* OpCode(i_return_to_trace) */
+static BeamInstr beam_return_to_trace_[1];
+ErtsCodePtr beam_return_to_trace;
+
+/* OpCode(i_return_trace) */
+static BeamInstr beam_return_trace_[1];
+ErtsCodePtr beam_return_trace;
+
+/* UGLY also OpCode(i_return_trace) */
+static BeamInstr beam_exception_trace_[1];
+ErtsCodePtr beam_exception_trace;
+
+/* OpCode(i_return_time_trace) */
+static BeamInstr beam_return_time_trace_[1];
+ErtsCodePtr beam_return_time_trace;
 
 /*
  * All Beam instructions in numerical order.
@@ -289,7 +306,7 @@ void process_main(ErtsSchedulerData *esdp)
 #endif
 
     Uint64 start_time = 0;          /* Monitor long schedule */
-    const BeamInstr *start_time_i = NULL;
+    ErtsCodePtr start_time_i = NULL;
 
     ERTS_MSACC_DECLARE_CACHE_X() /* a cached value of the tsd pointer for msacc */
 
@@ -652,14 +669,29 @@ init_emulator_finish(void)
     }
 #endif
 
-    beam_apply[0]             = BeamOpCodeAddr(op_i_apply);
-    beam_apply[1]             = BeamOpCodeAddr(op_normal_exit);
-    beam_exit[0]              = BeamOpCodeAddr(op_error_action_code);
-    beam_continue_exit[0]     = BeamOpCodeAddr(op_continue_exit);
-    beam_return_to_trace[0]   = BeamOpCodeAddr(op_i_return_to_trace);
-    beam_return_trace[0]      = BeamOpCodeAddr(op_return_trace);
-    beam_exception_trace[0]   = BeamOpCodeAddr(op_return_trace); /* UGLY */
-    beam_return_time_trace[0] = BeamOpCodeAddr(op_i_return_time_trace);
+    beam_apply_[0]             = BeamOpCodeAddr(op_i_apply);
+    beam_apply_[1]             = BeamOpCodeAddr(op_normal_exit);
+
+    beam_apply = (ErtsCodePtr)&beam_apply_[0];
+    beam_normal_exit = (ErtsCodePtr)&beam_apply_[1];
+
+    beam_exit_[0]              = BeamOpCodeAddr(op_error_action_code);
+    beam_exit = (ErtsCodePtr)&beam_exit_[0];
+
+    beam_continue_exit_[0]     = BeamOpCodeAddr(op_continue_exit);
+    beam_continue_exit = (ErtsCodePtr)&beam_continue_exit_[0];
+
+    beam_return_to_trace_[0]   = BeamOpCodeAddr(op_i_return_to_trace);
+    beam_return_to_trace = (ErtsCodePtr)&beam_return_to_trace_[0];
+
+    beam_return_trace_[0]      = BeamOpCodeAddr(op_return_trace);
+    beam_return_trace = (ErtsCodePtr)&beam_return_trace_[0];
+
+    beam_exception_trace_[0]   = BeamOpCodeAddr(op_return_trace); /* UGLY */
+    beam_exception_trace = (ErtsCodePtr)&beam_exception_trace_[0];
+
+    beam_return_time_trace_[0] = BeamOpCodeAddr(op_i_return_time_trace);
+    beam_return_time_trace = (ErtsCodePtr)&beam_return_time_trace_[0];
 
     install_bifs();
 }

--- a/erts/emulator/beam/emu/bif_instrs.tab
+++ b/erts/emulator/beam/emu/bif_instrs.tab
@@ -615,7 +615,8 @@ nif_bif.epilogue() {
         $DISPATCH();
     }
     {
-        BeamInstr *cp = erts_printable_return_address(c_p, E);
+        const BeamInstr *cp =
+            (const BeamInstr*)erts_printable_return_address(c_p, E);
         ASSERT(VALID_INSTR(*cp));
         I = handle_error(c_p, cp, reg, c_p->current);
     }
@@ -628,7 +629,7 @@ i_load_nif() {
         Eterm result;
 
         PRE_BIF_SWAPOUT(c_p);
-        result = erts_load_nif(c_p, (BeamInstr*)I, r(0), r(1));
+        result = erts_load_nif(c_p, I, r(0), r(1));
         erts_release_code_write_permission();
         ERTS_REQ_PROC_MAIN_LOCK(c_p);
         SWAPIN;

--- a/erts/emulator/beam/emu/macros.tab
+++ b/erts/emulator/beam/emu/macros.tab
@@ -43,12 +43,12 @@ SET_I_REL(Offset) {
 
 SET_CP_I_ABS(Target) {
     c_p->i = $Target;
-    ASSERT(VALID_INSTR(*c_p->i));
+    ASSERT(VALID_INSTR(*(const BeamInstr*)c_p->i));
 }
 
 SET_REL_I(Dst, Offset) {
     $Dst = I + ($Offset);
-    ASSERT(VALID_INSTR(*$Dst));
+    ASSERT(VALID_INSTR(*(const BeamInstr*)$Dst));
 }
 
 FAIL(Fail) {

--- a/erts/emulator/beam/emu/trace_instrs.tab
+++ b/erts/emulator/beam/emu/trace_instrs.tab
@@ -75,12 +75,12 @@ i_return_to_trace() {
             cpp++;
         }
         for(;;) {
-            if (IsOpCode(*cp_val(*cpp), return_trace)) {
+            if (IsOpCode(*(BeamInstr*)cp_val(*cpp), return_trace)) {
                 do
                     ++cpp;
                 while (is_not_CP(*cpp));
                 cpp += 2;
-            } else if (IsOpCode(*cp_val(*cpp), i_return_to_trace)) {
+            } else if (IsOpCode(*(BeamInstr*)cp_val(*cpp), i_return_to_trace)) {
                 do
                     ++cpp;
                 while (is_not_CP(*cpp));

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2023,7 +2023,7 @@ current_function(Process *c_p, ErtsHeapFactory *hfact, Process* rp,
     }
 
     if (c_p == rp && !(flags & ERTS_PI_FLAG_REQUEST_FOR_OTHER)) {
-        BeamInstr* return_address;
+        ErtsCodePtr return_address;
         FunctionInfo caller_fi;
 
         /*
@@ -2075,7 +2075,7 @@ current_stacktrace(Process *p, ErtsHeapFactory *hfact, Process* rp,
     Eterm res = NIL;
 
     depth = erts_backtrace_depth;
-    sz = offsetof(struct StackTrace, trace) + sizeof(BeamInstr *)*depth;
+    sz = offsetof(struct StackTrace, trace) + sizeof(ErtsCodePtr) * depth;
     s = (struct StackTrace *) erts_alloc(ERTS_ALC_T_TMP, sz);
     s->depth = 0;
     s->pc = NULL;
@@ -3534,9 +3534,12 @@ fun_info_2(BIF_ALIST_2)
 	    val = make_small(funp->arity);
 	    break;
 	case am_name:
-	    hp = HAlloc(p, 3);
-	    val = funp->fe->address[-2];
-	    break;
+            {
+                const ErtsCodeMFA *mfa = erts_code_to_codemfa((funp->fe)->address);
+                hp = HAlloc(p, 3);
+                val = mfa->function;
+            }
+            break;
 	default:
 	    goto error;
 	}
@@ -3605,9 +3608,16 @@ fun_info_mfa_1(BIF_ALIST_1)
     Eterm* hp;
 
     if (is_fun(fun)) {
-	ErlFunThing* funp = (ErlFunThing *) fun_val(fun);
-	hp = HAlloc(p, 4);
-	BIF_RET(TUPLE3(hp,funp->fe->module,funp->fe->address[-2],make_small(funp->arity)));
+        const ErtsCodeMFA *mfa;
+        ErlFunThing* funp;
+        funp = (ErlFunThing *) fun_val(fun);
+        mfa = erts_code_to_codemfa((funp->fe)->address);
+
+        hp = HAlloc(p, 4);
+        BIF_RET(TUPLE3(hp,
+                       (funp->fe)->module,
+                       mfa->function,
+                       make_small(funp->arity)));
     } else if (is_export(fun)) {
 	Export* exp = (Export *) ((UWord) (export_val(fun))[1]);
 	hp = HAlloc(p, 4);

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -1671,7 +1671,7 @@ uninstall_exp_breakpoints(BpFunctions* f)
 
         if (erts_is_export_trampoline_active(ep, code_ix)) {
             ASSERT(BeamIsOpCode(ep->trampoline.common.op, op_trace_jump_W));
-            ep->addresses[code_ix] = (BeamInstr *) ep->trampoline.trace.address;
+            ep->addresses[code_ix] = (ErtsCodePtr)ep->trampoline.trace.address;
         }
     }
 }

--- a/erts/emulator/beam/erl_fun.h
+++ b/erts/emulator/beam/erl_fun.h
@@ -34,13 +34,13 @@ typedef struct erl_fun_entry {
     int index;                  /* New style index. */
     int old_uniq;               /* Unique number (old_style) */
     int old_index;              /* Old style index */
-    const BeamInstr* address;   /* Pointer to code for fun */
+    ErtsCodePtr address;        /* Pointer to code for fun */
 
-    Uint arity;                 /* The arity of the fun. */
-    Eterm module;               /* Tagged atom for module. */
-    erts_refc_t refc;           /* Reference count: One for code + one for each
-                                 * fun object in each process. */
-    const BeamInstr *pend_purge_address; /* Address during a pending purge */
+    Uint arity;                     /* The arity of the fun. */
+    Eterm module;                   /* Tagged atom for module. */
+    erts_refc_t refc;               /* Reference count: One for code + one for
+                                     * each fun object in each process. */
+    ErtsCodePtr pend_purge_address; /* Address during a pending purge */
 } ErlFunEntry;
 
 /*
@@ -72,9 +72,13 @@ ErlFunEntry* erts_get_fun_entry(Eterm mod, int uniq, int index);
 ErlFunEntry* erts_put_fun_entry2(Eterm mod, int old_uniq, int old_index,
 				const byte* uniq, int index, int arity);
 
+int erts_is_fun_loaded(ErlFunEntry* fe);
+
 void erts_erase_fun_entry(ErlFunEntry* fe);
 void erts_cleanup_funs(ErlFunThing* funp);
-void erts_fun_purge_prepare(BeamInstr* start, BeamInstr* end);
+
+struct erl_module_instance;
+void erts_fun_purge_prepare(struct erl_module_instance* modi);
 void erts_fun_purge_abort_prepare(ErlFunEntry **funs, Uint no);
 void erts_fun_purge_abort_finalize(ErlFunEntry **funs, Uint no);
 void erts_fun_purge_complete(ErlFunEntry **funs, Uint no);

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -954,7 +954,7 @@ garbage_collect_hibernate(Process* p, int check_long_gc)
 
     /* Only allow one continuation pointer. */
     ASSERT(p->stop == p->hend - CP_SIZE);
-    ASSERT(p->stop[0] == make_cp(BeamCodeNormalExit()));
+    ASSERT(p->stop[0] == make_cp(beam_normal_exit));
 
     /*
      * Do it.
@@ -1018,7 +1018,7 @@ garbage_collect_hibernate(Process* p, int check_long_gc)
 
     p->hend = heap + heap_size;
     p->stop = p->hend - CP_SIZE;
-    p->stop[0] = make_cp(BeamCodeNormalExit());
+    p->stop[0] = make_cp(beam_normal_exit);
 
     offs = heap - p->heap;
     area = (char *) p->heap;

--- a/erts/emulator/beam/erl_nfunc_sched.c
+++ b/erts/emulator/beam/erl_nfunc_sched.c
@@ -62,7 +62,7 @@ erts_destroy_nfunc(Process *p)
 
 ErtsNativeFunc *
 erts_nfunc_schedule(Process *c_p, Process *dirty_shadow_proc,
-			 const ErtsCodeMFA *mfa, const BeamInstr *pc,
+			 const ErtsCodeMFA *mfa, ErtsCodePtr pc,
 			 BeamInstr instr,
 			 void *dfunc, void *ifunc,
 			 Eterm mod, Eterm func,
@@ -139,11 +139,11 @@ erts_nfunc_schedule(Process *c_p, Process *dirty_shadow_proc,
     used_proc->arity = argc;
     used_proc->freason = TRAP;
 #ifndef BEAMASM
-    used_proc->i = (BeamInstr*)&nep->trampoline.call_op;
+    used_proc->i = (ErtsCodePtr)&nep->trampoline.call_op;
 #else
     ERTS_CT_ASSERT(sizeof(nep->trampoline.trace) == BEAM_ASM_FUNC_PROLOGUE_SIZE);
-    used_proc->i = (BeamInstr*)&nep->trampoline.trace;
-    erts_code_to_codemfa(used_proc->i);
+    used_proc->i = (ErtsCodePtr)&nep->trampoline.trace;
+    ASSERT_MFA(erts_code_to_codemfa(used_proc->i));
 #endif
     return nep;
 }

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -4273,7 +4273,7 @@ typedef struct {
         /* data */
 #ifdef BEAMASM
         BeamInstr prologue[BEAM_ASM_FUNC_PROLOGUE_SIZE / sizeof(UWord)];
-        BeamInstr call_nif[9];
+        BeamInstr call_nif[10];
 #else
         BeamInstr call_nif[4];
 #endif

--- a/erts/emulator/beam/erl_printf_term.c
+++ b/erts/emulator/beam/erl_printf_term.c
@@ -352,7 +352,9 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
         } else if (is_CP(obj)) {
             const ErtsCodeMFA* mfa = erts_find_function_from_pc(cp_val(obj));
             if (mfa) {
-                const BeamInstr *start = erts_codemfa_to_code(mfa);
+                const UWord *func_start = erts_codemfa_to_code(mfa);
+                const UWord *cp_addr = (UWord*)cp_val(obj);
+
                 PRINT_STRING(res, fn, arg, "<");
                 PRINT_ATOM(res, fn, arg, mfa->module, dcount);
                 PRINT_STRING(res, fn, arg, ":");
@@ -360,7 +362,7 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
                 PRINT_STRING(res, fn, arg, "/");
                 PRINT_UWORD(res, fn, arg, 'u', 0, 1, (ErlPfUWord) mfa->arity);
                 PRINT_STRING(res, fn, arg, "+");
-                PRINT_UWORD(res, fn, arg, 'u', 0, 1, (ErlPfUWord) (cp_val(obj) - start));
+                PRINT_UWORD(res, fn, arg, 'u', 0, 1, (ErlPfUWord) (cp_addr - func_start));
                 PRINT_STRING(res, fn, arg, ">");
             } else {
                 PRINT_STRING(res, fn, arg, "<cp/header:");

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -658,7 +658,7 @@ typedef struct ErtsSchedulerRegisters_ {
 
 #ifdef BEAMASM
     /* Seldom-used scheduler-specific data. */
-    UWord start_time_i;
+    ErtsCodePtr start_time_i;
     UWord start_time;
 
 #if !defined(NATIVE_ERLANG_STACK) && defined(HARD_DEBUG)
@@ -1023,7 +1023,7 @@ struct process {
     unsigned max_arg_reg;	/* Maximum number of argument registers available. */
     Eterm def_arg_reg[6];	/* Default array for argument registers. */
 
-    const BeamInstr* i;         /* Program counter for threaded code. */
+    ErtsCodePtr i;              /* Program counter. */
     Sint catches;		/* Number of catches on stack */
     Uint32 rcount;		/* suspend count */
     int  schedule_count;	/* Times left to reschedule a low prio process */

--- a/erts/emulator/beam/erl_term.c
+++ b/erts/emulator/beam/erl_term.c
@@ -147,8 +147,8 @@ ET_DEFINE_CHECKED(struct erl_node_*,external_ref_node,Eterm,is_external_ref);
 ET_DEFINE_CHECKED(Eterm*,export_val,Wterm,is_export);
 ET_DEFINE_CHECKED(Uint,external_thing_data_words,ExternalThing*,is_thing_ptr);
 
-ET_DEFINE_CHECKED(Eterm,make_cp,const BeamInstr *,_is_taggable_pointer);
-ET_DEFINE_CHECKED(UWord *,cp_val,Eterm,is_CP);
+ET_DEFINE_CHECKED(Eterm,make_cp,ErtsCodePtr,_is_taggable_pointer);
+ET_DEFINE_CHECKED(ErtsCodePtr,cp_val,Eterm,is_CP);
 ET_DEFINE_CHECKED(Uint,catch_val,Eterm,is_catch);
 ET_DEFINE_CHECKED(Uint,loader_x_reg_index,Uint,_is_loader_x_reg);
 ET_DEFINE_CHECKED(Uint,loader_y_reg_index,Uint,_is_loader_y_reg);

--- a/erts/emulator/beam/erl_term.c
+++ b/erts/emulator/beam/erl_term.c
@@ -147,7 +147,7 @@ ET_DEFINE_CHECKED(struct erl_node_*,external_ref_node,Eterm,is_external_ref);
 ET_DEFINE_CHECKED(Eterm*,export_val,Wterm,is_export);
 ET_DEFINE_CHECKED(Uint,external_thing_data_words,ExternalThing*,is_thing_ptr);
 
-ET_DEFINE_CHECKED(Eterm,make_cp,ErtsCodePtr,_is_taggable_pointer);
+ET_DEFINE_CHECKED(Eterm,make_cp,ErtsCodePtr,_is_legal_cp);
 ET_DEFINE_CHECKED(ErtsCodePtr,cp_val,Eterm,is_CP);
 ET_DEFINE_CHECKED(Uint,catch_val,Eterm,is_catch);
 ET_DEFINE_CHECKED(Uint,loader_x_reg_index,Uint,_is_loader_x_reg);

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -1245,6 +1245,7 @@ _ET_DECLARE_CHECKED(struct erl_node_*,external_ref_node,Eterm)
 #error "fix yer arch, like"
 #endif
 
+#define _is_legal_cp(x)	 (((Uint)(x) & _CPMASK) == 0)
 #define _unchecked_make_cp(x)	((Eterm)(x))
 _ET_DECLARE_CHECKED(Eterm,make_cp,ErtsCodePtr)
 #define make_cp(x)	_ET_APPLY(make_cp,(x))

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -1246,14 +1246,14 @@ _ET_DECLARE_CHECKED(struct erl_node_*,external_ref_node,Eterm)
 #endif
 
 #define _unchecked_make_cp(x)	((Eterm)(x))
-_ET_DECLARE_CHECKED(Eterm,make_cp,const BeamInstr*)
+_ET_DECLARE_CHECKED(Eterm,make_cp,ErtsCodePtr)
 #define make_cp(x)	_ET_APPLY(make_cp,(x))
 
 #define is_not_CP(x)	((x) & _CPMASK)
 #define is_CP(x)	(!is_not_CP(x))
 
-#define _unchecked_cp_val(x)	((BeamInstr*) (x))
-_ET_DECLARE_CHECKED(BeamInstr*,cp_val,Eterm)
+#define _unchecked_cp_val(x)	((ErtsCodePtr) (x))
+_ET_DECLARE_CHECKED(ErtsCodePtr,cp_val,Eterm)
 #define cp_val(x)	_ET_APPLY(cp_val,(x))
 
 #define make_catch(x)	(((x) << _TAG_IMMED2_SIZE) | _TAG_IMMED2_CATCH)

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -948,7 +948,7 @@ seq_trace_output_generic(Eterm token, Eterm msg, Uint type,
  * or   {trace, Pid, return_to, {Mod, Func, Arity}}
  */
 void 
-erts_trace_return_to(Process *p, BeamInstr *pc)
+erts_trace_return_to(Process *p, ErtsCodePtr pc)
 {
     const ErtsCodeMFA *cmfa = erts_find_function_from_pc(pc);
     Eterm mfa;

--- a/erts/emulator/beam/erl_trace.h
+++ b/erts/emulator/beam/erl_trace.h
@@ -107,7 +107,7 @@ void erts_trace_return(Process* p, ErtsCodeMFA *mfa, Eterm retval,
                        ErtsTracer *tracer);
 void erts_trace_exception(Process* p, ErtsCodeMFA *mfa, Eterm class_, Eterm value,
                           ErtsTracer *tracer);
-void erts_trace_return_to(Process *p, BeamInstr *pc);
+void erts_trace_return_to(Process *p, ErtsCodePtr pc);
 void trace_sched(Process*, ErtsProcLocks, Eterm);
 void trace_proc(Process*, ErtsProcLocks, Process*, Eterm, Eterm);
 void trace_proc_spawn(Process*, Eterm what, Eterm pid, Eterm mod, Eterm func, Eterm args);

--- a/erts/emulator/beam/erl_vm.h
+++ b/erts/emulator/beam/erl_vm.h
@@ -272,14 +272,23 @@ extern void** beam_ops;
 #define BeamIsOpCode(InstrWord, OpCode) (BeamCodeAddr(InstrWord) == BeamOpCodeAddr(OpCode))
 
 #ifndef BEAMASM
-#define BeamIsReturnTimeTrace(w) BeamIsOpCode(*(w), op_i_return_time_trace)
-#define BeamIsReturnToTrace(w) BeamIsOpCode(*(w), op_i_return_to_trace)
-#define BeamIsReturnTrace(w) BeamIsOpCode(*(w), op_return_trace)
-#else
-#define BeamIsReturnTimeTrace(w) ((w) == beam_return_time_trace)
-#define BeamIsReturnToTrace(w) ((w) == beam_return_to_trace)
-#define BeamIsReturnTrace(w) ((w) == beam_return_trace || (w) == beam_exception_trace)
 
-#endif
+#define BeamIsReturnTimeTrace(w) \
+    BeamIsOpCode(*(const BeamInstr*)(w), op_i_return_time_trace)
+#define BeamIsReturnToTrace(w) \
+    BeamIsOpCode(*(const BeamInstr*)(w), op_i_return_to_trace)
+#define BeamIsReturnTrace(w) \
+    BeamIsOpCode(*(const BeamInstr*)(w), op_return_trace)
+
+#else /* BEAMASM */
+
+#define BeamIsReturnTimeTrace(w) \
+    ((w) == beam_return_time_trace)
+#define BeamIsReturnToTrace(w) \
+    ((w) == beam_return_to_trace)
+#define BeamIsReturnTrace(w) \
+    ((w) == beam_return_trace || (w) == beam_exception_trace)
+
+#endif /* BEAMASM */
 
 #endif	/* __ERL_VM_H__ */

--- a/erts/emulator/beam/error.h
+++ b/erts/emulator/beam/error.h
@@ -209,10 +209,10 @@ extern Eterm exception_tag[NUMBER_EXC_TAGS];
 struct StackTrace {
     Eterm header;	/* bignum header - must be first in struct */
     Eterm freason; /* original exception reason is saved in the struct */
-    const BeamInstr *pc;
+    ErtsCodePtr pc;
     const ErtsCodeMFA* current;
     int depth;	/* number of saved pointers in trace[] */
-    const BeamInstr *trace[1];  /* varying size - must be last in struct */
+    ErtsCodePtr trace[1];  /* varying size - must be last in struct */
 };
 
 #endif /* __ERROR_H__ */

--- a/erts/emulator/beam/export.c
+++ b/erts/emulator/beam/export.c
@@ -49,8 +49,6 @@ static erts_atomic_t total_entries_bytes;
  */
 erts_mtx_t export_staging_lock;
 
-extern BeamInstr* em_call_traced_function;
-
 struct export_entry
 {
     IndexSlot slot; /* MUST BE LOCATED AT TOP OF STRUCT!!! */

--- a/erts/emulator/beam/export.h
+++ b/erts/emulator/beam/export.h
@@ -55,7 +55,7 @@ typedef struct export_
      * accessing these directly.
      *
      * See `BeamAssembler::emit_setup_export_call` for details. */
-    const void *addresses[ERTS_ADDRESSV_SIZE];
+    ErtsCodePtr addresses[ERTS_ADDRESSV_SIZE];
 
     /* Index into bif_table[], or -1 if not a BIF. */
     int bif_number;
@@ -157,27 +157,27 @@ extern erts_mtx_t export_staging_lock;
 
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 
-extern BeamInstr *beam_export_trampoline;
-
 ERTS_GLB_INLINE void erts_activate_export_trampoline(Export *ep, int code_ix) {
-    void *trampoline_address;
+    ErtsCodePtr trampoline_address;
 
 #ifdef BEAMASM
+    extern ErtsCodePtr beam_export_trampoline;
     trampoline_address = beam_export_trampoline;
 #else
-    trampoline_address = &ep->trampoline.raw[0];
+    trampoline_address = (ErtsCodePtr)&ep->trampoline.raw[0];
 #endif
 
     ep->addresses[code_ix] = trampoline_address;
 }
 
 ERTS_GLB_INLINE int erts_is_export_trampoline_active(Export *ep, int code_ix) {
-    void *trampoline_address;
+    ErtsCodePtr trampoline_address;
 
 #ifdef BEAMASM
+    extern ErtsCodePtr beam_export_trampoline;
     trampoline_address = beam_export_trampoline;
 #else
-    trampoline_address = &ep->trampoline.raw[0];
+    trampoline_address = (ErtsCodePtr)&ep->trampoline.raw[0];
 #endif
 
     return ep->addresses[code_ix] == trampoline_address;

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -488,7 +488,7 @@ Sint erts_encode_ext_dist_header_finalize(ErtsDistOutputBuf* ob,
     ip = &instr_buf[0];
     sys_memcpy((void *) ip, (void *) ep, sz);
     ep += sz;
-    ASSERT(ep == (byte *) (ob->eiov->iov[1].iov_base + ob->eiov->iov[1].iov_len));
+    ASSERT(ep == &((byte *)ob->eiov->iov[1].iov_base)[ob->eiov->iov[1].iov_len]);
     if (ci > 0) {
 	Uint32 flgs_buf[((ERTS_DIST_HDR_ATOM_CACHE_FLAG_BYTES(
 			      ERTS_MAX_INTERNAL_ATOM_CACHE_ENTRIES)-1)
@@ -5963,7 +5963,7 @@ Sint transcode_dist_obuf(ErtsDistOutputBuf* ob,
                 bitsize = *ep++;
 
                 /* write fallback prolog... */
-                iov[hopefull_ix].iov_base -= 4;
+                iov[hopefull_ix].iov_base = &((byte*)iov[hopefull_ix].iov_base)[-4];
                 ep = (byte *) iov[hopefull_ix].iov_base;
 
                 *ep++ = SMALL_TUPLE_EXT;
@@ -6001,7 +6001,7 @@ Sint transcode_dist_obuf(ErtsDistOutputBuf* ob,
 
                 ASSERT(1 == iov[hopefull_ix].iov_len);
 
-                iov[hopefull_ix].iov_base -= 4;
+                iov[hopefull_ix].iov_base = &((byte*)iov[hopefull_ix].iov_base)[-4];
                 ep = (byte *) iov[hopefull_ix].iov_base;
                 new_hopefull_ix = get_int32(ep);
                 ASSERT(new_hopefull_ix == ERTS_NO_HIX
@@ -6055,7 +6055,7 @@ Sint transcode_dist_obuf(ErtsDistOutputBuf* ob,
         if (payload_ix) {
             ASSERT(0 < payload_ix && payload_ix < eiov->vsize);
             /* Prepend version magic on payload. */
-            iov[payload_ix].iov_base--;
+            iov[payload_ix].iov_base = &((byte*)iov[payload_ix].iov_base)[-1];
             *((byte *) iov[payload_ix].iov_base) = VERSION_MAGIC;
             iov[payload_ix].iov_len++;
             eiov->size++;

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -108,7 +108,7 @@ typedef struct ErtsResource_
 
 extern Eterm erts_bld_resource_ref(Eterm** hp, ErlOffHeap*, ErtsResource*);
 
-extern BeamInstr* erts_call_nif_early(Process* c_p, const ErtsCodeInfo* ci);
+extern ErtsCodePtr erts_call_nif_early(Process* c_p, const ErtsCodeInfo* ci);
 extern void erts_pre_nif(struct enif_environment_t*, Process*,
 			 struct erl_module_nif*, Process* tracee);
 extern void erts_post_nif(struct enif_environment_t* env);
@@ -123,7 +123,7 @@ extern Eterm erts_nif_taints(Process* p);
 extern void erts_print_nif_taints(fmtfn_t to, void* to_arg);
 
 /* Loads the specified NIF. The caller must have code write permission. */
-Eterm erts_load_nif(Process *c_p, BeamInstr *I, Eterm filename, Eterm args);
+Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args);
 
 void erts_unload_nif(struct erl_module_nif* nif);
 extern void erl_nif_init(void);
@@ -136,7 +136,7 @@ extern Eterm erts_nif_call_function(Process *p, Process *tracee,
                                     int argc, Eterm *argv);
 
 int erts_call_dirty_nif(ErtsSchedulerData *esdp, Process *c_p,
-                        const BeamInstr *I, Eterm *reg);
+                        ErtsCodePtr I, Eterm *reg);
 ErtsMessage* erts_create_message_from_nif_env(ErlNifEnv* msg_env);
 
 
@@ -888,8 +888,6 @@ void erts_bif_info_init(void);
 
 /* bif.c */
 
-void erts_write_bif_wrapper(Export *export_, BeamInstr *address);
-
 void erts_queue_monitor_message(Process *,
 				ErtsProcLocks*,
 				Eterm,
@@ -897,7 +895,7 @@ void erts_queue_monitor_message(Process *,
 				Eterm,
 				Eterm);
 void erts_init_trap_export(Export** epp, Eterm m, Eterm f, Uint a,
-			   Eterm (*bif)(Process*, Eterm*, const BeamInstr*));
+			   Eterm (*bif)(Process*, Eterm*, ErtsCodePtr));
 void erts_init_bif(void);
 Eterm erl_send(Process *p, Eterm to, Eterm msg);
 int erts_set_group_leader(Process *proc, Eterm new_gl);
@@ -967,7 +965,7 @@ Eterm erts_finish_loading(Binary* loader_state, Process* c_p,
 Eterm erts_preload_module(Process *c_p, ErtsProcLocks c_p_locks,
 			  Eterm group_leader, Eterm* mod, byte* code, Uint size);
 void init_load(void);
-const ErtsCodeMFA* erts_find_function_from_pc(const BeamInstr* pc);
+const ErtsCodeMFA* erts_find_function_from_pc(ErtsCodePtr pc);
 Eterm* erts_build_mfa_item(FunctionInfo* fi, Eterm* hp,
 			   Eterm args, Eterm* mfa_p);
 void erts_set_current_function(FunctionInfo* fi, const ErtsCodeMFA* mfa);
@@ -977,11 +975,11 @@ Eterm erts_make_stub_module(Process* p, Eterm Mod, Eterm Beam, Eterm Info);
 void erts_init_ranges(void);
 void erts_start_staging_ranges(int num_new);
 void erts_end_staging_ranges(int commit);
-void erts_update_ranges(BeamInstr* code, Uint size);
-void erts_remove_from_ranges(BeamInstr* code);
+void erts_update_ranges(const BeamCodeHeader* code, Uint size);
+void erts_remove_from_ranges(const BeamCodeHeader* code);
 UWord erts_ranges_sz(void);
 void erts_lookup_function_info(FunctionInfo* fi,
-                               const BeamInstr* pc,
+                               ErtsCodePtr pc,
                                int full_info);
 extern ErtsLiteralArea** erts_dump_lit_areas;
 extern Uint erts_dump_num_lit_areas;
@@ -1171,7 +1169,7 @@ void erts_dirty_process_main(ErtsSchedulerData *);
 Eterm build_stacktrace(Process* c_p, Eterm exc);
 Eterm expand_error_value(Process* c_p, Uint freason, Eterm Value);
 void erts_save_stacktrace(Process* p, struct StackTrace* s, int depth);
-BeamInstr *erts_printable_return_address(Process* p, Eterm *E) ERTS_NOINLINE;
+ErtsCodePtr erts_printable_return_address(Process* p, Eterm *E) ERTS_NOINLINE;
 
 /* erl_init.c */
 

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -661,10 +661,11 @@ int beam_load_finish_emit(LoaderState *stp) {
         Uint line_size = offsetof(BeamCodeLineTab, func_tab);
 
         /* func_tab */
-        line_size += (stp->beam.code.function_count + 1) * sizeof(BeamInstr **);
+        line_size +=
+                (stp->beam.code.function_count + 1) * sizeof(ErtsCodePtr *);
 
         /* line items */
-        line_size += (stp->current_li + 1) * sizeof(BeamInstr *);
+        line_size += (stp->current_li + 1) * sizeof(ErtsCodePtr);
 
         /* fname table */
         line_size += stp->beam.lines.name_count * sizeof(Eterm);
@@ -837,7 +838,7 @@ void beam_load_finalize_code(LoaderState *stp,
 
     for (i = 0; i < stp->beam.exports.count; i++) {
         BeamFile_ExportEntry *entry = &stp->beam.exports.entries[i];
-        const BeamInstr *address;
+        ErtsCodePtr address;
         Export *ep;
 
         address = beamasm_get_code(stp->ba, entry->label);
@@ -883,7 +884,7 @@ void beam_load_finalize_code(LoaderState *stp,
                                             lambda->index,
                                             lambda->arity - lambda->num_free);
 
-            if (fun_entry->address[0] != 0) {
+            if (erts_is_fun_loaded(fun_entry)) {
                 /* We've reloaded a module over itself and inherited the old
                  * instance's fun entries, so we need to undo the reference
                  * bump in `erts_put_fun_entry2` to make fun purging work. */

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -374,7 +374,7 @@ int beam_load_emit_op(LoaderState *stp, BeamOp *tmp_op) {
             break;
         case 'L': /* Define label */
             ASSERT(stp->specific_op == op_label_L ||
-                   stp->specific_op == op_aligned_label_L);
+                   stp->specific_op == op_aligned_label_Lt);
             BeamLoadVerifyTag(stp, tag, TAG_u);
             stp->last_label = curr->val;
             if (stp->last_label < 0 ||

--- a/erts/emulator/beam/jit/beam_asm.cpp
+++ b/erts/emulator/beam/jit/beam_asm.cpp
@@ -230,13 +230,17 @@ void beamasm_init() {
         func_label = label++;
         entry_label = label++;
 
-        bma->emit(op_aligned_label_L, {ArgVal(ArgVal::i, func_label)});
+        bma->emit(op_aligned_label_Lt,
+                  {ArgVal(ArgVal::i, func_label),
+                   ArgVal(ArgVal::u, sizeof(UWord))});
         bma->emit(op_i_func_info_IaaI,
                   {ArgVal(ArgVal::i, func_label),
                    ArgVal(ArgVal::i, am_erts_internal),
                    ArgVal(ArgVal::i, op.name),
                    ArgVal(ArgVal::i, 0)});
-        bma->emit(op_aligned_label_L, {ArgVal(ArgVal::i, entry_label)});
+        bma->emit(op_aligned_label_Lt,
+                  {ArgVal(ArgVal::i, entry_label),
+                   ArgVal(ArgVal::u, sizeof(UWord))});
         bma->emit(op.operand, {});
 
         op.operand = entry_label;
@@ -249,15 +253,21 @@ void beamasm_init() {
         apply_label = label++;
         normal_exit_label = label++;
 
-        bma->emit(op_aligned_label_L, {ArgVal(ArgVal::i, func_label)});
+        bma->emit(op_aligned_label_Lt,
+                  {ArgVal(ArgVal::i, func_label),
+                   ArgVal(ArgVal::u, sizeof(UWord))});
         bma->emit(op_i_func_info_IaaI,
                   {ArgVal(ArgVal::i, func_label),
                    ArgVal(ArgVal::i, am_erts_internal),
                    ArgVal(ArgVal::i, am_apply),
                    ArgVal(ArgVal::i, 3)});
-        bma->emit(op_aligned_label_L, {ArgVal(ArgVal::i, apply_label)});
+        bma->emit(op_aligned_label_Lt,
+                  {ArgVal(ArgVal::i, apply_label),
+                   ArgVal(ArgVal::u, sizeof(UWord))});
         bma->emit(op_i_apply, {});
-        bma->emit(op_aligned_label_L, {ArgVal(ArgVal::i, normal_exit_label)});
+        bma->emit(op_aligned_label_Lt,
+                  {ArgVal(ArgVal::i, normal_exit_label),
+                   ArgVal(ArgVal::u, sizeof(UWord))});
         bma->emit(op_normal_exit, {});
 
         bma->emit(op_int_code_end, {});
@@ -744,13 +754,15 @@ extern "C"
                                unsigned buff_len) {
         BeamModuleAssembler ba(bga, info->mfa.module, 3);
 
-        ba.emit(op_aligned_label_L, {ArgVal(ArgVal::i, 1)});
+        ba.emit(op_aligned_label_Lt,
+                {ArgVal(ArgVal::i, 1), ArgVal(ArgVal::u, sizeof(UWord))});
         ba.emit(op_i_func_info_IaaI,
                 {ArgVal(ArgVal::i, 1),
                  ArgVal(ArgVal::i, info->mfa.module),
                  ArgVal(ArgVal::i, info->mfa.function),
                  ArgVal(ArgVal::i, info->mfa.arity)});
-        ba.emit(op_aligned_label_L, {ArgVal(ArgVal::i, 2)});
+        ba.emit(op_aligned_label_Lt,
+                {ArgVal(ArgVal::i, 2), ArgVal(ArgVal::u, sizeof(UWord))});
         ba.emit(op_i_breakpoint_trampoline, {});
         ba.emit(op_call_nif_WWW,
                 {ArgVal(ArgVal::i, (BeamInstr)normal_fptr),
@@ -766,13 +778,15 @@ extern "C"
                                unsigned buff_len) {
         BeamModuleAssembler ba(bga, info->mfa.module, 3);
 
-        ba.emit(op_aligned_label_L, {ArgVal(ArgVal::i, 1)});
+        ba.emit(op_aligned_label_Lt,
+                {ArgVal(ArgVal::i, 1), ArgVal(ArgVal::u, sizeof(UWord))});
         ba.emit(op_i_func_info_IaaI,
                 {ArgVal(ArgVal::i, 1),
                  ArgVal(ArgVal::i, info->mfa.module),
                  ArgVal(ArgVal::i, info->mfa.function),
                  ArgVal(ArgVal::i, info->mfa.arity)});
-        ba.emit(op_aligned_label_L, {ArgVal(ArgVal::i, 2)});
+        ba.emit(op_aligned_label_Lt,
+                {ArgVal(ArgVal::i, 2), ArgVal(ArgVal::u, sizeof(UWord))});
         ba.emit(op_i_breakpoint_trampoline, {});
         ba.emit(op_call_bif_W, {ArgVal(ArgVal::i, (BeamInstr)bif)});
 

--- a/erts/emulator/beam/jit/beam_asm.h
+++ b/erts/emulator/beam/jit/beam_asm.h
@@ -47,7 +47,7 @@ void beamasm_purge_module(const void *native_module_exec,
                           void *native_module_rw);
 void beamasm_delete_assembler(void *ba);
 int beamasm_emit(void *ba, unsigned specific_op, BeamOp *op);
-const BeamInstr *beamasm_get_code(void *ba, int label);
+ErtsCodePtr beamasm_get_code(void *ba, int label);
 const byte *beamasm_get_rodata(void *ba, char *label);
 void beamasm_embed_rodata(void *ba,
                           const char *labelName,
@@ -72,7 +72,7 @@ void beamasm_emit_call_nif(const ErtsCodeInfo *info,
                            char *buff,
                            unsigned buff_len);
 Uint beamasm_get_header(void *ba, const BeamCodeHeader **);
-BeamInstr *beamasm_get_on_load(void *ba);
+const ErtsCodeInfo *beamasm_get_on_load(void *ba);
 
 /* Return the module base, for line information. */
 char *beamasm_get_base(void *instance);

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -948,8 +948,8 @@ public:
     }
 
     struct AsmRange {
-        const BeamInstr *start;
-        const BeamInstr *stop;
+        ErtsCodePtr start;
+        ErtsCodePtr stop;
         std::string name;
 
         /* Not used yet */
@@ -1178,7 +1178,7 @@ public:
 
     void codegen(char *buff, size_t len);
 
-    BeamInstr *getCode(unsigned label);
+    ErtsCodePtr getCode(unsigned label);
     void *getCode(Label label) {
         return BeamAssembler::getCode(label);
     }
@@ -1195,7 +1195,7 @@ public:
 
     void copyCodeHeader(BeamCodeHeader *hdr);
     BeamCodeHeader *getCodeHeader(void);
-    BeamInstr *getOnLoad(void);
+    const ErtsCodeInfo *getOnLoad(void);
 
     unsigned patchCatches(char *rw_base);
     void patchLambda(char *rw_base, unsigned index, BeamInstr I);

--- a/erts/emulator/beam/jit/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/beam_asm_global.cpp
@@ -77,13 +77,13 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
     ranges.reserve(emitPtrs.size());
 
     for (auto val : emitPtrs) {
-        BeamInstr *start = (BeamInstr *)getCode(labels[val.first]);
-        BeamInstr *stop;
+        ErtsCodePtr start = (ErtsCodePtr)getCode(labels[val.first]);
+        ErtsCodePtr stop;
 
         if (val.first + 1 < emitPtrs.size()) {
-            stop = (BeamInstr *)getCode(labels[(GlobalLabels)(val.first + 1)]);
+            stop = (ErtsCodePtr)getCode(labels[(GlobalLabels)(val.first + 1)]);
         } else {
-            stop = (BeamInstr *)((char *)getBaseAddress() + code.codeSize());
+            stop = (ErtsCodePtr)((char *)getBaseAddress() + code.codeSize());
         }
 
         ranges.push_back({.start = start,
@@ -286,9 +286,7 @@ void BeamGlobalAssembler::emit_handle_error_shared() {
 
     emit_enter_runtime<Update::eStack | Update::eHeap>();
 
-    /* The error address must be a valid CP or NULL. The check is done here
-     * rather than in handle_error since the compiler is free to assume that any
-     * BeamInstr* is properly aligned. */
+    /* The error address must be a valid CP or NULL. */
     a.test(ARG2d, imm(_CPMASK));
     a.short_().jne(crash);
 

--- a/erts/emulator/beam/jit/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/beam_asm_module.cpp
@@ -147,9 +147,9 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
     }
 }
 
-BeamInstr *BeamModuleAssembler::getCode(unsigned label) {
+ErtsCodePtr BeamModuleAssembler::getCode(unsigned label) {
     ASSERT(label < labels.size() + 1);
-    return (BeamInstr *)getCode(labels[label]);
+    return (ErtsCodePtr)getCode(labels[label]);
 }
 
 void BeamAssembler::embed_rodata(const char *labelName,
@@ -462,7 +462,7 @@ void BeamModuleAssembler::codegen(JitAllocator *allocator,
     }
 
     sys_memcpy(code_hdr_rw, in_hdr, sizeof(BeamCodeHeader));
-    code_hdr_rw->on_load_function_ptr = getOnLoad();
+    code_hdr_rw->on_load = getOnLoad();
 
     for (unsigned i = 0; i < functions.size(); i++) {
         ErtsCodeInfo *ci = (ErtsCodeInfo *)getCode(functions[i]);
@@ -489,12 +489,12 @@ void BeamModuleAssembler::codegen(JitAllocator *allocator,
         ranges.reserve(functions.size() + 2);
 
         /* Push info about the header */
-        ranges.push_back({.start = (BeamInstr *)getBaseAddress(),
+        ranges.push_back({.start = (ErtsCodePtr)getBaseAddress(),
                           .stop = getCode(functions[0]),
                           .name = name + "::codeHeader"});
 
         for (unsigned i = 0; i < functions.size(); i++) {
-            const BeamInstr *start, *stop;
+            ErtsCodePtr start, stop;
             const ErtsCodeInfo *ci;
             int n;
 
@@ -507,8 +507,8 @@ void BeamModuleAssembler::codegen(JitAllocator *allocator,
                               ci->mfa.module,
                               ci->mfa.function,
                               ci->mfa.arity);
-            stop = erts_codeinfo_to_code(ci) +
-                   BEAM_ASM_FUNC_PROLOGUE_SIZE / sizeof(UWord);
+            stop = ((const char *)erts_codeinfo_to_code(ci)) +
+                   BEAM_ASM_FUNC_PROLOGUE_SIZE;
 
             /* We use a different symbol for CodeInfo and the Prologue
                in order for the perf disassembly to be better. */
@@ -531,7 +531,7 @@ void BeamModuleAssembler::codegen(JitAllocator *allocator,
         /* Push info about the footer */
         ranges.push_back(
                 {.start = ranges.back().stop,
-                 .stop = (BeamInstr *)(code.baseAddress() + code.codeSize()),
+                 .stop = (ErtsCodePtr)(code.baseAddress() + code.codeSize()),
                  .name = name + "::codeFooter"});
 
         update_gdb_jit_info(name, ranges);
@@ -555,11 +555,12 @@ BeamCodeHeader *BeamModuleAssembler::getCodeHeader() {
     return (BeamCodeHeader *)getCode(codeHeader);
 }
 
-BeamInstr *BeamModuleAssembler::getOnLoad() {
-    if (on_load.isValid())
-        return (BeamInstr *)getCode(on_load);
-    else
+const ErtsCodeInfo *BeamModuleAssembler::getOnLoad() {
+    if (on_load.isValid()) {
+        return erts_code_to_codeinfo((ErtsCodePtr)getCode(on_load));
+    } else {
         return 0;
+    }
 }
 
 unsigned BeamModuleAssembler::patchCatches(char *rw_base) {
@@ -567,9 +568,9 @@ unsigned BeamModuleAssembler::patchCatches(char *rw_base) {
 
     for (const auto &c : catches) {
         const auto &patch = c.patch;
-        BeamInstr *handler;
+        ErtsCodePtr handler;
 
-        handler = reinterpret_cast<BeamInstr *>(getCode(c.handler));
+        handler = (ErtsCodePtr)getCode(c.handler);
         catch_no = beam_catches_cons(handler, catch_no, nullptr);
 
         /* Patch the `mov` instruction with the catch tag */

--- a/erts/emulator/beam/jit/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/beam_asm_module.cpp
@@ -388,8 +388,10 @@ void BeamModuleAssembler::emit_label(const ArgVal &Label) {
     a.bind(currLabel);
 }
 
-void BeamModuleAssembler::emit_aligned_label(const ArgVal &Label) {
-    a.align(kAlignCode, 8);
+void BeamModuleAssembler::emit_aligned_label(const ArgVal &Label,
+                                             const ArgVal &Alignment) {
+    ASSERT(Alignment.getType() == ArgVal::u);
+    a.align(kAlignCode, Alignment.getValue());
     emit_label(Label);
 }
 

--- a/erts/emulator/beam/jit/instr_bif.cpp
+++ b/erts/emulator/beam/jit/instr_bif.cpp
@@ -322,7 +322,7 @@ void BeamModuleAssembler::emit_i_length(const ArgVal &Fail,
                                         const ArgVal &Dst) {
     Label entry = a.newLabel();
 
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(entry);
 
     mov_arg(ARG2, Live);
@@ -612,10 +612,7 @@ void BeamModuleAssembler::emit_call_light_bif(const ArgVal &Bif,
                                               const ArgVal &Exp) {
     Label entry = a.newLabel();
 
-    /*
-     * The entry address must be aligned to a word boundary.
-     */
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(entry);
 
     make_move_patch(ARG4, imports[Exp.getValue()].patches);
@@ -627,11 +624,12 @@ void BeamModuleAssembler::emit_call_light_bif(const ArgVal &Bif,
 
 void BeamModuleAssembler::emit_send() {
     Label entry = a.newLabel();
+
     /* This is essentially a mirror of call_light_bif, there's no point to
      * specializing send/2 anymore.
      *
      * FIXME: Rewrite this to an ordinary BIF in the loader instead. */
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(entry);
 
     a.mov(ARG4, imm(BIF_TRAP_EXPORT(BIF_send_2)));
@@ -1119,7 +1117,7 @@ void BeamModuleAssembler::emit_i_load_nif() {
     fragment_call(entry);
     a.short_().jmp(next);
 
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(entry);
     {
         a.lea(ARG2, x86::qword_ptr(entry));
@@ -1136,7 +1134,7 @@ void BeamModuleAssembler::emit_i_load_nif() {
 
     Label entry = a.newLabel(), next = a.newLabel(), schedule = a.newLabel();
 
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(entry);
 
     emit_enter_runtime<Update::eStack | Update::eHeap>();

--- a/erts/emulator/beam/jit/instr_bif.cpp
+++ b/erts/emulator/beam/jit/instr_bif.cpp
@@ -344,7 +344,7 @@ void BeamModuleAssembler::emit_i_length(const ArgVal &Fail,
 
 static Eterm debug_call_light_bif(Process *c_p,
                                   Eterm *reg,
-                                  BeamInstr *I,
+                                  ErtsCodePtr I,
                                   ErtsBifFunc vbf) {
     Eterm result;
 
@@ -643,7 +643,7 @@ void BeamModuleAssembler::emit_send() {
 
 static Eterm call_bif(Process *c_p,
                       Eterm *reg,
-                      BeamInstr *I,
+                      ErtsCodePtr I,
                       ErtsBifFunc vbf,
                       Uint arity) {
     ErlHeapFragment *live_hf_end;
@@ -679,7 +679,7 @@ static Eterm call_bif(Process *c_p,
 typedef Eterm NifF(struct enif_environment_t *, int argc, Eterm argv[]);
 
 static Eterm call_nif(Process *c_p,
-                      BeamInstr *I,
+                      ErtsCodePtr I,
                       Eterm *reg,
                       NifF *fp,
                       struct erl_module_nif *NifMod) {
@@ -1046,7 +1046,7 @@ void BeamModuleAssembler::emit_call_nif(const ArgVal &Func,
 
 enum nif_load_ret { RET_NIF_success, RET_NIF_error, RET_NIF_yield };
 
-static enum nif_load_ret load_nif(Process *c_p, BeamInstr *I, Eterm *reg) {
+static enum nif_load_ret load_nif(Process *c_p, ErtsCodePtr I, Eterm *reg) {
     if (erts_try_seize_code_write_permission(c_p)) {
         Eterm result;
 

--- a/erts/emulator/beam/jit/instr_bif.cpp
+++ b/erts/emulator/beam/jit/instr_bif.cpp
@@ -641,22 +641,13 @@ void BeamModuleAssembler::emit_send() {
     fragment_call(ga->get_call_light_bif_shared());
 }
 
-static Eterm call_bif(Process *c_p, Eterm *reg, BeamInstr *I, ErtsBifFunc vbf) {
+static Eterm call_bif(Process *c_p,
+                      Eterm *reg,
+                      BeamInstr *I,
+                      ErtsBifFunc vbf,
+                      Uint arity) {
     ErlHeapFragment *live_hf_end;
-    const ErtsCodeMFA *codemfa;
     Eterm result;
-
-    codemfa = erts_code_to_codemfa(I);
-
-    /* In case we apply process_info/1,2 or load_nif/1 */
-    c_p->current = codemfa;
-
-    /* In case we apply check_process_code/2. */
-    c_p->i = I;
-
-    /* To allow garbage collection on ourselves
-     * (check_process_code/2, put/2, etc). */
-    c_p->arity = 0;
 
     ERTS_UNREQ_PROC_MAIN_LOCK(c_p);
     {
@@ -679,7 +670,7 @@ static Eterm call_bif(Process *c_p, Eterm *reg, BeamInstr *I, ErtsBifFunc vbf) {
                                             live_hf_end,
                                             result,
                                             reg,
-                                            codemfa->arity);
+                                            arity);
     }
 
     return result;
@@ -825,9 +816,24 @@ void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
     }
 }
 
+/* Used by call_bif, dispatch_bif, and export_trampoline.
+ *
+ * Note that we don't check reductions here as we may have jumped here through
+ * interpreted code (e.g. an ErtsNativeFunc or export entry) and it's very
+ * tricky to yield back. Reductions are checked in module code instead.
+ *
+ * ARG2 = BIF MFA
+ * ARG3 = I (rip), doesn't need to point past an MFA
+ * ARG4 = function to be called */
 void BeamGlobalAssembler::emit_call_bif_shared(void) {
-    a.dec(FCALLS);
-    a.jle(labels[context_switch]);
+    /* "Heavy" BIFs need up-to-date values for `c_p->i`, `c_p->current`, and
+     * `c_p->arity`. */
+
+    a.mov(x86::qword_ptr(c_p, offsetof(Process, current)), ARG2);
+    /* `call_bif` wants arity in ARG5. */
+    a.mov(ARG5, x86::qword_ptr(ARG2, offsetof(ErtsCodeMFA, arity)));
+    a.mov(x86::qword_ptr(c_p, offsetof(Process, arity)), ARG5);
+    a.mov(x86::qword_ptr(c_p, offsetof(Process, i)), ARG3);
 
     /* The corresponding leave can be found in the epilogue. */
     emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
@@ -835,38 +841,30 @@ void BeamGlobalAssembler::emit_call_bif_shared(void) {
 #ifdef ERTS_MSACC_EXTENDED_STATES
     {
         Label skip_msacc = a.newLabel();
-        int module_offset;
-
-        module_offset = -(Sint)sizeof(ErtsCodeInfo) +
-                        offsetof(ErtsCodeInfo, mfa.module);
 
         a.cmp(erts_msacc_cache, 0);
         a.short_().je(skip_msacc);
 
         a.mov(TMP_MEM1q, ARG3);
         a.mov(TMP_MEM2q, ARG4);
+        a.mov(TMP_MEM3q, ARG5);
 
         a.mov(ARG1, erts_msacc_cache);
-        a.mov(ARG2, x86::qword_ptr(ARG3, module_offset));
+        a.mov(ARG2, x86::qword_ptr(ARG2, offset(ErtsCodeMFA, module)));
         a.mov(ARG3, ARG4);
         runtime_call<3>(erts_msacc_set_bif_state);
 
         a.mov(ARG3, TMP_MEM1q);
         a.mov(ARG4, TMP_MEM2q);
+        a.mov(ARG5, TMP_MEM3q);
         a.bind(skip_msacc);
     }
 #endif
 
-    /* These arguments have already been provided:
-     *
-     *    ARG3 = I (rip)
-     *    ARG4 = function to be called
-     */
-
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    a.mov(RET, (uint64_t)call_bif);
-    a.call(RET);
+    /* ARG3 (I), ARG4 (func), and ARG5 (arity) have already been provided. */
+    runtime_call<5>(call_bif);
 
 #ifdef ERTS_MSACC_EXTENDED_STATES
     a.mov(TMP_MEM1q, RET);
@@ -881,21 +879,29 @@ void BeamGlobalAssembler::emit_call_bif_shared(void) {
 void BeamGlobalAssembler::emit_dispatch_bif(void) {
     /* c_p->i points into the trampoline of a ErtsNativeFunc, right after the
      * `info` structure. */
-    ssize_t dfunc_offset;
+    a.mov(ARG3, x86::qword_ptr(c_p, offsetof(Process, i)));
 
     ERTS_CT_ASSERT(offsetof(ErtsNativeFunc, trampoline.trace) ==
                    sizeof(ErtsCodeInfo));
-    dfunc_offset = offsetof(ErtsNativeFunc, trampoline.dfunc) -
-                   offsetof(ErtsNativeFunc, trampoline.trace);
 
-    a.mov(ARG3, x86::qword_ptr(c_p, offsetof(Process, i)));
+    ssize_t mfa_offset = offsetof(ErtsNativeFunc, trampoline.info.mfa) -
+                         offsetof(ErtsNativeFunc, trampoline.trace);
+    a.lea(ARG2, x86::qword_ptr(ARG3, mfa_offset));
+
+    ssize_t dfunc_offset = offsetof(ErtsNativeFunc, trampoline.dfunc) -
+                           offsetof(ErtsNativeFunc, trampoline.trace);
     a.mov(ARG4, x86::qword_ptr(ARG3, dfunc_offset));
+
     a.jmp(labels[call_bif_shared]);
 }
 
 void BeamModuleAssembler::emit_call_bif(const ArgVal &Func) {
+    int mfa_offset = -(int)sizeof(ErtsCodeMFA);
+
+    a.lea(ARG2, x86::qword_ptr(currLabel, mfa_offset));
     a.lea(ARG3, x86::qword_ptr(currLabel));
     mov_arg(ARG4, Func);
+
     abs_jmp(ga->get_call_bif_shared());
 }
 
@@ -945,57 +951,46 @@ void BeamGlobalAssembler::emit_call_nif_early() {
 
     /* Emulate `emit_call_nif`, loading the current (phony) instruction
      * pointer into ARG2. */
-    a.mov(ARG2, RET);
+    a.mov(ARG3, RET);
     a.jmp(labels[call_nif_shared]);
 }
 
-/* Both dispatch_nif and call_nif will end up in this function
+/* Used by call_nif, call_nif_early, and dispatch_nif.
  *
- * ARG2 = current I, just past the end of an ErtsCodeInfo */
+ * Note that we don't check reductions here as we may have jumped here through
+ * interpreted code (e.g. an ErtsNativeFunc or export entry) and it's very
+ * tricky to yield back. Reductions are checked in module code instead.
+ *
+ * ARG3 = current I, just past the end of an ErtsCodeInfo. */
 void BeamGlobalAssembler::emit_call_nif_shared(void) {
-    Label execute = a.newLabel(), yield = a.newLabel();
-
-    a.dec(FCALLS);
-    a.jl(yield);
-
-    a.bind(execute);
-    {
-        /* The corresponding leave can be found in the epilogue. */
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+    /* The corresponding leave can be found in the epilogue. */
+    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
 
 #ifdef ERTS_MSACC_EXTENDED_STATES
-        {
-            Label skip_msacc = a.newLabel();
+    {
+        Label skip_msacc = a.newLabel();
 
-            a.cmp(erts_msacc_cache, 0);
-            a.short_().je(skip_msacc);
-            a.mov(TMP_MEM1q, ARG2);
-            a.mov(ARG1, erts_msacc_cache);
-            a.mov(ARG2, imm(ERTS_MSACC_STATE_NIF));
-            a.mov(ARG3, imm(1));
-            runtime_call<3>(erts_msacc_set_state_m__);
-            a.mov(ARG2, TMP_MEM1q);
-            a.bind(skip_msacc);
-        }
+        a.cmp(erts_msacc_cache, 0);
+        a.short_().je(skip_msacc);
+        a.mov(TMP_MEM1q, ARG3);
+        a.mov(ARG1, erts_msacc_cache);
+        a.mov(ARG2, imm(ERTS_MSACC_STATE_NIF));
+        a.mov(ARG3, imm(1));
+        runtime_call<3>(erts_msacc_set_state_m__);
+        a.mov(ARG3, TMP_MEM1q);
+        a.bind(skip_msacc);
+    }
 #endif
 
-        a.mov(ARG1, c_p);
-        /* ARG2 set in caller */
-        load_x_reg_array(ARG3);
-        a.mov(ARG4, x86::qword_ptr(ARG2, 8 + BEAM_ASM_FUNC_PROLOGUE_SIZE));
-        a.mov(ARG5, x86::qword_ptr(ARG2, 16 + BEAM_ASM_FUNC_PROLOGUE_SIZE));
-        a.mov(ARG6, x86::qword_ptr(ARG2, 24 + BEAM_ASM_FUNC_PROLOGUE_SIZE));
-        runtime_call<5>(call_nif);
+    a.mov(ARG1, c_p);
+    a.mov(ARG2, ARG3);
+    load_x_reg_array(ARG3);
+    a.mov(ARG4, x86::qword_ptr(ARG2, 8 + BEAM_ASM_FUNC_PROLOGUE_SIZE));
+    a.mov(ARG5, x86::qword_ptr(ARG2, 16 + BEAM_ASM_FUNC_PROLOGUE_SIZE));
+    a.mov(ARG6, x86::qword_ptr(ARG2, 24 + BEAM_ASM_FUNC_PROLOGUE_SIZE));
+    runtime_call<5>(call_nif);
 
-        emit_bif_nif_epilogue();
-    }
-
-    a.bind(yield);
-    {
-        a.mov(ARG3, ARG2);
-        a.jmp(labels[context_switch]);
-    }
+    emit_bif_nif_epilogue();
 }
 
 void BeamGlobalAssembler::emit_dispatch_nif(void) {
@@ -1006,7 +1001,7 @@ void BeamGlobalAssembler::emit_dispatch_nif(void) {
      * do anything beyond loading the address. */
     ERTS_CT_ASSERT(offsetof(ErtsNativeFunc, trampoline.trace) ==
                    sizeof(ErtsCodeInfo));
-    a.mov(ARG2, x86::qword_ptr(c_p, offsetof(Process, i)));
+    a.mov(ARG3, x86::qword_ptr(c_p, offsetof(Process, i)));
     a.jmp(labels[call_nif_shared]);
 }
 
@@ -1015,12 +1010,11 @@ void BeamGlobalAssembler::emit_dispatch_nif(void) {
 void BeamModuleAssembler::emit_call_nif(const ArgVal &Func,
                                         const ArgVal &NifMod,
                                         const ArgVal &DirtyFunc) {
-    Label entry = a.newLabel();
+    Label dispatch = a.newLabel();
     uint64_t val;
 
-    /* The start of this function has to mimic the layout of ErtsNativeFunc...
-     */
-    a.jmp(entry); /* call_op */
+    /* The start of this function has to mimic the layout of ErtsNativeFunc. */
+    a.jmp(dispatch); /* call_op */
 
     a.align(kAlignCode, 8);
     /* ErtsNativeFunc.dfunc */
@@ -1034,10 +1028,20 @@ void BeamModuleAssembler::emit_call_nif(const ArgVal &Func,
     a.embed(&val, sizeof(val));
 
     /* The real code starts here */
-    a.bind(entry);
-    a.lea(ARG2, x86::qword_ptr(currLabel));
+    a.bind(dispatch);
+    {
+        Label yield = a.newLabel();
 
-    pic_jmp(ga->get_call_nif_shared());
+        a.lea(ARG3, x86::qword_ptr(currLabel));
+
+        a.dec(FCALLS);
+        a.jl(yield);
+
+        pic_jmp(ga->get_call_nif_shared());
+
+        a.bind(yield);
+        pic_jmp(ga->get_context_switch());
+    }
 }
 
 enum nif_load_ret { RET_NIF_success, RET_NIF_error, RET_NIF_yield };

--- a/erts/emulator/beam/jit/instr_call.cpp
+++ b/erts/emulator/beam/jit/instr_call.cpp
@@ -133,7 +133,7 @@ static ErtsCodeMFA apply3_mfa = {am_erlang, am_apply, 3};
 x86::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
     Label dispatch = a.newLabel(), entry = a.newLabel();
 
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(entry);
 
     emit_enter_runtime<Update::eStack | Update::eHeap>();
@@ -180,7 +180,7 @@ x86::Mem BeamModuleAssembler::emit_fixed_apply(const ArgVal &Arity,
                                                bool includeI) {
     Label dispatch = a.newLabel(), entry = a.newLabel();
 
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(entry);
 
     mov_arg(ARG3, Arity);

--- a/erts/emulator/beam/jit/instr_common.cpp
+++ b/erts/emulator/beam/jit/instr_common.cpp
@@ -1805,8 +1805,9 @@ void BeamModuleAssembler::emit_i_test_yield() {
     Label next = a.newLabel(), entry = a.newLabel();
 
     /* When present, this is guaranteed to be the first instruction after the
-     * function entry label, so we can use `currLabel`. */
-    a.align(kAlignCode, 8);
+     * breakpoint trampoline. */
+
+    ASSERT(a.offset() % 8 == 0);
     a.bind(entry);
     a.dec(FCALLS);
     a.short_().jg(next);

--- a/erts/emulator/beam/jit/instr_map.cpp
+++ b/erts/emulator/beam/jit/instr_map.cpp
@@ -138,7 +138,7 @@ static Uint i_get_map_elements(Eterm map,
                                Eterm *reg,
                                Eterm *E,
                                Uint n,
-                               BeamInstr *fs) {
+                               Eterm *fs) {
     Uint sz;
 
     /* This instruction assumes Arg1 is a map, i.e. that it follows a test
@@ -160,7 +160,7 @@ static Uint i_get_map_elements(Eterm map,
         vs = flatmap_get_values(mp);
 
         while (sz) {
-            if (EQ((Eterm)fs[0], *ks)) {
+            if (EQ(fs[0], *ks)) {
                 PUT_TERM_REG(*vs, fs[1]);
 
                 n--;
@@ -183,9 +183,9 @@ static Uint i_get_map_elements(Eterm map,
             Uint32 hx;
 
             hx = fs[2];
-            ASSERT(hx == hashmap_make_hash((Eterm)fs[0]));
+            ASSERT(hx == hashmap_make_hash(fs[0]));
 
-            if ((v = erts_hashmap_get(hx, (Eterm)fs[0], map)) == NULL) {
+            if ((v = erts_hashmap_get(hx, fs[0], map)) == NULL) {
                 return 0;
             }
 

--- a/erts/emulator/beam/jit/instr_msg.cpp
+++ b/erts/emulator/beam/jit/instr_msg.cpp
@@ -190,7 +190,7 @@ void BeamGlobalAssembler::emit_i_loop_rec_shared() {
 void BeamModuleAssembler::emit_i_loop_rec(const ArgVal &Wait) {
     Label entry = a.newLabel();
 
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(entry);
 
     a.lea(ARG1, x86::qword_ptr(entry));
@@ -452,7 +452,7 @@ void BeamModuleAssembler::emit_wait_timeout_locked(const ArgVal &Src,
     a.bind(wait);
     emit_wait_locked(Dest);
 
-    a.align(kAlignCode, 8);
+    align_erlang_cp();
     a.bind(next);
 }
 

--- a/erts/emulator/beam/jit/instr_msg.cpp
+++ b/erts/emulator/beam/jit/instr_msg.cpp
@@ -341,7 +341,7 @@ static void take_receive_lock(Process *c_p) {
     erts_proc_lock(c_p, ERTS_PROC_LOCKS_MSG_RECEIVE);
 }
 
-static void wait_locked(Process *c_p, BeamInstr *cp) {
+static void wait_locked(Process *c_p, ErtsCodePtr cp) {
     c_p->arity = 0;
     if (!ERTS_PTMR_IS_TIMED_OUT(c_p)) {
         erts_atomic32_read_band_relb(&c_p->state, ~ERTS_PSFLG_ACTIVE);
@@ -352,7 +352,7 @@ static void wait_locked(Process *c_p, BeamInstr *cp) {
     c_p->i = cp;
 }
 
-static void wait_unlocked(Process *c_p, BeamInstr *cp) {
+static void wait_unlocked(Process *c_p, ErtsCodePtr cp) {
     take_receive_lock(c_p);
     wait_locked(c_p, cp);
 }
@@ -385,7 +385,7 @@ enum tmo_ret { RET_next = 0, RET_wait = 1, RET_badarg = 2 };
 
 static enum tmo_ret wait_timeout(Process *c_p,
                                  Eterm timeout_value,
-                                 BeamInstr *next) {
+                                 ErtsCodePtr next) {
     /*
      * If we have already set the timer, we must NOT set it again.  Therefore,
      * we must test the F_INSLPQUEUE flag as well as the F_TIMO flag.

--- a/erts/emulator/beam/jit/instr_trace.cpp
+++ b/erts/emulator/beam/jit/instr_trace.cpp
@@ -195,7 +195,7 @@ static void i_return_to_trace(Process *c_p) {
             cpp++;
         }
         for (;;) {
-            BeamInstr *w = cp_val(*cpp);
+            ErtsCodePtr w = cp_val(*cpp);
             if (BeamIsReturnTrace(w)) {
                 do
                     ++cpp;

--- a/erts/emulator/beam/jit/load.h
+++ b/erts/emulator/beam/jit/load.h
@@ -60,7 +60,6 @@ struct LoaderState_ {
     const BeamCodeHeader *code_hdr; /* Actual code header */
     BeamCodeHeader *load_hdr;       /* Code header during load */
 
-    BeamInstr *codev; /* Loaded code buffer */
     int codev_size;   /* Size of code buffer in words. */
     int ci;           /* Current index into loaded code buffer. */
     Label *labels;

--- a/erts/emulator/beam/jit/load.h
+++ b/erts/emulator/beam/jit/load.h
@@ -60,14 +60,13 @@ struct LoaderState_ {
     const BeamCodeHeader *code_hdr; /* Actual code header */
     BeamCodeHeader *load_hdr;       /* Code header during load */
 
-    int codev_size;   /* Size of code buffer in words. */
-    int ci;           /* Current index into loaded code buffer. */
+    int codev_size; /* Size of code buffer in words. */
+    int ci;         /* Current index into loaded code buffer. */
     Label *labels;
     unsigned loaded_size; /* Final size of code when loaded. */
     int may_load_nif;     /* true if NIFs may later be loaded for this module */
-    BeamInstr *on_load;   /* Index in the code for the on_load function
-                           * (or 0 if there is no on_load function) */
-    unsigned max_opcode;  /* Highest opcode used in module */
+    const ErtsCodeInfo *on_load; /* Pointer to the on_load function, if any */
+    unsigned max_opcode;         /* Highest opcode used in module */
 
     /*
      * Generic instructions.

--- a/erts/emulator/beam/jit/ops.tab
+++ b/erts/emulator/beam/jit/ops.tab
@@ -71,10 +71,13 @@ put_tuple u==0 d => too_old_compiler
 
 label L
 
-# An label aligned to a word (8 byte) boundary. Must be used for addresses
-# that may be stored on the stack or that otherwise need to be properly tagged
-# as a continuation pointer.
-aligned_label L
+# An label aligned to a certain boundary. This is used in two cases:
+#
+# * When the label points to the start of a function, as the ErtsCodeInfo
+#   struct must be word-aligned.
+# * When the address is stored on the stack or otherwise needs to be properly
+#   tagged as a continuation pointer.
+aligned_label L t
 
 i_func_info I a a I
 int_code_end
@@ -339,22 +342,32 @@ move_two_words s d s d
 # Receive operations. We conservatively align all labels before any
 # of the receive instructions.
 #
+# As the labels may be stored in the process structure, we must align them to
+# the nearest 4-byte boundary to ensure they're properly tagged as continuation
+# pointers.
+#
 
-label L | loop_rec Fail Reg => aligned_label L | loop_rec Fail Reg
-label L | wait_timeout Fail Src => aligned_label L | wait_timeout Fail Src
-label L | wait Fail => aligned_label L | wait Fail
-label L | timeout => aligned_label L | timeout
+label L | loop_rec Fail Reg => \
+    aligned_label L u=4 | loop_rec Fail Reg
+label L | wait_timeout Fail Src => \
+    aligned_label L u=4 | wait_timeout Fail Src
+label L | wait Fail => \
+    aligned_label L u=4 | wait Fail
+label L | timeout => \
+    aligned_label L u=4 | timeout
 
 loop_rec Fail x==0 | smp_mark_target_label(Fail) => i_loop_rec Fail
 
-aligned_label L | wait_timeout Fail Src | smp_already_locked(L) => \
-    aligned_label L | wait_timeout_locked Src Fail
+aligned_label L A | wait_timeout Fail Src | smp_already_locked(L) => \
+    aligned_label L A | wait_timeout_locked Src Fail
 wait_timeout Fail Src => wait_timeout_unlocked Src Fail
 
-aligned_label L | wait Fail | smp_already_locked(L) => aligned_label L | wait_locked Fail
+aligned_label L A | wait Fail | smp_already_locked(L) => \
+    aligned_label L A | wait_locked Fail
 wait Fail => wait_unlocked Fail
 
-aligned_label L | timeout | smp_already_locked(L) => aligned_label L | timeout_locked
+aligned_label L A | timeout | smp_already_locked(L) => \
+    aligned_label L A | timeout_locked
 
 remove_message
 timeout
@@ -722,20 +735,20 @@ int_func_start Func_Label Func_Line M F A | \
 int_func_start Func_Label Func_Line M F A | \
   func_prologue Entry_Label Entry_Line | \
   is_mfa_bif(M, F, A) => \
-    aligned_label Func_Label | \
+    aligned_label Func_Label u=8 | \
     func_line Func_Line | \
     i_func_info Func_Label M F A | \
-      aligned_label Entry_Label | \
+      aligned_label Entry_Label u=8 | \
       line Entry_Line | \
       i_breakpoint_trampoline | \
       call_bif_mfa M F A
 
 int_func_start Func_Label Func_Line M F A | \
   func_prologue Entry_Label Entry_Line => \
-    aligned_label Func_Label | \
+    aligned_label Func_Label u=8 | \
     func_line Func_Line | \
     i_func_info Func_Label M F A | \
-      aligned_label Entry_Label | \
+      aligned_label Entry_Label u=8 | \
       line Entry_Line | \
       i_breakpoint_trampoline | \
       i_test_yield

--- a/erts/emulator/beam/lttng-wrapper.h
+++ b/erts/emulator/beam/lttng-wrapper.h
@@ -58,18 +58,21 @@
 #define lttng_mfa_to_str(m,f,a, Name) \
     erts_snprintf(Name, LTTNG_MFA_BUFFER_SZ, "%T:%T/%lu", (Eterm)(m), (Eterm)(f), (Uint)(a))
 
-#define lttng_proc_to_mfa_str(p, Name)                              \
-    do {                                                            \
-        if (ERTS_PROC_IS_EXITING((p))) {                            \
-            sys_strcpy(Name, "<exiting>");                              \
-        } else {                                                    \
-            BeamInstr *_fptr = erts_find_function_from_pc((p)->i);       \
-            if (_fptr) {                                            \
-                lttng_mfa_to_str(_fptr[0],_fptr[1],_fptr[2], Name); \
-            } else {                                                \
-                sys_strcpy(Name, "<unknown>");                          \
-            }                                                       \
-        }                                                           \
+#define lttng_proc_to_mfa_str(p, Name)                                      \
+    do {                                                                    \
+        if (ERTS_PROC_IS_EXITING((p))) {                                    \
+            sys_strcpy(Name, "<exiting>");                                  \
+        } else {                                                            \
+            const ErtsCodeMFA* _mfa = erts_find_function_from_pc((p)->i);   \
+            if (_fptr) {                                                    \
+                lttng_mfa_to_str(_mfa->module,                              \
+                                 _mfa->function,                            \
+                                 _mfa->arity,                               \
+                                 Name);                                     \
+            } else {                                                        \
+                sys_strcpy(Name, "<unknown>");                              \
+            }                                                               \
+        }                                                                   \
     } while(0)
 
 /* ErtsRunQueue->ErtsSchedulerData->Uint */

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -423,6 +423,7 @@ typedef Uint UWord;
 typedef Sint SWord;
 #define ERTS_UINT_MAX ERTS_UWORD_MAX
 
+typedef const void *ErtsCodePtr;
 typedef UWord BeamInstr;
 
 #ifndef HAVE_INT64

--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -712,7 +712,7 @@ static ErlDrvData spawn_start(ErlDrvPort port_num, char* name,
                 if (res >= io_vector[i].iov_len)
                     res -= io_vector[i].iov_len;
                 else {
-                    driver_enq(port_num, io_vector[i].iov_base + res,
+                    driver_enq(port_num, &((char*)io_vector[i].iov_base)[res],
                                io_vector[i].iov_len - res);
                     res = 0;
                 }

--- a/erts/emulator/utils/make_tables
+++ b/erts/emulator/utils/make_tables
@@ -263,7 +263,7 @@ for ($i = 0; $i < @bif; $i++) {
 print "\n";
 
 for ($i = 0; $i < @bif; $i++) {
-    my $args = join(', ', 'Process*', 'Eterm*', 'const BeamInstr*');
+    my $args = join(', ', 'Process*', 'Eterm*', 'ErtsCodePtr');
     my $name = $bif_info[$i]->[3];
     print "Eterm $name($args);\n";
     print "Eterm erts_gc_$name(Process* p, Eterm* reg, Uint live);\n"
@@ -327,7 +327,7 @@ for ($i = 0; $i < @bif_info; $i++) {
 	$dtype = "ERTS_SCHED_DIRTY_IO";
     }
 print <<EOF;
-Eterm $bif_info[$i]->[2](Process *c_p, Eterm *regs, const BeamInstr *I)
+Eterm $bif_info[$i]->[2](Process *c_p, Eterm *regs, ErtsCodePtr I)
 {
     return erts_reschedule_bif(c_p, regs, I,
                                &BIF_TRAP_EXPORT($i)->info.mfa,


### PR DESCRIPTION
Now that we have the JIT it's rather iffy to declare our code pointers `BeamInstr*` as they don't necessarily point to BEAM instructions anymore. Beyond that, it forces us to make all yield and return addresses  `BeamInstr`-aligned (8 bytes) which wastes precious instruction cache for no benefit.

This PR makes code pointers opaque instead, and reduces jitted code size by about 2% through shrinking code alignment to 4 bytes.