### PR TITLE
Add error info to io:format and friends

### DIFF
--- a/lib/stdlib/src/erl_error.erl
+++ b/lib/stdlib/src/erl_error.erl
@@ -360,9 +360,9 @@ format_arg_errors(ArgNum, [_|As], ErrorMap) ->
             [FirstLine | Lines] = string:lexemes(Err, "\r\n"),
             ArgStr = io_lib:format(<<"*** argument ~w: ">>, [ArgNum]),
             [io_lib:format(<<"~ts~ts">>, [ArgStr, FirstLine])] ++
-                [io_lib:format(<<"~*ts~ts">>,[string:length(ArgStr), "", Line]) ||
-                    Line <- Lines] ++
-             format_arg_errors(ArgNum + 1, As, ErrorMap);
+                [io_lib:format(<<"~*ts~ts">>,[string:length(ArgStr), "", Line])
+                 || Line <- Lines] ++
+                format_arg_errors(ArgNum + 1, As, ErrorMap);
         #{} ->
             format_arg_errors(ArgNum + 1, As, ErrorMap)
     end;

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -4198,6 +4198,10 @@ args_list(_Other) -> maybe.
 args_length({cons,_A,_H,T}) -> 1 + args_length(T);
 args_length({nil,_A}) -> 0.
 
+check_format_string(Fmt) when is_atom(Fmt) ->
+    check_format_string(atom_to_list(Fmt));
+check_format_string(Fmt) when is_binary(Fmt) ->
+    check_format_string(binary_to_list(Fmt));
 check_format_string(Fmt) ->
     extract_sequences(Fmt, []).
 

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -4221,6 +4221,7 @@ extract_sequence(1, [$*|Fmt], Need) ->
     extract_sequence(2, Fmt, [int|Need]);
 extract_sequence(1, Fmt, Need) ->
     extract_sequence(2, Fmt, Need);
+
 extract_sequence(2, [$.,C|Fmt], Need) when C >= $0, C =< $9 ->
     extract_sequence_digits(2, Fmt, Need);
 extract_sequence(2, [$.,$*|Fmt], Need) ->
@@ -4229,12 +4230,14 @@ extract_sequence(2, [$.|Fmt], Need) ->
     extract_sequence(3, Fmt, Need);
 extract_sequence(2, Fmt, Need) ->
     extract_sequence(4, Fmt, Need);
+
 extract_sequence(3, [$.,$*|Fmt], Need) ->
     extract_sequence(4, Fmt, [int|Need]);
 extract_sequence(3, [$.,_|Fmt], Need) ->
     extract_sequence(4, Fmt, Need);
 extract_sequence(3, Fmt, Need) ->
     extract_sequence(4, Fmt, Need);
+
 extract_sequence(4, [$t, $l | Fmt], Need) ->
     extract_sequence(4, [$l, $t | Fmt], Need);
 extract_sequence(4, [$t, $c | Fmt], Need) ->
@@ -4265,6 +4268,7 @@ extract_sequence(4, [$l, C | _Fmt], _Need) ->
     {error,"invalid control ~l" ++ [C]};
 extract_sequence(4, Fmt, Need) ->
     extract_sequence(5, Fmt, Need);
+
 extract_sequence(5, [C|Fmt], Need0) ->
     case control_type(C, Need0) of
         error -> {error,"invalid control ~" ++ [C]};
@@ -4287,10 +4291,10 @@ control_type($w, Need) -> [term|Need];
 control_type($p, Need) -> [term|Need];
 control_type($W, Need) -> [int,term|Need]; %% Note: reversed
 control_type($P, Need) -> [int,term|Need]; %% Note: reversed
