### PR TITLE
[cleanup] Replace test_server:os_type() with os:type()

### DIFF
--- a/erts/test/erlc_SUITE.erl
+++ b/erts/test/erlc_SUITE.erl
@@ -150,7 +150,7 @@ compile_mib(Config) when is_list(Config) ->
     %% Try -W option and more verbose.
 
     ok = file:delete(Output),
-    case test_server:os_type() of
+    case os:type() of
         {unix,_} ->
             run(Config, Cmd, FileName, "-W +'{verbosity,info}'",
                 ["\\[GOOD-MIB[.]mib\\]\\[INF\\]: No accessfunction for 'sysDescr' => using default",

--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -43,7 +43,6 @@
 -export([peer_name/2, start_peer/3, start_peer/5]).
 -export([app_test/1, app_test/2, appup_test/1]).
 -export([comment/1, make_priv_dir/0]).
--export([os_type/0]).
 -export([run_on_shielded_node/2]).
 -export([is_cover/0,is_debug/0,is_commercial/0]).
 
@@ -3027,15 +3026,6 @@ read_comment() ->
 %% for the current test case.
 make_priv_dir() ->
     tc_supervisor_req(make_priv_dir).
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% os_type() -> OsType
-%%
-%% Returns the OsType of the target node. OsType is
-%% the same as returned from os:type()
-os_type() ->
-    os:type().
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% is_cover() -> boolean()

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -428,7 +428,7 @@ post() ->
      "only care about the client side of the the post. The server "
      "script will not actually use the post data."}].
 post(Config) when is_list(Config) ->
-    CGI = case test_server:os_type() of
+    CGI = case os:type() of
 	      {win32, _} ->
 		  "/cgi-bin/cgi_echo.exe";
 	      _ ->
@@ -453,7 +453,7 @@ delete() ->
      "only care about the client side of the the delete. The server "
      "script will not actually use the delete data."}].
 delete(Config) when is_list(Config) ->
-    CGI = case test_server:os_type() of
+    CGI = case os:type() of
           {win32, _} ->
           "/cgi-bin/cgi_echo.exe";
           _ ->
@@ -477,7 +477,7 @@ patch() ->
      "only care about the client side of the the patch. The server "
      "script will not actually use the patch data."}].
 patch(Config) when is_list(Config) ->
-    CGI = case test_server:os_type() of
+    CGI = case os:type() of
 	      {win32, _} ->
 		  "/cgi-bin/cgi_echo.exe";
 	      _ ->
@@ -499,7 +499,7 @@ post_stream() ->
      "We only care about the client side of the the post. "
      "The server script will not actually use the post data."}].
 post_stream(Config) when is_list(Config) ->
-    CGI = case test_server:os_type() of
+    CGI = case os:type() of
 	      {win32, _} ->
 		  "/cgi-bin/cgi_echo.exe";
 	      _ ->
@@ -2053,7 +2053,7 @@ setup_server_dirs(ServerRoot, DocRoot, DataDir) ->
 			       end
 		  end, Files),
     
-    Cgi = case test_server:os_type() of
+    Cgi = case os:type() of
 	      {win32, _} ->
 		  "cgi_echo.exe";
 	      _ ->

--- a/lib/inets/test/httpd_1_1.erl
+++ b/lib/inets/test/httpd_1_1.erl
@@ -244,7 +244,7 @@ head(Type, Port, Host, Node)->
 			 [{statuscode, 200}]),
     %% mod_cgi
     Script =
-	case test_server:os_type() of
+	case os:type() of
 	    {win32, _} ->
 		"printenv.bat";
 	    _ ->

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -1042,7 +1042,7 @@ cgi() ->
 
 cgi(Config) when is_list(Config) -> 
     {Script, Script2, Script3} =
-	case test_server:os_type() of
+	case os:type() of
 	    {win32, _} ->
 		{"printenv.bat", "printenv.sh", "cgi_echo.exe"};
 	    _ ->
@@ -1117,7 +1117,7 @@ cgi_chunked_encoding_test() ->
 cgi_chunked_encoding_test(Config) when is_list(Config) ->
     Host = proplists:get_value(host, Config),
     Script =
-	case test_server:os_type() of
+	case os:type() of
 	    {win32, _} ->
 		"/cgi-bin/printenv.bat";
 	    _ ->
@@ -1947,7 +1947,7 @@ setup_server_dirs(ServerRoot, DocRoot, DataDir) ->
     inets_test_lib:copy_dirs(PicsSrc, PicsDir),
     inets_test_lib:copy_dirs(ConfigSrc, ConfigDir),
         
