### PR TITLE
crypto: disable EVP usage also for openssl-1.0.2

### DIFF
--- a/lib/crypto/c_src/openssl_config.h
+++ b/lib/crypto/c_src/openssl_config.h
@@ -120,7 +120,7 @@
 #endif
 
 #if defined(HAS_EVP_PKEY_CTX) \
-    && OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,0,2)
+    && OPENSSL_VERSION_NUMBER < PACKED_OPENSSL_VERSION_PLAIN(1,1,0)
      /* EVP is slow on antique crypto libs.
       * DISABLE_EVP_* is 0 or 1 from the configure script
       */


### PR DESCRIPTION
The initial fix for the crypto hmac performance loss (ERL-1400 / PR-2877) added code to automatically disable use of the EVP API for OpenSSL < 1.0.2. However, the EVP API is slow also in 1.0.2 as reported in ERL-1400. This adjusts the limit to < 1.1.0.

Tested on CentOS7 and verified it gives a decent speedup (roughly 30-40%) for the ERL-1400 test case.