### PR TITLE
Optimize signal sending to processes with message_queue_data=off_heap enabled

### DIFF
--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -639,6 +639,8 @@ erts_alloc_init(int *argc, char **argv, ErtsAllocInitOpts *eaiop)
 	= ERTS_MAGIC_BIN_UNALIGNED_SIZE(sizeof(ErtsMagicIndirectionWord));
     fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_RECV_MARK_BLK)]
         = sizeof(ErtsRecvMarkerBlock);
+    fix_type_sizes[ERTS_ALC_FIX_TYPE_IX(ERTS_ALC_T_SIGQ_BUFFERS)]
+        = sizeof(ErtsSignalInQueueBufferArray);
 
 #ifdef HARD_DEBUG
     hdbg_init();

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -254,6 +254,7 @@ type	BINARY_FIND	SHORT_LIVED	PROCESSES	binary_find
 type	CRASH_DUMP	STANDARD	SYSTEM		crash_dump
 type	DIST_TRANSCODE  SHORT_LIVED	SYSTEM		dist_transcode_context
 type	RLA_BLOCK_CNTRS	LONG_LIVED	SYSTEM		release_literal_area_block_counters
+type	SIGQ_BUFFERS	FIXED_SIZE	PROCESSES	process_signal_queue_buffers
 
 type	THR_Q_EL	STANDARD   	SYSTEM		thr_q_element
 type	THR_Q_EL_SL	FIXED_SIZE	SYSTEM		sl_thr_q_element

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -1110,7 +1110,7 @@ process_info_bif(Process *c_p, Eterm pid, Eterm opt, int always_wrap, int pi2)
         sreds = reds_left;
 
         if (!local_only) {
-            erts_proc_lock(c_p, ERTS_PROC_LOCK_MSGQ);
+            erts_proc_sig_queue_lock(c_p);
             erts_proc_sig_fetch(c_p);
             erts_proc_unlock(c_p, ERTS_PROC_LOCK_MSGQ);
         }
