### PR TITLE
Automatically build binary releases

### DIFF
--- a/.github/dockerfiles/Dockerfile.alpine-binary
+++ b/.github/dockerfiles/Dockerfile.alpine-binary
@@ -1,0 +1,30 @@
+ARG OS_VERSION
+FROM alpine:${OS_VERSION}
+ARG ARCHIVE
+RUN apk --no-cache upgrade
+RUN apk add --no-cache \
+  dpkg-dev \
+  dpkg \
+  bash \
+  pcre \
+  ca-certificates \
+  openssl-dev \
+  ncurses-dev \
+  unixodbc-dev \
+  zlib-dev \
+  lksctp-tools-dev \
+  autoconf \
+  build-base \
+  perl-dev \
+  wget \
+  tar \
+  binutils \
+  libxslt-dev
+COPY $ARCHIVE /tmp
+RUN cd /tmp && tar xzf otp_src.tar.gz
+WORKDIR /tmp/otp
+RUN ./otp_build autoconf
+RUN ./configure --with-ssl
+RUN make release -j$(getconf _NPROCESSORS_ONLN) RELEASE_ROOT=/tmp/release
+RUN make release_docs RELEASE_ROOT=/tmp/release DOC_TARGETS=chunks
+RUN cd /tmp && tar czf release.tar.gz release/

--- a/.github/dockerfiles/Dockerfile.ubuntu-binary
+++ b/.github/dockerfiles/Dockerfile.ubuntu-binary
@@ -1,0 +1,27 @@
+ARG OS_VERSION
+FROM ubuntu:${OS_VERSION}
+ARG ARCHIVE
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get -y --no-install-recommends install \
+  autoconf \
+  dpkg-dev \
+  gcc \
+  g++ \
+  make \
+  libncurses-dev \
+  unixodbc-dev \
+  libssl-dev \
+  libsctp-dev \
+  wget \
+  ca-certificates \
+  pax-utils \
+  xsltproc
+COPY $ARCHIVE /tmp
+RUN cd /tmp && tar xzf otp_src.tar.gz
+WORKDIR /tmp/otp
+RUN ./otp_build autoconf
+RUN ./configure --with-ssl
+RUN make release -j$(getconf _NPROCESSORS_ONLN) RELEASE_ROOT=/tmp/release
+RUN make release_docs RELEASE_ROOT=/tmp/release DOC_TARGETS=chunks
+RUN cd /tmp && tar czf release.tar.gz release/

--- a/.github/scripts/build_linux.sh
+++ b/.github/scripts/build_linux.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euox pipefail
+
+os=$1
+os_version=$2
+tmp_dir=$3
+
+image=otp:${os}
+container=otp_${os}
+dockerfile=.github/dockerfiles/Dockerfile.${os}-binary
+
+.github/scripts/init-pre-release.sh
+
+docker build \
+  -t ${image} \
+  -f $dockerfile \
+  --build-arg OS_VERSION=${os_version} \
+  --build-arg ARCHIVE=otp_src.tar.gz \
+  .
+
+docker run --name ${container} ${image}
+mkdir -p ${tmp_dir}
+docker cp ${container}:/tmp/release.tar.gz ${tmp_dir}/
+docker rm -f ${container}
+docker rmi -f ${image}
+rm -rf otp_src.tar.gz

--- a/.github/scripts/build_macos.sh
+++ b/.github/scripts/build_macos.sh
@@ -2,9 +2,11 @@
 set -euox pipefail
 
 tmp_dir=$1
+# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#utilities
+ssl_dir=/usr/local/opt/openssl
 
 ./otp_build autoconf
-./configure --with-ssl --disable-dynamic-ssl-lib
+./configure --with-ssl=$ssl_dir --disable-dynamic-ssl-lib
 make release -j$(getconf _NPROCESSORS_ONLN) RELEASE_ROOT=$PWD/release
 make release_docs RELEASE_ROOT=$PWD/release DOC_TARGETS=chunks
 tar czf ${tmp_dir}/release.tar.gz release/

