### PR TITLE
kernel: Add a missing raw option in erl_uds_dist

### DIFF
--- a/lib/kernel/examples/erl_uds_dist/src/erl_uds_dist.erl
+++ b/lib/kernel/examples/erl_uds_dist/src/erl_uds_dist.erl
@@ -755,8 +755,10 @@ close(ListeningSocket) ->
     %% Get the listening socket address in a {local, Pathname} format
     {ok, SocketAddress} = inet:sockname(ListeningSocket),
     {local, SocketPathname} = SocketAddress,
-    %% Remove the socket file from the filesystem
-    file:delete(SocketPathname),
+    %% Remove the socket file from the filesystem. The raw option is used
+    %% to bypass the need for a file server, which may not be available
+    %% and registered anymore (for instance during a node shutdown phase).
+    file:delete(SocketPathname, [raw]),
     gen_tcp:close(ListeningSocket).
 
 


### PR DESCRIPTION
The calls to file:open and file:delete are using the [raw] option to bypass the file server but one call to file:delete was missing the option.

Thanks, Jérôme