### PR TITLE
Add libwxgtk-webview3.0-gtk3-dev to base images #2

### DIFF
--- a/.github/dockerfiles/Dockerfile.debian-base
+++ b/.github/dockerfiles/Dockerfile.debian-base
@@ -9,7 +9,7 @@ ARG BASE=debian
 ARG HOST_ARCH=amd64
 ARG HOST_TRIP=x86_64-linux-gnu
 
-ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssh-dev unixodbc-dev libgmp3-dev libwxbase3.0-dev libwxgtk3.0-dev libwxgtk-webview3.0-gtk3-dev libsctp-dev lksctp-tools"
+ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssh-dev unixodbc-dev libgmp3-dev libwxbase3.0-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev libsctp-dev lksctp-tools"
 
 ## See https://wiki.debian.org/Multiarch/HOWTO for details on how to install things
 RUN if [ "$BASE" = "i386/debian" ]; then BUILD_ARCH=`dpkg --print-architecture` && \
@@ -32,3 +32,9 @@ RUN if [ "$BASE" = "i386/debian" ]; then apt-get install -y \
           cp -r `dirname $dir`/* `dirname /buildroot/sysroot$dir`; \
           cp -r $dir/* `dirname /buildroot/sysroot$dir`; \
         done; fi
+
+RUN if [ "$BASE" = "i386/debian" ]; then \
+          update-alternatives --set wx-config /usr/lib/i386-linux-gnu/wx/config/gtk3-unicode-3.0; \
+        else \
+          update-alternatives --set wx-config /usr/lib/x86_64-linux-gnu/wx/config/gtk3-unicode-3.0; \
+        fi

--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -11,3 +11,5 @@ RUN apt-get update && \
         apt-get -y upgrade && \
         apt-get install -y build-essential m4 autoconf fop xsltproc clang clang-format \
         default-jdk libxml2-utils $INSTALL_LIBS
+
+RUN update-alternatives --set wx-config /usr/lib/x86_64-linux-gnu/wx/config/gtk3-unicode-3.0


### PR DESCRIPTION
This fixes libwxgtk3.0-dev to be libwxgtk3.0-gtk3-dev and adds the update-alternatives call to the base-image building to select the correct wxWidgets build version. @dgud 