### PR TITLE
common_test: fix spec

### DIFF
--- a/lib/common_test/src/ct_gen_conn.erl
+++ b/lib/common_test/src/ct_gen_conn.erl
@@ -83,6 +83,7 @@
            | {use_existing_connection, boolean()}
            | {reconnect, boolean()}
            | {forward_messages, boolean()}
+           | {old, boolean()}
       ;    (Name, Address, InitData, CallbackMod)
    -> {ok, handle()} | {error, Reason :: term()}
  when Name :: ct:target_name(),


### PR DESCRIPTION
Add missing option to spec for ct_gen_conn:start/4.
Without it, dialyzer thinks ct_telnet:open would always fail
since it supplies this option.

CC: @tomas-abrahamsson @edvreu