### PR TITLE
Net tick intensity

### DIFF
--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -319,32 +319,67 @@
           setup time, but rather each individual network operation during
           the connection setup and handshake.</p>
       </item>
-      <tag><c>net_ticktime = TickTime</c></tag>
+      <tag><marker id="net_tickintensity"/><c>net_tickintensity = NetTickIntensity</c></tag>
       <item>
-        <marker id="net_ticktime"></marker>
-        <p>Specifies the <c>net_kernel</c> tick time in seconds. This is the
+        <p><i>Net tick intensity</i> specifies how many ticks to send during a
+        <seeapp marker="#net_ticktime">net tick time</seeapp> period when
+        no other data is sent over a connection to another node. This also
+        determines how often to check for data from the other node. The
+        higher net tick intensity, the closer to the chosen net tick time period
+        the node will detect an unresponsive node. The net tick intensity
+        defaults to <c>4</c>. The value of <c>NetTickIntensity</c> should be
+        an integer in the range <c>4..1000</c>. If the <c>NetTickIntensity</c>
+        is not an integer or an integer less than <c>4</c>, <c>4</c> will
+        silently be used. If <c>NetTickIntensity</c> is an integer larger than
+        <c>1000</c>, <c>1000</c> will silently be used.
+        </p>
+        <note>
+          <p>Note that all communicating nodes are expected to use the same
+          <i>net tick intensity</i> as well as the same <i>net tick time</i>.</p>
+        </note>
+        <warning>
+          <p>Be careful not to set a too high net tick intensity, since you
+          can overwhelm the node with work if it is set too high.</p>
+        </warning>
+      </item>
+      <tag><marker id="net_ticktime"/><c>net_ticktime = NetTickTime</c></tag>
+      <item>
+        <p>Specifies the <i>net tick time</i> in seconds. This is the
 	approximate time a connected node may be unresponsive until it is
 	considered down and thereby disconnected.</p>
-	<p>Once every <c>TickTime/4</c> seconds, each connected node is ticked
-	if nothing has been sent to it during that last <c>TickTime/4</c>
-	interval. A tick is a small package sent on the connection. A connected
-	node is considered to be down if no ticks or payload packages have been
-	received during the last four <c>TickTime/4</c> intervals. This ensures
-	that nodes that are not responding, for reasons such as hardware errors,
-	are considered to be down.</p>
-        <p>As the availability is only checked every <c>TickTime/4</c> seconds,
+        <p>Net tick time together with <seeapp marker="#net_tickintensity">net
+        tick intensity</seeapp> determines an interval <c>TickInterval =
+        NetTickTime/NetTickIntensity</c>. Once every <c>TickInterval</c> seconds,
+        each connected node is ticked if nothing has been sent to it during that
+        last <c>TickInterval</c> seconds. A tick is a small package sent on the
+        connection.
+        A connected node is considered to be down if no ticks or payload packages
+        have been received during the last <c>NetTickIntensity</c> number of
+        <c>TickInterval</c> seconds intervals. This ensures that nodes that
+        are not responding, for reasons such as hardware errors, are considered
+        to be down.</p>
+        <p>As the availability is only checked every <c>TickInterval</c> seconds,
 	the actual time <c>T</c> a node have been unresponsive when
 	detected may vary between <c>MinT</c> and <c>MaxT</c>,
 	where:</p>
         <code type="none">
-MinT = TickTime - TickTime / 4
-MaxT = TickTime + TickTime / 4</code>
-        <p><c>TickTime</c> defaults to <c>60</c> seconds. Thus,
+MinT = NetTickTime - NetTickTime / NetTickIntensity
+MaxT = NetTickTime + NetTickTime / NetTickIntensity</code>
+        <p><c>NetTickTime</c> defaults to <c>60</c> seconds and
+        <c>NetTickIntensity</c> defaults to <c>4</c>. Thus,
         <c><![CDATA[45 < T < 75]]></c> seconds.</p>
+        <note>
         <p>Notice that <em>all</em> communicating nodes are to have the
-	<em>same</em> <c>TickTime</c> value specified, as it determines both the
-	frequency of outgoing ticks and the expected frequency of incominging
-	ticks.</p>
+	<em>same</em> <c>NetTickTime</c> and <c>NetTickIntensity</c> values
+        specified, as it determines both the frequency of outgoing ticks and
+        the expected frequency of incominging ticks.</p>
+        </note>
+        <p><c>NetTickTime</c> needs to be a multiple of <c>NetTickIntensity</c>.
+        If the configured values are not, <c>NetTickTime</c> will internally be
+        rounded up to the nearest millisecond.
+        <seemfa marker="net_kernel#get_net_ticktime/0"><c>net_kernel:get_net_ticktime()</c></seemfa>
+        will, however, report net tick time truncated to the nearest second.
+        </p>
         <p>Normally, a terminating node is detected immediately by the transport
 	protocol (like TCP/IP).</p>
       </item>

--- a/lib/kernel/doc/src/net_kernel.xml
+++ b/lib/kernel/doc/src/net_kernel.xml
@@ -40,10 +40,10 @@
       <c>-name</c> or <c>-sname</c>:</p>
      <pre>
 $ <input>erl -sname foobar</input></pre>
-    <p>It is also possible to call <c>net_kernel:start([foobar])</c>
+    <p>It is also possible to call <c>net_kernel:start([{name, foobar}])</c>
       directly from the normal Erlang shell prompt:</p>
     <pre>
-1> <input>net_kernel:start([foobar, shortnames]).</input>
+1> <input>net_kernel:start([{name, foobar}, {name_type, shortnames}]).</input>
 {ok,&lt;0.64.0>}
 (foobar@gringotts)2></pre>
     <p>If the node is started with command-line flag <c>-sname</c>,
@@ -113,8 +113,11 @@ $ <input>erl -sname foobar</input></pre>
       <name name="get_net_ticktime" arity="0" since=""/>
       <fsummary>Get <c>net_ticktime</c>.</fsummary>
       <desc>
