### PR TITLE
Implement early_data for TLS clients

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1043,6 +1043,10 @@ fun(srp, Username :: binary(), UserState :: term()) ->
 	</desc>
       </datatype>
 
+      <datatype>
+	<name name="client_early_data"/>
+      </datatype>
+
     <!--   <datatype> -->
   <!-- 	<name name="ocsp_stapling"/> -->
   <!-- 	<desc><p>If true, OCSP stapling will be enabled, an extension of type "status_request" will be -->
@@ -1332,6 +1336,14 @@ fun(srp, Username :: binary(), UserState :: term()) ->
 	The cookie extension is enabled by default as it is a mandatory extension
 	in RFC8446.</p></note>
 	</desc>
+      </datatype>
+
+      <datatype>
+        <name name="server_early_data"/>
+      </datatype>
+
+      <datatype>
+        <name name="max_early_data"/>
       </datatype>
 
       <datatype>

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1045,6 +1045,17 @@ fun(srp, Username :: binary(), UserState :: term()) ->
 
       <datatype>
 	<name name="client_early_data"/>
+	<desc>
+	  <p>Configures the early data to be sent by the client.</p>
+	  <p>In order to be able to verify
+          that the server has the intention to process the early data, the following 3-tuple is
+	  sent to the user process:</p>
+	  <p><c>{ssl, SslSocket, {early_data, Result}}</c></p>
+	  <p>where <c>Result</c> is either <c>accepted</c> or <c>rejected</c>.</p>
+	  <warning>
+	  <p>It is the responsibility of the user to handle a rejected Early Data and
+	  to resend when it is appropriate.</p></warning>
+	</desc>
       </datatype>
 
     <!--   <datatype> -->
@@ -1340,10 +1351,13 @@ fun(srp, Username :: binary(), UserState :: term()) ->
 
       <datatype>
         <name name="server_early_data"/>
-      </datatype>
-
-      <datatype>
-        <name name="max_early_data"/>
+	<desc>
+          <p>Configures if the server accepts (<c>enabled</c>) or rejects (<c>rejects</c>) early
+	  data sent by a client. The default value is <c>disabled</c>.
+          </p>
+	  <warning><p>This option is a placeholder, early data is not yet implemented on the server side.
+          </p></warning>
+        </desc>
       </datatype>
 
       <datatype>

--- a/lib/ssl/doc/src/standards_compliance.xml
+++ b/lib/ssl/doc/src/standards_compliance.xml
@@ -140,7 +140,7 @@
     <list type="bulleted">
       <item>PSK and session resumption is supported (stateful and stateless tickets)</item>
       <item>Anti-replay protection using Bloom-filters with stateless tickets</item>
-      <item>Early data and 0-RTT not supported</item>
+      <item>Early data and 0-RTT is supported on the client side</item>
       <item>Key and Initialization Vector Update is supported</item>
     </list>
     <p>For more detailed information see the
@@ -251,8 +251,8 @@
 	  </url>
 	</cell>
         <cell align="left" valign="middle"></cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+	<cell align="left" valign="middle"><em>PC</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
 
       <row>
@@ -387,8 +387,8 @@
       <row>
         <cell align="left" valign="middle"></cell>
         <cell align="left" valign="middle">early_data (RFC8446)</cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+	<cell align="left" valign="middle"><em>C</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
       <row>
         <cell align="left" valign="middle"></cell>
@@ -1135,8 +1135,8 @@
 	  </url>
 	</cell>
         <cell align="left" valign="middle"><em>Client</em></cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+	<cell align="left" valign="middle"><em>C</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
       <row>
         <cell align="left" valign="middle"></cell>
@@ -1274,8 +1274,8 @@
       <row>
         <cell align="left" valign="middle"></cell>
         <cell align="left" valign="middle">early_data (RFC8446)</cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+	<cell align="left" valign="middle"><em>C</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
       <row>
         <cell align="left" valign="middle"></cell>
@@ -1667,8 +1667,8 @@
 	  </url>
 	</cell>
         <cell align="left" valign="middle"><em>Client</em></cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+	<cell align="left" valign="middle"><em>C</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
       <row>
         <cell align="left" valign="middle"></cell>
@@ -1684,27 +1684,27 @@
 	  </url>
 	</cell>
         <cell align="left" valign="middle"><em>Client</em></cell>
-	<cell align="left" valign="middle"><em>PC</em></cell>
-	<cell align="left" valign="middle"><em>22.2</em></cell>
+	<cell align="left" valign="middle"><em>C</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
       <row>
         <cell align="left" valign="middle"></cell>
         <cell align="left" valign="middle">early_data (RFC8446)</cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+	<cell align="left" valign="middle"><em>C</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
 
       <row>
         <cell align="left" valign="middle"></cell>
         <cell align="left" valign="middle"><em>Server</em></cell>
-	<cell align="left" valign="middle"><em>PC</em></cell>
-	<cell align="left" valign="middle"><em>22.2</em></cell>
+	<cell align="left" valign="middle"><em>C</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
       <row>
         <cell align="left" valign="middle"></cell>
         <cell align="left" valign="middle">early_data (RFC8446)</cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+	<cell align="left" valign="middle"><em>C</em></cell>
+	<cell align="left" valign="middle"><em>23.3</em></cell>
       </row>
 
       <row>

--- a/lib/ssl/doc/src/using_ssl.xml
+++ b/lib/ssl/doc/src/using_ssl.xml
@@ -559,6 +559,104 @@ ok
   </section>
 
   <section>
+    <title>Early Data in TLS 1.3</title>
+    <p>TLS 1.3 allows clients to send data on the first flight if the endpoints have
+    a shared crypographic secret (pre-shared key). This means that clients can send
+    early data if they have a valid session ticket received in a previous
+    successful handshake. For more information about session resumption see
+    <seeguide marker="ssl:using_ssl#session-tickets-and-session-resumption-in-tls-1.3">
+    Session Tickets and Session Resumption in TLS 1.3</seeguide>.
+    </p>
+    <p>The security properties of Early Data are weaker than other kinds of TLS data.
+    This data is not forward secret, and it is vulnerable to replay attacks. For available
+    mitigation strategies see
+    <seeguide marker="ssl:using_ssl#anti-replay-protection-in-tls-1.3">
+    Anti-Replay Protection in TLS 1.3</seeguide>.</p>
+    <p>In normal operation, clients will not know which, if any, of the available mitigation
+    strategies servers actually implement, and hence must only send early data which
+    they deem safe to be replayed. For example, idempotent HTTP operations, such as HEAD and
+    GET, can usually be regarded as safe but even they can be exploited by a large number of
+    replays causing resource limit exhaustion and other similar problems.</p>
+    <p>An example of sending early data with automatic and manual session ticket handling:</p>
+    <warning>
+    <p>The Early Data feature is implemented only on the client side in this version of OTP.
+    </p>
+    </warning>
+
+    <p><em>Server side (openssl s_server):</em></p>
+    <code type="none">
+    openssl s_server -accept 11029 \
+        -tls1_3 -verify 2 \
+        -cert certs/server.pem \
+        -CAfile certs/ca.pem \
+        -key certs/server.key \
+        -keylogfile keylog \
+        -msg -debug \
+        -early_data \
+        -no_anti_replay
+    </code>
+    <p><em>Client (automatic ticket handling):</em></p>
+    <code type="erl">
+    early_data_auto() -&gt;
+        %% First handshake 1-RTT - get session tickets
+	application:load(ssl),
+	{ok, _} = application:ensure_all_started(ssl),
+	Port = 11029,
+	Data = &lt;&lt;"HEAD / HTTP/1.1\r\nHost: \r\nConnection: close\r\n"&gt;&gt;,
+	COpts0 = [{cacertfile, ?CA_CERT},
+	          {versions, ['tlsv1.2', 'tlsv1.3']},
+	          {session_tickets, auto}],
+        {ok, Sock0} = ssl:connect("localhost", Port, COpts0),
+
+        %% Wait for session tickets
+	timer:sleep(500),
+	%% Close socket if server cannot handle multiple connections e.g. openssl s_server
+	ssl:close(Sock0),
+
+        %% Second handshake 0-RTT
+	COpts1 = [{cacertfile, ?CA_CERT},
+	          {versions, ['tlsv1.2', 'tlsv1.3']},
+		  {session_tickets, auto},
+		  {early_data, Data}],
+        {ok, Sock} = ssl:connect("localhost", Port, COpts1),
+	Sock.
+    </code>
+    <p><em>Client (manual ticket handling):</em></p>
+    <code type="erl">
+    early_data_manual() -&gt;
+        %% First handshake 1-RTT - get session tickets
+	application:load(ssl),
+	{ok, _} = application:ensure_all_started(ssl),
+	Port = 11029,
+	Data = &lt;&lt;"HEAD / HTTP/1.1\r\nHost: \r\nConnection: close\r\n"&gt;&gt;,
+	COpts0 = [{cacertfile, ?CA_CERT},
+	          {versions, ['tlsv1.2', 'tlsv1.3']},
+	          {session_tickets, manual}],
+        {ok, Sock0} = ssl:connect("localhost", Port, COpts0),
+
+        %% Wait for session tickets
+	Ticket =
+	    receive
+	        {ssl, session_ticket, Ticket0} ->
+		    Ticket0
+            end,
+
+       %% Close socket if server cannot handle multiple connections
+       %% e.g. openssl s_server
+       ssl:close(Sock0),
+
+       %% Second handshake 0-RTT
+       COpts1 = [{cacertfile, ?CA_CERT},
+                 {versions, ['tlsv1.2', 'tlsv1.3']},
+		 {session_tickets, manual},
+		 {use_ticket, [Ticket]},
+		 {early_data, Data}],
+       {ok, Sock} = ssl:connect("localhost", Port, COpts1),
+       Sock.
+    </code>
+  </section>
+
+  <section>
     <title>Anti-Replay Protection in TLS 1.3</title>
 
     <p>The TLS 1.3 protocol does not provide inherent protection for replay of 0-RTT data but

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -386,7 +386,6 @@
 -type middlebox_comp_mode()      :: boolean().
 -type client_early_data()        :: binary().
 -type server_early_data()        :: disabled | enabled.
