### PR TITLE
Fix the make configuration for macOS 11.0.1

### DIFF
--- a/make/configure.in
+++ b/make/configure.in
@@ -398,7 +398,7 @@ if test $CROSS_COMPILING = no; then
 	       [1-9][0-9].[0-9])
 	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\10\200|'`;;
 	       [1-9][0-9].[0-9].[0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
+	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\10\20\3|'`;;
 	       [1-9][0-9].[1-9][0-9])
 	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\1\200|'`;;
 	       [1-9][0-9].[1-9][0-9].[0-9])


### PR DESCRIPTION
This change is needed to ensure that we're able to configure make on macOS 11.0.1.

A smilar fix was applied for 11.0 in #2700 

Main changes:

 - Fix the integer macOS version correctly for the build version check

Verified via ./otp_build tests