### PR TITLE
diameter: Change callback anchors from `Mod:` to `Module:`

### DIFF
--- a/lib/diameter/doc/src/diameter_app.xml
+++ b/lib/diameter/doc/src/diameter_app.xml
@@ -180,7 +180,7 @@ process.</p>
 <funcs>
 
 <func>
-<name since="OTP R14B03">Mod:peer_up(SvcName, Peer, State) -> NewState</name>
+<name since="OTP R14B03">Module:peer_up(SvcName, Peer, State) -> NewState</name>
 <fsummary>Invoked when a transport connection has been established</fsummary>
 <type>
 <v>SvcName = &mod_service_name;</v>
@@ -215,7 +215,7 @@ handled independently of &peer_up; and &peer_down;.</p>
 </func>
 
 <func>
-<name since="OTP R14B03">Mod:peer_down(SvcName, Peer, State) -> NewState</name>
+<name since="OTP R14B03">Module:peer_down(SvcName, Peer, State) -> NewState</name>
 <fsummary>Invoked when a transport connection has been lost.</fsummary>
 <type>
 <v>SvcName = &mod_service_name;</v>
@@ -234,7 +234,7 @@ candidate in &pick_peer; callbacks.</p>
 </func>
 
 <func>
-<name since="OTP R14B03">Mod:pick_peer(LocalCandidates, RemoteCandidates, SvcName, State)
+<name since="OTP R14B03">Module:pick_peer(LocalCandidates, RemoteCandidates, SvcName, State)
       -> Selection | false</name>
 <fsummary>Select a target peer for an outgoing request.</fsummary>
 <type>
@@ -311,7 +311,7 @@ or &peer_down; callback.</p>
 </func>
 
 <func>
-<name since="OTP R14B03">Mod:prepare_request(Packet, SvcName, Peer) -> Action</name>
+<name since="OTP R14B03">Module:prepare_request(Packet, SvcName, Peer) -> Action</name>
 <fsummary>Return a request for encoding and transport.</fsummary>
 <type>
 <v>Packet = &packet;</v>
@@ -363,7 +363,7 @@ discarded}</c>.</p>
 </func>
 
 <func>
-<name since="OTP R14B03">Mod:prepare_retransmit(Packet, SvcName, Peer) -> Action</name>
+<name since="OTP R14B03">Module:prepare_retransmit(Packet, SvcName, Peer) -> Action</name>
 <fsummary>Return a request for encoding and retransmission.</fsummary>
 <type>
 <v>Packet  = &packet;</v>
@@ -393,7 +393,7 @@ discarded}</c>.</p>
 </func>
 
 <func>
-<name since="OTP R14B03">Mod:handle_answer(Packet, Request, SvcName, Peer) -> Result</name>
+<name since="OTP R14B03">Module:handle_answer(Packet, Request, SvcName, Peer) -> Result</name>
 <fsummary>Receive an answer message from a peer.</fsummary>
 <type>
 <v>Packet  = &packet;</v>
@@ -437,7 +437,7 @@ The &mod_application_opt;
 </func>
 
 <func>
-<name since="OTP R14B03">Mod:handle_error(Reason, Request, SvcName, Peer) -> Result</name>
+<name since="OTP R14B03">Module:handle_error(Reason, Request, SvcName, Peer) -> Result</name>
 <fsummary>Return an error from a outgoing request.</fsummary>
 <type>
 <v>Reason  = timeout | failover | term()</v>
@@ -465,7 +465,7 @@ not selected.</p>
 </func>
 
 <func>
-<name since="OTP R14B03">Mod:handle_request(Packet, SvcName, Peer) -> Action</name>
+<name since="OTP R14B03">Module:handle_request(Packet, SvcName, Peer) -> Action</name>
 <fsummary>Receive an incoming request.</fsummary>
 <type>
 <v>Packet  = &packet;</v>

