### PR TITLE
Keep supervisor children linked during shutdown

### DIFF
--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -72,6 +72,7 @@ MODULES= \
 	supervisor_1 \
 	supervisor_2 \
 	supervisor_3 \
+	supervisor_4 \
 	supervisor_deadlock \
 	naughty_child \
 	shell_SUITE \

--- a/lib/stdlib/test/supervisor_4.erl
+++ b/lib/stdlib/test/supervisor_4.erl
@@ -1,0 +1,49 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2016. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% Description: Simulates the behaviour that a child process may have.
+%% Is used by the supervisor_SUITE test suite.
+-module(supervisor_4).
+
+-export([start_child/0, start_child/1, init/1]).
+
+-export([handle_call/3, handle_info/2, terminate/2]).
+
+start_child() ->
+    gen_server:start_link(?MODULE, undefined, []).
+
+start_child(Reason) ->
+    gen_server:start_link(?MODULE, {Reason}, []).
+
+init(Reason) ->
+    process_flag(trap_exit, true),
+    {ok, Reason}.
+
+handle_call(Req, _From, State) ->
+    {reply, Req, State}.
+
+handle_info(stop, State) ->
+    {stop, normal, State};
+handle_info(_, State) ->
+    {noreply, State}.
+
+terminate(_, {Reason}) ->
+    exit(Reason);
+terminate(_, _) ->
+    ok.


### PR DESCRIPTION
This PR was prompted by [this thread on the Erlang Questions ML](http://erlang.org/pipermail/erlang-questions/2021-September/101433.html), concerning unexpected `noproc` exit reasons due to a race condition when a supervisor child self-terminates and is at the same time terminated via `supervisor:terminate_child/2`. In the course of the discussion, it was discovered that [there exists a condition](http://erlang.org/pipermail/erlang-questions/2021-September/101441.html) where a child could become orphaned when its supervisor dies at a critical moment.

In a nutshell, in the current implementation, the procedure of shutting down a child is as follows:
1) set a monitor on the child
2) unlink the child
3) try to flush out a possible `'EXIT'` message in case the child just died by itself
4) send a shutdown exit signal to the child and wait for a `'DOWN'` message
6) send a kill signal to the child if it does not shut down in time and wait for the `'DOWN'` message

However, if the supervisor dies between (2) and (4), the child will be left running, unaware even that it has become an orphan.

This PR changes the procedure as follows:
1) set a monitor on the child
2) send a shutdown exit signal to the child and wait for a `'DOWN'` message, then unlink it and flush out the possible `'EXIT'` message
3) send a kill signal to the child if it does not shut down in time and wait for the `'DOWN'` message, then unlink it and flush out the possible `'EXIT'` message

This way, the child remains linked to the supervisor until it is definitely dead.
Flushing out the `'EXIT'` messages implicitly serves as a way to retrieve the child's exit reason (the `'DOWN'` message might reach the child only after it has died earlier, ie too late, resulting in the `noproc` that prompted the initial post on the aforementioned thread). This is a best-effort approach (which comes for free), if the child unlinked itself from the supervisor ("naughty child"), there will be not `'EXIT'` message.

Additionally, this PR handles some exit reasons as normal (ie, not logging them as errors) which would be reported by the current implementation simply because the child exited at the wrong moment.