### PR TITLE
[erts] Expose parent process via process_info(_, parent) 

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6672,9 +6672,9 @@ receive_replies(ReqId, N, Acc) ->
             <item>
                 <p><c><anno>Pid</anno></c> is the identifier
                 of the parent process, the one that spawned current
-                process. When the process does not have a local parent
-                (e.g. <c>init</c>, or process is spawned remotely),
-                <c>undefined</c> is returned.</p>
+                process. When the process does not have a parent
+                <c>undefined</c> is returned. Only the initial process
+                (<c>init</c>) on a node lacks a parent, though.</p>
             </item>
           <tag><c>{priority, <anno>Level</anno>}</c></tag>
           <item>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6668,6 +6668,14 @@ receive_replies(ReqId, N, Acc) ->
               <seeerl marker="#process_flag_message_queue_data">
               <c>process_flag(message_queue_data, MQD)</c></seeerl>.</p>
           </item>
+            <tag><c>{parent, <anno>Pid</anno>}</c></tag>
+            <item>
+                <p><c><anno>Pid</anno></c> is the identifier
+                of the parent process, the one that spawned current
+                process. When the process does not have a local parent
+                (e.g. <c>init</c>, or process is spawned remotely),
+                <c>undefined</c> is returned.</p>
+            </item>
           <tag><c>{priority, <anno>Level</anno>}</c></tag>
           <item>
             <p><c><anno>Level</anno></c> is the current priority level for

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -530,6 +530,7 @@ atom owner
 atom packet
 atom packet_size
 atom parallelism
+atom parent
 atom Plus='+'
 atom PlusPlus='++'
 atom pause

--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -307,7 +307,8 @@ print_process_info(fmtfn_t to, void *to_arg, Process *p, ErtsProcLocks orig_lock
 		   p->current->arity);
     }
 
-    erts_print(to, to_arg, "Spawned by: %T\n", p->parent);
+    erts_print(to, to_arg, "Spawned by: %T\n",
+               p->parent == am_undefined ? NIL : p->parent);
 
     if (locks & ERTS_PROC_LOCK_MAIN) {
         erts_proc_lock(p, ERTS_PROC_LOCK_MSGQ);

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -769,6 +769,7 @@ collect_one_suspend_monitor(ErtsMonitor *mon, void *vsmicp, Sint reds)
 #define ERTS_PI_IX_GARBAGE_COLLECTION_INFO              33
 #define ERTS_PI_IX_MAGIC_REF                            34
 #define ERTS_PI_IX_FULLSWEEP_AFTER                      35
+#define ERTS_PI_IX_PARENT                               36
 
 #define ERTS_PI_FLAG_SINGELTON                          (1 << 0)
 #define ERTS_PI_FLAG_ALWAYS_WRAP                        (1 << 1)
@@ -824,7 +825,8 @@ static ErtsProcessInfoArgs pi_args[] = {
     {am_message_queue_data, 0, 0, ERTS_PROC_LOCK_MAIN},
     {am_garbage_collection_info, ERTS_PROCESS_GC_INFO_MAX_SIZE, 0, ERTS_PROC_LOCK_MAIN},
     {am_magic_ref, 0, ERTS_PI_FLAG_FORCE_SIG_SEND, ERTS_PROC_LOCK_MAIN},
-    {am_fullsweep_after, 0, 0, ERTS_PROC_LOCK_MAIN}
+    {am_fullsweep_after, 0, 0, ERTS_PROC_LOCK_MAIN},
+    {am_parent, 0, 0, ERTS_PROC_LOCK_MAIN}
 };
 
 #define ERTS_PI_ARGS ((int) (sizeof(pi_args)/sizeof(pi_args[0])))
@@ -943,6 +945,8 @@ pi_arg2ix(Eterm arg)
         return ERTS_PI_IX_MAGIC_REF;
     case am_fullsweep_after:
         return ERTS_PI_IX_FULLSWEEP_AFTER;
+    case am_parent:
+        return ERTS_PI_IX_PARENT;
     default:
         return -1;
     }
@@ -2024,6 +2028,10 @@ process_info_aux(Process *c_p,
 	    break;
 	}
 	break;
