### PR TITLE
ssl: fix docs for protocol_version and dtls_protocol_version application environment options

### DIFF
--- a/lib/ssl/doc/src/ssl_app.xml
+++ b/lib/ssl/doc/src/ssl_app.xml
@@ -65,14 +65,16 @@
     <p><c>erl -ssl protocol_version "['tlsv1.2', 'tlsv1.1']"</c></p>
 
     <taglist>
-      <tag><c>protocol_version = </c><seetype marker="ssl#protocol">ssl:ssl_tls_protocol()</seetype><c><![CDATA[<optional>]]></c></tag>
+      <tag><c>protocol_version = </c><seetype marker="ssl#tls_version">ssl:tls_version()</seetype> |
+        [<seetype marker="ssl#tls_version">ssl:tls_version()</seetype>] <c><![CDATA[<optional>]]></c></tag>
       <item><p>Protocol supported by started clients and
       servers. If this option is not set, it defaults to all
       TLS protocols currently supported, more might be configurable, by the SSL application.
       This option can be overridden by the version option
       to <c>ssl:connect/[2,3]</c> and <c>ssl:listen/2</c>.</p></item>
 
-      <tag><c>dtls_protocol_version = </c><seetype marker="ssl#protocol">ssl:dtls_protocol()</seetype><c><![CDATA[<optional>]]></c></tag>
+      <tag><c>dtls_protocol_version = </c><seetype marker="ssl#dtls_version">ssl:dtls_version()</seetype> |
+        [<seetype marker="ssl#dtls_version">ssl:dtls_version()</seetype>] <c><![CDATA[<optional>]]></c></tag>
       <item><p>Protocol supported by started clients and
       servers. If this option is not set, it defaults to all
       DTLS protocols currently supported, more might be configurable, by the SSL application.


### PR DESCRIPTION
The documentation for the ssl application environment options `protocol_version` and `dtls_protocol_version` was incorrect. They respectively specified `ssl:ssl_tls_protocol()` and `ssl:dtls_protocol()` (which both don't exist) as expected types, and linked both to `ssl:protocol()` (which is `tls | dtls`).

The correct types are `ssl:tls_version()` (or a list thereof) for the `protocol_version` option, and `ssl:dtls_version()` (or a list thereof) for the `dtls_protocol_version` option.