### PR TITLE
Seal memory leak of jit_code_entry

### DIFF
--- a/erts/emulator/beam/erl_lock_check.c
+++ b/erts/emulator/beam/erl_lock_check.c
@@ -167,6 +167,7 @@ static erts_lc_lock_order_t erts_lock_order[] = {
     {	"erts_alloc_hard_debug",		NULL			},
     {	"hard_dbg_mseg",		        NULL	                },
     {	"perf", 				NULL			},
+    {	"jit_debug_descriptor",			NULL			},
     {	"erts_mmap",				NULL			}
 };
 

--- a/erts/emulator/beam/jit/x86/beam_asm.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.cpp
@@ -624,6 +624,7 @@ struct jit_descriptor {
     jit_actions action_flag;
     struct jit_code_entry *relevant_entry;
     struct jit_code_entry *first_entry;
+    erts_mtx_t mutex;
 };
 
 extern "C"
@@ -665,6 +666,12 @@ static void beamasm_init_gdb_jit_info(void) {
     __jit_debug_descriptor.first_entry = entry;
     __jit_debug_descriptor.relevant_entry = entry;
     __jit_debug_register_code();
+
+    erts_mtx_init(&__jit_debug_descriptor.mutex,
+                  "jit_debug_descriptor",
+                  NIL,
+                  (ERTS_LOCK_FLAGS_PROPERTY_STATIC |
+                   ERTS_LOCK_FLAGS_CATEGORY_GENERIC));
 }
 
 void BeamAssembler::update_gdb_jit_info(std::string modulename,
@@ -711,6 +718,7 @@ void BeamAssembler::update_gdb_jit_info(std::string modulename,
     ASSERT(symfile_size == (symfile - entry->symfile_addr));
 
     /* Insert into linked list */
+    erts_mtx_lock(&__jit_debug_descriptor.mutex);
     entry->next_entry = __jit_debug_descriptor.first_entry;
     if (entry->next_entry) {
         entry->next_entry->prev_entry = entry;
@@ -723,6 +731,7 @@ void BeamAssembler::update_gdb_jit_info(std::string modulename,
     __jit_debug_descriptor.first_entry = entry;
     __jit_debug_descriptor.relevant_entry = entry;
     __jit_debug_register_code();
+    erts_mtx_unlock(&__jit_debug_descriptor.mutex);
 }
 
 extern "C"


### PR DESCRIPTION
by making the `__jit_debug_descriptor` linked list thread safe with a mutex.


(@garazdawi @jhogberg What is `__jit_debug_descriptor` used for anyway?)
