### PR TITLE
Remove a test for perl 4

### DIFF
--- a/erts/aclocal.m4
+++ b/erts/aclocal.m4
@@ -364,19 +364,10 @@ dnl
 dnl Try to find perl version 5. If found set PERL to the absolute path
 dnl of the program, if not found set PERL to false.
 dnl
-dnl On some systems /usr/bin/perl is perl 4 and e.g.
-dnl /usr/local/bin/perl is perl 5. We try to handle this case by
-dnl putting a couple of 
-dnl Tries to handle the case that there are two programs called perl
-dnl in the path and one of them is perl 5 and the other isn't. 
-dnl
 AC_DEFUN(LM_PROG_PERL5,
 [AC_PATH_PROGS(PERL, perl5 perl, false,
    /usr/local/bin:/opt/local/bin:/usr/local/gnu/bin:${PATH})
-changequote(, )dnl
-dnl[ That bracket is needed to balance the right bracket below
-if test "$PERL" = "false" || $PERL -e 'exit ($] >= 5)'; then
-changequote([, ])dnl
+if test "$PERL" = "false"; then
   ac_cv_path_PERL=false
   PERL=false
 dnl  AC_MSG_WARN(perl version 5 not found)


### PR DESCRIPTION
This test in the autoconf is both limited, relatively dangerous
(changequote really...) and simply redundant.

If someone built OTP on a machine where perl 4 is the default
they called it on themselves.


Yes i know it will be considered that this test cost "nothing" but it does have a cost. This code is "write only" and that is not a good thing. It is a small change, but i have more coming if this sound like a good idea.