### PR TITLE
Update Install Location and Registry Keys

### DIFF
--- a/erts/etc/win32/nsis/erlang20.nsi
+++ b/erts/etc/win32/nsis/erlang20.nsi
@@ -56,9 +56,9 @@ Var STARTMENU_FOLDER
 
 ;Folder selection page
 !if ${WINTYPE} == "win64"
-  	InstallDir "$PROGRAMFILES64\erl-${OTP_RELEASE_VERSION}"
+  	InstallDir "$PROGRAMFILES64\Erlang OTP"
 !else
-  	InstallDir "$PROGRAMFILES\erl-${OTP_RELEASE_VERSION}"
+  	InstallDir "$PROGRAMFILES\Erlang OTP"
 !endif  
 ;Remember install folder
   	InstallDirRegKey HKLM "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}" ""
@@ -214,22 +214,28 @@ done_startmenu:
   	WriteUninstaller "$INSTDIR\Uninstall.exe"
 
   	WriteRegStr HKLM \
-		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 		"DisplayName" "Erlang OTP ${OTP_RELEASE_VERSION} (${ERTS_VERSION})"
+	WriteRegStr HKLM \
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
+		"DisplayVersion" "${OTP_RELEASE_VERSION}"
+	WriteRegStr HKLM \
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
+		"Publisher" "Ericsson AB"
   	WriteRegStr HKLM \
-		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 		"UninstallString" "$INSTDIR\Uninstall.exe"
   	WriteRegDWORD HKLM \
-		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 		"NoModify" 1
   	WriteRegDWORD HKLM \
-		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 		"NoRepair" 1
 
 ; Check that the registry could be written, we only check one key,
 ; but it should be sufficient...
   	ReadRegStr $MYTEMP HKLM \
-	"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+	"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 	"NoRepair"
 
   	StrCmp $MYTEMP "" 0 done
@@ -238,16 +244,22 @@ done_startmenu:
 ; do the things below...
 
   	WriteRegStr HKCU \
-		"Software\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+		"Software\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 		"DisplayName" "Erlang OTP ${OTP_RELEASE_VERSION} (${ERTS_VERSION})"
+	WriteRegStr HKCU \
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
+		"DisplayVersion" "${OTP_RELEASE_VERSION}"
+	WriteRegStr HKCU \
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
+		"Publisher" "Ericsson AB"
   	WriteRegStr HKCU \
-		"Software\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+		"Software\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 		"UninstallString" "$INSTDIR\Uninstall.exe"
   	WriteRegDWORD HKCU \
-		"Software\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+		"Software\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 		"NoModify" 1
   	WriteRegDWORD HKCU \
-		"Software\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})" \
+		"Software\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP" \
 		"NoRepair" 1
 
 done:
@@ -464,9 +476,9 @@ noshortcuts:
   	DeleteRegKey /ifempty HKLM "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
   	DeleteRegKey /ifempty HKCU "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
   	DeleteRegKey HKLM \
-		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})"
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP"
   	DeleteRegKey HKCU \
-		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP ${OTP_VERSION} (${ERTS_VERSION})"
+		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP"
 
 
 ; Now remove shell/file associations we'we made...

--- a/lib/tools/emacs/README
+++ b/lib/tools/emacs/README
@@ -34,13 +34,13 @@ variable. If HOME is not set, Emacs will look for the .emacs file in
 C:\.
     
 Below is a complete example of what should be added to a user's .emacs
-provided that OTP is installed in the directory C:\Program
-Files\erl-<Ver>:
+provided that OTP is installed in the directory "C:\Program
+Files\Erlang OTP":
       
       (setq load-path (cons  "C:/Program Files/erl<Ver>/lib/tools-<ToolsVer>/emacs"
       load-path))
-      (setq erlang-root-dir "C:/Program Files/erl<Ver>")
-      (setq exec-path (cons "C:/Program Files/erl<Ver>/bin" exec-path))
+      (setq erlang-root-dir "C:/Program Files/Erlang OTP")
+      (setq exec-path (cons "C:/Program Files/Erlang OTP/bin" exec-path))
       (require 'erlang-start)
 
 


### PR DESCRIPTION
This PR should solve two issues - 

1) When installing a newer version, the old version remains, but uninstalling the older version removes the newer version from the start menu. This is solved by always updating in-place and using a single folder

2) This should write the version and the publisher in the uninstall entry 