-        <p>Gets <c>net_ticktime</c> (see
-          <seeapp marker="kernel_app"><c>kernel(6)</c></seeapp>).</p>
+        <p>Returns currently used net tick time in seconds. For more information
+        see the
+        <seeapp marker="kernel_app#net_ticktime"><c>net_ticktime</c></seeapp>
+        <c>kernel(6)</c> parameter.</p>
+
         <p>Defined return values (<c><anno>Res</anno></c>):</p>
         <taglist>
           <tag><c><anno>NetTicktime</anno></c></tag>
@@ -345,28 +348,105 @@ $ <input>erl -sname foobar</input></pre>
     </func>
 
     <func>
-      <name since="">start([Name]) -> {ok, pid()} | {error, Reason}</name>
-      <name since="">start([Name, NameType]) -> {ok, pid()} | {error, Reason}</name>
-      <name since="">start([Name, NameType, Ticktime]) -> {ok, pid()} | {error, Reason}</name>
+      <name name="start" arity="1" clause_i="1" since="OTP @OTP-17905@"/>
       <fsummary>Turn an Erlang runtime system into a distributed node.</fsummary>
-      <type>
-        <v>Name = atom()</v>
-        <v>NameType = shortnames | longnames</v>
-        <v>Reason = {already_started, pid()} | term()</v>
-      </type>
       <desc>
-        <p>Turns a non-distributed node into a distributed node by
-          starting <c>net_kernel</c> and other necessary processes.</p>
-        <p>Notice that the argument is a list with exactly one, two, or
-          three arguments. <c>NameType</c> defaults to <c>longnames</c>
-          and <c>Ticktime</c> to <c>15000</c>.
+        <p>
+          Turns a non-distributed node into a distributed node by
+          starting <c>net_kernel</c> and other necessary processes.
+        </p>
+        <p>Currently supported <c><anno>Arg</anno></c>s:</p>
+        <taglist>
+          <tag><c>{name, <anno>Name</anno>}</c></tag>
+          <item><p>
+            The name of the node. This argument is mandatory. If <c>Name</c> is
+            set to <em><c>undefined</c></em> the distribution will be started to
+            request a dynamic node name from the first node it connects to. See
+            <seeguide marker="system/reference_manual:distributed#dyn_node_name">
+              Dynamic Node Name</seeguide>.
+          </p></item>
+          <tag><c>{name_type, <anno>Name</anno>}</c></tag>
+          <item><p>
+            Determines the host name part of the node name. If
+            <c><anno>Name</anno></c> equals <c>longnames</c>,
+            fully qualified domain names will be used which
+            also is the default. If <c><anno>Name</anno></c>
+            equals <c>shortnames</c>, only the short name of
+            the host will be used.
+          </p></item>
+          <tag><c>{net_ticktime, <anno>NetTickTime</anno>}</c></tag>
+          <item><p>
+            <i>Net tick time</i> to use in seconds. Defaults to the value of the
+            <seeapp marker="kernel_app#net_ticktime"><c>net_ticktime</c></seeapp>
+            <c>kernel(6)</c> parameter. For more information about <i>net tick
+            time</i>, see the <c>kernel</c> parameter. However, note that if the
+            value of the <c>kernel</c> parameter is invalid, it will silently be
+            replaced by a valid value, but if an invalid
+            <c><anno>NetTickTime</anno></c> value is passed as argument to this
+            function, the call will fail.
+          </p></item>
+          <tag><c>{net_tickintensity, <anno>NetTickIntensity</anno>}</c></tag>
+          <item><p>
+            <i>Net tick intensity</i> to use. Defaults to the value of the
+            <seeapp marker="kernel_app#net_tickintensity"><c>net_tickintensity</c></seeapp>
+            <c>kernel(6)</c> parameter. For more information about <i>net tick
+            intensity</i>, see the <c>kernel</c> parameter. However, note that if
+            the value of the <c>kernel</c> parameter is invalid, it will silently
+            be replaced by a valid value, but if an invalid
+            <c><anno>NetTickIntensity</anno></c> value is passed as argument to
+            this function, the call will fail.
+          </p></item>
+        </taglist>
+      </desc>
+    </func>
+    <func>
+      <name name="start" arity="1" clause_i="2" since=""/>
+      <fsummary>Turn an Erlang runtime system into a distributed node.</fsummary>
+      <desc>
+        <warning><p>
+          <c>start(<anno>DeprecatedArgs</anno>)</c> is deprecated.
+          Use <seemfa marker="#start/1"><c>start(Args)</c></seemfa>
+          instead.
+        </p></warning>
+        <p>
+          Turns a non-distributed node into a distributed node by
+          starting <c>net_kernel</c> and other necessary processes.
         </p>
         <p>
-          If <c>Name</c> is set to <em><c>undefined</c></em> the distribution
-          will be started to request a dynamic node name from the first node it
-          connects to. See <seeguide marker="system/reference_manual:distributed#dyn_node_name">
-          Dynamic Node Name</seeguide>.
+          <c><anno>DeprecatedArgs</anno></c> can only be exactly one of
+          the following lists (order is imporant):
         </p>
+        <taglist>
+          <tag><c>[<anno>Name</anno>]</c></tag>
+          <item>
+            <p>
+              The same as <c>net_kernel:start([<anno>Name</anno>,
+              longnames, 15000])</c>.
+            </p>
+          </item>
+          <tag><c>[<anno>Name</anno>, <anno>NameType</anno>]</c></tag>
+          <item>
+            <p>
+              The same as <c>net_kernel:start([<anno>Name</anno>,
+              <anno>NameType</anno>, 15000])</c>.
+            </p>
+          </item>
+          <tag><c>[<anno>Name</anno>, <anno>NameType</anno>,
+                   <anno>TickTime</anno>]</c></tag>
+          <item>
+            <p>
+              The same as <seemfa marker="#start/1">
+              <c>net_kernel:start([{name, <anno>Name</anno>},
+              {name_type, <anno>NameType</anno>},
+              {net_ticktime, ((<anno>TickTime</anno>*4-1) div 1000) + 1},
+              {net_tickintensity, 4}])</c></seemfa>.
+              Note that <c><anno>TickTime</anno></c> is <i>not</i> the same
+              as net tick time expressed in milliseconds.
+              <c><anno>TickTime</anno></c> is the time between ticks when
+              net tick intensity equals <c>4</c>.
+            </p>
+          </item>
+        </taglist>
       </desc>
     </func>
 

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -464,6 +464,17 @@ flags_to_version(Flags) ->
 %% The connection has been established.
 %% --------------------------------------------------------------
 
