### PR TITLE
stdlib: Do not pretty-print parentheses around 'catch'

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -1617,7 +1617,7 @@ inop_prec('.') -> {900,900,1000}.
 
 -spec preop_prec(pre_op()) -> {0 | 600 | 700, 100 | 700 | 800}.
 
-preop_prec('catch') -> {0,100};
+preop_prec('catch') -> {950,100};
 preop_prec('+') -> {600,700};
 preop_prec('-') -> {600,700};
 preop_prec('bnot') -> {600,700};
@@ -1628,9 +1628,9 @@ preop_prec('#') -> {700,800}.
 
 func_prec() -> {800,700}.
 
--spec max_prec() -> 900.
+-spec max_prec() -> 1000.
 
-max_prec() -> 900.
+max_prec() -> 1000.
 
 -type prec() :: non_neg_integer().
 

--- a/lib/stdlib/src/erl_pp.erl
+++ b/lib/stdlib/src/erl_pp.erl
@@ -549,8 +549,7 @@ lexpr({nil,_}, _, _) -> '[]';
 lexpr({cons,_,H,T}, _, Opts) ->
     list(T, [H], Opts);
 lexpr({lc,_,E,Qs}, _Prec, Opts) ->
-    P = max_prec(),
-    Lcl = {list,[{step,[lexpr(E, P, Opts),leaf(" ||")],lc_quals(Qs, Opts)}]},
+    Lcl = {list,[{step,[lexpr(E, Opts),leaf(" ||")],lc_quals(Qs, Opts)}]},
     {list,[{seq,$[,[],[[]],[{force_nl,leaf(" "),[Lcl]}]},$]]};
     %% {list,[{step,$[,Lcl},$]]};
 lexpr({bc,_,E,Qs}, _Prec, Opts) ->

--- a/lib/stdlib/test/erl_pp_SUITE.erl
+++ b/lib/stdlib/test/erl_pp_SUITE.erl
@@ -373,7 +373,7 @@ try_catch(Config) when is_list(Config) ->
            <<"t() -> case catch foo of bar -> foo end.">>},
           {catch_3,
            <<"t() -> catch begin begin foo, bar, foo:bar(kljsldkfjdls,kljsdl),
-                           (catch bar:foo(foo)) end end.">>}
+                           catch bar:foo(foo) end end.">>}
           ],
     compile(Config, Ts),
     ok = pp_expr(<<"try
@@ -1304,7 +1304,10 @@ otp_16435(_Config) ->
 
     CheckF("f() ->\n    << \n      (catch <<1:4>>) ||\n"
            "          A <- []\n    >>.\n"),
-    CheckF("f() ->\n    [ \n     (catch foo) ||\n         A <- []\n    ].\n"),
+    CheckF("f() ->\n    [ \n     catch foo ||\n         A <- []\n    ].\n"),
+    CheckF("f() ->\n    1 = catch 1.\n"),
+    CheckF("f() ->\n    catch 1 = catch 1.\n"),
+    CheckF("f() ->\n    A = catch 1 / 0.\n"),
     CheckF("f() when erlang:float(3.0) ->\n    true.\n"),
 
     Check = fun(S) -> S = flat_parse_and_pp_expr(S, 0, []) end,

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -1347,14 +1347,6 @@ catch Expr</code>
 3
 2> <input>catch 1+a.</input>
 {'EXIT',{badarith,[...]}}</pre>
-    <p>Notice that <c>catch</c> has low precedence and catch
-      subexpressions often needs to be enclosed in a block
-      expression or in parentheses:</p>
-    <pre>
-3> <input>A = catch 1+2.</input>
-** 1: syntax error before: 'catch' **
-4> <input>A = (catch 1+2).</input>
-3</pre>
     <p>The BIF <c>throw(Any)</c> can be used for non-local return from
       a function. It must be evaluated within a <c>catch</c>, which
       returns the value <c>Any</c>.</p>


### PR DESCRIPTION
See PR-2584, where the parser grammar was partly rewritten using
operator precedence. As a consequence, parentheses are in many cases
no longer required around 'catch' expressions.

System doc: Remove comment and example about parentheses being
necessary around 'catch' in many situations.

Also: Do not write unnecessary parentheses around Expr (the template)
in list comprehensions.