### PR TITLE
fix: handle invalid timeout values returned from gen_server callback functions

### DIFF
--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -637,7 +637,11 @@ gen_server:abcast     -----> Module:handle_cast/2
       <name name="enter_loop" arity="3" since=""/>
       <name name="enter_loop" arity="4" clause_i="1" since=""/>
       <name name="enter_loop" arity="4" clause_i="2" since=""/>
-      <name name="enter_loop" arity="5" since=""/>
+      <name name="enter_loop" arity="4" clause_i="3" since=""/>
+      <name name="enter_loop" arity="4" clause_i="4" since=""/>
+      <name name="enter_loop" arity="5" clause_i="1" since=""/>
+      <name name="enter_loop" arity="5" clause_i="2" since=""/>
+      <name name="enter_loop" arity="5" clause_i="3" since=""/>
       <fsummary>Enter the <c>gen_server</c> receive loop.</fsummary>
       <desc>
         <p>
@@ -672,7 +676,8 @@ gen_server:abcast     -----> Module:handle_cast/2
           <em>before</em> this function is called.
         </p>
         <p>
-          <c>State</c> and <c>Timeout</c> have the same meanings as in
+          <c><anno>State</anno></c>, <c><anno>Timeout</anno></c>,
+          <c><anno>Hibernate</anno></c> and <c><anno>Cont</anno></c> have the same meanings as in
           the return value of
           <seemfa marker="#Module:init/1"><c>Module:init/1</c></seemfa>,
           which is <em>not</em> called when <c>enter_loop/3,4,5</c> is used.

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -137,6 +137,11 @@
    STACKTRACE(),
    element(2, erlang:process_info(self(), current_stacktrace))).
 
+-define(
+	is_timeout(X),
+	( (X) =:= infinity orelse ( is_integer(X) andalso (X) >= 0 ) )
+).
+
 %%%=========================================================================
 %%%  API
 %%%=========================================================================
@@ -557,7 +562,7 @@ multi_call(Nodes, Name, Request, Timeout)
        ) ->
                         no_return().
 %%
-enter_loop(Mod, Options, State) ->
+enter_loop(Mod, Options, State) when is_atom(Mod) andalso is_list(Options) ->
     enter_loop(Mod, Options, State, self(), infinity).
 
 -spec enter_loop(
@@ -573,33 +578,81 @@ enter_loop(Mod, Options, State) ->
          State   :: term(),
          Timeout :: timeout()
        ) ->
+                        no_return();
+       (
+           Module  :: module(),
+           Options :: [enter_loop_opt()],
+           State   :: term(),
+           Hibernate :: hibernate
+       ) ->
+                        no_return();
+       (
+           Module  :: module(),
+           Options :: [enter_loop_opt()],
+           State   :: term(),
+           Continue :: {continue, term()}
+       ) ->
                         no_return().
 %%
 enter_loop(Mod, Options, State, ServerName = {Scope, _})
-  when Scope == local; Scope == global ->
+    when is_atom(Mod) andalso
+         is_list(Options) andalso
+         (Scope == local orelse Scope == global) ->
     enter_loop(Mod, Options, State, ServerName, infinity);
 %%
-enter_loop(Mod, Options, State, ServerName = {via, _, _}) ->
+enter_loop(Mod, Options, State, ServerName = {via, _, _}) when is_atom(Mod) andalso is_list(Options) ->
     enter_loop(Mod, Options, State, ServerName, infinity);
 %%
-enter_loop(Mod, Options, State, Timeout) ->
-    enter_loop(Mod, Options, State, self(), Timeout).
+enter_loop(Mod, Options, State, TimeoutOrHibernate)
+    when is_atom(Mod) andalso
+         is_list(Options) andalso
+         (?is_timeout(TimeoutOrHibernate) orelse TimeoutOrHibernate =:= hibernate) ->
+    enter_loop(Mod, Options, State, self(), TimeoutOrHibernate);
+%%
+enter_loop(Mod, Options, State, {continue, _}=Continue) when is_atom(Mod) andalso is_list(Options) ->
+    enter_loop(Mod, Options, State, self(), Continue).
 
 -spec enter_loop(
         Module     :: module(),
         Options    :: [enter_loop_opt()],
         State      :: term(),
         ServerName :: server_name() | pid(),
-        Timeout    :: timeout()
+        Timeout    :: timeout() | hibernate | {continue, term()}
+       ) ->
+                        no_return();
+       (
+           Module     :: module(),
+           Options    :: [enter_loop_opt()],
+           State      :: term(),
+           ServerName :: server_name() | pid(),
+           Hibernate    :: hibernate
+       ) ->
+                        no_return();
+       (
+           Module     :: module(),
+           Options    :: [enter_loop_opt()],
+           State      :: term(),
+           ServerName :: server_name() | pid(),
+           Continue    :: {continue, term()}
        ) ->
                         no_return().
 %%
