### PR TITLE
erts: Detect libdlpi for cross compilation

### DIFF
--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -1695,12 +1695,12 @@ AS_IF([test x"$ac_cv_lib_dlpi_dlpi_open" = x"no"],
    dnl gcc makes /usr/ccs/bin/ld ignore the crle configured linker default paths
    dnl typically causing dlpi not being found on Solaris et.al
    save_ldflags="$LDFLAGS"
-   try_dlpi_lib=/lib
+   try_dlpi_lib=$erl_xcomp_sysroot/lib
    if test x"$ac_cv_sizeof_void_p" = x"8"; then
-      if test -d /lib64; then
-	 try_dlpi_lib=/lib64
-      elif test -d /lib/64; then
-	 try_dlpi_lib=/lib/64
+      if test -d  $erl_xcomp_sysroot/lib64; then
+	 try_dlpi_lib= $erl_xcomp_sysroot/lib64
+      elif test -d  $erl_xcomp_sysroot/lib/64; then
+	 try_dlpi_lib= $erl_xcomp_sysroot/lib/64
       fi
    fi
    if test ! -f "$try_dlpi_lib/libdlpi.so" && \
@@ -1719,7 +1719,7 @@ AS_IF([test x"$ac_cv_lib_dlpi_dlpi_open" = x"no"],
    fi
    LDFLAGS="-L$try_dlpi_lib -R$try_dlpi_lib $LDFLAGS"
    unset -v try_dlpi_lib
-   AC_MSG_NOTICE([Extending the search to include /lib])
+   AC_MSG_NOTICE([Extending the search to include  $erl_xcomp_sysroot/lib])
    AC_CHECK_LIB(dlpi, dlpi_open)
    if test x"$ac_cv_lib_dlpi_dlpi_open" = x"no"; then
       LDFLAGS="$save_ldflags"


### PR DESCRIPTION

Hello,

This PR fixes an `unsafe for cross-compilation` detected by autoconf when I was trying to cross-compile Erlang/OTP. It seems the erts/configure.ac is trying to find libdlpi in places not used for cross-compilation. However libdlpi is only provided by Solaris (I guess, not 100% sure). So this PR tries to test the host OS before trying to check the libdlpi.

```
builder@8f0f4d978071:/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0/git$ find -name config.log                                                                                                                                                                                           
./erts/config.log                                                                                                                                                                                                                                                                                                 
./lib/crypto/config.log                                                                                                                                                                                                                                                                                           
./lib/common_test/config.log                                                                                                                                                                                                                                                                                      
./lib/wx/config.log                                                                                                                                                                                                                                                                                               
./lib/snmp/config.log                                                                                                                                                                                                                                                                                             
./lib/megaco/config.log                                                                                                                                                                                                                                                                                           
./lib/erl_interface/config.log                                                                                                                                                                                                                                                                                    
./make/config.log                                                                                                                                                                                                                                                                                                 

$ grep  'unsafe for cross-compilation' ./erts/config.log                                                                                                                                                          
/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi/../../libexec/arm-poky-linux-gnueabi/gcc/arm-poky-linux-gnueabi/11.2.0/ld: warning: library search path "/lib" is unsafe for cross-compilation                                       
$ grep  'unsafe for cross-compilation' ./lib/crypto/config.log                                                                                                                                                    
$ grep  'unsafe for cross-compilation' ./lib/common_test/config.log                                                                                                                                               
$ grep  'unsafe for cross-compilation' ./lib/wx/config.log                                                                                                                                                        
$ grep  'unsafe for cross-compilation' ./lib/snmp/config.log                                                                                                                                                      
$ grep  'unsafe for cross-compilation' ./lib/megaco/config.log                                                                                                                                                    
$ grep  'unsafe for cross-compilation' ./lib/erl_interface/config.log  
```

Some details from erts/config.log are:

```
It was created by configure, which was
generated by GNU Autoconf 2.71.  Invocation command line was

  $ ./configure --build=x86_64-linux --host=arm-poky-linux-gnueabi --target=arm-poky-linux-gnueabi --prefix=/usr --exec_prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/libexec --datadir=/usr/share --sysconfdir=/etc --sharedstatedir=/com --localstatedir=/var --libdir=/usr/lib --includedir=/usr/include --oldincludedir=/usr/include --infodir=/usr/share/info --mandir=/usr/share/man --disable-silent-rules --disable-dependency-tracking --with-libtool-sysroot=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0/recipe-sysroot --with-ssl-rpath=no --disable-static --without-javac --without-dynamic-trace --without-observer --without-odbc --enable-pkg-config 'CFLAGS= -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0=/usr/src/debug/erlang/25.0-rc1-r0 -fdebug-prefix-map=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0=/usr/src/debug/erlang/25.0-rc1-r0 -fdebug-prefix-map=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0/recipe-sysroot= -fdebug-prefix-map=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0/recipe-sysroot-native= ' 'LDFLAGS=-Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -fmacro-prefix-map=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0=/usr/src/debug/erlang/25.0-rc1-r0 -fdebug-prefix-map=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0=/usr/src/debug/erlang/25.0-rc1-r0 -fdebug-prefix-map=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0/recipe-sysroot= -fdebug-prefix-map=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0/recipe-sysroot-native= -Wl,-z,relro,-z,now' --disable-option-checking --cache-file=/dev/null --srcdir=/build/tmp/work/arm1176jzfshf-vfp-poky-linux-gnueabi/erlang/25.0-rc1-r0/git/erts

## --------- ##
## Platform. ##
## --------- ##

hostname = b34d811fc800
uname -m = x86_64
uname -r = 5.13.0-28-generic
uname -s = Linux
uname -v = #31-Ubuntu SMP Thu Jan 13 17:41:06 UTC 2022

```