### PR TITLE
Correct typespec for inet_res:getbyname/2,3 (PR #5412, OTP-17986)

### DIFF
--- a/lib/kernel/doc/src/inet_res.xml
+++ b/lib/kernel/doc/src/inet_res.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>2009</year><year>2021</year>
+      <year>2009</year><year>2022</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -195,6 +195,9 @@ inet_dns:record_type(_) -> undefined.</pre>
           in the UTF-8 coding standard.</p>
       </desc>
     </datatype>
+    <datatype>
+      <name name="hostent"/>
+    </datatype>
   </datatypes>
 
   <funcs>
@@ -204,9 +207,20 @@ inet_dns:record_type(_) -> undefined.</pre>
       <fsummary>Resolve a DNS record of the specified type for the specified
       host.</fsummary>
       <desc>
-        <p>Resolves a DNS record of the specified type for the specified host,
-          of class <c>in</c>. Returns, on success, a <c>hostent()</c> record
-          with <c>dns_data()</c> elements in the address list field.</p>
+        <p>Resolves a DNS record of the specified <c><anno>Type</anno></c>
+          for the specified host, of class <c>in</c>.
+          Returns, on success, when resolving a
+          <c><anno>Type</anno>&nbsp;=&nbsp;a|aaaa</c> DNS record,
+          a <c>#hostent{}</c> record with
+          <c>#hostent.h_addrtype&nbsp;=&nbsp;inet|inet6</c>,
+          respectively; see
+          <seetype marker="inet#hostent"><c>inet:hostent()</c></seetype>.</p>
+        <p>When resolving other
+          <c><anno>Type</anno>&nbsp;=&nbsp;rr_type()</c>:s
+          also returns a <c>#hostent{}</c> record but with
+          <c>#hostent.h_addrtype&nbsp;=&nbsp;</c><seetype marker="#rr_type"><c>rr_type()</c></seetype>, and
+          <c>#hostent.h_addr_list&nbsp;=&nbsp;</c>[<seetype marker="#dns_data"><c>dns_data()</c></seetype>]; see
+          <seetype marker="#hostent"><c>hostent()</c></seetype>.</p>
         <p>This function uses resolver option <c>search</c> that
           is a list of domain names. If the name to resolve contains
           no dots, it is prepended to each domain name in the

--- a/lib/kernel/doc/src/inet_res.xml
+++ b/lib/kernel/doc/src/inet_res.xml
@@ -117,7 +117,7 @@
       <desc><p>A string with no adjacent dots.</p></desc>
     </datatype>
     <datatype>
-      <name name="rr_type"/>
+      <name name="dns_rr_type"/>
     </datatype>
     <datatype>
       <name name="dns_class"/>
@@ -153,7 +153,7 @@ dns_header() = DnsHeader
         | {rcode, integer(0..16)} ]
     inet_dns:header(DnsHeader, Field) -> Value
 
-query_type() = axfr | mailb | maila | any | rr_type()
+query_type() = axfr | mailb | maila | any | dns_rr_type()
 
 dns_query() = DnsQuery
     inet_dns:dns_query(DnsQuery) ->
@@ -165,7 +165,7 @@ dns_query() = DnsQuery
 dns_rr() = DnsRr
     inet_dns:rr(DnsRr) -> DnsRrFields | DnsRrOptFields
     DnsRrFields = [ {domain, dns_name()}
-                  | {type, rr_type()}
+                  | {type, dns_rr_type()}
                   | {class, dns_class()}
                   | {ttl, integer()}
                   | {data, dns_data()} ]
@@ -216,9 +216,9 @@ inet_dns:record_type(_) -> undefined.</pre>
           respectively; see
           <seetype marker="inet#hostent"><c>inet:hostent()</c></seetype>.</p>
         <p>When resolving other
-          <c><anno>Type</anno>&nbsp;=&nbsp;rr_type()</c>:s
+          <c><anno>Type</anno>&nbsp;=&nbsp;dns_rr_type()</c>:s
           also returns a <c>#hostent{}</c> record but with
-          <c>#hostent.h_addrtype&nbsp;=&nbsp;</c><seetype marker="#rr_type"><c>rr_type()</c></seetype>, and
+          <c>#hostent.h_addrtype&nbsp;=&nbsp;</c><seetype marker="#dns_rr_type"><c>dns_rr_type()</c></seetype>, and
           <c>#hostent.h_addr_list&nbsp;=&nbsp;</c>[<seetype marker="#dns_data"><c>dns_data()</c></seetype>]; see
           <seetype marker="#hostent"><c>hostent()</c></seetype>.</p>
         <p>This function uses resolver option <c>search</c> that

--- a/lib/kernel/doc/src/inet_res.xml
+++ b/lib/kernel/doc/src/inet_res.xml
@@ -217,9 +217,12 @@ inet_dns:record_type(_) -> undefined.</pre>
           <seetype marker="inet#hostent"><c>inet:hostent()</c></seetype>.</p>
         <p>When resolving other
           <c><anno>Type</anno>&nbsp;=&nbsp;dns_rr_type()</c>:s
