### PR TITLE
lists: takeuntil/2 and dropuntil/2

### DIFF
--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -38,8 +38,8 @@
 
 -export([all/2,any/2,map/2,flatmap/2,foldl/3,foldr/3,filter/2,
 	 partition/2,zf/2,filtermap/2,
-	 mapfoldl/3,mapfoldr/3,foreach/2,takewhile/2,dropwhile/2,
-         search/2, splitwith/2,split/2,
+	 mapfoldl/3,mapfoldr/3,foreach/2,takewhile/2,takeuntil/2,
+	 dropwhile/2, dropuntil/2, search/2, splitwith/2,split/2,
 	 join/2]).
 
 %%% BIFs
@@ -1390,6 +1390,19 @@ takewhile(Pred, [Hd|Tail]) ->
     end;
 takewhile(Pred, []) when is_function(Pred, 1) -> [].
 
+-spec takeuntil(Pred, List1) -> List2 when
+      Pred :: fun((Elem :: T) -> boolean()),
+      List1 :: [T],
+      List2 :: [T],
+      T :: term().
+
+takeuntil(Pred, [Hd|Tail]) ->
+    case Pred(Hd) of
+	true -> [Hd];
+	false -> [Hd|takeuntil(Pred, Tail)]
+    end;
+takeuntil(Pred, []) when is_function(Pred, 1) -> [].
+
 -spec dropwhile(Pred, List1) -> List2 when
       Pred :: fun((Elem :: T) -> boolean()),
       List1 :: [T],
@@ -1402,6 +1415,19 @@ dropwhile(Pred, [Hd|Tail]=Rest) ->
 	false -> Rest
     end;
 dropwhile(Pred, []) when is_function(Pred, 1) -> [].
+
+-spec dropuntil(Pred, List1) -> List2 when
+      Pred :: fun((Elem :: T) -> boolean()),
+      List1 :: [T],
+      List2 :: [T],
+      T :: term().
+
+dropuntil(Pred, [Hd|Tail]) ->
+    case Pred(Hd) of
+	true -> Tail;
+	false -> dropuntil(Pred, Tail)
+    end;
+dropuntil(Pred, []) when is_function(Pred, 1) -> [].
 
 -spec search(Pred, List) -> {value, Value} | false when
       Pred :: fun((T) -> boolean()),

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -38,7 +38,7 @@
 
 	 sublist_2/1, sublist_3/1, sublist_2_e/1, sublist_3_e/1,
 	 flatten_1/1, flatten_2/1, flatten_1_e/1, flatten_2_e/1,
-	 dropwhile/1, takewhile/1,
+	 dropwhile/1, dropuntil/1, takewhile/1, takeuntil/1,
 	 sort_1/1, sort_stable/1, merge/1, rmerge/1, sort_rand/1,
 	 usort_1/1, usort_stable/1, umerge/1, rumerge/1,usort_rand/1,
 	 keymerge/1, rkeymerge/1,
@@ -120,9 +120,10 @@ groups() ->
       [flatten_1, flatten_2, flatten_1_e, flatten_2_e]},
      {tickets, [parallel], [otp_5939, otp_6023, otp_6606, otp_7230]},
      {zip, [parallel], [zip_unzip, zip_unzip3, zipwith, zipwith3]},
-     {misc, [parallel], [reverse, member, dropwhile, takewhile,
-			 filter_partition, suffix, subtract, join,
-			 hof, droplast, search, error_info]}
+     {misc, [parallel], [reverse, member, dropwhile, dropuntil,
+			 takewhile, takeuntil,  filter_partition,
+			 suffix, subtract, join, hof, droplast,
+			 search, error_info]}
     ].
 
 init_per_suite(Config) ->
@@ -359,6 +360,33 @@ dropwhile(Config) when is_list(Config) ->
 
     ok.
 
