### PR TITLE
alloc_SUITE, distribution_SUITE: fix race conditions

### DIFF
--- a/erts/emulator/test/alloc_SUITE.erl
+++ b/erts/emulator/test/alloc_SUITE.erl
@@ -197,11 +197,11 @@ erts_mmap_do(Config, SCO, SCRPM, SCRFSD) ->
                     {false, {os,_}} -> ok
                 end,
 
-                Self ! {Ref, ok}
+                exit(ok)
         end,
 
-    spawn_link(Node, F),
-    Result = receive {Ref, Rslt} -> Rslt end,
+    {Pid, MRef} = spawn_monitor(Node, F),
+    Result = receive {'DOWN', MRef, process, Pid, Rslt} -> Rslt end,
     stop_node(Node),
     Result.
 

--- a/erts/emulator/test/distribution_SUITE.erl
+++ b/erts/emulator/test/distribution_SUITE.erl
@@ -857,9 +857,9 @@ stop_dist(Config) when is_list(Config) ->
                  ++ " -noshell -pa "
                  ++ proplists:get_value(data_dir, Config)
                  ++ " -s run"),
-    %% The "true" may be followed by an error report, so ignore anything that
-    %% follows it.
-    "true\n"++_ = Str,
+    %% The "true" may be followed or prepended by an error report
+    Lines = string:lexemes(Str, "\n"),
+    true = lists:member("true", Lines),
 
     %% "May fail on FreeBSD due to differently configured name lookup - ask Arndt",
     %% if you can find him.


### PR DESCRIPTION
Distribution suite suffers from the race between logger warning emitted, and "true" printed by the test code. There seems to be no specific order, logger may print before or after test suite outpit.
Alloc may fail when stop_node stops the node really fast, and linked process causes test case to exit with `{'EXIT', noconnection}`