### PR TITLE
ets: use initial salt different from phash2

### DIFF
--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -2792,6 +2792,13 @@ t_hashmap_balance(_Config) ->
     ok.
 
 hashmap_balance(KeyFun) ->
+    %% For uniformly distributed hash values, the average number of nodes N
+    %% in a hashmap varies between 0.3*K and 0.4*K where K is number of keys.
+    %% The standard deviation of N is about sqrt(K)/3.
+
+    %% For simplicity we use the higher expected average 0.4*K
+    %% and verfies that no map is too many standard deviation above it.
+
     F = fun(I, {M0,Max0}) ->
 		Key = KeyFun(I),
 		M1 = M0#{Key => Key},
@@ -2803,9 +2810,9 @@ hashmap_balance(KeyFun) ->
 			       SD_diff = abs(Nodes - Avg) / StdDev,
 			       %%io:format("~p keys: ~p nodes avg=~p SD_diff=~p\n",
 			       %%          [maps:size(M1), Nodes, Avg, SD_diff]),
-			       {MaxDiff0, _} = Max0,
+			       {MaxDiff0, _, Cnt} = Max0,
 			       case {Nodes > Avg, SD_diff > MaxDiff0} of
-				   {true, true} -> {SD_diff, M1};
+				   {true, true} -> {SD_diff, M1, Cnt+1};
 				   _ -> Max0
 			       end;
 
@@ -2814,13 +2821,15 @@ hashmap_balance(KeyFun) ->
 		{M1, Max1}
 	end,
 
-    {_,{MaxDiff,MaxMap}} = lists:foldl(F,
-				       {#{}, {0, undefined}},
-				       lists:seq(1,10000)),
+    {_,{MaxDiff,MaxMap, FatCnt}} = lists:foldl(F,
+					       {#{}, {0, undefined, 0}},
+					       lists:seq(1,10000)),
     case MaxMap of
 	undefined ->
-	    io:format("Wow, no maps below \"average\"\n", []);
+	    io:format("Wow, no map with more than \"average\" number of nodes\n");
 	_ ->
+	    io:format("Found ~p maps with more than \"average\" number of nodes\n",
+		      [FatCnt]),
 	    io:format("Max std dev diff ~p for map of size ~p (nodes=~p, flatsize=~p)\n",
 		      [MaxDiff, maps:size(MaxMap), hashmap_nodes(MaxMap),
 		       erts_debug:flat_size(MaxMap)])
@@ -2829,7 +2838,6 @@ hashmap_balance(KeyFun) ->
     true = (MaxDiff < 6),  % The probability of this line failing is about 0.000000001
                            % for a uniform hash. I've set the probability this "high" for now
                            % to detect flaws in our make_internal_hash.
-                           % Hard limit is 15 (see hashmap_over_estimated_heap_size).
     ok.
 
 hashmap_nodes(M) ->

--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -2815,10 +2815,16 @@ hashmap_balance(KeyFun) ->
 	end,
 
     {_,{MaxDiff,MaxMap}} = lists:foldl(F,
-				       {#{}, {0, 0}},
+				       {#{}, {0, undefined}},
 				       lists:seq(1,10000)),
-    io:format("Max std dev diff ~p for map of size ~p (nodes=~p, flatsize=~p)\n",
-	      [MaxDiff, maps:size(MaxMap), hashmap_nodes(MaxMap), erts_debug:flat_size(MaxMap)]),
+    case MaxMap of
+	undefined ->
+	    io:format("Wow, no maps below \"average\"\n", []);
+	_ ->
+	    io:format("Max std dev diff ~p for map of size ~p (nodes=~p, flatsize=~p)\n",
+		      [MaxDiff, maps:size(MaxMap), hashmap_nodes(MaxMap),
+		       erts_debug:flat_size(MaxMap)])
+    end,
 
     true = (MaxDiff < 6),  % The probability of this line failing is about 0.000000001
                            % for a uniform hash. I've set the probability this "high" for now

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -31,6 +31,7 @@
 -export([match_delete3/1]).
 -export([firstnext/1,firstnext_concurrent/1]).
 -export([slot/1]).
+-export([hash_clash/1]).
 -export([match1/1, match2/1, match_object/1, match_object2/1]).
 -export([dups/1, misc1/1, safe_fixtable/1, info/1, tab2list/1]).
 -export([info_binary_stress/1]).
@@ -132,7 +133,7 @@ suite() ->
 
 all() ->
     [{group, new}, {group, insert}, {group, lookup},
-     {group, delete}, firstnext, firstnext_concurrent, slot,
+     {group, delete}, firstnext, firstnext_concurrent, slot, hash_clash,
      {group, match}, t_match_spec_run,
      {group, lookup_element}, {group, misc}, {group, files},
      {group, heavy}, {group, insert_list}, ordered, ordered_match,
@@ -4560,6 +4561,16 @@ slot_loop(Tab,SlotNo,EltsSoFar) ->
 	Elts ->
 	    slot_loop(Tab,SlotNo+1,EltsSoFar+length(Elts))
     end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+hash_clash(Config) when is_list(Config) ->
+    %% ensure that erlang:phash2 and ets:slot use different hash seed
+    Tab = ets:new(tab, [set]),
+    Buckets = erlang:element(1, ets:info(Tab, stats)),
+    Phash = erlang:phash2(<<"123">>, Buckets),
+    true = ets:insert(Tab, {<<"123">>, "extra"}),
+    [] = ets:slot(Tab, Phash).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
It is convenient to use erlang:phash2 to determine frag (ETS table)
to use. If salt is the same, both phash2 and ets hashing generate
the same frag/bucket number.
Since ETS hash is not portable, there is no need to keep backwards
compatibility with previous releases.