### PR TITLE
Perf and msacc JIT fixes

### DIFF
--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -205,7 +205,7 @@ int erts_no_crash_dump = 0;	/* Use -d to suppress crash dump. */
 int erts_no_line_info = 0;	/* -L: Don't load line information */
 
 #ifdef BEAMASM
-int erts_asm_dump = 0;		/* -asmdump: Dump assembly code */
+int erts_jit_asm_dump = 0;	/* -JDdump: Dump assembly code */
 #endif
 
 /*
@@ -1629,6 +1629,20 @@ erl_start(int argc, char **argv)
 
             switch (sub_param[0])
             {
+            case 'D':
+                sub_param++;
+                if (has_prefix("dump", sub_param)) {
+                    arg = get_arg(sub_param+4, argv[i + 1], &i);
+                    if (sys_strcmp(arg, "true") == 0) {
+                        erts_jit_asm_dump = 1;
+                    } else if (sys_strcmp(arg, "false") == 0) {
+                        erts_jit_asm_dump = 0;
+                    } else {
+                        erts_fprintf(stderr, "bad +JDdump flag %s\n", arg);
+                        erts_usage();
+                    }
+                }
+                break;
             case 'P':
                 sub_param++;
 
@@ -2116,12 +2130,6 @@ erl_start(int argc, char **argv)
 	    break;
 
 	case 'a':
-#ifdef BEAMASM
-	    if (strcmp(argv[i]+2, "smdump") == 0) {
-		erts_asm_dump = 1;
-		break;
-	    }
-#endif
 	    /* suggested stack size (Kilo Words) for threads in thread pool */
 	    arg = get_arg(argv[i]+2, argv[i+1], &i);
 	    erts_async_thread_suggested_stack_size = atoi(arg);

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -1669,7 +1669,7 @@ erl_start(int argc, char **argv)
                 }
                 break;
             default:
-                erts_fprintf(stderr, "invalid JIT option %s\n", arg);
+                erts_fprintf(stderr, "invalid JIT option %s\n", argv[i]);
                 erts_usage();
                 break;
             }

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1263,7 +1263,7 @@ extern int erts_initialized;
 extern int erts_compat_rel;
 
 #ifdef BEAMASM
-extern int erts_asm_dump;
+extern int erts_jit_asm_dump;
 #endif
 
 void erl_start(int, char**);

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -187,7 +187,7 @@ public:
     }
 
     BeamAssembler(const std::string &log) : BeamAssembler() {
-        if (erts_asm_dump) {
+        if (erts_jit_asm_dump) {
             setLogger(log + ".asm");
         }
     }

--- a/erts/emulator/beam/jit/x86/beam_asm_perf.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_perf.cpp
@@ -141,6 +141,7 @@ public:
         for (BeamAssembler::AsmRange &r : ranges) {
             size_t nameLen = r.name.size();
             ptrdiff_t codeSize = (char *)r.stop - (char *)r.start;
+            ASSERT(codeSize > 0);
             record.header.total_size = sizeof(record) + nameLen + 1 + codeSize;
             record.vma = (Uint64)r.start;
             record.code_addr = (Uint64)r.start;
@@ -184,6 +185,7 @@ public:
             ptrdiff_t size = stop - start;
             fprintf(file, "%p %tx $%s\n", start, size, r.name.c_str());
         }
+        fflush(file);
     }
 };
 


### PR DESCRIPTION
* Flush perf logs after module is added
  * This makes `perf top` recognize the correct symbols right away instead of having to wait until the buffer is flushed.
*  Clear msacc state after exiting light bif call