### PR TITLE
jinterface: Support custom distribution protocols without epmd

### DIFF
--- a/lib/jinterface/doc/src/jinterface_users_guide.xml
+++ b/lib/jinterface/doc/src/jinterface_users_guide.xml
@@ -19,7 +19,7 @@
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
       See the License for the specific language governing permissions and
       limitations under the License.
-    
+
     </legalnotice>
 
     <title>The Jinterface Package</title>
@@ -140,17 +140,29 @@
       unique name in the form of an identifier composed partly of the
       hostname on which the node is running, e.g "gurka@sallad.com". Several
       such nodes can run on the same host as long as their names are unique.
-      The class <seefile marker="java/com/ericsson/otp/erlang/OtpNode">OtpNode</seefile> 
-      represents an Erlang node. It is created with a name
-      and optionally a port number on which it listens for incoming
-      connections. Before creating an instance of 
-      <seefile marker="java/com/ericsson/otp/erlang/OtpNode">OtpNode</seefile>, 
-      ensure that Epmd is running on the host machine. See the Erlang documentation 
-      for more information about Epmd. In this example, the host name is appended
+      The class <seefile marker="java/com/ericsson/otp/erlang/OtpNode">OtpNode</seefile>
+      represents an Erlang node.</p>
+    <p>It is created with a name
+      and optionally a TCP/IP socket port number on which it listens for incoming
+      connections. By default before creating an instance of
+      <seefile marker="java/com/ericsson/otp/erlang/OtpNode">OtpNode</seefile>,
+      ensure that Epmd is running on the host machine. See the Erlang documentation
+      for more information about Epmd.</p>
+    <p>In this example, the host name is appended
       automatically to the identifier, and the port number is chosen by the
       underlying system:</p>
     <code type="none">
 OtpNode node = new OtpNode("gurka");    </code>
+    <p>It is also possible to use alternative communication (or distribution)
+      protocols without Epmd by switching to a custom transport factory extending
+      the OtpGenericTransportFactory abstract class, for example based on
+      Unix Domain Sockets instead of the default TCP/IP sockets.</p>
+    <p>In this example, the host name is appended automatically to the identifier
+      and a custom transport factory is used:</p>
+    <code type="none">
+OtpGenericTransportFactory customFactory = new MyCustomFactory();
+OtpNode node = new OtpNode("gurka", customFactory);
+    </code>
   </section>
 
   <section>
@@ -227,8 +239,11 @@ OtpNode node = new OtpNode("gurka");    </code>
     <title>Transport Factory</title>
     <p>All necessary connections are made using methods of
     <seefile marker="java/com/ericsson/otp/erlang/OtpTransportFactory">OtpTransportFactory</seefile>
-    interface. Default OtpTransportFactory implementation is based on standard Socket class.
-    User may provide custom transport factory as needed. See java doc for details.</p>
+    interface. The default OtpTransportFactory implementation is based on standard TCP/IP Socket class
+    and relies on epmd. User may provide custom transport factory as needed. See java doc for details.</p>
+    <p>For alternative distribution protocols working without epmd, using a transport factory extending the
+    <seefile marker="java/com/ericsson/otp/erlang/OtpGenericTransportFactory">OtpGenericTransportFactory</seefile>
+    abstract class will disable the automatic epmd registration and lookup in Jinterface.</p>
   </section>
 
   <section>
@@ -356,18 +371,19 @@ OtpNode node = new OtpNode("gurka");    </code>
 
   <section>
     <title>Using EPMD</title>
-    <p>Epmd is the Erlang Port Mapper Daemon. Distributed Erlang nodes
-      register with epmd on the localhost to indicate to other nodes that
-      they exist and can accept connections. Epmd maintains a register of
-      node and port number information, and when a node wishes to connect to
+    <p>Epmd is the Erlang Port Mapper Daemon. By default distributed Erlang
+      nodes register with epmd on the localhost to indicate to other nodes that
+      they exist and can accept connections. Epmd maintains a register of node
+      and socket port number information, and when a node wishes to connect to
       another node, it first contacts epmd in order to find out the correct
-      port number to connect to.</p>
-    <p>The basic interaction with EPMD is done through instances of 
+      socket port number to connect to. It is also possible to use alternative
+      distribution protocols which don't need epmd at all.</p>
+    <p>The basic interaction with EPMD is done through instances of
       <seefile marker="java/com/ericsson/otp/erlang/OtpEpmd">OtpEpmd</seefile> class.
