### PR TITLE
[inets] httpd directory listing improvements

### DIFF
--- a/lib/inets/src/http_server/httpd_response.erl
+++ b/lib/inets/src/http_server/httpd_response.erl
@@ -215,7 +215,7 @@ send_body(#mod{socket_type = Type, socket = Socket}, _, nobody) ->
     ok;
 
 send_body(#mod{socket_type = Type, socket = Sock}, 
-	  _StatusCode, Body) when is_list(Body) ->
+	  _StatusCode, Body) when is_list(Body); is_binary(Body) ->
     case httpd_socket:deliver(Type, Sock, Body) of
 	socket_closed ->
 	    done;


### PR DESCRIPTION
* Replace links to non-existing (Apache) images with text emojis
* Fix column alignment for long filenames
* Fix column alignment for filenames containing &, <, > (length
  calculated on the original name rather than entity encoded name)
* Fix title on root directory "Index of " -> "Index of /"
* Fix link to Parent directory missing on the 2nd level
* Don't show link to Parent directory on root level
* Don't encode slash as %2F in links to sub/parent dirs

Fixes #4855, #4677