### PR TITLE
ssl: 32 bytes random for random nonce for TLS 1.3

### DIFF
--- a/lib/ssl/src/dtls_record.erl
+++ b/lib/ssl/src/dtls_record.erl
@@ -75,6 +75,9 @@ init_connection_states(Role, BeastMitigation) ->
     ConnectionEnd = ssl_record:record_protocol_role(Role),
     Initial = initial_connection_state(ConnectionEnd, BeastMitigation),
     Current = Initial#{epoch := 0},
+    %% No need to pass Version to ssl_record:empty_connection_state since
+    %% random nonce is generated with same algorithm for DTLS version
+    %% Might require a change for DTLS-1.3
     InitialPending = ssl_record:empty_connection_state(ConnectionEnd, BeastMitigation),
     Pending = empty_connection_state(InitialPending),
     #{saved_read  => Current,

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -42,7 +42,7 @@
 	 set_server_verify_data/3,
          set_max_fragment_length/2,
 	 empty_connection_state/2,
-	 empty_connection_state/3,
+	 empty_connection_state/4,
          record_protocol_role/1,
          step_encryption_state/1,
          step_encryption_state_read/1,
@@ -55,6 +55,7 @@
 -export([cipher/4, cipher/5, decipher/4,
          cipher_aead/4, cipher_aead/5, decipher_aead/5,
          is_correct_mac/2, nonce_seed/3]).
+-define(TLS_1_3, {3, 4}).
 
 -export_type([ssl_version/0, ssl_atom_version/0, connection_states/0, connection_state/0]).
 
@@ -465,10 +466,12 @@ nonce_seed(_,_, CipherState) ->
 
 empty_connection_state(ConnectionEnd, BeastMitigation) ->
     MaxEarlyDataSize = ssl_config:get_max_early_data_size(),
-    empty_connection_state(ConnectionEnd, BeastMitigation, MaxEarlyDataSize).
+    empty_connection_state(ConnectionEnd, _Version = undefined,
+                           BeastMitigation, MaxEarlyDataSize).
 %%
-empty_connection_state(ConnectionEnd, BeastMitigation, MaxEarlyDataSize) ->
-    SecParams = empty_security_params(ConnectionEnd),
+empty_connection_state(ConnectionEnd, Version,
+                       BeastMitigation, MaxEarlyDataSize) ->
+    SecParams = init_security_parameters(ConnectionEnd, Version),
     #{security_parameters => SecParams,
       beast_mitigation => BeastMitigation,
       compression_state  => undefined,
@@ -483,13 +486,16 @@ empty_connection_state(ConnectionEnd, BeastMitigation, MaxEarlyDataSize) ->
       early_data_limit => false
      }.
 
-empty_security_params(ConnectionEnd = ?CLIENT) ->
-    #security_parameters{connection_end = ConnectionEnd,
-                         client_random = random()};
-empty_security_params(ConnectionEnd = ?SERVER) ->
-    #security_parameters{connection_end = ConnectionEnd,
-                         server_random = random()}.
-random() ->
+init_security_parameters(?CLIENT, Version) ->
+    #security_parameters{connection_end = ?CLIENT,
+                         client_random = make_random(Version)};
+init_security_parameters(?SERVER, Version) ->
+    #security_parameters{connection_end = ?SERVER,
+                         server_random = make_random(Version)}.
+
+make_random({_Major, _Minor} = Version) when Version >= ?TLS_1_3 ->
+    ssl_cipher:random_bytes(32);
+make_random(_Version) ->
     Secs_since_1970 = calendar:datetime_to_gregorian_seconds(
 			calendar:universal_time()) - 62167219200,
     Random_28_bytes = ssl_cipher:random_bytes(28),

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -452,8 +452,12 @@ initial_state(Role, Sender, Host, Port, Socket, {SSLOptions, SocketOptions, Trac
 	      {CbModule, DataTag, CloseTag, ErrorTag, PassiveTag}) ->
     #{beast_mitigation := BeastMitigation,
       erl_dist := IsErlDist,
+      %% Use highest supported version for client/server random nonce generation
+      versions := [Version|_],
       client_renegotiation := ClientRenegotiation} = SSLOptions,
-    ConnectionStates = tls_record:init_connection_states(Role, BeastMitigation),
+    ConnectionStates = tls_record:init_connection_states(Role,
+                                                         Version,
+                                                         BeastMitigation),
     #{session_cb := SessionCacheCb} = ssl_config:pre_1_3_session_opts(Role),
     UserMonitor = erlang:monitor(process, User),
     InitStatEnv = #static_env{

--- a/lib/ssl/src/tls_connection_1_3.erl
+++ b/lib/ssl/src/tls_connection_1_3.erl
@@ -467,9 +467,14 @@ downgrade(Type, Event, State) ->
 initial_state(Role, Sender, Host, Port, Socket, {SSLOptions, SocketOptions, Trackers}, User,
 	      {CbModule, DataTag, CloseTag, ErrorTag, PassiveTag}) ->
     #{erl_dist := IsErlDist,
