### PR TITLE
jit: Generate multi-byte NOPs in the way GAS does

### DIFF
--- a/erts/emulator/beam/jit/beam_asm.cpp
+++ b/erts/emulator/beam/jit/beam_asm.cpp
@@ -907,3 +907,8 @@ extern "C"
         ba->patchStrings(rw_base, string_table);
     }
 }
+
+const uint8_t *BeamAssembler::nops[3] = {nop1, nop2, nop3};
+const uint8_t BeamAssembler::nop1[1] = {0x90};
+const uint8_t BeamAssembler::nop2[2] = {0x66, 0x90};
+const uint8_t BeamAssembler::nop3[3] = {0x0F, 0x1F, 0x00};

--- a/erts/emulator/beam/jit/beam_asm.hpp
+++ b/erts/emulator/beam/jit/beam_asm.hpp
@@ -571,9 +571,7 @@ protected:
         if (next_address % 4) {
             ssize_t nop_count = 4 - next_address % 4;
 
-            for (int i = 0; i < nop_count; i++) {
-                a.nop();
-            }
+            a.embed(nops[nop_count - 1], nop_count);
         }
 
 #ifdef HARD_DEBUG
@@ -584,6 +582,12 @@ protected:
         a.call(target);
         ASSERT(is_CP(a.offset()));
     }
+
+    /* Canned instruction sequences for multi-byte NOPs */
+    static const uint8_t *nops[3];
+    static const uint8_t nop1[1];
+    static const uint8_t nop2[2];
+    static const uint8_t nop3[3];
 
     void runtime_call(x86::Gp func, unsigned args) {
         ASSERT(args < 5);


### PR DESCRIPTION
BeamAssembler::aligned_call() generates a nop (0x90) instruction for
each byte of alignment required. Most modern CPU:s are able to execute
up to four NOP instructions in a cycle [1] during ideal conditions,
but there are no guarantees for the instruction stream generated by
the BEAM loader to be ideal.

Looking at the BEAM code loaded by a typical run of the
`scripts/diffable` benchmark-tool, we find that there are in total
211152 locations requiring alignment. Of those, the number of
alignment bytes needed have the following distribution:

  bytes   number
      0   43502
      1   45703
      2  121947

Interesting to note is that almost 80% of the alignments will, without
this patch, issue more than one instruction. Minimizing the number of
issued "useless" instructions is advantageous as it frees up execution
units for other instructions doing useful work. Therefore this changes
the BeamAssembler::aligned_call() implementation to generate
multi-byte NOPs. The multi-byte NOPs used are the same as the NOPs
produced by the GNU Assembler when doing alignment in a code segment.

[1] https://www.agner.org/optimize/