### PR TITLE
Fix a crashdump_viewer crash when showing process details

### DIFF
--- a/lib/observer/src/observer_html_lib.erl
+++ b/lib/observer/src/observer_html_lib.erl
@@ -147,7 +147,7 @@ stackdump_table(Tab,{Label0,Term0},Even, Colors) ->
                    %% Return address or catch tag. It is known to be a
                    %% flat list, shortish, possibly containing characters
                    %% greater than 255.
-                   href_proc_port(Term0)
+                   href_proc_port(lists:flatten(io_lib:format("~tp", [Term0])))
            end,
     tr(color(Even, Colors), [td("VALIGN=center",pre(Label)), td(pre(Term))]).
 


### PR DESCRIPTION
In Erlang 24.1.5, viewing process details in a crashdump causes a crash.

To reproduce:
1. `erl -eval 'halt("dummy").'; mv erl_crash.dump erl_crash.dummy; erl -eval 'crashdump_viewer:start("erl_crash.dummy").'`
2. In the crashdump_viewer window, click the Processes tab
3. Double click on a process, or right-click and select "Properties for <0.0.0>" (or some other process)
![image](https://user-images.githubusercontent.com/850307/143794418-0616a9ac-bc6f-4f80-b4d6-0972d8684d3f.png)
4. The crashdump viewer crashes as below:

```
=CRASH REPORT==== 28-Nov-2021::23:04:01.827267 ===
  crasher:
    initial call: cdv_detail_wx:init/1
    pid: <0.12913.0>
    registered_name: []
    exception exit: {function_clause,
                        [{observer_html_lib,href_proc_port,
                             [{state,
                                  [{root,[<<"/usr/lib/erlang">>]},
                                   {progname,[<<"erl">>]},
                                   {home,[<<"/home/someuser">>]}],
                                  [],
                                  [{eval,<<"halt(\"dummy\").">>}],
                                  [{application_controller,['#CDVPid',0,44,0]},
                                   {logger,['#CDVPid',0,42,0]},
                                   {erl_prim_loader,['#CDVPid',0,10,0]}],
                                  ['#CDVPid',0,9,0],
                                  {starting,applications_loaded},
                                  {"Erlang/OTP","24"},
                                  [],
                                  [['#CDVPid',0,74,0]],
                                  #{},
                                  {"/usr/local/src/otp",
                                   "/usr/lib/erlang/bin/start.boot"}},
                              [],true],
                             [{file,"observer_html_lib.erl"},{line,268}]},
                         {observer_html_lib,stackdump_table,4,
                             [{file,"observer_html_lib.erl"},{line,150}]},
                         {observer_html_lib,'-expandable_term_body/4-fun-2-',
                             4,
                             [{file,"observer_html_lib.erl"},{line,102}]},
                         {lists,mapfoldl,3,[{file,"lists.erl"},{line,1358}]},
                         {lists,mapfoldl,3,[{file,"lists.erl"},{line,1359}]},
                         {observer_html_lib,expandable_term_body,4,
                             [{file,"observer_html_lib.erl"},{line,101}]},
                         {observer_html_lib,expandable_term,4,
                             [{file,"observer_html_lib.erl"},{line,59}]},
                         {cdv_proc_cb,init_memory_page,4,
                             [{file,"cdv_proc_cb.erl"},{line,111}]}]}
      in function  wx_object:init_it/6 (wx_object.erl, line 417)
```

I'm not at all sure the fix in this PR is the correct one, so this is only a draft for now. Any comments are welcome. I was unsure as well how to make a test case for this.