### PR TITLE
Explain {continue,Continue} in gen_server:Module:init/1 doc

### DIFF
--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -1027,9 +1027,10 @@ gen_server:abcast     -----> Module:handle_cast/2
         <p><c>Args</c> is the <c>Args</c> argument provided to the start
           function.</p>
         <p>If the initialization is successful, the function is to
-          return <c>{ok,State}</c>, <c>{ok,State,Timeout}</c>, or
-          <c>{ok,State,hibernate}</c>, where <c>State</c> is the internal
-          state of the <c>gen_server</c> process.</p>
+          return <c>{ok,State}</c>, <c>{ok,State,Timeout}</c>,
+          <c>{ok,State,hibernate}</c>, or <c>{ok,State,{continue,Continue}}</c>
+          where <c>State</c> is the internal state of the <c>gen_server</c>
+           process.</p>
         <p>If an integer time-out value is provided, a time-out occurs
           unless a request or a message is received within
           <c>Timeout</c> milliseconds. A time-out is represented by
@@ -1043,6 +1044,10 @@ gen_server:abcast     -----> Module:handle_cast/2
           hibernation when waiting for the next message to arrive (by calling 
           <seemfa marker="proc_lib#hibernate/3">
           <c>proc_lib:hibernate/3</c></seemfa>).</p>
+        <p>If <c>{continue,Continue}</c> is specified, the process will
+          execute the <seemfa marker="#Module:handle_continue/2">
+          <c>Module:handle_continue/2</c></seemfa> callback function, with
+          <c>Continue</c> as the first argument.</p>
         <p>If the initialization fails, the function is to return
           <c>{stop,Reason}</c>, where <c>Reason</c> is any term, or
           <c>ignore</c>. An exit signal with this <c>Reason</c> (or with reason

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -395,9 +395,10 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 	{ok, {ok, State}} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
 	    loop(Parent, Name, State, Mod, infinity, HibernateAfterTimeout, Debug);
-	{ok, {ok, State, Timeout}} ->
+	{ok, {ok, State, TimeoutHibernateOrContinue}} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
-	    loop(Parent, Name, State, Mod, Timeout, HibernateAfterTimeout, Debug);
+	    loop(Parent, Name, State, Mod, TimeoutHibernateOrContinue,
+	         HibernateAfterTimeout, Debug);
 	{ok, {stop, Reason}} ->
 	    %% For consistency, we must make sure that the
 	    %% registered name (if any) is unregistered before


### PR DESCRIPTION
The value or the usage of `{continue,Continue}` is not explained on the documentation of `Module:init/1`. Although the meaning of `{continue,Continue}` and `handle_continue/2` are explained at the beginning of the gen_server documentation, I believe the context is lost if one is only reading the documentation of the individual functions, instead of reading the documentation for the entire module.

In the same vein, if one is reading the code for `gen_server`, the term `Timeout` might be confusing, because it can also refer to other values (`hibernate` or `continue`).