### PR TITLE
Add options to binary construction error_info formatting

### DIFF
--- a/erts/emulator/test/bs_construct_SUITE.erl
+++ b/erts/emulator/test/bs_construct_SUITE.erl
@@ -1007,7 +1007,18 @@ fp16(_Config) ->
                         error(should_fail)
                 catch
                     error:Reason:Stk ->
-                        error_info_verify(Reason, Stk, ??Expr)
+                        error_info_verify(Reason, Stk, ??Expr, #{})
+                end
+        end()).
+
+-define(ERROR_INFO(Expr, Overrides),
+        fun() ->
+                try Expr of
+                    _ ->
+                        error(should_fail)
+                catch
+                    error:Reason:Stk ->
+                        error_info_verify(Reason, Stk, ??Expr, Overrides)
                 end
         end()).
 
@@ -1019,49 +1030,49 @@ error_info(_Config) ->
     HugeBig = id(1 bsl 1500),
     LongList = lists:seq(1, 100),
 
-    {badarg, {1,binary,type,Atom}} = ?ERROR_INFO(<<Atom/binary, Binary/binary>>),
-    {badarg, {2,binary,type,Atom}} = ?ERROR_INFO(<<Binary/binary, Atom/binary>>),
-    {badarg, {3,binary,type,Atom}} = ?ERROR_INFO(<<1:32, Binary/binary, Atom/binary>>),
-    {badarg, {4,binary,type,Atom}} = ?ERROR_INFO(<<1:32, "xyz", Binary/binary, Atom/binary>>),
+    {badarg, {1,binary,type,Atom}, _} = ?ERROR_INFO(<<Atom/binary, Binary/binary>>),
+    {badarg, {2,binary,type,Atom}, _} = ?ERROR_INFO(<<Binary/binary, Atom/binary>>),
+    {badarg, {3,binary,type,Atom}, _} = ?ERROR_INFO(<<1:32, Binary/binary, Atom/binary>>),
+    {badarg, {4,binary,type,Atom}, _} = ?ERROR_INFO(<<1:32, "xyz", Binary/binary, Atom/binary>>),
 
-    {badarg, {1,integer,type,Atom}} = ?ERROR_INFO(<<Atom:32>>),
-    {badarg, {1,integer,type,Atom}} = ?ERROR_INFO(<<Atom:(id(32))>>),
-    {badarg, {1,integer,type,LongList}} = ?ERROR_INFO(<<LongList:32>>),
-    {badarg, {1,integer,size,Atom}} = ?ERROR_INFO(<<42:Atom>>),
-    {badarg, {1,integer,type,Atom}} = ?ERROR_INFO(<<Atom:32>>),
-    {badarg, {1,integer,size,NegSize}} = ?ERROR_INFO(<<42:NegSize>>),
-    {badarg, {1,integer,size,HugeNegSize}} = ?ERROR_INFO(<<42:HugeNegSize>>),
-    {system_limit, {1,integer,size,1 bsl 58}} = ?ERROR_INFO(<<42:(1 bsl 58)/unit:255>>),
-    {system_limit, {1,integer,size,1 bsl 60}} = ?ERROR_INFO(<<42:(1 bsl 60)/unit:8>>),
-    {system_limit, {1,integer,size,1 bsl 64}} = ?ERROR_INFO(<<42:(1 bsl 64)>>),
+    {badarg, {1,integer,type,Atom}, _} = ?ERROR_INFO(<<Atom:32>>),
+    {badarg, {1,integer,type,Atom}, _} = ?ERROR_INFO(<<Atom:(id(32))>>),
+    {badarg, {1,integer,type,LongList}, _} = ?ERROR_INFO(<<LongList:32>>),
+    {badarg, {1,integer,size,Atom}, _} = ?ERROR_INFO(<<42:Atom>>),
+    {badarg, {1,integer,type,Atom}, _} = ?ERROR_INFO(<<Atom:32>>),
+    {badarg, {1,integer,size,NegSize}, _} = ?ERROR_INFO(<<42:NegSize>>),
+    {badarg, {1,integer,size,HugeNegSize}, _} = ?ERROR_INFO(<<42:HugeNegSize>>),
+    {system_limit, {1,integer,size,1 bsl 58}, _} = ?ERROR_INFO(<<42:(1 bsl 58)/unit:255>>),
+    {system_limit, {1,integer,size,1 bsl 60}, _} = ?ERROR_INFO(<<42:(1 bsl 60)/unit:8>>),
+    {system_limit, {1,integer,size,1 bsl 64}, _} = ?ERROR_INFO(<<42:(1 bsl 64)>>),
 
