### PR TITLE
Make max_transfer_size parameter configurable to optimise mnesia table loading time

### DIFF
--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -3038,6 +3038,11 @@ raise(Name, Amount) ->
           understand this configuration.</p>
       </item>
       <item>
+        <p><c>-mnesia max_transfer_size Number</c>. Specifies the estimated size
+          in bytes of a single packet of data to be used when copying a table from the local
+          node to another one. Default is <c>64000</c>.</p>
+      </item>
+      <item>
         <p><c>-mnesia schema_location Loc</c>. Controls where
           Mnesia looks for its schema. Parameter
           <c>Loc</c> can be one of the following atoms:</p>

--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -2553,6 +2553,7 @@ system_info2(core_dir) ->  mnesia_monitor:get_env(core_dir);
 system_info2(no_table_loaders) ->  mnesia_monitor:get_env(no_table_loaders);
 system_info2(dc_dump_limit) ->  mnesia_monitor:get_env(dc_dump_limit);
 system_info2(send_compressed) -> mnesia_monitor:get_env(send_compressed);
+system_info2(max_transfer_size) -> mnesia_monitor:get_env(max_transfer_size);
 
 system_info2(Item) -> exit({badarg, Item}).
 
@@ -2598,6 +2599,7 @@ system_info_items(yes) ->
      no_table_loaders,
      dc_dump_limit,
      send_compressed,
+     max_transfer_size,
      version
     ];
 system_info_items(no) ->

--- a/lib/mnesia/src/mnesia_monitor.erl
+++ b/lib/mnesia/src/mnesia_monitor.erl
@@ -691,6 +691,7 @@ env() ->
      no_table_loaders,
      dc_dump_limit,
      send_compressed,
+     max_transfer_size,
      schema
     ].
 
@@ -741,6 +742,8 @@ default_env(dc_dump_limit) ->
     4;
 default_env(send_compressed) ->
     0;
+default_env(max_transfer_size) ->
+    64000;
 default_env(schema) ->
     [].
 
@@ -790,6 +793,7 @@ do_check_type(pid_sort_order, _) -> false;
 do_check_type(no_table_loaders, N) when is_integer(N), N > 0 -> N;
 do_check_type(dc_dump_limit,N) when is_number(N), N > 0 -> N;
 do_check_type(send_compressed, L) when is_integer(L), L >= 0, L =< 9 -> L;
+do_check_type(max_transfer_size, N) when is_integer(N), N > 0 -> N;
 do_check_type(schema, L) when is_list(L) -> L.
 
 bool(true) -> true;

--- a/lib/mnesia/test/mnesia_evil_coverage_test.erl
+++ b/lib/mnesia/test/mnesia_evil_coverage_test.erl
@@ -140,6 +140,7 @@ system_info(Config) when is_list(Config) ->
     ?match(A when is_atom(A), mnesia:system_info(dump_log_update_in_place)),
     ?match(I when is_integer(I), mnesia:system_info(transaction_log_writes)),
     ?match(I when is_integer(I), mnesia:system_info(send_compressed)),
+    ?match(I when is_integer(I), mnesia:system_info(max_transfer_size)),
     ?match(L when is_list(L), mnesia:system_info(all)),
     ?match(L when is_list(L), mnesia:system_info(backend_types)),
     ?match({'EXIT', {aborted, Reason }} when element(1, Reason) == badarg


### PR DESCRIPTION
When a table is sent from active node to another one it is done in chunks of N records each, where the N is calculated once based on size in bytes of first record and hard coded `MAX_TRANSFER_SIZE` (`7500`).
```erlang
    (?MAX_TRANSFER_SIZE div BinSize) + 1.
```
In practice it means that we are sending a huge number of super small chunks.
It is worth noting that value of `MAX_TRANSFER_SIZE` was not changed at least since 2009 :)

In our production setup by simply changing this hard coded value to `128000` we were able to reduce loading time of all tables from remote active node from 184s to 114s. Combining it with setting `send_compressed` parameter we were able to reduce it further to 70s.

The important thing is that with default  small chunks of max 7500 bytes using `send_compressed` option made loading time worse (220s). It is because compression of small chunks is ineffective (compared to atom dictionary compression in distribution protocol when sending raw terms).

In the proposed PR we are changing the default value of max transfer size to 64000 and make it configurable.

BTW. Since introducing fragmented packets in distribution protocol in OTP-22 sending big messages between nodes is no more a problem so setting this max transfer size to even bigger values is not a bad idea.