--type max_early_data()           :: pos_integer().
 
 %% -------------------------------------------------------------------------------------------------------
 
@@ -458,8 +457,7 @@
                                 {session_tickets, server_session_tickets()} |
                                 {anti_replay, anti_replay()} |
                                 {cookie, cookie()} |
-                                {early_data, server_early_data()} |
-                                {max_early_data, max_early_data()}.
+                                {early_data, server_early_data()}.
 
 -type server_cacerts()           :: [public_key:der_encoded()].
 -type server_cafile()            :: file:filename().

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -384,6 +384,9 @@
                                      bloom_filter_bits()}.          %% m - number of bits in bit vector
 -type use_ticket()               :: [binary()].
 -type middlebox_comp_mode()      :: boolean().
+-type client_early_data()        :: binary().
+-type server_early_data()        :: disabled | enabled.
+-type max_early_data()           :: pos_integer().
 
 %% -------------------------------------------------------------------------------------------------------
 
@@ -402,7 +405,8 @@
                                 {signature_algs, client_signature_algs()} |
                                 {fallback, fallback()} |
                                 {session_tickets, client_session_tickets()} |
-                                {use_ticket, use_ticket()}. %% |
+                                {use_ticket, use_ticket()} |
+                                {early_data, client_early_data()}.
                                 %% {ocsp_stapling, ocsp_stapling()} |
                                 %% {ocsp_responder_certs, ocsp_responder_certs()} |
                                 %% {ocsp_nonce, ocsp_nonce()}.
@@ -453,7 +457,9 @@
                                 {signature_algs, server_signature_algs()} |
                                 {session_tickets, server_session_tickets()} |
                                 {anti_replay, anti_replay()} |
-                                {cookie, cookie()}.
+                                {cookie, cookie()} |
+                                {early_data, server_early_data()} |
+                                {max_early_data, max_early_data()}.
 
 -type server_cacerts()           :: [public_key:der_encoded()].
 -type server_cafile()            :: file:filename().
@@ -1708,6 +1714,32 @@ handle_option(client_renegotiation = Option, Value0,
                              ['tlsv1','tlsv1.1','tlsv1.2']),
     Value = validate_option(Option, Value0),
     OptionsMap#{Option => Value};
