### PR TITLE
Typo corrections

### DIFF
--- a/HOWTO/BOOTSTRAP.md
+++ b/HOWTO/BOOTSTRAP.md
@@ -2,7 +2,7 @@ Notes about prebuilt beam files under version control
 =====================================================
 
 This information applies mostly to developers, some parts only
-to developers of the main branch i.e. Ericsson and HiPE personel.
+to developers of the main branch i.e. Ericsson and HiPE personnel.
 
 There are two types of derived code under version control, namely:
 

--- a/HOWTO/INSTALL-WIN32-OLD.md
+++ b/HOWTO/INSTALL-WIN32-OLD.md
@@ -37,7 +37,7 @@ documentation about this online.
 
 These instructions apply for both 32-bit and 64-bit Windows. Note that even 
 if you build a 64-bit version of Erlang, most of the directories and files 
-involved are still named win32. Some occurances of the name win64 are 
+involved are still named win32. Some occurrences of the name win64 are 
 however present. The installation file for a 64-bit Windows version of 
 Erlang, for example, is `otp_win64_%OTP-REL%.exe`.
 

--- a/HOWTO/INSTALL-WIN32.md
+++ b/HOWTO/INSTALL-WIN32.md
@@ -103,7 +103,7 @@ the different tools:
     <https://docs.microsoft.com/en-us/windows/wsl/install-win10>
 
     We have used and tested with WSL-1, WSL-2 was not available and may
-    not be prefered when building Erlang/OTP since access to the windows
+    not be preferred when building Erlang/OTP since access to the windows
     disk is (currently) slower WSL-2.
 
 *   Visual Studio 2019


### PR DESCRIPTION
Scope of changes is restricted to docs only, specifically HOWTO markdown files. Changes are in agreement with Standard American English.

occurances => occurrences
personel => personnel
prefered => preferred