### PR TITLE
Revert bug fix that caused much more problems than it solved

### DIFF
--- a/lib/compiler/test/property_test/compile_prop.erl
+++ b/lib/compiler/test/property_test/compile_prop.erl
@@ -37,7 +37,9 @@
 -import(lists, [duplicate/2,foldl/3]).
 
 compile() ->
-    Opts = [{resize,true}],
+    %% {weight, {yes_multi_field_init, 0}}
+    Opts = [{weight, {yes_multi_field_init, 0}},
+            {resize,true}],
     ?FORALL(Abstr, proper_erlang_abstract_code:module(Opts),
             compile(Abstr)).
 

--- a/lib/compiler/test/record_SUITE.erl
+++ b/lib/compiler/test/record_SUITE.erl
@@ -28,8 +28,7 @@
 	 init_per_testcase/2,end_per_testcase/2,
 	 errors/1,record_test_2/1,record_test_3/1,record_access_in_guards/1,
 	 guard_opt/1,eval_once/1,foobar/1,missing_test_heap/1,
-	 nested_access/1,coverage/1,grab_bag/1,slow_compilation/1,
-         wildcard_init/1]).
+	 nested_access/1,coverage/1,grab_bag/1,slow_compilation/1]).
 
 init_per_testcase(_Case, Config) ->
     Config.
@@ -49,7 +48,7 @@ groups() ->
       [errors,record_test_2,record_test_3,
        record_access_in_guards,guard_opt,eval_once,foobar,
        missing_test_heap,nested_access,coverage,grab_bag,
-       slow_compilation,wildcard_init]}].
+       slow_compilation]}].
 
 
 init_per_suite(Config) ->
@@ -746,21 +745,6 @@ slow_compilation(Config) when is_list(Config) ->
      {f56,R#slow_r.f56},{f57,R#slow_r.f57},{f58,R#slow_r.f58},
      {f59,R#slow_r.f59}].
 
-wildcard_init(_Config) ->
-    {42,#foo{a=1,b=2,c=3,d=4}} = wc_init_1(),
-    error = wc_init_2(),
-    ok.
-
-wc_init_1() ->
-    R = #foo{a=1,b=2,c=3,d=4,_=V=42},
-    {V,R}.
-
-wc_init_2() when #foo{a=1,b=2,c=3,d=4,_=42} -> ok;
-wc_init_2() -> error.
-
-
 first_arg(First, _) -> First.
-
-
 
 id(I) -> I.

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -310,28 +310,9 @@ expr({record_index,Anno,Name,F}, St) ->
     expr(I, St);
 expr({record,Anno0,Name,Is}, St) ->
     Anno = mark_record(Anno0, St),
-    case record_inits(record_fields(Name, Anno0, St), Is) of
-        {Inits,none} ->
-            %% There is no wildcard init or it was used at
-            %% least once.
-            expr({tuple,Anno,[{atom,Anno0,Name}|Inits]}, St);
-        {Inits,WcInits} ->
-            %% There is a wildcard init that was never used
-            %% because all fields had their own explicit inits.
-            %% Be sure to use the wildcard init in case it
-            %% binds any variables. Example:
-            %%
-            %%  -record(r, {a}).
-            %%  foo() ->
-            %%      R = #r{a = [], _ = V = 42},
-            %%      {R,V}.
-            %%
-            EmptyAnno = no_compiler_warning(erl_anno:new(0)),
-            Block = {block,EmptyAnno,
-                     [WcInits,
-                      {tuple,Anno,[{atom,Anno0,Name}|Inits]}]},
-            expr(Block, St)
-    end;
+    expr({tuple,Anno,[{atom,Anno0,Name} |
+                      record_inits(record_fields(Name, Anno0, St), Is)]},
+         St);
 expr({record_field,_A,R,Name,F}, St) ->
     Anno = erl_parse:first_anno(R),
     get_record_field(Anno, R, F, Name, St);
@@ -683,37 +664,20 @@ pattern_fields(Fs, Ms) ->
 		end
 	end, Fs).
 
-%% record_inits([RecDefField], [Init]) -> {[InitExpr],WildcardInit}.
+%% record_inits([RecDefField], [Init]) -> [InitExpr].
 %%  Build a list of initialisation expressions for the record tuple
 %%  elements. This expansion must be passed through expr
 %%  again. N.B. We are scanning the record definition field list!
 
 record_inits(Fs, Is) ->
     WildcardInit = record_wildcard_init(Is),
-    record_inits_1(Fs, Is, WildcardInit, false, []).
-
-record_inits_1([{record_field,_,{atom,_,F},Def}|Fs],
-               Is, WcInit, WcUsed, Acc) ->
-    case find_field(F, Is) of
-        {ok,Init} ->
-            record_inits_1(Fs, Is, WcInit, WcUsed, [Init|Acc]);
-        error when WcInit =:= none ->
-            record_inits_1(Fs, Is, WcInit, WcUsed, [Def|Acc]);
-        error ->
-            record_inits_1(Fs, Is, WcInit, true, [WcInit|Acc])
-    end;
-record_inits_1([], _Is, WcInit0, WcUsed, Acc) ->
-    WcInit = case {WcUsed,is_in_guard()} of
-                 {false,false} ->
-                     %% This code is in a body and the wildcard init
-                     %% expression (if any) was never used.
-                     WcInit0;
-                 {_,_} ->
-                     %% The wildcard init was either used at least
-                     %% once or this code is in a guard.
-                     none
-             end,
-    {reverse(Acc),WcInit}.
+    map(fun ({record_field,_,{atom,_,F},D}) ->
+                case find_field(F, Is) of
+                    {ok,Init} -> Init;
+                    error when WildcardInit =:= none -> D;
+                    error -> WildcardInit
+                end
+	end, Fs).
 
 record_wildcard_init([{record_field,_,{var,_,'_'},D} | _]) -> D;
 record_wildcard_init([_ | Is]) -> record_wildcard_init(Is);

--- a/lib/stdlib/test/erl_expand_records_SUITE.erl
+++ b/lib/stdlib/test/erl_expand_records_SUITE.erl
@@ -217,19 +217,6 @@ init(Config) when is_list(Config) ->
                  #r{b = b, _ = init} -> ok;
                  _ -> not_ok
              end.
-      ">>,
-      <<"-record(r, {a}).
-        t() ->
-            {42,#r{a=[]}} = foo(),
-            error = bar(),
-            ok.
-
-        foo() ->
-            R = #r{a = [], _ = V = 42},
-            {V,R}.
-
-        bar() when #r{a = [], _ = 42} -> ok;
-        bar() -> error.
       ">>
       ],
     run(Config, Ts),


### PR DESCRIPTION
Revert to the pre-OTP-25 behaviour when binding to `_` when all other fields had already been initialised.