### PR TITLE
Fix creation of small hashmaps in debug emulator

### DIFF
--- a/erts/emulator/beam/copy.c
+++ b/erts/emulator/beam/copy.c
@@ -163,6 +163,7 @@ Uint size_object_x(Eterm obj, erts_literal_area_t *litopt)
                                 mp  = (flatmap_t*)flatmap_val(obj);
                                 ptr = (Eterm *)mp;
                                 n   = flatmap_get_size(mp) + 1;
+                                ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
                                 sum += n + 2;
                                 ptr += 2; /* hdr + size words */
                                 while (n--) {
@@ -430,6 +431,7 @@ Uint size_shared(Eterm obj)
                     case MAP_HEADER_TAG_FLATMAP_HEAD : {
                         flatmap_t *mp  = (flatmap_t*)flatmap_val(obj);
                         Uint n = flatmap_get_size(mp) + 1;
+                        ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
                         ptr  = (Eterm *)mp;
                         sum += n + 2;
                         ptr += 2; /* hdr + size words */
@@ -566,6 +568,7 @@ cleanup:
                     case MAP_HEADER_TAG_FLATMAP_HEAD : {
                         flatmap_t *mp = (flatmap_t *) ptr;
                         Uint n = flatmap_get_size(mp) + 1;
+                        ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
                         ptr += 2; /* hdr + size words */
                         while (n--) {
                             obj = *ptr++;
@@ -916,6 +919,7 @@ Eterm copy_struct_x(Eterm obj, Uint sz, Eterm** hpp, ErlOffHeap* off_heap,
 		switch (MAP_HEADER_TYPE(hdr)) {
 		    case MAP_HEADER_TAG_FLATMAP_HEAD :
                         i = flatmap_get_size(objp) + 3;
+                        ASSERT(flatmap_get_size(objp) <= MAP_SMALL_MAP_LIMIT);
                         *argp = make_flatmap(htop);
                         while (i--) {
                             *htop++ = *objp++;
@@ -1318,6 +1322,7 @@ Uint copy_shared_calculate(Eterm obj, erts_shcopy_t *info)
                     case MAP_HEADER_TAG_FLATMAP_HEAD : {
                         flatmap_t *mp = (flatmap_t *) ptr;
                         Uint n = flatmap_get_size(mp) + 1;
+                        ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
                         sum += n + 2;
                         ptr += 2; /* hdr + size words */
                         while (n--) {
@@ -1629,6 +1634,7 @@ Uint copy_shared_perform_x(Eterm obj, Uint size, erts_shcopy_t *info,
                     case MAP_HEADER_TAG_FLATMAP_HEAD : {
                         flatmap_t *mp = (flatmap_t *) ptr;
                         Uint n = flatmap_get_size(mp) + 1;
+                        ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
                         *hp++  = *++ptr; /* keys */
                         while (n--) {
                             obj = *++ptr;
@@ -1832,6 +1838,7 @@ Uint copy_shared_perform_x(Eterm obj, Uint size, erts_shcopy_t *info,
                                 case MAP_HEADER_TAG_FLATMAP_HEAD : {
                                     flatmap_t *mp = (flatmap_t *) hscan;
                                     remaining = flatmap_get_size(mp) + 1;
+                                    ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
                                     hscan += 2;
                                     break;
                                 }

--- a/erts/emulator/beam/erl_bif_atomics.c
+++ b/erts/emulator/beam/erl_bif_atomics.c
@@ -227,15 +227,18 @@ BIF_RETTYPE atomics_compare_exchange_4(BIF_ALIST_4)
 BIF_RETTYPE atomics_info_1(BIF_ALIST_1)
 {
     AtomicsRef* p;
-    Uint hsz = MAP4_SZ;
+    Uint hsz = 0;
     Eterm *hp;
     Uint64 max;
     Sint64 min;
     UWord memory;
-    Eterm max_val, min_val, sz_val, mem_val;
+    Eterm keys[4], values[4], res;
+    ErtsHeapFactory factory;
 
     if (!get_ref(BIF_ARG_1, &p))
         BIF_ERROR(BIF_P, BADARG);
+
+    erts_factory_proc_init(&factory, BIF_P);
 
     max = p->is_signed ? ERTS_SINT64_MAX : ERTS_UINT64_MAX;
     min = p->is_signed ? ERTS_SINT64_MIN : 0;
@@ -246,14 +249,17 @@ BIF_RETTYPE atomics_info_1(BIF_ALIST_1)
     erts_bld_uword(NULL, &hsz, p->vlen);
     erts_bld_uword(NULL, &hsz, memory);
 
-    hp = HAlloc(BIF_P, hsz);
-    max_val = erts_bld_uint64(&hp, NULL, max);
-    min_val = erts_bld_sint64(&hp, NULL, min);
-    sz_val  = erts_bld_uword(&hp, NULL, p->vlen);
-    mem_val = erts_bld_uword(&hp, NULL, memory);
+    hp = erts_produce_heap(&factory, hsz, MAP4_SZ);
+    keys[0] = am_max;
+    values[0] = erts_bld_uint64(&hp, NULL, max);
+    keys[1] = am_min;
+    values[1] = erts_bld_sint64(&hp, NULL, min);
+    keys[2] = am_size;
+    values[2]  = erts_bld_uword(&hp, NULL, p->vlen);
+    keys[3] = am_memory;
+    values[3] = erts_bld_uword(&hp, NULL, memory);
 
-    return MAP4(hp, am_max, max_val,
-                am_memory, mem_val,
-                am_min, min_val,
-                am_size, sz_val);
+    res = erts_map_from_ks_and_vs(&factory, keys, values, 4);
+    erts_factory_close(&factory);
+    return res;
 }

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -1291,22 +1291,8 @@ _ET_DECLARE_CHECKED(struct erl_node_*,external_ref_node,Eterm)
      (hp)[MAP_HEADER_FLATMAP_SZ+1] = v2,                                \
      (hp)[MAP_HEADER_FLATMAP_SZ+2] = v3,                                \
      make_flatmap(hp))
-#define MAP4(hp, k1, v1, k2, v2, k3, v3, k4, v4)                \
-    (MAP_HEADER(hp, 4, TUPLE4(hp+4+MAP_HEADER_FLATMAP_SZ, k1, k2, k3, k4)), \
-     (hp)[MAP_HEADER_FLATMAP_SZ+0] = v1,                                \
-     (hp)[MAP_HEADER_FLATMAP_SZ+1] = v2,                                \
-     (hp)[MAP_HEADER_FLATMAP_SZ+2] = v3,                                \
-     (hp)[MAP_HEADER_FLATMAP_SZ+3] = v4,                                \
-     make_flatmap(hp))
-#define MAP5(hp, k1, v1, k2, v2, k3, v3, k4, v4, k5, v5)                \
-    (MAP_HEADER(hp, 5, TUPLE5(hp+5+MAP_HEADER_FLATMAP_SZ, k1, k2, k3, k4, k5)), \
-     (hp)[MAP_HEADER_FLATMAP_SZ+0] = v1,                                \
-     (hp)[MAP_HEADER_FLATMAP_SZ+1] = v2,                                \
-     (hp)[MAP_HEADER_FLATMAP_SZ+2] = v3,                                \
-     (hp)[MAP_HEADER_FLATMAP_SZ+3] = v4,                                \
-     (hp)[MAP_HEADER_FLATMAP_SZ+4] = v5,                                \
-     make_flatmap(hp))
-
+/* MAP4 and greater have to be created with erts_map_from_ks_and_vs as in the
+   debug emulator maps > 3 are hashmaps. */
 
 /* number tests */
 


### PR DESCRIPTION
In the debug emulator hashmaps start being used at maps size 4, so we need to make sure that any maps created in erts are hashmaps when they should be. This PR adds asserts and fixes a couple of places where flatmaps were created when they should not be.