### PR TITLE
Fix broken "make test" in erts/emulator

### DIFF
--- a/erts/emulator/Makefile
+++ b/erts/emulator/Makefile
@@ -23,3 +23,5 @@
 
 include $(ERL_TOP)/make/run_make.mk
 
+include $(ERL_TOP)/make/app_targets.mk
+


### PR DESCRIPTION
The test target in "$(ERL_TOP)/make/app_targets.mk" that is included
in the end of "erts/emulator/Makefile.in" is not picked up by make
when executing make in the emulator directory. The reason for this is
that the file generated from "erts/emulator/Makefile.in" is executed
by an external make call. Unfortunately, this makes running commands
such as the following not work as intended:

(cd $ERL_TOP/erts/emulator && make ARGS="-suite binary_SUITE -case deep_bitstr_lists" test)

Putting "include $(ERL_TOP)/make/app_targets.mk" in the end of
"erts/emulator/Makefile.in" fixes the problem.