### PR TITLE
Improve response handling for asynchronous gen and erpc requests

### DIFF
--- a/lib/kernel/doc/src/erpc.xml
+++ b/lib/kernel/doc/src/erpc.xml
@@ -64,12 +64,55 @@
       <name name="request_id"/>
       <desc>
         <p>
-	  An opaque type of call request identifiers. For more
-	  information see
+	  An opaque request identifier. For more information see
           <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
 	</p>
       </desc>
     </datatype>
+    <datatype>
+      <name name="request_id_collection"/>
+      <desc>
+        <p>
+	  An opaque collection of request identifiers
+          (<seetype marker="#request_id"><c>request_id()</c></seetype>)
+          where each request identifier can be associated with a label
+          chosen by the user. For more information see
+          <seemfa marker="#reqids_new/0"><c>reqids_new/0</c></seemfa>.
+	</p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="timeout_time"/>
+      <desc>
+        <taglist>
+          <tag><c>0..4294967295</c></tag>
+          <item><p>
+            Timeout relative to current time in milliseconds.
+          </p></item>
+          <tag><c>infinity</c></tag>
+          <item><p>
+            Infinite timeout. That is, the operation will never time out.
+          </p></item>
+          <tag><c>{abs, Timeout}</c></tag>
+          <item><p>
+            An absolute
+            <seemfa marker="erts:erlang#monotonic_time/1">Erlang monotonic time</seemfa>
+            timeout in milliseconds. That is, the operation will time out when
+            <seemfa marker="erts:erlang#monotonic_time/1"><c>erlang:monotonic_time(millisecond)</c></seemfa>
+            returns a value larger than or equal to <c>Timeout</c>. <c>Timeout</c>
+            is not allowed to identify a time further into the future than <c>4294967295</c>
+            milliseconds. Identifying the timeout using an absolute timeout value
+            is especially handy when you have a deadline for responses corresponding
+            to a complete collection of requests
+            (<seetype marker="#request_id_collection"><c>request_id_collection()</c></seetype>)
+,
+            since you do not have to recalculate the relative time until the deadline
+            over and over again.
+	  </p></item>
+        </taglist>
+      </desc>
+    </datatype>
+
   </datatypes>
 
   <funcs>
@@ -81,8 +124,9 @@
       <desc>
 	<p>
 	  The same as calling
-	  <seemfa marker="#call/5"><c>erpc:call(<anno>Node</anno>,erlang,apply,[<anno>Fun</anno>,[]],<anno>Timeout</anno>)</c></seemfa>.
-	  May raise all the same exceptions as <c>erpc:call/5</c>
+	  <seemfa marker="#call/5"><c>erpc:call(<anno>Node</anno>,
+          erlang, apply, [<anno>Fun</anno>,[]], <anno>Timeout</anno>)</c></seemfa>.
+	  May raise all the same exceptions as <c>call/5</c>
 	  plus an <c>{erpc, badarg}</c> <c>error</c>
 	  exception if <c><anno>Fun</anno></c> is not a fun of
 	  zero arity.
@@ -104,9 +148,8 @@
 	  Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
           <anno>Args</anno>)</c> on node <c><anno>Node</anno></c> and returns
           the corresponding value <c><anno>Result</anno></c>.
-	  <c><anno>Timeout</anno></c> is an integer representing
-	  the timeout in milliseconds or the atom <c>infinity</c>
-	  which prevents the operation from ever timing out.
+          <c><anno>Timeout</anno></c> sets an upper time limit
+          for the <c>call</c> operation to complete.
 	</p>
 	<p>The call <c>erpc:call(<anno>Node</anno>, <anno>Module</anno>,
 	<anno>Function</anno>, <anno>Args</anno>)</c> is equivalent
@@ -118,7 +161,7 @@
 	  exceptions, the operation did not time out, and no failures
 	  occurred. In all other cases an exception is raised. The
 	  following exceptions, listed by exception class, can
-	  currently be raised by <c>erpc:call()</c>:
+	  currently be raised by <c>call()</c>:
 	</p>
 	<taglist>
 	  <tag><c>throw</c></tag>
@@ -158,7 +201,7 @@
 	    
 	    <tag><c>{exception, ErrorReason, StackTrace}</c></tag>
 	    <item><p>
-	      A runtime error occurred which raised and error
+	      A runtime error occurred which raised an error
 	      exception while applying the function,
 	      and the applied function did not catch the
 	      exception. The error reason <c>ErrorReason</c>
@@ -186,9 +229,8 @@
 		  <item><p><c><anno>Args</anno></c> is not a list.
 		  Note that the list is not verified to be
 		  a proper list at the client side.</p></item>
-		  <item><p><c><anno>Timeout</anno></c> is not the
-		  atom <c>infinity</c> or an integer in valid
-		  range.</p></item>
+		  <item><p><c><anno>Timeout</anno></c> is
+                  invalid.</p></item>
 		</list>
 	      </item>
 	      
@@ -256,7 +298,7 @@
 	  The same as calling
 	  <seemfa marker="#cast/4"><c>erpc:cast(<anno>Node</anno>,erlang,apply,[<anno>Fun</anno>,[]])</c></seemfa>.
 	</p>
-	<p><c>erpc:cast/2</c> fails with an <c>{erpc, badarg}</c>
+	<p><c>cast/2</c> fails with an <c>{erpc, badarg}</c>
 	<c>error</c> exception if:</p>
 	<list>
 	  <item><p><c><anno>Node</anno></c> is not an atom.</p></item>
@@ -273,11 +315,11 @@
 	  Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
           <anno>Args</anno>)</c> on node
           <c><anno>Node</anno></c>. No response is delivered to the
-	  calling process. <c>erpc:cast()</c> returns immediately
+	  calling process. <c>cast()</c> returns immediately
 	  after the cast request has been sent. Any failures beside
 	  bad arguments are silently ignored.
 	</p>
-	<p><c>erpc:cast/4</c> fails with an <c>{erpc, badarg}</c>
+	<p><c>cast/4</c> fails with an <c>{erpc, badarg}</c>
 	<c>error</c> exception if:</p>
 	<list>
 	  <item><p><c><anno>Node</anno></c> is not an atom.</p></item>
@@ -305,13 +347,13 @@
 	<p>
 	  Check if a message is a response to a <c>call</c> request
 	  previously made by the calling process using
-	  <seemfa marker="#send_request/4"><c>erpc:send_request/4</c></seemfa>.
+	  <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
 	  <c><anno>RequestId</anno></c> should be the value returned
-	  from the previously made <c>erpc:send_request()</c> call,
+	  from the previously made <c>send_request/4</c> call,
 	  and the corresponding response should not already have been
-	  received and handled to completion by <c>erpc:check_response()</c>,
-	  <seemfa marker="#receive_response/2"><c>erpc:receive_response()</c></seemfa>, or
-	  <seemfa marker="#wait_response/2"><c>erpc:wait_response()</c></seemfa>.
+	  received and handled to completion by <c>check_response/2</c>,
+	  <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>, or
+	  <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>.
 	  <c><anno>Message</anno></c> is the message to check.
 	</p>
 	<p>
@@ -323,9 +365,9 @@
 	  corresponds to the value returned from the applied function
 	  or an exception is raised. The exceptions that can be raised
 	  corresponds to the same exceptions as can be raised by
-	  <seemfa marker="#call/4"><c>erpc:call/4</c></seemfa>.
+	  <seemfa marker="#call/4"><c>call/4</c></seemfa>.
 	  That is, no <c>{erpc, timeout}</c> <c>error</c> exception
-	  can be raised. <c>erpc:check_response()</c> will fail with
+	  can be raised. <c>check_response()</c> will fail with
 	  an <c>{erpc, badarg}</c> exception if/when an invalid
 	  <c><anno>RequestId</anno></c> is detected.
 	</p>
@@ -341,14 +383,89 @@
     </func>
 
     <func>
+      <name name="check_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Check if a message is a response corresponding to a
+      previously sent call request.</fsummary>
+      <desc>
+        <p>
+	  Check if a message is a response to a <c>call</c> request corresponding
+          to a request identifier saved in <c><anno>RequestIdCollection</anno></c>.
+          All request identifiers of <c><anno>RequestIdCollection</anno></c> must
+          correspond to requests that have been made using
+	  <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa> or
+	  <seemfa marker="#send_request/6"><c>send_request/6</c></seemfa>,
+          and all requests must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          <c><anno>Label</anno></c> is the label associated with the request
+          identifier of the request that the response corresponds to.
+          A request identifier is associated with a label when
+          <seemfa marker="#reqids_add/3">adding a request identifier</seemfa>
+          in a <seetype marker="#request_id_collection">request identifier
+          collection</seetype>, or when sending the request using
+          <seemfa marker="#send_request/6"><c>send_request/6</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#check_response/2"><c>check_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>check_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewRequestIdCollection</anno></c> is a possibly  modified
+          request identifier collection. The <c>error</c> exception <c>{erpc,
+          badarg}</c> is not associated with any specific request identifier,
+          and will hence not be wrapped.
+        </p>
+        <p>
+          If <c><anno>RequestIdCollection</anno></c> is empty, the atom
+          <c>no_request</c> will be returned. If <c><anno>Message</anno></c>
+          does not correspond to any of the request identifiers in
+          <c><anno>RequestIdCollection</anno></c>, the atom
+          <c>no_response</c> is returned.
+        </p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>RequestIdCollection</anno></c> in the resulting
+          <c><anno>NewRequestIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewRequestIdCollection</anno></c> will equal
+          <c><anno>RequestIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>check_response/3</c>,
+ 	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>check_response/3</c>, it will always
+          return <c>no_response</c>.
+        </p>
+        <p>
+          Note that a response might have been consumed uppon an <c>{erpc,
+          badarg}</c> exception and if so, will be lost for ever.
+        </p>
+      </desc>
+    </func>
+
+    <func>
       <name name="multicall" arity="2" since="OTP 23.0"/>
       <name name="multicall" arity="3" since="OTP 23.0"/>
       <fsummary>Evaluate a function call on a node.</fsummary>
       <desc>
 	<p>
 	  The same as calling
-	  <seemfa marker="#multicall/5"><c>erpc:multicall(<anno>Nodes</anno>,erlang,apply,[<anno>Fun</anno>,[]],<anno>Timeout</anno>)</c></seemfa>.
-	  May raise all the same exceptions as <c>erpc:multicall/5</c>
+	  <seemfa marker="#multicall/5"><c>erpc:multicall(<anno>Nodes</anno>,
+          erlang, apply, [<anno>Fun</anno>,[]], <anno>Timeout</anno>)</c></seemfa>.
+	  May raise all the same exceptions as <c>multicall/5</c>
 	  plus an <c>{erpc, badarg}</c> <c>error</c>
 	  exception if <c><anno>Fun</anno></c> is not a fun of
 	  zero arity.
@@ -372,15 +489,13 @@
 	  Performs multiple <c>call</c> operations in parallel
 	  on multiple nodes. That is, evaluates
 	  <c>apply(<anno>Module</anno>, <anno>Function</anno>,
-          <anno>Args</anno>)</c> on the nodes
-	  <c><anno>Nodes</anno></c> in parallel.
-	  <c><anno>Timeout</anno></c> is an integer representing
-	  the timeout in milliseconds or the atom <c>infinity</c>
-	  which prevents the operation from ever timing out.
-	  The result is returned as a list where
-	  the result from each node is placed at the same position
-	  as the node name is placed in <c><anno>Nodes</anno></c>.
-	  Each item in the resulting list is formatted as either:
+          <anno>Args</anno>)</c> on the nodes <c><anno>Nodes</anno></c>
+          in parallel. <c><anno>Timeout</anno></c> sets an upper time
+          limit for all <c>call</c> operations to complete. The result
+          is returned as a list where the result from each node is placed
+          at the same position as the node name is placed in
+          <c><anno>Nodes</anno></c>. Each item in the resulting list is
+          formatted as either:
 	</p>
 	<taglist>
 	  <tag><c>{ok, Result}</c></tag>
@@ -394,11 +509,11 @@
 	    raised an exception of class <c>Class</c> with
 	    exception reason <c>ExceptionReason</c>. These
 	    corresponds the the exceptions that
-	    <seemfa marker="#call/5"><c>erpc:call/5</c></seemfa>
+	    <seemfa marker="#call/5"><c>call/5</c></seemfa>
 	    can raise.
 	  </p></item>
 	</taglist>
-	<p><c>erpc:multicall/5</c> fails with an <c>{erpc, badarg}</c>
+	<p><c>multicall/5</c> fails with an <c>{erpc, badarg}</c>
 	<c>error</c> exception if:</p>
 	<list>
 	  <item><p><c><anno>Nodes</anno></c> is not a proper list of
@@ -416,8 +531,12 @@
 	  to the call <c>erpc:multicall(<anno>Nodes</anno>, <anno>Module</anno>,
 	  <anno>Function</anno>, <anno>Args</anno>, infinity)</c>. These
 	  calls are also equivalent to calling <c>my_multicall(Nodes, Module,
-	  Function, Args)</c> if one disregard performance and failure
-	  behavior:
+	  Function, Args)</c> below if one disregard performance and failure
+	  behavior. <c>multicall()</c> can utilize a selective receive
+          optimization which removes the need to scan the message queue from
+          the beginning in order to find a matching message. The
+	  <c>send_request()/receive_response()</c> combination can,
+          however, not utilize this optimization.
 	</p>
 	<pre>
 my_multicall(Nodes, Module, Function, Args) ->
@@ -435,12 +554,6 @@ my_multicall(Nodes, Module, Function, Args) ->
             end,
             ReqIds).
 </pre>
-
-        <p>
-	  The <c><anno>Timeout</anno></c> value in milliseconds
-	  sets an upper time limit for all <c>call</c> operations
-	  to complete.
-	</p>
 
 	<p>
 	  If an <c>erpc</c> operation fails, but it is unknown if
@@ -473,7 +586,7 @@ my_multicall(Nodes, Module, Function, Args) ->
 	  The same as calling
 	  <seemfa marker="#multicast/4"><c>erpc:multicast(<anno>Nodes</anno>,erlang,apply,[<anno>Fun</anno>,[]])</c></seemfa>.
 	</p>
-	<p><c>erpc:multicast/2</c> fails with an <c>{erpc, badarg}</c>
+	<p><c>multicast/2</c> fails with an <c>{erpc, badarg}</c>
 	<c>error</c> exception if:</p>
 	<list>
 	  <item><p><c><anno>Nodes</anno></c> is not a proper list of atoms.</p></item>
@@ -490,11 +603,11 @@ my_multicall(Nodes, Module, Function, Args) ->
 	  Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
           <anno>Args</anno>)</c> on the nodes
           <c><anno>Nodes</anno></c>. No response is delivered to the
-	  calling process. <c>erpc:multicast()</c> returns immediately
+	  calling process. <c>multicast()</c> returns immediately
 	  after the cast requests have been sent. Any failures beside
 	  bad arguments are silently ignored.
 	</p>
-	<p><c>erpc:multicast/4</c> fails with an <c>{erpc, badarg}</c>
+	<p><c>multicast/4</c> fails with an <c>{erpc, badarg}</c>
 	<c>error</c> exception if:</p>
 	<list>
 	  <item><p><c><anno>Nodes</anno></c> is not a proper list of
