### PR TITLE
Tune delays in user_sup

### DIFF
--- a/lib/kernel/src/user_sup.erl
+++ b/lib/kernel/src/user_sup.erl
@@ -86,19 +86,19 @@ relay1(Pid) ->
 -spec terminate(term(), pid()) -> 'ok'.
 
 terminate(_Reason, UserPid) ->
-    receive after 1000 -> ok end,
+    receive after 10 -> ok end,
     exit(UserPid, kill),
     ok.
 
 %%-----------------------------------------------------------------
 %% If there is a user, wait for it to register itself.  (But wait
-%% no more than 10 seconds).  This is so the application_controller
+%% no more than 5 seconds).  This is so the application_controller
 %% is guaranteed that the user is started.
 %%-----------------------------------------------------------------
 
 start_user(Mod, Func, A) ->
     apply(Mod, Func, A),
-    wait_for_user_p(100).
+    wait_for_user_p(5000).
 
 wait_for_user_p(0) ->
     {error, nouser};
@@ -108,7 +108,8 @@ wait_for_user_p(N) ->
 	    link(Pid),
 	    {ok, Pid};
 	_ ->
-	    receive after 100 -> ok end,
+            %% minimal sleep so the shell is not delayed more than needed
+	    receive after 1 -> ok end,
 	    wait_for_user_p(N-1)
     end.
 


### PR DESCRIPTION
Discovered while investigating startup and shutdown times:
 - The shell is delayed 100 ms because of the sleep time in the loop that checks if the user driver is started. By checking every 1 ms instead, this is more or less eliminated. Also, waiting a full 10 seconds until giving up seems way too much, so I lowered it to 5.
 - Waiting a whole second before killing the user driver seems excessive, since this holds up the whole shutdown sequence. I'm not sure what's a good number these days or if there are better solutions, but lowering it to 10 ms makes it less of a bother.
 - It seems brutal to terminate the system with halt() if running as slave node when the master user driver cannot be found. Changed to returning error just like in the normal case.

These patches are mainly meant as suggestions.