--- a/lib/diameter/doc/src/diameter_transport.xml
+++ b/lib/diameter/doc/src/diameter_transport.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE erlref SYSTEM "erlref.dtd" [
   <!ENTITY message '<seeerl marker="#message">message()</seeerl>'>
   <!ENTITY MESSAGES '<seeerl marker="#MESSAGES">MESSAGES</seeerl>'>
-  <!ENTITY start '<seemfa marker="#Mod:start/3">start/3</seemfa>'>
+  <!ENTITY start '<seemfa marker="#Module:start/3">start/3</seemfa>'>
   <!ENTITY ip_address
   '<seetype marker="kernel:inet#ip_address">inet:ip_address()</seetype>'>
   <!ENTITY % also SYSTEM "seealso.ent" >
@@ -95,7 +95,7 @@ and has the binary() to send in its <c>bin</c> field.</p>
 <funcs>
 
 <func>
-<name since="OTP R14B03">Mod:start({Type, Ref}, Svc, Config)
+<name since="OTP R14B03">Module:start({Type, Ref}, Svc, Config)
          -> {ok, Pid}
           | {ok, Pid, LAddrs}
           | {error, Reason}</name>

--- a/lib/diameter/doc/src/seealso.ent
+++ b/lib/diameter/doc/src/seealso.ent
@@ -76,14 +76,14 @@ significant.
 
 <!-- diameter_app -->
 
-<!ENTITY app_handle_answer '<seemfa marker="diameter_app#Mod:handle_answer/4">handle_answer/4</seemfa>'>
-<!ENTITY app_handle_request '<seemfa marker="diameter_app#Mod:handle_request/3">handle_request/3</seemfa>'>
-<!ENTITY app_handle_error '<seemfa marker="diameter_app#Mod:handle_error/4">handle_error/4</seemfa>'>
-<!ENTITY app_peer_down '<seemfa marker="diameter_app#Mod:peer_down/3">peer_down/3</seemfa>'>
-<!ENTITY app_peer_up '<seemfa marker="diameter_app#Mod:peer_up/3">peer_up/3</seemfa>'>
-<!ENTITY app_pick_peer '<seemfa marker="diameter_app#Mod:pick_peer/4">pick_peer/4</seemfa>'>
-<!ENTITY app_prepare_retransmit '<seemfa marker="diameter_app#Mod:prepare_retransmit/3">prepare_retransmit/3</seemfa>'>
-<!ENTITY app_prepare_request '<seemfa marker="diameter_app#Mod:prepare_request/3">prepare_request/3</seemfa>'>
+<!ENTITY app_handle_answer '<seemfa marker="diameter_app#Module:handle_answer/4">handle_answer/4</seemfa>'>
+<!ENTITY app_handle_request '<seemfa marker="diameter_app#Module:handle_request/3">handle_request/3</seemfa>'>
+<!ENTITY app_handle_error '<seemfa marker="diameter_app#Module:handle_error/4">handle_error/4</seemfa>'>
+<!ENTITY app_peer_down '<seemfa marker="diameter_app#Module:peer_down/3">peer_down/3</seemfa>'>
+<!ENTITY app_peer_up '<seemfa marker="diameter_app#Module:peer_up/3">peer_up/3</seemfa>'>
+<!ENTITY app_pick_peer '<seemfa marker="diameter_app#Module:pick_peer/4">pick_peer/4</seemfa>'>
+<!ENTITY app_prepare_retransmit '<seemfa marker="diameter_app#Module:prepare_retransmit/3">prepare_retransmit/3</seemfa>'>
+<!ENTITY app_prepare_request '<seemfa marker="diameter_app#Module:prepare_request/3">prepare_request/3</seemfa>'>
 
 <!ENTITY app_capabilities '<seeerl marker="diameter_app#capabilities">diameter_app:capabilities()</seeerl>'>
 <!ENTITY app_peer '<seeerl marker="diameter_app#peer">diameter_app:peer()</seeerl>'>
@@ -130,7 +130,7 @@ significant.
 <!-- diameter_transport -->
 
 <!ENTITY transport_start
- '<seemfa marker="diameter_transport#Mod:start/3">start/3</seemfa>'>
+ '<seemfa marker="diameter_transport#Module:start/3">start/3</seemfa>'>
 
 <!-- reference pages -->
 


### PR DESCRIPTION
- diameter: Change callback anchors from `Mod:` to standard `Module:`

`#Module:` is the more commonly used way of referring to callbacks in
the generated links.

By standardising on this, we improve interopability for external tools.
For example, ExDoc can generate URLs using the uniform pattern. (As
opposed to, for example, maintain a list of per-module exceptions.)

- ~diameter: Use `<seetype>` for types~
