### PR TITLE
Document new net_kernel:get_state

### DIFF
--- a/lib/kernel/doc/src/net_kernel.xml
+++ b/lib/kernel/doc/src/net_kernel.xml
@@ -154,7 +154,7 @@ $ <input>erl -sname foobar</input></pre>
       <fsummary>Get various distribution state.</fsummary>
       <desc>
         <p>Get the current state of the distribution for the local node.</p>
-        <p>Returns a map with (at least) the following key-vale pairs:</p>
+        <p>Returns a map with (at least) the following key-value pairs:</p>
         <taglist>
           <tag><c>started => Started</c></tag>
           <item>
@@ -210,12 +210,12 @@ $ <input>erl -sname foobar</input></pre>
           <item>
             <p>Valid values for <c>NameDomain</c>:</p>
             <taglist>
-              <tag><c>short</c></tag>
+              <tag><c>shortnames</c></tag>
               <item>
                 <p>The distribution was started to use node names with a short
                 host portion (not fully qualified).</p>
               </item>
-              <tag><c>long</c></tag>
+              <tag><c>longnames</c></tag>
               <item>
                 <p>The distribution was started to use node names with a long
                 fully qualified host portion.</p>

--- a/lib/kernel/doc/src/net_kernel.xml
+++ b/lib/kernel/doc/src/net_kernel.xml
@@ -150,6 +150,83 @@ $ <input>erl -sname foobar</input></pre>
     </func>
 
     <func>
+      <name name="get_state" arity="0" since="OTP @OTP-17558@"/>
+      <fsummary>Get various distribution state.</fsummary>
+      <desc>
+        <p>Get the current state of the distribution for the local node.</p>
+        <p>Returns a map with (at least) the following key-vale pairs:</p>
+        <taglist>
+          <tag><c>started => Started</c></tag>
+          <item>
+            <p>Valid values for <c>Started</c>:</p>
+            <taglist>
+              <tag><c>no</c></tag>
+              <item>
+                <p>The distribution is not started. In this state none of
+                the other keys below are present in the map.</p>
+              </item>
+              <tag><c>static</c></tag>
+              <item>
+                <p>The distribution was started with command line arguments
+                <seecom marker="erts:erl#name"><c>-name</c></seecom> or
+                <seecom marker="erts:erl#sname"><c>-sname</c></seecom>.</p>
+              </item>
+              <tag><c>dynamic</c></tag>
+              <item>
+                <p>The distribution was started with
+                <seemfa marker="#start/1"><c>net_kernel:start/1</c></seemfa>
+                and can be stopped with
+                <seemfa marker="#start/1"><c>net_kernel:stop/0</c></seemfa>.</p>
+              </item>
+            </taglist>
+          </item>
+          <tag><c>name => Name</c></tag>
+          <item>
+            <p>The name of the node. Same as returned by
+            <seemfa marker="erts:erlang#node/0"><c>erlang:node/0</c></seemfa>
+            except when <c>name_type</c> is <c>dynamic</c> in which case
+            <c>Name</c> may be <c>undefined</c> (instead of <c>nonode@nohost</c>).
+            </p>
+          </item>
+          <tag><c>name_type => NameType</c></tag>
+          <item>
+            <p>Valid values for <c>NameType</c>:</p>
+            <taglist>
+              <tag><c>static</c></tag>
+              <item>
+                <p>The node has a static node name set by the node itself.</p>
+              </item>
+              <tag><c>dynamic</c></tag>
+              <item>
+                <p>The distribution was started in
+                <seeguide marker="system/reference_manual:distributed#dyn_node_name">
+                dynamic node name</seeguide> mode, and will get its node name assigned
+                from the first node it connects to. If key <c>name</c> has value
+                <c>undefined</c> that has not happened yet.</p>
+              </item>
+            </taglist>
+          </item>
+          <tag><c>name_domain => NameDomain</c></tag>
+          <item>
+            <p>Valid values for <c>NameDomain</c>:</p>
+            <taglist>
+              <tag><c>short</c></tag>
+              <item>
+                <p>The distribution was started to use node names with a short
+                host portion (not fully qualified).</p>
+              </item>
+              <tag><c>long</c></tag>
+              <item>
+                <p>The distribution was started to use node names with a long
+                fully qualified host portion.</p>
+              </item>
+            </taglist>
+          </item>
+        </taglist>
+      </desc>
+    </func>
+
+    <func>
       <name name="monitor_nodes" arity="1" since=""/>
       <name name="monitor_nodes" arity="2" since=""/>
       <fsummary>Subscribe to node status change messages.</fsummary>

--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -199,7 +199,7 @@ nodename() ->                  request(nodename).
 -spec get_state() -> #{started => no | static | dynamic,
                        name => atom(),
                        name_type => static | dynamic,
-                       name_domain => short | long}.
+                       name_domain => shortnames | longnames}.
 get_state() ->
     case whereis(net_kernel) of
         undefined ->
@@ -866,8 +866,8 @@ handle_call(get_state, From, State) ->
                               {dynamic, Node}
                       end,
     NameDomain = case get(longnames) of
-                     true -> long;
-                     false -> short
+                     true -> longnames;
+                     false -> shortnames
                  end,
     Return = #{started => Started,
                name_type => NameType,

