### PR TITLE
Windows CI build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,6 +38,78 @@ jobs:
           name: otp_git_archive
           path: otp_src.tar.gz
 
+
+  build-windows:
+    defaults:
+      run:
+        shell: wsl-bash {0}
+    name: Build Erlang/OTP on Windows
+    runs-on: windows-latest
+    needs: pack
+    steps:
+      - uses: Vampire/setup-wsl@v1
+        with:
+          distribution: Ubuntu-18.04
+
+      - name: Install WSL dependencies
+        run: apt update && apt install -y g++-mingw-w64 gcc-mingw-w64 make autoconf unzip
+
+      - name: Install openssl
+        shell: cmd
+        run: |
+          choco install openssl
+          move "c:\\Program Files\\OpenSSL-Win64" "c:\\OpenSSL-Win64"
+
+      - name: Download wxWidgets
+        run: |
+          mkdir -p /mnt/c/opt/local64/pgm/
+          cd /mnt/c/opt/local64/pgm/
+          wget https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.zip
+          unzip wxWidgets-3.1.4.zip -d wxWidgets-3.1.4
+          sed -i -r -e 's/wxUSE_POSTSCRIPT +0/wxUSE_POSTSCRIPT 1/' /mnt/c/opt/local64/pgm/wxWidgets-3.1.4/include/wx/msw/setup.h
+          sed -i -r -e 's/wxUSE_WEBVIEW_EDGE +0/wxUSE_WEBVIEW_EDGE 1/' /mnt/c/opt/local64/pgm/wxWidgets-3.1.4/include/wx/msw/setup.h
+
+      - name: Install WebView2
+        shell: cmd
+        run: |
+          c:
+          cd c:\\opt\\local64\\pgm\\wxWidgets-3.1.4\\3rdparty
+          nuget install Microsoft.Web.WebView2 -Version 1.0.705.50
+          rename Microsoft.Web.WebView2.1.0.705.50 webview2
+
+      - name: Build wxWidgets
+        shell: cmd
+        run: |
+          c:
+          cd c:\\opt\\local64\\pgm\\wxWidgets-3.1.4\\build\\msw
+          call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\Auxiliary\\Build\\vcvars64.bat"
+          nmake TARGET_CPU=amd64 BUILD=release SHARED=0 DIR_SUFFIX_CPU= -f makefile.vc
+
+      - name: Download source archive
+        uses: actions/download-artifact@v2
+        with:
+          name: otp_git_archive
+
+      - name: Compile Erlang
+        run: |
+          tar -xzf ./otp_src.tar.gz
+          cd otp
+          export ERL_TOP=`pwd`
+          eval `./otp_build env_win32 x64`
+          ./otp_build autoconf
+          ./otp_build configure
+          if cat erts/CONF_INFO || cat lib/*/CONF_INFO || cat lib/*/SKIP || cat lib/SKIP-APPLICATIONS; then exit 1; fi
+          ./otp_build boot -a
+          ./otp_build release -a
+          cp /mnt/c/opt/local64/pgm/wxWidgets-3.1.4/3rdparty/webview2/runtimes/win-x64/native/WebView2Loader.dll $ERL_TOP/release/win32/erts-*/bin/
+          ./otp_build installer_win32
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v2
+        with:
+          name: otp_prebuilt_win32
+          path: otp/release/win32/otp*.exe
+
   build:
     name: Build Erlang/OTP
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -96,7 +96,6 @@ jobs:
           cd otp
           export ERL_TOP=`pwd`
           eval `./otp_build env_win32 x64`
-          ./otp_build autoconf
           ./otp_build configure
           if cat erts/CONF_INFO || cat lib/*/CONF_INFO || cat lib/*/SKIP || cat lib/SKIP-APPLICATIONS; then exit 1; fi
           ./otp_build boot -a

--- a/HOWTO/INSTALL-WIN32.md
+++ b/HOWTO/INSTALL-WIN32.md
@@ -68,7 +68,7 @@ This is the short story though, for the experienced and impatient:
         <http://www.erlang.org/download.html>) and unpack with `tar`
         to the windows disk for example to: /mnt/c/src/
 
