### PR TITLE
Implement EEP 49 (Value-Based Error Handling Mechanisms)

### DIFF
--- a/erts/doc/src/absform.xml
+++ b/erts/doc/src/absform.xml
@@ -430,6 +430,21 @@
           <c>{match,ANNO,Rep(P),Rep(E_0)}</c>.</p>
       </item>
       <item>
+        <p>If E is a conditional match operator expression <c>P ?= E_0</c>,
+          where <c>P</c> is a pattern, then Rep(E) =
+          <c>{maybe_match,ANNO,Rep(P),Rep(E_0)}</c>.</p>
+      </item>
+      <item>
+        <p>If E is a maybe expression <c>maybe B end</c>,
+          where <c>B</c> is a body then Rep(E) =
+          <c>{'maybe',ANNO,Rep(B)}</c>.</p>
+      </item>
+      <item>
+        <p>If E is a maybe expression <c>maybe B else Ec_1 ; ... ; Ec_k end end</c>,
+          where <c>B</c> is a body and each <c>Ec_i</c> is an else clause then Rep(E) =
+          <c>{'maybe',ANNO,Rep(B),{'else',ANNO,[Rep(Ec_1), ..., Rep(Tc_k)]}}</c>.</p>
+      </item>
+      <item>
         <p>If E is nil, <c>[]</c>, then Rep(E) = <c>{nil,ANNO}</c>.</p>
       </item>
       <item>

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1022,12 +1022,25 @@ do_parse_module(DefEncoding, #compile{ifile=File,options=Opts,dir=Dir}=St) ->
                         false ->
                             1
                     end,
+
+    %% FIXME: Rewrite this when the enable feature EEP has been implemented.
+    ResWordFun = case proplists:get_value(enable_feature, Opts, []) of
+                     maybe_expr ->
+                         fun('maybe') -> true;
+                            ('else') -> true;
+                            (Other) -> erl_scan:reserved_word(Other)
+                         end;
+                     _ ->
+                         fun erl_scan:reserved_word/1
+                 end,
+
     R = epp:parse_file(File,
                        [{includes,[".",Dir|inc_paths(Opts)]},
                         {source_name, SourceName},
                         {macros,pre_defs(Opts)},
                         {default_encoding,DefEncoding},
                         {location,StartLocation},
+                        {reserved_word_fun,ResWordFun},
                         extra]),
     case R of
 	{ok,Forms0,Extra} ->

--- a/lib/compiler/src/v3_kernel.hrl
+++ b/lib/compiler/src/v3_kernel.hrl
@@ -56,8 +56,8 @@
 -record(k_try_enter, {anno=[],arg,vars,body,evars,handler}).
 -record(k_catch, {anno=[],body,ret=[]}).
 
--record(k_letrec_goto, {anno=[],label,first,then,ret=[]}).
--record(k_goto, {anno=[],label}).
+-record(k_letrec_goto, {anno=[],label,vars=[],first,then,ret=[]}).
+-record(k_goto, {anno=[],label,args=[]}).
 
 -record(k_match, {anno=[],body,ret=[]}).
 -record(k_alt, {anno=[],first,then}).

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -173,10 +173,11 @@ format_1(#k_alt{first=O,then=T}, Ctxt) ->
      format(O, Ctxt1),
      nl_indent(Ctxt1),
      format(T, Ctxt1)];
-format_1(#k_letrec_goto{label=Label,first=First,then=Then,ret=Rs}, Ctxt) ->
+format_1(#k_letrec_goto{label=Label,vars=Vs,first=First,then=Then,ret=Rs}, Ctxt) ->
     Ctxt1 = ctxt_bump_indent(Ctxt, Ctxt#ctxt.item_indent),
     ["letrec_goto ",
      atom_to_list(Label),
+     format_args(Vs, Ctxt),
      nl_indent(Ctxt1),
      format(Then, Ctxt1),
      nl_indent(Ctxt1),
@@ -185,8 +186,8 @@ format_1(#k_letrec_goto{label=Label,first=First,then=Then,ret=Rs}, Ctxt) ->
      "end",
      format_ret(Rs, Ctxt1)
     ];
-format_1(#k_goto{label=Label}, _Ctxt) ->
-    ["goto ",atom_to_list(Label)];
+format_1(#k_goto{label=Label,args=As}, Ctxt) ->
+    ["goto ",atom_to_list(Label),format_args(As, Ctxt)];
 format_1(#k_select{var=V,types=Cs}, Ctxt) ->
     Ctxt1 = ctxt_bump_indent(Ctxt, 2),
     ["select ",

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -38,6 +38,7 @@ MODULES= \
 	lc_SUITE \
 	map_SUITE \
 	match_SUITE \
+	maybe_SUITE \
 	misc_SUITE \
 	overridden_bif_SUITE \
 	random_code_SUITE \
@@ -72,6 +73,7 @@ NO_OPT= \
 	lc \
 	map \
 	match \
+	maybe \
 	misc \
 	overridden_bif \
 	receive \
@@ -98,6 +100,7 @@ INLINE= \
 	lc \
 	map \
 	match \
+	maybe \
 	misc \
 	overridden_bif \
 	receive \
@@ -162,8 +165,9 @@ RELSYSDIR = $(RELEASE_PATH)/compiler_test
 # FLAGS
 # ----------------------------------------------------
 
+MAYBE_OPT = '+{enable_feature,maybe_expr}'
 ERL_MAKE_FLAGS +=
-ERL_COMPILE_FLAGS += +clint +clint0 +ssalint
+ERL_COMPILE_FLAGS += +clint +clint0 +ssalint $(MAYBE_OPT)
 
 EBIN = .
 

--- a/lib/compiler/test/beam_ssa_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_SUITE.erl
@@ -180,7 +180,7 @@ recv(_Config) ->
     self() ! 1,
     {1,yes} = tricky_recv_2(),
     self() ! 2,
-    {2,maybe} = tricky_recv_2(),
+    {2,'maybe'} = tricky_recv_2(),
 
     %% Test 'receive after infinity' in try/catch.
     Pid = spawn(fun recv_after_inf_in_try/0),
@@ -284,7 +284,7 @@ tricky_recv_2() ->
                 end,
             a;
         X=2 ->
-            Y = maybe,
+            Y = 'maybe',
             b
     end,
     {X,Y}.

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -272,10 +272,10 @@ booleans(_Config) ->
     true = is_atom(AnyAtom),
     false = is_boolean(AnyAtom),
 
-    MaybeBool = id(maybe),
+    MaybeBool = id('maybe'),
     case MaybeBool of
         true -> ok;
-        maybe -> ok;
+        'maybe' -> ok;
         false -> ok
     end,
     false = is_boolean(MaybeBool),

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1384,7 +1384,8 @@ warnings(_Config) ->
     test_lib:p_run(fun do_warnings/1, Files).
 
 do_warnings(F) ->
-    {ok,_,_,Ws} = compile:file(F, [binary,bin_opt_info,recv_opt_info,return]),
+    Options = [{enable_feature,maybe_expr},binary,bin_opt_info,recv_opt_info,return],
+    {ok,_,_,Ws} = compile:file(F, Options),
     do_warnings_1(Ws, F).
 
 do_warnings_1([{"no_file",Ws}|_], F) ->

--- a/lib/compiler/test/match_SUITE.erl
+++ b/lib/compiler/test/match_SUITE.erl
@@ -497,7 +497,7 @@ untuplify_2(V1, V2) ->
 shortcut_boolean(Config) when is_list(Config) ->
     false = shortcut_boolean_1([0]),
     true = shortcut_boolean_1({42}),
-    maybe = shortcut_boolean_1(self()),
+    'maybe' = shortcut_boolean_1(self()),
     {'EXIT',_} = (catch shortcut_boolean_1([a,b])),
     {'EXIT',_} = (catch shortcut_boolean_1({a,b})),
     ok.
@@ -511,7 +511,7 @@ shortcut_boolean_1(X) ->
 			end,
 		    not V;
 		false ->
-		    maybe
+		    'maybe'
 	    end,
     id(Outer).
 

--- a/lib/compiler/test/maybe_SUITE.erl
+++ b/lib/compiler/test/maybe_SUITE.erl
@@ -1,0 +1,273 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2003-2020. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(maybe_SUITE).
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0, groups/0, init_per_suite/1, end_per_suite/1]).
+-export([basic/1, nested/1]).
+
+all() ->
+    [{group,p}].
+
+groups() ->
+    [{p,[parallel],
+      [basic,nested]}].
+
+init_per_suite(Config) ->
+    test_lib:recompile(?MODULE),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+-record(value, {v}).
+
+basic(_Config) ->
+    {ok,42,fish} = basic_1(0, #{0 => {ok,42}, 42 => {ok,fish}}),
+    error = basic_1(0, #{0 => {ok,42}, 42 => {error,whatever}}),
+    error = basic_1(0, #{0 => {ok,42}, 42 => error}),
+    error = basic_1(0, #{0 => error}),
+    error = basic_1(0, #{0 => {error,whatever}}),
+    some_value = basic_1(0, #{0 => #value{v=some_value}}),
+    {'EXIT',{{else_clause,something_wrong},[_|_]}} = catch basic_1(0, #{0 => something_wrong}),
+
+    {ok,life,"universe",everything} = basic_2(0, #{0 => {ok,life},
+                                                   life => "universe",
+                                                   "universe" => {ok,everything}}),
+    error = basic_2(0, #{0 => {ok,life},
+                         life => "universe",
+                         "universe" => error}),
+    {'EXIT',{{badmatch,not_a_list},[_|_]}} = catch basic_2(0, #{0 => {ok,life},
+                                                                life => not_a_list}),
+    {'EXIT',{{else_clause,not_ok},[_|_]}} = catch basic_2(0, #{0 => {ok,life},
+                                                               life => "universe",
+                                                               "universe" => not_ok}),
+    {'EXIT',{{else_clause,not_ok},[_|_]}} = catch basic_2(0, #{0 => not_ok}),
+
+    {ok,42,fish,dolphins} = basic_3(0, #{0 => {ok,42}, 42 => {ok,fish},
+                                         fish => {ok,#value{v=dolphins}}}),
+    {error,whatever} = basic_3(0, #{0 => {ok,42}, 42 => {error,whatever}}),
+    failed = basic_3(0, #{0 => {ok,42}, 42 => failed}),
+    failed_early = basic_3(0, #{0 => failed_early}),
+
+    y = maybe nomatch ?= id(x) else _ -> y end,
+    y = maybe nomatch ?= id(x) else _ -> x, y end,
+
+    x = maybe nomatch ?= id(x) else E1 -> E1 end,
+
+    6 = maybe X1 = 2+2, X1+2 end,
+    6 = maybe X2 = 2+2, X2+2 else {error, T} -> T end,
+    {"llo", "hello", "hello"} = maybe Y1 = "he"++X3=Z1 ?= "hello", {X3,Y1,Z1} end,
+    {"llo", "hello", "llo"} = maybe Y2 = "he"++(X4=Z2) ?= "hello", {X4,Y2,Z2} end,
+
+    whatever = maybe
+                   AlwaysMatching ?= id(whatever),
+                   AlwaysMatching
+               else
+                   E2 -> E2
+               end,
+
+    ok.
+
+basic_1(V0, M) ->
+    Res = basic_1a(V0, M),
+    {wrapped,Res} = basic_1b(V0, M),
+    {wrapped,Res} = basic_1c(V0, M),
+    Res.
+
+basic_1a(V0, M) ->
+    maybe
+        {ok,V1} ?= do_something(V0, M),
+        {ok,V2} ?= do_something(V1, M),
+        {ok,V1,V2}
+    else
+        {error,_} ->
+            error;
+        error ->
+            error;
+        #value{v=V} ->
+            V
+    end.
+
+basic_1b(V0, M) ->
+    Result =
+        maybe
+            {ok,V1} ?= do_something(V0, M),
+            {ok,V2} ?= do_something(V1, M),
+            {ok,V1,V2}
+        else
+            {error,_} ->
+                error;
+            error ->
+                error;
+            #value{v=V} ->
+                V
+        end,
+    {wrapped,Result}.
+
+basic_1c(V0, M) ->
+    OK = id(ok),
+    Error = id(error),
+    Result =
+        maybe
+            {OK,V1} ?= do_something(V0, M),
+            {OK,V2} ?= do_something(V1, M),
+            {OK,V1,V2}
+        else
+            {Error,_} ->
+                Error;
+            Error ->
+                Error;
+            #value{v=V} ->
+                V
+        end,
+    {wrapped,Result}.
+
+basic_2(V0, M) ->
+    Res = basic_2a(V0, M),
+    {wrapped,Res} = basic_2b(V0, M),
+    Res.
+
+basic_2a(V0, M) ->
+    maybe
+        {ok,V1} ?= do_something(V0, M),
+        V2 = [_|_] = do_something(V1, M),
+        {ok,V3} ?= do_something(V2, M),
+        {ok,V1,V2,V3}
+    else
+        {error,_} ->
+            error;
+        error ->
+            error;
+        #value{v=V} ->
+            V
+    end.
+
+basic_2b(V0, M) ->
+    Result =
+        maybe
+            {ok,V1} ?= do_something(V0, M),
+            V2 = [_|_] = do_something(V1, M),
+            {ok,V3} ?= do_something(V2, M),
+            {ok,V1,V2,V3}
+        else
+            {error,_} ->
+                error;
+            error ->
+                error;
+            #value{v=V} ->
+                V
+        end,
+    _ = id(0),
+    {wrapped,Result}.
+
+basic_3(V0, M) ->
+    Res = basic_3a(V0, M),
+    {wrapped,Res} = basic_3b(V0, M),
+    Res.
+
+basic_3a(V0, M) ->
+    maybe
+        {ok,V1} ?= do_something(V0, M),
+        {ok,V2} ?= do_something(V1, M),
+        {ok,#value{v=V3}} ?= do_something(V2, M),
+        {ok,V1,V2,V3}
+    end.
+
+basic_3b(V0, M) ->
+    Result =
+        maybe
+            {ok,V1} ?= do_something(V0, M),
+            {ok,V2} ?= do_something(V1, M),
+            {ok,#value{v=V3}} ?= do_something(V2, M),
+            {ok,V1,V2,V3}
+        end,
+    {wrapped,Result}.
+
+nested(_Config) ->
+    {outer_fail,not_ok} = nested_1(0, #{0 => not_ok}),
+    {x,{error,inner}} = nested_1(0, #{0 => {ok,x}, x => {error,inner}}),
+    {outer_fail,{unexpected,not_error}} = nested_1(0, #{0 => {ok,x}, x => not_error}),
+    ok.
+
+nested_1(V0, M) ->
+    Res = nested_1a(V0, M),
+    {wrapped,Res} = nested_1b(V0, M),
+    {wrapped,Res} = nested_1c(V0, M),
+    Res.
+
+nested_1a(V0, M) ->
+    maybe
+        {ok,V1} ?= do_something(V0, M),
+        V2 = {error,_} ?=
+            maybe
+                {error, _} ?= id(do_something(V1, M))
+            else
+                Unexpected -> {unexpected, Unexpected}
+            end,
+        {V1,V2}
+    else
+        Res -> {outer_fail,Res}
+    end.
+
+nested_1b(V0, M) ->
+    Result =
+        maybe
+            {ok,V1} ?= do_something(V0, M),
+            V2 = {error,_} ?=
+                maybe
+                    {error, _} ?= id(do_something(V1, M))
+                else
+                    Unexpected -> {unexpected, Unexpected}
+                end,
+            {V1,V2}
+        else
+            Res -> {outer_fail,Res}
+        end,
+    {wrapped,Result}.
+
+nested_1c(V0, M) ->
+    Result =
+        maybe
+            R ?= maybe
+                     {ok,V1} ?= do_something(V0, M),
+                     {error,_} = V2 ?=
+                         maybe
+                             {error, _} ?= id(do_something(V1, M))
+                         else
+                             Unexpected -> {unexpected, Unexpected}
+                         end,
+                     {V1,V2}
+                 else
+                     Res -> {outer_fail,Res}
+                 end,
+            R
+        else
+            Var -> Var
+        end,
+    {wrapped,Result}.
+
+%% Utility functions.
+
+do_something(V, M) ->
+    map_get(id(V), M).
+
+id(X) -> X.

--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -86,6 +86,7 @@ opt_opts(Mod) ->
     lists:filter(fun
                      (debug_info) -> true;
                      (dialyzer) -> true;
+                     ({enable_feature,_}) -> true;
                      (inline) -> true;
                      (no_bs_create_bin) -> true;
                      (no_bsm_opt) -> true;

--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -43,7 +43,8 @@
          redundant_boolean_clauses/1,
 	 underscore/1,no_warnings/1,
 	 bit_syntax/1,inlining/1,tuple_calls/1,
-         recv_opt_info/1,opportunistic_warnings/1]).
+         recv_opt_info/1,opportunistic_warnings/1,
+         eep49/1]).
 
 init_per_testcase(_Case, Config) ->
     Config.
@@ -66,7 +67,8 @@ groups() ->
        maps_bin_opt_info,
        redundant_boolean_clauses,
        underscore,no_warnings,bit_syntax,inlining,
-       tuple_calls,recv_opt_info,opportunistic_warnings]}].
+       tuple_calls,recv_opt_info,opportunistic_warnings,
+       eep49]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -1173,6 +1175,28 @@ opportunistic_warnings(Config) ->
 
 
     ok.
+
+%% Test value-based error handling (EEP 49).
+eep49(Config) ->
+    Ts = [{basic,
+           <<"foo(X) ->
+                  maybe
+                      %% There should be no warning.
+                      Always ?= X,
+                      Always
+                  end.
+           ">>,
+           [{enable_feature,maybe_expr}],
+           []},
+          {disabled,
+           <<"foo() -> maybe.                        %Atom maybe.
+           ">>,
+           [{disable_feature,maybe_expr}],
+           []}
+	 ],
+    run(Config, Ts),
+    ok.
+
 
 %%%
 %%% End of test cases.

--- a/lib/dialyzer/src/dialyzer_clean_core.erl
+++ b/lib/dialyzer/src/dialyzer_clean_core.erl
@@ -109,6 +109,7 @@ clean_letrec(Tree) ->
       FunBody = cerl:fun_body(Fun),
       FunBody1 = clean(FunBody),
       Body = clean(cerl:letrec_body(Tree)),
+      FunVars = cerl:fun_vars(Fun),
       case dialyzer_ignore(Body) of
         true ->
           %% The body of the letrec directly transfer controls to
@@ -152,8 +153,10 @@ clean_letrec(Tree) ->
           %%    end
           %%
           PrimopUnknown = cerl:c_primop(cerl:abstract(dialyzer_unknown), []),
-          Clauses = [cerl:c_clause([cerl:abstract(a)], Body),
-                     cerl:c_clause([cerl:abstract(b)], FunBody1)],
+          PatA = [cerl:abstract(a)],
+          PatB = [cerl:c_tuple([cerl:abstract(b)|FunVars])],
+          Clauses = [cerl:c_clause(PatA, Body),
+                     cerl:c_clause(PatB, FunBody1)],
           cerl:c_case(PrimopUnknown, Clauses)
       end;
     false ->

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -837,6 +837,8 @@ scan_toks([{'-',_Lh},{atom,_Li,ifndef}=IfnDef|Toks], From, St) ->
     scan_ifndef(Toks, IfnDef, From, St);
 scan_toks([{'-',_Lh},{atom,_Le,'else'}=Else|Toks], From, St) ->
     scan_else(Toks, Else, From, St);
+scan_toks([{'-',_Lh},{'else',_Le}=Else|Toks], From, St) ->
+    scan_else(Toks, Else, From, St);
 scan_toks([{'-',_Lh},{'if',_Le}=If|Toks], From, St) ->
     scan_if(Toks, If, From, St);
 scan_toks([{'-',_Lh},{atom,_Le,elif}=Elif|Toks], From, St) ->
@@ -1328,6 +1330,8 @@ skip_toks(From, St, [I|Sis]) ->
 	{ok,[{'-',_Ah},{'if',_Ai}|_Toks],Cl} ->
 	    skip_toks(From, St#epp{location=Cl}, ['if',I|Sis]);
 	{ok,[{'-',_Ah},{atom,_Ae,'else'}=Else|_Toks],Cl}->
+	    skip_else(Else, From, St#epp{location=Cl}, [I|Sis]);
+	{ok,[{'-',_Ah},{'else',_Ae}=Else|_Toks],Cl}->
 	    skip_else(Else, From, St#epp{location=Cl}, [I|Sis]);
 	{ok,[{'-',_Ah},{atom,_Ae,'elif'}=Elif|Toks],Cl}->
 	    skip_elif(Toks, Elif, From, St#epp{location=Cl}, [I|Sis]);

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -73,7 +73,8 @@
 	            :: #{name() => [{argspec(), [used()]}]},
               default_encoding = ?DEFAULT_ENCODING :: source_encoding(),
 	      pre_opened = false :: boolean(),
-              fname = [] :: function_name_type()
+              fname = [] :: function_name_type(),
+              erl_scan_opts = [] :: erl_scan:options()
 	     }).
 
 %% open(Options)
@@ -604,11 +605,16 @@ init_server(Pid, FileName, Options, St0) ->
             %% first in path
             Path = [filename:dirname(FileName) |
                     proplists:get_value(includes, Options, [])],
+
+            ResWordFun = proplists:get_value(reserved_word_fun, Options,
+                                             fun erl_scan:reserved_word/1),
+
             %% the default location is 1 for backwards compatibility, not {1,1}
             AtLocation = proplists:get_value(location, Options, 1),
             St = St0#epp{delta=0, name=SourceName, name2=SourceName,
 			 path=Path, location=AtLocation, macs=Ms1,
-			 default_encoding=DefEncoding},
+			 default_encoding=DefEncoding,
+                         erl_scan_opts=[{reserved_word_fun,ResWordFun}]},
             From = wait_request(St),
             Anno = erl_anno:new(AtLocation),
             enter_file_reply(From, file_name(SourceName), Anno,
@@ -806,7 +812,7 @@ leave_file(From, St) ->
 %% scan_toks(Tokens, From, EppState)
 
 scan_toks(From, St) ->
-    case io:scan_erl_form(St#epp.file, '', St#epp.location) of
+    case io:scan_erl_form(St#epp.file, '', St#epp.location, St#epp.erl_scan_opts) of
 	{ok,Toks,Cl} ->
 	    scan_toks(Toks, From, St#epp{location=Cl});
 	{error,E,Cl} ->
@@ -1322,7 +1328,7 @@ new_location(Ln, {Le,_}, {Lf,_}) ->
 %%  nested conditionals and repeated 'else's.
 
 skip_toks(From, St, [I|Sis]) ->
-    case io:scan_erl_form(St#epp.file, '', St#epp.location) of
+    case io:scan_erl_form(St#epp.file, '', St#epp.location, St#epp.erl_scan_opts) of
 	{ok,[{'-',_Ah},{atom,_Ai,ifdef}|_Toks],Cl} ->
 	    skip_toks(From, St#epp{location=Cl}, [ifdef,I|Sis]);
 	{ok,[{'-',_Ah},{atom,_Ai,ifndef}|_Toks],Cl} ->

--- a/lib/stdlib/src/erl_eval.erl
+++ b/lib/stdlib/src/erl_eval.erl
@@ -123,6 +123,32 @@ exprs([E|Es], Bs0, Lf, Ef, RBs) ->
     {value,_V,Bs} = expr(E, Bs0, Lf, Ef, RBs1),
     exprs(Es, Bs, Lf, Ef, RBs).
 
+%% maybe_match_exprs(Expression, Bindings, LocalFuncHandler, ExternalFuncHandler)
+%%  Returns one of:
+%%	 {success,Value}
+%%	 {failure,Value}
+%%  or raises an exception.
+
+maybe_match_exprs([{maybe_match,_,Lhs,Rhs0}|Es], Bs0, Lf, Ef) ->
+    {value,Rhs,Bs1} = expr(Rhs0, Bs0, Lf, Ef, none),
+    case match(Lhs, Rhs, Bs1) of
+	{match,Bs} ->
+            case Es of
+                [] ->
+                    {success,Rhs};
+                [_|_] ->
+                    maybe_match_exprs(Es, Bs, Lf, Ef)
+            end;
+	nomatch ->
+            {failure,Rhs}
+    end;
+maybe_match_exprs([E], Bs0, Lf, Ef) ->
+    {value,V,_Bs} = expr(E, Bs0, Lf, Ef, none),
+    {success,V};
+maybe_match_exprs([E|Es], Bs0, Lf, Ef) ->
+    {value,_V,Bs} = expr(E, Bs0, Lf, Ef, none),
+    maybe_match_exprs(Es, Bs, Lf, Ef).
+
 %% expr(Expression, Bindings)
 %% expr(Expression, Bindings, LocalFuncHandler)
 %% expr(Expression, Bindings, LocalFuncHandler, ExternalFuncHandler)
@@ -448,6 +474,21 @@ expr({match,_,Lhs,Rhs0}, Bs0, Lf, Ef, RBs) ->
 	{match,Bs} ->
             ret_expr(Rhs, Bs, RBs);
 	nomatch -> erlang:raise(error, {badmatch,Rhs}, ?STACKTRACE)
+    end;
+expr({'maybe',_,Es}, Bs, Lf, Ef, RBs) ->
+    {_,Val} = maybe_match_exprs(Es, Bs, Lf, Ef),
+    ret_expr(Val, Bs, RBs);
+expr({'maybe',_,Es,{'else',_,Cs}}, Bs0, Lf, Ef, RBs) ->
+    case maybe_match_exprs(Es, Bs0, Lf, Ef) of
+        {success,Val} ->
+            ret_expr(Val, Bs0, RBs);
+        {failure,Val} ->
+            case match_clause(Cs, [Val], Bs0, Lf, Ef) of
+                {B, Bs} ->
+                    exprs(B, Bs, Lf, Ef, RBs);
+                nomatch ->
+                    erlang:raise(error, {else_clause,Val}, ?STACKTRACE)
+            end
     end;
 expr({op,_,Op,A0}, Bs0, Lf, Ef, RBs) ->
     {value,A,Bs} = expr(A0, Bs0, Lf, Ef, none),

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -406,6 +406,17 @@ expr({'try',Anno,Es0,Scs0,Ccs0,As0}, St0) ->
 expr({'catch',Anno,E0}, St0) ->
     {E,St1} = expr(E0, St0),
     {{'catch',Anno,E},St1};
+expr({'maybe',MaybeAnno,Es0}, St0) ->
+    {Es,St1} = exprs(Es0, St0),
+    {{'maybe',MaybeAnno,Es},St1};
+expr({'maybe',MaybeAnno,Es0,{'else',ElseAnno,Cs0}}, St0) ->
+    {Es,St1} = exprs(Es0, St0),
+    {Cs,St2} = clauses(Cs0, St1),
+    {{'maybe',MaybeAnno,Es,{'else',ElseAnno,Cs}},St2};
+expr({maybe_match,Anno,P0,E0}, St0) ->
+    {E,St1} = expr(E0, St0),
+    {P,St2} = pattern(P0, St1),
+    {{maybe_match,Anno,P,E},St2};
 expr({match,Anno,P0,E0}, St0) ->
     {E,St1} = expr(E0, St0),
     {P,St2} = pattern(P0, St1),

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -4170,7 +4170,7 @@ check_format_2a(Fmt, FmtAnno, As) ->
         false ->
             Anno = element(2, As),
             {warn,1,Anno,"format arguments not a list",[]};
-        maybe ->
+        'maybe' ->
             Anno = erl_parse:first_anno(As),
             {warn,2,Anno,"format arguments perhaps not a list",[]}
     end.
@@ -4216,12 +4216,12 @@ arguments(N) ->
 args_list({cons,_A,_H,T}) -> args_list(T);
 %% Strange case: user has written something like [a | "bcd"]; pretend
 %% we don't know:
-args_list({string,_A,_Cs}) -> maybe;
+args_list({string,_A,_Cs}) -> 'maybe';
 args_list({nil,_A}) -> true;
 args_list({atom,_,_}) -> false;
 args_list({integer,_,_}) -> false;
 args_list({float,_,_}) -> false;
-args_list(_Other) -> maybe.
+args_list(_Other) -> 'maybe'.
 
 args_length({cons,_A,_H,T}) -> 1 + args_length(T);
 args_length({nil,_A}) -> 0.

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2579,6 +2579,23 @@ expr({match,_Anno,P,E}, Vt, St0) ->
     {Pvt,Pnew,St2} = pattern(P, vtupdate(Evt, Vt), St1),
     St = reject_invalid_alias_expr(P, E, Vt, St2),
     {vtupdate(Pnew, vtmerge(Evt, Pvt)),St};
+expr({maybe_match,Anno,P,E}, Vt, St0) ->
+    expr({match,Anno,P,E}, Vt, St0);
+expr({'maybe',Anno,Es}, Vt, St) ->
+    %% No variables are exported.
+    {Evt0, St1} = exprs(Es, Vt, St),
+    Evt1 = vtupdate(vtunsafe({'maybe',Anno}, Evt0, Vt), Vt),
+    Evt2 = vtmerge(Evt0, Evt1),
+    {Evt2,St1};
+expr({'maybe',MaybeAnno,Es,{'else',ElseAnno,Cs}}, Vt, St) ->
+    %% No variables are exported.
+    {Evt0, St1} = exprs(Es, Vt, St),
+    Evt1 = vtupdate(vtunsafe({'maybe',MaybeAnno}, Evt0, Vt), Vt),
+    {Cvt0, St2} = icrt_clauses(Cs, {'else',ElseAnno}, Evt1, St1),
+    Cvt1 = vtupdate(vtunsafe({'else',ElseAnno}, Cvt0, Vt), Vt),
+    Evt2 = vtmerge(Evt0, Evt1),
+    Cvt2 = vtmerge(Cvt0, Cvt1),
+    {vtmerge(Evt2, Cvt2),St2};
 %% No comparison or boolean operators yet.
 expr({op,_Anno,_Op,A}, Vt, St) ->
     expr(A, Vt, St);

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -48,13 +48,15 @@ top_type top_types type typed_expr typed_attr_val
 type_sig type_sigs type_guard type_guards fun_type binary_type
 type_spec spec_fun typed_exprs typed_record_fields field_types field_type
 map_pair_types map_pair_type
-bin_base_type bin_unit_type.
+bin_base_type bin_unit_type
+maybe_expr maybe_match_exprs maybe_match.
 
 Terminals
 char integer float atom string var
 
 '(' ')' ',' '->' '{' '}' '[' ']' '|' '||' '<-' ';' ':' '#' '.'
 'after' 'begin' 'case' 'try' 'catch' 'end' 'fun' 'if' 'of' 'receive' 'when'
+'maybe' 'else'
 'andalso' 'orelse'
 'bnot' 'not'
 '*' '/' 'div' 'rem' 'band' 'and'
@@ -63,6 +65,7 @@ char integer float atom string var
 '==' '/=' '=<' '<' '>=' '>' '=:=' '=/=' '<=' '=>' ':='
 '<<' '>>'
 '!' '=' '::' '..' '...'
+'?='
 'spec' 'callback' % helper
 dot.
 
@@ -257,6 +260,7 @@ expr_max -> case_expr : '$1'.
 expr_max -> receive_expr : '$1'.
 expr_max -> fun_expr : '$1'.
 expr_max -> try_expr : '$1'.
+expr_max -> maybe_expr : '$1'.
 
 pat_expr -> pat_expr '=' pat_expr : {match,first_anno('$1'),'$1','$3'}.
 pat_expr -> pat_expr comp_op pat_expr : ?mkop2('$1', '$2', '$3').
@@ -401,7 +405,6 @@ if_clauses -> if_clause ';' if_clauses : ['$1' | '$3'].
 if_clause -> guard clause_body :
 	{clause,first_anno(hd(hd('$1'))),[],'$1','$2'}.
 
-
 case_expr -> 'case' expr 'of' cr_clauses 'end' :
 	{'case',?anno('$1'),'$2','$4'}.
 
@@ -476,6 +479,21 @@ try_clause -> var ':' pat_expr try_opt_stacktrace clause_guard clause_body :
 
 try_opt_stacktrace -> ':' var : '$2'.
 try_opt_stacktrace -> '$empty' : '_'.
+
+
+maybe_expr -> 'maybe' maybe_match_exprs 'end' :
+	{'maybe',?anno('$1'),'$2'}.
+maybe_expr -> 'maybe' maybe_match_exprs 'else' cr_clauses 'end' :
+        %% `erl_lint` can produce a better warning when the position
+        %% of the `else` keyword is known.
+	{'maybe',?anno('$1'),'$2',{'else',?anno('$3'),'$4'}}.
+
+maybe_match_exprs -> maybe_match : ['$1'].
+maybe_match_exprs -> maybe_match ',' maybe_match_exprs : ['$1' | '$3'].
+maybe_match_exprs -> expr : ['$1'].
+maybe_match_exprs -> expr ',' maybe_match_exprs : ['$1' | '$3'].
+
+maybe_match -> expr '?=' expr : {maybe_match,?anno('$2'),'$1','$3'}.
 
 argument_list -> '(' ')' : {[],?anno('$1')}.
 argument_list -> '(' exprs ')' : {'$2',?anno('$1')}.

--- a/lib/stdlib/src/erl_pp.erl
+++ b/lib/stdlib/src/erl_pp.erl
@@ -704,6 +704,14 @@ lexpr({'catch',_,Expr}, Prec, Opts) ->
     {P,R} = preop_prec('catch'),
     El = {list,[{step,'catch',lexpr(Expr, R, Opts)}]},
     maybe_paren(P, Prec, El);
+lexpr({'maybe',_,Es}, _, Opts) ->
+    {list,[{step,'maybe',body(Es, Opts)},{reserved,'end'}]};
+lexpr({'maybe',_,Es,{'else',_,Cs}}, _, Opts) ->
+    {list,[{step,'maybe',body(Es, Opts)},{step,'else',cr_clauses(Cs, Opts)},{reserved,'end'}]};
+lexpr({maybe_match,_,Lhs,Rhs}, _, Opts) ->
+    Pl = lexpr(Lhs, 0, Opts),
+    Rl = lexpr(Rhs, 0, Opts),
+    {list,[{cstep,[Pl,leaf(" ?=")],Rl}]};
 lexpr({match,_,Lhs,Rhs}, Prec, Opts) ->
     {L,P,R} = inop_prec('='),
     Pl = lexpr(Lhs, L, Opts),
@@ -1359,7 +1367,7 @@ wordtable() ->
     L = [begin {leaf,Sz,S} = leaf(W), {S,Sz} end ||
             W <- [" ->"," =","<<",">>","[]","after","begin","case","catch",
                   "end","fun","if","of","receive","try","when"," ::","..",
-                  " |"]],
+                  " |","maybe","else"]],
     list_to_tuple(L).
 
 word(' ->', WT) -> element(1, WT);
@@ -1380,7 +1388,9 @@ word('try', WT) -> element(15, WT);
 word('when', WT) -> element(16, WT);
 word(' ::', WT) -> element(17, WT);
 word('..', WT) -> element(18, WT);
-word(' |', WT) -> element(19, WT).
+word(' |', WT) -> element(19, WT);
+word('maybe', WT) -> element(20, WT);
+word('else', WT) -> element(21, WT).
 
 %% Make up an unique variable name for Name that won't clash with any
 %% name in Used. We first try by converting the name to uppercase and

--- a/lib/stdlib/src/erl_scan.erl
+++ b/lib/stdlib/src/erl_scan.erl
@@ -427,6 +427,11 @@ scan1([C|Cs], St, Line, Col, Toks) when ?WHITE_SPACE(C) ->
             skip_white_space(Cs, St, Line, Col, Toks, 1)
     end;
 %% Punctuation characters and operators, first recognise multiples.
+%% ?= for the maybe ... else ... end construct
+scan1("?="++Cs, St, Line, Col, Toks) ->
+    tok2(Cs, St, Line, Col, Toks, "?=", '?=', 2);
+scan1("?"=Cs, _St, Line, Col, Toks) ->
+    {more,{Cs,Col,Toks,Line,[],fun scan/6}};
 %% << <- <=
 scan1("<<"++Cs, St, Line, Col, Toks) ->
     tok2(Cs, St, Line, Col, Toks, "<<", '<<', 2);

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -273,11 +273,17 @@ server_loop(N0, Eval_0, Bs00, RT, Ds00, History0, Results0) ->
     end.
 
 get_command(Prompt, Eval, Bs, RT, Ds) ->
+    ResWordFun =
+        fun('maybe') -> true;
+           ('else') -> true;
+           (Other) -> erl_scan:reserved_word(Other)
+        end,
     Parse =
         fun() ->
                 exit(
                   case
-                      io:scan_erl_exprs(group_leader(), Prompt, {1,1}, [text])
+                      io:scan_erl_exprs(group_leader(), Prompt, {1,1},
+                                        [text,{reserved_word_fun,ResWordFun}])
                   of
                       {ok,Toks,_EndPos} ->
                           erl_eval:extended_parse_exprs(Toks);

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -118,9 +118,10 @@ RELSYSDIR = $(RELEASE_PATH)/stdlib_test
 # FLAGS
 # ----------------------------------------------------
 
+MAYBE_OPT = '+{enable_feature,maybe_expr}'
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS += -I$(ERL_TOP)/lib/kernel/include \
-		-I$(ERL_TOP)/lib/stdlib/include
+		-I$(ERL_TOP)/lib/stdlib/include $(MAYBE_OPT)
 
 EBIN = .
 

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -941,7 +941,7 @@ ifdef(Config) ->
              "-else.\n"
              "t() -> a.\n"
              "-endif.\n">>,
-           {errors,[{{3,1},epp,{bad,else}}],[]}},
+           {errors,[{{3,1},epp,{bad,'else'}}],[]}},
 
           {ifdef_c8,
            <<"-ifdef(a).\n"
@@ -1802,7 +1802,7 @@ otp_16824(Config) when is_list(Config) ->
           {otp_16824_8,
            <<"\n-else\n"
              "-endif.">>,
-           {errors,[{{3,1},epp,{bad,else}}],[]}},
+           {errors,[{{3,1},epp,{bad,'else'}}],[]}},
 
           {otp_16824_9,
            <<"\n-ifndef.\n"

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -2010,6 +2010,9 @@ eval_tests(Config, Fun, Tests) ->
     F = fun({N,P,Opts,E}, BadL) ->
                 %% io:format("Testing ~p~n", [P]),
                 Return = Fun(Config, P, Opts),
+                %% The result should be the same when enabling maybe ... end
+                %% (making 'else' a keyword instead of an atom).
+                Return = Fun(Config, P, [{enable_feature,maybe_expr}|Opts]),
                 case message_compare(E, Return) of
                     true ->
                         case E of

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -75,7 +75,8 @@
          otp_16824/1,
          underscore_match/1,
          unused_record/1,
-         unused_type2/1]).
+         unused_type2/1,
+         eep49/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -99,7 +100,8 @@ all() ->
      stacktrace_syntax, otp_14285, otp_14378, external_funs,
      otp_15456, otp_15563, unused_type, binary_types, removed, otp_16516,
      inline_nifs, warn_missing_spec, otp_16824,
-     underscore_match, unused_record, unused_type2].
+     underscore_match, unused_record, unused_type2,
+     eep49].
 
 groups() -> 
     [{unused_vars_warn, [],
@@ -4689,6 +4691,84 @@ unused_type2(Config) when is_list(Config) ->
          ],
     [] = run(Config, Ts),
 
+    ok.
+
+%% Test maybe ... else ... end.
+eep49(Config) when is_list(Config) ->
+    EnableMaybe = {enable_feature,maybe_expr},
+    Ts = [{exp1,
+           <<"t(X) ->
+                  maybe
+                      A = X()
+                  end,
+                  A.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{5,19},erl_lint,{unsafe_var,'A',{'maybe',{2,19}}}}],
+            []}},
+
+          {exp2,
+           <<"t(X) ->
+                  maybe
+                      A = X()
+                  else
+                      _ -> {ok,A}
+                  end,
+                  A.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{5,32},erl_lint,{unsafe_var,'A',{'maybe',{2,19}}}},
+                    {{7,19},erl_lint,{unsafe_var,'A',{'maybe',{2,19}}}}],
+            []}},
+
+          {exp3,
+           <<"t(X) ->
+                  maybe
+                      X()
+                  else
+                      A ->
+                          B = 42,
+                          {error,A}
+                  end,
+                  {A,B}.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{9,20},erl_lint,{unsafe_var,'A',{'else',{4,19}}}},
+                    {{9,22},erl_lint,{unsafe_var,'B',{'else',{4,19}}}}],
+            []}},
+
+          {exp4,
+           <<"t(X) ->
+                  maybe
+                      X()
+                  else
+                      ok ->
+                          A = 42;
+                      error ->
+                          error
+                  end,
+                  A.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{10,19},erl_lint,{unsafe_var,'A',{'else',{4,19}}}}],
+            []}},
+
+          %% Using '?=' not at the top-level of a 'maybe' ... 'else' is forbidden.
+          {illegal_maybe_match1,
+           <<"t(X) ->
+                  maybe (ok ?= X()) end.
+           ">>,
+           [EnableMaybe],
+           {errors,[{{2,29},erl_parse,["syntax error before: ","'?='"]}],[]}},
+          {illegal_maybe_match2,
+           <<"t(X) ->
+                  ok ?= X().
+           ">>,
+           [EnableMaybe],
+           {errors,[{{2,22},erl_parse,["syntax error before: ","'?='"]}],[]}}
+         ],
+
+    [] = run(Config, Ts),
     ok.
 
 format_error(E) ->

--- a/lib/stdlib/test/io_proto_SUITE.erl
+++ b/lib/stdlib/test/io_proto_SUITE.erl
@@ -1179,7 +1179,7 @@ get_and_put(CPid, [{getline_pred,Pred,Msg}|T]=T0, N)
 					   "(command number ~p)\n",
 					   [?MODULE,Msg,N]),
 		    {error, no_match};
-		maybe ->
+		'maybe' ->
 		    List = get(getline_skipped),
 		    put(getline_skipped, List ++ [Data]),
 		    get_and_put(CPid, T0, N)
@@ -1190,7 +1190,7 @@ get_and_put(CPid, [{getline, Match}|T],N) ->
     F = fun(Data) ->
 		case lists:prefix(Match, Data) of
 		    true -> yes;
-		    false -> maybe
+		    false -> 'maybe'
 		end
 	end,
     get_and_put(CPid, [{getline_pred,F,Match}|T], N);
@@ -1198,7 +1198,7 @@ get_and_put(CPid, [{getline_re, Match}|T],N) ->
     F = fun(Data) ->
 		case re:run(Data, Match, [{capture,none}]) of
 		    match -> yes;
-		    _ -> maybe
+		    _ -> 'maybe'
 		end
 	end,
     get_and_put(CPid, [{getline_pred,F,Match}|T], N);
@@ -1498,7 +1498,7 @@ get_default_shell() ->
 			    case re:run(Data, "<\\d+[.]\\d+[.]\\d+>",
 					[{capture,none}]) of
 				match -> no;
-				_ -> maybe
+				_ -> 'maybe'
 			    end
 		    end
 	    end,

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -904,7 +904,7 @@ child_specs_map(Config) when is_list(Config) ->
     B7 = CS0#{type => wrker},
     B8 = CS0#{modules => dy},
     B9 = CS0#{modules => [1,2,3]},
-    B10 = CS0#{significant => maybe},
+    B10 = CS0#{significant => 'maybe'},
 
     {error, missing_id} = supervisor:start_child(sup_test, B1),
     {error, missing_start} = supervisor:start_child(sup_test, B2),
@@ -932,7 +932,7 @@ child_specs_map(Config) when is_list(Config) ->
     {error, {invalid_modules,dy}} = supervisor:check_childspecs([B8]),
     {error, {invalid_module, 1}} =
 	supervisor:check_childspecs([B9]),
-    {error, {invalid_significant, maybe}} =
+    {error, {invalid_significant, 'maybe'}} =
 	supervisor:check_childspecs([B10]),
 
     CSFilter = fun (CS) -> maps:filter(fun (_, V) -> V =/= undefined end, CS) end,

--- a/lib/syntax_tools/src/epp_dodger.erl
+++ b/lib/syntax_tools/src/epp_dodger.erl
@@ -430,7 +430,17 @@ quick_parse_form(Dev, L0, Options) ->
 parse_form(Dev, L0, Parser, Options) ->
     NoFail = proplists:get_bool(no_fail, Options),
     Opt = #opt{clever = proplists:get_bool(clever, Options)},
-    case io:scan_erl_form(Dev, "", L0) of
+
+    %% FIXME: This should not be hard-coded. Either all keywords from
+    %% all features should be retrieved here, or there should be an option
+    %% to passes in either the keywords or the feature names.
+    ResWordFun =
+        fun('maybe') -> true;
+           ('else') -> true;
+           (Other) -> erl_scan:reserved_word(Other)
+        end,
+
+    case io:scan_erl_form(Dev, "", L0, [{reserved_word_fun,ResWordFun}]) of
         {ok, Ts, L1} ->
             case catch {ok, Parser(Ts, Opt)} of
                 {'EXIT', Term} ->
@@ -504,7 +514,9 @@ quickscan_form([{'-', _Anno}, {'if', AnnoA} | _Ts]) ->
     kill_form(AnnoA);
 quickscan_form([{'-', _Anno}, {atom, AnnoA, elif} | _Ts]) ->
     kill_form(AnnoA);
-quickscan_form([{'-', _Anno}, {atom, AnnoA, else} | _Ts]) ->
+quickscan_form([{'-', _Anno}, {atom, AnnoA, 'else'} | _Ts]) ->
+    kill_form(AnnoA);
+quickscan_form([{'-', _Anno}, {'else', AnnoA} | _Ts]) ->
     kill_form(AnnoA);
 quickscan_form([{'-', _Anno}, {atom, AnnoA, endif} | _Ts]) ->
     kill_form(AnnoA);
@@ -648,9 +660,12 @@ scan_form([{'-', _Anno}, {'if', AnnoA} | Ts], Opt) ->
 scan_form([{'-', _Anno}, {atom, AnnoA, elif} | Ts], Opt) ->
     [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA},
      {atom, AnnoA, 'elif'} | scan_macros(Ts, Opt)];
-scan_form([{'-', _Anno}, {atom, AnnoA, else} | Ts], Opt) ->
+scan_form([{'-', _Anno}, {atom, AnnoA, 'else'} | Ts], Opt) ->
     [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA},
-     {atom, AnnoA, else} | scan_macros(Ts, Opt)];
+     {atom, AnnoA, 'else'} | scan_macros(Ts, Opt)];
+scan_form([{'-', _Anno}, {'else', AnnoA} | Ts], Opt) ->
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA},
+     {atom, AnnoA, 'else'} | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, endif} | Ts], Opt) ->
     [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA},
      {atom, AnnoA, endif} | scan_macros(Ts, Opt)];

