### PR TITLE
ssl: Allow binary keyfile passwords

### DIFF
--- a/lib/public_key/src/pubkey_pbe.erl
+++ b/lib/public_key/src/pubkey_pbe.erl
@@ -33,7 +33,7 @@
 %%====================================================================
 
 %%--------------------------------------------------------------------
--spec encode(binary(), string(), string(), term()) -> binary().
+-spec encode(binary(), iodata(), string(), term()) -> binary().
 %%
 %% Description: Performs password based encoding
 %%--------------------------------------------------------------------
@@ -57,7 +57,7 @@ encode(Data, Password, "AES-256-CBC"= Cipher, KeyDevParams) ->
     crypto:crypto_one_time(aes_256_cbc, Key, IV,  pbe_pad(Data, block_size(aes_256_cbc)), true).
 
 %%--------------------------------------------------------------------
--spec decode(binary(), string(), string(), term()) -> binary().
+-spec decode(binary(), iodata(), string(), term()) -> binary().
 %%
 %% Description: Performs password based decoding
 %%--------------------------------------------------------------------

--- a/lib/public_key/src/pubkey_pem.erl
+++ b/lib/public_key/src/pubkey_pem.erl
@@ -72,7 +72,7 @@ encode(PemEntries) ->
 -spec decipher({public_key:pki_asn1_type(), DerEncrypted::binary(),
 		{Cipher :: string(), Salt :: iodata() | #'PBES2-params'{} 
 					   | {#'PBEParameter'{}, atom()}}},
-	       string()) -> Der::binary().
+	       iodata()) -> Der::binary().
 %%
 %% Description: Deciphers a decrypted pem entry.
 %%--------------------------------------------------------------------
@@ -82,7 +82,7 @@ decipher({_, DecryptDer, {Cipher, KeyDevParams}}, Password) ->
 %%--------------------------------------------------------------------
 -spec cipher(Der::binary(), {Cipher :: string(), Salt :: iodata() | #'PBES2-params'{} 
 						       | {#'PBEParameter'{}, atom()}}, 
-	     string()) -> binary().
+	     iodata()) -> binary().
 %%
 %% Description: Ciphers a PEM entry
 %%--------------------------------------------------------------------

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -243,7 +243,7 @@ pem_entry_decode({Asn1Type, Der, not_encrypted}) when is_atom(Asn1Type),
 
 -spec pem_entry_decode(PemEntry, Password) -> term() when
       PemEntry :: pem_entry(),
-      Password :: string() | fun(() -> string()).
+      Password :: iodata() | fun(() -> iodata()).
 pem_entry_decode(PemEntry, PasswordFun) when is_function(PasswordFun) ->
      pem_entry_decode(PemEntry, PasswordFun());
 pem_entry_decode({Asn1Type, Der, not_encrypted}, _) when is_atom(Asn1Type),
@@ -313,7 +313,7 @@ pem_entry_encode(Asn1Type, Entity)  when is_atom(Asn1Type) ->
                                                Entity :: term(),
                                                InfoPwd :: {CipherInfo,Password},
                                                CipherInfo :: cipher_info(),
-                                               Password :: string() .
+                                               Password :: iodata() .
 pem_entry_encode(Asn1Type, Entity, {{Cipher, #'PBES2-params'{}} = CipherInfo, 
 				    Password}) when is_atom(Asn1Type) andalso
 						    is_list(Password) andalso

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -349,7 +349,7 @@
                                        key_id := crypto:key_id(), 
                                        password => crypto:password()}. % exported
 -type key_pem()                   :: file:filename().
--type key_password()              :: string() | fun(() -> string()).
+-type key_password()              :: iodata() | fun(() -> iodata()).
 -type cipher_suites()             :: ciphers().    
 -type ciphers()                   :: [erl_cipher_suite()] |
                                      string(). % (according to old API) exported
@@ -2290,7 +2290,7 @@ validate_option(partial_chain, Value, _)
   when is_function(Value) ->
     Value;
 validate_option(password, Value, _)
-  when is_list(Value) ->
+  when is_list(Value); is_binary(Value) ->
     Value;
 validate_option(password, Value, _)
   when is_function(Value, 0) ->


### PR DESCRIPTION
A user has reported that while `{password, <<"pass">>}` doesn't work, `{password, [<<"pass">>]}` does. It doesn't seem to be useful to restrict the password to a list string.

For context: RabbitMQ has an option that allows encrypting passwords, but decrypted passwords are always returned as binary. It would be good to avoid special casing this.

This is a very early draft of a potential PR. There's a couple more options that could be improved by allowing binary strings as well.

@IngelaAndin What do you think?