### PR TITLE
Tweak inet keepalive option documentation

### DIFF
--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -1048,7 +1048,7 @@ get_tcpi_sacked(Sock) ->
               socket when no other data is exchanged. If
               the other end does not respond, the connection is
               considered broken and an error message is sent to
-              the controlling process. Defaults to <c>disabled</c>.</p>
+              the controlling process. Defaults to <c>false</c>.</p>
             <marker id="option-linger"></marker>
           </item>
           <tag><c>{linger, {true|false, Seconds}}</c></tag>


### PR DESCRIPTION
The value of the `keepalive` option should be a boolean, but the
documentation states that the default is `disabled` which is not a
boolean.