### PR TITLE
Add -nifs() attribute

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -100,6 +100,8 @@ ERL_NIF_INIT(niftest,nif_funcs,NULL,NULL,NULL,NULL)</code>
 
 -export([init/0, hello/0]).
 
+-nifs([hello/0]).
+
 -on_load(init/0).
 
 init() ->
@@ -127,7 +129,13 @@ $> erl
       which loads the NIF library and replaces the <c>hello</c> function with its
       native implementation in C. Once loaded, a NIF library is persistent. It
       will not be unloaded until the module code version that it belongs to is
-      purged.</p>
+      purged.
+    </p>
+    <p>
+      The <seeguide marker="system/reference_manual:modules#nifs_attribute">
+      <c>-nifs()</c></seeguide> attribute specifies which functions in the
+      module that are to be replaced by NIFs.
+    </p>
     <p>
       Each NIF must have an implementation in Erlang to be invoked if the
       function is called before the NIF library is successfully loaded. A

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -148,21 +148,6 @@ $> erl
         However, unused local stub functions will be optimized
         away by the compiler, causing loading of the NIF library to fail.</p>
     </note>
-    <warning>
-      <p>
-	There is a known limitation for Erlang fallback functions of NIFs. Avoid
-	functions involved in traversal of binaries by matching and
-	recursion. If a NIF is loaded over such function, binary arguments to
-	the NIF may get corrupted and cause VM crash or other misbehavior.
-      </p>
-      <p>Example of such bad fallback function:</p>
-	<code type="none">
-skip_until(Byte, &lt;&lt;Byte, Rest/binary&gt;&gt;) ->
-    Rest;
-skip_until(Byte, &lt;&lt;_, Rest/binary&gt;&gt;) ->
-    skip_until(Byte, Rest).
-</code>
-    </warning>
   </section>
 
   <section>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -3869,6 +3869,16 @@ is_process_alive(P2Pid),
             allowed.
           </item>
         </taglist>
+        <p>
+          If the <seeguide marker="system/reference_manual:modules#nifs_attribute">
+          <c>-nifs()</c></seeguide> attribute is used (which is recommended),
+          all NIFs in the dynamic library much be declared as such for
+          <c>load_nif/2</c> to succeed. On the other hand, all functions declared
+          with the <c>-nifs()</c> attribute do not have to be implemented by the
+          dynamic library. This allows a target independent Erlang file to
+          contain fallback implementations for functions that may lack NIF
+          support depending on target OS/hardware platform.
+        </p>
       </desc>
     </func>
 

--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -2027,6 +2027,10 @@ BIF_RETTYPE erts_internal_purge_module_2(BIF_ALIST_2)
 
 		erts_remove_from_ranges(modp->old.code_hdr);
 
+                if (modp->old.code_hdr->are_nifs) {
+                    erts_free(ERTS_ALC_T_PREPARED_CODE,
+                              modp->old.code_hdr->are_nifs);
+                }
 #ifndef BEAMASM
                 erts_free(ERTS_ALC_T_CODE, (void *) modp->old.code_hdr);
 #else

