### PR TITLE
Document the on_load result from erlang:load_module/2

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -3476,6 +3476,13 @@ is_process_alive(P2Pid),
           <item><c><anno>Binary</anno></c> contains a module that cannot be
             loaded because old code for this module already exists.
           </item>
+          <tag><c>on_load</c></tag>
+          <item>The code in <c><anno>Binary</anno></c> contains an
+          <c>on_load</c> declaration that must be executed before
+          <c><anno>Binary</anno></c> can become the current code. Any
+          previous current code for <c><anno>Module</anno></c> will remain
+          until the <c>on_load</c> call has finished.
+          </item>
         </taglist>
         <warning>
           <p>This BIF is intended for the code server (see


### PR DESCRIPTION
Tried to describe what this means but without mentioning the undocumented erlang:call_on_load_function/1 and friends.