### PR TITLE
Add link to Removed Functionality on the top page

### DIFF
--- a/system/doc/top/templates/index.html.src
+++ b/system/doc/top/templates/index.html.src
@@ -41,7 +41,11 @@ limitations under the License.
 <ul class="section-links">
  <li><a href="applications.html">Applications</a></li>
  <li><a href="man_index.html" class="modules">Modules</a></li>
+</ul>
+
+<ul class="section-links">
  <li><a href="general_info/deprecations.html" class="modules">Deprecations</a></li>
+ <li><a href="general_info/removed.html" class="modules">Removed Functionality</a></li>
  <li><a href="general_info/scheduled_for_removal.html" class="modules">Scheduled for Removal</a></li>
 </ul>
 


### PR DESCRIPTION
While at it, also add a blank line after Applications and Modules to
better separate them from Deprecations, Removed Functionality, and
Scheduled for Removal.