### PR TITLE
Compile time no longer available

### DIFF
--- a/lib/diameter/src/info/diameter_dbg.erl
+++ b/lib/diameter/src/info/diameter_dbg.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2010-2016. All Rights Reserved.
+%% Copyright Ericsson AB 2010-2022. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -30,9 +30,7 @@
          modules/0,
          versions/0,
          version_info/0,
-         compiled/0,
          procs/0,
-         latest/0,
          nl/0,
          sizes/0]).
 
@@ -165,25 +163,11 @@ version_info() ->
     ?I:version_info(modules()).
 
 %% ----------------------------------------------------------
-%% # compiled/0
-%% ----------------------------------------------------------
-
-compiled() ->
-    ?I:compiled(modules()).
-
-%% ----------------------------------------------------------
 %% # procs/0
 %% ----------------------------------------------------------
 
 procs() ->
     ?I:procs(?APP).
-
-%% ----------------------------------------------------------
-%% # latest/0
-%% ----------------------------------------------------------
-
-latest() ->
-    ?I:latest(modules()).
 
 %% ----------------------------------------------------------
 %% # nl/0

--- a/lib/inets/src/inets_app/inets.erl
+++ b/lib/inets/src/inets_app/inets.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
-%% Copyright Ericsson AB 2006-2021. All Rights Reserved.
-%% 
+%%
+%% Copyright Ericsson AB 2006-2022. All Rights Reserved.
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 %%
@@ -256,11 +256,9 @@ mod_version_info(Mod) ->
     {value, {app_vsn,    AppVsn}} = lists:keysearch(app_vsn,    1, Attr),
     {value, {compile,    Comp}}   = lists:keysearch(compile,    1, Info),
     {value, {version,    Ver}}    = lists:keysearch(version,    1, Comp),
-    {value, {time,       Time}}   = lists:keysearch(time,       1, Comp),
     {Mod, [{vsn,              Vsn},
            {app_vsn,          AppVsn},
-           {compiler_version, Ver},
-           {compile_time,     Time}]}.
+           {compiler_version, Ver}]}.
 
 sys_info() ->
     SysArch = string:strip(erlang:system_info(system_architecture),right,$\n),
@@ -328,22 +326,12 @@ print_mod_info({Module, Info}) ->
             _ ->
                 "Not found"
         end,
-    CompDate =
-        case key1search(compile_time, Info) of
-            {value, {Year, Month, Day, Hour, Min, Sec}} ->
-                lists:flatten(
-                  io_lib:format("~w-~2..0w-~2..0w ~2..0w:~2..0w:~2..0w",
-                                [Year, Month, Day, Hour, Min, Sec]));
-            _ ->
-                "Not found"
-        end,
     io:format("   ~w:~n"
               "      Vsn:          ~s~n"
               "      App vsn:      ~s~n"
               "      ASN.1 vsn:    ~s~n"
-              "      Compiler ver: ~s~n"
-              "      Compile time: ~s~n",
-              [Module, Vsn, AppVsn, Asn1Vsn, CompVer, CompDate]),
+              "      Compiler ver: ~s~n",
+              [Module, Vsn, AppVsn, Asn1Vsn, CompVer]),
     ok.
 
 

--- a/lib/megaco/src/app/megaco.erl
+++ b/lib/megaco/src/app/megaco.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
-%% Copyright Ericsson AB 1999-2020. All Rights Reserved.
-%% 
+%%
+%% Copyright Ericsson AB 1999-2022. All Rights Reserved.
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 
@@ -623,25 +623,15 @@ print_mod_info({Module, Info}) ->
 	    _ ->
 		"Not found"
 	end,
-    CompDate = 
-	case key1search(compile_time, Info) of
-	    {value, {Year, Month, Day, Hour, Min, Sec}} ->
-		lists:flatten(
-		  io_lib:format("~w-~2..0w-~2..0w ~2..0w:~2..0w:~2..0w", 
-				[Year, Month, Day, Hour, Min, Sec]));
-	    _ ->
-		"Not found"
-	end,
     io:format("   ~w:~n"
 	      "      Vsn:          ~s~n"
 	      "      App vsn:      ~s~n"
 	      "      ASN.1 vsn:    ~s~n"
-	      "      Compiler ver: ~s~n"
-	      "      Compile time: ~s~n", 
-	      [Module, Vsn, AppVsn, Asn1Vsn, CompVer, CompDate]),
+	      "      Compiler ver: ~s~n",
+	      [Module, Vsn, AppVsn, Asn1Vsn, CompVer]),
     ok.
