### PR TITLE
ssh: Add longname field  in sftp version 3

### DIFF
--- a/lib/ssh/src/ssh_xfer.erl
+++ b/lib/ssh/src/ssh_xfer.erl
@@ -809,6 +809,15 @@ decode_names(Vsn, I, <<?UINT32(Len), FileName:Len/binary,
 encode_names(Vsn, NamesAndAttrs) ->
     lists:mapfoldl(fun(N, L) -> encode_name(Vsn, N, L) end, 0, NamesAndAttrs).
 
+encode_name(Vsn, {{NameUC,LongNameUC},Attr}, Len) when Vsn =< 3 ->
+    Name = binary_to_list(unicode:characters_to_binary(NameUC)),
+    NLen = length(Name),
+	LongName = binary_to_list(unicode:characters_to_binary(LongNameUC)),
+    LNLen = length(LongName),
+	EncAttr = encode_ATTR(Vsn, Attr),
+    ALen = size(EncAttr),
+    NewLen = Len + NLen + LNLen + 4 + 4 + ALen,
+    {[<<?UINT32(NLen)>>, Name, <<?UINT32(LNLen)>>, LongName, EncAttr], NewLen};
 encode_name(Vsn, {NameUC,Attr}, Len) when Vsn =< 3 ->
     Name = binary_to_list(unicode:characters_to_binary(NameUC)),
     NLen = length(Name),


### PR DESCRIPTION
I encountered some problems using ssh_sftpd erlang because some sftp clients use the long name field in SSH_FXP_NAME response to display file information in sftp version 3. Looking at documentation ([https://tools.ietf.org/html/draft-ietf-secsh-filexfer-02](https://tools.ietf.org/html/draft-ietf-secsh-filexfer-02)), this field is an expanded format for the file name and although not specified by the protocol, the recommended format is similar to what is returned by "ls -l" on Unix systems.
I've made some changes to ssh_xfer and ssh_sftpd modules to add this field in the response for version 3 and it solved the issue for the sftp client I was using, if you could consider taking a look at this PR, I would really appreciate! I tried as much as I could to follow the contribution guide.