### PR TITLE
Fix process stack in crashdump

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -558,7 +558,7 @@ do {									\
 
 static void exec_misc_ops(ErtsRunQueue *);
 static void print_function_from_pc(fmtfn_t to, void *to_arg, ErtsCodePtr x);
-static int stack_element_dump(fmtfn_t to, void *to_arg, Eterm* sp, int yreg);
+static Uint stack_element_dump(fmtfn_t to, void *to_arg, Eterm* sp, Uint yreg);
 
 static void aux_work_timeout(void *unused);
 static void aux_work_timeout_early_init(int max_no_aux_work_threads);
@@ -14281,7 +14281,7 @@ void
 erts_stack_dump(fmtfn_t to, void *to_arg, Process *p)
 {
     Eterm* sp;
-    int yreg = -1;
+    Uint yreg = 0;
 
     if (ERTS_TRACE_FLAGS(p) & F_SENSITIVE) {
 	return;
@@ -14348,12 +14348,12 @@ print_function_from_pc(fmtfn_t to, void *to_arg, ErtsCodePtr x)
     }
 }
 
-static int
-stack_element_dump(fmtfn_t to, void *to_arg, Eterm* sp, int yreg)
+static Uint
+stack_element_dump(fmtfn_t to, void *to_arg, Eterm* sp, Uint yreg)
 {
     Eterm x = *sp;
 
-    if (yreg < 0 || is_CP(x)) {
+    if (is_CP(x)) {
         erts_print(to, to_arg, "\n%p ", sp);
     } else {
         char sbuf[16];

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -48,8 +48,8 @@ static void dump_process_info(fmtfn_t to, void *to_arg, Process *p);
 static void dump_element(fmtfn_t to, void *to_arg, Eterm x);
 static void dump_dist_ext(fmtfn_t to, void *to_arg, ErtsDistExternal *edep);
 static void dump_element_nl(fmtfn_t to, void *to_arg, Eterm x);
-static int stack_element_dump(fmtfn_t to, void *to_arg, Eterm* sp,
-			      int yreg);
+static Uint stack_element_dump(fmtfn_t to, void *to_arg, Eterm* sp,
+                               Uint yreg);
 static void stack_trace_dump(fmtfn_t to, void *to_arg, Eterm* sp);
 static void print_function_from_pc(fmtfn_t to, void *to_arg, ErtsCodePtr x);
 static void heap_dump(fmtfn_t to, void *to_arg, Eterm x);
@@ -223,7 +223,7 @@ static void
 dump_process_info(fmtfn_t to, void *to_arg, Process *p)
 {
     Eterm* sp;
-    int yreg = -1;
+    Uint yreg = 0;
 
     if (ERTS_TRACE_FLAGS(p) & F_SENSITIVE)
         return;
@@ -403,8 +403,8 @@ erts_limited_stack_trace(fmtfn_t to, void *to_arg, Process *p)
 
 }
 
-static int
-stack_element_dump(fmtfn_t to, void *to_arg, Eterm* sp, int yreg)
+static Uint
+stack_element_dump(fmtfn_t to, void *to_arg, Eterm* sp, Uint yreg)
 {
     Eterm x = *sp;
 

--- a/lib/observer/src/observer_html_lib.erl
+++ b/lib/observer/src/observer_html_lib.erl
@@ -139,15 +139,15 @@ msgq_table(Tab,Msg0, Id, Even, Colors) ->
 
 stackdump_table(Tab,{Label0,Term0},Even, Colors) ->
     Label = io_lib:format("~ts",[Label0]),
-    Term = case atom_to_list(Label0) of
-               "y" ++ _ ->
-                   %% Any term is possible, including huge ones.
-                   all_or_expand(Tab,Term0);
-               _ ->
+    Term = case string:split(Label, ":") of
+               [_Addr, "S" ++ _] ->
                    %% Return address or catch tag. It is known to be a
                    %% flat list, shortish, possibly containing characters
                    %% greater than 255.
-                   href_proc_port(Term0)
+                   href_proc_port(Term0);
+               _ ->
+                   %% Any term is possible, including huge ones.
+                   all_or_expand(Tab,Term0)
            end,
     tr(color(Even, Colors), [td("VALIGN=center",pre(Label)), td(pre(Term))]).
 


### PR DESCRIPTION
The optimization in #2351 inadvertently changed the way that the first stackframe in crash dumps is displayed. This PR fixes that problem in crash dumps and updates crash dump viewer to be able to read the stackframe of the broken processes.

Problem was also reported in #5459 