### PR TITLE
erl_docgen: Fix codeinclude

### DIFF
--- a/lib/erl_docgen/doc/src/Makefile
+++ b/lib/erl_docgen/doc/src/Makefile
@@ -47,13 +47,17 @@ XML_CHAPTER_FILES = \
 	inline_tags.xml \
 	header_tags.xml \
 	character_entities.xml \
-	block_tags.xml \
 	doc_storage.xml
+
+XML_CHAPTER_GEN_FILES = \
+	block_tags.xml
 
 BOOK_FILES = book.xml
 
 XML_FILES = $(BOOK_FILES) $(XML_APPLICATION_FILES) $(XML_REF6_FILES) \
             $(XML_PART_FILES) $(XML_CHAPTER_FILES) 
+
+XML_GEN_FILES = $(XML_CHAPTER_GEN_FILES:%=$(XMLDIR)/%)
 
 TECHNICAL_DESCR_FILES = 
 

--- a/lib/erl_docgen/doc/src/block_tags.xmlsrc
+++ b/lib/erl_docgen/doc/src/block_tags.xmlsrc
@@ -27,7 +27,7 @@
     <docno/>
     <date/>
     <rev/>
-    <file>block_tags.xml</file>
+    <file>block_tags.xmlsrc</file>
   </header>
 
   <p>Block tags typically define a separate block of information, such

--- a/lib/erl_docgen/priv/bin/codeline_preprocessing.escript
+++ b/lib/erl_docgen/priv/bin/codeline_preprocessing.escript
@@ -77,7 +77,7 @@ parse(InDev, OutDev, CPath) ->
 
 
 parse_line(CPath, Line) ->
-    case re:run(Line, "<codeinclude([^>]*)>.*</codeinclude>", [{capture, [1], list}]) of
+    case re:run(Line, "<codeinclude(.*)(>.*</codeinclude>|/>)", [{capture, [1], list}]) of
         {match,[Attributes]} ->
             File =
                 case re:run(Attributes,"file=\"([^\"]+)\"",[{capture, [1], list}]) of

--- a/lib/erl_docgen/priv/dtd/common.dtd
+++ b/lib/erl_docgen/priv/dtd/common.dtd
@@ -24,7 +24,7 @@
 
 <!ENTITY % refs               "seemfa|seeerl|seetype|seeapp|seecom|seecref|seefile|seeguide|url" >
 
-<!ENTITY % block              "p|pre|code|list|taglist|codeinclude" >
+<!ENTITY % block              "p|pre|code|list|taglist" >
 <!ENTITY % inline             "#PCDATA|c|i|em|strong|term|br|%refs;|
                                marker|anno|image" >
 <!-- XXX --> 


### PR DESCRIPTION
The regexp for finding <codeinclude> did not take into
consideration that elements in xml do not need to have
a closing tag. We shouldn't really try parsing xml with
regexp, but we try to make the best of the situation.

This commit also removed codeinclude from the dtd so that
at least in the future if any other codeinclude falls through
the regexp matching the xmllint will catch it.

Closes #5662