### PR TITLE
peer: new module to replace 'slave'

### DIFF
--- a/bootstrap/lib/stdlib/ebin/stdlib.app
+++ b/bootstrap/lib/stdlib/ebin/stdlib.app
@@ -81,6 +81,7 @@
 	     orddict,
 	     ordsets,
 	     otp_internal,
+	     peer,
 	     pool,
 	     proc_lib,
 	     proplists,

--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -400,7 +400,7 @@ $ <input>erl \
           the name supplied together with flag <c><![CDATA[-sname]]></c> or
           <c><![CDATA[-name]]></c>.</p>
       </item>
-      <tag><c><![CDATA[-init_debug]]></c></tag>
+      <tag><marker id="init_debug"/><c><![CDATA[-init_debug]]></c></tag>
       <item>
         <p>Makes <c><![CDATA[init]]></c> write some debug information while
           interpreting the boot script.</p>

--- a/erts/emulator/test/code_SUITE.erl
+++ b/erts/emulator/test/code_SUITE.erl
@@ -727,11 +727,11 @@ verify_lit_terms([], _) ->
     ok.
 
 get_external_terms() ->
-    {ok,Node} =	test_server:start_node(?FUNCTION_NAME, slave, []),
+    {ok, Peer, Node}= ?CT_PEER(),
     Ref = rpc:call(Node, erlang, make_ref, []),
     Ports = rpc:call(Node, erlang, ports, []),
     Pid = rpc:call(Node, erlang, self, []),
-    _ = test_server:stop_node(Node),
+    peer:stop(Peer),
     {Ref,hd(Ports),Pid}.
 
 %% OTP-7559: c_p->cp could contain garbage and create a false dependency

--- a/erts/emulator/test/distribution_SUITE.erl
+++ b/erts/emulator/test/distribution_SUITE.erl
@@ -34,9 +34,6 @@
 
 -include_lib("common_test/include/ct.hrl").
 
