### PR TITLE
Fix negative zero to string

### DIFF
--- a/erts/emulator/sys/common/erl_sys_common_misc.c
+++ b/erts/emulator/sys/common/erl_sys_common_misc.c
@@ -182,7 +182,7 @@ sys_double_to_chars_fast(double f, char *buffer, int buffer_size, int decimals,
     if (decimals < 0)
         return -1;
 
-    if (f < 0) {
+    if (signbit(f)) {
         neg = 1;
         af = -f;
     }

--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -187,6 +187,17 @@ t_float_to_string(Config) when is_list(Config) ->
     test_fts("1.2300000000e+20",1.23e20, [{scientific, 10}, compact]),
     test_fts("1.23000000000000000000e+20",1.23e20, []),
 
+    %% Negative zero
+    <<NegZero/float>> = <<16#8000000000000000:64>>,
+    "-0.0" = float_to_list(NegZero, [{decimals, 1}, compact]),
+    "-0.0" = float_to_list(NegZero, [{decimals, 1}]),
+    "-0.0e+00" = float_to_list(NegZero, [{scientific, 1}]),
+    "-0.0e+00" = float_to_list(NegZero, [{scientific, 1}, compact]),
+    <<"-0.0">> = float_to_binary(NegZero, [{decimals, 1}, compact]),
+    <<"-0.0">> = float_to_binary(NegZero, [{decimals, 1}]),
+    <<"-0.0e+00">> = float_to_binary(NegZero, [{scientific, 1}]),
+    <<"-0.0e+00">> = float_to_binary(NegZero, [{scientific, 1}, compact]),
+
     fts_rand_float_decimals(1000),
 
     ok.


### PR DESCRIPTION
Both float_to_binary and float_to_list will correctly
print negative zeros when using the scientific mode but
not when using the decimal representation. This patch
makes it consistent to always show negative floats.

This is important because some operations, such as math:atan2,
will return drastically different results if negative zeros
are given compared to positive zeros. Negative zeros also
are encoded differently in bitstrings.