### PR TITLE
Reduce confusion by rephrasing some compiler warnings

### DIFF
--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -237,12 +237,16 @@ guard(Config) when is_list(Config) ->
 	   {warnings,
             [{{2,15},sys_core_fold,no_clause_match},
              {{2,15},sys_core_fold,nomatch_guard},
-             {{2,28},sys_core_fold,{eval_failure,badarg}},
+             {{2,28},sys_core_fold,{eval_failure,
+                                    {function,{element,2}},
+                                    badarg}},
              {{4,15},sys_core_fold,no_clause_match},
              {{4,15},sys_core_fold,nomatch_guard},
              {{6,15},sys_core_fold,no_clause_match},
              {{6,15},sys_core_fold,nomatch_guard},
-             {{6,26},sys_core_fold,{eval_failure,badarg}}
+             {{6,26},sys_core_fold,{eval_failure,
+                                    {function,{element,2}},
+                                    badarg}}
 	    ]}}],
     [] = run(Config, Ts),
 
@@ -269,13 +273,21 @@ bad_arith(Config) when is_list(Config) ->
 	   [],
 	   {warnings,
             [{{3,19},sys_core_fold,nomatch_guard},
-             {{3,21},sys_core_fold,{eval_failure,badarith}},
+             {{3,21},sys_core_fold,{eval_failure,
+                                    {operator,{'+',2}},
+                                    badarith}},
              {{9,19},sys_core_fold,nomatch_guard},
              {{9,19},sys_core_fold,{no_effect,{erlang,is_integer,1}}},
-             {{9,36},sys_core_fold,{eval_failure,badarith}},
+             {{9,36},sys_core_fold,{eval_failure,
+                                    {operator,{'+',2}},
+                                    badarith}},
              {{10,19},sys_core_fold,nomatch_guard},
-             {{10,21},sys_core_fold,{eval_failure,badarith}},
-             {{15,19},sys_core_fold,{eval_failure,badarith}}
+             {{10,21},sys_core_fold,{eval_failure,
+                                     {operator,{'+',2}},
+                                     badarith}},
+             {{15,19},sys_core_fold,{eval_failure,
+                                     {operator,{'+',2}},
+                                     badarith}}
 	    ] }}],
     [] = run(Config, Ts),
     ok.
@@ -353,8 +365,12 @@ files(Config) when is_list(Config) ->
            ">>,
            [],
            {warnings,
-            [{"file1",[{{17,20},sys_core_fold,{eval_failure,badarith}}]},
-             {"file2",[{{10,20},sys_core_fold,{eval_failure,badarith}}]}]}}],
+            [{"file1",[{{17,20},sys_core_fold,{eval_failure,
+                                               {operator,{'/',2}},
+                                               badarith}}]},
+             {"file2",[{{10,20},sys_core_fold,{eval_failure,
+                                               {operator,{'/',2}},
+                                               badarith}}]}]}}],
 
     [] = run(Config, Ts),
     ok.
@@ -465,13 +481,13 @@ effect(Config) when is_list(Config) ->
            {warnings,[{{5,22},sys_core_fold,{no_effect,{erlang,is_integer,1}}},
                       {{7,22},sys_core_fold,useless_building},
                       {{9,22},sys_core_fold,useless_building},
-                      {{9,29},sys_core_fold,result_ignored},
+                      {{9,29},sys_core_fold,{result_ignored,{function,{abs,1}}}},
                       {{13,21},sys_core_fold,useless_building},
                       {{15,21},sys_core_fold,useless_building},
                       {{17,21},sys_core_fold,useless_building},
-                      {{19,22},sys_core_fold,result_ignored}]}},
+                      {{19,22},sys_core_fold,{result_ignored,{operator,{'*',2}}}}]}},
 
