### PR TITLE
dialyzer: Add option 'error_location'

### DIFF
--- a/lib/dialyzer/doc/src/dialyzer.xml
+++ b/lib/dialyzer/doc/src/dialyzer.xml
@@ -83,13 +83,14 @@ dialyzer --help</code>
 
     <code type="none">
 dialyzer [--add_to_plt] [--apps applications] [--build_plt]
-         [--check_plt] [-Ddefine]* [-Dname] [--dump_callgraph file]
-         [files_or_dirs] [--fullpath] [--get_warnings] [--gui] [--help]
-         [-I include_dir]* [--no_check_plt] [--no_indentation]
-         [-o outfile] [--output_plt file] [-pa dir]*
-         [--plt plt] [--plt_info] [--plts plt*] [--quiet] [-r dirs]
-         [--raw] [--remove_from_plt] [--shell] [--src] [--statistics]
-         [--verbose] [--version] [-Wwarn]*</code>
+         [--check_plt] [-Ddefine]* [-Dname]* [--dump_callgraph file]
+         [--error_location flag] [files_or_dirs] [--fullpath]
+         [--get_warnings] [--gui] [--help] [-I include_dir]*
+         [--no_check_plt] [--no_indentation] [-o outfile]
+         [--output_plt file] [-pa dir]* [--plt plt] [--plt_info]
+         [--plts plt*] [--quiet] [-r dirs] [--raw] [--remove_from_plt]
+         [--shell] [--src] [--statistics] [--verbose] [--version]
+         [-Wwarn]*</code>
 
     <note>
       <p>* denotes that multiple occurrences of the option are possible.</p>
@@ -145,6 +146,14 @@ dialyzer --apps inets ssl ./ebin ../other_lib/ebin/my_module.beam</code>
           determined by the filename extension. Supported extensions are:
           <c>raw</c>, <c>dot</c>, and <c>ps</c>. If something else is used as
           filename extension, default format <c>.raw</c> is used.</p>
+      </item>
+      <tag><marker id="error_location"></marker><c>--error_location
+        column | line</c></tag>
+      <item>
+        <p>Use a pair <c>{Line, Column}</c> or an integer <c>Line</c>
+          to pinpoint the location of warnings. The default is to use
+          a pair <c>{Line, Column}</c>. When formatted, the line
+          and the column are separated by a colon.</p>
       </item>
       <tag><c>files_or_dirs</c> (for backward compatibility also
         as <c>-c files_or_dirs</c>)</tag>
@@ -416,6 +425,26 @@ dialyzer --plts plt_1 ... plt_n -- files_to_analyze</code>
   </section>
 
   <section>
+    <title>Default Dialyzer Options</title>
+    <p>The (host operating system) environment variable
+      <c>ERL_COMPILER_OPTIONS</c> can be used to give default Dialyzer
+      options. Its value must be a valid Erlang term. If the value is a
+      list, it is used as is. If it is not a list, it is put
+      into a list.</p>
+
+    <p>The list is appended to any options given to
+    <seemfa marker="#run/1">run/1</seemfa> or on the command line.</p>
+
+    <p>The list can be retrieved with
+    <seemfa marker="compiler:compile#env_compiler_options/0">
+    compile:env_compiler_options/0</seemfa>.</p>
+
+    <p>Currently the only option used is the
+    <seeerl marker="#error_location"><c>error_location</c></seeerl> option.
+    </p>
+  </section>
+
+  <section>
     <marker id="suppression"></marker>
     <title>Requesting or Suppressing Warnings in Source Files</title>
     <p>Attribute <c>-dialyzer()</c> can be used for turning off
@@ -482,6 +511,15 @@ dialyzer --plts plt_1 ... plt_n -- files_to_analyze</code>
       <desc></desc>
     </datatype>
     <datatype>
