### PR TITLE
ci: Use prebuilt archive on Windows build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,7 +44,7 @@ jobs:
       WXWIDGETS_VERSION: 3.1.4
     name: Build Erlang/OTP on Windows
     runs-on: windows-latest
-    needs: pack
+    needs: build
     steps:
       - uses: Vampire/setup-wsl@v1
         with:
@@ -99,10 +99,10 @@ jobs:
           call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\Auxiliary\\Build\\vcvars64.bat"
           nmake TARGET_CPU=amd64 BUILD=release SHARED=0 DIR_SUFFIX_CPU= -f makefile.vc
 
-      - name: Download source archive
+      - name: Download pre-built archive
         uses: actions/download-artifact@v2
         with:
-          name: otp_git_archive
+          name: otp_prebuilt
 
       - name: Compile Erlang
         run: |


### PR DESCRIPTION
This cuts the build time from ~30min to ~20min. On the flip side, we're now doing it serially (first "build" job and then the "windows" job) whereas previously the windows build run in parallel.