### PR TITLE
Fix a bug that `mnesia:add_table_copy/3` could hold a read lock forever

### DIFF
--- a/lib/mnesia/src/mnesia_loader.erl
+++ b/lib/mnesia/src/mnesia_loader.erl
@@ -1014,15 +1014,15 @@ finish_copy(Pid, Tab, Storage, RemoteS, NeedLock) ->
                         mnesia_checkpoint:tm_add_copy(Tab, RecNode),
                         DatBin = dat2bin(Tab, ?catch_val({Tab, storage_type}), RemoteS),
                         Pid ! {self(), {no_more, DatBin}},
-                        cleanup_tab_copier(Pid, Storage, Tab)
-                end,
-		receive
-		    {Pid, no_more} -> % Dont bother about the spurious 'more' message
-			no_more;
-		    {copier_done, Node} ->
-			verbose("Tab receiver ~tp crashed (more): ~p~n", [Tab, Node]),
-			receiver_died
-		end
+                        cleanup_tab_copier(Pid, Storage, Tab),
+                        receive
+                            {Pid, no_more} -> % Dont bother about the spurious 'more' message
+                                no_more;
+                            {copier_done, Node} ->
+                                verbose("Tab receiver ~tp crashed (more): ~p~n", [Tab, Node]),
+                                receiver_died
+                        end
+                end
 	end,
     mnesia:transaction(Trans).
 