+handle_option(early_data = Option, unbound, OptionsMap, #{rules := Rules}) ->
+    Value = validate_option(Option, default_value(Option, Rules)),
+    OptionsMap#{Option => Value};
+handle_option(early_data = Option, Value0, #{session_tickets := SessionTickets,
+                                             versions := Versions} = OptionsMap,
+              #{role := server = Role}) ->
+    assert_option_dependency(Option, versions, Versions, ['tlsv1.3']),
+    assert_option_dependency(Option, session_tickets, [SessionTickets],
+                             [stateful, stateless]),
+    Value = validate_option(Option, Value0, Role),
+    OptionsMap#{Option => Value};
+handle_option(early_data = Option, Value0, #{session_tickets := SessionTickets,
+                                             use_ticket := UseTicket,
+                                             versions := Versions} = OptionsMap,
+              #{role := client = Role}) ->
+    assert_option_dependency(Option, versions, Versions, ['tlsv1.3']),
+    assert_option_dependency(Option, session_tickets, [SessionTickets],
+                             [manual, auto]),
+    case UseTicket of
+        undefined when SessionTickets =/= auto ->
+            throw({error, {options, dependency, {Option, use_ticket}}});
+        _ ->
+            ok
+    end,
+    Value = validate_option(Option, Value0, Role),
+    OptionsMap#{Option => Value};
 handle_option(eccs = Option, unbound, #{versions := [HighestVersion|_]} = OptionsMap, #{rules := _Rules}) ->
     Value = handle_eccs_option(eccs(), HighestVersion),
     OptionsMap#{Option => Value};
@@ -1751,6 +1783,21 @@ handle_option(key_update_at = Option, unbound, OptionsMap, #{rules := Rules}) ->
     OptionsMap#{Option => Value};
 handle_option(key_update_at = Option, Value0, #{versions := Versions} = OptionsMap, _Env) ->
     assert_option_dependency(Option, versions, Versions, ['tlsv1.3']),
+    Value = validate_option(Option, Value0),
+    OptionsMap#{Option => Value};
+handle_option(max_early_data = Option, unbound, OptionsMap, #{rules := Rules}) ->
+    Value = validate_option(Option, default_value(Option, Rules)),
+    OptionsMap#{Option => Value};
+handle_option(max_early_data = Option, Value0, #{early_data := EarlyData,
+                                                 session_tickets := SessionTickets,
+                                                 versions := Versions} = OptionsMap,
+              #{role := Role}) ->
+    assert_option_dependency(Option, versions, Versions, ['tlsv1.3']),
+    assert_role(server_only, Role, Option, Value0),
+    assert_option_dependency(Option, session_tickets, [SessionTickets],
+                             [stateful, stateless]),
+    assert_option_dependency(Option, early_data, [EarlyData],
+                             [enabled]),
     Value = validate_option(Option, Value0),
     OptionsMap#{Option => Value};
 handle_option(next_protocols_advertised = Option, unbound, OptionsMap,
@@ -1829,13 +1876,13 @@ handle_option(server_name_indication = Option, unbound, OptionsMap, #{host := Ho
 handle_option(server_name_indication = Option, Value0, OptionsMap, _Env) ->
     Value = validate_option(Option, Value0),
     OptionsMap#{Option => Value};
-handle_option(session_tickets = Option, unbound, OptionsMap, #{rules := Rules}) ->
-    Value = validate_option(Option, default_value(Option, Rules)),
+handle_option(session_tickets = Option, unbound, OptionsMap, #{role := Role,
+                                                               rules := Rules}) ->
+    Value = validate_option(Option, default_value(Option, Rules), Role),
     OptionsMap#{Option => Value};
 handle_option(session_tickets = Option, Value0, #{versions := Versions} = OptionsMap, #{role := Role}) ->
     assert_option_dependency(Option, versions, Versions, ['tlsv1.3']),
-    assert_role_value(Role, Option, Value0, [disabled, stateful, stateless], [disabled, manual, auto]),
-    Value = validate_option(Option, Value0),
+    Value = validate_option(Option, Value0, Role),
     OptionsMap#{Option => Value};
 handle_option(signature_algs = Option, unbound, #{versions := [HighestVersion|_]} = OptionsMap, #{role := Role}) ->
     Value =
@@ -2047,24 +2094,6 @@ assert_role(server_only, _, _, undefined) ->
 assert_role(Type, _, Key, _) ->
     throw({error, {option, Type, Key}}).
 
-
-assert_role_value(client, Option, Value, _, ClientValues) ->
-        case lists:member(Value, ClientValues) of
-            true ->
-                ok;
-            false ->
-                %% throw({error, {option, client, Option, Value, ClientValues}})
-                throw({error, {options, role, {Option, {Value, {client, ClientValues}}}}})
-        end;
-assert_role_value(server, Option, Value, ServerValues, _) ->
-        case lists:member(Value, ServerValues) of
-            true ->
-                ok;
-            false ->
-                %% throw({error, {option, server, Option, Value, ServerValues}})
-                throw({error, {options, role, {Option, {Value, {server, ServerValues}}}}})
-        end.
-
 assert_option_dependency(Option, OptionDep, Values0, AllowedValues) ->
     case is_dtls_configured(Values0) of
         true ->
@@ -2099,15 +2128,372 @@ is_dtls_configured(Versions) ->
           end,
     lists:any(Fun, Versions).
 
-validate_option(versions, Versions)  ->
-    validate_versions(Versions, Versions);
-validate_option(verify, Value)
+validate_option(Option, Value) ->
+    validate_option(Option, Value, undefined).
+%%
+validate_option(Opt, Value, _)
+  when Opt =:= alpn_advertised_protocols orelse
+       Opt =:= alpn_preferred_protocols,
+       is_list(Value) ->
+    validate_binary_list(Opt, Value),
+    Value;
+validate_option(Opt, Value, _)
+  when Opt =:= alpn_advertised_protocols orelse
+       Opt =:= alpn_preferred_protocols,
+       Value =:= undefined ->
+    undefined;
+validate_option(anti_replay, '10k', _) ->
+    %% n = 10000
+    %% p = 0.030003564 (1 in 33)
+    %% m = 72985 (8.91KiB)
+    %% k = 5
+    {10, 5, 72985};
+validate_option(anti_replay, '100k', _) ->
+    %% n = 100000
+    %% p = 0.03000428 (1 in 33)
+    %% m = 729845 (89.09KiB)
+    %% k = 5
+    {10, 5, 729845};
+validate_option(anti_replay, Value, _)
+  when (is_tuple(Value) andalso
+        tuple_size(Value) =:= 3) ->
+    Value;
+validate_option(beast_mitigation, Value, _)
+  when Value == one_n_minus_one orelse
+       Value == zero_n orelse
+       Value == disabled ->
+  Value;
+%% certfile must be present in some cases otherwhise it can be set
+%% to the empty string.
+validate_option(cacertfile, undefined, _) ->
+   <<>>;
+validate_option(cacertfile, Value, _)
+  when is_binary(Value) ->
+    Value;
+validate_option(cacertfile, Value, _)
+  when is_list(Value), Value =/= ""->
+    binary_filename(Value);
+validate_option(cacerts, Value, _)
+  when Value == undefined;
+       is_list(Value) ->
+    Value;
+validate_option(cb_info, {V1, V2, V3, V4} = Value, _)
+  when is_atom(V1),
+       is_atom(V2),
+       is_atom(V3),
+       is_atom(V4) ->
+    Value;
+validate_option(cb_info, {V1, V2, V3, V4, V5} = Value, _)
+  when is_atom(V1),
+       is_atom(V2),
+       is_atom(V3),
+       is_atom(V4),
+       is_atom(V5) ->
+    Value;
+validate_option(cert, Value, _) when Value == undefined;
+                                     is_list(Value)->
+    Value;
+validate_option(cert, Value, _) when Value == undefined;
+                                     is_binary(Value)->
+    [Value];
+validate_option(certfile, undefined = Value, _) ->
+    Value;
+validate_option(certfile, Value, _)
+  when is_binary(Value) ->
+    Value;
+validate_option(certfile, Value, _)
+  when is_list(Value) ->
+    binary_filename(Value);
+validate_option(client_preferred_next_protocols, {Precedence, PreferredProtocols}, _)
+  when is_list(PreferredProtocols) ->
+    validate_binary_list(client_preferred_next_protocols, PreferredProtocols),
+    validate_npn_ordering(Precedence),
+    {Precedence, PreferredProtocols, ?NO_PROTOCOL};
+validate_option(client_preferred_next_protocols,
+                {Precedence, PreferredProtocols, Default} = Value, _)
+  when is_list(PreferredProtocols), is_binary(Default),
+       byte_size(Default) > 0, byte_size(Default) < 256 ->
+    validate_binary_list(client_preferred_next_protocols, PreferredProtocols),
+    validate_npn_ordering(Precedence),
+    Value;
+validate_option(client_preferred_next_protocols, undefined, _) ->
+    undefined;
+validate_option(client_renegotiation, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(cookie, Value, _)
+  when is_boolean(Value)  ->
+    Value;
+validate_option(crl_cache, {Cb, {_Handle, Options}} = Value, _)
+  when is_atom(Cb) and is_list(Options) ->
+    Value;
+validate_option(crl_check, Value, _)
+  when is_boolean(Value)  ->
+    Value;
+validate_option(crl_check, Value, _)
+  when (Value == best_effort) or
+       (Value == peer) ->
+    Value;
+validate_option(customize_hostname_check, Value, _)
+  when is_list(Value) ->
+    Value;
+validate_option(depth, Value, _)
+  when is_integer(Value),
+       Value >= 0, Value =< 255->
+    Value;
+validate_option(dh, Value, _)
+  when Value == undefined;
+       is_binary(Value) ->
+    Value;
+validate_option(dhfile, undefined = Value, _)  ->
+    Value;
+validate_option(dhfile, Value, _)
+  when is_binary(Value) ->
+    Value;
+validate_option(dhfile, Value, _)
+  when is_list(Value), Value =/= "" ->
+    binary_filename(Value);
+validate_option(early_data, Value, server)
+  when Value =:= disabled orelse
+       Value =:= enabled ->
+    Value;
+validate_option(early_data = Option, Value, server) ->
+    throw({error,
+           {options, role, {Option, {Value, {server, [disabled, enabled]}}}}});
+validate_option(early_data, Value, client)
+  when is_binary(Value) ->
+    Value;
+validate_option(early_data = Option, Value, client) ->
+    throw({error,
+           {options, type, {Option, {Value, not_binary}}}});
+validate_option(erl_dist, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(fail_if_no_peer_cert, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(fallback, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(handshake, hello = Value, _) ->
+    Value;
+validate_option(handshake, full = Value, _) ->
+    Value;
+validate_option(hibernate_after, undefined, _) -> %% Backwards compatibility
+    infinity;
+validate_option(hibernate_after, infinity, _) ->
+    infinity;
+validate_option(hibernate_after, Value, _)
+  when is_integer(Value), Value >= 0 ->
+    Value;
+validate_option(honor_cipher_order, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(honor_ecc_order, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(keep_secrets, Value, _) when is_boolean(Value) ->
+    Value;
+validate_option(key, undefined, _) ->
+    undefined;
+validate_option(key, {KeyType, Value}, _)
+  when is_binary(Value),
+       KeyType == rsa; %% Backwards compatibility
+       KeyType == dsa; %% Backwards compatibility
+       KeyType == 'RSAPrivateKey';
+       KeyType == 'DSAPrivateKey';
+       KeyType == 'ECPrivateKey';
+       KeyType == 'PrivateKeyInfo' ->
+    {KeyType, Value};
+validate_option(key, #{algorithm := _} = Value, _) ->
+    Value;
+validate_option(keyfile, undefined, _) ->
+   <<>>;
+validate_option(keyfile, Value, _)
+  when is_binary(Value) ->
+    Value;
+validate_option(keyfile, Value, _)
+  when is_list(Value), Value =/= "" ->
+    binary_filename(Value);
+validate_option(key_update_at, Value, _)
+  when is_integer(Value) andalso
+       Value > 0 ->
+    Value;
+validate_option(log_alert, true, _) ->
+    notice;
+validate_option(log_alert, false, _) ->
+    warning;
+validate_option(log_level, Value, _)
+  when is_atom(Value) andalso
+       (Value =:= emergency orelse
+        Value =:= alert orelse
+        Value =:= critical orelse
+        Value =:= error orelse
+        Value =:= warning orelse
+        Value =:= notice orelse
+        Value =:= info orelse
+        Value =:= debug) ->
+    Value;
+validate_option(max_early_data, Value, _)
+  when is_integer(Value),
+       Value >= 0 ->
+    Value;
+validate_option(max_early_data = Option, Value, _) when Value =/= undefined ->
+    throw({error,
+           {options, type, {Option, {Value, not_integer}}}});
+%% RFC 6066, Section 4
+validate_option(max_fragment_length, I, _)
+  when I == ?MAX_FRAGMENT_LENGTH_BYTES_1;
+       I == ?MAX_FRAGMENT_LENGTH_BYTES_2;
+       I == ?MAX_FRAGMENT_LENGTH_BYTES_3;
+       I == ?MAX_FRAGMENT_LENGTH_BYTES_4 ->
+    I;
+validate_option(max_fragment_length, undefined, _) ->
+    undefined;
+validate_option(max_handshake_size, Value, _)
+  when is_integer(Value) andalso
+       Value =< ?MAX_UNIT24 ->
+    Value;
+validate_option(middlebox_comp_mode, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(next_protocols_advertised, Value, _) when is_list(Value) ->
+    validate_binary_list(next_protocols_advertised, Value),
+    Value;
+validate_option(next_protocols_advertised, undefined, _) ->
+    undefined;
+validate_option(ocsp_nonce, Value, _)
+  when Value =:= true orelse
+       Value =:= false ->
+    Value;
+%% The OCSP responders' certificates can be given as a suggestion and
+%% will be used to verify the OCSP response.
+validate_option(ocsp_responder_certs, Value, _)
+  when is_list(Value) ->
+    [public_key:pkix_decode_cert(CertDer, plain) || CertDer <- Value,
+                                                    is_binary(CertDer)];
+validate_option(ocsp_stapling, Value, _)
+  when Value =:= true orelse
+       Value =:= false ->
+    Value;
+validate_option(padding_check, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(partial_chain, Value, _)
+  when is_function(Value) ->
+    Value;
+validate_option(password, Value, _)
+  when is_list(Value) ->
+    Value;
+validate_option(protocol, Value = tls, _) ->
+    Value;
+validate_option(protocol, Value = dtls, _) ->
+    Value;
+validate_option(psk_identity, undefined, _) ->
+    undefined;
+validate_option(psk_identity, Identity, _)
+  when is_list(Identity), Identity =/= "", length(Identity) =< 65535 ->
+    binary_filename(Identity);
+validate_option(renegotiate_at, Value, _) when is_integer(Value) ->
+    erlang:min(Value, ?DEFAULT_RENEGOTIATE_AT);
+validate_option(reuse_session, undefined, _) ->
+    undefined;
+validate_option(reuse_session, Value, _)
+  when is_function(Value) ->
+    Value;
+validate_option(reuse_session, Value, _)
+  when is_binary(Value) ->
+    Value;
+validate_option(reuse_session, {Id, Data} = Value, _)
+  when is_binary(Id) andalso
+       is_binary(Data) ->
+    Value;
+validate_option(reuse_sessions, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(reuse_sessions, save = Value, _) ->
+    Value;
+validate_option(secure_renegotiate, Value, _)
+  when is_boolean(Value) ->
+    Value;
+validate_option(server_name_indication, Value, _)
+  when is_list(Value) ->
+    %% RFC 6066, Section 3: Currently, the only server names supported are
+    %% DNS hostnames
+    %% case inet_parse:domain(Value) of
+    %%     false ->
+    %%         throw({error, {options, {{Opt, Value}}}});
+    %%     true ->
+    %%         Value
+    %% end;
+    %%
+    %% But the definition seems very diffuse, so let all strings through
+    %% and leave it up to public_key to decide...
+    Value;
+validate_option(server_name_indication, undefined, _) ->
+    undefined;
+validate_option(server_name_indication, disable, _) ->
+    disable;
+validate_option(session_tickets, Value, server)
+  when Value =:= disabled orelse
+       Value =:= stateful orelse
+       Value =:= stateless ->
+    Value;
+validate_option(session_tickets, Value, server) ->
+    throw({error,
+           {options, role,
+            {session_tickets,
+             {Value, {server, [disabled, stateful, stateless]}}}}});
+validate_option(session_tickets, Value, client)
+  when Value =:= disabled orelse
+       Value =:= manual orelse
+       Value =:= auto ->
+    Value;
+validate_option(session_tickets, Value, client) ->
+    throw({error,
+           {options, role,
+            {session_tickets,
+             {Value, {client, [disabled, manual, auto]}}}}});
+validate_option(sni_fun, undefined, _) ->
+    undefined;
+validate_option(sni_fun, Fun, _)
+  when is_function(Fun) ->
+    Fun;
+validate_option(sni_hosts, [], _) ->
+    [];
+validate_option(sni_hosts, [{Hostname, SSLOptions} | Tail], _)
+  when is_list(Hostname) ->
+    RecursiveSNIOptions = proplists:get_value(sni_hosts, SSLOptions, undefined),
+    case RecursiveSNIOptions of
+        undefined ->
+            [{Hostname, validate_options(SSLOptions)} |
+             validate_option(sni_hosts, Tail)];
+        _ ->
+            throw({error, {options, {sni_hosts, RecursiveSNIOptions}}})
+    end;
+validate_option(srp_identity, undefined, _) ->
+    undefined;
+validate_option(srp_identity, {Username, Password}, _)
+  when is_list(Username),
+       is_list(Password), Username =/= "",
+       length(Username) =< 255 ->
+    {unicode:characters_to_binary(Username),
+     unicode:characters_to_binary(Password)};
+validate_option(user_lookup_fun, undefined, _) ->
+    undefined;
+validate_option(user_lookup_fun, {Fun, _} = Value, _)
+  when is_function(Fun, 3) ->
+   Value;
+validate_option(use_ticket, Value, _)
+  when is_list(Value) ->
+    Value;
+validate_option(verify, Value, _)
   when Value == verify_none; Value == verify_peer ->
     Value;
-validate_option(verify_fun, undefined)  ->
+validate_option(verify_fun, undefined, _)  ->
     undefined;
 %% Backwards compatibility
-validate_option(verify_fun, Fun) when is_function(Fun) ->
+validate_option(verify_fun, Fun, _) when is_function(Fun) ->
     {fun(_,{bad_cert, _} = Reason, OldFun) ->
 	     case OldFun([Reason]) of
 		 true ->
@@ -2122,281 +2508,11 @@ validate_option(verify_fun, Fun) when is_function(Fun) ->
 	(_, valid_peer, UserState) ->
 	     {valid, UserState}
      end, Fun};
-validate_option(verify_fun, {Fun, _} = Value) when is_function(Fun) ->
+validate_option(verify_fun, {Fun, _} = Value, _) when is_function(Fun) ->
    Value;
-validate_option(partial_chain, Value) when is_function(Value) ->
-    Value;
-validate_option(fail_if_no_peer_cert, Value) when is_boolean(Value) ->
-    Value;
-validate_option(depth, Value) when is_integer(Value),
-                                   Value >= 0, Value =< 255->
-    Value;
-validate_option(cert, Value) when Value == undefined;
-                                  is_list(Value)->
-    Value;
-validate_option(cert, Value) when Value == undefined;
-                                  is_binary(Value)->
-    [Value];
-validate_option(certfile, undefined = Value) ->
-    Value;
-validate_option(certfile, Value) when is_binary(Value) ->
-    Value;
-validate_option(certfile, Value) when is_list(Value) ->
-    binary_filename(Value);
-
-validate_option(key, undefined) ->
-    undefined;
-validate_option(key, {KeyType, Value}) when is_binary(Value),
-					    KeyType == rsa; %% Backwards compatibility
-					    KeyType == dsa; %% Backwards compatibility
-					    KeyType == 'RSAPrivateKey';
-					    KeyType == 'DSAPrivateKey';
-					    KeyType == 'ECPrivateKey';
-					    KeyType == 'PrivateKeyInfo' ->
-    {KeyType, Value};
-validate_option(key, #{algorithm := _} = Value) ->
-    Value;
-validate_option(keyfile, undefined) ->
-   <<>>;
-validate_option(keyfile, Value) when is_binary(Value) ->
-    Value;
-validate_option(keyfile, Value) when is_list(Value), Value =/= "" ->
-    binary_filename(Value);
-validate_option(key_update_at, Value) when is_integer(Value) andalso
-                                           Value > 0 ->
-    Value;
-validate_option(password, Value) when is_list(Value) ->
-    Value;
-
-validate_option(cacerts, Value) when Value == undefined;
-				     is_list(Value) ->
-    Value;
-%% certfile must be present in some cases otherwhise it can be set
-%% to the empty string.
-validate_option(cacertfile, undefined) ->
-   <<>>;
-validate_option(cacertfile, Value) when is_binary(Value) ->
-    Value;
-validate_option(cacertfile, Value) when is_list(Value), Value =/= ""->
-    binary_filename(Value);
-validate_option(dh, Value) when Value == undefined;
-				is_binary(Value) ->
-    Value;
-validate_option(dhfile, undefined = Value)  ->
-    Value;
-validate_option(dhfile, Value) when is_binary(Value) ->
-    Value;
-validate_option(dhfile, Value) when is_list(Value), Value =/= "" ->
-    binary_filename(Value);
-validate_option(psk_identity, undefined) ->
-    undefined;
-validate_option(psk_identity, Identity)
-  when is_list(Identity), Identity =/= "", length(Identity) =< 65535 ->
-    binary_filename(Identity);
-validate_option(user_lookup_fun, undefined) ->
-    undefined;
-validate_option(user_lookup_fun, {Fun, _} = Value) when is_function(Fun, 3) ->
-   Value;
-validate_option(srp_identity, undefined) ->
-    undefined;
-validate_option(srp_identity, {Username, Password})
-  when is_list(Username), is_list(Password), Username =/= "", length(Username) =< 255 ->
-    {unicode:characters_to_binary(Username),
-     unicode:characters_to_binary(Password)};
-
-validate_option(reuse_session, undefined) ->
-    undefined;
-validate_option(reuse_session, Value) when is_function(Value) ->
-    Value;
-validate_option(reuse_session, Value) when is_binary(Value) ->
-    Value;
-validate_option(reuse_session, {Id, Data} = Value) when is_binary(Id) andalso
-                                                        is_binary(Data) ->
-    Value;
-validate_option(reuse_sessions, Value) when is_boolean(Value) ->
-    Value;
-validate_option(reuse_sessions, save = Value) ->
-    Value;
-validate_option(secure_renegotiate, Value) when is_boolean(Value) ->
-    Value;
-validate_option(keep_secrets, Value) when is_boolean(Value) ->
-    Value;
-validate_option(client_renegotiation, Value) when is_boolean(Value) ->
-    Value;
-validate_option(renegotiate_at, Value) when is_integer(Value) ->
-    erlang:min(Value, ?DEFAULT_RENEGOTIATE_AT);
-
-validate_option(hibernate_after, undefined) -> %% Backwards compatibility
-    infinity;
-validate_option(hibernate_after, infinity) ->
-    infinity;
-validate_option(hibernate_after, Value) when is_integer(Value), Value >= 0 ->
-    Value;
-
-validate_option(erl_dist,Value) when is_boolean(Value) ->
-    Value;
-validate_option(Opt, Value) when Opt =:= alpn_advertised_protocols orelse Opt =:= alpn_preferred_protocols,
-                                 is_list(Value) ->
-    validate_binary_list(Opt, Value),
-    Value;
-validate_option(Opt, Value)
-  when Opt =:= alpn_advertised_protocols orelse Opt =:= alpn_preferred_protocols,
-       Value =:= undefined ->
-    undefined;
-validate_option(client_preferred_next_protocols, {Precedence, PreferredProtocols})
-  when is_list(PreferredProtocols) ->
-    validate_binary_list(client_preferred_next_protocols, PreferredProtocols),
-    validate_npn_ordering(Precedence),
-    {Precedence, PreferredProtocols, ?NO_PROTOCOL};
-validate_option(client_preferred_next_protocols, {Precedence, PreferredProtocols, Default} = Value)
-  when is_list(PreferredProtocols), is_binary(Default),
-       byte_size(Default) > 0, byte_size(Default) < 256 ->
-    validate_binary_list(client_preferred_next_protocols, PreferredProtocols),
-    validate_npn_ordering(Precedence),
-    Value;
-validate_option(client_preferred_next_protocols, undefined) ->
-    undefined;
-validate_option(log_alert, true) ->
-    notice;
-validate_option(log_alert, false) ->
-    warning;
-validate_option(log_level, Value) when
-      is_atom(Value) andalso
-      (Value =:= emergency orelse
-       Value =:= alert orelse
-       Value =:= critical orelse
-       Value =:= error orelse
-       Value =:= warning orelse
-       Value =:= notice orelse
-       Value =:= info orelse
-       Value =:= debug) ->
-    Value;
-validate_option(middlebox_comp_mode, Value) when is_boolean(Value) ->
-    Value;
-validate_option(next_protocols_advertised, Value) when is_list(Value) ->
-    validate_binary_list(next_protocols_advertised, Value),
-    Value;
-validate_option(next_protocols_advertised, undefined) ->
-    undefined;
-validate_option(server_name_indication, Value) when is_list(Value) ->
-    %% RFC 6066, Section 3: Currently, the only server names supported are
-    %% DNS hostnames
-    %% case inet_parse:domain(Value) of
-    %%     false ->
-    %%         throw({error, {options, {{Opt, Value}}}});
-    %%     true ->
-    %%         Value
-    %% end;
-    %%
-    %% But the definition seems very diffuse, so let all strings through
-    %% and leave it up to public_key to decide...
-    Value;
-validate_option(server_name_indication, undefined) ->
-    undefined;
-validate_option(server_name_indication, disable) ->
-    disable;
-
-%% RFC 6066, Section 4
-validate_option(max_fragment_length, I) when I == ?MAX_FRAGMENT_LENGTH_BYTES_1; I == ?MAX_FRAGMENT_LENGTH_BYTES_2;
-                                             I == ?MAX_FRAGMENT_LENGTH_BYTES_3; I == ?MAX_FRAGMENT_LENGTH_BYTES_4 ->
-    I;
-validate_option(max_fragment_length, undefined) ->
-    undefined;
-
-validate_option(sni_hosts, []) ->
-    [];
-validate_option(sni_hosts, [{Hostname, SSLOptions} | Tail]) when is_list(Hostname) ->
-	RecursiveSNIOptions = proplists:get_value(sni_hosts, SSLOptions, undefined),
-	case RecursiveSNIOptions of
-		undefined ->
-			[{Hostname, validate_options(SSLOptions)} | validate_option(sni_hosts, Tail)];
-		_ ->
-			throw({error, {options, {sni_hosts, RecursiveSNIOptions}}})
-	end;
-validate_option(sni_fun, undefined) ->
-    undefined;
-validate_option(sni_fun, Fun) when is_function(Fun) ->
-    Fun;
-validate_option(honor_cipher_order, Value) when is_boolean(Value) ->
-    Value;
-validate_option(honor_ecc_order, Value) when is_boolean(Value) ->
-    Value;
-validate_option(padding_check, Value) when is_boolean(Value) ->
-    Value;
-validate_option(fallback, Value) when is_boolean(Value) ->
-    Value;
-validate_option(cookie, Value) when is_boolean(Value)  ->
-    Value;
-validate_option(crl_check, Value) when is_boolean(Value)  ->
-    Value;
-validate_option(crl_check, Value) when (Value == best_effort) or (Value == peer) -> 
-    Value;
-validate_option(crl_cache, {Cb, {_Handle, Options}} = Value) when is_atom(Cb) and is_list(Options) ->
-    Value;
-validate_option(beast_mitigation, Value) when Value == one_n_minus_one orelse
-                                              Value == zero_n orelse
-                                              Value == disabled ->
-  Value;
-validate_option(max_handshake_size, Value) when is_integer(Value)  andalso Value =< ?MAX_UNIT24 ->
-    Value;
-validate_option(protocol, Value = tls) ->
-    Value;
-validate_option(protocol, Value = dtls) ->
-    Value;
-validate_option(handshake, hello = Value) ->
-    Value;
-validate_option(handshake, full = Value) ->
-    Value;
-validate_option(customize_hostname_check, Value) when is_list(Value) ->
-    Value;
-validate_option(cb_info, {V1, V2, V3, V4} = Value) when is_atom(V1),
-                                                        is_atom(V2),
-                                                        is_atom(V3),
-                                                        is_atom(V4)
-                                                ->
-    Value;
-validate_option(cb_info, {V1, V2, V3, V4, V5} = Value) when is_atom(V1),
-                                                            is_atom(V2),
-                                                            is_atom(V3),
-                                                            is_atom(V4),
-                                                            is_atom(V5)
-                                                ->
-    Value;
-validate_option(use_ticket, Value) when is_list(Value) ->
-    Value;
-validate_option(session_tickets, Value) when Value =:= disabled orelse
-                                             Value =:= manual orelse
-                                             Value =:= auto orelse
-                                             Value =:= stateless orelse
-                                             Value =:= stateful ->
-    Value;
-validate_option(anti_replay, '10k') ->
-    %% n = 10000
-    %% p = 0.030003564 (1 in 33)
-    %% m = 72985 (8.91KiB)
-    %% k = 5
-    {10, 5, 72985};
-validate_option(anti_replay, '100k') ->
-    %% n = 100000
-    %% p = 0.03000428 (1 in 33)
-    %% m = 729845 (89.09KiB)
-    %% k = 5
-    {10, 5, 729845};
-validate_option(anti_replay, Value) when (is_tuple(Value) andalso
-                                          tuple_size(Value) =:= 3) ->
-    Value;
-validate_option(ocsp_stapling, Value) when Value =:= true orelse
-                                           Value =:= false ->
-    Value;
-%% The OCSP responders' certificates can be given as a suggestion and
-%% will be used to verify the OCSP response.
-validate_option(ocsp_responder_certs, Value) when is_list(Value) ->
-    [public_key:pkix_decode_cert(CertDer, plain) || CertDer <- Value,
-                                                    is_binary(CertDer)];
-validate_option(ocsp_nonce, Value) when Value =:= true orelse
-                                        Value =:= false ->
-    Value;
-validate_option(Opt, undefined = Value) ->
+validate_option(versions, Versions, _)  ->
+    validate_versions(Versions, Versions);
+validate_option(Opt, undefined = Value, _) ->
     AllOpts = maps:keys(?RULES),
     case lists:member(Opt, AllOpts) of
         true ->
@@ -2404,7 +2520,7 @@ validate_option(Opt, undefined = Value) ->
         false ->
             throw({error, {options, {Opt, Value}}})
     end;
-validate_option(Opt, Value) ->
+validate_option(Opt, Value, _) ->
     throw({error, {options, {Opt, Value}}}).
 
 handle_cb_info({V1, V2, V3, V4}) ->

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -70,7 +70,8 @@
          hash_size/1, 
          effective_key_bits/1,
          key_material/1, 
-         signature_algorithm_to_scheme/1]).
+         signature_algorithm_to_scheme/1,
+         bulk_cipher_algorithm/1]).
 
 %% RFC 8446 TLS 1.3
 -export([generate_client_shares/1,

--- a/lib/ssl/src/ssl_connection.hrl
+++ b/lib/ssl/src/ssl_connection.hrl
@@ -64,6 +64,7 @@
                         resumption = false   :: boolean(),  %% TLS 1.3
                         change_cipher_spec_sent = false :: boolean(),  %% TLS 1.3
                         sni_guided_cert_selection = false :: boolean(), %% TLS 1.3
+                        early_data_accepted = false :: boolean(), %% TLS 1.3
                         allow_renegotiate = true                    ::boolean(),
                         %% Ext handling
                         hello,                %%:: #client_hello{} | #server_hello{}            

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -140,6 +140,9 @@
           depth                      => {10,         [versions]},
           dh                         => {undefined, [versions]},
           dhfile                     => {undefined, [versions]},
+          early_data                 => {undefined, [versions,
+                                                     session_tickets,
+                                                     use_ticket]},
           eccs                       => {undefined, [versions]},
           erl_dist                   => {false,     [versions]},
           fail_if_no_peer_cert       => {false,     [versions]},
@@ -155,6 +158,9 @@
           log_level                  => {notice,    [versions]},
           max_handshake_size         => {?DEFAULT_MAX_HANDSHAKE_SIZE, [versions]},
           middlebox_comp_mode        => {true, [versions]},
+          max_early_data             => {undefined, [versions,
+                                                     early_data,
+                                                     session_tickets]},
           max_fragment_length        => {undefined, [versions]},
           next_protocol_selector     => {undefined, [versions]},
           next_protocols_advertised  => {undefined, [versions]},
@@ -235,6 +241,17 @@
 				{next_state, state_name(), any(), timeout()} |
 				{stop, any(), any()}.
 -type ssl_options()          :: map().
+
+%% Internal ticket data record holding pre-processed ticket data.
+-record(ticket_data,
+        {key,                  %% key in client ticket store
+         pos,                  %% ticket position in binders list
+         identity,             %% opaque ticket binary
+         psk,                  %% pre-shared key
+         nonce,                %% ticket nonce
+         cipher_suite,         %% cipher suite - hash, bulk cipher algorithm
+         max_size              %% max early data size allowed by this ticket
+        }).
 
 -endif. % -ifdef(ssl_internal).
 

--- a/lib/ssl/src/ssl_logger.erl
+++ b/lib/ssl/src/ssl_logger.erl
@@ -254,8 +254,12 @@ parse_handshake(Direction, #key_update{} = KeyUpdate) ->
     Header = io_lib:format("~s Post-Handshake, KeyUpdate",
                            [header_prefix(Direction)]),
     Message = io_lib:format("~p", [?rec_info(key_update, KeyUpdate)]),
+    {Header, Message};
+parse_handshake(Direction, #end_of_early_data{} = EndOfEarlyData) ->
+    Header = io_lib:format("~s Handshake, EndOfEarlyData",
+                           [header_prefix(Direction)]),
+    Message = io_lib:format("~p", [?rec_info(end_of_early_data, EndOfEarlyData)]),
     {Header, Message}.
-
 
 parse_cipher_suites([_|_] = Ciphers) ->
     [format_cipher(C) || C <- Ciphers].

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -42,7 +42,9 @@
 	 set_server_verify_data/3,
          set_max_fragment_length/2,
 	 empty_connection_state/2, initial_connection_state/2, record_protocol_role/1,
-         step_encryption_state/1]).
+         step_encryption_state/1,
+         step_encryption_state_read/1,
+         step_encryption_state_write/1]).
 
 %% Compression
 -export([compress/3, uncompress/3, compressions/0]).
@@ -138,6 +140,17 @@ step_encryption_state(#state{connection_states =
                     ConnStates#{current_read => NewRead,
                                 current_write => NewWrite}}.
 
+step_encryption_state_read(#state{connection_states =
+                                 #{pending_read := PendingRead} = ConnStates} = State) ->
+    NewRead = PendingRead#{sequence_number => 0},
+    State#state{connection_states =
+                    ConnStates#{current_read => NewRead}}.
+
+step_encryption_state_write(#state{connection_states =
+                                 #{pending_write := PendingWrite} = ConnStates} = State) ->
+    NewWrite = PendingWrite#{sequence_number => 0},
+    State#state{connection_states =
+                    ConnStates#{current_write => NewWrite}}.
 
 %%--------------------------------------------------------------------
 -spec set_security_params(#security_parameters{}, #security_parameters{},

--- a/lib/ssl/src/tls_handshake_1_3.hrl
+++ b/lib/ssl/src/tls_handshake_1_3.hrl
@@ -87,9 +87,11 @@
 %% RFC 8446 4.2.10.  Early Data Indication
 -record(empty, {
          }).
--record(early_data_indication, {
-          indication % uint32 max_early_data_size (new_session_ticket) | 
-          %% #empty{} (client_hello, encrypted_extensions)
+
+%% #empty{} (client_hello, encrypted_extensions)
+-record(early_data_indication, {}).
+-record(early_data_indication_nst, {
+          indication % uint32 max_early_data_size (new_session_ticket)
          }).
 
 %% RFC 8446 4.2.11. Pre-Shared Key Extension

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -56,6 +56,7 @@
          hkdf_expand_label/5, 
          hkdf_extract/3, 
          hkdf_expand/4,
+         key_length/1,
          key_schedule/3, 
          key_schedule/4, 
          create_info/3,
@@ -455,12 +456,19 @@ update_traffic_secret(Algo, Secret) ->
 %%
 %%    [sender]_write_key = HKDF-Expand-Label(Secret, "key", "", key_length)
 %%    [sender]_write_iv  = HKDF-Expand-Label(Secret, "iv", "", iv_length)
--spec calculate_traffic_keys(atom(), atom(), binary()) -> {binary(), binary()}.
-calculate_traffic_keys(HKDFAlgo, Cipher, Secret) ->
-    Key = hkdf_expand_label(Secret, <<"key">>, <<>>, ssl_cipher:key_material(Cipher), HKDFAlgo),
+-spec calculate_traffic_keys(atom(), integer(), binary()) -> {binary(), binary()}.
+calculate_traffic_keys(HKDFAlgo, KeyLength, Secret) ->
+    Key = hkdf_expand_label(Secret, <<"key">>, <<>>, KeyLength, HKDFAlgo),
     %% TODO: remove hard coded IV size
     IV = hkdf_expand_label(Secret, <<"iv">>, <<>>, 12, HKDFAlgo),
     {Key, IV}.
+
+-spec key_length(CipherSuite) -> KeyLength when
+      CipherSuite :: binary(),
+      KeyLength :: 0 | 8 | 16 | 24 | 32.
+key_length(CipherSuite) ->
+    #{cipher := Cipher} = ssl_cipher_format:suite_bin_to_map(CipherSuite),
+    ssl_cipher:key_material(Cipher).
 
 %% TLS v1.3  ---------------------------------------------------
 

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -160,6 +160,14 @@
          client_options_negative_dependency_stateless/1,
          client_options_negative_dependency_role/0,
          client_options_negative_dependency_role/1,
+         client_options_negative_early_data/0,
+         client_options_negative_early_data/1,
+         client_options_negative_max_early_data/0,
+         client_options_negative_max_early_data/1,
+         server_options_negative_early_data/0,
+         server_options_negative_early_data/1,
+         server_options_negative_max_early_data/0,
+         server_options_negative_max_early_data/1,
          server_options_negative_version_gap/0,
          server_options_negative_version_gap/1,
          server_options_negative_dependency_role/0,
@@ -319,6 +327,10 @@ tls13_group() ->
      client_options_negative_dependency_version,
      client_options_negative_dependency_stateless,
      client_options_negative_dependency_role,
+     client_options_negative_early_data,
+     client_options_negative_max_early_data,
+     server_options_negative_early_data,
+     server_options_negative_max_early_data,
      server_options_negative_version_gap,
      server_options_negative_dependency_role,
      invalid_options_tls13,
@@ -2212,6 +2224,145 @@ client_options_negative_dependency_role(Config) when is_list(Config) ->
                            {session_tickets,{stateless,{client,[disabled,manual,auto]}}}}).
 
 %%--------------------------------------------------------------------
+client_options_negative_early_data() ->
+    [{doc,"Test client option early_data."}].
+client_options_negative_early_data(Config) when is_list(Config) ->
+    start_client_negative(Config, [{versions, ['tlsv1.2']},
+                                   {early_data, "test"}],
+                          {options,dependency,
+                           {early_data,{versions,['tlsv1.3']}}}),
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {early_data, "test"}],
+                          {options,dependency,
+                           {early_data,{session_tickets,[manual,auto]}}}),
+
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, stateful},
+                                   {early_data, "test"}],
+                          {options,role,
+                           {session_tickets,
+                            {stateful,{client,[disabled,manual,auto]}}}}),
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, disabled},
+                                   {early_data, "test"}],
+                          {options,dependency,
+                           {early_data,{session_tickets,[manual,auto]}}}),
+
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, manual},
+                                   {early_data, "test"}],
+                          {options,dependency,
+                           {early_data, use_ticket}}),
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, manual},
+                                   {use_ticket, [<<"ticket">>]},
+                                   {early_data, "test"}],
+                          {options, type,
+                           {early_data, {"test", not_binary}}}),
+    %% All options are ok but there is no server
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, manual},
+                                   {use_ticket, [<<"ticket">>]},
+                                   {early_data, <<"test">>}],
+                          econnrefused),
+
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, auto},
+                                   {early_data, "test"}],
+                          {options, type,
+                           {early_data, {"test", not_binary}}}),
+    %% All options are ok but there is no server
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, auto},
+                                   {early_data, <<"test">>}],
+                          econnrefused).
+
+client_options_negative_max_early_data() ->
+    [{doc,"Test server only option max_early_data."}].
+client_options_negative_max_early_data(Config) when is_list(Config) ->
+    start_client_negative(Config, [{versions, ['tlsv1.2']},
+                                   {max_early_data, "test"}],
+                          {options,dependency,
+                           {max_early_data,{versions,['tlsv1.3']}}}),
+    start_client_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {max_early_data, "test"}],
+                          {option, server_only, max_early_data}).
+
+%%--------------------------------------------------------------------
+server_options_negative_early_data() ->
+    [{doc,"Test server option early_data."}].
+server_options_negative_early_data(Config) when is_list(Config) ->
+    start_server_negative(Config, [{versions, ['tlsv1.2']},
+                                   {early_data, "test"}],
+                          {options,dependency,
+                           {early_data,{versions,['tlsv1.3']}}}),
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {early_data, "test"}],
+                          {options,dependency,
+                           {early_data,{session_tickets,[stateful,stateless]}}}),
+
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, manual},
+                                   {early_data, "test"}],
+                          {options,role,
+                           {session_tickets,
+                            {manual,{server,[disabled,stateful,stateless]}}}}),
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, disabled},
+                                   {early_data, "test"}],
+                          {options,dependency,
+                           {early_data,{session_tickets,[stateful,stateless]}}}),
+
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, stateful},
+                                   {early_data, "test"}],
+                          {options,role,
+                           {early_data,{"test",{server,[disabled,enabled]}}}}).
+
+server_options_negative_max_early_data() ->
+    [{doc,"Test server only option max_early_data."}].
+server_options_negative_max_early_data(Config) when is_list(Config) ->
+    start_server_negative(Config, [{versions, ['tlsv1.2']},
+                                   {max_early_data, "test"}],
+                          {options,dependency,
+                           {max_early_data,{versions,['tlsv1.3']}}}),
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {max_early_data, "test"}],
+                          {options,dependency,
+                           {max_early_data,{session_tickets,[stateful,stateless]}}}),
+
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, manual},
+                                   {max_early_data, "test"}],
+                          {options,role,
+                           {session_tickets,
+                            {manual,{server,[disabled,stateful,stateless]}}}}),
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, disabled},
+                                   {max_early_data, "test"}],
+                          {options,dependency,
+                           {max_early_data,{session_tickets,[stateful,stateless]}}}),
+
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, stateful},
+                                   {max_early_data, "test"}],
+                          {options,dependency,
+                           {max_early_data,{early_data,[enabled]}}}),
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, stateful},
+                                   {early_data, disabled},
+                                   {max_early_data, "test"}],
+                          {options,dependency,
+                           {max_early_data,{early_data,[enabled]}}}),
+
+    start_server_negative(Config, [{versions, ['tlsv1.2', 'tlsv1.3']},
+                                   {session_tickets, stateful},
+                                   {early_data, enabled},
+                                   {max_early_data, "test"}],
+                          {options, type,
+                           {max_early_data, {"test", not_integer}}}).
+
+%%--------------------------------------------------------------------
 server_options_negative_version_gap() ->
     [{doc,"Test server options with faulty version gap."}].
 server_options_negative_version_gap(Config) when is_list(Config) ->
