### PR TITLE
New link protocol

### DIFF
--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -974,7 +974,11 @@ DiB == gen_digest(ChA, ICA)?
     <section>
       <marker id="dflags"/>
       <title>Distribution Flags</title>
-      <p>The following capability flags are defined:</p>
+      <p>Early in the distribution handshake the two participating nodes
+      exchange capability flags. This in order to determine how the
+      communication between the two nodes should be performed. The intersection
+      of the capabilities presented by the two nodes defines the capabilities
+      that will be used. The following capability flags are defined:</p>
       <taglist>
         <tag><c>-define(DFLAG_PUBLISHED,16#1).</c></tag>
         <item>
@@ -1096,6 +1100,14 @@ DiB == gen_digest(ChA, ICA)?
           <p>The node supports the new connection setup handshake (version 6)
 	  introduced in OTP 23.</p>
         </item>
+        <tag><marker id="DFLAG_UNLINK_ID"/><c>-define(DFLAG_UNLINK_ID, 16#2000000).</c></tag>
+        <item>
+	  <p>Use the <seeguide marker="#new_link_protocol">new link protocol</seeguide>.</p>
+	  <note><p>This flag will become mandatory in OTP 26.</p></note>
+	  <p>Unless both nodes has set the <c>DFLAG_UNLINK_ID</c> flag, the
+	  <seeguide marker="#old_link_protocol">old link protocol</seeguide>
+	  will be used as a fallback.</p>
+	</item>
         <tag><marker id="DFLAG_SPAWN"/><c>-define(DFLAG_SPAWN, (1 bsl 32)).</c></tag>
         <item>
           <p>Set if the <seeguide marker="#SPAWN_REQUEST"><c>SPAWN_REQUEST</c></seeguide>,
@@ -1221,9 +1233,12 @@ DiB == gen_digest(ChA, ICA)?
       which distributed operation it encodes:</p>
 
     <taglist>
-      <tag><c>LINK</c></tag>
+      <tag><marker id="LINK"/><c>LINK</c></tag>
       <item>
         <p><c>{1, FromPid, ToPid}</c></p>
+	<p>This signal is sent by <c>FromPid</c> in order
+	to create a link between <c>FromPid</c> and
+	<c>ToPid</c>.</p>
       </item>
       <tag><c>SEND</c></tag>
       <item>
@@ -1236,9 +1251,18 @@ DiB == gen_digest(ChA, ICA)?
         <p><c>{3, FromPid, ToPid, Reason}</c></p>
         <p>This signal is sent when a link has been broken</p>
       </item>
-      <tag><c>UNLINK</c></tag>
+      <tag><marker id="UNLINK"/><c>UNLINK</c> (deprecated)</tag>
       <item>
         <p><c>{4, FromPid, ToPid}</c></p>
+	<p>This signal is sent by <c>FromPid</c> in order to remove
+	a link between <c>FromPid</c> and <c>ToPid</c>, when using the
+	<seeguide marker="#old_link_protocol">old link
+	protocol</seeguide>.</p>
+	<warning><p>This signal has been deprecated and will not
+	be supported in OTP 26. For more information see the
+	documentation of the
+	<seeguide marker="#new_link_protocol">new link protocol</seeguide>.
+	</p></warning>
       </item>
       <tag><c>NODE_LINK</c></tag>
       <item>
@@ -1300,9 +1324,8 @@ DiB == gen_digest(ChA, ICA)?
           <c>Reason</c> = exit reason for the monitored process</p>
       </item>
     </taglist>
-  </section>
 
-  <section>
+    <section>
     <title>New Ctrlmessages for Erlang/OTP 21</title>
     <taglist>
       <tag><c>SEND_SENDER</c></tag>
@@ -1513,6 +1536,247 @@ DiB == gen_digest(ChA, ICA)?
 	  has been passed.
 	</p>
       </item>
+      <tag><marker id="UNLINK_ID"/><c>UNLINK_ID</c></tag>
+      <item>
+        <p><c>{35, Id, FromPid, ToPid}</c></p>
+	<p>This signal is sent by <c>FromPid</c> in order to remove a
+	link between <c>FromPid</c> and <c>ToPid</c>. This unlink signal
+        replaces the <seeguide marker="#UNLINK"><c>UNLINK</c></seeguide>
+	signal. Besides process identifiers of the sender and receiver
+	the <c>UNLINK_ID</c> signal also contains an integer identifier
+	<c>Id</c>. Valid range of <c>Id</c> is <c>[1, (1 bsl 64) - 1]</c>.
+	<c>Id</c> is to be passed back to the sender by the receiver in an
+	<seeguide marker="#UNLINK_ID_ACK"><c>UNLINK_ID_ACK</c></seeguide>
+	signal. <c>Id</c> must uniquely identify the <c>UNLINK_ID</c> signal
+	among all not yet acknowledged <c>UNLINK_ID</c> signals from
+	<c>FromPid</c> to <c>ToPid</c>.</p>
+	<p>
+	  This signal is only passed when the 
+	  <seeguide marker="#new_link_protocol">new link protocol</seeguide>
+	  has been negotiated using the
+	  <seeguide marker="erl_dist_protocol#DFLAG_UNLINK_ID"><c>DFLAG_UNLINK_ID</c></seeguide>
+	  <seeguide marker="erl_dist_protocol#dflags">distribution flag</seeguide>.
+	</p>
+      </item>
+      <tag><marker id="UNLINK_ID_ACK"/><c>UNLINK_ID_ACK</c></tag>
+      <item>
+        <p><c>{36, Id, FromPid, ToPid}</c></p>
+        <p>An unlink acknowledgement signal. This signal is sent as an
+	acknowledgement of the reception of an 
+	<seeguide marker="#UNLINK_ID"><c>UNLINK_ID</c></seeguide>
+	signal. The <c>Id</c> element should be the same <c>Id</c>
+	as present in the <c>UNLINK_ID</c> signal. <c>FromPid</c>
+	identifies the sender of the <c>UNLINK_ID_ACK</c> signal and
+	<c>ToPid</c> identifies the sender of the <c>UNLINK_ID</c>
+	signal.</p>
+	<p>
+	  This signal is only passed when the 
+	  <seeguide marker="#new_link_protocol">new link protocol</seeguide>
+	  has been negotiated using the
+	  <seeguide marker="erl_dist_protocol#DFLAG_UNLINK_ID"><c>DFLAG_UNLINK_ID</c></seeguide>
+	  <seeguide marker="erl_dist_protocol#dflags">distribution flag</seeguide>.
+	</p>
+      </item>
     </taglist>
   </section>
+  <section>
+    <marker id="link_protocol"/>
+    <title>Link Protocol</title>
+
+    <section>
+      <marker id="new_link_protocol"/>
+      <title>New Link Protocol</title>
+
+      <p>
+	The new link protocol will be used when both nodes flag that
+	they understand it using the
+	<seeguide marker="#DFLAG_UNLINK_ID"><c>DFLAG_UNLINK_ID</c></seeguide>
+	<seeguide marker="#dflags">distribution flag</seeguide>. If
+	one of the nodes does not understand the new link protocol, the
+	<seeguide marker="#old_link_protocol">old link protocol</seeguide>
+	will be used as a fallback.
+      </p>
+      
+      <p>
+	The new link protocol introduces two new signals,
+	<seeguide marker="#UNLINK_ID"><c>UNLINK_ID</c></seeguide> and
+	<seeguide marker="#UNLINK_ID"><c>UNLINK_ID_ACK</c></seeguide>,
+	which replace the old
+	<seeguide marker="#UNLINK"><c>UNLINK</c></seeguide>
+	signal. The old <seeguide marker="#LINK"><c>LINK</c></seeguide>
+	signal is still sent in order to set up a link, but handled
+	differently upon reception.
+      </p>
+
+      <p>
+	In order to set up a link, a <c>LINK</c> signal is sent, from
+	the process initiating the operation, to the process that it
+	wants to link with. In order to remove a link, an
+	<c>UNLINK_ID</c> signal is sent, from the process initiating
+	the operation, to the linked process. The receiver of an
+	<c>UNLINK_ID</c> signal responds with an <c>UNLINK_ID_ACK</c>
+	signal. Upon reception of an <c>UNLINK_ID</c> signal, the
+	corresponding <c>UNLINK_ID_ACK</c> signal <em>must</em> be
+	sent before any other signals are sent to the sender of the
+	<c>UNLINK_ID</c> signal. This together with
+	<seeguide marker="erts:communication#passing-of-signals">the
+	signal ordering guarantees</seeguide> of Erlang makes it
+	possible for the sender of the <c>UNLINK_ID</c> signal to know
+	the order of other signals which is essential for the protocol.
+	The <c>UNLINK_ID_ACK</c> signal should contain the same
+	<c>Id</c> as the <c>Id</c> contained in the <c>UNLINK_ID</c>
+	signal being acknowledged.
+      </p>
+
+      <p>
+	Processes also need to maintain process local information about
+	links. The state of this process local information is changed
+	when the signals above are sent and received. This process
+	local information also determine if a signal should be sent
+	when a process calls
+	<seemfa marker="erlang#link/1"><c>link/1</c></seemfa> or
+	<seemfa marker="erlang#unlink/1"><c>unlink/1</c></seemfa>.
+	A <c>LINK</c> signal is only sent if there currently does not
+	exist an active link between the processes according to the
+	process local information and an <c>UNLINK_ID</c> signal is
+	only sent if there currently exists an active link between the
+	processes according to the process local information.
+      </p>
+
+      <p>
+	The process local information about a link contains:
+      </p>
+      <taglist>
+	<tag>Pid</tag>
+	<item>
+	  Process identifier of the linked process.
+	</item>
+	<tag>Active Flag</tag>
+	<item>
+	  If set, the link is active and the process will react on
+	  <seeguide marker="system/reference_manual:processes#receiving_exit_signals">incoming
+	  exit signals</seeguide> issued due to the link. If not set,
+	  the link is inactive and incoming exit signals issued due
+	  to the link will be ignored. That is, the processes are
+	  considered as <em>not</em> linked.
+	</item>
+	<tag>Unlink Id</tag>
+	<item>
+	  Identifier of an outstanding unlink operation. That is,
+	  an unlink operation that has not been acknowledged yet.
+	  This information is only used when the active flag is not
+	  set.
+	</item>
+      </taglist>
+
+      <p>
+	A process is only considered linked to another process
+	if it has process local information about the link
+	containing the process identifier of the other process and
+	with the active flag set.
+      </p>
+
+      <p>
+	The process local information about a link is updated as
+	follows:
+      </p>
+      <taglist>
+	<tag>A <c>LINK</c> signal is sent</tag>
+	<item>
+	  Link information is created if not already existing. The
+	  active flag is set, and unlink id is cleared. That is,
+	  if we had an outstanding unlink operation we will ignore
+	  the result of that operation and enable the link.
+	</item>
+	<tag>A <c>LINK</c> signal is received</tag>
+	<item>
+	  If no link information already exists, it is created, the
+	  active flag is set and unlink id is cleared. If the link
+	  information already exists, the signal is silently ignored.
+	  This regardless of whether the active flag is set or not.
+	  That is, if we have an outstanding unlink operation we will
+	  <em>not</em> activate the link. In this scenario, the sender
+	  of the <c>LINK</c> signal has not yet sent an
+	  <c>UNLINK_ID_ACK</c> signal corresponding to our
+	  <c>UNLINK_ID</c> signal which means that it will receive
+	  the our <c>UNLINK_ID</c> signal after it sent this
+	  <c>LINK</c> signal. This in turn means that both processes
+	  in the end will agree that there is no link between them.
+	</item>
+	<tag>An <c>UNLINK_ID</c> signal is sent</tag>
+	<item>
+	  Link information already exists and the active flag is set
+	  (otherwise the signal would not be sent). The active flag
+	  is unset, and the unlink id of the signal is saved in the
+	  link information.
+	</item>
+	<tag>An <c>UNLINK_ID</c> signal is received</tag>
+	<item>
+	  If the active flag is set, information about the link
+	  is removed. If the active flag is not set (that is, we have
+	  an outstanding unlink operation), the information about the
+	  link is left unchanged.
+	</item>
+	<tag>An <c>UNLINK_ID_ACK</c> signal is sent</tag>
+	<item>
+	  This is done when an <c>UNLINK_ID</c> signal is received and
+	  cause no further changes of the link information.
+	</item>
+	<tag>An <c>UNLINK_ID_ACK</c> signal is received</tag>
+	<item>
+	  If information about the link exist, the active flag is not
+	  set, and the unlink id in the link information equals the
+	  <c>Id</c> in the signal, the link information is removed;
+	  otherwise, the signal is ignored.
+	</item>
+      </taglist>
+
+      <p>
+	When a process receives an exit signal due to a link, the
+	process will first react to the exit signal if the link
+	is active and then remove the process local information about
+	the link.
+      </p>
+      <p>
+	In case the connection is lost between two nodes, exit signals
+	with exit reason <c>noconnection</c> are sent to all processes
+	with links over the connection. This will cause all process
+	local information about links over the connection to be
+	removed.
+      </p>
+      <p>
+	Exactly the same link protocol is also used internally on an
+	Erlang node. The signals however have different formats since
+	they do not have to be sent over the wire.
+      </p>
+    </section>
+
+    <section>
+      <marker id="old_link_protocol"/>
+      <title>Old Link Protocol</title>
+
+      <p>
+	The old link protocol utilize two signals
+	<seeguide marker="#LINK"><c>LINK</c></seeguide>, and
+	<seeguide marker="#UNLINK"><c>UNLINK</c></seeguide>. The
+	<c>LINK</c> signal informs the other process that a link
+	should be set up, and the <c>UNLINK</c> signal informs the
+	other process that a link should be removed. This protocol
+	is however a bit too naive. If both processes operate on the
+	link simultaneously, the link may end up in an inconsistent
+	state where one process thinks it is linked while the other
+	thinks it is not linked.
+      </p>
+      <p>
+	This protocol is deprecated and support for it will be removed
+	in OTP 26. Until then, it will be used as fallback when
+	communicating with old nodes that do not understand the
+	<seeguide marker="#new_link_protocol">new link
+	protocol</seeguide>.
+      </p>
+    </section>
+
+  </section>
+  </section>
+
 </chapter>

--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -975,7 +975,7 @@ DiB == gen_digest(ChA, ICA)?
       <marker id="dflags"/>
       <title>Distribution Flags</title>
       <p>Early in the distribution handshake the two participating nodes
-      exchange capability flags. This in order to determine how the
+      exchange capability flags. This is done in order to determine how the
       communication between the two nodes should be performed. The intersection
       of the capabilities presented by the two nodes defines the capabilities
       that will be used. The following capability flags are defined:</p>
@@ -1104,7 +1104,7 @@ DiB == gen_digest(ChA, ICA)?
         <item>
 	  <p>Use the <seeguide marker="#new_link_protocol">new link protocol</seeguide>.</p>
 	  <note><p>This flag will become mandatory in OTP 26.</p></note>
-	  <p>Unless both nodes has set the <c>DFLAG_UNLINK_ID</c> flag, the
+	  <p>Unless both nodes have set the <c>DFLAG_UNLINK_ID</c> flag, the
 	  <seeguide marker="#old_link_protocol">old link protocol</seeguide>
 	  will be used as a fallback.</p>
 	</item>
@@ -1611,16 +1611,16 @@ DiB == gen_digest(ChA, ICA)?
       <p>
 	In order to set up a link, a <c>LINK</c> signal is sent, from
 	the process initiating the operation, to the process that it
-	wants to link with. In order to remove a link, an
+	wants to link to. In order to remove a link, an
 	<c>UNLINK_ID</c> signal is sent, from the process initiating
 	the operation, to the linked process. The receiver of an
 	<c>UNLINK_ID</c> signal responds with an <c>UNLINK_ID_ACK</c>
 	signal. Upon reception of an <c>UNLINK_ID</c> signal, the
 	corresponding <c>UNLINK_ID_ACK</c> signal <em>must</em> be
 	sent before any other signals are sent to the sender of the
-	<c>UNLINK_ID</c> signal. This together with
+	<c>UNLINK_ID</c> signal. Together with
 	<seeguide marker="erts:communication#passing-of-signals">the
-	signal ordering guarantees</seeguide> of Erlang makes it
+	signal ordering guarantees</seeguide> of Erlang this makes it
 	possible for the sender of the <c>UNLINK_ID</c> signal to know
 	the order of other signals which is essential for the protocol.
 	The <c>UNLINK_ID_ACK</c> signal should contain the same
@@ -1632,11 +1632,11 @@ DiB == gen_digest(ChA, ICA)?
 	Processes also need to maintain process local information about
 	links. The state of this process local information is changed
 	when the signals above are sent and received. This process
-	local information also determine if a signal should be sent
+	local information also determines if a signal should be sent
 	when a process calls
 	<seemfa marker="erlang#link/1"><c>link/1</c></seemfa> or
 	<seemfa marker="erlang#unlink/1"><c>unlink/1</c></seemfa>.
-	A <c>LINK</c> signal is only sent if there currently does not
+	A <c>LINK</c> signal is only sent if there does not currently
 	exist an active link between the processes according to the
 	process local information and an <c>UNLINK_ID</c> signal is
 	only sent if there currently exists an active link between the
@@ -1656,14 +1656,14 @@ DiB == gen_digest(ChA, ICA)?
 	  If set, the link is active and the process will react on
 	  <seeguide marker="system/reference_manual:processes#receiving_exit_signals">incoming
 	  exit signals</seeguide> issued due to the link. If not set,
-	  the link is inactive and incoming exit signals issued due
-	  to the link will be ignored. That is, the processes are
+	  the link is inactive and incoming exit signals, issued due
+	  to the link, will be ignored. That is, the processes are
 	  considered as <em>not</em> linked.
 	</item>
 	<tag>Unlink Id</tag>
 	<item>
 	  Identifier of an outstanding unlink operation. That is,
-	  an unlink operation that has not been acknowledged yet.
+	  an unlink operation that has not yet been acknowledged.
 	  This information is only used when the active flag is not
 	  set.
 	</item>
@@ -1692,14 +1692,14 @@ DiB == gen_digest(ChA, ICA)?
 	<item>
 	  If no link information already exists, it is created, the
 	  active flag is set and unlink id is cleared. If the link
-	  information already exists, the signal is silently ignored.
-	  This regardless of whether the active flag is set or not.
+	  information already exists, the signal is silently ignored,
+	  regardless of whether the active flag is set or not.
 	  That is, if we have an outstanding unlink operation we will
 	  <em>not</em> activate the link. In this scenario, the sender
 	  of the <c>LINK</c> signal has not yet sent an
 	  <c>UNLINK_ID_ACK</c> signal corresponding to our
 	  <c>UNLINK_ID</c> signal which means that it will receive
-	  the our <c>UNLINK_ID</c> signal after it sent this
+	  our <c>UNLINK_ID</c> signal after it sent its
 	  <c>LINK</c> signal. This in turn means that both processes
 	  in the end will agree that there is no link between them.
 	</item>
@@ -1720,11 +1720,11 @@ DiB == gen_digest(ChA, ICA)?
 	<tag>An <c>UNLINK_ID_ACK</c> signal is sent</tag>
 	<item>
 	  This is done when an <c>UNLINK_ID</c> signal is received and
-	  cause no further changes of the link information.
+	  causes no further changes of the link information.
 	</item>
 	<tag>An <c>UNLINK_ID_ACK</c> signal is received</tag>
 	<item>
-	  If information about the link exist, the active flag is not
+	  If information about the link exists, the active flag is not
 	  set, and the unlink id in the link information equals the
 	  <c>Id</c> in the signal, the link information is removed;
 	  otherwise, the signal is ignored.

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2696,39 +2696,85 @@ false</code>
 
     <func>
       <name name="link" arity="1" since=""/>
-      <fsummary>Create a link to another process (or port).</fsummary>
+      <fsummary>Create a link to another process or port.</fsummary>
       <desc>
 
-        <p>Creates a link between the calling process and another process (or
-          port) <c><anno>PidOrPort</anno></c>. If the link already exists or a
-          process attempts to create a link to itself, nothing is done. Returns
-          <c>true</c> if the link is set up.</p>
+	<p>
+	  Sets up and activates a link between the calling process and
+	  another process or a port identified by
+	  <c><anno>PidOrPort</anno></c>. We will from here on call the
+	  identified process or port linkee. If the linkee is a port, it
+	  must reside on the same node as the caller.
+	</p>
 
-        <p>If <c><anno>PidOrPort</anno></c> does not exist and checking it is
-          cheap, a <c>noproc</c> error is raised. Currently, checking is cheap
-          if the <c><anno>PidOrPort</anno></c> is local and the caller does not
-          trap exits (see <seemfa marker="#process_flag/2"><c>process_flag/2
-          </c></seemfa>).</p>
+	<p>
+	  If one of the participants of a link terminates, it will
+	  <seeguide marker="system/reference_manual:processes#sending_exit_signals">send
+	  an exit signal</seeguide> to the other participant. The exit
+	  signal will contain the
+	  <seeguide marker="system/reference_manual:processes#link_exit_signal_reason">exit
+	  reason</seeguide> of the terminated participant. Other cases when
+	  exit signals are triggered due to a link are when no linkee exist
+	  (<c>noproc</c> exit reason) and when the connection between linked
+	  processes on different nodes is lost or cannot be established
+	  (<c>noconnection</c> exit reason).
+	</p>
 
-        <p>Apart from any exit signals from the linked process itself, two
-          special exit signals may be sent to the calling process:</p>
+	<p>
+	  An existing link can be removed by calling
+	  <seemfa marker="#unlink/1"><c>unlink/1</c></seemfa>.
+	  For more information on links and exit signals due to links, see
+	  the <i>Processes</i> chapter in the <i>Erlang Reference Manual</i>:
+	</p>
+	<list>
+	  <item>
+            <seeguide marker="system/reference_manual:processes#links">Links</seeguide>
+	  </item>
+	  <item>
+	    <seeguide marker="system/reference_manual:processes#sending_exit_signals">Sending
+	    Exit Signals</seeguide>
+	  </item>
+	  <item>
+	    <seeguide marker="system/reference_manual:processes#receiving_exit_signals">Receiving
+	    Exit Signals</seeguide>
+	  </item>
+	</list>
 
-        <list type="bulleted">
+	<p>
+	  For historical reasons, <c>link/1</c> has a strange
+	  semi-synchronous behavior when it is "cheap" to check if the
+	  linkee exists or not, and the caller does not
+	  <seeerl marker="erlang#process_flag_trap_exit">trap exits</seeerl>.
+	  If the above is true and the linkee does not exist, <c>link/1</c>
+	  will raise a <c>noproc</c> error <em>exception</em>. The expected
+	  behavior would instead have been that <c>link/1</c> returned
+	  <c>true</c>, and the caller later was sent an exit signal
+	  with <c>noproc</c> exit reason, but this is unfortunately not the
+	  case. The <c>noproc</c>
+	  <seeguide marker="system/reference_manual:errors#exceptions">
+	  exception</seeguide> is not to be confused with an
+	  <seeguide marker="system/reference_manual:processes#sending_exit_signals">exit
+	  signal</seeguide> with exit reason <c>noproc</c>. Currently it is "cheap"
+	  to check if the linkee exists when it is supposed to reside on
+	  the same node as the calling process.
+	</p>
 
-          <item><p><c>noproc</c> is sent immediately if
-            <c><anno>PidOrPort</anno></c> does not exist at the time of linking
-            (if the caller is trapping exits or <c><anno>PidOrPort</anno></c> is
-            remote).</p></item>
+	<p>
+	  The link setup and activation is performed asynchronously. If the
+	  link already exists, or if the caller attempts to create a link
+	  to itself, nothing is done. A detailed description of the
+	  <seeguide marker="erts:erl_dist_protocol#link_protocol">link
+	  protocol</seeguide> can be found in the <i>Distribution Protocol</i>
+	  chapter of the <i>ERTS User's Guide</i>.
+	</p>
 
-          <item><p><c>noconnection</c> if <c><anno>PidOrPort</anno></c> is
-            remote and a connection between the nodes could not be established
-            or was severed.</p></item>
-
-        </list>
-
-        <p>See <seeguide marker="system/reference_manual:processes#links">Processes
-          ➜ Links</seeguide> in the Erlang Reference Manual for more details.</p>
-
+	<p>Failure:</p>
+	<list>
+	  <item><c>badarg</c> if <c><anno>PidOrPort</anno></c> does not identify
+	  a process or a node local port.</item>
+	  <item><c>noproc</c> linkee does not exist and it is "cheap" to check
+	  if it exists as described above.</item>
+	</list>
       </desc>
     </func>
 
@@ -4955,7 +5001,8 @@ RealSystem = system + MissedSystem</code>
     </func>
 
     <func>
-      <name name="process_flag" arity="2" clause_i="1" since=""/>
+      <name name="process_flag" arity="2" clause_i="1"
+	    anchor="process_flag_trap_exit" since=""/>
       <fsummary>Set process flag trap_exit for the calling process.</fsummary>
       <desc>
         <p>When <c>trap_exit</c> is set to <c>true</c>, exit signals
@@ -11833,27 +11880,50 @@ timestamp() ->
       <name name="unlink" arity="1" since=""/>
       <fsummary>Remove a link to another process or port.</fsummary>
       <desc>
-        <p>Removes the link, if there is one, between the calling
-          process and the process or port referred to by
-          <c><anno>Id</anno></c>.</p>
-        <p>Returns <c>true</c> and does not fail, even if there is no
-          link to <c><anno>Id</anno></c>, or if <c><anno>Id</anno></c>
-          does not exist.</p>
-        <p>Once <c>unlink(<anno>Id</anno>)</c> has returned,
-          it is guaranteed that
-          the link between the caller and the entity referred to by
-          <c><anno>Id</anno></c> has no effect on the caller
-          in the future (unless
-          the link is setup again). If the caller is trapping exits, an
-          <c>{'EXIT', <anno>Id</anno>, _}</c> message from the link
-          can have been placed in the caller's message queue before
-          the call.</p>
-        <p>Notice that the <c>{'EXIT', <anno>Id</anno>, _}</c>
-          message can be the
-          result of the link, but can also be the result of <c>Id</c>
-          calling <c>exit/2</c>. Therefore, it <em>can</em> be
-          appropriate to clean up the message queue when trapping exits
-          after the call to <c>unlink(<anno>Id</anno>)</c>, as follows:</p>
+	<p>
+	  Removes a link between the calling process and another process
+	  or a port identified by <c><anno>Id</anno></c>. We will from
+	  here on call the identified process or port unlinkee.
+	</p>
+
+        <p>
+	  A link can be set up using the
+	  <seemfa marker="#link/1"><c>link/1</c></seemfa> BIF. For more
+	  information on links and exit signals due to links, see the
+	  <i>Processes</i> chapter in the <i>Erlang Reference Manual</i>:
+	</p>
+	<list>
+	  <item>
+            <seeguide marker="system/reference_manual:processes#links">Links</seeguide>
+	  </item>
+	  <item>
+	    <seeguide marker="system/reference_manual:processes#sending_exit_signals">Sending
+	    Exit Signals</seeguide>
+	  </item>
+	  <item>
+	    <seeguide marker="system/reference_manual:processes#receiving_exit_signals">Receiving
+	    Exit Signals</seeguide>
+	  </item>
+	</list>
+
+        <p>
+	  Once <c>unlink(<anno>Id</anno>)</c> has returned, it is
+	  guaranteed that the link between the caller and the unlinkee
+	  has no effect on the caller in the future (unless the link is
+	  setup again). Note that if the caller is
+	  <seeerl marker="erts:erlang#process_flag_trap_exit">trapping
+	  exits</seeerl>, an <c>{'EXIT', <anno>Id</anno>, ExitReason}</c>
+	  message due to the link may have been placed in the message
+	  queue of the caller before the <c>unlink(<anno>Id</anno>)</c>
+	  call completed. Also note that the <c>{'EXIT', <anno>Id</anno>,
+	  ExitReason}</c> message may be the result of the link, but
+	  may also be the result of the unlikee sending the caller an
+	  exit signal by calling the
+	  <seemfa marker="#exit/2"><c>exit/2</c></seemfa> BIF.
+	  Therefore, it may or may not be appropriate to clean up
+	  the message queue after a call to <c>unlink(<anno>Id</anno>)</c>
+	  as follows, when trapping exits:
+	</p>
         <code type="none">
 unlink(Id),
 receive
@@ -11862,16 +11932,19 @@ receive
 after 0 ->
         true
 end</code>
-        <note>
-          <p>Before Erlang/OTP R11B (ERTS 5.5) <c>unlink/1</c>
-            behaved completely asynchronously, that is, the link was active
-            until the "unlink signal" reached the linked entity. This
-            had an undesirable effect, as you could never know when
-            you were guaranteed <em>not</em> to be effected by the link.</p>
-          <p>The current behavior can be viewed as two combined operations:
-            asynchronously send an "unlink signal" to the linked entity
-            and ignore any future results of the link.</p>
-        </note>
+
+	<p>
+	  The link removal is performed asynchronously. If such a link
+	  does not exist, nothing is done. A detailed description of the
+	  <seeguide marker="erts:erl_dist_protocol#link_protocol">link
+	  protocol</seeguide> can be found in the <i>Distribution Protocol</i>
+	  chapter of the <i>ERTS User's Guide</i>.
+	</p>
+
+        <p>
+	  Failure: <c>badarg</c> if <c>Id</c> does not identify a process
+	  or a node local port.
+	</p>
       </desc>
     </func>
 

--- a/erts/emulator/internal_doc/NewLinking.tla
+++ b/erts/emulator/internal_doc/NewLinking.tla
@@ -1,0 +1,194 @@
+\*
+\* %CopyrightBegin%
+\*
+\* Copyright Ericsson AB 2021. All Rights Reserved.
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+\*
+\* %CopyrightEnd%
+\*
+
+(*
+    --- Model of the new link protocol introduced in Erlang/OTP 23.3 ---
+
+    The protocol is documented in the ERTS User's Guide ->
+    Distribution Protocol -> Protocol Between Connected Nodes ->
+    Link Protocol -> New Link Protocol
+
+    This model only models a link between two processes. This since a link
+    between one pair of processes is completely independent of links between
+    other pairs of processes. This model also assumes that the connection
+    between the processes does not fail. In the real world a connection can
+    of course fail. This is however taken care of by clearing the link
+    information on both ends when a connection fails, and tracking which
+    instantiation of a connection between the nodes signals arrive on and
+    ignoring signals from old instantiations of connections. That is,
+    connection loss is trivially taken care of since we just start over
+    again from scratch if the connection is lost.
+
+    The documentation of the protocol talks about "process local information
+    about links". This information is stored in the process state record below.
+    The 'other' field contains the identifier of the other process. The 'type'
+    field acts as "active flag". The link is active when 'type' equals
+    "linked" and not active when 'type' equals "unlinked". If the
+    'wait_unlink_ack' field contains a value larger than or equal to zero
+    it is the "unlink id" of an unlink request we have issued and are waiting
+    for to get acknowledged. If the 'wait_unlink_ack' field contains -1 we
+    are not waiting for an acknowledgment. When 'type' equals "unlinked" and
+    'wait_unlink_ack' equals -1, we would in the documented protocol have
+    removed the "process local information about the link". In this model we,
+    however, keep the state, but in this state instead of removing it.
+    Messages are tagged with a message number in order to model the signal
+    order of Erlang. The message number of the unlink signal is also used as
+    "unlink id".
+
+    The model has been checked with the following parameters:
+
+      Declared constants:
+        PROCS <- {"a", "b"}
+
+      Temporal formula:
+        FairSpec
+
+      Deadlock:
+        disabled
+
+      Invariants:
+        TypeOK
+        ValidState
+
+      State Constraint:
+        /\ \E proc \in PROCS : procState[proc].next_send =< 15
+        /\ Cardinality(msgs) =< 10
+
+    That is, we have checked all states where processes send up to 15 signals
+    with at most 10 outstanding signals.
+
+    Deadlock checking has been disabled since we intentionally stop when
+    we have no outstanding signals (in 'Next') in order to avoid checking
+    signal sequences equivalent to sequences we already have checked.
+
+*)
+------------------------------ MODULE NewLinking ------------------------------
+EXTENDS Integers, TLC, FiniteSets
+CONSTANTS PROCS \* PROCS should be a set of exactly two process names
+
+VARIABLES
+    procState, \* Set of process states; procState[proc] is state of proc
+    msgs \* Set of messages sent
+
+vars == <<procState, msgs>>
+
+\* Set of possible process states...
+procStateRec ==
+    [self : PROCS,
+     other: PROCS,
+     type : {"linked", "unlinked"},
+     wait_unlink_ack : Nat \cup {-1},
+     next_send : Nat,
+     next_recv : Nat]
+
+\* Set of possible messages...
+Messages ==
+  [type : {"link", "unlink", "unlink_ack"}, from : PROCS, to : PROCS, msg_no : Nat, ack : Nat \cup {-1}]
+
+TypeOK ==
+   /\ procState \in [PROCS -> procStateRec]
+   /\ msgs \subseteq Messages
+
+Init ==
+    /\ msgs = {}
+    /\ procState = [p \in PROCS |-> [self |-> p,
+                                     other |-> CHOOSE p2 \in PROCS : p2 /= p,
+                                     type |-> "unlinked",
+                                     next_send |-> 0,
+                                     next_recv |-> 0,
+                                     wait_unlink_ack |-> -1]]
+
+MkMsg(self, mtype, accnr) ==
+  [type |-> mtype,
+   from |-> procState[self].self,
+   to |-> procState[self].other,
+   msg_no |-> procState[self].next_send,
+   ack |-> accnr]
+
+Link(self) ==
+  /\ procState[self].type = "unlinked"
+  /\ msgs' = msgs \cup {MkMsg(self, "link", -1)}
+  /\ procState' = [procState EXCEPT ![self].type = "linked",
+                                    ![self].next_send = @ + 1,
+                                    ![self].wait_unlink_ack = -1]
+
+Unlink(self) ==
+  /\ procState[self].type = "linked"
+  /\ msgs' = msgs \cup {MkMsg(self, "unlink", -1)}
+  /\ procState' = [procState EXCEPT ![self].type = "unlinked",
+                                    ![self].next_send = @ + 1,
+                                    ![self].wait_unlink_ack = procState[self].next_send]
+
+RecvLink(self, msg) ==
+   LET type == IF procState[self].wait_unlink_ack /= -1
+               THEN "unlinked"
+               ELSE "linked"
+   IN /\ msgs' = msgs \ {msg}
+      /\ procState' = [procState EXCEPT ![self].type = type,
+                                        ![self].next_recv = @ + 1]
+
+RecvUnlink(self, msg) ==
+  /\ msgs' = (msgs \ {msg}) \cup {MkMsg(self,
+                                        "unlink_ack",
+                                        procState[self].next_recv)}
+  /\ procState' = [procState EXCEPT ![self].type = "unlinked",
+                                    ![self].next_recv = @ + 1,
+                                    ![self].next_send = @ + 1]
+
+RecvUnlinkAck(self, msg) ==
+   LET wack == IF procState[self].wait_unlink_ack = msg.ack
+               THEN -1
+               ELSE procState[self].wait_unlink_ack
+   IN /\ msgs' = msgs \ {msg}
+      /\ procState' = [procState EXCEPT ![self].next_recv = @ + 1,
+                                        ![self].wait_unlink_ack = wack]
+
+Recv(self) ==
+  /\ \E m \in msgs : /\ m.to = self
+                     /\ m.msg_no = procState[self].next_recv
+  /\ LET msg == CHOOSE m \in msgs : /\ m.to = self
+                                    /\ m.msg_no = procState[self].next_recv
+     IN CASE msg.type = "link" -> RecvLink(self, msg)
+          [] msg.type = "unlink" -> RecvUnlink(self, msg)
+          [] msg.type = "unlink_ack" -> RecvUnlinkAck(self, msg)
+
+(*
+   If we have no outstanding messages; both processes should
+   have the same view about whether they are linked or not...
+*)
+ValidState ==
+  IF msgs /= {}
+  THEN TRUE
+  ELSE \A p \in PROCS : \A p2 \in PROCS : procState[p].type = procState[p2].type
+
+Next ==
+    /\ (msgs /= {} \/ \A p \in PROCS : procState[p].next_send = 0)
+    /\ \E p \in PROCS : \/ Recv(p)
+                        \/ Link(p)
+                        \/ Unlink(p)
+                     
+Spec == Init /\ [][Next]_vars
+
+FairSpec == Spec /\ WF_vars(Next)
+
+=============================================================================
+\* Modification History
+\* Last modified Mon Jan 25 11:26:06 CET 2021 by rickard.green
+\* Created Wed Jan 20 13:11:46 CET 2021 by rickard.green