-    Cgi = case test_server:os_type() of
+    Cgi = case os:type() of
 	      {win32, _} ->
 		  "cgi_echo.exe";
 	      _ ->

--- a/lib/inets/test/httpd_all.erl
+++ b/lib/inets/test/httpd_all.erl
@@ -128,7 +128,7 @@ esi(Version, Type, Port, Host, Node) ->
 
 cgi(Version, Type, Port, Host, Node) ->
     {Script, Script2, Script3} =
-	case test_server:os_type() of
+	case os:type() of
 	    {win32, _} ->
 		{"printenv.bat", "printenv.sh", "cgi_echo.exe"};
 	    _ ->

--- a/lib/inets/test/httpd_basic_SUITE.erl
+++ b/lib/inets/test/httpd_basic_SUITE.erl
@@ -85,7 +85,7 @@ DUMMY
     DummyFile = filename:join([PrivDir,"dummy.html"]),
     CgiDir =  filename:join(PrivDir, "cgi-bin"),
     ok = file:make_dir(CgiDir),
-    {CgiPrintEnv, CgiSleep} = case test_server:os_type() of
+    {CgiPrintEnv, CgiSleep} = case os:type() of
 				  {win32, _} ->
 				      {"printenv.bat", "cgi_sleep.exe"};
 				  _ ->

--- a/lib/inets/test/httpd_mod.erl
+++ b/lib/inets/test/httpd_mod.erl
@@ -611,7 +611,7 @@ htaccess(Type, Port, Host, Node) ->
 %%--------------------------------------------------------------------
 cgi(Type, Port, Host, Node) ->
     {Script, Script2, Script3} =
-	case test_server:os_type() of
+	case os:type() of
 	    {win32, _} ->
 		{"printenv.bat", "printenv.sh", "cgi_echo.exe"};
 	    _ ->

--- a/lib/kernel/test/global_SUITE.erl
+++ b/lib/kernel/test/global_SUITE.erl
@@ -2902,7 +2902,7 @@ many_nodes(Config) when is_list(Config) ->
     OrigNames = global:registered_names(),
 
     {Rels, N_cps} = 
-        case test_server:os_type() of
+        case os:type() of
             {unix, Osname} when Osname =:= linux; 
                                 Osname =:= openbsd; 
                                 Osname =:= darwin ->
@@ -3051,7 +3051,7 @@ sync_0(Config) when is_list(Config) ->
     init_condition(Config),
 
     N_cps = 
-        case test_server:os_type() of
+        case os:type() of
             {unix, Osname} when Osname =:= linux; 
                                 Osname =:= openbsd; 
                                 Osname =:= darwin ->

--- a/lib/kernel/test/heart_SUITE.erl
+++ b/lib/kernel/test/heart_SUITE.erl
@@ -102,7 +102,7 @@ end_per_suite(Config) when is_list(Config) ->
 start_check(Type, Name) ->
     start_check(Type, Name, []).
 start_check(Type, Name, Envs) ->
-    Args = case test_server:os_type() of
+    Args = case os:type() of
 	{win32,_} ->
 	    "+t50000 -heart " ++ env_encode([{"HEART_COMMAND", no_reboot}|Envs]);
 	_ ->

--- a/lib/kernel/test/ignore_cores.erl
+++ b/lib/kernel/test/ignore_cores.erl
@@ -94,7 +94,7 @@ setup(Suite, Testcase, Config, SetCwd) when is_atom(Suite),
     end,
     ok = file:write_file(filename:join([IgnDir, "ignore_core_files"]), <<>>),
     %% cores are dumped in /cores on MacOS X
-    CoresDir = case {test_server:os_type(), filelib:is_dir("/cores")} of
+    CoresDir = case {os:type(), filelib:is_dir("/cores")} of
 		   {{unix,darwin}, true} ->
 		       filelib:fold_files("/cores",
 					  "^core.*$",

--- a/lib/odbc/test/mysql.erl
+++ b/lib/odbc/test/mysql.erl
@@ -27,7 +27,7 @@
 
 %-------------------------------------------------------------------------
 connection_string() ->
-    case test_server:os_type() of
+    case os:type() of
 	{unix, linux} ->
 	    "DSN=MySQL;Database=odbctest;Uid=odbctest;Pwd=gurka;CHARSET=utf8;SSTMT=SET NAMES 'utf8';";
 	{unix, sunos} ->

--- a/lib/odbc/test/postgres.erl
+++ b/lib/odbc/test/postgres.erl
@@ -27,7 +27,7 @@
 
 %-------------------------------------------------------------------------
 connection_string() ->
-    case test_server:os_type() of
+    case os:type() of
 	{unix, sunos} ->
 	    "DSN=Postgres;UID=odbctest";
 	{unix, linux} ->

--- a/lib/os_mon/test/cpu_sup_SUITE.erl
+++ b/lib/os_mon/test/cpu_sup_SUITE.erl
@@ -56,7 +56,7 @@ suite() ->
      {timetrap,{minutes,1}}].
 
 all() -> 