--- a/lib/mnesia/test/mnesia_evil_coverage_test.erl
+++ b/lib/mnesia/test/mnesia_evil_coverage_test.erl
@@ -30,7 +30,7 @@
 -export([system_info/1, table_info/1, error_description/1,
          db_node_lifecycle/1, evil_delete_db_node/1, start_and_stop/1,
          checkpoint/1, table_lifecycle/1, storage_options/1,
-         add_copy_conflict/1, add_copy_when_going_down/1,
+         add_copy_conflict/1, add_copy_when_going_down/1, add_copy_when_dst_going_down/1,
          add_copy_with_down/1,
          replica_management/1, clear_table_during_load/1,
          schema_availability/1, local_content/1,
@@ -66,7 +66,8 @@ all() ->
      db_node_lifecycle, evil_delete_db_node, start_and_stop,
      checkpoint, table_lifecycle, storage_options, 
      add_copy_conflict,
-     add_copy_when_going_down, add_copy_with_down, replica_management,
+     add_copy_when_going_down, add_copy_when_dst_going_down, add_copy_with_down,
+     replica_management,
      clear_table_during_load,
      schema_availability, local_content,
      {group, table_access_modifications}, replica_location,
@@ -734,6 +735,54 @@ add_copy_when_going_down(Config) ->
     mnesia_test_lib:kill_mnesia([Node1]),
     ?match_receive({test,{aborted,_}}),
     ?verify_mnesia([Node2], []).
+
+add_copy_when_dst_going_down(suite) -> [];
+add_copy_when_dst_going_down(doc) ->
+    ["Table copy destination node goes down. Verify that the issue fixed in erlang/otp#6013 doesn't happen again, whitebox testing."];
+add_copy_when_dst_going_down(Config) ->
+    [Node1, Node2] = ?acquire_nodes(2, Config),
+    ?match({atomic, ok}, mnesia:create_table(a, [{ram_copies, [Node1]}])),
+    lists:foreach(fun(I) ->
+                          ok = mnesia:sync_dirty(fun() -> mnesia:write({a, I, I}) end)
+                  end,
+                  lists:seq(1, 100000)),
+    ?match({ok, _}, mnesia:change_config(extra_db_nodes, [Node2])),
+
+    %% Start table copy
+    Tester = self(),
+    spawn_link(fun() ->
+                       mnesia:add_table_copy(a, Node2, ram_copies),
+                       Tester ! add_table_copy_finished
+               end),
+    timer:sleep(10),  % Wait for `mnesia_loader:send_more/6` has started
+
+    %% Grab a write lock
+    spawn_link(fun() ->
+                       Fun = fun() ->
+                                     ok = mnesia:write_lock_table(a),
+                                     Tester ! {write_lock_acquired, self()},
+                                     receive node2_mnesia_killed -> ok
+                                     end,
+                                     Tester ! write_lock_released,
+                                     ok
+                             end,
+                       mnesia:transaction(Fun)
+               end),
+    receive {write_lock_acquired, Locker} -> ok
+    end,
+    timer:sleep(200),  % Wait for `mnesia_loader:send_more/6` has finished
+    ?match([], mnesia_test_lib:kill_mnesia([Node2])),
+    Locker ! node2_mnesia_killed,
+
+    receive write_lock_released -> ok
+    end,
+    receive add_table_copy_finished -> ok
+    end,
+    timer:sleep(1000),  % Wait for `mnesia_loader:finish_copy/5` has acquired the read lock
+
+    %% Grab a write lock
+    ?match({atomic, ok}, mnesia:transaction(fun() -> mnesia:write_lock_table(a) end, 10)),
+    ?verify_mnesia([Node1], []).
 
 add_copy_with_down(suite) -> [];
 add_copy_with_down(Config) ->


### PR DESCRIPTION
Hi, 

I found a rare mnesia bug that could occure when a node ("A") executes `mnesia:add_table_copy/3` to send a table data to another node ("B").
If node B terminated during the sending process, node A could hold a read lock forever because that waits for an already received message `{copier_done, node()}` again in a transaction after acquiring a read lock.
This PR fixes the redundant `receive`s to prevent the problem.

## Example code to reproduce the problem

Because this problem is inherently timing dependent, it's difficult to write a deterministic reproducing code. However, the following example code can reproduce the issue with almost 100% probability on my laptop.

```erlang
-module(mnesia_debug).

-export([run/0]).

%% For RPC.
-export([init_node0/0, init_node1/0, add_table_copy/2]).

-record(table, {foo, bar, baz}).

run() ->
    {ok, Pid0, _Node0} = peer:start_link(#{name => peer:random_name(), connection => standard_io}),
    {ok, Pid1, Node1} = peer:start_link(#{name => peer:random_name(), connection => standard_io}),
    io:format("Started peer nodes\n"),

    ok = peer:call(Pid0, ?MODULE, init_node0, []),
    io:format("Initialized node0: started mnesia, created table, inserted data\n"),

    ok = peer:call(Pid1, ?MODULE, init_node1, []),
    io:format("Initialized node1: started mnesia\n"),

    {ok, _} = peer:call(Pid0, mnesia, change_config, [extra_db_nodes, [Node1]]),
    io:format("Added node1 to the `extra_db_nodes` of node`\n"),

    MainPid = self(),

    peer:cast(Pid0, ?MODULE, add_table_copy, [Node1, MainPid]),
    timer:sleep(10),  % Wait for `mnesia_loader:send_more/6` has started
    io:format("Started sending table data from node0 to node1\n"),

    AcquireLockFun = fun() ->
                             io:format("Acquire write lock to block the transaction in `mnesia_loader:finish_copy/5`\n"),
                             ok = mnesia:write_lock_table(table),
                             MainPid ! {write_lock_acquired, self()},
                             io:format("Acquired write lock\n"),
                             receive 
                                 node1_stopped -> ok
                             end,
                             io:format("Released write lock\n"),
                             MainPid ! write_lock_released,
                             ok
                     end,
    peer:cast(Pid0, mnesia, transaction, [AcquireLockFun]),

    receive
        {write_lock_acquired, LockPid} -> ok
    end,
    timer:sleep(200),  % Wait for `mnesia_loader:send_more/6` has finished
    ok = peer:stop(Pid1),
    LockPid ! node1_stopped,
    io:format("Stopped node1 so that the `{copier_done, Node1}` message will be received in `mnesia_loader:finish_copy/5`\n"),

    receive
        write_lock_released -> ok
    end,
    receive
        add_table_copy_finished -> ok
    end,
    timer:sleep(1000),  % Wait for `mnesia_loader:finish_copy/5` has acquired the read lock

    io:format("Try acquiring write lock. This call will be timed out (due to the bug).\n"),
    {atomic, ok} = peer:call(Pid0, mnesia, transaction, [fun() -> mnesia:write_lock_table(table) end]),
    io:format("Unexpectedlly acquired write lock\n"),

    ok = peer:stop(Pid0),
    io:format("Stopped node0\n"),

    ok.

init_node0() ->
    ok = mnesia:create_schema([node()]),
    ok = mnesia:start(),
    {atomic, ok} = mnesia:create_table(table, [{attributes, record_info(fields, table)}, {ram_copies, [node()]}]),

    Fun = fun() ->
                  lists:foreach(fun(I) -> ok = mnesia:write(#table{foo = I, bar = I, baz = I}) end,
                                lists:seq(1, 100000))
          end,
    {atomic, ok} = mnesia:transaction(Fun),
    ok.

init_node1() ->
    ok = mnesia:start(),
    ok.

add_table_copy(Node1, MainPid) ->
    mnesia:add_table_copy(table, Node1, ram_copies),
    MainPid ! add_table_copy_finished.
```

Execution result:
```erlang
$ erl -name foo@127.0.0.1
Erlang/OTP 25 [erts-13.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit:ns]
> c(mnesia_debug).
> mnesia_debug:run().
Started peer nodes
Initialized node0: started mnesia, created table, inserted data
Initialized node1: started mnesia
Added node1 to the `extra_db_nodes` of node`
Started sending table data from node0 to node1
Acquire write lock to block the transaction in `mnesia_loader:finish_copy/5`
Acquired write lock
Stopped node1 so that the `{copier_done, Node1}` message will be received in `mnesia_loader:finish_copy/5`
Released write lock
Try acquiring write lock. This call will be timed out.
** exception exit: {timeout,{gen_server,call,
                                        [<0.160.0>,
                                         {call,mnesia,transaction,[#Fun<mnesia_debug.1.103016018>]},
                                         5000]}}
     in function  gen_server:call/3 (gen_server.erl, line 382)
     in call from peer:call/5 (peer.erl, line 221)
     in call from mnesia_debug:run/0 (mnesia_debug.erl, line 82)
```