### PR TITLE
Prototype API for fetching os cacerts

### DIFF
--- a/lib/public_key/Makefile
+++ b/lib/public_key/Makefile
@@ -26,7 +26,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 # Macros
 # ----------------------------------------------------
 
-SUB_DIRECTORIES = asn1 src doc/src
+SUB_DIRECTORIES = asn1 src c_src doc/src
 
 include vsn.mk
 VSN = $(PUBLIC_KEY_VSN)

--- a/lib/public_key/c_src/Makefile
+++ b/lib/public_key/c_src/Makefile
@@ -1,0 +1,127 @@
+#
+# %CopyrightBegin%
+# 
+# Copyright Ericsson AB 2022. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# %CopyrightEnd%
+#
+
+include $(ERL_TOP)/make/target.mk
+include $(ERL_TOP)/make/$(TARGET)/otp.mk
+include $(ERL_TOP)/make/$(TARGET)/otp_ded.mk
+
+# ----------------------------------------------------
+# Application version
+# ----------------------------------------------------
+include ../vsn.mk
+VSN=$(PUBLIC_KEY_VSN)
+
+# ----------------------------------------------------
+# The following variables differ on different systems, we set
+# reasonable defaults, if something different is needed it should
+# be set for that system only.
+# ----------------------------------------------------
+CC = $(DED_CC)
+CFLAGS = $(DED_CFLAGS) -I./
+LD = $(DED_LD)
+SHELL = /bin/sh
+#LIBS = $(DED_LIBS) @LIBS@
+LIBS = $(DED_LIBS)
+LDFLAGS += $(DED_LDFLAGS)
+
+PUBKEY_LIBNAME = public_key
+
+SYSINCLUDE = $(DED_SYS_INCLUDE)
+
+PUBKEY_INCLUDES = $(SYSINCLUDE)
+
+ifeq ($(TYPE),debug)
+TYPEMARKER = .debug
+TYPE_FLAGS = $(subst -O3,,$(subst -O2,,$(CFLAGS))) -DDEBUG @DEBUG_FLAGS@
+else
+ifeq ($(TYPE),valgrind)
+TYPEMARKER = .valgrind
+TYPE_FLAGS = $(subst -O3,,$(subst -O2,,$(CFLAGS))) -DVALGRIND
+else
+TYPEMARKER =
+TYPE_FLAGS = $(CFLAGS)
+endif
+endif
+
+#DEFS = @DEFS@
+#CONFIG_H_DIR = @ERTS_CONFIG_H_IDIR@
+
+ALL_CFLAGS = $(DEFS) $(CONFIG_H_DIR) $(TYPE_FLAGS) $(PUBKEY_INCLUDES) \
+	-I$(OBJDIR) -I$(ERL_TOP)/erts/emulator/$(TARGET)
+
+ROOTDIR = $(ERL_TOP)/lib
+PRIVDIR = ../priv
+LIBDIR = $(PRIVDIR)/lib/$(TARGET)
+OBJDIR = $(PRIVDIR)/obj/$(TARGET)
+
+# ----------------------------------------------------
+# Release directory specification
+# ----------------------------------------------------
+RELSYSDIR = $(RELEASE_PATH)/lib/public_key-$(VSN)
+
+# ----------------------------------------------------
+# Misc Macros
+# ----------------------------------------------------
+
+ifeq ($(TARGET),win32)
+PUBKEY_LIB = $(LIBDIR)/$(PUBKEY_LIBNAME)$(TYPEMARKER).$(DED_EXT)
+DIRS = $(OBJDIR) $(LIBDIR)
+endif
+
+# ----------------------------------------------------
+# Targets
+# ----------------------------------------------------
+
+_create_dirs := $(shell mkdir -p $(OBJDIR) $(LIBDIR))
+
+debug opt valgrind: $(DIRS) $(PUBKEY_LIB)
+
+$(OBJDIR):
+	-@mkdir -p $(OBJDIR)
+
+$(LIBDIR):
+	-@mkdir -p $(LIBDIR)
+
+$(OBJDIR)/%$(TYPEMARKER).o: %.c
+	$(V_CC) -c -o $@ $(ALL_CFLAGS) $<
+
+$(LIBDIR)/%$(TYPEMARKER).$(DED_EXT): $(OBJDIR)/%$(TYPEMARKER).o
+	$(V_LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+
+clean:
+	rm -f $(PUBKEY_LIB)
+	rm -f core *~
+
+docs:
+
+# ----------------------------------------------------
+# Release Target
+# ----------------------------------------------------
+include $(ERL_TOP)/make/otp_release_targets.mk
+
+ifeq ($(TARGET),win32)
+release_spec: opt
+	$(INSTALL_DIR) "$(RELSYSDIR)/priv/lib"
+	$(INSTALL_PROGRAM) $(PUBKEY_LIB) "$(RELSYSDIR)/priv/lib"
+else
+release_spec: opt
+
+endif
+release_docs_spec:

--- a/lib/public_key/c_src/public_key.c
+++ b/lib/public_key/c_src/public_key.c
@@ -1,0 +1,107 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2022. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+/*
+ * Purpose:  CaCert fetcher
+ */
+
+#include <erl_nif.h>
+
+#ifdef WINVER  /* Windows */
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <Wincrypt.h>
+#pragma comment(lib, "crypt32.lib")
+#endif
+
+ERL_NIF_TERM ATOM_PKCS_7_ASN_ENCODING;
+ERL_NIF_TERM ATOM_X509_ASN_ENCODING;
+ERL_NIF_TERM ATOM_UNKNOWN;
+
+ERL_NIF_TERM ATOM_OPEN_ERROR;
+
+static ERL_NIF_TERM os_cacerts(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+
+static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+{
+    ATOM_UNKNOWN      = enif_make_atom(env,"unknown");
+    ATOM_OPEN_ERROR   = enif_make_atom(env, "internal_error");
+    ATOM_PKCS_7_ASN_ENCODING  = enif_make_atom(env,"pkcs_7_asn_encoding");
+    ATOM_X509_ASN_ENCODING  = enif_make_atom(env,"x509_asn_encoding");
+
+    return 0;
+}
+
+static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data,
+		   ERL_NIF_TERM load_info)
+{
+    return 0;
+}
+
+static void unload(ErlNifEnv* env, void* priv_data)
+{
+}
+
+static ErlNifFunc nif_funcs[] =
+  {
+   {"os_cacerts", 0, os_cacerts, 0},
+  };
+
+ERL_NIF_INIT(pubkey_os_cacerts, nif_funcs, load, NULL, upgrade, unload)
+
+
+#ifdef WINVER
+ERL_NIF_TERM os_cacerts(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    HANDLE          hStoreHandle = NULL;
+    PCCERT_CONTEXT  pCertContext = NULL;
+    ERL_NIF_TERM    head, tail, der, enc;
+    unsigned char * data;
+
+    hStoreHandle = CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0,
+                                 // CERT_SYSTEM_STORE_LOCAL_MACHINE,
+                                 CERT_SYSTEM_STORE_CURRENT_USER,
+                                 L"ROOT");
+    if (!hStoreHandle) {
+        return ATOM_OPEN_ERROR;
+    }
+
+    tail = enif_make_list(env, 0);
+    while((pCertContext = CertEnumCertificatesInStore(hStoreHandle,pCertContext))) {
+        switch (pCertContext->dwCertEncodingType) {
+        case X509_ASN_ENCODING:
+            enc = ATOM_X509_ASN_ENCODING;
+            break;
+        case PKCS_7_ASN_ENCODING:
+            enc = ATOM_PKCS_7_ASN_ENCODING;
+            break;
+        default:
+            enc = ATOM_UNKNOWN;
+        }
+        data = enif_make_new_binary(env, pCertContext->cbCertEncoded, &der);
+        memcpy(data, pCertContext->pbCertEncoded, pCertContext->cbCertEncoded);
+        head = enif_make_tuple2(env, enc, der);
+        tail = enif_make_list_cell(env, head, tail);
+    }
+
+    CertCloseStore(hStoreHandle, 0);
+    return tail;
+}
+#endif

