### PR TITLE
Fix regex generic character type description

### DIFF
--- a/lib/parsetools/doc/src/leex.xml
+++ b/lib/parsetools/doc/src/leex.xml
@@ -445,7 +445,7 @@ D = [0-9]
       <tag><c>\s</c></tag>
       <item><p>Space.</p></item>
       <tag><c>\d</c></tag>
-      <item><p>Delete.</p></item>
+      <item><p>Digit.</p></item>
       <tag><c>\ddd</c></tag>
       <item><p>The octal value <c>ddd</c>.</p></item>
       <tag><c>\xhh</c></tag>


### PR DESCRIPTION
Replace "Delete" to "Digit".
Regex  character type `\d` means any decimal digit.