### PR TITLE
ci: Cache wxWidgets on Windows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,9 +7,6 @@
 ## not possible so we need to rebuild all of Erlang/OTP multiple
 ## times.
 ##
-## Also once the windows runner supports WSL we should implement
-## support for building Erlang/OTP here.
-##
 ## When ghcr.io support using the GITHUB_TOKEN we should migrate
 ## over to use it instead as that should allow us to use the
 ## built-in caching mechanisms of docker/build-push-action@v2.
@@ -43,6 +40,8 @@ jobs:
     defaults:
       run:
         shell: wsl-bash {0}
+    env:
+      WXWIDGETS_VERSION: 3.1.4
     name: Build Erlang/OTP on Windows
     runs-on: windows-latest
     needs: pack
@@ -60,28 +59,34 @@ jobs:
           choco install openssl
           move "c:\\Program Files\\OpenSSL-Win64" "c:\\OpenSSL-Win64"
 
+      - name: Cache wxWidgets
+        id: wxwidgets-cache
+        uses: actions/cache@v2
+        with:
+          path: wxWidgets
+          key: wxWidgets-${{ env.WXWIDGETS_VERSION }}-${{ runner.os }}
+
       - name: Download wxWidgets
+        if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p /mnt/c/opt/local64/pgm/
-          cd /mnt/c/opt/local64/pgm/
-          wget https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.zip
-          unzip wxWidgets-3.1.4.zip -d wxWidgets-3.1.4
-          sed -i -r -e 's/wxUSE_POSTSCRIPT +0/wxUSE_POSTSCRIPT 1/' /mnt/c/opt/local64/pgm/wxWidgets-3.1.4/include/wx/msw/setup.h
-          sed -i -r -e 's/wxUSE_WEBVIEW_EDGE +0/wxUSE_WEBVIEW_EDGE 1/' /mnt/c/opt/local64/pgm/wxWidgets-3.1.4/include/wx/msw/setup.h
+          wget https://github.com/wxWidgets/wxWidgets/releases/download/v${{ env.WXWIDGETS_VERSION }}/wxWidgets-${{ env.WXWIDGETS_VERSION }}.zip
+          unzip wxWidgets-${{ env.WXWIDGETS_VERSION }}.zip -d wxWidgets
+          sed -i -r -e 's/wxUSE_POSTSCRIPT +0/wxUSE_POSTSCRIPT 1/' wxWidgets/include/wx/msw/setup.h
+          sed -i -r -e 's/wxUSE_WEBVIEW_EDGE +0/wxUSE_WEBVIEW_EDGE 1/' wxWidgets/include/wx/msw/setup.h
 
       - name: Install WebView2
+        if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
         shell: cmd
         run: |
-          c:
-          cd c:\\opt\\local64\\pgm\\wxWidgets-3.1.4\\3rdparty
+          cd wxWidgets\\3rdparty
           nuget install Microsoft.Web.WebView2 -Version 1.0.705.50 -Source https://api.nuget.org/v3/index.json
           rename Microsoft.Web.WebView2.1.0.705.50 webview2
 
       - name: Build wxWidgets
+        if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
         shell: cmd
         run: |
-          c:
-          cd c:\\opt\\local64\\pgm\\wxWidgets-3.1.4\\build\\msw
+          cd wxWidgets\\build\\msw
           call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\Auxiliary\\Build\\vcvars64.bat"
           nmake TARGET_CPU=amd64 BUILD=release SHARED=0 DIR_SUFFIX_CPU= -f makefile.vc
 
@@ -92,6 +97,8 @@ jobs:
 
       - name: Compile Erlang
         run: |
+          mkdir -p /mnt/c/opt/local64/pgm/
+          cp -R wxWidgets /mnt/c/opt/local64/pgm/wxWidgets-${{ env.WXWIDGETS_VERSION }}
           tar -xzf ./otp_src.tar.gz
           cd otp
           export ERL_TOP=`pwd`
@@ -100,7 +107,7 @@ jobs:
           if cat erts/CONF_INFO || cat lib/*/CONF_INFO || cat lib/*/SKIP || cat lib/SKIP-APPLICATIONS; then exit 1; fi
           ./otp_build boot -a
           ./otp_build release -a
-          cp /mnt/c/opt/local64/pgm/wxWidgets-3.1.4/3rdparty/webview2/runtimes/win-x64/native/WebView2Loader.dll $ERL_TOP/release/win32/erts-*/bin/
+          cp /mnt/c/opt/local64/pgm/wxWidgets-${{ env.WXWIDGETS_VERSION }}/3rdparty/webview2/runtimes/win-x64/native/WebView2Loader.dll $ERL_TOP/release/win32/erts-*/bin/
           ./otp_build installer_win32
 
       - name: Upload installer

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,6 +69,7 @@ jobs:
       - name: Download wxWidgets
         if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
         run: |
+          rm -rf wxWidgets*
           wget https://github.com/wxWidgets/wxWidgets/releases/download/v${{ env.WXWIDGETS_VERSION }}/wxWidgets-${{ env.WXWIDGETS_VERSION }}.zip
           unzip wxWidgets-${{ env.WXWIDGETS_VERSION }}.zip -d wxWidgets
           sed -i -r -e 's/wxUSE_POSTSCRIPT +0/wxUSE_POSTSCRIPT 1/' wxWidgets/include/wx/msw/setup.h


### PR DESCRIPTION
This shaves off ~7min from build time.

We put `~/wxWidgets`, as opposed to `/mnt/c/opt/local64/pgm/wxWidgets-*`, because with the latter restoring the cache doesn't work, it silently fails.