### PR TITLE
Add support for static Elixir NIF modules

### DIFF
--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -396,11 +396,10 @@ Some of the available `configure` options are:
     that do not support dynamic linking of libraries it is possible to statically
     link nifs and drivers with the main Erlang VM binary. This is done by passing
     a comma separated list to the archives that you want to statically link. e.g.
-    `--enable-static-nifs=/home/$USER/my_nif.a`. The path has to be absolute and the
-    name of the archive has to be the same as the module, i.e. `my_nif` in the
-    example above. This is also true for drivers, but then it is the driver name
-    that has to be the same as the filename. You also have to define
-    `STATIC_ERLANG_{NIF,DRIVER}` when compiling the .o files for the nif/driver.
+    `--enable-static-nifs=/home/$USER/my_nif.a`. The paths have to be absolute.
+    For drivers, the driver name has to be the same as the filename. You also
+    have to define `STATIC_ERLANG_NIF_LIBNAME` (see `erl_nif` documentation) or
+    `STATIC_ERLANG_DRIVER` when compiling the .o files for the nif/driver.
     If your nif/driver depends on some other dynamic library, you now have to link
     that to the Erlang VM binary. This is easily achieved by passing `LIBS=-llibname`
     to configure.

--- a/erts/configure
+++ b/erts/configure
@@ -1564,11 +1564,10 @@ Optional Features:
                           into the main binary. It is also possible to give a
                           list of nifs that should be linked statically. The
                           list should be a comma separated and contain the
-                          absolute path to a .a archive for each nif that is
-                          to be statically linked. The name of the .a archive
-                          has to be the same as the name of the nif. Note that
-                          you have to link any external dependencies that the
-                          nifs have to the main binary, so for the crypto nif
+                          absolute path to a .a archive for each nif lib
+                          that is to be statically linked. Note that you have
+                          to link any external dependencies, that the nifs have,
+                          to the main binary. So for the crypto nifs
                           you want to pass LIBS=-lcrypto to configure.
   --enable-static-drivers comma separated list of linked-in drivers to link
                           statically with the main binary. The list should

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -352,7 +352,7 @@ else
 fi
 
 AC_ARG_ENABLE(static-nifs,
-AS_HELP_STRING([--enable-static-nifs], [link nifs statically. If yes then all nifs in all Erlang/OTP applications will be statically linked into the main binary. It is also possible to give a list of nifs that should be linked statically. The list should be a comma separated and contain the absolute path to a .a archive for each nif that is to be statically linked. The name of the .a archive has to be the same as the name of the nif. Note that you have to link any external dependencies that the nifs have to the main binary, so for the crypto nif you want to pass LIBS=-lcrypto to configure.]),
+AS_HELP_STRING([--enable-static-nifs], [link nifs statically. If yes then all nifs in all Erlang/OTP applications will be statically linked into the main binary. It is also possible to give a list of nifs that should be linked statically. The list should be a comma separated and contain the absolute path to a .a archive for each nif that is to be statically linked. Note that you have to link any external dependencies, that the nifs have, to the main binary. So for the crypto nifs you want to pass LIBS=-lcrypto to configure.]),
 	       STATIC_NIFS="$enableval",
 	       STATIC_NIFS=no)
 AC_SUBST(STATIC_NIFS)

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -599,9 +599,15 @@ int writeiovec(ErlNifEnv *env, ERL_NIF_TERM term, ERL_NIF_TERM *tail,
        <p>The fourth argument <c>NULL</c> is ignored. It
           was earlier used for the deprecated <c>reload</c> callback
           which is no longer supported since OTP 20.</p>
-        <p>If compiling a NIF for static inclusion through
-          <c>--enable-static-nifs</c>, you must define <c>STATIC_ERLANG_NIF</c>
-           before the <c>ERL_NIF_INIT</c> declaration.</p>
+        <p>If compiling a NIF lib for static inclusion through
+           <c>--enable-static-nifs</c>, then the macro
+           <c>STATIC_ERLANG_NIF_LIBNAME</c> must be defined as the name of the
+           archive file (excluding file extension .a) without string
+           quotations. It must only contain characters allowed in a C
+           indentifier. The macro must be defined before <c>erl_nif.h</c> is
+           included. If the older macro <c>STATIC_ERLANG_NIF</c> is instead
+           used, then the name of the archive file must match the name of the
+           module.</p>
       </item>
       <tag><marker id="load"/><c>int (*load)(ErlNifEnv* caller_env, void** priv_data,
         ERL_NIF_TERM load_info)</c></tag>

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -335,6 +335,10 @@ extern TWinDynNifCallbacks WinDynNifCallbacks;
 #  undef ERL_NIF_API_FUNC_DECL
 #endif
 
+#ifdef STATIC_ERLANG_NIF_LIBNAME
+#  define STATIC_ERLANG_NIF
+#endif
+
 #if (defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_)) && !defined(STATIC_ERLANG_DRIVER) && !defined(STATIC_ERLANG_NIF)
 #  define ERL_NIF_API_FUNC_MACRO(NAME) (WinDynNifCallbacks.NAME)
 #  include "erl_nif_api_funcs.h"
@@ -365,11 +369,22 @@ extern TWinDynNifCallbacks WinDynNifCallbacks;
 #  endif
 #endif
 
+
 #ifdef STATIC_ERLANG_NIF
-#  define ERL_NIF_INIT_DECL(MODNAME) ErlNifEntry* MODNAME ## _nif_init(ERL_NIF_INIT_ARGS)
+#  ifdef STATIC_ERLANG_NIF_LIBNAME
+#    define ERL_NIF_INIT_NAME(MODNAME) ERL_NIF_INIT_NAME2(STATIC_ERLANG_NIF_LIBNAME)
+#    define ERL_NIF_INIT_NAME2(LIB) ERL_NIF_INIT_NAME3(LIB)
+#    define ERL_NIF_INIT_NAME3(LIB) LIB ## _nif_init
+#  else
+#    define ERL_NIF_INIT_NAME(MODNAME) MODNAME ## _nif_init
+#  endif
+#  define ERL_NIF_INIT_DECL(MODNAME) \
+          ErlNifEntry* ERL_NIF_INIT_NAME(MODNAME)(ERL_NIF_INIT_ARGS)
 #else
-#  define ERL_NIF_INIT_DECL(MODNAME) ERL_NIF_INIT_EXPORT ErlNifEntry* nif_init(ERL_NIF_INIT_ARGS)
+#  define ERL_NIF_INIT_DECL(MODNAME) \
+          ERL_NIF_INIT_EXPORT ErlNifEntry* nif_init(ERL_NIF_INIT_ARGS)
 #endif
+
 
 #ifdef __cplusplus
 }

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1308,14 +1308,15 @@ typedef struct {
     ErlDrvEntry* de;
     int taint;
 } ErtsStaticDriver;
