### PR TITLE
Expand group_leader, process_info and standard_io docs

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -4367,6 +4367,12 @@ receive_replies(ReqId, N, Acc) ->
           are delivered to the process. If there is no connection to
           <c><anno>Node</anno></c>, an attempt is made to create one.
           If this fails, a <c>nodedown</c> message is delivered.</p>
+        <p>The delivery of the <c>nodedown</c> signal is not ordered towards other
+          link or monitor signals from the node that goes down. If you need a
+          guarantee that all signals from the remote node has been delivered before
+          the <c>nodedown</c> signal is sent, you should use
+          <seemfa marker="kernel:net_kernel#monitor_nodes/1">
+            <c>net_kernel:monitor_nodes/1</c></seemfa>.</p>
         <p>Nodes connected through hidden connections can be monitored
           as any other nodes.</p>
         <p>Failure: <c>notalive</c> if the local node is not alive.</p>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6102,6 +6102,10 @@ receive_replies(ReqId, N, Acc) ->
           <c><anno>Item</anno></c>s were included
           in <c><anno>ItemList</anno></c>. Valid <c><anno>Item</anno></c>s can
           be included multiple times in <c><anno>ItemList</anno></c>.</p>
+        <p>Getting process informations follows the signal ordering guarentees
+          described in the
+          <seeguide marker="system/reference_manual:processes#signals">
+          Processes Chapter</seeguide> in the <i>Erlang Reference Manual</i>.</p>
         <note>
           <p>If <c>registered_name</c> is part of <c><anno>ItemList</anno></c>
             and the process has no name registered, a

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2556,6 +2556,10 @@ uncompiled code with the same arity are mapped to the same list by
           applications with a supervision tree, because OTP
           assumes the group leader of their processes is
           their application master.</p>
+        <p>Setting the group leader follows the signal ordering guarentees
+          described in the
+          <seeguide marker="system/reference_manual:processes#signals">
+          Processes Chapter</seeguide> in the <i>Erlang Reference Manual</i>.</p>
         <p>See also
           <seemfa marker="#group_leader/0"><c>group_leader/0</c></seemfa>
           and <seeguide marker="system/design_principles:applications#stopping">OTP

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6623,14 +6623,21 @@ end</pre>
       <name name="register" arity="2" since=""/>
       <fsummary>Register a name for a pid (or port).</fsummary>
       <desc>
-        <p>Associates the name <c><anno>RegName</anno></c> with a process
-          identifier (pid) or a port identifier.
+        <p>Registers the name <c><anno>RegName</anno></c> with a process
+          identifier (pid) or a port identifier in the
+          <seeguide marker="system/reference_manual:processes#runtime-service">
+            <c>name registry</c></seeguide>.
           <c><anno>RegName</anno></c>, which must be an atom, can be used
           instead of the pid or port identifier in send operator
-          (<c><anno>RegName</anno> ! Message</c>). Example:</p>
+          (<c><anno>RegName</anno> ! Message</c>) and most other BIFs that
+          take a pid or port identifies as an argument. Example:</p>
         <pre>
 > <input>register(db, Pid).</input>
 true</pre>
+        <p>The registered name is considered a
+          <seeguide marker="system/reference_manual:processes#visible-resources">
+            Directly Visible Erlang Resource</seeguide> and is automatically
+            unregistered when the process terminates.</p>
         <p>Failures:</p>
         <taglist>
           <tag><c>badarg</c></tag>
@@ -12815,12 +12822,17 @@ end</code>
       <name name="unregister" arity="1" since=""/>
       <fsummary>Remove the registered name for a process (or port).</fsummary>
       <desc>
-        <p>Removes the registered name <c><anno>RegName</anno></c>
-          associated with a
-          process identifier or a port identifier, for example:</p>
+        <p>Removes the <seemfa marker="#register/2"><c>registered name</c></seemfa>
+          <c><anno>RegName</anno></c> associated with a
+          process identifier or a port identifier from the
+          <seeguide marker="system/reference_manual:processes#runtime-service">
+            <c>name registry</c></seeguide>. For example:</p>
         <pre>
 > <input>unregister(db).</input>
 true</pre>
+        <p>Keep in mind that you can still receive signals associated with the
+          registered name after it has been unregistered as the sender may
+          have looked up the name before sending to it.</p>
         <p>Users are advised not to unregister system processes.</p>
         <p>Failure: <c>badarg</c> if <c>RegName</c> is not a registered
           name.</p>
