### PR TITLE
Implement the compiler part of EEP 49

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1020,12 +1020,24 @@ do_parse_module(DefEncoding, #compile{ifile=File,options=Opts,dir=Dir}=St) ->
                         false ->
                             1
                     end,
+
+    ResWordFun = case proplists:get_value(enable_feature, Opts, []) of
+                     maybe ->
+                         fun('maybe') -> true;
+                            ('else') -> true;
+                            (Other) -> erl_scan:reserved_word(Other)
+                         end;
+                     _ ->
+                         fun erl_scan:reserved_word/1
+                 end,
+
     R = epp:parse_file(File,
                        [{includes,[".",Dir|inc_paths(Opts)]},
                         {source_name, SourceName},
                         {macros,pre_defs(Opts)},
                         {default_encoding,DefEncoding},
                         {location,StartLocation},
+                        {reserved_word_fun,ResWordFun},
                         extra]),
     case R of
 	{ok,Forms0,Extra} ->

--- a/lib/compiler/src/v3_kernel.erl
+++ b/lib/compiler/src/v3_kernel.erl
@@ -392,19 +392,27 @@ letrec_local_function(A, Cfs, Cb, Sub0, St0) ->
 %% Implement letrec with the single definition as a label and each
 %% apply of it as a goto.
 
-letrec_goto([{#c_var{name={Label,0}},Cfail}], Cb, Sub0,
+letrec_goto([{#c_var{name={Label,_Arity}},Cfail}], Cb, Sub0,
             #kern{labels=Labels0}=St0) ->
+    #c_fun{vars=FunVars,body=FunBody} = Cfail,
+    {Kvars,{FunSub,St1}} =
+        mapfoldl(fun(#c_var{anno=A,name=V}, {SubInt,StInt0}) ->
+                         {New,StInt1} = new_var_name(StInt0),
+                         {#k_var{anno=A,name=New},
+                          {set_vsub(V, New, SubInt),
+                           StInt1#kern{ds=sets:add_element(New, StInt1#kern.ds)}}}
+                 end, {Sub0,St0}, FunVars),
     Labels = sets:add_element(Label, Labels0),
-    {Kb,Pb,St1} = body(Cb, Sub0, St0#kern{labels=Labels}),
-    #c_fun{body=FailBody} = Cfail,
-    {Kfail,Fb,St2} = body(FailBody, Sub0, St1),
+    {Kb,Pb,St2} = body(Cb, Sub0, St1#kern{labels=Labels}),
+    {Kfail,Fb,St3} = body(FunBody, FunSub, St2),
     case {Kb,Kfail,Fb} of
         {#k_goto{label=Label},#k_goto{}=InnerGoto,[]} ->
-            {InnerGoto,Pb,St2};
+            {InnerGoto,Pb,St3};
         {_,_,_} ->
-            St3 = St2#kern{labels=Labels0},
-            Alt = #k_letrec_goto{label=Label,first=Kb,then=pre_seq(Fb, Kfail)},
-            {Alt,Pb,St3}
+            St4 = St3#kern{labels=Labels0},
+            Alt = #k_letrec_goto{label=Label,vars=Kvars,
+                                 first=Kb,then=pre_seq(Fb, Kfail)},
+            {Alt,Pb,St4}
     end.
 
 %% translate_match_fail(Arg, Sub, Anno, St) -> {Kexpr,[PreKexpr],State}.
@@ -559,10 +567,11 @@ match_vars(Ka, St0) ->
 %%  Transform application.
 
 c_apply(A, #c_var{anno=Ra,name={F0,Ar}}, Cargs, Sub, #kern{labels=Labels}=St0) ->
-    case Ar =:= 0 andalso sets:is_element(F0, Labels) of
+    case sets:is_element(F0, Labels) of
         true ->
             %% This is a goto to a label in a letrec_goto construct.
-            {#k_goto{label=F0},[],St0};
+            {Kargs,Ap,St1} = atomic_list(Cargs, Sub, St0),
+            {#k_goto{label=F0,args=Kargs},Ap,St1};
         false ->
             {Kargs,Ap,St1} = atomic_list(Cargs, Sub, St0),
             F1 = get_fsub(F0, Ar, Sub),         %Has it been rewritten

--- a/lib/compiler/src/v3_kernel.hrl
+++ b/lib/compiler/src/v3_kernel.hrl
@@ -56,8 +56,8 @@
 -record(k_try_enter, {anno=[],arg,vars,body,evars,handler}).
 -record(k_catch, {anno=[],body,ret=[]}).
 
--record(k_letrec_goto, {anno=[],label,first,then,ret=[]}).
--record(k_goto, {anno=[],label}).
+-record(k_letrec_goto, {anno=[],label,vars=[],first,then,ret=[]}).
+-record(k_goto, {anno=[],label,args=[]}).
 
 -record(k_match, {anno=[],body,ret=[]}).
 -record(k_alt, {anno=[],first,then}).

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -173,10 +173,11 @@ format_1(#k_alt{first=O,then=T}, Ctxt) ->
      format(O, Ctxt1),
      nl_indent(Ctxt1),
      format(T, Ctxt1)];
-format_1(#k_letrec_goto{label=Label,first=First,then=Then,ret=Rs}, Ctxt) ->
+format_1(#k_letrec_goto{label=Label,vars=Vs,first=First,then=Then,ret=Rs}, Ctxt) ->
     Ctxt1 = ctxt_bump_indent(Ctxt, Ctxt#ctxt.item_indent),
     ["letrec_goto ",
      atom_to_list(Label),
+     format_args(Vs, Ctxt),
      nl_indent(Ctxt1),
      format(Then, Ctxt1),
      nl_indent(Ctxt1),
@@ -185,8 +186,8 @@ format_1(#k_letrec_goto{label=Label,first=First,then=Then,ret=Rs}, Ctxt) ->
      "end",
      format_ret(Rs, Ctxt1)
     ];
-format_1(#k_goto{label=Label}, _Ctxt) ->
-    ["goto ",atom_to_list(Label)];
+format_1(#k_goto{label=Label,args=As}, Ctxt) ->
+    ["goto ",atom_to_list(Label),format_args(As, Ctxt)];
 format_1(#k_select{var=V,types=Cs}, Ctxt) ->
     Ctxt1 = ctxt_bump_indent(Ctxt, 2),
     ["select ",

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -38,6 +38,7 @@ MODULES= \
 	lc_SUITE \
 	map_SUITE \
 	match_SUITE \
+	maybe_SUITE \
 	misc_SUITE \
 	overridden_bif_SUITE \
 	random_code_SUITE \
@@ -72,6 +73,7 @@ NO_OPT= \
 	lc \
 	map \
 	match \
+	maybe \
 	misc \
 	overridden_bif \
 	receive \
@@ -98,6 +100,7 @@ INLINE= \
 	lc \
 	map \
 	match \
+	maybe \
 	misc \
 	overridden_bif \
 	receive \
@@ -162,8 +165,9 @@ RELSYSDIR = $(RELEASE_PATH)/compiler_test
 # FLAGS
 # ----------------------------------------------------
 
+MAYBE_OPT = '+{enable_feature,maybe}'
 ERL_MAKE_FLAGS +=
-ERL_COMPILE_FLAGS += +clint +clint0 +ssalint
+ERL_COMPILE_FLAGS += +clint +clint0 +ssalint $(MAYBE_OPT)
 
 EBIN = .
 

--- a/lib/compiler/test/beam_ssa_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_SUITE.erl
@@ -180,7 +180,7 @@ recv(_Config) ->
     self() ! 1,
     {1,yes} = tricky_recv_2(),
     self() ! 2,
-    {2,maybe} = tricky_recv_2(),
+    {2,'maybe'} = tricky_recv_2(),
 
     %% Test 'receive after infinity' in try/catch.
     Pid = spawn(fun recv_after_inf_in_try/0),
@@ -284,7 +284,7 @@ tricky_recv_2() ->
                 end,
             a;
         X=2 ->
-            Y = maybe,
+            Y = 'maybe',
             b
     end,
     {X,Y}.

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -272,10 +272,10 @@ booleans(_Config) ->
     true = is_atom(AnyAtom),
     false = is_boolean(AnyAtom),
 
-    MaybeBool = id(maybe),
+    MaybeBool = id('maybe'),
     case MaybeBool of
         true -> ok;
-        maybe -> ok;
+        'maybe' -> ok;
         false -> ok
     end,
     false = is_boolean(MaybeBool),

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1352,7 +1352,8 @@ warnings(_Config) ->
     test_lib:p_run(fun do_warnings/1, Files).
 
 do_warnings(F) ->
-    {ok,_,_,Ws} = compile:file(F, [binary,bin_opt_info,recv_opt_info,return]),
+    Options = [{enable_feature,'maybe'},binary,bin_opt_info,recv_opt_info,return],
+    {ok,_,_,Ws} = compile:file(F, Options),
     do_warnings_1(Ws, F).
 
 do_warnings_1([{"no_file",Ws}|_], F) ->

--- a/lib/compiler/test/match_SUITE.erl
+++ b/lib/compiler/test/match_SUITE.erl
@@ -497,7 +497,7 @@ untuplify_2(V1, V2) ->
 shortcut_boolean(Config) when is_list(Config) ->
     false = shortcut_boolean_1([0]),
     true = shortcut_boolean_1({42}),
-    maybe = shortcut_boolean_1(self()),
+    'maybe' = shortcut_boolean_1(self()),
     {'EXIT',_} = (catch shortcut_boolean_1([a,b])),
     {'EXIT',_} = (catch shortcut_boolean_1({a,b})),
     ok.
@@ -511,7 +511,7 @@ shortcut_boolean_1(X) ->
 			end,
 		    not V;
 		false ->
-		    maybe
+		    'maybe'
 	    end,
     id(Outer).
 

--- a/lib/compiler/test/maybe_SUITE.erl
+++ b/lib/compiler/test/maybe_SUITE.erl
@@ -1,0 +1,273 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2003-2020. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(maybe_SUITE).
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0, groups/0, init_per_suite/1, end_per_suite/1]).
+-export([basic/1, nested/1]).
+
+all() ->
+    [{group,p}].
+
+groups() ->
+    [{p,[parallel],
+      [basic,nested]}].
+
+init_per_suite(Config) ->
+    test_lib:recompile(?MODULE),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+-record(value, {v}).
+
+basic(_Config) ->
+    {ok,42,fish} = basic_1(0, #{0 => {ok,42}, 42 => {ok,fish}}),
+    error = basic_1(0, #{0 => {ok,42}, 42 => {error,whatever}}),
+    error = basic_1(0, #{0 => {ok,42}, 42 => error}),
+    error = basic_1(0, #{0 => error}),
+    error = basic_1(0, #{0 => {error,whatever}}),
+    some_value = basic_1(0, #{0 => #value{v=some_value}}),
+    {'EXIT',{{else_clause,something_wrong},[_|_]}} = catch basic_1(0, #{0 => something_wrong}),
+
+    {ok,life,"universe",everything} = basic_2(0, #{0 => {ok,life},
+                                                   life => "universe",
+                                                   "universe" => {ok,everything}}),
+    error = basic_2(0, #{0 => {ok,life},
+                         life => "universe",
+                         "universe" => error}),
+    {'EXIT',{{badmatch,not_a_list},[_|_]}} = catch basic_2(0, #{0 => {ok,life},
+                                                                life => not_a_list}),
+    {'EXIT',{{else_clause,not_ok},[_|_]}} = catch basic_2(0, #{0 => {ok,life},
+                                                               life => "universe",
+                                                               "universe" => not_ok}),
+    {'EXIT',{{else_clause,not_ok},[_|_]}} = catch basic_2(0, #{0 => not_ok}),
+
+    {ok,42,fish,dolphins} = basic_3(0, #{0 => {ok,42}, 42 => {ok,fish},
+                                         fish => {ok,#value{v=dolphins}}}),
+    {error,whatever} = basic_3(0, #{0 => {ok,42}, 42 => {error,whatever}}),
+    failed = basic_3(0, #{0 => {ok,42}, 42 => failed}),
+    failed_early = basic_3(0, #{0 => failed_early}),
+
+    y = maybe nomatch ?= id(x) else _ -> y end,
+    y = maybe nomatch ?= id(x) else _ -> x, y end,
+
+    x = maybe nomatch ?= id(x) else E1 -> E1 end,
+
+    6 = maybe X1 = 2+2, X1+2 end,
+    6 = maybe X2 = 2+2, X2+2 else {error, T} -> T end,
+    {"llo", "hello", "hello"} = maybe Y1 = "he"++X3=Z1 ?= "hello", {X3,Y1,Z1} end,
+    {"llo", "hello", "llo"} = maybe Y2 = "he"++(X4=Z2) ?= "hello", {X4,Y2,Z2} end,
+
+    whatever = maybe
+                   AlwaysMatching ?= id(whatever),
+                   AlwaysMatching
+               else
+                   E2 -> E2
+               end,
+
+    ok.
+
+basic_1(V0, M) ->
+    Res = basic_1a(V0, M),
+    {wrapped,Res} = basic_1b(V0, M),
+    {wrapped,Res} = basic_1c(V0, M),
+    Res.
+
+basic_1a(V0, M) ->
+    maybe
+        {ok,V1} ?= do_something(V0, M),
+        {ok,V2} ?= do_something(V1, M),
+        {ok,V1,V2}
+    else
+        {error,_} ->
+            error;
+        error ->
+            error;
+        #value{v=V} ->
+            V
+    end.
+
+basic_1b(V0, M) ->
+    Result =
+        maybe
+            {ok,V1} ?= do_something(V0, M),
+            {ok,V2} ?= do_something(V1, M),
+            {ok,V1,V2}
+        else
+            {error,_} ->
+                error;
+            error ->
+                error;
+            #value{v=V} ->
+                V
+        end,
+    {wrapped,Result}.
+
+basic_1c(V0, M) ->
+    OK = id(ok),
+    Error = id(error),
+    Result =
+        maybe
+            {OK,V1} ?= do_something(V0, M),
+            {OK,V2} ?= do_something(V1, M),
+            {OK,V1,V2}
+        else
+            {Error,_} ->
+                Error;
+            Error ->
+                Error;
+            #value{v=V} ->
+                V
+        end,
+    {wrapped,Result}.
+
+basic_2(V0, M) ->
+    Res = basic_2a(V0, M),
+    {wrapped,Res} = basic_2b(V0, M),
+    Res.
+
+basic_2a(V0, M) ->
+    maybe
+        {ok,V1} ?= do_something(V0, M),
+        V2 = [_|_] = do_something(V1, M),
+        {ok,V3} ?= do_something(V2, M),
+        {ok,V1,V2,V3}
+    else
+        {error,_} ->
+            error;
+        error ->
+            error;
+        #value{v=V} ->
+            V
+    end.
+
+basic_2b(V0, M) ->
+    Result =
+        maybe
+            {ok,V1} ?= do_something(V0, M),
+            V2 = [_|_] = do_something(V1, M),
+            {ok,V3} ?= do_something(V2, M),
+            {ok,V1,V2,V3}
+        else
+            {error,_} ->
+                error;
+            error ->
+                error;
+            #value{v=V} ->
+                V
+        end,
+    _ = id(0),
+    {wrapped,Result}.
+
+basic_3(V0, M) ->
+    Res = basic_3a(V0, M),
+    {wrapped,Res} = basic_3b(V0, M),
+    Res.
+
+basic_3a(V0, M) ->
+    maybe
+        {ok,V1} ?= do_something(V0, M),
+        {ok,V2} ?= do_something(V1, M),
+        {ok,#value{v=V3}} ?= do_something(V2, M),
+        {ok,V1,V2,V3}
+    end.
+
+basic_3b(V0, M) ->
+    Result =
+        maybe
+            {ok,V1} ?= do_something(V0, M),
+            {ok,V2} ?= do_something(V1, M),
+            {ok,#value{v=V3}} ?= do_something(V2, M),
+            {ok,V1,V2,V3}
+        end,
+    {wrapped,Result}.
+
+nested(_Config) ->
+    {outer_fail,not_ok} = nested_1(0, #{0 => not_ok}),
+    {x,{error,inner}} = nested_1(0, #{0 => {ok,x}, x => {error,inner}}),
+    {outer_fail,{unexpected,not_error}} = nested_1(0, #{0 => {ok,x}, x => not_error}),
+    ok.
+
+nested_1(V0, M) ->
+    Res = nested_1a(V0, M),
+    {wrapped,Res} = nested_1b(V0, M),
+    {wrapped,Res} = nested_1c(V0, M),
+    Res.
+
+nested_1a(V0, M) ->
+    maybe
+        {ok,V1} ?= do_something(V0, M),
+        V2 = {error,_} ?=
+            maybe
+                {error, _} ?= id(do_something(V1, M))
+            else
+                Unexpected -> {unexpected, Unexpected}
+            end,
+        {V1,V2}
+    else
+        Res -> {outer_fail,Res}
+    end.
+
+nested_1b(V0, M) ->
+    Result =
+        maybe
+            {ok,V1} ?= do_something(V0, M),
+            V2 = {error,_} ?=
+                maybe
+                    {error, _} ?= id(do_something(V1, M))
+                else
+                    Unexpected -> {unexpected, Unexpected}
+                end,
+            {V1,V2}
+        else
+            Res -> {outer_fail,Res}
+        end,
+    {wrapped,Result}.
+
+nested_1c(V0, M) ->
+    Result =
+        maybe
+            R ?= maybe
+                     {ok,V1} ?= do_something(V0, M),
+                     {error,_} = V2 ?=
+                         maybe
+                             {error, _} ?= id(do_something(V1, M))
+                         else
+                             Unexpected -> {unexpected, Unexpected}
+                         end,
+                     {V1,V2}
+                  else
+                     Res -> {outer_fail,Res}
+                 end,
+            R
+        else
+            Var -> Var
+        end,
+    {wrapped,Result}.
+
+%% Utility functions.
+
+do_something(V, M) ->
+    map_get(id(V), M).
+
+id(X) -> X.

--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -86,6 +86,7 @@ opt_opts(Mod) ->
     lists:filter(fun
                      (debug_info) -> true;
                      (dialyzer) -> true;
+                     ({enable_feature,_}) -> true;
                      (inline) -> true;
                      (no_bs_create_bin) -> true;
                      (no_bsm_opt) -> true;

--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -43,7 +43,8 @@
          redundant_boolean_clauses/1,
 	 underscore/1,no_warnings/1,
 	 bit_syntax/1,inlining/1,tuple_calls/1,
-         recv_opt_info/1,opportunistic_warnings/1]).
+         recv_opt_info/1,opportunistic_warnings/1,
+         eep49/1]).
 
 init_per_testcase(_Case, Config) ->
     Config.
@@ -66,7 +67,8 @@ groups() ->
        maps_bin_opt_info,
        redundant_boolean_clauses,
        underscore,no_warnings,bit_syntax,inlining,
-       tuple_calls,recv_opt_info,opportunistic_warnings]}].
+       tuple_calls,recv_opt_info,opportunistic_warnings,
+       eep49]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -1173,6 +1175,23 @@ opportunistic_warnings(Config) ->
 
 
     ok.
+
+%% Test value-based error handling (EEP 49).
+eep49(Config) ->
+    Ts = [{basic,
+           <<"foo(X) ->
+                  maybe
+                      %% There should be no warning.
+                      Always ?= X,
+                      Always
+                  end.
+           ">>,
+           [{enable_feature,'maybe'}],
+           []}
+	 ],
+    run(Config, Ts),
+    ok.
+
 
 %%%
 %%% End of test cases.

--- a/lib/dialyzer/src/dialyzer_clean_core.erl
+++ b/lib/dialyzer/src/dialyzer_clean_core.erl
@@ -109,6 +109,7 @@ clean_letrec(Tree) ->
       FunBody = cerl:fun_body(Fun),
       FunBody1 = clean(FunBody),
       Body = clean(cerl:letrec_body(Tree)),
+      FunVars = cerl:fun_vars(Fun),
       case dialyzer_ignore(Body) of
         true ->
           %% The body of the letrec directly transfer controls to
@@ -152,8 +153,10 @@ clean_letrec(Tree) ->
           %%    end
           %%
           PrimopUnknown = cerl:c_primop(cerl:abstract(dialyzer_unknown), []),
-          Clauses = [cerl:c_clause([cerl:abstract(a)], Body),
-                     cerl:c_clause([cerl:abstract(b)], FunBody1)],
+          PatA = [cerl:abstract(a)],
+          PatB = [cerl:c_tuple([cerl:abstract(b)|FunVars])],
+          Clauses = [cerl:c_clause(PatA, Body),
+                     cerl:c_clause(PatB, FunBody1)],
           cerl:c_case(PrimopUnknown, Clauses)
       end;
     false ->

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -837,6 +837,8 @@ scan_toks([{'-',_Lh},{atom,_Li,ifndef}=IfnDef|Toks], From, St) ->
     scan_ifndef(Toks, IfnDef, From, St);
 scan_toks([{'-',_Lh},{atom,_Le,'else'}=Else|Toks], From, St) ->
     scan_else(Toks, Else, From, St);
+scan_toks([{'-',_Lh},{'else',_Le}=Else|Toks], From, St) ->
+    scan_else(Toks, Else, From, St);
 scan_toks([{'-',_Lh},{'if',_Le}=If|Toks], From, St) ->
     scan_if(Toks, If, From, St);
 scan_toks([{'-',_Lh},{atom,_Le,elif}=Elif|Toks], From, St) ->
@@ -1328,6 +1330,8 @@ skip_toks(From, St, [I|Sis]) ->
 	{ok,[{'-',_Ah},{'if',_Ai}|_Toks],Cl} ->
 	    skip_toks(From, St#epp{location=Cl}, ['if',I|Sis]);
 	{ok,[{'-',_Ah},{atom,_Ae,'else'}=Else|_Toks],Cl}->
+	    skip_else(Else, From, St#epp{location=Cl}, [I|Sis]);
+	{ok,[{'-',_Ah},{'else',_Ae}=Else|_Toks],Cl}->
 	    skip_else(Else, From, St#epp{location=Cl}, [I|Sis]);
 	{ok,[{'-',_Ah},{atom,_Ae,'elif'}=Elif|Toks],Cl}->
 	    skip_elif(Toks, Elif, From, St#epp{location=Cl}, [I|Sis]);

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -73,7 +73,8 @@
 	            :: #{name() => [{argspec(), [used()]}]},
               default_encoding = ?DEFAULT_ENCODING :: source_encoding(),
 	      pre_opened = false :: boolean(),
-              fname = [] :: function_name_type()
+              fname = [] :: function_name_type(),
+              erl_scan_opts = [] :: erl_scan:options()
 	     }).
 
 %% open(Options)
@@ -604,11 +605,16 @@ init_server(Pid, FileName, Options, St0) ->
             %% first in path
             Path = [filename:dirname(FileName) |
                     proplists:get_value(includes, Options, [])],
+
+            ResWordFun = proplists:get_value(reserved_word_fun, Options,
+                                             fun erl_scan:reserved_word/1),
+
             %% the default location is 1 for backwards compatibility, not {1,1}
             AtLocation = proplists:get_value(location, Options, 1),
             St = St0#epp{delta=0, name=SourceName, name2=SourceName,
 			 path=Path, location=AtLocation, macs=Ms1,
-			 default_encoding=DefEncoding},
+			 default_encoding=DefEncoding,
+                         erl_scan_opts=[{reserved_word_fun,ResWordFun}]},
             From = wait_request(St),
             Anno = erl_anno:new(AtLocation),
             enter_file_reply(From, file_name(SourceName), Anno,
@@ -806,7 +812,7 @@ leave_file(From, St) ->
 %% scan_toks(Tokens, From, EppState)
 
 scan_toks(From, St) ->
-    case io:scan_erl_form(St#epp.file, '', St#epp.location) of
+    case io:scan_erl_form(St#epp.file, '', St#epp.location, St#epp.erl_scan_opts) of
 	{ok,Toks,Cl} ->
 	    scan_toks(Toks, From, St#epp{location=Cl});
 	{error,E,Cl} ->
@@ -1322,7 +1328,7 @@ new_location(Ln, {Le,_}, {Lf,_}) ->
 %%  nested conditionals and repeated 'else's.
 
 skip_toks(From, St, [I|Sis]) ->
-    case io:scan_erl_form(St#epp.file, '', St#epp.location) of
+    case io:scan_erl_form(St#epp.file, '', St#epp.location, St#epp.erl_scan_opts) of
 	{ok,[{'-',_Ah},{atom,_Ai,ifdef}|_Toks],Cl} ->
 	    skip_toks(From, St#epp{location=Cl}, [ifdef,I|Sis]);
 	{ok,[{'-',_Ah},{atom,_Ai,ifndef}|_Toks],Cl} ->

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -406,6 +406,17 @@ expr({'try',Anno,Es0,Scs0,Ccs0,As0}, St0) ->
 expr({'catch',Anno,E0}, St0) ->
     {E,St1} = expr(E0, St0),
     {{'catch',Anno,E},St1};
+expr({'maybe',MaybeAnno,Es0}, St0) ->
+    {Es,St1} = exprs(Es0, St0),
+    {{'maybe',MaybeAnno,Es},St1};
+expr({'maybe',MaybeAnno,Es0,{'else',ElseAnno,Cs0}}, St0) ->
+    {Es,St1} = exprs(Es0, St0),
+    {Cs,St2} = clauses(Cs0, St1),
+    {{'maybe',MaybeAnno,Es,{'else',ElseAnno,Cs}},St2};
+expr({maybe_match,Anno,P0,E0}, St0) ->
+    {E,St1} = expr(E0, St0),
+    {P,St2} = pattern(P0, St1),
+    {{maybe_match,Anno,P,E},St2};
 expr({match,Anno,P0,E0}, St0) ->
     {E,St1} = expr(E0, St0),
     {P,St2} = pattern(P0, St1),

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2579,6 +2579,23 @@ expr({match,_Anno,P,E}, Vt, St0) ->
     {Pvt,Pnew,St2} = pattern(P, vtupdate(Evt, Vt), St1),
     St = reject_invalid_alias_expr(P, E, Vt, St2),
     {vtupdate(Pnew, vtmerge(Evt, Pvt)),St};
+expr({maybe_match,Anno,P,E}, Vt, St0) ->
+    expr({match,Anno,P,E}, Vt, St0);
+expr({'maybe',Anno,Es}, Vt, St) ->
+    %% No variables are exported.
+    {Evt0, St1} = exprs(Es, Vt, St),
+    Evt1 = vtupdate(vtunsafe({'maybe',Anno}, Evt0, Vt), Vt),
+    Evt2 = vtmerge(Evt0, Evt1),
+    {Evt2,St1};
+expr({'maybe',MaybeAnno,Es,{'else',ElseAnno,Cs}}, Vt, St) ->
+    %% No variables are exported.
+    {Evt0, St1} = exprs(Es, Vt, St),
+    Evt1 = vtupdate(vtunsafe({'maybe',MaybeAnno}, Evt0, Vt), Vt),
+    {Cvt0, St2} = icrt_clauses(Cs, {'else',ElseAnno}, Evt1, St1),
+    Cvt1 = vtupdate(vtunsafe({'else',ElseAnno}, Cvt0, Vt), Vt),
+    Evt2 = vtmerge(Evt0, Evt1),
+    Cvt2 = vtmerge(Cvt0, Cvt1),
+    {vtmerge(Evt2, Cvt2),St2};
 %% No comparison or boolean operators yet.
 expr({op,_Anno,_Op,A}, Vt, St) ->
     expr(A, Vt, St);

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -48,13 +48,15 @@ top_type top_types type typed_expr typed_attr_val
 type_sig type_sigs type_guard type_guards fun_type binary_type
 type_spec spec_fun typed_exprs typed_record_fields field_types field_type
 map_pair_types map_pair_type
-bin_base_type bin_unit_type.
+bin_base_type bin_unit_type
+maybe_expr maybe_match_exprs maybe_match.
 
 Terminals
 char integer float atom string var
 
 '(' ')' ',' '->' '{' '}' '[' ']' '|' '||' '<-' ';' ':' '#' '.'
 'after' 'begin' 'case' 'try' 'catch' 'end' 'fun' 'if' 'of' 'receive' 'when'
+'maybe' 'else'
 'andalso' 'orelse'
 'bnot' 'not'
 '*' '/' 'div' 'rem' 'band' 'and'
@@ -63,6 +65,7 @@ char integer float atom string var
 '==' '/=' '=<' '<' '>=' '>' '=:=' '=/=' '<=' '=>' ':='
 '<<' '>>'
 '!' '=' '::' '..' '...'
+'?='
 'spec' 'callback' % helper
 dot.
 
@@ -257,6 +260,7 @@ expr_max -> case_expr : '$1'.
 expr_max -> receive_expr : '$1'.
 expr_max -> fun_expr : '$1'.
 expr_max -> try_expr : '$1'.
+expr_max -> maybe_expr : '$1'.
 
 pat_expr -> pat_expr '=' pat_expr : {match,first_anno('$1'),'$1','$3'}.
 pat_expr -> pat_expr comp_op pat_expr : ?mkop2('$1', '$2', '$3').
@@ -401,7 +405,6 @@ if_clauses -> if_clause ';' if_clauses : ['$1' | '$3'].
 if_clause -> guard clause_body :
 	{clause,first_anno(hd(hd('$1'))),[],'$1','$2'}.
 
-
 case_expr -> 'case' expr 'of' cr_clauses 'end' :
 	{'case',?anno('$1'),'$2','$4'}.
 
@@ -476,6 +479,19 @@ try_clause -> var ':' pat_expr try_opt_stacktrace clause_guard clause_body :
 
 try_opt_stacktrace -> ':' var : '$2'.
 try_opt_stacktrace -> '$empty' : '_'.
+
+
+maybe_expr -> 'maybe' maybe_match_exprs 'end' :
+	{'maybe',?anno('$1'),'$2'}.
+maybe_expr -> 'maybe' maybe_match_exprs 'else' cr_clauses 'end' :
+	{'maybe',?anno('$1'),'$2',{'else',?anno('$3'),'$4'}}.
+
+maybe_match_exprs -> maybe_match : ['$1'].
+maybe_match_exprs -> maybe_match ',' maybe_match_exprs : ['$1' | '$3'].
+maybe_match_exprs -> expr : ['$1'].
+maybe_match_exprs -> expr ',' maybe_match_exprs : ['$1' | '$3'].
+
+maybe_match -> expr '?=' expr : {maybe_match,?anno('$2'),'$1','$3'}.
 
 argument_list -> '(' ')' : {[],?anno('$1')}.
 argument_list -> '(' exprs ')' : {'$2',?anno('$1')}.

--- a/lib/stdlib/src/erl_pp.erl
+++ b/lib/stdlib/src/erl_pp.erl
@@ -675,6 +675,14 @@ lexpr({'catch',_,Expr}, Prec, Opts) ->
     {P,R} = preop_prec('catch'),
     El = {list,[{step,'catch',lexpr(Expr, R, Opts)}]},
     maybe_paren(P, Prec, El);
+lexpr({'maybe',_,Es}, _, Opts) ->
+    {list,[{step,'maybe',body(Es, Opts)},{reserved,'end'}]};
+lexpr({'maybe',_,Es,{'else',_,Cs}}, _, Opts) ->
+    {list,[{step,'maybe',body(Es, Opts)},{step,'else',cr_clauses(Cs, Opts)},{reserved,'end'}]};
+lexpr({maybe_match,_,Lhs,Rhs}, _, Opts) ->
+    Pl = lexpr(Lhs, 0, Opts),
+    Rl = lexpr(Rhs, 0, Opts),
+    {list,[{cstep,[Pl,leaf(" ?=")],Rl}]};
 lexpr({match,_,Lhs,Rhs}, Prec, Opts) ->
     {L,P,R} = inop_prec('='),
     Pl = lexpr(Lhs, L, Opts),
@@ -1330,7 +1338,7 @@ wordtable() ->
     L = [begin {leaf,Sz,S} = leaf(W), {S,Sz} end ||
             W <- [" ->"," =","<<",">>","[]","after","begin","case","catch",
                   "end","fun","if","of","receive","try","when"," ::","..",
-                  " |"]],
+                  " |","maybe","else"]],
     list_to_tuple(L).
 
 word(' ->', WT) -> element(1, WT);
@@ -1351,4 +1359,6 @@ word('try', WT) -> element(15, WT);
 word('when', WT) -> element(16, WT);
 word(' ::', WT) -> element(17, WT);
 word('..', WT) -> element(18, WT);
-word(' |', WT) -> element(19, WT).
+word(' |', WT) -> element(19, WT);
+word('maybe', WT) -> element(20, WT);
+word('else', WT) -> element(21, WT).

--- a/lib/stdlib/src/erl_scan.erl
+++ b/lib/stdlib/src/erl_scan.erl
@@ -427,6 +427,11 @@ scan1([C|Cs], St, Line, Col, Toks) when ?WHITE_SPACE(C) ->
             skip_white_space(Cs, St, Line, Col, Toks, 1)
     end;
 %% Punctuation characters and operators, first recognise multiples.
+%% ?= for the maybe ... else ... end construct
+scan1("?="++Cs, St, Line, Col, Toks) ->
+    tok2(Cs, St, Line, Col, Toks, "?=", '?=', 2);
+scan1("?"=Cs, _St, Line, Col, Toks) ->
+    {more,{Cs,Col,Toks,Line,[],fun scan/6}};
 %% << <- <=
 scan1("<<"++Cs, St, Line, Col, Toks) ->
     tok2(Cs, St, Line, Col, Toks, "<<", '<<', 2);

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -2010,6 +2010,9 @@ eval_tests(Config, Fun, Tests) ->
     F = fun({N,P,Opts,E}, BadL) ->
                 %% io:format("Testing ~p~n", [P]),
                 Return = Fun(Config, P, Opts),
+                %% The result should be the same when enabling maybe ... end
+                %% (making 'else' a keyword instead of an atom).
+                Return = Fun(Config, P, [{enable_feature,maybe}|Opts]),
                 case message_compare(E, Return) of
                     true ->
                         case E of

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -75,7 +75,8 @@
          otp_16824/1,
          underscore_match/1,
          unused_record/1,
-         unused_type2/1]).
+         unused_type2/1,
+         eep49/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -99,7 +100,8 @@ all() ->
      stacktrace_syntax, otp_14285, otp_14378, external_funs,
      otp_15456, otp_15563, unused_type, binary_types, removed, otp_16516,
      inline_nifs, warn_missing_spec, otp_16824,
-     underscore_match, unused_record, unused_type2].
+     underscore_match, unused_record, unused_type2,
+     eep49].
 
 groups() -> 
     [{unused_vars_warn, [],
@@ -4689,6 +4691,84 @@ unused_type2(Config) when is_list(Config) ->
          ],
     [] = run(Config, Ts),
 
+    ok.
+
+%% Test maybe ... else ... end.
+eep49(Config) when is_list(Config) ->
+    EnableMaybe = {enable_feature,'maybe'},
+    Ts = [{exp1,
+           <<"t(X) ->
+                  maybe
+                      A = X()
+                  end,
+                  A.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{5,19},erl_lint,{unsafe_var,'A',{'maybe',{2,19}}}}],
+            []}},
+
+          {exp2,
+           <<"t(X) ->
+                  maybe
+                      A = X()
+                  else
+                      _ -> {ok,A}
+                  end,
+                  A.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{5,32},erl_lint,{unsafe_var,'A',{'maybe',{2,19}}}},
+                    {{7,19},erl_lint,{unsafe_var,'A',{'maybe',{2,19}}}}],
+            []}},
+
+          {exp3,
+           <<"t(X) ->
+                  maybe
+                      X()
+                  else
+                      A ->
+                          B = 42,
+                          {error,A}
+                  end,
+                  {A,B}.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{9,20},erl_lint,{unsafe_var,'A',{'else',{4,19}}}},
+                    {{9,22},erl_lint,{unsafe_var,'B',{'else',{4,19}}}}],
+            []}},
+
+          {exp4,
+           <<"t(X) ->
+                  maybe
+                      X()
+                  else
+                      ok ->
+                          A = 42;
+                      error ->
+                          error
+                  end,
+                  A.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{10,19},erl_lint,{unsafe_var,'A',{'else',{4,19}}}}],
+            []}},
+
+          %% Using '?=' not at the top-level of a 'maybe' ... 'else' is forbidden.
+          {illegal_maybe_match1,
+           <<"t(X) ->
+                  maybe (ok ?= X()) end.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{2,29},erl_parse,["syntax error before: ","'?='"]}],[]}},
+          {illegal_maybe_match2,
+           <<"t(X) ->
+                  ok ?= X().
+           ">>,
+           [EnableMaybe],
+           {errors,[{{2,22},erl_parse,["syntax error before: ","'?='"]}],[]}}
+         ],
+
+    [] = run(Config, Ts),
     ok.
 
 format_error(E) ->


### PR DESCRIPTION
This pull request implements the compiler part of EEP 49 (Value-Based Error
Handling Mechanisms).

There is one difference compared to the current version of the EEP 49
document, namely that the matching operator now is `?=` instead of
`<~`. Thus the rewritten Mnesia code from the EEP will now look like:

    commit_write(OpaqueData) ->
        maybe
            ok ?= disk_log:sync(OpaqueData#backup.file_desc),
            ok ?= disk_log:close(OpaqueData#backup.file_desc),
            ok ?= file:rename(OpaqueData#backup.tmp_file, OpaqueData#backup.file),
            {ok, OpaqueData#backup.file}
        end.

The reason for the change is that `<-` and `<~` look too similar to
each other (especially with some fonts and text sizes) and could
easily be confused. `?=` does not have that problem, and its similarity
to `=` suggests that it is a matching operator.

The preprocessor uses `?` to signal the start of a macro invocation.
Although `=` is a valid macro name, that does not cause any ambiguity,
because macro names that are not atoms or variables must be
single-quoted. Therefore, `?=` is not a valid invocation of the `=`
macro; the invocation of the `=` macro must be written like `?'='`.

The `maybe` ... `else` ... `end` construct is only allowed to be used
if the compiler option `{enable_feature,maybe}` has been given. If
not given, `maybe` and `else` will be interpreted as atoms, and code
that use those atoms can be compiled. As currently implemented, the
`enable_feature` option will not be recognized if given in the source
code for the module. This limitation will be lifted later (there is
ongoing work on a more robust and general implementation of
`enable_feature`).

This PR supersedes #5340.