+      <name name="error_location"></name>
+      <desc>
+        <p>If the value of this option is <c>line</c>, an integer
+          <c>Line</c> is used as <c>Location</c> in messages.
+          If the value is <c>column</c>, a pair <c>{Line, Column}</c>
+          is used as <c>Location</c>. The default is <c>column</c>.</p>
+      </desc>
+    </datatype>
+    <datatype>
       <name name="file_location"></name>
     </datatype>
     <datatype>
@@ -514,7 +552,11 @@ dialyzer --plts plt_1 ... plt_n -- files_to_analyze</code>
           <seemfa marker="#run/1"><c>run/1</c></seemfa>.</p>
 	<p>If <c>indent_opt</c> is set to <c>true</c> (default),
           line breaks are inserted in types, contracts, and Erlang
-	  code to improve readability.</p>
+          code to improve readability.</p>
+	<p>If <c>error_location</c> is set to <c>column</c> (default),
+          locations are formatted as <c>Line:Column</c> if the column
+          number is available, otherwise locations are formatted as
+          <c>Line</c> even if the column number is available.</p>
       </desc>
     </func>
 

--- a/lib/dialyzer/src/dialyzer.erl
+++ b/lib/dialyzer/src/dialyzer.erl
@@ -288,9 +288,9 @@ cl_check_log(Output) ->
 format_warning(W) ->
   format_warning(W, basename).
 
--type filename_opt() :: 'basename' | 'fullpath'.
--type format_option() :: {'indent_opt', boolean()}
-                       | {'filename_opt', filename_opt()}.
+-type format_option()  :: {'indent_opt', boolean()}
+                        | {'filename_opt', filename_opt()}
+                        | {'error_location', error_location()}.
 
 -spec format_warning(Warnings, Options) -> string() when
     %% raw_warning() | % not documented
@@ -307,8 +307,16 @@ format_warning({_Tag, {File, Location}, Msg}, Opts) when is_list(File) ->
 	basename -> filename:basename(File)
       end,
   Indent = proplists:get_value(indent_opt, Opts, ?INDENT_OPT),
-  String = message_to_string(Msg, Indent),
-  lists:flatten(io_lib:format("~ts:~s: ~ts", [F, pos(Location), String])).
+  ErrorLocation =
+    proplists:get_value(error_location, Opts, ?ERROR_LOCATION),
+  String = message_to_string(Msg, Indent, ErrorLocation),
+  PosString = pos(Location, ErrorLocation),
+  lists:flatten(io_lib:format("~ts:~s: ~ts", [F, PosString, String])).
+
+pos({Line, _Column}, line) ->
+  pos(Line);
+pos(Location, _ErrorLocation) ->
+  pos(Location).
 
 pos({Line, Column}) when is_integer(Line), is_integer(Column) ->
     io_lib:format("~w:~w", [Line, Column]);
@@ -322,60 +330,60 @@ pos(Line) when is_integer(Line) ->
 
 %%----- Warnings for general discrepancies ----------------
 message_to_string({apply, [Args, ArgNs, FailReason,
-			   SigArgs, SigRet, Contract]}, I) ->
+			   SigArgs, SigRet, Contract]}, I, _E) ->
   io_lib:format("Fun application with arguments ~ts ", [a(Args, I)]) ++
     call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet, Contract, I);
 message_to_string({app_call, [M, F, Args, Culprit, ExpectedType, FoundType]},
-                  I) ->
+                  I, _E) ->
   io_lib:format("The call ~s:~ts~ts requires that ~ts is of type ~ts not ~ts\n",
 		[M, F, a(Args, I), c(Culprit, I),
                  t(ExpectedType, I), t(FoundType, I)]);
-message_to_string({bin_construction, [Culprit, Size, Seg, Type]}, I) ->
+message_to_string({bin_construction, [Culprit, Size, Seg, Type]}, I, _E) ->
   io_lib:format("Binary construction will fail since the ~s field ~s in"
 		" segment ~s has type ~s\n",
                 [Culprit, c(Size, I), c(Seg, I), t(Type, I)]);
 message_to_string({call, [M, F, Args, ArgNs, FailReason,
-			  SigArgs, SigRet, Contract]}, I) ->
+			  SigArgs, SigRet, Contract]}, I, _E) ->
   io_lib:format("The call ~w:~tw~ts ", [M, F, a(Args, I)]) ++
     call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet, Contract, I);
