### PR TITLE
wx: Overload `OSXIsGUIApplication` with our own check

### DIFF
--- a/lib/wx/c_src/wxe_impl.cpp
+++ b/lib/wx/c_src/wxe_impl.cpp
@@ -224,6 +224,16 @@ void WxeApp::MacReopenApp() {
   wxString empty;
   send_msg("reopen_app", &empty);
 }
+
+bool WxeApp::OSXIsGUIApplication() {
+  // wx manually activates the application if it's not in the bundle [1]. In particular, it calls
+  // `[NSApp setActivationPolicy: NSApplicationActivationPolicyRegular]` which prevents the app
+  // from running in the background and we cannot control it with `LSUIElement` [2]. Their check
+  // if it's a bundle always returns false for wxErlang. Thus we use our own way of detecting it.
+  // [1] https://github.com/wxWidgets/wxWidgets/blob/v3.1.5/src/osx/cocoa/utils.mm#L76:L93
+  // [2] https://developer.apple.com/documentation/bundleresources/information_property_list/lsuielement
+  return !is_packaged_app();
+}
 #endif
 
 void WxeApp::shutdown(wxeMetaCommand& Ecmd) {

--- a/lib/wx/c_src/wxe_impl.h
+++ b/lib/wx/c_src/wxe_impl.h
@@ -64,6 +64,7 @@ public:
   virtual void MacOpenURL(const wxString &url);
   virtual void MacNewFile();
   virtual void MacReopenApp();
+  virtual bool OSXIsGUIApplication();
 #endif
 
   void init_consts(wxeMetaCommand& event);

--- a/lib/wx/c_src/wxe_nif.h
+++ b/lib/wx/c_src/wxe_nif.h
@@ -116,3 +116,7 @@ void stop_native_gui(ErlNifEnv *);
 /* wxe_ps_init */
 void * wxe_ps_init();
 void * wxe_ps_init2();
+
+#ifdef  _MACOSX
+int is_packaged_app();
+#endif


### PR DESCRIPTION
Some macOS apps only run in the background and thus have no GUI. Some apps only live in the "menu bar" (top-right corner) and thus don't have the traditional GUI either. In both cases, we don't want the application to show up in the Dock (and thus show up when switching apps with cmd+tab, etc)

A standard way to do this to set `LSUIElement` to `true`. See:
https://developer.apple.com/documentation/bundleresources/information_property_list/lsuielement

Here's an example script that builds such app:

    #!/bin/sh
    set -eo pipefail

    cat <<EOF > app1.swift
    import Cocoa
    _ = NSApplication.shared

    let window = NSWindow(
      contentRect: NSMakeRect(800, 600, 320, 200),
      styleMask: [.titled, .closable],
      backing: .buffered,
      defer: true
    )
    window.orderFrontRegardless()
    window.title = "Example"

    let menuItemOne = NSMenuItem()
    menuItemOne.submenu = NSMenu()
    menuItemOne.submenu?.items = [
      NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
    ]
    let menu = NSMenu()
    menu.items = [menuItemOne]
    NSApp.mainMenu = menu

    NSApp.activate(ignoringOtherApps: true)
    NSApp.run()
    EOF

    echo app1: building
    mkdir -p app1.app/Contents/MacOS
    swiftc app1.swift -o app1.app/Contents/MacOS/app1

    echo app1: setting LSUIElement
    cat <<EOF > app1.app/Contents/Info.plist
    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
    <plist version="1.0">
    <dict>
      <key>LSUIElement</key>
      <true/>
    </dict>
    </plist>
    EOF

Besides the `LSUIElemet` property, there's also a programatic way of setting this behaviour. If that is used, the property seems to be ignored.

In our example app, if we make this code change:

    + NSApp.setActivationPolicy(.regular)
      NSApp.run()

Then our app will show up in the Dock even though we set `LSUIElement`.

I tried using the `LSUIElement` property with wxErlang. Here's an example script:

    echo app2: building
    mkdir -p app2.app/Contents/MacOS
    cat <<EOF > app2.app/Contents/MacOS/app2
    #!/bin/sh
    set -eo pipefail
    export PATH="$(dirname $(which erl)):\$PATH"
    export WX_MACOS_NON_GUI_APP=true
    erl -noshell -eval 'WX=wx:new(), F=wxFrame:new(WX,-1,"Hello"),
    wxFrame:show(F),
    MB=wxMenuBar:new(),
    wxFrame:setMenuBar(F, MB),
    wxFrame:connect(F, command_menu_selected, [{skip,true}]),
    wxFrame:connect(F, close_window, [{skip,true}]),
    receive Evt ->
      io:format("~p~n", [Evt]),
      halt()
    end.
    '
    EOF
    chmod +x app2.app/Contents/MacOS/app2

    echo app2: setting LSUIElement
    cat <<EOF > app2.app/Contents/Info.plist
    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
    <plist version="1.0">
    <dict>
      <key>LSUIElement</key>
      <true/>
    </dict>
    </plist>
    EOF

When running it, the app shows up in the Dock.

I determined that wxWidgets sets the activation policy to regular here:

    if ( !wxApp::sm_isEmbedded && wxTheApp && wxTheApp->OSXIsGUIApplication() )
    {
        CFURLRef url = CFBundleCopyBundleURL(CFBundleGetMainBundle() ) ;
        CFStringRef path = CFURLCopyFileSystemPath ( url , kCFURLPOSIXPathStyle ) ;
        CFRelease( url ) ;
        wxString app = wxCFStringRef(path).AsString(wxLocale::GetSystemEncoding());
        if ( !app.EndsWith(".app") )
        {
            [NSApp setActivationPolicy: NSApplicationActivationPolicyRegular];
            [NSApp activateIgnoringOtherApps: YES];
        }
    }

https://github.com/wxWidgets/wxWidgets/blob/v3.1.5/src/osx/cocoa/utils.mm#L90

Now, there are two conditions that gate this behaviour. The first one is the one I'm overwriting, the call to `wxTheApp->OSXIsGUIApplication()` method.

The second one is checking if the application is bundled. When running wxErlang, that code is always executed even if the application is in fact bundled.

I copied this checking code to `wxe_impl.cpp`:

    --- a/lib/wx/c_src/wxe_impl.cpp
    +++ b/lib/wx/c_src/wxe_impl.cpp
    @@ -20,6 +20,7 @@

     #include <stdio.h>
     #include <signal.h>
    +#include <CoreServices/CoreServices.h>

     #include <wx/wx.h>
    @@ -180,6 +181,12 @@ bool WxeApp::OnInit()
       wxInitAllImageHandlers();

     #ifdef  _MACOSX
    +  CFURLRef url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
    +  CFStringRef path = CFURLCopyFileSystemPath(url, kCFURLPOSIXPathStyle);
    +  CFRelease(url);
    +  wxString app = wxCFStringRef(path).AsString(wxLocale::GetSystemEncoding());
    +  wxLogInfo(app);

And on my system the following was logged: `/Users/wojtek/src/otp/bin/aarch64-apple darwin21.4.0`.

For this reason I've added an implementation of the first check, `wxTheApp->OSXIsGUIApplication()` which uses wxErlang's way of detecting if we are in a bundle.