--- a/system/doc/reference_manual/processes.xml
+++ b/system/doc/reference_manual/processes.xml
@@ -124,7 +124,7 @@ spawn(Module, Name, Args) -> pid()
     <title>Links</title>
     <p>
       Two processes can be <em>linked</em> to each other. Also a
-      process and a port that resides on the same node can be linked
+      process and a port that reside on the same node can be linked
       to each other. A link beteen two processes can be created
       if one of them calls the
       <seemfa marker="erts:erlang#link/1"><c>link/1</c></seemfa> BIF
@@ -133,8 +133,8 @@ spawn(Module, Name, Args) -> pid()
       <seemfa marker="erts:erlang#spawn_link/4"><c>spawn_link()</c></seemfa>,
       <seemfa marker="erts:erlang#spawn_opt/5"><c>spawn_opt()</c></seemfa>, or
       <seemfa marker="erts:erlang#spawn_request/5"><c>spawn_request()</c></seemfa>.
-      The spawn operation and the link operation will in these cases
-      be performed atomically.
+      The spawn operation and the link operation will 
+      be performed atomically, in these cases.
     </p>
     <p>
       If one of the participants of a link terminates, it will
@@ -404,4 +404,3 @@ erase(Key)
 erase()</pre>
   </section>
 </chapter>
