### PR TITLE
Add process flag 'heap_growth'

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -331,6 +331,7 @@ atom group_leader
 atom handle
 atom have_dt_utag
 atom heap_block_size
+atom heap_growth
 atom heap_size
 atom heap_sizes
 atom heap_type

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1918,6 +1918,20 @@ BIF_RETTYPE process_flag_2(BIF_ALIST_2)
        MAX_HEAP_SIZE_FLAGS_SET(BIF_P, max_heap_flags);
        BIF_RET(old_value);
    }
+   else if (BIF_ARG_1 == am_heap_growth) {
+       old_value = (BIF_P->flags & F_HEAP_GROWTH_LOW) ? am_low : am_normal;
+       switch (BIF_ARG_2) {
+       case am_low:
+           BIF_P->flags |= F_HEAP_GROWTH_LOW;
+           break;
+       case am_normal:
+           BIF_P->flags &= ~F_HEAP_GROWTH_LOW;
+           break;
+       default:
+           goto error;
+       }
+       BIF_RET(old_value);
+   }
    else if (BIF_ARG_1 == am_message_queue_data) {
        old_value = erts_change_message_queue_management(BIF_P, BIF_ARG_2);
        if (is_non_value(old_value))
@@ -4995,6 +5009,21 @@ BIF_RETTYPE system_flag_2(BIF_ALIST_2)
         erts_proc_lock(BIF_P, ERTS_PROC_LOCK_MAIN);
 
         BIF_RET(old_value);
+    } else if (BIF_ARG_1 == am_heap_growth) {
+        erts_aint32_t old_val;
+        switch (BIF_ARG_2) {
+        case am_low:
+            old_val = erts_atomic32_read_bor_nob(&erts_default_proc_flags,
+                                                 F_HEAP_GROWTH_LOW);
+            break;
+        case am_normal:
+            old_val = erts_atomic32_read_band_nob(&erts_default_proc_flags,
+                                                  ~F_HEAP_GROWTH_LOW);
+            break;
+        default:
+            goto error;
+        }
+        BIF_RET((old_val & F_HEAP_GROWTH_LOW) ? am_low : am_normal);
     } else if (BIF_ARG_1 == am_debug_flags) {
 	BIF_RET(am_true);
     } else if (BIF_ARG_1 == am_backtrace_depth) {

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -764,6 +764,7 @@ collect_one_suspend_monitor(ErtsMonitor *mon, void *vsmicp, Sint reds)
 #define ERTS_PI_IX_GARBAGE_COLLECTION_INFO              33
 #define ERTS_PI_IX_MAGIC_REF                            34
 #define ERTS_PI_IX_FULLSWEEP_AFTER                      35
+#define ERTS_PI_IX_HEAP_GROWTH                          36
 
 #define ERTS_PI_FLAG_SINGELTON                          (1 << 0)
 #define ERTS_PI_FLAG_ALWAYS_WRAP                        (1 << 1)
@@ -819,7 +820,8 @@ static ErtsProcessInfoArgs pi_args[] = {
     {am_message_queue_data, 0, 0, ERTS_PROC_LOCK_MAIN},
     {am_garbage_collection_info, ERTS_PROCESS_GC_INFO_MAX_SIZE, 0, ERTS_PROC_LOCK_MAIN},
     {am_magic_ref, 0, ERTS_PI_FLAG_FORCE_SIG_SEND, ERTS_PROC_LOCK_MAIN},
-    {am_fullsweep_after, 0, 0, ERTS_PROC_LOCK_MAIN}
+    {am_fullsweep_after, 0, 0, ERTS_PROC_LOCK_MAIN},
+    {am_heap_growth, 0, 0, ERTS_PROC_LOCK_MAIN}
 };
 
 #define ERTS_PI_ARGS ((int) (sizeof(pi_args)/sizeof(pi_args[0])))
@@ -938,6 +940,8 @@ pi_arg2ix(Eterm arg)
         return ERTS_PI_IX_MAGIC_REF;
     case am_fullsweep_after:
         return ERTS_PI_IX_FULLSWEEP_AFTER;
+    case am_heap_growth:
+        return ERTS_PI_IX_HEAP_GROWTH;
     default:
         return -1;
     }
@@ -1783,6 +1787,10 @@ process_info_aux(Process *c_p,
                                      &hp, NULL);
 	break;
     }
