### PR TITLE
Fix cover bug when there is an export named clauses

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -2350,6 +2350,8 @@ patch_code1({'BUMP',_Line,Index}, {local_only,AbstrCref}) ->
      [AbstrCref,{integer,A,Index},{integer,A,1}]};
 patch_code1({clauses,Cs}, Key) ->
     {clauses,[patch_code1(El, Key) || El <- Cs]};
+patch_code1({attribute, _, _, _} = Attribute, _Key) ->
+    Attribute;
 patch_code1([_|_]=List, Key) ->
     [patch_code1(El, Key) || El <- List];
 patch_code1(Tuple, Key) when tuple_size(Tuple) >= 3 ->

--- a/lib/tools/test/cover_SUITE.erl
+++ b/lib/tools/test/cover_SUITE.erl
@@ -37,7 +37,7 @@ all() ->
                  dont_reconnect_after_stop, stop_node_after_disconnect,
                  export_import, otp_5031, otp_6115,
                  otp_8270, otp_10979_hanging_node, otp_14817,
-                 local_only, startup_race, otp_16476],
+                 local_only, startup_race, otp_16476, cover_clauses],
     case whereis(cover_server) of
         undefined ->
             [coverage,StartStop ++ NoStartStop];
@@ -1598,6 +1598,15 @@ otp_14817(Config) when is_list(Config) ->
     <<"1..|",_/binary>> = string:find(Bin, "1..|"),
     ok = file:delete(File),
     ok = file:delete(CovOut),
+    ok.
+
+%% Tests a bug where cover failed for an export named clauses
+cover_clauses(Config) when is_list(Config) ->
+    Test = <<"-module(cover_clauses).
+              -export([clauses/0]).
+              clauses() -> ok.
+             ">>,
+    File = cc_mod(cover_clauses, Test, Config),
     ok.
 
 %% Take compiler options from beam in cover:compile_beam


### PR DESCRIPTION
If there was an export in the shape of {clauses, Arity},
cover would attempt to handle it as the {clauses, List}
AST node, leading to the failure below:

```
=ERROR REPORT==== 23-Jan-2021::10:04:20.945556 ===
Error in process <0.159.0> with exit value: {{bad_generator,0},
 [{cover,'-patch_code1/2-lc$^0/1-1-',2,[{file,"cover.erl"},{line,2352}]},
  {cover,patch_code1,2,[{file,"cover.erl"},{line,2352}]},
  {cover,'-patch_code1/2-lc$^1/1-0-',2,[{file,"cover.erl"},{line,2354}]},
  {cover,patch_code_tuple,5,[{file,"cover.erl"},{line,2362}]},
  {cover,'-patch_code1/2-lc$^1/1-0-',2,[{file,"cover.erl"},{line,2354}]},
  {cover,'-patch_code1/2-lc$^1/1-0-',2,[{file,"cover.erl"},{line,2354}]},
  {cover,transform,4,[{file,"cover.erl"},{line,1820}]},
  {cover,do_compile_beam2,6,[{file,"cover.erl"},{line,1762}]}]}
  ```

The fix is to skip all attributes when traversing the
forms.