### PR TITLE
Expose math:nearbyint/1

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -773,3 +773,4 @@ bif erlang:unalias/1
 bif erlang:monitor/3
 bif erlang:error/3
 bif maps:from_keys/2
+bif math:nearbyint/1

--- a/erts/emulator/beam/erl_math.c
+++ b/erts/emulator/beam/erl_math.c
@@ -22,10 +22,12 @@
 #  include "config.h"
 #endif
 
+#include <fenv.h>
 #include "sys.h"
 #include "erl_vm.h"
 #include "global.h"
 #include "erl_process.h"
+#include "erl_math.h"
 #include "error.h"
 #include "bif.h"
 #include "big.h"
@@ -292,4 +294,85 @@ BIF_RETTYPE math_floor_1(BIF_ALIST_1)
 BIF_RETTYPE math_fmod_2(BIF_ALIST_2)
 {
     return math_call_2(BIF_P, fmod, BIF_ARG_1, BIF_ARG_2);
+}
+
+BIF_RETTYPE math_nearbyint_1(BIF_ALIST_1)
+{
+    Eterm res;
+    FloatDef f;
+    int curr_direction;
+
+    /* check arg */
+    if (is_not_float(BIF_ARG_1)) {
+	if (is_integer(BIF_ARG_1)) {
+	    BIF_RET(BIF_ARG_1);
+	}
+	BIF_ERROR(BIF_P, BADARG);
+    }
+
+    /* get the float */
+    GET_DOUBLE(BIF_ARG_1, f);
+
+#pragma STDC FENV_ACCESS ON
+    curr_direction = fegetround();
+    fesetround(FE_TONEAREST);
+    res = double_to_integer(BIF_P, nearbyint(f.fd));
+    fesetround(curr_direction);
+    BIF_RET(res);
+}
+
+/*
+ * Generate the integer part from a double.
+ */
+Eterm double_to_integer(Process* p, double x)
+{
+    int is_negative;
+    int ds;
+    ErtsDigit* xp;
+    int i;
+    Eterm res;
+    size_t sz;
+    Eterm* hp;
+    double dbase;
+
+    if ((x < (double) (MAX_SMALL+1)) && (x > (double) (MIN_SMALL-1))) {
+	Sint xi = x;
+	return make_small(xi);
+    }
+
+    if (x >= 0) {
+	is_negative = 0;
+    } else {
+	is_negative = 1;
+	x = -x;
+    }
+
+    /* Unscale & (calculate exponent) */
+    ds = 0;
+    dbase = ((double)(D_MASK)+1);
+    while(x >= 1.0) {
+	x /= dbase;         /* "shift" right */
+	ds++;
+    }
+    sz = BIG_NEED_SIZE(ds);          /* number of words including arity */
+
+    hp = HeapFragOnlyAlloc(p, sz);
+    res = make_big(hp);
+    xp = (ErtsDigit*) (hp + 1);
+
+    for (i = ds-1; i >= 0; i--) {
+	ErtsDigit d;
+
+	x *= dbase;      /* "shift" left */
+	d = x;            /* trunc */
+	xp[i] = d;        /* store digit */
+	x -= d;           /* remove integer part */
+    }
+
+    if (is_negative) {
+	*hp = make_neg_bignum_header(sz-1);
+    } else {
+	*hp = make_pos_bignum_header(sz-1);
+    }
+    return res;
 }

--- a/erts/emulator/beam/erl_math.h
+++ b/erts/emulator/beam/erl_math.h
@@ -1,0 +1,24 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2014-2021. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+#ifndef ERL_MATH_H__
+#define ERL_MATH_H__
+Eterm double_to_integer(Process* p, double x);
+#endif /* ERL_MATH_H__ */

--- a/lib/stdlib/doc/src/math.xml
+++ b/lib/stdlib/doc/src/math.xml
@@ -82,6 +82,25 @@
     </func>
 
     <func>
