### PR TITLE
gh-actions: Add macOS builds

### DIFF
--- a/.github/scripts/build-macos-wxwidgets.sh
+++ b/.github/scripts/build-macos-wxwidgets.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)
+
+if [ -z "$WXWIDGETS_VERSION" ]; then
+  WXWIDGETS_VERSION=3.1.5
+fi
+
+vsn=$WXWIDGETS_VERSION
+curl --fail -LO https://github.com/wxWidgets/wxWidgets/releases/download/v$vsn/wxWidgets-$vsn.tar.bz2
+tar -xf wxWidgets-$vsn.tar.bz2
+mv wxWidgets-$vsn/ wxWidgets
+
+cd wxWidgets
+./configure \
+  --disable-shared \
+  --prefix=$PWD/release \
+  --with-cocoa \
+  --with-macosx-version-min=10.15 \
+  --with-libjpeg=builtin \
+  --with-libtiff=builtin \
+  --with-libpng=builtin \
+  --with-liblzma=builtin \
+  --with-zlib=builtin \
+  --with-expat=builtin
+make
+make install

--- a/.github/scripts/build-macos.sh
+++ b/.github/scripts/build-macos.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)
+export ERL_TOP=`pwd`
+export RELEASE_ROOT=$ERL_TOP/release
+export ERLC_USE_SERVER=true
+
+./otp_build configure \
+  --disable-dynamic-ssl-lib
+./otp_build boot -a
+./otp_build release -a $RELEASE_ROOT
+make release_docs DOC_TARGETS=chunks

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Create initial pre-release tar 
+      - name: Create initial pre-release tar
         run: .github/scripts/init-pre-release.sh
       - name: Upload source tar archive
         uses: actions/upload-artifact@v2
@@ -36,6 +36,53 @@ jobs:
           path: otp_src.tar.gz
 
   build-macos:
+    name: Build Erlang/OTP on macOS
+    runs-on: macos-10.15
+    needs: pack
+    env:
+      WXWIDGETS_VERSION: 3.1.5
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download source archive
+        uses: actions/download-artifact@v2
+        with:
+          name: otp_git_archive
+
+      - name: Cache wxWidgets
+        id: wxwidgets-cache
+        uses: actions/cache@v2
+        with:
+          path: wxWidgets
+          key: wxWidgets-${{ env.WXWIDGETS_VERSION }}-${{ runner.os }}
+
+      - name: Compile wxWidgets
+        if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+        run: .github/scripts/build-macos-wxwidgets.sh
+
+      - name: Compile Erlang
+        run: |
+          tar -xzf ./otp_src.tar.gz
+          export PATH=$PWD/wxWidgets/release/bin:$PATH
+          cd otp
+          $GITHUB_WORKSPACE/.github/scripts/build-macos.sh
+          tar -czf otp_macos_$(cat OTP_VERSION)_x86-64.tar.gz -C release .
+
+      - name: Test Erlang
+        run: |
+          cd otp/release
+          ./Install -sasl $PWD
+          ./bin/erl -noshell -eval 'io:format("~s", [erlang:system_info(system_version)]), halt().'
+          ./bin/erl -noshell -eval 'ok = crypto:start(), io:format("crypto ok~n"), halt().'
+          ./bin/erl -noshell -eval '{wx_ref,_,_,_} = wx:new(), io:format("wx ok~n"), halt().'
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: otp_prebuilt_macos_x86-64
+          path: otp/otp_macos_*_x86-64.tar.gz
+
+  build-ios:
     env:
       RELEASE_LIBBEAM: yes
       TARGET_ARCH: aarch64-apple-ios
@@ -58,7 +105,7 @@ jobs:
           ./otp_build configure --xcomp-conf=./xcomp/erl-xcomp-arm64-ios.conf --without-ssl
           ./otp_build boot -a
           ./otp_build release -a
-      
+
       - name: Package .xcframework
         run: |
           cd otp


### PR DESCRIPTION
Another stab at https://github.com/erlang/otp/issues/4487.

We statically link OpenSSL:

    % otool -L otp/otp/lib/crypto-5.0.2/priv/lib/crypto.so
    otp/otp/lib/crypto-5.0.2/priv/lib/crypto.so:
            /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)

See https://rentzsch.tumblr.com/post/33696323211/wherein-i-write-apples-technote-about-openssl-on for rationale.

We also statically link wxWidgets:

    % otool -L otp/otp/lib/wx-2.0.1/priv/wxe_driver.so
    otp/otp/lib/wx-2.0.1/priv/wxe_driver.so:
            /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
            /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 164.0.0)
            /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 23.0.0)
            /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore (compatibility version 1.2.0, current version 1.11.0)
            /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox (compatibility version 1.0.0, current version 1000.0.0)
            /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.100.5)
            /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
            /System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
            /System/Library/Frameworks/WebKit.framework/Versions/A/WebKit (compatibility version 1.0.0, current version 611.1.21)
            /usr/lib/libexpat.1.dylib (compatibility version 7.0.0, current version 8.0.0)
            /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
            /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 59754.100.106)
            /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
            /usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
            /usr/local/opt/xz/lib/liblzma.5.dylib (compatibility version 8.0.0, current version 8.5.0)
            /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 905.6.0)

Worth remembering that when downloading the release from GitHub via Web browser, macOS will put the file under quarantine:

    % ~/Downloads% xattr -l otp_macos_24.0.3.tar
    com.apple.quarantine: 0082;60e71fca;Safari;

and after unpacking the executables will be put under quarantine as well, meaning they cannot be executed and you'll get a security warning. Here's how we can remove the tarball from quarantine:

    % xattr -d otp_macos_24.0.3.tar

This will not be a problem when downloading the tarball with curl, etc.