### PR TITLE
Tracing: Add new option `caller_line` for fun match spec body

### DIFF
--- a/erts/doc/src/match_spec.xml
+++ b/erts/doc/src/match_spec.xml
@@ -140,6 +140,7 @@
         <c><![CDATA[process_dump]]></c> | <c><![CDATA[enable_trace]]></c> |
         <c><![CDATA[disable_trace]]></c> | <c><![CDATA[trace]]></c> |
         <c><![CDATA[display]]></c> | <c><![CDATA[caller]]></c> |
+        <c><![CDATA[caller_line]]></c> |
         <c><![CDATA[set_tcw]]></c> | <c><![CDATA[silent]]></c>
       </item>
     </list>
@@ -435,6 +436,24 @@
            <p>Notice that if a "technically built in function" (that is, a
              function not written in Erlang) is traced, the
              <c><![CDATA[caller]]></c> function sometimes returns the atom
+             <c><![CDATA[undefined]]></c>. The calling
+             Erlang function is not available during such calls.</p>
+        </item>
+        <tag><c>caller_line</c></tag>
+        <item>
+          <p>Similar to <c>caller</c> but returns additional information about
+             the source code location of the function call-site within the
+             caller function. Returns the calling function as a tuple
+             <c>{Module, Function, Arity, {File, Line}}</c>. <c>File</c> is the
+             <seeguide marker="system/reference_manual:data_types#string">string</seeguide>
+             file name while <c>Line</c> is source line number. If the <c>File</c>
+             and <c>Line</c> cannot be determined, <c>{Module, Function, Arity, undefined}</c>
+             is returned. If the calling function cannot be determined, the atom
+             <c><![CDATA[undefined]]></c> is returned. Can only be used in the
+             <c><![CDATA[MatchBody]]></c> part when tracing.</p>
+           <p>Notice that if a "technically built in function" (that is, a
+             function not written in Erlang) is traced, the
+             <c><![CDATA[caller_line]]></c> function sometimes returns the atom
              <c><![CDATA[undefined]]></c>. The calling
              Erlang function is not available during such calls.</p>
         </item>

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -159,6 +159,7 @@ atom call_count
 atom call_error_handler
 atom call_time
 atom caller
+atom caller_line
 atom capture
 atom case_clause
 atom caseless

--- a/erts/emulator/test/match_spec_SUITE.erl
+++ b/erts/emulator/test/match_spec_SUITE.erl
@@ -21,7 +21,8 @@
 -module(match_spec_SUITE).
 
 -export([all/0, suite/0]).
