### PR TITLE
Add new lists:mapkeyfind/3 function to map finding

### DIFF
--- a/lib/stdlib/doc/src/lists.xml
+++ b/lib/stdlib/doc/src/lists.xml
@@ -467,6 +467,21 @@ flatmap(Fun, List1) ->
     </func>
 
     <func>
+      <name name="mapkeyfind" arity="3" since=""/>
+      <fsummary>Search for an element in a list of maps.</fsummary>
+      <desc>
+        <p>Searches the list of maps <c><anno>MapList</anno></c> for a map whose
+           value associated with key <c><anno>Key</anno></c> compares equal to
+           <c><anno>Value</anno></c>. Returns <c><anno>Map</anno></c> if such a
+           map is found, otherwise <c>false</c>.</p>
+        <p><em>Example:</em></p>
+        <pre>
+> <input>lists:mapkeyfind(42, id, [#{id => 1, person => jane},#{id => 42, answer => 42}]).</input>
+#{id => 42, answer => 42}</pre>
+      </desc>
+    </func>
+
+    <func>
       <name name="last" arity="1" since=""/>
       <fsummary>Return last element in a list.</fsummary>
       <desc>

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -32,7 +32,8 @@
 	 concat/1, flatten/1, flatten/2, flatlength/1,
 	 keydelete/3, keyreplace/4, keytake/3, keystore/4,
 	 keysort/2, keymerge/3, rkeymerge/3, rukeymerge/3, 
-	 ukeysort/2, ukeymerge/3, keymap/3]).
+	 ukeysort/2, ukeymerge/3, keymap/3,
+	 mapkeyfind/3]).
 
 -export([merge/3, rmerge/3, sort/2, umerge/3, rumerge/3, usort/2]).
 
@@ -956,6 +957,20 @@ keymap(Fun, Index, [Tup|Tail]) ->
    [setelement(Index, Tup, Fun(element(Index, Tup)))|keymap(Fun, Index, Tail)];
 keymap(Fun, Index, []) when is_integer(Index), Index >= 1, 
                             is_function(Fun, 1) -> [].
+
+-spec mapkeyfind(Value, Key, MapList) -> Map | false when
+      Value :: any(),
+      Key :: any(),
+      MapList :: [Map],
+      Map :: map().
+
+mapkeyfind(_Value, _Key, []) ->
+    false;
+mapkeyfind(Value, Key, [H | _]) when is_map(H), is_map_key(Key, H),
+                                     map_get(Key, H) =:= Value ->
+    H;
+mapkeyfind(Value, Key, [_ | T]) ->
+    mapkeyfind(Value, Key, T).
 
 %%% Suggestion from OTP-2948: sort and merge with Fun.
 

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -47,6 +47,7 @@
 	 ukeymerge/1, rukeymerge/1,
 	 ukeysort_1/1, ukeysort_i/1, ukeysort_stable/1,
 	 ukeysort_rand/1, ukeysort_error/1,
+	 mapkeyfind/1,
 	 funmerge/1, rfunmerge/1,
 	 funsort_1/1, funsort_stable/1, funsort_rand/1,
 	 funsort_error/1,
@@ -102,7 +103,7 @@ groups() ->
       [keymerge, rkeymerge, keysort_1, keysort_rand,
        keysort_i, keysort_stable, keysort_error]},
      {key, [parallel], [keymember, keysearch_keyfind, keystore,
-			keytake, keyreplace]},
+                        keytake, keyreplace, mapkeyfind]},
      {sort,[parallel],[merge, rmerge, sort_1, sort_rand]},
      {ukeysort, [parallel],
       [ukeymerge, rukeymerge, ukeysort_1, ukeysort_rand,
@@ -426,6 +427,31 @@ keyreplace(Config) when is_list(Config) ->
     %% Error cases.
     {'EXIT',_} = (catch lists:keyreplace(k, 1, [], not_tuple)),
     {'EXIT',_} = (catch lists:keyreplace(k, 0, [], {a,b})),
+    ok.
+
+%% Test lists:mapkeyfind/3.
+mapkeyfind(Config) when is_list(Config) ->
+    Q1 = #{id => 1,
+           question => "Question of Life, The Universe, and Everything",
+           answer => 42,
+           a_specific_field => test},
+    Q2 = #{id => 2,
+           question => "Six by nine.",
+           answer => 42,
+           {x,'*',y} => 13#42},
+    Q3 = #{id => 3,
+           question => "(bb|[^b]{2})",
+           answer => "That is the question",
+           recursive => true},
+    List = [Q1, Q2, Q3],
+    Q1 = lists:mapkeyfind(1, id, List),
+    Q2 = lists:mapkeyfind(2, id, List),
+    Q3 = lists:mapkeyfind(true, recursive, List),
+
+    %% Error cases.
+    false = lists:mapkeyfind(1, id, []),
+    false = lists:mapkeyfind(42, id, List),
+    {'EXIT',_} = (catch lists:mapkeyfind(1, id, not_list)),
     ok.
 
 merge(Config) when is_list(Config) ->


### PR DESCRIPTION
Stdlib's lists module has some functions for searching a list for a
tuple whose given element position compares equal to a given value, but
it lacks the same functionality for maps, i.e., a function for searching
a list for a map whose given key compares equal to the given value.

This new function allow us to find such a map in a list without the need
to create a fun to filter it every time a map search is required.

Usage:
```
1> lists:mapkeyfind(42, id, [#{id => 1, person => jane},
                             #{id => 42, answer => 42}]).
#{id => 42, answer => 42}

2> lists:mapkeyfind(not_found, id, [#{id => 1, person => jane},
                                    #{id => 42, answer => 42}]).
false

3> lists:mapkeyfind(not_found, id, []).
false
```