### PR TITLE
Skip one extra uri_string:parse for httpc URL

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -501,10 +501,7 @@ service_info(Pid) ->
 %%% Internal functions
 %%%========================================================================
 normalize_and_parse_url(Url) ->
-    case uri_string:normalize(Url) of
-        {error, _, _} = Error -> Error;
-        UriString -> uri_string:parse(unicode:characters_to_list(UriString))
-    end.
+    uri_string:normalize(unicode:characters_to_list(Url), [return_map]).
 
 handle_request(Method, Url, 
                URI,


### PR DESCRIPTION
From profiling I see we are spending surprisingly much time in uri_string, and to me it seems that the current implementation of parsing and normalizing the URL in httpc does the parse+recompose twice. I cannot see any reason for this, so trying here to just return the map directly from uri_string:normalize.

All existing tests in httpc_SUITE pass, but I don't know if there are any tests that should be added? Any cornercases that might break from this change?