### PR TITLE
ssl: Store ClientCert in Stateless SessionTicket

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1306,12 +1306,20 @@ encrypt_ticket(#stateless_ticket{
                   pre_shared_key = PSK,
                   ticket_age_add = TicketAgeAdd,
                   lifetime = Lifetime,
-                  timestamp = Timestamp
+                  timestamp = Timestamp,
+                  certificate = Certificate
                  }, Shard, IV) ->
-    Plaintext = <<(ssl_cipher:hash_algorithm(Hash)):8,PSK/binary,
+    Plaintext1 = <<(ssl_cipher:hash_algorithm(Hash)):8,PSK/binary,
                    ?UINT64(TicketAgeAdd),?UINT32(Lifetime),?UINT32(Timestamp)>>,
+    CertificateLength = case Certificate of
+        undefined -> 0;
+        _ -> byte_size(Certificate)
+    end,
+    Plaintext = case CertificateLength of
+        0 -> <<Plaintext1/binary,?UINT16(0)>>;
+        _ -> <<Plaintext1/binary,?UINT16(CertificateLength),Certificate/binary>>
+    end,
     encrypt_ticket_data(Plaintext, Shard, IV).
-
 
 decrypt_ticket(CipherFragment, Shard, IV) ->
     case decrypt_ticket_data(CipherFragment, Shard, IV) of
@@ -1321,14 +1329,20 @@ decrypt_ticket(CipherFragment, Shard, IV) ->
             <<?BYTE(HKDF),T/binary>> = Plaintext,
             Hash = hash_algorithm(HKDF),
             HashSize = hash_size(Hash),
-            <<PSK:HashSize/binary,?UINT64(TicketAgeAdd),?UINT32(Lifetime),?UINT32(Timestamp),_/binary>> = T,
+            <<PSK:HashSize/binary,?UINT64(TicketAgeAdd),?UINT32(Lifetime),?UINT32(Timestamp),
+                ?UINT16(CertificateLength),Certificate1:CertificateLength/binary,_/binary>> = T,
+            Certificate = case CertificateLength of
+                0 -> undefined;
+                _ -> Certificate1
+            end,
             #stateless_ticket{
                hash = Hash,
                pre_shared_key = PSK,
                ticket_age_add = TicketAgeAdd,
                lifetime = Lifetime,
-               timestamp = Timestamp
-              }
+               timestamp = Timestamp,
+               certificate = Certificate
+            }
     end.
 
 

--- a/lib/ssl/src/ssl_cipher.hrl
+++ b/lib/ssl/src/ssl_cipher.hrl
@@ -34,7 +34,8 @@
          pre_shared_key,
          ticket_age_add,
          lifetime,
-         timestamp
+         timestamp,
+         certificate
         }).
 
 %%% SSL cipher protocol  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/ssl/src/tls_handshake_1_3.erl
+++ b/lib/ssl/src/tls_handshake_1_3.erl
@@ -1313,22 +1313,27 @@ session_resumption({#state{ssl_options = #{session_tickets := Tickets}} = State,
     {ok, {State, negotiated}};
 session_resumption({#state{ssl_options = #{session_tickets := Tickets},
                            handshake_env = #handshake_env{
-                                              early_data_accepted = false}} = State0, negotiated}, PSK)
+                                              early_data_accepted = false}} = State0, negotiated}, PSK0)
   when Tickets =/= disabled ->
-    State = handle_resumption(State0, ok),
-    {ok, {State, negotiated, PSK}};
+    State1 = handle_resumption(State0, ok),
+    {Index, PSK, PeerCert} = PSK0,
+    PSK1 = {Index, PSK},
+    State = store_peer_cert(State1, PeerCert),
+    {ok, {State, negotiated, PSK1}};
 session_resumption({#state{ssl_options = #{session_tickets := Tickets},
                            handshake_env = #handshake_env{
                                               early_data_accepted = true}} = State0, negotiated}, PSK0)
   when Tickets =/= disabled ->
     State1 = handle_resumption(State0, ok),
     %% TODO Refactor PSK-tuple {Index, PSK}, index might not be needed.
-    {_ , PSK} = PSK0,
+    {Index, PSK, PeerCert} = PSK0,
+    PSK1 = {Index, PSK},
     State2 = calculate_client_early_traffic_secret(State1, PSK),
     %% Set 0-RTT traffic keys for reading early_data
     State3 = ssl_record:step_encryption_state_read(State2),
-    State = update_current_read(State3, true, true),
-    {ok, {State, negotiated, PSK0}}.
+    State4 = store_peer_cert(State3, PeerCert),
+    State = update_current_read(State4, true, true),
+    {ok, {State, negotiated, PSK1}}.
 
 %% Session resumption with early_data
 maybe_send_certificate_request(#state{
@@ -1398,15 +1403,15 @@ maybe_send_session_ticket(State, 0) ->
     State;
 maybe_send_session_ticket(#state{connection_states = ConnectionStates,
                                  static_env = #static_env{trackers = Trackers,
-                                                          protocol_cb = Connection}
-                                 
+                                                          protocol_cb = Connection},
+                                session = #session{peer_certificate = PeerCert}
                                 } = State0, N) ->
     Tracker = proplists:get_value(session_tickets_tracker, Trackers),
     #{security_parameters := SecParamsR} =
         ssl_record:current_connection_state(ConnectionStates, read),
     #security_parameters{prf_algorithm = HKDF,
                          resumption_master_secret = RMS} = SecParamsR, 
-    Ticket = tls_server_session_ticket:new(Tracker, HKDF, RMS),
+    Ticket = tls_server_session_ticket:new(Tracker, HKDF, RMS, PeerCert),
     {State, _} = Connection:send_handshake(Ticket, State0),
     maybe_send_session_ticket(State, N - 1).
 
@@ -1510,7 +1515,13 @@ validate_certificate_chain(CertEntries, CertDbHandle, CertDbRef,
                             ocsp_state => OcspState,
                             ocsp_responder_certs => OcspResponderCerts}).
 
-
+store_peer_cert(#state{session = Session} = State, PeerCert) ->
+    case PeerCert of
+        undefined -> 
+            State;
+        _ -> 
+            State#state{session = Session#session{peer_certificate = PeerCert}}
+    end.
 store_peer_cert(#state{session = Session,
                        handshake_env = HsEnv} = State, PeerCert, PublicKeyInfo) ->
     State#state{session = Session#session{peer_certificate = PeerCert},


### PR DESCRIPTION
During session resumption with stateless tickets a previously verified
client certificate will not be available in the resumed session.
Storing the certificate in the session ticket allows us to retrieve it
during session resumption handshake.

This PR is related to #5870 but only covers the case of storing the client certificate.