### PR TITLE
erts: Fix table info segfault during crash dump

### DIFF
--- a/erts/.gitignore
+++ b/erts/.gitignore
@@ -22,3 +22,5 @@
 /emulator/pcre/pcre_exec_loop_break_cases.inc
 /emulator/beam/erl_db_insert_list.ycf.h
 
+/emulator/ryu/obj
+/obj.debug/

--- a/erts/emulator/beam/big.c
+++ b/erts/emulator/beam/big.c
@@ -1483,6 +1483,18 @@ erts_make_integer(Uint x, Process *p)
 	return uint_to_big(x,hp);
     }
 }
+
+Eterm
+erts_make_integer_fact(Uint x, ErtsHeapFactory *hf)
+{
+    Eterm* hp;
+    if (IS_USMALL(0,x))
+	return make_small(x);
+    else {
+	hp = erts_produce_heap(hf, BIG_UINT_HEAP_SIZE, 0);
+	return uint_to_big(x, hp);
+    }
+}
 /*
  * As erts_make_integer, but from a whole UWord.
  */

--- a/erts/emulator/beam/big.h
+++ b/erts/emulator/beam/big.h
@@ -156,6 +156,7 @@ Eterm small_to_big(Sint, Eterm*);
 Eterm uint_to_big(Uint, Eterm*);
 Eterm uword_to_big(UWord, Eterm*);
 Eterm erts_make_integer(Uint, Process *);
+Eterm erts_make_integer_fact(Uint, ErtsHeapFactory *);
 Eterm erts_make_integer_from_uword(UWord x, Process *p);
 
 dsize_t big_bytes(Eterm);


### PR DESCRIPTION
When creating a crash dump there is no process available to
allocate terms to the heap. The new write_concurrency option
needs a heap to allocate a tuple on, so it would segfault
in the old code.

So the table_info function now takes a factory that we can use
to allocate all needed term in.