### PR TITLE
[RFC] Add kernel TLS support in prim_inet, inet_drv, and ssl application

### DIFF
--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -779,6 +779,9 @@
 /* Define if the targeted system supports the `perf` profiler */
 #undef HAVE_LINUX_PERF_SUPPORT
 
+/* Define to 1 if you have the <linux/tls.h> header file. */
+#undef HAVE_LINUX_TLS_H
+
 /* Define to 1 if you have the <linux/types.h> header file. */
 #undef HAVE_LINUX_TYPES_H
 

--- a/erts/configure
+++ b/erts/configure
@@ -20113,6 +20113,12 @@ then :
   printf "%s\n" "#define HAVE_SYS_UN_H 1" >>confdefs.h
 
 fi
+ac_fn_c_check_header_compile "$LINENO" "linux/tls.h" "ac_cv_header_linux_tls_h" "$ac_includes_default"
+if test "x$ac_cv_header_linux_tls_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_LINUX_TLS_H 1" >>confdefs.h
+
+fi
 
 ac_fn_c_check_func "$LINENO" "getifaddrs" "ac_cv_func_getifaddrs"
 if test "x$ac_cv_func_getifaddrs" = xyes

--- a/erts/preloaded/src/prim_inet.erl
+++ b/erts/preloaded/src/prim_inet.erl
@@ -1556,6 +1556,9 @@ enc_opt(show_econnreset) -> ?INET_LOPT_TCP_SHOW_ECONNRESET;
 enc_opt(line_delimiter)  -> ?INET_LOPT_LINE_DELIM;
 enc_opt(raw)             -> ?INET_OPT_RAW;
 enc_opt(bind_to_device)  -> ?INET_OPT_BIND_TO_DEVICE;
+enc_opt(tcp_ulp)         -> ?TCP_OPT_ULP;
+enc_opt(tls_tx)          -> ?TLS_OPT_TX;
+enc_opt(tls_rx)          -> ?TLS_OPT_RX;
 % Names of SCTP opts:
 enc_opt(sctp_rtoinfo)	 	   -> ?SCTP_OPT_RTOINFO;
 enc_opt(sctp_associnfo)	 	   -> ?SCTP_OPT_ASSOCINFO;
@@ -1623,6 +1626,9 @@ dec_opt(?INET_LOPT_TCP_SHOW_ECONNRESET) -> show_econnreset;
 dec_opt(?INET_LOPT_LINE_DELIM)      -> line_delimiter;
 dec_opt(?INET_OPT_RAW)              -> raw;
 dec_opt(?INET_OPT_BIND_TO_DEVICE) -> bind_to_device;
+dec_opt(?TCP_OPT_ULP)             -> tcp_ulp;
+dec_opt(?TLS_OPT_TX)              -> tls_tx;
+dec_opt(?TLS_OPT_RX)              -> tls_rx;
 dec_opt(I) when is_integer(I)     -> undefined.
 
 
@@ -1731,6 +1737,9 @@ type_opt_1(read_packets)    -> uint;
 type_opt_1(netns)           -> binary;
 type_opt_1(show_econnreset) -> bool;
 type_opt_1(bind_to_device)  -> binary;
+type_opt_1(tcp_ulp)         -> binary;
+type_opt_1(tls_tx)          -> binary;
+type_opt_1(tls_rx)          -> binary;
 %% 
 %% SCTP options (to be set). If the type is a record type, the corresponding
 %% record signature is returned, otherwise, an "elementary" type tag 

--- a/lib/kernel/src/inet_int.hrl
+++ b/lib/kernel/src/inet_int.hrl
@@ -164,6 +164,9 @@
 -define(INET_OPT_TTL,             46).
 -define(INET_OPT_RECVTTL,         47).
 -define(TCP_OPT_NOPUSH,           48).
+-define(TCP_OPT_ULP,              49).
+-define(TLS_OPT_TX,               50).
+-define(TLS_OPT_RX,               51).
 % Specific SCTP options: separate range:
 -define(SCTP_OPT_RTOINFO,	 	100).
 -define(SCTP_OPT_ASSOCINFO,	 	101).

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -988,6 +988,15 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       </desc>
     </datatype>
 
+    <datatype>
+      <name name="use_ktls"/>
+      <desc><p>Specifies whether to use linux kernel TLS offload</p>
+      <p>This is an experimental feature that could introduce a large performance boost.</p>
+      <p>Currently this feature only work for TLS 1.3 with AES_256_GCM_SHA384 cipher on certain linux kernel.</p>
+      <p>It also cannot be enabled when key_update_at is set.</p>
+      </desc>
+    </datatype>
+
     <datatype_title>TLS/DTLS OPTION DESCRIPTIONS - CLIENT</datatype_title>
     
     <datatype>

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -194,6 +194,7 @@
           sni_hosts                  => {[],        [versions]},
           srp_identity               => {undefined, [versions]},
           supported_groups           => {undefined, [versions]},
