### PR TITLE
logger: Don't use original meta data in internal log

### DIFF
--- a/lib/kernel/src/logger_server.erl
+++ b/lib/kernel/src/logger_server.erl
@@ -623,7 +623,7 @@ do_internal_log(Level,Location,Log,[Report] = Data) ->
 do_internal_log(Level,Location,Log,[Fmt,Args] = Data) ->
     do_internal_log(Level,Location,Log,Data,{Fmt,Args}).
 do_internal_log(Level,Location,Log,Data,Msg) ->
-    Meta = logger:add_default_metadata(maps:merge(Location,maps:get(meta,Log,#{}))),
+    Meta = logger:add_default_metadata(Location),
     %% Spawn these to avoid deadlocks
     case Log of
         #{ meta := #{ internal_log_event := true } } ->


### PR DESCRIPTION
logger_backend emits internal debug logs if a handler or a filter
fails. This is done using the ?LOG_INTERNAL macro. Prior to this
commit, these logs would get the meta data from the original failing
log event. This commit instead uses the actual location of the
internal debug log.

The original meta data is still included as a part of the log report,
so no data is lost.