### PR TITLE
Clarify return order of filelib:wildcard/1|2

### DIFF
--- a/lib/stdlib/doc/src/filelib.xml
+++ b/lib/stdlib/doc/src/filelib.xml
@@ -183,7 +183,7 @@
       <name name="wildcard" arity="1" since=""/>
       <fsummary>Match filenames using Unix-style wildcards.</fsummary>
       <desc>
-        <p>Returns a list of all files that match Unix-style wildcard string
+        <p>Returns a sorted list of all files that match Unix-style wildcard string
           <c><anno>Wildcard</anno></c>.</p>
         <p>The wildcard string looks like an ordinary filename, except
           that the following "wildcard characters" are interpreted in a special


### PR DESCRIPTION
filelib:wildcard sorts the files using `lists:sort/1` before returning them to the caller.