### PR TITLE
Remove undocumented and partially broken ets:filter/3

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -824,13 +824,11 @@ handle_call({stop_application, AppName}, _From, S) ->
     end;
 
 handle_call({change_application_data, Applications, Config}, _From, S) ->
-    OldAppls = ets:filter(ac_tab,
-			  fun([{{loaded, _AppName}, Appl}]) ->
-				  {true, Appl};
-			     (_) ->
-				  false
-			  end,
-			  []),
+    OldAppls = ets:foldl(fun({{loaded, _AppName}, Appl}, Acc) ->
+                                 [Appl|Acc];
+                            (_, Acc) ->
+                                 Acc
+                         end, [], ac_tab),
     case catch do_change_apps(Applications, Config, OldAppls) of
 	{error, _} = Error ->
 	    {reply, Error, S};

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -24,7 +24,6 @@
 
 -export([file2tab/1,
 	 file2tab/2,
-	 filter/3,
 	 foldl/3, foldr/3,
 	 match_delete/2,
 	 tab2file/2,
@@ -764,25 +763,7 @@ match_delete(Table, Pattern) ->
 tab2list(T) ->
     ets:match_object(T, '_').
 
--spec filter(tab(), function(), [term()]) -> [term()].
 
-filter(Tn, F, A) when is_atom(Tn) ; is_integer(Tn) ->
-    do_filter(Tn, ets:first(Tn), F, A, []).
-
-do_filter(_Tab, '$end_of_table', _, _, Ack) -> 
-    Ack;
-do_filter(Tab, Key, F, A, Ack) ->
-    case apply(F, [ets:lookup(Tab, Key)|A]) of
-	false ->
-	    do_filter(Tab, ets:next(Tab, Key), F, A, Ack);
-	true ->
-            Ack2 = ets:lookup(Tab, Key) ++ Ack,
-	    do_filter(Tab, ets:next(Tab, Key), F, A, Ack2);
-	{true, Value} ->
-	    do_filter(Tab, ets:next(Tab, Key), F, A, [Value|Ack])
-    end.
-
-    
 %% Dump a table to a file using the disk_log facility
 
 %% Options := [Option]


### PR DESCRIPTION
The `ets:filter/3` function is undocumented, untested, and broken in the
following ways:

* It only works for named tables.

* It does not fix the table before traversing it.

* It returns a list, not a filtered ETS table. Other `filter`
  functions usually return a term of the same type as its input
  argument.

Replace its only use in OTP with a call to `ets:foldl/3`.