### PR TITLE
compiler: Fix type inference for variable is_function/2

### DIFF
--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -2360,13 +2360,18 @@ infer_type({bif,is_float}, [#b_var{}=Arg], _Ts, _Ds) ->
 infer_type({bif,is_function}, [#b_var{}=Arg], _Ts, _Ds) ->
     T = {Arg, #t_fun{}},
     {[T], [T]};
-infer_type({bif,is_function}, [#b_var{}=Arg, Arity0], _Ts, _Ds) ->
-    Arity = case Arity0 of
-                #b_literal{val=V} when is_integer(V), V >= 0, V =< 255 -> V;
-                _ -> any
-            end,
-    T = {Arg, #t_fun{arity=Arity}},
-    {[T], [T]};
+infer_type({bif,is_function}, [#b_var{}=Arg, Arity], _Ts, _Ds) ->
+    case Arity of
+        #b_literal{val=V} when is_integer(V), V >= 0, V =< 255 ->
+            T = {Arg, #t_fun{arity=V}},
+            {[T], [T]};
+        _ ->
+            %% We cannot subtract the function type when the arity is unknown:
+            %% `Arg` may still be a function if the arity is outside the
+            %% allowed range.
+            T = {Arg, #t_fun{}},
+            {[T], []}
+    end;
 infer_type({bif,is_integer}, [#b_var{}=Arg], _Ts, _Ds) ->
     T = {Arg, #t_integer{}},
     {[T], [T]};

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -2090,6 +2090,16 @@ infer_types_1(#value{op={bif,is_function},args=[Src,{integer,Arity}]},
               Val, Op, Vst)
   when Arity >= 0, Arity =< 255 ->
     infer_type_test_bif(#t_fun{arity=Arity}, Src, Val, Op, Vst);
+infer_types_1(#value{op={bif,is_function},args=[Src,_Arity]}, Val, Op, Vst) ->
+    case Val of
+        {atom, Bool} when Op =:= eq_exact, Bool; Op =:= ne_exact, not Bool ->
+            update_type(fun meet/2, #t_fun{}, Src, Vst);
+        _ ->
+            %% We cannot subtract the function type when the arity is unknown:
+            %% `Src` may still be a function if the arity is outside the
+            %% allowed range.
+            Vst
+    end;
 infer_types_1(#value{op={bif,is_function},args=[Src]}, Val, Op, Vst) ->
     infer_type_test_bif(#t_fun{}, Src, Val, Op, Vst);
 infer_types_1(#value{op={bif,is_integer},args=[Src]}, Val, Op, Vst) ->

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -1258,8 +1258,22 @@ is_function_2(Config) when is_list(Config) ->
 
     F = fun(_) -> ok end,
     if
-	is_function(F, 1) -> ok
-    end.
+        is_function(F, 1) -> ok
+    end,
+
+    variable_is_function_2(),
+
+    ok.
+
+variable_is_function_2() ->
+    F = fun() -> ok end,
+    [F] = vif_2([F], id(0), []),
+    ok.
+
+vif_2([F | Fs], Arity, Acc) when is_function(F, Arity) ->
+    vif_2(Fs, Arity, [F | Acc]);
+vif_2([], _Arity, Acc) ->
+    Acc.
 
 tricky(Config) when is_list(Config) ->
     not_ok = tricky_1(1, 2),


### PR DESCRIPTION
Fixes https://github.com/erlang/otp/issues/5731