### PR TITLE
Enable horizontal scrolling in docs code block samples

### DIFF
--- a/lib/erl_docgen/priv/css/otp_doc.css
+++ b/lib/erl_docgen/priv/css/otp_doc.css
@@ -67,8 +67,8 @@ a:visited      { color: #1b6ec2; text-decoration: none }
 
 .innertube 
 {
-    margin-left: 15px; /* Magins for inner DIV inside each DIV (to provide padding) */
-    margin-right: 11em;
+    margin: 0 15px; /* Magins for inner DIV inside each DIV (to provide padding) */
+    max-width: 67ex;
 }
 
 .footer 
@@ -180,7 +180,7 @@ a:visited      { color: #1b6ec2; text-decoration: none }
   padding: 0.5em 1em;
   margin: 1em 0;
   font-size: 0.7em;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 .extrafrontpageinfo {
   color: #C00;
@@ -204,7 +204,8 @@ pre {
 }
 .exports-tube
 {
-    margin-right: 11em;
+    margin-right: 15px;
+    max-width: 67ex;
 }
 
 footer       { }

--- a/lib/erl_docgen/priv/css/otp_doc.css
+++ b/lib/erl_docgen/priv/css/otp_doc.css
@@ -180,6 +180,7 @@ a:visited      { color: #1b6ec2; text-decoration: none }
   padding: 0.5em 1em;
   margin: 1em 0;
   font-size: 0.7em;
+  overflow-x: scroll;
 }
 .extrafrontpageinfo {
   color: #C00;


### PR DESCRIPTION
While reading the [sys and proc_lib docs](http://erlang.org/doc/design_principles/spec_proc.html#id80464), I realised that the code blocks wrapped in a `<pre>` tag were overflowing its container. This prevents scrolling the container and seeing the text on smaller screens. 

This PR should fix that by enabling horizontal scrolling within code block samples.
Here is some screenshots and video of the before and after this PR.

## Before
<img width="1435" alt="Screenshot 2021-06-19 at 20 45 02" src="https://user-images.githubusercontent.com/2049560/122652531-b5501000-d13f-11eb-965f-d844feff0dd6.png">

## After
<img width="1429" alt="Screenshot 2021-06-19 at 20 49 18" src="https://user-images.githubusercontent.com/2049560/122652577-d44ea200-d13f-11eb-8481-9fa717310315.png">

## Video of the current solution being applied

https://user-images.githubusercontent.com/2049560/122652658-2bed0d80-d140-11eb-8237-ff062b4fa6a5.mp4

