### PR TITLE
tools/cover: Add method to generate summary file

### DIFF
--- a/lib/tools/doc/src/cover.xml
+++ b/lib/tools/doc/src/cover.xml
@@ -313,16 +313,20 @@
       <desc>
         <p>Makes copies of the source file for the given modules,
           where it for each executable line is specified
-          how many times it has been executed.</p>
+          how many times it has been executed. If summary is enabled a
+          file with a table summary of the coverage is generated.</p>
         <p>The output file <c><anno>OutFile</anno></c> defaults to
           <c><anno>Module</anno>.COVER.out</c>, or
           <c><anno>Module</anno>.COVER.html</c> if the option
           <c>html</c> was used.</p>
+        <p>The summary file <c><anno>SummaryFile</anno></c> defaults to
+          <c>all.COVER.summary</c>, or <c>all.COVER.summary.html</c> if the
+          option <c>html</c> was used.</p>
         <p>If <c><anno>Modules</anno></c> is an atom (one module), the
           return will be <c><anno>Answer</anno></c>, else the return
           will be a list, <c>{result, Ok, Fail}</c>.</p>
         <p>If <c><anno>Modules</anno></c> is not given, all modules
-          that have da ta in the cover data table, are analysed. Note
+          that have data in the cover data table, are analysed. Note
           that this includes both cover compiled modules and imported
           modules.</p>
         <p>If a module is not Cover compiled, this is indicated by the

--- a/lib/tools/priv/styles.css
+++ b/lib/tools/priv/styles.css
@@ -40,7 +40,7 @@ footer {
   justify-content: center;
 }
 
-table {
+table.code {
   width: 100%;
   margin-top: 10px;
   border-collapse: collapse;
@@ -93,4 +93,58 @@ td.source {
   line-height: 15px;
   white-space: pre;
   font: 12px monospace;
+}
+
+
+body.summary {
+  font: 1em/1.6 "Helvetica Neue", Helvetica, Arial, sans-serif;
+  justify-content: center;
+  align-items: center
+}
+
+body.summary h1 {
+  font-size: 140%;
+  font-weight: 100;
+  padding: 10px 0;
+  border: 0;
+  text-align: center
+}
+
+body.summary footer {
+  background-color: #fff;
+  font-size: 95%;
+  border: 0
+}
+
+table.summary {
+  margin-top: 10px;
+  min-width: 600px;
+  border: 1px solid #cbcbcb;
+  border-spacing: 0
+}
+table.summary thead {
+  display: table-header-group
+}
+table.summary tr,th,td {
+  padding: 5px
+}
+table.summary td.right {
+  text-align: right
+}
+table.summary thead th {
+  background: #eaeaea;
+  border-bottom: 1px solid #000
+}
+table.summary thead th.module {
+  width: 50%
+}
+table.summary tbody tr:nth-child(even) {
+  background:#f0f0f0
+}
+table.summary tbody td.module {
+  padding-right: 50px
+}
+table.summary tfoot td {
+  background: #eaeaea;
+  border-top: 1px solid #000
 }

--- a/lib/tools/test/cover_SUITE.erl
+++ b/lib/tools/test/cover_SUITE.erl
@@ -300,9 +300,23 @@ analyse(Config) when is_list(Config) ->
     {ok, "a.COVER.html"} = cover:analyse_to_file(a,[html]),
     {ok, "e.COVER.html"} = cover:analyse_to_file(e,[html]),
 
+    {result, ["all.COVER.summary", "a.COVER.out", "e.COVER.out"], []} =
+        cover:analyse_to_file([a, e]),
+    {result, ["all.COVER.summary.html", "a.COVER.html", "e.COVER.html"], []} =
+        cover:analyse_to_file([a, e], [html]),
+    {result, ["summary", "a.COVER.out", "e.COVER.out"], []} =
+        cover:analyse_to_file([a, e], [{summaryfile, "summary"}]),
+    {result, ["summary.html", "a.COVER.html", "e.COVER.html"], []} =
+        cover:analyse_to_file([a, e], [html, {summaryfile, "summary.html"}]),
+    {result, ["a.COVER.out", "e.COVER.out"], []} =
+        cover:analyse_to_file([a, e], [{summary, false}]),
+    {result, ["a.COVER.html", "e.COVER.html"], []} =
+        cover:analyse_to_file([a, e], [html, {summary, false}]),
+
+
     %% Analyse all modules
     Modules = cover:modules(),
-    N = length(Modules),
+    N = length(Modules) + 1,  %% Summary file is also included
 
     {result,CovFunc,[]} = cover:analyse(), % default = coverage, function
     ACovFunc = [A || {{a,_,_},_}=A<-CovFunc],


### PR DESCRIPTION
This commit adds the capability to cover:analyse_to_file/1,2 to generate
a coverage summary file. The summary file consists of a table where each
row contains module name, coverage percent, covered lines, and not
covered lines.

The summary file is generated by default if more than one module is
analyzed.

New options: {summary, boolean()} and {summaryfile, list()}.

By default the summary file is named "all.COVER.summary", or
"all.COVER.summary.html" if the option 'html' is enabled.

By default UTF-8 encoding is used for the summary file.

Signed-off-by: Per Andersson <avtobiff@foo.nu>