### PR TITLE
Quote source as part of error messages

### DIFF
--- a/erts/test/erlc_SUITE.erl
+++ b/erts/test/erlc_SUITE.erl
@@ -69,7 +69,8 @@ end_per_group(_GroupName, Config) ->
 %% Tests that compiling Erlang source code works.
 
 compile_erl(Config) when is_list(Config) ->
-    {SrcDir, OutDir, Cmd} = get_cmd(Config),
+    {SrcDir, OutDir, Cmd0} = get_cmd(Config),
+    Cmd = Cmd0 ++ " +brief",
     FileName = filename:join(SrcDir, "erl_test_ok.erl"),
 
     %% By default, warnings are now turned on.
@@ -98,7 +99,6 @@ compile_erl(Config) when is_list(Config) ->
     BadFile = filename:join(SrcDir, "erl_test_bad.erl"),
     run(Config, Cmd, BadFile, "", ["function non_existing/1 undefined\$",
                                    "_ERROR_"]),
-
     ok.
 
 %% Test that compiling yecc source code works.
@@ -221,7 +221,8 @@ deep_cwd_1(PrivDir) ->
 %% Test that a large number of command line switches does not
 %% overflow the argument buffer
 arg_overflow(Config) when is_list(Config) ->
-    {SrcDir, _OutDir, Cmd} = get_cmd(Config),
+    {SrcDir, _OutDir, Cmd0} = get_cmd(Config),
+    Cmd = Cmd0 ++ " +brief",
     FileName = filename:join(SrcDir, "erl_test_ok.erl"),
     %% Each -D option will be expanded to three arguments when
     %% invoking 'erl'.
@@ -266,33 +267,34 @@ erlc() ->
     end.
 
 make_dep_options(Config) ->
-    {SrcDir,OutDir,Cmd} = get_cmd(Config),
+    {SrcDir,OutDir,Cmd0} = get_cmd(Config),
+    Cmd = Cmd0 ++ " +brief",
     FileName = filename:join(SrcDir, "erl_test_ok.erl"),
     BeamFileName = filename:join(OutDir, "erl_test_ok.beam"),
 
     DepRE = ["/erl_test_ok[.]beam: \\\\$",
-             "/system_test/erlc_SUITE_data/src/erl_test_ok[.]erl \\\\$",
-             "/system_test/erlc_SUITE_data/include/erl_test[.]hrl$",
+             "/erlc_SUITE_data/src/erl_test_ok[.]erl \\\\$",
+             "/erlc_SUITE_data/include/erl_test[.]hrl$",
              "_OK_"],
 
     DepRETarget =
     ["^target: \\\\$",
-     "/system_test/erlc_SUITE_data/src/erl_test_ok[.]erl \\\\$",
-     "/system_test/erlc_SUITE_data/include/erl_test[.]hrl$",
+     "/erlc_SUITE_data/src/erl_test_ok[.]erl \\\\$",
+     "/erlc_SUITE_data/include/erl_test[.]hrl$",
      "_OK_"],
 
     DepREMP =
     ["/erl_test_ok[.]beam: \\\\$",
-     "/system_test/erlc_SUITE_data/src/erl_test_ok[.]erl \\\\$",
-     "/system_test/erlc_SUITE_data/include/erl_test[.]hrl$",
+     "/erlc_SUITE_data/src/erl_test_ok[.]erl \\\\$",
+     "/erlc_SUITE_data/include/erl_test[.]hrl$",
      [],
-     "/system_test/erlc_SUITE_data/include/erl_test.hrl:$",
+     "/erlc_SUITE_data/include/erl_test.hrl:$",
      "_OK_"],
 
     DepREMissing =
     ["/erl_test_missing_header[.]beam: \\\\$",
-     "/system_test/erlc_SUITE_data/src/erl_test_missing_header[.]erl \\\\$",
-     "/system_test/erlc_SUITE_data/include/erl_test[.]hrl \\\\$",
+     "/erlc_SUITE_data/src/erl_test_missing_header[.]erl \\\\$",
+     "/erlc_SUITE_data/include/erl_test[.]hrl \\\\$",
      "missing.hrl$",
      "_OK_"],
 
