### PR TITLE
ets: Rename and export some types

### DIFF
--- a/erts/preloaded/src/erts_internal.erl
+++ b/erts/preloaded/src/erts_internal.erl
@@ -797,7 +797,7 @@ spawn_system_process(_Mod, _Func, _Args) ->
 %%
 
 -spec ets_lookup_binary_info(Tab, Key) -> BinInfo when
-      Tab :: ets:tab(),
+      Tab :: ets:table(),
       Key :: term(),
       BinInfo :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}].
 
@@ -811,20 +811,20 @@ ets_super_user(_Bool) ->
     erlang:nif_error(undef).
 
 -spec ets_raw_first(Tab) -> term() when
-      Tab :: ets:tab().
+      Tab :: ets:table().
 
 ets_raw_first(_Tab) ->
     erlang:nif_error(undef).
     
 -spec ets_raw_next(Tab, Key) -> term() when
-      Tab :: ets:tab(),
+      Tab :: ets:table(),
       Key :: term().
 
 ets_raw_next(_Tab, _Key) ->
     erlang:nif_error(undef).
 
 -spec ets_info_binary(Tab) -> BinInfo when
-      Tab :: ets:tab(),
+      Tab :: ets:table(),
       BinInfo :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}].
 
 ets_info_binary(Tab) ->

--- a/lib/kernel/src/auth.erl
+++ b/lib/kernel/src/auth.erl
@@ -45,7 +45,7 @@
 -type cookie() :: atom().
 -record(state, {
 	  our_cookie    :: cookie(),  %% Our own cookie
-	  other_cookies :: ets:tab()  %% The send-cookies of other nodes
+	  other_cookies :: ets:table()%% The send-cookies of other nodes
 	 }).
 -type state() :: #state{}.
 

--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -42,8 +42,8 @@
 -record(state, {supervisor :: pid(),
 		root :: file:name_all(),
 		path :: [file:name_all()],
-		moddb :: ets:tab(),
-		namedb :: ets:tab(),
+		moddb :: ets:table(),
+		namedb :: ets:table(),
 		mode = interactive :: 'interactive' | 'embedded',
 		on_load = [] :: [on_load_item()]}).
 -type state() :: #state{}.

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -283,7 +283,7 @@ true
 
   <datatypes>
     <datatype>
-      <name name="access"/>
+      <name name="table_access"/>
     </datatype>
     <datatype>
       <name>continuation()</name>
@@ -297,17 +297,17 @@ true
     </datatype>
     <datatype>
       <name name="match_spec"/>
-      <desc><p>A match specification, see above.</p></desc>
+      <desc><p>A match specification, see <seeerl marker="#match_spec">Match Specifications</seeerl>.</p></desc>
     </datatype>
     <datatype>
-      <name name="comp_match_spec"/>
+      <name name="compiled_match_spec"/>
       <desc><p>A compiled match specification.</p></desc>
     </datatype>
     <datatype>
       <name name="match_pattern"/>
     </datatype>
     <datatype>
-      <name name="tab"/>
+      <name name="table"/>
     </datatype>
     <datatype>
       <name name="tid"/>
@@ -315,7 +315,7 @@ true
       <seemfa marker="#new/2"><c>new/2</c></seemfa>.</p></desc>
     </datatype>
     <datatype>
-      <name name="type"/>
+      <name name="table_type"/>
     </datatype>
   </datatypes>
 
@@ -339,7 +339,7 @@ true
       <name name="delete" arity="1" since=""/>
       <fsummary>Delete an entire ETS table.</fsummary>
       <desc>
-        <p>Deletes the entire table <c><anno>Tab</anno></c>.</p>
+        <p>Deletes the entire table <c><anno>Table</anno></c>.</p>
       </desc>
     </func>
 
@@ -349,7 +349,7 @@ true
         table.</fsummary>
       <desc>
         <p>Deletes all objects with key <c><anno>Key</anno></c> from table
-          <c><anno>Tab</anno></c>.</p>
+          <c><anno>Table</anno></c>.</p>
       </desc>
     </func>
 
@@ -357,7 +357,7 @@ true
       <name name="delete_all_objects" arity="1" since=""/>
       <fsummary>Delete all objects in an ETS table.</fsummary>
       <desc>
-        <p>Delete all objects in the ETS table <c><anno>Tab</anno></c>.
+        <p>Delete all objects in the ETS table <c><anno>Table</anno></c>.
           The operation is guaranteed to be
           <seeerl marker="#concurrency">atomic and isolated</seeerl>.</p>
       </desc>
@@ -382,7 +382,7 @@ true
         <p>Reads a file produced by <seemfa marker="#tab2file/2">
           <c>tab2file/2</c></seemfa> or 
           <seemfa marker="#tab2file/3"><c>tab2file/3</c></seemfa> and
-          creates the corresponding table <c><anno>Tab</anno></c>.</p>
+          creates the corresponding table <c><anno>Table</anno></c>.</p>
         <p>Equivalent to <c>file2tab(<anno>Filename</anno>, [])</c>.</p>
       </desc>
     </func>
@@ -394,7 +394,7 @@ true
         <p>Reads a file produced by <seemfa marker="#tab2file/2">
           <c>tab2file/2</c></seemfa> or <seemfa marker="#tab2file/3">
           <c>tab2file/3</c></seemfa> and creates the
-          corresponding table <c><anno>Tab</anno></c>.</p>
+          corresponding table <c><anno>Table</anno></c>.</p>
         <p>The only supported option is <c>{verify,boolean()}</c>.
           If verification is turned on (by specifying <c>{verify,true}</c>),
           the function uses whatever information is present in the file to
@@ -424,7 +424,7 @@ true
       <fsummary>Return the first key in an ETS table.</fsummary>
       <desc>
         <p>Returns the first key <c><anno>Key</anno></c> in table
-          <c><anno>Tab</anno></c>. For an <c>ordered_set</c> table, the first
+          <c><anno>Table</anno></c>. For an <c>ordered_set</c> table, the first
           key in Erlang term order is returned. For other
           table types, the first key according to the internal
           order of the table is returned. If the table is empty,
@@ -554,8 +554,8 @@ Error: fun containing local Erlang function calls
       <fsummary>Change owner of a table.</fsummary>
       <desc>
         <p>Make process <c><anno>Pid</anno></c> the new owner of table
-          <c><anno>Tab</anno></c>. If successful, message
-          <c>{'ETS-TRANSFER',<anno>Tab</anno>,FromPid,<anno>GiftData</anno>}</c>
+          <c><anno>Table</anno></c>. If successful, message
+          <c>{'ETS-TRANSFER',<anno>Table</anno>,FromPid,<anno>GiftData</anno>}</c>
           is sent to the new owner.</p>
         <p>The process <c><anno>Pid</anno></c> must be alive, local, and not
           already the owner of the table.
@@ -580,7 +580,7 @@ Error: fun containing local Erlang function calls
       <name name="i" arity="1" since=""/>
       <fsummary>Browse an ETS table on a terminal.</fsummary>
       <desc>
-        <p>Browses table <c><anno>Tab</anno></c> on a terminal.</p>
+        <p>Browses table <c><anno>Table</anno></c> on a terminal.</p>
       </desc>
     </func>
 
@@ -588,10 +588,10 @@ Error: fun containing local Erlang function calls
       <name name="info" arity="1" since=""/>
       <fsummary>Return information about an <c>table</c>.</fsummary>
       <desc>
-        <p>Returns information about table <c><anno>Tab</anno></c> as a list of
-          tuples. If <c><anno>Tab</anno></c> has the correct type
+        <p>Returns information about table <c><anno>Table</anno></c> as a list of
+          tuples. If <c><anno>Table</anno></c> has the correct type
           for a table identifier, but does not refer to an existing ETS
-          table, <c>undefined</c> is returned. If <c><anno>Tab</anno></c> is
+          table, <c>undefined</c> is returned. If <c><anno>Table</anno></c> is
           not of the correct type, a <c>badarg</c> exception is raised.</p>
         <taglist>
           <tag><c>{compressed, boolean()}</c></tag>
@@ -637,7 +637,7 @@ Error: fun containing local Erlang function calls
           <item>
             <p>The pid of the owner of the table.</p>
           </item>