+
+    case ERTS_PI_IX_HEAP_GROWTH:
+        res = (rp->flags & F_HEAP_GROWTH_LOW) ? am_low : am_normal;
+        break;
 
     case ERTS_PI_IX_TOTAL_HEAP_SIZE: {
 	Uint total_heap_size;
@@ -2632,6 +2640,12 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 	hp = HAlloc(BIF_P, 3);
 	res = TUPLE2(hp, am_min_bin_vheap_size,make_small(BIN_VH_MIN_SIZE));
 	BIF_RET(res);
+    } else if (BIF_ARG_1 == am_heap_growth) {
+        Eterm atom = (erts_atomic32_read_nob(&erts_default_proc_flags)
+                      & F_HEAP_GROWTH_LOW) ? am_low : am_normal;
+        hp = HAlloc(BIF_P, 3);
+        res = TUPLE2(hp, am_heap_growth, atom);
+        BIF_RET(res);
     } else if (BIF_ARG_1 == am_process_count) {
 	BIF_RET(make_small(erts_ptab_count(&erts_proc)));
     } else if (BIF_ARG_1 == am_process_limit) {

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -1402,7 +1402,13 @@ minor_collection(Process* p, ErlHeapFragment *live_hf_end,
 	Uint stack_size, size_after, adjust_size, need_after, new_sz, new_mature;
 
 	stack_size = STACK_START(p) - STACK_TOP(p);
-	new_sz = stack_size + size_before;
+        new_sz = stack_size + size_before;
+        if (p->flags & F_HEAP_GROWTH_LOW) {
+            /* Don't include mature_size as it will go onto the old-heap,
+             * instead reserve a constant capacity for new terms */
+            new_sz -= mature_size;
+            new_sz += p->min_heap_size/2;
+        }
         new_sz = next_heap_size(p, new_sz, 0);
 
 	prev_old_htop = p->old_htop;

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -171,6 +171,8 @@ int BIN_VH_MIN_SIZE;		/* The minimum binary virtual*/
 int H_MAX_SIZE;			/* The maximum heap size */
 int H_MAX_FLAGS;		/* The maximum heap flags */
 
+erts_atomic32_t erts_default_proc_flags;
+
 Uint32 erts_debug_flags;	/* Debug flags. */
 int erts_backtrace_depth;	/* How many functions to show in a backtrace
 				 * in error codes.
@@ -619,6 +621,7 @@ void erts_usage(void)
 	       erts_pd_initial_size);
     erts_fprintf(stderr, "-hmqd  val     set default message queue data flag for processes,\n");
     erts_fprintf(stderr, "               valid values are: off_heap | on_heap\n");
+    erts_fprintf(stderr, "-hg val        set heap growth for processes, valid values are: normal | low\n");
     erts_fprintf(stderr, "-IOp number    set number of pollsets to be used to poll for I/O,\n");
     erts_fprintf(stderr, "               This value has to be equal or smaller than the\n");
     erts_fprintf(stderr, "               number of poll threads. If the current platform\n");
@@ -842,6 +845,7 @@ early_init(int *argc, char **argv) /*
     erts_atomic32_init_nob(&erts_writing_erl_crash_dump, 0L);
     erts_tsd_key_create(&erts_is_crash_dumping_key,"erts_is_crash_dumping_key");
 
+    erts_atomic32_init_nob(&erts_default_proc_flags, 0);
     erts_atomic32_init_nob(&erts_max_gen_gcs,
 			       (erts_aint32_t) ((Uint16) -1));
 
@@ -1503,6 +1507,7 @@ erl_start(int argc, char **argv)
              * h|max   - max_heap_size
              * h|maxk  - max_heap_kill
              * h|maxel - max_heap_error_logger
+             * h|g     - heap_growth
 	     *
 	     */
 	    if (has_prefix("mbs", sub_param)) {
@@ -1578,6 +1583,20 @@ erl_start(int argc, char **argv)
 		    erts_usage();
 		}
 		VERBOSE(DEBUG_SYSTEM, ("using max heap size %d\n", H_MAX_SIZE));
+            } else if (has_prefix("g", sub_param)) {
+                arg = get_arg(sub_param+1, argv[i+1], &i);
+                if (sys_strcmp(arg, "low") == 0) {
+                    erts_atomic32_read_bor_nob(&erts_default_proc_flags,
+                                             F_HEAP_GROWTH_LOW);
+                }
+                else if (sys_strcmp(arg, "normal") == 0) {
+                    erts_atomic32_read_band_nob(&erts_default_proc_flags,
+                                              ~F_HEAP_GROWTH_LOW);
+                }
+                else {
+                    erts_fprintf(stderr, "Invalid heap_growth flag %s\n", arg);
+                    erts_usage();
+                }
 	    } else {
 	        /* backward compatibility */
 		arg = get_arg(argv[i]+2, argv[i+1], &i);

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -11789,6 +11789,17 @@ erts_parse_spawn_opts(ErlSpawnOpts *sop, Eterm opts_list, Eterm *tag,
 		} else {
 		    sop->max_gen_gcs = max_gen_gcs;
 		}
+            } else if (arg == am_heap_growth) {
+                switch (val) {
+                case am_low:
+                    sop->proc_flags |= F_HEAP_GROWTH_LOW;
+                    break;
+                case am_normal:
+                    sop->proc_flags &= ~F_HEAP_GROWTH_LOW;
+                    break;
+                default:
+                    result = -1;
+                }
 	    } else if (arg == am_scheduler && is_small(val)) {
 		Sint scheduler = signed_val(val);
                 if (sop->flags & SPO_SCHEDULER)
@@ -11862,7 +11873,7 @@ erl_create_process(Process* parent, /* Parent of process (default group leader).
 		   ErlSpawnOpts* so) /* Options for spawn. */
 {
     int bound = 0;
-    Uint flags = 0, qs_flags = 0;
+    Uint qs_flags = 0;
     ErtsRunQueue *rq = NULL;
     Process *p;
     Sint arity;			/* Number of arguments. */
@@ -11970,7 +11981,7 @@ erl_create_process(Process* parent, /* Parent of process (default group leader).
     /* Reserve place for continuation pointer, redzone, etc */
     heap_need = arg_size + S_RESERVED;
 
-    p->flags = flags;
+    p->flags = so->proc_flags;
     p->sig_qs.flags = qs_flags;
 
     p->static_flags = 0;

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1450,12 +1450,14 @@ typedef struct {
     Uint max_heap_size;         /* Maximum heap size in words */
     Uint max_heap_flags;        /* Maximum heap flags (kill | log) */
     int scheduler;
+    Uint32 proc_flags;          /* Process.flags */
 
 } ErlSpawnOpts;
 
 #define ERTS_SET_DEFAULT_SPAWN_OPTS(SOP)                                \
     do {                                                                \
         (SOP)->flags = erts_default_spo_flags;                          \
+        (SOP)->proc_flags = erts_atomic32_read_nob(&erts_default_proc_flags); \
         (SOP)->opts = NIL;                                              \
         (SOP)->tag = am_spawn_reply;                                    \
         (SOP)->monitor_tag = THE_NON_VALUE;                             \
@@ -1541,6 +1543,7 @@ extern int erts_system_profile_ts_type;
 #define F_HIBERNATED         (1 << 21) /* Hibernated */
 #define F_TRAP_EXIT          (1 << 22) /* Trapping exit */
 #define F_DBG_FORCED_TRAP    (1 << 23) /* DEBUG: Last BIF call was a forced trap */
+#define F_HEAP_GROWTH_LOW    (1 << 24) /* Keep new-heap small */
 
 /* Signal queue flags */
 #define FS_OFF_HEAP_MSGQ       (1 << 0) /* Off heap msg queue */

--- a/erts/emulator/beam/erl_vm.h
+++ b/erts/emulator/beam/erl_vm.h
@@ -230,6 +230,9 @@ extern int BIN_VH_MIN_SIZE;	/* minimum virtual (bin) heap */
 extern int H_MAX_SIZE;          /* maximum (heap + stack) */
 extern int H_MAX_FLAGS;         /* maximum heap flags  */
 
+extern erts_atomic32_t erts_default_proc_flags;  /* Process.flags */
+
+
 extern int erts_atom_table_size;/* Atom table size */
 extern int erts_pd_initial_size;/* Initial Process dictionary table size */
 

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -50,6 +50,7 @@
 	 process_info_messages/1, process_flag_badarg/1,
          process_flag_fullsweep_after/1, process_flag_heap_size/1,
 	 spawn_opt_heap_size/1, spawn_opt_max_heap_size/1,
+	 heap_growth/1,
 	 processes_large_tab/1, processes_default_tab/1, processes_small_tab/1,
 	 processes_this_tab/1, processes_apply_trap/1,
 	 processes_last_call_trap/1, processes_gc_trap/1,
@@ -110,6 +111,7 @@ all() ->
      process_flag_badarg,
      process_flag_fullsweep_after, process_flag_heap_size,
      spawn_opt_heap_size, spawn_opt_max_heap_size,
+     heap_growth,
      spawn_huge_arglist,
      spawn_request_bif,
      spawn_request_monitor_demonitor,
@@ -172,6 +174,8 @@ init_per_group(_GroupName, Config) ->
 end_per_group(_GroupName, Config) ->
     Config.
 
+init_per_testcase(heap_growth, Config) ->
+    [erlang:system_info(heap_growth) | Config];
 init_per_testcase(Func, Config)
   when Func =:= processes_default_tab;
        Func =:= processes_this_tab ->
@@ -184,6 +188,9 @@ init_per_testcase(Func, Config)
 init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
     [{testcase, Func}|Config].
 
+end_per_testcase(heap_growth, Config) when is_list(Config) ->
+    HG = proplists:get_value(heap_growth, Config),
+    erlang:system_flag(heap_growth, HG);
 end_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
     %% Restore max_heap_size to default value.
     erlang:system_flag(max_heap_size,
@@ -2374,6 +2381,56 @@ flush() ->
     after 0 ->
             ok
     end.
+
+heap_growth(_Config) ->
+    {heap_growth,Default} = erlang:system_info(heap_growth),
+    heap_growth_process(Default),
+    Other = heap_growth_change(Default),
+    Default = erlang:system_flag(heap_growth, Other),
+    {heap_growth,Other} = erlang:system_info(heap_growth),
+    Other = erlang:system_flag(heap_growth, Other),
+    {heap_growth,Other} = erlang:system_info(heap_growth),
+    heap_growth_process(Other),
+    Other = erlang:system_flag(heap_growth, Default),
+    {heap_growth,Default} = erlang:system_info(heap_growth),
+    Default = erlang:system_flag(heap_growth, Default),
+    {heap_growth,Default} = erlang:system_info(heap_growth),
+    ok.
+
+heap_growth_change(normal) -> low;
+heap_growth_change(low) -> normal.
+
+heap_growth_process(Default) ->
+    Other = heap_growth_change(Default),
+    Papa = self(),
+    Pid = spawn_link(
+	    fun() ->
+		    {heap_growth, Default} =
+			erlang:process_info(self(), heap_growth),
+		    Papa ! sync,
+		    receive go -> ok end,
+		    Default = erlang:process_flag(heap_growth, Other),
+		    {heap_growth, Other} =
+			erlang:process_info(self(), heap_growth),
+		    Papa ! sync,
+		    receive go -> ok end,
+		    Other = erlang:process_flag(heap_growth, Other),
+		    Other = erlang:process_flag(heap_growth, Default),
+		    {heap_growth, Default} =
+			erlang:process_info(self(), heap_growth),
+		    Default = erlang:process_flag(heap_growth, Default),
+		    Papa ! done
+	    end),
+
+    receive sync -> ok end,
+    {heap_growth, Default} = erlang:process_info(Pid, heap_growth),
+    Pid ! go,
+    receive sync -> ok end,
+    {heap_growth, Other} = erlang:process_info(Pid, heap_growth),
+    Pid ! go,
+    receive done -> ok end,
+    ok.
+
 
 %% error_logger report handler proxy
 init(Pid) ->

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -154,6 +154,7 @@ static char *plush_val_switches[] = {
     "maxk",
     "maxel",
     "mqd",
+    "g",
     "",
     NULL
 };


### PR DESCRIPTION
New process flag `heap_growth` to enable more **memory conservative garbage collections**.

- `normal` is the default old behavior. When allocating heap capacity during GC it takes into account the amount of live terms that survived the last GC. A process continuously generating live data will thus grow its heap capacity over time and get less frequent but larger GCs.
- `low` is the new memory conservative option. The GC maintains a bounded small heap capacity which results in more frequent but smaller GCs.

In both cases, terms that survive two GCs will be moved to the old-heap whose size calculation is not affected by this PR.

heap_growth can be set/read per process with
- `process_flag(heap_growth, low)`
- `process_info(Pid, heap_growth)`
- `spawn_opt(_, [{heap_growth}])`

and node wise with
- `system_flag(heap_growth, low)`
- `system_info(heap_growth)`
- `erl -hg low`