-      Nodes wishing to contact other nodes must first request information 
-      from Epmd before a connection can be set up, however this is done automatically 
+      Nodes wishing to contact other nodes must first request information
+      from Epmd before a connection can be set up, however this is done automatically
       by <seefile marker="java/com/ericsson/otp/erlang/OtpSelf#connect(com.ericsson.otp.erlang.OtpPeer)">OtpSelf.connect()</seefile> when necessary. </p>
-    <p>When you use <seefile marker="java/com/ericsson/otp/erlang/OtpSelf#connect(com.ericsson.otp.erlang.OtpPeer)">OtpSelf.connect()</seefile> to connect to an Erlang node, 
+    <p>When you use <seefile marker="java/com/ericsson/otp/erlang/OtpSelf#connect(com.ericsson.otp.erlang.OtpPeer)">OtpSelf.connect()</seefile> to connect to an Erlang node,
       a connection is first made to epmd and, if the node is known, a
       connection is then made to the Erlang node.</p>
     <p>Java nodes can also register themselves with epmd if they want other

--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractNode.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractNode.java
@@ -1,7 +1,7 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2021. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2022. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,7 +204,7 @@ public class AbstractNode implements OtpTransportFactory {
         this.cookie = cookie;
         this.transportFactory = transportFactory;
 
-        final int i = name.indexOf('@', 0);
+        final int i = name.indexOf('@');
         if (i < 0) {
             alive = name;
             host = localHost;
@@ -285,12 +285,12 @@ public class AbstractNode implements OtpTransportFactory {
         return creation;
     }
 
-	void setCreation(int cr) throws OtpErlangDecodeException {
-		if (cr == 0) {
-			throw new OtpErlangDecodeException("Node creation 0 not allowed");
-		}
-		this.creation = cr;
-	}
+    void setCreation(int cr) throws OtpErlangDecodeException {
+        if (cr == 0) {
+            throw new OtpErlangDecodeException("Node creation 0 not allowed");
+        }
+        this.creation = cr;
+    }
 
     /**
      * Set the authorization cookie used by this node.
@@ -331,5 +331,45 @@ public class AbstractNode implements OtpTransportFactory {
     public OtpServerTransport createServerTransport(final int port)
             throws IOException {
         return transportFactory.createServerTransport(port);
+    }
+
+    /**
+     * Create a client-side transport for alternative distribution protocols
+     * using a transport factory extending the OtpGenericTransportFactory
+     * abstract class. Connect it to the specified server.
+     *
+     * @param peer
+     *            the peer identifying the server to connect to
+     *
+     */
+    public OtpTransport createTransport(final OtpPeer peer)
+            throws IOException {
+        if (transportFactory instanceof OtpGenericTransportFactory) {
+            return ((OtpGenericTransportFactory) transportFactory)
+                .createTransport(peer);
+        }
+        throw new IOException("Method createTransport(OtpPeer) " +
+                              "applicable only for Nodes with a transport " +
+                              "factory instance of OtpGenericTransportFactory");
+    }
+
+    /**
+     * Create a server-side transport for alternative distribution protocols
+     * using a transport factory extending the OtpGenericTransportFactory
+     * abstract class.
+     *
+     * @param node
+     *            the local node identifying the transport to create server-side
+     *
+     */
+    public OtpServerTransport createServerTransport(final OtpLocalNode node)
+            throws IOException {
+        if (transportFactory instanceof OtpGenericTransportFactory) {
+            return ((OtpGenericTransportFactory) transportFactory)
+                .createServerTransport(node);
+        }
+        throw new IOException("Method createServerTransport(OtpLocalNode) " +
+                              "applicable only for Nodes with a transport " +
+                              "factory instance of OtpGenericTransportFactory");
     }
 }

--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/Makefile
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/Makefile
@@ -2,9 +2,9 @@
 
 #
 # %CopyrightBegin%
-# 
+#
 # Copyright Ericsson AB 2000-2022. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # %CopyrightEnd%
 #
 include $(ERL_TOP)/make/target.mk
@@ -82,7 +82,7 @@ ifneq ($(V),0)
 JARFLAGS=-cfv
 endif
 
-JAVA_OPTIONS = -Xlint 
+JAVA_OPTIONS = -Xlint -encoding UTF-8
 
 ifeq ($(TESTROOT),)
 RELEASE_PATH="$(ERL_TOP)/release/$(TARGET)"

--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpGenericTransportFactory.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpGenericTransportFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Jérôme de Bretagne
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %ExternalCopyright%
+ */
+
+package com.ericsson.otp.erlang;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+/**
+ * Transport factory abstract class used to create client-side and server-side
+ * transport instances defined using generic peers and local nodes (instead of
+ * a host + port combination as expected in the base OtpTransportFactory).
+ *
+ * It allows the creation of a transport using Unix Domain Sockets for example.
+ *
+ * OtpGenericTransportFactory is created as a subclass of OtpTransportFactory
+ * to keep backwards compatibility and ease the integration within existing
+ * Jinterface code, but in practice it doesn't support the 3 original methods.
+ */
+public abstract class OtpGenericTransportFactory implements OtpTransportFactory {
+
+    /**
+     * Create an instance of a client-side {@link OtpTransport}
+     *
+     * @param peer
+     *            the peer identifying the server to connect to
+     *
+     * @return a new transport object
+     *
+     * @throws IOException
+     */
+    public abstract OtpTransport createTransport(final OtpPeer peer)
+            throws IOException;
+
+    /**
+     * Create an instance of a server-side {@link OtpServerTransport}
+     *
+     * @param node
+     *            the local node identifying the transport to create server-side
+     *
+     * @return a new transport object
+     *
+     * @throws IOException
+     */
+    public abstract OtpServerTransport createServerTransport(final OtpLocalNode node)
+            throws IOException;
+
+
+    /**
+     * Implement the 3 original methods by throwing an exception as the usage
+     * of a port is not supported by this subclass of OtpTransportFactory.
+     */
+    @Override public OtpTransport createTransport(String addr, int port)
+            throws IOException {
+        throw new IOException("Method createTransport(String, int) " +
+                              "not applicable for OtpGenericTransportFactory");
+    }
+
+    @Override public OtpTransport createTransport(final InetAddress addr, final int port)
+            throws IOException {
+        throw new IOException("Method createTransport(InetAddress, int) " +
+                              "not applicable for OtpGenericTransportFactory");
+    }
+
+    @Override public OtpServerTransport createServerTransport(final int port)
+            throws IOException {
+        throw new IOException("Method createServerTransport(int) " +
+                              "not applicable for OtpGenericTransportFactory");
+    }
+
+}
+

--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpSelf.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/OtpSelf.java
@@ -196,12 +196,20 @@ public class OtpSelf extends OtpLocalNode {
             final OtpTransportFactory transportFactory) throws IOException {
         super(node, cookie, transportFactory);
 
-        sock = createServerTransport(port);
+        if (transportFactory instanceof OtpGenericTransportFactory) {
+            // For alternative distribution protocols using a transport factory
+            // extending the OtpGenericTransportFactory abstract class, pass the
+            // local node as the identifier to use for incoming connections.
+            sock = createServerTransport(this);
 
-        if (port != 0) {
-            this.port = port;
         } else {
-            this.port = sock.getLocalPort();
+            sock = createServerTransport(port);
+
+            if (port != 0) {
+                this.port = port;
+            } else {
+                this.port = sock.getLocalPort();
+            }
         }
 
         pid = createPid();

--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/java_files
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/java_files
@@ -2,9 +2,9 @@
 
 #
 # %CopyrightBegin%
-# 
-# Copyright Ericsson AB 2000-2016. All Rights Reserved.
-# 
+#
+# Copyright Ericsson AB 2000-2022. All Rights Reserved.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # %CopyrightEnd%
 #
 
@@ -44,6 +44,7 @@ COMM = \
 	OtpErlangFun \
 	OtpErlangExternalFun \
 	OtpExternal \
+	OtpGenericTransportFactory \
 	OtpInputStream \
 	OtpLocalNode \
 	OtpNodeStatus \

--- a/lib/jinterface/test/jinterface_SUITE.erl
+++ b/lib/jinterface/test/jinterface_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2004-2021. All Rights Reserved.
+%% Copyright Ericsson AB 2004-2022. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 	 init_per_suite/1, end_per_suite/1,
 	 init_per_testcase/2, end_per_testcase/2]).
 
--export([transport_factory/1,
+-export([generic_transport_factory/1, transport_factory/1,
 	 nodename/1, register_and_whereis/1, get_names/1, boolean_atom/1,
 	 node_ping/1, mbox_ping/1,
 	 java_erlang_send_receive/1,
@@ -114,14 +114,15 @@ end_per_group(_GroupName, Config) ->
 
 fundamental() ->
     [
-     transport_factory,    % TransportFactoryTest.java
-     nodename,             % Nodename.java
-     register_and_whereis, % RegisterAndWhereis.java
-     get_names,            % GetNames.java
-     boolean_atom,         % BooleanAtom.java
-     maps,                 % Maps.java
-     fun_equals,           % FunEquals.java
-     core_match_bind       % CoreMatchBind.java
+     generic_transport_factory, % GenericTransportFactoryTest.java
+     transport_factory,         % TransportFactoryTest.java
+     nodename,                  % Nodename.java
+     register_and_whereis,      % RegisterAndWhereis.java
+     get_names,                 % GetNames.java
+     boolean_atom,              % BooleanAtom.java
+     maps,                      % Maps.java
+     fun_equals,                % FunEquals.java
+     core_match_bind            % CoreMatchBind.java
     ].
 
 ping() ->
@@ -235,6 +236,17 @@ end_per_testcase(_Case,Config) ->
 
 %%%-----------------------------------------------------------------
 %%% TEST CASES
+%%%-----------------------------------------------------------------
+generic_transport_factory(doc) ->
+    ["GenericTransportFactoryTest.java: "
+     "Test custom OTP Generic Transport Factory"];
+generic_transport_factory(suite) ->
+    [];
+generic_transport_factory(Config) when is_list(Config) ->
+    ok = jitu:java(?config(java, Config),
+		   ?config(data_dir, Config),
+		   "GenericTransportFactoryTest").
+
 %%%-----------------------------------------------------------------
 transport_factory(doc) ->
     ["TransportFactoryTest.java: Test custom OTP Transport Factory"];

--- a/lib/jinterface/test/jinterface_SUITE_data/GenericTransportFactoryTest.java
+++ b/lib/jinterface/test/jinterface_SUITE_data/GenericTransportFactoryTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Jérôme de Bretagne
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %ExternalCopyright%
+ */
+
+import java.io.IOException;
+
+import com.ericsson.otp.erlang.OtpGenericTransportFactory;
+import com.ericsson.otp.erlang.OtpLocalNode;
+import com.ericsson.otp.erlang.OtpNode;
+import com.ericsson.otp.erlang.OtpPeer;
+import com.ericsson.otp.erlang.OtpServerTransport;
+import com.ericsson.otp.erlang.OtpSocketTransportFactory;
+import com.ericsson.otp.erlang.OtpTransport;
+import com.ericsson.otp.erlang.OtpTransportFactory;
+
+public class GenericTransportFactoryTest {
+
+    static boolean serverOk = false;
+
+    /**
+     * A minimalist custom generic transport factory working without epmd,
+     * using the node name as the identifier of the listening socket port.
+     */
+    public static class TestFactory extends OtpGenericTransportFactory {
+
+        OtpSocketTransportFactory tf = new OtpSocketTransportFactory();
+
+        public OtpTransport createTransport(final OtpPeer peer)
+                throws IOException {
+            String addr = "localhost";
+            String peerName = peer.alive();
+            int port = 0;
+            try {
+                port = Integer.parseInt(peerName);
+            } catch (NumberFormatException e) {
+            }
+            System.out.println("Creating transport to " + addr + ", " + port);
+            return tf.createTransport(addr, port);
+        }
+
+        public OtpServerTransport createServerTransport(final OtpLocalNode node)
+                throws IOException {
+            String nodeName = node.alive();
+            int port = 0;
+            try {
+                port = Integer.parseInt(nodeName);
+                serverOk = true;
+            } catch (NumberFormatException e) {
+                serverOk = false;
+            }
+            System.out.println("Creating server transport to " + port);
+            return tf.createServerTransport(port);
+        }
+
+    }
+
+    public static void main(final String[] args) throws IOException {
+
+        OtpTransportFactory customFactory = new TestFactory();
+
+        // The 2 test nodes with arbitrary socket port numbers
+        String nodeName1 = "65432";
+        String nodeName2 = "54321";
+
+        // Create the first node
+        final OtpNode node1 = new OtpNode(nodeName1, customFactory);
+        if (!serverOk) {
+            fail("Custom server transport 1 was not created");
+        }
+        System.out.println("Node 1 accepting connections on " + node1.port());
+
+        // Create the second node
+        final OtpNode node2 = new OtpNode(nodeName2, customFactory);
+        if (!serverOk) {
+            fail("Custom server transport 2 was not created");
+        }
+        System.out.println("Node 2 accepting connections on " + node2.port());
+
+        // Finally test the connection between the 2 nodes
+        if (!node1.ping(nodeName2, 2000)) {
+            fail("The 2 nodes couldn't connect");
+        }
+
+    }
+
+    private static void fail(final String string) {
+        System.err.println(string);
+        System.exit(1);
+    }
+}

--- a/lib/jinterface/test/jinterface_SUITE_data/Makefile.src
+++ b/lib/jinterface/test/jinterface_SUITE_data/Makefile.src
@@ -36,6 +36,7 @@ JINTERFACE_CLASSPATH = @jinterface_classpath@
 CLASSPATH = .@PS@$(JINTERFACE_CLASSPATH)@PS@
 
 JAVA_FILES = \
+	GenericTransportFactoryTest.java \
 	TransportFactoryTest.java \
 	Nodename.java \
 	RegisterAndWhereis.java \

--- a/lib/jinterface/test/jinterface_SUITE_data/Makefile.src
+++ b/lib/jinterface/test/jinterface_SUITE_data/Makefile.src
@@ -59,6 +59,6 @@ clean:
 	-del /F /Q $(CLASS_FILES)
 
 $(CLASS_FILES) : $(JAVA_FILES)
-	$(JAVAC) -classpath $(CLASSPATH) $(JAVA_FILES)
+	$(JAVAC) -encoding UTF-8 -classpath $(CLASSPATH) $(JAVA_FILES)
 
 #

--- a/lib/jinterface/test/nc_SUITE_data/Makefile.src
+++ b/lib/jinterface/test/nc_SUITE_data/Makefile.src
@@ -46,6 +46,6 @@ clean:
 	-del /F /Q $(CLASS_FILES)
 
 $(CLASS_FILES) : $(JAVA_FILES)
-	$(JAVAC) -classpath $(CLASSPATH) $(JAVA_FILES)
+	$(JAVAC) -encoding UTF-8 -classpath $(CLASSPATH) $(JAVA_FILES)
 
 #


### PR DESCRIPTION
Here is a change I've been working on for quite some time, to expand the Jinterface compatibility to a wider set of  distribution protocols (for instance based on Unix Domain Sockets) and to remove the mandatory dependency on epmd when using a custom transport factory.

The existing Jinterface classes and interfaces have been designed originally for transport protocols using a socket port number and didn't support other protocols working without epmd. I've tried a few approaches, some of them requiring quite a lot of code duplication so I've dropped those. The trickiest part has been to keep a full backwards compatibility with existing custom factories so it was not possible to extend existing interfaces with new abstract methods.

I've settled with the following approach, by creating a new base `OtpGenericTransportFactory` abstract class which does not expect a socket port number but use the node name instead as a generic identifier. New factories can be created as subclasses of `OtpGenericTransportFactory`, I've created a working example based on Unix Domain Sockets for Android here :
https://github.com/JeromeDeBretagne/erlanglauncher/pull/9/commits/dee25b20d21bbbf269d8bd6b9da1b54a58ecc110

Finally, I've just had to adapt 4 classes: AbstractConnection, AbstractNode, OtpNode and OtpSelf to accept factory instances of the new `OtpGenericTransportFactory` in parallel of the existing socket-based implementation, the changes are quite limited in each. With such transport factories, epmd is not used at all whereas the behaviors remain totally unchanged for regular factories.

I have an end-to-end implementation working on Android based on Unix Domain Sockets and without epmd here: https://github.com/JeromeDeBretagne/erlanglauncher/pull/9 with a connection between an Erlang node using the [erl_uds_dist.erl](https://github.com/JeromeDeBretagne/otp/blob/master/lib/kernel/examples/erl_uds_dist/src/erl_uds_dist.erl) alternative distribution protocol and a Jinterface node.

Let me know what you think, if you detect any issues or have suggestions for improvements.

Thanks a lot

(Edit : update the link to the working example following the renaming from `OtpNamedTransportFactory` to `OtpGenericTransportFactory`)