### PR TITLE
erl_lint: Remove -behaviour() checking

### DIFF
--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -54,7 +54,7 @@
          otp_11772/1, otp_11771/1, otp_11872/1,
          export_all/1,
          bif_clash/1,
-         behaviour_basic/1, behaviour_multiple/1, otp_11861/1,
+         otp_11861/1,
          otp_7550/1,
          otp_8051/1,
          format_warn/1,
@@ -85,7 +85,7 @@ all() ->
      otp_5362, otp_5371, otp_7227, otp_5494, otp_5644,
      otp_5878, otp_5917, otp_6585, otp_6885, otp_10436, otp_11254,
      otp_11772, otp_11771, otp_11872, export_all,
-     bif_clash, behaviour_basic, behaviour_multiple, otp_11861,
+     bif_clash, otp_11861,
      otp_7550, otp_8051, format_warn, {group, on_load},
      too_many_arguments, basic_errors, bin_syntax_errors, predef,
      maps, maps_type, maps_parallel_match,
@@ -3116,178 +3116,9 @@ bif_clash(Config) when is_list(Config) ->
     [] = run(Config, Ts),
     ok.
 
-%% Basic tests with one behaviour.
-behaviour_basic(Config) when is_list(Config) ->
-    Ts = [{behaviour1,
-           <<"-behaviour(application).
-             ">>,
-           [],
-	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{start,2},application}},
-		      {1,erl_lint,{undefined_behaviour_func,{stop,1},application}}]}},
-
-	  {behaviour2,
-           <<"-behaviour(application).
-              -export([stop/1]).
-              stop(_) -> ok.
-             ">>,
-           [],
-	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{start,2},application}}]}},
-	  
-	  {behaviour3,
-           <<"-behavior(application).  %% Test American spelling.
-              -export([start/2,stop/1]).
-              start(_, _) -> ok.
-              stop(_) -> ok.
-             ">>,
-           [],
-           []},
-
-          {behaviour4,
-           <<"-behavior(application).  %% Test callbacks with export_all
-              -compile([export_all, nowarn_export_all]).
-              stop(_) -> ok.
-             ">>,
-           [],
-           {warnings,[{1,erl_lint,{undefined_behaviour_func,{start,2},application}}]}}
-	 ],
-    [] = run(Config, Ts),
-    ok.
-
-%% Basic tests with multiple behaviours.
-behaviour_multiple(Config) when is_list(Config) ->
-    Ts = [{behaviour1,
-           <<"-behaviour(application).
-              -behaviour(supervisor).
-             ">>,
-           [],
-	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{start,2},application}},
-		      {1,erl_lint,{undefined_behaviour_func,{stop,1},application}},
-		      {2,erl_lint,{undefined_behaviour_func,{init,1},supervisor}}]}},
-
-	  {behaviour2,
-           <<"-behaviour(application).
-              -behaviour(supervisor).
-              -export([start/2,stop/1,init/1]).
-              start(_, _) -> ok.
-              stop(_) -> ok.
-              init(_) -> ok.
-             ">>,
-           [],
-	   []},
-
-	  {american_behavior2,
-           <<"-behavior(application).
-              -behavior(supervisor).
-              -export([start/2,stop/1,init/1]).
-              start(_, _) -> ok.
-              stop(_) -> ok.
-              init(_) -> ok.
-             ">>,
-           [],
-	   []},
-
-	  {behaviour3,
-           <<"-behaviour(gen_server).
-              -behaviour(supervisor).
-              -export([handle_call/3,handle_cast/2,handle_info/2]).
-              handle_call(_, _, _) -> ok.
-              handle_cast(_, _) -> ok.
-              handle_info(_, _) -> ok.
-             ">>,
-           [],
-	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{init,1},gen_server}},
-		      {2,erl_lint,{undefined_behaviour_func,{init,1},supervisor}},
-		      {2,
-		       erl_lint,
-		       {conflicting_behaviours,{init,1},supervisor,1,gen_server}}]}},
-	  {american_behavior3,
-           <<"-behavior(gen_server).
-              -behavior(supervisor).
-              -export([handle_call/3,handle_cast/2,handle_info/2]).
-              handle_call(_, _, _) -> ok.
-              handle_cast(_, _) -> ok.
-              handle_info(_, _) -> ok.
-             ">>,
-           [],
-	   {warnings,[{1,erl_lint,{undefined_behaviour_func,{init,1},gen_server}},
-		      {2,erl_lint,{undefined_behaviour_func,{init,1},supervisor}},
-		      {2,
-		       erl_lint,
-		       {conflicting_behaviours,{init,1},supervisor,1,gen_server}}]}},
-
-	  {behaviour4,
-           <<"-behaviour(gen_server).
-              -behaviour(gen_fsm).
-              -behaviour(supervisor).
-              -export([init/1,handle_call/3,handle_cast/2,
-                       handle_info/2,handle_info/3,
-                       handle_event/3,handle_sync_event/4,
-                       code_change/3,code_change/4,
-                       terminate/2,terminate/3,terminate/4]).
-              init(_) -> ok.
-              handle_call(_, _, _) -> ok.
-              handle_event(_, _, _) -> ok.
-              handle_sync_event(_, _, _, _) -> ok.
-              handle_cast(_, _) -> ok.
-              handle_info(_, _) -> ok.
-              handle_info(_, _, _) -> ok.
-              code_change(_, _, _) -> ok.
-              code_change(_, _, _, _) -> ok.
-              terminate(_, _) -> ok.
-              terminate(_, _, _) -> ok.
-              terminate(_, _, _, _) -> ok.
-             ">>,
-           [],
-	   {warnings,[{2,
-		       erl_lint,
-		       {conflicting_behaviours,{init,1},gen_fsm,1,gen_server}},
-		      {3,
-		       erl_lint,
-		       {conflicting_behaviours,{init,1},supervisor,1,gen_server}}]}}
-	 ],
-    [] = run(Config, Ts),
-    ok.
-
 %% OTP-11861. behaviour_info() and -callback.
 otp_11861(Conf) when is_list(Conf) ->
