### PR TITLE
minor memory leaks fixes

### DIFF
--- a/erts/emulator/asan/suppress
+++ b/erts/emulator/asan/suppress
@@ -1,8 +1,3 @@
-leak:erts_alloc_permanent_cache_aligned
-
-# Harmless leak of ErtsThrPrgrData from async threads in exiting emulator
-leak:erts_thr_progress_register_unmanaged_thread
-
 # Block passed to sigaltstack()
 leak:sys_thread_init_signal_stack
 

--- a/erts/emulator/beam/erl_async.c
+++ b/erts/emulator/beam/erl_async.c
@@ -368,7 +368,12 @@ static ERTS_INLINE void async_reply(ErtsAsync *a, ErtsThrQPrepEnQ_t *prep_enq)
 static void
 async_wakeup(void *vtse)
 {
-    erts_tse_set((erts_tse_t *) vtse);
+    /*
+     * 'vtse' might be NULL if we are called after an async thread
+     * has unregistered from thread progress prior to termination.
+     */
+    if (vtse)
+        erts_tse_set((erts_tse_t *) vtse);
 }
 
 static erts_tse_t *async_thread_init(ErtsAsyncQ *aq)
@@ -430,6 +435,7 @@ static void *async_main(void* arg)
 	async_reply(a, prep_enq);
     }
 
+    erts_thr_progress_unregister_unmanaged_thread();
     return NULL;
 }
 

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -6290,9 +6290,6 @@ erts_init_scheduling(int no_schedulers, int no_schedulers_online, int no_poll_th
 	erts_atomic32_set_nob(&schdlr_sspnd.changing,
 				  set_schdlr_sspnd_change_flags);
 
-    init_misc_aux_work();
-
-
     /* init port tasks */
     erts_port_task_init();
 

--- a/erts/emulator/beam/erl_thr_progress.c
+++ b/erts/emulator/beam/erl_thr_progress.c
@@ -554,6 +554,22 @@ erts_thr_progress_register_unmanaged_thread(ErtsThrPrgrCallbacks *callbacks)
     intrnl->unmanaged.callbacks[tpd->id] = *callbacks;
 }
 
+void
+erts_thr_progress_unregister_unmanaged_thread(void)
+{
+    /*
+     * If used, the previously registered wakeup callback
+     * must be prepared for NULL passed as argument. This since
+     * the callback might be called after this unregistration
+     * in case of an outstanding wakeup request when unregistration
+     * is made.
+     */
+    ErtsThrPrgrData* tpd = erts_thr_progress_data();
+    ASSERT(tpd->id >= 0);
+    intrnl->unmanaged.callbacks[tpd->id].arg = NULL;
+    erts_free(ERTS_ALC_T_THR_PRGR_DATA, tpd);
+}
+
 
 ErtsThrPrgrData *
 erts_thr_progress_register_managed_thread(ErtsSchedulerData *esdp,

--- a/erts/emulator/beam/erl_thr_progress.h
+++ b/erts/emulator/beam/erl_thr_progress.h
@@ -127,6 +127,7 @@ void erts_thr_progress_init(int no_schedulers, int managed, int unmanaged);
 ErtsThrPrgrData *erts_thr_progress_register_managed_thread(
     ErtsSchedulerData *esdp, ErtsThrPrgrCallbacks *, int, int);
 void erts_thr_progress_register_unmanaged_thread(ErtsThrPrgrCallbacks *);
+void erts_thr_progress_unregister_unmanaged_thread(void);
 void erts_thr_progress_active(ErtsThrPrgrData *, int on);
 void erts_thr_progress_wakeup(ErtsThrPrgrData *,
 			      ErtsThrPrgrVal value);


### PR DESCRIPTION
Running "erl -emu_type asan -eval "erlang:halt()." shows several minor issues straight away. First, init_misc_aux_work is called twice (and first allocation is made orphan), second, when shutting down, async threads don't clean up thread progress data, and - an expected leak, even documented - signal stack.