-           {nested,
+          {nested,
             <<"
              t(X) ->
                case X of
@@ -630,7 +646,7 @@ maps(Config) when is_list(Config) ->
                  ok.
            ">>,
            [],
-           {warnings,[{{4,48},sys_core_fold,{eval_failure,badmap}}]}},
+           {warnings,[{{4,48},sys_core_fold,bad_map_update}]}},
 	   {bad_map_src2,
            <<"
              t() ->
@@ -648,7 +664,7 @@ maps(Config) when is_list(Config) ->
                  ok.
            ">>,
            [],
-           {warnings,[{{3,51},sys_core_fold,{eval_failure,badmap}}]}},
+           {warnings,[{{3,51},sys_core_fold,bad_map_update}]}},
            {ok_map_literal_key,
            <<"
              t() ->
@@ -823,7 +839,7 @@ underscore(Config) when is_list(Config) ->
     Warnings = [{{3,23},sys_core_fold,useless_building},
                 {{4,23},sys_core_fold,useless_building},
                 {{5,23},sys_core_fold,useless_building},
-                {{8,24},sys_core_fold,result_ignored},
+                {{8,24},sys_core_fold,{result_ignored,{operator,{'/',2}}}},
                 {{9,23},sys_core_fold,{no_effect,{erlang,date,0}}},
                 {{12,24},sys_core_fold,useless_building},
                 {{15,24},sys_core_fold,useless_building}],


### PR DESCRIPTION
Consider this module:

    -module(w).
    -export([ll/0, sum/0, tt/0, ignored/2]).

    ll() ->
        L = {a,b,c},
        length(L).

    sum() ->
        A = a,
        B = b,
        A + B.

    tt() ->
        (try nan after whatever end) + 42.

    ignored(X, Y) ->
        X + Y,
        ok.

When compiling this module using https://github.com/erlang/otp/pull/3020,
the following warnings are emitted:

    w.erl:6:5: Warning: this expression will fail with a 'badarg' exception
    %    6|     length(L).
    %     |     ^

    w.erl:11:7: Warning: this expression will fail with a 'badarith' exception
    %   11|     A + B.
    %     |       ^

    w.erl:14:34: Warning: this expression will fail with a 'badarith' exception
    %   14|     (try nan after whatever end) + 42.
    %     |                                  ^

    w.erl:17:7: Warning: the result of the expression is ignored (suppress the warning by assigning the expression to the _ variable)
    %   17|     X + Y,
    %     |       ^

The last three warnings are slightly confusing, because the warnings
say "this expression" or "the expression", but the column position
points out the `+` operator in the middle of the expresson instead
of the beginning of the expression.

For the second warning, it would be better to point out the variable `A`:

    w.erl:11:5: Warning: this expression will fail with a 'badarith' exception
    %   11|     A + B.
    %     |     ^

However, to produce that warning would need a major rethinking of the
compiler pass, `sys_core_fold`, that produces that kind of warning.
`sys_core_fold` is an optimization pass that opportunistically emits
warnings while optimizing the code. When the warning for line 11 is
emitted, the original code has been lost and the line and column
number for the variable `A` is no longer available.

The third warning does not seem possible to fix by moving the position of the caret:

    w.erl:14:34: Warning: this expression will fail with a 'badarith' exception
    %   14|     (try nan after whatever end) + 42.
    %     |                                  ^

Pointing to the atom `nan` would be confusing.

Considering that the second warning would need a lot of work and that there is no good
solution for the third warning, I instead chose to rephrase the warnings like this:

    w.erl:6:5: Warning: the call to length/1 will fail with a 'badarg' exception
    %    6|     length(L).
    %     |     ^

    w.erl:11:7: Warning: evaluation of operator '+'/2 will fail with a 'badarith' exception
    %   11|     A + B.
    %     |       ^

    w.erl:14:34: Warning: evaluation of operator '+'/2 will fail with a 'badarith' exception
    %   14|     (try nan after whatever end) + 42.
    %     |                                  ^

    w.erl:17:7: Warning: the result of evaluating operator '+'/2 is ignored (suppress the warning by assigning the expression to the _ variable)
    %   17|     X + Y,
    %     |       ^