### PR TITLE
inets: fix 'all' handling for erl_script_alias

### DIFF
--- a/lib/inets/src/http_server/mod_esi.erl
+++ b/lib/inets/src/http_server/mod_esi.erl
@@ -222,8 +222,15 @@ erl(#mod{method = "POST", entity_body = Body} = ModData, ESIBody, Modules) ->
 
 generate_webpage(ModData, ESIBody, [all], Module, FunctionName,
 		 Input, ScriptElements) ->
-    generate_webpage(ModData, ESIBody, [Module], Module,
-		     FunctionName, Input, ScriptElements);
+    try
+        ModuleAtom = list_to_existing_atom(Module),
+        generate_webpage(ModData, ESIBody, [ModuleAtom], Module,
+                         FunctionName, Input, ScriptElements)
+    catch
+        _:_ ->
+            {proceed, [{status, {404, ModData#mod.request_uri, "Not found"}}
+                      | ModData#mod.data]}
+    end;
 generate_webpage(ModData, ESIBody, Modules, Module, Function,
 		 Input, ScriptElements) when is_atom(Module), is_atom(Function) ->
     case lists:member(Module, Modules) of

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -82,7 +82,8 @@ all() ->
      mime_types_format,
      erl_script_timeout_default,
      erl_script_timeout_option,
-     erl_script_timeout_proplist
+     erl_script_timeout_proplist,
+     erl_script_alias_all
     ].
 
 groups() ->
@@ -1846,6 +1847,16 @@ erl_script_timeout_proplist(Config) when is_list(Config) ->
     verify_body(Body, 3000),
     inets:stop().
 
+erl_script_alias_all(Config0) when is_list(Config0) ->
+    ok = start_apps(http_basic),
+    Config1 = [{http_version, "HTTP/1.0"},
+               {type, ip_comm} |
+               Config0],
+    Config2 = init_httpd(http_basic_erl_script_alias_all, Config1),
+    ok = http_status("GET /cgi-bin/erl/httpd_example:get ",
+        	     Config2, [{statuscode, 200}]),
+    inets:stop().
+
 tls_alert(Config) when is_list(Config) ->
     SSLOpts = proplists:get_value(client_alert_conf, Config),    
     Port = proplists:get_value(port, Config),    
@@ -2033,6 +2044,8 @@ init_ssl(Group, Config) ->
 
 server_config(http_basic, Config) ->
     basic_conf() ++ server_config(http, Config);
+server_config(http_basic_erl_script_alias_all, Config) ->
+    basic_conf() ++ server_config(http_erl_script_alias_all, Config);
 server_config(https_basic, Config) ->
     basic_conf() ++ server_config(https, Config);
 server_config(http_not_sup, Config) ->
@@ -2101,50 +2114,40 @@ server_config(https_alert, Config) ->
     basic_conf() ++ server_config(https, Config);
 server_config(http, Config) ->
     ServerRoot = proplists:get_value(server_root, Config),
-    [{port, 0},
-     {socket_type, {ip_comm, [{nodelay, true}]}},
-     {server_name,"httpd_test"},
-     {server_root, ServerRoot},
-     {document_root, proplists:get_value(doc_root, Config)},
-     {bind_address, any},
-     {ipfamily, proplists:get_value(ipfamily, Config)},
-     {max_header_size, 256},
-     {max_header_action, close},
-     {directory_index, ["index.html", "welcome.html"]},
-     {mime_types, [{"html","text/html"},{"htm","text/html"}, {"shtml","text/html"},
-		   {"gif", "image/gif"}]},
-     {alias, {"/icons/", filename:join(ServerRoot,"icons") ++ "/"}},
-     {alias, {"/pics/",  filename:join(ServerRoot,"icons") ++ "/"}},
-     {script_alias, {"/cgi-bin/", filename:join(ServerRoot, "cgi-bin") ++ "/"}},
-     {script_alias, {"/htbin/", filename:join(ServerRoot, "cgi-bin") ++ "/"}},
-     {erl_script_alias, {"/cgi-bin/erl", [httpd_example, io]}}
-    ];
+    config_template(Config, ServerRoot,
+                    filename:join(ServerRoot, "cgi-bin") ++ "/", [httpd_example, io]);
+server_config(http_erl_script_alias_all, Config) ->
+    ServerRoot = proplists:get_value(server_root, Config),
+    config_template(Config, ServerRoot, "./cgi-bin/", [all]);
 server_config(http_rel_path_script_alias, Config) ->
     ServerRoot = proplists:get_value(server_root, Config),
-    [{port, 0},
-     {socket_type, {ip_comm, [{nodelay, true}]}},
-     {server_name,"httpd_test"},
-     {server_root, ServerRoot},
-     {document_root, proplists:get_value(doc_root, Config)},
-     {bind_address, any},
-     {ipfamily, proplists:get_value(ipfamily, Config)},
-     {max_header_size, 256},
-     {max_header_action, close},
-     {directory_index, ["index.html", "welcome.html"]},
-     {mime_types, [{"html","text/html"},{"htm","text/html"}, {"shtml","text/html"},
-		   {"gif", "image/gif"}]},
-     {alias, {"/icons/", filename:join(ServerRoot,"icons") ++ "/"}},
-     {alias, {"/pics/",  filename:join(ServerRoot,"icons") ++ "/"}},
-     {script_alias, {"/cgi-bin/", "./cgi-bin/"}},
-     {script_alias, {"/htbin/", "./cgi-bin/"}},
-     {erl_script_alias, {"/cgi-bin/erl", [httpd_example, io]}}
-    ];
+    config_template(Config, ServerRoot, "./cgi-bin/", [httpd_example, io]);
 server_config(https, Config) ->
     SSLConf = proplists:get_value(ssl_conf, Config),
     ServerConf = proplists:get_value(server_config, SSLConf),
     [{socket_type, {essl,
 		    [{nodelay, true} | ServerConf]}}]
         ++ proplists:delete(socket_type, server_config(http, Config)).
+
+config_template(Config, ServerRoot, ScriptPath, Modules) ->
+    [{port, 0},
+     {socket_type, {ip_comm, [{nodelay, true}]}},
+     {server_name,"httpd_test"},
+     {server_root, ServerRoot},
+     {document_root, proplists:get_value(doc_root, Config)},
+     {bind_address, any},
+     {ipfamily, proplists:get_value(ipfamily, Config)},
+     {max_header_size, 256},
+     {max_header_action, close},
+     {directory_index, ["index.html", "welcome.html"]},
+     {mime_types, [{"html","text/html"},{"htm","text/html"}, {"shtml","text/html"},
+		   {"gif", "image/gif"}]},
+     {alias, {"/icons/", filename:join(ServerRoot,"icons") ++ "/"}},
+     {alias, {"/pics/",  filename:join(ServerRoot,"icons") ++ "/"}},
+     {script_alias, {"/cgi-bin/", ScriptPath}},
+     {script_alias, {"/htbin/", ScriptPath}},
+     {erl_script_alias, {"/cgi-bin/erl", Modules}}
+    ].
 
 init_httpd(Group, Config0) ->
     Config1 = proplists:delete(port, Config0),


### PR DESCRIPTION
- convert Module string to a known atom before generating webpage