### PR TITLE
queue: Remove unnecessary '+ 1' for pretty move half

### DIFF
--- a/lib/stdlib/src/queue.erl
+++ b/lib/stdlib/src/queue.erl
@@ -703,11 +703,11 @@ r2f([]) ->
     {[],[]};
 r2f([_]=R) ->
     {[],R};
-r2f([X,Y]) ->
-    {[X],[Y]};
+r2f([Y,X]) ->
+    {[Y],[X]};
 r2f(List) ->
-    {FF,RR} = lists:split(length(List) div 2, List),
-    {FF,lists:reverse(RR, [])}.
+    {RR,FF} = lists:split(length(List) div 2, List),
+    {RR,lists:reverse(FF, [])}.
 
 %% Move half of elements from F to R, if there are enough
 f2r([]) ->

--- a/lib/stdlib/src/queue.erl
+++ b/lib/stdlib/src/queue.erl
@@ -706,7 +706,7 @@ r2f([_]=R) ->
 r2f([X,Y]) ->
     {[X],[Y]};
 r2f(List) ->
-    {FF,RR} = lists:split(length(List) div 2 + 1, List),
+    {FF,RR} = lists:split(length(List) div 2, List),
     {FF,lists:reverse(RR, [])}.
 
 %% Move half of elements from F to R, if there are enough
@@ -717,5 +717,5 @@ f2r([_]=F) ->
 f2r([X,Y]) ->
     {[Y],[X]};
 f2r(List) ->
-    {FF,RR} = lists:split(length(List) div 2 + 1, List),
+    {FF,RR} = lists:split(length(List) div 2, List),
     {lists:reverse(RR, []),FF}.


### PR DESCRIPTION
# Background and Motivation

The queue module consists of lists of Rear and Front.

```console
1> queue:new().
{[],[]} % = {Rear, Front}
```

In the queue module, move half is performed when the list of Rear and Front is empty. This is a good way to reduce the complexity when elements are continuously removed from one side.

```console
1> {{value, V}, Q} = queue:out({[4,3,2], [1]}).
{{value,1},{[4,3],[2]}}
2> Q.
{[4,3],[2]}
```

However, when I tried locally, I noticed that the number of elements in Rear and Front after the move half is not equal (of course, this is unavoidable when the total number of elements is odd).

```console
1> {{value, V}, Q} = queue:out({[6,5,4,3,2,1], [0]}).
{{value,0},{[6,5,4,3],[1,2]}}
2> Q.
{[6,5,4,3],[1,2]} % <- I expect {[6,5,4], [1,2,3]}.
```

I fixed the behavior of the queue module to make it easier to understand.

# Behaviour (pseudo by REPL)

## Before

```console
1> UnbalancedQ = queue:in_r(-1, lists:foldl(fun queue:in/2, queue:new(), lists:seq(0,20))),
1> Test =
1>     fun(OutF) ->
1>         lists:foldl(
1>             fun(_, Q0) ->
1>                 {{value, V}, Q1} = OutF(Q0),
1>                 io:format("V: ~p, Q: ~p~n", [V, Q1]),
1>                 Q1
1>             end, UnbalancedQ, lists:seq(0,20))
1>     end.
#Fun<erl_eval.44.65746770>
2> Test(fun queue:out/1).
V: -1, Q: {[20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1],[0]} % Number of Elements
V: 0, Q: {[20,19,18,17,16,15,14,13,12,11,10],[1,2,3,4,5,6,7,8,9]}    % <- {11, 9} 🤨
V: 1, Q: {[20,19,18,17,16,15,14,13,12,11,10],[2,3,4,5,6,7,8,9]}
V: 2, Q: {[20,19,18,17,16,15,14,13,12,11,10],[3,4,5,6,7,8,9]}
V: 3, Q: {[20,19,18,17,16,15,14,13,12,11,10],[4,5,6,7,8,9]}
V: 4, Q: {[20,19,18,17,16,15,14,13,12,11,10],[5,6,7,8,9]}
V: 5, Q: {[20,19,18,17,16,15,14,13,12,11,10],[6,7,8,9]}
V: 6, Q: {[20,19,18,17,16,15,14,13,12,11,10],[7,8,9]}
V: 7, Q: {[20,19,18,17,16,15,14,13,12,11,10],"\b\t"}
V: 8, Q: {[20,19,18,17,16,15,14,13,12,11,10],"\t"}
V: 9, Q: {[20,19,18,17,16,15],[10,11,12,13,14]}                      % <- {6, 5} Odd
V: 10, Q: {[20,19,18,17,16,15],[11,12,13,14]}
V: 11, Q: {[20,19,18,17,16,15],[12,13,14]}
V: 12, Q: {[20,19,18,17,16,15],[13,14]}
V: 13, Q: {[20,19,18,17,16,15],[14]}
V: 14, Q: {[20,19,18,17],[15,16]}                                    % <- {4, 2}　🤨
V: 15, Q: {[20,19,18,17],[16]}
V: 16, Q: {[20,19,18],[17]}
V: 17, Q: {[20,19],[18]}                                             % <- {2, 1} Odd
V: 18, Q: {[20],[19]}
V: 19, Q: {[],[20]}
{[],[20]}
```

