### PR TITLE
Add maps:foreach/2 function

### DIFF
--- a/lib/stdlib/doc/src/maps.xml
+++ b/lib/stdlib/doc/src/maps.xml
@@ -143,6 +143,20 @@
     </func>
 
     <func>
+      <name name="foreach" arity="2" since="OTP @OTP-17179@"/>
+      <fsummary>Apply a function to each element of a map.</fsummary>
+      <desc>
+        <p>Calls <c>fun F(Key, Value)</c> for every <c><anno>Key</anno></c>
+          to value <c><anno>Value</anno></c> association in
+          <c><anno>MapOrIter</anno></c> in any order.</p>
+        <p>The call fails with a <c>{badmap,Map}</c> exception if
+          <c><anno>MapOrIter</anno></c> is not a map or valid iterator,
+          or with <c>badarg</c> if <c><anno>Fun</anno></c> is not a
+          function of arity 2.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="from_keys" arity="2" since="OTP 14.0"/>
       <fsummary></fsummary>
       <desc>

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -182,6 +182,8 @@ format_maps_error(filter, Args) ->
     format_maps_error(map, Args);
 format_maps_error(filtermap, Args) ->
     format_maps_error(map, Args);
+format_maps_error(foreach, Args) ->
+    format_maps_error(map, Args);
 format_maps_error(find, _Args) ->
     [[], not_map];
 format_maps_error(fold, [Pred, _Init, Map]) ->

--- a/lib/stdlib/test/maps_SUITE.erl
+++ b/lib/stdlib/test/maps_SUITE.erl
@@ -29,7 +29,7 @@
 
 -export([t_update_with_3/1, t_update_with_4/1,
          t_get_3/1, t_filter_2/1, t_filtermap_2/1,
-         t_fold_3/1,t_map_2/1,t_size_1/1,
+         t_fold_3/1,t_map_2/1,t_size_1/1, t_foreach_2/1,
          t_iterator_1/1, t_put_opt/1, t_merge_opt/1,
          t_with_2/1,t_without_2/1,
          t_intersect/1, t_intersect_with/1,
@@ -47,7 +47,7 @@ suite() ->
 all() ->
     [t_update_with_3,t_update_with_4,
      t_get_3,t_filter_2,t_filtermap_2,
-     t_fold_3,t_map_2,t_size_1,
+     t_fold_3,t_map_2,t_size_1,t_foreach_2,
      t_iterator_1,t_put_opt,t_merge_opt,
      t_with_2,t_without_2,
      t_intersect, t_intersect_with,
@@ -200,6 +200,25 @@ t_map_2(Config) when is_list(Config) ->
     %% error case
     ?badmap(a,map,[_,a]) = (catch maps:map(fun(_,_) -> ok end, id(a))),
     ?badarg(map,[<<>>,#{}]) = (catch maps:map(id(<<>>),#{})),
+    ok.
+
+t_foreach_2(Config) when is_list(Config) ->
+    %% error case
+    ?badmap(a,foreach,[_,a]) = (catch maps:foreach(fun(_,_) -> ok end, id(a))),
+    ?badmap([],foreach,[_,[]]) = (catch maps:foreach(fun(_,_) -> ok end, id([]))),
+    ?badmap({},foreach,[_,{}]) = (catch maps:foreach(fun(_,_) -> ok end, id({}))),
+    ?badmap(42,foreach,[_,42]) = (catch maps:foreach(fun(_,_) -> ok end, id(42))),
+    ?badmap(<<>>,foreach,[_,<<>>]) = (catch maps:foreach(fun(_,_) -> ok end, id(<<>>))),
+
+    ?badarg(foreach,[<<>>,#{}]) = (catch maps:foreach(id(<<>>),#{})),
+    F0 = fun() -> ok end,
+    F3 = fun(_, _, _) -> ok end,
+    ?badarg(foreach,[F0, #{}]) = (catch maps:foreach(id(F0), #{})),
+    ?badarg(foreach,[F3, #{}]) = (catch maps:foreach(id(F3), #{})),
+    ?badarg(foreach,[a, #{}]) = (catch maps:foreach(id(a), #{})),
+    ?badarg(foreach,[[], #{}]) = (catch maps:foreach(id([]), #{})),
+    ?badarg(foreach,[{}, #{}]) = (catch maps:foreach(id({}), #{})),
+    ?badarg(foreach,[42, #{}]) = (catch maps:foreach(id(42), #{})),
     ok.
 
 t_iterator_1(Config) when is_list(Config) ->
@@ -530,6 +549,11 @@ error_info(_Config) ->
          {fold, [fun(_, _, _) -> true end, init, BadIterator]},
          {fold, [fun(_) -> true end, init, GoodIterator]},
          {fold, [fun(_) -> ok end, init, #{}]},
+
+         {foreach, [fun(_, _) -> ok end, no_map]},
+         {foreach, [fun(_, _) -> ok end, BadIterator]},
+         {foreach, [fun(_) -> ok end, GoodIterator]},
+         {foreach, [fun(_) -> ok end, #{}]},
 
          {from_keys, [#{a => b}, whatever]},
          {from_keys, [[a|b], whatever]},


### PR DESCRIPTION
This pull request introduces `foreach/2` for the maps module. A basic function to iterate over a map without an accumulator.