### PR TITLE
timer: modernization and improvements

### DIFF
--- a/lib/stdlib/doc/src/timer.xml
+++ b/lib/stdlib/doc/src/timer.xml
@@ -50,7 +50,9 @@
     <p>Creating timers using
       <seemfa marker="erts:erlang#send_after/3">erlang:send_after/3</seemfa> and
       <seemfa marker="erts:erlang#start_timer/3">erlang:start_timer/3</seemfa>
-      is much more efficient than using the timers provided by this module. See
+      is more efficient than using the timers provided by this module. However,
+      the timer module has been improved in OTP 25, making it more efficient and
+      less susceptible to being overloaded. See
       <seeguide marker="system/efficiency_guide:commoncaveats#timer-module">the
       Timer Module section in the Efficiency Guide</seeguide>.</p>
   </description>
@@ -116,8 +118,9 @@
           <c>exit_after(<anno>Time</anno>, self(),
           <anno>Reason1</anno>)</c>.</p>
         <p><c>exit_after/3</c> sends an exit signal with reason
-          <c><anno>Reason1</anno></c> to
-          pid <c><anno>Pid</anno></c>. Returns <c>{ok, <anno>TRef</anno>}</c>
+          <c><anno>Reason1</anno></c> to <c><anno>Target</anno></c>,
+          which can be a local process identifier or an atom of a registered
+          name. Returns <c>{ok, <anno>TRef</anno>}</c>
           or <c>{error, <anno>Reason2</anno>}</c>.</p>
       </desc>
     </func>
@@ -149,7 +152,7 @@
         <p><c>kill_after/1</c> is the same as
           <c>exit_after(<anno>Time</anno>, self(), kill)</c>.</p>
         <p><c>kill_after/2</c> is the same as
-          <c>exit_after(<anno>Time</anno>, <anno>Pid</anno>, kill)</c>.</p>
+          <c>exit_after(<anno>Time</anno>, <anno>Target</anno>, kill)</c>.</p>
       </desc>
     </func>
 
@@ -190,15 +193,16 @@
     <func>
       <name name="send_after" arity="2" since=""/>
       <name name="send_after" arity="3" since=""/>
-      <fsummary>Send <c>Message</c> to <c>Pid</c> after a specified
+      <fsummary>Send <c>Message</c> to <c>Destination</c> after a specified
         <c>Time</c>.</fsummary>
       <desc>
         <taglist>
           <tag><c>send_after/3</c></tag>
           <item>
-            <p>Evaluates <c><anno>Pid</anno> ! <anno>Message</anno></c> after
-              <c><anno>Time</anno></c> milliseconds. (<c><anno>Pid</anno></c>
-              can also be an atom of a registered name.)</p>
+            <p>Evaluates <c><anno>Destination</anno> ! <anno>Message</anno></c> after
+              <c><anno>Time</anno></c> milliseconds. (<c><anno>Destination</anno></c> can
+              be a remote or local process identifier, an atom of a registered name or
+              a tuple <c>{RegName, Node}</c> for a registered name at another node.)</p>
             <p>Returns <c>{ok, <anno>TRef</anno>}</c> or
               <c>{error, <anno>Reason</anno>}</c>.</p>
             <p>See also
@@ -223,10 +227,11 @@
         <taglist>
           <tag><c>send_interval/3</c></tag>
           <item>
-            <p>Evaluates <c><anno>Pid</anno> ! <anno>Message</anno></c>
+            <p>Evaluates <c><anno>Destination</anno> ! <anno>Message</anno></c>
               repeatedly after <c><anno>Time</anno></c> milliseconds.
-              (<c><anno>Pid</anno></c> can also be
-              an atom of a registered name.)</p>
+              (<c><anno>Destination</anno></c> can be a remote or local process
+              identifier, an atom of a registered name or a tuple <c>{RegName, Node}</c>
+              for a registered name at another node.)</p>
             <p>Returns <c>{ok, <anno>TRef</anno>}</c> or
               <c>{error, <anno>Reason</anno>}</c>.</p>
           </item>
@@ -249,6 +254,11 @@
           or suspends the process forever if <c><anno>Time</anno></c> is the
           atom <c>infinity</c>. Naturally, this
           function does <em>not</em> return immediately.</p>
+        <note>
+          <p>Before OTP 25, <c>timer:sleep/1</c> did not accept integer
+            timeout values greater than <c>16#ffffffff</c>, that is, <c>2^32-1</c>.
+            Since OTP 25, arbitrarily high integer values are accepted.</p>
+        </note>
       </desc>
     </func>
 
@@ -350,4 +360,3 @@ timer:cancel(R),
       <seemfa marker="#cancel/1"><c>cancel/1</c></seemfa>.</p>
   </section>
 </erlref>
-

--- a/lib/stdlib/src/timer.erl
+++ b/lib/stdlib/src/timer.erl
@@ -26,129 +26,198 @@
 	 cancel/1, sleep/1, tc/1, tc/2, tc/3, now_diff/2,
 	 seconds/1, minutes/1, hours/1, hms/3]).
 
