### PR TITLE
erts: Fix gc to fetch sig queue at mqd change

### DIFF
--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -431,7 +431,7 @@ erts_gc_after_bif_call_lhf(Process* p, ErlHeapFragment *live_hf_end,
 	return result;
     }
 
-    if (p->sig_qs.flags & FS_ON_HEAP_MSGQ) {
+    if (p->sig_qs.flags & (FS_ON_HEAP_MSGQ|FS_OFF_HEAP_MSGQ_CHNG)) {
         erts_proc_lock(p, ERTS_PROC_LOCK_MSGQ);
         erts_proc_sig_fetch(p);
 	erts_proc_unlock(p, ERTS_PROC_LOCK_MSGQ);
@@ -890,7 +890,7 @@ int
 erts_garbage_collect_nobump(Process* p, int need, Eterm* objv, int nobj, int fcalls)
 {
     int reds, reds_left;
-    if (p->sig_qs.flags & FS_ON_HEAP_MSGQ) {
+    if (p->sig_qs.flags & (FS_ON_HEAP_MSGQ|FS_OFF_HEAP_MSGQ_CHNG)) {
         erts_proc_lock(p, ERTS_PROC_LOCK_MSGQ);
         erts_proc_sig_fetch(p);
 	erts_proc_unlock(p, ERTS_PROC_LOCK_MSGQ);
@@ -907,7 +907,7 @@ void
 erts_garbage_collect(Process* p, int need, Eterm* objv, int nobj)
 {
     int reds;
-    if (p->sig_qs.flags & FS_ON_HEAP_MSGQ) {
+    if (p->sig_qs.flags & (FS_ON_HEAP_MSGQ|FS_OFF_HEAP_MSGQ_CHNG)) {
         erts_proc_lock(p, ERTS_PROC_LOCK_MSGQ);
         erts_proc_sig_fetch(p);
 	erts_proc_unlock(p, ERTS_PROC_LOCK_MSGQ);
@@ -1185,7 +1185,7 @@ erts_garbage_collect_literals(Process* p, Eterm* literals,
 
     p->flags |= F_NEED_FULLSWEEP;
 
-    if (p->sig_qs.flags & FS_ON_HEAP_MSGQ) {
+    if (p->sig_qs.flags & (FS_ON_HEAP_MSGQ|FS_OFF_HEAP_MSGQ_CHNG)) {
         erts_proc_lock(p, ERTS_PROC_LOCK_MSGQ);
         erts_proc_sig_fetch(p);
 	erts_proc_unlock(p, ERTS_PROC_LOCK_MSGQ);
@@ -2637,7 +2637,7 @@ setup_rootset(Process *p, Eterm *objv, int nobj, Rootset *rootset)
 	 */
 
 #ifdef DEBUG
-        if (p->sig_qs.flags & FS_ON_HEAP_MSGQ) {
+        if (p->sig_qs.flags & (FS_ON_HEAP_MSGQ|FS_OFF_HEAP_MSGQ_CHNG)) {
             ErtsMessage *mp;
             erts_proc_lock(p, ERTS_PROC_LOCK_MSGQ);
             /*


### PR DESCRIPTION
When a process is changing from on heap to off heap
message queue data, there may still be messages in the
external queue with data on the heap. So we need to move
all signals in the external queue to the internal queue
before doing the GC.

Closes #5933 