### PR TITLE
dialyzer: Track type & behaviour dependencies

### DIFF
--- a/lib/dialyzer/src/Makefile
+++ b/lib/dialyzer/src/Makefile
@@ -67,6 +67,7 @@ MODULES = \
 	dialyzer_succ_typings \
 	dialyzer_timing \
 	dialyzer_typesig \
+	dialyzer_typegraph \
 	dialyzer_coordinator \
 	dialyzer_worker \
 	dialyzer_utils \
@@ -150,6 +151,7 @@ $(EBIN)/dialyzer_race_data_server.beam: dialyzer.hrl
 $(EBIN)/dialyzer_races.beam: dialyzer.hrl
 $(EBIN)/dialyzer_succ_typings.beam: dialyzer.hrl
 $(EBIN)/dialyzer_typesig.beam: dialyzer.hrl
+$(EBIN)/dialyzer_typegraph.beam: dialyzer.hrl
 $(EBIN)/dialyzer_utils.beam: dialyzer.hrl
 
 # ----------------------------------------------------

--- a/lib/dialyzer/src/dialyzer.app.src
+++ b/lib/dialyzer/src/dialyzer.app.src
@@ -27,6 +27,7 @@
 	     dialyzer_analysis_callgraph,
 	     dialyzer_behaviours,
 	     dialyzer_callgraph,
+	     dialyzer_typegraph,
 	     dialyzer_cl,
 	     dialyzer_cl_parse,
              dialyzer_clean_core,

--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -168,6 +168,7 @@
 -define(ERROR_LOCATION, column).
 
 -type doc_plt() :: 'undefined' | dialyzer_plt:plt().
+-record(plt_info, {files :: [dialyzer_plt:file_md5()], mod_deps :: dict:dict()}).
 
 -record(analysis, {analysis_pid			   :: pid() | 'undefined',
 		   type		  = succ_typings   :: anal_type(),

--- a/lib/dialyzer/src/dialyzer_behaviours.erl
+++ b/lib/dialyzer/src/dialyzer_behaviours.erl
@@ -22,7 +22,7 @@
 
 -module(dialyzer_behaviours).
 
--export([check_callbacks/5]).
+-export([check_callbacks/5, get_behaviours/1]).
 
 -export_type([behaviour/0]).
 
@@ -39,7 +39,7 @@
 -record(state, {plt        :: dialyzer_plt:plt(),
 		codeserver :: dialyzer_codeserver:codeserver(),
 		filename   :: file:filename(),
-		behlines   :: [{behaviour(), non_neg_integer()}],
+		behlines   :: [{behaviour(), file_location()}],
 		records    :: rectab()}).
 
 %%--------------------------------------------------------------------
@@ -63,6 +63,8 @@ check_callbacks(Module, Attrs, Records, Plt, Codeserver) ->
   end.
 
 %%--------------------------------------------------------------------
+
+-spec get_behaviours([{cerl:cerl(), cerl:cerl()}]) -> {[behaviour()], [{behaviour(), term()}]}.
 
 get_behaviours(Attrs) ->
   BehaviourListsAndLocation =
@@ -101,7 +103,7 @@ check_all_callbacks(Module, Behaviour, [Cb|Rest],
   CbReturnType = dialyzer_contracts:get_contract_return(Callback),
   CbArgTypes = dialyzer_contracts:get_contract_args(Callback),
   Acc0 = Acc,
-  Acc1 = 
+  Acc1 =
     case dialyzer_plt:lookup(Plt, CbMFA) of
       'none' ->
         case lists:member(optional_callback, Xtra) of

--- a/lib/dialyzer/src/dialyzer_contracts.erl
+++ b/lib/dialyzer/src/dialyzer_contracts.erl
@@ -25,7 +25,8 @@
 	 %% get_contract_signature/1,
 	 is_overloaded/1,
 	 process_contract_remote_types/1,
-	 store_tmp_contract/6]).
+	 store_tmp_contract/6,
+   constraint_form_to_remote_modules/1]).
 
 %% For dialyzer_worker.
 -export([process_contract_remote_types_module/2]).
@@ -1019,3 +1020,13 @@ blame_remote_list([CArg|CArgs], [NRArg|NRArgs], [SArg|SArgs], Opaques) ->
 is_subtype(T1, T2, Opaques) ->
   Inf = erl_types:t_inf(T1, T2, Opaques),
   erl_types:t_is_equal(T1, Inf).
+
+-spec constraint_form_to_remote_modules(Constraint :: term()) -> [module()].
+
+constraint_form_to_remote_modules([]) ->
+  [];
+
+constraint_form_to_remote_modules([{type, _, constraint, [{atom, _, _}, Types]}|Rest]) ->
+  ModulesFromTypes = erl_types:type_form_to_remote_modules(Types),
+  ModulesFromSubsequentConstraints = constraint_form_to_remote_modules(Rest),
+  lists:usort(lists:append(ModulesFromTypes, ModulesFromSubsequentConstraints)).

