### PR TITLE
erts: Fix NIL to be correct size

### DIFF
--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -283,7 +283,7 @@ _ET_DECLARE_CHECKED(Sint,signed_val,Eterm)
 #endif
 
 /* NIL access methods */
-#define NIL		_TAG_IMMED2_NIL
+#define NIL		((Eterm)(_TAG_IMMED2_NIL))
 #define is_nil(x)	((x) == NIL)
 #define is_not_nil(x)	((x) != NIL)
 


### PR DESCRIPTION
When used as an argument to a variadic function NIL has to have the correct size otherwise it is assumed to be an int which is not what the va_list function expects.

This was broken in: 8b8c7a63030360436f2ee6d6390d120199260823