-          <tag><c>{protection,</c> <seetype marker="#access">
+          <tag><c>{protection,</c> <seetype marker="#table_access">
               <c>access()</c></seetype><c>}</c></tag>
           <item>
             <p>The table access rights.</p>
@@ -646,7 +646,7 @@ Error: fun containing local Erlang function calls
           <item>
             <p>The number of objects inserted in the table.</p>
           </item>
-          <tag><c>{type,</c> <seetype marker="#type">
+          <tag><c>{type,</c> <seetype marker="#table_type">
               <c>type()</c></seetype><c>}</c></tag>
           <item>
             <p>The table type.</p>
@@ -677,9 +677,9 @@ Error: fun containing local Erlang function calls
         an ETS table.</fsummary>
       <desc>
         <p>Returns the information associated with <c>Item</c> for table
-          <c><anno>Tab</anno></c>, or returns <c>undefined</c> if <c>Tab</c>
+          <c><anno>Table</anno></c>, or returns <c>undefined</c> if <c>Table</c>
           does not refer an existing ETS table. If
-          <c><anno>Tab</anno></c> is
+          <c><anno>Table</anno></c> is
           not of the correct type, or if <c><anno>Item</anno></c> is not
           one of the allowed values, a <c>badarg</c> exception is raised.</p>
           <p>In addition to the <c>{<anno>Item</anno>,<anno>Value</anno>}</c>
@@ -769,7 +769,7 @@ Error: fun containing local Erlang function calls
       <name name="init_table" arity="2" since=""/>
       <fsummary>Replace all objects of an ETS table.</fsummary>
       <desc>
-        <p>Replaces the existing objects of table <c><anno>Tab</anno></c> with
+        <p>Replaces the existing objects of table <c><anno>Table</anno></c> with
           objects created by calling the input function
           <c><anno>InitFun</anno></c>,
           see below. This function is provided for compatibility with
@@ -801,7 +801,7 @@ Error: fun containing local Erlang function calls
       <desc>
         <p>Inserts the object or all of the objects in list
           <c><anno>ObjectOrObjects</anno></c> into table
-          <c><anno>Tab</anno></c>.</p>
+          <c><anno>Table</anno></c>.</p>
         <list type="bulleted">
           <item>
             <p>If the table type is <c>set</c> and the key of the inserted
@@ -880,7 +880,7 @@ Error: fun containing local Erlang function calls
         <c>ordered_set</c>.</fsummary>
       <desc>
         <p>Returns the last key <c><anno>Key</anno></c> according to Erlang
-          term order in table <c>Tab</c> of type <c>ordered_set</c>. For
+          term order in table <c>Table</c> of type <c>ordered_set</c>. For
           other table types, the function is synonymous to
           <seemfa marker="#first/1"><c>first/1</c></seemfa>.
           If the table is empty, <c>'$end_of_table'</c> is returned.</p>
@@ -895,7 +895,7 @@ Error: fun containing local Erlang function calls
       </fsummary>
       <desc>
         <p>Returns a list of all objects with key <c><anno>Key</anno></c> in
-          table <c><anno>Tab</anno></c>.</p>
+          table <c><anno>Table</anno></c>.</p>
         <list type="bulleted">
           <item>
             <p>For tables of type <c>set</c>, <c>bag</c>, or
@@ -934,7 +934,7 @@ Error: fun containing local Erlang function calls
       <fsummary>Return the <c>Pos</c>:th element of all objects with a
         specified key in an ETS table.</fsummary>
       <desc>
-        <p>For a table <c><anno>Tab</anno></c> of type <c>set</c> or
+        <p>For a table <c><anno>Table</anno></c> of type <c>set</c> or
           <c>ordered_set</c>, the function returns the
           <c><anno>Pos</anno></c>:th
           element of the object with key <c><anno>Key</anno></c>.</p>
@@ -971,7 +971,7 @@ Error: fun containing local Erlang function calls
       <fsummary>Match the objects in an ETS table against a pattern.
       </fsummary>
       <desc>
-        <p>Matches the objects in table <c><anno>Tab</anno></c> against
+        <p>Matches the objects in table <c><anno>Table</anno></c> against
           pattern <c><anno>Pattern</anno></c>.</p>
         <p>A pattern is a term that can contain:</p>
         <list type="bulleted">
@@ -1026,7 +1026,7 @@ Error: fun containing local Erlang function calls
         ETS table.</fsummary>
       <desc>
         <p>Deletes all objects that match pattern <c><anno>Pattern</anno></c>
-          from table <c><anno>Tab</anno></c>. For a description of patterns,
+          from table <c><anno>Table</anno></c>. For a description of patterns,
           see <seemfa marker="#match/2"><c>match/2</c></seemfa>.</p>
       </desc>
     </func>
@@ -1051,7 +1051,7 @@ Error: fun containing local Erlang function calls
       <fsummary>Match the objects in an ETS table against a pattern.
       </fsummary>
       <desc>
-        <p>Matches the objects in table <c><anno>Tab</anno></c> against
+        <p>Matches the objects in table <c><anno>Table</anno></c> against
           pattern <c><anno>Pattern</anno></c>. For a description of patterns,
           see <seemfa marker="#match/2"><c>match/2</c></seemfa>.
           The function returns a list of all objects that
@@ -1392,7 +1392,7 @@ ets:select(Table, MatchSpec),</code>
       <fsummary>Return the next key in an ETS table.</fsummary>
       <desc>
         <p>Returns the next key <c><anno>Key2</anno></c>, following key
-          <c><anno>Key1</anno></c> in table <c><anno>Tab</anno></c>. For table
+          <c><anno>Key1</anno></c> in table <c><anno>Table</anno></c>. For table
           type <c>ordered_set</c>, the next key in Erlang term order is
           returned. For other table types, the next key
           according to the internal order of the table is returned. If no
@@ -1417,7 +1417,7 @@ ets:select(Table, MatchSpec),</code>
       <desc>
         <p>Returns the previous key <c><anno>Key2</anno></c>, preceding key
           <c><anno>Key1</anno></c> according to Erlang term order in table
-          <c><anno>Tab</anno></c> of type <c>ordered_set</c>. For other
+          <c><anno>Table</anno></c> of type <c>ordered_set</c>. For other
           table types, the function is synonymous to
           <seemfa marker="#next/2"><c>next/2</c></seemfa>.
           If no previous key exists, <c>'$end_of_table'</c> is returned.</p>
@@ -1430,7 +1430,7 @@ ets:select(Table, MatchSpec),</code>
       <name name="rename" arity="2" since=""/>
       <fsummary>Rename a named ETS table.</fsummary>
       <desc>
-        <p>Renames the named table <c><anno>Tab</anno></c> to the new name
+        <p>Renames the named table <c><anno>Table</anno></c> to the new name
           <c><anno>Name</anno></c>. Afterwards, the old name cannot be used to
           access the table. Renaming an unnamed table has no effect.</p>
       </desc>
@@ -1502,9 +1502,9 @@ ets:select(ets:repair_continuation(MaybeBroken,MS)).</code>
 	<seemfa marker="#select/3"><c>select/3</c></seemfa> &amp;
 	<seemfa marker="#select/1"><c>select/1</c></seemfa>.</p>
         <p>A process fixes a table by calling
-          <c>safe_fixtable(<anno>Tab</anno>, true)</c>. The table remains
+          <c>safe_fixtable(<anno>Table</anno>, true)</c>. The table remains
           fixed until the process releases it by calling
-          <c>safe_fixtable(<anno>Tab</anno>, false)</c>, or until the process
+          <c>safe_fixtable(<anno>Table</anno>, false)</c>, or until the process
           terminates.</p>
         <p>If many processes fix a table, the table remains fixed
           until all processes have released it (or terminated).
@@ -1520,21 +1520,21 @@ ets:select(ets:repair_continuation(MaybeBroken,MS)).</code>
 	  <c>next/2</c> is called.</p>
         <p><em>Example:</em></p>
         <code type="none">
-clean_all_with_value(Tab,X) ->
-    safe_fixtable(Tab,true),
-    clean_all_with_value(Tab,X,ets:first(Tab)),
-    safe_fixtable(Tab,false).
+clean_all_with_value(Table,X) ->
+    safe_fixtable(Table,true),
+    clean_all_with_value(Table,X,ets:first(Table)),
+    safe_fixtable(Table,false).
 
-clean_all_with_value(Tab,X,'$end_of_table') ->
+clean_all_with_value(Table,X,'$end_of_table') ->
     true;
-clean_all_with_value(Tab,X,Key) ->
-    case ets:lookup(Tab,Key) of
+clean_all_with_value(Table,X,Key) ->
+    case ets:lookup(Table,Key) of
         [{Key,X}] ->
-            ets:delete(Tab,Key);
+            ets:delete(Table,Key);
         _ ->
             true
     end,
-    clean_all_with_value(Tab,X,ets:next(Tab,Key)).</code>
+    clean_all_with_value(Table,X,ets:next(Table,Key)).</code>
         <p>Notice that deleted objects are not freed from a
           fixed table until it has been released. If a process fixes a
           table but never releases it, the memory used by the deleted
@@ -1542,7 +1542,7 @@ clean_all_with_value(Tab,X,Key) ->
           the table also degrades significantly.</p>
         <p>To retrieve information about which processes have fixed which
           tables, use <seeerl marker="#info_2_safe_fixed_monotonic_time">
-          <c>info(Tab, safe_fixed_monotonic_time)</c></seeerl>. A system with
+          <c>info(Table, safe_fixed_monotonic_time)</c></seeerl>. A system with
           many processes fixing tables can need a monitor that sends alarms
           when tables have been fixed for too long.</p>
         <p>Notice that <c>safe_fixtable/2</c> is not necessary for table type
@@ -1570,7 +1570,7 @@ clean_all_with_value(Tab,X,Key) ->
       <fsummary>Match the objects in an ETS table against a
         match specification.</fsummary>
       <desc>
-        <p>Matches the objects in table <c><anno>Tab</anno></c> using a
+        <p>Matches the objects in table <c><anno>Table</anno></c> using a
           <seeerl marker="#match_spec">match specification</seeerl>.
           This is a more general call than
           <seemfa marker="#match/2"><c>match/2</c></seemfa> and
@@ -1599,23 +1599,23 @@ Result = "Term construct"</code>
           match variables in a list), so that the following
           <c>match/2</c> expression:</p>
         <code type="none">
-ets:match(Tab,{'$1','$2','$3'})</code>
+ets:match(Table,{'$1','$2','$3'})</code>
         <p>is exactly equivalent to:</p>
         <code type="none">
-ets:select(Tab,[{{'$1','$2','$3'},[],['$$']}])</code>
+ets:select(Table,[{{'$1','$2','$3'},[],['$$']}])</code>
         <p>And that the following <c>match_object/2</c> call:</p>
         <code type="none">
-ets:match_object(Tab,{'$1','$2','$1'})</code>
+ets:match_object(Table,{'$1','$2','$1'})</code>
         <p>is exactly equivalent to</p>
         <code type="none">
-ets:select(Tab,[{{'$1','$2','$1'},[],['$_']}])</code>
+ets:select(Table,[{{'$1','$2','$1'},[],['$_']}])</code>
         <p>Composite terms can be constructed in the <c>Result</c> part
           either by simply writing a list, so that the following code:</p>
         <code type="none">
-ets:select(Tab,[{{'$1','$2','$3'},[],['$$']}])</code>
+ets:select(Table,[{{'$1','$2','$3'},[],['$$']}])</code>
         <p>gives the same output as:</p>
         <code type="none">
-ets:select(Tab,[{{'$1','$2','$3'},[],[['$1','$2','$3']]}])</code>
+ets:select(Table,[{{'$1','$2','$3'},[],[['$1','$2','$3']]}])</code>
         <p>That is, all the bound variables in the match head as a list. If
           tuples are to be constructed, one has to write a tuple of
           arity 1 where the single element in the tuple is the tuple
@@ -1623,10 +1623,10 @@ ets:select(Tab,[{{'$1','$2','$3'},[],[['$1','$2','$3']]}])</code>
           for a <c>Guard</c>).</p>
         <p>Therefore the following call:</p>
         <code type="none">