--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -1314,7 +1314,7 @@ analyze_attribute(Node) ->
                 ifndef -> preprocessor;
                 'if' -> preprocessor;
                 elif -> preprocessor;
-                else -> preprocessor;
+                'else' -> preprocessor;
                 endif -> preprocessor;
                 A ->
                     {A, analyze_attribute(A, Node)}

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -106,7 +106,8 @@ revert(Config) when is_list(Config) ->
     test_server:timetrap_cancel(Dog).
 
 revert_file(File, Path) ->
-    case epp:parse_file(File, Path, []) of
+    case epp:parse_file(File, [{includes,Path},
+                               res_word_option()]) of
         {ok,Fs0} ->
             Fs1 = erl_syntax:form_list(Fs0),
             Fs2 = erl_syntax_lib:map(fun (Node) -> Node end, Fs1),
@@ -350,8 +351,7 @@ t_comment_scan(Config) when is_list(Config) ->
 t_prettypr(Config) when is_list(Config) ->
     DataDir   = ?config(data_dir, Config),
     PrivDir   = ?config(priv_dir, Config),
-    Filenames = ["type_specs.erl",
-                 "specs_and_funs.erl"],
+    Filenames = test_files(),
     ok = test_prettypr(Filenames,DataDir,PrivDir),
     ok.
 
