### PR TITLE
erts: crash dump improvements

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -4271,7 +4271,7 @@ BIF_RETTYPE halt_2(BIF_ALIST_2)
 	erts_exit(ERTS_ABORT_EXIT, "");
     }
     else if (is_list(BIF_ARG_1) || BIF_ARG_1 == NIL) {
-#       define HALT_MSG_SIZE 200
+#       define HALT_MSG_SIZE 1023
         static byte halt_msg[4*HALT_MSG_SIZE+1];
         Sint written;
 


### PR DESCRIPTION
Crash dump slogan tends to be quite long, and limiting it to
200 characters does not allow to understand the cause even in simple
cases (like read-only HOME directory when `erl -name name` wants to
write a .cookie file). Extending `halt` reason helps to have a longer
slogan.

When SUSPEND signal is available, crash dump thread suspends all other
scheduler threads. It may happen that a scheduler thread suspends in
`malloc` call after taking the arena mutex, therefore all subsequent
malloc calls will hang. There are a few malloc calls made by system
libraries: one in fdopen (allocating locked_FD struct), and another in
ctime. Moving code that suspends schedulers helps to avoid this
deadlock, and also solves the problem when file descriptor cannot be
open and erl_crash_dump_v returns keeping schedulers suspended.