### PR TITLE
ssl: ssl_dist_test_lib observability adjustment

### DIFF
--- a/lib/ssl/test/ssl_dist_test_lib.hrl
+++ b/lib/ssl/test/ssl_dist_test_lib.hrl
@@ -22,5 +22,7 @@
 	{connection_handler,
 	 socket,
 	 name,
-	 nodename}
+	 nodename,
+         logfile,
+         dumpfile}
        ).


### PR DESCRIPTION
- Improve visibilty of log and crash dump paths
- Insert easy to parse paths in console and HTML links in test log
- To troubleshoot errors happening on distributed Erlang nodes