-message_to_string({call_to_missing, [M, F, A]}, _I) ->
+message_to_string({call_to_missing, [M, F, A]}, _I, _E) ->
   io_lib:format("Call to missing or unexported function ~w:~tw/~w\n",
                 [M, F, A]);
-message_to_string({exact_eq, [Type1, Op, Type2]}, I) ->
+message_to_string({exact_eq, [Type1, Op, Type2]}, I, _E) ->
   io_lib:format("The test ~ts ~s ~ts can never evaluate to 'true'\n",
 		[t(Type1, I), Op, t(Type2, I)]);
-message_to_string({fun_app_args, [ArgNs, Args, Type]}, I) ->
+message_to_string({fun_app_args, [ArgNs, Args, Type]}, I, _E) ->
   PositionString = form_position_string(ArgNs),
   io_lib:format("Fun application with arguments ~ts will fail"
 		" since the function has type ~ts,"
                 " which differs in the ~s argument\n",
                 [a(Args, I), t(Type, I), PositionString]);
-message_to_string({fun_app_no_fun, [Op, Type, Arity]}, I) ->
+message_to_string({fun_app_no_fun, [Op, Type, Arity]}, I, _E) ->
   io_lib:format("Fun application will fail since ~ts :: ~ts"
 		" is not a function of arity ~w\n", [Op, t(Type, I), Arity]);
-message_to_string({guard_fail, []}, _I) ->
+message_to_string({guard_fail, []}, _I, _E) ->
   "Clause guard cannot succeed.\n";
-message_to_string({guard_fail, [Arg1, Infix, Arg2]}, I) ->
+message_to_string({guard_fail, [Arg1, Infix, Arg2]}, I, _E) ->
   io_lib:format("Guard test ~ts ~s ~ts can never succeed\n",
                 [a(Arg1, I), Infix, a(Arg2, I)]); % a/2 rather than c/2
-message_to_string({map_update, [Type, Key]}, I) ->
+message_to_string({map_update, [Type, Key]}, I, _E) ->
   io_lib:format("A key of type ~ts cannot exist "
 		"in a map of type ~ts\n", [t(Key, I), t(Type, I)]);
-message_to_string({neg_guard_fail, [Arg1, Infix, Arg2]}, I) ->
+message_to_string({neg_guard_fail, [Arg1, Infix, Arg2]}, I, _E) ->
   io_lib:format("Guard test not(~ts ~s ~ts) can never succeed\n",
 		[a(Arg1, I), Infix, a(Arg2, I)]); % a/2 rather than c/2
-message_to_string({guard_fail, [Guard, Args]}, I) ->
+message_to_string({guard_fail, [Guard, Args]}, I, _E) ->
   io_lib:format("Guard test ~s~ts can never succeed\n", [Guard, a(Args, I)]);
-message_to_string({neg_guard_fail, [Guard, Args]}, I) ->
+message_to_string({neg_guard_fail, [Guard, Args]}, I, _E) ->
   io_lib:format("Guard test not(~s~ts) can never succeed\n",
                 [Guard, a(Args, I)]);
-message_to_string({guard_fail_pat, [Pat, Type]}, I) ->
+message_to_string({guard_fail_pat, [Pat, Type]}, I, _E) ->
   io_lib:format("Clause guard cannot succeed. The ~ts was matched"
 		" against the type ~ts\n", [ps(Pat, I), t(Type, I)]);
-message_to_string({improper_list_constr, [TlType]}, I) ->
+message_to_string({improper_list_constr, [TlType]}, I, _E) ->
   io_lib:format("Cons will produce an improper list"
 		" since its 2nd argument is ~ts\n", [t(TlType, I)]);
-message_to_string({no_return, [Type|Name]}, _I) ->
+message_to_string({no_return, [Type|Name]}, _I, _E) ->
   NameString =
     case Name of
       [] -> "The created fun ";
