### PR TITLE
Early draft: showing non-unique labels in observer

### DIFF
--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -33,7 +33,8 @@
 	 init_ack/1, init_ack/2,
 	 init_p/3,init_p/5,format/1,format/2,format/3,report_cb/2,
 	 initial_call/1,
-         translate_initial_call/1,
+   translate_initial_call/1,
+   get_label/1,
 	 stop/1, stop/3]).
 
 %% Internal exports.
@@ -462,6 +463,13 @@ translate_initial_call(DictOrPid) ->
 	false ->
 	    {?MODULE,init_p,5}
     end.
+
+%% add spec
+get_label(Pid) ->
+  case get_dictionary(Pid, '$label') of
+    {'$label', Label} -> Label;
+    undefined -> undefined
+  end.
 
 %% -----------------------------------------------------
 %% Fetch the initial call information exactly as stored


### PR DESCRIPTION
This PR is nowhere close to complete. I'm posting it in the hopes of getting guidance and help to carry it through.

In observer, we sometimes have a number of "generic" processes, like database connections in a pool.
Because they do not have registered names, they are labeled only with a pid, which is not informative.
The process architecture would be more understandable if we could use non-unique labels, like `database_connection`. 

I brought this up on the erlang-questions mailing list a while back (see "Support for non-unique process labels?") and people seemed to like the idea.

I am inexperienced with Erlang (I mostly use Elixir), and I was not at all familiar with the code behind observer, but I've stumbled far enough to get a tiny demo working:

<img width="180" alt="non_unique_labels" src="https://user-images.githubusercontent.com/338814/126840367-ce16e848-b058-4026-9ce7-aaa12a42a653.png">


Here, processes which do not have a registered name, but *do* have a `'$label'` entry in their dictionary, are labeled accordingly in observer.

There are probably numerous things wrong with my approach so far.
And manually adding a label to the process dictionary is not very discoverable - ideally we could specify this label when (for example) starting a `gen_server`.

Does this seem like a worthwhile effort? If so, any pointers about how to proceed?