+          (of class <c>in</c>),
           also returns a <c>#hostent{}</c> record but with
-          <c>#hostent.h_addrtype&nbsp;=&nbsp;</c><seetype marker="#dns_rr_type"><c>dns_rr_type()</c></seetype>, and
-          <c>#hostent.h_addr_list&nbsp;=&nbsp;</c>[<seetype marker="#dns_data"><c>dns_data()</c></seetype>]; see
+          <seetype marker="#dns_rr_type"><c>dns_rr_type()</c></seetype>
+          in <c>#hostent.h_addrtype</c>, and the resolved
+          <seetype marker="#dns_data"><c>dns_data()</c></seetype> in
+          <c>#hostent.h_addr_list</c>; see
           <seetype marker="#hostent"><c>hostent()</c></seetype>.</p>
         <p>This function uses resolver option <c>search</c> that
           is a list of domain names. If the name to resolve contains

--- a/lib/kernel/include/inet.hrl
+++ b/lib/kernel/include/inet.hrl
@@ -22,9 +22,11 @@
 
 -record(hostent,
 	{
-	 h_name		  :: inet:hostname(),	%% official name of host
-	 h_aliases = []   :: [inet:hostname()],	%% alias list
-	 h_addrtype	  :: 'inet' | 'inet6',	%% host address type
-	 h_length	  :: non_neg_integer(),	%% length of address
-	 h_addr_list = [] :: [inet:ip_address()]%% list of addresses from name server
+	 h_name		  :: inet:hostname(),	 %% official name of host
+	 h_aliases = []   :: [inet:hostname()],	 %% alias list
+	 h_addrtype	  :: inet | inet6 | caa | cname | gid | hinfo | ns | mb | md | mg
+	               | mf | minfo | mx | naptr | null | ptr | soa | spf | srv | txt
+	               | uid | uinfo | unspec | uri | wks, %% host address type
+	 h_length	  :: non_neg_integer(),	 %% length of address
+	 h_addr_list = [] :: [inet:ip_address()] %% list of addresses from name server
 	}).

--- a/lib/kernel/include/inet.hrl
+++ b/lib/kernel/include/inet.hrl
@@ -22,11 +22,9 @@
 
 -record(hostent,
 	{
-	 h_name		  :: inet:hostname(),	 %% official name of host
-	 h_aliases = []   :: [inet:hostname()],	 %% alias list
-	 h_addrtype	  :: inet | inet6 | caa | cname | gid | hinfo | ns | mb | md | mg
-	               | mf | minfo | mx | naptr | null | ptr | soa | spf | srv | txt
-	               | uid | uinfo | unspec | uri | wks, %% host address type
-	 h_length	  :: non_neg_integer(),	 %% length of address
-	 h_addr_list = [] :: [inet:ip_address()] %% list of addresses from name server
+	 h_name		  :: inet:hostname(),	%% official name of host
+	 h_aliases = []   :: [inet:hostname()],	%% alias list
+	 h_addrtype	  :: 'inet' | 'inet6',	%% host address type
+	 h_length	  :: non_neg_integer(),	%% length of address
+	 h_addr_list = [] :: [inet:ip_address()]%% list of addresses from name server
 	}).

--- a/lib/kernel/src/inet_res.erl
+++ b/lib/kernel/src/inet_res.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -453,10 +453,20 @@ gethostbyname_tm(_Name, _Family, _Timer) ->
 %% Caches the answer.
 %% --------------------------------------------------------------------------
 
+%% Duplicate of inet.hrl: #hostent{}, but with DNS RR types in h_addrtype
+%% and dns_data() in h_addr_list.
+-type hostent() ::
+        {'hostent',
+         H_name      :: inet:hostname(),
+         H_aliases   :: [inet:hostname()],
+         H_addrtype  :: rr_type(),
+         H_length    :: non_neg_integer(),
+         H_addr_list :: [dns_data()]}.
+
 -spec getbyname(Name, Type) -> {ok, Hostent} | {error, Reason} when
       Name :: dns_name(),
       Type :: rr_type(),
-      Hostent :: inet:hostent(),
+      Hostent :: inet:hostent() | hostent(),
       Reason :: inet:posix() | res_error().
 
 getbyname(Name, Type) -> 
@@ -466,7 +476,7 @@ getbyname(Name, Type) ->
       Name :: dns_name(),
       Type :: rr_type(),
       Timeout :: timeout(),
-      Hostent :: inet:hostent(),
+      Hostent :: inet:hostent() | hostent(),
       Reason :: inet:posix() | res_error().
 
 getbyname(Name, Type, Timeout) ->

--- a/lib/kernel/src/inet_res.erl
+++ b/lib/kernel/src/inet_res.erl
@@ -71,7 +71,7 @@
 
 -type dns_name() :: string().
 
