### PR TITLE
JOB_OBJECT_LIMIT_BREAKAWAY_OK

### DIFF
--- a/erts/etc/win32/erlsrv/erlsrv_service.c
+++ b/erts/etc/win32/erlsrv/erlsrv_service.c
@@ -535,10 +535,14 @@ static BOOL start_a_service(ServerInfo *srvi){
 	  HANDLE hJob = CreateJobObject(NULL, NULL);
 	  JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = { 0 };
 	  /*
-	   * Causes all processes associated with the job to terminate when the
-	   * last handle to the job is closed.
-	   */
-	  jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        * JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        * Causes all processes associated with the job to terminate when the
+        * last handle to the job is closed.
+        *
+        * JOB_OBJECT_LIMIT_BREAKAWAY_OK
+        * Sometimes we want to break out, for example to start programs in another windows session
+      */
+      jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK;
 	  SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli));
 	  if (AssignProcessToJobObject(hJob, GetCurrentProcess()) == FALSE) {
 	      log_error(L"Could not AssignProcessToJobObject");


### PR DESCRIPTION
Sometimes we want to break out, for example to start programs in another windows session.

https://docs.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-createjobobjectw

All processes associated with a job must run in the same session. 
A job is associated with the session of the first process to be assigned to the job.
