### PR TITLE
Add 'Erlang OTP Version' to the Erlang shell title row

### DIFF
--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -150,6 +150,9 @@ static char erts_system_version[] = ("Erlang/OTP " ERLANG_OTP_RELEASE
 #ifdef SHCOPY
 				     " [sharing-preserving]"
 #endif
+#ifdef ERLANG_OTP_VERSION
+             " [otp-version:" ERLANG_OTP_VERSION "]"
+#endif
 				     "\n");
 
 #define ASIZE(a) (sizeof(a)/sizeof(a[0]))


### PR DESCRIPTION
Expose the _Erlang full version_ string stored in the `ERLANG_OTP_VERSION` constant (`erl_version.h` header) into the Erlang shell title row.

In this way the full '_Erlang OTP Version_' would be also available from the 'code' by `erlang:system_info(system_version)`:

```
> erl
Erlang/OTP 25 [RELEASE CANDIDATE 1] [erts-12.2.1] [source-88e3472555] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit:ns] [otp-version:25.0-rc1]

Eshell V12.2.1  (abort with ^G)
1> erlang:system_info(system_version).
"Erlang/OTP 25 [RELEASE CANDIDATE 1] [erts-12.2.1] [source-88e3472555] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit:ns] [otp-version:25.0-rc1]\n"
2> 

```


Note: this value is already exposed in the 'Windows' version of the 'Erlang shell' through the 'About' function.
