### PR TITLE
rpc require erpc support as of OTP 25

### DIFF
--- a/erts/emulator/test/hash_property_test_SUITE.erl
+++ b/erts/emulator/test/hash_property_test_SUITE.erl
@@ -80,7 +80,7 @@ test_phash2_no_diff_long(Config) when is_list(Config) ->
              Config).
 
 test_phash2_no_diff_between_versions(Config) when is_list(Config) ->
-    R = "21",
+    R = integer_to_list(list_to_integer(erlang:system_info(otp_release))-2) ++ "_latest",
     case test_server:is_release_available(R) of
         true ->
             Rel = {release,R},

--- a/lib/kernel/test/Makefile
+++ b/lib/kernel/test/Makefile
@@ -132,12 +132,16 @@ APP_FILES = \
 	topApp2.app \
 	topApp3.app
 
-ERL_FILES= $(MODULES:%=%.erl) code_a_test.erl
+SASL_MODULES= otp_vsns
+
+ERL_FILES= $(MODULES:%=%.erl) code_a_test.erl $(SASL_MODULES:%=$(ERL_TOP)/lib/sasl/test/%.erl)
 HRL_FILES= \
 	kernel_test_lib.hrl \
 	socket_test_evaluator.hrl \
 	socket_test_ttest.hrl \
 	socket_test_ttest_client.hrl
+
+EXTRA_FILES= $(ERL_TOP)/otp_versions.table
 
 TARGET_FILES= $(MODULES:%=$(EBIN)/%.$(EMULATOR))
 INSTALL_PROGS= $(TARGET_FILES)
@@ -176,7 +180,7 @@ erl_uds_dist.erl: ../examples/erl_uds_dist/src/erl_uds_dist.erl
 make_emakefile: $(ERL_FILES)
 	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) -o$(EBIN) '*_SUITE_make' \
 	> $(EMAKEFILE)
-	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) -o$(EBIN) $(MODULES) \
+	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) -o$(EBIN) $(MODULES) $(SASL_MODULES) \
 	>> $(EMAKEFILE)
 
 tests debug opt: make_emakefile
@@ -203,7 +207,7 @@ release_spec: opt
 release_tests_spec: make_emakefile
 	$(INSTALL_DIR) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(ERL_FILES) $(HRL_FILES) "$(RELSYSDIR)"
-	$(INSTALL_DATA) $(APP_FILES) "$(RELSYSDIR)"
+	$(INSTALL_DATA) $(APP_FILES) $(EXTRA_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) \
 		kernel.spec kernel_smoke.spec kernel_bench.spec logger.spec \
 		$(EMAKEFILE) $(COVERFILE) "$(RELSYSDIR)"

--- a/lib/kernel/test/erl_distribution_wb_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_wb_SUITE.erl
@@ -802,13 +802,13 @@ split(Atom) ->
 
 %% Build a distribution message that will make rex answer
 build_rex_message(Cookie,OurName) ->
-    [$?,term_to_binary({6,self(),Cookie,rex}),
+    [?PASS_THROUGH,term_to_binary({6,self(),Cookie,rex}),
      term_to_binary({'$gen_cast',
 		     {cast,
-		      rpc,
-		      cast,
-		      [OurName, hello, world, []],
-		      self()} })].
+		      erlang,
+		      send,
+		      [{regname, OurName}, "hello world"],
+                      self()}})].
 
 %% Receive a distribution message    
 recv_message(Socket) ->

--- a/lib/kernel/test/erpc_SUITE_data/Makefile.src
+++ b/lib/kernel/test/erpc_SUITE_data/Makefile.src
@@ -1,0 +1,39 @@
+#
+# %CopyrightBegin%
+# 
+# Copyright Ericsson AB 2021. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# %CopyrightEnd%
+#
+
+include @erl_interface_mk_include@
+
+CC = @CC@
+LD = @LD@
+
+CFLAGS = @EI_CFLAGS@ $(THR_DEFS) -I@erl_interface_include@ 
+
+LIBEI = @erl_interface_eilib@
+LIBFLAGS = $(LIBEI) @LIBS@ @erl_interface_sock_libs@ @erl_interface_threadlib@
+
+all: fwd_node@exe@
+
+fwd_node@exe@: fwd_node@obj@ $(LIBEI)
+	$(LD) @CROSSLDFLAGS@ -o $@ fwd_node@obj@ $(LIBFLAGS)
+
+clean:
+	$(RM) fwd_node@obj@
+	$(RM) fwd_node@exe@
+