@@ -391,15 +391,16 @@ test_comment_scan([File|Files],DataDir) ->
 test_prettypr([],_,_) -> ok;
 test_prettypr([File|Files],DataDir,PrivDir) ->
     Filename  = filename:join(DataDir,File),
+    Options = [res_word_option()],
     io:format("Parsing ~p~n", [Filename]),
-    {ok, Fs0} = epp:parse_file(Filename, [], []),
+    {ok, Fs0} = epp:parse_file(Filename, Options),
     Fs = erl_syntax:form_list(Fs0),
     PP = erl_prettypr:format(Fs, [{paper,  120}, {ribbon, 110}]),
     io:put_chars(PP),
     OutFile = filename:join(PrivDir, File),
     ok = file:write_file(OutFile,unicode:characters_to_binary(PP)),
     io:format("Parsing OutFile: ~ts~n", [OutFile]),
-    {ok, Fs2} = epp:parse_file(OutFile, [], []),
+    {ok, Fs2} = epp:parse_file(OutFile, Options),
     case [Error || {error, _} = Error <- Fs2] of
         [] ->
             ok;
@@ -407,7 +408,6 @@ test_prettypr([File|Files],DataDir,PrivDir) ->
             ct:fail(Errors)
     end,
     test_prettypr(Files,DataDir,PrivDir).
