### PR TITLE
Fix process_info that can hang waiting for reply

### DIFF
--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -4120,6 +4120,8 @@ handle_process_info(Process *c_p, ErtsSigRecvTracing *tracing,
             ASSERT(tracing);
 
             if (*next_nm_sig != &c_p->sig_qs.cont) {
+                if (c_p->sig_qs.save == &c_p->sig_qs.cont)
+                    c_p->sig_qs.save = c_p->sig_qs.last;
                 if (ERTS_SIG_IS_RECV_MARKER(c_p->sig_qs.cont)) {
                     ErtsRecvMarker *markp = (ErtsRecvMarker *) c_p->sig_qs.cont;
                     markp->prev_next = c_p->sig_qs.last;

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -1456,7 +1456,25 @@ define etp-sig-int
 	printf "!DIST_SPAWN_REPLY[%d]", $etp_sig_type
       else
       if $etp_sig_op == 15
+	printf "!ALIAS[%d]", $etp_sig_type
+      else
+      if $etp_sig_op == 16
 	printf "!RECV_MARKER[%d]", $etp_sig_type
+      else
+      if $etp_sig_op == 17
+	printf "!UNLINK_ACK[%d]", $etp_sig_type
+      else
+      if $etp_sig_op == 18
+	printf "!ADJUST_MSGQ[%d]", $etp_sig_type
+      else
+      if $etp_sig_op == 255
+	printf "->OFFSET_MARKER"
+      else
+	printf "UNKNOWN SIGNAL %d [%d]", $etp_sig_op, $etp_sig_type
+      end
+      end
+      end
+      end
       end
       end
       end
@@ -1511,6 +1529,9 @@ define etp-sigq-int
     end
     set $etp_sig = $etp_sig_next
   end
+  if $etp_sig_save && $etp_sig_save == ($arg2)
+    printf "\n     %% <== SAVE"
+  end
   printf "]\n\n"
   printf "    Message signals: %d\n", $etp_sigq_msig_len
   printf "    Non-message signals: %d\n\n", $etp_sigq_nmsig_len
@@ -1526,10 +1547,10 @@ define etp-sigq-flags-int
     printf "delayed-sigq-len "
   end
   if ($arg0 & (1 << 5))
-    printf "deferred-save "
+    printf "wait-handle-sig "
   end
   if ($arg0 & (1 << 4))
-    printf "deferred-saved-last "
+    printf "handling-sig "
   end
   if ($arg0 & (1 << 3))
     printf "local-signals-only "
@@ -1566,11 +1587,11 @@ define etp-sigqs
   printf "  Msgq Flags: "
   etp-sigq-flags $proc_int
   printf "  --- Inner signal queue (message queue) ---\n"
-  etp-sigq-int ($proc_int)->sig_qs.first ($proc_int)->sig_qs.save
+  etp-sigq-int ($proc_int)->sig_qs.first ($proc_int)->sig_qs.save ($proc_int)->sig_qs.last
   printf "  --- Middle signal queue ---\n"
-  etp-sigq-int ($proc_int)->sig_qs.cont ($proc_int)->sig_qs.save
+  etp-sigq-int ($proc_int)->sig_qs.cont ($proc_int)->sig_qs.save ($proc_int)->sig_qs.cont_last
   printf "  --- Outer queue ---\n"
-  etp-sigq-int ($proc_int)->sig_inq.first ($proc_int)->sig_qs.save
+  etp-sigq-int ($proc_int)->sig_inq.first ($proc_int)->sig_qs.save ($proc_int)->sig_inq.last
 end
 
 define etp-msgq


### PR DESCRIPTION
With multiple reusable receive markers, marker that is marked
to remove may be followed by process_info signal, which will
also be handled within the loop in erts_proc_sig_handle_incoming.

It is possible that process_info moves messages up to the next
non-message signal from the middle to inner queue. If there was a
receive marker at the very beginning of the middle queue, it
would set save pointer to sig_qs.cont, which will be overwritten
when linking middle queue head into inner queue. This would make
save pointer to skip all messages that were in between of removed
receive marker and process_info request.

To observe this behaviour using a debugger, run the test case
provided with a breakpoint set to handle_process_info part where
it reassigns c_p->sig_qs.cont to the next non-message signal
(**next_nm_sig)

Test case runs a process that triggers receive marker to enter
its middle queue. Currently it's done with process_info BIF, but
can also be triggered with erlang:cancel_timer (which also
places receive marker). Additional processes are sending
process_info requesting to move messages into inner queue, which
eventually makes middle queue to contain:
 - receive marker that is set to be removed but set_save
 - reply tuple ({Ref, Dictionary})
 - process_info request moving previous message into inner queue

Receive marker gets removed from the middle queue after setting
save pointer to sig_qs.cont, then erts_proc_sig_handle_incoming
proceeds to process_info. Which moves reply tuple into the
inner queue, but save pointer is left untouched pointing to the
head of the middle queue, which is beyond the reply. This
way reply never gets matched (as save pointer has already
moved past it), and process_info hangs forever.