### PR TITLE
jit-x86: Provide reason for assertion failure in assembly listing

### DIFF
--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -288,6 +288,7 @@ protected:
         a.short_().jle(ok);
 
         a.bind(crash);
+        a.comment("# Redzone touched");
         a.ud2();
 
         a.bind(ok);
@@ -335,6 +336,7 @@ protected:
         Label next = a.newLabel();
         a.cmp(x86::rsp, getInitialSPRef());
         a.short_().je(next);
+        a.comment("# The stack has grown");
         a.ud2();
         a.bind(next);
 #endif
@@ -538,6 +540,7 @@ protected:
         a.short_().je(next);
 
         a.bind(crash);
+        a.comment("# Runtime stack is corrupt");
         a.ud2();
 
         a.bind(next);
@@ -558,6 +561,7 @@ protected:
         a.short_().jle(next);
 
         a.bind(crash);
+        a.comment("Erlang stack is corrupt");
         a.ud2();
         a.bind(next);
 #endif

--- a/erts/emulator/beam/jit/x86/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.cpp
@@ -176,6 +176,7 @@ void BeamGlobalAssembler::emit_export_trampoline() {
     a.je(jump_trace);
 
     /* Must never happen. */
+    a.comment("# Unexpected export trampoline op");
     a.ud2();
 
     a.bind(call_bif);
@@ -286,6 +287,7 @@ void BeamGlobalAssembler::emit_process_exit() {
 
     a.test(RET, RET);
     a.je(labels[do_schedule]);
+    a.comment("# End of process");
     a.ud2();
 }
 
@@ -337,6 +339,7 @@ void BeamGlobalAssembler::emit_raise_exception_shared() {
     a.jmp(RET);
 
     a.bind(crash);
+    a.comment("# Error address is not a CP or NULL or ARG2 and ARG4 are unset");
     a.ud2();
 }
 

--- a/erts/emulator/beam/jit/x86/instr_bif.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bif.cpp
@@ -883,6 +883,7 @@ void BeamGlobalAssembler::emit_call_nif_early() {
         a.test(ARG2, imm(sizeof(UWord) - 1));
         a.short_().je(next);
 
+        a.comment("# Return address isn't word-aligned");
         a.ud2();
 
         a.bind(next);

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -407,7 +407,10 @@ void BeamModuleAssembler::emit_tuple_assertion(const ArgVal &Src,
     a.short_().je(ok);
 
     a.bind(fatal);
-    { a.ud2(); }
+    {
+        a.comment("# Tuple assertion failure");
+        a.ud2();
+    }
     a.bind(ok);
 }
 #endif

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -389,5 +389,6 @@ void BeamModuleAssembler::emit_i_call_fun_last(const ArgVal &Arity,
 
 /* Psuedo-instruction for signalling lambda load errors. Never actually runs. */
 void BeamModuleAssembler::emit_i_lambda_error(const ArgVal &Dummy) {
+    a.comment("# Lambda error");
     a.ud2();
 }

--- a/erts/emulator/beam/jit/x86/process_main.cpp
+++ b/erts/emulator/beam/jit/x86/process_main.cpp
@@ -154,6 +154,7 @@ void BeamGlobalAssembler::emit_process_main() {
         /* Check that ARG3 is set to a valid CP. */
         a.test(ARG3, imm(_CPMASK));
         a.je(check_i);
+        a.comment("# ARG3 is not a valid CP");
         a.ud2();
         a.bind(check_i);
 #endif


### PR DESCRIPTION
The x86 JIT uses the ud2-instruction to signal a failed assertion in
the generated machine code. Investigating a failed assert is
simplified if the reason for the failure is provided in the assembly
listing produced when running with `+JDdump true`.