### PR TITLE
GH-4396: exported function instead of fun to set up remote tracing

### DIFF
--- a/lib/runtime_tools/src/dbg.erl
+++ b/lib/runtime_tools/src/dbg.erl
@@ -34,7 +34,7 @@
 -export([fun2ms/1]).
 
 %% Local exports
--export([erlang_trace/3,get_info/0,deliver_and_flush/1]).
+-export([erlang_trace/3,get_info/0,deliver_and_flush/1,do_relay/2]).
 
 %% Debug exports
 -export([wrap_presort/2, wrap_sort/2, wrap_postsort/1, wrap_sortfix/2,
@@ -942,9 +942,9 @@ erlang_trace(AtomPid, How, Flags) ->
 
 relay(Node,To) when Node /= node() ->
     case get(Node) of
-	undefined -> 
+	undefined ->
 	    S = self(),
-	    Pid = spawn_link(Node, fun() -> do_relay(S,To) end),
+	    Pid = spawn_link(Node, dbg, do_relay, [S, To]),
 	    receive {started,Remote} -> put(Node, {Pid,Remote}) end,
 	    {ok,Pid};
 	{_Relay,PortOrPid} ->


### PR DESCRIPTION
This fixes GH-4396. The function `dbg:n/1` used a local fun to set up a tracer on a remote node. This works fine as long as the remote node is running exactly the same version of Erlang/OTP but does not work at all otherwise. This is fixed by exporting the relevant function (`dbg:do_relay/2`) and calling this function on the remote node to set up remote tracing.