@@ -1218,7 +1218,7 @@ process_info_bif(Process *c_p, Eterm pid, Eterm opt, int always_wrap, int pi2)
         }
         if (flags & ERTS_PI_FLAG_NEED_MSGQ_LEN) {
             ASSERT(locks & ERTS_PROC_LOCK_MAIN);
-            erts_proc_lock(rp, ERTS_PROC_LOCK_MSGQ);
+            erts_proc_sig_queue_lock(rp);
             erts_proc_sig_fetch(rp);
             if (c_p->sig_qs.cont) {
                 erts_proc_unlock(rp, locks|ERTS_PROC_LOCK_MSGQ);

--- a/erts/emulator/beam/erl_lock_check.c
+++ b/erts/emulator/beam/erl_lock_check.c
@@ -168,7 +168,8 @@ static erts_lc_lock_order_t erts_lock_order[] = {
     {	"hard_dbg_mseg",		        NULL	                },
     {	"perf", 				NULL			},
     {	"jit_debug_descriptor",			NULL			},
-    {	"erts_mmap",				NULL			}
+    {	"erts_mmap",				NULL			},
+    {	"proc_sig_queue_buffer",		"address"		}
 };
 
 #define ERTS_LOCK_ORDER_SIZE \

--- a/erts/emulator/beam/erl_message.h
+++ b/erts/emulator/beam/erl_message.h
@@ -33,6 +33,28 @@
 #define ERTS_MSG_COPY_WORDS_PER_REDUCTION 64
 #endif
 
+/* The number of buffers have to be 64 or less because we currenlty
+   use a single word to implement a bitset with information about
+   non-empty buffers */
+#ifdef DEBUG
+#define ERTS_PROC_SIG_INQ_BUFFERED_NR_OF_BUFFERS 64
+#define ERTS_PROC_SIG_INQ_BUFFERED_CONTENTION_INSTALL_LIMIT 250
+#define ERTS_PROC_SIG_INQ_BUFFERED_ALWAYS_TURN_ON 1
+#define ERTS_PROC_SIG_INQ_BUFFERED_MIN_FLUSH_ALL_OPS_BEFORE_CHANGE 2
+#define ERTS_PROC_SIG_INQ_BUFFERED_MIN_NO_ENQUEUES_TO_KEEP \
+    (ERTS_PROC_SIG_INQ_BUFFERED_MIN_FLUSH_ALL_OPS_BEFORE_CHANGE +                    \
+     ERTS_PROC_SIG_INQ_BUFFERED_MIN_FLUSH_ALL_OPS_BEFORE_CHANGE / 2)
+#else
+#define ERTS_PROC_SIG_INQ_BUFFERED_NR_OF_BUFFERS 64
+#define ERTS_PROC_SIG_INQ_BUFFERED_CONTENTION_INSTALL_LIMIT 50
+#define ERTS_PROC_SIG_INQ_BUFFERED_ALWAYS_TURN_ON 0
+#define ERTS_PROC_SIG_INQ_BUFFERED_MIN_FLUSH_ALL_OPS_BEFORE_CHANGE 8192
+/* At least 1.5 enqueues per flush all op */
+#define ERTS_PROC_SIG_INQ_BUFFERED_MIN_NO_ENQUEUES_TO_KEEP \
+    (ERTS_PROC_SIG_INQ_BUFFERED_MIN_FLUSH_ALL_OPS_BEFORE_CHANGE +     \
+     ERTS_PROC_SIG_INQ_BUFFERED_MIN_FLUSH_ALL_OPS_BEFORE_CHANGE / 2)
+#endif
+
 struct proc_bin;
 struct external_thing_;
 
@@ -339,6 +361,46 @@ typedef struct {
     int may_contain_heap_terms;
 #endif
 } ErtsSignalInQueue;
+
+typedef union {
+    struct ___ErtsSignalInQueueBufferFields {
+        erts_mtx_t lock;
+        /*
+         * Boolean value indicateing if the buffer is alive. An
+         * enqueue attempt to a dead buffer has to be canceled
+         */
+        int alive;
+        /*
+         * The number of enqueues that has been performed to this
+         * buffer. This value is used to decide if we should adapt
+         * back to an unbuffered state
+         */
+        Uint nr_of_enqueues;
+        ErtsSignalInQueue queue;
+    } b;
+    byte align__[ERTS_ALC_CACHE_LINE_ALIGN_SIZE(sizeof(struct ___ErtsSignalInQueueBufferFields))];
+} ErtsSignalInQueueBuffer;
+
+#if ERTS_PROC_SIG_INQ_BUFFERED_NR_OF_BUFFERS > 64
+#error The data structure holding information about which slots that are non-empty (the nonempty_slots field in the struct below) needs to be changed (it currently only supports up to 64 slots)
+#endif
+
+typedef struct {
+    ErtsSignalInQueueBuffer slots[ERTS_PROC_SIG_INQ_BUFFERED_NR_OF_BUFFERS];
+    ErtsThrPrgrLaterOp free_item;
+    erts_atomic64_t nonempty_slots;
+    erts_atomic64_t nonmsg_slots;
+    /*
+     * dirty_refc is incremented by dirty schedulers that access the
+     * buffer array to prevent deallocation while they are accessing
+     * the buffer array. This is needed since dirty schedulers are not
+     * part of the thread progress system.
+     */
+    erts_atomic64_t dirty_refc;
+    Uint nr_of_rounds;
+    Uint nr_of_enqueues;
+    int alive;
+} ErtsSignalInQueueBufferArray;
 
 typedef struct erl_trace_message_queue__ {
     struct erl_trace_message_queue__ *next; /* point to the next receiver */

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1116,8 +1116,9 @@ struct process {
 
     erts_atomic32_t state;  /* Process state flags (see ERTS_PSFLG_*) */
     erts_atomic32_t dirty_state; /* Process dirty state flags (see ERTS_PDSFLG_*) */
-
+    Uint sig_inq_contention_counter;
     ErtsSignalInQueue sig_inq;
+    erts_atomic_t sig_inq_buffers;
     ErlTraceMessageQueue *trace_msg_q;
     erts_proc_lock_t lock;
     ErtsSchedulerData *scheduler_data;

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -159,7 +159,7 @@ Uint erts_process_memory(Process *p, int include_sigs_in_transit)
          * Size of message queue plus size of all signals
          * in transit to the process!
          */
-        erts_proc_lock(p, ERTS_PROC_LOCK_MSGQ);
+        erts_proc_sig_queue_lock(p);
         erts_proc_sig_fetch(p);
         erts_proc_unlock(p, ERTS_PROC_LOCK_MSGQ);
 

--- a/erts/test/Makefile
+++ b/erts/test/Makefile
@@ -38,7 +38,8 @@ MODULES= \
 	run_erl_SUITE \
 	erlexec_SUITE \
 	z_SUITE \
-	upgrade_SUITE
+	upgrade_SUITE \
+	parallel_messages_SUITE
 
 ERL_FILES= $(MODULES:%=%.erl)
 

--- a/erts/test/parallel_messages_SUITE.erl
+++ b/erts/test/parallel_messages_SUITE.erl
@@ -1,0 +1,465 @@
+-module(parallel_messages_SUITE).
+
+-export([all/0,
+         suite/0,
+         test_throughput_benchmark/1,
+         test_message_queue_data_switching/1,
+         throughput_benchmark/0,
+         large_throughput_benchmark/0]).
+
+all() -> [test_throughput_benchmark,
+          test_message_queue_data_switching].
+
+suite() ->
+    [{timetrap, {minutes, 90}}].
+
+get_op([{_,O}], _RandNum) ->
+    O;
+get_op([{Prob,O}|Rest], RandNum) ->
+    case RandNum < Prob of
+        true -> O;
+        false -> get_op(Rest, RandNum)
+    end.
+do_op(ProbHelpTab, Operations, Receiver) ->
+    RandNum = rand:uniform(),
+    Op = get_op(ProbHelpTab, RandNum),
+    TheOp = Operations(Op),
+    TheOp(Receiver).
+do_work(WorksDoneSoFar, ProbHelpTab, Operations, Receiver) ->
+    receive
+        stop -> WorksDoneSoFar
+    after
+        0 -> do_op(ProbHelpTab, Operations, Receiver),
+             do_work(WorksDoneSoFar + 1, ProbHelpTab, Operations, Receiver)
+    end.
+
+-record(parallel_messages_bench_config,
+        {benchmark_duration_ms = 500,
+         recover_time_ms = 500,
+         thread_counts = not_set,
+         nr_of_repeats = 1,
+         report_receive_throughput = [false, true],
+         spawn_opts = [[{message_queue_data, off_heap}]],
+         scenarios =
+             [
+              [
+               {1.0, {message_size, 1}}
+              ],
+              [
+               {1.0, {exit_signal_size, 3}}
+              ],
+              [
+              {0.5, {exit_signal_size, 1}},
+              {0.5, {message_size, 1}}
+              ]
+             ],
+         notify_res_fun = fun(_Name, _Throughput) -> ok end,
+         print_result_paths_fun =
+             fun(ResultPath, _LatestResultPath) ->
+                     Comment =
+                         io_lib:format("<a href=\"file:///~s\">Result visualization</a>",[ResultPath]),
+                     {comment, Comment}
+             end
+       }).
+
+stdout_notify_res(ResultPath, LatestResultPath) ->
+    io:format("Result Location: /~s~n", [ResultPath]),
+    io:format("Latest Result Location: ~s~n", [LatestResultPath]).
+
+
+throughput_benchmark(
+  #parallel_messages_bench_config{
+     benchmark_duration_ms  = BenchmarkDurationMs,
+     recover_time_ms        = RecoverTimeMs,
+     thread_counts          = ThreadCountsOpt,
+     nr_of_repeats          = NrOfRepeats,
+     report_receive_throughput = ReportReceiveThroughputList,
+     spawn_opts = SpawnOptsList,
+     scenarios              = Scenarios,
+     notify_res_fun         = NotifyResFun,
+     print_result_paths_fun = PrintResultPathsFun}) ->
+    NrOfSchedulers = erlang:system_info(schedulers),
+    %Parent = self(),
+    %% Mapping benchmark operation names to their action
+    Operations =
+        fun({message_size, Size}) ->
+                case get(Size) of
+                    undefined ->
+                        Msg = lists:seq(1, Size),
+                        NewSendFun =
+                            fun(Receiver) ->
+                                    Receiver ! Msg
+                            end,
+                        put(Size, NewSendFun),
+                        NewSendFun;
+                    SendFun ->
+                        SendFun
+                end;
+           ({exit_signal_size, Size} = SigType) ->
+                case get(SigType) of
+                    undefined ->
+                        Msg = lists:seq(1, Size),
+                        NewSendFun =
+                            fun(Receiver) ->
+                                    erlang:exit(Receiver, Msg)
+                            end,
+                        put(SigType, NewSendFun),
+                        NewSendFun;
+                    SendFun ->
+                        SendFun
+                end;
+           ({message_queue_data_change, off_heap}) ->
+                fun(Receiver) ->
+                        Receiver ! off_heap
+                end;
+           ({message_queue_data_change, on_heap}) ->
+                fun(Receiver) ->
+                        Receiver ! on_heap
+                end
+        end,
+    %% Helper functions
+    CalculateThreadCounts =
+        fun Calculate([Count|Rest]) ->
+                case Count > NrOfSchedulers of
+                    true -> lists:reverse(Rest);
+                    false -> Calculate([Count*2,Count|Rest])
+                end
+        end,
+    CalculateOpsProbHelpTab =
+        fun Calculate([{_, OpName}], _) ->
+                [{1.0, OpName}];
+            Calculate([{OpPropability, OpName}|Res], Current) ->
+                NewCurrent = Current + OpPropability,
+                [{NewCurrent, OpName}| Calculate(Res, NewCurrent)]
+        end,
+    RenderScenario =
+        fun R([], StringSoFar) ->
+                StringSoFar;
+            R([{Fraction, Operation}], StringSoFar) ->
+                io_lib:format("~s ~f% ~w",[StringSoFar, Fraction * 100.0, Operation]);
+            R([{Fraction, Operation}|Rest], StringSoFar) ->
+                R(Rest,
+                  io_lib:format("~s ~f% ~w, ",[StringSoFar, Fraction * 100.0, Operation]))
+        end,
+    DataHolder =
+        fun DataHolderFun(Data)->
+                receive
+                    {get_data, Pid} -> Pid ! {message_bench_data, Data};
+                    D -> DataHolderFun([Data,D])
+                end
+        end,
+    DataHolderPid = spawn_link(fun()-> DataHolder([]) end),
+    PrintData =
+        fun (Str, List) ->
+                io:format(Str, List),
+                DataHolderPid ! io_lib:format(Str, List)
+        end,
+    GetData =
+        fun () ->
+                DataHolderPid ! {get_data, self()},
+                receive {message_bench_data, Data} -> Data end
+        end,
+    %% Function that runs a benchmark instance and returns the number
+    %% of operations that were performed and how long time they took
+    %% to perform
+    RunBenchmark =
+        fun({NrOfProcs, Scenario, Duration, SpawnOpts}) ->
+                ProbHelpTab = CalculateOpsProbHelpTab(Scenario, 0),
+                ParentPid = self(),
+                ReceiveFun =
+                    fun ReceiveFun(NrOfStops, ReceiveCount) when NrOfStops =:= NrOfProcs ->
+                            ParentPid ! {done_nothing_more_to_receive, ReceiveCount};
+                        ReceiveFun(NrOfStops, ReceiveCount) ->
+                            receive
+                                Msg ->
+                                    case Msg of
+                                        stop ->
+                                            ReceiveFun(NrOfStops + 1, ReceiveCount);
+                                        off_heap ->
+                                            erlang:process_flag(message_queue_data, off_heap),
+                                            ReceiveFun(NrOfStops, ReceiveCount + 1);
+                                        on_heap ->
+                                            erlang:process_flag(message_queue_data, on_heap),
+                                            ReceiveFun(NrOfStops, ReceiveCount + 1);
+                                        _X ->
+                                            ReceiveFun(NrOfStops, ReceiveCount + 1)
+                                    end
+                            end
+                    end,
+                Receiver =
+                    spawn_opt(
+                      fun() ->
+                              process_flag(trap_exit, true),
+                              ReceiveFun(0, 0)
+                      end,
+                      SpawnOpts),
+                Worker =
+                    fun() ->
+                            receive start -> ok end,
+                            WorksDone =
+                                do_work(0, ProbHelpTab, Operations, Receiver),
+                            ParentPid ! {works_done, WorksDone},
+                            Receiver ! stop
+                    end,
+                ChildPids =
+                    lists:map(fun(_N) -> spawn_link(Worker) end, lists:seq(1, NrOfProcs)),
+                erlang:garbage_collect(),
+                timer:sleep(RecoverTimeMs),
+                lists:foreach(fun(Pid) -> Pid ! start end, ChildPids),
+                timer:sleep(Duration),
+                lists:foreach(fun(Pid) -> Pid ! stop end, ChildPids),
+                TotalWorksDone = lists:foldl(
+                                   fun(_, Sum) ->
+                                           receive
+                                               {works_done, Count} -> Sum + Count
+                                           end
+                                   end, 0, ChildPids),
+                {TimeAfterSends, ok} =
+                    timer:tc(
+                      fun() ->
+                              receive
+                                  {done_nothing_more_to_receive, ReceiveCount} ->
+                                      %% Sanity check
+                                      ReceiveCount = TotalWorksDone,
+                                      ok
+                              end
+                      end),
+                {Duration + (TimeAfterSends div 1000), TotalWorksDone}
+        end,
+    RunBenchmarkInSepProcess =
+        fun(ParameterTuple) ->
+                P = self(),
+                Results =
+                    [begin
+                         spawn_link(fun()-> P ! {bench_result, RunBenchmark(ParameterTuple)} end),
+                         receive {bench_result, Res} -> Res end
+                     end || _ <- lists:seq(1, NrOfRepeats)],
+                {R1, R2} = lists:foldl(fun ({I1, I2}, {A1, A2}) ->
+                                               {I1 + A1, I2 + A2}
+                                       end, {0, 0}, Results),
+                {R1 / NrOfRepeats, R2 / NrOfRepeats}
+        end,
+    RunBenchmarkAndReport =
+        fun(ThreadCount,
+            Scenario,
+            Duration,
+            ReportReceive,
+            SpawnOpts) ->
+                {ReceiveTime, NrOfSends} =
+                    RunBenchmarkInSepProcess({ThreadCount,
+                                              Scenario,
+                                              Duration,
+                                              SpawnOpts}),
+                Throughput =
+                    case ReportReceive of
+                        true ->
+                            NrOfSends/(ReceiveTime/1000.0);
+                        false ->
+                            NrOfSends/(Duration/1000.0)
+                    end,
+                PrintData("; ~f",[Throughput]),
+                Name = io_lib:format("Scenario: ~w, "
+                                     "# of Processes: ~w",
+                                     [Scenario, ThreadCount]),
+                NotifyResFun(Name, Throughput)
+        end,
+    ThreadCounts =
+        case ThreadCountsOpt of
+            not_set ->
+                CalculateThreadCounts([1]);
+            _ -> ThreadCountsOpt
+        end,
+    Version =
+        (fun() ->
+                 VersionString =  erlang:system_info(system_version),
+                 case re:run(VersionString, "\\[(source\\-[^\\]]+)\\]") of
+                     {match, [_, {StartPos, Length}]} ->
+                         string:slice(VersionString, StartPos, Length);
+                     _ ->
+                         erlang:system_info(otp_release)
+                 end
+         end)(),
+    %% Run the benchmark
+    PrintData("# Each instance of the benchmark runs for ~w seconds:~n", [BenchmarkDurationMs/1000]),
+    PrintData("# The result of a benchmark instance is presented as a number representing~n",[]),
+    PrintData("# the number of operations performed per second:~n~n~n",[]),
+    PrintData("# To plot graphs for the results below:~n",[]),
+    PrintData("# 1. Open \"$ERL_TOP/erts/test/parallel_messages_SUITE_data/visualize_throughput.html\" in a web browser~n",[]),
+    PrintData("# 2. Copy the lines between \"#BENCHMARK STARTED$\" and \"#BENCHMARK ENDED$\" below~n",[]),
+    PrintData("# 3. Paste the lines copied in step 2 to the text box in the browser window opened in~n",[]),
+    PrintData("#    step 1 and press the Render button~n~n",[]),
+    PrintData("#BENCHMARK STARTED$~n",[]),
+    %% The following loop runs all benchmark scenarios and prints the results (i.e, operations/second)
+    lists:foreach(
+      fun(SpawnOpts) ->
+              lists:foreach(
+                fun(Scenario) ->
+                        lists:foreach(
+                          fun(ReportReceiveThroughput) ->
+                                  PrintData("Scenario: ~s, send_duration=~w ms, ~s, Spawn Options=~w$~n",
+                                            [case ReportReceiveThroughput of
+                                                 true -> "Receive Throughput";
+                                                 false -> "Send Throughput"
+                                             end,
+                                             BenchmarkDurationMs,
+                                             RenderScenario(Scenario, ""),
+                                             SpawnOpts]),
+                                  lists:foreach(
+                                    fun(ThreadCount) ->
+                                            PrintData("; ~w",[ThreadCount])
+                                    end,
+                                    ThreadCounts),
+                                  PrintData("$~n",[]),
+                                  PrintData(Version,[]),
+                                  lists:foreach(
+                                    fun(ThreadCount) ->
+                                            %erlang:display({thread_count, ThreadCount}),
+                                            RunBenchmarkAndReport(ThreadCount,
+                                                                  Scenario,
+                                                                  BenchmarkDurationMs,
+                                                                  ReportReceiveThroughput,
+                                                                  SpawnOpts)
+                                    end,
+                                    ThreadCounts),
+                                  PrintData("$~n",[])
+                          end,
+                          ReportReceiveThroughputList)
+                end,
+                Scenarios)
+      end,
+      SpawnOptsList),
+    PrintData("~n#BENCHMARK ENDED$~n~n",[]),
+    DataDir = filename:join(filename:dirname(code:which(?MODULE)), "parallel_messages_SUITE_data"),
+    TemplatePath = filename:join(DataDir, "visualize_throughput.html"),
+    {ok, Template} = file:read_file(TemplatePath),
+    OutputData = string:replace(Template, "#bench_data_placeholder", GetData()),
+    OutputPath1 = filename:join(DataDir, "message_bench_result.html"),
+    {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:now_to_datetime(erlang:timestamp()),
+    StrTime = lists:flatten(io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w",[Year,Month,Day,Hour,Minute,Second])),
+    OutputPath2 = filename:join(DataDir, io_lib:format("message_bench_result_~s.html", [StrTime])),
+    file:write_file(OutputPath1, OutputData),
+    file:write_file(OutputPath2, OutputData),
+    PrintResultPathsFun(OutputPath2, OutputPath1).
+
+
+throughput_benchmark() ->
+    throughput_benchmark(
+      #parallel_messages_bench_config{
+         benchmark_duration_ms = 500,
+         recover_time_ms = 500,
+         thread_counts = not_set,
+         nr_of_repeats = 1,
+         report_receive_throughput = [false, true],
+         spawn_opts = [[{message_queue_data, off_heap}]],
+         scenarios =
+             [
+              [
+               {1.0, {message_size, 1}}
+              ],
+              [
+               {1.0, {exit_signal_size, 3}}
+              ],
+              [
+               {0.5, {exit_signal_size, 1}},
+               {0.5, {message_size, 1}}
+              ]
+             ],
+         notify_res_fun = fun(_Name, _Throughput) -> ok end,
+         print_result_paths_fun =
+             fun(ResultPath, _LatestResultPath) ->
+                     Comment =
+                         io_lib:format("<a href=\"file:///~s\">Result visualization</a>",[ResultPath]),
+                     {comment, Comment}
+             end
+        }).
+
+test_throughput_benchmark(_) ->
+    throughput_benchmark().
+
+large_throughput_benchmark() ->
+    throughput_benchmark(
+      #parallel_messages_bench_config{
+         benchmark_duration_ms = 1000,
+         recover_time_ms = 1000,
+         thread_counts = [1,2,4,8,15,16,31,32,47,48,63,64],
+         nr_of_repeats = 3,
+         report_receive_throughput = [false, true],
+         spawn_opts = [[{message_queue_data, off_heap}]],
+         scenarios =
+             [
+              [
+               {1.0, {message_size, 1}}
+              ],
+              [
+               {1.0, {message_size, 10}}
+              ],
+              [
+               {1.0, {message_size, 100}}
+              ],
+              [
+               {1.0, {message_size, 1000}}
+              ],
+              [
+               {1.0, {exit_signal_size, 1}}
+              ],
+              [
+               {1.0, {exit_signal_size, 10}}
+              ],
+              [
+               {1.0, {exit_signal_size, 100}}
+              ],
+              [
+               {1.0, {exit_signal_size, 1000}}
+              ],
+              [
+               {0.5, {exit_signal_size, 1}},
+               {0.5, {message_size, 1}}
+              ],
+              [
+               {0.5, {exit_signal_size, 10}},
+               {0.5, {message_size, 10}}
+              ],
+              [
+               {0.5, {exit_signal_size, 100}},
+               {0.5, {message_size, 100}}
+              ],
+              [
+               {0.5, {exit_signal_size, 1000}},
+               {0.5, {message_size, 1000}}
+              ]
+             ],
+         notify_res_fun =
+             fun(Name, Throughput) ->
+                     io:format("~n~n#Name: ~s Throughput: ~w~n~n", [Name, Throughput])
+             end,
+         print_result_paths_fun =
+             fun stdout_notify_res/2
+       }).
+
+test_message_queue_data_switching(_) ->
+    throughput_benchmark(
+      #parallel_messages_bench_config{
+         benchmark_duration_ms = 100,
+         recover_time_ms = 500,
+         thread_counts = [1,2,4],
+         nr_of_repeats = 1,
+         report_receive_throughput = [true],
+         spawn_opts = [[{message_queue_data, off_heap}]],
+         scenarios =
+             [
+              [
+               {0.499995, {exit_signal_size, 1}},
+               {0.499995, {message_size, 1}},
+               %% About 1 in 100k changes message data type
+               {0.000005, {message_queue_data_change, off_heap}},
+               {0.000005, {message_queue_data_change, on_heap}}
+              ]
+             ],
+         notify_res_fun = fun(_Name, _Throughput) -> ok end,
+         print_result_paths_fun =
+             fun(ResultPath, _LatestResultPath) ->
+                     Comment =
+                         io_lib:format("<a href=\"file:///~s\">Result visualization</a>",[ResultPath]),
+                     {comment, Comment}
+             end
+       }).

--- a/erts/test/parallel_messages_SUITE_data/visualize_throughput.html
+++ b/erts/test/parallel_messages_SUITE_data/visualize_throughput.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+
+<!-- %% -->
+<!-- %% %CopyrightBegin% -->
+<!-- %% -->
+<!-- %% Copyright Ericsson AB and Kjell Winblad 1996-2020. All Rights Reserved. -->
+<!-- %% -->
+<!-- %% Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- %% you may not use this file except in compliance with the License. -->
+<!-- %% You may obtain a copy of the License at -->
+<!-- %% -->
+<!-- %%     http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- %% -->
+<!-- %% Unless required by applicable law or agreed to in writing, software -->
+<!-- %% distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- %% See the License for the specific language governing permissions and -->
+<!-- %% limitations under the License. -->
+<!-- %% -->
+<!-- %% %CopyrightEnd% -->
+<!-- %% -->
+<!-- %% Author: Kjell Winblad -->
+<!-- %% -->
+  
+  <head>
+    <meta charset="utf-8">
+    <title>Message Send/Receive Benchmark Result Viewer</title>
+  </head>
+
+  <body>
+    <div id="insertPlaceholder"></div>
+    <h1>Message Send/Receive Benchmark Result Viewer</h1>
+    <p>
+      This page generates graphs from data produced by the Message Send/Receive Benchmark which is defined in the function <code>parallel_messages_SUITE:test_throughput_benchmark/1</code> (see "<code>$ERL_TOP/erts/test/parallel_messages_SUITE.erl</code>").
+    </p>
+    <p>
+      Note that one can paste results from several benchmark runs into the field below. Results from the same scenario but from different benchmark runs will be relabeled and plotted in the same graph automatically.
+    </p>
+    <p>
+      Note also that that lines can be hidden by clicking on the corresponding label.
+    </p>
+    Paste the generated data in the field below and press the Render button:
+    <br>
+    <textarea id="dataField" rows="4" cols="50">#bench_data_placeholder</textarea> 
+    <br>
+    <input type="checkbox" id="throughputPlot" checked> Include Throughput Plot
+    <br>
+    <input type="checkbox" id="betterThanWorstPlot"> Include % More Throughput Than Worst Plot
+    <br>
+    <input type="checkbox" id="worseThanBestPlot"> Include % Less Throughput Than Best Plot
+    <br>
+    <input type="checkbox" id="barPlot"> Bar Plot
+    <br>
+    <input type="checkbox" id="sameSpacing" checked> Same X Spacing Between Points
+    <br>
+    <button id="renderButton" type="button">Render</button> 
+    
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+	    integrity="sha256-3edrmyuQ0w65f8gfBsqowzjJe2iM6n0nKciPUp8y+7E="
+	    crossorigin="anonymous"></script>
+    <script>
+      var loading = false;
+      function toggleLoadingScreen(){
+          if(loading){
+              $("#loading").remove();
+              loading = false;
+          }else{
+              $('<div id="loading">'+
+                '<span style="position: fixed; top: 50%;left: 50%;color: white;"><b>Loading...</b></span>'+
+                '</div>')
+                  .css({position: "fixed",
+                        top: 0,
+                        left: 0,
+                        width: "100%",
+                        height: "100%",
+                        'background-color': "#000",
+                        filter:"alpha(opacity=50)",
+                        '-moz-opacity':"0.5",
+                        '-khtml-opacity': "0.5",
+                        opacity: "0.5",
+                        'z-index': "10000"})
+                  .appendTo(document.body);
+              loading = true;
+
+          }
+      }
+      //Start loading screen before downloading plotly which is quite large
+      toggleLoadingScreen();
+    </script>
+    <script src="https://cdn.plot.ly/plotly-1.5.0.min.js"></script>    
+    <script>
+      String.prototype.replaceAll = function(search, replacement) {
+          var target = this;
+          return target.split(search).join(replacement);
+      };
+      String.prototype.myTrim = function() {
+          var target = this;
+          return target.replace(/^\s+|\s+$/g, '');
+      };
+      function plotGraph(lines, sameSpacing, barPlot, prefix) {
+          var xvals = null;
+          var data = [];
+          while(lines.length > 0 &&
+                (lines[0].myTrim() == "" ||
+                 lines[0].myTrim().indexOf(";") !== -1)){
+              var line = lines.shift().myTrim();
+              if(line == "" || line.startsWith("#")){
+                  continue;
+              } else if(line.startsWith(";")) {
+                  xvals = line.split(";")
+                  xvals.shift(); // Remove first
+                  xvals = $.map(xvals, function (i){
+                      if(sameSpacing){
+                          return "_"+i.myTrim();
+                      }else{
+                          return parseInt(i.myTrim(), 10);
+                      }
+                  });
+              }else{
+                  line = line.split(";")
+                  var label = prefix + line.shift().myTrim();
+                  var yvals = $.map(line, function (i){
+                      return parseFloat(i.myTrim(), 10);
+                  });
+                  var trace = {
+                      x: xvals,
+                      y: yvals,
+                      mode: 'lines+markers',
+                      name: label
+                  };
+                  if(barPlot){
+                      trace['type'] = "bar";
+                  }
+                  data.push(trace);
+              }
+              
+          }
+          return data;
+      }
+      function toCompareData(dataParam, compareWithWorst) {
+          var data = $.extend(true, [], dataParam);
+          var worstSoFarMap = {};
+          var defaultSoFarValue = compareWithWorst ? Number.MAX_VALUE : Number.MIN_VALUE;
+          function getWorstBestSoFar(x){
+              return worstSoFarMap[x] === undefined ? defaultSoFarValue : worstSoFarMap[x];
+          }
+          function setWorstBestSoFar(x, y){
+              return worstSoFarMap[x] = y;
+          }
+          function lessOrGreaterThan(n1, n2){
+            return compareWithWorst ? n1 < n2 : n1 > n2;
+          } 
+          $.each(data, function(i, allResConfig) {
+            $.each(allResConfig.y, function(index, res) {
+                var xName = allResConfig.x[index];
+                if(lessOrGreaterThan(res, getWorstBestSoFar(xName))){
+                    setWorstBestSoFar(xName, res);                     
+                }
+            });
+          });
+          $.each(data, function(i, allResConfig) {
+            $.each(allResConfig.y, function(index, res) {
+                var xName = allResConfig.x[index];
+                if(compareWithWorst){
+                    allResConfig.y[index] = ((res / getWorstBestSoFar(xName))-1.0) * 100;
+                }else{
+                    allResConfig.y[index] = (1.0 -(res / getWorstBestSoFar(xName))) * 100;
+                }
+            });
+          });
+          return data;
+      }
+      function toBetterThanWorstData(data){
+        return toCompareData(data, true);
+      }
+      function toWorseThanBestData(data){
+        return toCompareData(data, false);
+      }
+      function plotGraphs(){
+          var insertPlaceholder = $("#insertPlaceholder");
+          var sameSpacing = $('#sameSpacing').is(":checked");
+          var barPlot = $('#barPlot').is(":checked");
+          var throughputPlot = $('#throughputPlot').is(":checked");
+          var betterThanWorstPlot = $('#betterThanWorstPlot').is(":checked");
+          var worseThanBestPlot = $('#worseThanBestPlot').is(":checked");
+          var lines = $("#dataField").val();
+          $('.showCheck').each(function() {
+              var item = $(this);
+              if(!item.is(":checked")){
+                  lines = lines.replaceAll(item.val(), "#"+item.val())
+              }
+          });
+          lines = lines.split("$");
+          var nrOfGraphs = 0;
+          var scenarioDataMap = {};
+          var scenarioNrOfVersionsMap = {};
+          var scenarioList = [];
+          while(lines.length > 0){
+              var line = lines.shift().myTrim();
+              if(line == ""){
+                  continue;
+              } else if(line.startsWith("Scenario:")) {
+                  nrOfGraphs = nrOfGraphs + 1;
+                  var name = line;
+                  if(scenarioDataMap[name] === undefined){
+                      scenarioDataMap[name] = [];
+                      scenarioNrOfVersionsMap[name] = 0;
+                      scenarioList.push(line);
+                  }
+                  scenarioNrOfVersionsMap[name] = scenarioNrOfVersionsMap[name] + 1;
+                  var prefix = undefined;
+                  if(scenarioNrOfVersionsMap[name] === 1){
+                      prefix = "";
+                  }else{
+                      prefix = "Ver: " + scenarioNrOfVersionsMap[name] + " ";
+                  }
+                  scenarioDataMap[name] =
+                      scenarioDataMap[name].concat(
+                          plotGraph(lines, sameSpacing, barPlot, prefix));
+              }
+          }
+          var nrOfGraphs = 0;
+          function plotScenario(name, plotType) {
+              var data = scenarioDataMap[name];
+              var yAxisTitle = undefined;
+              nrOfGraphs = nrOfGraphs + 1;
+              $("<div class='added' id='graph" + nrOfGraphs + "'>")
+                  .insertBefore(insertPlaceholder);
+              $("<button type='button' class='added' id='fullscreenButton" + nrOfGraphs + "'>Fill screen</button>")
+                  .insertBefore(insertPlaceholder);
+              $("<span class='added'><br><hr><br></span>")
+                  .insertBefore(insertPlaceholder);
+              if (plotType === 'throughput') {
+                  yAxisTitle = 'Operations/Second';
+              } else if (plotType === 'better_than_worst') {
+                  yAxisTitle = '% More Throughput Than Worst';
+                  data = toBetterThanWorstData(data);
+              } else {
+                  yAxisTitle = '% Less Throughput Than Best';
+                  data = toWorseThanBestData(data);
+              }
+              var layout = {
+                  title: name,
+                  xaxis: {
+                      title: '# of Processes'
+                  },
+                  yaxis: {
+                      title: yAxisTitle
+                  }
+              };
+              $("#fullscreenButton" + nrOfGraphs).click(
+                  function () {
+                      $('#graph' + nrOfGraphs).replaceWith(
+                          $("<div class='added' id='graph" + nrOfGraphs + "'>"));
+                      layout = $.extend({}, layout, {
+                          width: $(window).width() - 40,
+                          height: $(window).height() - 40
+                      });
+                      Plotly.newPlot('graph' + nrOfGraphs, data, layout);
+                  });
+              Plotly.newPlot('graph' + nrOfGraphs, data, layout);
+          }
+          $.each(scenarioList,
+              function (index, name) {
+                  if (throughputPlot) {
+                      plotScenario(name, 'throughput');
+                  }
+                  if (betterThanWorstPlot) {
+                      plotScenario(name, 'better_than_worst');
+                  }
+                  if (worseThanBestPlot) {
+                      plotScenario(name, 'worse_than_best');
+                  }
+              });
+      }
+    $(document).ready(function(){
+        $('#renderButton').click(
+            function(){
+                toggleLoadingScreen();
+                setTimeout(function(){
+                    try {                       
+                        $( ".added" ).remove();
+                        plotGraphs();
+                        toggleLoadingScreen();
+                    } catch(e){
+                        toggleLoadingScreen();
+                        console.log(e);
+                        alert("Error happened when parsing data.\n" +
+                              "See console for more info");
+                    }
+                }, 10);
+            });
+        setTimeout(function(){
+            $( ".added" ).remove();
+            plotGraphs();
+            toggleLoadingScreen();
+        }, 10);
+    });
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
Erlang guarantees that signals (i.e., message signals and non-message signals) sent from a single process to another process are ordered in send order. However, there are no ordering guarantees for signals sent from different processes to a particular process. Therefore, several processes can send signals in parallel to a specific process without synchronizing with each other. However, such signal sending was previously always serialized as the senders had to acquire the lock for the outer signal queue of the receiving process. This commit makes it possible for several processes to send signals to a process with the message_queue_data=off_heap setting(1) activated in parallel and without interfering with each other. This parallel signal sending optimization yields much better scalability for signal sending than what was previously possible(2).

(1) Information about how to enable the message_queue_data=off_heap setting can be found in the documentation of the functions [erlang:process_flag/2](https://erlang.org/doc/man/erlang.html#process_flag-2) and [erlang:spawn_opt/4](https://erlang.org/doc/man/erlang.html#spawn_opt-4).

(2) http://winsh.me/bench/erlang_sig_q/sigq_bench_result.html

Implementation
--------------

The parallel signal sending optimization works only on processes with the message_queue_data=off_heap setting enabled. For processes with the message_queue_data=off_heap setting enabled, the new optimization is activated and deactivated on demand based on heuristics to give a small overhead when the optimization is unnecessary. The optimization is activated when the contention on the lock for the outer message queue is high. It is deactivated when the number of enqueued messages per fetch operation (that fetch messages from the outer message queue to the inner) is low.

When the optimization is active, the outer message queue has an array of signal buffers where sending processes enqueue signals. When the receiving process needs to fetch messages from the outer message queue, the contents of the non-empty buffers are append to the outer message queue. Each process is assigned a particular slot in the buffer array (the process ID is used to hash to a particular slot). That way, the system can preserve the send order between messages coming from the same process.