### PR TITLE
logger: Make logger_simple print pretty reports

### DIFF
--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -486,21 +486,15 @@ do_handle_msg(Msg,State) ->
 	{From, {ensure_loaded, _}} ->
 	    From ! {init, not_allowed};
 	X ->
-            %% This is equal to calling logger:info/3 which we don't
-            %% want to do from the init process, at least not during
-            %% system boot. We don't want to call logger:timestamp()
-            %% either.
-	    case whereis(user) of
-		undefined ->
-                    catch logger ! {log, info, "init got unexpected: ~p", [X],
-                                    #{pid=>self(),
-                                      gl=>self(),
-                                      time=>os:system_time(microsecond),
-                                      error_logger=>#{tag=>info_msg}}};
-		User ->
-		    User ! X,
-		    ok
-	    end
+            %% Only call the logger module if the logger_server is running.
+            %% If it is not running, then we don't know that the logger
+            %% module can be loaded.
+            case whereis(logger_server) =/= undefined of
+                true -> logger:info("init got unexpected: ~p", [X],
+                                    #{ error_logger=>#{tag=>info_msg}});
+                false -> erlang:display_string("init got unexpected: "),
+                         erlang:display(X)
+            end
     end.		  
 
 %%% -------------------------------------------------


### PR DESCRIPTION
When the simple logger has been started we are late enough in the boot cycle that we can load any modules that we need in order to handle printing the crash. We wrap the call to logger_formatter in a `try catch` just to make sure that in case we should fail we actually get something printed.

This will effect crash printouts coming in before the kernel application has been successfully started.