### PR TITLE
erl_docgen: Fix generating docs chunk entry for `<seeerl>`

### DIFF
--- a/lib/erl_docgen/src/docgen_xml_to_chunk.erl
+++ b/lib/erl_docgen/src/docgen_xml_to_chunk.erl
@@ -639,16 +639,21 @@ transform_datatype(Dom,_Acc) ->
 
 transform_see({See,[{marker,Marker}],Content}) ->
     AbsMarker =
-        case string:lexemes(Marker,"#") of
-            [Link] -> [get(application),":",get(module),"#",Link];
-            [AppMod, Link] ->
-                case string:lexemes(AppMod,":") of
-                    [Mod] -> [get(application),":",Mod,"#",Link];
-                    [App, Mod] -> [App,":",Mod,"#",Link]
-                end
+        case string:split(Marker, "#") of
+            [AppFile] -> marker_defaults(AppFile);
+            [AppFile, Anchor] -> [marker_defaults(AppFile), "#", Anchor]
         end,
+
     {a, [{href,iolist_to_binary(AbsMarker)},
          {rel,<<"https://erlang.org/doc/link/",(atom_to_binary(See))/binary>>}], Content}.
+
+marker_defaults("") ->
+    [get(application), ":", get(module)];
+marker_defaults(AppFile) ->
+    case string:split(AppFile, ":") of
+        [File] -> [get(application), ":", File];
+        [App, File] -> [App, ":", File]
+    end.
 
 to_chunk(Dom, Source, Module, AST) ->
     [{module,MAttr,Mcontent}] = Dom,


### PR DESCRIPTION
Before this patch, this XML:

```xml
<!-- https://github.com/erlang/otp/blob/a40b5380e05a8b390c776556521b6e94e9e11b73/lib/stdlib/doc/src/binary.xml#L472:L474 -->
are also available in the
<seeerl marker="erts:erlang"><c>erlang</c></seeerl>
module under the names
```

Produced this chunk entry:

```erlang
<<" are also available in the ">>,
{a,[{href,<<"stdlib:binary#erts:erlang">>},
    {rel,<<"https://erlang.org/doc/link/seeerl">>}],
   [{code,[],[<<"erlang">>]}]},
<<" module under the names ">>,
```

Note the `stdlib:binary#erts:erlang` instead of the expected `stdlib:binary`. We'd get similar result for `erlang` becoming `stdlib:binary#erlang`. This patch fixes that.

With this patch we have the following behaviour. Say, we are generating
docs for the app `myapp` and the module `mymod`:

    "app:mod#anchor" => "app:mod#anchor"
    "mod#anchor"     => "myapp:mod#anchor"
    "app:mod"        => "app:mod"
    "mod"            => "myapp:mod"

I have opened this PR against `maint`, please let me know otherwise.