### PR TITLE
xmerl: Fix the XPath normalize-space() function

### DIFF
--- a/lib/xmerl/src/xmerl_xpath_pred.erl
+++ b/lib/xmerl/src/xmerl_xpath_pred.erl
@@ -758,8 +758,8 @@ mk_boolean(C, Expr) ->
 normalize([H|T]) when ?whitespace(H) ->
     normalize(T);
 normalize(Str) ->
-    ContF = fun(_ContF, RetF, _S) ->
-		    RetF()
+    ContF = fun(_ContF, RetF, S) ->
+		    RetF(S)
 	    end,
     normalize(Str,
 	      #xmerl_scanner{acc_fun = fun() -> exit(acc_fun) end,
@@ -770,7 +770,7 @@ normalize(Str) ->
 
 
 normalize(Str = [H|_], S, Acc) when ?whitespace(H) ->
-    case xmerl_scan:accumulate_whitespace(Str, S, preserve, Acc) of
+    case xmerl_scan:accumulate_whitespace(Str, S, normalize, Acc) of
 	{" " ++ Acc1, [], _S1} ->
 	    lists:reverse(Acc1);
 	{Acc1, [], _S1} ->

--- a/lib/xmerl/test/xmerl_SUITE.erl
+++ b/lib/xmerl/test/xmerl_SUITE.erl
@@ -60,7 +60,8 @@ groups() ->
      {ticket_tests, [],
       [ticket_5998, ticket_7211, ticket_7214, ticket_7430,
        ticket_6873, ticket_7496, ticket_8156, ticket_8697,
-       ticket_9411, ticket_9457, ticket_9664_schema, ticket_9664_dtd]},
+       ticket_9411, ticket_9457, ticket_9664_schema, ticket_9664_dtd,
+       xpath_normalize]},
      {app_test, [], [{xmerl_app_test, all}]},
      {appup_test, [], [{xmerl_appup_test, all}]}].
 
@@ -626,6 +627,17 @@ ticket_9664_dtd(Config) ->
     {E, _} = xmerl_scan:file(datadir_join(Config,[misc,"ticket_9664_dtd.xml"]),[{validation, true}]),
     ok.
 
+%% Test that normalize-space() does not cause runtime error
+xpath_normalize(Config) ->
+    {E, _} = xmerl_scan:string(
+               "<table><x>User Name</x><x> User  Name </x><x>foo</x></table>",
+               []
+              ),
+    [ #xmlElement{name=x, content=[#xmlText{value="User Name"}]}
+    , #xmlElement{name=x, content=[#xmlText{value=" User  Name "}]}
+    ]
+        = xmerl_xpath:string("//x[normalize-space() = 'User Name']", E),
+    ok.
 
 %%======================================================================
 %% Support Functions


### PR DESCRIPTION
This pull request fixes two issues with `normalize-space()` where:
1. Evaluation of the function call caused the `badarith` error to be thrown; and
1. The call to `xmerl_scan:accumulate_whitespace/4` in the implementation of `normalize/1` passed the argument `preserve` instead of the correct atom `normalize`.