### PR TITLE
inet_tcp, inet6_tcp: do not bind connecting sockets by default

### DIFF
--- a/lib/kernel/src/inet6_tcp.erl
+++ b/lib/kernel/src/inet6_tcp.erl
@@ -120,12 +120,12 @@ do_connect(Addr = {A,B,C,D,E,F,G,H}, Port, Opts, Time)
 	{ok,
 	 #connect_opts{
 	    fd = Fd,
-	    ifaddr = BAddr = {Ab,Bb,Cb,Db,Eb,Fb,Gb,Hb},
+	    ifaddr = BAddr,
 	    port = BPort,
 	    opts = SockOpts}}
-	when ?ip6(Ab,Bb,Cb,Db,Eb,Fb,Gb,Hb), ?port(BPort) ->
+	when ?port(BPort) ->
 	    case inet:open(
-		   Fd, BAddr, BPort, SockOpts,
+		   Fd, check_ip_format(BAddr), BPort, SockOpts,
 		   ?PROTO, ?FAMILY, ?TYPE, ?MODULE) of
 		{ok, S} ->
 		    case prim_inet:connect(S, Addr, Port, Time) of
@@ -136,6 +136,13 @@ do_connect(Addr = {A,B,C,D,E,F,G,H}, Port, Opts, Time)
 	    end;
 	{ok, _} -> exit(badarg)
     end.
+
+check_ip_format(undefined) ->
+	undefined;
+check_ip_format(Ip = {Ab,Bb,Cb,Db,Eb,Fb,Gb,Hb}) when ?ip6(Ab,Bb,Cb,Db,Eb,Fb,Gb,Hb) ->
+	Ip;
+check_ip_format(_) ->
+	exit(badarg).
 
 %% 
 %% Listen

--- a/lib/kernel/src/inet_int.hrl
+++ b/lib/kernel/src/inet_int.hrl
@@ -395,7 +395,7 @@
 %%
 -record(connect_opts, 
 	{ 
-	  ifaddr = any,     %% bind to interface address
+	  ifaddr = undefined,   %% don't bind explicitly, let connect decide
 	  port   = 0,       %% bind to port (default is dynamic port)
 	  fd     = -1,      %% fd >= 0 => already bound
 	  opts   = []       %% [{active,true}] added in inet:connect_options

--- a/lib/kernel/src/inet_tcp.erl
+++ b/lib/kernel/src/inet_tcp.erl
@@ -117,12 +117,12 @@ do_connect(Addr = {A,B,C,D}, Port, Opts, Time)
 	{ok,
 	 #connect_opts{
 	    fd = Fd,
-	    ifaddr = BAddr = {Ab,Bb,Cb,Db},
+	    ifaddr = BAddr,
 	    port = BPort,
 	    opts = SockOpts}}
-	when ?ip(Ab,Bb,Cb,Db), ?port(BPort) ->
+	when ?port(BPort) ->
 	    case inet:open(
-		   Fd, BAddr, BPort, SockOpts,
+		   Fd, check_ip_format(BAddr), BPort, SockOpts,
 		   ?PROTO, ?FAMILY, ?TYPE, ?MODULE) of
 		{ok, S} ->
 		    case prim_inet:connect(S, Addr, Port, Time) of
@@ -133,6 +133,13 @@ do_connect(Addr = {A,B,C,D}, Port, Opts, Time)
 	    end;
 	{ok, _} -> exit(badarg)
     end.
+
+check_ip_format(undefined) ->
+	undefined;
+check_ip_format(Ip = {Ab,Bb,Cb,Db}) when ?ip(Ab,Bb,Cb,Db) ->
+	Ip;
+check_ip_format(_) ->
+	exit(badarg).
 
 %% 
 %% Listen

--- a/lib/kernel/src/local_tcp.erl
+++ b/lib/kernel/src/local_tcp.erl
@@ -105,16 +105,10 @@ do_connect(Addr = {?FAMILY, _}, 0, Opts, Time) ->
 	    port = 0,
 	    opts = SockOpts}}
 	when tuple_size(BAddr) =:= 2, element(1, BAddr) =:= ?FAMILY;
-	     BAddr =:= any ->
+	     BAddr =:= undefined ->
 	    case inet:open(
-		   Fd,
-		   case BAddr of
-		       any ->
-			   undefined;
-		       _ ->
-			   BAddr
-		   end,
-		   0, SockOpts, ?PROTO, ?FAMILY, ?TYPE, ?MODULE) of
+		   Fd, BAddr, 0, SockOpts,
+                   ?PROTO, ?FAMILY, ?TYPE, ?MODULE) of
 		{ok, S} ->
 		    case prim_inet:connect(S, Addr, 0, Time) of
 			ok -> {ok,S};


### PR DESCRIPTION
There is no need to bind a socket intended to be used for outgoing
connection. This operation exhaust ephemeral port range, preventing
large number of concurrent outgoing connections.
Omitting bind call also saves an extra trip to kernel.

There is no reliable way to test this, as different platforms have
various limitations on number of file descriptors open, ephemeral
port count and socket allocation mechanisms.

Manual testing can be done using this code:

  verify(0) ->
      ok;
  verify(Remain) ->
      receive
          {result, {error, Good}} when Good =:= timeout; Good =:= econnrefused ->
              verify(Remain - 1);
          {result, Any} ->
              Any
      end.

  test_conn() ->
      Self = self(),
      Expect = 66000, %% this number is guaranteed to be larger than ephemeral port count
      [spawn(
          fun() ->
              Res = catch (gen_tcp:connect(
                  {10, 20, (Seq div 254 + 1) rem 254, Seq rem 254 + 1}, 12345, [], 5000)),
              Self ! {result, Res}
          end) || Seq <- lists:seq(1, Expect)],
      verify(Expect).

To run this code, system must be configured for high file descriptor limit
(e.g."ulimit -n 100000").