### PR TITLE
inet_res: add option to include the DNS reply in nxdomain errors

### DIFF
--- a/lib/kernel/doc/src/inet_res.xml
+++ b/lib/kernel/doc/src/inet_res.xml
@@ -299,6 +299,12 @@ inet_dns:record_type(_) -> undefined.</pre>
           <seemfa marker="stdlib:io#format/3"><c>io:format/2</c></seemfa>
           of queries, replies retransmissions, and so on, similar
           to from utilities, such as <c>dig</c> and <c>nslookup</c>.</p>
+        <p>Option <c>nxdomain_reply</c> (or rather <c>{nxdomain_reply,true}</c>)
+	  causes nxdomain errors from DNS servers to be returned as
+	  <c>{error, {nxdomain, dns_msg()}}</c>.
+	  <c>dns_msg()</c> contains the additional sections that where included
+	  by the answering server. This is mainly useful to inspect the SOA record
+	  to get the TTL for negative caching.</p>
         <p>If <c><anno>Opt</anno></c> is any atom, it is interpreted
           as <c>{<anno>Opt</anno>,true}</c> unless the atom string starts with
           <c>"no"</c>, making the

--- a/lib/kernel/test/inet_res_SUITE.erl
+++ b/lib/kernel/test/inet_res_SUITE.erl
@@ -72,7 +72,7 @@ suite() ->
 
 all() -> 
     [basic, resolve, edns0, txt_record, files_monitor,
-     last_ms_answer,
+     nxdomain_reply, last_ms_answer,
      intermediate_error,
      servfail_retry_timeout_default, servfail_retry_timeout_1000,
      label_compression_limit,
@@ -939,14 +939,16 @@ do_files_monitor(Config) ->
 %% Check that we get the error code from the first server.
 
 nxdomain_reply(Config) when is_list(Config) ->
-    NS        = ns(Config),
-    Name      = "nxdomain.otptest",
-    Class     = in,
-    Type      = a,
-    Opts      = [{nameservers,[NS]}, {servfail_retry_timeout, 1000}, verbose],
+    NS    = ns(Config),
+    Name  = "nxdomain.otptest",
+    Class = in,
+    Type  = a,
+    Opts  =
+        [{nameservers,[NS]}, {servfail_retry_timeout, 1000}, verbose],
     ?P("try resolve"),
     {error, nxdomain} = inet_res:resolve(Name, Class, Type, Opts),
-    {error, {nxdomain, Rec}} = inet_res:resolve(Name, Class, Type, [nxdomain_reply|Opts]),
+    {error, {nxdomain, Rec}} =
+        inet_res:resolve(Name, Class, Type, [nxdomain_reply|Opts]),
     ?P("resolved: "
        "~n      ~p", [Rec]),
     ok.


### PR DESCRIPTION
A nxdomain error from a name server does contain the SOA record if
the domain exists at all. This record is usefull to determine a TTL
for negative caching of the failed entry.