### PR TITLE
Do not allocate large map when value is the same

### DIFF
--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -2399,11 +2399,10 @@ int erts_hashmap_insert_down(Uint32 hx, Eterm key, Eterm value, Eterm node, Uint
     Uint32 ix, cix, bp, hval, chx;
     Uint slot, lvl = 0, clvl;
     Uint size = 0, n = 0;
-    DeclareTmpHeapNoproc(th,2);
+    Eterm th[2];
 
     *update_size = 1;
 
-    UseTmpHeapNoproc(2);
     for (;;) {
 	switch(primary_tag(node)) {
 	    case TAG_PRIMARY_LIST: /* LEAF NODE [K|V] */
@@ -2418,7 +2417,6 @@ int erts_hashmap_insert_down(Uint32 hx, Eterm key, Eterm value, Eterm node, Uint
 		    goto unroll;
 		}
 		if (is_update) {
-                    UnUseTmpHeapNoproc(2);
 		    return 0;
 		}
 		goto insert_subnodes;
@@ -2451,7 +2449,6 @@ int erts_hashmap_insert_down(Uint32 hx, Eterm key, Eterm value, Eterm node, Uint
 
                         if (!(bp & hval)) { /* not occupied */
                             if (is_update) {
-				UnUseTmpHeapNoproc(2);
                                 return 0;
                             }
                             size += HAMT_NODE_BITMAP_SZ(n+1);
@@ -2483,7 +2480,6 @@ int erts_hashmap_insert_down(Uint32 hx, Eterm key, Eterm value, Eterm node, Uint
 			}
 			/* not occupied */
 			if (is_update) {
-                            UnUseTmpHeapNoproc(2);
 			    return 0;
 			}
 			size += HAMT_HEAD_BITMAP_SZ(n+1);
@@ -2517,7 +2513,6 @@ insert_subnodes:
 
 unroll:
     *sz = size + /* res cons */ 2;
-    UnUseTmpHeapNoproc(2);
     return 1;
 }
 

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -2375,7 +2375,7 @@ Eterm erts_hashmap_insert(Process *p, Uint32 hx, Eterm key, Eterm value,
         if (size) {
             /* We are putting a new value (under a new or existing key) */
 	    hp  = HAlloc(p, size);
-	    res = erts_hashmap_insert_up(hp, key, value, &upsz, &stack);
+	    res = erts_hashmap_insert_up(hp, key, value, upsz, &stack);
 	}
         else {
             /* We are putting the same key-value */
@@ -2517,7 +2517,7 @@ unroll:
 }
 
 Eterm erts_hashmap_insert_up(Eterm *hp, Eterm key, Eterm value,
-			     Uint *update_size, ErtsEStack *sp) {
+			     Uint update_size, ErtsEStack *sp) {
     Eterm node, *ptr, hdr;
     Eterm res;
     Eterm *nhp = NULL;
@@ -2562,7 +2562,7 @@ Eterm erts_hashmap_insert_up(Eterm *hp, Eterm key, Eterm value,
 			nhp   = hp;
 			n     = HAMT_HEAD_ARRAY_SZ - 2;
 			*hp++ = MAP_HEADER_HAMT_HEAD_ARRAY; ptr++;
-			*hp++ = (*ptr++) + *update_size;
+			*hp++ = (*ptr++) + update_size;
 			while(n--) { *hp++ = *ptr++; }
 			nhp[slot+2] = res;
 			res = make_hashmap(nhp);
@@ -2590,7 +2590,7 @@ Eterm erts_hashmap_insert_up(Eterm *hp, Eterm key, Eterm value,
 			hval  = MAP_HEADER_VAL(hdr);
 			nhp   = hp;
 			*hp++ = MAP_HEADER_HAMT_HEAD_BITMAP(hval | bp); ptr++;
-			*hp++ = (*ptr++) + *update_size;
+			*hp++ = (*ptr++) + update_size;
 
 			n -= slot;
 			while(slot--) { *hp++ = *ptr++; }

--- a/erts/emulator/beam/erl_map.h
+++ b/erts/emulator/beam/erl_map.h
@@ -88,7 +88,7 @@ Eterm  erts_hashmap_insert(Process *p, Uint32 hx, Eterm key, Eterm value,
 int    erts_hashmap_insert_down(Uint32 hx, Eterm key, Eterm value, Eterm node, Uint *sz,
 			        Uint *upsz, struct ErtsEStack_ *sp, int is_update);
 Eterm  erts_hashmap_insert_up(Eterm *hp, Eterm key, Eterm value,
-			      Uint *upsz, struct ErtsEStack_ *sp);
+			      Uint upsz, struct ErtsEStack_ *sp);
 
 int    erts_validate_and_sort_flatmap(flatmap_t* map);
 void   hashmap_iterator_init(struct ErtsWStack_* s, Eterm node, int reverse);

--- a/erts/emulator/beam/erl_map.h
+++ b/erts/emulator/beam/erl_map.h
@@ -85,7 +85,7 @@ int    erts_maps_take(Process *p, Eterm key, Eterm map, Eterm *res, Eterm *value
 
 Eterm  erts_hashmap_insert(Process *p, Uint32 hx, Eterm key, Eterm value,
 			   Eterm node, int is_update);
-int    erts_hashmap_insert_down(Uint32 hx, Eterm key, Eterm node, Uint *sz,
+int    erts_hashmap_insert_down(Uint32 hx, Eterm key, Eterm value, Eterm node, Uint *sz,
 			        Uint *upsz, struct ErtsEStack_ *sp, int is_update);
 Eterm  erts_hashmap_insert_up(Eterm *hp, Eterm key, Eterm value,
 			      Uint *upsz, struct ErtsEStack_ *sp);

--- a/lib/stdlib/test/maps_SUITE.erl
+++ b/lib/stdlib/test/maps_SUITE.erl
@@ -495,8 +495,12 @@ iter_kv(I) ->
 
 t_put_opt(Config) when is_list(Config) ->
     Value = id(#{complex => map}),
-    Map = id(#{a => Value}),
-    true = erts_debug:same(maps:put(a, Value, Map), Map),
+    Small = id(#{a => Value}),
+    true = erts_debug:same(maps:put(a, Value, Small), Small),
+
+    LargeBase = maps:from_list([{I,I}||I<-lists:seq(1,200)]),
+    Large = LargeBase#{a => Value},
+    true = erts_debug:same(maps:put(a, Value, Large), Large),
     ok.
 
 t_merge_opt(Config) when is_list(Config) ->


### PR DESCRIPTION
This is the same as 6007bf0f8 but applied to large maps.