-ets:select(Tab,[{{'$1','$2','$1'},[],['$_']}])</code>
+ets:select(Table,[{{'$1','$2','$1'},[],['$_']}])</code>
         <p>gives the same output as:</p>
         <code type="none">
-ets:select(Tab,[{{'$1','$2','$1'},[],[{{'$1','$2','$3'}}]}])</code>
+ets:select(Table,[{{'$1','$2','$1'},[],[{{'$1','$2','$3'}}]}])</code>
         <p>This syntax is equivalent to the syntax used in the trace
           patterns (see the
           <seeerl marker="runtime_tools:dbg">
@@ -1688,7 +1688,7 @@ is_integer(X), is_integer(Y), X + Y < 4711]]></code>
         specification and return the number of objects for which the match
         specification returned <c>true</c>.</fsummary>
       <desc>
-        <p>Matches the objects in table <c><anno>Tab</anno></c> using a
+        <p>Matches the objects in table <c><anno>Table</anno></c> using a
           <seeerl marker="#match_spec">match specification</seeerl>. If the
           match specification returns <c>true</c> for an object, that object
           considered a match and is counted. For any other result from
@@ -1707,7 +1707,7 @@ is_integer(X), is_integer(Y), X + Y < 4711]]></code>
         specification and delete objects where the match specification
         returns <c>true</c>.</fsummary>
       <desc>
-        <p>Matches the objects in table <c><anno>Tab</anno></c> using a
+        <p>Matches the objects in table <c><anno>Table</anno></c> using a
           <seeerl marker="#match_spec">match specification</seeerl>. If the
           match specification returns <c>true</c> for an object, that object is
           removed from the table. For any other result from the match
@@ -1729,7 +1729,7 @@ is_integer(X), is_integer(Y), X + Y < 4711]]></code>
       <name name="select_replace" arity="2" since="OTP 20.0"/>
       <fsummary>Match and replace objects atomically in an ETS table</fsummary>
       <desc>
-        <p>Matches the objects in the table <c><anno>Tab</anno></c> using a
+        <p>Matches the objects in the table <c><anno>Table</anno></c> using a
           <seeerl marker="#match_spec">match specification</seeerl>. For each
           matched object, the existing object is replaced with
           the match specification result.</p>
@@ -1847,7 +1847,7 @@ Success = (1 =:= ets:select_replace(T, [{Old, [], [{const, New}]}])),
           <c>first</c>/<c>next</c> or <c>last</c>/<c>prev</c> are to be used
           instead.</p>
         <p>Returns all objects in slot <c><anno>I</anno></c> of table
-          <c><anno>Tab</anno></c>. A table can be traversed by repeatedly
+          <c><anno>Table</anno></c>. A table can be traversed by repeatedly
           calling the function,
           starting with the first slot <c><anno>I</anno>=0</c> and
           ending when <c>'$end_of_table'</c> is returned.
@@ -1867,10 +1867,10 @@ Success = (1 =:= ets:select_replace(T, [{Old, [], [{const, New}]}])),
       <name name="tab2file" arity="2" since=""/>
       <fsummary>Dump an ETS table to a file.</fsummary>
       <desc>
-        <p>Dumps table <c><anno>Tab</anno></c> to file
+        <p>Dumps table <c><anno>Table</anno></c> to file
           <c><anno>Filename</anno></c>.</p>
         <p>Equivalent to
-          <c>tab2file(<anno>Tab</anno>, <anno>Filename</anno>,[])</c></p>
+          <c>tab2file(<anno>Table</anno>, <anno>Filename</anno>,[])</c></p>
       </desc>
     </func>
 
@@ -1878,7 +1878,7 @@ Success = (1 =:= ets:select_replace(T, [{Old, [], [{const, New}]}])),
       <name name="tab2file" arity="3" since=""/>
       <fsummary>Dump an ETS table to a file.</fsummary>
       <desc>
-        <p>Dumps table <c><anno>Tab</anno></c> to file
+        <p>Dumps table <c><anno>Table</anno></c> to file
           <c><anno>Filename</anno></c>.</p>
         <p>When dumping the table, some information about the table
           is dumped to a header at the beginning of the dump. This
@@ -1925,7 +1925,7 @@ Success = (1 =:= ets:select_replace(T, [{Old, [], [{const, New}]}])),
       <name name="tab2list" arity="1" since=""/>
       <fsummary>Return a list of all objects in an ETS table.</fsummary>
       <desc>
-        <p>Returns a list of all objects in table <c><anno>Tab</anno></c>.</p>
+        <p>Returns a list of all objects in table <c><anno>Table</anno></c>.</p>
       </desc>
     </func>
 
@@ -2019,7 +2019,7 @@ Success = (1 =:= ets:select_replace(T, [{Old, [], [{const, New}]}])),
           tables, Dets tables,
           and lists are also recognized by QLC as sources of
           data. Calling <c>table/1,2</c> is the means to make the
-          ETS table <c>Tab</c> usable to QLC.</p>
+          ETS table <c>Table</c> usable to QLC.</p>
         <p>When there are only simple restrictions on the key position,
           QLC uses <seemfa marker="#lookup/2"><c>lookup/2</c></seemfa>
           to look up the keys. When
@@ -2067,12 +2067,12 @@ Success = (1 =:= ets:select_replace(T, [{Old, [], [{const, New}]}])),
         <p>An explicit match specification is here used to traverse the
           table:</p>
         <pre>
-9> <input>true = ets:insert(Tab = ets:new(t, []), [{1,a},{2,b},{3,c},{4,d}]),</input>
+9> <input>true = ets:insert(Table = ets:new(t, []), [{1,a},{2,b},{3,c},{4,d}]),</input>
 <input>MS = ets:fun2ms(fun({X,Y}) when (X > 1) or (X &lt; 5) -> {Y} end),</input>
-<input>QH1 = ets:table(Tab, [{traverse, {select, MS}}]).</input></pre>
+<input>QH1 = ets:table(Table, [{traverse, {select, MS}}]).</input></pre>
         <p>An example with an implicit match specification:</p>
         <pre>
-10> <input>QH2 = qlc:q([{Y} || {X,Y} &lt;- ets:table(Tab), (X > 1) or (X &lt; 5)]).</input></pre>
+10> <input>QH2 = qlc:q([{Y} || {X,Y} &lt;- ets:table(Table), (X > 1) or (X &lt; 5)]).</input></pre>
         <p>The latter example is equivalent to the former, which
           can be verified using function <c>qlc:info/1</c>:</p>
         <pre>
@@ -2090,7 +2090,7 @@ true</pre>
         ETS table.</fsummary>
       <desc>
         <p>Returns and removes a list of all objects with key
-          <c><anno>Key</anno></c> in table <c><anno>Tab</anno></c>.</p>
+          <c><anno>Key</anno></c> in table <c><anno>Table</anno></c>.</p>
         <p>The specified <c><anno>Key</anno></c> is used to identify the object
           by either <em>comparing equal</em> the key of an object in an
           <c>ordered_set</c> table, or <em>matching</em> in other types of
@@ -2132,7 +2132,7 @@ true</pre>
       </fsummary>
       <desc>
         <p>Fills an already created/opened Dets table with the objects
-          in the already opened ETS table named <c><anno>Tab</anno></c>.
+          in the already opened ETS table named <c><anno>Table</anno></c>.
           The Dets table is emptied before the objects are inserted.</p>
       </desc>
     </func>
@@ -2145,7 +2145,7 @@ true</pre>
       <name name="update_counter" arity="3" clause_i="3" since=""/>
       <name name="update_counter" arity="4" clause_i="3" since="OTP 18.0"/>
       <fsummary>Update a counter object in an ETS table.</fsummary>
-      <type variable="Tab"/>
+      <type variable="Table"/>
       <type variable="Key"/>
       <type variable="UpdateOp" name_i="1"/>
       <type variable="Pos" name_i="1"/>
@@ -2159,7 +2159,7 @@ true</pre>
           object into the table again. The operation is guaranteed to be
           <seeerl marker="#concurrency">atomic and isolated</seeerl>.</p>
         <p>This function destructively update the object with key
-          <c><anno>Key</anno></c> in table <c><anno>Tab</anno></c> by adding
+          <c><anno>Key</anno></c> in table <c><anno>Table</anno></c> by adding
           <c><anno>Incr</anno></c> to the element at position
           <c><anno>Pos</anno></c>. The new counter value is
           returned. If no position is specified, the element directly
@@ -2225,7 +2225,7 @@ true</pre>
       <name name="update_element" arity="3" clause_i="2" since=""/>
       <fsummary>Update the <c>Pos</c>:th element of the object with a
         specified key in an ETS table.</fsummary>
-      <type variable="Tab"/>
+      <type variable="Table"/>
       <type variable="Key"/>
       <type variable="Value"/>
       <type variable="Pos"/>
@@ -2234,7 +2234,7 @@ true</pre>
           elements within an object, without the trouble of having to look up, 
           update, and write back the entire object.</p>
         <p>This function destructively updates the object with key
-          <c><anno>Key</anno></c> in table <c><anno>Tab</anno></c>.
+          <c><anno>Key</anno></c> in table <c><anno>Table</anno></c>.
           The element at position <c><anno>Pos</anno></c> is given
           the value <c><anno>Value</anno></c>.</p>
         <p>A list of <c>{<anno>Pos</anno>,<anno>Value</anno>}</c> can be

--- a/lib/stdlib/src/dets.erl
+++ b/lib/stdlib/src/dets.erl
@@ -149,7 +149,7 @@
           proc :: 'undefined' | pid(), % the pid of the Dets process
           match_program :: 'true'
                          | 'undefined'
