### PR TITLE
Ingela/ssl/tls record handling/gh 5961/otp 18087

### DIFF
--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -389,24 +389,15 @@ handle_protocol_record(#ssl_tls{type = ?APPLICATION_DATA, fragment = Data}, Stat
             next_event(StateName, Record, State)
     end;
 %%% TLS record protocol level handshake messages 
-handle_protocol_record(#ssl_tls{type = ?HANDSHAKE, fragment = Data}, 
-		    StateName, #state{protocol_buffers =
-					  #protocol_buffers{tls_handshake_buffer = Buf0} = Buffers,
-                                      connection_env = #connection_env{negotiated_version = Version},
-                                      static_env = #static_env{role = Role},
-				      ssl_options = Options} = State0) ->
+handle_protocol_record(#ssl_tls{type = ?HANDSHAKE, fragment = Data}, StateName, #state{protocol_buffers = Buffers,
+                                                                                       ssl_options = Options} = State0) ->
     try
-	%% Calculate the effective version that should be used when decoding an incoming handshake
-	%% message.
-	EffectiveVersion = effective_version(Version, Options, Role, StateName),
-        {Packets, Buf} = tls_handshake:get_tls_handshakes(EffectiveVersion,Data,Buf0, Options),
-
-        State = case EffectiveVersion =/= NegotiatedVersion of
-                    State0#state{protocol_buffers =
-                                     Buffers#protocol_buffers{tls_handshake_buffer = Buf}},
+        {Packets, Buffer} = get_tls_handshakes(Data, StateName, State0),
+        State = State0#state{protocol_buffers =
+                                 Buffers#protocol_buffers{tls_handshake_buffer = Buffer}},
 	case Packets of
             [] -> 
-                assert_buffer_sanity(Buf, Options),
+                assert_buffer_sanity(Buffer, Options),
                 next_event(StateName, no_record, State);
             _ ->                
                 Events = tls_handshake_events(Packets),
@@ -529,6 +520,13 @@ protocol_name() ->
 %%====================================================================
 %% Internal functions 
 %%====================================================================	     