--- a/.github/scripts/build_macos.sh
+++ b/.github/scripts/build_macos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euox pipefail
+
+tmp_dir=$1
+
+./otp_build autoconf
+./configure --with-ssl --disable-dynamic-ssl-lib
+make release -j$(getconf _NPROCESSORS_ONLN) RELEASE_ROOT=$PWD/release
+make release_docs RELEASE_ROOT=$PWD/release DOC_TARGETS=chunks
+tar czf ${tmp_dir}/release.tar.gz release/

--- a/.github/workflows/build_binary.yaml
+++ b/.github/workflows/build_binary.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: ${{ matrix.script }} $PWD/tmp
       - name: Set artifact name
         id: artifact-name
-        run: echo ::set-output name=NAME::$(echo ${{ github.ref }} | sed 's/refs\/heads\///')-x86_64-${{ matrix.os }}.tar.gz
+        run: echo ::set-output name=NAME::$(echo ${{ github.ref }} | sed -E 's/refs\/(heads|tags)\///' | sed -E 's/refs\/pull\/([0-9]+).*/pr-\1/')-x86_64-${{ matrix.os }}.tar.gz
       - run: mv tmp/release.tar.gz ${{ steps.artifact-name.outputs.NAME }}
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_binary.yaml
+++ b/.github/workflows/build_binary.yaml
@@ -1,0 +1,34 @@
+name: Build binary releases
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: macos-10.15
+            runs-on: macos-10.15
+            script: .github/scripts/build_macos.sh
+          - os: ubuntu-20.04
+            runs-on: ubuntu-20.04
+            script: .github/scripts/build_linux.sh ubuntu 20.04
+          - os: alpine-3.12
+            runs-on: ubuntu-20.04
+            script: .github/scripts/build_linux.sh alpine 3.12
+    runs-on: ${{ matrix.runs-on}}
+    steps:
+      - uses: actions/checkout@v2
+      - run: mkdir -p tmp
+      - run: ${{ matrix.script }} $PWD/tmp
+      - name: Set artifact name
+        id: artifact-name
+        run: echo ::set-output name=NAME::$(echo ${{ github.ref }} | sed 's/refs\/heads\///')-x86_64-${{ matrix.os }}.tar.gz
+      - run: mv tmp/release.tar.gz ${{ steps.artifact-name.outputs.NAME }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.artifact-name.outputs.NAME }}
+          path: ${{ steps.artifact-name.outputs.NAME }}

--- a/.github/workflows/build_binary.yaml
+++ b/.github/workflows/build_binary.yaml
@@ -2,8 +2,7 @@ name: Build binary releases
 
 on:
   push:
-    branches:
-      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,8 @@ on:
 jobs:
 
   pack:
-    if: github.repository == 'erlang/otp'
+    # TODO: re-enable
+    if: false
     name: Pack the Erlang/OTP tar.gz
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +35,7 @@ jobs:
           path: otp_src.tar.gz
 
   build:
-    if: github.repository == 'erlang/otp'
+    if: false
     name: Build Erlang/OTP
     runs-on: ubuntu-latest
     needs: pack
@@ -112,7 +113,7 @@ jobs:
 
   ## If this is a tag that has been pushed we do some release work
   release:
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'erlang/otp'
+    if: false
     name: Release Erlang/OTP
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,7 @@ on:
 jobs:
 
   pack:
+    if: github.repository == 'erlang/otp'
     name: Pack the Erlang/OTP tar.gz
     runs-on: ubuntu-latest
     steps:
@@ -33,6 +34,7 @@ jobs:
           path: otp_src.tar.gz
 
   build:
+    if: github.repository == 'erlang/otp'
     name: Build Erlang/OTP
     runs-on: ubuntu-latest
     needs: pack
@@ -110,6 +112,7 @@ jobs:
 
   ## If this is a tag that has been pushed we do some release work
   release:
+    if: github.repository == 'erlang/otp'
     name: Release Erlang/OTP
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -112,11 +112,10 @@ jobs:
 
   ## If this is a tag that has been pushed we do some release work
   release:
-    if: github.repository == 'erlang/otp'
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'erlang/otp'
     name: Release Erlang/OTP
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'erlang/otp'
     steps:
       ## This step outputs the tag name and whether the tag is a release or patch
       ## (all releases have only two version identifiers, while patches have three

--- a/.github/workflows/sync-github-releases.yaml
+++ b/.github/workflows/sync-github-releases.yaml
@@ -12,7 +12,8 @@ jobs:
 
   # Wait for up to a minute for previous runs to complete, abort if not done by then
   pre-ci:
