### PR TITLE
macOS: Remove version check in configure script

### DIFF
--- a/make/configure.in
+++ b/make/configure.in
@@ -387,50 +387,6 @@ if test X${enable_native_libs} = Xyes -a X${enable_hipe} != Xno; then
 fi
 AC_SUBST(NATIVE_LIBS_ENABLED)
 
-if test $CROSS_COMPILING = no; then
-   case $host_os in
-   	darwin*)
-	   macosx_version=`sw_vers -productVersion`
-	   test $? -eq 0 || {
-	   	AC_MSG_ERROR([Failed to execute 'sw_vers'; please provide it in PATH])
-	   }
-	   [case "$macosx_version" in
-	       [1-9][0-9].[0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\10\200|'`;;
-	       [1-9][0-9].[0-9].[0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\10\20\3|'`;;
-	       [1-9][0-9].[1-9][0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\1\200|'`;;
-	       [1-9][0-9].[1-9][0-9].[0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\20\3|'`;;
-	       [1-9][0-9].[1-9][0-9].[1-9][0-9])
-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
-	       *)
-		  int_macosx_version=unexpected;;
-	   esac]
-	   test $int_macosx_version != unexpected || {
-	   	AC_MSG_ERROR([Unexpected MacOSX version ($macosx_version) returned by 'sw_vers -productVersion'; this configure script probably needs to be updated])
-	   }
-	   AC_TRY_COMPILE([
-#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version
-#error Compiling for a newer MacOSX version...
-#endif
-		], [;],
-		[],
-		[AC_MSG_ERROR([
-
-  You are natively building Erlang/OTP for a later version of MacOSX
-  than current version ($macosx_version). You either need to
-  cross-build Erlang/OTP, or set the environment variable
-  MACOSX_DEPLOYMENT_TARGET to $macosx_version (or a lower version).
-
-])])
-	   ;;
-	*)
-	   ;;
-   esac
-fi
-
 ERL_DED
 
 AC_CONFIG_FILES([../Makefile output.mk ../make/$host/otp_ded.mk:../make/otp_ded.mk.in])


### PR DESCRIPTION
There is a version check in one of the configure scripts that
tests the version of macOS to ensure that the executables that
are built can be run on the same computer that built them.

The reason for this test has been lost in the mists of time.
Presumably there was a good reason for the test when it was
first added.

Since the test recently has become more complicated because of the
introduction of macOS 11.0 and 11.0.1, and is incorrect for some
versions of macOS, remove it. If there turns out that the version test
would be useful, it can be added back later (but in a less buggy way,
preferably using `awk` instead of `sed` to make the version parsing
simpler and more accurate).