### PR TITLE
Somewhat improve pretty printing of binaries in Dialyzer

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -1932,11 +1932,12 @@ map_sort_key(Key, KeyMap) ->
 %% pat_bin([BinElement], State) -> [BinSeg].
 
 pat_bin(Ps0, St) ->
-    Ps = pat_bin_expand_strings(Ps0),
+    Ps = pat_bin_expand_strings(Ps0, St),
     pat_segments(Ps, St).
 
-pat_bin_expand_strings(Es0) ->
-    foldr(fun ({bin_element,Line,{string,_,[_|_]=S},default,default}, Es1) ->
+pat_bin_expand_strings(Es0, #core{dialyzer=Dialyzer}) ->
+    foldr(fun ({bin_element,Line,{string,_,[_|_]=S},default,default}, Es1)
+                when not Dialyzer ->
                   bin_expand_string(S, Line, 0, 0, Es1);
               ({bin_element,Line,{string,_,S},Sz,Ts}, Es1) ->
                   foldr(


### PR DESCRIPTION
When running Dialyzer on this example:

    -spec foo() -> ok.
    foo() ->
        case foo of
          <<"bar">> -> ok;
          _ -> ok
        end.

the following error would be generated:

    The pattern <<6447474:24>> can never match the type 'foo'

That message is very confusing. Unfortunately, Dialyzer has only
access to Core Erlang version of the code, so there is no easy way to
exactly pretty print code fragments. However, the optimization of
strings that produces those huge numbers can be disabled when Dialyzer
invokes the compiler, producing the following message:

    The pattern <<98,97,114>> can never match the type 'foo'

Closes #5429.