### PR TITLE
Display value of '$process_label' in observer

### DIFF
--- a/lib/runtime_tools/src/appmon_info.erl
+++ b/lib/runtime_tools/src/appmon_info.erl
@@ -709,9 +709,17 @@ format(P) when is_pid(P), node(P) /= node() ->
     pid_to_list(P) ++ " " ++ atom_to_list(node(P));
 format(P) when is_pid(P) ->
     case process_info(P, registered_name) of
-	{registered_name, Name} -> atom_to_list(Name);
-	_ -> pid_to_list(P)
-    end;
+		{registered_name, Name} -> atom_to_list(Name);
+		_ ->
+			case sys:get_label(P) of
+				undefined ->
+					pid_to_list(P);
+				Label when is_list(Label); is_binary(Label) ->
+					io_lib:format("~ts ~tp", [Label, P]);
+				Label ->
+					io_lib:format("~tp ~tp", [Label, P])
+			end
+	end;
 format(P) when is_port(P) ->
     case erlang:port_info(P, id) of
         undefined -> "port closed";

--- a/lib/stdlib/src/sys.erl
+++ b/lib/stdlib/src/sys.erl
@@ -31,6 +31,7 @@
 	 install/2, install/3, remove/2, remove/3]).
 -export([handle_system_msg/6, handle_system_msg/7, handle_debug/4,
 	 print_log/1, get_log/1, get_debug/3, debug_options/1, suspend_loop_hib/6]).
+-export([put_label/1, get_label/0, get_label/1]).
 
 -deprecated([{get_debug,3,
               "incorrectly documented and only for internal use. Can often "
@@ -776,3 +777,20 @@ debug_options([_ | T], Debug) ->
     debug_options(T, Debug);
 debug_options([], Debug) -> 
     Debug.
+
+-spec put_label(Label :: any()) -> any().
+put_label(Label) ->
+    put('$process_label', Label).
+
+-spec get_label() -> any().
+get_label() ->
+    get_label(self()).
+
+-spec get_label(Pid :: pid()) -> any().
+get_label(Pid) when is_pid(Pid) ->
+    case process_info(Pid, dictionary) of
+        {dictionary, D} ->
+            proplists:get_value('$process_label', D);
+        _ ->
+            undefined
+    end.


### PR DESCRIPTION
In http://erlang.org/pipermail/erlang-questions/2021-May/100972.html, it was suggested (after some discussion) that non-unique process labels would make using `observer` nicer. I followed this up here: http://erlang.org/pipermail/erlang-questions/2021-June/101152.html

This is a first stab at implementing that, for feedback.

It defines a convention where the process dictionary can contain `'$process_label'`, which is assumed to be an Erlang string (list of chars). If there's interest in the concept, I'll look at extending `gen_server` et. al. to support this through options.

I'm currently using it to make it easier to observe a particularly nested supervision tree.