### PR TITLE
delete all use of -Wdeclaration-after-statement in configure

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -7984,31 +7984,6 @@ fi
       WFLAGS="$WFLAGS -Wmissing-prototypes";;
   esac
 
-  saved_CFLAGS=$CFLAGS
-  CFLAGS="$CFLAGS -Wdeclaration-after-statement"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  warn_decl_after_st=true
-else $as_nop
-  warn_decl_after_st=false
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-  if test "X$warn_decl_after_st" = "Xtrue"; then
-    WFLAGS="$WFLAGS -Wdeclaration-after-statement"
-  fi
-  CFLAGS=$saved_CFLAGS
-
   # Use -fno-common for gcc, that is link error if multiple definitions of
   # global variables are encountered. This is ISO C compliant.
   # Until version 10, gcc has had -fcommon as default, which allows and merges

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -645,14 +645,6 @@ AS_IF([test "x$GCC" = xyes],
       WFLAGS="$WFLAGS -Wmissing-prototypes";;
   esac
 
-  saved_CFLAGS=$CFLAGS
-  CFLAGS="$CFLAGS -Wdeclaration-after-statement"
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[;]])],[warn_decl_after_st=true],[warn_decl_after_st=false])
-  if test "X$warn_decl_after_st" = "Xtrue"; then
-    WFLAGS="$WFLAGS -Wdeclaration-after-statement"
-  fi
-  CFLAGS=$saved_CFLAGS
-
   # Use -fno-common for gcc, that is link error if multiple definitions of
   # global variables are encountered. This is ISO C compliant.
   # Until version 10, gcc has had -fcommon as default, which allows and merges

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -275,7 +275,7 @@ ifeq ($(FLAVOR),jit)
 CFLAGS  += -DBEAMASM=1
 ENABLE_ALLOC_TYPE_VARS += beamasm
 endif
-CXXFLAGS = $(filter-out -Werror=implicit -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement,$(CFLAGS)) @CXXFLAGS@
+CXXFLAGS = $(filter-out -Werror=implicit -Wstrict-prototypes -Wmissing-prototypes,$(CFLAGS)) @CXXFLAGS@
 HCC     = @HCC@
 LD      = @LD@
 DEXPORT = @DEXPORT@

--- a/erts/emulator/ryu/ryu.mk
+++ b/erts/emulator/ryu/ryu.mk
@@ -36,11 +36,7 @@ else
 RYU_LIBRARY = $(RYU_OBJDIR)/libryu.a
 endif
 
-ifeq ($(TARGET), win32)
 RYU_CFLAGS = $(CFLAGS)
-else
-RYU_CFLAGS = $(filter-out -Wdeclaration-after-statement,$(CFLAGS))
-endif
 
 ifeq ($(TARGET), win32)
 $(RYU_LIBRARY): $(RYU_OBJS)

--- a/erts/lib_src/yielding_c_fun/main_target.mk
+++ b/erts/lib_src/yielding_c_fun/main_target.mk
@@ -26,7 +26,7 @@ YCF_SOURCES = $(sort $(wildcard $(YCF_SOURCE_DIR)/*.c) $(YCF_EXTRA_SOURCES))
 
 YCF_OBJECTS = $(addprefix $(YCF_OBJ_DIR)/,$(notdir $(YCF_SOURCES:.c=.o)))
 
-YCF_CFLAGS = $(filter-out -Wstrict-prototypes -Wdeclaration-after-statement -Wmissing-prototypes,$(CFLAGS))
+YCF_CFLAGS = $(filter-out -Wstrict-prototypes -Wmissing-prototypes,$(CFLAGS))
 
 $(YCF_EXECUTABLE): $(YCF_OBJECTS)
 	$(V_LD) $(YCF_CFLAGS) $(LDFLAGS) $(YCF_OBJECTS) -o $@

--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -4939,44 +4939,6 @@ case "$host_cpu" in
 esac
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -Wdeclaration-after-statement to DED_WARN_FLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -Wdeclaration-after-statement to DED_WARN_FLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Wdeclaration-after-statement $DED_WARN_FLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else $as_nop
-  can_enable_flag=false
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-        DED_WARN_FLAGS="-Wdeclaration-after-statement $DED_WARN_FLAGS"
-
-else $as_nop
-
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-
-fi
-
-
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -Werror=return-type to DED_WERRORFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -Werror=return-type to DED_WERRORFLAGS (via CFLAGS)... " >&6; }

--- a/lib/megaco/configure
+++ b/lib/megaco/configure
@@ -5012,44 +5012,6 @@ case "$host_cpu" in
 esac
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -Wdeclaration-after-statement to DED_WARN_FLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -Wdeclaration-after-statement to DED_WARN_FLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Wdeclaration-after-statement $DED_WARN_FLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else $as_nop
-  can_enable_flag=false
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-        DED_WARN_FLAGS="-Wdeclaration-after-statement $DED_WARN_FLAGS"
-
-else $as_nop
-
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-
-fi
-
-
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -Werror=return-type to DED_WERRORFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -Werror=return-type to DED_WERRORFLAGS (via CFLAGS)... " >&6; }

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -3023,7 +3023,6 @@ case "$host_cpu" in
     DED_WARN_FLAGS="$DED_WARN_FLAGS -Wmissing-prototypes";;
 esac
   
-LM_TRY_ENABLE_CFLAG([-Wdeclaration-after-statement], [DED_WARN_FLAGS])
 
 LM_TRY_ENABLE_CFLAG([-Werror=return-type], [DED_WERRORFLAGS])
 LM_TRY_ENABLE_CFLAG([-Werror=implicit], [DED_WERRORFLAGS])

--- a/make/configure
+++ b/make/configure
@@ -6339,44 +6339,6 @@ case "$host_cpu" in
 esac
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -Wdeclaration-after-statement to DED_WARN_FLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -Wdeclaration-after-statement to DED_WARN_FLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Wdeclaration-after-statement $DED_WARN_FLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else $as_nop
-  can_enable_flag=false
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-        DED_WARN_FLAGS="-Wdeclaration-after-statement $DED_WARN_FLAGS"
-
-else $as_nop
-
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-
-fi
-
-
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -Werror=return-type to DED_WERRORFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -Werror=return-type to DED_WERRORFLAGS (via CFLAGS)... " >&6; }


### PR DESCRIPTION
Following a discussion with @garazdawi in #4719 , this delete all the checks to add `-Wdeclaration-after-statement` in the CFLAGS.

This is legal in C99 and at this point all compiler supported on all supported platform should be able to deal with it.