-    {badarg, {1,binary,type,Atom}} = ?ERROR_INFO(<<Atom:10/binary>>),
-    {badarg, {1,binary,type,Atom}} = ?ERROR_INFO(<<Atom:(id(10))/binary>>),
-    {badarg, {1,binary,size,Atom}} = ?ERROR_INFO(<<Binary:Atom/binary>>),
-    {badarg, {1,binary,size,NegSize}} = ?ERROR_INFO(<<Binary:NegSize/binary>>),
-    {badarg, {1,binary,size,HugeNegSize}} = ?ERROR_INFO(<<Binary:HugeNegSize/binary>>),
-    {badarg, {1,binary,short,Binary}} = ?ERROR_INFO(<<Binary:10/binary>>),
-    {badarg, {1,binary,short,Binary}} = ?ERROR_INFO(<<Binary:(id(10))/binary>>),
-    {badarg, {1,binary,type,Atom}} = ?ERROR_INFO(<<Atom/binary>>),
-    {badarg, {1,binary,unit,<<1:1>>}} = ?ERROR_INFO(<<(id(<<1:1>>))/binary>>),
-    {badarg, {1,binary,unit,<<0:1111>>}} = ?ERROR_INFO(<<(id(<<0:1111>>))/binary>>),
-    {badarg, {2,binary,unit,<<1:1>>}} = ?ERROR_INFO(<<0, (id(<<1:1>>))/binary>>),
-    {badarg, {2,binary,unit,<<0:1111>>}} = ?ERROR_INFO(<<0, (id(<<0:1111>>))/binary>>),
-    {system_limit, {1,binary,size,1 bsl 64}} = ?ERROR_INFO(<<Binary:(1 bsl 64)/binary>>),
-    {system_limit, {1,binary,size,1 bsl 64}} = ?ERROR_INFO(<<Binary:(id(1 bsl 64))/binary>>),
+    {badarg, {1,binary,type,Atom}, _} = ?ERROR_INFO(<<Atom:10/binary>>),
+    {badarg, {1,binary,type,Atom}, _} = ?ERROR_INFO(<<Atom:(id(10))/binary>>),
+    {badarg, {1,binary,size,Atom}, _} = ?ERROR_INFO(<<Binary:Atom/binary>>),
+    {badarg, {1,binary,size,NegSize}, _} = ?ERROR_INFO(<<Binary:NegSize/binary>>),
+    {badarg, {1,binary,size,HugeNegSize}, _} = ?ERROR_INFO(<<Binary:HugeNegSize/binary>>),
+    {badarg, {1,binary,short,Binary}, _} = ?ERROR_INFO(<<Binary:10/binary>>),
+    {badarg, {1,binary,short,Binary}, _} = ?ERROR_INFO(<<Binary:(id(10))/binary>>),
+    {badarg, {1,binary,type,Atom}, _} = ?ERROR_INFO(<<Atom/binary>>),
+    {badarg, {1,binary,unit,<<1:1>>}, _} = ?ERROR_INFO(<<(id(<<1:1>>))/binary>>),
+    {badarg, {1,binary,unit,<<0:1111>>}, _} = ?ERROR_INFO(<<(id(<<0:1111>>))/binary>>),
+    {badarg, {2,binary,unit,<<1:1>>}, _} = ?ERROR_INFO(<<0, (id(<<1:1>>))/binary>>),
+    {badarg, {2,binary,unit,<<0:1111>>}, _} = ?ERROR_INFO(<<0, (id(<<0:1111>>))/binary>>),
+    {system_limit, {1,binary,size,1 bsl 64}, _} = ?ERROR_INFO(<<Binary:(1 bsl 64)/binary>>),
+    {system_limit, {1,binary,size,1 bsl 64}, _} = ?ERROR_INFO(<<Binary:(id(1 bsl 64))/binary>>),
 
