### PR TITLE
Fix C++ compiler error on Raspberry Pi 4

### DIFF
--- a/erts/include/internal/gcc/ethr_atomic.h
+++ b/erts/include/internal/gcc/ethr_atomic.h
@@ -496,13 +496,13 @@ ETHR_NATMC_FUNC__(or_retold_mb)(ETHR_ATMC_T__ *var, ETHR_AINT_T__ mask)
 
 static ETHR_INLINE ETHR_AINT_T__
 ETHR_NATMC_FUNC__(cmpxchg)(ETHR_ATMC_T__ *var,
-			   ETHR_AINT_T__ new,
+			   ETHR_AINT_T__ new_val,
 			   ETHR_AINT_T__ exp)
 {
     ETHR_AINT_T__ xchg = exp;
     if (__atomic_compare_exchange_n(&var->value,
 				    &xchg,
-				    new,
+				    new_val,
 				    0, /* No spurious failures, please */
 				    __ATOMIC_RELAXED,
 				    __ATOMIC_RELAXED))
@@ -522,13 +522,13 @@ ETHR_NATMC_FUNC__(cmpxchg)(ETHR_ATMC_T__ *var,
 
 static ETHR_INLINE ETHR_AINT_T__
 ETHR_NATMC_FUNC__(cmpxchg_acqb)(ETHR_ATMC_T__ *var,
-				ETHR_AINT_T__ new,
+				ETHR_AINT_T__ new_val,
 				ETHR_AINT_T__ exp)
 {
     ETHR_AINT_T__ xchg = exp;
     if (__atomic_compare_exchange_n(&var->value,
 				    &xchg,
-				    new,
+				    new_val,
 				    0, /* No spurious failures, please */
 				    __ATOMIC_ACQUIRE,
 				    __ATOMIC_ACQUIRE))
@@ -551,10 +551,10 @@ ETHR_NATMC_FUNC__(cmpxchg_acqb)(ETHR_ATMC_T__ *var,
 
 static ETHR_INLINE ETHR_AINT_T__
 ETHR_NATMC_FUNC__(cmpxchg_mb)(ETHR_ATMC_T__ *var,
-			      ETHR_AINT_T__ new,
+			      ETHR_AINT_T__ new_val,
 			      ETHR_AINT_T__ old)
 {
-    return __sync_val_compare_and_swap(&var->value, old, new);
+    return __sync_val_compare_and_swap(&var->value, old, new_val);
 }
 
 #endif /* ETHR_HAVE___sync_val_compare_and_swap */

--- a/erts/include/internal/gcc/ethr_dw_atomic.h
+++ b/erts/include/internal/gcc/ethr_dw_atomic.h
@@ -178,7 +178,7 @@ ethr_native_su_dw_atomic_read_acqb(ethr_native_dw_atomic_t *var)
 
 static ETHR_INLINE ETHR_NATIVE_SU_DW_SINT_T
 ethr_native_su_dw_atomic_cmpxchg(ethr_native_dw_atomic_t *var,
-				 ETHR_NATIVE_SU_DW_SINT_T new,
+				 ETHR_NATIVE_SU_DW_SINT_T new_val,
 				 ETHR_NATIVE_SU_DW_SINT_T exp)
 {
     ethr_native_dw_ptr_t p = (ethr_native_dw_ptr_t) ETHR_DW_NATMC_MEM__(var);
@@ -186,7 +186,7 @@ ethr_native_su_dw_atomic_cmpxchg(ethr_native_dw_atomic_t *var,
     ETHR_DW_DBG_ALIGNED__(p);
     if (__atomic_compare_exchange_n(p,
 				    &xchg,
-				    new,
+				    new_val,
 				    0,
 				    __ATOMIC_RELAXED,
 				    __ATOMIC_RELAXED))
@@ -202,7 +202,7 @@ ethr_native_su_dw_atomic_cmpxchg(ethr_native_dw_atomic_t *var,
 
 static ETHR_INLINE ETHR_NATIVE_SU_DW_SINT_T
 ethr_native_su_dw_atomic_cmpxchg_acqb(ethr_native_dw_atomic_t *var,
-				      ETHR_NATIVE_SU_DW_SINT_T new,
+				      ETHR_NATIVE_SU_DW_SINT_T new_val,
 				      ETHR_NATIVE_SU_DW_SINT_T exp)
 {
     ethr_native_dw_ptr_t p = (ethr_native_dw_ptr_t) ETHR_DW_NATMC_MEM__(var);
@@ -210,7 +210,7 @@ ethr_native_su_dw_atomic_cmpxchg_acqb(ethr_native_dw_atomic_t *var,
     ETHR_DW_DBG_ALIGNED__(p);
     if (__atomic_compare_exchange_n(p,
 				    &xchg,
-				    new,
+				    new_val,
 				    0,
 				    __ATOMIC_ACQUIRE,
 				    __ATOMIC_ACQUIRE))
@@ -229,12 +229,12 @@ ethr_native_su_dw_atomic_cmpxchg_acqb(ethr_native_dw_atomic_t *var,
 
 static ETHR_INLINE ETHR_NATIVE_SU_DW_SINT_T
 ethr_native_su_dw_atomic_cmpxchg_mb(ethr_native_dw_atomic_t *var,
-				    ETHR_NATIVE_SU_DW_SINT_T new,
+				    ETHR_NATIVE_SU_DW_SINT_T new_val,
 				    ETHR_NATIVE_SU_DW_SINT_T old)
 {
     ethr_native_dw_ptr_t p = (ethr_native_dw_ptr_t) ETHR_DW_NATMC_MEM__(var);
     ETHR_DW_DBG_ALIGNED__(p);
-    return __sync_val_compare_and_swap(p, old, new);
+    return __sync_val_compare_and_swap(p, old, new_val);
 }
 
 #endif /* ETHR_HAVE___sync_val_compare_and_swap */


### PR DESCRIPTION
This fixes the following error:

```
In file included from ../include/internal/gcc/ethread.h:381,
                 from ../include/internal/ethread.h:382,
                 from beam/erl_threads.h:248,
                 from beam/sys.h:536,
                 from beam/jit/beam_jit_common.hpp:35,
                 from beam/jit/beam_jit_common.cpp:21:
../include/internal/gcc/ethr_dw_atomic.h:232:34: error: expected ',' or '...' before 'new'
  232 |         ETHR_NATIVE_SU_DW_SINT_T new,
      |                                  ^~~
../include/internal/gcc/ethr_dw_atomic.h: In function 'ethr_sint128_t ethr_native_su_dw_atomic_cmpxchg_mb(ethr_native_dw_atomic_t*, ethr_sint128_t)':
../include/internal/gcc/ethr_dw_atomic.h:237:43: error: 'old' was not declared in this scope
  237 |     return __sync_val_compare_and_swap(p, old, new);
      |                                           ^~~
../include/internal/gcc/ethr_dw_atomic.h:237:51: error: expected type-specifier before ')' token
  237 |     return __sync_val_compare_and_swap(p, old, new);
      |                                                   ^
```