--- a/lib/public_key/doc/src/public_key.xml
+++ b/lib/public_key/doc/src/public_key.xml
@@ -271,6 +271,34 @@
 <funcs>    
 
   <func>
+    <name name="cacerts_get" arity="0" since="OTP @OTP-17789@"/>
+    <fsummary>Returns CA certificates.</fsummary>
+    <desc>
+      <p>Returns the trusted CA certificates if any are loaded, otherwise
+      uses <seemfa marker="#cacerts_load/0">cacerts_load/0</seemfa> to load them.
+      The function fails if no <c>cacerts</c> could be loaded.</p>
+    </desc>
+  </func>
+
+  <func>
+    <name name="cacerts_load" arity="0" since="OTP @OTP-17789@"/>
+    <fsummary>Loads OS specific CA certificates.</fsummary>
+    <desc>
+      <p>Loads the OS supplied trusted CA certificates.
+      </p>
+    </desc>
+  </func>
+
+  <func>
+    <name name="cacerts_load" arity="1" since="OTP @OTP-17789@"/>
+    <fsummary>Loads CA certificates.</fsummary>
+    <desc>
+      <p>Loads the trusted CA certificates from a file.
+      </p>
+    </desc>
+  </func>
+
+  <func>
     <name name="compute_key" arity="2" since="OTP R16B01"/>
     <fsummary>Computes shared secret.</fsummary>
   <desc>