+
+    case ERTS_PI_IX_PARENT:
+        res = rp->parent == NIL ? am_undefined : rp->parent;
+        break;
 
     case ERTS_PI_IX_MAGIC_REF: {
 	Uint sz = 0;

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2030,7 +2030,17 @@ process_info_aux(Process *c_p,
 	break;
 
     case ERTS_PI_IX_PARENT:
-        res = rp->parent == NIL ? am_undefined : rp->parent;
+        if (is_immed(rp->parent)) {
+            ASSERT(is_internal_pid(rp->parent) || rp->parent == am_undefined);
+            res = rp->parent;
+        }
+        else {
+            Uint sz;
+            ASSERT(is_external_pid(rp->parent));
+            sz = size_object(rp->parent);
+            hp = erts_produce_heap(hfact, sz, reserve_size);
+            res = copy_struct(rp->parent, sz, &hp, hfact->off_heap);
+        }
         break;
 
     case ERTS_PI_IX_MAGIC_REF: {

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -2603,6 +2603,14 @@ setup_rootset(Process *p, Eterm *objv, int nobj, Rootset *rootset)
 	n++;
     }
 
+    ASSERT(p->parent == am_undefined
+           || is_pid(follow_moved(p->parent, (Eterm) 0)));
+    if (is_not_immed(p->parent)) {
+	roots[n].v  = &p->parent;
+	roots[n].sz = 1;
+	n++;
+    }
+
     /*
      * The process may be garbage-collected while it is terminating.
      * fvalue contains the EXIT reason.
@@ -3425,6 +3433,7 @@ offset_one_rootset(Process *p, Sint heap_offs, Sint stack_offs,
     offset_heap_ptr(&p->dt_utag, 1, heap_offs, area, area_sz);
 #endif
     offset_heap_ptr(&p->group_leader, 1, heap_offs, area, area_sz);
+    offset_heap_ptr(&p->parent, 1, heap_offs, area, area_sz);
     if (p->sig_qs.recv_mrk_blk) {
         offset_heap_ptr(&p->sig_qs.recv_mrk_blk->ref[0],
                         ERTS_RECV_MARKER_BLOCK_SIZE, heap_offs,

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -26,6 +26,7 @@
 %%	process_info/1,2
 %%	register/2 (partially)
 
+-include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
 
 -define(heap_binary_size, 64).
@@ -43,6 +44,7 @@
 	 process_info_lock_reschedule2/1,
 	 process_info_lock_reschedule3/1,
          process_info_garbage_collection/1,
+         process_info_parent/1,
          process_info_smoke_all/1,
          process_info_status_handled_signal/1,
          process_info_reductions/1,
@@ -105,6 +107,7 @@ all() ->
      process_info_lock_reschedule2,
      process_info_lock_reschedule3,
      process_info_garbage_collection,
+     process_info_parent,
      process_info_smoke_all,
      process_info_status_handled_signal,
      process_info_reductions,
@@ -1063,6 +1066,12 @@ process_info_garbage_collection(_Config) ->
 
 gv(Key,List) ->
     proplists:get_value(Key,List).
+
+process_info_parent(Config) when is_list(Config) ->
+    Child = spawn_link(fun () -> receive stop -> ok end end),
+    ?assertEqual({parent, self()}, erlang:process_info(Child, parent)),
+    Child ! stop,
+    ?assertEqual({parent, undefined}, erlang:process_info(whereis(init), parent)).
 
 process_info_smoke_all_tester() ->
     register(process_info_smoke_all_tester, self()),

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2478,6 +2478,7 @@ process_flag(_Flag, _Value) ->
       monitored_by |
       monitors |
       message_queue_data |
+      parent |
       priority |
       reductions |
       registered_name |
@@ -2522,6 +2523,7 @@ process_flag(_Flag, _Value) ->
        Monitors :: [{process | port, Pid :: pid() | port() |
                                      {RegName :: atom(), Node :: node()}}]} |
       {message_queue_data, MQD :: message_queue_data()} |
+      {parent, pid() | undefined} |
       {priority, Level :: priority_level()} |
       {reductions, Number :: non_neg_integer()} |
       {registered_name, [] | (Atom :: atom())} |


### PR DESCRIPTION
Parent process information is available in the VM process structure,
but is not exposed via process_info. Sometimes it is very convenient
to know who spawned processes that are not supporting any OTP
behaviours (where this information is stored in a process dictionary).

In addition to counting reductions, it may also be important to keep
track of total number sent to a process. This allows various monitoring
scenarios. For example, when message_queue_len is draining slowly, is
it because it the process being slow, or is it because it gets more
messages enqueued. Having both message_queue_len and messages_enqueued
provides a way to calculate queue fill rate (or drain rate) over time.
