### PR TITLE
Correct order of optimization passes

### DIFF
--- a/lib/compiler/src/beam_ssa_bool.erl
+++ b/lib/compiler/src/beam_ssa_bool.erl
@@ -110,7 +110,9 @@
 %% the same control flow graph analysis and simplification as
 %% bool_opt/3 already does.
 %%
-
+%% This optimization pass must be first to be run after conversion
+%% to SSA code, both for correctness and effectiveness reasons.
+%%
 
 -module(beam_ssa_bool).
 -export([module/2]).

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -867,13 +867,13 @@ kernel_passes() ->
      {iff,dssa,{listing,"ssa"}},
      {iff,ssalint,{pass,beam_ssa_lint}},
      {delay,
-      [{unless,no_share_opt,{pass,beam_ssa_share}},
-       {iff,dssashare,{listing,"ssashare"}},
-       {unless,no_share_opt,{iff,ssalint,{pass,beam_ssa_lint}}},
-
-       {unless,no_bool_opt,{pass,beam_ssa_bool}},
+      [{unless,no_bool_opt,{pass,beam_ssa_bool}},
        {iff,dbool,{listing,"bool"}},
        {unless,no_bool_opt,{iff,ssalint,{pass,beam_ssa_lint}}},
+
+       {unless,no_share_opt,{pass,beam_ssa_share}},
+       {iff,dssashare,{listing,"ssashare"}},
+       {unless,no_share_opt,{iff,ssalint,{pass,beam_ssa_lint}}},
 
        {unless,no_recv_opt,{pass,beam_ssa_recv}},
        {iff,drecv,{listing,"recv"}},

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -2345,6 +2345,7 @@ beam_bool_SUITE(_Config) ->
     erl1246(),
     erl1253(),
     erl1384(),
+    gh4788(),
     beam_ssa_bool_coverage(),
     ok.
 
@@ -2822,6 +2823,23 @@ erl1384_1(V) ->
         {_, false} -> gurka;
         _ -> gaffel
     end.
+
+gh4788() ->
+    ok = do_gh4788(id(0)),
+    ok = do_gh4788(id(1)),
+    ok = do_gh4788(id(undefined)),
+    lt_0_or_undefined = catch do_gh4788(id(-1)),
+    ok.
+
+do_gh4788(N) ->
+    %% beam_ssa_bool would do an unsafe optimization when run after
+    %% the beam_ssa_share pass.
+    case {N >= 0, N == undefined} of
+        {true, _} -> ok;
+        {_, true} -> ok;
+        _ -> throw(lt_0_or_undefined)
+    end,
+    ok.
 
 beam_ssa_bool_coverage() ->
     {"*","abc"} = collect_modifiers("abc*", []),


### PR DESCRIPTION
81bc659e4cf0 switched the order of some optimization passes to
speed up compilation. Unfortunately, in rare circumstances that
would cause the `beam_ssa_bool` pass to do unsafe optimizations.

This commit eliminates the problem by running the `beam_ssa_bool` pass
before the `beam_ssa_share` pass (that is a partial revert of the
problematic commit). On my computer, that increases the compilation
time for the `String.Unicode` module in the Elixir standard library
with about 2 seconds (13 seconds instead of 11 seconds,
approximately).

Closes #4788.