### PR TITLE
Further optimize off-heap traversal during minor GC

### DIFF
--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -1358,6 +1358,21 @@ erts_new_bs_put_string(ERL_BITS_PROTO_2(byte* iptr, Uint num_bytes))
     erts_bin_offset += num_bytes*8;
 }
 
+static ERTS_INLINE
+void increase_proc_bin_sz(Process* p, ProcBin* pb, Uint new_size)
+{
+    if (new_size > pb->size) {
+        if (ErtsInArea(pb, OLD_HEAP(p), ((OLD_HTOP(p) - OLD_HEAP(p))
+                                         * sizeof(Eterm)))) {
+            BIN_OLD_VHEAP(p) += (new_size / sizeof(Eterm) -
+                                 pb->size / sizeof(Eterm));
+        }
+        pb->size = new_size;
+    }
+    else
+        ASSERT(new_size == pb->size);
+}
+
 Eterm
 erts_bs_append(Process* c_p, Eterm* reg, Uint live, Eterm build_size_term,
 	    Uint extra_words, Uint unit)
@@ -1445,7 +1460,8 @@ erts_bs_append(Process* c_p, Eterm* reg, Uint live, Eterm build_size_term,
     used_size_in_bits = erts_bin_offset + build_size_in_bits;
 
     sb->is_writable = 0;	/* Make sure that no one else can write. */
-    pb->size = NBYTES(used_size_in_bits);
+
+    increase_proc_bin_sz(c_p, pb, NBYTES(used_size_in_bits));
     pb->flags |= PB_ACTIVE_WRITER;
 
     /*
@@ -1553,8 +1569,8 @@ erts_bs_append(Process* c_p, Eterm* reg, Uint live, Eterm build_size_term,
 	hp += PROC_BIN_SIZE;
 	pb->thing_word = HEADER_PROC_BIN;
 	pb->size = used_size_in_bytes;
-	pb->next = MSO(c_p).first;
-	MSO(c_p).first = (struct erl_off_heap_header*)pb;
+	pb->next = c_p->wrt_bins;
+        c_p->wrt_bins = (struct erl_off_heap_header*)pb;
 	pb->val = bptr;
 	pb->bytes = (byte*) bptr->orig_bytes;
 	pb->flags = PB_IS_WRITABLE | PB_ACTIVE_WRITER;
@@ -1635,7 +1651,7 @@ erts_bs_private_append(Process* p, Eterm bin, Eterm build_size_term, Uint unit)
     }
 
     pos_in_bits_after_build = erts_bin_offset + build_size_in_bits;
-    pb->size = (pos_in_bits_after_build+7) >> 3;
+    increase_proc_bin_sz(p, pb, (pos_in_bits_after_build+7) >> 3);
 
     /*
      * Reallocate the binary if it is too small.
@@ -1661,16 +1677,31 @@ erts_bs_private_append(Process* p, Eterm bin, Eterm build_size_term, Uint unit)
 	     * on. That means that a trace process now has (or have
 	     * had) a reference to the binary, so we are not allowed
 	     * to reallocate the binary. Instead, we must allocate a new
-	     * binary and copy the contents of the old binary into it.
+             * binary and copy the contents of the old binary into it.
+             *
+             * Also make a new ProcBin as the old one may have been moved
+             * from the 'wrt_bins' list to the regular 'off_heap' list by
+             * the GC. To move it back would mean traversing the off_heap list
+             * from the start. So instead create a new ProcBin for this
+             * (hopefully) rare case.
 	     */
 	    Binary* bptr = erts_bin_nrml_alloc(new_size);
-	    sys_memcpy(bptr->orig_bytes, binp->orig_bytes, binp->orig_size);
-	    pb->val = bptr;
-	    pb->bytes = (byte *) bptr->orig_bytes;
-            erts_bin_release(binp);
+            ProcBin* new_pb;
+
+            sys_memcpy(bptr->orig_bytes, binp->orig_bytes, binp->orig_size);
+
+            new_pb = (ProcBin*) HeapFragOnlyAlloc(p, PROC_BIN_SIZE);
+            new_pb->thing_word = HEADER_PROC_BIN;
+            new_pb->size = pb->size;
+            new_pb->val = bptr;
+            new_pb->bytes = (byte *) bptr->orig_bytes;
+            new_pb->next = p->wrt_bins;
+            p->wrt_bins = (struct erl_off_heap_header*) new_pb;
+            sb->orig = make_binary(new_pb);
+            pb = new_pb;
 	}
     }
