### PR TITLE
inets: remove apache config ref from manual

### DIFF
--- a/lib/inets/doc/src/httpd.xml
+++ b/lib/inets/doc/src/httpd.xml
@@ -274,13 +274,7 @@
 	  Files delivered to the client are MIME typed according to RFC
           1590. File suffixes are mapped to MIME types before file delivery.
           The mapping between file suffixes and MIME types can be specified
-	  as an Apache-like file or directly in the property list. Such
-        a file can look like the following:</p>
-        <pre>
-# MIME type	Extension  
-text/html	html htm
-text/plain	asc txt</pre>
-	
+	  in the property list.</p>
 	<p>Default is [{"html","text/html"},{"htm","text/html"}].</p>
       </item>
 

--- a/lib/inets/src/http_server/httpd_sup.erl
+++ b/lib/inets/src/http_server/httpd_sup.erl
@@ -104,7 +104,7 @@ init([HttpdServices]) ->
 %% The format of the httpd service is:
 %% httpd_service() -> {httpd,httpd()}
 %% httpd()         -> [httpd_config()] | file()
-%% httpd_config()  -> {file,file()} |
+%% httpd_config()  -> {proplist_file,file()} |
 %%                    {debug,debug()} |
 %%                    {accept_timeout,integer()}
 %% debug()         -> disable | [debug_options()]


### PR DESCRIPTION
- remove reference to Apache-like config file which is not supported anymore
- fixes #5276 (doc update only)