### PR TITLE
erl_interface: Avoid building dynamic libs by default

### DIFF
--- a/lib/erl_interface/src/Makefile.in
+++ b/lib/erl_interface/src/Makefile.in
@@ -261,10 +261,13 @@ endif
 
 TARGETS = \
 	$(OBJ_TARGETS) \
-	$(SH_TARGETS) \
 	$(EXE_TARGETS) \
 	$(APP_TARGET)  \
 	$(APPUP_TARGET)
+
+ifeq (@DYNAMIC_LIB@, yes)
+TARGETS += $(SH_TARGETS)
+endif
 
 ###########################################################################
 #  List all source files


### PR DESCRIPTION
Fix #5781 

Only build dynamic libs if `--enable-ei-dynamic-lib` is given.

Commit 96e8bea9c7f4e6071ae16588a6b2d3bbebff67f8 introduced `--enable-ei-dynamic-lib`, but always built dynamic libs
and only suppressed _installation_ of the libs if not enabled.