-control_type($b, Need) -> [term|Need];
-control_type($B, Need) -> [term|Need];
-control_type($x, Need) -> [string,term|Need]; %% Note: reversed
-control_type($X, Need) -> [string,term|Need]; %% Note: reversed
+control_type($b, Need) -> [int|Need];
+control_type($B, Need) -> [int|Need];
+control_type($x, Need) -> [string,int|Need]; %% Note: reversed
+control_type($X, Need) -> [string,int|Need]; %% Note: reversed
 control_type($+, Need) -> [term|Need];
 control_type($#, Need) -> [term|Need];
 control_type($n, Need) -> Need;

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -28,6 +28,8 @@
 -export([is_guard_expr/1]).
 -export([bool_option/4,value_option/3,value_option/7]).
 
+-export([check_format_string/1]).
+
 -export_type([error_info/0, error_description/0]).
 
 -import(lists, [all/2,any/2,

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -44,6 +44,8 @@ format_error(_Reason, [{M,F,As,Info}|_]) ->
                   format_re_error(F, As, Cause);
               unicode ->
                   format_unicode_error(F, As);
+              io ->
+                  format_io_error(F, As, Cause);
               _ ->
                   []
           end,
@@ -387,6 +389,181 @@ unicode_encoding(Enc) ->
             bad_encoding
     end.
 
+
+%% Rewrite fwrite to format and add info if call has an
+%% explicit Io Device as first argument.
+format_io_error(fwrite, Args, Cause) ->
+    format_io_error(format, Args, Cause);
+format_io_error(format = Fn, [_Io, _Fmt, _Args] = Args, Cause) ->
+    format_io_error(Fn, Args, Cause, true);
+format_io_error(put_chars = Fn, [_Io, _Chars] = Args, Cause) ->
+    format_io_error(Fn, Args, Cause, true);
+format_io_error(put_chars = Fn, [_Io, _Encoding, _Chars] = Args, Cause) ->
+    format_io_error(Fn, Args, Cause, true);
+format_io_error(nl = Fn, [_Io] = Args, Cause) ->
+    format_io_error(Fn, Args, Cause, true);
+format_io_error(write = Fn, [_Io, _Term] = Args, Cause) ->
+    format_io_error(Fn, Args, Cause, true);
+format_io_error(Fn, Args, Cause) ->
+    format_io_error(Fn, Args, Cause, false).
+
+%% The cause should always be wrapped in either `io` or
+%% `device`. If it is wrapped in `io` we know that the
+%% error originated in the io module. If it is wrapped
+%% in `device`, the error came from the called io device.
+
+%% arguments, whereis(Io) failed
+format_io_error(_, _, {io, arguments}, true) ->
+    [device_arguments];
+format_io_error(_, _, {io, arguments}, false) ->
+    [{general,device_arguments}];
+%% terminated, monitor(Io) failed
+format_io_error(_, _, {io, terminated}, true) ->
+    [device_terminated];
+format_io_error(_, _, {io, terminated}, false) ->
+    [{general,device_terminated}];
+%% Strip the wrapping as we no longer need it
+format_io_error(Fn, Args, {device, Cause}, HasDevice) ->
+    format_io_error_cause(Fn, Args, Cause, HasDevice).
+
+%% Could not translate from unicode to latin1
+format_io_error_cause(_, _, {no_translation, In, Out}, true) ->
+    [{no_translation, In, Out}];
+format_io_error_cause(_, _, {no_translation, In, Out}, false) ->
+    [{general,{no_translation, In, Out}}];
+format_io_error_cause(format, Args, Cause, HasDevice) ->
+    case maybe_posix_message(Cause, HasDevice) of
+        unknown ->
+            if
+                HasDevice ->
+                    [[]] ++ check_io_format(tl(Args), Cause);
+                not HasDevice ->
+                    check_io_format(Args, Cause)
+            end;
+        PosixError ->
+            PosixError
+    end;
+format_io_error_cause(put_chars, Args, Cause, HasDevice) ->
+    Data = if HasDevice -> hd(tl(Args)); not HasDevice -> hd(Args) end,
+    case maybe_posix_message(Cause, HasDevice) of
+        unknown ->
+            [[] || HasDevice] ++
+                case unicode_char_data(Data) of
+                    [] -> [{general,{unknown_error,Cause}}];
+                    InvalidData ->
+                        [InvalidData]
+                end;
+        PosixError ->
+            PosixError ++ [unicode_char_data(Data)]
+    end;
+format_io_error_cause(Fn, _Args, Cause, HasDevice)
+  when Fn =:= write; Fn =:= nl ->
+    case maybe_posix_message(Cause, HasDevice) of
+        unknown ->
+            [{general,{unknown_error,Cause}}];
+        PosixError ->
+            PosixError
+    end;
+format_io_error_cause(_, _, _, _HasDevice) ->
+    [].
+
+maybe_posix_message(Cause, HasDevice) ->
+    case erl_posix_msg:message(Cause) of
+        "unknown POSIX error" ->
+            unknown;
+        PosixStr when HasDevice ->
+            [io_lib:format("~ts (~p)",[PosixStr, Cause])];
+        PosixStr when not HasDevice ->
+            [{general,io_lib:format("~ts (~p)",[PosixStr, Cause])}]
+    end.
+
+check_io_format([Fmt], Cause) ->
+    check_io_format([Fmt, []], Cause);
+check_io_format([Fmt, Args], Cause) ->
+    case is_io_format(Fmt) of
+        false ->
+            [invalid_format, must_be_list(Args)] ++
+                case (is_pid(Fmt) or is_atom(Fmt)) and is_io_format(Args) of
+                    true ->
+                        %% The user seems to have called io:format(Dev,"string").
+                        [{general,missing_argument_list}];
+                    false ->
+                        []
+                end;
+        _ when not is_list(Args) ->
+                [[],must_be_list(Args)];
+        true ->
+            case erl_lint:check_format_string(Fmt) of
+                {error,S} ->
+                    [io_lib:format("format string invalid (~ts)",[S])];
+                {ok,ArgTypes} when length(ArgTypes) =/= length(Args) ->
+                    [<<"wrong number of arguments">>] ++
+                        %% The user seems to have called io:format(user,"string")
+                        [{general,missing_argument_list} || is_atom(Fmt)];
+                {ok,ArgTypes} ->
+                    case check_io_arguments(ArgTypes, Args) of
+                        [] when Cause =:= format ->
+                            [format_failed];
+                        [] ->
+                            try io_lib:format(Fmt, Args) of
+                                _ ->
+                                    [io_lib:format("unknown error: ~p",[Cause])]
+                            catch _:_ ->
+                                    [format_failed]
+                            end;
+                        ArgErrors ->
+                            ArgErrors
+                    end
+            end
+    end.
+
+is_io_format(Fmt) when is_list(Fmt) ->
+    try lists:all(fun erlang:is_integer/1, Fmt) of
+        Res -> Res
+    catch _:_ ->
+            false
+    end;
+is_io_format(Fmt) when is_atom(Fmt); is_binary(Fmt) ->
+    true;
+is_io_format(_Fmt) ->
+    false.
+
+check_io_arguments(Types, Args) ->
+    case check_io_arguments(Types, Args, 1) of
+        [] ->
+            [];
+        Checks ->
+            [[],lists:join("\n",Checks)]
+    end.
+
+check_io_arguments([], [], _No) ->
+    [];
+check_io_arguments([Type|TypeT], [Arg|ArgT], No) ->
+    case Type of
+        float when is_float(Arg) ->
+            check_io_arguments(TypeT, ArgT, No+1);
+        int when is_integer(Arg) ->
+            check_io_arguments(TypeT, ArgT, No+1);
+        term ->
+            check_io_arguments(TypeT, ArgT, No+1);
+        string when is_atom(Arg); is_binary(Arg) ->
+            check_io_arguments(TypeT, ArgT, No+1);
+        string when is_list(Arg) ->
+            try unicode:characters_to_binary(Arg) of
+                _ ->
+                    check_io_arguments(TypeT, ArgT, No+1)
+            catch _:_ ->
+                    [io_lib:format("element ~B must be of type ~p", [No, string]) |
+                    check_io_arguments(TypeT, ArgT, No+1)]
+            end;
+        int ->
+            [io_lib:format("element ~B must be of type ~p", [No, integer]) |
+             check_io_arguments(TypeT, ArgT, No+1)];
+        _ when Type =:= float; Type =:= string ->
+            [io_lib:format("element ~B must be of type ~p", [No, Type]) |
+             check_io_arguments(TypeT, ArgT, No+1)]
+    end.
+
 format_ets_error(delete_object, Args, Cause) ->
     format_object(Args, Cause);
 format_ets_error(give_away, [_Tab,Pid,_Gift]=Args, Cause) ->
@@ -683,6 +860,8 @@ is_update_op(Incr) ->
 
 format_error_map([""|Es], ArgNum, Map) ->
     format_error_map(Es, ArgNum + 1, Map);
+format_error_map([{general, E}|Es], ArgNum, Map) ->
+    format_error_map(Es, ArgNum, Map#{ general => expand_error(E)});
 format_error_map([E|Es], ArgNum, Map) ->
     format_error_map(Es, ArgNum + 1, Map#{ArgNum => expand_error(E)});
 format_error_map([], _, Map) ->
@@ -813,14 +992,27 @@ expand_error(counter_not_integer) ->
     <<"the value in the given position, in the object, is not an integer">>;
 expand_error(dead_process) ->
     <<"the pid refers to a terminated process">>;
+expand_error(device_arguments) ->
+    <<"the device does not exist">>;
+expand_error(device_terminated) ->
+    <<"the device has terminated">>;
 expand_error(domain_error) ->
     <<"is outside the domain for this function">>;
 expand_error(empty_binary) ->
     <<"a zero-sized binary is not allowed">>;
 expand_error(empty_tuple) ->
     <<"is an empty tuple">>;
+expand_error(format_failed) ->
+    <<"failed to format string">>;
+expand_error(invalid_format) ->
+    <<"not a valid format string">>;
+expand_error(missing_argument_list) ->
+    <<"possibly missing argument list">>;
 expand_error(name_already_exists) ->
     <<"table name already exists">>;
+expand_error({no_translation, In, Out}) ->
+    unicode:characters_to_binary(
+      io_lib:format("device failed to transcode string from ~p to ~p", [In, Out]));
 expand_error(not_atom) ->
     <<"not an atom">>;
 expand_error(not_binary) ->
@@ -861,6 +1053,9 @@ expand_error(range) ->
     <<"out of range">>;
 expand_error(same_as_keypos) ->
     <<"the position is the same as the key position">>;
+expand_error({unknown_error,Cause}) ->
+    unicode:characters_to_binary(
+      io_lib:format("unknown error: ~p", [Cause]));
 expand_error(update_op_range) ->
     <<"the position in the update operation is out of range">>;
 expand_error(Other) ->

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -472,9 +472,9 @@ maybe_posix_message(Cause, HasDevice) ->
         "unknown POSIX error" ->
             unknown;
         PosixStr when HasDevice ->
-            [io_lib:format("~ts (~p)",[PosixStr, Cause])];
+            [io_lib:format("~ts (~tp)",[PosixStr, Cause])];
         PosixStr when not HasDevice ->
-            [{general,io_lib:format("~ts (~p)",[PosixStr, Cause])}]
+            [{general,io_lib:format("~ts (~tp)",[PosixStr, Cause])}]
     end.
 
 check_io_format([Fmt], Cause) ->
@@ -507,7 +507,7 @@ check_io_format([Fmt, Args], Cause) ->
                         [] ->
                             try io_lib:format(Fmt, Args) of
                                 _ ->
-                                    [io_lib:format("unknown error: ~p",[Cause])]
+                                    [{general,{unknown_error,Cause}}]
                             catch _:_ ->
                                     [format_failed]
                             end;
@@ -1055,7 +1055,7 @@ expand_error(same_as_keypos) ->
     <<"the position is the same as the key position">>;
 expand_error({unknown_error,Cause}) ->
     unicode:characters_to_binary(
-      io_lib:format("unknown error: ~p", [Cause]));
+      io_lib:format("unknown error: ~tp", [Cause]));
 expand_error(update_op_range) ->
     <<"the position in the update operation is out of range">>;
 expand_error(Other) ->

--- a/lib/stdlib/src/io.erl
+++ b/lib/stdlib/src/io.erl
@@ -49,25 +49,63 @@
 -type location() :: erl_anno:location().
 
 %%-------------------------------------------------------------------------
+%% Needs to be inlined for error_info to be correct
+-compile({inline,[o_request/2]}).
+o_request(Function, OrigArgs) ->
+    {Io, Request} =
+        if
+            Function =:= format; Function =:= fwrite ->
+                case OrigArgs of
+                    [Format] ->
+                        {default_output(), {format, Format, []}};
+                    [Format, Args] ->
+                        {default_output(), {format, Format, Args}};
+                    [D, Format, Args] ->
+                        {D, {format, Format, Args}}
+                end;
+            Function =:= put_chars ->
+                case OrigArgs of
+                    [Chars] ->
+                        {default_output(), {put_chars, unicode, Chars}};
+                    [D, Chars] ->
+                        {D, {put_chars, unicode, Chars}};
+                    [D, Encoding, Chars] ->
+                        {D, {put_chars, Encoding, Chars}}
+                end;
+            Function =:= nl ->
+                case OrigArgs of
+                    [] ->
+                        {default_output(), nl};
+                    [D] ->
+                        {D, nl}
+                end;
+            Function =:= write ->
+                case OrigArgs of
+                    [Term] ->
+                        {default_output(), {write, Term}};
+                    [D, Term] ->
+                        {D, {write, Term}}
+                end
+        end,
+    ErrorRef = make_ref(),
+    case request(Io, Request, ErrorRef) of
+        {ErrorRef, Reason} ->
+            %% We differentiate between errors that are created by this module
+            erlang:error(conv_reason(Reason), OrigArgs,
+                         [{error_info,#{cause => {?MODULE, Reason},
+                                        module => erl_stdlib_errors}}]);
+        {error, Reason} ->
+            %% and the errors we get from the Device
+            erlang:error(conv_reason(Reason), OrigArgs,
+                         [{error_info,#{cause => {device, Reason},
+                                        module => erl_stdlib_errors}}]);
+        Other ->
+            Other
+    end.
 
 %%
 %% User interface.
 %%
-
-%% Writing and reading characters.
-
-to_tuple(T) when is_tuple(T) -> T;
-to_tuple(T) -> {T}.
-
-o_request(Io, Request, Func) ->
-    case request(Io, Request) of
-	{error, Reason} ->
-	    [_Name | Args] = tuple_to_list(to_tuple(Request)),
-	    {'EXIT',{get_stacktrace,[_Current|Mfas]}} = (catch erlang:error(get_stacktrace)),
-	    erlang:raise(error, conv_reason(Func, Reason), [{io, Func, [Io | Args]}|Mfas]);
-	Other ->
-	    Other
-    end.
 
 %% Request what the user considers printable characters
 -spec printable_range() -> 'unicode' | 'latin1'.
@@ -79,34 +117,25 @@ printable_range() ->
       CharData :: unicode:chardata().
 
 put_chars(Chars) ->
-    put_chars(default_output(), Chars).
+    o_request(?FUNCTION_NAME, [Chars]).
 
 -spec put_chars(IoDevice, CharData) -> 'ok' when
       IoDevice :: device(),
       CharData :: unicode:chardata().
 
 put_chars(Io, Chars) ->
-    put_chars(Io, unicode, Chars).
-
-%% This function is here to make the erlang:raise in o_request actually raise to
-%% a valid function.
--spec put_chars(IoDevice, Encoding, CharData) -> 'ok' when
-      IoDevice :: device(),
-      Encoding :: unicode,
-      CharData :: unicode:chardata().
-put_chars(Io, Encoding, Chars) ->
-    o_request(Io, {put_chars,Encoding,Chars}, put_chars).
+    o_request(?FUNCTION_NAME, [Io, Chars]).
 
 -spec nl() -> 'ok'.
 
 nl() ->
-    nl(default_output()).
+    o_request(?FUNCTION_NAME, []).
 
 -spec nl(IoDevice) -> 'ok' when
       IoDevice :: device().
 
 nl(Io) ->
-    o_request(Io, nl, nl).
+    o_request(?FUNCTION_NAME, [Io]).
 
 -spec columns() -> {'ok', pos_integer()} | {'error', 'enotsup'}.
 
@@ -222,14 +251,14 @@ setopts(Io, Opts) ->
       Term :: term().
 
 write(Term) ->
-    write(default_output(), Term).
+    o_request(?FUNCTION_NAME, [Term]).
 
 -spec write(IoDevice, Term) -> 'ok' when
       IoDevice :: device(),
       Term :: term().
 
 write(Io, Term) ->
-    o_request(Io, {write,Term}, write).
+    o_request(?FUNCTION_NAME, [Io, Term]).
 
 
 -spec read(Prompt) -> Result when
@@ -304,10 +333,10 @@ read(Io, Prompt, Pos0, Options) ->
 
 %% Formatted writing and reading.
 
-conv_reason(_, arguments) -> badarg;
-conv_reason(_, terminated) -> terminated;
-conv_reason(_, {no_translation,_,_}) -> no_translation;
-conv_reason(_, _Reason) -> badarg.
+conv_reason(arguments) -> badarg;
+conv_reason(terminated) -> terminated;
+conv_reason({no_translation,_,_}) -> no_translation;
+conv_reason(_Reason) -> badarg.
 
 -type format() :: atom() | string() | binary().
 
@@ -315,14 +344,14 @@ conv_reason(_, _Reason) -> badarg.
       Format :: format().
 
 fwrite(Format) ->
-    format(Format).
+    o_request(?FUNCTION_NAME, [Format]).
 
 -spec fwrite(Format, Data) -> 'ok' when
       Format :: format(),
       Data :: [term()].
 
 fwrite(Format, Args) ->
-    format(Format, Args).
+    o_request(?FUNCTION_NAME, [Format, Args]).
 
 -spec fwrite(IoDevice, Format, Data) -> 'ok' when
       IoDevice :: device(),
@@ -330,7 +359,7 @@ fwrite(Format, Args) ->
       Data :: [term()].
 
 fwrite(Io, Format, Args) ->
-    format(Io, Format, Args).
+    o_request(?FUNCTION_NAME, [Io, Format, Args]).
 
 -spec fread(Prompt, Format) -> Result when
       Prompt :: prompt(),
@@ -353,16 +382,15 @@ fread(Io, Prompt, Format) ->
 
 -spec format(Format) -> 'ok' when
       Format :: format().
-
 format(Format) ->
-    format(Format, []).
+    o_request(?FUNCTION_NAME, [Format]).
 
 -spec format(Format, Data) -> 'ok' when
       Format :: format(),
       Data :: [term()].
 
 format(Format, Args) ->
-    format(default_output(), Format, Args).
+    o_request(?FUNCTION_NAME, [Format, Args]).
 
 -spec format(IoDevice, Format, Data) -> 'ok' when
       IoDevice :: device(),
@@ -370,7 +398,7 @@ format(Format, Args) ->
       Data :: [term()].
 
 format(Io, Format, Args) ->
-    o_request(Io, {format,Format,Args}, format).
+    o_request(?FUNCTION_NAME, [Io, Format, Args]).
 
 %% Scanning Erlang code.
 
@@ -554,19 +582,21 @@ parse_erl_form(Io, Prompt, Pos0, Options) ->
 request(Request) ->
     request(default_output(), Request).
 
-request(standard_io, Request) ->
-    request(group_leader(), Request);
-request(Pid, Request) when is_pid(Pid) ->
-    execute_request(Pid, io_request(Pid, Request));
-request(Name, Request) when is_atom(Name) ->
+request(Name, Request) ->
+    request(Name, Request, error).
+request(standard_io, Request, ErrorTag) ->
+    request(group_leader(), Request, ErrorTag);
+request(Pid, Request, ErrorTag) when is_pid(Pid) ->
+    execute_request(Pid, io_request(Pid, Request), ErrorTag);
+request(Name, Request, ErrorTag) when is_atom(Name) ->
     case whereis(Name) of
 	undefined ->
-	    {error, arguments};
+	    {ErrorTag, arguments};
 	Pid ->
-	    request(Pid, Request)
+	    request(Pid, Request, ErrorTag)
     end.
 
-execute_request(Pid, {Convert,Converted}) ->
+execute_request(Pid, {Convert,Converted}, ErrorTag) ->
     Mref = erlang:monitor(process, Pid),
     Pid ! {io_request,self(),Mref,Converted},
 
@@ -584,7 +614,7 @@ execute_request(Pid, {Convert,Converted}) ->
 		{'EXIT', Pid, _What} -> true
 	    after 0 -> true
 	    end,
-	    {error,terminated}
+	    {ErrorTag,terminated}
     end.
 
 requests(Requests) ->				%Requests as atomic action
@@ -594,7 +624,7 @@ requests(standard_io, Requests) ->              %Requests as atomic action
     requests(group_leader(), Requests);
 requests(Pid, Requests) when is_pid(Pid) ->
     {Convert, Converted} = io_requests(Pid, Requests),
-    execute_request(Pid,{Convert,{requests,Converted}});
+    execute_request(Pid,{Convert,{requests,Converted}},error);
 requests(Name, Requests) when is_atom(Name) ->
     case whereis(Name) of
 	undefined ->

--- a/lib/stdlib/test/error_info_lib.erl
+++ b/lib/stdlib/test/error_info_lib.erl
@@ -90,7 +90,7 @@ eval_bif_error(F, Args, Opts, T, Module, Errors0) ->
             AllowRename = lists:member(allow_rename, Opts),
             SF = fun(Mod, _, _) -> Mod =:= test_server end,
             Str = erl_error:format_exception(error, Reason, Stk, #{stack_trim_fun => SF}),
-            BinStr = iolist_to_binary(Str),
+            BinStr = unicode:characters_to_binary(Str),
             ArgStr = lists:join(", ", [io_lib:format("~p", [A]) || A <- Args]),
             io:format("\n~p:~p(~s)\n~ts", [Module,F,ArgStr,BinStr]),
 
@@ -118,7 +118,7 @@ eval_bif_error(F, Args, Opts, T, Module, Errors0) ->
                             false ->
                                 lists:foldl(
                                   fun(Match, Errors) ->
-                                          case re:run(BinStr, Match, [global]) of
+                                          case re:run(BinStr, Match, [global, unicode]) of
                                               {match,[_]} ->
                                                   Errors;
                                               {match,_} ->

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -33,7 +33,7 @@
 	 maps/1, coverage/1, otp_14178_unicode_atoms/1, otp_14175/1,
          otp_14285/1, limit_term/1, otp_14983/1, otp_15103/1, otp_15076/1,
          otp_15159/1, otp_15639/1, otp_15705/1, otp_15847/1, otp_15875/1,
-				 github_4801/1]).
+         error_info/1,github_4801/1]).
 
 -export([pretty/2, trf/3]).
 
