### PR TITLE
dialyzer: Miscellaneous bug fixes and cleanups

### DIFF
--- a/lib/dialyzer/src/dialyzer.erl
+++ b/lib/dialyzer/src/dialyzer.erl
@@ -725,14 +725,14 @@ pp_type(Type) ->
   Form = {attribute, erl_anno:new(0), type, {t, Type, []}},
   TypeDef = erl_pp:form(Form, [{quote_singleton_atom_types, true}]),
   {match, [S]} = re:run(TypeDef, <<"::\\s*(.*)\\.\\n*">>,
-                        [{capture, all_but_first, list}, dotall]),
+                        [{capture, all_but_first, list}, dotall, unicode]),
   S.
 
 pp_spec(Spec) ->
   Form = {attribute, erl_anno:new(0), spec, {{a,b,0}, Spec}},
   Sig = erl_pp:form(Form, [{quote_singleton_atom_types, true}]),
   {match, [S]} = re:run(Sig, <<"-spec a:b\\s*(.*)\\.\\n*">>,
-                        [{capture, all_but_first, list}, dotall]),
+                        [{capture, all_but_first, list}, dotall, unicode]),
   S.
 
 parse_types_and_literals(Src) ->

--- a/lib/dialyzer/src/dialyzer_typesig.erl
+++ b/lib/dialyzer/src/dialyzer_typesig.erl
@@ -2130,7 +2130,7 @@ v2_solve_conj([I|Is], [Cs|Tail], I, Map0, Conj, IsFlat, V2State0,
                     [U|UL], NewFs, VarsUp, LastMap, LastFlags)
   end;
 v2_solve_conj([], _Cs, _I, Map, Conj, IsFlat, V2State, UL, NewFs, VarsUp,
-             LastMap, LastFlags) ->
+              LastMap, LastFlags) ->
   U = lists:umerge(UL),
   case lists:umerge(NewFs) of
     [] ->
