### PR TITLE
'extprg' needs to be properly addressed

### DIFF
--- a/system/doc/tutorial/c_port.xmlsrc
+++ b/system/doc/tutorial/c_port.xmlsrc
@@ -158,7 +158,7 @@ Eshell V4.9.1.2 (abort with ^G)
 {ok,complex1}</pre>
     <p><em>Step 3.</em> Run the example:</p>
     <pre>
-2> <input>complex1:start("extprg").</input>
+2> <input>complex1:start("./extprg").</input>
 &lt;0.34.0>
 3> <input>complex1:foo(3).</input>
 4


### PR DESCRIPTION
Without using "./extprg", an error occurs saying:
`sh: line 0: exec: extprg: not found`