-enter_loop(Mod, Options, State, ServerName, Timeout) ->
+enter_loop(Mod, Options, State, ServerName, TimeoutOrHibernate)
+    when is_atom(Mod) andalso
+         is_list(Options) andalso
+         (?is_timeout(TimeoutOrHibernate) orelse TimeoutOrHibernate =:= hibernate) ->
     Name = gen:get_proc_name(ServerName),
     Parent = gen:get_parent(),
     Debug = gen:debug_options(Name, Options),
     HibernateAfterTimeout = gen:hibernate_after(Options),
-    loop(Parent, Name, State, Mod, Timeout, HibernateAfterTimeout, Debug).
+    loop(Parent, Name, State, Mod, TimeoutOrHibernate, HibernateAfterTimeout, Debug);
+%%
+enter_loop(Mod, Options, State, ServerName, {continue, _}=Continue) when is_atom(Mod) andalso is_list(Options) ->
+    Name = gen:get_proc_name(ServerName),
+    Parent = gen:get_parent(),
+    Debug = gen:debug_options(Name, Options),
+    HibernateAfterTimeout = gen:hibernate_after(Options),
+    loop(Parent, Name, State, Mod, Continue, HibernateAfterTimeout, Debug).
 
 %%%========================================================================
 %%% Gen-callback functions
@@ -623,10 +676,12 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 	{ok, {ok, State}} ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
 	    loop(Parent, Name, State, Mod, infinity, HibernateAfterTimeout, Debug);
-	{ok, {ok, State, TimeoutHibernateOrContinue}} ->
+    {ok, {ok, State, TimeoutOrHibernate}} when ?is_timeout(TimeoutOrHibernate) orelse TimeoutOrHibernate =:= hibernate ->
 	    proc_lib:init_ack(Starter, {ok, self()}), 	    
-	    loop(Parent, Name, State, Mod, TimeoutHibernateOrContinue,
-	         HibernateAfterTimeout, Debug);
+	    loop(Parent, Name, State, Mod, TimeoutOrHibernate, HibernateAfterTimeout, Debug);
+	{ok, {ok, State, {continue, _}=Continue}} ->
+	    proc_lib:init_ack(Starter, {ok, self()}), 	    
+	    loop(Parent, Name, State, Mod, Continue, HibernateAfterTimeout, Debug);
 	{ok, {stop, Reason}} ->
 	    %% For consistency, we must make sure that the
 	    %% registered name (if any) is unregistered before
@@ -984,13 +1039,12 @@ handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod, HibernateAfterTim
 	{ok, {reply, Reply, NState}} ->
 	    reply(From, Reply),
 	    loop(Parent, Name, NState, Mod, infinity, HibernateAfterTimeout, []);
-	{ok, {reply, Reply, NState, Time1}} ->
+	{ok, {reply, Reply, NState, TimeoutOrHibernate}} when ?is_timeout(TimeoutOrHibernate) orelse TimeoutOrHibernate =:= hibernate ->
 	    reply(From, Reply),
-	    loop(Parent, Name, NState, Mod, Time1, HibernateAfterTimeout, []);
-	{ok, {noreply, NState}} ->
-	    loop(Parent, Name, NState, Mod, infinity, HibernateAfterTimeout, []);
-	{ok, {noreply, NState, Time1}} ->
-	    loop(Parent, Name, NState, Mod, Time1, HibernateAfterTimeout, []);
+	    loop(Parent, Name, NState, Mod, TimeoutOrHibernate, HibernateAfterTimeout, []);
+	{ok, {reply, Reply, NState, {continue, _}=Continue}} ->
+	    reply(From, Reply),
+	    loop(Parent, Name, NState, Mod, Continue, HibernateAfterTimeout, []);
 	{ok, {stop, Reason, Reply, NState}} ->
 	    try
 		terminate(Reason, ?STACKTRACE(), Name, From, Msg, Mod, NState, [])
