### PR TITLE
Ease static analysis of parse_transform implementations

### DIFF
--- a/lib/compiler/doc/src/Makefile
+++ b/lib/compiler/doc/src/Makefile
@@ -31,7 +31,7 @@ APPLICATION=compiler
 # Target Specs
 # ----------------------------------------------------
 XML_APPLICATION_FILES = ref_man.xml
-XML_REF3_FILES = compile.xml
+XML_REF3_FILES = compile.xml parse_transform.xml
 EDOC_REF3_FILES =  cerl.xml cerl_trees.xml cerl_clauses.xml
 
 XML_PART_FILES = internal.xml
@@ -48,5 +48,7 @@ XML_FILES = \
 
 $(XMLDIR)/%.xml: ../../internal_doc/%.md $(ERL_TOP)/make/emd2exml
 	$(ERL_TOP)/make/emd2exml $< $@
+
+NO_CHUNKS = parse_transform.xml
 
 include $(ERL_TOP)/make/doc.mk

--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -442,7 +442,9 @@ module.beam: module.erl \
           <item>
             <p>Causes the parse transformation function
               <c>Module:parse_transform/2</c> to be applied to the
-              parsed code before the code is checked for errors.</p>
+              parsed code before the code is checked for errors.
+              <c>Module</c> must implement behaviour
+              <seeerl marker="parse_transform">parse_transform</seeerl></p>
           </item>
 
 	  <tag><c>from_abstr</c></tag>

--- a/lib/compiler/doc/src/parse_transform.xml
+++ b/lib/compiler/doc/src/parse_transform.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE erlref SYSTEM "erlref.dtd">
+
+<erlref>
+  <header>
+    <copyright>
+      <year>2021</year>
+      <holder>Ericsson AB, All Rights Reserved</holder>
+    </copyright>
+    <legalnotice>
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+      The Initial Developer of the Original Code is Ericsson AB.
+    </legalnotice>
+    <title>parse_transform</title>
+    <prepared></prepared>
+    <docno></docno>
+    <date></date>
+    <rev></rev>
+  </header>
+  <module since="">parse_transform</module>
+  <modulesummary>-behaviour(parse_transform).</modulesummary>
+
+  <description>
+    <p>The following section describes the callback functions
+       that the compiler uses to apply a parse transformation to
+       parsed code.</p>
+  </description>
+
+  <funcs>
+    <fsdescription>
+      <title>Callback Functions</title>
+      <p>The following functions are to be exported from a
+         <c>parse_transform</c> callback module in order to define
+         the callback interface for a parse transformation.</p>
+    </fsdescription>
+
+    <func>
+      <name since="">Module:parse_transform(Forms, Options) -> Forms</name>
+      <fsummary></fsummary>
+      <type>
+        <v>Forms = [<seetype marker="stdlib:erl_parse#abstract_form">erl_parse:abstract_form()</seetype>
+           | <seetype marker="stdlib:erl_parse#form_info">erl_parse:form_info()</seetype>]</v>
+        <v>Options = [<seetype marker="compile#option">compile:option()</seetype>]</v>
+      </type>
+      <desc>
+        <p>MANDATORY</p>
+        <p>Defines the parse transformation function to be applied to
+           the parsed code.</p>
+      </desc>
+    </func>
+
+  </funcs>
+</erlref>

--- a/lib/compiler/doc/src/ref_man.xml
+++ b/lib/compiler/doc/src/ref_man.xml
@@ -35,5 +35,6 @@
       the Erlang emulator.</p>
   </description>
   <xi:include href="compile.xml"/>
+  <xi:include href="parse_transform.xml"/>
 </application>
 

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -45,6 +45,9 @@ RELSYSDIR = $(RELEASE_PATH)/lib/compiler-$(VSN)
 # ----------------------------------------------------
 # Target Specs
 # ----------------------------------------------------
+BEHAVIOUR_MODULES= \
+	parse_transform
+
 MODULES =  \
 	beam_a \
 	beam_asm \
@@ -118,8 +121,14 @@ YRL_FILE = core_parse.yrl
 
 EXTRA_FILES= $(EGEN)/beam_opcodes.hrl
 
-ERL_FILES= $(MODULES:%=%.erl)
-INSTALL_FILES= $(MODULES:%=$(EBIN)/%.$(EMULATOR)) $(APP_TARGET) $(APPUP_TARGET)
+ERL_FILES= \
+	$(BEHAVIOUR_MODULES:%=%.erl) \
+	$(MODULES:%=%.erl)
+INSTALL_FILES= \
+	$(BEHAVIOUR_MODULES:%=$(EBIN)/%.$(EMULATOR)) \
+	$(MODULES:%=$(EBIN)/%.$(EMULATOR)) \
+	$(APP_TARGET) \
+	$(APPUP_TARGET)
 TARGET_FILES= $(INSTALL_FILES)
  
 APP_FILE= compiler.app

--- a/lib/compiler/src/parse_transform.erl
+++ b/lib/compiler/src/parse_transform.erl
@@ -1,0 +1,9 @@
+-module(parse_transform).
+
+%%------------------------------------------------------------------
+%% Parse Transform Behaviour
+%% ------------------------------------------------------------------
+
+-callback parse_transform(Forms, Options) -> Forms
+          when Forms :: [erl_parse:abstract_form() | erl_parse:form_info()],
+               Options :: [compile:option()].


### PR DESCRIPTION
The goal of this pull request is to provide a mechanism to ease static analysis (e.g. `xref` and `dialyzer`) for implementations of `parse_transform`s, as well as have in/out-source documentation for that.

To this end:
1. I add a new `parse_transform.erl` module,
2. I add a documentation page for this module,
3. I reference this documentation from `compile.xml`.

What's missing?
- [ ] understanding if this is something we want in OTP,
- [ ] understanding if the behaviour-defining module name is acceptable,
- [ ] understanding if the documentation should be in the `compiler` namespace
- [ ] understanding if the new behaviour should be declared in modules like `merl_transform`, `ms_transform`, ...

**Note** on the motivation for this: I was going through some lib.s that implement parse transformations, looking at OTP 24, and figured that the recent change to the compiler's line v. line/col output would be sometimes difficult to achieve, but `dialyzer` could help if there were a well defined behaviour for this, and also not to have to add `rebar3`-specific `ignore_xref` where a parse_transform is defined.