### PR TITLE
erts: Fix trace running memory leak

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -9924,6 +9924,17 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
                     if (((state & (ERTS_PSFLG_SUSPENDED
                                    | ERTS_PSFLG_ACTIVE)) != ERTS_PSFLG_ACTIVE)
                         & !(state & ERTS_PSFLG_EXITING)) {
+
+                        /* Tracing, handling signals and running sys_tasks may
+                           have created data on the process heap that should
+                           be GC:ed. */
+                        if (ERTS_IS_GC_DESIRED(p)
+                            && !(p->flags & (F_DELAY_GC|F_DISABLE_GC))) {
+                            int cost = scheduler_gc_proc(p, reds);
+                            calls += cost;
+                            reds -= cost;
+                        }
+
                         goto sched_out_proc;
                     }
 


### PR DESCRIPTION
If a process is being tracing using 'running' trace and
at the same time polled using erlang:process_info, then
the memory allocated for the tracing will never trigger
a GC as there are no GC tests for when only signals/sys
tasks are run.

This commit moves the GC check so that it is done earlier
in order to catch any memory allocated when executing
signals/sys tasks.

The bug is triggered by running etop towards an idle node.