### PR TITLE
Stop allowing latin-1 files without an explicit comment

### DIFF
--- a/lib/compiler/test/error_SUITE.erl
+++ b/lib/compiler/test/error_SUITE.erl
@@ -276,10 +276,9 @@ maps_warnings(Config) when is_list(Config) ->
     ok.
 
 bad_utf8(Config) ->
-    Ts = [{bad_utf8,
+    Ts = [{bad_explicit_utf8,
 	   %% If coding is specified explicitly as utf-8, there should be
-	   %% a compilation error; we must not fallback to parsing the
-	   %% file in latin-1 mode.
+	   %% a compilation error for a latin-1 comment.
 	   <<"%% coding: utf-8
               %% Bj",246,"rn
               t() -> \"",246,"\".
@@ -288,7 +287,21 @@ bad_utf8(Config) ->
 	   {error,[{{2,15},epp,cannot_parse},
 		   {{2,15},file_io_server,invalid_unicode}],
 	    []}
-	  }],
+	  },
+
+          {bad_implicit_utf8,
+           %% If there is no coding comment given, encoding defaults to utf-8
+	   %% and there should be a compilation error for a latin-1 comment.
+	   <<"
+              %% Bj",246,"rn
+              t() -> \"",246,"\".
+             ">>,
+	   [],
+	   {error,[{{2,15},epp,cannot_parse},
+		   {{2,15},file_io_server,invalid_unicode}],
+	    []}
+          }
+         ],
     [] = run2(Config, Ts),
     ok.
 

--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -1,3 +1,4 @@
+
 %%
 %% %CopyrightBegin%
 %%
@@ -41,7 +42,7 @@
          files/1,effect/1,bin_opt_info/1,bin_construction/1,
 	 comprehensions/1,maps/1,maps_bin_opt_info/1,
          redundant_boolean_clauses/1,
-	 latin1_fallback/1,underscore/1,no_warnings/1,
+	 underscore/1,no_warnings/1,
 	 bit_syntax/1,inlining/1,tuple_calls/1,
          recv_opt_info/1]).
 
@@ -64,7 +65,7 @@ groups() ->
        bad_arith,bool_cases,bad_apply,files,effect,
        bin_opt_info,bin_construction,comprehensions,maps,
        maps_bin_opt_info,
-       redundant_boolean_clauses,latin1_fallback,
+       redundant_boolean_clauses,
        underscore,no_warnings,bit_syntax,inlining,
        tuple_calls,recv_opt_info]}].
 
@@ -796,51 +797,6 @@ redundant_boolean_clauses(Config) when is_list(Config) ->
            [],
            {warnings,[{{5,22},sys_core_fold,nomatch_shadow}]}}],
     run(Config, Ts),
-    ok.
-
-latin1_fallback(Conf) when is_list(Conf) ->
-    DataDir = ?privdir,
-    IncFile = filename:join(DataDir, "include_me.hrl"),
-    file:write_file(IncFile, <<"%% ",246," in include file\n">>),
-    Ts1 = [{latin1_fallback1,
-	    %% Test that the compiler fall backs to latin-1 with
-	    %% a warning if a file has no encoding and does not
-	    %% contain correct UTF-8 sequences.
-            <<"\n%% Bj",246,"rn
-              t(_) -> \"",246,"\";
-              t(x) -> ok.
-              ">>,
-            [],
-            {warnings,[{{2,1},compile,reparsing_invalid_unicode},
-                       {{4,15},sys_core_fold,{nomatch_shadow,3,{t,1}}}]}}],
-    [] = run(Conf, Ts1),
-
-    Ts2 = [{latin1_fallback2,
-	    %% Test that the compiler fall backs to latin-1 with
-	    %% a warning if a file has no encoding and does not
-	    %% contain correct UTF-8 sequences.
-	    <<"
-
-	      -include(\"include_me.hrl\").
-              ">>,
-	    [],
-	    {warnings,[{{1,1},compile,reparsing_invalid_unicode}]}
-	   }],
-    [] = run(Conf, Ts2),
-
-    Ts3 = [{latin1_fallback3,
-	    %% Test that the compiler fall backs to latin-1 with
-	    %% a warning if a file has no encoding and does not
-	    %% contain correct UTF-8 sequences.
-	    <<"-ifdef(NOTDEFINED).
-              t(_) -> \"",246,"\";
-              t(x) -> ok.
-              -endif.
-              ">>,
-	    [],
-	    {warnings,[{{2,24},compile,reparsing_invalid_unicode}]}}],
-    [] = run(Conf, Ts3),
-
     ok.
 
 underscore(Config) when is_list(Config) ->

--- a/system/doc/general_info/removed_24.inc
+++ b/system/doc/general_info/removed_24.inc
@@ -6,3 +6,9 @@
 	and was removed in OTP 24.
       </p>
     </section>
+    <section>
+       <title>Compilation of Latin-1 Encoded Erlang Files</title>
+       <p>The Erlang compiler now refuses to compile source files
+	encoded in Latin-1 without a <c>%% coding: latin-1</c> comment at the
+	beginning of the file.</p>
+    </section>

--- a/system/doc/general_info/scheduled_for_removal_24.inc
+++ b/system/doc/general_info/scheduled_for_removal_24.inc
@@ -24,9 +24,3 @@
       will still be supported, even though its no longer necessary to specify
       it this way. </p>
     </section>
-    <section>
-	<title>Compilation of Latin-1 Encoded Erlang Files</title>
-	<p>As of OTP 24, the Erlang compiler will refuse to compile source files
-	encoded in Latin-1 but without a <c>%% coding: latin-1</c> comment at the
-	beginning of the file.</p>
-    </section>


### PR DESCRIPTION
Having an latin-1 encoded Erlang source file without an explicit
"coding: latin-1" comment was deprecated in OTP 23. Turn invalid
encoding into an error.