### PR TITLE
Ingela/ssl/gh 4585

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -580,9 +580,7 @@ connect(Socket, SslOptions0, Timeout) when is_list(SslOptions0) andalso
     
     CbInfo = handle_option_cb_info(SslOptions0, tls),
     Transport = element(1, CbInfo),
-    EmulatedOptions = tls_socket:emulated_options(),
-    {ok, SocketValues} = tls_socket:getopts(Transport, Socket, EmulatedOptions),
-    try handle_options(SslOptions0 ++ SocketValues, client) of
+    try handle_options(Transport, Socket, SslOptions0, client, undefined) of
         {ok, Config} ->
             tls_socket:upgrade(Socket, Config, Timeout)
     catch
@@ -784,10 +782,8 @@ handshake(#sslsocket{pid = [Pid|_], fd = {_, _, _}} = Socket, SslOpts, Timeout) 
 handshake(Socket, SslOptions, Timeout) when (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
     CbInfo = handle_option_cb_info(SslOptions, tls),
     Transport = element(1, CbInfo),
-    EmulatedOptions = tls_socket:emulated_options(),
-    {ok, SocketValues} = tls_socket:getopts(Transport, Socket, EmulatedOptions),
     ConnetionCb = connection_cb(SslOptions),
-    try handle_options(SslOptions ++ SocketValues, server) of
+    try handle_options(Transport, Socket, SslOptions, server, undefined) of
         {ok, #config{transport_info = CbInfo, ssl = SslOpts, emulated = EmOpts}} ->
             ok = tls_socket:setopts(Transport, Socket, tls_socket:internal_inet_values()),
             {ok, Port} = tls_socket:port(Transport, Socket),
@@ -1577,24 +1573,24 @@ do_listen(Port, #config{transport_info = {Transport, _, _, _,_}} = Config, tls_g
 do_listen(Port,  Config, dtls_gen_connection) ->
     dtls_socket:listen(Port, Config).
 	
-
-
 -spec handle_options([any()], client | server) -> {ok, #config{}};
                     ([any()], ssl_options()) -> ssl_options().
 
 handle_options(Opts, Role) ->
-    handle_options(Opts, Role, undefined).   
+    handle_options(undefined, undefined, Opts, Role, undefined).   
 
+handle_options(Opts, Role, InheritedSslOpts) ->
+    handle_options(undefined, undefined, Opts, Role, InheritedSslOpts).   
 
 %% Handle ssl options at handshake, handshake_continue
-handle_options(Opts0, Role, InheritedSslOpts) when is_map(InheritedSslOpts) ->
+handle_options(_, _, Opts0, Role, InheritedSslOpts) when is_map(InheritedSslOpts) ->
     {SslOpts, _} = expand_options(Opts0, ?RULES),
     process_options(SslOpts, InheritedSslOpts, #{role => Role,
                                                  rules => ?RULES});
 %% Handle all options in listen, connect and handshake
-handle_options(Opts0, Role, Host) ->
-    {SslOpts0, SockOpts} = expand_options(Opts0, ?RULES),
-
+handle_options(Transport, Socket, Opts0, Role, Host) ->
+    {SslOpts0, SockOpts0} = expand_options(Opts0, ?RULES),
+    
     %% Ensure all options are evaluated at startup
     SslOpts1 = add_missing_options(SslOpts0, ?RULES),
     SslOpts = #{protocol := Protocol}
@@ -1605,7 +1601,7 @@ handle_options(Opts0, Role, Host) ->
                             rules => ?RULES}),
     
     %% Handle special options
-    {Sock, Emulated} = emulated_options(Protocol, SockOpts),
+    {Sock, Emulated} = emulated_options(Transport, Socket, Protocol, SockOpts0),
     ConnetionCb = connection_cb(Protocol),
     CbInfo = handle_option_cb_info(Opts0, Protocol),
 
@@ -2033,8 +2029,9 @@ expand_options(Opts0, Rules) ->
                                 cb_info,
                                 client_preferred_next_protocols,  %% next_protocol_selector
                                 log_alert]),                      %% obsoleted by log_level
-
-    SslOpts = {Opts -- SockOpts, [], length(Opts -- SockOpts)},
+    
+    SslOpts0 = Opts -- SockOpts,
+    SslOpts = {SslOpts0, [], length(SslOpts0)},
     {SslOpts, SockOpts}.
 
 
@@ -2619,13 +2616,18 @@ ca_cert_default(verify_peer, {Fun,_}, _) when is_function(Fun) ->
 %% some trusted certs.
 ca_cert_default(verify_peer, undefined, _) ->
     "".
