### PR TITLE
Add lists:transpose/1, useful for list of lists transposition

### DIFF
--- a/lib/stdlib/doc/src/lists.xml
+++ b/lib/stdlib/doc/src/lists.xml
@@ -1068,6 +1068,23 @@ splitwith(Pred, List) ->
     </func>
 
     <func>
+      <name name="transpose" arity="1" since=""/>
+      <fsummary>Transpose a list of lists.</fsummary>
+      <desc>
+        <p>Transposes a matrix (list of lists) into one list of lists
+          where the first element of each resulting list is taken from the first
+          list and the rest of elements are taken from the first element of the
+          following lists.</p>
+        <p>That is, if we have a matrix of 3x2 and we transpose it, we
+          obtain a matrix of 2x3.</p>
+        <p><em>Example:</em></p>
+        <pre>
+> <input>lists:transpose([[1,2,3], [4,5,6]]).</input>
+[[1,4],[2,5],[3,6]]</pre>
+      </desc>
+    </func>
+
+    <func>
       <name name="zip" arity="2" since=""/>
       <fsummary>Zip two lists into a list of two-tuples.</fsummary>
       <desc>
@@ -1075,6 +1092,9 @@ splitwith(Pred, List) ->
           where the first element of each tuple is taken from the first
           list and the second element is taken from the corresponding
           element in the second list.</p>
+        <p>If you need to transpose a list of lists instead of "zips"
+          together two lists, see
+          <seemfa marker="#transpose/1"><c>transpose/1</c></seemfa>.</p>
       </desc>
     </func>
 
@@ -1087,6 +1107,9 @@ splitwith(Pred, List) ->
           from the first list, the second element is taken from
           the corresponding element in the second list, and the third
           element is taken from the corresponding element in the third list.</p>
+        <p>If you need to transpose a list of lists instead of "zips"
+          together three lists, see
+          <seemfa marker="#transpose/1"><c>transpose/1</c></seemfa>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -27,6 +27,7 @@
 	 seq/2, seq/3, sum/1, duplicate/2, min/1, max/1, sublist/2, sublist/3,
 	 delete/2,
 	 unzip/1, unzip3/1, zip/2, zip3/3, zipwith/3, zipwith3/4,
+	 transpose/1,
 	 sort/1, merge/1, merge/2, rmerge/2, merge3/3, rmerge3/3,
 	 usort/1, umerge/1, umerge3/3, umerge/2, rumerge3/3, rumerge/2,
 	 concat/1, flatten/1, flatten/2, flatlength/1,
@@ -390,6 +391,35 @@ delete(_, []) -> [].
 
 zip([X | Xs], [Y | Ys]) -> [{X, Y} | zip(Xs, Ys)];
 zip([], []) -> [].
+
+%% Return [{A0, ..., Z0}, ..., {An, ..., Zn}] for lists [A0, ..., An],
+%% [B0, ..., Bn], ..., [Z0, ..., Zn].
+
+-spec transpose(Lists) -> Lists when
+      Lists :: [[A]],
+      A :: term().
+
+transpose([]) -> [];
+transpose([List|Tail] = Lists) ->
+    ListLen = length(List),
+    case all(fun(ListN) -> ListLen =:= length(ListN) end, Tail) of
+        true -> transpose(Lists, true, []);
+        false -> erlang:error(badarg, Lists)
+    end.
+
+transpose([[] | _], _MustReverse, Acc) -> reverse(Acc);
+transpose(Lists, MustReverse, Acc) ->
+    {Row, NewLists} = transpose_lists(Lists, [], []),
+    NewRow = case MustReverse of
+                 true -> reverse(Row);
+                 false -> Row
+             end,
+    transpose(NewLists, not MustReverse, [NewRow|Acc]).
+
+transpose_lists([[H|T]|List], Row, Acc) ->
+    transpose_lists(List, [H|Row], [T|Acc]);
+transpose_lists([], Row, Acc) ->
+    {Row, Acc}.
 
 %% Return {[X0, X1, ..., Xn], [Y0, Y1, ..., Yn]}, for a list [{X0, Y0},
 %% {X1, Y1}, ..., {Xn, Yn}].

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -54,6 +54,7 @@
 	 ufunsort_1/1, ufunsort_stable/1, ufunsort_rand/1,
 	 ufunsort_error/1,
 	 zip_unzip/1, zip_unzip3/1, zipwith/1, zipwith3/1,
+	 transpose/1,
 	 filter_partition/1, 
 	 join/1,
 	 otp_5939/1, otp_6023/1, otp_6606/1, otp_7230/1,
@@ -122,7 +123,8 @@ groups() ->
      {zip, [parallel], [zip_unzip, zip_unzip3, zipwith, zipwith3]},
      {misc, [parallel], [reverse, member, dropwhile, takewhile,
 			 filter_partition, suffix, subtract, join,
-			 hof, droplast, search, enumerate, error_info]}
+			 hof, droplast, search, enumerate, error_info,
+			 transpose]}
     ].
 
 init_per_suite(Config) ->
@@ -2332,6 +2334,27 @@ flatten_2(Config) when is_list(Config) ->
 %% flatten/2 error cases.
 flatten_2_e(Config) when is_list(Config) ->
     ok.
+
+%% Test lists:transpose/1.
+transpose(Config) when is_list(Config) ->
+    [] = lists:transpose([]),
+    [] = lists:transpose([[], [], [], []]),
+    [[a0, b0, c0], [a1, b1, c1], [a2, b2, c2]] =
+        lists:transpose([[a0, a1, a2], [b0, b1, b2], [c0, c1, c2]]),
+    [[a0, b0], [a1, b1], [a2, b2]] =
+        lists:transpose([[a0, a1, a2], [b0, b1, b2]]),
+    _ = [begin
+             Matrix = [[make_ref() || _ <- lists:seq(1, M)] ||
+                          _ <- lists:seq(1, N)],
+             Matrix = lists:transpose(lists:transpose(Matrix))
+         end || N <- lists:seq(1, 10), M <- lists:seq(1, 10)],
+
+    %% Error cases.
+    {'EXIT',{badarg,_}} = (catch lists:transpose([[], [b]])),
+    {'EXIT',{badarg,_}} = (catch lists:transpose([[a], []])),
+    {'EXIT',{badarg,_}} = (catch lists:transpose([[a], [b,c]])),
+    ok.
+
 
 %% Test lists:zip/2, lists:unzip/1.
 zip_unzip(Config) when is_list(Config) ->


### PR DESCRIPTION
When I was developing the Advent of Code 2021, using Elixir and Erlang, I just realized the rotating of a matrix like this:

```erlang
L = [
    [1, 2, 3],
    [4, 5, 6]
],
```

Could be rotated with `lists:zip/2` if we pass the lists as:

```erlang
L1 = [1, 2, 3],
L2 = [4, 5, 6],
lists:zip(L1, L2).
% [{1, 4}, {2, 5}, {3, 6}]
```

But, what if we have the need to rotate a matrix of arbitrary size? Then I've implemented `lists:zip/1` which is accepting the `L` parameter as a list of lists (matrix) and it's returning the rotated matrix:

```erlang
L = [
    [1, 2, 3],
    [4, 5, 6]
],
lists:zip(L).
% [[1, 4], [2, 5], [3, 6]]
```

And of course, we could use not only a matrix of 3x2 but also 9x7 or other completely different sizes.