### PR TITLE
JIT: Strengthen type-based optimizations

### DIFF
--- a/erts/emulator/beam/beam_file.c
+++ b/erts/emulator/beam/beam_file.c
@@ -607,7 +607,11 @@ static int parse_type_chunk(BeamFile *beam, IFF_Chunk *chunk) {
     beamreader_init(chunk->data, chunk->size, &reader);
 
     LoadAssert(beamreader_read_i32(&reader, &version));
-    LoadAssert(version == BEAM_TYPES_VERSION);
+    if (version != BEAM_TYPES_VERSION) {
+        /* Incompatible type format. */
+        init_fallback_type_table(beam);
+        return 1;
+    }
 
     types = &beam->types;
     ASSERT(types->entries == NULL);
@@ -624,8 +628,8 @@ static int parse_type_chunk(BeamFile *beam, IFF_Chunk *chunk) {
     for (i = 0; i < count; i++) {
         const byte *type_data;
 
-        LoadAssert(beamreader_read_bytes(&reader, 2, &type_data));
-        LoadAssert(beam_types_decode(type_data, 2, &types->entries[i]));
+        LoadAssert(beamreader_read_bytes(&reader, 18, &type_data));
+        LoadAssert(beam_types_decode(type_data, 18, &types->entries[i]));
     }
 
     /* The first entry MUST be the "any type." */

--- a/erts/emulator/beam/beam_types.c
+++ b/erts/emulator/beam/beam_types.c
@@ -28,20 +28,36 @@
 #include "erl_message.h"
 #include "external.h"
 
+static Sint64 get_sint64(const byte *data);
+
 int beam_types_decode(const byte *data, Uint size, BeamType *out) {
     int types;
 
-    if (size != 2) {
+    if (size != 18) {
         return 0;
     }
 
     types = (Uint16)data[0] << 8 | (Uint16)data[1];
-
     if (types == BEAM_TYPE_NONE) {
         return 0;
     }
 
     out->type_union = types;
 
+    data += 2;
+    out->min = get_sint64(data);
+    data += 8;
+    out->max = get_sint64(data);
+
     return 1;
+}
+
+static Sint64 get_sint64(const byte *data) {
+    Sint64 value = 0;
+    int i;
+
+    for (i = 0; i < 8; i++) {
+        value = value << 8 | (Sint16)data[i];
+    }
+    return value;
 }

--- a/erts/emulator/beam/beam_types.h
+++ b/erts/emulator/beam/beam_types.h
@@ -37,7 +37,7 @@
 
 #include "sys.h"
 
-#define BEAM_TYPES_VERSION 0
+#define BEAM_TYPES_VERSION 1
 
 #define BEAM_TYPE_NONE               (0)
 
@@ -90,6 +90,10 @@ typedef struct {
     /** @brief A set of the possible types (atom, tuple, etc) this term may
      * be. When a single bit is set, the term will always be of that type. */
     int type_union;
+
+    /** @brief Minimum and maximum values. Only valid if min <= max. */
+    Sint64 min;
+    Sint64 max;
 } BeamType;
 
 int beam_types_decode(const byte *data, Uint size, BeamType *out);

--- a/erts/emulator/beam/emu/emu_load.c
+++ b/erts/emulator/beam/emu/emu_load.c
@@ -1222,10 +1222,10 @@ int beam_load_emit_op(LoaderState *stp, BeamOp *tmp_op) {
             ci++;
             break;
         case TAG_x:
-            code[ci++] = make_loader_x_reg(tmp_op->a[arg].val);
+            code[ci++] = make_loader_x_reg(tmp_op->a[arg].val & REG_MASK);
             break;
         case TAG_y:
-            code[ci++] = make_loader_y_reg(tmp_op->a[arg].val + CP_SIZE);
+            code[ci++] = make_loader_y_reg((tmp_op->a[arg].val & REG_MASK) + CP_SIZE);
             break;
         case TAG_n:
             code[ci++] = NIL;

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -41,6 +41,7 @@ extern "C"
 #include "erl_vm.h"
 #include "global.h"
 #include "beam_catches.h"
+#include "big.h"
 
 #include "beam_asm.h"
 }
@@ -1204,6 +1205,20 @@ protected:
 
     bool exact_type(const ArgVal &arg, int type_id) const {
         return always_one_of(arg, type_id);
+    }
+
+    bool is_product_small(const ArgVal &LHS, const ArgVal &RHS) {
+        if (!(always_small(LHS) && always_small(RHS))) {
+            return false;
+        } else {
+            Sint64 res, min, max, min1, max1, min2, max2;
+            getIntRange(LHS, min1, max1);
+            getIntRange(RHS, min2, max2);
+            min = std::min(abs(min1), abs(min2));
+            max = std::max(abs(max1), abs(max2));
+            res = min * max;
+            return IS_SSMALL(res);
+        }
     }
 
     /* Helpers */

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -24,6 +24,7 @@
 #include <queue>
 #include <map>
 #include <functional>
+#include <algorithm>
 
 #ifndef ASMJIT_ASMJIT_H_INCLUDED
 #    include <asmjit/asmjit.hpp>
@@ -589,6 +590,13 @@ protected:
         a.tbnz(Src, imm(bitNumber), Fail);
     }
 
+    void emit_is_not_boxed(Label Fail, arm::Gp Src) {
+        const int bitNumber = 0;
+        ERTS_CT_ASSERT(_TAG_PRIMARY_MASK - TAG_PRIMARY_BOXED ==
+                       (1 << bitNumber));
+        a.tbz(Src, imm(bitNumber), Fail);
+    }
+
     arm::Gp emit_ptr_val(arm::Gp Dst, arm::Gp Src) {
 #if !defined(TAG_LITERAL_PTR)
         return Src;
@@ -1148,8 +1156,36 @@ protected:
         return beam->types.entries[arg.typeIndex()].type_union;
     }
 
+    auto getIntRange(const ArgVal &arg) const {
+        if (is_small(arg.getValue())) {
+            Sint value = signed_val(arg.getValue());
+            return std::make_pair(value, value);
+        } else {
+            ASSERT(arg.typeIndex() < beam->types.count);
+            const auto &entry = beam->types.entries[arg.typeIndex()];
+            ASSERT(entry.type_union & BEAM_TYPE_INTEGER);
+            return std::make_pair(entry.min, entry.max);
+        }
+    }
+
+    bool always_small(const ArgVal &arg) const {
+        if (arg.isImmed() && is_small(arg.getValue())) {
+            return true;
+        }
+        int type_union = getTypeUnion(arg);
+        if (type_union == BEAM_TYPE_INTEGER) {
+            auto [min, max] = getIntRange(arg);
+            return min <= max;
+        } else {
+            return false;
+        }
+    }
+
     bool always_immediate(const ArgVal &arg) const {
         if (arg.isImmed()) {
+            return true;
+        }
+        if (always_small(arg)) {
             return true;
         }
         int type_union = getTypeUnion(arg);
@@ -1207,17 +1243,47 @@ protected:
         return always_one_of(arg, type_id);
     }
 
+    bool is_sum_small(const ArgVal &LHS, const ArgVal &RHS) {
+        if (!(always_small(LHS) && always_small(RHS))) {
+            return false;
+        } else {
+            Sint min, max;
+            auto [min1, max1] = getIntRange(LHS);
+            auto [min2, max2] = getIntRange(RHS);
+            min = min1 + min2;
+            max = max1 + max2;
+            return IS_SSMALL(min) && IS_SSMALL(max);
+        }
+    }
+
+    bool is_difference_small(const ArgVal &LHS, const ArgVal &RHS) {
+        if (!(always_small(LHS) && always_small(RHS))) {
+            return false;
+        } else {
+            Sint min, max;
+            auto [min1, max1] = getIntRange(LHS);
+            auto [min2, max2] = getIntRange(RHS);
+            min = min1 - min2;
+            max = max1 - max2;
+            return IS_SSMALL(min) && IS_SSMALL(max);
+        }
+    }
+
     bool is_product_small(const ArgVal &LHS, const ArgVal &RHS) {
         if (!(always_small(LHS) && always_small(RHS))) {
             return false;
         } else {
-            Sint64 res, min, max, min1, max1, min2, max2;
-            getIntRange(LHS, min1, max1);
-            getIntRange(RHS, min2, max2);
-            min = std::min(abs(min1), abs(min2));
-            max = std::max(abs(max1), abs(max2));
-            res = min * max;
-            return IS_SSMALL(res);
+            auto [min1, max1] = getIntRange(LHS);
+            auto [min2, max2] = getIntRange(RHS);
+            auto mag1 = std::max(abs(min1), abs(max1));
+            auto mag2 = std::max(abs(min2), abs(max2));
+
+            /*
+             * mag1 * mag2 <= MAX_SMALL
+             * mag1 <= MAX_SMALL / mag2   (when mag2 != 0)
+             */
+            ERTS_CT_ASSERT(MAX_SMALL < -MIN_SMALL);
+            return mag2 == 0 || mag1 <= MAX_SMALL / mag2;
         }
     }
 
@@ -1261,7 +1327,11 @@ protected:
     void emit_div_rem(const ArgVal &Fail,
                       const ArgVal &LHS,
                       const ArgVal &RHS,
-                      const ErtsCodeMFA *error_mfa);
+                      const ErtsCodeMFA *error_mfa,
+                      const ArgVal &Quotient,
+                      const ArgVal &Remainder,
+                      bool need_div,
+                      bool need_rem);
 
     void emit_i_bif(const ArgVal &Fail, const ArgVal &Bif, const ArgVal &Dst);
 

--- a/erts/emulator/beam/jit/arm/instr_arith.cpp
+++ b/erts/emulator/beam/jit/arm/instr_arith.cpp
@@ -23,6 +23,7 @@
 extern "C"
 {
 #include "erl_bif_table.h"
+#include "big.h"
 }
 
 /*
@@ -70,12 +71,31 @@ void BeamModuleAssembler::emit_i_plus(const ArgVal &Fail,
                                       const ArgVal &LHS,
                                       const ArgVal &RHS,
                                       const ArgVal &Dst) {
+    bool rhs_is_arm_literal = RHS.isImmed() && is_small(RHS.getValue()) &&
+                              Support::isUInt12(RHS.getValue());
+
+    if (is_sum_small(LHS, RHS)) {
+        auto dst = init_destination(Dst, ARG1);
+        if (rhs_is_arm_literal) {
+            auto lhs = load_source(LHS, ARG2);
+            Uint cleared_tag = RHS.getValue() & ~_TAG_IMMED1_MASK;
+            comment("add small constant without overflow check");
+            a.add(dst.reg, lhs.reg, imm(cleared_tag));
+        } else {
+            auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
+            comment("addition without overflow check");
+            a.and_(TMP1, rhs.reg, imm(~_TAG_IMMED1_MASK));
+            a.add(dst.reg, lhs.reg, TMP1);
+        }
+        flush_var(dst);
+        return;
+    }
+
     Label next = a.newLabel();
 
     auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
-    bool rhs_is_small = RHS.isImmed() && is_small(RHS.getValue());
 
-    if (rhs_is_small && Support::isUInt12(RHS.getValue())) {
+    if (rhs_is_arm_literal) {
         comment("add small constant with overflow check");
         Uint cleared_tag = RHS.getValue() & ~_TAG_IMMED1_MASK;
         a.adds(ARG1, lhs.reg, imm(cleared_tag));
@@ -85,9 +105,9 @@ void BeamModuleAssembler::emit_i_plus(const ArgVal &Fail,
         a.adds(ARG1, lhs.reg, TMP1);
     }
 
-    if (rhs_is_small) {
+    if (always_small(RHS)) {
         a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
-    } else if (LHS.isImmed() && is_small(LHS.getValue())) {
+    } else if (always_small(LHS)) {
         a.and_(TMP1, rhs.reg, imm(_TAG_IMMED1_MASK));
     } else {
         ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
@@ -161,11 +181,22 @@ void BeamModuleAssembler::emit_i_unary_minus(const ArgVal &Fail,
                                              const ArgVal &Live,
                                              const ArgVal &Src,
                                              const ArgVal &Dst) {
-    Label next = a.newLabel();
     auto src = load_source(Src, ARG2);
+    ArgVal zero = ArgVal(ArgVal::Immediate, make_small(0));
 
     a.mov(TMP1, imm(_TAG_IMMED1_SMALL));
     a.and_(TMP2, src.reg, imm(~_TAG_IMMED1_MASK));
+
+    if (is_difference_small(zero, Src)) {
+        auto dst = init_destination(Dst, ARG1);
+        comment("no overflow test because result is always small");
+        a.sub(dst.reg, TMP1, TMP2);
+        flush_var(dst);
+        return;
+    }
+
+    Label next = a.newLabel();
+
     a.subs(ARG1, TMP1, TMP2);
 
     /* Test for not overflow AND small operands. */
@@ -234,12 +265,31 @@ void BeamModuleAssembler::emit_i_minus(const ArgVal &Fail,
                                        const ArgVal &LHS,
                                        const ArgVal &RHS,
                                        const ArgVal &Dst) {
+    bool rhs_is_arm_literal = RHS.isImmed() && is_small(RHS.getValue()) &&
+                              Support::isUInt12(RHS.getValue());
+
+    if (is_difference_small(LHS, RHS)) {
+        auto dst = init_destination(Dst, ARG1);
+        if (rhs_is_arm_literal) {
+            auto lhs = load_source(LHS, ARG2);
+            Uint cleared_tag = RHS.getValue() & ~_TAG_IMMED1_MASK;
+            comment("subtract small constant without overflow check");
+            a.sub(dst.reg, lhs.reg, imm(cleared_tag));
+        } else {
+            auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
+            comment("subtraction without overflow check");
+            a.and_(TMP1, rhs.reg, imm(~_TAG_IMMED1_MASK));
+            a.sub(dst.reg, lhs.reg, TMP1);
+        }
+        flush_var(dst);
+        return;
+    }
+
     Label next = a.newLabel();
 
     auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
-    bool rhs_is_small = RHS.isImmed() && is_small(RHS.getValue());
 
-    if (rhs_is_small && Support::isUInt12(RHS.getValue())) {
+    if (rhs_is_arm_literal) {
         comment("subtract small constant with overflow check");
         Uint cleared_tag = RHS.getValue() & ~_TAG_IMMED1_MASK;
         a.subs(ARG1, lhs.reg, imm(cleared_tag));
@@ -249,9 +299,9 @@ void BeamModuleAssembler::emit_i_minus(const ArgVal &Fail,
         a.subs(ARG1, lhs.reg, TMP1);
     }
 
-    if (rhs_is_small) {
+    if (always_small(RHS)) {
         a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
-    } else if (LHS.isImmed() && is_small(LHS.getValue())) {
+    } else if (always_small(LHS)) {
         a.and_(TMP1, rhs.reg, imm(_TAG_IMMED1_MASK));
     } else {
         ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
@@ -393,18 +443,36 @@ void BeamModuleAssembler::emit_i_times(const ArgVal &Fail,
                                        const ArgVal &LHS,
                                        const ArgVal &RHS,
                                        const ArgVal &Dst) {
-    auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
-    mov_var(ARG2, lhs);
-    mov_var(ARG3, rhs);
-
-    if (Fail.getValue() != 0) {
-        fragment_call(ga->get_times_guard_shared());
-        emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));
+    if (is_product_small(LHS, RHS)) {
+        auto dst = init_destination(Dst, ARG1);
+        comment("multiplication without overflow check");
+        if (RHS.isImmed()) {
+            auto lhs = load_source(LHS, ARG2);
+            a.and_(TMP1, lhs.reg, imm(~_TAG_IMMED1_MASK));
+            mov_imm(TMP2, signed_val(RHS.getValue()));
+        } else {
+            auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
+            a.and_(TMP1, lhs.reg, imm(~_TAG_IMMED1_MASK));
+            a.asr(TMP2, rhs.reg, imm(_TAG_IMMED1_SIZE));
+        }
+        a.mul(dst.reg, TMP1, TMP2);
+        a.orr(dst.reg, dst.reg, imm(_TAG_IMMED1_SMALL));
+        flush_var(dst);
     } else {
-        fragment_call(ga->get_times_body_shared());
-    }
+        auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
+        mov_var(ARG2, lhs);
+        mov_var(ARG3, rhs);
 
-    mov_arg(Dst, ARG1);
+        if (Fail.getValue() != 0) {
+            fragment_call(ga->get_times_guard_shared());
+            emit_branch_if_not_value(ARG1,
+                                     resolve_beam_label(Fail, dispUnknown));
+        } else {
+            fragment_call(ga->get_times_body_shared());
+        }
+
+        mov_arg(Dst, ARG1);
+    }
 }
 
 /*
@@ -552,18 +620,64 @@ void BeamGlobalAssembler::emit_int_div_rem_body_shared() {
 void BeamModuleAssembler::emit_div_rem(const ArgVal &Fail,
                                        const ArgVal &LHS,
                                        const ArgVal &RHS,
-                                       const ErtsCodeMFA *error_mfa) {
-    auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
+                                       const ErtsCodeMFA *error_mfa,
+                                       const ArgVal &Quotient,
+                                       const ArgVal &Remainder,
+                                       bool need_div,
+                                       bool need_rem) {
+    Sint divisor = 0;
 
-    mov_var(ARG2, lhs);
-    mov_var(ARG3, rhs);
+    if (RHS.isImmed() && is_small(RHS.getValue())) {
+        divisor = signed_val(RHS.getValue());
+    }
 
-    if (Fail.getValue() != 0) {
-        fragment_call(ga->get_int_div_rem_guard_shared());
-        a.cond_eq().b(resolve_beam_label(Fail, disp1MB));
+    if (always_small(LHS) && divisor != (Sint)0 && divisor != (Sint)-1) {
+        auto lhs = load_source(LHS, ARG3);
+        auto quotient = init_destination(Quotient, ARG1);
+        auto remainder = init_destination(Remainder, ARG2);
+
+        comment("skipped test for smalls operands and overflow");
+        a.asr(TMP1, lhs.reg, imm(_TAG_IMMED1_SIZE));
+        mov_imm(TMP2, divisor);
+        a.sdiv(quotient.reg, TMP1, TMP2);
+        if (need_rem) {
+            a.msub(remainder.reg, quotient.reg, TMP2, TMP1);
+        }
+        mov_imm(TMP3, _TAG_IMMED1_SMALL);
+        arm::Shift tagShift = arm::lsl(_TAG_IMMED1_SIZE);
+
+        if (need_div) {
+            a.orr(quotient.reg, TMP3, quotient.reg, tagShift);
+        }
+        if (need_rem) {
+            a.orr(remainder.reg, TMP3, remainder.reg, tagShift);
+        }
+        if (need_div) {
+            flush_var(quotient);
+        }
+        if (need_rem) {
+            flush_var(remainder);
+        }
     } else {
-        a.mov(ARG4, imm(error_mfa));
-        fragment_call(ga->get_int_div_rem_body_shared());
+        auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
+
+        mov_var(ARG2, lhs);
+        mov_var(ARG3, rhs);
+
+        if (Fail.getValue() != 0) {
+            fragment_call(ga->get_int_div_rem_guard_shared());
+            a.cond_eq().b(resolve_beam_label(Fail, disp1MB));
+        } else {
+            a.mov(ARG4, imm(error_mfa));
+            fragment_call(ga->get_int_div_rem_body_shared());
+        }
+
+        if (need_div) {
+            mov_arg(Quotient, ARG1);
+        }
+        if (need_rem) {
+            mov_arg(Remainder, ARG2);
+        }
     }
 }
 
@@ -575,10 +689,7 @@ void BeamModuleAssembler::emit_i_rem_div(const ArgVal &Fail,
                                          const ArgVal &Quotient) {
     static const ErtsCodeMFA bif_mfa = {am_erlang, am_rem, 2};
 
-    emit_div_rem(Fail, LHS, RHS, &bif_mfa);
-
-    mov_arg(Remainder, ARG2);
-    mov_arg(Quotient, ARG1);
+    emit_div_rem(Fail, LHS, RHS, &bif_mfa, Quotient, Remainder, true, true);
 }
 
 void BeamModuleAssembler::emit_i_div_rem(const ArgVal &Fail,
@@ -589,10 +700,7 @@ void BeamModuleAssembler::emit_i_div_rem(const ArgVal &Fail,
                                          const ArgVal &Remainder) {
     static const ErtsCodeMFA bif_mfa = {am_erlang, am_div, 2};
 
-    emit_div_rem(Fail, LHS, RHS, &bif_mfa);
-
-    mov_arg(Quotient, ARG1);
-    mov_arg(Remainder, ARG2);
+    emit_div_rem(Fail, LHS, RHS, &bif_mfa, Quotient, Remainder, true, true);
 }
 
 void BeamModuleAssembler::emit_i_int_div(const ArgVal &Fail,
@@ -601,10 +709,9 @@ void BeamModuleAssembler::emit_i_int_div(const ArgVal &Fail,
                                          const ArgVal &RHS,
                                          const ArgVal &Quotient) {
     static const ErtsCodeMFA bif_mfa = {am_erlang, am_div, 2};
+    ArgVal Dummy = ArgVal(TAG_y, 0);
 
-    emit_div_rem(Fail, LHS, RHS, &bif_mfa);
-
-    mov_arg(Quotient, ARG1);
+    emit_div_rem(Fail, LHS, RHS, &bif_mfa, Quotient, Dummy, true, false);
 }
 
 void BeamModuleAssembler::emit_i_rem(const ArgVal &Fail,
@@ -613,10 +720,9 @@ void BeamModuleAssembler::emit_i_rem(const ArgVal &Fail,
                                      const ArgVal &RHS,
                                      const ArgVal &Remainder) {
     static const ErtsCodeMFA bif_mfa = {am_erlang, am_rem, 2};
+    ArgVal Dummy = ArgVal(TAG_y, 0);
 
-    emit_div_rem(Fail, LHS, RHS, &bif_mfa);
-
-    mov_arg(Remainder, ARG2);
+    emit_div_rem(Fail, LHS, RHS, &bif_mfa, Dummy, Remainder, false, true);
 }
 
 void BeamModuleAssembler::emit_i_m_div(const ArgVal &Fail,
@@ -707,41 +813,46 @@ void BeamModuleAssembler::emit_i_band(const ArgVal &Fail,
                                       const ArgVal &LHS,
                                       const ArgVal &RHS,
                                       const ArgVal &Dst) {
-    Label next = a.newLabel();
     auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
     auto dst = init_destination(Dst, ARG1);
 
     /* TAG & TAG = TAG, so we don't need to tag it again. */
     a.and_(ARG1, lhs.reg, rhs.reg);
 
-    /* All other term types has at least one zero in the low 4
-     * bits. Therefore, the result will be a small iff both operands
-     * are small. */
-    ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
-    a.and_(TMP1, ARG1, imm(_TAG_IMMED1_MASK));
-    a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
-    a.cond_eq().b(next);
-
-    mov_var(ARG2, lhs);
-    mov_var(ARG3, rhs);
-
-    if (Fail.getValue() != 0) {
-        emit_enter_runtime(Live.getValue());
-        a.mov(ARG1, c_p);
-        runtime_call<3>(erts_band);
-        emit_leave_runtime(Live.getValue());
-        emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));
+    if (always_small(LHS) && always_small(RHS)) {
+        comment("skipped test for small operands since they are always small");
     } else {
-        emit_enter_runtime(Live.getValue());
-        fragment_call(ga->get_i_band_body_shared());
-        emit_leave_runtime(Live.getValue());
+        Label next = a.newLabel();
+
+        /* All other term types has at least one zero in the low 4
+         * bits. Therefore, the result will be a small iff both operands
+         * are small. */
+        ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
+        a.and_(TMP1, ARG1, imm(_TAG_IMMED1_MASK));
+        a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
+        a.cond_eq().b(next);
+
+        mov_var(ARG2, lhs);
+        mov_var(ARG3, rhs);
+
+        if (Fail.getValue() != 0) {
+            emit_enter_runtime(Live.getValue());
+            a.mov(ARG1, c_p);
+            runtime_call<3>(erts_band);
+            emit_leave_runtime(Live.getValue());
+            emit_branch_if_not_value(ARG1,
+                                     resolve_beam_label(Fail, dispUnknown));
+        } else {
+            emit_enter_runtime(Live.getValue());
+            fragment_call(ga->get_i_band_body_shared());
+            emit_leave_runtime(Live.getValue());
+        }
+
+        a.bind(next);
     }
 
-    a.bind(next);
-    {
-        mov_var(dst, ARG1);
-        flush_var(dst);
-    }
+    mov_var(dst, ARG1);
+    flush_var(dst);
 }
 
 /*
@@ -763,50 +874,53 @@ void BeamModuleAssembler::emit_i_bor(const ArgVal &Fail,
                                      const ArgVal &LHS,
                                      const ArgVal &RHS,
                                      const ArgVal &Dst) {
-    Label generic = a.newLabel(), next = a.newLabel();
     auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
     auto dst = init_destination(Dst, ARG1);
 
     /* TAG | TAG = TAG, so we don't need to tag it again. */
     a.orr(ARG1, lhs.reg, rhs.reg);
 
-    if (RHS.isImmed() && is_small(RHS.getValue())) {
-        a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
-    } else if (LHS.isImmed() && is_small(LHS.getValue())) {
-        a.and_(TMP1, rhs.reg, imm(_TAG_IMMED1_MASK));
+    if (always_small(LHS) && always_small(RHS)) {
+        comment("skipped test for small operands since they are always small");
     } else {
-        ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
-        a.and_(TMP1, lhs.reg, rhs.reg);
-        a.and_(TMP1, TMP1, imm(_TAG_IMMED1_MASK));
-    }
-
-    a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
-    a.cond_eq().b(next);
-
-    a.bind(generic);
-    {
-        mov_var(ARG2, lhs);
-        mov_var(ARG3, rhs);
-
-        if (Fail.getValue() != 0) {
-            emit_enter_runtime(Live.getValue());
-            a.mov(ARG1, c_p);
-            runtime_call<3>(erts_bor);
-            emit_leave_runtime(Live.getValue());
-            emit_branch_if_not_value(ARG1,
-                                     resolve_beam_label(Fail, dispUnknown));
+        Label generic = a.newLabel(), next = a.newLabel();
+        if (always_small(RHS)) {
+            a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
+        } else if (always_small(LHS)) {
+            a.and_(TMP1, rhs.reg, imm(_TAG_IMMED1_MASK));
         } else {
-            emit_enter_runtime(Live.getValue());
-            fragment_call(ga->get_i_bor_body_shared());
-            emit_leave_runtime(Live.getValue());
+            ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
+            a.and_(TMP1, lhs.reg, rhs.reg);
+            a.and_(TMP1, TMP1, imm(_TAG_IMMED1_MASK));
         }
+
+        a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
+        a.cond_eq().b(next);
+
+        a.bind(generic);
+        {
+            mov_var(ARG2, lhs);
+            mov_var(ARG3, rhs);
+
+            if (Fail.getValue() != 0) {
+                emit_enter_runtime(Live.getValue());
+                a.mov(ARG1, c_p);
+                runtime_call<3>(erts_bor);
+                emit_leave_runtime(Live.getValue());
+                emit_branch_if_not_value(ARG1,
+                                         resolve_beam_label(Fail, dispUnknown));
+            } else {
+                emit_enter_runtime(Live.getValue());
+                fragment_call(ga->get_i_bor_body_shared());
+                emit_leave_runtime(Live.getValue());
+            }
+        }
+
+        a.bind(next);
     }
 
-    a.bind(next);
-    {
-        mov_var(dst, ARG1);
-        flush_var(dst);
-    }
+    mov_var(dst, ARG1);
+    flush_var(dst);
 }
 
 /*
@@ -836,9 +950,9 @@ void BeamModuleAssembler::emit_i_bxor(const ArgVal &Fail,
     a.eor(ARG1, lhs.reg, rhs.reg);
     a.orr(ARG1, ARG1, imm(_TAG_IMMED1_SMALL));
 
-    if (RHS.isImmed() && is_small(RHS.getValue())) {
+    if (always_small(RHS)) {
         a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
-    } else if (LHS.isImmed() && is_small(LHS.getValue())) {
+    } else if (always_small(LHS)) {
         a.and_(TMP1, rhs.reg, imm(_TAG_IMMED1_MASK));
     } else {
         ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
@@ -945,9 +1059,14 @@ void BeamModuleAssembler::emit_i_bnot(const ArgVal &Fail,
     /* Invert everything except the tag so we don't have to tag it again. */
     a.eor(ARG1, src.reg, imm(~_TAG_IMMED1_MASK));
 
-    a.and_(TMP1, src.reg, imm(_TAG_IMMED1_MASK));
-    a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
-    a.cond_eq().b(next);
+    if (always_one_of(Src, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+        comment("simplified test for small operand since it is a number");
+        emit_is_boxed(next, Src, ARG1);
+    } else {
+        a.and_(TMP1, src.reg, imm(_TAG_IMMED1_MASK));
+        a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
+        a.cond_eq().b(next);
+    }
 
     if (Fail.getValue() != 0) {
         emit_enter_runtime(Live.getValue());
@@ -987,14 +1106,26 @@ void BeamModuleAssembler::emit_i_bsr(const ArgVal &Fail,
     Label generic = a.newLabel(), next = a.newLabel();
     auto lhs = load_source(LHS, ARG2);
     auto dst = init_destination(Dst, ARG1);
+    bool need_generic = true;
 
     if (RHS.isImmed() && is_small(RHS.getValue())) {
         Sint shift = signed_val(RHS.getValue());
 
         if (shift >= 0 && shift < SMALL_BITS - 1) {
-            a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
-            a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
-            a.cond_ne().b(generic);
+            if (always_small(LHS)) {
+                comment("skipped test for small left operand because it is "
+                        "always small");
+                need_generic = false;
+            } else if (always_one_of(LHS,
+                                     BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+                comment("simplified test for small operand since it is a "
+                        "number");
+                emit_is_not_boxed(generic, lhs.reg);
+            } else {
+                a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
+                a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
+                a.cond_ne().b(generic);
+            }
 
             /* We don't need to clear the mask after shifting because
              * _TAG_IMMED1_SMALL will set all the bits anyway. */
@@ -1002,7 +1133,9 @@ void BeamModuleAssembler::emit_i_bsr(const ArgVal &Fail,
             a.asr(TMP1, lhs.reg, imm(shift));
             a.orr(dst.reg, TMP1, imm(_TAG_IMMED1_SMALL));
 
-            a.b(next);
+            if (need_generic) {
+                a.b(next);
+            }
         } else {
             /* Constant shift is negative or too big to fit the `asr`
              * instruction; fall back to the generic path. */
@@ -1010,7 +1143,7 @@ void BeamModuleAssembler::emit_i_bsr(const ArgVal &Fail,
     }
 
     a.bind(generic);
-    {
+    if (need_generic) {
         mov_var(ARG2, lhs);
         mov_arg(ARG3, RHS);
 
@@ -1105,9 +1238,19 @@ void BeamModuleAssembler::emit_i_bsl(const ArgVal &Fail,
             a.cls(ARG4, TMP1);
             shiftLimit = ARG4;
 
-            a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
-            a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
-            a.cond_ne().b(generic);
+            if (always_small(LHS)) {
+                comment("skipped test for small operand since it is always "
+                        "small");
+            } else if (always_one_of(LHS,
+                                     BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+                comment("simplified test for small operand since it is a "
+                        "number");
+                emit_is_not_boxed(generic, TMP1);
+            } else {
+                a.and_(TMP1, lhs.reg, imm(_TAG_IMMED1_MASK));
+                a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
+                a.cond_ne().b(generic);
+            }
         } else {
             UWord value = LHS.getValue();
 

--- a/erts/emulator/beam/jit/arm/instr_float.cpp
+++ b/erts/emulator/beam/jit/arm/instr_float.cpp
@@ -132,11 +132,19 @@ void BeamGlobalAssembler::emit_fconv_shared() {
 }
 
 void BeamModuleAssembler::emit_fconv(const ArgVal &Src, const ArgVal &Dst) {
-    Label next = a.newLabel(), not_small = a.newLabel(),
-          fallback = a.newLabel();
-
     auto dst = init_destination(Dst, a64::d0);
     auto src = load_source(Src, ARG1);
+
+    if (always_small(Src)) {
+        comment("skipped test for small operand since it is always small");
+        a.asr(TMP1, src.reg, imm(_TAG_IMMED1_SIZE));
+        a.scvtf(dst.reg, TMP1);
+        flush_var(dst);
+        return;
+    }
+
+    Label next = a.newLabel(), not_small = a.newLabel(),
+          fallback = a.newLabel();
 
     a.and_(TMP1, src.reg, imm(_TAG_IMMED1_MASK));
     a.cmp(TMP1, imm(_TAG_IMMED1_MASK));

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -1161,34 +1161,42 @@ gc_bif2 Fail Live u$bif:erlang:div/2 S1 S2 Dst => \
   i_m_div Fail Live S1 S2 Dst
 
 # Fused 'rem'/'div' pair.
-gc_bif2 Fail Live u$bif:erlang:rem/2 LHS RHS Remainder | \
-    gc_bif2 A B u$bif:erlang:intdiv/2 LHS RHS Quotient | \
-    distinct(LHS, Remainder) | \
-    distinct(RHS, Remainder) => \
-      i_rem_div Fail Live LHS RHS Remainder Quotient
+gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder | \
+    gc_bif2 A B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient | \
+    equal(LHS1, LHS2) | \
+    equal(RHS1, RHS2) | \
+    distinct(LHS1, Remainder) | \
+    distinct(RHS1, Remainder) => \
+      i_rem_div Fail Live LHS1 RHS1 Remainder Quotient
 
 # As above but with a `line` in between
-gc_bif2 Fail Live u$bif:erlang:rem/2 LHS RHS Remainder | \
+gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder | \
     line Loc | \
-    gc_bif2 A B u$bif:erlang:intdiv/2 LHS RHS Quotient | \
-    distinct(LHS, Remainder) | \
-    distinct(RHS, Remainder) => \
-      i_rem_div Fail Live LHS RHS Remainder Quotient
+    gc_bif2 A B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient | \
+    equal(LHS1, LHS2) | \
+    equal(RHS1, RHS2) | \
+    distinct(LHS1, Remainder) | \
+    distinct(RHS1, Remainder) => \
+      i_rem_div Fail Live LHS1 RHS1 Remainder Quotient
 
 # Fused 'div'/'rem' pair
-gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS RHS Quotient | \
-    gc_bif2 A B u$bif:erlang:rem/2 LHS RHS Remainder | \
-    distinct(LHS, Quotient) | \
-    distinct(RHS, Quotient) => \
-      i_div_rem Fail Live LHS RHS Quotient Remainder
+gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient | \
+    gc_bif2 A B u$bif:erlang:rem/2 LHS2 RHS2 Remainder | \
+    equal(LHS1, LHS2) | \
+    equal(RHS1, RHS2) | \
+    distinct(LHS1, Quotient) | \
+    distinct(RHS1, Quotient) => \
+      i_div_rem Fail Live LHS1 RHS1 Quotient Remainder
 
 # As above but with a `line` in between
-gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS RHS Quotient | \
+gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient | \
     line Loc | \
-    gc_bif2 A B u$bif:erlang:rem/2 LHS RHS Remainder | \
-    distinct(LHS, Quotient) | \
-    distinct(RHS, Quotient) => \
-      i_div_rem Fail Live LHS RHS Quotient Remainder
+    gc_bif2 A B u$bif:erlang:rem/2 LHS2 RHS2 Remainder | \
+    equal(LHS1, LHS2) | \
+    equal(RHS1, RHS2) | \
+    distinct(LHS1, Quotient) | \
+    distinct(RHS1, Quotient) => \
+      i_div_rem Fail Live LHS1 RHS1 Quotient Remainder
 
 gc_bif2 Fail Live u$bif:erlang:intdiv/2 S1 S2 Dst => \
   i_int_div Fail Live S1 S2 Dst

--- a/erts/emulator/beam/jit/x86/instr_float.cpp
+++ b/erts/emulator/beam/jit/x86/instr_float.cpp
@@ -133,6 +133,15 @@ void BeamGlobalAssembler::emit_fconv_shared() {
 }
 
 void BeamModuleAssembler::emit_fconv(const ArgVal &Src, const ArgVal &Dst) {
+    if (always_small(Src)) {
+        comment("simplified fconv since source is always small");
+        mov_arg(ARG2, Src);
+        a.sar(ARG2, imm(_TAG_IMMED1_SIZE));
+        a.cvtsi2sd(x86::xmm0, ARG2);
+        a.movsd(getArgRef(Dst), x86::xmm0);
+        return;
+    }
+
     Label next = a.newLabel(), not_small = a.newLabel(),
           fallback = a.newLabel();
 

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -1171,34 +1171,42 @@ gc_bif2 Fail Live u$bif:erlang:div/2 S1 S2 Dst => \
   i_m_div Fail S1 S2 Dst
 
 # Fused 'rem'/'div' pair.
-gc_bif2 Fail Live u$bif:erlang:rem/2 LHS RHS Remainder | \
-    gc_bif2 A B u$bif:erlang:intdiv/2 LHS RHS Quotient | \
-    distinct(LHS, Remainder) | \
-    distinct(RHS, Remainder) => \
-      i_rem_div LHS RHS Fail Remainder Quotient
+gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder | \
+    gc_bif2 A B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient | \
+    equal(LHS1, LHS2) | \
+    equal(RHS1, RHS2) | \
+    distinct(LHS1, Remainder) | \
+    distinct(RHS1, Remainder) => \
+      i_rem_div LHS1 RHS1 Fail Remainder Quotient
 
 # As above but with a `line` in between
-gc_bif2 Fail Live u$bif:erlang:rem/2 LHS RHS Remainder | \
+gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder | \
     line Loc | \
-    gc_bif2 A B u$bif:erlang:intdiv/2 LHS RHS Quotient | \
-    distinct(LHS, Remainder) | \
-    distinct(RHS, Remainder) => \
-      i_rem_div LHS RHS Fail Remainder Quotient
+    gc_bif2 A B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient | \
+    equal(LHS1, LHS2) | \
+    equal(RHS1, RHS2) | \
+    distinct(LHS1, Remainder) | \
+    distinct(RHS1, Remainder) => \
+      i_rem_div LHS1 RHS1 Fail Remainder Quotient
 
 # Fused 'div'/'rem' pair
-gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS RHS Quotient | \
-    gc_bif2 A B u$bif:erlang:rem/2 LHS RHS Remainder | \
-    distinct(LHS, Quotient) | \
-    distinct(RHS, Quotient) => \
-      i_div_rem LHS RHS Fail Quotient Remainder
+gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient | \
+    gc_bif2 A B u$bif:erlang:rem/2 LHS2 RHS2 Remainder | \
+    equal(LHS1, LHS2) | \
+    equal(RHS1, RHS2) | \
+    distinct(LHS1, Quotient) | \
+    distinct(RHS1, Quotient) => \
+      i_div_rem LHS1 RHS1 Fail Quotient Remainder
 
 # As above but with a `line` in between
-gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS RHS Quotient | \
+gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient | \
     line Loc | \
-    gc_bif2 A B u$bif:erlang:rem/2 LHS RHS Remainder | \
-    distinct(LHS, Quotient) | \
-    distinct(RHS, Quotient) => \
-      i_div_rem LHS RHS Fail Quotient Remainder
+    gc_bif2 A B u$bif:erlang:rem/2 LHS2 RHS2 Remainder | \
+    equal(LHS1, LHS2) | \
+    equal(RHS1, RHS2) | \
+    distinct(LHS1, Quotient) | \
+    distinct(RHS1, Quotient) => \
+      i_div_rem LHS1 RHS1 Fail Quotient Remainder
 
 gc_bif2 Fail Live u$bif:erlang:intdiv/2 S1 S2 Dst => \
   i_int_div Fail S1 S2 Dst

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -821,13 +821,12 @@ erlang_band_type_1(LHS, Int) ->
             Max = max(Min, min(Max0, Union band Int)),
 
             #t_integer{elements={Min,Max}};
-        #t_integer{} when Int >= 0 ->
+        _ when Int > 0 ->
             %% The range is either unknown or too wide, conservatively assume
-            %% that the new range is 0 .. Int.
-            %%
-            %% NOTE: We must not produce a singleton type unless we are sure
-            %% that the operation can't fail. Therefore, we only do this
-            %% inference if LHS is known to be an integer.
+            %% that the new range is 0 .. Int. Note that since Int > 0, we
+            %% will never produce a singleton value. Producing a singleton value
+            %% is probably harmless, but will produce worse code when it
+            %% is not known that the operation will succeed.
             beam_types:meet(LHS, #t_integer{elements={0,Int}});
         _ ->
             %% We can't infer boundaries when LHS is not an integer or

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -133,6 +133,15 @@ succeeds_if_type(ArgType, Required) ->
     end.
 
 %%
+%% Define an upper limit for functions that return sizes of data
+%% structures. The chosen value is about half the maxium size of a
+%% smallnum. That means that adding a small constant to it will result
+%% in a smallnum, but still the value is still sufficiently high to
+%% make it impossible to reach in the foreseeable future.
+%%
+-define(SIZE_UPPER_LIMIT, ((1 bsl 58) - 1)).
+
+%%
 %% Returns the inferred return and argument types for known functions, and
 %% whether it's safe to subtract argument types on failure.
 %%
@@ -153,13 +162,18 @@ succeeds_if_type(ArgType, Required) ->
 %% Note that these are all from the erlang module; suitable functions in other
 %% modules could fail due to the module not being loaded.
 types(erlang, 'map_size', [_]) ->
-    sub_safe(#t_integer{}, [#t_map{}]);
-types(erlang, 'tuple_size', [_]) ->
-    sub_safe(#t_integer{}, [#t_tuple{}]);
+    sub_safe(#t_integer{elements={0,?SIZE_UPPER_LIMIT}}, [#t_map{}]);
+types(erlang, 'tuple_size', [Src]) ->
+    Min = case Src of
+              #t_tuple{size=Sz} -> Sz;
+              _ -> 0
+          end,
+    Max = (1 bsl 24) - 1,                       %Documented max size of a tuple.
+    sub_safe(#t_integer{elements={Min,Max}}, [#t_tuple{}]);
 types(erlang, 'bit_size', [_]) ->
-    sub_safe(#t_integer{}, [#t_bitstring{}]);
+    sub_safe(#t_integer{elements={0,?SIZE_UPPER_LIMIT}}, [#t_bitstring{}]);
 types(erlang, 'byte_size', [_]) ->
-    sub_safe(#t_integer{}, [#t_bitstring{}]);
+    sub_safe(#t_integer{elements={0,?SIZE_UPPER_LIMIT}}, [#t_bitstring{}]);
 types(erlang, hd, [Src]) ->
     RetType = erlang_hd_type(Src),
     sub_safe(RetType, [#t_cons{}]);
@@ -169,8 +183,12 @@ types(erlang, tl, [Src]) ->
 types(erlang, 'not', [_]) ->
     Bool = beam_types:make_boolean(),
     sub_safe(Bool, [Bool]);
-types(erlang, 'length', [_]) ->
-    sub_safe(#t_integer{}, [proper_list()]);
+types(erlang, 'length', [Src]) ->
+    Min = case Src of
+              #t_cons{} -> 1;
+              _ -> 0
+          end,
+    sub_safe(#t_integer{elements={Min,?SIZE_UPPER_LIMIT}}, [proper_list()]);
 
 %% Boolean ops
 types(erlang, 'and', [_,_]) ->
@@ -186,14 +204,21 @@ types(erlang, 'xor', [_,_]) ->
 %% Bitwise ops
 types(erlang, 'band', [_,_]=Args) ->
     sub_unsafe(erlang_band_type(Args), [#t_integer{}, #t_integer{}]);
-types(erlang, 'bor', [_,_]) ->
-    sub_unsafe(#t_integer{}, [#t_integer{}, #t_integer{}]);
+types(erlang, 'bor', [_,_]=Args) ->
+    sub_unsafe(erlang_bor_type(Args), [#t_integer{}, #t_integer{}]);
 types(erlang, 'bxor', [_,_]) ->
     sub_unsafe(#t_integer{}, [#t_integer{}, #t_integer{}]);
 types(erlang, 'bsl', [_,_]) ->
     sub_unsafe(#t_integer{}, [#t_integer{}, #t_integer{}]);
-types(erlang, 'bsr', [_,_]) ->
-    sub_unsafe(#t_integer{}, [#t_integer{}, #t_integer{}]);
+types(erlang, 'bsr', [_,_]=Types) ->
+    ArgTypes = [#t_integer{}, #t_integer{}],
+    case Types of
+        [#t_integer{elements={Min,Max}},#t_integer{elements={S,S}}] when S > 0 ->
+            T = #t_integer{elements={Min bsr S,Max bsr S}},
+            sub_unsafe(T, ArgTypes);
+        _ ->
+            sub_unsafe(#t_integer{}, ArgTypes)
+    end;
 types(erlang, 'bnot', [_]) ->
     sub_unsafe(#t_integer{}, [#t_integer{}]);
 
@@ -210,10 +235,28 @@ types(erlang, 'trunc', [_]) ->
     sub_unsafe(#t_integer{}, [number]);
 types(erlang, '/', [_,_]) ->
     sub_unsafe(#t_float{}, [number, number]);
-types(erlang, 'div', [_,_]) ->
-    sub_unsafe(#t_integer{}, [#t_integer{}, #t_integer{}]);
-types(erlang, 'rem', [_,_]) ->
-    sub_unsafe(#t_integer{}, [#t_integer{}, #t_integer{}]);
+types(erlang, 'div', [_,_]=Types) ->
+    ArgTypes = [#t_integer{}, #t_integer{}],
+    case Types of
+        [#t_integer{elements={Min,Max}},#t_integer{elements={D,D}}] when D > 0 ->
+            T = #t_integer{elements={Min div D,Max div D}},
+            sub_unsafe(T, ArgTypes);
+        _ ->
+            sub_unsafe(#t_integer{}, ArgTypes)
+    end;
+types(erlang, 'rem', [T1,T2]) ->
+    ArgTypes = [#t_integer{}, #t_integer{}],
+    case T2 of
+        #t_integer{elements={D,D}} when D > 0 ->
+            Max = abs(D) - 1,
+            Min = case T1 of
+                      #t_integer{elements={N,_}} when N >= 0 -> 0;
+                      _ -> -Max
+                  end,
+            sub_unsafe(#t_integer{elements={Min,Max}}, ArgTypes);
+        _ ->
+            sub_unsafe(#t_integer{}, ArgTypes)
+    end;
 
 %% Mixed-type arithmetic; '+'/2 and friends are handled in the catch-all
 %% clause for the 'erlang' module.
@@ -234,6 +277,11 @@ types(erlang, 'iolist_to_binary', [_]) ->
     %% Arg is an iodata(), despite its name.
     ArgType = beam_types:join(#t_list{}, #t_bitstring{size_unit=8}),
     sub_unsafe(#t_bitstring{size_unit=8}, [ArgType]);
+types(erlang, 'iolist_size', [_]) ->
+    %% Arg is an iodata(), despite its name. The size is NOT limited
+    %% by the size of memory.
+    ArgType = beam_types:join(#t_list{}, #t_bitstring{size_unit=8}),
+    sub_unsafe(#t_integer{}, [ArgType]);
 types(erlang, 'list_to_binary', [_]) ->
     %% Arg is an iolist(), despite its name.
     sub_unsafe(#t_bitstring{size_unit=8}, [#t_list{}]);
@@ -788,6 +836,26 @@ erlang_band_type_1(LHS, Int) ->
             %% negative number, as the latter sign-extends to infinity
             %% and we can't express an inverted range at the moment
             %% (cf. X band -8; either less than -7 or greater than 7).
+            beam_types:meet(LHS, #t_integer{})
+    end.
+
+erlang_bor_type([#t_integer{elements={Int,Int}}, RHS]) when is_integer(Int) ->
+    erlang_bor_type_1(RHS, Int);
+erlang_bor_type([LHS, #t_integer{elements={Int,Int}}]) when is_integer(Int) ->
+    erlang_bor_type_1(LHS, Int);
+erlang_bor_type(_) ->
+    #t_integer{}.
+
+erlang_bor_type_1(LHS, Int) ->
+    case LHS of
+        #t_integer{elements={Min0,Max0}} when Min0 >= 0, Max0 - Min0 < 1 bsl 256 ->
+            {_Intersection, Union} = range_masks(Min0, Max0),
+
+            Min = max(Min0, Int),
+            Max = Union bor Int,
+
+            #t_integer{elements={Min,Max}};
+        _ ->
             beam_types:meet(LHS, #t_integer{})
     end.
 

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -259,7 +259,7 @@ disasm_literals(<<Sz:32,Ext:Sz/binary,T/binary>>, Index) ->
 disasm_literals(<<>>, _) -> [].
 
 %%-----------------------------------------------------------------------
-%% Disassembles the literal table (constant pool) of a BEAM file.
+%% Disassembles the type table of a BEAM file.
 %%-----------------------------------------------------------------------
 
 -spec beam_disasm_types('none' | binary()) -> literals().
@@ -271,7 +271,7 @@ beam_disasm_types(<<?BEAM_TYPES_VERSION:32,Count:32,Table/binary>>) ->
     Count = gb_trees:size(Res),                 %Assertion.
     Res.
 
-disasm_types(<<Type:2/binary,Rest/binary>>, Index) ->
+disasm_types(<<Type:18/binary,Rest/binary>>, Index) ->
     [{Index,beam_types:decode_ext(Type)}|disasm_types(Rest, Index+1)];
 disasm_types(<<>>, _) ->
     [].

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -1105,11 +1105,12 @@ cg_block([#cg_set{anno=Anno,op={bif,Name},dst=Dst0,args=Args0}=I|T],
     end;
 cg_block([#cg_set{op=bs_create_bin,dst=Dst0,args=Args0,anno=Anno}=I,
           #cg_set{op=succeeded,dst=Bool}], {Bool,Fail0}, St) ->
+    Args1 = typed_args(Args0, Anno, St),
     Fail = bif_fail(Fail0),
     Line = line(Anno),
     Alloc = map_get(alloc, Anno),
     Live = get_live(I),
-    [Dst|Args1] = beam_args([Dst0|Args0], St),
+    Dst = beam_arg(Dst0, St),
     Args = bs_args(Args1),
     Unit = case Args of
                [{atom,append},_Seg,U|_] -> U;

--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -630,6 +630,8 @@ benefits_from_type_anno({bif,'=/='}, _Args) ->
     true;
 benefits_from_type_anno({bif,Op}, Args) ->
     not erl_internal:bool_op(Op, length(Args));
+benefits_from_type_anno(bs_create_bin, _Args) ->
+    true;
 benefits_from_type_anno(is_tagged_tuple, _Args) ->
     true;
 benefits_from_type_anno(call, [#b_var{} | _]) ->

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -19,7 +19,7 @@
 %%
 
 %% Type version, must be bumped whenever the external type format changes.
--define(BEAM_TYPES_VERSION, 0).
+-define(BEAM_TYPES_VERSION, 1).
 
 %% Common term types for passes operating on beam SSA and assembly. Helper
 %% functions for wrangling these can be found in beam_types.erl

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -1067,9 +1067,10 @@ vi(raw_raise=I, Vst0) ->
 
 vi(bs_init_writable=I, Vst) ->
     validate_body_call(I, 1, Vst);
-vi({bs_create_bin,{f,Fail},Heap,Live,Unit,Dst,{list,List}}, Vst0) ->
+vi({bs_create_bin,{f,Fail},Heap,Live,Unit,Dst,{list,List0}}, Vst0) ->
     verify_live(Live, Vst0),
     verify_y_init(Vst0),
+    List = [unpack_typed_arg(Arg) || Arg <- List0],
     verify_create_bin_list(List, Vst0),
     Vst = prune_x_regs(Live, Vst0),
     branch(Fail, Vst,

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -3055,7 +3055,28 @@ assert_not_fragile(Lit, #vst{}) ->
 
 bif_types(Op, Ss, Vst) ->
     Args = [normalize(get_term_type(Arg, Vst)) || Arg <- Ss],
-    beam_call_types:types(erlang, Op, Args).
+    case {Op,Ss} of
+        {element,[_,{literal,Tuple}]} when tuple_size(Tuple) > 0 ->
+            case beam_call_types:types(erlang, Op, Args) of
+                {any,ArgTypes,Safe} ->
+                    RetType = join_tuple_elements(Tuple),
+                    {RetType,ArgTypes,Safe};
+                Other ->
+                    Other
+            end;
+        {_,_} ->
+            beam_call_types:types(erlang, Op, Args)
+    end.
+
+join_tuple_elements(Tuple) ->
+    join_tuple_elements(tuple_size(Tuple), Tuple, none).
+
+join_tuple_elements(0, _Tuple, Type) ->
+    Type;
+join_tuple_elements(I, Tuple, Type0) ->
+    Type1 = beam_types:make_type_from_value(element(I, Tuple)),
+    Type = beam_types:join(Type0, Type1),
+    join_tuple_elements(I - 1, Tuple, Type).
 
 call_types({extfunc,M,F,A}, A, Vst) ->
     Args = get_call_args(A, Vst),

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -385,10 +385,25 @@ tuple(_Config) ->
     [] = [X || X <- [], #bird{b = b} == {bird,X}],
     [] = [X || X <- [], 3 == X#bird.a],
 
+    1 = do_literal_tuple_1(1),
+    1 = do_literal_tuple_1(20),
+    {'EXIT', _} = catch do_literal_tuple_1(id(0)),
+    {'EXIT', _} = catch do_literal_tuple_1(id(bad)),
+
+    2 = do_literal_tuple_2(1),
+    2 = do_literal_tuple_2(15),
+    2 = do_literal_tuple_2(20),
+
     ok.
 
 do_tuple() ->
     {0, _} = {necessary}.
+
+do_literal_tuple_1(X) ->
+    element(X, {1,1,1,1,1, 1,1,1,1,1, 1,1,1,1,1, 1,1,1,1,1}).
+
+do_literal_tuple_2(X) ->
+    element(X, {2,2,2,2,2, 2,2,2,2,2, 2,2,2,2,2, 2,2,2,2,2}).
 
 -record(x, {a}).
 


### PR DESCRIPTION
This pull requests strengthens the type-based optimizations in the JIT that were introduced in #5316.

The compiler has been enhanced to infer ranges for more operations. The ranges are now included in the type information stored in BEAM files.

With the enhanced type information, the JIT can now omit type checks and overflow checks for some arithmetic instructions, and can also omit some redundant tests when constructing binaries using the binary syntax.
