### PR TITLE
stdlib: Allow erlang to be started without HOME set

### DIFF
--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -792,12 +792,12 @@ lm() ->
 -spec erlangrc() -> {ok, file:filename()} | {error, term()}.
 
 erlangrc() ->
-    UserConfig = filename:basedir(user_config,"erlang"),
     case init:get_argument(home) of
         {ok,[[Home]]} ->
+            UserConfig = filename:basedir(user_config,"erlang"),
             erlangrc([Home, UserConfig]);
         _ ->
-            erlangrc([UserConfig])
+            {error, enoent}
     end.
 
 -spec erlangrc(PathList) -> {ok, file:filename()} | {error, term()}


### PR DESCRIPTION
It should be possible to strat erlang without having a home
and the call to filename:basedir crashes if no home is set.