### PR TITLE
Support ROOTDIR passed as an environment variable in erl and start scripts

### DIFF
--- a/erts/etc/unix/erl.src.src
+++ b/erts/etc/unix/erl.src.src
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
 # %CopyrightBegin%
-# 
-# Copyright Ericsson AB 1996-2016. All Rights Reserved.
-# 
+#
+# Copyright Ericsson AB 1996-2020. All Rights Reserved.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -15,10 +15,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # %CopyrightEnd%
 #
-ROOTDIR="%FINAL_ROOTDIR%"
+if [ -z "$ROOTDIR" ]
+then
+   ROOTDIR="%FINAL_ROOTDIR%"
+fi
 BINDIR=$ROOTDIR/erts-%VSN%/bin
 EMU=%EMULATOR%%EMULATOR_NUMBER%
 PROGNAME=`echo $0 | sed 's/.*\///'`

--- a/erts/etc/unix/start.src
+++ b/erts/etc/unix/start.src
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
 # %CopyrightBegin%
-# 
-# Copyright Ericsson AB 1996-2016. All Rights Reserved.
-# 
+#
+# Copyright Ericsson AB 1996-2020. All Rights Reserved.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # %CopyrightEnd%
 #
 # This program invokes the erlang emulator by calling run_erl.
@@ -25,7 +25,10 @@
 #
 # Usage: start [Data]
 #
-ROOTDIR=%FINAL_ROOTDIR%
+if [ -z "$ROOTDIR" ]
+then
+   ROOTDIR=%FINAL_ROOTDIR%
+fi
 
 if [ -z "$RELDIR" ]
 then


### PR DESCRIPTION
Here is a first step to address [ERL-1323](https://bugs.erlang.org/browse/ERL-1323) by allowing **ROOTDIR** passed as an environment variable in both the _erl_ and _start_ commands. I've followed exactly the same approach and shell syntax as already used for **RELDIR** in [start.src](https://github.com/erlang/otp/blob/master/erts/etc/unix/start.src)

In the context of [ERL-1323,](https://bugs.erlang.org/browse/ERL-1323) this small commit fixes a concrete issue on Android, as it finally allows to run Erlang/OTP on recent OS versions for which it's not possible to know in advance the absolute path of the Erlang runtime anymore. Being able to pass the install location via the **ROOTDIR** environment variable at runtime solves the issue in this case.

I've tested this approach on the following https://github.com/JeromeDeBretagne/erlanglauncher/ project to finally implement the support for multiple users and I can confirm it works perfectly.

Thanks, Jérôme