@@ -2767,10 +2918,12 @@ cookie_extension(Config, Cookie) ->
 
 start_client_negative(Config, Options, Error) ->
     ClientOpts = ssl_test_lib:ssl_options(client_rsa_opts, Config),
-    {ClientNode, _, Hostname} = ssl_test_lib:run_where(Config),
-    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, 0},
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Port = ssl_test_lib:inet_port(ServerNode),
+    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
 					{host, Hostname},
 					{from, self()},
+                                        {return_error, econnrefused},
 					{mfa, {?MODULE, connection_info_result, []}},
 					{options, Options ++ ClientOpts}]),
     ct:pal("Actual: ~p~nExpected: ~p", [Client, {connect_failed, Error}]),

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -98,6 +98,7 @@
          verify_active_session_resumption/2,
          verify_active_session_resumption/3,
          verify_active_session_resumption/4,
+         verify_active_session_resumption/5,
          check_sane_openssl_version/1,
          check_ok/1,
          check_result/4,
@@ -192,7 +193,8 @@
          version_flag/1,
          portable_cmd/2,
          portable_open_port/2,
-         close_port/1
+         close_port/1,
+         verify_early_data/1
         ]).
 
 -record(sslsocket, { fd = nil, pid = nil}).
@@ -644,7 +646,8 @@ start_openssl_server(Mode, Args0, Config) ->
     Node = proplists:get_value(node, Args0, ServerNode),
     Port = proplists:get_value(port, Args0, 0),
     ResponderPort = proplists:get_value(responder_port, Config, 0),