--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -861,14 +861,14 @@ handle_call(get_state, From, State) ->
                           {dynamic_node_name, Node} ->
                               {dynamic, Node}
                       end,
-    DomainType = case get(longnames) of
+    NameDomain = case get(longnames) of
                      true -> long;
                      false -> short
                  end,
     Return = #{started => Started,
                name_type => NameType,
                name => Name,
-               domain_type => DomainType},
+               name_domain => NameDomain},
     async_reply({reply, Return, State}, From);
 
 handle_call(_Msg, _From, State) ->

--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -196,6 +196,10 @@ longnames() ->                 request(longnames).
 
 nodename() ->                  request(nodename).
 
+-spec get_state() -> #{started => no | static | dynamic,
+                       name => atom(),
+                       name_type => static | dynamic,
+                       name_domain => short | long}.
 get_state() ->
     case whereis(net_kernel) of
         undefined ->

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -582,8 +582,8 @@ dyn_node_name(Config) when is_list(Config) ->
 
 dyn_node_name(DCfg, _Config) ->
     NameDomain = case net_kernel:get_state() of
-                     #{name_domain := short} -> "short";
-                     #{name_domain := long} -> "long"
+                     #{name_domain := shortnames} -> "shortnames";
+                     #{name_domain := longnames} -> "longnames"
                  end,
     {_N1F,Port1} = start_node_unconnected(DCfg ++ " -dist_listen false",
                                           undefined, ?MODULE, run_remote_test,
@@ -606,8 +606,8 @@ dyn_node_name_do(TestNode, [NameDomainStr]) ->
     MyName = node(),
     false = (MyName =:= undefined),
     false = (MyName =:= nonode@nohost),
-    #{started := static, name_type := dynamic, name := MyName}
-        = net_kernel:get_state(),
+    #{started := static, name_type := dynamic, name := MyName,
+      name_domain := NameDomain} = net_kernel:get_state(),
     check([MyName], rpc:call(TestNode, erlang, nodes, [hidden])),
 
     {nodeup, MyName, [{node_type, visible}]} = receive_any(0),
@@ -620,15 +620,15 @@ dyn_node_name_do(TestNode, [NameDomainStr]) ->
     {nodedown, MyName, [{node_type, visible}]} = receive_any(1000),
 
     nonode@nohost = node(),
-    #{started := static, name_type := dynamic, name := undefined}
-        = net_kernel:get_state(),
+    #{started := static, name_type := dynamic, name := undefined,
+      name_domain := NameDomain} = net_kernel:get_state(),
 
     net_kernel:connect_node(TestNode),
     [] = nodes(),
     [TestNode] = nodes(hidden),
     MyName = node(),
-    #{started := static, name_type := dynamic, name := MyName}
-        = net_kernel:get_state(),
+    #{started := static, name_type := dynamic, name := MyName,
+      name_domain := NameDomain} = net_kernel:get_state(),
 
     check([MyName], rpc:call(TestNode, erlang, nodes, [hidden])),
 
@@ -641,8 +641,8 @@ dyn_node_name_do(TestNode, [NameDomainStr]) ->
     [] = nodes(hidden),
     {nodedown, MyName, [{node_type, visible}]} = receive_any(1000),
     nonode@nohost = node(),
-    #{started := static, name_type := dynamic, name := undefined}
-        = net_kernel:get_state(),
+    #{started := static, name_type := dynamic, name := undefined,
+      name_domain := NameDomain} = net_kernel:get_state(),
     ok.
 
 check(X, X) -> ok.

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -581,24 +581,24 @@ dyn_node_name(Config) when is_list(Config) ->
     dyn_node_name("", Config).
 
 dyn_node_name(DCfg, _Config) ->
-    DomainType = case net_kernel:get_state() of
-                     #{domain_type := short} -> "short";
-                     #{domain_type := long} -> "long"
+    NameDomain = case net_kernel:get_state() of
+                     #{name_domain := short} -> "short";
+                     #{name_domain := long} -> "long"
                  end,
     {_N1F,Port1} = start_node_unconnected(DCfg ++ " -dist_listen false",
                                           undefined, ?MODULE, run_remote_test,
                                           ["dyn_node_name_do", atom_to_list(node()),
-                                           DomainType]),
+                                           NameDomain]),
     0 = wait_for_port_exit(Port1),
     ok.
 
-dyn_node_name_do(TestNode, [DomainTypeStr]) ->
+dyn_node_name_do(TestNode, [NameDomainStr]) ->
     nonode@nohost = node(),
     [] = nodes(),
     [] = nodes(hidden),
-    DomainType = list_to_atom(DomainTypeStr),
+    NameDomain = list_to_atom(NameDomainStr),
     #{started := static, name_type := dynamic, name := undefined,
-     domain_type := DomainType} = net_kernel:get_state(),
+     name_domain := NameDomain} = net_kernel:get_state(),
     net_kernel:monitor_nodes(true, [{node_type,all}]),
     net_kernel:connect_node(TestNode),
     [] = nodes(),


### PR DESCRIPTION
The implementation #5623 was already merged to master for OTP-25.0-rc1.

[`net_kernel:get_state/0`](https://erlang.github.io/prs/5735/lib/kernel-8.2/doc/html/net_kernel.html#get_state-0)