### PR TITLE
peer: Add detach option to allow peers to remain attached

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -294,7 +294,7 @@ $ <input>erl \
           <c><![CDATA[-setcookie]]></c>. Use <c><![CDATA[-setcookie]]></c>
           instead.</p>
       </item>
-      <tag><c><![CDATA[-detached]]></c></tag>
+      <tag><marker id="detach"/><c><![CDATA[-detached]]></c></tag>
       <item>
         <p>Starts the Erlang runtime system detached from the system
           console. Useful for running daemons and backgrounds processes. Implies

--- a/lib/stdlib/doc/src/peer.xml
+++ b/lib/stdlib/doc/src/peer.xml
@@ -300,6 +300,15 @@
             <p>Alternative connection specification. See the
               <seetype marker="#connection"><c>connection</c> datatype</seetype>.</p>
           </item>
+          <tag><c>detach</c></tag>
+          <item>
+              <p>If peer should <seecmd marker="erts:erl#detach"><c>detach</c></seecmd>
+                from the peer node. The default is <c>true</c>.
+                If set to <c>false</c>, all standard output and standard error
+                printouts will be sent to the group leader of the starting process.
+                This option cannot be set to <c>false</c> when the connection type
+                is <c>standard_io</c>.</p>
+            </item>
           <tag><c>args</c></tag>
           <item>
             <p>Extra command line arguments to append to the "erl" command. Arguments are


### PR DESCRIPTION
Add the option `detach` that can be set to false in order
for the peer process to remain attached to the peer node
and forward any output to stdout or stderr from that node.

This mode is mostly useful when testing the startup and
shutdown of Erlang.