### PR TITLE
Reconnect to epmd

### DIFF
--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -430,9 +430,6 @@ io:format("old/unused name ~ts at port ~p, fd = ~p ~n",
 
       <p>where n = <c>Length</c> - 1.</p>
 
-      <p>The current implementation of Erlang does not care if the connection
-        to the EPMD is broken.</p>
-
       <p>The response for a <c>STOP_REQ</c> is as follows:</p>
 
       <table align="left">

--- a/lib/kernel/doc/src/erl_epmd.xml
+++ b/lib/kernel/doc/src/erl_epmd.xml
@@ -56,8 +56,10 @@
       <desc>
         <p>Registers the node with <c>epmd</c> and tells epmd what port will be
         used for the current node. It returns a creation number. This number is
-        incremented on each register to help with identifying if a node is
-        reconnecting to epmd.</p>
+        incremented on each register to help differentiate a new node instance
+        connecting to epmd with the same name.</p>
+	<p>After the node has successfully registered with epmd it will automatically
+	attempt reconnect to the daemon if the connection is broken.</p>
       </desc>
     </func>
 

--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -53,12 +53,14 @@
 
 -import(lists, [reverse/1]).
 
--record(state, {socket, port_no = -1, name = ""}).
+-record(state, {socket, port_no = -1, name = "", family}).
 -type state() :: #state{}.
 
 -include("inet_int.hrl").
 -include("erl_epmd.hrl").
 -include_lib("kernel/include/inet.hrl").
+
+-define(RECONNECT_TIME, 2000).
 
 %%%----------------------------------------------------------------------
 %%% API
@@ -228,7 +230,8 @@ handle_call({register, Name, PortNo, Family}, _From, State) ->
 		{alive, Socket, Creation} ->
 		    S = State#state{socket = Socket,
 				    port_no = PortNo,
-				    name = Name},
+				    name = Name,
+				    family = Family},
 		    {reply, {ok, Creation}, S};
                 Error ->
                     case init:get_argument(erl_epmd_port) of
@@ -263,7 +266,17 @@ handle_cast(_, State) ->
 -spec handle_info(term(), state()) -> {'noreply', state()}.
 
 handle_info({tcp_closed, Socket}, State) when State#state.socket =:= Socket ->
+    erlang:send_after(?RECONNECT_TIME, self(), reconnect),
     {noreply, State#state{socket = -1}};
+handle_info(reconnect, State) when State#state.socket =:= -1 ->
+    case do_register_node(State#state.name, State#state.port_no, State#state.family) of
+	{alive, Socket, _Creation} ->
+            %% ignore the received creation
+            {noreply, State#state{socket = Socket}};
+	_Error ->
+	    erlang:send_after(?RECONNECT_TIME, self(), reconnect),
+	    {noreply, State}
+    end;
 handle_info(_, State) ->
     {noreply, State}.
 


### PR DESCRIPTION
Currently when the connection from a distributed node to epmd is lost, there is no attempt by the node to reconnect.
This leaves the node invisible to other nodes in the distribution that it is not already connected to.
This PR adds simple reconnect functionality.
If connecting to an epmd without big creation numbers, keep reconnecting until the original creation is received in order to avoid a later invocation of the same node name getting the same creation.