@@ -515,9 +628,21 @@ my_multicall(Nodes, Module, Function, Args) ->
 	</note>
       </desc>
     </func>
-    
+
     <func>
       <name name="receive_response" arity="1" since="OTP 23.0"/>
+      <fsummary>Receive a call response corresponding to a
+      previously sent call request.</fsummary>
+      <desc>
+        <p>
+          The same as calling
+          <seemfa marker="#receive_response/2"><c>erpc:receive_response(<anno>RequestId</anno>,
+          infinity)</c></seemfa>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
       <name name="receive_response" arity="2" since="OTP 23.0"/>
       <fsummary>Receive a call response corresponding to a
       previously sent call request.</fsummary>
@@ -525,34 +650,41 @@ my_multicall(Nodes, Module, Function, Args) ->
 	<p>
 	  Receive a response to a <c>call</c> request previously
 	  made by the calling process using
-	  <seemfa marker="#send_request/4"><c>erpc:send_request/4</c></seemfa>.
+	  <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
 	  <c><anno>RequestId</anno></c> should be the value returned from
-	  the previously made <c>erpc:send_request()</c> call, and
+	  the previously made <c>send_request/4</c> call, and
 	  the corresponding response should not already have been received
-	  and handled to completion by
-	  <seemfa marker="#check_response/2"><c>erpc:check_response()</c></seemfa>,
-	  <c>erpc:receive_response()</c>, or
-	  <seemfa marker="#wait_response/2"><c>erpc:wait_response()</c></seemfa>.
-	  <c><anno>Timeout</anno></c> is an integer representing
-	  the timeout in milliseconds or the atom <c>infinity</c>
-	  which prevents the operation from ever timing out. The <c>call</c>
-	  operation is completed once the <c>erpc:receive_response()</c> call
-	  returns or raise an exception.
+	  and handled to completion by <c>receive_response()</c>,
+	  <seemfa marker="#check_response/2"><c>check_response/4</c></seemfa>,
+          or
+	  <seemfa marker="#wait_response/2"><c>wait_response/4</c></seemfa>.
+        </p>
+        <p>
+          <c><anno>Timeout</anno></c> sets an upper time limit on how
+          long to wait for a response. If the operation times out, the request
+          identified by <c><anno>RequestId</anno></c> will be abandoned, then an
+          <c>{erpc, timeout}</c> <c>error</c> exception will be raised. That is,
+          no response corresponding to the request will ever be received after a
+          timeout. If a response is received, the <c>call</c> operation is
+          completed and either the result is returned or an exception is raised. The
+          exceptions that can be raised corresponds to the same exceptions as can
+          be raised by <seemfa marker="#call/5"><c>call/5</c></seemfa>.
+	  <c>receive_response/2</c> will fail with an <c>{erpc, badarg}</c>
+	  exception if/when an invalid <c><anno>RequestId</anno></c> is detected
+	  or if an invalid <c><anno>Timeout</anno></c> is passed.
 	</p>
-	<p>
-	  The call <c>erpc:receive_response(<anno>RequestId</anno>)</c> is
-	  equivalent to the call
-	  <c>erpc:receive_response(<anno>RequestId</anno>, infinity)</c>.
-	</p>
+
 	<p>
 	  A call to the function
 	  <c>my_call(Node, Module, Function, Args, Timeout)</c>
 	  below is equivalent to the call
 	  <seemfa marker="#call/5"><c>erpc:call(Node, Module, Function, Args,
-	  Timeout)</c></seemfa> if one disregards performance. <c>erpc:call()</c>
-	  can utilize a message queue optimization which removes the need to scan
-	  the whole message queue which the combination
-	  <c>erpc:send_request()/erpc:receive_response()</c> cannot.
+	  Timeout)</c></seemfa> if one disregards performance. <c>call()</c>
+	  can utilize a selective receive optimization which removes
+          the need to scan the message queue from the beginning in
+          order to find a matching message. The
+	  <c>send_request()/receive_response()</c> combination can,
+          however, not utilize this optimization.
 	</p>
 	<pre>
 my_call(Node, Module, Function, Args, Timeout) ->
@@ -568,15 +700,157 @@ my_call(Node, Module, Function, Args, Timeout) ->
 	  communicates with the calling process, such communication
 	  may, of course, reach the calling process.
         </p>
-	
-	<p>
-	  <c>erpc:receive_response()</c> will return or raise exceptions the
-	  same way as <seemfa marker="#call/5"><c>erpc:call/5</c></seemfa>
-	  does with the exception of <c>{erpc, badarg}</c>. An
-	  <c>{erpc, badarg}</c> exception will be raised if/when an invalid
-	  <c><anno>RequestId</anno></c> is detected or if an invalid
-	  <c><anno>Timeout</anno></c> is passed.
+      </desc>
+    </func>
+
+    <func>
+      <name name="receive_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Receive a call response corresponding to a
+      previously sent call request.</fsummary>
+      <desc>
+        <p>
+	  Receive a response to a <c>call</c> request corresponding to a request
+          identifier saved in <c><anno>RequestIdCollection</anno></c>. All
+          request identifiers of <c><anno>RequestIdCollection</anno></c> must
+          correspond to requests that have been made using
+	  <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa> or
+	  <seemfa marker="#send_request/6"><c>send_request/6</c></seemfa>,
+          and all requests must have been made by the process calling this
+          function.
 	</p>
+        <p>
+          <c><anno>Label</anno></c> is the label associated with the request
+          identifier of the request that the response corresponds to.
+          A request identifier is associated with a label when
+          <seemfa marker="#reqids_add/3">adding a request identifier</seemfa>
+          in a <seetype marker="#request_id_collection">request identifier
+          collection</seetype>, or when sending the request using
+          <seemfa marker="#send_request/6"><c>send_request/6</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>receive_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewRequestIdCollection</anno></c> is a possibly  modified
+          request identifier collection. The <c>error</c> exceptions <c>{erpc,
+          badarg}</c> and <c>{erpc, timeout}</c> are not associated with any
+          specific request identifiers, and will hence not be wrapped.
+        </p>
+        <p>
+          If <c><anno>RequestIdCollection</anno></c> is empty, the atom
+          <c>no_request</c> will be returned.
+        </p>
+        <p>
+          If the operation times out, all requests identified by
+          <c><anno>RequestIdCollection</anno></c> will be abandoned, then an
+          <c>{erpc, timeout}</c> <c>error</c> exception will be raised. That is,
+          no responses corresponding to any of the request identifiers in
+          <c><anno>RequestIdCollection</anno></c> will ever be received after a
+          timeout. The difference between <c>receive_response/3</c> and
+          <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>
+          is that <c>receive_response/3</c> abandons the requests at timeout
+          so that any potential future responses are ignored, while
+          <c>wait_response/3</c> does not.
+	</p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>RequestIdCollection</anno></c> in the resulting
+          <c><anno>NewRequestIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewRequestIdCollection</anno></c> will equal
+          <c><anno>RequestIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>receive_response/3</c>,
+ 	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>receive_response/3</c>, it will always block
+          until a timeout determined by <c><anno>Timeout</anno></c> is
+          triggered.
+        </p>
+        <p>
+          Note that a response might have been consumed uppon an <c>{erpc,
+          badarg}</c> exception and if so, will be lost for ever.
+        </p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="reqids_add" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Save a request identifier.</fsummary>
+      <desc>
+	<p>
+          Saves <c><anno>RequestId</anno></c> and associates a
+          <c><anno>Label</anno></c> with the request identifier by adding this
+          information to <c><anno>RequestIdCollection</anno></c> and returning
+          the resulting request identifier collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_new" arity="0" since="OTP @OTP-17784@"/>
+      <fsummary>Create a new empty request identifier collection.</fsummary>
+      <desc>
+	<p>
+          Returns a new empty request identifier collection. A 
+          request identifier collection can be utilized in order
+          the handle multiple outstanding requests.
+        </p>
+        <p>
+          Request identifiers of requests made by
+	  <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>
+          can be saved in a request identifier collection using 
+	  <seemfa marker="#reqids_add/3"><c>reqids_add/3</c></seemfa>.
+          Such a collection of request identifiers can later be used in
+          order to get one response corresponding to a request in the
+          collection by passing the collection as argument to
+          <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+        </p>
+        <p>
+          <seemfa marker="#reqids_size/1"><c>reqids_size/1</c></seemfa>
+          can be used to determine the amount of request identifiers in a
+          request identifier collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_size" arity="1" since="OTP @OTP-17784@"/>
+      <fsummary>Get size of a request identifier collection.</fsummary>
+      <desc>
+	<p>
+          Returns the amount of request identifiers saved in
+          <c><anno>RequestIdCollection</anno></c>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_to_list" arity="1" since="OTP @OTP-17784@"/>
+      <fsummary>Get a list a request identifier/label associations in a collection.</fsummary>
+      <desc>
+	<p>
+          Returns a list of <c>{<anno>RequestId</anno>, <anno>Label</anno>}</c>
+          tuples which corresponds to all request identifiers with their
+          associated labels present in the <c><anno>RequestIdCollection</anno></c>
+          collection.
+        </p>
       </desc>
     </func>
 
@@ -586,10 +860,10 @@ my_call(Node, Module, Function, Args, Timeout) ->
       <desc>
 	<p>
 	  The same as calling
-	  <seemfa marker="#send_request/4"><c>erpc:send_request(<anno>Node</anno>,erlang,apply,[<anno>Fun</anno>,[]])</c></seemfa>.
+	  <seemfa marker="#send_request/4"><c>erpc:send_request(<anno>Node</anno>,
+          erlang, apply, [<anno>Fun</anno>, []])</c></seemfa>.
 	</p>
-	<p><c>erpc:send_request/2</c> fails with an <c>{erpc, badarg}</c>
-	<c>error</c> exception if:</p>
+	<p>Fails with an <c>{erpc, badarg}</c> <c>error</c> exception if:</p>
 	<list>
 	  <item><p><c><anno>Node</anno></c> is not an atom.</p></item>
 	  <item><p><c><anno>Fun</anno></c> is not a fun of
@@ -606,22 +880,52 @@ my_call(Node, Module, Function, Args, Timeout) ->
     </func>
     
     <func>
-      <name name="send_request" arity="4" since="OTP 23.0"/>
+      <name name="send_request" arity="4" clause_i="1" since="OTP 23.0"/>
       <fsummary>Send a request to evaluate a function call on a node.</fsummary>
       <desc>
 	<p>
 	  Send an asynchronous <c>call</c> request to the node
-	  <c><anno>Node</anno></c>. <c>erpc:send_request()</c>
+	  <c><anno>Node</anno></c>. <c>send_request/4</c>
 	  returns a request identifier that later is to be passed
-	  as argument to either
-	  <seemfa marker="#receive_response/1"><c>erpc:receive_response()</c></seemfa>,
-	  <seemfa marker="#wait_response/1"><c>erpc:wait_response()</c></seemfa>,
+	  to either
+	  <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+	  <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
 	  or,
-	  <seemfa marker="#check_response/2"><c>erpc:check_response()</c></seemfa>
-	  in order to get the response of the call request.
+	  <seemfa marker="#check_response/2"><c>check_response/2</c></seemfa>
+	  in order to get the response of the call request. Besides passing
+          the request identifier directly to these functions, it can also be
+          added in a request identifier collection using 
+	  <seemfa marker="#reqids_add/3"><c>reqids_add/3</c></seemfa>.
+          Such a collection of request identifiers can later be used in
+          order to get one response corresponding to a request in the
+          collection by passing the collection as argument to
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>,
+	  or,
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+          If you are about to save the request identifier in a request identifier
+          collection, you may want to consider using
+          <seemfa marker="#send_request/6"><c>send_request/6</c></seemfa>
+          instead.
+        </p>
+        <p>
+	  A call to the function
+	  <c>my_call(Node, Module, Function, Args, Timeout)</c>
+	  below is equivalent to the call
+	  <seemfa marker="#call/5"><c>erpc:call(Node, Module, Function, Args,
+	  Timeout)</c></seemfa> if one disregards performance. <c>call()</c>
+	  can utilize a selective receive optimization which removes
+          the need to scan the message queue from the beginning in
+          order to find a matching message. The
+	  <c>send_request()/receive_response()</c> combination can,
+          however, not utilize this optimization.
 	</p>
-	<p><c>erpc:send_request()</c> fails with an <c>{erpc, badarg}</c>
-	<c>error</c> exception if:</p>
+	<pre>
+my_call(Node, Module, Function, Args, Timeout) ->
+  RequestId = erpc:send_request(Node, Module, Function, Args),
+  <seemfa marker="#receive_response/2">erpc:receive_response(RequestId, Timeout)</seemfa>.
+</pre>
+	<p>Fails with an <c>{erpc, badarg}</c> <c>error</c> exception if:</p>
 	<list>
 	  <item><p><c><anno>Node</anno></c> is not an atom.</p></item>
 	  <item><p><c><anno>Module</anno></c> is not an atom.</p></item>
@@ -629,11 +933,105 @@ my_call(Node, Module, Function, Args, Timeout) ->
 	  <item><p><c><anno>Args</anno></c> is not a list. Note that the
 	  list is not verified to be a proper list at the client side.</p></item>
 	</list>
+	<note>
+	  <p>
+	    You cannot make <em>any</em> assumptions about the
+	    process that will perform the <c>apply()</c>. It may
+	    be a server, or a freshly spawned process.
+	  </p>
+	</note>
       </desc>
     </func>
 
     <func>