--- a/lib/public_key/src/Makefile
+++ b/lib/public_key/src/Makefile
@@ -47,7 +47,8 @@ MODULES = \
 	pubkey_cert \
         pubkey_cert_records \
 	pubkey_crl\
-	pubkey_ocsp
+	pubkey_ocsp \
+	pubkey_os_cacerts
 
 HRL_FILES = $(INCLUDE)/public_key.hrl 
 

--- a/lib/public_key/src/pubkey_os_cacerts.erl
+++ b/lib/public_key/src/pubkey_os_cacerts.erl
@@ -1,0 +1,208 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2008-2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+
+-module(pubkey_os_cacerts).
+
+-include("public_key.hrl").
+-export([load/0, load/1, get/0, clear/0]).
+
+-on_load(on_load/0).
+-nifs([os_cacerts/0]).
+
+%% API
+
+%% Return cacerts
+-spec get() -> [public_key:combined_cert()].
+get() ->
+    case persistent_term:get(?MODULE, not_loaded) of
+        not_loaded ->
+            ok = load(),
+            persistent_term:get(?MODULE);
+        CaCerts ->
+            CaCerts
+    end.
+
+%% (Re)Load default os cacerts and cache result.
+-spec load() ->  ok | {error, Reason::term()}.
+load() ->
+    case os:type() of
+        {unix, linux} ->
+            load_from_file(linux_paths());
+        {unix, openbsd} ->
+            load_from_file(bsd_paths());
+        {unix, freebsd} ->
+            load_from_file(bsd_paths());
+        {unix, netbsd} ->
+            load_from_file(bsd_paths());
+        {unix, sunos} ->
+            load_from_files(sunos_path());
+        {win32, _} ->
+            load_win32();
+	{unix, darwin} ->
+            load_darwin();
+        Os ->
+            {error, {enotsup, Os}}
+    end.
+
+%% (Re)Load cacerts from file and cache result.
+%% The file-paths will be tried in order.
+%% Can be used when load/0 doesn't work for an unsupported os type.
+-spec load([file:filename_all()]) -> ok | {error, Reason::term()}.
+load(Paths) ->
+    load_from_file(Paths).
+
+
+%% cleanup persistent_key
+-spec clear() -> boolean().
+clear() ->
+    persistent_term:erase(?MODULE).
+
+%% Implementation
+load_from_file([Path|Paths]) when is_list(Path); is_binary(Path) ->
+    try
+        {ok, Binary} = file:read_file(Path),
+        ok = decode_result(Binary)
+    catch _:_Reason ->
+            load_from_file(Paths)
+    end;
+load_from_file([]) ->
+    {error, enoent}.
+
+decode_result(Binary) ->
+    try
+        MakeCert = fun({'Certificate', Der, not_encrypted}, Acc) ->
+                           try
+                               Decoded = public_key:pkix_decode_cert(Der, otp),
+                               [#cert{der=Der, otp=Decoded}|Acc]
+                           catch _:_ ->
+                                   Acc
+                           end
+                   end,
+        Certs = lists:foldl(MakeCert, [], pubkey_pem:decode(Binary)),
+        store(Certs)
+    catch _:Reason ->
+            {error, Reason}
+    end.
+
+
+load_from_files(Path) ->
+    MakeCert = fun(FileName, Acc) ->
+                       try
+                           {ok, Bin} = file:read_file(FileName),
+                           [#cert{der=Der, otp=public_key:pkix_decode_cert(Der, otp)}
+                            || {'Certificate', Der, not_encrypted} <- pubkey_pem:decode(Bin)]
+                               ++ Acc
+                       catch _:_ ->
+                               Acc
+                       end
+               end,
+    Certs = filelib:fold_files(Path, ".*\.pem", false, MakeCert, []),
+    store(Certs).
+
+
+load_win32() ->
+    Dec = fun({_Enc, Der}, Acc) ->
+                  try
+                      Decoded = public_key:pkix_decode_cert(Der, otp),
+                      [#cert{der=Der, otp=Decoded}|Acc]
+                  catch _:_ ->
+                          Acc
+                  end
+          end,
+    store(lists:foldl(Dec, [], os_cacerts())).
+
+load_darwin() ->
+    %% Could/should probably be re-written to use Keychain Access API
+    KeyChainFile = "/System/Library/Keychains/SystemRootCertificates.keychain",
+    case run_cmd("/usr/bin/security", ["export", "-t",  "certs", "-f", "pemseq", "-k", KeyChainFile]) of
+        {ok, Bin} -> decode_result(Bin);
+        Err -> Err
+    end.
+
+store([]) ->
+    {error, no_cacerts_found};
+store(CaCerts) ->
+    persistent_term:put(?MODULE, CaCerts).
+
+linux_paths() ->
+    ["/etc/ssl/certs/ca-certificates.crt",
+     "/etc/pki/tls/certs/ca-bundle.crt",
+     "/etc/ssl/ca-bundle.pem"
+    ].
+
+bsd_paths() ->
+    ["/usr/local/share/certs/ca-root-nss.crt",
+     "/etc/ssl/cert.pem",
+     "/etc/openssl/certs/cacert.pem",   %% netbsd (if installed)
+     "/etc/openssl/certs/ca-certificates.crt"
+    ].
+
+sunos_path() ->
+    "/etc/certs/CA/".
+
+run_cmd(Cmd, Args) ->
+    Port = open_port({spawn_executable, Cmd}, [{args, Args}, binary, exit_status]),
+    cmd_data(Port, <<>>).
+
+cmd_data(Port, Acc) ->
+    receive
+        {Port, {data, Bin}} ->
+            cmd_data(Port, <<Acc/binary, Bin/binary>>);
+        {Port, {exit_status, 0}} ->
+            {ok, Acc};
+        {Port, {exit_status, Status}} ->
+            {error, {eopnotsupp, Status, Acc}}
+    end.
+
+%%%
+%%% NIF placeholders
+%%%
+
+-spec os_cacerts() -> [{Encoding::atom(), Cert::binary()}].
+
+os_cacerts() ->
+    erlang:nif_error(nif_not_loaded).
+
+on_load() ->
+    case os:type() of
+        {win32, _} -> load_nif();
+        _ -> ok
+    end.
+
+load_nif() ->
+    PrivDir = code:priv_dir(public_key),
+    LibName = "public_key",
+    Lib = filename:join([PrivDir, "lib", LibName]),
+    case erlang:load_nif(Lib, 0) of
+        ok -> ok;
+        {error, {load_failed, _}}=Error1 ->
+            Arch = erlang:system_info(system_architecture),
+            ArchLibDir = filename:join([PrivDir, "lib", Arch]),
+            Candidate =  filelib:wildcard(filename:join([ArchLibDir,LibName ++ "*" ])),
+            case Candidate of
+                [] -> Error1;
+                _ ->
+                    ArchLib = filename:join([ArchLibDir, LibName]),
+                    erlang:load_nif(ArchLib, 0)
+            end;
+        Error1 -> Error1
+    end.

--- a/lib/public_key/src/public_key.app.src
+++ b/lib/public_key/src/public_key.app.src
@@ -9,6 +9,7 @@
 		  pubkey_cert_records,
 		  pubkey_crl,
                   pubkey_ocsp,
+                  pubkey_os_cacerts,
 		  'OTP-PUB-KEY',
 		  'PKCS-FRAME'
             ]},

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -63,7 +63,11 @@
          pkix_test_root_cert/2,
          pkix_ocsp_validate/5,
          ocsp_responder_id/1,