--export([start_link/0, start/0, 
-	 handle_call/3,  handle_info/2,  
+-export([start_link/0, start/0,
+	 handle_call/3,  handle_info/2,
 	 init/1,
 	 code_change/3, handle_cast/2, terminate/2]).
 
-%% internal exports for test purposes only
--export([get_status/0]).
-
-%% types which can be used by other modules
+%% Types which can be used by other modules
 -export_type([tref/0]).
 
-%% Max
--define(MAX_TIMEOUT, 16#0800000).
--define(TIMER_TAB, timer_tab).
--define(INTERVAL_TAB, timer_interval_tab).
+%% Max value for a receive's after clause.
+-define(MAX_RECEIVE_AFTER, 16#ffffffff).
+
+%% Validations
+-define(valid_time(T), is_integer(T), T >= 0).
+-define(valid_mfa(M, F, A), is_atom(M), is_atom(F), is_list(A)).
 
 %%
 %% Time is in milliseconds.
 %%
--opaque tref()    :: {integer(), reference()}.
+-opaque tref()    :: {type(), reference()}.
+-type type()      :: 'once' | 'interval' | 'instant' | 'send_local'.
 -type time()      :: non_neg_integer().
 
 %%
 %% Interface functions
 %%
 -spec apply_after(Time, Module, Function, Arguments) ->
-                         {'ok', TRef} | {'error', Reason} when
-      Time :: time(),
-      Module :: module(),
-      Function :: atom(),
-      Arguments :: [term()],
-      TRef :: tref(),
-      Reason :: term().
+          {'ok', TRef} | {'error', Reason}
+              when Time :: time(),
+                   Module :: module(),
+                   Function :: atom(),
+                   Arguments :: [term()],
+                   TRef :: tref(),
+                   Reason :: term().
+apply_after(0, M, F, A)
+  when ?valid_mfa(M, F, A) ->
+    do_apply({M, F, A}),
+    {ok, {instant, make_ref()}};
+apply_after(Time, M, F, A)
+  when ?valid_time(Time),
+       ?valid_mfa(M, F, A) ->
+    req(apply_once, {system_time(), Time, {M, F, A}});
+apply_after(_Time, _M, _F, _A) ->
+    {error, badarg}.
 
-apply_after(Time, M, F, A) ->
-    req(apply_after, {Time, {M, F, A}}).
+-spec send_after(Time, Destination, Message) -> {'ok', TRef} | {'error', Reason}
+              when Time :: time(),
+                   Destination :: pid() | (RegName :: atom()) | {RegName :: atom(), Node :: node()},
+                   Message :: term(),
+                   TRef :: tref(),
+                   Reason :: term().
+send_after(0, PidOrRegName, Message)
+  when is_pid(PidOrRegName);
+       is_atom(PidOrRegName) ->
+    PidOrRegName ! Message,
+    {ok, {instant, make_ref()}};
+send_after(0, {RegName, Node} = Dest, Message)
+  when is_atom(RegName),
+       is_atom(Node) ->
+    Dest ! Message,
+    {ok, {instant, make_ref()}};
+send_after(Time, Pid, Message)
+  when ?valid_time(Time),
+       is_pid(Pid),
+       node(Pid) =:= node() ->
+    TRef = erlang:send_after(Time, Pid, Message),
+    {ok, {send_local, TRef}};
+send_after(Time, Pid, Message)
+  when is_pid(Pid) ->
+    apply_after(Time, ?MODULE, send, [Pid, Message]);
+send_after(Time, RegName, Message)
+  when is_atom(RegName) ->
+    apply_after(Time, ?MODULE, send, [RegName, Message]);
+send_after(Time, {RegName, Node} = Dest, Message)
+  when is_atom(RegName),
+       is_atom(Node) ->
+    apply_after(Time, ?MODULE, send, [Dest, Message]);
+send_after(_Time, _PidOrRegName, _Message) ->
+    {error, badarg}.
 
--spec send_after(Time, Pid, Message) -> {'ok', TRef} | {'error', Reason} when
-      Time :: time(),
-      Pid :: pid() | (RegName :: atom()),
-      Message :: term(),
-      TRef :: tref(),
-      Reason :: term().
-send_after(Time, Pid, Message) ->
-    req(apply_after, {Time, {?MODULE, send, [Pid, Message]}}).
-
--spec send_after(Time, Message) -> {'ok', TRef} | {'error', Reason} when
-      Time :: time(),
-      Message :: term(),
-      TRef :: tref(),
-      Reason :: term().
+-spec send_after(Time, Message) -> {'ok', TRef} | {'error', Reason}
+              when Time :: time(),
+                   Message :: term(),
+                   TRef :: tref(),
+                   Reason :: term().
 send_after(Time, Message) ->
     send_after(Time, self(), Message).
 
--spec exit_after(Time, Pid, Reason1) -> {'ok', TRef} | {'error', Reason2} when
-      Time :: time(),
-      Pid :: pid() | (RegName :: atom()),
-      TRef :: tref(),
-      Reason1 :: term(),
-      Reason2 :: term().
+-spec exit_after(Time, Target, Reason1) -> {'ok', TRef} | {'error', Reason2}
+              when Time :: time(),
+                   Target :: pid() | (RegName :: atom()),
+                   TRef :: tref(),
+                   Reason1 :: term(),
+                   Reason2 :: term().
 exit_after(Time, Pid, Reason) ->
-    req(apply_after, {Time, {erlang, exit, [Pid, Reason]}}).
+    apply_after(Time, erlang, exit, [Pid, Reason]).
 
--spec exit_after(Time, Reason1) -> {'ok', TRef} | {'error', Reason2} when
-      Time :: time(),
-      TRef :: tref(),
-      Reason1 :: term(),
-      Reason2 :: term().
+-spec exit_after(Time, Reason1) -> {'ok', TRef} | {'error', Reason2}
+              when Time :: time(),
+                   TRef :: tref(),
+                   Reason1 :: term(),
+                   Reason2 :: term().
 exit_after(Time, Reason) ->
     exit_after(Time, self(), Reason).
 
--spec kill_after(Time, Pid) -> {'ok', TRef} | {'error', Reason2} when
-      Time :: time(),
-      Pid :: pid() | (RegName :: atom()),
-      TRef :: tref(),
-      Reason2 :: term().
+-spec kill_after(Time, Target) -> {'ok', TRef} | {'error', Reason2}
+              when Time :: time(),
+                   Target :: pid() | (RegName :: atom()),
+                   TRef :: tref(),
+                   Reason2 :: term().
 kill_after(Time, Pid) ->
     exit_after(Time, Pid, kill).
 
--spec kill_after(Time) -> {'ok', TRef} | {'error', Reason2} when
-      Time :: time(),
-      TRef :: tref(),
-      Reason2 :: term().
+-spec kill_after(Time) -> {'ok', TRef} | {'error', Reason2}
+              when Time :: time(),
+                   TRef :: tref(),
+                   Reason2 :: term().
 kill_after(Time) ->
     exit_after(Time, self(), kill).
 
 -spec apply_interval(Time, Module, Function, Arguments) ->
-                            {'ok', TRef} | {'error', Reason} when
-      Time :: time(),
-      Module :: module(),
-      Function :: atom(),
-      Arguments :: [term()],
-      TRef :: tref(),
-      Reason :: term().
-apply_interval(Time, M, F, A) ->
-    req(apply_interval, {Time, self(), {M, F, A}}).
+          {'ok', TRef} | {'error', Reason}
+              when Time :: time(),
+                   Module :: module(),
+                   Function :: atom(),
+                   Arguments :: [term()],
+                   TRef :: tref(),
+                   Reason :: term().
+apply_interval(Time, M, F, A)
+  when ?valid_time(Time),
+       ?valid_mfa(M, F, A) ->
+    req(apply_interval, {system_time(), Time, self(), {M, F, A}});
+apply_interval(_Time, _M, _F, _A) ->
+    {error, badarg}.
 
--spec send_interval(Time, Pid, Message) ->
-                           {'ok', TRef} | {'error', Reason} when
-      Time :: time(),
-      Pid :: pid() | (RegName :: atom()),
-      Message :: term(),
-      TRef :: tref(),
-      Reason :: term().
-send_interval(Time, Pid, Message) ->
-    req(apply_interval, {Time, Pid, {?MODULE, send, [Pid, Message]}}).
+-spec send_interval(Time, Destination, Message) -> {'ok', TRef} | {'error', Reason}
+              when Time :: time(),
+                   Destination :: pid() | (RegName :: atom()) | {RegName :: atom(), Node :: node()},
+                   Message :: term(),
+                   TRef :: tref(),
+                   Reason :: term().
+send_interval(Time, Pid, Message)
+  when ?valid_time(Time),
+       is_pid(Pid) ->
+    req(apply_interval, {system_time(), Time, Pid, {?MODULE, send, [Pid, Message]}});
+send_interval(Time, RegName, Message)
+  when ?valid_time(Time),
+       is_atom(RegName) ->
+    req(apply_interval, {system_time(), Time, RegName, {?MODULE, send, [RegName, Message]}});
+send_interval(Time, Dest = {RegName, Node}, Message)
+  when ?valid_time(Time),
+       is_atom(RegName),
+       is_atom(Node) ->
+    req(apply_interval, {system_time(), Time, Dest, {?MODULE, send, [Dest, Message]}});
+send_interval(_Time, _Pid, _Message) ->
+    {error, badarg}.
 
--spec send_interval(Time, Message) -> {'ok', TRef} | {'error', Reason} when
-      Time :: time(),
-      Message :: term(),
-      TRef :: tref(),
-      Reason :: term().
+-spec send_interval(Time, Message) -> {'ok', TRef} | {'error', Reason}
+              when Time :: time(),
+                   Message :: term(),
+                   TRef :: tref(),
+                   Reason :: term().
 send_interval(Time, Message) ->
     send_interval(Time, self(), Message).
 
--spec cancel(TRef) -> {'ok', 'cancel'} | {'error', Reason} when
-      TRef :: tref(),
-      Reason :: term().
-cancel(BRef) ->
-    req(cancel, BRef).
+-spec cancel(TRef) -> {'ok', 'cancel'} | {'error', Reason}
+              when TRef :: tref(),
+                   Reason :: term().
+cancel({instant, Ref})
+  when is_reference(Ref) ->
+    {ok, cancel};
+cancel({send_local, Ref})
+  when is_reference(Ref) ->
+    _ = erlang:cancel_timer(Ref),
+    {ok, cancel};
+cancel({once, Ref} = TRef)
+  when is_reference(Ref) ->
+    req(cancel, TRef);
+cancel({interval, Ref} = TRef)
+  when is_reference(Ref) ->
+    req(cancel, TRef);
+cancel(_TRef) ->
+    {error, badarg}.
 
--spec sleep(Time) -> 'ok' when
-      Time :: timeout().
+-spec sleep(Time) -> 'ok'
+              when Time :: timeout().
+sleep(T)
+  when is_integer(T),
+       T > ?MAX_RECEIVE_AFTER ->
+    receive
+    after ?MAX_RECEIVE_AFTER ->
+            sleep(T - ?MAX_RECEIVE_AFTER)
+    end;
 sleep(T) ->
     receive
     after T -> ok
@@ -157,10 +226,10 @@ sleep(T) ->
 %%
 %% Measure the execution time (in microseconds) for Fun().
 %%
--spec tc(Fun) -> {Time, Value} when
-      Fun :: function(),
-      Time :: integer(),
-      Value :: term().
+-spec tc(Fun) -> {Time, Value}
+              when Fun :: function(),
+                   Time :: integer(),
+                   Value :: term().
 tc(F) ->
     T1 = erlang:monotonic_time(),
     Val = F(),
@@ -171,11 +240,11 @@ tc(F) ->
 %%
 %% Measure the execution time (in microseconds) for Fun(Args).
 %%
--spec tc(Fun, Arguments) -> {Time, Value} when
-      Fun :: function(),
-      Arguments :: [term()],
-      Time :: integer(),
-      Value :: term().
+-spec tc(Fun, Arguments) -> {Time, Value}
+              when Fun :: function(),
+                   Arguments :: [term()],
+                   Time :: integer(),
+                   Value :: term().
 tc(F, A) ->
     T1 = erlang:monotonic_time(),
     Val = apply(F, A),
@@ -186,12 +255,12 @@ tc(F, A) ->
 %%
 %% Measure the execution time (in microseconds) for an MFA.
 %%
--spec tc(Module, Function, Arguments) -> {Time, Value} when
-      Module :: module(),
-      Function :: atom(),
-      Arguments :: [term()],
-      Time :: integer(),
-      Value :: term().
+-spec tc(Module, Function, Arguments) -> {Time, Value}
+              when Module :: module(),
+                   Function :: atom(),
+                   Arguments :: [term()],
+                   Time :: integer(),
+                   Value :: term().
 tc(M, F, A) ->
     T1 = erlang:monotonic_time(),
     Val = apply(M, F, A),
@@ -203,250 +272,245 @@ tc(M, F, A) ->
 %% Calculate the time difference (in microseconds) of two
 %% erlang:now() timestamps, T2-T1.
 %%
--spec now_diff(T2, T1) -> Tdiff when
-      T1 :: erlang:timestamp(),
-      T2 :: erlang:timestamp(),
-      Tdiff :: integer().
+-spec now_diff(T2, T1) -> Tdiff
+              when T1 :: erlang:timestamp(),
+                   T2 :: erlang:timestamp(),
+                   Tdiff :: integer().
 now_diff({A2, B2, C2}, {A1, B1, C1}) ->
     ((A2-A1)*1000000 + B2-B1)*1000000 + C2-C1.
 
 %%
-%% Convert seconds, minutes etc. to milliseconds.    
+%% Convert seconds, minutes etc. to milliseconds.
 %%
--spec seconds(Seconds) -> MilliSeconds when
-      Seconds :: non_neg_integer(),
-      MilliSeconds :: non_neg_integer().
+-spec seconds(Seconds) -> MilliSeconds
+              when Seconds :: non_neg_integer(),
+                   MilliSeconds :: non_neg_integer().
 seconds(Seconds) ->
     1000*Seconds.
--spec minutes(Minutes) -> MilliSeconds when
-      Minutes :: non_neg_integer(),
-      MilliSeconds :: non_neg_integer().
+
+-spec minutes(Minutes) -> MilliSeconds
+              when Minutes :: non_neg_integer(),
+                   MilliSeconds :: non_neg_integer().
 minutes(Minutes) ->
     1000*60*Minutes.
--spec hours(Hours) -> MilliSeconds when
-      Hours :: non_neg_integer(),
-      MilliSeconds :: non_neg_integer().
+
+-spec hours(Hours) -> MilliSeconds
+              when Hours :: non_neg_integer(),
+                   MilliSeconds :: non_neg_integer().
 hours(Hours) ->
     1000*60*60*Hours.
--spec hms(Hours, Minutes, Seconds) -> MilliSeconds when
-      Hours :: non_neg_integer(),
-      Minutes :: non_neg_integer(),
-      Seconds :: non_neg_integer(),
-      MilliSeconds :: non_neg_integer().
+
+-spec hms(Hours, Minutes, Seconds) -> MilliSeconds
+              when Hours :: non_neg_integer(),
+                   Minutes :: non_neg_integer(),
+                   Seconds :: non_neg_integer(),
+                   MilliSeconds :: non_neg_integer().
 hms(H, M, S) ->
     hours(H) + minutes(M) + seconds(S).
 
-%%   
+%%
 %%   Start/init functions
 %%
 
-%%   Start is only included because of backward compatibility!
 -spec start() -> 'ok'.
 start() ->
-    ensure_started().
+    {ok, _Pid} = do_start(),
+    ok.
+
+do_start() ->
+    case
+	supervisor:start_child(
+          kernel_sup,
+          #{
+            id => timer_server,
+            start => {?MODULE, start_link, []},
+            restart => permanent,
+            shutdown => 1000,
+            type => worker,
+            modules => [?MODULE]
+           }
+         )
+    of
+	{ok, Pid} ->
+	    {ok, Pid};
+	{ok, Pid, _} ->
+	    {ok, Pid};
+	{error, {already_started, Pid}} ->
+	    {ok, Pid};
+	Error ->
+	    Error
+    end.
 
 -spec start_link() -> {'ok', pid()} | {'error', term()}.
 start_link() ->
-    gen_server:start_link({local, timer_server}, ?MODULE, [], []).    
+    gen_server:start_link({local, timer_server}, ?MODULE, [], []).
 
--spec init([]) -> {'ok', [], 'infinity'}.
+-spec init([]) -> {'ok', ets:tid()}.
 init([]) ->
     process_flag(trap_exit, true),
-    ?TIMER_TAB = ets:new(?TIMER_TAB, [named_table,ordered_set,protected]),
-    ?INTERVAL_TAB = ets:new(?INTERVAL_TAB, [named_table,protected]),
-    {ok, [], infinity}.
-
--spec ensure_started() -> 'ok'.
-ensure_started() ->
-    case whereis(timer_server) of
-	undefined -> 
-	    C = {timer_server, {?MODULE, start_link, []}, permanent, 1000, 
-		 worker, [?MODULE]},
-	    _ = supervisor:start_child(kernel_safe_sup, C),
-	    ok;
-	_ -> ok
-    end.
+    Tab = ets:new(?MODULE, []),
+    {ok, Tab}.
 
 %% server calls
 
+%% Try sending a call. If it fails with reason noproc,
+%% try starting the timer server and try once again.
 req(Req, Arg) ->
-    SysTime = system_time(),
-    ensure_started(),
-    gen_server:call(timer_server, {Req, Arg, SysTime}, infinity).
+    try
+	maybe_req(Req, Arg)
+    catch
+	exit:{noproc, _} ->
+	    {ok, _Pid} = do_start(),
+	    maybe_req(Req, Arg)
+    end.
 
-%%
-%% handle_call(Request, From, Timers) -> 
-%%  {reply, Response, Timers, Timeout}
-%%
-%% Time and Timeout is in milliseconds. Started is in microseconds.
-%%
--type timers() :: term(). % XXX: refine?
+maybe_req(Req, Arg) ->
+    gen_server:call(timer_server, {Req, Arg}, infinity).
 
--spec handle_call(term(), term(), timers()) ->
-        {'reply', term(), timers(), timeout()} | {'noreply', timers(), timeout()}.
-handle_call({apply_after, {Time, Op}, Started}, _From, _Ts) 
-  when is_integer(Time), Time >= 0 ->
-    BRef = {Started + 1000*Time, make_ref()},
-    Timer = {BRef, timeout, Op},
-    ets:insert(?TIMER_TAB, Timer),
-    Timeout = timer_timeout(system_time()),
-    {reply, {ok, BRef}, [], Timeout};
-handle_call({apply_interval, {Time, To, MFA}, Started}, _From, _Ts) 
-  when is_integer(Time), Time >= 0 ->
-    %% To must be a pid or a registered name
-    case get_pid(To) of
-	Pid when is_pid(Pid) ->
-	    catch link(Pid),
-	    SysTime = system_time(),
-	    Ref = make_ref(),
-	    BRef1 = {interval, Ref},
-	    Interval = Time*1000,
-	    BRef2 = {Started + Interval, Ref},
-	    Timer = {BRef2, {repeat, Interval, Pid}, MFA},
-	    ets:insert(?INTERVAL_TAB, {BRef1,BRef2,Pid}),
-	    ets:insert(?TIMER_TAB, Timer),
-	    Timeout = timer_timeout(SysTime),
-	    {reply, {ok, BRef1}, [], Timeout};
-	_ ->
-	    {reply, {error, badarg}, [], next_timeout()}
-    end;
-handle_call({cancel, BRef = {_Time, Ref}, _}, _From, Ts) 
-  when is_reference(Ref) ->
-    delete_ref(BRef),
-    {reply, {ok, cancel}, Ts, next_timeout()};
-handle_call({cancel, _BRef, _}, _From, Ts) ->
-    {reply, {error, badarg}, Ts, next_timeout()};
-handle_call({apply_after, _, _}, _From, Ts) ->
-    {reply, {error, badarg}, Ts, next_timeout()};
-handle_call({apply_interval, _, _}, _From, Ts) ->
-    {reply, {error, badarg}, Ts, next_timeout()};
-handle_call(_Else, _From, Ts) ->		  % Catch anything else
-    {noreply, Ts, next_timeout()}.
+%% Call handling.
+-spec handle_call(term(), term(), Tab) ->
+          {'reply', term(), Tab} | {'noreply', Tab} when
+      Tab :: ets:tid().
+%% Start a one-shot timer.
+handle_call({apply_once, {Started, Time, MFA}}, _From, Tab) ->
+    Timeout = Started + Time,
+    Reply = try
+                erlang:start_timer(
+                  Timeout,
+                  self(),
+                  {apply_once, MFA},
+                  [{abs, true}]
+                 )
+            of
+                SRef ->
+                    ets:insert(Tab, {SRef, SRef}),
+                    {ok, {once, SRef}}
+            catch
+                error:badarg ->
+                    {error, badarg}
+            end,
+    {reply, Reply, Tab};
+%% Start an interval timer.
+handle_call({apply_interval, {Started, Time, Pid, MFA}}, _From, Tab) ->
+    NextTimeout = Started + Time,
+    TRef = monitor(process, Pid),
+    Reply = try
+                erlang:start_timer(
+                  NextTimeout,
+                  self(),
+                  {apply_interval, NextTimeout, Time, TRef, MFA},
+                  [{abs, true}]
+                 )
+            of
+                SRef ->
+                    ets:insert(Tab, {TRef, SRef}),
+                    {ok, {interval, TRef}}
+            catch
+                error:badarg ->
+                    demonitor(TRef, [flush]),
+                    {error, badarg}
+            end,
+    {reply, Reply, Tab};
+%% Cancel a one-shot timer.
+handle_call({cancel, {once, TRef}}, _From, Tab) ->
+    _ = remove_timer(TRef, Tab),
+    {reply, {ok, cancel}, Tab};
+%% Cancel an interval timer.
+handle_call({cancel, {interval, TRef}}, _From, Tab) ->
+    _ = case remove_timer(TRef, Tab) of
+            true ->
+                demonitor(TRef, [flush]);
+            false ->
+                ok
+        end,
+    {reply, {ok, cancel}, Tab};
+%% Unexpected.
+handle_call(_Req, _From, Tab) ->
+    {noreply, Tab}.
 
--spec handle_info(term(), timers()) -> {'noreply', timers(), timeout()}.
-handle_info(timeout, Ts) ->                       % Handle timeouts 
-    Timeout = timer_timeout(system_time()),
-    {noreply, Ts, Timeout};
-handle_info({'EXIT',  Pid, _Reason}, Ts) ->       % Oops, someone died
-    pid_delete(Pid),
-    {noreply, Ts, next_timeout()};
-handle_info(_OtherMsg, Ts) ->                     % Other Msg's
-    {noreply, Ts, next_timeout()}.
+%% Info handling.
+-spec handle_info(term(), Tab) -> {'noreply', Tab}
+              when Tab :: ets:tid().
+%% One-shot timer timeout.
+handle_info({timeout, TRef, {apply_once, MFA}}, Tab) ->
+    case ets:take(Tab, TRef) of
+        [{TRef, _SRef}] ->
+            do_apply(MFA);
+        [] ->
+            ok
+    end,
+    {noreply, Tab};
+%% Interval timer timeout.
+handle_info({timeout, _, {apply_interval, CurTimeout, Time, TRef, MFA}}, Tab) ->
+    case ets:member(Tab, TRef) of
+	true ->
+	    NextTimeout = CurTimeout + Time,
+	    SRef = erlang:start_timer(
+                     NextTimeout,
+                     self(),
+                     {apply_interval, NextTimeout, Time, TRef, MFA},
+                     [{abs, true}]
+                    ),
+	    ets:update_element(Tab, TRef, {2, SRef}),
+	    do_apply(MFA);
+	false ->
+	    ok
+    end,
+    {noreply, Tab};
+%% A process related to an interval timer died.
+handle_info({'DOWN', TRef, process, _Pid, _Reason}, Tab) ->
+    _ = remove_timer(TRef, Tab),
+    {noreply, Tab};
+%% Unexpected.
+handle_info(_Req, Tab) ->
+    {noreply, Tab}.
 
--spec handle_cast(term(), timers()) -> {'noreply', timers(), timeout()}.
-handle_cast(_Req, Ts) ->                          % Not predicted but handled
-    {noreply, Ts, next_timeout()}.
+%% Cast handling.
+-spec handle_cast(term(), Tab) -> {'noreply', Tab}
+              when Tab :: ets:tid().
+%% Unexpected.
+handle_cast(_Req, Tab) ->
+    {noreply, Tab}.
 
--spec terminate(term(), _State) -> 'ok'.
-terminate(_Reason, _State) ->
+-spec terminate(term(), _Tab) -> 'ok'.
+terminate(_Reason, _Tab) ->
     ok.
 
 -spec code_change(term(), State, term()) -> {'ok', State}.
-code_change(_OldVsn, State, _Extra) ->
+code_change(_OldVsn, Tab, _Extra) ->
     %% According to the man for gen server no timer can be set here.
-    {ok, State}.				
+    {ok, Tab}.
 
-%% 
-%% timer_timeout(SysTime)
-%%
-%% Apply and remove already timed-out timers. A timer is a tuple
-%% {Time, BRef, Op, MFA}, where Time is in microseconds.
-%% Returns {Timeout, Timers}, where Timeout is in milliseconds.
-%%
-timer_timeout(SysTime) ->
-    case ets:first(?TIMER_TAB) of
-	'$end_of_table' -> 
-	    infinity;
-	{Time, _Ref} when Time > SysTime ->
-	    Timeout = (Time - SysTime + 999) div 1000,
-	    %% Returned timeout must fit in a small int
-	    erlang:min(Timeout, ?MAX_TIMEOUT);
-	Key ->
-	    case ets:lookup(?TIMER_TAB, Key) of
-		[{Key, timeout, MFA}] ->
-		    ets:delete(?TIMER_TAB,Key),
-		    do_apply(MFA),
-		    timer_timeout(SysTime);
-		[{{Time, Ref}, Repeat = {repeat, Interv, To}, MFA}] ->
-		    ets:delete(?TIMER_TAB,Key),
-		    NewTime = Time + Interv,
-		    %% Update the interval entry (last in table)
-		    ets:insert(?INTERVAL_TAB,{{interval,Ref},{NewTime,Ref},To}),
-		    do_apply(MFA),
-		    ets:insert(?TIMER_TAB, {{NewTime, Ref}, Repeat, MFA}),
-		    timer_timeout(SysTime)
-	    end
-    end.
-
-%%
-%% delete_ref 
-%%
-
-delete_ref(BRef = {interval, _}) ->
-    case ets:lookup(?INTERVAL_TAB, BRef) of
-	[{_, BRef2, _Pid}] ->
-	    ets:delete(?INTERVAL_TAB, BRef),
-	    ets:delete(?TIMER_TAB, BRef2);
-	_ -> % TimerReference does not exist, do nothing
-	    ok
-    end;
-delete_ref(BRef) ->
-    ets:delete(?TIMER_TAB, BRef).
-
-%%
-%% pid_delete
-%%
-
--spec pid_delete(pid()) -> 'ok'.
-pid_delete(Pid) ->
-    IntervalTimerList = 
-	ets:select(?INTERVAL_TAB,
-		   [{{'_', '_','$1'},
-		     [{'==','$1',Pid}],
-		     ['$_']}]),
-    lists:foreach(fun({IntKey, TimerKey, _ }) ->
-			  ets:delete(?INTERVAL_TAB, IntKey),
-			  ets:delete(?TIMER_TAB, TimerKey)
-		  end, IntervalTimerList).
-
-%% Calculate time to the next timeout. Returned timeout must fit in a 
-%% small int.
-
--spec next_timeout() -> timeout().
-next_timeout() ->
-    case ets:first(?TIMER_TAB) of
-	'$end_of_table' -> 
-	    infinity;
-	{Time, _} ->
-	    erlang:min(positive((Time - system_time() + 999) div 1000), ?MAX_TIMEOUT)
+%% Remove a timer.
+remove_timer(TRef, Tab) ->
+    case ets:take(Tab, TRef) of
+	[{TRef, SRef}] ->
+	    ok = erlang:cancel_timer(SRef, [{async, true}, {info, false}]),
+	    true;
+	[] -> % TimerReference does not exist, do nothing
+	    false
     end.
 
 %% Help functions
+
+%% If send op. send directly (faster than spawn)
+do_apply({?MODULE, send, A}) ->
+    catch send(A);
+%% If exit op. resolve registered name
+do_apply({erlang, exit, [Name, Reason]}) ->
+    catch exit(get_pid(Name), Reason);
 do_apply({M,F,A}) ->
-    case {M, F, A} of
-	{?MODULE, send, A} -> 
-	    %% If send op. send directly, (faster than spawn)
-	    catch send(A);
-	{erlang, exit, [Name, Reason]} ->
-	    catch exit(get_pid(Name), Reason);
-	_ -> 
-	    %% else spawn process with the operation
-	    catch spawn(M,F,A)      
-    end.
+    catch spawn(M, F, A).
 
-positive(X) ->
-    erlang:max(X, 0).
-
-
-%%
-%%  system_time() -> time in microseconds
-%%
+%% Get current time in milliseconds,
+%% ceil'ed to the next millisecond.
 system_time() ->
-    erlang:monotonic_time(1000000).
+    (erlang:monotonic_time(microsecond) + 999) div 1000.
 
 send([Pid, Msg]) ->
     Pid ! Msg.
 
+%% Resolve a registered name.
 get_pid(Name) when is_pid(Name) ->
     Name;
 get_pid(undefined) ->
@@ -455,22 +519,3 @@ get_pid(Name) when is_atom(Name) ->
     get_pid(whereis(Name));
 get_pid(_) ->
     undefined.
-
-%%
-%% get_status() -> 
-%%    {{TimerTabName,TotalNumTimers},{IntervalTabName,NumIntervalTimers}}
-%%
-%% This function is for test purposes only; it is used by the test suite.
-%% There is a small possibility that there is a mismatch of one entry 
-%% between the 2 tables if this call is made when the timer server is 
-%% in the middle of a transaction
- 
--spec get_status() ->
-	{{?TIMER_TAB,non_neg_integer()},{?INTERVAL_TAB,non_neg_integer()}}.
-
-get_status() ->
-    Info1 = ets:info(?TIMER_TAB),
-    {size,TotalNumTimers} = lists:keyfind(size, 1, Info1),
-    Info2 = ets:info(?INTERVAL_TAB),
-    {size,NumIntervalTimers} = lists:keyfind(size, 1, Info2),
-    {{?TIMER_TAB,TotalNumTimers},{?INTERVAL_TAB,NumIntervalTimers}}.

--- a/lib/stdlib/test/timer_SUITE.erl
+++ b/lib/stdlib/test/timer_SUITE.erl
@@ -132,7 +132,7 @@ big_loop(C, N, Pids) ->
 	    %%Pids2=Pids1,
 
 	    %% wait a little while
-	    timer:sleep(rand:uniform(200)*3),
+	    ok = timer:sleep(rand:uniform(200)*3),
 
 	    %% spawn zero, one or two nrev to get some load ;-/
 	    Pids3 = start_nrev(Pids2, rand:uniform(100)),
@@ -168,7 +168,7 @@ s_a_t(C, TimeOut) ->
 a_t(C, TimeOut) ->
     start_watchdog(self(), TimeOut),
     Start = system_time(),
-    timer:send_after(TimeOut, self(), now),
+    {ok, _} = timer:send_after(TimeOut, self(), now),
     receive
 	now ->
 	    Stop = system_time(),
@@ -202,12 +202,12 @@ i_wait(Start, Prev, Times, TimeOut, Times, Ref, C) ->
 	interval ->
 	    Now = system_time(),
 	    report_interval(C, {final,Times}, Start, Prev, Now, TimeOut),
-	    timer:cancel(Ref),
+	    {ok, cancel} = timer:cancel(Ref),
 	    exit(done);
 	watchdog ->
 	    Now = system_time(),
 	    report_interval(C, {final,Times}, Start, Prev, Now, TimeOut),
-	    timer:cancel(Ref),
+	    {ok, cancel} = timer:cancel(Ref),
 	    ok = io:format("Internal watchdog timeout (i), not good!!~n",
 			   []),
 	    exit(done)
@@ -358,7 +358,7 @@ system_time() ->
 %% ------------------------------------------------------- %%
 
 do_nrev(Sleep) ->
-    timer:sleep(Sleep),
+    ok = timer:sleep(Sleep),
     test(1000,"abcdefghijklmnopqrstuvxyz1234"),
     exit(done).
 

--- a/system/doc/efficiency_guide/commoncaveats.xml
+++ b/system/doc/efficiency_guide/commoncaveats.xml
@@ -39,11 +39,16 @@
      marker="erts:erlang#send_after/3">erlang:send_after/3</seemfa>
      and
      <seemfa marker="erts:erlang#start_timer/3">erlang:start_timer/3</seemfa>,
-     is much more efficient than using the timers provided by the
-     <seeerl marker="stdlib:timer">timer</seeerl> module in STDLIB.
-     The <c>timer</c> module uses a separate process to manage the timers.
-     That process can easily become overloaded if many processes
-     create and cancel timers frequently.</p>
+     is more efficient than using the timers provided by the
+     <seeerl marker="stdlib:timer">timer</seeerl> module in STDLIB.</p>
+     <p>The <c>timer</c> module uses a separate process to manage the timers.
+     Before OTP 25, this management overhead was substantial and increasing
+     with the number of timers, especially when they were short-lived, so the
+     timer server process could easily become overloaded and unresponsive.
+     In OTP 25, the timer module was improved by removing most of the management
+     overhead and the resulting performance penalty. Still, the timer server
+     remains a single process, and it may at some point become a bottleneck
+     of an application.</p>
 
      <p>The functions in the <c>timer</c> module that do not manage timers
      (such as <c>timer:tc/3</c> or <c>timer:sleep/1</c>), do not call the


### PR DESCRIPTION
This started as a minor improvement, and gradually grew into, well, _this_... ^^; The `timer` module seems to be getting out of fashion these days, having a reputation for getting clogged when there are many timers. And no wonder, the most recent changes being 6 years ago, but most of it more than 10 years old. But the functionality is actually pretty handy (and I like old stuff ;)), so I went to dust it off a bit.

This is what has been done:
* All validations have been moved into the exported accessor functions, meaning they happen in the calling process and don't bother the timer server.
* An `apply_after` call (and thus, other functions using it, like `send_after`) do the apply (call `do_apply`) immediately without going through the timer server if the timeout is `0`.
* ~The `ensure_started/0` function, to start the timer server dynamically when needed, has been removed. It checked if `timer_server` was registered, on every call, and started it if not. Now, a call is always tried, and if it results in an exit exception with reason `{noproc, _}`, the timer server is started.~
* The backing `ets` tables are not named any more, instead their `tid`s are carried in a state field.
* ~The backing `ets` tables were made `public` so they can be accessed from other processes to enable parallelism.~
* Where possible, some of the newer `ets` functions are used, like `ets:take/2` to replace lookup-and-delete.
* ~The processing of the timers is now done in a spawned process.~
* ~The cancellation of timers is also done in spawned processes.~
* Interval timers are not linked to processes any more, but instead they are monitored. Linking, in the old implementation, had two downsides: processes that were linked once were never unlinked even when the interval timers were all cancelled; and, the tables needed to be scanned with `select` and subsequent `delete`s to find and remove all timers linked to a pid. While, with links, there would only be a single `EXIT` message, now with monitors there are `DOWN` messages for every interval timer tied to a process, ~but as cancellation is done in spawned processes, the timer server is not blocked while they pour in~.

~Doing timeout processing and cancellation in spawned processes has the potential for race conditions when it comes to interval timers, where two tables are involved and the scheduled timeouts are taken and re-inserted. For this case, the order of operations has been slightly changed. @juhlig and I, independently, played out every possible order of events on paper, and don't see a way where a race condition could lead to orphaned timers. But we may have missed something nevertheless, so it would be good if someone took another look at it.~

The test suite(s) have not been touched much and still pass (with only some very small alterations). The `get_status` function which is only for test purposes is now obsolete and replaced by retrieving the state and reading the table info. ~I left it in, though, if you think it should remain.~

~There was a special case that we don't know how to address properly, so it is still there. An interval timer with an interval of `0` will stall the timer server, as the `timer_timeout` function will hit it over and over again, that is, the timer does not "move". Ideas, anyone?~

~Another thing where we are unsure is the handling of manual cancellation. As mentioned, the actual operation is done in a spawned process (so it won't hinder the timer server), but the answer to the caller is kept back until it has finished. Not sure if this is necessary, after all, `{ok, cancelled}` is returned in any case, even if the timer didn't exist in the first place. So it would be possible to reply immediately. Opinions?~

[EDIT]: See https://github.com/erlang/otp/pull/4811#issuecomment-839833211 below.