### PR TITLE
Document UTF-8 as upcoming default atom encoding in OTP 26

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -11093,7 +11093,7 @@ hello
 	    </item>
 	    <tag><c>1</c></tag>
 	    <item>
-              <p>This is as of Erlang/OTP 17.0 the default. It forces any floats
+              <p>This is as of Erlang/OTP 17.0 the <em>default</em>. It forces any floats
 	      in the term to be encoded in a more space-efficient and exact way
 	      (namely in the 64-bit IEEE format, rather than converted to a
 	      textual representation). As from Erlang/OTP R11B-4,
@@ -11105,9 +11105,16 @@ hello
 	    <tag><c>2</c></tag>
 	    <item>
               <p>Drops usage of the latin1 atom encoding and unconditionally
-	      use utf8 encoding for all atoms. This will be changed to the
-	      default in a future major release of Erlang/OTP. Erlang/OTP
+	      use utf8 encoding for all atoms. Erlang/OTP
 	      systems as of R16B can decode this representation.</p>
+              <note>
+                <p>In Erlang/OTP 26, the default <c>minor_version</c> is planned
+                to change from 1 to 2. See
+                <seeguide marker="system/general_info:upcoming_incompatibilities#atoms_be_utf8">
+                  Upcoming Potential Incompatibilities
+                </seeguide>.
+                </p>
+              </note>
 	    </item>
 	  </taglist>
           <p>Option <c>deterministic</c> (introduced in OTP 24.1) can

--- a/system/doc/general_info/upcoming_incompatibilities.xml
+++ b/system/doc/general_info/upcoming_incompatibilities.xml
@@ -92,5 +92,45 @@
       </p>
     </section>
 
+    <section>
+      <marker id="atoms_be_utf8"/>
+      <title>Atoms will be encoded as UTF-8 by default</title>
+      <p>
+	As of OTP 26, the functions
+        <seemfa marker="erts:erlang#term_to_binary/1">
+        <c>erlang:term_to_binary/1,2</c></seemfa> and
+        <seemfa marker="erts:erlang#term_to_iovec/1">
+        <c>erlang:term_to_iovec/1,2</c></seemfa> will encode all atoms as
+        UTF-8 by default. The current default behavior is to encode atoms as
+        Latin-1 if possible.
+      </p>
+      <p>
+	If you implement your own decoding of the Erlang external format you
+        must either:
+      </p>
+      <list type="bulleted">
+        <item>
+          <p>
+            Make sure your implementation supports the UTF-8 encodings
+            <seeguide marker="erts:erl_ext_dist#ATOM_UTF8_EXT">
+              <c>ATOM_UTF8_EXT</c></seeguide> and
+            <seeguide marker="erts:erl_ext_dist#SMALL_ATOM_UTF8_EXT">
+              <c>SMALL_ATOM_UTF8_EXT</c></seeguide>.
+          </p>
+        </item>
+        <item>
+          <p>
+            Call <seemfa marker="erts:erlang#term_to_binary/2">
+            <c>erlang:term_to_binary/2</c></seemfa> or
+            <seemfa marker="erts:erlang#term_to_iovec/2">
+            <c>erlang:term_to_iovec/2</c></seemfa>
+            with option <c>{minor_version,1}</c> to force Latin-1 encoding. This
+            is a more short-term solution as Latin-1 encoding may be phased out
+            and removed in later OTP releases.
+          </p>
+        </item>
+      </list>
+    </section>
+
   </section>
 </chapter>


### PR DESCRIPTION
Today `erlang:term_to_binary` and `erlang:term_to_iovec` encodes atoms as Latin-1 if possible by default. This can be overridden with option `{minor_version, 2}` to encode atoms as UTF-8 unconditionally.

The aim of this PR is a step to further phase out the old Latin-1 encoding by documenting a planned change of the default atom encoding to UTF-8  in OTP 26. The default for `minor_version` will thus change from 1 to 2 in OTP 26.


