### PR TITLE
Remove superfluous "otp_build autoconf" and improve README build instructions

### DIFF
--- a/.github/scripts/init-pre-release.sh
+++ b/.github/scripts/init-pre-release.sh
@@ -1,26 +1,6 @@
 #!/bin/sh
 
-## We create a tar ball that has generated configure
-## (old versions might not have these included)
-## This is used later by build-otp-tar to create
-## the pre-built tar ball
+## We create a tar ball that is used later by build-otp-tar
+## to create the pre-built tar ball
 
-if [ -f ./configure ]; then
-    git archive --prefix otp/ -o otp_src.tar.gz HEAD
-else
-    ERL_TOP=`pwd`
-    ./otp_build autoconf
-    find . -name aclocal.m4 | xargs git add -f
-    find . -name configure | xargs git add -f
-    find . -name config.h.in | xargs git add -f
-    find . -name config.guess | xargs git add -f
-    find . -name config.sub | xargs git add -f
-    find . -name install-sh | xargs git add -f
-    if ! git config user.name; then
-	git config user.email "you@example.com"
-	git config user.name "Your Name"
-    fi
-    git commit --no-verify -m 'Add generated configure files'
-    git archive --prefix otp/ -o otp_src.tar.gz HEAD
-    git reset --hard HEAD~1
-fi
+git archive --prefix otp/ -o otp_src.tar.gz HEAD

--- a/HOWTO/OTP-PATCH-APPLY.md
+++ b/HOWTO/OTP-PATCH-APPLY.md
@@ -49,11 +49,6 @@ the updated applications.
 > *NOTE*: Before applying a patch you need to do a *full* build
 > of OTP in the source directory.
 
-If you are building in `git` you first need to generate the
-`configure` scripts:
-
-	$ ./otp_build autoconf
-
 Configure and build all applications in OTP:
 
 	$ configure

--- a/README.md
+++ b/README.md
@@ -41,7 +41,17 @@ To compile Erlang from source, run the following commands. The complete building
 ```
 git clone https://github.com/erlang/otp.git
 cd otp
+```
+Checkout the branch or tag of your choice
+```
+git checkout maint-24    # current latest stable version
+```
+For older versions run autoconf
+```
 ./otp_build autoconf
+```
+Configure, build and install
+```
 ./configure
 make
 make install

--- a/lib/megaco/Makefile
+++ b/lib/megaco/Makefile
@@ -115,7 +115,6 @@ include $(ERL_TOP)/make/otp_subdir.mk
 
 reconf:
 	(cd $(ERL_TOP) && \
-		./otp_build autoconf && \
 		./otp_build configure && \
 		cd $(ERL_TOP)/../libraries/megaco)
 

--- a/scripts/build-otp-tar
+++ b/scripts/build-otp-tar
@@ -469,16 +469,6 @@ else
     echo " === Environment ==================================== " >> $build_log
     env >> $build_log
 
-    progress "Running autoconf in OTP"
-    echo " " >> $build_log
-    echo " === Running autoconf in OTP ================================ " >> $build_log
-    echo " " >> $build_log
-    echo "./otp_build autoconf" >> $build_log
-    ./otp_build autoconf >> $build_log 2>&1
-    if [ $? -ne 0 ]; then
-	error "Failed to run autoconf in OTP"
-    fi
-
     progress "Configuring OTP"
     echo " " >> $build_log
     echo " === Configuring OTP ================================ " >> $build_log


### PR DESCRIPTION
One commit from @marcellanz (#5311) removing `otp_build autoconf` from various scripts and docs (except README.md). Also thanks to @v0idpwn and @kpy3 for earlier stabs at `otp_build autoconf` in README.md.


Added some comments and a "git checkout" step to the build instructions in README.md,
which can be viewed here:
https://github.com/sverker/otp/tree/sverker/otp_build-autoconf-cleanup