### PR TITLE
Fix lost error handling

### DIFF
--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -1805,7 +1805,7 @@ start_protos_listen(Name, Host, Node, [Proto | Ps], Ls, CleanHalt) ->
     catch error:undef ->
             proto_error(CleanHalt, Proto, "not supported"),
             start_protos_listen(Name, Host, Node, Ps, Ls, CleanHalt);
-          error:Reason ->
+          _:Reason ->
             register_error(CleanHalt, Proto, Reason),
             start_protos_listen(Name, Host, Node, Ps, Ls, CleanHalt)
     end;


### PR DESCRIPTION
Exit was lost in refactoring, causing some errors not to be printed
and the listen loop was aborted.