### PR TITLE
Dialyzer: Refine the types for some BIFs

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -1796,6 +1796,7 @@ put(_Key, _Val) ->
     erlang:nif_error(undefined).
 
 %% raise/3
+%% Shadowed by erl_bif_types: erlang:raise/3
 -spec erlang:raise(Class, Reason, Stacktrace) -> 'badarg' when
       Class :: 'error' | 'exit' | 'throw',
       Reason :: term(),

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -3987,6 +3987,7 @@ rvrs(Xs) -> rvrs(Xs, []).
 rvrs([],Ys) -> Ys;
 rvrs([X|Xs],Ys) -> rvrs(Xs, [X|Ys]).
 
+%% Shadowed by erl_bif_types: erlang:min/2
 -spec min(Term1, Term2) -> Minimum when
       Term1 :: term(),
       Term2 :: term(),
@@ -3994,6 +3995,7 @@ rvrs([X|Xs],Ys) -> rvrs(Xs, [X|Ys]).
 min(A, B) when A > B -> B;
 min(A, _) -> A.
 
+%% Shadowed by erl_bif_types: erlang:max/2
 -spec max(Term1, Term2) -> Maximum when
       Term1 :: term(),
       Term2 :: term(),

--- a/lib/common_test/src/ct.erl
+++ b/lib/common_test/src/ct.erl
@@ -296,6 +296,8 @@ capture_get([ExclCat | ExclCategories]) ->
 capture_get([]) ->
     test_server:capture_get().
 
+-spec fail(term()) -> no_return().
+
 fail(Reason) ->
     try
 	exit({test_case_failed,Reason})
@@ -307,6 +309,8 @@ fail(Reason) ->
 	    end,
 	    erlang:raise(Class, R, Stk)
     end.
+
+-spec fail(io:format(), [term()]) -> no_return().
 
 fail(Format, Args) ->
     try io_lib:format(Format, Args) of

--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -1971,6 +1971,9 @@ adjusted_sleep(MSecs) ->
 %%
 %% Immediately calls exit. Included because test suites are easier
 %% to read when using this function, rather than exit directly.
+
+-spec fail(term()) -> no_return().
+
 fail(Reason) ->
     comment(cast_to_list(Reason)),
     try
@@ -1995,6 +1998,9 @@ cast_to_list(X) -> lists:flatten(io_lib:format("~tp", [X])).
 %%
 %% Immediately calls exit. Included because test suites are easier
 %% to read when using this function, rather than exit directly.
+
+-spec fail() -> no_return().
+
 fail() ->
     try
 	exit(suite_failed)

--- a/lib/dialyzer/src/erl_bif_types.erl
+++ b/lib/dialyzer/src/erl_bif_types.erl
@@ -772,6 +772,10 @@ type(erlang, length, 1, Xs, Opaques) ->
 %% Guard bif, needs to be here.
 type(erlang, map_size, 1, Xs, Opaques) ->
   type(maps, size, 1, Xs, Opaques);
+type(erlang, max, 2, Xs, Opaques) ->
+  strict(erlang, max, 2, Xs,
+         fun([A, B]) -> t_sup(A, B) end,
+         Opaques);
 %% Guard bif, needs to be here.
 type(erlang, map_get, 2, Xs, Opaques) ->
   type(maps, get, 2, Xs, Opaques);
@@ -803,6 +807,10 @@ type(erlang, make_tuple, 3, Xs, Opaques) ->
 	       _Other -> t_tuple()
 	     end
 	 end, Opaques);
+type(erlang, min, 2, Xs, Opaques) ->
+  strict(erlang, min, 2, Xs,
+         fun([A, B]) -> t_sup(A, B) end,
+         Opaques);
 type(erlang, nif_error, 1, Xs, Opaques) ->
   %% this BIF and the next one are stubs for NIFs and never return
   strict(erlang, nif_error, 1, Xs, fun (_) -> t_any() end, Opaques);
@@ -2297,6 +2305,8 @@ arg_types(erlang, is_tuple, 1) ->
 %% Guard bif, needs to be here.
 arg_types(erlang, length, 1) ->
   [t_list()];