-    if: github.repository == 'erlang/otp'
+    # TODO: re-enable
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -24,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   sync-releases:
-    if: github.repository == 'erlang/otp'
+    if: false
     needs: pre-ci
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-github-releases.yaml
+++ b/.github/workflows/sync-github-releases.yaml
@@ -12,6 +12,7 @@ jobs:
 
   # Wait for up to a minute for previous runs to complete, abort if not done by then
   pre-ci:
+    if: github.repository == 'erlang/otp'
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -23,8 +24,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   sync-releases:
-    needs: pre-ci
     if: github.repository == 'erlang/otp'
+    needs: pre-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-base.yaml
+++ b/.github/workflows/update-base.yaml
@@ -11,7 +11,8 @@ on:
 jobs:
 
   build-debian-64bit:
-    if: github.repository == 'erlang/otp'
+    # TODO: re-enable
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +27,7 @@ jobs:
           tags: latest
 
   build-debian-32bit:
-    if: github.repository == 'erlang/otp'
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +43,7 @@ jobs:
           tags: latest
 
   build-ubuntu-64bit:
-    if: github.repository == 'erlang/otp'
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://bugs.erlang.org/browse/ERL-1428

Notes:

- First of all, this workflow file is isolated (it just uses [init-pre-release.sh](.github/scripts/init-pre-release.sh) for now) and there’s more work to be done to re-use existing scripts

- As a proof of concept, the workflow currently only builds on pushes to the “master” branch and the artifacts are attached to the action run, see e.g.: https://github.com/wojtekmach/otp/actions/runs/428356220. Instead of building on every push to master, there could be instead a “nightly” job for master. If these master/nightly/etc artifacts would prove useful, instead of just being attached to the job, should they have a more permanent home e.g. on erlang.org? Btw, looks like run artifacts are only accessible to users who have access to the repo, so I re-published the tarballs that were built in that action here: http://wojtekmach.pl/otp/. In particular, you can easily test it with Docker by running: `docker run -it --rm ubuntu:20.04 sh -c 'apt update && apt install -y curl && curl http://wojtekmach.pl/otp/master-x86_64-ubuntu-20.04.tar.gz | tar xz && cd release/ && ./Install -sasl $PWD && ./bin/erl'`

- Beyond this proof of concept that just builds master branch, and this is really the point of all this work, there will be a job that works on releases (tbd how it’s triggered: either on tag push, or on release creation, or by polling, etc) that will attach the artifacts to *the release*, this way the artifacts will be available under predictable and *public* URLs like: https://github.com/erlang/otp/releases/download/OTP-24.0/OTP-24.0-x86_64-macos-10.15.tar.gz

- When downloading the run artifacts on macOS using Safari, the tarball is put under quarantine which means you won’t be able run executables unless you allow it in security settings. You can work around it by running this before unpacking the tarball: `xattr -d com.apple.quarantine path/to/tar`. When we have tarballs attached to releases, they could be downloaded via curl (since we can guess the URL) and that way they won’t be quarantined. Thus, when tools like asdf-erlang/kerl/etc will use binary releases, they’ll simply use curl to fetch and it will just work. I’m not sure people would download release from GitHub via browser, after unpacking you still need to run the `./Install` script, so maybe the curl-based flow is enough. Otherwise, it would probably make sense to build (and sign) a gui installer.

- I’ve arbitrarily picked the naming scheme to be: `<ref>-<arch>-<os>-<osversion>.tar.gz`,
  - master-x86_64-alpine-3.12.tar.gz
  - master-x86_64-macos-10.15.tar.gz
  - master-x86_64-ubuntu-20.04.tar.gz

  Does that seem reasonable? Not sure if it should be more specific (e.g. instead darwin-19.6.0 for macOS Catalina)

- The tarball unpacks a release/ directory (release/Install, release/lib, etc), should it unpack to a directory with a more specific name? or simply to “.”?

- macOS ships with libressl but without header files and it's recommended to bring your own SSL library anyway so we statically link it. See: https://rentzsch.tumblr.com/post/33696323211/wherein-i-write-apples-technote-about-openssl-on.

- No consideration for wx yet