### PR TITLE
Add a default manifest for windows

### DIFF
--- a/erts/emulator/sys/win32/erl_win_sys.h
+++ b/erts/emulator/sys/win32/erl_win_sys.h
@@ -52,10 +52,6 @@
 #include <fcntl.h>
 #include <time.h>
 #include <sys/timeb.h>
-#pragma comment(linker,"/manifestdependency:\"type='win32' "\
-		"name='Microsoft.Windows.Common-Controls' "\
-		"version='6.0.0.0' processorArchitecture='*' "\
-		"publicKeyToken='6595b64144ccf1df' language='*'\"")
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/erts/etc/win32/erl.c
+++ b/erts/etc/win32/erl.c
@@ -17,10 +17,7 @@
  * 
  * %CopyrightEnd%
  */
-#pragma comment(linker,"/manifestdependency:\"type='win32' "\
-		"name='Microsoft.Windows.Common-Controls' "\
-		"version='6.0.0.0' processorArchitecture='*' "\
-		"publicKeyToken='6595b64144ccf1df' language='*'\"")
+
 #include <windows.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/erts/etc/win32/manifest.xml
+++ b/erts/etc/win32/manifest.xml
@@ -1,0 +1,17 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0"
+          processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*">
+      </assemblyIdentity>
+    </dependentAssembly>
+  </dependency>
+ <ms_asmv2:trustInfo xmlns:ms_asmv2="urn:schemas-microsoft-com:asm.v2">
+  <ms_asmv2:security>
+   <ms_asmv2:requestedPrivileges>
+    <ms_asmv2:requestedExecutionLevel level="AsInvoker" uiAccess="false"></ms_asmv2:requestedExecutionLevel>
+   </ms_asmv2:requestedPrivileges>
+  </ms_asmv2:security>
+ </ms_asmv2:trustInfo>
+</assembly>

--- a/erts/etc/win32/win_erlexec.c
+++ b/erts/etc/win32/win_erlexec.c
@@ -22,11 +22,6 @@
  * Most of this only used when beam is run as a separate process.
  */
 
-#pragma comment(linker,"/manifestdependency:\"type='win32' "\
-		"name='Microsoft.Windows.Common-Controls' "\
-		"version='6.0.0.0' processorArchitecture='*' "\
-		"publicKeyToken='6595b64144ccf1df' language='*'\"")
-
 #include <windows.h>
 #include <winuser.h>
 #include <wincon.h>

--- a/erts/etc/win32/wsl_tools/vc/ld.sh
+++ b/erts/etc/win32/wsl_tools/vc/ld.sh
@@ -177,11 +177,16 @@ RES=$?
 
 CMANIFEST=`w32_path.sh -u $MANIFEST`
 
-if [ "$RES" = "0" -a -f "$CMANIFEST" ]; then
-    # Add stuff to manifest to turn off "virtualization"
+if [ -f "$CMANIFEST" ]; then
+    ## Add stuff to manifest to turn off "virtualization"
     sed -n -i '1h;1!H;${;g;s,<trustInfo.*</trustInfo>.,,g;p;}' $CMANIFEST 2>/dev/null
     sed -i "s/<\/assembly>/ <ms_asmv2:trustInfo xmlns:ms_asmv2=\"urn:schemas-microsoft-com:asm.v2\">\n  <ms_asmv2:security>\n   <ms_asmv2:requestedPrivileges>\n    <ms_asmv2:requestedExecutionLevel level=\"AsInvoker\" uiAccess=\"false\"\/>\n   <\/ms_asmv2:requestedPrivileges>\n  <\/ms_asmv2:security>\n <\/ms_asmv2:trustInfo>\n<\/assembly>/" $CMANIFEST 2>/dev/null
+else
+    CMANIFEST=$ERL_TOP/erts/etc/win32/manifest.xml
+    MANIFEST=`w32_path.sh -d $CMANIFEST`
+fi
 
+if [ "$RES" = "0" ]; then
     eval mt.exe -nologo -manifest "$MANIFEST" -outputresource:"$OUTPUTRES" >>/tmp/link.exe.${p}.1 2>>/tmp/link.exe.${p}.2
     RES=$?
     if [ "$RES" != "0" ]; then
@@ -192,7 +197,6 @@ if [ "$RES" = "0" -a -f "$CMANIFEST" ]; then
         echo "If you get this error, make sure Windows Defender AND Windows Search is disabled">>/tmp/link.exe.${p}.1
 	rm -f "$CREMOVE"
     fi
-    rm -f "$CMANIFEST"
 fi
 
 # This works around some strange behaviour


### PR DESCRIPTION
Previously only erl werl and beam added the manifest.
Add it to all exe and dll's.

Specificly ./Install.exe that runs after the nsis installer,
needs it if somebody wants to run it manually.
The test runs don't want to elevate to admin for example.