### PR TITLE
compiler: Add ASM form to compile:forms/2 spec

### DIFF
--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -44,6 +44,14 @@
 -type disasm_tag()   :: symbolic_tag() | 'fr' | 'atom' | 'float' | 'literal'.
 -type disasm_term()  :: 'nil' | {disasm_tag(), _}.
 
+-type asm_form() :: {module(),
+                     [{atom(), arity()}],
+                     [beam_lib:attrib_entry()],
+                     [#function{}],
+                     beam_lib:label()}.
+
+-export_type([asm_form/0]).
+
 %%-----------------------------------------------------------------------
 
 -define(NO_DEBUG(Str,Xs), ok).

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -49,9 +49,7 @@
 
 -type abstract_code() :: [erl_parse:abstract_form()].
 
-%% Internal representations used for 'from_asm' compilation can also be valid,
-%% but have no relevant types defined.
--type forms() :: abstract_code() | cerl:c_module().
+-type forms() :: abstract_code() | cerl:c_module() | beam_disasm:asm_form().
 
 -type option() :: atom() | {atom(), term()} | {'d', atom(), term()}.
 


### PR DESCRIPTION
This was missing so far because the assembly form was never specified.

This patch adds a type spec for the assembly form to the `beam_disasm` module and exports it. This location was chosen because it also defines the `#function{}` record which is used in the assembly form.

I'm not sure if this qualifies as a new feature or a bug fix. The pull request is against the `master` branch currently.