### PR TITLE
wx: Detect OpenGL for cross compilation

### DIFF
--- a/lib/wx/configure.ac
+++ b/lib/wx/configure.ac
@@ -262,14 +262,14 @@ AS_IF([test X"$host_os" != X"win32"],
     AS_IF([test X"$ac_cv_header_GL_gl_h" != Xyes && test X"$ac_cv_header_OpenGL_gl_h" != Xyes],
       [
        	saved_CPPFLAGS="$CPPFLAGS"
-	AC_MSG_NOTICE(Checking for OpenGL headers in /usr/X11R6)
-       	CPPFLAGS="-isystem /usr/X11R6/include $CPPFLAGS"
+        AC_MSG_NOTICE(Checking for OpenGL headers in $erl_xcomp_sysroot/usr/X11R6)
+        CPPFLAGS="-isystem $erl_xcomp_sysroot/usr/X11R6/include $CPPFLAGS"
        	$as_unset ac_cv_header_GL_gl_h
        	AC_CHECK_HEADERS([GL/gl.h])
        	AS_IF([test X"$ac_cv_header_GL_gl_h" != Xyes],
           [
-	    AC_MSG_NOTICE(Checking for OpenGL headers in /usr/local)
-	    CPPFLAGS="-isystem /usr/local/include $saved_CPPFLAGS"
+	    AC_MSG_NOTICE(Checking for OpenGL headers in $erl_xcomp_sysroot/usr/local)
+	    CPPFLAGS="-isystem $erl_xcomp_sysroot/usr/local/include $saved_CPPFLAGS"
 	    $as_unset ac_cv_header_GL_gl_h
 	    AC_CHECK_HEADERS([GL/gl.h])
 	    AS_IF([test X"$ac_cv_header_GL_gl_h" != Xyes],
@@ -278,11 +278,11 @@ AS_IF([test X"$host_os" != X"win32"],
 		CPPFLAGS="$saved_CPPFLAGS"
               ],
               [
-	    	GL_LIBS="-L/usr/local/lib $GL_LIBS"
+                GL_LIBS="-L$erl_xcomp_sysroot/usr/local/lib $GL_LIBS"
               ])
 	  ],
           [
-    	    GL_LIBS="-L/usr/X11R6/lib $GL_LIBS"
+            GL_LIBS="-L$erl_xcomp_sysroot/usr/X11R6/lib $GL_LIBS"
        	  ])
       ])
   ],


### PR DESCRIPTION
Hello,

This PR intend to fix cross compilation issues for wx. And uses the same strategy following https://github.com/erlang/otp/pull/5728.

Without this patch I got:

```
builder@f985825fa055:/build/tmp/work/cortexa57-poky-linux/erlang/25.0-rc1-r0/git$ find -name config.log
./erts/config.log
./lib/crypto/config.log
./lib/common_test/config.log
./lib/wx/config.log
./lib/snmp/config.log
./lib/megaco/config.log
./lib/erl_interface/config.log
./make/config.log
builder@f985825fa055:/build/tmp/work/cortexa57-poky-linux/erlang/25.0-rc1-r0/git$ grep  'unsafe for cross-compilation' ./lib/wx/config.log
cc1: warning: include location "/usr/local/include" is unsafe for cross-compilation [-Wpoison-system-directories]
```

The general OpenGL detection is right, the issue is when the configure tries to find it in the alternative folders like /usr/X11R6 and usr/local/.