-
 
 test_epp_dodger([], _, _) -> ok;
 test_epp_dodger([Filename|Files],DataDir,PrivDir) ->
@@ -617,3 +617,13 @@ p_run_loop(Test, List, N, Refs0, Errors0) ->
 	    Refs = Refs0 -- [Ref],
 	    p_run_loop(Test, List, N, Refs, Errors)
     end.
+
+res_word_option() ->
+    %% FIXME: When the experimental features EEP has been implemented, we should
+    %% dig out all keywords defined in all features.
+    ResWordFun =
+        fun('maybe') -> true;
+           ('else') -> true;
+           (Other) -> erl_scan:reserved_word(Other)
+        end,
+    {reserved_word_fun, ResWordFun}.

--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/syntax_tools_SUITE_test_module.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/syntax_tools_SUITE_test_module.erl
@@ -8,6 +8,7 @@
 	 sub_word/2,sub_word/3,left/2,left/3,right/2,right/3,
 	 sub_string/2,sub_string/3,centre/2,centre/3, join/2]).
 -export([to_upper/1, to_lower/1]).
+-export([eep49/0]).
 
 -import(lists,[reverse/1,member/2]).
 
@@ -538,3 +539,45 @@ join([], Sep) when is_list(Sep) ->
     [];
 join([H|T], Sep) ->
     H ++ lists:append([Sep ++ X || X <- T]).
