### PR TITLE
fix: Handle SIGUSR1 even under +B i / +B d

### DIFF
--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -677,9 +677,6 @@ void erts_replace_intr(void) {
 void init_break_handler(void)
 {
    sys_signal(SIGINT,  request_break);
-#ifndef ETHR_UNUSABLE_SIGUSRX
-   sys_signal(SIGUSR1, generic_signal_handler);
-#endif /* #ifndef ETHR_UNUSABLE_SIGUSRX */
    sys_signal(SIGQUIT, generic_signal_handler);
 }
 
@@ -694,6 +691,9 @@ void
 erts_sys_unix_later_init(void)
 {
     sys_signal(SIGTERM, generic_signal_handler);
+#ifndef ETHR_UNUSABLE_SIGUSRX
+   sys_signal(SIGUSR1, generic_signal_handler);
+#endif /* #ifndef ETHR_UNUSABLE_SIGUSRX */
 
     /* Ignore SIGCHLD to ensure orphaned processes don't turn into zombies on
      * death when we're pid 1. */

--- a/erts/emulator/test/os_signal_SUITE.erl
+++ b/erts/emulator/test/os_signal_SUITE.erl
@@ -52,14 +52,14 @@ suite() ->
 all() ->
     case os:type() of
         {win32, _} -> [];
-        _ -> [set_unset,
-              t_sighup,
+        _ -> [t_sighup,
               t_sigusr1,
               t_sigusr2,
               t_sigterm,
               t_sigalrm,
               t_sigchld,
-              t_sigchld_fork]
+              t_sigchld_fork,
+              set_unset]
     end.
 
 init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
@@ -135,7 +135,7 @@ t_sighup(_Config) ->
 t_sigusr1(_Config) ->
     Pid1 = setup_service(),
     OsPid = os:getpid(),
-    os:set_signal(sigusr1, handle),
+    % shouldn't need to explicitly set_signal to handle USR1, it's the default
     ok = kill("USR1", OsPid),
     ok = kill("USR1", OsPid),
     ok = kill("USR1", OsPid),
@@ -157,7 +157,7 @@ t_sigusr1(_Config) ->
     Msgs2 = fetch_msgs(Pid2),
     io:format("Msgs2: ~p~n", [Msgs2]),
     [] = Msgs2,
-    %% reset to ignore (it's the default)
+    %% reset to handle (default) so as not to break other tests
     os:set_signal(sigusr1, handle),
     ok.
 


### PR DESCRIPTION
The OTP documentation states that SIGUSR1 causes a crash dump unconditionally.
However, under +B i or +B d, the call to install the SIGUSR1 handler was not
made before this change, causing SIGUSR1 to kill process immediately instead.

Fixes #4552.