### PR TITLE
gen: init_it given atom as parent PID

### DIFF
--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -113,7 +113,7 @@ do_spawn(GenMod, monitor, Mod, Args, Options) ->
 do_spawn(GenMod, _, Mod, Args, Options) ->
     Time = timeout(Options),
     proc_lib:start(?MODULE, init_it,
-		   [GenMod, self(), self, Mod, Args, Options], 
+		   [GenMod, self(), 'self', Mod, Args, Options],
 		   Time,
 		   spawn_opts(Options)).
 
@@ -133,7 +133,7 @@ do_spawn(GenMod, monitor, Name, Mod, Args, Options) ->
 do_spawn(GenMod, _, Name, Mod, Args, Options) ->
     Time = timeout(Options),
     proc_lib:start(?MODULE, init_it,
-		   [GenMod, self(), self, Name, Mod, Args, Options], 
+		   [GenMod, self(), 'self', Name, Mod, Args, Options],
 		   Time,
 		   spawn_opts(Options)).
 


### PR DESCRIPTION
The atom 'self' is passed instead of the parent's PID, using `self()`
when starting some gen-processes with 'monitor' or 'nolink'.

This patch change so that `self()` is called and the parent argument to
proc_lib will result in a PID instead of the atom 'self'.

I don't know the effect of this change. I assume this is a typo since a
corresponding clause, without `Name`, is using `self()` instead of `'self'`.