### PR TITLE
[ct_slave] deprecate the module completely

### DIFF
--- a/lib/common_test/src/ct_slave.erl
+++ b/lib/common_test/src/ct_slave.erl
@@ -29,6 +29,8 @@
 
 -export([slave_started/2, slave_ready/2, monitor_master/1]).
 
+-deprecated([{'_','_',"use ?CT_PEER(), or the 'peer' module instead"}]).
+
 -record(options, {username, password, boot_timeout, init_timeout,
 		  startup_timeout, startup_functions, monitor_master,
 		  kill_if_fail, erl_flags, env, ssh_port, ssh_opts,

--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -227,6 +227,8 @@ obsolete(random, _, _) ->
     {deprecated, "use the 'rand' module instead"};
 obsolete(slave, _, _) ->
     {deprecated, "use the 'peer' module instead", "OTP 27"};
+obsolete(ct_slave, _, _) ->
+    {deprecated, "use ?CT_PEER(), or the 'peer' module instead", "OTP 27"};
 obsolete(os_mon_mib, _, _) ->
     {removed, "this module was removed in OTP 22.0"};
 obsolete(pg2, _, _) ->

--- a/system/doc/general_info/DEPRECATIONS
+++ b/system/doc/general_info/DEPRECATIONS
@@ -21,6 +21,7 @@
 # Added in OTP 25.
 #
 slave:_/_ since=25 remove=27
+ct_slave:_/_ since=25 remove=27
 
 #
 # Added in OTP 24.


### PR DESCRIPTION
There is not a single usage for ct_slave within OTP codebase,
proving that replacement is complete.