--- a/erts/emulator/beam/beam_code.h
+++ b/erts/emulator/beam/beam_code.h
@@ -93,6 +93,13 @@ typedef struct beam_code_header {
     const byte *md5_ptr;
 
     /*
+     * Boolean array with functions declared as -nifs().
+     * Indexed same as functions[].
+     * NULL if no -nifs().
+     */
+    byte* are_nifs;
+
+    /*
      * Start of function pointer table.  This table contains pointers to
      * all functions in the module plus an additional pointer just beyond
      * the end of the last function.

--- a/erts/emulator/beam/emu/bif_instrs.tab
+++ b/erts/emulator/beam/emu/bif_instrs.tab
@@ -445,6 +445,9 @@ send() {
     }
 }
 
+nif_start() {
+}
+
 call_nif_early() {
     HEAVY_SWAPOUT;
     I = erts_call_nif_early(c_p, erts_code_to_codeinfo(I));

--- a/erts/emulator/beam/emu/emu_load.c
+++ b/erts/emulator/beam/emu/emu_load.c
@@ -76,6 +76,7 @@ int beam_load_prepare_emit(LoaderState *stp) {
     hdr->compile_size_on_heap = 0;
     hdr->literal_area = NULL;
     hdr->md5_ptr = NULL;
+    hdr->are_nifs = NULL;
 
     stp->code_hdr = hdr;
 
@@ -1343,6 +1344,19 @@ int beam_load_emit_op(LoaderState *stp, BeamOp *tmp_op) {
             }
 #endif
         }
+        break;
+    case op_nif_start:
+        if (!stp->code_hdr->are_nifs) {
+            int bytes = stp->beam.code.function_count * sizeof(byte);
+            stp->code_hdr->are_nifs = erts_alloc(ERTS_ALC_T_PREPARED_CODE,
+                                                 bytes);
+            sys_memzero(stp->code_hdr->are_nifs, bytes);
+        }
+        ASSERT(stp->function_number > 0);
+        ASSERT(stp->function_number <= stp->beam.code.function_count);
+        stp->code_hdr->are_nifs[stp->function_number-1] = 1;
+
+        ci -= 1;         /* Get rid of the instruction */
         break;
     case op_i_nif_padding:
         {

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -63,7 +63,7 @@ bif1 Fail u$func:erlang:is_constant/1 Src Dst => too_old_compiler
 label L
 i_func_info I a a I
 int_code_end
-nif_start =>
+nif_start
 
 i_generic_breakpoint
 i_debug_breakpoint

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -63,6 +63,7 @@ bif1 Fail u$func:erlang:is_constant/1 Src Dst => too_old_compiler
 label L
 i_func_info I a a I
 int_code_end
+nif_start =>
 
 i_generic_breakpoint
 i_debug_breakpoint

--- a/erts/emulator/beam/emu/predicates.tab
+++ b/erts/emulator/beam/emu/predicates.tab
@@ -53,9 +53,13 @@ pred.needs_nif_padding() {
         return 1;
     }
 
-    /* If the module may load a NIF all functions must be able to hold a NIF
-     * stub, so we'll pad to that size at the end of every function. */
-    return S->may_load_nif
+    /* If the module may load a NIF lib, all functions or functions declared as
+     * -nifs() must be able to hold a NIF stub. So we'll pad to that size at the
+     * end of every potential NIF function.
+     */
+    return S->may_load_nif &&
+        (S->code_hdr->are_nifs == NULL ||
+         S->code_hdr->are_nifs[S->function_number-1]);
 }
 
 // Test whether the given literal is a map.

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -4628,12 +4628,12 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
 #endif
         }
         erts_rwmtx_rwunlock(&erts_nif_call_tab_lock);
-        ASSERT(lib->finish->nstubs_hashed == lib->entry.num_of_funcs);
     }
 
     if (ret != am_ok) {
 	goto error;
     }
+    ASSERT(lib->finish->nstubs_hashed == lib->entry.num_of_funcs);
 
     /* Call load or upgrade:
      */

--- a/erts/emulator/beam/jit/arm/generators.tab
+++ b/erts/emulator/beam/jit/arm/generators.tab
@@ -490,7 +490,8 @@ gen.func_end(Func_Label, Entry_Label) {
         op = lambda;
     }
 
