### PR TITLE
Correct printing of Unicode atoms in crash dumps

### DIFF
--- a/lib/observer/src/crashdump_viewer.erl
+++ b/lib/observer/src/crashdump_viewer.erl
@@ -2943,7 +2943,8 @@ parse_term([$p|Line0], _, D) ->			%Port.
     {Port,Line} = get_id(Line0),
     {['#CDVPort'|Port],Line,D};
 parse_term([$S|Str0], _, D) ->			%Information string.
-    Str = lists:reverse(skip_blanks(lists:reverse(Str0))),
+    Str1 = byte_list_to_string(Str0),
+    Str = lists:reverse(skip_blanks(lists:reverse(Str1))),
     {Str,[],D};
 parse_term([$D|Line0], DecodeOpts, D) ->                 %DistExternal
     try

--- a/lib/observer/src/observer_html_lib.erl
+++ b/lib/observer/src/observer_html_lib.erl
@@ -138,8 +138,17 @@ msgq_table(Tab,Msg0, Id, Even, Colors) ->
     tr(color(Even, Colors),[td(integer_to_list(Id)), td(pre(Msg))]).
 
 stackdump_table(Tab,{Label0,Term0},Even, Colors) ->
-    Label = io_lib:format("~w",[Label0]),
-    Term = all_or_expand(Tab,Term0),
+    Label = io_lib:format("~ts",[Label0]),
+    Term = case atom_to_list(Label0) of
+               "y" ++ _ ->
+                   %% Any term is possible, including huge ones.
+                   all_or_expand(Tab,Term0);
+               _ ->
+                   %% Return address or catch tag. It is known to be a
+                   %% flat list, shortish, possibly containing characters
+                   %% greater than 255.
+                   href_proc_port(Term0)
+           end,
     tr(color(Even, Colors), [td("VALIGN=center",pre(Label)), td(pre(Term))]).
 
 dict_table(Tab,{Key0,Value0}, Even, Colors) ->

--- a/lib/observer/test/crashdump_helper_unicode.erl
+++ b/lib/observer/test/crashdump_helper_unicode.erl
@@ -1,6 +1,6 @@
 -module(crashdump_helper_unicode).
 -behaviour(gen_server).
--export([start/0, init/1, handle_call/3, handle_cast/2]).
+-export([start/0, init/1, handle_call/3, handle_cast/2, 'спутник'/0]).
 -record(state, {s,a,b,lb}).
 
 start() ->
@@ -8,6 +8,9 @@ start() ->
 
 init([]) ->
     process_flag(trap_exit, true),
+    process_flag(save_calls, 10),
+    erlang:yield(),
+    ?MODULE:'спутник'(),
     ets:new('tab_αβ',[set,named_table]),
     Bin = <<"bin αβ"/utf8>>,
     LongBin = <<"long bin αβ - a utf8 binary which can be expanded αβ"/utf8>>,
@@ -20,3 +23,6 @@ handle_call(_Info, _From, State) ->
     {reply, ok, State}.
 handle_cast(_Info, State) ->
     {noreply, State}.
+
+'спутник'() ->
+    ok.


### PR DESCRIPTION
Atoms containing Unicode code points greater than 255 would not
be printed correctly in crash dumps.

This commit corrects the printing of Unicode atoms done by the
runtime-internal function `erts_printf()` (used when producing crash
dumps) and also updates `crashdump_viewer` to correctly handle such
atoms in function names in stack backtraces.