### PR TITLE
ssl: Refactor to avoid re-encoding of decoded certs

### DIFF
--- a/lib/public_key/include/public_key.hrl
+++ b/lib/public_key/include/public_key.hrl
@@ -78,6 +78,8 @@
 	  point
 	 }).
 
+-record(cert, {der, otp}).
+
 -define(unspecified, 0).
 -define(keyCompromise, 1).
 -define(cACompromise, 2).

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -1096,7 +1096,7 @@ pkix_normalize_name(Issuer) ->
 
 %%-------------------------------------------------------------------- 
 -spec pkix_path_validation(Cert::binary()| #'OTPCertificate'{} | atom(),
-			   CertChain :: [binary() | #'OTPCertificate'{}] ,
+			   CertChain :: [binary() | #'OTPCertificate'{} | #cert{}] ,
 			   Options :: [{atom(),term()}]) ->
 				  {ok, {PublicKeyInfo :: term(), 
 					PolicyTree :: term()}} |
@@ -1641,13 +1641,17 @@ validate(Cert, #path_validation_state{working_issuer_name = Issuer,
 
 otp_cert(Der) when is_binary(Der) ->
     pkix_decode_cert(Der, otp);
-otp_cert(#'OTPCertificate'{} =Cert) ->
-    Cert.
+otp_cert(#'OTPCertificate'{} = Cert) ->
+    Cert;
+otp_cert(#cert{otp = OtpCert}) ->
+    OtpCert.
 
 der_cert(#'OTPCertificate'{} = Cert) ->
     pkix_encode('OTPCertificate', Cert, otp);
 der_cert(Der) when is_binary(Der) ->
-    Der.
+    Der;
+der_cert(#cert{der = DerCert}) ->
+    DerCert.
 
 pkix_crls_validate(_, [],_, Options, #revoke_state{details = Details}) ->
      case proplists:get_value(undetermined_details, Options, false) of

--- a/lib/ssl/src/ssl_crl.erl
+++ b/lib/ssl/src/ssl_crl.erl
@@ -105,7 +105,7 @@ find_issuer(IsIssuerFun, Db, _) ->
             Result
     end.
 
-verify_crl_issuer(CRL, ErlCertCandidate, Issuer, NotIssuer) ->
+verify_crl_issuer(CRL, #cert{otp = ErlCertCandidate}, Issuer, NotIssuer) ->
     TBSCert =  ErlCertCandidate#'OTPCertificate'.tbsCertificate,
     case public_key:pkix_normalize_name(TBSCert#'OTPTBSCertificate'.subject) of
 	Issuer ->

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -3726,9 +3726,9 @@ path_validate([], _, _, _, _, _, _, _, _, _, Error) ->
 path_validate([{TrustedCert, Path} | Rest], ServerName, Role, CertDbHandle, CertDbRef, CRLDbHandle,
               Version, SslOptions, CertExt, InvalidatedList, Error) ->
     CB = path_validation_cb(Version),
-    case CB:path_validation(TrustedCert, Path, ServerName,
-                         Role, CertDbHandle, CertDbRef, CRLDbHandle,
-                         Version, SslOptions, CertExt) of
+    case CB:path_validation(trusted_unwrap(TrustedCert), Path, ServerName,
+                            Role, CertDbHandle, CertDbRef, CRLDbHandle,
+                            Version, SslOptions, CertExt) of
         {error, {bad_cert, root_cert_expired}} = NewError ->
             NewInvalidatedList = [TrustedCert | InvalidatedList],
             Alt = ssl_certificate:find_cross_sign_root_paths(Path, CertDbHandle, CertDbRef, NewInvalidatedList),
@@ -3744,6 +3744,11 @@ path_validate([{TrustedCert, Path} | Rest], ServerName, Role, CertDbHandle, Cert
         Result ->
             Result
     end.
+
+trusted_unwrap(#cert{otp = TrustedCert}) ->
+    TrustedCert;
+trusted_unwrap(ErrAtom) ->
+    ErrAtom.
 
 %% Call basic path validation algorithm in public_key pre TLS-1.3
 path_validation(TrustedCert, Path, ServerName, Role, CertDbHandle, CertDbRef, CRLDbHandle, Version,

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -252,7 +252,6 @@
          max_size              %% max early data size allowed by this ticket
         }).
 
--record(cert, {der, otp}).
 
 -endif. % -ifdef(ssl_internal).
 


### PR DESCRIPTION
Let public key define the record #cert{} that can be used to provide
the original DER certs received from the peer and the decoded version
together as input to certificate handling functions such as
public:pkix_path_validation/3
    
It will be more efficient as we can avoid conversions and also a way for
applications such as ssl to tolerate certs with some ASN1-encoding errors that can be worked around.