-      <name name="wait_response" arity="1" since="OTP 23.0"/>
+      <name name="send_request" arity="4" clause_i="2" since="OTP @OTP-17784@"/>
+      <fsummary>Send a request to evaluate a function call on a node.</fsummary>
+      <desc>
+	<p>
+	  The same as calling
+	  <seemfa marker="#send_request/6"><c>erpc:send_request(<anno>Node</anno>,
+          erlang, apply, [<anno>Fun</anno>,[]]), <anno>Label</anno>,
+          <anno>RequestIdCollection</anno>)</c></seemfa>.
+	</p>
+	<p>Fails with an <c>{erpc, badarg}</c> <c>error</c> exception if:</p>
+	<list>
+	  <item><p><c><anno>Node</anno></c> is not an atom.</p></item>
+	  <item><p><c><anno>Fun</anno></c> is not a fun of zero arity.</p></item>
+	  <item><p><c><anno>RequestIdCollection</anno></c> is detected not to
+          be request identifier collection.</p></item>
+	</list>
+	<note>
+	  <p>
+	    You cannot make <em>any</em> assumptions about the
+	    process that will perform the <c>apply()</c>. It may
+	    be a server, or a freshly spawned process.
+	  </p>
+	</note>
+      </desc>
+    </func>
+
+    <func>
+      <name name="send_request" arity="6" since="OTP @OTP-17784@"/>
+      <fsummary>Send a request to evaluate a function call on a node.</fsummary>
+      <desc>
+	<p>
+	  Send an asynchronous <c>call</c> request to the node
+	  <c><anno>Node</anno></c>. The <c><anno>Label</anno></c> will be
+          associated with the request identifier of the operation and
+          added to the returned request identifier collection
+          <c><anno>NewRequestIdCollection</anno></c>. The collection can
+          later be used in order to get one response corresponding to a
+          request in the collection by passing the collection as argument to
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>,
+	  or,
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+        </p>
+
+        <p>
+          The same as calling
+          <seemfa marker="#reqids_add/3"><c>erpc:reqids_add</c></seemfa>(<seemfa
+          marker="#send_request/4"><c>erpc:send_request</c></seemfa><c>(<anno>Node</anno>,
+          <anno>Module</anno>, <anno>Function</anno>, <anno>Args</anno>),
+          <anno>Label</anno>, <anno>RequestIdCollection</anno>)</c>, but
+          calling <c>send_request/6</c> is slightly more efficient.
+        </p>
+
+	<p>Fails with an <c>{erpc, badarg}</c> <c>error</c> exception if:</p>
+	<list>
+	  <item><p><c><anno>Node</anno></c> is not an atom.</p></item>
+	  <item><p><c><anno>Module</anno></c> is not an atom.</p></item>
+	  <item><p><c><anno>Function</anno></c> is not an atom.</p></item>
+	  <item><p><c><anno>Args</anno></c> is not a list. Note that the
+	  list is not verified to be a proper list at the client side.</p></item>
+	  <item><p><c><anno>RequestIdCollection</anno></c> is detected not to
+          be request identifier collection.</p></item>
+	</list>
+	<note>
+	  <p>
+	    You cannot make <em>any</em> assumptions about the
+	    process that will perform the <c>apply()</c>. It may
+	    be a server, or a freshly spawned process.
+	  </p>
+	</note>
+      </desc>
+    </func>
+
+    <func>
+      <name name="wait_response" arity="1" clause_i="1" since="OTP 23.0"/>
+      <fsummary>Poll for a call response corresponding to a previously
+      sent call request.</fsummary>
+      <desc>
+        <p>
+          The same as calling
+          <seemfa marker="#wait_response/2"><c>erpc:wait_response(<anno>RequestId</anno>,
+          0)</c></seemfa>. That is, poll for a response message to a <c>call</c>
+          request previously made by the calling process.
+        </p>
+      </desc>
+    </func>
+
+    <func>
       <name name="wait_response" arity="2" since="OTP 23.0"/>
       <fsummary>Wait or poll for a call response corresponding to a previously
       sent call request.</fsummary>
@@ -641,40 +1039,30 @@ my_call(Node, Module, Function, Args, Timeout) ->
 	<p>
 	  Wait or poll for a response message to a <c>call</c> request
 	  previously made by the calling process using
-	  <seemfa marker="#send_request/4"><c>erpc:send_request/4</c></seemfa>.
+	  <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
 	  <c><anno>RequestId</anno></c> should be the value returned from
-	  the previously made <c>erpc:send_request()</c> call, and the
+	  the previously made <c>send_request()</c> call, and the
 	  corresponding response should not already have been received and handled
 	  to completion by
-	  <seemfa marker="#check_response/2"><c>erpc:check_response()</c></seemfa>,
-	  <seemfa marker="#receive_response/2"><c>erpc:receive_response()</c></seemfa>,
-	  or <c>erpc:wait_response()</c>. <c><anno>WaitTime</anno></c> equals the
-	  time to wait in milliseconds (or the atom <c>infinity</c>) during the wait.
-	  <c><anno>WaitTime</anno></c> is an integer representing time to wait
-	  in milliseconds or the atom <c>infinity</c> which will cause
-	  <c>wait_response/2</c> to wait for a response until it appears
-	  regardless of how long time that is.
+	  <seemfa marker="#check_response/2"><c>check_response/2</c></seemfa>,
+	  <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+	  or <c>wait_response()</c>.
 	</p>
 	<p>
-	  The call <c>erpc:wait_response(<anno>RequestId</anno>)</c> is equivalent
-	  to the call <c>erpc:wait_response(<anno>RequestId</anno>, 0)</c>. That is,
-	  poll for a response message to a <c>call</c> request previously made by
-	  the calling process.
-	</p>
-	<p>
-	  If no response is received before <c><anno>WaitTime</anno></c> milliseconds,
-	  the atom <c>no_response</c> is returned. It is valid to continue waiting
-	  for a response as many times as needed up until a response has
-	  been received and completed by <c>erpc:check_response()</c>,
-	  <c>erpc:receive_response()</c>, or <c>erpc:wait_response()</c>. If a
-	  response is received, the <c>call</c> operation is completed and either
-	  the result is returned as <c>{response, Result}</c> where <c>Result</c>
-	  corresponds to the value returned from the applied function or an
-	  exception is raised. The exceptions that can be raised corresponds to the
-	  same exceptions as can be raised by
-	  <seemfa marker="#call/4"><c>erpc:call/4</c></seemfa>.
+          <c><anno>WaitTime</anno></c> sets an upper time limit on how long to wait
+          for a response. If no response is received before the
+          <c><anno>WaitTime</anno></c> timeout has triggered, the atom
+          <c>no_response</c> is returned. It is valid to continue waiting for a
+          response as many times as needed up until a response has been received
+          and completed by <c>check_response()</c>, <c>receive_response()</c>, or
+          <c>wait_response()</c>. If a response is received, the <c>call</c>
+          operation is completed and either the result is returned as
+          <c>{response, Result}</c> where <c>Result</c> corresponds to the value
+          returned from the applied function or an exception is raised. The
+          exceptions that can be raised corresponds to the same exceptions as can
+          be raised by <seemfa marker="#call/4"><c>call/4</c></seemfa>.
 	  That is, no <c>{erpc, timeout}</c> <c>error</c> exception can be raised.
-	  <c>erpc:wait_response()</c> will fail with an <c>{erpc, badarg}</c>
+	  <c>wait_response/2</c> will fail with an <c>{erpc, badarg}</c>
 	  exception if/when an invalid <c><anno>RequestId</anno></c> is detected
 	  or if an invalid <c><anno>WaitTime</anno></c> is passed.
 	</p>
@@ -690,6 +1078,87 @@ my_call(Node, Module, Function, Args, Timeout) ->
       </desc>
     </func>
 
+    <func>
+      <name name="wait_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Wait or poll for a call response corresponding to a previously
+      sent call request.</fsummary>
+      <desc>
+        <p>
+	  Wait or poll for a response to a <c>call</c> request corresponding
+          to a request identifier saved in <c><anno>RequestIdCollection</anno></c>. All
+          request identifiers of <c><anno>RequestIdCollection</anno></c> must
+          correspond to requests that have been made using
+	  <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa> or
+	  <seemfa marker="#send_request/6"><c>send_request/6</c></seemfa>,
+          and all requests must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          <c><anno>Label</anno></c> is the label associated with the request
+          identifier of the request that the response corresponds to.
+          A request identifier is associated with a label when
+          <seemfa marker="#reqids_add/3">adding a request identifier</seemfa>
+          in a <seetype marker="#request_id_collection">request identifier
+          collection</seetype>, or when sending the request using
+          <seemfa marker="#send_request/6"><c>send_request/6</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>wait_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewRequestIdCollection</anno></c> is a possibly  modified
+          request identifier collection. The <c>error</c> exception <c>{erpc,
+          badarg}</c> is not associated with any specific request identifier,
+          and will hence not be wrapped.
+        </p>
+        <p>
+          If <c><anno>RequestIdCollection</anno></c> is empty, <c>no_request</c>
+          will be returned. If no response is received before the
+          <c><anno>WaitTime</anno></c> timeout has triggered, the atom
+          <c>no_response</c> is returned. It is valid to continue waiting for a
+          response as many times as needed up until a response has been received
+          and completed by <c>check_response()</c>, <c>receive_response()</c>,
+          or <c>wait_response()</c>. The difference between
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>
+	  and <c>wait_response/3</c> is that <c>receive_response/3</c>
+	  abandons requests at timeout so that any potential future
+	  responses are ignored, while <c>wait_response/3</c> does not.
+        </p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>RequestIdCollection</anno></c> in the resulting
+          <c><anno>NewRequestIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewRequestIdCollection</anno></c> will equal
+          <c><anno>RequestIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>wait_response/3</c>,
+ 	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>wait_response/3</c>, it will always block
+          until a timeout determined by <c><anno>WaitTime</anno></c> is
+          triggered and then return <c>no_response</c>.
+        </p>
+        <p>
+          Note that a response might have been consumed uppon an <c>{erpc,
+          badarg}</c> exception and if so, will be lost for ever.
+        </p>
+      </desc>
+    </func>
+    
   </funcs>
 </erlref>
 

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -119,24 +119,89 @@ gen_event:stop             ----->  Module:terminate/2
     <datatype>
       <name name="handler"/>
     </datatype>
+
     <datatype>
       <name name="handler_args"/>
     </datatype>
+
     <datatype>
       <name name="add_handler_ret"/>
     </datatype>
+
     <datatype>
       <name name="del_handler_ret"/>
     </datatype>
+
+    <datatype>
+      <name name="emgr_ref"/>
+    </datatype>    
+    
     <datatype>
       <name name="request_id"/>
       <desc>
 	<p>
-	  A request handle, see <seemfa marker="#send_request/3"> <c>send_request/3</c> </seemfa>
+	  An opaque request identifier. See
+          <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
 	  for details.
 	</p>
       </desc>
     </datatype>
+
+    <datatype>
+      <name name="request_id_collection"/>
+      <desc>
+        <p>
+	  An opaque collection of request identifiers
+          (<seetype marker="#request_id"><c>request_id()</c></seetype>)
+	  where each request identifier can be associated with a label
+          chosen by the user. For more information see
+          <seemfa marker="#reqids_new/0"><c>reqids_new/0</c></seemfa>.
+	</p>
+      </desc>
+    </datatype>
+
+    <datatype>
+      <name name="response_timeout"/>
+      <desc>
+        <p>
+          Used to set a time limit on how long to wait for a response using
+          either 
+          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
+          or
+          <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          The time unit used is <c>millisecond</c>. Currently valid values:
+        </p>
+        <taglist>
+          <tag><c>0..4294967295</c></tag>
+          <item><p>
+            Timeout relative to current time in milliseconds.
+          </p></item>
+          <tag><c>infinity</c></tag>
+          <item><p>
+            Infinite timeout. That is, the operation will never time out.
+          </p></item>
+          <tag><c>{abs, Timeout}</c></tag>
+          <item><p>
+            An absolute
+            <seemfa marker="erts:erlang#monotonic_time/1">Erlang monotonic time</seemfa>
+            timeout in milliseconds. That is, the operation will time out when
+            <seemfa marker="erts:erlang#monotonic_time/1"><c>erlang:monotonic_time(millisecond)</c></seemfa>
+            returns a value larger than or equal to <c>Timeout</c>. <c>Timeout</c>
+            is not allowed to identify a time further into the future than <c>4294967295</c>
+            milliseconds. Identifying the timeout using an absolute timeout value
+            is especially handy when you have a deadline for responses corresponding
+            to a complete collection of requests
+            (<seetype marker="#request_id_collection"><c>request_id_collection()</c></seetype>)
+,
+            since you do not have to recalculate the relative time until the deadline
+            over and over again.
+	  </p></item>
+        </taglist>
+      </desc>
+    </datatype>
+
   </datatypes>
 
   <funcs>
@@ -312,28 +377,24 @@ gen_event:stop             ----->  Module:terminate/2
       </desc>
     </func>
 
-
     <func>
-      <name since="OTP 23.0">check_response(Msg, RequestId) -> Result</name>
-      <fsummary>Check if a message is a reply from a server.</fsummary>
-      <type>
-	<v>Msg = term()</v>
-	<v>RequestId = request_id()</v>
-	<v>Result = {reply, Reply} | no_reply | {error, Error}</v>
-	<v>Reply = Error = term()</v>
-      </type>
+      <name name="check_response" arity="2" since="OTP 23.0"/>
+      <fsummary>Check if a message is a response to an asynchronous call request
+      to a generic event manager.</fsummary>
       <desc>
 	<p>
-	  This function is used to check if a previously received
-	  message, for example by <c>receive</c> or
-	  <c>handle_info/2</c>, is a result of a request made with
+	  Check if <c><anno>Msg</anno></c> is a response corresponding
+          to the request identifier <c><anno>ReqId</anno></c>. The request
+          must have been made by
 	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>.
-	  If <c>Msg</c> is a reply to the handle <c>RequestId</c>
-	  the result of the request is returned in <c>Reply</c>.
-	  Otherwise returns <c>no_reply</c> and no cleanup is done, and
-	  thus the function shall be invoked repeatedly until a reply
-	  is returned.
 	</p>
+        <p>
+          If <c><anno>Msg</anno></c> is a response corresponding to
+          <c><anno>ReqId</anno></c> the response is returned; otherwise,
+          <c>no_reply</c> is returned and no cleanup is done, and
+	  thus the function must be invoked repeatedly until a response
+	  is returned.
+        </p>
 	<p>
 	  If the specified event handler is not
           installed, the function returns <c>{error,bad_module}</c>. If
@@ -343,6 +404,74 @@ gen_event:stop             ----->  Module:terminate/2
           respectively. If the event manager dies before or during the
 	  request this function returns <c>{error,{Reason, EventMgrRef}}</c>.
 	</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="check_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Check if a message is a response to an asynchronous call request
+      to a generic event manager.</fsummary>
+      <desc>
+	<p>
+	  Check if <c><anno>Msg</anno></c> is a response corresponding
+          to a request identifier saved in <c><anno>ReqIdCollection</anno></c>.
+          All request identifiers of <c><anno>ReqIdCollection</anno></c>
+          must correspond to requests that have been made using
+	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa> or
+          <seemfa marker="#send_request/5"><c>send_request/5</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">saving the request id</seemfa>
+          in a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/5"><c>send_request/5</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#check_response/2"><c>check_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>check_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly  modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, the atom
+          <c>no_request</c> will be returned. If <c><anno>Msg</anno></c>
+          does not correspond to any of the request identifiers in
+          <c><anno>ReqIdCollection</anno></c>, the atom
+          <c>no_reply</c> is returned.
+        </p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>check_response/3</c>,
+ 	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>check_response/3</c>, it will always
+          return <c>no_reply</c>.
+        </p>
       </desc>
     </func>
 
@@ -409,34 +538,29 @@ gen_event:stop             ----->  Module:terminate/2
           does not exist, unless it is specified as <c>Name</c>.</p>
       </desc>
     </func>
-
+    
     <func>
-      <name since="OTP 24.0">receive_response(RequestId, Timeout) -> Result</name>
-      <fsummary>Receive for a reply from a server.</fsummary>
-      <type>
-	<v>RequestId = request_id()</v>
-	<v>Reply = term()</v>
-	<v>Timeout = timeout()</v>
-	<v>Result = {reply, Reply} | timeout | {error, Error}</v>
-	<v>Reply = Error = term()</v>
-      </type>
+      <name name="receive_response" arity="2" clause_i="1" since="OTP 24.0"/>
+      <fsummary>Receive a response to an asynchronous call request
+      to a generic event manager.</fsummary>
       <desc>
 	<p>
