### PR TITLE
Don't parse map update syntax in patterns

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -281,10 +281,6 @@ pat_expr_max -> '(' pat_expr ')' : '$2'.
 
 map_pat_expr -> '#' map_tuple :
 	{map, ?anno('$1'),'$2'}.
-map_pat_expr -> pat_expr_max '#' map_tuple :
-	{map, ?anno('$2'),'$1','$3'}.
-map_pat_expr -> map_pat_expr '#' map_tuple :
-	{map, ?anno('$2'),'$1','$3'}.
 
 record_pat_expr -> '#' atom '.' atom :
 	{record_index,?anno('$1'),element(3, '$2'),'$4'}.


### PR DESCRIPTION
This syntax is later rejected by `erl_lint` in:
  * https://github.com/erlang/otp/blob/738b597ff5a9489981a71102ae90d05276e1333f/lib/stdlib/src/erl_lint.erl#L1694-L1752
  * https://github.com/erlang/otp/blob/738b597ff5a9489981a71102ae90d05276e1333f/lib/stdlib/src/erl_lint.erl#L1886-L1899

This commit short-circuits the case where such syntax is encountered to reject it in `erl_parse` early. This simplifies `erl_parse` slightly and generates less code for it.

It's also consistent with types in `erl_parse` that don't allow the 4-element `map` tuple in patterns:
https://github.com/erlang/otp/blob/738b597ff5a9489981a71102ae90d05276e1333f/lib/stdlib/src/erl_parse.yrl#L834-L835