### PR TITLE
ETS optimizations: Configurable and automatically adjustable number of locks for set, bag, and duplicate_bag

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -734,3 +734,4 @@ atom x86
 atom yes
 atom yield
 atom nifs
+atom auto

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -735,3 +735,4 @@ atom yes
 atom yield
 atom nifs
 atom auto
+atom debug_hash_fixed_number_of_locks

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -2313,16 +2313,21 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
                         term_to_Sint(tp[2], &no_locks_param) &&
                         no_locks_param >= 1 &&
                         no_locks_param <= 32768) {
+                        is_decentralized_counters = 1;
                         is_fine_locked = 1;
                         is_explicit_lock_granularity = 1;
                         is_write_concurrency_auto = 0;
                         no_locks = no_locks_param;
                     } else if (tp[2] == am_auto) {
+                        is_decentralized_counters = 1;
                         is_write_concurrency_auto = 1;
                         is_fine_locked = 1;
                         is_explicit_lock_granularity = 0;
                         no_locks = -1;
                     } else if (tp[2] == am_true) {
+                        if (!(status & DB_ORDERED_SET)) {
+                            is_decentralized_counters = 0;
+                        }
                         is_fine_locked = 1;
                         is_explicit_lock_granularity = 0;
                         is_write_concurrency_auto = 0;

--- a/erts/emulator/beam/erl_db_hash.c
+++ b/erts/emulator/beam/erl_db_hash.c
@@ -307,7 +307,7 @@ void erl_db_hash_adapt_number_of_locks(DbTable* tb) {
     db_hash_lock_array_resize_state current_state;
     DbTableHash* tbl;
     int new_number_of_locks;
-    if(!(tb->common.type & DB_FINE_LOCKED_AUTO)) {
+    if(!IS_HASH_WITH_AUTO_TABLE(tb->common.type)) {
         return;
     }
     current_state = erts_atomic_read_nob(&tb->hash.lock_array_resize_state);

--- a/erts/emulator/beam/erl_db_hash.c
+++ b/erts/emulator/beam/erl_db_hash.c
@@ -395,12 +395,15 @@ void erl_db_hash_adapt_no_locks(DbTable* tb) {
             ERTS_ASSERT(total_new == total_old);
         }
 #endif
-        erts_db_free(ERTS_ALC_T_DB_SEG, tb, old_locks, sizeof(DbTableHashFineLockSlot) * old_no_locks);
 
         calc_shrink_limit(tbl);
 
         erts_atomic_set_nob(&tbl->lock_array_resize_state, DB_HASH_LOCK_ARRAY_RESIZE_STATUS_NORMAL);
         erts_rwmtx_rwunlock(&tb->common.rwlock);
+        for (i = 0; i < old_no_locks; i++) {
+            erts_rwmtx_destroy(&old_locks[i].u.lck_ctr.lck);
+        }
+        erts_db_free(ERTS_ALC_T_DB_SEG, tb, old_locks, sizeof(DbTableHashFineLockSlot) * old_no_locks);
     }
 }
 

--- a/erts/emulator/beam/erl_db_hash.h
+++ b/erts/emulator/beam/erl_db_hash.h
@@ -55,6 +55,7 @@ typedef struct hash_db_term {
 
 typedef struct DbTableHashLockAndCounter {
     Sint nitems;
+    Sint lck_stat;
     erts_rwmtx_t lck;
 } DbTableHashLockAndCounter;
 
@@ -67,7 +68,7 @@ typedef struct db_table_hash_fine_lock_slot {
 
 typedef struct db_table_hash {
     DbTableCommon common;
-
+    erts_atomic_t lock_array_resize_state;
     /* szm, nactive, shrink_limit are write-protected by is_resizing or table write lock */
     erts_atomic_t szm;     /* current size mask. */
     erts_atomic_t nactive; /* Number of "active" slots */
@@ -87,6 +88,14 @@ typedef struct db_table_hash {
     DbTableHashFineLockSlot* locks;
 } DbTableHash;
 
+typedef enum {
+    DB_HASH_LOCK_ARRAY_RESIZE_STATUS_NORMAL = 0,
+    DB_HASH_LOCK_ARRAY_RESIZE_STATUS_GROW   = 1,
+    DB_HASH_LOCK_ARRAY_RESIZE_STATUS_SHRINK = 2
+} db_hash_lock_array_resize_state;
+
+/* To adapt number of locks if hash table with {write_concurrency, auto} */
+void erl_db_hash_adapt_no_locks(DbTable* tb);
 
 /*
 ** Function prototypes, looks the same (except the suffix) for all 

--- a/erts/emulator/beam/erl_db_hash.h
+++ b/erts/emulator/beam/erl_db_hash.h
@@ -95,7 +95,7 @@ typedef enum {
 } db_hash_lock_array_resize_state;
 
 /* To adapt number of locks if hash table with {write_concurrency, auto} */
-void erl_db_hash_adapt_no_locks(DbTable* tb);
+void erl_db_hash_adapt_number_of_locks(DbTable* tb);
 
 /*
 ** Function prototypes, looks the same (except the suffix) for all 

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -345,6 +345,7 @@ typedef struct db_table_common {
 #define DB_FREQ_READ      (1 << 10) /* read_concurrency */
 #define DB_NAMED_TABLE    (1 << 11)
 #define DB_BUSY           (1 << 12)
+#define DB_EXPLICIT_LOCK_GRANULARITY  (1 << 13)
 
 #define DB_CATREE_FORCE_SPLIT (1 << 31)  /* erts_debug */
 #define DB_CATREE_DEBUG_RANDOM_SPLIT_JOIN (1 << 30)  /* erts_debug */

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -346,6 +346,7 @@ typedef struct db_table_common {
 #define DB_NAMED_TABLE    (1 << 11)
 #define DB_BUSY           (1 << 12)
 #define DB_EXPLICIT_LOCK_GRANULARITY  (1 << 13)
+#define DB_FINE_LOCKED_AUTO (1 << 14)
 
 #define DB_CATREE_FORCE_SPLIT (1 << 31)  /* erts_debug */
 #define DB_CATREE_DEBUG_RANDOM_SPLIT_JOIN (1 << 30)  /* erts_debug */

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -351,8 +351,11 @@ typedef struct db_table_common {
 #define DB_CATREE_FORCE_SPLIT (1 << 31)  /* erts_debug */
 #define DB_CATREE_DEBUG_RANDOM_SPLIT_JOIN (1 << 30)  /* erts_debug */
 
-#define IS_HASH_TABLE(Status) (!!((Status) & \
-				  (DB_BAG | DB_SET | DB_DUPLICATE_BAG)))
+#define IS_HASH_TABLE(Status) (!!((Status) &                       \
+                                  (DB_BAG | DB_SET | DB_DUPLICATE_BAG)))
+#define IS_HASH_WITH_AUTO_TABLE(Status) \
+    (((Status) &                                                        \
+      (DB_ORDERED_SET | DB_CA_ORDERED_SET | DB_FINE_LOCKED_AUTO)) == DB_FINE_LOCKED_AUTO)
 #define IS_TREE_TABLE(Status) (!!((Status) & \
 				  DB_ORDERED_SET))
 #define IS_CATREE_TABLE(Status) (!!((Status) & \

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -1306,14 +1306,9 @@ ets:select(Table, MatchSpec),</code>
               concurrent read bursts and large concurrent
               write bursts are common; for more information, see option
               <seeerl marker="#new_2_read_concurrency">
