### PR TITLE
Lock free atom table

### DIFF
--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -675,7 +675,7 @@ atom_text_alloc(int bytes)
 
     atom_write_lock();
     ASSERT(bytes <= MAX_ATOM_SZ_LIMIT);
-    if (atom_text_pos + bytes >= atom_text_end) {
+    if (bytes > atom_text_end - atom_text_pos) {
 	more_atom_space();
     }
     res = atom_text_pos;

--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -661,14 +661,16 @@ init_atom_table(void)
 	    ASSERT((a.atom.name[ix] & 0x80) == 0);
 	}
 #endif
-	ix = atom_index_put(&a);
+	/* am_ErtsSecretAtom should be entered in the index table but not the hash table */
+	if (i != atom_val(am_ErtsSecretAtom)) {
+	    ix = atom_index_put(&a);
+	} else {
+	    ix = atom_index_put_raw(atom_alloc(&a));
+	}
 	atom_text_pos -= a.atom.len;
 	atom_space -= a.atom.len;
 	atom_tab_int(ix)->atom.name = (byte*)erl_atom_names[i];
     }
-
-    /* Hide am_ErtsSecretAtom */
-    hash_erase(&erts_atom_table.htable, atom_tab_int(atom_val(am_ErtsSecretAtom)));
 }
 
 void

