### PR TITLE
crashdump_viewer: Fix remote process info

### DIFF
--- a/lib/observer/src/cdv_proc_cb.erl
+++ b/lib/observer/src/cdv_proc_cb.erl
@@ -77,7 +77,7 @@ get_details(Id, _) ->
 	    Info = "The process you are searching for was residing on "
 		"a remote node. No process information is available. "
 		"Show information about the remote node?",
-	    Fun = fun() -> cdv_virtual_list_wx:start_detail_win(NodeId, port) end,
+	    Fun = fun() -> cdv_virtual_list_wx:start_detail_win(NodeId, node) end,
 	    {yes_no, Info, Fun};
 	{error,not_found} ->
 	    Info = "The process you are searching for could not be found.",


### PR DESCRIPTION
Don't look up port information when we want node information