### PR TITLE
Update guidance on spec "when" for consistency

### DIFF
--- a/system/doc/reference_manual/typespec.xml
+++ b/system/doc/reference_manual/typespec.xml
@@ -550,40 +550,22 @@
       For example, the following specification defines the type of a
       polymorphic identity function:
     </p>
-    <pre>
-  -spec id(X) -> X.</pre>
+    <pre> -spec id(X) -> X.</pre>
     <p>
-      Notice that the above specification does not restrict the input
-      and output type in any way.
-      These types can be constrained by guard-like subtype constraints
-      and provide bounded quantification:
+    Notice that the above specification restricts the output type
+    to be the same as the input type, but imposes no other requirements.
+    So `id(atom())` is expected to return `atom()` and `id({a, b})` is
+    expected to return `{a, b}`.
     </p>
-    <pre>  -spec id(X) -> X when X :: tuple().</pre>
-    <p>
-      Currently, the <c>::</c> constraint
-      (read as &laquo;is a subtype of&raquo;) is
-      the only guard constraint that can be used in the <c>when</c>
-      part of a <c>-spec</c> attribute.
+    <p>Constraint syntax is permitted in function specifications.
+    The meaning of such constraints is the same as substituting the
+    right-hand side of <c>::</c> for the left-hand side. The following
+    two definitions are equivalent
     </p>
-    <note>
-      <p>
-      The above function specification uses multiple occurrences of
-      the same type variable. That provides more type information than the
-      following function specification, where the type variables are missing:
-      </p>
-      <pre>  -spec id(tuple()) -> tuple().</pre>
-      <p>
-	The latter specification says that the function takes some tuple
-	and returns some tuple. The specification with the <c>X</c> type
-	variable specifies that the function takes a tuple and returns
-	<em>the same</em> tuple.
-      </p>
-      <p>
-	However, it is up to the tools that process the specifications
-        to choose whether to take this extra information into account
-        or not.
-      </p>
-    </note>
+    <pre>  -spec id_atom(X) -> X when X :: atom().
+           % equivalent to
+           -spec id_atom(atom()) -> atom().
+    </pre>
     <p>
       The scope of a <c>::</c> constraint is the
       <c>(...) -> RetType</c>


### PR DESCRIPTION
*For now*, standardize on the simple substitution
interpretation of `::` in constraints. Bounded
quantification could always be added later with
dedicated syntax (`<:` or `subtype_of`, etc.).

## Standardization

Previously, guidance for `when` in specs was that tools could *decide* whether to implement bounded quantificaiton or not.

That's a dangerous path in a world where we want users and OTP team to be able to write specs *once* and not split the ecosystem.

So if we're going for consistency, then we have a choice of whether to say `when` in specs is for bounded quantification or simple substitution.

## Two Interpretations: Subsitution vs. Bounds

- Substitution interpretation: `-spec id_tup(X) -> X when X :: tuple()`
is equivalent to `-spec id_tup(tuple()) -> tuple().`
- Bounded quantification interpretation:
`-spec id_tuple(X) -> X :: tuple()` is generic and bounds
`X` to be a `tuple()`. This is the kind of thing that might
be written in made-up explicit syntax as
`-spec id_tuple<T extends tuple()>(T) -> T`.
`id_tuple(an_atom)` would lead to a type error and
`id_tuple({a, b})` would have return type `{a, b}`.

There are both pragmatic and theoretical reasons in favor of
the substitution interpretation.

## Reasons in Favor of The Substitution Interpretation

1. The substitution interpretation **reflects Erlang reality**.
   - Dialyzer, Gradualizer, and mystery-type-checker all use
   the substitution interpretation.
   - Most OTP specs don't make much sense on the bounded quanitification
   interpretation. `:: term()` appears over 2000 times in this repo,
   but why would someone bound something to be a subtype of `term()`?
2. The substitution interpretation makes things easier for implementers,
including contributors to this repo. Dialyzer currently (iuc) doesn't
handle generics as generics at all. It sounds easier to add unbounded
genericity first rather than committing to the more complex bounded
quantification.
3. The substitution interpretation is more syntactically consistent. In `-type ty() :: atom()`, for example, the `::` means "is", not  "some type that is a subtype of atom()".
4. I sometimes see Erlang devs confused about the difference between
type variables and `term()` ([example in Q&A](https://youtu.be/_u1NDuFsW2A?t=1528)). Bounded quantification is yet another rung of complexity for users.
5. Bounded quantification is a complex feature that ideally would be
incorporated into the language in a holistic way:
    - For example, it would be an odd barrier to composability if
    specs could express bounds but type aliases and opaques could not.
    Such an asymmetry would prevent seemingly trivial refactors such
    as extracting out parts of a long spec into type aliases.
    - To take another example, if bounds really are part of types,
    then error reporting for static analysis ideally would include
    bounds as well. It takes some work to do this in a way that
    is both informative and not befuddling.
    - Variance interacts with bounded quantification,
    but the variance story is still being written.
    [@jhogberg is investigating variance annotations for aliases and opaques](https://github.com/erlang/otp/pull/5223#issuecomment-924917745).

## Note on Backwards-Compatibility

This is a minor change in official guidance.

This change in guidance won't break anything as far as I can tell,
so I don't think we tarnish Erlang's great reputation as a stable, backwards-compatible language.

And this change improves the situation going forward: standardizing will help preventing the type-writing community from splitting in the future.


> Thanks for your time in considering this docs update