-    case test_server:os_type() of
+    case os:type() of
         {unix, sunos} ->
             [load_api, util_api, util_values, port, unavailable];
         {unix, linux} ->

--- a/lib/os_mon/test/disksup_SUITE.erl
+++ b/lib/os_mon/test/disksup_SUITE.erl
@@ -61,7 +61,7 @@ all() ->
     Bugs = [otp_5910],
     Always = [api, config, alarm, port, posix_only, unavailable,
               parse_df_output_posix, parse_df_output_susv3] ++ Bugs,
-    case test_server:os_type() of
+    case os:type() of
 	{unix, _OSname} -> Always;
 	{win32, _OSname} -> Always;
 	_OS -> [unavailable]

--- a/lib/os_mon/test/memsup_SUITE.erl
+++ b/lib/os_mon/test/memsup_SUITE.erl
@@ -63,7 +63,7 @@ suite() ->
      {timetrap,{minutes,1}}].
 
 all() -> 
-    All = case test_server:os_type() of
+    All = case os:type() of
               {unix, sunos} ->
                   [api, alarm1, alarm2, process, config, timeout,
                    unavailable, port];
@@ -551,7 +551,7 @@ timeout(Config) when is_list(Config) ->
 
     %% Linux should be handled the same way as solaris.
 
-    %    TimeoutMsg = case test_server:os_type() of
+    %    TimeoutMsg = case os:type() of
     %		     {unix, sunos} -> ext_collection_timeout;
     %		     {unix, linux} -> reg_collection_timeout
     %		 end,

--- a/lib/os_mon/test/os_mon_SUITE.erl
+++ b/lib/os_mon/test/os_mon_SUITE.erl
@@ -31,7 +31,7 @@ suite() ->
      {timetrap,{minutes,1}}].
 
 all() -> 
-    case test_server:os_type() of
+    case os:type() of
         {unix, sunos} -> [app_file, appup_file, config];
         _OS -> [app_file, appup_file]
     end.

--- a/lib/os_mon/test/os_sup_SUITE.erl
+++ b/lib/os_mon/test/os_sup_SUITE.erl
@@ -56,7 +56,7 @@ suite() ->
      {timetrap,{minutes,1}}].
 
 all() -> 
-    case test_server:os_type() of
+    case os:type() of
         {unix, sunos} -> [message, config, port];
         {win32, _OSname} -> [message];
         OS ->
@@ -76,7 +76,7 @@ message(Config) when is_list(Config) ->
     %% Check with message_receptor that it has been received
     ct:sleep({seconds,1}),
     Msg =
-    case test_server:os_type() of
+    case os:type() of
         {unix, sunos} ->
             {?TAG, Data};
         {win32, _} ->

--- a/lib/snmp/test/snmp_test_lib.erl
+++ b/lib/snmp/test/snmp_test_lib.erl
@@ -26,7 +26,7 @@
 -export([tc_try/2, tc_try/3,
          tc_try/4, tc_try/5]).
 -export([proxy_call/3]).
--export([hostname/0, hostname/1, localhost/0, localhost/1, os_type/0, sz/1,
+-export([hostname/0, hostname/1, localhost/0, localhost/1, sz/1,
 	 display_suite_info/1]).
 -export([non_pc_tc_maybe_skip/4,
          os_based_skip/1,
@@ -411,16 +411,6 @@ sz(B) when is_binary(B) ->
     size(B);
 sz(O) ->
     {unknown_size,O}.
-
-
-os_type() ->
-    case (catch test_server:os_type()) of
-	{'EXIT', _} ->
-	    %% Pre-R10 test server does not have this function
-	    os:type();
-	OsType ->
-	    OsType
-    end.
 
 display_suite_info(SUITE) when is_atom(SUITE) ->
     (catch do_display_suite_info(SUITE)).


### PR DESCRIPTION
Codemod, drops undocumented function in favour of a
documented one.