--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -500,7 +500,6 @@ typedef struct _atom_text {
 
 static AtomText* text_list;	/* List of text buffers */
 static byte *atom_text_pos;
-static byte *atom_text_end;
 static Uint reserved_atom_space;	/* Total amount of atom text space */
 static Uint atom_space;		/* Amount of atom text space used */
 
@@ -658,7 +657,6 @@ more_atom_space(void)
     text_list = ptr;
 
     atom_text_pos = ptr->text;
-    atom_text_end = atom_text_pos + ATOM_TEXT_SIZE;
     reserved_atom_space += sizeof(AtomText);
 
     VERBOSE(DEBUG_SYSTEM,("Allocated %d atom space\n",ATOM_TEXT_SIZE));
@@ -672,10 +670,12 @@ static byte*
 atom_text_alloc(int bytes)
 {
     byte *res;
+    byte *text_end;
 
     atom_write_lock();
     ASSERT(bytes <= MAX_ATOM_SZ_LIMIT);
-    if (bytes > atom_text_end - atom_text_pos) {
+    text_end = text_list->text + ATOM_TEXT_SIZE;
+    if (bytes > text_end - atom_text_pos) {
 	more_atom_space();
     }
     res = atom_text_pos;
@@ -1002,7 +1002,6 @@ init_atom_table(void)
         ERTS_LOCK_FLAGS_PROPERTY_STATIC | ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
 
     atom_text_pos = NULL;
-    atom_text_end = NULL;
     reserved_atom_space = 0;
     atom_space = 0;
     text_list = NULL;

--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -299,6 +299,8 @@ atom_text_alloc(int bytes)
 /*
  * Calculate atom hash value (using the hash algorithm
  * hashpjw from the Dragon Book).
+ *
+ * This cannot be changed, as phash2/[12] depend on it.
  */
 
 static HashValue

--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -531,3 +531,8 @@ erts_get_atom_limit(void)
 {
     return erts_atom_table.limit;
 }
+
+HashValue atom_hvalue(Eterm atom)
+{
+    return atom_tab(atom_val(atom))->slot.bucket.hvalue;
+}

--- a/erts/emulator/beam/atom.c
+++ b/erts/emulator/beam/atom.c
@@ -48,6 +48,25 @@ static ERTS_INLINE void atomic_set_ptr_mb(void **pptr, void *val)
 }
 
 /*
+ * Atomic operations on byte pointers.
+ */
+
+static ERTS_INLINE byte *atomic_read_bytep_mb(byte **ptr)
+{
+    return (byte *) atomic_read_ptr_mb((void **) ptr);
+}
+
+static ERTS_INLINE void atomic_set_bytep_mb(byte **ptr, byte *val)
+{
+    atomic_set_ptr_mb((void **) ptr, (void *) val);
+}
+
+static ERTS_INLINE byte *atomic_cmpxchg_bytep_mb(byte **ptr, byte *new, byte *exp)
+{
+    return (byte *) atomic_cmpxchg_ptr_mb((void **) ptr, new, exp);
+}
+
+/*
  * Atom entry.
  * Internal view, including hash/index table details.
  */
@@ -80,21 +99,6 @@ static ERTS_INLINE AtomInt *atomic_read_atomintp_mb(AtomInt **ptr)
 /*
  * Lock-free operations on AtomInt lists sorted on key (transformed hvalue)
  */
-
-static ERTS_INLINE byte *atomic_read_bytep_mb(byte **ptr)
-{
-    return (byte *) atomic_read_ptr_mb((void **) ptr);
-}
-
-static ERTS_INLINE void atomic_set_bytep_mb(byte **ptr, byte *val)
-{
-    atomic_set_ptr_mb((void **) ptr, (void *) val);
-}
-
-static ERTS_INLINE byte *atomic_cmpxchg_bytep_mb(byte **ptr, byte *new, byte *exp)
-{
-    return (byte *) atomic_cmpxchg_ptr_mb((void **) ptr, new, exp);
-}
 
 /* Find atom by key and name in list sorted on increasing key.
  * Returns atom if found, NULL if not found.

--- a/erts/emulator/beam/atom.h
+++ b/erts/emulator/beam/atom.h
@@ -142,5 +142,6 @@ void dump_atoms(fmtfn_t, void *);
 Uint erts_get_atom_limit(void);
 Eterm erts_atom_get(const char* name, Uint len, ErtsAtomEncoding enc);
 void erts_atom_get_text_space_sizes(Uint *reserved, Uint *used);
+HashValue atom_hvalue(Eterm atom);
 #endif
 

--- a/erts/emulator/beam/atom.h
+++ b/erts/emulator/beam/atom.h
@@ -21,7 +21,6 @@
 #ifndef __ATOM_H__
 #define __ATOM_H__
 
-#include "index.h"
 #include "erl_atom_table.h"
 
 #define MAX_ATOM_CHARACTERS 255
@@ -44,28 +43,20 @@
 
 /*
  * Atom entry.
+ * Public view, without hash/index table details.
  */
 typedef struct atom {
-    IndexSlot slot;  /* MUST BE LOCATED AT TOP OF STRUCT!!! */
     Sint16 len;      /* length of atom name (UTF-8 encoded) */
     Sint16 latin1_chars; /* 0-255 if atom can be encoded in latin1; otherwise, -1 */
     int ord0;        /* ordinal value of first 3 bytes + 7 bits */
     byte* name;      /* name of atom */
 } Atom;
 
-extern IndexTable erts_atom_table;
-
-ERTS_GLB_INLINE Atom* atom_tab(Uint i);
+Atom *atom_tab(Uint i);
 ERTS_GLB_INLINE int erts_is_atom_utf8_bytes(byte *text, size_t len, Eterm term);
 ERTS_GLB_INLINE int erts_is_atom_str(const char *str, Eterm term, int is_latin1);
 
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
-ERTS_GLB_INLINE Atom*
-atom_tab(Uint i)
-{
-    return (Atom *) erts_index_lookup(&erts_atom_table, i);
-}
-
 ERTS_GLB_INLINE int erts_is_atom_utf8_bytes(byte *text, size_t len, Eterm term)
 {
     Atom *a;
@@ -142,6 +133,6 @@ void dump_atoms(fmtfn_t, void *);
 Uint erts_get_atom_limit(void);
 Eterm erts_atom_get(const char* name, Uint len, ErtsAtomEncoding enc);
 void erts_atom_get_text_space_sizes(Uint *reserved, Uint *used);
-HashValue atom_hvalue(Eterm atom);
+UWord atom_hvalue(Eterm atom);
 #endif
 

--- a/erts/emulator/beam/atom.h
+++ b/erts/emulator/beam/atom.h
@@ -140,7 +140,7 @@ void init_atom_table(void);
 void atom_info(fmtfn_t, void *);
 void dump_atoms(fmtfn_t, void *);
 Uint erts_get_atom_limit(void);
-int erts_atom_get(const char* name, Uint len, Eterm* ap, ErtsAtomEncoding enc);
+Eterm erts_atom_get(const char* name, Uint len, ErtsAtomEncoding enc);
 void erts_atom_get_text_space_sizes(Uint *reserved, Uint *used);
 #endif
 

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -3207,7 +3207,8 @@ BIF_RETTYPE list_to_existing_atom_1(BIF_ALIST_1)
     } else {
 	Eterm a;
 	
-	if (erts_atom_get((char *) buf, written, &a, ERTS_ATOM_ENC_UTF8)) {
+	a = erts_atom_get((char *) buf, written, ERTS_ATOM_ENC_UTF8);
+	if (is_value(a)) {
 	    erts_free(ERTS_ALC_T_TMP, (void *) buf);
 	    BIF_RET(a);
 	} else {

--- a/erts/emulator/beam/erl_db_hash.c
+++ b/erts/emulator/beam/erl_db_hash.c
@@ -261,7 +261,7 @@ static ERTS_INLINE int is_pseudo_deleted(HashDbTerm* p)
 
 /* optimised version of make_hash (normal case? atomic key) */
 #define MAKE_HASH(term) \
-    ((is_atom(term) ? (atom_tab(atom_val(term))->slot.bucket.hvalue) : \
+    ((is_atom(term) ? (atom_hvalue(term)) :		\
       make_internal_hash(term, 0)) & MAX_HASH_MASK)
 
 #  define DB_HASH_LOCK_MASK (DB_HASH_LOCK_CNT-1)

--- a/erts/emulator/beam/erl_node_tables.c
+++ b/erts/emulator/beam/erl_node_tables.c
@@ -135,7 +135,8 @@ is_in_de_list(DistEntry *dep, DistEntry *dep_list)
 static HashValue
 dist_table_hash(void *dep)
 {
-    return atom_tab(atom_val(((DistEntry *) dep)->sysname))->slot.bucket.hvalue;
+    Eterm atom = ((DistEntry *) dep)->sysname;
+    return atom_hvalue(atom);
 }
 
 static int
@@ -800,7 +801,8 @@ static HashValue
 node_table_hash(void *venp)
 {
     Uint32 cre = ((ErlNode *) venp)->creation;
-    HashValue h = atom_tab(atom_val(((ErlNode *) venp)->sysname))->slot.bucket.hvalue;
+    Eterm atom = ((ErlNode *) venp)->sysname;
+    HashValue h = atom_hvalue(atom);
 
     return (h + cre) * PRIME0;
 }

--- a/erts/emulator/beam/erl_unicode.c
+++ b/erts/emulator/beam/erl_unicode.c
@@ -2024,8 +2024,11 @@ binary_to_atom(Process* proc, Eterm bin, Eterm enc, int must_exist)
 	    }
 
 	    a = make_atom(lix);
-	} else if (!erts_atom_get((char *)bytes, bin_size, &a, ERTS_ATOM_ENC_LATIN1)) {
-	    goto badarg;
+	} else {
+	    a = erts_atom_get((char *)bytes, bin_size, ERTS_ATOM_ENC_LATIN1);
+	    if (is_non_value(a)) {
+		goto badarg;
+	    }
 	}
 
     } else if (enc == am_utf8 || enc == am_unicode) {
@@ -2041,9 +2044,11 @@ binary_to_atom(Process* proc, Eterm bin, Eterm enc, int must_exist)
 	    }
 
 	    a = make_atom(uix);
-	}
-	else if (!erts_atom_get((char*)bytes, bin_size, &a, ERTS_ATOM_ENC_UTF8)) {
-	    goto badarg;
+	} else {
+	    a = erts_atom_get((char *)bytes, bin_size, ERTS_ATOM_ENC_UTF8);
+	    if (is_non_value(a)) {
+		goto badarg;
+	    }
 	}
     } else {
 	goto badarg;

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -2903,9 +2903,11 @@ dec_atom(ErtsDistExternal *edep, const byte* ep, Eterm* objp)
 	char_enc = ERTS_ATOM_ENC_UTF8;
     dec_atom_common:
         if (edep && (edep->flags & ERTS_DIST_EXT_BTT_SAFE)) {
-	    if (!erts_atom_get((char*)ep, len, objp, char_enc)) {
+	    Eterm atom = erts_atom_get((char*)ep, len, char_enc);
+	    if (is_non_value(atom)) {
                 goto error;
 	    }
+	    *objp = atom;
         } else {
 	    Eterm atom = erts_atom_put(ep, len, char_enc, 0);
 	    if (is_non_value(atom))
@@ -4149,9 +4151,11 @@ dec_term(ErtsDistExternal *edep,
 	    char_enc = ERTS_ATOM_ENC_UTF8;
 dec_term_atom_common:
 	    if (edep && (edep->flags & ERTS_DIST_EXT_BTT_SAFE)) {
-		if (!erts_atom_get((char*)ep, n, objp, char_enc)) {
+		Eterm atom = erts_atom_get((char*)ep, n, char_enc);
+		if (is_non_value(atom)) {
 		    goto error;
 		}
+		*objp = atom;
 	    } else {
 		Eterm atom = erts_atom_put(ep, n, char_enc, 0);
 		if (is_non_value(atom))

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -163,9 +163,10 @@ atom2cix(Eterm atom)
 {
     Uint val;
     ASSERT(is_atom(atom));
-    val = atom_val(atom);
 #ifdef ERTS_ATOM_CACHE_HASH
-    val = atom_tab(val)->slot.bucket.hvalue;
+    val = atom_hvalue(atom);
+#else
+    val = atom_val(atom);
 #endif
 #if ERTS_USE_ATOM_CACHE_SIZE == 256
     return (int) (val & ((Uint) 0xff));

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -915,7 +915,7 @@ tail_recur:
 	break;
     case ATOM_DEF:
 	hash = hash*FUNNY_NUMBER1 +
-	    (atom_tab(atom_val(term))->slot.bucket.hvalue);
+	    atom_hvalue(term);
 	break;
     case SMALL_DEF:
 	{
@@ -944,9 +944,9 @@ tail_recur:
 
 	    hash = hash * FUNNY_NUMBER11 + ep->info.mfa.arity;
 	    hash = hash*FUNNY_NUMBER1 +
-		(atom_tab(atom_val(ep->info.mfa.module))->slot.bucket.hvalue);
+		atom_hvalue(ep->info.mfa.module);
 	    hash = hash*FUNNY_NUMBER1 +
-		(atom_tab(atom_val(ep->info.mfa.function))->slot.bucket.hvalue);
+		atom_hvalue(ep->info.mfa.function);
 	    break;
 	}
 
@@ -957,7 +957,7 @@ tail_recur:
 
 	    hash = hash * FUNNY_NUMBER10 + num_free;
 	    hash = hash*FUNNY_NUMBER1 +
-		(atom_tab(atom_val(funp->fe->module))->slot.bucket.hvalue);
+		atom_hvalue(funp->fe->module);
 	    hash = hash*FUNNY_NUMBER2 + funp->fe->index;
 	    hash = hash*FUNNY_NUMBER2 + funp->fe->old_uniq;
 	    if (num_free > 0) {
@@ -1473,7 +1473,7 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
 	    switch (term & _TAG_IMMED2_MASK) {
 	    case _TAG_IMMED2_ATOM:
 		/* Fast, but the poor hash value should be mixed. */
-		return atom_tab(atom_val(term))->slot.bucket.hvalue;
+		return atom_hvalue(term);
 	    }
 	    break;
 	case _TAG_IMMED1_SMALL:
@@ -1675,10 +1675,10 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
 		Export* ep = *((Export **) (export_val(term) + 1));
 		UINT32_HASH_2
 		    (ep->info.mfa.arity,
-		     atom_tab(atom_val(ep->info.mfa.module))->slot.bucket.hvalue,
+		     atom_hvalue(ep->info.mfa.module),
 		     HCONST);
 		UINT32_HASH
-		    (atom_tab(atom_val(ep->info.mfa.function))->slot.bucket.hvalue,
+		    (atom_hvalue(ep->info.mfa.function),
 		     HCONST_14);
 		goto hash2_common;
 	    }
@@ -1691,7 +1691,7 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
                     .bptr = NULL};
 		UINT32_HASH_2
 		    (ctx.num_free,
-		     atom_tab(atom_val(funp->fe->module))->slot.bucket.hvalue,
+		     atom_hvalue(funp->fe->module),
 		     HCONST);
 		UINT32_HASH_2
 		    (funp->fe->index, funp->fe->old_uniq, HCONST);
@@ -1963,9 +1963,9 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
 		case _TAG_IMMED2_ATOM:
 		    if (hash == 0)
 			/* Fast, but the poor hash value should be mixed. */
-			hash = atom_tab(atom_val(term))->slot.bucket.hvalue;
+			hash = atom_hvalue(term);
 		    else
-			UINT32_HASH(atom_tab(atom_val(term))->slot.bucket.hvalue,
+			UINT32_HASH(atom_hvalue(term),
 				    HCONST_3);
 		    goto hash2_common;
 		case _TAG_IMMED2_NIL:


### PR DESCRIPTION
This converts the atom table to be lock-free. The central change is to use a lock-free hash table, based on the so-called "split-ordered lists" by Shalev and Shavit (Journal of the ACM, May 2006). The index table and text buffer have also been made lock-free, but those were straight-forward.

Even read-only workloads, e.g. `list_to_existing_atom/1` or the initial lookup in `list_to_atom/1`, need to take a shared lock around the atom table, causing cache-line ping-pongs between cores. By making the atom table lock-free, this is avoided. On a 32-core Xeon Platinum 8175M, a benchmark that repeatedly calls `binary_to_existing_atom/1` for all known atoms concurrently on all cores gets 9% faster with this lock-free atom table.

I did not convert the common hash table to be lock-free, since it needs to support deletions, and that gets tricky in a lock-free setting (not the unlinking of the object from the structure but the actual deallocation). The atom table doesn't need deletions. And the common index table is too tied to the common hash table to be useful here.

I couldn't find atomics support for pointers (mainly CAS, but then one also needs atomic read/write) so I implemented them as thin layers on top of the regular atomics. Please let me know if there's a cleaner way of doing this without losing proper typing.

As `atom.c` is almost entirely rewritten I recommend reading the individual commits.

Some TODOs:
* relax atomics to use less than full memory barriers, where applicable
* find a faster way to do the bit-reversal, even is that means using `asm()`
* likewise find a faster way to compute "parent bucket" (clear highest set bit)