### PR TITLE
erts: Fix seq_trace token gc

### DIFF
--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -1841,10 +1841,13 @@ new_seq_trace_token(Process* p, int ensure_new_heap)
 				    make_small(p->seq_trace_lastcnt));
     }
     else if (ensure_new_heap) {
+        Eterm *mature = p->abandoned_heap ? p->abandoned_heap : p->heap;
+        Uint mature_size = p->high_water - mature;
         Eterm* tpl = tuple_val(SEQ_TRACE_TOKEN(p));
         ASSERT(arityval(tpl[0]) == 5);
         if (ErtsInArea(tpl, OLD_HEAP(p),
-                       (OLD_HEND(p) - OLD_HEAP(p))*sizeof(Eterm))) {
+                       (OLD_HEND(p) - OLD_HEAP(p))*sizeof(Eterm)) ||
+            ErtsInArea(tpl, mature, mature_size*sizeof(Eterm))) {
             hp = HAlloc(p, 6);
             sys_memcpy(hp, tpl, 6*sizeof(Eterm));
             SEQ_TRACE_TOKEN(p) = make_tuple(hp);

--- a/lib/kernel/test/seq_trace_SUITE.erl
+++ b/lib/kernel/test/seq_trace_SUITE.erl
@@ -538,18 +538,24 @@ call(Config) when is_list(Config) ->
 
 %% The token should follow spawn, just like it follows messages.
 inherit_on_spawn(Config) when is_list(Config) ->
-    lists:foreach(fun (Test) ->
-                          inherit_on_spawn_test(Test)
-                  end,
-                  [spawn, spawn_link, spawn_monitor,
-                   spawn_opt, spawn_request]),
+    lists:foreach(
+      fun (Test) ->
+              lists:foreach(
+                fun (TraceFlags) ->
+                        inherit_on_spawn_test(Test, TraceFlags)
+                end,
+                combinations(spawn_trace_flags()))
+      end,
+      [spawn, spawn_link, spawn_monitor,
+       spawn_opt, spawn_request]),
     ok.
 
-inherit_on_spawn_test(Spawn) ->
-    io:format("Testing ~p()~n", [Spawn]),
+inherit_on_spawn_test(Spawn, TraceFlags) ->
+    io:format("Testing ~p() with ~p trace flags~n", [Spawn, TraceFlags]),
 
     seq_trace:reset_trace(),
     start_tracer(),
+    start_spawn_tracer(TraceFlags),
 
     Ref = make_ref(),
     seq_trace:set_token(label,Ref),
@@ -580,6 +586,7 @@ inherit_on_spawn_test(Spawn) ->
 
     receive {gurka,Ref} -> ok end,
     seq_trace:reset_trace(),
+    erlang:trace(self(),false,[procs|TraceFlags]),
 
     Sequence = lists:keysort(3, stop_tracer(6)),
     io:format("Sequence: ~p~n", [Sequence]),
@@ -644,8 +651,34 @@ inherit_on_spawn_test(Spawn) ->
        GurkaMsg},
       _} = RGurkaMsg,
 
+
+    Links = not(spawn =:= spawn orelse Spawn =:= spawn_monitor),
+    SoL = lists:member(set_on_link,TraceFlags) orelse
+        lists:member(set_on_first_link,TraceFlags),
+    SoS = lists:member(set_on_spawn,TraceFlags) orelse
+        lists:member(set_on_first_sapwn,TraceFlags),
+
+    NoTraceMessages =
+        if
+            SoS andalso Links ->
+                4;
+            SoS andalso not Links ->
+                2;
+            SoL andalso Links ->
+                4;
+            SoL andalso not Links->
+                1;
+            Links andalso not SoL andalso not SoS ->
+                2;
+            not Links andalso not SoL andalso not SoS ->
+                1
+        end,
+
+    TraceMessages = stop_spawn_tracer(NoTraceMessages),
+
     unlink(Other),
     exit(Other, kill),
+
 
     ok.
 
@@ -1384,7 +1417,6 @@ start_tracer(Node) ->
             unlink(Pid),
             Pid
     end.
-           
 
 set_token_flags([]) ->
     ok;
@@ -1396,6 +1428,51 @@ set_token_flags([no_timestamp|Flags]) ->
 set_token_flags([Flag|Flags]) ->
     seq_trace:set_token(Flag, true),
     set_token_flags(Flags).
+
+start_spawn_tracer(TraceFlags) ->
+
+    %% Disable old trace flags
+    erlang:trace(self(), false, spawn_trace_flags()),
+
+    Me = self(),
+    Ref = make_ref(),
+    Pid = spawn_link(
+            fun () ->
+                    register(spawn_tracer, self()),
+                    Me ! Ref,
+                    (fun F(Data) ->
+                             receive
+                                 {get, N, StopRef, Pid} when N =< length(Data) ->
+                                     Pid ! {lists:reverse(Data), StopRef};
+                                 M when element(1,M) =:= trace ->
+                                     F([M|Data])
+                             end
+                    end)([])
+            end),
+    receive
+        Ref ->
+            erlang:trace(self(),true,[{tracer,Pid}, procs | TraceFlags])
+    end.
+
+stop_spawn_tracer(N) ->
+    Ref = make_ref(),
+    spawn_tracer ! {get, N, Ref, self()},
+    receive
+        {Data, Ref} ->
+            Data
+    end.
+
+spawn_trace_flags() ->
+    [set_on_spawn, set_on_link, set_on_spawn,
+     set_on_first_link, set_on_first_spawn].
+
+combinations(Flags) ->
+    %% Do a bit of sofs magic to create a list of lists with
+    %% all the combinations of all the flags above
+    Set = sofs:from_term(Flags),
+    Product = sofs:product(list_to_tuple(lists:duplicate(length(Flags),Set))),
+    Combinations = [lists:usort(tuple_to_list(T)) || T <- sofs:to_external(Product)],
+    [[] | lists:usort(Combinations)].
 
 check_ts(no_timestamp, Ts) ->
     try


### PR DESCRIPTION
If the seq_trace tuple is on the mature side of the young heap we need to make a copy as otherwise
the tuple will be promited to the old heap before the token which will lead to all kinds of issues.