### PR TITLE
Further strengthen the type-based optimizations

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -844,6 +844,7 @@ class BeamGlobalAssembler : public BeamAssembler {
     _(fconv_shared)                                                            \
     _(handle_and_error)                                                        \
     _(handle_call_fun_error)                                                   \
+    _(handle_element_error_shared)                                             \
     _(handle_hd_error)                                                         \
     _(handle_map_size_error)                                                   \
     _(handle_not_error)                                                        \

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1263,8 +1263,8 @@ protected:
             Sint min, max;
             auto [min1, max1] = getIntRange(LHS);
             auto [min2, max2] = getIntRange(RHS);
-            min = min1 - min2;
-            max = max1 - max2;
+            min = min1 - max2;
+            max = max1 - min2;
             return IS_SSMALL(min) && IS_SSMALL(max);
         }
     }

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1276,8 +1276,8 @@ protected:
             Sint min, max;
             auto [min1, max1] = getIntRange(LHS);
             auto [min2, max2] = getIntRange(RHS);
-            min = min1 - min2;
-            max = max1 - max2;
+            min = min1 - max2;
+            max = max1 - min2;
             return IS_SSMALL(min) && IS_SSMALL(max);
         }
     }

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1491,6 +1491,13 @@ protected:
         } else {
             mov_imm(to, from.getValue());
         }
+
+#ifdef DEBUG
+        /* Explicitly clear flags to catch bugs quicker, it may be very rare
+         * for a certain instruction to load values that would otherwise cause
+         * flags to be cleared. */
+        a.test(to, to);
+#endif
     }
 
     void mov_arg(x86::Mem to, const ArgVal &from, const x86::Gp &spill) {

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -2046,7 +2046,6 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgVal &Fail,
             a.mov(ARG1, c_p);
             runtime_call<4>(erts_new_bs_put_float);
             if (Fail.getValue() == 0) {
-                mov_arg(ARG1, seg.src);
                 mov_imm(ARG4,
                         beam_jit_update_bsc_reason_info(seg.error_info,
                                                         BSC_REASON_BADARG,
@@ -2078,7 +2077,6 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgVal &Fail,
                 comment("skipped test for success because construction can't "
                         "fail");
             } else {
-                a.test(RETd, RETd);
                 if (Fail.getValue() == 0) {
                     mov_arg(ARG1, seg.src);
                     mov_imm(ARG4,
@@ -2087,6 +2085,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgVal &Fail,
                                                             BSC_INFO_TYPE,
                                                             BSC_VALUE_ARG1));
                 }
+                a.test(RETd, RETd);
                 a.je(error);
             }
             break;
@@ -2110,7 +2109,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgVal &Fail,
                                                         BSC_INFO_TYPE,
                                                         BSC_VALUE_ARG1));
             }
-            a.test(RET, RET);
+            a.test(RETd, RETd);
             a.je(error);
             break;
         case am_utf16:

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -292,7 +292,8 @@ epilogue_passes(Opts) ->
           ?PASS(ssa_opt_get_tuple_element),
           ?PASS(ssa_opt_tail_literals),
           ?PASS(ssa_opt_trim_unreachable),
-          ?PASS(ssa_opt_unfold_literals)],
+          ?PASS(ssa_opt_unfold_literals),
+          ?PASS(ssa_opt_ranges)],
     passes_1(Ps, Opts).
 
 passes_1(Ps, Opts0) ->
