### PR TITLE
Correct binary assignment notice

### DIFF
--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -1265,7 +1265,7 @@ Ei = Value |
     <p>Notice that bit string patterns cannot be nested.</p>
     <p>Notice also that "<c><![CDATA[B=<<1>>]]></c>" is interpreted as
       "<c><![CDATA[B =< <1>>]]></c>" which is a syntax error. The correct way is
-      to write a space after '=': "<c><![CDATA[B= <<1>>]]></c>.</p>
+      to write a space after '=': "<c><![CDATA[B = <<1>>]]></c>.</p>
     <p>More examples are provided in
     <seeguide marker="system/programming_examples:bit_syntax">
     Programming Examples</seeguide>.</p>


### PR DESCRIPTION
While "`B=<<1>>` is interpreted as `B =<<1>>`" is kinda correct in a sense, it doesn't make the point clear, namely that `B=<<1>>` is interpreted as `B =< <1>>`. In https://erlang.org/doc/programming_examples/bit_syntax.html#lexical-note, it is correct.