### PR TITLE
Add map conversion functions to proplists

### DIFF
--- a/lib/stdlib/doc/src/proplists.xml
+++ b/lib/stdlib/doc/src/proplists.xml
@@ -138,6 +138,14 @@ expand([{{foo, true}, [bar, baz]}], [{foo, false}, fie, foo, fum])</code>
     </func>
 
     <func>
+      <name name="from_map" arity="1" since=""/>
+      <fsummary></fsummary>
+      <desc>
+        <p>Converts the map <c><anno>Map</anno></c> to a property list.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="get_all_values" arity="2" since=""/>
       <fsummary></fsummary>
       <desc>
@@ -361,6 +369,30 @@ split([{c, 2}, {e, 1}, a, {c, 3, 4}, d, {b, 5}, b], [a, b, c])</code>
           <seemfa marker="#normalize/2"><c>normalize/2</c></seemfa>,
           <seemfa marker="#substitute_aliases/2">
           <c>substitute_aliases/2</c></seemfa>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="to_map" arity="1" since=""/>
+      <fsummary></fsummary>
+      <desc>
+        <p>Converts the property list <c><anno>List</anno></c> to a map.</p>
+        <p>Shorthand atom values in <c><anno>List</anno></c> will be expanded
+          to an association of the form <c>Atom => true</c>. Tuples of the
+          form <c>{Key, Value}</c> in <c><anno>List</anno></c> will be
+          converted to an association of the form <c>Key => Value</c>.
+          Anything else will be silently ignored.</p>
+        <p>If the same key appears in <c><anno>List</anno></c> multiple
+          times, the value of the one appearing nearest to the head of
+          <c><anno>List</anno></c> will be in the result map, that is
+          the value that would be returned by a call to
+          <c>get_value(Key, List)</c>.</p>
+        <p><em>Example:</em></p>
+        <code type="none">
+to_map([a, {b, 1}, {c, 2}, {c, 3}])</code>
+        <p>returns:</p>
+        <code type="none">
+#{a => true, b => 1, c => 2}</code>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/proplists.xml
+++ b/lib/stdlib/doc/src/proplists.xml
@@ -397,6 +397,18 @@ to_map([a, {b, 1}, {c, 2}, {c, 3}])</code>
     </func>
 
     <func>
+      <name name="to_map" arity="2" since=""/>
+      <fsummary></fsummary>
+      <desc>
+        <p>Converts the property list <c><anno>List</anno></c> to a map after
+          applying the normalizations given in <c><anno>Stages</anno></c>.</p>
+        <p>See also
+          <seemfa marker="#normalize/2"><c>normalize/2</c></seemfa>,
+          <seemfa marker="#to_map/1"><c>to_map/1</c></seemfa>.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="unfold" arity="1" since=""/>
       <fsummary></fsummary>
       <desc>

--- a/lib/stdlib/test/proplists_SUITE.erl
+++ b/lib/stdlib/test/proplists_SUITE.erl
@@ -23,7 +23,8 @@
 -export([all/0, suite/0,groups/0, init_per_suite/1, end_per_suite/1,
          init_per_group/2, end_per_group/2,
 	 init_per_testcase/2, end_per_testcase/2,
-         examples/1, map_conversion/1]).
+         examples/1, map_conversion/1, map_conversion_normalize/1,
+         pm_fold_test/1]).
 
 init_per_testcase(_Case, Config) ->
     Config.
@@ -36,7 +37,7 @@ suite() ->
      {timetrap,{minutes,5}}].
 
 all() ->
-    [examples, map_conversion].
+    [examples, map_conversion, map_conversion_normalize, pm_fold_test].
 
 groups() ->
     [].
@@ -103,39 +104,78 @@ map_conversion(_Config) ->
     %% map yields the same results as proplists:get_value/3 on the
     %% original proplist, ie they either all return the same `Value',
     %% or they all return the `Default' given as respective third argument.
