### PR TITLE
syntax_tools: Allow merl quote functions to accept an erl_anno:anno()

### DIFF
--- a/lib/syntax_tools/src/merl.erl
+++ b/lib/syntax_tools/src/merl.erl
@@ -310,7 +310,7 @@
 %% while a flat string or binary represents source code containing newlines.
 -type text() :: string() | binary() | [string()] | [binary()].
 
--type location() :: erl_anno:location().
+-type location() :: erl_anno:location() | erl_anno:anno().
 
 
 %% ------------------------------------------------------------------------
@@ -324,7 +324,7 @@ compile(Code) ->
 %% into a binary BEAM object.
 %% @see compile_and_load/2
 %% @see compile/1
-compile(Code, Options) when not is_list(Code)->
+compile(Code, Options) when not is_list(Code) ->
     case type(Code) of
         form_list -> compile(erl_syntax:form_list_elements(Code));
         _ -> compile([Code], Options)
@@ -471,11 +471,11 @@ quote(Text) ->
 %%
 %% @see quote/1
 
-quote({Line, Col}, Text)
-  when is_integer(Line), is_integer(Col) ->
-    quote_1(Line, Col, Text);
-quote(StartPos, Text) when is_integer(StartPos) ->
-    quote_1(StartPos, undefined, Text).
+quote(StartPos, Text) ->
+    Anno = erl_anno:from_term(StartPos),
+    StartLine = erl_anno:line(Anno),
+    StartCol = erl_anno:column(Anno),
+    quote_1(StartLine, StartCol, Text).
 
 quote_1(StartLine, StartCol, Text) ->
     %% be backwards compatible as far as R12, ignoring any starting column
@@ -1247,7 +1247,7 @@ a0() ->
     anno(0).
 
 anno(Location) ->
-    erl_anno:new(Location).
+    erl_anno:from_term(Location).
 
 get_line(Tree) ->
     Anno = erl_syntax:get_pos(Tree),

--- a/lib/syntax_tools/test/merl_SUITE.erl
+++ b/lib/syntax_tools/test/merl_SUITE.erl
@@ -9,11 +9,11 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% The Initial Developer of the Original Code is Ericsson Utvecklings AB.
 %% Portions created by Ericsson are Copyright 1999, Ericsson Utvecklings
 %% AB. All Rights Reserved.''
-%% 
+%%
 -module(merl_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
@@ -25,21 +25,22 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% Test server specific exports
--export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2]).
 
 %% Test cases
 -export([merl_smoke_test/1,
-         transform_parse_error_test/1, otp_15291/1]).
+         transform_parse_error_test/1, otp_15291/1, anno_test/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
     [merl_smoke_test,
      transform_parse_error_test,
-     otp_15291].
+     otp_15291,
+     anno_test].
 
-groups() -> 
+groups() ->
     [].
 
 init_per_suite(Config) ->
@@ -111,6 +112,13 @@ otp_15291(_Config) ->
     C1 = merl:quote("(_) -> ok"),
     {clause,A1,[{var,A1,'_'}],[],[{atom,A1,ok}]} = C1,
     ok.
+
+anno_test(_Config) ->
+    Anno0 = erl_anno:new(2),
+    Anno1 = erl_anno:set_file(?FILE, Anno0),
+    ?assert(is_integer(Anno0)),
+    ?assertNot(is_integer(Anno1)),
+    merl:quote(Anno1, "{foo, bar}").
 
 %% utilities
 


### PR DESCRIPTION
Merl currently assumes all annotations are locations, which can be
either an integer or a two-tuple of integers. However, erl_anno
supports more fields, like file and text. This is done through an
opaque type, which is actually a proplist.

OTP adds support for column numbers, and it would be nice if
merl would support those somewhere down the line. A first step
would be to allow the quote function(s) to accept the full
erl_anno:anno() type. It currently pulls the location and then
continues as normal.

I also renamed Line to Location in merl_transform to make it clear
that it can be both a integer and tuple of integers. Later perhaps
a full anno, but not now..

---

I'm not sure what to call the test, but I noticed `otp_15291`, is that named after some issue number? Should I change the name to this PR's number?