### PR TITLE
tools: emacs: add regexp for Edoc errors

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -5581,6 +5581,15 @@ future, a new shell on an already running host will be started."
   (interactive)
   (call-interactively erlang-next-error-function))
 
+(defconst erlang-edoc-error-regexp
+  "^\\(.*\\), function \\(.*\\): at line \\([0-9]+\\):"
+  "Regexp matching Edoc error message.")
+
+(add-to-list 'compilation-error-regexp-alist-alist
+             `(erlang-edoc
+               ,erlang-edoc-error-regexp
+               1 3 nil 1 nil (2 font-lock-function-name-face)))
+
 
 
 ;;;


### PR DESCRIPTION
<details>
<summary>Compilation example</summary>

![image](https://user-images.githubusercontent.com/4840430/128613689-9829f5fc-5127-4dfb-9157-0106e05d90e4.png)

</details>