+      <name name="nearbyint" arity="1" since="OTP 24.0"/>
+      <fsummary>Rounds to nearest integer.</fsummary>
+      <desc>
+        <p>Rounds to nearest integer where ties round towards even numbers.
+          This is a contrast to <seemfa marker="erts:erlang#round/1"><c>
+          erlang:round/1</c></seemfa> which rounds ties away from zero.</p>
+        <pre>
+> erlang:round(0.5).
+1
+> math:nearbyint(0.5).
+0
+> erlang:round(-0.5).
+-1
+> math:nearbyint(0.5).
+0</pre>
+      </desc>
+    </func>
+
+    <func>
       <name name="erf" arity="1" since=""/>
       <fsummary>Error function.</fsummary>
       <desc>

--- a/lib/stdlib/src/math.erl
+++ b/lib/stdlib/src/math.erl
@@ -26,7 +26,7 @@
 -export([sin/1, cos/1, tan/1, asin/1, acos/1, atan/1, atan2/2, sinh/1,
          cosh/1, tanh/1, asinh/1, acosh/1, atanh/1, exp/1, log/1,
          log2/1, log10/1, pow/2, sqrt/1, erf/1, erfc/1,
-         ceil/1, floor/1,
+         ceil/1, floor/1, nearbyint/1,
          fmod/2]).
 
 -spec acos(X) -> float() when
@@ -103,6 +103,11 @@ floor(_) ->
 -spec fmod(X, Y) -> float() when
       X :: number(), Y :: number().
 fmod(_, _) ->
+    erlang:nif_error(undef).
+
+-spec nearbyint(X) -> integer() when
+      X :: number().
+nearbyint(_) ->
     erlang:nif_error(undef).
 
 -spec log(X) -> float() when

--- a/lib/stdlib/test/math_SUITE.erl
+++ b/lib/stdlib/test/math_SUITE.erl
@@ -28,7 +28,7 @@
 	 init_per_testcase/2, end_per_testcase/2]).
 
 %% Test cases
--export([floor_ceil/1, error_info/1]).
+-export([floor_ceil/1, nearbyint/1, error_info/1]).
 
 
 suite() ->
@@ -36,7 +36,7 @@ suite() ->
      {timetrap,{minutes,1}}].
 
 all() ->
-    [floor_ceil, error_info].
+    [floor_ceil, nearbyint, error_info].
 
 groups() ->
     [].
@@ -58,6 +58,31 @@ init_per_testcase(_Case, Config) ->
     Config.
 
 end_per_testcase(_Case, _Config) ->
+    ok.
+
+nearbyint(_Config) ->
+    0 = math:nearbyint(0.0),
+    0 = math:nearbyint(-0.0),
+    0 = math:nearbyint(0.3),
+    0 = math:nearbyint(0.5),
+    1 = math:nearbyint(0.7),
+    0 = math:nearbyint(-0.3),
+    0 = math:nearbyint(-0.5),
+    -1 = math:nearbyint(-0.7),
+
+    0 = math:nearbyint(0),
+    1 = math:nearbyint(1),
+    -1 = math:nearbyint(-1),
+
+    1 = math:nearbyint(1.0),
+    -1 = math:nearbyint(-1.0),
+    1 = math:nearbyint(1.3),
+    2 = math:nearbyint(1.5),
+    2 = math:nearbyint(1.7),
+    -1 = math:nearbyint(-1.3),
+    -2 = math:nearbyint(-1.5),
+    -2 = math:nearbyint(-1.7),
+
     ok.
 
 floor_ceil(_Config) ->


### PR DESCRIPTION
IEEE 754 proposes five rounding modes:

  1. To positive infinity (achievable with ceil)
  2. To negative infinity (achievable with floor)
  3. To zero (achievable with floor+ceil)
  4. Ties away from zero (achievable with round)
  5. Ties to even (not achievable)

Erlang behaves according to C in those operations
but it doesn't expose an operation for "ties to even",
which is the recommended operation according to the
standard. We can provide the missing operation by
exposing math:nearbyint/1, added on C99.