### PR TITLE
erts: Fix memcpy buffer overwrite

### DIFF
--- a/erts/emulator/drivers/unix/ttsl_drv.c
+++ b/erts/emulator/drivers/unix/ttsl_drv.c
@@ -1105,7 +1105,7 @@ static int insert_buf(byte *s, int n)
                 if (ch == '\n')
                     outc('\n');
 	    if (llen > lpos) {
-		memcpy(lbuf, lbuf + lpos, llen - lpos);
+		memmove(lbuf, lbuf + lpos, llen - lpos);
 	    }
 	    llen -= lpos;
 	    lpos = buffpos = 0;


### PR DESCRIPTION
It is possible for lbuf and lbuf+pos to overlap so use memmove

Closes #5116