### PR TITLE
Make the SSA instruction bs_put conform to failure conventions

### DIFF
--- a/lib/compiler/src/beam_ssa_pre_codegen.erl
+++ b/lib/compiler/src/beam_ssa_pre_codegen.erl
@@ -835,18 +835,15 @@ sanitize_is([#b_set{op={succeeded,Kind},args=[Arg0]} | Is],
             true = Kind =:= guard orelse Kind =:= body, %Assertion.
             sanitize_is(Is, Last, Count, Values, true, Acc)
     end;
-sanitize_is([#b_set{op=Op}=I|Is], Last, Count, Values, Changed, Acc) ->
+sanitize_is([#b_set{op=bs_test_tail}=I], Last, Count, Values, Changed, Acc) ->
     case Last of
         #b_br{succ=Same,fail=Same} ->
-            case is_test_op(Op) of
-                true ->
-                    sanitize_is(Is, Last, Count, Values, true, Acc);
-                false ->
-                    do_sanitize_is(I, Is,  Last, Count, Values, Changed, Acc)
-            end;
+            sanitize_is([], Last, Count, Values, true, Acc);
         _ ->
-            do_sanitize_is(I, Is,  Last, Count, Values, Changed, Acc)
+            do_sanitize_is(I, [], Last, Count, Values, Changed, Acc)
     end;
+sanitize_is([#b_set{}=I|Is], Last, Count, Values, Changed, Acc) ->
+    do_sanitize_is(I, Is,  Last, Count, Values, Changed, Acc);
 sanitize_is([], Last, Count, Values, Changed, Acc) ->
     case Changed of
         true ->
@@ -855,10 +852,6 @@ sanitize_is([], Last, Count, Values, Changed, Acc) ->
             no_change
     end.
 
-is_test_op(bs_put) -> true;
-is_test_op(bs_test_tail) -> true;
-is_test_op(_) -> false.
-    
 do_sanitize_is(#b_set{op=Op,dst=Dst,args=Args0}=I0,
                Is, Last, Count, Values, Changed0, Acc) ->
     Args = sanitize_args(Args0, Values),

--- a/lib/compiler/src/beam_ssa_recv.erl
+++ b/lib/compiler/src/beam_ssa_recv.erl
@@ -191,10 +191,6 @@ scan_is([#b_set{op=new_try_tag,dst=Dst}], Blk, Lbl, _Blocks, FuncId, State) ->
     %% ignore that branch.
     #b_br{bool=Dst,succ=Succ} = Blk#b_blk.last, %Assertion.
     scan_add_edge({FuncId, Lbl}, {FuncId, Succ}, State);
-scan_is([#b_set{op=bs_put}], Blk, Lbl, Blocks, FuncId, State) ->
-    %% This may throw and returns a success variable, so we'll treat it as
-    %% that.
-    scan_is([#b_set{op={succeeded,body}}], Blk, Lbl, Blocks, FuncId, State);
 scan_is([#b_set{op=call,args=[#b_remote{} | _]}=Call | Is],
         Blk, Lbl, Blocks, FuncId, State0) ->
     case {Is, Blk#b_blk.last} of

--- a/lib/compiler/test/bs_construct_SUITE.erl
+++ b/lib/compiler/test/bs_construct_SUITE.erl
@@ -392,6 +392,9 @@ in_guard(Config) when is_list(Config) ->
 
     ok = in_guard_4(<<15:4>>, 255),
     nope = in_guard_4(<<15:8>>, 255),
+
+    nope = catch in_guard_5(),
+
     ok.
 
 in_guard_1(Bin, A, B) when <<A:13,B:3>> == Bin -> 1;
@@ -411,6 +414,10 @@ in_guard_3(_, _) -> nope.
 
 in_guard_4(Bin, A) when <<A:4>> =:= Bin -> ok;
 in_guard_4(_, _) -> nope.
+
+%% Would crash beam_ssa_recv when the no_copt option was given.
+in_guard_5() when 0; <<'':32,<<42/native>>>> -> ok;
+in_guard_5() -> nope.
 
 in_catch(Config) when is_list(Config) ->
     <<42,0,5>> = small(42, 5),


### PR DESCRIPTION
There is a convention in SSA code that an instruction that can fail
must be immediately followed by a `succeeded:Kind` instruction. For
example, a BIF call in a body would look like this:

    Result = bif:Bif Arg, ...
    Bool = succeeded:body Result
    br Bool, ^Success, ^Fail

Because the `bs_put` instruction does not have any return value,
we did not originally follow the failure convention, but instead
made it behave like a guard test:

    Bool = bs_put Type, ...
    br Bool, ^Success, ^Fail

That saves an instruction, but it necessitates special handling
of `bs_put` in some optimizations. To avoid that special handling,
change the representation of `bs_put` to (in a body):

    Result = bs_put Type, ...
    Bool = succeeded:body Result
    br Bool, ^Success, ^Fail

Or (in a guard):

    Result = bs_put Type, ...
    Bool = succeeded:guard Result
    br Bool, ^Success, ^Fail

`Result` is here a dummy variable that will be discarded in the
translation to BEAM code.