### PR TITLE
erl_docgen: fix ordered list rendering in HTML output

### DIFF
--- a/lib/erl_docgen/priv/xsl/db_html.xsl
+++ b/lib/erl_docgen/priv/xsl/db_html.xsl
@@ -1141,6 +1141,15 @@
 
 
   <!-- Lists -->
+  <xsl:template match="list[@type='ordered']">
+    <xsl:param name="chapnum"/>
+    <ol>
+      <xsl:apply-templates>
+        <xsl:with-param name="chapnum" select="$chapnum"/>
+      </xsl:apply-templates>
+    </ol>
+  </xsl:template>
+
   <xsl:template match="list">
     <xsl:param name="chapnum"/>
     <ul>


### PR DESCRIPTION
The tag `<list type="ordered">` was rendered as an unordered (bulleted instead of numbered) list in the HTML output due to a missing XSL template, as can be seen in [the documentation for the `<list>` tag](http://erlang.org/doc/apps/erl_docgen/block_tags.html#%3Clist%3E---list) itself =^^=