### PR TITLE
diffable: Stop diffable --dis from crashing when the JIT is used

### DIFF
--- a/scripts/diffable
+++ b/scripts/diffable
@@ -538,6 +538,8 @@ rejoin_atoms([Op|Ops]) ->
 rejoin_atoms([]) ->
     [].
 
+find_labels([], _Name, _Arity) ->
+    #{};
 find_labels(Is, Name, Arity) ->
     [_,[Entry|_]|_] = Is,
     EntryLabel = iolist_to_binary(io_lib:format("~p/~p", [Name,Arity])),


### PR DESCRIPTION
When testing the JIT code generator it is useful to run it on a large
number of functions. Running `diffable --dis` does just that, but as
disassembly of loaded code is not supported by the JIT, diffable
unfortunately crashes when trying to find labels in the empty output.

This patch changes diffable:find_labels/3 to not crash on empty input,
thus making diffable useful for exercising the JIT's code generator.