### PR TITLE
Fix parse transform column handling

### DIFF
--- a/erts/doc/src/absform.xml
+++ b/erts/doc/src/absform.xml
@@ -195,11 +195,14 @@
             The word <c>LOCATION</c> represents a location, and denotes the
             number of the last line, and possibly the number of the last
 	    column on that line, in the source file. See <seeerl
-	    marker="stdlib:erl_anno">erl_anno(3)</seeerl> for
+	    marker="stdlib:erl_anno"><c>erl_anno(3)</c></seeerl> for
 	    details.
           </p>
         </item>
       </list>
+      <p>See <seetype marker="stdlib:erl_parse#form_info">
+        <c>the form_info/0</c></seetype> type in
+        <c>erl_parse(3)</c> for more details about these values.</p>
     </section>
   </section>
 

--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -363,7 +363,7 @@ module.beam: module.erl \
             since R13B04.</p>
           </item>
 
-	  <tag><c>error_location</c></tag>
+	  <tag><c>{error_location,line | column}</c></tag>
 	  <item>
             <p>If the value of this flag is <c>line</c>, the location
             <seeerl marker="#error_information"><c>ErrorLocation</c></seeerl>

--- a/lib/compiler/test/compile_SUITE_data/column_pt.erl
+++ b/lib/compiler/test/compile_SUITE_data/column_pt.erl
@@ -19,11 +19,68 @@
 %%
 
 -module(column_pt).
--export([parse_transform/2, parse_transform_info/0]).
+-export([parse_transform/2, parse_transform_info/0, format_error/1]).
 
 parse_transform_info() ->
     %% Will default to {error_location,column}.
     #{}.
 
-parse_transform(Forms, _Options) ->
-    Forms.
+parse_transform(Forms, Options) ->
+
+    HasColumn =
+        case proplists:get_value(error_location, Options, column) of
+            column ->
+                true;
+            line ->
+                false
+        end,
+
+    AddColumns = proplists:get_value(add_columns, Options, false),
+    AddError = proplists:get_value(add_error, Options, false),
+
+    {eof,LastLocation} = lists:keyfind(eof, 1, Forms),
+    LastLine = erl_anno:line(erl_anno:new(LastLocation)),
+    ExtraFormsAnno =
+        if HasColumn ->
+                erl_anno:new({LastLine,1});
+           not HasColumn ->
+                erl_anno:new(LastLine)
+        end,
+
+    ExtraForms = [{warning,{ExtraFormsAnno,?MODULE,"injected warning"}}] ++
+        [{error,{ExtraFormsAnno,?MODULE,"injected error"}} || AddError],
+
+    lists:map(
+      fun
+          ({eof,Location}) ->
+              Anno = erl_anno:new(Location),
+              HasColumn = erl_anno:column(Anno) =/= undefined,
+              if AddColumns ->
+                      {eof,{erl_anno:line(Anno), 1}};
+                  not AddColumns ->
+                      {eof,Location}
+              end;
+          ({ErrorOrWarning,{Location,Module,Text}})
+            when ErrorOrWarning =:= error;
+                 ErrorOrWarning =:= warning ->
+              Anno = erl_anno:new(Location),
+              HasColumn = erl_anno:column(Anno) =/= undefined,
+              if AddColumns ->
+                      {ErrorOrWarning,{{erl_anno:line(Anno), 1}, Module, Text}};
+                  not AddColumns ->
+                      {ErrorOrWarning, {Location, Module, Text}}
+              end;
+          (Form) ->
+              erl_parse:map_anno(
+                fun(Anno) ->
+                        HasColumn = erl_anno:column(Anno) =/= undefined,
+                        if AddColumns ->
+                                erl_anno:set_location({erl_anno:line(Anno), 1}, Anno);
+                           not AddColumns ->
+                                Anno
+                        end
+                end, Form)
+      end, Forms ++ ExtraForms).
+
+format_error(Error) ->
+    Error.

--- a/lib/compiler/test/compile_SUITE_data/line_pt.erl
+++ b/lib/compiler/test/compile_SUITE_data/line_pt.erl
@@ -24,5 +24,17 @@
 parse_transform_info() ->
     #{error_location => line}.
 
-parse_transform(Forms, _Options) ->
-    Forms.
+parse_transform(Forms,_Options) ->
+    lists:map(
+      fun
+          ({eof,Location}) ->
+              Anno = erl_anno:new(Location),
+              false = erl_anno:column(Anno) =/= undefined,
+              {eof,Location};
+          (Form) ->
+              erl_parse:map_anno(
+                fun(Anno) ->
+                        false = erl_anno:column(Anno) =/= undefined,
+                        Anno
+                end, Form)
+      end, Forms).

--- a/lib/stdlib/examples/erl_id_trans.erl
+++ b/lib/stdlib/examples/erl_id_trans.erl
@@ -31,7 +31,7 @@ parse_transform(Forms, _Options) ->
     forms(Forms).
 
 parse_transform_info() ->
-    #{columns => true}.
+    #{error_location => column}.
 
 %% forms(Fs) -> lists:map(fun (F) -> form(F) end, Fs).
 


### PR DESCRIPTION
Fix so that parse_transforms are handed the correct AST without columns if requested by either the user or the parse transform.
    
Added test to verify that the column stripping works.