-

--- a/system/doc/reference_manual/processes.xml
+++ b/system/doc/reference_manual/processes.xml
@@ -122,14 +122,39 @@ spawn(Module, Name, Args) -> pid()
 
   <section>
     <title>Links</title>
-    <p>Two processes can be <em>linked</em> to each other. A link
-      between two processes <c>Pid1</c> and <c>Pid2</c> is created
-      by <c>Pid1</c> calling the BIF <c>link(Pid2)</c> (or conversely).
-      There also exist a number of <c>spawn_link</c> BIFs, which spawn
-      and link to a process in one operation.</p>
-    <p>Links are bidirectional and there can only be one link between
-      two processes. Repeated calls to <c>link(Pid)</c> have no effect.</p>
-    <p>A link can be removed by calling the BIF <c>unlink(Pid)</c>.</p>
+    <p>
+      Two processes can be <em>linked</em> to each other. Also a
+      process and a port that resides on the same node can be linked
+      to each other. A link beteen two processes can be created
+      if one of them calls the
+      <seemfa marker="erts:erlang#link/1"><c>link/1</c></seemfa> BIF
+      with the process identifier of the other process as argument.
+      Links can also be created using one the following spawn BIFs
+      <seemfa marker="erts:erlang#spawn_link/4"><c>spawn_link()</c></seemfa>,
+      <seemfa marker="erts:erlang#spawn_opt/5"><c>spawn_opt()</c></seemfa>, or
+      <seemfa marker="erts:erlang#spawn_request/5"><c>spawn_request()</c></seemfa>.
+      The spawn operation and the link operation will in these cases
+      be performed atomically.
+    </p>
+    <p>
+      If one of the participants of a link terminates, it will
+      <seeguide marker="system/reference_manual:processes#sending_exit_signals">send
+      an exit signal</seeguide> to the other participant. The exit
+      signal will contain the
+      <seeguide marker="system/reference_manual:processes#link_exit_signal_reason">exit
+      reason</seeguide> of the terminated participant.
+    </p>
+    <p>
+      A link can be removed by calling the
+      <seemfa marker="erts:erlang#unlink/1"><c>unlink/1</c></seemfa>
+      BIF.
+    </p>
+    <p>
+      Links are bidirectional and there can only be one link between
+      two processes. Repeated calls to <c>link()</c> have no effect.
+      Either one of the involved processes may create or remove a
+      link.
+    </p>
     <p>Links are used to monitor the behaviour of other processes, see
       <seeguide marker="#errors">Error Handling</seeguide>.</p>
   </section>