-    Args = [{from, self()}, {port, Port}] ++ ServerOpts ++ Args0,
+    PrivDir = proplists:get_value(priv_dir, Config),
+    Args = [{from, self()}, {port, Port}] ++ ServerOpts ++ Args0 ++ [{priv_dir, PrivDir}],
     Result = spawn_link(Node, ?MODULE, init_openssl_server,
                         [Mode, ResponderPort,lists:delete(return_port, Args)]),
     receive
@@ -666,10 +669,12 @@ init_openssl_server(openssl, _, Options) ->
     Exe = "openssl",
     Ciphers = proplists:get_value(ciphers, Options, default_ciphers(Version)),
     Groups0 = proplists:get_value(groups, Options),
+    EarlyData = proplists:get_value(early_data, Options, undefined),
+    PrivDir = proplists:get_value(priv_dir, Options),
     CertArgs = openssl_cert_options(Options, server), 
     AlpnArgs = openssl_alpn_options(proplists:get_value(alpn, Options, undefined)),
     NpnArgs =  openssl_npn_options(proplists:get_value(np, Options, undefined)),                
-    Debug = openssl_debug_options(),
+    Debug = openssl_debug_options(PrivDir),
 
     Args0 =  case Groups0 of
                 undefined ->
@@ -681,7 +686,14 @@ init_openssl_server(openssl, _, Options) ->
                         ciphers(Ciphers, Version), "-groups", Group,
                         version_flag(Version)] ++ AlpnArgs ++ NpnArgs ++ CertArgs ++ Debug
             end,
