### PR TITLE
Allow some configuration to be read from XDG config

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -461,10 +461,12 @@ $ <input>erl \
         <p>Makes the Erlang runtime system into a distributed node.
           This flag invokes all network servers necessary for a node to
           become distributed; see <seeerl marker="kernel:net_kernel">
-          <c>net_kernel(3)</c></seeerl>. It is also ensured that
+          <c>net_kernel(3)</c></seeerl>. It also ensures that
           <c><![CDATA[epmd]]></c> runs on the current host before Erlang is
-          started; see <seecom marker="epmd"><c>epmd(1)</c></seecom> and the
-          <seecom marker="#start_epmd"><c>-start_epmd</c></seecom> option.</p>
+          started (see <seecom marker="epmd"><c>epmd(1)</c></seecom> and the
+          <seecom marker="#start_epmd"><c>-start_epmd</c></seecom> option) and
+          that a magic cookie has been set
+          (see <seecom marker="#setcookie">-setcookie</seecom>).</p>
         <p>The node name will be <c><![CDATA[Name@Host]]></c>, where
           <c><![CDATA[Host]]></c> is the fully qualified host name of the
           current host. For short names, use flag <c><![CDATA[-sname]]></c>
@@ -626,11 +628,14 @@ $ <input>erl \
           passed as atoms. See <seeerl marker="init">
           <c>init(3)</c></seeerl>.</p>
       </item>
-      <tag><c><![CDATA[-setcookie Cookie]]></c></tag>
+      <tag><marker id="setcookie"/><c><![CDATA[-setcookie Cookie]]></c></tag>
       <item>
         <p>Sets the magic cookie of the node to <c><![CDATA[Cookie]]></c>; see
-          <seemfa marker="erlang#set_cookie/2">
-          <c>erlang:set_cookie/2</c></seemfa>.</p>
+          <seemfa marker="erlang#set_cookie/1"><c>erlang:set_cookie/1</c></seemfa>.
+          See see section
+          <seeguide marker="system/reference_manual:distributed">Distributed Erlang</seeguide>
+          in the Erlang Reference Manual for more details.
+        </p>
       </item>
       <tag><c><![CDATA[-setcookie Node Cookie]]></c></tag>
       <item>

--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -1875,14 +1875,17 @@ $ <input>erl \
       <tag>The <c>.erlang</c> startup file</tag>
       <item>
         <p>When Erlang/OTP is started, the system searches for a file named
-        <c>.erlang</c> in the user&apos;s home directory.</p>
+          <c>.erlang</c> in the <seeerl marker="erts:init#home">
+          user&apos;s home directory</seeerl> and then
+          <seeerl marker="stdlib:filename#user_config">
+            <c>filename:basedir(user_config, "erlang")</c></seeerl>.</p>
         <p>If an <c>.erlang</c> file is found, it is assumed to contain valid
           Erlang expressions. These expressions are evaluated as if they were
           input to the shell.</p>
         <p>A typical <c>.erlang</c> file contains a set of search paths, for
           example:</p>
     <code type="none"><![CDATA[
-io:format("executing user profile in HOME/.erlang\n",[]).
+io:format("executing user profile in $HOME/.erlang\n",[]).
 code:add_path("/home/calvin/test/ebin").
 code:add_path("/home/hobbes/bigappl-1.2/ebin").
 io:format(".erlang rc finished\n",[]).    ]]></code>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2513,7 +2513,9 @@ uncompiled code with the same arity are mapped to the same list by
       <fsummary>Get the magic cookie of the local node.</fsummary>
       <desc>
         <p>Returns the magic cookie of the local node if the node is
-          alive, otherwise the atom <c>nocookie</c>.</p>
+          alive, otherwise the atom <c>nocookie</c>. This value is set by
+          <seemfa marker="#set_cookie/1"><c>set_cookie/1</c></seemfa>.
+        </p>
       </desc>
     </func>
 
