### PR TITLE
Do not centralize type/cname lookups through inet_db

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -35,10 +35,10 @@
 -export([start/0, start_link/0, stop/0, reset/0, clear_cache/0]).
 -export([add_rr/1,add_rr/5,del_rr/4]).
 -export([add_ns/1,add_ns/2, ins_ns/1, ins_ns/2,
-	 del_ns/2, del_ns/1, del_ns/0]).
--export([add_alt_ns/1,add_alt_ns/2, ins_alt_ns/1, ins_alt_ns/2, 
-	 del_alt_ns/2, del_alt_ns/1, del_alt_ns/0]).
--export([add_search/1,ins_search/1,del_search/1, del_search/0]).
+	 del_ns/2, del_ns/1]).
+-export([add_alt_ns/1,add_alt_ns/2, ins_alt_ns/1, ins_alt_ns/2,
+	 del_alt_ns/2, del_alt_ns/1]).
+-export([add_search/1,ins_search/1,del_search/1]).
 -export([set_lookup/1, set_recurse/1]).
 -export([set_socks_server/1, set_socks_port/1, add_socks_methods/1,
 	 del_socks_methods/1, del_socks_methods/0,
@@ -166,9 +166,6 @@ del_ns(IP) ->
 del_ns(IP, Port) ->
     call({listop, nameservers, del, {IP,Port}}).
 
-del_ns() -> 
-    call({listdel, nameservers}).
-
 %% ALTERNATIVE NAME SERVER
 %% add to the end of name server list
 add_alt_ns(IP) -> 
@@ -188,9 +185,6 @@ del_alt_ns(IP) ->
 del_alt_ns(IP, Port) ->
     call({listop, alt_nameservers, del, {IP,Port}}).
 
-del_alt_ns() -> 
-    call({listdel, alt_nameservers}).
-
 %% add this domain to the search list
 add_search(Domain) when is_list(Domain) -> 
     call({listop, search, add, Domain}).
@@ -200,9 +194,6 @@ ins_search(Domain) when is_list(Domain) ->
 
 del_search(Domain) ->
     call({listop, search, del, Domain}).
-
-del_search() ->
-    call({listdel, search}).
 
 %% set host name used by inet
 %% Should only be used by inet_config at startup!
@@ -706,7 +697,7 @@ lookup_cname(Domain) ->
 %% Have to do all lookups (changes to the db) in the
 %% process in order to make it possible to refresh the cache.
 lookup_rr(Domain, Class, Type) ->
-    call({lookup_rr, Domain, Class, Type}).
+    match_rr({Domain, Class, Type}).
 
 %%
 %% hostent_by_domain (newly resolved version)
@@ -992,9 +983,6 @@ handle_call(Request, From, #state{db=Db}=State) ->
 	    ets:delete(Cache, cache_key(RR)),
 	    {reply, ok, State};
 
-	{lookup_rr, Domain, Class, Type} ->
-	    {reply, match_rr({Domain, Class, Type}), State};
-
 	{listop, Opt, Op, E} ->
 	    El = [E],
 	    case res_check_option(Opt, El) of
@@ -1012,9 +1000,14 @@ handle_call(Request, From, #state{db=Db}=State) ->
 		    {reply,error,State}
 	    end;
 
-	{listdel, Opt} ->
- 	    ets:insert(Db, {res_optname(Opt), []}),
- 	    {reply, ok, State};
+	{listreplace, Opt, Els} ->
+	    case res_check_option(Opt, Els) of
+		true ->
+		    ets:insert(Db, {res_optname(Opt), Els}),
+		    {reply,ok,State};
+		false ->
+		    {reply,error,State}
+	    end;
 
 	{set_hostname, Name} ->
 	    case inet_parse:visible_string(Name) of
@@ -1065,11 +1058,10 @@ handle_call(Request, From, #state{db=Db}=State) ->
 					(_, S) ->
 					    S
 				    end, [], Opts),
-			      [del_ns,
-			       clear_search,
-			       clear_cache,
-			       {search,Search}
-			       |[Opt || {nameserver,_}=Opt <- Opts]];
+			      NSs = [{NS,?NAMESERVER_PORT} || {nameserver,NS} <- Opts],
+			      [{replace_search,Search},
+			       {replace_ns,NSs},
+			       clear_cache];
 			  _ -> error
 		      end
 	      end,
@@ -1556,6 +1548,10 @@ rc_opt_req({lookup, Ls}) ->
     try {res_set, lookup, translate_lookup(Ls)}
     catch error:_ -> undefined
     end;
+rc_opt_req({replace_ns,Ns}) ->
+    {listreplace,nameservers,Ns};
+rc_opt_req({replace_search,Search}) ->
+    {listreplace,search,Search};
 rc_opt_req({Name,Arg}) ->
     case rc_reqname(Name) of
 	undefined ->
@@ -1565,14 +1561,10 @@ rc_opt_req({Name,Arg}) ->
 	    end;
 	Req -> {Req, Arg}
     end;
-rc_opt_req(del_ns) ->
-    {listdel,nameservers};
-rc_opt_req(del_alt_ns) ->
-    {listdel,alt_nameservers};
 rc_opt_req(clear_ns) ->
-    [{listdel,nameservers},{listdel,alt_nameservers}];
+    [{listreplace,nameservers,[]},{listreplace,alt_nameservers,[]}];
 rc_opt_req(clear_search) ->
-    {listdel,search};
+    {listreplace,search,[]};
 rc_opt_req(Opt) when is_atom(Opt) ->
     case is_reqname(Opt) of
 	true -> Opt;


### PR DESCRIPTION
Before this patch, inet_res:getbyname lookups
were centralized through the inet_db process, which
made it a bottleneck on concurrent machines that need
to establish many connections to several hosts quickly.

Since the lookups are now concurrent, the update of
resolve.conf has been changed to use atomic operations
that replace the list of servers and list of names.

The inet_db API has also been cleaned up to no longer
expose operations that delete all searches/namespaces/etc.
Those functions seem safe to remove as they are not
used anywhere within Erlang/OTP. The atomic replace
operations can be made public if desired in the future.
There are also other unused functions which we can
remove in the future.

This is a regen of #2818 and follow up to #2891.