-	This function is used to receive for a reply of a request made with
-	<seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
-	to the event manager. This function must be called from the same
-	process from which <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
-	was made.
+	  Receive a response corresponding to the request identifier
+          <c><anno>ReqId</anno></c>- The request must have been made by
+	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
+	  to the <c>gen_statem</c> process. This function must be called
+	  from the same process from which
+	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
+	  was made.
 	</p>
 	<p>
-	  <c>Timeout</c> is an integer greater then or equal to zero
-	  that specifies how many milliseconds to wait for an reply, or
-	  the atom <c>infinity</c> to wait indefinitely.
-	  If no reply is received within the specified
-	  time, the function returns <c>timeout</c>. Assuming that the
+	  <c><anno>Timeout</anno></c> specifies how long to wait for
+          a response. If no response is received within the specified time,
+          the function returns <c>timeout</c>. Assuming that the
 	  server executes on a node supporting aliases (introduced in
-	  OTP 24) no response will be received after a timeout. Otherwise,
-	  a garbage response might be received at a later time.
+	  OTP 24) the request will also be abandoned. That is, no
+          response will be received after a timeout. Otherwise, a
+          stray response might be received at a later time.
 	</p>
 	<p>
 	  The return value <c>Reply</c> is defined in the return value
@@ -453,44 +577,197 @@ gen_event:stop             ----->  Module:terminate/2
 	</p>
 	<p>
 	  The difference between
-	  <seemfa marker="#wait_response/2"><c>wait_response()</c></seemfa>
-	  and <c>receive_response()</c> is that <c>receive_response()</c>
+	  <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>
+	  and <c>receive_response/2</c> is that <c>receive_response/2</c>
 	  abandons the request at timeout so that a potential future
-	  response is ignored, while <c>wait_response()</c> does not.
+	  response is ignored, while <c>wait_response/2</c> does not.
 	</p>
       </desc>
     </func>
 
     <func>
-      <name since="OTP 23.0">send_request(EventMgrRef, Handler, Request) -> RequestId</name>
-      <fsummary>Send a request to a generic event manager.</fsummary>
-      <type>
-        <v>EventMgrRef = Name | {Name,Node} | {global,GlobalName}</v>
-        <v>&nbsp;&nbsp;| {via,Module,ViaName} | pid()</v>
-        <v>&nbsp;Node = atom()</v>
-        <v>&nbsp;GlobalName = ViaName = term()</v>
-	<v>Handler = Module | {Module,Id}</v>
-        <v>&nbsp;Module = atom()</v>
-        <v>&nbsp;Id = term()</v>
-        <v>Request = term()</v>
-        <v>RequestId = request_id()</v>
-      </type>
+      <name name="receive_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Receive a response to an asynchronous call request
+      to a generic event manager.</fsummary>
       <desc>
+	<p>
+	  Receive a response corresponding to a request identifier saved
+          in <c><anno>ReqIdCollection</anno></c>. All request identifiers
+          of <c><anno>ReqIdCollection</anno></c> must correspond to requests
+          that have been made using
+	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa> or
+          <seemfa marker="#send_request/5"><c>send_request/5</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
         <p>
-	  Sends a request to event handler <c>Handler</c> installed in
-	  event manager <c>EventMgrRef</c> and returns a handle
-	  <c>RequestId</c>.  The return value <c>RequestId</c> shall
-	  later be used with <seemfa marker="#receive_response/2">
-	  <c>receive_response/2</c></seemfa>, <seemfa marker="#wait_response/2">
-	  <c>wait_response/2</c></seemfa>, or <seemfa
-	  marker="#check_response/2">
-	  <c>check_response/2</c></seemfa> in the same process to
-	  fetch the actual result of the request.
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">adding the request id</seemfa>
+          in a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/5"><c>send_request/5</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          will be wrapped in a 3-tuple. The first element of this tuple equals
+          the value that would have been produced by <c>receive_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, the atom
+          <c>no_request</c> will be returned.
+        </p>
+	<p>
+	  <c><anno>Timeout</anno></c> specifies how long to wait for
+          a response. If no response is received within the specified time,
+          the function returns <c>timeout</c>. Assuming that the
+	  server executes on a node supporting aliases (introduced in
+	  OTP 24) all requests identified by <c><anno>ReqIdCollection</anno></c>
+          will also be abandoned. That is, no responses will be received
+          after a timeout. Otherwise, stray responses might be received
+          at a later time.
 	</p>
 	<p>
-	  The call <c>gen_event:wait_response(gen_event:send_request(EventMgrRef,Handler,Request), Timeout)</c>
+	  The difference between <c>receive_response/3</c> and
+          <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>
+          is that <c>receive_response/3</c> abandons the requests at timeout
+          so that potential future responses are ignored, while
+          <c>wait_response/3</c> does not.
+	</p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>receive_response/3</c>,
+ 	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>receive_response/3</c>, it will always block
+          until a timeout determined by <c><anno>Timeout</anno></c> is
+          triggered.
+        </p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="reqids_add" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Save a request identifier.</fsummary>
+      <desc>
+	<p>
+          Saves <c><anno>ReqId</anno></c> and associates a <c><anno>Label</anno></c>
+          with the request identifier by adding this information to
+          <c><anno>ReqIdCollection</anno></c> and returning the
+          resulting request identifier collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_new" arity="0" since="OTP @OTP-17784@"/>
+      <fsummary>Create a new empty request identifier collection.</fsummary>
+      <desc>
+	<p>
+          Returns a new empty request identifier collection. A 
+          request identifier collection can be utilized in order
+          the handle multiple outstanding requests.
+        </p>
+        <p>
+          Request identifiers of requests made by
+	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
+          can be saved in a request identifier collection using 
+	  <seemfa marker="#reqids_add/3"><c>reqids_add/3</c></seemfa>.
+          Such a collection of request identifiers can later be used in
+          order to get one response corresponding to a request in the
+          collection by passing the collection as argument to
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>,
+	  or,
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+        </p>
+        <p>
+          <seemfa marker="#reqids_size/1"><c>reqids_size/1</c></seemfa>
+          can be used to determine the amount of request identifiers in a
+          request identifier collection.
+        </p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="reqids_size" arity="1" since="OTP @OTP-17784@"/>
+      <fsummary>Get size of a request identifier collection.</fsummary>
+      <desc>
+	<p>
+          Returns the amount of request identifiers saved in
+          <c><anno>ReqIdCollection</anno></c>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_to_list" arity="1" since="OTP @OTP-17784@"/>
+      <fsummary>List a request identifiers.</fsummary>
+      <desc>
+	<p>
+          Returns a list of <c>{<anno>ReqId</anno>, <anno>Label</anno>}</c>
+          tuples which corresponds to all request identifiers with their
+          associated labels present in the <c><anno>ReqIdCollection</anno></c>
+          collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="send_request" arity="3" since="OTP 23.0"/>
+      <fsummary>Send an asyncronous call request to a generic event manager.</fsummary>
+      <desc>
+        <p>
+          Sends an asynchronous <c>call</c> request <c><anno>Request</anno></c> to
+          event handler <c><anno>Handler</anno></c> installed in the event manager
+          identified by <c><anno>EventMgrRef</anno></c> and returns a request
+          identifier <c>ReqId</c>. The return value <c><anno>ReqId</anno></c>
+          shall later be used with
+          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>, or
+	  <seemfa marker="#check_response/2"><c>check_response/2</c></seemfa>
+	  to fetch the actual result of the request. Besides passing
+          the request identifier directly to these functions, it can also be
+          saved in a request identifier collection using 
+	  <seemfa marker="#reqids_add/3"><c>reqids_add/3</c></seemfa>.
+          Such a collection of request identifiers can later be used in
+          order to get one response corresponding to a request in the
+          collection by passing the collection as argument to
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>, or
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+          If you are about to save the request identifier in a request identifier
+          collection, you may want to consider using
+          <seemfa marker="#send_request/5"><c>send_request/5</c></seemfa>
+          instead.
+	</p>
+	<p>
+	  The call <c>gen_event:receive_response(gen_event:send_request(<anno>EventMgrRef</anno>,
+          <anno>Handler</anno>, <anno>Request</anno>), Timeout)</c>
 	  can be seen as equivalent to
-	  <seemfa marker="#call/3"><c>gen_event:call(EventMgrRef,Handler,Request,Timeout)</c></seemfa>,
+	  <seemfa marker="#call/3"><c>gen_event:call(<anno>EventMgrRef</anno>,
+          <anno>Handler</anno>, <anno>Request</anno>, Timeout)</c></seemfa>,
 	  ignoring the error handling.
 	</p>
 	<p>
@@ -501,6 +778,38 @@ gen_event:stop             ----->  Module:terminate/2
 	  <c>Request</c> is any term that is passed as one of
           the arguments to <c>Module:handle_call/3</c>.
 	</p>
+      </desc>
+    </func>
+
+
+    <func>
+      <name name="send_request" arity="5" since="OTP @OTP-17784@"/>
+      <fsummary>Sends a request to a generic server.</fsummary>
+      <desc>
+	<p>
+          Sends an asynchronous <c>call</c> request <c><anno>Request</anno></c> to
+          event handler <c><anno>Handler</anno></c> installed in the event manager
+          identified by <c><anno>EventMgrRef</anno></c>.
+          The <c><anno>Label</anno></c> will be associated with the request
+          identifier of the operation and added to the returned request
+          identifier collection <c><anno>NewReqIdCollection</anno></c>.
+          The collection can later be used in order to get one response
+          corresponding to a request in the collection by passing the
+          collection as argument to
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>,
+	  or,
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+        </p>
+
+        <p>
+          The same as calling
+          <seemfa marker="#reqids_add/3"><c>gen_event:reqids_add</c></seemfa>(<seemfa
+          marker="#send_request/3"><c>gen_event:send_request</c></seemfa><c>(<anno>EventMgrRef</anno>,
+          <anno>Handler</anno>, <anno>Request</anno>), <anno>Label</anno>,
+          <anno>ReqIdCollection</anno>)</c>, but calling <c>send_request/5</c>
+          is slightly more efficient.
+        </p>
       </desc>
     </func>
 
@@ -742,30 +1051,24 @@ gen_event:stop             ----->  Module:terminate/2
     </func>
 
     <func>
-      <name since="OTP 23.0">wait_response(RequestId, Timeout) -> Result</name>
-      <fsummary>Wait for a reply from a server.</fsummary>
-      <type>
-	<v>RequestId = request_id()</v>
-	<v>Reply = term()</v>
-	<v>Timeout = timeout()</v>
-	<v>Result = {reply, Reply} | timeout | {error, Error}</v>
-	<v>Reply = Error = term()</v>
-      </type>
+      <name name="wait_response" arity="2" since="OTP 23.0"/>
+      <fsummary>Wait or poll for a response to an asynchronous call request
+      to a generic event manager.</fsummary>
       <desc>
 	<p>
-	This function is used to wait for a reply of a request made with
-	<seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
-	to the event manager. This function must be called from the same
-	process from which <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
-	was made.
+	  Wait for a response corresponding to the request identifier
+          <c><anno>ReqId</anno></c>. The request must have been made by
+	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
+	  to the <c>gen_statem</c> process. This function must be called
+	  from the same process from which
+	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa>
+	  was made.
 	</p>
 	<p>
-	  <c>Timeout</c> is an integer greater then or equal to zero
-	  that specifies how many milliseconds to wait for an reply, or
-	  the atom <c>infinity</c> to wait indefinitely.
-	  If no reply is received within the specified
+	  <c><anno>WaitTime</anno></c> specifies how long to wait for
+          a response. If no response is received within the specified
 	  time, the function returns <c>timeout</c> and no cleanup is
-	  done, and thus the function must be invoked repeatedly until a
+	  done, and thus the function can be invoked repeatedly until a
 	  reply is returned.
 	</p>
 	<p>
@@ -783,11 +1086,89 @@ gen_event:stop             ----->  Module:terminate/2
 	</p>
 	<p>
 	  The difference between
-	  <seemfa marker="#receive_response/2"><c>receive_response()</c></seemfa>
-	  and <c>wait_response()</c> is that <c>receive_response()</c>
+	  <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>
+	  and <c>wait_response/2</c> is that <c>receive_response/2</c>
 	  abandons the request at timeout so that a potential future
-	  response is ignored, while <c>wait_response()</c> does not.
+	  response is ignored, while <c>wait_response/2</c> does not.
 	</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="wait_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Wait or poll for a response to an asynchronous call request
+      to a generic event manager.</fsummary>
+      <desc>
+	<p>
+	  Wait for a response corresponding to a request identifier saved
+          in <c><anno>ReqIdCollection</anno></c>. All request identifiers
+          of <c><anno>ReqIdCollection</anno></c> must correspond to requests
+          that have been made using
+	  <seemfa marker="#send_request/3"><c>send_request/3</c></seemfa> or
+          <seemfa marker="#send_request/5"><c>send_request/5</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">saving the request id</seemfa> in
+          a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/5"><c>send_request/5</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>wait_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly  modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, <c>no_request</c>
+          will be returned. If no response is received before the
+          <c><anno>WaitTime</anno></c> timeout has triggered, the atom
+          <c>timeout</c> is returned. It is valid to continue waiting for a
+          response as many times as needed up until a response has been received
+          and completed by <c>check_response()</c>, <c>receive_response()</c>,
+          or <c>wait_response()</c>.
+        </p>
+	<p>
+	  The difference between
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>
+	  and <c>wait_response/3</c> is that <c>receive_response/3</c>
+	  abandons requests at timeout so that a potential future
+	  responses are ignored, while <c>wait_response/3</c> does not.
+	</p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>wait_response/3</c>,
+ 	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>wait_response/3</c>, it will always block
+          until a timeout determined by <c><anno>WaitTime</anno></c> is
+          triggered and then return <c>no_reply</c>.
+        </p>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -412,10 +412,65 @@ gen_server:abcast     -----> Module:handle_cast/2
       <name name="request_id"/>
       <desc>
 	<p>
-	  A request handle, see
-          <seemfa marker="#send_request/2"> <c>send_request/2</c> </seemfa>
+	  An opaque request identifier. See
+          <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>
 	  for details.
 	</p>
