### PR TITLE
gen_event: store callbacks in handler record

### DIFF
--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -79,13 +79,6 @@
 				     {swap_handler, Reply :: term(), Args1 :: term(), NewState :: term(),
 				      Handler2 :: (atom() | {atom(), Id :: term()}), Args2 :: term()} |
 				     {remove_handler, Reply :: term()}),
-		  handle_info = error(uninitialized_handle_info)
-			      :: fun((Info :: term(), State :: term()) ->
-				     {ok, NewState :: term()} |
-				     {ok, NewState :: term(), hibernate} |
-				     {swap_handler, Args1 :: term(), NewState :: term(),
-				      Handler2 :: (atom() | {atom(), Id :: term()}), Args2 :: term()} |
-				     remove_handler),
 		  id = false,
 		  state,
 		  supervised = false :: 'false' | pid()}).
@@ -836,7 +829,7 @@ server_update_slow(Handler1, Event, SName, Result) ->
 
 -compile({inline, [get_callback/2]}).
 get_callback(handle_event, #handler{handle_event = Fun}) -> Fun;
-get_callback(handle_info, #handler{handle_info = Fun}) -> Fun.
+get_callback(handle_info, #handler{module = Mod}) -> fun Mod:handle_info/2.
 
 do_swap(Mod1, Handler1, Args1, State1, Handler2, Args2, SName) ->
     %% finalise the existing handler
@@ -862,7 +855,6 @@ mk_handler({Mod, Id}, Parent) ->
     #handler{module = Mod,
 	     handle_event = fun Mod:handle_event/2,
 	     handle_call = fun Mod:handle_call/2,
-	     handle_info = fun Mod:handle_info/2,
 	     id = Id,
 	     supervised = Parent};
 mk_handler(Mod, Parent) when is_atom(Mod) -> mk_handler({Mod, _Id = false}, Parent).

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -685,8 +685,8 @@ print_event(Dev, Dbg, Name) ->
 %%   event handler
 
 server_add_handler(ModId, Args, MSL) ->
-    Handler = mk_handler(ModId),
-    server_add_handler(Handler#handler.module, Handler, Args, MSL).
+    {Mod, Handler} = mk_handler(ModId),
+    server_add_handler(Mod, Handler, Args, MSL).
 
 server_add_handler(Mod, Handler, Args, MSL) ->
     case catch Mod:init(Args) of
@@ -705,8 +705,8 @@ server_add_handler(Mod, Handler, Args, MSL) ->
 %% own link to this process.
 server_add_sup_handler(ModId, Args, MSL, Parent) ->
     link(Parent),
-    Handler = mk_handler(ModId, Parent),
-    server_add_handler(Handler#handler.module, Handler, Args, MSL).
+    {Mod, Handler} = mk_handler(ModId, Parent),
+    server_add_handler(Mod, Handler, Args, MSL).
 
 %% server_delete_handler(HandlerId, Args, MSL) -> {Ret, MSL'}
 
@@ -839,16 +839,16 @@ do_swap(Mod1, Handler1, Args1, State1, Handler2, Args2, SName) ->
     end.
 
 new_handler(ModId, Handler1) ->
-    Handler = mk_handler(ModId, Handler1#handler.supervised),
-    {Handler#handler.module, Handler}.
+    mk_handler(ModId, Handler1#handler.supervised).
 
 mk_handler(ModId) -> mk_handler(ModId, _Parent = false).
 
 mk_handler({Mod, Id}, Parent) ->
-    #handler{module = Mod,
-	     handle_event = fun Mod:handle_event/2,
-	     id = Id,
-	     supervised = Parent};
+    {Mod,
+     #handler{module = Mod,
+	      handle_event = fun Mod:handle_event/2,
+	      id = Id,
+	      supervised = Parent}};
 mk_handler(Mod, Parent) when is_atom(Mod) -> mk_handler({Mod, _Id = false}, Parent).
 
 -spec split(handler(), [#handler{}]) ->


### PR DESCRIPTION
This was inspired by the PR to cache callback funs in gen_server (https://github.com/erlang/otp/pull/5831) but applies to gen_event instead. Same idea: store callback funs and invoke those instead of going though apply-like Mod:Func(...) calls. In my environments I'm generally seeing a 2x to 3x speedup for the fun calls using Lukas' micro-benchmark in that other PR.

There's also some refactoring to reduce the amount of duplicated code for initializing handlers. The server_update functions are refactored to avoid fetching data we don't need in the fast paths. The format_status/2 change is there to prevent leaking the internal data structure change which would regress gen_event_SUITE.