### PR TITLE
fix crypto hmac performance loss

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -250,6 +250,7 @@ static int initialize(ErlNifEnv* env, ERL_NIF_TERM load_info)
 #if OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
 #ifdef OPENSSL_THREADS
     if (nlocks > 0) {
+	CRYPTO_set_add_lock_callback(ccb->add_lock_function);
 	CRYPTO_set_locking_callback(ccb->locking_function);
 	CRYPTO_set_id_callback(ccb->id_function);
 	CRYPTO_set_dynlock_create_callback(ccb->dyn_create_function);

--- a/lib/crypto/c_src/crypto_callback.h
+++ b/lib/crypto/c_src/crypto_callback.h
@@ -36,6 +36,8 @@ struct crypto_callbacks
     /* openssl callbacks */
 #if OPENSSL_VERSION_NUMBER < 0x10100000
   #ifdef OPENSSL_THREADS
+    int (*add_lock_function)(int *num, int amount, int type,
+			     const char *file, int line);
     void (*locking_function)(int mode, int n, const char *file, int line);
     unsigned long (*id_function)(void);
     struct CRYPTO_dynlock_value* (*dyn_create_function)(const char *file,

--- a/lib/crypto/c_src/hmac.c
+++ b/lib/crypto/c_src/hmac.c
@@ -233,18 +233,19 @@ int hmac_low_level(ErlNifEnv* env, const EVP_MD *md,
 {
     unsigned int size_int;
     size_t size;
+    unsigned char buff[EVP_MAX_MD_SIZE];
 
-    /* Find the needed space */
     if (HMAC(md,
              key_bin.data, (int)key_bin.size,
              text.data, text.size,
-             NULL, &size_int) == NULL)
+             buff, &size_int) == NULL)
         {
-            *return_term = EXCP_ERROR(env, "Get HMAC size failed");
+            *return_term = EXCP_ERROR(env, "HMAC sign failed");
             return 0;
         }
 
     size = (size_t)size_int; /* Otherwise "size" is unused in 0.9.8.... */
+    ASSERT(0 < size && size <= EVP_MAX_MD_SIZE);
     if (!enif_alloc_binary(size, ret_bin))
         {
             *return_term = EXCP_ERROR(env, "Alloc binary");
@@ -252,15 +253,7 @@ int hmac_low_level(ErlNifEnv* env, const EVP_MD *md,
         }
     *ret_bin_alloc = 1;
 
-    /* And do the real HMAC calc */
-    if (HMAC(md,
-             key_bin.data, (int)key_bin.size,
-             text.data, text.size,
-             ret_bin->data, &size_int) == NULL)
-        {
-            *return_term = EXCP_ERROR(env, "HMAC sign failed");
-            return 0;
-        }
+    memcpy(ret_bin->data, buff, size);
                     
     return 1;
 }

--- a/lib/crypto/c_src/hmac.c
+++ b/lib/crypto/c_src/hmac.c
@@ -225,7 +225,7 @@ ERL_NIF_TERM hmac_final_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return ret;
 }
 
-
+#endif /* HAS_EVP_PKEY_CTX */
 
 int hmac_low_level(ErlNifEnv* env, const EVP_MD *md,
                    ErlNifBinary key_bin, ErlNifBinary text,
@@ -264,5 +264,3 @@ int hmac_low_level(ErlNifEnv* env, const EVP_MD *md,
                     
     return 1;
 }
-
-#endif

--- a/lib/crypto/c_src/hmac.h
+++ b/lib/crypto/c_src/hmac.h
@@ -31,9 +31,10 @@ ERL_NIF_TERM hmac_init_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM hmac_update_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM hmac_final_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
+#endif /* HAS_EVP_PKEY_CTX */
+
 int hmac_low_level(ErlNifEnv* env, const EVP_MD *md,
                    ErlNifBinary key_bin, ErlNifBinary text,
                    ErlNifBinary *ret_bin, int *ret_bin_alloc, ERL_NIF_TERM *return_term);
-#endif
 
 #endif /* E_HMAC_H__ */

--- a/lib/crypto/c_src/mac.c
+++ b/lib/crypto/c_src/mac.c
@@ -271,21 +271,10 @@ ERL_NIF_TERM mac_one_time(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                 }
             md = digp->md.p;
 
-#ifdef HAS_EVP_PKEY_CTX
-# ifdef HAVE_PKEY_new_raw_private_key
-            /* Prefered for new applications according to EVP_PKEY_new_mac_key(3) */
-            pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, /*engine*/ NULL, key_bin.data,  key_bin.size);
-# else
-            /* Available in older versions */
-            pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, /*engine*/ NULL, key_bin.data,  key_bin.size);
-# endif
-
-#else
             if (!hmac_low_level(env, md, key_bin, text, &ret_bin, &ret_bin_alloc, &return_term))
                 goto err;
             else
                 goto success;
-#endif
         }
         break;
 


### PR DESCRIPTION
Fixes the crypto hmac performance loss reported in [ERL-1400](https://bugs.erlang.org/browse/ERL-1400).

When upgrading from OTP-21 to OTP-22/23, the crypto hmac calls change from using openssl's low-level `HMAC()` interface to its higher-level `EVP_PKEY` interface. With openssl-1.0.x (as found in some enterprise environments), this causes each hmac call to require several reference count changes in openssl as pkey objects are accessed and released. openssl-1.0.x allows the client application to register an `add_lock` callback to atomically add to an integer in memory and return its new value. OTP does not register that callback, which causes openssl-1.0.x to fall back to taking and releasing a global pkey mutex in each reference count change. That mutex quickly causes exponential slowdown even with moderate concurrency. The solution is to implement and register the callback. With openssl-1.1.x this is not an issue since it implements this synchronization primitive itself.

With the above fix the exponential slowdown was cured, but we still saw a 2X slowdown compared to OTP-21. Profiling with gprof revealed that the new API has a lot of internal overheads from dynamic object allocation and deletion. A simpler interface not using EVP_PKEY is still present in crypto as `hmac_low_level()`, so we switched to that.

Even when using `hmac_low_level()` we saw a 2X slowdown compared to OTP-21, with both openssl-1.0.x and openssl-1.1.x. A comparison between the `hmac_nif()` in OTP-21 and `hmac_low_level()` in OTP-22/23 revealed the reason for that: the newer code calls `HMAC()` twice where the older code only called it once, which is enough since the size of the result is bounded by a small constant. Reinstating that logic in `hmac_low_level()` eliminated the final 2X slowdown.