@@ -387,151 +395,151 @@ message_to_string({no_return, [Type|Name]}, _I) ->
     only_normal -> NameString ++ "has no local return\n";
     both -> NameString ++ "has no local return\n"
   end;
-message_to_string({record_constr, [RecConstr, FieldDiffs]}, I) ->
+message_to_string({record_constr, [RecConstr, FieldDiffs]}, I, _E) ->
   io_lib:format("Record construction ~ts violates the"
 		" declared type of field ~ts\n",
                 [t(RecConstr, I), field_diffs(FieldDiffs, I)]);
-message_to_string({record_constr, [Name, Field, Type]}, I) ->
+message_to_string({record_constr, [Name, Field, Type]}, I, _E) ->
   io_lib:format("Record construction violates the declared type for #~tw{}"
 		" since ~ts cannot be of type ~ts\n",
                 [Name, ps(Field, I), t(Type, I)]);
-message_to_string({record_matching, [String, Name]}, I) ->
+message_to_string({record_matching, [String, Name]}, I, _E) ->
   io_lib:format("The ~ts violates the"
 		" declared type for #~tw{}\n", [rec_type(String, I), Name]);
-message_to_string({record_match, [Pat, Type]}, I) ->
+message_to_string({record_match, [Pat, Type]}, I, _E) ->
   io_lib:format("Matching of ~ts tagged with a record name violates"
                 " the declared type of ~ts\n", [ps(Pat, I), t(Type, I)]);
-message_to_string({pattern_match, [Pat, Type]}, I) ->
+message_to_string({pattern_match, [Pat, Type]}, I, _E) ->
   io_lib:format("The ~ts can never match the type ~ts\n",
                 [ps(Pat, I), t(Type, I)]);
-message_to_string({pattern_match_cov, [Pat, Type]}, I) ->
+message_to_string({pattern_match_cov, [Pat, Type]}, I, _E) ->
   io_lib:format("The ~ts can never match since previous"
 		" clauses completely covered the type ~ts\n",
 		[ps(Pat, I), t(Type, I)]);
-message_to_string({unmatched_return, [Type]}, I) ->
+message_to_string({unmatched_return, [Type]}, I, _E) ->
   io_lib:format("Expression produces a value of type ~ts,"
 		" but this value is unmatched\n", [t(Type, I)]);
-message_to_string({unused_fun, [F, A]}, _I) ->
+message_to_string({unused_fun, [F, A]}, _I, _E) ->
   io_lib:format("Function ~tw/~w will never be called\n", [F, A]);
 %%----- Warnings for specs and contracts -------------------
-message_to_string({contract_diff, [M, F, _A, Contract, Sig]}, I) ->
+message_to_string({contract_diff, [M, F, _A, Contract, Sig]}, I, _E) ->
   io_lib:format("Type specification ~ts"
 		" is not equal to the success typing: ~ts\n",
 		[con(M, F, Contract, I), con(M, F, Sig, I)]);
-message_to_string({contract_subtype, [M, F, _A, Contract, Sig]}, I) ->
+message_to_string({contract_subtype, [M, F, _A, Contract, Sig]}, I, _E) ->
   io_lib:format("Type specification ~ts"
 		" is a subtype of the success typing: ~ts\n",
 		[con(M, F, Contract, I), con(M, F, Sig, I)]);
