### PR TITLE
Replace "expr --" usage with sed

### DIFF
--- a/configure
+++ b/configure
@@ -55,7 +55,7 @@ skip_applications=
 while test $# != 0; do
     case $1 in
 	-srcdir=* | --srcdir=*)
-	    user_srcdir=`expr -- "$1" : '[^=]*=\(.*\)'`
+        user_srcdir=`echo "$1" | sed 's/^[^=]*=//'`
 	    if test "$ERL_TOP" != ""; then
 		echo "WARNING: Overriding ERL_TOP with $user_srcdir" 1>&2
 		echo "" 1>&2
@@ -95,7 +95,7 @@ while test $# != 0; do
 	    echo "" 1>&2
 	    ;;
 	-cache-file=* | --cache-file=* )
-	    static_cache=`expr -- "$1" : '[^=]*=\(.*\)'`
+        static_cache=`echo "$1" | sed 's/^[^=]*=//'`
 	    if test "$static_cache" != "/dev/null"; then
 		echo "WARNING: Only using config cache file '$static_cache' as static cache" 1>&2
 		echo "" 1>&2
@@ -140,8 +140,8 @@ while test $# != 0; do
 	    pie_ldflags="-no-pie"
 	    ;;
 	CFLAGS=* | LDFLAGS=*)
-	    flgs_var=`expr -- "$1" : '\([^=]*\)=.*'`
-	    flgs_val=`expr -- "$1" : '[^=]*=\(.*\)'`
+        flgs_var=`echo "$1" | sed 's/=.*$//'`
+        flgs_val=`echo "$1" | sed 's/^[^=]*=//'`
 	    eval $flgs_var=\$flgs_val
 	    ;;
 	--help=r* | -help=r*)
@@ -151,7 +151,7 @@ while test $# != 0; do
         *)
 	    case $1 in
 		--without-*)
-		    skip_app=`expr -- "$1" : '--without-\(.*\)'`
+            skip_app=`echo "$1" | sed 's/^--without-//'`
                     if [ "$skip_app" = "stdlib" ] ||
                            [ "$skip_app" = "kernel" ] ||
                            [ "$skip_app" = "sasl" ] ||

--- a/configure.src
+++ b/configure.src
@@ -55,7 +55,7 @@ skip_applications=
 while test $# != 0; do
     case $1 in
 	-srcdir=* | --srcdir=*)
-	    user_srcdir=`expr -- "$1" : '[^=]*=\(.*\)'`
+        user_srcdir=`echo "$1" | sed 's/^[^=]*=//'`
 	    if test "$ERL_TOP" != ""; then
 		echo "WARNING: Overriding ERL_TOP with $user_srcdir" 1>&2
 		echo "" 1>&2
@@ -95,7 +95,7 @@ while test $# != 0; do
 	    echo "" 1>&2
 	    ;;
 	-cache-file=* | --cache-file=* )
-	    static_cache=`expr -- "$1" : '[^=]*=\(.*\)'`
+        static_cache=`echo "$1" | sed 's/^[^=]*=//'`
 	    if test "$static_cache" != "/dev/null"; then
 		echo "WARNING: Only using config cache file '$static_cache' as static cache" 1>&2
 		echo "" 1>&2
@@ -140,8 +140,8 @@ while test $# != 0; do
 	    pie_ldflags="-no-pie"
 	    ;;
 	CFLAGS=* | LDFLAGS=*)
-	    flgs_var=`expr -- "$1" : '\([^=]*\)=.*'`
-	    flgs_val=`expr -- "$1" : '[^=]*=\(.*\)'`
+        flgs_var=`echo "$1" | sed 's/=.*$//'`
+        flgs_val=`echo "$1" | sed 's/^[^=]*=//'`
 	    eval $flgs_var=\$flgs_val
 	    ;;
 	--help=r* | -help=r*)
@@ -151,7 +151,7 @@ while test $# != 0; do
         *)
 	    case $1 in
 		--without-*)
-		    skip_app=`expr -- "$1" : '--without-\(.*\)'`
+            skip_app=`echo "$1" | sed 's/^--without-//'`
                     if [ "$skip_app" = "stdlib" ] ||
                            [ "$skip_app" = "kernel" ] ||
                            [ "$skip_app" = "sasl" ] ||


### PR DESCRIPTION
Ideally, this would use POSIX shell parameter expansions (https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02), but as noted in https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Shell-Substitutions.html these are not supported properly on many platforms where Erlang still is.

This is #5236 (take two), fixing the issue I noted in https://github.com/erlang/otp/pull/4909#issuecomment-925425681.  I have tested this change in the same Alpine-based build environment against 24.1 (where it works successfully).

Here's a similar proof that these expressions _should_ be correct (assuming they work on Solaris 10 -- I unfortunately don't have Solaris 10 handy to verify :grimacing:):

```console
$ set -- '--srcdir=foo-bar=baz-buzz'
$ echo "$1" | sed 's/^[^=]*=//'
foo-bar=baz-buzz
$ set -- '-srcdir=foo-bar=baz-buzz'
$ echo "$1" | sed 's/^[^=]*=//'
foo-bar=baz-buzz

$ set -- 'CFLAGS=foo=bar=baz'
$ echo "$1" | sed 's/=.*$//'
CFLAGS
$ echo "$1" | sed 's/^[^=]*=//'
foo=bar=baz

$ set -- '--without-foo-bar-baz'
$ echo "$1" | sed 's/^--without-//'
foo-bar-baz
```

(I modeled them after some of the examples in https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Shell-Substitutions.html, so I _hope_ they're right. :innocent:)