### PR TITLE
Make flaky tests less flaky

### DIFF
--- a/erts/emulator/test/driver_SUITE.erl
+++ b/erts/emulator/test/driver_SUITE.erl
@@ -78,6 +78,7 @@
          otp_9302/1,
          thr_free_drv/1,
          async_blast/1,
+         thr_msg_blast/0,
          thr_msg_blast/1,
          consume_timeslice/1,
          env/1,
@@ -2156,6 +2157,9 @@ thr_msg_blast_receiver_proc(Port, Max, Parent, Done) ->
         "done" ->
             Parent ! Done
     end.
+
+thr_msg_blast() ->
+    [{timetrap, {minutes, 10}}].
 
 thr_msg_blast(Config) when is_list(Config) ->
     Path = proplists:get_value(data_dir, Config),

--- a/erts/emulator/test/timer_bif_SUITE.erl
+++ b/erts/emulator/test/timer_bif_SUITE.erl
@@ -493,19 +493,36 @@ registered_process(Config) when is_list(Config) ->
 same_time_yielding(Config) when is_list(Config) ->
     Mem = mem(),
     Ref = make_ref(),
-    SchdlrsOnln = erlang:system_info(schedulers_online),
-    Tmo = erlang:monotonic_time(millisecond) + 6000,
+    SchdlrsOnline = erlang:system_info(schedulers_online),
+    SchdlrsToUse = erlang:max(1, erlang:min(8, SchdlrsOnline) - 1),
+    StartTime = erlang:monotonic_time(millisecond),
+    Tmo = StartTime + 20000,
+    NrOfTimeouts = (?TIMEOUT_YIELD_LIMIT*3+1) * SchdlrsToUse,
+    NrOfTimeoutsPerScheduler = NrOfTimeouts div SchdlrsToUse,
     Tmrs = lists:map(fun (I) ->
-                             process_flag(scheduler, (I rem SchdlrsOnln) + 1),
-                             erlang:start_timer(Tmo, self(), Ref, [{abs, true}])
+                             SchedulerId =
+                                 case SchdlrsOnline of
+                                     1 -> 1;
+                                     _ ->
+                                         ((I div NrOfTimeoutsPerScheduler) rem SchdlrsToUse)  + 2
+                                 end,
+                             process_flag(scheduler, SchedulerId),
+                             erlang:start_timer(Tmo, self(), Ref, [{abs, true}]),
+                             SchedulerId
                      end,
-                     lists:seq(1, (?TIMEOUT_YIELD_LIMIT*3+1)*SchdlrsOnln)),
+                     lists:seq(1, NrOfTimeouts)),
+    process_flag(scheduler, 1),
+    AllTimersStartedTime = erlang:monotonic_time(millisecond),
     true = mem_larger_than(Mem),
-    receive_all_timeouts(length(Tmrs), Ref),
+    {TimeToReceive, TimeUntilFirst} = receive_all_timeouts(length(Tmrs), Ref),
     Done = erlang:monotonic_time(millisecond),
     true = Done >= Tmo,
     MsAfterTmo = Done - Tmo,
-    io:format("Done ~p ms after Tmo\n", [MsAfterTmo]),
+    io:format("Done ~p ms after Tmo\nInfo: ~p\n",
+              [MsAfterTmo,
+               {'TimeToStartAllTimers', AllTimersStartedTime - StartTime,
+                'TimeInReceiveUntilFirst',TimeUntilFirst,
+                'TimeToReceive', TimeToReceive}]),
     case erlang:system_info(build_type) of
         opt ->
             true = MsAfterTmo < 200;
@@ -518,12 +535,26 @@ same_time_yielding(Config) when is_list(Config) ->
 %% Read out all timeouts in receive queue order. This is efficient
 %% even if there are very many messages.
 
-receive_all_timeouts(0, _Ref) ->
-    ok;
 receive_all_timeouts(N, Ref) ->
+    receive_all_timeouts(N, Ref, not_set).
+
+receive_all_timeouts(0, _Ref, {FirstTime, TimeUntilFirst}) ->
+    {erlang:monotonic_time(millisecond) - FirstTime, TimeUntilFirst};
+receive_all_timeouts(N, Ref, Timings) ->
+    StartTime = case Timings of
+        not_set -> erlang:monotonic_time(millisecond);
+        _ -> ok
+    end,
     receive
         {timeout, _Tmr, Ref} ->
-            receive_all_timeouts(N-1, Ref)
+            NewTimings =
+                case Timings of
+                    not_set ->
+                        FirstMessageAtTime = erlang:monotonic_time(millisecond),
+                        {FirstMessageAtTime, FirstMessageAtTime - StartTime};
+                    _ -> Timings
+                end,
+            receive_all_timeouts(N-1, Ref, NewTimings)
     end.
 
 same_time_yielding_with_cancel(Config) when is_list(Config) ->
@@ -554,7 +585,10 @@ do_cancel_tmrs(Tmo, Tmrs, Tester) ->
 
 same_time_yielding_with_cancel_test(Other, Accessor) ->
     Mem = mem(),
-    SchdlrsOnln = erlang:system_info(schedulers_online),
+    SchdlrsOnline = erlang:system_info(schedulers_online),
+    SchdlrsToUse = erlang:max(1, erlang:min(8, SchdlrsOnline) - 1),
+    NrOfTimeouts = (?TIMEOUT_YIELD_LIMIT*3+1) * SchdlrsToUse,
+    NrOfTimeoutsPerScheduler = NrOfTimeouts div SchdlrsToUse,
     Tmo = erlang:monotonic_time(millisecond) + 6000,
     Tester = self(),
     Cancelor = case Other of
@@ -573,10 +607,17 @@ same_time_yielding_with_cancel_test(Other, Accessor) ->
                true -> [{accessor, Cancelor}, {abs, true}]
            end,
     Tmrs = lists:map(fun (I) ->
-                             process_flag(scheduler, (I rem SchdlrsOnln) + 1),
+                             SchedulerId =
+                                 case SchdlrsOnline of
+                                     1 -> 1;
+                                     _ ->
+                                         ((I div NrOfTimeoutsPerScheduler) rem SchdlrsToUse)  + 2
+                                 end,
+                             process_flag(scheduler, SchedulerId),
                              erlang:start_timer(Tmo, self(), hej, Opts)
                      end,
-                     lists:seq(1, (?TIMEOUT_YIELD_LIMIT*3+1)*SchdlrsOnln)),
+                     lists:seq(1, NrOfTimeouts)),
+    process_flag(scheduler, 1),
     true = mem_larger_than(Mem),
     case Other of
         false ->


### PR DESCRIPTION
This pull-request fixes some test cases that gave false-positive results on the Erlang/OTP team's PowerPC machine with 64 cores and 32 GB memory.