### PR TITLE
Correct error messages for timer BIFs

### DIFF
--- a/erts/emulator/beam/erl_hl_timer.c
+++ b/erts/emulator/beam/erl_hl_timer.c
@@ -2434,8 +2434,10 @@ BIF_RETTYPE send_after_3(BIF_ALIST_3)
 
     tres = parse_timeout_pos(erts_proc_sched_data(BIF_P), BIF_ARG_1,
 			     NULL, 0, &timeout_pos, &short_time, &tmo);
-    if (tres != 0)
-	BIF_ERROR(BIF_P, BADARG);
+    if (tres != 0) {
+        BIF_P->fvalue = am_time;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+    }
 
     return setup_bif_timer(BIF_P, tmo < ERTS_TIMER_WHEEL_MSEC,
                            timeout_pos, short_time, BIF_ARG_2,
@@ -2447,13 +2449,17 @@ BIF_RETTYPE send_after_4(BIF_ALIST_4)
     ErtsMonotonicTime timeout_pos, tmo;
     int short_time, abs, tres;
 
-    if (!parse_bif_timer_options(BIF_ARG_4, NULL, NULL, &abs))
-	BIF_ERROR(BIF_P, BADARG);
-    
+    if (!parse_bif_timer_options(BIF_ARG_4, NULL, NULL, &abs)) {
+        BIF_P->fvalue = am_badopt;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+    }
+
     tres = parse_timeout_pos(erts_proc_sched_data(BIF_P), BIF_ARG_1, NULL,
 			     abs, &timeout_pos, &short_time, &tmo);
-    if (tres != 0)
-	BIF_ERROR(BIF_P, BADARG);
+    if (tres != 0) {
+        BIF_P->fvalue = am_time;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+    }
 
     return setup_bif_timer(BIF_P, tmo < ERTS_TIMER_WHEEL_MSEC,
                            timeout_pos, short_time, BIF_ARG_2,
@@ -2467,8 +2473,10 @@ BIF_RETTYPE start_timer_3(BIF_ALIST_3)
 
     tres = parse_timeout_pos(erts_proc_sched_data(BIF_P), BIF_ARG_1, NULL,
 			     0, &timeout_pos, &short_time, &tmo);
-    if (tres != 0)
-	BIF_ERROR(BIF_P, BADARG);
+    if (tres != 0) {
+        BIF_P->fvalue = am_time;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+    }
 
     return setup_bif_timer(BIF_P, tmo < ERTS_TIMER_WHEEL_MSEC,
                            timeout_pos, short_time, BIF_ARG_2,
@@ -2480,13 +2488,17 @@ BIF_RETTYPE start_timer_4(BIF_ALIST_4)
     ErtsMonotonicTime timeout_pos, tmo;
     int short_time, abs, tres;
 
-    if (!parse_bif_timer_options(BIF_ARG_4, NULL, NULL, &abs))
-	BIF_ERROR(BIF_P, BADARG);
+    if (!parse_bif_timer_options(BIF_ARG_4, NULL, NULL, &abs)) {
+        BIF_P->fvalue = am_badopt;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+    }
 
     tres = parse_timeout_pos(erts_proc_sched_data(BIF_P), BIF_ARG_1, NULL,
 			     abs, &timeout_pos, &short_time, &tmo);
-    if (tres != 0)
-	BIF_ERROR(BIF_P, BADARG);
+    if (tres != 0) {
+        BIF_P->fvalue = am_time;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+    }
 
     return setup_bif_timer(BIF_P, tmo < ERTS_TIMER_WHEEL_MSEC,
                            timeout_pos, short_time, BIF_ARG_2,

--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -681,6 +681,7 @@ do_error_3(Reason, Args, Options) ->
 error_info(_Config) ->
     DeadProcess = dead_process(),
     NewAtom = non_existing_atom(),
+    Eons = 1 bsl 50,
 
     %% We'll need an incorrect memory type for erlang:memory/1. We want to test an
     %% incorrect atom if our own allocators are enabled, but if they are disabled,
@@ -1119,7 +1120,13 @@ error_info(_Config) ->
          {send, [[bad,dest], message]},
          {send, [[bad,dest], message, bad]},
 
+         {send_after, [Eons, self(), message]},
+         {send_after, [Eons, {bad,dest}, message]},
          {send_after, [bad_time, {bad,dest}, message]},
+         {send_after, [20, ExternalPid, message]},
+
+         {send_after, [Eons, self(), message, bad_options]},
+         {send_after, [Eons, {bad,dest}, message, bad_options]},
          {send_after, [bad_time, {bad,dest}, message, bad_options]},
          {send_after, [20, self(), message, [bad]]},
          {send_after, [20, ExternalPid, message, []]},
@@ -1198,7 +1205,12 @@ error_info(_Config) ->
          {split_binary, [a, -1]},
          {split_binary, [<<>>, 1]},
 
+         {start_timer, [Eons, self(), message]},
+         {start_timer, [Eons, {bad,dest}, message]},
          {start_timer, [bad_time, {bad,dest}, message]},
+
+         {start_timer, [Eons, self(), message, []]},
+         {start_timer, [Eons, {bad,dest}, message, [bad]]},
          {start_timer, [bad_time, {bad,dest}, message, bad_options]},
          {start_timer, [20, self(), message, [bad]]},
          {start_timer, [20, ExternalPid, message, []]},

--- a/lib/kernel/src/erl_erts_errors.erl
+++ b/lib/kernel/src/erl_erts_errors.erl
@@ -855,20 +855,21 @@ format_erlang_error(split_binary, [Bin,Pos], _) ->
         Errors ->
             Errors
     end;
-format_erlang_error(start_timer, [Time,Process,_], _) ->
-    [must_be_non_neg_int(Time),
+format_erlang_error(start_timer, [Time,Process,_], Cause) ->
+    [must_be_time(Time, Cause),
      if
          is_pid(Process), node(Process) =/= node() -> not_local_pid;
          is_pid(Process), node(Process) =:= node(); is_atom(Process) -> [];
          true -> <<"not a pid or an atom">>
      end];
 format_erlang_error(start_timer, [A1,A2,A3,Options], Cause) ->
-    case format_erlang_error(start_timer, [A1,A2,A3], Cause) of
-        [[],[]] ->
-            [[],[],[],must_be_list(Options, bad_option)];
-        Errors ->
-            Errors ++ [must_be_list(Options, [])]
-    end;
+    format_erlang_error(start_timer, [A1,A2,A3], Cause) ++
+        [case Cause of
+             badopt ->
+                 must_be_list(Options, bad_option);
+             _ ->
+                 must_be_list(Options, [])
+         end];
 format_erlang_error(subtract, [A,B], _) ->
     [must_be_list(A),must_be_list(B)];
 format_erlang_error(suspend_process, [Pid], _) ->
@@ -1185,6 +1186,17 @@ must_be_size(N) when is_integer(N) ->
     end;
 must_be_size(_) -> not_integer.
 
+must_be_time(Time, Cause) ->
+    case must_be_non_neg_int(Time) of
+        [] ->
+            case Cause of
+                time -> beyond_end_time;
+                _ -> []
+            end;
+        Error ->
+            Error
+    end.
+
 must_be_time_unit(Unit) ->
     try erlang:convert_time_unit(1, native, Unit) of
         _ ->
@@ -1280,6 +1292,8 @@ expand_error(bad_unicode) ->
     <<"invalid UTF8 encoding">>;
 expand_error(bad_universaltime) ->
     <<"not a valid universal time">>;
+expand_error(beyond_end_time) ->
+    <<"exceeds the maximum supported time value">>;
 expand_error(dead_process) ->
     <<"the pid does not refer to an existing process">>;
 expand_error({not_encodable,Type}) ->


### PR DESCRIPTION
The extended error information for timer BIFs would be incorrect if a
time value that exceeded the maximum allowed value was given:

    1> erlang:send_after(1 bsl 50, self(), whatever).
    ** exception error: bad argument
         in function  erlang:send_after/3
            called as erlang:send_after(1125899906842624,<0.83.0>,whatever)
    2> erlang:send_after(1 bsl 50, self(), whatever, []).
    ** exception error: bad argument
         in function  erlang:send_after/4
            called as erlang:send_after(1125899906842624,<0.85.0>,whatever,[])
            *** argument 4: invalid option in list

For the call to `erlang:send_after/3`, no extended errors information would be
reported, while for the call to `erlang:send_after/4` there would be an incorrect
error message for the fourth argument.

This commit correct the messages, producing:

    1> erlang:send_after(1 bsl 50, self(), whatever).
    ** exception error: bad argument
         in function  erlang:send_after/3
            called as erlang:send_after(1125899906842624,<0.83.0>,whatever)
            *** argument 1: exceeds the maximum supported time value
    2> erlang:send_after(1 bsl 50, self(), whatever, []).
    ** exception error: bad argument
         in function  erlang:send_after/4
            called as erlang:send_after(1125899906842624,<0.85.0>,whatever,[])
            *** argument 1: exceeds the maximum supported time value