-message_to_string({contract_supertype, [M, F, _A, Contract, Sig]}, I) ->
+message_to_string({contract_supertype, [M, F, _A, Contract, Sig]}, I, _E) ->
   io_lib:format("Type specification ~ts"
 		" is a supertype of the success typing: ~ts\n",
 		[con(M, F, Contract, I), con(M, F, Sig, I)]);
 message_to_string({contract_range, [Contract, M, F, ArgStrings,
-                                    Location, CRet]}, I) ->
+                                    Location, CRet]}, I, E) ->
   io_lib:format("The contract ~ts cannot be right because the inferred"
 		" return for ~tw~ts on position ~s is ~ts\n",
 		[con(M, F, Contract, I), F, a(ArgStrings, I),
-                 pos(Location), t(CRet, I)]);
-message_to_string({invalid_contract, [M, F, A, Sig]}, I) ->
+                 pos(Location, E), t(CRet, I)]);
+message_to_string({invalid_contract, [M, F, A, Sig]}, I, _E) ->
   io_lib:format("Invalid type specification for function ~w:~tw/~w."
 		" The success typing is ~ts\n", [M, F, A, sig(Sig, I)]);
 message_to_string({contract_with_opaque, [M, F, A, OpaqueType, SigType]},
-                 I) ->
+                 I, _E) ->
   io_lib:format("The specification for ~w:~tw/~w"
                 " has an opaque subtype ~ts which is violated by the"
                 " success typing ~ts\n",
                 [M, F, A, t(OpaqueType, I), sig(SigType, I)]);
-message_to_string({extra_range, [M, F, A, ExtraRanges, SigRange]}, I) ->
+message_to_string({extra_range, [M, F, A, ExtraRanges, SigRange]}, I, _E) ->
   io_lib:format("The specification for ~w:~tw/~w states that the function"
 		" might also return ~ts but the inferred return is ~ts\n",
 		[M, F, A, t(ExtraRanges, I), t(SigRange, I)]);
-message_to_string({missing_range, [M, F, A, ExtraRanges, ContrRange]}, I) ->
+message_to_string({missing_range, [M, F, A, ExtraRanges, ContrRange]}, I, _E) ->
   io_lib:format("The success typing for ~w:~tw/~w implies that the function"
 		" might also return ~ts but the specification return is ~ts\n",
 		[M, F, A, t(ExtraRanges, I), t(ContrRange, I)]);
-message_to_string({overlapping_contract, [M, F, A]}, _I) ->
+message_to_string({overlapping_contract, [M, F, A]}, _I, _E) ->
   io_lib:format("Overloaded contract for ~w:~tw/~w has overlapping domains;"
 		" such contracts are currently unsupported and are simply ignored\n",
 		[M, F, A]);
-message_to_string({spec_missing_fun, [M, F, A]}, _I) ->
+message_to_string({spec_missing_fun, [M, F, A]}, _I, _E) ->
   io_lib:format("Contract for function that does not exist: ~w:~tw/~w\n",
 		[M, F, A]);
 %%----- Warnings for opaque type violations -------------------
-message_to_string({call_with_opaque, [M, F, Args, ArgNs, ExpArgs]}, I) ->
+message_to_string({call_with_opaque, [M, F, Args, ArgNs, ExpArgs]}, I, _E) ->
   io_lib:format("The call ~w:~tw~ts contains ~ts when ~ts\n",
 		[M, F, a(Args, I), form_positions(ArgNs),
                  form_expected(ExpArgs, I)]);
-message_to_string({call_without_opaque, [M, F, Args, ExpectedTriples]}, I) ->
+message_to_string({call_without_opaque, [M, F, Args, ExpectedTriples]}, I, _E) ->
   io_lib:format("The call ~w:~tw~ts does not have ~ts\n",
 		[M, F, a(Args, I),
                  form_expected_without_opaque(ExpectedTriples, I)]);
-message_to_string({opaque_eq, [Type, _Op, OpaqueType]}, I) ->
+message_to_string({opaque_eq, [Type, _Op, OpaqueType]}, I, _E) ->
   io_lib:format("Attempt to test for equality between a term of type ~ts"
 		" and a term of opaque type ~ts\n",
                 [t(Type, I), t(OpaqueType, I)]);
-message_to_string({opaque_guard, [Arg1, Infix, Arg2, ArgNs]}, I) ->
+message_to_string({opaque_guard, [Arg1, Infix, Arg2, ArgNs]}, I, _E) ->
   io_lib:format("Guard test ~ts ~s ~ts contains ~s\n",
 		[a(Arg1, I), Infix, a(Arg2, I), form_positions(ArgNs)]);
