### PR TITLE
Eliminate incorrect warning for useless building

### DIFF
--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -564,7 +564,19 @@ effect(Config) when is_list(Config) ->
              ">>,
            [],
            {warnings,[{{3,16},sys_core_fold,{ignored,useless_building}},
-                      {{3,30},sys_core_fold,{ignored,useless_building}}]}}
+                      {{3,30},sys_core_fold,{ignored,useless_building}}]}},
+
+          {propagated_literal,
+           <<"
+            foo(X) ->
+                Y = [$.],
+                %% There must not be a warning for constructing a term that
+                %% is never used.
+                fun() -> X = Y ++ [$.] end(),
+                ok.
+             ">>,
+           [],
+           []}
          ],
     [] = run(Config, Ts),
     ok.


### PR DESCRIPTION
In OTP 24, there will be a warning for the following code:

    foo(X) ->
        Y = ".",
        fun() ->
                X = Y ++ "."  %Warning: a term is constructed, but never used
        end(),
        ok.

The warning is incorrect, because the built term will be matched to
the previous value of `X`. This commit eliminates the warning.

To explain the bug, I will illustrate how the example program is transformed
by the Core Erlang passes. My illustrative examples will use Erlang instead
of Core Erlang.

The first transformation makes the match `X = Y ++ "."` explicit:

    foo(X) ->
        Y = ".",
        fun() ->
                X1 = Y ++ ".",
                case X1 =:= X of
                    true ->
                        X1;
                    false ->
                        error({badmatch,X})
                end
        end(),
        ok.

The variable `X1` is only needed for the matching. It will be
annotated with a `compiler_generated` annotation to ensure that no
compiler warnings will be generated if it would later turn out that it
would never be used.

Next constants are propagated and constant expressions are evaluated.
Since the fun is only used once, it will be eliminated and its body
inlined. Now we have:

    foo(X) ->
        case ".." =:= X of
            true ->
                "..";
            false ->
                error({badmatch,X})
        end,
        ok.

The final optimization for this example is simplification of expressions
whose values are never used:

    foo(X) ->
        case ".." =:= X of
            true ->
                ok;  %Warning: a term is constructed, but never used
            false ->
                error({badmatch,X})
        end,
        ok.

The `".."` string will never be used, so it will be replaced with `ok`.
At the same time, a warning will be emitted.

The reason for the warning is that the `".."` string does not have a
`compiler_generated` annotation to indicate that it was introduced by
the compiler. The `X1` variable had a `compiler_generated` annotation,
but it was lost when `X1` was replaced with `".."`.

To eliminate the unwanted warning, the `compiler_generated` annotation
must be propagated from the variable to the substituted value.

Thanks to Jose Maria Perez Ramos (@Kuroneer) for noticing this bug and
suggesting a way to fix it.