### PR TITLE
fixes #5311 – remove mention of "./otp_build autoconf" in README.md

### DIFF
--- a/.github/scripts/init-pre-release.sh
+++ b/.github/scripts/init-pre-release.sh
@@ -9,7 +9,6 @@ if [ -f ./configure ]; then
     git archive --prefix otp/ -o otp_src.tar.gz HEAD
 else
     ERL_TOP=`pwd`
-    ./otp_build autoconf
     find . -name aclocal.m4 | xargs git add -f
     find . -name configure | xargs git add -f
     find . -name config.h.in | xargs git add -f

--- a/HOWTO/OTP-PATCH-APPLY.md
+++ b/HOWTO/OTP-PATCH-APPLY.md
@@ -49,11 +49,6 @@ the updated applications.
 > *NOTE*: Before applying a patch you need to do a *full* build
 > of OTP in the source directory.
 
-If you are building in `git` you first need to generate the
-`configure` scripts:
-
-	$ ./otp_build autoconf
-
 Configure and build all applications in OTP:
 
 	$ configure

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ To compile Erlang from source, run the following commands. The complete building
 ```
 git clone https://github.com/erlang/otp.git
 cd otp
-./otp_build autoconf
 ./configure
 make
 make install

--- a/lib/megaco/Makefile
+++ b/lib/megaco/Makefile
@@ -115,7 +115,6 @@ include $(ERL_TOP)/make/otp_subdir.mk
 
 reconf:
 	(cd $(ERL_TOP) && \
-		./otp_build autoconf && \
 		./otp_build configure && \
 		cd $(ERL_TOP)/../libraries/megaco)
 

--- a/scripts/build-otp-tar
+++ b/scripts/build-otp-tar
@@ -473,11 +473,6 @@ else
     echo " " >> $build_log
     echo " === Running autoconf in OTP ================================ " >> $build_log
     echo " " >> $build_log
-    echo "./otp_build autoconf" >> $build_log
-    ./otp_build autoconf >> $build_log 2>&1
-    if [ $? -ne 0 ]; then
-	error "Failed to run autoconf in OTP"
-    fi
 
     progress "Configuring OTP"
     echo " " >> $build_log


### PR DESCRIPTION
- fixes #5311
- tested by building otp on macOS

The PR does not yet remove the autoconf task in [otp_build](https://github.com/erlang/otp/blob/OTP-24.1.2/otp_build#L1205-L1218) itself, so it still can be started with the note that it is not necessary to execute anymore.