### PR TITLE
Disable the JIT compiler when cross-compiling for Android

### DIFF
--- a/xcomp/erl-xcomp-arm-android.conf
+++ b/xcomp/erl-xcomp-arm-android.conf
@@ -2,7 +2,7 @@
 ##
 ## %CopyrightBegin%
 ##
-## Copyright Ericsson AB 2009-2019. All Rights Reserved.
+## Copyright Ericsson AB 2009-2021. All Rights Reserved.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -61,8 +61,8 @@ erl_xcomp_host=arm-linux-androideabi
 # * `erl_xcomp_configure_flags' - Extra configure flags to pass to the
 #   `configure' script.
 # Set --enable-builtin-zlib to avoid a inflateGetDictionary missing symbol
-erl_xcomp_configure_flags="--without-termcap --without-wx \
-                                          --enable-builtin-zlib"
+erl_xcomp_configure_flags="--disable-jit --without-termcap --without-wx \
+                           --enable-builtin-zlib"
 
 
 ## -- Cross Compiler and Other Tools -------------------------------------------

--- a/xcomp/erl-xcomp-arm64-android.conf
+++ b/xcomp/erl-xcomp-arm64-android.conf
@@ -2,7 +2,7 @@
 ##
 ## %CopyrightBegin%
 ##
-## Copyright Ericsson AB 2019. All Rights Reserved.
+## Copyright Ericsson AB 2021. All Rights Reserved.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -61,8 +61,8 @@ erl_xcomp_host=aarch64-linux-android
 # * `erl_xcomp_configure_flags' - Extra configure flags to pass to the
 #   `configure' script.
 # Set --enable-builtin-zlib to avoid a inflateGetDictionary missing symbol
-erl_xcomp_configure_flags="--without-termcap --without-wx \
-                                          --enable-builtin-zlib"
+erl_xcomp_configure_flags="--disable-jit --without-termcap --without-wx \
+                           --enable-builtin-zlib"
 
 
 ## -- Cross Compiler and Other Tools -------------------------------------------

--- a/xcomp/erl-xcomp-x86_64-android.conf
+++ b/xcomp/erl-xcomp-x86_64-android.conf
@@ -60,8 +60,8 @@ erl_xcomp_host=x86_64-linux-android
 
 # * `erl_xcomp_configure_flags' - Extra configure flags to pass to the
 #   `configure' script.
-erl_xcomp_configure_flags="--disable-hipe --without-termcap --without-wx \
-                                          --enable-builtin-zlib"
+erl_xcomp_configure_flags="--disable-jit --without-termcap --without-wx \
+                           --enable-builtin-zlib"
 
 ## -- Cross Compiler and Other Tools -------------------------------------------
 


### PR DESCRIPTION
This PR fixes the cross compilation of Erlang/OTP 24.0 for Android x86_64 which is failing due to the 2 `shm_open` / `shm_unlink`  functions used by AsmJit in [virtmem.cpp](https://github.com/erlang/otp/blob/master/erts/emulator/asmjit/core/virtmem.cpp) but not supported on Android. Disabling the JIT compiler simply fixes the compilation in this case.

The build failure was detected by @D4no0 and discussed here: https://github.com/JeromeDeBretagne/erlanglauncher/issues/5#issuecomment-839726608.

As AsmJit is not supporting the specificities of Android at the moment, I've also disabled the JIT compiler when cross-compiling for Android ARM architectures to cover the case when BeamAsm is enabled for ARM later on.

I've also removed a remaining `--disable-hipe` option since this is not applicable anymore.

I don't know when yet, but I'll try to investigate the best allocation strategy in [virtmem.cpp](https://github.com/erlang/otp/blob/master/erts/emulator/asmjit/core/virtmem.cpp) to see how it should be implemented for Android, if it can reuse an existing case or if it needs a dedicated one.

Thanks a lot

P.S. For reference, the non-support of these 2 functions on Android is officially documented here: https://android.googlesource.com/platform/bionic/+/master/docs/status.md :
```
Missing functions are either obsolete or explicitly disallowed by SELinux:
    [...]
    shm_open/shm_unlink
```
and they are commented out in the Android NDK headers here:
https://android.googlesource.com/platform/bionic/+/master/tests/headers/posix/sys_mman_h.c#90
```
#if !defined(__BIONIC__) // Disallowed by SELinux, so not implemented.
  FUNCTION(shm_open, int (*f)(const char*, int, mode_t));
  FUNCTION(shm_unlink, int (*f)(const char*));
#endif
```