@@ -358,9 +360,9 @@ make_dep_options(Config) ->
     %% since compiler is run on the erlang code a warning will be
     %% issued by the compiler, match that.
     WarningRE =
-         "/system_test/erlc_SUITE_data/src/erl_test_ok.erl:[0-9]+:[0-9]+: "
+         "/erlc_SUITE_data/src/erl_test_ok.erl:[0-9]+:[0-9]+: "
         "Warning: function foo/0 is unused$",
-    ErrorRE = "/system_test/erlc_SUITE_data/src/erl_test_missing_header.erl:"
+    ErrorRE = "/erlc_SUITE_data/src/erl_test_missing_header.erl:"
         "[0-9]+:[0-9]+: can't find include file \"missing.hrl\"$",
 
     DepRE_MMD = insert_before("_OK_", WarningRE, DepRE),

--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -95,6 +95,13 @@
 
         <p>Available options:</p>
         <taglist>
+	  <tag><c>brief</c></tag>
+          <item>
+            <p>Restricts error and warning messages to a single line of output.
+            As of OTP 24, the compiler will by default also display the part
+            of the source code that the message refers to.</p>
+          </item>
+
           <tag><c>basic_validation</c></tag>
           <item>
             <p>This option is a fast way to test whether a module will

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -98,6 +98,7 @@ MODULES =  \
 	sys_core_fold_lists \
 	sys_core_inline \
 	sys_core_prepare \
+	sys_messages \
 	sys_pre_attributes \
 	v3_core \
 	v3_kernel \

--- a/lib/compiler/src/compiler.app.src
+++ b/lib/compiler/src/compiler.app.src
@@ -73,6 +73,7 @@
 	     sys_core_fold_lists,
 	     sys_core_inline,
 	     sys_core_prepare,
+	     sys_messages,
 	     sys_pre_attributes,
 	     v3_core,
 	     v3_kernel,