-message_to_string({opaque_guard, [Guard, Args]}, I) ->
+message_to_string({opaque_guard, [Guard, Args]}, I, _E) ->
   io_lib:format("Guard test ~w~ts breaks the opacity of its argument\n",
 		[Guard, a(Args, I)]);
-message_to_string({opaque_match, [Pat, OpaqueType, OpaqueTerm]}, I) ->
+message_to_string({opaque_match, [Pat, OpaqueType, OpaqueTerm]}, I, _E) ->
   Term = if OpaqueType =:= OpaqueTerm -> "the term";
 	    true -> t(OpaqueTerm, I)
 	 end,
   io_lib:format("The attempt to match a term of type ~ts against the ~ts"
 		" breaks the opacity of ~ts\n",
                 [t(OpaqueType, I), ps(Pat, I), Term]);
-message_to_string({opaque_neq, [Type, _Op, OpaqueType]}, I) ->
+message_to_string({opaque_neq, [Type, _Op, OpaqueType]}, I, _E) ->
   io_lib:format("Attempt to test for inequality between a term of type ~ts"
 		" and a term of opaque type ~ts\n",
                 [t(Type, I), t(OpaqueType, I)]);
-message_to_string({opaque_type_test, [Fun, Args, Arg, ArgType]}, I) ->
+message_to_string({opaque_type_test, [Fun, Args, Arg, ArgType]}, I, _E) ->
   io_lib:format("The type test ~ts~ts breaks the opacity of the term ~ts~ts\n",
                 [Fun, a(Args, I), Arg, t(ArgType, I)]);
-message_to_string({opaque_size, [SizeType, Size]}, I) ->
+message_to_string({opaque_size, [SizeType, Size]}, I, _E) ->
   io_lib:format("The size ~ts breaks the opacity of ~ts\n",
                 [t(SizeType, I), c(Size, I)]);
-message_to_string({opaque_call, [M, F, Args, Culprit, OpaqueType]}, I) ->
+message_to_string({opaque_call, [M, F, Args, Culprit, OpaqueType]}, I, _E) ->
   io_lib:format("The call ~s:~ts~ts breaks the opacity of the term ~ts :: ~ts\n",
                 [M, F, a(Args, I), c(Culprit, I), t(OpaqueType, I)]);
 %%----- Warnings for concurrency errors --------------------
-message_to_string({race_condition, [M, F, Args, Reason]}, I) ->
+message_to_string({race_condition, [M, F, Args, Reason]}, I, _E) ->
   %% There is a possibly huge type in Reason.
   io_lib:format("The call ~w:~tw~ts ~ts\n", [M, F, a(Args, I), Reason]);
 %%----- Warnings for behaviour errors --------------------
-message_to_string({callback_type_mismatch, [B, F, A, ST, CT]}, I) ->
+message_to_string({callback_type_mismatch, [B, F, A, ST, CT]}, I, _E) ->
   io_lib:format("The inferred return type of ~tw/~w ~ts has nothing in"
                 " common with ~ts, which is the expected return type for"
                 " the callback of the ~w behaviour\n",
                 [F, A, t("("++ST++")", I), t(CT, I), B]);
-message_to_string({callback_arg_type_mismatch, [B, F, A, N, ST, CT]}, I) ->
+message_to_string({callback_arg_type_mismatch, [B, F, A, N, ST, CT]}, I, _E) ->
   io_lib:format("The inferred type for the ~s argument of ~tw/~w (~ts) is"
 		" not a supertype of ~ts, which is expected type for this"
 		" argument in the callback of the ~w behaviour\n",
 		[ordinal(N), F, A, t(ST, I), t(CT, I), B]);
