### PR TITLE
SCTP: Fix type specs for inet:getopts/2 and inet:setopts/2

### DIFF
--- a/lib/kernel/doc/src/gen_sctp.xml
+++ b/lib/kernel/doc/src/gen_sctp.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>2007</year><year>2021</year>
+      <year>2007</year><year>2022</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -69,6 +69,7 @@
   </description>
 
   <datatypes>
+    <datatype_title>Exported data types</datatype_title>
     <datatype>
       <name>assoc_id()</name>
       <desc>
@@ -79,26 +80,47 @@
       </desc>
     </datatype>
     <datatype>
-      <name name="setoption"/>
+      <name name="option"/>
       <desc>
-        <p>One of the
-          <seeerl marker="#options">SCTP Socket Options</seeerl> used to set an option.</p>
+        <p>
+          One of the
+          <seeerl marker="#options">SCTP Socket Options</seeerl>
+          used to set an option.
+        </p>
       </desc>
     </datatype>
     <datatype>
-      <name name="getoption"/>
+      <name name="option_name"/>
       <desc>
-        <p>One of the
-          <seeerl marker="#options">SCTP Socket Options</seeerl> or name used to get an option.</p>
+        <p>
+          An option name or one of the
+          <seeerl marker="#options">SCTP Socket Options</seeerl>
+          used to get an option.
+        </p>
       </desc>
     </datatype>
     <datatype>
-      <name name="optionval"/>
+      <name name="option_value"/>
       <desc>
-        <p>One of the
-          <seeerl marker="#options">SCTP Socket Options</seeerl>.</p>
+        <p>
+          One of the
+          <seeerl marker="#options">SCTP Socket Options</seeerl>
+          as returned when getting an option.
+        </p>
       </desc>
     </datatype>