+
+eep49() ->
+    maybe ok ?= ok end,
+
+    {a,b} =
+        maybe
+            {ok,A} ?= {ok,a},
+            {ok,B} ?= {ok,b},
+            {A,B}
+        end,
+
+    maybe
+        ok ?= {ok,x}
+    else
+        error -> error;
+        {error,_} -> error
+    end,
+
+    maybe
+        ok ?= {ok,x}
+    else
+        error -> error
+    end,
+
+    maybe
+        {ok,X} ?= {ok,x},
+        {ok,Y} ?= {ok,y},
+        {X,Y}
+    else
+        error -> error;
+        {error,_} -> error
+    end,
+
+    maybe
+        {ok,X2} ?= {ok,x},
+        {ok,Y2} ?= {ok,y},
+        {X2,Y2}
+    else
+        error -> error
+    end,
+
+    ok.

--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -336,6 +336,7 @@ filter_options(Options) ->
                              {d, _Macro, _Value} -> true;
                              export_all -> true;
                              tuple_calls -> true;
+                             {enable_feature,_} -> true; %FIXME: To be removed.
                              _ -> false
                          end
                  end,
@@ -2169,6 +2170,10 @@ munge_expr({match,Anno,ExprL,ExprR}, Vars) ->
     {MungedExprL, Vars2} = munge_expr(ExprL, Vars),
     {MungedExprR, Vars3} = munge_expr(ExprR, Vars2),
     {{match,Anno,MungedExprL,MungedExprR}, Vars3};
