### PR TITLE
beam_lib: Don't crash when an abstract code backend is missing

### DIFF
--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -682,10 +682,13 @@ chunks_to_data([{abst_chunk, Name} | CNs], Chunks, File, Cs, Module, Atoms, L) -
     {NewAtoms, Ret} =
 	case catch chunk_to_data(debug_info, DbgiChunk, File, Cs, Atoms, Module) of
 	    {DbgiAtoms, {debug_info, {debug_info_v1, Backend, Metadata}}} ->
-		case Backend:debug_info(erlang_v1, Module, Metadata, []) of
+		try Backend:debug_info(erlang_v1, Module, Metadata, []) of
 		    {ok, Code} -> {DbgiAtoms, {abstract_code, {raw_abstract_v1, Code}}};
 		    {error, _} -> {DbgiAtoms, {abstract_code, no_abstract_code}}
-		end;
+                catch
+                    error:undef ->
+                        {DbgiAtoms, {abstract_code, no_abstract_code}}
+                end;
             {error,beam_lib,{key_missing_or_invalid,Path,debug_info}} ->
                 error({key_missing_or_invalid,Path,abstract_code});
 	    _ ->

--- a/lib/stdlib/test/beam_lib_SUITE.erl
+++ b/lib/stdlib/test/beam_lib_SUITE.erl
@@ -36,7 +36,8 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
 	 init_per_group/2,end_per_group/2, 
 	 normal/1, error/1, cmp/1, cmp_literals/1, strip/1, strip_add_chunks/1, otp_6711/1,
-         building/1, md5/1, encrypted_abstr/1, encrypted_abstr_file/1]).
+         building/1, md5/1, encrypted_abstr/1, encrypted_abstr_file/1,
+         missing_debug_info_backend/1]).
 
 -export([init_per_testcase/2, end_per_testcase/2]).
 
@@ -46,7 +47,7 @@ suite() ->
 
 all() -> 
     [error, normal, cmp, cmp_literals, strip, strip_add_chunks, otp_6711,
-     building, md5, encrypted_abstr, encrypted_abstr_file].
+     building, md5, encrypted_abstr, encrypted_abstr_file, missing_debug_info_backend].
 
 groups() -> 
     [].
@@ -774,6 +775,26 @@ write_crypt_file(Contents0) ->
     Contents = list_to_binary([Contents0]),
     io:format("~s\n", [binary_to_list(Contents)]),
     ok = file:write_file(".erlang.crypt", Contents).
+
+missing_debug_info_backend(Conf) ->
+    PrivDir = ?privdir,
+    Simple = filename:join(PrivDir, "simple"),
+    Source = Simple ++ ".erl",
+    BeamFile = Simple ++ ".beam",
+    simple_file(Source),
+
+    %% Create a debug_info chunk with a non-existing backend.
+    {ok,simple} = compile:file(Source, [{outdir,PrivDir}]),
+    {ok,simple,All0} = beam_lib:all_chunks(BeamFile),
+    FakeDebugInfo = {debug_info_v1, definitely__not__an__existing__backend, nothing_here},
+    All = lists:keyreplace("Dbgi", 1, All0, {"Dbgi", term_to_binary(FakeDebugInfo)}),
+    {ok,NewBeam} = beam_lib:build_module(All),
+    ok = file:write_file(BeamFile, NewBeam),
+
+    %% beam_lib should not crash.
+    {ok, {simple, [{abstract_code,no_abstract_code}]}} = beam_lib:chunks(BeamFile, [abstract_code]),
+
+    ok.
 
 compare_chunks(File1, File2, ChunkIds) ->
     {ok, {_, Chunks1}} = beam_lib:chunks(File1, ChunkIds),


### PR DESCRIPTION
On a computer without Elixir installed, `beam_lib` would crash
when asked to retrieve the abstract code for a BEAM produced
by the Elixir compiler. Instead of crashing when the backend
module is missing, return `no_abstract_code` as the content of
the `abstract_code` chunk.

Resolves #2408