### PR TITLE
Add more checking for dynamic M:F(A)

### DIFF
--- a/lib/dialyzer/test/small_SUITE_data/results/dynamic_application
+++ b/lib/dialyzer/test/small_SUITE_data/results/dynamic_application
@@ -1,0 +1,6 @@
+
+dynamic_application.erl:27:17: The call module_func_wrong_arg_type_list:func('an_arg') will never return since it differs in the 1st argument from the success typing arguments: ([])
+dynamic_application.erl:27:17: The call module_func_wrong_arg_type_number:func('an_arg') will never return since it differs in the 1st argument from the success typing arguments: (2 | 4)
+dynamic_application.erl:27:5: Call to missing or unexported function module_func_missing:func/1
+dynamic_application.erl:31:17: The call module_func_wrong_arg_type_list:func('an_arg') will never return since it differs in the 1st argument from the success typing arguments: ([])
+dynamic_application.erl:31:17: The call module_func_wrong_arg_type_number:func('an_arg') will never return since it differs in the 1st argument from the success typing arguments: (2 | 4)

--- a/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/dynamic_application.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/dynamic_application.erl
@@ -1,0 +1,35 @@
+-module(dynamic_application).
+
+-export([test_detect_bad_application_if_all_modules_have_wrong_type/0]).
+-export([test_detect_bad_application_if_all_modules_have_wrong_type_or_missing_function/0]).
+-export([test_accept_application_if_some_modules_are_ok/0]).
+
+% This test verifies that function calls on (potentially multiple) dynamically
+% provided modules are checked for incorrect argument types or entirely missing
+% functions.
+
+test_detect_bad_application_if_all_modules_have_wrong_type() ->
+    invoke_all_wrong_type(module_func_wrong_arg_type_list),
+    invoke_all_wrong_type(module_func_wrong_arg_type_number).
+
+test_detect_bad_application_if_all_modules_have_wrong_type_or_missing_function() ->
+    invoke_all_wrong_type_or_missing(module_func_missing),
+    invoke_all_wrong_type_or_missing(module_func_wrong_arg_type_list),
+    invoke_all_wrong_type_or_missing(module_func_wrong_arg_type_number).
+
+test_accept_application_if_some_modules_are_ok() ->
+    invoke_some_ok(module_func_wrong_arg_type_list),
+    invoke_some_ok(module_func_wrong_arg_type_number),
+    invoke_some_ok(module_func_ok).
+
+-spec invoke_all_wrong_type_or_missing(module_func_wrong_arg_type_list | module_func_wrong_arg_type_number | module_func_missing) -> term().
+invoke_all_wrong_type_or_missing(Module) ->
+    Module:func(an_arg).
+
+-spec invoke_all_wrong_type(module_func_wrong_arg_type_list | module_func_wrong_arg_type_number) -> term().
+invoke_all_wrong_type(Module) ->
+    Module:func(an_arg).
+
+-spec invoke_some_ok(module_func_wrong_arg_type_list | module_func_wrong_arg_type_number | module_func_ok) -> term().
+invoke_some_ok(Module) ->
+    Module:func(an_arg).

--- a/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/module_func_missing.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/module_func_missing.erl
@@ -1,0 +1,4 @@
+-module(module_func_missing).
+-export([quux/1]).
+
+quux([]) -> [].

--- a/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/module_func_ok.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/module_func_ok.erl
@@ -1,0 +1,4 @@
+-module(module_func_ok).
+-export([func/1]).
+
+func(an_arg) -> ok.

--- a/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/module_func_wrong_arg_type_list.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/module_func_wrong_arg_type_list.erl
@@ -1,0 +1,4 @@
+-module(module_func_wrong_arg_type_list).
+-export([func/1]).
+
+func([]) -> [].

--- a/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/module_func_wrong_arg_type_number.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/dynamic_application/module_func_wrong_arg_type_number.erl
@@ -1,0 +1,5 @@
+-module(module_func_wrong_arg_type_number).
+-export([func/1]).
+
+func(2) -> 3;
+func(4) -> 6.


### PR DESCRIPTION
This involves two parts:
1. Make Dialyzer check M:F(A) if there is more than one module atom inferred by the success typing
2. Make Dialyzer reject calls where a module exists but the function doesn't (i.e. we know for sure the function is not implemented)

There's still some cruft here to clean up, including some comments that need to be deleted/resolved and some whitespace changes that I should probably undo.