### PR TITLE
Avoid unnecessary linking against libnsl

### DIFF
--- a/lib/erl_interface/configure.ac
+++ b/lib/erl_interface/configure.ac
@@ -161,8 +161,8 @@ case $host_os in
 esac
 
 # Checks for libraries.
-AC_CHECK_LIB([nsl], [gethostbyname])
-AC_CHECK_LIB([socket], [getpeername])
+AC_SEARCH_LIBS([gethostbyname], [nsl])
+AC_SEARCH_LIBS([getpeername], [socket])
 
 # Checks for header files.
 AC_CHECK_INCLUDES_DEFAULT


### PR DESCRIPTION
Currently, `AC_CHECK_LIB`  is used for deciding whether to link [Erl_Interface][1] (and therefore [erl_call][2]) against libnsl. This results in linking against libnsl _if possible_, rather than _if necessary_. The Autoconf documentation [says][3]:

> `AC_CHECK_LIB` requires some care in usage, and should be avoided in some common cases. Many standard functions like `gethostbyname` appear in the standard C library on some hosts, and in special libraries like `nsl` on other hosts. On some hosts the special libraries contain variant implementations that you may not want to use. These days it is normally better to use `AC_SEARCH_LIBS([gethostbyname], [nsl])` instead of `AC_CHECK_LIB([nsl], [gethostbyname])`.

Another issue with glibc specifically is that the usual backward compatibility isn't offered for libnsl, so binaries linked against older libnsl versions may not work with newer libnsl versions. This can be a [problem][4] when trying to offer portable Linux binaries by linking against an old-ish glibc version.

Therefore, don't link against libnsl if gethostbyname is provided by the standard libc. While at it, avoid unnecessary linking against libsocket as well.

[1]: https://www.erlang.org/doc/man/ei.html
[2]: https://www.erlang.org/doc/man/erl_call.html
[3]: https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Libraries.html
[4]: https://github.com/processone/eturnal/issues/19#issuecomment-1002653506