### PR TITLE
wx: Fix configure on win32 with newer wxWidgets

### DIFF
--- a/lib/wx/c_src/wxe_gl.cpp
+++ b/lib/wx/c_src/wxe_gl.cpp
@@ -22,8 +22,6 @@
 #include <string.h>
 #ifndef _WIN32
 #include <dlfcn.h>
-#else
-#include <windows.h>
 #endif
 #include "wxe_impl.h"
 #include "wxe_return.h"

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -2026,37 +2026,6 @@ $as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_type
-
-# ac_fn_cxx_check_header_compile LINENO HEADER VAR INCLUDES
-# ---------------------------------------------------------
-# Tests whether HEADER exists and can be compiled using the include files in
-# INCLUDES, setting the cache variable VAR accordingly.
-ac_fn_cxx_check_header_compile ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
-$as_echo_n "checking for $2... " >&6; }
-if eval \${$3+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$4
-#include <$2>
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-  eval "$3=yes"
-else
-  eval "$3=no"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-eval ac_res=\$$3
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-
-} # ac_fn_cxx_check_header_compile
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -5910,9 +5879,6 @@ CXXFLAGS="$CXXFLAGS $WX_CXXFLAGS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-  #ifdef WIN32
-  # include <windows.h>
-  #endif
   #include "wx/wx.h"
 
 int
@@ -5972,9 +5938,6 @@ CXXFLAGS="$CXXFLAGS $WX_CXXFLAGS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-  #ifdef WIN32
-  # include <windows.h>
-  #endif
   #include "wx/wx.h"
 
 int
@@ -6184,35 +6147,6 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $TESS_CB_TIGER_STYLE" >&5
 $as_echo "$TESS_CB_TIGER_STYLE" >&6; }
-
-
-
-for ac_header in wx/stc/stc.h
-do :
-  ac_fn_cxx_check_header_compile "$LINENO" "wx/stc/stc.h" "ac_cv_header_wx_stc_stc_h" "#ifdef WIN32
-	 # include <windows.h>
-         #endif
-         #include \"wx/wx.h\"
-"
-if test "x$ac_cv_header_wx_stc_stc_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_WX_STC_STC_H 1
-_ACEOF
-
-else
-  	echo "Can not find wx/stc/stc.h $CXXFLAGS" >> ./CONF_INFO
-    WXERL_CAN_BUILD_DRIVER=false
-    if test X"$with_wx" = X"yes" ; then
-        as_fn_error $? "Can not find wx/stc/stc.h $CXXFLAGS" "$LINENO" 5
-    else
-        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Can not find wx/stc/stc.h $CXXFLAGS" >&5
-$as_echo "$as_me: WARNING: Can not find wx/stc/stc.h $CXXFLAGS" >&2;}
-    fi
-
-
-fi
-
-done
 
 
 

--- a/lib/wx/configure.in
+++ b/lib/wx/configure.in
@@ -549,9 +549,6 @@ CXXFLAGS="$CXXFLAGS $WX_CXXFLAGS"
 
 AC_COMPILE_IFELSE(
  [AC_LANG_PROGRAM([[
-  #ifdef WIN32
-  # include <windows.h>
-  #endif
   #include "wx/wx.h"
   ]], [[
   #if wxMAJOR_VERSION > 2 && (wxMINOR_VERSION == 0 || WXWIN_COMPATIBILITY_3_0 == 1)
@@ -577,9 +574,6 @@ CXXFLAGS="$CXXFLAGS $WX_CXXFLAGS"
 
 AC_COMPILE_IFELSE(
  [AC_LANG_PROGRAM([[
-  #ifdef WIN32
-  # include <windows.h>
-  #endif
   #include "wx/wx.h"
   ]], [[
   #if wxUSE_GLCANVAS
@@ -648,22 +642,9 @@ AC_TRY_COMPILE([
 AC_MSG_RESULT($TESS_CB_TIGER_STYLE)
 AC_SUBST(TESS_CB_TIGER_STYLE)
 
-dnl 
-dnl Check that we wx have stc (wxStyledTextControl) headers 
-dnl 
-
-AC_CHECK_HEADERS([wx/stc/stc.h],
-        [],
-    	[WX_MSG_ERROR([Can not find wx/stc/stc.h $CXXFLAGS])      
-     	],
-	[#ifdef WIN32
-	 # include <windows.h>
-         #endif
-         #include "wx/wx.h"])
-
-dnl 
+dnl
 dnl Check that we can link all the libraries
-dnl 
+dnl
 
 AC_MSG_CHECKING(if we can link wxwidgets programs)
 saved_LIBS=$LIBS


### PR DESCRIPTION
On win32 "windows.h" can not be included before wxWidgets headers with
wxWidgets-3.1.6.

Remove them they doesn't seem to be needed anymore.

Fixes #5883 