-message_to_string({callback_spec_type_mismatch, [B, F, A, ST, CT]}, I) ->
+message_to_string({callback_spec_type_mismatch, [B, F, A, ST, CT]}, I, _E) ->
   io_lib:format("The return type ~ts in the specification of ~tw/~w is not a"
 		" subtype of ~ts, which is the expected return type for the"
 		" callback of the ~w behaviour\n",
                 [t(ST, I), F, A, t(CT, I), B]);
 message_to_string({callback_spec_arg_type_mismatch, [B, F, A, N, ST, CT]},
-                  I) ->
+                  I, _E) ->
   io_lib:format("The specified type for the ~ts argument of ~tw/~w (~ts) is"
 		" not a supertype of ~ts, which is expected type for this"
 		" argument in the callback of the ~w behaviour\n",
 		[ordinal(N), F, A, t(ST, I), t(CT, I), B]);
-message_to_string({callback_missing, [B, F, A]}, _I) ->
+message_to_string({callback_missing, [B, F, A]}, _I, _E) ->
   io_lib:format("Undefined callback function ~tw/~w (behaviour ~w)\n",
 		[F, A, B]);
-message_to_string({callback_info_missing, [B]}, _I) ->
+message_to_string({callback_info_missing, [B]}, _I, _E) ->
   io_lib:format("Callback info about the ~w behaviour is not available\n", [B]);
 %%----- Warnings for unknown functions, types, and behaviours -------------
-message_to_string({unknown_type, {M, F, A}}, _I) ->
+message_to_string({unknown_type, {M, F, A}}, _I, _E) ->
   io_lib:format("Unknown type ~w:~tw/~w", [M, F, A]);
-message_to_string({unknown_function, {M, F, A}}, _I) ->
+message_to_string({unknown_function, {M, F, A}}, _I, _E) ->
   io_lib:format("Unknown function ~w:~tw/~w", [M, F, A]);
-message_to_string({unknown_behaviour, B}, _I) ->
+message_to_string({unknown_behaviour, B}, _I, _E) ->
   io_lib:format("Unknown behaviour ~w", [B]).
 
 %%-----------------------------------------------------------------------------

--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -145,9 +145,11 @@
                                            'plt_check' |
                                            'plt_remove'}
                        | {'warnings', [warn_option()]}
-                       | {'get_warnings', boolean()}.
+                       | {'get_warnings', boolean()}
+                       | {'error_location', error_location()}.
 -type dial_options()  :: [dial_option()].
--type fopt()          :: 'basename' | 'fullpath'.
+-type filename_opt()  :: 'basename' | 'fullpath'.
+-type error_location():: 'column' | 'line'.
 -type format()        :: 'formatted' | 'raw'.
 -type iopt()          :: boolean().
 -type label()	      :: non_neg_integer().
@@ -162,6 +164,7 @@
 %%--------------------------------------------------------------------
 
 -define(INDENT_OPT, true).
+-define(ERROR_LOCATION, column).
 
 -type doc_plt() :: 'undefined' | dialyzer_plt:plt().
 
@@ -197,10 +200,11 @@
 		  use_contracts   = true           :: boolean(),
 		  output_file     = none	   :: 'none' | file:filename(),
 		  output_format   = formatted      :: format(),
-		  filename_opt	  = basename       :: fopt(),
+		  filename_opt	  = basename       :: filename_opt(),
                   indent_opt      = ?INDENT_OPT    :: iopt(),
 		  callgraph_file  = ""             :: file:filename(),
 		  check_plt       = true           :: boolean(),
