### PR TITLE
Fix code generation in guard for not (X =:= true)

### DIFF
--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -217,6 +217,10 @@ basic_not(Config) when is_list(Config) ->
     check(fun() -> if not (True xor False) -> ok;
 		      true -> error end end, error),
 
+    check(fun() -> if not (True =:= true) -> ok; true -> error end end, error),
+    check(fun() -> if not (False =:= true) -> ok; true -> error end end, ok),
+    check(fun() -> if not (Glurf =:= true) -> ok; true -> error end end, ok),
+
     ok.
 
 complex_not(Config) when is_list(Config) ->

--- a/lib/dialyzer/test/indent_SUITE_data/results/guard_warnings
+++ b/lib/dialyzer/test/indent_SUITE_data/results/guard_warnings
@@ -126,9 +126,9 @@ guard_warnings.erl:92:15: Guard test
 guard_warnings.erl:94:15: Guard test 
           'true' == 
           'false' can never succeed
-guard_warnings.erl:96:20: Guard test 
+guard_warnings.erl:96:20: Guard test not(
           'true' =:= 
-          'false' can never succeed
+          'true') can never succeed
 guard_warnings.erl:98:20: Guard test not(
           'true' == 
           'true') can never succeed

--- a/lib/dialyzer/test/small_SUITE_data/results/guard_warnings
+++ b/lib/dialyzer/test/small_SUITE_data/results/guard_warnings
@@ -92,6 +92,6 @@ guard_warnings.erl:92:1: Function test41/0 has no local return
 guard_warnings.erl:94:15: Guard test 'true' == 'false' can never succeed
 guard_warnings.erl:94:1: Function test42/0 has no local return
 guard_warnings.erl:96:1: Function test43/0 has no local return
-guard_warnings.erl:96:20: Guard test 'true' =:= 'false' can never succeed
+guard_warnings.erl:96:20: Guard test not('true' =:= 'true') can never succeed
 guard_warnings.erl:98:1: Function test44/0 has no local return
 guard_warnings.erl:98:20: Guard test not('true' == 'true') can never succeed


### PR DESCRIPTION
In a guard, `not (X =:= true)` would incorrectly evaluate to `false`
for non-boolean values of `X`.

The reason for the bug is an unsafe transformation in the `v3_core`
pass that transforms `not (X =:= true)` to `X =:= false`. That
transformation is safe only if `not (X =:= true)` was transformed from
`not X` by the compiler itself. (This bug was introduced in OTP R13.)

Eliminate the problem by only doing the transformation when `X =:= true`
is known to have been expanded from `not X` by the compiler.

While at it, also improve the comments.

Fixes #5007.