### PR TITLE
compile: Refactor handling of internal errors

### DIFF
--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1747,6 +1747,8 @@ do_transforms(Config) ->
     {ok,simple,[_|_]} = compile:file(Simple, [return, {parse_transform,generic_pt}, {action, warning}]),
     error = compile:file(Simple, [report, {parse_transform,generic_pt}, {action, error}]),
     {error,[_|_],[_|_]} = compile:file(Simple, [return, {parse_transform,generic_pt}, {action, error}]),
+    error = compile:file(Simple, [report, {parse_transform,generic_pt}, {action, undefined_error}]),
+    {error,[_|_],[]} = compile:file(Simple, [return, {parse_transform,generic_pt}, {action, undefined_error}]),
 
     ok.
 

--- a/lib/compiler/test/compile_SUITE_data/generic_pt.erl
+++ b/lib/compiler/test/compile_SUITE_data/generic_pt.erl
@@ -38,7 +38,9 @@ actions(Source, Forms, Options) ->
         warning ->
             {warning, Forms, Es};
         error ->
-            {error, Es, Ws}
+            {error, Es, Ws};
+        undefined_error ->
+            {error, [{Source, [{{1,1}, ?MODULE, unknown_error}]}], []}
     end.
 
 format_error(bad_moon_phase) ->


### PR DESCRIPTION
Use of old-style catches in `compile` made some internal errors very
hard to debug. For example, an error in a `format_error/1` function
would result in the following message:

    Compiler function compile:compile/3 returned:
    {error,function_clause}

This commit revises the error handling to provide more information
when an error occurs. With this change a missing clause in a
`format_error/1` function will printed like this:

    *** Internal compiler error ***
    exception error: no function clause matching sys_core_fold:format_error(no_clause_match) (sys_core_fold.erl, line 2847)
      in function  sys_messages:format_messages/4 (sys_messages.erl, line 43)
      in call from sys_messages:format_messages/4 (sys_messages.erl, line 47)
      in call from lists:flatmap/2 (lists.erl, line 1254)
      in call from compile:report_warnings/1 (compile.erl, line 1718)
      in call from compile:comp_ret_ok/2 (compile.erl, line 532)
      in call from compile:'-internal_fun/2-anonymous-0-'/2 (compile.erl, line 229)
      in call from compile:'-do_compile/2-anonymous-0-'/1 (compile.erl, line 219)

Internal errors in compiler passes will be printed like this:

    Function: send_deadline_cont/5
    t.erl: internal error in pass sys_core_fold:
    exception error: bad argument
      in function  element/2
         called as element(2,[{4,1},{file,"t.erl"}])
         *** argument 2: not a tuple
      in call from cerl:get_ann/1 (cerl.erl, line 333)
      in call from core_lib:make_values/1 (core_lib.erl, line 42)
      in call from sys_core_fold:case_opt/3 (sys_core_fold.erl, line 1711)
      in call from sys_core_fold:expr/3 (sys_core_fold.erl, line 332)
      in call from sys_core_fold:expr/3 (sys_core_fold.erl, line 248)
      in call from sys_core_fold:find_fixpoint/3 (sys_core_fold.erl, line 139)
      in call from sys_core_fold:function_1/1 (sys_core_fold.erl, line 125)