### PR TITLE
ssl: avoid decoding certs several times

### DIFF
--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -261,8 +261,7 @@ certificate_chain(#cert{otp=OtpCert}=Cert, CertDbHandle, CertsDbRef, Chain, List
 	    false  ->
 		{public_key:pkix_issuer_id(OtpCert, other), false}
 	end,
-    
-    case IssuerAndSelfSigned of 
+    case IssuerAndSelfSigned of
 	{_, true = SelfSigned} ->
 	    do_certificate_chain(CertDbHandle, CertsDbRef, Chain, ignore, ignore, SelfSigned, ListDb);
 	{{error, issuer_not_found}, SelfSigned} ->
@@ -270,7 +269,7 @@ certificate_chain(#cert{otp=OtpCert}=Cert, CertDbHandle, CertsDbRef, Chain, List
 		{ok, {SerialNr, Issuer}} ->
 		    do_certificate_chain(CertDbHandle, CertsDbRef, Chain,
 					 SerialNr, Issuer, SelfSigned, ListDb);
-		_ ->
+		_Err ->
 		    %% Guess the the issuer must be the root
 		    %% certificate. The verification of the
 		    %% cert chain will fail if guess is
@@ -287,8 +286,7 @@ do_certificate_chain(_, _, [RootCert | _] = Chain, _, _, true, _) ->
 do_certificate_chain(CertDbHandle, CertsDbRef, Chain, SerialNr, Issuer, _, ListDb) ->
     case ssl_manager:lookup_trusted_cert(CertDbHandle, CertsDbRef,
 						SerialNr, Issuer) of
-	{ok, {IssuerCert, ErlCert}} ->
-            Cert = #cert{der=IssuerCert, otp=ErlCert},
+	{ok, Cert} ->
 	    certificate_chain(Cert, CertDbHandle, CertsDbRef, [Cert | Chain], ListDb);
 	_ ->
 	    %% The trusted cert may be obmitted from the chain as the
@@ -300,7 +298,7 @@ do_certificate_chain(CertDbHandle, CertsDbRef, Chain, SerialNr, Issuer, _, ListD
 
 find_issuer(#cert{der=DerCert, otp=OtpCert}, CertDbHandle, CertsDbRef, ListDb) ->
     IsIssuerFun =
-	fun({_Key, {_Der, #'OTPCertificate'{} = ErlCertCandidate}}, Acc) ->
+	fun({_Key, #cert{otp=ErlCertCandidate}}, Acc) ->
 		case public_key:pkix_is_issuer(OtpCert, ErlCertCandidate) of
 		    true ->
 			case verify_cert_signer(DerCert, ErlCertCandidate#'OTPCertificate'.tbsCertificate) of
@@ -501,7 +499,7 @@ handle_partial_chain([#cert{der=IssuerCert, otp=OTPCert}=Cert| Rest] = Path, Par
         true -> %% IssuerCert = ROOT (That is ROOT was included in chain)
             {ok, {SerialNr, IssuerId}} = public_key:pkix_issuer_id(OTPCert, self),
             case ssl_manager:lookup_trusted_cert(CertDbHandle, CertDbRef, SerialNr, IssuerId) of
-                {ok, {IssuerCert, _}} -> %% Match sent ROOT to trusted ROOT 
+                {ok, #cert{der=IssuerCert}} -> %% Match sent ROOT to trusted ROOT 
                     maybe_shorten_path(Path, PartialChainHandler, {Cert, Rest});
                 {ok, _} -> %% Did not match trusted ROOT
                     maybe_shorten_path(Path, PartialChainHandler, {invalid_issuer, Path});
@@ -512,8 +510,7 @@ handle_partial_chain([#cert{der=IssuerCert, otp=OTPCert}=Cert| Rest] = Path, Par
             case other_issuer(Cert, CertDbHandle, CertDbRef) of
                 {other, {SerialNr, IssuerId}} ->
                     case ssl_manager:lookup_trusted_cert(CertDbHandle, CertDbRef, SerialNr, IssuerId) of
-                        {ok, {NewDer, NewOtp}} ->
-                            NewCert = #cert{der=NewDer, otp=NewOtp},
+                        {ok, #cert{otp=NewOtp}=NewCert} ->
                             case public_key:pkix_is_self_signed(NewOtp) of
                                 true -> %% NewIssuerCert is a trusted ROOT cert
                                     maybe_shorten_path([NewCert | Path], PartialChainHandler, {NewCert, Path});

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -135,22 +135,9 @@ certificate(undefined, _, _, client) ->
     %% SHOULD send a certificate message containing no
     %% certificates. (chapter 7.4.6. RFC 4346)
     #certificate{asn1_certificates = []};
-certificate([OwnCert], CertDbHandle, CertDbRef, client) ->
-    Chain =
-	case ssl_certificate:certificate_chain(OwnCert, CertDbHandle, CertDbRef) of
-	    {ok, _,  CertChain} ->
-		CertChain;
-	    {error, _} ->
-                certificate(undefined, CertDbHandle, CertDbRef, client)
-        end,
-    #certificate{asn1_certificates = Chain};
-certificate([OwnCert], CertDbHandle, CertDbRef, server) ->
-    case ssl_certificate:certificate_chain(OwnCert, CertDbHandle, CertDbRef) of
-	{ok, _, Chain} ->
-	    #certificate{asn1_certificates = Chain};
-	{error, Error} ->
-            ?ALERT_REC(?FATAL, ?INTERNAL_ERROR, {server_has_no_suitable_certificates, Error})
-    end;
+certificate([OwnCert], CertDbHandle, CertDbRef, _) ->
+    {ok, _,  CertChain} = ssl_certificate:certificate_chain(OwnCert, CertDbHandle, CertDbRef),
+    #certificate{asn1_certificates = CertChain};
 certificate([_, _ |_] = Chain, _, _, _) ->
     #certificate{asn1_certificates = Chain}.
 

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -252,6 +252,8 @@
          max_size              %% max early data size allowed by this ticket
         }).
 
+-record(cert, {der, otp}).
+
 -endif. % -ifdef(ssl_internal).
 
 

--- a/lib/ssl/src/ssl_manager.erl
+++ b/lib/ssl/src/ssl_manager.erl
@@ -138,9 +138,9 @@ cache_pem_file(File, DbHandle) ->
 
 %%--------------------------------------------------------------------
 -spec lookup_trusted_cert(term(), reference(), serialnumber(), issuer()) ->
-				 undefined | 
-				 {ok, {der_cert(), #'OTPCertificate'{}}}.
-%%				 
+          undefined |
+          {ok, #cert{}}.
+%%
 %% Description: Lookup the trusted cert with Key = {reference(),
 %% serialnumber(), issuer()}.
 %% --------------------------------------------------------------------

--- a/lib/ssl/src/ssl_pkix_db.erl
+++ b/lib/ssl/src/ssl_pkix_db.erl
@@ -306,11 +306,11 @@ add_certs(Cert, Ref, CertsDb) ->
 decode_certs(Ref, DerOrBoth) ->
     try
         {Cert, ErlCert} = case DerOrBoth of
-                             {_, _} ->
-                                  DerOrBoth;
-                             Der ->
-                                 {Der, public_key:pkix_decode_cert(Der, otp)}
-                         end,
+                              #cert{der=Der, otp=Otp} ->
+                                  {Der, Otp};
+                              Der ->
+                                  {Der, public_key:pkix_decode_cert(Der, otp)}
+                          end,
         TBSCertificate = ErlCert#'OTPCertificate'.tbsCertificate,
         SerialNumber = TBSCertificate#'OTPTBSCertificate'.serialNumber,
         Issuer = public_key:pkix_normalize_name(

--- a/lib/ssl/src/tls_dtls_connection.erl
+++ b/lib/ssl/src/tls_dtls_connection.erl
@@ -1017,12 +1017,9 @@ certify_server(#state{handshake_env = #handshake_env{kex_algorithm = KexAlg}} =
 certify_server(#state{static_env = #static_env{cert_db = CertDbHandle,
                                                cert_db_ref = CertDbRef},
 		      session = #session{own_certificates = OwnCerts}} = State, Connection) ->
-    case ssl_handshake:certificate(OwnCerts, CertDbHandle, CertDbRef, server) of
-	Cert = #certificate{} ->
-	    Connection:queue_handshake(Cert, State);
-	Alert = #alert{} ->
-	    throw(Alert)
-    end.
+    Cert = ssl_handshake:certificate(OwnCerts, CertDbHandle, CertDbRef, server),
+    #certificate{} = Cert,  %% Assert
+    Connection:queue_handshake(Cert, State).
 
 key_exchange(#state{static_env = #static_env{role = server}, 
                     handshake_env = #handshake_env{kex_algorithm = rsa}} = State,_) ->

--- a/lib/ssl/test/ssl_cert_SUITE.erl
+++ b/lib/ssl/test/ssl_cert_SUITE.erl
@@ -224,7 +224,8 @@ all_version_tests() ->
      extended_key_usage_client_auth,
      cert_expired,
      no_auth_key_identifier_ext,
-     no_auth_key_identifier_ext_keyEncipherment
+     no_auth_key_identifier_ext_keyEncipherment,
+     duplicate_chain
     ].
 
 init_per_suite(Config) ->


### PR DESCRIPTION
The asn.1 decoding can be expansive avoid it by keeping both der and the
decoded cert available.