### PR TITLE
Teach beam_lib:strip/* to retain new chunk types introduced in OTP 25

### DIFF
--- a/lib/stdlib/doc/src/beam_lib.xml
+++ b/lib/stdlib/doc/src/beam_lib.xml
@@ -462,11 +462,11 @@ CryptoKeyFun(clear) -> term()</code>
 
     <func>
       <name name="strip" arity="1" since=""/>
-      <fsummary>Remove chunks not needed by the loader from a BEAM file.
+      <fsummary>Remove chunks not used by the loader from a BEAM file.
       </fsummary>
       <desc>
         <p>Removes all chunks from a BEAM
-          file except those needed by the loader. In particular,
+          file except those used by the loader. In particular,
           the debug information (chunk <c>debug_info</c> and <c>abstract_code</c>)
           is removed.</p>
       </desc>
@@ -474,23 +474,23 @@ CryptoKeyFun(clear) -> term()</code>
 
     <func>
       <name name="strip" arity="2" since="OTP 22.0"/>
-      <fsummary>Remove chunks not needed by the loader from a BEAM file.
+      <fsummary>Remove chunks not used by the loader from a BEAM file.
       </fsummary>
       <desc>
-        <p>Removes all chunks from a BEAM
-          file except those needed by the loader or passed in. In particular,
-          the debug information (chunk <c>debug_info</c> and <c>abstract_code</c>)
-          is removed.</p>
+        <p>Removes all chunks from a BEAM file except those used by
+        the loader or mentioned in <c><anno>AdditionalChunks</anno></c>. In
+        particular, the debug information (chunk <c>debug_info</c> and
+        <c>abstract_code</c>) is removed.</p>
       </desc>
     </func>
 
     <func>
       <name name="strip_files" arity="1" since=""/>
-      <fsummary>Removes chunks not needed by the loader from BEAM files.
+      <fsummary>Removes chunks not used by the loader from BEAM files.
       </fsummary>
       <desc>
         <p>Removes all chunks except
-          those needed by the loader from BEAM files. In particular,
+          those used by the loader from BEAM files. In particular,
           the debug information (chunk <c>debug_info</c> and <c>abstract_code</c>)
           is removed. The returned list contains one element for each
           specified filename, in the same order as in <c>Files</c>.</p>
@@ -499,24 +499,25 @@ CryptoKeyFun(clear) -> term()</code>
 
     <func>
       <name name="strip_files" arity="2" since="OTP 22.0"/>
-      <fsummary>Removes chunks not needed by the loader from BEAM files.
+      <fsummary>Removes chunks not used by the loader from BEAM files.
       </fsummary>
       <desc>
-        <p>Removes all chunks except
-          those needed by the loader or passed in from BEAM files. In particular,
-          the debug information (chunk <c>debug_info</c> and <c>abstract_code</c>)
-          is removed. The returned list contains one element for each
-          specified filename, in the same order as in <c>Files</c>.</p>
+        <p>Removes all chunks except those used by the loader or
+        mentioned in <c><anno>AdditionalChunks</anno></c>. In
+        particular, the debug information (chunk <c>debug_info</c> and
+        <c>abstract_code</c>) is removed. The returned list contains
+        one element for each specified filename, in the same order as
+        in <c>Files</c>.</p>
       </desc>
     </func>
 
     <func>
       <name name="strip_release" arity="1" since=""/>
-      <fsummary>Remove chunks not needed by the loader from all BEAM files of
+      <fsummary>Remove chunks not used by the loader from all BEAM files of
         a release.</fsummary>
       <desc>
         <p>Removes all chunks
-          except those needed by the loader from the BEAM files of a
+          except those used by the loader from the BEAM files of a
           release. <c><anno>Dir</anno></c> is to be the installation root
           directory. For example, the current OTP release can be
           stripped with the call
@@ -529,12 +530,12 @@ CryptoKeyFun(clear) -> term()</code>
       <fsummary>Remove chunks not needed by the loader from all BEAM files of
         a release.</fsummary>
       <desc>
-        <p>Removes all chunks
-          except those needed by the loader or passed in from the BEAM files of a
-          release. <c><anno>Dir</anno></c> is to be the installation root
-          directory. For example, the current OTP release can be
-          stripped with the call
-          <c>beam_lib:strip_release(code:root_dir())</c>.</p>
+        <p>Removes all chunks except those used by the loader or
+        mentioned in <c><anno>AdditionalChunks</anno></c>.
+        <c><anno>Dir</anno></c> is to be the installation
+        root directory. For example, the current OTP release can be
+        stripped with the call
+        <c>beam_lib:strip_release(code:root_dir())</c>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -953,7 +953,7 @@ error(Reason) ->
 %% The following chunks must be kept when stripping a BEAM file.
 
 significant_chunks() ->
-    ["Line" | md5_chunks()].
+    ["Line", "Type", "Meta" | md5_chunks()].
 
 %% The following chunks are significant when calculating the MD5
 %% for a module. They are listed in the order that they should be MD5:ed.

--- a/lib/stdlib/test/beam_lib_SUITE.erl
+++ b/lib/stdlib/test/beam_lib_SUITE.erl
@@ -453,8 +453,7 @@ strip_add_chunks(Conf) when is_list(Conf) ->
     compare_chunks(B1, NB1, NBId1),
 
     %% Keep all the extra chunks
-    ExtraChunks = ["Abst", "Dbgi", "Attr", "CInf", "LocT", "Atom",
-                   "Type", "Meta"],
+    ExtraChunks = ["Abst", "Dbgi", "Attr", "CInf", "LocT", "Atom"],
     {ok, {simple, AB1}} = beam_lib:strip(B1, ExtraChunks),
     ABId1 = chunk_ids(AB1),
     true = length(BId1) == length(ABId1),


### PR DESCRIPTION
When stripping BEAM files, be sure to retain the "Type" and "Meta"
chunk types introduced in OTP 25.

Also update the documention to make it clearer what the `strip` functions
do.