### PR TITLE
compiler: Improve deterministic builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -294,6 +294,13 @@ RELEASE_ROOT = $(TESTROOT)
 endif
 endif
 
+# ----------------------------------------------------------------------
+
+ifeq ($(ERL_DETERMINISTIC),yes)
+	DETERMINISM_FLAG = +deterministic
+else
+	DETERMINISM_FLAG =
+endif
 
 # ----------------------------------------------------------------------
 
@@ -1036,7 +1043,7 @@ primary_bootstrap:
 
 primary_bootstrap_build: primary_bootstrap_mkdirs primary_bootstrap_compiler \
   primary_bootstrap_stdlib
-	$(make_verbose)cd lib && $(MAKE) ERLC_FLAGS='-pa $(BOOTSTRAP_COMPILER)/ebin' \
+	$(make_verbose)cd lib && $(MAKE) ERLC_FLAGS='-pa $(BOOTSTRAP_COMPILER)/ebin $(DETERMINISM_FLAG)' \
 		BOOTSTRAP_TOP=$(BOOTSTRAP_TOP) \
 		BOOTSTRAP=1 opt
 

--- a/configure
+++ b/configure
@@ -139,6 +139,10 @@ while test $# != 0; do
 	    pie_cflags="-fno-PIE"
 	    pie_ldflags="-no-pie"
 	    ;;
+	--enable-deterministic-build)
+      config_arguments="$config_arguments --enable-deterministic-build";;
+	--disable-deterministic-build)
+      config_arguments="$config_arguments --disable-deterministic-build";;
 	CFLAGS=* | LDFLAGS=*)
         flgs_var=`echo "$1" | sed 's/=.*$//'`
         flgs_val=`echo "$1" | sed 's/^[^=]*=//'`

--- a/configure.src
+++ b/configure.src
@@ -139,6 +139,10 @@ while test $# != 0; do
 	    pie_cflags="-fno-PIE"
 	    pie_ldflags="-no-pie"
 	    ;;
+	--enable-deterministic-build)
+      config_arguments="$config_arguments --enable-deterministic-build";;
+	--disable-deterministic-build)
+      config_arguments="$config_arguments --disable-deterministic-build";;
 	CFLAGS=* | LDFLAGS=*)
         flgs_var=`echo "$1" | sed 's/=.*$//'`
         flgs_val=`echo "$1" | sed 's/^[^=]*=//'`

--- a/erts/configure
+++ b/erts/configure
@@ -650,6 +650,7 @@ ac_func_c_list=
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 DEBUG_CFLAGS
+ERL_DETERMINISTIC
 CFLAGS32
 CC32
 JAVAC
@@ -868,6 +869,7 @@ enable_prefer_elapsed_monotonic_time_during_suspend
 enable_gettimeofday_as_os_system_time
 with_javac
 enable_sanitizers
+enable_deterministic_build
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1610,6 +1612,9 @@ Optional Features:
                           Force usage of gettimeofday() for OS system time
   --enable-sanitizers[=comma-separated list of sanitizers]
                           Default=address,undefined
+  --enable-deterministic-build
+                          enable build determinism, stripping absolute paths
+                          from build output
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -25433,6 +25438,20 @@ CFLAGS="$CFLAGS $sanitizers"
 LDFLAGS="$LDFLAGS $sanitizers"
 
 fi
+
+
+
+# Check whether --enable-deterministic-build was given.
+if test ${enable_deterministic_build+y}
+then :
+  enableval=$enable_deterministic_build;  case "$enableval" in
+    no)  ERL_DETERMINISTIC=no ;;
+    *) ERL_DETERMINISTIC=yes ;;
+  esac
+else $as_nop
+  ERL_DETERMINISTIC=no
+fi
+
 
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CFLAGS for -O switch" >&5

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -3570,6 +3570,19 @@ CFLAGS="$CFLAGS $sanitizers"
 LDFLAGS="$LDFLAGS $sanitizers"
 ])
 
+dnl ----------------------------------------------------------------------
+dnl Enable build determinism flag
+dnl ----------------------------------------------------------------------
+
+AC_ARG_ENABLE(deterministic-build,
+AS_HELP_STRING([--enable-deterministic-build], [enable build determinism, stripping absolute paths from build output]),
+[ case "$enableval" in
+    no)  ERL_DETERMINISTIC=no ;;
+    *) ERL_DETERMINISTIC=yes ;;
+  esac ],
+ERL_DETERMINISTIC=no)
+AC_SUBST(ERL_DETERMINISTIC)
+
 AC_MSG_CHECKING([CFLAGS for -O switch])
 dnl                               Remove all "-O*" options
 no_opt_CFLAGS=$(echo " $CFLAGS" | sed 's/ -O[[^ ]]*/ /g')

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -182,7 +182,7 @@ RELSYSDIR = $(RELEASE_PATH)/emulator_test
 # FLAGS
 # ----------------------------------------------------
 ERL_MAKE_FLAGS += 
-ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$($(ERL_COMPILE_FLAGS)))
 
 # ----------------------------------------------------
 # Targets

--- a/erts/preloaded/src/Makefile
+++ b/erts/preloaded/src/Makefile
@@ -86,6 +86,10 @@ STDLIB_INCLUDE=$(ERL_TOP)/lib/stdlib/include
 
 ERL_COMPILE_FLAGS += +debug_info -I$(KERNEL_SRC) -I$(KERNEL_INCLUDE)
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	ERL_COMPILE_FLAGS += deterministic
+endif
+
 DIA_PLT      = erts-preloaded.plt
 DIA_ANALYSIS = $(basename $(DIA_PLT)).dialyzer_analysis
 ifeq ($(DIAW_EH),true)