-    {badarg, {1,float,type,Atom}} = ?ERROR_INFO(<<Atom:64/float>>),
-    {badarg, {1,float,size,Atom}} = ?ERROR_INFO(<<Atom:Atom/float>>),
-    {badarg, {1,float,size,NegSize}} = ?ERROR_INFO(<<42.0:NegSize/float>>),
-    {badarg, {1,float,size,HugeNegSize}} = ?ERROR_INFO(<<42.0:HugeNegSize/float>>),
-    {badarg, {1,float,invalid,1}} = ?ERROR_INFO(<<42.0:(id(1))/float>>),
-    {badarg, {1,float,no_float,HugeBig}} = ?ERROR_INFO(<<HugeBig:(id(64))/float>>),
-    {badarg, {1,float,no_float,HugeBig}} = ?ERROR_INFO(<<HugeBig:64/float>>),
-    {system_limit, {1,float,size,1 bsl 64}} = ?ERROR_INFO(<<42.0:(id(1 bsl 64))/float>>),
+    {badarg, {1,float,type,Atom}, _} = ?ERROR_INFO(<<Atom:64/float>>),
+    {badarg, {1,float,size,Atom}, _} = ?ERROR_INFO(<<Atom:Atom/float>>),
+    {badarg, {1,float,size,NegSize}, _} = ?ERROR_INFO(<<42.0:NegSize/float>>),
+    {badarg, {1,float,size,HugeNegSize}, _} = ?ERROR_INFO(<<42.0:HugeNegSize/float>>),
+    {badarg, {1,float,invalid,1}, _} = ?ERROR_INFO(<<42.0:(id(1))/float>>),
+    {badarg, {1,float,no_float,HugeBig}, _} = ?ERROR_INFO(<<HugeBig:(id(64))/float>>),
+    {badarg, {1,float,no_float,HugeBig}, _} = ?ERROR_INFO(<<HugeBig:64/float>>),
+    {system_limit, {1,float,size,1 bsl 64}, _} = ?ERROR_INFO(<<42.0:(id(1 bsl 64))/float>>),
 
-    {badarg, {1,utf8,type,Atom}} = ?ERROR_INFO(<<Atom/utf8>>),
-    {badarg, {1,utf16,type,Atom}} = ?ERROR_INFO(<<Atom/utf16>>),
-    {badarg, {1,utf32,type,Atom}} = ?ERROR_INFO(<<Atom/utf32>>),
+    {badarg, {1,utf8,type,Atom}, _} = ?ERROR_INFO(<<Atom/utf8>>),
+    {badarg, {1,utf16,type,Atom}, _} = ?ERROR_INFO(<<Atom/utf16>>),
+    {badarg, {1,utf32,type,Atom}, _} = ?ERROR_INFO(<<Atom/utf32>>),
 
     Bin = id(<<>>),
     Float = id(42.0),
@@ -1069,50 +1080,64 @@ error_info(_Config) ->
 
     %% Attempt constructing a binary with total size 1^64 + 32.
 
