### PR TITLE
Implement fast niche PRNGs

### DIFF
--- a/lib/stdlib/doc/src/rand.xml
+++ b/lib/stdlib/doc/src/rand.xml
@@ -59,6 +59,20 @@
     </p>
 
     <p>
+      At the end of this module documentation there are also some
+      <seeerl marker="#niche_algorithms">
+        niche algorithms
+      </seeerl>
+      to be used without this module's normal
+      <seeerl marker="#plug_in_api">
+        plug-in framework API
+      </seeerl>
+      that may be useful for special purposes like
+      short generation time when quality is not essential,
+      for seeding other generators, and such.
+    </p>
+
+    <p>
       <marker id="algorithms"/>
       The following algorithms are provided:
     </p>
@@ -407,6 +421,7 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
 
   <funcs>
     <fsdescription>
+      <marker id="plug_in_api"/>
       <title>Plug-in framework API</title>
     </fsdescription>
     <func>
@@ -793,6 +808,7 @@ end.</pre>
 
   <funcs>
     <fsdescription>
+      <marker id="niche_algorithms"/>
       <title>Niche algorithms API</title>
     </fsdescription>
     <func>
@@ -878,8 +894,8 @@ end.</pre>
       <fsummary>Return a new generator state / number.</fsummary>
       <desc>
         <p>
