### PR TITLE
Also generate SHA256 checksums for releases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -144,7 +144,7 @@ jobs:
           name: otp_doc_man
 
       ## We add the correct version name into the file names
-      ## and create the MD5 file for all assets
+      ## and create the hash files for all assets
       - name: Create pre-build and doc archives
         run: .github/scripts/create-artifacts.sh artifacts ${{ steps.tag.outputs.tag }}
 
@@ -153,12 +153,13 @@ jobs:
         run: |
           scripts/bundle-otp ${{ steps.tag.outputs.tag }}
 
-      ## Create md5sum
+      ## Create hash files
       - name: Create pre-build and doc archives
         run: |
           shopt -s nullglob
           cd artifacts
           md5sum {*.tar.gz,*.txt} > MD5.txt
+          sha256sum {*.tar.gz,*.txt} > SHA256.txt
 
       - name: Upload pre-built and doc tar archives
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
See https://marc-stevens.nl/research/md5-1block-collision/ and https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html -- both MD5 and SHA1 are considered "broken" and unsafe for serious use, so this updates the release workflow to also generate SHA256 checksums of the built artifacts.