### PR TITLE
Eliminate dialyzer crashing when analyzing try/catch

### DIFF
--- a/lib/dialyzer/test/small_SUITE_data/results/try2
+++ b/lib/dialyzer/test/small_SUITE_data/results/try2
@@ -1,0 +1,2 @@
+
+try2.erl:33: Function run3/2 has no local return

--- a/lib/dialyzer/test/small_SUITE_data/src/try2.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/try2.erl
@@ -1,0 +1,46 @@
+-module(try2).
+-export([main/0, run/2, run2/2, run3/2]).
+
+main() ->
+    try A = foo() of
+        _ -> A
+    after ok
+    end.
+
+foo() -> 1.
+
+run(Module, Args) ->
+    try
+        Module:main(Args),
+        halt(0)
+    catch
+        Class:Reason:StackTrace ->
+            format_exception(Class, Reason, StackTrace)
+    end.
+
+run2(Module, Args) ->
+    try
+        Result = Module:main(Args),
+        ok
+    of
+        ok ->
+            Result
+    catch
+        Class:Reason:StackTrace ->
+            format_exception(Class, Reason, StackTrace)
+    end.
+
+run3(Module, Args) ->                           %Function run3/2 has no local return
+    try
+        Result = error(badarg),
+        ok
+    of
+        ok ->
+            Result
+    catch
+        Class:Reason:StackTrace ->
+            format_exception(Class, Reason, StackTrace)
+    end.
+
+format_exception(Class, Reason, StackTrace) ->
+    erlang:raise(Class, Reason, StackTrace).


### PR DESCRIPTION
In commit 8a9a443a454327cbf17120f63664caa0973e9050 introduced by https://github.com/erlang/otp/pull/2662, a restriction regarding variables in try/catch was lifted, allowing variables bound between `try` and `of` to be used later:

    baz() ->
        try Bar = 0 of
          _ -> Bar
        after 0
        end.

(In OTP 23 and earlier that would be a compilation error because `Bar` would be considered unsafe.)

The lifted restriction was not properly handled by dialyzer. Attempting to analyze the the following module would crash dialyzer:

    -module(dialyzer_bug).
    -export([main/0]).

    main() ->
        try A = foo() of
            _ -> A
        after ok
        end.

    foo() -> 1.

https://bugs.erlang.org/browse/ERL-1454