-    pb->flags |= PB_IS_WRITABLE | PB_ACTIVE_WRITER;
+    pb->flags = PB_IS_WRITABLE | PB_ACTIVE_WRITER;
 
     erts_current_bin = pb->bytes;
 
@@ -1717,8 +1748,8 @@ erts_bs_init_writable(Process* p, Eterm sz)
     hp += PROC_BIN_SIZE;
     pb->thing_word = HEADER_PROC_BIN;
     pb->size = 0;
-    pb->next = MSO(p).first;
-    MSO(p).first = (struct erl_off_heap_header*) pb;
+    pb->next = p->wrt_bins;
+    p->wrt_bins = (struct erl_off_heap_header*) pb;
     pb->val = bptr;
     pb->bytes = (byte*) bptr->orig_bytes;
     pb->flags = PB_IS_WRITABLE | PB_ACTIVE_WRITER;

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -1636,7 +1636,6 @@ erts_bs_private_append(Process* p, Eterm bin, Eterm build_size_term, Uint unit)
 
     pos_in_bits_after_build = erts_bin_offset + build_size_in_bits;
     pb->size = (pos_in_bits_after_build+7) >> 3;
-    pb->flags |= PB_ACTIVE_WRITER;
 
     /*
      * Reallocate the binary if it is too small.
@@ -1666,12 +1665,13 @@ erts_bs_private_append(Process* p, Eterm bin, Eterm build_size_term, Uint unit)
 	     */
 	    Binary* bptr = erts_bin_nrml_alloc(new_size);
 	    sys_memcpy(bptr->orig_bytes, binp->orig_bytes, binp->orig_size);
-	    pb->flags |= PB_IS_WRITABLE | PB_ACTIVE_WRITER;
 	    pb->val = bptr;
 	    pb->bytes = (byte *) bptr->orig_bytes;
             erts_bin_release(binp);
 	}
     }
+    pb->flags |= PB_IS_WRITABLE | PB_ACTIVE_WRITER;
+
     erts_current_bin = pb->bytes;
 
     sb->size = pos_in_bits_after_build >> 3;

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -161,11 +161,11 @@ erts_resize_message_buffer(ErlHeapFragment *bp, Uint size,
 
 
 void
-erts_cleanup_offheap(ErlOffHeap *offheap)
+erts_cleanup_offheap_list(struct erl_off_heap_header* first)
 {
     union erl_off_heap_ptr u;
 
-    for (u.hdr = offheap->first; u.hdr; u.hdr = u.hdr->next) {
+    for (u.hdr = first; u.hdr; u.hdr = u.hdr->next) {
 	switch (thing_subtag(u.hdr->thing_word)) {
 	case REFC_BINARY_SUBTAG:
             erts_bin_release(u.pb->val);
@@ -186,6 +186,13 @@ erts_cleanup_offheap(ErlOffHeap *offheap)
 	}
     }
 }
+
+void
+erts_cleanup_offheap(ErlOffHeap *offheap)
+{
+    erts_cleanup_offheap_list(offheap->first);
+}
+
 
 void
 free_message_buffer(ErlHeapFragment* bp)

--- a/erts/emulator/beam/erl_message.h
+++ b/erts/emulator/beam/erl_message.h
@@ -485,6 +485,7 @@ void erts_link_mbuf_to_proc(Process *proc, ErlHeapFragment *bp);
 
 Uint erts_msg_attached_data_size_aux(ErtsMessage *msg);
 
+void erts_cleanup_offheap_list(struct erl_off_heap_header* first);
 void erts_cleanup_offheap(ErlOffHeap *offheap);
 void erts_save_message_in_proc(Process *p, ErtsMessage *msg);
 Sint erts_move_messages_off_heap(Process *c_p);

--- a/erts/emulator/beam/erl_nfunc_sched.h
+++ b/erts/emulator/beam/erl_nfunc_sched.h
@@ -248,6 +248,8 @@ erts_flush_dirty_shadow_proc(Process *sproc)
     }
 
     c_p->off_heap.overhead += sproc->off_heap.overhead;
+
+    ASSERT(sproc->wrt_bins == NULL);
 }
 
 ERTS_GLB_INLINE void