-    if (S->may_load_nif) {
+    if (S->may_load_nif && (S->load_hdr->are_nifs == NULL ||
+                            S->load_hdr->are_nifs[S->function_number-1])) {
         BeamOp *padding;
 
         $NewBeamOp(S, padding);

--- a/erts/emulator/beam/jit/arm/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bif.cpp
@@ -578,6 +578,10 @@ void BeamModuleAssembler::emit_send() {
     fragment_call(ga->get_call_light_bif_shared());
 }
 
+void BeamModuleAssembler::emit_nif_start() {
+    /* load time only instruction */
+}
+
 void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
     Label check_trap = a.newLabel(), trap = a.newLabel(), error = a.newLabel();
 

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -75,6 +75,7 @@ aligned_label L t
 
 i_func_info I a a I
 int_code_end
+nif_start
 
 i_generic_breakpoint
 i_debug_breakpoint

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -67,6 +67,7 @@ int beam_load_prepare_emit(LoaderState *stp) {
     hdr->compile_size_on_heap = 0;
     hdr->literal_area = NULL;
     hdr->md5_ptr = NULL;
+    hdr->are_nifs = NULL;
 
     stp->load_hdr = hdr;
 
@@ -535,6 +536,17 @@ int beam_load_emit_op(LoaderState *stp, BeamOp *tmp_op) {
             stp->func_line[stp->function_number] = stp->current_li;
         }
 
+        break;
+    case op_nif_start:
+        if (!stp->load_hdr->are_nifs) {
+            int bytes = stp->beam.code.function_count * sizeof(byte);
+            stp->load_hdr->are_nifs =
+                    erts_alloc(ERTS_ALC_T_PREPARED_CODE, bytes);
+            sys_memzero(stp->load_hdr->are_nifs, bytes);
+        }
+        ASSERT(stp->function_number > 0);
+        ASSERT(stp->function_number <= stp->beam.code.function_count);
+        stp->load_hdr->are_nifs[stp->function_number - 1] = 1;
         break;
     }
 

--- a/erts/emulator/beam/jit/x86/generators.tab
+++ b/erts/emulator/beam/jit/x86/generators.tab
@@ -558,7 +558,8 @@ gen.func_end(Func_Label, Entry_Label) {
         op = lambda;
     }
 
-    if (S->may_load_nif) {
+    if (S->may_load_nif && (S->load_hdr->are_nifs == NULL ||
+                            S->load_hdr->are_nifs[S->function_number-1])) {
         BeamOp *padding;
 
         $NewBeamOp(S, padding);

--- a/erts/emulator/beam/jit/x86/instr_bif.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bif.cpp
@@ -670,6 +670,10 @@ void BeamModuleAssembler::emit_send() {
     fragment_call(ga->get_call_light_bif_shared());
 }
 
+void BeamModuleAssembler::emit_nif_start() {
+    /* load time only instruction */
+}
+
 void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
     Label check_trap = a.newLabel(), trap = a.newLabel(), error = a.newLabel();
 

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -75,7 +75,7 @@ aligned_label L t
 
 i_func_info I a a I
 int_code_end
-nif_start =>
+nif_start
 
 i_generic_breakpoint
 i_debug_breakpoint

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -75,6 +75,7 @@ aligned_label L t
 
 i_func_info I a a I
 int_code_end
+nif_start =>
 
 i_generic_breakpoint
 i_debug_breakpoint

--- a/erts/emulator/internal_doc/beam_makeops.md
+++ b/erts/emulator/internal_doc/beam_makeops.md
@@ -538,7 +538,7 @@ It is also possible to add an `%else` clause:
 The following symbols are always defined.
 
 * `ARCH_64` - is 1 for a 64-bit machine, and 0 otherwise.
-* `ARCH_32` - is 1 for 32-bit machine, and 1 otherwise.
+* `ARCH_32` - is 1 for 32-bit machine, and 0 otherwise.
 
 The `Makefile` for building the emulator currently defines the
 following symbols by using the `-D` option on the command line for

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -72,12 +72,122 @@
          nif_whereis/1, nif_whereis_parallel/1,
          nif_whereis_threaded/1, nif_whereis_proxy/1,
          nif_ioq/1,
+         match_state_arg/1,
          pid/1,
          id/1,
          nif_term_type/1
 	]).
 
 -export([many_args_100/100]).
+
+-nifs([lib_version/0,
+       call_history/0,
+       hold_nif_mod_priv_data/1,
+       nif_mod_call_history/0,
+       list_seq/1,
+       type_test/0,
+       tuple_2_list/1,
+       is_identical/2,
+       compare/2,
+       hash_nif/3,
+       many_args_100/100,
+       clone_bin/1,
+       make_sub_bin/3,
+       string_to_bin/2,
+       atom_to_bin/2,
+       macros/1,
+       tuple_2_list_and_tuple/1,
+       iolist_2_bin/1,
+       get_resource_type/1,
+       alloc_resource/2,
+       make_resource/1,
+       get_resource/2,
+       release_resource/1,
+       release_resource_from_thread/1,
+       last_resource_dtor_call_nif/0,
+       make_new_resource/2,
+       check_is/11,
+       check_is_exception/0,
+       length_test/6,
+       make_atoms/0,
+       make_strings/0,
+       make_new_resource_binary/1,
+       send_list_seq/2,
+       send_new_blob/2,
+       alloc_msgenv/0,
+       clear_msgenv/1,
+       grow_blob/2,
+       grow_blob/3,
+       send_blob/2,
+       send3_blob/3,
+       send_blob_thread/3,
+       join_send_thread/1,
+       copy_blob/1,
+       send_term/2,
+       send_copy_term/2,
+       reverse_list/1,
+       echo_int/1,
+       type_sizes/0,
+       otp_9668_nif/1,
+       otp_9828_nif/1,
+       consume_timeslice_nif/2,
+       call_nif_schedule/2,
+       call_nif_exception/1,
+       call_nif_nan_or_inf/1,
+       call_nif_atom_too_long/1,
+       unique_integer_nif/1,
+       is_process_alive_nif/1,
+       is_port_alive_nif/1,
+       term_to_binary_nif/2,
+       binary_to_term_nif/3,
+       port_command_nif/2,
+       format_term_nif/2,
+       select_nif/6,
+       dupe_resource_nif/1,
+       pipe_nif/0,
+       write_nif/2,
+       read_nif/2,
+       close_nif/1,
+       is_closed_nif/1,
+       clear_select_nif/1,
+       last_fd_stop_call/0,
+       alloc_monitor_resource_nif/0,
+       monitor_process_nif/4,
+       demonitor_process_nif/2,
+       compare_monitors_nif/2,
+       make_monitor_term_nif/1,
+       monitor_frenzy_nif/4,
+       ioq_nif/1,
+       ioq_nif/2,
+       ioq_nif/3,
+       ioq_nif/4,
+       whereis_send/3,
+       whereis_term/2,
+       whereis_thd_lookup/3,
+       whereis_thd_result/1,
+       is_map_nif/1,
+       get_map_size_nif/1,
+       make_new_map_nif/0,
+       make_map_put_nif/3,
+       get_map_value_nif/2,
+       make_map_update_nif/3,
+       make_map_remove_nif/2,
+       maps_from_list_nif/1,
+       sorted_list_from_maps_nif/1,
+       monotonic_time/1,
+       time_offset/1,
+       convert_time_unit/3,
+       now_time/0,
+       cpu_time/0,
+       get_local_pid_nif/1,
+       make_pid_nif/1,
+       set_pid_undefined_nif/0,
+       is_pid_undefined_nif/1,
+       compare_pids_nif/2,
+       term_type_nif/1,
+       dynamic_resource_call/4,
+       msa_find_y_nif/1
+      ]).
 
 -define(nif_stub,nif_stub_error(?LINE)).
 
@@ -121,6 +231,7 @@ all() ->
      nif_phash2,
      nif_whereis, nif_whereis_parallel, nif_whereis_threaded,
      nif_ioq,
+     match_state_arg,
      pid,
      nif_term_type].
 
@@ -3829,6 +3940,30 @@ nif_term_type(Config) ->
     tuple = term_type_nif({}),
 
     ok.
+
+%% Verify match state arguments are not passed to declared NIFs.
+match_state_arg(Config) ->
+    ensure_lib_loaded(Config),
+    Bin = term_to_binary([<<"x">> | Config]), % a non-literal binary with an $x byte
+    <<"nif says ok">> = msa_find_x_y(Bin),
+    ok.
+
+%% Without declaring msa_find_y_nif/1 as NIF, the compiler would do
+%% optimization and pass it a match state as argument.
+msa_find_x_y(<<$x, Rest/binary>>) ->
+    msa_find_y_nif(Rest);
+msa_find_x_y(<<_, Rest/binary>>) ->
+    msa_find_x_y(Rest);
+msa_find_x_y(<<>>) ->
+    "no x".
+
+msa_find_y_nif(<<$y, Rest/binary>>) ->
+    Rest;
+msa_find_y_nif(<<_, Rest/binary>>) ->
+    msa_find_y_nif(Rest);
+msa_find_y_nif(<<>>) ->
+    "no y".
+
 
 last_resource_dtor_call() ->
     erts_debug:set_internal_state(wait, aux_work),

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -2505,8 +2505,10 @@ neg(Config) when is_list(Config) ->
     {ok,nif_mod,Bin} = compile:file(File, [binary,return_errors]),
     {module,nif_mod} = erlang:load_module(nif_mod,Bin),
 
-    {error,{load_failed,_}} = nif_mod:load_nif_lib(Config, 0),
-    {error,{bad_lib,_}} = nif_mod:load_nif_lib(Config, no_init),    
+    {error,{load_failed,"Failed to load NIF library"++_}} = nif_mod:load_nif_lib(Config, 0),
+    {error,{bad_lib,"Failed to find library init"++_}} = nif_mod:load_nif_lib(Config, 3),
+    {error,{bad_lib,"Function not found"++_}} = nif_mod:load_nif_lib(Config, 4),
+    {error,{bad_lib,"Duplicate NIF entry for"++_}} = nif_mod:load_nif_lib(Config, 5),
     verify_tmpmem(TmpMem),
     ok.
 

--- a/erts/emulator/test/nif_SUITE_data/Makefile.src
+++ b/erts/emulator/test/nif_SUITE_data/Makefile.src
@@ -3,6 +3,8 @@ NIF_LIBS = nif_SUITE.1@dll@ \
            nif_mod.1@dll@ \
            nif_mod.2@dll@ \
            nif_mod.3@dll@ \
+           nif_mod.4@dll@ \
+           nif_mod.5@dll@ \
 	   nif_mod.1.2_0@dll@ \
 	   nif_mod.2.2_0@dll@ \
 	   nif_mod.3.2_0@dll@ \

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -3685,6 +3685,22 @@ static ERL_NIF_TERM term_type_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
     }
 }
 
