### PR TITLE
Add enif_dynamic_resource_call

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -693,8 +693,9 @@ int writeiovec(ErlNifEnv *env, ERL_NIF_TERM term, ERL_NIF_TERM *tail,
 	    <seecref marker="#upgrade"><c>upgrade</c></seecref>,
 	    <seecref marker="#unload"><c>unload</c></seecref>,
 	    <seecref marker="#ErlNifResourceDtor"><c>dtor</c></seecref>,
-	    <seecref marker="#ErlNifResourceDown"><c>down</c></seecref> and
-	    <seecref marker="#ErlNifResourceStop"><c>stop</c></seecref>).
+	    <seecref marker="#ErlNifResourceDown"><c>down</c></seecref>,
+	    <seecref marker="#ErlNifResourceStop"><c>stop</c></seecref> and
+	    <seecref marker="#ErlNifResourceDynCall"><c>dyncall</c></seecref>).
 	    Works like a process bound environment but with a temporary
 	    pseudo process that "terminates" when the callback has
 	    returned. Terms may be created in this environment but they will
@@ -823,12 +824,15 @@ typedef struct {
       <item>
         <code type="none">
 typedef struct {
-    ErlNifResourceDtor* dtor;
-    ErlNifResourceStop* stop;
-    ErlNifResourceDown* down;
+    ErlNifResourceDtor* dtor;       // #1 Destructor
+    ErlNifResourceStop* stop;       // #2 Select stop
+    ErlNifResourceDown* down;       // #3 Monitor down
+    int members;
+    ErlNifResourceDynCall* dyncall; // #4 Dynamic call
 } ErlNifResourceTypeInit;</code>
-        <p>Initialization structure read by <seecref marker="#enif_open_resource_type_x">
-	enif_open_resource_type_x</seecref>.</p>
+        <p>Initialization structure read by
+	<seecref marker="#enif_open_resource_type_x">enif_open_resource_type_x</seecref>
+	<seecref marker="#enif_init_resource_type">enif_init_resource_type</seecref>.</p>
       </item>
       <tag><marker id="ErlNifResourceDtor"/><c>ErlNifResourceDtor</c></tag>
       <item>
@@ -860,6 +864,18 @@ typedef void ErlNifResourceStop(ErlNifEnv* caller_env, void* obj, ErlNifEvent ev
 	  enif_select</seecref>. <c>obj</c> is the resource, <c>event</c> is OS event,
 	  <c>is_direct_call</c> is true if the call is made directly from <c>enif_select</c>
 	  or false if it is a scheduled call (potentially from another thread).</p>
+      </item>
+      <tag><marker id="ErlNifResourceDynCall"/><c>ErlNifResourceDynCall</c></tag>
+      <item>
+        <code type="none">
+typedef void ErlNifResourceDynCall(ErlNifEnv* caller_env, void* obj, void* call_data);</code>
+        <p>
+	  The function prototype of a dynamic resource call function, called by
+	  <seecref marker="#enif_dynamic_resource_call">
+	  enif_dynamic_resource_call</seecref>. Argument <c>obj</c> is the
+	  resource object and <c>call_data</c> is the last argument to
+	  <c>enif_dynamic_resource_call</c> passed through.
+	</p>
       </item>
       <tag><marker id="ErlNifCharEncoding"/><c>ErlNifCharEncoding</c></tag>
       <item>
@@ -1288,6 +1304,38 @@ typedef struct {
         <p>This function is only thread-safe when the emulator with SMP support
           is used. It can only be used in a non-SMP emulator from a NIF-calling
           thread.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name since="OTP @OTP-14753@"><ret>int</ret>
+        <nametext>enif_dynamic_resource_call(ErlNifEnv* caller_env,
+	ERL_NIF_MODULE rt_module, ERL_NIF_MODULE rt_name, ERL_NIF_TERM resource,
+	void* call_data)</nametext>
+      </name>
+      <fsummary>Call a resource in another module.</fsummary>
+      <desc>
+        <p>
+	  Call code of a resource type implemented by another NIF module. The
+	  atoms <c>rt_module</c> and <c>rt_name</c> identifies the resource type
+	  to be called. Argument <c>resource</c> identifies a resource object of
+	  that type.
+	</p>
+	<p>
+	  The callback <seecref marker="#ErlNifResourceDynCall"><c>dyncall</c></seecref>
+	  of the identified resource type will be called with a pointer to the
+	  resource objects <c>obj</c> and the argument <c>call_data</c> passed
+	  through. The <c>call_data</c> argument is typically a pointer to a
+	  struct used to passed both arguments to the <c>dyncall</c> function as
+	  well as results back to the caller.
+	</p>
+	<p>
+	  Returns 0 if the <c>dyncall</c> callback function was called.
+	  Returns a non-zero value if no call was made, which happens if <c>rt_module</c>
+	  and <c>rt_name</c> did not identify a resource type with a
+	  <c>dyncall</c> callback or if <c>resource</c> was not a resource
+	  object of that type.
+	</p>
       </desc>
     </func>
 
@@ -2842,7 +2890,41 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
 	<p>Argument <c>init</c> is a pointer to an
 	  <seecref marker="#ErlNifResourceTypeInit"><c>ErlNifResourceTypeInit</c></seecref>
 	  structure that contains the function pointers for destructor, down and stop callbacks
-	  for the resource type.</p>
+	  for the resource type.
+	</p>
+	<note>
+	  <p>
+	    Only members <c>dtor</c>, <c>down</c> and <c>stop</c> in <seecref
+	    marker="#ErlNifResourceTypeInit"><c>ErlNifResourceTypeInit</c></seecref>
+	    are read by <c>enif_open_resource_type_x</c>. To implement the new
+	    <c>dyncall</c> callback use <seecref
+	    marker="#enif_init_resource_type"><c>enif_init_resource_type</c></seecref>.
+	  </p>
+	</note>
+      </desc>
+    </func>
+
+    <func>
+      <name since="OTP @OTP-14753@"><ret>ErlNifResourceType *</ret>
+        <nametext>enif_init_resource_type(ErlNifEnv* env, const char* name,
+	const ErlNifResourceTypeInit* init,
+        ErlNifResourceFlags flags, ErlNifResourceFlags* tried)</nametext>
+      </name>
+      <fsummary>Create or takeover a resource type.</fsummary>
+      <desc>
+	<p>Same as <seecref marker="#enif_open_resource_type_x"><c>enif_open_resource_type_x</c></seecref>
+	  except it accepts an additional callback function for resource types that are
+	  used together with <seecref marker="#enif_dynamic_resource_call">
+	  <c>enif_dynamic_resource_call</c></seecref>.</p>
+	<p>Argument <c>init</c> is a pointer to an
+	  <seecref marker="#ErlNifResourceTypeInit"><c>ErlNifResourceTypeInit</c></seecref>
+	  structure that contains the callback function pointers <c>dtor</c>,
+	  <c>down</c>, <c>stop</c> and the new <c>dyncall</c>. The struct also
+	  contains the field <c>members</c> that must be set to the number of initialized
+	  callbacks counted from the top of the struct. For example, to
+	  initialize all callbacks including <c>dyncall</c>, <c>members</c>
+	  should be set to 4. All callbacks are optional and may be set to <c>NULL</c>.
+	</p>
       </desc>
     </func>
 

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -56,9 +56,10 @@
 **                enif_vfprintf, enif_vsnprintf, enif_make_map_from_arrays
 ** 2.15: 22.0 ERL_NIF_SELECT_CANCEL, enif_select_(read|write)
 **            enif_term_type
+** 2.16: 24.0 enif_init_resource_type, enif_dynamic_resource_call
 */
 #define ERL_NIF_MAJOR_VERSION 2
-#define ERL_NIF_MINOR_VERSION 15
+#define ERL_NIF_MINOR_VERSION 16
 
 /*
  * WHEN CHANGING INTERFACE VERSION, also replace erts version below with
@@ -69,7 +70,7 @@
  * If you're not on the OTP team, you should use a placeholder like
  * erts-@MyName@ instead.
  */
-#define ERL_NIF_MIN_ERTS_VERSION "erts-10.4"
+#define ERL_NIF_MIN_ERTS_VERSION "erts-@OTP-14753@"
 
 /*
  * The emulator will refuse to load a nif-lib with a major version
@@ -96,7 +97,7 @@ typedef ErlNapiSInt64 ErlNifSInt64;
 typedef ErlNapiUInt ErlNifUInt;
 typedef ErlNapiSInt ErlNifSInt;
 
-#  define ERL_NIF_VM_VARIANT "beam.vanilla" 
+#define ERL_NIF_VM_VARIANT "beam.vanilla"
 typedef ErlNifUInt ERL_NIF_TERM;
 
 typedef ERL_NIF_TERM ERL_NIF_UINT;
@@ -204,11 +205,14 @@ typedef struct enif_resource_type_t ErlNifResourceType;
 typedef void ErlNifResourceDtor(ErlNifEnv*, void*);
 typedef void ErlNifResourceStop(ErlNifEnv*, void*, ErlNifEvent, int is_direct_call);
 typedef void ErlNifResourceDown(ErlNifEnv*, void*, ErlNifPid*, ErlNifMonitor*);
+typedef void ErlNifResourceDynCall(ErlNifEnv*, void* obj, void* call_data);
 
 typedef struct {
     ErlNifResourceDtor* dtor;
     ErlNifResourceStop* stop;  /* at ERL_NIF_SELECT_STOP event */
     ErlNifResourceDown* down;  /* enif_monitor_process */
+    int members;
+    ErlNifResourceDynCall* dyncall;
 } ErlNifResourceTypeInit;
 
 typedef ErlDrvSysInfo ErlNifSysInfo;

--- a/erts/emulator/beam/erl_nif_api_funcs.h
+++ b/erts/emulator/beam/erl_nif_api_funcs.h
@@ -216,6 +216,8 @@ ERL_NIF_API_FUNC_DECL(void,enif_set_pid_undefined,(ErlNifPid* pid));
 ERL_NIF_API_FUNC_DECL(int,enif_is_pid_undefined,(const ErlNifPid* pid));
 
 ERL_NIF_API_FUNC_DECL(ErlNifTermType,enif_term_type,(ErlNifEnv* env, ERL_NIF_TERM term));
+ERL_NIF_API_FUNC_DECL(ErlNifResourceType*,enif_init_resource_type,(ErlNifEnv*, const char* name_str, const ErlNifResourceTypeInit*, ErlNifResourceFlags flags, ErlNifResourceFlags* tried));
+ERL_NIF_API_FUNC_DECL(int,enif_dynamic_resource_call,(ErlNifEnv*, ERL_NIF_TERM mod, ERL_NIF_TERM name, ERL_NIF_TERM rsrc, void* call_data));
 
 /*
 ** ADD NEW ENTRIES HERE (before this comment) !!!
@@ -404,7 +406,7 @@ ERL_NIF_API_FUNC_DECL(ErlNifTermType,enif_term_type,(ErlNifEnv* env, ERL_NIF_TER
 #  define enif_set_pid_undefined ERL_NIF_API_FUNC_MACRO(enif_set_pid_undefined)
 #  define enif_is_pid_undefined ERL_NIF_API_FUNC_MACRO(enif_is_pid_undefined)
 #  define enif_term_type ERL_NIF_API_FUNC_MACRO(enif_term_type)
-
+#  define enif_resource_handshake ERL_NIF_API_FUNC_MACRO(enif_resource_handshake)
 /*
 ** ADD NEW ENTRIES HERE (before this comment)
 */

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -3343,6 +3343,23 @@ static void frenzy_resource_down(ErlNifEnv* env, void* obj, ErlNifPid* pid,
     abort();
 }
 
+static ERL_NIF_TERM dynamic_resource_call(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    const ERL_NIF_TERM rt_module = argv[0];
+    const ERL_NIF_TERM rt_name = argv[1];
+    const ERL_NIF_TERM rsrc = argv[2];
+    int call_data;
+    int ret;
+
+    if (!enif_get_int(env, argv[3], &call_data)) {
+	return enif_make_badarg(env);
+    }
+    ret = enif_dynamic_resource_call(env, rt_module, rt_name, rsrc, &call_data);
+    return enif_make_tuple2(env,
+			    enif_make_int(env, ret),
+			    enif_make_int(env, call_data));
+}
+
 /*********** testing ioq ************/
 
 static void ioq_resource_dtor(ErlNifEnv* env, void* obj) {
@@ -3412,7 +3429,7 @@ static ERL_NIF_TERM ioq(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         ERL_NIF_TERM *elems, tail, list;
         ErlNifEnv *myenv = NULL;
 
-        if (argv >= 3 && enif_is_identical(argv[2], enif_make_atom(env, "use_stack")))
+        if (argc >= 3 && enif_is_identical(argv[2], enif_make_atom(env, "use_stack")))
             iovec = &vec;
         if (argc >= 4 && enif_is_identical(argv[3], enif_make_atom(env, "use_env")))
             myenv = env;
@@ -3763,6 +3780,7 @@ static ErlNifFunc nif_funcs[] =
     {"compare_monitors_nif", 2, compare_monitors_nif},
     {"make_monitor_term_nif", 1, make_monitor_term_nif},
     {"monitor_frenzy_nif", 4, monitor_frenzy_nif},
+    {"dynamic_resource_call", 4, dynamic_resource_call},
     {"whereis_send", 3, whereis_send},
     {"whereis_term", 2, whereis_term},
     {"whereis_thd_lookup", 3, whereis_thd_lookup},
@@ -3777,6 +3795,7 @@ static ErlNifFunc nif_funcs[] =
     {"is_pid_undefined_nif", 1, is_pid_undefined_nif},
     {"compare_pids_nif", 2, compare_pids_nif},
     {"term_type_nif", 1, term_type_nif}
+
 };
 
 ERL_NIF_INIT(nif_SUITE,nif_funcs,load,NULL,upgrade,unload)


### PR DESCRIPTION
As a "safe" way to call NIF code in another module.

Also add `enif_init_resource_type` as a new (and hopefully the final) way to create a resource type with the new callback function `dyncall`.
