### PR TITLE
Improve the 'Last calls' section included in crash dumps

### DIFF
--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -348,11 +348,11 @@ print_process_info(fmtfn_t to, void *to_arg, Process *p, ErtsProcLocks orig_lock
 	     if (j < 0)
 		j += scb->len;
 	     if (scb->ct[j] == &exp_send)
-		erts_print(to, to_arg, "send");
+		erts_print(to, to_arg, "send\n");
 	     else if (scb->ct[j] == &exp_receive)
-		erts_print(to, to_arg, "'receive'");
+		erts_print(to, to_arg, "'receive'\n");
 	     else if (scb->ct[j] == &exp_timeout)
-		   erts_print(to, to_arg, "timeout");
+		   erts_print(to, to_arg, "timeout\n");
 	     else
 		 erts_print(to, to_arg, "%T:%T/%bpu\n",
 			    scb->ct[j]->info.mfa.module,


### PR DESCRIPTION
The **Last calls** section of a crash dump is present, if the `save_calls` process flag is set. If the process sends or receives messages, the section lists events like `send`, `'receive'` or `timeout`. This PR adds '\n' at the end of the line for such events. It helps with parsing it.

In the current version there is [a workaround](https://github.com/erlang/otp/blob/master/lib/observer/src/crashdump_viewer.erl#L1288) for the missing \n characters. After the fix it will only be needed for older versions of the crash dump file.