### PR TITLE
Add filelib:ensure_path/1

### DIFF
--- a/lib/stdlib/doc/src/filelib.xml
+++ b/lib/stdlib/doc/src/filelib.xml
@@ -108,6 +108,20 @@
     </func>
 
     <func>
+      <name name="ensure_path" arity="1" since=""/>
+      <fsummary>Ensure that all parent directories for a target directory exist.</fsummary>
+      <desc>
+        <p>Ensures that all parent directories for the specified path <c><anno>Path</anno></c>
+          exist, trying to create them if necessary.</p>
+	    <p>Unlike <seemfa marker="#ensure_dir/1"><c>ensure_dir/1</c></seemfa>, this function will attempt
+        to create all path segments as a directory, including the last segment.</p>
+        <p>Returns <c>ok</c> if all parent directories already exist
+          or can be created. Returns <c>{error, <anno>Reason</anno>}</c> if
+          some parent directory does not exist and cannot be created.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="file_size" arity="1" since=""/>
       <fsummary>Return the size in bytes of a file.</fsummary>
       <desc>

--- a/lib/stdlib/test/filelib_SUITE.erl
+++ b/lib/stdlib/test/filelib_SUITE.erl
@@ -25,6 +25,8 @@
 	 init_per_testcase/2,end_per_testcase/2,
 	 wildcard_one/1,wildcard_two/1,wildcard_errors/1,
 	 fold_files/1,otp_5960/1,ensure_dir_eexist/1,ensure_dir_symlink/1,
+     ensure_path_single_dir/1, ensure_path_nested_dirs/1,ensure_path_binary_args/1, ensure_path_symlink/1,
+     ensure_path_relative_path/1, ensure_path_relative_path_dot_dot/1, ensure_path_invalid_path/1,
 	 wildcard_symlink/1, is_file_symlink/1, file_props_symlink/1,
          find_source/1, find_source_subdir/1, find_source_otp/1,
          safe_relative_path/1, safe_relative_path_links/1]).
@@ -49,7 +51,9 @@ suite() ->
 all() -> 
     [wildcard_one, wildcard_two, wildcard_errors,
      fold_files, otp_5960, ensure_dir_eexist, ensure_dir_symlink,
-     wildcard_symlink, is_file_symlink, file_props_symlink,
+     ensure_path_single_dir, ensure_path_nested_dirs, ensure_path_binary_args,
+     ensure_path_symlink, ensure_path_relative_path, ensure_path_relative_path_dot_dot, 
+     ensure_path_invalid_path, wildcard_symlink, is_file_symlink, file_props_symlink,
      find_source, find_source_subdir, find_source_otp,
      safe_relative_path, safe_relative_path_links].
 
@@ -447,6 +451,75 @@ ensure_dir_symlink(Config) when is_list(Config) ->
     ok = file:write_file(Name, <<"some string\n">>),
     %% With a symlink to the directory.
     Symlink = filename:join(PrivDir, "ensure_dir_symlink_link"),
+    case file:make_symlink(Dir, Symlink) of
+        {error,enotsup} ->
+            {skip,"Symlinks not supported on this platform"};
+        {error,eperm} ->
+            {win32,_} = os:type(),
+            {skip,"Windows user not privileged to create symlinks"};
+        ok ->
+            SymlinkedName = filename:join(Symlink, "same_name_as_file_and_dir"),
+            ok = filelib:ensure_dir(SymlinkedName)
+    end.
+
+ensure_path_single_dir(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    Dir = filename:join(PrivDir, "ensure_path_single_dir"),
+    ok = filelib:ensure_path(Dir),
+    true = filelib:is_dir(Dir).
+
+ensure_path_nested_dirs(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    BaseDir = filename:join(PrivDir, "ensure_path_nested_dirs"),
+    Path = filename:join(BaseDir, "foo/bar/baz"),
+    ok = filelib:ensure_path(Path),
+    true = filelib:is_dir(Path).
+
+ensure_path_binary_args(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    BaseDir = filename:join(PrivDir, "ensure_path_binary_args"),
+    Path = filename:join(BaseDir, "foo/bar/baz"),
+    ok = filelib:ensure_path(list_to_binary(Path)),
+    true = filelib:is_dir(Path).
+
+ensure_path_invalid_path(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    BaseDir = filename:join(PrivDir, "ensure_path_invalid_path"),
+    ok = filelib:ensure_path(BaseDir),
+    FileName =  filename:join(BaseDir, "foo"),
+    ok = file:write_file(FileName, <<"eh?\n">>),
+    Path = filename:join(FileName, "foo/bar/baz"),
+    {error,enotdir} = filelib:ensure_path(Path),
+    false = filelib:is_dir(Path).
+
+ensure_path_relative_path(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    BaseDir = filename:join(PrivDir, "ensure_path_relative_path"),
+    ok = filelib:ensure_path(BaseDir),
+    file:set_cwd(BaseDir),
+    Path = filename:join(BaseDir, "foo/bar/baz"),
+    ok = filelib:ensure_path("foo/bar/baz"),
+    true = filelib:is_dir(Path).
+
+ensure_path_relative_path_dot_dot(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    BaseDir = filename:join(PrivDir, "ensure_path_relative_path"),
+    SubDir = filename:join(BaseDir, "dot_dot"),
+    ok = filelib:ensure_path(SubDir),
+    file:set_cwd(SubDir),
+    Path = filename:join(BaseDir, "foo/bar/baz"),
+    erlang:display(Path),
+    ok = filelib:ensure_path("../foo/bar/baz"),
+    true = filelib:is_dir(Path).
+
+ensure_path_symlink(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    Dir = filename:join(PrivDir, "ensure_path_symlink"),
+    Name = filename:join(Dir, "same_name_as_file_and_dir"),
+    ok = filelib:ensure_path(Dir),
+    ok = file:write_file(Name, <<"some string\n">>),
+    %% With a symlink to the directory.
+    Symlink = filename:join(PrivDir, "ensure_path_symlink_link"),
     case file:make_symlink(Dir, Symlink) of
         {error,enotsup} ->
             {skip,"Symlinks not supported on this platform"};


### PR DESCRIPTION
This commit adds `ensure_path/1` to `filelib`. Unlike `ensure_dir/1` this will always create the last path segment, `mkdir -p` style. 

In the wild you will find lots of implementations of this function, mostly using `ensure_dir/1` for a side effect to produce this behavior. Specifically, `filelib:ensure_dir("/some/path/" ++ "some_file_i_will_not_actually_create")`. 

I have left two implementations in the source code, one which is completely unrelated to `ensure_dir/1` and one which makes use of `ensure_dir/1` (this one is commented out).  I don't have strong feelings as to which implementation should be favored, but if it were up to me I'd go with the uncommitted version. It seems like duplicate code, but as mentioned, the functionality is different. 

I will glady add tests and docs if OTP would accept this PR. 

Edit:

Note I did do a version of `filelib:ensure_dir/2`, but I felt that made for a very strange API and would lead to confusing documentation. 

Edit:

We could also simply call `ensure_dir(filename:join(Path, "fake_file")))` but IMO it feels odd, but I would not be against it either. Likewise, an alternative name for the function `ensure_path/1` could be `mkdir_p/1`  