### PR TITLE
crypto: Fix out-of-bounds read bug in otp_test_engine.c

### DIFF
--- a/lib/crypto/c_src/otp_test_engine.c
+++ b/lib/crypto/c_src/otp_test_engine.c
@@ -203,7 +203,7 @@ static int test_engine_digest_selector(ENGINE *e, const EVP_MD **digest,
     if (!digest) {
         *nids = test_digest_ids;
         fprintf(stderr, "Digest is empty! Nid:%d\r\n", nid);
-        return 2;
+        return sizeof(test_digest_ids) / sizeof(*test_digest_ids);
     }
     fprintf(stderr, "Digest no %d requested\r\n",nid);
     if (nid == NID_md5) {


### PR DESCRIPTION
Found with OpenSSL built with address-sanitizer:

ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f848de3b5c4 ...
READ of size 4 at 0x7f848de3b5c4 thread T9 (6_scheduler)
    #0 0x7f848fed28ea in engine_table_register crypto/engine/eng_table.c:97
    #1 0x7f848fd83dac in ENGINE_register_digests crypto/engine/tb_digest.c:30
    #2 0x7f848fd201d1 in engine_register_nif otp/lib/crypto/c_src/engine.c:447
    #3 0x556fe2e15de4 in process_main x86_64-unknown-linux-gnu/asan/emu/beam_cold.h:177
    #4 0x556fe2db96e7 in sched_thread_func beam/erl_process.c:8496
    #5 0x556fe346bd1b in thr_wrapper pthread/ethread.c:122
    #6 0x7f8498b886da in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76da)
    #7 0x7f84988b171e in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x12171e)

0x7f848de3b5c4 is located 0 bytes to the right of global variable 'test_digest_ids'
defined in 'otp_test_engine.c:199:12' (0x7f848de3b5c0) of size 4

## Solution

Without much understanding of the ENGINE interface it seems the digest callback function `test_engine_digest_selector` should return the number of elements in the array, and `test_digest_ids` has only one element not two.