--- a/lib/dialyzer/src/dialyzer_typegraph.erl
+++ b/lib/dialyzer/src/dialyzer_typegraph.erl
@@ -1,0 +1,109 @@
+%% -*- erlang-indent-level: 2 -*-
+-module(dialyzer_typegraph).
+
+-export([module_type_deps/3]).
+
+-export_type([type_mod_deps/0]).
+
+-include("dialyzer.hrl").
+
+%% Maps a module to those modules that depend on it
+-type type_mod_deps() :: #{module() => [module()]}.
+
+%% We track type dependecies so that we know which modules we ultimately
+%% depend upon for type definitions which, in turn, affect the checking
+%% of a module.
+
+%% Any non-local types that are used in a spec (aka contract) / callback, any
+%% locally-defined types that may depend on a non-local type, and any
+%% implementations of a behaviour, introduce type-level dependencies on other
+%% modules such that if the definition of that other module were to change,
+%% this module would need to be checked again to account for those changes.
+
+-spec module_type_deps(UseContracts :: boolean(), dialyzer_codeserver:codeserver(), [module()]) -> type_mod_deps().
+
+%% The module type deps of a module are modules that depend on the module to
+%% define types, contracts, callbacks or behaviours
+module_type_deps(UseContracts, CodeServer, Modules) ->
+
+  Contracts =
+    case UseContracts of
+      true -> maps:from_list(dict:to_list(dialyzer_codeserver:get_contracts(CodeServer)));
+      false -> []
+    end,
+  Callbacks = maps:from_list(dialyzer_codeserver:get_callbacks(CodeServer)),
+  TypeDefinitions =
+    maps:from_list(
+      [{M, dialyzer_codeserver:lookup_mod_records(M, CodeServer)} || M <- Modules]
+    ),
+  Behaviours =
+    maps:from_list(
+      [{M, get_behaviours_for_module(M, CodeServer)} || M <- Modules]
+    ),
+  collect_module_type_deps(Contracts, Callbacks, TypeDefinitions, Behaviours).
+
+-spec get_behaviours_for_module(module(), dialyzer_codeserver:codeserver()) -> [module()].
+
+get_behaviours_for_module(M, CodeServer) ->
+  ModCode = dialyzer_codeserver:lookup_mod_code(M, CodeServer),
+  Attrs = cerl:module_attrs(ModCode),
+  {Behaviours, _BehaviourLocations} = dialyzer_behaviours:get_behaviours(Attrs),
+  Behaviours.
+
+-spec collect_module_type_deps(Specs, Callbacks, TypeDefinitions, Behaviours) -> type_mod_deps() when
+    Specs :: #{mfa() => dialyzer_contracts:file_contract()},
+    Callbacks :: #{mfa() => dialyzer_contracts:file_contract()},
+    TypeDefinitions :: #{module() => erl_types:type_table()},
+    Behaviours :: #{module() => [module()]}.
+
+collect_module_type_deps(Specs, Callbacks, TypeDefinitions, Behaviours) ->
+
+  Contracts =
+    [{M, Spec} || {{M, _F, _A}, {_FileLine, Spec, _Extra}} <- maps:to_list(Specs)] ++
+    [{M, Callback} || {{M, _F, _A}, {_FileLine, Callback, _Extra}} <- maps:to_list(Callbacks)],
+
+  ModulesMentionedInTypeDefinitions =
+    [{FromTypeDefM, erl_types:module_type_deps_of_type_defs(TypeTable)}
+      || {FromTypeDefM, TypeTable} <- maps:to_list(TypeDefinitions)],
+
+  ModulesMentionedInContracts =
+    [{FromContractM, module_type_deps_of_contract(C)}
+      || {FromContractM, C} <- Contracts],
+
+  ModulesMentionedAsBehaviours =
+    maps:to_list(Behaviours),
+
+  AllDepsRaw =
+    ModulesMentionedInContracts ++
+    ModulesMentionedInTypeDefinitions ++
+    ModulesMentionedAsBehaviours,
+
+  %% Find the union of module dependencies from all sources, removing
+  %% self-references, and flipping the direction of the mapping to
+  %% match the expectations of Dialyzer elsewhere,
+  %% i.e., from:
+  %%   module -> those modules it depends on
+  %% to
+  %%   module -> those modules that depend on it
+  S0 = sofs:relation(AllDepsRaw, [{atom,[atom]}]),
+  S1 = sofs:relation_to_family(S0),
+  S2 = sofs:family_union(S1),
+  S3 = sofs:family_to_relation(S2),
+  S4 = sofs:converse(S3),
+  S5 = sofs:strict_relation(S4),
+  S6 = sofs:relation_to_family(S5),
+  S7 = sofs:to_external(S6),
+  ModuleToThoseModulesThatDependOnIt = maps:from_list(S7),
+
+  ModuleToThoseModulesThatDependOnIt.
+
+-spec module_type_deps_of_contract(#contract{}) -> [module()].
+
+module_type_deps_of_contract(#contract{forms = Forms}) ->
+  TypeForms = [TypeForm || {TypeForm, _Constraints} <- Forms],
+  ConstraintForms =
+    lists:append([Constraints || {_TypeForm, Constraints} <- Forms]),
+  lists:usort(
+    lists:append(
+      erl_types:type_form_to_remote_modules(TypeForms),
+      dialyzer_contracts:constraint_form_to_remote_modules(ConstraintForms))).

--- a/lib/dialyzer/test/Makefile
+++ b/lib/dialyzer/test/Makefile
@@ -12,6 +12,7 @@ AUXILIARY_FILES=\
 	dialyzer_common.erl\
 	file_utils.erl\
 	dialyzer_SUITE.erl\
+	dialyzer_cl_SUITE.erl\
 	abstract_SUITE.erl\
 	plt_SUITE.erl\
 	typer_SUITE.erl\

--- a/lib/dialyzer/test/dialyzer_cl_SUITE.erl
+++ b/lib/dialyzer/test/dialyzer_cl_SUITE.erl
@@ -1,0 +1,129 @@
+-module(dialyzer_cl_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("dialyzer/src/dialyzer.hrl").
+
+%% Test server specific exports
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+
+%% Test cases must be exported.
+-export([
+    unknown_function_warning_includes_callsite/1,
+    call_to_missing_warning_includes_callsite/1
+]).
+
+suite() -> [{timetrap, {minutes, 1}}].
+
+all() ->
+    [
+        unknown_function_warning_includes_callsite,
+        call_to_missing_warning_includes_callsite
+    ].
+
+init_per_suite(Config) ->
+    %% Prime PLT with common stuff so we don't get errors about get_module_info
+    %% being unknown, etc.
+    PrivDir = proplists:get_value(priv_dir,Config),
+    PltBase = plt_base_file(PrivDir),
+    _ = dialyzer:run([{analysis_type, plt_build},
+                      {apps, [erts]},
+                      {output_plt, PltBase}]),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+plt_base_file(PrivDir) ->
+    filename:join(PrivDir, "dialyzer_cl_base.plt").
+
+%%%
+%%% Test cases starts here.
+%%%
+
+%% Test running Dialyzer programatically can yield call to missing
+%% errors with information on both the callsite and the unknown call
+%% itself.
+%% Missing function logic is tested elsewhere, but here we're specifically
+%% interested in the details of the error that are accessible from the
+%% dialyzer_cl API
+call_to_missing_warning_includes_callsite(Config) when is_list(Config) ->
+
+    PrivDir = proplists:get_value(priv_dir,Config),
+    PltBase = plt_base_file(PrivDir),
+    Plt = filename:join(PrivDir, "previously_defined.plt"),
+
+    {ok, BeamFileForPlt} = compile(Config, previously_defined, []),
+    [] = dialyzer:run([{analysis_type, plt_build},
+                      {files, [BeamFileForPlt]},
+                      {output_plt, Plt}]),
+
+    {ok, Beam} = compile(Config, call_to_missing_example, []),
+    Opts =
+        #options{
+            analysis_type = succ_typings,
+            init_plts = [Plt, PltBase],
+            output_file = none,
+            get_warnings = true,
+            legal_warnings = ordsets:from_list([warn_unknown, warn_callgraph]),
+            erlang_mode = true,
+            files = [Beam]
+        },
+    Res = dialyzer_cl:start(Opts),
+
+    ?assertMatch(
+        {2, [
+            {warn_callgraph, {_Filename, {5, 5}}, {
+                call_to_missing, [
+                    previously_defined, function, 0
+                ]
+            }}
+        ]},
+        Res),
+
+    ok.
+
+%% Test running Dialyzer programatically can yield unknown function
+%% errors with information on both the callsite and the unknown call
+%% itself.
+%% Missing function logic is tested elsewhere, but here we're specifically
+%% interested in the details of the error that are accessible from the
+%% dialyzer_cl API
+unknown_function_warning_includes_callsite(Config) when is_list(Config) ->
+
+    PrivDir = proplists:get_value(priv_dir,Config),
+    PltBase = plt_base_file(PrivDir),
+
+    {ok, Beam} = compile(Config, unknown_function_example, []),
+    Opts =
+        #options{
+            analysis_type = succ_typings,
+            init_plts = [PltBase],
+            output_file = none,
+            get_warnings = true,
+            legal_warnings = ordsets:from_list([warn_unknown, warn_callgraph]),
+            erlang_mode = true,
+            files = [Beam]
+        },
+    Res = dialyzer_cl:start(Opts),
+
+    ?assertMatch(
+        {2, [
+            {warn_unknown, {_Filename, {5,5}},
+                {unknown_function, {
+                    does_not_exist, function, 0
+                }}
+            }
+        ]},
+        Res),
+
+    ok.
+
+compile(Config, Module, CompileOpts) ->
+    Source = lists:concat([Module, ".erl"]),
+    PrivDir = proplists:get_value(priv_dir,Config),
+    DataDir = proplists:get_value(data_dir,Config),
+    SrcFilename = filename:join([DataDir, Source]),
+    Opts = [{outdir, PrivDir}, debug_info | CompileOpts],
+    {ok, Module} = compile:file(SrcFilename, Opts),
+    {ok, filename:join([PrivDir, lists:concat([Module, ".beam"])])}.

--- a/lib/dialyzer/test/dialyzer_cl_SUITE_data/call_to_missing_example.erl
+++ b/lib/dialyzer/test/dialyzer_cl_SUITE_data/call_to_missing_example.erl
@@ -1,0 +1,5 @@
+-module(call_to_missing_example).
+-export([call_to_missing_test/0]).
+
+call_to_missing_test() ->
+    previously_defined:function().

--- a/lib/dialyzer/test/dialyzer_cl_SUITE_data/previously_defined.erl
+++ b/lib/dialyzer/test/dialyzer_cl_SUITE_data/previously_defined.erl
@@ -1,0 +1,5 @@
+-module(previously_defined).
+
+-export([do_thing/0]).
+
+do_thing() -> ok.

--- a/lib/dialyzer/test/dialyzer_cl_SUITE_data/unknown_function_example.erl
+++ b/lib/dialyzer/test/dialyzer_cl_SUITE_data/unknown_function_example.erl
@@ -1,0 +1,5 @@
+-module(unknown_function_example).
+-export([unknown_function_test/0]).
+
+unknown_function_test() ->
+    does_not_exist:function().

--- a/lib/dialyzer/test/dialyzer_common.erl
+++ b/lib/dialyzer/test/dialyzer_common.erl
@@ -13,6 +13,7 @@
 
 -define(suite_suffix, "_SUITE").
 -define(data_folder, "_data").
+-define(excludes, ["dialyzer_cl", "plt"]). % _SUITE_data dirs that we shouldn't automatically make suites for
 -define(suite_data, ?suite_suffix ++ ?data_folder).
 -define(erlang_extension, ".erl").
 -define(output_file_mode, write).
@@ -45,7 +46,7 @@ check_plt(OutDir) ->
 	{error, _ } ->
 	    io:format("No plt found in test run directory!"),
 	    PltLockFile = filename:join(OutDir, ?plt_lockfile),
-	    case file:read_file_info(PltLockFile) of 
+	    case file:read_file_info(PltLockFile) of
 		{ok, _} ->
 		    explain_fail_with_lock(),
 		    fail;
@@ -178,7 +179,7 @@ fix_options([{pa, Path} | Rest], Dir, Acc) ->
 	true       -> fix_options(Rest, Dir, Acc);
 	{error, _} -> erlang:error("Bad directory for pa: " ++ Path)
     end;
-fix_options([{DirOption, RelativeDirs} | Rest], Dir, Acc) 
+fix_options([{DirOption, RelativeDirs} | Rest], Dir, Acc)
   when DirOption =:= include_dirs ;
        DirOption =:= files_rec ;
        DirOption =:= files ->
@@ -215,15 +216,21 @@ get_suites(Dir) ->
 	{error, _} -> [];
 	{ok, Filenames} ->
 	    FullFilenames = [filename:join(Dir, F) || F <-Filenames ],
-	    Dirs = [suffix(filename:basename(F), ?suite_data) ||
+	    Dirs = [is_suite_data(filename:basename(F), ?suite_data) ||
 		       F <- FullFilenames,
 		       file_utils:file_type(F) =:= {ok, 'directory'}],
 	    [S || {yes, S} <- Dirs]
     end.
 
-suffix(String, Suffix) ->
+is_suite_data(String, Suffix) ->
     case string:split(String, Suffix, trailing) of
-	[Prefix,[]] -> {yes, Prefix};
+        [Prefix,[]] ->
+            case lists:member(Prefix, ?excludes) of
+                true ->
+                   no;
+                false ->
+                   {yes, Prefix}
+            end;
         _ -> no
     end.
 

--- a/lib/dialyzer/test/plt_SUITE.erl
+++ b/lib/dialyzer/test/plt_SUITE.erl
@@ -5,6 +5,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
+-include_lib("dialyzer/src/dialyzer.hrl").
 -include("dialyzer_test_constants.hrl").
 
 -export([suite/0, all/0,
@@ -12,7 +13,34 @@
          local_fun_same_as_callback/1,
          remove_plt/1, run_plt_check/1, run_succ_typings/1,
          bad_dialyzer_attr/1, merge_plts/1, bad_record_type/1,
-         letrec_rvals/1, missing_plt_file/1, build_xdg_plt/1]).
+         letrec_rvals/1,
+         missing_plt_file/1,
+         build_xdg_plt/1,
+         mod_dep_from_behaviour/1,
+         mod_dep_from_record_definition_field_value_default_used/1,
+         mod_dep_from_record_definition_field_value_default_unused/1,
+         mod_dep_from_record_definition_field_type/1,
+         mod_dep_from_overloaded_callback/1,
+         mod_dep_from_exported_overloaded_fun_spec/1,
+         mod_dep_from_unexported_overloaded_fun_spec/1,
+         mod_dep_from_callback_constraint/1,
+         mod_dep_from_unexported_fun_spec_constraint/1,
+         mod_dep_from_exported_fun_spec_constraint/1,
+         mod_dep_from_exported_type/1,
+         mod_dep_from_callback_return/1,
+         mod_dep_from_callback_args/1,
+         mod_dep_from_unexported_opaque_type_args/1,
+         mod_dep_from_exported_opaque_type_args/1,
+         mod_dep_from_unexported_opaque_type/1,
+         mod_dep_from_exported_opaque_type/1,
+         mod_dep_from_unexported_type_args/1,
+         mod_dep_from_exported_type_args/1,
+         mod_dep_from_unexported_fun_spec_args/1,
+         mod_dep_from_exported_fun_spec_args/1,
+         mod_dep_from_unexported_fun_spec_return/1,
+         mod_dep_from_exported_fun_spec_return/1,
+         mod_dep_from_unexported_type/1
+         ]).
 
 suite() ->
   [{timetrap, ?plt_timeout}].
