### PR TITLE
JIT: Optimize `bsl` and `bxor` with known small operands

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1313,6 +1313,26 @@ protected:
         }
     }
 
+    bool is_bsl_small(const ArgSource &LHS, const ArgSource &RHS) {
+        /*
+         * In the code compiled by scripts/diffable, there never
+         * seems to be any range information for the RHS. Therefore,
+         * don't bother unless RHS is an immediate small.
+         */
+        if (!(always_small(LHS) && RHS.isSmall())) {
+            return false;
+        } else {
+            auto [min1, max1] = getIntRange(LHS);
+            auto rhs_val = RHS.as<ArgSmall>().getSigned();
+
+            if (min1 < 0 || max1 == 0 || rhs_val < 0) {
+                return false;
+            }
+
+            return rhs_val < Support::clz(max1) - _TAG_IMMED1_SIZE;
+        }
+    }
+
     /* Helpers */
     void emit_gc_test(const ArgWord &Stack,
                       const ArgWord &Heap,

--- a/erts/emulator/beam/jit/arm/instr_arith.cpp
+++ b/erts/emulator/beam/jit/arm/instr_arith.cpp
@@ -1219,11 +1219,21 @@ void BeamModuleAssembler::emit_i_bsl(const ArgLabel &Fail,
                                      const ArgSource &LHS,
                                      const ArgSource &RHS,
                                      const ArgRegister &Dst) {
-    Label generic = a.newLabel(), next = a.newLabel();
     auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
     auto dst = init_destination(Dst, ARG1);
 
+    if (is_bsl_small(LHS, RHS)) {
+        comment("skipped tests because operands and result are always small");
+        a.and_(TMP1, lhs.reg, imm(~_TAG_IMMED1_MASK));
+        a.lsl(TMP1, TMP1, imm(RHS.as<ArgSmall>().getSigned()));
+        a.orr(dst.reg, TMP1, imm(_TAG_IMMED1_SMALL));
+        flush_var(dst);
+        return;
+    }
+
+    Label generic = a.newLabel(), next = a.newLabel();
     bool inline_shift = true;
+
     if (LHS.isImmed() && RHS.isImmed()) {
         /* The compiler should've optimized this away, so we'll fall
          * back to the generic path to simplify the inline

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1308,6 +1308,26 @@ protected:
         }
     }
 
+    bool is_bsl_small(const ArgSource &LHS, const ArgSource &RHS) {
+        /*
+         * In the code compiled by scripts/diffable, there never
+         * seems to be any range information for the RHS. Therefore,
+         * don't bother unless RHS is an immediate small.
+         */
+        if (!(always_small(LHS) && RHS.isSmall())) {
+            return false;
+        } else {
+            auto [min1, max1] = getIntRange(LHS);
+            auto rhs_val = RHS.as<ArgSmall>().getSigned();
+
+            if (min1 < 0 || max1 == 0 || rhs_val < 0) {
+                return false;
+            }
+
+            return rhs_val < Support::clz(max1) - _TAG_IMMED1_SIZE;
+        }
+    }
+
     /* Helpers */
     void emit_gc_test(const ArgWord &Stack,
                       const ArgWord &Heap,

--- a/erts/emulator/beam/jit/x86/instr_arith.cpp
+++ b/erts/emulator/beam/jit/x86/instr_arith.cpp
@@ -1336,6 +1336,17 @@ void BeamModuleAssembler::emit_i_bsl(const ArgSource &LHS,
                                      const ArgSource &RHS,
                                      const ArgLabel &Fail,
                                      const ArgRegister &Dst) {
+    if (is_bsl_small(LHS, RHS)) {
+        comment("skipped tests because operands and result are always small");
+        mov_arg(RET, LHS);
+        ERTS_CT_ASSERT(_TAG_IMMED1_MASK == _TAG_IMMED1_SMALL);
+        a.xor_(RET, imm(_TAG_IMMED1_MASK));
+        a.sal(RET, imm(RHS.as<ArgSmall>().getSigned()));
+        a.or_(RET, imm(_TAG_IMMED1_SMALL));
+        mov_arg(Dst, RET);
+        return;
+    }
+
     bool inline_shift = hasCpuFeature(CpuFeatures::X86::kLZCNT);
     Label generic = a.newLabel(), next = a.newLabel();
 

--- a/erts/emulator/beam/jit/x86/instr_arith.cpp
+++ b/erts/emulator/beam/jit/x86/instr_arith.cpp
@@ -1008,7 +1008,7 @@ void BeamModuleAssembler::emit_i_band(const ArgSource &LHS,
     if (always_small(RHS)) {
         emit_is_small(generic, LHS, ARG2);
     } else {
-        emit_are_both_small(generic, LHS, RET, RHS, ARG2);
+        emit_are_both_small(generic, LHS, ARG2, RHS, RET);
     }
 
     /* TAG & TAG = TAG, so we don't need to tag it again. */
@@ -1063,7 +1063,7 @@ void BeamModuleAssembler::emit_i_bor(const ArgLabel &Fail,
     if (always_small(RHS)) {
         emit_is_small(generic, LHS, ARG2);
     } else {
-        emit_are_both_small(generic, LHS, RET, RHS, ARG2);
+        emit_are_both_small(generic, LHS, ARG2, RHS, RET);
     }
 
     /* TAG | TAG = TAG, so we don't need to tag it again. */
@@ -1111,7 +1111,7 @@ void BeamModuleAssembler::emit_i_bxor(const ArgLabel &Fail,
     if (always_small(RHS)) {
         emit_is_small(generic, LHS, ARG2);
     } else {
-        emit_are_both_small(generic, LHS, RET, RHS, ARG2);
+        emit_are_both_small(generic, LHS, ARG2, RHS, RET);
     }
 
     /* TAG ^ TAG = 0, so we need to tag it again. */

--- a/erts/emulator/beam/jit/x86/instr_arith.cpp
+++ b/erts/emulator/beam/jit/x86/instr_arith.cpp
@@ -1103,10 +1103,19 @@ void BeamModuleAssembler::emit_i_bxor(const ArgLabel &Fail,
                                       const ArgSource &LHS,
                                       const ArgSource &RHS,
                                       const ArgRegister &Dst) {
-    Label generic = a.newLabel(), next = a.newLabel();
-
     mov_arg(ARG2, LHS);
     mov_arg(RET, RHS);
+
+    if (always_small(LHS) && always_small(RHS)) {
+        comment("skipped test for small operands since they are always small");
+        /* TAG ^ TAG = 0, so we need to tag it again. */
+        a.xor_(RET, ARG2);
+        a.or_(RET, imm(_TAG_IMMED1_SMALL));
+        mov_arg(Dst, RET);
+        return;
+    }
+
+    Label generic = a.newLabel(), next = a.newLabel();
 
     if (always_small(RHS)) {
         emit_is_small(generic, LHS, ARG2);


### PR DESCRIPTION
This pull request optimizes the `bsl` and `bxor` instructions when they have known small operands, and also fix a bug where unsafe code could would be generated for `band`, `bor`, and `bxor` in the x86 JIT.

