### PR TITLE
Encode generated dependency files in UTF-8

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -237,6 +237,7 @@
                 <c>binary</c> is set, nothing is written and the rule is
                 returned in <c>Binary</c>.
             </p>
+            <p>The output will be encoded in UTF-8.</p>
             <p>For example, if you have the following module:
             </p>
             <code>

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1309,7 +1309,7 @@ makedep(Code0, #compile{ifile=Ifile,ofile=Ofile,options=Opts}=St) ->
 		   true -> MainRule ++ PhonyRules;
 		   _ -> MainRule
 	       end,
-    Code = iolist_to_binary([Makefile,"\n"]),
+    Code = unicode:characters_to_binary([Makefile,"\n"]),
     {ok,Code,St}.
 
 makedep_add_headers(Ifile, [{attribute,_,file,{File,_}}|Rest],


### PR DESCRIPTION
If the dependency output (generated when the compiler is invoked
with the `makedep` option) contained non-latin1 characters,
the compiler would crash.

To avoid the crash, encode the output in UTF-8.