--- a/lib/kernel/test/erpc_SUITE_data/fwd_node.c
+++ b/lib/kernel/test/erpc_SUITE_data/fwd_node.c
@@ -1,0 +1,205 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2021. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifndef __WIN32__
+#include <unistd.h>
+#include <errno.h>
+#include <pthread.h>
+#endif
+#include "ei.h"
+
+static void usage1(char *what);
+static void usage2(char *what, char *val);
+static void fail1(char *what);
+
+char *progname;
+ei_cnode cnode;
+char *node_name = NULL;
+char *cookie = NULL;
+short creation = -1;
+
+#ifndef __WIN32__
+
+static void *ei_node_executor(void *unused)
+{
+    int lfd, pfd, res, port;
+
+    ei_init();
+    res = ei_connect_init(&cnode, node_name, cookie, creation);
+    if (res < 0)
+        fail1("ei_connect_init");
+    port = 0;
+    lfd = ei_listen(&cnode, &port, 5);
+    if (lfd < 0)
+	fail1("ei_listen");
+    pfd = ei_publish(&cnode, port);
+    if (pfd < 0)
+	fail1("ei_publish");
+
+    printf("accepting");
+    fflush(stdout);
+
+    while (!0)  {
+        ErlConnect conn;
+        int afd = ei_accept(&cnode, lfd, &conn);
+        if (afd < 0)
+            fail1("ei_accept");
+
+        while (!0) {
+            ei_x_buff x;
+            erlang_msg msg;
+            ei_x_new(&x);
+            do {
+                res = ei_xreceive_msg(afd, &msg, &x);
+            } while (res == ERL_TICK);
+            if (res != ERL_MSG) {
+                /* connection closed... */
+                ei_close_connection(afd);
+                break;
+            }
+
+            switch (msg.msgtype) {
+            case ERL_SEND:
+            case ERL_REG_SEND:
+                ei_send_reg_encoded(afd, &cnode.self, "cnode_forward_receiver",
+                                    x.buff, x.index);
+                break;
+            case ERL_LINK:
+                fail1("received link");
+                break;
+            case ERL_UNLINK:
+                fail1("received unlink");
+                break;
+            case ERL_EXIT:
+                fail1("received exit");
+                break;
+            default:
+                fail1("received invalid signal");
+                break;
+            }
+            ei_x_free(&x);
+        }
+    }
+    
+    return NULL;
+}
+
+#endif
+
+int
+main(int argc, char *argv[])
+{
+#ifndef __WIN32__
+    pthread_t tid;
+#endif
+    int i;
+    
+    progname = argv[0];
+    i = 1;
+    while (i < argc) {
+        if (strcmp(argv[i], "-sname") == 0) {
+            i++;
+            if (i == argc)
+                usage1("Missing -sname value");
+            node_name = argv[i];
+        }
+        else if (strcmp(argv[i], "-cookie") == 0) {
+            i++;
+            if (i == argc)
+                usage1("Missing -cookie value");
+            cookie = argv[i];
+        }
+        else if (strcmp(argv[i], "-creation") == 0) {
+            char *endp;
+            long int val;
+            i++;
+            if (i == argc)
+                usage1("Missing -creation value");
+            val = strtol(argv[i], &endp, 10);
+            creation = (short) val;
+            if (*endp != '\0' || creation < 4)
+                usage2("Invalid creation", argv[i]);
+        }
+        else {
+            usage2("Unkown parameter", argv[i]);
+        }
+        i++;
+    }
+
+    if (!node_name)
+        usage1("Missing -sname parameter");
+    if (!cookie)
+        usage1("Missing -cookie parameter");
+    if (creation < 0)
+        usage1("Missing -creation parameter");
+
+#ifdef __WIN32__
+    fail1("Not supported on windows");
+#else
+    if (pthread_create(&tid, NULL, ei_node_executor, NULL) != 0)
+        fail1("pthread_create() failed");
+    
+    /* Wait until stdin is closed. Terminate when that happens... */
+    while (!0) {
+        char buf[128];
+        ssize_t res = read(0, (void *) &buf[0], sizeof(buf));
+        if (res == 0)
+            exit(0); /* erlang port closed... */
+        if (res < 0 && errno != EINTR) {
+            fail1("read() failed");
+        }
+    }
+#endif
+
+    return 0;
+}
+
+static void
+usage1(char *what)
+{
+    fprintf(stderr,
+            "ERROR: %s\n\n"
+            "  Usage:\n"
+            "    %s -sname <node name> -cookie <cookie> -creation <creation>\n",
+            what, progname);
+    exit(1);
+}
+
+static void
+usage2(char *what, char *val)
+{
+    fprintf(stderr,
+            "ERROR: %s: %s\n\n"
+            "  Usage:\n"
+            "    %s -sname <node name> -cookie <cookie> -creation <creation>\n",
+            what, val, progname);
+    exit(1);
+}
+
+static void
+fail1(char *what)
+{
+    fprintf(stderr, "%s FAILED: %s; %d\n",
+            cnode.thisalivename, what, erl_errno);
+    exit(1);
+}