-          Returns a new generator state which is also
-          the generated number, <c><anno>X1</anno></c>,
+          Returns a generated Pseudo Random Number which is also
+          the new generated state, <c><anno>X1</anno></c>,
           according to a classical Multiplicative Congruential Generator
           (a.k.a Multiplicative Linear Congruential Generator,
           Lehmer random number generator,
@@ -929,8 +945,8 @@ end.</pre>
       <fsummary>Return a new generator state / number.</fsummary>
       <desc>
         <p>
-          Returns a new generator state which is also
-          the generated number, <c><anno>X1</anno></c>,
+          Returns a generated Pseudo Random Number which is also
+          the new generated state, <c><anno>X1</anno></c>,
           according to a classical Linear Congruential Generator,
           a power of 2 mixed congruential generator.
         </p>

--- a/lib/stdlib/doc/src/rand.xml
+++ b/lib/stdlib/doc/src/rand.xml
@@ -54,7 +54,8 @@
       non-overlapping sequences for parallel computations.
       The jump functions perform calculations
       equivalent to perform a large number of repeated calls
-      for calculating new states.
+      for calculating new states, but execute in a time
+      roughly equivalent to one regular iteration per generator bit.
     </p>
 
     <p>
@@ -290,9 +291,10 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
       If this is a problem; to generate a boolean with these algorithms
       use something like this:
     </p>
-    <pre>(rand:uniform(16) > 8)</pre>
+    <pre>(rand:uniform(256) > 128) % -> boolean()</pre>
+    <pre>((rand:uniform(256) - 1) bsr 7) % -> 0 | 1</pre>
     <p>
-      And for a general range, with <c>N = 1</c> for <c>exrop</c>,
+      For a general range, with <c>N = 1</c> for <c>exrop</c>,
       and <c>N = 3</c> for <c>exs1024s</c>:
     </p>
     <pre>(((rand:uniform(Range bsl N) - 1) bsr N) + 1)</pre>
@@ -380,13 +382,37 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
       <name name="dummy_state"/>
       <desc><p>Algorithm specific internal state</p></desc>
     </datatype>
+    <datatype>
+      <name name="splitmix64_state"/>
+      <desc><p>Algorithm specific state</p></desc>
+    </datatype>
+    <datatype>
+      <name name="uint58"/>
+      <desc><p>0 .. (2^58 - 1)</p></desc>
+    </datatype>
+    <datatype>
+      <name name="uint64"/>
+      <desc><p>0 .. (2^64 - 1)</p></desc>
+    </datatype>
+    <datatype>
+      <name name="mcg35_state"/>
+      <desc><p>1 .. ((2^35 - 31) - 1)</p></desc>
+    </datatype>
+    <datatype>
+      <name name="lcg35_state"/>
+      <desc><p>0 .. (2^35 - 1)</p></desc>
+    </datatype>
   </datatypes>
 
+
   <funcs>
+    <fsdescription>
+      <title>Plug-in framework API</title>
+    </fsdescription>
     <func>
       <name name="bytes" arity="1" since="OTP 24.0"/>
       <fsummary>Return a random binary.</fsummary>
-      <desc><marker id="bytes-1"/>
+      <desc>
       <p>
         Returns, for a specified integer <c><anno>N</anno> >= 0</c>,
         a <c>binary()</c> with that number of random bytes.
@@ -400,7 +426,7 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
     <func>
       <name name="bytes_s" arity="2" since="OTP 24.0"/>
       <fsummary>Return a random binary.</fsummary>
-      <desc><marker id="bytes-1"/>
+      <desc>
       <p>
         Returns, for a specified integer <c><anno>N</anno> >= 0</c>
         and a state, a <c>binary()</c> with that number of random bytes,
@@ -415,7 +441,7 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
     <func>
       <name name="export_seed" arity="0" since="OTP 18.0"/>
       <fsummary>Export the random number generation state.</fsummary>
-      <desc><marker id="export_seed-0"/>
+      <desc>
         <p>Returns the random number state in an external format.
           To be used with <seemfa marker="#seed/1"><c>seed/1</c></seemfa>.</p>
       </desc>
@@ -424,7 +450,7 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
     <func>
       <name name="export_seed_s" arity="1" since="OTP 18.0"/>
       <fsummary>Export the random number generation state.</fsummary>
-      <desc><marker id="export_seed_s-1"/>
+      <desc>
         <p>Returns the random number generator state in an external format.
           To be used with <seemfa marker="#seed/1"><c>seed/1</c></seemfa>.</p>
       </desc>
@@ -434,7 +460,7 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
       <name name="jump" arity="0" since="OTP 20.0"/>
       <fsummary>Return the seed after performing jump calculation
           to the state in the process dictionary.</fsummary>
-      <desc><marker id="jump-0" />
+      <desc>
           <p>Returns the state
               after performing jump calculation
               to the state in the process dictionary.</p>
@@ -448,7 +474,7 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
     <func>
       <name name="jump" arity="1" since="OTP 20.0"/>
       <fsummary>Return the seed after performing jump calculation.</fsummary>
-      <desc><marker id="jump-1" />
+      <desc>
           <p>Returns the state after performing jump calculation
               to the given state. </p>
       <p>This function generates a <c>not_implemented</c> error exception
@@ -500,7 +526,6 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
       <name name="seed" arity="1" clause_i="2" since="OTP 24.0"/>
       <fsummary>Seed random number generator.</fsummary>
       <desc>
-        <marker id="seed-1"/>
         <p>
 	  Seeds random number generation with the specifed algorithm and
           time-dependent data if <c><anno>AlgOrStateOrExpState</anno></c>
@@ -575,7 +600,7 @@ tests. We suggest to use a sign test to extract a random Boolean value.</pre>
     <func>
       <name name="uniform" arity="0" since="OTP 18.0"/>
       <fsummary>Return a random float.</fsummary>
-      <desc><marker id="uniform-0"/>
+      <desc>
         <p>
 	  Returns a random float uniformly distributed in the value
           range <c>0.0 =&lt; <anno>X</anno> &lt; 1.0</c> and
@@ -611,7 +636,7 @@ end.</pre>
     <func>
       <name name="uniform_real" arity="0" since="OTP 21.0"/>
       <fsummary>Return a random float.</fsummary>
-      <desc><marker id="uniform_real-0"/>
+      <desc>
         <p>
 	  Returns a random float
 	  uniformly distributed in the value range
@@ -647,7 +672,7 @@ end.</pre>
     <func>
       <name name="uniform" arity="1" since="OTP 18.0"/>
       <fsummary>Return a random integer.</fsummary>
-      <desc><marker id="uniform-1"/>
+      <desc>
         <p>Returns, for a specified integer <c><anno>N</anno> >= 1</c>,
           a random integer uniformly distributed in the value range
           <c>1 =&lt; <anno>X</anno> =&lt; <anno>N</anno></c> and
@@ -761,6 +786,199 @@ end.</pre>
           and a state, a random integer uniformly distributed in the value
           range <c>1 =&lt; <anno>X</anno> =&lt; <anno>N</anno></c> and a
           new state.</p>
+      </desc>
+    </func>
+  </funcs>
+
+
+  <funcs>
+    <fsdescription>
+      <title>Niche algorithms API</title>
+    </fsdescription>
+    <func>
+      <name name="splitmix64_next" arity="1" since="OTP 25.0"/>
+      <fsummary>Return a random integer and new state.</fsummary>
+      <desc>
+        <p>
+          Returns a random 64-bit integer <c><anno>X</anno></c>
+          and a new generator state <c><anno>NewAlgState</anno></c>,
+          according to the SplitMix64 algorithm.
+        </p>
+        <p>
+          This generator is used internally in the <c>rand</c>
+          module for seeding other generators since it is of a
+          quite different breed which reduces the probability for
+          creating an accidentally bad seed.
+        </p>
+      </desc>
+    </func>
+    <func>
+      <name name="exsp_next" arity="1" since="OTP 25.0"/>
+      <fsummary>Return a random integer and new state.</fsummary>
+      <desc>
+        <p>
+          Returns a random 58-bit integer <c><anno>X</anno></c>
+          and a new generator state <c><anno>NewAlgState</anno></c>,
+          according to the Xorshift116+ algorithm.
+        </p>
+        <p>
+          This is an API function into the internal implementation of the
+          <seeerl marker="#algorithms"><c>exsp</c></seeerl>
+          algorithm that enables using it without the overhead
+          of the plug-in framework, which might be useful
+          for time critial applications.
+          On a typical 64 bit Erlang VM this approach executes
+          in just above 30% (1/3) of the time
+          for the default algorithm through
+          this module's normal plug-in framework.
+        </p>
+        <p>
+          To seed this generator use
+          <seemfa marker="#seed_s/1">
+            <c>{_, <anno>AlgState</anno>} = rand:seed_s(exsp)</c>
+          </seemfa>
+          or
+          <seemfa marker="#seed_s/1">
+            <c>{_, <anno>AlgState</anno>} = rand:seed_s(exsp, Seed)</c>
+          </seemfa>
+          with a specific <c>Seed</c>.
+        </p>
+        <note>
+          <p>
+            This function offers no help in generating a number
+            on a selected range, nor in generating a floating point number.
+            It is easy to accidentally mess up the fairly good
+            statistical properties of this generator when doing either.
+            Note also the caveat about weak low bits that
+            this generator suffers from.
+            The generator is exported in this form primarily for speed.
+          </p>
+        </note>
+      </desc>
+    </func>
+    <func>
+      <name name="exsp_jump" arity="1" since="OTP 25.0"/>
+      <fsummary>Return the new state as from 2^64 iterations.</fsummary>
+      <desc>
+        <p>
+          Returns a new generator state equivalent of the state
+          after iterating over
+          <seemfa marker="#exsp_next/1"><c>exsp_next/1</c></seemfa>
+          2^64 times.
+        </p>
+        <p>
+          See the description of jump functions
+          at the top of this module description.
+        </p>
+      </desc>
+    </func>
+    <func>
+      <name name="mcg35" arity="1" since="OTP 25.0"/>
+      <fsummary>Return a new generator state / number.</fsummary>
+      <desc>
+        <p>
+          Returns a new generator state which is also
+          the generated number, <c><anno>X1</anno></c>,
+          according to a classical Multiplicative Congruential Generator
+          (a.k.a Multiplicative Linear Congruential Generator,
+          Lehmer random number generator,
+          Park-Miller random number generator).
+        </p>
+        <p>
+          This generator uses the modulus 2^35 - 31
+          and the multiplication constant 185852
+          from the paper "Tables of Linear Congruential Generators
+          of different sizes and good lattice structure" by
+          Pierre L'Ecuyer (1997) and they are selected
+          for speed to keep the computation under
+          the Erlang bignum limit.
+        </p>
+        <p>
+          The generator may be written as
+          <c><anno>X1</anno>&nbsp;=&nbsp;(185852*<anno>X0</anno>)&nbsp;rem&nbsp;((1&nbsp;bsl&nbsp;35)-31)</c>,
+          but the properties of the chosen constants has allowed
+          an optimization of the otherwise expensive <c>rem</c> operation.
+        </p>
+        <p>
+          On a typical 64 bit Erlang VM this generator executes
+          in just below 10% (1/10) of the time
+          for the default algorithm in this module.
+        </p>
+        <note>
+          <p>
+            This generator is only suitable for insensitive
+            special niche applications since it has
+            a short period (2^35 - 32),
+            few bits (under 35),
+            is not a power of 2 generator (range 1 .. (2^35 - 32)),
+            offers no help in generating numbers on a specified range,
+            etc...
+          </p>
+          <p>
+            But for pseudo random load distribution
+            and such it might be useful, since it is very fast.
+            It normally beats even the known-to-be-fast trick
+            <c>erlang:phash2(erlang:unique_integer())</c>.
+          </p>
+        </note>
+      </desc>
+    </func>
+    <func>
+      <name name="lcg35" arity="1" since="OTP 25.0"/>
+      <fsummary>Return a new generator state / number.</fsummary>
+      <desc>
+        <p>
+          Returns a new generator state which is also
+          the generated number, <c><anno>X1</anno></c>,
+          according to a classical Linear Congruential Generator,
+          a power of 2 mixed congruential generator.
+        </p>
+        <p>
+          This generator uses the modulus 2^35
+          and the multiplication constant 15319397
+          from the paper "Tables of Linear Congruential Generators
+          of different sizes and good lattice structure" by
+          Pierre L'Ecuyer (1997) and they are selected
+          for speed to keep the computation under
+          the Erlang bignum limit.
+          The addition constant has been selected to
+          15366142135 (it has to be odd) which looks
+          more interesting than simply 1.
+        </p>
+        <p>
+          The generator may be written as
+          <c><anno>X1</anno>&nbsp;=&nbsp;((15319397*<anno>X0</anno>)&nbsp;+&nbsp;15366142135)&nbsp;band&nbsp;((1&nbsp;bsl&nbsp;35)-1)</c>.
+        </p>
+        <p>
+          On a typical 64 bit Erlang VM this generator executes
+          in just below 7% (1/15) of the time
+          for the default algorithm in this module,
+          which is the fastest generator the author has seen.
+          It can hardly be beaten by even a BIF
+          implementation of any generator since the execution
+          time is close to the overhead of a BIF call.
+        </p>
+        <note>
+          <p>
+            This generator is only suitable for insensitive
+            special niche applications since it has
+            a short period (2^35), few bits (35),
+            offers no help in generating numbers on a specified range,
+            and has, among others, the known statistical artifact
+            that the lowest bit simply alternates,
+            the next to lowest has a period of 4,
+            and so on, so it is only the highest bits
+            that achieve any form of statistical quality.
+          </p>
+          <p>
+            But for pseudo random load distribution
+            and such it might be useful, since it is extremely fast.
+            The <seemfa marker="#mcg35/1"><c>mcg35/1</c></seemfa>
+            generator above has got less statistical artifacts,
+            but instead other pecularities since it is not
+            a power of 2 generator.
+          </p>
+        </note>
       </desc>
     </func>
   </funcs>

--- a/lib/stdlib/doc/src/rand.xml
+++ b/lib/stdlib/doc/src/rand.xml
@@ -912,7 +912,7 @@ end.</pre>
             few bits (under 35),
             is not a power of 2 generator (range 1 .. (2^35 - 32)),
             offers no help in generating numbers on a specified range,
-            etc...
+            and so on.
           </p>
           <p>
             But for pseudo random load distribution
@@ -974,8 +974,8 @@ end.</pre>
             But for pseudo random load distribution
             and such it might be useful, since it is extremely fast.
             The <seemfa marker="#mcg35/1"><c>mcg35/1</c></seemfa>
-            generator above has got less statistical artifacts,
-            but instead other pecularities since it is not
+            generator above has less statistical artifacts,
+            but instead it has other peculiarities since it is not
             a power of 2 generator.
           </p>
         </note>

--- a/lib/stdlib/doc/src/rand.xml
+++ b/lib/stdlib/doc/src/rand.xml
@@ -851,7 +851,8 @@ end.</pre>
             statistical properties of this generator when doing either.
             Note also the caveat about weak low bits that
             this generator suffers from.
-            The generator is exported in this form primarily for speed.
+            The generator is exported in this form
+            primarily for performance.
           </p>
         </note>
       </desc>
@@ -890,7 +891,7 @@ end.</pre>
           from the paper "Tables of Linear Congruential Generators
           of different sizes and good lattice structure" by
           Pierre L'Ecuyer (1997) and they are selected
-          for speed to keep the computation under
+          for performance to keep the computation under
           the Erlang bignum limit.
         </p>
         <p>
@@ -939,7 +940,7 @@ end.</pre>
           from the paper "Tables of Linear Congruential Generators
           of different sizes and good lattice structure" by
           Pierre L'Ecuyer (1997) and they are selected
-          for speed to keep the computation under
+          for performance to keep the computation under
           the Erlang bignum limit.
           The addition constant has been selected to
           15366142135 (it has to be odd) which looks

--- a/lib/stdlib/test/rand_SUITE.erl
+++ b/lib/stdlib/test/rand_SUITE.erl
@@ -1480,7 +1480,7 @@ do_measure(Iterations) ->
     %%
     ByteSize = 16, % At about 100 bytes crypto_bytes breaks even to exsss
     ct:pal("~nRNG ~w bytes performance~n",[ByteSize]),
-    [TMarkBytes16,OverheadBytes16|_] =
+    [TMarkBytes1,OverheadBytes1|_] =
         measure_1(
           fun (Mod, _State) ->
                   Generator = fun Mod:bytes_s/2,
@@ -1503,7 +1503,34 @@ do_measure(Iterations) ->
                              lcg35_bytes(ByteSize, St0), ByteSize, Bin, St1)
                   end
           end, lcg35_bytes, Iterations,
-          TMarkBytes16, OverheadBytes16),
+          TMarkBytes1, OverheadBytes1),
+    %%
+    ByteSize2 = 1000, % At about 100 bytes crypto_bytes breaks even to exsss
+    ct:pal("~nRNG ~w bytes performance~n",[ByteSize2]),
+    [TMarkBytes2,OverheadBytes2|_] =
+        measure_1(
+          fun (Mod, _State) ->
+                  Generator = fun Mod:bytes_s/2,
+                  fun (St0) ->
+                          ?CHECK_BYTE_SIZE(
+                             Generator(ByteSize2, St0), ByteSize2, Bin, St1)
+                  end
+          end,
+          case crypto_support() of
+              ok ->
+                  Algs ++ [crypto_bytes, crypto_bytes_cached];
+              _ ->
+                  Algs
+          end, Iterations div 50),
+    _ =
+        measure_1(
+          fun (_Mod, _State) ->
+                  fun (St0) ->
+                          ?CHECK_BYTE_SIZE(
+                             lcg35_bytes(ByteSize2, St0), ByteSize2, Bin, St1)
+                  end
+          end, lcg35_bytes, Iterations div 50,
+          TMarkBytes2, OverheadBytes2),
     %%
     ct:pal("~nRNG uniform float performance~n",[]),
     [TMarkUniformFloat,OverheadUniformFloat|_] =

