### PR TITLE
[stdlib] peer-ify application tests

### DIFF
--- a/lib/stdlib/test/calendar_SUITE.erl
+++ b/lib/stdlib/test/calendar_SUITE.erl
@@ -112,21 +112,23 @@ leap_years(Config) when is_list(Config) ->
 last_day_of_the_month(Config) when is_list(Config) ->
     check_last_day_of_the_month({?START_YEAR, 1}, {?END_YEAR, 1}).
 
-%% Tests local_time_to_universal_time_dst for MET.
+%% Tests local_time_to_universal_time_dst for CET/CEST/MET/MEST.
 local_time_to_universal_time_dst(Config) when is_list(Config) ->
     case os:type() of
 	{unix,_} ->
 	    case os:cmd("date '+%Z'") of
-		"SAST"++_ ->
-		    {comment, "Spoky time zone with zero-set DST, skipped"};
+                "ME"++_ -> %% covers MET/MEST
+                    local_time_to_universal_time_dst_x(Config);
+                "CE"++_ -> %% covers CET/CEST
+                    local_time_to_universal_time_dst_x(Config);
 		_ ->
-		    local_time_to_universal_time_dst_x(Config)
+                    {skip, "This test runs only for MET/MEST/CET/CEST"}
 	    end;
 	_ ->
 	    local_time_to_universal_time_dst_x(Config)
     end.
 local_time_to_universal_time_dst_x(Config) when is_list(Config) ->
-    %% Assumes MET (UTC+1 / UTC+2(dst)
+    %% Assumes CET (UTC+1 / UTC+2(dst) or MET (same as CET)
     LtW   = {{2003,01,15},{14,00,00}}, % Winter
     UtW   = {{2003,01,15},{13,00,00}}, %
     UtWd  = {{2003,01,15},{12,00,00}}, % dst

--- a/lib/stdlib/test/dets_SUITE.erl
+++ b/lib/stdlib/test/dets_SUITE.erl
@@ -115,9 +115,9 @@ end_per_group(_GroupName, Config) ->
 %% OTP-3621
 newly_started(Config) when is_list(Config) ->
     true = is_alive(),
-    {ok, Node} = test_server:start_node(slave1, slave, []),
+    {ok, Peer, Node} = ?CT_PEER(),
     [] = rpc:call(Node, dets, all, []),
-    test_server:stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 basic(Config) when is_list(Config) ->
@@ -153,7 +153,7 @@ open(Config) when is_list(Config) ->
     %% Running this test twice means that the Dets server is restarted
     %% twice. dets_sup specifies a maximum of 4 restarts in an hour.
     %% If this becomes a problem, one should consider running this
-    %% test on a slave node.
+    %% test on a peer node.
 
     {Sets, Bags, Dups} = args(Config),
     
@@ -373,12 +373,7 @@ dirty_mark(Config) when is_list(Config) ->
 			   exit(other_process_dead)
 		   end
 	   end,
-    {ok, Node} = test_server:start_node(dets_dirty_mark,
-                                        slave,
-                                        [{linked, false},
-                                         {args, "-pa " ++
-                                              filename:dirname
-						(code:which(?MODULE))}]),
+    {ok, Peer, Node} = ?CT_PEER(),
     ok = ensure_node(20, Node),
     %% io:format("~p~n",[rpc:call(Node, code, get_path, [])]),
     %% io:format("~p~n",[rpc:call(Node, file, get_cwd, [])]),
@@ -387,7 +382,7 @@ dirty_mark(Config) when is_list(Config) ->
 			 [?MODULE, dets_dirty_loop, []]),
     {ok, Tab} = Call(Pid, [open, Tab, [{file, FName}]]),
     [{opel,germany}] = Call(Pid, [read,Tab,opel]),
-    test_server:stop_node(Node),
+    peer:stop(Peer),
     {ok, Tab} = dets:open_file(Tab,[{file, FName},
                                     {repair,false}]),
     ok = dets:close(Tab),
@@ -421,12 +416,7 @@ dirty_mark2(Config) when is_list(Config) ->
 			   exit(other_process_dead)
 		   end
 	   end,
-    {ok, Node} = test_server:start_node(dets_dirty_mark2,
-                                        slave,
-                                        [{linked, false},
-                                         {args, "-pa " ++
-                                              filename:dirname
-						(code:which(?MODULE))}]),
+    {ok, Peer, Node} = ?CT_PEER(),
     ok = ensure_node(20, Node),
     Pid = rpc:call(Node,erlang, spawn,
                    [?MODULE, dets_dirty_loop, []]),
@@ -435,7 +425,7 @@ dirty_mark2(Config) when is_list(Config) ->
     timer:sleep(2100),
     %% Read something, just to give auto save time to finish.
     [{opel,germany}] = Call(Pid, [read,Tab,opel]),
-    test_server:stop_node(Node),
+    peer:stop(Peer),
     {ok, Tab} = dets:open_file(Tab, [{file, FName}, {repair,false}]),
     ok = dets:close(Tab),
     file:delete(FName),

--- a/lib/stdlib/test/error_logger_h_SUITE.erl
+++ b/lib/stdlib/test/error_logger_h_SUITE.erl
@@ -57,8 +57,7 @@ logfile(Config) ->
 
     do_one_logfile(Log, Ev, unlimited),
 
-    Pa = "-pa " ++ filename:dirname(code:which(?MODULE)),
-    {ok,Node} = start_node(logfile, Pa),
+    {ok,Peer,Node} = ?CT_PEER(),
     error_logger:logfile({open,Log}),
     ok = rpc:call(Node, erlang, apply, [fun gen_events/1,[Ev]]),
     AtNode = iolist_to_binary(["** at node ",atom_to_list(Node)," **"]),
@@ -79,7 +78,7 @@ logfile(Config) ->
                    end
            end, processes()),
 
