### PR TITLE
odbc: Fix odbcserver not terminated at timeout

### DIFF
--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -259,10 +259,10 @@ static void str_tolower(char *str, int len);
 /* ----------------------------- CODE ------------------------------------*/
 
 #if defined(WIN32)
-#  define DO_EXIT(code) do { ExitProcess((code)); exit((code));} while (0)
-/* exit() called only to avoid a warning */
+#  define DO_EXIT(code) do { ExitProcess((code)); _exit((code));} while (0)
+/* _exit() called only to avoid a warning */
 #else
-#  define DO_EXIT(code) exit((code))
+#  define DO_EXIT(code) _exit((code))
 #endif
 
 /* ----------------- Main functions --------------------------------------*/


### PR DESCRIPTION
When a query timeout and makes the client process exit with reason
timeout the odbcserver port pogram is not terminated on port_close/1.

https://bugs.erlang.org/browse/ERL-1448

This happens on CentOS Linux 7.8 x86_64 as well as Red Hat Enterprise Linux 7.8 x86_64
and that is the only platforms I have tested the fix on.

I can reproduce this behaviour with the following code

`
F1 = fun() -> {ok, Ref} = odbc:connect(Conn, Opts),
             odbc:sql_query(Ref, SomeQuery, 1)
        end,
P1 = spawn_link(F1).
`
And then I run the following command too see that the process is still up
`
ps aux | grep odbcserver
`
