### PR TITLE
Document the -no_epmd option

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -460,7 +460,7 @@ $ <input>erl \
           become distributed; see <seeerl marker="kernel:net_kernel">
           <c>net_kernel(3)</c></seeerl>. It is also ensured that
           <c><![CDATA[epmd]]></c> runs on the current host before Erlang is
-          started; see <seecom marker="epmd"><c>epmd(1)</c></seecom>.and the
+          started; see <seecom marker="epmd"><c>epmd(1)</c></seecom> and the
           <seecom marker="#start_epmd"><c>-start_epmd</c></seecom> option.</p>
         <p>The node name will be <c><![CDATA[Name@Host]]></c>, where
           <c><![CDATA[Host]]></c> is the fully qualified host name of the
@@ -501,6 +501,22 @@ $ <input>erl \
             network is configured to keep potential attackers out.
           </p>
         </warning>
+      </item>
+      <tag><c><![CDATA[-no_epmd]]></c></tag>
+      <item>
+        <p>Specifies that the distributed node does not need
+          <seecom marker="epmd">epmd</seecom> at all.</p>
+        <p>This option ensures that the Erlang runtime system does not
+          start <seecom marker="epmd">epmd</seecom> and does not start
+          the <seeerl marker="kernel:erl_epmd">erl_epmd</seeerl> process
+          for distribution either.</p>
+        <p>This option only works if Erlang is started as a distributed node
+          with the <seecom marker="#proto_dist">-proto_dist</seecom> option
+          using an alternative protocol for Erlang distribution which
+          does not rely on epmd for node registration and discovery.
+          For more information, see <seeguide marker="erts:alt_dist">How
+          to implement an Alternative Carrier for the Erlang
+          Distribution</seeguide>.</p>
       </item>
       <tag><c><![CDATA[-noinput]]></c></tag>
       <item>

--- a/erts/emulator/test/distribution_SUITE.erl
+++ b/erts/emulator/test/distribution_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2020. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@
          bad_dist_ext_control/1,
          bad_dist_ext_connection_id/1,
          bad_dist_ext_size/1,
-	 start_epmd_false/1, epmd_module/1,
+	 start_epmd_false/1, no_epmd/1, epmd_module/1,
          bad_dist_fragments/1,
          message_latency_large_message/1,
          message_latency_large_link_exit/1,
@@ -104,7 +104,7 @@ all() ->
      contended_atom_cache_entry, contended_unicode_atom_cache_entry,
      {group, message_latency},
      {group, bad_dist}, {group, bad_dist_ext},
-     start_epmd_false, epmd_module, system_limit,
+     start_epmd_false, no_epmd, epmd_module, system_limit,
      hopefull_data_encoding, hopefull_export_fun_bug,
      huge_iovec].
 
@@ -2546,6 +2546,11 @@ start_epmd_false(Config) when is_list(Config) ->
     stop_node(OtherNode),
 
     ok.
+
+no_epmd(Config) when is_list(Config) ->
+    %% Trying to start a node with -no_epmd but without passing the
+    %% --proto_dist option should fail.
+    {error, timeout} = start_node(no_epmd, "-no_epmd").
 
 epmd_module(Config) when is_list(Config) ->
     %% We need a relay node to test this, since the test node uses the


### PR DESCRIPTION
Hello,

The option is already mentioned in https://erlang.org/doc/apps/erts/alt_dist.html but was not documented in https://erlang.org/doc/man/erl.html until now. I'm proposing this pull request as a follow-up to a recent question on the erlang-questions mailing list.

Cheers,
Jérôme