-    Args = maybe_force_ipv4(Args0),
+    Args1 = case EarlyData of
+               undefined ->
+                   Args0;
+               MaxSize ->
+                   Args0 ++ ["-early_data", "-no_anti_replay", "-max_early_data",
+                             integer_to_list(MaxSize)]
+           end,
+    Args = maybe_force_ipv4(Args1),
     SslPort = portable_open_port(Exe, Args),
     wait_for_openssl_server(Port, proplists:get_value(protocol, Options, tls)),
     Pid ! {started, SslPort},
@@ -909,16 +921,21 @@ client_loop(_Node, Host, Port, Pid, Transport, Options, Opts) ->
 	    end,
             client_loop_core(Socket, Pid, Transport);
 	{error, econnrefused = Reason} ->
-	    case get(retries) of
-		N when N < 5 ->
-		    ct:log("~p:~p~neconnrefused retries=~p sleep ~p",[?MODULE,?LINE, N,?SLEEP]),
-		    put(retries, N+1),
-		    ct:sleep(?SLEEP),
-		    run_client(Opts);
-	       _ ->
-		    ct:log("~p:~p~nClient faild several times: connection failed: ~p ~n", [?MODULE,?LINE, Reason]),
-		    Pid ! {self(), {error, Reason}}
-	    end;
+            case proplists:get_value(return_error, Opts, undefined) of
+                econnrefused ->
+                    Pid ! {connect_failed, Reason};
+                _ ->
+                    case get(retries) of
+                        N when N < 5 ->
+                            ct:log("~p:~p~neconnrefused retries=~p sleep ~p",[?MODULE,?LINE, N,?SLEEP]),
+                            put(retries, N+1),
+                            ct:sleep(?SLEEP),
+                            run_client(Opts);
+                        _ ->
+                            ct:log("~p:~p~nClient faild several times: connection failed: ~p ~n", [?MODULE,?LINE, Reason]),
+                            Pid ! {self(), {error, Reason}}
+                    end
+            end;
 	{error, econnreset = Reason} ->
 	      case get(retries) of
 		N when N < 5 ->
