### PR TITLE
erts: Fix open_port({spawn,"a"},[{args,[]}]) error info

### DIFF
--- a/erts/emulator/test/exception_SUITE.erl
+++ b/erts/emulator/test/exception_SUITE.erl
@@ -1032,6 +1032,7 @@ error_info(_Config) ->
          {open_port, [{bad,name}, []]},
          {open_port, [{spawn, "no_command"}, bad_option_list]},
          {open_port, [{spawn, "no_command"}, [xyz]]},
+         {open_port, [{spawn, "no_command"}, [{args,[]}]],[{1,".*spawn_executable.*"}]},
 
          {port_call, 2},                        %Internal BIF.
 

--- a/lib/kernel/src/erl_erts_errors.erl
+++ b/lib/kernel/src/erl_erts_errors.erl
@@ -589,12 +589,19 @@ format_erlang_error(node, [_], _) ->
     [not_pid];
 format_erlang_error(nodes, [_], _) ->
     [<<"not a valid node type">>];
-format_erlang_error(open_port, [Name,_Settings], Cause) ->
+format_erlang_error(open_port, [Name, Settings], Cause) ->
     case Cause of
         badopt ->
             [must_be_tuple(Name),bad_option];
+        _ when is_tuple(Name) ->
+            case lists:keysearch(args, 1, Settings) of
+                {value,_} when element(1,Name) =/= spawn_executable ->
+                    [<<"must be spawn_executable">>];
+                _ ->
+                    [<<"invalid port name">>]
+            end;
         _ ->
-            [must_be_tuple(Name, <<"invalid port name">>)]
+            must_be_tuple(Name)
     end;
 format_erlang_error(phash, [_,N], _) ->
     [must_be_pos_int(N)];


### PR DESCRIPTION
Before this fix the error reason would be "invalid port name",
which is true but not as helpfull as it could be. So now it returns
"must be spawn_executable".