### PR TITLE
Correct distribution handshake challenge cookie handling

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -4,7 +4,7 @@
 <comref>
   <header>
     <copyright>
-      <year>1996</year><year>2020</year>
+      <year>1996</year><year>2021</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -626,6 +626,12 @@ $ <input>erl \
       <tag><c><![CDATA[-setcookie Cookie]]></c></tag>
       <item>
         <p>Sets the magic cookie of the node to <c><![CDATA[Cookie]]></c>; see
+          <seemfa marker="erlang#set_cookie/2">
+          <c>erlang:set_cookie/2</c></seemfa>.</p>
+      </item>
+      <tag><c><![CDATA[-setcookie Node Cookie]]></c></tag>
+      <item>
+        <p>Sets the magic cookie of Node to <c><![CDATA[Cookie]]></c>; see
           <seemfa marker="erlang#set_cookie/2">
           <c>erlang:set_cookie/2</c></seemfa>.</p>
       </item>

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2020. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ all() ->
      table_waste, net_setuptime, inet_dist_options_options,
      {group, monitor_nodes},
      erl_uds_dist_smoke_test,
-     erl_1424].
+     erl_1424, simultaneous_remote_linking].
 
 groups() -> 
     [{monitor_nodes, [],

--- a/system/doc/reference_manual/distributed.xml
+++ b/system/doc/reference_manual/distributed.xml
@@ -4,7 +4,7 @@
 <chapter>
   <header>
     <copyright>
-      <year>2003</year><year>2017</year>
+      <year>2003</year><year>2021</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -272,6 +272,10 @@ dilbert@uab</pre>
       <row>
         <cell align="left" valign="middle"><c>-setcookie Cookie</c></cell>
         <cell align="left" valign="middle">Same as calling <c>erlang:set_cookie(node(), Cookie)</c>.</cell>
+      </row>
+      <row>
+        <cell align="left" valign="middle"><c>-setcookie Node Cookie</c></cell>
+        <cell align="left" valign="middle">Same as calling <c>erlang:set_cookie(Node, Cookie)</c>.</cell>
       </row>
       <row>
         <cell align="left" valign="middle"><c>-sname Name</c></cell>


### PR DESCRIPTION
This is an alternative correction (to the pull request #5062) of issue #5063, that I believe to be correct.

It is based on PR #5062 and reverts the protocol change in `dist_util.erl` but keeps the test case.  The test case is modified in a later commit to use hidden slave nodes, which is a harder problem and a better test, hopefully.

The functional change is instead in `auth.erl` to return `{OurCookie,OtherCookie}` as appropriate for the connection, and a possibility to specify other nodes' cookies on the command line has been added.

This correction uses `OurCookie` and `OtherCookie` in the handshake, both for incoming and for outgoing connections. `OtherCookie` is used for generating the challenge message to the other party, and `OurCookie` when verifying incoming challenge message.  This way both sides' cookies are used in all connection setups, and both sides' cookies has to be configured correctly on both sides before connection setup.

The command line argument `-setcookie` is augmented to allow arity 2 arguments, so `-setcookie OurCookie` as before sets the starting nodes' cookie, and `-setcookie OtherNode OtherCookie` sets the cookie to be used for `OtherNode` using `erlang:set_cookie/2`.  This facilitates starting a node with usable cookies without having to run code before starting the distribution so utilities like `slave:start/*` works.

That a node needs to have the other nodes' cookie for both incoming and outgoing connections to succeed has been documented since OTP_R11B, but it seems to have been broken since at least OTP_R12B.  In OTP_R7B (the oldest release I have access to) it was possible to configure a cookie pair `{CookieIn,CookieOut}` for a specific node (Using `erlang:set_cookie/2`), although a comment in `erlang.erl` claims that that feature is discarded, indicating that our cookie should be `CookieIn` and the other node's cookie should be `CookieOut`.  Getting a such a cookie pair was disabled in OTP_R12B, maybe by accident, thinking that `OurCookie` and `OtherCookie` had replaced the cookie pair, despite that detail had never been implemented.  Setting a cookie pair was disabled in OTP_R14B01.

So, using a cookie pair has not worked since R12B, and using our for incoming and the other's for outgoing as a cookie pair has never been implemented.  Until in this pull request.  Now it will finally be possible to connect nodes with different cookies as it was documented in OTP_R10B and clarified in OTP_R12B.  The same explanation remains today in http://erlang.org/doc/reference_manual/distributed.html#security, fifth paragraph:
> For a node Node1 with magic cookie Cookie to be able to connect to, or accept a connection from, another node Node2 with a different cookie DiffCookie, the function erlang:set_cookie(Node2, DiffCookie) must first be called at Node1. Distributed systems with multiple user IDs can be handled in this way.