### PR TITLE
erts: Fix FRAME_POINTER to be valid when stack adjusted

### DIFF
--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -1661,6 +1661,7 @@ erts_hibernate(Process* c_p, Eterm* reg)
         ASSERT(c_p->stop[0] == make_cp(beam_normal_exit));
         break;
     case ERTS_FRAME_LAYOUT_FP_RA:
+        FRAME_POINTER(c_p) = &c_p->stop[0];
         ASSERT(c_p->stop[0] == make_cp(NULL));
         ASSERT(c_p->stop[1] == make_cp(beam_normal_exit));
         break;


### PR DESCRIPTION
The frame pointer is not used by anything after hibernate, but some
ASSERTS assume that it is correct so we set it to the correct value
after the stack has been dropped when we hibernate.

Fault found by Max Federov and can be reproduced by running
hibernate_SUITE with the flags -emu_type debug +JPperf true.