### PR TITLE
Reduce compile time for huge straight-line functions

### DIFF
--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -785,6 +785,9 @@ dom_intersection([S], _Df) ->
 dom_intersection([S|Ss], Df) ->
     dom_intersection(S, Ss, Df).
 
+dom_intersection([0]=S, [_|_], _Df) ->
+    %% No need to continue. (We KNOW that all sets end in [0].)
+    S;
 dom_intersection(S1, [S2|Ss], Df) ->
     dom_intersection(dom_intersection_1(S1, S2, Df), Ss, Df);
 dom_intersection(S, [], _Df) -> S.
@@ -793,11 +796,12 @@ dom_intersection_1([E1|Es1]=Set1, [E2|Es2]=Set2, Df) ->
     %% Blocks are numbered in the order they are found in
     %% reverse postorder.
     #{E1:=Df1,E2:=Df2} = Df,
-    if Df1 > Df2 ->
+    if
+        Df1 > Df2 ->
             dom_intersection_1(Es1, Set2, Df);
-       Df2 > Df1 ->
-            dom_intersection_1(Es2, Set1, Df);  %switch arguments!
-       true ->                                  %Set1 == Set2
+        Df2 > Df1 ->
+            dom_intersection_1(Es2, Set1, Df);  %switch arguments
+        true ->                                  %Set1 == Set2
             %% The common suffix of the sets is the intersection.
             Set1
     end.

--- a/lib/compiler/src/beam_ssa_pre_codegen.erl
+++ b/lib/compiler/src/beam_ssa_pre_codegen.erl
@@ -1783,7 +1783,7 @@ find_yregs(#st{frames=[_|_]=Frames,args=Args,ssa=Blocks0}=St) ->
 
 find_yregs_1([{F,Defs}|Fs], Blocks0) ->
     DK = #dk{d=Defs,k=sets:new([{version, 2}])},
-    D0 = #{F=>DK},
+    D0 = #{F => DK,?EXCEPTION_BLOCK => DK#dk{d=[]}},
     Ls = beam_ssa:rpo([F], Blocks0),
     Yregs0 = sets:new([{version, 2}]),
     Yregs = find_yregs_2(Ls, Blocks0, D0, Yregs0),
@@ -1836,6 +1836,8 @@ find_defs_is([#b_set{dst=Dst}|Is], Acc) ->
     find_defs_is(Is, [Dst|Acc]);
 find_defs_is([], Acc) -> Acc.
 
+find_update_succ([?EXCEPTION_BLOCK|Ss], DK, D) ->
+    find_update_succ(Ss, DK, D);
 find_update_succ([S|Ss], #dk{d=Defs0,k=Killed0}=DK0, D0) ->
     case D0 of
         #{S:=#dk{d=Defs1,k=Killed1}} ->


### PR DESCRIPTION
This pull request makes the `beam_ssa_pre_codegen` pass of the compiler about 4 times faster for the example in #5140.