### PR TITLE
Fix some typos in SSL docs

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -115,7 +115,7 @@
 	<c>inet:peername/1</c>, <c>inet:sockname/1</c>, and
 	<c>inet:port/1</c>.  The callback <c>gen_tcp</c> is treated
 	specially and calls <c>inet</c> directly. For DTLS this
-	feature must be considered exprimental.
+	feature must be considered experimental.
 	</p>
       </desc>
     </datatype>
@@ -308,9 +308,9 @@
     <datatype>
       <name name="cert"/>
       <desc>
-	<p>The DER-encoded users certificate. Note that the cert option may also
-	be a list of DER-encoded certificates where the first one is the users
-	certificate and the rest of the certificates constitutes the
+	<p>The DER-encoded user certificate. Note that the cert option may also
+	be a list of DER-encoded certificates where the first one is the user
+	certificate, and the rest of the certificates constitutes the
 	certificate chain. For maximum interoperability the
 	certificates in the chain should be in the correct order, the
 	chain will be sent as is to the peer. If chain certificates
@@ -328,7 +328,7 @@
       <name name="cert_pem"/>
       <desc>
 	<p>Path to a file containing the user certificate on PEM format or possible several
-	certificates where the first one is the users certificate and the rest of the certificates
+	certificates where the first one is the user certificate and the rest of the certificates
 	constitutes the certificate chain. For more details see <seetype marker="#cert">cert()</seetype>,
 	</p>
       </desc>
@@ -337,9 +337,9 @@
     <datatype>
       <name name="key"/>
       <desc>
-	<p>The DER-encoded user's private key or a map refering to a crypto
+	<p>The DER-encoded user's private key or a map referring to a crypto
 	engine and its key reference that optionally can be password protected,
-	seealso <seemfa marker="crypto:crypto#engine_load/4"> crypto:engine_load/4
+	see also <seemfa marker="crypto:crypto#engine_load/4"> crypto:engine_load/4
 	</seemfa> and  <seeguide marker="crypto:engine_load"> Crypto's Users Guide</seeguide>. If this option 
 	is supplied, it overrides option <c>keyfile</c>.</p>
       </desc>
@@ -377,7 +377,7 @@
 	sure they are filtered for cryptolib support
 	<seemfa
 	    marker="#filter_cipher_suites/2"> ssl:filter_cipher_suites/2 </seemfa>
-	Additionaly the functions <seemfa
+	Additionally the functions <seemfa
 	marker="#append_cipher_suites/2"> ssl:append_cipher_suites/2 </seemfa>
 	, <seemfa
 	marker="#prepend_cipher_suites/2"> ssl:prepend_cipher_suites/2</seemfa>,
@@ -498,9 +498,8 @@ version.
       <name name="sign_schemes"/>
 
       <desc>
-	<p>Explicitly list acceptable signature schemes (algorithms),
-	in prefered ordered, for certificates, overrides the
-	algorithms supplied in  <seetype
+	<p>Explicitly list acceptable signature schemes (algorithms)
+	in the preferred order. Overrides the algorithms supplied in <seetype
 	marker="#signature_algs"><c>signature_algs</c></seetype> option for
 	certificates.</p>
 
@@ -889,7 +888,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
 
     <datatype>
       <name name="session_tickets"/>
-      <desc><p>Configures the session ticket functionalty in TLS 1.3 client and server. </p>
+      <desc><p>Configures the session ticket functionality in TLS 1.3 client and server. </p>
       </desc>
     </datatype>
 
@@ -945,7 +944,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
     <datatype>
       <name name="client_reuse_session"/>
       <desc>
-	<p>Reuses a specific session. The session should be refered by its session id if it is
+	<p>Reuses a specific session. The session should be referred by its session id if it is
 	earlier saved with the option <c>{reuse_sessions, save}</c> since OTP-21.3 or
 	explicitly specified by its session id and associated data since OTP-22.3.
 	See also
@@ -1599,7 +1598,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       argument is an <c>inet:ip_address()</c> the <c>ReferenceID</c> used for the check will be <c>{ip, Host}</c> otherwise
       <c>dns_id</c> will be assumed with a fallback to <c>ip</c> if that fails. </p>
       <note><p>According to good practices certificates should not use IP-addresses as "server names". It would
-      be very surprising if this happen outside a closed network. </p></note> 
+      be very surprising if this happened outside a closed network. </p></note>
 
 
       <p> If the option <c>{handshake, hello}</c> is used the
@@ -1689,7 +1688,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       
       For examples see <seeguide marker="ssl:using_ssl#customizing-cipher-suites"> Customizing cipher suites </seeguide> 
       
-      Additionaly this function also filters the cipher suites to
+      Additionally, this function also filters the cipher suites to
       exclude cipher suites not supported by the cryptolib used by the
       OTP crypto application. That is calling
       ssl:filter_cipher_suites(Suites, []) will be equivalent to only
@@ -1791,7 +1790,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       <name since="OTP 21.0" name="handshake_continue" arity="3" />
       <fsummary>Continue the TLS handshake.</fsummary>
       <desc>
-        <p>Continue the TLS handshake possiby with new, additional or changed options.</p>
+        <p>Continue the TLS handshake, possibly with new, additional or changed options.</p>
       </desc>
     </func>
     


### PR DESCRIPTION
Some typos and language errors fixed.

A note about the changing "users certificate": I'm not sure what was the meaning intended here, I went with a compound noun - "user certificate", but I feel like a possessive - "user's certificate", is equally valid.

As a little disclaimer, I'm not an English native speaker.