## After

```console
3> NewR2f =
3>     fun([]) ->
3>             {[],[]};
3>        ([_]=R) ->
3>             {[],R};
3>        ([X,Y]) ->
3>             {[X],[Y]};
3>        (List) ->
3>             {FF,RR} = lists:split(length(List) div 2, List), % Remove ' + 1'
3>             {FF,lists:reverse(RR, [])}
3>     end.
#Fun<erl_eval.44.65746770>
4>
4> NewOut =
4>     fun({[],[]}=Q) ->
4>             {empty,Q};
4>        ({[V],[]}) ->
4>             {{value,V},{[],[]}};
4>        ({[Y|In],[]}) ->
4>             [V|Out] = lists:reverse(In, []),
4>             {{value,V},{[Y],Out}};
4>        ({In,[V]}) when is_list(In) ->
4>             {{value,V},NewR2f(In)}; % <- NewR2f
4>        ({In,[V|Out]}) when is_list(In) ->
4>             {{value,V},{In,Out}};
4>        (Q) ->
4>             erlang:error(badarg, [Q])
4>     end.
#Fun<erl_eval.44.65746770>
5> Test(NewOut).
V: -1, Q: {[20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1],[0]} % Number of Elements
V: 0, Q: {[20,19,18,17,16,15,14,13,12,11],[1,2,3,4,5,6,7,8,9,10]}    % <- {10, 10} 🥳
V: 1, Q: {[20,19,18,17,16,15,14,13,12,11],[2,3,4,5,6,7,8,9,10]}
V: 2, Q: {[20,19,18,17,16,15,14,13,12,11],[3,4,5,6,7,8,9,10]}
V: 3, Q: {[20,19,18,17,16,15,14,13,12,11],[4,5,6,7,8,9,10]}
V: 4, Q: {[20,19,18,17,16,15,14,13,12,11],[5,6,7,8,9,10]}
V: 5, Q: {[20,19,18,17,16,15,14,13,12,11],[6,7,8,9,10]}
V: 6, Q: {[20,19,18,17,16,15,14,13,12,11],[7,8,9,10]}
V: 7, Q: {[20,19,18,17,16,15,14,13,12,11],"\b\t\n"}
V: 8, Q: {[20,19,18,17,16,15,14,13,12,11],"\t\n"}
V: 9, Q: {[20,19,18,17,16,15,14,13,12,11],"\n"}
V: 10, Q: {[20,19,18,17,16],[11,12,13,14,15]}                        % <- {5, 5} 🥳 
V: 11, Q: {[20,19,18,17,16],[12,13,14,15]}
V: 12, Q: {[20,19,18,17,16],[13,14,15]}
V: 13, Q: {[20,19,18,17,16],[14,15]}
V: 14, Q: {[20,19,18,17,16],[15]}
V: 15, Q: {[20,19],[16,17,18]}                                       % <- {2, 3} Odd
V: 16, Q: {[20,19],[17,18]}
V: 17, Q: {[20,19],[18]}
V: 18, Q: {[20],[19]}
V: 19, Q: {[],[20]}
{[],[20]}
```
<details>

<summary>This is also true for f2r.</summary>

