### PR TITLE
Remove case that filters all logs with defined domains

### DIFF
--- a/lib/common_test/src/cth_log_redirect.erl
+++ b/lib/common_test/src/cth_log_redirect.erl
@@ -171,8 +171,6 @@ log(#{msg:={report,Msg},meta:=#{domain:=[otp,sasl]}}=Log,Config) ->
     end;
 log(#{meta:=#{domain:=[otp]}}=Log,Config) ->
     do_log(add_log_category(Log,error_logger),Config);
-log(#{meta:=#{domain:=_}},_) ->
-    ok;
 log(Log,Config) ->
     do_log(add_log_category(Log,error_logger),Config).
 


### PR DESCRIPTION
The code as it was before resulted in `cth_log_redirect` hiding all log messages from the ct log that included a (custom) `domain`.