### PR TITLE
Add no_return() spec to gen_statem:init/1 note

### DIFF
--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -2469,6 +2469,7 @@ handle_event(_, _, State, Data) ->
 	    in that case be implemented as:
 	  </p>
 	  <pre>
+-spec init(_) -> no_return().
 init(Args) -> erlang:error(not_implemented, [Args]).</pre>
         </note>
       </desc>


### PR DESCRIPTION
If no spec is given, dialyzer will complain that `init/1` only terminates with explicit exception.