+arg_types(erlang, max, 2) ->
+  [t_any(), t_any()];
 %% Guard bif, needs to be here.
 arg_types(erlang, map_size, 1) ->
   [t_map()];
@@ -2309,6 +2319,8 @@ arg_types(erlang, make_tuple, 2) ->
   [t_non_neg_fixnum(), t_any()];  % the value 0 is OK as first argument
 arg_types(erlang, make_tuple, 3) ->
   [t_non_neg_fixnum(), t_any(), t_list(t_tuple([t_pos_integer(), t_any()]))];
+arg_types(erlang, min, 2) ->
+  [t_any(), t_any()];
 arg_types(erlang, nif_error, 1) ->
   [t_any()];
 arg_types(erlang, nif_error, 2) ->

--- a/lib/dialyzer/src/erl_bif_types.erl
+++ b/lib/dialyzer/src/erl_bif_types.erl
@@ -813,6 +813,13 @@ type(erlang, node, 0, _, _Opaques) -> t_node();
 %% Guard bif, needs to be here.
 type(erlang, node, 1, Xs, Opaques) ->
   strict(erlang, node, 1, Xs, fun (_) -> t_node() end, Opaques);
+type(erlang, raise, 3, Xs, Opaques) ->
+  Ts = arg_types(erlang, raise, 3),
+  Xs1 = inf_lists(Xs, Ts, Opaques),
+  case any_is_none_or_unit(Xs1) of
+    true -> t_atom('badarg');
+    false -> t_none()
+  end;
 %% Guard bif, needs to be here.
 type(erlang, round, 1, Xs, Opaques) ->
   strict(erlang, round, 1, Xs, fun (_) -> t_integer() end, Opaques);
@@ -2312,6 +2319,20 @@ arg_types(erlang, node, 0) ->
 %% Guard bif, needs to be here.
 arg_types(erlang, node, 1) ->
   [t_identifier()];
+arg_types(erlang, raise, 3) ->
+  %% The types are based on the implementation of erlang:raise/3, not
+  %% the documention. That is, those are the types for which
+  %% erlang:raise/3 will raise an exception. If the arguments do not
+  %% conform to those types, erlang:raise/3 will return 'badarg'.
+  Class = t_sup([t_atom('error'), t_atom('exit'), t_atom('throw')]),
+  InfoList = t_list(),                 %erlang:raise/3 does not check the contents of the list.
+  ArityOrArgs = t_any(),               %erlang:raise/3 does not check the type.
+  MFA = t_tuple([t_module(), t_atom(), ArityOrArgs]),
+  MFAS = t_tuple([t_module(), t_atom(), ArityOrArgs, InfoList]),
+  Fun = t_tuple([t_fun(), ArityOrArgs]),
+  FunI = t_tuple([t_fun(), ArityOrArgs, InfoList]),
+  Stack = t_list(t_sup([MFA, MFAS, Fun, FunI])),
+  [Class, t_any(), Stack];
 %% Guard bif, needs to be here.
 arg_types(erlang, round, 1) ->
   [t_number()];
@@ -2550,7 +2571,6 @@ check_fun_application(Fun, Args, Opaques) ->
     false ->
       error
   end.
-
 
 %% =====================================================================
 %% Some basic types used in various parts of the system

--- a/lib/dialyzer/test/small_SUITE_data/results/try2
+++ b/lib/dialyzer/test/small_SUITE_data/results/try2
@@ -1,2 +1,3 @@
 
+try2.erl:12:1: Function run/2 has no local return
 try2.erl:33:1: Function run3/2 has no local return

--- a/lib/stdlib/src/unicode.erl
+++ b/lib/stdlib/src/unicode.erl
@@ -390,6 +390,8 @@ characters_to_binary_int(ML, InEncoding) ->
             fake_stacktrace(Reason, characters_to_binary, [ML, InEncoding])
     end.
 
+-spec fake_stacktrace(term(), atom(), [term()]) -> no_return().
+
 fake_stacktrace(Reason, Name, Args) ->
     try
         error(new_stacktrace, Args)


### PR DESCRIPTION
Refine the types for `max/2`, `min/2`, and `erlang:raise/3`.