### PR TITLE
Fix ip_mreq spec to match implementation

### DIFF
--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -232,7 +232,7 @@
 
 -type ip_mreq() ::
         #{multiaddr := in_addr(),
-          address   := in_addr()}.
+          interface := in_addr()}.
 
 -type ip_mreq_source() ::
         #{multiaddr  := in_addr(),


### PR DESCRIPTION
This changes the `address` key to `interface` which matches what is
wanted for the `add_membership` option.