@@ -66,7 +66,7 @@ all() ->
      io_lib_width_too_small, io_with_huge_message_queue,
      format_string, maps, coverage, otp_14178_unicode_atoms, otp_14175,
      otp_14285, limit_term, otp_14983, otp_15103, otp_15076, otp_15159,
-     otp_15639, otp_15705, otp_15847, otp_15875, github_4801].
+     otp_15639, otp_15705, otp_15847, otp_15875, github_4801, error_info].
 
 %% Error cases for output.
 error_1(Config) when is_list(Config) ->
@@ -2949,5 +2949,111 @@ otp_15875(_Config) ->
     S = io_lib:format("~tp", [[{0, [<<"00">>]}]], [{chars_limit, 18}]),
     "[{0,[<<48,...>>]}]" = lists:flatten(S).
 
+
 github_4801(_Config) ->
 	  <<"{[81.6]}">> = iolist_to_binary(io_lib:format("~p", [{[81.6]}], [{chars_limit,40}])).
+
+error_info(_Config) ->
+
+    FullDev =
+        fun() ->
+                {ok, Dev} = file:open("/dev/full",[read, write]),
+                Dev
+        end,
+
+    Latin1Dev = fun() ->
+                        {ok, Dev} = file:open("/dev/full",[read, write,
+                                                           {encoding, latin1}]),
+                        Dev
+                end,
+
+    DeadDev = spawn(fun() -> ok end),
+
+    UserDev = fun() -> whereis(user) end,
+    FileDev = FullDev,
+    TestServerDev = fun() -> group_leader() end,
+    ApplicationMasterDev =
+        fun() ->
+                {_,GL} = process_info(whereis(kernel_sup),group_leader),
+                GL
+        end,
+    GroupDev = TestServerDev,
+    StandardError = fun() -> whereis(standard_error) end,
+
+    L = [
+         {put_chars,[DeadDev,"test"],[{1,"terminated"}]},
+         {put_chars,["test"],[{gl,DeadDev},{general,"terminated"}]},
+         {put_chars,[?MODULE,"test"],[{1,"does not exist"}]},
+         {put_chars,[FullDev(),"test"], [{1,"no space left on device"}]},
+         {put_chars,["test"], [{gl,FullDev()},{general,"no space left on device"}]},
+         {put_chars,[Latin1Dev(),"Спутник-1"], [{1,"transcode"}]},
+         {put_chars,[a], [{1,"not valid character data"}]},
+
+         {write,[DeadDev,"test"],[{1,"terminated"}]},
+         {write,["test"],[{gl,DeadDev},{general,"terminated"}]},
+         {write,[?MODULE,"test"],[{1,"does not exist"}]},
+         {write,[FullDev(),"test"], [{1,"no space left on device"}]},
+         {write,["test"], [{gl,FullDev()},{general,"no space left on device"}]},
+
+         {nl,[DeadDev],[{1,"terminated"}]},
+         {nl,[?MODULE],[{1,"does not exist"}]},
+         {nl,[],[{gl,DeadDev},{general,"terminated"}]},
+         {nl,[FullDev()], [{1,"no space left on device"}]},
+         {nl,[], [{gl,FullDev()},{general,"no space left on device"}]},
+
+         [[{Format,[DeadDev,"test",[]],   [{1,"terminated"}]},
+           {Format,["test",[{gl,DeadDev},  {general,"terminated"}]]},
+           {Format,[?MODULE,"test",[]],   [{1,"does not exist"}]},
+           {Format,[FullDev(),"test",[]], [{1,"no space left on device"}]},
+           {Format,["test"], [{gl,FullDev()},{general,"no space left on device"}]},
+           {Format,[standard_io,"test"],  [{1,"wrong number of arguments"},
+                                           {general,"possibly missing argument list"}]},
+
+           %% Test a latin1 device
+           {Format,[Latin1Dev(), "~ts", [<<"Спутник-1"/utf8>>]],[{1,"transcode"}]},
+           {Format,["~ts", [<<"Спутник-1"/utf8>>]],[{gl,Latin1Dev()},{general,"transcode"}]},
+
+           %% The format error is reported differently
+           %% depending on the current group_leader.
+           %% The different group leaders we test are:
+           %%  * file_io_server
+           %%  * standard_error
+           %%  * test_server_gl
+           %%  * user
+           %%  * application_master
+           %%  * ssh_cli (TODO)
+           %%  * eunit (TODO)
+           %%  * group (TODO)
+           [ [{Format,[Device(),make_ref(),[]],    [{2,"format string"}]},
+              {Format,[Device(),"~p",make_ref()],  [{3, "not a list"}]},
+              {Format,[make_ref(),[]],[{gl,Device()},{1,"format string"}]},
+              {Format,["~p",make_ref()],[{gl,Device()},{2, "not a list"}]}]
+             || Device <- [UserDev, FileDev, TestServerDev, StandardError,
+                           GroupDev, ApplicationMasterDev]],
+
+           %% Test number of arguments
+           {Format,["~p",["Sputnik-1","Laika"]],[{1,"wrong number of arguments"}]},
+           {Format,[standard_io, "~p",["Sputnik-1","Laika"]],[{2,"wrong number of arguments"}]},
+
+           %% Test different formatting strings
+           {Format,["~B",["Sputnik-1"]],[{2,"1 must be of type integer"}]},
+           {Format,[standard_io, "~B",["Sputnik-1"]],[{3,"1 must be of type integer"}]},
+           {Format,["~b",["Sputnik-1"]],[{2,"1 must be of type integer"}]},
+           {Format,["~*b",["Sputnik-1",16]],[{2,"1 must be of type integer"}]},
+           {Format,["~*f",[1.0,1]],[{2,"1 must be of type integer\\n.*2 must be of type float"}]},
+           {Format,["~1.*f",[1.0,1]],[{2,"1 must be of type integer\\n.*2 must be of type float"}]},
+           {Format,["~*.*f",[a,b,c]],[{2,"1 must be of type integer\\n.*"
+                                       "2 must be of type integer\\n.*"
+                                       "3 must be of type float"}]},
+           {Format,["~s",["Спутник-1"]],[{1,"failed to format string"}]},
+           {Format,["~s",[1]],[{2,"1 must be of type string"}]},
+           {Format,["~s~s",[a,1]],[{2,"2 must be of type string"}]},
+           {Format,["~s",[[a]]],[{2,"1 must be of type string"}]}] || Format <- [format,fwrite]]
+
+        ],
+
+    try
+        error_info_lib:test_error_info(io, lists:flatten(L), [allow_nyi])
+    after
+        dbg:stop_clear()
+    end.


