### PR TITLE
Improve the type analysis

### DIFF
--- a/bootstrap/lib/stdlib/ebin/stdlib.appup
+++ b/bootstrap/lib/stdlib/ebin/stdlib.appup
@@ -19,25 +19,16 @@
 %%
 %% We allow upgrade from, and downgrade to all previous
 %% versions from the following OTP releases:
-%% - OTP 22
 %% - OTP 23
 %% - OTP 24
+%% - OTP 25
 %%
 %% We also allow upgrade from, and downgrade to all
 %% versions that have branched off from the above
 %% stated previous versions.
 %%
-{"3.17.1",
- [{<<"^3\\.10$">>,[restart_new_emulator]},
-  {<<"^3\\.10\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.11$">>,[restart_new_emulator]},
-  {<<"^3\\.11\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.11\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
-  {<<"^3\\.11\\.2(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
-  {<<"^3\\.12$">>,[restart_new_emulator]},
-  {<<"^3\\.12\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.12\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
-  {<<"^3\\.13$">>,[restart_new_emulator]},
+{"4.0",
+ [{<<"^3\\.13$">>,[restart_new_emulator]},
   {<<"^3\\.13\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
   {<<"^3\\.13\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
   {<<"^3\\.13\\.2(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
@@ -54,20 +45,9 @@
   {<<"^3\\.16\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
   {<<"^3\\.17$">>,[restart_new_emulator]},
   {<<"^3\\.17\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.9$">>,[restart_new_emulator]},
-  {<<"^3\\.9\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.9\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
-  {<<"^3\\.9\\.2(?:\\.[0-9]+)*$">>,[restart_new_emulator]}],
- [{<<"^3\\.10$">>,[restart_new_emulator]},
-  {<<"^3\\.10\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.11$">>,[restart_new_emulator]},
-  {<<"^3\\.11\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.11\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
-  {<<"^3\\.11\\.2(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
-  {<<"^3\\.12$">>,[restart_new_emulator]},
-  {<<"^3\\.12\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.12\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
-  {<<"^3\\.13$">>,[restart_new_emulator]},
+  {<<"^3\\.17\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
+  {<<"^3\\.17\\.2(?:\\.[0-9]+)*$">>,[restart_new_emulator]}],
+ [{<<"^3\\.13$">>,[restart_new_emulator]},
   {<<"^3\\.13\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
   {<<"^3\\.13\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
   {<<"^3\\.13\\.2(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
@@ -84,7 +64,5 @@
   {<<"^3\\.16\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
   {<<"^3\\.17$">>,[restart_new_emulator]},
   {<<"^3\\.17\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.9$">>,[restart_new_emulator]},
-  {<<"^3\\.9\\.0(?:\\.[0-9]+)+$">>,[restart_new_emulator]},
-  {<<"^3\\.9\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
-  {<<"^3\\.9\\.2(?:\\.[0-9]+)*$">>,[restart_new_emulator]}]}.
+  {<<"^3\\.17\\.1(?:\\.[0-9]+)*$">>,[restart_new_emulator]},
+  {<<"^3\\.17\\.2(?:\\.[0-9]+)*$">>,[restart_new_emulator]}]}.

--- a/erts/emulator/test/tuple_SUITE_data/get_two_tuple_elements.S
+++ b/erts/emulator/test/tuple_SUITE_data/get_two_tuple_elements.S
@@ -63,7 +63,7 @@
     {trim,2,0}.
     {line,[{location,"get_two_tuple_elements.erl",5}]}.
     {call,2,{f,5}}.
-    {'%',{var_info,{x,0},[{type,number}]}}.
+    {'%',{var_info,{x,0},[{type,{t_number,any}}]}}.
     {test,is_eq_exact,{f,3},[{x,0},{integer,3}]}.
     {move,{atom,ok},{x,0}}.
     {deallocate,0}.

--- a/lib/compiler/src/beam_bounds.erl
+++ b/lib/compiler/src/beam_bounds.erl
@@ -26,45 +26,224 @@
 %%
 %%
 -module(beam_bounds).
--export(['+'/2, '-'/2, '*'/2, 'div'/2, 'rem'/2,
-         'band'/2, 'bor'/2, 'bxor'/2, 'bsr'/2, 'bsl'/2,
-         relop/3]).
+-export([bounds/2, bounds/3, relop/3, infer_relop_types/3]).
+-export_type([range/0]).
 
--type range() :: {integer(), integer()} | 'any'.
+-type range() :: {integer(), integer()} |
+                 {'-inf', integer()} |
+                 {integer(), '+inf'} |
+                 'any'.
 -type range_result() :: range() | 'any'.
 -type relop() :: '<' | '=<' | '>' | '>='.
 -type bool_result() :: 'true' | 'false' | 'maybe'.
+-type op() :: atom().
 
--spec '+'(range(), range()) -> range_result().
+%% Maximum size of integers in bits to keep ranges for.
+-define(NUM_BITS, 128).
 
-'+'({A,B}, {C,D}) when abs(A) bsr 256 =:= 0, abs(B) bsr 256 =:= 0,
-                       abs(C) bsr 256 =:= 0, abs(D) bsr 256 =:= 0 ->
-    verify_range({A+C,B+D});
-'+'(_, _) ->
+-spec bounds(op(), range()) -> range_result().
+
+bounds(abs, R) ->
+    case R of
+        {A,B} when is_integer(A), is_integer(B) ->
+            Min = 0,
+            Max = max(abs(A), abs(B)),
+            {Min,Max};
+        _ ->
+            {0,'+inf'}
+    end.
+
+-spec bounds(op(), range(), range()) -> range_result().
+
+bounds('+', R1, R2) ->
+    case {R1,R2} of
+        {{A,B}, {C,D}} when abs(A) bsr ?NUM_BITS =:= 0,
+                            abs(B) bsr ?NUM_BITS =:= 0,
+                            abs(C) bsr ?NUM_BITS =:= 0,
+                            abs(D) bsr ?NUM_BITS =:= 0 ->
+            normalize({A+C,B+D});
+        {{A,'+inf'}, {C,_D}} when abs(A) bsr ?NUM_BITS =:= 0,
+                                  abs(C) bsr ?NUM_BITS =:= 0 ->
+            normalize({A+C,'+inf'});
+        {{A,_B}, {C,'+inf'}} when abs(A) bsr ?NUM_BITS =:= 0,
+                                  abs(C) bsr ?NUM_BITS =:= 0 ->
+            normalize({A+C,'+inf'});
+        {_, _} ->
+            any
+    end;
+bounds('-', R1, R2) ->
+    case {R1,R2} of
+        {{A,B}, {C,D}} when abs(A) bsr ?NUM_BITS =:= 0,
+                            abs(B) bsr ?NUM_BITS =:= 0,
+                            abs(C) bsr ?NUM_BITS =:= 0,
+                            abs(D) bsr ?NUM_BITS =:= 0 ->
+            normalize({A-D,B-C});
+        {{_A,B}, {C,'+inf'}} when abs(B) bsr ?NUM_BITS =:= 0,
+                                  abs(C) bsr ?NUM_BITS =:= 0 ->
+            normalize({'-inf',B-C});
+        {_, _} ->
+            any
+    end;
+bounds('*', R1, R2) ->
+    case {R1,R2} of
+        {{A,B}, {C,D}} when abs(A) bsr ?NUM_BITS =:= 0,
+                            abs(B) bsr ?NUM_BITS =:= 0,
+                            abs(C) bsr ?NUM_BITS =:= 0,
+                            abs(D) bsr ?NUM_BITS =:= 0 ->
+            All = [X * Y || X <- [A,B], Y <- [C,D]],
+            Min = lists:min(All),
+            Max = lists:max(All),
+            normalize({Min,Max});
+        {{A,'+inf'}, {C,D}} when abs(A) bsr ?NUM_BITS =:= 0,
+                                 abs(C) bsr ?NUM_BITS =:= 0,
+                                 abs(D) bsr ?NUM_BITS =:= 0,
+                                 C >= 0 ->
+            {min(A*C, A*D),'+inf'};
+        {{'-inf',B}, {C,D}} when abs(B) bsr ?NUM_BITS =:= 0,
+                                 abs(C) bsr ?NUM_BITS =:= 0,
+                                 abs(D) bsr ?NUM_BITS =:= 0,
+                                 C >= 0 ->
+            {'-inf',max(B*C, B*D)};
+        {{A,B}, {'-inf',_}} when is_integer(A), is_integer(B) ->
+            bounds('*', R2, R1);
+        {{A,B}, {_,'+inf'}} when is_integer(A), is_integer(B) ->
+            bounds('*', R2, R1);
+        {_, _} ->
+            any
+    end;
+bounds('div', R1, R2) ->
+    div_bounds(R1, R2);
+bounds('rem', R1, R2) ->
+    rem_bounds(R1, R2);
+bounds('band', R1, R2) ->
+    case {R1,R2} of
+        {{A,B}, {C,D}} when A bsr ?NUM_BITS =:= 0, A >= 0,
+                            C bsr ?NUM_BITS =:= 0, C >= 0,
+                            is_integer(B), is_integer(D) ->
+            Min = min_band(A, B, C, D),
+            Max = max_band(A, B, C, D),
+            {Min,Max};
+        {_, {C,D}} when is_integer(C), C >= 0 ->
+            {0,D};
+        {{A,B}, _} when is_integer(A), A >= 0 ->
+            {0,B};
+        {_, _} ->
+            any
+    end;
+bounds('bor', R1, R2) ->
+    case {R1,R2} of
+        {{A,B}, {C,D}} when A bsr ?NUM_BITS =:= 0, A >= 0,
+                            C bsr ?NUM_BITS =:= 0, C >= 0,
+                            is_integer(B), is_integer(D) ->
+            Min = min_bor(A, B, C, D),
+            Max = max_bor(A, B, C, D),
+            {Min,Max};
+        {_, _} ->
+            any
+    end;
+bounds('bxor', R1, R2) ->
+    case {R1,R2} of
+        {{A,B}, {C,D}} when A bsr ?NUM_BITS =:= 0, A >= 0,
+                            C bsr ?NUM_BITS =:= 0, C >= 0,
+                            is_integer(B), is_integer(D) ->
+            Max = max_bxor(A, B, C, D),
+            {0,Max};
+        {_, _} ->
+            any
+    end;
+bounds('bsr', R1, R2) ->
+    case {R1,R2} of
+        {{A,B}, {C,D}} when is_integer(C), C >= 0 ->
+            Min = inf_min(inf_bsr(A, C), inf_bsr(A, D)),
+            Max = inf_max(inf_bsr(B, C), inf_bsr(B, D)),
+            normalize({Min,Max});
+        {_, _} ->
+            any
+    end;
+bounds('bsl', R1, R2) ->
+    case {R1,R2} of
+        {{A,B}, {C,D}} when abs(A) bsr ?NUM_BITS =:= 0,
+                            abs(B) bsr ?NUM_BITS =:= 0 ->
+            Min = inf_min(inf_bsl(A, C), inf_bsl(A, D)),
+            Max = inf_max(inf_bsl(B, C), inf_bsl(B, D)),
+            normalize({Min,Max});
+        {_, _} ->
+            any
+    end;
+bounds(max, R1, R2) ->
+    case {R1,R2} of
+        {{A,B},{C,D}} ->
+            normalize({inf_max(A, C),inf_max(B, D)});
+        {_,_} ->
+            any
+    end;
+bounds(min, R1, R2) ->
+    case {R1,R2} of
+        {{A,B},{C,D}} ->
+            normalize({inf_min(A, C),inf_min(B, D)});
+        {_,_} ->
+            any
+    end.
+
+-spec relop(relop(), range(), range()) -> bool_result().
+
+relop('<', {A,B}, {C,D}) ->
+    case {inf_lt(B, C),inf_lt(A, D)} of
+        {Bool,Bool} -> Bool;
+        {_,_} -> 'maybe'
+    end;
+relop('=<', {A,B}, {C,D}) ->
+    case {inf_le(B, C),inf_le(A, D)} of
+        {Bool,Bool} -> Bool;
+        {_,_} -> 'maybe'
+    end;
+relop('>=', {A,B}, {C,D}) ->
+    case {inf_ge(B, C),inf_ge(A, D)} of
+        {Bool,Bool} -> Bool;
+        {_,_} -> 'maybe'
+    end;
+relop('>', {A,B}, {C,D}) ->
+    case {inf_gt(B, C),inf_gt(A, D)} of
+        {Bool,Bool} -> Bool;
+        {_,_} -> 'maybe'
+    end;
+relop(_, _, _) ->
+    'maybe'.
+
+-spec infer_relop_types(relop(), range(), range()) -> any().
+
+infer_relop_types(Op, {_,_}=Range1, {_,_}=Range2) ->
+    case relop(Op, Range1, Range2) of
+        'maybe' ->
+            infer_relop_types_1(Op, Range1, Range2);
+        _ ->
+            any
+    end;
+infer_relop_types('<', {A,_}=R1, any) ->
+    {R1, normalize({inf_add(A, 1), '+inf'})};
+infer_relop_types('<', any, {_,D}=R2) ->
+    {normalize({'-inf', inf_add(D, -1)}), R2};
+infer_relop_types('=<', {A,_}=R1, any) ->
+    {R1, normalize({A, '+inf'})};
+infer_relop_types('=<', any, {_,D}=R2) ->
+    {normalize({'-inf', D}), R2};
+infer_relop_types('>=', {_,B}=R1, any) ->
+    {R1, normalize({'-inf', B})};
+infer_relop_types('>=', any, {C,_}=R2) ->
+    {normalize({C, '+inf'}), R2};
+infer_relop_types('>', {_,B}=R1, any) ->
+    {R1, normalize({'-inf', inf_add(B, -1)})};
+infer_relop_types('>', any, {C,_}=R2) ->
+    {normalize({inf_add(C, 1), '+inf'}), R2};
+infer_relop_types(_Op, _R1, _R2) ->
     any.
 
--spec '-'(range(), range()) -> range_result().
+%%%
+%%% Internal functions.
+%%%
 
-'-'({A,B}, {C,D}) when abs(A) bsr 256 =:= 0, abs(B) bsr 256 =:= 0,
-                       abs(C) bsr 256 =:= 0, abs(D) bsr 256 =:= 0 ->
-    verify_range({A-D,B-C});
-'-'(_, _) ->
-    any.
-
--spec '*'(range(), range()) -> range_result().
-
-'*'({A,B}, {C,D}) when abs(A) bsr 256 =:= 0, abs(B) bsr 256 =:= 0,
-                       abs(C) bsr 256 =:= 0, abs(D) bsr 256 =:= 0 ->
-    All = [X * Y || X <- [A,B], Y <- [C,D]],
-    Min = lists:min(All),
-    Max = lists:max(All),
-    verify_range({Min,Max});
-'*'(_, _) ->
-    any.
-
--spec 'div'(range(), range()) -> range_result().
-
-'div'({A,B}, {C,D}) ->
+div_bounds({A,B}, {C,D}) when is_integer(A), is_integer(B),
+                         is_integer(C), is_integer(D) ->
     Denominators = [min(C, D),max(C, D)|
                     %% Handle zero crossing for the denominator.
                     if
@@ -78,89 +257,33 @@
                       Y =/= 0],
     Min = lists:min(All),
     Max = lists:max(All),
-    verify_range({Min,Max});
-'div'(_, _) ->
+    normalize({Min,Max});
+div_bounds({A,'+inf'}, {C,D}) when is_integer(C), C > 0, is_integer(D) ->
+    Min = min(A div C, A div D),
+    Max = '+inf',
+    normalize({Min,Max});
+div_bounds({'-inf',B}, {C,D}) when is_integer(C), C > 0, is_integer(D) ->
+    Min = '-inf',
+    Max = max(B div C, B div D),
+    normalize({Min,Max});
+div_bounds(_, _) ->
     any.
 
--spec 'rem'(range(), range()) -> range_result().
-
-'rem'({A,_}, {C,D}) when C > 0 ->
-    Max = D - 1,
+rem_bounds({A,_}, {C,D}) when is_integer(C), is_integer(D), C > 0 ->
+    Max = inf_add(D, -1),
     Min = if
+              A =:= '-inf' -> -Max;
               A >= 0 -> 0;
               true -> -Max
           end,
-    verify_range({Min,Max});
-'rem'(_, {C,D}) when C =/= 0; D =/= 0 ->
+    normalize({Min,Max});
+rem_bounds(_, {C,D}) when is_integer(C), is_integer(D),
+                     C =/= 0 orelse D =/= 0 ->
     Max = max(abs(C), abs(D)) - 1,
     Min = -Max,
-    verify_range({Min,Max});
-'rem'(_, _) ->
+    normalize({Min,Max});
+rem_bounds(_, _) ->
     any.
-
--spec 'band'(range(), range()) -> range_result().
-
-'band'({A,B}, {C,D}) when A >= 0, A bsr 256 =:= 0, C >= 0, C bsr 256 =:= 0 ->
-    Min = min_band(A, B, C, D),
-    Max = max_band(A, B, C, D),
-    {Min,Max};
-'band'(_, {C,D}) when C >= 0 ->
-    {0,D};
-'band'({A,B}, _) when A >= 0 ->
-    {0,B};
-'band'(_, _) ->
-    any.
-
--spec 'bor'(range(), range()) -> range_result().
-
-'bor'({A,B}, {C,D}) when A >= 0, A bsr 256 =:= 0, C >= 0, C bsr 256 =:= 0 ->
-    Min = min_bor(A, B, C, D),
-    Max = max_bor(A, B, C, D),
-    {Min,Max};
-'bor'(_, _) ->
-    any.
-
--spec 'bxor'(range(), range()) -> range_result().
-
-'bxor'({A,B}, {C,D}) when A >= 0, A bsr 256 =:= 0, C >= 0, C bsr 256 =:= 0 ->
-    Max = max_bxor(A, B, C, D),
-    {0,Max};
-'bxor'(_, _) ->
-    any.
-
--spec 'bsr'(range(), range()) -> range_result().
-
-'bsr'({A,B}, {C,D}) when C >= 0 ->
-    Min = min(A bsr C, A bsr D),
-    Max = max(B bsr C, B bsr D),
-    {Min,Max};
-'bsr'(_, _) ->
-    any.
-
--spec 'bsl'(range(), range()) -> range_result().
-
-'bsl'({A,B}, {C,D}) when abs(B) bsr 128 =:= 0, C >= 0, D < 128 ->
-    Min = min(A bsl C, A bsl D),
-    Max = max(B bsl C, B bsl D),
-    {Min,Max};
-'bsl'(_, _) ->
-    any.
-
--spec relop(relop(), range(), range()) -> bool_result().
-
-relop(Op, {A,B}, {C,D}) ->
-    case {erlang:Op(B, C),erlang:Op(A, D)} of
-        {Bool,Bool} -> Bool;
-        {_,_} -> 'maybe'
-    end;
-relop(_, _, _) ->
-    'maybe'.
-
-%%%
-%%% Internal functions.
-%%%
-
-verify_range({Min,Max}=T) when Min =< Max -> T.
 
 min_band(A, B, C, D) ->
     M = 1 bsl (upper_bit(A bor C) + 1),
@@ -295,3 +418,92 @@ upper_bit_1(Val0, N) ->
         0 -> N;
         Val -> upper_bit_1(Val, N + 1)
     end.
+
+infer_relop_types_1('<', {A,B}, {C,D}) ->
+    Left = normalize({A, clamp(inf_add(D, -1), A, B)}),
+    Right = normalize({clamp(inf_add(A, 1), C, D), D}),
+    {Left,Right};
+infer_relop_types_1('=<', {A,B}, {C,D}) ->
+    Left = normalize({A, clamp(D, A, B)}),
+    Right = normalize({clamp(A, C, D), D}),
+    {Left,Right};
+infer_relop_types_1('>=', {A,B}, {C,D}) ->
+    Left = normalize({clamp(C, A, B), B}),
+    Right = normalize({C, clamp(B, C, D)}),
+    {Left,Right};
+infer_relop_types_1('>', {A,B}, {C,D}) ->
+    Left = normalize({clamp(inf_add(C, 1), A, B), B}),
+    Right = normalize({C,clamp(inf_add(B, -1), C, D)}),
+    {Left,Right}.
+
+%%%
+%%% Handling of ranges.
+%%%
+%%% A range can begin with '-inf' OR end with '+inf'.
+%%%
+%%% Atoms are greater than all integers. Therefore, we don't
+%%% need any special handling of '+inf'.
+%%%
+
+normalize({'-inf','-inf'}) ->
+    {'-inf',-1};
+normalize({'-inf','+inf'}) ->
+    any;
+normalize({'+inf','+inf'}) ->
+    {0,'+inf'};
+normalize({Min,Max}=T) ->
+    true = inf_ge(Max, Min),
+    T.
+
+clamp(V, A, B) ->
+    inf_min(inf_max(V, A), B).
+
+inf_min(A, B) when A =:= '-inf'; B =:= '-inf' -> '-inf';
+inf_min(A, B) when A =< B -> A;
+inf_min(A, B) when A > B -> B.
+
+inf_max('-inf', B) -> B;
+inf_max(A, '-inf') -> A;
+inf_max(A, B) when A >= B -> A;
+inf_max(A, B) when A < B -> B.
+
+inf_neg('-inf') -> '+inf';
+inf_neg('+inf') -> '-inf';
+inf_neg(N) -> -N.
+
+inf_add(Int, N) when is_integer(Int) -> Int + N;
+inf_add(Inf, _N) -> Inf.
+
+inf_bsr('-inf', _S) ->
+    '-inf';
+inf_bsr('+inf', _S) ->
+    '+inf';
+inf_bsr(N, S0) when S0 =:= '-inf'; S0 < 0 ->
+    S = inf_neg(S0),
+    if
+        S >= ?NUM_BITS, N < 0 -> '-inf';
+        S >= ?NUM_BITS, N >= 0 -> '+inf';
+        true -> N bsl S
+    end;
+inf_bsr(N, '+inf') ->
+    if
+        N < 0 -> -1;
+        N >= 0 -> 0
+    end;
+inf_bsr(N, S) when S >= 0 ->
+    N bsr S.
+
+inf_bsl(N, S) ->
+    inf_bsr(N, inf_neg(S)).
+
+inf_lt(_, '-inf') -> false;
+inf_lt('-inf', _) -> true;
+inf_lt(A, B) -> A < B.
+
+inf_ge(_, '-inf') -> true;
+inf_ge('-inf', _) -> false;
+inf_ge(A, B) -> A >= B.
+
+inf_le(A, B) -> inf_ge(B, A).
+
+inf_gt(A, B) -> inf_lt(B, A).

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -333,6 +333,12 @@ format_type(#t_integer{elements={X,X}}) ->
     io_lib:format("~p", [X]);
 format_type(#t_integer{elements={Low,High}}) ->
     io_lib:format("~p..~p", [Low,High]);
+format_type(#t_number{elements=any}) ->
+    "number()";
+format_type(#t_number{elements={X,X}}) ->
+    io_lib:format("number(~p)", [X]);
+format_type(#t_number{elements={Low,High}}) ->
+    io_lib:format("number(~p, ~p)", [Low,High]);
 format_type(#t_list{type=ET,terminator=nil}) ->
     ["list(", format_type(ET), ")"];
 format_type(#t_list{type=ET,terminator=TT}) ->
@@ -347,6 +353,8 @@ format_type(#t_tuple{elements=Es,exact=Ex,size=S}) ->
     ["{",
      string:join(format_tuple_elems(S, Ex, Es, 1), ", "),
      "}"];
+format_type(other) ->
+    "other()";
 format_type(pid) ->
     "pid()";
 format_type(port) ->

--- a/lib/compiler/src/beam_ssa_throw.erl
+++ b/lib/compiler/src/beam_ssa_throw.erl
@@ -442,7 +442,7 @@ ois_is([#b_set{op={bif,is_list},dst=Dst,args=[Src]} | Is], Ts) ->
 ois_is([#b_set{op={bif,is_map},dst=Dst,args=[Src]} | Is], Ts) ->
     ois_type_test(Src, Dst, #t_map{}, Is, Ts);
 ois_is([#b_set{op={bif,is_number},dst=Dst,args=[Src]} | Is], Ts) ->
-    ois_type_test(Src, Dst, number, Is, Ts);
+    ois_type_test(Src, Dst, #t_number{}, Is, Ts);
 ois_is([#b_set{op={bif,is_tuple},dst=Dst,args=[Src]} | Is], Ts) ->
     ois_type_test(Src, Dst, #t_tuple{}, Is, Ts);
 ois_is([#b_set{op=is_nonempty_list,dst=Dst,args=[Src]} | Is], Ts) ->

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -61,7 +61,7 @@
         N =:= nil).
 
 -define(IS_NUMBER_TYPE(N),
-        N =:= number orelse
+        is_record(N, t_number) orelse
         is_record(N, t_float) orelse
         is_record(N, t_integer)).
 
@@ -277,19 +277,17 @@ join_unions(#t_union{atom=AtomA,list=ListA,number=NumberA,
                      other=lub(OtherA, OtherB)},
     shrink_union(Union);
 join_unions(#t_union{atom=AtomA}=A, #t_atom{}=B) ->
-    A#t_union{atom=lub(AtomA, B)};
+    shrink_union(A#t_union{atom=lub(AtomA, B)});
 join_unions(#t_union{list=ListA}=A, B) when ?IS_LIST_TYPE(B) ->
-    A#t_union{list=lub(ListA, B)};
+    shrink_union(A#t_union{list=lub(ListA, B)});
 join_unions(#t_union{number=NumberA}=A, B) when ?IS_NUMBER_TYPE(B) ->
-    A#t_union{number=lub(NumberA, B)};
+    shrink_union(A#t_union{number=lub(NumberA, B)});
 join_unions(#t_union{tuple_set=TSetA}=A, #t_tuple{}=B) ->
     Set = join_tuple_sets(TSetA, new_tuple_set(B)),
     shrink_union(A#t_union{tuple_set=Set});
 join_unions(#t_union{other=OtherA}=A, B) ->
-    case lub(OtherA, B) of
-        any -> any;
-        T -> A#t_union{other=T}
-    end.
+    T = lub(OtherA, B),
+    shrink_union(A#t_union{other=T}).
 
 join_tuple_sets(A, none) ->
     A;
@@ -334,6 +332,14 @@ jts_records([], [{KeyB, B} | RsB], N, Acc) ->
 
 -spec subtract(type(), type()) -> type().
 
+subtract(any, #t_number{elements={'-inf',Max}}) ->
+    %% We handle this case specially in order to represent the type
+    %% Var in Var =< Integer.
+    #t_union{atom=#t_atom{},
+             list=#t_list{},
+             number=#t_number{elements={Max,'+inf'}},
+             tuple_set=#t_tuple{},
+             other=other};
 subtract(#t_atom{elements=[_|_]=Set0}, #t_atom{elements=[_|_]=Set1}) ->
     case ordsets:subtract(Set0, Set1) of
         [] -> none;
@@ -358,8 +364,10 @@ subtract(#t_integer{elements={Min, Max}}, #t_integer{elements={N,N}}) ->
         Max =:= N ->
             #t_integer{elements={Min, Max - 1}}
     end;
-subtract(number, #t_float{elements=any}) -> #t_integer{};
-subtract(number, #t_integer{elements=any}) -> #t_float{};
+subtract(#t_number{elements=R}, #t_float{elements=any}) ->
+    integer_from_range(R);
+subtract(#t_number{elements=R}, #t_integer{elements=any}) ->
+    float_from_range(R);
 
 %% A list is essentially `#t_cons{} | nil`, so we're left with nil if we
 %% subtract a cons cell that is more general than the one in the list.
@@ -475,7 +483,7 @@ is_boolean_type(_) ->
 
 -spec is_numerical_type(type()) -> boolean().
 is_numerical_type(#t_integer{}) -> true;
-is_numerical_type(number) -> true;
+is_numerical_type(#t_number{}) -> true;
 is_numerical_type(_) -> false.
 
 -spec set_tuple_element(Index, Type, Elements) -> Elements when
@@ -757,15 +765,8 @@ glb(#t_cons{type=TypeA,terminator=TermA},
         {_, none} -> none;
         {Type, Term} -> #t_cons{type=Type,terminator=Term}
     end;
-glb(#t_float{}=T, #t_float{elements=any}) ->
-    T;
-glb(#t_float{elements=any}, #t_float{}=T) ->
-    T;
-glb(#t_float{elements={MinA,MaxA}}, #t_float{elements={MinB,MaxB}})
-  when MinA >= MinB, MinA =< MaxB;
-       MinB >= MinA, MinB =< MaxA ->
-    true = MinA =< MaxA andalso MinB =< MaxB,   %Assertion.
-    #t_float{elements={max(MinA, MinB),min(MaxA, MaxB)}};
+glb(#t_float{elements=R1}, #t_float{elements=R2}) ->
+    float_from_range(glb_ranges(R1, R2));
 glb(#t_fun{arity=SameArity,target=SameTarget,type=TypeA},
     #t_fun{arity=SameArity,target=SameTarget,type=TypeB}=T) ->
     T#t_fun{type=meet(TypeA, TypeB)};
@@ -777,19 +778,12 @@ glb(#t_fun{arity=any}=A, #t_fun{arity=ArityB}=B) when ArityB =/= any->
     glb(A#t_fun{arity=ArityB}, B);
 glb(#t_fun{arity=ArityA}=A, #t_fun{arity=any}=B) when ArityA =/= any ->
     glb(A, B#t_fun{arity=ArityA});
-glb(#t_integer{elements={_,_}}=T, #t_integer{elements=any}) ->
-    T;
-glb(#t_integer{elements=any}, #t_integer{elements={_,_}}=T) ->
-    T;
-glb(#t_integer{elements={MinA,MaxA}}, #t_integer{elements={MinB,MaxB}})
-  when MinA >= MinB, MinA =< MaxB;
-       MinB >= MinA, MinB =< MaxA ->
-    true = MinA =< MaxA andalso MinB =< MaxB,   %Assertion.
-    #t_integer{elements={max(MinA, MinB),min(MaxA, MaxB)}};
-glb(#t_integer{}=T, number) ->
-    T;
-glb(#t_float{}=T, number) ->
-    T;
+glb(#t_integer{elements=R1}, #t_integer{elements=R2}) ->
+    integer_from_range(glb_ranges(R1, R2));
+glb(#t_integer{elements=R1}, #t_number{elements=R2}) ->
+    integer_from_range(glb_ranges(R1, R2));
+glb(#t_float{elements=R1}, #t_number{elements=R2}) ->
+    float_from_range(glb_ranges(R1, R2));
 glb(#t_list{type=TypeA,terminator=TermA},
     #t_list{type=TypeB,terminator=TermB}) ->
     %% A list is a union of `[type() | _]` and `[]`, so we're left with
@@ -805,10 +799,12 @@ glb(#t_list{}, nil) ->
     nil;
 glb(nil, #t_list{}) ->
     nil;
-glb(number, #t_integer{}=T) ->
-    T;
-glb(number, #t_float{}=T) ->
-    T;
+glb(#t_number{elements=R1}, #t_number{elements=R2}) ->
+    number_from_range(glb_ranges(R1, R2));
+glb(#t_number{elements=R1}, #t_integer{elements=R2}) ->
+    integer_from_range(glb_ranges(R1, R2));
+glb(#t_number{elements=R1}, #t_float{elements=R2}) ->
+    float_from_range(glb_ranges(R1, R2));
 glb(#t_map{super_key=SKeyA,super_value=SValueA},
     #t_map{super_key=SKeyB,super_value=SValueB}) ->
     %% Note the use of meet/2; elements don't need to be normal types.
@@ -817,9 +813,33 @@ glb(#t_map{super_key=SKeyA,super_value=SValueA},
     #t_map{super_key=SKey,super_value=SValue};
 glb(#t_tuple{}=T1, #t_tuple{}=T2) ->
     glb_tuples(T1, T2);
+glb(other, T) ->
+    case is_other(T) of
+        true -> T;
+        false -> none
+    end;
+glb(T, other) ->
+    glb(other, T);
 glb(_, _) ->
     %% Inconsistent types. There will be an exception at runtime.
     none.
+
+glb_ranges({MinA,MaxA}, {MinB,MaxB}) ->
+    true = inf_le(MinA, MaxA) andalso inf_le(MinB, MaxB), %Assertion.
+    case (inf_ge(MinA, MinB) andalso inf_le(MinA, MaxB)) orelse
+        (inf_ge(MinB, MinA) andalso inf_le(MinB, MaxA)) of
+        true ->
+            true = inf_le(MinA, MaxA) andalso inf_le(MinB, MaxB),   %Assertion.
+            {inf_max(MinA, MinB),inf_min(MaxA, MaxB)};
+        false ->
+            none
+    end;
+glb_ranges({MinA,MaxA}, any) ->
+    {MinA,MaxA};
+glb_ranges(any, {MinB,MaxB}) ->
+    {MinB,MaxB};
+glb_ranges(_, _) ->
+    any.
 
 glb_tuples(#t_tuple{size=Sz1,exact=Ex1}, #t_tuple{size=Sz2,exact=Ex2})
   when Ex1, Sz1 < Sz2;
@@ -918,15 +938,12 @@ lub(#t_cons{type=TypeA,terminator=TermA},
     #t_list{type=join(TypeA,TypeB),terminator=join(TermA, TermB)};
 lub(#t_cons{type=Type,terminator=Term}, nil) ->
     #t_list{type=Type,terminator=Term};
-lub(#t_float{elements={MinA,MaxA}},
-    #t_float{elements={MinB,MaxB}}) ->
-    #t_float{elements={min(MinA,MinB),max(MaxA,MaxB)}};
-lub(#t_float{}, #t_float{}) ->
-    #t_float{};
-lub(#t_float{}, #t_integer{}) ->
-    number;
-lub(#t_float{}, number) ->
-    number;
+lub(#t_float{elements=R1}, #t_float{elements=R2}) ->
+    float_from_range(lub_ranges(R1, R2));
+lub(#t_float{elements=R1}, #t_integer{elements=R2}) ->
+    number_from_range(lub_ranges(R1, R2));
+lub(#t_float{elements=R1}, #t_number{elements=R2}) ->
+    number_from_range(lub_ranges(R1, R2));
 lub(#t_fun{arity=SameArity,target=SameTarget,type=TypeA},
     #t_fun{arity=SameArity,target=SameTarget,type=TypeB}) ->
     #t_fun{arity=SameArity,target=SameTarget,type=join(TypeA, TypeB)};
@@ -934,15 +951,12 @@ lub(#t_fun{arity=SameArity,type=TypeA}, #t_fun{arity=SameArity,type=TypeB}) ->
     #t_fun{arity=SameArity,type=join(TypeA, TypeB)};
 lub(#t_fun{type=TypeA}, #t_fun{type=TypeB}) ->
     #t_fun{type=join(TypeA, TypeB)};
-lub(#t_integer{elements={MinA,MaxA}},
-    #t_integer{elements={MinB,MaxB}}) ->
-    #t_integer{elements={min(MinA,MinB),max(MaxA,MaxB)}};
-lub(#t_integer{}, #t_integer{}) ->
-    #t_integer{};
-lub(#t_integer{}, #t_float{}) ->
-    number;
-lub(#t_integer{}, number) ->
-    number;
+lub(#t_integer{elements=R1}, #t_integer{elements=R2}) ->
+    integer_from_range(lub_ranges(R1, R2));
+lub(#t_integer{elements=R1}, #t_float{elements=R2}) ->
+    number_from_range(lub_ranges(R1, R2));
+lub(#t_integer{elements=R1}, #t_number{elements=R2}) ->
+    number_from_range(lub_ranges(R1, R2));
 lub(#t_list{type=TypeA,terminator=TermA},
     #t_list{type=TypeB,terminator=TermB}) ->
     #t_list{type=join(TypeA, TypeB),terminator=join(TermA, TermB)};
@@ -954,10 +968,12 @@ lub(nil, #t_list{}=T) ->
     T;
 lub(#t_list{}=T, nil) ->
     T;
-lub(number, #t_integer{}) ->
-    number;
-lub(number, #t_float{}) ->
-    number;
+lub(#t_number{elements=R1}, #t_number{elements=R2}) ->
+    number_from_range(lub_ranges(R1, R2));
+lub(#t_number{elements=R1}, #t_integer{elements=R2}) ->
+    number_from_range(lub_ranges(R1, R2));
+lub(#t_number{elements=R1}, #t_float{elements=R2}) ->
+    number_from_range(lub_ranges(R1, R2));
 lub(#t_map{super_key=SKeyA,super_value=SValueA},
     #t_map{super_key=SKeyB,super_value=SValueB}) ->
     %% Note the use of join/2; elements don't need to be normal types.
@@ -973,8 +989,24 @@ lub(#t_tuple{size=SzA,elements=EsA}, #t_tuple{size=SzB,elements=EsB}) ->
     Sz = min(SzA, SzB),
     Es = lub_tuple_elements(Sz, EsA, EsB),
     #t_tuple{size=Sz,elements=Es};
-lub(_T1, _T2) ->
-    %%io:format("~p ~p\n", [_T1,_T2]),
+lub(T1, T2) ->
+    %%io:format("~p ~p\n", [T1,T2]),
+    case is_other(T1) andalso is_other(T2) of
+        true -> other;
+        false -> any
+    end.
+
+is_other(Type) ->
+    AnyMinusOther = #t_union{atom=#t_atom{},
+                             list=#t_list{},
+                             number=#t_number{},
+                             tuple_set=#t_tuple{},
+                             other=none},
+    meet(AnyMinusOther, Type) =:= none.
+
+lub_ranges({MinA,MaxA}, {MinB,MaxB}) ->
+    {inf_min(MinA, MinB), inf_max(MaxA, MaxB)};
+lub_ranges(_, _) ->
     any.
 
 lub_bs_matchable(UnitA, UnitB) ->
@@ -1011,6 +1043,65 @@ gcd(A, B) ->
         X -> gcd(B, X)
     end.
 
+%%%
+%%% Handling of ranges.
+%%%
+%%% A range can begin with '-inf' OR end with '+inf'.
+%%%
+%%% Atoms are greater than all integers. Therefore, we don't
+%%% need any special handling of '+inf'.
+%%%
+
+float_from_range(none) ->
+    none;
+float_from_range(any) ->
+    #t_float{};
+float_from_range({'-inf','+inf'}) ->
+    #t_float{};
+float_from_range({'-inf',Max}) ->
+    #t_float{elements={'-inf',float(Max)}};
+float_from_range({Min,'+inf'}) ->
+    #t_float{elements={float(Min),'+inf'}};
+float_from_range({Min,Max}) ->
+    #t_float{elements={float(Min),float(Max)}}.
+
+integer_from_range(none) ->
+    none;
+integer_from_range(any) ->
+    #t_integer{};
+integer_from_range({'-inf','+inf'}) ->
+    #t_integer{};
+integer_from_range({'-inf',Max}) ->
+    #t_integer{elements={'-inf',ceil(Max)}};
+integer_from_range({Min,'+inf'}) ->
+    #t_integer{elements={floor(Min),'+inf'}};
+integer_from_range({Min,Max}) ->
+    #t_integer{elements={floor(Min),ceil(Max)}}.
+
+number_from_range(N) ->
+    case integer_from_range(N) of
+        #t_integer{elements=R} ->
+            #t_number{elements=R};
+        none ->
+            none
+    end.
+
+inf_le('-inf', _) -> true;
+inf_le(A, B) -> A =< B.
+
+inf_ge(_, '-inf') -> true;
+inf_ge('-inf', _) -> false;
+inf_ge(A, B) -> A >= B.
+
+inf_min(A, B) when A =:= '-inf'; B =:= '-inf' -> '-inf';
+inf_min(A, B) when A =< B -> A;
+inf_min(A, B) when A > B -> B.
+
+inf_max('-inf', B) -> B;
+inf_max(A, '-inf') -> A;
+inf_max(A, B) when A >= B -> A;
+inf_max(A, B) when A < B -> B.
+
 %%
 
 record_key(#t_tuple{exact=true,size=Size,elements=#{ 1 := Tag }}) ->
@@ -1029,8 +1120,6 @@ new_tuple_set(T) ->
 
 %%
 
-shrink_union(#t_union{other=any}) ->
-    any;
 shrink_union(#t_union{atom=Atom,list=none,number=none,
                       tuple_set=none,other=none}) ->
     Atom;
@@ -1049,6 +1138,12 @@ shrink_union(#t_union{atom=none,list=none,number=none,
 shrink_union(#t_union{atom=none,list=none,number=none,
                       tuple_set=none,other=Other}) ->
     Other;
+shrink_union(#t_union{atom=#t_atom{elements=any},
+                      list=#t_list{type=any,terminator=any},
+                      number=#t_number{elements=any},
+                      tuple_set=#t_tuple{size=0,exact=false},
+                      other=other}) ->
+    any;
 shrink_union(#t_union{}=T) ->
     T.
 
@@ -1124,6 +1219,12 @@ verified_normal_type(#t_fun{arity=Arity,
     T;
 verified_normal_type(#t_float{}=T) -> T;
 verified_normal_type(#t_integer{elements=any}=T) -> T;
+verified_normal_type(#t_integer{elements={'-inf',Max}}=T)
+  when is_integer(Max) ->
+    T;
+verified_normal_type(#t_integer{elements={Min,'+inf'}}=T)
+  when is_integer(Min) ->
+    T;
 verified_normal_type(#t_integer{elements={Min,Max}}=T)
   when is_integer(Min), is_integer(Max), Min =< Max ->
     T;
@@ -1133,7 +1234,8 @@ verified_normal_type(#t_list{type=Type,terminator=Term}=T) ->
     T;
 verified_normal_type(#t_map{}=T) -> T;
 verified_normal_type(nil=T) -> T;
-verified_normal_type(number=T) -> T;
+verified_normal_type(#t_number{}=T) -> T;
+verified_normal_type(other=T) -> T;
 verified_normal_type(pid=T) -> T;
 verified_normal_type(port=T) -> T;
 verified_normal_type(reference=T) -> T;

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -29,21 +29,22 @@
 %%  any                      Any Erlang term (top element).
 %%
 %%    - #t_atom{}            Atom, or a set thereof.
-%%    - #t_bs_matchable{}    Binary-matchable types.
-%%        - #t_bitstring{}   Bitstring.
-%%        - #t_bs_context{}  Match context.
-%%    - #t_fun{}             Fun.
-%%    - #t_map{}             Map.
-%%    - number               Any number.
+%%    - #t_number{}          Any number.
 %%       -- #t_float{}       Floating point number.
 %%       -- #t_integer{}     Integer.
 %%    - #t_list{}            Any list.
 %%       -- #t_cons{}        Cons (nonempty list).
 %%       -- nil              The empty list.
-%%    - pid
-%%    - port
-%%    - reference
 %%    - #t_tuple{}           Tuple.
+%%    - other                Other types.
+%%       -- #t_fun{}          Fun.
+%%       -- #t_map{}          Map.
+%%       -- pid
+%%       -- port
+%%       -- reference
+%%       -- #t_bs_matchable{} Binary-matchable types.
+%%         -- #t_bitstring{}    Bitstring.
+%%         -- #t_bs_context{}   Match context.
 %%
 %%  none                     No type (bottom element).
 %%
@@ -83,15 +84,18 @@
 -define(ATOM_SET_SIZE, 5).
 -define(MAX_FUNC_ARGS, 255).
 
+-type float_range() :: 'any' | {'-inf',float()} | {float(),'+inf'}.
+
 -record(t_atom, {elements=any :: 'any' | ordsets:ordset(atom())}).
 -record(t_bitstring, {size_unit=1 :: pos_integer()}).
 -record(t_bs_context, {tail_unit=1 :: pos_integer()}).
 -record(t_bs_matchable, {tail_unit=1 :: pos_integer()}).
--record(t_float, {elements=any :: 'any' | {float(),float()}}).
+-record(t_float, {elements=any :: float_range()}).
 -record(t_fun, {arity=any :: arity() | 'any',
                 target=any :: {atom(), non_neg_integer()} | 'any',
                 type=any :: type() }).
--record(t_integer, {elements=any :: 'any' | {integer(),integer()}}).
+-record(t_integer, {elements=any :: 'any' | beam_bounds:range()}).
+-record(t_number, {elements=any :: 'any' | beam_bounds:range()}).
 
 %% `super_key` and `super_value` are the join of all key and value types.
 %%
@@ -132,27 +136,35 @@
 -define(TUPLE_ELEMENT_LIMIT, 12).
 -type tuple_elements() :: #{ Key :: pos_integer() => type() }.
 
--type normal_type() :: any | none |
-                       number | #t_float{} | #t_integer{} |
+-type normal_type() :: 'any' | 'none' |
+                       #t_number{} | #t_float{} | #t_integer{} |
                        #t_atom{} |
                        #t_bitstring{} | #t_bs_context{} | #t_bs_matchable{} |
                        #t_fun{} |
-                       #t_list{} | #t_cons{} | nil |
+                       #t_list{} | #t_cons{} | 'nil' |
+                       'other' |
                        #t_map{} |
-                       pid |
-                       port |
-                       reference |
+                       'pid' |
+                       'port' |
+                       'reference' |
                        #t_tuple{}.
+
+-type other_type() :: 'none' | #t_fun{} | #t_map{} |
+                      'pid' | 'port' | 'reference' |
+                      #t_bitstring{} | #t_bs_context{} |
+                      #t_bs_matchable{}.
 
 -type record_key() :: {Arity :: integer(), Tag :: normal_type() }.
 -type record_set() :: ordsets:ordset({record_key(), #t_tuple{}}).
 -type tuple_set() :: #t_tuple{} | record_set().
 
--record(t_union, {atom=none :: none | #t_atom{},
-                  list=none :: none | #t_list{} | #t_cons{} | nil,
-                  number=none :: none | number | #t_float{} | #t_integer{},
-                  tuple_set=none :: none | tuple_set(),
-                  other=none :: normal_type()}).
+%% The fields in the union must not overlap. In particular, that means
+%% that the type `any` is not allowed in any field.
+-record(t_union, {atom=none :: 'none' | #t_atom{},
+                  list=none :: 'none' | #t_list{} | #t_cons{} | nil,
+                  number=none :: 'none' | #t_number{} | #t_float{} | #t_integer{},
+                  tuple_set=none :: 'none' | tuple_set(),
+                  other=none :: 'other' | other_type()}).
 
 -type type() :: #t_union{} | normal_type().
 

--- a/lib/compiler/test/beam_bounds_SUITE.erl
+++ b/lib/compiler/test/beam_bounds_SUITE.erl
@@ -25,7 +25,10 @@
          multiplication_bounds/1, division_bounds/1, rem_bounds/1,
          band_bounds/1, bor_bounds/1, bxor_bounds/1,
          bsr_bounds/1, bsl_bounds/1,
-         lt_bounds/1, le_bounds/1, gt_bounds/1, ge_bounds/1]).
+         lt_bounds/1, le_bounds/1, gt_bounds/1, ge_bounds/1,
+         min_bounds/1, max_bounds/1,
+         abs_bounds/1,
+         infer_lt_gt_bounds/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -47,7 +50,11 @@ groups() ->
        lt_bounds,
        le_bounds,
        gt_bounds,
-       ge_bounds]}].
+       ge_bounds,
+       min_bounds,
+       max_bounds,
+       abs_bounds,
+       infer_lt_gt_bounds]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -69,16 +76,47 @@ subtraction_bounds(_Config) ->
     test_noncommutative('-', {-12,12}).
 
 multiplication_bounds(_Config) ->
-    test_commutative('*', {-12,12}).
+    test_commutative('*', {-12,12}),
+
+    {'-inf',-40} = beam_bounds:bounds('*', {'-inf',-20}, {2,5}),
+    {'-inf',1000} = beam_bounds:bounds('*', {'-inf',100}, {1,10}),
+    any = beam_bounds:bounds('*', {'-inf',100}, {-10,10}),
+
+    {-100,'+inf'} = beam_bounds:bounds('*', {-10,'+inf'}, {1,10}),
+    {7,'+inf'} = beam_bounds:bounds('*', {7,'+inf'}, {1,10}),
+    any = beam_bounds:bounds('*', {-10,'+inf'}, {-5,5}),
+
+    {'-inf',1000} = beam_bounds:bounds('*', {1,10}, {'-inf',100}),
+    {-100,'+inf'} = beam_bounds:bounds('*', {1,10}, {-10,'+inf'}),
+
+    ok.
 
 division_bounds(_Config) ->
-    test_noncommutative('div', {-12,12}).
+    test_noncommutative('div', {-12,12}),
+
+    {'-inf',-5} = beam_bounds:bounds('div', {'-inf',-20}, {2,4}),
+    {'-inf',50} = beam_bounds:bounds('div', {'-inf',100}, {2,4}),
+
+    {-5,'+inf'} = beam_bounds:bounds('div', {-10,'+inf'}, {2,4}),
+    {2,'+inf'} = beam_bounds:bounds('div', {10,'+inf'}, {2,4}),
+
+
+    ok.
 
 rem_bounds(_Config) ->
     test_noncommutative('rem', {-12,12}),
 
-    {-7,7} = beam_bounds:'rem'(any, {1,8}),
-    {-11,11} = beam_bounds:'rem'(any, {-12,8}),
+    {-7,7} = beam_bounds:bounds('rem', any, {1,8}),
+    {-11,11} = beam_bounds:bounds('rem', any, {-12,8}),
+
+    {-7,7} = beam_bounds:bounds('rem', {'-inf',10}, {1,8}),
+    {0,7} = beam_bounds:bounds('rem', {10,'+inf'}, {1,8}),
+
+    any = beam_bounds:bounds('rem', {1,10}, {'-inf',10}),
+    any = beam_bounds:bounds('rem', {1,10}, {10,'+inf'}),
+
+    any = beam_bounds:bounds('rem', {-10,10}, {'-inf',10}),
+    any = beam_bounds:bounds('rem', {-10,10}, {10,'+inf'}),
 
     ok.
 
@@ -86,36 +124,66 @@ band_bounds(_Config) ->
     test_commutative('band'),
 
     %% Coverage.
-    {0,17} = beam_bounds:'band'(any, {7,17}),
-    {0,42} = beam_bounds:'band'({0,42}, any),
-    any = beam_bounds:'band'({-1,1}, any),
-    any = beam_bounds:'band'(any, {-10,0}),
-    any = beam_bounds:'band'({-10,0},{-1,10}),
-    any = beam_bounds:'band'({-20,-10},{-1,10}),
+    {0,17} = beam_bounds:bounds('band', any, {7,17}),
+    {0,42} = beam_bounds:bounds('band', {0,42}, any),
+    any = beam_bounds:bounds('band', {-1,1}, any),
+    any = beam_bounds:bounds('band', any, {-10,0}),
+    any = beam_bounds:bounds('band', {-10,0}, {-1,10}),
+    any = beam_bounds:bounds('band', {-20,-10}, {-1,10}),
 
     ok.
 
 bor_bounds(_Config) ->
     test_commutative('bor'),
 
-    any = beam_bounds:'bor'({-10,0},{-1,10}),
-    any = beam_bounds:'bor'({-20,-10},{-1,10}),
+    any = beam_bounds:bounds('bor', {-10,0},{-1,10}),
+    any = beam_bounds:bounds('bor', {-20,-10}, {-1,10}),
 
     ok.
 
 bxor_bounds(_Config) ->
     test_commutative('bxor'),
 
-    any = beam_bounds:'bxor'({-10,0},{-1,10}),
-    any = beam_bounds:'bxor'({-20,-10},{-1,10}),
+    any = beam_bounds:bounds('bxor', {-10,0}, {-1,10}),
+    any = beam_bounds:bounds('bxor', {-20,-10}, {-1,10}),
 
     ok.
 
 bsr_bounds(_Config) ->
-    test_noncommutative('bsr', {-12,12}, {0,7}).
+    test_noncommutative('bsr', {-12,12}, {0,7}),
+
+    {0,10} = beam_bounds:bounds('bsr', {0,10}, {0,'+inf'}),
+    {0,2} = beam_bounds:bounds('bsr', {0,10}, {2,'+inf'}),
+
+    {-1,10} = beam_bounds:bounds('bsr', {-1,10}, {0,'+inf'}),
+    {-100,900} = beam_bounds:bounds('bsr', {-100,900}, {0,'+inf'}),
+    {-50,450} = beam_bounds:bounds('bsr', {-100,900}, {1,'+inf'}),
+
+    {'-inf',16} = beam_bounds:bounds('bsr', {'-inf',32}, {1,10}),
+    {-5,'+inf'} = beam_bounds:bounds('bsr', {-10,'+inf'}, {1,10}),
+
+    ok.
 
 bsl_bounds(_Config) ->
-    test_noncommutative('bsl', {-12,12}, {0,7}).
+    test_noncommutative('bsl', {-12,12}, {-7,7}),
+
+    {2,'+inf'} = beam_bounds:bounds('bsl', {1,10}, {1,10_000}),
+    {0,'+inf'} = beam_bounds:bounds('bsl', {1,10}, {-10,10_000}),
+    any = beam_bounds:bounds('bsl', {-7,10}, {1,10_000}),
+
+    any = beam_bounds:bounds('bsl', {-10,100}, {0,'+inf'}),
+    any = beam_bounds:bounds('bsl', {-10,100}, {1,'+inf'}),
+    any = beam_bounds:bounds('bsl', {-10,100}, {-1,'+inf'}),
+
+    {0,10} = beam_bounds:bounds('bsl', {1,10}, {'-inf',0}),
+    {0,20} = beam_bounds:bounds('bsl', {1,10}, {'-inf',1}),
+    {-7,10} = beam_bounds:bounds('bsl', {-7,10}, {'-inf',0}),
+    {-28,40} = beam_bounds:bounds('bsl', {-7,10}, {'-inf',2}),
+
+    {'-inf',-1} = beam_bounds:bounds('bsl', {-10,-1}, {500,1024}),
+    {0,'+inf'} = beam_bounds:bounds('bsl', {1,10}, {500,1024}),
+
+    ok.
 
 lt_bounds(_Config) ->
     test_relop('<').
@@ -129,7 +197,97 @@ gt_bounds(_Config) ->
 ge_bounds(_Config) ->
     test_relop('>=').
 
+min_bounds(_Config) ->
+    test_commutative(min, {-12,12}),
+
+    {'-inf',-10} = min_bounds({'-inf',-10}, {1,100}),
+    {'-inf',1} = min_bounds({'-inf',1}, {1,100}),
+    {'-inf',50} = min_bounds({'-inf',50}, {1,100}),
+    {'-inf',100} = min_bounds({'-inf',500}, {1,100}),
+
+    {'-inf',-10} = min_bounds({'-inf',-10}, {1,'+inf'}),
+    {'-inf',1} = min_bounds({'-inf',1}, {1,'+inf'}),
+    {'-inf',700} = min_bounds({'-inf',700}, {1,'+inf'}),
+
+    {1,99} = min_bounds({1,99}, {100,'+inf'}),
+    {1,100} = min_bounds({1,100}, {100,'+inf'}),
+    {100,200} = min_bounds({150,200}, {100,'+inf'}),
+
+    ok.
+
+min_bounds(R1, R2) ->
+    Result = beam_bounds:bounds(min, R1, R2),
+    Result = beam_bounds:bounds(min, R2, R1).
+
+max_bounds(_Config) ->
+    test_commutative(max, {-12,12}),
+
+    {1,100} = max_bounds({'-inf',-10}, {1,100}),
+    {1,100} = max_bounds({'-inf',1}, {1,100}),
+    {1,100} = max_bounds({'-inf',50}, {1,100}),
+    {1,500} = max_bounds({'-inf',500}, {1,100}),
+
+    {1,'+inf'}  = max_bounds({'-inf',-10}, {1,'+inf'}),
+    {1,'+inf'} = max_bounds({'-inf',1}, {1,'+inf'}),
+    {1,'+inf'} = max_bounds({'-inf',700}, {1,'+inf'}),
+
+    {100,'+inf'} = max_bounds({1,99}, {100,'+inf'}),
+    {100,'+inf'} = max_bounds({1,100}, {100,'+inf'}),
+    {150,'+inf'} = max_bounds({150,200}, {100,'+inf'}),
+
+    ok.
+
+max_bounds(R1, R2) ->
+    Result = beam_bounds:bounds(max, R1, R2),
+    Result = beam_bounds:bounds(max, R2, R1).
+
+abs_bounds(_Config) ->
+    Min = -7,
+    Max = 7,
+    Seq = lists:seq(Min, Max),
+    _ = [abs_bounds_1({A,B}) ||
+            A <- Seq,
+            B <- lists:nthtail(A-Min, Seq)],
+    ok.
+
+abs_bounds_1(R) ->
+    {HighestMin,LowestMax} = min_max_unary_op('abs', R),
+    {Min,Max} = beam_bounds:bounds(abs, R),
+    if
+        Min =< HighestMin, LowestMax =< Max ->
+            ok;
+        true ->
+            io:format("~p(~p) evaluates to ~p; should be ~p\n",
+                      [bif_abs,R,{Min,Max},{HighestMin,LowestMax}]),
+            ct:fail(bad_min_or_max)
+        end.
+
+infer_lt_gt_bounds(_Config) ->
+    {{'-inf',-1}, {'-inf',0}} = infer_lt_gt({'-inf',0}, {'-inf',0}),
+    {{'-inf',1}, {'-inf',2}} = infer_lt_gt({'-inf',1}, {'-inf',2}),
+    {{'-inf',-2}, {'-inf',-1}} = infer_lt_gt({'-inf',1}, {'-inf',-1}),
+    {{'-inf',2}, {1,3}} = infer_lt_gt({'-inf',2}, {1,3}),
+
+    any = infer_lt_gt({'-inf',2}, {3,10}),
+    any = infer_lt_gt({'-inf',2}, {3,'+inf'}),
+
+    {{0,10}, {1,84}}  = infer_lt_gt({0,10}, {'-inf',84}),
+    {{0,83}, {1,84}}  = infer_lt_gt({0,'+inf'}, {'-inf',84}),
+
+    {{0,'+inf'}, {42, '+inf'}}  = infer_lt_gt({0,'+inf'}, {42, '+inf'}),
+    {{100,'+inf'}, {101, '+inf'}}  = infer_lt_gt({100,'+inf'}, {42, '+inf'}),
+
+    ok.
+
 %%% Utilities
+
+infer_lt_gt(R1, R2) ->
+    case beam_bounds:infer_relop_types('>', R2, R1) of
+        {Rb,Ra} ->
+            {Ra,Rb} = beam_bounds:infer_relop_types('<', R1, R2);
+        any ->
+            any = beam_bounds:infer_relop_types('<', R1, R2)
+    end.
 
 test_commutative(Op) ->
     test_commutative(Op, {0,32}).
@@ -146,8 +304,8 @@ test_commutative(Op, {Min,Max}) ->
 
 test_commutative_1(Op, R1, R2) ->
     {HighestMin,LowestMax} = min_max_op(Op, R1, R2),
-    {Min,Max} = beam_bounds:Op(R1, R2),
-    {Min,Max} = beam_bounds:Op(R2, R1),
+    {Min,Max} = beam_bounds:bounds(Op, R1, R2),
+    {Min,Max} = beam_bounds:bounds(Op, R2, R1),
     if
         Min =< HighestMin, LowestMax =< Max ->
             ok;
@@ -156,6 +314,7 @@ test_commutative_1(Op, R1, R2) ->
                       [Op,R1,R2,{Min,Max},{HighestMin,LowestMax}]),
             ct:fail(bad_min_or_max)
         end.
+
 test_noncommutative(Op, Range) ->
     test_noncommutative(Op, Range, Range).
 
@@ -171,7 +330,7 @@ test_noncommutative(Op, {Min1,Max1}, {Min2,Max2}) ->
 
 test_noncommutative_1(Op, R1, R2) ->
     {HighestMin,LowestMax} = min_max_op(Op, R1, R2),
-    case beam_bounds:Op(R1, R2) of
+    case beam_bounds:bounds(Op, R1, R2) of
         any ->
             case {Op,R2} of
                 {'rem',{0,0}} -> ok
@@ -206,6 +365,20 @@ min_max_op_2(Op, A, C, D, MinMax) when C =< D ->
 min_max_op_2(_Op, _, _, _, MinMax) ->
     MinMax.
 
+min_max_unary_op(Op, {A,B}) ->
+    min_max_unary_op_1(Op, A, B, {infinity,-(1 bsl 24)}).
+
+min_max_unary_op_1(Op, A, B, {Min,Max}) when A =< B ->
+    Val = erlang:Op(A),
+    if
+        Min =< Val, Val =< Max ->
+            min_max_unary_op_1(Op, A + 1, B, {Min,Max});
+        true ->
+            min_max_unary_op_1(Op, A + 1, B, {min(Min, Val),max(Max, Val)})
+    end;
+min_max_unary_op_1(_Op, _, _, MinMax) ->
+    MinMax.
+
 test_relop(Op) ->
     Max = 15,
     Seq = lists:seq(0, Max),
@@ -220,12 +393,42 @@ test_relop_1(Op, R1, R2) ->
     Bool = rel_op(Op, R1, R2),
     case beam_bounds:relop(Op, R1, R2) of
         Bool ->
-            ok;
+            test_infer_relop(Bool, Op, R1, R2);
         Wrong ->
             io:format("~p(~p, ~p) evaluates to ~p; should be ~p\n",
                       [Op,R1,R2,Wrong,Bool]),
             ct:fail(bad_bool_result)
     end.
+
+test_infer_relop(Bool, Op, R1, R2) when is_boolean(Bool) ->
+    any = beam_bounds:infer_relop_types(Op, R1, R2);
+test_infer_relop('maybe', Op, {A0,B0}=R1, {C0,D0}=R2) ->
+    {{A,B},{C,D}} = beam_bounds:infer_relop_types(Op, R1, R2),
+    if
+        A =< B, C =< D, A0 =< A, B0 >= B, C0 =< C, D0 >= D ->
+            ok;
+        true ->
+            io:format("~p ~p infers as ~p ~p\n",
+                      [R1,R2,{A,B},{C,D}]),
+            ct:fail(ranges_grew)
+    end,
+    _ = [begin
+             case in_range(X, {A,B}) andalso in_range(Y, {C,D}) of
+                 true ->
+                     ok;
+                 false ->
+                     io:format("X = ~p; Y = ~p\n", [X,Y]),
+                     io:format("~p ~p infers as ~p ~p\n",
+                               [R1,R2,{A,B},{C,D}]),
+                     ct:fail(bad_inference)
+             end
+         end || X <- lists:seq(A0, B0),
+                Y <- lists:seq(C0, D0),
+                erlang:Op(X, Y)],
+    ok.
+
+in_range(Int, {A,B}) ->
+    A =< Int andalso Int =< B.
 
 rel_op(Op, {A,B}, {C,D}) ->
     rel_op_1(Op, A, B, C, D, none).

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -104,6 +104,15 @@ integers(_Config) ->
 
     -693 = do_integers_9(id(7), id(1)),
 
+    3 = do_integers_10(1, 2),
+    10 = do_integers_10(-2, -5),
+
+    {'EXIT',{badarith,_}} = catch do_integers_11(42),
+    {'EXIT',{badarith,_}} = catch do_integers_11({a,b}),
+
+    {'EXIT',{system_limit,_}} = catch do_integers_12(42),
+    {'EXIT',{system_limit,_}} = catch do_integers_12([]),
+
     ok.
 
 do_integers_1(B0) ->
@@ -175,6 +184,18 @@ do_integers_8() ->
 do_integers_9(X, Y) ->
     X * (-100 bor (Y band 1)).
 
+do_integers_10(A, B) when is_integer(A), is_integer(B), A < 2, B < 5 ->
+    if
+        A < B -> A + B;
+        true -> A * B
+    end.
+
+do_integers_11(V) ->
+    true - V bsl [].
+
+do_integers_12(X) ->
+    (1 bsl (1 bsl 100)) + X.
+
 numbers(_Config) ->
     Int = id(42),
     true = is_integer(Int),
@@ -226,7 +247,15 @@ numbers(_Config) ->
     Meet1 = id(0) + -10.0,                       %Float.
     10.0 = abs(Meet1),                           %Number.
 
+    %% Cover code in beam_call_types:beam_bounds_type/3.
+    ok = fcmp(0.0, 1.0),
+    error = fcmp(1.0, 0.0),
+
     ok.
+
+fcmp(0.0, 0.0) -> ok;
+fcmp(F1, F2) when (F1 - F2) / F2 < 0.0000001 -> ok;
+fcmp(_, _) -> error.
 
 coverage(Config) ->
     {'EXIT',{badarith,_}} = (catch id(1) bsl 0.5),

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -2027,7 +2027,7 @@ types_pp(Config) when is_list(Config) ->
                      "{any(), any(), any(), any(), any()}"},
                     {make_inexact_tuple, "{any(), any(), any(), ...}"},
                     {make_union,
-                     "'foo' | nonempty_list(1..3) | number() |"
+                     "'foo' | nonempty_list(1..3) | number(3, 7) |"
                      " {'tag0', 1, 2} | {'tag1', 3, 4} | bitstring(24)"},
                     {make_bitstring, "bitstring(24)"},
                     {make_none, "none()"}],


### PR DESCRIPTION
Refactor the type analysis modules in the Erlang compiler to
be able to derive type information from relational operators
in guards.

Consider this function:

    f(A) when is_integer(A), 0 =< A, A =< 1000 ->
        A + 1.

From the guard, a human can easily figure out that `A` must be
an integer in the range 0 through 1000. The compiler in OTP 25
cannot:

    {test,is_integer,{f,1},[{x,0}]}.
    {test,is_ge,{f,1},[{tr,{x,0},{t_integer,any}},{integer,0}]}.
    {test,is_ge,{f,1},[{integer,1000},{tr,{x,0},{t_integer,any}}]}.
    {gc_bif,'+',{f,0},1,[{tr,{x,0},{t_integer,any}},{integer,1}],{x,0}}.

With this pull request, the compiler generates the following code:

    {test,is_integer,{f,1},[{x,0}]}.
    {test,is_ge,{f,1},[{tr,{x,0},{t_integer,any}},{integer,0}]}.
    {test,is_ge,{f,1},[{integer,1000},{tr,{x,0},{t_integer,{0,'+inf'}}}]}.
    {gc_bif,'+',{f,0},1,[{tr,{x,0},{t_integer,{0,1000}}},{integer,1}],{x,0}}.

The compiler can now also derive better types for the following function:

    g(A) when 0 =< A, A =< 1000 ->
         A + 1.

Since `A` is sandwiched between two numbers, `A` must be a number:

    {test,is_ge,{f,3},[{x,0},{integer,0}]}.
    {test,is_ge,
          {f,3},
          [{integer,1000},
           {tr,{x,0},
               {t_union,{t_atom,any},
                        {t_list,any,any},
                        {t_number,{0,'+inf'}},
                        {t_tuple,0,false,#{}},
                        other}}]}.
    {gc_bif,'+',{f,0},1,[{tr,{x,0},{t_number,{0,1000}}},{integer,1}],{x,0}}.

The JIT will generate slightly better code for known numeric operands than
for unknown operands.

As part of this commit, the following major changes were made:

* Ranges for integers can now extend to infinity at one endpoint. That
  is, a range can go from negative infinity to some integer, or from
  some integer to positive infinity. That change allows the compiler to
  represent the type for the variable `A` when `A` is known to be an
  integer and `A >= 0` is true.

* Changed the number type to also include a (potentially infinite) range.

* Introduced an `other` type as a mean to construct a union type that
  is equivalent to the `any` type. That makes it possible to represent
  the type for `A` when all we know is that `A >= 0` (see the type in
  in the second `is_ge` test in the generated code for `g/1` above).

* The API for the `beam_bounds` module was changed to avoid having to
  create functions with the same name as operators and BIFs. Having
  functions named `min` and `max` in the module would have been
  error-prone and painful.