### PR TITLE
Completed list of handled MacOS wxApp events

### DIFF
--- a/lib/wx/c_src/wxe_impl.cpp
+++ b/lib/wx/c_src/wxe_impl.cpp
@@ -178,8 +178,26 @@ bool WxeApp::OnInit()
 
 
 #ifdef  _MACOSX
+void WxeApp::MacPrintFile(const wxString &filename) {
+  send_msg("print_file", &filename);
+}
+
 void WxeApp::MacOpenFile(const wxString &filename) {
   send_msg("open_file", &filename);
+}
+
+void WxeApp::MacOpenURL(const wxString &url) {
+  send_msg("open_url", &url);
+}
+
+void WxeApp::MacNewFile() {
+  wxString empty;
+  send_msg("new_file", &empty);
+}
+
+void WxeApp::MacReopenApp() {
+  wxString empty;
+  send_msg("reopen_app", &empty);
 }
 #endif
 

--- a/lib/wx/c_src/wxe_impl.h
+++ b/lib/wx/c_src/wxe_impl.h
@@ -59,7 +59,11 @@ public:
 				const wxChar *cond, const wxChar *msg);
 
 #ifdef  _MACOSX
+  virtual void MacPrintFile(const wxString &filename);
   virtual void MacOpenFile(const wxString &filename);
+  virtual void MacOpenURL(const wxString &url);
+  virtual void MacNewFile();
+  virtual void MacReopenApp();
 #endif
 
   void init_consts(wxeMetaCommand& event);

--- a/lib/wx/src/wx.erl
+++ b/lib/wx/src/wx.erl
@@ -63,7 +63,7 @@
 -module(wx).
 
 -export([parent_class/1, new/0, new/1, destroy/0,
-	 get_env/0,set_env/1, debug/1,
+	 get_env/0, set_env/1, subscribe_events/0, debug/1,
 	 batch/1,foreach/2,map/2,foldl/3,foldr/3,
 	 getObjectType/1, typeCast/2,
 	 null/0, is_null/1, equal/2]).
@@ -143,6 +143,23 @@ set_env(#wx_env{sv=Pid} = Env) ->
     %%    wxe_util:cast(?REGISTER_PID, <<>>),
     wxe_server:register_me(Pid),
     ok.
+
+%% @doc Adds the calling process to the list of of processes that are
+%% listening to wx application events. At the moment these are
+%% all MacOSX specific events corresponding to MacNewFile() and friends
+%% from wxWidgets wxApp https://docs.wxwidgets.org/trunk/classwx_app.html
+%%
+%% * `{file_new, ""}` 
+%% * `{file_open, Filename}`
+%% * `{file_print, Filename}`
+%% * `{url_open, Url}`
+%% * `{reopen_app, ""}`
+%%
+%% The call always returns ok but will have sent any already received
+%% events to the calling process. 
+-spec subscribe_events() -> 'ok'.
+subscribe_events() ->
+    gen_server:call(wxe_master, subscribe_msgs, infinity).
 
 %% @doc Returns the null object
 -spec null() -> wx_object().


### PR DESCRIPTION
Until now the `new_file` application event was handled
and there was only an undocumented function to
fetch those events. Now all 5 existing wxApp events are captured
and can be subscribed to from a client application with
a documented call. @dgud

Apps can register a user clicking on the app icon, users
dragging icons on an app icon and users double-clicking
files while the associated app is open.