### PR TITLE
Improve the etp commands for lldb

### DIFF
--- a/erts/etc/unix/etp.py
+++ b/erts/etc/unix/etp.py
@@ -310,7 +310,14 @@ def cons(valobj, depth = float('inf')):
     improper = False
     truncated = False
     depth *= 20
-    
+
+    ptr = cdr.CreateValueFromData(
+        "unconsed",
+        lldb.SBData.CreateDataFromInt(cdr.unsigned - 1),
+        EtermPtr(cdr.target))
+    if ptr.deref.error.fail:
+        return "#ConsError<%x>" % cdr.unsigned;
+
     while True:
         ptr = cdr.CreateValueFromData(
             "unconsed",
@@ -370,7 +377,10 @@ def boxed(valobj, depth = float('inf')):
         "unboxed",
         lldb.SBData.CreateDataFromInt(valobj.unsigned - 2),
         EtermPtr(valobj.target))
-    boxed_hdr = ptr.deref.unsigned
+    boxed_hdr = ptr.deref
+    if boxed_hdr.error.fail:
+        return "#BoxedError<%x>" % valobj.unsigned;
+    boxed_hdr = boxed_hdr.unsigned
     if boxed_hdr & 0x3f == 0x00:
         arity = (boxed_hdr >> 6)
         terms = []

--- a/erts/etc/unix/etp.py
+++ b/erts/etc/unix/etp.py
@@ -2,7 +2,7 @@
 #
 # %CopyrightBegin%
 # 
-# Copyright Ericsson AB 2013-2022. All Rights Reserved.
+# Copyright Ericsson AB 2013-2021. All Rights Reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 # %CopyrightEnd%
 #
 #
-# This script was orinally written by Anthony Ramine (aka nox) in 2013
+# This script was orinally written by Anthony Ramine (aka nox) in 2013.
 # A lot of things have changed since then, but the same base remains.
 #
 

--- a/erts/etc/unix/etp.py
+++ b/erts/etc/unix/etp.py
@@ -394,9 +394,9 @@ def boxed(valobj, depth = float('inf')):
         return F"{{{res}}}"
     if boxed_hdr & 0x3c == 0x3c:
         if boxed_hdr & 0xc0 == 0x0:
-            return "flat_map"
+            return "#FlatMap"
         else:
-            return "hash_map"
+            return "#HashMap"
     boxed_type = (boxed_hdr >> 2) & 0xF
     if boxed_type == 0xC:
         return '#ExternalPid'

--- a/erts/etc/unix/etp.py
+++ b/erts/etc/unix/etp.py
@@ -72,6 +72,7 @@ def process_info(proc):
     print('  Pid: %s' % eterm(proc.GetChildMemberWithName('common').GetChildMemberWithName('id')))
     print('  State: %s' % process_state(proc))
     print('  Flags: %s' % process_flags(proc))
+    print_process_reg_name(proc)
     current = proc.GetChildMemberWithName('current')
     if current.unsigned != 0 and proc.GetChildMemberWithName('state').GetChildMemberWithName('counter').unsigned & 0x800 == 0:
         print('  Current function: %s' % mfa(current))
@@ -83,6 +84,14 @@ def process_info(proc):
     else:
         print('  I: %s' % 'unknown')
     print('  Pointer: %#x' % proc.unsigned)
+
+def print_process_reg_name(proc):
+    state = proc.GetChildMemberWithName('state').unsigned
+    if (state & 0x800) == 0:
+        # Not exiting.
+        reg = proc.GetChildMemberWithName('common').GetChildMemberWithName('u').GetChildMemberWithName('alive').GetChildMemberWithName('reg')
+        if reg.unsigned != 0:
+            print('  Registered name: %s' % eterm(reg.GetChildMemberWithName('name')))
 
 def process_state(proc):
     state = proc.GetChildMemberWithName('state').unsigned


### PR DESCRIPTION
Improve the functionality of the etp commands for lldb. The most important fix is that continuation pointers on platforms that use GNU-C atomics (such as macOS on M1 Macs) can now be converted to "M:F/A" when printing stack backtraces.