@@ -20,10 +48,36 @@ suite() ->
 all() -> [build_plt, build_xdg_plt, beam_tests, update_plt, run_plt_check,
           remove_plt, run_succ_typings, local_fun_same_as_callback,
           bad_dialyzer_attr, merge_plts, bad_record_type,
-          letrec_rvals, missing_plt_file].
+          letrec_rvals,
+          missing_plt_file,
+          mod_dep_from_behaviour,
+          mod_dep_from_record_definition_field_value_default_used,
+          mod_dep_from_record_definition_field_value_default_unused,
+          mod_dep_from_record_definition_field_type,
+          mod_dep_from_overloaded_callback,
+          mod_dep_from_exported_overloaded_fun_spec,
+          mod_dep_from_unexported_overloaded_fun_spec,
+          mod_dep_from_callback_constraint,
+          mod_dep_from_unexported_fun_spec_constraint,
+          mod_dep_from_exported_fun_spec_constraint,
+          mod_dep_from_exported_type,
+          mod_dep_from_callback_return,
+          mod_dep_from_callback_args,
+          mod_dep_from_unexported_opaque_type_args,
+          mod_dep_from_exported_opaque_type_args,
+          mod_dep_from_unexported_opaque_type,
+          mod_dep_from_exported_opaque_type,
+          mod_dep_from_unexported_type_args,
+          mod_dep_from_exported_type_args,
+          mod_dep_from_unexported_fun_spec_args,
+          mod_dep_from_exported_fun_spec_args,
+          mod_dep_from_unexported_fun_spec_return,
+          mod_dep_from_exported_fun_spec_return,
+          mod_dep_from_unexported_type
+          ].
 
 build_plt(Config) ->
