### PR TITLE
crypto:macN - fix specs

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -666,7 +666,7 @@ mac(Type, SubType, Key0, Data) ->
     mac_nif(Type, alias(SubType,Key), Key, Data).
 
 
--spec macN(Type :: poly1305, Key, Data, MacLength) -> Mac | descriptive_error()
+-spec macN(Type :: poly1305, Key, Data, MacLength) -> Mac
                      when Key :: iodata(),
                           Data :: iodata(),
                           Mac :: binary(),
@@ -676,7 +676,7 @@ macN(Type, Key, Data, MacLength) ->
     macN(Type, undefined, Key, Data, MacLength).
 
 
--spec macN(Type, SubType, Key, Data, MacLength) -> Mac | descriptive_error()
+-spec macN(Type, SubType, Key, Data, MacLength) -> Mac
                      when Type :: hmac | cmac | poly1305,
                           SubType :: hmac_hash_algorithm() | cmac_cipher_algorithm() | undefined,
                           Key :: iodata(),


### PR DESCRIPTION
both `macN/4` and `macN/5` finally call `erlang:binary_part/3` which can return ONLY `binary()` (or throw an exception).