### PR TITLE
erts: Generate beamasm_protos.h deterministically

### DIFF
--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -713,7 +713,8 @@ sub emulator_output {
         open(STDOUT, ">$name") || die "Failed to open $name for writing: $!\n";
         comment('C');
 
-        foreach $key (keys %specific_op) {
+        # Sort the generated code to create beamasm_protos.h deterministically
+        foreach $key (sort keys %specific_op) {
             foreach (@{$specific_op{$key}}) {
                 my($name, $hotness, $varargs, @args) = @$_;
 


### PR DESCRIPTION
Here is another PR, sorting the code generated in beamasm_protos.h, to get closer to deterministic builds.

EDIT: Linked to #4417