### PR TITLE
Fix busy port handling in port_command()

### DIFF
--- a/erts/emulator/beam/erl_bif_port.c
+++ b/erts/emulator/beam/erl_bif_port.c
@@ -211,8 +211,8 @@ BIF_RETTYPE erts_internal_port_command_3(BIF_ALIST_3)
                 ERTS_BIF_PREP_RET(res, am_false);
             else {
                 erts_suspend(BIF_P, ERTS_PROC_LOCK_MAIN, prt);
-                ERTS_BIF_PREP_YIELD3(res, bif_export[BIF_erts_internal_port_command_3],
-                                     BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3);
+                ERTS_BIF_YIELD3(bif_export[BIF_erts_internal_port_command_3],
+                                BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3);
             }
             break;
         case ERTS_PORT_OP_BUSY_SCHEDULED:


### PR DESCRIPTION
A call to `port_command()` could cause a scheduler to end up in an eternal loop if the port was busy and the calling process had incoming signals at the time of the call. This bug was introduced in OTP 23.3.2 (ERTS version 11.2.1), OTP 22.3.4.18 (ERTS version 10.7.2.10), and OTP 21.3.8.23 (ERTS version 10.3.5.18).

Closes #4898