### PR TITLE
Fixes analysing a wild attribute to return Info

### DIFF
--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -1335,7 +1335,8 @@ analyze_attribute(record, Node) ->
     analyze_record_attribute(Node);
 analyze_attribute(_, Node) ->
     %% A "wild" attribute (such as e.g. a `compile' directive).
-    analyze_wild_attribute(Node).
+    {_, Info} = analyze_wild_attribute(Node),
+    Info.
 
 
 %% =====================================================================


### PR DESCRIPTION
As per #4671:

`erl_syntax_lib:analyze_attribute({attribute,17,mark,mark_1}).`

returns `{mark, {mark, mark_1}}` due to the attribute being wrapped on
line 1320:

`{A, analyze_attribute(A, Node)}`

when what would be expected as per the documentation is:

`{mark, mark1}`

Returning *just* the Info from `{_, Info} = analyze_wild_attribute(Node)`
within `analyze_attribute/2`, this double wrapping does not occur, fixing
the original issue.