-                         | {'match_spec', ets:comp_match_spec()}
+                         | {'match_spec', ets:compiled_match_spec()}
 	 }).
 
 -record(open_args, {

--- a/lib/stdlib/src/dets.erl
+++ b/lib/stdlib/src/dets.erl
@@ -321,7 +321,7 @@ foldl(Fun, Acc, Tab) ->
 
 -spec from_ets(Name, EtsTab) -> 'ok' | {'error', Reason} when
       Name :: tab_name(),
-      EtsTab :: ets:tab(),
+      EtsTab :: ets:table(),
       Reason :: term().
 
 from_ets(DTab, ETab) ->
@@ -861,7 +861,7 @@ table_info(_Tab, _) ->
 
 -spec to_ets(Name, EtsTab) -> EtsTab | {'error', Reason} when
       Name :: tab_name(),
-      EtsTab :: ets:tab(),
+      EtsTab :: ets:table(),
       Reason :: term().
 
 to_ets(DTab, ETab) ->

--- a/lib/stdlib/src/digraph.erl
+++ b/lib/stdlib/src/digraph.erl
@@ -39,9 +39,9 @@
 
 -export_type([graph/0, d_type/0, vertex/0, edge/0, label/0]).
 
--record(digraph, {vtab = notable :: ets:tab(),
-		  etab = notable :: ets:tab(),
-		  ntab = notable :: ets:tab(),
+-record(digraph, {vtab = notable :: ets:table(),
+		  etab = notable :: ets:table(),
+		  ntab = notable :: ets:table(),
 	          cyclic = true  :: boolean()}).
 
 -opaque graph() :: #digraph{}.

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -42,21 +42,25 @@
 
 -export([i/0, i/1, i/2, i/3]).
 
--export_type([tab/0, tid/0, match_spec/0, comp_match_spec/0, match_pattern/0]).
+-export_type([table/0, tid/0, match_spec/0, compiled_match_spec/0, match_pattern/0]).
 
 %%-----------------------------------------------------------------------------
 
--type access()     :: public | protected | private.
--type tab()        :: atom() | tid().
--type type()       :: set | ordered_set | bag | duplicate_bag.
--type continuation() :: '$end_of_table'
-                      | {tab(),integer(),integer(),comp_match_spec(),list(),integer()}
-                      | {tab(),_,_,integer(),comp_match_spec(),list(),integer(),integer()}.
+-type table_access()  :: public | protected | private.
+-type table()         :: atom() | tid().
+-type table_type()    :: set | ordered_set | bag | duplicate_bag.
+-type continuation()  :: '$end_of_table'
+                       | {table(),integer(),integer(),compiled_match_spec(),list(),integer()}
+                       | {table(),_,_,integer(),compiled_match_spec(),list(),integer(),integer()}.
 
--opaque tid()      :: reference().
+-opaque tid()         :: reference().
 
 -type match_pattern() :: atom() | tuple().
 -type match_spec()    :: [{match_pattern(), [_], [_]}].
+
+%% Keep for backwards compatibility
+-export_type([tab/0, comp_match_spec/0]).
+-type tab()           :: table().
 
 %%-----------------------------------------------------------------------------
 
@@ -80,8 +84,8 @@
          internal_delete_all/2,
          internal_select_delete/2]).
 
--spec all() -> [Tab] when
-      Tab :: tab().
+-spec all() -> [Table] when
+      Table :: table().
 
 all() ->
     receive_all(ets:internal_request_all(),
@@ -101,57 +105,57 @@ receive_all(Ref, N, All) ->
 internal_request_all() ->
     erlang:nif_error(undef).
 
--spec delete(Tab) -> true when
-      Tab :: tab().
+-spec delete(Table) -> true when
+      Table :: table().
 
 delete(_) ->
     erlang:nif_error(undef).
 
--spec delete(Tab, Key) -> true when
-      Tab :: tab(),
+-spec delete(Table, Key) -> true when
+      Table :: table(),
       Key :: term().
 
 delete(_, _) ->
     erlang:nif_error(undef).
 
--spec delete_all_objects(Tab) -> true when
-      Tab :: tab().
+-spec delete_all_objects(Table) -> true when
+      Table :: table().
 
-delete_all_objects(Tab) ->
-    _ = ets:internal_delete_all(Tab, undefined),
+delete_all_objects(Table) ->
+    _ = ets:internal_delete_all(Table, undefined),
     true.
 
--spec internal_delete_all(Tab, undefined) -> NumDeleted when
-      Tab :: tab(),
+-spec internal_delete_all(Table, undefined) -> NumDeleted when
+      Table :: table(),
       NumDeleted :: non_neg_integer().
 
 internal_delete_all(_, _) ->
     erlang:nif_error(undef).
 
--spec delete_object(Tab, Object) -> true when
-      Tab :: tab(),
+-spec delete_object(Table, Object) -> true when
+      Table :: table(),
       Object :: tuple().
 
 delete_object(_, _) ->
     erlang:nif_error(undef).
 
--spec first(Tab) -> Key | '$end_of_table' when
-      Tab :: tab(),
+-spec first(Table) -> Key | '$end_of_table' when
+      Table :: table(),
       Key :: term().
 
 first(_) ->
     erlang:nif_error(undef).
 
--spec give_away(Tab, Pid, GiftData) -> true when
-      Tab :: tab(),
+-spec give_away(Table, Pid, GiftData) -> true when
+      Table :: table(),
       Pid :: pid(),
       GiftData :: term().
 
 give_away(_, _, _) ->
     erlang:nif_error(undef).
 
--spec info(Tab) -> InfoList | undefined when
-      Tab :: tab(),
+-spec info(Table) -> InfoList | undefined when
+      Table :: table(),
       InfoList :: [InfoTuple],
       InfoTuple :: {compressed, boolean()}
                  | {decentralized_counters, boolean()}
@@ -163,17 +167,17 @@ give_away(_, _, _) ->
                  | {named_table, boolean()}
                  | {node, node()}
                  | {owner, pid()}
-                 | {protection, access()}
+                 | {protection, table_access()}
                  | {size, non_neg_integer()}
-                 | {type, type()}
+                 | {type, table_type()}
 		 | {write_concurrency, boolean()}
 		 | {read_concurrency, boolean()}.
 
 info(_) ->
     erlang:nif_error(undef).
 
--spec info(Tab, Item) -> Value | undefined when
-      Tab :: tab(),
+-spec info(Table, Item) -> Value | undefined when
+      Table :: table(),
       Item :: binary | compressed | decentralized_counters | fixed | heir | id | keypos | memory
             | name | named_table | node | owner | protection
             | safe_fixed | safe_fixed_monotonic_time | size | stats | type
@@ -183,15 +187,15 @@ info(_) ->
 info(_, _) ->
     erlang:nif_error(undef).
 
--spec insert(Tab, ObjectOrObjects) -> true when
-      Tab :: tab(),
+-spec insert(Table, ObjectOrObjects) -> true when
+      Table :: table(),
       ObjectOrObjects :: tuple() | [tuple()].
 
 insert(_, _) ->
     erlang:nif_error(undef).
 
--spec insert_new(Tab, ObjectOrObjects) -> boolean() when
-      Tab :: tab(),
+-spec insert_new(Table, ObjectOrObjects) -> boolean() when
+      Table :: table(),
       ObjectOrObjects :: tuple() | [tuple()].
 
 insert_new(_, _) ->
@@ -203,23 +207,23 @@ insert_new(_, _) ->
 is_compiled_ms(_) ->
     erlang:nif_error(undef).
 
--spec last(Tab) -> Key | '$end_of_table' when
-      Tab :: tab(),
+-spec last(Table) -> Key | '$end_of_table' when
+      Table :: table(),
       Key :: term().
 
 last(_) ->
     erlang:nif_error(undef).
 
--spec lookup(Tab, Key) -> [Object] when
-      Tab :: tab(),
+-spec lookup(Table, Key) -> [Object] when
+      Table :: table(),
       Key :: term(),
       Object :: tuple().
 
 lookup(_, _) ->
     erlang:nif_error(undef).
 
--spec lookup_element(Tab, Key, Pos) -> Elem when
-      Tab :: tab(),
+-spec lookup_element(Table, Key, Pos) -> Elem when
+      Table :: table(),
       Key :: term(),
       Pos :: pos_integer(),
       Elem :: term() | [term()].
@@ -227,17 +231,17 @@ lookup(_, _) ->
 lookup_element(_, _, _) ->
     erlang:nif_error(undef).
 
--spec match(Tab, Pattern) -> [Match] when
-      Tab :: tab(),
+-spec match(Table, Pattern) -> [Match] when
+      Table :: table(),
       Pattern :: match_pattern(),
       Match :: [term()].
 
 match(_, _) ->
     erlang:nif_error(undef).
 
--spec match(Tab, Pattern, Limit) -> {[Match], Continuation} |
+-spec match(Table, Pattern, Limit) -> {[Match], Continuation} |
                                        '$end_of_table'  when
-      Tab :: tab(),
+      Table :: table(),
       Pattern :: match_pattern(),
       Limit :: pos_integer(),
       Match :: [term()],
@@ -254,17 +258,17 @@ match(_, _, _) ->
 match(_) ->
     erlang:nif_error(undef).
 
--spec match_object(Tab, Pattern) -> [Object] when
-      Tab :: tab(),
+-spec match_object(Table, Pattern) -> [Object] when
+      Table :: table(),
       Pattern :: match_pattern(),
       Object :: tuple().
 
 match_object(_, _) ->
     erlang:nif_error(undef).
 
--spec match_object(Tab, Pattern, Limit) -> {[Object], Continuation} |
+-spec match_object(Table, Pattern, Limit) -> {[Object], Continuation} |
                                            '$end_of_table' when
-      Tab :: tab(),
+      Table :: table(),
       Pattern :: match_pattern(),
       Limit :: pos_integer(),
       Object :: tuple(),
@@ -283,32 +287,32 @@ match_object(_) ->
 
 -spec match_spec_compile(MatchSpec) -> CompiledMatchSpec when
       MatchSpec :: match_spec(),
-      CompiledMatchSpec :: comp_match_spec().
+      CompiledMatchSpec :: compiled_match_spec().
 
 match_spec_compile(_) ->
     erlang:nif_error(undef).
 
 -spec match_spec_run_r(List, CompiledMatchSpec, list()) -> list() when
       List :: [term()],
-      CompiledMatchSpec :: comp_match_spec().
+      CompiledMatchSpec :: compiled_match_spec().
 
 match_spec_run_r(_, _, _) ->
     erlang:nif_error(undef).
 
--spec member(Tab, Key) -> boolean() when
-      Tab :: tab(),
+-spec member(Table, Key) -> boolean() when
+      Table :: table(),
       Key :: term().
 
 member(_, _) ->
     erlang:nif_error(undef).
 
--spec new(Name, Options) -> tid() | atom() when
+-spec new(Name, Options) -> table() when
       Name :: atom(),
       Options :: [Option],
       Option :: Type | Access | named_table | {keypos,Pos}
               | {heir, Pid :: pid(), HeirData} | {heir, none} | Tweaks,
-      Type :: type(),
-      Access :: access(),
+      Type :: table_type(),
+      Access :: table_access(),
       WriteConcurrencyAlternative :: boolean() | auto,
       Tweaks :: {write_concurrency, WriteConcurrencyAlternative}
               | {read_concurrency, boolean()}
@@ -320,16 +324,16 @@ member(_, _) ->
 new(_, _) ->
     erlang:nif_error(undef).
 
--spec next(Tab, Key1) -> Key2 | '$end_of_table' when
-      Tab :: tab(),
+-spec next(Table, Key1) -> Key2 | '$end_of_table' when
+      Table :: table(),
       Key1 :: term(),
       Key2 :: term().
 
 next(_, _) ->
     erlang:nif_error(undef).
 
--spec prev(Tab, Key1) -> Key2 | '$end_of_table' when
-      Tab :: tab(),
+-spec prev(Table, Key1) -> Key2 | '$end_of_table' when
+      Table :: table(),
       Key1 :: term(),
       Key2 :: term().
 
@@ -337,31 +341,31 @@ prev(_, _) ->
     erlang:nif_error(undef).
 
 %% Shadowed by erl_bif_types: ets:rename/2
--spec rename(Tab, Name) -> Name when
-      Tab :: tab(),
+-spec rename(Table, Name) -> Name when
+      Table :: table(),
       Name :: atom().
 
 rename(_, _) ->
     erlang:nif_error(undef).
 
--spec safe_fixtable(Tab, Fix) -> true when
-      Tab :: tab(),
+-spec safe_fixtable(Table, Fix) -> true when
+      Table :: table(),
       Fix :: boolean().
 
 safe_fixtable(_, _) ->
     erlang:nif_error(undef).
 
--spec select(Tab, MatchSpec) -> [Match] when
-      Tab :: tab(),
+-spec select(Table, MatchSpec) -> [Match] when
+      Table :: table(),
       MatchSpec :: match_spec(),
       Match :: term().
 
 select(_, _) ->
     erlang:nif_error(undef).
 
--spec select(Tab, MatchSpec, Limit) -> {[Match],Continuation} |
+-spec select(Table, MatchSpec, Limit) -> {[Match],Continuation} |
                                        '$end_of_table' when
-      Tab :: tab(),
+      Table :: table(),
       MatchSpec :: match_spec(),
       Limit :: pos_integer(),
       Match :: term(),
@@ -377,51 +381,51 @@ select(_, _, _) ->
 select(_) ->
     erlang:nif_error(undef).
 
--spec select_count(Tab, MatchSpec) -> NumMatched when
-      Tab :: tab(),
+-spec select_count(Table, MatchSpec) -> NumMatched when
+      Table :: table(),
       MatchSpec :: match_spec(),
       NumMatched :: non_neg_integer().
 
 select_count(_, _) ->
     erlang:nif_error(undef).
 
--spec select_delete(Tab, MatchSpec) -> NumDeleted when
-      Tab :: tab(),
+-spec select_delete(Table, MatchSpec) -> NumDeleted when
+      Table :: table(),
       MatchSpec :: match_spec(),
       NumDeleted :: non_neg_integer().
 
-select_delete(Tab, [{'_',[],[true]}]) ->
-    ets:internal_delete_all(Tab, undefined);
-select_delete(Tab, MatchSpec) ->
-    ets:internal_select_delete(Tab, MatchSpec).
+select_delete(Table, [{'_',[],[true]}]) ->
+    ets:internal_delete_all(Table, undefined);
+select_delete(Table, MatchSpec) ->
+    ets:internal_select_delete(Table, MatchSpec).
 
--spec internal_select_delete(Tab, MatchSpec) -> NumDeleted when
-      Tab :: tab(),
+-spec internal_select_delete(Table, MatchSpec) -> NumDeleted when
+      Table :: table(),
       MatchSpec :: match_spec(),
       NumDeleted :: non_neg_integer().
 
 internal_select_delete(_, _) ->
     erlang:nif_error(undef).
 
--spec select_replace(Tab, MatchSpec) -> NumReplaced when
-      Tab :: tab(),
+-spec select_replace(Table, MatchSpec) -> NumReplaced when
+      Table :: table(),
       MatchSpec :: match_spec(),
       NumReplaced :: non_neg_integer().
 
 select_replace(_, _) ->
     erlang:nif_error(undef).
 
--spec select_reverse(Tab, MatchSpec) -> [Match] when
-      Tab :: tab(),
+-spec select_reverse(Table, MatchSpec) -> [Match] when
+      Table :: table(),
       MatchSpec :: match_spec(),
       Match :: term().
 
 select_reverse(_, _) ->
     erlang:nif_error(undef).
 
--spec select_reverse(Tab, MatchSpec, Limit) -> {[Match],Continuation} |
+-spec select_reverse(Table, MatchSpec, Limit) -> {[Match],Continuation} |
                                                '$end_of_table' when
-      Tab :: tab(),
+      Table :: table(),
       MatchSpec :: match_spec(),
       Limit :: pos_integer(),
       Match :: term(),
@@ -438,8 +442,8 @@ select_reverse(_, _, _) ->
 select_reverse(_) ->
     erlang:nif_error(undef).
 
--spec setopts(Tab, Opts) -> true when
-      Tab :: tab(),
+-spec setopts(Table, Opts) -> true when
+      Table :: table(),
       Opts :: Opt | [Opt],
       Opt :: {heir, pid(), HeirData} | {heir,none},
       HeirData :: term().
@@ -447,24 +451,24 @@ select_reverse(_) ->
 setopts(_, _) ->
     erlang:nif_error(undef).
 
--spec slot(Tab, I) -> [Object] | '$end_of_table' when
-      Tab :: tab(),
+-spec slot(Table, I) -> [Object] | '$end_of_table' when
+      Table :: table(),
       I :: non_neg_integer(),
       Object :: tuple().
 
 slot(_, _) ->
     erlang:nif_error(undef).
 
--spec take(Tab, Key) -> [Object] when
-      Tab :: tab(),
+-spec take(Table, Key) -> [Object] when
+      Table :: table(),
       Key :: term(),
       Object :: tuple().
 
 take(_, _) ->
     erlang:nif_error(undef).
 
--spec update_counter(Tab, Key, UpdateOp) -> Result when
-      Tab :: tab(),
+-spec update_counter(Table, Key, UpdateOp) -> Result when
+      Table :: table(),
       Key :: term(),
       UpdateOp :: {Pos, Incr} | {Pos, Incr, Threshold, SetValue},
       Pos :: integer(),
@@ -472,8 +476,8 @@ take(_, _) ->
       Threshold :: integer(),
       SetValue :: integer(),
       Result :: integer();
-                       (Tab, Key, [UpdateOp]) -> [Result] when
-      Tab :: tab(),
+                       (Table, Key, [UpdateOp]) -> [Result] when
+      Table :: table(),
       Key :: term(),
       UpdateOp :: {Pos, Incr} | {Pos, Incr, Threshold, SetValue},
       Pos :: integer(),
@@ -481,8 +485,8 @@ take(_, _) ->
       Threshold :: integer(),
       SetValue :: integer(),
       Result :: integer();
-                       (Tab, Key, Incr) -> Result when
-      Tab :: tab(),
+                       (Table, Key, Incr) -> Result when
+      Table :: table(),
       Key :: term(),
       Incr :: integer(),
       Result :: integer().
@@ -490,8 +494,8 @@ take(_, _) ->
 update_counter(_, _, _) ->
     erlang:nif_error(undef).
 
--spec update_counter(Tab, Key, UpdateOp, Default) -> Result when
-                        Tab :: tab(),
+-spec update_counter(Table, Key, UpdateOp, Default) -> Result when
+                        Table :: table(),
                         Key :: term(),
                         UpdateOp :: {Pos, Incr}
                                   | {Pos, Incr, Threshold, SetValue},
@@ -501,8 +505,8 @@ update_counter(_, _, _) ->
                         SetValue :: integer(),
                         Result :: integer(),
                         Default :: tuple();
-                    (Tab, Key, [UpdateOp], Default) -> [Result] when
-                        Tab :: tab(),
+                    (Table, Key, [UpdateOp], Default) -> [Result] when
+                        Table :: table(),
                         Key :: term(),
                         UpdateOp :: {Pos, Incr}
                                   | {Pos, Incr, Threshold, SetValue},
@@ -512,8 +516,8 @@ update_counter(_, _, _) ->
                         SetValue :: integer(),
                         Result :: integer(),
                         Default :: tuple();
-                    (Tab, Key, Incr, Default) -> Result when
-                        Tab :: tab(),
+                    (Table, Key, Incr, Default) -> Result when
+                        Table :: table(),
                         Key :: term(),
                         Incr :: integer(),
                         Result :: integer(),
@@ -522,13 +526,13 @@ update_counter(_, _, _) ->
 update_counter(_, _, _, _) ->
     erlang:nif_error(undef).
 
--spec update_element(Tab, Key, ElementSpec :: {Pos, Value}) -> boolean() when
-      Tab :: tab(),
+-spec update_element(Table, Key, ElementSpec :: {Pos, Value}) -> boolean() when
+      Table :: table(),
       Key :: term(),
       Pos :: pos_integer(),
       Value :: term();
-                       (Tab, Key, ElementSpec :: [{Pos, Value}]) -> boolean() when
-      Tab :: tab(),
+                       (Table, Key, ElementSpec :: [{Pos, Value}]) -> boolean() when
+      Table :: table(),
       Key :: term(),
       Pos :: pos_integer(),
       Value :: term().
@@ -543,11 +547,12 @@ whereis(_) ->
 
 %%% End of BIFs
 
--opaque comp_match_spec() :: reference().
+-opaque compiled_match_spec() :: reference().
+-type comp_match_spec() :: compiled_match_spec().
 
 -spec match_spec_run(List, CompiledMatchSpec) -> list() when
       List :: [term()],
-      CompiledMatchSpec :: comp_match_spec().
+      CompiledMatchSpec :: compiled_match_spec().
 
 match_spec_run(List, CompiledMS) ->
     lists:reverse(ets:match_spec_run_r(List, CompiledMS, [])).
@@ -614,9 +619,9 @@ fun2ms(ShellFun) when is_function(ShellFun) ->
                            shell]}})
     end.
 