@@ -2142,6 +2142,7 @@ v2_solve_conj([], _Cs, _I, Map, Conj, IsFlat, V2State, UL, NewFs, VarsUp,
       report_detected_loop(Conj),
       {ok, Map, V2State, lists:umerge([U|VarsUp])};
     NewFlags ->
+      ?debug("conjunct restart Id=~w\n", [Conj#constraint_list.id]),
       #constraint_list{type = conj, list = Cs} = Conj,
       v2_solve_conj(NewFlags, Cs, 1, Map, Conj, IsFlat, V2State,
                     [], [], [U|VarsUp], Map, NewFlags)

--- a/lib/dialyzer/test/dialyzer_common.erl
+++ b/lib/dialyzer/test/dialyzer_common.erl
@@ -154,7 +154,7 @@ check(TestCase, Opts, Dir, OutDir) ->
 		_  ->
 		    case file:open(NewResFile,[?output_file_mode]) of
 			{ok, OutFile} ->
-			    io:format(OutFile,"\n~s",[Warns]),
+			    file:write(OutFile, [$\n, unicode:characters_to_binary(Warns)]),
 			    file:close(OutFile);
 			Other -> erlang:error(Other)
 		    end

--- a/lib/dialyzer/test/map_SUITE_data/results/opaque_key
+++ b/lib/dialyzer/test/map_SUITE_data/results/opaque_key
@@ -4,8 +4,8 @@ opaque_key_adt.erl:41:2: Invalid type specification for function opaque_key_adt:
 opaque_key_adt.erl:44:2: Invalid type specification for function opaque_key_adt:s5/0. The success typing is () -> #{2:=3}
 opaque_key_adt.erl:56:2: Invalid type specification for function opaque_key_adt:smt1/0. The success typing is () -> #{3:='a'}
 opaque_key_adt.erl:59:2: Invalid type specification for function opaque_key_adt:smt2/0. The success typing is () -> #{1:='a'}
-opaque_key_use.erl:13:5: The test opaque_key_use:t() =:= opaque_key_use:t(integer()) can never evaluate to 'true'
-opaque_key_use.erl:24:5: Attempt to test for equality between a term of type opaque_key_adt:t(integer()) and a term of opaque type opaque_key_adt:t()
+opaque_key_use.erl:13:5: The test opaque_key_use:t() =:= opaque_key_use:t(_) can never evaluate to 'true'
+opaque_key_use.erl:24:5: Attempt to test for equality between a term of type opaque_key_adt:t(_) and a term of opaque type opaque_key_adt:t()
 opaque_key_use.erl:37:1: Function adt_mm1/0 has no local return
 opaque_key_use.erl:40:5: The attempt to match a term of type opaque_key_adt:m() against the pattern #{A:=R} breaks the opacity of the term
 opaque_key_use.erl:48:1: Function adt_mu1/0 has no local return

--- a/lib/dialyzer/test/opaque_SUITE_data/results/para
+++ b/lib/dialyzer/test/opaque_SUITE_data/results/para
@@ -1,34 +1,24 @@
 
-para1.erl:18:5: The test para1:t(atom()) =:= para1:t(integer()) can never evaluate to 'true'
-para1.erl:23:5: The test para1:t(atom()) =:= para1:t() can never evaluate to 'true'
-para1.erl:28:5: The test para1:t() =:= para1:t(integer()) can never evaluate to 'true'
+para1.erl:18:5: The test para1:t(_) =:= para1:t(_) can never evaluate to 'true'
+para1.erl:23:5: The test para1:t(_) =:= para1:t() can never evaluate to 'true'
+para1.erl:28:5: The test para1:t() =:= para1:t(_) can never evaluate to 'true'
 para1.erl:33:5: The test {3,2} =:= {'a','b'} can never evaluate to 'true'
-para1.erl:38:5: Attempt to test for equality between a term of type para1_adt:t(integer()) and a term of opaque type para1_adt:t(atom())
-para1.erl:43:5: Attempt to test for equality between a term of type para1_adt:t() and a term of opaque type para1_adt:t(atom())
-para1.erl:48:5: Attempt to test for equality between a term of type para1_adt:t(integer()) and a term of opaque type para1_adt:t()
+para1.erl:38:5: The test para1_adt:t(_) =:= para1_adt:t(_) can never evaluate to 'true'
+para1.erl:43:5: Attempt to test for equality between a term of type para1_adt:t() and a term of opaque type para1_adt:t(_)
+para1.erl:48:5: Attempt to test for equality between a term of type para1_adt:t(_) and a term of opaque type para1_adt:t()
 para1.erl:53:5: The test {3,2} =:= {'a','b'} can never evaluate to 'true'
-para2.erl:103:5: Attempt to test for equality between a term of type para2_adt:circ(integer(),integer()) and a term of opaque type para2_adt:circ(integer())
-para2.erl:117:5: Attempt to test for equality between a term of type para2_adt:un(atom(),integer()) and a term of opaque type para2_adt:un(integer(),atom())
+para2.erl:103:5: Attempt to test for equality between a term of type para2_adt:circ(_,_) and a term of opaque type para2_adt:circ(_)
 para2.erl:31:5: The test 'a' =:= 'b' can never evaluate to 'true'
 para2.erl:61:5: Attempt to test for equality between a term of type para2_adt:c2() and a term of opaque type para2_adt:c1()
 para2.erl:66:5: The test 'a' =:= 'b' can never evaluate to 'true'
-para2.erl:88:5: The test para2:circ(integer()) =:= para2:circ(integer(),integer()) can never evaluate to 'true'
+para2.erl:88:5: The test para2:circ(_) =:= para2:circ(_,_) can never evaluate to 'true'
 para3.erl:28:2: Invalid type specification for function para3:ot2/0. The success typing is () -> 'foo'
 para3.erl:36:5: The pattern {{{17}}} can never match the type {{{{{{_,_,_,_,_}}}}}}
 para3.erl:55:2: Invalid type specification for function para3:t2/0. The success typing is () -> 'foo'
 para3.erl:65:5: The attempt to match a term of type {{{{{para3_adt:ot1(_,_,_,_,_)}}}}} against the pattern {{{{{17}}}}} breaks the opacity of para3_adt:ot1(_,_,_,_,_)
 para3.erl:68:5: The pattern {{{{17}}}} can never match the type {{{{{para3_adt:ot1(_,_,_,_,_)}}}}}
-para3.erl:74:2: The specification for para3:exp_adt/0 has an opaque subtype para3_adt:exp1(para3_adt:exp2()) which is violated by the success typing () -> 3
-para4.erl:21:2: Invalid type specification for function para4:a/1. The success typing is (para4:d_all() | para4:d_atom()) -> [{atom() | integer(),atom() | integer()}]
-para4.erl:26:2: Invalid type specification for function para4:i/1. The success typing is (para4:d_all() | para4:d_integer()) -> [{atom() | integer(),atom() | integer()}]
+para3.erl:74:2: The specification for para3:exp_adt/0 has an opaque subtype para3_adt:exp1(_) which is violated by the success typing () -> 3
 para4.erl:31:2: Invalid type specification for function para4:t/1. The success typing is (para4:d_all() | para4:d_tuple()) -> [{atom() | integer(),atom() | integer()}]
-para4.erl:59:5: Attempt to test for equality between a term of type para4_adt:t(atom() | integer()) and a term of opaque type para4_adt:t(integer())
-para4.erl:64:5: Attempt to test for equality between a term of type para4_adt:t(atom() | integer()) and a term of opaque type para4_adt:t(atom())
-para4.erl:69:5: Attempt to test for equality between a term of type para4_adt:int(1 | 2 | 3 | 4) and a term of opaque type para4_adt:int(1 | 2)
-para4.erl:74:5: Attempt to test for equality between a term of type para4_adt:int(2 | 3 | 4) and a term of opaque type para4_adt:int(1 | 2)
-para4.erl:79:5: Attempt to test for equality between a term of type para4_adt:int(2 | 3 | 4) and a term of opaque type para4_adt:int(5 | 6 | 7)
-para4.erl:84:5: Attempt to test for equality between a term of type para4_adt:un(3 | 4) and a term of opaque type para4_adt:un(1 | 2)
-para4.erl:89:5: Attempt to test for equality between a term of type para4_adt:tup({_,_}) and a term of opaque type para4_adt:tup(tuple())
-para4.erl:94:5: Attempt to test for equality between a term of type para4_adt:t(#{1=>'a'}) and a term of opaque type para4_adt:t(#{2=>'b'})
-para5.erl:13:5: Attempt to test for inequality between a term of type para5_adt:dd(atom()) and a term of opaque type para5_adt:d()
+para4.erl:79:5: The test para4_adt:int(_) =:= para4_adt:int(_) can never evaluate to 'true'
+para5.erl:13:5: Attempt to test for inequality between a term of type para5_adt:dd(_) and a term of opaque type para5_adt:d()
 para5.erl:8:5: The test para5_adt:d() =:= para5_adt:d() can never evaluate to 'true'

--- a/lib/dialyzer/test/opaque_SUITE_data/results/unicode
+++ b/lib/dialyzer/test/opaque_SUITE_data/results/unicode
@@ -1,0 +1,2 @@
+
+exposer.erl:5:26: The call problematic:'🔍'('bug') does not have an opaque term of type problematic:'🐛'() as 1st argument

--- a/lib/dialyzer/test/opaque_SUITE_data/src/unicode/exposer.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/unicode/exposer.erl
@@ -1,0 +1,5 @@
+-module(exposer).
+
+-export(['💣'/0]).
+
+'💣'() -> problematic:'🔍'(bug).

--- a/lib/dialyzer/test/opaque_SUITE_data/src/unicode/problematic.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/unicode/problematic.erl
@@ -1,0 +1,9 @@
+-module(problematic).
+
+-opaque '🐛'() :: bug.
+-export_type(['🐛'/0]).
+
+-export(['🔍'/1]).
+
+-spec '🔍'('🐛'()) -> true.
+'🔍'(bug) -> true.


### PR DESCRIPTION
This PR cleans up some cruft and fixes various bugs. Most of it is rather straightforward but there's a bug in the type lattice that I can't figure out how to fix without drastic measures, and I'd really appreciate it if someone more familiar with `dialyzer` (@kostis?) could have a look.

The gist of it is that opaque types are invariant on their type parameters: an opaque type `foo:bar(gurka | gaffel)` _is not_ a subtype of `foo:bar(atom())` nor is it a supertype of `foo:bar(gurka)`. For an opaque type to be compatible with another instance of the same type, their type arguments have to be exactly equal.

This may seem a bit strict but is required for correctness: while we can see that one can pass an `[integer()]` to a function expecting `[number()]` as lists are covariant on the element type, we don't have a way to specify the variance of an opaque type parameter, nor can we infer it beyond toy cases.

The easiest way to keep the type system sound in the face of that is to treat all type parameters as invariant. It's perhaps a bit surprising but there's nothing wrong with it. So far so good.

Then we hit this marvel in `gb_sets`:

```erlang
-spec add(Element, Set1) -> Set2 when
      Set1 :: set(Element),
      Set2 :: set(Element).
```

A strict reading of this says that it accepts a set containing a singleton `Element` and produces a set containing `Element` alone. If we were to pass a set produced by this function to one that expects (say) `gb_sets:set(atom())`, we should get a type error unless `Element` had already collapsed to `atom()`. Other funny consequences are left as an exercise to the reader.

Yet that works at the moment. Huh?!

1. `dialyzer` throws away type variables in specs, replacing them with `any()` and removing all relations between them.
    
   Trying to improve that is how I noticed this quirk.
2. `dialyzer` considers `any()` in type variables to be compatible with all other types. That is, `gb_sets:set(any())` is okay in functions  that expect (say) `gb_sets:set(atom())` and vice versa.

The former is awkward but the latter is where things go off the rails. We may pass `any()`'d and more explicitly typed opaques around interchangeably, but since type parameters are invariant there's no way for us to tell which is the subtype and which is the supertype (note that saying that "`any()` is always the supertype" will be wrong if the type parameter happens to be contravariant). This breaks the type lattice and sends `dialyzer` into infinite loops often enough that adding a test case for this bug is rather pointless: you can hardly even begin building a PLT of OTP before hitting it. The only reason it works at present is because we hide the error by detecting and breaking out of loops, accepting subtly wrong results.

I can't see a way around this without inventing a new notation and requiring people to rewrite their specs with it, so I've decided to treat all type arguments as `any()` in this PR. Unfortunately this makes `dialyzer` less useful and I'd be very grateful if someone could propose an alternative solution or point out where I had a brainfart.