### PR TITLE
Remove mentions of non-SMP emulator

### DIFF
--- a/erts/doc/src/crash_dump.xml
+++ b/erts/doc/src/crash_dump.xml
@@ -233,8 +233,7 @@ Slogan: &lt;reason&gt;</pre>
       <item>
         <p>If empty, the scheduler was doing some work.
           If not empty, the scheduler is either in some state of sleep,
-          or suspended. This entry is only present in an SMP-enabled
-          emulator.</p>
+          or suspended.</p>
       </item>
       <tag><em>Scheduler Sleep Info Aux Work</em></tag>
       <item>

--- a/erts/doc/src/driver_entry.xml
+++ b/erts/doc/src/driver_entry.xml
@@ -465,8 +465,7 @@ typedef struct erl_drv_entry {
           <item>
             <p>The runtime system uses port-level locking on
               all ports executing this driver instead of driver-level
-              locking when the driver is run in a runtime
-              system with SMP support. For more information, see
+              locking. For more information, see
               <seecref marker="erl_driver#smp_support">
               <c>erl_driver</c></seecref>.</p>
           </item>

--- a/erts/doc/src/erl_driver.xml
+++ b/erts/doc/src/erl_driver.xml
@@ -112,9 +112,8 @@
       the port. (Although in the latest Erlang versions there is
       the binary syntax, which enables you to match on the beginning of
       a binary.)</p>
-    <p><marker id="smp_support"></marker>In the runtime system with
-      SMP support, drivers are locked either on driver level
-      or port level (driver instance level). By default
+      <p><marker id="smp_support"></marker>Drivers are locked either on
+      driver level or port level (driver instance level). By default
       driver level locking will be used, that is, only one emulator thread
       will execute code in the driver at a time. If port level locking
       is used, multiple emulator threads can execute code in the driver
@@ -139,18 +138,6 @@
         communication" is strongly discouraged.</p>
     </note>
 
-    <p>Previously, in the runtime system without SMP support,
-      specific driver callbacks were always called from the same
-      thread. This is <em>not</em> the case in the runtime system
-      with SMP support. Regardless of locking scheme used, calls
-      to driver callbacks can be made from different threads. For example,
-      two consecutive calls to exactly the same callback for exactly
-      the same port can be made from two different threads. This
-      is for <em>most</em> drivers not a problem, but it can be.
-      Drivers that depend on all callbacks that are called in the
-      same thread, <em>must</em> be rewritten before they are used
-      in the runtime system with SMP support.</p>
-
     <note>
       <p>Regardless of locking scheme used, calls to driver
         callbacks can be made from different threads.</p>
@@ -167,9 +154,7 @@
 
     <warning>
       <p>Functions not explicitly documented as thread-safe are
-        <em>not</em> thread safe. Also notice that some functions
-        are <em>only</em> thread-safe when used in a runtime
-        system with SMP support.</p>
+        <em>not</em> thread safe.</p>
       <p>A function not explicitly documented as thread-safe can, at
         some point in time, have a thread-safe implementation in the
         runtime system. Such an implementation can however change to
@@ -287,19 +272,8 @@
           omitted it from the Erlang driver thread API. In the Erlang driver
           case, time-outs can and are to be handled with the timer functionality
           of the Erlang driver API.</p>
-        <p>In order for the Erlang driver thread API to function, thread
-          support must be enabled in the runtime system. An Erlang driver
-          can check if thread support is enabled by use of
-          <seecref marker="#driver_system_info">
-          <c>driver_system_info</c></seecref>.
-          Notice that some functions in the Erlang driver API are thread-safe
-          only when the runtime system has SMP support, also this
-          information can be retrieved through
-          <seecref marker="#driver_system_info">
-          <c>driver_system_info</c></seecref>.
-          Also notice that many functions in the Erlang driver API are
-          <em>not</em> thread-safe, regardless of whether SMP support is
-          enabled or not. If a function is not documented as thread-safe, it
+        <p>Notice that many functions in the Erlang driver API are
+          <em>not</em> thread-safe. If a function is not documented as thread-safe, it
           is <em>not</em> thread-safe.</p>
         <note>
           <p>When executing in an emulator thread, it is
@@ -1177,8 +1151,7 @@ r = driver_async(myPort, &myKey, myData, myFunc);    ]]></code>
           <item>Called from <seemfa marker="erlang#port_call/3">
             <c>erlang:port_call/3</c></seemfa>.</item>
         </taglist>
