### PR TITLE
Simplify configuration of cross-compiling to Android x86_64

### DIFF
--- a/xcomp/erl-xcomp-x86_64-android.conf
+++ b/xcomp/erl-xcomp-x86_64-android.conf
@@ -1,0 +1,280 @@
+## -*-shell-script-*-
+##
+## %CopyrightBegin%
+##
+## Copyright Ericsson AB 2021. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## %CopyrightEnd%
+##
+## File: erl-xcomp-x86_64-android.conf
+## Author: Paulo Oliveira
+##
+## -----------------------------------------------------------------------------
+## When cross compiling Erlang/OTP using `otp_build', copy this file and set
+## the variables needed below. Then pass the path to the copy of this file as
+## an argument to `otp_build' in the configure stage:
+##   `otp_build configure --xcomp-conf=<FILE>'
+## -----------------------------------------------------------------------------
+
+## Note that you cannot define arbitrary variables in a cross compilation
+## configuration file. Only the ones listed below will be guaranteed to be
+## visible throughout the whole execution of all `configure' scripts. Other
+## variables needs to be defined as arguments to `configure' or exported in
+## the environment.
+
+## -- Variables for `otp_build' Only -------------------------------------------
+
+## Variables in this section are only used, when configuring Erlang/OTP for
+## cross compilation using `$ERL_TOP/otp_build configure'.
+
+## *NOTE*! These variables currently have *no* effect if you configure using
+## the `configure' script directly.
+
+# * `erl_xcomp_build' - The build system used. This value will be passed as
+#   `--build=$erl_xcomp_build' argument to the `configure' script. It does
+#   not have to be a full `CPU-VENDOR-OS' triplet, but can be. The full
+#   `CPU-VENDOR-OS' triplet will be created by
+#   `$ERL_TOP/erts/autoconf/config.sub $erl_xcomp_build'. If set to `guess',
+#   the build system will be guessed using
+#   `$ERL_TOP/erts/autoconf/config.guess'.
+erl_xcomp_build=guess
+
+# * `erl_xcomp_host' - Cross host/target system to build for. This value will
+#   be passed as `--host=$erl_xcomp_host' argument to the `configure' script.
+#   It does not have to be a full `CPU-VENDOR-OS' triplet, but can be. The
+#   full `CPU-VENDOR-OS' triplet will be created by
+#   `$ERL_TOP/erts/autoconf/config.sub $erl_xcomp_host'.
+erl_xcomp_host=x86_64-linux-android
+
+# * `erl_xcomp_configure_flags' - Extra configure flags to pass to the
+#   `configure' script.
+erl_xcomp_configure_flags="--disable-hipe --without-termcap --without-wx \
+                                          --enable-builtin-zlib"
+
+## -- Cross Compiler and Other Tools -------------------------------------------
+
+## If the cross compilation tools are prefixed by `<HOST>-' you probably do
+## not need to set these variables (where `<HOST>' is what has been passed as
+## `--host=<HOST>' argument to `configure').
+
+## All variables in this section can also be used when native compiling.
+
+# * `CC' - C compiler.
+CC=x86_64-linux-$NDK_ABI_PLAT-clang
+
+# * `CFLAGS' - C compiler flags.
+#CFLAGS=
+
+# * `STATIC_CFLAGS' - Static C compiler flags.
+#STATIC_CFLAGS=
+
+# * `CFLAG_RUNTIME_LIBRARY_PATH' - This flag should set runtime library
+#   search path for the shared libraries. Note that this actually is a
+#   linker flag, but it needs to be passed via the compiler.
+#CFLAG_RUNTIME_LIBRARY_PATH=
+
+# * `CPP' - C pre-processor.
+#CPP=
+
+# * `CPPFLAGS' - C pre-processor flags.
+#CPPFLAGS=
+
+# * `CXX' - C++ compiler.
+CXX=x86_64-linux-$NDK_ABI_PLAT-clang++
+
+# * `CXXFLAGS' - C++ compiler flags.
+#CXXFLAGS=
+
+# * `LD' - Linker.
+LD=x86_64-linux-android-ld.gold
+
+# * `LDFLAGS' - Linker flags.
+#LDFLAGS=
+
+# * `LIBS' - Libraries.
+#LIBS=
+
+## -- *D*ynamic *E*rlang *D*river Linking --
+
+## *NOTE*! Either set all or none of the `DED_LD*' variables.
+
+# * `DED_LD' - Linker for Dynamically loaded Erlang Drivers.
+#DED_LD=
+
+# * `DED_LDFLAGS' - Linker flags to use with `DED_LD'.
+#DED_LDFLAGS=
+
+# * `DED_LD_FLAG_RUNTIME_LIBRARY_PATH' - This flag should set runtime library
+#   search path for shared libraries when linking with `DED_LD'.
+#DED_LD_FLAG_RUNTIME_LIBRARY_PATH=
+
+## -- Large File Support --
+
+## *NOTE*! Either set all or none of the `LFS_*' variables.
+
+# * `LFS_CFLAGS' - Large file support C compiler flags.
+#LFS_CFLAGS=
+
+# * `LFS_LDFLAGS' - Large file support linker flags.
+#LFS_LDFLAGS=
+
+# * `LFS_LIBS' - Large file support libraries.
+#LFS_LIBS=
+
+## -- Other Tools --
+
+# * `RANLIB' - `ranlib' archive index tool.
+#RANLIB=
+
+# * `AR' - `ar' archiving tool.
+#AR=
+
+# * `GETCONF' - `getconf' system configuration inspection tool. `getconf' is
+#   currently used for finding out large file support flags to use, and
+#   on Linux systems for finding out if we have an NPTL thread library or
+#   not.
+#GETCONF=
+
+## -- Cross System Root Locations ----------------------------------------------
+
+# * `erl_xcomp_sysroot' - The absolute path to the system root of the cross
+#   compilation environment. Currently, the `crypto', `odbc', `ssh' and
+#   `ssl' applications need the system root. These applications will be
+#   skipped if the system root has not been set. The system root might be
+#   needed for other things too. If this is the case and the system root
+#   has not been set, `configure' will fail and request you to set it.
+erl_xcomp_sysroot="$NDK_ROOT/sys_root"
+
+# * `erl_xcomp_isysroot' - The absolute path to the system root for includes
+#   of the cross compilation environment. If not set, this value defaults
+#   to `$erl_xcomp_sysroot', i.e., only set this value if the include system
+#   root path is not the same as the system root path.
+#erl_xcomp_isysroot=
+
+## -- Optional Feature, and Bug Tests ------------------------------------------
+
+## These tests cannot (always) be done automatically when cross compiling. You
+## usually do not need to set these variables. Only set these if you really
+## know what you are doing.
+
+## Note that some of these values will override results of tests performed
+## by `configure', and some will not be used until `configure' is sure that
+## it cannot figure the result out.
+
+## The `configure' script will issue a warning when a default value is used.
+## When a variable has been set, no warning will be issued.
+
+# * `erl_xcomp_after_morecore_hook' - `yes|no'. Defaults to `no'. If `yes',
+#   the target system must have a working `__after_morecore_hook' that can be
+#   used for tracking used `malloc()' implementations core memory usage.
+#   This is currently only used by unsupported features.
+#erl_xcomp_after_morecore_hook=
+
+# * `erl_xcomp_bigendian' - `yes|no'. No default. If `yes', the target system
+#   must be big endian. If `no', little endian. This can often be
+#   automatically detected, but not always. If not automatically detected,
+#   `configure' will fail unless this variable is set. Since no default
+#   value is used, `configure' will try to figure this out automatically.
+#erl_xcomp_bigendian=
+
+# * `erl_xcomp_double_middle` - `yes|no`. No default. If `yes`, the
+#   target system must have doubles in "middle-endian" format. If
+#   `no`, it has "regular" endianness. This can often be automatically
+#   detected, but not always. If not automatically detected,
+#   `configure` will fail unless this variable is set. Since no
+#   default value is used, `configure` will try to figure this out
+#   automatically.
+#erl_xcomp_double_middle_endian
+
+# * `erl_xcomp_clock_gettime_cpu_time' - `yes|no'. Defaults to `no'. If `yes',
+#   the target system must have a working `clock_gettime()' implementation
+#   that can be used for retrieving process CPU time.
+#erl_xcomp_clock_gettime_cpu_time=
+
+# * `erl_xcomp_getaddrinfo' - `yes|no'. Defaults to `no'. If `yes', the target
+#   system must have a working `getaddrinfo()' implementation that can
+#   handle both IPv4 and IPv6.
+#erl_xcomp_getaddrinfo=
+
+# * `erl_xcomp_gethrvtime_procfs_ioctl' - `yes|no'. Defaults to `no'. If `yes',
+#   the target system must have a working `gethrvtime()' implementation and
+#   is used with procfs `ioctl()'.
+#erl_xcomp_gethrvtime_procfs_ioctl=
+
+# * `erl_xcomp_dlsym_brk_wrappers' - `yes|no'. Defaults to `no'. If `yes', the
+#   target system must have a working `dlsym(RTLD_NEXT, <S>)' implementation
+#   that can be used on `brk' and `sbrk' symbols used by the `malloc()'
+#   implementation in use, and by this track the `malloc()' implementations
+#   core memory usage. This is currently only used by unsupported features.
+#erl_xcomp_dlsym_brk_wrappers=
+
+# * `erl_xcomp_kqueue' - `yes|no'. Defaults to `no'. If `yes', the target
+#   system must have a working `kqueue()' implementation that returns a file
+#   descriptor which can be used by `poll()' and/or `select()'. If `no' and
+#   the target system has not got `epoll()' or `/dev/poll', the kernel-poll
+#   feature will be disabled.
+#erl_xcomp_kqueue=
+
+# * `erl_xcomp_linux_clock_gettime_correction' - `yes|no'. Defaults to `yes' on
+#   Linux; otherwise, `no'. If `yes', `clock_gettime(CLOCK_MONOTONIC, _)' on
+#   the target system must work. This variable is recommended to be set to
+#   `no' on Linux systems with kernel versions less than 2.6.
+#erl_xcomp_linux_clock_gettime_correction=
+
+# * `erl_xcomp_linux_nptl' - `yes|no'. Defaults to `yes' on Linux; otherwise,
+#   `no'. If `yes', the target system must have NPTL (Native POSIX Thread
+#   Library). Older Linux systems have LinuxThreads instead of NPTL (Linux
+#   kernel versions typically less than 2.6).
+#erl_xcomp_linux_nptl=
+
+# * `erl_xcomp_linux_usable_sigaltstack' - `yes|no'. Defaults to `yes' on Linux;
+#   otherwise, `no'. If `yes', `sigaltstack()' must be usable on the target
+#   system. `sigaltstack()' on Linux kernel versions less than 2.4 are
+#   broken.
+#erl_xcomp_linux_usable_sigaltstack=
+
+# * `erl_xcomp_linux_usable_sigusrx' - `yes|no'. Defaults to `yes'. If `yes',
+#   the `SIGUSR1' and `SIGUSR2' signals must be usable by the ERTS. Old
+#   LinuxThreads thread libraries (Linux kernel versions typically less than
+#   2.2) used these signals and made them unusable by the ERTS.
+#erl_xcomp_linux_usable_sigusrx=
+
+# * `erl_xcomp_poll' - `yes|no'. Defaults to `no' on Darwin/MacOSX; otherwise,
+#   `yes'. If `yes', the target system must have a working `poll()'
+#   implementation that also can handle devices. If `no', `select()' will be
+#   used instead of `poll()'.
+#erl_xcomp_poll=
+
+# * `erl_xcomp_putenv_copy' - `yes|no'. Defaults to `no'. If `yes', the target
+#   system must have a `putenv()' implementation that stores a copy of the
+#   key/value pair.
+#erl_xcomp_putenv_copy=
+
+# * `erl_xcomp_reliable_fpe' - `yes|no'. Defaults to `no'. If `yes', the target
+#   system must have reliable floating point exceptions.
+#erl_xcomp_reliable_fpe=
+
+# * `erl_xcomp_posix_memalign' - `yes|no'. Defaults to `yes' if `posix_memalign'
+#   system call exists; otherwise `no'. If `yes', the target system must have a
+#   `posix_memalign' implementation that accepts larger than page size
+#   alignment.
+#erl_xcomp_posix_memalign=
+
+# * `erl_xcomp_code_model_small` - `yes|no`. Default to `no`. If `yes`, the target
+#   system must place the beam.smp executable in the lower 2 GB of memory. That is it
+#   should not use position independent executable.
+#erl_xcomp_code_model_small=
+
+## -----------------------------------------------------------------------------


### PR DESCRIPTION
I was fiddling around with [@JeromeDeBretagne's erlanglauncher's fork](https://github.com/JeromeDeBretagne/erlanglauncher) to get a sense of how to use `jinterface` in an Android env. and wanted to use an x86_64 arch. emulator (that project targets ARM but I couldn't get an ARM emulator to work correctly or with a decent performance). I looked at the [OTP doc.](https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-ANDROID.md) and followed it until I figured I didn't have a readily-available `xcomp.conf` for my use case. This pull request presents one, heavily inspired by `erl-xcomp-arm64-android.conf`.

I'm not sure there's a need to add tests for this, or what other elements I'd need changed in the scope of this pull request, but will gladly follow your guidance.