### PR TITLE
Remove duplicate trace message description

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -11608,13 +11608,6 @@ improper_end</pre>
             <p>When <c>PidPort</c> gets unlinked from a process <c>Pid2</c>.</p>
           </item>
           <tag>
-            <marker id="trace_3_trace_messages_exit"></marker>
-            <c>{trace, Pid, exit, Reason}</c>
-          </tag>
-          <item>
-            <p>When <c>Pid</c> exits with reason <c>Reason</c>.</p>
-          </item>
-          <tag>
             <marker id="trace_3_trace_messages_open"></marker>
             <c>{trace, Port, open, Pid, Driver}</c>
           </tag>


### PR DESCRIPTION
The `{trace, Pid, exit, Reason}` message is described twice.