--- a/erts/preloaded/src/add_abstract_code
+++ b/erts/preloaded/src/add_abstract_code
@@ -39,7 +39,12 @@ main([BeamFile,AbstrFile]) ->
 
 fix_options(CInf0) ->
     CInf1 = binary_to_term(CInf0),
-    {options,Opts0} = lists:keyfind(options, 1, CInf1),
-    Opts = Opts0 -- [from_asm],
+    Opts =
+        case lists:keyfind(options, 1, CInf1) of
+            {options,Opts0} ->
+                Opts0 -- [from_asm];
+            false ->
+                []
+        end,
     CInf = lists:keyreplace(options, 1, CInf1, {options,Opts}),
     {term_to_binary(CInf), Opts}.

--- a/lib/asn1/doc/src/asn1ct.xml
+++ b/lib/asn1/doc/src/asn1ct.xml
@@ -83,7 +83,7 @@
 	legacy_bit_string | legacy_erlang_types |
 	noobj | {n2n, EnumTypeName} |{outdir, Dir} | {i, IncludeDir} |
 	asn1config | undec_rest | no_ok_wrapper |
-	{macro_name_prefix, Prefix} | {record_name_prefix, Prefix} | verbose | warnings_as_errors</v>
+	{macro_name_prefix, Prefix} | {record_name_prefix, Prefix} | verbose | warnings_as_errors | deterministic</v>
         <v>OldOption = ber | per</v> 
         <v>Reason = term()</v>
         <v>Prefix = string()</v>
@@ -345,6 +345,11 @@ File3.asn</pre>
           <tag><c>warnings_as_errors</c></tag>
           <item>
             <p>Causes warnings to be treated as errors.</p>
+          </item>
+          <tag><c>deterministic</c></tag>
+          <item>
+            <p>Causes all non-deterministic options to be stripped from the
+              -asn1_info() attribute.</p>
           </item>
         </taglist>
         <p>Any more option that is applied is passed to

--- a/lib/asn1/src/Makefile
+++ b/lib/asn1/src/Makefile
@@ -102,7 +102,13 @@ ERL_COMPILE_FLAGS += \
 	-I$(ERL_TOP)/lib/stdlib \
 	-Werror
 
-YRL_FLAGS = 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	YRL_FLAGS = +deterministic
+	DETERMINISM_FLAG = +deterministic
+else
+	YRL_FLAGS = 
+	DETERMINISM_FLAG =
+endif
 
 # ----------------------------------------------------
 # Targets
@@ -182,10 +188,10 @@ asn1ct_rtt.erl: prepare_templates.$(EMULATOR) $(RT_TEMPLATES_TARGET)
            $(RT_TEMPLATES_TARGET)
 
 prepare_templates.$(EMULATOR): prepare_templates.erl
-	$(V_ERLC) prepare_templates.erl
+	$(V_ERLC) $(DETERMINISM_FLAG) prepare_templates.erl
 
 asn1rtt_%.$(EMULATOR): asn1rtt_%.erl
-	$(V_ERLC) +debug_info $<
+	$(V_ERLC) +debug_info $(DETERMINISM_FLAG) $<
 
 $(EVAL_CT_MODULES:%=%.erl): prepare_templates.$(EMULATOR) \
 			    $(EBIN)/asn1ct_rtt.$(EMULATOR) \

--- a/lib/asn1/src/asn1ct_gen.erl
+++ b/lib/asn1/src/asn1ct_gen.erl
@@ -1327,9 +1327,25 @@ gen_head(#gen{options=Options}=Gen, Mod, Hrl) ->
 	0 -> ok;
 	_ -> emit(["-include(\"",Mod,".hrl\").",nl])
     end,
+    Deterministic = proplists:get_bool(deterministic, Options),
+    Options1 =
+        case Deterministic of
+            true ->
+                % compile:keep_compile_option will filter some of these
+                % out of generated .beam files, but this will keep
+                % them out of the generated .erl files
+                lists:filter(
+                    fun({cwd, _}) -> false;
+                       ({outdir, _}) -> false;
+                       ({i, _}) -> false;
+                       (_) -> true end,
+                    Options);
+            false ->
+                Options
+         end,
     emit(["-asn1_info([{vsn,'",asn1ct:vsn(),"'},",nl,
 	  "            {module,'",Mod,"'},",nl,
-	  "            {options,",io_lib:format("~p",[Options]),"}]).",nl,nl]),
+	  "            {options,",io_lib:format("~p",[Options1]),"}]).",nl,nl]),
     JerDefines = case Gen of
                      #gen{erule=jer} ->
                          true;

--- a/lib/asn1/src/asn1ct_gen.erl
+++ b/lib/asn1/src/asn1ct_gen.erl
@@ -1331,9 +1331,9 @@ gen_head(#gen{options=Options}=Gen, Mod, Hrl) ->
     Options1 =
         case Deterministic of
             true ->
-                % compile:keep_compile_option will filter some of these
-                % out of generated .beam files, but this will keep
-                % them out of the generated .erl files
+                %% compile:keep_compile_option will filter some of these
+                %% out of generated .beam files, but this will keep
+                %% them out of the generated .erl files
                 lists:filter(
                     fun({cwd, _}) -> false;
                        ({outdir, _}) -> false;

--- a/lib/asn1/test/Makefile
+++ b/lib/asn1/test/Makefile
@@ -138,6 +138,7 @@ RELSYSDIR = $(RELEASE_PATH)/asn1_test
 # FLAGS
 # ----------------------------------------------------
 ERL_COMPILE_FLAGS += +warnings_as_errors +nowarn_export_all
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 EBIN = .
 
 # ----------------------------------------------------

--- a/lib/asn1/test/asn1_SUITE.erl
+++ b/lib/asn1/test/asn1_SUITE.erl
@@ -1062,7 +1062,8 @@ test_compile_options(Config) ->
     ok = test_compile_options:noobj(Config),
     ok = test_compile_options:record_name_prefix(Config),
     ok = test_compile_options:verbose(Config),
-    ok = test_compile_options:maps(Config).
+    ok = test_compile_options:maps(Config),
+    ok = test_compile_options:determinism(Config).
 
 testDoubleEllipses(Config) -> test(Config, fun testDoubleEllipses/3).
 testDoubleEllipses(Config, Rule, Opts) ->

--- a/lib/asn1/test/test_compile_options.erl
+++ b/lib/asn1/test/test_compile_options.erl
@@ -22,10 +22,11 @@
 -module(test_compile_options).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 
 -export([wrong_path/1,comp/2,path/1,noobj/1,
-	 record_name_prefix/1,verbose/1,maps/1]).
+	 record_name_prefix/1,verbose/1,maps/1,determinism/1]).
 
 %% OTP-5689
 wrong_path(Config) ->
