### PR TITLE
erts: Optimize fun calls

### DIFF
--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -870,7 +870,8 @@ BIF_RETTYPE finish_after_on_load_2(BIF_ALIST_2)
             DBG_CHECK_EXPORT(ep, code_ix);
 
             if (ep->trampoline.not_loaded.deferred != 0) {
-                    ep->addresses[code_ix] = (void*)ep->trampoline.not_loaded.deferred;
+                    ep->dispatch.addresses[code_ix] =
+                        (void*)ep->trampoline.not_loaded.deferred;
                     ep->trampoline.not_loaded.deferred = 0;
             } else {
                 if (ep->bif_number != -1) {

--- a/erts/emulator/beam/beam_common.h
+++ b/erts/emulator/beam/beam_common.h
@@ -257,8 +257,6 @@ Export* fixed_apply(Process* p, Eterm* reg, Uint arity,
 Export* apply(Process* p, Eterm* reg, ErtsCodePtr I, Uint offs);
 ErtsCodePtr call_fun(Process* p, int arity, Eterm* reg, Eterm args);
 ErtsCodePtr apply_fun(Process* p, Eterm fun, Eterm args, Eterm* reg);
-Eterm new_fun(Process* p, Eterm* reg,
-		     ErlFunEntry* fe, int num_free);
 ErlFunThing* new_fun_thing(Process* p,
                            ErlFunEntry* fe,
                            int arity,

--- a/erts/emulator/beam/beam_common.h
+++ b/erts/emulator/beam/beam_common.h
@@ -153,80 +153,81 @@ do {						\
 
 #ifdef USE_VM_CALL_PROBES
 
-#define DTRACE_LOCAL_CALL(p, mfa)					\
-    if (DTRACE_ENABLED(local_function_entry)) {				\
-        DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);		\
-        DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);			\
-        int depth = STACK_START(p) - STACK_TOP(p);			\
-        dtrace_fun_decode(p, mfa, process_name, mfa_buf);               \
-        DTRACE3(local_function_entry, process_name, mfa_buf, depth);	\
+#define DTRACE_LOCAL_CALL(p, cmfa)                                      \
+    if (DTRACE_ENABLED(local_function_entry)) {                         \
+        DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);             \
+        DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);                  \
+        int depth = STACK_START(p) - STACK_TOP(p);                      \
+        dtrace_fun_decode(p, cmfa, process_name, mfa_buf);              \
+        DTRACE3(local_function_entry, process_name, mfa_buf, depth);    \
     }
 
-#define DTRACE_GLOBAL_CALL(p, mfa)					\
-    if (DTRACE_ENABLED(global_function_entry)) {			\
-        DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);		\
-        DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);			\
-        int depth = STACK_START(p) - STACK_TOP(p);			\
-        dtrace_fun_decode(p, mfa, process_name, mfa_buf);               \
+#define DTRACE_GLOBAL_CALL(p, cmfa)                                     \
+    if (DTRACE_ENABLED(global_function_entry)) {	                    \
+        DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);             \
+        DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);                  \
+        int depth = STACK_START(p) - STACK_TOP(p);                      \
+        dtrace_fun_decode(p, cmfa, process_name, mfa_buf);              \
         DTRACE3(global_function_entry, process_name, mfa_buf, depth);	\
     }
 
-#define DTRACE_RETURN(p, mfa)                                    \
+#define DTRACE_RETURN(p, cmfa)                                  \
     if (DTRACE_ENABLED(function_return)) {                      \
         DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);     \
         DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);          \
         int depth = STACK_START(p) - STACK_TOP(p);              \
-        dtrace_fun_decode(p, mfa, process_name, mfa_buf);       \
+        dtrace_fun_decode(p, cmfa, process_name, mfa_buf);      \
         DTRACE3(function_return, process_name, mfa_buf, depth); \
     }
 
-#define DTRACE_BIF_ENTRY(p, mfa)                                    \
+#define DTRACE_BIF_ENTRY(p, cmfa)                                   \
     if (DTRACE_ENABLED(bif_entry)) {                                \
         DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);         \
         DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);              \
-        dtrace_fun_decode(p, mfa, process_name, mfa_buf);           \
+        dtrace_fun_decode(p, cmfa, process_name, mfa_buf);          \
         DTRACE2(bif_entry, process_name, mfa_buf);                  \
     }
 
-#define DTRACE_BIF_RETURN(p, mfa)                                   \
+#define DTRACE_BIF_RETURN(p, cmfa)                                  \
     if (DTRACE_ENABLED(bif_return)) {                               \
         DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);         \
         DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);              \
-        dtrace_fun_decode(p, mfa, process_name, mfa_buf);           \
+        dtrace_fun_decode(p, cmfa, process_name, mfa_buf);          \
         DTRACE2(bif_return, process_name, mfa_buf);                 \
     }
 
-#define DTRACE_NIF_ENTRY(p, mfa)                                        \
+#define DTRACE_NIF_ENTRY(p, cmfa)                                       \
     if (DTRACE_ENABLED(nif_entry)) {                                    \
         DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);             \
         DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);                  \
-        dtrace_fun_decode(p, mfa, process_name, mfa_buf);               \
+        dtrace_fun_decode(p, cmfa, process_name, mfa_buf);              \
         DTRACE2(nif_entry, process_name, mfa_buf);                      \
     }
 
-#define DTRACE_NIF_RETURN(p, mfa)                                       \
+#define DTRACE_NIF_RETURN(p, cmfa)                                      \
     if (DTRACE_ENABLED(nif_return)) {                                   \
         DTRACE_CHARBUF(process_name, DTRACE_TERM_BUF_SIZE);             \
         DTRACE_CHARBUF(mfa_buf, DTRACE_TERM_BUF_SIZE);                  \
-        dtrace_fun_decode(p, mfa, process_name, mfa_buf);               \
+        dtrace_fun_decode(p, cmfa, process_name, mfa_buf);              \
         DTRACE2(nif_return, process_name, mfa_buf);                     \
     }
 
