### PR TITLE
common_test: add anchor links to log

### DIFF
--- a/lib/common_test/priv/ct_default.css
+++ b/lib/common_test/priv/ct_default.css
@@ -207,3 +207,8 @@ th + td {
     color: #fff;
     background-color: #809FFF;
 }
+
+a.link-to-entry {
+    float: right;
+    text-decoration: none;
+}


### PR DESCRIPTION
This adds "anchor links" to the common_test log output. This enables linking to a particular log entry.
A-tags with an ever-incremented id, and href to that same #id are added after 'hd' parts of logged data.
![Screenshot from 2021-11-12 13-01-20](https://user-images.githubusercontent.com/3988878/141466351-8dbcf8f3-24e5-4158-90e7-e92e40f39f51.png)

As suggested/inspired by: @tomas-abrahamsson 
