### PR TITLE
Floats for ct multiply timetraps

### DIFF
--- a/lib/common_test/doc/src/ct_run_cmd.xml
+++ b/lib/common_test/doc/src/ct_run_cmd.xml
@@ -117,7 +117,7 @@
   [-include InclDir1 InclDir2 .. InclDirN]
   [-no_auto_compile]
   [-abort_if_missing_suites]
-  [-muliply_timetraps Multiplier]
+  [-multiply_timetraps Multiplier]
   [-scale_timetraps]
   [-create_priv_dir auto_per_run | auto_per_tc | manual_per_tc]
   [-repeat N] |
@@ -157,7 +157,7 @@
   [-include InclDir1 InclDir2 .. InclDirN]
   [-no_auto_compile]
   [-abort_if_missing_suites]
-  [-muliply_timetraps Multiplier]
+  [-multiply_timetraps Multiplier]
   [-scale_timetraps]
   [-create_priv_dir auto_per_run | auto_per_tc | manual_per_tc]
   [-repeat N] |
@@ -187,7 +187,7 @@
   [-include InclDir1 InclDir2 .. InclDirN]
   [-no_auto_compile]
   [-abort_if_missing_suites]
-  [-muliply_timetraps Multiplier]
+  [-multiply_timetraps Multiplier]
   [-scale_timetraps]
   [-create_priv_dir auto_per_run | auto_per_tc | manual_per_tc]
   [-basic_html]

--- a/lib/common_test/src/ct_run.erl
+++ b/lib/common_test/src/ct_run.erl
@@ -237,7 +237,7 @@ script_start1(Parent, Args) ->
 			    [], Args),
     Verbosity = verbosity_args2opts(Args),
     MultTT = get_start_opt(multiply_timetraps,
-			   fun([MT]) -> list_to_integer(MT) end, Args),
+			   fun([MT]) -> list_to_number(MT) end, Args),
     ScaleTT = get_start_opt(scale_timetraps,
 			    fun([CT]) -> list_to_atom(CT);
 			       ([]) -> true
@@ -3148,6 +3148,8 @@ opts2args(EnvStartOpts) ->
 			  [{Opt,[atom_to_list(A)]}];
 		     ({Opt,I}) when is_integer(I) ->
 			  [{Opt,[integer_to_list(I)]}];
+		     ({Opt,I}) when is_float(I) ->
+			  [{Opt,[float_to_list(I)]}];
 		     ({Opt,S}) when is_list(S) ->
 			  [{Opt,[S]}];
 		     (Opt) ->
@@ -3262,6 +3264,11 @@ stop_trace(true) ->
     dbg:stop_clear();
 stop_trace(false) ->
     ok.
+
+list_to_number(S) ->
+    try list_to_integer(S)
+    catch error:badarg -> list_to_float(S)
+    end.
 
 ensure_atom(Atom) when is_atom(Atom) ->
     Atom;

--- a/lib/common_test/src/ct_testspec.erl
+++ b/lib/common_test/src/ct_testspec.erl
@@ -1154,7 +1154,7 @@ handle_data(verbosity,Node,VLvls,_Spec) when is_list(VLvls) ->
     VLvls1 = lists:map(fun(VLvl = {_Cat,_Lvl}) -> VLvl;
 			  (Lvl) -> {'$unspecified',Lvl} end, VLvls),
     [{Node,VLvls1}];
-handle_data(multiply_timetraps,Node,Mult,_Spec) when is_integer(Mult) ->
+handle_data(multiply_timetraps,Node,Mult,_Spec) when is_number(Mult) ->
     [{Node,Mult}];
 handle_data(scale_timetraps,Node,Scale,_Spec) when Scale == true;
                                                    Scale == false ->

--- a/lib/common_test/src/test_server_ctrl.erl
+++ b/lib/common_test/src/test_server_ctrl.erl
@@ -768,7 +768,7 @@ handle_call({reject_io_reqs,Bool}, _From, State) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% handle_call({multiply_timetraps,N}, _, State) -> ok
-%% N = integer() | infinity
+%% N = number() | infinity
 %%
 %% Multiplies all timetraps set by test cases with N
 

--- a/lib/common_test/test/ct_error_SUITE_data/error/test/timetrap_9_SUITE.erl
+++ b/lib/common_test/test/ct_error_SUITE_data/error/test/timetrap_9_SUITE.erl
@@ -1,0 +1,122 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2021. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(timetrap_9_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+%%--------------------------------------------------------------------
+%% Function: suite() -> Info
+%% Info = [tuple()]
+%%--------------------------------------------------------------------
+suite() ->
+    [{timetrap,{seconds,3}},
+     {require,multiply}].
+
+%%--------------------------------------------------------------------
+%% Function: init_per_suite(Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Function: end_per_suite(Config0) -> void() | {save_config,Config1}
+%% Config0 = Config1 = [tuple()]
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Function: init_per_group(GroupName, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%%--------------------------------------------------------------------
+init_per_group(_GroupName, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Function: end_per_group(GroupName, Config0) ->
+%%               void() | {save_config,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%%--------------------------------------------------------------------
+end_per_group(_GroupName, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Function: init_per_testcase(TestCase, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% TestCase = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Function: end_per_testcase(TestCase, Config0) ->
+%%               void() | {save_config,Config1}
+%% TestCase = atom()
+%% Config0 = Config1 = [tuple()]
+%%--------------------------------------------------------------------
+end_per_testcase(_, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Function: groups() -> [Group]
+%% Group = {GroupName,Properties,GroupsAndTestCases}
+%% GroupName = atom()
+%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+%% TestCase = atom()
+%% Shuffle = shuffle | {shuffle,{integer(),integer(),integer()}}
+%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+%%              repeat_until_any_ok | repeat_until_any_fail
+%% N = integer() | forever
+%%--------------------------------------------------------------------
+groups() ->
+    [].
+
+%%--------------------------------------------------------------------
+%% Function: all() -> GroupsAndTestCases | {skip,Reason}
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%% TestCase = atom()
+%% Reason = term()
+%%--------------------------------------------------------------------
+all() ->
+    [tc0].
+
+tc0(_) ->
+    N = list_to_number(ct:get_config(multiply)),
+    ct:comment(io_lib:format("TO after ~w sec", [3*N])),
+    ct:sleep({seconds,5}),
+    ok.
+
+list_to_number(S) ->
+    try list_to_integer(S)
+    catch error:badarg -> list_to_float(S)
+    end.


### PR DESCRIPTION
For the `ct_run` option `-multiply_timetraps N`, allow `N` to be a float as well as previously an integer.  This makes it possible to scale down time traps, which can be useful for instance when running locally and the time traps are long to avoid false positives on slower hosts.

Also fix a doc typo while at it.

