### PR TITLE
Implement extended error information for binary construction

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -297,9 +297,11 @@ atom flags
 atom flush
 atom flush_monitor_messages
 atom force
+atom format_bs_fail
 atom format_cpu_topology
 atom free
 atom fullsweep_after
+atom function
 atom functions
 atom function_clause
 atom garbage_collect
@@ -358,6 +360,7 @@ atom inherit
 atom init
 atom initial_call
 atom input
+atom integer
 atom internal
 atom internal_error
 atom instruction_counts
@@ -546,6 +549,7 @@ atom prepare_on_load
 atom print
 atom priority
 atom private
+atom private_append
 atom process
 atom processes
 atom processes_used
@@ -711,10 +715,11 @@ atom unregister
 atom urun
 atom use_stdio
 atom used
-atom utf8
+atom utf8 utf16 utf32
 atom unblock
 atom unblock_normal
 atom uniq
+atom unit
 atom unless_suspending
 atom unloaded
 atom unloaded_only

--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -996,10 +996,13 @@ save_stacktrace(Process* c_p, ErtsCodePtr pc, Eterm* reg,
 
 	args = make_arglist(c_p, reg, bif_mfa->arity);
     } else {
+        if (c_p->freason & EXF_HAS_EXT_INFO && is_map(c_p->fvalue)) {
+            error_info = c_p->fvalue;
+        }
 
     non_bif_stacktrace:
-
 	s->current = c_p->current;
+
         /*
 	 * For a function_clause error, the arguments are in the beam
 	 * registers and c_p->current is set.

--- a/erts/emulator/beam/beam_debug.c
+++ b/erts/emulator/beam/beam_debug.c
@@ -898,6 +898,55 @@ print_op(fmtfn_t to, void *to_arg, int op, int size, BeamInstr* addr)
 	    }
 	}
 	break;
+    case op_i_bs_create_bin_jIWdW:
+        {
+            int n = unpacked[-1];
+            int i = 0;
+            Eterm type = 0;
+
+            while (n > 0) {
+                switch (i % 5) {
+                case 0:           /* Type */
+                    type = ap[i];
+                    erts_print(to, to_arg, " `%d`", type);
+                    break;
+                case 1:           /* Unit */
+                case 2:           /* Flags */
+                    erts_print(to, to_arg, " `%d`", (Eterm) ap[i]);
+                    break;
+                case 4:         /* Size */
+                    if (type == BSC_BINARY_FIXED_SIZE ||
+                        type == BSC_FLOAT_FIXED_SIZE ||
+                        type == BSC_INTEGER_FIXED_SIZE ||
+                        type == BSC_STRING ||
+                        type == BSC_UTF32) {
+                        erts_print(to, to_arg, " `%d`", ap[i]);
+                        break;
+                    }
+
+                    /*FALLTHROUGH*/
+                case 3:         /* Src */
+                    if (type == BSC_STRING) {
+                        erts_print(to, to_arg, " ");
+                        print_byte_string(to, to_arg, (byte *) ap[i], ap[i+1]);
+                        break;
+                    }
+                    switch (loader_tag(ap[i])) {
+                    case LOADER_X_REG:
+                        erts_print(to, to_arg, " x(%d)", loader_x_reg_index(ap[i]));
+                        break;
+                    case LOADER_Y_REG:
+                        erts_print(to, to_arg, " y(%d)", loader_y_reg_index(ap[i]) - CP_SIZE);
+                        break;
+                    default:
+                        erts_print(to, to_arg, " `%T`", (Eterm) ap[i]);
+                        break;
+                    }
+                }
+                i++, size++, n--;
+            }
+        }
+        break;
     }
     erts_print(to, to_arg, "\n");
 

