### PR TITLE
Fix A Bug That Causes The Test System To Not Run

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1095,7 +1095,7 @@ tests release_tests: $(TEST_DIRS)
 
 $(TEST_DIRS):
 	if test -f $@/Makefile; then \
-	    (cd $@; $(MAKE) TESTROOT="$(TESTSUITE_ROOT)" \
+	    (cd $@; $(MAKE) TESTROOT="$(TESTSUITE_ROOT)" ERL_TOP="$(ERL_TOP)" \
 	    PATH=$(TEST_PATH_PREFIX)$(BOOT_PREFIX)"$${PATH}" release_tests) || exit $$?; \
 	fi
 


### PR DESCRIPTION
The test system doesn't run because subsystem tests
don't know where ERL_TOP is.