### PR TITLE
OTP-17355: socket select return value unification

### DIFF
--- a/lib/kernel/src/gen_tcp_socket.erl
+++ b/lib/kernel/src/gen_tcp_socket.erl
@@ -1636,7 +1636,7 @@ handle_connect(
               P, D#{type => connect},
               [{{timeout, connect}, cancel},
                {reply, From, {ok, Socket}}]);
-        {select, SelectInfo} ->
+        {select, ?select_info(_) = SelectInfo} ->
             {next_state,
              #connect{info = SelectInfo, from = From, addr = Addr},
              {P, D#{type => connect}},
@@ -1661,7 +1661,7 @@ handle_accept(P, D, From, ListenSocket, Timeout) ->
               P#params{socket = Socket}, D#{type => accept},
               [{{timeout, accept}, cancel},
                {reply, From, {ok, Socket}}]);
-        {select, SelectInfo} ->
+        {select, ?select_info(_) = SelectInfo} ->
             %% ?DBG({accept_select, SelectInfo}),
             {next_state,
              #accept{
@@ -1755,12 +1755,12 @@ handle_recv_peek(P, D, ActionsR, Packet) ->
                     handle_recv_peek(
                       P, D, ActionsR, Packet,
                       <<ShortData/binary, FinalData/binary>>);
-                {select, SelectInfo} ->
+                {select, {?select_info(_) = SelectInfo, _}} ->
                     {next_state,
                      #recv{info = SelectInfo},
                      {P, D},
                      reverse(ActionsR)};
-                {select, {SelectInfo, _}} ->
+                {select, ?select_info(_) = SelectInfo} ->
                     {next_state,
                      #recv{info = SelectInfo},
                      {P, D},
@@ -1807,16 +1807,16 @@ handle_recv_length(P, D, ActionsR, Length, Buffer) when 0 < Length ->
             handle_recv_deliver(
               P, D#{buffer := <<>>}, ActionsR,
               condense_buffer([Data | Buffer]));
-        {select, SelectInfo} ->
-            {next_state,
-             #recv{info = SelectInfo},
-             {P, D#{buffer := Buffer}},
-             reverse(ActionsR)};
-        {select, {SelectInfo, Data}} ->
+        {select, {?select_info(_) = SelectInfo, Data}} ->
             N = Length - byte_size(Data),
             {next_state,
              #recv{info = SelectInfo},
              {P, D#{buffer := [Data | Buffer], recv_length := N}},
+             reverse(ActionsR)};
+        {select, ?select_info(_) = SelectInfo} ->
+            {next_state,
+             #recv{info = SelectInfo},
+             {P, D#{buffer := Buffer}},
              reverse(ActionsR)};
         {error, {Reason, <<Data/binary>>}} ->
             %% Error before all data
@@ -1840,13 +1840,7 @@ handle_recv_length(P, D, ActionsR, _0, Buffer) ->
                 {ok, <<Data/binary>>} ->
 		    %% ?DBG({'got some', byte_size(Data)}),
                     handle_recv_deliver(P, D, ActionsR, Data);
-                {select, SelectInfo} ->
-		    %% ?DBG({'got another select', SelectInfo}),
-                    {next_state,
-                     #recv{info = SelectInfo},
-                     {P, D},
-                     reverse(ActionsR)};
-                {select, {SelectInfo, Data}} ->
+                {select, {?select_info(_) = SelectInfo, Data}} ->
 		    %% ?DBG({'got another select with data', byte_size(Data)}),
                     case socket:cancel(Socket, SelectInfo) of
                         ok ->
@@ -1854,6 +1848,12 @@ handle_recv_length(P, D, ActionsR, _0, Buffer) ->
                         {error, Reason} ->
                             handle_recv_error(P, D, ActionsR, Reason, Data)
                     end;
+                {select, ?select_info(_) = SelectInfo} ->
+		    %% ?DBG({'got another select', SelectInfo}),
+                    {next_state,
+                     #recv{info = SelectInfo},
+                     {P, D},
+                     reverse(ActionsR)};
                 {error, {Reason, <<Data/binary>>}} ->
 		    %% ?DBG({'error with data', Reason, byte_size(Data)}),
                     handle_recv_error(P, D, ActionsR, Reason, Data);
@@ -1944,7 +1944,7 @@ handle_recv_more(P, D, ActionsR, BufferedData) ->
 	    %% ?DBG([{more_data_sz, byte_size(MoreData)}]), 
 	    Data = catbin(BufferedData, MoreData),
             handle_recv_decode(P, D, ActionsR, Data);
-        {select, SelectInfo} ->
+        {select, ?select_info(_) = SelectInfo} ->
 	    %% ?DBG([{select_info, SelectInfo}]), 
             {next_state,
              #recv{info = SelectInfo},

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -1339,7 +1339,7 @@ send(Socket, Data) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket     :: socket(),
@@ -1352,7 +1352,7 @@ send(Socket, Data) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket       :: socket(),
@@ -1395,7 +1395,7 @@ send(Socket, Data, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket     :: socket(),
@@ -1409,7 +1409,7 @@ send(Socket, Data, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket       :: socket(),
@@ -1447,7 +1447,7 @@ send(Socket, Data, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket     :: socket(),
@@ -1461,7 +1461,7 @@ send(Socket, Data, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket       :: socket(),
@@ -1578,7 +1578,7 @@ send_common_nowait_result(SelectHandle, Op, Result) ->
         {select, ContData} ->
             {select, ?SELECT_INFO({Op, ContData}, SelectHandle)};
         {select, Data, ContData} ->
-            {ok, {Data, ?SELECT_INFO({Op, ContData}, SelectHandle)}};
+            {select, {?SELECT_INFO({Op, ContData}, SelectHandle), Data}};
         %%
         Result ->
             Result
@@ -1690,7 +1690,7 @@ sendto(Socket, Data, Dest_Cont) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket     :: socket(),
@@ -1704,7 +1704,7 @@ sendto(Socket, Data, Dest_Cont) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket       :: socket(),
@@ -1742,7 +1742,7 @@ sendto(Socket, Data, Dest_Cont) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket     :: socket(),
@@ -1756,7 +1756,7 @@ sendto(Socket, Data, Dest_Cont) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket       :: socket(),
@@ -1826,7 +1826,7 @@ sendto(Socket, Data, Dest, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket     :: socket(),
@@ -1841,7 +1841,7 @@ sendto(Socket, Data, Dest, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason}
                       when
       Socket       :: socket(),
@@ -2000,7 +2000,7 @@ sendmsg(Socket, Msg) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason} |
                   {'error', {Reason, RestData}}
                       when
@@ -2014,7 +2014,7 @@ sendmsg(Socket, Msg) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason} |
                   {'error', {Reason, RestData}}
                       when
@@ -2058,7 +2058,7 @@ sendmsg(Socket, Msg, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason} |
                   {'error', {Reason, RestData}}
                       when
@@ -2073,7 +2073,7 @@ sendmsg(Socket, Msg, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason} |
                   {'error', {Reason, RestData}}
                       when
@@ -2112,7 +2112,7 @@ sendmsg(Socket, Msg, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason} |
                   {'error', {Reason, RestData}}
                       when
@@ -2127,7 +2127,7 @@ sendmsg(Socket, Msg, Timeout) ->
                   'ok' |
                   {'ok', RestData} |
                   {'select', SelectInfo} |
-                  {'ok', {RestData, SelectInfo}} |
+                  {'select', {SelectInfo, RestData}} |
                   {'error', Reason} |
                   {'error', {Reason, RestData}}
                       when
@@ -2256,7 +2256,7 @@ sendfile(Socket, FileHandle_Cont, Offset, Count) ->
                SelectHandle :: 'nowait') ->
                       {'ok', BytesSent} |
                       {'select', SelectInfo} |
-                      {'ok', {BytesSent, SelectInfo}} |
+                      {'select', {SelectInfo, BytesSent}} |
                       {'error', Reason}
                           when
       Socket     :: socket(),
@@ -2271,7 +2271,7 @@ sendfile(Socket, FileHandle_Cont, Offset, Count) ->
                SelectHandle :: select_handle()) ->
                       {'ok', BytesSent} |
                       {'select', SelectInfo} |
-                      {'ok', {BytesSent, SelectInfo}} |
+                      {'select', {SelectInfo, BytesSent}} |
                       {'error', Reason}
                           when
       Socket     :: socket(),
@@ -2313,7 +2313,7 @@ sendfile(Socket, FileHandle_Cont, Offset, Count) ->
                SelectHandle :: 'nowait') ->
                       {'ok', BytesSent} |
                       {'select', SelectInfo} |
-                      {'ok', {BytesSent, SelectInfo}} |
+                      {'select', {SelectInfo, BytesSent}} |
                       {'error', Reason}
                           when
       Socket     :: socket(),
@@ -2328,7 +2328,7 @@ sendfile(Socket, FileHandle_Cont, Offset, Count) ->
                SelectHandle :: select_handle()) ->
                       {'ok', BytesSent} |
                       {'select', SelectInfo} |
-                      {'ok', {BytesSent, SelectInfo}} |
+                      {'select', {SelectInfo, BytesSent}} |
                       {'error', Reason}
                           when
       Socket     :: socket(),
@@ -2448,8 +2448,7 @@ sendfile_nowait(SockRef, State, SelectHandle) ->
             {FRef, _Offset, _Count} = State,
             {select, ?SELECT_INFO({sendfile, FRef}, SelectHandle)};
         {select, BytesSent} ->
-            {ok,
-             {BytesSent, ?SELECT_INFO(sendfile, SelectHandle)}};
+            {select, {?SELECT_INFO(sendfile, SelectHandle), BytesSent}};
         %%
         Result ->
             Result
@@ -2572,8 +2571,8 @@ recv(Socket, Length) ->
 
 -spec recv(Socket, Flags, SelectHandle :: 'nowait') ->
                   {'ok', Data} |
-                  {'ok', {Data, SelectInfo}} |
                   {'select', SelectInfo} |
+                  {'select', {SelectInfo, Data}} |
                   {'error', Reason} |
                   {'error', {Reason, Data}} when
       Socket     :: socket(),
@@ -2584,8 +2583,8 @@ recv(Socket, Length) ->
 
           (Socket, Flags, SelectHandle :: select_handle()) ->
                   {'ok', Data} |
-                  {'ok', {Data, SelectInfo}} |
                   {'select', SelectInfo} |
+                  {'select', {SelectInfo, Data}} |
                   {'error', Reason} |
                   {'error', {Reason, Data}} when
       Socket       :: socket(),
@@ -2624,8 +2623,8 @@ recv(Socket, Length) ->
 
           (Socket, Length, SelectHandle :: 'nowait') ->
                   {'ok', Data} |
-                  {'ok', {Data, SelectInfo}} |
                   {'select', SelectInfo} |
+                  {'select', {SelectInfo, Data}} |
                   {'error', Reason} |
                   {'error', {Reason, Data}} when
       Socket     :: socket(),
@@ -2636,8 +2635,8 @@ recv(Socket, Length) ->
 
           (Socket, Length, SelectHandle :: select_handle()) ->
                   {'ok', Data} |
-                  {'ok', {Data, SelectInfo}} |
                   {'select', SelectInfo} |
+                  {'select', {SelectInfo, Data}} |
                   {'error', Reason} |
                   {'error', {Reason, Data}} when
       Socket       :: socket(),
@@ -2673,8 +2672,8 @@ recv(Socket, Length, Timeout) ->
 
 -spec recv(Socket, Length, Flags, SelectHandle :: 'nowait') ->
                   {'ok', Data} |
-                  {'ok', {Data, SelectInfo}} |
                   {'select', SelectInfo} |
+                  {'select', {SelectInfo, Data}} |
                   {'error', Reason} |
                   {'error', {Reason, Data}} when
       Socket     :: socket(),
@@ -2686,8 +2685,8 @@ recv(Socket, Length, Timeout) ->
 
           (Socket, Length, Flags, SelectHandle :: select_handle()) ->
                   {'ok', Data} |
-                  {'ok', {Data, SelectInfo}} |
                   {'select', SelectInfo} |
+                  {'select', {SelectInfo, Data}} |
                   {'error', Reason} |
                   {'error', {Reason, Data}} when
       Socket       :: socket(),
@@ -2755,7 +2754,7 @@ recv_nowait(SockRef, Length, Flags, SelectHandle, Acc) ->
         {select, Bin} ->
             %% We got less than requested so the caller will
             %% get a select message when there might be more to read
-            {ok, {bincat(Acc, Bin), ?SELECT_INFO(recv, SelectHandle)}};
+            {select, {?SELECT_INFO(recv, SelectHandle), bincat(Acc, Bin)}};
         select ->
             %% The caller will get a select message when there
             %% might be data to read
@@ -2763,7 +2762,7 @@ recv_nowait(SockRef, Length, Flags, SelectHandle, Acc) ->
                 byte_size(Acc) =:= 0 ->
                     {select, ?SELECT_INFO(recv, SelectHandle)};
                 true ->
-                    {ok, {Acc, ?SELECT_INFO(recv, SelectHandle)}}
+                    {select, {?SELECT_INFO(recv, SelectHandle), Acc}}
             end;
         Result ->
             recv_result(Acc, Result)

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -2255,6 +2255,7 @@ sendfile(Socket, FileHandle_Cont, Offset, Count) ->
 -spec sendfile(Socket, Cont, Offset, Count,
                SelectHandle :: 'nowait') ->
                       {'ok', BytesSent} |
+                      {'select', SelectInfo} |
                       {'ok', {BytesSent, SelectInfo}} |
                       {'error', Reason}
                           when
@@ -2269,8 +2270,9 @@ sendfile(Socket, FileHandle_Cont, Offset, Count) ->
               (Socket, Cont, Offset, Count,
                SelectHandle :: select_handle()) ->
                       {'ok', BytesSent} |
+                      {'select', SelectInfo} |
                       {'ok', {BytesSent, SelectInfo}} |
-                      {'error', {Reason, BytesSent}}
+                      {'error', Reason}
                           when
       Socket     :: socket(),
       Cont       :: select_info(),


### PR DESCRIPTION
Oops!

I just figured out that the return values from all socket functions really would benefit from a unification of the select return value.
Example:
``` erlang
send(Socket, Data, SendRef) ->
        ok |
        {ok, {RestData, SelectInfo}} |
        {select, SelectInfo} |
        {error, Reason}
```
The two values with `SelectInfo` have tags `ok` and `select`, respectively.  This gets in the way because for both values with `SelectInfo` you want to do a receive, and you want to do it in the function that calls creates `SendRef` and calls `send/3` to get the receive optimization for the `SendRef`.

So better would be:
``` erlang
send(Socket, Data, SendRef) ->
        ok |
        {select, SelectInfo} |
        {select, {SelectInfo, RestData}} |
        {error, Reason}
```
Because then you can:
``` erlang
    SendRef = make_ref(),
    case send(Socket, Data, SendRef) of
        {select, Select} ->
            receive
                {'$socket', Socket, select, SendRef} ->
                     case Select of
                         {SelectInfo, RestData} ->
                             loop(Socket, SelectInfo, RestData);
                         SelectInfo ->
                             loop(Socket, SelectInfo, [])
                     end;
```
and hence not have to duplicate the receive statement for both the `{ok, {RestData, SelectInfo}}` and the `{select, SelectInfo}` return values.

Therefore this panic change before 24.0...