### PR TITLE
crypto: Remove OpenSSL search through uninstall

### DIFF
--- a/lib/crypto/configure.in
+++ b/lib/crypto/configure.in
@@ -223,25 +223,6 @@ case "$erl_xcomp_without_sysroot-$with_ssl" in
     done
     ;;
   no-yes | no- )
-    # On windows, we could try to find the installation
-    # of Shining Light OpenSSL, which can be found by poking in
-    # the uninstall section in the registry, it's worth a try...
-    extra_dir=""
-    if  test "$host_os" = "win32"; then
-    	AC_CHECK_PROG(REGTOOL, reg_query.sh, reg_query.sh, false)
-	if test "$ac_cv_prog_REGTOOL" != false; then
-	   	if test "x$ac_cv_sizeof_void_p" = "x8"; then
-		   rp="HKLM/SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/OpenSSL (64-bit)_is1"
-		else
-		   rp="HKLM/SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/OpenSSL_is1"
-		fi
-		key="Inno Setup: App Path"
-		if "$ac_cv_prog_REGTOOL" "$rp" "$key" > /dev/null; then
-			ssl_install_dir=`"$ac_cv_prog_REGTOOL" "$rp" "$key"`
-			extra_dir=`w32_path.sh -u "$ssl_install_dir"`
-		fi
-	fi
-    fi
     # We search for OpenSSL in the common OS standard locations.
     SSL_APP=ssl
     CRYPTO_APP=crypto
@@ -265,7 +246,7 @@ case "$erl_xcomp_without_sysroot-$with_ssl" in
 
 
     AC_MSG_CHECKING(for OpenSSL >= 0.9.8c in standard locations)
-    for rdir in "$extra_dir" $std_win_ssl_locations $std_ssl_locations; do
+    for rdir in $std_win_ssl_locations $std_ssl_locations; do
 	dir="$erl_xcomp_sysroot$rdir"
 	if test -f "$erl_xcomp_isysroot$rdir/include/openssl/opensslv.h"; then
 		is_real_ssl=yes
@@ -615,7 +596,7 @@ yes
     SSL_KRB5_INCLUDE=
     if test "x$ssl_krb5_enabled" = "xyes" ; then
         AC_MSG_CHECKING(for krb5.h in standard locations)
-	for dir in $extra_dir "$SSL_INCDIR/include" "$SSL_INCDIR/include/openssl" \
+	for dir in "$SSL_INCDIR/include" "$SSL_INCDIR/include/openssl" \
 		"$SSL_INCDIR/include/kerberos" \
 		"$erl_xcomp_isysroot/cygdrive/c/kerberos/include" \
 		"$erl_xcomp_isysroot/usr/local/kerberos/include" \


### PR DESCRIPTION
On Windows, we in rare case try a "last chance" search through the uninstall registry.

This basically reward broken installs and is really brittle code. The crypto configuration code is already complex enough as it is.