### PR TITLE
compiler: Comment BEAM assembly with callee names in clear-text

### DIFF
--- a/lib/compiler/test/compile_SUITE_data/asm_labels.erl
+++ b/lib/compiler/test/compile_SUITE_data/asm_labels.erl
@@ -1,0 +1,47 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2021. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%% A module which when compiled to a BEAM assembly listing will
+%% contain call instructions with comments containing the called
+%% function in clear text.
+
+-module(asm_labels).
+
+-export([foo/0, bar/0]).
+
+%% Expected to generate a `call_only` instruction
+foo() ->
+    foo(10).
+
+%% Expected to generate a `call` instruction
+foo(0) ->
+    17;
+foo(N) ->
+    foo(N-1) + 1.
+
+%% Expected to generate a `call_last` instruction
+bar() ->
+    receive
+	X ->
+	    bar(X)
+    end.
+
+bar([]) ->
+    ok.


### PR DESCRIPTION
Looking at BEAM assembly listings, figuring out where a local call
goes requires you to keep track of which `{f,<index>}`-label
corresponds to which function. This patch increases the readability of
the assembly listing by annotating each call instruction with a
comment containing the name of the called function.

Instead of, for example, `{call,1,{f,4}}.`, the listing will now say
`{call,1,{f,4}}. % foo/1`.