### PR TITLE
Correct memsup:get_os_wordsize/0 on an M1 Mac

### DIFF
--- a/lib/os_mon/src/memsup.erl
+++ b/lib/os_mon/src/memsup.erl
@@ -575,7 +575,8 @@ get_os_wordsize_with_uname() ->
 	"ppc64"   -> 64;
 	"ppc64le" -> 64;
 	"s390x"   -> 64;
-        "aarch64" -> 64;
+        "aarch64" -> 64;                        %Linux
+        "arm64"   -> 64;                        %macOS
 	_         -> 32
     end.
 


### PR DESCRIPTION
On a Mac with Apple Silicon, `memsup:get_os_wordsize/0` would return
32 instead of the correct 64.