### PR TITLE
[erts] reduce console output for Common Test

### DIFF
--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -2955,12 +2955,8 @@ erts_check_io_debug(ErtsCheckIoDebugInfo *ciodip)
     erts_dsprintf(dsbufp, "internal fds=%d\n", counters.internal_fds);
 #endif
     erts_dsprintf(dsbufp, "---------------------------------------------------------\n");
-    if (counters.num_errors > 0)
-        erts_send_error_to_logger_nogl(dsbufp);
-    else {
-        erts_free(ERTS_ALC_T_LOGGER_DSBUF, (void *) dsbufp->str);
-        erts_free(ERTS_ALC_T_LOGGER_DSBUF, (void *) dsbufp);
-    }
+
+    erts_send_error_to_logger_nogl(dsbufp);
 #ifdef ERTS_SYS_CONTINOUS_FD_NUMBERS
     erts_free(ERTS_ALC_T_TMP, (void *) counters.epep);
 #endif

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -2955,7 +2955,12 @@ erts_check_io_debug(ErtsCheckIoDebugInfo *ciodip)
     erts_dsprintf(dsbufp, "internal fds=%d\n", counters.internal_fds);
 #endif
     erts_dsprintf(dsbufp, "---------------------------------------------------------\n");
-    erts_send_error_to_logger_nogl(dsbufp);
+    if (counters.num_errors > 0)
+        erts_send_error_to_logger_nogl(dsbufp);
+    else {
+        erts_free(ERTS_ALC_T_LOGGER_DSBUF, (void *) dsbufp->str);
+        erts_free(ERTS_ALC_T_LOGGER_DSBUF, (void *) dsbufp);
+    }
 #ifdef ERTS_SYS_CONTINOUS_FD_NUMBERS
     erts_free(ERTS_ALC_T_TMP, (void *) counters.epep);
 #endif

--- a/erts/emulator/test/busy_port_SUITE.erl
+++ b/erts/emulator/test/busy_port_SUITE.erl
@@ -255,7 +255,7 @@ no_trap_exit(Config) when is_list(Config) ->
     Pid = fun_spawn(fun no_trap_exit_process/3, [self(), linked, Config]),
     receive
         {Pid, port_created, Port} ->
-            io:format("Process ~w created port ~w", [Pid, Port]),
+            ct:log("Process ~w created port ~w", [Pid, Port]),
             exit(Port, die);
         Other1 ->
             ct:fail({unexpected_message, Other1})
@@ -278,7 +278,7 @@ no_trap_exit_unlinked(Config) when is_list(Config) ->
                     [self(), unlink, Config]),
     receive
         {Pid, port_created, Port} ->
-            io:format("Process ~w created port ~w", [Pid, Port]),
+            ct:log("Process ~w created port ~w", [Pid, Port]),
             exit(Port, die);
         Other1 ->
             ct:fail({unexpected_message, Other1})
@@ -320,7 +320,7 @@ trap_exit(Config) when is_list(Config) ->
     Pid = fun_spawn(fun busy_port_exit_process/2, [self(), Config]),
     receive
 	      {Pid, port_created, Port} ->
-		  io:format("Process ~w created port ~w", [Pid, Port]),
+                  ct:log("Process ~w created port ~w", [Pid, Port]),
 		  unlink(Pid),
 		  {status, suspended} = process_info(Pid, status),
 		  exit(Port, die);
@@ -755,7 +755,7 @@ run_command(_M,spawn,{Args,Opts}) ->
 run_command(M,spawn,Args) ->
     run_command(M,spawn,{Args,[]});
 run_command(Mod,Func,Args) ->
-    erlang:display({{Mod,Func,Args}, erlang:system_time(microsecond)}),
+    %% erlang:display({{Mod,Func,Args}, erlang:system_time(microsecond)}),
     apply(Mod,Func,Args).
 
 validate_scenario(Data,[{print,Var}|T]) ->
@@ -869,7 +869,7 @@ chk_not_value(_, _) ->
 wait_for([]) ->
     ok;
 wait_for(Pids) ->
-    io:format("Waiting for ~p", [Pids]),
+    ct:log("Waiting for ~p", [Pids]),
     receive
 	{'EXIT', Pid, normal} ->
 	    wait_for(lists:delete(Pid, Pids));

--- a/erts/emulator/test/driver_SUITE.erl
+++ b/erts/emulator/test/driver_SUITE.erl
@@ -211,12 +211,10 @@ init_per_testcase(Case, Config) when is_atom(Case), is_list(Config) ->
                        end,
                        erts_debug:get_internal_state(check_io_debug)
                end),
-    erlang:display({init_per_testcase, Case}),
     0 = element(1, CIOD),
     [{testcase, Case}|Config].
 
