### PR TITLE
shell_docs: Fix signature rendering

### DIFF
--- a/lib/stdlib/test/shell_docs_SUITE.erl
+++ b/lib/stdlib/test/shell_docs_SUITE.erl
@@ -118,29 +118,34 @@ render_smoke(_Config) ->
               lists:foreach(
                 fun(Config) ->
                         try
-                            shell_docs:render(Mod, D, Config),
-                            shell_docs:render_type(Mod, D, Config),
-                            shell_docs:render_callback(Mod, D, Config),
+                            E = fun({error,_}) ->
+                                        ok;
+                                   (Doc) ->
+                                        unicode:characters_to_binary(Doc)
+                                end,
+                            E(shell_docs:render(Mod, D, Config)),
+                            E(shell_docs:render_type(Mod, D, Config)),
+                            E(shell_docs:render_callback(Mod, D, Config)),
                             Exports = try Mod:module_info(exports)
                                       catch _:undef -> []
                                       end, %% nif file not available on this platform
 
                             [try
-                                 shell_docs:render(Mod, F, A, D, Config)
+                                 E(shell_docs:render(Mod, F, A, D, Config))
                              catch _E:R:ST ->
                                      io:format("Failed to render ~p:~p/~p~n~p:~p~n~p~n",
                                                [Mod,F,A,R,ST,shell_docs:get_doc(Mod,F,A)]),
                                      erlang:raise(error,R,ST)
                              end || {F,A} <- Exports],
                             [try
-                                 shell_docs:render_type(Mod, T, A, D, Config)
+                                 E(shell_docs:render_type(Mod, T, A, D, Config))
                              catch _E:R:ST ->
                                      io:format("Failed to render type ~p:~p/~p~n~p:~p~n~p~n",
                                                [Mod,T,A,R,ST,shell_docs:get_type_doc(Mod,T,A)]),
                                      erlang:raise(error,R,ST)
                              end || {{type,T,A},_,_,_,_} <- Docs],
                             [try
-                                 shell_docs:render_callback(Mod, T, A, D, Config)
+                                 E(shell_docs:render_callback(Mod, T, A, D, Config))
                              catch _E:R:ST ->
                                      io:format("Failed to render callback ~p:~p/~p~n~p:~p~n~p~n",
                                                [Mod,T,A,R,ST,shell_docs:get_callback_doc(Mod,T,A)]),
@@ -155,8 +160,8 @@ render_smoke(_Config) ->
                       #{ ansi => true },
                       #{ columns => 5 },
                       #{ columns => 150 },
-                      #{ encoding => unicode},
-                      #{ encoding => latin1}])
+                      #{ encoding => unicode },
+                      #{ encoding => latin1 }])
       end),
     ok.
 


### PR DESCRIPTION
Prior to this change the rendered signature looks like this:

```
1> h(certifi, cacertfile).

\240\240cacertfile()

  CACertFile gives the path to the file with an X.509 certificate list containing the Mozilla CA
  ...
```

With this fix, i.e. by using an ordinary space for padding instead of a non-breaking space, the signature is rendered as expected:

```
1> h(certifi, cacertfile).

  cacertfile()

  CACertFile gives the path to the file with an X.509 certificate list containing the Mozilla CA
  ...
```

My env is iterm2 Build 3.4.9beta1 on macOS Catalina 10.15.7 (19H1323) running Erlang master (85530f5fb3), but the problem appeared at least since 24.0 RC1 (see https://github.com/erlef/build-and-packaging-wg/issues/25). I'm not sure if the NBSP handling behaviour is the same in other environments.