### PR TITLE
Enable possibility to skip reading CPU topology at startup

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -1511,6 +1511,16 @@ $ <input>erl \
               <seeerl marker="erlang#system_info_cpu_topology">
               <c>erlang:system_info(cpu_topology)</c></seeerl>.</p>
           </item>
+          <tag><marker id="+ssrct"/><c>+ssrct</c></tag>
+          <item>
+            <p>Skips reading CPU topology.</p>
+            <note>
+              <p>Reading CPU topology slows down startup when starting many
+                parallel instances of ERTS on systems with large amount of
+                cores, using this flag might speed up execution in such
+                scenarios.</p>
+            </note>
+          </item>
           <tag><marker id="+sfwi"/><c>+sfwi Interval</c></tag>
           <item>
             <p>Sets scheduler-forced wakeup interval. All run queues are

--- a/erts/emulator/beam/erl_cpu_topology.c
+++ b/erts/emulator/beam/erl_cpu_topology.c
@@ -1674,8 +1674,10 @@ erts_early_init_cpu_topology(int no_schedulers,
 			     int max_reader_groups,
 			     int *reader_groups_p,
                              int max_decentralized_counter_groups,
-                             int *decentralized_counter_groups_p)
+                             int *decentralized_counter_groups_p,
+                             int skip_read_topology)
 {
+    erts_cpu_info_update(cpuinfo, skip_read_topology);
     user_cpudata = NULL;
     user_cpudata_size = 0;
 
@@ -1758,7 +1760,7 @@ erts_update_cpu_info(void)
 {
     int changed;
     erts_rwmtx_rwlock(&cpuinfo_rwmtx);
-    changed = erts_cpu_info_update(cpuinfo);
+    changed = erts_cpu_info_update(cpuinfo, 0);
     if (changed) {
 	erts_cpu_topology_t *cpudata;
 	int cpudata_size;

--- a/erts/emulator/beam/erl_cpu_topology.h
+++ b/erts/emulator/beam/erl_cpu_topology.h
@@ -40,7 +40,8 @@ erts_early_init_cpu_topology(int no_schedulers,
 			     int max_reader_groups,
 			     int *reader_groups_p,
                              int max_decentralized_counter_groups,
-                             int *decentralized_counter_groups_p);
+                             int *decentralized_counter_groups_p,
+                             int skip_read_topology);
 void erts_init_cpu_topology(void);
 
 

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -682,6 +682,7 @@ void erts_usage(void)
     erts_fprintf(stderr, "               none | very_short | short | medium | long | very_long\n");
     erts_fprintf(stderr, "-scl bool      enable/disable compaction of scheduler load\n");
     erts_fprintf(stderr, "-sct cput      set cpu topology\n");
+    erts_fprintf(stderr, "-ssrct         skip reading cpu topology\n");
     erts_fprintf(stderr, "-secio bool    enable or disable eager check I/O scheduling\n");
 #if ERTS_HAVE_SCHED_UTIL_BALANCING_SUPPORT_OPT
     erts_fprintf(stderr, "-sub bool      enable or disable scheduler utilization balancing\n");
@@ -829,6 +830,7 @@ early_init(int *argc, char **argv) /*
     int decentralized_counter_groups;
     char envbuf[21]; /* enough for any 64-bit integer */
     size_t envbufsz;
+    int skip_read_topology = 0;
 
     erts_save_emu_args(*argc, argv);
 
@@ -968,7 +970,18 @@ early_init(int *argc, char **argv) /*
 		    }
 		    break;
 		}
-
+		case 's' : {
+		    char *sub_param = argv[i]+2;
+		    if (has_prefix("srct", sub_param)) {
+			/* skip reading cpu topology */
+			skip_read_topology = 1;
+		    }
+		    else if (has_prefix("ct", sub_param)) {
+			/* cpu topology */
+			skip_read_topology = 1;
+		    }
+		    break;
+		}
 		case 'S' :
 		    if (argv[i][2] == 'P') {
 			int ptot, ponln;
@@ -1262,7 +1275,8 @@ early_init(int *argc, char **argv) /*
 				 max_reader_groups,
 				 &reader_groups,
                                  max_decentralized_counter_groups,
-                                 &decentralized_counter_groups);
+                                 &decentralized_counter_groups,
+                                 skip_read_topology);
     erts_flxctr_setup(decentralized_counter_groups);
     {
 	erts_thr_late_init_data_t elid = ERTS_THR_LATE_INIT_DATA_DEF_INITER;
@@ -2087,6 +2101,9 @@ erl_start(int argc, char **argv)
 		    erts_usage();
 		}
 		erts_runq_supervision_interval = val;
+	    }
+	    else if (has_prefix("srct", sub_param)) {
+		/* skip reading cpu topology, already handled */
 	    }
 	    else {
 		erts_fprintf(stderr, "bad scheduling option %s\n", argv[i]);

--- a/erts/emulator/test/scheduler_SUITE.erl
+++ b/erts/emulator/test/scheduler_SUITE.erl
@@ -52,6 +52,7 @@
 	 cpu_topology/1,
 	 update_cpu_info/1,
 	 sct_cmd/1,
+	 ssrct_cmd/1,
 	 sbt_cmd/1,
 	 scheduler_threads/1,
 	 scheduler_suspend_basic/1,
@@ -786,6 +787,8 @@ cpu_topology_bif_test(Config, Topology) ->
     {ok, Node} = start_node(Config),
     _ = rpc:call(Node, erlang, system_flag, [cpu_topology, Topology]),
     cmp(Topology, rpc:call(Node, erlang, system_info, [cpu_topology])),
+    cmp(Topology,
+        rpc:call(Node, erlang, system_info, [{cpu_topology, defined}])),
     stop_node(Node),
     ok.
 
@@ -794,6 +797,10 @@ cpu_topology_cmdline_test(_Config, _Topology, false) ->
 cpu_topology_cmdline_test(Config, Topology, Cmd) ->
     {ok, Node} = start_node(Config, Cmd),
     cmp(Topology, rpc:call(Node, erlang, system_info, [cpu_topology])),
+    cmp(undefined,
+        rpc:call(Node, erlang, system_info, [{cpu_topology, detected}])),
+    cmp(Topology,
+        rpc:call(Node, erlang, system_info, [{cpu_topology, defined}])),
     stop_node(Node),
     ok.
 
@@ -979,6 +986,10 @@ sct_cmd(Config) when is_list(Config) ->
 	{ok, Node} = start_node(Config, ?TOPOLOGY_A_CMD),
 	cmp(Topology,
 		  rpc:call(Node, erlang, system_info, [cpu_topology])),
+	cmp(undefined,
+		  rpc:call(Node, erlang, system_info, [{cpu_topology, detected}])),
+	cmp(Topology,
+		  rpc:call(Node, erlang, system_info, [{cpu_topology, defined}])),
 	cmp(Topology,
 		  rpc:call(Node, erlang, system_flag, [cpu_topology, Topology])),
 	cmp(Topology,
@@ -986,6 +997,22 @@ sct_cmd(Config) when is_list(Config) ->
 	stop_node(Node)
     after
 	restore_erl_rel_flags(OldRelFlags)
+    end,
+    ok.
+
+ssrct_cmd(Config) when is_list(Config) ->
+    OldRelFlags = clear_erl_rel_flags(),
+    try
+        {ok, Node} = start_node(Config, "+ssrct"),
+        cmp(undefined,
+            rpc:call(Node, erlang, system_info, [cpu_topology])),
+        cmp(undefined,
+            rpc:call(Node, erlang, system_info, [{cpu_topology, detected}])),
+        cmp(undefined,
+            rpc:call(Node, erlang, system_info, [{cpu_topology, defined}])),
+        stop_node(Node)
+    after
+        restore_erl_rel_flags(OldRelFlags)
     end,
     ok.
 

--- a/erts/include/internal/erl_misc_utils.h
+++ b/erts/include/internal/erl_misc_utils.h
@@ -35,7 +35,7 @@ typedef struct {
 
 erts_cpu_info_t *erts_cpu_info_create(void);
 void erts_cpu_info_destroy(erts_cpu_info_t *cpuinfo);
-int erts_cpu_info_update(erts_cpu_info_t *cpuinfo);
+int erts_cpu_info_update(erts_cpu_info_t *cpuinfo, int skip_read_topology);
 int erts_get_cpu_configured(erts_cpu_info_t *cpuinfo);
 int erts_get_cpu_online(erts_cpu_info_t *cpuinfo);
 int erts_get_cpu_available(erts_cpu_info_t *cpuinfo);

--- a/erts/lib_src/common/erl_misc_utils.c
+++ b/erts/lib_src/common/erl_misc_utils.c
@@ -234,7 +234,7 @@ erts_cpu_info_create(void)
     cpuinfo->online = -1;
     cpuinfo->available = -1;
     cpuinfo->quota = -1;
-    erts_cpu_info_update(cpuinfo);
+    erts_cpu_info_update(cpuinfo, 1);
     return cpuinfo;
 }
 
@@ -259,7 +259,8 @@ erts_cpu_info_destroy(erts_cpu_info_t *cpuinfo)
 }
 
 int
-erts_cpu_info_update(erts_cpu_info_t *cpuinfo)
+erts_cpu_info_update(erts_cpu_info_t *cpuinfo,
+                     int skip_read_topology)
 {
     int changed = 0;
     int configured = 0;
@@ -424,7 +425,9 @@ erts_cpu_info_update(erts_cpu_info_t *cpuinfo)
     old_topology_size = cpuinfo->topology_size;
     cpuinfo->topology = NULL;
 
-    read_topology(cpuinfo);
+    if (!skip_read_topology) {
+        read_topology(cpuinfo);
+    }
 
     if (cpuinfo->topology_size != old_topology_size
 	|| (old_topology_size != 0


### PR DESCRIPTION
Reading CPU topology slows down startup when starting many
parallel instances of ERTS on systems with large amount of cores,
this PR adds the possibility to skip it.

Use new emulator flag +ssrct to skip reading CPU topology.
Reading CPU topology will also be skipped if a user defined topology
is set using the +sct flag.

Fixes #5204