### PR TITLE
Add lists:enumerate/1 and lists:enumerate/2

### DIFF
--- a/lib/stdlib/doc/src/lists.xml
+++ b/lib/stdlib/doc/src/lists.xml
@@ -175,6 +175,48 @@
     </func>
 
     <func>
+      <name name="enumerate" arity="1" since="OTP @OTP-17523@"/>
+      <fsummary>Annotates elements with their index.</fsummary>
+      <desc>
+        <p>Returns <c><anno>List1</anno></c> with each element
+        <c>H</c> replaced by a tuple of form <c>{I, H}</c> where
+        <c>I</c> is the position of <c>H</c> in
+        <c><anno>List1</anno></c>. The enumeration starts with 1 and
+        increases by 1 in each step.</p>
+        <p>That is, <c>enumerate/1</c> behaves as if it had been defined as follows:</p>
+        <code type="erl">
+enumerate(List) ->
+  {List1, _ } = lists:mapfoldl(fun(T, Acc) -> {{Acc, T}, Acc+1} end, 1, List),
+  List1.</code>
+        <p><em>Example:</em></p>
+        <pre>
+> <input>lists:enumerate([a,b,c]).</input>
+[{1,a},{2,b},{3,c}]</pre>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="enumerate" arity="2" since="OTP @OTP-17523@"/>
+      <fsummary>Annotates elements with their index.</fsummary>
+      <desc>
+        <p>Returns <c><anno>List1</anno></c> with each element
+        <c>H</c> replaced by a tuple of form <c>{I, H}</c> where
+        <c>I</c> is the position of <c>H</c> in
+        <c><anno>List1</anno></c>. The enumeration starts with
+        <c><anno>Index</anno></c> and increases by 1 in each step.</p>
+        <p>That is, <c>enumerate/2</c> behaves as if it had been defined as follows:</p>
+        <code type="erl">
+enumerate(I, List) ->
+  {List1, _ } = lists:mapfoldl(fun(T, Acc) -> {{Acc, T}, Acc+1} end, I, List),
+  List1.</code>
+        <p><em>Example:</em></p>
+        <pre>
+> <input>lists:enumerate(10, [a,b,c]).</input>
+[{10,a},{11,b},{12,c}]</pre>
+      </desc>
+    </func>
+    
+    <func>
       <name name="filter" arity="2" since=""/>
       <fsummary>Select elements that satisfy a predicate.</fsummary>
       <desc>

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -32,7 +32,7 @@
 	 concat/1, flatten/1, flatten/2, flatlength/1,
 	 keydelete/3, keyreplace/4, keytake/3, keystore/4,
 	 keysort/2, keymerge/3, rkeymerge/3, rukeymerge/3, 
-	 ukeysort/2, ukeymerge/3, keymap/3]).
+	 ukeysort/2, ukeymerge/3, keymap/3, enumerate/1, enumerate/2]).
 
 -export([merge/3, rmerge/3, sort/2, umerge/3, rumerge/3, usort/2]).
 
@@ -956,6 +956,24 @@ keymap(Fun, Index, [Tup|Tail]) ->
    [setelement(Index, Tup, Fun(element(Index, Tup)))|keymap(Fun, Index, Tail)];
 keymap(Fun, Index, []) when is_integer(Index), Index >= 1, 
                             is_function(Fun, 1) -> [].
+
+-spec enumerate(List1) -> List2 when
+      List1 :: [T],
+      List2 :: [{Index, T}],
+      Index :: integer(),
+      T :: term().
+enumerate(List1) ->
+    enumerate(1, List1).
+
+-spec enumerate(Index, List1) -> List2 when
+      List1 :: [T],
+      List2 :: [{Index, T}],
+      Index :: integer(),
+      T :: term().
+enumerate(Index, [H|T]) when is_integer(Index) ->
+    [{Index, H}|enumerate(Index + 1, T)];
+enumerate(Index, []) when is_integer(Index) ->
+    [].
 
 %%% Suggestion from OTP-2948: sort and merge with Fun.
 

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -58,7 +58,7 @@
 	 join/1,
 	 otp_5939/1, otp_6023/1, otp_6606/1, otp_7230/1,
 	 suffix/1, subtract/1, droplast/1, search/1, hof/1,
-         error_info/1]).
+         enumerate/1, error_info/1]).
 
 %% Sort randomized lists until stopped.
 %%
@@ -122,7 +122,7 @@ groups() ->
      {zip, [parallel], [zip_unzip, zip_unzip3, zipwith, zipwith3]},
      {misc, [parallel], [reverse, member, dropwhile, takewhile,
 			 filter_partition, suffix, subtract, join,
-			 hof, droplast, search, error_info]}
+			 hof, droplast, search, enumerate, error_info]}
     ].
 
 init_per_suite(Config) ->
@@ -2740,6 +2740,22 @@ hof(Config) when is_list(Config) ->
 
     true = lists:all(fun(N) -> is_integer(N) end, L),
     false = lists:all(fun(N) -> N rem 2 =:= 0 end, L),
+
+    ok.
+
+%% Test lists:enumerate/1 and lists:enumerate/2
+enumerate(Config) when is_list(Config) ->
+    [] = lists:enumerate([]),
+    [] = lists:enumerate(10, []),
+    [{1,a},{2,b},{3,c}] = lists:enumerate([a,b,c]),
+    [{10,a},{11,b},{12,c}] = lists:enumerate(10, [a,b,c]),
+    {'EXIT', {function_clause, _}} = catch lists:enumerate(0),
+    {'EXIT', {function_clause, _}} = catch lists:enumerate(0, 10),
+    {'EXIT', {function_clause, _}} = catch lists:enumerate(1.0, []),
+    {'EXIT', {function_clause, _}} = catch lists:enumerate(1.0, [a,b,c]),
+    {'EXIT', {function_clause, _}} = catch lists:enumerate(<<1>>, []),
+    {'EXIT', {function_clause, _}} = catch lists:enumerate(<<1>>, [a,b,c]),
+    {'EXIT', {function_clause, _}} = catch lists:enumerate(1, <<1,2,3>>),
 
     ok.
 


### PR DESCRIPTION
This PR introduces `enumerate/1` and `enumerate/2` functions to
the `lists` module in the standard library. Simple unit tests and
documentation for the introduced functions are included.

### Motivation

I am working a lot with ASTs in Erlang and I very often run into a
situation where I need to do something with a list of arguments of
some function definition knowing their index and each time I am doing
so I need to write something like

```
[ ...
  || {I, Arg} <- lists:zip(lists:seq(0, length(Args)), Args)
]
```

This is really annoying and can be expressed with a single function
`enumerate` which does exactly that. The mentioned use case is not
the only one, of course. I run into this pattern really commonly.

Also, many modern languages support this already. The first that come
to my mind are Rust and Python. In Haskell one may use `zip [0..]` for
that.

Next thing is... why not? 

----------------------------

This is my first contribution to OTP. If it lacks something or misses
some guidelines, please let me know so I can fix it.