-        <p>Notice that this function is <em>not</em> thread-safe, not
-          even when the emulator with SMP support is used.</p>
+        <p>Notice that this function is <em>not</em> thread-safe.</p>
       </desc>
     </func>
 
@@ -1217,8 +1190,7 @@ r = driver_async(myPort, &myKey, myData, myFunc);    ]]></code>
       <desc>
         <marker id="driver_connected"></marker>
         <p>Returns the port owner process.</p>
-        <p>Notice that this function is <em>not</em> thread-safe, not
-          even when the emulator with SMP support is used.</p>
+        <p>Notice that this function is <em>not</em> thread-safe.</p>
       </desc>
     </func>
 
@@ -1495,8 +1467,7 @@ r = driver_async(myPort, &myKey, myData, myFunc);    ]]></code>
           <c>string</c>. The atom is created and does not change, so the
           return value can be saved and reused, which is faster than
           looking up the atom several times.</p>
-        <p>Notice that this function is <em>not</em> thread-safe, not
-          even when the emulator with SMP support is used.</p>
+        <p>Notice that this function is <em>not</em> thread-safe.</p>
       </desc>
     </func>
 
@@ -1511,8 +1482,7 @@ r = driver_async(myPort, &myKey, myData, myFunc);    ]]></code>
           <c>erl_drv_output_term</c></seecref> and 
           <seecref marker="#erl_drv_send_term">
           <c>erl_drv_send_term</c></seecref>.</p>
-        <p>Notice that this function is <em>not</em> thread-safe, not
-          even when the emulator with SMP support is used.</p>
+        <p>Notice that this function is <em>not</em> thread-safe.</p>
       </desc>
     </func>
 
@@ -1602,8 +1572,7 @@ r = driver_async(myPort, &myKey, myData, myFunc);    ]]></code>
         <p>Parameters <c>term</c> and <c>n</c> work as in
           <seecref marker="#erl_drv_output_term">
           <c>erl_drv_output_term</c></seecref>.</p>
-        <p>Notice that this function is <em>not</em> thread-safe, not
-          even when the emulator with SMP support is used.</p>
+        <p>Notice that this function is <em>not</em> thread-safe.</p>
       </desc>
     </func>
 
@@ -1905,8 +1874,7 @@ r = driver_async(myPort, &myKey, myData, myFunc);    ]]></code>
             value of <c>mode</c>.</p>
         </note>
         <p><c>ERL_DRV_USE</c> specifies if we are using the event object or
-          if we want to close it.
-          On an emulator with SMP support, it is not safe to clear all events
+          if we want to close it. It is not safe to clear all events
           and then close the event object after <c>driver_select</c> has
           returned. Another thread can still be using the event object
           internally. To safely close an event object, call
@@ -1952,8 +1920,7 @@ r = driver_async(myPort, &myKey, myData, myFunc);    ]]></code>
         <p>Parameters <c>term</c> and <c>n</c> work as in
           <seecref marker="#erl_drv_output_term">
           <c>erl_drv_output_term</c></seecref>.</p>
-        <p>This function is only thread-safe when the emulator with SMP
-          support is used.</p>
+        <p>This function is thread-safe.</p>
       </desc>
     </func>
 