@@ -1119,9 +1136,13 @@ check_client_alert(Pid, Alert) ->
 	{Pid, {error, {tls_alert, {Alert, CTxt}}}} ->
             check_client_txt(CTxt),
             ok;
+        {Pid, {error, {tls_alert, {OtherAlert, CTxt}}}} ->
+            ct:fail("Unexpected alert during negative test: ~p - ~p", [OtherAlert, CTxt]);
         {Pid, {ssl_error, _, {tls_alert, {Alert, CTxt}}}} ->
             check_client_txt(CTxt),
             ok;
+        {Pid, {ssl_error, _, {tls_alert, {OtherAlert, CTxt}}}} ->
+            ct:fail("Unexpected alert during negative test: ~p - ~p", [OtherAlert, CTxt]);
         {Pid, {error, closed}} ->
             ok;
         {Pid, {ok, _}} ->
@@ -2091,6 +2112,23 @@ openssl_maxfag_option(Int) ->
 
 openssl_debug_options() ->
     ["-msg", "-debug"].
+%%
+openssl_debug_options(PrivDir) ->
+    case is_keylogfile_supported() of
+        true ->
+            ["-msg", "-debug","-keylogfile", PrivDir ++ "keylog"];
+        false ->
+            ["-msg", "-debug"]
+    end.
+
+is_keylogfile_supported() ->
+    [{_,_, Bin}]  = crypto:info_lib(),
+    case binary_to_list(Bin) of
+	"OpenSSL 1.1.1" ++ _ ->
+	    true;
+	_ ->
+	    false
+    end.
 
 start_server_with_raw_key(erlang, ServerOpts, Config) ->
     {_, ServerNode, _} = run_where(Config),
@@ -2542,12 +2580,15 @@ send_recv_result_active_once(Socket) ->
     active_once_recv_list(Socket, length(Data)).
 
 verify_active_session_resumption(Socket, SessionResumption) ->
-    verify_active_session_resumption(Socket, SessionResumption, wait_reply, no_tickets).
+    verify_active_session_resumption(Socket, SessionResumption, wait_reply, no_tickets, no_early_data).
 %%
 verify_active_session_resumption(Socket, SessionResumption, WaitReply) ->
-    verify_active_session_resumption(Socket, SessionResumption, WaitReply, no_tickets).
+    verify_active_session_resumption(Socket, SessionResumption, WaitReply, no_tickets, no_early_data).
 %%
