### PR TITLE
Replace old test BIFs w/o is_ prefix in documentation code examples

### DIFF
--- a/lib/tools/doc/src/fprof.xml
+++ b/lib/tools/doc/src/fprof.xml
@@ -598,7 +598,7 @@
 -module(foo).
 -export([create_file_slow/2]).
 
-create_file_slow(Name, N) when integer(N), N >= 0 ->
+create_file_slow(Name, N) when is_integer(N), N >= 0 ->
     {ok, FD} = 
         file:open(Name, [raw, write, delayed_write, binary]),
     if N > 256 ->

--- a/system/doc/programming_examples/list_comprehensions.xml
+++ b/system/doc/programming_examples/list_comprehensions.xml
@@ -40,10 +40,10 @@
         <c>[1,2,a,...]</c> and X is greater than 3.</p>
     <p>The notation <c><![CDATA[X <- [1,2,a,...]]]></c> is a generator and
       the expression <c>X > 3</c> is a filter.</p>
-    <p>An additional filter, <c>integer(X)</c>, can be added to restrict
+    <p>An additional filter, <c>is_integer(X)</c>, can be added to restrict
       the result to integers:</p>
     <pre>
-> <input>[X || X &lt;- [1,2,a,3,4,b,5,6], integer(X), X > 3].</input>
+> <input>[X || X &lt;- [1,2,a,3,4,b,5,6], is_integer(X), X > 3].</input>
 [4,5,6]</pre>
     <p>Generators can be combined. For example, the Cartesian product
       of two lists can be written as follows:</p>

--- a/system/doc/programming_examples/records.xml
+++ b/system/doc/programming_examples/records.xml
@@ -222,7 +222,7 @@ print(#person{name = Name, age = Age,
 
 %% Demonstrates type testing, selector, updating.
 
-birthday(P) when record(P, person) -> 
+birthday(P) when is_record(P, person) -> 
    P#person{age = P#person.age + 1}.
 
 register_two_hackers() ->


### PR DESCRIPTION
As proposed in my email from erlang-questions as of 11.12.2020, here is a patch for the documentation.
It replaces usages of the old BIFs without the is_ prefix.

An initial find-grep for the BIFs showed over 300 occurrences, but finally I only found 4 occurrences in the code
examples.

There is no test case, as the patch does not affect real source code. ´
However, I tried the code examples in an erl shell.

dieter