### PR TITLE
Error message types

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -55,10 +55,10 @@
 
 -type option() :: atom() | {atom(), term()} | {'d', atom(), term()}.
 
--type err_info() :: {erl_anno:line() | 'none',
-		     module(), term()}. %% ErrorDescriptor
--type errors()   :: [{file:filename(), [err_info()]}].
--type warnings() :: [{file:filename(), [err_info()]}].
+-type error_description() :: erl_lint:error_description().
+-type error_info() :: erl_lint:error_info().
+-type errors()   :: [{file:filename(), [error_info()]}].
+-type warnings() :: [{file:filename(), [error_info()]}].
 -type mod_ret()  :: {'ok', module()}
                   | {'ok', module(), cerl:c_module()} %% with option 'to_core'
                   | {'ok',                            %% with option 'to_pp'
@@ -292,9 +292,8 @@ expand_opt_before_21(Os) ->
      no_put_tuple2, no_get_hd_tl, no_ssa_opt_record,
      no_utf8_atoms, no_recv_opt | expand_opt(no_bsm3, Os)].
 
-%% format_error(ErrorDescriptor) -> string()
 
--spec format_error(term()) -> iolist().
+-spec format_error(error_description()) -> iolist().
 
 format_error(no_crypto) ->
     "this system is not configured with crypto support.";
@@ -340,8 +339,6 @@ format_error_reason({Reason, Stack}) when is_list(Stack) ->
 format_error_reason(Reason) ->
     io_lib:format("~tp", [Reason]).
 
--type err_warn_info() :: tuple().
-
 %% The compile state record.
 -record(compile, {filename="" :: file:filename(),
 		  dir=""      :: file:filename(),
@@ -353,8 +350,8 @@ format_error_reason(Reason) ->
 		  options=[]  :: [option()],  %Options for compilation
 		  mod_options=[]  :: [option()], %Options for module_info
                   encoding=none :: none | epp:source_encoding(),
-		  errors=[]     :: [err_warn_info()],
-		  warnings=[]   :: [err_warn_info()],
+		  errors=[]     :: errors(),
+		  warnings=[]   :: warnings(),
 		  extra_chunks=[] :: [{binary(), binary()}]}).
 
 internal({forms,Forms}, Opts0) ->

--- a/lib/compiler/src/sys_messages.erl
+++ b/lib/compiler/src/sys_messages.erl
@@ -22,11 +22,10 @@
 
 -export([format_messages/4, list_errors/3]).
 
--type pos() :: integer() | {integer(), integer()}.
--type err_warn_info() :: tuple().
--type message() :: {Where :: none | {File::string(), pos()}, Text :: iolist()}.
+-type loc() :: erl_anno:location().
+-type message() :: {Where :: none | {File::string(), loc()}, Text :: iolist()}.
 