@@ -149,6 +150,51 @@ do_maps(Erule, InFile, OutDir) ->
     _ = [file:delete(N) || N <- All],
 
     ok.
+
+determinism(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir,Config),
+    OutDir = proplists:get_value(priv_dir,Config),
+    Asn1File = filename:join([DataDir,"Comment.asn"]),
+    ErlFile = filename:join([OutDir,"Comment.erl"]),
+
+    ContainsNonDeterministicOptions =
+       fun
+           ({attribute,_Anno,asn1_info,Elems}) ->
+               lists:any(
+                   fun
+                       ({options, Opts}) ->
+                           lists:any(fun ({i, _}) -> true; (_) -> false end, Opts)
+                           andalso
+                           lists:any(fun ({outdir, _}) -> true; (_) -> false end, Opts)
+                           andalso
+                           lists:any(fun ({cwd, _}) -> true; (_) -> false end, Opts);
+                       (_) ->
+                           false
+                   end,
+                   Elems);
+           (_) ->
+               false
+       end,
+
+    BaseOptions = [{i,DataDir},{outdir,OutDir},{cwd,DataDir},noobj],
+
+    %% Test deterministic compile
+    ok = asn1ct:compile(Asn1File, BaseOptions ++ [deterministic]),
+    {ok, List1} = epp:parse_file(ErlFile, [{includes, [DataDir]},
+                                       {source_name, "Comment.erl"}]),
+    ?assertNot(lists:any(ContainsNonDeterministicOptions, List1),
+            "Expected no debugging option values (i, outdir, cwd) in asn1_info attribute " ++
+            "in deterministic mode"),
+
+    %% Test non-deterministic compile
+    ok = asn1ct:compile(Asn1File, BaseOptions),
+    {ok, List2} = epp:parse_file(ErlFile, [{includes, [DataDir]},
+                                       {source_name, "Comment.erl"}]),
+    ?assert(lists:any(ContainsNonDeterministicOptions, List2),
+            "Expected debugging option values (i, outdir, cwd) in asn1_info attribute " ++
+            "in non-deterministic mode"),
+    ok.
+
 
 outfiles_check(OutDir) ->
     outfiles_check(OutDir,outfiles1()).

