### PR TITLE
jinterface: make OtpErlangExternalFun transparent

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpErlangExternalFun.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpErlangExternalFun.java
@@ -23,9 +23,9 @@ public class OtpErlangExternalFun extends OtpErlangObject {
     // don't change this!
     private static final long serialVersionUID = 6443965570641913886L;
 
-    private final String module;
-    private final String function;
-    private final int arity;
+    public final String module;
+    public final String function;
+    public final int arity;
 
     public OtpErlangExternalFun(final String module, final String function,
             final int arity) {


### PR DESCRIPTION
Not being able to access the internals of OtpErlangExternalFun is problematic.
The real use case: performing some analysis of Core Erlang (cerl) from inside java/scala - the construct `fun module:fun/arity` is represented as "itself", and when accessing cerl forms from jinterface - it's represented as OtpErlangExternalFun correspondingly.  Unfortunately, - the internals are private, - which makes some forms of Erlang core not analysable through jinterface.

Also, - since all `module`, `function` and `arity` fields are final/immutable - it doesn't make much sense to hide/incapsulate them.