+munge_expr({maybe_match,Anno,ExprL,ExprR}, Vars) ->
+    {MungedExprL, Vars2} = munge_expr(ExprL, Vars),
+    {MungedExprR, Vars3} = munge_expr(ExprR, Vars2),
+    {{maybe_match,Anno,MungedExprL,MungedExprR}, Vars3};
 munge_expr({tuple,Anno,Exprs}, Vars) ->
     {MungedExprs, Vars2} = munge_exprs(Exprs, Vars, []),
     {{tuple,Anno,MungedExprs}, Vars2};
@@ -2260,6 +2265,13 @@ munge_expr({'try',Anno,Body,Clauses,CatchClauses,After}, Vars) ->
     {MungedAfter, Vars4} = munge_body(After, Vars3),
     {{'try',Anno,MungedBody,MungedClauses,MungedCatchClauses,MungedAfter},
      Vars4};
+munge_expr({'maybe',Anno,Exprs}, Vars) ->
+    {MungedExprs, Vars2} = munge_body(Exprs, Vars),
+    {{'maybe',Anno,MungedExprs}, Vars2};
+munge_expr({'maybe',MaybeAnno,Exprs,{'else',ElseAnno,Clauses}}, Vars) ->
+    {MungedExprs, Vars2} = munge_body(Exprs, Vars),
+    {MungedClauses, Vars3} = munge_clauses(Clauses, Vars2),
+    {{'maybe',MaybeAnno,MungedExprs,{'else',ElseAnno,MungedClauses}}, Vars3};
 munge_expr({'fun',Anno,{clauses,Clauses}}, Vars) ->
     {MungedClauses,Vars2}=munge_clauses(Clauses, Vars),
     {{'fun',Anno,{clauses,MungedClauses}}, Vars2};