-typedef void *(*ErtsStaticNifInitFPtr)(void);
-typedef struct ErtsStaticNifEntry_ {
-    const char *nif_name;
-    ErtsStaticNifInitFPtr nif_init;
-    int taint;
-} ErtsStaticNifEntry;
-ErtsStaticNifEntry* erts_static_nif_get_nif_init(const char *name, int len);
-int erts_is_static_nif(void *handle);
+typedef void* ErtsStaticNifInitF(void);
+typedef struct {
+    ErtsStaticNifInitF* const nif_init;
+    const int taint;
+
+    Eterm mod_atom;
+    ErlNifEntry* entry;
+} ErtsStaticNif;
+extern ErtsStaticNif erts_static_nif_tab[];
 void erts_init_static_drivers(void);
 
 /* erl_drv_thread.c */

--- a/erts/emulator/utils/make_driver_tab
+++ b/erts/emulator/utils/make_driver_tab
@@ -130,38 +130,19 @@ foreach (@static_nifs) {
 }
 
 # The array itself
-print "static ErtsStaticNifEntry static_nif_tab[] =\n{\n";
+print "ErtsStaticNif erts_static_nif_tab[] =\n{\n";
 
 foreach (@emu_nifs) {
     my $d = ${_};
     $d =~ s/\.debug//; # strip .debug
-    print "    {\"${_}\", &".$d."_nif_init, 0},\n";
+    print "    {&".$d."_nif_init, 0, THE_NON_VALUE, NULL},\n";
 }
 foreach (@static_nifs) {
     my $d = ${_};
     $d =~ s/\.debug//; # strip .debug
-    print "    {\"${_}\", &".$d."_nif_init, 1},\n";
+    print "    {&".$d."_nif_init, 1, THE_NON_VALUE, NULL},\n";
 }
 
-print "    {NULL,NULL}\n};\n";
-
-print <<EOF;
-ErtsStaticNifEntry* erts_static_nif_get_nif_init(const char *name, int len) {
-    ErtsStaticNifEntry* p;
-    for (p = static_nif_tab; p->nif_name != NULL; p++)
-        if (strncmp(p->nif_name, name, len) == 0 && p->nif_name[len] == 0)
-            return p;
-    return NULL;
-}
-
-int erts_is_static_nif(void *handle) {
-    ErtsStaticNifEntry* p;
-    for (p = static_nif_tab; p->nif_name != NULL; p++)
-        if (((void*)p->nif_init) == handle)
-            return 1;
-    return 0;
-}
-
-EOF
+print "    {NULL}\n};\n";
 
 # That's it


### PR DESCRIPTION
or any modules with "exotic" characters in the name (like '.').

* Add STATIC_ERLANG_NIF_LIBNAME macro which is used both to
  identify the archive name and create a unique C identifier for
  the _nif_init function.

* Run all static *_nif_init functions unconditionally at VM boot to
  get the corresponding module names. erlang:load_nif/2 can then
  match only against module names and does not have to care about
  archive filenames for static nifs.