-    CallbackFiles = [callback1, callback2, callback3,
-                     bad_behaviour1, bad_behaviour2],
-    lists:foreach(fun(M) ->
-                          F = filename:join(?datadir, M),
-                          Opts = [{outdir,?privdir}, return],
-                          {ok, M, []} = compile:file(F, Opts)
-                  end, CallbackFiles),
-    CodePath = code:get_path(),
-    true = code:add_path(?privdir),
-    Ts = [{otp_11861_1,
-           <<"
-              -export([b1/1]).
-              -behaviour(callback1).
-              -behaviour(callback2).
-
-              -spec b1(atom()) -> integer().
-              b1(A) when is_atom(A)->
-                  3.
-             ">>,
-           [],
-           %% b2/1 is optional in both modules
-           {warnings,[{4,erl_lint,
-                       {conflicting_behaviours,{b1,1},callback2,3,callback1}}]}},
-          {otp_11861_2,
-           <<"
-              -export([b2/1]).
-              -behaviour(callback1).
-              -behaviour(callback2).
-
-              -spec b2(integer()) -> atom().
-              b2(I) when is_integer(I)->
-                  a.
-             ">>,
-           [],
-           %% b2/1 is optional in callback2, but not in callback1
-           {warnings,[{3,erl_lint,{undefined_behaviour_func,{b1,1},callback1}},
-                      {4,erl_lint,
-                       {conflicting_behaviours,{b2,1},callback2,3,callback1}}]}},
+    Ts = [
           {otp_11861_3,
            <<"
               -callback b(_) -> atom().
@@ -3373,26 +3204,6 @@ otp_11861(Conf) when is_list(Conf) ->
              ">>,
            [],
            []},
-          {otp_11861_11,
-           <<"
-              -behaviour(bad_behaviour1).
-             ">>,
-           [],
-           {warnings,[{2,erl_lint,
-                       {ill_defined_behaviour_callbacks,bad_behaviour1}}]}},
-          {otp_11861_12,
-           <<"
-              -behaviour(non_existing_behaviour).
-             ">>,
-           [],
-           {warnings,[{2,erl_lint,
-                       {undefined_behaviour,non_existing_behaviour}}]}},
-          {otp_11861_13,
-           <<"
-              -behaviour(bad_behaviour_none).
-             ">>,
-           [],
-           {warnings,[{2,erl_lint,{undefined_behaviour,bad_behaviour_none}}]}},
           {otp_11861_14,
            <<"
               -callback b(_) -> atom().
@@ -3413,13 +3224,6 @@ otp_11861(Conf) when is_list(Conf) ->
              ">>,
            [],
            {errors,[{3,erl_lint,{redefine_callback,{b,1}}}],[]}},
-          {otp_11861_17,
-           <<"
-              -behaviour(bad_behaviour2).
-             ">>,
-           [],
-           {warnings,[{2,erl_lint,{undefined_behaviour_callbacks,
-                                   bad_behaviour2}}]}},
           {otp_11861_18,
            <<"
               -export([f1/1]).
@@ -3430,7 +3234,6 @@ otp_11861(Conf) when is_list(Conf) ->
            []}
 	 ],
     [] = run(Conf, Ts),
-    true = code:set_path(CodePath),
     ok.
 
 %% Test that the new utf8/utf16/utf32 types do not allow size or
@@ -4082,9 +3885,6 @@ non_latin1_module(Config) ->
     "explicit module not allowed for callback "
     "'кирилли́ческий атом':'кирилли́ческий атом'/0" =
         format_error(BadCallback),
-    UndefBehav = {undefined_behaviour,'кирилли́ческий атом'},
-    "behaviour 'кирилли́ческий атом' undefined" =
-        format_error(UndefBehav),
     Ts = [{non_latin1_module,
            <<"
             %% Report uses of module names with non-Latin-1 characters.
@@ -4112,7 +3912,7 @@ non_latin1_module(Config) ->
                 F = f,
                 'кирилли́ческий атом':F()."/utf8>>,
            [],
-           {error,
+           {errors,
             [{4,erl_lint,non_latin1_module_unsupported},
              {5,erl_lint,non_latin1_module_unsupported},
              {6,erl_lint,non_latin1_module_unsupported},
@@ -4125,8 +3925,7 @@ non_latin1_module(Config) ->
              {20,erl_lint,non_latin1_module_unsupported},
              {23,erl_lint,non_latin1_module_unsupported},
              {25,erl_lint,non_latin1_module_unsupported}],
-            [{5,erl_lint,UndefBehav},
-             {6,erl_lint,UndefBehav}]}}],
+            []}}],
     run(Config, Ts),
     ok.
 

