### PR TITLE
ssl: Do not exclude legacy suite

### DIFF
--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -807,7 +807,7 @@ des_exclusive(_) ->
 %% Are not considered secure any more.
 %%--------------------------------------------------------------------
 rsa_suites({3, 3}) ->
-    rsa_exclusive(3) ++ rsa_exclusive(1) -- [?TLS_RSA_WITH_3DES_EDE_CBC_SHA];
+    rsa_exclusive(3) ++ rsa_exclusive(1);
 rsa_suites({3, 2}) ->
     rsa_exclusive(1);
 rsa_suites({3, 1}) ->


### PR DESCRIPTION
Before TLS-1.3 cipher suites from previous versions are inclusive.
No rsa suites are included as default values so this function
should list all still possible rsa suites.