### PR TITLE
Improve the readability of .asm-dumps

### DIFF
--- a/erts/emulator/beam/beam_file.h
+++ b/erts/emulator/beam/beam_file.h
@@ -150,6 +150,9 @@ typedef struct {
     BeamFile_AtomTable atoms;
     BeamFile_ImportTable imports;
     BeamFile_ExportTable exports;
+#ifdef BEAMASM
+    BeamFile_ExportTable locals;
+#endif
     BeamFile_LambdaTable lambdas;
     BeamFile_LineTable lines;
 
@@ -185,6 +188,7 @@ enum beamfile_read_result {
     BEAMFILE_READ_CORRUPT_EXPORT_TABLE,
     BEAMFILE_READ_MISSING_IMPORT_TABLE,
     BEAMFILE_READ_CORRUPT_IMPORT_TABLE,
+    BEAMFILE_READ_CORRUPT_LOCALS_TABLE,
 
     /* Optional chunks */
     BEAMFILE_READ_CORRUPT_LAMBDA_TABLE,

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -148,6 +148,8 @@ erts_prepare_loading(Binary* magic, Process *c_p, Eterm group_leader,
         BeamLoadError0(stp, "corrupt line table");
     case BEAMFILE_READ_CORRUPT_LITERAL_TABLE:
         BeamLoadError0(stp, "corrupt literal table");
+    case BEAMFILE_READ_CORRUPT_LOCALS_TABLE:
+        BeamLoadError0(stp, "corrupt locals table");
     case BEAMFILE_READ_SUCCESS:
         break;
     }

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -920,6 +920,17 @@ class BeamModuleAssembler : public BeamAssembler {
     typedef std::unordered_map<BeamLabel, Label> LabelMap;
     LabelMap rawLabels;
 
+    /* Map of label number to function name. Only defined for the
+     * entry label of a function. This map will be populated and
+     * used only when assembly output has been requested. */
+    typedef std::unordered_map<BeamLabel, std::string> LabelNames;
+    LabelNames labelNames;
+
+    /* Sequence number used to create unique named labels by
+     * resolve_label(). Only used when assembly output has been
+     * requested. */
+    long labelSeq = 0;
+
     struct patch {
         Label where;
         uint64_t val_offs;
@@ -1213,7 +1224,9 @@ protected:
      * When the branch type is not `dispUnknown`, this must be used
      * _IMMEDIATELY BEFORE_ the instruction that the label is used in. */
     Label resolve_beam_label(const ArgVal &Label, enum Displacement disp);
-    Label resolve_label(Label target, enum Displacement disp);
+    Label resolve_label(Label target,
+                        enum Displacement disp,
+                        std::string *name = nullptr);
 
     /* Resolves a shared fragment, creating a trampoline that loads the
      * appropriate address before jumping there.

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1063,11 +1063,13 @@ class BeamModuleAssembler : public BeamAssembler {
 public:
     BeamModuleAssembler(BeamGlobalAssembler *ga,
                         Eterm mod,
-                        unsigned num_labels);
+                        unsigned num_labels,
+                        BeamFile_ExportTable *named_labels = NULL);
     BeamModuleAssembler(BeamGlobalAssembler *ga,
                         Eterm mod,
                         unsigned num_labels,
-                        unsigned num_functions);
+                        unsigned num_functions,
+                        BeamFile_ExportTable *named_labels = NULL);
 
     bool emit(unsigned op, const Span<ArgVal> &args);
 

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -79,7 +79,8 @@ ErtsCodePtr BeamModuleAssembler::getLambda(unsigned index) {
 
 BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
                                          Eterm mod,
-                                         unsigned num_labels)
+                                         unsigned num_labels,
+                                         BeamFile_ExportTable *named_labels)
         : BeamAssembler(getAtom(mod)) {
     this->ga = ga;
     this->mod = mod;
@@ -104,8 +105,9 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
 BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
                                          Eterm mod,
                                          unsigned num_labels,
-                                         unsigned num_functions)
-        : BeamModuleAssembler(ga, mod, num_labels) {
+                                         unsigned num_functions,
+                                         BeamFile_ExportTable *named_labels)
+        : BeamModuleAssembler(ga, mod, num_labels, named_labels) {
     codeHeader = a.newLabel();
     a.align(kAlignCode, 8);
     a.bind(codeHeader);

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <algorithm>
+#include <sstream>
 #include <float.h>
 
 #include "beam_asm.hpp"
@@ -88,18 +89,44 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
     _veneers.reserve(num_labels + 1);
     rawLabels.reserve(num_labels + 1);
 
-    for (unsigned i = 1; i < num_labels; i++) {
-        Label lbl;
-
-#ifdef DEBUG
-        std::string lblName = "label_" + std::to_string(i);
-        lbl = a.newNamedLabel(lblName.data());
-#else
-        lbl = a.newLabel();
-#endif
-
-        rawLabels[i] = lbl;
+    if (erts_jit_asm_dump && named_labels) {
+        BeamFile_ExportEntry *e = &named_labels->entries[0];
+        for (unsigned i = 1; i < num_labels; i++) {
+            Label lbl;
+            char tmp[512]; // Large enough to hold most realistic
+                           // function names. We will truncate too
+                           // long names, but as the label name is not
+                           // important for the functioning of asmjit
+                           // and this functionality is probably only
+                           // used by developers, we don't bother with
+                           // dynamic allocation.
+            // The named_labels are sorted, so no need for a search.
+            if ((unsigned)e->label == i) {
+                erts_snprintf(tmp, sizeof(tmp), "%T/%d", e->function, e->arity);
+                lbl = a.newNamedLabel(tmp);
+                labelNames[i] = tmp;
+                e++;
+            } else {
+                std::string lblName = "label_" + std::to_string(i);
+                lbl = a.newNamedLabel(lblName.data());
+            }
+            rawLabels[i] = lbl;
+        }
+        return;
     }
+    if (erts_jit_asm_dump) {
+        // There is no naming info, but dumping of the assembly code
+        // has been requested, so do the best we can and number the
+        // labels.
+        for (unsigned i = 1; i < num_labels; i++) {
+            std::string lblName = "label_" + std::to_string(i);
+            rawLabels[i] = a.newNamedLabel(lblName.data());
+        }
+        return;
+    }
+    // No output is requested, go with unnamed labels
+    for (unsigned i = 1; i < num_labels; i++)
+        rawLabels[i] = a.newLabel();
 }
 
 BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
@@ -549,10 +576,17 @@ void BeamModuleAssembler::patchStrings(char *rw_base,
 Label BeamModuleAssembler::resolve_beam_label(const ArgVal &Lbl,
                                               enum Displacement disp) {
     ASSERT(Lbl.isLabel());
-    return resolve_label(rawLabels[Lbl.getValue()], disp);
+    auto it = labelNames.find(Lbl.getValue());
+    if (it != labelNames.end()) {
+        return resolve_label(rawLabels[Lbl.getValue()], disp, &it->second);
+    } else {
+        return resolve_label(rawLabels[Lbl.getValue()], disp);
+    }
 }
 
-Label BeamModuleAssembler::resolve_label(Label target, enum Displacement disp) {
+Label BeamModuleAssembler::resolve_label(Label target,
+                                         enum Displacement disp,
+                                         std::string *labelName) {
     ssize_t currOffset = a.offset();
 
     ssize_t minOffset = currOffset - disp;
@@ -587,9 +621,22 @@ Label BeamModuleAssembler::resolve_label(Label target, enum Displacement disp) {
         }
     }
 
+    Label anchor;
+    if (!labelName) {
+        anchor = a.newLabel();
+    } else {
+        /* This is the entry label for a function. Create an unique
+         * name for the anchor label. It is necessary to include a
+         * sequence number in the label name because if the module is
+         * huge more than one veneer can be created for each entry
+         * label. */
+        std::stringstream name;
+        name << '@' << *labelName << '-' << labelSeq++;
+        anchor = a.newNamedLabel(name.str().c_str());
+    }
     auto it = _veneers.emplace(target.id(),
                                Veneer{.latestOffset = maxOffset,
-                                      .anchor = a.newLabel(),
+                                      .anchor = anchor,
                                       .target = target});
 
     const Veneer &veneer = it->second;

--- a/erts/emulator/beam/jit/beam_asm.h
+++ b/erts/emulator/beam/jit/beam_asm.h
@@ -40,7 +40,10 @@ extern int erts_jit_perf_support;
 
 void beamasm_init(void);
 void beamasm_init_perf(void);
-void *beamasm_new_assembler(Eterm mod, int num_labels, int num_functions);
+void *beamasm_new_assembler(Eterm mod,
+                            int num_labels,
+                            int num_functions,
+                            BeamFile_ExportTable *named_labels);
 void beamasm_codegen(void *ba,
                      const void **native_module_exec,
                      void **native_module_rw,

--- a/erts/emulator/beam/jit/beam_jit_main.cpp
+++ b/erts/emulator/beam/jit/beam_jit_main.cpp
@@ -493,8 +493,15 @@ extern "C"
 #endif
     }
 
-    void *beamasm_new_assembler(Eterm mod, int num_labels, int num_functions) {
-        return new BeamModuleAssembler(bga, mod, num_labels, num_functions);
+    void *beamasm_new_assembler(Eterm mod,
+                                int num_labels,
+                                int num_functions,
+                                BeamFile_ExportTable *named_labels) {
+        return new BeamModuleAssembler(bga,
+                                       mod,
+                                       num_labels,
+                                       num_functions,
+                                       named_labels);
     }
 
     int beamasm_emit(void *instance, unsigned specific_op, BeamOp *op) {

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1046,11 +1046,13 @@ class BeamModuleAssembler : public BeamAssembler {
 public:
     BeamModuleAssembler(BeamGlobalAssembler *ga,
                         Eterm mod,
-                        unsigned num_labels);
+                        unsigned num_labels,
+                        BeamFile_ExportTable *named_labels = NULL);
     BeamModuleAssembler(BeamGlobalAssembler *ga,
                         Eterm mod,
                         unsigned num_labels,
-                        unsigned num_functions);
+                        unsigned num_functions,
+                        BeamFile_ExportTable *named_labels = NULL);
 
     bool emit(unsigned op, const Span<ArgVal> &args);
 

--- a/erts/emulator/beam/jit/x86/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_module.cpp
@@ -79,7 +79,8 @@ ErtsCodePtr BeamModuleAssembler::getLambda(unsigned index) {
 
 BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
                                          Eterm mod,
-                                         unsigned num_labels)
+                                         unsigned num_labels,
+                                         BeamFile_ExportTable *named_labels)
         : BeamAssembler(getAtom(mod)) {
     this->ga = ga;
     this->mod = mod;
@@ -102,8 +103,9 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
 BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
                                          Eterm mod,
                                          unsigned num_labels,
-                                         unsigned num_functions)
-        : BeamModuleAssembler(ga, mod, num_labels) {
+                                         unsigned num_functions,
+                                         BeamFile_ExportTable *named_labels)
+        : BeamModuleAssembler(ga, mod, num_labels, named_labels) {
     codeHeader = a.newLabel();
     a.align(kAlignCode, 8);
     a.bind(codeHeader);

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -76,6 +76,7 @@ MODULES= \
 	hello_SUITE \
 	hibernate_SUITE \
 	iovec_SUITE \
+	jit_SUITE \
 	list_bif_SUITE \
 	lttng_SUITE \
 	lcnt_SUITE \
@@ -92,7 +93,6 @@ MODULES= \
 	message_queue_data_SUITE \
 	op_SUITE \
 	os_signal_SUITE \
-	perf_SUITE \
 	port_SUITE \
 	port_bif_SUITE \
 	prim_eval_SUITE \

--- a/erts/emulator/test/jit_SUITE.erl
+++ b/erts/emulator/test/jit_SUITE.erl
@@ -22,8 +22,9 @@
 
 -export([suite/0, groups/0, all/0,
          init_per_suite/1, end_per_suite/1,
-         init_per_group/2, end_per_group/2]).
--export([symbols/1, annotate/1]).
+         init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2]).
+-export([annotate/1, named_labels/1, symbols/1]).
 
 suite() ->
     [{timetrap, {minutes, 4}}].
@@ -32,7 +33,7 @@ groups() ->
     [{perf, [symbols, annotate]}].
 
 all() ->
-    [{group, perf}].
+    [{group, perf}, named_labels].
 
 init_per_suite(Config) ->
     case erlang:system_info(emu_flavor) of
@@ -101,6 +102,29 @@ end_per_group(perf, Config) ->
 end_per_group(_, _Config) ->
     ok.
 
+init_per_testcase(named_labels, Config) ->
+    %% Only run named_labels on platforms where we know it works.
+    case erlang:system_info(system_architecture) of
+	"x86" ++ _ ->
+	    [{asmbefore,get_tmp_asm_files()}|Config];
+	"aarch64" ++ _ ->
+	    [{asmbefore,get_tmp_asm_files()}|Config];
+	_ ->
+	    {skip, "Unsupported architecture"}
+    end;
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(named_labels, Config) ->
+    AsmToDelete = get_tmp_asm_files() -- proplists:get_value(asmbefore, Config),
+    lists:foreach(
+      fun(File) ->
+              ok = file:delete(File)
+      end, AsmToDelete),
+    ok;
+end_per_testcase(_, _Config) ->
+    ok.
+
 get_tmp_so_files() ->
     {ok, Home} = init:get_argument(home),
     filelib:wildcard("/tmp/jitted-*.so") ++
@@ -148,4 +172,52 @@ annotate(Config) ->
             ct:log("Did not find disassembly test for ~ts.~n~ts",
                    [Symbol, Anno])
     end.
-    
+
+get_tmp_asm_files() ->
+    {ok, Cwd} = file:get_cwd(),
+    filelib:wildcard(filename:join(Cwd, "*.asm")).
+
+named_labels(_Config) ->
+    %% Check that pretty printing of named labels is working. We do
+    %% that by loading this module in an emulator running with +JDdump
+    %% true and then checking that the produced jit_SUITE.asm contains
+    %% a label for each exported function. We also check that the
+    %% label for the non-exported function get_tmp_asm_files/0, which
+    %% is used by this test, is present.
+    Exports = proplists:get_value(exports, ?MODULE:module_info()),
+    ModName = atom_to_list(?MODULE),
+    ModulePath = filename:dirname(code:which(?MODULE)),
+    Cmd = "erl +JDdump true -noshell -pa " ++ ModulePath ++ " -eval \""
+        ++ ModName ++ ":module_info(),erlang:halt(0).\"",
+    os:cmd(Cmd),
+    {ok, Cwd} = file:get_cwd(),
+    AsmFile = filename:join(Cwd, ModName ++ ".asm"),
+    {ok, Data} = file:read_file(AsmFile),
+    Expected = sets:from_list([ lists:flatten(io_lib:format("~p/~p", [N,A]))
+                                || {N,A} <- Exports]
+                              ++ ["get_tmp_asm_files/0"]),
+    StripSeqNo = fun(Lbl) ->
+                         %% In the Arm JIT, labels have the form
+                         %% @Mod:Name/Arity-SequenceNumber, so strip
+                         %% out the Mod part and the sequence number
+                         %% as we can't know anything about them.
+                         case re:run(Lbl, "^.*\:(.*)-[0-9]*$",
+                                     [{capture,all_but_first,list}]) of
+                             {match,[R]} -> R;
+                             nomatch -> Lbl
+                         end
+                 end,
+    case re:run(Data, "^(.*)\:\n",
+                [global,multiline,{capture,all_but_first,list}]) of
+        {match,Labels} ->
+            Found = sets:from_list([ StripSeqNo(NA) || [NA] <- Labels]),
+            case sets:is_subset(Expected, Found) of
+                true ->
+                    ok;
+                false ->
+                    ct:fail("Expected ~p, found ~p",
+                            [sets:to_list(Expected), sets:to_list(Found)])
+            end;
+        _ ->
+            ct:fail("No labels found in assembly dump")
+    end.


### PR DESCRIPTION
This is a set of patches which improve the readability of the
.asm-dumps, produced when running the emulator with the `+JDump true`
flag, by pretty-printing the labels marking the start of a function
using its <name>/<arity> Erlang name.

If this PR is accepted I can do an Arm-version of the last patch, but
I will require a volunteer to test it.
