### PR TITLE
ssl: Use new inet:monitor/1 to monitor listen sockets

### DIFF
--- a/lib/ssl/src/ssl_server_session_cache.erl
+++ b/lib/ssl/src/ssl_server_session_cache.erl
@@ -255,5 +255,5 @@ monitor_listener(ssl_unknown_listener) ->
     %% Backwards compatible Erlang node
     %% global process.
     undefined;
-monitor_listener(Listen) when is_port(Listen) ->
-    erlang:monitor(port, Listen).
+monitor_listener(Listen) ->
+    inet:monitor(Listen).


### PR DESCRIPTION
To be able to fully work with new gen_tcp socket backend.

Also Make sure TLS-1.3 server session ticket handler processes
monitor the listen socket so that it can terminate gracefully.