### PR TITLE
erts: Fix leak in erl_drv_send/output_term

### DIFF
--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -1805,6 +1805,15 @@ void erts_factory_undo(ErtsHeapFactory* factory)
                                    ERTS_HEAP_FRAG_SIZE(factory->heap_frags_saved->alloc_size));
                 }
             }
+            if (factory->message) {
+                ASSERT(factory->message->data.attached != ERTS_MSG_COMBINED_HFRAG);
+                ASSERT(!factory->message->data.heap_frag);
+
+                /* Set the message to NIL in order for it not to be treated as
+                   a distributed message by erts_cleanup_messages */
+                factory->message->m[0] = NIL;
+                erts_cleanup_messages(factory->message);
+            }
         }
         break;
 


### PR DESCRIPTION
Small memory leak when driver trying to send an invalid term