@@ -149,35 +174,198 @@ spawn(Module, Name, Args) -> pid()
       OTP supervision trees, which use this feature.</p>
 
     <section>
-      <title>Emitting Exit Signals</title>
-      <p>When a process terminates, it terminates with an
-        <em>exit reason</em> as explained in <seeguide marker="#term">
-        Process Termination</seeguide>. This exit reason is emitted in
-        an <em>exit signal</em> to all linked processes.</p>
-      <p>A process can also call the function <c>exit(Pid,Reason)</c>.
-        This results in an exit signal with exit reason
-        <c>Reason</c> being emitted to <c>Pid</c>, but does not affect
-        the calling process.</p>
+      <marker id="sending_exit_signals"/>
+      <title>Sending Exit Signals</title>
+      <p>
+	When a process or port
+	<seeguide marker="#term">terminates</seeguide> it will
+	send exit signals to all processes and ports that it
+	is <seeguide marker="#links">linked</seeguide> to.
+	The exit signal will contain the following information:
+      </p>
+      <taglist>
+	<tag>Sender identifier</tag>
+	<item><p>
+	  The process or port identifier of the process or port
+	  that terminated.
+	</p></item>
+	<tag>Receiver identifier</tag>
+	<item><p>
+	  The process or port identifier of the process or port
+	  which the exit signal is sent to.
+	</p></item>
+	<tag>The <c>link</c> flag</tag>
+	<item><p>
+	  This flag will be set indicating that the exit signal
+	  was sent due to a link.
+	</p></item>
+	<tag><marker id="link_exit_signal_reason"/>Exit reason</tag>
+	<item><p>
+	  The exit reason of the process or port that
+	  terminated or the atom:</p>
+	  <list>
+	    <item><p>
+	      <c>noproc</c> in case no process or port was
+	      found when setting up a link in a preceeding
+	      call to the
+	      <seemfa marker="erts:erlang#link/1"><c>link(PidOrPort)</c></seemfa>
+	      BIF. The process or port identified as sender
+	      of the exit signal will equal the <c>PidOrPort</c>
+	      argument passed to <c>link/1</c>.
+	    </p></item>
+	    <item><p>
+	      <c>noconnection</c> in case the linked
+	      processes resides on different nodes and
+	      the connection between the nodes was lost or
+	      could not be established. The process or port
+	      identified as sender of the exit signal might
+	      in this case still be alive.
+	    </p></item>
+	  </list>
+	</item>
+      </taglist>
+      
+      <p>
+	Exit signals can also be sent explicitly by calling the
+	<seemfa marker="erts:erlang#exit/2"><c>exit(PidOrPort,
+	Reason)</c></seemfa> BIF. The exit signal is sent to the
+	process or port identified by the <c>PidOrPort</c> argument.
+	The exit signal sent will contain the following information:
+      </p>
+      <taglist>
+	<tag>Sender identifier</tag>
+	<item><p>
+	  The process identifier of the process that called
+	  <c>exit/2</c>.
+	</p></item>
+	<tag>Receiver identifier</tag>
+	<item><p>
+	  The process or port identifier of the process or port
+	  which the exit signal is sent to.
+	</p></item>
+	<tag>The <c>link</c> flag</tag>
+	<item><p>
+	  This flag will not be set, indicating that this exit
+	  signal was not sent due to a link.
+	</p></item>
+	<tag>Exit reason</tag>
+	<item><p>
+	  The term passed as <c>Reason</c> in the call to
+	  <c>exit/2</c>. If <c>Reason</c> is the atom <c>kill</c>,
+	  the receiver cannot
+	  <seeerl marker="erts:erlang#process_flag_trap_exit">trap
+	  the exit</seeerl> signal and will unconditionally
+	  terminate when it receives the signal.
+	</p></item>
+      </taglist>
     </section>
 
     <section>
