### PR TITLE
beam_call_types: Correct optimization of setelement/3

### DIFF
--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -90,10 +90,15 @@ will_succeed(erlang, 'not', [Arg]) ->
     succeeds_if_type(Arg, beam_types:make_boolean());
 will_succeed(erlang, setelement, [#t_integer{elements={Min,Max}},
                                   #t_tuple{exact=Exact,size=Size}, _]) ->
-    case Min >= 1 andalso Max =< Size of
-        true -> yes;
-        false when Exact -> no;
-        false -> 'maybe'
+    if
+        1 =< Min, Max =< Size ->
+            %% The index is always in range.
+            yes;
+        Max < 1; Exact, Size < Min ->
+            %% The index is always out of range.
+            no;
+        true ->
+            'maybe'
     end;
 will_succeed(erlang, size, [Arg]) ->
     ArgType = beam_types:join(#t_tuple{}, #t_bitstring{}),

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -396,6 +396,15 @@ tuple(_Config) ->
     2 = do_literal_tuple_2(15),
     2 = do_literal_tuple_2(20),
 
+    Counters0 = id({0,0,0}),                    %Inexact size.
+    {1,0,0} = Counters1 = increment_element(1, Counters0),
+    {1,1,0} = increment_element(2, Counters1),
+
+    Counters10 = {id(0),id(0),id(0)},           %Exact size.
+    {0,-1,0} = decrement_element(2, Counters10),
+    {0,0,-1} = decrement_element(3, Counters10),
+    {'EXIT',{badarg,_}} = catch decrement_element(4, Counters10),
+
     ok.
 
 do_tuple() ->
@@ -406,6 +415,14 @@ do_literal_tuple_1(X) ->
 
 do_literal_tuple_2(X) ->
     element(X, {2,2,2,2,2, 2,2,2,2,2, 2,2,2,2,2, 2,2,2,2,2}).
+
+increment_element(Pos, Cs) ->
+    Ns = element(Pos, Cs),
+    setelement(Pos, Cs, Ns + 1).
+
+decrement_element(Pos, Cs) ->
+    Ns = element(Pos, Cs),
+    setelement(Pos, Cs, Ns - 1).
 
 -record(x, {a}).
 


### PR DESCRIPTION
2ea04617d18bc3 introduced a bug in the handling of calls to
`setelement/3`. Consider this module:

    -module(bug).
    -export([bug/0]).

    bug() ->
        set(2, {a,b}),
        set(3, {a,b}).

    set(Pos, Tuple) ->
        setelement(Pos, Tuple, something).

The second call to `set/2` will fail because the position is `3` is
beyond the end of the tuple. Because of that failed call, the compiler
would incorrectly assume that the call to `setelement/3` in `set/2`
would always fail, and there would be a very confusing exception:

    1> bug:bug().
    ** exception error: no true branch found when evaluating an if expression
         in function  bug:set/2 (bug.erl, line 8)

This pull request fixes the bug. With this bug fix, the exception will look
like:

    4> bug:bug().
    ** exception error: bad argument
         in function  setelement/3
            called as setelement(3,{a,b},something)
            *** argument 1: out of range
         in call from bug:set/2 (bug.erl, line 9)