### PR TITLE
Ensure that Xref does not see Debugger as a dependency for Kernel

### DIFF
--- a/lib/kernel/src/error_handler.erl
+++ b/lib/kernel/src/error_handler.erl
@@ -24,6 +24,10 @@
 %% "error_handler: add no_native compiler directive"
 -compile(no_native).
 
+%% See the comment before the int/0 function for an explanation
+%% why this option is needed.
+-compile(no_module_opt).
+
 %% Callbacks called from the run-time system.
 -export([undefined_function/3,undefined_lambda/3,breakpoint/3]).
 
@@ -84,7 +88,10 @@ raise_undef_exception(Module, Func, Args) ->
     crash({Module,Func,Args,[]}).
 
 %% Used to make the call to the 'int' module a "weak" one, to avoid
-%% building strong components in xref or dialyzer.
+%% making Kernel a visible dependency to Debugger in xref. (To ensure
+%% that the call in breakpoint/3 is kept as an apply to an unknown
+%% module, this module must be compiled with the 'no_module_opt'
+%% option to turn off inter-function type analysis.)
 
 int() -> int.
 


### PR DESCRIPTION
The `error_handler` module in the Kernel application has a call to the
`int` module in the Debugger application. That call is only there to
make the Debugger work. To avoid that Xref sees Debugger as a
dependency for Kernel, the call to the `int` module is obfuscated in
the following way:

    breakpoint(Module, Func, Args) ->
        (int()):eval(Module, Func, Args).
    int() -> int.

That is, the call will show up as a call to an unknown module in
Xref.

With the improved whole-module type analysis introduced in
294d66a295f6 (#2100), the compiler sees through the obfuscation
and rewrites the code to:

    breakpoint(Module, Func, Args) ->
        int:eval(Module, Func, Args).

It would be fun to solve this issue by introducing further obfuscations,
but such tricks could stop working in the future when the compiler is
improved. Instead, turn off whole-module type analysis by compiling
the module with the `no_module_opt` option.

Resolves #4546