@@ -442,6 +443,9 @@ ssa_opt_merge_blocks({#opt_st{ssa=Blocks0}=St, FuncDb}) ->
     RPO = beam_ssa:rpo(Blocks0),
     Blocks = beam_ssa:merge_blocks(RPO, Blocks0),
     {St#opt_st{ssa=Blocks}, FuncDb}.
+
+ssa_opt_ranges({#opt_st{ssa=Blocks}=St, FuncDb}) ->
+    {St#opt_st{ssa=beam_ssa_type:opt_ranges(Blocks)}, FuncDb}.
 
 %%%
 %%% Split blocks before certain instructions to enable more optimizations.

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -1214,9 +1214,12 @@ float_opt_is([#b_set{op={succeeded,_},args=[Src]}=I0],
 float_opt_is([#b_set{anno=Anno0}=I0|Is0], Fs0, Count0, Acc) ->
     case Anno0 of
         #{float_op:=FTypes} ->
-            Anno = maps:remove(float_op, Anno0),
+            ArgTypes0 = maps:get(arg_types, Anno0, #{}),
+            ArgTypes = float_arg_types(FTypes, 0, ArgTypes0),
+            Anno1 = maps:remove(float_op, Anno0),
+            Anno = maps:remove(arg_types, Anno1),
             I1 = I0#b_set{anno=Anno},
-            {Is,Fs,Count} = float_make_op(I1, FTypes, Fs0, Count0),
+            {Is,Fs,Count} = float_make_op(I1, FTypes, ArgTypes, Fs0, Count0),
             float_opt_is(Is0, Fs, Count, reverse(Is, Acc));
         #{} ->
             float_opt_is(Is0, Fs0, Count0, [I0|Acc])
@@ -1224,9 +1227,18 @@ float_opt_is([#b_set{anno=Anno0}=I0|Is0], Fs0, Count0, Acc) ->
 float_opt_is([], _Fs, _Count, _Acc) ->
     none.
 
+float_arg_types([_|As], Index, ArgTypes) ->
+    case ArgTypes of
+        #{Index := ArgType} ->
+            [ArgType|float_arg_types(As, Index + 1, ArgTypes)];
+        #{} ->
+            [any|float_arg_types(As, Index + 1, ArgTypes)]
+    end;
+float_arg_types([], _, _) -> [].
+
 float_make_op(#b_set{op={bif,Op},dst=Dst,args=As0,anno=Anno}=I0,
-              Ts, #fs{regs=Rs0}=Fs, Count0) ->
-    {As1,Rs1,Count1} = float_load(As0, Ts, Anno, Rs0, Count0, []),
+              Ts, ArgTypes, #fs{regs=Rs0}=Fs, Count0) ->
+    {As1,Rs1,Count1} = float_load(As0, Ts, ArgTypes, Anno, Rs0, Count0, []),
     {As,Is0} = unzip(As1),
     {FrDst,Count2} = new_var('@fr', Count1),
     I = I0#b_set{op={float,Op},dst=FrDst,args=As},
@@ -1234,19 +1246,23 @@ float_make_op(#b_set{op={bif,Op},dst=Dst,args=As0,anno=Anno}=I0,
     Is = append(Is0) ++ [I],
     {Is,Fs#fs{regs=Rs},Count2}.
 
-float_load([A|As], [T|Ts], Anno, Rs0, Count0, Acc) ->
-    {Load,Rs,Count} = float_reg_arg(A, T, Anno, Rs0, Count0),
-    float_load(As, Ts, Anno, Rs, Count, [Load|Acc]);
-float_load([], [], _Anno, Rs, Count, Acc) ->
+float_load([A|As], [T|Ts], [AT|ATs], Anno, Rs0, Count0, Acc) ->
+    {Load,Rs,Count} = float_reg_arg(A, T, AT, Anno, Rs0, Count0),
+    float_load(As, Ts, ATs, Anno, Rs, Count, [Load|Acc]);
+float_load([], [], [], _Anno, Rs, Count, Acc) ->
     {reverse(Acc),Rs,Count}.
 
-float_reg_arg(A, T, Anno, Rs, Count0) ->
+float_reg_arg(A, T, AT, Anno0, Rs, Count0) ->
     case Rs of
         #{A:=Fr} ->
             {{Fr,[]},Rs,Count0};
         #{} ->
             {Dst,Count} = new_var('@fr_copy', Count0),
             I0 = float_load_reg(T, A, Dst),
+            Anno = case AT of
+                       any-> Anno0;
+                       _ -> Anno0#{arg_types => #{0 => AT}}
+                   end,
             I = I0#b_set{anno=Anno},
             {{Dst,[I]},Rs#{A=>Dst},Count}
     end.

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -277,7 +277,7 @@ expand_opt(r23, Os) ->
                               no_recv_opt, no_init_yregs |
                               expand_opt(r24, Os)]);
 expand_opt(r24, Os) ->
-    expand_opt(no_type_opt, [no_bs_create_bin | Os]);
+    expand_opt(no_type_opt, [no_bs_create_bin, no_ssa_opt_ranges | Os]);
 expand_opt(no_make_fun3, Os) ->
     [no_make_fun3, no_fun_opt | Os];
 expand_opt({debug_info_key,_}=O, Os) ->

--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -99,6 +99,7 @@ opt_opts(Mod) ->
                      (no_share_opt) -> true;
                      (no_shared_fun_wrappers) -> true;
                      (no_ssa_opt_float) -> true;
+                     (no_ssa_opt_ranges) -> true;
                      (no_ssa_opt) -> true;
                      (no_stack_trimming) -> true;
                      (no_swap) -> true;


### PR DESCRIPTION
Building on #5316 and #5664, this pull request annotates more arithmetic instructions with type information to allow the JIT to generate better code.

With this PR, the compiler and the JIT can now optimize a tuple used as a lookup table such as in the following example (similar to real code in the `base64` module):

```
foo(N0) ->
    N1 = N0 band 3,
    N = N1 + 1,
    element(N, {zero,one,two,three}).
```

Because `N` is known to be an integer in the range 1 through 4, the JIT will omit all type and range checks and generate inlined code to fetch the `N`th element of the tuple.