@@ -12833,8 +12845,11 @@ true</pre>
       </fsummary>
       <desc>
         <p>Returns the process identifier or port identifier with
-          the registered name <c>RegName</c>. Returns <c>undefined</c>
-          if the name is not registered. Example:</p>
+          the <seemfa marker="#register/2"><c>registered name</c></seemfa>
+          <c>RegName</c> from the
+          <seeguide marker="system/reference_manual:processes#runtime-service">
+            <c>name registry</c></seeguide>.
+          Returns <c>undefined</c> if the name is not registered. Example:</p>
         <pre>
 > <input>whereis(db).</input>
 &lt;0.43.0></pre>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -4367,7 +4367,7 @@ receive_replies(ReqId, N, Acc) ->
           are delivered to the process. If there is no connection to
           <c><anno>Node</anno></c>, an attempt is made to create one.
           If this fails, a <c>nodedown</c> message is delivered.</p>
-        <p>The delivery of the <c>nodedown</c> signal is not ordered towards other
+        <p>The delivery of the <c>nodedown</c> signal is not ordered with respect to other
           link or monitor signals from the node that goes down. If you need a
           guarantee that all signals from the remote node has been delivered before
           the <c>nodedown</c> signal is sent, you should use
@@ -6108,7 +6108,7 @@ receive_replies(ReqId, N, Acc) ->
           <c><anno>Item</anno></c>s were included
           in <c><anno>ItemList</anno></c>. Valid <c><anno>Item</anno></c>s can
           be included multiple times in <c><anno>ItemList</anno></c>.</p>
-        <p>Getting process informations follows the signal ordering guarentees
+        <p>Getting process informations follows the signal ordering guarantees
           described in the
           <seeguide marker="system/reference_manual:processes#signals">
           Processes Chapter</seeguide> in the <i>Erlang Reference Manual</i>.</p>

--- a/lib/stdlib/doc/src/io.xml
+++ b/lib/stdlib/doc/src/io.xml
@@ -1234,9 +1234,9 @@ enter><input>bar.</input>
 
     <p><c>standard_io</c> is an alias for <seemfa marker="erts:erlang#group_leader/0"><c>
       group_leader/0</c></seemfa>, so in order to change where the default input/output
-      requests are sent you can change the group leader using
+      requests are sent you can change the group leader for the current process using
       <seemfa marker="erts:erlang#group_leader/2"><c>
-      group_leader(self(), NewGroupLeader).</c></seemfa></p>
+      group_leader(NewGroupLeader, self()).</c></seemfa></p>
 
     <p>There is always a process registered under the name of
       <c>user</c>. This can be used for sending output to the user.</p>
@@ -1272,4 +1272,3 @@ Error: error 11</pre>
 Module:format_error(ErrorDescriptor)</code>
   </section>
 </erlref>
-

--- a/lib/stdlib/doc/src/io.xml
+++ b/lib/stdlib/doc/src/io.xml
@@ -36,10 +36,12 @@
       or exit if they are not.</p>
  
    <p>All functions in this module have an optional
-      parameter <c>IoDevice</c>. If included, it must be the pid of a
-      process that handles the I/O protocols. Normally, it is the
-      <c>IoDevice</c> returned by
-      <seemfa marker="kernel:file#open/2"><c>file:open/2</c></seemfa>.</p>
+     parameter <seetype marker="#device"><c>IoDevice</c></seetype>.
+     If included, it must be the pid of a process that handles the I/O
+     protocols. Normally, it is a <c>IoDevice</c> returned by
+     <seemfa marker="kernel:file#open/2"><c>file:open/2</c></seemfa>.
+     If no <seetype marker="#device"><c>IoDevice</c></seetype> is given,
+     <c>standard_io</c> is used.</p>
 
     <p>For a description of the I/O protocols, see section
       <seeguide marker="io_protocol">The Erlang I/O Protocol</seeguide>
@@ -71,7 +73,10 @@
       <desc>
         <p>An I/O device, either <c>standard_io</c>, <c>standard_error</c>, a
           registered name, or a pid handling I/O protocols (returned from
-          <seemfa marker="kernel:file#open/2"><c>file:open/2</c></seemfa>).
+          <seemfa marker="kernel:file#open/2"><c>file:open/2</c></seemfa>).</p>
+        <p>For more information about the built-in devices see
+          <seeerl marker="#standard-input-output">Standard Input/Output</seeerl>
+          and <seeerl marker="#standard-error">Standard Error</seeerl>.
         </p>
       </desc>
     </datatype>
