### PR TITLE
Fix OpenSSH encoding of Ed25519/Ed448

### DIFF
--- a/lib/ssh/src/ssh_file.erl
+++ b/lib/ssh/src/ssh_file.erl
@@ -1018,13 +1018,8 @@ openssh_key_v1_decode(<<?DEC_BIN(Encrypted,_L)>>,
         openssh_key_v1_decode_priv_keys(Plain, N, N, [], [])
     of
         {PrivKeys, _Comments} ->
-            lists:map(fun({ {ed_pub,A,Pub}, {ed_pri,A,Pub,Pri0} }) ->
-                              Pri = binary:part(Pri0, {0,size(Pri0)-size(Pub)}),
-                              {{ed_pub,A,Pub}, {ed_pri,A,Pub,Pri}};
-                         (Pair) ->
-                              Pair
-                      end, lists:zip(PubKeys, PrivKeys))
-            %%                      end, lists:zip3(PubKeys, PrivKeys,_ Comments))
+            lists:zip(PubKeys, PrivKeys)
+            %% lists:zip3(PubKeys, PrivKeys,_ Comments))
     catch
         error:{decryption, DecryptError} ->
             error({decryption, DecryptError})

--- a/lib/ssh/src/ssh_message.erl
+++ b/lib/ssh/src/ssh_message.erl
@@ -686,7 +686,7 @@ ssh2_privkey_encode({ed_pri, Alg, Pub, Priv}) ->
     Name = atom_to_binary(Alg),
     <<?STRING(<<"ssh-",Name/binary>>),
       ?STRING(Pub),
-      ?STRING(Priv)>>.
+      ?STRING(<<Priv/binary,Pub/binary>>)>>.
 
 %%%--------
 ssh2_privkey_decode2(<<?UINT32(7), "ssh-rsa",
@@ -736,12 +736,16 @@ ssh2_privkey_decode2(<<?UINT32(TL), "ecdsa-sha2-",KeyRest/binary>>) ->
                     }, Rest};
 ssh2_privkey_decode2(<<?UINT32(11), "ssh-ed25519",
                        ?DEC_BIN(Pub,_Lpub),
-                       ?DEC_BIN(Priv,_Lpriv),
+                       64:32/unsigned-big-integer,
+                       Priv:32/binary,
+                       _Pub:32/binary,
                        Rest/binary>>) ->
     {{ed_pri, ed25519, Pub, Priv}, Rest};
 ssh2_privkey_decode2(<<?UINT32(9), "ssh-ed448",
                        ?DEC_BIN(Pub,_Lpub),
-                       ?DEC_BIN(Priv,_Lpriv),
+                       114:32/unsigned-big-integer,
+                       Priv:57/binary,
+                       _Pub:57/binary,
                        Rest/binary>>) ->
     {{ed_pri, ed448, Pub, Priv}, Rest}.
 
@@ -938,4 +942,3 @@ ssh_dbg_format(raw_messages, {return_from,{?MODULE,encode,1},BytesPT}) ->
 ?wr_record(ssh_msg_channel_failure);
 
 wr_record(R) -> io_lib:format('~p~n',[R]).
-


### PR DESCRIPTION
Encoding of OpenSSH Key V1 is technically listed as an experimental feature so this isn't the most crucial. But in playing with it I discovered the encoding is incorrect when writing the "encrypted" section of Ed25519/Ed448 keys

