### PR TITLE
crypto: Add /opt/homebrew/opt/openssl to standard locations

### DIFF
--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -5528,7 +5528,20 @@ printf "%s\n" "#define SIZEOF_VOID_P $ac_cv_sizeof_void_p" >>confdefs.h
 
 
 
-std_ssl_locations="/usr/local /usr/sfw /usr /opt/local /usr/pkg /usr/local/openssl /usr/local/opt/openssl /usr/lib/openssl /usr/openssl /usr/local/ssl /usr/lib/ssl /usr/ssl /"
+std_ssl_locations="\
+/usr/local \
+/usr/sfw \
+/usr \
+/opt/local \
+/usr/pkg \
+/usr/local/openssl \
+/usr/local/opt/openssl \
+/usr/lib/openssl \
+/usr/openssl \
+/usr/local/ssl \
+/usr/lib/ssl \
+/usr/ssl \
+/"
 
 
 # Check whether --with-ssl was given.

--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -5536,6 +5536,7 @@ std_ssl_locations="\
 /usr/pkg \
 /usr/local/openssl \
 /usr/local/opt/openssl \
+/opt/homebrew/opt/openssl \
 /usr/lib/openssl \
 /usr/openssl \
 /usr/local/ssl \

--- a/lib/crypto/configure.ac
+++ b/lib/crypto/configure.ac
@@ -84,6 +84,7 @@ std_ssl_locations="\
 /usr/pkg \
 /usr/local/openssl \
 /usr/local/opt/openssl \
+/opt/homebrew/opt/openssl \
 /usr/lib/openssl \
 /usr/openssl \
 /usr/local/ssl \

--- a/lib/crypto/configure.ac
+++ b/lib/crypto/configure.ac
@@ -76,7 +76,20 @@ dnl use "PATH/include" and "PATH/lib".
 
 AC_CHECK_SIZEOF(void *)
 
-std_ssl_locations="/usr/local /usr/sfw /usr /opt/local /usr/pkg /usr/local/openssl /usr/local/opt/openssl /usr/lib/openssl /usr/openssl /usr/local/ssl /usr/lib/ssl /usr/ssl /"
+std_ssl_locations="\
+/usr/local \
+/usr/sfw \
+/usr \
+/opt/local \
+/usr/pkg \
+/usr/local/openssl \
+/usr/local/opt/openssl \
+/usr/lib/openssl \
+/usr/openssl \
+/usr/local/ssl \
+/usr/lib/ssl \
+/usr/ssl \
+/"
 			
 AC_ARG_WITH(ssl,
 AS_HELP_STRING([--with-ssl=PATH], [base location of OpenSSL include and lib directories])


### PR DESCRIPTION
crypto: Format ssl standard locations
crypto: Add /opt/homebrew/opt/openssl to standard locations

This is the default location on Homebrew on M1 Macs.

Before this patch:

    $ ./otp_build configure
    (...)
    *********************************************************************
    **********************  APPLICATIONS DISABLED  **********************
    *********************************************************************

    crypto         : No usable OpenSSL found
    jinterface     : No Java compiler found
    odbc           : ODBC library - link check failed
    ssh            : No usable OpenSSL found
    ssl            : No usable OpenSSL found

After this patch:

    $ ./otp_build configure
    (...)
    *********************************************************************
    **********************  APPLICATIONS DISABLED  **********************
    *********************************************************************

    jinterface     : No Java compiler found
    odbc           : ODBC library - link check failed