+      <marker id="receiving_exit_signals"/>
       <title>Receiving Exit Signals</title>
-      <p>The default behaviour when a process receives an exit signal
-        with an exit reason other than <c>normal</c>, is to terminate
-        and in turn emit exit signals with the same exit reason to its
-        linked processes. An exit signal with reason <c>normal</c> is
-        ignored.</p>
-      <p>A process can be set to trap exit signals by calling:</p>
-      <pre>
-process_flag(trap_exit, true)</pre>
-      <p>When a process is trapping exits, it does not terminate when
-        an exit signal is received. Instead, the signal is transformed
-        into a message <c>{'EXIT',FromPid,Reason}</c>, which is put into
-        the mailbox of the process, just like a regular message.</p>
-      <p>An exception to the above is if the exit reason is <c>kill</c>,
-        that is if <c>exit(Pid,kill)</c> has been called. This
-        unconditionally terminates the process, regardless of if it is
-        trapping exit signals.</p>
+
+      <p>What happens when a process receives an exit signal depends on:</p>
+      <list>
+	<item><p>
+	  The <seeerl marker="erts:erlang#process_flag_trap_exit">trap exit</seeerl>
+	  state of the receiver at the time when the exit signal is received.
+	</p></item>
+	<item><p>
+	  The exit reason of the exit signal.
+	</p></item>
+	<item><p>
+	  The sender of the exit signal.
+	</p></item>
+	<item><p>
+	  The state of the <c>link</c> flag of the exit signal. If the
+	  <c>link</c> flag is set, the exit signal was sent due to a
+	  link; otherwise, the exit signal was sent by a call to the
+	  <seemfa marker="erts:erlang#exit/2"><c>exit/2</c></seemfa> BIF.
+	</p></item>
+	<item><p>
+	  If the <c>link</c> flag is set, what happens also depends on
+	  whether the <seemfa marker="erts:erlang#unlink/1">link is still active
+	  or not</seemfa> when the exit signal is received.
+	</p></item>
+      </list>
+
+      <p>
+	Based on the above states, the following will happen when an
+	exit signal is received by a process:
+      </p>
+      <list>
+	<item>
+	  <p>The exit signal is silently dropped if:</p>
+	  <list>
+	    <item><p>
+	      the <c>link</c> flag of the exit signal is set and
+	      the corresponding link has been deactivated.
+	    </p></item>
+	    <item><p>
+	      the exit reason of the exit signal is the atom <c>normal</c>,
+	      the receiver is not trapping exits, and the receiver and
+	      sender are not the same process.
+	    </p></item>
+	  </list>
+	</item>
+	<item>
+	  <p>The receiving process is terminated if:</p>
+	  <list>
+	    <item><p>
+	      the <c>link</c> flag of the exit signal
+	      is not set, and the exit reason of the exit signal
+	      is the atom <c>kill</c>. The receiving process will
+	      terminate with the atom <c>killed</c> as exit reason.
+	    </p></item>
+	    <item><p>
+	      the receiver is not trapping exits, and the exit
+	      reason is something other than the atom <c>normal</c>.
+	      Also, if the <c>link</c> flag of the exit signal
+	      is set, the link also needs to be active otherwise the
+	      exit signal will be dropped. The exit reason of the
+	      receiving process will equal the exit reason of the
+	      exit signal. Note that if the <c>link</c> flag
+	      is set, an exit reason of <c>kill</c> will <em>not</em>
+	      be converted to <c>killed</c>.
+	    </p></item>
+	    <item><p>
+	      the exit reason of the exit signal is the atom
+	      <c>normal</c> and the sender of the exit signal is
+	      the same process as the receiver. The <c>link</c>
+	      flag cannot be set in this case. The exit reason
+	      of the receiving process will be the atom <c>normal</c>.
+	    </p></item>
+	  </list>
+	</item>
+	<item>
+	  <p>
+	    The exit signal is converted to a message signal and
+	    moved into the message queue of the receiver, if the
+	    receiver is trapping exits, the <c>link</c> flag
+	    of the exit signal is:
+	  </p>
+	    <list>
+	      <item><p>
+		not set, and the exit reason of the signal is not
+		the atom <c>kill</c>.
+	      </p></item>
+	      <item><p>
+		set, and the corresponding link is active.
+		Note that an exit reason of <c>kill</c> will
+		<em>not</em> terminate the process in this
+		case and it will not be converted to
+		<c>killed</c>.
+	      </p></item>
+	    </list>
+	    <p>
+	      The converted message will be on the form
+	      <c>{'EXIT', SenderID, Reason}</c> where <c>Reason</c>
+	      equals the exit reason of the exit signal and
+	      <c>SenderID</c> is the identifier of the process
+	      or port that sent the exit signal.
+	    </p>
+	</item>
+      </list>
     </section>
   </section>
 


### PR DESCRIPTION
Introduce a new link protocol which prevents links from ending up in an inconsistent state where one participant considers itself linked while the other doesn't. This bug has always existed in the distributed case, but has since OTP 21 also existed in the node local case since the distributed link protocol then was adopted also for node local links.

Besides the introduction of the new link protocol, the documentation regarding links and exit signals has also been improved.

* The [new link protocol](https://erlang.org/~rickard/OTP-17127/erts-11.1.8/doc/html/erl_dist_protocol.html#new_link_protocol)
* The [`link/1`](https://erlang.org/~rickard/OTP-17127/erts-11.1.8/doc/html/erlang.html#link-1) BIF
* The [`unlink/1`](https://erlang.org/~rickard/OTP-17127/erts-11.1.8/doc/html/erlang.html#unlink-1) BIF
* [Links](https://erlang.org/~rickard/OTP-17127/doc/reference_manual/processes.html#links)
* [Sending exit signals](https://erlang.org/~rickard/OTP-17127/doc/reference_manual/processes.html#sending_exit_signals)
* [Receiving exit signals](https://erlang.org/~rickard/OTP-17127/doc/reference_manual/processes.html#receiving_exit_signals)

---
Code merged into `maint` branch 10/3-2021