### PR TITLE
erts: Remove `CFBundle*` fields from `Info.plist`

### DIFF
--- a/erts/etc/darwin/Info.plist
+++ b/erts/etc/darwin/Info.plist
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleName</key>
-	<string>Erlang</string>
-	<key>CFBundleDisplayname</key>
-	<string>Erlang</string>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
-	<key>CFBundleIdentifier</key>
-	<string>org.erlang.beam</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>


### PR DESCRIPTION
I'm building an `.app` bundle with it's own `Info.plist`. In my plist,
the values I'm putting in seem to be ignored, when running the app,
the app name in the menu bar is always "Erlang".

With this patch, the `CFBundle*` from my app's plist take effect.

One should be able to re-produce this issue by executing this shell
script:

```sh
#!/bin/bash
set -e

rm -rf Example.app
mkdir -p Example.app/Contents/MacOS

cat <<EOF > Example.app/Contents/Info.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>CFBundleName</key>
  <string>Example</string>
  <key>CFBundleDisplayName</key>
  <string>Example</string>
</dict>
</plist>
EOF

cat <<EOF > Example.app/Contents/MacOS/Example
#!/bin/bash
erl -noshell -eval '
Wx=wx:new(), F=wxFrame:new(Wx,-1,"Example",[]), wxFrame:show(F),

%% listen for menubar events, in particular cmd+q so we can quit.
MenuBar = wxMenuBar:new(), wxFrame:setMenuBar(F,MenuBar),
wxFrame:connect(F,command_menu_selected),
receive Event ->
    io:format("~p~n", [Event])
end,
halt().
' > ~/Example.stdout 2> ~/Example.stderr
EOF

chmod +x Example.app/Contents/MacOS/Example
open Example.app
```