--- a/lib/stdlib/test/rand_SUITE.erl
+++ b/lib/stdlib/test/rand_SUITE.erl
@@ -35,7 +35,8 @@ all() ->
     [seed, interval_int, interval_float,
      bytes_count,
      api_eq,
-     mcg35_api, mcg35_rem, lcg35_api, exsp_next_api, exsp_jump_api,
+     mcg35_api, mcg35_rem, lcg35_api,
+     exsp_next_api, exsp_jump_api, splitmix64_next_api,
      reference,
      {group, basic_stats},
      {group, distr_stats},
@@ -287,6 +288,22 @@ exsp_jump_api(State, AlgState, N) ->
       rand:jump(NewState),
       rand:exsp_jump(NewAlgState),
       N - 1).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% Verify splitmix64_next behaviour
+%%
+splitmix64_next_api(Config) when is_list(Config) ->
+    splitmix64_next_api(55555555, 100000, 0).
+
+splitmix64_next_api(_State, 0, X) ->
+    X0 = 13069087632117122295,
+    {X0, X0} = {X, X0},
+    ok;
+splitmix64_next_api(AlgState, N, X)
+  when is_integer(X), 0 =< X, X < 1 bsl 64 ->
+    {X1, NewAlgState} = rand:splitmix64_next(AlgState),
+    splitmix64_next_api(NewAlgState, N - 1, X1).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This PR adds two very fast but low quality niche algorithms to the `rand` module, not as part of the plug-in framework, to avoid the overhead.

