### PR TITLE
EDoc: Add @vendor tag

### DIFF
--- a/lib/edoc/doc/overview.edoc
+++ b/lib/edoc/doc/overview.edoc
@@ -245,6 +245,10 @@ The following tags can be used in an overview file.
       <em>only</em> be used in an overview file. The content can be
       arbitrary text.</dd>
 
+  <dt><a name="otag-vendor">`@vendor'</a></dt>
+      <dd>See the <a href="#mtag-vendor">`@vendor' module tag</a> for
+      details.</dd>
+
   <dt><a name="otag-version">`@version'</a></dt>
       <dd>See the <a href="#mtag-version">`@version' module
       tag</a> for details.</dd>
@@ -338,6 +342,30 @@ The following tags can be used before a module declaration:
       <dd>Specifies when the module was introduced, with respect to
       the application, release or distribution it is part
       of. The content can be arbitrary text.</dd>
+
+  <dt><a name="mtag-vendor">`@vendor'</a></dt>
+      <dd>Specifies the name of the vendor, along with a website URI and
+      logo. An URI can be given within `[...]', and a logo within `<...>'.
+      The URI and logo are optional. A completely empty `@vendor' tag can
+      be used to explicitly indicate "no vendor". Any surrounding
+      whitespaces are stripped from all strings.
+
+      The name is the first nonempty string that is not within `<...>'
+      or `[...]', and does not contain only whitespace. (In other words,
+      the name can come before, between, or after the URI and logo,
+      but cannot be split up; any sections after the first are ignored.)
+
+      Examples:
+```%% @vendor Example Inc. [http://www.example.net/] <http://www.example.net/logo.png>'''
+
+```%% @vendor Example Inc. [http://www.example.net/]'''
+
+```%% @vendor Example Inc. <http://www.example.net/logo.png>'''
+
+```%% @vendor Example Inc.'''
+
+```%% @vendor'''
+      </dd>
 
   <dt><a name="mtag-version">`@version'</a></dt>
       <dd>Specifies the module version. The content can be arbitrary

--- a/lib/edoc/priv/edoc.dtd
+++ b/lib/edoc/priv/edoc.dtd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- EDoc DTD Version 0.3 -->
 
-<!ELEMENT overview (title, description?, author*, copyright?, version?,
-                    since?, see*, reference*, todo?, modules)>
+<!ELEMENT overview (title, description?, vendor?, author*, copyright?,
+                    version?, since?, see*, reference*, todo?, modules)>
 <!ATTLIST overview
   root CDATA #IMPLIED
   encoding CDATA #IMPLIED>
@@ -12,8 +12,8 @@
 <!ELEMENT modules (module+)>
 
 
-<!ELEMENT module (args?, description?, author*, copyright?, version?,
-		  since?, deprecated?, see*, reference*, todo?,
+<!ELEMENT module (args?, description?, vendor?, author*, copyright?,
+                  version?, since?, deprecated?, see*, reference*, todo?,
 		  behaviour*, callbacks?, typedecls?, functions)>
 <!ATTLIST module
   name CDATA #REQUIRED
@@ -25,6 +25,12 @@
 <!ELEMENT description (briefDescription, fullDescription?)>
 <!ELEMENT briefDescription (#PCDATA)>
 <!ELEMENT fullDescription (#PCDATA)>
+
+<!ELEMENT vendor EMPTY>
+<!ATTLIST vendor
+  name CDATA #REQUIRED
+  website CDATA #IMPLIED
+  logo CDATA #IMPLIED>
 
 <!ELEMENT author EMPTY>
 <!ATTLIST author

--- a/lib/edoc/src/edoc_tags.erl
+++ b/lib/edoc/src/edoc_tags.erl
@@ -63,7 +63,7 @@
 
 -type tag() :: author | copyright | deprecated | doc | docfile | 'end' | equiv | headerfile
 	     | hidden | param | private | reference | returns | see | since | spec | throws
-	     | title | 'TODO' | todo | type | version.
+	     | title | 'TODO' | todo | type | vendor | version.
 -type parser() :: text | xml | fun().
 -type tag_flag() :: module | footer | function | overview | single.
 
@@ -91,6 +91,7 @@ tags() ->
      {'TODO', xml, All},
      {todo, xml, All},
      {type, fun parse_typedef/4, [module,footer,function]},
+     {vendor, fun parse_vendor/4, [module,overview,single]},
      {version, text, [module,overview,single]}].
 
 aliases('TODO') -> todo;
@@ -335,6 +336,16 @@ parse_contact(Data, Line, _Env, _Where) ->
 	    throw_error(Line, "must specify name or e-mail.");
 	Info ->
 	    Info
+    end.
+
+parse_vendor(Data, Line, _Env, _Where) ->
+    case edoc_lib:parse_vendor(Data, Line) of
+	{"", "", ""} = V ->
+	    V;
+	{"", _, _} ->
+	    throw_error(Line, "must specify name.");
+	V ->
+	    V
     end.
 
 parse_typedef(Data, Line, _Env, Where) ->

--- a/lib/edoc/test/edoc_SUITE_data/myapp/doc/overview.edoc
+++ b/lib/edoc/test/edoc_SUITE_data/myapp/doc/overview.edoc
@@ -1,0 +1,21 @@
+Example comment 1
+Example comment 2
+
+@vendor Example Vendor [http://www.example.org/] <http://www.example.org/logo.png>
+
+@author Example Author <author@example.com> [http://www.example.com/]
+
+@copyright 2021 Example Copyright
+
+@reference Example Reference
+
+@see edoc
+
+@since 2021
+
+@title Example Title
+
+@version 0.0.1
+
+@doc This is an example overview page.
+It is used for EDoc testing.

--- a/lib/edoc/test/edoc_SUITE_data/myapp/src/c.erl
+++ b/lib/edoc/test/edoc_SUITE_data/myapp/src/c.erl
@@ -1,0 +1,3 @@
+%% @vendor Example Vendor [http://www.example.org/] <http://www.example.org/logo.png>
+
+-module(c).


### PR DESCRIPTION
The current implementation of `edoc` places an Erlang logo and a link to `http://www.erlang.org/` in the top/bottom right corners of all generated overview and module pages. This has always bothered me, since (to me at least) it suggests that the documented modules are in some way related to Erlang _as an organization_, while most of the time it really is just some software _written_ in Erlang. For an example, see [the API documentation for MySQL-OTP](https://mysql-otp.github.io/mysql-otp/), which is a MySQL driver written in/for Erlang, but otherwise has no relation to Erlang as such.

The logo and link are hardcoded into the `edoc_layout` module, and there is no easy way to change it other than post-processing the generated files (something which I guess is being done with [the API documentation for PropEr](http://proper.softlab.ntua.gr/doc/)) or maybe some CSS/JS trickery.

This PR introduces the `@vendor` tag for the overview and module pages in to allow customization of the link and logo, with the following semantics (when using the standard layout that comes with `edoc`):
* if the `@vendor` tag is absent, the layout renders the Erlang logo and the link to `http://www.erlang.org/` as it does now. While this is actually counter-intuitive, this behavior is required to keep backwards compatibility, especially with software that post-processes the generated files in order to replace the logo and link with their own
* if the `@vendor` tag is present but empty, the layout renders no logo or link, ie "no vendor"
* if the `@vendor` tag is present and not empty, it _must_  contain the vendor name, and _may_ optionally contain a website URI (ie, link to vendor website) in square brackets (`[...]`) and/or a logo URI (ie. the URI of a logo image) in angle brackets (`<...>`), in any order (or rather, the same ordering rules as for the `@author` tags apply). This information is used by the standard layout to render what is displayed in the top/bottom right corners instead of the Erlang logo/link according to the following rules:
  * if only the name is given (no website or logo URIs), only that name appears
  * if a logo URI is given, the logo appears, and the name is placed in the `alt` attribute of the `img` tag
  * if a website URI is given, the name or logo, a link is placed on the name or logo

There is a slight difference between the current (or the equivalent no-@vendor-tag) behavior and the one introduced with the `@vendor` tag: The Erlang logo is copied to the location of the generated documentation (ie, it is _part of_ the documentation), while logo images denoted via the `@vendor` tag are not.

<hr />

About the same could be achieved by introducing a new `{vendor, ...}` option instead of a new `@vendor` tag. This way, a mechanism to copy a logo image to the documentation would probably be easy to implement as well. On the other hand, it takes the vendor information out of the source files and places it in the hands of the caller. For this reason, I decided against it, but I'm open to suggestions of course ;)