-    test_server:stop_node(Node),
+    peer:stop(Peer),
 
     cleanup(Log),
     ok.
@@ -119,8 +118,7 @@ tty(Config) ->
 
     do_one_tty(Log, Ev, unlimited),
 
-    Pa = "-pa " ++ filename:dirname(code:which(?MODULE)),
-    {ok,Node} = start_node(tty, Pa),
+    {ok,Peer,Node} = ?CT_PEER(),
     tty_log_open(Log),
     ok = rpc:call(Node, erlang, apply, [fun gen_events/1,[Ev]]),
     tty_log_close(),
@@ -128,7 +126,7 @@ tty(Config) ->
     timer:sleep(1000), % some time get all log events in the log
     analyse_events(Log, Ev, [AtNode], unlimited),
 
-    test_server:stop_node(Node),
+    peer:stop(Peer),
 
     cleanup(Log),
     ok.
@@ -338,14 +336,6 @@ match_head(Tag, Head) ->
 	   " REPORT==== \\d\\d?-[A-Z][a-z][a-z]-\\d{4}::"
 	   "\\d\\d:\\d\\d:\\d\\d ===$">>,
     {match,_} = re:run(Head, Re).
-
-start_node(Name, Args) ->
-    case test_server:start_node(Name, slave, [{args,Args}]) of
-	{ok,Node} ->
-	    {ok,Node};
-	Error  ->
-	    ct:fail(Error)
-    end.
 
 cleanup(File) ->
     %% The point of this test case is not to test file operations.

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -5247,13 +5247,13 @@ test_delete_table_while_size_snapshot(Config) when is_list(Config) ->
     %% Run test case in a slave node as other test suites in stdlib
     %% depend on that pids are ordered in creation order which is no
     %% longer the case when many processes have been started before
-    Node = start_slave(),
+    {ok, Peer, Node} = ?CT_PEER(),
     [ok = rpc:call(Node,
                    ?MODULE,
                    test_delete_table_while_size_snapshot_helper,
                    [TableType])
      || TableType <- [set, ordered_set]],
-    test_server:stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 test_delete_table_while_size_snapshot_helper(TableType) ->
@@ -5289,13 +5289,6 @@ size_process(Table, Parent) ->
     catch
         E -> Parent ! {got_unexpected_exception, E}
     end.
-
-start_slave() ->
-    MicroSecs = erlang:monotonic_time(),
-    Name = "ets_" ++ integer_to_list(MicroSecs),
-    Pa = filename:dirname(code:which(?MODULE)),
-    {ok, Node} = test_server:start_node(list_to_atom(Name), slave, [{args, "-pa " ++ Pa}]),
-    Node.
 
 repeat_par(FunToRepeat, NrOfTimes) ->
     repeat_par_help(FunToRepeat, NrOfTimes, NrOfTimes).