-    
-    
+
+
 
 key1search(Key, Vals) ->
     case lists:keysearch(Key, 1, Vals) of
@@ -691,11 +681,9 @@ mod_version_info(Mod) ->
     {value, {app_vsn,    AppVsn}} = lists:keysearch(app_vsn,    1, Attr),
     {value, {compile,    Comp}}   = lists:keysearch(compile,    1, Info),
     {value, {version,    Ver}}    = lists:keysearch(version,    1, Comp),
-    {value, {time,       Time}}   = lists:keysearch(time,       1, Comp),
     {Mod, [{vsn,              Vsn}, 
 	   {app_vsn,          AppVsn}, 
-	   {compiler_version, Ver}, 
-	   {compile_time,     Time}]}.
+	   {compiler_version, Ver}]}.
 
 sys_info() ->
     SysArch = string:strip(erlang:system_info(system_architecture),right,$\n),

--- a/lib/snmp/src/app/snmp.erl
+++ b/lib/snmp/src/app/snmp.erl
@@ -1,8 +1,8 @@
-%% 
+%%
 %% %CopyrightBegin%
-%% 
-%% Copyright Ericsson AB 1996-2020. All Rights Reserved.
-%% 
+%%
+%% Copyright Ericsson AB 1996-2022. All Rights Reserved.
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,9 +14,9 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
-%% 
+%%
 -module(snmp).
 
 
@@ -608,13 +608,7 @@ mod_version_info(Mod) ->
 			 [{compiler_version, Ver}];
 		     not_found ->
 			 []
-		 end ++
-		     case key1search(time, Comp) of
-			 {value, Ver} ->
-			     [{compile_time, Ver}];
-			 not_found ->
-			     []
-		     end;
+		 end;
 	     not_found ->
 		 []
 	 end ++

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1996-2021. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2022. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -840,12 +840,9 @@ bi(I) ->
 m(M) ->
     L = M:module_info(),
     {exports,E} = lists:keyfind(exports, 1, L),
-    Time = get_compile_time(L),
     COpts = get_compile_options(L),
     format("Module: ~w~n", [M]),
     print_md5(L),
-    format("Compiled: "),
-    print_time(Time),
     print_object_file(M),
     format("Compiler options:  ~p~n", [COpts]),
     format("Exports: ~n",[]), print_exports(keysort(1, E)).
@@ -862,12 +859,6 @@ print_md5(L) ->
     case lists:keyfind(md5, 1, L) of
         {md5,<<MD5:128>>} -> io:format("MD5: ~.16b~n",[MD5]);
         _ -> ok
-    end.
-
-get_compile_time(L) ->
-    case get_compile_info(L, time) of
-	{ok,Val} -> Val;
-	error -> notime
     end.
 
 get_compile_options(L) ->
@@ -909,25 +900,6 @@ split_print_exports([{F1, A1}|T1], [{F2, A2} | T2]) ->
     format("~-30ts~tw/~w~n", [Str, F2, A2]),
     split_print_exports(T1, T2);
 split_print_exports([], []) -> ok.
-
-print_time({Year,Month,Day,Hour,Min,_Secs}) ->
-    format("~s ~w ~w, ", [month(Month),Day,Year]),
-    format("~.2.0w:~.2.0w~n", [Hour,Min]);
-print_time(notime) ->
-    format("No compile time info available~n",[]).
-
-month(1) -> "January";
-month(2) -> "February";
-month(3) -> "March";
-month(4) -> "April";
-month(5) -> "May";
-month(6) -> "June";
-month(7) -> "July";
-month(8) -> "August";
-month(9) -> "September";
-month(10) -> "October";
-month(11) -> "November";
-month(12) -> "December".
 
 %% Just because we can't eval receive statements...
 -spec flush() -> 'ok'.


### PR DESCRIPTION
Here is a PR inspired by https://github.com/erlang/otp/commit/b58478b9d3e2433ebb20d9af362f174333631bec which removed an occurence of the old `compile time` info.

While preparing #5589 I detected a few more similar leftover cases so I'm proposing to remove those as well to complete the clean-up. I'm not sure if this is a good candidate for `maint` or for `master` though.
