### PR TITLE
beam_makeops: Make syntax nicer

### DIFF
--- a/erts/emulator/beam/beam_transform_engine.c
+++ b/erts/emulator/beam/beam_transform_engine.c
@@ -128,22 +128,6 @@ erts_transform_engine(LoaderState* st)
             ap++;
             break;
 #endif
-#if defined(TOP_is_same_var)
-	case TOP_is_same_var:
-	    ASSERT(ap < instr->arity);
-	    i = *pc++;
-	    ASSERT(i < TE_MAX_VARS);
-	    if (var[i].type != instr->a[ap].type)
-		goto restart;
-	    switch (var[i].type) {
-	    case TAG_n:
-		break;
-	    default:
-		if (var[i].val != instr->a[ap].val)
-		    goto restart;
-	    }
-	    break;
-#endif
 #if defined(TOP_is_bif)
 	case TOP_is_bif:
 	    {

--- a/erts/emulator/beam/beam_transform_engine.c
+++ b/erts/emulator/beam/beam_transform_engine.c
@@ -128,6 +128,7 @@ erts_transform_engine(LoaderState* st)
             ap++;
             break;
 #endif
+#if defined(TOP_is_same_var)
 	case TOP_is_same_var:
 	    ASSERT(ap < instr->arity);
 	    i = *pc++;
@@ -142,6 +143,7 @@ erts_transform_engine(LoaderState* st)
 		    goto restart;
 	    }
 	    break;
