### PR TITLE
Correct extended error for binary_to_term/2

### DIFF
--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -2101,7 +2101,8 @@ BIF_RETTYPE binary_to_term_2(BIF_ALIST_2)
     return binary_to_term_int(BIF_P, BIF_ARG_1, &ctx);
 
 error:
-    BIF_ERROR(BIF_P, BADARG);
+    BIF_P->fvalue = am_badopt;
+    BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
 }
 
 Eterm

--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -680,7 +680,7 @@ do_error_3(Reason, Args, Options) ->
 
 error_info(_Config) ->
     DeadProcess = dead_process(),
-    NewAtom = non_existing_atom(),
+    {NewAtom,NewAtomExt} = non_existing_atom(),
     Eons = 1 bsl 50,
 
     %% We'll need an incorrect memory type for erlang:memory/1. We want to test an
@@ -767,9 +767,14 @@ error_info(_Config) ->
          {binary_to_list, [<<1,2,3>>, 4, 5]},
 
          {binary_to_term, [abc]},
-         {binary_to_term, [<<"abc">>]},
+         {binary_to_term, [<<"bad">>]},
+
          {binary_to_term, [term_to_binary(a), abc]},
          {binary_to_term, [<<"bad">>, abc]},
+         {binary_to_term, [<<"bad">>, [bad]]},
+         {binary_to_term, [<<"bad">>, []]},
+         {binary_to_term, [<<"bad">>, [safe]]},
+         {binary_to_term, [NewAtomExt, [safe]]},
 
          {bit_size, [abc]},
          {bitstring_to_list, [abc]},
@@ -1322,7 +1327,9 @@ non_existing_atom(Atom) ->
             non_existing_atom([Char|Atom])
     catch
         error:badarg ->
-            Atom
+            AtomBin = list_to_binary(Atom),
+            AtomExt = <<131,100,(byte_size(AtomBin)):16,AtomBin/binary>>,
+            {Atom,AtomExt}
     end.
 
 do_error_info(L0) ->


### PR DESCRIPTION
When `binary_to_term/2` failed with a `badarg` exception, the extended error
information would always blame the second argument even if the error was
in the first argument:

    1> binary_to_term(<<"">>, []).
    ** exception error: bad argument
         in function  binary_to_term/2
            called as binary_to_term(<<>>,[])
            *** argument 2: invalid option in list
    2> binary_to_term(<<131,100,0,10,97,95,110,101,119,95,97,116,111,109>>, [safe]).
    ** exception error: bad argument
         in function  binary_to_term/2
            called as binary_to_term(<<131,100,0,10,97,95,110,101,119,95,97,116,111,109>>,
                                     [safe])
            *** argument 2: invalid option in list

Correct the extended error information like this:

    1> binary_to_term(<<"">>, []).
    ** exception error: bad argument
         in function  binary_to_term/2
            called as binary_to_term(<<>>,[])
            *** argument 1: invalid external representation of a term
    2> binary_to_term(<<131,100,0,10,97,95,110,101,119,95,97,116,111,109>>, [safe]).
    ** exception error: bad argument
         in function  binary_to_term/2
            called as binary_to_term(<<131,100,0,10,97,95,110,101,119,95,97,116,111,109>>,
                                     [safe])
            *** argument 1: invalid or unsafe external representation of a term

Closes #5171.