### PR TITLE
wx: Fix compile error

### DIFF
--- a/lib/wx/c_src/wxe_return.cpp
+++ b/lib/wx/c_src/wxe_return.cpp
@@ -183,12 +183,38 @@ ERL_NIF_TERM  wxeReturn::make(wxArrayString val) {
     return tail;
 }
 
-ERL_NIF_TERM wxeReturn::make_list_objs(const wxObjectList& list, WxeApp *app, const char *cname)
+ERL_NIF_TERM wxeReturn::make_list_objs(const wxSizerItemList& list, WxeApp *app, const char *cname)
 {
   ERL_NIF_TERM head, tail;
   ERL_NIF_TERM class_name = enif_make_atom(env, cname);
   tail = enif_make_list(env, 0);
-  for(wxObjectList::const_reverse_iterator it = list.rbegin(); it != list.rend(); ++it) {
+  for(wxSizerItemList::const_reverse_iterator it = list.rbegin(); it != list.rend(); ++it) {
+    void * ResultTmp = *it;
+    head = make_ref(app->getRef(ResultTmp,memenv), class_name);
+    tail = enif_make_list_cell(env, head, tail);
+  }
+  return tail;
+}
+
+ERL_NIF_TERM wxeReturn::make_list_objs(const wxMenuItemList& list, WxeApp *app, const char *cname)
+{
+  ERL_NIF_TERM head, tail;
+  ERL_NIF_TERM class_name = enif_make_atom(env, cname);
+  tail = enif_make_list(env, 0);
+  for(wxMenuItemList::const_reverse_iterator it = list.rbegin(); it != list.rend(); ++it) {
+    void * ResultTmp = *it;
+    head = make_ref(app->getRef(ResultTmp,memenv), class_name);
+    tail = enif_make_list_cell(env, head, tail);
+  }
+  return tail;
+}
+
+ERL_NIF_TERM wxeReturn::make_list_objs(const wxWindowList& list, WxeApp *app, const char *cname)
+{
+  ERL_NIF_TERM head, tail;
+  ERL_NIF_TERM class_name = enif_make_atom(env, cname);
+  tail = enif_make_list(env, 0);
+  for(wxWindowList::const_reverse_iterator it = list.rbegin(); it != list.rend(); ++it) {
     void * ResultTmp = *it;
     head = make_ref(app->getRef(ResultTmp,memenv), class_name);
     tail = enif_make_list_cell(env, head, tail);

--- a/lib/wx/c_src/wxe_return.h
+++ b/lib/wx/c_src/wxe_return.h
@@ -62,7 +62,11 @@ public:
     ERL_NIF_TERM make_ext2term(wxETreeItemData * term);
 
     ERL_NIF_TERM make_list_strings(size_t size, wxString* atomName);
-    ERL_NIF_TERM make_list_objs(const wxObjectList& wx_list, WxeApp *app, const char *cname);
+
+    ERL_NIF_TERM make_list_objs(const wxWindowList& wx_list, WxeApp *app, const char *cname);
+    ERL_NIF_TERM make_list_objs(const wxSizerItemList& wx_list, WxeApp *app, const char *cname);
+    ERL_NIF_TERM make_list_objs(const wxMenuItemList& wx_list, WxeApp *app, const char *cname);
+
     ERL_NIF_TERM make_array_objs(wxGridCellCoordsArray& arr);
     // ERL_NIF_TERM make_array_objs(const wxList& wx_list, WxeApp *app, const char *cname);
     ERL_NIF_TERM make_array_objs(wxArrayTreeItemIds& arr);


### PR DESCRIPTION
Make it compile when wxWidgets is built with "-enable-std".

Fixes GH-4834