+#endif
 #if defined(TOP_is_bif)
 	case TOP_is_bif:
 	    {

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -37,7 +37,7 @@ FORBIDDEN_TYPES=h
 # needs to be re-compiled with a modern compiler.
 
 too_old_compiler/0
-too_old_compiler | never() =>
+too_old_compiler | never() => _
 
 # In R9C and earlier, the loader used to insert special instructions inside
 # the module_info/0,1 functions. (In R10B and later, the compiler inserts
@@ -82,7 +82,7 @@ int_func_start Lbl Line M F A => label Lbl | i_func_info u M F A | line Line
 # The end of a function.
 int_func_end/2
 int_func_end Func Entry | needs_nif_padding() => i_nif_padding
-int_func_end Func Entry =>
+int_func_end Func Entry => _
 
 i_nif_padding
 
@@ -117,7 +117,7 @@ move S X0=x==0 | line Loc | call_only Ar Func => \
 move S X0=x==0 | line Loc => line Loc | move S X0
 
 # The line number in int_func_start/5 can be NIL.
-line n =>
+line n => _
 line I
 
 # For the JIT, the init_yregs/1 instruction allows generation of better code.
@@ -258,7 +258,8 @@ i_get_tuple_element3 x P x
 is_number f? xy
 %hot
 
-is_number Fail=f i =>
+is_number Fail=f i => _
+
 is_number Fail=f na => jump Fail
 is_number Fail Literal=q => move Literal x | is_number Fail x
 
@@ -288,7 +289,7 @@ i_raise
 
 # Workaround the limitation that generators must always return at least one instruction.
 delete_me/0
-delete_me =>
+delete_me => _
 
 system_limit/1
 system_limit p => system_limit_body
@@ -479,7 +480,8 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl S S =>
+is_eq_exact Lbl S S => _
+
 is_eq_exact Lbl C1=c C2=c => move C1 x | is_eq_exact Lbl x C2
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
 
@@ -697,7 +699,7 @@ get_tuple_element Reg=x P1 D1=y | get_tuple_element Reg=x P2 D2=y | \
 
 get_tuple_element Reg P Dst => i_get_tuple_element Reg P Dst
 
-is_integer Fail=f i =>
+is_integer Fail=f i => _
 is_integer Fail=f an => jump Fail
 is_integer Fail Literal=q => move Literal x | is_integer Fail x
 
@@ -707,7 +709,7 @@ is_integer_allocate f? x t t
 
 is_integer f? xy
 
-is_list Fail=f n =>
+is_list Fail=f n => _
 is_list Fail Literal=q => move Literal x | is_list Fail x
 is_list Fail=f c => jump Fail
 is_list f? x
@@ -738,7 +740,7 @@ is_atom f? x
 %cold
 is_atom f? y
 %hot
-is_atom Fail=f a =>
+is_atom Fail=f a => _
 is_atom Fail=f niq => jump Fail
 
 is_float f? x
@@ -748,7 +750,7 @@ is_float f? y
 is_float Fail=f nai => jump Fail
 is_float Fail Literal=q => move Literal x | is_float Fail x
 
-is_nil Fail=f n =>
+is_nil Fail=f n => _
 is_nil Fail=f qia => jump Fail
 
 is_nil f? xy
@@ -788,8 +790,8 @@ is_port f? x
 is_port f? y
 %hot
 
-is_boolean Fail=f a==am_true =>
-is_boolean Fail=f a==am_false =>
+is_boolean Fail=f a==am_true => _
+is_boolean Fail=f a==am_false => _
 is_boolean Fail=f ac => jump Fail
 
 %cold
@@ -1128,7 +1130,7 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d => \
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Same Same =>
+bs_start_match4 a==am_resume Live Same Same => _
 bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
 
 bs_start_match3 Fail Bin Live Ctx | bs_get_position Ctx Pos=x Ignored => \
@@ -1303,7 +1305,7 @@ i_bs_validate_unicode Fail Src=c => move Src x | i_bs_validate_unicode Fail x
 
 # Will fail. No need to keep the instruction, because bs_add or
 # bs_init* would already have raised an exception.
-bs_put_float Fail Sz=q Unit Flags Val =>
+bs_put_float Fail Sz=q Unit Flags Val => _
 
 bs_put_float Fail=j Sz=s Unit=u Flags=u Src=s => \
 			put_float(Fail, Sz, Unit, Flags, Src)
@@ -1369,8 +1371,8 @@ i_fnegate l l
 # FPE signals were disabled in OTP 21 and we don't intend to ever
 # enable them again.
 #
-fclearerror =>
-fcheckerror p =>
+fclearerror => _
+fcheckerror p => _
 
 %hot
 
@@ -1421,9 +1423,8 @@ i_new_small_map_lit d t q *
 update_map_assoc xyc d t I *
 update_map_exact xy j? d t I *
 
-is_map Fail Lit=q | literal_is_map(Lit) =>
+is_map Fail Lit=q | literal_is_map(Lit) => _
 is_map Fail cq => jump Fail
-
 is_map f? xy
 
 ## Transform has_map_fields #{ K1 := _, K2 := _ } to has_map_elements
@@ -1597,7 +1598,7 @@ gc_bif3 Fail=f Live Bif S1 S2 S3 Dst => i_bif3 S3 S2 S1 Fail Bif Dst
 # encountered.
 #
 unsupported_guard_bif/3
-unsupported_guard_bif A B C | never() =>
+unsupported_guard_bif A B C | never() => _
 
 #
 # R13B03

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -168,32 +168,40 @@ init3 y y y
 
 select_val S=aiq Fail=f Size=u Rest=* => const_select_val(S, Fail, Size, Rest)
 
-select_val S=s Fail=f Size=u Rest=* | use_jump_tab(Size, Rest, 2) => \
+select_val S=s Fail=f Size=u Rest=* | use_jump_tab(Size, Rest, 2) =>
   jump_tab(S, Fail, Size, Rest)
 
-is_integer Fail=f S | select_val S=s Fail=f Size=u Rest=* | use_jump_tab(Size, Rest, 2) => \
-  jump_tab(S, Fail, Size, Rest)
+is_integer Fail=f S | select_val S2=s Fail2=f Size=u Rest=* |
+  equal(Fail, Fail2) | equal(S, S2) |
+  use_jump_tab(Size, Rest, 2) =>
+    jump_tab(S, Fail, Size, Rest)
 
-is_integer TypeFail=f S | select_val S=s Fail=f Size=u Rest=* | \
-	   mixed_types(Size, Rest) => \
-  split_values(S, TypeFail, Fail, Size, Rest)
+is_integer TypeFail=f S | select_val S2=s Fail=f Size=u Rest=* |
+  equal(S, S2) |
+  mixed_types(Size, Rest) =>
+    split_values(S, TypeFail, Fail, Size, Rest)
 
-select_val S=s Fail=f Size=u Rest=* | mixed_types(Size, Rest) => \
+select_val S=s Fail=f Size=u Rest=* | mixed_types(Size, Rest) =>
   split_values(S, Fail, Fail, Size, Rest)
 
-is_integer Fail=f S | select_val S=d Fail=f Size=u Rest=* | \
-  fixed_size_values(Size, Rest) => select_val(S, Fail, Size, Rest)
+is_integer Fail=f S | select_val S2=d Fail2=f Size=u Rest=* |
+  equal(Fail, Fail2) | equal(S, S2) |
+  fixed_size_values(Size, Rest) =>
+    select_val(S, Fail, Size, Rest)
 
-is_atom Fail=f S | select_val S=d Fail=f Size=u Rest=* | \
-  fixed_size_values(Size, Rest) => select_val(S, Fail, Size, Rest)
+is_atom Fail=f S | select_val S2=d Fail2=f Size=u Rest=* |
+  equal(Fail, Fail2) | equal(S, S2) |
+  fixed_size_values(Size, Rest) =>
+    select_val(S, Fail, Size, Rest)
 
-select_val S=s Fail=f Size=u Rest=* | floats_or_bignums(Size, Rest) => \
+select_val S=s Fail=f Size=u Rest=* | floats_or_bignums(Size, Rest) =>
   select_literals(S, Fail, Size, Rest)
 
-select_val S=d Fail=f Size=u Rest=* | fixed_size_values(Size, Rest) => \
+select_val S=d Fail=f Size=u Rest=* | fixed_size_values(Size, Rest) =>
   select_val(S, Fail, Size, Rest)
 
-is_tuple Fail=f S | select_tuple_arity S=d Fail=f Size=u Rest=* => \
+is_tuple Fail=f S | select_tuple_arity S2=d Fail2=f Size=u Rest=* |
+  equal(Fail, Fail2) | equal(S, S2) =>
   select_tuple_arity(S, Fail, Size, Rest)
 
 select_tuple_arity S=d Fail=f Size=u Rest=* => \
@@ -361,17 +369,31 @@ swap R1=x R2=y => swap R2 R1
 swap xy x
 swap y y
 
-swap R1=x R2=x | swap R3=x R1 => swap2 R1 R2 R3
+swap R1=x R2=x | swap R3=x R1Other | equal(R1, R1Other) => swap2 R1 R2 R3
 
 swap2 x x x
 
 # move_shift
 
-move SD=x    D=x | move Src=cxy SD=x  | distinct(D, Src) => move_shift Src SD D
-move SD=y    D=x | move Src=x  SD=y   | distinct(D, Src) => move_shift Src SD D
-move SD=y    D=x | init SD            |                  => move_shift n   SD D
-move SD=x    D=y | move Src=x  SD=x   | distinct(D, Src) => move_shift Src SD D
-move SD=x==0 D=y | move Src=y SD=x==0 | distinct(D, Src) => move_shift Src SD D
+move SD=x    D=x | move Src=cxy SDOther=x |
+  equal(SD, SDOther) | distinct(D, Src) =>
+    move_shift Src SD D
+
+move SD=y    D=x | move Src=x  SDOther=y  |
+  equal(SD, SDOther) | distinct(D, Src) =>
+    move_shift Src SD D
+
+move SD=y    D=x | init SDOther           |
+  equal(SD, SDOther) =>
+     move_shift n   SD D
+
+move SD=x    D=y | move Src=x  SDOther=x  |
+  equal(SD, SDOther) | distinct(D, Src) =>
+    move_shift Src SD D
+
+move SD=x==0 D=y | move Src=y SDOther |
+  equal(SD, SDOther) | distinct(D, Src) =>
+    move_shift Src SD D
 
 move_shift cxy x x
 move_shift nx y x
@@ -480,7 +502,7 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl S S => _
+is_eq_exact Lbl LHS RHS | equal(LHS, RHS) => _
 
 is_eq_exact Lbl C1=c C2=c => move C1 x | is_eq_exact Lbl x C2
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
@@ -489,7 +511,7 @@ is_eq_exact Lbl R=xy n => is_nil Lbl R
 is_eq_exact Lbl R=xy C=ia => i_is_eq_exact_immed Lbl R C
 is_eq_exact Lbl R=xy C=q => i_is_eq_exact_literal Lbl R C
 
-is_ne_exact Lbl S S => jump Lbl
+is_ne_exact Lbl LHS RHS | equal(LHS, RHS) => jump Lbl
 is_ne_exact Lbl C1=c C2=c => move C1 x | is_ne_exact Lbl x C2
 is_ne_exact Lbl C=c R=xy => is_ne_exact Lbl R C
 
@@ -561,7 +583,7 @@ put_tuple2 xy I *
 #
 put_list Const=c n Dst => move Const x | put_list x n Dst
 
-put_list Src Dst=x Dst => update_list Src Dst
+put_list Head Tail=x Dst | equal(Tail, Dst) => update_list Head Dst
 
 update_list xyc x
 
@@ -656,7 +678,9 @@ is_tagged_tuple f? rxy A a
 
 is_tuple Fail Literal=q => move Literal x | is_tuple Fail x
 is_tuple Fail=f c => jump Fail
-is_tuple Fail=f S=xy | test_arity Fail=f S=xy Arity => is_tuple_of_arity Fail S Arity
+is_tuple Fail=f S=xy | test_arity Fail2=f S2=xy Arity |
+  equal(Fail, Fail2) | equal(S, S2) =>
+    is_tuple_of_arity Fail S Arity
 
 is_tuple_of_arity f? rxy A
 
@@ -664,7 +688,8 @@ is_tuple f? rxy
 
 test_arity Fail Literal=q Arity => move Literal x | test_arity Fail x Arity
 test_arity Fail=f c Arity => jump Fail
-test_arity Fail Tuple=x Arity | get_tuple_element Tuple Pos Dst=x => \
+test_arity Fail Tuple=x Arity | get_tuple_element Tuple2 Pos Dst=x |
+   equal(Tuple, Tuple2) =>
    test_arity_get_tuple_element Fail Tuple Arity Pos Dst
 
 test_arity f? xy A
@@ -678,24 +703,28 @@ is_tuple NotTupleFail Src=x | \
 
 is_tagged_tuple_ff f? f? rx A a
 
-get_tuple_element Reg=x P1 D1=x | \
-   get_tuple_element Reg=x P2 D2=x | \
-   get_tuple_element Reg=x P3 D3=x | \
-   succ(P1, P2) | succ(P2, P3) | succ(D1, D2) | succ(D2, D3) | \
-   distinct(D1, Reg) | distinct(D2, Reg) => \
+get_tuple_element Reg=x P1 D1=x |
+   get_tuple_element Reg2 P2 D2=x |
+   get_tuple_element Reg3 P3 D3=x |
+   equal(Reg, Reg2) | equal(Reg, Reg3) |
+   succ(P1, P2) | succ(P2, P3) | succ(D1, D2) | succ(D2, D3) |
+   distinct(D1, Reg) | distinct(D2, Reg) =>
       i_get_tuple_element3 Reg P1 D1
 
-get_tuple_element Reg=x P1 D1=x | \
-   get_tuple_element Reg=x P2 D2=x | \
-   succ(P1, P2) | succ(D1, D2) | \
+get_tuple_element Reg=x P1 D1=x |
+   get_tuple_element Reg2 P2 D2=x |
+   equal(Reg, Reg2) |
+   succ(P1, P2) | succ(D1, D2) |
    distinct(D1, Reg) => \
       i_get_tuple_element2 Reg P1 D1
 
-get_tuple_element Reg=x P1 D1=x | get_tuple_element Reg=x P2 D2=x | \
-   succ(P1, P2) | distinct(D1, Reg) => i_get_tuple_element2_dst Reg P1 D1 D2
+get_tuple_element Reg=x P1 D1=x | get_tuple_element Reg2=x P2 D2=x |
+   equal(Reg, Reg2) | succ(P1, P2) | distinct(D1, Reg) =>
+      i_get_tuple_element2_dst Reg P1 D1 D2
 
-get_tuple_element Reg=x P1 D1=y | get_tuple_element Reg=x P2 D2=y | \
-   succ(P1, P2) => i_get_tuple_element2_dst Reg P1 D1 D2
+get_tuple_element Reg=x P1 D1=y | get_tuple_element Reg2=x P2 D2=y |
+   equal(Reg, Reg2) | succ(P1, P2) =>
+      i_get_tuple_element2_dst Reg P1 D1 D2
 
 get_tuple_element Reg P Dst => i_get_tuple_element Reg P Dst
 
@@ -719,13 +748,16 @@ is_list f? y
 
 is_nonempty_list Fail=f S=x | allocate Need Rs => is_nonempty_list_allocate Fail S Need Rs
 
-is_nonempty_list Fail=f S=x | get_list S D1=x D2=x => \
-  is_nonempty_list_get_list Fail S D1 D2
+is_nonempty_list Fail=f S=x | get_list S2 D1=x D2=x |
+  equal(S, S2) =>
+    is_nonempty_list_get_list Fail S D1 D2
 
-is_nonempty_list Fail=f S=x | get_hd S Dst=x => \
+is_nonempty_list Fail=f S=x | get_hd S2 Dst=x |
+  equal(S, S2) =>
   is_nonempty_list_get_hd Fail S Dst
 
-is_nonempty_list Fail=f S=x | get_tl S Dst=x => \
+is_nonempty_list Fail=f S=x | get_tl S2 Dst=x |
+  equal(S, S2) =>
   is_nonempty_list_get_tl Fail S Dst
 
 is_nonempty_list_allocate f? rx t t
@@ -1130,10 +1162,11 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d => \
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Same Same => _
+bs_start_match4 a==am_resume Live Ctx Dst | equal(Ctx, Dst) => _
 bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
 
-bs_start_match3 Fail Bin Live Ctx | bs_get_position Ctx Pos=x Ignored => \
+bs_start_match3 Fail Bin Live Ctx | bs_get_position Ctx2 Pos=x Ignored |
+  equal(Ctx, Ctx2) =>
     i_bs_start_match3_gp Bin Live Fail Ctx Pos
 i_bs_start_match3_gp xy t j d x
 

--- a/erts/emulator/beam/jit/arm/generators.tab
+++ b/erts/emulator/beam/jit/arm/generators.tab
@@ -584,13 +584,3 @@ gen.create_bin(Fail, Alloc, Live, Unit, Dst, N, Segments) {
 
     return op;
 }
-
-gen.remove_tuple_type(Tuple) {
-    BeamOp* op;
-
-    $NewBeamOp(S, op);
-    $BeamOpNameArity(op, current_tuple, 1);
-    op->a[0] = Tuple;
-    op->a[0].val = Tuple.val & REG_MASK;
-    return op;
-}

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -1073,21 +1073,13 @@ void BeamModuleAssembler::emit_i_is_tuple(const ArgVal &Fail,
     auto src = load_source(Src, ARG1);
 
     emit_is_boxed(resolve_beam_label(Fail, dispUnknown), Src, src.reg);
+    emit_untag_ptr(ARG1, src.reg);
 
     /* As an optimization for the `error | {ok, Value}` case, skip checking the
      * header word when we know that the only possible boxed type is a tuple. */
     if (masked_types(Src, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_TUPLE) {
         comment("skipped header test since we know it's a tuple when boxed");
-
-        /* Note: ARG1 will NOT be set. This is OK since the operand
-         * for `current_tuple` has a type; that operand will not match
-         * the type-less operand for `get_tuple_element`. Thus, there
-         * will always be a `load_tuple_ptr` instruction emitted if
-         * this instruction is immediately followed by a
-         * `get_tuple_element` instruction. */
     } else {
-        emit_untag_ptr(ARG1, src.reg);
-
         a.ldr(TMP1, arm::Mem(ARG1));
         ERTS_CT_ASSERT(_TAG_HEADER_ARITYVAL == 0);
         a.tst(TMP1, imm(_TAG_HEADER_MASK));

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -135,34 +135,41 @@ init_yregs I *
 # table). Therefore we shouldn't use a jump table if there are too few
 # values.
 
-select_val S Fail=fn Size=u Rest=* | use_jump_tab(Size, Rest, 6) => \
-  jump_tab(S, Fail, Size, Rest)
-is_integer Fail=f S | select_val S=s Fail=fn Size=u Rest=* | use_jump_tab(Size, Rest, 6) => \
+select_val S Fail=fn Size=u Rest=* | use_jump_tab(Size, Rest, 6) =>
   jump_tab(S, Fail, Size, Rest)
 
-is_integer TypeFail=f S | select_val S=s Fail=fn Size=u Rest=* | \
-	   mixed_types(Size, Rest) => \
-  split_values(S, TypeFail, Fail, Size, Rest)
+is_integer Fail=f S=s | select_val S2 Fail2 Size=u Rest=* |
+  equal(Fail, Fail2) | equal(S, S2) |
+  use_jump_tab(Size, Rest, 6) =>
+    jump_tab(S, Fail, Size, Rest)
 
-select_val S Fail=fn Size=u Rest=* | mixed_types(Size, Rest) => \
+is_integer TypeFail=f S=s | select_val S2 Fail=fn Size=u Rest=* |
+  equal(S, S2) |
+  mixed_types(Size, Rest) =>
+    split_values(S, TypeFail, Fail, Size, Rest)
+
+select_val S Fail=fn Size=u Rest=* | mixed_types(Size, Rest) =>
   split_values(S, Fail, Fail, Size, Rest)
 
-is_integer Fail=f S | select_val S=d Fail=fn Size=u Rest=* | \
+is_integer Fail=f S=d | select_val S2 Fail2 Size=u Rest=* |
+  equal(Fail, Fail2) | equal(S, S2) |
   fixed_size_values(Size, Rest) => select_val(S, Fail, Size, Rest)
 
-is_atom Fail=f S | select_val S=d Fail=fn Size=u Rest=* | \
+is_atom Fail=f S=d | select_val S2 Fail2 Size=u Rest=* |
+  equal(Fail, Fail2) | equal(S, S2) |
   fixed_size_values(Size, Rest) => select_val(S, Fail, Size, Rest)
 
-select_val S Fail=fn Size=u Rest=* | floats_or_bignums(Size, Rest) => \
+select_val S Fail=fn Size=u Rest=* | floats_or_bignums(Size, Rest) =>
   select_literals(S, Fail, Size, Rest)
 
-select_val S Fail=fn Size=u Rest=* | fixed_size_values(Size, Rest) => \
+select_val S Fail=fn Size=u Rest=* | fixed_size_values(Size, Rest) =>
   select_val(S, Fail, Size, Rest)
 
-is_tuple Fail=f S | select_tuple_arity S=d Fail=f Size=u Rest=* => \
+is_tuple Fail=f S=d | select_tuple_arity S2 Fail2 Size=u Rest=* |
+  equal(Fail, Fail2) | equal(S, S2) =>
   select_tuple_arity(S, Fail, Size, Rest)
 
-select_tuple_arity S=d Fail=f Size=u Rest=* => \
+select_tuple_arity S=d Fail=f Size=u Rest=* =>
   select_tuple_arity(S, Fail, Size, Rest)
 
 i_select_val_bins s fn I *
@@ -213,25 +220,23 @@ set_tuple_element s S P
 
 current_tuple/1
 current_tuple/2
-typed_current_tuple/1
 
-is_tuple Fail=f Src | test_arity Fail Src Arity => \
-   i_is_tuple_of_arity Fail Src Arity | current_tuple Src
+is_tuple Fail=f Src | test_arity Fail2 Src2 Arity |
+  equal(Fail, Fail2) | equal(Src, Src) =>
+    i_is_tuple_of_arity Fail Src Arity | current_tuple Src
 
 test_arity Fail Src Arity => i_test_arity Fail Src Arity | current_tuple Src
 
-is_tuple NotTupleFail Src | \
-  is_tagged_tuple WrongRecordFail Tuple Arity Atom | \
-  equal(Src, Tuple) => \
-   i_is_tagged_tuple_ff NotTupleFail WrongRecordFail Src Arity Atom | \
-   current_tuple Src
+is_tuple NotTupleFail Src |
+  is_tagged_tuple WrongRecordFail Tuple Arity Atom |
+  equal(Src, Tuple) =>
+    i_is_tagged_tuple_ff NotTupleFail WrongRecordFail Src Arity Atom |
+    current_tuple Src
 
-is_tagged_tuple Fail Tuple Arity Atom => \
-   i_is_tagged_tuple Fail Tuple Arity Atom | typed_current_tuple Tuple
+is_tagged_tuple Fail Tuple Arity Atom =>
+   i_is_tagged_tuple Fail Tuple Arity Atom | current_tuple Tuple
 
 is_tuple Fail=f Src => i_is_tuple Fail Src | current_tuple Src
-
-typed_current_tuple Tuple => remove_tuple_type(Tuple)
 
 i_is_tuple_of_arity f? s A
 i_test_arity f? s A
@@ -244,13 +249,17 @@ i_is_tuple f? s
 # Generate instruction sequence for fetching the tuple element and remember
 # that we have a current tuple pointer.
 
-get_tuple_element Tuple Pos Dst => \
+get_tuple_element Tuple Pos Dst =>
   load_tuple_ptr Tuple | i_get_tuple_element Tuple Pos Dst | current_tuple Tuple
-current_tuple Tuple | get_tuple_element Tuple Pos Dst => \
+
+current_tuple Tuple | get_tuple_element Tuple2 Pos Dst |
+  equal(Tuple, Tuple2) =>
   i_get_tuple_element Tuple Pos Dst | current_tuple Tuple
 
 # Drop the current_tuple instruction if the tuple is overwritten.
-i_get_tuple_element Tuple Pos Tuple | current_tuple Tuple => i_get_tuple_element Tuple Pos Tuple
+i_get_tuple_element Tuple Pos Tuple2 | current_tuple Tuple3 |
+  equal(Tuple, Tuple2) | equal(Tuple, Tuple3) =>
+    i_get_tuple_element Tuple Pos Tuple
 
 # This is a current_tuple instruction instruction not followed by get_tuple_element.
 # Invalidate the current tuple pointer.
@@ -259,17 +268,17 @@ current_tuple Tuple => _
 
 load_tuple_ptr s
 
-# If both positions and destinations are in consecutive memory, fetch and store
-# two words at once.
-i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple | \
-   get_tuple_element Tuple Pos2 Dst2 | consecutive_words(Pos1, Pos2) => \
-      get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
-i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple | \
-   get_tuple_element Tuple Pos2 Dst2 | consecutive_words(Pos1, Pos2) => \
-      get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
+# If positions are in consecutive memory, fetch and store two words at
+# once.
+i_get_tuple_element Tuple Pos1 Dst1 |
+  current_tuple Tuple2 |
+  get_tuple_element Tuple3 Pos2 Dst2 |
+  equal(Tuple, Tuple2) | equal(Tuple, Tuple3) |
+  consecutive_words(Pos1, Pos2) =>
+    get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
 
 # Drop the current_tuple instruction if the tuple is overwritten.
-current_tuple Tuple Tuple => _
+current_tuple Tuple Tuple2 | equal(Tuple, Tuple2) => _
 current_tuple Tuple Dst => current_tuple Tuple
 
 # The first operand will only be used in the debug-compiled runtime
@@ -307,46 +316,74 @@ system_limit_body
 # Optimize moves of consecutive memory addresses.
 #
 move Src=c Dst => i_move Src Dst
-move Src SrcDst | move SrcDst Dst => i_move Src SrcDst | move SrcDst Dst
+move Src SrcDst | move SrcDst2 Dst |
+  equal(SrcDst, SrcDst2) =>
+    i_move Src SrcDst | move SrcDst Dst
 
-# Optimize two moves from X registers to Y registers when destination Y registers are consecutive.
-move S1=x D1=y | move S2=x D2=y | consecutive_words(D1, D2) => store_two_xregs S1 D1 S2 D2
-move S1=x D1=y | move S2=x D2=y | consecutive_words(D2, D1) => store_two_xregs S2 D2 S1 D1
+# Optimize two moves from X registers to Y registers when destination
+# Y registers are consecutive.
 
-# Optimize two moves from Y registers to X registers when source Y registers are consecutive.
-move S1=y D1=x | move S2=y D2=x | consecutive_words(S1, S2) | distinct(D1, D2) => load_two_xregs S1 D1 S2 D2
-move S1=y D1=x | move S2=y D2=x | consecutive_words(S2, S1) | distinct(D1, D2) => load_two_xregs S2 D2 S1 D1
+move S1=x D1=y | move S2=x D2=y | consecutive_words(D1, D2) =>
+  store_two_xregs S1 D1 S2 D2
+move S1=x D1=y | move S2=x D2=y | consecutive_words(D2, D1) =>
+  store_two_xregs S2 D2 S1 D1
+
+# Optimize two moves from Y registers to X registers when source Y
+# registers are consecutive.
+
+move S1=y D1=x | move S2=y D2=x |
+  consecutive_words(S1, S2) |
+  distinct(D1, D2) =>
+    load_two_xregs S1 D1 S2 D2
+
+move S1=y D1=x | move S2=y D2=x |
+  consecutive_words(S2, S1) |
+  distinct(D1, D2) =>
+    load_two_xregs S2 D2 S1 D1
 
 # Optimize two moves of Y registers when destinations are consecutive.
-move S1=y D1=y | move S2=y D2=y | consecutive_words(D1, D2) => move_two_yregs S1 D1 S2 D2
-move S1=y D1=y | move S2=y D2=y | consecutive_words(D2, D1) => move_two_yregs S2 D2 S1 D1
+move S1=y D1=y | move S2=y D2=y |
+  consecutive_words(D1, D2) =>
+    move_two_yregs S1 D1 S2 D2
+
+move S1=y D1=y | move S2=y D2=y |
+  consecutive_words(D2, D1) =>
+    move_two_yregs S2 D2 S1 D1
 
 move Src Dst => i_move Src Dst
-
-#
-# Move instructions.
-#
-
-swap R1 R2 | swap R2 R3 => swap2 R1 R2 R3
-swap R1 R2 | swap R1 R3 => swap2 R2 R1 R3
-swap R1 R2 | swap R3 R2 => swap2 R1 R2 R3
-swap R1 R2 | swap R3 R1 => swap2 R2 R1 R3
-
-swap2 R1 R2 R3 | swap R3 R4 => swap3 R1 R2 R3 R4
-swap2 R1 R2 R3 | swap R4 R3 => swap3 R1 R2 R3 R4
-
-swap3 R1 R2 R3 R4 | swap R4 R5 => swap4 R1 R2 R3 R4 R5
-swap3 R1 R2 R3 R4 | swap R5 R4 => swap4 R1 R2 R3 R4 R5
-
-swap d d
-swap2 d d d
-swap3 d d d d
-swap4 d d d d d
 
 i_move s d
 store_two_xregs x y x y
 load_two_xregs y x y x
 move_two_yregs y y y y
+
+#
+# Swap instructions.
+#
+
+swap R1 R2 | swap R2Other R3 | equal(R2, R2Other) => swap2 R1 R2 R3
+swap R1 R2 | swap R1Other R3 | equal(R1, R1Other) => swap2 R2 R1 R3
+swap R1 R2 | swap R3 R1Other | equal(R1, R1Other) => swap2 R2 R1 R3
+swap R1 R2 | swap R3 R2Other | equal(R2, R2Other) => swap2 R1 R2 R3
+
+swap2 R1 R2 R3 | swap R3Other R4 |
+  equal(R3, R3Other) =>
+    swap3 R1 R2 R3 R4
+swap2 R1 R2 R3 | swap R4 R3Other |
+  equal(R3, R3Other) =>
+    swap3 R1 R2 R3 R4
+
+swap3 R1 R2 R3 R4 | swap R4Other R5 |
+  equal(R4, R4Other) =>
+    swap4 R1 R2 R3 R4 R5
+swap3 R1 R2 R3 R4 | swap R5 R4Other |
+  equal(R4, R4Other) =>
+    swap4 R1 R2 R3 R4 R5
+
+swap d d
+swap2 d d d
+swap3 d d d d
+swap4 d d d d d
 
 #
 # Receive operations. We conservatively align all labels before any
@@ -397,12 +434,12 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl S S => _
+is_eq_exact Lbl LHS RHS | equal(LHS, RHS) => _
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
 
 is_eq_exact Lbl R=xy n => is_nil Lbl R
 
-is_ne_exact Lbl S S => jump Lbl
+is_ne_exact Lbl LHS RHS | equal(LHS, RHS) => jump Lbl
 is_ne_exact Lbl C=c R=xy => is_ne_exact Lbl R C
 
 is_eq_exact f? s s
@@ -431,7 +468,9 @@ put_tuple2 S A *
 # Putting lists.
 #
 
-put_list Hd1=y Tl Dst | put_list Hd2=y Dst Dst | consecutive_words(Hd1, Hd2) => \
+put_list Hd1=y Tl Dst | put_list Hd2=y Dst2 Dst3 |
+  equal(Dst, Dst2) | equal(Dst, Dst3) |
+  consecutive_words(Hd1, Hd2) =>
     put_list2 Hd1 Hd2 Tl Dst
 
 put_list s s d
@@ -856,7 +895,7 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d => \
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Same Same => _
+bs_start_match4 a==am_resume Live Ctx Dst | equal(Ctx, Dst) => _
 bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
 
 %else

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -37,7 +37,7 @@ FORBIDDEN_TYPES=hQ
 # needs to be re-compiled with a modern compiler.
 
 too_old_compiler/0
-too_old_compiler | never() =>
+too_old_compiler | never() => _
 
 # In R9C and earlier, the loader used to insert special instructions inside
 # the module_info/0,1 functions. (In R10B and later, the compiler inserts
@@ -108,7 +108,7 @@ func_line n => empty_func_line
 empty_func_line
 func_line I
 
-line n =>
+line n => _
 line I
 
 allocate t t?
@@ -255,7 +255,7 @@ i_get_tuple_element Tuple Pos Tuple | current_tuple Tuple => i_get_tuple_element
 # This is a current_tuple instruction instruction not followed by get_tuple_element.
 # Invalidate the current tuple pointer.
 
-current_tuple Tuple =>
+current_tuple Tuple => _
 
 load_tuple_ptr s
 
@@ -269,7 +269,7 @@ i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple | \
       get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
 
 # Drop the current_tuple instruction if the tuple is overwritten.
-current_tuple Tuple Tuple =>
+current_tuple Tuple Tuple => _
 current_tuple Tuple Dst => current_tuple Tuple
 
 # The first operand will only be used in the debug-compiled runtime
@@ -293,7 +293,7 @@ raise s s
 
 # Workaround the limitation that generators must always return at least one instruction.
 delete_me/0
-delete_me =>
+delete_me => _
 
 system_limit/1
 system_limit p => system_limit_body
@@ -397,7 +397,7 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl S S =>
+is_eq_exact Lbl S S => _
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
 
 is_eq_exact Lbl R=xy n => is_nil Lbl R
@@ -464,7 +464,7 @@ is_list f? s
 is_atom f? s
 is_float f? s
 
-is_nil Fail=f n =>
+is_nil Fail=f n => _
 is_nil Fail=f qia => jump Fail
 is_nil f? S
 
@@ -856,7 +856,7 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d => \
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Same Same =>
+bs_start_match4 a==am_resume Live Same Same => _
 bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
 
 %else
@@ -1018,7 +1018,7 @@ i_bs_validate_unicode j? s
 
 # Will fail. No need to keep the instruction, because bs_add or
 # bs_init* would already have raised an exception.
-bs_put_float Fail Sz=q Unit Flags Val =>
+bs_put_float Fail Sz=q Unit Flags Val => _
 
 bs_put_float Fail=j Sz=s Unit=u Flags=u Src=s => \
 			put_float(Fail, Sz, Unit, Flags, Src)
@@ -1069,8 +1069,8 @@ i_fmul l l l
 i_fdiv l l l
 i_fnegate l l
 
-fclearerror =>
-fcheckerror p =>
+fclearerror => _
+fcheckerror p => _
 
 %hot
 
@@ -1282,7 +1282,7 @@ gc_bif3 Fail Live Bif S1 S2 S3 Dst => i_bif3 S1 S2 S3 Fail Bif Dst
 # encountered.
 #
 unsupported_guard_bif/3
-unsupported_guard_bif A B C | never() =>
+unsupported_guard_bif A B C | never() => _
 
 #
 # R13B03

--- a/erts/emulator/beam/jit/x86/generators.tab
+++ b/erts/emulator/beam/jit/x86/generators.tab
@@ -652,13 +652,3 @@ gen.create_bin(Fail, Alloc, Live, Unit, Dst, N, Segments) {
 
     return op;
 }
-
-gen.remove_tuple_type(Tuple) {
-    BeamOp* op;
-
-    $NewBeamOp(S, op);
-    $BeamOpNameArity(op, current_tuple, 1);
-    op->a[0] = Tuple;
-    op->a[0].val = Tuple.val & REG_MASK;
-    return op;
-}

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -136,23 +136,31 @@ init_yregs I *
 # bytes. Therefore we shouldn't use a jump table if there are too few
 # values.
 
-select_val S Fail=fn Size=u Rest=* | use_jump_tab(Size, Rest, 6) => \
-  jump_tab(S, Fail, Size, Rest)
-is_integer Fail=f S | select_val S=s Fail=fn Size=u Rest=* | use_jump_tab(Size, Rest, 6) => \
+select_val S Fail=fn Size=u Rest=* | use_jump_tab(Size, Rest, 6) =>
   jump_tab(S, Fail, Size, Rest)
 
-is_integer TypeFail=f S | select_val S=s Fail=fn Size=u Rest=* | \
-	   mixed_types(Size, Rest) => \
-  split_values(S, TypeFail, Fail, Size, Rest)
+is_integer Fail=f S | select_val S2=s Fail2=fn Size=u Rest=* |
+  equal(S, S2) | equal(Fail, Fail2) |
+  use_jump_tab(Size, Rest, 6) =>
+    jump_tab(S, Fail, Size, Rest)
 
-select_val S Fail=fn Size=u Rest=* | mixed_types(Size, Rest) => \
+is_integer TypeFail=f S | select_val S2=s Fail=fn Size=u Rest=* |
+  equal(S, S2) |
+  mixed_types(Size, Rest) =>
+    split_values(S, TypeFail, Fail, Size, Rest)
+
+select_val S Fail=fn Size=u Rest=* | mixed_types(Size, Rest) =>
   split_values(S, Fail, Fail, Size, Rest)
 
-is_integer Fail=f S | select_val S=d Fail=fn Size=u Rest=* | \
-  fixed_size_values(Size, Rest) => select_val(S, Fail, Size, Rest)
+is_integer Fail=f S | select_val S2=d Fail2=fn Size=u Rest=* |
+  equal(S, S2) | equal(Fail, Fail2) |
+  fixed_size_values(Size, Rest) =>
+    select_val(S, Fail, Size, Rest)
 
-is_atom Fail=f S | select_val S=d Fail=fn Size=u Rest=* | \
-  fixed_size_values(Size, Rest) => select_val(S, Fail, Size, Rest)
+is_atom Fail=f S | select_val S2=d Fail2=fn Size=u Rest=* |
+  equal(S, S2) | equal(Fail, Fail2) |
+  fixed_size_values(Size, Rest) =>
+     select_val(S, Fail, Size, Rest)
 
 select_val S Fail=fn Size=u Rest=* | floats_or_bignums(Size, Rest) => \
   select_literals(S, Fail, Size, Rest)
@@ -160,8 +168,9 @@ select_val S Fail=fn Size=u Rest=* | floats_or_bignums(Size, Rest) => \
 select_val S Fail=fn Size=u Rest=* | fixed_size_values(Size, Rest) => \
   select_val(S, Fail, Size, Rest)
 
-is_tuple Fail=f S | select_tuple_arity S=d Fail=f Size=u Rest=* => \
-  select_tuple_arity(S, Fail, Size, Rest)
+is_tuple Fail=f S | select_tuple_arity S2=d Fail2=f Size=u Rest=* |
+  equal(S, S2) | equal(Fail, Fail2) =>
+    select_tuple_arity(S, Fail, Size, Rest)
 
 select_tuple_arity S=d Fail=f Size=u Rest=* => \
   select_tuple_arity(S, Fail, Size, Rest)
@@ -184,9 +193,15 @@ jump f
 # by get_{list/hd/tl} are common, so we will optimize that.
 #
 is_nonempty_list Fail nqia => jump Fail
-is_nonempty_list Fail Src | get_list Src Hd Tl => is_nonempty_list_get_list Fail Src Hd Tl
-is_nonempty_list Fail Src | get_hd Src Hd => is_nonempty_list_get_hd Fail Src Hd
-is_nonempty_list Fail Src | get_tl Src Tl => is_nonempty_list_get_tl Fail Src Tl
+
+is_nonempty_list Fail Src | get_list Src2 Hd Tl | equal(Src, Src2) =>
+  is_nonempty_list_get_list Fail Src Hd Tl
+
+is_nonempty_list Fail Src | get_hd Src2 Hd | equal(Src, Src2) =>
+  is_nonempty_list_get_hd Fail Src Hd
+
+is_nonempty_list Fail Src | get_tl Src2 Tl | equal(Src, Src2) =>
+   is_nonempty_list_get_tl Fail Src Tl
 
 is_nonempty_list f? S
 
@@ -222,25 +237,23 @@ set_tuple_element s S P
 
 current_tuple/1
 current_tuple/2
-typed_current_tuple/1
 
-is_tuple Fail=f Src | test_arity Fail Src Arity => \
-   i_is_tuple_of_arity Fail Src Arity | current_tuple Src
+is_tuple Fail=f Src | test_arity Fail2 Src2 Arity |
+  equal(Fail, Fail2) | equal(Src, Src2) =>
+    i_is_tuple_of_arity Fail Src Arity | current_tuple Src
 
 test_arity Fail Src Arity => i_test_arity Fail Src Arity | current_tuple Src
 
-is_tuple NotTupleFail Src | \
-  is_tagged_tuple WrongRecordFail Tuple Arity Atom | \
-  equal(Src, Tuple) => \
-   i_is_tagged_tuple_ff NotTupleFail WrongRecordFail Src Arity Atom | \
+is_tuple NotTupleFail Src |
+  is_tagged_tuple WrongRecordFail Tuple Arity Atom |
+  equal(Src, Tuple) =>
+   i_is_tagged_tuple_ff NotTupleFail WrongRecordFail Src Arity Atom |
    current_tuple Src
 
-is_tagged_tuple Fail Tuple Arity Atom => \
-   i_is_tagged_tuple Fail Tuple Arity Atom | typed_current_tuple Tuple
+is_tagged_tuple Fail Tuple Arity Atom =>
+   i_is_tagged_tuple Fail Tuple Arity Atom | current_tuple Tuple
 
 is_tuple Fail=f Src => i_is_tuple Fail Src | current_tuple Src
-
-typed_current_tuple Tuple => remove_tuple_type(Tuple)
 
 i_is_tuple_of_arity f? s A
 i_test_arity f? s A
@@ -253,13 +266,17 @@ i_is_tuple f? s
 # Generate instruction sequence for fetching the tuple element and remember
 # that we have a current tuple pointer.
 
-get_tuple_element Tuple Pos Dst => \
+get_tuple_element Tuple Pos Dst =>
   load_tuple_ptr Tuple | i_get_tuple_element Tuple Pos Dst | current_tuple Tuple
-current_tuple Tuple | get_tuple_element Tuple Pos Dst => \
-  i_get_tuple_element Tuple Pos Dst | current_tuple Tuple
+
+current_tuple Tuple | get_tuple_element Tuple2 Pos Dst |
+  equal(Tuple, Tuple2) =>
+    i_get_tuple_element Tuple Pos Dst | current_tuple Tuple
 
 # Drop the current_tuple instruction if the tuple is overwritten.
-i_get_tuple_element Tuple Pos Tuple | current_tuple Tuple => i_get_tuple_element Tuple Pos Tuple
+i_get_tuple_element Tuple Pos Tuple2 | current_tuple Tuple3 |
+  equal(Tuple, Tuple2) | equal(Tuple, Tuple3) =>
+    i_get_tuple_element Tuple Pos Tuple
 
 # This is a current_tuple instruction instruction not followed by get_tuple_element.
 # Invalidate the current tuple pointer.
@@ -270,15 +287,21 @@ load_tuple_ptr s
 
 # If both positions and destinations are in consecutive memory, fetch and store
 # two words at once.
-i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple | \
-   get_tuple_element Tuple Pos2 Dst2 | consecutive_words(Pos1, Dst1, Pos2, Dst2) => \
+i_get_tuple_element Tuple Pos1 Dst1 |
+   current_tuple Tuple2 |
+   get_tuple_element Tuple3 Pos2 Dst2 |
+   equal(Tuple, Tuple2) | equal(Tuple, Tuple3) |
+   consecutive_words(Pos1, Dst1, Pos2, Dst2) =>
       get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
-i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple | \
-   get_tuple_element Tuple Pos2 Dst2 | consecutive_words(Pos1, Dst2, Pos2, Dst1) => \
+
+i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple2 |
+   get_tuple_element Tuple3 Pos2 Dst2 |
+   equal(Tuple, Tuple2) | equal(Tuple, Tuple3) |
+   consecutive_words(Pos1, Dst2, Pos2, Dst1) =>
       get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
 
 # Drop the current_tuple instruction if the tuple is overwritten.
-current_tuple Tuple Tuple => _
+current_tuple Tuple Tuple2 | equal(Tuple, Tuple2) => _
 current_tuple Tuple Dst => current_tuple Tuple
 
 # The first operand will only be used in the debug-compiled runtime
@@ -318,7 +341,8 @@ system_limit_body
 
 move Src=c Dst => i_move Src Dst
 
-move Src SrcDst | move SrcDst Dst => i_move Src SrcDst | move SrcDst Dst
+move Src SrcDst | move SrcDst2 Dst | equal(SrcDst, SrcDst2) =>
+  i_move Src SrcDst | move SrcDst Dst
 
 # Try to move two words at once. Always arrange the source operands in
 # consecutive order; the destination operands may be in consecutive or
@@ -388,13 +412,13 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl S S => _
+is_eq_exact Lbl LHS RHS | equal(LHS, RHS) => _
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
 
 is_eq_exact Lbl R=xy n => is_nil Lbl R
 is_eq_exact Lbl R=xy C=q => is_eq_exact_literal(Lbl, R, C)
 
-is_ne_exact Lbl S S => jump Lbl
+is_ne_exact Lbl LHS RHS | equal(LHS, RHS) => jump Lbl
 is_ne_exact Lbl C=c R=xy => is_ne_exact Lbl R C
 
 is_ne_exact Lbl R=xy C=q => i_is_ne_exact_literal Lbl R C
@@ -432,8 +456,13 @@ put_tuple2 S A *
 
 store_cons/2
 put_list Hd Tl Dst => put_cons Hd Tl | store_cons u=1 Dst
-store_cons Len Dst | put_list Hd Dst Dst | distinct(Dst, Hd) => combine_conses(Len, Dst, Hd)
-store_cons Len Dst | put_list Hd Dst OtherDst => store_cons Len Dst | append_cons u Hd | store_cons u=1 OtherDst
+
+store_cons Len Dst | put_list Hd Tl Dst2 |
+  equal(Dst, Tl) | equal(Dst, Dst2) | distinct(Dst, Hd)  =>
+    combine_conses(Len, Dst, Hd)
+
+store_cons Len Dst | put_list Hd Tl OtherDst | equal(Dst, Tl) =>
+    store_cons Len Dst | append_cons u Hd | store_cons u=1 OtherDst
 
 put_cons s s
 append_cons I s
@@ -835,7 +864,7 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d => \
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Same Same => _
+bs_start_match4 a==am_resume Live Ctx Dst | equal(Ctx, Dst) => _
 bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
 
 %else

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -37,7 +37,7 @@ FORBIDDEN_TYPES=hQ
 # needs to be re-compiled with a modern compiler.
 
 too_old_compiler/0
-too_old_compiler | never() =>
+too_old_compiler | never() => _
 
 # In R9C and earlier, the loader used to insert special instructions inside
 # the module_info/0,1 functions. (In R10B and later, the compiler inserts
@@ -108,7 +108,7 @@ func_line n => empty_func_line
 empty_func_line
 func_line I
 
-line n =>
+line n => _
 line I
 
 allocate t t?
@@ -264,7 +264,7 @@ i_get_tuple_element Tuple Pos Tuple | current_tuple Tuple => i_get_tuple_element
 # This is a current_tuple instruction instruction not followed by get_tuple_element.
 # Invalidate the current tuple pointer.
 
-current_tuple Tuple =>
+current_tuple Tuple => _
 
 load_tuple_ptr s
 
@@ -278,7 +278,7 @@ i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple | \
       get_two_tuple_elements Tuple Pos1 Dst1 Dst2 | current_tuple Tuple Dst2
 
 # Drop the current_tuple instruction if the tuple is overwritten.
-current_tuple Tuple Tuple =>
+current_tuple Tuple Tuple => _
 current_tuple Tuple Dst => current_tuple Tuple
 
 # The first operand will only be used in the debug-compiled runtime
@@ -302,7 +302,7 @@ raise s s
 
 # Workaround the limitation that generators must always return at least one instruction.
 delete_me/0
-delete_me =>
+delete_me => _
 
 system_limit/1
 system_limit p => system_limit_body
@@ -388,7 +388,7 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl S S =>
+is_eq_exact Lbl S S => _
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
 
 is_eq_exact Lbl R=xy n => is_nil Lbl R
@@ -466,7 +466,7 @@ is_list f? s
 is_atom f? s
 is_float f? s
 
-is_nil Fail=f n =>
+is_nil Fail=f n => _
 is_nil Fail=f qia => jump Fail
 is_nil f? S
 
@@ -835,7 +835,7 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d => \
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Same Same =>
+bs_start_match4 a==am_resume Live Same Same => _
 bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
 
 %else
@@ -997,7 +997,7 @@ i_bs_validate_unicode j? s
 
 # Will fail. No need to keep the instruction, because bs_add or
 # bs_init* would already have raised an exception.
-bs_put_float Fail Sz=q Unit Flags Val =>
+bs_put_float Fail Sz=q Unit Flags Val => _
 
 bs_put_float Fail=j Sz=s Unit=u Flags=u Src=s => \
 			put_float(Fail, Sz, Unit, Flags, Src)
@@ -1048,8 +1048,8 @@ i_fmul l l l
 i_fdiv l l l
 i_fnegate l l
 
-fclearerror =>
-fcheckerror p =>
+fclearerror => _
+fcheckerror p => _
 
 %hot
 
@@ -1288,7 +1288,7 @@ gc_bif3 Fail Live Bif S1 S2 S3 Dst => i_bif3 S1 S2 S3 Fail Bif Dst
 # encountered.
 #
 unsupported_guard_bif/3
-unsupported_guard_bif A B C | never() =>
+unsupported_guard_bif A B C | never() => _
 
 #
 # R13B03

--- a/erts/emulator/beam/predicates.tab
+++ b/erts/emulator/beam/predicates.tab
@@ -215,27 +215,33 @@ pred.map_key_sort(Size, Rest) {
     return beam_load_map_key_sort(S, Size, Rest);
 }
 
-// Test that the two registers are distinct.
-pred.distinct(Reg1, Reg2) {
-    if (Reg1.type != Reg2.type) {
+// Test that two operands are distinct.
+pred.distinct(Val1, Val2) {
+    if (Val1.type != Val2.type) {
         return 1;
-    } else if (Reg1.type == TAG_x || Reg1.type == TAG_y) {
+    } else if (Val1.type == TAG_x || Val1.type == TAG_y) {
         /* We must not compare the type indices (if any). */
-        return (Reg1.val & REG_MASK) != (Reg2.val & REG_MASK);
+        return (Val1.val & REG_MASK) != (Val2.val & REG_MASK);
+    } else if (Val1.type == TAG_n) {
+        /* NIL has no associated value. */
+        return 0;
     } else {
-        return Reg1.val != Reg2.val;
+        return Val1.val != Val2.val;
     }
 }
 
-// Test that two registers are equal when disregarding types. Opposite of the
+// Test that two operands are equal when disregarding types. Opposite of the
 // `distinct` predicate.
-pred.equal(Reg1, Reg2) {
-    if (Reg1.type != Reg2.type) {
+pred.equal(Val1, Val2) {
+    if (Val1.type != Val2.type) {
         return 0;
-    } else if (Reg1.type == TAG_x || Reg1.type == TAG_y) {
+    } else if (Val1.type == TAG_x || Val1.type == TAG_y) {
         /* We must not compare the type indices (if any). */
-        return (Reg1.val & REG_MASK) == (Reg2.val & REG_MASK);
+        return (Val1.val & REG_MASK) == (Val2.val & REG_MASK);
+    } else if (Val1.type == TAG_n) {
+        /* NIL has no associated value. */
+        return 1;
     } else {
-        return Reg1.val == Reg2.val;
+        return Val1.val == Val2.val;
     }
 }

--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -380,6 +380,12 @@ while (<>) {
     if (s/\\$//) {
 	$_ .= <>;
 	redo unless eof(ARGV);
+    } elsif (/([|]|=>)$/) {
+        # Automatically continue a line that ends in '|' or '=>'.
+        my $next_line = <>;
+	$_ .= $next_line;
+        chomp $next_line;
+	redo unless eof(ARGV) or $next_line eq '';
     }
     next if /^\s*$/;
     next if /^\#/;
@@ -2391,9 +2397,13 @@ sub parse_transformation {
     local($_) = @_;
     my($orig) = $_;
 
-    my($from, $to) = split(/\s*=>\s*/);
+    my($from, $to, @rest) = split(/\s*=>\s*/);
     my(@op);
     my $rest_var;
+
+    if (@rest) {
+        error("only one '=>' operator is allowed");
+    }
 
     # The source instructions.
 
@@ -2421,15 +2431,22 @@ sub parse_transformation {
             error("garbage after call to '$name()'");
         }
 	@to = (compile_transform_function($name, split(/\s*,\s*/, $arglist)));
+    } elsif ($to =~ /^\s*_\s*$/) {
+        # _ means that instructions on the left side should be removed.
+        @to = ();
     } else {
 	@to = split(/\s*\|\s*/, $to);
+        if (@to == 0) {
+            error("the right-hand side of a transformation must not be empty;\n" .
+                  "  use _ to indicate that no instructions should be produced");
+        }
 	foreach (@to) {
 	    (@op) = split;
 	    (undef,$_) = compile_transform(0, $rest_var, @op);
 	}
     }
     $orig =~ tr/ \t/ /s;
-    push(@transformations, [$., $orig, [@from], [reverse @to]]);
+    push(@transformations, ["$ARGV($.)", $orig, [@from], [reverse @to]]);
 }
 
 sub compile_transform_function {
@@ -2634,7 +2651,7 @@ sub tr_gen_from {
     my($var_num) = 0;
     my(@code);
     my($op, $ref);		# Loop variables.
-    my $where = "left side of transformation in line $line: ";
+    my $where = "$line: (left of =>): ";
     my $may_fail = 0;
     my $is_first = 1;
     my @instrs;
@@ -2832,7 +2849,7 @@ sub tr_gen_to {
     my(%var_type) = %$var_type_ref;
     my(@code) = @$code_ref;
     my($op, $ref);		# Loop variables.
-    my($where) = "right side of transformation in line $line: ";
+    my($where) = "$line: (right of =>): ";
 
     my $last_instr = $code[$#code];
     my $cannot_fail = is_instr($last_instr, 'commit') &&

--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -49,6 +49,7 @@ my $code_pointers_are_short = 0; # Whether code pointers (to C code) are short.
 my $code_model = 'unknown';
 my $jit = 'no';
 my %defs;                        # Defines (from command line).
+my $pending_errors = 0;          # Number of pending errors.
 
 # Intentionally unused macros, predicates, and generators.
 my %intentionally_unused;
@@ -600,7 +601,6 @@ $num_file_opcodes = @gen_opname;
 # or use forbidden types.
 #
 
-my $any_errors;
 foreach my $key (keys %specific_op) {
     my($arity) = (split('/', $key))[1];
     my @specific_ops = @{$specific_op{$key}};
@@ -625,23 +625,27 @@ foreach my $key (keys %specific_op) {
 	    my $cleaned_arg = $arg;
 	    $cleaned_arg =~ s/[?]$//;
 	    if ($jit ne 'no' and $cleaned_arg eq 'r') {
-		warn "specific instruction '$name @args' uses type 'r' which is is not supported for BeamAsm\n";
-		$any_errors = 1;
+                pending_error("specific instruction '$name @args' uses type " .
+                              "'r' which is is not supported for BeamAsm");
 	    } elsif ($forbidden_type{$cleaned_arg}) {
-		warn "specific instruction '$name @args' uses forbidden type '$arg'\n";
-		$any_errors = 1;
+		pending_error("specific instruction '$name @args' uses " .
+                              "forbidden type '$arg'\n");
 	    }
 	}
     }
 }
 
-error("there were previous type errors") if $any_errors;
+error("beam_makeops: terminating because there were previous errors")
+    if $pending_errors > 0;
 
 #
 # Produce output for the chosen target.
 #
 
 &$target();
+
+error("beam_makeops: terminating because there were previous errors")
+    if $pending_errors > 0;
 
 #
 # Ensure that all C code implementations have been used.
@@ -1287,6 +1291,13 @@ sub parse_c_args {
     }
     $_ eq '' or error("garbage in argument list: $_");
     @res;
+}
+
+sub pending_error {
+    my(@message) = @_;
+    my($where) = $. ? "$ARGV($.): " : "";
+    $pending_errors++;
+    warn $where, @message, "\n";
 }
 
 sub error {
@@ -2760,14 +2771,14 @@ sub tr_gen_from {
 
 	    if ($var ne '') {
 		if (defined $var{$var}) {
-		    $ignored_var = '';
-		    $may_fail = 1;
-		    my $op = make_op($var, 'is_same_var', $var{$var});
-		    op_slot_usage($op, $var{$var});
-		    push(@code, $op);
+                    my $msg = "variable $var used more than once\n" .
+                        "   (repeated variables in matching is not supported;\n" .
+                        "   use the predicate equal(Var1, Var2) " .
+                        "to compare variables)";
+                    pending_error($where, $msg);
 		} elsif ($type eq '*') {
 		    foreach my $type (values %var_type) {
-			error("only one use of a '*' variable is " .
+			error($where, "only one use of a '*' variable is " .
 			      "allowed on the left hand side of " .
 			      "a transformation")
 			    if $type eq 'array';


### PR DESCRIPTION
This pull request updates the syntax of `*..tab` files to make it nicer and more explicit.

Repeating variables in patterns is no longer allowed. For example:

```
move R R =>
```

This must now be written:

```
move R1 R2 | equal(R1, R2) => _
```

This examples also illustrates another change. When instructions are to be removed (rather than replaced), the substitution on the right-hand side must now be written as '_'. That makes it clearer, and also enabling automatic continuation of lines that end in `|` or `=>`. For example, a complex transformation such as:

```
is_tuple NotTupleFail Src | \
  is_tagged_tuple WrongRecordFail Tuple Arity Atom | \
  equal(Src, Tuple) => \
   i_is_tagged_tuple_ff NotTupleFail WrongRecordFail Src Arity Atom | \
   current_tuple Src
```

can now be written simply as:

```
is_tuple NotTupleFail Src |
  is_tagged_tuple WrongRecordFail Tuple Arity Atom |
  equal(Src, Tuple) =>
   i_is_tagged_tuple_ff NotTupleFail WrongRecordFail Src Arity Atom |
   current_tuple Src
```


