### PR TITLE
Fix lost line numbers in Dialyzer warnings for Elixir code

### DIFF
--- a/lib/dialyzer/src/dialyzer_utils.erl
+++ b/lib/dialyzer/src/dialyzer_utils.erl
@@ -1008,7 +1008,7 @@ get_all_locations(Tree) ->
   ++
   lists:append([get_all_locations(T) || T <- SubTrees]).
 
-maybe_get_location([Line|_]) when is_integer(Line) ->
+maybe_get_location([Line|_]) when is_integer(Line), Line > 0 ->
   Line;
 maybe_get_location([{Line, Column}|_Tail]) when is_integer(Line),
                                                 is_integer(Column) ->


### PR DESCRIPTION
Elixir code often generates Erlang forms, e.g. literals
with Location set to 0. A change in Dialyzer warning generation
caused those 0 Locations to be picked up and shown
to the user even if there are valid line numbers elsewhere
in the tree. As a fix, when reading Location from the tree,
ignore all line numbers lower than 1.