+      </desc>
+    </datatype>
+
+    <datatype>
+      <name name="request_id_collection"/>
+      <desc>
+        <p>
+	  An opaque collection of request identifiers
+          (<seetype marker="#request_id"><c>request_id()</c></seetype>)
+	  where each request identifier can be associated with a label
+          chosen by the user. For more information see
+          <seemfa marker="#reqids_new/0"><c>reqids_new/0</c></seemfa>.
+	</p>
+      </desc>
+    </datatype>
+
+    <datatype>
+      <name name="response_timeout"/>
+      <desc>
+        <p>
+          Used to set a time limit on how long to wait for a response using
+          either 
+          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
+          or
+          <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          The time unit used is <c>millisecond</c>. Currently valid values:
+        </p>
+        <taglist>
+          <tag><c>0..4294967295</c></tag>
+          <item><p>
+            Timeout relative to current time in milliseconds.
+          </p></item>
+          <tag><c>infinity</c></tag>
+          <item><p>
+            Infinite timeout. That is, the operation will never time out.
+          </p></item>
+          <tag><c>{abs, Timeout}</c></tag>
+          <item><p>
+            An absolute
+            <seemfa marker="erts:erlang#monotonic_time/1">Erlang monotonic time</seemfa>
+            timeout in milliseconds. That is, the operation will time out when
+            <seemfa marker="erts:erlang#monotonic_time/1"><c>erlang:monotonic_time(millisecond)</c></seemfa>
+            returns a value larger than or equal to <c>Timeout</c>. <c>Timeout</c>
+            is not allowed to identify a time further into the future than <c>4294967295</c>
+            milliseconds. Identifying the timeout using an absolute timeout value
+            is especially handy when you have a deadline for responses corresponding
+            to a complete collection of requests
+            (<seetype marker="#request_id_collection"><c>request_id_collection()</c></seetype>)
+,
+            since you do not have to recalculate the relative time until the deadline
+            over and over again.
+	  </p></item>
+        </taglist>
       </desc>
     </datatype>
   </datatypes>
@@ -607,29 +662,99 @@ gen_server:abcast     -----> Module:handle_cast/2
     </func>
 
     <func>
-      <name name="check_response" arity="2" since="OTP-23"/>
-      <fsummary>Check if a message is a reply from a server.</fsummary>
+      <name name="check_response" arity="2" since="OTP 23.0"/>
+      <fsummary>Check if a message is a response from a server.</fsummary>
       <desc>
 	<p>
-	  This function is used to check if a previously received
-	  message, for example by <c>receive</c> or
-	  <c>handle_info/2</c>, is a result of a request made with
-	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>.
-	  If <c><anno>Msg</anno></c> is a reply
-          to the handle <c><anno>RequestId</anno></c>
-	  the result of the request is returned in <c><anno>Reply</anno></c>.
-	  Otherwise returns <c>no_reply</c> and no cleanup is done, and
-	  thus the function must be invoked repeatedly until a reply
-	  is returned.
+	  Check if <c><anno>Msg</anno></c> is a response corresponding
+          to the request identifier <c><anno>ReqId</anno></c>. The request
+          must have been made by
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>,
+	  and it must have been made by the same process calling
+          this function.
 	</p>
+        <p>
+          If <c><anno>Msg</anno></c> is a response corresponding to
+          <c><anno>ReqId</anno></c> the response is returned; otherwise,
+          <c>no_reply</c> is returned and no cleanup is done, and
+	  thus the function must be invoked repeatedly until a response
+	  is returned.
+        </p>
 	<p>
-	  The return value <c>Reply</c> is passed from the return value
-	  of <c>Module:handle_call/3</c>.
+	  The return value <c><anno>Reply</anno></c> is passed from the
+          return value of <c>Module:handle_call/3</c>.
 	</p>
 	<p>
 	  The function returns an error if the <c>gen_server</c>
-	  dies before or during this request.
+	  died before a reply was sent.
 	</p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="check_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Check if a message is a response from a server.</fsummary>
+      <desc>
+	<p>
+	  Check if <c><anno>Msg</anno></c> is a response corresponding
+          to a request identifier saved in <c><anno>ReqIdCollection</anno></c>.
+          All request identifiers of <c><anno>ReqIdCollection</anno></c>
+          must correspond to requests that have been made using
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa> or
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">saving the request id</seemfa>
+          in a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#check_response/2"><c>check_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>check_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly  modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, the atom
+          <c>no_request</c> will be returned. If <c><anno>Msg</anno></c>
+          does not correspond to any of the request identifiers in
+          <c><anno>ReqIdCollection</anno></c>, the atom
+          <c>no_reply</c> is returned.
+        </p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>check_response/3</c>,
+ 	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>check_response/3</c>, it will always
+          return <c>no_reply</c>.
+        </p>
       </desc>
     </func>
 
@@ -781,45 +906,123 @@ gen_server:abcast     -----> Module:handle_cast/2
 
     <func>
       <name name="receive_response" arity="2" since="OTP 24.0"/>
-      <fsummary>Receive a reply from a server.</fsummary>
+      <fsummary>Receive a response from a server.</fsummary>
       <desc>
 	<p>
-	  This function is used to receive a reply to a request made with
-	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>
-	  to a <c>gen_server</c> process.
-          This function must be called by the same process that called
-	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>.
+	  Receive a response corresponding to the request identifier
+          <c><anno>ReqId</anno></c>. The request must have been made by
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>,
+	  and it must have been made by the same process calling
+          this function.
 	</p>
 	<p>
-	  <c><anno>Timeout</anno></c> is an integer
-          that specifies how many milliseconds
-          to wait for a reply, or the atom <c>infinity</c>
-          to wait indefinitely.
-	  If no reply is received within the specified time,
-          the function returns <c>timeout</c>.
-          If the server executes on a node supporting aliases
-          (introduced in OTP 24) no response will be received
-          after a time-out. Otherwise, a garbage response
-          might be received at a later time.
+	  <c><anno>Timeout</anno></c> specifies how long to wait for
+          a response. If no response is received within the specified time,
+          the function returns <c>timeout</c>. Assuming that the
+	  server executes on a node supporting aliases (introduced in
+	  OTP 24) the request will also be abandoned. That is, no
+          response will be received after a timeout. Otherwise, a
+          stray response might be received at a later time.
 	</p>
 	<p>
-	  A returned <c><anno>Reply</anno></c> is passed from
-          the return value of <c>Module:handle_call/3</c>.
+	  The return value <c><anno>Reply</anno></c> is passed from the
+          return value of <c>Module:handle_call/3</c>.
 	</p>
 	<p>
 	  The function returns an error if the <c>gen_server</c>
-	  dies before or during this request.
+	  died before a reply was sent.
 	</p>
 	<p>
-	  The difference between
-	  <seemfa marker="#wait_response/2"><c>wait_response()</c></seemfa>
-	  and <c>receive_response()</c> is that <c>receive_response()</c>
-	  abandons the request at time-out so that a potential late
-	  response is ignored, while <c>wait_response()</c> does not.
+	  The difference between <c>receive_response/2</c> and
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>
+	  is that <c>receive_response/2</c> abandons the request at
+          timeout so that a potential future response is ignored, while
+          <c>wait_response/2</c> does not.
 	</p>
       </desc>
     </func>
 
+    <func>
+      <name name="receive_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Receive a response from a server.</fsummary>
+      <desc>
+	<p>
+	  Receive a response corresponding to a request identifier saved
+          in <c><anno>ReqIdCollection</anno></c>. All request identifiers
+          of <c><anno>ReqIdCollection</anno></c> must correspond to requests
+          that have been made using
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa> or
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">adding the request id</seemfa>
+          in a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          will be wrapped in a 3-tuple. The first element of this tuple equals
+          the value that would have been produced by <c>receive_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, the atom
+          <c>no_request</c> will be returned.
+        </p>
+	<p>
+	  <c><anno>Timeout</anno></c> specifies how long to wait for
+          a response. If no response is received within the specified time,
+          the function returns <c>timeout</c>. Assuming that the
+	  server executes on a node supporting aliases (introduced in
+	  OTP 24) all requests identified by <c><anno>ReqIdCollection</anno></c>
+          will also be abandoned. That is, no responses will be received
+          after a timeout. Otherwise, stray responses might be received
+          at a later time.
+	</p>
+	<p>
+	  The difference between <c>receive_response/3</c> and
+          <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>
+          is that <c>receive_response/3</c> abandons the requests at timeout
+          so that potential future responses are ignored, while
+          <c>wait_response/3</c> does not.
+	</p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>receive_response/3</c>,
+ 	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>receive_response/3</c>, it will always block
+          until a timeout determined by <c><anno>Timeout</anno></c> is
+          triggered.
+        </p>
+      </desc>
+    </func>
+    
     <func>
       <name name="reply" arity="2" since=""/>
       <fsummary>Send a reply to a client.</fsummary>
@@ -844,28 +1047,104 @@ gen_server:abcast     -----> Module:handle_cast/2
     </func>
 
     <func>
+      <name name="reqids_add" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Save a request identifier.</fsummary>
+      <desc>
+	<p>
+          Saves <c><anno>ReqId</anno></c> and associates a <c><anno>Label</anno></c>
+          with the request identifier by adding this information to
+          <c><anno>ReqIdCollection</anno></c> and returning the
+          resulting request identifier collection.
+        </p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="reqids_new" arity="0" since="OTP @OTP-17784@"/>
+      <fsummary>Create a new empty request identifier collection.</fsummary>
+      <desc>
+	<p>
+          Returns a new empty request identifier collection. A 
+          request identifier collection can be utilized in order
+          the handle multiple outstanding requests.
+        </p>
+        <p>
+          Request identifiers of requests made by
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>
+          can be saved in a request identifier collection using 
+	  <seemfa marker="#reqids_add/3"><c>reqids_add/3</c></seemfa>.
+          Such a collection of request identifiers can later be used in
+          order to get one response corresponding to a request in the
+          collection by passing the collection as argument to
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>,
+	  or,
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+        </p>
+        <p>
+          <seemfa marker="#reqids_size/1"><c>reqids_size/1</c></seemfa>
+          can be used to determine the amount of request identifiers in a
+          request identifier collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_size" arity="1" since="OTP @OTP-17784@"/>
+      <fsummary>Get size of a request identifier collection.</fsummary>
+      <desc>
+	<p>
+          Returns the amount of request identifiers saved in
+          <c><anno>ReqIdCollection</anno></c>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_to_list" arity="1" since="OTP @OTP-17784@"/>
+      <fsummary>List a request identifiers.</fsummary>
+      <desc>
+	<p>
+          Returns a list of <c>{<anno>ReqId</anno>, <anno>Label</anno>}</c>
+          tuples which corresponds to all request identifiers with their
+          associated labels present in the <c><anno>ReqIdCollection</anno></c>
+          collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
       <name name="send_request" arity="2" since="OTP 23.0"/>
       <fsummary>Sends a request to a generic server.</fsummary>
       <desc>
         <p>
-	  Sends a request to the <c><anno>ServerRef</anno></c>
-          of the <c>gen_server</c> process
-          and returns a handle <c><anno>RequestId</anno></c>.
-	  The returned handle shall later be used with
-          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
-          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>, or
-	  <seemfa marker="#check_response/2"><c>check_response/2</c></seemfa>
-	  to fetch the actual result of the request.
+	  Sends an asynchronous <c>call</c> request <c><anno>Request</anno></c>
+          to the <c>gen_server</c> process identified by <c><anno>ServerRef</anno></c>
+          and returns a request identifier <c><anno>ReqId</anno></c>. The return
+          value <c><anno>ReqId</anno></c> shall later be used with
+          <seemfa marker="#receive_response/2"> <c>receive_response/2</c></seemfa>,
+          <seemfa marker="#wait_response/2"> <c>wait_response/2</c></seemfa>, or
+	  <seemfa marker="#check_response/2"> <c>check_response/2</c></seemfa>
+	  to fetch the actual result of the request. Besides passing
+          the request identifier directly to these functions, it can also be
+          saved in a request identifier collection using 
+	  <seemfa marker="#reqids_add/3"><c>reqids_add/3</c></seemfa>.
+          Such a collection of request identifiers can later be used in
+          order to get one response corresponding to a request in the
+          collection by passing the collection as argument to
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>, or
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+          If you are about to save the request identifier in a request identifier
+          collection, you may want to consider using
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>
+          instead.
 	</p>
 	<p>
-	  The call
-          <c>
-            gen_server:wait_response(gen_server:send_request(<anno>ServerRef</anno>,
-            <anno>Request</anno>), Timeout)
-          </c>
-	  can be seen as equivalent to
-	  <seemfa marker="#call/3"><c>gen_server:call(<anno>ServerRef</anno>, <anno>Request</anno>, Timeout)</c></seemfa>,
-	  ignoring the error handling.
+          The call <c>gen_server:receive_response(gen_server:send_request(<anno>ServerRef</anno>,
+          <anno>Request</anno>), Timeout)</c> can be seen as equivalent to
+	  <seemfa marker="#call/3"><c>gen_server:call(<anno>ServerRef</anno>, <anno>Request</anno>,
+          Timeout)</c></seemfa>, ignoring the error handling.
 	</p>
 	<p>
 	  The <c>gen_server</c> process calls
@@ -882,6 +1161,36 @@ gen_server:abcast     -----> Module:handle_cast/2
         <p>
           <c><anno>Request</anno></c> is any term that is passed
           as the first argument to <c>Module:handle_call/3</c>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="send_request" arity="4" since="OTP @OTP-17784@"/>
+      <fsummary>Sends a request to a generic server.</fsummary>
+      <desc>
+	<p>
+          Sends an asynchronous <c>call</c> request <c><anno>Request</anno></c>
+          to the <c>gen_server</c> process identified by <c><anno>ServerRef</anno></c>.
+          The <c><anno>Label</anno></c> will be associated with the request
+          identifier of the operation and added to the returned request
+          identifier collection <c><anno>NewReqIdCollection</anno></c>.
+          The collection can later be used in order to get one response
+          corresponding to a request in the collection by passing the
+          collection as argument to
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>,
+	  or,
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+        </p>
+
+        <p>
+          The same as calling
+          <seemfa marker="#reqids_add/3"><c>gen_server:reqids_add</c></seemfa>(<seemfa
+          marker="#send_request/2"><c>gen_server:send_request</c></seemfa><c>(<anno>ServerRef</anno>,
+          <anno>Request</anno>), <anno>Label</anno>,
+          <anno>ReqIdCollection</anno>)</c>, but calling <c>send_request/4</c>
+          is slightly more efficient.
         </p>
       </desc>
     </func>
@@ -1028,39 +1337,114 @@ gen_server:abcast     -----> Module:handle_cast/2
 
     <func>
       <name name="wait_response" arity="2" since="OTP 23.0"/>
-      <fsummary>Wait for a reply from a server.</fsummary>
+      <fsummary>Wait or poll for a response from a server.</fsummary>
       <desc>
 	<p>
-	  This function is used to wait for a reply of a request made with
-	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>
-	  from the <c>gen_server</c> process.
-          This function must be called from the same process that called
-	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>.
+	  Wait for a response corresponding to the request identifier
+          <c><anno>ReqId</anno></c>. The request must have been made by
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>,
+	  and it must have been made by the same process calling
+          this function.
 	</p>
 	<p>
-	  <c><anno>Timeout</anno></c> is an integer
-	  that specifies how many milliseconds to wait for a reply,
-          or the atom <c>infinity</c> to wait indefinitely.
-	  If no reply is received within the specified time,
-	  the function returns <c>timeout</c> and no cleanup is done;
-          thus the function can be invoked repeatedly until a
+	  <c><anno>WaitTime</anno></c> specifies how long to wait for
+          a reply. If no reply is received within the specified
+	  time, the function returns <c>timeout</c> and no cleanup is
+	  done, and thus the function can be invoked repeatedly until a
 	  reply is returned.
 	</p>
 	<p>
-	  The return value <c><anno>Reply</anno></c> is passed from
-          the return value of <c>Module:handle_call/3</c>.
+	  The return value <c><anno>Reply</anno></c> is passed from the
+          return value of <c>Module:handle_call/3</c>.
 	</p>
 	<p>
 	  The function returns an error if the <c>gen_server</c>