--- a/lib/common_test/test/Makefile
+++ b/lib/common_test/test/Makefile
@@ -99,6 +99,7 @@ RELSYSDIR = $(RELEASE_PATH)/common_test_test
 
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -138,6 +138,12 @@ ERL_COMPILE_FLAGS += -Werror
 ERL_COMPILE_FLAGS += +inline +warn_unused_import \
  -I../../stdlib/include -I$(EGEN) -W +warn_missing_spec
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	DETERMINISM_FLAG = +deterministic
+else
+	DETERMINISM_FLAG =
+endif
+
 # ----------------------------------------------------
 # Targets
 # ----------------------------------------------------

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1020,6 +1020,7 @@ do_parse_module(DefEncoding, #compile{ifile=File,options=Opts,dir=Dir}=St) ->
             R = epp:parse_file(File,
                                [{includes,[".",Dir|inc_paths(Opts)]},
                                 {source_name, SourceName},
+                                {deterministic, member(deterministic, Opts)},
                                 {macros,pre_defs(Opts)},
                                 {default_encoding,DefEncoding},
                                 {location,StartLocation},

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -168,6 +168,7 @@ RELSYSDIR = $(RELEASE_PATH)/compiler_test
 
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS += +clint +clint0 +ssalint
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -82,32 +82,36 @@ uniq() ->
 
 opt_opts(Mod) ->
     Comp = Mod:module_info(compile),
-    {options,Opts} = lists:keyfind(options, 1, Comp),
-    lists:filter(fun
-                     (debug_info) -> true;
-                     (dialyzer) -> true;
-                     ({feature,_,enable}) -> true;
-                     ({feature,_,disable}) -> true;
-                     (inline) -> true;
-                     (no_bs_create_bin) -> true;
-                     (no_bsm_opt) -> true;
-                     (no_copt) -> true;
-                     (no_fun_opt) -> true;
-                     (no_init_yregs) -> true;
-                     (no_make_fun3) -> true;
-                     (no_module_opt) -> true;
-                     (no_postopt) -> true;
-                     (no_recv_opt) -> true;
-                     (no_share_opt) -> true;
-                     (no_shared_fun_wrappers) -> true;
-                     (no_ssa_opt_float) -> true;
-                     (no_ssa_opt_ranges) -> true;
-                     (no_ssa_opt) -> true;
-                     (no_stack_trimming) -> true;
-                     (no_swap) -> true;
-                     (no_type_opt) -> true;
-                     (_) -> false
-                end, Opts).
+    case lists:keyfind(options, 1, Comp) of
+        {options,Opts} ->
+            lists:filter(fun
+                            (debug_info) -> true;
+                            (dialyzer) -> true;
+                            (deterministic) -> true;
+                            ({enable_feature,_}) -> true;
+                            (inline) -> true;
+                            (no_bs_create_bin) -> true;
+                            (no_bsm_opt) -> true;
+                            (no_copt) -> true;
+                            (no_fun_opt) -> true;
+                            (no_init_yregs) -> true;
+                            (no_make_fun3) -> true;
+                            (no_module_opt) -> true;
+                            (no_postopt) -> true;
+                            (no_recv_opt) -> true;
+                            (no_share_opt) -> true;
+                            (no_shared_fun_wrappers) -> true;
+                            (no_ssa_opt_float) -> true;
+                            (no_ssa_opt_ranges) -> true;
+                            (no_ssa_opt) -> true;
+                            (no_stack_trimming) -> true;
+                            (no_swap) -> true;
+                            (no_type_opt) -> true;
+                            (_) -> false
+                         end, Opts);
+          %% `options` may not be set at all if +deterministic is enabled
+          false -> []
+    end.
 
 %% Some test suites gets cloned (e.g. to "record_SUITE" to
 %% "record_no_opt_SUITE"), but the data directory is not cloned.

--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -82,36 +82,33 @@ uniq() ->
 
 opt_opts(Mod) ->
     Comp = Mod:module_info(compile),
-    case lists:keyfind(options, 1, Comp) of
-        {options,Opts} ->
-            lists:filter(fun
-                            (debug_info) -> true;
-                            (dialyzer) -> true;
-                            (deterministic) -> true;
-                            ({enable_feature,_}) -> true;
-                            (inline) -> true;
-                            (no_bs_create_bin) -> true;
-                            (no_bsm_opt) -> true;
-                            (no_copt) -> true;
-                            (no_fun_opt) -> true;
-                            (no_init_yregs) -> true;
-                            (no_make_fun3) -> true;
-                            (no_module_opt) -> true;
-                            (no_postopt) -> true;
-                            (no_recv_opt) -> true;
-                            (no_share_opt) -> true;
-                            (no_shared_fun_wrappers) -> true;
-                            (no_ssa_opt_float) -> true;
-                            (no_ssa_opt_ranges) -> true;
-                            (no_ssa_opt) -> true;
-                            (no_stack_trimming) -> true;
-                            (no_swap) -> true;
-                            (no_type_opt) -> true;
-                            (_) -> false
-                         end, Opts);
-          %% `options` may not be set at all if +deterministic is enabled
-          false -> []
-    end.
+    %% `options` may not be set at all if +deterministic is enabled.
+    Opts = proplists:get_value(options, Comp, []),
+    lists:filter(fun
+                     (debug_info) -> true;
+                     (dialyzer) -> true;
+                     ({feature,_,enable}) -> true;
+                     ({feature,_,disable}) -> true;
+                     (inline) -> true;
+                     (no_bs_create_bin) -> true;
+                     (no_bsm_opt) -> true;
+                     (no_copt) -> true;
+                     (no_fun_opt) -> true;
+                     (no_init_yregs) -> true;
+                     (no_make_fun3) -> true;
+                     (no_module_opt) -> true;
+                     (no_postopt) -> true;
+                     (no_recv_opt) -> true;
+                     (no_share_opt) -> true;
+                     (no_shared_fun_wrappers) -> true;
+                     (no_ssa_opt_float) -> true;
+                     (no_ssa_opt_ranges) -> true;
+                     (no_ssa_opt) -> true;
+                     (no_stack_trimming) -> true;
+                     (no_swap) -> true;
+                     (no_type_opt) -> true;
+                     (_) -> false
+                end, Opts).
 
 %% Some test suites gets cloned (e.g. to "record_SUITE" to
 %% "record_no_opt_SUITE"), but the data directory is not cloned.

--- a/lib/debugger/test/Makefile
+++ b/lib/debugger/test/Makefile
@@ -71,6 +71,7 @@ RELSYSDIR = $(RELEASE_PATH)/debugger_test
 
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/diameter/src/Makefile
+++ b/lib/diameter/src/Makefile
@@ -122,6 +122,12 @@ ERL_COMPILE_FLAGS += \
 # -pa is to be able to include_lib from the include directory: the
 # path must contain the application name.
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	DETERMINISM_FLAG = +deterministic
+else
+	DETERMINISM_FLAG =
+endif
+
 # ----------------------------------------------------
 # Targets
 # ----------------------------------------------------
@@ -152,7 +158,7 @@ $(filter-out opt, $(TYPES)):
 # The dictionary parser.
 gen/$(DICT_YRL).erl: compiler/$(DICT_YRL).yrl
 	$(yecc_verbose) \
-	$(ERLC) -Werror -o $(@D) $<
+	$(ERLC) -Werror $(DETERMINISM_FLAG) -o $(@D) $<
 
 # Generate the app file.
 $(APP_TARGET): $(APP_SRC) ../vsn.mk modules.mk
@@ -256,8 +262,8 @@ release_spec: opt
 	$(INSTALL_DATA) $(EXTERNAL_HRLS:%=../include/%) $(DICT_HRLS) \
 	                "$(RELSYSDIR)/include"
 	$(INSTALL_DATA) $(DICTS:%=dict/%.dia) "$(RELSYSDIR)/src/dict"
-	$(MAKE) $(TARGET_DIRS:%/=release_src_%)
-	$(MAKE) $(EXAMPLE_DIRS:%/=release_examples_%)
+	$(MAKE) ERL_DETERMINISTIC=$(ERL_DETERMINISTIC) $(TARGET_DIRS:%/=release_src_%)
+	$(MAKE) ERL_DETERMINISTIC=$(ERL_DETERMINISTIC) $(EXAMPLE_DIRS:%/=release_examples_%)
 
 $(TARGET_DIRS:%/=release_src_%): release_src_%:
 	$(INSTALL_DIR) "$(RELSYSDIR)/src/$*"

--- a/lib/diameter/test/Makefile
+++ b/lib/diameter/test/Makefile
@@ -59,6 +59,7 @@ ERL_COMPILE_FLAGS += +warn_export_vars \
                      -I ../include \
                      -I ../src/gen \
                      $(STRICT_FLAGS)
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 # ----------------------------------------------------
 # Targets

--- a/lib/edoc/test/Makefile
+++ b/lib/edoc/test/Makefile
@@ -27,6 +27,7 @@ RELSYSDIR = $(RELEASE_PATH)/edoc_test
 
 ERL_MAKE_FLAGS += 
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/eldap/test/Makefile
+++ b/lib/eldap/test/Makefile
@@ -54,6 +54,7 @@ RELSYSDIR = $(RELEASE_PATH)/eldap_test
 # FLAGS
 # ----------------------------------------------------
 ERL_COMPILE_FLAGS += $(INCLUDES) -pa $(ERL_TOP)/lib/eldap/ebin
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/erl_docgen/test/Makefile
+++ b/lib/erl_docgen/test/Makefile
@@ -26,6 +26,7 @@ RELSYSDIR = $(RELEASE_PATH)/erl_docgen_test
 
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/eunit/test/Makefile
+++ b/lib/eunit/test/Makefile
@@ -45,6 +45,7 @@ RELSYSDIR = $(RELEASE_PATH)/eunit_test
 # ----------------------------------------------------
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/ftp/test/Makefile
+++ b/lib/ftp/test/Makefile
@@ -152,6 +152,7 @@ RELTESTSYSBINDIR     = $(RELTESTSYSALLDATADIR)/bin
 ERL_COMPILE_FLAGS += \
 	$(INCLUDES) \
 	$(FTP_FLAGS)
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 # ----------------------------------------------------
 # Targets

--- a/lib/inets/test/Makefile
+++ b/lib/inets/test/Makefile
@@ -200,6 +200,7 @@ RELTESTSYSBINDIR     = $(RELTESTSYSALLDATADIR)/bin
 ERL_COMPILE_FLAGS += \
 	$(INCLUDES) \
 	$(INETS_FLAGS)
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 # ----------------------------------------------------
 # Targets

--- a/lib/kernel/test/Makefile
+++ b/lib/kernel/test/Makefile
@@ -159,6 +159,7 @@ RELSYSDIR = $(RELEASE_PATH)/kernel_test
 
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/megaco/Makefile
+++ b/lib/megaco/Makefile
@@ -98,7 +98,13 @@ else
   FLEX_SCANNER_REENTRANT_ENABLER = --enable-megaco-reentrant-flex-scanner
 endif
 
-CONFIGURE_OPTS = $(FLEX_SCANNER_LINENO_ENABLER) $(FLEX_SCANNER_REENTRANT_ENABLER)
+ifeq ($(ERL_DETERMINISTIC),yes)
+  ERL_DETERMINISTIC_ENABLER = --enable-deterministic-build
+else
+  ERL_DETERMINISTIC_ENABLER = --disable-deterministic-build
+endif
+
+CONFIGURE_OPTS = $(FLEX_SCANNER_LINENO_ENABLER) $(FLEX_SCANNER_REENTRANT_ENABLER) $(ERL_DETERMINISTIC_ENABLER)
 
 
 DIA_PLT      = ./priv/plt/$(APPLICATION).plt
@@ -115,7 +121,7 @@ include $(ERL_TOP)/make/otp_subdir.mk
 
 reconf:
 	(cd $(ERL_TOP) && \
-		./otp_build configure && \
+		./otp_build configure $(ERL_DETERMINISTIC_ENABLER) && \
 		cd $(ERL_TOP)/../libraries/megaco)
 
 conf: do_configure

--- a/lib/megaco/src/app/megaco.mk
+++ b/lib/megaco/src/app/megaco.mk
@@ -42,6 +42,12 @@ ifeq ($(WARN_UNUSED_WARS), true)
 ERL_COMPILE_FLAGS += +warn_unused_vars
 endif
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+ERL_COMPILE_FLAGS += +deterministic
+YRL_FLAGS += +deterministic
+XRL_FLAGS += +deterministic
+endif
+
 MEGACO_APP_VSN_COMPILE_FLAGS = \
 	+'{parse_transform,sys_pre_attributes}' \
 	+'{attribute,insert,app_vsn,$(APP_VSN)}'

--- a/lib/megaco/src/binary/depend.mk
+++ b/lib/megaco/src/binary/depend.mk
@@ -35,6 +35,10 @@ ifeq ($(MEGACO_INLINE_ASN1_RT),true)
 ASN1_CT_OPTS += +inline
 endif
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+ASN1_CT_OPTS += +deterministic
+endif
+
 BER_V1_FLAGS             = $(ASN1_CT_OPTS) +asn1config
 BER_V2_FLAGS             = $(ASN1_CT_OPTS) +asn1config
 BER_V3_FLAGS             = $(ASN1_CT_OPTS) +asn1config

--- a/lib/megaco/test/Makefile
+++ b/lib/megaco/test/Makefile
@@ -90,6 +90,8 @@ ERL_COMPILE_FLAGS += $(MEGACO_ERL_COMPILE_FLAGS)
 # We have a behaviour in the test catalog (megaco_test_generator)
 ERL_COMPILE_FLAGS += -pa ../../megaco/test
 
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
+
 ERL_PATH = -pa ../../megaco/examples/simple \
            -pa ../../megaco/ebin \
            -pa ../../et/ebin

--- a/lib/mnesia/test/Makefile
+++ b/lib/mnesia/test/Makefile
@@ -91,6 +91,7 @@ RELSYSDIR = $(RELEASE_PATH)/mnesia_test
 # FLAGS
 # ----------------------------------------------------
 #ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/observer/test/Makefile
+++ b/lib/observer/test/Makefile
@@ -52,6 +52,7 @@ RELSYSDIR = $(RELEASE_PATH)/observer_test
 # ----------------------------------------------------
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS += +warnings_as_errors +nowarn_export_all
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/odbc/test/Makefile
+++ b/lib/odbc/test/Makefile
@@ -72,6 +72,8 @@ RELSYSDIR = $(RELEASE_PATH)/odbc_test
 
 ERL_COMPILE_FLAGS += $(INCLUDES) \
 
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
+
 # ----------------------------------------------------
 # Targets
 # ----------------------------------------------------

--- a/lib/os_mon/test/Makefile
+++ b/lib/os_mon/test/Makefile
@@ -55,6 +55,7 @@ RELSYSDIR = $(RELEASE_PATH)/os_mon_test
 # ----------------------------------------------------
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS += -I$(ERL_TOP)/lib/snmp/include
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 # ----------------------------------------------------
 # Targets

--- a/lib/parsetools/doc/src/leex.xml
+++ b/lib/parsetools/doc/src/leex.xml
@@ -110,6 +110,11 @@
             <item>
               <p>Causes warnings to be treated as errors.</p>
             </item>
+            <tag><c>{deterministic, boolean()}</c></tag>
+            <item>
+              <p>Causes generated -file() attributes to only include
+                the basename of the file path.</p>
+            </item>
           </taglist>
         <p>Any of the Boolean options can be set to <c>true</c> by 
           stating the name of the option. For example, <c>verbose</c>

--- a/lib/parsetools/doc/src/yecc.xml
+++ b/lib/parsetools/doc/src/yecc.xml
@@ -134,6 +134,11 @@
             is <c>column</c>, the location includes a line number and
             a column number. Default is <c>column</c>.
           </item>
+          <tag><c>{deterministic, boolean()}</c></tag>
+          <item>
+            <p>Causes generated -file() attributes to only include the
+              basename of the file path.</p>
+          </item>
         </taglist>
         <p>Any of the Boolean options can be set to <c>true</c> by 
           stating the name of the option. For example, <c>verbose</c>

--- a/lib/parsetools/src/yecc.erl
+++ b/lib/parsetools/src/yecc.erl
@@ -141,9 +141,10 @@ compile(Input0, Output0,
     Output = shorten_filename(Output0),
     Includefile = lists:sublist(Includes, 1),
     Werror = proplists:get_bool(warnings_as_errors, Specific),
+    Deterministic = proplists:get_bool(deterministic, Specific),
     Opts = [{parserfile,Output}, {includefile,Includefile}, {verbose,Verbose},
             {report_errors, true}, {report_warnings, WarnLevel > 0},
-	    {warnings_as_errors, Werror}],
+	    {warnings_as_errors, Werror}, {deterministic, Deterministic}],
     case file(Input, Opts) of
         {ok, _OutFile} ->
             ok;
@@ -265,6 +266,7 @@ file(GrammarFile) ->
               | {'parserfile', Parserfile :: file:filename()}
               | {'verbose', boolean()}
               | {'warnings_as_errors', boolean()}
+              | {'deterministic', boolean()}
               | 'report_errors' | 'report_warnings' | 'report'
               | 'return_errors' | 'return_warnings' | 'return'
               | 'verbose' | 'warnings_as_errors'.
@@ -407,7 +409,7 @@ check_options(_Options, _, _L) ->
 all_options() ->
     [error_location, file_attributes, includefile, parserfile,
      report_errors, report_warnings, return_errors, return_warnings,
-     time, verbose, warnings_as_errors].
+     time, verbose, warnings_as_errors, deterministic].
 
 default_option(error_location) -> column;
 default_option(file_attributes) -> true;
@@ -419,7 +421,8 @@ default_option(return_errors) -> false;
 default_option(return_warnings) -> false;
 default_option(time) -> false;
 default_option(verbose) -> false;
-default_option(warnings_as_errors) -> false.
+default_option(warnings_as_errors) -> false;
+default_option(deterministic) -> false.
 
 atom_option(file_attributes) -> {file_attributes, true};
 atom_option(report_errors) -> {report_errors, true};
@@ -429,6 +432,7 @@ atom_option(return_warnings) -> {return_warnings, true};
 atom_option(time) -> {time, true};
 atom_option(verbose) -> {verbose, true};
 atom_option(warnings_as_errors) -> {warnings_as_errors, true};
+atom_option(deterministic) -> {deterministic, true};
 atom_option(Key) -> Key.
 
 is_filename(T) ->
@@ -2695,7 +2699,12 @@ nl(#yecc{outport = Outport, line = Line}=St) ->
     St#yecc{line = Line + 1}.
 
 format_filename(Filename0, St) ->
-    Filename = filename:flatten(Filename0),
+    Deterministic = proplists:get_bool(deterministic, St#yecc.options),
+    Filename =
+      case Deterministic of
+        true -> filename:basename(filename:flatten(Filename0));
+        false -> filename:flatten(Filename0)
+      end,
     case lists:keyfind(encoding, 1, io:getopts(St#yecc.outport)) of
         {encoding, unicode} -> io_lib:write_string(Filename);
         _ ->                   io_lib:write_string_as_latin1(Filename)

--- a/lib/parsetools/test/Makefile
+++ b/lib/parsetools/test/Makefile
@@ -42,6 +42,7 @@ RELSYSDIR = $(RELEASE_PATH)/parsetools_test
 # ----------------------------------------------------
 ERL_MAKE_FLAGS += 
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/public_key/asn1/Makefile
+++ b/lib/public_key/asn1/Makefile
@@ -70,6 +70,10 @@ ERL_COMPILE_FLAGS += $(EXTRA_ERLC_FLAGS)
 
 ASN_FLAGS = -bber +der +noobj +asn1config
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	ASN_FLAGS += +deterministic
+endif
+
 # ----------------------------------------------------
 # Targets
 # ----------------------------------------------------

--- a/lib/public_key/test/Makefile
+++ b/lib/public_key/test/Makefile
@@ -55,6 +55,7 @@ RELSYSDIR = $(RELEASE_PATH)/public_key_test
 # FLAGS
 # ----------------------------------------------------
 ERL_COMPILE_FLAGS += $(INCLUDES)
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/reltool/test/Makefile
+++ b/lib/reltool/test/Makefile
@@ -51,6 +51,7 @@ RELSYSDIR = $(RELEASE_PATH)/reltool_test
 # FLAGS
 # ----------------------------------------------------
 ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/reltool/ebin/
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/runtime_tools/test/Makefile
+++ b/lib/runtime_tools/test/Makefile
@@ -31,6 +31,7 @@ RELSYSDIR = $(RELEASE_PATH)/runtime_tools_test
 
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS += -Werror
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/sasl/test/Makefile
+++ b/lib/sasl/test/Makefile
@@ -58,6 +58,7 @@ RELSYSDIR = $(RELEASE_PATH)/sasl_test
 # ----------------------------------------------------
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS += -I$(ERL_TOP)/lib/sasl/src
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/snmp/src/compile/Makefile
+++ b/lib/snmp/src/compile/Makefile
@@ -85,6 +85,10 @@ ERL_COMPILE_FLAGS += -I../../include \
 
 YRL_FLAGS = -o .
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	YRL_FLAGS += +deterministic
+endif
+
 
 # ----------------------------------------------------
 # Targets

--- a/lib/snmp/test/Makefile
+++ b/lib/snmp/test/Makefile
@@ -161,6 +161,7 @@ ERL_COMPILE_FLAGS += -I../../snmp/src/app \
                      +'{parse_transform,sys_pre_attributes}' \
                      +'{attribute,insert,app_vsn,$(APP_VSN)}' \
                      $(SNMP_FLAGS)
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 ERL_SNMP_FLAGS = $(SNMP_MIB_FLAGS) \
                  -I../priv/mibs

--- a/lib/ssh/test/Makefile
+++ b/lib/ssh/test/Makefile
@@ -98,6 +98,7 @@ RELSYSDIR = $(RELEASE_PATH)/ssh_test
 INCLUDES = -I$(ERL_TOP)/lib/ssh/src
 
 ERL_COMPILE_FLAGS += $(INCLUDES) -pa ../ebin
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/ssl/test/Makefile
+++ b/lib/ssl/test/Makefile
@@ -143,6 +143,7 @@ RELSYSDIR = $(RELEASE_PATH)/ssl_test
 # running the target "targets".
 # ----------------------------------------------------
 ERL_COMPILE_FLAGS += $(INCLUDES)
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 # ----------------------------------------------------
 # Targets

--- a/lib/stdlib/doc/src/epp.xml
+++ b/lib/stdlib/doc/src/epp.xml
@@ -131,6 +131,10 @@
           attributes inserted during preprocessing, you can do with
           <c>{source_name, <anno>SourceName</anno>}</c>. If unset it will
           default to the name of the opened file.</p>
+        <p>Setting <c>{deterministic, <anno>Enabled</anno>}</c> will
+          additionally reduce the file name of the implicit -file()
+          attributes inserted during preprocessing to only the basename
+          of the path.</p>
         <p>If <c>extra</c> is specified in
           <c><anno>Options</anno></c>, the return value is
           <c>{ok, <anno>Epp</anno>, <anno>Extra</anno>}</c> instead

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -166,6 +166,12 @@ endif
 ERL_COMPILE_FLAGS += -Werror
 ERL_COMPILE_FLAGS += -I../include -I../../kernel/include
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	DETERMINISM_FLAG = +deterministic
+else
+	DETERMINISM_FLAG =
+endif
+
 # ----------------------------------------------------
 # Targets
 # ----------------------------------------------------
@@ -191,16 +197,17 @@ primary_bootstrap_compiler: \
   $(BOOTSTRAP_COMPILER)/ebin/io.beam \
   $(BOOTSTRAP_COMPILER)/ebin/otp_internal.beam
 
+
 $(BOOTSTRAP_COMPILER)/ebin/erl_parse.beam: erl_parse.yrl
 	$(gen_verbose)
-	$(V_at)$(ERLC) -o $(BOOTSTRAP_COMPILER)/egen erl_parse.yrl
-	$(V_at)$(ERLC) -o $(BOOTSTRAP_COMPILER)/ebin $(BOOTSTRAP_COMPILER)/egen/erl_parse.erl
+	$(V_at)$(ERLC) -o $(BOOTSTRAP_COMPILER)/egen $(DETERMINISM_FLAG) erl_parse.yrl
+	$(V_at)$(ERLC) -o $(BOOTSTRAP_COMPILER)/ebin $(DETERMINISM_FLAG) $(BOOTSTRAP_COMPILER)/egen/erl_parse.erl
 
 $(BOOTSTRAP_TOP)/lib/stdlib/egen/erl_parse.erl: erl_parse.yrl
 	$(yecc_verbose)$(ERLC) $(YRL_FLAGS) -o$(BOOTSTRAP_TOP)/lib/stdlib/egen erl_parse.yrl
 
 $(BOOTSTRAP_COMPILER)/ebin/%.beam: %.erl
-	$(V_ERLC) -o $(BOOTSTRAP_COMPILER)/ebin $<
+	$(V_ERLC) -o $(BOOTSTRAP_COMPILER)/ebin $(DETERMINISM_FLAG) $<
 
 # ----------------------------------------------------
 # Special Build Targets

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -120,6 +120,7 @@ RELSYSDIR = $(RELEASE_PATH)/stdlib_test
 
 ERL_COMPILE_FLAGS += -I$(ERL_TOP)/lib/kernel/include \
 		-I$(ERL_TOP)/lib/stdlib/include
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/stdlib/test/epp_SUITE_data/deterministic_include.erl
+++ b/lib/stdlib/test/epp_SUITE_data/deterministic_include.erl
@@ -1,0 +1,6 @@
+-module(deterministic_include).
+
+-export([]).
+
+-include("include/baz.hrl").
+-include_lib("kernel/include/file.hrl").

--- a/lib/stdlib/test/epp_SUITE_data/include/baz.hrl
+++ b/lib/stdlib/test/epp_SUITE_data/include/baz.hrl
@@ -1,0 +1,1 @@
+-define(BAZ, true).

--- a/lib/syntax_tools/test/Makefile
+++ b/lib/syntax_tools/test/Makefile
@@ -27,6 +27,7 @@ RELSYSDIR = $(RELEASE_PATH)/syntax_tools_test
 
 ERL_MAKE_FLAGS += 
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/tftp/test/Makefile
+++ b/lib/tftp/test/Makefile
@@ -152,6 +152,7 @@ RELTESTSYSBINDIR     = $(RELTESTSYSALLDATADIR)/bin
 ERL_COMPILE_FLAGS += \
 	$(INCLUDES) \
 	$(TFTP_FLAGS)
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 # ----------------------------------------------------
 # Targets

--- a/lib/tools/test/Makefile
+++ b/lib/tools/test/Makefile
@@ -54,6 +54,7 @@ RELSYSDIR = $(RELEASE_PATH)/tools_test
 # ----------------------------------------------------
 ERL_MAKE_FLAGS +=
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .
 

--- a/lib/xmerl/src/Makefile
+++ b/lib/xmerl/src/Makefile
@@ -127,6 +127,11 @@ ERL_COMPILE_FLAGS += \
 
 #		+bin_opt_info 
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	DETERMINISM_FLAG = +deterministic
+else
+	DETERMINISM_FLAG =
+endif
 
 # ----------------------------------------------------
 # Targets
@@ -173,10 +178,10 @@ $(APPUP_TARGET): $(APPUP_SRC) ../vsn.mk
 	$(vsn_verbose)sed -e 's;%VSN%;$(VSN);' $< > $@
 
 xmerl_xpath_parse.erl:	xmerl_xpath_parse.yrl
-	$(yecc_verbose)$(ERLC)  -o  $(ESRC) $<
+	$(yecc_verbose)$(ERLC)  -o  $(ESRC) $(DETERMINISM_FLAG) $<
 
 xmerl_b64Bin.erl: xmerl_b64Bin.yrl
-	$(yecc_verbose)$(ERLC)  -o  $(ESRC) $<
+	$(yecc_verbose)$(ERLC)  -o  $(ESRC) $(DETERMINISM_FLAG) $<
 
 xmerl_sax_parser_list.erl: xmerl_sax_parser_list.erlsrc xmerl_sax_parser_base.erlsrc
 	$(gen_verbose)cat xmerl_sax_parser_list.erlsrc xmerl_sax_parser_base.erlsrc >$@

--- a/lib/xmerl/test/Makefile
+++ b/lib/xmerl/test/Makefile
@@ -86,6 +86,7 @@ RELSYSDIR = $(RELEASE_PATH)/xmerl_test
 # ----------------------------------------------------
 
 ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 
 # ----------------------------------------------------

--- a/make/otp.mk.in
+++ b/make/otp.mk.in
@@ -92,6 +92,8 @@ BITS64 = @BITS64@
 
 OTP_RELEASE = @OTP_RELEASE@
 
+ERL_DETERMINISTIC = @ERL_DETERMINISTIC@
+
 # ----------------------------------------------------
 #	Erlang language section
 # ----------------------------------------------------
@@ -103,6 +105,11 @@ ifdef BOOTSTRAP
   ERL_COMPILE_FLAGS += +slim
 else
   ERL_COMPILE_FLAGS += +debug_info
+endif
+ifeq ($(ERL_DETERMINISTIC),yes)
+  ERL_COMPILE_FLAGS += +deterministic
+  YRL_FLAGS += +deterministic
+  XRL_FLAGS += +deterministic
 endif
 
 ERLC_WFLAGS = -W


### PR DESCRIPTION
Improves build determinism for non-native code by:
 - Making codegen and the preprocessor fully respect the `+deterministic` option (for all code, OTP or otherwise)
 - Adding an `--enable-deterministic-build` flag to `configure` that controls OTP's build determinism by setting `+deterministic` appropriately in its Makefiles
 
This addresses absolute paths being included in generated `.erl` files and compiled `.beam` files that resulted in builds from different source directories generating different artefacts (which is a component of the issue in #4482, but is also useful in its own right, for example around caching builds and for the upcoming Dialyzer incremental mode).

OTP itself can now be built in deterministic mode by giving the `--enable-deterministic-build` flag to `configure`. I think it would make sense to make this the default at some stage, but I've put the change behind an option for now in an attempt to decouple making deterministic OTP builds possible from making them the default.

Having `+deterministic` set also results in the compiler options being removed from the `module_info` for modules where this options was used. This may have other implications for users of OTP.

For tests themselves, `+deterministic` is disabled, since many test cases depend on accessing the test module's compilation options or other features not available in deterministic mode, in order to configure themselves. For tests of the determinism feature in particular, `+deterministic` is explicitly passed to the compiler within the relevant test cases.

To run a deterministic build, you can execute a script such as the following:

```
./otp_build configure --enable-deterministic-build
./otp_build boot -a
./otp_build release -a
```

This PR is a reformulated version of #5863, which splits the change up into more manageable commits that can be reviewed separately.

> **N.B. the bootstrap/preloaded .beam files need to be updated in order for this feature to work properly**