### PR TITLE
public_key,ssl: add password fun for decoding keyfiles

### DIFF
--- a/lib/public_key/doc/src/public_key.xml
+++ b/lib/public_key/doc/src/public_key.xml
@@ -418,6 +418,7 @@
     entries. Notice that if the PEM entry is of type
     'SubjectPublickeyInfo', it is further decoded to an
     <c>rsa_public_key()</c> or <c>dsa_public_key()</c>.</p>
+    <p>Password can be either an octet string or function which returns same type.</p>
   </desc> 
   </func>
 

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -241,8 +241,11 @@ pem_entry_decode({Asn1Type, Der, not_encrypted}) when is_atom(Asn1Type),
 						      is_binary(Der) ->
     der_decode(Asn1Type, Der).
 
--spec pem_entry_decode(PemEntry, Password) -> term() when PemEntry :: pem_entry(),
-                                                          Password :: string() .
+-spec pem_entry_decode(PemEntry, Password) -> term() when
+      PemEntry :: pem_entry(),
+      Password :: string() | fun(() -> string()).
+pem_entry_decode(PemEntry, PasswordFun) when is_function(PasswordFun) ->
+     pem_entry_decode(PemEntry, PasswordFun());
 pem_entry_decode({Asn1Type, Der, not_encrypted}, _) when is_atom(Asn1Type),
 							 is_binary(Der) ->
     der_decode(Asn1Type, Der);
@@ -264,8 +267,7 @@ pem_entry_decode({Asn1Type, CryptDer, {Cipher, Salt}} = PemEntry,
 				is_binary(Salt) andalso
 				((erlang:byte_size(Salt) == 8) or (erlang:byte_size(Salt) == 16)) andalso
 				is_list(Password) ->
-    do_pem_entry_decode(PemEntry, Password).	
-
+    do_pem_entry_decode(PemEntry, Password).
 
 %%--------------------------------------------------------------------
 %%

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -358,11 +358,11 @@
     <datatype>
       <name name="key_password"/>
       <desc>
-	<p>String containing the user's password. Only used if the 
+	<p>String containing the user's password or a function returning same type. Only used if the
 	private keyfile is password-protected.</p>
       </desc>
     </datatype>
-    
+
     <datatype>
       <name name="cipher_suites"/>
       <desc>

--- a/lib/ssl/src/ssl_config.erl
+++ b/lib/ssl/src/ssl_config.erl
@@ -43,7 +43,7 @@
 init(#{erl_dist := ErlDist,
        key := Key,
        keyfile := KeyFile,
-       password := Password,
+       password := Password, %% Can be fun() or string()
        dh := DH,
        dhfile := DHFile} = SslOpts, Role) ->
     

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -2621,7 +2621,8 @@ check_random_nonce(Config) when is_list(Config) ->
     Randoms = lists:flatten([ssl_test_lib:get_result([Server, Client]) ||
                                 {Server, Client} <- ConnectionPairs]),
     Deltas = [abs(FourBytes - SecsSince) ||
-                 {_Id, {_, <<FourBytes:32, _/binary>>}, SecsSince} <- Randoms],
+                 {_FromPid,
+                  {_Id, {_, <<FourBytes:32, _/binary>>}, SecsSince}} <- Randoms],
     MeanDelta = lists:sum(Deltas) div N,
     case ?config(version, Config) of
         'tlsv1.3' ->


### PR DESCRIPTION
Implementing password fun option for ssl connect API

This change allows password option to accept as a value
either a string or a fun. Added specific tests and
documentation.

The motivation for this change is to better protect a
private key. If the private key is protected by password the
password may be retreived using user supplied function therefore
enabling storing password in a secure vault or something similar.

This replaces #5320