### PR TITLE
Do not bind sockets created from FDs

### DIFF
--- a/lib/kernel/src/gen_tcp_socket.erl
+++ b/lib/kernel/src/gen_tcp_socket.erl
@@ -164,7 +164,10 @@ connect_open(Addrs, Domain, ConnectOpts, Opts, Fd, Timer, BindAddr) ->
             ErrRef = make_ref(),
             try
                 ok(ErrRef, call(Server, {setopts, SocketOpts ++ Setopts})),
-                ok(ErrRef, call_bind(Server, BindAddr)),
+                if
+                    not is_integer(Fd) -> ok(ErrRef, call_bind(Server, BindAddr));
+                    true -> ok
+                end,
                 DefaultError = {error, einval},
                 Socket =  
                     val(ErrRef,
@@ -294,7 +297,10 @@ listen_open(Domain, ListenOpts, Opts, Fd, Backlog, BindAddr) ->
                      Server,
                      {setopts,
                       [{start_opts, StartOpts}] ++ SocketOpts ++ Setopts})),
-                ok(ErrRef, call_bind(Server, BindAddr)),
+                if
+                    not is_integer(Fd) -> ok(ErrRef, call_bind(Server, BindAddr));
+                    true -> ok
+                end,
                 Socket = val(ErrRef, call(Server, {listen, Backlog})),
                 {ok, ?MODULE_socket(Server, Socket)}
             catch

--- a/lib/kernel/src/gen_tcp_socket.erl
+++ b/lib/kernel/src/gen_tcp_socket.erl
@@ -165,8 +165,8 @@ connect_open(Addrs, Domain, ConnectOpts, Opts, Fd, Timer, BindAddr) ->
             try
                 ok(ErrRef, call(Server, {setopts, SocketOpts ++ Setopts})),
                 if
-                    not is_integer(Fd) -> ok(ErrRef, call_bind(Server, BindAddr));
-                    true -> ok
+                    is_map_key(fd, ExtraOpts) -> ok;
+                    true -> ok(ErrRef, call_bind(Server, BindAddr))
                 end,
                 DefaultError = {error, einval},
                 Socket =  
@@ -298,8 +298,8 @@ listen_open(Domain, ListenOpts, Opts, Fd, Backlog, BindAddr) ->
                      {setopts,
                       [{start_opts, StartOpts}] ++ SocketOpts ++ Setopts})),
                 if
-                    not is_integer(Fd) -> ok(ErrRef, call_bind(Server, BindAddr));
-                    true -> ok
+                    is_map_key(fd, ExtraOpts) -> ok;
+                    true -> ok(ErrRef, call_bind(Server, BindAddr))
                 end,
                 Socket = val(ErrRef, call(Server, {listen, Backlog})),
                 {ok, ?MODULE_socket(Server, Socket)}


### PR DESCRIPTION
These sockets should be already bound for us, otherwise it is pointless to pass them. In the end we are (almost) always able to create sockets on our own (while we can not be able to bind it to some values). This will check if socket is created form existing FD, and if so, it will silently skip bind, assuming that it is already bound.

Fix #4680