### PR TITLE
[tools] replace test_server:start_node with ?CT_PEER()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ TAGS
 # vscode
 .vscode
 
+# IntelliJ IDEA
+.idea
+
 autom4te.cache
 *.beam
 *.asn1db

--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -2832,7 +2832,9 @@ start_peer(#{name := Name} = Opts, Module) ->
         end,
     FullArgs = CookieArg ++ ["-pa", filename:dirname(code:which(Module)),
         "-env", "ERL_CRASH_DUMP", CrashFile] ++ Args,
-    case test_server:is_cover() of
+    %% start_cover => false is intentionally undocumented, and is not
+    %%  expected to be used by anything but cover_SUITE test.
+    case maps:get(start_cover, Opts, true) andalso test_server:is_cover() of
         true ->
             %% when cover is active, node must shut down gracefully, otherwise
             %% coverage information won't be sent to cover master

--- a/lib/tools/test/cover_SUITE.erl
+++ b/lib/tools/test/cover_SUITE.erl
@@ -25,7 +25,7 @@
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
-     {timetrap,{minutes,5}}].
+     {timetrap,{minutes,2}}].
 
 all() -> 
     NoStartStop = [eif,otp_5305,otp_5418,otp_7095,otp_8273,
@@ -440,14 +440,14 @@ distribution(Config) when is_list(Config) ->
     DataDir = proplists:get_value(data_dir, Config),
     ok = file:set_cwd(DataDir),
 
-    {ok,N1} = test_server:start_node(cover_SUITE_distribution1,slave,[]),
-    {ok,N2} = test_server:start_node(cover_SUITE_distribution2,slave,[]),
-    {ok,N3} = test_server:start_node(cover_SUITE_distribution3,slave,[]),
-    {ok,N4} = test_server:start_node(cover_SUITE_distribution4,slave,[]),
+    {ok,P1,N1} = ?CT_PEER(),
+    {ok,P2,N2} = ?CT_PEER(),
+    {ok,P3,N3} = ?CT_PEER(),
+    {ok,P4,N4} = ?CT_PEER(),
 
     %% Check that an already compiled module is loaded on new nodes
     {ok,f} = cover:compile(f),
-    {ok,[_,_,_,_]} = cover:start(nodes()),
+    {ok,[_,_,_,_]} = cover:start([N1,N2,N3,N4]),
     cover_compiled = code:which(f),
     cover_compiled = rpc:call(N1,code,which,[f]),
     cover_compiled = rpc:call(N2,code,which,[f]),
@@ -474,7 +474,7 @@ distribution(Config) when is_list(Config) ->
 
     %% this is lost when the node is killed
     rpc:call(N3,f,f2,[]),
-    rpc:call(N3,erlang,halt,[]),
+    peer:stop(P3),
 
     %% this should be visible in analyse
     rpc:call(N1,f,f1,[]),
@@ -514,7 +514,7 @@ distribution(Config) when is_list(Config) ->
     %% Check that flush collects data so calls are not lost if node is killed
     rpc:call(N4,f,f2,[]),
     ok = cover:flush(N4),
-    rpc:call(N4,erlang,halt,[]),
+    peer:stop(P4),
     check_f_calls(1,3),
 
     %% Check that stop() unloads on all nodes
@@ -535,8 +535,8 @@ distribution(Config) when is_list(Config) ->
     %% Cleanup
     Files = lsfiles(),
     remove(files(Files, ".beam")),
-    test_server:stop_node(N1),
-    test_server:stop_node(N2).
+    peer:stop(P1),
+    peer:stop(P2).
 
 %% Test that a lost node is reconnected
 reconnect(Config) ->
@@ -547,12 +547,10 @@ reconnect(Config) ->
     {ok,b} = compile:file(b),
     {ok,f} = compile:file(f),
 
-    {ok,N1} = test_server:start_node(cover_SUITE_reconnect,peer,
-                                     [{args," -pa " ++ DataDir},
-                                      {start_cover,false}]),
+    {ok,P1,N1} = ?CT_PEER(#{connection => 0, args => ["-pa", DataDir]}),
     {ok,a} = cover:compile(a),
     {ok,f} = cover:compile(f),
-    {ok,[N1]} = cover:start(nodes()),
+    {ok,[N1]} = cover:start([N1]),
 
     %% Some calls to check later
     rpc:call(N1,f,f1,[]),
@@ -590,7 +588,7 @@ reconnect(Config) ->
     check_f_calls(2,1),
 
     cover:stop(),
-    test_server:stop_node(N1),
+    peer:stop(P1),
     ok.
 
 %% Test that a lost node is reconnected - also if it has been dead
@@ -600,13 +598,10 @@ die_and_reconnect(Config) ->
 
     {ok,f} = compile:file(f),
 
-    NodeName = cover_SUITE_die_and_reconnect,
-    {ok,N1} = test_server:start_node(NodeName,peer,
-                                     [{args," -pa " ++ DataDir},
-                                      {start_cover,false}]),
+    {ok, P1, N1} = ?CT_PEER(#{name => ?CT_PEER_NAME(), args => ["-pa", DataDir]}),
     %% {ok,a} = cover:compile(a),
     {ok,f} = cover:compile(f),
-    {ok,[N1]} = cover:start(nodes()),
+    {ok,[N1]} = cover:start([N1]),
 
     %% Some calls to check later
     rpc:call(N1,f,f1,[]),
@@ -614,15 +609,13 @@ die_and_reconnect(Config) ->
     rpc:call(N1,f,f1,[]),
 
     %% Kill the node
-    rpc:call(N1,erlang,halt,[]),
+    peer:stop(P1),
     cover_which_nodes([]),
 
     check_f_calls(1,0), % only the first call - before the flush
 
     %% Restart the node and check that cover reconnects
-    {ok,N1} = test_server:start_node(NodeName,peer,
-                                     [{args," -pa " ++ DataDir},
-                                      {start_cover,false}]),
+    {ok,P2,N1} = ?CT_PEER(#{name => N1, args => ["-pa", DataDir]}),
     timer:sleep(100),
     [N1] = cover:which_nodes(), % we are reconnected
     cover_compiled = rpc:call(N1,code,which,[f]),
@@ -634,7 +627,7 @@ die_and_reconnect(Config) ->
     check_f_calls(2,0),
 
     cover:stop(),
-    test_server:stop_node(N1),
+    peer:stop(P2),
     ok.
 
 %% Test that a stopped node is not marked as lost, i.e. that it is not
@@ -645,27 +638,23 @@ dont_reconnect_after_stop(Config) ->
 
     {ok,f} = compile:file(f),
 
-    NodeName = cover_SUITE_dont_reconnect_after_stop,
-    {ok,N1} = test_server:start_node(NodeName,peer,
-                                     [{args," -pa " ++ DataDir},
-                                      {start_cover,false}]),
+    {ok, P1, N1} = ?CT_PEER(#{name => ?CT_PEER_NAME(), args => ["-pa", DataDir],
+        start_cover => false}),
     {ok,f} = cover:compile(f),
-    {ok,[N1]} = cover:start(nodes()),
+    {ok,[N1]} = cover:start([N1]),
 
     %% A call to check later
     rpc:call(N1,f,f1,[]),
 
     %% Stop cover on the node, then terminate the node
     cover:stop(N1),
-    rpc:call(N1,erlang,halt,[]),
+    peer:stop(P1),
     cover_which_nodes([]),
 
     check_f_calls(1,0),
 
     %% Restart the node and check that cover does not reconnect
-    {ok,N1} = test_server:start_node(NodeName,peer,
-                                     [{args," -pa " ++ DataDir},
-                                      {start_cover,false}]),
+    {ok, P2, N1} = ?CT_PEER(#{name => N1, args => ["-pa", DataDir], start_cover => false}),
     timer:sleep(300),
     cover_which_nodes([]),
     Beam = rpc:call(N1,code,which,[f]),
@@ -679,7 +668,7 @@ dont_reconnect_after_stop(Config) ->
     check_f_calls(1,0),
 
     cover:stop(),
-    test_server:stop_node(N1),
+    peer:stop(P2),
     ok.
 
 %% Test that a node which is stopped while it is marked as lost is not
@@ -690,19 +679,17 @@ stop_node_after_disconnect(Config) ->
 
     {ok,f} = compile:file(f),
 
-    NodeName = cover_SUITE_stop_node_after_disconnect,
-    {ok,N1} = test_server:start_node(NodeName,peer,
-                                     [{args," -pa " ++ DataDir},
-                                      {start_cover,false}]),
+    {ok, P1, N1} = ?CT_PEER(#{name => ?CT_PEER_NAME(), args => ["-pa", DataDir],
+        start_cover => false}),
     {ok,f} = cover:compile(f),
-    {ok,[N1]} = cover:start(nodes()),
+    {ok,[N1]} = cover:start([N1]),
 
     %% A call to check later
     rpc:call(N1,f,f1,[]),
 
     %% Flush the node, then terminate the node to make it marked as lost
     cover:flush(N1),
-    rpc:call(N1,erlang,halt,[]),
+    peer:stop(P1),
 
     check_f_calls(1,0),
 
@@ -710,9 +697,7 @@ stop_node_after_disconnect(Config) ->
     cover:stop(N1),
 
     %% Restart the node and check that cover does not reconnect
-    {ok,N1} = test_server:start_node(NodeName,peer,
-                                     [{args," -pa " ++ DataDir},
-                                      {start_cover,false}]),
+    {ok, P2, N1} = ?CT_PEER(#{name => N1, args => ["-pa", DataDir], start_cover => false}),
     timer:sleep(300),
     cover_which_nodes([]),
     Beam = rpc:call(N1,code,which,[f]),
@@ -726,7 +711,7 @@ stop_node_after_disconnect(Config) ->
     check_f_calls(1,0),
 
     cover:stop(),
-    test_server:stop_node(N1),
+    peer:stop(P2),
     ok.
 
 distribution_performance(Config) ->
@@ -742,18 +727,14 @@ distribution_performance(Config) ->
 
     %    test_server:break(""),
 
-    NodeName = cover_SUITE_distribution_performance,
-    {ok,N1} = test_server:start_node(NodeName,peer,[{start_cover,false}]),
+    {ok, P1, N1} = ?CT_PEER(),
     %% CFun = fun() ->
     %% 		   [{ok,_} = cover:compile_beam(Mod) || Mod <- Mods]
     %% 	   end,
     CFun = fun() -> cover:compile_beam(Mods) end,
-    {CT,_CA} = timer:tc(CFun),
-    %    erlang:display(_CA),
-    erlang:display({compile,CT}),
+    {_CT, _CA} = timer:tc(CFun),
 
-    {SNT,_} = timer:tc(fun() -> {ok,[N1]} = cover:start(nodes()) end),
-    erlang:display({start_node,SNT}),
+    {ok,[N1]} = cover:start([N1]),
 
     [1 = rpc:call(N1,Mod,f1,[1]) || Mod <- Mods],
 
@@ -769,16 +750,14 @@ distribution_performance(Config) ->
 
     %    Fun = fun() -> cover:reset() end,
 
-    {AT,_A} = timer:tc(Fun),
-    erlang:display({analyse,AT}),
+    {_AT, _A} = timer:tc(Fun),
     %    erlang:display(lists:sort([X || X={_MFA,N} <- lists:append([L || {ok,L}<-A]), N=/=0])),
 
     %% fprof:apply(Fun, [],[{procs,[whereis(cover_server)]}]),
     %% fprof:profile(),
     %% fprof:analyse(dest,[]),
 
-    {SNT2,_} = timer:tc(fun() -> test_server:stop_node(N1) end),
-    erlang:display({stop_node,SNT2}),
+    peer:stop(P1),
 
     code:del_path(Dir),
     Files = filelib:wildcard(AllFiles),
@@ -946,11 +925,11 @@ export_import(Config) when is_list(Config) ->
 otp_5031(Config) when is_list(Config) ->
     ct:timetrap({seconds, 10}),
 
-    {ok,N1} = test_server:start_node(cover_SUITE_otp_5031,slave,[]),
+    {ok,Peer,N1} = ?CT_PEER(),
     {ok,[N1]} = cover:start(N1),
     {error,not_main_node} = rpc:call(N1,cover,modules,[]),
     cover:stop(),
-    test_server:stop_node(N1),
+    peer:stop(Peer),
     ok.
 
 %% Test the \'Exclude Included Functions\' functionality
@@ -1159,13 +1138,13 @@ otp_8270(Config) when is_list(Config) ->
 
     PrivDir = proplists:get_value(priv_dir, Config),
 
-    As = [{args," -pa " ++ PrivDir}],
-    {ok,N1} = test_server:start_node(cover_n1,slave,As),
-    {ok,N2} = test_server:start_node(cover_n2,slave,As),
-    {ok,N3} = test_server:start_node(cover_n3,slave,As),
+    As = ["-pa", PrivDir],
+    {ok,P1,N1} = ?CT_PEER(As),
+    {ok,P2,N2} = ?CT_PEER(As),
+    {ok,P3,N3} = ?CT_PEER(As),
 
     timer:sleep(500),
-    {ok,[_,_,_]} = cover:start(nodes()),
+    {ok,[_,_,_]} = cover:start([N1,N2,N3]),
 
     Test = <<"-module(m).\n"
              "-compile(export_all).\n"
@@ -1203,9 +1182,9 @@ otp_8270(Config) when is_list(Config) ->
     {N3,true} = {N3,is_list(N3_info)},
 
     exit(Pid1,kill),
-    test_server:stop_node(N1),
-    test_server:stop_node(N2),
-    test_server:stop_node(N3),
+    peer:stop(P1),
+    peer:stop(P2),
+    peer:stop(P3),
     ok.
 
 %% OTP-8273. Bug.
@@ -1607,7 +1586,7 @@ cover_clauses(Config) when is_list(Config) ->
               -export([clauses/0]).
               clauses() -> ok.
              ">>,
-    File = cc_mod(cover_clauses, Test, Config),
+    _File = cc_mod(cover_clauses, Test, Config),
     ok.
 
 %% Take compiler options from beam in cover:compile_beam
@@ -1835,9 +1814,9 @@ local_only(Config) ->
 
     %% Make sure that it is not possible to run cover on
     %% slave nodes.
-    {ok,Name} = test_server:start_node(?FUNCTION_NAME, slave, []),
+    {ok,Peer,Name} = ?CT_PEER(),
     {error,local_only} = cover:start([Name]),
-    test_server:stop_node(Name),
+    peer:stop(Peer),
     ok.
 
 %% ERL-943; We should not crash on startup when multiple servers race to


### PR DESCRIPTION
Make tests more robust - node names can never clash now.