-#define DTRACE_GLOBAL_CALL_FROM_EXPORT(p,e)                                        \
-    do {                                                                           \
-        if (DTRACE_ENABLED(global_function_entry)) {                               \
-            ErtsCodePtr fp__ = (((Export *) (e))->addresses[erts_active_code_ix()]); \
-            DTRACE_GLOBAL_CALL((p), erts_code_to_codemfa(fp__));                   \
-        }                                                                          \
+#define DTRACE_GLOBAL_CALL_FROM_EXPORT(p,e)                               \
+    do {                                                                  \
+        if (DTRACE_ENABLED(global_function_entry)) {                      \
+            ErtsDispatchable *disp__ = &(e)->dispatch;                    \
+            ErtsCodePtr fp__ = disp__->addresses[erts_active_code_ix()];  \
+            DTRACE_GLOBAL_CALL((p), erts_code_to_codemfa(fp__));          \
+        }                                                                 \
     } while(0)
 
-#define DTRACE_RETURN_FROM_PC(p, i)                                                      \
-    do {                                                                                 \
-        const ErtsCodeMFA* cmfa;                                                         \
-        if (DTRACE_ENABLED(function_return) && (cmfa = erts_find_function_from_pc(i))) { \
-            DTRACE_RETURN((p), cmfa);                                                    \
-        }                                                                                \
-    } while(0)
+#define DTRACE_RETURN_FROM_PC(p, i)                                     \
+    if (DTRACE_ENABLED(function_return)) {                              \
+        const ErtsCodeMFA* cmfa  = erts_find_function_from_pc(i);       \
+        if (cmfa) {                                                     \
+            DTRACE_RETURN((p), cmfa);                                   \
+        }                                                               \
+    }
 
 #else /* USE_VM_PROBES */
 #define DTRACE_LOCAL_CALL(p, mfa)        do {} while (0)
@@ -257,10 +258,6 @@ Export* fixed_apply(Process* p, Eterm* reg, Uint arity,
 Export* apply(Process* p, Eterm* reg, ErtsCodePtr I, Uint offs);
 ErtsCodePtr call_fun(Process* p, int arity, Eterm* reg, Eterm args);
 ErtsCodePtr apply_fun(Process* p, Eterm fun, Eterm args, Eterm* reg);
-ErlFunThing* new_fun_thing(Process* p,
-                           ErlFunEntry* fe,
-                           int arity,
-                           int num_free);
 int is_function2(Eterm Term, Uint arity);
 Eterm erts_gc_new_map(Process* p, Eterm* reg, Uint live,
                       Uint n, const Eterm* data);

--- a/erts/emulator/beam/beam_debug.c
+++ b/erts/emulator/beam/beam_debug.c
@@ -299,7 +299,7 @@ erts_debug_disassemble_1(BIF_ALIST_1)
 	     * But this code_ptr will point to the start of the Export,
 	     * not the function's func_info instruction. BOOM !?
 	     */
-	    cmfa = erts_code_to_codemfa(ep->addresses[code_ix]);
+	    cmfa = erts_code_to_codemfa(ep->dispatch.addresses[code_ix]);
 	} else if (modp == NULL || (code_hdr = modp->curr.code_hdr) == NULL) {
 	    BIF_RET(am_undef);
 	} else {

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -235,7 +235,7 @@ erts_finish_loading(Binary* magic, Process* c_p,
 
                     erts_clear_export_break(mod_tab_p, ep);
 
-                    ep->addresses[code_ix] =
+                    ep->dispatch.addresses[code_ix] =
                         (ErtsCodePtr)ep->trampoline.breakpoint.address;
                     ep->trampoline.breakpoint.address = 0;
 
@@ -630,7 +630,12 @@ erts_release_literal_area(ErtsLiteralArea* literal_area)
             }
         case FUN_SUBTAG:
             {
-                ErlFunEntry* fe = ((ErlFunThing*)oh)->fe;
+                /* We _KNOW_ that this is a local fun, otherwise it would not
+                 * be part of the off-heap list. */
+                ErlFunEntry* fe = ((ErlFunThing*)oh)->entry.fun;
+
+                ASSERT(is_local_fun((ErlFunThing*)oh));
+
                 if (erts_refc_dectest(&fe->refc, 0) == 0) {
                     erts_erase_fun_entry(fe);
                 }

--- a/erts/emulator/beam/bif.h
+++ b/erts/emulator/beam/bif.h
@@ -327,7 +327,7 @@ extern ErtsCodePtr beam_bif_export_trap;
 
 #define ERTS_BIF_PREP_TRAP(Export, Proc, Arity)                               \
     do {                                                                      \
-        (Proc)->i = (Export)->addresses[erts_active_code_ix()];               \
+        (Proc)->i = (Export)->dispatch.addresses[erts_active_code_ix()];      \
         (Proc)->arity = (Arity);                                              \
         (Proc)->freason = TRAP;                                               \
     } while(0);

--- a/erts/emulator/beam/code_ix.h
+++ b/erts/emulator/beam/code_ix.h
@@ -63,6 +63,20 @@ struct process;
 
 
 #define ERTS_NUM_CODE_IX 3
+
+#ifdef BEAMASM
+#define ERTS_ADDRESSV_SIZE (ERTS_NUM_CODE_IX + 1)
+#define ERTS_SAVE_CALLS_CODE_IX (ERTS_ADDRESSV_SIZE - 1)
+#else
+#define ERTS_ADDRESSV_SIZE ERTS_NUM_CODE_IX
+#endif
+
+/* This structure lets `Export` entries and `ErlFunEntry` share dispatch code,
+ * which greatly improves the performance of fun calls. */
+typedef struct ErtsDispatchable_ {
+    ErtsCodePtr addresses[ERTS_ADDRESSV_SIZE];
+} ErtsDispatchable;
+
 typedef unsigned ErtsCodeIndex;
 
 typedef struct ErtsCodeMFA_ {

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -4638,7 +4638,7 @@ BIF_RETTYPE setnode_2(BIF_ALIST_2)
 	goto error;
 
     /* Check that all trap functions are defined !! */
-    if (dmonitor_node_trap->addresses[0] == NULL) {
+    if (dmonitor_node_trap->dispatch.addresses[0] == NULL) {
 	goto error;
     }
 

--- a/erts/emulator/beam/emu/emu_load.c
+++ b/erts/emulator/beam/emu/emu_load.c
@@ -632,7 +632,8 @@ void beam_load_finalize_code(LoaderState* stp, struct erl_module_instance* inst_
                 erts_refc_dectest(&fun_entry->refc, 1);
             }
 
-            fun_entry->address = stp->codev + stp->labels[lambda->label].value;
+            erts_set_fun_code(fun_entry,
+                              stp->codev + stp->labels[lambda->label].value);
         }
 
         lp = stp->lambda_patches;
@@ -688,7 +689,7 @@ void beam_load_finalize_code(LoaderState* stp, struct erl_module_instance* inst_
              */
             ep->trampoline.not_loaded.deferred = (BeamInstr) address;
         } else {
-            ep->addresses[erts_staging_code_ix()] = address;
+            ep->dispatch.addresses[erts_staging_code_ix()] = address;
         }
     }
 
@@ -701,7 +702,8 @@ void beam_load_finalize_code(LoaderState* stp, struct erl_module_instance* inst_
             Export *ep = erts_export_put(entry->module,
                                          entry->name,
                                          entry->arity);
-            const BeamInstr *addr = ep->addresses[erts_staging_code_ix()];
+            const BeamInstr *addr =
+                ep->dispatch.addresses[erts_staging_code_ix()];
 
             if (!ErtsInArea(addr, stp->codev, stp->ci * sizeof(BeamInstr))) {
                 erts_exit(ERTS_ABORT_EXIT,

--- a/erts/emulator/beam/emu/instrs.tab
+++ b/erts/emulator/beam/emu/instrs.tab
@@ -243,7 +243,7 @@ APPLY(I, Deallocate, Next) {
         save_calls(c_p, ep);
     }
 
-    $Next = ep->addresses[erts_active_code_ix()];
+    $Next = ep->dispatch.addresses[erts_active_code_ix()];
 }
 
 HANDLE_APPLY_ERROR() {
@@ -290,7 +290,7 @@ FIXED_APPLY(Arity, I, Deallocate, Next) {
         save_calls(c_p, ep);
     }
 
-    $Next = ep->addresses[erts_active_code_ix()];
+    $Next = ep->dispatch.addresses[erts_active_code_ix()];
 }
 
 apply(Arity) {
@@ -546,7 +546,7 @@ i_make_fun3(FunP, Dst, Arity, NumFree) {
     int i, num_free = $NumFree;
     //| -no_next
     SWAPOUT;
-    funp = new_fun_thing(c_p, fe, $Arity, num_free);
+    funp = erts_new_local_fun_thing(c_p, fe, $Arity, num_free);
     SWAPIN;
     I = $NEXT_INSTRUCTION;
     for (i = 0; i < num_free; i++) {

--- a/erts/emulator/beam/emu/macros.tab
+++ b/erts/emulator/beam/emu/macros.tab
@@ -170,7 +170,7 @@ DISPATCH_EXPORT(Export) {
 
     DTRACE_GLOBAL_CALL_FROM_EXPORT(c_p, ep);
 
-    SET_I(ep->addresses[erts_active_code_ix()]);
+    SET_I(ep->dispatch.addresses[erts_active_code_ix()]);
     CHECK_ARGS(I);
     dis_next = *I;
 
@@ -198,7 +198,7 @@ DISPATCH_FUN(I) {
         FCALLS--;
         Goto(dis_next);
     } else {
-        goto context_switch_fun;
+        goto context_switch;
     }
 }
 

--- a/erts/emulator/beam/emu/trace_instrs.tab
+++ b/erts/emulator/beam/emu/trace_instrs.tab
@@ -165,7 +165,7 @@ i_debug_breakpoint() {
     HEAVY_SWAPIN;
 
     if (breakpoint_handler) {
-        I = breakpoint_handler->addresses[erts_active_code_ix()];
+        I = breakpoint_handler->dispatch.addresses[erts_active_code_ix()];
         Goto(*I);
     }
 

--- a/erts/emulator/beam/erl_async.c
+++ b/erts/emulator/beam/erl_async.c
@@ -115,17 +115,6 @@ typedef struct {
     ErtsAlgndAsyncReadyQ *ready_queue;
 } ErtsAsyncData;
 
-#if defined(USE_VM_PROBES)
-
-/*
- * Some compilers, e.g. GCC 4.2.1 and -O3, will optimize away DTrace
- * calls if they're the last thing in the function.  :-(
- * Many thanks to Trond Norbye, via:
- * https://github.com/memcached/memcached/commit/6298b3978687530bc9d219b6ac707a1b681b2a46
- */
-static unsigned gcc_optimizer_hack = 0;
-#endif
-
 int erts_async_max_threads; /* Initialized by erl_init.c */
 int erts_async_thread_suggested_stack_size; /* Initialized by erl_init.c */
 
@@ -238,10 +227,6 @@ erts_get_async_ready_queue(Uint sched_id)
 
 static ERTS_INLINE void async_add(ErtsAsync *a, ErtsAsyncQ* q)
 {
-#ifdef USE_VM_PROBES
-    int len;
-#endif
-
     if (is_internal_port(a->port)) {
 	ErtsAsyncReadyQ *arq = async_ready_q(a->sched_id);
 	a->q.prep_enq = erts_thr_q_prepare_enqueue(&arq->thr_q);
@@ -263,9 +248,6 @@ static ERTS_INLINE ErtsAsync *async_get(ErtsThrQ_t *q,
 {
     int saved_fin_deq = 0;
     ErtsThrQFinDeQ_t fin_deq;
-#ifdef USE_VM_PROBES
-    int len;
-#endif
 
     while (1) {
 	ErtsAsync *a = (ErtsAsync *) erts_thr_q_dequeue(q);

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -3528,126 +3528,93 @@ fun_info_2(BIF_ALIST_2)
     Process* p = BIF_P;
     Eterm fun = BIF_ARG_1;
     Eterm what = BIF_ARG_2;
+
+    const ErtsCodeMFA *mfa;
+    ErlFunThing *funp;
+    ErlFunEntry *fe;
     Eterm* hp;
     Eterm val;
 
-    if (is_fun(fun)) {
-	ErlFunThing* funp = (ErlFunThing *) fun_val(fun);
-
-	switch (what) {
-	case am_type:
-	    hp = HAlloc(p, 3);
-	    val = am_local;
-	    break;
-	case am_pid:
-	    hp = HAlloc(p, 3);
-	    val = funp->creator;
-	    break;
-	case am_module:
-	    hp = HAlloc(p, 3);
-	    val = funp->fe->module;
-	    break;
-	case am_new_index:
-	    hp = HAlloc(p, 3);
-	    val = make_small(funp->fe->index);
-	    break;
-	case am_new_uniq:
-	    val = new_binary(p, funp->fe->uniq, 16);
-	    hp = HAlloc(p, 3);
-	    break;
-	case am_index:
-	    hp = HAlloc(p, 3);
-	    val = make_small(funp->fe->old_index);
-	    break;
-	case am_uniq:
-	    hp = HAlloc(p, 3);
-	    val = make_small(funp->fe->old_uniq);
-	    break;
-	case am_env:
-	    {
-		Uint num_free = funp->num_free;
-		int i;
-
-		hp = HAlloc(p, 3 + 2*num_free);
-		val = NIL;
-		for (i = num_free-1; i >= 0; i--) {
-		    val = CONS(hp, funp->env[i], val);
-		    hp += 2;
-		}
-	    }
-	    break;
-	case am_refc:
-	    val = erts_make_integer(erts_atomic_read_nob(&funp->fe->refc), p);
-	    hp = HAlloc(p, 3);
-	    break;
-	case am_arity:
-	    hp = HAlloc(p, 3);
-	    val = make_small(funp->arity);
-	    break;
-	case am_name:
-            {
-                const ErtsCodeMFA *mfa = erts_get_fun_mfa(funp->fe);
-                hp = HAlloc(p, 3);
-                val = mfa->function;
-            }
-            break;
-	default:
-	    goto error;
-	}
-    } else if (is_export(fun)) {
-	Export* exp = (Export *) ((UWord) (export_val(fun))[1]);
-	switch (what) {
-	case am_type:
-	    hp = HAlloc(p, 3);
-	    val = am_external;
-	    break;
-	case am_pid:
-	    hp = HAlloc(p, 3);
-	    val = am_undefined;
-	    break;
-	case am_module:
-	    hp = HAlloc(p, 3);
-	    val = exp->info.mfa.module;
-	    break;
-	case am_new_index:
-	    hp = HAlloc(p, 3);
-	    val = am_undefined;
-	    break;
-	case am_new_uniq:
-	    hp = HAlloc(p, 3);
-	    val = am_undefined;
-	    break;
-	case am_index:
-	    hp = HAlloc(p, 3);
-	    val = am_undefined;
-	    break;
-	case am_uniq:
-	    hp = HAlloc(p, 3);
-	    val = am_undefined;
-	    break;
-	case am_env:
-	    hp = HAlloc(p, 3);
-	    val = NIL;
-	    break;
-	case am_refc:
-	    hp = HAlloc(p, 3);
-	    val = am_undefined;
-	    break;
-	case am_arity:
-	    hp = HAlloc(p, 3);
-	    val = make_small(exp->info.mfa.arity);
-	    break;
-	case am_name:
-	    hp = HAlloc(p, 3);
-	    val = exp->info.mfa.function;
-	    break;
-	default:
-	    goto error;
-	}
-    } else {
-    error:
-	BIF_ERROR(p, BADARG);
+    if (is_not_any_fun(fun)) {
+        BIF_ERROR(p, BADARG);
     }
+
+    funp = (ErlFunThing *) fun_val(fun);
+
+    if (is_local_fun(funp)) {
+        fe = funp->entry.fun;
+        mfa = erts_get_fun_mfa(fe);
+    } else {
+        ASSERT(is_external_fun(funp) && funp->next == NULL);
+        mfa = &(funp->entry.exp)->info.mfa;
+        fe = NULL;
+    }
+
+    switch (what) {
+    case am_type:
+        val = is_local_fun(funp) ? am_local : am_external;
+        hp = HAlloc(p, 3);
+        break;
+    case am_pid:
+        val = is_local_fun(funp) ? funp->creator : am_undefined;
+        hp = HAlloc(p, 3);
+        break;
+    case am_module:
+        val = mfa->module;
+        hp = HAlloc(p, 3);
+        break;
+    case am_new_index:
+        val = is_local_fun(funp) ? make_small(fe->index) : am_undefined;
+        hp = HAlloc(p, 3);
+        break;
+    case am_new_uniq:
+        val = is_local_fun(funp) ? new_binary(p, fe->uniq, 16) :
+                                   am_undefined;
+        hp = HAlloc(p, 3);
+        break;
+    case am_index:
+        val = is_local_fun(funp) ? make_small(fe->old_index) : am_undefined;
+        hp = HAlloc(p, 3);
+        break;
+    case am_uniq:
+        val = is_local_fun(funp) ? make_small(fe->old_uniq) : am_undefined;
+        hp = HAlloc(p, 3);
+        break;
+    case am_env:
+        {
+            Uint num_free = funp->num_free;
+            int i;
+
+            hp = HAlloc(p, 3 + 2 * num_free);
+            val = NIL;
+
+            for (i = num_free - 1; i >= 0; i--) {
+                val = CONS(hp, funp->env[i], val);
+                hp += 2;
+            }
+        }
+        break;
+    case am_refc:
+        if (is_local_fun(funp)) {
+            val = erts_make_integer(erts_atomic_read_nob(&fe->refc), p);
+        } else {
+            val = am_undefined;
+        }
+
+        hp = HAlloc(p, 3);
+        break;
+    case am_arity:
+        val = make_small(funp->arity);
+        hp = HAlloc(p, 3);
+        break;
+    case am_name:
+        hp = HAlloc(p, 3);
+        val = mfa->function;
+        break;
+    default:
+        BIF_ERROR(p, BADARG);
+    }
+
     return TUPLE2(hp, what, val);
 }
 
@@ -3658,25 +3625,26 @@ fun_info_mfa_1(BIF_ALIST_1)
     Eterm fun = BIF_ARG_1;
     Eterm* hp;
 
-    if (is_fun(fun)) {
+    if (is_any_fun(fun)) {
         const ErtsCodeMFA *mfa;
         ErlFunThing* funp;
 
         funp = (ErlFunThing *) fun_val(fun);
-        mfa = erts_get_fun_mfa(funp->fe);
+
+        if (is_local_fun(funp)) {
+            mfa = erts_get_fun_mfa(funp->entry.fun);
+        } else {
+            ASSERT(is_external_fun(funp) && funp->next == NULL);
+            mfa = &(funp->entry.exp)->info.mfa;
+        }
 
         hp = HAlloc(p, 4);
         BIF_RET(TUPLE3(hp,
-                       (funp->fe)->module,
+                       mfa->module,
                        mfa->function,
                        make_small(funp->arity)));
-    } else if (is_export(fun)) {
-	Export* exp = (Export *) ((UWord) (export_val(fun))[1]);
-	hp = HAlloc(p, 4);
-	BIF_RET(TUPLE3(hp,exp->info.mfa.module,
-                       exp->info.mfa.function,
-                       make_small(exp->info.mfa.arity)));
     }
+
     BIF_ERROR(p, BADARG);
 }
 

--- a/erts/emulator/beam/erl_bif_op.c
+++ b/erts/emulator/beam/erl_bif_op.c
@@ -251,19 +251,14 @@ Eterm erl_is_function(Process* p, Eterm arg1, Eterm arg2)
 	goto error;
     }
 
-    if (is_fun(arg1)) {
+    if (is_any_fun(arg1)) {
 	ErlFunThing* funp = (ErlFunThing *) fun_val(arg1);
 
 	if (funp->arity == (Uint) arity) {
 	    BIF_RET(am_true);
 	}
-    } else if (is_export(arg1)) {
-	Export* exp = (Export *) (export_val(arg1)[1]);
-
-	if (exp->info.mfa.arity == (Uint) arity) {
-	    BIF_RET(am_true);
-	}
     }
+
     BIF_RET(am_false);
 }
 

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -1459,7 +1459,8 @@ erts_set_trace_pattern(Process*p, ErtsCodeMFA *mfa, int specified,
                 ep->info.op = BeamOpCodeAddr(op_i_func_info_IaaI);
 #endif
                 ep->trampoline.common.op = BeamOpCodeAddr(op_trace_jump_W);
-                ep->trampoline.trace.address = (BeamInstr) ep->addresses[code_ix];
+                ep->trampoline.trace.address =
+                    (BeamInstr) ep->dispatch.addresses[code_ix];
             }
 
             erts_set_export_trace(ci_rw, match_prog_set, 0);
@@ -1687,7 +1688,8 @@ uninstall_exp_breakpoints(BpFunctions* f)
 
         if (erts_is_export_trampoline_active(ep, code_ix)) {
             ASSERT(BeamIsOpCode(ep->trampoline.common.op, op_trace_jump_W));
-            ep->addresses[code_ix] = (ErtsCodePtr)ep->trampoline.trace.address;
+            ep->dispatch.addresses[code_ix] =
+                (ErtsCodePtr)ep->trampoline.trace.address;
         }
     }
 }

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -1278,16 +1278,14 @@ erts_garbage_collect_literals(Process* p, Eterm* literals,
      */
 
     while (oh) {
-	if (IS_MOVED_BOXED(oh->thing_word)) {
-	    struct erl_off_heap_header* ptr;
+        if (IS_MOVED_BOXED(oh->thing_word)) {
+            struct erl_off_heap_header* ptr;
 
-            /*
-	     * This off-heap object has been copied to the heap.
-	     * We must increment its reference count and
-	     * link it into the MSO list for the process.
-	     */
+            /* This off-heap object has been copied to the heap.
+             * We must increment its reference count and
+             * link it into the MSO list for the process.*/
 
-	    ptr = (struct erl_off_heap_header*) boxed_val(oh->thing_word);
+            ptr = (struct erl_off_heap_header*) boxed_val(oh->thing_word);
             switch (thing_subtag(ptr->thing_word)) {
             case REFC_BINARY_SUBTAG:
                 {
@@ -1297,7 +1295,10 @@ erts_garbage_collect_literals(Process* p, Eterm* literals,
                 }
             case FUN_SUBTAG:
                 {
-                    ErlFunEntry* fe = ((ErlFunThing*)ptr)->fe;
+                    /* We _KNOW_ that this is a local fun, otherwise it would
+                     * not be part of the off-heap list. */
+                    ErlFunEntry* fe = ((ErlFunThing*)ptr)->entry.fun;
+                    ASSERT(is_local_fun((ErlFunThing*)ptr));
                     erts_refc_inc(&fe->refc, 2);
                     break;
                 }
@@ -1319,10 +1320,12 @@ erts_garbage_collect_literals(Process* p, Eterm* literals,
                     break;
                 }
             }
-	    *prev = ptr;
-	    prev = &ptr->next;
-	}
-	oh = oh->next;
+
+            *prev = ptr;
+            prev = &ptr->next;
+        }
+
+        oh = oh->next;
     }
 
     if (prev) {
@@ -2494,13 +2497,25 @@ erts_copy_one_frag(Eterm** hpp, ErlOffHeap* off_heap,
 		if (!is_magic_ref_thing(fhp - 1))
 		    goto the_default;
 	    case REFC_BINARY_SUBTAG:
-	    case FUN_SUBTAG:
 	    case EXTERNAL_PID_SUBTAG:
 	    case EXTERNAL_PORT_SUBTAG:
 	    case EXTERNAL_REF_SUBTAG:
 		oh = (struct erl_off_heap_header*) (hp-1);
 		cpy_sz = thing_arityval(val);
 		goto cpy_words;
+            case FUN_SUBTAG:
+            {
+                ErlFunThing *funp = (ErlFunThing*) (fhp - 1);
+
+                if (is_local_fun(funp)) {
+                    oh = (struct erl_off_heap_header*) (hp - 1);
+                } else {
+                    ASSERT(is_external_fun(funp) && funp->next == NULL);
+                }
+
+                cpy_sz = thing_arityval(val);
+                goto cpy_words;
+            }
 	    default:
 	    the_default:
 		cpy_sz = header_arity(val);
@@ -3026,10 +3041,17 @@ sweep_off_heap(Process *p, int fullsweep)
 		}
 	    case FUN_SUBTAG:
 		{
-		    ErlFunEntry* fe = ((ErlFunThing*)ptr)->fe;
-		    if (erts_refc_dectest(&fe->refc, 0) == 0) {
-			erts_erase_fun_entry(fe);
-		    }
+                    ErlFunThing* funp = ((ErlFunThing*)ptr);
+
+                    if (is_local_fun(funp)) {
+                        ErlFunEntry* fe = funp->entry.fun;
+
+                        if (erts_refc_dectest(&fe->refc, 0) == 0) {
+                            erts_erase_fun_entry(fe);
+                        }
+                    } else {
+                        ASSERT(is_external_fun(funp) && funp->next == NULL);
+                    }
 		    break;
 		}
 	    case REF_SUBTAG:
@@ -3851,8 +3873,14 @@ erts_check_off_heap2(Process *p, Eterm *htop)
 	case REFC_BINARY_SUBTAG:
 	    refc = erts_refc_read(&u.pb->val->intern.refc, 1);
 	    break;
-	case FUN_SUBTAG:
-	    refc = erts_refc_read(&u.fun->fe->refc, 1);
+        case FUN_SUBTAG:
+            if (is_local_fun(u.fun)) {
+                refc = erts_refc_read(&u.fun->entry.fun->refc, 1);
+            } else {
+                /* Export fun, fake a valid refc. */
+                ASSERT(is_external_fun(u.fun) && u.fun->next == NULL);
+                refc = 1;
+            }
 	    break;
 	case EXTERNAL_PID_SUBTAG:
 	case EXTERNAL_PORT_SUBTAG:

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -3147,10 +3147,17 @@ BIF_RETTYPE erts_internal_term_type_1(BIF_ALIST_1) {
             switch (hdr & _TAG_HEADER_MASK) {
                 case ARITYVAL_SUBTAG:
                     BIF_RET(ERTS_MAKE_AM("tuple"));
-                case EXPORT_SUBTAG:
-                    BIF_RET(ERTS_MAKE_AM("export"));
                 case FUN_SUBTAG:
-                    BIF_RET(ERTS_MAKE_AM("fun"));
+                    {
+                        ErlFunThing *funp = (ErlFunThing *)fun_val(obj);
+
+                        if (is_local_fun(funp)) {
+                            BIF_RET(ERTS_MAKE_AM("fun"));
+                        } else {
+                            ASSERT(is_external_fun(funp) && funp->next == NULL);
+                            BIF_RET(ERTS_MAKE_AM("export"));
+                        }
+                    }
                 case MAP_SUBTAG:
                     switch (MAP_HEADER_TYPE(hdr)) {
                         case MAP_HEADER_TAG_FLATMAP_HEAD :

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -171,9 +171,12 @@ erts_cleanup_offheap(ErlOffHeap *offheap)
             erts_bin_release(u.pb->val);
 	    break;
 	case FUN_SUBTAG:
-	    if (erts_refc_dectest(&u.fun->fe->refc, 0) == 0) {
-		erts_erase_fun_entry(u.fun->fe);		    
-	    }
+            /* We _KNOW_ that this is a local fun, otherwise it would not
+             * be part of the off-heap list. */
+            ASSERT(is_local_fun(u.fun));
+            if (erts_refc_dectest(&u.fun->entry.fun->refc, 0) == 0) {
+                erts_erase_fun_entry(u.fun->entry.fun);
+            }
 	    break;
 	case REF_SUBTAG:
 	    ASSERT(is_magic_ref_thing(u.hdr));

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1166,7 +1166,7 @@ int enif_is_empty_list(ErlNifEnv* env, ERL_NIF_TERM term)
 
 int enif_is_fun(ErlNifEnv* env, ERL_NIF_TERM term)
 {
-    return is_fun(term);
+    return is_any_fun(term);
 }
 
 int enif_is_pid(ErlNifEnv* env, ERL_NIF_TERM term)
@@ -1214,7 +1214,6 @@ ErlNifTermType enif_term_type(ErlNifEnv* env, ERL_NIF_TERM term) {
         return ERL_NIF_TERM_TYPE_BITSTRING;
     case FLOAT_DEF:
         return ERL_NIF_TERM_TYPE_FLOAT;
-    case EXPORT_DEF:
     case FUN_DEF:
         return ERL_NIF_TERM_TYPE_FUN;
     case BIG_DEF:

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -455,6 +455,7 @@ sig_enqueue_trace(Process *c_p, ErtsMessage **sigp, int op,
             ErtsExitSignalData *xsigd;
 
             ASSERT(type == ERTS_SIG_Q_TYPE_GEN_EXIT);
+            (void)type;
 
             xsigd = get_exit_signal_data(sig);
             reason = xsigd->reason;

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -708,7 +708,7 @@ dump_externally(fmtfn_t to, void *to_arg, Eterm term)
     byte* s; 
     byte* p;
 
-    if (is_fun(term)) {
+    if (is_any_fun(term)) {
 	/*
 	 * The fun's environment used to cause trouble. There were
 	 * two kind of problems:

--- a/erts/emulator/beam/erl_term.c
+++ b/erts/emulator/beam/erl_term.c
@@ -121,7 +121,7 @@ ET_DEFINE_CHECKED(Uint,arityval,Eterm,is_sane_arity_value);
 ET_DEFINE_CHECKED(Uint,thing_arityval,Eterm,is_thing);
 ET_DEFINE_CHECKED(Uint,thing_subtag,Eterm,is_thing);
 ET_DEFINE_CHECKED(Eterm*,binary_val,Wterm,is_binary);
-ET_DEFINE_CHECKED(Eterm*,fun_val,Wterm,is_fun);
+ET_DEFINE_CHECKED(Eterm*,fun_val,Wterm,is_any_fun);
 ET_DEFINE_CHECKED(int,bignum_header_is_neg,Eterm,_is_bignum_header);
 ET_DEFINE_CHECKED(Eterm,bignum_header_neg,Eterm,_is_bignum_header);
 ET_DEFINE_CHECKED(Uint,bignum_header_arity,Eterm,_is_bignum_header);
@@ -144,7 +144,6 @@ ET_DEFINE_CHECKED(struct erl_node_*,external_port_node,Wterm,is_external_port);
 ET_DEFINE_CHECKED(Uint,external_ref_data_words,Wterm,is_external_ref);
 ET_DEFINE_CHECKED(Uint32*,external_ref_data,Wterm,is_external_ref);
 ET_DEFINE_CHECKED(struct erl_node_*,external_ref_node,Eterm,is_external_ref);
-ET_DEFINE_CHECKED(Eterm*,export_val,Wterm,is_export);
 ET_DEFINE_CHECKED(Uint,external_thing_data_words,ExternalThing*,is_thing_ptr);
 
 ET_DEFINE_CHECKED(Eterm,make_cp,ErtsCodePtr,_is_legal_cp);

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -129,7 +129,6 @@ struct erl_node_; /* Declared in erl_node_tables.h */
 #define REF_SUBTAG		(0x4 << _TAG_PRIMARY_SIZE) /* REF */
 #define FUN_SUBTAG		(0x5 << _TAG_PRIMARY_SIZE) /* FUN */
 #define FLOAT_SUBTAG		(0x6 << _TAG_PRIMARY_SIZE) /* FLOAT */
-#define EXPORT_SUBTAG		(0x7 << _TAG_PRIMARY_SIZE) /* FLOAT */
 #define _BINARY_XXX_MASK	(0x3 << _TAG_PRIMARY_SIZE)
 #define REFC_BINARY_SUBTAG	(0x8 << _TAG_PRIMARY_SIZE) /* BINARY */
 #define HEAP_BINARY_SUBTAG	(0x9 << _TAG_PRIMARY_SIZE) /* BINARY */
@@ -146,7 +145,6 @@ struct erl_node_; /* Declared in erl_node_tables.h */
 #define _TAG_HEADER_POS_BIG        (TAG_PRIMARY_HEADER|POS_BIG_SUBTAG)
 #define _TAG_HEADER_NEG_BIG        (TAG_PRIMARY_HEADER|NEG_BIG_SUBTAG)
 #define _TAG_HEADER_FLOAT          (TAG_PRIMARY_HEADER|FLOAT_SUBTAG)
-#define _TAG_HEADER_EXPORT         (TAG_PRIMARY_HEADER|EXPORT_SUBTAG)
 #define _TAG_HEADER_REF            (TAG_PRIMARY_HEADER|REF_SUBTAG)
 #define _TAG_HEADER_REFC_BIN       (TAG_PRIMARY_HEADER|REFC_BINARY_SUBTAG)
 #define _TAG_HEADER_HEAP_BIN       (TAG_PRIMARY_HEADER|HEAP_BINARY_SUBTAG)
@@ -374,29 +372,15 @@ _ET_DECLARE_CHECKED(Eterm*,binary_val,Wterm)
 /* process binaries stuff (special case of binaries) */
 #define HEADER_PROC_BIN	_make_header(PROC_BIN_SIZE-1,_TAG_HEADER_REFC_BIN)
 
-/* fun & export objects */
-#define is_any_fun(x)   (is_fun((x)) || is_export((x)))
-#define is_not_any_fun(x) (!is_any_fun((x)))
-
 /* fun objects */
-#define HEADER_FUN		_make_header(ERL_FUN_SIZE-2,_TAG_HEADER_FUN)
-#define is_fun_header(x)	((x) == HEADER_FUN)
-#define make_fun(x)		make_boxed((Eterm*)(x))
-#define is_fun(x)		(is_boxed((x)) && is_fun_header(*boxed_val((x))))
-#define is_not_fun(x)		(!is_fun((x)))
+#define HEADER_FUN              _make_header(ERL_FUN_SIZE-2,_TAG_HEADER_FUN)
+#define is_fun_header(x)        ((x) == HEADER_FUN)
+#define make_fun(x)             make_boxed((Eterm*)(x))
+#define is_any_fun(x)           (is_boxed((x)) && is_fun_header(*boxed_val((x))))
+#define is_not_any_fun(x)       (!is_any_fun((x)))
 #define _unchecked_fun_val(x)   _unchecked_boxed_val((x))
 _ET_DECLARE_CHECKED(Eterm*,fun_val,Wterm)
 #define fun_val(x)		_ET_APPLY(fun_val,(x))
-
-/* export access methods */
-#define make_export(x)	 make_boxed((x))
-#define is_export(x)     (is_boxed((x)) && is_export_header(*boxed_val((x))))
-#define is_not_export(x) (!is_export((x)))
-#define _unchecked_export_val(x)   _unchecked_boxed_val(x)
-_ET_DECLARE_CHECKED(Eterm*,export_val,Wterm)
-#define export_val(x)	_ET_APPLY(export_val,(x))
-#define is_export_header(x)	((x) == HEADER_EXPORT)
-#define HEADER_EXPORT   _make_header(1,_TAG_HEADER_EXPORT)
 
 /* bignum access methods */
 #define make_pos_bignum_header(sz)	_make_header((sz),_TAG_HEADER_POS_BIG)
@@ -1398,7 +1382,6 @@ _ET_DECLARE_CHECKED(Uint,loader_y_reg_index,Uint)
 #define EXTERNAL_PID_DEF	0x6
 #define PORT_DEF		0x7
 #define EXTERNAL_PORT_DEF	0x8
-#define EXPORT_DEF		0x9
 #define FUN_DEF			0xa
 #define REF_DEF			0xb
 #define EXTERNAL_REF_DEF	0xc
@@ -1468,7 +1451,6 @@ ERTS_GLB_INLINE unsigned tag_val_def(Wterm x)
 	    case (_TAG_HEADER_NEG_BIG >> _TAG_PRIMARY_SIZE):	return BIG_DEF;
 	    case (_TAG_HEADER_REF >> _TAG_PRIMARY_SIZE):	return REF_DEF;
 	    case (_TAG_HEADER_FLOAT >> _TAG_PRIMARY_SIZE):	return FLOAT_DEF;
-	    case (_TAG_HEADER_EXPORT >> _TAG_PRIMARY_SIZE):     return EXPORT_DEF;
 	    case (_TAG_HEADER_FUN >> _TAG_PRIMARY_SIZE):	return FUN_DEF;
 	    case (_TAG_HEADER_EXTERNAL_PID >> _TAG_PRIMARY_SIZE):	return EXTERNAL_PID_DEF;
 	    case (_TAG_HEADER_EXTERNAL_PORT >> _TAG_PRIMARY_SIZE):	return EXTERNAL_PORT_DEF;

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -3683,45 +3683,49 @@ enc_term_int(TTBEncodeContext* ctx, ErtsAtomCacheMap *acmp, Eterm obj, byte* ep,
 		}
 	    }
 	    break;
-	case EXPORT_DEF:
-	    {
-		Export* exp = *((Export **) (export_val(obj) + 1));
-                *ep++ = EXPORT_EXT;
-                ep = enc_atom(acmp, exp->info.mfa.module, ep, dflags);
-                ep = enc_atom(acmp, exp->info.mfa.function, ep, dflags);
-                ep = enc_term(acmp, make_small(exp->info.mfa.arity),
-                              ep, dflags, off_heap);
-		break;
-	    }
-	    break;
-	case FUN_DEF:
-	    {
-		ErlFunThing* funp = (ErlFunThing *) fun_val(obj);
-		int ei;
+        case FUN_DEF:
+            {
+                ErlFunThing* funp = (ErlFunThing *) fun_val(obj);
 
-                *ep++ = NEW_FUN_EXT;
-                WSTACK_PUSH2(s, ENC_PATCH_FUN_SIZE,
-                             (UWord) ep); /* Position for patching in size */
-                ep += 4;
-                *ep = funp->arity;
-                ep += 1;
-                sys_memcpy(ep, funp->fe->uniq, 16);
-                ep += 16;
-                put_int32(funp->fe->index, ep);
-                ep += 4;
-                put_int32(funp->num_free, ep);
-                ep += 4;
-                ep = enc_atom(acmp, funp->fe->module, ep, dflags);
-                ep = enc_term(acmp, make_small(funp->fe->old_index), ep, dflags, off_heap);
-                ep = enc_term(acmp, make_small(funp->fe->old_uniq), ep, dflags, off_heap);
-                ep = enc_pid(acmp, funp->creator, ep, dflags);
+                if (is_local_fun(funp)) {
+                    ErlFunEntry* fe = funp->entry.fun;
+                    int ei;
 
-		for (ei = funp->num_free-1; ei >= 0; ei--) {
-		    WSTACK_PUSH2(s, ENC_TERM, (UWord) funp->env[ei]);
-		}
-	    }
-	    break;
-	}
+                    *ep++ = NEW_FUN_EXT;
+                    WSTACK_PUSH2(s, ENC_PATCH_FUN_SIZE,
+                                (UWord) ep); /* Position for patching in size */
+                    ep += 4;
+                    *ep = funp->arity;
+                    ep += 1;
+                    sys_memcpy(ep, fe->uniq, 16);
+                    ep += 16;
+                    put_int32(fe->index, ep);
+                    ep += 4;
+                    put_int32(funp->num_free, ep);
+                    ep += 4;
+                    ep = enc_atom(acmp, fe->module, ep, dflags);
+                    ep = enc_term(acmp, make_small(fe->old_index), ep, dflags, off_heap);
+                    ep = enc_term(acmp, make_small(fe->old_uniq), ep, dflags, off_heap);
+                    ep = enc_pid(acmp, funp->creator, ep, dflags);
+
+                    for (ei = funp->num_free-1; ei >= 0; ei--) {
+                        WSTACK_PUSH2(s, ENC_TERM, (UWord) funp->env[ei]);
+                    }
+                } else {
+                    Export *exp = funp->entry.exp;
+
+                    ASSERT(is_external_fun(funp) && funp->next == NULL);
+
+                    *ep++ = EXPORT_EXT;
+                    ep = enc_atom(acmp, exp->info.mfa.module, ep, dflags);
+                    ep = enc_atom(acmp, exp->info.mfa.function, ep, dflags);
+                    ep = enc_term(acmp, make_small(exp->info.mfa.arity),
+                                 ep, dflags, off_heap);
+
+                }
+            }
+            break;
+        }
     }
     DESTROY_WSTACK(s);
     if (ctx) {
@@ -4584,42 +4588,45 @@ dec_term_atom_common:
 		}
 		break;
 	    }
-	case EXPORT_EXT:
-	    {
-		Eterm mod;
-		Eterm name;
-		Eterm temp;
-		Sint arity;
+        case EXPORT_EXT:
+            {
+                ErlFunThing *funp;
+                Export *export;
+                Eterm mod;
+                Eterm name;
+                Eterm temp;
+                Sint arity;
 
-		if ((ep = dec_atom(edep, ep, &mod)) == NULL) {
-		    goto error;
-		}
-		if ((ep = dec_atom(edep, ep, &name)) == NULL) {
-		    goto error;
-		}
-		factory->hp = hp;
-		ep = dec_term(edep, factory, ep, &temp, NULL, 0);
-		hp = factory->hp;
-		if (ep == NULL) {
-		    goto error;
-		}
-		if (!is_small(temp)) {
-		    goto error;
-		}
-		arity = signed_val(temp);
-		if (arity < 0) {
-		    goto error;
-		}
-		if (edep && (edep->flags & ERTS_DIST_EXT_BTT_SAFE)) {
-		    if (!erts_active_export_entry(mod, name, arity))
-			goto error;
+                if ((ep = dec_atom(edep, ep, &mod)) == NULL) {
+                    goto error;
                 }
-		*objp = make_export(hp);
-		*hp++ = HEADER_EXPORT;
-		*hp++ = (Eterm) erts_export_get_or_make_stub(mod, name, arity);
-		break;
-	    }
-	    break;
+                if ((ep = dec_atom(edep, ep, &name)) == NULL) {
+                    goto error;
+                }
+                factory->hp = hp;
+                ep = dec_term(edep, factory, ep, &temp, NULL, 0);
+                if (ep == NULL) {
+                    goto error;
+                }
+                if (!is_small(temp)) {
+                    goto error;
+                }
+                arity = signed_val(temp);
+                if (arity < 0) {
+                    goto error;
+                }
+                if (edep && (edep->flags & ERTS_DIST_EXT_BTT_SAFE)) {
+                    if (!erts_active_export_entry(mod, name, arity)) {
+                        goto error;
+                    }
+                }
+
+                export = erts_export_get_or_make_stub(mod, name, arity);
+                funp = erts_new_export_fun_thing(&factory->hp, export, arity);
+                hp = factory->hp;
+                *objp = make_fun(funp);
+            }
+            break;
 	case MAP_EXT:
 	    {
 		Uint32 size,n;
@@ -4732,8 +4739,9 @@ dec_term_atom_common:
 		funp->next = factory->off_heap->first;
 		factory->off_heap->first = (struct erl_off_heap_header*)funp;
 
-		funp->fe = erts_put_fun_entry2(module, old_uniq, old_index,
-					       uniq, index, arity);
+                funp->entry.fun = erts_put_fun_entry2(module, old_uniq,
+                                                      old_index, uniq,
+                                                      index, arity);
 		funp->arity = arity;
 		hp = factory->hp;
 
@@ -5258,52 +5266,55 @@ encode_size_struct_int(TTBSizeContext* ctx, ErtsAtomCacheMap *acmp, Eterm obj,
             }
 	    break;
         }
-	case FUN_DEF:
-	    {
-		ErlFunThing* funp = (ErlFunThing *) fun_val(obj);
+        case FUN_DEF:
+            {
+                ErlFunThing *funp = (ErlFunThing *) fun_val(obj);
 
-                result += 20+1+1+4;	/* New ID + Tag */
-                result += 4; /* Length field (number of free variables */
-                result += encode_size_struct2(acmp, funp->creator, dflags);
-                result += encode_size_struct2(acmp, funp->fe->module, dflags);
-                result += 2 * (1+4);	/* Index, Uniq */
-		if (funp->num_free > 1) {
-		    WSTACK_PUSH2(s, (UWord) (funp->env + 1),
-				    (UWord) TERM_ARRAY_OP(funp->num_free-1));
-		}
-		if (funp->num_free != 0) {
-		    obj = funp->env[0];
-		    continue; /* big loop */
-		}
-		break;
-	    }
+                if (is_local_fun(funp)) {
+                    result += 20+1+1+4;	/* New ID + Tag */
+                    result += 4; /* Length field (number of free variables */
+                    result += encode_size_struct2(acmp, funp->creator, dflags);
+                    result += encode_size_struct2(acmp, funp->entry.fun->module, dflags);
+                    result += 2 * (1+4);	/* Index, Uniq */
+                    if (funp->num_free > 1) {
+                        WSTACK_PUSH2(s, (UWord) (funp->env + 1),
+                                    (UWord) TERM_ARRAY_OP(funp->num_free-1));
+                    }
+                    if (funp->num_free != 0) {
+                        obj = funp->env[0];
+                        continue; /* big loop */
+                    }
+                } else {
+                    Export* ep = funp->entry.exp;
+                    Uint tmp_result = result;
 
-	case EXPORT_DEF:
-	    {
-		Export* ep = *((Export **) (export_val(obj) + 1));
-                Uint tmp_result = result;
-		result += 1;
-		result += encode_size_struct2(acmp, ep->info.mfa.module, dflags);
-		result += encode_size_struct2(acmp, ep->info.mfa.function, dflags);
-		result += encode_size_struct2(acmp, make_small(ep->info.mfa.arity), dflags);
-                if (dflags & DFLAG_PENDING_CONNECT) {
-                    Uint csz;
-		    ASSERT(ctx);
+                    ASSERT(is_external_fun(funp) && funp->next == NULL);
 
-                    /*
-                     * Fallback is 1 + 1 + Module size + Function size, that is,
-                     * the hopefull index + hopefull encoding is larger...
-                     */
-                    ASSERT(dflags & DFLAG_EXPORT_PTR_TAG);
-                    csz = tmp_result - ctx->last_result;
-                    /* potentially multiple elements leading up to hopefull entry */
-                    vlen += (csz/MAX_SYSIOVEC_IOVLEN + 1
-			     + 1); /* hopefull entry */
-                    result += 4; /* hopefull index */
-                    ctx->last_result = result;
+                    result += 1;
+                    result += encode_size_struct2(acmp, ep->info.mfa.module, dflags);
+                    result += encode_size_struct2(acmp, ep->info.mfa.function, dflags);
+                    result += encode_size_struct2(acmp, make_small(ep->info.mfa.arity), dflags);
+
+                    if (dflags & DFLAG_PENDING_CONNECT) {
+                        Uint csz;
+                        ASSERT(ctx);
+
+                        /* Fallback is 1 + 1 + Module size + Function size,
+                         * that is, the hopeful index + hopeful encoding is
+                         * larger... */
+                        ASSERT(dflags & DFLAG_EXPORT_PTR_TAG);
+                        csz = tmp_result - ctx->last_result;
+
+                        /* Potentially multiple elements leading up to hopeful
+                         * entry */
+                        vlen += (csz/MAX_SYSIOVEC_IOVLEN + 1
+                                 + 1); /* hopeful entry */
+                        result += 4; /* hopeful index */
+                        ctx->last_result = result;
+                    }
                 }
-	    }
-	    break;
+                break;
+        }
 
 	default:
 	    erts_exit(ERTS_ERROR_EXIT,"Internal data structure error (in encode_size_struct_int) %x\n",
@@ -5619,7 +5630,7 @@ init_done:
 	    break;
 	case EXPORT_EXT:
 	    terms += 3;
-	    heap_size += 2;
+	    heap_size += ERL_FUN_SIZE;
 	    break;
 	case NEW_FUN_EXT:
 	    {

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1732,8 +1732,10 @@ int erts_beam_jump_table(void);
 ERTS_GLB_INLINE void dtrace_pid_str(Eterm pid, char *process_buf);
 ERTS_GLB_INLINE void dtrace_proc_str(Process *process, char *process_buf);
 ERTS_GLB_INLINE void dtrace_port_str(Port *port, char *port_buf);
-ERTS_GLB_INLINE void dtrace_fun_decode(Process *process, ErtsCodeMFA *mfa,
-				       char *process_buf, char *mfa_buf);
+ERTS_GLB_INLINE void dtrace_fun_decode(Process *process,
+                                       const ErtsCodeMFA *mfa,
+                                       char *process_buf,
+                                       char *mfa_buf);
 
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 
@@ -1766,7 +1768,7 @@ dtrace_port_str(Port *port, char *port_buf)
 }
 
 ERTS_GLB_INLINE void
-dtrace_fun_decode(Process *process, ErtsCodeMFA *mfa,
+dtrace_fun_decode(Process *process, const ErtsCodeMFA *mfa,
                   char *process_buf, char *mfa_buf)
 {
     if (process_buf) {

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -376,21 +376,26 @@ protected:
         }
     }
 
-    /* Returns the current code address for the export entry in `Src`
+    /* Returns the current code address for the `Export` or `ErlFunEntry` in
+     * `Src`.
      *
-     * Export tracing, save_calls, etc is implemented by shared fragments that
-     * assume that the export entry is in ARG1, so we have to copy it over if it
-     * isn't already. */
-    arm::Mem emit_setup_export_call(const arm::Gp &Src) {
-        return emit_setup_export_call(Src, active_code_ix);
+     * Export tracing, save_calls, etc are implemented by shared fragments that
+     * assume that the respective entry is in ARG1, so we have to copy it over
+     * if it isn't already. */
+    arm::Mem emit_setup_dispatchable_call(const arm::Gp &Src) {
+        return emit_setup_dispatchable_call(Src, active_code_ix);
     }
 
-    arm::Mem emit_setup_export_call(const arm::Gp &Src,
-                                    const arm::Gp &CodeIndex) {
+    arm::Mem emit_setup_dispatchable_call(const arm::Gp &Src,
+                                          const arm::Gp &CodeIndex) {
         if (ARG1 != Src) {
             a.mov(ARG1, Src);
         }
-        ERTS_CT_ASSERT(offsetof(Export, addresses) == 0);
+
+        ERTS_CT_ASSERT(offsetof(ErlFunEntry, dispatch) == 0);
+        ERTS_CT_ASSERT(offsetof(Export, dispatch) == 0);
+        ERTS_CT_ASSERT(offsetof(ErtsDispatchable, addresses) == 0);
+
         return arm::Mem(ARG1, CodeIndex, arm::lsl(3));
     }
 

--- a/erts/emulator/beam/jit/arm/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.cpp
@@ -151,7 +151,7 @@ void BeamGlobalAssembler::emit_bif_export_trap() {
 
     emit_leave_erlang_frame();
 
-    branch(emit_setup_export_call(ARG1));
+    branch(emit_setup_dispatchable_call(ARG1));
 }
 
 /* Handles export breakpoints, error handler, jump tracing, and so on.
@@ -232,7 +232,7 @@ void BeamGlobalAssembler::emit_export_trampoline() {
 
         a.cbz(ARG1, labels[process_exit]);
 
-        branch(emit_setup_export_call(ARG1));
+        branch(emit_setup_dispatchable_call(ARG1));
     }
 }
 

--- a/erts/emulator/beam/jit/arm/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bif.cpp
@@ -535,7 +535,7 @@ void BeamGlobalAssembler::emit_call_light_bif_shared() {
     a.bind(trace);
     {
         /* Call the export entry instead of the BIF. */
-        branch(emit_setup_export_call(ARG4));
+        branch(emit_setup_dispatchable_call(ARG4));
     }
 
     a.bind(yield);

--- a/erts/emulator/beam/jit/arm/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/instr_call.cpp
@@ -88,20 +88,20 @@ void BeamGlobalAssembler::emit_dispatch_save_calls() {
     a.mov(TMP1, imm(&the_active_code_index));
     a.ldr(TMP1.w(), arm::Mem(TMP1));
 
-    branch(emit_setup_export_call(ARG1, TMP1));
+    branch(emit_setup_dispatchable_call(ARG1, TMP1));
 }
 
 void BeamModuleAssembler::emit_i_call_ext(const ArgVal &Exp) {
     mov_arg(ARG1, Exp);
 
-    arm::Mem target = emit_setup_export_call(ARG1);
+    arm::Mem target = emit_setup_dispatchable_call(ARG1);
     erlang_call(target);
 }
 
 void BeamModuleAssembler::emit_i_call_ext_only(const ArgVal &Exp) {
     mov_arg(ARG1, Exp);
 
-    arm::Mem target = emit_setup_export_call(ARG1);
+    arm::Mem target = emit_setup_dispatchable_call(ARG1);
     emit_leave_erlang_frame();
     branch(target);
 }
@@ -142,7 +142,7 @@ arm::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
     emit_raise_exception(entry, &apply3_mfa);
 
     a.bind(dispatch);
-    return emit_setup_export_call(ARG1);
+    return emit_setup_dispatchable_call(ARG1);
 }
 
 void BeamModuleAssembler::emit_i_apply() {
@@ -195,7 +195,7 @@ arm::Mem BeamModuleAssembler::emit_fixed_apply(const ArgVal &Arity,
 
     a.bind(dispatch);
 
-    return emit_setup_export_call(ARG1);
+    return emit_setup_dispatchable_call(ARG1);
 }
 
 void BeamModuleAssembler::emit_apply(const ArgVal &Arity) {

--- a/erts/emulator/beam/jit/arm/instr_trace.cpp
+++ b/erts/emulator/beam/jit/arm/instr_trace.cpp
@@ -121,7 +121,7 @@ void BeamGlobalAssembler::emit_debug_bp() {
     a.cbz(ARG1, error);
 
     emit_leave_erlang_frame();
-    branch(emit_setup_export_call(ARG1));
+    branch(emit_setup_dispatchable_call(ARG1));
 
     a.bind(error);
     {

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -942,7 +942,7 @@ void beam_load_finalize_code(LoaderState *stp,
              * code callable. */
             ep->trampoline.not_loaded.deferred = (BeamInstr)address;
         } else {
-            ep->addresses[staging_ix] = address;
+            ep->dispatch.addresses[staging_ix] = address;
         }
     }
 
@@ -983,7 +983,7 @@ void beam_load_finalize_code(LoaderState *stp,
                 erts_refc_dectest(&fun_entry->refc, 1);
             }
 
-            fun_entry->address = beamasm_get_lambda(stp->ba, i);
+            erts_set_fun_code(fun_entry, beamasm_get_lambda(stp->ba, i));
 
             beamasm_patch_lambda(stp->ba,
                                  stp->native_module_rw,

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -1099,7 +1099,9 @@ Export *beam_jit_handle_unloaded_fun(Process *c_p,
     Export *ep;
 
     funp = (ErlFunThing *)fun_val(fun_thing);
-    fe = funp->fe;
+    ASSERT(is_local_fun(funp));
+
+    fe = funp->entry.fun;
     module = fe->module;
 
     ERTS_THR_READ_MEMORY_BARRIER;

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -500,22 +500,29 @@ protected:
         }
     }
 
-    /* Returns the current code address for the export entry in `Src`
+    /* Returns the current code address for the `Export` or `ErlFunEntry` in
+     * `Src`.
      *
-     * Export tracing, save_calls, etc is implemented by shared fragments that
-     * assume that the export entry is in RET, so we have to copy it over if it
-     * isn't already. */
-    x86::Mem emit_setup_export_call(const x86::Gp &Src) {
-        return emit_setup_export_call(Src, active_code_ix);
+     * Export tracing, save_calls, etc are implemented by shared fragments that
+     * assume that the respective entry is in RET, so we have to copy it over
+     * if it isn't already. */
+    x86::Mem emit_setup_dispatchable_call(const x86::Gp &Src) {
+        return emit_setup_dispatchable_call(Src, active_code_ix);
     }
 
-    x86::Mem emit_setup_export_call(const x86::Gp &Src,
-                                    const x86::Gp &CodeIndex) {
+    x86::Mem emit_setup_dispatchable_call(const x86::Gp &Src,
+                                          const x86::Gp &CodeIndex) {
         if (RET != Src) {
             a.mov(RET, Src);
         }
 
-        return x86::qword_ptr(RET, CodeIndex, 3, offsetof(Export, addresses));
+        ERTS_CT_ASSERT(offsetof(ErlFunEntry, dispatch) == 0);
+        ERTS_CT_ASSERT(offsetof(Export, dispatch) == 0);
+
+        return x86::qword_ptr(RET,
+                              CodeIndex,
+                              3,
+                              offsetof(ErtsDispatchable, addresses));
     }
 
     void emit_assert_runtime_stack() {

--- a/erts/emulator/beam/jit/x86/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.cpp
@@ -148,7 +148,7 @@ void BeamGlobalAssembler::emit_bif_export_trap() {
     a.sub(RET, imm(offsetof(Export, info.mfa)));
 
     emit_leave_frame();
-    a.jmp(emit_setup_export_call(RET));
+    a.jmp(emit_setup_dispatchable_call(RET));
 }
 
 /* Handles export breakpoints, error handler, jump tracing, and so on.
@@ -218,7 +218,7 @@ void BeamGlobalAssembler::emit_export_trampoline() {
         a.je(labels[process_exit]);
 
         emit_leave_frame();
-        a.jmp(emit_setup_export_call(RET));
+        a.jmp(emit_setup_dispatchable_call(RET));
     }
 }
 

--- a/erts/emulator/beam/jit/x86/instr_bif.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bif.cpp
@@ -622,7 +622,7 @@ void BeamGlobalAssembler::emit_call_light_bif_shared() {
         a.pop(getCPRef());
 #endif
 
-        x86::Mem destination = emit_setup_export_call(ARG4);
+        x86::Mem destination = emit_setup_dispatchable_call(ARG4);
         a.jmp(destination);
     }
 

--- a/erts/emulator/beam/jit/x86/instr_call.cpp
+++ b/erts/emulator/beam/jit/x86/instr_call.cpp
@@ -116,18 +116,18 @@ void BeamGlobalAssembler::emit_dispatch_save_calls() {
     a.mov(ARG1, imm(&the_active_code_index));
     a.mov(ARG1d, x86::dword_ptr(ARG1));
 
-    a.jmp(emit_setup_export_call(RET, ARG1));
+    a.jmp(emit_setup_dispatchable_call(RET, ARG1));
 }
 
 void BeamModuleAssembler::emit_i_call_ext(const ArgVal &Exp) {
     make_move_patch(RET, imports[Exp.getValue()].patches);
-    x86::Mem destination = emit_setup_export_call(RET);
+    x86::Mem destination = emit_setup_dispatchable_call(RET);
     erlang_call(destination, ARG1);
 }
 
 void BeamModuleAssembler::emit_i_call_ext_only(const ArgVal &Exp) {
     make_move_patch(RET, imports[Exp.getValue()].patches);
-    x86::Mem destination = emit_setup_export_call(RET);
+    x86::Mem destination = emit_setup_dispatchable_call(RET);
 
     emit_leave_frame();
     a.jmp(destination);
@@ -138,7 +138,7 @@ void BeamModuleAssembler::emit_i_call_ext_last(const ArgVal &Exp,
     emit_deallocate(Deallocate);
 
     make_move_patch(RET, imports[Exp.getValue()].patches);
-    x86::Mem destination = emit_setup_export_call(RET);
+    x86::Mem destination = emit_setup_dispatchable_call(RET);
 
     emit_leave_frame();
     a.jmp(destination);
@@ -174,7 +174,7 @@ x86::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
     emit_raise_exception(entry, &apply3_mfa);
     a.bind(dispatch);
 
-    return emit_setup_export_call(RET);
+    return emit_setup_dispatchable_call(RET);
 }
 
 void BeamModuleAssembler::emit_i_apply() {
@@ -226,7 +226,7 @@ x86::Mem BeamModuleAssembler::emit_fixed_apply(const ArgVal &Arity,
     emit_raise_exception(entry, &apply3_mfa);
     a.bind(dispatch);
 
-    return emit_setup_export_call(RET);
+    return emit_setup_dispatchable_call(RET);
 }
 
 void BeamModuleAssembler::emit_apply(const ArgVal &Arity) {

--- a/erts/emulator/beam/jit/x86/instr_trace.cpp
+++ b/erts/emulator/beam/jit/x86/instr_trace.cpp
@@ -148,7 +148,7 @@ void BeamGlobalAssembler::emit_debug_bp() {
     a.test(RET, RET);
     a.je(error);
 
-    a.jmp(emit_setup_export_call(RET));
+    a.jmp(emit_setup_dispatchable_call(RET));
 
     a.bind(error);
     {

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -939,37 +939,43 @@ tail_recur:
 	    hash = hash*FUNNY_NUMBER4 + sz;
 	    break;
 	}
-    case EXPORT_DEF:
-	{
-	    Export* ep = *((Export **) (export_val(term) + 1));
-
-	    hash = hash * FUNNY_NUMBER11 + ep->info.mfa.arity;
-	    hash = hash*FUNNY_NUMBER1 +
-		(atom_tab(atom_val(ep->info.mfa.module))->slot.bucket.hvalue);
-	    hash = hash*FUNNY_NUMBER1 +
-		(atom_tab(atom_val(ep->info.mfa.function))->slot.bucket.hvalue);
-	    break;
-	}
-
     case FUN_DEF:
-	{
-	    ErlFunThing* funp = (ErlFunThing *) fun_val(term);
-	    Uint num_free = funp->num_free;
+        {
+            ErlFunThing* funp = (ErlFunThing *) fun_val(term);
 
-	    hash = hash * FUNNY_NUMBER10 + num_free;
-	    hash = hash*FUNNY_NUMBER1 +
-		(atom_tab(atom_val(funp->fe->module))->slot.bucket.hvalue);
-	    hash = hash*FUNNY_NUMBER2 + funp->fe->index;
-	    hash = hash*FUNNY_NUMBER2 + funp->fe->old_uniq;
-	    if (num_free > 0) {
-		if (num_free > 1) {
-		    WSTACK_PUSH3(stack, (UWord) &funp->env[1], (num_free-1), MAKE_HASH_TERM_ARRAY_OP);
-		}
-		term = funp->env[0];
-		goto tail_recur;
-	    }
-	    break;
-	}
+            if (is_local_fun(funp)) {
+
+                ErlFunEntry* fe = funp->entry.fun;
+                Uint num_free = funp->num_free;
+
+                hash = hash * FUNNY_NUMBER10 + num_free;
+                hash = hash*FUNNY_NUMBER1 +
+                        (atom_tab(atom_val(fe->module))->slot.bucket.hvalue);
+                hash = hash*FUNNY_NUMBER2 + fe->index;
+                hash = hash*FUNNY_NUMBER2 + fe->old_uniq;
+
+                if (num_free > 0) {
+                    if (num_free > 1) {
+                        WSTACK_PUSH3(stack, (UWord) &funp->env[1],
+                                     (num_free-1), MAKE_HASH_TERM_ARRAY_OP);
+                    }
+
+                    term = funp->env[0];
+                    goto tail_recur;
+                }
+            } else {
+                const ErtsCodeMFA *mfa = &funp->entry.exp->info.mfa;
+
+                ASSERT(is_external_fun(funp) && funp->next == NULL);
+
+                hash = hash * FUNNY_NUMBER11 + mfa->arity;
+                hash = hash*FUNNY_NUMBER1 +
+                       (atom_tab(atom_val(mfa->module))->slot.bucket.hvalue);
+                hash = hash*FUNNY_NUMBER1 +
+                        (atom_tab(atom_val(mfa->function))->slot.bucket.hvalue);
+            }
+            break;
+        }
     case PID_DEF:
 	/* only 15 bits... */
 	UINT32_HASH_RET(internal_pid_number(term),FUNNY_NUMBER5,FUNNY_NUMBER6);
@@ -1671,43 +1677,50 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
                 goto hash2_common;
             }
             break;
-	    case EXPORT_SUBTAG:
-	    {
-		Export* ep = *((Export **) (export_val(term) + 1));
-		UINT32_HASH_2
-		    (ep->info.mfa.arity,
-		     atom_tab(atom_val(ep->info.mfa.module))->slot.bucket.hvalue,
-		     HCONST);
-		UINT32_HASH
-		    (atom_tab(atom_val(ep->info.mfa.function))->slot.bucket.hvalue,
-		     HCONST_14);
-		goto hash2_common;
-	    }
 
-	    case FUN_SUBTAG:
-	    {
-		ErlFunThing* funp = (ErlFunThing *) fun_val(term);
-                ErtsMakeHash2Context_FUN_SUBTAG ctx = {
-                    .num_free = funp->num_free,
-                    .bptr = NULL};
-		UINT32_HASH_2
-		    (ctx.num_free,
-		     atom_tab(atom_val(funp->fe->module))->slot.bucket.hvalue,
-		     HCONST);
-		UINT32_HASH_2
-		    (funp->fe->index, funp->fe->old_uniq, HCONST);
-		if (ctx.num_free == 0) {
-		    goto hash2_common;
-		} else {
-		    ctx.bptr = funp->env + ctx.num_free - 1;
-		    while (ctx.num_free-- > 1) {
-			term = *ctx.bptr--;
-			ESTACK_PUSH(s, term);
+            case FUN_SUBTAG:
+            {
+                ErlFunThing* funp = (ErlFunThing *) fun_val(term);
+
+                if (is_local_fun(funp)) {
+                    ErlFunEntry* fe = funp->entry.fun;
+                    ErtsMakeHash2Context_FUN_SUBTAG ctx = {
+                        .num_free = funp->num_free,
+                        .bptr = NULL};
+
+                    UINT32_HASH_2
+                        (ctx.num_free,
+                         atom_tab(atom_val(fe->module))->slot.bucket.hvalue,
+                         HCONST);
+                    UINT32_HASH_2
+                        (fe->index, fe->old_uniq, HCONST);
+                    if (ctx.num_free == 0) {
+                        goto hash2_common;
+                    } else {
+                        ctx.bptr = funp->env + ctx.num_free - 1;
+                        while (ctx.num_free-- > 1) {
+                            term = *ctx.bptr--;
+                            ESTACK_PUSH(s, term);
                         TRAP_LOCATION(fun_subtag);
-		    }
-		    term = *ctx.bptr;
-		}
-	    }
+                        }
+                        term = *ctx.bptr;
+                    }
+                } else {
+                    Export *ep = funp->entry.exp;
+
+                    ASSERT(is_external_fun(funp) && funp->next == NULL);
+
+                    UINT32_HASH_2
+                        (ep->info.mfa.arity,
+                         atom_tab(atom_val(ep->info.mfa.module))->slot.bucket.hvalue,
+                         HCONST);
+                    UINT32_HASH
+                        (atom_tab(atom_val(ep->info.mfa.function))->slot.bucket.hvalue,
+                         HCONST_14);
+
+                    goto hash2_common;
+                }
+            }
 	    break;
 	    case REFC_BINARY_SUBTAG:
 	    case HEAP_BINARY_SUBTAG:
@@ -2216,32 +2229,34 @@ make_internal_hash(Eterm term, Uint32 salt)
                 goto pop_next;
             }
             break;
-	    case EXPORT_SUBTAG:
-	    {
-		Export* ep = *((Export **) (export_val(term) + 1));
-                /* Assumes Export entries never move */
-                POINTER_HASH(ep, HCONST_14);
-		goto pop_next;
-	    }
+            case FUN_SUBTAG:
+            {
+                ErlFunThing* funp = (ErlFunThing *) fun_val(term);
 
-	    case FUN_SUBTAG:
-	    {
-		ErlFunThing* funp = (ErlFunThing *) fun_val(term);
-		Uint num_free = funp->num_free;
-                UINT32_HASH_2(num_free, funp->fe->module, HCONST_20);
-                UINT32_HASH_2(funp->fe->index, funp->fe->old_uniq, HCONST_21);
-		if (num_free == 0) {
-		    goto pop_next;
-		} else {
-		    Eterm* bptr = funp->env + num_free - 1;
-		    while (num_free-- > 1) {
-			term = *bptr--;
-			ESTACK_PUSH(s, term);
-		    }
-		    term = *bptr;
-		}
-	    }
-	    break;
+                if (is_local_fun(funp)) {
+                    ErlFunEntry* fe = funp->entry.fun;
+                    Uint num_free = funp->num_free;
+                    UINT32_HASH_2(num_free, fe->module, HCONST_20);
+                    UINT32_HASH_2(fe->index, fe->old_uniq, HCONST_21);
+                    if (num_free == 0) {
+                        goto pop_next;
+                    } else {
+                        Eterm* bptr = funp->env + num_free - 1;
+                        while (num_free-- > 1) {
+                            term = *bptr--;
+                            ESTACK_PUSH(s, term);
+                        }
+                        term = *bptr;
+                    }
+                } else {
+                    ASSERT(is_external_fun(funp) && funp->next == NULL);
+
+                    /* Assumes Export entries never move */
+                    POINTER_HASH(funp->entry.exp, HCONST_14);
+                    goto pop_next;
+                }
+            }
+            break;
 	    case REFC_BINARY_SUBTAG:
 	    case HEAP_BINARY_SUBTAG:
 	    case SUB_BINARY_SUBTAG:
@@ -2852,35 +2867,46 @@ tailrecur_ne:
 		    }
 		    break; /* not equal */
 		}
-	    case EXPORT_SUBTAG:
-		{
-		    if (is_export(b)) {
-			Export* a_exp = *((Export **) (export_val(a) + 1));
-			Export* b_exp = *((Export **) (export_val(b) + 1));
-			if (a_exp == b_exp) goto pop_next;
-		    }
-		    break; /* not equal */
-		}
-	    case FUN_SUBTAG:
-		{
-		    ErlFunThing* f1;
-		    ErlFunThing* f2;
+            case FUN_SUBTAG:
+                {
+                    ErlFunThing* f1;
+                    ErlFunThing* f2;
 
-		    if (!is_fun(b))
-			goto not_equal;
-		    f1 = (ErlFunThing *) fun_val(a);
-		    f2 = (ErlFunThing *) fun_val(b);
-		    if (f1->fe->module != f2->fe->module ||
-			f1->fe->index != f2->fe->index ||
-			f1->fe->old_uniq != f2->fe->old_uniq ||
-			f1->num_free != f2->num_free) {
-			goto not_equal;
-		    }
-		    if ((sz = f1->num_free) == 0) goto pop_next;
-		    aa = f1->env;
-		    bb = f2->env;
-		    goto term_array;
-		}
+                    if (is_not_any_fun(b)) {
+                        goto not_equal;
+                    }
+
+                    f1 = (ErlFunThing *) fun_val(a);
+                    f2 = (ErlFunThing *) fun_val(b);
+
+                    if (is_local_fun(f1) && is_local_fun(f2)) {
+                        ErlFunEntry *fe1, *fe2;
+
+                        fe1 = f1->entry.fun;
+                        fe2 = f2->entry.fun;
+
+                        if (fe1->module != fe2->module ||
+                            fe1->index != fe2->index ||
+                            fe1->old_uniq != fe2->old_uniq ||
+                            f1->num_free != f2->num_free) {
+                            goto not_equal;
+                        }
+
+                        if ((sz = f1->num_free) == 0) {
+                            goto pop_next;
+                        }
+
+                        aa = f1->env;
+                        bb = f2->env;
+                        goto term_array;
+                    } else if (is_external_fun(f1) && is_external_fun(f2)) {
+                        if (f1->entry.exp == f2->entry.exp) {
+                            goto pop_next;
+                        }
+                    }
+
+                    goto not_equal;
+                }
 
 	    case EXTERNAL_PID_SUBTAG: {
 		ExternalThing *ap;
@@ -3475,58 +3501,69 @@ tailrecur_ne:
 		    goto mixed_types;
 		}
 		ON_CMP_GOTO(big_comp(a, b));
-	    case (_TAG_HEADER_EXPORT >> _TAG_PRIMARY_SIZE):
-		if (!is_export(b)) {
-		    a_tag = EXPORT_DEF;
-		    goto mixed_types;
-		} else {
-		    Export* a_exp = *((Export **) (export_val(a) + 1));
-		    Export* b_exp = *((Export **) (export_val(b) + 1));
 
-		    if ((j = erts_cmp_atoms(a_exp->info.mfa.module,
-                                            b_exp->info.mfa.module)) != 0) {
-			RETURN_NEQ(j);
-		    }
-		    if ((j = erts_cmp_atoms(a_exp->info.mfa.function,
-                                            b_exp->info.mfa.function)) != 0) {
-			RETURN_NEQ(j);
-		    }
-		    ON_CMP_GOTO((Sint) a_exp->info.mfa.arity - (Sint) b_exp->info.mfa.arity);
-		}
-		break;
-	    case (_TAG_HEADER_FUN >> _TAG_PRIMARY_SIZE):
-		if (!is_fun(b)) {
-		    a_tag = FUN_DEF;
-		    goto mixed_types;
-		} else {
-		    ErlFunThing* f1 = (ErlFunThing *) fun_val(a);
-		    ErlFunThing* f2 = (ErlFunThing *) fun_val(b);
-		    Sint diff;
+            case (_TAG_HEADER_FUN >> _TAG_PRIMARY_SIZE):
+                if (is_not_any_fun(b)) {
+                    a_tag = FUN_DEF;
+                    goto mixed_types;
+                } else {
+                    ErlFunThing* f1 = (ErlFunThing *) fun_val(a);
+                    ErlFunThing* f2 = (ErlFunThing *) fun_val(b);
 
-                    diff = erts_cmp_atoms((f1->fe)->module, (f2->fe)->module);
-		    if (diff != 0) {
-			RETURN_NEQ(diff);
-		    }
-		    diff = f1->fe->index - f2->fe->index;
-		    if (diff != 0) {
-			RETURN_NEQ(diff);
-		    }
-		    diff = f1->fe->old_uniq - f2->fe->old_uniq;
-		    if (diff != 0) {
-			RETURN_NEQ(diff);
-		    }
-		    diff = f1->num_free - f2->num_free;
-		    if (diff != 0) {
-			RETURN_NEQ(diff);
-		    }
-		    i = f1->num_free;
-		    if (i == 0) goto pop_next;
-		    aa = f1->env;
-		    bb = f2->env;
-		    goto term_array;
-		}
-	    case (_TAG_HEADER_EXTERNAL_PID >> _TAG_PRIMARY_SIZE):
-		if (!is_pid(b)) {
+                    if (is_local_fun(f1) && is_local_fun(f2)) {
+                        ErlFunEntry* fe1 = f1->entry.fun;
+                        ErlFunEntry* fe2 = f2->entry.fun;
+
+                        Sint diff;
+
+                        diff = erts_cmp_atoms(fe1->module, (fe2)->module);
+
+                        if (diff != 0) {
+                            RETURN_NEQ(diff);
+                        }
+
+                        diff = fe1->index - fe2->index;
+                        if (diff != 0) {
+                            RETURN_NEQ(diff);
+                        }
+
+                        diff = fe1->old_uniq - fe2->old_uniq;
+                        if (diff != 0) {
+                            RETURN_NEQ(diff);
+                        }
+
+                        diff = f1->num_free - f2->num_free;
+                        if (diff != 0) {
+                            RETURN_NEQ(diff);
+                        }
+
+                        i = f1->num_free;
+                        if (i == 0) goto pop_next;
+                        aa = f1->env;
+                        bb = f2->env;
+                        goto term_array;
+                    } else if (is_external_fun(f1) && is_external_fun(f2)) {
+                        Export* a_exp = f1->entry.exp;
+                        Export* b_exp = f2->entry.exp;
+
+                        if ((j = erts_cmp_atoms(a_exp->info.mfa.module,
+                                                b_exp->info.mfa.module)) != 0) {
+                            RETURN_NEQ(j);
+                        }
+                        if ((j = erts_cmp_atoms(a_exp->info.mfa.function,
+                                                b_exp->info.mfa.function)) != 0) {
+                            RETURN_NEQ(j);
+                        }
+
+                        ON_CMP_GOTO((Sint) a_exp->info.mfa.arity -
+                                     (Sint) b_exp->info.mfa.arity);
+                    } else {
+                        /* External funs compare greater than local ones. */
+                        RETURN_NEQ(is_external_fun(f1) - is_external_fun(f2));
+                    }
+                }
+            case (_TAG_HEADER_EXTERNAL_PID >> _TAG_PRIMARY_SIZE):
+                if (!is_pid(b)) {
                     a_tag = EXTERNAL_PID_DEF;
                     goto mixed_types;
                 }

--- a/erts/emulator/internal_doc/BeamAsm.md
+++ b/erts/emulator/internal_doc/BeamAsm.md
@@ -258,11 +258,11 @@ means that all remote calls _must_ place the export entry in said register,
 even when we don't know beforehand that the call is remote, such as when
 calling a fun.
 
-This is pretty easy to do in assembler and the `emit_setup_export_call` helper
-handles it nicely for us, but we can't set registers when trapping out from C
-code. When trapping to an export entry from C code one must set `c_p->current`
-to the `ErtsCodeMFA` inside the export entry in question, and then set `c_p->i`
-to `beam_bif_export_trap`.
+This is pretty easy to do in assembler and the `emit_setup_dispatchable_call`
+helper handles it nicely for us, but we can't set registers when trapping out
+from C code. When trapping to an export entry from C code one must set
+`c_p->current` to the `ErtsCodeMFA` inside the export entry in question, and
+then set `c_p->i` to `beam_bif_export_trap`.
 
 The `BIF_TRAP` macros handle this for you, so you generally don't need to
 think about it.

--- a/erts/emulator/test/erts_debug_SUITE.erl
+++ b/erts/emulator/test/erts_debug_SUITE.erl
@@ -86,7 +86,8 @@ test_size(Config) when is_list(Config) ->
 
     FunSz1 = do_test_size(fun() -> ConsCell1 end) - do_test_size(ConsCell1),
 
-    2 = do_test_size(fun lists:sort/1),
+    %% External funs are the same size as local ones without environment
+    FunSz0 = do_test_size(fun lists:sort/1),
 
     Arch = 8 * erlang:system_info({wordsize, external}),
     case {Arch, do_test_size(mk_ext_pid({a@b, 1}, 17, 42))} of


### PR DESCRIPTION
By making local and external funs share the same structure, we can remove a substantial amount of code from fun-related instructions.

As a result fun calls are now about 15% faster with the interpreter on my machine, 10% faster with the x64 JIT on that same machine, and 15% faster with the AArch64 JIT on my M1 Mac. The improvement is a bit less pronounced for funs with free variables, and a bit more for those without (including external funs).

This PR is partially reliant on some upcoming work by @kjellwinblad, which will guarantee that the second word of a boxed term is always readable. It only affects the AArch64 JIT and is not a practical hindrance in testing as things can only go awry when calling the empty tuple as a fun, so I've taken the liberty to post this for review now.