### PR TITLE
Fix inet:get_rc/0 host entries

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2020. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -430,10 +430,12 @@ get_rc_ns([], _Tag, Ks, Ls) ->
     get_rc(Ks, Ls).
 
 get_rc_hosts(Ks, Ls, Tab) ->
-    case ets:tab2list(Tab) of
-	[] -> get_rc(Ks, Ls);
-	Hosts -> get_rc(Ks, [ [{host, IP, Names} || {{_Fam, IP}, Names} <- Hosts] | Ls])
-    end.
+    get_rc(Ks, get_rc_hosts(ets:tab2list(Tab), Ls)).
+
+get_rc_hosts([], Ls) ->
+    Ls;
+get_rc_hosts([{{_Fam, IP}, Names} | Hosts], Ls) ->
+    get_rc_hosts(Hosts, [{host, IP, Names} | Ls]).
 
 %%
 %% Resolver options

--- a/lib/kernel/test/inet_SUITE.erl
+++ b/lib/kernel/test/inet_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2020. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -1013,6 +1013,7 @@ hosts_file_quirks(Config) when is_list(Config) ->
     %% ensure it has our RC
     Rc = rpc:call(TestNode, inet_db, get_rc, []),
     {hosts_file, HostsFile} = lists:keyfind(hosts_file, 1, Rc),
+    false = lists:keyfind(host, 1, Rc),
     %%
     %% check entries
     io:format("Check hosts file contents~n", []),
@@ -1031,14 +1032,13 @@ hosts_file_quirks(Config) when is_list(Config) ->
     hosts_file_quirks_verify(TestNode, V1),
     %%
     %% test add and del
-    ok =
-        rpc:call(
-          TestNode, inet_db, add_host,
-          [inet_ex(1), [h_ex("a"), h_ex("B")]]),
+    A1 = inet_ex(1),
+    Hs1 = [h_ex("a"), h_ex("B")],
+    ok = rpc:call(TestNode, inet_db, add_host, [A1, Hs1]),
     io:format("Check after add host~n", []),
     hosts_file_quirks_verify(
       TestNode,
-      [{R1, inet_ex(1)},
+      [{R1, A1},
        {R2, inet_ex(2)},
        {R3, inet6_ex(3)},
        {R5, inet_ex(5)},
@@ -1049,6 +1049,8 @@ hosts_file_quirks(Config) when is_list(Config) ->
        {R3, h_ex("a"), inet6},
        {R3, h_ex("c"), inet6}
       ]),
+    {host, A1, Hs1} =
+        lists:keyfind(host, 1, rpc:call(TestNode, inet_db, get_rc, [])),
     ok = rpc:call(TestNode, inet_db, del_host, [inet_ex(1)]),
     io:format("Check after del host~n", []),
     hosts_file_quirks_verify(TestNode, V1),


### PR DESCRIPTION
Correct inet:get_rc/0 to return host entries as separate entries
instead of (incorrectly) in a list within the list.  This bug
was introduced by OTP-16487 (fb39f1024) in OTP-23.0-rc1.

This PR fixes the issue GH-4588.