### PR TITLE
dialyzer: Add options for missing/extra range warnings

### DIFF
--- a/lib/dialyzer/doc/src/dialyzer.xml
+++ b/lib/dialyzer/doc/src/dialyzer.xml
@@ -316,6 +316,16 @@ dialyzer --plts plt_1 ... plt_n -- files_to_analyze</code>
       <item>
         <p>Include warnings for functions that only return by an exception.</p>
       </item>
+      <tag><c>-Wextra_return</c> (***)</tag>
+      <item>
+        <p>Warn about functions that return values that are not part of the
+          specification.</p>
+      </item>
+      <tag><c>-Wmissing_return</c> (***)</tag>
+      <item>
+        <p>Warn about functions whose specification includes types that the
+          function cannot return.</p>
+      </item>
       <tag><c>-Wno_behaviours</c></tag>
       <item>
         <p>Suppress warnings about behavior callbacks that drift from the
@@ -426,6 +436,16 @@ dialyzer --plts plt_1 ... plt_n -- files_to_analyze</code>
         <p>Suppress warnings about underspecified functions (the
           specification is strictly more allowing than the success typing).
           </p>
+      </item>
+      <tag><c>-Wno_extra_return</c></tag>
+      <item>
+        <p>Suppress warnings about functions that return values that are not
+          part of the specification.</p>
+      </item>
+      <tag><c>-Wno_missing_return</c></tag>
+      <item>
+        <p>Suppress warnings about functions whose specification includes types
+          that the function cannot return.</p>
       </item>
     </taglist>
 

--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -46,7 +46,9 @@
 -define(WARN_CONTRACT_SYNTAX, warn_contract_syntax).
 -define(WARN_CONTRACT_NOT_EQUAL, warn_contract_not_equal).
 -define(WARN_CONTRACT_SUBTYPE, warn_contract_subtype).
+-define(WARN_CONTRACT_MISSING_RETURN, warn_contract_missing_return).
 -define(WARN_CONTRACT_SUPERTYPE, warn_contract_supertype).
+-define(WARN_CONTRACT_EXTRA_RETURN, warn_contract_extra_return).
 -define(WARN_CONTRACT_RANGE, warn_contract_range).
 -define(WARN_CALLGRAPH, warn_callgraph).
 -define(WARN_UNMATCHED_RETURN, warn_umatched_return).

--- a/lib/dialyzer/src/dialyzer_contracts.erl
+++ b/lib/dialyzer/src/dialyzer_contracts.erl
@@ -898,13 +898,13 @@ overlapping_contract_warning({M, F, A}, WarningInfo) ->
 extra_range_warning({M, F, A}, WarningInfo, ExtraRanges, STRange) ->
   ERangesStr = erl_types:t_to_string(ExtraRanges),
   STRangeStr = erl_types:t_to_string(STRange),
-  {?WARN_CONTRACT_SUPERTYPE, WarningInfo,
+  {?WARN_CONTRACT_EXTRA_RETURN, WarningInfo,
    {extra_range, [M, F, A, ERangesStr, STRangeStr]}}.
 
 missing_range_warning({M, F, A}, WarningInfo, ExtraRanges, CRange) ->
   ERangesStr = erl_types:t_to_string(ExtraRanges),
   CRangeStr = erl_types:t_to_string(CRange),
-  {?WARN_CONTRACT_SUBTYPE, WarningInfo,
+  {?WARN_CONTRACT_MISSING_RETURN, WarningInfo,
    {missing_range, [M, F, A, ERangesStr, CRangeStr]}}.
 
 picky_contract_check(CSig0, Sig0, MFA, WarningInfo, Contract, RecDict,

--- a/lib/dialyzer/src/dialyzer_options.erl
+++ b/lib/dialyzer/src/dialyzer_options.erl
@@ -338,20 +338,34 @@ build_warnings([Opt|Opts], Warnings) ->
       no_missing_calls ->
         ordsets:del_element(?WARN_CALLGRAPH, Warnings);
       specdiffs ->
-	S = ordsets:from_list([?WARN_CONTRACT_SUBTYPE, 
-			       ?WARN_CONTRACT_SUPERTYPE,
-			       ?WARN_CONTRACT_NOT_EQUAL]),
-	ordsets:union(S, Warnings);
+        S = ordsets:from_list([?WARN_CONTRACT_SUBTYPE, 
+                               ?WARN_CONTRACT_SUPERTYPE,
+                               ?WARN_CONTRACT_NOT_EQUAL,
+                               ?WARN_CONTRACT_MISSING_RETURN,
+                               ?WARN_CONTRACT_EXTRA_RETURN]),
+        ordsets:union(S, Warnings);
       overspecs ->
-	ordsets:add_element(?WARN_CONTRACT_SUBTYPE, Warnings);
+        S = ordsets:from_list([?WARN_CONTRACT_SUBTYPE,
+                               ?WARN_CONTRACT_MISSING_RETURN]),
+        ordsets:union(S, Warnings);
       underspecs ->
-	ordsets:add_element(?WARN_CONTRACT_SUPERTYPE, Warnings);
+        S = ordsets:from_list([?WARN_CONTRACT_SUPERTYPE,
+                               ?WARN_CONTRACT_EXTRA_RETURN]),
+        ordsets:union(S, Warnings);
       no_underspecs ->
-	ordsets:del_element(?WARN_CONTRACT_SUPERTYPE, Warnings);
+        ordsets:del_element(?WARN_CONTRACT_SUPERTYPE, Warnings);
+      extra_return ->
+        ordsets:add_element(?WARN_CONTRACT_EXTRA_RETURN, Warnings);
+      no_extra_return ->
+        ordsets:del_element(?WARN_CONTRACT_EXTRA_RETURN, Warnings);
+      missing_return ->
+        ordsets:add_element(?WARN_CONTRACT_MISSING_RETURN, Warnings);
+      no_missing_return ->
+        ordsets:del_element(?WARN_CONTRACT_MISSING_RETURN, Warnings);
       unknown ->
-	ordsets:add_element(?WARN_UNKNOWN, Warnings);
+        ordsets:add_element(?WARN_UNKNOWN, Warnings);
       OtherAtom ->
-	bad_option("Unknown dialyzer warning option", OtherAtom)
+        bad_option("Unknown dialyzer warning option", OtherAtom)
     end,
   build_warnings(Opts, NewWarnings);
 build_warnings([], Warnings) ->


### PR DESCRIPTION
These warnings are useful on their own, and I think they're worth breaking out from the more chatty `-Wunderspecs`/`-Woverspecs`.

```erlang
-module(t).
-export([t/1, q/1]).

-spec t(integer()) -> odd.
t(N) when N rem 2 =/= 0 ->
    odd;
t(_) ->
    even.

-spec q(integer()) -> positive | negative | zero.
q(N) when N > 0 ->
    positive;
q(N) when N < 0 ->
    negative.
```
```
# (The first message is an extra_range warning, the second is a missing_range warning.)
$ dialyzer t.erl -Wextra_range -Wmissing_range
  Checking whether the PLT /home/ejohogb/.dialyzer_plt is up-to-date... yes
  Proceeding with analysis...
t.erl:4:2: The success typing for t:t/1 implies that the function might also return 
          'even' but the specification return is 
          'odd'
t.erl:10:2: The specification for t:q/1 states that the function might also return 
          'zero' but the inferred return is 
          'negative' | 'positive'
 done in 0m0.59s
done (warnings were emitted)
```

I'm not a huge fan of the names for these options though, so suggestions are very welcome.