### PR TITLE
Restore SIGPIPE default handling for port children

### DIFF
--- a/erts/emulator/sys/unix/erl_child_setup.c
+++ b/erts/emulator/sys/unix/erl_child_setup.c
@@ -338,6 +338,12 @@ start_new_child(int pipes[])
 
     sys_sigrelease(SIGCHLD);
 
+    /* Restore default handling of sigpipe just before exec */
+    if (sigaction(SIGPIPE, &sa, 0) == -1) {
+        perror(NULL);
+        exit(1);
+    }
+
     if (args) {
         /* spawn_executable */
         execve(cmd, args, new_environ);


### PR DESCRIPTION
While answering [this stackoverflow question](https://stackoverflow.com/questions/67704043/erlang-how-to-make-connected-external-os-process-automatically-die-when-control) I noticed that the default handling for `SIGPIPE` in `open_port` children was set to `SIG_IGN`.

After a little investigation, I found that it's set as such in `sys_drivers.c:erl_sys_late_init`, and inherited through the `fork()`s.

This is a problem because if the port owner dies, the pipes attaching the port to the children (the external command) break and the children may not notice it.

The problem arises when the spawned command has no knowledge about this behaviour and ignores the `EPIPE` when writing or reading from the port's FDs, as the spawned command may rely on the SIGPIPE to terminate and ends orphanded instead.

In this commit, the behaviour is reset to the default just before `exec` is called in the children. **BUT** this is a breaking change. Any external command that knowingly (or unknowingly) relied on not being killed when reading from these file descriptors would be killed after this change.

### Example

This behaviour can be tested with the following codes:
```c
//dot_sigpipe_dfl
#include <unistd.h>
#include <stdio.h>
#include <signal.h>

int main(int argc, char** argv) {
    if (signal(SIGPIPE, SIG_DFL) != SIG_ERR)
        while(1) {
            fprintf(stdout, ".");
            fflush(stdout);
            sleep(1);
        }
}
```
```c
//dot
#include <unistd.h>
#include <stdio.h>
#include <signal.h>

int main(int argc, char** argv) {
        while(1) {
            fprintf(stdout, ".");
            fflush(stdout);
            sleep(1);
        }
}
```
```erlang
-module(test).
-export([test/0, spawn/1, spawn/2]).

test() ->
    watch0(),
    dot0(),
    signal_dot0(),
    ok.

watch0() ->
    ?MODULE:spawn("watch date", 0).

dot0() ->
    ?MODULE:spawn("./dot", 0).

signal_dot0() ->
    ?MODULE:spawn("./dot_sigpipe_dfl", 0).

spawn(Cmd) ->
    ?MODULE:spawn(Cmd, 0).
spawn(Cmd, WaitTimeMs) ->
    spawn_monitor(fun() ->
                          Port = open_port({spawn, Cmd},[stream, exit_status]),
                          OSPid = proplists:get_value(os_pid, erlang:port_info(Port)),
                          io:format("~p: OS PID for ~s: ~p~n", [self(), Cmd, OSPid]),
                          timer:sleep(WaitTimeMs),
                          io:format("~p: Bye!~n", [self()])
                  end).
```

Both `dot` and `watch date` will get orphanded before this change whereas `dot_sigpipe_dfl` will terminate correctly regardless.



 
 
 ### Alternatives
 
As an alternative solution, I'd allow providing some sort of signal action option in `open_port`, but it'd be strange to have an spawned command with signal handling that's not default. If it's decided that this is too breaking, I'd add it to the documentation at least.