### PR TITLE
logger: Fix logger_metadata app env var

### DIFF
--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -988,11 +988,19 @@ get_logger_level() ->
     end.
 
 get_primary_metadata() ->
-    case application:get_env(kernel,logger_default_metadata,#{}) of
-        Meta when is_map(Meta) ->
+    case application:get_env(kernel,logger_metadata) of
+        {ok, Meta} when is_map(Meta) ->
             Meta;
-        Meta ->
-            throw({logger_metadata, Meta})
+        {ok, Meta} ->
+            throw({logger_metadata, Meta});
+        undefined ->
+            %% This case is here to keep bug compatability. Can be removed in OTP 25.
+            case application:get_env(kernel,logger_default_metadata,#{}) of
+                Meta when is_map(Meta) ->
+                    Meta;
+                Meta ->
+                    throw({logger_metadata, Meta})
+            end
     end.
 
 get_primary_filter_default(Env) ->

--- a/lib/kernel/test/logger_SUITE.erl
+++ b/lib/kernel/test/logger_SUITE.erl
@@ -1004,7 +1004,7 @@ app_config(Config) ->
 
     ok.
 
-%% This test case is maintly to see code coverage. Note that
+%% This test case is mainly to see code coverage. Note that
 %% logger_env_var_SUITE tests a lot of the same, and checks the
 %% functionality more thoroughly, but since it all happens at node
 %% start, it is not possible to see code coverage in that test.

--- a/lib/kernel/test/logger_env_var_SUITE.erl
+++ b/lib/kernel/test/logger_env_var_SUITE.erl
@@ -60,7 +60,8 @@ groups() ->
                  logger_many_handlers_default_first,
                  logger_many_handlers_default_last,
                  logger_many_handlers_default_last_broken_filter,
-                 logger_proxy
+                 logger_proxy,
+                 logger_metadata
                 ]},
      {bad,[],[bad_error_logger,
               bad_level,
@@ -81,6 +82,7 @@ all() ->
 default(Config) ->
     {ok,#{primary:=P,handlers:=Hs,module_levels:=ML},_Node} = setup(Config,[]),
     notice = maps:get(level,P),
+    true = #{} == maps:get(metadata,P),
     #{module:=logger_std_h} = StdC = find(?STANDARD_HANDLER,Hs),
     all = maps:get(level,StdC),
     StdFilters = maps:get(filters,StdC),
@@ -552,6 +554,12 @@ logger_proxy(Config) ->
                         drop_mode_qlen:=2},
     Expected = rpc:call(Node,logger_olp,get_opts,[logger_proxy]),
     Expected = rpc:call(Node,logger,get_proxy_config,[]),
+
+    ok.
+
+logger_metadata(Config) ->
+    {ok,#{ primary := #{ metadata := #{ test := test } } }, _}
+        = setup(Config, [{logger_metadata,#{ test => test }}]),
 
     ok.
 


### PR DESCRIPTION
The variable name in the code was not the same as in the docs. So we fix the code and add a test case to make sure that it works.

Thanks, @sirihansen for reporting this issue.