### PR TITLE
debug emulator build: clean up unused assertions

### DIFF
--- a/erts/emulator/beam/jit/x86/beam_asm.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.cpp
@@ -809,8 +809,6 @@ extern "C"
 
     void beamasm_purge_module(const void *native_module_exec,
                               void *native_module_rw) {
-        ASSERT(native_module_exec != native_module_rw);
-
         jit_allocator->release(const_cast<void *>(native_module_exec));
     }
 

--- a/erts/emulator/beam/jit/x86/beam_asm_perf.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_perf.cpp
@@ -137,7 +137,7 @@ public:
         for (BeamAssembler::AsmRange &r : ranges) {
             size_t nameLen = r.name.size();
             ptrdiff_t codeSize = (char *)r.stop - (char *)r.start;
-            ASSERT(codeSize > 0);
+            ASSERT(codeSize >= 0);
             record.header.total_size = sizeof(record) + nameLen + 1 + codeSize;
             record.vma = (Uint64)r.start;
             record.code_addr = (Uint64)r.start;


### PR DESCRIPTION
Two asserts can be safely removed. One asserts that code size is
greater than zero (which is not necessarily so), and another one
verifies that dual mapping is enabled (and it's not if we enable
Linux Perf support in either dump or map mode)