-              <c>read_concurrency</c></seeerl>. The
-              <c>decentralized_counters</c> option is turned on by
-              default for tables of type <c>ordered_set</c> with any
-              of the <c>write_concurrency</c> options expcept
-              <c>false</c> enabled, and the
-              <c>decentralized_counters</c> option is turned
-              <em>off</em> by default for all other table types.  For
-              more information, see the documentation for the
+              <c>read_concurrency</c></seeerl>. It is almost always a
+              good idea to combine the <c>write_concurrency</c> option
+              with the
               <seeerl marker="#new_2_decentralized_counters">
               <c>decentralized_counters</c></seeerl> option.</p>
             <p>Notice that this option does not change any guarantees about
@@ -1366,12 +1361,15 @@ ets:select(Table, MatchSpec),</code>
           <tag><c>{decentralized_counters,boolean()}</c></tag>
           <item>
             <p>
-              Performance tuning. Defaults to <c>true</c> for tables
-              of type <c>ordered_set</c> with the
-              <seeerl marker="#new_2_write_concurrency">
-              <c>write_concurrency</c></seeerl> option enabled, and defaults to
-	      false for all other   table types. This option has no effect if
-	      the <c>write_concurrency</c> option is set to <c>false</c>.</p>
+              Performance tuning. Defaults to <c>true</c> for all
+              tables with the <c>write_concurrency</c> option set
+              to something else than <c>true</c> or <c>false</c>. For
+              tables of type <c>ordered_set</c> the option also
+              defaults to true when the <c>write_concurrency</c> option
+              is set to <c>true</c>. The option defaults to
+              <c>false</c> for all other configurations. This option
+              has no effect if the <c>write_concurrency</c> option is
+              set to <c>false</c>.</p>
 	    <p>
 	      When this option is set to <c>true</c>, the table is optimized for
 	      frequent concurrent calls to operations that modify the tables

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -656,9 +656,9 @@ Error: fun containing local Erlang function calls
             <p>Indicates whether the table uses <c>read_concurrency</c> or
               not.</p>
           </item>
-          <tag><c>{write_concurrency, boolean()}</c></tag>
+          <tag><c>{write_concurrency, WriteConcurrencyAlternative}</c></tag>
           <item>
-            <p>Indicates whether the table uses <c>write_concurrency</c>.</p>
+            <p>Indicates which <c>write_concurrency</c> option the table uses.</p>
           </item>
         </taglist>
 	<note><p>The execution time of this function is affected by
@@ -1258,7 +1258,7 @@ ets:select(Table, MatchSpec),</code>
               when the owner terminates.</p>
             <marker id="new_2_write_concurrency"></marker>
           </item>
-          <tag><c>{write_concurrency,boolean()}</c></tag>
+          <tag><c>{write_concurrency,WriteConcurrencyAlternative}</c></tag>
           <item>
             <p>Performance tuning. Defaults to <c>false</c>, in which case an
               operation that
@@ -1269,6 +1269,29 @@ ets:select(Table, MatchSpec),</code>
               (and read) by concurrent processes. This is achieved to some
               degree at the expense of memory consumption and the performance
               of sequential access and concurrent reading.</p>
+            <p>Users can explicitly control the synchronization
+            granularity for tables of types <c>set</c>, <c>bag</c>,
+            and <c>duplicate_bag</c> by setting the
+            <c>write_concurrency</c> option to an integer in the range
+            <c>[2, 32768]</c>. Currently, setting the
+            <c>write_concurrency</c> option to a number for
+            <c>ordered_set</c> tables has the same effect as setting
+            its value to true. Explicitly setting the synchronization
+            granularity is not recommended unless it is motivated and
+            possible to do experimentation to figure out which
+            synchronization granularity gives the best performance.
+            Currently, the number
+            automatically rounds down to the nearest power of two. A
+            high number for this setting should usually not be
+            combined with the <c>{read_concurrency, true}</c> setting
+            as this usally lead to worse performance and high memory
+            utilization. It is usually not a good idea to set this
+            setting to a number that is much greater than the number
+            of expected items in the table, as this can lead to slow
+            table traversals. The effect of this setting might change
+            in future versions of Erlang/OTP. If you are unsure what
+            number to set this setting to, it is probably best to use
+            {write_concurrency, true} instead.</p>
               <p>The <c>write_concurrency</c> option can be combined with the options
               <seeerl marker="#new_2_read_concurrency">
               <c>read_concurrency</c></seeerl> and
@@ -1281,7 +1304,7 @@ ets:select(Table, MatchSpec),</code>
               <c>read_concurrency</c></seeerl>. The <c>decentralized_counters</c>
               option is turned on by default for tables of type <c>ordered_set</c>
               with the <c>write_concurrency</c> option enabled, and the
-              <c>decentralized_counters</c> option is turned off by default for
+              <c>decentralized_counters</c> option is turned <em>off</em> by default for
               all other table types.
               For more information, see the documentation for the
               <seeerl marker="#new_2_decentralized_counters">

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -1269,29 +1269,34 @@ ets:select(Table, MatchSpec),</code>
               (and read) by concurrent processes. This is achieved to some
               degree at the expense of memory consumption and the performance
               of sequential access and concurrent reading.</p>