-    Default1 = make_ref(),
-    Default2 = make_ref(),
-    Default3 = make_ref(),
-    InList=[a, b, {a, 1}, {}, {a}, {a, 1, 2}, "foo"],
-    lists:foreach(
-        fun (L1) ->
-            LKs = proplists:get_keys(L1),
-            M = proplists:to_map(L1),
-            L2 = proplists:from_map(M),
-            [] = maps:keys(M) -- LKs,
-            [] = proplists:get_keys(L2) -- LKs, 
-            lists:foreach(
-                fun (K) ->
-                    case
-                        {
-                            maps:get(K, M, Default1),
-                            proplists:get_value(K, L1, Default2),
-                            proplists:get_value(K, L2, Default3)
-                        }
-                    of
-                        {V, V, V} -> true;
-                        {Default1, Default2, Default3} -> true
-                    end
-                end,
-                LKs
-            )
+    Default = make_ref(),
+    InList=[a, b, {a, 1}, {}, {a}, {a, 1, 2}, {c, 1, 2}, "foo"],
+    Fun = fun (L1, Acc) ->
+        LKs = proplists:get_keys(L1),
+        M = proplists:to_map(L1),
+        L2 = proplists:from_map(M),
+        true = lists:sort(maps:keys(M)) =:= lists:sort(proplists:get_keys(L2)),
+        lists:foreach(
+            fun (K) ->
+                case
+                    {
+                        maps:get(K, M, Default),
+                        proplists:get_value(K, L1, Default),
+                        proplists:get_value(K, L2, Default)
+                    }
+                of
+                    {Default, Default, Default} -> ok;
+                    {V, V, V} -> ok
+                end
+            end,
+            LKs
+        ),
+        Acc
+    end,
+    _ = pm_fold(Fun, undefined, InList),
+    ok.
+
+map_conversion_normalize(_Config) ->
+    Stages = [
+        {aliases, [{a, alias_a}]},
+        {negations, [{no_b, b}]},
+        {expand, [{c, [d]}]}
+    ],
+
+    M1 = proplists:to_map([], Stages),
+    true = M1 =:= #{},
+    true = M1 =:= proplists:to_map(proplists:normalize([], Stages)),
+
+    List = [a, no_b, c],
+    M2 = proplists:to_map(List, Stages),
+    true = M2 =:= #{alias_a => true, b => false, d => true},
+    true = M2 =:= proplists:to_map(proplists:normalize(List, Stages)),
+
+    ok.
+
+pm_fold(_, _, []) ->
+    [];
+pm_fold(Fun, Acc0, L) ->
+    pm_fold(Fun, Acc0, L, []).
+
+pm_fold(Fun, Acc, [], Mut) ->
+    Fun(Mut, Acc);
+pm_fold(Fun, Acc, L, Mut) ->
+    lists:foldl(
+        fun
+            (X, AccIn) -> pm_fold(Fun, AccIn, lists:delete(X, L), [X|Mut])
         end,
-        [[A, B, C, D, E, F, G] || A <- InList,
-                                  B <- InList -- [A],
-                                  C <- InList -- [A, B],
-                                  D <- InList -- [A, B, C],
-                                  E <- InList -- [A, B, C, D],
-                                  F <- InList -- [A, B, C, D, E],
-                                  G <- InList -- [A, B, C, D, E, F]]
-    ),
+        Acc,
+        L
+    ).
+
+pm_fold_test(_Config) ->
+    Fun = fun (M, A) -> [M|A] end,
+
+    [] = pm_fold(Fun, [], []),
+
+    [[1]] = lists:sort(pm_fold(Fun, [], [1])),
+
+    Exp1 = lists:sort([[1, 2], [2, 1]]),
+    Exp1 = lists:sort(pm_fold(Fun, [], [1, 2])),
+
+    Exp2 = lists:sort([[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]),
+    Exp2 = lists:sort(pm_fold(Fun, [], [1, 2, 3])),
+
     ok.


### PR DESCRIPTION
Converting `proplists` (usually used in older projects/dependencies) from/to `maps` (used in more recent projects) is usually done with `maps:from_list/1`. Generally, you want to use `maps:get/2,3` (or pattern matching) then instead of `proplists:get_value/2,3`.

A conversion via `maps:from_list/1` is fragile in several ways here:
* proplists may contain single atoms as shorthand for `{Atom, true}`. `maps:from_list/1` cannot handle this.
* proplists may even contain _any_ term besides single atoms and key-value 2-tuples. They are accepted and ignored by the proplists API, but `maps:from_list/1` cannot handle those.
* proplists may contain the same keys multiple times with different values, and `proplists:get_value/2,3` will return the _first_ such value for a key. A map created from such a list via `maps:from_list/1` will contain the _last_ value for a key.

The `proplists:to_map/1` function introduced with this PR addresses the cases outlined above:
* (key-value 2-tuples will be converted to `Key => Value` associations, as usual).
* single atoms in the list will be expanded and appear in the map as `Atom => true`.
* any other terms are silently ignored and won't appear in the map at all; in general, it might be appropriate to raise a `badarg` exception here, but since the proplists API accepts and just ignores them, this function necessarily follows suit.
* if a key appears multiple times, the _first_ value will be in the result map, not the _last_, so `maps:get/2,3` on the created map yields the same result as would `proplists:get_value/2,3` on the proplist it was created from.

While `proplists` offers functions to access _all_ values of properties with the same key (`get_all_values/2`, `lookup_all/2`), this is not possible with a map, at least not without taking out all the conveniences you get by using a map in the first place. But if you were using `maps:from_list/1` before for this purpose, you got only single values anyway, just not necessarily the ones you wanted ;)

The other function in this PR, `proplists:from_map/1`, creates a proplist from a map, which is just `maps:to_list/1`. This function is only there for symmetry.