### PR TITLE
eunit: Include a stacktrace when a test times out

### DIFF
--- a/lib/eunit/src/eunit_lib.erl
+++ b/lib/eunit/src/eunit_lib.erl
@@ -36,7 +36,7 @@
 	 command/2, command/3, trie_new/0, trie_store/2, trie_match/2,
 	 split_node/1, consult_file/1, list_dir/1, format_exit_term/1,
 	 format_exception/1, format_exception/2, format_error/1, format_error/2,
-         is_not_test/1]).
+         format_stacktrace/1, is_not_test/1]).
 
 -define(DEFAULT_DEPTH, 20).
 

--- a/lib/eunit/src/eunit_surefire.erl
+++ b/lib/eunit/src/eunit_surefire.erl
@@ -395,6 +395,10 @@ format_testcase_result({skipped, {abort, Error}}) when is_tuple(Error) ->
     [?INDENT, ?INDENT, <<"<skipped type=\"">>, escape_attr(atom_to_list(element(1, Error))), <<"\">">>, ?NEWLINE,
     escape_text(eunit_lib:format_error(Error)),
     ?INDENT, ?INDENT, <<"</skipped>">>, ?NEWLINE];
+format_testcase_result({skipped, {timeout, #{stacktrace := Stack}}}) ->
+    [?INDENT, ?INDENT, <<"<skipped type=\"timeout\">">>, ?NEWLINE,
+    escape_text(eunit_lib:format_stacktrace(Stack)),
+    ?INDENT, ?INDENT, <<"</skipped>">>, ?NEWLINE];
 format_testcase_result({skipped, {Type, Term}}) when is_atom(Type) ->
     [?INDENT, ?INDENT, <<"<skipped type=\"">>, escape_attr(atom_to_list(Type)), <<"\">">>, ?NEWLINE,
     escape_text(io_lib:write(Term)),

--- a/lib/eunit/src/eunit_tty.erl
+++ b/lib/eunit/src/eunit_tty.erl
@@ -253,6 +253,9 @@ format_cancel(undefined, _) ->
     "*skipped*\n";
 format_cancel(timeout, _) ->
     "*timed out*\n";
+format_cancel({timeout, #{stacktrace := Stack}}, _) ->
+    ["*timed out*\n",
+     eunit_lib:format_stacktrace(Stack)];
 format_cancel({startup, Reason}, Depth) ->
     io_lib:fwrite("*could not start test process*\n::~tP\n\n",
 		  [Reason, Depth]);

--- a/lib/eunit/test/Makefile
+++ b/lib/eunit/test/Makefile
@@ -24,7 +24,8 @@ MODULES =  \
 	eunit_SUITE \
 	tc0 \
 	tlatin \
-	tutf8
+	tutf8 \
+	ttimesout
 
 ERL_FILES= $(MODULES:%=%.erl)
 

--- a/lib/eunit/test/eunit_SUITE.erl
+++ b/lib/eunit/test/eunit_SUITE.erl
@@ -22,7 +22,8 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
 	 app_test/1,appup_test/1,eunit_test/1,surefire_utf8_test/1,surefire_latin_test/1,
-	 surefire_c0_test/1, surefire_ensure_dir_test/1]).
+	 surefire_c0_test/1, surefire_ensure_dir_test/1,
+	 stacktrace_at_timeout_test/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -30,7 +31,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
     [app_test, appup_test, eunit_test, surefire_utf8_test, surefire_latin_test,
-     surefire_c0_test, surefire_ensure_dir_test].
+     surefire_c0_test, surefire_ensure_dir_test, stacktrace_at_timeout_test].
 
 groups() ->
     [].
@@ -80,6 +81,16 @@ surefire_ensure_dir_test(Config) when is_list(Config) ->
     XMLDir = filename:join(proplists:get_value(priv_dir, Config), "c1"),
     ok = eunit:test(tc0, [{report,{eunit_surefire,[{dir,XMLDir}]}}]),
     ok = file:del_dir_r(XMLDir).
+
+stacktrace_at_timeout_test(Config) when is_list(Config) ->
+    Chars = check_surefire(ttimesout),
+    case string:find(Chars, "in call from") of
+        nomatch ->
+            ct:pal("Surefire XML:~n~ts", [Chars]),
+            ct:fail(missing_stacktrace_in_surefire);
+        _ ->
+            ok
+    end.
 
 check_surefire(Module) ->
 	File = "TEST-"++atom_to_list(Module)++".xml",

--- a/lib/eunit/test/ttimesout.erl
+++ b/lib/eunit/test/ttimesout.erl
@@ -1,0 +1,6 @@
+-module(ttimesout).
+
+-include_lib("eunit/include/eunit.hrl").
+
+times_out_test_() ->
+    {timeout, 1, fun() -> timer:sleep(20_000) end}.


### PR DESCRIPTION
In an eunit test, when a test case times out, include a stacktrace. This can be useful when debugging.

In the event of a test timeout, the printout now looks like this:

```
  1> eunit:test(tl, [verbose]).
  eunit:test(tl, [verbose]).
  ======================== EUnit ========================
  tl: takes_too_long_test (module 'tl')...*timed out*
  in function timer:sleep/1 (timer.erl, line 152)
  in call from tl:takes_too_long_test/0 (/.../tl.erl, line 6)
  in call from eunit_test:'-mf_wrapper/2-fun-0-'/2 (eunit_test.erl, line 273)
  in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
  in call from eunit_proc:run_test/1 (/.../eunit_proc.erl, line 528)
  in call from eunit_proc:with_timeout/3 (/.../eunit_proc.erl, line 353)
  in call from eunit_proc:handle_test/2 (/.../eunit_proc.erl, line 511)
  in call from eunit_proc:tests_inorder/3 (/.../eunit_proc.erl, line 453)
  undefined
  =======================================================
    Failed: 0.  Skipped: 0.  Passed: 0.
  One or more tests were cancelled.
  error
```

Previously, it looked like below. The problem was if the test was more than a few lines long, it could be difficult to know what line was causing the delay.

```
  1> eunit:test(tl, [verbose]).
  eunit:test(tl, [verbose]).
  ======================== EUnit ========================
  tl: takes_too_long_test (module 'tl')...*timed out*
  undefined
  =======================================================
    Failed: 0.  Skipped: 0.  Passed: 0.
  One or more tests were cancelled.
  error
```

For an `eunit_listener`, the `handle_cancel/3` will now be called with `{timeout, #{stacktrace => Stacktrace}}` as 2nd argument,in case of a timeout. Previously it was only the atom `timeout`.

In the `eunit_surefire` handler, include the stacktrace in the xml,as well.

I have tested this with the [eunit_formatters](https://github.com/seancribbs/eunit_formatters) library which is used by rebar3, and it seems to work, albeit the stacktrace is printed as a term, instead of as in the example above.