### PR TITLE
Compiler: Improve bounds calculation for bitwise operators

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -48,6 +48,7 @@ RELSYSDIR = $(RELEASE_PATH)/lib/compiler-$(VSN)
 MODULES =  \
 	beam_a \
 	beam_asm \
+	beam_bounds \
 	beam_block \
 	beam_call_types \
 	beam_clean \

--- a/lib/compiler/src/beam_bounds.erl
+++ b/lib/compiler/src/beam_bounds.erl
@@ -1,0 +1,195 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% Purpose: Calculate tight bounds for integer operations.
+%%
+%% Reference:
+%%
+%%    Henry S. Warren, Jr. Hacker's Delight (2 ed). Addison Wesley -
+%%    Pearson Education, Inc. Chapter 4. Arithmetic Bounds.
+%%
+%%
+-module(beam_bounds).
+-export(['band'/2,'bor'/2,'bxor'/2]).
+
+-type range() :: {integer(), integer()} | 'any'.
+
+-spec 'band'(range(), range()) -> range().
+
+'band'({A,B}, {C,D}) when A >= 0, A bsr 256 =:= 0, C >= 0, C bsr 256 =:= 0 ->
+    Min = min_band(A, B, C, D),
+    Max = max_band(A, B, C, D),
+    {Min,Max};
+'band'(_, {C,D}) when C >= 0 ->
+    {0,D};
+'band'({A,B}, _) when A >= 0 ->
+    {0,B};
+'band'(_, _) ->
+    any.
+
+-spec 'bor'(range(), range()) -> range().
+
+'bor'({A,B}, {C,D}) when A >= 0, A bsr 256 =:= 0, C >= 0, C bsr 256 =:= 0 ->
+    Min = min_bor(A, B, C, D),
+    Max = max_bor(A, B, C, D),
+    {Min,Max};
+'bor'(_, _) ->
+    any.
+
+-spec 'bxor'(range(), range()) -> range().
+
+'bxor'({A,B}, {C,D}) when A >= 0, A bsr 256 =:= 0, C >= 0, C bsr 256 =:= 0 ->
+    Max = max_bxor(A, B, C, D),
+    {0,Max};
+'bxor'(_, _) ->
+    any.
+
+min_band(A, B, C, D) ->
+    M = 1 bsl (upper_bit(A bor C) + 1),
+    min_band(A, B, C, D, M).
+
+min_band(A, _B, C, _D, 0) ->
+    A band C;
+min_band(A, B, C, D, M) ->
+    if
+        (bnot A) band (bnot C) band M =/= 0 ->
+            case (A bor M) band -M of
+                NewA when NewA =< B ->
+                    min_band(NewA, B, C, D, 0);
+                _ ->
+                    case (C bor M) band -M of
+                        NewC when NewC =< D ->
+                            min_band(A, B, NewC, D, 0);
+                        _ ->
+                            min_band(A, B, C, D, M bsr 1)
+                    end
+            end;
+        true ->
+            min_band(A, B, C, D, M bsr 1)
+    end.
+
+max_band(A, B, C, D) ->
+    M = 1 bsl upper_bit(B bxor D),
+    max_band(A, B, C, D, M).
+
+max_band(_A, B, _C, D, 0) ->
+    B band D;
+max_band(A, B, C, D, M) ->
+    if
+        B band (bnot D) band M =/= 0 ->
+            case (B band (bnot M)) bor (M - 1) of
+                NewB when NewB >= A ->
+                    max_band(A, NewB, C, D, 0);
+                _ ->
+                    max_band(A, B, C, D, M bsr 1)
+            end;
+        (bnot B) band D band M =/= 0 ->
+            case (D band (bnot M)) bor (M - 1) of
+                NewD when NewD >= C ->
+                    max_band(A, B, C, NewD, 0);
+                _ ->
+                    max_band(A, B, C, D, M bsr 1)
+            end;
+        true ->
+            max_band(A, B, C, D, M bsr 1)
+    end.
+
+min_bor(A, B, C, D) ->
+    M = 1 bsl upper_bit(A bxor C),
+    min_bor(A, B, C, D, M).
+
+min_bor(A, _B, C, _D, 0) ->
+    A bor C;
+min_bor(A, B, C, D, M) ->
+    if
+        (bnot A) band C band M =/= 0 ->
+            case (A bor M) band -M of
+                NewA when NewA =< B ->
+                    min_bor(NewA, B, C, D, 0);
+                _ ->
+                    min_bor(A, B, C, D, M bsr 1)
+            end;
+        A band (bnot C) band M =/= 0 ->
+            case (C bor M) band -M of
+                NewC when NewC =< D ->
+                    min_bor(A, B, NewC, D, 0);
+                _ ->
+                    min_bor(A, B, C, D, M bsr 1)
+            end;
+        true ->
+            min_bor(A, B, C, D, M bsr 1)
+    end.
+
+max_bor(A, B, C, D) ->
+    Intersection = B band D,
+    M = 1 bsl upper_bit(Intersection),
+    max_bor(Intersection, A, B, C, D, M).
+
+max_bor(_Intersection, _A, B, _C, D, 0) ->
+    B bor D;
+max_bor(Intersection, A, B, C, D, M) ->
+    if
+        Intersection band M =/= 0 ->
+            case (B - M) bor (M - 1) of
+                NewB when NewB >= A ->
+                    max_bor(Intersection, A, NewB, C, D, 0);
+                _ ->
+                    case (D - M) bor (M - 1) of
+                        NewD when NewD >= C ->
+                            max_bor(Intersection, A, B, C, NewD, 0);
+                        _ ->
+                            max_bor(Intersection, A, B, C, D, M bsr 1)
+                    end
+            end;
+        true ->
+            max_bor(Intersection, A, B, C, D, M bsr 1)
+    end.
+
+max_bxor(A, B, C, D) ->
+    M = 1 bsl upper_bit(B band D),
+    max_bxor(A, B, C, D, M).
+
+max_bxor(_A, B, _C, D, 0) ->
+    B bxor D;
+max_bxor(A, B, C, D, M) ->
+    if
+        B band D band M =/= 0 ->
+            case (B - M) bor (M - 1) of
+                NewB when NewB >= A ->
+                    max_bxor(A, NewB, C, D, M bsr 1);
+                _ ->
+                    case (D - M) bor (M - 1) of
+                        NewD when NewD >= C ->
+                            max_bxor(A, B, C, NewD, M bsr 1);
+                        _ ->
+                            max_bxor(A, B, C, D, M bsr 1)
+                    end
+            end;
+        true ->
+            max_bxor(A, B, C, D, M bsr 1)
+    end.
+
+upper_bit(Val) ->
+    upper_bit_1(Val, 0).
+
+upper_bit_1(Val0, N) ->
+    case Val0 bsr 1 of
+        0 -> N;
+        Val -> upper_bit_1(Val, N + 1)
+    end.

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -831,6 +831,8 @@ arith_type({bif,'band'}, ArgTypes) ->
     erlang_band_type(ArgTypes);
 arith_type({bif,'bor'}, Args) ->
     erlang_bor_type(Args);
