### PR TITLE
Allow h4,h5 and h6 headers in application/erlang+html EEP-48 documentation

### DIFF
--- a/lib/erl_docgen/doc/src/doc_storage.xml
+++ b/lib/erl_docgen/doc/src/doc_storage.xml
@@ -61,7 +61,8 @@
 -type chunk_element_type() :: chunk_element_inline_type() | chunk_element_block_type().
 -type chunk_element_inline_type() :: a | code |  em | i.
 -type chunk_element_block_type() :: p | 'div' | br | pre | ul |
-                              ol | li | dl | dt | dd | h1 | h2 | h3.
+                                    ol | li | dl | dt | dd |
+                                    h1 | h2 | h3 | h4 | h5 | h6.
       </code>
       <p>The different element types follow their HTML meaning when rendered.
         The following are some general rules for how the chunk elements are allowed

--- a/lib/erl_docgen/doc/src/doc_storage.xml
+++ b/lib/erl_docgen/doc/src/doc_storage.xml
@@ -59,7 +59,7 @@
 -type chunk_element_attrs() :: [chunk_element_attr()].
 -type chunk_element_attr() :: {atom(),unicode:unicode_binary()}.
 -type chunk_element_type() :: chunk_element_inline_type() | chunk_element_block_type().
--type chunk_element_inline_type() :: a | code |  em | i.
+-type chunk_element_inline_type() :: a | code | strong | b | em | i.
 -type chunk_element_block_type() :: p | 'div' | br | pre | ul |
                                     ol | li | dl | dt | dd |
                                     h1 | h2 | h3 | h4 | h5 | h6.

--- a/lib/erl_docgen/src/docgen_xml_to_chunk.erl
+++ b/lib/erl_docgen/src/docgen_xml_to_chunk.erl
@@ -228,7 +228,7 @@ build_dom({ignorableWhitespace, String},
           #state{dom=[{Name,_,_} = _E|_]} = State) ->
     case lists:member(Name,
                       [p,pre,input,code,quote,warning,
-                       note,dont,do,c,i,em,strong,
+                       note,dont,do,c,b,i,em,strong,
                        seemfa,seeerl,seetype,seeapp,
                        seecom,seecref,seefile,seeguide,
                        tag,item]) of
@@ -354,8 +354,6 @@ transform([{datatype_title,_Attr,_Content}|T],Acc) ->
 %% transform <desc>Content</desc> to Content
 transform([{desc,_Attr,Content}|T],Acc) ->
     transform(T,[transform(Content,[])|Acc]);
-transform([{strong,Attr,Content}|T],Acc) ->
-    transform([{em,Attr,Content}|T],Acc);
 %% transform <marker id="name"/>  to <a id="name"/>....
 transform([{marker,Attrs,Content}|T],Acc) ->
     transform(T,[{a,a2b(Attrs),transform(Content,[])}|Acc]);

--- a/lib/erl_docgen/src/docgen_xml_to_chunk.erl
+++ b/lib/erl_docgen/src/docgen_xml_to_chunk.erl
@@ -692,18 +692,16 @@ to_chunk(Dom, Source, Module, AST) ->
                       end,
 
                   MetaDepr
-                      = case otp_internal:obsolete_type(Module, TypeName, TypeArity) of
-                            %% Commented out to make dialyzer happy
-                            %% {deprecated, Text} ->
-                            %%     MetaSig#{ deprecated =>
-                            %%                   unicode:characters_to_binary(
-                            %%                     erl_lint:format_error({deprecated_type,{Module,TypeName,TypeArity}, Text})) };
-
-                            %% Commented out to make dialyzer happy
-                            %% {deprecated, Replacement, Rel} ->
-                            %%     MetaSig#{ deprecated =>
-                            %%                   unicode:characters_to_binary(
-                            %%                     erl_lint:format_error({deprecated_type,{Module,TypeName,TypeArity}, Replacement, Rel})) };
+                      = case apply(otp_internal,obsolete_type,[Module, TypeName, TypeArity]) of
+                            %% apply/3 in order to silence dialyzer
+                            {deprecated, Text} ->
+                                MetaSig#{ deprecated =>
+                                              unicode:characters_to_binary(
+                                                erl_lint:format_error({deprecated_type,{Module,TypeName,TypeArity}, Text})) };
+                            {deprecated, Replacement, Rel} ->
+                                MetaSig#{ deprecated =>
+                                              unicode:characters_to_binary(
+                                                erl_lint:format_error({deprecated_type,{Module,TypeName,TypeArity}, Replacement, Rel})) };
                             {removed, _Text} ->
                                 %% Just skip
                                 MetaSig;
@@ -725,7 +723,8 @@ to_chunk(Dom, Source, Module, AST) ->
                   FMeta = proplists:get_value(meta,Attr),
                   MetaWSpec = add_spec(AST,FMeta),
                   MetaDepr