-	  dies before or during this request.
+	  died before a reply was sent.
 	</p>
 	<p>
 	  The difference between
-	  <seemfa marker="#receive_response/2"><c>receive_response()</c></seemfa>
-	  and <c>wait_response()</c> is that <c>receive_response()</c>
+	  <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>
+	  and <c>wait_response/2</c> is that <c>receive_response/2</c>
 	  abandons the request at time-out so that a potential future
-	  response is ignored, while <c>wait_response()</c> does not.
+	  response is ignored, while <c>wait_response/2</c> does not.
 	</p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="wait_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Wait or poll for a response from a server.</fsummary>
+      <desc>
+	<p>
+	  Wait for a response corresponding to a request identifier saved
+          in <c><anno>ReqIdCollection</anno></c>. All request identifiers
+          of <c><anno>ReqIdCollection</anno></c> must correspond to requests
+          that have been made using
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa> or
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">saving the request id</seemfa> in
+          a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>wait_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly  modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, <c>no_request</c>
+          will be returned. If no response is received before the
+          <c><anno>WaitTime</anno></c> timeout has triggered, the atom
+          <c>timeout</c> is returned. It is valid to continue waiting for a
+          response as many times as needed up until a response has been received
+          and completed by <c>check_response()</c>, <c>receive_response()</c>,
+          or <c>wait_response()</c>.
+        </p>
+	<p>
+	  The difference between
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>
+	  and <c>wait_response/3</c> is that <c>receive_response/3</c>
+	  abandons requests at timeout so that a potential future
+	  responses are ignored, while <c>wait_response/3</c> does not.
+	</p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>wait_response/3</c>,
+ 	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>wait_response/3</c>, it will always block
+          until a timeout determined by <c><anno>WaitTime</anno></c> is
+          triggered and then return <c>no_reply</c>.
+        </p>
       </desc>
     </func>
   </funcs>

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -1624,9 +1624,65 @@ handle_event(_, _, State, Data) ->
       <name name="request_id"/>
       <desc>
 	<p>
-	  A request handle, see <seemfa marker="#send_request/2"> <c>send_request/2</c> </seemfa>
+	  An opaque request identifier. See
+          <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>
 	  for details.
 	</p>
+      </desc>
+    </datatype>
+
+    <datatype>
+      <name name="request_id_collection"/>
+      <desc>
+        <p>
+	  An opaque collection of request identifiers
+          (<seetype marker="#request_id"><c>request_id()</c></seetype>)
+	  where each request identifier can be associated with a label
+          chosen by the user. For more information see
+          <seemfa marker="#reqids_new/0"><c>reqids_new/0</c></seemfa>.
+	</p>
+      </desc>
+    </datatype>
+
+    <datatype>
+      <name name="response_timeout"/>
+      <desc>
+        <p>
+          Used to set a time limit on how long to wait for a response using
+          either 
+          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
+          or
+          <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          The time unit used is <c>millisecond</c>. Currently valid values:
+        </p>
+        <taglist>
+          <tag><c>0..4294967295</c></tag>
+          <item><p>
+            Timeout relative to current time in milliseconds.
+          </p></item>
+          <tag><c>infinity</c></tag>
+          <item><p>
+            Infinite timeout. That is, the operation will never time out.
+          </p></item>
+          <tag><c>{abs, Timeout}</c></tag>
+          <item><p>
+            An absolute
+            <seemfa marker="erts:erlang#monotonic_time/1">Erlang monotonic time</seemfa>
+            timeout in milliseconds. That is, the operation will time out when
+            <seemfa marker="erts:erlang#monotonic_time/1"><c>erlang:monotonic_time(millisecond)</c></seemfa>
+            returns a value larger than or equal to <c>Timeout</c>. <c>Timeout</c>
+            is not allowed to identify a time further into the future than <c>4294967295</c>
+            milliseconds. Identifying the timeout using an absolute timeout value
+            is especially handy when you have a deadline for responses corresponding
+            to a complete collection of requests
+            (<seetype marker="#request_id_collection"><c>request_id_collection()</c></seetype>)
+,
+            since you do not have to recalculate the relative time until the deadline
+            over and over again.
+	  </p></item>
+        </taglist>
       </desc>
     </datatype>
   </datatypes>
@@ -1744,15 +1800,15 @@ handle_event(_, _, State, Data) ->
     </func>
 
     <func>
-      <name name="check_response" arity="2" since="OTP-23"/>
+      <name name="check_response" arity="2" since="OTP 23.0"/>
       <fsummary>Check if a message is a reply from a server.</fsummary>
       <desc>
 	<p>
-	  This function is used to check if a previously received
-	  message, for example by <c>receive</c> or
-	  <c>handle_info/2</c>, is a result of a request made with
+	  Check if <c><anno>Msg</anno></c> is a response corresponding
+          to the request identifier <c><anno>ReqId</anno></c>. The request
+          must have been made by
 	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>.
-	  If <c>Msg</c> is a reply to the handle <c>RequestId</c>
+	  If <c>Msg</c> is a reply to the handle <c>ReqId</c>
 	  the result of the request is returned in <c>Reply</c>.
 	  Otherwise returns <c>no_reply</c> and no cleanup is done, and
 	  thus the function shall be invoked repeatedly until a reply
@@ -1771,6 +1827,73 @@ handle_event(_, _, State, Data) ->
 	  The function returns an error if the <c>gen_statem</c>
 	  dies before or during this request.
 	</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="check_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Check if a message is a reply from a server.</fsummary>
+      <desc>
+	<p>
+	  Check if <c><anno>Msg</anno></c> is a response corresponding
+          to a request identifier saved in <c><anno>ReqIdCollection</anno></c>.
+          All request identifiers of <c><anno>ReqIdCollection</anno></c>
+          must correspond to requests that have been made using
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa> or
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">saving the request id</seemfa>
+          in a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#check_response/2"><c>check_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>check_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly  modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, the atom
+          <c>no_request</c> will be returned. If <c><anno>Msg</anno></c>
+          does not correspond to any of the request identifiers in
+          <c><anno>ReqIdCollection</anno></c>, the atom
+          <c>no_reply</c> is returned.
+        </p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>check_response/3</c>,
+ 	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>check_response/3</c>, it will always
+          return <c>no_reply</c>.
+        </p>
       </desc>
     </func>
 
@@ -1871,11 +1994,23 @@ handle_event(_, _, State, Data) ->
 
     <func>
       <name name="receive_response" arity="1" since="OTP 24.0"/>
-      <name name="receive_response" arity="2" since="OTP 24.0"/>
       <fsummary>Receive for a reply from a server.</fsummary>
       <desc>
 	<p>
-	  This function is used to receive for a reply of a request made with
+          The same as calling 
+	  <seemfa marker="#receive_response/2"><c>gen_statem:receive_response(ReqId,
+          infinity)</c></seemfa>.
+        </p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="receive_response" arity="2" clause_i="1" since="OTP 24.0"/>
+      <fsummary>Receive for a reply from a server.</fsummary>
+      <desc>
+	<p>
+	  Receive a response corresponding to the request identifier
+          <c><anno>ReqId</anno></c>- The request must have been made by
 	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>
 	  to the <c>gen_statem</c> process. This function must be called
 	  from the same process from which
@@ -1883,15 +2018,13 @@ handle_event(_, _, State, Data) ->
 	  was made.
 	</p>
 	<p>
-	  <c>Timeout</c> is an integer
-	  that specifies how many milliseconds to wait for an reply, or
-	  the atom <c>infinity</c> to wait indefinitely. Defaults to
-	  <c>infinity</c>.
-	  If no reply is received within the specified
-	  time, the function returns <c>timeout</c>. Assuming that the
+	  <c><anno>Timeout</anno></c> specifies how long to wait for
+          a response. If no response is received within the specified time,
+          the function returns <c>timeout</c>. Assuming that the
 	  server executes on a node supporting aliases (introduced in
-	  OTP 24) no response will be received after a timeout. Otherwise,
-	  a garbage response might be received at a later time.
+	  OTP 24) the request will also be abandoned. That is, no
+          response will be received after a timeout. Otherwise, a
+          stray response might be received at a later time.
 	</p>
 	<p>
 	  The return value <c><anno>Reply</anno></c> is generated when a
@@ -1908,11 +2041,92 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>
 	  The difference between
-	  <seemfa marker="#wait_response/2"><c>wait_response()</c></seemfa>
-	  and <c>receive_response()</c> is that <c>receive_response()</c>
+	  <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>
+	  and <c>receive_response/2</c> is that <c>receive_response/2</c>
 	  abandons the request at timeout so that a potential future
-	  response is ignored, while <c>wait_response()</c> does not.
+	  response is ignored, while <c>wait_response/2</c> does not.
 	</p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="receive_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Receive a response from a server.</fsummary>
+      <desc>
+	<p>
+	  Receive a response corresponding to a request identifier saved
+          in <c><anno>ReqIdCollection</anno></c>. All request identifiers
+          of <c><anno>ReqIdCollection</anno></c> must correspond to requests
+          that have been made using
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa> or
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">adding the request id</seemfa>
+          in a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          will be wrapped in a 3-tuple. The first element of this tuple equals
+          the value that would have been produced by <c>receive_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, the atom
+          <c>no_request</c> will be returned.
+        </p>
+	<p>
+	  <c><anno>Timeout</anno></c> specifies how long to wait for
+          a response. If no response is received within the specified time,
+          the function returns <c>timeout</c>. Assuming that the
+	  server executes on a node supporting aliases (introduced in
+	  OTP 24) all requests identified by <c><anno>ReqIdCollection</anno></c>
+          will also be abandoned. That is, no responses will be received
+          after a timeout. Otherwise, stray responses might be received
+          at a later time.
+	</p>
+	<p>
+	  The difference between <c>receive_response/3</c> and
+          <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>
+          is that <c>receive_response/3</c> abandons the requests at timeout
+          so that potential future responses are ignored, while
+          <c>wait_response/3</c> does not.
+	</p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>receive_response/3</c>,
+ 	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>receive_response/3</c>, it will always block
+          until a timeout determined by <c><anno>Timeout</anno></c> is
+          triggered.
+        </p>
       </desc>
     </func>
 
@@ -1950,20 +2164,98 @@ handle_event(_, _, State, Data) ->
     </func>
 
     <func>
-      <name name="send_request" arity="2" since="OTP-23"/>
+      <name name="reqids_add" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Save a request identifier.</fsummary>
+      <desc>
+	<p>
+          Saves <c><anno>ReqId</anno></c> and associates a <c><anno>Label</anno></c>
+          with the request identifier by adding this information to
+          <c><anno>ReqIdCollection</anno></c> and returning the
+          resulting request identifier collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_new" arity="0" since="OTP @OTP-17784@"/>
+      <fsummary>Create a new empty request identifier collection.</fsummary>
+      <desc>
+	<p>
+          Returns a new empty request identifier collection. A 
+          request identifier collection can be utilized in order
+          the handle multiple outstanding requests.
+        </p>
+        <p>
+          Request identifiers of requests made by
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>
+          can be saved in a request identifier collection using 
+	  <seemfa marker="#reqids_add/3"><c>reqids_add/3</c></seemfa>.
+          Such a collection of request identifiers can later be used in
+          order to get one response corresponding to a request in the
+          collection by passing the collection as argument to
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>,
+	  or,
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+        </p>
+        <p>
+          <seemfa marker="#reqids_size/1"><c>reqids_size/1</c></seemfa>
+          can be used to determine the amount of request identifiers in a
+          request identifier collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_size" arity="1" since="OTP @OTP-17784@"/>
+      <fsummary>Get size of a request identifier collection.</fsummary>
+      <desc>
+	<p>
+          Returns the amount of request identifiers saved in
+          <c><anno>ReqIdCollection</anno></c>.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="reqids_to_list" arity="1" since="OTP @OTP-17784@"/>
+      <fsummary>List a request identifiers.</fsummary>
+      <desc>
+	<p>
+          Returns a list of <c>{<anno>ReqId</anno>, <anno>Label</anno>}</c>
+          tuples which corresponds to all request identifiers with their
+          associated labels present in the <c><anno>ReqIdCollection</anno></c>
+          collection.
+        </p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="send_request" arity="2" since="OTP 23.0"/>
       <fsummary>Send a request to a <c>gen_statem</c>.</fsummary>
       <desc>
         <p>
-	  Sends a request to the <c>gen_statem</c>
-	  <seetype marker="#server_ref"><c><anno>ServerRef</anno></c></seetype>
-	  and returns a handle <c><anno>RequestId</anno></c>.
-	</p>
-	<p>
-	  The return value <c><anno>RequestId</anno></c> shall later be used with
-          <seemfa marker="#receive_response/2"> <c>receive_response/1,2</c></seemfa>,
-          <seemfa marker="#wait_response/2"> <c>wait_response/1,2</c></seemfa>, or
+	  Sends an asynchronous <c>call</c> request <c><anno>Request</anno></c>
+          to the <c>gen_statem</c> process identified by <c><anno>ServerRef</anno></c>
+          and returns a request identifier <c><anno>ReqId</anno></c>. The return
+          value <c><anno>ReqId</anno></c> shall later be used with
+          <seemfa marker="#receive_response/2"> <c>receive_response/2</c></seemfa>,
+          <seemfa marker="#wait_response/2"> <c>wait_response/2</c></seemfa>, or
 	  <seemfa marker="#check_response/2"> <c>check_response/2</c></seemfa>
-	  to fetch the actual result of the request.
+	  to fetch the actual result of the request. Besides passing
+          the request identifier directly to these functions, it can also be
+          saved in a request identifier collection using 
+	  <seemfa marker="#reqids_add/3"><c>reqids_add/3</c></seemfa>.
+          Such a collection of request identifiers can later be used in
+          order to get one response corresponding to a request in the
+          collection by passing the collection as argument to
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>, or
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+          If you are about to save the request identifier in a request identifier
+          collection, you may want to consider using
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>
+          instead.
 	</p>
 	<p>
 	  The call <c>gen_statem:wait_response(gen_statem:send_request(ServerRef,Request), Timeout)</c>
@@ -1990,6 +2282,36 @@ handle_event(_, _, State, Data) ->
 	  <seemfa marker="#wait_response/2"> <c>wait_response/1,2</c></seemfa>, or
 	  <seemfa marker="#check_response/2"> <c>check_response/2</c></seemfa> function.
 	</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="send_request" arity="4" since="OTP @OTP-17784@"/>
