### PR TITLE
Fix spec for peer:start_link/0

### DIFF
--- a/lib/stdlib/src/peer.erl
+++ b/lib/stdlib/src/peer.erl
@@ -174,7 +174,7 @@ random_name(Prefix) ->
 %% @doc Starts a distributed node with random name, on this host,
 %%      and waits for that node to boot. Returns full node name,
 %%      registers local process with the same name as peer node.
--spec start_link() -> {ok, node()} | {error, Reason :: term()}.
+-spec start_link() -> {ok, pid(), node()} | {error, Reason :: term()}.
 start_link() ->
     start_link(#{name => random_name()}).
 


### PR DESCRIPTION
`peer:start_link/0` returns 3-tuple `{ok,Pid,Node}`.

Other peer issues:
- A lot of functions accept type `Dest :: gen_statem:server_ref()` as identifier of the peer node to communicate with. But nowhere is a  `gen_statem:server_ref()` returned. Why? Whether the controlling process is a gen_statem server or not, seems to me as an implementation issue. 
- I carelessly wrote `peer:start().` in the shell and got strange ERROR REPORT followed by a _frozen shell prompt_. It turns out that `start/0` is not part of the API but must be exported to satisfy the user.erl I/O interface. This is unfortunate, as it's an easy lets-try-this mistake to do.