@@ -272,6 +274,7 @@ erts_cache_dirty_shadow_proc(Process *sproc)
     sproc->mbuf = NULL;
     sproc->mbuf_sz = 0;
     ERTS_INIT_OFF_HEAP(&sproc->off_heap);
+    sproc->wrt_bins = NULL;
 }
 
 ERTS_GLB_INLINE Process *

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -643,6 +643,7 @@ void enif_clear_env(ErlNifEnv* env)
     menv->env.hp = menv->env.hp_end = HEAP_TOP(p);
     
     ASSERT(!is_offheap(&MSO(p)));
+    ASSERT(!p->wrt_bins);
 }
 
 #ifdef DEBUG
@@ -5042,6 +5043,9 @@ Eterm erts_nif_call_function(Process *p, Process *tracee,
         ErlHeapFragment *orig_hf = MBUF(p);
         ErlOffHeap orig_oh = MSO(p);
         Eterm *orig_htop = HEAP_TOP(p);
+#ifdef DEBUG
+        struct erl_off_heap_header* orig_wrt_bins = p->wrt_bins;
+#endif
         ASSERT(is_internal_pid(p->common.id));
         MBUF(p) = NULL;
         clear_offheap(&MSO(p));
@@ -5067,6 +5071,7 @@ Eterm erts_nif_call_function(Process *p, Process *tracee,
         MBUF(p) = orig_hf;
         MSO(p) = orig_oh;
         HEAP_TOP(p) = orig_htop;
+        ASSERT(p->wrt_bins == orig_wrt_bins);
     } else {
         /* Nif call was done without a process context,
            so we create a phony one. */

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1101,6 +1101,7 @@ struct process {
     Uint16 gen_gcs;		/* Number of (minor) generational GCs. */
     Uint16 max_gen_gcs;		/* Max minor gen GCs before fullsweep. */
     ErlOffHeap off_heap;	/* Off-heap data updated by copy_struct(). */
+    struct erl_off_heap_header* wrt_bins; /* Writable binaries */
     ErlHeapFragment* mbuf;	/* Pointer to heap fragment list */
     ErlHeapFragment* live_hf_end;
     ErtsMessage *msg_frag;	/* Pointer to message fragment list */


### PR DESCRIPTION
Only traverse first part of off-heap list that reside on the new-heap, except for writable binaries that are now kept in a separate list.

Fixes #4424.
    
Earlier during minor GC, traversing the off-heap list was continued to the end over terms residing on the old-heap. This for two reasons:
1. The BIN_OLD_VHEAP value was calculated by adding the sizes of all `ProcBin`'s on the old-heap.
2. All writable binaries are handled by shrinking (reallocating) binaries that have not been written to since last GC. Even binaries residing on the old-heap.

To optimize and only traverse the first part the off-heap list that reside on the new-heap, we now
1. maintain a correct value of BIN_OLD_VHEAP so it does not have to be recalculated during GC.
2. keep all writable binaries in a separate list `Process.wrt_bins` that is traversed to the end during every GC.

The aim of this PR has been to maintain the overall GC semantics and especially not alter the value of BIN_OLD_VHEAP or how binaries have been reallocated at the end of a GC.