--- a/lib/kernel/test/kernel_SUITE.erl
+++ b/lib/kernel/test/kernel_SUITE.erl
@@ -75,8 +75,6 @@ app_test(Config) when is_list(Config) ->
 appup_test(_Config) ->
     appup_tests(kernel,create_test_vsns(kernel)).
 
-appup_tests(_App,{[],[]}) ->
-    {skip,"no previous releases available"};
 appup_tests(App,{OkVsns0,NokVsns}) ->
     application:load(App),
     {_,_,Vsn} = lists:keyfind(App,1,application:loaded_applications()),
@@ -89,8 +87,7 @@ appup_tests(App,{OkVsns0,NokVsns}) ->
 	    OkVsns0 ->
 		OkVsns0;
 	    Ok ->
-		ct:log("Current version, ~p, is same as in previous release.~n"
-		       "Removing this from the list of ok versions.",
+		ct:log("Removed current version ~p from the list of ok versions to test.",
 		      [Vsn]),
 		Ok
 	end,
@@ -105,57 +102,46 @@ appup_tests(App,{OkVsns0,NokVsns}) ->
     ok.
 
 create_test_vsns(App) ->
-    ThisMajor = erlang:system_info(otp_release),
-    FirstMajor = previous_major(ThisMajor),
-    SecondMajor = previous_major(previous_major(FirstMajor)),
-    Ok = app_vsn(App,[ThisMajor,FirstMajor]),
-    Nok0 = app_vsn(App,[SecondMajor]),
+    S = otp_vsns:read_state(),
+    Rel = list_to_integer(erlang:system_info(otp_release)),
+    AppStr = atom_to_list(App),
+    Ok = ok_app_vsns(S, Rel, AppStr),
+    Nok0 = nok_app_vsns(S, Rel, AppStr, hd(Ok)),
     Nok = case Ok of
-	       [Ok1|_] ->
-		   [Ok1 ++ ",1" | Nok0]; % illegal
-	       _ ->
-		   Nok0
-	   end,
-    {Ok,Nok}.
+              [Ok1|_] ->
+                  [Ok1 ++ ",1" | Nok0]; % illegal
+              _ ->
+                  Nok0
+          end,
+    {Ok, Nok}.
 
-previous_major("17") ->
-    "r16b";
-previous_major("r16b") ->
-    "r15b";
-previous_major(Rel) ->
-    integer_to_list(list_to_integer(Rel)-1).
+ok_app_vsns(S, Rel, AppStr) ->
+    AppVsns0 = get_rel_app_vsns(S, Rel-2, AppStr),
+    AppVsns1 = get_rel_app_vsns(S, Rel-1, AppStr),
+    AppVsns2 = try
+                   get_rel_app_vsns(S, Rel, AppStr)
+               catch
+                   _:_ -> []
+               end,
+    lists:usort(AppVsns2 ++ AppVsns1 ++ AppVsns0).
 
-app_vsn(App,[R|Rs]) ->
-    OldRel =
-	case test_server:is_release_available(R) of
-	    true ->
-		{release,R};
-	    false ->
-		case ct:get_config({otp_releases,list_to_atom(R)}) of
-		    undefined ->
-			false;
-		    Prog0 ->
-			case os:find_executable(Prog0) of
-			    false ->
-				false;
-			    Prog ->
-				{prog,Prog}
-			end
-		end
-	end,
-    case OldRel of
-	false ->
-	    app_vsn(App,Rs);
-	_ ->
-	    {ok,N} = test_server:start_node(prevrel,peer,[{erl,[OldRel]}]),
-	    _ = rpc:call(N,application,load,[App]),
-	    As = rpc:call(N,application,loaded_applications,[]),
-	    {_,_,V} = lists:keyfind(App,1,As),
-	    test_server:stop_node(N),
-	    [V|app_vsn(App,Rs)]
-    end;
-app_vsn(_App,[]) ->
-    [].
+nok_app_vsns(S, Rel, AppStr, EarliestOkVsn) ->
+    AppVsns0 = get_rel_app_vsns(S, Rel-4, AppStr),
+    AppVsns1 = get_rel_app_vsns(S, Rel-3, AppStr),
+    %% Earliest OK version may exist in not OK versions
+    %% as well if there were no application version bump
+    %% between two releases, so we need to remove it
+    %% if that is the case...
+    lists:usort(AppVsns1 ++ AppVsns0) -- EarliestOkVsn.
+
+get_rel_app_vsns(S, Rel, App) ->
+    RelStr = integer_to_list(Rel),
+    OtpVsns = otp_vsns:branch_vsns(S, "maint-"++RelStr),
+    lists:map(fun (OtpVsn) ->
+                      AppVsn = otp_vsns:app_vsn(S, OtpVsn, App),
+                      [_, Vsn] = string:lexemes(AppVsn, "-"),
+                      Vsn
+              end, OtpVsns).
 
 check_appup([Vsn|Vsns],Instrs,Expected) ->
     case systools_relup:appup_search_for_version(Vsn, Instrs) of

--- a/lib/sasl/test/Makefile
+++ b/lib/sasl/test/Makefile
@@ -41,7 +41,7 @@ ERL_FILES= $(MODULES:%=%.erl)
 
 EXTRA_FILES= $(ERL_TOP)/otp_versions.table
 
-HRL_FILES= test_lib.hrl
+HRL_FILES=
 
 TARGET_FILES= $(MODULES:%=$(EBIN)/%.$(EMULATOR))
 INSTALL_PROGS= $(TARGET_FILES)

--- a/lib/sasl/test/Makefile
+++ b/lib/sasl/test/Makefile
@@ -35,8 +35,11 @@ MODULES= \
 	systools_rc_SUITE \
 	rb_SUITE \
 	rh_test_lib \
+	otp_vsns
 
 ERL_FILES= $(MODULES:%=%.erl)
+
+EXTRA_FILES= $(ERL_TOP)/otp_versions.table
 
 HRL_FILES= test_lib.hrl
 
@@ -87,7 +90,7 @@ release_spec: opt
 
 release_tests_spec: make_emakefile
 	$(INSTALL_DIR) "$(RELSYSDIR)"
-	$(INSTALL_DATA) $(ERL_FILES) $(HRL_FILES) "$(RELSYSDIR)"
+	$(INSTALL_DATA) $(ERL_FILES) $(HRL_FILES) $(EXTRA_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) sasl.spec sasl.cover $(EMAKEFILE) "$(RELSYSDIR)"
 	chmod -R u+w "$(RELSYSDIR)"
 	@tar cfh - *_SUITE_data | (cd "$(RELSYSDIR)"; tar xf -)

--- a/lib/sasl/test/installer.erl
+++ b/lib/sasl/test/installer.erl
@@ -20,8 +20,6 @@
 
 -module(installer).
 
--include("test_lib.hrl").
-
 %%-compile(export_all).
 -export([install_1/2]).
 -export([install_2/1]).
@@ -330,7 +328,7 @@ install_11(TestNode) ->
     true = lists:member("a-1.0", Libs),
     false = lists:member("a-1.1", Libs),
     {ok, Dirs} = file:list_dir(code:root_dir()),
-    ErtsDir = "erts-"++?ertsvsn,
+    ErtsDir = "erts-"++rh_test_lib:old_app_vsn(erts),
     [ErtsDir] = lists:filter(fun(Dir) -> lists:prefix("erts-",Dir) end, Dirs),
     ?print(["install_11 file checks ok"]),
     ok.
@@ -918,7 +916,9 @@ start_client_unix(TestNode,Sname,Node) ->
 start_client_win32(TestNode,Client,ClientSname) ->
     Name = atom_to_list(ClientSname) ++ "_P1G",
     RootDir = code:root_dir(),
-    ErtsBinDir = filename:join([RootDir,"erts-"++?ertsvsn,"bin"]),
+    ErtsBinDir = filename:join([RootDir,
+                                "erts-"++rh_test_lib:old_app_vsn(erts),
+                                "bin"]),
 
     {ClientArgs,RelClientDir} = rh_test_lib:get_client_args(Client,ClientSname,
 							    RootDir),

--- a/lib/sasl/test/otp_vsns.erl
+++ b/lib/sasl/test/otp_vsns.erl
@@ -20,11 +20,26 @@
 
 -module(otp_vsns).
 
--export([read_state/0, branch_latest/2, branch_vsns/2, app_vsn/3]).
+-export([read_state/0, read_state/1, branch_latest/2, branch_vsns/2, app_vsn/3]).
 
 read_state() ->
-    OtpVsnsTabFile = filename:join([filename:dirname(code:which(?MODULE)),
-                                    "otp_versions.table"]),
+    File = "otp_versions.table",
+    Dir = filename:dirname(code:which(?MODULE)),
+    Alt0 = filename:join([Dir, File]),
+    case file:read_file_info(Alt0) of
+        {ok, _} ->
+            read_state(Alt0);
+        _ ->
+            Alt1 = filename:join([Dir, "..", "priv", File]),
+            case file:read_file_info(Alt1) of
+                {ok, _} ->
+                    read_state(Alt1);
+                _ ->
+                    error(no_otp_versions_table)
+            end
+    end.
+
+read_state(OtpVsnsTabFile) ->
     {ok, OtpVsnsTabData} = file:read_file(OtpVsnsTabFile),
     lists:foldl(fun (OtpAppVsnsBin, Acc0) ->
                         [OtpVsnBin

--- a/lib/sasl/test/otp_vsns.erl
+++ b/lib/sasl/test/otp_vsns.erl
@@ -1,0 +1,145 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 2021. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+-module(otp_vsns).
+
+-export([read_state/0, branch_latest/2, branch_vsns/2, app_vsn/3]).
+
+read_state() ->
+    OtpVsnsTabFile = filename:join([filename:dirname(code:which(?MODULE)),
+                                    "otp_versions.table"]),
+    {ok, OtpVsnsTabData} = file:read_file(OtpVsnsTabFile),
+    lists:foldl(fun (OtpAppVsnsBin, Acc0) ->
+                        [OtpVsnBin
+                        | AppVsnBins] = binary:split(OtpAppVsnsBin,
+                                                     [<<" ">>,
+                                                      <<":">>,
+                                                      <<"#">>],
+                                                     [global, trim_all]),
+                        OtpVsn = mk_vsn(OtpVsnBin),
+                        AppList = lists:map(fun (AppVsnBin) ->
+                                                    AppVsn = mk_vsn(AppVsnBin),
+                                                    {App, _} = AppVsn,
+                                                    {App, AppVsn}
+                                            end,
+                                            AppVsnBins),
+                        AppMap = maps:from_list(AppList),
+                        Acc1 = maps:put(OtpVsn, AppMap, Acc0),
+                        Acc2 = update_branch(OtpVsn, Acc1),
+                        update_branch_versions(OtpVsn, Acc2)
+                end,
+                #{},
+                binary:split(OtpVsnsTabData, <<"\n">>, [global, trim_all])).
+
+branch_latest(State, "maint-" ++ RelStr) ->
+    mk_vsn_str(maps:get({maint, list_to_integer(RelStr)}, State)).
+
+branch_vsns(State, "maint-" ++ RelStr) ->
+    Rel = list_to_integer(RelStr),
+    NrmlVsns = lists:map(fun (V) -> mk_vsn_str(V) end,
+                         maps:get({normal_maint_vsns, Rel}, State)),
+    case maps:get({maint, Rel}, State) of
+        {'OTP', [_, _]} ->
+            NrmlVsns;
+        {'OTP', [_, _, _]} ->
+            NrmlVsns;
+        {'OTP', [_, _, _, _]} = Vsn ->
+            add_branched_vsns(1, Vsn, NrmlVsns)
+    end.
+
+add_branched_vsns(MinorPatch,
+                  {'OTP', [_Major, _Minor, _Patch, MinorPatch]} = Vsn,
+                  VsnStrs) ->
+    [mk_vsn_str(Vsn) | VsnStrs];
+add_branched_vsns(N,
+                  {'OTP', [Major, Minor, Patch, _MinorPatch]} = Vsn,
+                  VsnStrs) ->
+    VsnStr = mk_vsn_str({'OTP', [Major, Minor, Patch, N]}),
+    add_branched_vsns(N+1, Vsn, [VsnStr | VsnStrs]).
+
+app_vsn(State, "OTP-"++OtpVsn, App) ->
+    AppMap = maps:get({'OTP', vsnstr2vsnlist(OtpVsn)}, State),
+    mk_vsn_str(maps:get(list_to_atom(App), AppMap)).
+
+mk_vsn_str({App, Vsn}) ->
+    VsnStr = lists:flatten(lists:join($., lists:map(fun (V) ->
+                                                            integer_to_list(V)
+                                                    end, Vsn))),
+    atom_to_list(App) ++ "-" ++ VsnStr.
+
+mk_vsn(AppVsnBin) ->
+    [AppBin, VsnBin] = binary:split(AppVsnBin, <<"-">>),
+    {binary_to_atom(AppBin), vsnstr2vsnlist(VsnBin)}.
+
+vsnstr2vsnlist(VsnStr) ->
+    lists:map(fun (SV) when is_list(SV) ->
+                      list_to_integer(SV);
+                  (BV) when is_binary(BV) ->
+                      binary_to_integer(BV)
+              end, string:lexemes(VsnStr, ".")).
+
+update_branch({'OTP', [Major, Minor | _] = Vsn} = OtpVsn,
+              VsnMap) when length(Vsn) =< 4 ->
+    Branch = {maint, Major},
+    case maps:get(Branch, VsnMap, undefined) of
+        undefined ->
+            maps:put(Branch, OtpVsn, VsnMap);
+        {'OTP', [Major, OldMinor | _] = OldVsn} ->
+            if OldMinor < Minor ->
+                    maps:put(Branch, OtpVsn, VsnMap);
+               OldMinor > Minor ->
+                    VsnMap;
+               true ->
+                    {Patch, MinorPatch} = get_patch_vsns(Vsn),
+                    {OldPatch, OldMinorPatch} = get_patch_vsns(OldVsn),
+                    if OldPatch < Patch ->
+                            maps:put(Branch, OtpVsn, VsnMap);
+                       OldPatch > Patch ->
+                            VsnMap;
+                       OldMinorPatch < MinorPatch ->
+                            maps:put(Branch, OtpVsn, VsnMap);
+                       true ->
+                            VsnMap
+                    end
+            end
+    end;
+update_branch({'OTP', [_Major, _Minor | _]}, VsnMap) ->
+    VsnMap.
+
+update_branch_versions({'OTP', [Rel | _] = Vsn} = OtpVsn,
+                       VsnMap) when length(Vsn) =< 3 ->
+    %% Save normal versions. Branched versions are added on request
+    %% since we do not know the right branch until all versions has
+    %% been parsed.
+    BranchVsnsKey = {normal_maint_vsns, Rel},
+    OtherOtpVsns = case maps:get(BranchVsnsKey, VsnMap, undefined) of
+                       undefined -> [];
+                       Vsns -> Vsns
+                   end,
+    maps:put(BranchVsnsKey, [OtpVsn|OtherOtpVsns], VsnMap);
+update_branch_versions({'OTP', _}, VsnMap) ->
+    VsnMap.
+
+get_patch_vsns([_Major, _Minor]) ->
+    {0, 0};
+get_patch_vsns([_Major, _Minor, Patch]) ->
+    {Patch, 0};
+get_patch_vsns([_, _, Patch, MinorPatch | _]) ->
+    {Patch, MinorPatch}.

--- a/lib/sasl/test/release_handler_SUITE_data/lib/installer-1.0/ebin/installer.app
+++ b/lib/sasl/test/release_handler_SUITE_data/lib/installer-1.0/ebin/installer.app
@@ -1,6 +1,6 @@
 {application, installer,
 	     [{description, "Installer application"},
               {vsn, "1.0"},
-	      {modules, [installer,rh_test_lib]},
+	      {modules, [installer,rh_test_lib,otp_vsns]},
 	      {registered, []},
 	      {applications, [kernel, stdlib, sasl]}]}.

--- a/lib/sasl/test/rh_test_lib.erl
+++ b/lib/sasl/test/rh_test_lib.erl
@@ -12,6 +12,8 @@
 -export([clean_dir/1,
 	 clean_dir/2]).
 
+-export([old_app_vsn/1]).
+
 -include_lib("kernel/include/file.hrl").
 
 cmd(Cmd,Args,Env) ->
@@ -160,3 +162,23 @@ rm_rf([File|Files],Save) ->
     end;
 rm_rf([],_) ->
     ok.
+
+old_app_vsn(App) ->
+    %% Get oldest application version (erts, kernel, sasl,
+    %% stdlib) we support upgrade from, i.e., the first
+    %% application version in the release two releases
+    %% prior to current release...
+    State = case get('__otp_vsns_state__') of
+                undefined ->
+                    S = otp_vsns:read_state(),
+                    put('__otp_vsns_state__', S),
+                    S;
+                S ->
+                    S
+            end,
+    Rel = integer_to_list(list_to_integer(erlang:system_info(otp_release))-2),
+    AppVsn = otp_vsns:app_vsn(State, "OTP-"++Rel++".0", atom_to_list(App)),
+    [_, Vsn] = string:lexemes(AppVsn, "-"),
+    Vsn.
+
+

--- a/lib/sasl/test/sasl_SUITE.erl
+++ b/lib/sasl/test/sasl_SUITE.erl
@@ -74,8 +74,6 @@ app_test(Config) when is_list(Config) ->
 appup_test(_Config) ->
     appup_tests(sasl,create_test_vsns(sasl)).
 
-appup_tests(_App,{[],[]}) ->
-    {skip,"no previous releases available"};
 appup_tests(App,{OkVsns0,NokVsns}) ->
     application:load(App),
     {_,_,Vsn} = lists:keyfind(App,1,application:loaded_applications()),
@@ -88,8 +86,7 @@ appup_tests(App,{OkVsns0,NokVsns}) ->
 	    OkVsns0 ->
 		OkVsns0;
 	    Ok ->
-		ct:log("Current version, ~p, is same as in previous release.~n"
-		       "Removing this from the list of ok versions.",
+		ct:log("Removed current version ~p from the list of ok versions to test.",
 		      [Vsn]),
 		Ok
 	end,
@@ -104,57 +101,46 @@ appup_tests(App,{OkVsns0,NokVsns}) ->
     ok.
 
 create_test_vsns(App) ->
-    ThisMajor = erlang:system_info(otp_release),
-    FirstMajor = previous_major(ThisMajor),
-    SecondMajor = previous_major(previous_major(FirstMajor)),
-    Ok = app_vsn(App,[ThisMajor,FirstMajor]),
-    Nok0 = app_vsn(App,[SecondMajor]),
+    S = otp_vsns:read_state(),
+    Rel = list_to_integer(erlang:system_info(otp_release)),
+    AppStr = atom_to_list(App),
+    Ok = ok_app_vsns(S, Rel, AppStr),
+    Nok0 = nok_app_vsns(S, Rel, AppStr, hd(Ok)),
     Nok = case Ok of
-	       [Ok1|_] ->
-		   [Ok1 ++ ",1" | Nok0]; % illegal
-	       _ ->
-		   Nok0
-	   end,
-    {Ok,Nok}.
+              [Ok1|_] ->
+                  [Ok1 ++ ",1" | Nok0]; % illegal
+              _ ->
+                  Nok0
+          end,
+    {Ok, Nok}.
 
-previous_major("17") ->
-    "r16b";
-previous_major("r16b") ->
-    "r15b";
-previous_major(Rel) ->
-    integer_to_list(list_to_integer(Rel)-1).
+ok_app_vsns(S, Rel, AppStr) ->
+    AppVsns0 = get_rel_app_vsns(S, Rel-2, AppStr),
+    AppVsns1 = get_rel_app_vsns(S, Rel-1, AppStr),
+    AppVsns2 = try
+                   get_rel_app_vsns(S, Rel, AppStr)
+               catch
+                   _:_ -> []
+               end,
+    lists:usort(AppVsns2 ++ AppVsns1 ++ AppVsns0).
 
-app_vsn(App,[R|Rs]) ->
-    OldRel =
-	case test_server:is_release_available(R) of
-	    true ->
-		{release,R};
-	    false ->
-		case ct:get_config({otp_releases,list_to_atom(R)}) of
-		    undefined ->
-			false;
-		    Prog0 ->
-			case os:find_executable(Prog0) of
-			    false ->
-				false;
-			    Prog ->
-				{prog,Prog}
-			end
-		end
-	end,
-    case OldRel of
-	false ->
-	    app_vsn(App,Rs);
-	_ ->
-	    {ok,N} = test_server:start_node(prevrel,peer,[{erl,[OldRel]}]),
-	    _ = rpc:call(N,application,load,[App]),
-	    As = rpc:call(N,application,loaded_applications,[]),
-	    {_,_,V} = lists:keyfind(App,1,As),
-	    test_server:stop_node(N),
-	    [V|app_vsn(App,Rs)]
-    end;
-app_vsn(_App,[]) ->
-    [].
+nok_app_vsns(S, Rel, AppStr, EarliestOkVsn) ->
+    AppVsns0 = get_rel_app_vsns(S, Rel-4, AppStr),
+    AppVsns1 = get_rel_app_vsns(S, Rel-3, AppStr),
+    %% Earliest OK version may exist in not OK versions
+    %% as well if there were no application version bump
+    %% between two releases, so we need to remove it
+    %% if that is the case...
+    lists:usort(AppVsns1 ++ AppVsns0) -- EarliestOkVsn.
+
+get_rel_app_vsns(S, Rel, App) ->
+    RelStr = integer_to_list(Rel),
+    OtpVsns = otp_vsns:branch_vsns(S, "maint-"++RelStr),
+    lists:map(fun (OtpVsn) ->
+                      AppVsn = otp_vsns:app_vsn(S, OtpVsn, App),
+                      [_, Vsn] = string:lexemes(AppVsn, "-"),
+                      Vsn
+              end, OtpVsns).
 
 check_appup([Vsn|Vsns],Instrs,Expected) ->
     case systools_relup:appup_search_for_version(Vsn, Instrs) of

--- a/lib/sasl/test/test_lib.hrl
+++ b/lib/sasl/test/test_lib.hrl
@@ -1,3 +1,0 @@
--define(ertsvsn,"10.4").
--define(kernelvsn,"6.4").
--define(stdlibvsn,"3.9").

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -100,8 +100,13 @@ MODULES= \
 	zzz_SUITE
 
 ERTS_MODULES= erts_test_utils
+SASL_MODULES= otp_vsns
 
-ERL_FILES= $(MODULES:%=%.erl) $(ERTS_MODULES:%=$(ERL_TOP)/erts/emulator/test/%.erl)
+ERL_FILES=	$(MODULES:%=%.erl) \
+		$(ERTS_MODULES:%=$(ERL_TOP)/erts/emulator/test/%.erl) \
+		$(SASL_MODULES:%=$(ERL_TOP)/lib/sasl/test/%.erl)
+
+EXTRA_FILES= $(ERL_TOP)/otp_versions.table
 
 # ----------------------------------------------------
 # Release directory specification
@@ -126,7 +131,8 @@ COVERFILE=stdlib.cover
 # ----------------------------------------------------
 
 make_emakefile:
-	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) -o$(EBIN) $(MODULES) $(ERTS_MODULES) \
+	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) -o$(EBIN) \
+		$(MODULES) $(ERTS_MODULES) $(SASL_MODULES) \
 	> $(EMAKEFILE)
 
 tests debug opt: make_emakefile
@@ -149,7 +155,7 @@ release_spec: opt
 release_tests_spec: make_emakefile
 	$(INSTALL_DIR) "$(RELSYSDIR)"
 	$(INSTALL_DATA) stdlib.spec stdlib_bench.spec error_info.spec $(EMAKEFILE) \
-		$(ERL_FILES) $(COVERFILE) "$(RELSYSDIR)"
+		$(ERL_FILES) $(COVERFILE) $(EXTRA_FILES) "$(RELSYSDIR)"
 	chmod -R u+w "$(RELSYSDIR)"
 	@tar cf - *_SUITE_data property_test | (cd "$(RELSYSDIR)"; tar xf -)
 


### PR DESCRIPTION
erpc was introduced in OTP 23. That is, a lot of (most) rpc operations against nodes of releases prior to OTP 23 will fail.