### PR TITLE
Improve handling of exceptions from parse transforms

### DIFF
--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1768,14 +1768,26 @@ do_transforms(Config) ->
                                     {core_transform,generic_pt},
                                     {parse_transform,generic_pt}]),
 
-    %% Test crashing in a core transform.
+    %% Test exceptions from a core transform.
     Simple = filename:join(DataDir, simple),
     error = compile:file(Simple, [report, {core_transform,generic_pt}, {action, crash}]),
-    {error,_,_} = compile:file(Simple, [return, {core_transform,generic_pt}, {action, crash}]),
+    {error,_,[]} = compile:file(Simple, [return, {core_transform,generic_pt}, {action, crash}]),
 
-    %% Test crashing in a parse transform.
+    error = compile:file(Simple, [report, {core_transform,generic_pt}, {action, throw}]),
+    {error,_,[]} = compile:file(Simple, [return, {core_transform,generic_pt}, {action, throw}]),
+
+    error = compile:file(Simple, [report, {core_transform,generic_pt}, {action, exit}]),
+    {error,_,[]} = compile:file(Simple, [return, {core_transform,generic_pt}, {action, exit}]),
+
+    %% Test exceptions from a parse transform.
     error = compile:file(Simple, [report, {parse_transform,generic_pt}, {action, crash}]),
-    {error,_,_} = compile:file(Simple, [return, {parse_transform,generic_pt}, {action, crash}]),
+    {error,_,[]} = compile:file(Simple, [return, {parse_transform,generic_pt}, {action, crash}]),
+
+    error = compile:file(Simple, [report, {parse_transform,generic_pt}, {action, throw}]),
+    {error,_,[]} = compile:file(Simple, [return, {parse_transform,generic_pt}, {action, throw}]),
+
+    error = compile:file(Simple, [report, {parse_transform,generic_pt}, {action, exit}]),
+    {error,_,[]} = compile:file(Simple, [return, {parse_transform,generic_pt}, {action, exit}]),
 
     %% Test generating errors and warnings in a parse_transform.
     {ok,simple} = compile:file(Simple, [report, {parse_transform,generic_pt}, {action, warning}]),

--- a/lib/compiler/test/compile_SUITE_data/generic_pt.erl
+++ b/lib/compiler/test/compile_SUITE_data/generic_pt.erl
@@ -40,7 +40,11 @@ actions(Source, Forms, Options) ->
         error ->
             {error, Es, Ws};
         undefined_error ->
-            {error, [{Source, [{{1,1}, ?MODULE, unknown_error}]}], []}
+            {error, [{Source, [{{1,1}, ?MODULE, unknown_error}]}], []};
+        throw ->
+            throw(thrown);
+        exit ->
+            exit(exited)
     end.
 
 format_error(bad_moon_phase) ->


### PR DESCRIPTION
746fb27c38c7e1 (#4528) refactored handling of internal compiler
errors. An unintended consequence was that `exit` and `throw` exceptions
raised by parse transforms or core transforms would be reported as
internal compiler errors. As well as being confusing, the return value
from `compile:file/2` would be the atom `error` even when the `return_errors`
option was given. (The `return_errors` and `return_warnings` options are
intentionally ignored when the compiler has crashed in an unexpected way.)

Change the error handling so that exceptions in parse and core
transforms are reported as an error in the given transform. While at
it, also improve the formatting of the exception reasons and
stacktraces for transforms.