### PR TITLE
Add a type for application:start's result

### DIFF
--- a/lib/kernel/doc/src/application.xml
+++ b/lib/kernel/doc/src/application.xml
@@ -58,6 +58,9 @@
       <name name="start_type"/>
     </datatype>
     <datatype>
+      <name name="start_result"/>
+    </datatype>
+    <datatype>
       <name name="restart_type"/>
     </datatype>
     <datatype>
@@ -523,13 +526,14 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
         <c>application</c> callback module.</p>
     </fsdescription>
     <func>
-      <name since="">Module:start(StartType, StartArgs) -> {ok, Pid} | {ok, Pid, State} | {error, Reason}</name>
+      <name since="">Module:start(StartType, StartArgs) -> StartResult</name>
       <fsummary>Start an application.</fsummary>
       <type>
         <v>StartType = <seetype marker="#start_type"><c>start_type()</c></seetype></v>
         <v>StartArgs = term()</v>
         <v>Pid = pid()</v>
         <v>State = term()</v>
+        <v>StartResult = <seetype marker="#start_result"><c>start_result()</c></seetype></v>
       </type>
       <desc>
         <p>This function is called whenever an application is started

--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -32,12 +32,14 @@
 -export([start_type/0]).
 
 -export_type([start_type/0]).
+-export_type([start_result/0]).
 
 %%%-----------------------------------------------------------------
 
 -type start_type() :: 'normal'
                     | {'takeover', Node :: node()}
                     | {'failover', Node :: node()}.
+-type start_result() :: {'ok', pid()} | {'ok', pid(), State :: term()} | {'error', Reason :: term()}.
 -type restart_type() :: 'permanent' | 'transient' | 'temporary'.
 -type application_opt() :: {'description', Description :: string()}
                          | {'vsn', Vsn :: string()}
@@ -62,7 +64,7 @@
 %%------------------------------------------------------------------
 
 -callback start(StartType :: start_type(), StartArgs :: term()) ->
-    {'ok', pid()} | {'ok', pid(), State :: term()} | {'error', Reason :: term()}.
+    start_result().
 
 -callback stop(State :: term()) ->
     term().


### PR DESCRIPTION
I don't expect `application:start`'s result to change that much, but I keep having to write the same elements (the ones in this new type) over and over, so it seems more appropriate to do it here, upstream.

I'd also like to note that `{error, Reason}` is not documented in callback `:start_phase` or `:start` except by reference (e.g. in `application:ensure_all_started` or `application:start`, though this is probably expected).