+      <fsummary>Sends a request to a generic server.</fsummary>
+      <desc>
+	<p>
+          Sends an asynchronous <c>call</c> request <c><anno>Request</anno></c>
+          to the <c>gen_statem</c> process identified by <c><anno>ServerRef</anno></c>.
+          The <c><anno>Label</anno></c> will be associated with the request
+          identifier of the operation and added to the returned request
+          identifier collection <c><anno>NewReqIdCollection</anno></c>.
+          The collection can later be used in order to get one response
+          corresponding to a request in the collection by passing the
+          collection as argument to
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>,
+	  <seemfa marker="#wait_response/3"><c>wait_response/3</c></seemfa>,
+	  or,
+	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>.
+        </p>
+
+        <p>
+          The same as calling
+          <seemfa marker="#reqids_add/3"><c>gen_statem:reqids_add</c></seemfa>(<seemfa
+          marker="#send_request/2"><c>statem:send_request</c></seemfa><c>(<anno>ServerRef</anno>,
+          <anno>Request</anno>), <anno>Label</anno>,
+          <anno>ReqIdCollection</anno>)</c>, but calling <c>send_request/4</c>
+          is slightly more efficient.
+        </p>
       </desc>
     </func>
 
@@ -2222,12 +2544,24 @@ handle_event(_, _, State, Data) ->
     </func>
 
     <func>
-      <name name="wait_response" arity="1" since="OTP 23.0"/>
-      <name name="wait_response" arity="2" since="OTP 23.0"/>
+      <name name="wait_response" arity="1" clause_i="1" since="OTP 23.0"/>
       <fsummary>Wait for a reply from a server.</fsummary>
       <desc>
 	<p>
-	  This function is used to wait for a reply of a request made with
+          The same as calling 
+	  <seemfa marker="#receive_response/2"><c>gen_statem:receive_response(ReqId,
+          infinity)</c></seemfa>.
+        </p>
+      </desc>
+    </func>
+    
+    <func>
+      <name name="wait_response" arity="2" since="OTP 23.0"/>
+      <fsummary>Wait or poll for a reply from a server.</fsummary>
+      <desc>
+	<p>
+	  Wait for a response corresponding to the request identifier
+          <c><anno>ReqId</anno></c>. The request must have been made by
 	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa>
 	  to the <c>gen_statem</c> process. This function must be called
 	  from the same process from which
@@ -2235,11 +2569,8 @@ handle_event(_, _, State, Data) ->
 	  was made.
 	</p>
 	<p>
-	  <c>Timeout</c> is an integer
-	  that specifies how many milliseconds to wait for an reply, or
-	  the atom <c>infinity</c> to wait indefinitely. Defaults to
-	  <c>infinity</c>.
-	  If no reply is received within the specified
+	  <c><anno>WaitTime</anno></c> specifies how long to wait for
+          a reply. If no reply is received within the specified
 	  time, the function returns <c>timeout</c> and no cleanup is
 	  done, and thus the function can be invoked repeatedly until a
 	  reply is returned.
@@ -2259,11 +2590,88 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>
 	  The difference between
-	  <seemfa marker="#receive_response/2"><c>receive_response()</c></seemfa>
-	  and <c>wait_response()</c> is that <c>receive_response()</c>
+	  <seemfa marker="#receive_response/2"><c>receive_response/2</c></seemfa>
+	  and <c>wait_response/2</c> is that <c>receive_response/2</c>
 	  abandons the request at timeout so that a potential future
-	  response is ignored, while <c>wait_response()</c> does not.
+	  response is ignored, while <c>wait_response/2</c> does not.
 	</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="wait_response" arity="3" since="OTP @OTP-17784@"/>
+      <fsummary>Wait or poll for a response from a server.</fsummary>
+      <desc>
+	<p>
+	  Wait for a response corresponding to a request identifier saved
+          in <c><anno>ReqIdCollection</anno></c>. All request identifiers
+          of <c><anno>ReqIdCollection</anno></c> must correspond to requests
+          that have been made using
+	  <seemfa marker="#send_request/2"><c>send_request/2</c></seemfa> or
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>,
+          and all request must have been made by the process calling this
+          function.
+	</p>
+        <p>
+          The <c><anno>Label</anno></c> in the response equals the
+          <c><anno>Label</anno></c> associated with the request identifier
+          that the response corresponds to. The <c><anno>Label</anno></c>
+          of a request identifier is associated when
+          <seemfa marker="#reqids_add/3">saving the request id</seemfa> in
+          a request identifier collection, or when sending the request using
+          <seemfa marker="#send_request/4"><c>send_request/4</c></seemfa>.
+        </p>
+        <p>
+          Compared to
+          <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
+          the returned result associated with a specific request identifier
+          or an exception associated with a specific request identifier will
+          be wrapped in a 3-tuple. The first element of this tuple equals the
+          value that would have been produced by <c>wait_response/2</c>,
+          the second element equals the <c><anno>Label</anno></c> associated
+          with the specific request identifier, and the third element
+          <c><anno>NewReqIdCollection</anno></c> is a possibly  modified
+          request identifier collection.
+        </p>
+        <p>
+          If <c><anno>ReqIdCollection</anno></c> is empty, <c>no_request</c>
+          will be returned. If no response is received before the
+          <c><anno>WaitTime</anno></c> timeout has triggered, the atom
+          <c>timeout</c> is returned. It is valid to continue waiting for a
+          response as many times as needed up until a response has been received
+          and completed by <c>check_response()</c>, <c>receive_response()</c>,
+          or <c>wait_response()</c>.
+        </p>
+	<p>
+	  The difference between
+          <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>
+	  and <c>wait_response/3</c> is that <c>receive_response/3</c>
+	  abandons requests at timeout so that a potential future
+	  responses are ignored, while <c>wait_response/3</c> does not.
+	</p>
+        <p>
+          If <c><anno>Delete</anno></c> equals <c>true</c>, the association
+          with <c><anno>Label</anno></c> will have been deleted from
+          <c><anno>ReqIdCollection</anno></c> in the resulting
+          <c><anno>NewReqIdCollection</anno></c>. If
+          <c><anno>Delete</anno></c> equals <c>false</c>,
+          <c><anno>NewReqIdCollection</anno></c> will equal
+          <c><anno>ReqIdCollection</anno></c>. Note that deleting an
+          association is not for free and that a collection containing
+          already handled requests can still be used by subsequent calls to
+          <c>wait_response/3</c>,
+ 	  <seemfa marker="#check_response/3"><c>check_response/3</c></seemfa>,
+          and
+	  <seemfa marker="#receive_response/3"><c>receive_response/3</c></seemfa>.
+          However, without deleting handled associations, the above calls will
+          not be able to detect when there are no more outstanding requests to
+          handle, so you will have to keep track of this some other way than
+          relying on a <c>no_request</c> return. Note that if you pass a
+          collection only containing associations of already handled or
+          abandoned requests to <c>wait_response/3</c>, it will always block
+          until a timeout determined by <c><anno>WaitTime</anno></c> is
+          triggered and then return <c>no_reply</c>.
+        </p>
       </desc>
     </func>
   </funcs>

--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -29,23 +29,27 @@
 -export([start/5, start/6, debug_options/2, hibernate_after/1,
 	 name/1, unregister_name/1, get_proc_name/1, get_parent/0,
 	 call/3, call/4, reply/2,
-         send_request/3, wait_response/2,
-         receive_response/2, check_response/2,
+         send_request/3, send_request/5,
+         wait_response/2, receive_response/2, check_response/2,
+         wait_response/3, receive_response/3, check_response/3,
+         reqids_new/0, reqids_size/1,
+         reqids_add/3, reqids_to_list/1,
          stop/1, stop/3]).
 
 -export([init_it/6, init_it/7]).
 
 -export([format_status_header/2, format_status/4]).
 
+-define(MAX_INT_TIMEOUT, 4294967295).
 -define(default_timeout, 5000).
 
 -include("logger.hrl").
 
 %%-----------------------------------------------------------------
 
--export_type(
-   [reply_tag/0,
-    request_id/0]).
+-export_type([reply_tag/0,
+              request_id/0,
+              request_id_collection/0]).
 
 -type linkage()    :: 'monitor' | 'link' | 'nolink'.
 -type emgr_name()  :: {'local', atom()}
@@ -73,6 +77,10 @@
 
 -opaque request_id() :: reference().
 
+-opaque request_id_collection() :: map().
+
+-type response_timeout() ::
+        0..?MAX_INT_TIMEOUT | 'infinity' | {abs, integer()}.
 
 %%-----------------------------------------------------------------
 %% Starts a generic process.
@@ -278,11 +286,12 @@ get_node(Process) ->
 	    node(Process)
     end.
 
--spec send_request(Name::server_ref(), Label::term(), Request::term()) -> request_id().
-send_request(Process, Label, Request) when is_pid(Process) ->
-    do_send_request(Process, Label, Request);
-send_request(Process, Label, Request) ->
-    Fun = fun(Pid) -> do_send_request(Pid, Label, Request) end,
+-spec send_request(Name::server_ref(), Tag::term(), Request::term()) ->
+          request_id().
+send_request(Process, Tag, Request) when is_pid(Process) ->
+    do_send_request(Process, Tag, Request);
+send_request(Process, Tag, Request) ->
+    Fun = fun(Pid) -> do_send_request(Pid, Tag, Request) end,
     try do_for_proc(Process, Fun)
     catch exit:Reason ->
             %% Make send_request async and fake a down message
@@ -291,61 +300,231 @@ send_request(Process, Label, Request) ->
             Mref
     end.
 
+-spec send_request(Name::server_ref(), Tag::term(), Request::term(),
+                   Label::term(), ReqIdCol::request_id_collection()) ->
+          request_id_collection().
+send_request(Process, Tag, Request, Label, ReqIdCol) when is_map(ReqIdCol) ->
+    maps:put(send_request(Process, Tag, Request), Label, ReqIdCol).
+
 -dialyzer({no_improper_lists, do_send_request/3}).
 
-do_send_request(Process, Label, Request) ->
-    Mref = erlang:monitor(process, Process, [{alias, demonitor}]),
-    erlang:send(Process, {Label, {self(), [alias|Mref]}, Request}, [noconnect]),
-    Mref.
+do_send_request(Process, Tag, Request) ->
+    ReqId = erlang:monitor(process, Process, [{alias, demonitor}]),
+    _ = erlang:send(Process, {Tag, {self(), [alias|ReqId]}, Request}, [noconnect]),
+    ReqId.
 
 %%
 %% Wait for a reply to the client.
 %% Note: if timeout is returned monitors are kept.
 
--spec wait_response(RequestId::request_id(), timeout()) ->
-        {reply, Reply::term()} | 'timeout' | {error, {term(), server_ref()}}.
-wait_response(Mref, Timeout) when is_reference(Mref) ->
+-spec wait_response(ReqId, Timeout) -> Result when
+      ReqId :: request_id(),
+      Timeout :: response_timeout(),
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Result :: Resp | 'timeout'.
+
+wait_response(ReqId, Timeout) ->
+    TMO = timeout_value(Timeout),
     receive
-        {[alias|Mref], Reply} ->
-            erlang:demonitor(Mref, [flush]),
+        {[alias|ReqId], Reply} ->
+            erlang:demonitor(ReqId, [flush]),
             {reply, Reply};
-        {'DOWN', Mref, _, Object, Reason} ->
+        {'DOWN', ReqId, _, Object, Reason} ->
             {error, {Reason, Object}}
-    after Timeout ->
+    after TMO ->
             timeout
     end.
 
--spec receive_response(RequestId::request_id(), timeout()) ->
-        {reply, Reply::term()} | 'timeout' | {error, {term(), server_ref()}}.
-receive_response(Mref, Timeout) when is_reference(Mref) ->
+-spec wait_response(ReqIdCol, Timeout, Delete) -> Result when
+      ReqIdCol :: request_id_collection(),
+      Timeout :: response_timeout(),
+      Delete :: boolean(),
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Result :: {Resp, Label::term(), NewReqIdCol::request_id_collection()} |
+                'no_request' | 'timeout'.
+
+wait_response(ReqIdCol, Timeout, Delete) when map_size(ReqIdCol) == 0,
+                                              is_boolean(Delete) ->
+    _ = timeout_value(Timeout),
+    no_request;
+wait_response(ReqIdCol, Timeout, Delete) when is_map(ReqIdCol),
+                                              is_boolean(Delete) ->
+    TMO = timeout_value(Timeout),
     receive
-        {[alias|Mref], Reply} ->
-            erlang:demonitor(Mref, [flush]),
+        {[alias|ReqId], _} = Msg when is_map_key(ReqId, ReqIdCol) ->
+            collection_result(Msg, ReqIdCol, Delete);
+        {'DOWN', ReqId, _, _, _} = Msg when is_map_key(ReqId, ReqIdCol) ->
+            collection_result(Msg, ReqIdCol, Delete)
+    after TMO ->
+            timeout
+    end.
+
+-spec receive_response(ReqId, Timeout) -> Result when
+      ReqId :: request_id(),
+      Timeout :: response_timeout(),
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Result :: Resp | 'timeout'.
+
+receive_response(ReqId, Timeout) ->
+    TMO = timeout_value(Timeout),
+    receive
+        {[alias|ReqId], Reply} ->
+            erlang:demonitor(ReqId, [flush]),
             {reply, Reply};
-        {'DOWN', Mref, _, Object, Reason} ->
+        {'DOWN', ReqId, _, Object, Reason} ->
             {error, {Reason, Object}}
-    after Timeout ->
-            erlang:demonitor(Mref, [flush]),
+    after TMO ->
+            erlang:demonitor(ReqId, [flush]),
             receive
-                {[alias|Mref], Reply} ->
+                {[alias|ReqId], Reply} ->
                     {reply, Reply}
             after 0 ->
                     timeout
             end
     end.
 
--spec check_response(RequestId::term(), Key::request_id()) ->
-        {reply, Reply::term()} | 'no_reply' | {error, {term(), server_ref()}}.
-check_response(Msg, Mref) when is_reference(Mref) ->
+-spec receive_response(ReqIdCol, Timeout, Delete) -> Result when
+      ReqIdCol :: request_id_collection(),
+      Timeout :: response_timeout(),
+      Delete :: boolean(),
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Result :: {Resp, Label::term(), NewReqIdCol::request_id_collection()}
+              | 'no_request' | 'timeout'.
+
+receive_response(ReqIdCol, Timeout, Delete) when map_size(ReqIdCol) == 0,
+                                                 is_boolean(Delete) ->
+    _ = timeout_value(Timeout),
+    no_request;
+receive_response(ReqIdCol, Timeout, Delete) when is_map(ReqIdCol),
+                                                 is_boolean(Delete) ->
+    TMO = timeout_value(Timeout),
+    receive
+        {[alias|ReqId], _} = Msg when is_map_key(ReqId, ReqIdCol) ->
+            collection_result(Msg, ReqIdCol, Delete);
+        {'DOWN', Mref, _, _, _} = Msg when is_map_key(Mref, ReqIdCol) ->
+            collection_result(Msg, ReqIdCol, Delete)
+    after TMO ->
+            maps:foreach(fun (ReqId, _Label) when is_reference(ReqId) ->
+                                 erlang:demonitor(ReqId, [flush]);
+                             (_, _) ->
+                                 error(badarg)
+                         end, ReqIdCol),
+            flush_responses(ReqIdCol),
+            timeout
+    end.
+
+-spec check_response(Msg::term(), ReqIdOrReqIdCol) -> Result when
+      ReqIdOrReqIdCol :: request_id() | request_id_collection(),
+      ReqIdResp :: {reply, Reply::term()} |
+                   {error, {Reason::term(), server_ref()}},
+      ReqIdColResp :: {{reply, Reply::term()}, Label::term()} |
+                             {{error, {Reason::term(), server_ref()}}, Label::term()},
+      Result :: ReqIdResp | ReqIdColResp | 'no_reply'.
+
+check_response(Msg, ReqId) when is_reference(ReqId) ->
     case Msg of