-    {system_limit, {1,integer,size,MaxSmall}} = ?ERROR_INFO(<<0:(MaxSmall)/unit:32,0:64>>),
-    {system_limit, {1,integer,size,MaxSmall}} = ?ERROR_INFO(<<0:(MaxSmall)/unit:32,(id(0)):64>>),
-    {system_limit, {1,integer,size,MaxSmall}} = ?ERROR_INFO(<<0:(id(MaxSmall))/unit:32,0:64>>),
-    {system_limit, {1,integer,size,MaxSmall}} = ?ERROR_INFO(<<0:(id(MaxSmall))/unit:32,(id(0)):64>>),
+    {system_limit, {1,integer,size,MaxSmall}, _} = ?ERROR_INFO(<<0:(MaxSmall)/unit:32,0:64>>),
+    {system_limit, {1,integer,size,MaxSmall}, _} = ?ERROR_INFO(<<0:(MaxSmall)/unit:32,(id(0)):64>>),
+    {system_limit, {1,integer,size,MaxSmall}, _} = ?ERROR_INFO(<<0:(id(MaxSmall))/unit:32,0:64>>),
+    {system_limit, {1,integer,size,MaxSmall}, _} = ?ERROR_INFO(<<0:(id(MaxSmall))/unit:32,(id(0)):64>>),
 
-    {system_limit, {1,binary,size,MaxSmall}} = ?ERROR_INFO(<<Bin:(MaxSmall)/binary-unit:32,0:64>>),
-    {system_limit, {1,binary,size,MaxSmall}} = ?ERROR_INFO(<<Bin:(MaxSmall)/binary-unit:32,(id(0)):64>>),
-    {system_limit, {1,binary,size,MaxSmall}} = ?ERROR_INFO(<<Bin:(id(MaxSmall))/binary-unit:32,0:64>>),
-    {system_limit, {1,binary,size,MaxSmall}} = ?ERROR_INFO(<<Bin:(id(MaxSmall))/binary-unit:32,(id(0)):64>>),
+    {system_limit, {1,binary,size,MaxSmall}, _} = ?ERROR_INFO(<<Bin:(MaxSmall)/binary-unit:32,0:64>>),
+    {system_limit, {1,binary,size,MaxSmall}, _} = ?ERROR_INFO(<<Bin:(MaxSmall)/binary-unit:32,(id(0)):64>>),
+    {system_limit, {1,binary,size,MaxSmall}, _} = ?ERROR_INFO(<<Bin:(id(MaxSmall))/binary-unit:32,0:64>>),
+    {system_limit, {1,binary,size,MaxSmall}, _} = ?ERROR_INFO(<<Bin:(id(MaxSmall))/binary-unit:32,(id(0)):64>>),
 
-    {system_limit, {1,float,size,MaxSmall}} = ?ERROR_INFO(<<Float:(MaxSmall)/float-unit:32,0:64>>),
-    {system_limit, {1,float,size,MaxSmall}} = ?ERROR_INFO(<<Float:(MaxSmall)/float-unit:32,(id(0)):64>>),
-    {system_limit, {1,float,size,MaxSmall}} = ?ERROR_INFO(<<Float:(id(MaxSmall))/float-unit:32,0:64>>),
-    {system_limit, {1,float,size,MaxSmall}} = ?ERROR_INFO(<<Float:(id(MaxSmall))/float-unit:32,(id(0)):64>>),
+    {system_limit, {1,float,size,MaxSmall}, _} = ?ERROR_INFO(<<Float:(MaxSmall)/float-unit:32,0:64>>),
+    {system_limit, {1,float,size,MaxSmall}, _} = ?ERROR_INFO(<<Float:(MaxSmall)/float-unit:32,(id(0)):64>>),
+    {system_limit, {1,float,size,MaxSmall}, _} = ?ERROR_INFO(<<Float:(id(MaxSmall))/float-unit:32,0:64>>),
+    {system_limit, {1,float,size,MaxSmall}, _} = ?ERROR_INFO(<<Float:(id(MaxSmall))/float-unit:32,(id(0)):64>>),
 
     %% Test a size exceeding 1^64, where the sign bit (bit 63) is not set.
     0 = (((MaxSmall) * 33) bsr 63) band 1, %Assertion: The sign bit is not set.
 