-  OutDir = ?config(priv_dir, Config),
+  OutDir = proplists:get_value(priv_dir, Config),
   case dialyzer_common:check_plt(OutDir) of
     ok   -> ok;
     fail -> ct:fail(plt_build_fail)
@@ -60,29 +114,29 @@ build_xdg_plt(Config) ->
     peer:stop(Peer).
 
 beam_tests(Config) when is_list(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Plt = filename:join(PrivDir, "beam_tests.plt"),
-    Prog = <<"
-              -module(no_auto_import).
+    Src = <<"
+        -module(no_auto_import).
 
-              %% Copied from erl_lint_SUITE.erl, clash6
+        %% Copied from erl_lint_SUITE.erl, clash6
 
-              -export([size/1]).
+        -export([size/1]).
 
-              size([]) ->
-                  0;
-              size({N,_}) ->
-                  N;
-              size([_|T]) ->
-                  1+size(T).
-             ">>,
+        size([]) ->
+            0;
+        size({N,_}) ->
+            N;
+        size([_|T]) ->
+            1+size(T).
+    ">>,
     Opts = [no_auto_import],
-    {ok, BeamFile} = compile(Config, Prog, no_auto_import, Opts),
+    {ok, BeamFile} = compile(Config, Src, no_auto_import, Opts),
     [] = run_dialyzer(plt_build, [BeamFile], [{output_plt, Plt}]),
     ok.
 
 run_plt_check(Config) when is_list(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Plt = filename:join(PrivDir, "run_plt_check.plt"),
     Mod1 = <<"
 	      -module(run_plt_check1).
@@ -106,14 +160,14 @@ run_plt_check(Config) when is_list(Config) ->
 
     {ok, BeamFile2} = compile(Config, Mod2B, run_plt_check2, []),
 
-    % callgraph warning as run_plt_check2:call/1 makes a call to unexported
-    % function run_plt_check1:call/1.
+    %% callgraph warning as run_plt_check2:call/1 makes a call to unexported
+    %% function run_plt_check1:call/1.
     [_] = run_dialyzer(plt_check, [], [{init_plt, Plt}]),
 
     ok.
 
 run_succ_typings(Config) when is_list(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Plt = filename:join(PrivDir, "run_succ_typings.plt"),
     Mod1A = <<"
 	       -module(run_succ_typings1).
@@ -145,11 +199,11 @@ run_succ_typings(Config) when is_list(Config) ->
 
     {ok, BeamFile1} = compile(Config, Mod1B, run_succ_typings1, []),
     {ok, BeamFile2} = compile(Config, Mod2, run_succ_typings2, []),
-    % contract types warning as run_succ_typings2:call/0 makes a call to
-    % run_succ_typings1:call/0, which returns a (not b) in the PLT.
+    %% contract types warning as run_succ_typings2:call/0 makes a call to
+    %% run_succ_typings1:call/0, which returns a (not b) in the PLT.
     [_] = run_dialyzer(succ_typings, [BeamFile2],
                        [{check_plt, false}, {init_plt, Plt}]),
-    % warning not returned as run_succ_typings1 is updated in the PLT.
+    %% warning not returned as run_succ_typings1 is updated in the PLT.
     [] = run_dialyzer(succ_typings, [BeamFile2],
                       [{check_plt, true}, {init_plt, Plt}]),
 
@@ -165,7 +219,7 @@ run_succ_typings(Config) when is_list(Config) ->
 %%% contract types warning, might be emitted when the removed function
 %%% nolonger exists.
 update_plt(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Prog1 = <<"-module(plt_gc).
                -export([one/0]).
                one() ->
@@ -211,7 +265,7 @@ update_plt(Config) ->
 %%% up the callback table. This bug was reported by Brujo Benavides.
 
 local_fun_same_as_callback(Config) when is_list(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Prog1 =
       <<"-module(bad_behaviour).
          -callback bad() -> bad.
@@ -263,7 +317,7 @@ local_fun_same_as_callback(Config) when is_list(Config) ->
 %%% from a PLT when the beam file no longer exists. Dialyzer should not to
 %%% check files exist on disk when removing from the PLT.
 remove_plt(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Prog1 = <<"-module(m1).
                -export([t/0]).
                t() ->
@@ -301,7 +355,7 @@ remove_plt(Config) ->
 %% needs to be updated when/if the Dialyzer can analyze Core Erlang
 %% without compiling abstract code.
 bad_dialyzer_attr(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Source = lists:concat([dial, ".erl"]),
     Filename = filename:join(PrivDir, Source),
     ok = dialyzer_common:check_plt(PrivDir),
@@ -378,7 +432,7 @@ types() ->
 	     ">>,
     {Mod1, Mod2}.
 
-callbacks() -> % A very shallow test.
+callbacks() -> %% A very shallow test.
     Mod1 = <<"-module(merge_plts_1).
               -callback t() -> merge_plts_2:t().
 	      ">>,
@@ -389,7 +443,7 @@ callbacks() -> % A very shallow test.
     {Mod1, Mod2}.
 
 create_plts(Mod1, Mod2, Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Plt1 = filename:join(PrivDir, "merge_plts_1.plt"),
     Plt2 = filename:join(PrivDir, "merge_plts_2.plt"),
     ErlangBeam = erlang_beam(),
@@ -404,7 +458,7 @@ create_plts(Mod1, Mod2, Config) ->
 %% End of merge_plts().
 
 bad_record_type(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Source = lists:concat([bad_record_type, ".erl"]),
     Filename = filename:join(PrivDir, Source),
     PltFilename = dialyzer_common:plt_file(PrivDir),
@@ -430,7 +484,7 @@ bad_record_type(Config) ->
     ok.
 
 letrec_rvals(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     Plt = filename:join(PrivDir, "letrec_rvals.plt"),
     Prog = <<"
 -module(letrec_rvals).
@@ -465,7 +519,7 @@ check_done(_) ->
 
 %% GH-4501
 missing_plt_file(Config) ->
-    PrivDir = ?config(priv_dir, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
     PltFile = filename:join(PrivDir, "missing_plt_file.plt"),
     Prog2 = <<"-module(missing_plt_file2).
               t() -> foo.">>,
@@ -521,6 +575,316 @@ check(PltFile, _BeamFile2) ->
     dialyzer:run([{plts,[PltFile]},
                   {analysis_type, plt_check}]).
 
+mod_dep_from_record_definition_field_value_default_unused(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+
+      -record(my_record,
+        { num_field = type_deps:get_num() :: number(),
+          str_field,
+          bool_field
+        }).
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, []}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_record_definition_field_value_default_used(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -export([f/0]).
+
+      -record(my_record,
+        { num_field = type_deps:get_num() :: number(),
+          str_field,
+          bool_field
+        }).
+
+      f() -> #my_record{str_field = \"foo\", bool_field = true}. % type_deps:get_num() used implicitly here
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_behaviour(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -behaviour(type_deps).
+      -export([quux/1]).
+
+      quux(N) -> N + 1. % Depends on behaviour module to check the callback implementation
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_record_definition_field_type(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+
+      -record(my_record,
+        { num_field = 1 :: type_deps:number_like(),
+          str_field,
+          bool_field
+        }).
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_overloaded_callback(Config) ->
+    DependerSrc1 = <<"
+      -module(depender).
+
+      -callback f(string()) -> string()
+                ; (type_deps:number_like()) -> type_deps:number_like().
+      ">>,
+    DependerSrc2 = <<"
+      -module(depender).
+
+      -callback f(type_deps:number_like()) -> type_deps:number_like()
+                ; (string()) -> string().
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc1, ExpectedTypeDepsInPlt),
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc2, ExpectedTypeDepsInPlt).
+
+mod_dep_from_exported_overloaded_fun_spec(Config) ->
+    DependerSrc1 = <<"
+      -module(depender).
+      -export([f/1]).
+
+      -spec f({a, atom()}) -> atom()
+            ; ({n, type_deps:number_like()}) -> type_deps:number_like().
+      f({a, X}) when is_atom(X) -> X;
+      f({n, X}) when is_number(X) -> X.
+      ">>,
+    DependerSrc2 = <<"
+      -module(depender).
+      -export([f/1]).
+
+      -spec f({n, type_deps:number_like()}) -> type_deps:number_like()
+            ; ({a, atom()}) -> atom().
+      f({n, X}) when is_number(X) -> X;
+      f({a, X}) when is_atom(X) -> X.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc1, ExpectedTypeDepsInPlt),
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc2, ExpectedTypeDepsInPlt).
+
+mod_dep_from_unexported_overloaded_fun_spec(Config) ->
+    DependerSrc1 = <<"
+      -module(depender).
+      -compile({nowarn_unused_function, [f/1]}).
+
+      -spec f({a, atom()}) -> atom()
+            ; ({n, type_deps:number_like()}) -> type_deps:number_like().
+      f({a, X}) when is_atom(X) -> X;
+      f({n, X}) when is_number(X) -> X.
+      ">>,
+    DependerSrc2 = <<"
+      -module(depender).
+      -compile({nowarn_unused_function, [f/1]}).
+
+      -spec f({n, type_deps:number_like()}) -> type_deps:number_like()
+            ; ({a, atom()}) -> atom().
+      f({n, X}) when is_number(X) -> X;
+      f({a, X}) when is_atom(X) -> X.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc1, ExpectedTypeDepsInPlt),
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc2, ExpectedTypeDepsInPlt).
+
+mod_dep_from_callback_constraint(Config) ->
+    DependerSrc1 = <<"
+      -module(depender).
+
+      -callback f(X) -> string() when X :: type_deps:number_like().
+      ">>,
+    DependerSrc2 = <<"
+      -module(depender).
+
+      -callback f(X :: type_deps:number_like()) -> string().
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc1, ExpectedTypeDepsInPlt),
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc2, ExpectedTypeDepsInPlt).
+
+mod_dep_from_unexported_fun_spec_constraint(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -compile({nowarn_unused_function, [f/1]}).
+
+      -spec f(N) -> number() when N :: type_deps:number_like().
+      f(N) -> N.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_exported_fun_spec_constraint(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -export([f/1]).
+
+      -spec f(N) -> number() when N :: type_deps:number_like().
+      f(N) -> N.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_callback_return(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+
+      -callback f(string()) -> type_deps:number_like().
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_callback_args(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+
+      -callback f(type_deps:number_like()) -> string().
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_unexported_opaque_type(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+
+      -opaque my_type() :: {string(), type_deps:number_like()}.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_exported_opaque_type(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -export_type([my_type/0]).
+
+      -opaque my_type() :: {string(), type_deps:number_like()}.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_unexported_opaque_type_args(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+
+      -type my_type() :: type_deps:my_opaque(number()).
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_exported_opaque_type_args(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -export_type([my_type/0]).
+
+      -type my_type() :: type_deps:my_opaque(number()).
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_unexported_type_args(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+
+      -type my_type() :: {string(), type_deps:number_like()}.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_exported_type_args(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -export_type([my_type/0]).
+
+      -type my_type() :: {string(), type_deps:number_like()}.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_unexported_fun_spec_args(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -compile({nowarn_unused_function, [f/1]}).
+
+      -spec f(type_deps:number_like()) -> number().
+      f(N) -> N.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_exported_fun_spec_args(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -export([f/1]).
+
+      -spec f(N :: type_deps:number_like()) -> number().
+      f(N) -> N.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_unexported_fun_spec_return(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -compile({nowarn_unused_function, [f/0]}).
+
+      -spec f() -> type_deps:number_like().
+      f() -> 1.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_exported_fun_spec_return(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -export([f/0]).
+
+      -spec f() -> type_deps:number_like().
+      f() -> 1.
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_unexported_type(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+
+      -type my_type() :: type_deps:list_like(number()).
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+mod_dep_from_exported_type(Config) ->
+    DependerSrc = <<"
+      -module(depender).
+      -export_type([my_type/0]).
+
+      -type my_type() :: type_deps:list_like(number()).
+      ">>,
+    ExpectedTypeDepsInPlt = [{depender, []}, {type_deps, [depender]}],
+    ok = check_plt_deps(Config, ?FUNCTION_NAME, DependerSrc, ExpectedTypeDepsInPlt).
+
+check_plt_deps(Config, TestName, DependerSrc, ExpectedTypeDepsInPltUnsorted) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    PltFile = filename:join(PrivDir, atom_to_list(TestName) ++ ".plt"),
+    {ok, DepsBeamFile} = compile(Config, type_deps, []),
+    {ok, DependerBeamFile} = compile(Config, DependerSrc, depender, []),
+    [] = run_dialyzer(plt_build, [DependerBeamFile, DepsBeamFile], [{output_plt, PltFile}]),
+    {_ResPlt, #plt_info{mod_deps = DepsByModule}} = dialyzer_plt:plt_and_info_from_file(PltFile),
+
+    ActualTypeDepsInPlt =
+      lists:sort(dict:to_list(dict:erase(erlang, DepsByModule))),
+    ExpectedTypeDepsInPlt =
+      lists:usort(ExpectedTypeDepsInPltUnsorted),
+
+    ?assertEqual(
+      ExpectedTypeDepsInPlt,
+      ActualTypeDepsInPlt,
+      {missing, ExpectedTypeDepsInPlt -- ActualTypeDepsInPlt,
+       extra, ActualTypeDepsInPlt -- ExpectedTypeDepsInPlt}).
+
 erlang_beam() ->
     case code:where_is_file("erlang.beam") of
         non_existing ->
@@ -531,9 +895,20 @@ erlang_beam() ->
             EBeam
     end.
 
+%% Builds the named module using the source in the plt_SUITE_data dir
+compile(Config, Module, CompileOpts) ->
+    Source = lists:concat([Module, ".erl"]),
+    PrivDir = proplists:get_value(priv_dir,Config),
+    DataDir = proplists:get_value(data_dir,Config),
+    SrcFilename = filename:join([DataDir, Source]),
+    Opts = [{outdir, PrivDir}, debug_info | CompileOpts],
+    {ok, Module} = compile:file(SrcFilename, Opts),
+    {ok, filename:join([PrivDir, lists:concat([Module, ".beam"])])}.
+
+%% Builds the named module using the literal source given
 compile(Config, Prog, Module, CompileOpts) ->
     Source = lists:concat([Module, ".erl"]),
-    PrivDir = ?config(priv_dir,Config),
+    PrivDir = proplists:get_value(priv_dir,Config),
     Filename = filename:join([PrivDir, Source]),
     ok = file:write_file(Filename, Prog),
     Opts = [{outdir, PrivDir}, debug_info | CompileOpts],

--- a/lib/dialyzer/test/plt_SUITE_data/type_deps.erl
+++ b/lib/dialyzer/test/plt_SUITE_data/type_deps.erl
@@ -1,0 +1,18 @@
+-module(type_deps).
+
+-export([func/1, get_num/0]).
+
+-export_type([number_like/0, my_opaque/1, list_like/1]).
+
+-type number_like() :: number().
+-type list_like(X) :: [X].
+-opaque my_opaque(X) :: {X,X}.
+
+-callback quux(number()) -> number().
+
+-spec func(T) -> T.
+func(X) ->
+  X + X.
+
+get_num() ->
+  3.


### PR DESCRIPTION
Dialyzer now tracks the dependencies between modules induced by
type-level information, such as type definitions & specs, as well
as behaviour callbacks.

Previously, only function calls were considered when computing dependencies.
This was incomplete because changes to types and behaviours can also affect
the result of a Dialyzer analysis.

Aside from the immediate impact of this change, it also serves as a prelude to
adding full incrementality to Dialyzer.