### PR TITLE
gen_statem: Make it possible to spec data

### DIFF
--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -1452,7 +1452,8 @@ handle_event(_, _, State, Data) ->
       </desc>
     </datatype>
     <datatype>
-      <name name="init_result"/>
+      <name name="init_result" n_vars="1"/>
+      <name name="init_result" n_vars="2"/>
       <desc>
 	<p>
 	  For a succesful initialization,
@@ -1479,7 +1480,8 @@ handle_event(_, _, State, Data) ->
       </desc>
     </datatype>
     <datatype>
-      <name name="state_enter_result"/>
+      <name name="state_enter_result" n_vars="1"/>
+      <name name="state_enter_result" n_vars="2"/>
       <desc>
 	<p>
 	  <c><anno>State</anno></c> is the current state
@@ -1502,7 +1504,8 @@ handle_event(_, _, State, Data) ->
       </desc>
     </datatype>
     <datatype>
-      <name name="event_handler_result"/>
+      <name name="event_handler_result" n_vars="1"/>
+      <name name="event_handler_result" n_vars="2"/>
       <desc>
 	<p>
 	  <c><anno>StateType</anno></c> is
@@ -1532,7 +1535,8 @@ handle_event(_, _, State, Data) ->
       </desc>
     </datatype>
     <datatype>
-      <name name="state_callback_result"/>
+      <name name="state_callback_result" n_vars="1"/>
+      <name name="state_callback_result" n_vars="2"/>
       <desc>
 	<p>
 	  <c><anno>ActionType</anno></c> is

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -63,8 +63,11 @@
     from/0,
     callback_mode_result/0,
     init_result/1,
+    init_result/2,
     state_enter_result/1,
+    state_enter_result/2,
     event_handler_result/1,
+    event_handler_result/2,
     reply_action/0,
     enter_action/0,
     action/0
@@ -204,9 +207,10 @@
 	{'reply', % Reply to a caller
 	 From :: from(), Reply :: term()}.
 
--type init_result(StateType) ::
-    {ok, State :: StateType, Data :: data()} |
-    {ok, State :: StateType, Data :: data(),
+-type init_result(StateType) :: init_result(StateType, term()).
+-type init_result(StateType, DataType) ::
+    {ok, State :: StateType, Data :: DataType} |
+    {ok, State :: StateType, Data :: DataType,
      Actions :: [action()] | action()} |
     'ignore' |
     {'stop', Reason :: term()}.
@@ -217,38 +221,43 @@
 -type handle_event_result() ::
 	event_handler_result(state()).
 %%
--type state_enter_result(State) ::
-	{'next_state', % {next_state,NextState,NewData,[]}
+-type state_enter_result(State) :: state_enter_result(State, term()).
+-type state_enter_result(State, DataType) ::
+	{'next_state', % {next_state,State,NewData,[]}
 	 State,
-	 NewData :: data()} |
-	{'next_state', % State transition, maybe to the same state
+	 NewData :: DataType} |
+	{'next_state', % State entry for state State
 	 State,
-	 NewData :: data(),
+	 NewData :: DataType,
 	 Actions :: [enter_action()] | enter_action()} |
 	state_callback_result(enter_action()).
 -type event_handler_result(StateType) ::
+    event_handler_result(StateType, term()).
+-type event_handler_result(StateType, DataType) ::
 	{'next_state', % {next_state,NextState,NewData,[]}
 	 NextState :: StateType,
-	 NewData :: data()} |
+	 NewData :: DataType} |
 	{'next_state', % State transition, maybe to the same state
 	 NextState :: StateType,
-	 NewData :: data(),
+	 NewData :: DataType,
 	 Actions :: [action()] | action()} |
 	state_callback_result(action()).
 -type state_callback_result(ActionType) ::
+    state_callback_result(ActionType, term()).
+-type state_callback_result(ActionType, DataType) ::
 	{'keep_state', % {keep_state,NewData,[]}
-	 NewData :: data()} |
+	 NewData :: DataType} |
 	{'keep_state', % Keep state, change data
-	 NewData :: data(),
+	 NewData :: DataType,
 	 Actions :: [ActionType] | ActionType} |
 	'keep_state_and_data' | % {keep_state_and_data,[]}
 	{'keep_state_and_data', % Keep state and data -> only actions
 	 Actions :: [ActionType] | ActionType} |
 	%%
 	{'repeat_state', % {repeat_state,NewData,[]}
-	 NewData :: data()} |
+	 NewData :: DataType} |
 	{'repeat_state', % Repeat state, change data
-	 NewData :: data(),
+	 NewData :: DataType,
 	 Actions :: [ActionType] | ActionType} |
 	'repeat_state_and_data' | % {repeat_state_and_data,[]}
 	{'repeat_state_and_data', % Repeat state and data -> only actions
@@ -259,7 +268,7 @@
 	 Reason :: term()} |
 	{'stop', % Stop the server
 	 Reason :: term(),
-	 NewData :: data()} |
+	 NewData :: DataType} |
 	%%
 	{'stop_and_reply', % Reply then stop the server
 	 Reason :: term(),
@@ -267,7 +276,7 @@
 	{'stop_and_reply', % Reply then stop the server
 	 Reason :: term(),
 	 Replies :: [reply_action()] | reply_action(),
-	 NewData :: data()}.
+	 NewData :: DataType}.
 
 -type request_id() :: term().
 


### PR DESCRIPTION
Add /2 variants of types returning data, so a user can use them to
spec their implementation (parameterized with their own data type)
and thus get validation for it.

**NB**: There is one problem though, the docs doesn't work. [Bug report](https://github.com/erlang/otp/issues/4927)
There seems to be code in the xsl to handle selection with arity, but nobody is using it for types.
Putting both arities in the same datatype block is inspired by function documentation, where it is somewhat commonly used.

Regardless of if i use one of both names, with arity, i get errors like:
`gen_statem:init_result/1: unknown spec`
