### PR TITLE
kernel|stdlib: Fix io:puts_char error with invalid binary

### DIFF
--- a/lib/kernel/src/file_io_server.erl
+++ b/lib/kernel/src/file_io_server.erl
@@ -445,6 +445,10 @@ put_chars(Chars, InEncoding, #state{handle=Handle, unic=OutEncoding}=State) ->
 	{error,_,_} ->
 	    {stop,no_translation,
 	     {error,{no_translation, InEncoding, OutEncoding}},
+	     NewState};
+	{incomplete,_,_} ->
+	    {stop,no_translation,
+	     {error,{no_translation, InEncoding, OutEncoding}},
 	     NewState}
     end.
 

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -399,6 +399,12 @@ format_unicode_error(characters_to_nfkd_list, [_]) ->
 
 unicode_char_data(Chars) ->
     try unicode:characters_to_binary(Chars) of
+        {error,_,_} ->
+            bad_char_data;
+
+        {incomplete,_,_} ->
+            bad_char_data;
+
         _ ->
             []
     catch

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -3004,6 +3004,11 @@ error_info(Config) ->
                         Dev
                 end,
 
+    UnicodeDev = fun() ->
+                        {ok, Dev} = file:open(TmpFile, [read, write, {encoding, unicode}]),
+                        Dev
+                end,
+
     DeadDev = spawn(fun() -> ok end),
 
     UserDev = fun() -> whereis(user) end,
@@ -3025,6 +3030,8 @@ error_info(Config) ->
          {put_chars,["test"], [{gl,FullDev()},{general,"no space left on device"}]},
          {put_chars,[Latin1Dev(),"Спутник-1"], [{1,"transcode"}]},
          {put_chars,[a], [{1,"not valid character data"}]},
+         {put_chars,[UnicodeDev(), <<222>>], [{1,"transcode"}]},
+         {put_chars,[<<1:1>>], [{1,"not valid character data"}]},
          {put_chars,[UnknownDev(),"test"], [{general,"unknown error: 'Спутник-1'"}]},
          {put_chars,["test"], [{gl,UnknownDev()},{general,"unknown error: 'Спутник-1'"}]},
          {put_chars,[self(),"test"],[{1,"the device is not allowed to be the current process"}]},


### PR DESCRIPTION
Makes sure that io:puts_char/2 emits a no_translation error
when called with an incomplete binary and adds detail to the
resulting error message.

Follow up of https://groups.google.com/g/elixir-lang-core/c/RR7nbeHsluQ  
Related to https://github.com/elixir-lang/elixir/pull/11756

Since this slightly changes the behavior of the function (although in a way that I think is intended), I opened the PR for the `master` branch and not for `maint`. If that is a miscalculation, I'll rebase this onto `maint`.

This is my first PR to OTP and I tried to follow all guidelines. If something is not up to the usual standards, please let me know :)