-            <p>Users can explicitly control the synchronization
+            <p>The <c>auto</c> alternative for the
+            <c>write_concurrency</c> option is similar to the
+            <c>true</c> option but automatically adjusts the
+            synchronization granularity at runtime depending on how the
+            table is used. This is the recommended
+            <c>write_concurrency</c> option when using Erlang/OTP 25
+            and above as it performs well in most scenarios.</p>
+            <p>Users can also explicitly set the synchronization
             granularity for tables of types <c>set</c>, <c>bag</c>,
             and <c>duplicate_bag</c> by setting the
             <c>write_concurrency</c> option to an integer in the range
-            <c>[2, 32768]</c>. Currently, setting the
-            <c>write_concurrency</c> option to a number for
-            <c>ordered_set</c> tables has the same effect as setting
-            its value to true. Explicitly setting the synchronization
-            granularity is not recommended unless it is motivated and
-            possible to do experimentation to figure out which
-            synchronization granularity gives the best performance.
-            Currently, the number
-            automatically rounds down to the nearest power of two. A
-            high number for this setting should usually not be
-            combined with the <c>{read_concurrency, true}</c> setting
-            as this usally lead to worse performance and high memory
-            utilization. It is usually not a good idea to set this
-            setting to a number that is much greater than the number
-            of expected items in the table, as this can lead to slow
-            table traversals. The effect of this setting might change
-            in future versions of Erlang/OTP. If you are unsure what
-            number to set this setting to, it is probably best to use
-            {write_concurrency, true} instead.</p>
+            <c>[2, 32768]</c>. Currently, the number automatically
+            rounds down to the nearest power of two. The likelihood of
+            conflicts between operations reduces with an increased
+            value. Explicitly setting the synchronization granularity
+            is not recommended unless it is possible to
+            do experimentation to figure out which synchronization
+            granularity gives the best performance. If you are unsure
+            what number to set this setting to, it is probably best to
+            use <c>{write_concurrency, auto}</c> instead. One should be
+            careful about combining the <c>{read_concurrency, true}</c>
+            setting with explicitly setting the synchronization
+            granularity as this can lead to worse performance and high
+            memory utilization. It is usually not a good idea to set
+            this setting to a number that is much greater than the
+            number of expected items in the table, as this can lead to
+            slow table traversals. The effect of this setting might
+            change in future versions of Erlang/OTP.</p>
               <p>The <c>write_concurrency</c> option can be combined with the options
               <seeerl marker="#new_2_read_concurrency">
               <c>read_concurrency</c></seeerl> and
@@ -1301,12 +1306,14 @@ ets:select(Table, MatchSpec),</code>
               concurrent read bursts and large concurrent
               write bursts are common; for more information, see option
               <seeerl marker="#new_2_read_concurrency">
-              <c>read_concurrency</c></seeerl>. The <c>decentralized_counters</c>
-              option is turned on by default for tables of type <c>ordered_set</c>
-              with the <c>write_concurrency</c> option enabled, and the
-              <c>decentralized_counters</c> option is turned <em>off</em> by default for
-              all other table types.
-              For more information, see the documentation for the
+              <c>read_concurrency</c></seeerl>. The
+              <c>decentralized_counters</c> option is turned on by
+              default for tables of type <c>ordered_set</c> with any
+              of the <c>write_concurrency</c> options expcept
+              <c>false</c> enabled, and the
+              <c>decentralized_counters</c> option is turned
+              <em>off</em> by default for all other table types.  For
+              more information, see the documentation for the
               <seeerl marker="#new_2_decentralized_counters">
               <c>decentralized_counters</c></seeerl> option.</p>
             <p>Notice that this option does not change any guarantees about
@@ -1314,13 +1321,17 @@ ets:select(Table, MatchSpec),</code>
               Functions that makes such promises over many objects (like
               <seemfa marker="#insert/2"><c>insert/2</c></seemfa>)
               gain less (or nothing) from this option.</p>
-            <p>The memory consumption inflicted by both <c>write_concurrency</c>
-	      and <c>read_concurrency</c> is a constant overhead per table for
-	      <c>set</c>, <c>bag</c> and <c>duplicate_bag</c>. For
-	      <c>ordered_set</c> the memory overhead depends on the number
-	      of inserted objects and the amount of actual detected
-	      concurrency in runtime. The memory overhead can be especially
-	      large when both options are combined.</p>
+            <p>The memory consumption inflicted by both
+            <c>write_concurrency</c> and <c>read_concurrency</c> is a
+            constant overhead per table for <c>set</c>, <c>bag</c> and
+            <c>duplicate_bag</c> when the <c>auto</c> alternative for
+            the <c>write_concurrency</c> option is not used. For
+            <c>ordered_set</c> as well as <c>set</c>, <c>bag</c> and
+            <c>duplicate_bag</c> with the <c>auto</c> alternative the
+            memory overhead depends on the number of inserted objects
+            and the amount of actual detected concurrency during
+            runtime. The memory overhead can be especially large when
+            both options are combined.</p>
 	    <note>
               <p>Prior to stdlib-3.7 (OTP-22.0) <c>write_concurrency</c> had no
 	      effect on <c>ordered_set</c>.</p>

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -1264,7 +1264,7 @@ ets:select(Table, MatchSpec),</code>
               operation that
               mutates (writes to) the table obtains exclusive access,
               blocking any concurrent access of the same table until finished.
-              If set to <c>true</c>, the table is optimized to concurrent
+              If set to <c>true</c>, the table is optimized for concurrent
               write access. Different objects of the same table can be mutated
               (and read) by concurrent processes. This is achieved to some
               degree at the expense of memory consumption and the performance
@@ -1272,31 +1272,10 @@ ets:select(Table, MatchSpec),</code>
             <p>The <c>auto</c> alternative for the
             <c>write_concurrency</c> option is similar to the
             <c>true</c> option but automatically adjusts the
-            synchronization granularity at runtime depending on how the
+            synchronization granularity during runtime depending on how the
             table is used. This is the recommended
             <c>write_concurrency</c> option when using Erlang/OTP 25
             and above as it performs well in most scenarios.</p>
