### PR TITLE
Allow building VM with static and gprof-enabled crypto NIF

### DIFF
--- a/erts/emulator/utils/make_driver_tab
+++ b/erts/emulator/utils/make_driver_tab
@@ -52,6 +52,7 @@ while (@ARGV) {
     if ( $d =~ /^.*\.a$/ ) {
 	$d = basename $d;
 	$d =~ s/\.a$//;	# strip .a
+	$d =~ s/\.gprof$//;	# strip .gprof
 	if ($mode == 1) {
 	    push(@static_drivers, $d);
 	}

--- a/lib/crypto/c_src/Makefile.in
+++ b/lib/crypto/c_src/Makefile.in
@@ -54,8 +54,14 @@ ifeq ($(TYPE),valgrind)
 TYPEMARKER = .valgrind
 TYPE_FLAGS = $(subst -O3,,$(subst -O2,,$(CFLAGS))) -DVALGRIND
 else
+ifeq ($(TYPE),gprof)
+TYPEMARKER = .gprof
+TYPE_EXTRA_CFLAGS = -DGPROF -pg
+TYPE_FLAGS = $(CFLAGS) $(TYPE_EXTRA_CFLAGS)
+else
 TYPEMARKER =
 TYPE_FLAGS = $(CFLAGS)
+endif
 endif
 endif
 
@@ -145,7 +151,7 @@ endif
 CONFIGURE_ARGS = -DDISABLE_EVP_DH=@DISABLE_EVP_DH@
 
 ALL_CFLAGS = $(TYPE_FLAGS) $(EXTRA_FLAGS) $(CONFIGURE_ARGS) $(INCLUDES)
-ALL_STATIC_CFLAGS = @DED_STATIC_CFLAGS@ $(CONFIGURE_ARGS) $(INCLUDES)
+ALL_STATIC_CFLAGS = @DED_STATIC_CFLAGS@ $(TYPE_EXTRA_CFLAGS) $(CONFIGURE_ARGS) $(INCLUDES)
 
 # ----------------------------------------------------
 # Targets


### PR DESCRIPTION
While investigating the crypto hmac performance loss in [ERL-1400](https://bugs.erlang.org/browse/ERL-1400) I needed to build with crypto and openssl gprof-enabled and statically linked into the VM. That didn't work due to two separate build issues, fixed by this series.