### PR TITLE
changes to fix erlang hung issue on IPv6 setup

### DIFF
--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -1558,14 +1558,12 @@ static void *realloc_wrapper(void *current, ErlDrvSizeT size){
     return ret;
 }
 #define REALLOC(X,Y) realloc_wrapper(X,Y)
-#define FREE(P) { driver_free((P)); \
-    (P) = NULL;}
+#define FREE(P)      driver_free((P))
 #else /* FATAL_MALLOC */
 
-#define ALLOC(X) driver_alloc((X))
+#define ALLOC(X)     driver_alloc((X))
 #define REALLOC(X,Y) driver_realloc((X), (Y))
-#define FREE(P) { driver_free((P)); \
-    (P) = NULL;}
+#define FREE(P)      driver_free((P))
 
 #endif /* FATAL_MALLOC */
 
@@ -5908,6 +5906,7 @@ static ErlDrvSSizeT inet_ctl_getifaddrs(inet_descriptor* desc_p,
 	    }
 	    if (! i) {
 		FREE(ip_adaddrs_p);
+                ip_adaddrs_p = NULL;
 	    }
 	} else ip_adaddrs_p = NULL;
     }
@@ -5926,7 +5925,10 @@ static ErlDrvSSizeT inet_ctl_getifaddrs(inet_descriptor* desc_p,
 	    i = 0;
 	    break;
 	}
-	if (! i) FREE(info_p);
+	if (! i) {
+            FREE(info_p);
+            info_p = NULL;
+        }
     }
 
     if (! ip_adaddrs_p) {

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -5994,6 +5994,7 @@ index:
 		        }
 		        break;
 		    }
+                }
 	    }
 	}
 	if (wname_p) {


### PR DESCRIPTION
Fixing problem in inet_drv.c where code is crashing due to infinite loop while searching interfaces
Also updated code to avoid use of uninitialised pointer and updated macro to set variable to NULL after free.

For more details refer rabbitMQ thread: https://groups.google.com/g/rabbitmq-users/c/FJgf_Pp1O4c?pli=1