### PR TITLE
erts: Shrink ErlFunThing structure

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -4417,7 +4417,7 @@ BIF_RETTYPE make_fun_3(BIF_ALIST_3)
     }
 
     arity = signed_val(BIF_ARG_3);
-    if (arity < 0) {
+    if (arity < 0 || arity > MAX_ARG) {
         BIF_ERROR(BIF_P, BADARG);
     }
 

--- a/erts/emulator/beam/erl_fun.h
+++ b/erts/emulator/beam/erl_fun.h
@@ -69,8 +69,8 @@ typedef struct erl_fun_thing {
     /* Next off-heap object, must be NULL when this is an external fun. */
     struct erl_off_heap_header *next;
 
-    Uint arity;             /* The _apparent_ arity of the fun. */
-    Uint num_free;          /* Number of free variables (in env). */
+    byte arity;             /* The _apparent_ arity of the fun. */
+    byte num_free;          /* Number of free variables (in env). */
 
     /* -- The following may be compound Erlang terms ---------------------- */
     Eterm creator;          /* Pid of creator process (contains node). */

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -809,7 +809,7 @@ void BeamModuleAssembler::emit_is_function2(const ArgLabel &Fail,
         a.b_ne(resolve_beam_label(Fail, disp1MB));
     }
 
-    a.ldur(TMP2, emit_boxed_val(boxed_ptr, offsetof(ErlFunThing, arity)));
+    a.ldurb(TMP2.w(), emit_boxed_val(boxed_ptr, offsetof(ErlFunThing, arity)));
     emit_branch_if_ne(TMP2, arity, resolve_beam_label(Fail, dispUnknown));
 }
 

--- a/erts/emulator/beam/jit/arm/instr_fun.cpp
+++ b/erts/emulator/beam/jit/arm/instr_fun.cpp
@@ -366,7 +366,7 @@ arm::Gp BeamModuleAssembler::emit_call_fun(bool skip_box_test,
     }
 
     if (!skip_arity_test) {
-        a.ldr(TMP2, arm::Mem(TMP2, offsetof(ErlFunThing, arity)));
+        a.ldrb(TMP2.w(), arm::Mem(TMP2, offsetof(ErlFunThing, arity)));
         a.cmp(TMP2, ARG3);
     } else {
         comment("skipped arity test since source always has right arity");

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -942,7 +942,8 @@ void BeamModuleAssembler::emit_is_function2(const ArgLabel &Fail,
         a.jne(resolve_beam_label(Fail));
     }
 
-    a.cmp(emit_boxed_val(boxed_ptr, offsetof(ErlFunThing, arity)), imm(arity));
+    a.cmp(emit_boxed_val(boxed_ptr, offsetof(ErlFunThing, arity), sizeof(byte)),
+          imm(arity));
     a.jne(resolve_beam_label(Fail));
 }
 

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -347,7 +347,10 @@ x86::Gp BeamModuleAssembler::emit_call_fun(bool skip_box_test,
     if (skip_arity_test) {
         comment("skipped arity test since source always has right arity");
     } else {
-        a.cmp(emit_boxed_val(fun_thing, offsetof(ErlFunThing, arity)), ARG3);
+        a.cmp(emit_boxed_val(fun_thing,
+                             offsetof(ErlFunThing, arity),
+                             sizeof(byte)),
+              ARG3.r8());
     }
 
     a.mov(RET, emit_boxed_val(fun_thing, offsetof(ErlFunThing, entry)));

--- a/erts/emulator/test/erts_debug_SUITE.erl
+++ b/erts/emulator/test/erts_debug_SUITE.erl
@@ -76,7 +76,7 @@ test_size(Config) when is_list(Config) ->
 
     %% Fun environment size = 0 (the smallest fun possible)
     SimplestFun = fun() -> ok end,
-    FunSz0 = 6,
+    FunSz0 = 5,
     FunSz0 = do_test_size(SimplestFun),
 
     %% Fun environment size = 1


### PR DESCRIPTION
The sum of `arity` and `num_free` cannot exceed 255, so there's no point using a whole word for each.

Note that we will now badarg when passing an arity above 255 to `erlang:make_fun/3`, instead of creating a fun that can never be called and had iffy behavior when sent over the distribution (the arity got truncated down to 8 bits), but it ought to be okay as its spec has always said the valid range is 0..255.