### PR TITLE
Improve error messages for lists:seq/3

### DIFF
--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -189,7 +189,20 @@ format_lists_error(keysearch, Args) ->
 format_lists_error(member, [_Key, List]) ->
     [[], must_be_list(List)];
 format_lists_error(reverse, [List, _Acc]) ->
-    [must_be_list(List)].
+    [must_be_list(List)];
+format_lists_error(seq, [First, Last, Inc]) ->
+    case [must_be_integer(First), must_be_integer(Last), must_be_integer(Inc)] of
+        [[], [], []] ->
+            IncError = if
+                (Inc =< 0 andalso First - Inc =< Last) ->
+                    <<"not a positive increment">>;
+                (Inc >= 0 andalso First - Inc >= Last) ->
+                    <<"not a negative increment">>
+            end,
+            [[], [], IncError];
+        Errors -> Errors
+    end.
+
 
 format_maps_error(filter, Args) ->
     format_maps_error(map, Args);

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -259,16 +259,16 @@ seq_loop(0, _, L) ->
       Incr :: integer(),
       Seq :: [integer()].
 
-seq(First, Last, Inc) 
-    when is_integer(First), is_integer(Last), is_integer(Inc) -> 
-    if
-        Inc > 0, First - Inc =< Last;
-        Inc < 0, First - Inc >= Last ->
-            N = (Last - First + Inc) div Inc,
-            seq_loop(N, Inc*(N-1)+First, Inc, []);
-        Inc =:= 0, First =:= Last ->
-            seq_loop(1, First, Inc, [])
-    end.
+seq(First, Last, Inc)
+    when is_integer(First), is_integer(Last), is_integer(Inc),
+        (Inc > 0 andalso First - Inc =< Last) orelse
+        (Inc < 0 andalso First - Inc >= Last) ->
+    N = (Last - First + Inc) div Inc,
+    seq_loop(N, Inc * (N - 1) + First, Inc, []);
+seq(Same, Same, 0) when is_integer(Same) ->
+    [Same];
+seq(First, Last, Inc) ->
+    erlang:error(badarg, [First, Last, Inc], [{error_info, #{module => erl_stdlib_errors}}]).
 
 seq_loop(N, X, D, L) when N >= 4 ->
      Y = X-D, Z = Y-D, W = Z-D,


### PR DESCRIPTION
Right now, lists:seq performs as documented if you provide bad input.

> Failures:
> - If To < From - Incr and Incr > 0.
> - If To > From - Incr and Incr < 0.
> - If Incr =:= 0 and From =/= To.

However, the current error message is really confusing when it can be a lot better with just a little bit of rejigging.

```
% currently:
> lists:seq(1,5,-1).
** exception error: no true branch found when evaluating an if expression
     in function  lists:seq/3 (lists.erl, line 264)
% with this patch:
> seq:seq(1,5,-1).   
** exception error: no function clause matching seq:seq(1,5,-1) (seq.erl, line 32)
```

This error brings your attention to the incorrect input you've provided rather than pointing to some possible internal misbehavings.

The code still behaves as it should with all inputs I quickly tested.
```
14> seq:seq(1,5,0).       
** exception error: no function clause matching seq:seq(1,5,0) (seq.erl, line 32)
15> seq:seq(1,5,1). 
[1,2,3,4,5]
16> seq:seq(1,5,-1). 
** exception error: no function clause matching seq:seq(1,5,-1) (seq.erl, line 32)
17> seq:seq(5,1,-1). 
[5,4,3,2,1]
18> seq:seq(5,1,1).  
** exception error: no function clause matching seq:seq(5,1,1) (seq.erl, line 32)
19> seq:seq(1,1,1). 
[1]
21> seq:seq(1,1,0). 
[1]
22> seq:seq(1,2,0).
** exception error: no function clause matching seq:seq(1,2,0) (seq.erl, line 32)
```