### PR TITLE
kernel: Let option 'size' of disk_log:open/1 change size

### DIFF
--- a/lib/kernel/doc/src/disk_log.xml
+++ b/lib/kernel/doc/src/disk_log.xml
@@ -817,11 +817,28 @@
               at least the header (if there is one) and one
               item are written on each wrap log file before
               wrapping to the next file.</p>
+            <p>The first time an existing wrap log is opened, that is,
+              when the disk log process is created, the value of the
+              option <c>size</c> is allowed to differ from the current
+              log size, and the size of the disk log is changed as per
+              <seemfa
+              marker="#change_size/2"><c>change_size/2</c></seemfa>.
+              </p>
             <p>When opening an existing wrap log, it is not
-              necessary to supply a value for option <c>Size</c>, but any
-              supplied value must equal the current log size, otherwise
+              necessary to supply a value for option <c>size</c>,
+              but if the log is already open, that is, the disk log
+              process exists,
+              the supplied value must equal the current log size, otherwise
               the tuple <c>{error, {size_mismatch, <anno>CurrentSize</anno>,
-	      <anno>NewSize</anno>}}</c> is returned.</p>
+              <anno>NewSize</anno>}}</c> is returned.</p>
+            <note>
+              <p>Before Erlang/OTP 24.0, the supplied value of option
+                <c>size</c> was to be equal to the current log size when
+                opening an existing wrap log for the first time, that
+                is, when creating the disk log process.</p>
+            </note>
+	    <p>When opening an already open halt log, option <c>size</c>
+	      is ignored.</p>
           </item>
 	  <tag><c>{notify, boolean()}</c><marker id="notify"></marker></tag>
           <item>

--- a/lib/kernel/src/disk_log.hrl
+++ b/lib/kernel/src/disk_log.hrl
@@ -95,6 +95,7 @@
 	      file = none         :: 'none' | file:filename(),
 	      repair = true       :: dlog_repair(),
 	      size = infinity     :: dlog_size(),
+	      old_size = infinity :: dlog_size(), % read from size file
 	      type = halt         :: dlog_type(),
 	      format = internal   :: dlog_format(),
 	      linkto = self()     :: 'none' | pid(),


### PR DESCRIPTION
If the value of option 'size' does not match existing wrap log size,
the 'size_mismatch' error is no longer returned, but the size of the
log changed. This applies only if the disk log is not already open.

We have made this incompatible modification to help customers handle
upgrade scenarios.

Fixes GH-4469.