### PR TITLE
Detect repeated occurrences of the stacktrace variable in a try clause

### DIFF
--- a/lib/compiler/test/trycatch_SUITE.erl
+++ b/lib/compiler/test/trycatch_SUITE.erl
@@ -1414,7 +1414,9 @@ test_raise_4(Expr) ->
     try
         do_test_raise_4(Expr)
     catch
-        exit:{exception,C,E,Stk}:Stk ->
+        exit:{exception,C,E,StkTerm}:Stk ->
+            %% it's not allowed to do the matching directly in the clause head
+            true = (Stk =:= StkTerm),
             try
                 Expr()
             catch

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -466,12 +466,14 @@ try_clause -> pat_expr clause_guard clause_body :
 	{clause,A,[{tuple,A,[{atom,A,throw},'$1',{var,A,'_'}]}],'$2','$3'}.
 try_clause -> atom ':' pat_expr try_opt_stacktrace clause_guard clause_body :
 	A = ?anno('$1'),
-	{clause,A,[{tuple,A,['$1','$3',{var,A,'$4'}]}],'$5','$6'}.
+	T = case '$4' of '_' -> {var,A,'_'}; V -> V end,
+	{clause,A,[{tuple,A,['$1','$3',T]}],'$5','$6'}.
 try_clause -> var ':' pat_expr try_opt_stacktrace clause_guard clause_body :
 	A = ?anno('$1'),
-	{clause,A,[{tuple,A,['$1','$3',{var,A,'$4'}]}],'$5','$6'}.
+	T = case '$4' of '_' -> {var,A,'_'}; V -> V end,
+	{clause,A,[{tuple,A,['$1','$3',T]}],'$5','$6'}.
 
-try_opt_stacktrace -> ':' var : element(3, '$2').
+try_opt_stacktrace -> ':' var : '$2'.
 try_opt_stacktrace -> '$empty' : '_'.
 
 argument_list -> '(' ')' : {[],?anno('$1')}.

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -4223,6 +4223,14 @@ stacktrace_syntax(Config) ->
            ">>,
            [],
            {errors,[{4,erl_lint,{stacktrace_bound,'Stk'}}],[]}},
+          {bound_in_pattern,
+           <<"t1() ->
+                  try error(foo)
+                  catch _:{x,T}:T -> ok
+                  end.
+           ">>,
+           [],
+           {errors,[{3,erl_lint,{stacktrace_bound,'T'}}],[]}},
           {guard_and_bound,
            <<"t1() ->
                   Stk = [],


### PR DESCRIPTION
Previously, in `try ... catch _:T:T -> ...`, the compiler would treat the two
occurrences of T as separate variables, not adding any check that they have the
same value. Since such a check can be expensive for stacktraces, we don't want
to allow this, just like we don't allow T to be already bound.

This provides a more robust mechanism for handling the stacktrace variable, only
affecting catch-clauses, and sets proper position information on the trace var.