### PR TITLE
reltool: Add option for selective beam stripping

### DIFF
--- a/lib/reltool/doc/src/reltool.xml
+++ b/lib/reltool/doc/src/reltool.xml
@@ -226,10 +226,10 @@
 
       <tag><c>debug_info</c></tag>
       <item>
-        <p>The <c>debug_info</c> parameter controls whether the debug
-        information in the beam file should be kept (<c>keep</c>) or
-        stripped <c>strip</c> when the file is copied to the target
-        system.</p>
+        <p>The <c>debug_info</c> parameter controls what debug
+        information in the beam file should be kept or stripped.
+        <c>keep</c> keeps all debug info, <c>strip</c> strips all debug
+        info, and a list of chunkids keeps only those chunks.</p>
       </item>
 
       <tag><c>excl_lib</c></tag>
@@ -542,7 +542,7 @@ app_vsn()           = string()
 archive_opt         = zip_create_opt()
 boot_rel()          = rel_name()
 app_file()          = keep | strip | all
-debug_info()        = keep | strip
+debug_info()        = keep | strip | [beam_lib:chunkid()]
 dir()               = string()
 escript()           = {incl_cond, incl_cond()}
 escript_file()      = file()

--- a/lib/reltool/src/reltool.app.src
+++ b/lib/reltool/src/reltool.app.src
@@ -36,6 +36,6 @@
   {registered, []},
   {applications, [stdlib, kernel]},
   {env, []},
-  {runtime_dependencies, ["wx-1.2","tools-2.6.14","stdlib-3.4","sasl-2.4",
+  {runtime_dependencies, ["wx-1.2","tools-2.6.14","stdlib-@OTP-15680@","sasl-2.4",
 			  "kernel-3.0","erts-7.0"]}
  ]}.

--- a/lib/reltool/src/reltool.hrl
+++ b/lib/reltool/src/reltool.hrl
@@ -28,7 +28,7 @@
 %% derived  - Include only those modules that others are dependent on
 -type mod_cond()         :: all | app | ebin | derived | none.
 -type incl_cond()        :: include | exclude | derived.
--type debug_info()       :: keep | strip.
+-type debug_info()       :: keep | strip | [beam_lib:chunkid()].
 -type app_file()         :: keep | strip | all.
 -type re_regexp()        :: string(). % re:regexp()
 -type regexps()          :: [re_regexp()] |

--- a/lib/reltool/src/reltool_server.erl
+++ b/lib/reltool/src/reltool_server.erl
@@ -1587,7 +1587,7 @@ decode(#sys{} = Sys, [{Key, Val} | KeyVals]) ->
                 Sys#sys{embedded_app_type = Val};
             app_file when Val =:= keep; Val =:= strip; Val =:= all ->
                 Sys#sys{app_file = Val};
-            debug_info when Val =:= keep; Val =:= strip ->
+            debug_info when Val =:= keep; Val =:= strip; is_list(Val) ->
                 Sys#sys{debug_info = Val};
             _ ->
 		reltool_utils:throw_error("Illegal option: ~tp", [{Key, Val}])
@@ -1608,7 +1608,8 @@ decode(#app{} = App, [{Key, Val} | KeyVals]) ->
                 App#app{incl_cond = Val};
 
             debug_info when Val =:= keep;
-			    Val =:= strip ->
+			    Val =:= strip;
+                            is_list(Val) ->
                 App#app{debug_info = Val};
             app_file when Val =:= keep;
 			  Val =:= strip;
@@ -1663,7 +1664,7 @@ decode(#mod{} = Mod, [{Key, Val} | KeyVals]) ->
         case Key of
             incl_cond when Val =:= include; Val =:= exclude; Val =:= derived ->
                 Mod#mod{incl_cond = Val};
-            debug_info when Val =:= keep; Val =:= strip ->
+            debug_info when Val =:= keep; Val =:= strip; is_list(Val) ->
                 Mod#mod{debug_info = Val};
             _ ->
 		reltool_utils:throw_error("Illegal option: ~tp", [{Key, Val}])

--- a/lib/reltool/src/reltool_target.erl
+++ b/lib/reltool/src/reltool_target.erl
@@ -1172,7 +1172,9 @@ spec_mod(Mod, DebugInfo) ->
         keep ->
             {copy_file, File};
         strip ->
-            {strip_beam, File}
+            {strip_beam, File, []};
+        ChunkIds ->
+            {strip_beam, File, ChunkIds}
     end.
 
 spec_app_file(#app{name = Name,
@@ -1315,11 +1317,14 @@ do_eval_spec({write_file, File, Bin},
 	     TargetDir) ->
     TargetFile = filename:join([TargetDir, File]),
     reltool_utils:write_file(TargetFile, Bin);
-do_eval_spec({strip_beam, File}, _OrigSourceDir, SourceDir, TargetDir) ->
+do_eval_spec({strip_beam, File, ChunkIds},
+             _OrigSourceDir,
+             SourceDir,
+             TargetDir) ->
     SourceFile = filename:join([SourceDir, File]),
     TargetFile = filename:join([TargetDir, File]),
     BeamBin = reltool_utils:read_file(SourceFile),
-    {ok, {_, BeamBin2}} = beam_lib:strip(BeamBin),
+    {ok, {_, BeamBin2}} = beam_lib:strip(BeamBin, ChunkIds),
     reltool_utils:write_file(TargetFile, BeamBin2).
 
 cleanup_spec(List, TargetDir) when is_list(List) ->
@@ -1349,7 +1354,7 @@ cleanup_spec({copy_file, NewFile, _OldFile}, TargetDir) ->
 cleanup_spec({write_file, File, _}, TargetDir) ->
     TargetFile = filename:join([TargetDir, File]),
     file:delete(TargetFile);
-cleanup_spec({strip_beam, File}, TargetDir) ->
+cleanup_spec({strip_beam, File, _ChunkIds}, TargetDir) ->
     TargetFile = filename:join([TargetDir, File]),
     file:delete(TargetFile).
 
@@ -1419,7 +1424,7 @@ do_filter_spec(Path,
 do_filter_spec(Path, {write_file, File, _}, InclRegexps, ExclRegexps) ->
     Path2 = opt_join(Path, File),
     match(Path2, InclRegexps, ExclRegexps);
-do_filter_spec(Path, {strip_beam, File}, InclRegexps, ExclRegexps) ->
+do_filter_spec(Path, {strip_beam, File, _ChunkIds}, InclRegexps, ExclRegexps) ->
     Path2 = opt_join(Path, File),
     match(Path2, InclRegexps, ExclRegexps).
 

--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -51,6 +51,7 @@
 -export([make_crypto_key/2, get_crypto_key/1]).	%Utilities used by compiler
 
 -export_type([attrib_entry/0, compinfo_entry/0, labeled_entry/0, label/0]).
+-export_type([chunkid/0]).
 -export_type([chnk_rsn/0]).
 
 -import(lists, [append/1, delete/2, foreach/2, keysort/2, 


### PR DESCRIPTION
The debug_info option can now take a list of chunk ids to keep.
Chunk ids are as per beam_lib:chunkid().

For example, {debug_info, ["Attr"]} will keep only the attributes
in the beam files and strip the rest.

---
Why?
We have some code that introspects itself for some declarative use-cases (mainly "wild" attributes), and recently we started needing to be able to deliver stripped binaries.
