### PR TITLE
Improve warnings for failing io:format() calls

### DIFF
--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -3509,7 +3509,7 @@ otp_8051(Config) when is_list(Config) ->
 
 %% Check that format warnings are generated.
 format_warn(Config) when is_list(Config) ->
-    L1 = 14,
+    L1 = 16,
     L2 = 5,
     format_level(1, L1, Config),
     format_level(2, L1+L2, Config),

--- a/lib/stdlib/test/erl_lint_SUITE_data/format.erl
+++ b/lib/stdlib/test/erl_lint_SUITE_data/format.erl
@@ -24,6 +24,8 @@
 %%% There will be warnings at level 2 and 3.
 
 f(F) ->
+    io:format("~p"),                            %1
+
     io:format("~", F),				%2
     io:format("~", [F]),			%1
     io:format(a, b),				%1
@@ -35,6 +37,7 @@ f(F) ->
     io:format("la cucaracha~n"),
     io:format(""),
     io:format("~p ~p~n", [F]),			%1
+    io:format("~p ~p~n", [1,2,F]),		%1
     io:format("~p~n", [F]),
     io:format("~m"),				%1
     io:format(F, "~p", []),			%1


### PR DESCRIPTION
The following call to `io:format/1`:

    t() ->
        io:format("~p\n"),
        ok.

would produce a warning with line number 0:

    t.erl:0: Warning: wrong number of arguments in format call

This commit fixes that issue, and while at it also provides more
information than just "wrong number of arguments in format call" for
other failing calls. For example, given the following function:

    t(A) ->
        io:format("~p\n"),
        io:format("~p\n", []),
        io:format("~p ~p\n", [A]),
        io:format("\n", [A]),
        ok.

the following warnings will be produced:

    t.erl:5:15: Warning: the format string requires an argument list with 1 argument, but no argument list is given
    %    5|     io:format("~p\n"),
    %     |               ^

    t.erl:6:23: Warning: the format string requires an argument list with 1 argument, but the argument list is empty
    %    6|     io:format("~p\n", []),
    %     |                       ^

    t.erl:7:26: Warning: the format string requires an argument list with 2 arguments, but the argument list contains only 1 argument
    %    7|     io:format("~p ~p\n", [A]),
    %     |                          ^

    t.erl:8:21: Warning: the format string requires an empty argument list, but the argument list contains 1 argument
    %    8|     io:format("\n", [A]),
    %     |                     ^