### PR TITLE
jit: Fix rem guard bif segfault

### DIFF
--- a/erts/emulator/beam/jit/x86/instr_arith.cpp
+++ b/erts/emulator/beam/jit/x86/instr_arith.cpp
@@ -417,13 +417,12 @@ void BeamGlobalAssembler::emit_int_div_rem_guard_shared() {
 
         emit_leave_runtime();
 
+        /* erts_int_div returns 0 on failure and 1 on success. */
+        a.test(RETd, RETd);
+
         /* Place the result in RAX:RDX, mirroring the `idiv` instruction. */
         a.mov(x86::rax, TMP_MEM1q);
         a.mov(x86::rdx, TMP_MEM2q);
-
-        /* erts_int_div returns a tagged value, so we know it's non-zero and can
-         * clear ZF by and it with itself. */
-        a.test(RET, RET);
 
         /* Fall through */
     }
@@ -498,7 +497,8 @@ void BeamGlobalAssembler::emit_int_div_rem_body_shared() {
 
         emit_leave_runtime();
 
-        a.test(RET, RET);
+        /* erts_int_div returns 0 on failure and 1 on success. */
+        a.test(RETd, RETd);
 
         /* Place the result in RAX:RDX, mirroring the `idiv` instruction. */
         a.mov(x86::rax, TMP_MEM4q);

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -2251,6 +2251,8 @@ bad_guards(Config) when is_list(Config) ->
 
     fc(catch bad_guards_4()),
 
+    {0,undefined} = bad_guards_5(id(<<>>), id(undefined)),
+
     ok.
 
 %% beam_bool used to produce GC BIF instructions whose
@@ -2273,6 +2275,15 @@ bad_guards_3(M, [_]) when is_map(M) andalso M#{a := 0, b => 0}, length(M) ->
 %% x(0) to be initialized.
 
 bad_guards_4() when not (error#{}); {not 0.0} -> freedom.
+
+%% The JIT used to segfault when a guard rem instruction failed
+%% with badarith AND a bif had been called just before it.
+bad_guards_5(A, B) ->
+    {byte_size(A), undefined = bad_guards_5_1(B)}.
+bad_guards_5_1(A) when is_integer(A rem 255) ->
+    A rem 255;
+bad_guards_5_1(_) ->
+    undefined.
 
 %% Building maps in a guard in a 'catch' would crash v3_codegen.
 


### PR DESCRIPTION
In x86 rax and RET are the same values, so for rem guards, the
value in RET was overwritten with the content of TMP[1] before
the test was done. This caused the rem to not fail as it should
and instead return the contents of TMP[1] which could be anything.