### PR TITLE
dialyzer: Allow suppressing localized underspecs

### DIFF
--- a/lib/dialyzer/src/dialyzer_options.erl
+++ b/lib/dialyzer/src/dialyzer_options.erl
@@ -333,6 +333,8 @@ build_warnings([Opt|Opts], Warnings) ->
 	ordsets:add_element(?WARN_CONTRACT_SUBTYPE, Warnings);
       underspecs ->
 	ordsets:add_element(?WARN_CONTRACT_SUPERTYPE, Warnings);
+      no_underspecs ->
+    ordsets:del_element(?WARN_CONTRACT_SUPERTYPE, Warnings);
       unknown ->
 	ordsets:add_element(?WARN_UNKNOWN, Warnings);
       OtherAtom ->


### PR DESCRIPTION
(opening as a draft, since I also asked a question in https://bugs.erlang.org/browse/ERL-1480)

I'm not fully aware of all the implications of suppressing that warning just in this fashion, but my local tests yielded the results I expected (no warning).