-            <p>Users can also explicitly set the synchronization
-            granularity for tables of types <c>set</c>, <c>bag</c>,
-            and <c>duplicate_bag</c> by setting the
-            <c>write_concurrency</c> option to an integer in the range
-            <c>[2, 32768]</c>. Currently, the number automatically
-            rounds down to the nearest power of two. The likelihood of
-            conflicts between operations reduces with an increased
-            value. Explicitly setting the synchronization granularity
-            is not recommended unless it is possible to
-            do experimentation to figure out which synchronization
-            granularity gives the best performance. If you are unsure
-            what number to set this setting to, it is probably best to
-            use <c>{write_concurrency, auto}</c> instead. One should be
-            careful about combining the <c>{read_concurrency, true}</c>
-            setting with explicitly setting the synchronization
-            granularity as this can lead to worse performance and high
-            memory utilization. It is usually not a good idea to set
-            this setting to a number that is much greater than the
-            number of expected items in the table, as this can lead to
-            slow table traversals. The effect of this setting might
-            change in future versions of Erlang/OTP.</p>
               <p>The <c>write_concurrency</c> option can be combined with the options
               <seeerl marker="#new_2_read_concurrency">
               <c>read_concurrency</c></seeerl> and
@@ -1319,17 +1298,20 @@ ets:select(Table, MatchSpec),</code>
             <p>The memory consumption inflicted by both
             <c>write_concurrency</c> and <c>read_concurrency</c> is a
             constant overhead per table for <c>set</c>, <c>bag</c> and
-            <c>duplicate_bag</c> when the <c>auto</c> alternative for
+            <c>duplicate_bag</c> when the <c>true</c> alternative for
             the <c>write_concurrency</c> option is not used. For
-            <c>ordered_set</c> as well as <c>set</c>, <c>bag</c> and
-            <c>duplicate_bag</c> with the <c>auto</c> alternative the
-            memory overhead depends on the number of inserted objects
-            and the amount of actual detected concurrency during
+            all tables with the <c>auto</c> alternative and <c>ordered_set</c>
+            tables with <c>true</c> alternative the
+            memory overhead depends on the amount of actual detected concurrency during
             runtime. The memory overhead can be especially large when
-            both options are combined.</p>
+            both <c>write_concurrency</c> and <c>read_concurrency</c> are combined.</p>
 	    <note>
               <p>Prior to stdlib-3.7 (OTP-22.0) <c>write_concurrency</c> had no
 	      effect on <c>ordered_set</c>.</p>
+            </note>
+            <note>
+              <p>The <c>auto</c> alternative for the <c>write_concurrency</c>
+              option is only available in OTP-25.0 and above.</p>
             </note>
             <marker id="new_2_read_concurrency"></marker>
           </item>
@@ -1363,7 +1345,7 @@ ets:select(Table, MatchSpec),</code>
             <p>
               Performance tuning. Defaults to <c>true</c> for all
               tables with the <c>write_concurrency</c> option set
-              to something else than <c>true</c> or <c>false</c>. For
+              to <c>auto</c>. For
               tables of type <c>ordered_set</c> the option also
               defaults to true when the <c>write_concurrency</c> option
               is set to <c>true</c>. The option defaults to

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -309,7 +309,7 @@ member(_, _) ->
               | {heir, Pid :: pid(), HeirData} | {heir, none} | Tweaks,
       Type :: type(),
       Access :: access(),
-      WriteConcurrencyAlternative :: boolean() | auto | 2..32768,
+      WriteConcurrencyAlternative :: boolean() | auto,
       Tweaks :: {write_concurrency, WriteConcurrencyAlternative}
               | {read_concurrency, boolean()}
               | {decentralized_counters, boolean()}

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -309,7 +309,8 @@ member(_, _) ->
               | {heir, Pid :: pid(), HeirData} | {heir, none} | Tweaks,
       Type :: type(),
       Access :: access(),
-      Tweaks :: {write_concurrency, boolean()}
+      WriteConcurrencyAlternative :: boolean() | 2..32768,
+      Tweaks :: {write_concurrency, WriteConcurrencyAlternative}
               | {read_concurrency, boolean()}
               | {decentralized_counters, boolean()}
               | compressed,

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -309,7 +309,7 @@ member(_, _) ->
               | {heir, Pid :: pid(), HeirData} | {heir, none} | Tweaks,
       Type :: type(),
       Access :: access(),
-      WriteConcurrencyAlternative :: boolean() | 2..32768,
+      WriteConcurrencyAlternative :: boolean() | auto | 2..32768,
       Tweaks :: {write_concurrency, WriteConcurrencyAlternative}
               | {read_concurrency, boolean()}
               | {decentralized_counters, boolean()}

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -7427,9 +7427,15 @@ whereis_table(Config) when is_list(Config) ->
     Tid = ets:whereis(whereis_test),
 
     ets:insert(whereis_test, [{hello}, {there}]),
-
-    [[{hello}],[{there}]] = ets:match(whereis_test, '$1'),
-    [[{hello}],[{there}]] = ets:match(Tid, '$1'),
+    CheckMatch =
+        fun(MatchRes) ->
+                case MatchRes of
+                    [[{there}],[{hello}]] -> ok;
+                    [[{hello}],[{there}]] -> ok
+                end
+        end,
+    CheckMatch(ets:match(whereis_test, '$1')),
+    CheckMatch(ets:match(Tid, '$1')),
 
     true = ets:delete_all_objects(Tid),
 

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -5238,8 +5238,13 @@ do_test_decentralized_counters_setting(TableType) ->
               check_decentralized_counters(T1, false, FlxCtrMemUsage),
               ets:delete(T1)
       end,
-      [[{write_concurrency, false}],
-       [{write_concurrency, true}, {decentralized_counters, false}]]),
+      [[{write_concurrency, false}]] ++
+          case TableType of
+              set ->
+                  [[{write_concurrency, true}, {decentralized_counters, false}],
+                   [{write_concurrency, 1024}, {write_concurrency, true}]];
+              ordered_set -> []
+          end),
     lists:foreach(
       fun(OptList) ->
               T1 = ets:new(t1, [public,
@@ -5250,7 +5255,9 @@ do_test_decentralized_counters_setting(TableType) ->
               wait_for_memory_deallocations(),
               FlxCtrMemUsage = erts_debug:get_internal_state(flxctr_memory_usage)
       end,
-      [[{decentralized_counters, true}]]),
+      [[{decentralized_counters, true}],
+       [{write_concurrency, 1024}],
+       [{write_concurrency, auto}]]),
     ok.
 
 do_test_decentralized_counters_default_setting() ->

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -8136,12 +8136,15 @@ long_throughput_benchmark(Config) when is_list(Config) ->
               ]
              ],
          table_types =