-%-define(Line, erlang:display({line,?LINE}),).
--define(Line,).
-
 -export([all/0, suite/0, groups/0,
          init_per_suite/1, end_per_suite/1,
          init_per_group/2, end_per_group/2,
@@ -82,7 +79,7 @@
 -export([sender/3, receiver2/2, dummy_waiter/0, dead_process/0,
          group_leader_1/1,
          optimistic_dflags_echo/0, optimistic_dflags_sender/1,
-         roundtrip/1, bounce/1, do_dist_auto_connect/1, inet_rpc_server/1,
+         roundtrip/1, bounce/1,
          dist_parallel_sender/3, dist_parallel_receiver/0,
          derr_run/1,
          dist_evil_parallel_receiver/0, make_busy/2]).
@@ -168,10 +165,10 @@ ping(Config) when is_list(Config) ->
 
     %% Pings another node.
 
-    {ok, OtherNode} = start_node(distribution_SUITE_other),
+    {ok, Peer, OtherNode} = ?CT_PEER(),
     io:format("Pinging ~s (assumed to exist)", [OtherNode]),
     test_server:do_times(Times, fun() -> pong = net_adm:ping(OtherNode) end),
-    stop_node(OtherNode),
+    peer_stop(Peer, OtherNode),
 
     %% Pings our own node many times.
 
@@ -183,54 +180,44 @@ ping(Config) when is_list(Config) ->
 
 %% Test erlang:group_leader(_, ExternalPid), i.e. DOP_GROUP_LEADER
 group_leader(Config) when is_list(Config) ->
-    ?Line Sock = start_relay_node(group_leader_1, []),
-    ?Line Sock2 = start_relay_node(group_leader_2, []),
-    try
-        ?Line Node2 = inet_rpc_nodename(Sock2),
-        ?Line {ok, ok} = do_inet_rpc(Sock, ?MODULE, group_leader_1, [Node2])
-    after
-        ?Line stop_relay_node(Sock),
-        ?Line stop_relay_node(Sock2)
-    end,
-    ok.
+    {ok, Peer1, Node1} = ?CT_PEER(#{connection => 0, args => ["-setcookie", "NONE"]}),
+    {ok, Peer2, Node2} = ?CT_PEER(#{connection => 0, args => ["-setcookie", "NONE"]}),
+    pang = net_adm:ping(Node1), pang = net_adm:ping(Node2), %% extra check, may be skipped
+    ok = peer:call(Peer1, ?MODULE, group_leader_1, [Node2]),
+    peer:stop(Peer1), %% verify_nc() will fail because peer is not dist-connected
+    peer:stop(Peer2).
 
 group_leader_1(Node2) ->
-    ?Line ExtPid = spawn(Node2, fun F() ->
+    ExtPid = spawn(Node2, fun F() ->
                                         receive {From, group_leader} ->
                                                 From ! {self(), group_leader, group_leader()}
                                         end,
                                         F()
                                 end),
-    ?Line GL1 = self(),
-    ?Line group_leader(GL1, ExtPid),
-    ?Line ExtPid ! {self(), group_leader},
-    ?Line {ExtPid, group_leader, GL1} = receive_one(),
+    GL1 = self(),
+    group_leader(GL1, ExtPid),
+    ExtPid ! {self(), group_leader},
+    {ExtPid, group_leader, GL1} = receive_one(),
 
     %% Kill connection and repeat test when group_leader/2 triggers auto-connect
-    ?Line net_kernel:monitor_nodes(true),
-    ?Line net_kernel:disconnect(Node2),
-    ?Line {nodedown, Node2} = receive_one(),
-    ?Line GL2 = spawn(fun() -> dummy end),
-    ?Line group_leader(GL2, ExtPid),
-    ?Line {nodeup, Node2} = receive_one(),
-    ?Line ExtPid ! {self(), group_leader},
-    ?Line {ExtPid, group_leader, GL2} = receive_one(),
+    net_kernel:monitor_nodes(true),
+    net_kernel:disconnect(Node2),
+    {nodedown, Node2} = receive_one(),
+    GL2 = spawn(fun() -> dummy end),
+    group_leader(GL2, ExtPid),
+    {nodeup, Node2} = receive_one(),
+    ExtPid ! {self(), group_leader},
+    {ExtPid, group_leader, GL2} = receive_one(),
     ok.
 
 %% Test optimistic distribution flags toward pending connections (DFLAG_DIST_HOPEFULLY)
 optimistic_dflags(Config) when is_list(Config) ->
-    ?Line Sender = start_relay_node(optimistic_dflags_sender, []),
-    ?Line Echo = start_relay_node(optimistic_dflags_echo, []),
-    try
-        ?Line {ok, ok} = do_inet_rpc(Echo, ?MODULE, optimistic_dflags_echo, []),
-
-        ?Line EchoNode = inet_rpc_nodename(Echo),
-        ?Line {ok, ok} = do_inet_rpc(Sender, ?MODULE, optimistic_dflags_sender, [EchoNode])
-    after
-        ?Line stop_relay_node(Sender),
-        ?Line stop_relay_node(Echo)
-    end,
-    ok.
+    {ok, PeerSender, _Sender} = ?CT_PEER(#{connection => 0, args => ["-setcookie", "NONE"]}),
+    {ok, PeerEcho, Echo} = ?CT_PEER(#{connection => 0, args => ["-setcookie", "NONE"]}),
+    ok = peer:call(PeerEcho, ?MODULE, optimistic_dflags_echo, []),
+    ok = peer:call(PeerSender, ?MODULE, optimistic_dflags_sender, [Echo]),
+    peer:stop(PeerSender),
+    peer:stop(PeerEcho).
 
 optimistic_dflags_echo() ->
     P = spawn(fun F() ->
@@ -245,25 +232,25 @@ optimistic_dflags_echo() ->
     ok.
 
 optimistic_dflags_sender(EchoNode) ->
-    ?Line net_kernel:monitor_nodes(true),
+    net_kernel:monitor_nodes(true),
 
     optimistic_dflags_do(EchoNode, <<1:1>>),
     optimistic_dflags_do(EchoNode, fun lists:map/2),
     ok.
 
 optimistic_dflags_do(EchoNode, Term) ->
-    ?Line {optimistic_dflags_echo, EchoNode} ! {self(), Term},
-    ?Line {nodeup, EchoNode} = receive_one(),
-    ?Line {EchoPid, Term} = receive_one(),
+    {optimistic_dflags_echo, EchoNode} ! {self(), Term},
+    {nodeup, EchoNode} = receive_one(),
+    {EchoPid, Term} = receive_one(),
     %% repeat with pid destination
-    ?Line net_kernel:disconnect(EchoNode),
-    ?Line {nodedown, EchoNode} = receive_one(),
-    ?Line EchoPid ! {self(), Term},
-    ?Line {nodeup, EchoNode} = receive_one(),
-    ?Line {EchoPid, Term} = receive_one(),
+    net_kernel:disconnect(EchoNode),
+    {nodedown, EchoNode} = receive_one(),
+    EchoPid ! {self(), Term},
+    {nodeup, EchoNode} = receive_one(),
+    {EchoPid, Term} = receive_one(),
 
-    ?Line net_kernel:disconnect(EchoNode),
-    ?Line {nodedown, EchoNode} = receive_one(),
+    net_kernel:disconnect(EchoNode),
+    {nodedown, EchoNode} = receive_one(),
     ok.
 
 
@@ -281,13 +268,13 @@ bulk_send(Terms, BinSize) ->
     ct:timetrap({seconds, 30}),
 
     io:format("Sending ~w binaries, each of size ~w K", [Terms, BinSize]),
-    {ok, Node} = start_node(bulk_receiver),
+    {ok, Peer, Node} = ?CT_PEER(),
     Recv = spawn(Node, erlang, apply, [fun receiver/2, [0, 0]]),
     Bin = binary:copy(<<253>>, BinSize*1024),
     Size = Terms*size(Bin),
     {Elapsed, {Terms, Size}} = test_server:timecall(?MODULE, sender,
                                                     [Recv, Bin, Terms]),
-    stop_node(Node),
+    peer_stop(Peer, Node),
     {comment, integer_to_list(round(Size/1024/max(1,Elapsed))) ++ " K/s"}.
 
 sender(To, _Bin, 0) ->
@@ -321,7 +308,7 @@ bulk_sendsend2(Terms, BinSize, BusyBufSize) ->
 
     io:format("\nSending ~w binaries, each of size ~w K",
               [Terms, BinSize]),
-    {ok, NodeRecv} = start_node(bulk_receiver),
+    {ok, RecvPeer, NodeRecv} = ?CT_PEER(),
     Recv = spawn(NodeRecv, erlang, apply, [fun receiver/2, [0, 0]]),
     Bin = binary:copy(<<253>>, BinSize*1024),
 
@@ -334,8 +321,7 @@ bulk_sendsend2(Terms, BinSize, BusyBufSize) ->
     %% default busy size and "+zdbbl 5", and if the 5 case gets
     %% "many many more" monitor messages, then we know we're working.
 
-    {ok, NodeSend} = start_node(bulk_sender, "+zdbbl " ++
-                                    integer_to_list(BusyBufSize)),
+    {ok, SendPeer, NodeSend} = ?CT_PEER(["+zdbbl", integer_to_list(BusyBufSize)]),
     _Send = spawn(NodeSend, erlang, apply,
                   [fun sendersender/4, [self(), Recv, Bin, Terms]]),
     {Elapsed, {_TermsN, SizeN}, MonitorCount} =
@@ -347,8 +333,8 @@ bulk_sendsend2(Terms, BinSize, BusyBufSize) ->
             {sendersender, BigRes} ->
                 BigRes
         end,
-    stop_node(NodeRecv),
-    stop_node(NodeSend),
+    peer_stop(RecvPeer, NodeRecv),
+    peer_stop(SendPeer, NodeSend),
     {round(SizeN/1024/Elapsed), MonitorCount}.
 
 %% Sender process to be run on a slave node
@@ -449,7 +435,7 @@ receiver2(Num, TotSize) ->
 %% Test that link/1 to a busy distribution port works.
 link_to_busy(Config) when is_list(Config) ->
     ct:timetrap({seconds, 60}),
-    {ok, Node} = start_node(link_to_busy),
+    {ok, Peer, Node} = ?CT_PEER(),
     Recv = spawn(Node, erlang, apply, [fun sink/1, [link_to_busy_sink]]),
 
     Tracer = case os:getenv("TRACE_BUSY_DIST_PORT") of
@@ -475,7 +461,7 @@ link_to_busy(Config) when is_list(Config) ->
     do_busy_test(Node, fun () -> tail_applied_linker(Recv) end),
 
     %% Done.
-    stop_node(Node),
+    peer_stop(Peer, Node),
     stop_busy_dist_port_tracer(Tracer),
     ok.
 
@@ -495,7 +481,7 @@ tail_applied_linker(Pid) ->
 %% Test that exit/2 to a busy distribution port works.
 exit_to_busy(Config) when is_list(Config) ->
     ct:timetrap({seconds, 60}),
-    {ok, Node} = start_node(exit_to_busy),
+    {ok, Peer, Node} = ?CT_PEER(),
 
     Tracer = case os:getenv("TRACE_BUSY_DIST_PORT") of
                  "true" -> start_busy_dist_port_tracer();
@@ -545,7 +531,7 @@ exit_to_busy(Config) when is_list(Config) ->
     end,
 
     %% Done.
-    stop_node(Node),
+    peer_stop(Peer, Node),
     stop_busy_dist_port_tracer(Tracer),
     ok.
 
@@ -664,7 +650,7 @@ sink1() ->
 %% Test that EXIT and DOWN messages send to another node are not lost if
 %% the distribution port is busy.
 lost_exit(Config) when is_list(Config) ->
-    {ok, Node} = start_node(lost_exit),
+    {ok, Peer, Node} = ?CT_PEER(),
 
     Tracer = case os:getenv("TRACE_BUSY_DIST_PORT") of
                  "true" -> start_busy_dist_port_tracer();
@@ -717,7 +703,7 @@ lost_exit(Config) when is_list(Config) ->
 
     %% Done.
     stop_busy_dist_port_tracer(Tracer),
-    stop_node(Node),
+    peer_stop(Peer, Node),
     ok.
 
 dummy_waiter() ->
@@ -730,9 +716,7 @@ dummy_waiter() ->
 %% AND that the link is teared down.
 link_to_dead(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
-    {ok, Node} = start_node(link_to_dead),
-    %    monitor_node(Node, true),
-    net_adm:ping(Node), %% Ts_cross_server workaround.
+    {ok, Peer, Node} = ?CT_PEER(),
     Pid = spawn(Node, ?MODULE, dead_process, []),
     receive
     after 5000 -> ok
@@ -749,13 +733,14 @@ link_to_dead(Config) when is_list(Config) ->
     {links, Links} = process_info(self(), links),
     io:format("Pid=~p, links=~p", [Pid, Links]),
     false = lists:member(Pid, Links),
-    stop_node(Node),
     receive
         Message ->
             ct:fail({unexpected_message, Message})
     after 3000 ->
               ok
     end,
+    process_flag(trap_exit, false),
+    peer_stop(Peer, Node),
     ok.
 
 dead_process() ->
@@ -767,18 +752,24 @@ link_to_dead_new_node(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
 
     %% Start the node, get a Pid and stop the node again.
-    {ok, Node} = start_node(link_to_dead_new_node),
+    Name = ?CT_PEER_NAME(?FUNCTION_NAME),
+    {ok, Peer, Node} = ?CT_PEER(#{name => Name}),
     Pid = spawn(Node, ?MODULE, dead_process, []),
-    stop_node(Node),
+
+    peer_stop(Peer, Node),
+    %% since exits are trapped, need to catch exiting peer
+    receive {'EXIT', Peer, normal} -> ok end,
 
     %% Start a new node with the same name.
-    {ok, Node} = start_node(link_to_dead_new_node),
+    {ok, Peer2, Node} = ?CT_PEER(#{name => Name}),
     link(Pid),
+
     receive
         {'EXIT', Pid, noproc} ->
             ok;
         Other ->
-            stop_node(Node),
+            process_flag(trap_exit, false),
+            peer_stop(Peer2, Node),
             ct:fail({unexpected_message, Other})
     after 5000 ->
               ct:fail(nothing_received)
@@ -788,13 +779,16 @@ link_to_dead_new_node(Config) when is_list(Config) ->
     {links, Links} = process_info(self(), links),
     io:format("Pid=~p, links=~p", [Pid, Links]),
     false = lists:member(Pid, Links),
-    stop_node(Node),
     receive
         Message ->
+            process_flag(trap_exit, false),
             ct:fail({unexpected_message, Message})
     after 3000 ->
               ok
     end,
+    %% stop trapping exits, and let the peer stop
+    process_flag(trap_exit, false),
+    peer_stop(Peer2, Node),
     ok.
 
 %% Test that sending a port or reference to another node and back again
@@ -803,13 +797,13 @@ ref_port_roundtrip(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     Port = make_port(),
     Ref = make_ref(),
-    {ok, Node} = start_node(ref_port_roundtrip),
+    {ok, Peer, Node} = ?CT_PEER(),
     net_adm:ping(Node),
     Term = {Port, Ref},
     io:format("Term before: ~p", [show_term(Term)]),
     Pid = spawn_link(Node, ?MODULE, roundtrip, [Term]),
     receive after 5000 -> ok end,
-    stop_node(Node),
+    peer_stop(Peer, Node),
     receive
         {'EXIT', Pid, {Port, Ref}} ->
             io:format("Term after: ~p", [show_term(Term)]),
@@ -832,7 +826,7 @@ roundtrip(Term) ->
 %% another node node and back again.
 nil_roundtrip(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
-    {ok, Node} = start_node(nil_roundtrip),
+    {ok, Peer, Node} = ?CT_PEER(),
     net_adm:ping(Node),
     Pid = spawn_link(Node, ?MODULE, bounce, [self()]),
     Pid ! [],
@@ -840,7 +834,7 @@ nil_roundtrip(Config) when is_list(Config) ->
         [] ->
             receive
                 {'EXIT', Pid, []} ->
-                    stop_node(Node),
+                    peer_stop(Peer, Node),
                     ok
             end
     end.
@@ -900,7 +894,7 @@ tr3() ->
 
 
 
-% This has to be done by nodes with differrent cookies, otherwise global
+% This has to be done by nodes with different cookies, otherwise global
 % will connect nodes, which is correct, but makes it hard to test.
 % * Start two nodes, n1 and n2. n2 with the dist_auto_connect once parameter
 % * n2 pings n1 -> connection
@@ -913,177 +907,65 @@ tr3() ->
 % * n2 now also gets pong when pinging n1
 % * disconnect n2 from n1
 % * n2 gets pang when pinging n1
-% * n2 forces connection by using net_kernel:connect_node (ovverrides)
+% * n2 forces connection by using net_kernel:connect_node (overrides)
 % * n2 gets pong when pinging n1.
 
 %% Test the dist_auto_connect once kernel parameter
 dist_auto_connect_once(Config) when is_list(Config) ->
-    Sock = start_relay_node(dist_auto_connect_relay_node,[]),
-    NN = inet_rpc_nodename(Sock),
-    Sock2 = start_relay_node(dist_auto_connect_once_node,
-                             "-kernel dist_auto_connect once"),
-    NN2 = inet_rpc_nodename(Sock2),
-    {ok,[]} = do_inet_rpc(Sock,erlang,nodes,[]),
-    {ok, pong} = do_inet_rpc(Sock2,net_adm,ping,[NN]),
-    {ok,[NN2]} = do_inet_rpc(Sock,erlang,nodes,[]),
-    {ok,[NN]} = do_inet_rpc(Sock2,erlang,nodes,[]),
-    [_,HostPartPeer] = string:lexemes(atom_to_list(NN),"@"),
-    [_,MyHostPart] = string:lexemes(atom_to_list(node()),"@"),
+    {ok, PN, NN} = ?CT_PEER(#{connection => 0, args => ["-setcookie", "NONE"]}),
+    {ok, PN2, NN2} = ?CT_PEER(#{connection => 0,
+        args => ["-setcookie", "NONE", "-kernel", "dist_auto_connect", "once"]}),
+    [] = peer:call(PN,erlang,nodes,[]),
+    pong = peer:call(PN2,net_adm,ping,[NN]),
+    [NN2] = peer:call(PN,erlang,nodes,[]),
+    [NN] = peer:call(PN2,erlang,nodes,[]),
     % Give net_kernel a chance to change the state of the node to up to.
     receive after 1000 -> ok end,
-    case HostPartPeer of
-        MyHostPart ->
-            ok = stop_relay_node(Sock),
-            {ok,pang} = do_inet_rpc(Sock2,net_adm,ping,[NN]);
-        _ ->
-            {ok, true} = do_inet_rpc(Sock,net_kernel,disconnect,[NN2]),
-            receive
-            after 500 -> ok
-            end
-    end,
-    {ok, []} = do_inet_rpc(Sock2,erlang,nodes,[]),
-    Sock3 = case HostPartPeer of
-                MyHostPart ->
-                    start_relay_node(dist_auto_connect_relay_node,[]);
-                _ ->
-                    Sock
-            end,
+    ok = peer:stop(PN),
+    pang = peer:call(PN2,net_adm,ping,[NN]),
+    [] = peer:call(PN2,erlang,nodes,[]),
+    %% restart NN node
+    {ok, PN3, NN} = ?CT_PEER(#{connection => 0, args => ["-setcookie", "NONE"],
+        name => hd(string:lexemes(atom_to_list(NN), "@"))}),
     TS1 = timestamp(),
-    {ok, pang} = do_inet_rpc(Sock2,net_adm,ping,[NN]),
+    pang = peer:call(PN2,net_adm,ping,[NN]),
     TS2 = timestamp(),
     RefT = net_kernel:connecttime() - 1000,
     true = ((TS2 - TS1) < RefT),
     TS3 = timestamp(),
-    {ok, true} = do_inet_rpc(Sock2,erlang,monitor_node,
-                             [NN,true,[allow_passive_connect]]),
+    true = peer:call(PN2,erlang,monitor_node,
+                             [NN,true,[allow_passive_connect]], 60000),
     TS4 = timestamp(),
     true = ((TS4 - TS3) > RefT),
-    {ok, pong} = do_inet_rpc(Sock3,net_adm,ping,[NN2]),
-    {ok, pong} = do_inet_rpc(Sock2,net_adm,ping,[NN]),
-    {ok, true} = do_inet_rpc(Sock3,net_kernel,disconnect,[NN2]),
+    pong = peer:call(PN3,net_adm,ping,[NN2]),
+    pong = peer:call(PN2,net_adm,ping,[NN]),
+    true = peer:call(PN3,net_kernel,disconnect,[NN2]),
     receive
     after 500 -> ok
     end,
-    {ok, pang} = do_inet_rpc(Sock2,net_adm,ping,[NN]),
-    {ok, true} = do_inet_rpc(Sock2,net_kernel,connect_node,[NN]),
-    {ok, pong} = do_inet_rpc(Sock2,net_adm,ping,[NN]),
-    stop_relay_node(Sock3),
-    stop_relay_node(Sock2).
+    pang = peer:call(PN2,net_adm,ping,[NN]),
+    true = peer:call(PN2,net_kernel,connect_node,[NN]),
+    pong = peer:call(PN2,net_adm,ping,[NN]),
+    peer:stop(PN3),
+    peer:stop(PN2).
 
 
 
-%% Start a relay node and a lonely (dist_auto_connect never) node.
-%% Lonely node pings relay node. That should fail. 
-%% Lonely node connects to relay node with net_kernel:connect_node/1.
-%% Result is sent here through relay node.
+%% Spawn dist_auto_connect never node, ensure it won't
+%%  connect to the origin with net_adm:ping(), but will with
+%%  explicit net_kernel:connect_node.
 dist_auto_connect_never(Config) when is_list(Config) ->
-    Self = self(),
-    {ok, RelayNode} = start_node(dist_auto_connect_relay),
-    spawn(RelayNode,
-          fun() ->
-                  register(dist_auto_connect_relay, self()),
-                  dist_auto_connect_relay(Self)
-          end),
-    {ok, Handle} = dist_auto_connect_start(dist_auto_connect, never),
-    Result = receive
-                 {do_dist_auto_connect, ok} ->
-                     ok;
-                 {do_dist_auto_connect, Error} ->
-                     {error, Error};
-                 %% The io:formats in dos_dist_auto_connect will
-                 %% generate port output messages that are ok
-                 Other when not is_port(element(1, Other))->
-                     {error, Other}
-             after 32000 ->
-                       timeout
-             end,
-    stop_node(RelayNode),
-    Stopped = dist_auto_connect_stop(Handle),
-    Junk = receive
-               {do_dist_auto_connect, _} = J -> J
-           after 0 -> ok
-           end,
-    {ok, ok, ok} = {Result, Stopped, Junk},
+    {ok, LonelyPeer, Node} = ?CT_PEER(#{connection => 0, args => ["-kernel", "dist_auto_connect", "never"]}),
+    pang = peer:call(LonelyPeer, net_adm, ping, [node()]),
+    false = lists:member(Node, nodes()),
+    true = peer:call(LonelyPeer, net_kernel, connect_node, [node()]),
+    true = lists:member(Node, nodes()),
+    peer:stop(LonelyPeer),
     ok.
 
-
-do_dist_auto_connect([never]) ->
-    Node = list_to_atom("dist_auto_connect_relay@" ++ hostname()),
-    io:format("~p:do_dist_auto_connect([false]) Node=~p~n", [?MODULE, Node]),
-    Ping = net_adm:ping(Node),
-    io:format("~p:do_dist_auto_connect([false]) Ping=~p~n", [?MODULE, Ping]),
-    Result = case Ping of
-                 pang -> ok;
-                 _ -> {error, Ping}
-             end,
-    io:format("~p:do_dist_auto_connect([false]) Result=~p~n", [?MODULE, Result]),
-    net_kernel:connect_node(Node),
-    catch {dist_auto_connect_relay, Node} ! {do_dist_auto_connect, Result};
-%    receive after 1000 -> ok end,
-%    halt();
-
-do_dist_auto_connect(Arg) ->
-    io:format("~p:do_dist_auto_connect(~p)~n", [?MODULE, Arg]),
-    receive after 10000 -> ok end,
-    halt().
-
-
-dist_auto_connect_start(Name, Value) when is_atom(Name) ->
-    dist_auto_connect_start(atom_to_list(Name), Value);
-dist_auto_connect_start(Name, Value) when is_list(Name), is_atom(Value) ->
-    Node = list_to_atom(lists:append([Name, "@", hostname()])),
-    ModuleDir = filename:dirname(code:which(?MODULE)),
-    ValueStr = atom_to_list(Value),
-    Cookie = atom_to_list(erlang:get_cookie()),
-    Cmd = lists:append(
-            [%"xterm -e ",
-             ct:get_progname(),
-             %	     " -noinput ",
-             " -detached ",
-             long_or_short(), " ", Name,
-             " -setcookie ", Cookie,
-             " -pa ", ModuleDir,
-             " -s ", atom_to_list(?MODULE),
-             " do_dist_auto_connect ", ValueStr,
-             " -kernel dist_auto_connect ", ValueStr]),
-    io:format("~p:dist_auto_connect_start() cmd: ~p~n", [?MODULE, Cmd]),
-    Port = open_port({spawn, Cmd}, [stream]),
-    {ok, {Port, Node}}.
-
-
-dist_auto_connect_stop({Port, Node}) ->
-    Pid = spawn_link(fun() -> rpc:call(Node, erlang, halt, []) end),
-    dist_auto_connect_stop(Port, Node, Pid, 5000).
-
-dist_auto_connect_stop(Port, _Node, Pid, N) when is_integer(N), N =< 0 ->
-    exit(Pid, normal),
-    catch erlang:port_close(Port),
-    Result = {error, node_not_down},
-    io:format("~p:dist_auto_connect_stop() ~p~n", [?MODULE, Result]),
-    Result;
-dist_auto_connect_stop(Port, Node, Pid, N) when is_integer(N) ->
-    case net_adm:ping(Node) of
-        pong ->
-            receive after 100 -> ok end,
-            dist_auto_connect_stop(Port, Node, Pid, N-100);
-        pang ->
-            exit(Pid, normal),
-            catch erlang:port_close(Port),
-            io:format("~p:dist_auto_connect_stop() ok~n", [?MODULE]),
-            ok
-    end.
-
-
-dist_auto_connect_relay(Parent) ->
-    receive X ->
-                catch Parent ! X
-    end,
-    dist_auto_connect_relay(Parent).
-
-
 dist_parallel_send(Config) when is_list(Config) ->
-    {ok, RNode} = start_node(dist_parallel_receiver),
-    {ok, SNode} = start_node(dist_parallel_sender),
+    {ok, RPeer, RNode} = ?CT_PEER(),
+    {ok, SPeer, SNode} = ?CT_PEER(),
     WatchDog = spawn_link(
                  fun () ->
                          TRef = erlang:start_timer((2*60*1000), self(), oops),
@@ -1136,8 +1018,8 @@ dist_parallel_send(Config) when is_list(Config) ->
     unlink(WatchDog),
     exit(WatchDog, bang),
 
-    stop_node(RNode),
-    stop_node(SNode),
+    peer_stop(RPeer, RNode),
+    peer_stop(SPeer, SNode),
 
     ok.
 
@@ -1163,17 +1045,17 @@ dist_evil_parallel_receiver() ->
 atom_roundtrip(Config) when is_list(Config) ->
     AtomData = atom_data(),
     verify_atom_data(AtomData),
-    {ok, Node} = start_node(Config),
+    {ok, Peer, Node} = ?CT_PEER(),
     do_atom_roundtrip(Node, AtomData),
-    stop_node(Node),
+    peer_stop(Peer, Node),
     ok.
 
 unicode_atom_roundtrip(Config) when is_list(Config) ->
     AtomData = unicode_atom_data(),
     verify_atom_data(AtomData),
-    {ok, Node} = start_node(Config),
+    {ok, Peer, Node} = ?CT_PEER(),
     do_atom_roundtrip(Node, AtomData),
-    stop_node(Node),
+    peer_stop(Peer, Node),
     ok.
 
 do_atom_roundtrip(Node, AtomData) ->
@@ -1269,17 +1151,17 @@ unicode_atom_data() ->
                  end, lists:seq(1, 2000))].
 
 contended_atom_cache_entry(Config) when is_list(Config) ->
-    contended_atom_cache_entry_test(Config, latin1).
+    contended_atom_cache_entry_test(latin1).
 
 contended_unicode_atom_cache_entry(Config) when is_list(Config) ->
-    contended_atom_cache_entry_test(Config, unicode).
+    contended_atom_cache_entry_test(unicode).
 
-contended_atom_cache_entry_test(Config, Type) ->
+contended_atom_cache_entry_test(Type) ->
     TestServer = self(),
     ProcessPairs = 10,
     Msgs = 100000,
-    {ok, SNode} = start_node(Config),
-    {ok, RNode} = start_node(Config),
+    {ok, SPeer, SNode} = ?CT_PEER(),
+    {ok, RPeer, RNode} = ?CT_PEER(),
     Success = make_ref(),
     spawn_link(
       SNode,
@@ -1341,8 +1223,8 @@ contended_atom_cache_entry_test(Config, Type) ->
         Success ->
             ok
     end,
-    stop_node(SNode),
-    stop_node(RNode),
+    peer_stop(SPeer, SNode),
+    peer_stop(RPeer, RNode),
     ok.
 
 send_ref_atom(_To, _Ref, _Atom, 0) ->
@@ -1417,15 +1299,15 @@ get_conflicting_unicode_atoms(CIX, N) ->
 %% they no longer fail when the latency is incorrect. However, they are
 %% kept as they continue to find bugs in the distribution implementation.
 message_latency_large_message(Config) when is_list(Config) ->
-    measure_latency_large_message(?FUNCTION_NAME, fun(Dropper, Payload) -> Dropper ! Payload end).
+    measure_latency_large_message(fun(Dropper, Payload) -> Dropper ! Payload end).
 message_latency_large_exit2(Config) when is_list(Config) ->
-    measure_latency_large_message(?FUNCTION_NAME, fun erlang:exit/2).
+    measure_latency_large_message(fun erlang:exit/2).
 
 message_latency_large_link_exit(Config) when is_list(Config) ->
-    message_latency_large_exit(?FUNCTION_NAME, fun erlang:link/1).
+    message_latency_large_exit(fun erlang:link/1).
 
 message_latency_large_monitor_exit(Config) when is_list(Config) ->
-    message_latency_large_exit(?FUNCTION_NAME,
+    message_latency_large_exit(
                                fun(Dropper) ->
                                        Dropper ! {monitor, self()},
                                        receive ok -> ok end
@@ -1440,9 +1322,8 @@ message_latency_large_link_exit() ->
 message_latency_large_monitor_exit() ->
     message_latency_large_message().
 
-message_latency_large_exit(Nodename, ReasonFun) ->
+message_latency_large_exit(ReasonFun) ->
     measure_latency_large_message(
-      Nodename,
       fun(Dropper, Payload) ->
               Pid  = spawn(fun() ->
                                    receive go -> ok end,
@@ -1467,11 +1348,11 @@ message_latency_large_exit(Nodename, ReasonFun) ->
               end
       end).
 
-measure_latency_large_message(Nodename, DataFun) ->
+measure_latency_large_message(DataFun) ->
 
     erlang:system_monitor(self(), [busy_dist_port]),
 
-    {ok, N} = start_node(Nodename),
+    {ok, Peer, N} = ?CT_PEER(),
 
     Dropper = spawn(N, fun F() ->
                                process_flag(trap_exit, true),
@@ -1505,7 +1386,7 @@ measure_latency_large_message(Nodename, DataFun) ->
 
     ct:pal("~p",[IndexTimes]),
 
-    stop_node(N),
+    peer_stop(Peer, N),
 
     case {lists:max(Times), lists:min(Times)} of
         {Max, Min} when Max * 0.25 > Min, BuildType =:= opt ->
@@ -1519,8 +1400,6 @@ measure_latency_large_message(Nodename, DataFun) ->
     end.
 
 measure_latency(DataFun, Dropper, Echo, Payload) ->
-
-    TCProc = self(),
 
     flush(),
 
@@ -1599,7 +1478,7 @@ test_system_limit(Config) when is_list(Config) ->
     Bits = ((1 bsl 32)+1)*8,
     HugeBin = <<0:Bits>>,
     HugeListBin = [lists:duplicate(2000000,2000000), HugeBin],
-    {ok, N1} = start_node(Config),
+    {ok, _Peer1, N1} = ?CT_PEER(),
     monitor_node(N1, true),
     receive
         {nodedown, N1} ->
@@ -1672,7 +1551,7 @@ test_system_limit(Config) when is_list(Config) ->
           end),
     receive {nodedown, N1} -> ok end,
 
-    {ok, N2} = start_node(Config),
+    {ok, _Peer2, N2} = ?CT_PEER(),
     monitor_node(N2, true),
     P2 = spawn(N2,
                fun () ->
@@ -1685,7 +1564,7 @@ test_system_limit(Config) when is_list(Config) ->
     receive {nodedown, N2} -> ok end,
 
     io:format("~n** distributed monitor down **~n~n", []),
-    {ok, N3} = start_node(Config),
+    {ok, _Peer3, N3} = ?CT_PEER(),
     monitor_node(N3, true),
     Go1 = make_ref(),
     LP1 = spawn(fun () ->
@@ -1700,7 +1579,7 @@ test_system_limit(Config) when is_list(Config) ->
                end),
     receive {nodedown, N3} -> ok end,
 
-    {ok, N4} = start_node(Config),
+    {ok, _Peer4, N4} = ?CT_PEER(),
     monitor_node(N4, true),
     Go2 = make_ref(),
     LP2 = spawn(fun () ->
@@ -1785,8 +1664,8 @@ start_link(Offender,P) ->
 bad_dist_structure(Config) when is_list(Config) ->
     ct:timetrap({seconds, 15}),
 
-    {ok, Offender} = start_node(bad_dist_structure_offender),
-    {ok, Victim} = start_node(bad_dist_structure_victim),
+    {ok, OffenderPeer, Offender} = ?CT_PEER(),
+    {ok, VictimPeer, Victim} = ?CT_PEER(),
     start_node_monitors([Offender,Victim]),
     Parent = self(),
     P = spawn(Victim,
@@ -1872,16 +1751,16 @@ bad_dist_structure(Config) when is_list(Config) ->
 
     unlink(P),
     P ! done,
-    stop_node(Offender),
-    stop_node(Victim),
+    peer_stop(OffenderPeer, Offender),
+    peer_stop(VictimPeer, Victim),
     ok.
 
 %% Test various dist fragmentation errors
 bad_dist_fragments(Config) when is_list(Config) ->
     ct:timetrap({seconds, 15}),
 
-    {ok, Offender} = start_node(bad_dist_fragment_offender),
-    {ok, Victim} = start_node(bad_dist_fragment_victim),
+    {ok, OffenderPeer, Offender} = ?CT_PEER(),
+    {ok, VictimPeer, Victim} = ?CT_PEER(),
 
     Msg = iolist_to_binary(dmsg_ext(lists:duplicate(255,255))),
 
@@ -1974,8 +1853,8 @@ bad_dist_fragments(Config) when is_list(Config) ->
 
     unlink(P),
     P ! done,
-    stop_node(Offender),
-    stop_node(Victim),
+    peer_stop(OffenderPeer, Offender),
+    peer_stop(VictimPeer, Victim),
     ok.
 
 dmsg_frag_hdr(Frag) ->
@@ -2035,8 +1914,8 @@ send_bad_fragments(Offender,VictimNode,Victim,Ctrl,WhereToPutSelf,Fragments) ->
     end.
 
 bad_dist_ext_receive(Config) when is_list(Config) ->
-    {ok, Offender} = start_node(bad_dist_ext_receive_offender),
-    {ok, Victim} = start_node(bad_dist_ext_receive_victim),
+    {ok, OffenderPeer, Offender} = ?CT_PEER(),
+    {ok, VictimPeer, Victim} = ?CT_PEER(),
     start_node_monitors([Offender,Victim]),
 
     Parent = self(),
@@ -2102,13 +1981,13 @@ bad_dist_ext_receive(Config) when is_list(Config) ->
     P ! done,
     unlink(P),
     verify_no_down(Offender, Victim),
-    stop_node(Offender),
-    stop_node(Victim).
+    peer_stop(OffenderPeer, Offender),
+    peer_stop(VictimPeer, Victim).
 
 
 bad_dist_ext_process_info(Config) when is_list(Config) ->
-    {ok, Offender} = start_node(bad_dist_ext_process_info_offender),
-    {ok, Victim} = start_node(bad_dist_ext_process_info_victim),
+    {ok, OffenderPeer, Offender} = ?CT_PEER(),
+    {ok, VictimPeer, Victim} = ?CT_PEER(),
     start_node_monitors([Offender,Victim]),
 
     Parent = self(),
@@ -2163,12 +2042,12 @@ bad_dist_ext_process_info(Config) when is_list(Config) ->
     P ! done,
     unlink(P),
     verify_no_down(Offender, Victim),
-    stop_node(Offender),
-    stop_node(Victim).
+    peer_stop(OffenderPeer, Offender),
+    peer_stop(VictimPeer, Victim).
 
 bad_dist_ext_control(Config) when is_list(Config) ->
-    {ok, Offender} = start_node(bad_dist_ext_control_offender),
-    {ok, Victim} = start_node(bad_dist_ext_control_victim),
+    {ok, OffenderPeer, Offender} = ?CT_PEER(),
+    {ok, VictimPeer, Victim} = ?CT_PEER(),
     start_node_monitors([Offender,Victim]),
 
     pong = rpc:call(Victim, net_adm, ping, [Offender]),
@@ -2182,12 +2061,12 @@ bad_dist_ext_control(Config) when is_list(Config) ->
     verify_down(Offender, connection_closed, Victim, killed),
 
     verify_no_down(Offender, Victim),
-    stop_node(Offender),
-    stop_node(Victim).
+    peer_stop(OffenderPeer, Offender),
+    peer_stop(VictimPeer, Victim).
 
 bad_dist_ext_connection_id(Config) when is_list(Config) ->
-    {ok, Offender} = start_node(bad_dist_ext_connection_id_offender),
-    {ok, Victim} = start_node(bad_dist_ext_connection_id_victim),
+    {ok, OffenderPeer, Offender} = ?CT_PEER(),
+    {ok, VictimPeer, Victim} = ?CT_PEER(),
     start_node_monitors([Offender,Victim]),
 
     Parent = self(),
@@ -2248,15 +2127,13 @@ bad_dist_ext_connection_id(Config) when is_list(Config) ->
     P ! done,
     unlink(P),
     verify_no_down(Offender, Victim),
-    stop_node(Offender),
-    stop_node(Victim).
+    peer_stop(OffenderPeer, Offender),
+    peer_stop(VictimPeer, Victim).
 
 %% OTP-14661: Bad message is discovered by erts_msg_attached_data_size
 bad_dist_ext_size(Config) when is_list(Config) ->
-    {ok, Offender} = start_node(bad_dist_ext_process_info_offender),
-    %%Prog = "Prog=/home/uabseri/src/otp_new3/bin/cerl -rr -debug",
-    Prog = [],
-    {ok, Victim} = start_node(bad_dist_ext_process_info_victim, [], Prog),
+    {ok, OffenderPeer, Offender} = ?CT_PEER(),
+    {ok, VictimPeer, Victim} = ?CT_PEER(),
     start_node_monitors([Offender,Victim]),
 
     Parent = self(),
@@ -2303,8 +2180,8 @@ bad_dist_ext_size(Config) when is_list(Config) ->
 
     unlink(P),
     verify_no_down(Offender, Victim),
-    stop_node(Offender),
-    stop_node(Victim).
+    peer_stop(OffenderPeer, Offender),
+    peer_stop(VictimPeer, Victim).
 
 
 bad_dist_struct_check_msgs([]) ->
@@ -2543,43 +2420,47 @@ dmsg_bad_tag() ->  %% Will fail early at heap size calculation
 
 start_epmd_false(Config) when is_list(Config) ->
     %% Start a node with the option -start_epmd false.
-    {ok, OtherNode} = start_node(start_epmd_false, "-start_epmd false"),
+    {ok, Peer, OtherNode} = ?CT_PEER(["-start_epmd", "false"]),
     %% We should be able to ping it, as epmd was started by us:
     pong = net_adm:ping(OtherNode),
-    stop_node(OtherNode),
+    peer_stop(Peer,OtherNode),
 
     ok.
 
 no_epmd(Config) when is_list(Config) ->
     %% Trying to start a node with -no_epmd but without passing the
     %% --proto_dist option should fail.
-    {error, timeout} = start_node(no_epmd, "-no_epmd").
+    try
+        ?CT_PEER(#{connection => standard_io, args => ["-no_epmd"]}),
+        ct:fail(unexpected_no_epmd_start)
+    catch
+        exit:{boot_failed, {exit_status, 1}} ->
+            ok
+    end.
 
 epmd_module(Config) when is_list(Config) ->
     %% We need a relay node to test this, since the test node uses the
     %% standard epmd module.
-    Sock1 = start_relay_node(epmd_module_node1, "-epmd_module " ++ ?MODULE_STRING),
-    Node1 = inet_rpc_nodename(Sock1),
+    {ok, Peer1, Node1} = ?CT_PEER(#{connection => 0, args => ["-setcookie", "NONE", "-epmd_module", ?MODULE_STRING]}),
     %% Ask what port it's listening on - it won't have registered with
     %% epmd.
-    {ok, {ok, Port1}} = do_inet_rpc(Sock1, application, get_env, [kernel, dist_listen_port]),
+    {ok, Port1} = peer:call(Peer1, application, get_env, [kernel, dist_listen_port]),
 
     %% Start a second node, passing the port number as a secret
     %% argument.
-    Sock2 = start_relay_node(epmd_module_node2, "-epmd_module " ++ ?MODULE_STRING
-			     ++ " -other_node_port " ++ integer_to_list(Port1)),
-    Node2 = inet_rpc_nodename(Sock2),
+    {ok, Peer2, Node2} = ?CT_PEER(#{connection => 0,
+        args => ["-setcookie", "NONE", "-epmd_module", ?MODULE_STRING, "-other_node_port", integer_to_list(Port1)]}),
     %% Node 1 can't ping node 2
-    {ok, pang} = do_inet_rpc(Sock1, net_adm, ping, [Node2]),
-    {ok, []} = do_inet_rpc(Sock1, erlang, nodes, []),
-    {ok, []} = do_inet_rpc(Sock2, erlang, nodes, []),
+    pang = peer:call(Peer1, net_adm, ping, [Node2]),
+    [] = peer:call(Peer1, erlang, nodes, []),
+    [] = peer:call(Peer2, erlang, nodes, []),
     %% But node 2 can ping node 1
-    {ok, pong} = do_inet_rpc(Sock2, net_adm, ping, [Node1]),
-    {ok, [Node2]} = do_inet_rpc(Sock1, erlang, nodes, []),
-    {ok, [Node1]} = do_inet_rpc(Sock2, erlang, nodes, []),
+    pong = peer:call(Peer2, net_adm, ping, [Node1]),
+    [Node2] = peer:call(Peer1, erlang, nodes, []),
+    [Node1] = peer:call(Peer2, erlang, nodes, []),
 
-    stop_relay_node(Sock2),
-    stop_relay_node(Sock1).
+    peer:stop(Peer2),
+    peer:stop(Peer1).
 
 %% epmd_module functions:
 
@@ -2618,8 +2499,8 @@ hopefull_data_encoding(Config) when is_list(Config) ->
     test_hopefull_data_encoding(Config, false).
 
 test_hopefull_data_encoding(Config, Fallback) when is_list(Config) ->
-    {ok, ProxyNode} = start_node(hopefull_data_normal),
-    {ok, BouncerNode} = start_node(hopefull_data_bouncer, "-hidden"),
+    {ok, PeerProxy, ProxyNode} = ?CT_PEER(),
+    {ok, PeerBouncer, BouncerNode} = ?CT_PEER(["-hidden"]),
     case Fallback of
         false ->
             ok;
@@ -2678,8 +2559,8 @@ test_hopefull_data_encoding(Config, Fallback) when is_list(Config) ->
     exit(Proxy, bye),
     unlink(Bouncer),
     exit(Bouncer, bye),
-    stop_node(ProxyNode),
-    stop_node(BouncerNode),
+    peer_stop(PeerProxy, ProxyNode),
+    peer_stop(PeerBouncer, BouncerNode),
     ok.
 
 bounce_loop() ->
@@ -2774,14 +2655,14 @@ hopefull_export_fun_bug(Config) when is_list(Config) ->
            2, fun blipp:blapp/7],
     {dummy, dummy@dummy} ! Msg.  % Would crash on debug VM
 
-huge_iovec(Config) ->
+huge_iovec(Config) when is_list(Config) ->
     %% Make sure that we can pass a term that will produce
     %% an io-vector larger than IOV_MAX over the distribution...
     %% IOV_MAX is typically 1024. Currently we produce an
     %% element in the io-vector for all off heap binaries...
     NoBinaries = 1 bsl 14,
     BinarySize = 65,
-    {ok, Node} = start_node(huge_iovec),
+    {ok, Peer, Node} = ?CT_PEER(),
     P = spawn_link(Node,
                    fun () ->
                            receive {From, Data} ->
@@ -2797,7 +2678,7 @@ huge_iovec(Config) ->
     P ! {self(), RBL},
     receive
         {P, EchoedRBL} ->
-            stop_node(Node),
+            peer_stop(Peer, Node),
             RBL = EchoedRBL
     end,
     ok.
@@ -2821,10 +2702,10 @@ mk_rand_bin(N, Data) ->
 
 %% Try provoke DistEntry refc bugs (OTP-17513).
 dist_entry_refc_race(_Config) ->
-    {ok, Node} = start_node(dist_entry_refc_race, "+zdntgc 1"),
+    {ok, Peer, Node} = ?CT_PEER(["+zdntgc", "1"]),
     Pid = spawn_link(Node, ?MODULE, derr_run, [self()]),
     {Pid, done} = receive M -> M end,
-    stop_node(Node),
+    peer_stop(Peer, Node),
     ok.
 
 derr_run(Papa) ->
@@ -2866,36 +2747,9 @@ derr_sender(Main, Nodes) ->
 timestamp() ->
     erlang:monotonic_time(millisecond).
 
-start_node(X) ->
-    start_node(X, [], []).
-
-start_node(X, Y) ->
-    start_node(X, Y, []).
-
-start_node(Name, Args, Rel) when is_atom(Name), is_list(Rel) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Cookie = atom_to_list(erlang:get_cookie()),
-    RelArg = case Rel of
-                 [] -> [];
-                 _ -> [{erl,[{release,Rel}]}]
-             end,
-    test_server:start_node(Name, slave,
-                           [{args,
-                             Args++" -setcookie "++Cookie++" -pa \""++Pa++"\""}
-                            | RelArg]);
-start_node(Config, Args, Rel) when is_list(Config), is_list(Rel) ->
-    Name = list_to_atom((atom_to_list(?MODULE)
-                         ++ "-"
-                         ++ atom_to_list(proplists:get_value(testcase, Config))
-                         ++ "-"
-                         ++ integer_to_list(erlang:system_time(second))
-                         ++ "-"
-                         ++ integer_to_list(erlang:unique_integer([positive])))),
-    start_node(Name, Args, Rel).
-
-stop_node(Node) ->
+peer_stop(Peer, Node) ->
     verify_nc(Node),
-    test_server:stop_node(Node).
+    peer:stop(Peer).
 
 verify_nc(Node) ->
     P = self(),
@@ -2930,78 +2784,6 @@ freeze_node(Node, MS) ->
                end),
     receive DoingIt -> ok end,
     receive after Own -> ok end.
-
-inet_rpc_nodename({N,H,_Sock}) ->
-    list_to_atom(N++"@"++H).
-
-do_inet_rpc({_,_,Sock},M,F,A) ->
-    Bin = term_to_binary({M,F,A}),
-    gen_tcp:send(Sock,Bin),
-    case gen_tcp:recv(Sock,0) of
-        {ok, Bin2} ->
-            T = binary_to_term(Bin2),
-            {ok,T};
-        Else ->
-            {error, Else}
-    end.
-
-inet_rpc_server([Host, PortList]) ->
-    Port = list_to_integer(PortList),
-    {ok, Sock} = gen_tcp:connect(Host, Port,[binary, {packet, 4}, 
-                                             {active, false}]),
-    inet_rpc_server_loop(Sock).
-
-inet_rpc_server_loop(Sock) ->
-    case gen_tcp:recv(Sock,0) of
-        {ok, Bin} ->
-            {M,F,A} = binary_to_term(Bin),
-            Res = (catch apply(M,F,A)),
-            RB = term_to_binary(Res),
-            gen_tcp:send(Sock,RB),
-            inet_rpc_server_loop(Sock);
-        _ ->
-            erlang:halt()
-    end.
-
-
-start_relay_node(Node, Args) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Cookie = "NOT"++atom_to_list(erlang:get_cookie()),
-    {ok, LSock} = gen_tcp:listen(0, [binary, {packet, 4}, {active, false}]),
-    {ok, Port} = inet:port(LSock),
-    {ok, Host} = inet:gethostname(),
-    RunArg = "-run " ++ atom_to_list(?MODULE) ++ " inet_rpc_server " ++
-    Host ++ " " ++ integer_to_list(Port),
-    {ok, NN} = test_server:start_node(Node, peer,
-                                      [{args, Args ++
-                                        " -setcookie "++Cookie++" -pa "++Pa++" "++
-                                        RunArg}]),
-    [N,H] = string:lexemes(atom_to_list(NN),"@"),
-    {ok, Sock} = gen_tcp:accept(LSock),
-    pang = net_adm:ping(NN),
-    {N,H,Sock}.
-
-stop_relay_node({N,H,Sock}) ->
-    catch do_inet_rpc(Sock,erlang,halt,[]),
-    catch gen_tcp:close(Sock),
-    wait_dead(N,H,10).
-
-wait_dead(N,H,0) ->
-    {error,{not_dead,N,H}};
-wait_dead(N,H,X) ->
-    case erl_epmd:port_please(N,H) of
-        {port,_,_} ->
-            receive
-            after 1000 ->
-                      ok
-            end,
-            wait_dead(N,H,X-1);
-        noport ->
-            ok;
-        Else ->
-            {error, {unexpected, Else}}
-    end.
-
 
 start_node_monitors(Nodes) ->
     Master = self(),
@@ -3108,13 +2890,6 @@ from(_, []) -> [].
 
 %% fun_spawn(Fun, Args) ->
 %%     spawn_link(erlang, apply, [Fun, Args]).
-
-
-long_or_short() -> 
-    case net_kernel:longnames() of
-        true -> " -name ";
-        false -> " -sname "
-    end.
 
 until(Fun) ->
     case Fun() of

--- a/erts/emulator/test/distribution_SUITE_data/run.erl
+++ b/erts/emulator/test/distribution_SUITE_data/run.erl
@@ -54,7 +54,7 @@ start() ->
 
 do_it() ->
     {ok, _} = net_kernel:start([fideridum,shortnames]),
-    {ok, Node} = slave:start(host(), heppel),
+    {ok, _Peer, Node} = peer:start(#{name => peer:random_name(heppel)}),
     P = spawn(Node, net_kernel, stop, []),
     B1 = term_to_binary(P),
     N1 = node(P),

--- a/erts/emulator/test/dump_SUITE.erl
+++ b/erts/emulator/test/dump_SUITE.erl
@@ -66,7 +66,7 @@ signal_abort(Config) ->
 
     Dump = filename:join(proplists:get_value(priv_dir, Config),"signal_abort.dump"),
 
-    {ok, Node} = start_node(Config),
+    {ok, _Peer, Node} = ?CT_PEER(),
 
     SO = rpc:call(Node, erlang, system_info, [schedulers_online]),
 
@@ -106,7 +106,7 @@ load() ->
 exiting_dump(Config) when is_list(Config) ->
     Dump = filename:join(proplists:get_value(priv_dir, Config),"signal_abort.dump"),
 
-    {ok, Node} = start_node(Config),
+    {ok, _Peer, Node} = ?CT_PEER(),
 
     Self = self(),
 
@@ -142,8 +142,8 @@ exiting_dump(Config) when is_list(Config) ->
 free_dump(Config) when is_list(Config) ->
     Dump = filename:join(proplists:get_value(priv_dir, Config),"signal_abort.dump"),
 
-    {ok, NodeA} = start_node(Config),
-    {ok, NodeB} = start_node(Config),
+    {ok, _PeerA, NodeA} = ?CT_PEER(),
+    {ok, PeerB, NodeB} = ?CT_PEER(),
 
     Self = self(),
 
@@ -197,7 +197,7 @@ free_dump(Config) when is_list(Config) ->
 
     unlink(PidB),
 
-    rpc:call(NodeB, erlang, halt, [0]),
+    peer:stop(PeerB),
 
     ok.
 
@@ -222,13 +222,3 @@ get_dump_when_done(Dump, Sz) ->
             get_dump_when_done(Dump, NewSz)
     end.
 
-start_node(Config) when is_list(Config) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Name = list_to_atom(atom_to_list(?MODULE)
-                        ++ "-"
-                        ++ atom_to_list(proplists:get_value(testcase, Config))
-                        ++ "-"
-                        ++ integer_to_list(erlang:system_time(second))
-                        ++ "-"
-                        ++ integer_to_list(erlang:unique_integer([positive]))),
-    test_server:start_node(Name, slave, [{args, "-pa "++Pa}]).

--- a/erts/emulator/test/efile_SUITE.erl
+++ b/erts/emulator/test/efile_SUITE.erl
@@ -52,11 +52,9 @@ iter_max_files_1(Config) ->
             N = 10
     end,
     %% Run on a different node in order to make the test more stable.
-    Dir = filename:dirname(code:which(?MODULE)),
-    {ok,Node} = test_server:start_node(test_iter_max_files,slave,
-                                       [{args,"-pa " ++ Dir}]),
+    {ok, Peer, Node} = ?CT_PEER(),
     L = rpc:call(Node,?MODULE,do_iter_max_files,[N, TestFile]),
-    test_server:stop_node(Node),
+    peer:stop(Peer),
     io:format("Number of files opened in each test:~n~w\n", [L]),
     verify_max_files(L),
     Head = hd(L),

--- a/erts/emulator/test/erts_debug_SUITE.erl
+++ b/erts/emulator/test/erts_debug_SUITE.erl
@@ -260,29 +260,21 @@ instructions(Config) when is_list(Config) ->
 
 alloc_blocks_size(Config) when is_list(Config) ->
     F = fun(Args) ->
-                Node = start_slave(Args),
+                {ok, Peer, Node} = ?CT_PEER(Args),
                 ok = rpc:call(Node, ?MODULE, do_alloc_blocks_size, []),
-                true = test_server:stop_node(Node)
+                peer:stop(Peer)
         end,
     case test_server:is_asan() of
-	false -> F("+Meamax");
+	false -> F(["+Meamax"]);
 	true -> skip
     end,
-    F("+Meamin"),
-    F(""),
+    F(["+Meamin"]),
+    F([]),
     ok.
 
 do_alloc_blocks_size() ->
     _ = erts_debug:alloc_blocks_size(binary_alloc),
     ok.
-
-start_slave(Args) ->
-    Name = ?MODULE_STRING ++ "_slave",
-    Pa = filename:dirname(code:which(?MODULE)),
-    {ok, Node} = test_server:start_node(list_to_atom(Name),
-                                        slave,
-                                        [{args, "-pa " ++ Pa ++ " " ++ Args}]),
-    Node.
 
 id(I) ->
     I.

--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -693,7 +693,7 @@ error_info(_Config) ->
                     end,
 
     %% Pick up external pid and port.
-    {ok, ExternalNode} = test_server:start_node(?FUNCTION_NAME, slave, []),
+    {ok, Peer, ExternalNode} = ?CT_PEER(),
     ExternalPid = rpc:call(ExternalNode, erlang, whereis, [code_server]),
     ExternalPort = hd(rpc:call(ExternalNode, erlang, ports, [])),
 
@@ -1307,7 +1307,7 @@ error_info(_Config) ->
     try
         do_error_info(L)
     after
-        test_server:stop_node(ExternalNode)
+        peer:stop(Peer)
     end.
 
 dead_process() ->

--- a/erts/emulator/test/float_SUITE.erl
+++ b/erts/emulator/test/float_SUITE.erl
@@ -98,7 +98,7 @@ fp_drv_thread(Config) when is_list(Config) ->
     %% Run in a separate node since it used to crash the emulator...
     Parent = self(),
     DrvDir = proplists:get_value(data_dir, Config),
-    {ok,Node} = start_node(Config),
+    {ok, Peer, Node} = ?CT_PEER(),
     Tester = spawn_link(Node,
                         fun () ->
                                 Parent !
@@ -107,7 +107,7 @@ fp_drv_thread(Config) when is_list(Config) ->
                                              DrvDir)}
                         end),
     Result = receive {Tester, Res} -> Res end,
-    stop_node(Node),
+    peer:stop(Peer),
     Result.
 
 fp_drv_test(Test, DrvDir) ->
@@ -284,21 +284,6 @@ cmp(Big,Small,BigGtSmall,BigLtSmall,SmallGtBig,SmallLtBig,
                      Big == Small}.
 
 id(I) -> I.
-
-start_node(Config) when is_list(Config) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Name = list_to_atom(atom_to_list(?MODULE)
-                        ++ "-"
-                        ++ atom_to_list(proplists:get_value(testcase, Config))
-                        ++ "-"
-                        ++ integer_to_list(erlang:system_time(second))
-                        ++ "-"
-                        ++ integer_to_list(erlang:unique_integer([positive]))),
-    test_server:start_node(Name, slave, [{args, "-pa "++Pa}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).
-
 
 %% Test that operations that might hide infinite intermediate results
 %% do not supress the badarith.

--- a/erts/emulator/test/hash_SUITE.erl
+++ b/erts/emulator/test/hash_SUITE.erl
@@ -563,12 +563,12 @@ last_byte(Bin) ->
 test_phash2_4GB_plus_bin(Config) when is_list(Config) ->
     run_when_enough_resources(
       fun() ->
-              {ok, N} = start_node(?FUNCTION_NAME),
+              {ok, Peer, N} = ?CT_PEER(),
               erpc:call(N,
                         fun() ->
                                 test_phash2_4GB_plus_bin_tc()
                         end),
-              stop_node(N)
+              peer:stop(Peer)
       end).
 
 test_phash2_4GB_plus_bin_tc() ->
@@ -720,36 +720,6 @@ total_memory() ->
         _ : _ ->
             undefined
     end.
-
-start_node(X) ->
-    start_node(X, [], []).
-
-start_node(X, Y) ->
-    start_node(X, Y, []).
-
-start_node(Name, Args, Rel) when is_atom(Name), is_list(Rel) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Cookie = atom_to_list(erlang:get_cookie()),
-    RelArg = case Rel of
-                 [] -> [];
-                 _ -> [{erl,[{release,Rel}]}]
-             end,
-    test_server:start_node(Name, slave,
-                           [{args,
-                             Args++" -setcookie "++Cookie++" -pa \""++Pa++"\""}
-                            | RelArg]);
-start_node(Config, Args, Rel) when is_list(Config), is_list(Rel) ->
-    Name = list_to_atom((atom_to_list(?MODULE)
-                         ++ "-"
-                         ++ atom_to_list(proplists:get_value(testcase, Config))
-                         ++ "-"
-                         ++ integer_to_list(erlang:system_time(second))
-                         ++ "-"
-                         ++ integer_to_list(erlang:unique_integer([positive])))),
-    start_node(Name, Args, Rel).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).
 
 -ifdef(FALSE).
 f1() ->

--- a/erts/emulator/test/hash_property_test_SUITE.erl
+++ b/erts/emulator/test/hash_property_test_SUITE.erl
@@ -81,23 +81,15 @@ test_phash2_no_diff_long(Config) when is_list(Config) ->
 
 test_phash2_no_diff_between_versions(Config) when is_list(Config) ->
     R = "21",
-    case test_server:is_release_available(R) of
-        true ->
-            Rel = {release,R},
-            case test_server:start_node(rel21,peer,[{erl,[Rel]}]) of
-                {error, Reason} -> {skip, io_lib:format("Could not start node: ~p~n", [Reason])};
-                {ok, Node} ->
-                    try
-                        true = ct_property_test:quickcheck(
-                                 phash2_properties:prop_phash2_same_in_different_versions(Node),
-                                 Config),
-                        true = ct_property_test:quickcheck(
-                                 phash2_properties:prop_phash2_same_in_different_versions_with_long_input(Node),
-                                 Config)
-                    after
-                        test_server:stop_node(Node)
-                    end
-            end;
-        false ->
+    case ?CT_PEER([], R, proplists:get_value(priv_dir, Config)) of
+        {ok, Peer, Node} ->
+            true = ct_property_test:quickcheck(
+                     phash2_properties:prop_phash2_same_in_different_versions(Node),
+                     Config),
+            true = ct_property_test:quickcheck(
+                     phash2_properties:prop_phash2_same_in_different_versions_with_long_input(Node),
+                     Config),
+            peer:stop(Peer);
+        not_available ->
             {skip, io_lib:format("Release ~s not available~n", [R])}
     end.

--- a/erts/emulator/test/list_bif_SUITE.erl
+++ b/erts/emulator/test/list_bif_SUITE.erl
@@ -143,7 +143,7 @@ t_list_to_ref(Config) when is_list(Config) ->
 
 %% Test list_to_pid/port/ref for external pids/ports/refs.
 t_list_to_ext_pidportref(Config) when is_list(Config) ->
-    {ok, Node} = slave:start(net_adm:localhost(), t_list_to_ext_pidportref),
+    {ok, Peer, Node} = ?CT_PEER(),
     Pid = rpc:call(Node, erlang, self, []),
     Port = hd(rpc:call(Node, erlang, ports, [])),
     Ref = rpc:call(Node, erlang, make_ref, []),
@@ -195,7 +195,7 @@ t_list_to_ext_pidportref(Config) when is_list(Config) ->
     true = rpc:call(Node, erlang, '=:=', [Ref, Ref0]),
     true = rpc:call(Node, erlang, '==',  [Ref, Ref0]),
 
-    slave:stop(Node),
+    peer:stop(Peer),
     ok.
 
 -define(NEW_PID_EXT, 88).

--- a/erts/emulator/test/lttng_SUITE.erl
+++ b/erts/emulator/test/lttng_SUITE.erl
@@ -298,14 +298,14 @@ chk_caller(Port, Callback, ExpectedCaller) ->
             ExpectedCaller = Caller
     end.
 
-ets_load(Config) ->
+ets_load(Config) when is_list(Config) ->
 
     %% Have to do on a fresh node to guarantee that carriers are created
-    {ok,Node} = start_node(Config),
+    {ok, Peer, Node} = ?CT_PEER(),
 
     Res = rpc:call(Node, ?MODULE, ets_load, []),
 
-    stop_node(Node),
+    peer:stop(Peer),
 
     Res.
 
@@ -447,19 +447,3 @@ cmd(Cmd) ->
     io:format(">> ~ts~n", [Res]),
     {ok,Res}.
 
-start_node(Config) ->
-    start_node(Config, "").
-
-start_node(Config, Args) when is_list(Config) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Name = list_to_atom(atom_to_list(?MODULE)
-			++ "-"
-			++ atom_to_list(proplists:get_value(testcase, Config))
-			++ "-"
-			++ integer_to_list(erlang:system_time(second))
-			++ "-"
-			++ integer_to_list(erlang:unique_integer([positive]))),
-    test_server:start_node(Name, slave, [{args, "-pa "++Pa++" "++Args}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).

--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -90,6 +90,7 @@
          t_large_unequal_bins_same_hash_bug/1]).
 
 -include_lib("stdlib/include/ms_transform.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 -define(CHECK(Cond,Term),
 	case (catch (Cond)) of
@@ -3250,8 +3251,7 @@ t_hash_entropy(Config) when is_list(Config)  ->
 %% Provoke major GC with a lot of "fat" maps on external format in msg queue
 %% causing heap fragments to be allocated.
 t_gc_rare_map_overflow(Config) when is_list(Config) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    {ok, Node} = test_server:start_node(gc_rare_map_overflow, slave, [{args, "-pa \""++Pa++"\""}]),
+    {ok, Peer, Node} = ?CT_PEER(),
     erts_debug:set_internal_state(available_internal_state, true),
     try
 	Echo = spawn_link(Node, fun Loop() -> receive {From,Msg} -> From ! Msg
@@ -3282,7 +3282,7 @@ t_gc_rare_map_overflow(Config) when is_list(Config) ->
     after
 	process_flag(trap_exit, false),
 	erts_debug:set_internal_state(available_internal_state, false),
-	test_server:stop_node(Node)
+	peer:stop(Peer)
     end.
 
 t_gc_rare_map_overflow_do(Echo, FatMap, GcFun) ->

--- a/erts/emulator/test/match_spec_SUITE.erl
+++ b/erts/emulator/test/match_spec_SUITE.erl
@@ -176,7 +176,7 @@ test_3(Config) when is_list(Config) ->
 %% Test that caller and return to work as they should
 %% There was a bug where caller would be undefined when return_to was set
 %% for r the bif erlang:put().
-caller_and_return_to(Config) ->
+caller_and_return_to(Config) when is_list(Config) ->
     tr(
       fun do_put_wrapper/0,
       fun (Tracee) ->
@@ -686,10 +686,9 @@ destructive_in_test_bif(Config) when is_list(Config) ->
 
 %% Test that the comparison between boxed and small does not crash emulator
 boxed_and_small(Config) when is_list(Config) ->
-    {ok, Node} = start_node(match_spec_suite_other),
+    {ok, Peer, Node} = ?CT_PEER(),
     ok = rpc:call(Node,?MODULE,do_boxed_and_small,[]),
-    stop_node(Node),
-    ok.
+    peer:stop(Peer).
 
 do_boxed_and_small() ->
     {ok, false, _, _} = erlang:match_spec_test({0,3},[{{1.47,'_'},[],['$_']}],table),
@@ -700,10 +699,9 @@ do_boxed_and_small() ->
 
 %% Test that faulty seq_trace_call does not crash emulator
 faulty_seq_trace(Config) when is_list(Config) ->
-    {ok, Node} = start_node(match_spec_suite_other),
+    {ok, Peer, Node} = ?CT_PEER(),
     ok = rpc:call(Node,?MODULE,do_faulty_seq_trace,[]),
-    stop_node(Node),
-    ok.
+    peer:stop(Peer).
 
 do_faulty_seq_trace() ->
     {ok,'EXIT',_,_} = erlang:match_spec_test([],[{'_',[],[{message,{set_seq_token,yxa,true}}]}],trace),
@@ -1154,12 +1152,3 @@ fbinmatch(<<>>, Acc) -> Acc.
 
 id(X) ->
     X.
-
-start_node(Name) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Cookie = atom_to_list(erlang:get_cookie()),
-    test_server:start_node(Name, slave, 
-                           [{args, "-setcookie " ++ Cookie ++" -pa " ++ Pa}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).

--- a/erts/emulator/test/message_queue_data_SUITE.erl
+++ b/erts/emulator/test/message_queue_data_SUITE.erl
@@ -53,13 +53,13 @@ basic(Config) when is_list(Config) ->
 
     basic_test(erlang:system_info(message_queue_data)),
 
-    {ok, Node1} = start_node(Config, "+hmqd off_heap"),
+    {ok, Peer1, Node1} = ?CT_PEER(["+hmqd", "off_heap"]),
     ok = rpc:call(Node1, ?MODULE, basic_test, [off_heap]),
-    stop_node(Node1),
+    peer:stop(Peer1),
 
-    {ok, Node2} = start_node(Config, "+hmqd on_heap"),
+    {ok, Peer2, Node2} = ?CT_PEER(["+hmqd", "on_heap"]),
     ok = rpc:call(Node2, ?MODULE, basic_test, [on_heap]),
-    stop_node(Node2),
+    peer:stop(Peer2),
 
     ok.
 
@@ -326,17 +326,3 @@ recv_msgs(Msgs) ->
     after 0 ->
 	    lists:reverse(Msgs)
     end.
-
-start_node(Config, Opts) when is_list(Config), is_list(Opts) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Name = list_to_atom(atom_to_list(?MODULE)
-			++ "-"
-			++ atom_to_list(proplists:get_value(testcase, Config))
-			++ "-"
-			++ integer_to_list(erlang:system_time(second))
-			++ "-"
-			++ integer_to_list(erlang:unique_integer([positive]))),
-    test_server:start_node(Name, slave, [{args, Opts++" -pa "++Pa}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).

--- a/erts/emulator/test/persistent_term_SUITE.erl
+++ b/erts/emulator/test/persistent_term_SUITE.erl
@@ -74,10 +74,10 @@ end_per_suite(Config) ->
 init_per_testcase(_, Config) ->
     Config.
 
-end_per_testcase(_, _Config) ->
-    ok;
 end_per_testcase(get_all_race, _Config) ->
     get_all_race_cleanup(),
+    ok;
+end_per_testcase(_, _Config) ->
     ok.
 
 basic(_Config) ->

--- a/erts/emulator/test/ref_SUITE.erl
+++ b/erts/emulator/test/ref_SUITE.erl
@@ -132,7 +132,7 @@ external_size(Config) when is_list(Config) ->
     %% matches what the documentation say in the advanced chapter of the
     %% efficiency guide. Note that the values in the efficiency guide
     %% also add the word referencing the heap structure.
-    {ok, Node} = start_node(Config),
+    {ok, Peer, Node} = ?CT_PEER(),
 
     %% Ordinary external reference
     ORef = check_external_size(erpc:call(Node, fun () -> make_ref() end)),
@@ -145,7 +145,7 @@ external_size(Config) when is_list(Config) ->
     io:format("PRef = ~p~n", [PRef]),
 
 
-    stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 check_external_size(Ref) when is_reference(Ref) ->
@@ -165,25 +165,3 @@ check_external_size(Ref) when is_reference(Ref) ->
                     error({internal_ref_size_out_of_range, Sz})
             end
     end.
-
-%% Internal stuff...
-
-make_nodename(Config) when is_list(Config) ->
-    list_to_atom(atom_to_list(?MODULE)
-                 ++ "-"
-                 ++ atom_to_list(proplists:get_value(testcase, Config))
-                 ++ "-"
-                 ++ integer_to_list(erlang:system_time(second))
-                 ++ "-"
-                 ++ integer_to_list(erlang:unique_integer([positive]))).
-    
-start_node(Config) ->
-    start_node(Config, "").
-
-start_node(Config, Args) when is_list(Config) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Name = make_nodename(Config),
-    test_server:start_node(Name, slave, [{args, "-pa "++Pa++" "++Args}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).

--- a/erts/emulator/test/scheduler_SUITE.erl
+++ b/erts/emulator/test/scheduler_SUITE.erl
@@ -276,7 +276,7 @@ bound_loop(NS, N, M, Sched) ->
 
 
 -define(TOPOLOGY_A_CMD,
-	"+sct"
+	["+sct"
 	"L0-1t0-1c0p0n0"
 	":L2-3t0-1c1p0n0"
 	":L4-5t0-1c0p1n0"
@@ -284,7 +284,7 @@ bound_loop(NS, N, M, Sched) ->
 	":L8-9t0-1c0p2n1"
 	":L10-11t0-1c1p2n1"
 	":L12-13t0-1c0p3n1"
-	":L14-15t0-1c1p3n1").
+	":L14-15t0-1c1p3n1"]).
 
 -define(TOPOLOGY_A_TERM,
 	[{node,[{processor,[{core,[{thread,{logical,0}},
@@ -305,7 +305,7 @@ bound_loop(NS, N, M, Sched) ->
 				   {thread,{logical,15}}]}]}]}]).
 
 -define(TOPOLOGY_B_CMD,
-	"+sct"
+	["+sct"
 	"L0-1t0-1c0n0p0"
 	":L2-3t0-1c1n0p0"
 	":L4-5t0-1c2n1p0"
@@ -313,7 +313,7 @@ bound_loop(NS, N, M, Sched) ->
 	":L8-9t0-1c0n2p1"
 	":L10-11t0-1c1n2p1"
 	":L12-13t0-1c2n3p1"
-	":L14-15t0-1c3n3p1").
+	":L14-15t0-1c3n3p1"]).
 
 -define(TOPOLOGY_B_TERM,
 	[{processor,[{node,[{core,[{thread,{logical,0}},
@@ -369,7 +369,7 @@ bound_loop(NS, N, M, Sched) ->
 
 
 -define(TOPOLOGY_C_CMD,
-	"+sct"
+	["+sct"
 	"L0-1t0-1c0p0n0"
 	":L2-3t0-1c1p0n0"
 	":L4-5t0-1c0p1n0"
@@ -385,7 +385,7 @@ bound_loop(NS, N, M, Sched) ->
 	":L24-25t0-1c0n4p5"
 	":L26-27t0-1c1n4p5"
 	":L28-29t0-1c2n5p5"
-	":L30-31t0-1c3n5p5").
+	":L30-31t0-1c3n5p5"]).
 
 -define(TOPOLOGY_D_TERM,
 	[{processor,[{node,[{core,[{thread,{logical,0}},
@@ -422,7 +422,7 @@ bound_loop(NS, N, M, Sched) ->
 				   {thread,{logical,31}}]}]}]}]).
 
 -define(TOPOLOGY_D_CMD,
-	"+sct"
+	["+sct"
 	"L0-1t0-1c0n0p0"
 	":L2-3t0-1c1n0p0"
 	":L4-5t0-1c2n1p0"
@@ -438,10 +438,10 @@ bound_loop(NS, N, M, Sched) ->
 	":L24-25t0-1c0p4n5"
 	":L26-27t0-1c1p4n5"
 	":L28-29t0-1c0p5n5"
-	":L30-31t0-1c1p5n5").
+	":L30-31t0-1c1p5n5"]).
 
 -define(TOPOLOGY_E_CMD,
-	"+sct"
+	["+sct"
 	"L0-1t0-1c0p0n0"
 	":L2-3t0-1c1p0n0"
 	":L4-5t0-1c2p0n0"
@@ -449,7 +449,7 @@ bound_loop(NS, N, M, Sched) ->
 	":L8-9t0-1c0p1n1"
 	":L10-11t0-1c1p1n1"
 	":L12-13t0-1c2p1n1"
-	":L14-15t0-1c3p1n1").
+	":L14-15t0-1c3p1n1"]).
 
 -define(TOPOLOGY_E_TERM,
 	[{node,[{processor,[{core,[{thread,{logical,0}},
@@ -470,7 +470,7 @@ bound_loop(NS, N, M, Sched) ->
 				   {thread,{logical,15}}]}]}]}]).
 
 -define(TOPOLOGY_F_CMD,
-	"+sct"
+	["+sct"
 	"L0-1t0-1c0n0p0"
 	":L2-3t0-1c1n0p0"
 	":L4-5t0-1c2n0p0"
@@ -486,7 +486,7 @@ bound_loop(NS, N, M, Sched) ->
 	":L24-25t0-1c12n3p0"
 	":L26-27t0-1c13n3p0"
 	":L28-29t0-1c14n3p0"
-	":L30-31t0-1c15n3p0").
+	":L30-31t0-1c15n3p0"]).
 
 -define(TOPOLOGY_F_TERM,
         [{processor,[{node,[{core,[{thread,{logical,0}},
@@ -543,27 +543,27 @@ bindings(Node, BindType) ->
 scheduler_bind_types(Config) when is_list(Config) ->
     OldRelFlags = clear_erl_rel_flags(),
     try
-	scheduler_bind_types_test(Config,
+	scheduler_bind_types_test(
 				  ?TOPOLOGY_A_TERM,
 				  ?TOPOLOGY_A_CMD,
 				  a),
-	scheduler_bind_types_test(Config,
+	scheduler_bind_types_test(
 				  ?TOPOLOGY_B_TERM,
 				  ?TOPOLOGY_B_CMD,
 				  b),
-	scheduler_bind_types_test(Config,
+	scheduler_bind_types_test(
 				  ?TOPOLOGY_C_TERM,
 				  ?TOPOLOGY_C_CMD,
 				  c),
-	scheduler_bind_types_test(Config,
+	scheduler_bind_types_test(
 				  ?TOPOLOGY_D_TERM,
 				  ?TOPOLOGY_D_CMD,
 				  d),
-	scheduler_bind_types_test(Config,
+	scheduler_bind_types_test(
 				  ?TOPOLOGY_E_TERM,
 				  ?TOPOLOGY_E_CMD,
 				  e),
-	scheduler_bind_types_test(Config,
+	scheduler_bind_types_test(
 				  ?TOPOLOGY_F_TERM,
 				  ?TOPOLOGY_F_CMD,
 				  f)
@@ -572,17 +572,17 @@ scheduler_bind_types(Config) when is_list(Config) ->
     end,
     ok.
 
-scheduler_bind_types_test(Config, Topology, CmdLine, TermLetter) ->
+scheduler_bind_types_test(Topology, CmdLine, TermLetter) ->
     io:format("Testing (~p): ~p~n", [TermLetter, Topology]),
-    {ok, Node0} = start_node(Config),
+    {ok, Peer, Node0} = ?CT_PEER(),
     _ = rpc:call(Node0, erlang, system_flag, [cpu_topology, Topology]),
     cmp(Topology, rpc:call(Node0, erlang, system_info, [cpu_topology])),
     check_bind_types(Node0, TermLetter),
-    stop_node(Node0),
-    {ok, Node1} = start_node(Config, CmdLine),
+    peer:stop(Peer),
+    {ok, Peer1, Node1} = ?CT_PEER(CmdLine),
     cmp(Topology, rpc:call(Node1, erlang, system_info, [cpu_topology])),
     check_bind_types(Node1, TermLetter),
-    stop_node(Node1).
+    peer:stop(Peer1).
 
 check_bind_types(Node, a) ->
     {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}
@@ -707,7 +707,6 @@ cpu_topology(Config) when is_list(Config) ->
     OldRelFlags = clear_erl_rel_flags(),
     try
         cpu_topology_test(
-          Config,
           [{node,[{processor,[{core,{logical,0}},
                               {core,{logical,1}}]}]},
            {processor,[{node,[{core,{logical,2}},
@@ -716,13 +715,12 @@ cpu_topology(Config) when is_list(Config) ->
                               {core,{logical,5}}]}]},
            {processor,[{node,[{core,{logical,6}},
                               {core,{logical,7}}]}]}],
-          "+sct "
+          ["+sct",
           "L0-1c0-1p0n0"
           ":L2-3c0-1n1p1"
           ":L4-5c0-1p2n2"
-          ":L6-7c0-1n3p3"),
+          ":L6-7c0-1n3p3"]),
         cpu_topology_test(
-          Config,
           [{node,[{processor,[{core,{logical,0}},
                               {core,{logical,1}}]},
                   {processor,[{core,{logical,2}},
@@ -739,7 +737,7 @@ cpu_topology(Config) when is_list(Config) ->
                               {core,{logical,13}}]},
                        {node,[{core,{logical,14}},
                               {core,{logical,15}}]}]}],
-          "+sct "
+          ["+sct",
           "L0-1c0-1p0n0"
           ":L2-3c0-1p1n0"
           ":L4-5c0-1n1p2"
@@ -747,9 +745,8 @@ cpu_topology(Config) when is_list(Config) ->
           ":L8-9c0-1p3n3"
           ":L10-11c0-1p4n3"
           ":L12-13c0-1n4p5"
-          ":L14-15c2-3n5p5"),
+          ":L14-15c2-3n5p5"]),
         cpu_topology_test(
-          Config,
           [{node,[{processor,[{core,{logical,0}},
                               {core,{logical,1}}]}]},
            {processor,[{node,[{core,{logical,2}},
@@ -762,39 +759,39 @@ cpu_topology(Config) when is_list(Config) ->
                               {core,{logical,9}}]}]},
            {processor,[{node,[{core,{logical,10}},
                               {core,{logical,11}}]}]}],
-          "+sct "
+          ["+sct",
           "L0-1c0-1p0n0"
           ":L2-3c0-1n1p1"
           ":L4-5c0-1n2p2"
           ":L6-7c0-1p3n3"
           ":L8-9c0-1p4n4"
-          ":L10-11c0-1n5p5")
+          ":L10-11c0-1n5p5"])
     after
         restore_erl_rel_flags(OldRelFlags)
     end,
     ok.
 
-cpu_topology_test(Config, Topology, Cmd) ->
+cpu_topology_test(Topology, Cmd) ->
     io:format("Testing~n ~p~n ~p~n", [Topology, Cmd]),
-    cpu_topology_bif_test(Config, Topology),
-    cpu_topology_cmdline_test(Config, Topology, Cmd),
+    cpu_topology_bif_test(Topology),
+    cpu_topology_cmdline_test(Topology, Cmd),
     ok.
 
-cpu_topology_bif_test(_Config, false) ->
+cpu_topology_bif_test(false) ->
     ok;
-cpu_topology_bif_test(Config, Topology) ->
-    {ok, Node} = start_node(Config),
+cpu_topology_bif_test(Topology) ->
+    {ok, Peer, Node} = ?CT_PEER(),
     _ = rpc:call(Node, erlang, system_flag, [cpu_topology, Topology]),
     cmp(Topology, rpc:call(Node, erlang, system_info, [cpu_topology])),
-    stop_node(Node),
+    peer:stop(Peer),
     ok.
 
-cpu_topology_cmdline_test(_Config, _Topology, false) ->
+cpu_topology_cmdline_test(_Topology, false) ->
     ok;
-cpu_topology_cmdline_test(Config, Topology, Cmd) ->
-    {ok, Node} = start_node(Config, Cmd),
+cpu_topology_cmdline_test(Topology, Cmd) ->
+    {ok, Peer, Node} = ?CT_PEER(Cmd),
     cmp(Topology, rpc:call(Node, erlang, system_info, [cpu_topology])),
-    stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 update_cpu_info(Config) when is_list(Config) ->
@@ -976,14 +973,14 @@ sct_cmd(Config) when is_list(Config) ->
     Topology = ?TOPOLOGY_A_TERM,
     OldRelFlags = clear_erl_rel_flags(),
     try
-	{ok, Node} = start_node(Config, ?TOPOLOGY_A_CMD),
+	{ok, Peer, Node} = ?CT_PEER(?TOPOLOGY_A_CMD),
 	cmp(Topology,
 		  rpc:call(Node, erlang, system_info, [cpu_topology])),
 	cmp(Topology,
 		  rpc:call(Node, erlang, system_flag, [cpu_topology, Topology])),
 	cmp(Topology,
 		  rpc:call(Node, erlang, system_info, [cpu_topology])),
-	stop_node(Node)
+	peer:stop(Peer)
     after
 	restore_erl_rel_flags(OldRelFlags)
     end,
@@ -1013,7 +1010,7 @@ sbt_cmd(Config) when is_list(Config) ->
                     OldRelFlags = clear_erl_rel_flags(),
                     try
                         lists:foreach(fun ({ClBt, Bt}) ->
-                                              sbt_test(Config, CpuTCmd,
+                                              sbt_test(CpuTCmd,
                                                        ClBt, Bt, LP)
                                       end,
                                       ?BIND_TYPES)
@@ -1031,10 +1028,10 @@ sbt_make_topology_args() ->
                 linux ->
                     case erlang:system_info(logical_processors) of
                         1 ->
-                            "+sctL0";
+                            ["+sctL0"];
                         N ->
                             NS = integer_to_list(N - 1),
-                            "+sctL0-"++NS++"p0-"++NS
+                            ["+sctL0-"++NS++"p0-"++NS]
                     end;
                 _ ->
                     false
@@ -1078,11 +1075,11 @@ sbt_check_prereqs() ->
         throw:{skip,_Reason}=Skip -> Skip
     end.
 
-sbt_test(Config, CpuTCmd, ClBt, Bt, LP) ->
+sbt_test(CpuTCmd, ClBt, Bt, LP) ->
     io:format("Testing +sbt ~s (~p)~n", [ClBt, Bt]),
     LPS = integer_to_list(LP),
-    Cmd = CpuTCmd++" +sbt "++ClBt++" +S"++LPS++":"++LPS,
-    {ok, Node} = start_node(Config, Cmd),
+    Cmd = CpuTCmd++["+sbt", ClBt, "+S"++LPS++":"++LPS],
+    {ok, Peer, Node} = ?CT_PEER(Cmd),
     Bt = rpc:call(Node,
 			erlang,
 			system_info,
@@ -1106,16 +1103,16 @@ sbt_test(Config, CpuTCmd, ClBt, Bt, LP) ->
 		      end,
 		      BS,
 		      tuple_to_list(SB)),
-    stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 scheduler_threads(Config) when is_list(Config) ->
-    {Sched, SchedOnln, _} = get_sstate(Config, ""),
+    {Sched, SchedOnln, _} = get_sstate(""),
     %% Configure half the number of both the scheduler threads and
     %% the scheduler threads online.
     {HalfSched, HalfSchedOnln} = {lists:max([1,Sched div 2]),
                                   lists:max([1,SchedOnln div 2])},
-    {HalfSched, HalfSchedOnln, _} = get_sstate(Config, "+SP 50:50"),
+    {HalfSched, HalfSchedOnln, _} = get_sstate(["+SP", "50:50"]),
     %% Use +S to configure 4x the number of scheduler threads and
     %% 4x the number of scheduler threads online, but alter that
     %% setting using +SP to 50% scheduler threads and 25% scheduler
@@ -1124,19 +1121,19 @@ scheduler_threads(Config) when is_list(Config) ->
     TwiceSched = Sched*2,
     FourSched = integer_to_list(Sched*4),
     FourSchedOnln = integer_to_list(SchedOnln*4),
-    CombinedCmd1 = "+S "++FourSched++":"++FourSchedOnln++" +SP50:25",
-    {TwiceSched, SchedOnln, _} = get_sstate(Config, CombinedCmd1),
+    CombinedCmd1 = ["+S", FourSched++":"++FourSchedOnln, "+SP50:25"],
+    {TwiceSched, SchedOnln, _} = get_sstate(CombinedCmd1),
     %% Now do the same test but with the +S and +SP options in the
     %% opposite order, since order shouldn't matter.
-    CombinedCmd2 = "+SP50:25 +S "++FourSched++":"++FourSchedOnln,
-    {TwiceSched, SchedOnln, _} = get_sstate(Config, CombinedCmd2),
+    CombinedCmd2 = ["+SP50:25", "+S", FourSched++":"++FourSchedOnln],
+    {TwiceSched, SchedOnln, _} = get_sstate(CombinedCmd2),
     %% Apply two +SP options to make sure the second overrides the first
-    TwoCmd = "+SP 25:25 +SP 100:100",
-    {Sched, SchedOnln, _} = get_sstate(Config, TwoCmd),
+    TwoCmd = ["+SP", "25:25", "+SP", "100:100"],
+    {Sched, SchedOnln, _} = get_sstate(TwoCmd),
     %% Configure 50% of scheduler threads online only
-    {Sched, HalfSchedOnln, _} = get_sstate(Config, "+SP:50"),
+    {Sched, HalfSchedOnln, _} = get_sstate(["+SP:50"]),
     %% Configure 2x scheduler threads only
-    {TwiceSched, SchedOnln, _} = get_sstate(Config, "+SP 200"),
+    {TwiceSched, SchedOnln, _} = get_sstate(["+SP", "200"]),
 
     LProc = erlang:system_info(logical_processors),
     LProcAvail = erlang:system_info(logical_processors_available),
@@ -1150,30 +1147,30 @@ scheduler_threads(Config) when is_list(Config) ->
         is_integer(LProc); is_integer(LProcAvail) ->
             ExpectedOnln = st_expected_onln(LProcAvail, Quota),
 
-            st_reset(Config, LProc, ExpectedOnln, FourSched, FourSchedOnln),
+            st_reset(LProc, ExpectedOnln, FourSched, FourSchedOnln),
 
             if
                 LProc =:= 1; LProcAvail =:= 1 ->
                     {comment, "Skipped reduced amount of schedulers test due "
                               "to too few logical processors"};
                 LProc > 1, LProcAvail > 1 ->
-                    st_reduced(Config, LProc, ExpectedOnln)
+                    st_reduced(LProc, ExpectedOnln)
             end
     end.
 
-st_reset(Config, LProc, ExpectedOnln, FourSched, FourSchedOnln) ->
+st_reset(LProc, ExpectedOnln, FourSched, FourSchedOnln) ->
     %% Test resetting # of schedulers.
-    ResetCmd = "+S "++FourSched++":"++FourSchedOnln++" +S 0:0",
-    {LProc, ExpectedOnln, _} = get_sstate(Config, ResetCmd),
+    ResetCmd = ["+S", FourSched++":"++FourSchedOnln, "+S", "0:0"],
+    {LProc, ExpectedOnln, _} = get_sstate(ResetCmd),
     ok.
 
-st_reduced(Config, LProc, ExpectedOnln) ->
+st_reduced(LProc, ExpectedOnln) ->
     %% Test negative +S settings
     SchedMinus1 = LProc-1,
     SchedOnlnMinus1 = ExpectedOnln-1,
-    {SchedMinus1, SchedOnlnMinus1, _} = get_sstate(Config, "+S -1"),
-    {LProc, SchedOnlnMinus1, _} = get_sstate(Config, "+S :-1"),
-    {SchedMinus1, SchedOnlnMinus1, _} = get_sstate(Config, "+S -1:-1"),
+    {SchedMinus1, SchedOnlnMinus1, _} = get_sstate(["+S", "-1"]),
+    {LProc, SchedOnlnMinus1, _} = get_sstate(["+S", ":-1"]),
+    {SchedMinus1, SchedOnlnMinus1, _} = get_sstate(["+S", "-1:-1"]),
     ok.
 
 st_expected_onln(LProcAvail, unknown) -> LProcAvail;
@@ -1185,18 +1182,19 @@ dirty_scheduler_threads(Config) when is_list(Config) ->
         _ -> dirty_scheduler_threads_test(Config)
     end.
 
-dirty_scheduler_threads_test(Config) ->
-    {Sched, SchedOnln, _} = get_dsstate(Config, ""),
+dirty_scheduler_threads_test(Config) when is_list(Config) ->
+    {Sched, SchedOnln, _} = get_dsstate(""),
     {HalfSched, HalfSchedOnln} = {lists:max([1,Sched div 2]),
                                   lists:max([1,SchedOnln div 2])},
-    Cmd1 = "+SDcpu "++integer_to_list(HalfSched)++":"++
-	integer_to_list(HalfSchedOnln),
-    {HalfSched, HalfSchedOnln, _} = get_dsstate(Config, Cmd1),
-    {HalfSched, HalfSchedOnln, _} = get_dsstate(Config, "+SDPcpu 50:50"),
+    Cmd1 = ["+SDcpu", integer_to_list(HalfSched)++":"++
+	integer_to_list(HalfSchedOnln)],
+    {HalfSched, HalfSchedOnln, _} = get_dsstate(Cmd1),
+    {HalfSched, HalfSchedOnln, _} = get_dsstate(["+SDPcpu", "50:50"]),
     IOSched = 20,
-    {_, _, IOSched} = get_dsstate(Config, "+SDio "++integer_to_list(IOSched)),
-    {ok, Node} = start_node(Config, ""),
+    {_, _, IOSched} = get_dsstate(["+SDio", integer_to_list(IOSched)]),
+    {ok, Peer, Node} = ?CT_PEER(),
     [ok] = mcall(Node, [fun() -> dirty_schedulers_online_test() end]),
+    peer:stop(Peer),
     ok.
 
 dirty_schedulers_online_test() ->
@@ -1220,16 +1218,16 @@ dirty_schedulers_online_smp_test(SchedOnln) ->
     QrtrDirtyCPUSchedOnln = erlang:system_info(dirty_cpu_schedulers_online),
     ok.
 
-get_sstate(Config, Cmd) ->
-    {ok, Node} = start_node(Config, Cmd),
+get_sstate(Cmd) ->
+    {ok, Peer, Node} = ?CT_PEER(Cmd),
     [SState] = mcall(Node, [fun () ->
                                     erlang:system_info(schedulers_state)
                             end]),
-    stop_node(Node),
+    peer:stop(Peer),
     SState.
 
-get_dsstate(Config, Cmd) ->
-    {ok, Node} = start_node(Config, Cmd),
+get_dsstate(Cmd) ->
+    {ok, Peer, Node} = ?CT_PEER(Cmd),
     [DSCPU] = mcall(Node, [fun () ->
 				   erlang:system_info(dirty_cpu_schedulers)
 			   end]),
@@ -1239,7 +1237,7 @@ get_dsstate(Config, Cmd) ->
     [DSIO] = mcall(Node, [fun () ->
 				  erlang:system_info(dirty_io_schedulers)
 			  end]),
-    stop_node(Node),
+    peer:stop(Peer),
     {DSCPU, DSCPUOnln, DSIO}.
 
 scheduler_suspend_basic(Config) when is_list(Config) ->
@@ -1351,18 +1349,19 @@ scheduler_suspend_basic_test() ->
 
 scheduler_suspend(Config) when is_list(Config) ->
     ct:timetrap({minutes, 5}),
-    lists:foreach(fun (S) -> scheduler_suspend_test(Config, S) end,
+    lists:foreach(fun (S) -> scheduler_suspend_test(S) end,
 			[64, 32, 16, default]),
     ok.
-scheduler_suspend_test(Config, Schedulers) ->
+
+scheduler_suspend_test(Schedulers) ->
     Cmd = case Schedulers of
 		    default ->
 			"";
 		    _ ->
 			S = integer_to_list(Schedulers),
-			"+S"++S++":"++S
+			["+S"++S++":"++S]
 		end,
-    {ok, Node} = start_node(Config, Cmd),
+    {ok, Peer, Node} = ?CT_PEER(Cmd),
     [SState] = mcall(Node, [fun () ->
                                     erlang:system_info(schedulers_state)
                             end]),
@@ -1404,7 +1403,7 @@ scheduler_suspend_test(Config, Schedulers) ->
 								     native)),
 				    erlang:system_info(schedulers_state)
                             end]),
-    stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 until(Pred, MaxTime) ->
@@ -1494,58 +1493,52 @@ sst5_loop(N) ->
     sst5_loop(N-1).
 
 poll_threads(Config) when is_list(Config) ->
-    {Conc, PollType, KP} = get_ioconfig(Config),
-    {Sched, SchedOnln, _} = get_sstate(Config, ""),
+    [PS | _] = get_iostate(""),
+    Conc = proplists:get_value(concurrent_updates, PS),
 
-    [1, 1] = get_ionum(Config,"+IOt 2 +IOp 2"),
-    [1, 1, 1, 1, 1] = get_ionum(Config,"+IOt 5 +IOp 5"),
-    [1, 1] = get_ionum(Config, "+S 2 +IOPt 100 +IOPp 100"),
+    [1, 1] = get_ionum(["+IOt", "2", "+IOp", "2"]),
+    [1, 1, 1, 1, 1] = get_ionum(["+IOt", "5", "+IOp", "5"]),
+    [1, 1] = get_ionum(["+S", "2", "+IOPt", "100", "+IOPp", "100"]),
 
     if
         Conc ->
 
-            [5] = get_ionum(Config,"+IOt 5 +IOp 1"),
-            [3, 2] = get_ionum(Config,"+IOt 5 +IOp 2"),
-            [2, 2, 2, 2, 2] = get_ionum(Config,"+IOt 10 +IOPp 50"),
+            [5] = get_ionum(["+IOt", "5", "+IOp", "1"]),
+            [3, 2] = get_ionum(["+IOt", "5", "+IOp", "2"]),
+            [2, 2, 2, 2, 2] = get_ionum(["+IOt", "10", "+IOPp", "50"]),
 
-            [2] = get_ionum(Config, "+S 2 +IOPt 100"),
-            [4] = get_ionum(Config, "+S 4 +IOPt 100"),
-            [4] = get_ionum(Config, "+S 4:2 +IOPt 100"),
-            [4, 4] = get_ionum(Config, "+S 8 +IOPt 100 +IOPp 25"),
+            [2] = get_ionum(["+S", "2", "+IOPt", "100"]),
+            [4] = get_ionum(["+S", "4", "+IOPt", "100"]),
+            [4] = get_ionum(["+S", "4:2", "+IOPt", "100"]),
+            [4, 4] = get_ionum(["+S", "8", "+IOPt", "100", "+IOPp", "25"]),
 
-            fail = get_ionum(Config, "+IOt 1 +IOp 2"),
+            fail = get_ionum(["+IOt", "1", "+IOp", "2"]),
 
             ok;
         not Conc ->
 
-            [1, 1, 1, 1, 1] = get_ionum(Config,"+IOt 5 +IOp 1"),
-            [1, 1, 1, 1, 1] = get_ionum(Config,"+IOt 5 +IOp 2"),
-            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1] = get_ionum(Config,"+IOt 10 +IOPp 50"),
+            [1, 1, 1, 1, 1] = get_ionum(["+IOt", "5", "+IOp", "1"]),
+            [1, 1, 1, 1, 1] = get_ionum(["+IOt", "5", "+IOp", "2"]),
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1] = get_ionum(["+IOt", "10", "+IOPp", "50"]),
 
-            [1, 1] = get_ionum(Config, "+S 2 +IOPt 100"),
-            [1, 1, 1, 1] = get_ionum(Config, "+S 4 +IOPt 100"),
-            [1, 1, 1, 1] = get_ionum(Config, "+S 4:2 +IOPt 100"),
-            [1, 1, 1, 1, 1, 1, 1, 1] = get_ionum(Config, "+S 8 +IOPt 100 +IOPp 25"),
+            [1, 1] = get_ionum(["+S", "2", "+IOPt", "100"]),
+            [1, 1, 1, 1] = get_ionum(["+S", "4", "+IOPt", "100"]),
+            [1, 1, 1, 1] = get_ionum(["+S", "4:2", "+IOPt", "100"]),
+            [1, 1, 1, 1, 1, 1, 1, 1] = get_ionum(["+S", "8", "+IOPt", "100"  "+IOPp", "25"]),
 
-            [1] = get_ionum(Config, "+IOt 1 +IOp 2"),
+            [1] = get_ionum(["+IOt", "1", "+IOp", "2"]),
 
             ok
     end,
 
-    fail = get_ionum(Config, "+IOt 1 +IOPp 101"),
-    fail = get_ionum(Config, "+IOt 0"),
-    fail = get_ionum(Config, "+IOPt 101"),
+    fail = get_ionum(["+IOt", "1", "+IOPp", "101"]),
+    fail = get_ionum(["+IOt", "0"]),
+    fail = get_ionum(["+IOPt", "101"]),
 
     ok.
 
-get_ioconfig(Config) ->
-    [PS | _] = get_iostate(Config, ""),
-    {proplists:get_value(concurrent_updates, PS),
-     proplists:get_value(primary, PS),
-     proplists:get_value(kernel_poll, PS)}.
-
-get_ionum(Config, Cmd) ->
-    case get_iostate(Config, Cmd) of
+get_ionum(Cmd) ->
+    case get_iostate(Cmd) of
         fail -> fail;
         PSs ->
             lists:reverse(
@@ -1553,18 +1546,17 @@ get_ionum(Config, Cmd) ->
                 [proplists:get_value(poll_threads, PS) || PS <- PSs]))
     end.
 
-get_iostate(Config, Cmd)->
-    case start_node(Config, Cmd) of
-        {ok, Node} ->
-            [IOStates] = mcall(Node,[fun () ->
-                                             erlang:system_info(check_io)
-                                     end]),
-            IO = [IOState || IOState <- IOStates,
-                             proplists:get_value(fallback, IOState) == false,
-                             proplists:get_value(poll_threads, IOState) /= 0],
-            stop_node(Node),
-            IO;
-        {error,timeout} ->
+get_iostate(Cmd)->
+    try
+        {ok, Peer, Node} = ?CT_PEER(#{connection => standard_io, args => Cmd}),
+        [IOStates] = mcall(Node,[fun () -> erlang:system_info(check_io) end]),
+        IO = [IOState || IOState <- IOStates,
+            proplists:get_value(fallback, IOState) == false,
+            proplists:get_value(poll_threads, IOState) /= 0],
+        peer:stop(Peer),
+        IO
+    catch
+        exit:{boot_failed, _} ->
             fail
     end.
 
@@ -2481,24 +2473,6 @@ active_schedulers() ->
 		enabled -> N
 	    end
     end.
-    
-start_node(Config) ->
-    start_node(Config, "").
-
-start_node(Config, Args) when is_list(Config) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Name = list_to_atom(atom_to_list(?MODULE)
-			++ "-"
-			++ atom_to_list(proplists:get_value(testcase, Config))
-			++ "-"
-			++ integer_to_list(erlang:system_time(second))
-			++ "-"
-			++ integer_to_list(erlang:unique_integer([positive]))),
-    test_server:start_node(Name, slave, [{args, "-pa "++Pa++" "++Args}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).
-
 
 enable_internal_state() ->
     case catch erts_debug:get_internal_state(available_internal_state) of

--- a/erts/emulator/test/send_term_SUITE.erl
+++ b/erts/emulator/test/send_term_SUITE.erl
@@ -212,14 +212,14 @@ make_expected_ext2term_drv([T|Ts]) ->
 %%
 
 generate_external_terms_files(BaseDir) ->
-    {ok,Node} = slave:start(hostname(), a_node),
+    {ok, Peer, Node} = ?CT_PEER(),
     RPid = rpc:call(Node, erlang, self, []),
     true = is_pid(RPid),
     RRef = rpc:call(Node, erlang, make_ref, []),
     true = is_reference(RRef),
     RPort = hd(rpc:call(Node, erlang, ports, [])),
     true = is_port(RPort),
-    slave:stop(Node),
+    peer:stop(Peer),
     Terms = [{4711, -4711, [an_atom, "a list"]},
              [1000000000000000000000,-1111111111111111, "blupp!", blipp],
              {RPid, {RRef, RPort}, self(), hd(erlang:ports()), make_ref()},
@@ -341,12 +341,3 @@ write_license(IoDev) ->
 	" * and needs to be consistent with each other.~n"
 	" */~n",
     io:format(IoDev, S, []).
-
-
-hostname() ->    
-    hostname(atom_to_list(node())).
-
-hostname([$@ | Hostname]) ->
-    list_to_atom(Hostname);
-hostname([_C | Cs]) ->
-    hostname(Cs).

--- a/erts/emulator/test/signal_SUITE.erl
+++ b/erts/emulator/test/signal_SUITE.erl
@@ -63,9 +63,9 @@ all() ->
 xm_sig_order(Config) when is_list(Config) ->
     LNode = node(),
     repeat(fun () -> xm_sig_order_test(LNode) end, 1000),
-    {ok, RNode} = start_node(Config),
+    {ok, Peer, RNode} = ?CT_PEER(),
     repeat(fun () -> xm_sig_order_test(RNode) end, 1000),
-    stop_node(RNode),
+    peer:stop(Peer),
     ok.
     
 
@@ -95,10 +95,9 @@ xm_sig_order_proc() ->
 kill2killed(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     kill2killed_test(node()),
-    {ok, Node} = start_node(Config),
+    {ok, Peer, Node} = ?CT_PEER(),
     kill2killed_test(Node),
-    stop_node(Node),
-    ok.
+    peer:stop(Peer).
 
 kill2killed_test(Node) ->
     if Node == node() ->
@@ -237,14 +236,3 @@ repeat(_Fun, N) when is_integer(N), N =< 0 ->
 repeat(Fun, N) when is_integer(N)  ->
     Fun(),
     repeat(Fun, N-1).
-
-start_node(Config) ->
-    Name = list_to_atom(atom_to_list(?MODULE)
-			++ "-" ++ atom_to_list(proplists:get_value(testcase, Config))
-			++ "-" ++ integer_to_list(erlang:system_time(second))
-			++ "-" ++ integer_to_list(erlang:unique_integer([positive]))),
-    Pa = filename:dirname(code:which(?MODULE)),
-    test_server:start_node(Name, slave, [{args,  "-pa " ++ Pa}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).

--- a/erts/emulator/test/smoke_test_SUITE.erl
+++ b/erts/emulator/test/smoke_test_SUITE.erl
@@ -24,29 +24,29 @@
 
 %-compile(export_all).
 -export([all/0, suite/0,
-	 init_per_testcase/2, end_per_testcase/2]).
+    init_per_testcase/2, end_per_testcase/2]).
 
 -export([boot_combo/1, native_atomics/1, jump_table/1]).
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
-     {timetrap, {minutes, 2}}].
+    [{ct_hooks, [ts_install_cth]},
+        {timetrap, {minutes, 2}}].
 
-all() -> 
+all() ->
     [boot_combo, native_atomics, jump_table].
 
 init_per_testcase(boot_combo = Case, Config) when is_list(Config) ->
     case erlang:system_info(build_type) of
-	opt ->
-	    init_per_tc(Case, Config);
-	_ ->
-	    {skip,"Cannot test boot_combo in special builds since beam.* may not exist"}
+        opt ->
+            init_per_tc(Case, Config);
+        _ ->
+            {skip, "Cannot test boot_combo in special builds since beam.* may not exist"}
     end;
 init_per_testcase(Case, Config) when is_list(Config) ->
     init_per_tc(Case, Config).
 
 init_per_tc(Case, Config) ->
-    [{testcase, Case}|Config].
+    [{testcase, Case} | Config].
 
 end_per_testcase(_Case, Config) when is_list(Config) ->
     ok.
@@ -56,39 +56,31 @@ end_per_testcase(_Case, Config) when is_list(Config) ->
 %%%
 
 boot_combo(Config) when is_list(Config) ->
-    ZFlags = os:getenv("ERL_ZFLAGS", ""),
-    NOOP = fun () -> ok end,
-    A42 = fun () ->
-		  case erlang:system_info(threads) of
-		      true ->
-			  42 = erlang:system_info(thread_pool_size);
-		      false ->
-			  ok
-		  end
-	  end,
-    try
-	chk_boot(Config, "+Ktrue", NOOP),
-	chk_boot(Config, "+A42", A42),
-	chk_boot(Config, "+Ktrue +A42", A42),
+    NOOP = fun() -> ok end,
+    A42 = fun() ->
+        case erlang:system_info(threads) of
+            true ->
+                42 = erlang:system_info(thread_pool_size);
+            false ->
+                ok
+        end
+          end,
 
-        WBTArgs = ["very_short", "short", "medium", "long", "very_long"],
-        WTArgs = ["very_low", "low", "medium", "high", "very_high"],
-        [chk_boot(Config,
-                 " +sbwt " ++ WBT ++
-                 " +sbwtdcpu " ++ WBT ++
-                 " +sbwtdio " ++ WBT ++
-                 " +swt " ++ WT ++
-                 " +swtdcpu " ++ WT ++
-                 " +swtdio " ++ WT, NOOP) || WBT <- WBTArgs,  WT <- WTArgs],
+    chk_boot(["+Ktrue"], NOOP),
+    chk_boot(["+A42"], A42),
+    chk_boot(["+Ktrue", "+A42"], A42),
 
-        WSArgs = ["legacy", "default"],
-        [chk_boot(Config, " +sws " ++ WS, NOOP) || WS <- WSArgs],
+    WBTArgs = ["very_short", "short", "medium", "long", "very_long"],
+    WTArgs = ["very_low", "low", "medium", "high", "very_high"],
+    [chk_boot(["+sbwt", WBT,
+        "+sbwtdcpu", WBT,
+        "+sbwtdio", WBT,
+        "+swt", WT,
+        "+swtdcpu", WT,
+        "+swtdio", WT], NOOP) || WBT <- WBTArgs, WT <- WTArgs],
 
-	%% A lot more combos could be implemented...
-	ok
-    after
-	os:putenv("ERL_ZFLAGS", ZFlags)
-    end.
+    WSArgs = ["legacy", "default"],
+    [chk_boot(["+sws", WS], NOOP) || WS <- WSArgs].
 
 native_atomics(Config) when is_list(Config) ->
     NA32Key = "32-bit native atomics",
@@ -96,70 +88,55 @@ native_atomics(Config) when is_list(Config) ->
     DWNAKey = "Double word native atomics",
     EthreadInfo = erlang:system_info(ethread_info),
     io:format("~p~n", [EthreadInfo]),
-    {value,{NA32Key, NA32, _}} = lists:keysearch(NA32Key, 1, EthreadInfo),
-    {value,{NA64Key, NA64, _}} = lists:keysearch(NA64Key, 1, EthreadInfo),
-    {value,{DWNAKey, DWNA, _}} = lists:keysearch(DWNAKey, 1, EthreadInfo),
+    {value, {NA32Key, NA32, _}} = lists:keysearch(NA32Key, 1, EthreadInfo),
+    {value, {NA64Key, NA64, _}} = lists:keysearch(NA64Key, 1, EthreadInfo),
+    {value, {DWNAKey, DWNA, _}} = lists:keysearch(DWNAKey, 1, EthreadInfo),
     case {erlang:system_info(build_type), NA32, NA64, DWNA} of
-	{opt, "no", "no", _} ->
-	    ct:fail(optimized_smp_runtime_without_native_atomics);
-	_ ->
-	    {comment,
-	     NA32 ++ " 32-bit, "
-	     ++ NA64 ++ " 64-bit, and "
-	     ++ DWNA ++ " double word native atomics"}
+        {opt, "no", "no", _} ->
+            ct:fail(optimized_smp_runtime_without_native_atomics);
+        _ ->
+            {comment,
+                    NA32 ++ " 32-bit, "
+                    ++ NA64 ++ " 64-bit, and "
+                    ++ DWNA ++ " double word native atomics"}
     end.
 
 jump_table(Config) when is_list(Config) ->
     case erlang:system_info(beam_jump_table) of
-	true ->
-	    ok;
-	false ->
-	    case erlang:system_info(build_type) of
-		opt ->
-		    ct:fail(optimized_without_beam_jump_table);
-		BT ->
-		    {comment, "No beam jump table, but build type is " ++ atom_to_list(BT)}
-	    end
+        true ->
+            ok;
+        false ->
+            case erlang:system_info(build_type) of
+                opt ->
+                    ct:fail(optimized_without_beam_jump_table);
+                BT ->
+                    {comment, "No beam jump table, but build type is " ++ atom_to_list(BT)}
+            end
     end.
-	    
+
 
 %%%
 %%% Aux functions --------------------------------------------------------------
 %%%
 
-chk_boot(Config, Args, Fun) ->
-    true = os:putenv("ERL_ZFLAGS", Args),
+chk_boot(Args, Fun) ->
     Success = make_ref(),
     Parent = self(),
-    io:format("--- Testing ~s~n", [Args]),
-    {ok, Node} = start_node(Config),
-    Pid = spawn_link(Node, fun () ->
-				   Fun(),
-				   Parent ! {self(), Success}
-			   end),
+    io:format("--- Testing ~s~n", [lists:join(" ", Args)]),
+    {ok, Peer, Node} = ?CT_PEER(Args),
+    %% if spawn_link is used, race condition happens when
+    %%  remote process exits with 'noconnection' reason and fails
+    %%  the test case
+    Pid = spawn(Node, fun() ->
+        Fun(),
+        Parent ! {self(), Success}
+                           end),
     receive
-	{Pid, Success} ->
-	    Node = node(Pid),
-	    stop_node(Node),
-	    io:format("--- Success!~n", []),
-	    ok
+        {Pid, Success} ->
+            Node = node(Pid),
+            peer:stop(Peer),
+            io:format("--- Success!~n", []),
+            ok
     end.
 
-start_node(Config) ->
-    start_node(Config, "").
-
-start_node(Config, Args) when is_list(Config) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Name = list_to_atom(atom_to_list(?MODULE)
-	      ++ "-"
-	      ++ atom_to_list(proplists:get_value(testcase, Config))
-	      ++ "-"
-	      ++ integer_to_list(erlang:system_time(second))
-	      ++ "-"
-	      ++ integer_to_list(erlang:unique_integer([positive]))),
-    Opts = [{args, "-pa "++Pa++" "++Args}],
-    test_server:start_node(Name, slave, Opts).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).
 

--- a/erts/emulator/test/trace_SUITE.erl
+++ b/erts/emulator/test/trace_SUITE.erl
@@ -130,8 +130,7 @@ receive_trace(Config) when is_list(Config) ->
 		       {true, true}]),
 
     %% Remote messages
-    OtherName = atom_to_list(?MODULE)++"_receive_trace",
-    {ok, OtherNode} = start_node(OtherName),
+    {ok, Peer, OtherNode} = ?CT_PEER(),
     RemoteProc = spawn_link(OtherNode, ?MODULE, process, [self()]),
     io:format("RemoteProc = ~p ~n", [RemoteProc]),
 
@@ -179,7 +178,7 @@ receive_trace(Config) when is_list(Config) ->
     F2(NN, {true, true}),
 
     unlink(RemoteProc),
-    true = stop_node(OtherNode),
+    peer:stop(Peer),
 
     %% Timeout
     Receiver ! {set_timeout, 10},
@@ -647,8 +646,7 @@ procs_trace(Config) when is_list(Config) ->
 
 dist_procs_trace(Config) when is_list(Config) ->
     ct:timetrap({seconds, 15}),
-    OtherName = atom_to_list(?MODULE)++"_dist_procs_trace",
-    {ok, OtherNode} = start_node(OtherName),
+    {ok, Peer, OtherNode} = ?CT_PEER(),
     Self = self(),
     process_flag(trap_exit, true),
     %%
@@ -695,7 +693,7 @@ dist_procs_trace(Config) when is_list(Config) ->
 
     %%
     %% exit (with registered name, due to link)
-    Name = list_to_atom(OtherName),
+    Name = list_to_atom(hd(string:lexemes(atom_to_list(OtherNode), "@"))),
     Reason2 = make_ref(),
     Proc1 ! {link_please, Proc2},
     {trace, Proc1, link, Proc2} = receive_first_trace(),
@@ -708,8 +706,7 @@ dist_procs_trace(Config) when is_list(Config) ->
     receive_nothing(),
     %%
     %% Done.
-    true = stop_node(OtherNode),
-    ok.
+    peer:stop(Peer).
 
 %% Test trace(new, How, [procs]).
 procs_new_trace(Config) when is_list(Config) ->
@@ -1724,7 +1721,7 @@ trace_delivered(Config) when is_list(Config) ->
 
 %% This testcase checks that receive trace works on exit signal messages
 %% when the sender of the exit signal is the process itself.
-trap_exit_self_receive(Config) ->
+trap_exit_self_receive(Config) when is_list(Config) ->
     Parent = self(),
     Proc = spawn_link(fun() -> process(Parent) end),
 
@@ -1754,7 +1751,7 @@ trace_info_badarg(Config) when is_list(Config) ->
 %% An incoming suspend monitor down wasn't handled
 %% correct when the local monitor half had been
 %% removed with an emulator crash as result.
-erl_704(Config) ->
+erl_704(Config) when is_list(Config) ->
     erl_704_test(100).
 
 erl_704_test(0) ->
@@ -1942,16 +1939,6 @@ fun_spawn(Fun) ->
 
 fun_spawn(Fun, Args) ->
     spawn_link(erlang, apply, [Fun, Args]).
-
-
-start_node(Name) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    Cookie = atom_to_list(erlang:get_cookie()),
-    test_server:start_node(Name, slave,
-                           [{args, "-setcookie " ++ Cookie ++" -pa " ++ Pa}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).
 
 
 wait_for_empty_runq(DeadLine) ->

--- a/erts/emulator/test/unique_SUITE.erl
+++ b/erts/emulator/test/unique_SUITE.erl
@@ -54,7 +54,7 @@ end_per_suite(_Config) ->
 %%
 
 unique_monotonic_integer_white_box(Config) when is_list(Config) ->
-    {ok, Node} = start_node(Config),
+    {ok, Peer, Node} = ?CT_PEER(),
     TestServer = self(),
     Success = make_ref(),
     %% Run this in a separate node, so we don't mess up
@@ -72,8 +72,7 @@ unique_monotonic_integer_white_box(Config) when is_list(Config) ->
             ok
     end,
     erlang:demonitor(Mon, [flush]),
-    stop_node(Node),
-    ok.
+    peer:stop(Peer).
 
 set_unique_monotonic_integer_state(MinCounter, NextValue) ->
     true = erts_debug:set_internal_state(unique_monotonic_integer_state,
@@ -355,21 +354,3 @@ check_unique_integer_around(Int, #uniqint_info{min_int = MinInt,
 print_ret_val(File, Line, Value) ->    
     io:format("~s:~p: ~p~n", [File, Line, Value]),
     Value.
-
-start_node(Config) ->
-    start_node(Config, []).
-start_node(Config, Opts) when is_list(Config), is_list(Opts) ->
-    Pa = filename:dirname(code:which(?MODULE)),
-    A = erlang:monotonic_time(1) + erlang:time_offset(1),
-    B = erlang:unique_integer([positive]),
-    Name = list_to_atom(atom_to_list(?MODULE)
-                        ++ "-"
-                        ++ atom_to_list(proplists:get_value(testcase, Config))
-                        ++ "-"
-                        ++ integer_to_list(A)
-                        ++ "-"
-                        ++ integer_to_list(B)),
-    test_server:start_node(Name, slave, [{args, Opts++" -pa "++Pa}]).
-
-stop_node(Node) ->
-    test_server:stop_node(Node).

--- a/lib/asn1/test/asn1_SUITE.erl
+++ b/lib/asn1/test/asn1_SUITE.erl
@@ -715,18 +715,17 @@ ber_decode_error(Config, Rule, Opts) ->
     ber_decode_error:run(Opts).
 
 otp_14440(_Config) ->
-    Args = " -pa \"" ++ filename:dirname(code:which(?MODULE)) ++ "\"",
-    {ok,N} = slave:start(hostname(), otp_14440, Args),
+    {ok, Peer, N} = ?CT_PEER(),
     Result = rpc:call(N, ?MODULE, otp_14440_decode, []),
     io:format("Decode result = ~p~n", [Result]),
+    peer:stop(Peer),
     case Result of
         {exit,{error,{asn1,{invalid_value,5}}}} ->
-            ok = slave:stop(N);
+            ok;
         %% We get this if stack depth limit kicks in:
         {exit,{error,{asn1,{unknown,_}}}} ->
-            ok = slave:stop(N);
+            ok;
         _ ->
-            _ = slave:stop(N),
             ct:fail(Result)
     end.
 %%
@@ -1395,11 +1394,3 @@ all_called_1([F|T]) when is_atom(F) ->
     L ++ all_called_1(T);
 all_called_1([]) ->
     [].
-
-hostname() ->
-    hostname(atom_to_list(node())).
-
-hostname([$@ | Hostname]) ->
-    list_to_atom(Hostname);
-hostname([_C | Cs]) ->
-    hostname(Cs).

--- a/lib/common_test/include/ct.hrl
+++ b/lib/common_test/include/ct.hrl
@@ -36,6 +36,17 @@
 -define(CT_HOOK_INIT_PROCESS, ct_util_server).
 -define(CT_HOOK_TERMINATE_PROCESS, ct_util_server).
 
+%% Peer node names generated for Common Test purposes:
+-define(CT_PEER_NAME(TestCase), test_server:peer_name(?MODULE_STRING, TestCase)).
+-define(CT_PEER_NAME(), ?CT_PEER_NAME(?FUNCTION_NAME)).
+
+%% Start nodes with command line arguments or extended options
+-define(CT_PEER(Opts), test_server:start_peer(Opts, ?MODULE, ?FUNCTION_NAME)).
+%% Start a peer with name prefix of current ?MODULE and ?FUNCTION_NAME
+-define(CT_PEER(), ?CT_PEER([])).
+%% Start a compatibility node - for OTP test suites only
+-define(CT_PEER(Opts, Release, PrivDir), test_server:start_peer(Opts, ?MODULE, ?FUNCTION_NAME, Release, PrivDir)).
+
 %% Backward compatibility for test_server test suites.
 %% DO NOT USE IN NEW TEST SUITES.
 -define(line,).

--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -2688,6 +2688,7 @@ wait_for_node(Slave) ->
     end,
     Result.
 
+-compile([{nowarn_deprecated_function, [{slave, stop, 1}]}]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% stop_node(Name) -> true|false

--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -40,6 +40,7 @@
 -export([call_crash/3,call_crash/4,call_crash/5]).
 -export([temp_name/1]).
 -export([start_node/3, stop_node/1, wait_for_node/1, is_release_available/1, find_release/1]).
+-export([peer_name/2, start_peer/3, start_peer/5]).
 -export([app_test/1, app_test/2, appup_test/1]).
 -export([comment/1, make_priv_dir/0]).
 -export([os_type/0]).
@@ -2779,6 +2780,103 @@ find_release(Release) ->
 		      {test_server_ctrl,find_release,[Release]}},
     receive {sync_result,R} -> R end.
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% API for starting peer nodes according to Common Test conventions
+peer_name(Module, TestCase) ->
+    peer:random_name(lists:concat([Module, "-", TestCase])).
+
+%% Command line arguments passed
+-spec start_peer([string()] | peer:start_options(), atom() | string(), TestCase :: atom() | string()) ->
+    {ok, gen_statem:server_ref(), node()} | {error, term()}.
+start_peer(Args, Module, TestCase) when is_list(Args) ->
+    start_peer(#{args => Args, name => peer_name(Module, TestCase)}, Module);
+
+%% Full set of options passed
+start_peer(#{name := _Name} = Opts, Module, _TestCase) ->
+    start_peer(Opts, Module);
+start_peer(Opts, Module, TestCase) ->
+    start_peer(Opts#{name => peer_name(Module, TestCase)}, Module).
+
+%% Release compatibility testing
+-spec start_peer([string()] | peer:start_options(), atom() | string(), TestCase :: atom() | string(),
+    Release :: string(), OutDir :: file:filename()) ->
+        {ok, gen_statem:server_ref(), node()} | {error, term()} | not_available.
+start_peer(Args, Module, TestCase, Release, OutDir) when is_list(Args) ->
+    start_peer(#{args => Args}, Module, TestCase, Release, OutDir);
+start_peer(Opts, Module, TestCase, Release, OutDir) ->
+    case find_release(Release) of
+        not_available ->
+            not_available;
+        Erl ->
+            %% remove ERL_FLAGS/ERL_AFLAGS, because they may contain
+            %% "-emu_type debug" which does not exist for old releases. Keep "ERL_ZFLAGS",
+            %% for sometimes you might really need it...
+            Env = maps:get(env, Opts, []) ++ [{"ERL_AFLAGS", false}, {"ERL_FLAGS", false}],
+            NewArgs = ["-pa", peer_compile(Erl, code:which(peer), OutDir) | maps:get(args, Opts, [])],
+            start_peer(Opts#{exec => Erl, args => NewArgs,
+                env => Env}, Module, TestCase)
+    end.
+
+%% Internal implementation
+start_peer(#{name := Name} = Opts, Module) ->
+    CrashDir = test_server_sup:crash_dump_dir(),
+    CrashFile = filename:join([CrashDir, lists:concat(["erl_crash_dump.", Name])]),
+    Args = maps:get(args, Opts, []),
+    CookieArg =
+        case lists:member("-setcookie", Args) of
+            false ->
+                ["-setcookie", atom_to_list(erlang:get_cookie())];
+            true ->
+                []
+        end,
+    FullArgs = CookieArg ++ ["-pa", filename:dirname(code:which(Module)),
+        "-env", "ERL_CRASH_DUMP", CrashFile] ++ Args,
+    case test_server:is_cover() of
+        true ->
+            %% when cover is active, node must shut down gracefully, otherwise
+            %% coverage information won't be sent to cover master
+            CoverMain = cover:get_main_node(),
+            %% next line is a way to trick Dialyzer into not complaining over undocumented type
+            Shutdown = binary_to_term(term_to_binary({10000, CoverMain})),
+            case peer:start_link(Opts#{args => FullArgs, shutdown => Shutdown}) of
+                {ok, Peer, Node} ->
+                    do_cover_for_node(Node, start),
+                    {ok, Peer, Node};
+                Other ->
+                    Other
+            end;
+        false ->
+            peer:start_link(Opts#{args => FullArgs})
+    end.
+
+%% When a different release is requested, peer.erl needs to be compiled for
+%%  that specific release using the path supplied for 'erl'
+peer_compile(Erl, cover_compiled, OutDir) ->
+    {file, Path} = cover:is_compiled(peer),
+    peer_compile(Erl, Path, OutDir);
+peer_compile(Erl, ModPath, OutDir) ->
+    {ok, ModSrc} = filelib:find_source(ModPath),
+    Erlc = filename:join(filename:dirname(Erl), "erlc"),
+    cmd(Erlc, ["-o", OutDir, ModSrc]),
+    OutDir.
+
+%% This should really be implemented as os:cmd.
+cmd(Exec, Args) ->
+    %% remove all ERL_FLAGS/ERL_AFLAGS to drop "-emu_type debug"
+    Env = [{"ERL_AFLAGS", false}, {"ERL_FLAGS", false}],
+    Port = open_port({spawn_executable, Exec}, [{args, Args}, {env, Env},
+        stream, binary, exit_status, stderr_to_stdout]),
+    read_std(Port, lists:join(" ", [Exec|Args]), <<>>).
+
+read_std(Port, Exec, Out) ->
+    receive
+        {Port, {data, More}} ->
+            read_std(Port, Exec, <<Out/binary, More/binary>>);
+        {Port, {exit_status, 0}}  ->
+            Out;
+       {Port, {exit_status, Status}} ->
+            erlang:error({exit, Status, Exec, Out})
+    end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% run_on_shielded_node(Fun, CArgs) -> term()

--- a/lib/common_test/src/test_server_node.erl
+++ b/lib/common_test/src/test_server_node.erl
@@ -179,6 +179,9 @@ start_node_slave(SlaveName, OptList, From, _TI) ->
 	end,
     gen_server:reply(From,Ret).
 
+%% Temporary suppression, to avoid a warning calling undocumented
+%%  but deprecated function.
+-compile([{nowarn_deprecated_function,[{slave,start,5}]}]).
 
 do_start_node_slave(Host0, SlaveName, Args, Prog, Cleanup) ->
     Host =

--- a/lib/diameter/test/diameter_distribution_SUITE.erl
+++ b/lib/diameter/test/diameter_distribution_SUITE.erl
@@ -25,19 +25,18 @@
 
 -module(diameter_distribution_SUITE).
 
--export([suite/0,
-         all/0]).
+-export([
+    suite/0,
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1
+]).
 
 %% testcases
--export([enslave/1, enslave/0,
-         ping/1,
-         start/1,
-         connect/1,
-         send_local/1,
+-export([send_local/1,
          send_remote/1,
          send_timeout/1,
-         send_failover/1,
-         stop/1, stop/0]).
+         send_failover/1]).
 
 %% diameter callbacks
 -export([peer_up/3,
@@ -49,193 +48,59 @@
          handle_error/5,
          handle_request/3]).
 
--export([call/1]).
+%% Internal export for RPC
+-export([start_server/5, start_client/6, call/1]).
 
 -include("diameter.hrl").
 -include("diameter_gen_base_rfc6733.hrl").
 
-%% ===========================================================================
+-include_lib("common_test/include/ct.hrl").
 
--define(util, diameter_util).
+%% ===========================================================================
 
 -define(CLIENT, 'CLIENT').
 -define(SERVER, 'SERVER').
 -define(REALM, "erlang.org").
 -define(DICT, diameter_gen_base_rfc6733).
 -define(ADDR, {127,0,0,1}).
-
-%% Config for diameter:start_service/2.
--define(SERVICE(Host),
-        [{'Origin-Host', Host ++ [$.|?REALM]},
-         {'Origin-Realm', ?REALM},
-         {'Host-IP-Address', [?ADDR]},
-         {'Vendor-Id', 12345},
-         {'Product-Name', "OTP/diameter"},
-         {'Auth-Application-Id', [?DICT:id()]},
-         {'Origin-State-Id', origin()},
-         {share_peers, peers()},
-         {use_shared_peers, peers()},
-         {restrict_connections, false},
-         {spawn_opt, {diameter_dist, spawn_local, []}},
-         {sequence, fun sequence/0},
-         {application, [{dictionary, ?DICT},
-                        {module, ?MODULE},
-                        {request_errors, callback},
-                        {answer_errors, callback}]}]).
-
 -define(SUCCESS, 2001).
 -define(BUSY,    3004).
 -define(LOGOUT,  ?'DIAMETER_BASE_TERMINATION-CAUSE_LOGOUT').
 -define(MOVED,   ?'DIAMETER_BASE_TERMINATION-CAUSE_USER_MOVED').
 -define(TIMEOUT, ?'DIAMETER_BASE_TERMINATION-CAUSE_SESSION_TIMEOUT').
 
--define(L, atom_to_list).
--define(A, list_to_atom).
-
-%% The order here is significant and causes the server to listen
-%% before the clients connect.
--define(NODES, [{server, ?SERVER},
-                {client0, ?CLIENT},
-                {client1, ?CLIENT},
-                {client2, ?CLIENT}]).
-
-%% Options to ct_slave:start/2.
--define(TIMEOUTS, [{T, 15000} || T <- [boot_timeout,
-                                       init_timeout,
-                                       start_timeout]]).
-
 %% ===========================================================================
 
 suite() ->
-    [{timetrap, {seconds, 60}}].
+    [{timetrap, {seconds, 30}}].
 
 all() ->
-    [enslave,
-     ping,
-     start,
-     connect,
-     send_local,
+    [send_local,
      send_remote,
      send_timeout,
-     send_failover,
-     stop].
+     send_failover].
 
-%% ===========================================================================
-%% start/stop testcases
+init_per_suite(Config) ->
+    {ok, ServerPeer, ServerNode} = ?CT_PEER(),
+    ListenPort = erpc:call(ServerNode, ?MODULE, start_server, [?SERVER, "server0", 99, 0, 32]),
+    %% client nodes
+    Indices = lists:seq(0, 2),
+    {_Ok, ClientPeers, Nodes} = lists:unzip3([{ok, _P, _N} = ?CT_PEER() || _ <- Indices]),
+    %% Ensure the client nodes are connected since the sharing of
+    %% transports is only between connected nodes.
+    [pong = erpc:call(N, net_adm, ping, [M]) || N <- Nodes, M <- Nodes, N < M],
+    %% Start diameter clients
+    %% not exactly multi-call, call args are different
+    [ok = erpc:call(N, ?MODULE, start_client,
+        [?CLIENT, ListenPort, "client" ++ integer_to_list(Seq), Seq, Seq, 30])
+        || {N, Seq} <- lists:zip(Nodes, Indices)],
+    %% unlink peers, assuming end_per_suite is executed reliably
+    Peers = [ServerPeer | ClientPeers],
+    [unlink(P) || P <- Peers],
+    [{server, ServerNode}, {clients, Nodes}, {peers, Peers} | Config].
 
-%% enslave/1
-%%
-%% Start four slave nodes, one to implement a Diameter server,
-%% three to implement a client.
-
-enslave() ->
-    [{timetrap, {seconds, 30*length(?NODES)}}].
-
-enslave(Config) ->
-    Here = filename:dirname(code:which(?MODULE)),
-    Ebin = filename:join([Here, "..", "ebin"]),
-    Dirs = [Here, Ebin],
-    Nodes = [{N,S} || {M,S} <- ?NODES, N <- [slave(M, Dirs)]],
-    ?util:write_priv(Config, nodes, [{N,S} || {{N,ok},S} <- Nodes]),
-    [] = [{T,S} || {{_,E} = T, S} <- Nodes, E /= ok].
-
-slave(Name, Dirs) ->
-    add_pathsa(Dirs, ct_slave:start(Name, ?TIMEOUTS)).
-
-add_pathsa(Dirs, {ok, Node}) ->
-    {Node, rpc:call(Node, code, add_pathsa, [Dirs])};
-add_pathsa(_, No) ->
-    {No, error}.
-
-%% ping/1
-%%
-%% Ensure the client nodes are connected since the sharing of
-%% transports is only between connected nodes.
-
-ping({?SERVER, _Nodes}) ->
-    [];
-
-ping({?CLIENT, Nodes}) ->
-    [N || {N,_} <- Nodes,
-          node() /= N,
-          pang <- [net_adm:ping(N)]];
-
-ping(Config) ->
-    Nodes = ?util:read_priv(Config, nodes),
-    [] = [{N,RC} || {N,S} <- Nodes,
-                    RC <- [rpc:call(N, ?MODULE, ping, [{S, Nodes}])],
-                    RC /= []].
-
-%% start/1
-%%
-%% Start diameter services.
-
-start(SvcName)
-  when is_atom(SvcName) ->
-    ok = diameter:start(),
-    ok = diameter:start_service(SvcName, ?SERVICE((?L(SvcName))));
-
-start(Config) ->
-    Nodes = ?util:read_priv(Config, nodes),
-    [] = [{N,RC} || {N,S} <- Nodes,
-                    RC <- [rpc:call(N, ?MODULE, start, [S])],
-                    RC /= ok].
-
-sequence() ->
-    sequence(sname()).
-
-sequence(server) ->
-    {0,32};
-sequence(Client) ->
-    "client" ++ N = ?L(Client),
-    {list_to_integer(N), 30}.
-
-origin() ->
-    origin(sname()).
-
-origin(server) ->
-    99;
-origin(Client) ->
-    "client" ++ N = ?L(Client),
-    list_to_integer(N).
-
-peers() ->
-    peers(sname()).
-
-peers(server)  -> true;
-peers(client0) -> [node() | nodes()];
-peers(client1) -> fun erlang:nodes/0;
-peers(client2) -> nodes().
-
-%% connect/1
-%%
-%% Establish one connection to the server from each of the client
-%% nodes.
-
-connect({?SERVER, Config}) ->
-    ?util:write_priv(Config, lref, {node(), ?util:listen(?SERVER, tcp)}),
-    ok;
-
-connect({?CLIENT, Config}) ->
-    ?util:connect(?CLIENT, tcp, ?util:read_priv(Config, lref)),
-    ok;
-
-connect(Config) ->
-    Nodes = ?util:read_priv(Config, nodes),
-    [] = [{N,RC} || {N,S} <- Nodes,
-                    RC <- [rpc:call(N, ?MODULE, connect, [{S,Config}])],
-                    RC /= ok].
-
-%% stop/1
-%%
-%% Stop the slave nodes.
-
-stop() ->
-    [{timetrap, {seconds, 30*length(?NODES)}}].
-
-stop(_Config) ->
-    [] = [{N,E} || {N,_} <- ?NODES,
-                   {error, _, _} = E <- [ct_slave:stop(N)]].
+end_per_suite(Config) ->
+    [peer:stop(P) || P <- proplists:get_value(peers, Config)].
 
 %% ===========================================================================
 %% traffic testcases
@@ -283,18 +148,65 @@ str(Cause) ->
 %% send/2
 
 send(Config, Where, Req) ->
-    [_, {Node, _} | _] = ?util:read_priv(Config, nodes) ,
+    [Node | _] = proplists:get_value(clients, Config) ,
     rpc:call(Node, ?MODULE, call, [{Where, Req}]).
 
 %% call/1
 
 call({Where, Req}) ->
-    diameter:call(?CLIENT, ?DICT, Req, [{extra, [{Where, sname()}]}]).
+    diameter:call(?CLIENT, ?DICT, Req, [{extra, [{Where, node()}]}]).
 
-%% sname/0
 
-sname() ->
-    ?A(hd(string:tokens(?L(node()), "@"))).
+%% Starts a peer node with Diameter server running
+start_server(Server, Host, Origin, SeqFrom, SeqTo) ->
+    ok = diameter:start(),
+    ok = diameter:start_service(Server, service_opt(Host, Origin, SeqFrom, SeqTo)),
+    %% Listener config
+    ListenConfig = [{transport_module, diameter_tcp}, {transport_config, [{ip, ?ADDR},
+        {port, 0}, {accept, {256, 0, 0, 1}}, {accept, ["256.0.0.1", ["^.+$"]]}]}],
+    %% start listener on Server0, get the listener port number
+    {ok, ListenRef} = diameter:add_transport(Server, {listen, ListenConfig}),
+    %% wait for listener to be up
+    [_] = diameter_reg:wait({diameter_tcp, listener, {ListenRef, '_'}}),
+    [{listen, ListenPort, _}] = diameter_tcp:ports(),
+    ListenPort.
+
+%% Starts Diameter client node connected to Server
+start_client(Client, ServerPort, Host, Origin, SeqFrom, SeqTo) ->
+    ok = diameter:start(),
+    ok = diameter:start_service(Client, service_opt(Host, Origin, SeqFrom, SeqTo)),
+    %% Establish connection to the server
+    ConnectConfig = [{transport_module, diameter_tcp},
+        {transport_config, [{ip, ?ADDR}, {port, 0}, {raddr, ?ADDR}, {rport, ServerPort}]}],
+    true = diameter:subscribe(Client),
+    {ok, Ref} = diameter:add_transport(Client, {connect, ConnectConfig}),
+    receive
+        {diameter_event, Client, {up, Ref, _, _, _}} -> ok
+    end.
+
+%% Config for diameter:start_service/2.
+service_opt(Host, Origin, SeqFrom, SeqTo) ->
+    [{'Origin-Host', Host ++ [$.|?REALM]},
+        {'Origin-Realm', ?REALM},
+        {'Host-IP-Address', [?ADDR]},
+        {'Vendor-Id', 12345},
+        {'Product-Name', "OTP/diameter"},
+        {'Auth-Application-Id', [?DICT:id()]},
+        {'Origin-State-Id', Origin},
+        {share_peers, peers(Host)},
+        {use_shared_peers, peers(Host)},
+        {restrict_connections, false},
+        {spawn_opt, {diameter_dist, spawn_local, []}},
+        {sequence, fun () -> {SeqFrom, SeqTo} end},
+        {application, [{dictionary, ?DICT},
+            {module, ?MODULE},
+            {request_errors, callback},
+            {answer_errors, callback}]}].
+
+peers("server0")  -> true;
+peers("client0") -> [node() | nodes()];
+peers("client1") -> fun erlang:nodes/0;
+peers("client2") -> nodes().
 
 %% ===========================================================================
 %% diameter callbacks
@@ -311,18 +223,18 @@ peer_down(_SvcName, _Peer, State) ->
 
 %% pick_peer/4
 
-pick_peer([LP], [_, _], ?CLIENT, _State, {local, client0}) ->
+pick_peer([LP], [_, _], ?CLIENT, _State, {local, _Client0Node}) ->
     {ok, LP};
 
-pick_peer([_], [RP | _], ?CLIENT, _State, {remote, client0}) ->
+pick_peer([_], [RP | _], ?CLIENT, _State, {remote, _Client0Node}) ->
     {ok, RP};
 
-pick_peer([LP], [], ?CLIENT, _State, {remote, client0}) ->
+pick_peer([LP], [], ?CLIENT, _State, {remote, _Client0Node}) ->
     {ok, LP}.
 
 %% prepare_request/4
 
-prepare_request(Pkt, ?CLIENT, {_Ref, Caps}, {_, client0}) ->
+prepare_request(Pkt, ?CLIENT, {_Ref, Caps}, {_, _Client0Node}) ->
     #diameter_packet{msg = Req}
         = Pkt,
     #diameter_caps{origin_host  = {OH, _},
@@ -334,26 +246,25 @@ prepare_request(Pkt, ?CLIENT, {_Ref, Caps}, {_, client0}) ->
 
 %% prepare_retransmit/4
 
-prepare_retransmit(Pkt, ?CLIENT, _, {_, client0}) ->
+prepare_retransmit(Pkt, ?CLIENT, _, {_, _Client0Node}) ->
     #diameter_packet{msg = #diameter_base_STR{'Termination-Cause' = ?MOVED}}
         = Pkt,  %% assert
     {send, Pkt}.
 
 %% handle_answer/5
 
-handle_answer(Pkt, _Req, ?CLIENT, _Peer, {_, client0}) ->
+handle_answer(Pkt, _Req, ?CLIENT, _Peer, {_, _Client0Node}) ->
     #diameter_packet{msg = Rec, errors = []} = Pkt,
     Rec.
 
 %% handle_error/5
 
-handle_error(Reason, _Req, ?CLIENT, _Peer, {_, client0}) ->
+handle_error(Reason, _Req, ?CLIENT, _Peer, {_, _Client0Node}) ->
     {error, Reason}.
 
 %% handle_request/3
 
 handle_request(Pkt, ?SERVER, Peer) ->
-    server = sname(),  %% assert
     #diameter_packet{msg = Req}
         = Pkt,
     request(Req, Peer).

--- a/lib/eunit/src/eunit_data.erl
+++ b/lib/eunit/src/eunit_data.erl
@@ -182,6 +182,9 @@ next(Tests) ->
 	    none
     end.
 
+%% Temporary suppression
+-compile([{nowarn_deprecated_function,[{slave,start_link,3},{slave,stop,1}]}]).
+
 %% this returns either a #test{} or #group{} record, or {data, T} to
 %% signal that T has been substituted for the given representation
 

--- a/lib/kernel/src/net.erl
+++ b/lib/kernel/src/net.erl
@@ -49,7 +49,6 @@
 	 cast/4,
 	 broadcast/3,
 	 ping/1,
-	 relay/1,
 	 sleep/1]).
 
 %% Should we define these here or refer to the prim_net module
@@ -73,7 +72,7 @@
 -deprecated({cast,      4, "use rpc:cast/4 instead"}).
 -deprecated({broadcast, 3, "use rpc:eval_everywhere/3 instead"}).
 -deprecated({ping,      1, "use net_adm:ping/1 instead"}).
--deprecated({relay,     1, "use slave:relay/1 instead"}).
+-removed({relay,        1, "use fun Relay(Pid) -> receive X -> Pid ! X end, Relay(Pid) instead"}).
 -deprecated({sleep,     1, "use 'receive after T -> ok end' instead"}).
 
 
@@ -130,7 +129,6 @@ cast(N,M,F,A) -> rpc:cast(N,M,F,A).
 broadcast(M,F,A) -> rpc:eval_everywhere(M,F,A).
 ping(Node) -> net_adm:ping(Node).
 sleep(T) -> receive after T -> ok end.
-relay(X) -> slave:relay(X).
 
 
 %% ===========================================================================

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -1676,14 +1676,10 @@ monitor_nodes_many(DCfg, _Config) ->
 
 %% Test order of messages nodedown and nodeup.
 monitor_nodes_down_up(Config) when is_list(Config) ->
-    [An] = get_nodenames(1, monitor_nodeup),
-    {ok, A} = ct_slave:start(An),
-
-    try
-        monitor_nodes_yoyo(A)
-    after
-        catch ct_slave:stop(A)
-    end.
+    {ok, Peer, Node} = ?CT_PEER(#{connection => 0}),
+    true = net_kernel:connect_node(Node),
+    monitor_nodes_yoyo(Node),
+    peer:stop(Peer).
 
 monitor_nodes_yoyo(A) ->
     net_kernel:monitor_nodes(true),

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -16417,11 +16417,11 @@ api_opt_sock_peercred_tcp(_InitState) ->
     %%      #{desc => "create node",
     %%        cmd  => fun(#{host := Host} = State) ->
     %%     		   ?SEV_IPRINT("try create node on ~p", [Host]),
-    %%                        case start_node(Host, client) of
-    %%                            {ok, Node} ->
+    %%                        case ?CT_PEER() of
+    %%                            {ok, Peer, Node} ->
     %%                                ?SEV_IPRINT("client node ~p started",
     %%                                            [Node]),
-    %%                                {ok, State#{node => Node}};
+    %%                                {ok, State#{node => Node, peer => Peer}};
     %%                            {error, Reason} ->
     %%                                {skip, Reason}
     %%                        end
@@ -16530,8 +16530,8 @@ api_opt_sock_peercred_tcp(_InitState) ->
     %%                        {ok, State1}
     %%                end},
     %%      #{desc => "stop client node",
-    %%        cmd  => fun(#{node := Node} = _State) ->
-    %%                        stop_node(Node)
+    %%        cmd  => fun(#{peer := Peer} = _State) ->
+    %%                        peer:stop(Peer)
     %%                end},
     %%      #{desc => "await client node termination",
     %%        cmd  => fun(#{node := Node} = State) ->
@@ -24056,11 +24056,11 @@ api_to_connect_tcp(InitState) ->
          #{desc => "create node",
            cmd  => fun(#{host := Host} = State) ->
 			   ?SEV_IPRINT("try create node on ~p", [Host]),
-                           case start_node(Host, client) of
-                               {ok, Node} ->
+                           case ?CT_PEER() of
+                               {ok, Peer, Node} ->
                                    ?SEV_IPRINT("client node ~p started",
                                                [Node]),
-                                   {ok, State#{node => Node}};
+                                   {ok, State#{node => Node, peer => Peer}};
                                {error, Reason} ->
                                    {skip, Reason}
                            end
@@ -24168,8 +24168,8 @@ api_to_connect_tcp(InitState) ->
                            {ok, State1}
                    end},
          #{desc => "stop client node",
-           cmd  => fun(#{node := Node} = _State) ->
-                           stop_node(Node)
+           cmd  => fun(#{peer := Peer} = _State) ->
+                           peer:stop(Peer)
                    end},
          #{desc => "await client node termination",
            cmd  => fun(#{node := Node} = State) ->
@@ -33116,12 +33116,11 @@ sc_rc_receive_response_tcp(InitState) ->
          %% *** Init part ***
          #{desc => "create node",
            cmd  => fun(#{host := Host, node_id := NodeID} = State) ->
-                           case start_node(Host,
-                                           l2a(f("client_~w", [NodeID]))) of
-                               {ok, Node} ->
+                           case ?CT_PEER(#{name => ?CT_PEER_NAME(f("client_~w", [NodeID]))}) of
+                               {ok, Peer, Node} ->
                                    ?SEV_IPRINT("client node ~p started",
                                                [Node]),
-                                   {ok, State#{node => Node}};
+                                   {ok, State#{node => Node, peer => Peer}};
                                {error, Reason} ->
                                    ?SEV_EPRINT("failed starting "
                                                "client node ~p (=> SKIP):"
@@ -33236,8 +33235,8 @@ sc_rc_receive_response_tcp(InitState) ->
                            {ok, State1}
                    end},
          #{desc => "stop client node",
-           cmd  => fun(#{node := Node} = _State) ->
-                           stop_node(Node)
+           cmd  => fun(#{peer := Peer} = _State) ->
+                           peer:stop(Peer)
                    end},
          #{desc => "await client node termination",
            cmd  => fun(#{node := Node} = State) ->
@@ -34088,11 +34087,11 @@ sc_rs_send_shutdown_receive_tcp(InitState) ->
          %% *** Init part ***
          #{desc => "create node",
            cmd  => fun(#{host := Host} = State) ->
-                           case start_node(Host, client) of
-                               {ok, Node} ->
+                           case ?CT_PEER() of
+                               {ok, Peer, Node} ->
                                    ?SEV_IPRINT("client node ~p started",
                                                [Node]),
-                                   {ok, State#{node => Node}};
+                                   {ok, State#{peer => Peer, node => Node}};
                                {error, Reason} ->
                                    {skip, Reason}
                            end
@@ -34260,8 +34259,8 @@ sc_rs_send_shutdown_receive_tcp(InitState) ->
                            {ok, State1}
                    end},
          #{desc => "stop client node",
-           cmd  => fun(#{node := Node} = _State) ->
-                           stop_node(Node)
+           cmd  => fun(#{peer := Peer} = _State) ->
+                           peer:stop(Peer)
                    end},
          #{desc => "await client node termination",
            cmd  => fun(#{node := Node} = State) ->
@@ -37371,11 +37370,11 @@ traffic_send_and_recv_chunks_tcp(InitState) ->
          %% *** Init part ***
          #{desc => "create node",
            cmd  => fun(#{host := Host} = State) ->
-                           case start_node(Host, client) of
-                               {ok, Node} ->
+                           case ?CT_PEER() of
+                               {ok, Peer, Node} ->
                                    ?SEV_IPRINT("(remote) client node ~p started",
                                                [Node]),
-                                   {ok, State#{node => Node}};
+                                   {ok, State#{peer => Peer, node => Node}};
                                {error, Reason} ->
                                    {skip, Reason}
                            end
@@ -37742,8 +37741,8 @@ traffic_send_and_recv_chunks_tcp(InitState) ->
                            {ok, State1}
                    end},
          #{desc => "stop client node",
-           cmd  => fun(#{node := Node} = _State) ->
-                           stop_node(Node)
+           cmd  => fun(#{peer := Peer} = _State) ->
+                           peer:stop(Peer)
                    end},
          #{desc => "await client node termination",
            cmd  => fun(#{node := Node} = State) ->
@@ -39298,11 +39297,11 @@ traffic_ping_pong_send_and_receive_tcp2(InitState) ->
          %% *** Init part ***
          #{desc => "create node",
            cmd  => fun(#{host := Host} = State) ->
-                           case start_node(Host, client) of
-                               {ok, Node} ->
+                           case ?CT_PEER() of
+                               {ok, Peer, Node} ->
                                    ?SEV_IPRINT("(remote) client node ~p started", 
                                                [Node]),
-                                   {ok, State#{node => Node}};
+                                   {ok, State#{peer => Peer, node => Node}};
                                {error, Reason} ->
                                    {skip, Reason}
                            end
@@ -39439,8 +39438,8 @@ traffic_ping_pong_send_and_receive_tcp2(InitState) ->
                            {ok, State1}
                    end},
          #{desc => "stop client node",
-           cmd  => fun(#{node := Node} = _State) ->
-                           stop_node(Node)
+           cmd  => fun(#{peer := Peer} = _State) ->
+                           peer:stop(Peer)
                    end},
          #{desc => "await client node termination",
            cmd  => fun(#{node := Node} = State) ->
@@ -40258,11 +40257,11 @@ traffic_ping_pong_send_and_receive_udp2(InitState) ->
          %% *** Init part ***
          #{desc => "create node",
            cmd  => fun(#{host := Host} = State) ->
-                           case start_node(Host, client) of
-                               {ok, Node} ->
+                           case ?CT_PEER() of
+                               {ok, Peer, Node} ->
                                    ?SEV_IPRINT("(remote) client node ~p started", 
                                                [Node]),
-                                   {ok, State#{node => Node}};
+                                   {ok, State#{peer => Peer, node => Node}};
                                {error, Reason} ->
                                    {skip, Reason}
                            end
@@ -40366,8 +40365,8 @@ traffic_ping_pong_send_and_receive_udp2(InitState) ->
                            {ok, State1}
                    end},
          #{desc => "stop client node",
-           cmd  => fun(#{node := Node} = _State) ->
-                           stop_node(Node)
+           cmd  => fun(#{peer := Peer} = _State) ->
+                           peer:stop(Peer)
                    end},
          #{desc => "await client node termination",
            cmd  => fun(#{node := Node} = State) ->
@@ -46802,9 +46801,9 @@ ttest_tcp(InitState) ->
          %% *** Init part ***
          #{desc => "create node",
            cmd  => fun(#{host := Host} = State) ->
-                           case start_node(Host, server) of
-                               {ok, Node} ->
-                                   {ok, State#{node => Node}};
+                           case ?CT_PEER() of
+                               {ok, Peer, Node} ->
+                                   {ok, State#{peer => Peer, node => Node}};
                                {error, Reason} ->
                                    {skip, Reason}
                            end
@@ -46882,8 +46881,8 @@ ttest_tcp(InitState) ->
                            {ok, State1}
                    end},
          #{desc => "stop (server) node",
-           cmd  => fun(#{node := Node} = _State) ->
-                           stop_node(Node)
+           cmd  => fun(#{peer := Peer} = _State) ->
+                           peer:stop(Peer)
                    end},
          #{desc => "await (server) node termination",
            cmd  => fun(#{node := Node} = State) ->
@@ -46924,9 +46923,9 @@ ttest_tcp(InitState) ->
          %% *** Init part ***
          #{desc => "create node",
            cmd  => fun(#{host := Host} = State) ->
-                           case start_node(Host, client) of
-                               {ok, Node} ->
-                                   {ok, State#{node => Node}};
+                           case ?CT_PEER() of
+                               {ok, Peer, Node} ->
+                                   {ok, State#{peer => Peer, node => Node}};
                                {error, Reason} ->
                                    {skip, Reason}
                            end
@@ -47036,8 +47035,8 @@ ttest_tcp(InitState) ->
                            end
                    end},
          #{desc => "stop (client) node",
-           cmd  => fun(#{node := Node} = _State) ->
-                           stop_node(Node)
+           cmd  => fun(#{peer := Peer} = _State) ->
+                           peer:stop(Peer)
                    end},
          #{desc => "await (client) node termination",
            cmd  => fun(#{node := Node} = State) ->
@@ -48150,68 +48149,6 @@ otp16359_maccept_tcp(InitState) ->
     ok = ?SEV_AWAIT_FINISH([PrimAcceptor, SecAcceptor1, SecAcceptor2,
                             Client1, Client2, Client3,
                             Tester]).
-
-
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-%% This mechanism has only one purpose: So that we are able to kill
-%% the node-starter process if it takes to long. The node-starter
-%% runs on the local node.
-%% This crapola is hopefully temporary, but we have seen that on
-%% some platforms the ct_slave:start simply hangs.
--define(NODE_START_TIMEOUT, 10000).
-start_node(Host, NodeName) ->
-    start_node(Host, NodeName, ?NODE_START_TIMEOUT).
-
-start_node(Host, NodeName, Timeout) ->
-    {NodeStarter, _} =
-        spawn_monitor(fun() -> exit(start_unique_node(Host, NodeName)) end),
-    receive
-        {'DOWN', _, process, NodeStarter, Result} ->
-            %% i("Node Starter (~p) reported: ~p", [NodeStarter, Result]),
-            Result
-    after Timeout ->
-            exit(NodeStarter, kill),
-            {error, {failed_starting_node, NodeName, timeout}}
-    end.
-
-start_unique_node(Host, NodeName) ->
-    UniqueNodeName = f("~w_~w", [NodeName, erlang:system_time(millisecond)]),
-    case do_start_node(Host, UniqueNodeName) of
-        {ok, _} = OK ->
-            global:sync(),
-            %% i("Node ~p started: "
-            %%    "~n   Nodes:        ~p"
-            %%    "~n   Logger:       ~p"
-            %%    "~n   Global Names: ~p",
-            %%    [NodeName, nodes(),
-            %%     global:whereis_name(socket_test_logger),
-            %%     global:registered_names()]),
-            OK;
-        {error, Reason, _} ->
-            {error, Reason}
-    end.
-
-do_start_node(Host, NodeName) when is_list(NodeName) ->
-    do_start_node(Host, list_to_atom(NodeName));
-do_start_node(Host, NodeName) when is_atom(NodeName) ->
-    Dir   = filename:dirname(code:which(?MODULE)),
-    Flags = "-pa " ++ Dir,
-    Opts  = [{monitor_master, true}, {erl_flags, Flags}],
-    ct_slave:start(Host, NodeName, Opts).
-
-
-stop_node(Node) ->
-    case ct_slave:stop(Node) of
-        {ok, _} ->
-            ok;
-        {error, _} = ERROR ->
-            ERROR
-    end.
-
-    
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/lib/sasl/test/systools_SUITE.erl
+++ b/lib/sasl/test/systools_SUITE.erl
@@ -278,9 +278,7 @@ unicode_script(Config) when is_list(Config) ->
 
     %% Need to do this on a separate node to make sure it has unicode
     %% filename mode (+fnu*)
-    {ok,HostStr} = inet:gethostname(),
-    Host = list_to_atom(HostStr),
-    {ok,Node} = ct_slave:start(Host,unicode_script_node,[{erl_flags,"+fnui"}]),
+    {ok,Peer,Node} = ?CT_PEER(["+fnui"]),
 
     ok = rpc:call(Node,erl_tar,extract,
 		  [TarFile, [{cwd,UnicodeLibDir},compressed]]),
@@ -313,10 +311,11 @@ unicode_script(Config) when is_list(Config) ->
     rpc:call(Node,code,add_pathz,[filename:dirname(code:which(?MODULE))]),
     rpc:call(Node,?MODULE,delete_tree,[UnicodeLibDir]),
 
+    peer:stop(Peer),
+
     ok.
 
 unicode_script(cleanup,Config) ->
-    _ = ct_slave:stop(unicode_script_node),
     file:delete(fname(?privdir, "unicode_app.tgz")),
     ok.
 

--- a/lib/stdlib/doc/src/Makefile
+++ b/lib/stdlib/doc/src/Makefile
@@ -74,6 +74,7 @@ XML_REF3_FILES = \
 	ms_transform.xml \
 	orddict.xml \
 	ordsets.xml \
+	peer.xml \
 	pool.xml \
 	proc_lib.xml \
 	proplists.xml \

--- a/lib/stdlib/doc/src/peer.xml
+++ b/lib/stdlib/doc/src/peer.xml
@@ -1,0 +1,539 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE erlref SYSTEM "erlref.dtd">
+
+<!-- %ExternalCopyright% -->
+
+<erlref>
+  <header>
+    <copyright>
+      <year>2021</year><year>2021</year>
+      <holder>Maxim Fedorov, WhatsApp Inc.</holder>
+    </copyright>
+    <legalnotice>
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+    </legalnotice>
+
+    <title>peer</title>
+    <prepared>maximfca@gmail.com</prepared>
+    <docno></docno>
+    <date></date>
+    <rev></rev>
+    <file>peer.xml</file>
+  </header>
+  <module since="OTP 25.0">peer</module>
+  <modulesummary>Start and control linked Erlang nodes.
+  </modulesummary>
+  <description>
+    <p>
+      This module provides functions for starting linked Erlang nodes.
+      The node spawning new nodes is called <em>origin</em>, and newly started
+      nodes are <em>peer</em> nodes, or peers. A peer node automatically
+      terminates when it loses the <em>control connection</em> to the origin. This
+      connection could be an Erlang distribution connection, or an alternative -
+      TCP or standard I/O. The alternative connection provides a way to execute
+      remote procedure calls even when Erlang Distribution is not available,
+      allowing to test the distribution itself.
+    </p>
+
+    <p>
+      Peer node terminal input/output is relayed through the origin.
+      If a standard I/O alternative connection is requested, console output
+      also goes via the origin, allowing debugging of node startup and boot
+      script execution (see <seecom marker="erts:erl#init_debug">
+      <c>-init_debug</c></seecom>). File I/O is not redirected, contrary to
+      <seeerl marker="slave"><c>slave(3)</c></seeerl> behaviour.
+    </p>
+
+    <p>
+      The peer node can start on the same or a different host (via <c>ssh</c>)
+      or in a separate container (for example Docker).
+      When the peer starts on the same host as the origin, it inherits
+      the current directory and environment variables from the origin.
+    </p>
+
+    <note>
+      <p>
+      This module is designed to facilitate multi-node testing with Common Test.
+      Use the <c>?CT_PEER()</c> macro to start a linked peer node according to
+      Common Test conventions: crash dumps written to specific location, node
+      name prefixed with module name, calling function, and origin OS process
+      ID). Use <seemfa marker="#random_name/1"><c>random_name/1</c></seemfa> to
+      create sufficiently unique node names if you need more control.
+      </p>
+      <p>
+      A peer node started without alternative connection behaves similarly
+      to <seeerl marker="slave"><c>slave(3)</c></seeerl>. When an alternative
+      connection is requested, the behaviour is similar to
+      <c>test_server:start_node(Name, peer, Args).</c>
+    </p> </note>
+
+  </description>
+
+  <section>
+    <title>Example</title>
+    <p>
+      The following example implements a test suite starting extra Erlang nodes.
+      It employs a number of techniques to speed up testing and reliably shut
+      down peer nodes:
+    </p>
+    <list>
+      <item>peers start linked to test runner process. If the test case fails,
+      the peer node is stopped automatically, leaving no rogue nodes running in
+      the background</item>
+      <item>arguments used to start the peer are saved in the control process
+      state for manual analysis. If the test case fails, the CRASH REPORT contains
+      these arguments</item>
+      <item>multiple test cases can run concurrently speeding up overall testing
+      process, peer node names are unique even when there are multiple instances
+      of the same test suite running in parallel</item>
+    </list>
+    <code type="erl">
+      -module(my_SUITE).
+      -behaviour(ct_suite).
+      -export([all/0, groups/0]).
+      -export([basic/1, args/1, named/1, restart_node/1, multi_node/1]).
+
+      -include_lib("common_test/include/ct.hrl").
+
+      groups() ->
+          [{quick, [parallel],
+              [basic, args, named, restart_node, multi_node]}].
+
+      all() ->
+          [{group, quick}].
+
+      basic(Config) when is_list(Config) ->
+          {ok, Peer, _Node} = ?CT_PEER(),
+          peer:stop(Peer).
+
+      args(Config) when is_list(Config) ->
+          %% specify additional arguments to the new node
+          {ok, Peer, _Node} = ?CT_PEER(["-emu_flavor", "smp"]),
+          peer:stop(Peer).
+
+      named(Config) when is_list(Config) ->
+          %% pass test case name down to function starting nodes
+          Peer = start_node_impl(named_test),
+          peer:stop(Peer).
+
+      start_node_impl(ActualTestCase) ->
+          {ok, Peer, Node} = ?CT_PEER(#{name => ?CT_PEER_NAME(ActualTestCase)}),
+          %% extra setup needed for multiple test cases
+          ok = rpc:call(Node, application, set_env, [kernel, key, value]),
+          Peer.
+
+      restart_node(Config) when is_list(Config) ->
+          Name = ?CT_PEER_NAME(),
+          {ok, Peer, Node} = ?CT_PEER(#{name => Name}),
+          peer:stop(Peer),
+          %% restart the node with the same name as before
+          {ok, Peer2, Node} = ?CT_PEER(#{name => Name, args => ["+fnl"]}),
+          peer:stop(Peer2).
+    </code>
+
+    <p>
+      The next example demonstrates how to start multiple nodes concurrently:
+    </p>
+    <code type="erl">
+      multi_node(Config) when is_list(Config) ->
+          Peers = [?CT_PEER(#{wait_boot => {self(), tag}})
+              || _ &lt;- lists:seq(1, 4)],
+          %% wait for all nodes to complete boot process, get their names:
+          _Nodes = [receive {tag, {started, Node, Peer}} -> Node end
+              || {ok, Peer} &lt;- Peers],
+          [peer:stop(Peer) || {ok, Peer} &lt;- Peers].
+    </code>
+
+    <p>
+      Start a peer on a different host. Requires <c>ssh</c> key-based
+      authentication set up, allowing "another_host" connection without password
+      prompt.
+    </p>
+    <code type="erl">
+      Ssh = os:find_executable("ssh"),
+      peer:start_link(#{exec => {Ssh, ["another_host", "erl"]},
+          connection => standard_io}),
+    </code>
+
+    <p>
+      The following Common Test case demonstrates Docker integration, starting two
+      containers with hostnames "one" and "two". In this example Erlang nodes
+      running inside containers form an Erlang cluster.
+    </p>
+    <code type="erl">
+      docker(Config) when is_list(Config) ->
+          Docker = os:find_executable("docker"),
+          PrivDir = proplists:get_value(priv_dir, Config),
+          build_release(PrivDir),
+          build_image(PrivDir),
+
+          %% start two Docker containers
+          {ok, Peer, Node} = peer:start_link(#{name => lambda,
+              connection => standard_io,
+              exec => {Docker, ["run", "-h", "one", "-i", "lambda"]}}),
+          {ok, Peer2, Node2} = peer:start_link(#{name => lambda,
+              connection => standard_io,
+              exec => {Docker, ["run", "-h", "two", "-i", "lambda"]}}),
+
+          %% find IP address of the second node using alternative connection RPC
+          {ok, Ips} = peer:call(Peer2, inet, getifaddrs, []),
+          {"eth0", Eth0} = lists:keyfind("eth0", 1, Ips),
+          {addr, Ip} = lists:keyfind(addr, 1, Eth0),
+
+          %% make first node to discover second one
+          ok = peer:call(Peer, inet_db, set_lookup, [[file]]),
+          ok = peer:call(Peer, inet_db, add_host, [Ip, ["two"]]),
+
+          %% join a cluster
+          true = peer:call(Peer, net_kernel, connect_node, [Node2]),
+          %% verify that second peer node has only the first node visible
+          [Node] = peer:call(Peer2, erlang, nodes, []),
+
+          %% stop peers, causing containers to also stop
+          peer:stop(Peer2),
+          peer:stop(Peer).
+
+      build_release(Dir) ->
+          %% load sasl.app file, otherwise application:get_key will fail
+          application:load(sasl),
+          %% create *.rel - release file
+          RelFile = filename:join(Dir, "lambda.rel"),
+          Release = {release, {"lambda", "1.0.0"},
+              {erts, erlang:system_info(version)},
+              [{App, begin {ok, Vsn} = application:get_key(App, vsn), Vsn end}
+                  || App &lt;- [kernel, stdlib, sasl]]},
+          ok = file:write_file(RelFile, list_to_binary(lists:flatten(
+              io_lib:format("~tp.", [Release])))),
+          RelFileNoExt = filename:join(Dir, "lambda"),
+
+          %% create boot script
+          {ok, systools_make, []} = systools:make_script(RelFileNoExt,
+              [silent, {outdir, Dir}]),
+          %% package release into *.tar.gz
+          ok = systools:make_tar(RelFileNoExt, [{erts, code:root_dir()}]).
+
+      build_image(Dir) ->
+          %% Create Dockerfile example, working only for Ubuntu 20.04
+          %% Expose port 4445, and make Erlang distribution to listen
+          %%  on this port, and connect to it without EPMD
+          %% Set cookie on both nodes to be the same.
+          BuildScript = filename:join(Dir, "Dockerfile"),
+          Dockerfile =
+            "FROM ubuntu:20.04 as runner\n"
+            "EXPOSE 4445\n"
+            "WORKDIR /opt/lambda\n"
+            "COPY lambda.tar.gz /tmp\n"
+            "RUN tar -zxvf /tmp/lambda.tar.gz -C /opt/lambda\n"
+            "ENTRYPOINT [\"/opt/lambda/erts-" ++ erlang:system_info(version) ++
+            "/bin/dyn_erl\", \"-boot\", \"/opt/lambda/releases/1.0.0/start\","
+            " \"-kernel\", \"inet_dist_listen_min\", \"4445\","
+            " \"-erl_epmd_port\", \"4445\","
+            " \"-setcookie\", \"secret\"]\n",
+          ok = file:write_file(BuildScript, Dockerfile),
+          os:cmd("docker build -t lambda " ++ Dir).
+    </code>
+  </section>
+
+  <datatypes>
+    <datatype>
+      <name name="start_options"/>
+      <desc>
+        <p>
+          Options that can be used when starting
+          a <c>peer</c> node through <seemfa marker="#start/1"><c>start/1</c></seemfa>
+          and <seemfa marker="#start_link/0"><c>start_link/0,1</c></seemfa>.
+        </p>
+        <taglist>
+          <tag><c>name</c></tag>
+          <item>
+            <p>
+              Node name (the part before "@"). When <c>name</c> is not specified, but <c>host</c>
+              is, <c>peer</c> follows compatibility behaviour and uses the origin node name.
+            </p>
+          </item>
+          <tag><c>host</c></tag>
+          <item>
+            <p>
+              Enforces a specific host name. Can be used to override the default
+              behaviour and start "node@localhost" instead of "node@realhostname".
+            </p>
+          </item>
+          <tag><c>longnames</c></tag>
+          <item>
+            <p>
+              Use long names to start a node. Default is taken from the origin
+              using <c>net_kernel:longnames()</c>. If the origin is not distributed,
+              short names is the default.
+            </p>
+          </item>
+          <tag><c>peer_down</c></tag>
+          <item>
+            <p>
+              Defines the peer control process behaviour when the control connection is
+              closed from the peer node side (for example when the peer crashes or dumps core).
+              When set to <c>stop</c> (default), a lost control connection causes
+              the control process to exit normally. Setting <c>peer_down</c> to <c>continue</c>
+              keeps the control process running, and <c>crash</c> will cause
+              the controlling process to exit abnormally.
+            </p>
+          </item>
+          <tag><c>exec</c></tag>
+          <item>
+            <p>
+              Alternative mechanism to start peer nodes with, for example, ssh instead of the
+              default bash.
+            </p>
+          </item>
+          <tag><c>connection</c></tag>
+          <item>
+            <p>Alternative connection specification. See the
+              <seetype marker="#connection"><c>connection</c> datatype</seetype>.</p>
+          </item>
+          <tag><c>args</c></tag>
+          <item>
+            <p>Extra command line arguments to append to the "erl" command. Arguments are
+              passed as is, no escaping or quoting is needed or accepted.</p>
+          </item>
+          <tag><c>env</c></tag>
+          <item>
+            <p>
+              List of environment variables with their values. This list is applied
+              to a locally started executable. If you need to change the environment of
+              the remote peer, adjust <c>args</c> to contain
+              <c>-env ENV_KEY ENV_VALUE</c>.
+            </p>
+          </item>
+          <tag><c>wait_boot</c></tag>
+          <item>
+            <p>Specifies the start/start_link timeout.
+            See <seetype marker="#wait_boot"><c>wait_boot</c> datatype</seetype>.
+            </p>
+          </item>
+          <tag><c>shutdown</c></tag>
+          <item>
+            <p>Specifies the peer node stopping behaviour. See
+              <seemfa marker="#stop/1"><c>stop()</c></seemfa>.</p>
+          </item>
+        </taglist>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="peer_state"/>
+      <desc><p>Peer node state.</p></desc>
+    </datatype>
+    <datatype>
+      <name name="connection"/>
+      <desc><p>Alternative connection between the origin and the peer. When the
+        connection closes, the peer node terminates automatically. If
+        the <c>peer_down</c> startup flag is set to <c>crash</c>, the controlling
+        process on the origin node exits with corresponding reason, effectively
+        providing a two-way link. </p>
+        <p>When <c>connection</c> is set to a port number, the origin starts listening on
+          the requested TCP port, and the peer node connects to the port. When it is set to
+          an <c>{IP, Port}</c> tuple, the origin listens only on the specified IP. The port
+          number can be set to 0 for automatic selection.
+        </p>
+        <p>Using the <c>standard_io</c> alternative connection starts the peer attached to
+          the origin (other connections use <c>-detached</c> flag to erl). In this mode
+          peer and origin communicate via stdin/stdout.
+        </p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="exec"/>
+      <desc>
+        <p>
+          Overrides executable to start peer nodes with. By default it is
+          the path to "erl", taken from <c>init:get_argument(progname)</c>.
+          If <c>progname</c> is not known, <c>peer</c> makes best guess given the current
+          ERTS version.
+        </p>
+        <p>
+          When a tuple is passed, the first element is the path to executable,
+          and the second element is prepended to the final command line. This can be used
+          to start peers on a remote host or in a Docker container. See the examples
+          above.
+        </p>
+        <p>
+          This option is useful for testing backwards compatibility with previous releases,
+          installed at specific paths, or when the Erlang installation location
+          is missing from the <c>PATH</c>.
+        </p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="wait_boot"/>
+      <desc><p>Specifies start/start_link timeout in milliseconds. Can be set to
+        <c>false</c>, allowing the peer to start asynchronously. If <c>{Pid, Tag}</c>
+        is specified instead of a timeout, the peer will send <c>Tag</c> to the
+        requested process.</p></desc>
+    </datatype>
+  </datatypes>
+
+  <funcs>
+
+    <func>
+      <name name="call" arity="4" since="OTP 25.0"/>
+      <name name="call" arity="5" since="OTP 25.0"/>
+      <fsummary>Evaluates a function call on a peer node.</fsummary>
+      <desc>
+        <p>
+          Uses the alternative connection to
+          evaluate <c>apply(<anno>Module</anno>, <anno>Function</anno>,
+          <anno>Args</anno>)</c> on the peer node and returns
+          the corresponding value <c><anno>Result</anno></c>.
+          <c><anno>Timeout</anno></c> is an integer representing
+          the timeout in milliseconds or the atom <c>infinity</c>
+          which prevents the operation from ever timing out.
+        </p>
+        <p>
+          When an alternative connection is not requested, this
+          function will raise <c>exit</c> signal with the <c>noconnection</c>
+          reason. Use <seeerl marker="kernel:erpc"><c>erpc</c></seeerl> module
+          to communicate over Erlang distribution.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="cast" arity="4" since="OTP 25.0"/>
+      <fsummary>Evaluates a function call on a peer node ignoring the result.</fsummary>
+      <desc>
+        <p>
+          Uses the alternative connection to
+          evaluate <c>apply(<anno>Module</anno>, <anno>Function</anno>,
+          <anno>Args</anno>)</c> on the peer node. No response is delivered to the
+          calling process.
+        </p>
+        <p>
+          <c>peer:cast/4</c> fails silently when the alternative connection is not
+          configured. Use <seeerl marker="kernel:erpc"><c>erpc</c></seeerl> module
+          to communicate over Erlang distribution.
+      </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="send" arity="3" since="OTP 25.0"/>
+      <fsummary>Sends a message to a process on the peer node.</fsummary>
+      <desc>
+        <p>
+          Uses the alternative connection to send <anno>Message</anno> to a process on the
+          the peer node. Silently fails if no alternative connection is configured.
+          The process can be referenced by process ID or registered name.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="get_state" arity="1" since="OTP 25.0"/>
+      <fsummary>Returns peer node state.</fsummary>
+      <desc>
+        <p>Returns the peer node state. Th initial state is <c>booting</c>; the node stays in that
+          state until then boot script is complete, and then the node progresses to <c>running</c>.
+          If the node stops (gracefully or not), the state changes to <c>down</c>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="random_name" arity="0" since="OTP 25.0"/>
+      <fsummary>Creates a sufficiently unique node name.</fsummary>
+      <desc>
+        <p>
+          The same as <seemfa marker="#random_name/1"><c>random_name(peer)</c></seemfa>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="random_name" arity="1" since="OTP 25.0"/>
+      <fsummary>Creates a sufficiently unique node name given a prefix.</fsummary>
+      <desc>
+        <p>
+          Creates a sufficiently unique node name for the current host,
+          combining a prefix, a unique number, and the current OS process ID.
+        </p>
+        <note>
+          <p>
+            Use the <c>?CT_PEER(["erl_arg1"])</c> macro provided by Common Test
+            <c>-include_lib("common_test/include/ct.hrl")</c> for convenience.
+            It starts a new peer using Erlang distribution as the control channel,
+            supplies thes calling module's code path to the peer, and uses the calling
+            function name for the name prefix.
+          </p>
+        </note>
+      </desc>
+    </func>
+
+    <func>
+      <name name="start" arity="1" since="OTP 25.0"/>
+      <fsummary>Starts a peer node.</fsummary>
+      <desc>
+        <p>
+          Starts a peer node with the specified
+          <seetype marker="#start_options"><c>start_options()</c></seetype>.
+          Returns the controlling process and the full peer node name, unless
+          <c>wait_boot</c> is not requested and the host name is not known in advance.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="start_link" arity="0" since="OTP 25.0"/>
+      <fsummary>Starts a peer node, and links controlling process to caller process.</fsummary>
+      <desc>
+        <p>
+          The same as
+          <seemfa marker="#start_link/1"><c>start_link(#{name => random_name()})</c></seemfa>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="start_link" arity="1" since="OTP 25.0"/>
+      <fsummary>Starts a peer node, and links controlling process to caller process.</fsummary>
+      <desc>
+        <p>Starts a peer node in the same way as <seemfa marker="#start/1"><c>start/1</c></seemfa>,
+          except that the peer node is linked to the currently
+          executing process. If that process terminates, the peer node
+          also terminates.</p>
+        <p>
+          Accepts <seetype marker="#start_options"><c>start_options()</c></seetype>.
+          Returns the controlling process and the full peer node name, unless <c>wait_boot</c> is not
+          requested and host name is not known in advance.
+        </p>
+        <p>
+          When the <c>standard_io</c> alternative connection is requested, and <c>wait_boot</c> is
+          not set to <c>false</c>, a failed peer boot sequence causes the caller to exit with
+          the <c>{boot_failed, {exit_status, ExitCode}}</c> reason.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="stop" arity="1" since="OTP 25.0"/>
+      <fsummary>Stop controlling process and terminate peer node.</fsummary>
+      <desc>
+        <p>Depending on the <c>shutdown</c> option used to start the peer,
+        stopping may be graceful (via <c>init:stop()</c>) or less so,
+        by just closing the control connection, which triggers <c>erlang:halt()</c>
+        executed by the peer.</p>
+        <p>A graceful shutdown can be slower, or even block indefinitely.</p>
+      </desc>
+    </func>
+
+  </funcs>
+</erlref>
+

--- a/lib/stdlib/doc/src/ref_man.xml
+++ b/lib/stdlib/doc/src/ref_man.xml
@@ -74,6 +74,7 @@
   <xi:include href="ms_transform.xml"/>
   <xi:include href="orddict.xml"/>
   <xi:include href="ordsets.xml"/>
+  <xi:include href="peer.xml"/>
   <xi:include href="pool.xml"/>
   <xi:include href="proc_lib.xml"/>
   <xi:include href="proplists.xml"/>

--- a/lib/stdlib/doc/src/specs.xml
+++ b/lib/stdlib/doc/src/specs.xml
@@ -41,6 +41,7 @@
   <xi:include href="../specs/specs_ms_transform.xml"/>
   <xi:include href="../specs/specs_orddict.xml"/>
   <xi:include href="../specs/specs_ordsets.xml"/>
+  <xi:include href="../specs/specs_peer.xml"/>
   <xi:include href="../specs/specs_pool.xml"/>
   <xi:include href="../specs/specs_proc_lib.xml"/>
   <xi:include href="../specs/specs_proplists.xml"/>

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -102,6 +102,7 @@ MODULES= \
 	orddict \
 	ordsets \
 	re \
+	peer \
 	pool \
 	proc_lib \
 	proplists \

--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -83,8 +83,6 @@ obsolete(net, cast, 4) ->
     {deprecated, "use rpc:cast/4 instead"};
 obsolete(net, ping, 1) ->
     {deprecated, "use net_adm:ping/1 instead"};
-obsolete(net, relay, 1) ->
-    {deprecated, "use slave:relay/1 instead"};
 obsolete(net, sleep, 1) ->
     {deprecated, "use 'receive after T -> ok end' instead"};
 obsolete(public_key, ssh_decode, 2) ->
@@ -191,6 +189,8 @@ obsolete(httpd_conf, is_file, 1) ->
     {removed, "use filelib:is_file/1 instead"};
 obsolete(httpd_conf, make_integer, 1) ->
     {removed, "use erlang:list_to_integer/1 instead"};
+obsolete(net, relay, 1) ->
+    {removed, "use fun Relay(Pid) -> receive X -> Pid ! X end, Relay(Pid) instead"};
 obsolete(rpc, safe_multi_server_call, 2) ->
     {removed, "use rpc:multi_server_call/2 instead"};
 obsolete(rpc, safe_multi_server_call, 3) ->
@@ -225,6 +225,8 @@ obsolete(gen_fsm, _, _) ->
     {deprecated, "use the 'gen_statem' module instead"};
 obsolete(random, _, _) ->
     {deprecated, "use the 'rand' module instead"};
+obsolete(slave, _, _) ->
+    {deprecated, "use the 'peer' module instead", "OTP 27"};
 obsolete(os_mon_mib, _, _) ->
     {removed, "this module was removed in OTP 22.0"};
 obsolete(pg2, _, _) ->

--- a/lib/stdlib/src/pool.erl
+++ b/lib/stdlib/src/pool.erl
@@ -103,6 +103,8 @@ pspawn(M, F, A) ->
 pspawn_link(M, F, A) ->
     spawn_link(get_node(), M, F, A).
 
+-compile([{nowarn_deprecated_function,[{slave,start,3}]}]).
+
 start_nodes([], _, _) -> [];
 start_nodes([Host|Tail], Name, Args) -> 
     case slave:start(Host, Name, Args) of 

--- a/lib/stdlib/src/slave.erl
+++ b/lib/stdlib/src/slave.erl
@@ -19,6 +19,8 @@
 %%
 -module(slave).
 
+-deprecated([{'_','_',"use the 'peer' module instead"}]).
+
 %% If the macro DEBUG is defined during compilation, 
 %% debug printouts are done through erlang:display/1.
 %% Activate this feature by starting the compiler 

--- a/lib/stdlib/src/stdlib.app.src
+++ b/lib/stdlib/src/stdlib.app.src
@@ -81,6 +81,7 @@
 	     orddict,
 	     ordsets,
 	     otp_internal,
+	     peer,
 	     pool,
 	     proc_lib,
 	     proplists,

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -51,6 +51,7 @@ MODULES= \
 	log_mf_h_SUITE \
 	math_SUITE \
 	ms_transform_SUITE \
+	peer_SUITE \
 	pool_SUITE \
 	proc_lib_SUITE \
 	proplists_SUITE \

--- a/lib/stdlib/test/peer_SUITE.erl
+++ b/lib/stdlib/test/peer_SUITE.erl
@@ -1,0 +1,463 @@
+%%% @doc
+%%% Smoke tests for peer node controller
+%%% @end
+-module(peer_SUITE).
+-author("maximfca@gmail.com").
+
+%% Common Test headers
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+%% Test server callbacks
+-export([
+    suite/0,
+    all/0,
+    groups/0,
+    init_per_group/2,
+    end_per_group/2
+]).
+
+%% Test cases
+-export([
+    dist/0, dist/1,
+    peer_down_crash/0, peer_down_crash/1,
+    peer_down_continue/0, peer_down_continue/1,
+    peer_down_boot/0, peer_down_boot/1,
+    dist_io_redirect/0, dist_io_redirect/1,
+    dist_localhost/0, dist_localhost/1,
+    errors/0, errors/1,
+    basic/0, basic/1,
+    peer_states/0, peer_states/1,
+    cast/0, cast/1,
+    detached/0, detached/1,
+    dyn_peer/0, dyn_peer/1,
+    stop_peer/0, stop_peer/1,
+    init_debug/0, init_debug/1,
+    io_redirect/0, io_redirect/1,
+    multi_node/0, multi_node/1,
+    dist_up_down/0, dist_up_down/1,
+    duplicate_name/0, duplicate_name/1,
+    old_release/0, old_release/1,
+    ssh/0, ssh/1,
+    docker/0, docker/1
+]).
+
+suite() ->
+    [{timetrap, {minutes, 1}}].
+
+alternative() ->
+    [basic, peer_states, cast, detached, dyn_peer, stop_peer, io_redirect,
+        multi_node, duplicate_name].
+
+groups() ->
+    [
+        {dist, [parallel], [errors, dist, peer_down_crash, peer_down_continue, peer_down_boot,
+            dist_io_redirect, dist_up_down, dist_localhost]},
+        {tcp, [parallel], alternative()},
+        {standard_io, [parallel], [init_debug | alternative()]},
+        {compatibility, [parallel], [old_release]},
+        {remote, [parallel], [ssh]}
+    ].
+
+all() ->
+    [{group, dist}, {group, tcp}, {group, standard_io}, {group, compatibility}, {group, remote}].
+
+init_per_group(remote, Config) ->
+    %% check that SSH can connect to localhost, skip the test if not
+    try os:cmd("ssh localhost echo ok") of
+        "ok\n" -> Config;
+        _ -> {skip, "'ssh localhost echo ok' did not return ok"}
+    catch
+        Class:Reason ->
+            SkipReason = io_lib:format("'ssh localhost echo ok' failed with ~s:~p", [Class, Reason]),
+            {skip, SkipReason}
+    end;
+init_per_group(dist, Config) ->
+    case erlang:is_alive() of
+        true -> Config;
+        false -> {skip, "origin is not distributed"}
+    end;
+init_per_group(tcp, Config) ->
+    [{connection, 0} | Config];
+init_per_group(standard_io, Config) ->
+    [{connection, standard_io} | Config];
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_TestCase, Config) ->
+    proplists:delete(connection, Config).
+
+%% -------------------------------------------------------------------
+%% Distribution-enabled cases
+
+errors() ->
+    [{doc, "Verify that invalid command line is rejected immediately"}].
+
+errors(Config) when is_list(Config) ->
+    ?assertException(error, {invalid_arg, atom}, peer:start(#{args => atom})),
+    ?assertException(error, {invalid_arg, $s}, peer:start(#{args => "string"})),
+    ?assertException(error, {invalid_arg, ["2"]}, peer:start(#{args => ["1", ["2"]]})),
+    ?assertException(error, {exec, atom}, peer:start(#{exec => atom, name => name})),
+    ?assertException(error, {exec, atom}, peer:start(#{exec => {atom, []}, name => name})),
+    ?assertException(error, {exec, atom}, peer:start(#{exec => {"erl", [atom]}, name => name})),
+    ?assertException(error, not_alive, peer:start(#{})). %% peer node won't start - it's not alive
+
+dist() ->
+    [{doc, "Classic behaviour: detached peer with no alternative, connects via dist"}].
+
+%% Classic 'slave': start new node locally, with random name, ask peer control process to exit normally
+dist(Config) when is_list(Config) ->
+    {ok, Peer, Node} = peer:start_link(),
+    %% distribution is expected to be connected
+    ?assertEqual(Node, erpc:call(Node, erlang, node, [])),
+    %% but not alternative...
+    ?assertException(error, noconnection, peer:call(Peer, erlang, node, [])),
+    ?assertEqual(true, net_kernel:disconnect(Node)),
+    %% ^^^ this makes the node go down, but we also need to ensure that net_kernel
+    %%  finished processing
+    ct:sleep(500),
+    _ = sys:get_state(net_kernel),
+    ?assertException(exit, {noproc, _}, peer:get_state(Peer)).
+
+peer_down_crash() ->
+    [{doc, "Tests peer_down handling when crash mode is requested"}].
+
+peer_down_crash(Config) when is_list(Config) ->
+    %% two-way link: "crash" mode
+    {ok, Peer, Node} = peer:start_link(#{name => peer:random_name(?FUNCTION_NAME), peer_down => crash}),
+    %% verify node started locally
+    ?assertEqual(Node, erpc:call(Node, erlang, node, [])),
+    %% verify there is no alternative connection
+    ?assertException(error, noconnection, peer:call(Peer, erlang, node, [])),
+    %% unlink and monitor
+    unlink(Peer),
+    MRef = monitor(process, Peer),
+    ?assertEqual(true, net_kernel:disconnect(Node)),
+    %% ^^^ this makes the node go down
+    %% since two-way link is requested, it triggers peer to stop
+    receive
+        {'DOWN', MRef, process, Peer, {nodedown, Node}} ->
+            ok
+    after 2000 ->
+        link(Peer),
+        {fail, disconnect_timeout}
+    end.
+
+peer_down_continue() ->
+    [{doc, "Tests peer_down handling for continue setting"}].
+
+peer_down_continue(Config) when is_list(Config) ->
+    {ok, Peer, Node} = peer:start_link(#{name => peer:random_name(?FUNCTION_NAME), peer_down => continue}),
+    ?assertEqual(ok, erpc:cast(Node, erlang, halt, [])),
+    ct:sleep(500),
+    sys:replace_state(net_kernel, fun(S) -> sys:get_state(Peer), S end),
+    ?assertMatch({down, _}, peer:get_state(Peer)),
+    peer:stop(Peer).
+
+peer_down_boot() ->
+    [{doc, "Tests that peer node failing boot fails start_link correctly"}].
+
+peer_down_boot(Config) when is_list(Config) ->
+    ?assertException(exit, {boot_failed, {exit_status, 1}},
+        peer:start_link(#{connection => standard_io, name => peer:random_name(), args => ["-no_epmd"]})).
+
+dist_io_redirect() ->
+    [{doc, "Tests i/o redirection working for dist"}].
+
+dist_io_redirect(Config) when is_list(Config) ->
+    %% Common Test changes group leader process to capture output.
+    %% 'peer' relays output via control process group leader.
+    ct:capture_start(),
+    {ok, Peer, Node} = peer:start_link(#{name => peer:random_name(?FUNCTION_NAME),
+        args => ["-eval", "io:format(\"out\")."]}),
+    %% RPC is smart enough to set the group leader, so force 'user' output
+    %% to check that peer node redirects 'user' to the current process group
+    %% leader.
+    ?assertEqual(ok, erpc:call(Node, io, format, [user, "STRONGFLOUR.", []])),
+    %% verify that 'send' is ignored when no alternative connection is done
+    ?assertEqual(ok, peer:send(Peer, init, {stop, stop})),
+    %% check that RPC sets the group leader, even via 'apply'
+    ?assertEqual(ok, erpc:call(Node, erlang, apply, [io, format, ["second."]])),
+    %% 'eval' at the end may be quite slow, so have to wait here
+    ct:sleep(500),
+    peer:stop(Peer),
+    ct:capture_stop(),
+    Texts = ct:capture_get(),
+    %% order is not guaranteed, so sort explicitly
+    ?assertEqual(lists:sort(["STRONGFLOUR.", "second.", "out"]), lists:sort(Texts)).
+
+dist_up_down() ->
+    [{doc, "Test that Erlang distribution can go up and down (with TCP alternative)"}].
+
+dist_up_down(Config) when is_list(Config) ->
+    %% skip establishing full mesh, for it makes 'global' hang
+    %% TODO: fix 'global.erl' locker process so it does not hang
+    {ok, Peer, Node} = peer:start_link(#{name => peer:random_name(?FUNCTION_NAME),
+        connection => {{127, 0, 0, 1}, 0}, args => ["-connect_all", "false"]}),
+    ?assertEqual(true, net_kernel:connect_node(Node)),
+    ?assertEqual(true, net_kernel:disconnect(Node)),
+    ?assertEqual(true, net_kernel:connect_node(Node)),
+    peer:stop(Peer).
+
+dist_localhost() ->
+    [{doc, "Test that localhost and gethostname operate together"}].
+
+dist_localhost(Config) when is_list(Config) ->
+    {ok, Peer, Node} = peer:start_link(#{name => peer:random_name(?FUNCTION_NAME), host => "localhost"}),
+    ?assertMatch([_, "localhost"], string:lexemes(atom_to_list(Node), "@")),
+    %% start second peer, ensure they see each other
+    {ok, Host} = inet:gethostname(),
+    {ok, Peer2, Node2} = peer:start_link(#{name => peer:random_name(?FUNCTION_NAME), host => Host}),
+    true = erpc:call(Node, net_kernel, connect_node, [Node2]),
+    peer:stop(Peer),
+    peer:stop(Peer2).
+
+%% -------------------------------------------------------------------
+%% alternative connection cases
+
+%% Runs in the peer node context, forward a message from peer node to origin
+%%  node via alternative connection.
+-spec forward(Dest :: pid() | atom(), Message :: term()) -> term().
+forward(Dest, Message) ->
+    group_leader() ! {message, Dest, Message}.
+
+basic() ->
+    [{doc, "Tests peer node start, and do some RPC via stdin/stdout"}].
+
+basic(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    {ok, Peer, _Node} = peer:start_link(#{connection => Conn}),
+    %% test the alternative connection
+    ?assertEqual('nonode@nohost', peer:call(Peer, erlang, node, [])),
+    ?assertException(throw, ball, peer:call(Peer, erlang, throw, [ball])),
+    %% setup code path to this module (needed to "fancy RPC")
+    Path = filename:dirname(code:which(?MODULE)),
+    ?assertEqual(true, peer:call(Peer, code, add_path, [Path])),
+    %% fancy RPC via message exchange (uses forwarding from the peer)
+    Control = self(),
+    RFun = fun() -> receive do -> forward(Control, done) end end,
+    RemotePid = peer:call(Peer, erlang, spawn, [RFun]),
+    peer:send(Peer, RemotePid, do),
+    %% wait back from that process
+    receive done -> ok end,
+    %% shutdown the node
+    ?assertEqual(ok, peer:stop(Peer)),
+    ?assertNot(is_process_alive(Peer)).
+
+peer_states() ->
+    [{doc, "Tests peer node states"}].
+
+peer_states(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    {ok, Peer} = peer:start_link(#{connection => Conn, wait_boot => {self(), ?FUNCTION_NAME},
+        peer_down => continue}),
+    ?assertEqual(booting, peer:get_state(Peer)),
+    %% running
+    receive {?FUNCTION_NAME, {started, _Node, Peer}} -> ok end,
+    ?assertEqual(running, peer:get_state(Peer)),
+    peer:cast(Peer, erlang, halt, []),
+    ct:sleep(1000), %% source of flakiness, should switch to some better notification mechanism
+    %% down
+    ?assertMatch({down, _}, peer:get_state(Peer)),
+    peer:stop(Peer).
+
+cast() ->
+    [{doc, "Tests casts via alternative connections"}].
+
+cast(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    {ok, Peer, _Node} = peer:start_link(#{connection => Conn}),
+    %% cast RPC
+    ?assertEqual(undefined, peer:call(Peer, application, get_env, [kernel, foo])),
+    peer:cast(Peer, application, set_env, [kernel, foo, bar]),
+    %% this is only to ensure application_controller completed processing
+    peer:call(Peer, sys, get_state, [application_controller]),
+    ?assertEqual({ok, bar}, peer:call(Peer, application, get_env, [kernel, foo])),
+    peer:stop(Peer).
+
+detached() ->
+    [{doc, "Tests detached node (RPC via alternative connection)"}].
+
+detached(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    {ok, Peer, _Node} = peer:start_link(#{connection => Conn}),
+    ?assertEqual('nonode@nohost', peer:call(Peer, erlang, node, [])),
+    %% check exceptions
+    ?assertException(throw, ball, peer:call(Peer, erlang, throw, [ball])),
+    %% check tcp forwarding
+    Path = filename:dirname(code:which(?MODULE)),
+    ?assertEqual(true, peer:call(Peer, code, add_path, [Path])),
+    %% fancy RPC via message exchange (uses forwarding from the peer)
+    Control = self(),
+    RFun = fun() -> receive do -> forward(Control, done) end end,
+    RemotePid = peer:call(Peer, erlang, spawn, [RFun]),
+    %% test that sending message over alternative TCP connection works
+    peer:send(Peer, RemotePid, do),
+    %% wait back from that process
+    receive done -> ok end,
+    %% logging via TCP
+    ct:capture_start(),
+    peer:call(Peer, io, format, ["one."]),
+    peer:call(Peer, erlang, apply, [io, format, ["two."]]),
+    peer:stop(Peer),
+    ct:capture_stop(),
+    Texts = ct:capture_get(),
+    %% just stop
+    ?assertEqual(["one.", "two."], Texts).
+
+dyn_peer() ->
+    [{doc, "Origin is not distributed, and peer becomes distributed dynamically"}].
+
+dyn_peer(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    {ok, Peer, 'nonode@nohost'} = peer:start_link(#{connection => Conn}), %% start not distributed
+    Node = list_to_atom(lists:concat([peer:random_name(?FUNCTION_NAME), "@forced.host"])),
+    {ok, _} = peer:call(Peer, net_kernel, start, [[Node, longnames]]),
+    ?assertEqual(Node, peer:call(Peer, erlang, node, [])),
+    peer:stop(Peer).
+
+stop_peer() ->
+    [{doc, "Test that peer shuts down even when node sleeps, but control connection closed"}].
+
+stop_peer(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    {ok, Peer, _Node} = peer:start_link(#{name => peer:random_name(?FUNCTION_NAME),
+        connection => Conn, args => ["-eval", "timer:sleep(60000)."]}),
+    %% shutdown node
+    peer:stop(Peer).
+
+init_debug() ->
+    [{doc, "Test that debug messages in init work"}].
+
+init_debug(Config) when is_list(Config) ->
+    ct:capture_start(),
+    {ok, Peer, _Node} = peer:start_link(#{name => peer:random_name(?FUNCTION_NAME), shutdown => 1000,
+        connection => standard_io, args => ["-init_debug"]}),
+    ct:sleep(200), %% without this sleep, peer is not fast enough to print
+    peer:stop(Peer),
+    ct:capture_stop(),
+    Texts = lists:append([string:trim(Str, trailing, "\r\n") || Str <- ct:capture_get()]),
+    %% every boot script starts with this
+    Expected = "{progress,preloaded}",
+    Actual = lists:sublist(Texts, 1, length(Expected)),
+    ?assertEqual(Expected, Actual).
+
+io_redirect() ->
+    [{doc, "Tests i/o redirection working for std"}].
+
+io_redirect(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    {ok, Peer, _Node} = peer:start_link(#{connection => Conn}),
+    ct:capture_start(),
+    peer:call(Peer, io, format, [user, "test.", []]),
+    peer:call(Peer, erlang, apply, [io, format, ["second."]]),
+    %% ensure no dist connection is set up
+    ?assertNot(lists:member(Peer, nodes()), {dist_connected, Peer, nodes()}),
+    ct:capture_stop(),
+    Texts = ct:capture_get(),
+    peer:stop(Peer),
+    ?assertEqual(["test.", "second."], Texts).
+
+multi_node() ->
+    [{doc, "Tests several nodes starting concurrently"}].
+
+multi_node(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    Peers = [
+        peer:start_link(#{name => peer:random_name(?FUNCTION_NAME),
+            wait_boot => {self(), tag}, connection => Conn})
+        || _ <- lists:seq(1, 4)],
+    Nodes = [receive {tag, {started, Node, Peer}} -> Node end || {ok, Peer} <- Peers],
+    ?assertEqual(4, length(Nodes)),
+    [?assertEqual(ok, peer:stop(Peer)) || {ok, Peer} <- Peers].
+
+duplicate_name() ->
+    [{doc, "Tests that a node with the same name fails to start"}].
+
+duplicate_name(Config) when is_list(Config) ->
+    Conn = proplists:get_value(connection, Config),
+    {ok, Peer, _Node} = peer:start_link(#{connection => Conn, name => ?FUNCTION_NAME, register => false}),
+    ?assertException(exit, _, peer:start_link(#{connection => standard_io, name => ?FUNCTION_NAME})),
+    peer:stop(Peer).
+
+%% -------------------------------------------------------------------
+%% Compatibility: old releases
+old_release() ->
+    [{doc, "Verity running with previous OTP release"}].
+
+old_release(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    %% don't expect OTP 10 to be available
+    ?assertEqual(not_available, ?CT_PEER([], "10", PrivDir)),
+    PrevRel = integer_to_list(list_to_integer(erlang:system_info(otp_release)) - 2),
+    case ?CT_PEER([], PrevRel, PrivDir) of
+        not_available ->
+            {skip, "OTP " ++ PrevRel ++ " not found"};
+        {ok, Peer, Node} ->
+            ?assertEqual(PrevRel, rpc:call(Node, erlang, system_info, [otp_release])),
+            peer:stop(Peer)
+    end.
+
+%% -------------------------------------------------------------------
+%% SSH/Docker cases
+
+ssh() ->
+    [{doc, "Tests ssh (localhost) node support"}].
+
+ssh(Config) when is_list(Config) ->
+    %% figure out path to 'erl' locally ('erl' may not be in path via SSH)
+    case {os:find_executable("erl"), os:find_executable("ssh")} of
+        {false, _} ->
+            {skip, "erl not found"};
+        {ErlPath, SshPath} ->
+            Name = peer:random_name(?FUNCTION_NAME),
+            {ok, Peer, _Node} = peer:start_link(#{exec => {SshPath, ["localhost", ErlPath]},
+                connection => standard_io, name => Name,
+                args => ["-env", "BINDIR", os:getenv("BINDIR")], host => "localhost"}),
+            %% TODO: how to check it really goes over SSH?
+            %% ssh-ed node is not distributed
+            ?assertEqual(list_to_atom(Name ++ "@localhost"), peer:call(Peer, erlang, node, [])),
+            peer:stop(Peer)
+    end.
+
+docker() ->
+    [{doc, "Tests starting peer node in Docker container"}, {timetrap, {seconds, 60}}].
+
+build_release(Dir) ->
+    application:load(sasl), %% otherwise application:get_key will fail
+    %% build release (tarball)
+    RelFile = filename:join(Dir, "lambda.rel"),
+    Release = {release, {"lambda", "1.0.0"}, {erts, erlang:system_info(version)},
+        [{App, begin {ok, Vsn} = application:get_key(App, vsn), Vsn end} || App <- [kernel, stdlib, sasl]]},
+    ok = file:write_file(RelFile, list_to_binary(lists:flatten(io_lib:format("~tp.", [Release])))),
+    RelFileNoExt = filename:join(Dir, "lambda"),
+    {ok, systools_make, []} = systools:make_script(RelFileNoExt, [silent, {outdir, Dir}]),
+    ok = systools:make_tar(RelFileNoExt, [{erts, code:root_dir()}]).
+
+build_image(Dir) ->
+    %% build docker image
+    BuildScript = filename:join(Dir, "Dockerfile"),
+    Dockerfile =
+        "FROM ubuntu:20.04 as runner\n"
+        "WORKDIR /opt/lambda\n"
+        "COPY lambda.tar.gz /tmp\n"
+        "RUN tar -zxvf /tmp/lambda.tar.gz -C /opt/lambda\n"
+        "ENTRYPOINT [\"/opt/lambda/erts-" ++ erlang:system_info(version) ++ "/bin/dyn_erl\", \"-boot\", \"/opt/lambda/releases/1.0.0/start\"]\n",
+    ok = file:write_file(BuildScript, Dockerfile),
+    Output = os:cmd("docker build -t lambda " ++ Dir),
+    ct:pal("Build result: ~s~n", [Output]).
+
+docker(Config) when is_list(Config) ->
+    case os:find_executable("docker") of
+        false ->
+            {skip, "Docker not found"};
+        Docker ->
+            PrivDir = proplists:get_value(priv_dir, Config),
+            build_release(PrivDir),
+            build_image(PrivDir),
+
+            {ok, Peer, Node} = peer:start_link(#{name => ?CT_PEER_NAME(),
+                exec => {Docker, ["run", "-i", "lambda"]}, connection => standard_io}),
+            ?assertEqual(Node, peer:call(Peer, erlang, node, [])),
+            peer:stop(Peer)
+    end.

--- a/lib/tools/test/make_SUITE.erl
+++ b/lib/tools/test/make_SUITE.erl
@@ -58,16 +58,6 @@ end_per_group(_GroupName, Config) ->
 init_per_testcase(_,Config) ->
     Config.
 
-end_per_testcase(netload,_Config) ->
-    %% Stop slave - in case of failure
-    Nodes = nodes(),
-    case [N || N <- Nodes,
-               "make_SUITE_netload" == hd(string:lexemes(atom_to_list(N),"@"))] of
-        [Node] ->
-            ct_slave:stop(Node);
-        _ ->
-            ok
-    end;
 end_per_testcase(_,_Config) ->
     ok.
 
@@ -114,12 +104,12 @@ netload(Config) ->
     code:purge(test1),
     code:delete(test1),
     false = code:is_loaded(test1),
-    {ok,Node} = ct_slave:start(make_SUITE_netload),
+    {ok,Peer,Node} = ?CT_PEER(),
     up_to_date = make:files([test1], [netload]),
     timer:sleep(1000), % async, so give some time
     {file,F} = code:is_loaded(test1),
     {file,F} = rpc:call(Node,code,is_loaded,[test1]),
-    ct_slave:stop(Node),
+    peer:stop(Peer),
     file:set_cwd(Current),
     ensure_no_messages(),
     ok.

--- a/system/doc/general_info/DEPRECATIONS
+++ b/system/doc/general_info/DEPRECATIONS
@@ -18,6 +18,11 @@
 #
 
 #
+# Added in OTP 25.
+#
+slave:_/_ since=25 remove=27
+
+#
 # Added in OTP 24.
 #
 


### PR DESCRIPTION
New 'peer' module is designed to replace multiple implementations present in the codebase, mostly in tests. The changeset implements 'peer' with related documentation, replaces usage in test suites, removes 'loose_node' implementing a similar concept, and then marks all functions of old 'slave' as deprecated.