### PR TITLE
fix(crl): insert the CRLs individually when an URI is provided

### DIFF
--- a/lib/ssl/src/ssl_crl_cache.erl
+++ b/lib/ssl/src/ssl_crl_cache.erl
@@ -175,7 +175,7 @@ cache_lookup(URL, {{Cache, _}, _}) ->
     case ssl_pkix_db:lookup(string:trim(Path, leading, "/"), Cache) of
 	undefined ->
 	    [];
-	CRLs ->
+	[CRLs] ->
 	    CRLs
     end.
 

--- a/lib/ssl/src/ssl_crl_cache.erl
+++ b/lib/ssl/src/ssl_crl_cache.erl
@@ -64,7 +64,7 @@ fresh_crl(#'DistributionPoint'{distributionPoint = {fullName, Names}}, CRL) ->
     case get_crls(Names, undefined) of
 	not_available ->
 	    CRL;
-	[NewCRL] ->
+	NewCRL ->
 	    NewCRL
     end.
 

--- a/lib/ssl/src/ssl_pkix_db.erl
+++ b/lib/ssl/src/ssl_pkix_db.erl
@@ -365,7 +365,7 @@ remove_crls([_,_,_, {Cache, Mapping} | _], Path) ->
     case lookup(Path, Cache) of
 	undefined ->
 	    ok;
-	CRLs ->
+	[CRLs] ->
 	    remove(Path, Cache),
 	    [rm_crls(CRL, Mapping) || CRL <- CRLs]
     end.

--- a/lib/ssl/src/ssl_pkix_db.erl
+++ b/lib/ssl/src/ssl_pkix_db.erl
@@ -352,7 +352,7 @@ new_trusted_cert_entry(File, [CertsDb, RefsDb, _ | _]) ->
 add_crls([_,_,_, {_, Mapping} | _], ?NO_DIST_POINT, CRLs) ->
     [add_crls(CRL, Mapping) || CRL <- CRLs];
 add_crls([_,_,_, {Cache, Mapping} | _], Path, CRLs) ->
-    insert(Path, CRLs, Cache), 
+    insert(Path, CRLs, Cache),
     [add_crls(CRL, Mapping) || CRL <- CRLs].
 
 add_crls(CRL, Mapping) ->

--- a/lib/ssl/test/ssl_crl_SUITE.erl
+++ b/lib/ssl/test/ssl_crl_SUITE.erl
@@ -240,6 +240,8 @@ crl_verify_valid(Config) when is_list(Config) ->
 		  end,			  
     {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
 
+    ssl_crl_cache:insert("http://localhost/erlangCA/crl.pem", {file, filename:join([PrivDir, "erlangCA", "crl.pem"])}),
+    ssl_crl_cache:insert("http://localhost/otpCA/crl.pem", {file, filename:join([PrivDir, "otpCA", "crl.pem"])}),
     ssl_crl_cache:insert({file, filename:join([PrivDir, "erlangCA", "crl.pem"])}),
     ssl_crl_cache:insert({file, filename:join([PrivDir, "otpCA", "crl.pem"])}),
     

--- a/lib/ssl/test/ssl_crl_SUITE.erl
+++ b/lib/ssl/test/ssl_crl_SUITE.erl
@@ -52,7 +52,8 @@
          crl_hash_dir_collision/0,
          crl_hash_dir_collision/1,
          crl_hash_dir_expired/0,
-         crl_hash_dir_expired/1]).
+         crl_hash_dir_expired/1,
+         delete_crl_with_path/1]).
 
 -define(TIMEOUT, {seconds, 30}).
 
@@ -83,7 +84,7 @@ groups() ->
 			      {group, crl_hash_dir}]},
      {v2_crl,  [], basic_tests()},
      {v1_crl,  [], basic_tests()},
-     {idp_crl, [], basic_tests()},
+     {idp_crl, [], basic_tests() ++ idp_crl_tests()},
      {crl_hash_dir, [], basic_tests() ++ crl_hash_dir_tests()},
      {crl_verify_crldp_crlissuer, [], [crl_verify_valid]}].
 