--- a/lib/compiler/src/sys_messages.erl
+++ b/lib/compiler/src/sys_messages.erl
@@ -1,0 +1,206 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2018. All Rights Reserved.
+%% Copyright 2020 Facebook, Inc. and its affiliates.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+
+-module(sys_messages).
+
+-export([format_messages/4, list_errors/3]).
+
+-type pos() :: integer() | {integer(), integer()}.
+-type err_warn_info() :: tuple().
+-type message() :: {Where :: none | {File::string(), pos()}, Text :: iolist()}.
+
+-spec format_messages(File::string(), Prefix::string(), [err_warn_info()],
+                      Opts::[term()]) -> [message()].
+
+format_messages(F, P, [{none, Mod, E} | Es], Opts) ->
+    M = {none, io_lib:format("~ts: ~s~ts\n", [F, P, Mod:format_error(E)])},
+    [M | format_messages(F, P, Es, Opts)];
+format_messages(F, P, [{Loc, Mod, E} | Es], Opts) ->
+    StartLoc = Loc,
+    EndLoc = StartLoc,
+    Src = quote_source(F, StartLoc, EndLoc, Opts),
+    Msg = io_lib:format("~ts:~ts: ~s~ts\n~ts", [
+        F,
+        fmt_pos(StartLoc),
+        P,
+        Mod:format_error(E),
+        Src
+    ]),
+    Pos = StartLoc,
+    [{{F, Pos}, Msg} | format_messages(F, P, Es, Opts)];
+format_messages(_, _, [], _Opts) ->
+    [].
+
+-spec list_errors(File::string(), [err_warn_info()], Opts::[term()]) -> ok.
+
+list_errors(F, [{none, Mod, E} | Es], Opts) ->
+    io:fwrite("~ts: ~ts\n", [F, Mod:format_error(E)]),
+    list_errors(F, Es, Opts);
+list_errors(F, [{Loc, Mod, E} | Es], Opts) ->
+    StartLoc = Loc,
+    EndLoc = StartLoc,
+    Src = quote_source(F, StartLoc, EndLoc, Opts),
+    io:fwrite("~ts:~ts: ~ts\n~ts", [F, fmt_pos(StartLoc), Mod:format_error(E), Src]),
+    list_errors(F, Es, Opts);
+list_errors(_F, [], _Opts) ->
+    ok.
+
+fmt_pos({Line, Col}) ->
+    io_lib:format("~w:~w", [Line, Col]);
+fmt_pos(Line) ->
+    io_lib:format("~w", [Line]).
+
+quote_source(File, StartLoc, EndLoc, Opts) ->
+    case proplists:get_bool(brief, Opts) of
+        true -> "";
+        false -> quote_source_1(File, StartLoc, EndLoc)
+    end.
+
+quote_source_1(File, Line, Loc2) when is_integer(Line) ->
+    quote_source_1(File, {Line, 1}, Loc2);
+quote_source_1(File, Loc1, Line) when is_integer(Line) ->
+    quote_source_1(File, Loc1, {Line, -1});
+quote_source_1(File, {StartLine, StartCol}, {EndLine, EndCol}) ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            Enc = case epp:read_encoding_from_binary(Bin) of
+                      none -> epp:default_encoding();
+                      Enc0 -> Enc0
+                  end,
+            Ctx =
+                if
+                    StartLine =:= EndLine -> 0;
+                    true -> 1
+                end,
+            case seek_line(Bin, 1, StartLine - Ctx) of
+                {ok, Bin1} ->
+                    quote_source_2(Bin1, Enc, StartLine, StartCol, EndLine, EndCol, Ctx);
+                error ->
+                    ""
+            end;
+        {error, _} ->
+            ""
+    end.
+
+quote_source_2(Bin, Enc, StartLine, StartCol, EndLine, EndCol, Ctx) ->
+    case take_lines(Bin, Enc, StartLine - Ctx, EndLine + Ctx) of
+        [] ->
+            "";
+        Lines ->
+            Lines1 =
+                case length(Lines) =< (4 + Ctx) of
+                    true ->
+                        Lines;
+                    false ->
+                        %% before = context + start line + following line
+                        %% after = end line + context
+                        %% (total lines: 3 + 1 + context)
+                        Before = lists:sublist(Lines, 2 + Ctx),
+                        After = lists:reverse(
+                            lists:sublist(lists:reverse(Lines), 1 + Ctx)
+                        ),
+                        Before ++ [{0, "..."}] ++ After
+                end,
+            Lines2 = decorate(Lines1, StartLine, StartCol, EndLine, EndCol),
+            [[fmt_line(L, Text) || {L, Text} <- Lines2], $\n]
+    end.
+
+line_prefix() ->
+    "% ".
+
+fmt_line(L, Text) ->
+    [line_prefix(), io_lib:format("~4.ts| ", [line_to_txt(L)]), Text, "\n"].
+
+line_to_txt(0) -> "";
+line_to_txt(L) -> integer_to_list(L).
+
+decorate([{Line, Text} = L | Ls], StartLine, StartCol, EndLine, EndCol) when
+  Line =:= StartLine, EndLine =:= StartLine ->
+    %% start and end on same line
+    S = underline(Text, StartCol, EndCol),
+    decorate(S, L, Ls, StartLine, StartCol, EndLine, EndCol);
+decorate([{Line, Text} = L | Ls], StartLine, StartCol, EndLine, EndCol) when Line =:= StartLine ->
+    %% start with end on separate line
+    S = underline(Text, StartCol, string:length(Text) + 1),
+    decorate(S, L, Ls, StartLine, StartCol, EndLine, EndCol);
+decorate([{_Line, _Text} = L | Ls], StartLine, StartCol, EndLine, EndCol) ->
+    [L | decorate(Ls, StartLine, StartCol, EndLine, EndCol)];
+decorate([], _StartLine, _StartCol, _EndLine, _EndCol) ->
+    [].
+
+%% don't produce empty decoration lines
+decorate("", L, Ls, StartLine, StartCol, EndLine, EndCol) ->
+    [L | decorate(Ls, StartLine, StartCol, EndLine, EndCol)];
+decorate(Text, L, Ls, StartLine, StartCol, EndLine, EndCol) ->
+    [L, {0, Text} | decorate(Ls, StartLine, StartCol, EndLine, EndCol)].
+
+%% End typically points to the first position after the actual region.
+%% If End = Start, we adjust it to Start+1 to mark at least one character
+%% TODO: colorization option
+underline(_Text, Start, End) when End < Start ->
+    % no underlining at all if end column is unknown
+    "";
+underline(Text, Start, Start) ->
+    underline(Text, Start, Start + 1);
+underline(Text, Start, End) ->
+    underline(Text, Start, End, 1).
+
+underline([$\t | Text], Start, End, N) when N < Start ->
+    [$\t | underline(Text, Start, End, N + 1)];
+underline([_ | Text], Start, End, N) when N < Start ->
+    [$\s | underline(Text, Start, End, N + 1)];
+underline(_Text, _Start, End, N) ->
+    underline_1(N, End).
+
+underline_1(N, End) when N < End ->
+    [$^ | underline_1(N + 1, End)];
+underline_1(_N, _End) ->
+    "".
+
+seek_line(Bin, L, L) -> {ok, Bin};
+seek_line(<<$\n, Rest/binary>>, N, L) -> seek_line(Rest, N + 1, L);
+seek_line(<<$\r, $\n, Rest/binary>>, N, L) -> seek_line(Rest, N + 1, L);
+seek_line(<<_, Rest/binary>>, N, L) -> seek_line(Rest, N, L);
+seek_line(<<>>, _, _) -> error.
+
+take_lines(<<>>, _Enc, _Here, _To) ->
+    [];
+take_lines(Bin, Enc, Here, To) when Here =< To ->
+    {Text, Rest} = take_line(Bin, <<>>),
+    [{Here, text_to_string(Text, Enc)}
+     | take_lines(Rest, Enc, Here + 1, To)];
+take_lines(_Bin, _Enc, _Here, _To) ->
+    [].
+
+text_to_string(Text, Enc) ->
+    case unicode:characters_to_list(Text, Enc) of
+        String when is_list(String) -> String;
+        {error, String, _Rest} -> String;
+        {incomplete, String, _Rest} -> String
+    end.
+
+take_line(<<$\n, Rest/binary>>, Ack) ->
+    {Ack, Rest};
+take_line(<<$\r, $\n, Rest/binary>>, Ack) ->
+    {Ack, Rest};
+take_line(<<B, Rest/binary>>, Ack) ->
+    take_line(Rest, <<Ack/binary, B>>);
+take_line(<<>>, Ack) ->
+    {Ack, <<>>}.

