### PR TITLE
dialyzer: Do not expose line number 0 in message locations

### DIFF
--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -3649,11 +3649,6 @@ add_work(New, {List, Rev, Set} = Work) ->
 %%%
 %%% ===========================================================================
 
-get_line([Line|_]) when is_integer(Line) -> Line;
-get_line([{Line, _Column} | _Tail]) when is_integer(Line) -> Line;
-get_line([_|Tail]) -> get_line(Tail);
-get_line([]) -> -1.
-
 get_location(Tree) ->
   dialyzer_utils:get_location(Tree, 1).
 
@@ -3669,7 +3664,7 @@ get_file([_|Tail], State) ->
   get_file(Tail, State).
 
 is_compiler_generated(Ann) ->
-  lists:member(compiler_generated, Ann) orelse (get_line(Ann) < 1).
+  dialyzer_utils:is_compiler_generated(Ann).
 
 is_literal_record(Tree) ->
   Ann = cerl:get_ann(Tree),


### PR DESCRIPTION
See also GH-4890: https://github.com/erlang/otp/pull/4890.

Commit 04b905d assigned better start locations to messages, but also
sometimes let line number 0 slip through. This is now corrected.

Closes GH-4890.