Currently, we only write the 32 bytes of the Private key. However, the encrypted section is 64 bytes of a "secret" key which includes the private key and public key combined. This is confirmed through a few sources:
* [sshkey.c](https://github.com/openssh/openssh-portable/blob/master/sshkey.c#L3317-L3320) of OpenSSH writes both [public and private when serializing the private section](https://github.com/openssh/openssh-portable/blob/master/sshkey.c#L3207)
* In the current implementation the [32 bytes of the public key was also striped from the return of decoding the private key](https://github.com/erlang/otp/compare/maint...jjcarstens:fix-openssh-v1-encode-ed?expand=1#diff-1f38e03c06943f104389be8ea3775245e33afe872c3f19c114e9e723fa7b1732L1022)
* [This article](https://dnaeon.github.io/openssh-private-key-binary-format/) also had a really insightful breakdown of the OpenSSH private key binary format

This experimental feature seems untested (or I haven't found the right place) so below is some console output. Note the current behavior is missing the private key binary when decoding a key generated from `ssh_file:encode/2`. Happy to add tests if there is an expected place

<details>
<summary>Current behavior (from console)</summary>

```erlang
1> {Pub, Priv} = crypto:generate_key(eddsa, ed25519).
{<<215,125,77,247,17,30,232,110,152,159,130,127,155,239,
   39,228,237,136,11,249,153,125,21,51,185,76,228,190,...>>,
 <<194,101,237,100,119,133,35,110,181,76,5,224,211,5,192,
   70,54,228,216,2,165,220,229,249,243,202,130,...>>}

2> Keypairs = [{{ed_pri, ed25519, Pub, Priv}, <<"nerves@nerves.local">>}].
[{{ed_pri,ed25519,
          <<215,125,77,247,17,30,232,110,152,159,130,127,155,239,39,
            228,237,136,11,249,153,125,21,51,...>>,
          <<194,101,237,100,119,133,35,110,181,76,5,224,211,5,192,
            70,54,228,216,2,165,220,229,...>>},
  <<"nerves@nerves.local">>}]

3> Encoded = ssh_file:encode([{Keypairs, []}], openssh_key_v1).
<<"-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gt\nZWQyNTUxOQA"...>>

4> ssh_file:decode(Encoded, openssh_key_v1).
[{{ed_pri,ed25519,
          <<215,125,77,247,17,30,232,110,152,159,130,127,155,239,39,
            228,237,136,11,249,153,125,21,51,...>>,
          <<>>},
% NOTE: The missing private Key ^
  []},
 {{ed_pub,ed25519,
          <<215,125,77,247,17,30,232,110,152,159,130,127,155,239,
            39,228,237,136,11,249,153,125,21,...>>},
  []}]
```

</details>


<details>
<summary>With proposed fix</summary>

```erlang
1> {Pub, Priv} = crypto:generate_key(eddsa, ed25519).
{<<242,112,197,146,120,78,235,14,133,240,247,77,162,57,45,
   50,179,218,243,60,91,106,214,240,55,84,255,0,...>>,
 <<11,157,146,182,123,184,78,30,164,173,8,76,179,133,19,
   122,197,107,143,105,129,118,194,115,127,23,141,...>>}

2> Keypairs = [{{ed_pri, ed25519, Pub, Priv}, <<"nerves@nerves.local">>}].
[{{ed_pri,ed25519,
          <<242,112,197,146,120,78,235,14,133,240,247,77,162,57,45,
            50,179,218,243,60,91,106,214,240,...>>,
          <<11,157,146,182,123,184,78,30,164,173,8,76,179,133,19,
            122,197,107,143,105,129,118,194,...>>},
  <<"nerves@nerves.local">>}]

3> Encoded = ssh_file:encode([{Keypairs, []}], openssh_key_v1).
<<"-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gt\nZWQyNTUxOQA"...>>

4> ssh_file:decode(Encoded, openssh_key_v1).
[{{ed_pri,ed25519,
          <<242,112,197,146,120,78,235,14,133,240,247,77,162,57,45,
            50,179,218,243,60,91,106,214,240,...>>,
          <<11,157,146,182,123,184,78,30,164,173,8,76,179,133,19,
            122,197,107,143,105,129,118,194,...>>},
  []},
 {{ed_pub,ed25519,
          <<242,112,197,146,120,78,235,14,133,240,247,77,162,57,45,
            50,179,218,243,60,91,106,214,...>>},
  []}]
```

</details>

<details>
<summary>Proposed fix with fixture</summary>

```erlang
1> {ok,Encoded} = file:read_file(<<"lib/ssh/test/ssh_algorithms_SUITE_data/id_ed25519">>).
{ok,<<"-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQ"...>>}

2> ssh_file:decode(Encoded, openssh_key_v1).
[{{ed_pri,ed25519,
          <<230,244,255,63,128,45,8,56,169,176,28,180,175,146,97,45,
            75,101,241,209,20,106,80,58,...>>,
          <<115,11,246,118,88,98,97,103,121,119,180,128,103,81,206,
            131,9,186,126,149,118,54,201,...>>},
  []},
 {{ed_pub,ed25519,
          <<230,244,255,63,128,45,8,56,169,176,28,180,175,146,97,
            45,75,101,241,209,20,106,80,...>>},
  []}]
```

</details>