### PR TITLE
EDoc: suggest {preprocess, true} when redundant spec assertion fails

### DIFF
--- a/lib/edoc/src/edoc.erl
+++ b/lib/edoc/src/edoc.erl
@@ -77,7 +77,8 @@
 			       exports :: ordset(function_name()),
 			       attributes :: ordset({atom(), term()}),
 			       records :: [{atom(), [{atom(), term()}]}],
-			       encoding :: epp:source_encoding()}.
+			       encoding :: epp:source_encoding(),
+			       file :: file:filename()}.
 %% Module information.
 
 -type env() :: #env{}.

--- a/lib/edoc/src/edoc.hrl
+++ b/lib/edoc/src/edoc.hrl
@@ -50,7 +50,8 @@
 		 exports = [],
 		 attributes = [],
 		 records = [],
-		 encoding = latin1}).
+		 encoding = latin1,
+		 file}).
 
 -record(env, {module = [],
 	      root = "",


### PR DESCRIPTION
This might happen when `-spec`s are generated conditionally by the preprocessor. EDoc has to be aware of this, so `{preprocess, true}` is required.