### PR TITLE
erts: fix dtrace integration and MSACC extras 

### DIFF
--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -35,6 +35,10 @@
 #include "beam_catches.h"
 #include "beam_common.h"
 
+#ifdef USE_VM_PROBES
+#include "dtrace-wrapper.h"
+#endif
+
 static Eterm *get_freason_ptr_from_exc(Eterm exc);
 static ErtsCodePtr next_catch(Process* c_p, Eterm *reg);
 static void terminate_proc(Process* c_p, Eterm Value);

--- a/erts/emulator/beam/beam_common.h
+++ b/erts/emulator/beam/beam_common.h
@@ -215,7 +215,7 @@ do {						\
 #define DTRACE_GLOBAL_CALL_FROM_EXPORT(p,e)                                        \
     do {                                                                           \
         if (DTRACE_ENABLED(global_function_entry)) {                               \
-            ErtsCodePtr fp__ (((Export *) (e))->addresses[erts_active_code_ix()]); \
+            ErtsCodePtr fp__ = (((Export *) (e))->addresses[erts_active_code_ix()]); \
             DTRACE_GLOBAL_CALL((p), erts_code_to_codemfa(fp__));                   \
         }                                                                          \
     } while(0)

--- a/erts/emulator/beam/dtrace-wrapper.h
+++ b/erts/emulator/beam/dtrace-wrapper.h
@@ -47,7 +47,18 @@
 
 #if defined(USE_DYNAMIC_TRACE) && defined(USE_VM_PROBES) 
 
+#ifdef __cplusplus
+extern "C++" {
+/* Generated erlang_dtrace.h contains #include <sys/sdt.h>, which
+ * has C++ code requiring C++ linkage. However beam_asm.hpp includes
+ * global.h with C linkage, and compilation fails, because <sdt.h>
+ * uses C++ templates when __cplusplus is defined.
+*/
 #include "erlang_dtrace.h"
+}
+#else
+#include "erlang_dtrace.h"
+#endif
 
 #define DTRACE_ENABLED(name)                         \
     erlang_##name##_enabled()

--- a/erts/emulator/beam/jit/instr_bif.cpp
+++ b/erts/emulator/beam/jit/instr_bif.cpp
@@ -848,7 +848,7 @@ void BeamGlobalAssembler::emit_call_bif_shared(void) {
         a.mov(TMP_MEM3q, ARG5);
 
         a.mov(ARG1, erts_msacc_cache);
-        a.mov(ARG2, x86::qword_ptr(ARG2, offset(ErtsCodeMFA, module)));
+        a.mov(ARG2, x86::qword_ptr(ARG2, offsetof(ErtsCodeMFA, module)));
         a.mov(ARG3, ARG4);
         runtime_call<3>(erts_msacc_set_bif_state);
 

--- a/erts/emulator/beam/jit/instr_msg.cpp
+++ b/erts/emulator/beam/jit/instr_msg.cpp
@@ -25,6 +25,9 @@ extern "C"
 #include "bif.h"
 #include "code_ix.h"
 #include "erl_proc_sig_queue.h"
+#ifdef USE_VM_PROBES
+#    include "dtrace-wrapper.h"
+#endif
 }
 
 static ErtsMessage *decode_dist(Process *c_p, ErtsMessage *msgp) {


### PR DESCRIPTION
This commit fixes several issues breaking dtrace/systemtap integration.
 - beam_common.h: missing assignment operator breaks compilation
 - dtrace-wrapper.h: generated erlang_dtrace.h contains #include <sys/sdt.h>,
   which has C++ code requiring C++ linkage. However beam_asm.hpp includes
   global.h with C linkage, and compilation fails, because <sdt.h> uses C++
   templates when __cplusplus is defined. Override linkage to always be
   C++ if C++ compiler is used
 - debug FLAVOUR could not be built with DTRACE, because beam_common.c and
   instr_msg.c do not contain erlang_dtrace.h include, which is needed
   for debug builds where inlining is not enabled
- fixed compilation for microstate accounting configured with extra states