+static ERL_NIF_TERM msa_find_y_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ErlNifBinary bin;
+    const char ok_str[] = "nif says ok";
+    ERL_NIF_TERM ok_bin;
+
+    /* just verify that arg is a binary (and not a match state) */
+    if (!enif_inspect_binary(env, argv[0], &bin) ||
+        !enif_is_binary(env, argv[0])) {
+        return enif_make_string(env, "nif says arg not a binary", ERL_NIF_LATIN1);
+    }
+    memcpy(enif_make_new_binary(env, strlen(ok_str), &ok_bin),
+           ok_str, strlen(ok_str));
+    return ok_bin;
+}
+
 static ErlNifFunc nif_funcs[] =
 {
     {"lib_version", 0, lib_version},
@@ -3794,7 +3810,8 @@ static ErlNifFunc nif_funcs[] =
     {"set_pid_undefined_nif", 0, set_pid_undefined_nif},
     {"is_pid_undefined_nif", 1, is_pid_undefined_nif},
     {"compare_pids_nif", 2, compare_pids_nif},
-    {"term_type_nif", 1, term_type_nif}
+    {"term_type_nif", 1, term_type_nif},
+    {"msa_find_y_nif", 1, msa_find_y_nif}
 
 };
 

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.4.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.4.c
@@ -1,0 +1,2 @@
+#define NIF_LIB_VER 4
+#include "nif_mod.c"

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.5.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.5.c
@@ -1,0 +1,2 @@
+#define NIF_LIB_VER 5
+#include "nif_mod.c"

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.c
@@ -391,6 +391,13 @@ static ErlNifFunc nif_funcs[] =
 #ifdef HAVE_ENIF_MONITOR_PROCESS
     {"monitor_process", 3, monitor_process},
 #endif