@@ -1226,6 +1231,12 @@ enter><input>foo.</input>
 28> <input>io:read(standard_io, 'enter>').</input>
 enter><input>bar.</input>
 {ok,bar}</pre>
+
+    <p><c>standard_io</c> is an alias for <seemfa marker="erts:erlang#group_leader/0"><c>
+      group_leader/0</c></seemfa>, so in order to change where the default input/output
+      requests are sent you can change the group leader using
+      <seemfa marker="erts:erlang#group_leader/2"><c>
+      group_leader(self(), NewGroupLeader).</c></seemfa></p>
 
     <p>There is always a process registered under the name of
       <c>user</c>. This can be used for sending output to the user.</p>

--- a/system/doc/reference_manual/processes.xml
+++ b/system/doc/reference_manual/processes.xml
@@ -379,7 +379,7 @@ spawn(Module, Name, Args) -> pid()
 	  or
           <seemfa marker="erts:erlang#whereis/1"><c>whereis/1</c></seemfa>
 	  BIFs. The request signal is sent to the
-	  <seeguide marker="#runtime-service">name service</seeguide> which
+	  <seeguide marker="#runtime-service">name service</seeguide>, which
 	  responds with the reply signal.
 	</item>
 
@@ -402,7 +402,7 @@ spawn(Module, Name, Args) -> pid()
 
       <p><marker id="runtime-service"/>
         The clock service, the name service, the timer service, and the spawn
-        service mentioned above are services provided by the runtime system.
+        service mentioned previously are services provided by the runtime system.
         Each of these services consists of multiple independently executing
         entities. Such a service can be viewed as a group of processes, and
         could actually be implemented like that. Since each service consists of

--- a/system/doc/reference_manual/processes.xml
+++ b/system/doc/reference_manual/processes.xml
@@ -367,6 +367,22 @@ spawn(Module, Name, Args) -> pid()
 	  responds with the reply signal.
 	</item>
 
+        <tag>
+          <c>register_name_request</c>/<c>register_name_reply</c>,
+	  <c>unregister_name_request</c>/<c>unregister_name_reply</c>,
+	  <c>whereis_name_request</c>/<c>whereis_name_reply</c>
+	</tag>
+	<item>
+	  Sent due to a call to one of the
+          <seemfa marker="erts:erlang#register/2"><c>register/2</c></seemfa>,
+          <seemfa marker="erts:erlang#unregister/1"><c>unregister/1</c></seemfa>,
+	  or
+          <seemfa marker="erts:erlang#whereis/1"><c>whereis/1</c></seemfa>
+	  BIFs. The request signal is sent to the
+	  <seeguide marker="#runtime-service">name service</seeguide> which
+	  responds with the reply signal.
+	</item>
+
 	<tag>
 	  <c>timer_start_request</c>/<c>timer_start_reply</c>,
 	  <c>timer_cancel_request</c>/<c>timer_cancel_reply</c>
@@ -381,17 +397,17 @@ spawn(Module, Name, Args) -> pid()
 	  <seeguide marker="#runtime-service">timer service</seeguide> which
 	  responds with the reply signal.
 	</item>
-	
+
       </taglist>
 
       <p><marker id="runtime-service"/>
-	The clock service, the timer service, and the spawn service mentioned
-	above are services provided by the runtime system. Each of these
-	services consists of multiple independently executing entities. Such a
-	service can be viewed as a group of processes, and could actually be
-	implemented like that. Since each service consists of multiple
-	independently executing entities, the order between multiple signals
-	sent from one service to one process is <em>not</em> preserved. Note
+        The clock service, the name service, the timer service, and the spawn
+        service mentioned above are services provided by the runtime system.
+        Each of these services consists of multiple independently executing
+        entities. Such a service can be viewed as a group of processes, and
+        could actually be implemented like that. Since each service consists of
+        multiple independently executing entities, the order between multiple
+        signals sent from one service to one process is <em>not</em> preserved. Note
 	that this does <em>not</em> violate the
 	<seeguide marker="#signal-delivery">signal ordering
 	guarantee</seeguide> of the language.


### PR DESCRIPTION
Add a link to signal order guarantees for group_leader and process_info.

Expand io docs to show that standard_io is group leader. This was previously not documented, but it is mentioned in a lot of places that it is the group leader that all I/O is sent to by default. So we can just as well make it explicit that standard_io is just an alias for group_leader() and thus the target of standard_io is changed when the group leader is changed.