### PR TITLE
jinterface: Fix a NullPointerException in AbstractConnection

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java
@@ -1,7 +1,7 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2017. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -565,6 +565,11 @@ public abstract class AbstractConnection extends Thread {
                     // received tick? send tock!
                     if (len == 0) {
                         synchronized (this) {
+                            if (socket == null) {
+                                // protect from a potential thin race when the
+                                // connection to the remote node is closed
+                                throw new IOException("socket was closed");
+                            }
                             OutputStream out = socket.getOutputStream();
                             out.write(tock);
                             out.flush();


### PR DESCRIPTION
After a call to close(), `socket` is set to null which can lead to a NullPointerException in the `receive_loop` still handling tick messages [in AbstractConnection line 568](https://github.com/erlang/otp/blob/master/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java#L568):
```
567                        synchronized (this) {
568                            OutputStream out = socket.getOutputStream();
569                            out.write(tock);
570                            out.flush();
571                        }
```

Cleanly end the `receive_loop` instead in this case. 

The crash was detected through future changes to the https://github.com/JeromeDeBretagne/erlanglauncher/ project, I have confirmed this change is fixing the issue as expected.

Thanks a lot