+#if NIF_LIB_VER == 4
+    {"non_existing", 2, get_resource},      /* error: not found */
+#endif
+#if NIF_LIB_VER == 5
+    {"make_new_resource", 2, get_resource}, /* error: duplicate */
+#endif
+
     /* Keep lib_version_check last to maximize the loading "patch distance"
        between it and lib_version */
     {"lib_version_check", 0, lib_version}

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.erl
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.erl
@@ -31,6 +31,16 @@
 
 -define(nif_stub,nif_stub_error(?LINE)).
 
+-ifdef(USE_NIFS_ATTRIB).
+-nifs([lib_version/0, nif_api_version/0, get_priv_data_ptr/0]).
+-if(?USE_NIFS_ATTRIB > 1).
+-nifs([make_new_resource/2, get_resource/2, monitor_process/3]).
+-if(?USE_NIFS_ATTRIB > 2).
+-nifs([lib_version_check/0]).
+-endif.
+-endif.
+-endif.
+
 -ifdef(USE_ON_LOAD).
 -on_load(on_load/0).
 

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -202,6 +202,7 @@ $(EBIN)/beam_kernel_to_ssa.beam: v3_kernel.hrl beam_ssa.hrl
 $(EBIN)/beam_listing.beam: core_parse.hrl v3_kernel.hrl beam_ssa.hrl beam_asm.hrl
 $(EBIN)/beam_ssa.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_bsm.beam: beam_ssa.hrl
