### PR TITLE
Add is_map_key/2 as a guard BIF to the reference documentation

### DIFF
--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -1085,6 +1085,10 @@ handle_call(change, From, #{ state := start } = S) ->
 			   in the <c>erlang</c> module
 		  </item>
 		  <item>
+			  <seemfa marker="erts:erlang#is_map_key/2">is_map_key/2</seemfa>
+			   in the <c>erlang</c> module
+		  </item>
+		  <item>
 			  <seemfa marker="erts:erlang#map_get/2">map_get/2</seemfa>
 			   in the <c>erlang</c> module
 		  </item>
@@ -1756,6 +1760,9 @@ end</pre>
       </row>
       <row>
         <cell align="left" valign="middle"><c>hd(List)</c></cell>
+      </row>
+      <row>
+        <cell align="left" valign="middle"><c>is_map_key(Key, Map)</c></cell>
       </row>
       <row>
         <cell align="left" valign="middle"><c>length(List)</c></cell>


### PR DESCRIPTION
I noticed [`is_map_key/2`](https://erlang.org/doc/man/erlang.html#is_map_key-2) is allowed in guard tests, but the reference documentation currently does not list it, neither the [Maps in Guards](https://erlang.org/doc/reference_manual/expressions.html#maps-in-guards) section, nor the [Guard Expressions](https://erlang.org/doc/reference_manual/expressions.html#guard-expressions) section. This PR adds it to the reference documentation. I added it to the table of type test BIFs since this is where the rest of the `is_...` functions are listed. 