-        {[alias|Mref], Reply} ->
-            erlang:demonitor(Mref, [flush]),
+        {[alias|ReqId], Reply} ->
+            erlang:demonitor(ReqId, [flush]),
             {reply, Reply};
-        {'DOWN', Mref, _, Object, Reason} ->
+        {'DOWN', ReqId, _, Object, Reason} ->
             {error, {Reason, Object}};
         _ ->
             no_reply
+    end;
+check_response(_, _) ->
+    error(badarg).
+
+-spec check_response(Msg, ReqIdCol, Delete) -> Result when
+      Msg :: term(),
+      ReqIdCol :: request_id_collection(),
+      Delete :: boolean(),
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Result :: {Resp, Label::term(), NewReqIdCol::request_id_collection()}
+              | 'no_request' | 'no_reply'.
+
+check_response(_Msg, ReqIdCol, Delete) when map_size(ReqIdCol) == 0,
+                                            is_boolean(Delete) ->
+    no_request;
+check_response(Msg, ReqIdCol, Delete) when is_map(ReqIdCol),
+                                           is_boolean(Delete) ->
+    case Msg of
+        {[alias|ReqId], _} = Msg when is_map_key(ReqId, ReqIdCol) ->
+            collection_result(Msg, ReqIdCol, Delete);
+        {'DOWN', Mref, _, _, _} = Msg when is_map_key(Mref, ReqIdCol) ->
+            collection_result(Msg, ReqIdCol, Delete);
+        _ ->
+            no_reply
     end.
+
+collection_result({[alias|ReqId], Reply}, ReqIdCol, Delete) ->
+    _ = erlang:demonitor(ReqId, [flush]),
+    collection_result({reply, Reply}, ReqId, ReqIdCol, Delete);
+collection_result({'DOWN', ReqId, _, Object, Reason}, ReqIdCol, Delete) ->
+    collection_result({error, {Reason, Object}}, ReqId, ReqIdCol, Delete).
+
+collection_result(Resp, ReqId, ReqIdCol, false) ->
+    {Resp, maps:get(ReqId, ReqIdCol), ReqIdCol};
+collection_result(Resp, ReqId, ReqIdCol, true) ->
+    {Label, NewReqIdCol} = maps:take(ReqId, ReqIdCol),
+    {Resp, Label, NewReqIdCol}.
+
+flush_responses(ReqIdCol) ->
+    receive
+        {[alias|Mref], _Reply} when is_map_key(Mref, ReqIdCol) ->
+            flush_responses(ReqIdCol)
+    after 0 ->
+            ok
+    end.
+
+timeout_value(infinity) ->
+    infinity;
+timeout_value(Timeout) when 0 =< Timeout, Timeout =< ?MAX_INT_TIMEOUT ->
+    Timeout;
+timeout_value({abs, Timeout}) when is_integer(Timeout) ->
+    case Timeout - erlang:monotonic_time(millisecond) of
+        TMO when TMO < 0 ->
+            0;
+        TMO when TMO > ?MAX_INT_TIMEOUT ->
+            error(badarg);
+        TMO ->
+            TMO
+    end;
+timeout_value(_) ->
+    error(badarg).
+
+-spec reqids_new() ->
+          NewReqIdCol::request_id_collection().
+
+reqids_new() ->
+    maps:new().
+
+-spec reqids_size(request_id_collection()) ->
+          non_neg_integer().
+reqids_size(ReqIdCol) when is_map(ReqIdCol) ->
+    maps:size(ReqIdCol);
+reqids_size(_) ->
+    error(badarg).
+
+-spec reqids_add(ReqId::request_id(), Label::term(),
+                 ReqIdCol::request_id_collection()) ->
+          NewReqIdCol::request_id_collection().
+
+reqids_add(ReqId, _, ReqIdCol) when is_reference(ReqId),
+                                    is_map_key(ReqId, ReqIdCol) ->
+    error(badarg);
+reqids_add(ReqId, Label, ReqIdCol) when is_reference(ReqId),
+                                        is_map(ReqIdCol) ->
+    maps:put(ReqId, Label, ReqIdCol);
+reqids_add(_, _, _) ->
+    error(badarg).
+
+-spec reqids_to_list(ReqIdCol::request_id_collection()) ->
+          [{ReqId::request_id(), Label::term()}].
+
+reqids_to_list(ReqIdCol) when is_map(ReqIdCol) ->
+    maps:to_list(ReqIdCol);
+reqids_to_list(_) ->
+    error(badarg).
 
 %%
 %% Send a reply to the client.

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -97,8 +97,11 @@
          start_monitor/3, start_monitor/4,
 	 stop/1, stop/3,
 	 call/2, call/3,
-         send_request/2, wait_response/2,
-         receive_response/2, check_response/2,
+         send_request/2, send_request/4,
+         wait_response/2, receive_response/2, check_response/2,
+         wait_response/3, receive_response/3, check_response/3,
+         reqids_new/0, reqids_size/1,
+         reqids_add/3, reqids_to_list/1,
 	 cast/2, reply/2,
 	 abcast/2, abcast/3,
 	 multi_call/2, multi_call/3, multi_call/4,
@@ -123,7 +126,8 @@
 -export_type(
    [from/0,
     reply_tag/0,
-    request_id/0]).
+    request_id/0,
+    request_id_collection/0]).
 
 -export_type(
    [server_name/0,
@@ -194,6 +198,11 @@
 -opaque reply_tag() :: gen:reply_tag().
 
 -opaque request_id() :: gen:request_id().
+
+-opaque request_id_collection() :: gen:request_id_collection().
+
+-type response_timeout() ::
+        timeout() | {abs, integer()}.
 
 %%%  -----------------------------------------------------------------
 %%% Starts a generic server.
@@ -373,45 +382,172 @@ call(ServerRef, Request, Timeout) ->
 %% used with wait_response/2 or check_response/2 to fetch the
 %% result of the request.
 
--spec send_request(
-        ServerRef :: server_ref(),
-        Request   :: term()
-       ) ->
-                          RequestId :: request_id().
+-spec send_request(ServerRef::server_ref(), Request::term()) ->
+          ReqId::request_id().
+
 send_request(ServerRef, Request) ->
-    gen:send_request(ServerRef, '$gen_call', Request).
+    try
+        gen:send_request(ServerRef, '$gen_call', Request)
+    catch
+        error:badarg ->
+            error(badarg, [ServerRef, Request])
+    end.
 
--spec wait_response(
-        RequestId :: request_id(),
-        Timeout   :: timeout()) ->
-                           {reply, Reply :: term()} |
-                           'timeout' |
-                           {error,
-                            {Reason :: term(), ServerRef :: server_ref()}}.
-wait_response(RequestId, Timeout) ->
-    gen:wait_response(RequestId, Timeout).
+-spec send_request(ServerRef::server_ref(),
+                   Request::term(),
+                   Label::term(),
+                   ReqIdCollection::request_id_collection()) ->
+          NewReqIdCollection::request_id_collection().
 
--spec receive_response(
-        RequestId :: request_id(),
-        Timeout   :: timeout()
-       ) ->
-                              {reply, Reply :: term()} |
-                              'timeout' |
-                              {error,
-                               {Reason :: term(), ServerRef :: server_ref()}}.
-receive_response(RequestId, Timeout) ->
-    gen:receive_response(RequestId, Timeout).
+send_request(ServerRef, Request, Label, ReqIdCol) ->
+    try
+        gen:send_request(ServerRef, '$gen_call', Request, Label, ReqIdCol)
+    catch
+        error:badarg ->
+            error(badarg, [ServerRef, Request, Label, ReqIdCol])
+    end.
 
--spec check_response(
-        Msg       :: term(),
-        RequestId :: request_id()
-       ) ->
-                            {reply, Reply :: term()} |
-                            'no_reply' |
-                            {error,
-                             {Reason :: term(), ServerRef :: server_ref()}}.
-check_response(Msg, RequestId) ->
-    gen:check_response(Msg, RequestId).
+-spec wait_response(ReqId, WaitTime) -> Result when
+      ReqId :: request_id(),
+      WaitTime :: response_timeout(),
+      Response :: {reply, Reply::term()}
+                | {error, {Reason::term(), server_ref()}},
+      Result :: Response | 'timeout'.
+
+wait_response(ReqId, WaitTime) ->
+    try
+        gen:wait_response(ReqId, WaitTime)
+    catch
+        error:badarg ->
+            error(badarg, [ReqId, WaitTime])
+    end.
+
+-spec wait_response(ReqIdCollection, WaitTime, Delete) -> Result when
+      ReqIdCollection :: request_id_collection(),
+      WaitTime :: response_timeout(),
+      Delete :: boolean(),
+      Response :: {reply, Reply::term()} |
+                  {error, {Reason::term(), server_ref()}},
+      Result :: {Response,
+                 Label::term(),
+                 NewReqIdCollection::request_id_collection()} |
+                'no_request' |
+                'timeout'.
+
+wait_response(ReqIdCol, WaitTime, Delete) ->
+    try
+        gen:wait_response(ReqIdCol, WaitTime, Delete)
+    catch
+        error:badarg ->
+            error(badarg, [ReqIdCol, WaitTime, Delete])
+    end.
+
+-spec receive_response(ReqId, Timeout) -> Result when
+      ReqId :: request_id(),
+      Timeout :: response_timeout(),
+      Response :: {reply, Reply::term()} |
+                  {error, {Reason::term(), server_ref()}},
+      Result :: Response | 'timeout'.
+
+receive_response(ReqId, Timeout) ->
+    try
+        gen:receive_response(ReqId, Timeout)
+    catch
+        error:badarg ->
+            error(badarg, [ReqId, Timeout])
+    end.
+
+-spec receive_response(ReqIdCollection, Timeout, Delete) -> Result when
+      ReqIdCollection :: request_id_collection(),
+      Timeout :: response_timeout(),
+      Delete :: boolean(),
+      Response :: {reply, Reply::term()} |
+                  {error, {Reason::term(), server_ref()}},
+      Result :: {Response,
+                 Label::term(),
+                 NewReqIdCollection::request_id_collection()} |
+                'no_request' |
+                'timeout'.
+
+receive_response(ReqIdCol, Timeout, Delete) ->
+    try
+        gen:receive_response(ReqIdCol, Timeout, Delete)
+    catch
+        error:badarg ->
+            error(badarg, [ReqIdCol, Timeout, Delete])
+    end.
+
+-spec check_response(Msg, ReqId) -> Result when
+      Msg :: term(),
+      ReqId :: request_id(),
+      Response :: {reply, Reply::term()} |
+                  {error, {Reason::term(), server_ref()}},
+      Result :: Response | 'no_reply'.
+
+check_response(Msg, ReqId) ->
+    try
+        gen:check_response(Msg, ReqId)
+    catch
+        error:badarg ->
+            error(badarg, [Msg, ReqId])
+    end.
+
+-spec check_response(Msg, ReqIdCollection, Delete) -> Result when
+      Msg :: term(),
+      ReqIdCollection :: request_id_collection(),
+      Delete :: boolean(),
+      Response :: {reply, Reply::term()} |
+                  {error, {Reason::term(), server_ref()}},
+      Result :: {Response,
+                 Label::term(),
+                 NewReqIdCollection::request_id_collection()} |
+                'no_request' |
+                'no_reply'.
+
+check_response(Msg, ReqIdCol, Delete) ->
+    try
+        gen:check_response(Msg, ReqIdCol, Delete)
+    catch
+        error:badarg ->
+            error(badarg, [Msg, ReqIdCol, Delete])
+    end.
+
+-spec reqids_new() ->
+          NewReqIdCollection::request_id_collection().
+
+reqids_new() ->
+    gen:reqids_new().
+
+-spec reqids_size(ReqIdCollection::request_id_collection()) ->
+          non_neg_integer().
+
+reqids_size(ReqIdCollection) ->
+    try
+        gen:reqids_size(ReqIdCollection)
+    catch
+        error:badarg -> error(badarg, [ReqIdCollection])
+    end.
+
+-spec reqids_add(ReqId::request_id(), Label::term(),
+                 ReqIdCollection::request_id_collection()) ->
+          NewReqIdCollection::request_id_collection().
+
+reqids_add(ReqId, Label, ReqIdCollection) ->
+    try
+        gen:reqids_add(ReqId, Label, ReqIdCollection)
+    catch
+        error:badarg -> error(badarg, [ReqId, Label, ReqIdCollection])
+    end.
+
+-spec reqids_to_list(ReqIdCollection::request_id_collection()) ->
+          [{ReqId::request_id(), Label::term()}].
+
+reqids_to_list(ReqIdCollection) ->
+    try
+        gen:reqids_to_list(ReqIdCollection)
+    catch
+        error:badarg -> error(badarg, [ReqIdCollection])
+    end.
 
 %% -----------------------------------------------------------------
 %% Make a cast to a generic server.

--- a/lib/stdlib/test/dummy_h.erl
+++ b/lib/stdlib/test/dummy_h.erl
@@ -63,6 +63,9 @@ handle_call(hibernate, _State) ->
 handle_call(hibernate_later, _State) ->
     timer:send_after(1000,sleep),
     {ok,later,[]};
+handle_call({delayed_answer, T}, State) ->
+    receive after T -> ok end,
+    {ok, delayed, State};
 handle_call(_Query, State) ->
     {ok, ok, State}.
 


### PR DESCRIPTION
`receive_response()`, `wait_response()`, and `check_response()` in `gen_server`, `gen_statem`, `gen_event`, and `erpc` can now take a collection of request identifiers as argument and handle any responses corresponding to a request identifier in the collection.

* `gen_server` - [`send_request/4`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_server.html#send_request-4), [`receive_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_server.html#receive_response-3), [`wait_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_server.html#wait_response-3), [`check_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_server.html#check_response-3)
* `gen_statem` - [`send_request/4`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_statem.html#send_request-4), [`receive_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_statem.html#receive_response-3), [`wait_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_statem.html#wait_response-3), [`check_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_statem.html#check_response-3)
* `gen_event` - [`send_request/5`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_event.html#send_request-5), [`receive_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_event.html#receive_response-3), [`wait_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_event.html#wait_response-3), [`check_response/3`](https://erlang.github.io/prs/5792/lib/stdlib-3.17.1/doc/html/gen_event.html#check_response-3)
* `erpc` - [`send_request/6`](https://erlang.github.io/prs/5792/lib/kernel-8.3.1/doc/html/erpc.html#send_request-6), [`receive_response/3`](https://erlang.github.io/prs/5792/lib/kernel-8.3.1/doc/html/erpc.html#receive_response-3), [`wait_response/3`](https://erlang.github.io/prs/5792/lib/kernel-8.3.1/doc/html/erpc.html#wait_response-3), [`check_response/3`](https://erlang.github.io/prs/5792/lib/kernel-8.3.1/doc/html/erpc.html#check_response-3)

---
Edit: API changed 19/3-2022 due to OTP Technical Board decision