-         ocsp_extensions/1
+         ocsp_extensions/1,
+         cacerts_get/0,
+         cacerts_load/0,
+         cacerts_load/1,
+         cacerts_clear/0
 	]).
 
 %%----------------
@@ -1397,6 +1401,39 @@ ocsp_extensions(Nonce) ->
 %%--------------------------------------------------------------------
 ocsp_responder_id(Cert) ->
     pubkey_ocsp:get_ocsp_responder_id(Cert).
+
+%%--------------------------------------------------------------------
+-spec cacerts_get() -> [combined_cert()].
+%%
+%% Description: Get loaded cacerts, if none are loaded it will try to
+%%              load OS provided cacerts
+%%--------------------------------------------------------------------
+cacerts_get() ->
+    pubkey_os_cacerts:get().
+
+%%--------------------------------------------------------------------
+-spec cacerts_load() -> ok | {error, Reason::term()}.
+%%
+%% Description: (Re)Load OS provided cacerts
+%%--------------------------------------------------------------------
+cacerts_load() ->
+    pubkey_os_cacerts:load().
+
+%%--------------------------------------------------------------------
+-spec cacerts_load(File::file:filename_all()) -> ok | {error, Reason::term()}.
+%%
+%% Description: (Re)Load cacerts from a file
+%%--------------------------------------------------------------------
+cacerts_load(File) ->
+    pubkey_os_cacerts:load([File]).
+
+%%--------------------------------------------------------------------
+-spec cacerts_clear() -> boolean().
+%%
+%% Description: Clears loaded cacerts, returns true if any was loaded.
+%%--------------------------------------------------------------------
+cacerts_clear() ->
+    pubkey_os_cacerts:clear().
 
 %%--------------------------------------------------------------------
 %%% Internal functions

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -119,8 +119,12 @@
          gen_ec_param_prime_field/0,
          gen_ec_param_prime_field/1,
          gen_ec_param_char_2_field/0,
