### PR TITLE
Add a "Coming Potential Incompatibilities" page to the documentation

### DIFF
--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -988,7 +988,7 @@ DiB == gen_digest(ChA, ICA)?
         <tag><c>-define(DFLAG_EXTENDED_REFERENCES,16#4).</c></tag>
         <item>
           <p>The node implements extended (3 &times; 32 bits) references. This
-            is required today. If not present, the  connection is refused.</p>
+            flag is mandatory. If not present, the  connection is refused.</p>
         </item>
         <tag><c>-define(DFLAG_DIST_MONITOR,16#8).</c></tag>
         <item>
@@ -997,7 +997,8 @@ DiB == gen_digest(ChA, ICA)?
         <tag><c>-define(DFLAG_FUN_TAGS,16#10).</c></tag>
         <item>
           <p>The node uses separate tag for funs (lambdas) in the distribution
-            protocol.</p>
+          protocol.</p>
+          <note><p>This flag will become mandatory in OTP 25.</p></note>
         </item>
         <tag><c>-define(DFLAG_DIST_MONITOR_NAME,16#20).</c></tag>
         <item>
@@ -1009,28 +1010,34 @@ DiB == gen_digest(ChA, ICA)?
         </item>
         <tag><c>-define(DFLAG_NEW_FUN_TAGS,16#80).</c></tag>
         <item>
-	  <p>The node understands the <seeguide marker="erl_ext_dist#NEW_FUN_EXT">
-	    <c>NEW_FUN_EXT</c></seeguide> tag.</p>
+	  <p>The node understands the <seeguide
+	  marker="erl_ext_dist#NEW_FUN_EXT">
+	  <c>NEW_FUN_EXT</c></seeguide> tag. This flag is
+	  mandatory. If not present, the connection is refused.</p>
         </item>
         <tag><c>-define(DFLAG_EXTENDED_PIDS_PORTS,16#100).</c></tag>
         <item>
-          <p>The node can handle extended pids and ports. This is required
-            today. If not present, the connection is refused.</p>
+          <p>The node can handle extended pids and ports. This
+          flag is mandatory.  If not present, the connection is
+          refused.</p>
         </item>
         <tag><c>-define(DFLAG_EXPORT_PTR_TAG,16#200).</c></tag>
         <item>
 	  <p>The node understands the <seeguide marker="erl_ext_dist#EXPORT_EXT">
-	    <c>EXPORT_EXT</c></seeguide> tag.</p>
+	  <c>EXPORT_EXT</c></seeguide> tag.</p>
+          <note><p>This flag will become mandatory in OTP 25.</p></note>
         </item>
         <tag><c>-define(DFLAG_BIT_BINARIES,16#400).</c></tag>
         <item>
 	  <p>The node understands the <seeguide marker="erl_ext_dist#BIT_BINARY_EXT">
-	    <c>BIT_BINARY_EXT</c></seeguide> tag.</p>
+	  <c>BIT_BINARY_EXT</c></seeguide> tag.</p>
+          <note><p>This flag will become mandatory in OTP 25.</p></note>
         </item>
         <tag><c>-define(DFLAG_NEW_FLOATS,16#800).</c></tag>
         <item>
 	  <p>The node understands the <seeguide marker="erl_ext_dist#NEW_FLOAT_EXT">
-	    <c>NEW_FLOAT_EXT</c></seeguide> tag.</p>
+	  <c>NEW_FLOAT_EXT</c></seeguide> tag.</p>
+          <note><p>This flag will become mandatory in OTP 25.</p></note>
         </item>
         <tag><c>-define(DFLAG_UNICODE_IO,16#1000).</c></tag>
         <item>
@@ -1050,12 +1057,14 @@ DiB == gen_digest(ChA, ICA)?
 	    <seeguide marker="erl_ext_dist#ATOM_UTF8_EXT">
 	    <c>ATOM_UTF8_EXT</c></seeguide> and
 	    <seeguide marker="erl_ext_dist#SMALL_ATOM_UTF8_EXT">
-	    <c>SMALL ATOM_UTF8_EXT</c></seeguide>.</p>
+	      <c>SMALL ATOM_UTF8_EXT</c></seeguide>.  This flag is
+	      mandatory. If not present, the connection is refused.</p>
         </item>
         <tag><c>-define(DFLAG_MAP_TAG, 16#20000).</c></tag>
         <item>
           <p>The node understands the map tag
 	  <seeguide marker="erl_ext_dist#MAP_EXT"><c>MAP_EXT</c></seeguide>.</p>
+          <note><p>This flag will become mandatory in OTP 25.</p></note>
         </item>
         <tag><marker id="DFLAG_BIG_CREATION"/><c>-define(DFLAG_BIG_CREATION, 16#40000).</c></tag>
         <item>
@@ -1063,7 +1072,7 @@ DiB == gen_digest(ChA, ICA)?
 	  <seeguide marker="erl_ext_dist#NEW_PID_EXT"><c>NEW_PID_EXT</c></seeguide>,
 	  <seeguide marker="erl_ext_dist#NEW_PORT_EXT"><c>NEW_PORT_EXT</c></seeguide> and
 	  <seeguide marker="erl_ext_dist#NEWER_REFERENCE_EXT"><c>NEWER_REFERENCE_EXT</c></seeguide>.
-	  </p>
+          This flag is mandatory. If not present, the connection is refused.</p>
         </item>
         <tag><c>-define(DFLAG_SEND_SENDER, 16#80000).</c></tag>
         <item>

--- a/system/doc/general_info/upcoming_incompatibilities.xml
+++ b/system/doc/general_info/upcoming_incompatibilities.xml
@@ -65,4 +65,32 @@
       </taglist>
     </section>
   </section>
+
+  <section>
+    <title>OTP 26</title>
+    <section>
+      <title>The distribution flag DFLAG_V4_NC will become mandatory</title>
+      <p>As of OTP 26, the distribution flag <seeguide
+      marker="erts:erl_dist_protocol#DFLAG_V4_NC">DFLAG_V4_NC</seeguide>
+      will become mandatory. If you implement the Erlang distribution
+      protocol yourself, you will need to implement support for
+      <c>DFLAG_V4_NC</c> in order to communicate with Erlang nodes
+      running OTP 26.</p>
+    </section>
+
+    <section>
+      <title>The new link protocol will become mandatory</title>
+      <p>
+	As of OTP 26, the <seeguide
+	marker="erts:erl_dist_protocol#new_link_protocol">new link
+	protocol</seeguide> will become mandatory. That is, Erlang
+	nodes will then refuse to connect to nodes not implementing
+	the new link protocol. If you implement the Erlang
+	distribution yourself, you are, however, encouraged to
+	implement the new link protocol as soon as possible since the
+	old protocol can cause links to enter an inconsistent state.
+      </p>
+    </section>
+
+  </section>
 </chapter>

--- a/system/doc/general_info/upcoming_incompatibilities.xml
+++ b/system/doc/general_info/upcoming_incompatibilities.xml
@@ -34,4 +34,35 @@
     <p>This document lists planned upcoming potential incompatibilities in
     Erlang/OTP.</p>
   </section>
+
+  <section>
+    <title>OTP 25</title>
+    <section>
+      <title>Distribution flags will become mandatory</title>
+      <p>In OTP 25, more <seeguide
+      marker="erts:erl_dist_protocol#dflags">distribution
+      flags</seeguide> will become mandatory. That is, Erlang nodes
+      will refuse to connect to nodes not implementing all of the
+      mandatory distribution flags. If you implement the Erlang
+      distribution protocol yourself, you will need to implement
+      support for all mandatory distribution flags in order to
+      communicate with Erlang nodes running OTP 25.</p>
+      <p>The following distribution flags will become mandatory in OTP
+      25:</p>
+      <taglist>
+        <tag><c>DFLAG_BIT_BINARIES</c></tag>
+        <item>Support for bitstrings.</item>
+        <tag><c>DFLAG_EXPORT_PTR_TAG</c></tag>
+        <item>Support for external funs (<c>fun Module:Name/Arity</c>).</item>
+        <tag><c>DFLAG_MAP_TAGS</c></tag>
+        <item>Support for maps.</item>
+        <tag><c>DFLAG_NEW_FLOATS</c></tag>
+        <item>Support for the new encoding of floats.</item>
+        <tag><c>DFLAG_FUN_TAGS</c></tag>
+        <item>Support for funs, but only in the new format
+        (<c>NEW_FUN_EXT</c>) because <c>DFLAG_NEW_FUN_TAGS</c> is also
+        mandatory.</item>
+      </taglist>
+    </section>
+  </section>
 </chapter>

--- a/system/doc/general_info/upcoming_incompatibilities.xml
+++ b/system/doc/general_info/upcoming_incompatibilities.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE part SYSTEM "part.dtd">
+<!DOCTYPE chapter SYSTEM "chapter.dtd">
 
-<part xmlns:xi="http://www.w3.org/2001/XInclude">
+<chapter>
   <header>
     <copyright>
-      <year>2019</year>
+      <year>2021</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.
       You may obtain a copy of the License at
- 
+
           http://www.apache.org/licenses/LICENSE-2.0
 
       Unless required by applicable law or agreed to in writing, software
@@ -19,18 +19,19 @@
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
       See the License for the specific language governing permissions and
       limitations under the License.
-    
+
     </legalnotice>
 
-    <title>General Information</title>
-    <prepared>OTP Team</prepared>
+    <title>Upcoming Potential Incompatibilities</title>
+    <prepared></prepared>
     <docno></docno>
-    <date>2019-02-23</date>
+    <date></date>
     <rev></rev>
-    <file>part.xml</file>
+    <file>upcoming_incompatibilities.xml</file>
   </header>
-  <xi:include href="deprecations.xml"/>
-  <xi:include href="removed.xml"/>
-  <xi:include href="scheduled_for_removal.xml"/>
-  <xi:include href="upcoming_incompatibilities.xml"/>
-</part>
+  <section>
+    <title>Introduction</title>
+    <p>This document lists planned upcoming potential incompatibilities in
+    Erlang/OTP.</p>
+  </section>
+</chapter>

--- a/system/doc/general_info/xmlfiles.mk
+++ b/system/doc/general_info/xmlfiles.mk
@@ -23,4 +23,5 @@ GENERAL_INFO_CHAPTER_FILES =
 GENERAL_INFO_CHAPTER_GEN_FILES = \
 	deprecations.xml \
 	removed.xml \
-	scheduled_for_removal.xml
+	scheduled_for_removal.xml \
+	upcoming_incompatibilities.xml

--- a/system/doc/top/templates/index.html.src
+++ b/system/doc/top/templates/index.html.src
@@ -47,6 +47,7 @@ limitations under the License.
  <li><a href="general_info/deprecations.html" class="modules">Deprecations</a></li>
  <li><a href="general_info/removed.html" class="modules">Removed Functionality</a></li>
  <li><a href="general_info/scheduled_for_removal.html" class="modules">Scheduled for Removal</a></li>
+ <li><a href="general_info/upcoming_incompatibilities.html" class="modules">Upcoming Potential Incompatibilities</a></li>
 </ul>
 
 <ul class="expand-collapse-items">


### PR DESCRIPTION
Some upcoming changes can be awkward to fit into the "Deprecations" and "Scheduled for Removal" pages. Add a new "Coming Potential Incompatibilities" pages to address that issue.

To that page, add a list of the distribution capabilities that will become mandatory in OTP 25 (see #4972).

Also copy with edits some upcoming changes to the distribution now described in "Scheduled for Removal".