@@ -2647,8 +2614,7 @@ erl_drv_output_term(driver_mk_port(drvport), spec, sizeof(spec) / sizeof(spec[0]
         <p>The <c>ERL_DRV_UINT</c>, <c>ERL_DRV_BUF2BINARY</c>, and
           <c>ERL_DRV_EXT2TERM</c> term types were introduced in
           ERTS 5.6.</p>
-        <p>This function is only thread-safe when the emulator with SMP
-          support is used.</p>
+        <p>This function is thread-safe.</p>
       </desc>
     </func>
 
@@ -2853,8 +2819,7 @@ erl_drv_output_term(driver_mk_port(drvport), spec, sizeof(spec) / sizeof(spec[0]
         <p>Parameters <c>port</c>, <c>term</c>, and <c>n</c> work as in
           <seecref marker="#erl_drv_output_term">
           <c>erl_drv_output_term</c></seecref>.</p>
-        <p>This function is only thread-safe when the emulator with SMP
-          support is used.</p>
+        <p>This function is thread-safe.</p>
       </desc>
     </func>
 

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -496,17 +496,6 @@ int writeiovec(ErlNifEnv *env, ERL_NIF_TERM term, ERL_NIF_TERM *tail,
           </item>
           <tag><marker id="dirty_nifs"/>Dirty NIF</tag>
           <item>
-            <note>
-              <p>Dirty NIF support is available only when the emulator is
-	        configured with dirty scheduler support. As of ERTS version
-		9.0, dirty scheduler support is enabled by default on the
-		runtime system with SMP support. The Erlang runtime without
-		SMP support does <em>not</em> support dirty schedulers even
-		when the dirty scheduler support is explicitly enabled. To
-		check at runtime for the presence of dirty scheduler threads,
-		code can use the <seecref marker="#enif_system_info">
-                <c>enif_system_info()</c></seecref> API function.</p>
-            </note>
             <p>A NIF that cannot be split and cannot execute in a millisecond
               or less is called a "dirty NIF", as it performs work that the
               ordinary schedulers of the Erlang runtime system cannot handle cleanly.
@@ -1301,9 +1290,7 @@ typedef struct {
           <item>already triggered</item>
           <item>just about to be triggered by a concurrent thread</item>
         </list>
-        <p>This function is only thread-safe when the emulator with SMP support
-          is used. It can only be used in a non-SMP emulator from a NIF-calling
-          thread.</p>
+        <p>This function is thread-safe.</p>
       </desc>
     </func>
 
@@ -1991,9 +1978,7 @@ enif_inspect_iovec(env, max_elements, term, &amp;tail, &amp;iovec);
       <fsummary>Determine if a local port is alive.</fsummary>
       <desc>
         <p>Returns <c>true</c> if <c>port_id</c> is alive.</p>
-        <p>This function is only thread-safe when the emulator with SMP support
-          is used. It can only be used in a non-SMP emulator from a NIF-calling
-          thread.</p>
+        <p>This function is thread-safe.</p>
       </desc>
     </func>
 
@@ -2003,9 +1988,7 @@ enif_inspect_iovec(env, max_elements, term, &amp;tail, &amp;iovec);
       <fsummary>Determine if a local process is alive.</fsummary>
       <desc>
         <p>Returns <c>true</c> if <c>pid</c> is alive.</p>
-        <p>This function is only thread-safe when the emulator with SMP support
-          is used. It can only be used in a non-SMP emulator from a NIF-calling
-          thread.</p>
+        <p>This function is thread-safe.</p>
       </desc>
     </func>
 
@@ -2738,9 +2721,7 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
           provided, and &gt; 0 if the process is no longer alive or if
 	  <c>target_pid</c> is <seecref marker="#enif_set_pid_undefined">
 	  undefined</seecref>.</p>
-        <p>This function is only thread-safe when the emulator with SMP support
-          is used. It can only be used in a non-SMP emulator from a NIF-calling
-          thread.</p>
+        <p>This function is thread-safe.</p>
       </desc>
     </func>
 
@@ -3424,9 +3405,7 @@ if (retval &amp; ERL_NIF_SELECT_STOP_CALLED) {
         <p>If <c>msg_env</c> is set to <c>NULL</c>, the <c>msg</c> term is
           copied and the original term and its environment is still valid after
           the call.</p>
-        <p>This function is only thread-safe when the emulator with SMP support
-          is used. It can only be used in a non-SMP emulator from a NIF-calling
-          thread.</p>
+        <p>This function is thread-safe.</p>
         <note>
           <p>Passing <c>msg_env</c> as <c>NULL</c> is only supported as from
             ERTS 8.0 (Erlang/OTP 19).</p>

--- a/erts/doc/src/erts_alloc.xml
+++ b/erts/doc/src/erts_alloc.xml
@@ -718,9 +718,7 @@
         <tag><marker id="M_t"/><c><![CDATA[+M<S>t true|false]]></c></tag>
         <item>
           <p>Multiple, thread-specific instances of the allocator.
-            This option has only effect on the runtime system
-            with SMP support. Default behavior on the runtime system with
-            SMP support is <c>NoSchedulers+1</c> instances. Each scheduler
+            Default behavior is <c>NoSchedulers+1</c> instances. Each scheduler
             uses a lock-free instance of its own and other threads use
             a common instance.</p>
           <p>Before ERTS 5.9 it was possible to configure

--- a/erts/doc/src/escript_cmd.xml
+++ b/erts/doc/src/escript_cmd.xml
@@ -72,7 +72,7 @@ $ <input>chmod u+x factorial</input>
 $ <input>cat factorial</input>
 #!/usr/bin/env escript
 %% -*- erlang -*-
-%%! -smp enable -sname factorial -mnesia debug verbose
+%%! -sname factorial -mnesia debug verbose
 main([String]) ->
     try
         N = list_to_integer(String),
@@ -129,7 +129,7 @@ io:setopts([{encoding, unicode}])</code>
           of the Emacs directive), arguments can be specified to
           the emulator, for example:</p>
         <pre>
-%%! -smp enable -sname factorial -mnesia debug verbose</pre>
+%%! -sname factorial -mnesia debug verbose</pre>
         <p>Such an argument line must start with <c>%%!</c> and the
           remaining line is interpreted as arguments to the emulator.</p>
         <p>If you know the location of the <c>escript</c> executable, the first
@@ -272,27 +272,27 @@ factorial 5 = 120</pre>
           can either be returned as a binary or written to file.</p>
         <p>As an example of how the function can be used, we create an
           interpreted escript that uses <c>emu_args</c> to set some emulator
-          flag. In this case, it happens to disable the <c>smp_support</c>. We
+          flag. In this case, it happens to set number of schedulers with <c>+S3</c>. We
           also extract the different sections from the newly created script:</p>
         <pre>
-&gt; <input>Source = "%% Demo\nmain(_Args) ->\n    io:format(erlang:system_info(smp_support)).\n".</input>
-"%% Demo\nmain(_Args) ->\n    io:format(erlang:system_info(smp_support)).\n"
+&gt; <input>Source = "%% Demo\nmain(_Args) ->\n    io:format(\"~p\",[erlang:system_info(schedulers)]).\n".</input>
+"%% Demo\nmain(_Args) ->\n    io:format(erlang:system_info(schedulers)).\n"
 &gt; <input>io:format("~s\n", [Source]).</input>
 %% Demo
 main(_Args) ->
-    io:format(erlang:system_info(smp_support)).
+    io:format(erlang:system_info(schedulers)).
 
 ok
-&gt; <input>{ok, Bin} = escript:create(binary, [shebang, comment, {emu_args, "-smp disable"},
+&gt; <input>{ok, Bin} = escript:create(binary, [shebang, comment, {emu_args, "+S3"},
                                       {source, list_to_binary(Source)}]).</input>
-{ok,&lt;&lt;"#!/usr/bin/env escript\n%% This is an -*- erlang -*- file\n%%!-smp disabl"...&gt;&gt;}
+{ok,&lt;&lt;"#!/usr/bin/env escript\n%% This is an -*- erlang -*- file\n%%!+S3"...&gt;&gt;}
 &gt; <input>file:write_file("demo.escript", Bin).</input>
 ok
 &gt; <input>os:cmd("escript demo.escript").</input>
-"false"
+"3"
 &gt; <input>escript:extract("demo.escript", []).</input>
-{ok,[{shebang,default}, {comment,default}, {emu_args,"-smp disable"},
-     {source,&lt;&lt;"%% Demo\nmain(_Args) ->\n    io:format(erlang:system_info(smp_su"...&gt;&gt;}]}</pre>
+{ok,[{shebang,default}, {comment,default}, {emu_args,"+S3"},
+     {source,&lt;&lt;"%% Demo\nmain(_Args) ->\n    io:format(erlang:system_info(schedu"...&gt;&gt;}]}</pre>
         <p>An escript without header can be created as follows:</p>
         <pre>
 &gt; <input>file:write_file("demo.erl",

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -1308,8 +1308,8 @@ ets:select(Table, MatchSpec),</code>
           <item>
             <p>Performance tuning. Defaults to <c>false</c>. When set to
               <c>true</c>, the table is optimized for concurrent read
-              operations. When this option is enabled on a runtime system with
-              SMP support, read operations become much cheaper; especially on
+              operations. When this option is enabled read operations
+	      become much cheaper; especially on
               systems with multiple physical processors. However, switching
               between read and write operations becomes more expensive.</p>
             <p>You typically want to enable this option when concurrent read

--- a/system/doc/efficiency_guide/commoncaveats.xml
+++ b/system/doc/efficiency_guide/commoncaveats.xml
@@ -43,8 +43,7 @@
      <seeerl marker="stdlib:timer">timer</seeerl> module in STDLIB.
      The <c>timer</c> module uses a separate process to manage the timers.
      That process can easily become overloaded if many processes
-     create and cancel timers frequently (especially when using the
-     SMP emulator).</p>
+     create and cancel timers frequently.</p>
 
      <p>The functions in the <c>timer</c> module that do not manage timers
      (such as <c>timer:tc/3</c> or <c>timer:sleep/1</c>), do not call the

--- a/system/doc/efficiency_guide/processes.xml
+++ b/system/doc/efficiency_guide/processes.xml
@@ -36,13 +36,11 @@
     <p>An Erlang process is lightweight compared to threads and
     processes in operating systems.</p>
 
-    <p>A newly spawned Erlang process uses 309 words of memory
-    in the non-SMP emulator without HiPE support. (SMP support
-    and HiPE support both add to this size.) The size can
+    <p>A newly spawned Erlang process uses 326 words of memory. The size can
     be found as follows:</p>
 
     <pre>
-Erlang (BEAM) emulator version 5.6 [async-threads:0] [kernel-poll:false]
+Erlang/OTP 24 [erts-12.0] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]
 
 Eshell V5.6  (abort with ^G)
 1> <input>Fun = fun() -> receive after infinity -> ok end end.</input>
@@ -372,18 +370,14 @@ true
   <section>
     <title>SMP Emulator</title>
 
-    <p>The SMP emulator (introduced in R11B) takes advantage of a
-    multi-core or multi-CPU computer by running several Erlang scheduler
-    threads (typically, the same as the number of cores). Each scheduler
-    thread schedules Erlang processes in the same way as the Erlang scheduler
-    in the non-SMP emulator.</p>
+    <p>The emulator takes advantage of a multi-core or multi-CPU
+    computer by running several Erlang scheduler
+    threads (typically, the same as the number of cores).</p>
 
-    <p>To gain performance by using the SMP emulator, your application
+    <p>To gain performance from a multi-core computer, your application
     <em>must have more than one runnable Erlang process</em> most of the time.
     Otherwise, the Erlang emulator can still only run one Erlang process
-    at the time, but you must still pay the overhead for locking. Although
-    Erlang/OTP tries to reduce the locking overhead as much as possible,
-    it will never become exactly zero.</p>
+    at the time.</p>
 
     <p>Benchmarks that appear to be concurrent are often sequential.
     The estone benchmark, for example, is entirely sequential. So is


### PR DESCRIPTION
The non-SMP emulator was removed in OTP 21.0.