-verify_active_session_resumption(Socket, SessionResumption, WaitForReply, TicketOption) ->
+verify_active_session_resumption(Socket, SessionResumption, WaitReply, TicketOption) ->
+    verify_active_session_resumption(Socket, SessionResumption, WaitReply, TicketOption, no_early_data).
+%%
+verify_active_session_resumption(Socket, SessionResumption, WaitForReply, TicketOption, EarlyData) ->
     case ssl:connection_information(Socket, [session_resumption]) of
         {ok, [{session_resumption, SessionResumption}]} ->
             Msg = boolean_to_log_msg(SessionResumption),
@@ -2573,13 +2614,28 @@ verify_active_session_resumption(Socket, SessionResumption, WaitForReply, Ticket
         Else1 ->
             ct:fail("~p:~p~nFaulty parameter: ~p", [?MODULE, ?LINE, Else1])
     end,
-    case TicketOption of
-        {tickets, N} ->
-            receive_tickets(N);
-        no_tickets ->
-            ok;
-        Else2 ->
-            ct:fail("~p:~p~nFaulty parameter: ~p", [?MODULE, ?LINE, Else2])
+    Tickets =
+        case TicketOption of
+            {tickets, N} ->
+                receive_tickets(N);
+            no_tickets ->
+                ok;
+            Else2 ->
+                ct:fail("~p:~p~nFaulty parameter: ~p", [?MODULE, ?LINE, Else2])
+        end,
+    case EarlyData of
+        {verify_early_data, Atom} ->
+            case verify_early_data(Atom) of
+                ok ->
+                    Tickets;
+                Else ->
+                    ct:fail("~p:~p~nFailed to verify early_data! (expected ~p, got ~p)",
+                            [?MODULE, ?LINE, Atom, Else])
+            end;
+        no_early_data ->
+            Tickets;
+        Else3 ->
+            ct:fail("~p:~p~nFaulty parameter: ~p", [?MODULE, ?LINE, Else3])
     end.
 
 boolean_to_log_msg(true) ->
@@ -2594,7 +2650,7 @@ receive_tickets(0, Acc) ->
     Acc;
 receive_tickets(N, Acc) ->
     receive
-        {ssl, session_ticket, {_, Ticket}} ->
+        {ssl, session_ticket, Ticket} ->
             receive_tickets(N - 1, [Ticket|Acc])
     end.
 
@@ -2628,7 +2684,8 @@ active_recv(_Socket, N, Acc) when N < 0 ->
     T;
 active_recv(Socket, N, Acc) ->
     receive 
-	{ssl, Socket, Bytes} ->
+        %% Filter {ssl, Socket, {early_data, Atom}} messages
+	{ssl, Socket, Bytes} when not is_tuple(Bytes) ->
             active_recv(Socket, N-data_length(Bytes),  Acc ++ Bytes);
         {Socket, {data, Bytes0}} ->
             Bytes = filter_openssl_debug_data(Bytes0),
@@ -3624,4 +3681,12 @@ default_ciphers(Version) ->
                 ssl:cipher_suites(default, Version)
         end, 
     [Cipher || Cipher <- Ciphers, lists:member(ssl:suite_to_openssl_str(Cipher), OpenSSLCiphers)].
-                           
+
+verify_early_data(Atom) ->
+    receive
+        {ssl, _Socket, {early_data, Atom}} ->
+            ok;
+        {ssl, _Socket, {early_data, Other}} ->
+            Other
+    end.
+

--- a/lib/ssl/test/tls_1_3_record_SUITE.erl
+++ b/lib/ssl/test/tls_1_3_record_SUITE.erl
@@ -544,7 +544,8 @@ encode_decode(_Config) ->
     %% TODO: remove hardcoded IV size
     WriteIVInfo = tls_v1:create_info(<<"iv">>, <<>>,  12),
 
-    {WriteKey, WriteIV} = tls_v1:calculate_traffic_keys(HKDFAlgo, Cipher, SHSTrafficSecret),
+    KeyLength = ssl_cipher:key_material(Cipher),
+    {WriteKey, WriteIV} = tls_v1:calculate_traffic_keys(HKDFAlgo, KeyLength, SHSTrafficSecret),
 
     %% {server}  construct an EncryptedExtensions handshake message:
     %%
@@ -824,7 +825,7 @@ encode_decode(_Config) ->
     SWIV =
         hexstr2bin("cf 78 2b 88 dd 83 54 9a ad f1 e9 84"),
 
-    {SWKey, SWIV} = tls_v1:calculate_traffic_keys(HKDFAlgo, Cipher, SAPTrafficSecret),
+    {SWKey, SWIV} = tls_v1:calculate_traffic_keys(HKDFAlgo, KeyLength, SAPTrafficSecret),
 
     %% {server}  derive read traffic keys for handshake data:
     %%
@@ -849,7 +850,7 @@ encode_decode(_Config) ->
     SRIV =
         hexstr2bin("5b d3 c7 1b 83 6e 0b 76 bb 73 26 5f"),
 
-    {SRKey, SRIV} = tls_v1:calculate_traffic_keys(HKDFAlgo, Cipher, CHSTrafficSecret),
+    {SRKey, SRIV} = tls_v1:calculate_traffic_keys(HKDFAlgo, KeyLength, CHSTrafficSecret),
 
     %% {client}  calculate finished "tls13 finished":
     %%
@@ -926,7 +927,7 @@ encode_decode(_Config) ->
     CWIV =
         hexstr2bin("5b 78 92 3d ee 08 57 90 33 e5 23 d9"),
 
-    {CWKey, CWIV} = tls_v1:calculate_traffic_keys(HKDFAlgo, Cipher, CAPTrafficSecret),
+    {CWKey, CWIV} = tls_v1:calculate_traffic_keys(HKDFAlgo, KeyLength, CAPTrafficSecret),
 
     %% {client}  derive secret "tls13 res master":
     %%


### PR DESCRIPTION
This PR implements the early data feature on the client side. Two new ssl options have been added ```early_data``` and ```max_early_data```. On the client side ```early_data``` is a ```binary()``` to be sent as early_data in a 0-RTT handshake. ```max_early_data``` configures the maximum size of early data accepted by the server. In this early version only the server's session ticket message has been updated to reflect the configured limit on the early data size.

Sample usage with automatic ticket handling:

```shell
# Start openssl s_server
openssl s_server -accept 11029 \
	-tls1_3 -verify 2 \
	-cert certs/server.pem \
	-CAfile certs/ca.pem \
	-key certs/server.key \
	-keylogfile keylog \
	-msg -debug \
	-early_data \
        -no_anti_replay

```

```erlang
early_data_auto() ->
    %% First handshake 1-RTT - get session tickets
    application:load(ssl),
    {ok, _} = application:ensure_all_started(ssl),
    Port = 11029,
    Data = <<"Hello World">>,
    COpts0 = [{cacertfile, ?CA_CERT},
	      {versions, ['tlsv1.2', 'tlsv1.3']},
	      {session_tickets, auto}],
    {ok, Sock0} = ssl:connect("localhost", Port, COpts0),

    %% Wait for session tickets
    timer:sleep(500),
    %% Close socket if server cannot handle multiple connections e.g. openssl s_server
    ssl:close(Sock0),

    %% Second handshake 0-RTT
    COpts1 = [{cacertfile, ?CA_CERT},
	      {versions, ['tlsv1.2', 'tlsv1.3']},
	      {session_tickets, auto},
	      {early_data, Data}],
    {ok, Sock} = ssl:connect("localhost", Port, COpts1),
    Sock.
```

Manual ticket handling:
```erlang
early_data_manual() ->
    %% First handshake 1-RTT - get session tickets
    application:load(ssl),
    {ok, _} = application:ensure_all_started(ssl),
    Port = 11029,
    Data = <<"Hello World">>,
    COpts0 = [{cacertfile, ?CA_CERT},
	      {versions, ['tlsv1.2', 'tlsv1.3']},
	      {session_tickets, manual}],
    {ok, Sock0} = ssl:connect("localhost", Port, COpts0),

    %% Wait for session tickets
    Ticket = 
	receive
	    {ssl, session_ticket, Ticket0} ->
		Ticket0
	end,

    %% Close socket if server cannot handle multiple connections
    %% e.g. openssl s_server
    ssl:close(Sock0),

    %% Second handshake 0-RTT
    COpts1 = [{cacertfile, ?CA_CERT},
	      {versions, ['tlsv1.2', 'tlsv1.3']},
	      {session_tickets, manual},
	      {use_ticket, [Ticket]},
	      {early_data, Data}],
    {ok, Sock} = ssl:connect("localhost", Port, COpts1),
    Sock.
```

In both cases the user process will be informed if the server has accepted the early_data.
The API message has the following format: ```{ssl, SslSocket, {early_data, Result}}```.

```shell
1> tt:early_data_auto().
{sslsocket,{gen_tcp,#Port<0.8>,tls_connection,undefined},
           [<0.128.0>,<0.127.0>]}
2> flush().
Shell got {ssl,{sslsocket,{gen_tcp,#Port<0.8>,tls_connection,undefined},
                          [<0.128.0>,<0.127.0>]},
               {early_data,accepted}}
```