--spec foldl(Function, Acc0, Tab) -> Acc1 when
+-spec foldl(Function, Acc0, Table) -> Acc1 when
       Function :: fun((Element :: term(), AccIn) -> AccOut),
-      Tab :: tab(),
+      Table :: table(),
       Acc0 :: term(),
       Acc1 :: term(),
       AccIn :: term(),
@@ -641,9 +646,9 @@ do_foldl(F, Accu0, Key, T) ->
 		     ets:next(T, Key), T)
     end.
 
--spec foldr(Function, Acc0, Tab) -> Acc1 when
+-spec foldr(Function, Acc0, Table) -> Acc1 when
       Function :: fun((Element :: term(), AccIn) -> AccOut),
-      Tab :: tab(),
+      Table :: table(),
       Acc0 :: term(),
       Acc1 :: term(),
       AccIn :: term(),
@@ -668,8 +673,8 @@ do_foldr(F, Accu0, Key, T) ->
 		     ets:prev(T, Key), T)
     end.
 
--spec from_dets(Tab, DetsTab) -> 'true' when
-      Tab :: tab(),
+-spec from_dets(Table, DetsTab) -> 'true' when
+      Table :: table(),
       DetsTab :: dets:tab_name().
 
 from_dets(EtsTable, DetsTable) ->
