### PR TITLE
Documentation typo in crypto module for RFC 3447 

### DIFF
--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -436,7 +436,7 @@
 	the private exponent. The longer key format contains redundant
 	information that will make the calculation faster. P1,P2 are first
 	and second prime factors. E1,E2 are first and second exponents. C
-	is the CRT coefficient. Terminology is taken from <url href="http://www.ietf.org/rfc/rfc3477.txt"> RFC 3447</url>.</p>
+	is the CRT coefficient. Terminology is taken from <url href="http://www.ietf.org/rfc/rfc3447.txt"> RFC 3447</url>.</p>
       </desc>
     </datatype>
 


### PR DESCRIPTION
Hi,

When I was reading the documentation, I found a typo on one of the RFC 3447 links in `crypto` module documentation.