### PR TITLE
ssh: Handle eacces like enoent in ssh_sftpd:get_attrs/6

### DIFF
--- a/lib/ssh/src/ssh_sftpd.erl
+++ b/lib/ssh/src/ssh_sftpd.erl
@@ -564,7 +564,10 @@ get_attrs(RelPath, [F | Rest], FileMod, FS0, Vsn, Acc) ->
 	     end,
 	    Attrs = ssh_sftp:info_to_attr(Info),
 	    get_attrs(RelPath, Rest, FileMod, FS1, Vsn, [{Name, Attrs} | Acc]);
-	{{error, enoent}, FS1} ->
+	{{error, Msg}, FS1} when 
+              Msg == enoent ;   % The item has disappeared after reading the list of items to check
+              Msg == eacces ->  % You are not allowed to read this
+            %% Skip this F and check the remaining Rest
 	    get_attrs(RelPath, Rest, FileMod, FS1, Vsn, Acc);
 	{Error, FS1} ->
 	    {Error, FS1}


### PR DESCRIPTION
Fixes GH-5014

Handle {error, eacces} the same as {error, enoent} in ssh_sftpd:get_attrs/5 internal function.

This prevents an error while the sftpd answers a client for a request to return a directory contents but a file is deleted in that very directory after the replying is initiated, but before it is ended.