### PR TITLE
Show docs from any textual chunk in the shell

### DIFF
--- a/lib/stdlib/doc/src/shell_docs.xml
+++ b/lib/stdlib/doc/src/shell_docs.xml
@@ -54,10 +54,11 @@ Since:
     > maps:new().
     #{}
 </code>
-    <p>This module can only render EEP-48 documentation of the format
-      <c>application/erlang+html</c>. For more information about this format see
-      <seeguide marker="erl_docgen:doc_storage">Documentation Storage</seeguide>
-      in Erl_Docgen's User's Guide.
+    <p>This module formats and renders EEP-48 documentation of
+      the format <c>application/erlang+html</c>. For more information about
+      this format see <seeguide marker="erl_docgen:doc_storage">Documentation
+      Storage</seeguide> in Erl_Docgen's User's Guide. It can also render
+      any other format of "text" type, although those will be rendered as is.
     </p>
   </description>
 

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -158,10 +158,14 @@ c(SrcFile, NewOpts, Filter, BeamFile, Info) ->
 -type ht_return() :: h_return() | {error, type_missing}.
 -type hcb_return() :: h_return() | {error, callback_missing}.
 
+-define(RENDERABLE_FORMAT(Format),
+        Format =:= ?NATIVE_FORMAT;
+        binary_part(Format, 0, 5) =:= <<"text/">>).
+
 -spec h(module()) -> h_return().
 h(Module) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render(Module, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};
@@ -172,7 +176,7 @@ h(Module) ->
 -spec h(module(),function()) -> hf_return().
 h(Module,Function) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render(Module, Function, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};
@@ -183,7 +187,7 @@ h(Module,Function) ->
 -spec h(module(),function(),arity()) -> hf_return().
 h(Module,Function,Arity) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render(Module, Function, Arity, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};
@@ -194,7 +198,7 @@ h(Module,Function,Arity) ->
 -spec ht(module()) -> h_return().
 ht(Module) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render_type(Module, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};
@@ -205,7 +209,7 @@ ht(Module) ->
 -spec ht(module(),Type :: atom()) -> ht_return().
 ht(Module,Type) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render_type(Module, Type, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};
@@ -217,7 +221,7 @@ ht(Module,Type) ->
           ht_return().
 ht(Module,Type,Arity) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render_type(Module, Type, Arity, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};
@@ -228,7 +232,7 @@ ht(Module,Type,Arity) ->
 -spec hcb(module()) -> h_return().
 hcb(Module) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render_callback(Module, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};
@@ -239,7 +243,7 @@ hcb(Module) ->
 -spec hcb(module(),Callback :: atom()) -> hcb_return().
 hcb(Module,Callback) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render_callback(Module, Callback, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};
@@ -251,7 +255,7 @@ hcb(Module,Callback) ->
           hcb_return().
 hcb(Module,Callback,Arity) ->
     case code:get_doc(Module) of
-        {ok, #docs_v1{ format = ?NATIVE_FORMAT } = Docs} ->
+        {ok, #docs_v1{ format = Format } = Docs} when ?RENDERABLE_FORMAT(Format) ->
             format_docs(shell_docs:render_callback(Module, Callback, Arity, Docs));
         {ok, #docs_v1{ format = Enc }} ->
             {error, {unknown_format, Enc}};

--- a/lib/stdlib/test/shell_docs_SUITE.erl
+++ b/lib/stdlib/test/shell_docs_SUITE.erl
@@ -19,9 +19,10 @@
 %%
 -module(shell_docs_SUITE).
 -export([all/0, suite/0, groups/0, init_per_suite/1, end_per_suite/1,
-	 init_per_group/2, end_per_group/2]).
+   init_per_group/2, end_per_group/2]).
 
--export([render/1, render_smoke/1, links/1, normalize/1, render_prop/1]).
+-export([render/1, render_smoke/1, links/1, normalize/1, render_prop/1,
+         render_non_native/1]).
 
 -export([render_all/1, update_render/0, update_render/1]).
 
@@ -32,7 +33,7 @@ suite() ->
     [{timetrap,{minutes,10}}].
 
 all() ->
-    [render_smoke, render, links, normalize, {group, prop}].
+    [render_smoke, render, render_non_native, links, normalize, {group, prop}].
 
 groups() ->
     [{prop,[],[render_prop]}].
@@ -234,6 +235,24 @@ b2a(Bin) ->
         {ok,[{atom,_,A}],_} -> A;
         {ok,[{A,_}],_} -> A
     end.
+
+%% Test rendering of non-native modules
+render_non_native(_Config) ->
+    Docs = #docs_v1{
+        anno = erl_anno:new(13),
+        beam_language = not_erlang,
+        format = <<"text/asciidoc">>,
+        module_doc = #{<<"en">> => <<"This is\n\npure text">>},
+        docs= []
+    },
+
+    <<"\n\tnot_an_erlang_module\n\n"
+      "    This is\n"
+      "    \n"
+      "    pure text\n">> =
+        unicode:characters_to_binary(shell_docs:render(not_an_erlang_module, Docs, #{})),
+
+    ok.
 
 %% Testing functions
 render_all(Dir) ->


### PR DESCRIPTION
This pull request augments shell_docs to also
handle any chunk with type of "text". Those will
be rendered as is and allow the Erlang shell to
show the documentation of projects that do not
adhere to the application/erlang+html format.
This is useful because many documentation formats
(Markdown, Asciidoc, etc) are readable in their
native format.  