-             [
-              [ordered_set, public, {write_concurrency, true}, {read_concurrency, true}],
-              [set, public, {write_concurrency, true}, {read_concurrency, true}],
-              [set, public, {write_concurrency, auto}, {read_concurrency, true}],
-              [set, public, {write_concurrency, {debug_hash_fixed_number_of_locks, 16384}}]
-             ],
+             ([
+               [ordered_set, public, {write_concurrency, true}, {read_concurrency, true}],
+               [set, public, {write_concurrency, true}, {read_concurrency, true}]
+              ] ++
+                  case catch list_to_integer(erlang:system_info(otp_release)) of
+                      Recent when is_integer(Recent), Recent >= 25 ->
+                          [[set, public, {write_concurrency, auto}, {read_concurrency, true}]];
+                      _Old -> []
+                  end),
          etsmem_fun = fun etsmem/0,
          verify_etsmem_fun = fun verify_etsmem/1,
          notify_res_fun =

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -588,7 +588,8 @@ t_repair_continuation_do(Opts) ->
     MS = [{'_',[],[true]}],
     MS2 = [{{{'$1','_'},'_'},[],['$1']}],
     (fun() ->
-	     T = ets_new(x,[ordered_set|Opts]),
+	     T = ets_new(x,
+                         replace_dbg_hash_fixed_nr_of_locks([ordered_set|Opts])),
 	     F = fun(0,_)->ok;(N,F) -> ets:insert(T,{N,N}), F(N-1,F) end,
 	     F(1000,F),
 	     {_,C} = ets:select(T,MS,5),
@@ -600,7 +601,8 @@ t_repair_continuation_do(Opts) ->
 	     true = ets:delete(T)
      end)(),
     (fun() ->
-	     T = ets_new(x,[ordered_set|Opts]),
+	     T = ets_new(x,
+                         replace_dbg_hash_fixed_nr_of_locks([ordered_set|Opts])),
 	     F = fun(0,_)->ok;(N,F) -> ets:insert(T,{N,N}), F(N-1,F) end,
 	     F(1000,F),
 	     {_,C} = ets:select(T,MS,1001),
@@ -612,7 +614,8 @@ t_repair_continuation_do(Opts) ->
      end)(),
 
     (fun() ->
-	     T = ets_new(x,[ordered_set|Opts]),
+	     T = ets_new(x,
+                         replace_dbg_hash_fixed_nr_of_locks([ordered_set|Opts])),
 	     F = fun(0,_)->ok;(N,F) ->
 			 ets:insert(T,{integer_to_list(N),N}),
 			 F(N-1,F)
@@ -627,7 +630,8 @@ t_repair_continuation_do(Opts) ->
 	     true = ets:delete(T)
      end)(),
     (fun() ->
-	     T = ets_new(x,[ordered_set|Opts]),
+	     T = ets_new(x,
+                         replace_dbg_hash_fixed_nr_of_locks([ordered_set|Opts])),
 	     F = fun(0,_)->ok;(N,F) ->
 			 ets:insert(T,{{integer_to_list(N),N},N}),
 			 F(N-1,F)
@@ -890,7 +894,8 @@ whitebox_1(Opts) ->
     ok.
 
 whitebox_2(Opts) ->
-    T=ets_new(x,[ordered_set, {keypos,2} | Opts]),
+    T=ets_new(x,
+              replace_dbg_hash_fixed_nr_of_locks([ordered_set, {keypos,2} | Opts])),
     T2=ets_new(x,[set, {keypos,2}| Opts]),
     0 = ets:select_delete(T,[{{hej},[],[true]}]),
     0 = ets:select_delete(T,[{{hej,hopp},[],[true]}]),
@@ -1063,7 +1068,8 @@ t_delete_object_do(Opts) ->
     3999 = ets:info(T,size),
     0 = get_kept_objects(T),
     ets:delete(T),
-    T1 = ets_new(x,[ordered_set | Opts]),
+    T1 = ets_new(x,
+                 replace_dbg_hash_fixed_nr_of_locks([ordered_set | Opts])),
     filltabint(T1,4000),
     del_one_by_one_set(T1,1,4001),
     filltabint(T1,4000),
@@ -2247,7 +2253,8 @@ update_element_opts(Opts) ->
 
 update_element_opts(Tuple,KeyPos,UpdPos,Opts) ->
     Set = ets_new(set,[{keypos,KeyPos} | Opts]),
-    OrdSet = ets_new(ordered_set,[ordered_set,{keypos,KeyPos} | Opts]),
+    OrdSet = ets_new(ordered_set,
+                     replace_dbg_hash_fixed_nr_of_locks([ordered_set,{keypos,KeyPos} | Opts])),
     update_element(Set,Tuple,KeyPos,UpdPos),
     update_element(OrdSet,Tuple,KeyPos,UpdPos),
     true = ets:delete(Set),
@@ -2336,7 +2343,8 @@ update_tuple([], Tpl) ->
 
 update_element_neg(Opts) ->
     Set = ets_new(set,Opts),
-    OrdSet = ets_new(ordered_set,[ordered_set | Opts]),
+    OrdSet = ets_new(ordered_set,
+                     replace_dbg_hash_fixed_nr_of_locks([ordered_set | Opts])),
     update_element_neg_do(Set),
     update_element_neg_do(OrdSet),
     ets:delete(Set),
@@ -2393,7 +2401,8 @@ update_counter(Config) when is_list(Config) ->
 
 update_counter_do(Opts) ->
     Set = ets_new(set,Opts),
-    OrdSet = ets_new(ordered_set,[ordered_set | Opts]),
+    OrdSet = ets_new(ordered_set,
+                     replace_dbg_hash_fixed_nr_of_locks([ordered_set | Opts])),
     update_counter_for(Set),
     update_counter_for(OrdSet),
     ets:delete_all_objects(Set),
@@ -2553,7 +2562,8 @@ uc_adder(Init, {_Pos, Add, Thres, Warp}) ->
 
 update_counter_neg(Opts) ->
     Set = ets_new(set,Opts),
-    OrdSet = ets_new(ordered_set,[ordered_set | Opts]),
+    OrdSet = ets_new(ordered_set,
+                     replace_dbg_hash_fixed_nr_of_locks([ordered_set | Opts])),
     update_counter_neg_for(Set),
     update_counter_neg_for(OrdSet),
     ets:delete(Set),
@@ -2684,7 +2694,7 @@ update_counter_with_default_do(Opts) ->
     2 = ets:info(T1, size),
 
     %% Same with ordered set.
-    T2 = ets_new(b, [ordered_set | Opts]),
+    T2 = ets_new(b, replace_dbg_hash_fixed_nr_of_locks([ordered_set | Opts])),
     3 = ets:update_counter(T2, foo, 2, {maroilles,1}),
     1 = ets:info(T2, size),
     5 = ets:update_counter(T2, foo, 2, {mimolette,1}),
@@ -2740,7 +2750,8 @@ update_counter_table_growth(_Config) ->
 update_counter_table_growth_do(Opts) ->
     Set = ets_new(b, [set | Opts]),
     [ets:update_counter(Set, N, {2, 1}, {N, 1}) || N <- lists:seq(1,10000)],
-    OrderedSet = ets_new(b, [ordered_set | Opts]),
+    OrderedSet =
+        ets_new(b, replace_dbg_hash_fixed_nr_of_locks([ordered_set | Opts])),
     [ets:update_counter(OrderedSet, N, {2, 1}, {N, 1}) || N <- lists:seq(1,10000)],
     ok.
 
@@ -3511,7 +3522,8 @@ interface_equality(Config) when is_list(Config) ->
 interface_equality_do(Opts) ->
     EtsMem = etsmem(),
     Set = ets_new(set,[set | Opts]),
-    OrderedSet = ets_new(ordered_set,[ordered_set | Opts]),
+    OrderedSet = ets_new(ordered_set,
+                         replace_dbg_hash_fixed_nr_of_locks([ordered_set | Opts])),
     F = fun(X,T,FF) -> case X of
                            0 -> true;
                            _ ->
@@ -3570,7 +3582,7 @@ maybe_sort(Any) ->
 
 %% Test match, match_object and match_delete in ordered set's.
 ordered_match(Config) when is_list(Config)->
-    repeat_for_opts(fun ordered_match_do/1).
+    repeat_for_opts_extra_opt(fun ordered_match_do/1, ordered_set).
 
 ordered_match_do(Opts) ->
     EtsMem = etsmem(),
@@ -3616,7 +3628,7 @@ ordered_match_do(Opts) ->
 
 %% Test basic functionality in ordered_set's.
 ordered(Config) when is_list(Config) ->
-    repeat_for_opts(fun ordered_do/1).
+    repeat_for_opts_extra_opt(fun ordered_do/1, ordered_set).
 
 ordered_do(Opts) ->
     EtsMem = etsmem(),
@@ -4053,8 +4065,16 @@ delete_large_tab(Config) when is_list(Config) ->
 
 delete_large_tab_do(Config, Opts,Data) ->
     delete_large_tab_1(Config, foo_hash, Opts, Data, false),
-    delete_large_tab_1(Config, foo_tree, [ordered_set | Opts], Data, false),
-    delete_large_tab_1(Config, foo_tree, [stim_cat_ord_set | Opts], Data, false),
+    delete_large_tab_1(Config,
+                       foo_tree,
+                       replace_dbg_hash_fixed_nr_of_locks([ordered_set | Opts]),
+                       Data,
+                       false),
+    delete_large_tab_1(Config,
+                       foo_tree,
+                       replace_dbg_hash_fixed_nr_of_locks([stim_cat_ord_set | Opts]),
+                       Data,
+                       false),
     delete_large_tab_1(Config, foo_hash_fix, Opts, Data, true).
 
 
@@ -4143,8 +4163,14 @@ delete_large_named_table(Config) when is_list(Config) ->
 
 delete_large_named_table_do(Opts,Data) ->
     delete_large_named_table_1(foo_hash, [named_table | Opts], Data, false),
-    delete_large_named_table_1(foo_tree, [ordered_set,named_table | Opts], Data, false),
-    delete_large_named_table_1(foo_tree, [stim_cat_ord_set,named_table | Opts], Data, false),
+    delete_large_named_table_1(foo_tree,
+                               replace_dbg_hash_fixed_nr_of_locks([ordered_set,named_table | Opts]),
+                               Data,
+                               false),
+    delete_large_named_table_1(foo_tree,
+                               replace_dbg_hash_fixed_nr_of_locks([stim_cat_ord_set,named_table | Opts]),
+                               Data,
+                               false),
     delete_large_named_table_1(foo_hash, [named_table | Opts], Data, true).
 
 delete_large_named_table_1(Name, Flags, Data, Fix) ->
@@ -4889,22 +4915,44 @@ info(Config) when is_list(Config) ->
     {'EXIT',{badarg,_}} = (catch ets:info(make_ref())),
     {'EXIT',{badarg,_}} = (catch ets:info(make_ref(), type)),
 
-    %% Test that one can set the synchronization granularity level for
-    %% tables of type set
-    T1 = ets:new(t1, [public, {write_concurrency, 1024}]),
-    1024 = ets:info(T1, write_concurrency),
-    T2 = ets:new(t2, [public, {write_concurrency, 2048}]),
-    2048 = ets:info(T2, write_concurrency),
-    T3 = ets:new(t3, [public, {write_concurrency, 1024}, {write_concurrency, true}]),
-    true = ets:info(T3, write_concurrency),
-    T4 = ets:new(t4, [private, {write_concurrency, 1024}]),
-    false = ets:info(T4, write_concurrency),
-    T5 = ets:new(t5, [public, {write_concurrency, auto}]),
-    auto = ets:info(T5, write_concurrency),
-    T6 = ets:new(t6, [private, {write_concurrency, true}]),
-    false = ets:info(T6, write_concurrency),
-    T7 = ets:new(t7, [private, {write_concurrency, auto}]),
-    false = ets:info(T7, write_concurrency),
+    case erlang:system_info(schedulers) of
+        1 -> %% Fine grained locking is not activated when there is only one scheduler
+            lists:foreach(
+              fun(Type) ->
+                      T1 = ets:new(t1, [public, Type, {write_concurrency, auto}]),
+                      false = ets:info(T1, write_concurrency),
+                      T2 = ets:new(t2, [public, Type, {write_concurrency, true}]),
+                      false = ets:info(T2, write_concurrency)
+              end,
+              [set, bag, duplicate_bag, ordered_set]),
+            T2 = ets:new(t2, [public, {write_concurrency, {debug_hash_fixed_number_of_locks, 2049}}]),
+            false = ets:info(T2, write_concurrency);
+        _ ->
+            %% Test that one can set the synchronization granularity level for
+            %% tables of type set
+            T1 = ets:new(t1, [public, {write_concurrency, {debug_hash_fixed_number_of_locks, 1024}}]),
+            {debug_hash_fixed_number_of_locks, 1024} = ets:info(T1, write_concurrency),
+            T2 = ets:new(t2, [public, {write_concurrency, {debug_hash_fixed_number_of_locks, 2048}}]),
+            {debug_hash_fixed_number_of_locks, 2048} = ets:info(T2, write_concurrency),
+            T3 = ets:new(t3, [public, {write_concurrency, {debug_hash_fixed_number_of_locks, 1024}}, {write_concurrency, true}]),
+            true = ets:info(T3, write_concurrency),
+            T4 = ets:new(t4, [private, {write_concurrency, {debug_hash_fixed_number_of_locks, 1024}}]),
+            false = ets:info(T4, write_concurrency),
+            %% Test the auto option
+            lists:foreach(
+              fun(Type) ->
+                      T5 = ets:new(t5, [public, Type, {write_concurrency, auto}]),
+                      auto = ets:info(T5, write_concurrency)
+              end,
+              [set, bag, duplicate_bag, ordered_set]),
+            T6 = ets:new(t6, [private, {write_concurrency, true}]),
+            false = ets:info(T6, write_concurrency),
+            T7 = ets:new(t7, [private, {write_concurrency, auto}]),
+            false = ets:info(T7, write_concurrency),
+            %% Test that the number of locks is rounded down to the nearest power of two
+            T8 = ets:new(t8, [public, {write_concurrency, {debug_hash_fixed_number_of_locks, 2049}}]),
+            {debug_hash_fixed_number_of_locks, 2048} = ets:info(T8, write_concurrency)
+    end,
     ok.
 
 info_do(Opts) ->
@@ -5131,18 +5179,26 @@ test_table_size_concurrency(Config) when is_list(Config) ->
     case erlang:system_info(schedulers) of
         1 -> {skip,"Only valid on smp > 1 systems"};
         _ ->
-            BaseOptions = [public, {write_concurrency, true}],
-            test_table_counter_concurrency(size, [set | BaseOptions]),
-            test_table_counter_concurrency(size, [ordered_set | BaseOptions])
+            lists:foreach(
+              fun(WriteConcurrencyOpt) ->
+                      BaseOptions = [public, {write_concurrency, WriteConcurrencyOpt}],
+                      test_table_counter_concurrency(size, [set | BaseOptions]),
+                      test_table_counter_concurrency(size, [ordered_set | BaseOptions])
+              end,
+              [true, auto])
     end.
 
 test_table_memory_concurrency(Config) when is_list(Config) ->
     case erlang:system_info(schedulers) of
         1 -> {skip,"Only valid on smp > 1 systems"};
         _ ->
-            BaseOptions = [public, {write_concurrency, true}],
-            test_table_counter_concurrency(memory, [set | BaseOptions]),
-            test_table_counter_concurrency(memory, [ordered_set | BaseOptions])
+            lists:foreach(
+              fun(WriteConcurrencyOpt) ->
+                      BaseOptions = [public, {write_concurrency, WriteConcurrencyOpt}],
+                      test_table_counter_concurrency(memory, [set | BaseOptions]),
+                      test_table_counter_concurrency(memory, [ordered_set | BaseOptions])
+              end,
+              [true, auto])
     end.
 
 %% Tests that calling the ets:delete operation on a table T with
@@ -5232,9 +5288,18 @@ test_decentralized_counters_setting(Config) when is_list(Config) ->
 do_test_decentralized_counters_setting(TableType) ->
     wait_for_memory_deallocations(),
     FlxCtrMemUsage = erts_debug:get_internal_state(flxctr_memory_usage),
+    FixOptsList =
+        fun(Opts) ->
+                case TableType of
+                    ordered_set ->
+                        replace_dbg_hash_fixed_nr_of_locks(Opts);
+                    set ->
+                        Opts
+                end
+        end,
     lists:foreach(
       fun(OptList) ->
-              T1 = ets:new(t1, [public, TableType] ++ OptList ++ [TableType]),
+              T1 = ets:new(t1, FixOptsList([public, TableType] ++ OptList ++ [TableType])),
               check_decentralized_counters(T1, false, FlxCtrMemUsage),
               ets:delete(T1)
       end,
@@ -5242,21 +5307,22 @@ do_test_decentralized_counters_setting(TableType) ->
           case TableType of
               set ->
                   [[{write_concurrency, true}, {decentralized_counters, false}],
-                   [{write_concurrency, 1024}, {write_concurrency, true}]];
+                   [{write_concurrency, {debug_hash_fixed_number_of_locks, 1024}}, {write_concurrency, true}]];
               ordered_set -> []
           end),
     lists:foreach(
       fun(OptList) ->
-              T1 = ets:new(t1, [public,
-                                TableType,
-                                {write_concurrency, true}] ++ OptList ++ [TableType]),
+              T1 = ets:new(t1,
+                           FixOptsList([public,
+                                        TableType,
+                                        {write_concurrency, true}] ++ OptList ++ [TableType])),
               check_decentralized_counters(T1, true, FlxCtrMemUsage),
               ets:delete(T1),
               wait_for_memory_deallocations(),
               FlxCtrMemUsage = erts_debug:get_internal_state(flxctr_memory_usage)
       end,
       [[{decentralized_counters, true}],
-       [{write_concurrency, 1024}],
+       [{write_concurrency, {debug_hash_fixed_number_of_locks, 1024}}],
        [{write_concurrency, auto}]]),
     ok.
 
