### PR TITLE
Fixed OTP_RELEASE macro

### DIFF
--- a/system/doc/reference_manual/macros.xml
+++ b/system/doc/reference_manual/macros.xml
@@ -255,9 +255,11 @@ or
     %% Code that will work in OTP 22 or higher
   -elif(?OTP_RELEASE >= 21).
     %% Code that will work in OTP 21 or higher
+  -else.
+    %% OTP 20 or lower.
   -endif.
 -else.
-  %% OTP 20 or lower.
+  %% OTP_RELEASE is not defined.
 -endif.
 ...</code>
     <p>The code uses the <c>OTP_RELEASE</c> macro to conditionally


### PR DESCRIPTION
One of the examples (OTP_RELEASE macro) had a logical mistake.