### PR TITLE
Handle negative zeros on unary minus

### DIFF
--- a/erts/emulator/beam/emu/arith_instrs.tab
+++ b/erts/emulator/beam/emu/arith_instrs.tab
@@ -19,6 +19,24 @@
 // %CopyrightEnd%
 //
 
+OUTLINED_ARITH_1(Fail, Name, BIF, Op1,Dst) {
+    Eterm result;
+#ifdef DEBUG
+    Eterm* orig_htop = HTOP;
+    Eterm* orig_stop = E;
+#endif
+    DEBUG_SWAPOUT;
+    result = erts_$Name (c_p, $Op1);
+    DEBUG_SWAPIN;
+    ASSERT(orig_htop == HTOP && orig_stop == E);
+    ERTS_HOLE_CHECK(c_p);
+    if (ERTS_LIKELY(is_value(result))) {
+        $Dst = result;
+        $NEXT0();
+    }
+    $BIF_ERROR_ARITY_1($Fail, $BIF, $Op1);
+}
+
 OUTLINED_ARITH_2(Fail, Name, BIF, Op1, Op2, Dst) {
     Eterm result;
 #ifdef DEBUG
@@ -134,6 +152,27 @@ minus.execute(Fail, Dst) {
 #endif
     }
     $OUTLINED_ARITH_2($Fail, mixed_minus, BIF_sminus_2, MinusOp1, MinusOp2, $Dst);
+}
+
+i_unary_minus := unary_minus.fetch.execute;
+
+unary_minus.head() {
+    Eterm MinusOp;
+}
+
+unary_minus.fetch(Op) {
+    MinusOp = $Op;
+}
+
+unary_minus.execute(Fail, Dst) {
+    if (ERTS_LIKELY(is_small(MinusOp))) {
+        Sint i = -signed_val(MinusOp);
+        if (ERTS_LIKELY(IS_SSMALL(i))) {
+            $Dst = make_small(i);
+            $NEXT0();
+        }
+    }
+    $OUTLINED_ARITH_1($Fail, unary_minus, BIF_sminus_1, MinusOp, $Dst);
 }
 
 i_increment := increment.fetch.execute;

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -1503,7 +1503,7 @@ gc_bif2 Fail Live u$bif:erlang:splus/2 S1 S2 Dst => \
    gen_plus Fail Live S1 S2 Dst
 
 gc_bif1 Fail Live u$bif:erlang:sminus/1 Src Dst => \
-   gen_minus Fail Live i Src Dst
+   i_unary_minus Src Fail Dst
 gc_bif2 Fail Live u$bif:erlang:sminus/2 S1 S2 Dst => \
    gen_minus Fail Live S1 S2 Dst
 
@@ -1568,6 +1568,8 @@ i_plus S1=c S2=c Fail Dst => move S1 x | i_plus x S2 Fail Dst
 i_plus S1=c S2=xy Fail Dst => i_plus S2 S1 Fail Dst
 
 i_plus xy xyc j? d
+
+i_unary_minus cxy j? d
 
 # A minus instruction with a constant right operand will be
 # converted to an i_increment instruction, except in guards or

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1448,6 +1448,7 @@ Eterm collect_memory(Process *);
 void dump_memory_to_fd(int);
 int dump_memory_data(const char *);
 
+Eterm erts_unary_minus(Process* p, Eterm arg1);
 Eterm erts_mixed_plus(Process* p, Eterm arg1, Eterm arg2);
 Eterm erts_mixed_minus(Process* p, Eterm arg1, Eterm arg2);
 Eterm erts_mixed_times(Process* p, Eterm arg1, Eterm arg2);

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -1032,6 +1032,8 @@ class BeamGlobalAssembler : public BeamAssembler {
     _(process_main)                                                            \
     _(times_body_shared)                                                       \
     _(times_guard_shared)                                                      \
+    _(unary_minus_body_shared)                                                 \
+    _(unary_minus_guard_shared)                                                \
     _(update_map_assoc_shared)                                                 \
     _(update_map_exact_guard_shared)                                           \
     _(update_map_exact_body_shared)

--- a/erts/emulator/beam/jit/ops.tab
+++ b/erts/emulator/beam/jit/ops.tab
@@ -1156,7 +1156,7 @@ gc_bif2 Fail Live u$bif:erlang:splus/2 S1 S2 Dst => \
    gen_plus Fail Live S1 S2 Dst
 
 gc_bif1 Fail Live u$bif:erlang:sminus/1 Src Dst => \
-   gen_minus Fail Live i Src Dst
+   i_unary_minus Src Fail Dst
 gc_bif2 Fail Live u$bif:erlang:sminus/2 S1 S2 Dst => \
    gen_minus Fail Live S1 S2 Dst
 
@@ -1249,6 +1249,8 @@ i_increment S W d
 
 i_plus s s j? d
 i_minus s s j? d
+
+i_unary_minus s j? d
 
 i_times j? s s d
 


### PR DESCRIPTION
Before this patch, unary minus "-value" was implemented
as "0 - value" but that is not equivalent for floats when
0.0 is given.

This patch addresses this issue by implementing unary
minus as its own operation and improves the coverage.