### PR TITLE
Replace "expr --" usage with (POSIX) parameter expansion

### DIFF
--- a/configure
+++ b/configure
@@ -55,7 +55,7 @@ skip_applications=
 while test $# != 0; do
     case $1 in
 	-srcdir=* | --srcdir=*)
-	    user_srcdir=`expr -- "$1" : '[^=]*=\(.*\)'`
+		user_srcdir="${1#*=}"
 	    if test "$ERL_TOP" != ""; then
 		echo "WARNING: Overriding ERL_TOP with $user_srcdir" 1>&2
 		echo "" 1>&2
@@ -95,7 +95,7 @@ while test $# != 0; do
 	    echo "" 1>&2
 	    ;;
 	-cache-file=* | --cache-file=* )
-	    static_cache=`expr -- "$1" : '[^=]*=\(.*\)'`
+		static_cache="${1#*=}"
 	    if test "$static_cache" != "/dev/null"; then
 		echo "WARNING: Only using config cache file '$static_cache' as static cache" 1>&2
 		echo "" 1>&2
@@ -140,8 +140,8 @@ while test $# != 0; do
 	    pie_ldflags="-no-pie"
 	    ;;
 	CFLAGS=* | LDFLAGS=*)
-	    flgs_var=`expr -- "$1" : '\([^=]*\)=.*'`
-	    flgs_val=`expr -- "$1" : '[^=]*=\(.*\)'`
+		flgs_var="${1%%=*}"
+		flgs_val="${1#$flgs_var=}"
 	    eval $flgs_var=\$flgs_val
 	    ;;
 	--help=r* | -help=r*)
@@ -151,7 +151,7 @@ while test $# != 0; do
         *)
 	    case $1 in
 		--without-*)
-		    skip_app=`expr -- "$1" : '--without-\(.*\)'`
+			skip_app="${1#--without-}"
                     if [ "$skip_app" = "stdlib" ] ||
                            [ "$skip_app" = "kernel" ] ||
                            [ "$skip_app" = "sasl" ] ||

--- a/configure.src
+++ b/configure.src
@@ -55,7 +55,7 @@ skip_applications=
 while test $# != 0; do
     case $1 in
 	-srcdir=* | --srcdir=*)
-	    user_srcdir=`expr -- "$1" : '[^=]*=\(.*\)'`
+		user_srcdir="${1#*=}"
 	    if test "$ERL_TOP" != ""; then
 		echo "WARNING: Overriding ERL_TOP with $user_srcdir" 1>&2
 		echo "" 1>&2
@@ -95,7 +95,7 @@ while test $# != 0; do
 	    echo "" 1>&2
 	    ;;
 	-cache-file=* | --cache-file=* )
-	    static_cache=`expr -- "$1" : '[^=]*=\(.*\)'`
+		static_cache="${1#*=}"
 	    if test "$static_cache" != "/dev/null"; then
 		echo "WARNING: Only using config cache file '$static_cache' as static cache" 1>&2
 		echo "" 1>&2
@@ -140,8 +140,8 @@ while test $# != 0; do
 	    pie_ldflags="-no-pie"
 	    ;;
 	CFLAGS=* | LDFLAGS=*)
-	    flgs_var=`expr -- "$1" : '\([^=]*\)=.*'`
-	    flgs_val=`expr -- "$1" : '[^=]*=\(.*\)'`
+		flgs_var="${1%%=*}"
+		flgs_val="${1#$flgs_var=}"
 	    eval $flgs_var=\$flgs_val
 	    ;;
 	--help=r* | -help=r*)
@@ -151,7 +151,7 @@ while test $# != 0; do
         *)
 	    case $1 in
 		--without-*)
-		    skip_app=`expr -- "$1" : '--without-\(.*\)'`
+			skip_app="${1#--without-}"
                     if [ "$skip_app" = "stdlib" ] ||
                            [ "$skip_app" = "kernel" ] ||
                            [ "$skip_app" = "sasl" ] ||


### PR DESCRIPTION
See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02

(Whitespace throughout this file is very inconsistent -- I've used purely tabs on the new lines I wrote, but I'm happy to adjust them to match what the lines they're replacing used, or any other adjustment desired. :heart:)

Easiest way to test/validate these:

```console
$ a='--srcdir=foo-bar=baz-buzz'
$ echo "${a#*=}"
foo-bar=baz-buzz
$ a='-srcdir=foo-bar=baz-buzz'
$ echo "${a#*=}"
foo-bar=baz-buzz

$ a='CFLAGS=foo=bar=baz'
$ var="${a%%=*}"
$ val="${a#$var=}"
$ echo " var='$var'  val='$val' "
 var='CFLAGS'  val='foo=bar=baz' 

$ a='--without-foo-bar-baz'
$ echo "${a#--without-}"
foo-bar-baz
```

(This should fix the issue I noted in https://github.com/erlang/otp/pull/4909#issuecomment-925425681)