-end_per_testcase(Case, Config) ->
-    erlang:display({end_per_testcase, Case}),
+end_per_testcase(_Case, Config) ->
     try rpc(Config, fun() ->
                             get_stable_check_io_info(),
                             erts_debug:get_internal_state(check_io_debug)
@@ -1016,12 +1014,11 @@ chkio_test({erts_poll_info, Before},
             chk_chkio_port(Port),
             Fun(),
             During = get_check_io_total(erlang:system_info(check_io)),
-            erlang:display(During),
 
             [0 = element(1, erts_debug:get_internal_state(check_io_debug)) ||
                 %% The pollset is not stable when running the fallback testcase
                 Test /= ?CHKIO_USE_FALLBACK_POLLSET],
-            io:format("During test: ~p~n", [During]),
+            ct:log("During test: ~p~n", [During]),
             chk_chkio_port(Port),
             case erlang:port_control(Port, ?CHKIO_STOP, "") of
                 Res when is_list(Res) ->
@@ -2085,12 +2082,12 @@ async_blast(Config) when is_list(Config) ->
                   end, Ps),
     End = os:timestamp(),
     MemAfter = driver_alloc_size(),
-    io:format("MemBefore=~p, MemMid=~p, MemAfter=~p~n",
+    ct:log("MemBefore=~p, MemMid=~p, MemAfter=~p~n",
               [MemBefore, MemMid, MemAfter]),
     AsyncBlastTime = timer:now_diff(End,Start)/1000000,
-    io:format("AsyncBlastTime=~p~n", [AsyncBlastTime]),
+    ct:log("AsyncBlastTime=~p~n", [AsyncBlastTime]),
     MemBefore = MemAfter,
-    erlang:display({async_blast_time, AsyncBlastTime}),
+    ct:log({async_blast_time, AsyncBlastTime}),
     ok.
 
 thr_msg_blast_receiver(_Port, N, N) ->
@@ -2141,13 +2138,12 @@ thr_msg_blast(Config) when is_list(Config) ->
             ok
     end,
     MemAfter = driver_alloc_size(),
-    io:format("MemBefore=~p, MemAfter=~p~n",
+    ct:log("MemBefore=~p, MemAfter=~p~n",
               [MemBefore, MemAfter]),
     ThrMsgBlastTime = timer:now_diff(End,Start)/1000000,
-    io:format("ThrMsgBlastTime=~p~n", [ThrMsgBlastTime]),
+    ct:log("ThrMsgBlastTime=~p~n", [ThrMsgBlastTime]),
     MemBefore = MemAfter,
     Res = {thr_msg_blast_time, ThrMsgBlastTime},
-    erlang:display(Res),
     Res.
 
 -define(IN_RANGE(LoW_, VaLuE_, HiGh_),
@@ -2408,8 +2404,7 @@ count_pp_sched_stop(Ps) ->
     PNs = lists:map(fun (P) -> {P, 0} end, Ps),
     receive {trace_delivered, all, Td} -> ok end,
     Res = count_proc_sched(Ps, PNs),
-    io:format("Scheduling counts: ~p~n", [Res]),
-    erlang:display({scheduling_counts, Res}),
+    ct:log("Scheduling counts: ~p~n", [Res]),
     Res.
 
 do_inc_pn(_P, []) ->
@@ -2713,7 +2708,7 @@ rpc(Config, Fun) ->
         undefined ->
             Fun();
         {_Peer, Node} ->
-            io:format("Running RPC ~p on ~p/~p~n", [Fun, _Peer, Node]),
+            ct:log("Running RPC ~p on ~p/~p~n", [Fun, _Peer, Node]),
             Self = self(),
             Ref = make_ref(),
             Pid = spawn(Node,

--- a/erts/emulator/test/port_SUITE.erl
+++ b/erts/emulator/test/port_SUITE.erl
@@ -764,7 +764,7 @@ iter_max_ports_test(Config) ->
     L = rpc:call(Node,?MODULE,do_iter_max_ports,[Iters, Command]),
     peer:stop(Peer),
 
-    io:format("Result: ~p",[L]),
+    ct:log("Result: ~p",[L]),
     all_equal(L),
     all_equal(L),
     {comment, "Max ports: " ++ integer_to_list(hd(L))}.
@@ -2244,7 +2244,7 @@ port_expect(Config, Actions, HSize, CmdLine, Options0) ->
         _ -> {packet, HSize}
     end,
     Options = [PortType|Options0],
-    io:format("open_port({spawn, ~p}, ~p)", [Cmd, Options]),
+    ct:log("open_port({spawn, ~p}, ~p)", [Cmd, Options]),
     Port = open_port({spawn, Cmd}, Options),
     port_expect(Port, Actions, Options),
     Port.


### PR DESCRIPTION
Some test cases produce 20+ Mb of debug output which does
not help to figure out a problem. This change suppresses
logs, leaving a chance to remove suppression for local runs.