### PR TITLE
Optimize off-heap list traversal during GC

### DIFF
--- a/erts/emulator/beam/erl_binary.h
+++ b/erts/emulator/beam/erl_binary.h
@@ -413,7 +413,7 @@ erts_bin_nrml_alloc_fnf(Uint size)
 
     if (!IS_BINARY_SIZE_OK(size))
         return NULL;
-    bsize = ERTS_SIZEOF_Binary(size) + CHICKEN_PAD;
+    bsize = ERTS_SIZEOF_Binary(size);
 
     res = (Binary *)erts_alloc_fnf(ERTS_ALC_T_BINARY, bsize);
     ERTS_CHK_BIN_ALIGNMENT(res);
@@ -430,7 +430,7 @@ erts_bin_nrml_alloc_fnf(Uint size)
 ERTS_GLB_INLINE Binary *
 erts_bin_nrml_alloc(Uint size)
 {
-    Binary *res = erts_bin_drv_alloc_fnf(size);
+    Binary *res = erts_bin_nrml_alloc_fnf(size);
 
     if (res) {
         return res;
@@ -446,13 +446,18 @@ erts_bin_realloc_fnf(Binary *bp, Uint size)
     Binary *nbp;
     Uint bsize;
     
-    type = (bp->intern.flags & BIN_FLAG_DRV) ? ERTS_ALC_T_DRV_BINARY
-                                             : ERTS_ALC_T_BINARY;
     ASSERT((bp->intern.flags & BIN_FLAG_MAGIC) == 0);
     if (!IS_BINARY_SIZE_OK(size))
         return NULL;
+    bsize = ERTS_SIZEOF_Binary(size);
 
-    bsize = ERTS_SIZEOF_Binary(size) + CHICKEN_PAD;
+    if (bp->intern.flags & BIN_FLAG_DRV) {
+        type = ERTS_ALC_T_DRV_BINARY;
+        bsize += CHICKEN_PAD;
+    }
+    else {
+        type = ERTS_ALC_T_BINARY;
+    }
 
     nbp = (Binary *)erts_realloc_fnf(type, (void *) bp, bsize);
     ERTS_CHK_BIN_ALIGNMENT(nbp);

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -2811,11 +2811,7 @@ link_live_proc_bin(struct shrink_cand_data *shrink,
 
     *currpp = pbp->next;
     if (pbp->flags & (PB_ACTIVE_WRITER|PB_IS_WRITABLE)) {
-	ASSERT(((pbp->flags & (PB_ACTIVE_WRITER|PB_IS_WRITABLE))
-		== (PB_ACTIVE_WRITER|PB_IS_WRITABLE))
-	       || ((pbp->flags & (PB_ACTIVE_WRITER|PB_IS_WRITABLE))
-		   == PB_IS_WRITABLE));
-
+	ASSERT(pbp->flags & PB_IS_WRITABLE);
 
 	if (pbp->flags & PB_ACTIVE_WRITER) {
             pbp->flags &= ~PB_ACTIVE_WRITER;

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -456,17 +456,19 @@ erts_gc_after_bif_call(Process* p, Eterm result, Eterm* regs, Uint arity)
                                       result, regs, arity);
 }
 
-static ERTS_INLINE void reset_active_writer(Process *p)
+static ERTS_INLINE void assert_no_active_writers(Process *p)
 {
+#ifdef DEBUG
     struct erl_off_heap_header* ptr;
     ptr = MSO(p).first;
     while (ptr) {
 	if (ptr->thing_word == HEADER_PROC_BIN) {	
 	    ProcBin *pbp = (ProcBin*) ptr;
-	    pbp->flags &= ~PB_ACTIVE_WRITER;
+	    ERTS_ASSERT(!(pbp->flags & PB_ACTIVE_WRITER));
 	}
 	ptr = ptr->next;
     }
+#endif
 }
 
 #define ERTS_DELAY_GC_EXTRA_FREE 40
@@ -771,7 +773,7 @@ do_major_collection:
         ERTS_MSACC_SET_STATE_CACHED_X(ERTS_MSACC_STATE_GC);
     }
 
-    reset_active_writer(p);
+    assert_no_active_writers(p);
 
     /*
      * Finish.
@@ -2816,6 +2818,7 @@ link_live_proc_bin(struct shrink_cand_data *shrink,
 
 
 	if (pbp->flags & PB_ACTIVE_WRITER) {
+            pbp->flags &= ~PB_ACTIVE_WRITER;
 	    shrink->no_of_active++;
 	}
 	else { /* inactive */


### PR DESCRIPTION
The entire off-heap list (reference counted objects; binaries, funs, external pids/ports/refs) is traversed twice at the end of a GC. The second time by `reset_active_writer()` to reset active writable binaries. This is now instead done during the first and only traversal.

Also some benign bug fixes and code cleanup.