+                  error_location  = ?ERROR_LOCATION :: error_location(),
                   solvers         = []             :: [solver()]}).
 
 -record(contract, {contracts	  = []		   :: [contract_pair()],

--- a/lib/dialyzer/src/dialyzer_gui_wx.erl
+++ b/lib/dialyzer/src/dialyzer_gui_wx.erl
@@ -492,7 +492,7 @@ gui_loop(#gui_state{backend_pid = BackendPid, doc_plt = DocPlt,
       update_editor(Log, LogMsg),
       gui_loop(State);
     {BackendPid, warnings, Warns} ->
-      SortedWarns = lists:keysort(2, Warns),  %% Sort on file/line
+      SortedWarns = lists:keysort(2, Warns),  %% Sort on file/location
       NewState = add_warnings(State, SortedWarns),
       gui_loop(NewState);
     {BackendPid, cserver, CServer, Plt} ->
@@ -1141,6 +1141,7 @@ add_warnings(#gui_state{warnings_box = WarnBox,
 			rawWarnings = RawWarns} = State, Warnings) ->
   NewRawWarns = RawWarns ++ Warnings,
   %% The indentation cannot be turned off.
+  %% The column numbers of locations are always displayed.
   WarnList = [string:trim(dialyzer:format_warning(W), trailing) ||
                W <- NewRawWarns],
   wxListBox:set(WarnBox, WarnList),

--- a/lib/dialyzer/test/line_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/line_SUITE_data/dialyzer_options
@@ -1,0 +1,1 @@
+{dialyzer_options, [{error_location, line}, {warnings, [no_return]}]}.

--- a/lib/dialyzer/test/line_SUITE_data/results/trec
+++ b/lib/dialyzer/test/line_SUITE_data/results/trec
@@ -1,0 +1,10 @@
+
+trec.erl:29: The call trec:mk_foo_loc
+         (42,
+          any()) will never return since it differs in the 1st argument from the success typing arguments: 
+         ('undefined',
+          atom())
+trec.erl:32: Record construction violates the declared type for #foo{} since variable A cannot be of type 
+          atom()
+trec.erl:39: Record construction violates the declared type for #foo{} since variable A cannot be of type 
+          atom()

--- a/lib/dialyzer/test/line_SUITE_data/src/trec.erl
+++ b/lib/dialyzer/test/line_SUITE_data/src/trec.erl
@@ -1,0 +1,39 @@
+%%
+%% The current treatment of typed records leaves much to be desired.
+%% These are not made up examples; I have cases like that the branch
+%% of the HiPE compiler with types in records. I get very confusing
+%% warnings which require a lot of effort to find their cause and why
+%% a function has no local return.
+%%
+-module(trec).
+-export([test/0, mk_foo_exp/2]).
+
+-record(foo, {a :: integer() | 'undefined', b :: [atom()]}).
+
+%%
+%% For these functions we currently get the following warnings:
+%%   1. Function test/0 has no local return
+%%   2. The call trec:mk_foo_loc(42,any()) will fail since it differs
+%%      in argument position 1 from the success typing arguments:
+%%      ('undefined',atom())
+%%   3. Function mk_foo_loc/2 has no local return
+%%
+%% Arguably, the second warning is not what most users have in mind when
+%% they wrote the type declarations in the 'foo' record, so no doubt
+%% they'll find it confusing. But note that it is also quite confusing!
+%% Many users may be wondering: How come there is a success typing for a
+%% function that has no local return? Running typer on this module
+%% reveals a success typing for this function that is interesting indeed.
+%%
+test() ->
+   mk_foo_loc(42, some_mod:some_function()).
+
+mk_foo_loc(A, B) ->
+    #foo{a = A, b = [A,B]}.
+
+%%
+%% For this function we used to get a "has no local return" warning
+%% but we got no reason. This has now been fixed.
+%%
+mk_foo_exp(A, B) when is_integer(A) ->
+    #foo{a = A, b = [A,B]}.

--- a/lib/dialyzer/test/small_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/small_SUITE_data/dialyzer_options
@@ -1,1 +1,1 @@
-{dialyzer_options, [{indent_opt, false}]}.
+{dialyzer_options, [{indent_opt, false}, {error_location, column}]}.


### PR DESCRIPTION
Since PR 3006 column numbers are by default included in abstract code,
which implies that Dialyzer includes column numbers in warnings. This
can be a problem for tools using Dialyzer, such as Rebar3.

It does not suffice to say that all analyzed files are to be compiled
with `{error_location, line}' (can be set in ERL_COMPILER_OPTIONS)
since Dialyzer can also analyze source code.

Therefore, the `error_location' option is introduced in Dialyzer as
well. The environment variable ERL_COMPILER_OPTIONS is also
recognized.