+    <datatype>
+      <name>sctp_socket()</name>
+      <desc>
+        <p>Socket identifier returned from
+          <seemfa marker="#open/0"><c>open/*</c></seemfa>.</p>
+        <marker id="exports"></marker>
+      </desc>
+    </datatype>
+  </datatypes>
+
+  <datatypes>
+    <datatype_title>Internal data types</datatype_title>
     <datatype>
       <name name="elementary_option"/>
     </datatype>
@@ -110,14 +132,6 @@
     </datatype>
     <datatype>
       <name name="ro_option"/>
-    </datatype>
-    <datatype>
-      <name>sctp_socket()</name>
-      <desc>
-        <p>Socket identifier returned from
-          <seemfa marker="#open/0"><c>open/*</c></seemfa>.</p>
-        <marker id="exports"></marker>
-      </desc>
     </datatype>
   </datatypes>
 

--- a/lib/kernel/doc/src/gen_sctp.xml
+++ b/lib/kernel/doc/src/gen_sctp.xml
@@ -79,14 +79,37 @@
       </desc>
     </datatype>
     <datatype>
-      <name name="option"/>
+      <name name="setoption"/>
+      <desc>
+        <p>One of the
+          <seeerl marker="#options">SCTP Socket Options</seeerl> used to set an option.</p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="getoption"/>
+      <desc>
+        <p>One of the
+          <seeerl marker="#options">SCTP Socket Options</seeerl> or name used to get an option.</p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="optionval"/>
       <desc>
         <p>One of the
           <seeerl marker="#options">SCTP Socket Options</seeerl>.</p>
       </desc>
     </datatype>
     <datatype>
-      <name name="option_name"/>
+      <name name="elementary_option"/>
+    </datatype>
+    <datatype>
+      <name name="elementary_option_name"/>
+    </datatype>
+    <datatype>
+      <name name="record_option"/>
+    </datatype>
+    <datatype>
+      <name name="ro_option"/>
     </datatype>
     <datatype>
       <name>sctp_socket()</name>
@@ -479,7 +502,7 @@ connect(Socket, Ip, Port>,
 	    ancillary data
 	  </seetype>
 	  from the socket
-	  <seetype marker="#option">options</seetype>
+	  <seeerl marker="#options">options</seeerl>
 	  <seeerl marker="inet#option-recvtos"><c>recvtos</c></seeerl>,
 	  <seeerl marker="inet#option-recvtclass"><c>recvtclass</c></seeerl>
 	  or

--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>1997</year><year>2021</year>
+      <year>1997</year><year>2022</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -92,6 +92,7 @@ fe80::204:acff:fe17:bf38
   </description>
 
   <datatypes>
+    <datatype_title>Exported data types</datatype_title>
     <datatype>
       <name name="hostent"/>
       <desc>
@@ -127,30 +128,6 @@ fe80::204:acff:fe17:bf38
 	  and is a complete address
 	  (for example an IP address including port number).
 	</p>
-      </desc>
-    </datatype>
-    <datatype>
-      <name name="inet_address" since="OTP 22.1"/>
-      <desc>
-	<warning>
-	  <p>
-	    This address format is for now experimental
-	    and for completeness to make all address families have a
-	    <c>{Family, Destination}</c> representation.
-	  </p>
-	</warning>
-      </desc>
-    </datatype>
-    <datatype>
-      <name name="inet6_address" since="OTP 22.1"/>
-      <desc>
-	<warning>
-	  <p>
-	    This address format is for now experimental
-	    and for completeness to make all address families have a
-	    <c>{Family, Destination}</c> representation.
-	  </p>
-	</warning>
       </desc>
     </datatype>
     <datatype>
@@ -260,6 +237,61 @@ fe80::204:acff:fe17:bf38
       </desc>
     </datatype>
     <datatype>
+      <name name="posix"/>
+      <desc>
+        <p>An atom that is named from the POSIX error codes used in Unix,
+          and in the runtime libraries of most C compilers. See section
+          <seeerl marker="#error_codes">POSIX Error Codes</seeerl>.</p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name>socket()</name>
+      <desc>
+        <p>See
+          <seetype marker="gen_tcp#socket"><c>gen_tcp:type-socket</c></seetype>
+          and
+          <seetype marker="gen_udp#socket"><c>gen_udp:type-socket</c></seetype>.
+        </p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="address_family"/>
+    </datatype>
+    <datatype>
+      <name name="socket_protocol"/>
+    </datatype>
+    <datatype>
+      <name name="stat_option"/>
+    </datatype>
+  </datatypes>
+
+  <datatypes>
+    <datatype_title>Internal data types</datatype_title>
+    <datatype>
+      <name name="inet_address" since="OTP 22.1"/>
+      <desc>
+	<warning>
+	  <p>
+	    This address format is for now experimental
+	    and for completeness to make all address families have a
+	    <c>{Family, Destination}</c> representation.
+	  </p>
+	</warning>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="inet6_address" since="OTP 22.1"/>
+      <desc>
+	<warning>
+	  <p>
+	    This address format is for now experimental
+	    and for completeness to make all address families have a
+	    <c>{Family, Destination}</c> representation.
+	  </p>
+	</warning>
+      </desc>
+    </datatype>
+    <datatype>
       <name name="getifaddrs_ifopts"/>
       <desc>
 	<p>
@@ -332,34 +364,8 @@ fe80::204:acff:fe17:bf38
 	</warning>
       </desc>
     </datatype>
-    <datatype>
-      <name name="posix"/>
-      <desc>
-        <p>An atom that is named from the POSIX error codes used in Unix,
-          and in the runtime libraries of most C compilers. See section
-          <seeerl marker="#error_codes">POSIX Error Codes</seeerl>.</p>
-      </desc>
-    </datatype>
-    <datatype>
-      <name>socket()</name>
-      <desc>
-        <p>See
-          <seetype marker="gen_tcp#socket"><c>gen_tcp:type-socket</c></seetype>
-          and
-          <seetype marker="gen_udp#socket"><c>gen_udp:type-socket</c></seetype>.
-        </p>
-      </desc>
-    </datatype>
-    <datatype>
-      <name name="address_family"/>
-    </datatype>
-    <datatype>
-      <name name="socket_protocol"/>
-    </datatype>
-    <datatype>
-      <name name="stat_option"/>
-    </datatype>
   </datatypes>
+
 
   <funcs>
     <func>
@@ -560,7 +566,8 @@ fe80::204:acff:fe17:bf38
         <p>Gets one or more options for a socket. For a list of available
           inet options, see
           <seemfa marker="#setopts/2"><c>setopts/2</c></seemfa>.
-	  See also the descriptions for the protocol specific types referenced by
+	  See also the descriptions
+          for the protocol specific types referenced by
           <seetype marker="#socket_optval">
 	    <c>socket_optval()</c>
 	  </seetype>.</p>

--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -210,6 +210,9 @@ fe80::204:acff:fe17:bf38
       <name name="socket_setopt"/>
     </datatype>
     <datatype>
+      <name name="socket_optval"/>
+    </datatype>
+    <datatype>
       <name name="returned_non_ip_address"/>
       <desc>
 	<p>
@@ -555,11 +558,11 @@ fe80::204:acff:fe17:bf38
       <fsummary>Get one or more options for a socket.</fsummary>
       <desc>
         <p>Gets one or more options for a socket. For a list of available
-          options, see
+          inet options, see
           <seemfa marker="#setopts/2"><c>setopts/2</c></seemfa>.
-	  See also the description for the type
-          <seetype marker="gen_tcp#pktoptions_value">
-	    <c>gen_tcp:pktoptions_value()</c>
+	  See also the descriptions for the protocol specific types referenced by
+          <seetype marker="#socket_optval">
+	    <c>socket_optval()</c>
 	  </seetype>.</p>
         <p>The number of elements in the returned
           <c><anno>OptionValues</anno></c>

--- a/lib/kernel/src/gen_sctp.erl
+++ b/lib/kernel/src/gen_sctp.erl
@@ -37,7 +37,22 @@
 -export([controlling_process/2]).
 
 -type assoc_id() :: term().
--type option() ::
+
+-type setoption() ::
+        elementary_option() |
+        record_option().
+
+-type getoption() ::
+        elementary_option_name() |
+        record_option() |
+        ro_option().
+
+-type optionval() ::
+        elementary_option() |
+        record_option() |
+        ro_option().
+
+-type elementary_option() ::
         {active, true | false | once | -32768..32767} |
         {buffer, non_neg_integer()} |
         {dontroute, boolean()} |
@@ -49,31 +64,20 @@
         {recbuf, non_neg_integer()} |
         {reuseaddr, boolean()} |
 	{ipv6_v6only, boolean()} |
-        {sctp_adaptation_layer, #sctp_setadaptation{}} |
-        {sctp_associnfo, #sctp_assocparams{}} |
+        {sndbuf, non_neg_integer()} |
         {sctp_autoclose, non_neg_integer()} |
-        {sctp_default_send_param, #sctp_sndrcvinfo{}} |
-        {sctp_delayed_ack_time, #sctp_assoc_value{}} |
         {sctp_disable_fragments, boolean()} |
-        {sctp_events, #sctp_event_subscribe{}} |
-        {sctp_get_peer_addr_info, #sctp_paddrinfo{}} |
         {sctp_i_want_mapped_v4_addr, boolean()} |
-        {sctp_initmsg, #sctp_initmsg{}} |
         {sctp_maxseg, non_neg_integer()} |
         {sctp_nodelay, boolean()} |
-        {sctp_peer_addr_params, #sctp_paddrparams{}} |
-        {sctp_primary_addr, #sctp_prim{}} |
-        {sctp_rtoinfo, #sctp_rtoinfo{}} |
-        {sctp_set_peer_primary_addr, #sctp_setpeerprim{}} |
-        {sctp_status, #sctp_status{}} |
-        {sndbuf, non_neg_integer()} |
         {tos, non_neg_integer()} |
         {tclass, non_neg_integer()} |
         {ttl, non_neg_integer()} |
         {recvtos, boolean()} |
         {recvtclass, boolean()} |
         {recvttl, boolean()}.
--type option_name() ::
+
+-type elementary_option_name() ::
         active |
         buffer |
         dontroute |
@@ -85,23 +89,11 @@
         recbuf |
         reuseaddr |
 	ipv6_v6only |
-        sctp_adaptation_layer |
-        sctp_associnfo |
         sctp_autoclose |
-        sctp_default_send_param |
-        sctp_delayed_ack_time |
         sctp_disable_fragments |
-        sctp_events |
-        sctp_get_peer_addr_info |
         sctp_i_want_mapped_v4_addr |
-        sctp_initmsg |
         sctp_maxseg |
         sctp_nodelay |
-        sctp_peer_addr_params |
-        sctp_primary_addr |
-        sctp_rtoinfo |
-        sctp_set_peer_primary_addr |
-        sctp_status |
         sndbuf |
         tos |
         tclass |
@@ -109,9 +101,26 @@
         recvtos |
         recvtclass |
         recvttl.
+
+-type record_option() ::
+        {sctp_adaptation_layer, #sctp_setadaptation{}} |
+        {sctp_associnfo, #sctp_assocparams{}} |
+        {sctp_default_send_param, #sctp_sndrcvinfo{}} |
+        {sctp_delayed_ack_time, #sctp_assoc_value{}} |
+        {sctp_events, #sctp_event_subscribe{}} |
+        {sctp_initmsg, #sctp_initmsg{}} |
+        {sctp_peer_addr_params, #sctp_paddrparams{}} |
+        {sctp_primary_addr, #sctp_prim{}} |
+        {sctp_rtoinfo, #sctp_rtoinfo{}} |
+        {sctp_set_peer_primary_addr, #sctp_setpeerprim{}}.
+
+-type ro_option() ::
+        {sctp_get_peer_addr_info, #sctp_paddrinfo{}} |
+        {sctp_status, #sctp_status{}}.
+
 -type sctp_socket() :: port().
 
--export_type([assoc_id/0, option/0, option_name/0, sctp_socket/0]).
+-export_type([assoc_id/0, setoption/0, getoption/0, optionval/0, sctp_socket/0]).
 
 -spec open() -> {ok, Socket} | {error, inet:posix()} when
       Socket :: sctp_socket().
@@ -131,7 +140,7 @@ open() ->
         	   | {type, SockType}
                    | {netns, file:filename_all()}
                    | {bind_to_device, binary()}
-                   | option(),
+                   | setoption(),
               IP       :: inet:ip_address() | any | loopback,
               SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
               Port     :: inet:port_number(),
@@ -161,7 +170,7 @@ open(X) ->
                    | {type, SockType}
                    | {netns, file:filename_all()}
                    | {bind_to_device, binary()}
-                   | option(),
+                   | setoption(),
       IP       :: inet:ip_address() | any | loopback,
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
       Port     :: inet:port_number(),
@@ -229,7 +238,7 @@ peeloff(S, AssocId) when is_port(S), is_integer(AssocId) ->
                          when
       Socket   :: sctp_socket(),
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
-      Opts     :: [Opt :: option()].
+      Opts     :: [Opt :: setoption()].
 
 connect(S, SockAddr, Opts) ->
     connect(S, SockAddr, Opts, infinity).
@@ -241,7 +250,7 @@ connect(S, SockAddr, Opts) ->
                          when
       Socket   :: sctp_socket(),
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
-      Opts     :: [Opt :: option()],
+      Opts     :: [Opt :: setoption()],
       Timeout  :: timeout();
              (Socket, Addr, Port, Opts) ->
                      {ok, #sctp_assoc_change{state :: 'comm_up'}} |
@@ -251,7 +260,7 @@ connect(S, SockAddr, Opts) ->
       Socket :: sctp_socket(),
       Addr   :: inet:ip_address() | inet:hostname(),
       Port   :: inet:port_number(),
-      Opts   :: [Opt :: option()].
+      Opts   :: [Opt :: setoption()].
 
 connect(S, SockAddr, Opts, Timeout)
   when is_map(SockAddr) andalso is_list(Opts) ->
@@ -272,7 +281,7 @@ connect(S, Addr, Port, Opts) ->
       Socket :: sctp_socket(),
       Addr :: inet:ip_address() | inet:hostname(),
       Port :: inet:port_number(),
-      Opts :: [Opt :: option()],
+      Opts :: [Opt :: setoption()],
       Timeout :: timeout().
 
 connect(S, Addr, Port, Opts, Timeout) ->
@@ -287,7 +296,7 @@ connect(S, Addr, Port, Opts, Timeout) ->
                           ok | {error, inet:posix()} when
       Socket   :: sctp_socket(),
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
-      Opts     :: [option()].
+      Opts     :: [setoption()].
 
 connect_init(S, SockAddr, Opts) ->
     connect_init(S, SockAddr, Opts, infinity).
@@ -296,14 +305,14 @@ connect_init(S, SockAddr, Opts) ->
                           ok | {error, inet:posix()} when
       Socket   :: sctp_socket(),
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
-      Opts     :: [option()],
+      Opts     :: [setoption()],
       Timeout  :: timeout();
                   (Socket, Addr, Port, Opts) ->
                           ok | {error, inet:posix()} when
       Socket :: sctp_socket(),
       Addr   :: inet:ip_address() | inet:hostname(),
       Port   :: inet:port_number(),
-      Opts   :: [option()].
+      Opts   :: [setoption()].
 
 connect_init(S, SockAddr, Opts, Timeout)
   when is_map(SockAddr) andalso is_list(Opts) ->
@@ -321,7 +330,7 @@ connect_init(S, Addr, Port, Opts) ->
       Socket :: sctp_socket(),
       Addr :: inet:ip_address() | inet:hostname(),
       Port :: inet:port_number(),
-      Opts :: [option()],
+      Opts :: [setoption()],
       Timeout :: timeout().
 
 connect_init(S, Addr, Port, Opts, Timeout) ->

--- a/lib/kernel/src/gen_sctp.erl
+++ b/lib/kernel/src/gen_sctp.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2007-2021. All Rights Reserved.
+%% Copyright Ericsson AB 2007-2022. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -38,16 +38,16 @@
 
 -type assoc_id() :: term().
 
--type setoption() ::
+-type option() ::
         elementary_option() |
         record_option().
 
--type getoption() ::
+-type option_name() ::
         elementary_option_name() |
         record_option() |
         ro_option().
 
--type optionval() ::
+-type option_value() ::
         elementary_option() |
         record_option() |
         ro_option().
@@ -120,7 +120,8 @@
 
 -type sctp_socket() :: port().
 
--export_type([assoc_id/0, setoption/0, getoption/0, optionval/0, sctp_socket/0]).
+-export_type(
+   [assoc_id/0, option/0, option_name/0,  option_value/0, sctp_socket/0]).
 
 -spec open() -> {ok, Socket} | {error, inet:posix()} when
       Socket :: sctp_socket().
@@ -140,7 +141,7 @@ open() ->
         	   | {type, SockType}
                    | {netns, file:filename_all()}
                    | {bind_to_device, binary()}
-                   | setoption(),
+                   | option(),
               IP       :: inet:ip_address() | any | loopback,
               SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
               Port     :: inet:port_number(),
@@ -170,7 +171,7 @@ open(X) ->
                    | {type, SockType}
                    | {netns, file:filename_all()}
                    | {bind_to_device, binary()}
-                   | setoption(),
+                   | option(),
       IP       :: inet:ip_address() | any | loopback,
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
       Port     :: inet:port_number(),
@@ -238,7 +239,7 @@ peeloff(S, AssocId) when is_port(S), is_integer(AssocId) ->
                          when
       Socket   :: sctp_socket(),
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
-      Opts     :: [Opt :: setoption()].
+      Opts     :: [Opt :: option()].
 
 connect(S, SockAddr, Opts) ->
     connect(S, SockAddr, Opts, infinity).
@@ -250,7 +251,7 @@ connect(S, SockAddr, Opts) ->
                          when
       Socket   :: sctp_socket(),
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
-      Opts     :: [Opt :: setoption()],
+      Opts     :: [Opt :: option()],
       Timeout  :: timeout();
              (Socket, Addr, Port, Opts) ->
                      {ok, #sctp_assoc_change{state :: 'comm_up'}} |
@@ -260,7 +261,7 @@ connect(S, SockAddr, Opts) ->
       Socket :: sctp_socket(),
       Addr   :: inet:ip_address() | inet:hostname(),
       Port   :: inet:port_number(),
-      Opts   :: [Opt :: setoption()].
+      Opts   :: [Opt :: option()].
 
 connect(S, SockAddr, Opts, Timeout)
   when is_map(SockAddr) andalso is_list(Opts) ->
@@ -281,7 +282,7 @@ connect(S, Addr, Port, Opts) ->
       Socket :: sctp_socket(),
       Addr :: inet:ip_address() | inet:hostname(),
       Port :: inet:port_number(),
-      Opts :: [Opt :: setoption()],
+      Opts :: [Opt :: option()],
       Timeout :: timeout().
 
 connect(S, Addr, Port, Opts, Timeout) ->
@@ -296,7 +297,7 @@ connect(S, Addr, Port, Opts, Timeout) ->
                           ok | {error, inet:posix()} when
       Socket   :: sctp_socket(),
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
-      Opts     :: [setoption()].
+      Opts     :: [option()].
 
 connect_init(S, SockAddr, Opts) ->
     connect_init(S, SockAddr, Opts, infinity).
@@ -305,14 +306,14 @@ connect_init(S, SockAddr, Opts) ->
                           ok | {error, inet:posix()} when
       Socket   :: sctp_socket(),
       SockAddr :: socket:sockaddr_in() | socket:sockaddr_in6(),
-      Opts     :: [setoption()],
+      Opts     :: [option()],
       Timeout  :: timeout();
                   (Socket, Addr, Port, Opts) ->
                           ok | {error, inet:posix()} when
       Socket :: sctp_socket(),
       Addr   :: inet:ip_address() | inet:hostname(),
       Port   :: inet:port_number(),
-      Opts   :: [setoption()].
+      Opts   :: [option()].
 
 connect_init(S, SockAddr, Opts, Timeout)
   when is_map(SockAddr) andalso is_list(Opts) ->
@@ -330,7 +331,7 @@ connect_init(S, Addr, Port, Opts) ->
       Socket :: sctp_socket(),
       Addr :: inet:ip_address() | inet:hostname(),
       Port :: inet:port_number(),
-      Opts :: [setoption()],
+      Opts :: [option()],
       Timeout :: timeout().
 
 connect_init(S, Addr, Port, Opts, Timeout) ->

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -144,10 +144,14 @@
 -type inet_backend() :: {'inet_backend', 'inet' | 'socket'}.
 
 -type socket_setopt() ::
-        gen_sctp:option() | gen_tcp:option() | gen_udp:option().
+        gen_sctp:setoption() | gen_tcp:option() | gen_udp:option().
+
+-type socket_optval() ::
+        gen_sctp:optionval() | gen_tcp:option() | gen_udp:option() | gen_tcp:pktoptions_value().
 
 -type socket_getopt() ::
-        gen_sctp:option_name() | gen_tcp:option_name() | gen_udp:option_name().
+        gen_sctp:getoption() | gen_tcp:option_name() | gen_udp:option_name().
+
 -type ether_address() :: [0..255].
 
 -type if_setopt() ::
@@ -398,7 +402,7 @@ setopts(Socket, Opts) ->
 	{'ok', OptionValues} | {'error', posix()} when
       Socket :: socket(),
       Options :: [socket_getopt()],
-      OptionValues :: [socket_setopt() | gen_tcp:pktoptions_value()].
+      OptionValues :: [socket_optval()].
 
 getopts(?module_socket(GenSocketMod, _) = Socket, Opts)
   when is_atom(GenSocketMod) ->

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -85,7 +85,8 @@
               ip6_address/0, ip_address/0, port_number/0,
 	      family_address/0, local_address/0,
               socket_address/0, returned_non_ip_address/0,
-	      socket_setopt/0, socket_getopt/0, ancillary_data/0,
+	      socket_setopt/0, socket_getopt/0, socket_optval/0,
+              ancillary_data/0,
 	      posix/0, socket/0, inet_backend/0, stat_option/0]).
 %% imports
 -import(lists, [append/1, duplicate/2, filter/2, foldl/3]).
@@ -144,13 +145,14 @@
 -type inet_backend() :: {'inet_backend', 'inet' | 'socket'}.
 
 -type socket_setopt() ::
-        gen_sctp:setoption() | gen_tcp:option() | gen_udp:option().
+        gen_sctp:option() | gen_tcp:option() | gen_udp:option().
 
 -type socket_optval() ::
-        gen_sctp:optionval() | gen_tcp:option() | gen_udp:option() | gen_tcp:pktoptions_value().
+        gen_sctp:option_value() | gen_tcp:option() | gen_udp:option() |
+        gen_tcp:pktoptions_value().
 
 -type socket_getopt() ::
-        gen_sctp:getoption() | gen_tcp:option_name() | gen_udp:option_name().
+        gen_sctp:option_name() | gen_tcp:option_name() | gen_udp:option_name().
 
 -type ether_address() :: [0..255].
 


### PR DESCRIPTION
SCTP Socket options have some weird[^1] semantics that this PR fixes.

Specifically:

- two options are read-only (see `prim_inet:type_opt/2`)
- many options for getopts require a  `#sctp_...` record to specify the association

Previously, the same type specification was used for both getopts and setopts which caused dialyzer to barf on perfectly valid code like this:
```erlang
    inet:getopts(Sock, [{sctp_status, #sctp_status{assoc_id = AssocId}}])
```

[^1]: Weird, as in not like TCP or UDP but perfectly fine for SCTP!