@@ -686,8 +691,8 @@ from_dets(EtsTable, DetsTable) ->
 	    erlang:error(Unexpected,[EtsTable,DetsTable])
     end.
 
--spec to_dets(Tab, DetsTab) -> DetsTab when
-      Tab :: tab(),
+-spec to_dets(Table, DetsTab) -> DetsTab when
+      Table :: table(),
       DetsTab :: dets:tab_name().
 
 to_dets(EtsTable, DetsTable) ->
@@ -718,8 +723,8 @@ test_ms(Term, MS) ->
 	    Error
     end.
 
--spec init_table(Tab, InitFun) -> 'true' when
-      Tab :: tab(),
+-spec init_table(Table, InitFun) -> 'true' when
+      Table :: table(),
       InitFun :: fun((Arg) -> Res),
       Arg :: 'read' | 'close',
       Res :: 'end_of_input' | {Objects :: [term()], InitFun} | term().
@@ -747,8 +752,8 @@ init_table_sub(Table, [H|T]) ->
     ets:insert(Table, H),
     init_table_sub(Table, T).
 
--spec match_delete(Tab, Pattern) -> 'true' when
-      Tab :: tab(),
+-spec match_delete(Table, Pattern) -> 'true' when
+      Table :: table(),
       Pattern :: match_pattern().
 
 match_delete(Table, Pattern) ->
@@ -757,8 +762,8 @@ match_delete(Table, Pattern) ->
 
 %% Produce a list of tuples from a table
 
--spec tab2list(Tab) -> [Object] when
-      Tab :: tab(),
+-spec tab2list(Table) -> [Object] when
+      Table :: table(),
       Object :: tuple().
 
 tab2list(T) ->
@@ -781,23 +786,23 @@ tab2list(T) ->
 	  sync         = false :: boolean()
 	 }).
 
--spec tab2file(Tab, Filename) -> 'ok' | {'error', Reason} when
-      Tab :: tab(),
+-spec tab2file(Table, Filename) -> 'ok' | {'error', Reason} when
+      Table :: table(),
       Filename :: file:name(),
       Reason :: term().
 
-tab2file(Tab, File) ->
-    tab2file(Tab, File, []).
+tab2file(Table, File) ->
+    tab2file(Table, File, []).
 
--spec tab2file(Tab, Filename, Options) -> 'ok' | {'error', Reason} when
-      Tab :: tab(),
+-spec tab2file(Table, Filename, Options) -> 'ok' | {'error', Reason} when
+      Table :: table(),
       Filename :: file:name(),
       Options :: [Option],
       Option :: {'extended_info', [ExtInfo]} | {'sync', boolean()},
       ExtInfo :: 'md5sum' | 'object_count',
       Reason :: term().
 
-tab2file(Tab, File, Options) ->
+tab2file(Table, File, Options) ->
     try
 	{ok, FtOptions} = parse_ft_options(Options),
 	_ = file:delete(File),
@@ -813,9 +818,9 @@ tab2file(Tab, File, Options) ->
 		throw(Reason)
 	end,
 	try
-	    Info0 = case ets:info(Tab) of
+	    Info0 = case ets:info(Table) of
 		       undefined ->
-			   %% erlang:error(badarg, [Tab, File, Options]);
+			   %% erlang:error(badarg, [Table, File, Options]);
 			   throw(badtab);
 		       I ->
 			   I
@@ -846,14 +851,14 @@ tab2file(Tab, File, Options) ->
 		     end, 
 		     true}
 	    end,
-	    ets:safe_fixtable(Tab,true),
+	    ets:safe_fixtable(Table,true),
 	    {NewState1,Num} = try
 				  NewState = LogFun(InitState,Info),
 				  dump_file(
-				      ets:select(Tab,[{'_',[],['$_']}],100),
+				      ets:select(Table,[{'_',[],['$_']}],100),
 				      LogFun, NewState, 0)
 			      after
-				  (catch ets:safe_fixtable(Tab,false))
+				  (catch ets:safe_fixtable(Table,false))
 			      end,
 	    EndInfo = 
 	    case  FtOptions#filetab_options.object_count of
@@ -968,24 +973,24 @@ parse_ft_info_options(_,Malformed) ->
 %% Opt := {verify,boolean()}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec file2tab(Filename) -> {'ok', Tab} | {'error', Reason} when
+-spec file2tab(Filename) -> {'ok', Table} | {'error', Reason} when
       Filename :: file:name(),
-      Tab :: tab(),
+      Table :: table(),
       Reason :: term().
 
 file2tab(File) ->
     file2tab(File, []).
 
--spec file2tab(Filename, Options) -> {'ok', Tab} | {'error', Reason} when
+-spec file2tab(Filename, Options) -> {'ok', Table} | {'error', Reason} when
       Filename :: file:name(),
-      Tab :: tab(),
+      Table :: table(),
       Options :: [Option],
       Option :: {'verify', boolean()},
       Reason :: term().
 
 file2tab(File, Opts) ->
     try
