### PR TITLE
erts/emulator: use single type for ErlDrvEvent

### DIFF
--- a/erts/emulator/beam/erl_bif_unique.h
+++ b/erts/emulator/beam/erl_bif_unique.h
@@ -114,7 +114,7 @@ ERTS_GLB_INLINE Eterm erts_get_pid_of_ref(Eterm ref);
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 
 ERTS_GLB_INLINE void
-erts_set_ref_numbers(Uint32 ref[ERTS_REF_NUMBERS], Uint32 thr_id, Uint64 value)
+erts_set_ref_numbers(Uint32 *ref, Uint32 thr_id, Uint64 value)
 {
     /*
      * We cannot use thread id in the first 18-bit word since

--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -142,9 +142,7 @@ typedef struct erl_drv_binary {
  */
 
 typedef struct _erl_drv_data* ErlDrvData; /* Data to be used by the driver itself. */
-#ifndef ERL_SYS_DRV
 typedef struct _erl_drv_event* ErlDrvEvent; /* An event to be selected on. */
-#endif
 typedef struct _erl_drv_port* ErlDrvPort; /* A port descriptor. */
 typedef struct _erl_drv_port* ErlDrvThreadData; /* Thread data. */
 

--- a/erts/emulator/beam/erl_sys_driver.h
+++ b/erts/emulator/beam/erl_sys_driver.h
@@ -31,8 +31,6 @@
 
 #define ERL_SYS_DRV
 
-typedef SWord ErlDrvEvent; /* An event to be selected on. */
-
 typedef struct _SysDriverOpts SysDriverOpts;
 
 #include "erl_driver.h"


### PR DESCRIPTION
In https://bugs.gentoo.org/797886 I noticed that LTO build
complains about inconsistent type within a single final binary.

The simplest way to find it is to use `-Werror=lto-type-mismatch`:

```
 LD     otp/bin/x86_64-pc-linux-gnu/beam.jit
  beam/erl_driver.h:331:12: error:
    type of 'driver_select' does not match original declaration [-Werror=lto-type-mismatch]
  331 | EXTERN int driver_select(ErlDrvPort port, ErlDrvEvent event, int mode, int on);
      |            ^
sys/common/erl_check_io.c:796:1: note: type mismatch in parameter 2
  796 | driver_select(ErlDrvPort ix, ErlDrvEvent e, int mode, int on)
      | ^
sys/common/erl_check_io.c:796:1: note: type 'ErlDrvEvent' should match type 'struct _erl_drv_event *'
sys/common/erl_check_io.c:796:1: note: 'driver_select' was previously declared here
sys/common/erl_check_io.c:796:1: note: code may be misoptimized unless '-fno-strict-aliasing' is used
lto1: some warnings being treated as errors
...
```

Multiple definitions are located in:

```
$ git grep ErlDrvEvent | fgrep typedef
erts/emulator/beam/erl_driver.h:typedef struct _erl_drv_event* ErlDrvEvent; /* An event to be selected on. */
erts/emulator/beam/erl_sys_driver.h:typedef SWord ErlDrvEvent; /* An event to be selected on. */
```

The change uses the first `typedef struct _erl_drv_event* ErlDrvEvent;` everywhere.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>