@@ -1009,17 +1063,12 @@ handle_msg({'$gen_call', From, Msg}, Parent, Name, State, Mod, HibernateAfterTim
 	{ok, {reply, Reply, NState}} ->
 	    Debug1 = reply(Name, From, Reply, NState, Debug),
 	    loop(Parent, Name, NState, Mod, infinity, HibernateAfterTimeout, Debug1);
-	{ok, {reply, Reply, NState, Time1}} ->
+	{ok, {reply, Reply, NState, TimeoutOrHibernate}} when ?is_timeout(TimeoutOrHibernate) orelse TimeoutOrHibernate =:= hibernate ->
 	    Debug1 = reply(Name, From, Reply, NState, Debug),
-	    loop(Parent, Name, NState, Mod, Time1, HibernateAfterTimeout, Debug1);
-	{ok, {noreply, NState}} ->
-	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name,
-				      {noreply, NState}),
-	    loop(Parent, Name, NState, Mod, infinity, HibernateAfterTimeout, Debug1);
-	{ok, {noreply, NState, Time1}} ->
-	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name,
-				      {noreply, NState}),
-	    loop(Parent, Name, NState, Mod, Time1, HibernateAfterTimeout, Debug1);
+	    loop(Parent, Name, NState, Mod, TimeoutOrHibernate, HibernateAfterTimeout, Debug1);
+	{ok, {reply, Reply, NState, {continue, _}=Continue}} ->
+	    Debug1 = reply(Name, From, Reply, NState, Debug),
+	    loop(Parent, Name, NState, Mod, Continue, HibernateAfterTimeout, Debug1);
 	{ok, {stop, Reason, Reply, NState}} ->
 	    try
 		terminate(Reason, ?STACKTRACE(), Name, From, Msg, Mod, NState, Debug)
@@ -1037,8 +1086,10 @@ handle_common_reply(Reply, Parent, Name, From, Msg, Mod, HibernateAfterTimeout, 
     case Reply of
 	{ok, {noreply, NState}} ->
 	    loop(Parent, Name, NState, Mod, infinity, HibernateAfterTimeout, []);
-	{ok, {noreply, NState, Time1}} ->
-	    loop(Parent, Name, NState, Mod, Time1, HibernateAfterTimeout, []);
+	{ok, {noreply, NState, TimeoutOrHibernate}} when ?is_timeout(TimeoutOrHibernate) orelse TimeoutOrHibernate =:= hibernate ->
+	    loop(Parent, Name, NState, Mod, TimeoutOrHibernate, HibernateAfterTimeout, []);
+	{ok, {noreply, NState, {continue, _}=Continue}} ->
+	    loop(Parent, Name, NState, Mod, Continue, HibernateAfterTimeout, []);
 	{ok, {stop, Reason, NState}} ->
 	    terminate(Reason, ?STACKTRACE(), Name, From, Msg, Mod, NState, []);
 	{'EXIT', Class, Reason, Stacktrace} ->
@@ -1053,10 +1104,12 @@ handle_common_reply(Reply, Parent, Name, From, Msg, Mod, HibernateAfterTimeout, 
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name,
 				      {noreply, NState}),
 	    loop(Parent, Name, NState, Mod, infinity, HibernateAfterTimeout, Debug1);
-	{ok, {noreply, NState, Time1}} ->
-	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name,
-				      {noreply, NState}),
-	    loop(Parent, Name, NState, Mod, Time1, HibernateAfterTimeout, Debug1);
+	{ok, {noreply, NState, TimeoutOrHibernate}} when ?is_timeout(TimeoutOrHibernate) orelse TimeoutOrHibernate =:= hibernate ->
+	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name, {noreply, NState}),
+	    loop(Parent, Name, NState, Mod, TimeoutOrHibernate, HibernateAfterTimeout, Debug1);
+	{ok, {noreply, NState, {continue, _}=Continue}} ->
+	    Debug1 = sys:handle_debug(Debug, fun print_event/3, Name, {noreply, NState}),
+	    loop(Parent, Name, NState, Mod, Continue, HibernateAfterTimeout, Debug1);
 	{ok, {stop, Reason, NState}} ->
 	    terminate(Reason, ?STACKTRACE(), Name, From, Msg, Mod, NState, Debug);
 	{'EXIT', Class, Reason, Stacktrace} ->

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -580,17 +580,17 @@ enter_loop(Mod, Options, State) when is_atom(Mod) andalso is_list(Options) ->
        ) ->
                         no_return();
        (
-           Module  :: module(),
-           Options :: [enter_loop_opt()],
-           State   :: term(),
-           Hibernate :: hibernate
+           Module    :: module(),
+           Options   :: [enter_loop_opt()],
+           State     :: term(),
+           Hibernate :: 'hibernate'
        ) ->
                         no_return();
        (
            Module  :: module(),
            Options :: [enter_loop_opt()],
            State   :: term(),
-           Continue :: {continue, term()}
+           Cont    :: {'continue', term()}
        ) ->
                         no_return().
 %%
@@ -617,7 +617,7 @@ enter_loop(Mod, Options, State, {continue, _}=Continue) when is_atom(Mod) andals
         Options    :: [enter_loop_opt()],
         State      :: term(),
         ServerName :: server_name() | pid(),
