### PR TITLE
[RFC] mnesia: Add post-commit hook

### DIFF
--- a/lib/mnesia/src/Makefile
+++ b/lib/mnesia/src/Makefile
@@ -72,7 +72,8 @@ MODULES= \
 	mnesia_sup \
 	mnesia_sp  \
 	mnesia_text \
-	mnesia_tm
+	mnesia_tm \
+	mnesia_hook
 
 HRL_FILES= mnesia.hrl
 

--- a/lib/mnesia/src/mnesia.app.src
+++ b/lib/mnesia/src/mnesia.app.src
@@ -32,7 +32,8 @@
 	     mnesia_sup,
 	     mnesia_sp,
 	     mnesia_text,
-	     mnesia_tm
+	     mnesia_tm,
+	     mnesia_hook
             ]},
   {registered, [
 		mnesia_dumper_load_regulator,

--- a/lib/mnesia/src/mnesia_hook.erl
+++ b/lib/mnesia/src/mnesia_hook.erl
@@ -1,0 +1,74 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2021. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(mnesia_hook).
+
+-include("mnesia.hrl").
+
+-export([
+         register_hook/2,
+         do_post_commit/2
+        ]).
+
+-define(hook(NAME), {mnesia_hook, NAME}).
+
+-type post_commit_hook_data() ::
+        #{ node => node()
+         , ram_copies => list()
+         , disc_copies => list()
+         , disc_only_copies => list()
+         , ext => list()
+         , schema_ops => list()
+         }.
+
+-type post_commit_hook() :: fun((_Tid, post_commit_hook_data()) -> ok).
+
+-spec register_hook(post_commit, post_commit_hook()) -> ok | {error, term()}.
+register_hook(post_commit, Hook) when is_function(Hook, 2) ->
+    persistent_term:put(?hook(post_commit), Hook);
+register_hook(_, _) ->
+    {error, bad_type}.
+
+-spec do_post_commit(_Tid, #commit{}) -> ok.
+do_post_commit(Tid, Commit) ->
+    case persistent_term:get(?hook(post_commit), undefined) of
+        undefined ->
+            ok;
+        Fun ->
+            #commit{ node = Node
+                   , ram_copies = Ram
+                   , disc_copies = Disc
+                   , disc_only_copies = DiscOnly
+                   , ext = Ext
+                   , schema_ops = SchemaOps
+                   } = Commit,
+            CommitData = #{ node => Node
+                          , ram_copies => Ram
+                          , disc_copies => Disc
+                          , disc_only_copies => DiscOnly
+                          , ext => Ext
+                          , schema_ops => SchemaOps
+                          },
+            try Fun(Tid, CommitData)
+            catch EC:Err:Stack ->
+                    mnesia_lib:error("Mnesia post_commit hook failed: ~p:~p~nStacktrace:~p~n", [EC, Err, Stack])
+            end,
+            ok
+    end.

--- a/lib/mnesia/src/mnesia_tm.erl
+++ b/lib/mnesia/src/mnesia_tm.erl
@@ -1785,6 +1785,7 @@ do_commit(Tid, C, DumperMode) ->
     R4 = do_update(Tid, disc_only_copies, C#commit.disc_only_copies, R3),
     R5 = do_update_ext(Tid, C#commit.ext, R4),
     mnesia_subscr:report_activity(Tid),
+    mnesia_hook:do_post_commit(Tid, C),
     R5.
 
 %% This could/should be optimized


### PR DESCRIPTION
Hello, OTP team. 

Our team has been working on improving horizontal scalability of mnesia by making replication partially eventually consistent. ["Whitepaper"](https://www.emqx.com/en/blog/mqtt-broker-clustering-part-3-challenges-and-solutions-of-emqx-horizontal-scalability#introducing-mria) [Source code](https://github.com/emqx/mria).
The results are quite promising, we've been able to run 20+ node mria/mnesia clusters with high write and read throughput.
However, in order to do this we had to add a hook point in `mnesia_tm`. Although the patch is really small, ideally we would like to merge it upstream.

Currently thsi PR is WIP, it lacks at least two things:
- Documentation
- Tests
If you are interested in accepting this patch, I will fix both issues.
Documentation is missing because I am not sure how to present this feature. It exposes some internal data structures, so it's not meant for use in the business logic. So the documentation should either go with a large disclaimer that the backward compatibility is not guaranteed, or, perhaps, it can be omitted altogether.
As for tests, we have some in mria repo, but I am not sure in which test suite in OTP can we put it. Some advice is welcome.

Thank you.