### PR TITLE
Correct error message for binary_to_existing_atom/2

### DIFF
--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -737,7 +737,9 @@ error_info(_Config) ->
          {binary_to_existing_atom, [abc, latin1]},
          {binary_to_existing_atom, [<<128,128,255>>,utf8]},
          {binary_to_existing_atom, [list_to_binary(NewAtom), latin1]},
+         {binary_to_existing_atom, [list_to_binary(NewAtom), utf8]},
          {binary_to_existing_atom, [list_to_binary(NewAtom), utf42]},
+         {binary_to_existing_atom, [[<<"abc">>], utf8]},
          {binary_to_existing_atom, [<<0:512/unit:8>>, latin1]},
 
          {binary_to_float, [abc]},

--- a/lib/kernel/src/erl_erts_errors.erl
+++ b/lib/kernel/src/erl_erts_errors.erl
@@ -1223,7 +1223,12 @@ do_binary_to_atom(Bin, Enc0, DefaultError) ->
         unicode ->
             if
                 is_binary(Bin) ->
-                    [bad_unicode];
+                    case unicode:characters_to_list(Bin, Enc) of
+                        CharList when is_list(CharList) ->
+                            [non_existing_atom];
+                        _ ->
+                            [bad_unicode]
+                    end;
                 true ->
                     [not_binary]
             end;
@@ -1239,7 +1244,8 @@ is_flat_char_list([H|T]) ->
         error:badarg ->
             false
     end;
-is_flat_char_list(_) -> true.
+is_flat_char_list([]) -> true;
+is_flat_char_list(_) -> false.
 
 format_error_map([""|Es], ArgNum, Map) ->
     format_error_map(Es, ArgNum + 1, Map);


### PR DESCRIPTION
The extended error information for `binary_to_existing_atom/2` was wrong
when the encoding was `utf8` or `unicode`:

    1> binary_to_existing_atom(<<"oops doesnt_really_exist">>, utf8).
    ** exception error: bad argument
         in function  binary_to_existing_atom/2
            called as binary_to_existing_atom(<<"oops doesnt_really_exist">>,utf8)
            *** argument 1: invalid UTF8 encoding

Corrected:

    1> binary_to_existing_atom(<<"oops doesnt_really_exist">>, utf8).
    ** exception error: bad argument
         in function  binary_to_existing_atom/2
            called as binary_to_existing_atom(<<"oops doesnt_really_exist">>,utf8)
            *** argument 1: not an already existing atom

Also fixed a similar problem for `list_to_existing_atom/1`.

Closes #4900.