+$(EBIN)/beam_ssa_bool.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_codegen.beam: beam_ssa.hrl beam_asm.hrl
 $(EBIN)/beam_ssa_dead.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_funs.beam: beam_ssa.hrl
@@ -223,6 +224,7 @@ $(EBIN)/core_lint.beam: core_parse.hrl
 $(EBIN)/core_parse.beam: core_parse.hrl $(EGEN)/core_parse.erl
 $(EBIN)/core_pp.beam: core_parse.hrl
 $(EBIN)/sys_core_alias.beam: core_parse.hrl
+$(EBIN)/sys_core_bsm.beam: core_parse.hrl
 $(EBIN)/sys_core_fold.beam: core_parse.hrl
 $(EBIN)/sys_core_fold_lists.beam: core_parse.hrl
 $(EBIN)/sys_core_inline.beam: core_parse.hrl

--- a/lib/compiler/src/beam_ssa_bsm.erl
+++ b/lib/compiler/src/beam_ssa_bsm.erl
@@ -128,15 +128,20 @@ has_bsm_ops(#b_function{bs=Blocks}) ->
 
 hbo_blocks([{_,#b_blk{is=Is}} | Blocks]) ->
     case hbo_is(Is) of
-        false -> hbo_blocks(Blocks);
-        true -> true
+        no -> hbo_blocks(Blocks);
+        yes -> true;
+        nif_start ->
+            %% Disable optimizations for declared -nifs()
+            %% to avoid leaking match contexts as NIF arguments.
+            false
     end;
 hbo_blocks([]) ->
     false.
 
-hbo_is([#b_set{op=bs_start_match} | _]) -> true;
+hbo_is([#b_set{op=bs_start_match} | _]) -> yes;
+hbo_is([#b_set{op=nif_start} | _]) -> nif_start;
 hbo_is([_I | Is]) -> hbo_is(Is);
-hbo_is([]) -> false.
+hbo_is([]) -> no.
 
 %% Checks whether it's legal to make a call with the given argument as a match
 %% context, returning the param_info() of the relevant parameter.

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -391,6 +391,7 @@ classify_heap_need(is_tagged_tuple) -> neutral;
 classify_heap_need(kill_try_tag) -> gc;
 classify_heap_need(landingpad) -> gc;
 classify_heap_need(match_fail) -> gc;
+classify_heap_need(nif_start) -> neutral;
 classify_heap_need(nop) -> neutral;
 classify_heap_need(new_try_tag) -> gc;
 classify_heap_need(old_make_fun) -> gc;
@@ -1735,6 +1736,8 @@ cg_instr(get_tuple_element=Op, [Src,{integer,N}], Dst) ->
     [{Op,Src,N,Dst}];
 cg_instr(has_map_field, [Map,Key], Dst) ->
     [{bif,is_map_key,{f,0},[Key,Map],Dst}];
+cg_instr(nif_start, [], _Dst) ->
+    [nif_start];
 cg_instr(put_list=Op, [Hd,Tl], Dst) ->
     [{Op,Hd,Tl,Dst}];
 cg_instr(nop, [], _Dst) ->

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -367,7 +367,8 @@ vi({'%',_}, Vst) ->
     Vst;
 vi({line,_}, Vst) ->
     Vst;
-
+vi(nif_start, Vst) ->
+    Vst;
 %%
 %% Moves
 %%

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -658,3 +658,7 @@ BEAM_FORMAT_NUMBER=0
 ## @doc Calls the fun Func with arity Arity. Assume arguments in registers x(0)
 ##      to x(Arity-1). The call will never fail when Safe is 'true'.
 178: call_fun2/3
+
+## @spec nif_start
+## @doc  No-op at start of each function declared in -nifs().
+179: nif_start/0

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -164,7 +164,8 @@ value_option(Flag, Default, On, OnVal, Off, OffVal, Opts) ->
                    :: gb_sets:set(ta()),
                bvt = none :: 'none' | [any()],  %Variables in binary pattern
                gexpr_context = guard            %Context of guard expression
-                   :: gexpr_context()
+                   :: gexpr_context(),
+               load_nif=false :: boolean()      %true if calls erlang:load_nif/2
               }).
 
 -type lint_state() :: #lint{}.
@@ -201,6 +202,10 @@ format_error({redefine_import,{{F,A},M}}) ->
     io_lib:format("function ~tw/~w already imported from ~w", [F,A,M]);
 format_error({bad_inline,{F,A}}) ->
     io_lib:format("inlined function ~tw/~w undefined", [F,A]);
+format_error({undefined_nif,{F,A}}) ->
+    io_lib:format("nif ~tw/~w undefined", [F,A]);
+format_error(no_load_nif) ->
+    io_lib:format("nifs defined, but no call to erlang:load_nif/2", []);
 format_error({invalid_deprecated,D}) ->
     io_lib:format("badly formed deprecated attribute ~tw", [D]);
 format_error({bad_deprecated,{F,A}}) ->
@@ -990,7 +995,8 @@ post_traversal_check(Forms, St0) ->
     StF = check_local_opaque_types(StE),
     StG = check_dialyzer_attribute(Forms, StF),
     StH = check_callback_information(StG),
-    check_removed(Forms, StH).
+    StI = check_nifs(Forms, StH),
+    check_removed(Forms, StI).
 
 %% check_behaviour(State0) -> State
 %% Check that the behaviour attribute is valid.
@@ -1322,6 +1328,19 @@ check_option_functions(Forms, Tag0, Type, St0) ->
 	[{F,A} || {{F,A},_} <- orddict:to_list(St0#lint.imports)],
     Bad = [{FA,Anno} || {FA,Anno} <- FAsAnno, not member(FA, DefFunctions)],
     func_location_error(Type, Bad, St0).
+
+check_nifs(Forms, St0) ->
+    FAsAnno = [{FA,Anno} || {attribute, Anno, nifs, Args} <- Forms,
+                            FA <- Args],
+    St1 = case {FAsAnno, St0#lint.load_nif} of
+              {[{_,Anno1}|_], false} ->
+                  add_warning(Anno1, no_load_nif, St0);
+              _ ->
+                  St0
+          end,
+    DefFunctions = gb_sets:subtract(St1#lint.defined, gb_sets:from_list(pseudolocals())),
+    Bad = [{FA,Anno} || {FA,Anno} <- FAsAnno, not gb_sets:is_element(FA, DefFunctions)],
+    func_location_error(undefined_nif, Bad, St1).
 
 nowarn_function(Tag, Opts) ->
     ordsets:from_list([FA || {Tag1,FAs} <- Opts,
@@ -3984,7 +4003,8 @@ check_remote_function(Anno, M, F, As, St0) ->
 %% check_load_nif(Anno, ModName, FuncName, [Arg], State) -> State
 %%  Add warning if erlang:load_nif/2 is called when any kind of inlining has
 %%  been enabled.
-check_load_nif(Anno, erlang, load_nif, [_, _], St) ->
+check_load_nif(Anno, erlang, load_nif, [_, _], St0) ->
+    St = St0#lint{load_nif = true},
     case is_warn_enabled(nif_inline, St) of
         true -> check_nif_inline(Anno, St);
         false -> St

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -71,6 +71,8 @@
          external_funs/1,otp_15456/1,otp_15563/1,
          unused_type/1,binary_types/1,removed/1, otp_16516/1,
          inline_nifs/1,
+         undefined_nifs/1,
+         no_load_nif/1,
          warn_missing_spec/1,
          otp_16824/1,
          underscore_match/1,
@@ -98,6 +100,8 @@ all() ->
      record_errors, otp_11879_cont, non_latin1_module, otp_14323,
      stacktrace_syntax, otp_14285, otp_14378, external_funs,
      otp_15456, otp_15563, unused_type, binary_types, removed, otp_16516,
+     undefined_nifs,
+     no_load_nif,
      inline_nifs, warn_missing_spec, otp_16824,
      underscore_match, unused_record, unused_type2].
 
@@ -4481,6 +4485,34 @@ inline_nifs(Config) ->
            [],
            {warnings,[{{2,22},erl_lint,nif_inline}]}}],
     [] = run(Config, Ts).
+
+undefined_nifs(Config) when is_list(Config) ->
+    Ts = [{undefined_nifs,
+          <<"-export([t/0]).
+             -nifs([hej/1]).
+              t() ->
+                  erlang:load_nif(\"lib\", []).
+            ">>,
+           [],
+           {errors,[{{2,15},erl_lint,{undefined_nif,{hej,1}}}],[]}}
+         ],
+    [] = run(Config, Ts),
+
+    ok.
+
+no_load_nif(Config) when is_list(Config) ->
+    Ts = [{no_load_nif,
+          <<"-export([t/0]).
+             -nifs([t/0]).
+              t() ->
+                  a.
+            ">>,
+           [],
+           {warnings,[{{2,15},erl_lint,no_load_nif}]}}
+         ],
+    [] = run(Config, Ts),
+
+    ok.
 
 warn_missing_spec(Config) ->
     Test = <<"-export([external_with_spec/0, external_no_spec/0]).

--- a/system/doc/reference_manual/modules.xml
+++ b/system/doc/reference_manual/modules.xml
@@ -129,6 +129,36 @@ fact(0) ->           %  |
 	    <seeguide marker="code_loading#on_load">
             Running a Function When a Module is Loaded</seeguide>.</p>
         </item>
+        <tag><marker id="nifs_attribute"/><c>-nifs(Function).</c></tag>
+        <item>
+          <p>
+            Specifies which of the functions, defined within the module, that
+            may be loaded as NIFs with <seemfa marker="erts:erlang#load_nif/2">
+            <c>erlang:load_nif/2</c></seemfa>.
+          </p>
+          <p>
+            <c>Functions</c> is a list
+            <c>[Name1/Arity1, ..., NameN/ArityN]</c>, where each
+            <c>NameI</c> is an atom and <c>ArityI</c> an integer.
+          </p>
+          <note>
+            <p>
+              The <c>-nifs()</c> attribute was introduced in OTP 25.0. For older
+              Erlang source code without it, any functions in the module may be
+              loaded as NIFs. However, it is recommended to declare the NIFs with
+              the <c>-nifs</c> attribute. This allows the compiler to make better
+              decisions regarding optimizations for example.
+            </p>
+            <p>
+              There is no need to add <c>-nifs([])</c> in modules that do not
+              load NIFs. The lack of any call to
+              <seemfa marker="erts:erlang#load_nif/2"><c>erlang:load_nif/2</c></seemfa>,
+              from within the module, is enough for the compiler to draw the
+              same conclusion.
+            </p>
+          </note>
+        </item>
+
       </taglist>
     </section>
 


### PR DESCRIPTION
New `nifs` attribute.

```
-module(m).
-export([foo/0, bar/1, baz/2]).
-nifs([foo/0, baz/2, mylocal/3]).
```

The purpose it to give compiler and loader information about which functions that may be overridden as NIFs by `erlang:load_nif/2`, and thereby empower them to make better decisions, for example regarding optimizations.

To maintain **backward compatibility**, if no `-nifs()` in module, allow any functions as before. If `-nifs()` are declared, fail `erlang:load_nif/2` if undeclared functions are specified as NIFs in the dynamic lib.

This PR does

- Add new beam instruction `nif_start` at the top of every function declared as nif. Only to be used by compiler itself and loader to identify potential NIFs.
- Restrict the function size padding we do, to only declared nifs. Function size padding is done during load of Erlang functions to ensure minimal size needed for `call_nif` instruction overwritten by `erlang:load_nif`.
- Fix the "match state passed to NIF" bug by letting compiler disable match state optimizations for declared nifs.

Other potential use:
- Let compiler avoid inlining for functions declares as nifs.
- Add padding with no-ops before recursive call instructions early in functions declared as nifs. This will make sure the instruction after a recursive call (at the return address) can never be destroyed when writing the call_nif instruction.