+arith_type({bif,'bxor'}, Args) ->
+    erlang_bxor_type(Args);
 arith_type({bif,'bsr'}, [#t_integer{elements={Min0,Max0}},
                          #t_integer{elements={S1,S2}}])
   when 0 < S1 ->
@@ -879,58 +881,23 @@ erlang_tl_type(Src) ->
         none -> none
     end.
 
-erlang_band_type([#t_integer{elements={Int,Int}}, RHS]) when is_integer(Int) ->
-    erlang_band_type_1(RHS, Int);
-erlang_band_type([LHS, #t_integer{elements={Int,Int}}]) when is_integer(Int) ->
-    erlang_band_type_1(LHS, Int);
-erlang_band_type(_) ->
+erlang_band_type([#t_integer{elements=Range1}, #t_integer{elements=Range2}]) ->
+    #t_integer{elements=beam_bounds:'band'(Range1, Range2)};
+erlang_band_type([#t_integer{elements=Range}, _RHS]) ->
+    #t_integer{elements=beam_bounds:'band'(Range, any)};
+erlang_band_type([_LHS, #t_integer{elements=Range}]) ->
+    #t_integer{elements=beam_bounds:'band'(any, Range)};
+erlang_band_type([_, _]) ->
     #t_integer{}.
 
-erlang_band_type_1(LHS, Int) ->
-    case LHS of
-        #t_integer{elements={Min0,Max0}} when Max0 - Min0 < 1 bsl 256 ->
-            {Intersection, Union} = range_masks(Min0, Max0),
-
-            Min = Intersection band Int,
-            Max = max(Min, min(Max0, Union band Int)),
-
-            #t_integer{elements={Min,Max}};
-        _ when Int > 0 ->
-            %% The range is either unknown or too wide, conservatively assume
-            %% that the new range is 0 .. Int. Note that since Int > 0, we
-            %% will never produce a singleton value. Producing a singleton value
-            %% is probably harmless, but will produce worse code when it
-            %% is not known that the operation will succeed.
-            beam_types:meet(LHS, #t_integer{elements={0,Int}});
-        _ ->
-            %% We can't infer boundaries when LHS is not an integer or
-            %% the range is unknown and the other operand is a
-            %% negative number, as the latter sign-extends to infinity
-            %% and we can't express an inverted range at the moment
-            %% (cf. X band -8; either less than -7 or greater than 7).
-            beam_types:meet(LHS, #t_integer{})
-    end.
-
-erlang_bor_type([#t_integer{elements={Int,Int}}, RHS]) when is_integer(Int) ->
-    erlang_bor_type_1(RHS, Int);
-erlang_bor_type([LHS, #t_integer{elements={Int,Int}}]) when is_integer(Int) ->
-    erlang_bor_type_1(LHS, Int);
-erlang_bor_type(_) ->
+erlang_bor_type([#t_integer{elements=Range1}, #t_integer{elements=Range2}]) ->
+    #t_integer{elements=beam_bounds:'bor'(Range1, Range2)};
+erlang_bor_type([_, _]) ->
     #t_integer{}.
 
-erlang_bor_type_1(LHS, Int) when Int >= 0 ->
-    case LHS of
-        #t_integer{elements={Min0,Max0}} when Min0 >= 0, Max0 - Min0 < 1 bsl 256 ->
-            {_Intersection, Union} = range_masks(Min0, Max0),
-
-            Min = max(Min0, Int),
-            Max = Union bor Int,
-
-            #t_integer{elements={Min,Max}};
-        _ ->
-            beam_types:meet(LHS, #t_integer{})
-    end;
-erlang_bor_type_1(_, _) ->
+erlang_bxor_type([#t_integer{elements=Range1}, #t_integer{elements=Range2}]) ->
+    #t_integer{elements=beam_bounds:'bxor'(Range1, Range2)};
+erlang_bxor_type([_, _]) ->
     #t_integer{}.
 
 erlang_div_type(ArgTypes) ->
@@ -1136,21 +1103,6 @@ discard_tuple_element_info(Min, Max, Es) ->
                   maps:remove(El, Acc);
              (_El, Acc) -> Acc
           end, Es, maps:keys(Es)).
-
-%% Returns two bitmasks describing all possible values between From and To.
-%%
-%% The first contains the bits that are common to all values, and the second
-%% contains the bits that are set by any value in the range.
-range_masks(From, To) when From =< To ->
-    range_masks_1(From, To, 0, -1, 0).
-
-range_masks_1(From, To, BitPos, Intersection, Union) when From < To ->
-    range_masks_1(From + (1 bsl BitPos), To, BitPos + 1,
-                  Intersection band From, Union bor From);
-range_masks_1(_From, To, _BitPos, Intersection0, Union0) ->
-    Intersection = To band Intersection0,
-    Union = To bor Union0,
-    {Intersection, Union}.
 
 proper_cons() ->
     #t_cons{terminator=nil}.

--- a/lib/compiler/src/compiler.app.src
+++ b/lib/compiler/src/compiler.app.src
@@ -23,6 +23,7 @@
   {modules, [
 	     beam_a,
 	     beam_asm,
+             beam_bounds,
 	     beam_block,
              beam_call_types,
 	     beam_clean,

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -9,6 +9,7 @@ MODULES= \
 	andor_SUITE \
 	apply_SUITE \
 	beam_block_SUITE \
+	beam_bounds_SUITE \
 	beam_validator_SUITE \
 	beam_disasm_SUITE \
 	beam_except_SUITE \

--- a/lib/compiler/test/beam_bounds_SUITE.erl
+++ b/lib/compiler/test/beam_bounds_SUITE.erl
@@ -1,0 +1,116 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(beam_bounds_SUITE).
+-export([all/0, suite/0, groups/0, init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+         band_bounds/1, bor_bounds/1, bxor_bounds/1]).
+
+suite() -> [{ct_hooks,[ts_install_cth]}].
+
+all() ->
+    [{group,p}].
+
+groups() ->
+    [{p,[parallel],
+      [band_bounds,
+       bor_bounds,
+       bxor_bounds]}].
+
+init_per_suite(Config) ->
+    test_lib:recompile(?MODULE),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+band_bounds(_Config) ->
+    test_commutative('band'),
+
+    %% Coverage.
+    {0,17} = beam_bounds:'band'(any, {7,17}),
+    {0,42} = beam_bounds:'band'({0,42}, any),
+    any = beam_bounds:'band'({-1,1}, any),
+    any = beam_bounds:'band'(any, {-10,0}),
+
+    ok.
+
+bor_bounds(_Config) ->
+    test_commutative('bor').
+
+bxor_bounds(_Config) ->
+    test_commutative('bxor').
+
+%%% Utilities
+
+-define(MAX_RANGE, 32).
+
+test_commutative(Op) ->
+    Seq = lists:seq(0, ?MAX_RANGE),
+    _ = [test_commutative_1(Op, {A,B}, {C,D}) ||
+            A <- Seq,
+            B <- lists:nthtail(A, Seq),
+            C <- lists:nthtail(A, Seq),
+            D <- lists:nthtail(C, Seq),
+            {A,B} =< {C,D}],
+
+    any = beam_bounds:Op({-10,0},{-1,10}),
+    any = beam_bounds:Op({-20,-10},{-1,10}),
+
+    ok.
+
+test_commutative_1(Op, R1, R2) ->
+    {HighestMin,LowestMax} = max_op(Op, R1, R2),
+    {Min,Max} = beam_bounds:Op(R1, R2),
+    {Min,Max} = beam_bounds:Op(R2, R1),
+    if
+        Min =< HighestMin, LowestMax =< Max ->
+            ok;
+        true ->
+            io:format("~p(~p, ~p) evaluates to ~p; should be ~p\n",
+                      [Op,R1,R2,{Min,Max},{HighestMin,LowestMax}]),
+            ct:fail(bad_min_or_max)
+        end.
+
+max_op(Op, {A,B}, {C,D}) ->
+    max_op_1(Op, A, B, C, D, {infinity,0}).
+
+max_op_1(Op, A, B, C, D, MinMax0) when A =< B ->
+    MinMax = max_op_2(Op, A, C, D, MinMax0),
+    max_op_1(Op, A + 1, B, C, D, MinMax);
+max_op_1(_Op, _, _, _, _, MinMax) ->
+    MinMax.
+
+max_op_2(Op, A, C, D, MinMax) when C =< D ->
+    Val = erlang:Op(A, C),
+    case MinMax of
+        {Min,Max} when Min =< Val, Val =< Max ->
+            max_op_2(Op, A, C + 1, D, {Min,Max});
+        {Min,Max} ->
+            max_op_2(Op, A, C + 1, D, {min(Min, Val),max(Max, Val)})
+    end;
+max_op_2(_Op, _, _, _, MinMax) ->
+    MinMax.


### PR DESCRIPTION
Refactor and improve bounds calculations for the `band`, `bor`,
and `bxor` operators. That will result in smaller (and possibly
faster) code for `rand`, `base64`, and parts of the `asn1`
application.