--- a/lib/stdlib/test/erl_lint_SUITE_data/bad_behaviour1.erl
+++ b/lib/stdlib/test/erl_lint_SUITE_data/bad_behaviour1.erl
@@ -1,6 +1,0 @@
--module(bad_behaviour1).
-
--export([behaviour_info/1]).
-
-behaviour_info(callbacks) ->
-    [{a,1,bad}].

--- a/lib/stdlib/test/erl_lint_SUITE_data/bad_behaviour2.erl
+++ b/lib/stdlib/test/erl_lint_SUITE_data/bad_behaviour2.erl
@@ -1,6 +1,0 @@
--module(bad_behaviour2).
-
--export([behaviour_info/1]).
-
-behaviour_info(callbacks) ->
-    undefined.

--- a/lib/stdlib/test/erl_lint_SUITE_data/callback1.erl
+++ b/lib/stdlib/test/erl_lint_SUITE_data/callback1.erl
@@ -1,6 +1,0 @@
--module(callback1).
-
--callback b1(I :: integer()) -> atom().
--callback b2(A :: atom()) -> integer().
-
--optional_callbacks([{b2,1}]).

--- a/lib/stdlib/test/erl_lint_SUITE_data/callback2.erl
+++ b/lib/stdlib/test/erl_lint_SUITE_data/callback2.erl
@@ -1,6 +1,0 @@
--module(callback2).
-
--callback b1(I :: integer()) -> atom().
--callback b2(A :: atom()) -> integer().
-
--optional_callbacks([b1/1, b2/1]).

--- a/lib/stdlib/test/erl_lint_SUITE_data/callback3.erl
+++ b/lib/stdlib/test/erl_lint_SUITE_data/callback3.erl
@@ -1,8 +1,0 @@
--module(callback3).
-
--export([behaviour_info/1]).
-
-behaviour_info(callbacks) ->
-    [{f1, 1}];
-behaviour_info(_) ->
-    undefined.


### PR DESCRIPTION
`-behaviour()` requires that the behavior module is built before the module we're compiling, and that it can be found in the build system's code path (which may have no relation to the host system). This is very annoying to deal with so we've decided to remove it as `dialyzer` already does this check in a far better fashion than the linter.

The only thing `dialyzer` lacks is that it doesn't understand the `behavior_info/1` callback (and raises a warning to that effect), but we consider that less important than fixing this issue. We can fix that separately should it become a problem.