--- a/lib/compiler/test/compile_SUITE_data/bad_enc.erl
+++ b/lib/compiler/test/compile_SUITE_data/bad_enc.erl
@@ -1,0 +1,7 @@
+%% coding: utf-8
+%% This file claims to be in UTF-8 but is actually in Latin-1
+%% causing the parser to give up
+-module(bad_enc).
+bar() ->
+	    %% these lines are indented with TAB+SPC to check error column
+	    {ok, "xyzåäö"}.

--- a/lib/compiler/test/compile_SUITE_data/col_lat1.erl
+++ b/lib/compiler/test/compile_SUITE_data/col_lat1.erl
@@ -1,0 +1,7 @@
+%% coding: latin-1
+-module(col_lat1).
+-export([bar/0]).
+bar() ->
+    %% the below line contains both TAB and SPC to check error column
+    B = <<"xyzåäö">>,	<<"12345">>,
+    B.

--- a/lib/compiler/test/compile_SUITE_data/col_utf8.erl
+++ b/lib/compiler/test/compile_SUITE_data/col_utf8.erl
@@ -1,0 +1,6 @@
+-module(col_utf8).
+-export([bar/0]).
+bar() ->
+    %% the below line contains both TAB and SPC to check error column
+    B = <<"xyzåäö">>,	<<"12345">>,
+    B.