-                      = case otp_internal:obsolete(Module, Name, Arity) of
+                      = case apply(otp_internal,obsolete,[Module, Name, Arity]) of
+                            %% apply/3 in order to silence dialyzer
                             {deprecated, Text} ->
                                 MetaWSpec#{ deprecated =>
                                                 unicode:characters_to_binary(

--- a/lib/kernel/doc/src/application.xml
+++ b/lib/kernel/doc/src/application.xml
@@ -371,12 +371,12 @@ Nodes = [cp1@cave, {cp2@cave, cp3@cave}]</code>
         <list type="bulleted">
           <item>If a permanent application terminates, all other
            applications and the entire Erlang node are also terminated.</item>
-          <item>
+          <item>If a transient application terminates:
 	    <list type="bulleted">
-	      <item>If a transient application terminates with <c>Reason == normal</c>,
-	      this is reported but no other applications are terminated.</item>
-	      <item>If a transient application terminates abnormally, all other
-	      applications and the entire Erlang node are also terminated.</item>
+	      <item>with <c>Reason == normal</c>, this is reported but no other
+                applications are terminated.</item>
+	      <item>abnormally, all other applications and the entire Erlang
+                node are also terminated.</item>
 	    </list>
 	   </item>
           <item>If a temporary application terminates, this is reported

--- a/lib/stdlib/doc/src/array.xml
+++ b/lib/stdlib/doc/src/array.xml
@@ -356,9 +356,9 @@ array:new([{size,10},{fixed,false},{default,-1}])</pre>
           Notice that any size specifications in <c><anno>Options</anno></c>
           override parameter <c><anno>Size</anno></c>.</p>
         <p>If <c><anno>Options</anno></c> is a list, this is equivalent to
-          <c>new([{size, <anno>Size</anno>} | <anno>Options</anno>]</c>,
+          <c>new([{size, <anno>Size</anno>} | <anno>Options</anno>])</c>,
           otherwise it is equivalent to <c>new([{size, <anno>Size</anno>} |
-          [<anno>Options</anno>]]</c>. However, using this function directly is
+          [<anno>Options</anno>]])</c>. However, using this function directly is
           more efficient.</p>
         <p><em>Example:</em></p>
         <pre>

--- a/lib/stdlib/doc/src/shell_docs.xml
+++ b/lib/stdlib/doc/src/shell_docs.xml
@@ -162,5 +162,14 @@
       </desc>
     </func>
 
+    <func>
+      <name name="supported_tags" arity="0" since="OTP @OTP-17120@"/>
+      <fsummary>Which tags are supported</fsummary>
+      <desc>
+        <p>This function can be used to find out which tags are
+          supported by <c>application/erlang+html</c> documentation.</p>
+      </desc>
+    </func>
+
   </funcs>
 </erlref>

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -252,6 +252,9 @@ format_error({deprecated, MFA, String, Rel}) ->
 		  [format_mfa(MFA), Rel, String]);
 format_error({deprecated, MFA, String}) when is_list(String) ->
     io_lib:format("~s is deprecated; ~s", [format_mfa(MFA), String]);
+format_error({deprecated_type, {M1, F1, A1}, String, Rel}) ->
+    io_lib:format("the type ~p:~p~s is deprecated and will be removed in ~s; ~s",
+                  [M1, F1, gen_type_paren(A1), Rel, String]);
 format_error({deprecated_type, {M1, F1, A1}, String}) when is_list(String) ->
     io_lib:format("the type ~p:~p~s is deprecated; ~s",
                   [M1, F1, gen_type_paren(A1), String]);

--- a/lib/stdlib/src/shell_docs.erl
+++ b/lib/stdlib/src/shell_docs.erl
@@ -19,6 +19,17 @@
 %%
 -module(shell_docs).
 
+%% This module takes care of rendering and normalization of
+%% application/erlang+html style documentation.
+
+
+%% IMPORTANT!!
+%% When changing the rendering in the module, there are no tests as such
+%% that you do not break anything else. So you should use the function
+%% shell_docs_SUITE:render_all(Dir) to write all documentation to that
+%% folder and then you can use `diff -b` to see if you inadvertently changed
+%% something.
+
 -include_lib("kernel/include/eep48.hrl").
 
 -export([render/2, render/3, render/4, render/5]).

--- a/lib/stdlib/src/shell_docs.erl
+++ b/lib/stdlib/src/shell_docs.erl
@@ -37,7 +37,7 @@
 -export([render_callback/2, render_callback/3, render_callback/4, render_callback/5]).
 
 %% Used by chunks.escript in erl_docgen
--export([validate/1, normalize/1]).
+-export([validate/1, normalize/1, supported_tags/0]).
 
 %% Convinience functions
 -export([get_doc/1, get_doc/3, get_type_doc/3, get_callback_doc/3]).
@@ -77,6 +77,10 @@
 -type chunk_element_block_type() :: p | 'div' | br | pre | ul |
                                     ol | li | dl | dt | dd |
                                     h1 | h2 | h3 | h4 | h5 | h6.
+
+-spec supported_tags() -> [chunk_element_type()].
+supported_tags() ->
+    ?ALL_ELEMENTS.
 
 -spec validate(Module) -> ok when
       Module :: module() | docs_v1().


### PR DESCRIPTION
This is needed as edoc (implemented in #2803) can emit such headers.