### PR TITLE
test suites: replace ?t: with test_server:

### DIFF
--- a/lib/asn1/test/asn1_SUITE.erl
+++ b/lib/asn1/test/asn1_SUITE.erl
@@ -587,7 +587,7 @@ constraint_equivalence_abs(Config) ->
 	[_|_] ->
 	    io:put_chars("Not equivalent:\n"),
 	    [io:format("~s: ~p\n", [N,D]) || {N,D} <- Diff],
-	    test_server:fail(length(Diff))
+	    ct:fail(length(Diff))
     end.
 
 parse(Config) ->
@@ -727,7 +727,7 @@ otp_14440(_Config) ->
             ok = slave:stop(N);
         _ ->
             _ = slave:stop(N),
-            ?t:fail(Result)
+            ct:fail(Result)
     end.
 %%
 otp_14440_decode() ->
@@ -1345,8 +1345,7 @@ xref(_Config) ->
 	{ok,[]} ->
 	    ok;
 	{ok,[_|_]=Res} ->
-	    io:format("Exported, but unused: ~p\n", [Res]),
-	    ?t:fail()
+	    ct:fail("Exported, but unused: ~p\n", [Res])
     end.
 
 %% Ensure that all functions that are implicitly exported by
@@ -1367,8 +1366,7 @@ xref_export_all(_Config) ->
             ok;
         [_|_] ->
             Msg = [io_lib:format("~p:~p/~p\n", [M,F,A]) || {M,F,A} <- Unused],
-            io:format("There are unused functions:\n\n~s\n", [Msg]),
-            ?t:fail(unused_functions)
+            ct:fail("There are unused functions:\n\n~s\n", [Msg])
     end.
 
 %% Collect all functions that common_test will call in this module.

--- a/lib/asn1/test/syntax_SUITE.erl
+++ b/lib/asn1/test/syntax_SUITE.erl
@@ -308,7 +308,7 @@ run(List, File0, Config, Module) ->
     File = filename:join(proplists:get_value(priv_dir, Config), Base),
     case run_1(List, Base, File, Module, 0) of
 	0 -> ok;
-	Errors -> ?t:fail(Errors)
+	Errors -> ct:fail(Errors)
     end.
 
 run_1([{Source,Line,Error}=Exp|T], Base, File, Module, N) ->

--- a/lib/asn1/test/testInfObjExtract.erl
+++ b/lib/asn1/test/testInfObjExtract.erl
@@ -67,7 +67,7 @@ roundtrip(T, V) ->
 roundtrip_error(T, V) ->
     try asn1_test_lib:roundtrip('InfObjExtract', T, V) of
 	ok ->
-	    test_server:fail()
+	    ct:fail(expected_exception)
     catch
 	_:_ ->
 	    ok

--- a/lib/asn1/test/testPrim.erl
+++ b/lib/asn1/test/testPrim.erl
@@ -208,7 +208,7 @@ enc_error(Tag,T, V) ->
                      true ->
                          try 'Prim':encode(T, V) of
                              _ ->
-                                 ?t:fail()
+                                 ct:fail(expected_exception)
                          catch
                              _:{error,{asn1,Reason}} ->
                                  Reason

--- a/lib/asn1/test/testSeqSetDefaultVal.erl
+++ b/lib/asn1/test/testSeqSetDefaultVal.erl
@@ -195,8 +195,7 @@ main(Rule, Opts) ->
 	[] ->
 	    ok;
 	[_|_]=R ->
-	    io:format("~p\n", [R]),
-	    ?t:fail()
+	    ct:fail("~p\n", [R])
     end.
 
 legacy_filter({_,_}=Keep) ->

--- a/lib/asn1/test/testValueTest.erl
+++ b/lib/asn1/test/testValueTest.erl
@@ -111,7 +111,7 @@ roundtrip(T, V) ->
 roundtrip_error(T, V) ->
     try asn1_test_lib:roundtrip('ValueTest', T, V) of
 	ok ->
-	    test_server:fail()
+	    ct:fail(expected_exception)
     catch _:_ ->
 	    ok
     end.

--- a/lib/common_test/include/ct.hrl
+++ b/lib/common_test/include/ct.hrl
@@ -39,5 +39,4 @@
 %% Backward compatibility for test_server test suites.
 %% DO NOT USE IN NEW TEST SUITES.
 -define(line,).
--define(t,test_server).
 -define(config,test_server:lookup_config).

--- a/lib/common_test/src/ct_release_test.erl
+++ b/lib/common_test/src/ct_release_test.erl
@@ -885,7 +885,7 @@ wait_node_up(ExpStatus,ExpVsn,ExpAppsVsns0) ->
     wait_node_up(Node,ExpStatus,ExpVsn,lists:keysort(1,ExpAppsVsns),60).
 
 wait_node_up(Node,ExpStatus,ExpVsn,ExpAppsVsns,0) ->
-    test_server:fail({node_not_started,app_check_failed,ExpVsn,ExpAppsVsns,
+    ct:fail({node_not_started,app_check_failed,ExpVsn,ExpAppsVsns,
 		      rpc:call(Node,release_handler,which_releases,[ExpStatus]),
 		      rpc:call(Node,application,which_applications,[])});
 wait_node_up(Node,ExpStatus,ExpVsn,ExpAppsVsns,N) ->

--- a/lib/common_test/src/test_server_sup.erl
+++ b/lib/common_test/src/test_server_sup.erl
@@ -181,7 +181,7 @@ app_test(Application, Mode) ->
 	{ok, AppFile} ->
 	    do_app_tests(AppFile, Application, Mode);
 	Error ->
-	    test_server:fail(Error)
+	    ct:fail(Error)
     end.
 
 is_app(Application) ->
@@ -241,8 +241,8 @@ do_app_tests(AppFile, AppName, Mode) ->
     case A+B+C+D+E of
 	5 ->
 	    ok;
-	_ ->
-	    test_server:fail()
+	NotFive ->
+	    ct:fail(NotFive)
     end.
 
 app_check_export_all([]) ->
@@ -286,10 +286,10 @@ appup_test(Application) ->
                     Modules = proplists:get_value(modules, AppFile),
                     do_appup_tests(StartMod, Application, Up, Down, Modules);
                 Error ->
-                    test_server:fail(Error)
+                    ct:fail(Error)
             end;
         Error ->
-            test_server:fail(Error)
+            ct:fail(Error)
     end.
 
 is_appup(Application, Version) ->
@@ -336,11 +336,11 @@ do_appup_tests(_, _Application, Up, Down, Modules) ->
                     test_server:format(minor, "OK~n");
                 Error ->
                     test_server:format(minor, "ERROR ~tp~n", [Error]),
-                    test_server:fail(Error)
+                    ct:fail(Error)
             end;
         Error ->
             test_server:format(minor, "ERROR ~tp~n", [Error]),
-            test_server:fail(Error)
+            ct:fail(Error)
     end.
     
 check_appup_clauses_plausible([], _Direction, _Modules) ->

--- a/lib/common_test/test/ct_cover_SUITE_data/cover_SUITE.erl
+++ b/lib/common_test/test/ct_cover_SUITE_data/cover_SUITE.erl
@@ -32,7 +32,7 @@
 -compile(export_all).
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 suite() ->
     [].

--- a/lib/common_test/test/ct_cover_nomerge_SUITE_data/cover_nomerge_local_SUITE.erl
+++ b/lib/common_test/test/ct_cover_nomerge_SUITE_data/cover_nomerge_local_SUITE.erl
@@ -24,7 +24,7 @@
 -compile(export_all).
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 suite() ->
     [].

--- a/lib/common_test/test/ct_cover_nomerge_SUITE_data/cover_nomerge_remote_SUITE.erl
+++ b/lib/common_test/test/ct_cover_nomerge_SUITE_data/cover_nomerge_remote_SUITE.erl
@@ -24,7 +24,7 @@
 -compile(export_all).
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 suite() ->
     [].

--- a/lib/common_test/test/ct_cover_nomerge_SUITE_data/cover_nomerge_remote_nostop_SUITE.erl
+++ b/lib/common_test/test/ct_cover_nomerge_SUITE_data/cover_nomerge_remote_nostop_SUITE.erl
@@ -24,7 +24,7 @@
 -compile(export_all).
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 suite() ->
     [].

--- a/lib/common_test/test/ct_group_leader_SUITE.erl
+++ b/lib/common_test/test/ct_group_leader_SUITE.erl
@@ -103,8 +103,7 @@ verify_cases([{?eh,tc_done,{M,F,_}}|Ts], Cases0, true) ->
 	    Cases = Cases0 -- [{M,F}],
 	    verify_cases(Ts, Cases, true);
 	false ->
-	    io:format("~p not found\n", [{M,F}]),
-	    ?t:fail()
+	    ct:fail("~p not found\n", [{M,F}])
     end;
 verify_cases([{?eh,_,_}|Ts], Cases, Par) ->
     verify_cases(Ts, Cases, Par);

--- a/lib/common_test/test/ct_netconfc_SUITE_data/netconfc_test_lib.hrl
+++ b/lib/common_test/test/ct_netconfc_SUITE_data/netconfc_test_lib.hrl
@@ -1,5 +1,5 @@
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 -define(NS,ns). % netconf server module
 -define(LOCALHOST, "127.0.0.1").

--- a/lib/common_test/test/ct_repeat_testrun_SUITE_data/a_test/r1_SUITE.erl
+++ b/lib/common_test/test/ct_repeat_testrun_SUITE_data/a_test/r1_SUITE.erl
@@ -26,7 +26,7 @@
 -compile(export_all).
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:seconds(30)).
+-define(default_timeout, test_server:seconds(30)).
 
 all() ->
     testcases() ++ [{group,g},  tc2].

--- a/lib/common_test/test/ct_repeat_testrun_SUITE_data/b_test/r2_SUITE.erl
+++ b/lib/common_test/test/ct_repeat_testrun_SUITE_data/b_test/r2_SUITE.erl
@@ -26,7 +26,7 @@
 -compile(export_all).
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:seconds(30)).
+-define(default_timeout, test_server:seconds(30)).
 
 all() ->
     testcases() ++ [{group,g}, tc2].

--- a/lib/common_test/test/ct_snmp_SUITE_data/snmp_SUITE.erl
+++ b/lib/common_test/test/ct_snmp_SUITE_data/snmp_SUITE.erl
@@ -35,7 +35,7 @@
 -compile(export_all).
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 -define(AGENT_UDP, 4000).
 

--- a/lib/common_test/test/ct_surefire_SUITE_data/surefire_SUITE.erl
+++ b/lib/common_test/test/ct_surefire_SUITE_data/surefire_SUITE.erl
@@ -32,7 +32,7 @@
 -compile(export_all).
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 all() ->
     testcases() ++ [{group,g},{group,g_fail}].

--- a/lib/common_test/test/ct_test_support.erl
+++ b/lib/common_test/test/ct_test_support.erl
@@ -94,7 +94,7 @@ start_slave(NodeName, Config, Level) ->
     PR = proplists:get_value(printable_range,Config,io:printable_range()),
     case slave:start(Host, NodeName, "+pc " ++ atom_to_list(PR)) of
 	{error,Reason} ->
-	    test_server:fail(Reason);
+	    ct:fail(Reason);
 	{ok,CTNode} ->
 	    test_server:format(0, "Node ~p started~n", [CTNode]),
 	    IsCover = test_server:is_cover(),

