### PR TITLE
Typo on https://erlang.org/doc/oam/oam_intro.html#snmp-based-oam

### DIFF
--- a/system/doc/oam/oam_intro.xml
+++ b/system/doc/oam/oam_intro.xml
@@ -219,7 +219,7 @@ snmp:c("MY-MIB", [{il, ["snmp/priv/mibs"]}]).</code>
       code-only, while others need a server. One way, used by the
       code-only MIB implementations, is for the user to call a
       function such as
-      <c>snmpa:unload_mibs(Agent, [Mib])</c>
+      <c>snmpa:load_mibs(Agent, [Mib])</c>
       to load the MIB, and
       <c>snmpa:unload_mibs(Agent, [Mib])</c>
       to unload the MIB. See the manual page for each application for


### PR DESCRIPTION
Spotted a typo on https://erlang.org/doc/oam/oam_intro.html#snmp-based-oam(in the last paragraph)