### PR TITLE
Improve inet_backend = socket option parsing for gen_tcp (OTP-17580)

### DIFF
--- a/lib/kernel/src/gen_tcp_socket.erl
+++ b/lib/kernel/src/gen_tcp_socket.erl
@@ -898,13 +898,13 @@ splitmap_opts_1(SplitMap, [Opt | Opts]) ->
         ok ->
             case SplitMap(Opt) of
                 false -> ok;
-                true  -> [[]      | Opts];
+                %% true  -> [[]      | Opts]; % not used now
                 Opt_1 -> [[Opt_1] | Opts]
             end;
         [SplitOptsR | Opts_1] ->
             case SplitMap(Opt) of
                 false -> [SplitOptsR           | [Opt | Opts_1]];
-                true  -> [[Opt   | SplitOptsR] | Opts_1];
+                %% true  -> [[Opt   | SplitOptsR] | Opts_1]; % not used now
                 Opt_1 -> [[Opt_1 | SplitOptsR] | Opts_1]
             end
     end;


### PR DESCRIPTION
This is a rewrite of the option parsing in `gen_tcp_socket`, a.k.a the implementation module for `inet_backend = socket`.

The intention is to make it a little less messy, and to fix the bug in #5122.