--export([test_1/1, test_2/1, test_3/1, caller_and_return_to/1, bad_match_spec_bin/1,
+-export([test_1/1, test_2/1, test_3/1, test_4a/1, test_4b/1, test_5a/1,
+         test_5b/1, caller_and_return_to/1, bad_match_spec_bin/1,
 	 trace_control_word/1, silent/1, silent_no_ms/1, silent_test/1,
 	 ms_trace2/1, ms_trace3/1, ms_trace_dead/1, boxed_and_small/1,
 	 destructive_in_test_bif/1, guard_exceptions/1,
@@ -34,6 +35,7 @@
 -export([runner/2, loop_runner/3]).
 -export([f1/1, f2/2, f3/2, fn/1, fn/2, fn/3]).
 -export([do_boxed_and_small/0]).
+-export([f1_test4/1, f2_test4/2, f3_test4/2]).
 
 % This test suite assumes that tracing in general works. What we test is
 % the match spec functionality.
@@ -45,7 +47,7 @@ suite() ->
      {timetrap, {minutes, 1}}].
 
 all() ->
-    [test_1, test_2, test_3, caller_and_return_to, bad_match_spec_bin,
+    [test_1, test_2, test_3, test_4a, test_4b, test_5a, test_5b, caller_and_return_to, bad_match_spec_bin,
      trace_control_word, silent, silent_no_ms, silent_test, ms_trace2,
      ms_trace3, ms_trace_dead, boxed_and_small, destructive_in_test_bif,
      guard_exceptions, unary_plus, unary_minus, fpe,
@@ -171,6 +173,64 @@ test_3(Config) when is_list(Config) ->
     collect(P2, [{trace, P2, call, {?MODULE, f2, [a, a]}, [true,
 							     {?MODULE,f3,2}]}]),
     collect(P1, [{trace, P1, call, {?MODULE, f2, [a, b]}, [true]}]),
+    ok.
+
+%% Test `caller_line` trace with `call` and `global`
+test_4a(Config) when is_list(Config) ->
+    Fun = fun() -> ?MODULE:f3_test4(a, b) end,
+    Pat = [{'_', [],[{message, {caller_line}}]}],
+    P = spawn(?MODULE, runner, [self(), Fun]),
+    erlang:trace(P, true, [call]),
+    %% `global` is implied but we still mention explictly
+    erlang:trace_pattern({?MODULE, f2_test4, 2}, Pat, [global]),
+    erlang:trace_pattern({?MODULE, f1_test4, 1}, Pat, [global]),
+    collect(P, [{trace, P, call, {?MODULE, f2_test4, [a, b]}, {?MODULE, f3_test4, 2, {"test4.erl", 3}}},
+                {trace, P, call, {?MODULE, f1_test4, [a]}, {?MODULE, f3_test4, 2, {"test4.erl", 3}}}]),
+    ok.
+
+%% Test `caller_line` trace with `return_trace`, `call` and `global`
+test_4b(Config) when is_list(Config) ->
+    Fun = fun() -> ?MODULE:f3_test4(a, b) end,
+    P = spawn(?MODULE, runner, [self(), Fun]),
+    Pat = [{'_', [], [{return_trace}, {message, {caller_line}}]}],
+    erlang:trace(P, true, [call]),
+    %% `global` is implied but we still mention explictly
+    erlang:trace_pattern({?MODULE, f2_test4, 2}, Pat, [global]),
+    erlang:trace_pattern({?MODULE, f1_test4, 1}, Pat, [global]),
+    collect(P, [{trace, P, call, {?MODULE, f2_test4, [a, b]}, {?MODULE, f3_test4, 2, {"test4.erl", 3}}},
+                {trace, P, call, {?MODULE, f1_test4, [a]}, {?MODULE, f3_test4, 2, {"test4.erl", 3}}},
+                {trace, P, return_from, {?MODULE, f1_test4, 1}, {a}},
+                {trace, P, return_from, {?MODULE, f2_test4, 2}, {a}}
+               ]),
+    ok.
+
+%% Test `caller_line` trace with `call` and `local`
+test_5a(Config) when is_list(Config) ->
+    Fun = fun() -> f3_test5(a, b) end,
+    Pat = [{'_', [],[{message, {caller_line}}]}],
+    P = spawn(?MODULE, runner, [self(), Fun]),
+    erlang:trace(P, true, [call]),
+    %% Notice `local` function tracing
+    erlang:trace_pattern({?MODULE, f2_test5, 2}, Pat, [local]),
+    erlang:trace_pattern({?MODULE, f1_test5, 1}, Pat, [local]),
+    collect(P, [{trace, P, call, {?MODULE, f2_test5, [a, b]}, {?MODULE, f3_test5, 2, {"test5.erl", 3}}},
+                {trace, P, call, {?MODULE, f1_test5, [a]}, {?MODULE, f3_test5, 2, {"test5.erl", 3}}}]),
+    ok.
+
+%% Test `caller_line` trace with `return_trace`, `call` and `local`
+test_5b(Config) when is_list(Config) ->
+    Fun = fun() -> f3_test5(a, b) end,
+    P = spawn(?MODULE, runner, [self(), Fun]),
+    Pat = [{'_', [], [{return_trace}, {message, {caller_line}}]}],
+    erlang:trace(P, true, [call]),
+    %% Notice `local` function tracing
+    erlang:trace_pattern({?MODULE, f2_test5, 2}, Pat, [local]),
+    erlang:trace_pattern({?MODULE, f1_test5, 1}, Pat, [local]),
+    collect(P, [{trace, P, call, {?MODULE, f2_test5, [a, b]}, {?MODULE, f3_test5, 2, {"test5.erl", 3}}},
+                {trace, P, call, {?MODULE, f1_test5, [a]}, {?MODULE, f3_test5, 2, {"test5.erl", 3}}},
+                {trace, P, return_from, {?MODULE, f1_test5, 1}, {a}},
+                {trace, P, return_from, {?MODULE, f2_test5, 2}, {a}}
+               ]),
     ok.
 
 %% Test that caller and return to work as they should
@@ -1163,3 +1223,25 @@ start_node(Name) ->
 
 stop_node(Node) ->
     test_server:stop_node(Node).
+
+-file("test4.erl", 1).
+f3_test4(X,Y) ->
+    ?MODULE:f2_test4(X,Y), % Line 3 - This line number should remain stable
+    ok.
+
+f2_test4(X, _) ->
+    ?MODULE:f1_test4(X).
+
+f1_test4(X) ->
+    {X}.
+
+-file("test5.erl", 1).
+f3_test5(X,Y) ->
+    f2_test5(X,Y), % Line 3 - This line number should remain stable
+    ok.
+
+f2_test5(X, _) ->
+    f1_test5(X).
+
+f1_test5(X) ->
+    {X}.


### PR DESCRIPTION
```
   Tracing: Add new option `caller_line` for fun match spec body
    
    This is similar to `caller`. `caller` gives you {M, F, Arity} while
    `caller_line` gives you {M, F, Arity, {File, Line}} where
    File:Line is the source location of the function call site.
    
    If the location cannot be found you will get {M, F, Arity, undefined}.
```
-------
(The description below is the outdated one and can be ignored)
```
Tracing: Add new option `caller_line` for fun match spec body

This is similar to `caller`. `caller` gives you {M, F, Arity} while
`caller_line` gives you {M, F, Arity, Line} where Line is the source
code line number in which module M is located.
```

This is my first attempt at #5297 -- please suggest improvements. 

**BTW thanks for the pointers and tips on how to approach this feature**. 

I was able to create the new option `caller_line` by using the code for `caller` which is quite similar.

Continuing with the example mentioned here: https://github.com/erlang/otp/issues/5297#issuecomment-948587395

```erlang
-module(test_prog).
-export([foo/0]).

foo() ->
    lots(),
    ok.

lots() ->
    'of'().

'of'() ->
    indirections().

indirections() ->
    bar(10).

bar(0) ->
    done;
bar(N) ->
    bar(N - 1).
```

**And using the trace pattern:**

```elixir
 :erlang.trace_pattern(
      {:test_prog, :_, :_},
      [{:_, [], [{:return_trace}, {:message, {:caller_line}}]}],
      [:local]
    )
```
Notice `caller_line` (which is what this PR adds) instead of `caller` in the `:erlang.trace_pattern` 

**The trace from my custom tracer when invoking `test_prog:foo()` looks like this:**

```
1 call: :test_prog.foo() (from {erl_eval,do_apply,6,685})
2 call: :test_prog.lots() (from {test_prog,foo,0,16777221})
3 call: :test_prog.of() (from {test_prog,foo,0,16777221})
4 call: :test_prog.indirections() (from {test_prog,foo,0,16777221})
5 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
6 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
7 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
8 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
9 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
10 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
11 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
12 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
13 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
14 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
15 call: :test_prog.bar() (from {test_prog,foo,0,16777221})
```

- The `caller_line` option sends `{M, F, Arity, Line}`. **The first line 685 is correct**
- The rest of the line numbers are wrong, I'm guessing this is because of tail recursion
- For some reason, running traces on Elixir code also always gives junk line numbers 16777XXX though I need to explore this some more and see if it will work in some situations
 
cc: @jhogberg @garazdawi 