-    {system_limit, {1,integer,size,MaxSmall}} = ?ERROR_INFO(<<0:(MaxSmall)/unit:33>>),
-    {system_limit, {1,integer,size,MaxSmall}} = ?ERROR_INFO(<<0:(MaxSmall)/unit:33>>),
-    {system_limit, {1,integer,size,MaxSmall}} = ?ERROR_INFO(<<0:(id(MaxSmall))/unit:33>>),
-    {system_limit, {1,integer,size,MaxSmall}} = ?ERROR_INFO(<<0:(id(MaxSmall))/unit:33>>),
+    {system_limit, {1,integer,size,MaxSmall}, _} = ?ERROR_INFO(<<0:(MaxSmall)/unit:33>>),
+    {system_limit, {1,integer,size,MaxSmall}, _} = ?ERROR_INFO(<<0:(MaxSmall)/unit:33>>),
+    {system_limit, {1,integer,size,MaxSmall}, _} = ?ERROR_INFO(<<0:(id(MaxSmall))/unit:33>>),
+    {system_limit, {1,integer,size,MaxSmall}, _} = ?ERROR_INFO(<<0:(id(MaxSmall))/unit:33>>),
 
-    {system_limit, {1,binary,size,MaxSmall}} = ?ERROR_INFO(<<Bin:(MaxSmall)/binary-unit:33>>),
-    {system_limit, {1,binary,size,MaxSmall}} = ?ERROR_INFO(<<Bin:(MaxSmall)/binary-unit:33>>),
-    {system_limit, {1,binary,size,MaxSmall}} = ?ERROR_INFO(<<Bin:(id(MaxSmall))/binary-unit:33>>),
-    {system_limit, {1,binary,size,MaxSmall}} = ?ERROR_INFO(<<Bin:(id(MaxSmall))/binary-unit:33>>),
+    {system_limit, {1,binary,size,MaxSmall}, _} = ?ERROR_INFO(<<Bin:(MaxSmall)/binary-unit:33>>),
+    {system_limit, {1,binary,size,MaxSmall}, _} = ?ERROR_INFO(<<Bin:(MaxSmall)/binary-unit:33>>),
+    {system_limit, {1,binary,size,MaxSmall}, _} = ?ERROR_INFO(<<Bin:(id(MaxSmall))/binary-unit:33>>),
+    {system_limit, {1,binary,size,MaxSmall}, _} = ?ERROR_INFO(<<Bin:(id(MaxSmall))/binary-unit:33>>),
 
