### PR TITLE
eunit: ensure the output directory exist for surefire xml files

### DIFF
--- a/lib/eunit/src/eunit_surefire.erl
+++ b/lib/eunit/src/eunit_surefire.erl
@@ -95,6 +95,7 @@ start(Options) ->
 
 init(Options) ->
     XMLDir = proplists:get_value(dir, Options, ?XMLDIR),
+    ensure_xmldir(XMLDir),
     St = #state{verbose = proplists:get_bool(verbose, Options),
 		xmldir = XMLDir,
 		testsuites = []},
@@ -253,6 +254,19 @@ add_testcase_to_testsuite({error, Exception}, TestCaseTmp, TestSuite) ->
 	    TestSuite#testsuite{
 	      aborted = TestSuite#testsuite.aborted+1,
 	      testcases = [TestCase|TestSuite#testsuite.testcases] }
+    end.
+
+ensure_xmldir(XMLDir) ->
+    Steps = [
+        fun filelib:ensure_dir/1,
+        fun file:make_dir/1],
+    lists:foldl(fun ensure_xmldir/2, XMLDir, Steps).
+
+ensure_xmldir(Fun, XMLDir) ->
+    case Fun(XMLDir) of
+        ok -> XMLDir;
+        {error, eexist} -> XMLDir;
+        {error, _Reason} = Error -> throw(Error)
     end.
 
 %% ----------------------------------------------------------------------------

--- a/lib/eunit/test/eunit_SUITE.erl
+++ b/lib/eunit/test/eunit_SUITE.erl
@@ -22,7 +22,7 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
 	 app_test/1,appup_test/1,eunit_test/1,surefire_utf8_test/1,surefire_latin_test/1,
-	 surefire_c0_test/1]).
+	 surefire_c0_test/1, surefire_ensure_dir_test/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -30,7 +30,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
     [app_test, appup_test, eunit_test, surefire_utf8_test, surefire_latin_test,
-     surefire_c0_test].
+     surefire_c0_test, surefire_ensure_dir_test].
 
 groups() ->
     [].
@@ -75,6 +75,11 @@ surefire_c0_test(Config) when is_list(Config) ->
     true = lists:member($\r, Chars),
     true = lists:member($\t, Chars),
     ok.
+
+surefire_ensure_dir_test(Config) when is_list(Config) ->
+    XMLDir = filename:join(proplists:get_value(priv_dir, Config), "c1"),
+    ok = eunit:test(tc0, [{report,{eunit_surefire,[{dir,XMLDir}]}}]),
+    ok = file:del_dir_r(XMLDir).
 
 check_surefire(Module) ->
 	File = "TEST-"++atom_to_list(Module)++".xml",


### PR DESCRIPTION
Hello,

This PR is about eunit, when using surefire reports, creating the output directory if it does not exist. The main use case is for Jenkins or any other CI server.