### PR TITLE
Backport: epmd: don't fail if non-critical interfaces fail to bind

### DIFF
--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -239,6 +239,7 @@ void run(EpmdVars *g)
   char socknamebuf[INET_ADDRSTRLEN];
 #endif
   int num_sockets = 0;
+  int nonfatal_sockets = 0;
   int i;
   int opt;
   unsigned short sport = g->port;
@@ -295,6 +296,14 @@ void run(EpmdVars *g)
       SET_ADDR6(iserv_addr[num_sockets],in6addr_loopback,sport);
       num_sockets++;
 #endif
+
+      /* IPv4 and/or IPv6 loopback may not be present, for example if
+       * the protocol stack is explicitly disabled in the kernel.  If
+       * any sockets to this point fail, log the error but do not exit
+       * with failure.  If any socket after this (explicitly
+       * configured via addresses) fails, then consider the error
+       * fatal. */
+      nonfatal_sockets = num_sockets;
 
 	  if ((tmp = strdup(g->addresses)) == NULL)
 	{
@@ -411,7 +420,6 @@ void run(EpmdVars *g)
 	          epmd_cleanup_exit(g,1);
 	  }
 	}
-      g->listenfd[bound++] = listensock[i];
 
 #if HAVE_DECL_IPV6_V6ONLY
       opt = 1;
@@ -469,7 +477,14 @@ void run(EpmdVars *g)
               dbg_perror(g,"failed to bind on ipaddr %s",
                          epmd_ntop(&iserv_addr[num_sockets],
                                    socknamebuf, sizeof(socknamebuf)));
-              epmd_cleanup_exit(g,1);
+              if (i >= nonfatal_sockets)
+                  epmd_cleanup_exit(g,1);
+              else
+              {
+                  close(listensock[i]);
+                  continue;
+              }
+
 	    }
 	}
 
@@ -479,6 +494,7 @@ void run(EpmdVars *g)
                                socknamebuf, sizeof(socknamebuf)));
           epmd_cleanup_exit(g,1);
       }
+      g->listenfd[bound++] = listensock[i];
       select_fd_set(g, listensock[i]);
     }
   if (bound == 0) {


### PR DESCRIPTION
Backporting e8c9e12 (#5762) to v23.

When specifying bind address(es) via ERL_EPMD_ADDRESS or the -address
option, epmd will bind to the IPv4/IPv6 loopback intefaces in addition
to the user-supplied address(es).

However, it is possible that one of the loopback interfaces does not
exist.  For example, if the host system has ipv6 disabled via the
disable_ipv6 sysctl, there will be no loopback interface "::1", and
attmepting to bind to "::1" will fail.

Under these circumstances, log the failure but do not consider the
failure to bind to the loopback interface as fatal.

If any of the user-supplied addresses fail to bind, however, that is
still considered fatal and epmd will terminate.