### PR TITLE
Export the dst/0 type from erlang.erl

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -112,6 +112,9 @@
 -type iovec() :: [binary()].
 -export_type([iovec/0]).
 
+%% Type for the destination of sends.
+-export_type([dst/0]).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Native code BIF stubs and their types
 %% (BIF's actually implemented in this module goes last in the file)


### PR DESCRIPTION
The dst/0 type describes what types of values that it is possible to send messages to in Erlang. It would be useful to have one source of truth for this type when referring to it in other modules, since it is somewhat complex it is easy to miss acceptable values when defining it yourself.