### PR TITLE
Don't crash when an abstract code backend is missing

### DIFF
--- a/lib/tools/doc/src/cover.xml
+++ b/lib/tools/doc/src/cover.xml
@@ -217,9 +217,10 @@
 	<v>ModFiles = ModFile | [ModFile]</v>
         <v>ModFile = Module | BeamFile</v>
         <v>&nbsp;Module = atom()</v>
+        <v>&nbsp;BackendModule = atom()</v>
         <v>&nbsp;BeamFile = string()</v>
         <v>Result = {ok,Module} | {error,BeamFile} | {error,Reason}</v>
-        <v>&nbsp;Reason = non_existing | {no_abstract_code,BeamFile} | {encrypted_abstract_code,BeamFile} | {already_cover_compiled,no_beam_found,Module} | not_main_node</v>
+        <v>&nbsp;Reason = non_existing | {no_abstract_code,BeamFile} | {{missing_backend,BackendModule},BeamFile} | {encrypted_abstract_code,BeamFile} | {already_cover_compiled,no_beam_found,Module} | not_main_node</v>
       </type>
       <desc>
         <p>Does the same as <c>compile/1,2</c>, but uses an existing


### PR DESCRIPTION
On a computer without Elixir installed, `beam_lib` would crash
when asked to retrieve the abstract code for a BEAM produced
by the Elixir compiler. Instead of crashing when the backend
module is missing, return `{error,{missing_backend,BeamFile,Backend}}`.
Also update `cover` to handle the new error from `beam_lib`.

Resolves #4353