### PR TITLE
stdlib: accept empty list of patterns in binary matching functions

### DIFF
--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -1039,9 +1039,10 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
 	characters = binary_size(argument);
     }
 
-    if (characters == 0) {
-	goto badarg;
-    }
+	if (!(argument == THE_NON_VALUE || argument == NIL) && characters == 0) {
+	    goto badarg;
+	}
+
     ASSERT(words > 0);
 
     if (words == 1) {

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -154,11 +154,11 @@ badargs(Config) when is_list(Config) ->
 	   binary:bin_to_list([1,2,3])),
 
     nomatch =
+	?MASK_ERROR(binary:match(<<1,2,3>>,[])),
+    nomatch =
 	?MASK_ERROR(binary:match(<<1,2,3>>,<<1>>,[{scope,{0,0}}])),
     badarg =
 	?MASK_ERROR(binary:match(<<1,2,3>>,{bm,<<>>},[{scope,{0,1}}])),
-    badarg =
-	?MASK_ERROR(binary:match(<<1,2,3>>,[],[{scope,{0,1}}])),
     badarg =
 	?MASK_ERROR(binary:match(<<1,2,3>>,{ac,<<>>},[{scope,{0,1}}])),
     {bm,BMMagic} = binary:compile_pattern([<<1,2,3>>]),
@@ -178,11 +178,11 @@ badargs(Config) when is_list(Config) ->
 			{ac,ets:match_spec_compile([{'_',[],['$_']}])},
 			[{scope,{0,1}}])),
     [] =
+	?MASK_ERROR(binary:matches(<<1,2,3>>,[])),
+    [] =
 	?MASK_ERROR(binary:matches(<<1,2,3>>,<<1>>,[{scope,{0,0}}])),
     badarg =
 	?MASK_ERROR(binary:matches(<<1,2,3>>,{bm,<<>>},[{scope,{0,1}}])),
-    badarg =
-	?MASK_ERROR(binary:matches(<<1,2,3>>,[],[{scope,{0,1}}])),
     badarg =
 	?MASK_ERROR(binary:matches(<<1,2,3>>,{ac,<<>>},[{scope,{0,1}}])),
     badarg =
@@ -358,6 +358,7 @@ interesting(Config) when is_list(Config) ->
     X = do_interesting(binref).
 
 do_interesting(Module) ->
+    nomatch = Module:match(<<"123456">>, Module:compile_pattern([])),
     {0,4} = Module:match(<<"123456">>,
 			 Module:compile_pattern([<<"12">>,<<"1234">>,
 						 <<"23">>,<<"3">>,
@@ -495,6 +496,7 @@ do_interesting(Module) ->
     [] = binary:split(<<>>, <<",">>, [global,trim]),
     [] = binary:split(<<>>, <<",">>, [global,trim_all]),
 
+    <<1,2,3,4,5,6,7,8>> = Module:replace(<<1,2,3,4,5,6,7,8>>, [], <<99>>,[global]),
     badarg = ?MASK_ERROR(
 		Module:replace(<<1,2,3,4,5,6,7,8>>,
 			       [<<4,5>>,<<7>>,<<8>>],<<99>>,


### PR DESCRIPTION
This changes the binary_match_compile BIF so that it throws badarg only on empty binaries, and not on empty lists.
This change cascades into all functions that rely on binary matching, such as `binary:replace`. This is coming from discussion on https://github.com/elixir-lang/elixir/issues/11485

The general idea of this PR is that an empty list of patterns will never match, but shouldn't throw an error, only follow the usual flow.