### PR TITLE
Fix uses of AC_CONFIG_AUX_DIRS() in configure scripts

### DIFF
--- a/lib/crypto/configure.in
+++ b/lib/crypto/configure.in
@@ -25,12 +25,7 @@ dnl define([AC_CACHE_SAVE], )dnl
 
 AC_INIT(vsn.mk)
 
-if test -z "$ERL_TOP" || test ! -d "$ERL_TOP" ; then
-  AC_CONFIG_AUX_DIRS(autoconf)
-else
-  erl_top=${ERL_TOP}
-  AC_CONFIG_AUX_DIRS($erl_top/erts/autoconf)
-fi
+AC_CONFIG_AUX_DIRS(${ERL_TOP}/erts/autoconf)
 
 if test "X$host" != "Xfree_source" -a "X$host" != "Xwin32"; then
     AC_CANONICAL_HOST

--- a/lib/megaco/configure.in
+++ b/lib/megaco/configure.in
@@ -25,12 +25,7 @@ dnl define([AC_CACHE_SAVE], )dnl
 
 AC_INIT(vsn.mk)
 
-if test -z "$ERL_TOP" || test ! -d $ERL_TOP ; then
-  AC_CONFIG_AUX_DIRS(autoconf)
-else
-  erl_top=${ERL_TOP}
-  AC_CONFIG_AUX_DIRS($erl_top/erts/autoconf)
-fi
+AC_CONFIG_AUX_DIRS(${ERL_TOP}/erts/autoconf)
 
 if test "X$host" != "Xfree_source" -a "X$host" != "Xwin32"; then
     AC_CANONICAL_HOST

--- a/lib/odbc/configure.in
+++ b/lib/odbc/configure.in
@@ -25,12 +25,7 @@ dnl define([AC_CACHE_SAVE], )dnl
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(c_src/odbcserver.c)
 
-if test -z "$ERL_TOP" || test ! -d $ERL_TOP ; then
-  AC_CONFIG_AUX_DIRS(autoconf)
-else
-  erl_top=${ERL_TOP}
-  AC_CONFIG_AUX_DIRS($erl_top/erts/autoconf)
-fi
+AC_CONFIG_AUX_DIRS(${ERL_TOP}/erts/autoconf)
 
 if test "X$host" != "Xfree_source" -a "X$host" != "Xwin32"; then
     AC_CANONICAL_HOST

--- a/lib/snmp/configure.in
+++ b/lib/snmp/configure.in
@@ -4,12 +4,7 @@ define([AC_CACHE_SAVE], )dnl
 
 AC_INIT(vsn.mk)
 
-if test -z "$ERL_TOP" || test ! -d $ERL_TOP ; then
-  AC_CONFIG_AUX_DIRS(autoconf)
-else
-  erl_top=${ERL_TOP}
-  AC_CONFIG_AUX_DIRS($erl_top/erts/autoconf)
-fi
+AC_CONFIG_AUX_DIRS(${ERL_TOP}/erts/autoconf)
 
 if test "X$host" != "Xfree_source" -a "X$host" != "Xwin32"; then
     AC_CANONICAL_HOST

--- a/make/configure.in
+++ b/make/configure.in
@@ -76,13 +76,13 @@ esac
 #
 # Now srcdir is absolute and also the top of Erlang distribution, ERL_TOP.
 #
-test "X$ERL_TOP" != "X" || ERL_TOP="$srcdir"
+test "X$ERL_TOP" != "X" || AC_MSG_ERROR([ERL_TOP not set])
 AC_SUBST(ERL_TOP)
 
 dnl
 dnl Aux programs are found in erts/autoconf
 dnl
-AC_CONFIG_AUX_DIR(${srcdir}/erts/autoconf)
+AC_CONFIG_AUX_DIR(${ERL_TOP}/erts/autoconf)
 
 dnl
 dnl Figure out what we are running on. And in violation of autoconf


### PR DESCRIPTION
Proposed fix for [ERL-1447](https://bugs.erlang.org/browse/ERL-1447).

Now builds with autoconf version 2.70 although we get lots of warnings for use of obsolete macros. Those will however have to be fixed at a later time. 