### PR TITLE
Fix typo on Erl_Docgen User's Guide

### DIFF
--- a/lib/erl_docgen/doc/src/doc-build.xml
+++ b/lib/erl_docgen/doc/src/doc-build.xml
@@ -43,7 +43,7 @@
       </p>
       <code>
 
-	1> escript $(ERL_TOP)/lib/erl_docgen/priv/bin/xml_from_edoc.escript ex1.erl
+	1> escript ${ERL_TOP}/lib/erl_docgen/priv/bin/xml_from_edoc.escript ex1.erl
       </code>
     </section>
     <section>
@@ -57,7 +57,7 @@
       </p>
       <code>
 
-	1> escript $(ERL_TOP)/lib/erl_docgen/priv/bin/codeline_preprocessing.escript \
+	1> escript ${ERL_TOP}/lib/erl_docgen/priv/bin/codeline_preprocessing.escript \
 	   ex1.xmlsrc ex1.xml
       </code>
     </section>


### PR DESCRIPTION
As per https://bugs.erlang.org/browse/ERL-1386.