### PR TITLE
erts: Fix small leak in process_flag/3 on dead process

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1722,8 +1722,10 @@ BIF_RETTYPE erts_internal_process_flag_3(BIF_ALIST_3)
                                         exec_process_flag_3,
                                         (void *) pf3a);
 
-   if (is_non_value(res))
+   if (is_non_value(res)) {
+       erts_free(ERTS_ALC_T_PF3_ARGS, pf3a);
        BIF_RET(am_badarg);
+   }
 
    return res;
 }

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -1534,10 +1534,13 @@ process_flag_badarg(Config) when is_list(Config) ->
 
     chk_badarg(fun () -> process_flag(priority, 4711) end),
     chk_badarg(fun () -> process_flag(save_calls, hmmm) end),
-    P= spawn_link(fun () -> receive die -> ok end end),
+    {P,Mref} = spawn_monitor(fun () -> receive "in vain" -> no end end),
     chk_badarg(fun () -> process_flag(P, save_calls, hmmm) end),
     chk_badarg(fun () -> process_flag(gurka, save_calls, hmmm) end),
-    P ! die,
+    exit(P, die),
+    chk_badarg(fun () -> process_flag(P, save_calls, 0) end),
+    {'DOWN', Mref, process, P, die} = receive M -> M end,
+    chk_badarg(fun () -> process_flag(P, save_calls, 0) end),
     ok.
 
 -include_lib("stdlib/include/ms_transform.hrl").


### PR DESCRIPTION
Calling `process_flag(DeadProcess, Flag, Value)` would leak about 6 words.

However, the only valid `Flag` for proces_flag/3 is `save_calls` which is a tracing/debugging feature.


