### PR TITLE
Add support for paged search results to LDAP

### DIFF
--- a/lib/eldap/asn1/ELDAPv3.asn1
+++ b/lib/eldap/asn1/ELDAPv3.asn1
@@ -286,5 +286,16 @@ PasswdModifyRequestValue ::= SEQUENCE {
 PasswdModifyResponseValue ::= SEQUENCE {
      genPasswd        [0]     OCTET STRING OPTIONAL }
 
+-- LDAP Control Extension for Simple Paged Results Manipulation
+-- https://www.rfc-editor.org/rfc/rfc2696.txt
+-- controlType 1.2.840.113556.1.4.319
+
+RealSearchControlValue ::= SEQUENCE {
+    size            INTEGER (0..maxInt),
+                            -- requested page size from client
+                            -- result set size estimate from server
+    cookie          OCTET STRING
+}
+
 END
 

--- a/lib/eldap/doc/src/eldap.xml
+++ b/lib/eldap/doc/src/eldap.xml
@@ -482,6 +482,72 @@
       </type>
       <desc> <p>Negate a filter.</p> </desc>
     </func>
+    <func>
+      <name since="OTP 24.3">paged_result_control(PageSize) -&gt;
+      {control, "1.2.840.113556.1.4.319", true, binary()}</name>
+      <fsummary>Create a paged result control tuple</fsummary>
+      <type>
+        <v>PageSize = positive_integer()</v>
+      </type>
+      <desc>
+        <p>Paged results is an extension to the LDAP protocol
+        specified by RFC2696</p>
+        <p>This function creates a control with the specified page
+        size for use in
+        <c>search/3</c>, for example:</p>
+   	<code>
+Control = eldap:paged_result_control(50),
+{ok, SearchResults} = search(Handle, [{base, "dc=example, dc=com"}], [Control]),
+	</code>     
+      </desc>
+    </func>
+    <func>
+      <name since="OTP 24.3">paged_result_control(PageSize, Cookie)
+      -&gt; {control, "1.2.840.113556.1.4.319", true,
+      binary()}</name>
+      <fsummary>Create a paged result control tuple with the given
+      Cookie</fsummary>
+      <type>
+        <v>PageSize = positive_integer()</v>
+        <v>Cookie = binary()</v>
+      </type>
+      <desc>
+        <p>Paged results is an extension to the LDAP protocol
+        specified by RFC2696</p>
+        <p>This function creates a control with the specified page
+        size and cookie for use in
+        <c>search/3</c> to retrieve the next results page.</p>
+        <p>For example:</p>
+        <code>
+PageSize = 50,
+Control1 = eldap:paged_result_control(PageSize),
+{ok, SearchResults1} = search(Handle, [{base, "dc=example, dc=com"}], [Control1]),
+%% retrieve the returned cookie from the search results
+{ok, Cookie1} = eldap:paged_result_cookie(SearchResults1),
+Control2 = eldap:paged_result_control(PageSize, Cookie1),
+{ok, SearchResults2} = eldap:search(Handle, [{base, "dc=example,dc=com"}], [Control2]),
+%% etc
+	</code>
+      </desc>
+    </func>
+    <func>
+      <name since="OTP 24.3">paged_result_cookie(SearchResult)
+      -&gt; binary()</name>
+      <fsummary>Extract a cookie from search results for use in the
+      subsequent search.</fsummary>
+      <type>
+        <v>SearchResult = #eldap_search_result{}</v>
+      </type>
+      <desc>
+        <p>Paged results is an extension to the LDAP protocol
+        specified by RFC2696.</p>
+        <p>This function extracts the cookie returned from the
+        server as a result of a paged search result.</p>
+        <p>If the returned cookie is the empty string
+        <c>""</c>, then these search results represent the last in
+        the series.</p>
+      </desc>
+    </func>
 
   </funcs>
 

--- a/lib/eldap/include/eldap.hrl
+++ b/lib/eldap/include/eldap.hrl
@@ -20,7 +20,8 @@
 %%%
 -record(eldap_search_result, {
 	  entries = [],          % List of #eldap_entry{} records
-	  referrals = []         % List of referrals
+	  referrals = [],        % List of referrals
+	  controls = []          % List of controls
 	  }).
 
 %%%

--- a/lib/eldap/test/README
+++ b/lib/eldap/test/README
@@ -11,7 +11,18 @@ erl
 > make_certs:all("/dev/null", "eldap_basic_SUITE_data/certs").
 
 2)-------
-To start slapd:
+To start slapd you have two options:
+
+- Via Docker and provided `run_server.sh` script.
+
+This uses the [bitnami/openldap:2.5](https://hub.docker.com/r/bitnami/openldap)
+image to run an openldap/slapd server using docker.
+
+It will also take care of generating the server TLS certificates if they're not
+present.
+
+- Using system installed slapd:
+
    sudo slapd -f $ERL_TOP/lib/eldap/test/ldap_server/slapd.conf -F /tmp/slapd/slapd.d -h "ldap://localhost:9876 ldaps://localhost:9877"
 
 This will however not work, since slapd is guarded by apparmor that checks that slapd does not access other than allowed files...

--- a/lib/eldap/test/make_certs.erl
+++ b/lib/eldap/test/make_certs.erl
@@ -347,7 +347,7 @@ req_cnf(C) ->
      "default_bits	= ", integer_to_list(C#config.default_bits), "\n"
      "RANDFILE		= $ROOTDIR/RAND\n"
      "encrypt_key	= no\n"
-     "default_md	= sha1\n"
+     "default_md	= sha256\n"
      "#string_mask	= pkix\n"
      "x509_extensions	= ca_ext\n"
      "prompt		= no\n"
@@ -393,7 +393,7 @@ ca_cnf(C) ->
      ["crl_extensions = crl_ext\n" || C#config.v2_crls],
      "unique_subject  = no\n"
      "default_days	= 3600\n"
-     "default_md	= sha1\n"
+     "default_md	= sha256\n"
      "preserve	        = no\n"
      "policy		= policy_match\n"
      "\n"

--- a/lib/eldap/test/run_server.sh
+++ b/lib/eldap/test/run_server.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+__dir__="$(cd "$(dirname "$0")"; pwd)"
+
+if [ ! -d "$__dir__/eldap_basic_SUITE_data/certs" ]; then
+    echo "Creating certs..."
+    (
+        cd $__dir__ \
+        && erlc make_certs.erl \
+        && erl -noinput -eval 'make_certs:all("/dev/null", "eldap_basic_SUITE_data/certs").' -s init stop
+    )
+fi
+
+docker run \
+    --rm \
+    -v "${__dir__}/eldap_basic_SUITE_data/certs:/opt/otp/openldap/certs" \
+    -e LDAP_ENABLE_TLS=yes \
+    -e LDAP_TLS_CERT_FILE=/opt/otp/openldap/certs/server/cert.pem \
+    -e LDAP_TLS_KEY_FILE=/opt/otp/openldap/certs/server/keycert.pem \
+    -e LDAP_TLS_CA_FILE=/opt/otp/openldap/certs/server/cacerts.pem  \
+    -e LDAP_ROOT="dc=ericsson,dc=se" \
+    -e LDAP_ADMIN_USERNAME="Manager" \
+    -e LDAP_ADMIN_PASSWORD="hejsan" \
+    -p 9877:1636 \
+    -p 9876:1389 \
+    bitnami/openldap:2.5


### PR DESCRIPTION
Returns the controls from an LDAP search and includes the
PagedResultsControl ASN so that user code can perform paged searches
according to https://www.rfc-editor.org/rfc/rfc2696.txt