### PR TITLE
Fix backend_init call check + add test case

### DIFF
--- a/lib/mnesia/src/mnesia_schema.erl
+++ b/lib/mnesia/src/mnesia_schema.erl
@@ -1385,7 +1385,7 @@ do_add_backend_type(Name, Module) ->
     ModuleRegistered = lists:keymember(Module, 2, Types),
     do_write_table_property(schema, {mnesia_backend_types,
 				     [{Name, Module}|Types]}),
-    ModuleRegistered.
+    not ModuleRegistered.
 
 delete_backend_type(Name) ->
     schema_transaction(fun() -> do_delete_backend_type(Name) end).

--- a/lib/mnesia/test/ext_test.erl
+++ b/lib/mnesia/test/ext_test.erl
@@ -70,10 +70,26 @@ semantics(_Alias, _) ->
 
 init_backend() ->
     ?DBG(init_backend),
+    ct:log("init_backend ~p", [?MODULE]),
+    %% cheat and stuff a marker in mnesia_gvar
+    K = backend_init_marker(),
+    case try mnesia_lib:val(K) catch _:_ -> error end of
+        error ->
+            ct:log("BACKEND marker will be inserted (~p)", [?MODULE]),
+            mnesia_lib:set(K, true);
+        Other ->
+            ct:log("BACKEND marker already present (~p)", [?MODULE]),
+            error({backend_already_initialized, {?MODULE, Other}})
+    end,
     ok.
+
+backend_init_marker() ->
+    {test, ?MODULE, backend_init}.
 
 add_aliases(_As) ->
     ?DBG(_As),
+    ct:log("add_aliases(~p)", [_As]),
+    true = mnesia_lib:val(backend_init_marker()),
     ok.
 
 remove_aliases(_) ->

--- a/lib/mnesia/test/mnesia_config_test.erl
+++ b/lib/mnesia/test/mnesia_config_test.erl
@@ -38,6 +38,7 @@
 	
 	 dump_log_update_in_place/1,
 	 event_module/1,
+         backend_plugin_registration/1,
 	 inconsistent_database/1,
 	 max_wait_for_decision/1,
 	 send_compressed/1,
@@ -104,7 +105,7 @@ all() ->
     [access_module, auto_repair, backup_module, debug, dir,
      dump_log_load_regulation, {group, dump_log_thresholds},
      dump_log_update_in_place,
-     event_module,
+     event_module, backend_plugin_registration,
      inconsistent_database, max_wait_for_decision,
      send_compressed, app_test, {group, schema_config},
      unknown_config].
@@ -719,6 +720,21 @@ event_module(Config) when is_list(Config) ->
     ?verify_mnesia(Nodes, []),
     ?cleanup(1, Config),
     ok.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+backend_plugin_registration(doc) ->
+    ["Ensure that backend plugins can be registered at runtime,",
+     "that the init_backend is called exactly once when registering",
+     "a plugin, and not again when registering a new alias"];
+backend_plugin_registration(Config) when is_list(Config) ->
+    Nodes = ?acquire_schema(1, [{default_properties, []} | Config]),
+    ?match(ok, mnesia:start()),
+    ?match({atomic,ok}, mnesia:add_backend_type(ext_ets, ext_test)),
+    ?match({atomic,ok}, mnesia:add_backend_type(ext_dets, ext_test)),
+    ?verify_mnesia(Nodes, []),
+    ?cleanup(1, Config).
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/mnesia/test/mnesia_test_lib.erl
+++ b/lib/mnesia/test/mnesia_test_lib.erl
@@ -672,7 +672,7 @@ do_prepare([delete_schema | Actions], Selected, All, Config, File, Line) ->
     end,
     do_prepare(Actions, Selected, All, Config, File, Line);
 do_prepare([create_schema | Actions], Selected, All, Config, File, Line) ->
-    Ext = ?BACKEND,
+    Ext = proplists:get_value(default_properties, Config, ?BACKEND),
     case diskless(Config) of
 	true ->
 	    rpc:multicall(Selected, application, set_env, [mnesia, schema, Ext]),


### PR DESCRIPTION
fixes issue #4525 

The added test case ensures that `backend_init()` is called before `add_alias()` (i.e. it _is_ called the first time), and not called again if another alias is added.

The test case fails if run without the fix in `mnesia_schema.erl`.