### PR TITLE
compiler: Refactor type analysis and improve tests

### DIFF
--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -181,6 +181,11 @@ succeeds_if_smallish(LHS, RHS) ->
 -define(SIZE_UPPER_LIMIT, ((1 bsl 58) - 1)).
 
 %%
+%% The document maximum size of a tuple.
+%%
+-define(MAX_TUPLE_SIZE, (1 bsl 24) - 1).
+
+%%
 %% Returns the inferred return and argument types for known functions, and
 %% whether it's safe to subtract argument types on failure.
 %%
@@ -207,7 +212,7 @@ types(erlang, 'tuple_size', [Src]) ->
               #t_tuple{size=Sz} -> Sz;
               _ -> 0
           end,
-    Max = (1 bsl 24) - 1,                       %Documented max size of a tuple.
+    Max = ?MAX_TUPLE_SIZE,
     sub_safe(#t_integer{elements={Min,Max}}, [#t_tuple{}]);
 types(erlang, 'bit_size', [_]) ->
     sub_safe(#t_integer{elements={0,?SIZE_UPPER_LIMIT}}, [#t_bitstring{}]);
@@ -385,7 +390,10 @@ types(erlang, element, [PosType, TupleType]) ->
                       any
               end,
 
-    sub_unsafe(RetType, [#t_integer{}, #t_tuple{size=Index}]);
+    ArgTypes = [#t_integer{elements={1,?MAX_TUPLE_SIZE}},
+                #t_tuple{size=Index}],
+
+    sub_unsafe(RetType, ArgTypes);
 types(erlang, setelement, [PosType, TupleType, ArgType]) ->
     RetType = case {PosType,TupleType} of
                   {#t_integer{elements={Index,Index}},

--- a/lib/compiler/test/beam_bounds_SUITE.erl
+++ b/lib/compiler/test/beam_bounds_SUITE.erl
@@ -21,7 +21,11 @@
 -module(beam_bounds_SUITE).
 -export([all/0, suite/0, groups/0, init_per_suite/1, end_per_suite/1,
          init_per_group/2, end_per_group/2,
-         band_bounds/1, bor_bounds/1, bxor_bounds/1]).
+         addition_bounds/1, subtraction_bounds/1,
+         multiplication_bounds/1, division_bounds/1, rem_bounds/1,
+         band_bounds/1, bor_bounds/1, bxor_bounds/1,
+         bsr_bounds/1, bsl_bounds/1,
+         lt_bounds/1, le_bounds/1, gt_bounds/1, ge_bounds/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -30,9 +34,20 @@ all() ->
 
 groups() ->
     [{p,[parallel],
-      [band_bounds,
+      [addition_bounds,
+       subtraction_bounds,
+       multiplication_bounds,
+       division_bounds,
+       rem_bounds,
+       band_bounds,
        bor_bounds,
-       bxor_bounds]}].
+       bxor_bounds,
+       bsr_bounds,
+       bsl_bounds,
+       lt_bounds,
+       le_bounds,
+       gt_bounds,
+       ge_bounds]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -47,6 +62,26 @@ init_per_group(_GroupName, Config) ->
 end_per_group(_GroupName, Config) ->
     Config.
 
+addition_bounds(_Config) ->
+    test_commutative('+', {-12,12}).
+
+subtraction_bounds(_Config) ->
+    test_noncommutative('-', {-12,12}).
+
+multiplication_bounds(_Config) ->
+    test_commutative('*', {-12,12}).
+
+division_bounds(_Config) ->
+    test_noncommutative('div', {-12,12}).
+
+rem_bounds(_Config) ->
+    test_noncommutative('rem', {-12,12}),
+
+    {-7,7} = beam_bounds:'rem'(any, {1,8}),
+    {-11,11} = beam_bounds:'rem'(any, {-12,8}),
+
+    ok.
+
 band_bounds(_Config) ->
     test_commutative('band'),
 
@@ -55,35 +90,62 @@ band_bounds(_Config) ->
     {0,42} = beam_bounds:'band'({0,42}, any),
     any = beam_bounds:'band'({-1,1}, any),
     any = beam_bounds:'band'(any, {-10,0}),
+    any = beam_bounds:'band'({-10,0},{-1,10}),
+    any = beam_bounds:'band'({-20,-10},{-1,10}),
 
     ok.
 
 bor_bounds(_Config) ->
-    test_commutative('bor').
+    test_commutative('bor'),
 
-bxor_bounds(_Config) ->
-    test_commutative('bxor').
-
-%%% Utilities
-
--define(MAX_RANGE, 32).
-
-test_commutative(Op) ->
-    Seq = lists:seq(0, ?MAX_RANGE),
-    _ = [test_commutative_1(Op, {A,B}, {C,D}) ||
-            A <- Seq,
-            B <- lists:nthtail(A, Seq),
-            C <- lists:nthtail(A, Seq),
-            D <- lists:nthtail(C, Seq),
-            {A,B} =< {C,D}],
-
-    any = beam_bounds:Op({-10,0},{-1,10}),
-    any = beam_bounds:Op({-20,-10},{-1,10}),
+    any = beam_bounds:'bor'({-10,0},{-1,10}),
+    any = beam_bounds:'bor'({-20,-10},{-1,10}),
 
     ok.
 
+bxor_bounds(_Config) ->
+    test_commutative('bxor'),
+
+    any = beam_bounds:'bxor'({-10,0},{-1,10}),
+    any = beam_bounds:'bxor'({-20,-10},{-1,10}),
+
+    ok.
+
+bsr_bounds(_Config) ->
+    test_noncommutative('bsr', {-12,12}, {0,7}).
+
+bsl_bounds(_Config) ->
+    test_noncommutative('bsl', {-12,12}, {0,7}).
+
+lt_bounds(_Config) ->
+    test_relop('<').
+
+le_bounds(_Config) ->
+    test_relop('=<').
+
+gt_bounds(_Config) ->
+    test_relop('>').
+
+ge_bounds(_Config) ->
+    test_relop('>=').
+
+%%% Utilities
+
+test_commutative(Op) ->
+    test_commutative(Op, {0,32}).
+
+test_commutative(Op, {Min,Max}) ->
+    Seq = lists:seq(Min, Max),
+    _ = [test_commutative_1(Op, {A,B}, {C,D}) ||
+            A <- Seq,
+            B <- lists:nthtail(A-Min, Seq),
+            C <- lists:nthtail(A-Min, Seq),
+            D <- lists:nthtail(C-Min, Seq),
+            {A,B} =< {C,D}],
+    ok.
+
 test_commutative_1(Op, R1, R2) ->
-    {HighestMin,LowestMax} = max_op(Op, R1, R2),
+    {HighestMin,LowestMax} = min_max_op(Op, R1, R2),
     {Min,Max} = beam_bounds:Op(R1, R2),
     {Min,Max} = beam_bounds:Op(R2, R1),
     if
@@ -94,23 +156,93 @@ test_commutative_1(Op, R1, R2) ->
                       [Op,R1,R2,{Min,Max},{HighestMin,LowestMax}]),
             ct:fail(bad_min_or_max)
         end.
+test_noncommutative(Op, Range) ->
+    test_noncommutative(Op, Range, Range).
 
-max_op(Op, {A,B}, {C,D}) ->
-    max_op_1(Op, A, B, C, D, {infinity,0}).
+test_noncommutative(Op, {Min1,Max1}, {Min2,Max2}) ->
+    Seq1 = lists:seq(Min1, Max1),
+    Seq2 = lists:seq(Min2, Max2),
+    _ = [test_noncommutative_1(Op, {A,B}, {C,D}) ||
+            A <- Seq1,
+            B <- lists:nthtail(A-Min1, Seq1),
+            C <- Seq2,
+            D <- lists:nthtail(C-Min2, Seq2)],
+    ok.
 
-max_op_1(Op, A, B, C, D, MinMax0) when A =< B ->
-    MinMax = max_op_2(Op, A, C, D, MinMax0),
-    max_op_1(Op, A + 1, B, C, D, MinMax);
-max_op_1(_Op, _, _, _, _, MinMax) ->
+test_noncommutative_1(Op, R1, R2) ->
+    {HighestMin,LowestMax} = min_max_op(Op, R1, R2),
+    case beam_bounds:Op(R1, R2) of
+        any ->
+            case {Op,R2} of
+                {'rem',{0,0}} -> ok
+            end;
+        {Min,Max} when Min =< HighestMin, LowestMax =< Max ->
+            ok;
+        {Min,Max} ->
+            io:format("~p(~p, ~p) evaluates to ~p; should be ~p\n",
+                      [Op,R1,R2,{Min,Max},{HighestMin,LowestMax}]),
+            ct:fail(bad_min_or_max)
+        end.
+
+min_max_op(Op, {A,B}, {C,D}) ->
+    min_max_op_1(Op, A, B, C, D, {infinity,-(1 bsl 24)}).
+
+min_max_op_1(Op, A, B, C, D, MinMax0) when A =< B ->
+    MinMax = min_max_op_2(Op, A, C, D, MinMax0),
+    min_max_op_1(Op, A + 1, B, C, D, MinMax);
+min_max_op_1(_Op, _, _, _, _, MinMax) ->
     MinMax.
 
-max_op_2(Op, A, C, D, MinMax) when C =< D ->
+min_max_op_2(Op, A, 0, D, MinMax) when Op =:= 'div'; Op =:= 'rem' ->
+    min_max_op_2(Op, A, 1, D, MinMax);
+min_max_op_2(Op, A, C, D, MinMax) when C =< D ->
     Val = erlang:Op(A, C),
     case MinMax of
         {Min,Max} when Min =< Val, Val =< Max ->
-            max_op_2(Op, A, C + 1, D, {Min,Max});
+            min_max_op_2(Op, A, C + 1, D, {Min,Max});
         {Min,Max} ->
-            max_op_2(Op, A, C + 1, D, {min(Min, Val),max(Max, Val)})
+            min_max_op_2(Op, A, C + 1, D, {min(Min, Val),max(Max, Val)})
     end;
-max_op_2(_Op, _, _, _, MinMax) ->
+min_max_op_2(_Op, _, _, _, MinMax) ->
     MinMax.
+
+test_relop(Op) ->
+    Max = 15,
+    Seq = lists:seq(0, Max),
+    _ = [test_relop_1(Op, {A,B}, {C,D}) ||
+            A <- Seq,
+            B <- lists:nthtail(A, Seq),
+            C <- Seq,
+            D <- lists:nthtail(C, Seq)],
+    ok.
+
+test_relop_1(Op, R1, R2) ->
+    Bool = rel_op(Op, R1, R2),
+    case beam_bounds:relop(Op, R1, R2) of
+        Bool ->
+            ok;
+        Wrong ->
+            io:format("~p(~p, ~p) evaluates to ~p; should be ~p\n",
+                      [Op,R1,R2,Wrong,Bool]),
+            ct:fail(bad_bool_result)
+    end.
+
+rel_op(Op, {A,B}, {C,D}) ->
+    rel_op_1(Op, A, B, C, D, none).
+
+rel_op_1(Op, A, B, C, D, BoolResult0) when A =< B ->
+    BoolResult = rel_op_2(Op, A, C, D, BoolResult0),
+    rel_op_1(Op, A + 1, B, C, D, BoolResult);
+rel_op_1(_Op, _, _, _, _, BoolResult) ->
+    BoolResult.
+
+rel_op_2(Op, A, C, D, BoolResult0) when C =< D ->
+    Val = erlang:Op(A, C),
+    BoolResult = case BoolResult0 of
+                     none -> Val;
+                     Val -> BoolResult0;
+                     _ -> 'maybe'
+                 end,
+    rel_op_2(Op, A, C + 1, D, BoolResult);
+rel_op_2(_Op, _, _, _, BoolResult) ->
+    BoolResult.


### PR DESCRIPTION
The main purpose of this pull request is to improve the test of the value type analysis for integer arithmetic operations. To achieve that, all bounds checking for arithmetic instructions have been moved from `beam_call_types` to `beam_bounds`. Along the way, a bug for the bounds of `bsr` has been fixed. I have also moved the handling of guard BIFs from `beam_ssa_type` to the more appropriate `beam_call_types` module (because it handles all other BIFs).
 