### PR TITLE
Add data_only option to binary_to_term

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -200,6 +200,7 @@ atom current_function
 atom current_location
 atom current_stacktrace
 atom data
+atom data_only
 atom debug_flags
 atom decentralized_counters
 atom decimals

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1408,13 +1408,21 @@ size_t enif_binary_to_term(ErlNifEnv *dst_env,
     Sint size;
     ErtsHeapFactory factory;
     const byte *bp = (byte*) data;
+    Uint32 Xopts = (Uint32)opts;
     Uint32 flags = 0;
 
-    switch ((Uint32)opts) {
-    case 0: break;
-    case ERL_NIF_BIN2TERM_SAFE: flags = ERTS_DIST_EXT_BTT_SAFE; break;
-    default: return 0;
+    if (Xopts & ERL_NIF_BIN2TERM_SAFE) {
+        flags |= ERTS_DIST_EXT_BTT_SAFE;
+        Xopts &= ~ERL_NIF_BIN2TERM_SAFE;
     }
+    if (Xopts & ERL_NIF_BIN2TERM_DATA_ONLY) {
+        flags |= ERTS_DIST_EXT_BTT_DATA_ONLY;
+        Xopts &= ~ERL_NIF_BIN2TERM_DATA_ONLY;
+    }
+    if (Xopts != 0) {
+        return 0;
+    }
+
     if ((size = erts_decode_ext_size(bp, data_sz)) < 0)
         return 0;
 

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -258,7 +258,8 @@ typedef enum {
 } ErlNifUniqueInteger;
 
 typedef enum {
-    ERL_NIF_BIN2TERM_SAFE = 0x20000000
+    ERL_NIF_BIN2TERM_SAFE = 0x20000000,
+    ERL_NIF_BIN2TERM_DATA_ONLY = 0x40000000
 } ErlNifBinaryToTerm;
 
 typedef enum {

--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -124,6 +124,7 @@ typedef struct {
 #define ERTS_DIST_EXT_DFLAG_HDR      ((Uint32) 0x1)
 #define ERTS_DIST_EXT_ATOM_TRANS_TAB ((Uint32) 0x2)
 #define ERTS_DIST_EXT_BTT_SAFE       ((Uint32) 0x4)
+#define ERTS_DIST_EXT_BTT_DATA_ONLY  ((Uint32) 0x8)
 
 #define ERTS_DIST_CON_ID_MASK ((Uint32) 0x00ffffff)
 

--- a/erts/emulator/test/binary_SUITE.erl
+++ b/erts/emulator/test/binary_SUITE.erl
@@ -64,6 +64,7 @@
 	 bad_size/1,
 	 bad_term_to_binary/1,
 	 bad_binary_to_term_2/1,safe_binary_to_term2/1,
+         data_only_binary_to_term2/1,
 	 bad_binary_to_term/1, bad_terms/1, more_bad_terms/1,
 	 otp_5484/1,otp_5933/1,
 	 ordering/1,unaligned_order/1,gc_test/1,
@@ -92,6 +93,7 @@ all() ->
      {group, iolist_size_benchmarks},
      b2t_used_big,
      bad_binary_to_term_2, safe_binary_to_term2,
+     data_only_binary_to_term2,
      bad_binary_to_term, bad_terms, t_hash, bad_size,
      sub_bin_copy, bad_term_to_binary, t2b_system_limit,
      term_to_iovec, more_bad_terms,
@@ -936,7 +938,7 @@ bad_bin_to_term(BadBin) ->
 bad_bin_to_term(BadBin,Opts) ->
     {'EXIT',{badarg,_}} = (catch binary_to_term_stress(BadBin,Opts)).
 
-%% Test safety options for binary_to_term/2
+%% Test safe option for binary_to_term/2
 safe_binary_to_term2(Config) when is_list(Config) ->
     bad_bin_to_term(<<131,100,0,14,"undefined_atom">>, [safe]),
     bad_bin_to_term(<<131,100,0,14,"other_bad_atom">>, [safe]),
@@ -948,6 +950,14 @@ safe_binary_to_term2(Config) when is_list(Config) ->
     fullsweep_after = binary_to_term_stress(<<131,100,0,15,"fullsweep_after">>, [safe]), % should be a good atom
     BadExtFun = <<131,113,100,0,4,98,108,117,101,100,0,4,109,111,111,110,97,3>>,
     bad_bin_to_term(BadExtFun, [safe]),
+    ok.
+
+%% Test data_only option for binary_to_term/2
+data_only_binary_to_term2(Config) when is_list(Config) ->
+    Fun = term_to_binary(fun() -> ok end),
+    bad_bin_to_term(Fun, [data_only]),
+    Export = term_to_binary(fun erlang:self/0),
+    bad_bin_to_term(Export, [data_only]),
     ok.
 
 %% Tests bad input to binary_to_term/1.

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -477,7 +477,7 @@ binary_to_term(_Binary) ->
 %% binary_to_term/2
 -spec binary_to_term(Binary, Opts) -> term() | {term(), Used} when
       Binary :: ext_binary(),
-      Opt :: safe | used,
+      Opt :: safe | data_only | used,
       Opts :: [Opt],
       Used :: pos_integer().
 binary_to_term(_Binary, _Opts) ->


### PR DESCRIPTION
This option allows enforcing that only "regular data" terms
are decoded. Forbidden terms include funs, but also pids, ports,
and references. This makes use of ETF somewhat safer for generic data
interchange, where node-specific terms (like ports, pids, and references)
or funs that carry instructions alongside data, are not needed.

See: https://www.alphabot.com/security/blog/2020/elixir/Remote-code-execution-vulnerability-in-Elixir-based-Paginator-project.html

---

This is only a PoC showing the general idea. It lacks documentation,
and thorough testing, but I wanted to open this early to get feedback
on the feature from the OTP team. In particular, it might make more
sense to have more granular options, e.g. `{without, [fun, ref, port, pid]}`
alongside the generic option.
Additionally, I think it would make sense to deprecate the `safe` option
in favour of something more descriptive - e.g. `only_existing_atoms`,
given the option doesn't really make the decoder safe - there are still
possible safety issues to guard against.

\cc @josevalim 