### PR TITLE
supervisor: optimize restart intensity calculation

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1500,7 +1500,7 @@ add_restart(State) ->
     P = State#state.period,
     R = State#state.restarts,
     Now = erlang:monotonic_time(1),
-    R1 = add_restart([Now|R], Now, P),
+    R1 = add_restart(R, Now, P),
     State1 = State#state{restarts = R1},
     case length(R1) of
 	CurI when CurI  =< I ->
@@ -1509,18 +1509,13 @@ add_restart(State) ->
 	    {terminate, State1}
     end.
 
-add_restart([R|Restarts], Now, Period) ->
-    case inPeriod(R, Now, Period) of
-	true ->
-	    [R|add_restart(Restarts, Now, Period)];
-	_ ->
-	    []
-    end;
-add_restart([], _, _) ->
-    [].
-
-inPeriod(Then, Now, Period) ->
-    Now =< Then + Period.
+add_restart(Restarts0, Now, Period) ->
+    Treshold = Now - Period,
+    Restarts1 = lists:takewhile(
+                  fun (R) -> R >= Treshold end,
+                  Restarts0
+                 ),
+    [Now | Restarts1].
 
 %%% ------------------------------------------------------
 %%% Error and progress reporting.


### PR DESCRIPTION
This PR is just a micro-optimization and some cleaning =^^= It should be pretty obvious what has been done.

`add_restart/3` was just a customized re-invention of `lists:takewhile/2`, and as such even a misnomer, as it didn't _add_ anything. And by putting the new restart on the list (in `add_restart/1`) _before_ passing it to `add_restart/3` to be filtered caused an unnecessary filter step, as the new restart would never be removed anyway. Finally, the `inPeriod/3` function (used for checking if a restart was in or out of period) did a calculation that could really be replaced by a pre-calculated constant value, as the `Now` and `Period` arguments were always the same over a run of `add_restart/3`, and `Now =< Then + Period` could be rewritten as `Now - Period =< Then`.

This PR pre-calculates the treshold time beyond which restarts are considered as out of period, filters the old list of restarts by means of `lists:takewhile/2` using this treshold, and only then adds the new restart. This way, even the name `add_restart` starts to fit, and the `inPeriod/3` function became obsolete.