### PR TITLE
Add aead attribute to map from crypto:cipher_info/1

### DIFF
--- a/lib/crypto/c_src/atoms.c
+++ b/lib/crypto/c_src/atoms.c
@@ -52,7 +52,7 @@ ERL_NIF_TERM atom_not_supported;
 ERL_NIF_TERM atom_type;
 ERL_NIF_TERM atom_size;
 ERL_NIF_TERM atom_block_size;
-ERL_NIF_TERM atom_aead;
+ERL_NIF_TERM atom_prop_aead;
 ERL_NIF_TERM atom_key_length;
 ERL_NIF_TERM atom_iv_length;
 ERL_NIF_TERM atom_mode;
@@ -187,7 +187,7 @@ int init_atoms(ErlNifEnv *env, const ERL_NIF_TERM fips_mode, const ERL_NIF_TERM 
     atom_type = enif_make_atom(env,"type");
     atom_size = enif_make_atom(env,"size");
     atom_block_size = enif_make_atom(env,"block_size");
-    atom_aead = enif_make_atom(env,"aead");
+    atom_prop_aead = enif_make_atom(env,"prop_aead");
     atom_key_length = enif_make_atom(env,"key_length");
     atom_iv_length = enif_make_atom(env,"iv_length");
     atom_mode = enif_make_atom(env,"mode");

--- a/lib/crypto/c_src/atoms.c
+++ b/lib/crypto/c_src/atoms.c
@@ -52,6 +52,7 @@ ERL_NIF_TERM atom_not_supported;
 ERL_NIF_TERM atom_type;
 ERL_NIF_TERM atom_size;
 ERL_NIF_TERM atom_block_size;
+ERL_NIF_TERM atom_aead;
 ERL_NIF_TERM atom_key_length;
 ERL_NIF_TERM atom_iv_length;
 ERL_NIF_TERM atom_mode;
@@ -186,6 +187,7 @@ int init_atoms(ErlNifEnv *env, const ERL_NIF_TERM fips_mode, const ERL_NIF_TERM 
     atom_type = enif_make_atom(env,"type");
     atom_size = enif_make_atom(env,"size");
     atom_block_size = enif_make_atom(env,"block_size");
+    atom_aead = enif_make_atom(env,"aead");
     atom_key_length = enif_make_atom(env,"key_length");
     atom_iv_length = enif_make_atom(env,"iv_length");
     atom_mode = enif_make_atom(env,"mode");

--- a/lib/crypto/c_src/atoms.h
+++ b/lib/crypto/c_src/atoms.h
@@ -57,7 +57,7 @@ extern ERL_NIF_TERM atom_type;
 extern ERL_NIF_TERM atom_size;
 extern ERL_NIF_TERM atom_block_size;
 extern ERL_NIF_TERM atom_key_length;
-extern ERL_NIF_TERM atom_aead;
+extern ERL_NIF_TERM atom_prop_aead;
 extern ERL_NIF_TERM atom_iv_length;
 extern ERL_NIF_TERM atom_mode;
 extern ERL_NIF_TERM atom_encrypt;

--- a/lib/crypto/c_src/atoms.h
+++ b/lib/crypto/c_src/atoms.h
@@ -57,6 +57,7 @@ extern ERL_NIF_TERM atom_type;
 extern ERL_NIF_TERM atom_size;
 extern ERL_NIF_TERM atom_block_size;
 extern ERL_NIF_TERM atom_key_length;
+extern ERL_NIF_TERM atom_aead;
 extern ERL_NIF_TERM atom_iv_length;
 extern ERL_NIF_TERM atom_mode;
 extern ERL_NIF_TERM atom_encrypt;

--- a/lib/crypto/c_src/cipher.c
+++ b/lib/crypto/c_src/cipher.c
@@ -229,6 +229,7 @@ ERL_NIF_TERM cipher_info_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
         enif_make_int(env, EVP_CIPHER_iv_length(cipher)), &ret);
     enif_make_map_put(env, ret, atom_block_size,
         enif_make_int(env, EVP_CIPHER_block_size(cipher)), &ret);
+    enif_make_map_put(env, ret, atom_aead, (((EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0) ? atom_true : atom_false), &ret);
 
     mode = EVP_CIPHER_mode(cipher);
     switch (mode) {

--- a/lib/crypto/c_src/cipher.c
+++ b/lib/crypto/c_src/cipher.c
@@ -229,7 +229,9 @@ ERL_NIF_TERM cipher_info_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
         enif_make_int(env, EVP_CIPHER_iv_length(cipher)), &ret);
     enif_make_map_put(env, ret, atom_block_size,
         enif_make_int(env, EVP_CIPHER_block_size(cipher)), &ret);
-    enif_make_map_put(env, ret, atom_aead, (((EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0) ? atom_true : atom_false), &ret);
+    enif_make_map_put(env, ret, atom_prop_aead, 
+            (((EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0) ? atom_true : atom_false), 
+            &ret);
 
     mode = EVP_CIPHER_mode(cipher);
     switch (mode) {

--- a/lib/crypto/doc/src/crypto.xml
+++ b/lib/crypto/doc/src/crypto.xml
@@ -1189,7 +1189,7 @@
       <name name="cipher_info" arity="1" since="OTP 22.0"/>
       <fsummary>Information about supported ciphers.</fsummary>
       <desc>
-	<p>Provides a map with information about block_size, key_length, iv_length and possibly other properties of the
+	<p>Provides a map with information about block_size, key_length, iv_length, aead support and possibly other properties of the
 	cipher algorithm in question.
 	</p>
         <note>

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -725,7 +725,8 @@ mac_final_nif(_Ref) -> ?nif_stub.
                                                 iv_length := integer(),
                                                 block_size := integer(),
                                                 mode := CipherModes,
-                                                type := undefined | integer()
+                                                type := undefined | integer(),
+                                                aead := boolean()
                                                },
                                     CipherModes :: undefined
                                                  | cbc_mode

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -726,7 +726,7 @@ mac_final_nif(_Ref) -> ?nif_stub.
                                                 block_size := integer(),
                                                 mode := CipherModes,
                                                 type := undefined | integer(),
-                                                aead := boolean()
+                                                prop_aead := boolean()
                                                },
                                     CipherModes :: undefined
                                                  | cbc_mode

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -1269,7 +1269,7 @@ cipher_info_aead_attr(Config) when is_list(Config) ->
     case lists:foldl(fun(C,Ok) ->
                         case crypto:cipher_info(C) of
                             #{aead := false} ->
-                                true;
+                                true and Ok;
                             _ ->
                                 false
                         end

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -1250,7 +1250,7 @@ cipher_info_prop_aead_attr(Config) when is_list(Config) ->
     AeadCiphers = [aes_128_ccm, aes_192_ccm, aes_256_ccm, aes_128_gcm, aes_192_gcm, aes_256_gcm, chacha20_poly1305],
     case lists:foldl(fun(C,Ok) ->
                         case crypto:cipher_info(C) of
-                            #{aead := true} ->
+                            #{prop_aead := true} ->
                                 true and Ok;
                             _ ->
                                 false

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -57,6 +57,8 @@
          bad_verify_name/1,
          cipher_info/0,
          cipher_info/1,
+         cipher_info_aead_attr/0,
+         cipher_info_aead_attr/1,
          cipher_padding/1,
          compute/0,
          compute/1,
@@ -1242,6 +1244,45 @@ cipher_info(Config) when is_list(Config) ->
             ct:fail('Cipher unsupported',[])
     end.
                                                                          
+cipher_info_aead_attr() ->
+    [{doc, "crypto cipher_info aead attribute testing"}].
+cipher_info_aead_attr(Config) when is_list(Config) ->
+    AeadCiphers = [aes_128_ccm, aes_192_ccm, aes_256_ccm, aes_128_gcm, aes_192_gcm, aes_256_gcm, chacha20_poly1305],
+    case lists:foldl(fun(C,Ok) ->
+                        case crypto:cipher_info(C) of
+                            #{aead := true} ->
+                                true;
+                            _ ->
+                                false
+                        end
+                     end,
+                     true,
+                     AeadCiphers
+                    )
+    of
+        true ->
+            ok;
+        false ->
+            ct:fail('AEAD Cipher attribute reported false',[])
+    end,
+    NonAeadCiphers = [aes_ige256, blowfish_cbc, blowfish_cfb64],
+    case lists:foldl(fun(C,Ok) ->
+                        case crypto:cipher_info(C) of
+                            #{aead := false} ->
+                                true;
+                            _ ->
+                                false
+                        end
+                     end,
+                     true,
+                     NonAeadCiphers
+                    )
+    of
+        true ->
+            ok;
+        false ->
+            ct:fail('Non-AEAD Cipher attribute reported true',[])
+    end.
 
 %%--------------------------------------------------------------------
 hash_info() ->

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -1268,7 +1268,7 @@ cipher_info_prop_aead_attr(Config) when is_list(Config) ->
     NonAeadCiphers = [aes_ige256, blowfish_cbc, blowfish_cfb64],
     case lists:foldl(fun(C,Ok) ->
                         case crypto:cipher_info(C) of
-                            #{aead := false} ->
+                            #{prop_aead := false} ->
                                 true and Ok;
                             _ ->
                                 false

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -1251,7 +1251,7 @@ cipher_info_aead_attr(Config) when is_list(Config) ->
     case lists:foldl(fun(C,Ok) ->
                         case crypto:cipher_info(C) of
                             #{aead := true} ->
-                                true;
+                                true and Ok;
                             _ ->
                                 false
                         end

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -57,8 +57,8 @@
          bad_verify_name/1,
          cipher_info/0,
          cipher_info/1,
-         cipher_info_aead_attr/0,
-         cipher_info_aead_attr/1,
+         cipher_info_prop_aead_attr/0,
+         cipher_info_prop_aead_attr/1,
          cipher_padding/1,
          compute/0,
          compute/1,
@@ -1244,9 +1244,9 @@ cipher_info(Config) when is_list(Config) ->
             ct:fail('Cipher unsupported',[])
     end.
                                                                          
-cipher_info_aead_attr() ->
-    [{doc, "crypto cipher_info aead attribute testing"}].
-cipher_info_aead_attr(Config) when is_list(Config) ->
+cipher_info_prop_aead_attr() ->
+    [{doc, "crypto cipher_info prop_aead attribute testing"}].
+cipher_info_prop_aead_attr(Config) when is_list(Config) ->
     AeadCiphers = [aes_128_ccm, aes_192_ccm, aes_256_ccm, aes_128_gcm, aes_192_gcm, aes_256_gcm, chacha20_poly1305],
     case lists:foldl(fun(C,Ok) ->
                         case crypto:cipher_info(C) of


### PR DESCRIPTION
- changes map returned by cipher_info/1 nif to include an aead attribute
which indictates whether the cipher is AEAD or not

Closes #4491 