@@ -6049,7 +6115,8 @@ xfilltabstr(Tab,N) ->
 fill_sets_int(N) ->
     fill_sets_int(N,[]).
 fill_sets_int(N,Opts) ->
-    Tab1 = ets_new(xxx, [ordered_set|Opts]),
+    Tab1 = ets_new(xxx,
+                   replace_dbg_hash_fixed_nr_of_locks([ordered_set|Opts])),
     filltabint(Tab1,N),
     Tab2 = ets_new(xxx, [set|Opts]),
     filltabint(Tab2,N),
@@ -6060,7 +6127,8 @@ fill_sets_int(N,Opts) ->
     [Tab1,Tab2,Tab3,Tab4].
 
 fill_sets_intup(N,Opts) ->
-    Tab1 = ets_new(xxx, [ordered_set|Opts]),
+    Tab1 = ets_new(xxx,
+                   replace_dbg_hash_fixed_nr_of_locks([ordered_set|Opts])),
     filltabintup(Tab1,N),
     Tab2 = ets_new(xxx, [set|Opts]),
     filltabintup(Tab2,N),
@@ -7703,7 +7771,7 @@ prefill_insert_map_loop(T, RS0, N, ObjFun, InsertMap, NrOfSchedulers) ->
               [set, public, {read_concurrency, true}],
               [set, public, {write_concurrency, true}, {read_concurrency, true}],
               [set, public, {write_concurrency, auto}, {read_concurrency, true}],
