### PR TITLE
edoc: Use local definition of context

### DIFF
--- a/lib/edoc/src/edoc_extract.erl
+++ b/lib/edoc/src/edoc_extract.erl
@@ -41,6 +41,7 @@
 
 -type filename() :: file:filename().
 -type proplist() :: proplists:proplist().
+-type context() :: module | footer | function | overview | single.
 
 %% @doc Like {@link source/5}, but reads the syntax tree and the
 %% comments from the specified file.
@@ -233,7 +234,7 @@ add_macro_defs(Defs0, Opts, Env) ->
 
 -spec file(File, Context, Env, Opts) -> {ok, Tags} | {error, Reason} when
       File :: filename(),
-      Context :: edoc_tags:tag_flag(),
+      Context :: context(),
       Env :: edoc:env(),
       Opts :: proplist(),
       Tags :: [term()],
@@ -264,7 +265,7 @@ file(File, Context, Env, Opts) ->
 
 -spec text(Text, Context, Env, Opts) -> Tags when
       Text :: string(),
-      Context :: overview,
+      Context :: context(),
       Env :: edoc:env(),
       Opts :: proplist(),
       Tags :: [term()].


### PR DESCRIPTION
The module edoc_tags is an internal module and thus
we cannot refer to a type within it. So instead we
inline the type into edoc_extract so that the user
can view it.

Closes #5058