### PR TITLE
erl_docgen: Translate type links in specs

### DIFF
--- a/lib/erl_docgen/priv/bin/specs_gen.escript
+++ b/lib/erl_docgen/priv/bin/specs_gen.escript
@@ -99,7 +99,7 @@ read_file(File, Opts) ->
     edoc:read_source(File, Opts).
 
 extract(File, Forms, Opts) ->
-    Env = edoc_lib:get_doc_env([], [], _Opts=[]),
+    Env = edoc_lib:get_doc_env([], [], [{app_default,"specs:/"}]),
     {_Module, Doc} = edoc_extract:source(Forms, File, Env, Opts),
     Doc.
 

--- a/lib/erl_docgen/src/docgen_otp_specs.erl
+++ b/lib/erl_docgen/src/docgen_otp_specs.erl
@@ -318,6 +318,14 @@ app_fix(L, I) -> % a bit slow
         _ -> app_fix(L, I+1)
     end.
 
+%% Translate edoc absolute links to local links
+fix_mod_ref([{marker, "specs://" ++ HRef}], Opts) ->
+    case string:split(HRef,"/",all) of
+        %% We don't need to prefix with "app:" on the link
+        %% it will be added later anyway
+        [_App, "doc", ModRef] ->
+            fix_mod_ref([{marker,ModRef}], Opts)
+    end;
 %% Remove the file suffix from module references.
 fix_mod_ref(HRef, #opts{file_suffix = ""}) ->
     HRef;


### PR DESCRIPTION
With edoc 1.0 the href links created for modules in
another application now have a complete URI pointing
to that application. So in erl_docgen we have to take
care of this by stripping it and only generating the
module that is needed.

Solves #4849