### PR TITLE
Fix code generation in guard for not (X =:= true)

### DIFF
--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -217,6 +217,10 @@ basic_not(Config) when is_list(Config) ->
     check(fun() -> if not (True xor False) -> ok;
 		      true -> error end end, error),
 
+    check(fun() -> if not (True =:= true) -> ok; true -> error end end, error),
+    check(fun() -> if not (False =:= true) -> ok; true -> error end end, ok),
+    check(fun() -> if not (Glurf =:= true) -> ok; true -> error end end, ok),
+
     ok.
 
 complex_not(Config) when is_list(Config) ->


### PR DESCRIPTION
In a guard, `not (X =:= true)` would incorrectly evaluate to `false`
for non-boolean values of `X`.

The is because of an unsafe transformation in the `v3_core` that
transforms `not (X =:= true)` to `X =:= false`. Unfortunately, that
transformation is only safe if `X` is known to be a boolean. (The
bug was introduced in OTP R13.)

Fixes #5007.