The algorithms are two Linear Congruential Generators, one purely multiplicative - **`mcg35`**, with a prime modulus and one power of two based - **`lcg35`**.  Both have 35 bits, the multiplicative just short of.  According to state of the art today these are historical toy generators with plenty of statistical shortcomings, but an impressive speed, which is what still might make them relevant for niche applications such as "random" load balancing, routing, etc.

The reason for adding them to the `rand` module is so that users will not need to roll their own and accidentally do some unfortunate mistake that makes their implementation even worse.

This PR also exports the internal functions `exsp_next/1` and `exsp_jump/1` from the fastest generator in the `rand` module's normal repertoire, which enables users to use them without the plug-in framework overhead (and without the range facilities, `float()` generation and all the other conveniences of the plug-in framework).  This can cut down the number generation time to 1/3 of the framework's, provided that the application can make use of just a raw 58-bit number.

The function `splitmix64_next/1` is also exported to tap in to the generator internally used in the `rand` module for seeding other generators with large state arrays, which can be useful for customizing generator seeding.


#### Test improvements and optimizations
* Add a warm-up set to measure/1
* Compensate measure/1 numbers for overhead
* Measure the process dictionary variant of the default generator
* Remove redundant mask operations on the argument
  to splitmix64_next/1

#### Implement, document and measure niche PRNGs
* splitmix64_next
* exsp_next & exsp_jump
* mcg35
* lcg35