### PR TITLE
stdlib: Add helper to support round tripping using erl_pp:form/{1,2}

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -806,6 +806,7 @@ abstr_passes(AbstrStatus) ->
 
          ?pass(expand_records),
          {iff,'dexp',{listing,"expand"}},
+         {iff,'E',?pass(legalize_vars)},
          {iff,'E',{src_listing,"E"}},
          {iff,'to_exp',{done,"E"}},
 
@@ -1420,6 +1421,14 @@ makedep_output(Code, #compile{options=Opts,ofile=Ofile}=St) ->
 
 expand_records(Code0, #compile{options=Opts}=St) ->
     Code = erl_expand_records:module(Code0, Opts),
+    {ok,Code,St}.
+
+legalize_vars(Code0, St) ->
+    Code = map(fun(F={function,_,_,_,_}) ->
+                       erl_pp:legalize_vars(F);
+                  (F) ->
+                       F
+               end, Code0),
     {ok,Code,St}.
 
 compile_directives(Forms, #compile{options=Opts0}=St0) ->

--- a/lib/compiler/test/compile_SUITE_data/bigE.erl
+++ b/lib/compiler/test/compile_SUITE_data/bigE.erl
@@ -1,0 +1,22 @@
+-module(bigE).
+
+-export([f/1]).
+
+-record(r, {a, b}).
+
+f(#r{b = B} = C) ->
+    receive
+	B ->
+	    X = C#r.a,
+            %% The compiler will do a case to extract the `a` field
+            %% using a pattern variable named `rec0`. Without
+            %% legalization the variable will be output as an atom and
+            %% the compiler will report an error as the following `X +
+            %% X` will always fail.
+	    REC0 = X + X,
+            %% If the legalization fails to detect that the default
+            %% legalization of uppercasing the pattern variable would
+            %% collide with the `REC0` below, we will get a warning
+            %% for an unsafe use.
+	    REC0
+    end.

--- a/lib/stdlib/doc/src/erl_pp.xml
+++ b/lib/stdlib/doc/src/erl_pp.xml
@@ -45,6 +45,14 @@
 
     <p>All functions can have an optional argument, which specifies a hook
       that is called if an attempt is made to print an unknown form.</p>
+
+    <p>Note that if the functions in this module are used to convert
+      abstract code back to Erlang source code, the enclosing function
+      should first be processed by <seemfa
+      marker="#legalize_vars/1"><c>legalize_vars/1</c></seemfa> in order
+      to ensure that the output is semantically equivalent to the
+      abstract code.</p>
+
   </description>
 
   <datatypes>
@@ -144,6 +152,29 @@
       <desc>
         <p>Same as <seemfa marker="#form/1"><c>form/1,2</c></seemfa>,
           but only for the guard test <c><anno>Guard</anno></c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="legalize_vars" arity="1" since=""/>
+      <fsummary>Ensure all variable names are valid.</fsummary>
+      <desc>
+        <p>The Erlang compiler will, when expanding records to tuples,
+          introduce new variables in the abstract representation. As the
+          expansion is done on the abstract representation, the compiler
+          can safely name the new variables with names that are not
+          syntactically valid in Erlang source code (the name starts
+          with a lowercase letter), thus ensuring the uniqueness of the
+          new names.</p>
+
+        <p>The above strategy leads to problems if a user wants to
+          convert the abstract representation, using the functions of
+          this module back to Erlang source code. Typically, pattern
+          variables are output as atoms thus changing the sematics of
+          the program. To solve this problem <c>legalize_vars/1</c>,
+          when run on the abstract representation of a function, will
+          return an equivalent function where all variables will have
+          syntactically valid names.</p>
       </desc>
     </func>
   </funcs>


### PR DESCRIPTION
The Erlang compiler will, when expanding records to tuples, introduce
new variables in the abstract representation. As the expansion is done
on the abstract representation, the compiler can safely name the new
variables with names that are not syntactically valid in Erlang source
code (The name starts with a lowercase letter), thus ensuring the
uniqueness of the new names.

The above strategy leads to problems if a user uses the compiler to
produce the abstract representation (using options `E` and `binary`),
transforms it and intends to use the functions in erl_pp to produce
source code, as the generated variable names will be printed as atoms.

This patch introduces an utility function, `erl_pp:legalize_vars/1`,
which when given the abstract representation of a function, will
return an equivalent function where all variables will have
syntactically valid names. As outputting Erlang source code from the
abstract representation is a niche application, the solution with an
utility function, instead of modifying compiler passes, was chosen to
not slow down the common use case.