### PR TITLE
tools: Fix emacs compiler warnings (#4451)

### DIFF
--- a/lib/tools/emacs/erlang-eunit.el
+++ b/lib/tools/emacs/erlang-eunit.el
@@ -216,7 +216,7 @@ buffer and vice versa"
 
 With prefix arg, compiles for debug and runs tests with the verbose flag set."
   (interactive)
-  (case (erlang-eunit-recent 'mode)
+  (cl-case (erlang-eunit-recent 'mode)
     ('test-mode
      (erlang-eunit-compile-and-test
       'erlang-eunit-run-test (list (erlang-eunit-recent 'module)

--- a/lib/tools/emacs/erlang-test.el
+++ b/lib/tools/emacs/erlang-test.el
@@ -62,8 +62,6 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
 (require 'ert)
 (require 'erlang)
 
@@ -127,8 +125,8 @@ concatenated to form an erlang file to test on.")
 
 (defun erlang-test-create-erlang-file (erlang-file)
   (with-temp-file erlang-file
-    (loop for (_ . code) in erlang-test-code
-          do (insert code "\n"))))
+    (cl-loop for (_ . code) in erlang-test-code
+             do (insert code "\n"))))
 
 (defun erlang-test-compile-tags (erlang-file tags-file)
   (should (zerop (call-process "etags" nil nil nil
@@ -143,20 +141,20 @@ concatenated to form an erlang file to test on.")
                  (sort (erlang-expected-completion-table) #'string-lessp))))
 
 (defun erlang-expected-completion-table ()
-  (append (loop for (symbol . _) in erlang-test-code
-                when (stringp symbol)
-                append (list symbol (concat "erlang_test:" symbol)))
+  (append (cl-loop for (symbol . _) in erlang-test-code
+                   when (stringp symbol)
+                   append (list symbol (concat "erlang_test:" symbol)))
           (list "erlang_test:" "erlang_test:module_info")))
 
 (defun erlang-test-xref-find-definitions (erlang-file erlang-buffer)
-  (loop for (tagname . code) in erlang-test-code
-        for line = 1 then (1+ line)
-        do (when tagname
-             (switch-to-buffer erlang-buffer)
-             (erlang-test-xref-jump tagname erlang-file line)
-             (when (string-equal tagname "function")
-               (erlang-test-xref-jump (concat "erlang_test:" tagname)
-                                      erlang-file line))))
+  (cl-loop for (tagname . code) in erlang-test-code
+           for line = 1 then (1+ line)
+           do (when tagname
+                (switch-to-buffer erlang-buffer)
+                (erlang-test-xref-jump tagname erlang-file line)
+                (when (string-equal tagname "function")
+                  (erlang-test-xref-jump (concat "erlang_test:" tagname)
+                                         erlang-file line))))
   (erlang-test-xref-jump "erlang_test:" erlang-file 1))
 
 (defun erlang-test-xref-jump (id expected-file expected-line)
@@ -225,27 +223,27 @@ concatenated to form an erlang file to test on.")
 
 
 (ert-deftest erlang-test-parse-id ()
-  (loop for id-string in '("fun/10"
-                           "qualified-function module:fun/10"
-                           "record reko"
-                           "macro _SYMBOL"
-                           "macro MACRO/10"
-                           "module modula"
-                           "macro"
-                           nil)
-        for id-list in '((nil nil "fun" 10)
-                         (qualified-function "module" "fun" 10)
-                         (record nil "reko" nil)
-                         (macro nil "_SYMBOL" nil)
-                         (macro nil "MACRO" 10)
-                         (module nil "modula" nil)
-                         (nil nil "macro" nil)
-                         nil)
-        for id-list2 = (erlang-id-to-list id-string)
-        do (should (equal id-list id-list2))
-        for id-string2 = (erlang-id-to-string id-list)
-        do (should (equal id-string id-string2))
-        collect id-list2))
+  (cl-loop for id-string in '("fun/10"
+                              "qualified-function module:fun/10"
+                              "record reko"
+                              "macro _SYMBOL"
+                              "macro MACRO/10"
+                              "module modula"
+                              "macro"
+                              nil)
+           for id-list in '((nil nil "fun" 10)
+                            (qualified-function "module" "fun" 10)
+                            (record nil "reko" nil)
+                            (macro nil "_SYMBOL" nil)
+                            (macro nil "MACRO" 10)
+                            (module nil "modula" nil)
+                            (nil nil "macro" nil)
+                            nil)
+           for id-list2 = (erlang-id-to-list id-string)
+           do (should (equal id-list id-list2))
+           for id-string2 = (erlang-id-to-string id-list)
+           do (should (equal id-string id-string2))
+           collect id-list2))
 
 
 (provide 'erlang-test)

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -81,7 +81,9 @@
 (require 'tempo)
 
 ;;; `caddr' is builtin since Emacs 26.
-(or (fboundp 'caddr) (defun caddr (x) (car (cdr (cdr x)))))
+(eval-and-compile
+  (or (fboundp 'caddr)
+      (defun caddr (x) (car (cdr (cdr x))))))
 
 ;; Variables:
 

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -76,10 +76,12 @@
 ;;     M-x toggle-debug-on-error RET
 ;;; Code:
 
-(eval-when-compile (require 'cl))
 (require 'align)
 (require 'comint)
 (require 'tempo)
+
+;;; `caddr' is builtin since Emacs 26.
+(or (fboundp 'caddr) (defun caddr (x) (car (cdr (cdr x)))))
 
 ;; Variables:
 
@@ -1420,7 +1422,7 @@ Other commands:
   (erlang-electric-init)
   (erlang-menu-init)
   (erlang-mode-variables)
-  (erlang-check-module-name-init)
+  (add-hook 'before-save-hook 'erlang-check-module-name nil t)
   (erlang-man-init)
   (erlang-tags-init)
   (erlang-font-lock-init)
@@ -1431,7 +1433,6 @@ Other commands:
         (setq-local eldoc-documentation-function #'ignore))
     (add-function :before-until (local 'eldoc-documentation-function)
                   #'erldoc-eldoc-function))
-  (run-hooks 'erlang-mode-hook)
 
   ;; Align maps.
   (add-to-list 'align-rules-list
@@ -2674,8 +2675,6 @@ This is automagically called by the user level function `indent-region'."
 
 (defmacro erlang-push (x stack) (list 'setq stack (list 'cons x stack)))
 (defmacro erlang-pop (stack) (list 'setq stack (list 'cdr stack)))
-;; Would much prefer to make caddr a macro but this clashes.
-(defun erlang-caddr (x) (car (cdr (cdr x))))
 
 
 (defun erlang-calculate-indent (&optional parse-start)
@@ -3076,8 +3075,8 @@ Return nil if inside string, t if in a comment."
                         (if (eq (car stack-top) '->)
                             (erlang-pop stack))
                         (cond ((and stack (looking-at ";"))
-                               (+ (erlang-caddr (car stack)) (- erlang-indent-level 2)))
-                              (stack (erlang-caddr (car stack)))
+                               (+ (caddr (car stack)) (- erlang-indent-level 2)))
+                              (stack (caddr (car stack)))
                               (t off)))
                        ((looking-at "catch\\b\\($\\|[^_a-zA-Z0-9]\\)")
                         ;; Are we in a try
@@ -3091,12 +3090,12 @@ Return nil if inside string, t if in a comment."
                                    (if (eq (car stack-top) '->)
                                        (erlang-pop stack))
                                    (if stack
-                                       (erlang-caddr (car stack))
+                                       (caddr (car stack))
                                      0)))
                                 (t (erlang-indent-standard indent-point token base 'nil))))) ;; old catch
                        ;; Indent result types
                        ((eq (car (car (cdr stack))) 'spec_arg)
-                        (setq base (+ (erlang-caddr (car (last stack))) erlang-indent-level))
+                        (setq base (+ (caddr (car (last stack))) erlang-indent-level))
                         (erlang-indent-standard indent-point token base 'nil))
                        (t
                         (erlang-indent-standard indent-point token base 'nil)
@@ -3224,7 +3223,7 @@ Return nil if inside string, t if in a comment."
                   ;; Take parent identation + offset,
                   ;; else just erlang-indent-level if no parent
                   (if stack
-                      (+ (erlang-caddr (car stack))
+                      (+ (caddr (car stack))
                          offset)
                     erlang-indent-level))
               (erlang-skip-blank indent-point)
@@ -4084,11 +4083,11 @@ of arguments could be found, otherwise nil."
 (defun erlang-match-next-exported-function (max)
   "Returns non-nil if there is an exported function in the current
 buffer between point and MAX."
-  (block nil
-         (while (and (not erlang-inhibit-exported-function-name-face)
-                     (erlang-match-next-function max))
-           (when (erlang-last-match-exported-p)
-             (return (match-data))))))
+  (catch 'return
+    (while (and (not erlang-inhibit-exported-function-name-face)
+                (erlang-match-next-function max))
+      (when (erlang-last-match-exported-p)
+        (throw 'return (match-data))))))
 
 (defun erlang-match-next-function (max)
   "Searches forward in current buffer for the next erlang function,
@@ -4116,28 +4115,6 @@ exported function."
 
 ;;; Check module name
 
-;; The function `write-file', bound to C-x C-w, calls
-;; `set-visited-file-name' which clears the hook.  :-(
-;; To make sure that the hook always is present, we advise
-;; `set-visited-file-name'.
-(defun erlang-check-module-name-init ()
-  "Initialize the functionality to compare file and module names.
-
-Unless we have `before-save-hook', we advice the function
-`set-visited-file-name' since it clears the variable
-`local-write-file-hooks'."
-  (if (boundp 'before-save-hook)
-      (add-hook 'before-save-hook 'erlang-check-module-name nil t)
-    (require 'advice)
-    (when (fboundp 'ad-advised-definition-p)
-      (unless (ad-advised-definition-p 'set-visited-file-name)
-        (defadvice set-visited-file-name (after erlang-set-visited-file-name
-                                                activate)
-          (if (eq major-mode 'erlang-mode)
-              (add-hook 'local-write-file-hooks 'erlang-check-module-name))))
-      (add-hook 'local-write-file-hooks 'erlang-check-module-name))))
-
-
 (defun erlang-check-module-name ()
   "If the module name doesn't match file name, ask for permission to change.
 
@@ -4146,7 +4123,7 @@ function.  It it is nil, this function does nothing.  If it is t, the
 source is silently changed.  If it is set to the atom `ask', the user
 is prompted.
 
-This function is normally placed in the hook `local-write-file-hooks'."
+This function is normally placed in the hook `before-save-hook'."
   (if erlang-check-module-name
       (let ((mn (erlang-add-quotes-if-needed
                  (erlang-get-module)))
@@ -5358,7 +5335,7 @@ is non-nil then TAG is a regexp."
         (cl-loop for xref in xrefs
                  for loc = (xref-item-location xref)
                  for file = (xref-location-group loc)
-                 do (pushnew file files :test 'string-equal))
+                 do (cl-pushnew file files :test 'string-equal))
         (or (cl-loop for file in files
                      append (erlang-xrefs-in-file file kind tag is-regexp))
             ;; Failed for some reason.  Pretend like it is raining and

--- a/lib/tools/emacs/erldoc.el
+++ b/lib/tools/emacs/erldoc.el
@@ -60,9 +60,10 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'url-parse))
 (require 'cl-lib)
+(require 'json)
 (require 'erlang)
+(eval-when-compile (require 'url-parse))
 
 (eval-and-compile                       ;for emacs < 24.3
   (or (fboundp 'user-error) (defalias 'user-error 'error)))
@@ -268,7 +269,6 @@ up the indexing."
     (with-temp-buffer
       (if (not json)
           (pp table (current-buffer))
-        (eval-and-compile (require 'json))
         (let ((json-encoding-pretty-print t))
           (insert (json-encode table))))
       (unless (file-directory-p (file-name-directory output))

--- a/lib/tools/test/emacs_SUITE.erl
+++ b/lib/tools/test/emacs_SUITE.erl
@@ -107,7 +107,7 @@ compile_and_load(_Config) ->
                 %% Workaround byte-compile-error-on-warn which seem broken in
                 %% Emacs 25.
                 "\"(advice-add #'display-warning :after "
-                    "(lambda (_ f _ _) (error \"%s\" f)))\"";
+                    "(lambda (_ f &optional _ _) (error \\\"%s\\\" f)))\"";
             _ ->
                 "\"(setq byte-compile-error-on-warn t)\""
         end,


### PR DESCRIPTION
Do not depend on cl. Assume presence of before-save-hook (Emacs 22)
and remove erlang-check-module-name-init. Remove (run-hooks
'erlang-mode-hook) from erlang-mode definition because
define-derived-mode does it already. Replace erlang-caddr with caddr
from Emacs 26.

erlang.el now compiles cleanly in Emacs 24.5, 25, 26, 27.