-              [set, public, {write_concurrency, 16384}]
+              [set, public, {write_concurrency, {debug_hash_fixed_number_of_locks, 16384}}]
              ],
          etsmem_fun = fun() -> ok end,
          verify_etsmem_fun = fun(_) -> true end,
@@ -8072,7 +8140,7 @@ long_throughput_benchmark(Config) when is_list(Config) ->
               [ordered_set, public, {write_concurrency, true}, {read_concurrency, true}],
               [set, public, {write_concurrency, true}, {read_concurrency, true}],
               [set, public, {write_concurrency, auto}, {read_concurrency, true}],
-              [set, public, {write_concurrency, 16384}]
+              [set, public, {write_concurrency, {debug_hash_fixed_number_of_locks, 16384}}]
              ],
          etsmem_fun = fun etsmem/0,
          verify_etsmem_fun = fun verify_etsmem/1,
@@ -9241,8 +9309,30 @@ make_unaligned_sub_binary(Bin0) when is_binary(Bin0) ->
 make_unaligned_sub_binary(List) ->
     make_unaligned_sub_binary(list_to_binary(List)).
 
+replace_dbg_hash_fixed_nr_of_locks(Opts) ->
+    [case X of
+         {write_concurrency, {debug_hash_fixed_number_of_locks, _}} ->
+             {write_concurrency, true};
+         _ -> X
+     end || X <- Opts].
+
 %% Repeat test function with different combination of table options
