### PR TITLE
gh-actions: Use parallel make for windows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -111,6 +111,8 @@ jobs:
           tar -xzf ./otp_src.tar.gz
           cd otp
           export ERL_TOP=`pwd`
+          export MAKEFLAGS=-j4
+          export ERLC_USE_SERVER=true
           eval `./otp_build env_win32 x64`
           ./otp_build configure
           if cat erts/CONF_INFO || cat lib/*/CONF_INFO || cat lib/*/SKIP || cat lib/SKIP-APPLICATIONS; then exit 1; fi


### PR DESCRIPTION
Makes the windows builds run about 8 minutes faster.

See #5267 for a bit of background of this PR.

Thanks to @wojtekmach for triggering this change.