--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -333,13 +333,13 @@ i_new_bs_put_float(Fail, Sz, Flags, Src) {
     Eterm flags = $Flags;
     Sint _size;
     $BS_GET_UNCHECKED_FIELD_SIZE(sz, (flags >> 3), $BADARG($Fail), _size);
-    if (!erts_new_bs_put_float(c_p, ($Src), _size, flags)) {
+    if (is_value(erts_new_bs_put_float(c_p, ($Src), _size, flags))) {
         $BADARG($Fail);
     }
 }
 
 i_new_bs_put_float_imm(Fail, Sz, Flags, Src) {
-    if (!erts_new_bs_put_float(c_p, ($Src), ($Sz), ($Flags))) {
+    if (is_value(erts_new_bs_put_float(c_p, ($Src), ($Sz), ($Flags)))) {
         $BADARG($Fail);
     }
 }
@@ -833,6 +833,449 @@ i_bs_validate_unicode_retract(Fail, Src, Ms) {
         mb->offset -= 32;
         $BADARG($Fail);
     }
+}
+
+BS_GET_TERM(Term, Dst) {
+    $Dst = $Term;
+    switch (loader_tag($Dst)) {
+    case LOADER_X_REG:
+        $Dst = x(loader_x_reg_index($Dst));
+        break;
+    case LOADER_Y_REG:
+        $Dst = y(loader_y_reg_index($Dst));
+        break;
+    }
+}
+
+BS_LOAD_UNIT(Ptr, Dst) {
+    $Dst = $Ptr[1];
+}
+
+BS_LOAD_FLAGS(Ptr, Dst) {
+    $Dst = $Ptr[2];
+}
+
+BS_LOAD_SRC(Ptr, Dst) {
+    $BS_GET_TERM($Ptr[3], $Dst);
+}
+
+BS_LOAD_STRING_SRC(Ptr, Dst) {
+    $Dst = (byte *) $Ptr[3];
+}
+
+BS_LOAD_SIZE(Ptr, Dst) {
+    $BS_GET_TERM($Ptr[4], $Dst);
+}
+
+BS_LOAD_FIXED_SIZE(Ptr, Dst) {
+    $Dst = $Ptr[4];
+}
+
+// Implicitly uses the c_p and p variables (for convenience).
+BS_FAIL_INFO(Fail, Reason, ErrorType, Value) {
+    erts_prepare_bs_construct_fail_info(c_p, p, $Reason, $ErrorType, $Value);
+    $FAIL_HEAD_OR_BODY($Fail);
+}
+
+// Implicitly uses the Size variable because of limitations of parsing in
+// beam_makeops of nested macro call; a nested macro call can only have one
+// argument.
+BS_FAIL_INFO_SYSTEM_LIMIT(Fail) {
+    $BS_FAIL_INFO($Fail, SYSTEM_LIMIT, am_size, Size);
+}
+
+i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
+    //| -no_prefetch
+    int n = $N;
+    const BeamInstr* p_start = $NEXT_INSTRUCTION;
+    const BeamInstr* p_end = p_start + n;
+    const BeamInstr* p;
+    Uint num_bytes;
+    Uint alloc = $Alloc;
+    Eterm new_binary;
+
+    /* We count the total number of bits in an unsigned integer. To avoid
+     * having to check for overflow when adding to `num_bits`, we ensure that the
+     * signed size of each segment fits in a word. */
+    Uint num_bits = 0;
+
+    /* Calculate size of binary in bits. */
+    for (p = p_start; p < p_end; p += BSC_NUM_ARGS) {
+        Eterm Src;
+        Eterm Size;
+        Uint unit;
+        Uint fixed_size;
+
+        switch (p[0]) {
+        case BSC_APPEND:
+        case BSC_PRIVATE_APPEND:
+            break;
+        case BSC_BINARY_ALL:
+            {
+                Uint byte_size;
+                Uint bit_size;
+
+                $BS_LOAD_SRC(p, Src);
+                if (is_not_binary(Src)) {
+                    $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
+                }
+                byte_size = binary_size(Src);
+#ifndef ARCH_64
+                if ((byte_size >> 28) != 0) {
+                    /* The size of the binary in bits will not fit in
+                     * a 32-bit signed integer. */
+                    $BS_FAIL_INFO($Fail, SYSTEM_LIMIT, am_binary, am_size);
+                }
+#endif
+                bit_size = (byte_size << 3) + binary_bitsize(Src);
+                num_bits += bit_size;
+            }
+            break;
+        case BSC_BINARY_FIXED_SIZE:
+        case BSC_FLOAT_FIXED_SIZE:
+        case BSC_INTEGER_FIXED_SIZE:
+            $BS_LOAD_FIXED_SIZE(p, fixed_size);
+            num_bits += fixed_size;
+            break;
+        case BSC_STRING:
+            $BS_LOAD_FIXED_SIZE(p, fixed_size);
+            num_bits += fixed_size * 8;
+            break;
+        case BSC_BINARY:
+        case BSC_FLOAT:
+        case BSC_INTEGER:
+            $BS_LOAD_UNIT(p, unit);
+            $BS_LOAD_SIZE(p, Size);
+            if (is_small(Size)) {
+                Sint signed_size = signed_val(Size);
+                Uint size;
+                if (signed_size >= 0) {
+                    $BS_SAFE_MUL(signed_size, unit, $BS_FAIL_INFO_SYSTEM_LIMIT($Fail), size);
+                    if (size >> (sizeof(Uint) * 8 - 1) != 0) {
+                        /* The signed size does not fit in a word. */
+                        $BS_FAIL_INFO($Fail, SYSTEM_LIMIT, am_size, Size);
+                    }
+                    num_bits += size;
+                } else {
+                    $BS_FAIL_INFO($Fail, BADARG, am_size, Size);
+                }
+            } else {
+#ifdef ARCH_64
+                /* The size must fit in a small on 64-bit platforms. */
+                if (is_big(Size)) {
+                    if (!big_sign(Size)) {
+                        $BS_FAIL_INFO($Fail, SYSTEM_LIMIT, am_size, Size);
+                    } else {
+                        $BS_FAIL_INFO($Fail, BADARG, am_size, Size);
+                    }
+                } else {
+                    /* Not an integer. */
+                    $BS_FAIL_INFO($Fail, BADARG, am_size, Size);
+                }
+#else
+                Uint size;
+
+                if (!term_to_Uint(Size, &size)) {
+                    if (size == BADARG) {
+                        /* Not an integer or a negative integer. Determine which. */
+                        if (is_big(Size)) {
+                            /* Negative integer. */
+                            $BS_FAIL_INFO($Fail, BADARG, am_size, Size);
+                        }
+                        /* Not an integer. */
+                        $BS_FAIL_INFO($Fail, BADARG, am_size, Size);
+                    }
+                    /* Huge positive integer. */
+                    $BS_FAIL_INFO_SYSTEM_LIMIT($Fail);
+                }
+                $BS_SAFE_MUL(size, unit, $BS_FAIL_INFO_SYSTEM_LIMIT($Fail), size);
+                if ((size >> 31) != 0) {
+                    $BS_FAIL_INFO_SYSTEM_LIMIT($Fail);
+                } else {
+                    num_bits += size;
+                }
+#endif
+            }
+            break;
+        case BSC_UTF8:
+            {
+                int num_bytes;
+
+                /*
+                 * Calculate the number of bits needed to encode the
+                 * source operand to UTF-8. If the source operand is
+                 * invalid (e.g. wrong type or range) we return a
+                 * nonsense integer result (32). We can get away
+                 * with that because we KNOW that full error checking
+                 * will be done in the construction phase.
+                 */
+
+                $BS_LOAD_SRC(p, Src);
+                if (Src < make_small(0x80UL)) {
+                    num_bytes = 1;
+                } else if (Src < make_small(0x800UL)) {
+                    num_bytes = 2;
+                } else if (Src < make_small(0x10000UL)) {
+                    num_bytes = 3;
+                } else {
+                    num_bytes = 4;
+                }
+                num_bits += num_bytes * 8;
+            }
+            break;
+        case BSC_UTF16:
+            {
+                int num_bytes = 2;
+
+                /*
+                 * Calculate the number of bits needed to encode the
+                 * source operarand to UTF-16. If the source operand
+                 * is invalid (e.g. wrong type or range) we return a
+                 * nonsense integer result (16 or 32). We can get away
+                 * with that because we KNOW that full error checking
+                 * will be done in the construction phase.
+                 */
+
+                $BS_LOAD_SRC(p, Src);
+                if (Src >= make_small(0x10000UL)) {
+                    num_bytes = 4;
+                }
+                num_bits += num_bytes * 8;
+            }
+            break;
+        case BSC_UTF32:
+            $BS_LOAD_SRC(p, Src);
+
+            /*
+             * There is no need to untag the integer, but it IS
+             * necessary to make sure it is small (if the term is a
+             * bignum, it could slip through the test, and there is no
+             * further test that would catch it, since bit syntax
+             * construction silently masks too big numbers).
+             */
+            if (is_not_small(Src) || Src > make_small(0x10FFFFUL) ||
+                (make_small(0xD800UL) <= Src && Src <= make_small(0xDFFFUL))) {
+                $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
+            }
+            num_bits += 4 * 8;
+            break;
+        default:
+            ASSERT(0);
+            break;
+        }
+    }
+
+    c_p->fcalls = FCALLS;
+
+    /* Allocate binary. */
+    p = p_start;
+    if (p[0] == BSC_APPEND) {
+        Uint live = $Live;
+        Uint unit;
+        Eterm Src;
+
+        $BS_LOAD_UNIT(p, unit);
+        $BS_LOAD_SRC(p, Src);
+        HEAVY_SWAPOUT;
+        reg[live] = Src;
+        new_binary = erts_bs_append_checked(c_p, reg, live, num_bits, alloc, unit);
+        HEAVY_SWAPIN;
+        if (is_non_value(new_binary)) {
+            $BS_FAIL_INFO($Fail, c_p->freason, c_p->fvalue, reg[live]);
+        }
+        p_start += BSC_NUM_ARGS;
+    } else if (p[0] == BSC_PRIVATE_APPEND) {
+        Uint unit;
+        Eterm Src;
+
+        if (alloc) {
+            $test_heap(alloc, $Live);
+        }
+
+        $BS_LOAD_UNIT(p, unit);
+        $BS_LOAD_SRC(p, Src);
+        new_binary = erts_bs_private_append_checked(c_p, Src, num_bits, unit);
+        if (is_non_value(new_binary)) {
+            $BS_FAIL_INFO($Fail, c_p->freason, c_p->fvalue, Src);
+        }
+        p_start += BSC_NUM_ARGS;
+    } else {
+        num_bytes = ((Uint64)num_bits+(Uint64)7) >> 3;
+        if (num_bits & 7) {
+            alloc += ERL_SUB_BIN_SIZE;
+        }
+        if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
+            alloc += heap_bin_size(num_bytes);
+        } else {
+            alloc += PROC_BIN_SIZE;
+        }
+
+        /* num_bits = Number of bits to build
+         * num_bytes = Number of bytes to allocate in the binary
+         * alloc = Total number of words to allocate on heap
+         */
+        erts_bin_offset = 0;
+        erts_writable_bin = 0;
+        if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
+            ErlHeapBin* hb;
+
+            $test_heap(alloc, $Live);
+            hb = (ErlHeapBin *) HTOP;
+            HTOP += heap_bin_size(num_bytes);
+            hb->thing_word = header_heap_bin(num_bytes);
+            hb->size = num_bytes;
+            erts_current_bin = (byte *) hb->data;
+            new_binary = make_binary(hb);
+        } else {
+            Binary* bptr;
+            ProcBin* pb;
+
+            $TEST_BIN_VHEAP(num_bytes / sizeof(Eterm), alloc, $Live);
+
+            /*
+             * Allocate the binary struct itself.
+             */
+            bptr = erts_bin_nrml_alloc(num_bytes);
+            erts_current_bin = (byte *) bptr->orig_bytes;
+
+            /*
+             * Now allocate the ProcBin on the heap.
+             */
+            pb = (ProcBin *) HTOP;
+            HTOP += PROC_BIN_SIZE;
+            pb->thing_word = HEADER_PROC_BIN;
+            pb->size = num_bytes;
+            pb->next = MSO(c_p).first;
+            MSO(c_p).first = (struct erl_off_heap_header*) pb;
+            pb->val = bptr;
+            pb->bytes = (byte*) bptr->orig_bytes;
+            pb->flags = 0;
+            OH_OVERHEAD(&(MSO(c_p)), pb->size / sizeof(Eterm));
+            new_binary = make_binary(pb);
+        }
+
+        if (num_bits & 7) {
+            ErlSubBin* sb;
+
+            sb = (ErlSubBin *) HTOP;
+            HTOP += ERL_SUB_BIN_SIZE;
+            sb->thing_word = HEADER_SUB_BIN;
+            sb->size = num_bytes - 1;
+            sb->bitsize = num_bits & 7;
+            sb->offs = 0;
+            sb->bitoffs = 0;
+            sb->is_writable = 0;
+            sb->orig = new_binary;
+            new_binary = make_binary(sb);
+        }
+        HEAP_SPACE_VERIFIED(0);
+    }
+
+    /* Construct the segments. */
+    for (p = p_start; p < p_end; p += BSC_NUM_ARGS) {
+        Eterm Src;
+        Eterm Size;
+        Eterm flags;
+        Eterm unit;
+        Sint _size;
+
+        if(p[0] == BSC_STRING) {
+            byte* string;
+            $BS_LOAD_STRING_SRC(p, string);
+            $BS_LOAD_FIXED_SIZE(p, Size);
+            erts_new_bs_put_string(ERL_BITS_ARGS_2(string, Size));
+            continue;
+        }
+
+        $BS_LOAD_SRC(p, Src);
+
+        switch (p[0]) {
+        case BSC_BINARY_ALL:
+            $BS_LOAD_UNIT(p, unit);
+            if (!erts_new_bs_put_binary_all(c_p, Src, unit)) {
+                $BS_FAIL_INFO($Fail, BADARG, am_unit, Src);
+            }
+            break;
+        case BSC_BINARY:
+            $BS_LOAD_UNIT(p, unit);
+            $BS_LOAD_FLAGS(p, flags);
+            $BS_LOAD_SIZE(p, Size);
+            $BS_GET_UNCHECKED_FIELD_SIZE(Size, unit, $BADARG($Fail), _size);
+            if (!erts_new_bs_put_binary(c_p, Src, _size)) {
+                Eterm reason = is_binary(Src) ? am_short : am_type;
+                $BS_FAIL_INFO($Fail, BADARG, reason, Src);
+            }
+            break;
+        case BSC_BINARY_FIXED_SIZE:
+            $BS_LOAD_FIXED_SIZE(p, Size);
+            if (!erts_new_bs_put_binary(c_p, Src, Size)) {
+                Eterm reason = is_binary(Src) ? am_short : am_type;
+                $BS_FAIL_INFO($Fail, BADARG, reason, Src);
+            }
+            break;
+        case BSC_FLOAT:
+            $BS_LOAD_UNIT(p, unit);
+            $BS_LOAD_FLAGS(p, flags);
+            $BS_LOAD_SIZE(p, Size);
+            $BS_GET_UNCHECKED_FIELD_SIZE(Size, unit, $BADARG($Fail), _size);
+            Src = erts_new_bs_put_float(c_p, Src, _size, flags);
+            if (is_value(Src)) {
+                $BS_FAIL_INFO($Fail, BADARG, c_p->fvalue, Src);
+            }
+            break;
+        case BSC_FLOAT_FIXED_SIZE:
+            $BS_LOAD_FLAGS(p, flags);
+            $BS_LOAD_FIXED_SIZE(p, Size);
+            Src = erts_new_bs_put_float(c_p, Src, Size, flags);
+            if (is_value(Src)) {
+                $BS_FAIL_INFO($Fail, BADARG, c_p->fvalue, Src);
+            }
+            break;
+        case BSC_INTEGER:
+            {
+                Sint _size;
+
+                $BS_LOAD_UNIT(p, unit);
+                $BS_LOAD_FLAGS(p, flags);
+                $BS_LOAD_SIZE(p, Size);
+                $BS_GET_UNCHECKED_FIELD_SIZE(Size, unit, $BADARG($Fail), _size);
+                if (!erts_new_bs_put_integer(ERL_BITS_ARGS_3(Src, _size, flags))) {
+                    $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
+                }
+            }
+            break;
+        case BSC_INTEGER_FIXED_SIZE:
+        case BSC_UTF32:
+            $BS_LOAD_FLAGS(p, flags);
+            $BS_LOAD_FIXED_SIZE(p, Size);
+            if (!erts_new_bs_put_integer(ERL_BITS_ARGS_3(Src, Size, flags))) {
+                $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
+            }
+            break;
+        case BSC_UTF8:
+            if (!erts_bs_put_utf8(ERL_BITS_ARGS_1(Src))) {
+                $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
+            }
+            break;
+        case BSC_UTF16:
+            $BS_LOAD_FLAGS(p, flags);
+            $BS_LOAD_SRC(p, Src);
+            if (!erts_bs_put_utf16(ERL_BITS_ARGS_2(Src, flags))) {
+                $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
+            }
+            break;
+        default:
+            ASSERT(0);
+            break;
+        }
+    }
+
+    FCALLS = c_p->fcalls;
+
+    /* Return the resulting binary. */
+    $REFRESH_GEN_DEST();
+    $Dst = new_binary;
+    I += n;
 }
 
 

