### PR TITLE
ssl: Use new socket:monitor/1

### DIFF
--- a/lib/ssl/src/ssl_server_session_cache.erl
+++ b/lib/ssl/src/ssl_server_session_cache.erl
@@ -255,5 +255,5 @@ monitor_listener(ssl_unknown_listener) ->
     %% Backwards compatible Erlang node
     %% global process.
     undefined;
-monitor_listener(Listen) when is_port(Listen) ->
-    erlang:monitor(port, Listen).
+monitor_listener(Listen) ->
+    inet:monitor(Listen).


### PR DESCRIPTION
To be able to fully work with new gen_tcp socket backend.