+get_tls_handshakes(Data, StateName, #state{protocol_buffers =
+                                               #protocol_buffers{tls_handshake_buffer = Buffer},
+                                           connection_env = #connection_env{negotiated_version = Version},
+                                           static_env = #static_env{role = Role},
+                                           ssl_options = Options}) ->
+    handle_unnegotiated_version(Version, Options, Data, Buffer, Role, StateName).
+
 tls_handshake_events(Packets) ->
     lists:map(fun(Packet) ->
 		      {next_event, internal, {handshake, Packet}}
@@ -756,21 +754,27 @@ next_record_done(#state{protocol_buffers = Buffers} = State, CipherTexts, Connec
 %% Pre TLS-1.3, on the client side, the connection state variable `negotiated_version` will initially be
 %% the requested version. On the server side the same variable is initially undefined.
 %% When the client can support TLS-1.3 and one or more prior versions and we are waiting
-%% for the server hello (with or without a RetryRequest, that is in state hello or in state wait_sh),
-%% the "initial requested version" kept in the connection state variable `negotiated_version`
+%% for the server hello the "initial requested version" kept in the connection state variable `negotiated_version`
 %% (before the versions is actually negotiated) will always be the value of TLS-1.2 (which is a legacy
 %% field in TLS-1.3 client hello). The versions are instead negotiated with an hello extension. When
 %% decoding the server_hello messages we want to go through TLS-1.3 decode functions to be able
 %% to handle TLS-1.3 extensions if TLS-1.3 will be the negotiated version.
-effective_version({3,3} , #{versions := [{3,4} = Version |_]}, client, StateName) when StateName == hello;
-                                                                                       StateName == wait_sh ->
-    Version;
+handle_unnegotiated_version({3,3} , #{versions := [{3,4} = Version |_]} = Options, Data, Buffer, client, hello) ->
+    %% The effective version for decoding the server hello message should be the TLS-1.3. Possible coalesced TLS-1.2
+    %% server handshake messages should be decoded with the negotiated version in later state.
+    <<_:8, ?UINT24(Length), _/binary>> = Data,
+    <<FirstPacket:(Length+4)/binary, Rest/binary>> = Data,
+    {Packet, <<>>} = tls_handshake:get_tls_handshakes(Version, FirstPacket, Buffer, Options),
+    {Packet, Rest};
+%% TLS-1.3 RetryRequest
+handle_unnegotiated_version({3,3} , #{versions := [{3,4} = Version |_]} = Options, Data, Buffer, client, wait_sh) ->
+    tls_handshake:get_tls_handshakes(Version, Data, Buffer, Options);
 %% When the `negotiated_version` variable is not yet set use the highest supported version.
-effective_version(undefined, #{versions := [Version|_]}, _, _) ->
-    Version;
+handle_unnegotiated_version(undefined, #{versions := [Version|_]} = Options, Data, Buff, _, _) ->
+    tls_handshake:get_tls_handshakes(Version, Data, Buff, Options);
 %% In all other cases use the version saved in the connection state variable `negotiated_version`
-effective_version(Version, _, _, _) ->
-    Version.
+handle_unnegotiated_version(Version, Options, Data, Buff, _, _) ->
+    tls_handshake:get_tls_handshakes(Version, Data, Buff, Options).
 
 assert_buffer_sanity(<<?BYTE(_Type), ?UINT24(Length), Rest/binary>>, 
                      #{max_handshake_size := Max}) when

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -399,10 +399,11 @@ handle_protocol_record(#ssl_tls{type = ?HANDSHAKE, fragment = Data},
 	%% Calculate the effective version that should be used when decoding an incoming handshake
 	%% message.
 	EffectiveVersion = effective_version(Version, Options, Role, StateName),
-	{Packets, Buf} = tls_handshake:get_tls_handshake(EffectiveVersion,Data,Buf0, Options),
-	State =
-	    State0#state{protocol_buffers =
-			     Buffers#protocol_buffers{tls_handshake_buffer = Buf}},
+        {Packets, Buf} = tls_handshake:get_tls_handshakes(EffectiveVersion,Data,Buf0, Options),
+
+        State = case EffectiveVersion =/= NegotiatedVersion of
+                    State0#state{protocol_buffers =
+                                     Buffers#protocol_buffers{tls_handshake_buffer = Buf}},
 	case Packets of
             [] -> 
                 assert_buffer_sanity(Buf, Options),

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -42,7 +42,7 @@
 -export([encode_handshake/2]).
 
 %% Handshake decoding
--export([get_tls_handshake/4, decode_handshake/3]).
+-export([get_tls_handshakes/4, decode_handshake/3]).
 
 %% Handshake helper
 -export([ocsp_nonce/2]).
@@ -285,7 +285,7 @@ encode_handshake(Package, Version) ->
 %%--------------------------------------------------------------------
 
 %%--------------------------------------------------------------------
--spec get_tls_handshake(tls_record:tls_version(), binary(), binary() | iolist(), 
+-spec get_tls_handshakes(tls_record:tls_version(), binary(), binary() | iolist(),
                         ssl_options()) ->
      {[{tls_handshake(), binary()}], binary()}.
 %%
@@ -293,10 +293,10 @@ encode_handshake(Package, Version) ->
 %% and returns it as a list of handshake messages, also returns leftover
 %% data.
 %%--------------------------------------------------------------------
-get_tls_handshake(Version, Data, <<>>, Options) ->
-    get_tls_handshake_aux(Version, Data, Options, []);
-get_tls_handshake(Version, Data, Buffer, Options) ->
-    get_tls_handshake_aux(Version, list_to_binary([Buffer, Data]), Options, []).
+get_tls_handshakes(Version, Data, <<>>, Options) ->
+    get_tls_handshakes_aux(Version, Data, Options, []);
+get_tls_handshakes(Version, Data, Buffer, Options) ->
+    get_tls_handshakes_aux(Version, list_to_binary([Buffer, Data]), Options, []).
 
 %%--------------------------------------------------------------------
 %%% Handshake helper
@@ -426,19 +426,19 @@ enc_handshake(HandshakeMsg, Version) ->
     ssl_handshake:encode_handshake(HandshakeMsg, Version).
 
 %%--------------------------------------------------------------------
-get_tls_handshake_aux(Version, <<?BYTE(Type), ?UINT24(Length),
+get_tls_handshakes_aux(Version, <<?BYTE(Type), ?UINT24(Length),
 				 Body:Length/binary,Rest/binary>>, 
                       #{log_level := LogLevel} = Opts,  Acc) ->
     Raw = <<?BYTE(Type), ?UINT24(Length), Body/binary>>,
     try decode_handshake(Version, Type, Body) of
 	Handshake ->
             ssl_logger:debug(LogLevel, inbound, 'handshake', Handshake),
-	    get_tls_handshake_aux(Version, Rest, Opts, [{Handshake,Raw} | Acc])
+	    get_tls_handshakes_aux(Version, Rest, Opts, [{Handshake,Raw} | Acc])
     catch
 	error:_ ->
 	    throw(?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE, handshake_decode_error))
     end;
-get_tls_handshake_aux(_Version, Data, _, Acc) ->
+get_tls_handshakes_aux(_Version, Data, _, Acc) ->
     {lists:reverse(Acc), Data}.
 
 decode_handshake({3, N}, ?HELLO_REQUEST, <<>>) when N < 4 ->

--- a/lib/ssl/test/ssl_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_handshake_SUITE.erl
@@ -129,8 +129,8 @@ decode_hello_handshake(_Config) ->
 		    16#70, 16#64, 16#79, 16#2f, 16#32>>,
 	
     Version = {3, 0},
-    {Records, _Buffer} = tls_handshake:get_tls_handshake(Version, HelloPacket, <<>>, 
-                                                         default_options_map()),
+    {Records, _Buffer} = tls_handshake:get_tls_handshakes(Version, HelloPacket, <<>>,
+                                                          default_options_map()),
 
     {Hello, _Data} = hd(Records),
     Extensions = Hello#server_hello.extensions,

--- a/lib/ssl/test/ssl_npn_hello_SUITE.erl
+++ b/lib/ssl/test/ssl_npn_hello_SUITE.erl
@@ -87,7 +87,7 @@ encode_and_decode_client_hello_test(Config) ->
     HandShakeData = create_client_handshake(undefined),
     Version = ssl_test_lib:protocol_version(Config),
     {[{DecodedHandshakeMessage, _Raw}], _} =
-	tls_handshake:get_tls_handshake(Version, list_to_binary(HandShakeData), <<>>,
+	tls_handshake:get_tls_handshakes(Version, list_to_binary(HandShakeData), <<>>,
                                         default_options_map()),
     Extensions = DecodedHandshakeMessage#client_hello.extensions,
     #{next_protocol_negotiation := undefined} = Extensions.
@@ -96,7 +96,7 @@ encode_and_decode_npn_client_hello_test(Config) ->
     HandShakeData = create_client_handshake(#next_protocol_negotiation{extension_data = <<>>}),
     Version = ssl_test_lib:protocol_version(Config),
     {[{DecodedHandshakeMessage, _Raw}], _} =
-	tls_handshake:get_tls_handshake(Version, list_to_binary(HandShakeData), <<>>,
+	tls_handshake:get_tls_handshakes(Version, list_to_binary(HandShakeData), <<>>,
                                         default_options_map()),
     Extensions = DecodedHandshakeMessage#client_hello.extensions,
     #{next_protocol_negotiation := #next_protocol_negotiation{extension_data = <<>>}} = Extensions.
@@ -105,7 +105,7 @@ encode_and_decode_server_hello_test(Config) ->
     HandShakeData = create_server_handshake(undefined),
     Version = ssl_test_lib:protocol_version(Config),
     {[{DecodedHandshakeMessage, _Raw}], _} =
-	tls_handshake:get_tls_handshake(Version, list_to_binary(HandShakeData), <<>>,
+	tls_handshake:get_tls_handshakes(Version, list_to_binary(HandShakeData), <<>>,
                                         default_options_map()),
     Extensions = DecodedHandshakeMessage#server_hello.extensions,
     #{next_protocol_negotiation := undefined} = Extensions.
@@ -115,7 +115,7 @@ encode_and_decode_npn_server_hello_test(Config) ->
     HandShakeData = create_server_handshake(#next_protocol_negotiation{extension_data = <<6, "spdy/2">>}),
     Version = ssl_test_lib:protocol_version(Config),
     {[{DecodedHandshakeMessage, _Raw}], _} =
-	tls_handshake:get_tls_handshake(Version, list_to_binary(HandShakeData), <<>>,
+	tls_handshake:get_tls_handshakes(Version, list_to_binary(HandShakeData), <<>>,
                                         default_options_map()),
     Extensions = DecodedHandshakeMessage#server_hello.extensions, 
     ct:log("~p ~n", [Extensions]),


### PR DESCRIPTION
I think this should solve #5961  The problem seems to be that an optimization bug happened to not show itself until some other unrelated things happened to expose it. This has to do with how handshake messages are packed into TLS records. I will try to write a withe-box test to test it. I would also appreciate @michaelklishin, and @lukebakken  if you could also try it out.