### PR TITLE
Fix use of ssl_pkix_db:lookup for CRLs

### DIFF
--- a/lib/ssl/src/ssl_crl_cache.erl
+++ b/lib/ssl/src/ssl_crl_cache.erl
@@ -56,7 +56,7 @@ select(Issuer, {{_Cache, Mapping},_}) ->
     case ssl_pkix_db:lookup(Issuer, Mapping) of
 	undefined ->
 	    [];
-	CRLs ->
+	[CRLs] ->
 	    CRLs
     end.
 
@@ -175,7 +175,7 @@ cache_lookup(URL, {{Cache, _}, _}) ->
     case ssl_pkix_db:lookup(string:trim(Path, leading, "/"), Cache) of
 	undefined ->
 	    [];
-	CRLs ->
+	[CRLs] ->
 	    CRLs
     end.
 

--- a/lib/ssl/src/ssl_pkix_db.erl
+++ b/lib/ssl/src/ssl_pkix_db.erl
@@ -365,7 +365,7 @@ remove_crls([_,_,_, {Cache, Mapping} | _], Path) ->
     case lookup(Path, Cache) of
 	undefined ->
 	    ok;
-	CRLs ->
+	[CRLs] ->
 	    remove(Path, Cache),
 	    [rm_crls(CRL, Mapping) || CRL <- CRLs]
     end.


### PR DESCRIPTION
In all other usages of `ssl_pkix_db:lookup/2`, the code takes into
account that `ets:lookup/2` returns a list of matching objects, such as
here:

https://github.com/erlang/otp/blob/22554251b4cd944053035021289c2a5a71cf72fa/lib/ssl/src/ssl_pkix_db.erl#L106-L112

This fixes the cases for CRLs.