### PR TITLE
Eliminate confusing `case_clause` exception

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -264,7 +264,7 @@ body(Cs0, Name, Arity, St0) ->
     Args = reverse(Args0),                      %Nicer order
     {Cs1,St2} = clauses(Cs0, St1),
     {Ps,St3} = new_vars(Arity, St2),    %Need new variables here
-    Fc = function_clause(Ps, Anno),
+    Fc = function_clause(Ps, FunAnno),
     {#ifun{anno=#a{anno=FunAnno},id=[],vars=Args,clauses=Cs1,fc=Fc},St3}.
 
 %% clause(Clause, State) -> {Cclause,State}.

--- a/lib/compiler/test/beam_except_SUITE.erl
+++ b/lib/compiler/test/beam_except_SUITE.erl
@@ -135,13 +135,17 @@ coverage(_) ->
     {'EXIT',{function_clause,[{?MODULE,foobar,[[fail],1,2],
                                [{file,"fake.erl"},{line,16}]}|_]}} =
         (catch foobar([fail], 1, 2)),
+
     {'EXIT',{function_clause,[{?MODULE,fake_function_clause1,[{a,b},42.0],_}|_]}} =
         (catch fake_function_clause1({a,b})),
 
     {'EXIT',{function_clause,[{?MODULE,fake_function_clause2,[42|bad_tl],_}|_]}} =
         (catch fake_function_clause2(42, bad_tl)),
+
     {'EXIT',{function_clause,[{?MODULE,fake_function_clause3,[x,y],_}|_]}} =
         (catch fake_function_clause3(42, id([x,y]))),
+
+    {'EXIT',{{function_clause,a,b,c}, _}} = catch fake_function_clause4(),
 
     {'EXIT',{{badmatch,0.0},_}} = (catch coverage_1(id(42))),
     {'EXIT',{badarith,_}} = (catch coverage_1(id(a))),
@@ -153,8 +157,12 @@ coverage_1(X) ->
     true = 0 / X.
 
 fake_function_clause1(A) -> error(function_clause, [A,42.0]).
+
 fake_function_clause2(A, Tl) -> error(function_clause, [A|Tl]).
+
 fake_function_clause3(_, Stk) -> error(function_clause, Stk).
+
+fake_function_clause4() -> error({function_clause,a,b,c}).
 
 binary_construction_allocation(_Config) ->
     ok = do_binary_construction_allocation("PUT"),

--- a/lib/compiler/test/bs_match_SUITE.erl
+++ b/lib/compiler/test/bs_match_SUITE.erl
@@ -1468,10 +1468,11 @@ haystack_2(Haystack) ->
 fc({'EXIT',{function_clause,_}}) -> ok;
 fc({'EXIT',{{case_clause,_},_}}) when ?MODULE =:= bs_match_inline_SUITE -> ok.
 
-fc(Name, Args, {'EXIT',{function_clause,[{?MODULE,Name,Args,_}|_]}}) -> ok;
-fc(_, Args, {'EXIT',{{case_clause,ActualArgs},_}})
+fc(Name, Args, {'EXIT',{function_clause,[{?MODULE,Name,Args,_}|_]}}) ->
+    ok;
+fc(Name, Args, {'EXIT',{function_clause,[{?MODULE,_,Args,_}|_]}})
   when ?MODULE =:= bs_match_inline_SUITE ->
-    Args = tuple_to_list(ActualArgs).
+    ok.
 
 %% Cover the clause handling bs_context to binary in
 %% beam_block:initialized_regs/2.

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -3070,5 +3070,4 @@ check(F, Result) ->
 	    ct:fail(check_failed)
     end.
 
-fc({'EXIT',{function_clause,_}}) -> ok;
-fc({'EXIT',{{case_clause,_},_}}) when ?MODULE =:= guard_inline_SUITE -> ok.
+fc({'EXIT',{function_clause,_}}) -> ok.

--- a/lib/compiler/test/inline_SUITE.erl
+++ b/lib/compiler/test/inline_SUITE.erl
@@ -332,7 +332,7 @@ badarg(Reply, _A) ->
     Reply.
 
 otp_7223(Config) when is_list(Config) ->
-    {'EXIT', {{case_clause,{1}},_}} = (catch otp_7223_1(1)),
+    {'EXIT', {function_clause, [{?MODULE,_,[1],_}|_]}} = (catch otp_7223_1(1)),
     ok.
 
 -compile({inline,[{otp_7223_1,1}]}).


### PR DESCRIPTION
Consider this module:

    -module(bug).
    -export([foo/0]).

    foo() ->
        fun(a) -> ok end(b).

The call to the fun will always fail, which will be noted by
the compiler:

    1> c(bug).
    bug.erl:5:5: Warning: no clause will ever match
    %    5|     fun(a) -> ok end(b).
    %     |     ^

    {ok,bug}

What is unexpected is that the exception that is raised is not
a `function_clause` exception:

    2> bug:foo().
    ** exception error: no case clause matching {b}
         in function  bug:foo/0 (bug.erl, line 5)

This confusing `case_clause` exception started to appear in OTP 24
because of 72675baaa9fd30 (#4545) that inlines funs that are
immediately used.

Before OTP 24, when the fun was not inlined, the exception would be:

    2> bug:foo().
    ** exception error: no function clause matching bug:'-foo/0-fun-0-'(b) (bug.erl, line 5)

The reason that `function_clause` exceptions are rewritten to
`case_clause` exceptions in inlined code is to avoid the even more
confusing and misleading exception:

    2> bug:foo().
    ** exception error: no function clause matching bug:foo(b) (bug.erl, line 5)

This is confusing because it seems that `foo/0` was called with one argument.

To reduce the confusion, this pull request ensures that `function_clause` exceptions in
inlined code remains `function_clause` exceptions, but with a generated name that
makes it clear that the `function_clause` exception occurred in a fun:

    2> bug:foo().
    ** exception error: no function clause matching bug:'-foo/0-inlined-0-'(b) (bug.erl, line 5)

Fixes #5513