### PR TITLE
Add documentation and some handling about undocumented pki_asn1_type {no_asn1, new_openssh}

### DIFF
--- a/lib/public_key/src/pubkey_ssh.erl
+++ b/lib/public_key/src/pubkey_ssh.erl
@@ -78,6 +78,8 @@ decode(Bin, Type) ->
 %%--------------------------------------------------------------------
 encode(Bin, ssh2_pubkey) ->
     ssh2_pubkey_encode(Bin);
+encode(Bin, new_openssh) ->
+    new_openssh_encode(Bin);
 encode(Entries, Type) ->
     iolist_to_binary(lists:map(fun({Key, Attributes}) ->
 					      do_encode(Type, Key, Attributes)

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -95,7 +95,7 @@
 			       | 'DSAPrivateKey' | 'DSAPublicKey' | 'DHParameter'
                                | 'SubjectPublicKeyInfo' | 'PrivateKeyInfo' | 
 				 'CertificationRequest' | 'CertificateList' |
-				 'ECPrivateKey' | 'EcpkParameters'.
+				 'ECPrivateKey' | 'EcpkParameters' | {no_asn1, new_openssh}.
 -type pem_entry()            :: {pki_asn1_type(), 
 				 der_or_encrypted_der(),
 				 not_encrypted | cipher_info()
@@ -213,7 +213,8 @@ pem_entry_decode({Asn1Type, CryptDer, {Cipher, Salt}} = PemEntry,
 %%--------------------------------------------------------------------
 -spec pem_entry_encode(Asn1Type, Entity) -> pem_entry() when Asn1Type :: pki_asn1_type(),
                                                              Entity :: term() .
-
+pem_entry_encode({no_asn1, new_openssh}, Entity) ->
+  ssh_encode(Entity, new_openssh);
 pem_entry_encode('SubjectPublicKeyInfo', Entity=#'RSAPublicKey'{}) ->
     Der = der_encode('RSAPublicKey', Entity),
     Spki = {'SubjectPublicKeyInfo',

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -1162,7 +1162,7 @@ ssh_decode(SshBin, Type) when is_binary(SshBin),
                         binary()
                             when Type :: ssh2_pubkey | OtherType | InternalType,
                                  OtherType :: public_key | ssh_file(),
-                                 OtherType :: public_key | ssh_file(),
+                                 InternalType :: new_openssh,
                                  InData :: InData_ssh2_pubkey | OtherInData,
                                  InData_ssh2_pubkey :: public_key(),
                                  OtherInData :: [{Key,Attributes}],

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -1159,7 +1159,8 @@ ssh_decode(SshBin, Type) when is_binary(SshBin),
 %%--------------------------------------------------------------------
 -spec ssh_encode(InData, Type) ->
                         binary()
-                            when Type :: ssh2_pubkey | OtherType,
+                            when Type :: ssh2_pubkey | OtherType | InternalType,
+                                 OtherType :: public_key | ssh_file(),
                                  OtherType :: public_key | ssh_file(),
                                  InData :: InData_ssh2_pubkey | OtherInData,
                                  InData_ssh2_pubkey :: public_key(),
@@ -1176,7 +1177,8 @@ ssh_encode(Entries, Type) when is_list(Entries),
 			       Type == openssh_public_key;
 			       Type == auth_keys;
 			       Type == known_hosts;
-			       Type == ssh2_pubkey ->
+			       Type == ssh2_pubkey;
+                               Type == new_openssh ->
     pubkey_ssh:encode(Entries, Type).
 
 %%--------------------------------------------------------------------

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -1161,7 +1161,8 @@ ssh_decode(SshBin, Type) when is_binary(SshBin),
 -spec ssh_encode(InData, Type) ->
                         binary()
                             when Type :: ssh2_pubkey | OtherType | InternalType,
-                                 OtherType :: public_key | ssh_file(),
+                                 OtherType :: PublicKey | ssh_file(),
+                                 PublicKey :: rfc4716_public_key | openssh_public_key,
                                  InternalType :: new_openssh,
                                  InData :: InData_ssh2_pubkey | OtherInData,
                                  InData_ssh2_pubkey :: public_key(),


### PR DESCRIPTION
Hello,
Here was the old way to do fully encode and decode of key genrated by `ssh-keygen`
Old way to treat complete path
```elixir
algo = :ed25519
type = :eddsa
{pub, priv} = :crypto.generate_key(type, algo)
special = :pubkey_ssh.new_openssh_encode({:ed_pri, algo, pub, priv})
 :public_key.pem_encode([{{:no_asn1, :new_openssh}, (special), :not_encrypted}])
```

New way to treat complete path
```elixir
algo = :ed25519
type = :eddsa
pki_asn1_type = {:no_asn1, :new_openssh}
{pub, priv} = :crypto.generate_key(type, algo)
special = :public_key.pem_entry_encode(pki_asn1_type, {:ed_pri, algo, pub, priv})
:public_key.pem_encode([{{:no_asn1, :new_openssh}, (special), :not_encrypted}])
```

You should have a carefull look to these changes as I am not very familiar with erlang