### PR TITLE
Remove old mac init code

### DIFF
--- a/lib/wx/c_src/wxe_ps_init.c
+++ b/lib/wx/c_src/wxe_ps_init.c
@@ -29,19 +29,8 @@
 
 extern OSErr  CPSSetProcessName (ProcessSerialNumber *psn, char *processname);
 
-void * wxe_ps_init() 
+void * wxe_ps_init()
 {
-   ProcessSerialNumber psn;
-   // Enable GUI 
-   if(!GetCurrentProcess(&psn)) {
-      TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-#ifdef  MAC_OS_X_VERSION_10_6
-      [[NSRunningApplication currentApplication] activateWithOptions:
-       (NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
-#else 
-      SetFrontProcess(&psn);
-#endif
-   }
    return (void *) 0;
 }
 
@@ -66,7 +55,6 @@ void * wxe_ps_init2() {
    char * app_title;
    size_t app_icon_len = 1023;
    char app_icon_buf[1024];
-   char * app_icon;
 
    // Setup and enable gui
    pool = [[NSAutoreleasePool alloc] init];


### PR DESCRIPTION
wxWidgets does it in its init code and it causes harm on newer MacOs's,
i.e. the top-menus doesn't work.

A fix is merged to wxWidgets master branch and will be released as
wxWidgets-3.1.5 until then top menues will not work on mac.

On old macos the old init code in wxWidgets still work and is not
needed in wx driver init.