### PR TITLE
Update httpc.xml

### DIFF
--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -109,7 +109,7 @@
     <p><c>headers() = [header()]</c></p>
     <p><c>header() = {field(), value()}</c></p>
     <p><c>field() = [byte()]</c></p>
-    <p><c>value() = binary() | iolist()</c></p>
+    <p><c>value() = iolist()</c></p>
     <taglist>
       <tag><c>body()</c></tag>
       <item><p>= <c>http_string() | binary()</c></p>


### PR DESCRIPTION
Documentation states that HTTP header values can be binaries but code does not accept it.

```
10> httpc:request(get, {"http://www.google.com", [{"some header", <<"some value">>}]}, [], []).
{error,{headers_error,not_strings}}

11> httpc:request(get, {"http://www.google.com", [{"some header", "some value"}]}, [], []).    
{ok,{{"HTTP/1.0",400,"Bad Request"},
     [{"date","Tue, 19 Apr 2022 20:58:49 GMT"},
      {"content-length","1555"},
      {"content-type","text/html; charset=UTF-8"},
      {"referrer-policy","no-referrer"}],
     [60,33,68,79,67,84,89,80,69,32,104,116,109,108,62,10,60,104,
      116,109,108,32,108,97|...]}}
```