### PR TITLE
Ssl: implement custom hello extensions

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1350,6 +1350,53 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       </datatype>
 
       <datatype>
+	<name name="custom_extensions"/>
+      <desc>
+        <p>Announce custom hello extensions to be encoded/decoded with given module</p>
+        <p>For example, user can implement an extension with this callback module:</p>
+	<code>
+-module(example_ext).
+-export(encode_extension/3, decode_extension/4]).
+
+-spec encode_extension(Type::integer(), CbOpts::any(), Context::map()) ->
+    binary() | {last, binary()} | undefined.
+encode_extension(16#4201, #{custom_01 := V}, _) ->
+    &lt;&lt;V:16&gt;&gt;;
+encode_extension(16#4202, #{custom_02 := V}, #{version := {3,3}) ->
+    {last, &lt;&lt;"test", V:16&gt;&gt;};
+encode_extension(16#4202, _, _} ->
+    undefined.
+
+-spec decode_extension(Type::integer(), ExtData::binary(), Context::map()) ->
+    {Key::atom(), any()} | undefined.
+decode_extension(16#4201, &lt;&lt;V:16&gt;&gt;, _) ->
+    {custom_01, #{custom_01 => V}};
+decode_extension(16#4202, &lt;&lt;_:4/binary, V:16&gt;&gt;, #{version := {3,3}) ->
+    {test, V};
+decode_extension(16#4202, _, _) ->
+    undefined.
+	</code>
+
+	<p>
+	  When hello extensions are encoded, for each given ExtType
+		the <c>CallbackMod:encode_extension/3</c> is called.
+		Third argument, <c>Context</c>, contains <c>version</c>,
+		<c>cipher_suites</c>, <c>ssl_opts</c>, <c>connection_states</c>.
+		Valid return values are <c>ExtData::binary()</c>,
+		<c>{last, ExtData}</c> (when extension must be the last one)
+		and <c>undefined</c> (do not encode this extension).
+	</p>
+	<p>
+	  When hello extensions are decoded, given extension types
+		are decoded only with <c>CallbackMod:decode_extension/3</c>.
+		Valid return values are <c>{Key, Value}</c>
+		(so that extensions contain <c>#{Key => Value})</c>
+    and <c>undefined</c> (to skip this extension).
+	</p>
+	</desc>
+      </datatype>
+
+      <datatype>
         <name name="server_early_data"/>
 	<desc>
           <p>Configures if the server accepts (<c>enabled</c>) or rejects (<c>rejects</c>) early

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -310,6 +310,7 @@
                                 {keep_secrets, keep_secrets()} |
                                 {depth, allowed_cert_chain_length()} |
                                 {verify_fun, custom_verify()} |
+                                {custom_extensions, custom_extensions()} |
                                 {crl_check, crl_check()} |
                                 {crl_cache, crl_cache_opts()} |
                                 {max_handshake_size, handshake_size()} |
@@ -365,6 +366,7 @@
 -type beast_mitigation()         :: one_n_minus_one | zero_n | disabled.
 -type srp_identity()             :: {Username :: string(), Password :: string()}.
 -type psk_identity()             :: string().
+-type custom_extensions()        :: {[ExtType :: integer()], CallbackMod :: atom(), CbOpts :: any()}.
 -type log_alert()                :: boolean().
 -type logging_level()            :: logger:level() | none | all.
 -type client_session_tickets()   :: disabled | manual | auto.
@@ -2367,6 +2369,12 @@ validate_option(srp_identity, {Username, Password}, _)
        length(Username) =< 255 ->
     {unicode:characters_to_binary(Username),
      unicode:characters_to_binary(Password)};
+validate_option(custom_extensions, undefined, _) ->
+    undefined;
+validate_option(custom_extensions, {ExtTypes, CbMod, _CbOpts} = Value, _) when is_list(ExtTypes), is_atom(CbMod) ->
+    BadExtTypes = [Type || Type <- ExtTypes, not is_integer(Type) orelse Type < 0 orelse Type >= 16#10000],
+    (BadExtTypes == []) orelse throw({error, {options, {custom_extensions, {BadExtTypes, '_', '_'}}}}),
+    Value;
 validate_option(user_lookup_fun, undefined, _) ->
     undefined;
 validate_option(user_lookup_fun, {Fun, _} = Value, _)

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -656,9 +656,11 @@ connection(Type, Msg, State) ->
 %%====================================================================
 %%  Event/Msg handling
 %%====================================================================
-handle_common_event(internal, {handshake, {Handshake, Raw}}, StateName,
-		    #state{handshake_env = #handshake_env{tls_handshake_history = Hist0} = HsEnv,
+handle_common_event(internal, {handshake, {Handshake0, Raw}}, StateName,
+                    #state{ssl_options = SslOpts,
+                           handshake_env = #handshake_env{tls_handshake_history = Hist0} = HsEnv,
                            connection_env = #connection_env{negotiated_version = _Version}} = State0) ->
+    Handshake = ssl_handshake:maybe_decode_custom_extensions(Handshake0, SslOpts),
     Hist = ssl_handshake:update_handshake_history(Hist0, Raw),
     {next_state, StateName,
      State0#state{handshake_env =

--- a/lib/ssl/src/ssl_handshake.hrl
+++ b/lib/ssl/src/ssl_handshake.hrl
@@ -197,6 +197,24 @@
 -define(SIGNATURE_RSA, 1).
 -define(SIGNATURE_DSA, 2).
 
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% User-specified extension overrides
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-record(custom_extension, {
+    type,             %% extension_type, such as ?SUPPORTED_VERSIONS_EXT
+    module,
+    options,
+    context
+   }).
+
+-record(raw_extensions, {
+    context,
+    empty,            %% empty extensions as passed to decode_extensions/4
+    split             %% list of {ExtType, ExtData}
+   }).
+
+
 -record(hello_request, {}).
 -record(server_hello_done, {}).
 

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -189,6 +189,7 @@
                                                      sni_hosts]},
           sni_hosts                  => {[],        [versions]},
           srp_identity               => {undefined, [versions]},
+          custom_extensions          => {undefined, [versions]},
           supported_groups           => {undefined, [versions]},
           use_ticket                 => {undefined, [versions]},
           user_lookup_fun            => {undefined, [versions]},


### PR DESCRIPTION
_Work in progress: no tests yet_

This PR implements custom hello extensions -- a way the user
can add extensions encoders and decoders without having to modify
ssl code.

Usage:
For example, this module implements two extensions with types `16#4201` and `16#4202`:
```
-module(example_ext).
-export(encode_extension/3, decode_extension/4]).

-spec encode_extension(Type::integer(), CbOpts::any(), Context::map()) ->
    binary() | {last, binary()} | undefined.
encode_extension(16#4201, #{custom_01 := V}, _) ->
    &lt;&lt;V:16&gt;&gt;;
encode_extension(16#4202, #{custom_02 := V}, #{version := {3,3}) ->
    {last, &lt;&lt;"test", V:16&gt;&gt;};
encode_extension(16#4202, _, _} ->
    undefined.

-spec decode_extension(Type::integer(), ExtData::binary(), Context::map()) ->
    {Key::atom(), any()} | undefined.
decode_extension(16#4201, &lt;&lt;V:16&gt;&gt;, _) ->
    {custom_01, #{custom_01 => V}};
decode_extension(16#4202, &lt;&lt;_:4/binary, V:16&gt;&gt;, #{version := {3,3}) ->
    {test, V};
decode_extension(16#4202, _, _) ->
    undefined.
```
User may send and receive extensions in server/client hello:
```
CustomExts = {[16#4201, 16#4202], example_ext, #{custom_01 => 78, custom_02 => 9873}},
{ok, S, Ext} = ssl:connect("localhost", 12345, [{custom_extensions, CustomExts}, {handshake, hello}]),
#{test := T} = Ext
```

This may be also useful for testing (e.g. add or remove some extensions to see how the other side reacts to this).