### PR TITLE
cover:reset/1: correct -spec

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -724,7 +724,7 @@ is_compiled(Module) when is_atom(Module) ->
 
 -spec reset(Module) -> 'ok' |
                        {'error', 'not_main_node'} |
-                       {'error', 'not_cover_compiled', Module} when
+                       {'error', {'not_cover_compiled', Module}} when
       Module :: module().
 
 reset(Module) when is_atom(Module) ->


### PR DESCRIPTION
The error return is not a 3-tuple but a 2-tuple with another 2-tuple in element 2. This is a typo affecting OTP-24 and master.