### PR TITLE
erts: Remove unused CERL_DETACHED_PROG code

### DIFF
--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -456,21 +456,6 @@ int main(int argc, char **argv)
 	goto skip_arg_massage;
     }
     free_env_val(s);
-#else
-    int reset_cerl_detached = 0;
-
-    s = get_env("CERL_DETACHED_PROG");
-    if (s && strcmp(s, "") != 0) {
-	emu = s;
-	start_detached = 1;
-	reset_cerl_detached = 1;
-	ensure_EargsSz(argc + 1);
-	memcpy((void *) Eargsp, (void *) argv, argc * sizeof(char *));
-	Eargsp[argc] = emu;
-	Eargsp[argc] = NULL;
-	goto skip_arg_massage;
-    }
-    free_env_val(s);
 #endif
 
     initial_argv_massage(&argc, &argv); /* Merge with env; expand -args_file */
@@ -1142,14 +1127,10 @@ int main(int argc, char **argv)
 
 #else
 
- skip_arg_massage:
     if (start_detached) {
 	int status = fork();
 	if (status != 0)	/* Parent */
 	    return 0;
-
-	if (reset_cerl_detached)
-	    putenv("CERL_DETACHED_PROG=");
 
 	/* Detach from controlling terminal */
 #ifdef HAVE_SETSID

--- a/lib/runtime_tools/src/system_information.erl
+++ b/lib/runtime_tools/src/system_information.erl
@@ -387,7 +387,6 @@ os_getenv_erts_specific() ->
     os_getenv_erts_specific([
 	    "BINDIR",
 	    "DIALYZER_EMULATOR",
-	    "CERL_DETACHED_PROG",
 	    "EMU",
 	    "ERL_CONSOLE_MODE",
 	    "ERL_CRASH_DUMP",

--- a/lib/runtime_tools/test/system_information_SUITE_data/information_test_report.dat
+++ b/lib/runtime_tools/test/system_information_SUITE_data/information_test_report.dat
@@ -9729,7 +9729,6 @@
                 [{"BINDIR",
                   "/ldisk/daily_build/r16b02_opu_c_Muacul100.2013-07-10_20/otp/erts-5.10.3/bin"},
                  {"DIALYZER_EMULATOR",false},
-                 {"CERL_DETACHED_PROG",false},
                  {"EMU","beam"},
                  {"ERL_CONSOLE_MODE",false},
                  {"ERL_CRASH_DUMP",false},


### PR DESCRIPTION
The CERL_DETACHED_PROG code seems to be a relic that is no
longer used. So we delete it doesn't work anyway.

Closes #4323