--- a/lib/debugger/test/int_SUITE.erl
+++ b/lib/debugger/test/int_SUITE.erl
@@ -54,7 +54,7 @@ end_per_testcase(_Case, Config) ->
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
-     {timetrap,{minutes,1}}].
+     {timetrap,{minutes,10}}].
 
 all() -> 
     [interpret, guards, {group, list_suite}, interpretable].

--- a/lib/stdlib/test/escript_SUITE.erl
+++ b/lib/stdlib/test/escript_SUITE.erl
@@ -92,11 +92,20 @@ basic(Config) when is_list(Config) ->
 	[data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
 		    "factorial 20 = 2432902008176640000\nExitCode:0">>]),
     run_with_opts(Config, Dir, "-s", "factorial_warning",
-		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\nExitCode:0">>]),
+		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
+                              "%   12| bar() ->\n"
+                              "%     | ^\n\n"
+                              "ExitCode:0">>]),
     run_with_opts(Config, Dir, "-s -i", "factorial_warning",
-		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\nExitCode:0">>]),
+		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
+                              "%   12| bar() ->\n"
+                              "%     | ^\n\n"
+                              "ExitCode:0">>]),
     run_with_opts(Config, Dir, "-c -s", "factorial_warning",
-		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\nExitCode:0">>]),
+		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
+                              "%   12| bar() ->\n"
+                              "%     | ^\n\n"
+                              "ExitCode:0">>]),
     run(Config, Dir, "filesize "++filename:join(proplists:get_value(data_dir, Config),"filesize"),
 	[data_dir,<<"filesize:11:1: Warning: function id/1 is unused\n324\nExitCode:0">>]),
     run(Config, Dir, "test_script_name",
@@ -124,8 +133,12 @@ errors(Config) when is_list(Config) ->
 	 data_dir,"lint_error:8:10: variable 'ExitCode' is unbound\n",
 	 <<"escript: There were compilation errors.\nExitCode:127">>]),
     run_with_opts(Config, Dir, "-s", "lint_error",
-		  [data_dir,<<"lint_error:6:1: function main/1 already defined\n">>,
-		   data_dir,"lint_error:8:10: variable 'ExitCode' is unbound\n",
+		  [data_dir,<<"lint_error:6:1: function main/1 already defined\n"
+                              "%    6| main(Args) ->\n"
+                              "%     | ^\n\n">>,
+		   data_dir,("lint_error:8:10: variable 'ExitCode' is unbound\n"
+                             "%    8|     halt(ExitCode).\n"
+                             "%     |          ^\n\n"),
 		   <<"escript: There were compilation errors.\nExitCode:127">>]),
     ok.
 


### PR DESCRIPTION
Provides one or more additional lines of context for compiler messages,  showing the relevant source code with the error position indicated by ^, like this:
```
foo.erl:13:10: variable 'X' is unbound
%   13|     case X of
%     |          ^

foo.erl:18:16: illegal guard expression
%   18| foo(A, B) when is_lit(A), is_list(B) ->
%     |                ^

foo.erl:23:22: function bar/1 undefined
%   23|             {ok, {H, bar(T)}}
%     |                      ^

foo.erl:27:5: record foo undefined
%   26| bar(X, Y) ->
%   27|     #foo{a = baz(X, Y),
%     |     ^
%   28|          b = f(),
%     | ...
%   31|          y = false,
%   32|          z = true}.
```
These long messages can be suppressed with the 'brief' compiler option.
The message formatting code is moved out to a separate module.

The followup PR https://github.com/erlang/otp/pull/3026 also adds end position to the parser, allowing the error ranges to be underlined.