### PR TITLE
Fix monotonic time on MacOS

### DIFF
--- a/erts/aclocal.m4
+++ b/erts/aclocal.m4
@@ -700,14 +700,30 @@ esac
 
 AC_DEFUN(ERL_MONOTONIC_CLOCK,
 [
+  # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+  # and Monterey, since it may step backwards.
   if test "$3" = "yes"; then
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW";;
+          *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE";;
+     esac
   else
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW";;
+                *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE";;
+     esac
   fi
 
   case "$1" in
@@ -1538,7 +1554,7 @@ esac
 LM_CHECK_THR_LIB
 ERL_INTERNAL_LIBS
 
-ERL_MONOTONIC_CLOCK(try_find_pthread_compatible, CLOCK_HIGHRES CLOCK_MONOTONIC, no)
+ERL_MONOTONIC_CLOCK(try_find_pthread_compatible, CLOCK_HIGHRES CLOCK_UPTIME_RAW CLOCK_MONOTONIC, no)
 
 case $erl_monotonic_clock_func in
   clock_gettime)
@@ -2500,6 +2516,15 @@ case "$with_clock_gettime_monotonic_id" in
    CLOCK_REALTIME*|CLOCK_TAI*)
      AC_MSG_ERROR([Invalid clock_gettime() monotonic clock id: Refusing to use the realtime clock id $with_clock_gettime_monotonic_id as monotonic clock id])
      ;;
+   CLOCK_MONOTONIC)
+     case $host_os in
+         darwin*)
+           # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+           # and Monterey, since it may step backwards.
+           AC_MSG_ERROR([Invalid clock_gettime() monotonic clock id: Refusing to use $with_clock_gettime_monotonic_id as monotonic clock id since it is buggy on MacOS]);;
+         *)
+           ;;
+     esac;;
    CLOCK_*)
      ;;
    *)

--- a/erts/configure
+++ b/erts/configure
@@ -8301,14 +8301,30 @@ fi
 
 
 
+  # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+  # and Monterey, since it may step backwards.
   if test "no" = "yes"; then
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW";;
+          *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE";;
+     esac
   else
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW";;
+                *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE";;
+     esac
   fi
 
   case "try_find_pthread_compatible" in
@@ -8322,11 +8338,11 @@ fi
 	;;
     custom_resolution)
 	check_msg="custom resolution "
-	prefer_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_MONOTONIC"
+	prefer_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME_RAW CLOCK_MONOTONIC"
 	;;
     *)
 	check_msg="custom "
-	prefer_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_MONOTONIC"
+	prefer_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME_RAW CLOCK_MONOTONIC"
 	;;
   esac
 
@@ -19938,6 +19954,15 @@ case "$with_clock_gettime_monotonic_id" in
    CLOCK_REALTIME*|CLOCK_TAI*)
      as_fn_error $? "Invalid clock_gettime() monotonic clock id: Refusing to use the realtime clock id $with_clock_gettime_monotonic_id as monotonic clock id" "$LINENO" 5
      ;;
+   CLOCK_MONOTONIC)
+     case $host_os in
+         darwin*)
+           # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+           # and Monterey, since it may step backwards.
+           as_fn_error $? "Invalid clock_gettime() monotonic clock id: Refusing to use $with_clock_gettime_monotonic_id as monotonic clock id since it is buggy on MacOS" "$LINENO" 5;;
+         *)
+           ;;
+     esac;;
    CLOCK_*)
      ;;
    *)
@@ -19948,14 +19973,30 @@ esac
 case "$with_clock_resolution-$with_clock_gettime_monotonic_id" in
   high-no)
 
+  # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+  # and Monterey, since it may step backwards.
   if test "$prefer_elapsed_monotonic_time_during_suspend" = "yes"; then
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW";;
+          *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE";;
+     esac
   else
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW";;
+                *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE";;
+     esac
   fi
 
   case "high_resolution" in
@@ -20240,14 +20281,30 @@ $as_echo "$erl_cv_mach_clock_get_time_monotonic" >&6; }
 ;;
   low-no)
 
+  # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+  # and Monterey, since it may step backwards.
   if test "$prefer_elapsed_monotonic_time_during_suspend" = "yes"; then
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW";;
+          *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE";;
+     esac
   else
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW";;
+                *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE";;
+     esac
   fi
 
   case "low_resolution" in
@@ -20532,14 +20589,30 @@ $as_echo "$erl_cv_mach_clock_get_time_monotonic" >&6; }
 ;;
   default-no)
 
+  # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+  # and Monterey, since it may step backwards.
   if test "$prefer_elapsed_monotonic_time_during_suspend" = "yes"; then
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW";;
+          *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE";;
+     esac
   else
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW";;
+                *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE";;
+     esac
   fi
 
   case "default_resolution" in
@@ -20824,14 +20897,30 @@ $as_echo "$erl_cv_mach_clock_get_time_monotonic" >&6; }
 ;;
   *)
 
+  # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+  # and Monterey, since it may step backwards.
   if test "$prefer_elapsed_monotonic_time_during_suspend" = "yes"; then
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW";;
+          *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE";;
+     esac
   else
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW";;
+                *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE";;
+     esac
   fi
 
   case "custom_resolution" in
@@ -21190,14 +21279,30 @@ $as_echo "#define HAVE_CLOCK_GETTIME_MONOTONIC_RAW 1" >>confdefs.h
 fi
 
 
+  # CLOCK_MONOTONIC is buggy on MacOS (darwin), or at least on Big Sur
+  # and Monterey, since it may step backwards.
   if test "no" = "yes"; then
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_RAW";;
+          *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_BOOTTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_PRECISE";;
+     esac
   else
-     default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
-     low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
-     high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE"
+     case $host_os in
+          darwin*)
+                default_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW"
+                low_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW_APPROX"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_RAW";;
+                *)
+                default_resolution_clock_gettime_monotonic="CLOCK_HIGHRES CLOCK_UPTIME CLOCK_MONOTONIC"
+                low_resolution_clock_gettime_monotonic="CLOCK_MONOTONIC_COARSE CLOCK_UPTIME_FAST"
+                high_resolution_clock_gettime_monotonic="CLOCK_UPTIME_PRECISE";;
+     esac
   fi
 
   case "high_resolution" in


### PR DESCRIPTION
The `clock_gettime()` clock id `CLOCK_MONOTONIC` on MacOS, at least on Big Sur and Monterey, is buggy since its values may step backwards. This fix rejects the use of `CLOCK_MONOTONIC` on MacOS and will instead use `CLOCK_UPTIME_RAW`, or `CLOCK_MONOTONIC_RAW` in case configured for inclusion of sleep time, which appears not to be buggy.

Fixes #5554 