### PR TITLE
Reenable tls prf test

### DIFF
--- a/lib/ssl/src/tls_dtls_connection.erl
+++ b/lib/ssl/src/tls_dtls_connection.erl
@@ -646,6 +646,8 @@ connection({call, From}, negotiated_protocol,
                                                  negotiated_protocol = undefined}} = State) ->
     ssl_gen_statem:hibernate_after(?FUNCTION_NAME, State,
                                        [{reply, From, {ok, SelectedProtocol}}]);
+connection({call, From}, Msg, State) when element(1, Msg) =:= prf ->
+    handle_call(Msg, From, ?FUNCTION_NAME, State);
 connection(cast, {internal_renegotiate, WriteState}, #state{static_env = #static_env{protocol_cb = tls_gen_connection},
                                                             handshake_env = HsEnv,
                                                             connection_states = ConnectionStates}

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -650,15 +650,12 @@ prf() ->
 prf(Config) when is_list(Config) ->
     Version = ssl_test_lib:protocol_version(Config),
     TestPlan = proplists:get_value(prf_test_plan, Config),
-    case TestPlan of
-        [] -> ct:fail({error, empty_prf_test_plan});
-        _ -> lists:foreach(fun(Test) ->
-                                   C = proplists:get_value(ciphers, Test),
-                                   E = proplists:get_value(expected, Test),
-                                   P = proplists:get_value(prf, Test),
-                                   prf_run_test(Config, Version, C, E, P)
-                           end, TestPlan)
-    end.
+    lists:foreach(fun(Test) ->
+                          C = proplists:get_value(ciphers, Test),
+                          E = proplists:get_value(expected, Test),
+                          P = proplists:get_value(prf, Test),
+                          prf_run_test(Config, Version, C, E, P)
+                  end, TestPlan).
 
 %%--------------------------------------------------------------------
 dh_params() ->

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -2651,7 +2651,7 @@ connection_info_result(Socket) ->
 prf_create_plan(TlsVer, _PRFs, Results) when TlsVer == tlsv1
                                              orelse TlsVer == 'tlsv1.1'
                                              orelse TlsVer == 'dtlsv1' ->
-    Ciphers = ssl:cipher_suites(all, TlsVer),
+    Ciphers = prf_get_ciphers(TlsVer, default_prf),
     {_, Expected} = lists:keyfind(md5sha, 1, Results),
     [[{ciphers, Ciphers}, {expected, Expected}, {prf, md5sha}]];
 prf_create_plan(TlsVer, PRFs, Results) when TlsVer == 'tlsv1.2' orelse TlsVer == 'dtlsv1.2' ->

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -2654,7 +2654,7 @@ connection_info_result(Socket) ->
 prf_create_plan(TlsVer, _PRFs, Results) when TlsVer == tlsv1
                                              orelse TlsVer == 'tlsv1.1'
                                              orelse TlsVer == 'dtlsv1' ->
-    Ciphers = ssl:cipher_suites(default, TlsVer),
+    Ciphers = ssl:cipher_suites(all, TlsVer),
     {_, Expected} = lists:keyfind(md5sha, 1, Results),
     [[{ciphers, Ciphers}, {expected, Expected}, {prf, md5sha}]];
 prf_create_plan(TlsVer, PRFs, Results) when TlsVer == 'tlsv1.2' orelse TlsVer == 'dtlsv1.2' ->
@@ -2680,10 +2680,10 @@ prf_get_ciphers(TlsVer, PRF) ->
                                 false
                         end
                 end,
-    ssl:filter_cipher_suites(ssl:cipher_suites(default, TlsVer), [{prf, PrfFilter}]).
+    ssl:filter_cipher_suites(ssl:cipher_suites(all, TlsVer), [{prf, PrfFilter}]).
 
 prf_run_test(_, TlsVer, [], _, Prf) ->
-    ct:fail({error, cipher_list_empty, TlsVer, Prf});
+    ct:comment(lists:flatten(io_lib:format("cipher_list_empty Ver: ~p  PRF: ~p", [TlsVer, Prf])));
 prf_run_test(Config, TlsVer, Ciphers, Expected, Prf) ->
     {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
     BaseOpts = [{active, true}, {versions, [TlsVer]}, {ciphers, Ciphers}, {protocol, tls_or_dtls(TlsVer)}],


### PR DESCRIPTION
As far as I could discover, it seems to me that in the commit
ec0f8d69a98b08b2effd07121b5f87e327d370ee, when moving around many test
suites, the prf test was left out, and it hasn't been running tests for
a while. Here I re-enable it, fixing also any other changes that seemed
necessary to make the test pass.

@IngelaAndin @peterdmv 

edit: there's a second commit, 8e19af3, removing some duplicated code as well, the prf code was copy&pasted and duplicated.