### PR TITLE
supervisor: allow 0 for shutdown

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1455,7 +1455,7 @@ validSignificant(Significant, _RestartType, _AutoShutdown) ->
     throw({invalid_significant, Significant}).
 
 validShutdown(Shutdown)
-  when is_integer(Shutdown), Shutdown > 0 -> true;
+  when is_integer(Shutdown), Shutdown >= 0 -> true;
 validShutdown(infinity)             -> true;
 validShutdown(brutal_kill)          -> true;
 validShutdown(Shutdown)             -> throw({invalid_shutdown, Shutdown}).

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -702,15 +702,6 @@ child_specs(Config) when is_list(Config) ->
     B5 = {child, {m,f,[a]}, permanent, 1000, worker, dy},
     B6 = {child, {m,f,[a]}, permanent, 1000, worker, [1,2,3]},
 
-    %% Correct child specs!
-    %% <Modules> (last parameter in a child spec) can be [] as we do 
-    %% not test code upgrade here.  
-    C1 = {child, {m,f,[a]}, permanent, infinity, supervisor, []},
-    C2 = {child, {m,f,[a]}, permanent, 1000, supervisor, []},
-    C3 = {child, {m,f,[a]}, temporary, 1000, worker, dynamic},
-    C4 = {child, {m,f,[a]}, transient, 1000, worker, [m]},
-    C5 = {child, {m,f,[a]}, permanent, infinity, worker, [m]},
-
     {error, {invalid_mfa,mfa}} = supervisor:start_child(sup_test, B1),
     {error, {invalid_restart_type, prmanent}} =
 	supervisor:start_child(sup_test, B2),
@@ -732,11 +723,22 @@ child_specs(Config) when is_list(Config) ->
     {error, {invalid_module, 1}} =
 	supervisor:check_childspecs([B6]),
 
-    ok = supervisor:check_childspecs([C1]),
-    ok = supervisor:check_childspecs([C2]),
-    ok = supervisor:check_childspecs([C3]),
-    ok = supervisor:check_childspecs([C4]),
-    ok = supervisor:check_childspecs([C5]),
+    lists:foreach(
+	fun (ChildSpec) ->
+	    ok = supervisor:check_childspecs([ChildSpec])
+	end,
+	[
+	    {child, {m, f, [a]}, Restart, Shutdown, Type, Modules}
+	    ||
+		Restart <- [permanent, transient, temporary],
+		Shutdown <- [0, 1000, infinity, brutal_kill],
+		Type <- [supervisor, worker],
+		Modules <- [dynamic, [], [m], [m1, m2]]
+	]
+    ),
+
+    C1 = {child, {m,f,[a]}, permanent, infinity, supervisor, []},
+    C2 = {child, {m,f,[a]}, permanent, 1000, supervisor, []},
 
     {error,{duplicate_child_name,child}} = supervisor:check_childspecs([C1,C2]),
 
@@ -836,7 +838,7 @@ child_specs_map(Config) when is_list(Config) ->
 	    ||
 		AutoShutdown <- [undefined, never, any_significant, all_significant],
 		Restart <- [undefined, permanent, transient, temporary],
-		Shutdown <- [undefined, 1000, infinity, brutal_kill],
+		Shutdown <- [undefined, 0, 1000, infinity, brutal_kill],
 		Type <- [undefined, supervisor, worker],
 		Modules <- [undefined, dynamic, [], [m], [m1, m2]],
 		Significant <- [undefined, true, false],


### PR DESCRIPTION
The shutdown flag of a supervisor child spec is typed (and documented) as `shutdown()`, which in turn is `brutal_kill | timeout()`. The `timeout()` type includes `0`. However, supervisors will reject child specs with a shutdown value of `0`.

This PR is really just plain cosmetics. There probably is no use case for a shutdown value of `0`, at least I can't imagine one. But rejecting `0` violates the spec.

The relevant test cases now include a check for `0` shutdown, too. While I was at it, I remodeled the `child_specs` test case (for the tuple format) a bit to test all possible combinations of valid child spec flags, like the recent `child_specs_map` test case (for the map format) does.