--- a/lib/tools/test/emacs_SUITE_data/icr
+++ b/lib/tools/test/emacs_SUITE_data/icr
@@ -155,3 +155,42 @@ indent_receive() ->
             5*43
     end,
     ok.
+
+indent_maybe(1) ->
+    begin
+        maybe_should_be_indented_as_begin,
+    end,
+    maybe
+        1 = foo(X),
+        2 ?= asd(X),
+        line_with_break =
+            foo(X+1),
+        line_with_break ?=
+             foo(X+1)
+    end,
+    ok;
+indent_maybe(1) ->
+    maybe
+        2 ?= foo(X),
+        3 ?= bar(Y)
+    else
+        %% else indented as a standard icr (if-case-receive)
+        {error, Z} when Z == 1 ->
+            error1;
+        {error, Z}
+          when Z == 2 ->
+            error2
+    end;
+indent_maybe(3) ->
+    maybe
+        2 ?= foo(x),
+        maybe
+            nested ?= foo(y)
+        else
+            error ->
+                ok
+        end
+    else
+        error -> ok
+    end.
+

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -395,6 +395,134 @@ is_valid_signal(Signal) ->
   </section>
 
   <section>
+    <marker id="maybe"></marker>
+    <title>Maybe</title>
+    <note><p><c>maybe</c> is an experimental new feature introduced in
+    OTP 25. By default, it is disabled. To enable <c>maybe</c>, use
+    compiler option <c>{enable_feature,maybe_expr}</c>.</p></note>
+
+    <code type="erl"><![CDATA[
+maybe
+    Expr1,
+    ...,
+    ExprN
+end]]></code>
+
+    <p>The expressions in a <c>maybe</c> block are evaluated sequentially. If all
+    expressions are evaluated successfully, the return value of the <c>maybe</c>
+    block is <c>ExprN</c>. However, execution can be short-circuited by a
+    conditional match expression:</p>
+
+    <code type="erl"><![CDATA[
+Expr1 ?= Expr2]]></code>
+
+    <p><c>?=</c> is called the conditional match operator. It is only
+    allowed to be used at the top-level of a <c>maybe</c> block. It
+    matches the pattern <c>Expr1</c> against <c>Expr2</c>. If the
+    matching succeeds, any unbound variable in the pattern becomes
+    bound. If the expression is the last expression in the
+    <c>maybe</c> block, it also returns the value of <c>Expr2</c>. If the
+    matching is unsuccessful, the rest of the expressions in the <c>maybe</c>
+    block are skipped and the return value of the <c>maybe</c>
+    block is <c>Expr2</c>.</p>
+
+    <p>None of the variables bound in a <c>maybe</c> block must be
+    used in the code that follows the block.</p>
+
+    <p>Here is an example:</p>
+
+    <code type="erl"><![CDATA[
+maybe
+    {ok, A} ?= a(),
+    true = A >= 0,
+    {ok, B} ?= b(),
+    A + B
+end]]></code>
+
+    <p>Let us first assume that <c>a()</c> returns <c>{ok,42}</c> and
+    <c>b()</c> returns <c>{ok,58}</c>. With those return values, all
+    of the match operators will succeed, and the return value of the
+    <c>maybe</c> block is <c>A + B</c>, which is equal to <c>42 +
+    58 = 100</c>.</p>
+
+    <p>Now let us assume that <c>a()</c> returns <c>error</c>. The
+    conditional match operator in <c>{ok, A} ?= a()</c> fails to
+    match, and the return value of the <c>maybe</c> block is the
+    value of the expression that failed to match, namely <c>error</c>.
+    Similarly, if <c>b()</c> returns <c>wrong</c>, the return value of
+    the <c>maybe</c> block is <c>wrong</c>.</p>
+
+    <p>Finally, let us assume that <c>a()</c> returns
+    <c>-1</c>. Because <c>true = A >= 0</c> uses the match operator
+    `=`, a <c>{badmatch,false}</c> run-time error occurs when the
+    expression fails to match the pattern.</p>
+
+    <p>The example can be written in a less succient way using nested
+    case expressions:</p>
+
+    <code type="erl"><![CDATA[
+case a() of
+    {ok, A} ->
+        true = A >= 0,
+        case b() of
+            {ok, B} ->
+                A + B;
+            Other1 ->
+                Other1
+        end;
+    Other2 ->
+        Other2
+end]]></code>
+
+    <p>The <c>maybe</c> block can be augmented with <c>else</c> clauses:</p>
+
+    <code type="erl"><![CDATA[
+maybe
+    Expr1,
+    ...,
+    ExprN
+else
+    Pattern1 [when GuardSeq1] ->
+        Body1;
+    ...;
+    PatternN [when GuardSeqN] ->
+        BodyN
+end]]></code>
+
+    <p>If a conditional match operator fails, the failed expression is
+    matched against the patterns in all clauses between the
+    <c>else</c> and <c>end</c> keywords. If a match succeeds and the
+    optional guard sequence <c>GuardSeq</c> is true, the corresponding
+    <c>Body</c> is evaluated. The value returned from the body is the
+    return value of the <c>maybe</c> block.</p>
+
+    <p>If there is no matching pattern with a true guard sequence,
+    an <c>else_clause</c> run-time error occurs.</p>
+
+    <p>None of the variables bound in a <c>maybe</c> block must be used in
+    the <c>else</c> clauses. None of the variables bound in the <c>else</c> clauses
+    must be used in the code that follows the <c>maybe</c> block.</p>
+
+    <p>Here is the previous example augmented with a <c>else</c> clauses:</p>
+
+    <code type="erl"><![CDATA[
+maybe
+    {ok, A} ?= a(),
+    true = A >= 0,
+    {ok, B} ?= b(),
+    A + B
+else
+    error -> error;
+    wrong -> error
+end]]></code>
+
+    <p>The <c>else</c> clauses translate the failing value from
+    the conditional match operators to the value <c>error</c>. If the
+    failing value is not one of the recognized values, a
+    <c>else_clause</c> run-time error occurs.</p>
+  </section>
+
+  <section>
     <marker id="send"></marker>
     <title>Send</title>
     <pre>
@@ -1852,6 +1980,10 @@ end</pre>
       <row>
         <cell align="left" valign="middle">= !</cell>
         <cell align="left" valign="middle">Right associative</cell>
+      </row>
+      <row>
+        <cell align="left" valign="middle">?=</cell>
+        <cell align="left" valign="middle">&nbsp;</cell>
       </row>
       <row>
         <cell align="left" valign="middle">catch</cell>


### PR DESCRIPTION
This is (I hope) a complete implementation of EEP 49. Thanks to @dgud for implementing the erlang-mode for Emacs.

It is still a draft because the implementation will have to be revised when the `enable_feature` EEP has been published and implemented.