### PR TITLE
Remove race conditions on inet_db access

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -1706,12 +1706,12 @@ match_rr(CacheDb, [RR | RRs], Time, ResultRRs, InsertRRs, DeleteRRs) ->
             Key = match_rr_key(RR),
             match_rr(
               CacheDb, RRs, Time,
-              ResultRRs#{Key => RR}, InsertRRs, [RRs | DeleteRRs]);
+              ResultRRs#{Key => RR}, InsertRRs, [RR | DeleteRRs]);
         TM + TTL < Time ->
             %% Expired, delete
             match_rr(
               CacheDb, RRs, Time,
-              ResultRRs, InsertRRs, [RRs | DeleteRRs]);
+              ResultRRs, InsertRRs, [RR | DeleteRRs]);
         Time =< Cnt ->
             %% Valid and just updated, return and do not update
             Key = match_rr_key(RR),


### PR DESCRIPTION
Prior to this patch, a client could delete
data which would cause the server to crash.
We now change it so we ask the server to delete
the data in case of TTL=0 and avoid deleting it
altogether in other cases (we wait until the
server eventually purges it when necessary).

We also change the table structure to store
the last access separate from the dns_rr record,
allowing us to update only the latest time without
overriding any potential updated dns_rr entry.

Closes #4631.

/cc @RaimoNiskanen 