-emulated_options(Protocol, Opts) ->
+emulated_options(undefined, undefined, Protocol, Opts) ->
     case Protocol of
 	tls ->
 	    tls_socket:emulated_options(Opts);
 	dtls ->
 	    dtls_socket:emulated_options(Opts)
-    end.
+    end;
+emulated_options(Transport, Socket, Protocol, Opts) ->
+    EmulatedOptions = tls_socket:emulated_options(),
+    {ok, Original} = tls_socket:getopts(Transport, Socket, EmulatedOptions),
+    {Inet, Emulated0} = emulated_options(undefined, undefined, Protocol, Opts),
+    {Inet, lists:ukeymerge(1, Emulated0, Original)}.
 
 handle_cipher_option(Value, Versions)  when is_list(Value) ->       
     try binary_cipher_suites(Versions, Value) of

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2798,7 +2798,7 @@ binary_filename(FileName) ->
 %% Assert that basic options are on the format {Key, Value}
 %% with a few exceptions and phase out log_alert 
 handle_option_format([], Acc) ->
-    Acc;
+    lists:reverse(Acc);
 handle_option_format([{log_alert, Bool} | Rest], Acc) when is_boolean(Bool) ->
     case proplists:get_value(log_level, Acc ++ Rest, undefined) of
         undefined -> 

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -39,6 +39,8 @@
 %% Test cases
 -export([tls_upgrade/0,
          tls_upgrade/1,
+         tls_upgrade_new_opts/0,
+         tls_upgrade_new_opts/1,         
          tls_upgrade_with_timeout/0,
          tls_upgrade_with_timeout/1,
          tls_downgrade/0,
@@ -83,6 +85,7 @@
 
 %% Apply export
 -export([upgrade_result/1,
+         upgrade_result_new_opts/1,
          tls_downgrade_result/2,
          tls_shutdown_result/2,
          tls_shutdown_write_result/2,
@@ -117,6 +120,7 @@ groups() ->
 api_tests() ->
     [
      tls_upgrade,
+     tls_upgrade_new_opts,
      tls_upgrade_with_timeout,
      tls_downgrade,
      tls_shutdown,
@@ -199,6 +203,44 @@ tls_upgrade(Config) when is_list(Config) ->
     
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
+
+%%--------------------------------------------------------------------
+tls_upgrade_new_opts() ->
+    [{doc,"Test that you can upgrade an tcp connection to an ssl connection and give new socket opts"}].
+
+tls_upgrade_new_opts(Config) when is_list(Config) ->
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    TcpOpts = [binary, {reuseaddr, true}],
+
+    Server = ssl_test_lib:start_upgrade_server([{node, ServerNode}, {port, 0}, 
+						{from, self()}, 
+						{mfa, {?MODULE, 
+						       upgrade_result_new_opts, []}},
+						{tcp_options, 
+						 [{active, false} | TcpOpts]},
+						{ssl_options, [{verify, verify_peer},
+                                                               {mode, list} | ServerOpts]}]),
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_upgrade_client([{node, ClientNode}, 
+						{port, Port}, 
+				   {host, Hostname},
+				   {from, self()}, 
+				   {mfa, {?MODULE, upgrade_result_new_opts, []}},
+				   {tcp_options, [binary]},
+				   {ssl_options,  [{verify, verify_peer},
+                                                   {mode, list},
+                                                   {server_name_indication, Hostname} | ClientOpts]}]),
+    
+    ct:log("Testcase ~p, Client ~p  Server ~p ~n",
+		       [self(), Client, Server]),
+    
+    ssl_test_lib:check_result(Server, ok, Client, ok),
+    
+    ssl_test_lib:close(Server),
+    ssl_test_lib:close(Client).
+
 %%--------------------------------------------------------------------
 tls_upgrade_with_timeout() ->
     [{doc,"Test ssl_accept/3"}].
@@ -815,6 +857,14 @@ upgrade_result(Socket) ->
     %% Make sure binary is inherited from tcp socket and that we do
     %% not get the list default!
     <<"Hello world">> =  ssl_test_lib:active_recv(Socket, length("Hello world")),
+    ok.
+
+upgrade_result_new_opts(Socket) ->
+    ssl:setopts(Socket, [{active, true}]),
+    ok = ssl:send(Socket, "Hello world"),
+    %% Make sure list option set in ssl:connect/handskae overrides 
+    %% previous gen_tcp socket option that was set to binary.
+    "Hello world" =  ssl_test_lib:active_recv(Socket, length("Hello world")),
     ok.
 
 tls_downgrade_result(Socket, Pid) ->


### PR DESCRIPTION
Correctly handles socket options in upgrade scenarios while keeping the order of the options list in order to keep backwards compatibility behavior if options are supplied more than once (which they ought not to be). 

Hopefully also solves issues in #4585  so that we can have this instead of being bug compatible.