### PR TITLE
port_please/2 returns {port, _, _}, not {ok, _, _}

### DIFF
--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -79,7 +79,7 @@ stop() ->
 %% return {port, P, Version} | noport
 %%
 
--spec port_please(Name, Host) -> {ok, Port, Version} | noport | closed | {error, term()} when
+-spec port_please(Name, Host) -> {port, Port, Version} | noport | closed | {error, term()} when
 	  Name :: atom() | string(),
 	  Host :: atom() | string() | inet:ip_address(),
 	  Port :: non_neg_integer(),


### PR DESCRIPTION
This is a followup PR to https://github.com/erlang/otp/pull/2616 which fixed the type spec for port_please/3, but missed the incorrect `{ok, _, _}` term in port_please/2 which should be `{port, _, _}`.