### PR TITLE
erts: Make 'test' PHONY so that make test works

### DIFF
--- a/make/run_make.mk
+++ b/make/run_make.mk
@@ -29,7 +29,7 @@
 include $(ERL_TOP)/make/output.mk
 include $(ERL_TOP)/make/target.mk
 
-.PHONY: valgrind asan
+.PHONY: valgrind asan test
 
 opt debug valgrind asan gcov gprof lcnt frmptr icount:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile TYPE=$@


### PR DESCRIPTION
Before this commit you had to do 'make -f */Makefile test'
in order to run the erts tests, now you can just run 'make test'.