### PR TITLE
Fix iOS build

### DIFF
--- a/erts/emulator/nifs/common/socket_util.c
+++ b/erts/emulator/nifs/common/socket_util.c
@@ -35,7 +35,10 @@
 #include <stddef.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+
+#ifndef __IOS__
 #include <net/if_arp.h>
+#endif
 
 #include "socket_int.h"
 #include "sys.h"


### PR DESCRIPTION
iOS doesn't ship <net/if_arp.h> so that file can't be included on that platform. This fix removes the include on iOS.

It seems it was anyway only included to check for additionally defined constants, so no further change here. 

FYI @garazdawi