### PR TITLE
Added erlang:statistics(message_queues).

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -8219,6 +8219,24 @@ ok
     </func>
 
     <func>
+      <name name="statistics" arity="1" clause_i="20"
+        anchor="statistics_message_queues"  since="OTP 24.0"/>
+      <fsummary>Information about message queues.</fsummary>
+      <desc>
+        <p>Returns a tuple
+          <c>{<anno>MsgqSum</anno>, <anno>MsgqProcNonzero</anno>,
+            <anno>MsgqProcMax</anno>, <anno>MaxPid</anno>}</c>, where
+          <c><anno>MsgqSum</anno></c> is the sum of all message queue lengths
+          in the system, <c><anno>MsgqProcNonzero</anno></c> is
+          the number of processes with non-empty queue,
+          <c><anno>MsgqProcMax</anno></c> is the length of the longest
+          message queue, and <c><anno>MaxPid</anno></c> is the process
+          accumulated the longest queue, or <c>undefined</c> if there is no such
+          process (all queues are empty). </p>
+      </desc>
+    </func>
+
+    <func>
       <name name="suspend_process" arity="1" since=""/>
       <fsummary>Suspend a process.</fsummary>
       <desc>

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2583,7 +2583,12 @@ setelement(_Index, _Tuple1, _Value) ->
                 (wall_clock) -> {Total_Wallclock_Time,
                                  Wallclock_Time_Since_Last_Call} when
       Total_Wallclock_Time :: non_neg_integer(),
-      Wallclock_Time_Since_Last_Call :: non_neg_integer().
+      Wallclock_Time_Since_Last_Call :: non_neg_integer();
+                (message_queues) -> {MsgqSum, MsgqProcNonzero, MsgqProcMax, MaxPid} when
+       MsgqSum :: non_neg_integer(),
+       MsgqProcNonzero :: non_neg_integer(),
+       MsgqProcMax :: non_neg_integer(),
+       MaxPid :: pid() | undefined.
 statistics(_Item) ->
     erlang:nif_error(undefined).
 


### PR DESCRIPTION
Counts sum of all messages in all processes message queues. Includes both private message queue and incoming signal/message queue lengths, thus accounts for pending signals too.
Returns process ID that has accumulated the longest queue (or undefined, if all message queues are empty).