### PR TITLE
Handle when cover doesn't have any clause data

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -2990,8 +2990,12 @@ merge([],ModuleList) ->
 
 write_module_data([{Module,File}|ModList],Fd) ->
     write({file,Module,File},Fd),
-    [Clauses] = ets:lookup(?COLLECTION_CLAUSE_TABLE,Module),
-    write(Clauses,Fd),
+    case ets:lookup(?COLLECTION_CLAUSE_TABLE,Module) of
+        [] ->
+	    ok;
+        [Clauses] ->
+            write(Clauses,Fd)
+    end,
     ModuleData = ets:match_object(?COLLECTION_TABLE,{#bump{module=Module},'_'}),
     do_write_module_data(ModuleData,Fd),
     write_module_data(ModList,Fd);


### PR DESCRIPTION
When cover runs against an erlang module that implements functions for a NIF, cover doesn't have any clause data to emit in its report. Currently, the code expects clauses always exist for a module, but in this particular they don't and it causes cover to crash when run in the context of rebar3.

You can test this by cloning the repo at [erlang-h3](https://github.com/helium/erlang-h3) and running `rebar3 cover` . An error similar to

```erlang
{{badmatch,[]},
 [{cover,write_module_data,2,[{file,"cover.erl"},{line,2789}]},
  {cover,do_export,4,[{file,"cover.erl"},{line,2745}]}]}
```

(line numbers are different because this error was generated against 23.3.1 instead of against HEAD)