### PR TITLE
kernel: Fix erl_epmd:address_please

### DIFF
--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -828,7 +828,9 @@ split_node(Node) ->
                     Split;
                 false ->
                     {host,Host}
-            end
+            end;
+        _ ->
+            {error, {invalid_node, Node}}
     end.
 
 %% Check if connecting node is allowed to connect

--- a/lib/kernel/src/inet_tcp_dist.erl
+++ b/lib/kernel/src/inet_tcp_dist.erl
@@ -39,9 +39,6 @@
 
 -include("net_address.hrl").
 
-
-
-
 -include("dist.hrl").
 -include("dist_util.hrl").
 
@@ -54,10 +51,13 @@ select(Node) ->
     gen_select(inet_tcp, Node).
 
 gen_select(Driver, Node) ->
-    case split_node(atom_to_list(Node), $@, []) of
-	[_, Host] ->
-	    case inet:getaddr(Host, Driver:family()) of
-                {ok,_} -> true;
+    case dist_util:split_node(Node) of
+	{node, Name, Host} ->
+            case call_epmd_function(
+                   net_kernel:epmd_module(), address_please,
+                   [Name, Host, Driver:family()]) of
+                {ok, _Addr} -> true;
+                {ok, _Addr, _Port, _Creation} -> true;
                 _ -> false
             end;
 	_ -> false

--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -53,15 +53,7 @@ select(Node) ->
     gen_select(inet_tcp, Node).
 
 gen_select(Driver, Node) ->
-    case dist_util:split_node(Node) of
-        {node,_,Host} ->
-	    case Driver:getaddr(Host) of
-		{ok, _} -> true;
-		_ -> false
-	    end;
-        _ ->
-            false
-    end.
+    inet_tcp_dist:gen_select(Driver, Node).
 
 %% ------------------------------------------------------------
 %% Get the address family that this distribution uses
@@ -582,8 +574,8 @@ do_setup_connect(Driver, Kernel, Node, Address, Ip, TcpPort, Version, Type, MyNo
     Opts =  trace(connect_options(get_ssl_options(client))),
     dist_util:reset_timer(Timer),
     case ssl:connect(
-        Address, TcpPort,
-        [binary, {active, false}, {packet, 4},
+        Ip, TcpPort,
+        [binary, {active, false}, {packet, 4}, {server_name_indication, Address},
             Driver:family(), {nodelay, true}] ++ Opts,
         net_kernel:connecttime()) of
     {ok, #sslsocket{pid = [_, DistCtrl| _]} = SslSocket} ->

--- a/lib/ssl/test/ssl_dist_test_lib.erl
+++ b/lib/ssl/test/ssl_dist_test_lib.erl
@@ -108,8 +108,7 @@ start_ssl_node(Name, Args) ->
 	    case await_ssl_node_up(Name, LSock) of
 		#node_handle{} = NodeHandle ->
 		    test_server:format("Ssl node ~s started.~n", [Name]),
-		    NodeName = list_to_atom(Name ++ "@" ++ host_name()),
-		    NodeHandle#node_handle{nodename = NodeName};
+		    NodeHandle;
 		Error ->
 		    exit({failed_to_start_node, Name, Error})
 	    end;
@@ -173,31 +172,36 @@ await_ssl_node_up(Name, LSock) ->
     end.
 
 check_ssl_node_up(Socket, Name, Bin) ->
+    NodeName =
+        case string:find(Name,"@") of
+            nomatch ->
+                list_to_atom(Name++"@"++host_name());
+            _ ->
+                list_to_atom(Name)
+        end,
     case catch binary_to_term(Bin) of
 	{'EXIT', _} ->
 	    gen_tcp:close(Socket),
 	    exit({bad_data_received_from_ssl_node, Name, Bin});
 	{ssl_node_up, NodeName} ->
-	    case list_to_atom(Name++"@"++host_name()) of
-		NodeName ->
-		    Parent = self(),
-		    Go = make_ref(),
-		    %% Spawn connection handler on test server side
-		    Pid = spawn(
-			    fun () ->
-                                    link(group_leader()),
-				    receive Go -> ok end,
-                                    process_flag(trap_exit, true),
-				    tstsrvr_con_loop(Name, Socket, Parent)
-			    end),
-		    ok = gen_tcp:controlling_process(Socket, Pid),
-		    Pid ! Go,
-		    #node_handle{connection_handler = Pid,
-				 socket = Socket,
-				 name = Name};
-		_ ->
-		    exit({unexpected_ssl_node_connected, NodeName})
-	    end;
+            Parent = self(),
+            Go = make_ref(),
+            %% Spawn connection handler on test server side
+            Pid = spawn(
+                    fun () ->
+                            link(group_leader()),
+                            receive Go -> ok end,
+                            process_flag(trap_exit, true),
+                            tstsrvr_con_loop(Name, Socket, Parent)
+                    end),
+            ok = gen_tcp:controlling_process(Socket, Pid),
+            Pid ! Go,
+            #node_handle{connection_handler = Pid,
+                         socket = Socket,
+                         nodename = NodeName,
+                         name = Name};
+        {ssl_node_up, OtherNodeName} ->
+            exit({unexpected_ssl_node_connected, OtherNodeName});
 	Msg ->
 	    exit({unexpected_msg_instead_of_ssl_node_up, Name, Msg})
     end.


### PR DESCRIPTION
The initial check for ipv4 vs ipv6 did not use the
erl_epmd interface to lookup the address which caused
invalid addresses to not be resolvable by erl_epmd callback
modules.

Closes #5334