### PR TITLE
Fix configure on macOS Big Sur 11.0.1

### DIFF
--- a/make/configure.in
+++ b/make/configure.in
@@ -113,8 +113,8 @@ AS_HELP_STRING([--enable-bootstrap-only],
 [ if test "X$enableval" = "Xyes"; then
      BOOTSTRAP_ONLY=yes
   else
-     BOOTSTRAP_ONLY=no  
-  fi	
+     BOOTSTRAP_ONLY=no
+  fi
 ],
 BOOTSTRAP_ONLY=no)
 
@@ -252,7 +252,7 @@ AS_HELP_STRING([--enable-native-libs],
 AC_ARG_WITH(dynamic-trace,
 AS_HELP_STRING([--with-dynamic-trace={dtrace|lttng|systemtap}],
 	       [specify use of dynamic trace framework, dtrace, lttng or systemtap])
-AS_HELP_STRING([--without-dynamic-trace], 
+AS_HELP_STRING([--without-dynamic-trace],
                [don't enable any dynamic tracing (default)]))
 AC_ARG_ENABLE(vm-probes,
 AS_HELP_STRING([--enable-vm-probes],
@@ -395,18 +395,28 @@ if test $CROSS_COMPILING = no; then
 	   	AC_MSG_ERROR([Failed to execute 'sw_vers'; please provide it in PATH])
 	   }
 	   [case "$macosx_version" in
-	       [1-9][0-9].[0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\10\200|'`;;
-	       [1-9][0-9].[0-9].[0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
-	       [1-9][0-9].[1-9][0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\1\200|'`;;
-	       [1-9][0-9].[1-9][0-9].[0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\20\3|'`;;
-	       [1-9][0-9].[1-9][0-9].[1-9][0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
+	       [1-9][0-9].[0-9] | [1-9][0-9].[1-9][0-9])
+	   	  macosx_major=`echo $macosx_version | sed 's|\([0-9]*\)\.\([0-9]*\)|\1|'`
+	          macosx_minor=`echo $macosx_version | sed 's|\([0-9]*\)\.\([0-9]*\)|\2|'`
+	          macosx_point=00;;
+	       [1-9][0-9].[0-9].[0-9] | [1-9][0-9].[0-9].[1-9][0-9] | [1-9][0-9].[1-9][0-9].[0-9] | [1-9][0-9].[1-9][0-9].[1-9][0-9])
+	          macosx_major=`echo $macosx_version | sed 's|\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)|\1|'`
+	          macosx_minor=`echo $macosx_version | sed 's|\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)|\2|'`
+	          macosx_point=`echo $macosx_version | sed 's|\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)|\3|'`;;
 	       *)
-		  int_macosx_version=unexpected;;
+	          int_macosx_version=unexpected;;
+	   esac
+	   [ ! "$int_macosx_version" = unexpected ] && case "$macosx_major"."$macosx_minor" in
+	       10.[0-9])
+	          int_macosx_version=$macosx_major$macosx_minor"0";;
+	       *)
+	          case $macosx_minor in
+	             [0-9]) macosx_minor=0$macosx_minor;;
+	          esac
+	          case $macosx_point in
+	             [0-9]) macosx_point=0$macosx_point;;
+	          esac
+	          int_macosx_version=$macosx_major$macosx_minor$macosx_point;;
 	   esac]
 	   test $int_macosx_version != unexpected || {
 	   	AC_MSG_ERROR([Unexpected MacOSX version ($macosx_version) returned by 'sw_vers -productVersion'; this configure script probably needs to be updated])


### PR DESCRIPTION
I'll just reproduce the commit message below:

```
Generate plausible synthetic __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__

This generates comparison values for the predefined macro in line with the
precedent set by Apple. Single-digit 10.x versions followed 10x0, and starting
with 10.10, moved to MMmmPP, Major/minor/Point. Left-padding on the minor is an
educated guess. This should now produce the correct value, from OS versions
Erlang never even ran on, to the current Big Sur Patch (11.0.1) that broke
configure, to future versions.
```