### PR TITLE
Handle macros in patterns

### DIFF
--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/epp_dodger_clever.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/epp_dodger_clever.erl
@@ -1,0 +1,12 @@
+-module(epp_dodger_clever).
+
+-export([foo1/0]).
+
+-define(macro_string, "hello world").
+
+foo1() ->
+    % string combining ?
+    [?macro_string
+     "hello world ",
+     "more hello"
+     ?macro_string].

--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/syntax_tools_test.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/syntax_tools_test.erl
@@ -6,7 +6,7 @@
 
 -module(syntax_tools_test).
 
--export([foo1/0,foo2/2,foo3/0,foo4/3,foo5/1]).
+-export([foo1/0,foo2/2,foo3/0,foo4/3,foo5/1,foo6/2]).
 
 -include_lib("kernel/include/file.hrl").
 -record(state, { a, b, c, d}).
@@ -24,6 +24,7 @@
 -define(macro_string, "hello world").
 -define(macro_argument1(X), (X + 3)).
 -define(macro_argument2(X,Y), (X + 3 * Y)).
+-define(macro_argument3(X), {error, X}).
 -define(macro_block(X), begin X end).
 -define(macro_if(X1,X2), if X1 -> X2; true -> none end).
 
@@ -48,8 +49,7 @@ foo1() ->
 %% macro test
 foo2(A,B) ->
     % string combining ?
-    [?macro_string, ?macro_string
-     ?macro_string,
+    [?macro_string, ?macro_string ++
      "hello world "
      "more hello",
      [?macro_simple1,
@@ -112,4 +112,17 @@ foo5(A) ->
     catch
 	error:?macro_simple5 ->
 	    nope
+    end.
+
+%% macros in patterns
+foo6(?MACRO_SIMPLE2, ?macro_argument3(A)) ->
+    try foo2(A,A) of
+	R -> R
+    catch
+	?macro_argument3(B) ->
+	    B;
+	error:?macro_argument3(B) ->
+	    B;
+	error:?macro_argument3(B):_ ->
+	    B
     end.


### PR DESCRIPTION
The dodger used to replace a macro with a local function call. That works in
expressions but not in patterns like function heads or catch patterns. Instead
of a function call a tuple syntax is used which works in more places.

This change is motivated by the commonly used `?EXCEPTION` macro

```
try
  ...
catch
  ?EXCEPTION(Class, Reason, StackToken) ->
    ...
end.
```

Open source examples:
https://github.com/devinus/poolboy/commit/5d40cc517edc9bb8ee70756544167b63f66662f0
https://github.com/eproxus/meck/commit/558e925b48ce257b12e381080c851dc49c87d7bb

Fixes ERL-1429