+dropuntil(Config) when is_list(Config) ->
+    F = fun(C) -> C =/= $@ end,
+
+    [] = lists:dropuntil(F, []),
+    [] = lists:dropuntil(F, [a]),
+    [b] = lists:dropuntil(F, [a,b]),
+    [b,c] = lists:dropuntil(F, [a,b,c]),
+
+    [] = lists:dropuntil(F, [$@]),
+    [] = lists:dropuntil(F, [$@,$@]),
+    [$@] = lists:dropuntil(F, [$@,a,$@]),
+
+    [] = lists:dropuntil(F, [$@,$k]),
+    [$l] = lists:dropuntil(F, [$@,$@,$k,$l]),
+    [] = lists:dropuntil(F, [$@,$@,$@,a]),
+
+    [$@,b] = lists:dropuntil(F, [$@,a,$@,b]),
+    [$@,b] = lists:dropuntil(F, [$@,$@,a,$@,b]),
+    [$@,b] = lists:dropuntil(F, [$@,$@,$@,a,$@,b]),
+
+    Long = lists:seq(1, 1024),
+    Shorter = lists:seq(801, 1024),
+
+    Shorter = lists:dropuntil(fun(E) -> E >= 800 end, Long),
+
+    ok.
+
 takewhile(Config) when is_list(Config) ->
     F = fun(C) -> C =/= $@ end,
 
@@ -383,6 +411,33 @@ takewhile(Config) when is_list(Config) ->
     Shorter = lists:seq(1, 400),
 
     Shorter = lists:takewhile(fun(E) -> E =< 400 end, Long),
+
+    ok.
+
+takeuntil(Config) when is_list(Config) ->
+    F = fun(C) -> C =:= $@ end,
+
+    [] = lists:takeuntil(F, []),
+    [a] = lists:takeuntil(F, [a]),
+    [a,b] = lists:takeuntil(F, [a,b]),
+    [a,b,c] = lists:takeuntil(F, [a,b,c]),
+
+    [$@] = lists:takeuntil(F, [$@]),
+    [$@] = lists:takeuntil(F, [$@,$@]),
+    [a,$@] = lists:takeuntil(F, [a,$@]),
+
+    [$k,$@] = lists:takeuntil(F, [$k,$@]),
+    [$k,$l,$@] = lists:takeuntil(F, [$k,$l,$@,$@]),
+    [a,$@] = lists:takeuntil(F, [a,$@,$@,$@]),
+
+    [$@] = lists:takeuntil(F, [$@,a,$@,b]),
+    [$@] = lists:takeuntil(F, [$@,$@,a,$@,b]),
+    [$@] = lists:takeuntil(F, [$@,$@,$@,a,$@,b]),
+
+    Long = lists:seq(1, 1024),
+    Shorter = lists:seq(1, 400),
+
+    Shorter = lists:takeuntil(fun(E) -> E >= 400 end, Long),
 
     ok.
 


### PR DESCRIPTION
This PR provides two functions similar to `takewhile/2` and `dropwhile/2` for the `lists` module, but with the following differences:

`takewhile/2` will return a list of all elements from the beginning of the input list up to the point where the predicate returns `false` for the first time, _excluding this element_ (it is not taken)
`takeuntil/2` will return a list of all elements from the beginning of the input list up to the point where the predicate returns `true` for the first time, _including this element_ (it is taken)


`dropwhile/2` will return a list with all elements removed from the beginning of the input list up to the point where the predicate returns `false` for the first time, _including this element_ (it is not dropped)
`dropuntil/2` will return a list with all elements removed from the beginning of the input list up to the point where the predicate returns `true` for the first time, _excluding this element_ (it is dropped)

The reversal of the predicate result is necessary to "chime" with the chosen name(s), ie `takewhile`/`dropwhile` --> "while ... is true" vs `takeuntil`/`dropuntil` --> "until ... is true".

Another function that could use a companion of this sort is `splitwith/2`, but here I'm really at a loss for a good name 😓

A use case I often come across is taking/dropping things from a list until some sort of special item is found, and the need to get (or remove) this item, too. Removing another item from a `dropwhile/2` result is easy via `tl/1`, but one has to make sure that the list is not empty. Adding another to the result from a `takewhile/2` is hard.