@@ -2523,7 +2525,8 @@ uncompiled code with the same arity are mapped to the same list by
       <desc>
         <p>Returns the magic cookie for node <c><anno>Node</anno></c>
           if the local node is alive,
-          otherwise the atom <c>nocookie</c>.</p>
+          otherwise the atom <c>nocookie</c>. This value is set by
+          <seemfa marker="#set_cookie/2"><c>set_cookie/2</c></seemfa>.</p>
       </desc>
     </func>
 
@@ -6967,6 +6970,8 @@ true</pre>
           <seeguide marker="system/reference_manual:distributed">
           Distributed Erlang</seeguide>
           in the Erlang Reference Manual in System Documentation).</p>
+        <p>You can get this value using
+          <seemfa marker="#get_cookie/0"><c>get_cookie/0</c></seemfa>.</p>
         <p>Failure: <c>function_clause</c> if the local node is not
           alive.</p>
       </desc>
@@ -6984,6 +6989,8 @@ true</pre>
           <seeguide marker="system/reference_manual:distributed">
           Distributed Erlang</seeguide>
           in the Erlang Reference Manual in System Documentation).</p>
+        <p>You can get this value using
+          <seemfa marker="#get_cookie/1"><c>get_cookie/1</c></seemfa>.</p>
         <p>Failure: <c>function_clause</c> if the local node is not
           alive.</p>
       </desc>

--- a/erts/doc/src/init.xml
+++ b/erts/doc/src/init.xml
@@ -108,7 +108,7 @@
 3> <input>init:get_argument(progname).</input>
 {ok,[["erl"]]}</pre>
           </item>
-          <tag><c>home</c></tag>
+          <tag><marker id="home"/><c>home</c></tag>
           <item>
             <p>The home directory (on Unix, the value of $HOME):</p>
             <pre>

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -666,7 +666,7 @@ encrypted_abstr(Config) when is_list(Config) ->
 		  %% Now run the tests that require crypto.
 		  encrypted_abstr_1(Simple, Target),
 		  ok = file:delete(Target),
-		  ok = file:del_dir(filename:dirname(Target))
+		  ok = file:del_dir_r(filename:dirname(Target))
 	  end,
     
     %% Cleanup.
@@ -710,22 +710,77 @@ encrypted_abstr_1(Simple, Target) ->
     error = compile:file(Simple,
 			       [debug_info,{debug_info_key,42},report]),
 
-    %% Place the crypto key in .erlang.crypt.
     beam_lib:clear_crypto_key_fun(),
-    {ok,OldCwd} = file:get_cwd(),
-    ok = file:set_cwd(TargetDir),
 
-    error = compile:file(Simple, [encrypt_debug_info,report]),
+    %% Test to place the crypto file on disk. The test is dependent on the
+    %% $HOME of the emulator, so we do this test in another node.
+    TestHome = filename:join(TargetDir, "home"),
+    filelib:ensure_dir(TestHome),
+    HomeEnv = case os:type() of
+                  {win32, _} ->
+                      [Drive | Path] = filename:split(TestHome),
+                      [{"APPDATA", filename:join(TestHome,"AppData")},
+                       {"HOMEDRIVE", Drive}, {"HOMEPATH", Path}];
+                  _ ->
+                      [{"HOME", TestHome}]
+              end,
 
