### PR TITLE
erts: Fix crash dump assert when heart is set

### DIFF
--- a/erts/emulator/beam/erl_thr_progress.c
+++ b/erts/emulator/beam/erl_thr_progress.c
@@ -1369,7 +1369,7 @@ erts_thr_progress_fatal_error_block(ErtsThrPrgrData *tmp_tpd_bufp)
 	init_tmp_thr_prgr_data(tpd);
     }
 
-    /* Returns number of threads that have not yes been blocked */
+    /* Returns number of threads that have not yet been blocked */
     return thr_progress_block(tpd, 0);
 }
 

--- a/erts/emulator/test/dump_SUITE.erl
+++ b/erts/emulator/test/dump_SUITE.erl
@@ -24,7 +24,8 @@
 
 -export([all/0, suite/0, init_per_testcase/2, end_per_testcase/2]).
 
--export([signal_abort/1, exiting_dump/1, free_dump/1]).
+-export([signal_abort/1, exiting_dump/1, free_dump/1,
+         heart_dump/1, heart_no_dump/1]).
 
 -export([load/1]).
 
@@ -35,7 +36,7 @@ suite() ->
      {timetrap, {minutes, 2}}].
 
 all() ->
-    [signal_abort, exiting_dump, free_dump].
+    [signal_abort, exiting_dump, free_dump, heart_dump, heart_no_dump].
 
 init_per_testcase(signal_abort, Config) ->
     SO = erlang:system_info(schedulers_online),
@@ -212,6 +213,26 @@ free_dump(Config) when is_list(Config) ->
 
     ok.
 
+%% Test that crash dumping works when heart is used
+heart_dump(Config) ->
+    Dump = filename:join(proplists:get_value(priv_dir, Config),"heart.dump"),
+    {ok, Node} = start_node(Config,"-heart"),
+    true = rpc:call(Node, os, putenv, ["ERL_CRASH_DUMP",Dump]),
+    true = rpc:call(Node, os, putenv, ["ERL_CRASH_DUMP_SECONDS","10"]),
+    rpc:call(Node, erlang, halt, ["dump"]),
+    {ok, _Bin} = get_dump_when_done(Dump),
+    ok.
+
+%% Test that there is no crash dump if heart is used and DUMP_SECONDS is not set
+heart_no_dump(Config) ->
+    Dump = filename:join(proplists:get_value(priv_dir, Config),"heart_no.dump"),
+    {ok, Node} = start_node(Config,"-heart"),
+    true = rpc:call(Node, os, putenv, ["ERL_CRASH_DUMP",Dump]),
+    true = rpc:call(Node, os, unsetenv, ["ERL_CRASH_DUMP_SECONDS"]),
+    rpc:call(Node, erlang, halt, ["dump"]),
+    timer:sleep(1000),
+    {error, enoent} = file:read_file_info(Dump),
+    ok.
 
 get_dump_when_done(Dump) ->
     case file:read_file_info(Dump) of
@@ -234,6 +255,8 @@ get_dump_when_done(Dump, Sz) ->
     end.
 
 start_node(Config) when is_list(Config) ->
+    start_node(Config, "").
+start_node(Config, Extra) when is_list(Config) ->
     Pa = filename:dirname(code:which(?MODULE)),
     Name = list_to_atom(atom_to_list(?MODULE)
                         ++ "-"
@@ -242,4 +265,4 @@ start_node(Config) when is_list(Config) ->
                         ++ integer_to_list(erlang:system_time(second))
                         ++ "-"
                         ++ integer_to_list(erlang:unique_integer([positive]))),
-    test_server:start_node(Name, slave, [{args, "-pa "++Pa}]).
+    test_server:start_node(Name, slave, [{args, "-pa "++Pa++" "++Extra}]).


### PR DESCRIPTION
If a crash dump was generated while the VM was supervised
with heart, the debug build would assert because the heart
port was flushed.

This commit moves where erts_is_crash_dumping is set so that
the heart flush works as it should.

More importantly the commit also moves the
erts_thr_progress_fatal_error_block to be earlier so
that multiple threads do not race to create the crash dump.
The thr progress block was incorrectly moved by [#5315](https://github.com/erlang/otp/pull/5315) when
fixing a problem with the suspension of schedulers.