-    {system_limit, {1,float,size,MaxSmall}} = ?ERROR_INFO(<<Float:(MaxSmall)/float-unit:33>>),
-    {system_limit, {1,float,size,MaxSmall}} = ?ERROR_INFO(<<Float:(MaxSmall)/float-unit:33>>),
-    {system_limit, {1,float,size,MaxSmall}} = ?ERROR_INFO(<<Float:(id(MaxSmall))/float-unit:33>>),
-    {system_limit, {1,float,size,MaxSmall}} = ?ERROR_INFO(<<Float:(id(MaxSmall))/float-unit:33>>),
+    {system_limit, {1,float,size,MaxSmall}, _} = ?ERROR_INFO(<<Float:(MaxSmall)/float-unit:33>>),
+    {system_limit, {1,float,size,MaxSmall}, _} = ?ERROR_INFO(<<Float:(MaxSmall)/float-unit:33>>),
+    {system_limit, {1,float,size,MaxSmall}, _} = ?ERROR_INFO(<<Float:(id(MaxSmall))/float-unit:33>>),
+    {system_limit, {1,float,size,MaxSmall}, _} = ?ERROR_INFO(<<Float:(id(MaxSmall))/float-unit:33>>),
+
+    %% error messages with options
+    PP = fun(Term) -> <<"'", (erlang:atom_to_binary(Term))/binary, "'">> end,
+
+    {_, _, <<"segment 1 of type 'float': expected a float or an integer but got: some_atom">>} =
+        ?ERROR_INFO(<<Atom:64/float>>, #{}),
+
+    {_, _, <<"segment 2 of type 'float': expected a float or an integer but got: some_atom">>} =
+        ?ERROR_INFO(<<Atom:64/float>>, #{override_segment_position => 2}),
+
+    {_, _, <<"segment 1 of type 'float': expected a float or an integer but got: 'some_atom'">>} =
+        ?ERROR_INFO(<<Atom:64/float>>, #{pretty_printer => PP}),
 
     ok.
 
-error_info_verify(Reason, Stk, Expr) ->
-    [{?MODULE, _, _, Info}|_] = Stk,
-    {error_info, ErrorInfo} = lists:keyfind(error_info, 1, Info),
+error_info_verify(Reason, Stk0, Expr, Overrides) ->
+    [{?MODULE, Fun, Arity, Info0}|Rest] = Stk0,
+    {value, {error_info, ErrorInfo}, Info1} = lists:keytake(error_info, 1, Info0),
     #{cause := Cause, module := Module, function := Function} = ErrorInfo,
-    Result = Module:Function(Reason, Stk),
+    Info2 = maps:merge(ErrorInfo, Overrides),
+    Stk1 = [{?MODULE, Fun, Arity, Info1 ++ [{error_info, Info2}]} | Rest],
+    Result = Module:Function(Reason, Stk1),
     #{general := String} = Result,
     true = is_binary(String),
     io:format("~ts: ~ts\n", [Expr,String]),
-    {Reason, Cause}.
+    {Reason, Cause, String}.
 
 %%%
 %%% Common utilities.

--- a/lib/stdlib/test/shell_SUITE.erl
+++ b/lib/stdlib/test/shell_SUITE.erl
@@ -590,11 +590,11 @@ otp_5327(Config) when is_list(Config) ->
                                       default,default}]}),
     [<<"abc">>] = scan(<<"<<(<<\"abc\">>):3/binary>>.">>),
     [<<"abc">>] = scan(<<"<<(<<\"abc\">>)/binary>>.">>),
-    "exception error: bad argument" =
+    "exception error: construction of binary failed" =
         comm_err(<<"<<(<<\"abc\">>):4/binary>>.">>),
     true = byte_size(hd(scan("<<3.14:64/float>>."))) =:= 8,
     true = byte_size(hd(scan("<<3.14:32/float>>."))) =:= 4,
-    "exception error: bad argument" =
+    "exception error: construction of binary failed" =
         comm_err(<<"<<3.14:128/float>>.">>),
     "exception error: bad argument" =
         comm_err(<<"<<10:default>>.">>),


### PR DESCRIPTION
The new options are:

* `override_segment_position` is used by erl_eval/eval_bits
  to override the actual binary segment

* `pretty_printer` can be used by other BEAM languages to
  customize how values in error messages are printed

Prior to this commit, binary construction errors in the
shell reported the following:

    1> A = "foo".
    "foo"
    2> <<A/integer>>.
    ** exception error: bad argument
         in function  eval_bits:eval_exp_field1/6 (eval_bits.erl, line 123)

With this commit:

    1> A = "foo".
    "foo"
    2> <<A/integer>>.
    ** exception error: construction of binary failed
         in function  eval_bits:eval_exp_field/6 (src/eval_bits.erl, line 143)
            *** segment 1 of type 'integer': expected an integer but got: "foo"
    3> <<0, A/integer>>.
    ** exception error: construction of binary failed
         in function  eval_bits:eval_exp_field/6 (src/eval_bits.erl, line 143)
            *** segment 2 of type 'integer': expected an integer but got: "foo"