### PR TITLE
Hans/update deprecations script

### DIFF
--- a/lib/stdlib/scripts/update_deprecations
+++ b/lib/stdlib/scripts/update_deprecations
@@ -238,9 +238,7 @@ make_xml(Top, Type, OutFile, InfoText0) ->
     Collected = make_xml_collect(Depr, RelKey, InfoTextMap, []),
 
     All = make_xml_gen(lists:reverse(Collected), Type, OutDir),
-    file:write_file(OutFile, All),
-
-    ok.
+    ok = file:write_file(OutFile, All).
 
 make_xml_info([{Tag,M,F,A,Text} | Attributes], Tag) ->
     [{{M,F,A}, info_string(Text)} | make_xml_info(Attributes, Tag)];

--- a/lib/stdlib/scripts/update_deprecations
+++ b/lib/stdlib/scripts/update_deprecations
@@ -243,7 +243,7 @@ make_xml(Top, Type, OutFile, InfoText0) ->
     ok.
 
 make_xml_info([{Tag,M,F,A,Text} | Attributes], Tag) ->
-    [{{M,F,A}, Text} | make_xml_info(Attributes, Tag)];
+    [{{M,F,A}, info_string(Text)} | make_xml_info(Attributes, Tag)];
 make_xml_info([_ | Attributes], Tag) ->
     make_xml_info(Attributes, Tag);
 make_xml_info([], _Tag) ->


### PR DESCRIPTION
The update deprecation's script didn't handle `-deprecated([f/1])` without text correctly.  Without text, an atom 'undefined' slipped through where there should have been a string with a default text.