### PR TITLE
Add wxWebView to base images

### DIFF
--- a/.github/dockerfiles/Dockerfile.debian-base
+++ b/.github/dockerfiles/Dockerfile.debian-base
@@ -9,7 +9,7 @@ ARG BASE=debian
 ARG HOST_ARCH=amd64
 ARG HOST_TRIP=x86_64-linux-gnu
 
-ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssh-dev unixodbc-dev libgmp3-dev libwxbase3.0-dev libwxgtk3.0-dev libsctp-dev lksctp-tools"
+ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssh-dev unixodbc-dev libgmp3-dev libwxbase3.0-dev libwxgtk3.0-dev libwxgtk-webview3.0-gtk3-dev libsctp-dev lksctp-tools"
 
 ## See https://wiki.debian.org/Multiarch/HOWTO for details on how to install things
 RUN if [ "$BASE" = "i386/debian" ]; then BUILD_ARCH=`dpkg --print-architecture` && \

--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -3,7 +3,7 @@
 ##
 FROM ubuntu
 
-ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssh-dev unixodbc-dev libgmp3-dev libwxbase3.0-dev libwxgtk3.0-gtk3-dev libsctp-dev lksctp-tools"
+ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssh-dev unixodbc-dev libgmp3-dev libwxbase3.0-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev libsctp-dev lksctp-tools"
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This adds the `libwxgtk-webview3.0-gtk3-dev` build dependency for wxWebView to the base images. This is a prerequisite to pull in https://github.com/diodechain/otp/tree/letz/wxWebView which only builds if the dependencies are installed. @dgud 