### PR TITLE
delete part of fts_rand_float_decimals that depend on libc rounding

### DIFF
--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -305,7 +305,7 @@ fts_rand_float_decimals(N) ->
               end,
          F1 = list_to_float(L1),
          Diff = abs(F0-F1),
-         MaxDiff = max_diff_decimals(F0, D),
+         MaxDiff = max_diff_decimals(F0, D-1),
          ok = case Diff =< MaxDiff of
                   true -> ok;
                   false ->


### PR DESCRIPTION
This is a fix for #5128 

I am happy to hear for solution that are not just about deleting it, but i do not see how else to handle the fact that the rounding of the last decimal digit is unspecified in the spec and let to the implementers