### PR TITLE
tls_connection: spread RAM/CPU spike induced by flow control

### DIFF
--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -458,12 +458,6 @@ initial_state(Role, Sender, Host, Port, Socket, {SSLOptions, SocketOptions, Trac
 			 _  ->
 			     ssl_session_cache
 		     end,
-    InternalActiveN =  case application:get_env(ssl, internal_active_n) of
-                           {ok, N} when is_integer(N) andalso (not IsErlDist) ->
-                               N;
-                           _  ->
-                               ?INTERNAL_ACTIVE_N
-                       end,
     UserMonitor = erlang:monitor(process, User),
     InitStatEnv = #static_env{
                      role = Role,
@@ -496,10 +490,27 @@ initial_state(Role, Sender, Host, Port, Socket, {SSLOptions, SocketOptions, Trac
        start_or_recv_from = undefined,
        flight_buffer = [],
        protocol_specific = #{sender => Sender,
-                             active_n => InternalActiveN,
+                             active_n => internal_active_n(IsErlDist),
                              active_n_toggle => true
                             }
       }.
+
+internal_active_n(true) ->
+    %% Start with a random number between 1 and ?INTERNAL_ACTIVE_N
+    %% In most cases distribution connections are established all at
+    %%  the same time, and flow control engages with ?INTERNAL_ACTIVE_N for
+    %%  all connections. Which creates a wave of "passive" messages, leading
+    %%  to significant bump of memory & scheduler utilisation. Starting with
+    %%  a random number between 1 and ?INTERNAL_ACTIVE_N helps to spread the
+    %%  spike.
+    erlang:system_time() rem ?INTERNAL_ACTIVE_N + 1;
+internal_active_n(false) ->
+    case application:get_env(ssl, internal_active_n) of
+        {ok, N} when is_integer(N) ->
+            N;
+        _  ->
+            ?INTERNAL_ACTIVE_N
+    end.
 
 handle_client_hello(#client_hello{client_version = ClientVersion} = Hello, State0) ->
     case tls_dtls_connection:handle_sni_extension(State0, Hello) of


### PR DESCRIPTION
When Distribution over TLS is used in large clusters, many
connections are established upfront. All of them have the same
{active_n, 100} setting enabled. When 100 packets are received,
which tends to happen simultaneously for many connections,
a significant spike in RAM and CPU % is observed, due to the way
switching to 'passive' is currently implemented.
Starting with the random number between 1 and 100 helps to spread
the spike and avoid momentarily overload.
This patch also removes unnecessary configuration lookup when
tls_connection is established for Erlang distribution purposes.