+-record(state, {kernel,
+                node,
+                tick_intensity,
+                socket,
+                publish_type,
+                handle,
+                f_tick,
+                f_getstat,
+                f_setopts,
+                f_getopts}).
+
 connection(#hs_data{other_node = Node,
 		    socket = Socket,
 		    f_address = FAddress,
@@ -475,22 +486,23 @@ connection(#hs_data{other_node = Node,
 	ok -> 
 	    {DHandle,NamedMe} = do_setnode(HSData), % Succeeds or exits the process.
 	    Address = FAddress(Socket,Node),
-	    mark_nodeup(HSData,Address,NamedMe),
+	    TickIntensity = mark_nodeup(HSData,Address,NamedMe),
 	    case FPostNodeup(Socket) of
 		ok ->
                     case HSData#hs_data.f_handshake_complete of
                         undefined -> ok;
                         HsComplete -> HsComplete(Socket, Node, DHandle)
                     end,
-		    con_loop({HSData#hs_data.kernel_pid,
-			      Node,
-			      Socket,
-			      PType,
-                              DHandle,
-			      HSData#hs_data.mf_tick,
-			      HSData#hs_data.mf_getstat,
-			      HSData#hs_data.mf_setopts,
-			      HSData#hs_data.mf_getopts},
+		    con_loop(#state{kernel = HSData#hs_data.kernel_pid,
+                                    node = Node,
+                                    socket = Socket,
+                                    tick_intensity = TickIntensity,
+                                    publish_type = PType,
+                                    handle = DHandle,
+                                    f_tick = HSData#hs_data.mf_tick,
+                                    f_getstat = HSData#hs_data.mf_getstat,
+                                    f_setopts = HSData#hs_data.mf_setopts,
+                                    f_getopts = HSData#hs_data.mf_getopts},
 			     #tick{});
 		_ ->
 		    ?shutdown2(Node, connection_setup_failed)
@@ -567,8 +579,8 @@ mark_nodeup(#hs_data{kernel_pid = Kernel,
 	    Address, NamedMe) ->
     Kernel ! {self(), {nodeup,Node,Address,publish_type(Flags),NamedMe}},
     receive
-	{Kernel, inserted} ->
-	    ok;
+	{Kernel, inserted, TickIntensity} ->
+	    TickIntensity;
 	{Kernel, bad_request} ->
 	    TypeT = case OtherStarted of
 		       true ->
@@ -587,8 +599,10 @@ getstat(DHandle, _Socket, undefined) ->
 getstat(_DHandle, Socket, MFGetstat) ->
     MFGetstat(Socket).
 
-con_loop({Kernel, Node, Socket, Type, DHandle, MFTick, MFGetstat,
-          MFSetOpts, MFGetOpts}=ConData,
+con_loop(#state{kernel = Kernel, node = Node,
+                socket = Socket, handle = DHandle,
+                f_getstat = MFGetstat, f_setopts = MFSetOpts,
+                f_getopts = MFGetOpts} = ConData,
 	 Tick) ->
     receive
 	{tcp_closed, Socket} ->
@@ -598,14 +612,13 @@ con_loop({Kernel, Node, Socket, Type, DHandle, MFTick, MFGetstat,
 	{Kernel, aux_tick} ->
 	    case getstat(DHandle, Socket, MFGetstat) of
 		{ok, _, _, PendWrite} ->
-		    send_aux_tick(Type, Socket, PendWrite, MFTick);
+		    send_aux_tick(ConData, PendWrite);
 		_ ->
 		    ignore_it
 	    end,
 	    con_loop(ConData, Tick);
 	{Kernel, tick} ->
-	    case send_tick(DHandle, Socket, Tick, Type, 
-			   MFTick, MFGetstat) of
+	    case send_tick(ConData, Tick) of
 		{ok, NewTick} ->
 		    con_loop(ConData, NewTick);
 		{error, not_responding} ->
@@ -1177,13 +1190,16 @@ send_status(#hs_data{socket = Socket, other_node = Node,
 %% A HIDDEN node is always ticked if we haven't read anything
 %% as a (primitive) hidden node only ticks when it receives a TICK !!
 	
-send_tick(DHandle, Socket, Tick, Type, MFTick, MFGetstat) ->
+send_tick(#state{handle = DHandle, socket = Socket,
+                 tick_intensity = TickIntensity,
+                 publish_type = Type, f_tick = MFTick,
+                 f_getstat = MFGetstat}, Tick) ->
     #tick{tick = T0,
 	  read = Read,
 	  write = Write,
 	  ticked = Ticked0} = Tick,
     T = T0 + 1,
-    T1 = T rem 4,
+    T1 = T rem TickIntensity,
     case getstat(DHandle, Socket, MFGetstat) of
 	{ok, Read, _, _} when Ticked0 =:= T ->
 	    {error, not_responding};
@@ -1221,9 +1237,10 @@ need_to_tick(hidden, 0, _, _) ->  % nothing read from hidden
 need_to_tick(_, _, _, _) ->
     false.
 
-send_aux_tick(normal, _, Pend, _) when Pend /= false, Pend /= 0 ->
+send_aux_tick(#state{publish_type = normal}, Pend) when Pend /= false,
+                                                        Pend /= 0 ->
     ok; %% Dont send tick if pending write.
-send_aux_tick(_Type, Socket, _Pend, MFTick) ->
+send_aux_tick(#state{socket = Socket, f_tick = MFTick}, _Pend) ->
     MFTick(Socket).
 
 %% ------------------------------------------------------------

--- a/lib/kernel/src/erl_distribution.erl
+++ b/lib/kernel/src/erl_distribution.erl
@@ -104,11 +104,13 @@ init(NetArgs) ->
 do_start_link([{Arg,Flag}|T]) ->
     case init:get_argument(Arg) of
 	{ok,[[Name]]} ->
-	    start_link([list_to_atom(Name),Flag|ticktime()], true, net_sup);
+	    start_link([{name, list_to_atom(Name)},
+                        {name_type, Flag}], true, net_sup);
         {ok,[[Name]|_Rest]} ->
             ?LOG_WARNING("Multiple -~p given to erl, using the first, ~p",
                          [Arg, Name]),
-	    start_link([list_to_atom(Name),Flag|ticktime()], true, net_sup);
+	    start_link([{name, list_to_atom(Name)},
+                        {name_type, Flag}], true, net_sup);
         {ok,[Invalid|_]} ->
             ?LOG_ERROR("Invalid -~p given to erl, ~ts",
                        [Arg, lists:join(" ",Invalid)]),
@@ -118,15 +120,3 @@ do_start_link([{Arg,Flag}|T]) ->
     end;
 do_start_link([]) ->
     ignore.
-
-ticktime() ->
-    %% catch, in case the system was started with boot file start_old,
-    %% i.e. running without the application_controller.
-    %% Time is given in seconds. The net_kernel tick time is
-    %% Time/4 milliseconds.
-    case catch application:get_env(net_ticktime) of
-	{ok, Value} when is_integer(Value), Value > 0 ->
-	    [Value * 250]; %% i.e. 1000 / 4 = 250 ms.
-	_ ->
-	    []
-    end.

--- a/lib/kernel/src/kernel.app.src
+++ b/lib/kernel/src/kernel.app.src
@@ -152,8 +152,10 @@
   {applications, []},
   {env, [{logger_level, notice},
          {logger_sasl_compatible, false},
-         {shell_docs_ansi,auto},
-         {prevent_overlapping_partitions, false}
+         {net_tickintensity, 4},
+         {net_ticktime, 60},
+         {prevent_overlapping_partitions, false},
+         {shell_docs_ansi,auto}
         ]},
   {mod, {kernel, []}},
   {runtime_dependencies, ["erts-@OTP-17843@", "stdlib-3.13", "sasl-3.0", "crypto-5.0"]}

--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -151,14 +151,18 @@
 	  node %% remote node name
 	 }).
 
--record(tick, {ticker,        %% ticker                     : pid()
-	       time           %% Ticktime in milli seconds  : integer()
-	      }).
+-record(tick,
+        {ticker,        %% ticker                      : pid()
+         time,          %% net tick time (ms)          : integer() > 0
+         intensity      %% ticks until timout          : integer() >= 4
+        }).
 
--record(tick_change, {ticker, %% Ticker                     : pid()
-		      time,   %% Ticktime in milli seconds  : integer()
-		      how     %% What type of change        : atom()
-		     }).
+-record(tick_change,
+        {ticker,        %% ticker                      : pid()
+         time,          %% net tick time (ms)          : integer() > 0
+         intensity,     %% ticks until timout          : integer() >= 4
+         how            %% What type of change         : atom()
+        }).
 
 %% Default connection setup timeout in milliseconds.
 %% This timeout is set for every distributed action during
@@ -234,7 +238,7 @@ verbose(Level) when is_integer(Level) ->
            | {ongoing_change_to, NewNetTicktime},
       NewNetTicktime :: pos_integer().
 set_net_ticktime(T, TP) when is_integer(T), T > 0, is_integer(TP), TP >= 0 ->
-    ticktime_res(request({new_ticktime, T*250, TP*1000})).
+    ticktime_res(request({new_ticktime, T*1000, TP*1000})).
 
 -spec set_net_ticktime(NetTicktime) -> Res when
       NetTicktime :: pos_integer(),
@@ -279,8 +283,8 @@ monitor_nodes(Flag, Opts) ->
     end.
 
 %% ...
-ticktime_res({A, I}) when is_atom(A), is_integer(I) -> {A, I div 250};
-ticktime_res(I)      when is_integer(I)          -> I div 250;
+ticktime_res({A, I}) when is_atom(A), is_integer(I) -> {A, I div 1000};
+ticktime_res(I)      when is_integer(I)          -> I div 1000;
 ticktime_res(A)      when is_atom(A)             -> A.
 
 %% Called though BIF's
@@ -362,21 +366,112 @@ retry_request_maybe(Req) ->
 %% This function is used to dynamically start the
 %% distribution.
 
+-spec start(Args) -> {ok, pid()} | {error, Reason} when
+      Args :: nonempty_list(Arg),
+      Arg :: {name, Name}
+           | {name_type, NameType}
+           | {net_ticktime, NetTickTime}
+           | {net_tickintensity, NetTickIntensity},
+      Name :: atom(),
+      NameType :: shortnames | longnames,
+      NetTickTime :: pos_integer(),
+      NetTickIntensity :: 4..1000,
+      Reason :: {already_started, pid()} | term();
+           (DeprecatedArgs) -> {ok, pid()} | {error, Reason} when
+      DeprecatedArgs :: nonempty_list(Name | NameType | TickTime),
+      Name :: atom(),
+      NameType :: shortnames | longnames,
+      TickTime :: pos_integer(),
+      Reason :: {already_started, pid()} | term().
+
 start(Args) ->
-    erl_distribution:start(Args).
+    erl_distribution:start(start_args(Args)).
+
+start_args([Name]) when is_atom(Name) ->
+    %% Old deprecated start args...
+    start_args([Name, longnames, 15000]);
+start_args([Name, NameType]) when is_atom(Name),
+                                  is_atom(NameType) ->
+    %% Old deprecated start args...
+    start_args([Name, NameType, 15000]);
+start_args([Name, NameType, TickTime]) when is_atom(Name),
+                                            is_atom(NameType),
+                                            is_integer(TickTime),
+                                            TickTime > 0 ->
+    %% Old deprecated start args...
+
+    %% NetTickTime is in seconds. TickTime is time in milliseconds
+    %% between ticks when net tick intensity is 4. We round upwards...
+    NetTickTime = ((TickTime*4-1) div 1000)+1,
+    start_args([{name, Name},
+                {name_type, NameType},
+                {net_ticktime, NetTickTime},
+                {net_tickintensity, 4}]);
+start_args(Args) ->
+    check_start_args(Args),
+    Args.
+
+check_start_args(Args) ->
+    check_start_args(Args, false).
+
+check_start_args([], true) ->
+    ok;
+check_start_args([], false) ->
+    error(missing_name);
+check_start_args([{name, Name}|Args], _GotName) ->
+    try
+        true = is_atom(Name),
+        ok
+    catch
+        _:_ ->
+            error({bad_name, Name})
+    end,
+    check_start_args(Args, true);
+check_start_args([{name_type, longnames}|Args], GotName) ->
+    check_start_args(Args, GotName);
+check_start_args([{name_type, shortnames}|Args], GotName) ->
+    check_start_args(Args, GotName);
+check_start_args([{name_type, BadType}|_Args], _GotName) ->
+    error({bad_name_type, BadType});
+check_start_args([{net_ticktime, NetTickTime}|Args], GotName) ->
+    try
+        true = is_integer(NetTickTime),
+        true = NetTickTime > 0,
+        ok
+    catch
+        _:_ ->
+            error({bad_net_ticktime, NetTickTime})
+    end,
+    check_start_args(Args, GotName);
+check_start_args([{net_tickintensity, NetTickIntensity}|Args], GotName) ->
+    try
+        true = is_integer(NetTickIntensity),
+        true = NetTickIntensity >= 4,
+        true = NetTickIntensity =< 1000,
+        ok
+    catch
+        _:_ ->
+            error({bad_net_tickintensity, NetTickIntensity})
+    end,
+    check_start_args(Args, GotName);
+check_start_args([InvalidArg|_Args], _GotName) ->
+    error({invalid_argument, InvalidArg}).
+
+-record(init_args, {name,
+                    name_type = longnames,
+                    net_ticktime,
+                    net_tickintensity,
+                    clean_halt,
+                    net_sup}).
 
 %% This is the main startup routine for net_kernel (only for internal
 %% use by the Kernel application.
 
-start_link([Name], CleanHalt, NetSup) ->
-    start_link([Name, longnames], CleanHalt, NetSup);
-start_link([Name, LongOrShortNames], CleanHalt, NetSup) ->
-    start_link([Name, LongOrShortNames, 15000], CleanHalt, NetSup);
-
-start_link([Name, LongOrShortNames, Ticktime], CleanHalt, NetSup) ->
-    Args = {Name, LongOrShortNames, Ticktime, CleanHalt, NetSup},
+start_link(Args, CleanHalt, NetSup) ->
+    InitArgs = parse_args(#init_args{clean_halt = CleanHalt,
+                                     net_sup = NetSup}, Args),
     case gen_server:start_link({local, net_kernel}, ?MODULE,
-			       Args, []) of
+			       InitArgs, []) of
 	{ok, Pid} ->
 	    {ok, Pid};
 	{error, {already_started, Pid}} ->
@@ -385,16 +480,87 @@ start_link([Name, LongOrShortNames, Ticktime], CleanHalt, NetSup) ->
 	    exit(nodistribution)
     end.
 
-init({Name, LongOrShortNames, TickT, CleanHalt, NetSup}) ->
+parse_args(#init_args{clean_halt = undefined}, []) ->
+    error(missing_clean_halt);
+parse_args(#init_args{net_sup = undefined}, []) ->
+    error(missing_net_sup);
+parse_args(#init_args{net_ticktime = undefined} = IAs, []) ->
+    NTT = case application:get_env(kernel, net_ticktime) of
+              {ok, I} when is_integer(I), I < 1 ->
+                  1000;
+              {ok, I} when is_integer(I) ->
+                  I*1000;
+              _ ->
+                  60000
+          end,
+    parse_args(IAs#init_args{net_ticktime = NTT}, []);
+parse_args(#init_args{net_tickintensity = undefined} = IAs, []) ->
+    NTI = case application:get_env(kernel, net_tickintensity) of
+              {ok, I} when is_integer(I), I < 4 ->
+                  4;
+              {ok, I} when is_integer(I), I > 1000 ->
+                  1000;
+              {ok, I} when is_integer(I) ->
+                  I;
+              _ ->
+                  4
+          end,
+    parse_args(IAs#init_args{net_tickintensity = NTI}, []);
+parse_args(#init_args{net_ticktime = NTT,
+                      net_tickintensity = NTI} = IAs,
+           []) when (NTT rem NTI) =/= 0 ->
+    %% Net tick time needs to be a multiple of net tick intensity;
+    %% round net tick time upwards...
+    IAs#init_args{net_ticktime = ((NTT div NTI) + 1) * NTI};
+parse_args(#init_args{} = IAs, []) ->
+    IAs;
+parse_args(#init_args{} = IAs, [{name, Name}|Args]) ->
+    if not is_atom(Name) ->
+            error({bad_name, Name});
+       true ->
+            ok
+    end,
+    parse_args(IAs#init_args{name = Name}, Args);
+parse_args(#init_args{} = IAs, [{name_type, NameType}|Args]) ->
+    if NameType =/= longnames, NameType =/= shortnames ->
+            error({bad_name_type, NameType});
+       true ->
+            ok
+    end,
+    parse_args(IAs#init_args{name_type = NameType}, Args);
+parse_args(#init_args{} = IAs, [{net_ticktime, NTT0}|Args]) ->
+    %% Given in seconds, but kept in milliseconds...
+    NTT = if not is_integer(NTT0); NTT0 < 1 ->
+                  error({bad_net_ticktime, NTT0});
+             true ->
+                  NTT0*1000
+          end,
+    parse_args(IAs#init_args{net_ticktime = NTT}, Args);
+parse_args(#init_args{} = IAs, [{net_tickintensity, NTI0}|Args]) ->
+    NTI = if not is_integer(NTI0); NTI0 < 4; NTI0 >= 1000 ->
+                  error({bad_net_tickintensity, NTI0});
+             true ->
+                  NTI0
+          end,
+    parse_args(IAs#init_args{net_tickintensity = NTI}, Args).
+
+init(#init_args{name = Name,
+                name_type = NameType,
+                net_ticktime = NetTicktime,
+                net_tickintensity = NetTickIntensity,
+                clean_halt = CleanHalt,
+                net_sup = NetSup}) ->
     process_flag(trap_exit,true),
-    case init_node(Name, LongOrShortNames, CleanHalt) of
+    case init_node(Name, NameType, CleanHalt) of
 	{ok, Node, Listeners} ->
 	    process_flag(priority, max),
-	    Ticktime = to_integer(TickT),
-	    Ticker = spawn_link(net_kernel, ticker, [self(), Ticktime]),
+            TickInterval = NetTicktime div NetTickIntensity,
+	    Ticker = spawn_link(net_kernel, ticker, [self(), TickInterval]),
 	    {ok, #state{node = Node,
-			type = LongOrShortNames,
-			tick = #tick{ticker = Ticker, time = Ticktime},
+			type = NameType,
+			tick = #tick{ticker = Ticker,
+                                     time = NetTicktime,
+                                     intensity = NetTickIntensity},
 			connecttime = connecttime(),
 			connections =
 			ets:new(sys_dist,[named_table,
@@ -636,8 +802,7 @@ handle_call({verbose, Level}, From, State) ->
 %%
 
 %% The tick field of the state contains either a #tick{} or a
-%% #tick_change{} record if the ticker process has been upgraded;
-%% otherwise, an integer or an atom.
+%% #tick_change{} record.
 
 handle_call(ticktime, From, #state{tick = #tick{time = T}} = State) ->
     async_reply({reply, T, State}, From);
@@ -649,22 +814,46 @@ handle_call({new_ticktime,T,_TP}, From, #state{tick = #tick{time = T}} = State) 
     async_reply({reply, unchanged, State}, From);
 
 handle_call({new_ticktime,T,TP}, From, #state{tick = #tick{ticker = Tckr,
-							time = OT}} = State) ->
+                                                           time = OT,
+                                                           intensity = I}} = State) ->
     ?tckr_dbg(initiating_tick_change),
-    start_aux_ticker(T, OT, TP),
-    How = case T > OT of
-	      true ->
-		  ?tckr_dbg(longer_ticktime),
-		  Tckr ! {new_ticktime,T},
-		  longer;
-	      false ->
-		  ?tckr_dbg(shorter_ticktime),
-		  shorter
-	  end,
-    async_reply({reply, change_initiated,
-                 State#state{tick = #tick_change{ticker = Tckr,
-                                                 time = T,
-                                                 how = How}}}, From);
+    %% We need to preserve tick intensity and net tick time needs to be a
+    %% multiple of tick intensity...
+    {NT, NIntrvl} = case T < I of
+                        true ->
+                            %% Max 1 tick per millisecond implies that
+                            %% minimum net tick time equals intensity...
+                            {I, 1};
+                        _ ->
+                            NIntrvl0 = T div I,
+                            case T rem I of
+                                0 ->
+                                    {T, NIntrvl0};
+                                _ ->
+                                    %% Round net tick time upwards...
+                                    {(NIntrvl0+1)*I, NIntrvl0+1}
+                            end
+                    end,
+    case NT == OT of
+        true ->
+                async_reply({reply, unchanged, State}, From);
+        false ->
+            start_aux_ticker(NIntrvl, OT div I, TP),
+            How = case NT > OT of
+                      true ->
+                          ?tckr_dbg(longer_ticktime),
+                          Tckr ! {new_ticktime, NIntrvl},
+                          longer;
+                      false ->
+                          ?tckr_dbg(shorter_ticktime),
+                          shorter
+                  end,
+            async_reply({reply, change_initiated,
+                         State#state{tick = #tick_change{ticker = Tckr,
+                                                         time = NT,
+                                                         intensity = I,
+                                                         how = How}}}, From)
+    end;
 
 handle_call({new_ticktime,_T,_TP},
 	    From,
@@ -813,7 +1002,8 @@ handle_info({dist_ctrlr, Ctrlr, Node, SetupPid} = Msg,
 %%
 %% A node has successfully been connected.
 %%
-handle_info({SetupPid, {nodeup,Node,Address,Type,NamedMe}}, State) ->
+handle_info({SetupPid, {nodeup,Node,Address,Type,NamedMe}},
+            #state{tick = Tick} = State) ->
     case ets:lookup(sys_dist, Node) of
 	[Conn] when (Conn#connection.state =:= pending)
                     andalso (Conn#connection.owner =:= SetupPid)
@@ -823,7 +1013,11 @@ handle_info({SetupPid, {nodeup,Node,Address,Type,NamedMe}}, State) ->
                                                  waiting = [],
                                                  type = Type,
                                                  named_me = NamedMe}),
-            SetupPid ! {self(), inserted},
+            TickIntensity = case Tick of
+                              #tick{intensity = TI} -> TI;
+                              #tick_change{intensity = TI} ->  TI
+                         end,
+            SetupPid ! {self(), inserted, TickIntensity},
             reply_waiting(Node,Conn#connection.waiting, true),
             State1 = case NamedMe of
                          true -> State#state{node = node()};
@@ -956,13 +1150,20 @@ handle_info(aux_tick, State) ->
 handle_info(transition_period_end,
 	    #state{tick = #tick_change{ticker = Tckr,
 				       time = T,
+                                       intensity = I,
 				       how = How}} = State) ->
     ?tckr_dbg(transition_period_ended),
     case How of
-	shorter -> Tckr ! {new_ticktime, T}, done;
-	_       -> done
+	shorter ->
+            Interval = T div I,
+            Tckr ! {new_ticktime, Interval},
+            ok;
+	_ ->
+            ok
     end,
-    {noreply,State#state{tick = #tick{ticker = Tckr, time = T}}};
+    {noreply,State#state{tick = #tick{ticker = Tckr,
+                                      time = T,
+                                      intensity = I}}};
 
 handle_info(X, State) ->
     error_msg("Net kernel got ~tw~n",[X]),
@@ -1386,12 +1587,6 @@ ticker(Kernel, Tick) when is_integer(Tick) ->
     process_flag(priority, max),
     ?tckr_dbg(ticker_started),
     ticker_loop(Kernel, Tick).
-
-to_integer(T) when is_integer(T) -> T;
-to_integer(T) when is_atom(T) ->
-    list_to_integer(atom_to_list(T));
-to_integer(T) when is_list(T) ->
-    list_to_integer(T).
 
 ticker_loop(Kernel, Tick) ->
     receive

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -25,7 +25,7 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
 	 init_per_group/2,end_per_group/2]).
 
--export([tick/1, tick_change/1,
+-export([tick/1, tick_intensity/1, tick_change/1,
          connect_node/1,
          nodenames/1, hostnames/1,
          illegal_nodenames/1, hidden_node/1,
@@ -48,13 +48,13 @@
          dist_ctrl_proc_smoke/1,
          dist_ctrl_proc_reject/1,
          erl_uds_dist_smoke_test/1,
-         erl_1424/1, differing_cookies/1,
+         erl_1424/1, net_kernel_start/1, differing_cookies/1,
          cmdline_setcookie_2/1, connection_cookie/1,
          dyn_differing_cookies/1]).
 
 %% Performs the test at another node.
 -export([get_socket_priorities/0,
-	 tick_cli_test/1, tick_cli_test1/1,
+	 tick_cli_test/3, tick_cli_test1/3,
 	 tick_serv_test/2, tick_serv_test1/1,
 	 run_remote_test/1,
          dyn_node_name_do/2,
@@ -62,6 +62,8 @@
 	 setopts_do/2,
 	 keep_conn/1, time_ping/1,
          ddc_remote_run/2]).
+
+-export([net_kernel_start_do_test/1]).
 
 -export([init_per_testcase/2, end_per_testcase/2]).
 
@@ -89,15 +91,15 @@ suite() ->
 all() -> 
     [dist_ctrl_proc_smoke,
      dist_ctrl_proc_reject,
-     tick, tick_change, nodenames, hostnames, illegal_nodenames,
-     connect_node,
+     tick, tick_intensity, tick_change, nodenames, hostnames,
+     illegal_nodenames, connect_node,
      dyn_node_name,
      epmd_reconnect,
      hidden_node, setopts,
      table_waste, net_setuptime, inet_dist_options_options,
      {group, monitor_nodes},
      erl_uds_dist_smoke_test,
-     erl_1424,
+     erl_1424, net_kernel_start,
      {group, differing_cookies}].
 
 groups() -> 
@@ -156,25 +158,44 @@ connect_node(Config) when is_list(Config) ->
 tick(Config) when is_list(Config) ->
     run_dist_configs(fun tick/2, Config).
 
-tick(DCfg, _Config) ->
+tick(DCfg, Config) ->
+    tick_test(DCfg, Config, false).
+
+tick_intensity(Config) when is_list(Config) ->
+    run_dist_configs(fun tick_intensity/2, Config).
+
+tick_intensity(DCfg, Config) ->
+    tick_test(DCfg, Config, true).
+
+tick_test(DCfg, _Config, CheckIntensityArg) ->
     %%
     %% This test case use disabled "connect all" so that
     %% global wont interfere...
     %%
 
-    %% First check that the normal case is OK!
     [Name1, Name2] = get_nodenames(2, dist_test),
-    {ok, Node} = start_node(DCfg, Name1),
-    rpc:call(Node, erl_distribution_SUITE, tick_cli_test, [node()]),
 
-    erlang:monitor_node(Node, true),
-    receive
-	{nodedown, Node} ->
-	    ct:fail("nodedown from other node")
-    after 30000 ->
-	    erlang:monitor_node(Node, false),
-	    stop_node(Node)
+    {ok, Node} = start_node(DCfg, Name1),
+
+    case CheckIntensityArg of
+        true ->
+            %% Not for intensity test...
+            ok;
+        false ->
+            %% First check that the normal case is OK!
+            rpc:call(Node, erl_distribution_SUITE, tick_cli_test, [node(), 8000, 16000]),
+
+            erlang:monitor_node(Node, true),
+            receive
+                {nodedown, Node} ->
+                    ct:fail("nodedown from other node")
+            after 30000 ->
+                    erlang:monitor_node(Node, false)
+            end,
+            ok
     end,
+
+    stop_node(Node),
 
     %% Now, set the net_ticktime for the other node to 12 secs.
     %% After the sleep(2sec) and cast the other node shall destroy
@@ -192,9 +213,20 @@ tick(DCfg, _Config) ->
 				"-kernel net_ticktime 100 -connect_all false"),
     rpc:call(ServNode, erl_distribution_SUITE, tick_serv_test, [Node, node()]),
 
+    %% We set min/max half a second lower/higher than expected since it
+    %% takes time for termination dist controller, delivery of messages
+    %% scheduling of process receiving nodedown, etc...
+    {IArg, Min, Max} = case CheckIntensityArg of
+                           false ->
+                               {"", 7500, 16500};
+                           true ->
+                               {" -kernel net_tickintensity 24", 11000, 13000}
+                       end,
+    
     {ok, Node} = start_node(DCfg, Name1,
-			 "-kernel net_ticktime 12 -connect_all false"),
-    rpc:call(Node, erl_distribution_SUITE, tick_cli_test, [ServNode]),
+                            "-kernel net_ticktime 12 -connect_all false" ++ IArg),
+
+    rpc:call(Node, erl_distribution_SUITE, tick_cli_test, [ServNode, Min, Max]),
 
     spawn_link(erl_distribution_SUITE, keep_conn, [Node]),
 
@@ -207,6 +239,7 @@ tick(DCfg, _Config) ->
 	{tick_test, T} when is_integer(T) ->
 	    stop_node(ServNode),
 	    stop_node(Node),
+            io:format("Result: ~p~n", [T]),
 	    T;
 	{tick_test, Error} ->
 	    stop_node(ServNode),
@@ -429,10 +462,10 @@ tick_serv_test1(Node) ->
 	    end
     end.
 
-tick_cli_test(Node) ->
-    spawn(erl_distribution_SUITE, tick_cli_test1, [Node]).
+tick_cli_test(Node, Min, Max) ->
+    spawn(erl_distribution_SUITE, tick_cli_test1, [Node, Min, Max]).
 
-tick_cli_test1(Node) ->
+tick_cli_test1(Node, Min, Max) ->
     register(tick_test, self()),
     erlang:monitor_node(Node, true),
     sleep(2),
@@ -446,11 +479,14 @@ tick_cli_test1(Node) ->
 		    Diff = erlang:convert_time_unit(T2-T1, native,
 						    millisecond),
 		    case Diff of
-			T when T > 8000, T < 16000 ->
+			T when Min =< T, T =< Max ->
 			    From ! {tick_test, T};
 			T ->
 			    From ! {tick_test,
-				    {"T not in interval 8000 < T < 16000",
+				    {"T not in interval "
+                                     ++ integer_to_list(Min)
+                                     ++ " =< T =< "
+                                     ++ integer_to_list(Max),
 				     T}}
 		    end
 	    end
@@ -2004,6 +2040,91 @@ start_uds_node(NodeName, LPort) ->
 erl_1424(Config) when is_list(Config) ->
     {error, Reason} = erl_epmd:names("."),
     {comment, lists:flatten(io_lib:format("Reason: ~p", [Reason]))}.
+
+net_kernel_start(Config) when is_list(Config) ->
+    MyName = net_kernel_start_tester,
+    register(MyName, self()),
+    net_kernel_start_test(MyName, 120, 8),
+    net_kernel_start_test(MyName, undefined, undefined).
+
+net_kernel_start_test(MyName, NetTickTime, NetTickIntesity) ->
+    TestNameStr = "net_kernel_start_test_node-"
+        ++ integer_to_list(erlang:system_time(seconds))
+        ++ "-" ++ integer_to_list(erlang:unique_integer([monotonic,positive])),
+    TestNode = list_to_atom(TestNameStr ++ "@" ++ atom_to_list(gethostname())),
+    CmdLine = net_kernel_start_cmdline(MyName, list_to_atom(TestNameStr),
+                                       NetTickTime, NetTickIntesity),
+    io:format("Starting test node ~p: ~s~n", [TestNode, CmdLine]),
+    case open_port({spawn, CmdLine}, []) of
+	Port when is_port(Port) ->
+            receive
+                {i_am_alive, Pid, Node, NTT} = Msg ->
+                    io:format("Response from ~p: ~p~n", [Node, Msg]),
+                    rpc:cast(Node, erlang, halt, []),
+                    catch erlang:port_close(Port),
+                    TestNode = node(Pid),
+                    TestNode = Node,
+                    case NetTickTime == undefined of
+                        true ->
+                            {ok, DefNTT} = application:get_env(kernel, net_ticktime),
+                            DefNTT = NTT;
+                        false ->
+                            NetTickTime = NTT
+                    end
+            end,
+            ok;
+	Error ->
+	    error({open_port_failed, TestNode, Error})
+    end.
+
+net_kernel_start_cmdline(TestName, Name, NetTickTime, NetTickIntensity) ->
+    Pa = filename:dirname(code:which(?MODULE)),
+    Prog = case catch init:get_argument(progname) of
+	       {ok, [[Prg]]} -> Prg;
+	       _ -> error(missing_progname)
+	   end,
+    NameType = case net_kernel:longnames() of
+                   false -> "shortnames";
+                   true -> "longnames"
+               end,
+    {ok, Pwd} = file:get_cwd(),
+    NameStr = atom_to_list(Name),
+    Prog ++ " -noinput -noshell -detached -pa " ++ Pa
+	++ " -env ERL_CRASH_DUMP " ++ Pwd ++ "/erl_crash_dump." ++ NameStr
+	++ " -setcookie " ++ atom_to_list(erlang:get_cookie())
+	++ " -run " ++ atom_to_list(?MODULE) ++ " net_kernel_start_do_test "
+	++ atom_to_list(TestName) ++ " " ++ atom_to_list(node()) ++ " "
+        ++ NameStr ++ " " ++ NameType
+        ++ case NetTickTime == undefined of
+               true ->
+                   "";
+               false ->
+                   " " ++ integer_to_list(NetTickTime) ++
+                       " " ++ integer_to_list(NetTickIntensity)
+           end.
+
+net_kernel_start_do_test([TestName, TestNode, Name, NameType]) ->
+    net_kernel_start_do_test(TestName, TestNode,
+                             [{name_type, list_to_atom(NameType)},
+                              {name, list_to_atom(Name)}]);
+
+net_kernel_start_do_test([TestName, TestNode, Name, NameType, NetTickTime, NetTickIntensity]) ->
+    net_kernel_start_do_test(TestName, TestNode,
+                             [{net_ticktime, list_to_integer(NetTickTime)},
+                              {name_type, list_to_atom(NameType)},
+                              {name, list_to_atom(Name)},
+                              {net_tickintensity, list_to_integer(NetTickTime)}]).
+
+net_kernel_start_do_test(TestName, TestNode, Args) ->
+    case net_kernel:start(Args) of
+        {ok, Pid} ->
+            Tester = {list_to_atom(TestName), list_to_atom(TestNode)},
+            Tester ! {i_am_alive, self(), node(), net_kernel:get_net_ticktime()},
+            receive after 60000 -> ok end,
+            erlang:halt();
+        Error ->
+            erlang:halt(lists:flatten(io_lib:format("~p", [Error])))
+    end.
 
 differing_cookies(Config) when is_list(Config) ->
     test_server:timetrap({minutes, 1}),


### PR DESCRIPTION
Introduce a `net_tickintensity` kernel parameter with which one can control the amount of ticks during `net_ticktime`.

Also improve the `net_kernel:start/1` options making it possible to easier to add new options.