@@ -93,6 +94,9 @@ basic_tests() ->
      crl_verify_valid_derCAs,
      crl_verify_revoked_derCAs,
      crl_verify_no_crl].
+
+idp_crl_tests() ->
+    [delete_crl_with_path].
 
 crl_hash_dir_tests() ->
     [crl_hash_dir_collision, crl_hash_dir_expired].
@@ -557,6 +561,35 @@ crl_verify_error(Hostname, ServerNode, ServerOpts, ClientNode, ClientOpts, Expec
 					      {options, ClientOpts}]),
 
     ssl_test_lib:check_client_alert(Server, Client, ExpectedAlert).
+
+delete_crl_with_path(Config) ->
+    PrivDir = proplists:get_value(cert_dir, Config),
+
+    CertFilepath = filename:join([PrivDir, "server", "cert.pem"]),
+    {ok, PemCert} = file:read_file(CertFilepath),
+    [{_, DerCert, _}] = public_key:pem_decode(PemCert),
+    OTPCert = public_key:pkix_decode_cert(DerCert, otp),
+    [DP | _] = public_key:pkix_dist_points(OTPCert),
+
+    CRLFilepath = filename:join([PrivDir, "otpCA", "crl.pem"]),
+    {ok, PemBin} = file:read_file(CRLFilepath),
+    PemEntries = public_key:pem_decode(PemBin),
+    CRLs = [CRL || {'CertificateList', CRL, not_encrypted}
+                       <- PemEntries],
+
+    {status, _, _, StatusInfo} = sys:get_status(whereis(ssl_manager)),
+    [_, _,_, _, Prop] = StatusInfo,
+    State = ssl_test_lib:state(Prop),
+    case element(5, State) of
+        [_, _, _, {CRLCache, _}] ->
+            URI = "http://localhost/otpCA/crl.pem",
+            not_available = ssl_crl_cache:lookup(DP, issuer, {{CRLCache, unused}, unused}),
+            ok = ssl_crl_cache:insert(URI, {der, CRLs}),
+            CRLs = ssl_crl_cache:lookup(DP, issuer, {{CRLCache, unused}, unused}),
+            ok = ssl_crl_cache:delete(URI),
+            not_available = ssl_crl_cache:lookup(DP, issuer, {{CRLCache, unused}, unused}),
+            ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------

--- a/lib/ssl/test/ssl_crl_SUITE.erl
+++ b/lib/ssl/test/ssl_crl_SUITE.erl
@@ -244,8 +244,11 @@ crl_verify_valid(Config) when is_list(Config) ->
     ssl_crl_cache:insert("http://localhost/otpCA/crl.pem", {file, filename:join([PrivDir, "otpCA", "crl.pem"])}),
     ssl_crl_cache:insert({file, filename:join([PrivDir, "erlangCA", "crl.pem"])}),
     ssl_crl_cache:insert({file, filename:join([PrivDir, "otpCA", "crl.pem"])}),
-    
-    crl_verify_valid(Hostname, ServerNode, ServerOpts, ClientNode, ClientOpts).
+
+    crl_verify_valid(Hostname, ServerNode, ServerOpts, ClientNode, ClientOpts),
+
+    %% check that delete WITH URI works as well.
+    ssl_crl_cache:delete("http://localhost/erlangCA/crl.pem").
 
 crl_verify_revoked() ->
     [{doc,"Verify a simple CRL chain when peer cert is reveoked"}].


### PR DESCRIPTION
Currently, if one uses `ssl_crl_cache:insert/2` providing the URI of
the distribution point of a CRL, when a connection is attempted, it
fails with a `{unexpected_error,function_clause}`.

This traces to [`ssl_handshake:dps_and_crls/3`](https://github.com/erlang/otp/blob/8c182956e1bde761ea1541fd1d061b208356cb48/lib/ssl/src/ssl_handshake.erl#L2244), which eventually ends
up calling `public_key:der_decode/2` with a list-wrapped CRL DER
binary instead of simply the DER binary.