--type rr_type() :: a | aaaa | caa | cname | gid | hinfo | ns | mb | md | mg
+-type dns_rr_type() :: a | aaaa | caa | cname | gid | hinfo | ns | mb | md | mg
                  | mf | minfo | mx | naptr | null | ptr | soa | spf | srv
                  | txt | uid | uinfo | unspec | uri | wks.
 
@@ -109,7 +109,7 @@
 -spec resolve(Name, Class, Type) -> {ok, dns_msg()} | Error when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Error :: {error, Reason} | {error,{Reason,dns_msg()}},
       Reason :: inet:posix() | res_error().
 
@@ -120,7 +120,7 @@ resolve(Name, Class, Type) ->
                      {ok, dns_msg()} | Error when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Opts :: [Opt],
       Opt :: res_option() | verbose | atom(),
       Error :: {error, Reason} | {error,{Reason,dns_msg()}},
@@ -133,7 +133,7 @@ resolve(Name, Class, Type, Opts) ->
                      {ok, dns_msg()} | Error when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Opts :: [Opt],
       Opt :: res_option() | verbose | atom(),
       Timeout :: timeout(),
@@ -160,7 +160,7 @@ resolve(Name, Class, Type, Opts, Timeout) ->
 -spec lookup(Name, Class, Type) -> [dns_data()] when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type().
+      Type :: dns_rr_type().
 
 lookup(Name, Class, Type) ->
     lookup(Name, Class, Type, []).
@@ -168,7 +168,7 @@ lookup(Name, Class, Type) ->
 -spec lookup(Name, Class, Type, Opts) -> [dns_data()] when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Opts :: [res_option() | verbose].
 
 lookup(Name, Class, Type, Opts) ->
@@ -177,7 +177,7 @@ lookup(Name, Class, Type, Opts) ->
 -spec lookup(Name, Class, Type, Opts, Timeout) -> [dns_data()] when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Opts :: [res_option() | verbose],
       Timeout :: timeout().
 
@@ -203,7 +203,7 @@ lookup_filter({error,_}, _, _) -> [].
 -spec nslookup(Name, Class, Type) -> {ok, dns_msg()} | {error, Reason} when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Reason :: inet:posix() | res_error().
 
 nslookup(Name, Class, Type) ->
@@ -213,14 +213,14 @@ nslookup(Name, Class, Type) ->
                       {ok, dns_msg()} | {error, Reason} when
                   Name :: dns_name() | inet:ip_address(),
                   Class :: dns_class(),
-                  Type :: rr_type(),
+                  Type :: dns_rr_type(),
                   Timeout :: timeout(),
                   Reason :: inet:posix() | res_error();
               (Name, Class, Type, Nameservers) ->
                       {ok, dns_msg()} | {error, Reason} when
                   Name :: dns_name() | inet:ip_address(),
                   Class :: dns_class(),
-                  Type :: rr_type(),
+                  Type :: dns_rr_type(),
                   Nameservers :: [nameserver()],
                   Reason :: inet:posix() | res_error().
 
@@ -233,7 +233,7 @@ nslookup(Name, Class, Type, NSs) ->             % For backwards compatibility
                       {ok, dns_msg()} | {error, Reason} when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Nameservers :: [nameserver()],
       Reason :: inet:posix().
 
@@ -244,7 +244,7 @@ nnslookup(Name, Class, Type, NSs) ->
                       {ok, dns_msg()} | {error, Reason} when
       Name :: dns_name() | inet:ip_address(),
       Class :: dns_class(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Timeout :: timeout(),
       Nameservers :: [nameserver()],
       Reason :: inet:posix().
@@ -459,13 +459,13 @@ gethostbyname_tm(_Name, _Family, _Timer) ->
         {'hostent',
          H_name      :: inet:hostname(),
          H_aliases   :: [inet:hostname()],
-         H_addrtype  :: rr_type(),
+         H_addrtype  :: dns_rr_type(),
          H_length    :: non_neg_integer(),
          H_addr_list :: [dns_data()]}.
 
 -spec getbyname(Name, Type) -> {ok, Hostent} | {error, Reason} when
       Name :: dns_name(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Hostent :: inet:hostent() | hostent(),
       Reason :: inet:posix() | res_error().
 
@@ -474,7 +474,7 @@ getbyname(Name, Type) ->
 
 -spec getbyname(Name, Type, Timeout) -> {ok, Hostent} | {error, Reason} when
       Name :: dns_name(),
-      Type :: rr_type(),
+      Type :: dns_rr_type(),
       Timeout :: timeout(),
       Hostent :: inet:hostent() | hostent(),
       Reason :: inet:posix() | res_error().


### PR DESCRIPTION
Closes PR #5412.

Instead of changing the `#hostent{}` record type; correct the return type for `inet_res:getbyname/2,3` by creating a parallel tuple type that defines the peculiar use of the `#hostent{}` record.