### PR TITLE
sasl: Make release scripts build reproducibly

### DIFF
--- a/lib/sasl/src/systools_make.erl
+++ b/lib/sasl/src/systools_make.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
-%% Copyright Ericsson AB 1996-2020. All Rights Reserved.
-%% 
+%%
+%% Copyright Ericsson AB 1996-2021. All Rights Reserved.
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 -module(systools_make).
@@ -1198,8 +1198,8 @@ generate_script(Output, Release, Appls, Flags) ->
     ScriptFile = Output ++ ".script",
     case file:open(ScriptFile, [write,{encoding,utf8}]) of
 	{ok, Fd} ->
-	    io:format(Fd, "%% ~s\n%% script generated at ~w ~w\n~tp.\n",
-		      [epp:encoding_to_string(utf8), date(), time(), Script]),
+	    io:format(Fd, "%% ~s\n~tp.\n",
+		      [epp:encoding_to_string(utf8), Script]),
 	    case file:close(Fd) of
 		ok ->
 		    BootFile = Output ++ ".boot",


### PR DESCRIPTION
Remove the current date/time in scripts generated by systools_make.

Contributes to #4417 (ERL-1445) and #4482 (ERL-1446).