--- a/lib/common_test/test/test_server_SUITE.erl
+++ b/lib/common_test/test/test_server_SUITE.erl
@@ -300,7 +300,7 @@ check([{Str,Expected,Actual}|T], _) ->
     io:format("~s: expected ~p, actual ~p\n", [Str,Expected,Actual]),
     check(T, error);
 check([], ok) -> ok;
-check([], error) -> ?t:fail().
+check([], error) -> test_server:fail().
 
 until(Fun) ->
     case Fun() of
@@ -393,7 +393,7 @@ create_unicode_test_suite(Dir,Encoding) ->
 	 "    init_timetrap(500,Config).\n"
 	 "\n"
 	 "init_timetrap(T,Config) ->\n"
-	 "    Dog = ?t:timetrap(T),\n"
+	 "    Dog = test_server:timetrap(T),\n"
 	 "    [{watchdog, Dog}|Config].\n"
 	 "\n"
 	 "end_per_testcase(_Case,Config) ->\n"
@@ -401,7 +401,7 @@ create_unicode_test_suite(Dir,Encoding) ->
 	 "\n"
 	 "cancel_timetrap(Config) ->\n"
 	 "    Dog=?config(watchdog, Config),\n"
-	 "    ?t:timetrap_cancel(Dog),\n"
+	 "    test_server:timetrap_cancel(Dog),\n"
 	 "    ok.\n"
 	 "\n"
 	 "tc_äöå(Config) when is_list(Config) ->\n"

--- a/lib/common_test/test/test_server_SUITE_data/test_server_SUITE.erl
+++ b/lib/common_test/test/test_server_SUITE_data/test_server_SUITE.erl
@@ -65,7 +65,7 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(2)),
+    Dog = test_server:timetrap(test_server:minutes(2)),
     Config1 = [{watchdog, Dog}|Config],
     case Func of
 	init_per_tc ->
@@ -80,11 +80,11 @@ init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
 init_per_testcase(Func, Config) ->
     io:format("Func:~p",[Func]),
     io:format("Config:~p",[Config]),
-    ?t:fail("Arguments to init_per_testcase not correct").
+    test_server:fail("Arguments to init_per_testcase not correct").
 
 end_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
     Dog=?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     case Func of
 	end_per_tc -> io:format("CLEANUP => this test case is ok\n");
 	_Other -> ok
@@ -92,12 +92,12 @@ end_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
 end_per_testcase(Func, Config) ->
     io:format("Func:~p",[Func]),
     io:format("Config:~p",[Config]),
-    ?t:fail("Arguments to end_per_testcase not correct").
+    test_server:fail("Arguments to end_per_testcase not correct").
 
 fin_per_testcase(Func, Config) ->
     io:format("Func:~p",[Func]),
     io:format("Config:~p",[Config]),
-    ?t:fail("fin_per_testcase/2 called, should have called end_per_testcase/2").
+    test_server:fail("fin_per_testcase/2 called, should have called end_per_testcase/2").
     
 
 config(suite) -> [];
@@ -117,7 +117,7 @@ config(Config) when is_list(Config) ->
     Dp = ?config(priv_dir,Config),
     ok;
 config(_Config) ->
-    ?t:fail("Config variable is not a list.").
+    test_server:fail("Config variable is not a list.").
 
 is_tuplelist([]) ->
     true;
@@ -137,9 +137,9 @@ is_dir(Dir) ->
 comment(suite) -> [];
 comment(doc) -> ["Print a comment in the HTML log"];
 comment(Config) when is_list(Config) ->