-         gen_ec_param_char_2_field/1
+         gen_ec_param_char_2_field/1,
+         cacerts_load/0, cacerts_load/1
         ]).
+
+-export([list_cacerts/0]).  % debug exports
+
 
 -define(TIMEOUT, 120000). % 2 min
 -define(PASSWORD1, "1234abcd").
@@ -157,7 +161,8 @@ all() ->
      pkix_test_data_all_default,
      pkix_test_data,
      short_cert_issuer_hash, 
-     short_crl_issuer_hash
+     short_crl_issuer_hash,
+     cacerts_load
     ].
 
 groups() -> 
@@ -1215,6 +1220,97 @@ gen_ec_param_char_2_field() ->
 gen_ec_param_char_2_field(Config) when is_list(Config) ->
     Datadir = proplists:get_value(data_dir, Config),
     do_gen_ec_param(filename:join(Datadir, "ec_key_param1.pem")).
+
+%%--------------------------------------------------------------------
+cacerts_load() ->
+    [{doc, "Basic tests of cacerts functionality"}].
+cacerts_load(Config) ->
+    Datadir = proplists:get_value(data_dir, Config),
+    {error, enoent} = public_key:cacerts_load("/dummy.file"),
+    %% Load default OS certs
+    %%    there is no default installed OS certs on netbsd
+    %%    can be installed with 'pkgin install mozilla-rootcerts'
+    IsNetBsd = element(2, os:type()) =:= netbsd,
+    OsCerts = try
+                  Certs = public_key:cacerts_get(),
+                  true = public_key:cacerts_clear(),
+                  Certs
+              catch _:{badmatch, {error, enoent}} when IsNetBsd -> netbsd
+              end,
+
+    false = public_key:cacerts_clear(),
+
+    %% Reload from file
+    ok = public_key:cacerts_load(filename:join(Datadir, "cacerts.pem")),
+    [_TestCert1, _TestCert2] = public_key:cacerts_get(),
+
+    %% Re-Load default OS certs
+    try
+        ok = public_key:cacerts_load(),
+        ct:log("~p: ~p~n", [os:type(), length(OsCerts)]),
+        OsCerts = public_key:cacerts_get(),
+        Ids = cert_info(OsCerts),
+        Check = fun(ShouldBeThere) ->
+                        lists:any(fun(#{id:=Id}) -> lists:prefix(ShouldBeThere, Id) end, Ids)
+                end,
+        case lists:partition(Check, ["digicert", "globalsign"]) of
+            {_, []} -> ok;
+            {_, Fail} ->
+                cert_info(OsCerts),
+                [] = Fail
+        end,
+        ok
+    catch _:{badmatch, {error, enoent}} when IsNetBsd ->
+            ok
+    end.
+
+cert_info([#cert{der=Der, otp=#'OTPCertificate'{tbsCertificate = C0}=Cert}|Rest]) when is_binary(Der) ->
+    #'OTPTBSCertificate'{subject = Subject, serialNumber = _Nr, issuer = Issuer0} = C0,
+    C = case public_key:pkix_is_self_signed(Cert) of
+            true  -> #{id => subject(Subject), ss => true};
+            false ->
+                case public_key:pkix_issuer_id(Cert, other) of
+                    {ok, {_IsNr, Issuer}} ->
+                        #{id => subject(Subject), ss => false, issuer => subject(Issuer)};
+                    {error, _} ->
+                        #{id => subject(Subject), ss => false, issuer => subject(Issuer0)}
+                end
+        end,
+    [C|cert_info(Rest)];
+cert_info([]) ->
+    [].
+
+
+subject(S) ->
+    string:lowercase(subject(public_key:pkix_normalize_name(S), "unknown")).
+
+subject({rdnSequence, Seq}, Def) ->
+    subject(Seq, Def);
+subject([[{'AttributeTypeAndValue', ?'id-at-commonName', Name0}]|_], _Def) ->
+    case Name0 of
+        {printableString, Name} -> Name;
+        {utf8String, Name} -> unicode:characters_to_list(Name);
+        Name -> Name
+    end;
+subject([[{'AttributeTypeAndValue', ?'id-at-organizationName', Name0}]|Rest], _Def) ->
+    Name = case Name0 of
+               {printableString, Name1} -> Name1;
+               {utf8String, Name1} -> unicode:characters_to_list(Name1);
+               Name1 -> Name1
+           end,
+    subject(Rest, Name);
+subject([_|R], Def) ->
+    subject(R, Def);
+subject([], Def) ->
+    Def.
+
+list_cacerts() ->
+    Certs = public_key:cacerts_get(),
+    %% io:format("~P~n",[Certs, 20]),
+    IO = fun(C, N) -> io:format("~.3w:~0p~n", [N,C]), N+1 end,
+    lists:foldl(IO, 0, lists:sort(cert_info(Certs))),
+    ok.
+
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -423,7 +423,7 @@
 -type client_reuse_session()     :: session_id() | {session_id(), SessionData::binary()}.
 -type client_reuse_sessions()    :: boolean() | save.
 -type certificate_authorities()  :: boolean().
--type client_cacerts()           :: [public_key:der_encoded()].
+-type client_cacerts()           :: [public_key:der_encoded()] | [public_key:combined_cert()].
 -type client_cafile()            :: file:filename().
 -type app_level_protocol()       :: binary().
 -type client_alpn()              :: [app_level_protocol()].
@@ -466,7 +466,7 @@
                                 {cookie, cookie()} |
                                 {early_data, server_early_data()}.
 
--type server_cacerts()           :: [public_key:der_encoded()].
+-type server_cacerts()           :: [public_key:der_encoded()] | [public_key:combined_cert()].
 -type server_cafile()            :: file:filename().
 -type server_alpn()              :: [app_level_protocol()].
 -type server_next_protocol()     :: [app_level_protocol()].

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -25,6 +25,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("ssl/src/ssl_api.hrl").
+-include_lib("public_key/include/public_key.hrl").
 
 %% Common test
 -export([all/0,
@@ -1832,7 +1833,36 @@ der_input(Config) when is_list(Config) ->
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client),
     %% Using only DER input should not increase file indexed DB 
-    Size = ets:info(CADb, size).
+    Size = ets:info(CADb, size),
+
+    ServerOpts1 = [{verify, verify_peer}, {fail_if_no_peer_cert, true},
+                   {dh, DHParams},
+                   {cert, ServerCert}, {key, ServerKey},
+                   {cacerts, [ #cert{der=Der, otp=public_key:pkix_decode_cert(Der, otp)}
+                               || Der <- ServerCaCerts]}],
+    ClientOpts1 = [{verify, verify_peer}, {fail_if_no_peer_cert, true},
+                   {dh, DHParams},
+                   {cert, ClientCert}, {key, ClientKey},
+                   {cacerts, [ #cert{der=Der, otp=public_key:pkix_decode_cert(Der, otp)}
+                               || Der <- ClientCaCerts]}],
+    Server1 = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                                         {from, self()},
+                                         {mfa, {ssl_test_lib, send_recv_result, []}},
+                                         {options, [{active, false} | ServerOpts1]}]),
+    Port1 = ssl_test_lib:inet_port(Server1),
+    Client1 = ssl_test_lib:start_client([{node, ClientNode}, {port, Port1},
+                                         {host, Hostname},
+                                         {from, self()},
+                                         {mfa, {ssl_test_lib, send_recv_result, []}},
+                                         {options, [{active, false} | ClientOpts1]}]),
+
+    ssl_test_lib:check_result(Server1, ok, Client1, ok),
+    ssl_test_lib:close(Server1),
+    ssl_test_lib:close(Client1),
+    %% Using only DER input should not increase file indexed DB 
+    Size = ets:info(CADb, size),
+
+    ok.
 
 %%--------------------------------------------------------------------
 invalid_certfile() ->

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -1324,7 +1324,10 @@ format_certs(Cert) when is_binary(Cert) ->
     lists:flatten(format_cert(Cert)).
 
 format_cert(BinCert) when is_binary(BinCert) ->
-    OtpCert = #'OTPCertificate'{tbsCertificate = Cert} = public_key:pkix_decode_cert(BinCert, otp),
+    format_cert(public_key:pkix_decode_cert(BinCert, otp));
+format_cert(#cert{otp=Otp}) ->
+    format_cert(Otp);
+format_cert(#'OTPCertificate'{tbsCertificate = Cert} = OtpCert) ->
     #'OTPTBSCertificate'{subject = Subject, serialNumber = Nr, issuer = Issuer} = Cert,
     case public_key:pkix_is_self_signed(OtpCert) of
         true ->


### PR DESCRIPTION
API: load/0 load/1 and get/0

Writes to persistent_term to cache the results,
user can re-load cache with load/0 and load/1 functions.

load/1 is made for users with an unsupported OS, or if they
want to load the cache with data from another file.

Currently works on linux (ubuntu) and win32