### PR TITLE
Include the error reason when loading a nif fails

### DIFF
--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -1475,7 +1475,7 @@ run_on_load_handlers([M|Ms], Debug) ->
 	    erlang:finish_after_on_load(M, Keep),
 	    case Keep of
 		false ->
-		    Error = {on_load_function_failed,M},
+		    Error = {on_load_function_failed,M,OnLoadRes},
 		    debug(Debug, Error),
 		    exit(Error);
 		true ->


### PR DESCRIPTION
When a nifs `on_load` function returns a non-ok value loading fails today silently without showing the returned error reason. 

This is especially sad when the `on_load` callback is calling `erlang:load_nif/2` as it lasts statement which many nif `on_load` callbacks do. `erlang:load_nif/2` typically returns quite helpful error tuples that help to identify the reasons for why the nif failed loading. This change makes the error message appear in the output and in debug messages when debugging is enabled. 

```erlang
-on_load(init/0).

init() ->
    SoName = filename:join(code:priv_dir(?APPNAME), ?LIBNAME),
    erlang:load_nif(SoName, 0).
```