### PR TITLE
mnesia: Handle starting and stopping in connect_nodes

### DIFF
--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -460,8 +460,6 @@ connect_nodes(Ns) ->
 
 connect_nodes(Ns, UserFun) ->
     case mnesia:system_info(is_running) of
-	no ->
-	    {error, {node_not_running, node()}};
 	yes ->
 	    Pid = spawn_link(?MODULE,connect_nodes2,[self(),Ns, UserFun]),
 	    receive
@@ -478,7 +476,9 @@ connect_nodes(Ns, UserFun) ->
 		    end;
 		{'EXIT', Pid, Reason} ->
 		    {error, Reason}
-	    end
+	    end;
+        _ -> %% no, starting or stopping not ready to make a connection yet
+	    {error, {node_not_running, node()}}
     end.
 
 connect_nodes2(Father, Ns, UserFun) ->


### PR DESCRIPTION
system_info(is_running) can also return starting and stopping,
error out if that is the case since mnesia is not yet in a state
to connect to new nodes

Fixes #4616