### PR TITLE
Introducing lists:foldlwhile

### DIFF
--- a/lib/stdlib/doc/src/lists.xml
+++ b/lib/stdlib/doc/src/lists.xml
@@ -324,6 +324,28 @@ flatmap(Fun, List1) ->
     </func>
 
     <func>
+      <name name="foldlwhile" arity="3" since=""/>
+      <fsummary>Fold a function over a list until <anno>halt</anno> is returned</fsummary>
+      <desc>
+        <p>Calls <c><anno>Fun</anno>(<anno>Elem</anno>, <anno>AccIn</anno>)</c>
+          on successive elements <c>A</c> of <c><anno>List</anno></c>, starting
+          with <c><anno>AccIn</anno> == <anno>Acc0</anno></c>.
+          <c><anno>Fun</anno>/2</c> must return a tuple <c>{cont, Acc}</c>
+          to continue or <c>{halt, Acc}</c>
+          to stop the folding. The second element of the tuple is the accumulator, which is
+          passed to the next call. The function returns the final value of
+          the accumulator. <c><anno>Acc0</anno></c> is returned if the list is
+          empty.</p>
+        <p><em>Example:</em></p>
+        <pre>
+> <input>lists:foldlwhile(fun(X, Sum) when X=&lt;3 -> {cont, X + Sum}; (_X, Sum) -> {halt, Sum} end, 0, [1,2,3,4,5]).</input>
+6
+> <input>lists:foldlwhile(fun(X, Prod) when X=&lt;3 -> {cont, X * Prod}; (_X, Prod} -> {halt, Prod} end, 1, [1,2,3,4,5]).</input>
+6</pre>
+      </desc>
+    </func>
+
+    <func>
       <name name="foldr" arity="3" since=""/>
       <fsummary>Fold a function over a list.</fsummary>
       <desc>

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -39,7 +39,7 @@
 -export([all/2,any/2,map/2,flatmap/2,foldl/3,foldr/3,foldlwhile/3,filter/2,
 	 partition/2,zf/2,filtermap/2,
 	 mapfoldl/3,mapfoldr/3,foreach/2,takewhile/2,dropwhile/2,
-         search/2, splitwith/2,split/2,
+	 search/2, splitwith/2,split/2,
 	 join/2]).
 
 %%% BIFs
@@ -1347,11 +1347,11 @@ foldr_1(_F, Accu, []) ->
 %%  example:
 %%  lists:foldlwhile(
 %%    fun
-%%      (X, Acc) when X < 3 ->
-%%        {cont, Acc+X};
-%%      (X, Acc) ->
-%%        {halt, Acc+X}
-%%    end, 0, [1,2,3,4,5]).
+%%      (X, Acc) when X =< 3 ->
+%%        {cont, Acc + X};
+%%      (_X, Acc) ->
+%%        {halt, Acc}
+%%    end, 0, [1, 2, 3, 4, 5]).
 %%  > 6
 
 -spec foldlwhile(Fun, Acc0, List) -> Acc1 when
@@ -1363,7 +1363,6 @@ foldr_1(_F, Accu, []) ->
       List :: [T],
       T :: term().
 
-foldlwhile(_F, Accu, []) -> Accu;
 foldlwhile(F, Accu, List) when is_function(F, 2) ->
     foldlwhile_1(F, Accu, List).
 

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -36,7 +36,7 @@
 
 -export([merge/3, rmerge/3, sort/2, umerge/3, rumerge/3, usort/2]).
 
