### PR TITLE
Make warn_missing_spec warn for functions exported using export_all

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -1084,11 +1084,7 @@ behaviour_add_conflict([], _, _, _, St) -> St.
 %% check_deprecated(Forms, State0) -> State
 
 check_deprecated(Forms, St0) ->
-    %% Get the correct list of exported functions.
-    Exports = case member(export_all, St0#lint.compile) of
-		  true -> St0#lint.defined;
-		  false -> St0#lint.exports
-	      end,
+    Exports = exports(St0),
     X = ignore_predefined_funcs(gb_sets:to_list(Exports)),
     #lint{module = Mod} = St0,
     Bad = [{E,Anno} || {attribute, Anno, deprecated, Depr} <- Forms,
@@ -1142,11 +1138,7 @@ deprecated_desc(_) -> false.
 %% check_removed(Forms, State0) -> State
 
 check_removed(Forms, St0) ->
-    %% Get the correct list of exported functions.
-    Exports = case member(export_all, St0#lint.compile) of
-                  true -> St0#lint.defined;
-                  false -> St0#lint.exports
-              end,
+    Exports = exports(St0),
     X = ignore_predefined_funcs(gb_sets:to_list(Exports)),
     #lint{module = Mod} = St0,
     Bad = [{E,Anno} || {attribute, Anno, removed, Removed} <- Forms,
@@ -3253,7 +3245,7 @@ add_missing_spec_warnings(Forms, St0, Type) ->
 		[{FA,Anno} || {function,Anno,F,A,_} <- Forms,
 			   not lists:member(FA = {F,A}, Specs)];
 	    exported ->
-		Exps0 = gb_sets:to_list(St0#lint.exports) -- pseudolocals(),
+                Exps0 = gb_sets:to_list(exports(St0)) -- pseudolocals(),
                 Exps = Exps0 -- Specs,
 		[{FA,Anno} || {function,Anno,F,A,_} <- Forms,
 			   member(FA = {F,A}, Exps)]

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -4491,13 +4491,22 @@ warn_missing_spec(Config) ->
               internal_with_spec() -> ok.
 
               internal_no_spec() -> ok.">>,
-    run(Config, [
-        {warn_missing_spec, Test, [warn_missing_spec],
-            {warnings, [{{6,15}, erl_lint, {missing_spec, {external_no_spec, 0}}}]}},
-        {warn_missing_spec_all, Test, [warn_missing_spec_all],
-            {warnings, [{{6,15}, erl_lint, {missing_spec, {external_no_spec, 0}}},
-                        {{11,15}, erl_lint, {missing_spec, {internal_no_spec, 0}}}]}}
-    ]).
+
+    %% Be sure to avoid adding export_all using the option-list-in-a-tuple trick.
+    {warnings, [{{6,15}, erl_lint, {missing_spec, {external_no_spec, 0}}}]} =
+        run_test(Config, Test, {[warn_missing_spec, nowarn_unused_function]}),
+
+    Ts = [{warn_missing_spec_all, Test, [warn_missing_spec_all],
+           {warnings, [{{6,15}, erl_lint, {missing_spec, {external_no_spec, 0}}},
+                       {{11,15}, erl_lint, {missing_spec, {internal_no_spec, 0}}}]}},
+          {warn_missing_spec_export_all,
+           <<"-compile([export_all, nowarn_export_all]).
+              -compile([warn_missing_spec]).
+              main(_) -> ok.
+             ">>,
+           [],
+           {warnings,[{{3,15},erl_lint,{missing_spec,{main,1}}}]}}],
+    run(Config, Ts).
 
 otp_16824(Config) ->
     Ts = [{otp_16824_1,


### PR DESCRIPTION
There would be no warning for missing specs for functions that
were implicitly exported using `export_all`.

While we are at it, use the helper function `exports/1` in all places
where the lists of functions that are effectively exported should be
retrieved.

Closes #4772