-    NewKey = "better use another key here",
-    write_crypt_file(["[{debug_info,des3_cbc,simple,\"",NewKey,"\"}].\n"]),
-    {ok,simple} = compile:file(Simple, [encrypt_debug_info,report]),
-    verify_abstract("simple.beam", erl_abstract_code),
-    ok = file:delete(".erlang.crypt"),
-    beam_lib:clear_crypto_key_fun(),
-    {error,beam_lib,{key_missing_or_invalid,"simple.beam",abstract_code}} =
-	beam_lib:chunks("simple.beam", [abstract_code]),
-    ok = file:set_cwd(OldCwd),
+    {ok, Peer, Node} = ?CT_PEER(#{ env => HomeEnv }),
+
+    erpc:call(
+      Node,
+      fun() ->
+              {ok,OldCwd} = file:get_cwd(),
+              ok = file:set_cwd(TargetDir),
+
+              error = compile:file(Simple, [encrypt_debug_info,report]),
+
+              CWDKey = "better use another key here",
+              CWDFile = ".erlang.crypt",
+              XDGKey = "better use yet another key here",
+              XDGFile = filename:join(
+                          filename:basedir(user_config,"erlang"),
+                          ".erlang.crypt"),
+              HOMEKey = "better use the home key here",
+              HOMEFile = filename:join(TestHome,".erlang.crypt"),
+
+              write_crypt_file(CWDFile, CWDKey),
+              write_crypt_file(XDGFile, XDGKey),
+              write_crypt_file(HOMEFile, HOMEKey),
+
+              %% First we test that .erlang.crypt in cwd works
+              {ok,simple} = compile:file(Simple, [encrypt_debug_info,report]),
+              verify_abstract("simple.beam", erl_abstract_code),
+              ok = file:delete(CWDFile),
+              beam_lib:clear_crypto_key_fun(),
+
+              %% Then we test that .erlang.crypt in HOME does **not** work
+              {error,beam_lib,{key_missing_or_invalid,"simple.beam",abstract_code}} =
+                  beam_lib:chunks("simple.beam", [abstract_code]),
+
+              %% Then we test that .erlang.crypt in HOME does work
+              {ok,simple} = compile:file(Simple, [encrypt_debug_info,report]),
+              verify_abstract("simple.beam", erl_abstract_code),
+              ok = file:delete(HOMEFile),
+              beam_lib:clear_crypto_key_fun(),
+
+              %% Then we test that .erlang.crypt in XDG does **not** work
+              {error,beam_lib,{key_missing_or_invalid,"simple.beam",abstract_code}} =
+                  beam_lib:chunks("simple.beam", [abstract_code]),
+
+
+              %% Then we test that .erlang.crypt in XDG does work
+              {ok,simple} = compile:file(Simple, [encrypt_debug_info,report]),
+              verify_abstract("simple.beam", erl_abstract_code),
+              ok = file:delete(XDGFile),
+
+              beam_lib:clear_crypto_key_fun(),
+              {error,beam_lib,{key_missing_or_invalid,"simple.beam",abstract_code}} =
+                  beam_lib:chunks("simple.beam", [abstract_code])
+
+      end),
+
+    peer:stop(Peer),
 
     %% Test key compatibility by reading a BEAM file produced before
     %% the update to the new crypto functions.
@@ -738,11 +793,11 @@ encrypted_abstr_1(Simple, Target) ->
 
     ok.
 
-
-write_crypt_file(Contents0) ->
-    Contents = list_to_binary([Contents0]),
-    io:format("~s\n", [binary_to_list(Contents)]),
-    ok = file:write_file(".erlang.crypt", Contents).
+write_crypt_file(File, Key) ->
+    Contents = ["[{debug_info,des3_cbc,simple,\"",Key,"\"}].\n"],
+    io:format("~s: ~s\n", [File, Contents]),
+    ok = filelib:ensure_dir(File),
+    ok = file:write_file(File, Contents).
 
 encrypted_abstr_no_crypto(Simple, Target) ->
     io:format("simpe: ~p~n", [Simple]),

--- a/lib/debugger/src/dbg_wx_settings.erl
+++ b/lib/debugger/src/dbg_wx_settings.erl
@@ -80,30 +80,35 @@ default_settings_dir(Win) ->
     case filelib:is_dir(DefDir) of
 	true -> DefDir;
 	false ->
-	    {ok, CWD} = file:get_cwd(),
-	    
-	    Msg = ["Default directory ", DefDir, " does not exist. ",
-		   "Click OK to create it or ",
-		   "Cancel to use other directory."],
-	    case dbg_wx_win:confirm(Win, Msg) of
-		ok ->
-		    ToolsDir = filename:dirname(DefDir),
-		    case filelib:is_dir(ToolsDir) of
-			true ->
-			    case file:make_dir(DefDir) of
-				ok -> DefDir;
-				_Error -> CWD
-			    end;
-			false ->
-			    case file:make_dir(ToolsDir) of
-				ok ->
-				    case file:make_dir(DefDir) of
-					ok -> DefDir;
-					_Error -> CWD
-				    end;
-				_Error -> CWD
-			    end
-		    end;
-		cancel -> CWD
-	    end
+            XDGDir = filename:join(filename:basedir(user_config,"erlang"),"debugger"),
+            case filelib:is_dir(XDGDir) of
+                true -> XDGDir;
+                false ->
+                    {ok, CWD} = file:get_cwd(),
+
+                    Msg = ["Default directory ", XDGDir, " does not exist. ",
+                           "Click OK to create it or ",
+                           "Cancel to use other directory."],
+                    case dbg_wx_win:confirm(Win, Msg) of
+                        ok ->
+                            ToolsDir = filename:dirname(XDGDir),
+                            case filelib:is_dir(ToolsDir) of
+                                true ->
+                                    case file:make_dir(XDGDir) of
+                                        ok -> XDGDir;
+                                        _Error -> CWD
+                                    end;
+                                false ->
+                                    case file:make_dir(ToolsDir) of
+                                        ok ->
+                                            case file:make_dir(XDGDir) of
+                                                ok -> XDGDir;
+                                                _Error -> CWD
+                                            end;
+                                        _Error -> CWD
+                                    end
+                            end;
+                        cancel -> CWD
+                    end
+            end
     end.

--- a/lib/dialyzer/doc/src/dialyzer_chapter.xml
+++ b/lib/dialyzer/doc/src/dialyzer_chapter.xml
@@ -68,9 +68,11 @@ dialyzer --build_plt --apps erts kernel stdlib mnesia</code>
 
     <p>Dialyzer looks if there is an environment variable called
       <c>DIALYZER_PLT</c> and places the PLT at this location. If no such
-      variable is set, Dialyzer places the PLT at
-      <c>$HOME/.dialyzer_plt</c>. The placement can also be specified using
-      the options <c>--plt</c> or <c>--output_plt</c>.</p>
+      variable is set, Dialyzer places the PLT in a file called .dialyzer_plt
+      in the <seeerl marker="stdlib:filename#user_cache">
+        <c>filename:basedir(user_cache, "erlang")</c></seeerl> folder.
+      The placement can also be specified using the options
+      <c>--plt</c> or <c>--output_plt</c>.</p>
 
     <p>Information can be added to an existing PLT using option
       <c>--add_to_plt</c>. If you also want to include the Erlang compiler in

--- a/lib/dialyzer/src/dialyzer_cl.erl
+++ b/lib/dialyzer/src/dialyzer_cl.erl
@@ -431,7 +431,18 @@ check_if_writable(PltFile) ->
 	true -> false;
 	false ->
 	  DirName = filename:dirname(PltFile),
-	  filelib:is_dir(DirName) andalso is_writable_file_or_dir(DirName)
+	  case filelib:is_dir(DirName) of
+            false ->
+              case filelib:ensure_dir(PltFile) of
+                ok ->
+                  io:format("  Creating ~ts as it did not exist...~n", [DirName]),
+                  true;
+                {error, _} ->
+                  false
+              end;
+            true ->
+              is_writable_file_or_dir(DirName)
+          end
       end
   end.
 

--- a/lib/dialyzer/src/dialyzer_plt.erl
+++ b/lib/dialyzer/src/dialyzer_plt.erl
@@ -235,8 +235,8 @@ contains_mfa(#plt{info = Info, contracts = Contracts}, MFA) ->
 get_default_plt() ->
   case os:getenv("DIALYZER_PLT") of
     false ->
-      {ok,[[HomeDir]]} = init:get_argument(home),
-      filename:join(HomeDir, ".dialyzer_plt");
+      CacheDir = filename:basedir(user_cache, "erlang"),
+      filename:join(CacheDir, ".dialyzer_plt");
     UserSpecPlt -> UserSpecPlt
   end.
 

--- a/lib/erl_docgen/priv/bin/validate_links.escript
+++ b/lib/erl_docgen/priv/bin/validate_links.escript
@@ -231,14 +231,19 @@ validate_link(Filename, "seemfa", Line, Link, CachedFiles) ->
                     try list_to_integer(Arity) of
                         _ ->
                             MF = App ++ ":" ++ Mod ++ "#" ++ Func,
-                            Funcs = maps:get(funcs,maps:get({App,Mod},CachedFiles)),
-                            case lists:member({Func,Arity},Funcs) of
-                                true ->
-                                    validate_type(Line, "seemfa",
-                                                  read_link(Line, ParsedLink, CachedFiles));
-                                false ->
-                                    fail(Line, "Could not find documentation for ~s when "
-                                         "resolving link",[MF  ++ "/" ++ Arity])
+                            case maps:find({App,Mod},CachedFiles) of
+                                error ->
+                                    fail(Line, "Could not find ~ts in ~ts", [Mod, App]);
+                                {ok, ModInfo} ->
+                                    Funcs = maps:get(funcs,ModInfo),
+                                    case lists:member({Func,Arity},Funcs) of
+                                        true ->
+                                            validate_type(Line, "seemfa",
+                                                          read_link(Line, ParsedLink, CachedFiles));
+                                        false ->
+                                            fail(Line, "Could not find documentation for ~s when "
+                                                 "resolving link",[MF  ++ "/" ++ Arity])
+                                    end
                             end
                     catch _:_ ->
                             fail(Line, "Invalid arity for seemfa. "

--- a/lib/observer/src/observer_wx.erl
+++ b/lib/observer/src/observer_wx.erl
@@ -661,7 +661,7 @@ create_connect_dialog(connect, #state{frame = Frame}) ->
     {ok,[[HomeDir]]} = init:get_argument(home),
     XDGHome = filename:basedir(user_config,"erlang"),
     DefaultCookie =
-        case file:path_open([HomeDir,XDGHome], ".erlang.cookie", read) of
+        case file:path_open([HomeDir,XDGHome], ".erlang.cookie", [read]) of
             {ok, File, _} ->
                 {ok, #file_info{ size = Sz }} = file:read_file_info(File),
                 {ok, Data} = file:read(File, Sz),

--- a/lib/observer/src/observer_wx.erl
+++ b/lib/observer/src/observer_wx.erl
@@ -29,6 +29,7 @@
 
 %% Includes
 -include_lib("wx/include/wx.hrl").
+-include_lib("kernel/include/file.hrl").
 
 -include("observer_defs.hrl").
 
@@ -658,14 +659,16 @@ create_connect_dialog(connect, #state{frame = Frame}) ->
     wxWindow:setSizerAndFit(Dialog, VSizer),
     wxSizer:setSizeHints(VSizer, Dialog),
     {ok,[[HomeDir]]} = init:get_argument(home),
-    CookiePath = filename:join(HomeDir, ".erlang.cookie"),
-    DefaultCookie = case filelib:is_file(CookiePath) of
-			true ->
-			    {ok, Bin} = file:read_file(CookiePath),
-			    binary_to_list(Bin);
-			false ->
-			    ""
-		    end,
+    XDGHome = filename:basedir(user_config,"erlang"),
+    DefaultCookie =
+        case file:path_open([HomeDir,XDGHome], ".erlang.cookie", read) of
+            {ok, File, _} ->
+                {ok, #file_info{ size = Sz }} = file:read_file_info(File),
+                {ok, Data} = file:read(File, Sz),
+                Data;
+            _ ->
+                ""
+        end,
     wxTextCtrl:setValue(CookieCtrl, DefaultCookie),
     case wxDialog:showModal(Dialog) of
 	?wxID_OK ->

--- a/lib/stdlib/doc/src/beam_lib.xml
+++ b/lib/stdlib/doc/src/beam_lib.xml
@@ -138,8 +138,11 @@ io:fwrite("~s~n", [erl_prettypr:format(erl_syntax:form_list(AC))]).</code>
   <section>
     <title>.erlang.crypt</title>
     <p><c>beam_lib</c> searches for <c>.erlang.crypt</c> in the current
-      directory and then the home directory for the current user. If
-      the file is found and contains a key, <c>beam_lib</c>
+      directory, then the <seeerl marker="erts:init#home">
+      user&apos;s home directory</seeerl> and then
+      <seeerl marker="stdlib:filename#user_config">
+        <c>filename:basedir(user_config, "erlang")</c></seeerl>.
+      If the file is found and contains a key, <c>beam_lib</c>
       implicitly creates a crypto key fun and registers it.</p>
 
     <p>File <c>.erlang.crypt</c> is to contain a single list of tuples:</p>

--- a/lib/stdlib/doc/src/filename.xml
+++ b/lib/stdlib/doc/src/filename.xml
@@ -188,7 +188,7 @@ basedir(<anno>PathsType</anno>, <anno>Application</anno>, #{})</seeerl>.
               The options <c>'author'</c> and <c>'version'</c> are only used with <c>'windows'</c> option mode.
           </p>
         <list type="bulleted">
-            <item><c>user_cache</c>
+            <item><marker id="user_cache"/><c>user_cache</c>
                 <p>The path location is intended for transient data files on a local machine.</p>
                 <p>
                     On Linux:
@@ -212,7 +212,7 @@ basedir(<anno>PathsType</anno>, <anno>Application</anno>, #{})</seeerl>.
 5> <input>filename:basedir(user_cache, "My App", #{author=>"Erlang",version=>"1.2"}).</input>
 "c:/Users/otptest/AppData/Local/Erlang/My App/1.2/Cache"</pre>
             </item>
-            <item><c>user_config</c>
+            <item><marker id="user_config"/><c>user_config</c>
                 <p>
                     The path location is intended for persistent configuration files.
                 </p>
@@ -232,7 +232,7 @@ basedir(<anno>PathsType</anno>, <anno>Application</anno>, #{})</seeerl>.
 2> <input>filename:basedir(user_config, "My App", #{author=>"Erlang", version=>"1.2"}).</input>
 "c:/Users/otptest/AppData/Roaming/Erlang/My App/1.2"</pre>
             </item>
-            <item><c>user_data</c>
+            <item><marker id="user_data"/><c>user_data</c>
                 <p>
                     The path location is intended for persistent data files.
                 </p>
@@ -252,7 +252,7 @@ basedir(<anno>PathsType</anno>, <anno>Application</anno>, #{})</seeerl>.
 9> <input>filename:basedir(user_data, "My App",#{author=>"Erlang",version=>"1.2"}).</input>
 "c:/Users/otptest/AppData/Local/Erlang/My App/1.2"</pre>
             </item>
-            <item><c>user_log</c>
+            <item><marker id="user_log"/><c>user_log</c>
                 <p>The path location is intended for transient log files on a local machine.</p>
                 <p>
                 On Linux:
@@ -269,7 +269,7 @@ basedir(<anno>PathsType</anno>, <anno>Application</anno>, #{})</seeerl>.
 13> <input>filename:basedir(user_log, "My App",#{author=>"Erlang",version=>"1.2"}).</input>
 "c:/Users/otptest/AppData/Local/Erlang/My App/1.2/Logs"</pre>
             </item>
-            <item><c>site_config</c><p>
+            <item><marker id="site_config"/><c>site_config</c><p>
                 On Linux:
                 Respects the os environment variable <c>XDG_CONFIG_DIRS</c>.</p>
 <pre>
@@ -290,7 +290,7 @@ true
 5> <input>filename:basedir(site_config, "my_application", #{os=>darwin}).</input>
 ["/Library/Application Support/my_application"]</pre>
             </item>
-            <item><c>site_data</c><p>
+            <item><marker id="site_data"/><c>site_data</c><p>
                     On Linux:
                     Respects the os environment variable <c>XDG_DATA_DIRS</c>.</p>
                 <pre>

--- a/lib/stdlib/doc/src/filename.xml
+++ b/lib/stdlib/doc/src/filename.xml
@@ -273,7 +273,7 @@ basedir(<anno>PathsType</anno>, <anno>Application</anno>, #{})</seeerl>.
                 On Linux:
                 Respects the os environment variable <c>XDG_CONFIG_DIRS</c>.</p>
 <pre>
-5> <input>filename:basedir(site_data, "my_application", #{os=>linux}).</input>
+5> <input>filename:basedir(site_config, "my_application", #{os=>linux}).</input>
 ["/usr/local/share/my_application",
  "/usr/share/my_application"]
 6> <input>os:getenv("XDG_CONFIG_DIRS").</input>

--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -1150,11 +1150,12 @@ terminate(_Reason, _State) ->
     ok.
 
 crypto_key_fun_from_file() ->
+    UserConfig = filename:basedir(user_config,"erlang"),
     case init:get_argument(home) of
 	{ok,[[Home]]} ->
-	    crypto_key_fun_from_file_1([".",Home]);
+	    crypto_key_fun_from_file_1([".", Home, UserConfig]);
 	_ ->
-	    crypto_key_fun_from_file_1(["."])
+	    crypto_key_fun_from_file_1([".", UserConfig])
     end.
 
 crypto_key_fun_from_file_1(Path) ->

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -792,11 +792,12 @@ lm() ->
 -spec erlangrc() -> {ok, file:filename()} | {error, term()}.
 
 erlangrc() ->
+    UserConfig = filename:basedir(user_config,"erlang"),
     case init:get_argument(home) of
-	{ok,[[Home]]} ->
-	    erlangrc([Home]);
-	_ ->
-            {error, enoent}
+        {ok,[[Home]]} ->
+            erlangrc([Home, UserConfig]);
+        _ ->
+            erlangrc([UserConfig])
     end.
 
 -spec erlangrc(PathList) -> {ok, file:filename()} | {error, term()}

--- a/system/doc/reference_manual/distributed.xml
+++ b/system/doc/reference_manual/distributed.xml
@@ -180,9 +180,14 @@ dilbert@uab</pre>
     <p>At start-up, a node has a random atom assigned as its default
       magic cookie and the cookie of other nodes is assumed to be
       <c>nocookie</c>. The first action of the Erlang network
-      authentication server (<c>auth</c>) is then to read a file named
-      <c>$HOME/.erlang.cookie</c>. If the file does not exist, it is
-      created. The UNIX permissions mode of the file is set to octal
+      authentication server (<c>auth</c>) is then to search for a file named
+      <c>.erlang.cookie</c> in the <seeerl marker="erts:init#home">
+      user&apos;s home directory</seeerl> and then in
+      <seeerl marker="stdlib:filename#user_config">
+        <c>filename:basedir(user_config, "erlang")</c></seeerl>.
+      If none of the files exist, a <c>.erlang.cooke</c> file is created
+      in the user&apos;s home directory.
+      The UNIX permissions mode of the file is set to octal
       400 (read-only by user) and its content is a random string. An
       atom <c>Cookie</c> is created from the contents of the file and
       the cookie of the local node is set to this using


### PR DESCRIPTION
This PR changes so that the location of some system global files can be configured using XDG. The files are:

* $XDG_CONFIG_HOME/erlang
  * `.erlang`
  * `.erlang.cookie`
  * `.erlang.crypt`
  * `debugger`
* $XDG_CACHE_HOME/erlang
  * `.dialyzer_plt`

In order to keep backward compatibility, the config files are first read from $HOME, and then if they don't exist the $XDG_CONFIG_HOME/erlang directory is checked.

Since the dialyzer plt is a cache than a config file I decided to change the default location for it.

I decided to not do anything about `.erlang.hosts` as that file is hardly used by anyone.

Closes #5016 