### PR TITLE
etp-commands: fix decoding of aux-work SSI flags

### DIFF
--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -3029,51 +3029,57 @@ define etp-aux-work-flags
 # Args: int
 #
   if ($arg0 & 0x1)
-    printf " delayed-dealloc"
+    printf " delayed-aw-wakeup"
   end
   if ($arg0 & 0x2)
-    printf " delayed-dealloc-thr-prgr"
+    printf " delayed-dealloc"
   end
   if ($arg0 & 0x4)
-    printf " fix-alloc-dealloc"
+    printf " delayed-dealloc-thr-prgr"
   end
   if ($arg0 & 0x8)
-    printf " fix-alloc-lower-lim"
+    printf " fix-alloc-dealloc"
   end
   if ($arg0 & 0x10)
-    printf " later-op"
+    printf " fix-alloc-lower-lim"
   end
   if ($arg0 & 0x20)
-    printf " canceled-timers"
+    printf " later-op"
   end
   if ($arg0 & 0x40)
-    printf " canceled-timers-thr-prgr"
+    printf " canceled-timers"
   end
   if ($arg0 & 0x80)
-    printf " async-ready"
+    printf " canceled-timers-thr-prgr"
   end
   if ($arg0 & 0x100)
-    printf " async-ready-clean"
+    printf " async-ready"
   end
   if ($arg0 & 0x200)
-    printf " misc-thr-prgr"
+    printf " async-ready-clean"
   end
   if ($arg0 & 0x400)
-    printf " misc"
+    printf " misc-thr-prgr"
   end
   if ($arg0 & 0x800)
+    printf " misc"
+  end
+  if ($arg0 & 0x1000)
     printf " set-tmo"
   end
-  if ($arg0 & 0x1000)
+  if ($arg0 & 0x2000)
     printf " mseg-cache-check"
   end
-  if ($arg0 & 0x2000)
+  if ($arg0 & 0x4000)
     printf " yield"
   end
-  if ($arg0 & 0x1000)
+  if ($arg0 & 0x8000)
     printf " reap-ports"
   end
-  if ($arg0 & ~0x7ff)
+  if ($arg0 & 0x10000)
+    printf " debug-wait-completed"
+  end
+  if ($arg0 & ~0x1ffff)
     printf " GARBAGE"
   end
   printf "\n"


### PR DESCRIPTION
The `etp-aux-work-flags` gdb subroutine had gotten out of sync with the actual
flags defined in erl_process.h.