### PR TITLE
Do not crash on late gen_server:call replies

### DIFF
--- a/lib/kernel/src/logger_proxy.erl
+++ b/lib/kernel/src/logger_proxy.erl
@@ -134,7 +134,11 @@ handle_load({log,Level,Report,Meta},State) ->
 
 %% Log event sent to this process e.g. from the emulator - it is really load
 handle_info(Log,State) when is_tuple(Log), element(1,Log)==log ->
-    {load,State}.
+    {load,State};
+handle_info(_Log,State) ->
+    %% Handle stray reply messages from sync try_log, not needed after OTP-24
+    %% as then aliases will prevent late messages.
+    State.
 
 terminate(overloaded, _State) ->
     _ = erlang:system_flag(system_logger,undefined),


### PR DESCRIPTION
Fix bug reported in http://erlang.org/pipermail/erlang-questions/2020-October/100029.html