--- a/lib/stdlib/test/gen_fsm_SUITE.erl
+++ b/lib/stdlib/test/gen_fsm_SUITE.erl
@@ -366,20 +366,20 @@ stop7(_Config) ->
 
 %% Anonymous on remote node
 stop8(_Config) ->
-    {ok,Node} = test_server:start_node(gen_fsm_SUITE_stop8,slave,[]),
+    {ok,Peer,Node} = ?CT_PEER(),
     Dir = filename:dirname(code:which(?MODULE)),
     rpc:call(Node,code,add_path,[Dir]),
     {ok, Pid} = rpc:call(Node,gen_fsm,start,[?MODULE,[],[]]),
     ok = gen_fsm:stop(Pid),
     false = rpc:call(Node,erlang,is_process_alive,[Pid]),
     {'EXIT',noproc} = (catch gen_fsm:stop(Pid)),
-    true = test_server:stop_node(Node),
+    peer:stop(Peer),
     {'EXIT',{{nodedown,Node},_}} = (catch gen_fsm:stop(Pid)),
     ok.
 
 %% Registered name on remote node
 stop9(_Config) ->
-    {ok,Node} = test_server:start_node(gen_fsm_SUITE_stop9,slave,[]),
+    {ok,Peer,Node} = ?CT_PEER(),
     Dir = filename:dirname(code:which(?MODULE)),
     rpc:call(Node,code,add_path,[Dir]),
     {ok, Pid} = rpc:call(Node,gen_fsm,start,[{local,to_stop},?MODULE,[],[]]),
@@ -387,13 +387,13 @@ stop9(_Config) ->
     undefined = rpc:call(Node,erlang,whereis,[to_stop]),
     false = rpc:call(Node,erlang,is_process_alive,[Pid]),
     {'EXIT',noproc} = (catch gen_fsm:stop({to_stop,Node})),
-    true = test_server:stop_node(Node),
+    peer:stop(Peer),
     {'EXIT',{{nodedown,Node},_}} = (catch gen_fsm:stop({to_stop,Node})),
     ok.
 
 %% Globally registered name on remote node
 stop10(_Config) ->
-    {ok,Node} = test_server:start_node(gen_fsm_SUITE_stop10,slave,[]),
+    {ok,Peer,Node} = ?CT_PEER(),
     Dir = filename:dirname(code:which(?MODULE)),
     rpc:call(Node,code,add_path,[Dir]),
     {ok, Pid} = rpc:call(Node,gen_fsm,start,[{global,to_stop},?MODULE,[],[]]),
@@ -401,7 +401,7 @@ stop10(_Config) ->
     ok = gen_fsm:stop({global,to_stop}),
     false = rpc:call(Node,erlang,is_process_alive,[Pid]),
     {'EXIT',noproc} = (catch gen_fsm:stop({global,to_stop})),
-    true = test_server:stop_node(Node),
+    peer:stop(Peer),
     {'EXIT',noproc} = (catch gen_fsm:stop({global,to_stop})),
     ok.
 

--- a/lib/stdlib/test/pool_SUITE.erl
+++ b/lib/stdlib/test/pool_SUITE.erl
@@ -23,6 +23,8 @@
 	 init_per_group/2,end_per_group/2]).
 -export([basic/1, link_race/1, echo/1]).
 
+-include_lib("common_test/include/ct.hrl").
+
 suite() -> [{ct_hooks,[{ts_install_cth,[{nodenames, 1}]}]}].
 
 all() ->
@@ -45,7 +47,7 @@ end_per_group(_GroupName, Config) ->
 
 basic(Config) ->
 
-    {ok, Node, PoolNode} = init_pool(pool_SUITE_basic, basic, Config),
+    {ok, Peer, Node, PoolNode} = init_pool(?FUNCTION_NAME, basic, Config),
 
     Node = rpc:call(Node, pool, get_node, []),
     PoolNode = rpc:call(Node, pool, get_node, []),
