### PR TITLE
erts: Fix bug in call time tracing

### DIFF
--- a/erts/emulator/beam/beam_bp.c
+++ b/erts/emulator/beam/beam_bp.c
@@ -661,7 +661,7 @@ static void fixup_cp_before_trace(Process *c_p, int *return_to_trace)
         *return_to_trace = 1;
         cpp = &E[0];
     } else if (BeamIsOpCode(w, op_i_return_time_trace)) {
-        cpp = &E[0];
+        cpp = &E[1];
     } else {
         cpp = NULL;
     }

--- a/erts/emulator/test/trace_call_time_SUITE.erl
+++ b/erts/emulator/test/trace_call_time_SUITE.erl
@@ -65,6 +65,7 @@
 -export([all/0, suite/0,
 	 init_per_testcase/2, end_per_testcase/2, not_run/1]).
 -export([basic/1, on_and_off/1, info/1,
+         apply_bif_bug/1, abb_worker/1,
          disable_ongoing/1,
 	 pause_and_restart/1, scheduling/1, called_function/1, combo/1, 
 	 bif/1, nif/1]).
@@ -91,6 +92,7 @@ all() ->
 	false ->
 	    [basic, on_and_off, info, pause_and_restart, scheduling,
              disable_ongoing,
+             apply_bif_bug,
 	     combo, bif, nif, called_function, dead_tracer, return_stop]
     end.
 
@@ -778,3 +780,26 @@ loop() ->
             Pid ! {self(), answer, erlang:apply(M, F, A)},
             loop()
     end.
+
+%% OTP-17290, GH-4635
+apply_bif_bug(_Config) ->
+    Pid = spawn(?MODULE, abb_worker, [self()]),
+    erlang:trace(Pid, true, [call]),
+    erlang:trace_pattern({?MODULE,abb_foo,'_'}, true, [call_time]),
+    erlang:trace_pattern({erlang,display,1}, true, [call_time]),
+    Pid ! {call, erlang, display, ["Hej"]},
+    receive
+        done -> ok
+    end,
+    erlang:trace_pattern({'_','_','_'}, false, [call_time]).
+
+abb_worker(Papa) ->
+    receive
+        {call, M, F, Args} ->
+            abb_foo(M, F, Args),
+            Papa ! done
+    end.
+
+
+abb_foo(M,F,Args) ->
+    apply(M,F,Args).


### PR DESCRIPTION
Fix #4635

Looks like this bug was "always" there but was exposed by
1f5fb6de3e20cf433606c8d8c33a9813d6337aa2
when E[0] could also be NIL.

The bug only exists in 22.2 <= OTP < 23.0.