+          use_ktls                   => {undefined, [versions]},
           use_ticket                 => {undefined, [versions]},
           user_lookup_fun            => {undefined, [versions]},
           verify                     => {verify_none, [versions,

--- a/lib/ssl/test/ktls_basic_SUITE
+++ b/lib/ssl/test/ktls_basic_SUITE
@@ -1,0 +1,143 @@
+-module(ktls_basic_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("public_key/include/public_key.hrl").
+-include("ssl_api.hrl").
+-include("ssl_cipher.hrl").
+-include("ssl_connection.hrl").
+
+%% Callback functions
+-export([
+    all/0,
+    groups/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+%% Testcases
+-export([
+    tls_1_3_aes_gcm_256/0,
+    tls_1_3_aes_gcm_256/1
+]).
+
+%% Apply export
+-export([
+    wait_and_send_recv_result/1,
+    set_ktls_and_send_recv_result/1
+]).
+
+%%--------------------------------------------------------------------
+%% Common Test interface functions -----------------------------------
+%%--------------------------------------------------------------------
+all() ->
+    [{group, basic}].
+
+groups() ->
+    [{basic, [], [tls_1_3_aes_gcm_256]}].
+
+init_per_suite(Config0) ->
+    catch crypto:stop(),
+    try crypto:start() of
+        ok ->
+            ssl_test_lib:clean_start(),
+            ssl_test_lib:make_rsa_cert(Config0)
+    catch _:_ ->
+        {skip, "Crypto did not start"}
+    end.
+
+end_per_suite(_Config) ->
+    ssl:stop(),
+    application:stop(crypto).
+
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    ssl_test_lib:ct_log_supported_protocol_versions(Config),
+    ct:timetrap({seconds, 5}),
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Test Cases --------------------------------------------------------
+%%--------------------------------------------------------------------
+tls_1_3_aes_gcm_256() ->
+    [{doc, "Test that ktls can communicate with ssl application"}].
+tls_1_3_aes_gcm_256(Config) when is_list(Config) ->
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_verify_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_verify_opts, Config),
+
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+
+    Server = ssl_test_lib:start_server([
+        {node, ServerNode},
+        {port, 0},
+        {from, self()},
+        {mfa, {?MODULE, wait_and_send_recv_result, []}},
+        {options, [
+            {keepalive, true},
+            {active, false},
+            {versions, ['tlsv1.3']},
+            {ciphers, [#{cipher => aes_256_gcm, key_exchange => any, mac => aead, prf => sha384}]}
+            | ServerOpts
+        ]}
+    ]),
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_client([
+        {node, ClientNode},
+        {port, Port},
+        {host, Hostname},
+        {from, self()},
+        {mfa, {?MODULE, set_ktls_and_send_recv_result, []}},
+        {options, [
+            {keepalive, true},
+            {active, false},
+            {versions, ['tlsv1.3']},
+            {ciphers, [#{cipher => aes_256_gcm, key_exchange => any, mac => aead, prf => sha384}]}
+            | ClientOpts
+        ]}
+    ]),
+
+    ssl_test_lib:check_result(Server, ok, Client, ok),
+
+    ssl_test_lib:close(Server),
+    ssl_test_lib:close(Client).
+
+wait_and_send_recv_result(Socket) ->
+    timer:sleep(100),
+    Data = "Hello world",
+    ssl:send(Socket, Data),
+    {ok, Data} = ssl:recv(Socket, length(Data)),
+    ok.
+
+set_ktls_and_send_recv_result(#sslsocket{fd = {_, Socket, _, _}, pid = [Receiver | _]}) ->
+    inet:setopts(Socket, [list, {active, false}]),
+    ControlPid = self(),
+    State = sys:replace_state(
+        Receiver,
+        fun(State) ->
+            gen_tcp:controlling_process(Socket, ControlPid),
+            State
+        end
+    ),
+    {_, #state{connection_states = ConnectionStates}} = State,
+    CurrentWrite = maps:get(current_write, ConnectionStates),
+    CurrentRead = maps:get(current_read, ConnectionStates),
+    #cipher_state{iv = <<WriteSalt:4/bytes, WriteIV:8/bytes>>, key = WriteKey} = maps:get(cipher_state, CurrentWrite),
+    #cipher_state{iv = <<ReadSalt:4/bytes, ReadIV:8/bytes>>, key = ReadKey} = maps:get(cipher_state, CurrentRead),
+    WriteSeq = maps:get(sequence_number, CurrentWrite),
+    ReadSeq = maps:get(sequence_number, CurrentRead),
+    % SOL_TCP = 6, TCP_ULP = 31
+    % inet:setopts(Socket, [{raw, 6, 31, <<"tls">>}]),
+    inet:setopts(Socket, [{tcp_ulp, <<"tls">>}]),
+    % SOL_TLS = 282, TLS_TX = 1, TLS_RX = 2, TLS_1_3_VERSION = <<4, 3>>, TLS_CIPHER_AES_GCM_256 = <<52, 0>>
+    % inet:setopts(Socket, [{raw, 282, 1, <<4, 3, 52, 0, WriteIV/binary, WriteKey/binary, WriteSalt/binary, WriteSeq:64>>}]),
+    % inet:setopts(Socket, [{raw, 282, 2, <<4, 3, 52, 0, ReadIV/binary, ReadKey/binary, ReadSalt/binary, ReadSeq:64>>}]),
+    inet:setopts(Socket, [{tls_tx, <<4, 3, 52, 0, WriteIV/binary, WriteKey/binary, WriteSalt/binary, WriteSeq:64>>}]),
+    inet:setopts(Socket, [{tls_rx, <<4, 3, 52, 0, ReadIV/binary, ReadKey/binary, ReadSalt/binary, ReadSeq:64>>}]),
+
+    Data = "Hello world",
+    gen_tcp:send(Socket, Data),
+    {ok, Data} = gen_tcp:recv(Socket, length(Data)),
+    ok.


### PR DESCRIPTION
Linux kernel supports TLS encryption/decryption offload from user space
to kernel space (https://www.kernel.org/doc/html/latest/networking/tls.html).
Add options in prim_inet and inet_drv to support setting this up using atoms,
and get success/fail responses.
Also add ssl application change to illustrate how it will be used.

These two commits is a follow up of discussion in https://erlangforums.com/t/introduce-kernel-tls-in-ssl-application/952
We already experimented replacing inet6_tls_dist with kernel TLS dist protocol in our cluster, and saw **10%~20% global CPU savings** on our major services. We think kernel TLS is a good feature to be supported in OTP, and the change will contain 3 major parts.

1. First commit (optional): add constants in inet_drv, better configuration in prim_inet, and be able to detect setopt failures.
2. Second commit (add 'use_ktls' in ssl options):  With this option enabled, ssl will do kTLS offload setup in ssl_gen_statem:prepare_connection, move the socket control back to the user pid, and close the tls_sender/receiver processes. ssl:send/recv API will also be modified accordingly. (Step 1 is optional because those TLS cipher constants must be copied to the ssl application.)
3. add ktls_dist and ktls6_dist to use kernel TLS feature in dist (optional)

I would like to get some feedback on:
1. Is there any concern on adding these TLS related code in inet_drv? or raw options are more suggested.
2. If it is fine to add these prim_inet options. Does the current API of tcp_ulp/tls_tx/tls_rx looks good?

some other options:
1. make {tcp_ulp, tls} being the only supported option, instead of {tcp_ulp, <<"tls">>} which supports other TCP_ULP
2. use {ktls, init} instead of {tcp_ulp, <<"tls">>}
3. use {tls_1_3_aes_gcm_256_tx, <<WriteIV/binary, WriteKey/binary, WriteSalt/binary, WriteSeq:64>>} instead of {tls_tx, <<4, 3, 52, 0, WriteIV/binary, WriteKey/binary, WriteSalt/binary, WriteSeq:64>>}, this will occupy 12 integers in inet_drv options, where there are only 50 available (out of 256) to be used now
4. use {ktls, {tls_1_3_aes_gcm_256_tx, <<WriteIV/binary, WriteKey/binary, WriteSalt/binary, WriteSeq:64>>}} instead of {tls_tx, <<4, 3, 52, 0, WriteIV/binary, WriteKey/binary, WriteSalt/binary, WriteSeq:64>>}

Is there any suggestion on this? Thanks!

A note not related to this commit but related to the entire kernel TLS effort: I found that once tcp_ulp/tls_tx/tls_rx has been set, the option cannot be changed. So TLS 1.3 key update will result as a disconnect and we need to redo the handshake. I checked openssl 3.1 and it is also the behavior there.

cc: @IngelaAndin 