### PR TITLE
jit: Make mov_imm(Gp, NIL) shorter

### DIFF
--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -283,7 +283,7 @@ _ET_DECLARE_CHECKED(Sint,signed_val,Eterm)
 #endif
 
 /* NIL access methods */
-#define NIL		((~((Uint) 0) << _TAG_IMMED2_SIZE) | _TAG_IMMED2_NIL)
+#define NIL		_TAG_IMMED2_NIL
 #define is_nil(x)	((x) == NIL)
 #define is_not_nil(x)	((x) != NIL)
 

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -278,6 +278,7 @@ public:
 #ifdef DEBUG
         a.addValidationOptions(BaseEmitter::kValidationOptionAssembler);
 #endif
+        a.addEncodingOptions(BaseEmitter::kEncodingOptionOptimizeForSize);
         code.setErrorHandler(this);
     }
 
@@ -896,18 +897,9 @@ protected:
              *
              * Thus, "xor eax, eax" is five bytes shorter than "mov rax, 0".
              *
-             * Note: xor clears ZF and C; mov does not change any flags.
+             * Note: xor clears ZF and CF; mov does not change any flags.
              */
             a.xor_(to.r32(), to.r32());
-        } else if (Support::isInt32(value)) {
-            /*
-             * Generate the shortest instruction to set the register
-             * to an unsigned immediate value that fits in 32 bits.
-             *
-             *   48 c7 c0 2a 00 00 00    mov    rax, 42
-             *   b8 2a 00 00 00          mov    eax, 42
-             */
-            a.mov(to.r32(), imm(value));
         } else {
             a.mov(to, imm(value));
         }

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -4712,12 +4712,11 @@ end
 define etp-init
   set $etp_arch64 = (sizeof(void *) == 8)
   if $etp_arch64
-    set $etp_nil = 0xfffffffffffffffb
     set $etp_MBC_ABLK_OFFSET_BITS = 23
   else
-    set $etp_nil = 0xfffffffb
     set $etp_MBC_ABLK_OFFSET_BITS = 8
   end
+  set $etp_nil = 0x3b
   set $etp_MBC_ABLK_OFFSET_SHIFT = (sizeof(UWord)*8 - 1 - $etp_MBC_ABLK_OFFSET_BITS)
   set $etp_MBC_ABLK_OFFSET_MASK = ((((UWord)1 << $etp_MBC_ABLK_OFFSET_BITS) - 1) << $etp_MBC_ABLK_OFFSET_SHIFT)
   set $etp_MBC_ABLK_SZ_MASK = ((UWord)1 << $etp_MBC_ABLK_OFFSET_SHIFT) - 1 - 7


### PR DESCRIPTION
This PR shaves off a few bytes here and there by making the empty list constant (`NIL`) positive:

Before:
```
    ; When NIL is negative, we need to sign-extend it when moving to a 64-bit register,
    ; which uses 7 bytes:
    ;
    ; 48 c7 c0 fb ff ff ff
    mov rax, -5
```
After:
```
    ; When NIL is positive, we can use the fact that a move to the lower 32 bits of any
    ; 64-bit register implicitly zeroes its upper 32 bits. This uses 5 bytes instead:
    ;
    ; b8 3b 00 00 00
    mov eax, 0x3b
```