### PR TITLE
EDoc: Fix links in module index when using the file_suffix option

### DIFF
--- a/lib/edoc/src/edoc_doclet.erl
+++ b/lib/edoc/src/edoc_doclet.erl
@@ -131,7 +131,7 @@ gen(Sources, App, Modules, Ctxt) ->
     Title = title(App, Options),
     CSS = stylesheet(Options),
     {Modules1, Error} = sources(Sources, Dir, Modules, Env, Options),
-    modules_frame(Dir, Modules1, Title, CSS),
+    modules_frame(Dir, Modules1, Title, CSS, Options),
     overview(Dir, Title, Env, Options),
     index_file(Dir, Title),
     edoc_lib:write_info_file(App, Modules1, Dir),
@@ -249,7 +249,8 @@ index_file(Dir, Title) ->
     Text = xmerl:export_simple([XML], xmerl_html, []),
     edoc_lib:write_file(Text, Dir, ?INDEX_FILE).
 
-modules_frame(Dir, Ms, Title, CSS) ->
+modules_frame(Dir, Ms, Title, CSS, Options) ->
+    Suffix = proplists:get_value(file_suffix, Options, ?DEFAULT_FILE_SUFFIX),
     Body = [?NL,
 	    {h2, [{class, "indextitle"}], ["Modules"]},
 	    ?NL,
@@ -258,7 +259,7 @@ modules_frame(Dir, Ms, Title, CSS) ->
 	     lists:append(
 	       [[?NL,
 		 {tr, [{td, [],
-			[{a, [{href, module_ref(M)},
+			[{a, [{href, module_ref(M, Suffix)},
 			      {target, "overviewFrame"},
 			      {class, "module"}],
 			  [atom_to_list(M)]}]}]}]
@@ -268,8 +269,8 @@ modules_frame(Dir, Ms, Title, CSS) ->
     Text = xmerl:export_simple([XML], xmerl_html, []),
     edoc_lib:write_file(Text, Dir, ?MODULES_FRAME).
 
-module_ref(M) ->
-    atom_to_list(M) ++ ?DEFAULT_FILE_SUFFIX.
+module_ref(M, Suffix) ->
+    atom_to_list(M) ++ Suffix.
 
 xhtml(Title, CSS, Content) ->
     xhtml_1(Title, CSS, {body, [{bgcolor, "white"}], Content}).
@@ -438,7 +439,7 @@ app_index_file(Paths, Dir, Env, Options) ->
     Apps1 = [{filename:dirname(A),filename:basename(A)} || A <- Paths],
     index_file(Dir, Title),
     application_frame(Dir, Apps1, Title, CSS),
-    modules_frame(Dir, [], Title, CSS),
+    modules_frame(Dir, [], Title, CSS, Options),
     overview(Dir, Title, Env, Options),
 %    edoc_lib:write_info_file(Prod, [], Modules1, Dir),
     copy_stylesheet(Dir, Options).


### PR DESCRIPTION
`edoc_doclet` has an option `file_suffix` for generating module files with different file extensions than the default `".html"`, e.g. `".htm"`. The generated module index (`modules-frame.html`) did not consider the different file suffix and always used `".html"`, so the links did not work at all. This is fixed by this PR.

<hr />

Judging from `git blame`, this option was introduced in 2009 and has been broken ever since.

Furthermore, the application of this option is incomplete, as only the module files are generated according to this option, but not the overview, the module index itself, and the index (frameset) files. While it appears to be safe to apply the file suffix option to the overview and module index as well, I'm not sure about the index (frameset), as this seems to be used for linking between applications.

It stands to reason to assume that nobody has ever been seriously using this option (I only happened to notice this bug while working on something different). It _may_ be used in some way or other, but probably only if the generated module files are processed/used further in other ways, not to generate a complete, ready-to-deliver documentation.

Therefore, I put it up to discussion if this option should not be removed from the `edoc` documentation. Removal from the code may not be feasible, or even impossible, so I'm not suggesting that.