### PR TITLE
inets: re-use connect_timeout option in TLS upgrade

### DIFF
--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -1637,14 +1637,14 @@ host_header(_, URI) ->
 tls_upgrade(#state{status = 
 		       {ssl_tunnel, 
 			#request{settings = 
-				     #http_options{ssl = {_, TLSOptions0} = SocketType},
+				     #http_options{ssl = {_, TLSOptions0} = SocketType,
+						   connect_timeout = ConnectTimeout},
 				     address = {Host, _} = Address} = Request},
 		   session = #session{socket = TCPSocket} = Session0,
 		   options = Options} = State) ->
 
     TLSOptions = maybe_add_sni(Host, TLSOptions0),
-
-    case ssl:connect(TCPSocket, TLSOptions) of
+    case ssl:connect(TCPSocket, TLSOptions, ConnectTimeout) of
 	{ok, TLSSocket} ->
 	    ClientClose = httpc_request:is_client_closing(Request#request.headers),
 	    SessionType = httpc_manager:session_type(Options),

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -51,6 +51,7 @@
          start_upgrade_server/1,
          start_upgrade_server_error/1,
          start_upgrade_client/1,
+         start_upgrade_client_error/1,
          start_client_error/1,
          start_server_error/1,
          start_server_transport_abuse_socket/1,
@@ -70,6 +71,7 @@
          run_upgrade_server/1,
          run_upgrade_client/1,
          run_upgrade_server_error/1,
+         run_upgrade_client_error/1,
          run_client_error/1,
          send_recv_result_active/3,
          wait_for_result/2,
@@ -1989,6 +1991,25 @@ run_upgrade_client(Opts) ->
 	    ?LOG("~nUpgrade Client closing~n", []),
 	    ssl:close(SslSocket)
     end.
+
+start_upgrade_client_error(Args) ->
+    Node = proplists:get_value(node, Args),
+    spawn_link(Node, ?MODULE, run_upgrade_client_error, [Args]).
+
+run_upgrade_client_error(Opts) ->
+    Host = proplists:get_value(host, Opts),
+    Port = proplists:get_value(port, Opts),
+    Pid = proplists:get_value(from, Opts),
+    Timeout = proplists:get_value(timeout, Opts, infinity),
+    TcpOptions = proplists:get_value(tcp_options, Opts),
+    SslOptions = proplists:get_value(ssl_options, Opts),
+    ?LOG("gen_tcp:connect(~p, ~p, ~p)",
+               [Host, Port, TcpOptions]),
+    {ok, Socket} = gen_tcp:connect(Host, Port, TcpOptions),
+    send_selected_port(Pid, Port, Socket),
+    ?LOG("ssl:connect(~p, ~p)", [Socket, SslOptions]),
+    Error = ssl:connect(Socket, SslOptions, Timeout),
+    Pid ! {self(), Error}.
 
 start_upgrade_server_error(Args) ->
     Node = proplists:get_value(node, Args),

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -47,6 +47,8 @@
          tls_upgrade_new_opts/1,
          tls_upgrade_with_timeout/0,
          tls_upgrade_with_timeout/1,
+         tls_upgrade_with_client_timeout/0,
+         tls_upgrade_with_client_timeout/1,
          tls_downgrade/0,
          tls_downgrade/1,
          tls_shutdown/0,
@@ -144,6 +146,7 @@ api_tests() ->
      tls_upgrade,
      tls_upgrade_new_opts,
      tls_upgrade_with_timeout,
+     tls_upgrade_with_client_timeout,
      tls_downgrade,
      tls_shutdown,
      tls_shutdown_write,
@@ -314,6 +317,37 @@ tls_upgrade_with_timeout(Config) when is_list(Config) ->
 
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
+
+tls_upgrade_with_client_timeout() ->
+    [{doc,"Test upgrade with connect/3 and a timeout value"}].
+
+tls_upgrade_with_client_timeout(Config) when is_list(Config) ->
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    TcpOpts = [binary, {reuseaddr, true}],
+
+    Server = ssl_test_lib:start_upgrade_server([{node, ServerNode}, {port, 0},
+						{from, self()},
+						{mfa, {?MODULE,
+						       upgrade_result, []}},
+						{tcp_options,
+						 [{active, false} | TcpOpts]},
+						{ssl_options, [{verify, verify_peer} | ServerOpts]}]),
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_upgrade_client_error([{node, ClientNode},
+						{port, Port},
+				   {host, Hostname},
+				   {from, self()},
+                                   {timeout, 0},
+				   {mfa, {?MODULE, upgrade_result, []}},
+				   {tcp_options, [binary]},
+				   {ssl_options,  [{verify, verify_peer},
+                                                   {server_name_indication, Hostname} | ClientOpts]}]),
+
+    ct:log("Testcase ~p, Client ~p  Server ~p", [self(), Client, Server]),
+    ok = ssl_test_lib:check_result(Client, {error, timeout}),
+    ssl_test_lib:close(Server).
 
 %%--------------------------------------------------------------------
 tls_downgrade() ->


### PR DESCRIPTION
    - re-use connect_timeout during TLS upgrade of connection over proxy
    - connect_timeout test in inets
    - TLS upgrade client timeout test in ssl