@@ -53,19 +55,19 @@ basic(Config) ->
     do_echo(Node),
     do_echo(Node),
 
-    test_server:stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 link_race(Config) ->
 
-    {ok, Node, PoolNode} = init_pool(pool_SUITE_basic, basic, Config),
+    {ok, Peer, Node, PoolNode} = init_pool(?FUNCTION_NAME, basic, Config),
 
     Node = rpc:call(Node, pool, get_node, []),
     PoolNode = rpc:call(Node, pool, get_node, []),
 
     rpc:call(Node, pool, pspawn_link, [erlang, is_atom, [?MODULE]]),
 
-    test_server:stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 do_echo(Node) ->
@@ -79,10 +81,9 @@ echo(Parent) ->
     end.
 
 
-init_pool(Proxy, Name, Config) ->
+init_pool(Case, Name, Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
-    [Slave] = proplists:get_value(nodenames, Config),
-    {ok, Node} = test_server:start_node(Proxy, slave, []),
+    {ok, Peer, Node} = ?CT_PEER(#{name => Case}),
     {ok, Hostname} = inet:gethostname(),
     file:write_file(filename:join(PrivDir,".hosts.erlang"),"'"++Hostname++"'.\n"),
     ok = rpc:call(Node, file, set_cwd, [PrivDir]),
@@ -92,4 +93,4 @@ init_pool(Proxy, Name, Config) ->
     Nodes = rpc:call(Node, pool, get_nodes, []),
     [rpc:call(N, code, add_patha, [filename:dirname(code:which(?MODULE))]) || N <- Nodes],
 
-    {ok, Node, PoolNode}.
+    {ok, Peer, Node, PoolNode}.

--- a/lib/stdlib/test/proc_lib_SUITE.erl
+++ b/lib/stdlib/test/proc_lib_SUITE.erl
@@ -700,7 +700,7 @@ stop(_Config) ->
     false = erlang:is_process_alive(Pid7),
 
     %% Remote registered name
-    {ok,Node} = test_server:start_node(proc_lib_SUITE_stop,slave,[]),
+    {ok, Peer, Node} = ?CT_PEER(),
     Dir = filename:dirname(code:which(?MODULE)),
     rpc:call(Node,code,add_path,[Dir]),
     Pid8 = spawn(Node,SysMsgProc),
@@ -714,7 +714,7 @@ stop(_Config) ->
     {'EXIT',noproc} = (catch proc_lib:stop(to_stop)),
     {'EXIT',noproc} = (catch proc_lib:stop({to_stop,Node})),
 
-    true = test_server:stop_node(Node),
+    peer:stop(Peer),
 
     %% Remote registered name, but non-existing node
     {'EXIT',{{nodedown,Node},_}} = (catch proc_lib:stop({to_stop,Node})),

--- a/lib/stdlib/test/qlc_SUITE.erl
+++ b/lib/stdlib/test/qlc_SUITE.erl
@@ -1163,9 +1163,9 @@ append(Config) when is_list(Config) ->
 evaluator(Config) when is_list(Config) ->
     true = is_alive(),
     evaluator_2(Config, []),
-    {ok, Node} = start_node(qlc_SUITE_evaluator),
+    {ok, Peer, Node} = ?CT_PEER(),
     ok = rpc:call(Node, ?MODULE, evaluator_2, [Config, [compiler]]),
-    test_server:stop_node(Node),
+    peer:stop(Peer),
     ok.
 
 evaluator_2(Config, Apps) ->
@@ -1190,10 +1190,6 @@ evaluator_2(Config, Apps) ->
 
     _ = file:delete(FileName),
     ok.
-
-start_node(Name) ->
-    PA = filename:dirname(code:which(?MODULE)),
-    test_server:start_node(Name, slave, [{args, "-pa " ++ PA}]).
 
 %% string_to_handle/1,2.
 string_to_handle(Config) when is_list(Config) ->


### PR DESCRIPTION
Replace usage of `test_server:start_node` with `?CT_PEER`.
Additionally, disable local_time_to_universal_time_dst when running in
Pacific Time (as it inevitably fails), and fix tar_SUITE test that
fails when `compile` module is taken from the installed system (in
that case compile.beam would be read-only, and after un-tarring
mode will be read-write, making this test fail).