### PR TITLE
Add hex encoding fonctions on the binary module

### DIFF
--- a/lib/stdlib/doc/src/binary.xml
+++ b/lib/stdlib/doc/src/binary.xml
@@ -243,6 +243,34 @@
     </func>
 
     <func>
+      <name name="encode_hex" arity="1" since=""/>
+      <fsummary>Encodes a binary into a hex encoded binary.</fsummary>
+      <desc>
+      <p>Encodes a binary into a hex encoded binary.</p>
+
+      <p><em>Example:</em></p>
+
+      <code>
+1> binary:encode_hex(&lt;&lt;"f"&gt;&gt;).
+&lt;&lt;"66"&gt;&gt;</code>
+      </desc>
+    </func>
+
+    <func>
+      <name name="decode_hex" arity="1" since=""/>
+      <fsummary>Decodes a hex encoded binary into a binary.</fsummary>
+      <desc>
+      <p>Decodes a hex encoded binary into a binary.</p>
+
+      <p><em>Example</em></p>
+
+      <code>
+1> binary:decode_hex(&lt;&lt;"66"&gt;&gt;).
+&lt;&lt;"f"&gt;&gt;</code>
+      </desc>
+    </func>
+
+    <func>
       <name name="first" arity="1" since="OTP R14B"/>
       <fsummary>Return the first byte of a binary.</fsummary>
       <desc>

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -69,6 +69,25 @@ format_binary_error(encode_unsigned, [Subject], _) ->
     [must_be_non_neg_integer(Subject)];
 format_binary_error(encode_unsigned, [Subject, Endianness], _) ->
     [must_be_non_neg_integer(Subject), must_be_endianness(Endianness)];
+format_binary_error(encode_hex, [Subject], _) ->
+    [must_be_binary(Subject)];
+format_binary_error(decode_hex, [Subject], _) ->
+    if
+        is_binary(Subject), byte_size(Subject) rem 2 == 1 ->
+            ["must contain an even number of bytes"];
+        true ->
+            [must_be_binary(Subject)]
+    end;
+format_binary_error(decode_hex_char, [Subject], _) ->
+    if
+        is_integer(Subject),
+        (Subject >= $a andalso Subject =< $f) orelse
+        (Subject >= $A andalso Subject =< $F) orelse
+        (Subject >= $0 andalso Subject =< $9) ->
+            [[]];
+        true ->
+            [range]
+    end;
 format_binary_error(first, [Subject], _) ->
     [case Subject of
          <<>> -> empty_binary;


### PR DESCRIPTION
I propose to add the `encode_hex/1`, `encode_hex/2` and `decode_hex/1`
functions on the `binary` module.

Dealing with the hex format is frequent in many codebases. At this time,
we all copy-paste similar helpers in our codebases to encode and decode
a hex-encoded binary.

It's why I suggest enriching the binary module with these functions.

I've added these functions on the binary module because it makes sense
to me, and it avoids polluting the global namespace with a new
module. Maybe create a new module called hex, for example, is a better
solution.

I tried as much as possible to follow the contribution guide. Don't
hesitate to tell me if I made a mistake somewhere.