### PR TITLE
Define list() + list(ContentType) using built-ins

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -92,8 +92,8 @@
 -type integer() :: integer().
 -type iodata() :: iolist() | binary().
 -type iolist() :: maybe_improper_list(byte() | binary() | iolist(), binary() | []).
--type list() :: list().
--type list(ContentType) :: list(ContentType).
+-type list() :: [any()].
+-type list(ContentType) :: [ContentType].
 -type map() :: #{ any() => any() }.
 -type maybe_improper_list() :: maybe_improper_list(any(), any()).
 -type maybe_improper_list(ContentType, TerminationType) :: maybe_improper_list(ContentType, TerminationType).


### PR DESCRIPTION
Define list() + list(ContentType) using built-ins

Change the implementation of the `list/0` and `list/1` types exposed in the `erlang`
module to be as documented in https://www.erlang.org/doc/reference_manual/typespec.html
- My motivation for this change is to make it easier
to implement a type checker for Erlang specs,
since then we can remove some hard-coding for
the meaning of `list()` and rely on `erlang.erl`
as the source of truth.
