### PR TITLE
Fix infinite loop in emulator startup

### DIFF
--- a/erts/emulator/sys/common/erl_poll.c
+++ b/erts/emulator/sys/common/erl_poll.c
@@ -646,6 +646,9 @@ int erts_poll_new_table_len(int old_len, int need_len)
     }
     else {
         new_len = old_len;
+        if (new_len < ERTS_FD_TABLE_MIN_LENGTH) {
+            new_len = ERTS_FD_TABLE_MIN_LENGTH;
+        }
         do {
             if (new_len < ERTS_FD_TABLE_EXP_THRESHOLD)
                 new_len *= 2;


### PR DESCRIPTION
The system hangs when 1024 file descriptors are open at startup:

    for ((i = 3; i < 1024; i++)); do
        eval "exec $i>&1;"
    done

    erl