### PR TITLE
supervisor: refine error reasons for bad combinations of options

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1444,10 +1444,10 @@ validRestartType(temporary)   -> true;
 validRestartType(transient)   -> true;
 validRestartType(RestartType) -> throw({invalid_restart_type, RestartType}).
 
-validSignificant(true, permanent, _AutoShutdown) ->
-    throw({invalid_significant, true});
 validSignificant(true, _RestartType, never) ->
-    throw({invalid_significant, true});
+    throw({bad_combination, [{auto_shutdown, never}, {significant, true}]});
+validSignificant(true, permanent, _AutoShutdown) ->
+    throw({bad_combination, [{restart, permanent}, {significant, true}]});
 validSignificant(Significant, _RestartType, _AutoShutdown)
   when is_boolean(Significant) ->
     true;


### PR DESCRIPTION
This PR is a follow-up for #4638 (@garazdawi @HansN @IngelaAndin)

It is invalid to combine the child spec flag `significant => true` with the sup flag `auto_shutdown => never` or with the child spec flag `restart => permanent`. The current implementation returns `{invalid_significant, true}` in those cases, which is ambiguous because a similar reason is returned when invalid (ie, non-boolean) values are given for `significant`.

This PR changes and refines the error reasons for the aforementioned cases, as requested in #4638:
* `{bad_combination, [{auto_shutdown, never}, {significant, true}]}` for the first case
* `{bad_combination, [{restart, permanent}, {significant, true}]}` for the second case
* (if both `auto_shutdown => never` _AND_ `restart => permanent` are combined with `significant => true`, the rule for the first case applies)
* `{invalid_significant, Significant}` if a non-boolean value is given in `Significant`, as before

The tuple-list format for describing the options in question has been chosen over the other suggested possibilities (maps or strings) because it seems to be the smallest deviation from the practice overall common in the `supervisor` module, while still containing all the relevant information.