### PR TITLE
[ssl] fix SSL tests run in specific environment

### DIFF
--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -409,7 +409,7 @@ run_where(_, ipv6) ->
     {ClientNode, ServerNode, Host}.
 
 node_to_hostip(Node, Role) ->
-    [_ , Host] = string:tokens(atom_to_list(Node), "@"),
+    Host = rpc:call(Node, net_adm, localhost, []),
     {ok, Address} = inet:getaddr(Host, inet),
     %% Convert client addresses in 127.0.0.0/24 subnet to the atom 'localhost'.
     %% This is a workaround for testcase problems caused by the fact that


### PR DESCRIPTION
Before this patch, run_where and node_to_hostip were returning
different IP addresses, failing large number of tests when /etc/hosts
file was containing
    host 127.0.0.1
    host.domain 127.0.0.2

It was happening because `node()` was `test_server@host`, while
`net_adm:localhost()` was returning `host.domain`, so they were
returning different IP addresses, subsequently failing in verification
in check_result/4.