### PR TITLE
Inline funs that are immediately used

### DIFF
--- a/lib/compiler/test/fun_SUITE.erl
+++ b/lib/compiler/test/fun_SUITE.erl
@@ -56,12 +56,14 @@ end_per_group(_GroupName, Config) ->
 
 %%% The help functions below are copied from emulator:bs_construct_SUITE.
 
--define(T(B, L), {B, ??B, L}).
+-define(T(B, L), {fun() -> B end(), ??B, L}).
 
 l1() ->
     [
      ?T((begin A = 3, F = fun(A) -> 1; (_) -> 2 end, F(2) end), 1),
-     ?T((begin G = fun(1=0) -> ok end, {'EXIT',_} = (catch G(2)), ok end), ok)
+     ?T((begin G = fun(1=0) -> ok end, {'EXIT',_} = (catch G(2)), ok end), ok),
+     ?T((begin F = fun(_, 1) -> 1; (F, N) -> N * F(F, N-1) end, F(F, 5) end), 120),
+     ?T((begin F = fun(_, 1) -> 1; (F, N) -> N * F(F, N-1) end, F(F, 1), ok end), ok)
     ].
 
 test1(Config) when is_list(Config) ->
@@ -241,6 +243,7 @@ dup2() ->
 
 badarity(Config) when is_list(Config) ->
     {'EXIT',{{badarity,{_,[]}},_}} = (catch (fun badarity/1)()),
+    {'EXIT',{{badarity,_},_}} = (catch fun() -> 42 end(0)),
     ok.
 
 badfun(_Config) ->

--- a/lib/debugger/test/int_eval_SUITE_data/stacktrace.erl
+++ b/lib/debugger/test/int_eval_SUITE_data/stacktrace.erl
@@ -106,10 +106,10 @@ do_fun(Bool) ->
     F(Bool).					%Tail-recursive
 
 do_fun2(Bool) ->
-    F = fun(true) ->
+    F = fun(true, _) ->
 		cons(Bool)			%Tail-recursive
 	end,
-    F(Bool),					%Not tail-recursive
+    F(Bool, F),                                 %Not tail-recursive. (The fun is not inlined)
     ?LINE.
 
 cons(Bool) ->

--- a/lib/stdlib/test/qlc_SUITE.erl
+++ b/lib/stdlib/test/qlc_SUITE.erl
@@ -2382,10 +2382,12 @@ filter(Config) when is_list(Config) ->
                       false = lookup_keys(QH)
               end, [{1,1},{2,2},{3,3}])">>,
 
-       <<"fun(Z) ->
+       {cres,
+        <<"fun(Z) ->
             Q = qlc:q([X || Z < 2, X <- [1,2,3]]),
             [] = qlc:e(Q)
-          end(3)">>,
+           end(3)">>, [], {warnings,[{{2,31},sys_core_fold,no_clause_match},
+                                     {{2,31},sys_core_fold,nomatch_guard}]}},
 
        <<"H = qlc:q([{P1,A,P2,B,P3,C} ||
                   P1={A,_} <- [{1,a},{2,b}],
@@ -3095,13 +3097,14 @@ lookup2(Config) when is_list(Config) ->
         %% {warnings,[{{4,35},qlc,nomatch_filter}]}},
         []},
 
-       <<"F = fun(U) ->
+       {cres,
+        <<"F = fun(U) ->
                 Q = qlc:q([X || {X} <- [a,b,c], 
                                  X =:= if U -> true; true -> false end]),
                 [] = qlc:eval(Q),
                 false = lookup_keys(Q)
               end,
-          F(apa)">>,
+           F(apa)">>, [], {warnings,[{{3,43},sys_core_fold,nomatch_guard}]}},
 
        {cres,
         <<"etsc(fun(E) ->


### PR DESCRIPTION
Funs can be used to hide local variables. Example:

    a() ->
        A = fun() -> A = 21, 2 * A end(),
        foo:bar(A).

To avoid the slight runtime cost for such use of funs, teach the
compiler to inline funs that are used only once immediately after
creation.

Resolves #4019