-%%       
+%%
+repeat_for_opts_extra_opt(F, Extra) ->
+    repeat_for_opts(
+      fun(Opts) ->
+              WithExtra =
+                  case erlang:is_list(Extra) of
+                      true -> Extra ++ Opts;
+                      false ->[Extra | Opts]
+                  end,
+              case is_invalid_opts_combo(WithExtra) of
+                  true -> ok;
+                  false -> F(WithExtra)
+              end
+      end,
+      [write_concurrency, read_concurrency, compressed]).
+
 repeat_for_opts(F) ->
     repeat_for_opts(F, [write_concurrency, read_concurrency, compressed]).
 
@@ -9303,21 +9393,35 @@ repeat_for_opts_atom2list(all_non_stim_types) -> [set,ordered_set,cat_ord_set,ba
 repeat_for_opts_atom2list(all_non_stim_set_types) -> [set,ordered_set,cat_ord_set];
 repeat_for_opts_atom2list(write_concurrency) -> [{write_concurrency,false},
                                                  {write_concurrency,true},
-                                                 {write_concurrency,2},
-                                                 {write_concurrency,2048},
+                                                 {write_concurrency, {debug_hash_fixed_number_of_locks, 2048}},
                                                  {write_concurrency,auto}];
 repeat_for_opts_atom2list(read_concurrency) -> [{read_concurrency,false},{read_concurrency,true}];
 repeat_for_opts_atom2list(compressed) -> [void,compressed].
 
+is_invalid_opts_combo(Opts) ->
+    FixedNumLocksOption =
+        lists:any(
+          fun({write_concurrency, {debug_hash_fixed_number_of_locks, _}}) ->
+                  true;
+             (_) ->
+                  false
+          end,
+          Opts),
+    OrderedSet = lists:member(ordered_set, Opts) orelse
+                 lists:member(stim_cat_ord_set, Opts) orelse
+                 lists:member(cat_ord_set, Opts),
+    OrderedSet andalso FixedNumLocksOption.
+
 is_redundant_opts_combo(Opts) ->
-    ((lists:member(stim_cat_ord_set, Opts) orelse
-      lists:member(cat_ord_set, Opts))
-     andalso
-       (lists:member({write_concurrency, 2}, Opts) orelse
-        lists:member({write_concurrency, 2048}, Opts) orelse
-        lists:member({write_concurrency, false}, Opts) orelse
-        lists:member(private, Opts) orelse
-        lists:member(protected, Opts))).
+    IsRed1 =
+        ((lists:member(stim_cat_ord_set, Opts) orelse
+          lists:member(cat_ord_set, Opts))
+         andalso
+           (lists:member({write_concurrency, false}, Opts) orelse
+            lists:member(private, Opts) orelse
+            lists:member(protected, Opts))),
+    IsRed2 = is_invalid_opts_combo(Opts),
+    IsRed1 orelse IsRed2.
 
 %% Add fake table option with info about key range.
 %% Will be consumed by ets_new and used for stim_cat_ord_set.


### PR DESCRIPTION

Before the commits in this pull request, ETS tables of types set, bag and duplicate_bag used a fixed number of locks to protect the hash buckets from concurrent access. The number of locks was 64 by default but could be changed up to 256 by setting a special flag when compiling the Erlang run-time system. Unfortunately, this is not enough to provide good scalability on modern multi-core machines. This pull request introduces new ETS table options that let the user configure the number of locks used per table or configure a table to automatically adjust the number of locks based on the detected concurrency level.

* Commit 1 (f6e1cb0) Make it possible to set the number of locks used for an ETS table of type set, bag, or duplicate_bag by configuring the table with {write_concurrency, N}, where N is the number of locks.
* Commit 2 (cb21fa4) Add the ETS table configuration option {write_concurrency, auto} that causes the table to detect contention in its locks. The number of locks automatically grows and shrinks based on the detected contention.
* Commit 3 (f6e1cb0) Make {decentralized_counters, true} default for all table types when the setting {write_concurrency, auto} and {write_concurrency, N} is active. This makes sense since centralized counters quickly become a bottleneck on big server machines where the new options are most useful. We did not dare to make {decentralized_counters, true} for tables with {write_concurrency, true} before as decentralized counters can make existing applications that frequently call ets:info(T, size) and ets:info(T, memory) perform much worse, but it makes sense to make {decentralized_counters, true} default for the new options.

Benchmark results for the new table options on a machine with 64 hardware threads are available here:

https://winsh.me/bench/ets_config_locks/ets_bench_result_lock_config.html

* Click on the "Fill screen" buttons to make the graphs larger
* One can hide/show lines by clicking on their labels in the legend of the graphs
