### PR TITLE
RFC: diameter: allow `{error, Cause}` return from pick_peer/4

### DIFF
--- a/lib/diameter/src/base/diameter_service.erl
+++ b/lib/diameter/src/base/diameter_service.erl
@@ -331,6 +331,8 @@ pick(#state{options = SvcOpts}
     App = App0#diameter_app{module = ModX ++ Xtra},
     [_,_] = RealmAndHost = diameter_lib:eval([DestF, Dict]),
     case pick_peer(App, RealmAndHost, [Filter | TPids], S) of
+        {error, _} = No ->
+            No;
         {_TPid, _Caps} = TC ->
             {{TC, App}, SvcOpts};
         false = No ->
@@ -1568,8 +1570,8 @@ pick_peer(Local, Remote, Pid, _SvcName, #diameter_app{mutable = true} = App)
             T;
         false = No ->
             No;
-        {error, _} ->
-            false
+        {error, _} = No ->
+            No
     end;
 
 %% App state isn't mutable or it is and we're in the service process:
@@ -1593,13 +1595,20 @@ pick_peer(Local,
         {false = No, ModS} when M ->
             mod_state(Alias, ModS),
             No;
+        {{error, _} = No, ModS} when M ->
+            mod_state(Alias, ModS),
+            No;
         {ok, false = No} ->
             No;
         false = No ->
             No;
+        {error, _} = No ->
+            No;
         {{TPid, #diameter_caps{}} = T, S} when is_pid(TPid) ->
             T;                     %% Accept returned state in the immutable
         {false = No, S} ->         %% case as long it isn't changed.
+            No;
+        {{error, _} = No, S} ->    %% case as long it isn't changed.
             No;
         T when M ->
             ModX = App#diameter_app.module,


### PR DESCRIPTION
Currently, when pick_peer/4 can not pick a peer, it return false.
This is translated to a `{error, no_connection}` from diameter:call/4.

The are instance when the inability to choose a peer does not
mean that we don't have a connection to that peer. The main reason
is that we have somehow determined that all peers are overload or close
to beeing overload and want to moderate load.

This kind of load control can not be done the level of diameter:call/4
because at that level only the type of the call is know, not the
possible peers nor can it account for the failover to other peers.

By allowing errors returned from pick_peer/4, it can inform the
application that the request was actually dropped for other (e.g.
load) reasons.