### PR TITLE
queue, maps, proplists: add since information to docs for new functions

### DIFF
--- a/lib/stdlib/doc/src/maps.xml
+++ b/lib/stdlib/doc/src/maps.xml
@@ -73,7 +73,7 @@
     </func>
 
     <func>
-      <name name="filtermap" arity="2" since=""/>
+      <name name="filtermap" arity="2" since="OTP 24.0"/>
       <fsummary>Filter and map a map.</fsummary>
       <desc>
         <p>Returns a map <c><anno>Map</anno></c> that is the result of calling

--- a/lib/stdlib/doc/src/proplists.xml
+++ b/lib/stdlib/doc/src/proplists.xml
@@ -138,7 +138,7 @@ expand([{{foo, true}, [bar, baz]}], [{foo, false}, fie, foo, fum])</code>
     </func>
 
     <func>
-      <name name="from_map" arity="1" since=""/>
+      <name name="from_map" arity="1" since="OTP 24.0"/>
       <fsummary></fsummary>
       <desc>
         <p>Converts the map <c><anno>Map</anno></c> to a property list.</p>
@@ -373,7 +373,7 @@ split([{c, 2}, {e, 1}, a, {c, 3, 4}, d, {b, 5}, b], [a, b, c])</code>
     </func>
 
     <func>
-      <name name="to_map" arity="1" since=""/>
+      <name name="to_map" arity="1" since="OTP 24.0"/>
       <fsummary></fsummary>
       <desc>
         <p>Converts the property list <c><anno>List</anno></c> to a map.</p>
@@ -397,7 +397,7 @@ to_map([a, {b, 1}, {c, 2}, {c, 3}])</code>
     </func>
 
     <func>
-      <name name="to_map" arity="2" since=""/>
+      <name name="to_map" arity="2" since="OTP 24.0"/>
       <fsummary></fsummary>
       <desc>
         <p>Converts the property list <c><anno>List</anno></c> to a map after

--- a/lib/stdlib/doc/src/queue.xml
+++ b/lib/stdlib/doc/src/queue.xml
@@ -122,7 +122,7 @@
       <title>Original API</title>
     </fsdescription>
     <func>
-      <name name="all" arity="2" since=""/>
+      <name name="all" arity="2" since="OTP 24.0"/>
       <fsummary>Return <c>true</c> if all items in a queue satisfy
         <c>Pred</c>.</fsummary>
       <desc>
@@ -133,7 +133,7 @@
     </func>
 
     <func>
-      <name name="any" arity="2" since=""/>
+      <name name="any" arity="2" since="OTP 24.0"/>
       <fsummary>Return <c>true</c> if any of the items in a queue satisfy
         <c>Pred</c>.</fsummary>
       <desc>
@@ -144,7 +144,7 @@
     </func>
 
     <func>
-      <name name="delete" arity="2" since=""/>
+      <name name="delete" arity="2" since="OTP 24.0"/>
       <fsummary>Delete an item from the front of a queue.</fsummary>
       <desc>
         <p>Returns a copy of <c><anno>Q1</anno></c> where the first item
@@ -154,7 +154,7 @@
     </func>
 
     <func>
-      <name name="delete_r" arity="2" since=""/>
+      <name name="delete_r" arity="2" since="OTP 24.0"/>
       <fsummary>Delete an item from the rear of a queue.</fsummary>
       <desc>
         <p>Returns a copy of <c><anno>Q1</anno></c> where the last item
@@ -164,7 +164,7 @@
     </func>
 
     <func>
-      <name name="delete_with" arity="2" since=""/>
+      <name name="delete_with" arity="2" since="OTP 24.0"/>
       <fsummary>Delete an item matching a predicate from the front of a
         queue.</fsummary>
       <desc>
@@ -175,7 +175,7 @@
     </func>
 
     <func>
-      <name name="delete_with_r" arity="2" since=""/>
+      <name name="delete_with_r" arity="2" since="OTP 24.0"/>
       <fsummary>Delete an item matching a predicate from the rear of a
         queue.</fsummary>
       <desc>
@@ -207,7 +207,7 @@
     </func>
 
     <func>
-      <name name="filtermap" arity="2" since=""/>
+      <name name="filtermap" arity="2" since="OTP 24.0"/>
       <fsummary>Filter and map a queue.</fsummary>
       <desc>
         <p>Returns a queue <c><anno>Q2</anno></c> that is the result of calling
@@ -222,7 +222,7 @@
     </func>
 
     <func>
-      <name name="fold" arity="3" since=""/>
+      <name name="fold" arity="3" since="OTP 24.0"/>
       <fsummary>Fold a function over a queue.</fsummary>
       <desc>
         <p>Calls <c><anno>Fun</anno>(<anno>Item</anno>, <anno>AccIn</anno>)</c>


### PR DESCRIPTION
In past PRs #2791, #2850, #2900 and #2910, I contributed some new functions to the `queue`, `maps` and `proplists` modules, but forgot to add the `since` information in the documentation.