-        Timeout    :: timeout() | hibernate | {continue, term()}
+        Timeout    :: timeout()
        ) ->
                         no_return();
        (
@@ -625,7 +625,7 @@ enter_loop(Mod, Options, State, {continue, _}=Continue) when is_atom(Mod) andals
            Options    :: [enter_loop_opt()],
            State      :: term(),
            ServerName :: server_name() | pid(),
-           Hibernate    :: hibernate
+           Hibernate  :: 'hibernate'
        ) ->
                         no_return();
        (
@@ -633,7 +633,7 @@ enter_loop(Mod, Options, State, {continue, _}=Continue) when is_atom(Mod) andals
            Options    :: [enter_loop_opt()],
            State      :: term(),
            ServerName :: server_name() | pid(),
-           Continue    :: {continue, term()}
+           Cont       :: {'continue', term()}
        ) ->
                         no_return().
 %%


### PR DESCRIPTION
`gen_server` module currently does not check returned timeout from `init` and all other `handle_*` callback functions. IMO in this case it should terminate with a `{bad_return_value, _}` too.  

### Example
```erlang
-module(m).
-compile(export_all).
-compile(nowarn_export_all).

start_link(Timeout) ->
    gen_server:start_link({local, ?MODULE}, ?MODULE, Timeout, []).

init(Timeout) ->
    {ok, undefined, Timeout}.

handle_info(_, S) ->
    % Max 'receive' timeout value + 1
    {noreply, S, 16#FFFFFFFF+1}.

terminate(_, _) ->
    ok.
```

#### Before this change
```erlang
1> erlang:process_flag(trap_exit, true).
false

2> m:start_link(-1).
{ok,<0.80.0>} % Dies right after entering the gen_server loop
=CRASH REPORT==== 5-Feb-2022::03:18:40.013997 ===
  crasher:
    initial call: m:init/1
    pid: <0.80.0>
    registered_name: m
    exception error: bad receive timeout value
      in function  gen_server:loop/7 (gen_server.erl, line 411)
    ancestors: [<0.77.0>]
    message_queue_len: 0
    messages: []
    links: [<0.77.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 376
    stack_size: 27
    reductions: 207
  neighbours:

3> flush().
Shell got {'EXIT',<0.80.0>,
              {timeout_value,
                  [{gen_server,loop,7,[{file,"gen_server.erl"},{line,411}]},
                   {proc_lib,init_p_do_apply,3,
                       [{file,"proc_lib.erl"},{line,249}]}]}}
ok


% let it start and live:
4> m:start_link(infinity).
{ok,<0.83.0>}

5> m ! oops.
oops
=CRASH REPORT==== 5-Feb-2022::03:19:09.405236 ===
  crasher:
    initial call: m:init/1
    pid: <0.83.0>
    registered_name: m
    exception error: bad receive timeout value
      in function  gen_server:loop/7 (gen_server.erl, line 411)
    ancestors: [<0.77.0>]
    message_queue_len: 0
    messages: []
    links: [<0.77.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 376
    stack_size: 27
    reductions: 199
  neighbours:

6> flush().
Shell got {'EXIT',<0.83.0>,
              {timeout_value,
                  [{gen_server,loop,7,[{file,"gen_server.erl"},{line,411}]},
                   {proc_lib,init_p_do_apply,3,
                       [{file,"proc_lib.erl"},{line,249}]}]}}
ok
```

#### After this change
```erlang
1> erlang:process_flag(trap_exit, true).
false

2> m:start_link(-1).
{error,{bad_return_value,{ok,undefined,-1}}}

=CRASH REPORT==== 5-Feb-2022::03:24:44.849737 ===
  crasher:
    initial call: m:init/1
    pid: <0.81.0>
    registered_name: m
    exception exit: {bad_return_value,{ok,undefined,-1}}
      in function  gen_server:init_it/6 (gen_server.erl, line 403)
    ancestors: [<0.77.0>]
    message_queue_len: 0
    messages: []
    links: [<0.77.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 376
    stack_size: 27
    reductions: 203
  neighbours:


3> flush().
Shell got {'EXIT',<0.81.0>,{bad_return_value,{ok,undefined,-1}}}
ok


% let it start and live:
4> m:start_link(infinity).
{ok,<0.84.0>}

5> m ! oops.
oops

=ERROR REPORT==== 5-Feb-2022::03:25:09.760708 ===
** Generic server m terminating 
** Last message in was oops
** When Server state == undefined
** Reason for termination ==
** {bad_return_value,{noreply,undefined,4294967296}}

=CRASH REPORT==== 5-Feb-2022::03:25:09.761283 ===
  crasher:
    initial call: m:init/1
    pid: <0.84.0>
    registered_name: m
    exception exit: {bad_return_value,{noreply,undefined,4294967296}}
      in function  gen_server:handle_common_reply/8 (gen_server.erl, line 825)
    ancestors: [<0.77.0>]
    message_queue_len: 0
    messages: []
    links: [<0.77.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 2586
    stack_size: 27
    reductions: 4652
  neighbours:


6> flush().
Shell got {'EXIT',<0.84.0>,{bad_return_value,{noreply,undefined,4294967296}}}
ok
```
