### PR TITLE
Make re copy small subbinaries 

### DIFF
--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -1292,7 +1292,7 @@ re_run(Process *p, Eterm arg1, Eterm arg2, Eterm arg3)
     }
 
     /*  Optimized - if already in binary off heap, keep that and avoid
-       copying, also binary returns can be sub binaries in that case */
+        copying, also binary returns can be sub binaries in that case. */
 
     restart.flags = 0;
     if (is_binary(arg1)) {
@@ -1307,7 +1307,10 @@ re_run(Process *p, Eterm arg1, Eterm arg2, Eterm arg3)
 
 	slength = binary_size(arg1);
 	bptr = binary_val(real_bin);
-	if (bitsize != 0 || bitoffs != 0 ||  (*bptr != HEADER_PROC_BIN)) {
+	if (bitsize != 0 || bitoffs != 0 || slength <= ERL_ONHEAP_BIN_LIMIT) {
+            /* If this is an unaligned subbinary,
+               or the binary is smaller than the ERL_ONHEAP_BIN_LIMIT
+               we make a copy of the binary. */
 	    goto handle_iolist;
 	}
 	pb = (ProcBin *) bptr;


### PR DESCRIPTION
Because small subbinaries can be converted to heapbinaries
during GC, we do not want to have references to those in the
re state, so we copy any binary that is small enough to fit
on the heap.

Closes #5150