```console
1> UnbalancedQ = queue:in(-1, lists:foldl(fun queue:in_r/2, queue:new(), lists:seq(0,20))),
1> Test =
1>     fun(OutF) ->
1>         lists:foldl(
1>             fun(_, Q0) ->
1>                 {{value, V}, Q1} = OutF(Q0),
1>                 io:format("V: ~p, Q: ~p~n", [V, Q1]),
1>                 Q1
1>             end, UnbalancedQ, lists:seq(0,20))
1>     end.
#Fun<erl_eval.44.65746770>
2> Test(fun queue:out_r/1).
V: -1, Q: {[0],[20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1]}
V: 0, Q: {[1,2,3,4,5,6,7,8,9],[20,19,18,17,16,15,14,13,12,11,10]}
V: 1, Q: {[2,3,4,5,6,7,8,9],[20,19,18,17,16,15,14,13,12,11,10]}
V: 2, Q: {[3,4,5,6,7,8,9],[20,19,18,17,16,15,14,13,12,11,10]}
V: 3, Q: {[4,5,6,7,8,9],[20,19,18,17,16,15,14,13,12,11,10]}
V: 4, Q: {[5,6,7,8,9],[20,19,18,17,16,15,14,13,12,11,10]}
V: 5, Q: {[6,7,8,9],[20,19,18,17,16,15,14,13,12,11,10]}
V: 6, Q: {[7,8,9],[20,19,18,17,16,15,14,13,12,11,10]}
V: 7, Q: {"\b\t",[20,19,18,17,16,15,14,13,12,11,10]}
V: 8, Q: {"\t",[20,19,18,17,16,15,14,13,12,11,10]}
V: 9, Q: {[10,11,12,13,14],[20,19,18,17,16,15]}
V: 10, Q: {[11,12,13,14],[20,19,18,17,16,15]}
V: 11, Q: {[12,13,14],[20,19,18,17,16,15]}
V: 12, Q: {[13,14],[20,19,18,17,16,15]}
V: 13, Q: {[14],[20,19,18,17,16,15]}
V: 14, Q: {[15,16],[20,19,18,17]}
V: 15, Q: {[16],[20,19,18,17]}
V: 16, Q: {[17],[20,19,18]}
V: 17, Q: {[18],[20,19]}
V: 18, Q: {[19],[20]}
V: 19, Q: {[20],[]}
{[20],[]}
3>
3> NewF2r =
3>     fun([]) ->
3>             {[],[]};
3>        ([_]=F) ->
3>             {F,[]};
3>        ([X,Y]) ->
3>             {[Y],[X]};
3>        (List) ->
3>             {FF,RR} = lists:split(length(List) div 2, List),
3>             {lists:reverse(RR, []),FF}
3>        end.
#Fun<erl_eval.44.65746770>
4>
4> NewOutR =
4>     fun({[],[]}=Q) ->
4>             {empty,Q};
4>        ({[],[V]}) ->
4>             {{value,V},{[],[]}};
4>        ({[],[Y|Out]}) ->
4>             [V|In] = lists:reverse(Out, []),
4>             {{value,V},{In,[Y]}};
4>        ({[V],Out}) when is_list(Out) ->
4>             {{value,V},NewF2r(Out)};
4>        ({[V|In],Out}) when is_list(Out) ->
4>             {{value,V},{In,Out}};
4>        (Q) ->
4>             erlang:error(badarg, [Q])
4>     end.
#Fun<erl_eval.44.65746770>
5>
5> Test(NewOutR).
V: -1, Q: {[0],[20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1]}
V: 0, Q: {[1,2,3,4,5,6,7,8,9,10],[20,19,18,17,16,15,14,13,12,11]}
V: 1, Q: {[2,3,4,5,6,7,8,9,10],[20,19,18,17,16,15,14,13,12,11]}
V: 2, Q: {[3,4,5,6,7,8,9,10],[20,19,18,17,16,15,14,13,12,11]}
V: 3, Q: {[4,5,6,7,8,9,10],[20,19,18,17,16,15,14,13,12,11]}
V: 4, Q: {[5,6,7,8,9,10],[20,19,18,17,16,15,14,13,12,11]}
V: 5, Q: {[6,7,8,9,10],[20,19,18,17,16,15,14,13,12,11]}
V: 6, Q: {[7,8,9,10],[20,19,18,17,16,15,14,13,12,11]}
V: 7, Q: {"\b\t\n",[20,19,18,17,16,15,14,13,12,11]}
V: 8, Q: {"\t\n",[20,19,18,17,16,15,14,13,12,11]}
V: 9, Q: {"\n",[20,19,18,17,16,15,14,13,12,11]}
V: 10, Q: {[11,12,13,14,15],[20,19,18,17,16]}
V: 11, Q: {[12,13,14,15],[20,19,18,17,16]}
V: 12, Q: {[13,14,15],[20,19,18,17,16]}
V: 13, Q: {[14,15],[20,19,18,17,16]}
V: 14, Q: {[15],[20,19,18,17,16]}
V: 15, Q: {[16,17,18],[20,19]}
V: 16, Q: {[17,18],[20,19]}
V: 17, Q: {[18],[20,19]}
V: 18, Q: {[19],[20]}
V: 19, Q: {[20],[]}
{[20],[]}
```

</details>