### PR TITLE
Fix minor leaks in erlang:trace/3

### DIFF
--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -465,19 +465,25 @@ erts_trace_flags(Eterm List,
 	    cpu_timestamp = !0;
 #endif
 	} else if (is_tuple(item)) {
+            ERTS_TRACER_CLEAR(&tracer);
             tracer = erts_term_to_tracer(am_tracer, item);
             if (tracer == THE_NON_VALUE)
                 goto error;
 	} else goto error;
 	list = CDR(list_val(list));
     }
-    if (is_not_nil(list)) goto error;
+    if (is_not_nil(list)) {
+        goto error;
+    }
     
     if (mask)                        *pMask         = mask;
     if (!ERTS_TRACER_IS_NIL(tracer)) *pTracer       = tracer;
     if (cpu_timestamp)               *pCpuTimestamp = cpu_timestamp;
     return !0;
+
  error:
+    if (tracer != THE_NON_VALUE)
+	ERTS_TRACER_CLEAR(&tracer);
     return 0;
 }
 
@@ -541,6 +547,7 @@ Eterm erts_internal_trace_3(BIF_ALIST_3)
     }
 
     if (!erts_try_seize_code_write_permission(BIF_P)) {
+        ERTS_TRACER_CLEAR(&tracer);
 	ERTS_BIF_YIELD3(&bif_trap_export[BIF_erts_internal_trace_3],
                         BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3);
     }

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -473,9 +473,9 @@ erts_trace_flags(Eterm List,
     }
     if (is_not_nil(list)) goto error;
     
-    if (pMask && mask)                           *pMask         = mask;
-    if (pTracer && !ERTS_TRACER_IS_NIL(tracer))  *pTracer       = tracer;
-    if (pCpuTimestamp && cpu_timestamp)          *pCpuTimestamp = cpu_timestamp;
+    if (mask)                        *pMask         = mask;
+    if (!ERTS_TRACER_IS_NIL(tracer)) *pTracer       = tracer;
+    if (cpu_timestamp)               *pCpuTimestamp = cpu_timestamp;
     return !0;
  error:
     return 0;

--- a/erts/emulator/test/trace_SUITE.erl
+++ b/erts/emulator/test/trace_SUITE.erl
@@ -1684,6 +1684,18 @@ bad_flag(Config) when is_list(Config) ->
     {'EXIT', {badarg, _}} = (catch erlang:trace(new,
                                                 true,
                                                 [not_a_valid_flag])),
+
+    %% Leaks of {tracer,_} in OTP 23.2
+    Pid = spawn(fun() -> receive die -> ok end end),
+    1 = erlang:trace(Pid, true, [{tracer, self()},
+                                 {tracer, self()}]),
+    Pid ! die,
+    {'EXIT', {badarg, _}} =
+        (catch erlang:trace(new, true, [{tracer, self()}
+                                        | improper])),
+    {'EXIT', {badarg, _}} =
+        (catch erlang:trace(new, true, [{tracer, self()},
+                                        not_a_valid_flag])),
     ok.
 
 %% Test erlang:trace_delivered/1


### PR DESCRIPTION
Leaks a couple of words per erlang:trace/3 call if FlagList argument
- has more than one {tracer, _} in list
- has {tracer, _} followed by invalid option or improper list
- has {tracer, _} in list but fails to seize code write permission
