### PR TITLE
Fix test of runtime dependencies

### DIFF
--- a/lib/erl_docgen/src/erl_docgen.app.src
+++ b/lib/erl_docgen/src/erl_docgen.app.src
@@ -10,6 +10,6 @@
   {registered,[]},
   {applications, [kernel,stdlib]},
   {env, []},
-  {runtime_dependencies, ["xmerl-1.3.7","stdlib-@OTP-17120@","edoc-@OTP-16949@","erts-9.0"]}
+  {runtime_dependencies, ["xmerl-1.3.7","kernel-8.0","stdlib-@OTP-17120@","edoc-@OTP-16949@","erts-9.0"]}
  ]
 }.

--- a/lib/ftp/src/ftp.app.src
+++ b/lib/ftp/src/ftp.app.src
@@ -15,5 +15,5 @@
              ftp_response,
              ftp_sup
             ]},
-  {runtime_dependencies, ["erts-7.0","stdlib-3.5","kernel-6.0"]}
+  {runtime_dependencies, ["erts-7.0","stdlib-3.5","kernel-6.0","ssl-10.2","runtime_tools-1.15.1"]}
  ]}.

--- a/lib/kernel/src/kernel.app.src
+++ b/lib/kernel/src/kernel.app.src
@@ -154,6 +154,6 @@
          {shell_docs_ansi,auto}
         ]},
   {mod, {kernel, []}},
-  {runtime_dependencies, ["erts-@OTP-16718@", "stdlib-3.13", "sasl-3.0"]}
+  {runtime_dependencies, ["erts-@OTP-16718@", "stdlib-3.13", "sasl-3.0", "crypto-5.0"]}
  ]
 }.

--- a/lib/ssh/src/ssh.app.src
+++ b/lib/ssh/src/ssh.app.src
@@ -58,5 +58,6 @@
 			  "erts-9.0",
 			  "kernel-5.3",
 			  "public_key-1.6.1",
-			  "stdlib-3.4.1"
+                          "stdlib-3.4.1",
+                          "runtime_tools-1.15.1"
 			 ]}]}.

--- a/lib/ssl/src/ssl.app.src
+++ b/lib/ssl/src/ssl.app.src
@@ -85,4 +85,5 @@
     {env, []},
     {mod, {ssl_app, []}},
     {runtime_dependencies, ["stdlib-3.12","public_key-1.8","kernel-6.0",
-			    "erts-10.0","crypto-4.2", "inets-5.10.7"]}]}.
+                            "erts-10.0","crypto-4.2", "inets-5.10.7",
+                            "runtime_tools-1.15.1"]}]}.

--- a/lib/tftp/src/tftp.app.src
+++ b/lib/tftp/src/tftp.app.src
@@ -18,5 +18,5 @@
              tftp_logger,
              tftp_sup
             ]},
-  {runtime_dependencies, ["stdlib-3.5","kernel-6.0"]}
+  {runtime_dependencies, ["erts-6.0","stdlib-3.5","kernel-6.0"]}
  ]}.


### PR DESCRIPTION
A test that was supposed to fail when an applications's app file was missing runtime dependencies didn't actually fail when dependencies were missing. (The test case has been broken in exactly five years since 77046ef3d886574.)

This pull request mends the failed test case, and also adds a test case to make sure that the runtime dependencies are correct when Xref is run in the same way as when reltoool runs Xref (that is, in `modules` mode).

When a test case has not been run in five years, some errors have slipped into some app files. This PR adds the missing dependencies. @IngelaAndin and @HansN, could you please take look at the commit that update the app files?