### PR TITLE
Add [32-bit] to the Erlang shell title row

### DIFF
--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -92,8 +92,12 @@ static char erts_system_version[] = ("Erlang/OTP " ERLANG_OTP_RELEASE
 				     " [source]"
 #endif
 #endif	
-#ifdef ARCH_64
+#if defined(ARCH_64)
 				     " [64-bit]"
+#elif defined(ARCH_32)
+                                     " [32-bit]"
+#else
+# error "Unknown ARCH_?"
 #endif
 				     " [smp:%beu:%beu]"
 				     " [ds:%beu:%beu:%beu]"


### PR DESCRIPTION
As 32-bit is nowadays the more divergent one.

```
> erl
Erlang/OTP 25 [erts-12.1.2] [32-bit] [smp:8:8] [ds:8:8:10] [async-threads:1]

Eshell V12.1.2  (abort with ^G)
1> 
```