--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -426,13 +426,14 @@ bs_init.verify(Fail) {
 }
 
 bs_init.execute(Live, Dst) {
+    erts_bin_offset = 0;
+    erts_writable_bin = 0;
+
     if (BsOp1 <= ERL_ONHEAP_BIN_LIMIT) {
         ErlHeapBin* hb;
         Uint bin_need;
 
         bin_need = heap_bin_size(BsOp1);
-        erts_bin_offset = 0;
-        erts_writable_bin = 0;
         $GC_TEST(0, bin_need+BsOp2+ERL_SUB_BIN_SIZE, $Live);
         hb = (ErlHeapBin *) HTOP;
         HTOP += bin_need;
@@ -444,10 +445,7 @@ bs_init.execute(Live, Dst) {
         Binary* bptr;
         ProcBin* pb;
 
-        erts_bin_offset = 0;
-        erts_writable_bin = 0;
-        $TEST_BIN_VHEAP(BsOp1 / sizeof(Eterm),
-                        BsOp2 + PROC_BIN_SIZE + ERL_SUB_BIN_SIZE, $Live);
+        $TEST_BIN_VHEAP(BsOp1 / sizeof(Eterm), BsOp2 + PROC_BIN_SIZE, $Live);
 
         /*
          * Allocate the binary struct itself.
@@ -539,7 +537,9 @@ bs_init_bits.execute(Live, Dst) {
      } else {
 	 alloc += PROC_BIN_SIZE;
      }
-     $test_heap(alloc, $Live);
+
+     erts_bin_offset = 0;
+     erts_writable_bin = 0;
 
      /* num_bits = Number of bits to build
       * num_bytes = Number of bytes to allocate in the binary
@@ -549,38 +549,18 @@ bs_init_bits.execute(Live, Dst) {
      if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
 	 ErlHeapBin* hb;
 
-	 erts_bin_offset = 0;
-	 erts_writable_bin = 0;
+         $test_heap(alloc, $Live);
 	 hb = (ErlHeapBin *) HTOP;
 	 HTOP += heap_bin_size(num_bytes);
 	 hb->thing_word = header_heap_bin(num_bytes);
 	 hb->size = num_bytes;
 	 erts_current_bin = (byte *) hb->data;
 	 new_binary = make_binary(hb);
-
-     do_bits_sub_bin:
-	 if (num_bits & 7) {
-	     ErlSubBin* sb;
-
-	     sb = (ErlSubBin *) HTOP;
-	     HTOP += ERL_SUB_BIN_SIZE;
-	     sb->thing_word = HEADER_SUB_BIN;
-	     sb->size = num_bytes - 1;
-	     sb->bitsize = num_bits & 7;
-	     sb->offs = 0;
-	     sb->bitoffs = 0;
-	     sb->is_writable = 0;
-	     sb->orig = new_binary;
-	     new_binary = make_binary(sb);
-	 }
-	 HEAP_SPACE_VERIFIED(0);
-         $Dst = new_binary;
      } else {
 	 Binary* bptr;
 	 ProcBin* pb;
 
-	 erts_bin_offset = 0;
-	 erts_writable_bin = 0;
+         $TEST_BIN_VHEAP(num_bytes / sizeof(Eterm), alloc, $Live);
 
 	 /*
 	  * Allocate the binary struct itself.
@@ -602,8 +582,24 @@ bs_init_bits.execute(Live, Dst) {
 	 pb->flags = 0;
 	 OH_OVERHEAD(&(MSO(c_p)), pb->size / sizeof(Eterm));
 	 new_binary = make_binary(pb);
-	 goto do_bits_sub_bin;
      }
+
+     if (num_bits & 7) {
+         ErlSubBin* sb;
+
+         sb = (ErlSubBin *) HTOP;
+         HTOP += ERL_SUB_BIN_SIZE;
+         sb->thing_word = HEADER_SUB_BIN;
+         sb->size = num_bytes - 1;
+         sb->bitsize = num_bits & 7;
+         sb->offs = 0;
+         sb->bitoffs = 0;
+         sb->is_writable = 0;
+         sb->orig = new_binary;
+         new_binary = make_binary(sb);
+     }
+     HEAP_SPACE_VERIFIED(0);
+     $Dst = new_binary;
 }
 
 bs_add(Fail, Src1, Src2, Unit, Dst) {

--- a/erts/emulator/beam/emu/emu_load.c
+++ b/erts/emulator/beam/emu/emu_load.c
@@ -1376,6 +1376,21 @@ int beam_load_emit_op(LoaderState *stp, BeamOp *tmp_op) {
     case op_i_bs_match_string_yfWW:
         new_string_patch(stp, ci-1);
         break;
+    case op_i_bs_create_bin_jIWdW:
+        {
+            int n = tmp_op->arity;
+            BeamInstr* p = &code[ci-n];
+            BeamInstr* end_p = &code[ci];
+            while (p < end_p) {
+                switch (*p) {
+                case BSC_STRING:
+                    new_string_patch(stp, p+3-code);
+                    break;
+                }
+                p += 5;
+            }
+        }
+        break;
     case op_catch_yf:
         /* code[ci-3]        &&lb_catch_yf
 	 * code[ci-2]        y-register offset in E

--- a/erts/emulator/beam/emu/generators.tab
+++ b/erts/emulator/beam/emu/generators.tab
@@ -831,3 +831,163 @@ gen.init_yregs(N, Yregs) {
     $INIT_YREGS(S, N.val);
     return first;
 }
+
+gen.create_bin(Fail, Alloc, Live, Unit, Dst, N, Segments) {
+    BeamOp* op;
+    int fixed_args;
+    BeamOpArg* src;
+    BeamOpArg* dst;
+    BeamOpArg* endp;
+
+    endp = Segments + N.val;
+    N.val = 5*N.val/6;
+
+    $NewBeamOp(S, op);
+    $BeamOpNameArity(op, i_bs_create_bin, 5);
+    fixed_args = op->arity;
+    $BeamOpArity(op, (N.val + fixed_args));
+
+    op->a[0] = Fail;
+    op->a[1] = Alloc;
+    op->a[2] = Live;
+    op->a[3] = Dst;
+    op->a[4] = N;
+
+    for (src = Segments, dst = op->a+fixed_args; src < endp; src += 6, dst += 5) {
+        UWord unit;
+        BeamOpArg Flags;
+        Uint flags = 0;
+        BeamOpArg Size;
+        Uint type;
+        Uint segment;
+
+        ASSERT(src[0].type = TAG_a);
+        ASSERT(src[1].type == TAG_u);
+        ASSERT(src[2].type == TAG_u);
+        segment = src[1].val;
+
+        /* Get unit. */
+        dst[1] = src[2];
+        unit = dst[1].val;
+
+        /* Translate flags. */
+        Flags = src[3];              /* Flags */
+        if (Flags.type != TAG_n) {
+            if (Flags.type == TAG_q) {
+                Eterm term = beamfile_get_literal(&S->beam, Flags.val);
+                while (is_list(term)) {
+                    Eterm* consp = list_val(term);
+                    Eterm elem = CAR(consp);
+                    switch (elem) {
+                    case am_little:
+                        flags |= BSF_LITTLE;
+                        break;
+                    case am_native:
+                        flags |= BSF_NATIVE;
+                        break;
+                    }
+                    term = CDR(consp);
+                }
+                ASSERT(is_nil(term));
+            }
+        }
+        Flags.type = TAG_u;
+        Flags.val = flags;
+        $NativeEndian(Flags);
+        Flags.val = (segment << 3) | Flags.val;
+        dst[2] = Flags;
+
+        /* Store source. */
+        dst[3] = src[4];        /* Src */
+
+        /* Get size */
+        Size = src[5];          /* Size */
+
+        /* Translate type. */
+        switch (src[0].val) {
+        case am_append:
+            type = BSC_APPEND;
+            break;
+        case am_private_append:
+            type = BSC_PRIVATE_APPEND;
+            break;
+        case am_binary:
+            {
+                UWord bits;
+                type = BSC_BINARY;
+                if (Size.type == TAG_a && Size.val == am_all) {
+                    type = BSC_BINARY_ALL;
+                } else if (Size.type == TAG_i &&
+                           (Sint) Size.val >= 0 &&
+                           beam_load_safe_mul(Size.val, unit, &bits) &&
+                           (bits >> (sizeof(Uint)-1)*8) == 0) {
+                    type = BSC_BINARY_FIXED_SIZE;
+                    Size.type = TAG_u;
+                    Size.val = bits;
+                    unit = 0;
+                }
+            }
+            break;
+        case am_float:
+            {
+                UWord bits;
+                type = BSC_FLOAT;
+                if (Size.type == TAG_i &&
+                    (Sint) Size.val >= 0 &&
+                    beam_load_safe_mul(Size.val, unit, &bits) &&
+                    (bits >> (sizeof(Uint)-1)*8) == 0) {
+                    type = BSC_FLOAT_FIXED_SIZE;
+                    Size.type = TAG_u;
+                    Size.val = bits;
+                    unit = 0;
+                }
+            }
+            break;
+        case am_integer:
+            {
+                UWord bits;
+                type = BSC_INTEGER;
+                if (Size.type == TAG_i &&
+                    (Sint) Size.val >= 0 &&
+                    beam_load_safe_mul(Size.val, unit, &bits) &&
+                    (bits >> (sizeof(Uint)-1)*8) == 0) {
+                    type = BSC_INTEGER_FIXED_SIZE;
+                    Size.type = TAG_u;
+                    Size.val = bits;
+                    unit = 0;
+                }
+            }
+            break;
+        case am_string:
+            type = BSC_STRING;
+            ASSERT(Size.type == TAG_i);
+            ASSERT(unit == 8);
+            Size.type = TAG_u;
+            Size.val = Size.val; /* Size of string in bytes. */
+            unit = 0;
+            break;
+        case am_utf8:
+            type = BSC_UTF8;
+            break;
+        case am_utf16:
+            type = BSC_UTF16;
+            break;
+        case am_utf32:
+            type = BSC_UTF32;
+            Size.type = TAG_u;
+            Size.val = 32;
+            break;
+        default:
+            abort();
+        }
+        dst[0].type = TAG_u;
+        dst[0].val = type;
+
+        /* Store value of unit. */
+        dst[1].val = unit;
+
+        /* Store size. */
+        dst[4] = Size;
+    }
+    return op;
+}

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -1177,9 +1177,19 @@ bs_skip_utf32 Fail=f Ms=xy Live=u Flags=u => \
 i_bs_validate_unicode_retract j s S
 %hot
 
-#
-# Constructing binaries
-#
+# ================================================================
+# New binary construction (OTP 25).
+# ================================================================
+
+bs_create_bin Fail Alloc=u Live=u Unit=u Dst=xy N=u Segments=* => \
+  create_bin(Fail, Alloc, Live, Unit, Dst, N, Segments)
+
+i_bs_create_bin j I W d W *
+
+# ================================================================
+# Old instruction for constructing binaries (up to OTP 24).
+# ================================================================
+
 %warm
 
 bs_init2 Fail Sz Words Regs Flags Dst | binary_too_big(Sz) => system_limit Fail

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -1043,16 +1043,10 @@ erts_new_bs_put_binary_all(Process *c_p, Eterm arg, Uint unit)
    ERL_BITS_DEFINE_STATEP(c_p);
 
    /*
-    * This type test is not needed if the code was compiled with
-    * an R12B or later compiler, since there would have been a
-    * call to bit_size/1 or byte_size/1 that would have failed if
-    * 'arg' was not a binary. However, in R11B and earlier releases,
-    * size/1 was use for calculating the size of the binary, and
-    * therefore 'arg' could be a tuple.
+    * This instruction is always preceded by a size calculation that
+    * will guarantee that 'arg' is a binary.
     */
-   if (!is_binary(arg)) {
-       return 0;
-   }
+   ASSERT(is_binary(arg));
 
    ERTS_GET_BINARY_BYTES(arg, bptr, bitoffs, bitsize);
    num_bits = 8*binary_size(arg)+bitsize;

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -173,7 +173,7 @@ int erts_bs_put_utf8(ERL_BITS_PROTO_1(Eterm Integer));
 int erts_bs_put_utf16(ERL_BITS_PROTO_2(Eterm Integer, Uint flags));
 int erts_new_bs_put_binary(Process *c_p, Eterm Bin, Uint num_bits);
 int erts_new_bs_put_binary_all(Process *c_p, Eterm Bin, Uint unit);
-int erts_new_bs_put_float(Process *c_p, Eterm Float, Uint num_bits, int flags);
+Eterm erts_new_bs_put_float(Process *c_p, Eterm Float, Uint num_bits, int flags);
 void erts_new_bs_put_string(ERL_BITS_PROTO_2(byte* iptr, Uint num_bytes));
 
 Uint erts_bits_bufs_size(void);
@@ -182,7 +182,10 @@ Eterm erts_bs_get_utf8(ErlBinMatchBuffer* mb);
 Eterm erts_bs_get_utf16(ErlBinMatchBuffer* mb, Uint flags);
 Eterm erts_bs_append(Process* p, Eterm* reg, Uint live, Eterm build_size_term,
 		     Uint extra_words, Uint unit);
+Eterm erts_bs_append_checked(Process* p, Eterm* reg, Uint live, Uint size,
+                             Uint extra_words, Uint unit);
 Eterm erts_bs_private_append(Process* p, Eterm bin, Eterm sz, Uint unit);
+Eterm erts_bs_private_append_checked(Process* p, Eterm bin, Uint size, Uint unit);
 Eterm erts_bs_init_writable(Process* p, Eterm sz);
 
 /*
@@ -204,7 +207,7 @@ Eterm erts_extract_sub_binary(Eterm **hp, Eterm base_bin, byte *base_data,
 #define EXTRACT_SUB_BIN_HEAP_NEED (heap_bin_size(ERL_ONHEAP_BIN_LIMIT))
 
 /*
- * Flags for bs_get_* / bs_put_* / bs_init* instructions.
+ * Flags for bs_create_bin / bs_get_* / bs_put_* / bs_init* instructions.
  */
 
 #define BSF_ALIGNED 1		/* Field is guaranteed to be byte-aligned. */
@@ -212,5 +215,25 @@ Eterm erts_extract_sub_binary(Eterm **hp, Eterm base_bin, byte *base_data,
 #define BSF_SIGNED 4		/* Field is signed (otherwise unsigned). */
 #define BSF_EXACT 8		/* Size in bs_init is exact. */
 #define BSF_NATIVE 16		/* Native endian. */
+
+/*
+ * Binary construction operations.
+ */
+
+#define BSC_APPEND              0
+#define BSC_PRIVATE_APPEND      1
+#define BSC_BINARY              2
+#define BSC_BINARY_FIXED_SIZE   3
+#define BSC_BINARY_ALL          4
+#define BSC_FLOAT               5
+#define BSC_FLOAT_FIXED_SIZE    6
+#define BSC_INTEGER             7
+#define BSC_INTEGER_FIXED_SIZE  8
+#define BSC_STRING              9
+#define BSC_UTF8               10
+#define BSC_UTF16              11
+#define BSC_UTF32              12
+
+#define BSC_NUM_ARGS            5
 
 #endif /* __ERL_BITS_H__ */

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1236,6 +1236,7 @@ void print_pass_through(int, byte*, int);
 int catchlevel(Process*);
 void init_emulator(void);
 void process_main(ErtsSchedulerData *);
+void erts_prepare_bs_construct_fail_info(Process* c_p, const BeamInstr* p, Eterm reason, Eterm Info, Eterm value);
 void erts_dirty_process_main(ErtsSchedulerData *);
 Eterm build_stacktrace(Process* c_p, Eterm exc);
 Eterm expand_error_value(Process* c_p, Uint freason, Eterm Value);

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -800,6 +800,8 @@ class BeamGlobalAssembler : public BeamAssembler {
     _(bif_tuple_size_guard)                                                    \
     _(bs_add_guard_shared)                                                     \
     _(bs_add_body_shared)                                                      \
+    _(bs_bit_size_shared)                                                      \
+    _(bs_create_bin_error_shared)                                              \
     _(bs_get_tail_shared)                                                      \
     _(bs_size_check_shared)                                                    \
     _(call_bif_shared)                                                         \

--- a/erts/emulator/beam/jit/arm/generators.tab
+++ b/erts/emulator/beam/jit/arm/generators.tab
@@ -495,3 +495,72 @@ gen.func_end(Func_Label, Entry_Label) {
 
     return op;
 }
+
+gen.create_bin(Fail, Alloc, Live, Unit, Dst, N, Segments) {
+    BeamOp* op;
+    int fixed_args;
+    int i;
+
+    $NewBeamOp(S, op);
+    $BeamOpNameArity(op, i_bs_create_bin, 4);
+    fixed_args = op->arity;
+    $BeamOpArity(op, (N.val + fixed_args));
+
+    op->a[0] = Fail;
+    op->a[1] = Alloc;
+    op->a[2] = Live;
+    op->a[3] = Dst;
+
+    for (i = 0; i < N.val; i += 6) {
+        BeamOpArg Flags;
+        Uint flags = 0;
+
+        /* Copy all but flags. */
+        op->a[i+fixed_args+0] = Segments[i+0];
+        op->a[i+fixed_args+1] = Segments[i+1];
+        op->a[i+fixed_args+2] = Segments[i+2];
+        op->a[i+fixed_args+4] = Segments[i+4];
+        op->a[i+fixed_args+5] = Segments[i+5];
+
+        /* Translate flags. */
+        Flags = Segments[i+3];              /* Flags */
+        if (Flags.type != TAG_n) {
+            if (Flags.type == TAG_q) {
+                Eterm term = beamfile_get_literal(&S->beam, Flags.val);
+                while (is_list(term)) {
+                    Eterm* consp = list_val(term);
+                    Eterm elem = CAR(consp);
+                    switch (elem) {
+                    case am_little:
+                        flags |= BSF_LITTLE;
+                        break;
+                    case am_native:
+                        flags |= BSF_NATIVE;
+                        break;
+                    }
+                    term = CDR(consp);
+                }
+                ASSERT(is_nil(term));
+            }
+        }
+        Flags.type = TAG_u;
+        Flags.val = flags;
+        $NativeEndian(Flags);
+        op->a[i+fixed_args+3] = Flags;
+    }
+
+    if (op->a[4].val == am_private_append && Alloc.val != 0) {
+        BeamOp* th;
+        $NewBeamOp(S, th);
+        $BeamOpNameArity(th, test_heap, 2);
+        th->a[0] = Alloc;
+        th->a[1] = Live;
+        th->next = op;
+
+        op->a[1].val = 0;
+
+        op = th;
+    }
+
+    return op;
+}

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -893,9 +893,19 @@ bs_skip_utf32 Fail=f Ms=xy Live=u Flags=u => \
 i_bs_validate_unicode_retract j s S
 %hot
 
-#
-# Constructing binaries
-#
+# ================================================================
+# New binary construction (OTP 25).
+# ================================================================
+
+bs_create_bin Fail=j Alloc=u Live=u Unit=u Dst=xy N=u Segments=* => \
+    create_bin(Fail, Alloc, Live, Unit, Dst, N, Segments)
+
+i_bs_create_bin j I t d *
+
+# ================================================================
+# Old instruction for constructing binaries (up to OTP 24).
+# ================================================================
+
 %warm
 
 bs_init2 Fail Sz Words Regs Flags Dst | binary_too_big(Sz) => system_limit Fail

--- a/erts/emulator/beam/jit/beam_jit_common.hpp
+++ b/erts/emulator/beam/jit/beam_jit_common.hpp
@@ -269,8 +269,8 @@ void beam_jit_bs_add_argument_error(Process *c_p, Eterm A, Eterm B);
 Eterm beam_jit_bs_init(Process *c_p,
                        Eterm *reg,
                        ERL_BITS_DECLARE_STATEP,
-                       Eterm BsOp1,
-                       Eterm BsOp2,
+                       Eterm num_bytes,
+                       Uint alloc,
                        unsigned Live);
 Eterm beam_jit_bs_init_bits(Process *c_p,
                             Eterm *reg,

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -874,6 +874,7 @@ class BeamGlobalAssembler : public BeamAssembler {
     _(bif_element_shared)                                                      \
     _(bif_export_trap)                                                         \
     _(bs_add_shared)                                                           \
+    _(bs_create_bin_error_shared)                                              \
     _(bs_size_check_shared)                                                    \
     _(bs_fixed_integer_shared)                                                 \
     _(bs_get_tail_shared)                                                      \

--- a/erts/emulator/beam/jit/x86/generators.tab
+++ b/erts/emulator/beam/jit/x86/generators.tab
@@ -563,3 +563,72 @@ gen.func_end(Func_Label, Entry_Label) {
 
     return op;
 }
+
+gen.create_bin(Fail, Alloc, Live, Unit, Dst, N, Segments) {
+    BeamOp* op;
+    int fixed_args;
+    int i;
+
+    $NewBeamOp(S, op);
+    $BeamOpNameArity(op, i_bs_create_bin, 4);
+    fixed_args = op->arity;
+    $BeamOpArity(op, (N.val + fixed_args));
+
+    op->a[0] = Fail;
+    op->a[1] = Alloc;
+    op->a[2] = Live;
+    op->a[3] = Dst;
+
+    for (i = 0; i < N.val; i += 6) {
+        BeamOpArg Flags;
+        Uint flags = 0;
+
+        /* Copy all but flags. */
+        op->a[i+fixed_args+0] = Segments[i+0];
+        op->a[i+fixed_args+1] = Segments[i+1];
+        op->a[i+fixed_args+2] = Segments[i+2];
+        op->a[i+fixed_args+4] = Segments[i+4];
+        op->a[i+fixed_args+5] = Segments[i+5];
+
+        /* Translate flags. */
+        Flags = Segments[i+3];              /* Flags */
+        if (Flags.type != TAG_n) {
+            if (Flags.type == TAG_q) {
+                Eterm term = beamfile_get_literal(&S->beam, Flags.val);
+                while (is_list(term)) {
+                    Eterm* consp = list_val(term);
+                    Eterm elem = CAR(consp);
+                    switch (elem) {
+                    case am_little:
+                        flags |= BSF_LITTLE;
+                        break;
+                    case am_native:
+                        flags |= BSF_NATIVE;
+                        break;
+                    }
+                    term = CDR(consp);
+                }
+                ASSERT(is_nil(term));
+            }
+        }
+        Flags.type = TAG_u;
+        Flags.val = flags;
+        $NativeEndian(Flags);
+        op->a[i+fixed_args+3] = Flags;
+    }
+
+    if (op->a[4].val == am_private_append && Alloc.val != 0) {
+        BeamOp* th;
+        $NewBeamOp(S, th);
+        $BeamOpNameArity(th, test_heap, 2);
+        th->a[0] = Alloc;
+        th->a[1] = Live;
+        th->next = op;
+
+        op->a[1].val = 0;
+
+        op = th;
+    }
+
+    return op;
+}

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -25,9 +25,14 @@
  * one byte shorter than instructions that use 64-bits registers
  * (e.g. rax). This does not apply to registers r8-r15 beacuse they'll
  * always need a rex prefix. The `and`, `or`, and `cmp` instructions
- * are even shorter than operating on the RETb (al) register. The
+ * are even shorter when operating on the RETb (al) register. The
  * `test` instruction with an immediate second operand is shorter
  * when operating on an 8-bit register.
+ *
+ * When loading an immediate value to a register, storing to the
+ * 32-bit register in one or two bytes shorter than storing to
+ * the corresponding 64-bit register. The mov_imm() helper
+ * will automatically choose the shortest instruction.
  *
  * On both Unix and Windows, instructions can be shortened by using
  * RETd, ARG1d, or ARG2d instead of RET, ARG1, or ARG2, respectively.

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -878,9 +878,19 @@ bs_skip_utf32 Fail=f Ms=xy Live=u Flags=u => \
 i_bs_validate_unicode_retract j s S
 %hot
 
-#
-# Constructing binaries
-#
+# ================================================================
+# New binary construction (OTP 25).
+# ================================================================
+
+bs_create_bin Fail=j Alloc=u Live=u Unit=u Dst=xy N=u Segments=* => \
+    create_bin(Fail, Alloc, Live, Unit, Dst, N, Segments)
+
+i_bs_create_bin j I t d *
+
+# ================================================================
+# Old instruction for constructing binaries (up to OTP 24).
+# ================================================================
+
 %warm
 
 bs_init2 Fail Sz Words Regs Flags Dst | binary_too_big(Sz) => system_limit Fail

--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -1485,7 +1485,7 @@ line_numbers(Config) when is_list(Config) ->
     <<0,0>> = build_binary1(16),
     {'EXIT',{badarg,
              [{?MODULE,build_binary1,1,
-               [{file,"bit_syntax.erl"},{line,72503}]},
+               [{file,"bit_syntax.erl"},{line,72503},{error_info,_}]},
               {?MODULE,line_numbers,1,
                [{file,ModFile},{line,_}]}|_]}} =
     (catch build_binary1(bad_size)),
@@ -1493,21 +1493,20 @@ line_numbers(Config) when is_list(Config) ->
     <<7,1,2,3>> = build_binary2(8, <<1,2,3>>),
     {'EXIT',{badarg,
              [{?MODULE,build_binary2,2,
-               [{file,"bit_syntax.erl"},{line,72507}]},
+               [{file,"bit_syntax.erl"},{line,72507},{error_info,_}]},
               {?MODULE,line_numbers,1,
                [{file,ModFile},{line,_}]}|_]}} =
     (catch build_binary2(bad_size, <<>>)),
     {'EXIT',{badarg,
-             [{erlang,bit_size,[bad_binary],[{error_info,_}]},
-              {?MODULE,build_binary2,2,
-               [{file,"bit_syntax.erl"},{line,72507}]},
+             [{?MODULE,build_binary2,2,
+               [{file,"bit_syntax.erl"},{line,72507},{error_info,_}]},
               {?MODULE,line_numbers,1,
                [{file,ModFile},{line,_}]}|_]}} =
     (catch build_binary2(8, bad_binary)),
 
     <<"abc",357:16>> = build_binary3(<<"abc">>),
     {'EXIT',{badarg,[{?MODULE,build_binary3,1,
-                      [{file,"bit_syntax.erl"},{line,72511}]},
+                      [{file,"bit_syntax.erl"},{line,72511},{error_info,_}]},
                      {?MODULE,line_numbers,1,
                       [{file,ModFile},{line,_}]}|_]}} =
     (catch build_binary3(no_binary)),

--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -1042,6 +1042,7 @@ sub emulator_output {
     print '#include "erl_term.h"', "\n";
     print '#include "erl_map.h"', "\n";
     print '#include "big.h"', "\n";
+    print '#include "erl_bits.h"', "\n";
     print '#include "beam_transform_helpers.h"', "\n";
     print "\n";
     gen_tr_code('pred.');

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -391,14 +391,9 @@ make_op({Name,Arg1,Arg2,Arg3}, Dict) ->
     encode_op(Name, [Arg1,Arg2,Arg3], Dict);
 make_op({Name,Arg1,Arg2,Arg3,Arg4}, Dict) ->
     encode_op(Name, [Arg1,Arg2,Arg3,Arg4], Dict);
-make_op({Name,Arg1,Arg2,Arg3,Arg4,Arg5}, Dict) ->
-    encode_op(Name, [Arg1,Arg2,Arg3,Arg4,Arg5], Dict);
-make_op({Name,Arg1,Arg2,Arg3,Arg4,Arg5,Arg6}, Dict) ->
-    encode_op(Name, [Arg1,Arg2,Arg3,Arg4,Arg5,Arg6], Dict);
-%% make_op({Name,Arg1,Arg2,Arg3,Arg4,Arg5,Arg6,Arg7}, Dict) ->
-%%     encode_op(Name, [Arg1,Arg2,Arg3,Arg4,Arg5,Arg6,Arg7], Dict);
-make_op({Name,Arg1,Arg2,Arg3,Arg4,Arg5,Arg6,Arg7,Arg8}, Dict) ->
-    encode_op(Name, [Arg1,Arg2,Arg3,Arg4,Arg5,Arg6,Arg7,Arg8], Dict);
+make_op(Instr, Dict) when tuple_size(Instr) >= 6 ->
+    [Name|Args] = tuple_to_list(Instr),
+    encode_op(Name, Args, Dict);
 make_op(Op, Dict) when is_atom(Op) ->
     encode_op(Op, [], Dict).
 

--- a/lib/compiler/src/beam_clean.erl
+++ b/lib/compiler/src/beam_clean.erl
@@ -186,9 +186,7 @@ remove_lines_block([]) -> [].
 %%%
 
 fix_bs_create_bin(Fs, Opts) ->
-    %% Force translation to old instructions before we have actually
-    %% implemented the `bs_create_bin` instruction.
-    case true orelse proplists:get_bool(no_bs_create_bin, Opts) of
+    case proplists:get_bool(no_bs_create_bin, Opts) of
         false -> Fs;
         true -> fold_functions(fun fix_bs_create_bin/1, Fs)
     end.

--- a/lib/compiler/src/beam_clean.erl
+++ b/lib/compiler/src/beam_clean.erl
@@ -34,7 +34,8 @@ module({Mod,Exp,Attr,Fs0,_}, Opts) ->
     Fs1 = remove_unused(Order, Used, All),
     {Fs2,Lc} = clean_labels(Fs1),
     Fs3 = fix_swap(Fs2, Opts),
-    Fs = maybe_remove_lines(Fs3, Opts),
+    Fs4 = fix_bs_create_bin(Fs3, Opts),
+    Fs = maybe_remove_lines(Fs4, Opts),
     {ok,{Mod,Exp,Attr,Fs,Lc}}.
 
 %% Determine the rootset, i.e. exported functions and
@@ -178,6 +179,146 @@ remove_lines_block([I|Is]) ->
     [I|remove_lines_block(Is)];
 remove_lines_block([]) -> [].
 
+%%%
+%%% If compatibility with a previous release (OTP 24 or earlier) has
+%%% been requested, eliminate bs_create_bin instructions by translating
+%%% them to the old binary syntax instructions.
+%%%
+
+fix_bs_create_bin(Fs, Opts) ->
+    %% Force translation to old instructions before we have actually
+    %% implemented the `bs_create_bin` instruction.
+    case true orelse proplists:get_bool(no_bs_create_bin, Opts) of
+        false -> Fs;
+        true -> fold_functions(fun fix_bs_create_bin/1, Fs)
+    end.
+
+fix_bs_create_bin([{bs_create_bin,Fail,Alloc,Live,Unit,Dst,{list,List}}|Is]) ->
+    Tail = fix_bs_create_bin(Is),
+    Flags = {field_flags,[]},
+    try bs_pre_size_calc(List) of
+        SizeCalc0 ->
+            SizeCalc = fold_size_calc(SizeCalc0, 0, []),
+            TmpDst = SizeReg = {x,Live},
+            SizeIs0 = bs_size_calc(SizeCalc, Fail, SizeReg, {x,Live+1}),
+            SizeIs = [{move,{integer,0},SizeReg}|SizeIs0],
+            RestIs = bs_puts(List, Fail) ++ [{move,TmpDst,Dst}|Tail],
+            case List of
+                [{atom,append},_,_,_,Src|_] ->
+                    SizeIs ++ [{bs_append,Fail,SizeReg,Alloc,Live+1,Unit,Src,Flags,TmpDst}|RestIs];
+                [{atom,private_append},_,_,_,Src|_] ->
+                    TestHeap = {test_heap,Alloc,Live+1},
+                    SizeIs ++ [TestHeap,{bs_private_append,Fail,SizeReg,Unit,Src,Flags,TmpDst}|RestIs];
+                _ ->
+                    SizeIs ++ [{bs_init_bits,Fail,SizeReg,Alloc,Live+1,Flags,TmpDst}|RestIs]
+            end
+    catch
+        throw:invalid_size ->
+            [{move,{atom,badarg},{x,0}},
+             {call_ext_only,1,{extfunc,erlang,error,1}}|Tail]
+    end;
+fix_bs_create_bin([I|Is]) ->
+    [I|fix_bs_create_bin(Is)];
+fix_bs_create_bin([]) -> [].
+
+bs_pre_size_calc([Type,_Seg,Unit,_Flags,Src,Size|Segs]) ->
+    case Type of
+        {atom,T} when T =:= append; T =:= private_append ->
+            bs_pre_size_calc(Segs);
+        _ ->
+            [bs_pre_size_calc_1(Type, Unit, Src, Size)|bs_pre_size_calc(Segs)]
+    end;
+bs_pre_size_calc([]) -> [].
+
+bs_pre_size_calc_1({atom,Type}, Unit, Src, Size) ->
+    case {Unit,Size} of
+        {0,{atom,undefined}} ->
+            %% No size/unit given.
+            {8,case Type of
+                   utf8 -> {{instr,bs_utf8_size},Src};
+                   utf16 -> {{instr,bs_utf16_size},Src};
+                   utf32 -> {term,{integer,4}}
+               end};
+        {Unit,_} ->
+            case {Type,Size} of
+                {binary,{atom,all}} ->
+                    case Unit rem 8 of
+                        0 -> {8,{{bif,byte_size},Src}};
+                        _ -> {1,{{bif,bit_size},Src}}
+                    end;
+                {_,_} ->
+                    ensure_valid_size(Size),
+                    {Unit,{term,Size}}
+            end
+    end.
+
+ensure_valid_size({x,_}) -> ok;
+ensure_valid_size({y,_}) -> ok;
+ensure_valid_size({integer,Size}) when Size >= 0 -> ok;
+ensure_valid_size(_) -> throw(invalid_size).
+
+fold_size_calc([{Unit,{term,{integer,Size}}}|T], Bits, Acc) ->
+    fold_size_calc(T, Bits + Unit*Size, Acc);
+fold_size_calc([{Unit,{{bif,Bif},{literal,Lit}}}=H|T], Bits, Acc) ->
+    try erlang:Bif(Lit) of
+        Result ->
+            fold_size_calc([{Unit,{term,{integer,Result}}}|T], Bits, Acc)
+    catch
+        _:_ ->
+            fold_size_calc(T, Bits, [H|Acc])
+    end;
+fold_size_calc([{U,_}=H|T], Bits, Acc) when U =:= 1; U =:= 8 ->
+    fold_size_calc(T, Bits, [H|Acc]);
+fold_size_calc([{U,Var}|T], Bits, Acc) ->
+    fold_size_calc(T, Bits, [{1,{'*',{term,{integer,U}},Var}}|Acc]);
+fold_size_calc([], Bits, Acc) ->
+    Bytes = Bits div 8,
+    RemBits = Bits rem 8,
+    Sizes = [{1,{term,{integer,RemBits}}},{8,{term,{integer,Bytes}}}|Acc],
+    [Pair || {_,Sz}=Pair <- Sizes, Sz =/= {term,{integer,0}}].
+
+bs_size_calc([{Unit,{{bif,Bif},Reg}}|T], Fail, SizeReg, TmpReg) ->
+    Live = element(2, SizeReg) + 1,
+    [{gc_bif,Bif,Fail,Live,[Reg],TmpReg},
+     {bs_add,Fail,[SizeReg,TmpReg,Unit],SizeReg}|bs_size_calc(T, Fail, SizeReg, TmpReg)];
+bs_size_calc([{Unit,{'*',{term,Term1},{term,Term2}}}|T], Fail, SizeReg, TmpReg) ->
+    Live = element(2, SizeReg) + 1,
+    [{gc_bif,'*',Fail,Live,[Term1,Term2],TmpReg},
+     {bs_add,Fail,[SizeReg,TmpReg,Unit],SizeReg}|bs_size_calc(T, Fail, SizeReg, TmpReg)];
+bs_size_calc([{Unit,{{instr,Instr},Reg}}|T], Fail, SizeReg, TmpReg) ->
+    [{Instr,Fail,Reg,TmpReg},
+     {bs_add,Fail,[SizeReg,TmpReg,Unit],SizeReg}|bs_size_calc(T, Fail, SizeReg, TmpReg)];
+bs_size_calc([{Unit,{term,Term}}|T], Fail, SizeReg, TmpReg) ->
+    [{bs_add,Fail,[SizeReg,Term,Unit],SizeReg}|bs_size_calc(T, Fail, SizeReg, TmpReg)];
+bs_size_calc([], _Fail, _SizeReg, _TmpReg) -> [].
+
+bs_puts([{atom,string},_Seg,_Unit,_Flags,{string,_}=Str,{integer,Size}|Is], Fail) ->
+    [{bs_put_string,Size,Str}|bs_puts(Is, Fail)];
+bs_puts([{atom,append},_,_,_,_,_|Is], Fail) ->
+    bs_puts(Is, Fail);
+bs_puts([{atom,private_append},_,_,_,_,_|Is], Fail) ->
+    bs_puts(Is, Fail);
+bs_puts([{atom,Type},_Seg,Unit,Flags0,Src,Size|Is], Fail) ->
+    Op = case Type of
+             integer -> bs_put_integer;
+             float   -> bs_put_float;
+             binary  -> bs_put_binary;
+             utf8    -> bs_put_utf8;
+             utf16   -> bs_put_utf16;
+             utf32   -> bs_put_utf32
+         end,
+    Flags = case Flags0 of
+                nil -> [];
+                {literal,Fs} -> Fs
+            end,
+    I = if
+            Unit =:= 0 ->
+                {bs_put,Fail,{Op,{field_flags,Flags}},[Src]};
+            true ->
+                {bs_put,Fail,{Op,Unit,{field_flags,Flags}},[Size,Src]}
+        end,
+    [I|bs_puts(Is, Fail)];
+bs_puts([], _Fail) -> [].
 
 %%%
 %%% Helpers.

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -379,6 +379,8 @@ disasm_instr(B, Bs, Atoms, Literals) ->
 	    disasm_make_fun3(Bs, Atoms, Literals);
 	init_yregs ->
 	    disasm_init_yregs(Bs, Atoms, Literals);
+	bs_create_bin ->
+	    disasm_bs_create_bin(Bs, Atoms, Literals);
 	_ ->
 	    try decode_n_args(Arity, Bs, Atoms, Literals) of
 		{Args, RestBs} ->
@@ -442,6 +444,18 @@ disasm_init_yregs(Bs1, Atoms, Literals) ->
     {u, Len} = U,
     {List, RestBs} = decode_n_args(Len, Bs3, Atoms, Literals),
     {{init_yregs, [{Z,U,List}]}, RestBs}.
+
+disasm_bs_create_bin(Bs0, Atoms, Literals) ->
+    {A1, Bs1} = decode_arg(Bs0, Atoms, Literals),
+    {A2, Bs2} = decode_arg(Bs1, Atoms, Literals),
+    {A3, Bs3} = decode_arg(Bs2, Atoms, Literals),
+    {A4, Bs4} = decode_arg(Bs3, Atoms, Literals),
+    {A5, Bs5} = decode_arg(Bs4, Atoms, Literals),
+    {Z, Bs6} = decode_arg(Bs5, Atoms, Literals),
+    {U, Bs7} = decode_arg(Bs6, Atoms, Literals),
+    {u, Len} = U,
+    {List, RestBs} = decode_n_args(Len, Bs7, Atoms, Literals),
+    {{bs_create_bin, [{A1,A2,A3,A4,A5,Z,U,List}]}, RestBs}.
 
 %%-----------------------------------------------------------------------
 %% decode_arg([Byte]) -> {Arg, [Byte]}
@@ -1173,6 +1187,13 @@ resolve_inst({recv_marker_reserve,[Reg]},_,_,_) ->
 resolve_inst({recv_marker_use,[Reg]},_,_,_) ->
     {recv_marker_use,Reg};
 
+%%
+%% OTP 25.
+%%
+
+resolve_inst({bs_create_bin,Args},_,_,_) ->
+    io:format("~p\n", [Args]),
+    {bs_create_bin,Args};
 
 %%
 %% Catches instructions that are not yet handled.

--- a/lib/compiler/src/beam_jump.erl
+++ b/lib/compiler/src/beam_jump.erl
@@ -896,6 +896,8 @@ instr_labels({bif,_Name,Lbl,_As,_R}) ->
     do_instr_labels(Lbl);
 instr_labels({gc_bif,_Name,Lbl,_Live,_As,_R}) ->
     do_instr_labels(Lbl);
+instr_labels({bs_create_bin,Lbl,_,_,_,_,_}) ->
+    do_instr_labels(Lbl);
 instr_labels({bs_init,Lbl,_,_,_,_}) ->
     do_instr_labels(Lbl);
 instr_labels({bs_put,Lbl,_,_}) ->

--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -105,10 +105,9 @@
 %% To avoid the collapsing, change the value of SET_LIMIT to 50 in the
 %% file erl_types.erl in the dialyzer application.
 
--type prim_op() :: 'bs_add' | 'bs_extract' | 'bs_get_tail' |
-                   'bs_init' | 'bs_init_writable' |
-                   'bs_match' | 'bs_put' | 'bs_start_match' | 'bs_test_tail' |
-                   'bs_utf16_size' | 'bs_utf8_size' | 'build_stacktrace' |
+-type prim_op() :: 'bs_extract' | 'bs_get_tail' | 'bs_init_writable' |
+                   'bs_match' | 'bs_start_match' | 'bs_test_tail' |
+                   'build_stacktrace' |
                    'call' | 'catch_end' |
                    'extract' |
                    'get_hd' | 'get_map_element' | 'get_tl' | 'get_tuple_element' |
@@ -197,17 +196,13 @@ no_side_effect(#b_set{op=Op}) ->
     case Op of
         {bif,_} -> true;
         {float,get} -> true;
-        bs_add -> true;
-        bs_init -> true;
+        bs_create_bin -> true;
         bs_init_writable -> true;
         bs_extract -> true;
         bs_match -> true;
         bs_start_match -> true;
         bs_test_tail -> true;
         bs_get_tail -> true;
-        bs_put -> true;
-        bs_utf16_size -> true;
-        bs_utf8_size -> true;
         build_stacktrace -> true;
         extract -> true;
         get_hd -> true;

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -277,7 +277,7 @@ module_passes(Opts) ->
 repeated_passes(Opts) ->
     Ps = [?PASS(ssa_opt_live),
           ?PASS(ssa_opt_ne),
-          ?PASS(ssa_opt_bs_puts),
+          ?PASS(ssa_opt_bs_create_bin),
           ?PASS(ssa_opt_dead),
           ?PASS(ssa_opt_cse),
           ?PASS(ssa_opt_tail_phis),
@@ -1788,105 +1788,73 @@ bsm_shortcut([], _PosMap) -> [].
 %%% If an integer segment or a float segment has a literal size and
 %%% a literal value, convert to a binary segment. Coalesce adjacent
 %%% literal binary segments. Literal binary segments will be converted
-%%% to bs_put_string instructions in later pass.
+%%% to bs_put_string instructions in a later pass.
 %%%
 
-ssa_opt_bs_puts({#opt_st{ssa=Linear0,cnt=Count0}=St, FuncDb}) ->
-    {Linear,Count} = opt_bs_puts(Linear0, Count0, []),
-    {St#opt_st{ssa=Linear,cnt=Count}, FuncDb}.
+ssa_opt_bs_create_bin({#opt_st{ssa=Linear0}=St, FuncDb}) ->
+    Linear = opt_create_bin_fs(Linear0),
+    {St#opt_st{ssa=Linear}, FuncDb}.
 
-opt_bs_puts([{L,#b_blk{is=Is}=Blk0}|Bs], Count0, Acc0) ->
-    case Is of
-        [#b_set{op=bs_put},#b_set{op={succeeded,_}}]=Is ->
-            case opt_bs_put(L, Is, Blk0, Count0, Acc0) of
-                not_possible ->
-                    opt_bs_puts(Bs, Count0, [{L,Blk0}|Acc0]);
-                {Count,Acc1} ->
-                    Acc = opt_bs_puts_merge(Acc1),
-                    opt_bs_puts(Bs, Count, Acc)
-            end;
-        _ ->
-            opt_bs_puts(Bs, Count0, [{L,Blk0}|Acc0])
-    end;
-opt_bs_puts([], Count, Acc) ->
-    {reverse(Acc),Count}.
+opt_create_bin_fs([{L,#b_blk{is=Is0}=Blk0}|Bs]) ->
+    Is = opt_create_bin_is(Is0),
+    Blk = Blk0#b_blk{is=Is},
+    [{L,Blk}|opt_create_bin_fs(Bs)];
+opt_create_bin_fs([]) -> [].
 
-opt_bs_puts_merge([{L1,#b_blk{is=Is}=Blk0},{L2,#b_blk{is=AccIs}}=BAcc|Acc]) ->
-    case {AccIs,Is} of
-        {[#b_set{op=bs_put,
-                 args=[#b_literal{val=binary},
-                       #b_literal{},
-                       #b_literal{val=Bin0},
-                       #b_literal{val=all},
-                       #b_literal{val=1}]},
-          #b_set{op={succeeded,_}}],
-         [#b_set{op=bs_put,
-                 args=[#b_literal{val=binary},
-                       #b_literal{},
-                       #b_literal{val=Bin1},
-                       #b_literal{val=all},
-                       #b_literal{val=1}]}=I0,
-          #b_set{op={succeeded,_}}=Succeeded]} ->
-            %% Coalesce the two segments to one.
-            Bin = <<Bin0/bitstring,Bin1/bitstring>>,
-            I = I0#b_set{args=bs_put_args(binary, Bin, all)},
-            Blk = Blk0#b_blk{is=[I,Succeeded]},
-            [{L2,Blk}|Acc];
-        {_,_} ->
-            [{L1,Blk0},BAcc|Acc]
-    end.
+opt_create_bin_is([#b_set{op=bs_create_bin,args=Args0}=I0|Is]) ->
+    Args = opt_create_bin_args(Args0),
+    I = I0#b_set{args=Args},
+    [I|opt_create_bin_is(Is)];
+opt_create_bin_is([I|Is]) ->
+    [I|opt_create_bin_is(Is)];
+opt_create_bin_is([]) -> [].
 
-opt_bs_put(L, [I0,Succeeded], #b_blk{last=Br0}=Blk0, Count0, Acc) ->
-    case opt_bs_put(I0) of
-        [Bin] when is_bitstring(Bin) ->
-            Args = bs_put_args(binary, Bin, all),
-            I = I0#b_set{args=Args},
-            Blk = Blk0#b_blk{is=[I,Succeeded]},
-            {Count0,[{L,Blk}|Acc]};
-        [{int,Int,Size},Bin] when is_bitstring(Bin) ->
-            %% Construct a bs_put_integer instruction following
-            %% by a bs_put_binary instruction.
-            IntArgs = bs_put_args(integer, Int, Size),
-            BinArgs = bs_put_args(binary, Bin, all),
-
-            {BinL,BinVarNum,BinBoolNum} = {Count0,Count0+1,Count0+2},
-            Count = Count0 + 3,
-            BinVar = #b_var{name={'@ssa_bs_put',BinVarNum}},
-            BinBool = #b_var{name={'@ssa_bool',BinBoolNum}},
-
-            BinI = I0#b_set{dst=BinVar,args=BinArgs},
-            BinSucceeded = Succeeded#b_set{dst=BinBool,args=[BinVar]},
-            BinBlk = Blk0#b_blk{is=[BinI,BinSucceeded],
-                                last=Br0#b_br{bool=BinBool}},
-
-            IntI = I0#b_set{args=IntArgs},
-            IntBlk = Blk0#b_blk{is=[IntI,Succeeded],last=Br0#b_br{succ=BinL}},
-
-            {Count,[{BinL,BinBlk},{L,IntBlk}|Acc]};
+opt_create_bin_args([#b_literal{val=binary},#b_literal{val=[1|_]},
+                     #b_literal{val=Bin0},#b_literal{val=all},
+                     #b_literal{val=binary},#b_literal{val=[1|_]},
+                     #b_literal{val=Bin1},#b_literal{val=all}|Args0]) ->
+    %% Coalesce two litary binary segments to one.
+    Bin = <<Bin0/bitstring,Bin1/bitstring>>,
+    Args = [#b_literal{val=binary},#b_literal{val=[1]},
+            #b_literal{val=Bin},#b_literal{val=all}|Args0],
+    opt_create_bin_args(Args);
+opt_create_bin_args([#b_literal{val=Type}=Type0,#b_literal{val=UFs}=UFs0,Val,Size|Args0]) ->
+    [Unit|Flags] = UFs,
+    case opt_create_bin_arg(Type, Unit, UFs, Val, Size) of
         not_possible ->
-            not_possible
-    end.
-
-opt_bs_put(#b_set{args=[#b_literal{val=binary},_,#b_literal{val=Val},
-                        #b_literal{val=all},#b_literal{val=Unit}]})
-  when is_bitstring(Val) ->
-    if
-        bit_size(Val) rem Unit =:= 0 ->
-            [Val];
-        true ->
-            not_possible
+            [Type0,UFs0,Val,Size|opt_create_bin_args(Args0)];
+        [Bin] when is_bitstring(Bin) ->
+            Args = [#b_literal{val=binary},#b_literal{val=[1]},
+                    #b_literal{val=Bin},#b_literal{val=all}|Args0],
+            opt_create_bin_args(Args);
+        [{int,Int,IntSize},Bin] when is_bitstring(Bin) ->
+            Args = [#b_literal{val=integer},#b_literal{val=[1|Flags]},
+                    #b_literal{val=Int},#b_literal{val=IntSize},
+                    #b_literal{val=binary},#b_literal{val=[1]},
+                    #b_literal{val=Bin},#b_literal{val=all}|Args0],
+            opt_create_bin_args(Args)
     end;
-opt_bs_put(#b_set{args=[#b_literal{val=Type},#b_literal{val=Flags},
-                        #b_literal{val=Val},#b_literal{val=Size},
-                        #b_literal{val=Unit}]}=I0) when is_integer(Size) ->
+opt_create_bin_args([]) -> [].
+
+opt_create_bin_arg(binary, Unit, _Flags, #b_literal{val=Val}, #b_literal{val=all})
+  when Unit =/= 1, bit_size(Val) rem Unit =:= 0 ->
+    [Val];
+opt_create_bin_arg(Type, Unit, Flags, #b_literal{val=Val}, #b_literal{val=Size})
+  when is_integer(Size), is_integer(Unit) ->
     EffectiveSize = Size * Unit,
     if
         EffectiveSize > 0 ->
-            case {Type,opt_bs_put_endian(Flags)} of
+            case {Type,opt_create_bin_endian(Flags)} of
                 {integer,big} when is_integer(Val) ->
                     if
                         EffectiveSize < 64 ->
                             [<<Val:EffectiveSize>>];
+                        EffectiveSize > 1 bsl 24 ->
+                            %% The binary construction could fail with a
+                            %% system_limit. Don't optimize to ensure that
+                            %% the extended error information will be
+                            %% accurate.
+                            not_possible;
                         true ->
                             opt_bs_put_split_int(Val, EffectiveSize)
                     end;
@@ -1894,9 +1862,8 @@ opt_bs_put(#b_set{args=[#b_literal{val=Type},#b_literal{val=Flags},
                     %% To avoid an explosion in code size, we only try
                     %% to optimize relatively small fields.
                     <<Int:EffectiveSize>> = <<Val:EffectiveSize/little>>,
-                    Args = bs_put_args(Type, Int, EffectiveSize),
-                    I = I0#b_set{args=Args},
-                    opt_bs_put(I);
+                    opt_create_bin_arg(Type, 1, [], #b_literal{val=Int},
+                                       #b_literal{val=EffectiveSize});
                 {binary,_} when is_bitstring(Val) ->
                     case Val of
                         <<Bitstring:EffectiveSize/bits,_/bits>> ->
@@ -1907,8 +1874,14 @@ opt_bs_put(#b_set{args=[#b_literal{val=Type},#b_literal{val=Flags},
                     end;
                 {float,Endian} ->
                     try
-                        [opt_bs_put_float(Val, EffectiveSize, Endian)]
-                    catch error:_ ->
+                        case Endian of
+                            big ->
+                                [<<Val:EffectiveSize/big-float-unit:1>>];
+                            little ->
+                                [<<Val:EffectiveSize/little-float-unit:1>>]
+                        end
+                    catch
+                        error:_ ->
                             not_possible
                     end;
                 {_,_} ->
@@ -1917,25 +1890,12 @@ opt_bs_put(#b_set{args=[#b_literal{val=Type},#b_literal{val=Flags},
         true ->
             not_possible
     end;
-opt_bs_put(#b_set{}) -> not_possible.
+opt_create_bin_arg(_, _, _, _, _) -> not_possible.
 
-opt_bs_put_float(N, Sz, Endian) ->
-    case Endian of
-        big -> <<N:Sz/big-float-unit:1>>;
-        little -> <<N:Sz/little-float-unit:1>>
-    end.
-
-bs_put_args(Type, Val, Size) ->
-    [#b_literal{val=Type},
-     #b_literal{val=[unsigned,big]},
-     #b_literal{val=Val},
-     #b_literal{val=Size},
-     #b_literal{val=1}].
-
-opt_bs_put_endian([big=E|_]) -> E;
-opt_bs_put_endian([little=E|_]) -> E;
-opt_bs_put_endian([native=E|_]) -> E;
-opt_bs_put_endian([_|Fs]) -> opt_bs_put_endian(Fs).
+opt_create_bin_endian([little=E|_]) -> E;
+opt_create_bin_endian([native=E|_]) -> E;
+opt_create_bin_endian([_|Fs]) -> opt_create_bin_endian(Fs);
+opt_create_bin_endian([]) -> big.
 
 opt_bs_put_split_int(Int, Size) ->
     Pos = opt_bs_put_split_int_1(Int, 0, Size - 1),
@@ -2512,7 +2472,6 @@ unsuitable(Linear, Blocks) ->
 unsuitable_1([{L,#b_blk{is=[#b_set{op=Op}=I|_]}}|Bs]) ->
     Unsuitable = case Op of
                      bs_extract -> true;
-                     bs_put -> true;
                      {float,_} -> true;
                      landingpad -> true;
                      _ -> beam_ssa:is_loop_header(I)

--- a/lib/compiler/src/beam_trim.erl
+++ b/lib/compiler/src/beam_trim.erl
@@ -270,14 +270,6 @@ remap([{get_map_elements,Fail,M,{list,L0}}|Is], Map, Acc) ->
     L = [Map(E) || E <- L0],
     I = {get_map_elements,Fail,Map(M),{list,L}},
     remap(Is, Map, [I|Acc]);
-remap([{bs_init,Fail,Info,Live,Ss0,Dst0}|Is], Map, Acc) ->
-    Ss = [Map(Src) || Src <- Ss0],
-    Dst = Map(Dst0),
-    I = {bs_init,Fail,Info,Live,Ss,Dst},
-    remap(Is, Map, [I|Acc]);
-remap([{bs_put=Op,Fail,Info,Ss}|Is], Map, Acc) ->
-    I = {Op,Fail,Info,[Map(S) || S <- Ss]},
-    remap(Is, Map, [I|Acc]);
 remap([{init_yregs,{list,Yregs0}}|Is], Map, Acc) ->
     Yregs = sort([Map(Y) || Y <- Yregs0]),
     I = {init_yregs,{list,Yregs}},
@@ -418,10 +410,6 @@ frame_size([{test,_,{f,L},_}|Is], Safe) ->
     frame_size_branch(L, Is, Safe);
 frame_size([{test,_,{f,L},_,_,_}|Is], Safe) ->
     frame_size_branch(L, Is, Safe);
-frame_size([{bs_init,{f,L},_,_,_,_}|Is], Safe) ->
-    frame_size_branch(L, Is, Safe);
-frame_size([{bs_put,{f,L},_,_}|Is], Safe) ->
-    frame_size_branch(L, Is, Safe);
 frame_size([{init_yregs,_}|Is], Safe) ->
     frame_size(Is, Safe);
 frame_size([{make_fun2,_,_,_,_}|Is], Safe) ->
@@ -480,10 +468,6 @@ is_not_used(Y, [{block,Bl}|Is]) ->
     end;
 is_not_used(Y, [{bs_get_tail,Src,Dst,_}|Is]) ->
     is_not_used_ss_dst(Y, [Src], Dst, Is);
-is_not_used(Y, [{bs_init,_,_,_,Ss,Dst}|Is]) ->
-    is_not_used_ss_dst(Y, Ss, Dst, Is);
-is_not_used(Y, [{bs_put,{f,_},_,Ss}|Is]) ->
-    not member(Y, Ss) andalso is_not_used(Y, Is);
 is_not_used(Y, [{bs_start_match4,_Fail,_Live,Src,Dst}|Is]) ->
     Y =/= Src andalso Y =/= Dst andalso
         is_not_used(Y, Is);

--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -97,6 +97,10 @@ replace_labels_1([{make_fun2,{f,Lbl},U1,U2,U3}|Is], Acc, D, Fb) ->
     replace_labels_1(Is, [{make_fun2,{f,label(Lbl, D, Fb)},U1,U2,U3}|Acc], D, Fb);
 replace_labels_1([{make_fun3,{f,Lbl},U1,U2,U3,U4}|Is], Acc, D, Fb) ->
     replace_labels_1(Is, [{make_fun3,{f,label(Lbl, D, Fb)},U1,U2,U3,U4}|Acc], D, Fb);
+replace_labels_1([{bs_create_bin,{f,Lbl},Alloc,Live,Unit,Dst,{list,List}}|Is], Acc, D, Fb)
+  when Lbl =/= 0 ->
+    replace_labels_1(Is, [{bs_create_bin,{f,label(Lbl, D, Fb)},
+                           Alloc,Live,Unit,Dst,{list,List}}|Acc], D, Fb);
 replace_labels_1([{bs_init,{f,Lbl},Info,Live,Ss,Dst}|Is], Acc, D, Fb) when Lbl =/= 0 ->
     replace_labels_1(Is, [{bs_init,{f,label(Lbl, D, Fb)},Info,Live,Ss,Dst}|Acc], D, Fb);
 replace_labels_1([{bs_put,{f,Lbl},Info,Ss}|Is], Acc, D, Fb) when Lbl =/= 0 ->

--- a/lib/compiler/src/beam_z.erl
+++ b/lib/compiler/src/beam_z.erl
@@ -87,32 +87,6 @@ undo_renames([{get_hd,Src,Hd},{get_tl,Src,Tl}|Is]) ->
     get_list(Src, Hd, Tl, Is);
 undo_renames([{get_tl,Src,Tl},{get_hd,Src,Hd}|Is]) ->
     get_list(Src, Hd, Tl, Is);
-undo_renames([{bs_put,_,{bs_put_binary,1,_},
-               [{atom,all},{literal,<<>>}]}|Is]) ->
-    undo_renames(Is);
-undo_renames([{bs_put,Fail,{bs_put_binary,1,_Flags},
-               [{atom,all},{literal,BinString}]}|Is0])
-  when is_bitstring(BinString)->
-    Bits = bit_size(BinString),
-    Bytes = Bits div 8,
-    case Bits rem 8 of
-        0 ->
-            I = {bs_put_string,byte_size(BinString),
-                 {string,BinString}},
-            [undo_rename(I)|undo_renames(Is0)];
-        Rem ->
-            <<Binary:Bytes/bytes,Int:Rem>> = BinString,
-            PutInt = {bs_put_integer,Fail,{integer,Rem},1,
-                      {field_flags,[unsigned,big]},{integer,Int}},
-            Is = [PutInt|undo_renames(Is0)],
-            case Binary of
-                <<>> ->
-                    Is;
-                _ ->
-                    [{bs_put_string,byte_size(Binary),
-                      {string,Binary}}|Is]
-            end
-    end;
 undo_renames([I|Is]) ->
     [undo_rename(I)|undo_renames(Is)];
 undo_renames([]) -> [].

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -272,9 +272,13 @@ expand_opt(no_bsm4, Os) ->
     %% that a match instruction won't fail.
     expand_opt(no_type_opt, Os);
 expand_opt(r22, Os) ->
-    expand_opt(r23, [no_shared_fun_wrappers, no_swap | expand_opt(no_bsm4, Os)]);
+    expand_opt(r23, [no_bs_create_bin, no_shared_fun_wrappers,
+                     no_swap | expand_opt(no_bsm4, Os)]);
 expand_opt(r23, Os) ->
-    expand_opt(no_make_fun3, [no_ssa_opt_float, no_recv_opt, no_init_yregs | Os]);
+    expand_opt(no_make_fun3, [no_bs_create_bin, no_ssa_opt_float,
+                              no_recv_opt, no_init_yregs | Os]);
+expand_opt(r24, Os) ->
+    [no_bs_create_bin | Os];
 expand_opt(no_make_fun3, Os) ->
     [no_make_fun3, no_fun_opt | Os];
 expand_opt({debug_info_key,_}=O, Os) ->

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -647,3 +647,9 @@ BEAM_FORMAT_NUMBER=0
 ## @doc  Sets the current receive cursor to the marker associated with
 ##       the given Reference.
 176: recv_marker_use/1
+
+# OTP 25
+
+## @spec bs_create_bin Fail Alloc Live Unit Dst OpList
+## @doc  Builda a new binary using the binary syntax.
+177: bs_create_bin/6

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -601,10 +601,7 @@ eval_binary(#c_binary{anno=Anno,segments=Ss}=Bin) ->
 	    Bin;
 	  throw:{badarg,Warning} ->
 	    add_warning(Bin, {failed,Warning}),
-	    #c_call{anno=Anno,
-		    module=#c_literal{val=erlang},
-		    name=#c_literal{val=error},
-		    args=[#c_literal{val=badarg}]}
+            Bin
     end.
 
 eval_binary_1([#c_bitstr{val=#c_literal{val=Val},size=#c_literal{val=Sz},

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -106,6 +106,11 @@ INLINE= \
 R23= \
         fun
 
+R24= \
+	bs_construct \
+	bs_utf \
+	bs_bincomp
+
 DIALYZER = bs_match
 
 CORE_MODULES = \
@@ -128,6 +133,8 @@ INLINE_MODULES= $(INLINE:%=%_inline_SUITE)
 INLINE_ERL_FILES= $(INLINE_MODULES:%=%.erl)
 R23_MODULES= $(R23:%=%_r23_SUITE)
 R23_ERL_FILES= $(R23_MODULES:%=%.erl)
+R24_MODULES= $(R24:%=%_r24_SUITE)
+R24_ERL_FILES= $(R24_MODULES:%=%.erl)
 NO_MOD_OPT_MODULES= $(NO_MOD_OPT:%=%_no_module_opt_SUITE)
 NO_MOD_OPT_ERL_FILES= $(NO_MOD_OPT_MODULES:%=%.erl)
 NO_SSA_OPT_MODULES= $(NO_SSA_OPT:%=%_no_ssa_opt_SUITE)
@@ -169,7 +176,7 @@ DISABLE_SSA_OPT = +no_bool_opt +no_share_opt +no_bsm_opt +no_fun_opt +no_ssa_opt
 make_emakefile: $(NO_OPT_ERL_FILES) $(POST_OPT_ERL_FILES) $(NO_SSA_OPT_ERL_FILES) \
   $(NO_CORE_OPT_ERL_FILES) $(INLINE_ERL_FILES) $(R23_ERL_FILES) \
   $(NO_MOD_OPT_ERL_FILES) $(NO_TYPE_OPT_ERL_FILES) \
-  $(DIALYZER_ERL_FILES)
+  $(DIALYZER_ERL_FILES) $(R24_ERL_FILES)
 	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) -o$(EBIN) $(MODULES) \
 	  > $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +no_copt $(DISABLE_SSA_OPT) +no_postopt \
@@ -184,6 +191,8 @@ make_emakefile: $(NO_OPT_ERL_FILES) $(POST_OPT_ERL_FILES) $(NO_SSA_OPT_ERL_FILES
 	  -o$(EBIN) $(INLINE_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +r23 $(ERL_COMPILE_FLAGS) \
 	  -o$(EBIN) $(R23_MODULES) >> $(EMAKEFILE)
+	$(ERL_TOP)/make/make_emakefile +r24 $(ERL_COMPILE_FLAGS) \
+	  -o$(EBIN) $(R24_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +no_module_opt $(ERL_COMPILE_FLAGS) \
 	  -o$(EBIN) $(NO_MOD_OPT_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +from_core $(ERL_COMPILE_FLAGS) \
@@ -225,6 +234,9 @@ docs:
 %_r23_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 
+%_r24_SUITE.erl: %_SUITE.erl
+	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
+
 %_no_module_opt_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 
@@ -246,7 +258,9 @@ release_tests_spec: make_emakefile
 	$(INSTALL_DATA) compiler.spec compiler.cover \
 		$(EMAKEFILE) $(ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(NO_OPT_ERL_FILES) $(POST_OPT_ERL_FILES) \
-		$(INLINE_ERL_FILES) $(R23_ERL_FILES) \
+		$(INLINE_ERL_FILES) \
+	        $(R23_ERL_FILES) \
+	        $(R24_ERL_FILES) \
 		$(NO_CORE_OPT_ERL_FILES) \
 		$(NO_MOD_OPT_ERL_FILES) \
 		$(NO_SSA_OPT_ERL_FILES) \

--- a/lib/compiler/test/bs_bincomp_SUITE.erl
+++ b/lib/compiler/test/bs_bincomp_SUITE.erl
@@ -387,6 +387,12 @@ sizes(Config) when is_list(Config) ->
     <<>> = Fun6([], 42),
     <<42,43:20>> = Fun6([42], 20),
 
+    Fun7 = fun(B) ->
+                   cs_default(<< <<C/utf8>> || C <- B >>)
+            end,
+    <<"Foundation"/utf8>> = Fun7("Foundation"),
+    <<"Основание"/utf8>> = Fun7("Основание"),
+
     %% Binary generators.
 
     Fun10 = fun(Bin) ->
@@ -436,6 +442,12 @@ sizes(Config) when is_list(Config) ->
             end,
     <<$a:32,$b:32,$c:32,($a bsl 8 bor $b):32>> = Fun14([8,16], <<"abc">>),
     <<$a:32,$b:32,$c:32>> = Fun14([8,bad], <<"abc">>),
+
+    Fun15 = fun(B) ->
+                    cs_default(<< <<C/utf8>> || << C:32 >> <= id(B) >>)
+            end,
+    <<"Foundation"/utf8>> = Fun15(<<"Foundation"/utf32>>),
+    <<"Основание"/utf8>> = Fun15(<<"Основание"/utf32>>),
 
     {'EXIT',_} = (catch << <<C:4>> || <<C:8>> <= {1,2,3} >>),
 

--- a/lib/compiler/test/bs_construct_SUITE.erl
+++ b/lib/compiler/test/bs_construct_SUITE.erl
@@ -72,10 +72,10 @@ end_per_testcase(Case, Config) when is_atom(Case), is_list(Config) ->
 
 verify_highest_opcode(_Config) ->
     case ?MODULE of
-        bs_construct_r21_SUITE ->
+        bs_construct_r24_SUITE ->
             {ok,Beam} = file:read_file(code:which(?MODULE)),
             case test_lib:highest_opcode(Beam) of
-                Highest when Highest =< 163 ->
+                Highest when Highest =< 176 ->
                     ok;
                 TooHigh ->
                     ct:fail({too_high_opcode_for_21,TooHigh})

--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -87,7 +87,7 @@ opt_opts(Mod) ->
                      (debug_info) -> true;
                      (dialyzer) -> true;
                      (inline) -> true;
-                     (no_bsm3) -> true;
+                     (no_bs_create_bin) -> true;
                      (no_bsm_opt) -> true;
                      (no_copt) -> true;
                      (no_fun_opt) -> true;
@@ -95,11 +95,10 @@ opt_opts(Mod) ->
                      (no_make_fun3) -> true;
                      (no_module_opt) -> true;
                      (no_postopt) -> true;
-                     (no_put_tuple2) -> true;
                      (no_recv_opt) -> true;
                      (no_share_opt) -> true;
                      (no_shared_fun_wrappers) -> true;
-                     (no_ssa_float) -> true;
+                     (no_ssa_opt_float) -> true;
                      (no_ssa_opt) -> true;
                      (no_stack_trimming) -> true;
                      (no_swap) -> true;
@@ -136,7 +135,8 @@ is_cloned_mod_1("_no_copt_SUITE") -> true;
 is_cloned_mod_1("_no_ssa_opt_SUITE") -> true;
 is_cloned_mod_1("_post_opt_SUITE") -> true;
 is_cloned_mod_1("_inline_SUITE") -> true;
-is_cloned_mod_1("_21_SUITE") -> true;
+is_cloned_mod_1("_23_SUITE") -> true;
+is_cloned_mod_1("_24_SUITE") -> true;
 is_cloned_mod_1("_no_module_opt_SUITE") -> true;
 is_cloned_mod_1([_|T]) -> is_cloned_mod_1(T);
 is_cloned_mod_1([]) -> false.


### PR DESCRIPTION
This pull request implements extended error information for binary construction using the binary syntax. Consider this module:

    -module(foo).
    -export([bin/2, int/2, float/2, var_int/2]).

    bin(A, B) -> <<A/binary, B/binary>>.
    int(A, B) -> <<A/integer, B/integer>>.
    float(A, B) -> <<A/float, B/float>>.
    var_int(A, Size) -> <<A:Size>>.

With the extended error information introduced in this pull request, failures to build binaries will be reported like this:

        1> c(foo).
        {ok,foo}
        2> foo:bin(2, <<>>).
        ** exception error: construction of binary failed
             in function  foo:bin/2 (foo.erl, line 4)
                *** segment 1 of type 'binary': expected a binary but got: 2
        3> foo:bin(<<>>, 42).
        ** exception error: construction of binary failed
             in function  foo:bin/2 (foo.erl, line 4)
                *** segment 2 of type 'binary': expected a binary but got: 42
        4> foo:bin(<<>>, <<1:1>>).
        ** exception error: construction of binary failed
             in function  foo:bin/2 (foo.erl, line 4)
                *** segment 2 of type 'binary': the size of the value <<1:1>> is not a multiple of the unit for the segment
        5> foo:int(a, 42).
        ** exception error: construction of binary failed
             in function  foo:int/2 (foo.erl, line 5)
                *** segment 1 of type 'integer': expected an integer but got: a
        6> foo:float(<<>>, <<>>).
        ** exception error: construction of binary failed
             in function  foo:float/2 (foo.erl, line 6)
                *** segment 1 of type 'float': expected a float or an integer but got: <<>>
        7> foo:var_int(42, -1).
        ** exception error: construction of binary failed
             in function  foo:var_int/2 (foo.erl, line 7)
                *** segment 1 of type 'integer': expected a non-negative integer as size but got: -1
        8> foo:var_int(42, a).
        ** exception error: construction of binary failed
             in function  foo:var_int/2 (foo.erl, line 7)
                *** segment 1 of type 'integer': expected a non-negative integer as size but got: a
        9> foo:var_int(42, 1 bsl 64).
        ** exception error: construction of binary failed
             in function  foo:var_int/2 (foo.erl, line 7)
                *** segment 1 of type 'integer': the size 18446744073709551616 is too large

(Example has been updated to comply with the updated implementation.)