### PR TITLE
inet_res: fix dns compression encoder for large responses

### DIFF
--- a/lib/kernel/src/inet_dns.erl
+++ b/lib/kernel/src/inet_dns.erl
@@ -697,7 +697,7 @@ encode_labels(Bin, Comp0, Pos, [L|Ls]=Labels)
   when 1 =< byte_size(L), byte_size(L) =< 63 ->
     case gb_trees:lookup(Labels, Comp0) of
 	none ->
-	    Comp = if Pos < (3 bsl 14) ->
+	    Comp = if Pos < (1 bsl 14) ->
 			   %% Just in case - compression
 			   %% pointers cannot reach further
 			   gb_trees:insert(Labels, Pos, Comp0);


### PR DESCRIPTION
The [pointer in the label is 14bit wide](https://tools.ietf.org/html/rfc1035#section-4.1.4) and a typo looks to have used the flag value (3) for the left shift rather than just 1; leading to a limit of 49152 being used rather than 16384.

This bug only shows up for large responses involving several hundred records such as those seen in an AXFR transfer.

This PR resolves this more than 11 year old bug.