### PR TITLE
Fix infinite loop triggered using CTRL-R when history file fails to open

### DIFF
--- a/lib/kernel/src/group_history.erl
+++ b/lib/kernel/src/group_history.erl
@@ -166,7 +166,8 @@ open_new_log(Name) ->
     case open_log() of
         {error, Reason} ->
             handle_open_error(Reason),
-            disable_history();
+            disable_history(),
+            [];
         _ ->
             _ = disk_log:close(Name),
             load()


### PR DESCRIPTION
This fixes an infinite loop with group:up_stack/1 that could be
triggered when commandline history is enabled, but it wasn't possible to
create the log file. In this case, an `ok` atom was being stored as the
history which would confuse the history search.

If you pressed CTRL-R and started typing, an infinite loop would be
started that would eventually terminate when out of memory.

To reproduce:

```sh
$ export ERL_AFLAGS="-kernel shell_history enabled -kernel shell_history_path '\"/proc\"'"
$ erl

Type CTRL-R and then press any key
```