-    ?t:comment("This comment should not occur in the HTML log because a later"
+    test_server:comment("This comment should not occur in the HTML log because a later"
 	       " comment shall overwrite it"),
-    ?t:comment("This comment is printed with the comment/1 function."
+    test_server:comment("This comment is printed with the comment/1 function."
 	       " It should occur in the HTML log").
 
 
@@ -148,32 +148,32 @@ timetrap(suite) -> [];
 timetrap(doc) -> ["Test that timetrap works."];
 timetrap(Config) when is_list(Config) ->
     TrapAfter = 3000,
-    Dog=?t:timetrap(TrapAfter),
+    Dog=test_server:timetrap(TrapAfter),
     process_flag(trap_exit, true),
     TimeOut = TrapAfter * test_server:timetrap_scale_factor() + 1000,
     receive
 	{'EXIT', Dog, {timetrap_timeout, _, _}} ->
 	    ok;
 	{'EXIT', _OtherPid, {timetrap_timeout, _, _}} ->
-	    ?t:fail("EXIT signal from wrong process")
+	    test_server:fail("EXIT signal from wrong process")
     after
 	TimeOut ->
-	    ?t:fail("Timetrap is not working.")
+	    test_server:fail("Timetrap is not working.")
     end,
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     ok.
 
 
 timetrap_cancel(suite) -> [];
 timetrap_cancel(doc) -> ["Test that timetrap_cancel works."];
 timetrap_cancel(Config) when is_list(Config) ->
-    Dog=?t:timetrap(1000),
+    Dog=test_server:timetrap(1000),
     receive
     after
 	500 ->
 	    ok
     end,
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     receive
     after 1000 ->
 	    ok
@@ -186,9 +186,9 @@ multiply_timetrap(Config) when is_list(Config) ->
     %% This simulates the call to test_server_ctrl:multiply_timetraps/1:
     put(test_server_multiply_timetraps,{2,true}),
 
-    Dog = ?t:timetrap(500),
+    Dog = test_server:timetrap(500),
     timer:sleep(800),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
 
     %% Reset
     put(test_server_multiply_timetraps,1),
@@ -227,7 +227,7 @@ end_per_tc(suite) -> [];
 end_per_tc(doc) -> ["Test that end_per_testcase/2 is called even if"
 		    " test case fails"];
 end_per_tc(Config) when is_list(Config) ->
-    ?t:fail("This case should fail! Check that \"CLEANUP\" is"
+    test_server:fail("This case should fail! Check that \"CLEANUP\" is"
 	    " printed in the minor log file.").
 
 
@@ -239,9 +239,9 @@ timeconv(Config) when is_list(Config) ->
     Secs=Val*1000,
     Mins=Secs*60,
     Hrs=Mins*60,
-    Secs=?t:seconds(2),
-    Mins=?t:minutes(2),
-    Hrs=?t:hours(2),
+    Secs=test_server:seconds(2),
+    Mins=test_server:minutes(2),
+    Hrs=test_server:hours(2),
     ok.
 
 
@@ -251,7 +251,7 @@ msgs(Config) when is_list(Config) ->
     self() ! {hej, du},
     self() ! {lite, "data"},
     self() ! en_atom,
-    [{hej, du}, {lite, "data"}, en_atom] = ?t:messages_get(),
+    [{hej, du}, {lite, "data"}, en_atom] = test_server:messages_get(),
     ok.
 
 capture(suite) -> [];
@@ -259,30 +259,30 @@ capture(doc) -> ["Test that the capture functions work properly."];
 capture(Config) when is_list(Config) ->
     String1="abcedfghjiklmnopqrstuvwxyz",
     String2="0123456789",
-    ?t:capture_start(),
+    test_server:capture_start(),
     io:format(String1),
-    [String1]=?t:capture_get(),
+    [String1]=test_server:capture_get(),
     io:format(String2),
-    [String2]=?t:capture_get(),
-    ?t:capture_stop(),
-    []=?t:capture_get(),
+    [String2]=test_server:capture_get(),
+    test_server:capture_stop(),
+    []=test_server:capture_get(),
     io:format(String2),
-    []=?t:capture_get(),
+    []=test_server:capture_get(),
     ok.
 
 timecall(suite) -> [];
 timecall(doc) -> ["Tests that timed calls work."];
 timecall(Config) when is_list(Config) ->
-    {_Time1, liten_apa_e_oxo_farlig} = ?t:timecall(?MODULE, dummy_function, []),
-    {Time2, jag_ar_en_gorilla} = ?t:timecall(?MODULE, dummy_function, [gorilla]),
+    {_Time1, liten_apa_e_oxo_farlig} = test_server:timecall(?MODULE, dummy_function, []),
+    {Time2, jag_ar_en_gorilla} = test_server:timecall(?MODULE, dummy_function, [gorilla]),
     DTime=round(Time2),
     if
 	DTime<1 ->
-	    ?t:fail("Timecall reported a too low time.");
+	    test_server:fail("Timecall reported a too low time.");
 	DTime==1 ->
 	    ok;
 	DTime>1 ->
-	    ?t:fail("Timecall reported a too high time.")
+	    test_server:fail("Timecall reported a too high time.")
     end,
     ok.
 
@@ -299,16 +299,16 @@ do_times(doc) -> ["Test the do_times function."].
 do_times_mfa(suite) -> [];
 do_times_mfa(doc) -> ["Test the do_times function with M,F,A given."];
 do_times_mfa(Config) when is_list(Config) ->
-    ?t:do_times(100, ?MODULE, doer, [self()]),
-    100=length(?t:messages_get()),
+    test_server:do_times(100, ?MODULE, doer, [self()]),
+    100=length(test_server:messages_get()),
     ok.
 
 do_times_fun(suite) -> [];
 do_times_fun(doc) -> ["Test the do_times function with fun given."];
 do_times_fun(Config) when is_list(Config) ->
     Self = self(),
-    ?t:do_times(100, fun() -> doer(Self) end),
-    100=length(?t:messages_get()),
+    test_server:do_times(100, fun() -> doer(Self) end),
+    100=length(test_server:messages_get()),
     ok.
 
 doer(From) ->
@@ -325,7 +325,7 @@ skip_case1(doc) -> ["Test that you can return {skipped, Reason},"
 		    " and that Reason is in the comment field in the HTML log"];
 skip_case1(Config) when is_list(Config) ->
     %% If this comment shows, the case failed!!
-    ?t:comment("ERROR: This case should have been noted as `Skipped'"),
+    test_server:comment("ERROR: This case should have been noted as `Skipped'"),
     %% The Reason in {skipped, Reason} should overwrite a 'comment'
     {skipped, "This case should be noted as `Skipped'"}.
 
@@ -334,7 +334,7 @@ skip_case2(doc) -> ["Test that you can return {skipped, Reason},"
 		    " and that Reason is in the comment field in the HTML log"];
 skip_case2(Config) when is_list(Config) ->
     %% If this comment shows, the case failed!!
-    ?t:comment("ERROR: This case should have been noted as `Skipped'"),
+    test_server:comment("ERROR: This case should have been noted as `Skipped'"),
     %% The Reason in {skipped, Reason} should overwrite a 'comment'
     exit({skipped, "This case should be noted as `Skipped'"}).    
 
@@ -343,7 +343,7 @@ skip_case3(doc) -> ["Test that you can return {skip, Reason},"
 		    " and that Reason is in the comment field in the HTML log"];
 skip_case3(Config) when is_list(Config) ->
     %% If this comment shows, the case failed!!
-    ?t:comment("ERROR: This case should have been noted as `Skipped'"),
+    test_server:comment("ERROR: This case should have been noted as `Skipped'"),
     %% The Reason in {skip, Reason} should overwrite a 'comment'
     {skip, "This case should be noted as `Skipped'"}.
 
@@ -352,7 +352,7 @@ skip_case4(doc) -> ["Test that you can return {skip, Reason},"
 		    " and that Reason is in the comment field in the HTML log"];
 skip_case4(Config) when is_list(Config) ->
     %% If this comment shows, the case failed!!
-    ?t:comment("ERROR: This case should have been noted as `Skipped'"),
+    test_server:comment("ERROR: This case should have been noted as `Skipped'"),
     %% The Reason in {skip, Reason} should overwrite a 'comment'
     exit({skip, "This case should be noted as `Skipped'"}).    
 
@@ -370,7 +370,7 @@ skip_case7(Config) when is_list(Config) ->
     %% This case shall be skipped by adding 
     %% {skip, {test_server_SUITE, skip_case7, Reason}}. 
     %% to the test specification file.
-    ?t:fail("This case should have been Skipped by the .spec file").
+    test_server:fail("This case should have been Skipped by the .spec file").
 
 skip_case8(suite) -> [];
 skip_case8(doc) -> ["Test that {skipped, Reason} works from"
@@ -378,14 +378,14 @@ skip_case8(doc) -> ["Test that {skipped, Reason} works from"
 skip_case8(Config) when is_list(Config) ->
     %% This case shall be skipped by adding a specific clause to 
     %% returning {skipped, Reason} from init_per_testcase/2 for this case. 
-    ?t:fail("This case should have been Skipped by init_per_testcase/2").
+    test_server:fail("This case should have been Skipped by init_per_testcase/2").
 
 skip_case9(suite) -> [];
 skip_case9(doc) -> ["Test that {skip, Reason} works from a init_per_testcase/2"];
 skip_case9(Config) when is_list(Config) ->
     %% This case shall be skipped by adding a specific clause to 
     %% returning {skip, Reason} from init_per_testcase/2 for this case. 
-    ?t:fail("This case should have been Skipped by init_per_testcase/2").
+    test_server:fail("This case should have been Skipped by init_per_testcase/2").
 
 conf_init(doc) -> ["Test successful conf case: Change Config parameter"];
 conf_init(Config) when is_list(Config) ->
@@ -412,7 +412,7 @@ check_old_conf(Config) when is_list(Config) ->
 conf_init_fail(doc) -> ["Test that config members are skipped if"
 			" conf init function fails."];
 conf_init_fail(Config) when is_list(Config) -> 
-    ?t:fail("This case should fail! Check that conf_member_skip and"
+    test_server:fail("This case should fail! Check that conf_member_skip and"
 	    " conf_cleanup_skip are skipped.").
 
 
@@ -420,44 +420,44 @@ conf_init_fail(Config) when is_list(Config) ->
 start_stop_node(suite) -> [];
 start_stop_node(doc) -> ["Test start and stop of slave and peer nodes"];
 start_stop_node(Config) when is_list(Config) ->
-    {ok,Node2} = ?t:start_node(node2,peer,[]),
-    {error, _} = ?t:start_node(node2,peer,[{fail_on_error,false}]),
+    {ok,Node2} = test_server:start_node(node2,peer,[]),
+    {error, _} = test_server:start_node(node2,peer,[{fail_on_error,false}]),
     true = lists:member(Node2,nodes()),
 
-    {ok,Node3} = ?t:start_node(node3,slave,[]),
-    {error, _} = ?t:start_node(node3,slave,[]),
+    {ok,Node3} = test_server:start_node(node3,slave,[]),
+    {error, _} = test_server:start_node(node3,slave,[]),
     true = lists:member(Node3,nodes()),
 
-    {ok,Node4} = ?t:start_node(node4,peer,[{wait,false}]),
+    {ok,Node4} = test_server:start_node(node4,peer,[{wait,false}]),
     case lists:member(Node4,nodes()) of
 	true -> 
-	    ?t:comment("WARNING: Node started with {wait,false}"
+	    test_server:comment("WARNING: Node started with {wait,false}"
 			     " is up faster than expected...");
 	false ->
 	    test_server:wait_for_node(Node4),
 	    true = lists:member(Node4,nodes())
     end,
 
-    true = ?t:stop_node(Node2),
+    true = test_server:stop_node(Node2),
     false = lists:member(Node2,nodes()),
 
-    true = ?t:stop_node(Node3),
+    true = test_server:stop_node(Node3),
     false = lists:member(Node3,nodes()),
     
-    true = ?t:stop_node(Node4),
+    true = test_server:stop_node(Node4),
     false = lists:member(Node4,nodes()),
     timer:sleep(2000),
-    false = ?t:stop_node(Node4),
+    false = test_server:stop_node(Node4),
 
     ok.
 
 cleanup_nodes_init(doc) -> ["Test that nodes are terminated when test case"
 			    " is finished unless {cleanup,false} is given."];
 cleanup_nodes_init(Config) when is_list(Config) ->
-    {ok,DieSlave} = ?t:start_node(die_slave, slave, []),
-    {ok,SurviveSlave} = ?t:start_node(survive_slave, slave, [{cleanup,false}]),
-    {ok,DiePeer} = ?t:start_node(die_peer, peer, []),
-    {ok,SurvivePeer} = ?t:start_node(survive_peer, peer, [{cleanup,false}]),
+    {ok,DieSlave} = test_server:start_node(die_slave, slave, []),
+    {ok,SurviveSlave} = test_server:start_node(survive_slave, slave, [{cleanup,false}]),
+    {ok,DiePeer} = test_server:start_node(die_peer, peer, []),
+    {ok,SurvivePeer} = test_server:start_node(survive_peer, peer, [{cleanup,false}]),
     [{die_slave,DieSlave},
      {survive_slave,SurviveSlave},
      {die_peer,DiePeer},
@@ -482,9 +482,9 @@ cleanup_nodes_fin(Config) when is_list(Config) ->
     Slave = ?config(survive_slave,Config),
     Peer = ?config(survive_peer,Config),
     
-    true = ?t:stop_node(Slave),
+    true = test_server:stop_node(Slave),
     false = lists:member(Slave,nodes()),
-    true = ?t:stop_node(Peer),
+    true = test_server:stop_node(Peer),
     false = lists:member(Peer,nodes()),
     
     C1 = lists:keydelete(die_slave,1,Config),
@@ -493,7 +493,7 @@ cleanup_nodes_fin(Config) when is_list(Config) ->
     lists:keydelete(survive_peer,1,C3).
 
 commercial(Config) when is_list(Config) ->
-    case ?t:is_commercial() of
+    case test_server:is_commercial() of
 	false -> {comment,"Open-source build"};
 	true -> {comment,"Commercial build"}
     end.

--- a/lib/common_test/test/test_server_SUITE_data/test_server_cover_SUITE.erl
+++ b/lib/common_test/test/test_server_SUITE_data/test_server_cover_SUITE.erl
@@ -35,12 +35,12 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(_Case,Config) ->
-    Dog = ?t:timetrap({minutes,10}),
+    Dog = test_server:timetrap({minutes,10}),
     [{watchdog, Dog}|Config].
 
 end_per_testcase(_Case,Config) ->
     Dog=?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     ok.
 
 

--- a/lib/common_test/test/test_server_SUITE_data/test_server_skip_SUITE.erl
+++ b/lib/common_test/test/test_server_SUITE_data/test_server_skip_SUITE.erl
@@ -34,10 +34,10 @@ init_per_suite(Config) when is_list(Config) ->
 dummy(suite) -> [];
 dummy(doc) -> ["This testcase should never be executed"];
 dummy(Config) when is_list(Config) ->
-    ?t:fail("This testcase should be executed since"
+    test_server:fail("This testcase should be executed since"
 	    " init_per_suite/1 is skipped").
 
 end_per_suite(doc) -> ["This testcase should never be executed"];
 end_per_suite(Config) when is_list(Config) ->
-    ?t:fail("end_per_suite/1 should not be executed when"
+    test_server:fail("end_per_suite/1 should not be executed when"
 	    " init_per_suite/1 is skipped").

--- a/lib/common_test/test/test_server_SUITE_data/test_server_unicode_SUITE.erl
+++ b/lib/common_test/test/test_server_SUITE_data/test_server_unicode_SUITE.erl
@@ -42,7 +42,7 @@ init_per_testcase(_Case,Config) ->
     init_timetrap(500,Config).
 
 init_timetrap(T,Config) ->
-    Dog = ?t:timetrap(T),
+    Dog = test_server:timetrap(T),
     [{watchdog, Dog}|Config].
 
 end_per_testcase(_Case,Config) ->
@@ -50,7 +50,7 @@ end_per_testcase(_Case,Config) ->
 
 cancel_timetrap(Config) ->
     Dog=?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     ok.
 
 

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1460,7 +1460,7 @@ do_pre_load_check(Config) ->
 	true ->
 	    io:put_chars("The 'compile' module should not be included "
 			 "in the list of modules to be pre-loaded."),
-	    ?t:fail(compile);
+	    ct:fail(compile);
 	false ->
 	    []
     end,
@@ -1491,7 +1491,7 @@ do_pre_load_check(Config) ->
 	    io:format("The following modules were used "
 		      "but not pre-loaded:\n~p\n",
 		      [NotPreLoaded]),
-	    ?t:fail({not_preload,NotPreLoaded})
+	    ct:fail({not_preload,NotPreLoaded})
     end,
 
     %% Check for modules that should not be pre-loaded.
@@ -1502,7 +1502,7 @@ do_pre_load_check(Config) ->
 	    io:format("The following modules were pre-loaded"
 		      " but not used:\n~p\n",
 		      [NotUsed]),
-	    ?t:fail({not_used,NotUsed})
+	    ct:fail({not_used,NotUsed})
     end,
 
     ok.

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -558,12 +558,12 @@ end_per_testcase(_Name,Config) ->
 app() ->
     [{doc, "Test that the crypto app file is ok"}].
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(crypto).
+    ok = test_server:app_test(crypto).
 %%--------------------------------------------------------------------
 appup() ->
     [{doc, "Test that the crypto appup file is ok"}].
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(crypto).
+    ok = test_server:appup_test(crypto).
 
 %%--------------------------------------------------------------------
 %% Simple encode/decode for all ciphers in crypto:supports(ciphers). No

--- a/lib/debugger/test/int_eval_SUITE_data/my_int_eval_module.erl
+++ b/lib/debugger/test/int_eval_SUITE_data/my_int_eval_module.erl
@@ -40,7 +40,6 @@
 -import(lists, [member/2]).
 
 -define(line,put(test_server_loc,{?MODULE,?LINE}),).
--define(t,test_server).
 -define(m,test_server:match).
 -define(config,test_server:lookup_config).
 

--- a/lib/dialyzer/test/dialyzer_SUITE.erl
+++ b/lib/dialyzer/test/dialyzer_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 %% Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 -define(application, dialyzer).
 
 %% Test server specific exports
@@ -71,8 +71,8 @@ app_test(doc) ->
 app_test(suite) ->
     [];
 app_test(Config) when is_list(Config) ->
-    ?line ?t:app_test(dialyzer).
+    ?line test_server:app_test(dialyzer).
 
 %% Test that the .appup file does not contain any `basic' errors
 appup_test(Config) when is_list(Config) ->
-    ok = ?t:appup_test(dialyzer).
+    ok = test_server:appup_test(dialyzer).

--- a/lib/edoc/test/edoc_SUITE.erl
+++ b/lib/edoc/test/edoc_SUITE.erl
@@ -49,11 +49,11 @@ end_per_group(_GroupName, Config) ->
 
 %% Test that the .app file does not contain any `basic' errors
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(edoc).
+    ok = test_server:app_test(edoc).
 
 %% Test that the .appup file does not contain any `basic' errors
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(edoc).
+    ok = test_server:appup_test(edoc).
 
 build_std(suite) -> [];
 build_std(doc) -> ["Build some documentation using standard EDoc layout"];

--- a/lib/et/test/et_SUITE.erl
+++ b/lib/et/test/et_SUITE.erl
@@ -28,8 +28,8 @@ all() ->
 
 %% Test that the et app file is ok
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(et).
+    ok = test_server:app_test(et).
 
 %% Test that the et appup file is ok
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(et).
+    ok = test_server:appup_test(et).

--- a/lib/eunit/test/eunit_SUITE.erl
+++ b/lib/eunit/test/eunit_SUITE.erl
@@ -49,10 +49,10 @@ end_per_group(_GroupName, Config) ->
     Config.
 
 app_test(Config) when is_list(Config) ->
-    ok = ?t:app_test(eunit).
+    ok = test_server:app_test(eunit).
 
 appup_test(Config) when is_list(Config) ->
-    ok = ?t:appup_test(eunit).
+    ok = test_server:appup_test(eunit).
 
 eunit_test(Config) when is_list(Config) ->
     ok = file:set_cwd(code:lib_dir(eunit)),

--- a/lib/ftp/test/ftp_SUITE.erl
+++ b/lib/ftp/test/ftp_SUITE.erl
@@ -425,13 +425,13 @@ vsftpd_tls() ->
 app() ->
     [{doc, "Test that the ftp app file is ok"}].
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(ftp).
+    ok = test_server:app_test(ftp).
 
 %%--------------------------------------------------------------------
 appup() ->
     [{doc, "Test that the ftp appup file is ok"}].
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(ftp).
+    ok = test_server:appup_test(ftp).
 
 %%--------------------------------------------------------------------
 

--- a/lib/inets/test/inets_SUITE.erl
+++ b/lib/inets/test/inets_SUITE.erl
@@ -109,12 +109,12 @@ end_per_testcase(_, Config) ->
 app() ->
     [{doc, "Test that the inets app file is ok"}].
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(inets).
+    ok = test_server:app_test(inets).
 %%--------------------------------------------------------------------
 appup() ->
     [{doc, "Test that the inets appup file is ok"}].
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(inets).
+    ok = test_server:appup_test(inets).
 
 start_inets() ->
     [{doc, "Test inets API functions"}].

--- a/lib/jinterface/test/jinterface_SUITE.erl
+++ b/lib/jinterface/test/jinterface_SUITE.erl
@@ -220,7 +220,7 @@ init_per_testcase(Case, _Config)
        Case =:= kill_mbox_from_erlang ->
     {skip, "Not yet implemented"};
 init_per_testcase(_Case,Config) ->
-    Dog = ?t:timetrap({seconds,30}),
+    Dog = test_server:timetrap({seconds,30}),
     [{watch_dog,Dog}|Config].
 
 end_per_testcase(_Case,Config) ->
@@ -229,7 +229,7 @@ end_per_testcase(_Case,Config) ->
 	Pid -> exit(Pid,kill)
     end,
     jitu:kill_all_jnodes(),
-    ?t:timetrap_cancel(?config(watch_dog,Config)),
+    test_server:timetrap_cancel(?config(watch_dog,Config)),
     ok.
 
 

--- a/lib/jinterface/test/nc_SUITE.erl
+++ b/lib/jinterface/test/nc_SUITE.erl
@@ -417,19 +417,19 @@ unicode(Config) when is_list(Config) ->
 		    case L of
 			X -> ok;
 			_ ->
-			    ?t:fail({mismatch,Out,In})
+			    ct:fail({mismatch,Out,In})
 		    end;
 		(Echoer, {L,Tag}=Out, {Echoer,X,Tag}=In) ->
 		    case unicode:characters_to_binary(L, utf8) of
 			X -> ok;
 			_ ->
-			    ?t:fail({mismatch,Out,In})
+			    ct:fail({mismatch,Out,In})
 		    end;
 		(Echoer, {L}=Out, {Echoer,X}=In) ->
 		    case L of
 			X -> ok;
 			_ ->
-			    ?t:fail({mismatch,Out,In})
+			    ct:fail({mismatch,Out,In})
 		    end
 	    end, ["unicode"]).
 
@@ -456,14 +456,14 @@ unicode_list_to_string(Config) when is_list(Config) ->
 		    case L of
 			X -> ok;
 			_ ->
-			    ?t:fail({mismatch,Out,In})
+			    ct:fail({mismatch,Out,In})
 		    end;
 		(Echoer, {L,valid}=Out, {Echoer,X,_}=In) ->
 		    B = unicode:characters_to_binary(L, unicode, {utf16,big}),
 		    case [-D || <<D:16/big>> <= B] of
 			X -> ok;
 			_ ->
-			    ?t:fail({mismatch,Out,In})
+			    ct:fail({mismatch,Out,In})
 		    end
 	    end).
 
@@ -478,13 +478,13 @@ unicode_string_to_list(Config) when is_list(Config) ->
 		    case L of
 			X -> ok;
 			_ ->
-			    ?t:fail({mismatch,Out,In})
+			    ct:fail({mismatch,Out,In})
 		    end;
 		(Echoer, {L,valid}=Out, {Echoer,X,_}=In) ->
 		    case [-C || C <- L] of
 			X -> ok;
 			_ ->
-			    ?t:fail({mismatch,Out,In})
+			    ct:fail({mismatch,Out,In})
 		    end
 	    end, ["unicode"]).
 
@@ -596,7 +596,7 @@ connect(doc) -> [];
 connect(suite) -> [];
 connect(Config) when is_list(Config) ->
     WD = filename:dirname(code:which(?MODULE)),
-    {ok,Other} = ?t:start_node(make_name(), slave, [{args,"-pa "++WD}]),
+    {ok,Other} = test_server:start_node(make_name(), slave, [{args,"-pa "++WD}]),
     Action =
 	fun (Pid) ->
 		JName = node(Pid),
@@ -606,7 +606,7 @@ connect(Config) when is_list(Config) ->
 		    {Pid,Other,true} ->
 			ok;
 		    Unexpected1 ->
-			?t:fail({result,Unexpected1})
+			ct:fail({result,Unexpected1})
 		end,
 		Hidden = erlang:nodes(hidden),
 		Hidden = rpc:call(Other, erlang, nodes, [hidden]),
@@ -624,7 +624,7 @@ connect(Config) when is_list(Config) ->
 		    {Pid,Other,true} ->
 			ok;
 		    Unexpected2->
-			?t:fail({result,Unexpected2})
+			ct:fail({result,Unexpected2})
 		end,
 		Hidden = rpc:call(Other, erlang, nodes, [hidden])
 	end,
@@ -686,7 +686,7 @@ echo_loop(Cont, Echoer, OutTrans, InTrans, TermAcc)
 	Other ->
 	    io:format("echo_server_terms unexpected ~p: receive ~P~n",
 		      [self(),Other,10]),
-	    ?t:fail({unexpected, Other})
+	    ct:fail({unexpected, Other})
     end,
     echo_loop(Cont(), Echoer, OutTrans, InTrans, []).
 
@@ -701,7 +701,7 @@ check_terms(Echoer, [Term | Rest]) ->
 	Other ->
 	    io:format("check_terms unexpected ~p: receive ~P~n",
 		      [self(),Other,10]),
-	    ?t:fail({unexpected, Other})
+	    ct:fail({unexpected, Other})
     end;
 check_terms(_, []) ->
     ok.
@@ -727,9 +727,9 @@ run_server(Server, Config, Action, ExtraArgs) ->
 	       end),
     receive
 	{Server, JName, Pid} ->
-	    ?t:format("~w: ~p (~p)~n",
+	    test_server:format("~w: ~p (~p)~n",
 		      [Server, Pid, node(Pid)]),
-	    ?t:format("nodes(hidden): ~p~n",
+	    test_server:format("nodes(hidden): ~p~n",
 		      [nodes(hidden)]),
 	    Action(Pid),
 	    Pid ! bye,
@@ -738,7 +738,7 @@ run_server(Server, Config, Action, ExtraArgs) ->
 		    ok
 	    end;
 	Other ->
-	    ?t:fail({unexpected,Other})
+	    ct:fail({unexpected,Other})
     end.
 
 %%

--- a/lib/kernel/test/disk_log_SUITE.erl
+++ b/lib/kernel/test/disk_log_SUITE.erl
@@ -27,7 +27,6 @@
 -define(privdir(_), "./disk_log_SUITE_priv").
 -define(datadir(_), "./disk_log_SUITE_data").
 -define(config(X,Y), foo).
--define(t,test_server).
 -else.
 -include_lib("common_test/include/ct.hrl").
 -define(format(S, A), ok).

--- a/lib/kernel/test/wrap_log_reader_SUITE.erl
+++ b/lib/kernel/test/wrap_log_reader_SUITE.erl
@@ -27,7 +27,6 @@
 -define(line, put(line, ?LINE), ).
 -define(privdir(_), "./disk_log_SUITE_priv").
 -define(config(X,Y), foo).
--define(t,test_server).
 -else.
 -include_lib("common_test/include/ct.hrl").
 -define(format(S, A), ok).

--- a/lib/mnesia/test/mnesia_SUITE.erl
+++ b/lib/mnesia/test/mnesia_SUITE.erl
@@ -146,13 +146,13 @@ silly() ->
 
 %% Test structure of the mnesia application resource file
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(mnesia).
+    ok = test_server:app_test(mnesia).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% Test that all required versions have appup directives
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(mnesia).
+    ok = test_server:appup_test(mnesia).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/lib/observer/test/etop_SUITE.erl
+++ b/lib/observer/test/etop_SUITE.erl
@@ -28,7 +28,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 init_per_testcase(_Case, Config) ->
     ?line Dog=test_server:timetrap(?default_timeout),
@@ -38,7 +38,7 @@ end_per_testcase(Case, Config) ->
     catch error:undef -> ok
     end,
     Dog=?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     ok.
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
@@ -64,7 +64,7 @@ end_per_group(_GroupName, Config) ->
 
 %% Start etop with text presentation
 text(_) ->
-    ?line {ok,Node} = ?t:start_node(node2,peer,[]),
+    ?line {ok,Node} = test_server:start_node(node2,peer,[]),
 
     %% Must spawn this process, else the test case will never end.
     ?line spawn_link(etop,start,[[{node,Node},{output,text},{interval,3}]]),
@@ -86,14 +86,14 @@ text(cleanup,_Config) ->
     etop:stop(),
     {ok,Host} = inet:gethostname(),
     Node = list_to_atom("node2@"++Host),
-    ?t:stop_node(Node).
+    test_server:stop_node(Node).
 
 text_tracing_off(suite) ->
     [];
 text_tracing_off(doc) ->
     ["Start etop with text presentation, and tracing turned off"];
 text_tracing_off(Config) when is_list(Config) ->
-    ?line {ok,Node} = ?t:start_node(node2,peer,[]),
+    ?line {ok,Node} = test_server:start_node(node2,peer,[]),
 
     %% Must spawn this process, else the test case will never end.
     ?line spawn_link(etop,start,[[{node,Node},
@@ -118,5 +118,5 @@ text_tracing_off(cleanup,_Config) ->
     etop:stop(),
     {ok,Host} = inet:gethostname(),
     Node = list_to_atom("node2@"++Host),
-    ?t:stop_node(Node).
+    test_server:stop_node(Node).
 

--- a/lib/observer/test/observer_SUITE.erl
+++ b/lib/observer/test/observer_SUITE.erl
@@ -39,7 +39,7 @@
 	]).
 
 %% Default timetrap timeout (set in init_per_testcase)
--define(default_timeout, ?t:minutes(2)).
+-define(default_timeout, test_server:minutes(2)).
 
 -define(SECS(__S__), timer:seconds(__S__)).
 
@@ -77,14 +77,14 @@ end_per_suite(Config) ->
 init_per_testcase(Case, Config) ->
     ?P("init_per_testcase(~w) -> entry with"
        "~n   Config: ~p", [Case, Config]),
-    Dog = ?t:timetrap(?default_timeout),
+    Dog = test_server:timetrap(?default_timeout),
     [{watchdog, Dog} | Config].
 
 end_per_testcase(Case, Config) ->
     ?P("end_per_testcase(~w) -> entry with"
        "~n   Config: ~p", [Case, Config]),
     Dog = ?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     ok.
 
 
@@ -132,12 +132,12 @@ app_file(suite) ->
 app_file(doc) ->
     ["Testing .app file"];
 app_file(Config) when is_list(Config) ->
-    ?line ok = ?t:app_test(observer),
+    ?line ok = test_server:app_test(observer),
     ok.
 
 %% Testing .appup file
 appup_file(Config) when is_list(Config) ->
-    ok = ?t:appup_test(observer).
+    ok = test_server:appup_test(observer).
 
 -define(DBG(Foo), io:format("~p: ~p~n",[?LINE, catch Foo])).
 

--- a/lib/observer/test/ttb_SUITE.erl
+++ b/lib/observer/test/ttb_SUITE.erl
@@ -34,7 +34,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 -define(OUTPUT, "handler_output").
 -define(FNAME, "temptest").
 -define(DIRNAME, "ddtemp").
@@ -64,7 +64,7 @@ end_per_testcase(_Case, Config) ->
     %% catch error:undef -> ok
     %% end,
     Dog=?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     ok.
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
@@ -116,7 +116,7 @@ file(doc) ->
     ["Start tracing on multiple nodes, single file"];
 file(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -147,7 +147,7 @@ file(Config) when is_list(Config) ->
     ok.
 
 file(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 file_no_pi(suite) ->
     [];
@@ -155,7 +155,7 @@ file_no_pi(doc) ->
     ["Start tracing on multiple nodes, single file, no process information"];
 file_no_pi(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -182,7 +182,7 @@ file_no_pi(Config) when is_list(Config) ->
     ok.
 
 file_no_pi(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 
 file_fetch(suite) ->
@@ -191,7 +191,7 @@ file_fetch(doc) ->
     ["stop with the fetch option, i.e. collect all files when ttb is stopped"];
 file_fetch(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -217,10 +217,10 @@ file_fetch(Config) when is_list(Config) ->
     ?line {ok,[{matched,_,1},{matched,_,1}]} = ttb:tp(?MODULE,foo,[]),
     ?line ?MODULE:foo(),
     ?line rpc:call(OtherNode,?MODULE,foo,[]),
-    ?line ?t:capture_start(),
+    ?line test_server:capture_start(),
     ?line ttb:stop([return_fetch_dir]),
-    ?line ?t:capture_stop(),
-    ?line [StoreString] = ?t:capture_get(),
+    ?line test_server:capture_stop(),
+    ?line [StoreString] = test_server:capture_get(),
     ?line UploadDir =
 	lists:last(string:lexemes(lists:flatten(StoreString),"$ \n")),
 
@@ -250,7 +250,7 @@ file_fetch(Config) when is_list(Config) ->
     ok.
 
 file_fetch(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 
 wrap(suite) ->
@@ -259,7 +259,7 @@ wrap(doc) ->
     ["Start tracing on multiple nodes, wrap files"];
 wrap(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -305,7 +305,7 @@ wrap(Config) when is_list(Config) ->
     ok.
 
 wrap(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 wrap_merge(suite) ->
     [];
@@ -313,7 +313,7 @@ wrap_merge(doc) ->
     ["Start tracing on multiple nodes, wrap files, merge logs from both nodes"];
 wrap_merge(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -345,7 +345,7 @@ wrap_merge(Config) when is_list(Config) ->
     ok.
 
 wrap_merge(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 
 wrap_merge_fetch_format(suite) ->
@@ -354,7 +354,7 @@ wrap_merge_fetch_format(doc) ->
     ["Start tracing on multiple nodes, wrap files, fetch and format at stop"];
 wrap_merge_fetch_format(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -389,7 +389,7 @@ wrap_merge_fetch_format(Config) when is_list(Config) ->
     ok.
 
 wrap_merge_fetch_format(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 write_config1(suite) ->
     [];
@@ -397,7 +397,7 @@ write_config1(doc) ->
     ["Write config given commands"];
 write_config1(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
 
@@ -433,7 +433,7 @@ write_config1(Config) when is_list(Config) ->
 					atom_to_list(OtherNode)++
 					"-write_config1")]),
 	    ?line io:format("\nTrying again: ~p\n",[flush()]),
-	    ?line ?t:fail(Reason);
+	    ?line ct:fail(Reason);
 	ok ->
 	    ok
     end,	    
@@ -441,7 +441,7 @@ write_config1(Config) when is_list(Config) ->
 
 
 write_config1(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 write_config2(suite) ->
     [];
@@ -449,7 +449,7 @@ write_config2(doc) ->
     ["Write config from history (all)"];
 write_config2(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -485,14 +485,14 @@ write_config2(Config) when is_list(Config) ->
 					atom_to_list(OtherNode)++
 					"-write_config2")]),
 	    ?line io:format("\nTrying again: ~p\n",[flush()]),
-	    ?line ?t:fail(Reason);
+	    ?line ct:fail(Reason);
 	ok ->
 	    ok
     end,
     ok.
 
 write_config2(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 
 write_config3(suite) ->
@@ -501,7 +501,7 @@ write_config3(doc) ->
     ["Write config from history (selected and append)"];
 write_config3(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -551,14 +551,14 @@ write_config3(Config) when is_list(Config) ->
 					atom_to_list(OtherNode)++
 					"-write_config3")]),
 	    ?line io:format("\nTrying again: ~p\n",[flush()]),
-	    ?line ?t:fail(Reason);
+	    ?line ct:fail(Reason);
 	ok ->
 	    ok
     end,
     ok.
 
 write_config3(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 
 
@@ -568,7 +568,7 @@ history(doc) ->
     ["List history and execute entry from history"];
 history(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
 
@@ -599,7 +599,7 @@ history(Config) when is_list(Config) ->
     ok.
 
 history(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 
 write_trace_info(suite) ->
@@ -608,7 +608,7 @@ write_trace_info(doc) ->
     ["Write trace info and give handler explicitly in format command"];
 write_trace_info(Config) when is_list(Config) ->
     ?line Node = node(),
-    ?line {ok,OtherNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,OtherNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -634,7 +634,7 @@ write_trace_info(Config) when is_list(Config) ->
     ok.
 
 write_trace_info(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 
 seq_trace(suite) ->
@@ -692,7 +692,7 @@ seq_trace(Config) when is_list(Config) ->
 		      [ttb:dump_ti(
 			 filename:join(Privdir,
 				       atom_to_list(Node)++"-seq_trace.ti"))]),
-	    ?t:fail("metatrace failed for startproc")
+	    ct:fail("metatrace failed for startproc")
     end,
     case P1Proc of
 	{P1,_,_} -> ok;
@@ -704,7 +704,7 @@ seq_trace(Config) when is_list(Config) ->
 		      [ttb:dump_ti(
 			 filename:join(Privdir,
 				       atom_to_list(Node)++"-seq_trace.ti"))]),
-	    ?t:fail("metatrace failed for P1")
+	    ct:fail("metatrace failed for P1")
     end,
     case P2Proc of
 	{P2,_,_} -> ok;
@@ -716,7 +716,7 @@ seq_trace(Config) when is_list(Config) ->
 		      [ttb:dump_ti(
 			 filename:join(Privdir,
 				       atom_to_list(Node)++"-seq_trace.ti"))]),
-	    ?t:fail("metatrace failed for P2")
+	    ct:fail("metatrace failed for P2")
     end,
     ok.
 
@@ -726,7 +726,7 @@ diskless(suite) ->
 diskless(doc) ->
     ["Start tracing on diskless remote node"];
 diskless(Config) when is_list(Config) ->
-    ?line {ok,RemoteNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,RemoteNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -748,14 +748,14 @@ diskless(Config) when is_list(Config) ->
     ok.
 
 diskless(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 diskless_wrap(suite) ->
     [];
 diskless_wrap(doc) ->
     ["Start tracing on diskless remote node, save to local wrapped file"];
 diskless_wrap(Config) when is_list(Config) ->
-    ?line {ok,RemoteNode} = ?t:start_node(node2,slave,[]),
+    ?line {ok,RemoteNode} = test_server:start_node(node2,slave,[]),
     ?line c:nl(?MODULE),
     ?line S = self(),
     ?line Privdir=priv_dir(Config),
@@ -777,7 +777,7 @@ diskless_wrap(Config) when is_list(Config) ->
     ok.
 
 diskless_wrap(cleanup,_Config) ->
-    ?line ?t:stop_node(ttb_helper:get_node(node2)).
+    ?line test_server:stop_node(ttb_helper:get_node(node2)).
 
 otp_4967_1(suite) ->
     [];
@@ -904,7 +904,7 @@ metatest(Proc,Node,Privdir,Filename) ->
 	    io:format("Trace information file:\n~p\n",
 		      [ttb:dump_ti(
 			 filename:join(Privdir,atom_to_list(Node)++Filename))]),
-%	    ?t:fail("metatrace failed on "++atom_to_list(Node))
+%	    ct:fail("metatrace failed on "++atom_to_list(Node))
 	    {error,"metatrace failed on "++atom_to_list(Node)}
     end.
 
@@ -918,7 +918,7 @@ check_gone(Dir,File) ->
 		      true ->
 			  io:format("~p: ~p~n",
 				    [Dir,NewList]),
-			  ?t:fail(File ++ " not removed from original place");
+			  ct:fail(File ++ " not removed from original place");
 		      false ->
 			  io:format("gone after 2 sec....~n",[]),
 			  ok
@@ -928,9 +928,9 @@ check_gone(Dir,File) ->
 	  end.
 
 start_client_and_server() ->
-    ?line {ok,ClientNode} = ?t:start_node(client,slave,[]),
+    ?line {ok,ClientNode} = test_server:start_node(client,slave,[]),
     ?line ok = ttb_helper:c(code, add_paths, [code:get_path()]),
-    ?line {ok,ServerNode} = ?t:start_node(server,slave,[]),
+    ?line {ok,ServerNode} = test_server:start_node(server,slave,[]),
     ?line ok = ttb_helper:s(code, add_paths, [code:get_path()]),
     ?line ttb_helper:clear(),
     {ServerNode, ClientNode}.
@@ -940,8 +940,8 @@ stop_client_and_server() ->
     ServerNode = ttb_helper:get_node(server),
     erlang:monitor_node(ClientNode,true),
     erlang:monitor_node(ServerNode,true),
-    ?line ?t:stop_node(ClientNode),
-    ?line ?t:stop_node(ServerNode),
+    ?line test_server:stop_node(ClientNode),
+    ?line test_server:stop_node(ServerNode),
     wait_for_client_and_server_stop(ClientNode,ServerNode).
 
 wait_for_client_and_server_stop(undefined,undefined) ->
@@ -1508,9 +1508,9 @@ trace_resumed_after_node_restart_wrap_mult(cleanup,_Config) ->
 
 logic(N, M, TracingType) ->
     helper_msgs(N, TracingType),
-    ?t:stop_node(ttb_helper:get_node(client)),
+    test_server:stop_node(ttb_helper:get_node(client)),
     timer:sleep(2500),
-    ?line {ok,_ClientNode} = ?t:start_node(client,slave,[]),
+    ?line {ok,_ClientNode} = test_server:start_node(client,slave,[]),
     ct:log("client started",[]),
     ?line ok = ttb_helper:c(code, add_paths, [code:get_path()]),
     ct:log("paths added",[]),

--- a/lib/odbc/test/odbc_start_SUITE.erl
+++ b/lib/odbc/test/odbc_start_SUITE.erl
@@ -121,11 +121,11 @@ end_per_group(_GroupName, Config) ->
 
 %% Test that the odbc app file is ok
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(odbc).
+    ok = test_server:app_test(odbc).
 
 %% Test that the odbc appup file is ok
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(odbc).
+    ok = test_server:appup_test(odbc).
 
 start() -> 
     [{doc,"Test start/stop of odbc"}].

--- a/lib/odbc/test/odbc_test.hrl
+++ b/lib/odbc/test/odbc_test.hrl
@@ -22,7 +22,7 @@
 % Default timetrap timeout (set in init_per_testcase).
 % This should be set relatively high (10-15 times the expected
 % max testcasetime).
--define(default_timeout, ?t:minutes(10)).
+-define(default_timeout, test_server:minutes(10)).
 
 -define(RDBMS, case os:type() of
 		   {unix, sunos} ->

--- a/lib/os_mon/test/memsup_SUITE.erl
+++ b/lib/os_mon/test/memsup_SUITE.erl
@@ -551,7 +551,7 @@ timeout(Config) when is_list(Config) ->
 
     %% Linux should be handled the same way as solaris.
 
-    %    TimeoutMsg = case ?t:os_type() of
+    %    TimeoutMsg = case test_server:os_type() of
     %		     {unix, sunos} -> ext_collection_timeout;
     %		     {unix, linux} -> reg_collection_timeout
     %		 end,

--- a/lib/os_mon/test/os_sup_SUITE.erl
+++ b/lib/os_mon/test/os_sup_SUITE.erl
@@ -76,7 +76,7 @@ message(Config) when is_list(Config) ->
     %% Check with message_receptor that it has been received
     ct:sleep({seconds,1}),
     Msg =
-    case ?t:os_type() of
+    case test_server:os_type() of
         {unix, sunos} ->
             {?TAG, Data};
         {win32, _} ->

--- a/lib/parsetools/test/app_SUITE.erl
+++ b/lib/parsetools/test/app_SUITE.erl
@@ -43,9 +43,9 @@ end_per_group(_GroupName, Config) ->
 app() ->
     [{doc, "Test that the parsetools app file is ok"}].
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(parsetools).
+    ok = test_server:app_test(parsetools).
 
 appup() ->
     [{doc, "Test that the parsetools appup file is ok"}].
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(parsetools).
+    ok = test_server:appup_test(parsetools).

--- a/lib/parsetools/test/leex_SUITE.erl
+++ b/lib/parsetools/test/leex_SUITE.erl
@@ -28,7 +28,6 @@
 -define(config(X,Y), foo).
 -define(datadir, "leex_SUITE_data").
 -define(privdir, "leex_SUITE_priv").
--define(t, test_server).
 -else.
 -include_lib("common_test/include/ct.hrl").
 -define(datadir, ?config(data_dir, Config)).
@@ -48,10 +47,10 @@
          otp_17023/1, compiler_warnings/1]).
 
 % Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 init_per_testcase(_Case, Config) ->
-    Dog = ?t:timetrap(?default_timeout),
+    Dog = test_server:timetrap(?default_timeout),
     [{watchdog, Dog} | Config].
 
 end_per_testcase(_Case, Config) ->
@@ -1216,7 +1215,7 @@ start_node(Name, Args) ->
     ct:log("Trying to start ~w@~s~n", [Name,Host]),
     case test_server:start_node(Name, peer, [{args,Args}]) of
 	{error,Reason} ->
-	    test_server:fail(Reason);
+	    ct:fail(Reason);
 	{ok,Node} ->
 	    ct:log("Node ~p started~n", [Node]),
 	    Node
@@ -1238,9 +1237,8 @@ run(Config, Tests) ->
                     E -> 
                         ok;
                     Bad -> 
-                        ?t:format("~nTest ~p failed. Expected~n  ~p~n"
-                                  "but got~n  ~p~n", [N, E, Bad]),
-			fail()
+                        ct:fail("~nTest ~p failed. Expected~n  ~p~n"
+                                  "but got~n  ~p~n", [N, E, Bad])
                 end
         end,
     lists:foreach(F, Tests).
@@ -1287,6 +1285,3 @@ extract(File, {error, Es, Ws}) ->
     {errors, extract(File, Es), extract(File, Ws)};    
 extract(File, Ts) ->
     lists:append([T || {F, T} <- Ts,  F =:= File]).
-
-fail() ->
-    ?t:fail().

--- a/lib/parsetools/test/yecc_SUITE.erl
+++ b/lib/parsetools/test/yecc_SUITE.erl
@@ -27,7 +27,6 @@
 -define(config(X,Y), foo).
 -define(datadir, "yecc_SUITE_data").
 -define(privdir, "yecc_SUITE_priv").
--define(t, test_server).
 -else.
 -include_lib("common_test/include/ct.hrl").
 -define(datadir, ?config(data_dir, Config)).
@@ -52,10 +51,10 @@
          otp_11286/1, otp_14285/1, otp_17023/1, otp_17535/1]).
 
 % Default timetrap timeout (set in init_per_testcase).
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 init_per_testcase(_Case, Config) ->
-    Dog = ?t:timetrap(?default_timeout),
+    Dog = test_server:timetrap(?default_timeout),
     [{watchdog, Dog} | Config].
 
 end_per_testcase(_Case, Config) ->
@@ -97,7 +96,7 @@ app_test(doc) ->
 app_test(suite) ->
     [];
 app_test(Config) when is_list(Config) ->
-    ok=?t:app_test(parsetools),
+    ok=test_server:app_test(parsetools),
     ok.
 
 
@@ -1782,9 +1781,8 @@ run(Config, Tests) ->
                     E -> 
                         ok;
                     Bad -> 
-                        ?t:format("~nTest ~p failed. Expected~n  ~p~n"
-                                  "but got~n  ~p~n", [N, E, Bad]),
-			fail()
+                        ct:fail("~nTest ~p failed. Expected~n  ~p~n"
+                                  "but got~n  ~p~n", [N, E, Bad])
                 end
         end,
     lists:foreach(F, Tests).
@@ -2200,7 +2198,7 @@ start_node(Name, Args) ->
     ct:log("Trying to start ~w@~s~n", [Name,Host]),
     case test_server:start_node(Name, peer, [{args,Args}]) of
 	{error,Reason} ->
-	    test_server:fail(Reason);
+	    ct:fail(Reason);
 	{ok,Node} ->
 	    ct:log("Node ~p started~n", [Node]),
 	    Node
@@ -2255,8 +2253,7 @@ run_test(Config, Def, Pre) ->
         {P0, {error, [{YrlFile,YEs}], [{YrlFile,YWs}]}} -> {error, YEs, YWs};
         {P0, YError} -> YError;
         {P, _} ->
-            io:format("failure, got ~p~n, expected ~p\n", [P, P0]),
-            fail()
+            ct:fail("failure, got ~p~n, expected ~p\n", [P, P0])
     end.
 
 extract(File, {error, Es, Ws}) ->
@@ -2277,6 +2274,3 @@ process_list() ->
 
 safe_second_element({_,Info}) -> Info;
 safe_second_element(Other) -> Other.
-
-fail() ->
-    ?t:fail().

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -239,14 +239,14 @@ end_per_testcase(_TestCase, _Config) ->
 app() ->
     [{doc, "Test that the public_key app file is ok"}].
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(public_key).
+    ok = test_server:app_test(public_key).
 
 %%--------------------------------------------------------------------
 
 appup() ->
     [{doc, "Test that the public_key appup file is ok"}].
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(public_key).
+    ok = test_server:appup_test(public_key).
 
 %%--------------------------------------------------------------------
 

--- a/lib/reltool/test/reltool_app_SUITE.erl
+++ b/lib/reltool/test/reltool_app_SUITE.erl
@@ -297,4 +297,4 @@ key1search(Key, L) ->
 
 %% Test that the reltool appup file is ok
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(reltool).
+    ok = test_server:appup_test(reltool).

--- a/lib/reltool/test/reltool_server_SUITE.erl
+++ b/lib/reltool/test/reltool_server_SUITE.erl
@@ -2774,7 +2774,7 @@ stop_node(Node) ->
     wait_for_node_down(Node,50).
 
 wait_for_node_down(Node,0) ->
-    test_server:fail({cant_terminate_node,Node});
+    ct:fail({cant_terminate_node,Node});
 wait_for_node_down(Node,N) ->
     case net_adm:ping(Node) of
 	pong ->
@@ -2836,7 +2836,7 @@ wait_for_app(_Node, Name, 0) ->
 wait_for_app(Node, Name, N) when is_integer(N), N > 0 ->
     case rpc:call(Node,application,which_applications,[]) of
 	{badrpc,Reason} ->
-	    test_server:fail({failed_to_get_applications,Reason});
+	    ct:fail({failed_to_get_applications,Reason});
 	Apps ->
 	    case lists:member(Name,Apps) of
 		false ->

--- a/lib/sasl/test/alarm_handler_SUITE.erl
+++ b/lib/sasl/test/alarm_handler_SUITE.erl
@@ -144,7 +144,7 @@ reported(Tag, Data) ->
 	    test_server:messages_get(),
 	    ok
     after 1000 ->
-	    test_server:fail(no_alarm_received)
+	    ct:fail(no_alarm_received)
     end.
 
 %%-----------------------------------------------------------------

--- a/lib/sasl/test/rb_SUITE.erl
+++ b/lib/sasl/test/rb_SUITE.erl
@@ -288,7 +288,7 @@ filter_date(Config) ->
     [] = rb_filter([],{After,from},OutFile),
     All = rb_filter([],{Before,After},OutFile),
 
-    %%?t:format("~p~n",[All]),
+    %%test_server:format("~p~n",[All]),
     AllButLast = [{N-1,R} || {N,R} <- tl(All)],
     AllButLast = rb_filter([],{Before,Between1},OutFile),
 
@@ -454,7 +454,7 @@ empty_error_logs(Config) ->
 wait_for_sasl() ->
     wait_for_sasl(50).
 wait_for_sasl(0) ->
-    ?t:fail("sasl application did not start within 5 seconds");
+    ct:fail("sasl application did not start within 5 seconds");
 wait_for_sasl(N) ->
     case lists:keymember(sasl,1,application:which_applications()) of
 	true ->
@@ -506,8 +506,8 @@ init_error_logs() ->
     gen_server:cast(?MODULE,crash),
     receive {'DOWN',Ref,process,_,{rb_SUITE,rb_test_crash}} -> ok
     after 2000 ->
-	    ?t:format("Got: ~p~n",[process_info(self(),messages)]),
-	    ?t:fail("rb_SUITE server never died")
+	    test_server:format("Got: ~p~n",[process_info(self(),messages)]),
+	    ct:fail("rb_SUITE server never died")
     end,
     erlang:demonitor(Ref),
     wait_for_server(),
@@ -523,11 +523,11 @@ wait_for_server() ->
     end.
 
 capture(Fun) ->
-    ?t:capture_start(),
+    test_server:capture_start(),
     ok = Fun(),
     timer:sleep(1000),
-    ?t:capture_stop(),
-    string:tokens(lists:append(?t:capture_get()),"\n").
+    test_server:capture_stop(),
+    string:tokens(lists:append(test_server:capture_get()),"\n").
 
 
 rb_filter(Filter,OutFile) ->

--- a/lib/sasl/test/sasl_SUITE.erl
+++ b/lib/sasl/test/sasl_SUITE.erl
@@ -66,7 +66,7 @@ end_per_testcase(_Case, _Config) ->
     ok.
 
 app_test(Config) when is_list(Config) ->
-    ?t:app_test(sasl, allow),
+    test_server:app_test(sasl, allow),
     ok.
 
 %% Test that appup allows upgrade from/downgrade to a maximum of one
@@ -230,7 +230,7 @@ test_log_file(File, Arg) ->
     %% There must be at least four PROGRESS lines.
     if
 	length(Lines) >= 4 -> ok;
-	true -> ?t:fail()
+	true -> ct:fail({progress, Lines})
     end,
     Bin.
 
@@ -303,7 +303,7 @@ verify_utc_log(Log, UTC) ->
 match_error(Expected,{error,{bad_return,{_,{'EXIT',{Expected,{sasl,_}}}}}}) ->
     ok;
 match_error(Expected,Actual) ->
-    ?t:fail({unexpected_return,Expected,Actual}).
+    ct:fail({unexpected_return,Expected,Actual}).
 
 clear_env(App) ->
     [application:unset_env(App,Opt) || {Opt,_} <- application:get_all_env(App)],

--- a/lib/sasl/test/sasl_report_SUITE.erl
+++ b/lib/sasl/test/sasl_report_SUITE.erl
@@ -192,10 +192,10 @@ check_file(File, Encoding, Min, Max) ->
     if
 	Sz < Min ->
 	    %% Truncated? Other problem?
-	    ?t:fail({too_short,Base});
+	    ct:fail({too_short,Base});
 	Sz > Max ->
 	    %% Truncation doesn't work?
-	    ?t:fail({too_big,Base});
+	    ct:fail({too_big,Base});
 	true ->
 	    ok
     end.

--- a/lib/sasl/test/systools_SUITE.erl
+++ b/lib/sasl/test/systools_SUITE.erl
@@ -43,7 +43,7 @@
 
 -import(lists, [foldl/3]).
 
--define(default_timeout, ?t:minutes(20)).
+-define(default_timeout, test_server:minutes(20)).
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -833,16 +833,16 @@ check_exref_warnings(with_db1, W) ->
 	      {lists,non_existing_func,1}]} ->
 	    ok;
 	{ok, L} ->
-	    test_server:fail({exref_warning_undef, L});
+	    ct:fail({exref_warning_undef, L});
 	_E ->
-	    test_server:fail({bad_undef,_E})
+	    ct:fail({bad_undef,_E})
     end;
 check_exref_warnings(without_db1, W) ->
     case get_exref(undef, W) of
 	false ->
 	    ok;
 	{ok, L} ->
-	    test_server:fail({exref_warning_undef, L})
+	    ct:fail({exref_warning_undef, L})
     end.
 
 get_exref(undef, W)   -> filter(get_exref1(exref_undef, W)).
@@ -1904,8 +1904,8 @@ app_start_type_relup(Dir2,Name2,Config) ->
     {"LATEST_APP_START_TYPE2",
      [{"LATEST_APP_START_TYPE1",[], UpInstructions}],
      [{"LATEST_APP_START_TYPE1",[], DownInstructions}]} = Release2Relup,
-    %% ?t:format("Up: ~p",[UpInstructions]),
-    %% ?t:format("Dn: ~p",[DownInstructions]),
+    %% test_server:format("Up: ~p",[UpInstructions]),
+    %% test_server:format("Dn: ~p",[DownInstructions]),
     [{load_object_code, {mnesia, _, _}},
      {load_object_code, {runtime_tools, _, _}},
      {load_object_code, {snmp, _, _}},
@@ -2393,14 +2393,14 @@ check_var_script_file(VarDirs, NoExistDirs, RelName) ->
 	VarDirs ->
 	    ok;
 	_ ->
-	    test_server:fail("All variable dirs not in generated script")
+	    ct:fail("All variable dirs not in generated script")
     end,
     case lists:filter(fun(NoExistDir) -> lists:member(NoExistDir, AllPaths) end,
 		      NoExistDirs) of
 	[] ->
 	    ok;
 	_ ->
-	    test_server:fail("Unexpected dirs in generated script")
+	    ct:fail("Unexpected dirs in generated script")
     end.
 
 check_include_script(RelName, ExpectedLoad, ExpectedStart) ->
@@ -2414,7 +2414,7 @@ check_include_script(RelName, ExpectedLoad, ExpectedStart) ->
 		App=/=stdlib],
 
     if ActualLoad =:= ExpectedLoad -> ok;
-       true -> test_server:fail({bad_load_order, ActualLoad, ExpectedLoad})
+       true -> ct:fail({bad_load_order, ActualLoad, ExpectedLoad})
     end,
 
     %% Check that applications are started in given order !
@@ -2424,7 +2424,7 @@ check_include_script(RelName, ExpectedLoad, ExpectedStart) ->
 		App =/= stdlib],
 
     if ActualStart =:= ExpectedStart -> ok;
-       true -> test_server:fail({bad_start_order, ActualStart,ExpectedStart})
+       true -> ct:fail({bad_start_order, ActualStart,ExpectedStart})
     end,
 
     ok.

--- a/lib/snmp/test/exp/snmp_agent_bl_test.erl
+++ b/lib/snmp/test/exp/snmp_agent_bl_test.erl
@@ -87,12 +87,12 @@ all(suite) -> {req,
 	       [{conf, init_all, cases(), finish_all}]}.
 
 init_per_testcase(_Case, Config) when list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(6)),
+    Dog = test_server:timetrap(test_server:minutes(6)),
     [{watchdog, Dog}|Config].
 
 end_per_testcase(_Case, Config) when list(Config) ->
     Dog = ?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     Config.
 
 cases() ->

--- a/lib/snmp/test/exp/snmp_agent_ms_test.erl
+++ b/lib/snmp/test/exp/snmp_agent_ms_test.erl
@@ -223,12 +223,12 @@ end_per_group(_GroupName, Config) ->
 
 
 init_per_testcase(_Case, Config) when list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(6)),
+    Dog = test_server:timetrap(test_server:minutes(6)),
     [{watchdog, Dog}|Config].
 
 end_per_testcase(_Case, Config) when list(Config) ->
     Dog = ?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     Config.
 
 cases() -> 

--- a/lib/snmp/test/exp/snmp_agent_mt_test.erl
+++ b/lib/snmp/test/exp/snmp_agent_mt_test.erl
@@ -223,12 +223,12 @@ end_per_group(_GroupName, Config) ->
 
 
 init_per_testcase(_Case, Config) when list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(6)),
+    Dog = test_server:timetrap(test_server:minutes(6)),
     [{watchdog, Dog}|Config].
 
 end_per_testcase(_Case, Config) when list(Config) ->
     Dog = ?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     Config.
 
 cases() -> 

--- a/lib/snmp/test/exp/snmp_agent_v1_test.erl
+++ b/lib/snmp/test/exp/snmp_agent_v1_test.erl
@@ -101,12 +101,12 @@ all(suite) -> {req,
 	       [{conf, init, cases(), finish}]}.
 
 init_per_testcase(_Case, Config) when list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(6)),
+    Dog = test_server:timetrap(test_server:minutes(6)),
     [{watchdog, Dog}|Config].
 
 end_per_testcase(_Case, Config) when list(Config) ->
     Dog = ?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     Config.
 
 cases() ->

--- a/lib/snmp/test/exp/snmp_agent_v2_test.erl
+++ b/lib/snmp/test/exp/snmp_agent_v2_test.erl
@@ -223,12 +223,12 @@ end_per_group(_GroupName, Config) ->
 
 
 init_per_testcase(_Case, Config) when list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(6)),
+    Dog = test_server:timetrap(test_server:minutes(6)),
     [{watchdog, Dog}|Config].
 
 end_per_testcase(_Case, Config) when list(Config) ->
     Dog = ?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     Config.
 
 cases() -> 

--- a/lib/snmp/test/exp/snmp_agent_v3_test.erl
+++ b/lib/snmp/test/exp/snmp_agent_v3_test.erl
@@ -223,12 +223,12 @@ end_per_group(_GroupName, Config) ->
 
 
 init_per_testcase(_Case, Config) when list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(6)),
+    Dog = test_server:timetrap(test_server:minutes(6)),
     [{watchdog, Dog}|Config].
 
 end_per_testcase(_Case, Config) when list(Config) ->
     Dog = ?config(watchdog, Config),
-    ?t:timetrap_cancel(Dog),
+    test_server:timetrap_cancel(Dog),
     Config.
 
 cases() -> 

--- a/lib/snmp/test/snmp_appup_test.erl
+++ b/lib/snmp/test/snmp_appup_test.erl
@@ -87,4 +87,4 @@ end_per_testcase(_Case, Config) when is_list(Config) ->
 
 %% Perform a simple check of the appup file
 appup_file(Config) when is_list(Config) ->
-    ok = ?t:appup_test(snmp).
+    ok = test_server:appup_test(snmp).

--- a/lib/ssh/test/ssh_basic_SUITE.erl
+++ b/lib/ssh/test/ssh_basic_SUITE.erl
@@ -242,12 +242,12 @@ end_per_testcase(_Config) ->
 %%--------------------------------------------------------------------
 %%% Application consistency test.
 app_test(Config) when is_list(Config) ->
-    ?t:app_test(ssh),
+    test_server:app_test(ssh),
     ok.
 %%--------------------------------------------------------------------
 %%% Appup file consistency test.
 appup_test(Config) when is_list(Config) ->
-    ok = ?t:appup_test(ssh).
+    ok = test_server:appup_test(ssh).
 %%--------------------------------------------------------------------
 %%% Test that we can set some misc options not tested elsewhere
 %%% some options not yet present are not decided if we should support or

--- a/lib/ssh/test/ssh_sftp_SUITE.erl
+++ b/lib/ssh/test/ssh_sftp_SUITE.erl
@@ -82,7 +82,7 @@
 -include_lib("kernel/include/file.hrl").
 -include("ssh_test_lib.hrl").
 						% Default timetrap timeout
--define(default_timeout, ?t:minutes(1)).
+-define(default_timeout, test_server:minutes(1)).
 
 %%--------------------------------------------------------------------
 %% Common Test interface functions -----------------------------------

--- a/lib/ssl/test/ssl_basic_SUITE.erl
+++ b/lib/ssl/test/ssl_basic_SUITE.erl
@@ -179,12 +179,12 @@ end_per_testcase(_TestCase, Config) ->
 app() ->
     [{doc, "Test that the ssl app file is ok"}].
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(ssl).
+    ok = test_server:app_test(ssl).
 %%--------------------------------------------------------------------
 appup() ->
     [{doc, "Test that the ssl appup file is ok"}].
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(ssl).
+    ok = test_server:appup_test(ssl).
 %%--------------------------------------------------------------------
 version_option() ->
     [{doc, "Use version option and do no specify ciphers list. Bug specified incorrect ciphers"}].

--- a/lib/stdlib/test/beam_lib_SUITE.erl
+++ b/lib/stdlib/test/beam_lib_SUITE.erl
@@ -25,7 +25,6 @@
 -define(format(S, A), io:format(S, A)).
 -define(line, put(line, ?LINE), ).
 -define(config(X,Y), "./log_dir/").
--define(t,test_server).
 -define(privdir, "beam_lib_SUITE_priv").
 -else.
 -include_lib("common_test/include/ct.hrl").

--- a/lib/stdlib/test/file_sorter_SUITE.erl
+++ b/lib/stdlib/test/file_sorter_SUITE.erl
@@ -25,7 +25,6 @@
 -define(format(S, A), io:format(S, A)).
 -define(line, put(line, ?LINE), ).
 -define(config(X,Y), foo).
--define(t,test_server).
 -define(privdir(_), "./file_sorter_SUITE_priv").
 -else.
 -include_lib("common_test/include/ct.hrl").

--- a/lib/stdlib/test/gen_statem_SUITE.erl
+++ b/lib/stdlib/test/gen_statem_SUITE.erl
@@ -541,7 +541,7 @@ abnormal1(Config) ->
 	   gen_statem:call(Name, {delayed_answer,2000}, 100),
 	   Reason),
     ok = gen_statem:stop(Name),
-    ?t:sleep(1100),
+    ct:sleep(1100),
     ok = verify_empty_msgq().
 
 %% Check that time outs in calls work
@@ -561,7 +561,7 @@ abnormal1clean(Config) ->
 	     Name, {delayed_answer,1000}, {clean_timeout,10}),
 	   Reason),
     ok = gen_statem:stop(Name),
-    ?t:sleep(1100),
+    ct:sleep(1100),
     ok = verify_empty_msgq().
 
 %% Check that time outs in calls work
@@ -581,7 +581,7 @@ abnormal1dirty(Config) ->
 	     Name, {delayed_answer,1000}, {dirty_timeout,10}),
 	   Reason),
     ok = gen_statem:stop(Name),
-    ?t:sleep(1100),
+    ct:sleep(1100),
     case flush() of
 	[] -> ok
     end.
@@ -2259,7 +2259,7 @@ do_func_test(STM) ->
     ok = do_connect(STM),
     ok = gen_statem:cast(STM, {'alive?',self()}),
     wfor(yes),
-    ?t:do_times(3, ?MODULE, do_msg, [STM]),
+    test_server:do_times(3, ?MODULE, do_msg, [STM]),
     ok = gen_statem:cast(STM, {'alive?',self()}),
     wfor(yes),
     ok = do_disconnect(STM),
@@ -2310,7 +2310,7 @@ do_sync_func_test(STM) ->
     yes = gen_statem:call(STM, 'alive?'),
     ok = do_sync_connect(STM),
     yes = gen_statem:call(STM, 'alive?'),
-    ?t:do_times(3, ?MODULE, do_sync_msg, [STM]),
+    test_server:do_times(3, ?MODULE, do_sync_msg, [STM]),
     yes = gen_statem:call(STM, 'alive?'),
     ok = do_sync_disconnect(STM),
     yes = gen_statem:call(STM, 'alive?'),
@@ -2368,7 +2368,7 @@ init(stop) ->
 init(stop_shutdown) ->
     {stop,shutdown};
 init(sleep) ->
-    ?t:sleep(1000),
+    ct:sleep(1000),
     init_sup({ok,idle,data});
 init(hiber) ->
     init_sup({ok,hiber_idle,[]});

--- a/lib/stdlib/test/re_SUITE.erl
+++ b/lib/stdlib/test/re_SUITE.erl
@@ -673,7 +673,7 @@ pcre_compile_workspace_overflow(Config) when is_list(Config) ->
         {error, {"parentheses are too deeply nested (stack check)" = Str, _No}} ->
             {comment, ExpStr ++ Str};
         Other ->
-            ?t:fail({unexpected, Other})
+            ct:fail({unexpected, Other})
     end.
 
 %% Make sure matches that really loop infinitely actually fail.

--- a/lib/stdlib/test/shell_SUITE.erl
+++ b/lib/stdlib/test/shell_SUITE.erl
@@ -47,7 +47,6 @@
 
 -ifdef(STANDALONE).
 -define(config(A,B),config(A,B)).
--define(t,test_server).
 -export([config/2]).
 -define(line, noop, ).
 config(priv_dir,_) ->

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -54,22 +54,22 @@ end_per_group(_GroupName, Config) ->
     Config.
 
 app_test(Config) when is_list(Config) ->
-    ok = ?t:app_test(syntax_tools).
+    ok = test_server:app_test(syntax_tools).
 
 appup_test(Config) when is_list(Config) ->
-    ok = ?t:appup_test(syntax_tools).
+    ok = test_server:appup_test(syntax_tools).
 
 %% Read and parse all source in the OTP release.
 smoke_test(Config) when is_list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(12)),
+    Dog = test_server:timetrap(test_server:minutes(12)),
     Wc = filename:join([code:lib_dir(),"*","src","*.erl"]),
     Fs = filelib:wildcard(Wc) ++ test_files(Config),
     io:format("~p files\n", [length(Fs)]),
     case p_run(fun smoke_test_file/1, Fs) of
         0 -> ok;
-        N -> ?t:fail({N,errors})
+        N -> ct:fail({N,errors})
     end,
-    ?t:timetrap_cancel(Dog).
+    test_server:timetrap_cancel(Dog).
 
 smoke_test_file(File) ->
     case epp_dodger:parse_file(File) of
@@ -93,7 +93,7 @@ print_error_markers(F, File) ->
 
 %% Read with erl_parse, wrap and revert with erl_syntax and check for equality.
 revert(Config) when is_list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(12)),
+    Dog = test_server:timetrap(test_server:minutes(12)),
     Wc = filename:join([code:lib_dir("stdlib"),"src","*.erl"]),
     Fs = filelib:wildcard(Wc) ++ test_files(Config),
     Path = [filename:join(code:lib_dir(stdlib), "include"),
@@ -101,9 +101,9 @@ revert(Config) when is_list(Config) ->
     io:format("~p files\n", [length(Fs)]),
     case p_run(fun (File) -> revert_file(File, Path) end, Fs) of
         0 -> ok;
-        N -> ?t:fail({N,errors})
+        N -> ct:fail({N,errors})
         end,
-    ?t:timetrap_cancel(Dog).
+    test_server:timetrap_cancel(Dog).
 
 revert_file(File, Path) ->
     case epp:parse_file(File, Path, []) of
@@ -118,16 +118,16 @@ revert_file(File, Path) ->
 
 %% Testing bug fix for reverting map_field_assoc
 revert_map(Config) when is_list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(1)),
+    Dog = test_server:timetrap(test_server:minutes(1)),
     [{map_field_assoc,16,{atom,17,name},{var,18,'Value'}}] =
     erl_syntax:revert_forms([{tree,map_field_assoc,
                              {attr,16,[],none},
 			     {map_field_assoc,{atom,17,name},{var,18,'Value'}}}]),
-    ?t:timetrap_cancel(Dog).
+    test_server:timetrap_cancel(Dog).
 
 %% Testing bug fix for reverting map_field_assoc in types
 revert_map_type(Config) when is_list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(1)),
+    Dog = test_server:timetrap(test_server:minutes(1)),
     Form1 = {attribute,4,record,
              {state,
               [{typed_record_field,
@@ -144,12 +144,12 @@ revert_map_type(Config) when is_list(Config) ->
                  [{type,5,map_field_assoc,[{atom,5,y},{atom,5,z}]}]}}]}},
     Mapped2 = erl_syntax_lib:map(fun(X) -> X end, Form2),
     Form2 = erl_syntax:revert(Mapped2),
-    ?t:timetrap_cancel(Dog).
+    test_server:timetrap_cancel(Dog).
 
 %% Read with erl_parse, wrap each tree node with erl_syntax and check that
 %% erl_syntax:subtrees can access the wrapped node.
 wrapped_subtrees(Config) when is_list(Config) ->
-    Dog = ?t:timetrap(?t:minutes(2)),
+    Dog = test_server:timetrap(test_server:minutes(2)),
     Wc = filename:join([code:lib_dir(stdlib),"src","*.erl"]),
     Fs = filelib:wildcard(Wc) ++ test_files(Config),
     Path = [filename:join(code:lib_dir(stdlib), "include"),
@@ -158,9 +158,9 @@ wrapped_subtrees(Config) when is_list(Config) ->
     Map = fun (File) -> wrapped_subtrees_file(File, Path) end,
     case p_run(Map, Fs) of
         0 -> ok;
-        N -> ?t:fail({N,errors})
+        N -> ct:fail({N,errors})
     end,
-    ?t:timetrap_cancel(Dog).
+    test_server:timetrap_cancel(Dog).
 
 wrapped_subtrees_file(File, Path) ->
     case epp:parse_file(File, Path, []) of
@@ -404,7 +404,7 @@ test_prettypr([File|Files],DataDir,PrivDir) ->
         [] ->
             ok;
         Errors ->
-            ?t:fail(Errors)
+            ct:fail(Errors)
     end,
     test_prettypr(Files,DataDir,PrivDir).
 

--- a/lib/tftp/test/tftp_SUITE.erl
+++ b/lib/tftp/test/tftp_SUITE.erl
@@ -107,13 +107,13 @@ end_per_group(_GroupName, Config) ->
 app() ->
     [{doc, "Test that the tftp app file is ok"}].
 app(Config) when is_list(Config) ->
-    ok = ?t:app_test(tftp).
+    ok = test_server:app_test(tftp).
 
 %%--------------------------------------------------------------------
 appup() ->
     [{doc, "Test that the tftp appup file is ok"}].
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(tftp).
+    ok = test_server:appup_test(tftp).
 
 start_tftpd() ->
     [{doc, "Start/stop of tfpd service"}].

--- a/lib/tools/test/xref_SUITE.erl
+++ b/lib/tools/test/xref_SUITE.erl
@@ -25,7 +25,6 @@
 -define(format(S, A), io:format(S, A)).
 -define(line, put(line, ?LINE), ).
 -define(config(X,Y), "./log_dir/").
--define(t,test_server).
 -define(datadir, "xref_SUITE_data").
 -define(privdir, "xref_SUITE_priv").
 -define(copydir, "xref_SUITE_priv/datacopy").

--- a/lib/wx/test/wx_app_SUITE.erl
+++ b/lib/wx/test/wx_app_SUITE.erl
@@ -291,4 +291,4 @@ key1search(Key, L) ->
 
 %% Test that the wx appup file is ok
 appup(Config) when is_list(Config) ->
-    ok = ?t:appup_test(wx).
+    ok = test_server:appup_test(wx).


### PR DESCRIPTION
Removing `?t` previously retained for backward compatibility allows to
search for test_server callsites easier.