-    *   Install mingw-gcc, make and autoconf: `sudo apt install gcc-mingw-w64 make autoconf`
+    *   Install mingw-gcc, make and autoconf: `sudo apt install g++-mingw-w64 gcc-mingw-w64 make autoconf`
 
     *   `$ cd UNPACK_DIR`
 
@@ -153,22 +153,22 @@ the different tools:
 *   wxWidgets (optional)
     You need this to build wx and use gui's in debugger and observer.
 
-    We recommend v3.1.3 or later.
-    Unpack into `c:/opt/local64/pgm/wxWidgets-3.1.3`
+    We recommend v3.1.4 or later.
+    Unpack into `c:/opt/local64/pgm/wxWidgets-3.1.4`
 
-    If the `wxUSE_POSTSCRIPT` isn't enabled in  `c:/opt/local64/pgm/wxWidgets-3.1.3/include/wx/msw/setup.h`,
+    If the `wxUSE_POSTSCRIPT` isn't enabled in  `c:/opt/local64/pgm/wxWidgets-3.1.4/include/wx/msw/setup.h`,
     enable it.
 
-    We recommend to enable for wxWebView  wxUSE_WEBVIEW_EDGE.
-    Download the WebView2 SDK nuget package (Version 0.9.488 or newer)
-    Extract the package (it's a zip archive) to wxWidgets/3rdparty/webview2 (you should have 3rdparty/webview2/build/native/include/WebView2.h file after unpacking it)
-    Enable wxUSE_WEBVIEW_EDGE in CMake or setup.h
-    After `otp_build release -a` copy WebView2Loader.dll from the subdirectory corresponding to the architecture used (x86 or x64) of wxWidgets/3rdparty/webview2/build/ to your $ERL_TOP/release/win32/erts-*/bin/ directory
+    We recommend to enable for wxWebView wxUSE_WEBVIEW_EDGE.
+    *   Download the nuget package 'Microsoft.Web.WebView2' (Version 0.9.488 or newer)
+    *   Extract the package (it's a zip archive) to wxWidgets/3rdparty/webview2 (you should have 3rdparty/webview2/build/native/include/WebView2.h file after unpacking it)
+    *   Enable wxUSE_WEBVIEW_EDGE in `c:/opt/local64/pgm/wxWidgets-3.1.4/include/wx/msw/setup.h`
+    *   After `otp_build release -a` copy WebView2Loader.dll from the subdirectory corresponding to the architecture used (x86 or x64) of wxWidgets/3rdparty/webview2/build/ to your $ERL_TOP/release/win32/erts-*/bin/ directory
         `cp /mnt/c/opt/local64/pgm/wxWidgets-3.1.4/3rdparty/webview2/runtimes/win-x64/native/WebView2Loader.dll $ERL_TOP/release/win32/erts-11.1.7/bin/`
 
     Build with:
 
-        C:\...\> cd c:\opt\local64\pgm\wxWidgets-3.1.3\build\msw
+        C:\...\> cd c:\opt\local64\pgm\wxWidgets-3.1.4\build\msw
         C:\...\> nmake TARGET_CPU=amd64 BUILD=release SHARED=0 DIR_SUFFIX_CPU= -f makefile.vc
 
     Remove the `TARGET_CPU=amd64` for 32bit build.

--- a/erts/etc/win32/wsl_tools/SetupWSLcross.bat
+++ b/erts/etc/win32/wsl_tools/SetupWSLcross.bat
@@ -13,6 +13,11 @@ IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxi
    goto continue
 )
 
+IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat". (
+   call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %~1 > nul
+   goto continue
+)
+
 IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvarsall.bat". (
    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvarsall.bat" %~1 > nul
    goto continue


### PR DESCRIPTION
As per discussion in #3027 @dgud @garazdawi this is adding a windows CI build based on Github Windows image + WSL.

This build skips building the docs intentionally but produces a Windows installer with all apps (including wxWidgets 3.1.4 and WebView2).

It's not signing any of the executables, but it's definitely good enough to see whether everything still compiles and for quick downloading and testing.

Cheers!