-	{ok,Verify,TabArg} = parse_f2t_opts(Opts,false,[]),
+	{ok,Verify,TableArg} = parse_f2t_opts(Opts,false,[]),
 	Name = make_ref(),
         {ok, Name} =
 	    case disk_log:open([{name, Name}, 
@@ -1020,7 +1025,7 @@ file2tab(File, Opts) ->
 		true ->
 		    ok
 	    end,
-	    {ok, Tab, HeadCount} = create_tab(FullHeader, TabArg),
+	    {ok, Table, HeadCount} = create_tab(FullHeader, TableArg),
 	    StrippedOptions = 				   
 	        case Verify of
 		    true ->
@@ -1062,17 +1067,17 @@ file2tab(File, Opts) ->
 			 {false,0,[],DLContext}}
 		end,
 	    try
-		do_read_and_verify(ReadFun,InitState,Tab,
+		do_read_and_verify(ReadFun,InitState,Table,
 				   StrippedOptions,HeadCount,Verify)
 	    catch
 		throw:TReason ->
-		    ets:delete(Tab),    
+		    ets:delete(Table),    
 		    throw(TReason);
 		exit:ExReason ->
-		    ets:delete(Tab),
+		    ets:delete(Table),
 		    exit(ExReason);
 		error:ErReason:StackTrace ->
-		    ets:delete(Tab),
+		    ets:delete(Table),
 		    erlang:raise(error,ErReason,StackTrace)
 	    end
 	after
@@ -1085,8 +1090,8 @@ file2tab(File, Opts) ->
 	    {error,ExReason2}
     end.
 
-do_read_and_verify(ReadFun,InitState,Tab,FtOptions,HeadCount,Verify) ->
-    case load_table(ReadFun,InitState,Tab) of
+do_read_and_verify(ReadFun,InitState,Table,FtOptions,HeadCount,Verify) ->
+    case load_table(ReadFun,InitState,Table) of
 	{ok,{_,FinalCount,[],_}} ->
 	    case {FtOptions#filetab_options.md5sum,
 		  FtOptions#filetab_options.object_count} of
@@ -1105,7 +1110,7 @@ do_read_and_verify(ReadFun,InitState,Tab,FtOptions,HeadCount,Verify) ->
 		_ ->
 		    throw(badfile)
 	    end,
-	    {ok,Tab};
+	    {ok,Table};
 	{ok,{FinalMD5State,FinalCount,['$end_of_table',LastInfo],_}} ->
 	    ECount = case lists:keyfind(count,1,LastInfo) of
 			 {count,N} ->
@@ -1153,17 +1158,17 @@ do_read_and_verify(ReadFun,InitState,Tab,FtOptions,HeadCount,Verify) ->
 			    ok
 		    end
 	    end,
-	    {ok,Tab}
+	    {ok,Table}
     end.
 
-parse_f2t_opts([],Verify,Tab) ->
-    {ok,Verify,Tab};
-parse_f2t_opts([{verify, true}|T],_OV,Tab) ->
-    parse_f2t_opts(T,true,Tab);
-parse_f2t_opts([{verify,false}|T],OV,Tab) ->
-    parse_f2t_opts(T,OV,Tab);
-parse_f2t_opts([{table,Tab}|T],OV,[]) ->
-    parse_f2t_opts(T,OV,Tab);
+parse_f2t_opts([],Verify,Table) ->
+    {ok,Verify,Table};
+parse_f2t_opts([{verify, true}|T],_OV,Table) ->
+    parse_f2t_opts(T,true,Table);
+parse_f2t_opts([{verify,false}|T],OV,Table) ->
+    parse_f2t_opts(T,OV,Table);
+parse_f2t_opts([{table,Table}|T],OV,[]) ->
+    parse_f2t_opts(T,OV,Table);
 parse_f2t_opts([Unexpected|_],_,_) ->
     throw({unknown_option,Unexpected});
 parse_f2t_opts(Malformed,_,_) ->
@@ -1332,17 +1337,17 @@ scan_for_endinfo([Term|T], Count) ->
     {NewLast,NCount,Rest} = scan_for_endinfo(T, Count+1),
     {NewLast,NCount,[Term | Rest]}.
 
-load_table(ReadFun, State, Tab) ->
+load_table(ReadFun, State, Table) ->
     {NewState,NewData} = ReadFun(State),
     case NewData of
 	[] ->
 	    {ok,NewState};
 	List ->
-	    ets:insert(Tab, List),
-	    load_table(ReadFun, NewState, Tab)
+	    ets:insert(Table, List),
+	    load_table(ReadFun, NewState, Table)
     end.
 
-create_tab(I, TabArg) ->
+create_tab(I, TableArg) ->
     {name, Name} = lists:keyfind(name, 1, I),
     {type, Type} = lists:keyfind(type, 1, I),
     {protection, P} = lists:keyfind(protection, 1, I),
@@ -1366,16 +1371,16 @@ create_tab(I, TabArg) ->
 	     {read_concurrency, _}=Rcc -> [Rcc | L4];
 	     false -> L4
 	 end,
-    case TabArg of
+    case TableArg of
         [] ->
 	    try
-		Tab = ets:new(Name, L5),
-		{ok, Tab, Sz}
+		Table = ets:new(Name, L5),
+		{ok, Table, Sz}
 	    catch _:_ ->
 		throw(cannot_create_table)
             end;
         _ ->
-            {ok, TabArg, Sz}
+            {ok, TableArg, Sz}
     end.
 
 
@@ -1447,15 +1452,15 @@ tabfile_info(File) when is_list(File) ; is_atom(File) ->
 	    {error,ExReason}
     end.
 
--spec table(Tab) -> QueryHandle when
-      Tab :: tab(),
+-spec table(Table) -> QueryHandle when
+      Table :: table(),
       QueryHandle :: qlc:query_handle().
 
-table(Tab) ->
-    table(Tab, []).
+table(Table) ->
+    table(Table, []).
 
--spec table(Tab, Options) -> QueryHandle when
-      Tab :: tab(),
+-spec table(Table, Options) -> QueryHandle when
+      Table :: table(),
       QueryHandle :: qlc:query_handle(),
       Options :: [Option] | Option,
       Option :: {'n_objects', NObjects}
@@ -1464,25 +1469,25 @@ table(Tab) ->
       TraverseMethod :: 'first_next' | 'last_prev'
                       | 'select' | {'select', MatchSpec :: match_spec()}.
 
-table(Tab, Opts) ->
+table(Table, Opts) ->
     case options(Opts, [traverse, n_objects]) of
         {badarg,_} ->
-            erlang:error(badarg, [Tab, Opts]);
+            erlang:error(badarg, [Table, Opts]);
         [[Traverse, NObjs], QlcOptions] ->
             TF = case Traverse of
                      first_next -> 
-                         fun() -> qlc_next(Tab, ets:first(Tab)) end;
+                         fun() -> qlc_next(Table, ets:first(Table)) end;
                      last_prev -> 
-                         fun() -> qlc_prev(Tab, ets:last(Tab)) end;
+                         fun() -> qlc_prev(Table, ets:last(Table)) end;
                      select -> 
-                         fun(MS) -> qlc_select(ets:select(Tab, MS, NObjs)) end;
+                         fun(MS) -> qlc_select(ets:select(Table, MS, NObjs)) end;
                      {select, MS} ->
-                         fun() -> qlc_select(ets:select(Tab, MS, NObjs)) end
+                         fun() -> qlc_select(ets:select(Table, MS, NObjs)) end
                  end,
-            PreFun = fun(_) -> ets:safe_fixtable(Tab, true) end,
-            PostFun = fun() -> ets:safe_fixtable(Tab, false) end,
-            InfoFun = fun(Tag) -> table_info(Tab, Tag) end,
-            KeyEquality = case ets:info(Tab, type) of
+            PreFun = fun(_) -> ets:safe_fixtable(Table, true) end,
+            PostFun = fun() -> ets:safe_fixtable(Table, false) end,
+            InfoFun = fun(Tag) -> table_info(Table, Tag) end,
+            KeyEquality = case ets:info(Table, type) of
                               ordered_set -> '==';
                               _ -> '=:='
                           end,
@@ -1492,28 +1497,28 @@ table(Tab, Opts) ->
                         undefined;
                     _ -> 
                         fun(_Pos, [K]) ->
-                                ets:lookup(Tab, K);
+                                ets:lookup(Table, K);
                            (_Pos, Ks) -> 
-                                lists:flatmap(fun(K) -> ets:lookup(Tab, K) 
+                                lists:flatmap(fun(K) -> ets:lookup(Table, K) 
                                               end, Ks) 
                         end
                 end,
             FormatFun = 
                 fun({all, _NElements, _ElementFun}) ->
-                        As = [Tab | [Opts || _ <- [[]], Opts =/= []]],
+                        As = [Table | [Opts || _ <- [[]], Opts =/= []]],
                         {?MODULE, table, As};
                    ({match_spec, MS}) ->
                         {?MODULE, table, 
-                         [Tab, [{traverse, {select, MS}} | 
+                         [Table, [{traverse, {select, MS}} | 
                                 listify(Opts)]]};
                    ({lookup, _KeyPos, [Value], _NElements, ElementFun}) ->
                         io_lib:format("~w:lookup(~w, ~w)", 
-                                      [?MODULE, Tab, ElementFun(Value)]);
+                                      [?MODULE, Table, ElementFun(Value)]);
                    ({lookup, _KeyPos, Values, _NElements, ElementFun}) ->
                         Vals = [ElementFun(V) || V <- Values],
                         io_lib:format("lists:flatmap(fun(V) -> "
                                       "~w:lookup(~w, V) end, ~w)", 
-                                      [?MODULE, Tab, Vals])
+                                      [?MODULE, Table, Vals])
                 end,
             qlc:table(TF, [{pre_fun, PreFun}, {post_fun, PostFun}, 
                            {info_fun, InfoFun}, {format_fun, FormatFun},
@@ -1521,26 +1526,26 @@ table(Tab, Opts) ->
                            {lookup_fun, LookupFun}] ++ QlcOptions)
     end.
          
-table_info(Tab, num_of_objects) ->
-    ets:info(Tab, size);
-table_info(Tab, keypos) ->
-    ets:info(Tab, keypos);
-table_info(Tab, is_unique_objects) ->
-    ets:info(Tab, type) =/= duplicate_bag;
-table_info(Tab, is_sorted_key) ->
-    ets:info(Tab, type) =:= ordered_set;
-table_info(_Tab, _) ->
+table_info(Table, num_of_objects) ->
+    ets:info(Table, size);
+table_info(Table, keypos) ->
+    ets:info(Table, keypos);
+table_info(Table, is_unique_objects) ->
+    ets:info(Table, type) =/= duplicate_bag;
+table_info(Table, is_sorted_key) ->
+    ets:info(Table, type) =:= ordered_set;
+table_info(_Table, _) ->
     undefined.
 
-qlc_next(_Tab, '$end_of_table') ->
+qlc_next(_Table, '$end_of_table') ->
     [];
-qlc_next(Tab, Key) ->
-    ets:lookup(Tab, Key) ++ fun() -> qlc_next(Tab, ets:next(Tab, Key)) end.
+qlc_next(Table, Key) ->
+    ets:lookup(Table, Key) ++ fun() -> qlc_next(Table, ets:next(Table, Key)) end.
 
-qlc_prev(_Tab, '$end_of_table') ->
+qlc_prev(_Table, '$end_of_table') ->
     [];
-qlc_prev(Tab, Key) ->
-    ets:lookup(Tab, Key) ++ fun() -> qlc_prev(Tab, ets:prev(Tab, Key)) end.
+qlc_prev(Table, Key) ->
+    ets:lookup(Table, Key) ++ fun() -> qlc_prev(Table, ets:prev(Table, Key)) end.
 
 qlc_select('$end_of_table') -> 
     [];
@@ -1605,20 +1610,20 @@ i() ->
 tabs() ->
     lists:sort(ets:all()).
 
-prinfo(Tab) ->
-    case catch prinfo2(Tab) of
+prinfo(Table) ->
+    case catch prinfo2(Table) of
 	{'EXIT', _} ->
-	    io:format("~-10s ... unreadable \n", [to_string(Tab)]);
+	    io:format("~-10s ... unreadable \n", [to_string(Table)]);
 	ok -> 
 	    ok
     end.
-prinfo2(Tab) ->
-    Name = ets:info(Tab, name),
-    Type = ets:info(Tab, type),
-    Size = ets:info(Tab, size),
-    Mem = ets:info(Tab, memory),
-    Owner = ets:info(Tab, owner),
-    hform(Tab, Name, Type, Size, Mem, is_reg(Owner)).
+prinfo2(Table) ->
+    Name = ets:info(Table, name),
+    Type = ets:info(Table, type),
+    Size = ets:info(Table, size),
+    Mem = ets:info(Table, memory),
+    Owner = ets:info(Table, owner),
+    hform(Table, Name, Type, Size, Mem, is_reg(Owner)).
 
 is_reg(Owner) ->
     case process_info(Owner, registered_name) of
@@ -1652,69 +1657,69 @@ to_string(X) ->
     lists:flatten(io_lib:format("~p", [X])).
 
 %% view a specific table
--spec i(Tab) -> 'ok' when
-      Tab :: tab().
+-spec i(Table) -> 'ok' when
+      Table :: table().
 
-i(Tab) ->
-    i(Tab, 40).
+i(Table) ->
+    i(Table, 40).
 
--spec i(tab(), pos_integer()) -> 'ok'.
+-spec i(table(), pos_integer()) -> 'ok'.
 
-i(Tab, Height) ->
-    i(Tab, Height, 80).
+i(Table, Height) ->
+    i(Table, Height, 80).
 
--spec i(tab(), pos_integer(), pos_integer()) -> 'ok'.
+-spec i(table(), pos_integer(), pos_integer()) -> 'ok'.
 
-i(Tab, Height, Width) ->
-    First = ets:first(Tab),
-    display_items(Height, Width, Tab, First, 1, 1).
+i(Table, Height, Width) ->
+    First = ets:first(Table),
+    display_items(Height, Width, Table, First, 1, 1).
 
-display_items(Height, Width, Tab, '$end_of_table', Turn, Opos) -> 
+display_items(Height, Width, Table, '$end_of_table', Turn, Opos) -> 
     P = 'EOT  (q)uit (p)Digits (k)ill /Regexp -->',
-    choice(Height, Width, P, eot, Tab, '$end_of_table', Turn, Opos);
-display_items(Height, Width, Tab, Key, Turn, Opos) when Turn < Height ->
-    do_display(Height, Width, Tab, Key, Turn, Opos);
-display_items(Height, Width, Tab, Key, Turn, Opos) when Turn >=  Height ->
+    choice(Height, Width, P, eot, Table, '$end_of_table', Turn, Opos);
+display_items(Height, Width, Table, Key, Turn, Opos) when Turn < Height ->
+    do_display(Height, Width, Table, Key, Turn, Opos);
+display_items(Height, Width, Table, Key, Turn, Opos) when Turn >=  Height ->
     P = '(c)ontinue (q)uit (p)Digits (k)ill /Regexp -->',
-    choice(Height, Width, P, normal, Tab, Key, Turn, Opos).
+    choice(Height, Width, P, normal, Table, Key, Turn, Opos).
 
-choice(Height, Width, P, Mode, Tab, Key, Turn, Opos) ->
+choice(Height, Width, P, Mode, Table, Key, Turn, Opos) ->
     case get_line(P, "c\n") of
 	"c\n" when Mode =:= normal ->
-	    do_display(Height, Width, Tab, Key, 1, Opos);
+	    do_display(Height, Width, Table, Key, 1, Opos);
 	"c\n" when is_tuple(Mode), element(1, Mode) =:= re ->
 	    {re, Re} = Mode,
-	    re_search(Height, Width, Tab, Key, Re, 1, Opos);
+	    re_search(Height, Width, Table, Key, Re, 1, Opos);
 	"q\n" ->
 	    ok;
 	"k\n" ->
-	    ets:delete(Tab),
+	    ets:delete(Table),
 	    ok;
 	[$p|Digs]  ->
 	    catch case catch list_to_integer(nonl(Digs)) of
 		      {'EXIT', _} ->
 			  io:put_chars("Bad digits\n");
 		      Number when Mode =:= normal ->
-			  print_number(Tab, ets:first(Tab), Number);
+			  print_number(Table, ets:first(Table), Number);
 		      Number when Mode =:= eot ->
-			  print_number(Tab, ets:first(Tab), Number);
+			  print_number(Table, ets:first(Table), Number);
 		      Number -> %% regexp
 			  {re, Re} = Mode,
-			  print_re_num(Tab, ets:first(Tab), Number, Re)
+			  print_re_num(Table, ets:first(Table), Number, Re)
 		  end,
-	    choice(Height, Width, P, Mode, Tab, Key, Turn, Opos);
+	    choice(Height, Width, P, Mode, Table, Key, Turn, Opos);
 	[$/|Regexp]   -> %% from regexp
 	    case re:compile(nonl(Regexp),[unicode]) of
 		{ok,Re} ->
-		    re_search(Height, Width, Tab, ets:first(Tab), Re, 1, 1);
+		    re_search(Height, Width, Table, ets:first(Table), Re, 1, 1);
 		{error,{ErrorString,_Pos}} ->
 		    io:format("~ts\n", [ErrorString]),
-		    choice(Height, Width, P, Mode, Tab, Key, Turn, Opos)
+		    choice(Height, Width, P, Mode, Table, Key, Turn, Opos)
 	    end;
         eof ->
             ok;
 	_  ->
-	    choice(Height, Width, P, Mode, Tab, Key, Turn, Opos)
+	    choice(Height, Width, P, Mode, Table, Key, Turn, Opos)
     end.
 
 get_line(P, Default) ->
@@ -1732,22 +1737,22 @@ line_string(Other) -> Other.
 
 nonl(S) -> string:trim(S, trailing, "$\n").
 
-print_number(Tab, Key, Num) ->
-    Os = ets:lookup(Tab, Key),
+print_number(Table, Key, Num) ->
+    Os = ets:lookup(Table, Key),
     Len = length(Os),
     if 
 	(Num - Len) < 1 ->
 	    O = lists:nth(Num, Os),
 	    io:format("~p~n", [O]); %% use ppterm here instead
 	true ->
-	    print_number(Tab, ets:next(Tab, Key), Num - Len)
+	    print_number(Table, ets:next(Table, Key), Num - Len)
     end.
 
-do_display(Height, Width, Tab, Key, Turn, Opos) ->
-    Objs = ets:lookup(Tab, Key),
+do_display(Height, Width, Table, Key, Turn, Opos) ->
+    Objs = ets:lookup(Table, Key),
     do_display_items(Height, Width, Objs, Opos),
     Len = length(Objs),
-    display_items(Height, Width, Tab, ets:next(Tab, Key), Turn+Len, Opos+Len).
+    display_items(Height, Width, Table, ets:next(Table, Key), Turn+Len, Opos+Len).
 
 do_display_items(Height, Width, [Obj|Tail], Opos) ->
     do_display_item(Height, Width, Obj, Opos),
@@ -1765,37 +1770,37 @@ do_display_item(_Height, Width, I, Opos)  ->
 	 end,
     io:format("<~-4w> ~s~n", [Opos,L2]).
 
-re_search(Height, Width, Tab, '$end_of_table', Re, Turn, Opos) ->
+re_search(Height, Width, Table, '$end_of_table', Re, Turn, Opos) ->
     P = 'EOT  (q)uit (p)Digits (k)ill /Regexp -->',
-    choice(Height, Width, P, {re, Re}, Tab, '$end_of_table', Turn, Opos);
-re_search(Height, Width, Tab, Key, Re, Turn, Opos) when Turn < Height ->
-    re_display(Height, Width, Tab, Key, ets:lookup(Tab, Key), Re, Turn, Opos);
-re_search(Height, Width, Tab, Key, Re, Turn, Opos)  ->
+    choice(Height, Width, P, {re, Re}, Table, '$end_of_table', Turn, Opos);
+re_search(Height, Width, Table, Key, Re, Turn, Opos) when Turn < Height ->
+    re_display(Height, Width, Table, Key, ets:lookup(Table, Key), Re, Turn, Opos);
+re_search(Height, Width, Table, Key, Re, Turn, Opos)  ->
     P = '(c)ontinue (q)uit (p)Digits (k)ill /Regexp -->',
-    choice(Height, Width, P, {re, Re}, Tab, Key, Turn, Opos).
+    choice(Height, Width, P, {re, Re}, Table, Key, Turn, Opos).
 
-re_display(Height, Width, Tab, Key, [], Re, Turn, Opos) ->
-    re_search(Height, Width, Tab, ets:next(Tab, Key), Re, Turn, Opos);
-re_display(Height, Width, Tab, Key, [H|T], Re, Turn, Opos) ->
+re_display(Height, Width, Table, Key, [], Re, Turn, Opos) ->
+    re_search(Height, Width, Table, ets:next(Table, Key), Re, Turn, Opos);
+re_display(Height, Width, Table, Key, [H|T], Re, Turn, Opos) ->
     Str = to_string(H),
     case re:run(Str, Re, [{capture,none}]) of
 	match ->
 	    do_display_item(Height, Width, H, Opos),
-	    re_display(Height, Width, Tab, Key, T, Re, Turn+1, Opos+1);
+	    re_display(Height, Width, Table, Key, T, Re, Turn+1, Opos+1);
 	nomatch ->
-	    re_display(Height, Width, Tab, Key, T, Re, Turn, Opos)
+	    re_display(Height, Width, Table, Key, T, Re, Turn, Opos)
     end.
 
 print_re_num(_,'$end_of_table',_,_) -> ok;
-print_re_num(Tab, Key, Num, Re) ->
-    Os = re_match(ets:lookup(Tab, Key), Re),
+print_re_num(Table, Key, Num, Re) ->
+    Os = re_match(ets:lookup(Table, Key), Re),
     Len = length(Os),
     if 
 	(Num - Len) < 1 ->
 	    O = lists:nth(Num, Os),
 	    io:format("~p~n", [O]); %% use ppterm here instead
 	true ->
-	    print_re_num(Tab, ets:next(Tab, Key), Num - Len, Re)
+	    print_re_num(Table, ets:next(Table, Key), Num - Len, Re)
     end.
 
 re_match([], _) -> [];

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -42,7 +42,8 @@
 
 -export([i/0, i/1, i/2, i/3]).
 
--export_type([table/0, tid/0, match_spec/0, compiled_match_spec/0, match_pattern/0]).
+-export_type([table/0, table_access/0, table_type/0,
+              tid/0, match_spec/0, compiled_match_spec/0, match_pattern/0]).
 
 %%-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Rename some ets types to clearer name:

* access() -> table_access()
* tab() -> table()
* type() -> table_type()
* comp_match_spec() -> compiled_match_spec()

The exported types have their old variants kept for backward compatibility.

The types `table_access` and `table_type` have been exported.

For consistency, I also renamed all usage of `Tab` to `Table` within the ets module itself.