### PR TITLE
Fix crash in c:ls/1

### DIFF
--- a/lib/stdlib/test/c_SUITE.erl
+++ b/lib/stdlib/test/c_SUITE.erl
@@ -178,7 +178,10 @@ ls(Config) when is_list(Config) ->
     ok = c:ls(Directory),
     File = filename:join(Directory, "m.erl"),
     ok = c:ls(File),
-    ok = c:ls("no_such_file").
+    ok = c:ls([[[[File]]]]),
+    ok = c:ls("no_such_file"),
+    ok = c:ls(list_to_atom(code:which(c))),
+    ok.
 
 %% Check that c:memory/[0,1] returns consistent results.
 memory(Config) when is_list(Config) ->


### PR DESCRIPTION
A call to `c:ls/1` with a filename given as an atom would crash.
Example:

    1> c:ls('/bin/sh').
    ** exception error: bad argument
         in function  length/1
            called as length('/bin/sh')
            *** argument 1: not a list
         in call from c:lengths/2 (c.erl, line 1083)
         in call from c:ls_print/1 (c.erl, line 1071)

Closes #4916