### PR TITLE
Fix spec for name for supervisor_bridge:start_link

### DIFF
--- a/lib/stdlib/doc/src/supervisor_bridge.xml
+++ b/lib/stdlib/doc/src/supervisor_bridge.xml
@@ -72,16 +72,16 @@
               <c><anno>Name</anno></c> using <c>register/2</c>.</p>
           </item>
           <item>
-            <p>If <c><anno>SupBridgeName</anno>={global,<anno>Name</anno>}</c>,
+            <p>If <c><anno>SupBridgeName</anno>={global,<anno>GlobalName</anno>}</c>,
               the supervisor bridge is registered globally as
-              <c><anno>Name</anno></c> using
+              <c><anno>GlobalName</anno></c> using
               <seemfa marker="kernel:global#register_name/2">
               <c>global:register_name/2</c></seemfa>.</p>
           </item>
           <item>
             <p>If
-            <c><anno>SupBridgeName</anno>={via,<anno>Module</anno>,<anno>Name</anno>}</c>,
-            the supervisor bridge is registered as <c><anno>Name</anno></c>
+            <c><anno>SupBridgeName</anno>={via,<anno>Module</anno>,<anno>ViaName</anno>}</c>,
+            the supervisor bridge is registered as <c><anno>ViaName</anno></c>
             using a registry represented by <anno>Module</anno>. The
             <c>Module</c> callback is to export functions
             <c>register_name/2</c>, <c>unregister_name/1</c>, and <c>send/2</c>,

--- a/lib/stdlib/src/supervisor_bridge.erl
+++ b/lib/stdlib/src/supervisor_bridge.erl
@@ -64,8 +64,11 @@ start_link(Mod, StartArgs) ->
     gen_server:start_link(supervisor_bridge, [Mod, StartArgs, self], []).
 
 -spec start_link(SupBridgeName, Module, Args) -> Result when
-      SupBridgeName :: {local, Name} | {global, Name},
+      SupBridgeName :: {local, Name} | {global, GlobalName} |
+		       {via, Module, ViaName},
       Name :: atom(),
+      GlobalName :: term(),
+      ViaName :: term(),
       Module :: module(),
       Args :: term(),
       Result :: {ok, Pid} | ignore | {error, Error},


### PR DESCRIPTION
Add `{via, Module, ViaName}` that was missing, and correct the `Name` in `{global, Name}` to `term()`.

Without this fix, running dialyzer on a module calling for instance
```erlang
start_link() ->
    supervisor_bridge:start_link({via, gproc, {n, l, {x, y}}}, ?MODULE, []).
```
would wrongly lead to this error:
```
$ dialyzer -q --build_plt --output_plt p.plt --apps erts kernel stdlib
$ dialyzer -q --plt p.plt x.beam 

x.erl:34:1: Function start_link/0 has no local return
x.erl:35:34: The call supervisor_bridge:start_link
         ({'via', 'gproc', {'n', 'l', {'x', 'y'}}},
          'x',
          []) breaks the contract 
          (SupBridgeName, Module, Args) -> Result
             when
                 SupBridgeName :: {'local', Name} | {'global', Name},
                 Name :: atom(),
                 Module :: module(),
                 Args :: term(),
                 Result :: {'ok', Pid} | 'ignore' | {'error', Error},
                 Error :: {'already_started', Pid} | term(),
                 Pid :: pid()
```
With this PR, such a call dialyzes cleanly.