### PR TITLE
erts: on macOS, prefer F_BARRIERFSYNC over of F_FULLFSYNC

### DIFF
--- a/erts/emulator/nifs/unix/unix_prim_file.c
+++ b/erts/emulator/nifs/unix/unix_prim_file.c
@@ -538,7 +538,9 @@ int efile_sync(efile_data_t *d, int data_only) {
     }
 #endif
 
-#if defined(__DARWIN__) && defined(F_FULLFSYNC)
+#if defined(__DARWIN__) && defined(F_BARRIERFSYNC)
+    if(fcntl(u->fd, F_BARRIERFSYNC) < 0) {
+#elif defined(__DARWIN__) && defined(F_FULLFSYNC)
     if(fcntl(u->fd, F_FULLFSYNC) < 0) {
 #else
     if(fsync(u->fd) < 0) {


### PR DESCRIPTION
macOS doesn't really flush buffers to disk during `fsync()` and therefore currently an additional `fcntl()` call is performed to force macOS to do so. Unfortunately that call, known as F_FULLFSYNC, performs more work than an `fsync()` would. This leads to poor I/O performance on macOS (and still doesn't really guarantee data safety according to Apple).

There is another call however, `F_BARRIERFSYNC`, which has more relaxed guarantees than `F_FULLFSYNC` but offers better performance. This PR defaults to `F_BARRIERFSYNC` and still uses `F_FULLFSYNC` if `F_BARRIERFSYNC` is not unavailable for some reason. This is just one way to do it - it could be a compile-time or runtime decision to optimize for data safety or performance. I'm definitely open to suggestions, but I wanted to get feedback through this PR.

On the RabbitMQ team, we ran some of the tasks we perform daily, and found this change to provide significant improvements:
* many CT test suites run 30-50% faster
* some data loading operations are 5 times faster
* publishing to a queue is 2 times faster

What do you think about such a change? Do you think a compile-time or runtime switch is necessary, given this change theoretically could lead to higher risk of data loss (but again, it's not like there is no such risk right now).

For those who want go deeper:
* [Apple Developer portal article recommending `F_BARRIERFSYNC`](https://developer.apple.com/documentation/xcode/reducing-disk-writes)
* [A very long and detailed Twitter thread from the folks porting Linux to Apply Silicon (and many others interested in the topic)](https://twitter.com/marcan42/status/1494213855387734019)
* [Erlang Slack thread about this proposal](https://erlanger.slack.com/archives/C055DJA49/p1648720574451669)