### PR DESCRIPTION
This PR adds error information to `io:format`, `io:fwrite`, `io:put_chars`, `io:write` and `io:nl` and is aimed to be released in OTP-24.1.

Initially, this was triggered by `io:format(FileDev,"test",[])` trying to write to a full disk and io:format then only throws a `badarg` error. Now it throws this:

```erlang
1> proc_lib:spawn(fun() -> io:format(FullDevice,"test",[]) end).
<0.87.0>
=CRASH REPORT==== 21-Apr-2021::14:26:14.701154 ===
  crasher:
    initial call: erl_eval:'-expr/5-fun-3-'/0
....
    exception error: bad argument
      in function  io:format/3
         called as io:format(<0.86.0>,"test",[])
         *** argument 1: no space left on device (enospc)
    ancestors: [<0.84.0>]
....
```

while at it we decided to implement error info for many more of the io:format errors. For example:

```erlang
1> io:format("as",[a]).
** exception error: bad argument
     in function  io:format/2
        called as io:format("as",[a])
        *** argument 1: wrong number of arguments
2> io:format("~p",[]).
** exception error: bad argument
     in function  io:format/2
        called as io:format("~p",[])
        *** argument 1: wrong number of arguments
3> io:format("~t",[]).
** exception error: bad argument
     in function  io:format/2
        called as io:format("~t",[])
        *** argument 1: format string invalid (invalid control ~t)
4> io:format("~.*f",[1.0,1]).
** exception error: bad argument
     in function  io:format/2
        called as io:format("~.*f",[1.0,1])
        *** argument 2: element 1 must be of type integer 
                        element 2 must be of type float
5> io:format("~",[]). % "
** exception error: bad argument
     in function  io:format/2
        called as io:format("~",[]) % "
        *** argument 1: format string invalid (truncated)
```

This PR extends the possible values returned from a `Mod:format_error/3` callback to include `general` which is to be returned when an error happens that is not related to an argument. Thus EEP-54 will also have to be updated.

Also, it changes the formatting a bit so that multiline error info strings are correctly indented.