### PR TITLE
Fix race related to precompiled header during compilation

### DIFF
--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -930,7 +930,8 @@ $(OBJDIR)/%.o: beam/jit/%.cpp $(ASMJIT_PCH_OBJ)
           $(subst -O2, $(GEN_OPT_FLGS), $(CXXFLAGS))                \
           -include $(ASMJIT_PCH_SRC) -c $< -o $@
 
-$(OBJDIR)/%.o: beam/jit/$(JIT_ARCH)/%.cpp beam/jit/$(JIT_ARCH)/beam_asm.hpp
+$(OBJDIR)/%.o: beam/jit/$(JIT_ARCH)/%.cpp beam/jit/$(JIT_ARCH)/beam_asm.hpp \
+	$(ASMJIT_PCH_OBJ)
 	$(V_CXX) $(ASMJIT_FLAGS) $(INCLUDES)                            \
           $(subst -O2, $(GEN_OPT_FLGS), $(CXXFLAGS))                \
           -include $(ASMJIT_PCH_SRC) -c $< -o $@


### PR DESCRIPTION
Files matching `erts/emulator/beam/jit/$(JIT_ARCH)/%.cpp` are compiled
with the command line flag `-include $(ASMJIT_PCH_SRC)`, but as there
is no dependency on `$(ASMJIT_PCH_OBJ)` the compilation of the C++
module will race with the precompilation of `$(ASMJIT_PCH_SRC)`. The
missing dependency leads to intermittent build failures as g++ will,
when reading an incomplete precompiled header, abort with `cc1plus:
error: while reading precompiled header: No such file or directory`.

Avoid this race by adding a dependency on `$(ASMJIT_PCH_OBJ)` just as
for files matching `erts/emulator/beam/jit/%.cpp` and
`erts/emulator/asmjit/%.cpp`.