### PR TITLE
Keep `compiler_generated` annotation in `sub_get_var`

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -1333,8 +1333,17 @@ sub_new(#sub{}=Sub) ->
 
 sub_get_var(#c_var{name=V}=Var, #sub{v=S}) ->
     case orddict:find(V, S) of
-	{ok,Val} -> Val;
-	error -> Var
+        {ok,Val} -> case is_compiler_generated(Var) andalso
+                         not is_compiler_generated(Val) of
+                        true ->
+                            %% Propagate the 'compiler_generated' annotation
+                            %% along with the value.
+                            Ann = [compiler_generated|cerl:get_ann(Val)],
+                            cerl:set_ann(Val, Ann);
+                        false ->
+                            Val
+                    end;
+        error -> Var
     end.
 
 sub_set_var(#c_var{name=V}, Val, Sub) ->

--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -29,7 +29,7 @@
 	 no_no_file/1,configuration/1,supplies/1,
          redundant_stack_frame/1,export_from_case/1,
          empty_values/1,cover_letrec_effect/1,
-         receive_effect/1]).
+         receive_effect/1,compiler_generated_in_sub_get_var/1]).
 
 -export([foo/0,foo/1,foo/2,foo/3]).
 
@@ -50,7 +50,7 @@ groups() ->
        no_no_file,configuration,supplies,
        redundant_stack_frame,export_from_case,
        empty_values,cover_letrec_effect,
-       receive_effect]}].
+       receive_effect,compiler_generated_in_sub_get_var]}].
 
 
 init_per_suite(Config) ->
@@ -682,5 +682,16 @@ receive_effect(_Config) ->
 
 do_receive_effect() ->
     {} = receive _ -> {} = {} end.
+
+%% This test verifies that a variable substitution maintains the
+%% 'compiler_generated' annotation that supresses the warnings.
+compiler_generated_in_sub_get_var(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    Dir = test_lib:get_data_dir(Config),
+    Core = filename:join(Dir, "compiler_generated_in_sub_get_var"),
+    Opts = [warnings_as_errors,return,from_core,{outdir,PrivDir}
+           |test_lib:opt_opts(?MODULE)],
+    {error, [], []} = c:c(Core, Opts),
+    ok.
 
 id(I) -> I.

--- a/lib/compiler/test/core_fold_SUITE_data/compiler_generated_in_sub_get_var.core
+++ b/lib/compiler/test/core_fold_SUITE_data/compiler_generated_in_sub_get_var.core
@@ -1,0 +1,49 @@
+module 'compiler_generated_in_sub_get_var' ['foo'/1]
+    attributes []
+
+'foo'/1 =
+    ( fun (_0) ->
+      ( case ( _0
+           -| [] ) of
+          <X> when 'true' ->
+          let <Y> =
+              [46]
+          in  let <_3> =
+              fun () ->
+                  case <> of
+                <> when 'true' ->
+                    let <_5> =
+                    call 'erlang':'++'
+                        (Y,
+                        [46])
+                    in
+                    case _5 of
+                      <_6>
+                          when call 'erlang':'=:='
+                            (_6,
+                             X) ->
+                          ( _5
+                        -| ['compiler_generated'] )
+                           %% Keep this annotation after sub_get_var
+                      ( <_2> when 'true' ->
+                        primop 'match_fail'
+                            ({'badmatch',_2})
+                        -| ['compiler_generated'] )
+                    end
+                ( <> when 'true' ->
+                      primop 'match_fail'
+                      ({'function_clause'})
+                  -| ['compiler_generated'] )
+                  end
+              in  do
+                  apply _3
+                  ()
+                  'ok'
+          ( <_4> when 'true' ->
+            primop 'match_fail'
+            ({'function_clause',_4})
+        -| ['compiler_generated'] )
+        end
+        -| [] )
+      -| [] )
+end


### PR DESCRIPTION
In snippets like
```erlang
 foo(X) ->
     Y = ".",
     fun() -> X = Y ++ "." end(),
     ok.
```
the expression `Y ++ "."` builds a term that's unused when substituted
as the return expression in core erlang's compiler-generated clause
body.
The `compiler_generated` annotation guarantees that this substitution
won't generate a `"A term is constructed but never used"` warning.