### PR TITLE
fix internal hash for external pids

### DIFF
--- a/erts/doc/src/erl_ext_dist.xml
+++ b/erts/doc/src/erl_ext_dist.xml
@@ -657,12 +657,12 @@
 	    <cell align="center">4</cell>
 	  </row>
 	  <row>
-	    <cell align="center"><c>89</c></cell>
+	    <cell align="center"><c>120</c></cell>
 	    <cell align="center"><c>Node</c></cell>
 	    <cell align="center"><c>ID</c></cell>
 	    <cell align="center"><c>Creation</c></cell>
 	  </row>
-	<tcaption>NEW_PORT_EXT</tcaption></table>
+	<tcaption>V4_PORT_EXT</tcaption></table>
 	<p>
 	  Encodes a port identifier (obtained from
           <seemfa marker="erlang#open_port/2"><c>erlang:open_port/2</c></seemfa>).

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -2343,23 +2343,15 @@ make_internal_hash(Eterm term, Uint32 salt)
             case EXTERNAL_PID_SUBTAG: {
                 ExternalThing* thing = external_thing_ptr(term);
                 /* See limitation #2 */
-            #ifdef ARCH_64
                 POINTER_HASH(thing->node, HCONST_5);
-                UINT32_HASH(thing->data.ui[0], HCONST_5);
-            #else
-                UINT32_HASH_2(thing->node, thing->data.ui[0], HCONST_5);
-            #endif
+                UINT32_HASH_2(thing->data.pid.num, thing->data.pid.ser, HCONST_5);
 		goto pop_next;
             }
 	    case EXTERNAL_PORT_SUBTAG: {
                 ExternalThing* thing = external_thing_ptr(term);
                 /* See limitation #2 */
-            #ifdef ARCH_64
                 POINTER_HASH(thing->node, HCONST_6);
-                UINT32_HASH(thing->data.ui[0], HCONST_6);
-            #else
-                UINT32_HASH_2(thing->node, thing->data.ui[0], HCONST_6);
-            #endif
+                UINT32_HASH_2(thing->data.ui32[0], thing->data.ui32[1], HCONST_6);
 		goto pop_next;
             }
 	    case FLOAT_SUBTAG:

--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -2966,6 +2966,19 @@ t_erts_internal_hash(_Config) when is_list(_Config) ->
     i  = maps:get({[0,0,0,0,0,0,0]},M7),
     j  = maps:get({[0,0,0,0,0,0,0,0]},M7),
     k  = maps:get({[0,0,0,0,0,0,0,0,0]},M7),
+
+    %% Test that external pids and ports don't introduce hash clash,
+    %% caused by high word being ignored (OTP-17436).
+    maps:from_keys([erts_test_utils:mk_ext_pid({a@a, 17},
+					       1 bsl NumBit,
+					       1 bsl SerBit)
+		    || NumBit <- lists:seq(0, 31),
+		       SerBit <- lists:seq(0, 31)],
+		   1),
+    maps:from_keys([erts_test_utils:mk_ext_port({a@a, 17}, 1 bsl NumBit)
+		    || NumBit <- lists:seq(0, 63)],
+		   1),
+
     ok.
 
 t_pdict(_Config) ->

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -866,8 +866,8 @@ define etp-extpid-1
       printf "#NotExternalPid<%p>", $etp_extpid_1_p->header
     else
       ## External pid
-      set $etp_extpid_1_number = $etp_extpid_1_p->data.ui[0]&0x7fff
-      set $etp_extpid_1_serial = ($etp_extpid_1_p->data.ui[0]>>15)&0x1fff
+      set $etp_extpid_1_number = $etp_extpid_1_p->data.ui32[0]
+      set $etp_extpid_1_serial = $etp_extpid_1_p->data.ui32[1]
       set $etp_extpid_1_np = $etp_extpid_1_p->node
       set $etp_extpid_1_creation = $etp_extpid_1_np->creation
       set $etp_extpid_1_dep = $etp_extpid_1_np->dist_entry
@@ -926,7 +926,11 @@ define etp-extport-1
       printf "#NotExternalPort<%p>", $etp_extport_1->header
     else
       ## External port
-      set $etp_extport_1_number = $etp_extport_1_p->data.ui[0]&0x3ffff
+      if $etp_arch64
+	set $etp_extport_1_number = $etp_extport_1_p->data.port.id
+      else
+	set $etp_extport_1_number = $etp_extport_1_p->data.port.low | (((Uint64)$etp_extport_1_p->data.port.high) << 32)
+      end
       set $etp_extport_1_np = $etp_extport_1_p->node
       set $etp_extport_1_creation = $etp_extport_1_np->creation
       set $etp_extport_1_dep = $etp_extport_1_np->dist_entry
@@ -941,7 +945,7 @@ define etp-extport-1
           printf "#Port<%u:", $etp_extport_1_node>>6
         end
         etp-atom-1 ($etp_extport_1_node)
-        printf "/%u.%u>", $etp_extport_1_creation, $etp_extport_1_number
+        printf "/%u.%lu>", $etp_extport_1_creation, $etp_extport_1_number
       end
     end
   end


### PR DESCRIPTION
When 64-bit external pids were introduced in e9ab9a75a, internal
hash function was not adjusted accordingly. This led to a large
amount of hash collisions, ultimately making maps:from_list and
maps:from_keys to crash the emulator (stack overflow, or assertion
in a debug build).