--export([all/2,any/2,map/2,flatmap/2,foldl/3,foldr/3,filter/2,
+-export([all/2,any/2,map/2,flatmap/2,foldl/3,foldr/3,foldlwhile/3,filter/2,
 	 partition/2,zf/2,filtermap/2,
 	 mapfoldl/3,mapfoldr/3,foreach/2,takewhile/2,dropwhile/2,
          search/2, splitwith/2,split/2,
@@ -1340,6 +1340,41 @@ foldr(F, Accu, List) when is_function(F, 2) ->
 foldr_1(F, Accu, [Hd | Tail]) ->
     F(Hd, foldr_1(F, Accu, Tail));
 foldr_1(_F, Accu, []) ->
+    Accu.
+
+%% foldlwhile(Fun, Acc, List) -> AccOut
+%%  reduces the List until the Fun returns `{halt, Acc}`.
+%%  example:
+%%  lists:foldlwhile(
+%%    fun
+%%      (X, Acc) when X < 3 ->
+%%        {cont, Acc+X};
+%%      (X, Acc) ->
+%%        {halt, Acc+X}
+%%    end, 0, [1,2,3,4,5]).
+%%  > 6
+
+-spec foldlwhile(Fun, Acc0, List) -> Acc1 when
+      Fun :: fun((Elem :: T, AccIn) -> {cont, AccOut} | {halt, AccOut}),
+      Acc0 :: term(),
+      Acc1 :: term(),
+      AccIn :: term(),
+      AccOut :: term(),
+      List :: [T],
+      T :: term().
+
+foldlwhile(_F, Accu, []) -> Accu;
+foldlwhile(F, Accu, List) when is_function(F, 2) ->
+    foldlwhile_1(F, Accu, List).
+
+foldlwhile_1(F, Accu, [Hd | Tail]) ->
+    case F(Hd, Accu) of
+        {cont, NewAccu} ->
+            foldlwhile_1(F, NewAccu, Tail);
+        {halt, NewAccu} ->
+            NewAccu
+    end;
+foldlwhile_1(_F, Accu, []) ->
     Accu.
 
 -spec filter(Pred, List1) -> List2 when

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -58,7 +58,7 @@
 	 join/1,
 	 otp_5939/1, otp_6023/1, otp_6606/1, otp_7230/1,
 	 suffix/1, subtract/1, droplast/1, search/1, hof/1,
-         enumerate/1, error_info/1]).
+   enumerate/1, foldlwhile/1, error_info/1]).
 
 %% Sort randomized lists until stopped.
 %%
@@ -122,7 +122,7 @@ groups() ->
      {zip, [parallel], [zip_unzip, zip_unzip3, zipwith, zipwith3]},
      {misc, [parallel], [reverse, member, dropwhile, takewhile,
 			 filter_partition, suffix, subtract, join,
-			 hof, droplast, search, enumerate, error_info]}
+			 hof, droplast, search, enumerate, foldlwhile, error_info]}
     ].
 
 init_per_suite(Config) ->
@@ -2759,6 +2759,23 @@ enumerate(Config) when is_list(Config) ->
 
     ok.
 
+%% Test lists:foldlwhile/3
+foldlwhile(_Config) ->
+    0 = lists:foldlwhile(fun(X, _Acc) -> {cont, X} end, 0, []),
+    0 = lists:foldlwhile(fun(X, _Acc) -> {halt, X} end, 0, []),
+
+    6 = lists:foldlwhile(
+          fun
+              (X, Acc) when X < 3 -> {cont, Acc + X};
+              (X, Acc) -> {halt, Acc + X}
+          end,
+          0,
+          [1, 2, 3, 4, 5]
+        ),
+
+    one = lists:foldlwhile(fun(_, Acc) -> {halt, Acc} end, one, [a, b, c]),
+    ok.
+
 error_info(_Config) ->
     L = [{keyfind, [whatever, bad_position, bad_list], [{2,".*"},{3,".*"}]},
          {keymember, [key, 0, bad_list], [{2,".*"}, {3,".*"}]},
@@ -2783,3 +2800,4 @@ do_error_info(L0) ->
     NYI = [{F,lists:duplicate(A, '*'),nyi} || {F,A} <- Bifs -- Tests],
     L = lists:sort(NYI ++ L1),
     error_info_lib:test_error_info(lists, L, [snifs_only]).
+

--- a/lib/stdlib/test/lists_SUITE.erl
+++ b/lib/stdlib/test/lists_SUITE.erl
@@ -2766,8 +2766,8 @@ foldlwhile(_Config) ->
 
     6 = lists:foldlwhile(
           fun
-              (X, Acc) when X < 3 -> {cont, Acc + X};
-              (X, Acc) -> {halt, Acc + X}
+              (X, Acc) when X =< 3 -> {cont, Acc + X};
+              (_X, Acc) -> {halt, Acc}
           end,
           0,
           [1, 2, 3, 4, 5]


### PR DESCRIPTION
The goal of the PR is to introduce `lists:foldlwhile` taking inspiration from the Elixir `Enum:reduce_while`.
The motivation is to add an easy way to interrupt the folding action as soon as some condition has been detected.