### PR TITLE
stdlib: Fix erl_error to print re compile errors

### DIFF
--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -296,7 +296,9 @@ format_re_error(compile, [_], _) ->
     [not_iodata];
 format_re_error(compile, [Re, _Options], Cause) ->
     ReError = try re:compile(Re) of
-                  _ -> []
+                  {ok, _} -> [];
+                  {error, Reason} ->
+                      {bad_regexp, Reason}
               catch
                   _:_ -> not_iodata
               end,
@@ -957,10 +959,21 @@ must_be_position(Pos) when is_integer(Pos) -> range;
 must_be_position(_) -> not_integer.
 
 must_be_regexp(Term) ->
-    try re:run("", Term) of
-        _ -> []
-    catch
-        error:_ -> not_regexp
+    %% First check if we can compile the regexp as this
+    %% returns better error messages
+    try re:compile(Term) of
+        {ok, _} ->
+            [];
+        {error, Reason} ->
+            {bad_regexp, Reason}
+    catch error:_ ->
+            %% Then check if we can run it as this also allows
+            %% compiled reg exps
+            try re:run("", Term) of
+                _ -> []
+            catch
+                error:_ -> not_regexp
+            end
     end.
 
 expand_error(already_owner) ->
@@ -1052,6 +1065,11 @@ expand_error(not_pid) ->
     <<"not a pid">>;
 expand_error(not_regexp) ->
     <<"neither an iodata term nor a compiled regular expression">>;
+expand_error({bad_regexp, {Reason,Column}}) ->
+    unicode:characters_to_binary(
+      io_lib:format("could not parse regular expression~n"
+                    "~ts on character ~p",
+                    [Reason, Column]));
 expand_error(not_tuple) ->
     <<"not a tuple">>;
 expand_error(not_tuple_or_list) ->

--- a/lib/stdlib/test/re_SUITE.erl
+++ b/lib/stdlib/test/re_SUITE.erl
@@ -1003,7 +1003,10 @@ bad_utf8_subject(Config) when is_list(Config) ->
 
 error_info(_Config) ->
     BadRegexp = {re_pattern,0,0,0,<<"xyz">>},
+    BadErr = "neither an iodata term",
     {ok,GoodRegexp} = re:compile(".*"),
+    InvalidRegexp = <<"(.*))">>,
+    InvalidErr = "could not parse regular expression\n.*unmatched parentheses.*",
 
     L = [{compile, [not_iodata]},
          {compile, [not_iodata, not_list],[{1,".*"},{2,".*"}]},
@@ -1021,28 +1024,35 @@ error_info(_Config) ->
          {internal_run, 4},                     %Internal.
 
          {replace, [{a,b}, {x,y}, {z,z}],[{1,".*"},{2,".*"},{3,".*"}]},
-         {replace, [{a,b}, BadRegexp, {z,z}],[{1,".*"},{2,".*"},{3,".*"}]},
+         {replace, [{a,b}, BadRegexp, {z,z}],[{1,".*"},{2,BadErr},{3,".*"}]},
+         {replace, [{a,b}, InvalidRegexp, {z,z}],[{1,".*"},{2,InvalidErr},{3,".*"}]},
 
          {replace, [{a,b}, {x,y}, {z,z}, [a|b]],[{1,".*"},{2,".*"},{3,".*"},{4,".*"}]},
-         {replace, [{a,b}, BadRegexp, [bad_option]],[{1,".*"},{2,".*"},{3,".*"}]},
+         {replace, [{a,b}, BadRegexp, [bad_option]],[{1,".*"},{2,BadErr},{3,".*"}]},
+         {replace, [{a,b}, InvalidRegexp, [bad_option]],[{1,".*"},{2,InvalidErr},{3,".*"}]},
          {replace, ["", "", {z,z}, not_a_list],[{3,".*"},{4,".*"}]},
 
          {run, [{a,b}, {x,y}],[{1,".*"},{2,".*"}]},
          {run, [{a,b}, ".*"]},
          {run, ["abc", {x,y}]},
-         {run, ["abc", BadRegexp]},
+         {run, ["abc", BadRegexp],[{2,BadErr}]},
+         {run, ["abc", InvalidRegexp],[{2,InvalidErr}]},
 
          {run, [{a,b}, {x,y}, []],[{1,".*"},{2,".*"}]},
-         {run, ["abc", BadRegexp, []]},
+         {run, ["abc", BadRegexp, []],[{2,BadErr}]},
+         {run, ["abc", InvalidRegexp, []],[{2,InvalidErr}]},
          {run, [{a,b}, {x,y}, [a|b]],[{1,".*"},{2,".*"},{3,".*"}]},
          {run, [{a,b}, ".*", bad_options],[{1,".*"},{3,".*"}]},
          {run, ["abc", {x,y}, [bad_option]],[{2,".*"},{3,".*"}]},
-         {run, ["abc", BadRegexp, 9999],[{2,".*"},{3,".*"}]},
+         {run, ["abc", BadRegexp, 9999],[{2,BadErr},{3,".*"}]},
+         {run, ["abc", InvalidRegexp, 9999],[{2,InvalidErr},{3,".*"}]},
 
-         {split, ["abc", BadRegexp]},
+         {split, ["abc", BadRegexp],[{2,BadErr}]},
+         {split, ["abc", InvalidRegexp],[{2,InvalidErr}]},
          {split, [{a,b}, ".*"]},
 
-         {split, ["abc", BadRegexp, [a|b]],[{2,".*"},{3,".*"}]},
+         {split, ["abc", BadRegexp, [a|b]],[{2,BadErr},{3,".*"}]},
+         {split, ["abc", InvalidRegexp, [a|b]],[{2,InvalidErr},{3,".*"}]},
          {split, [{a,b}, ".*", [bad_option]]},
 
          {ucompile, 2},                         %Internal.


### PR DESCRIPTION
When re:run and friends fail because the regexp is invalid it would print in the error message that the regexp was of
an invalid type. Now it will instead print the compilation error message gotten from running re:compile.

Before:

    > re:run("asd",")").
    ** exception error: bad argument
         in function  re:run/2
            called as re:run("asd",")")
            *** argument 2: neither an iodata term nor a compiled regular expression

After:

    > re:run("asd",")").
    ** exception error: bad argument
         in function  re:run/2
            called as re:run("asd",")")
            *** argument 2: could not parse regular expression
                            unmatched parentheses on character 0