--spec format_messages(File::string(), Prefix::string(), [err_warn_info()],
+-spec format_messages(File::string(), Prefix::string(), [erl_lint:error_info()],
                       Opts::[term()]) -> [message()].
 
 format_messages(F, P, [{none, Mod, E} | Es], Opts) ->
@@ -48,7 +47,7 @@ format_messages(F, P, [{Loc, Mod, E} | Es], Opts) ->
 format_messages(_, _, [], _Opts) ->
     [].
 
--spec list_errors(File::string(), [err_warn_info()], Opts::[term()]) -> ok.
+-spec list_errors(File::string(), [erl_lint:error_info()], Opts::[term()]) -> ok.
 
 list_errors(F, [{none, Mod, E} | Es], Opts) ->
     io:fwrite("~ts: ~ts\n", [F, Mod:format_error(E)]),

--- a/lib/compiler/test/core_SUITE.erl
+++ b/lib/compiler/test/core_SUITE.erl
@@ -163,7 +163,7 @@ core_lint_function(Exports, Attributes, Body) ->
     MainFun = cerl:c_fun([], Body),
     MainVar = cerl:c_var({main,0}),
     Mod = cerl:c_module(ModName, Exports, Attributes, [{MainVar,MainFun}]),
-    {error,[{core_lint_test,Errors}],[]} =
+    {error,[{"core_lint_test",Errors}],[]} =
         compile:forms(Mod, [from_core,clint0,return]),
     io:format("~p\n", [Errors]),
     [] = lists:filter(fun({none,core_lint,_}) -> false;

--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -414,7 +414,7 @@ unused_multiple_values_error(Config) when is_list(Config) ->
     Core = filename:join(Dir, "unused_multiple_values_error"),
     Opts = [no_copt,clint,ssalint,return,from_core,{outdir,PrivDir}
 	   |test_lib:opt_opts(?MODULE)],
-    {error,[{unused_multiple_values_error,
+    {error,[{"unused_multiple_values_error",
 	     [{none,core_lint,{return_mismatch,{hello,1}}}]}],
      []} = c:c(Core, Opts),
     ok.

--- a/lib/stdlib/doc/src/erl_lint.xml
+++ b/lib/stdlib/doc/src/erl_lint.xml
@@ -132,7 +132,7 @@
           <seeerl marker="erl_parse"><c>erl_parse(3)</c></seeerl> module).
           The returned errors and warnings have the following format:</p>
         <code type="none">
-[{<anno>FileName2</anno>,[<anno>ErrorInfo</anno>]}]</code>
+[{<anno>SourceFile</anno>,[<anno>ErrorInfo</anno>]}]</code>
         <p>The errors and warnings are listed in the order in which they are
           encountered in the forms. The errors from one file can therefore be
           split into different entries in the list of errors.</p>

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -28,6 +28,8 @@
 -export([is_guard_expr/1]).
 -export([bool_option/4,value_option/3,value_option/7]).
 
+-export_type([error_info/0, error_description/0]).
+
 -import(lists, [all/2,any/2,
                 foldl/3,foldr/3,
                 map/2,mapfoldl/3,member/2,
@@ -129,8 +131,8 @@ value_option(Flag, Default, On, OnVal, Off, OffVal, Opts) ->
                warn_format=0,                   %Warn format calls
 	       enabled_warnings=[],		%All enabled warnings (ordset).
                nowarn_bif_clash=[],             %All no warn bif clashes (ordset).
-               errors=[],                       %Current errors
-               warnings=[],                     %Current warnings
+               errors=[]   :: [{file:filename(),error_info()}], %Current errors
+               warnings=[] :: [{file:filename(),error_info()}], %Current warnings
                file = ""        :: string(),	%From last file attribute
                recdef_top=false :: boolean(),	%true in record initialisation
 						%outside any fun or lc
@@ -154,7 +156,7 @@ value_option(Flag, Default, On, OnVal, Off, OffVal, Opts) ->
 
 -type lint_state() :: #lint{}.
 -type error_description() :: term().
--type error_info() :: {erl_anno:location(), module(), error_description()}.
+-type error_info() :: {erl_anno:location()|'none', module(), error_description()}.
 
 %% format_error(Error)
 %%  Return a string describing the error.
@@ -529,8 +531,9 @@ used_vars(Exprs, BindingsList) ->
 
 -spec(module(AbsForms) -> {ok, Warnings} | {error, Errors, Warnings} when
       AbsForms :: [erl_parse:abstract_form() | erl_parse:form_info()],
-      Warnings :: [{file:filename(),[ErrorInfo]}],
-      Errors :: [{FileName2 :: file:filename(),[ErrorInfo]}],
+      Warnings :: [{SourceFile,[ErrorInfo]}],
+      Errors :: [{SourceFile,[ErrorInfo]}],
+      SourceFile :: file:filename(),
       ErrorInfo :: error_info()).
 
 module(Forms) ->
@@ -542,8 +545,9 @@ module(Forms) ->
              {ok, Warnings} | {error, Errors, Warnings} when
       AbsForms :: [erl_parse:abstract_form() | erl_parse:form_info()],
       FileName :: atom() | string(),
-      Warnings :: [{file:filename(),[ErrorInfo]}],
-      Errors :: [{FileName2 :: file:filename(),[ErrorInfo]}],
+      Warnings :: [{SourceFile,[ErrorInfo]}],
+      Errors :: [{SourceFile,[ErrorInfo]}],
+      SourceFile :: file:filename(),
       ErrorInfo :: error_info()).
 
 module(Forms, FileName) ->
@@ -556,8 +560,9 @@ module(Forms, FileName) ->
       AbsForms :: [erl_parse:abstract_form() | erl_parse:form_info()],
       FileName :: atom() | string(),
       CompileOptions :: [compile:option()],
-      Warnings :: [{file:filename(),[ErrorInfo]}],
-      Errors :: [{FileName2 :: file:filename(),[ErrorInfo]}],
+      Warnings :: [{SourceFile,[ErrorInfo]}],
+      Errors :: [{SourceFile,[ErrorInfo]}],
+      SourceFile :: file:filename(),
       ErrorInfo :: error_info()).
 
 module(Forms, FileName, Opts0) ->


### PR DESCRIPTION
Followup based on https://github.com/erlang/otp/pull/3020.
Makes the compiler use the type declarations in erl_lint as the source of truth for how errors and warnings are represented.
(A minor snag was that the core_lint pass returned a module name (an atom) as the "filename", and the file:filename() type doesn't officially include atoms even if they have always worked.