### PR TITLE
jit: Output size of emitted code in assembly dumps

### DIFF
--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -337,6 +337,11 @@ protected:
         code.copyFlattenedData(*writable_ptr,
                                code.codeSize(),
                                CodeHolder::kCopyPadSectionBuffer);
+#ifdef DEBUG
+        if (FileLogger *l = dynamic_cast<FileLogger *>(code.logger()))
+            if (FILE *f = l->file())
+                fprintf(f, "; CODE_SIZE: %zd\n", code.codeSize());
+#endif
     }
 
     void *getCode(Label label) {


### PR DESCRIPTION
With this patch, a debug compiled emulator will output a line with
"; CODE_SIZE: <size in bytes>" at the end of the assembler dump files.