### PR TITLE
ssl: Handle protocol version change in sni_fun

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -1333,7 +1333,9 @@ filter_for_versions(['tlsv1.1'], OrigSSLOptions) ->
     maps:without(Opts, OrigSSLOptions);
 filter_for_versions(['tlsv1.1'| Rest], OrigSSLOptions) ->
     Opts = ?'TLS-1_3_ONLY_OPTIONS' ++ ?'FROM_TLS-1_2_ONLY_OPTIONS',
-    maybe_exclude_tlsv1(Rest, maps:without(Opts, OrigSSLOptions)).
+    maybe_exclude_tlsv1(Rest, maps:without(Opts, OrigSSLOptions));
+filter_for_versions(['tlsv1'], OrigSSLOptions) ->
+    OrigSSLOptions.
 
 maybe_exclude_tlsv1(Versions, Options) ->
     case lists:member('tlsv1', Versions) of

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -561,7 +561,7 @@ encode_handshake(#server_key_params{params_bin = Keys, hashsign = HashSign,
 encode_handshake(#certificate_request{certificate_types = CertTypes,
                                       hashsign_algorithms = #hash_sign_algos{hash_sign_algos = HashSignAlgos},
                                       certificate_authorities = CertAuths},
-                 {Major, Minor}) when Major == 3, Minor >= 3 ->
+                 {3,3}) ->
     HashSigns = << <<(ssl_cipher:signature_scheme(SignatureScheme)):16 >> ||
 		       SignatureScheme <- HashSignAlgos >>,
     CertTypesLen = byte_size(CertTypes),
@@ -3843,12 +3843,12 @@ path_validation(TrustedCert, Path, ServerName, Role, CertDbHandle, CertDbRef, CR
                   customize_hostname_check := CustomizeHostnameCheck,
                   crl_check := CrlCheck,
                   log_level := Level,
-                  signature_algs := SignAlgos,
-                  signature_algs_cert := SignAlgosCert,
-                  depth := Depth}, 
+                  depth := Depth} = Opts,
                 #{cert_ext := CertExt,
                   ocsp_responder_certs := OcspResponderCerts,
                   ocsp_state := OcspState}) ->
+    SignAlgos = maps:get(signature_algs, Opts, undefined),
+    SignAlgosCert = maps:get(signature_algs_cert, Opts, undefined),
     ValidationFunAndState = 
         validation_fun_and_state(VerifyFun, #{role => Role,
                                               certdb => CertDbHandle,

--- a/lib/ssl/src/tls_dtls_connection.erl
+++ b/lib/ssl/src/tls_dtls_connection.erl
@@ -731,6 +731,7 @@ do_server_hello(Type, #{next_protocol_negotiation := NextProtocols} =
     ServerHello =
 	ssl_handshake:server_hello(SessId, ssl:tls_version(Version),
                                    ConnectionStates1, ServerHelloExt),
+    
     State = server_hello(ServerHello,
 			 State1#state{handshake_env = HsEnv#handshake_env{expecting_next_protocol_negotiation =
                                                                               NextProtocols =/= undefined}}, Connection),
@@ -1285,8 +1286,8 @@ request_client_cert(#state{handshake_env = #handshake_env{kex_algorithm = Alg}} 
 request_client_cert(#state{static_env = #static_env{cert_db = CertDbHandle,
                                                     cert_db_ref = CertDbRef},
                            connection_env = #connection_env{negotiated_version = Version},
-                           ssl_options = #{verify := verify_peer,
-                                           signature_algs := SupportedHashSigns}} = State0, Connection) ->
+                           ssl_options = #{verify := verify_peer} = Opts} = State0, Connection) ->
+    SupportedHashSigns = maps:get(signature_algs, Opts, undefined),
     TLSVersion =  ssl:tls_version(Version),
     HashSigns = ssl_handshake:available_signature_algs(SupportedHashSigns, 
 						       TLSVersion),

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -45,6 +45,8 @@
          tls_upgrade/1,
          tls_upgrade_new_opts/0,
          tls_upgrade_new_opts/1,
+         tls_upgrade_new_opts_with_sni_fun/0,
+         tls_upgrade_new_opts_with_sni_fun/1,
          tls_upgrade_with_timeout/0,
          tls_upgrade_with_timeout/1,
          tls_downgrade/0,
@@ -143,6 +145,7 @@ api_tests() ->
     [
      tls_upgrade,
      tls_upgrade_new_opts,
+     tls_upgrade_new_opts_with_sni_fun,
      tls_upgrade_with_timeout,
      tls_downgrade,
      tls_shutdown,
@@ -278,6 +281,52 @@ tls_upgrade_new_opts(Config) when is_list(Config) ->
 
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
+
+%%--------------------------------------------------------------------
+tls_upgrade_new_opts_with_sni_fun() ->
+    [{doc,"Test that you can upgrade an tcp connection to an ssl connection with new versions option provided by sni_fun"}].
+
+tls_upgrade_new_opts_with_sni_fun(Config) when is_list(Config) ->
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    TcpOpts = [binary, {reuseaddr, true}],
+    Version = ssl_test_lib:protocol_version(Config),
+    NewVersions = new_versions(Version),
+    Ciphers =  ssl:filter_cipher_suites(ssl:cipher_suites(all, Version), []),
+
+    NewOpts = [{versions, NewVersions},
+               {ciphers, Ciphers},
+               {verify, verify_peer}],
+
+    Server = ssl_test_lib:start_upgrade_server([{node, ServerNode}, {port, 0},
+						{from, self()},
+						{mfa, {?MODULE,
+						       upgrade_result, []}},
+						{tcp_options,
+						 [{active, false} | TcpOpts]},
+						{ssl_options, [{versions,  [Version |NewVersions]}, {sni_fun, fun(_SNI) -> ServerOpts ++ NewOpts end}]}]),
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_upgrade_client([{node, ClientNode},
+						{port, Port},
+				   {host, Hostname},
+				   {from, self()},
+				   {mfa, {?MODULE, upgrade_result, []}},
+				   {tcp_options, [binary]},
+				   {ssl_options,  [{verify, verify_peer},
+                                                   {versions,  [Version |NewVersions]},
+                                                   {ciphers, Ciphers},
+                                                   {server_name_indication, Hostname} | ClientOpts]}]),
+
+    ct:log("Testcase ~p, Client ~p  Server ~p ~n",
+		       [self(), Client, Server]),
+
+    ssl_test_lib:check_result(Server, ok, Client, ok),
+
+    ssl_test_lib:close(Server),
+    ssl_test_lib:close(Client).
+
+
 
 %%--------------------------------------------------------------------
 tls_upgrade_with_timeout() ->
@@ -1304,3 +1353,13 @@ session_info(_) ->
 
 count_children(ChildType, SupRef) ->
     proplists:get_value(ChildType, supervisor:count_children(SupRef)).
+
+
+new_versions('tlsv1.3') ->
+    ['tlsv1.2'];
+new_versions('tlsv1.2') ->
+    ['tlsv1.1'];
+new_versions('tlsv1.1') ->
+    ['tlsv1'];
+new_versions('tlsv1') ->
+    ['tlsv1'].


### PR DESCRIPTION
If upgrading a TCP socket to a TLS socket and in the same
time changing the supported protocol version in the
sni_fun callback, so that it does not match the default, care must
be applied to make sure correct decoding of hello information is used.

Closes #5985