+      %% Use highest supported version for client/server random nonce generation
+      versions := [Version|_],
       client_renegotiation := ClientRenegotiation} = SSLOptions,
     MaxEarlyDataSize = init_max_early_data_size(Role),
-    ConnectionStates = tls_record:init_connection_states(Role, disabled, MaxEarlyDataSize),
+    ConnectionStates = tls_record:init_connection_states(Role,
+                                                         Version,
+                                                         disabled,
+                                                         MaxEarlyDataSize),
     UserMonitor = erlang:monitor(process, User),
     InitStatEnv = #static_env{
                      role = Role,

--- a/lib/ssl/src/tls_record.erl
+++ b/lib/ssl/src/tls_record.erl
@@ -34,8 +34,8 @@
 
 %% Handling of incoming data
 -export([get_tls_records/5,
-         init_connection_states/2,
-         init_connection_states/3]).
+         init_connection_states/3,
+         init_connection_states/4]).
 
 %% Encoding TLS records
 -export([encode_handshake/3, encode_alert_record/3,
@@ -66,29 +66,35 @@
 %% Handling of incoming data
 %%====================================================================
 %%--------------------------------------------------------------------
--spec init_connection_states(Role, BeastMitigation) ->
+-spec init_connection_states(Role, Version, BeastMitigation) ->
           ssl_record:connection_states() when
       Role :: client | server,
+      Version :: tls_version(),
       BeastMitigation :: one_n_minus_one | zero_n | disabled.
 
-%% 
+%%
 %% Description: Creates a connection_states record with appropriate
 %% values for the initial SSL connection setup.
 %%--------------------------------------------------------------------
-init_connection_states(Role, BeastMitigation) ->
+init_connection_states(Role, Version, BeastMitigation) ->
     MaxEarlyDataSize = ssl_config:get_max_early_data_size(),
-    init_connection_states(Role, BeastMitigation, MaxEarlyDataSize).
+    init_connection_states(Role, Version, BeastMitigation, MaxEarlyDataSize).
 %%
--spec init_connection_states(Role, BeastMitigation, MaxEarlyDataSize) ->
+-spec init_connection_states(Role, Version, BeastMitigation,
+                             MaxEarlyDataSize) ->
           ssl_record:connection_states() when
       Role :: client | server,
+      Version :: tls_version(),
       BeastMitigation :: one_n_minus_one | zero_n | disabled,
       MaxEarlyDataSize :: non_neg_integer().
 
-init_connection_states(Role, BeastMitigation, MaxEarlyDataSize) ->
+init_connection_states(Role, Version, BeastMitigation, MaxEarlyDataSize) ->
     ConnectionEnd = ssl_record:record_protocol_role(Role),
     Current = initial_connection_state(ConnectionEnd, BeastMitigation, MaxEarlyDataSize),
-    Pending = ssl_record:empty_connection_state(ConnectionEnd, BeastMitigation, MaxEarlyDataSize),
+    Pending = ssl_record:empty_connection_state(ConnectionEnd,
+                                                Version,
+                                                BeastMitigation,
+                                                MaxEarlyDataSize),
     #{current_read  => Current,
       pending_read  => Pending,
       current_write => Current,

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -108,6 +108,7 @@
          check_ok/1,
          check_result/4,
          check_result/2,
+         get_result/1,
          gen_check_result/4,
          basic_alert/4,
          session_id/1,
@@ -1121,9 +1122,20 @@ close(Pid, Timeout) ->
 	    exit(Pid, kill)
     end.
 
+get_result(Pids) ->
+    get_result(Pids, []).
+
+get_result([], Acc) ->
+    Acc;
+get_result([Pid | Tail], Acc) ->
+    receive
+	{Pid, Msg} ->
+	    get_result(Tail, [Msg | Acc])
+    end.
+
 check_result(Server, ServerMsg, Client, ClientMsg) ->
     {ClientIP, ClientPort} = get_ip_port(ServerMsg),
-    receive 
+    receive
 	{Server, ServerMsg} ->
 	    check_result(Client, ClientMsg);
         %% Workaround to accept local addresses (127.0.0.0/24)

--- a/lib/ssl/test/tls_1_3_record_SUITE.erl
+++ b/lib/ssl/test/tls_1_3_record_SUITE.erl
@@ -36,7 +36,7 @@
 -export([encode_decode/0,
          encode_decode/1,
          finished_verify_data/0,
-          finished_verify_data/1,
+         finished_verify_data/1,
          '1_RTT_handshake'/0,
          '1_RTT_handshake'/1,
          '0_RTT_handshake'/0,


### PR DESCRIPTION
In TLS 1.2 and prior, the client and server 32 byte random nonce was
defined as the first 4 bytes being the UTC epoch followed by 28 bytes
random. In TLS 1.3 the client and server random nonce is defined as 32
bytes random.

This commit passes the tls_version() tuple so when the empty security
parameters are initialized and generate client and server random, the
version specific random nonce is generated accordingly.

For further details see:

RFC 5246 The Transport Layer Security (TLS) Protocol Version 1.2,
Section 7.4.1.2. Client Hello

RFC 8446 The Transport Layer Security (TLS) Protocol Version 1.3,
Section 4.1.2. Client Hello