### PR TITLE
JIT: Optimise common combinations of relational operators

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -739,6 +739,17 @@ protected:
         }
     }
 
+    void cmp(arm::Gp src, int64_t val) {
+        if (Support::isUInt12(val)) {
+            a.cmp(src, imm(val));
+        } else if (Support::isUInt12(-val)) {
+            a.cmn(src, imm(-val));
+        } else {
+            mov_imm(SUPER_TMP, val);
+            a.cmp(src, SUPER_TMP);
+        }
+    }
+
     void ldur(arm::Gp reg, arm::Mem mem) {
         safe_9bit_imm(a64::Inst::kIdLdur, reg, mem);
     }
@@ -1589,14 +1600,8 @@ protected:
         if (arg.isImmed() || arg.isWord()) {
             Sint val = arg.isImmed() ? arg.as<ArgImmed>().get()
                                      : arg.as<ArgWord>().get();
-
-            if (Support::isUInt12(val)) {
-                a.cmp(gp, imm(val));
-                return;
-            } else if (Support::isUInt12(-val)) {
-                a.cmn(gp, imm(-val));
-                return;
-            }
+            cmp(gp, val);
+            return;
         }
 
         auto tmp = load_source(arg, SUPER_TMP);

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1599,8 +1599,8 @@ protected:
             }
         }
 
-        mov_arg(SUPER_TMP, arg);
-        a.cmp(gp, SUPER_TMP);
+        auto tmp = load_source(arg, SUPER_TMP);
+        a.cmp(gp, tmp.reg);
     }
 
     void safe_stp(arm::Gp gp1,

--- a/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
@@ -88,6 +88,8 @@ my @beam_global_funcs = qw(
     int_div_rem_body_shared
     int_div_rem_guard_shared
     internal_hash_helper
+    is_in_range_shared
+    is_ge_lt_shared
     minus_body_shared
     new_map_shared
     update_map_assoc_shared

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -455,6 +455,36 @@ is_eq_exact f s s
 
 is_ne_exact f s s
 
+is_integer NotInt N0 | is_ge Small N1=xy Min=i | is_ge Large Max=i N2=xy |
+  equal(N0, N1) | equal(N1, N2) |
+  equal(NotInt, Small) | equal(Small, Large) =>
+    is_int_in_range NotInt N0 Min Max
+
+is_integer NotInt N0 | is_ge Large Max=i N2=xy | is_ge Small N1=xy Min=i |
+  equal(N0, N1) | equal(N1, N2) |
+  equal(NotInt, Small) | equal(Small, Large) =>
+    is_int_in_range NotInt N0 Min Max
+
+is_integer NotInt N0 | is_ge Fail N1=xy Min=i |
+  equal(N0, N1) | equal(NotInt, Fail) =>
+    is_int_ge NotInt N0 Min
+
+is_int_in_range f S c c
+is_int_ge f S c
+
+is_ge Small N1=xy Min=i | is_ge Large Max=i N2=xy | equal(N1, N2) =>
+    is_in_range Small Large N1 Min Max
+
+is_ge Large Max=i N2=xy | is_ge Small N1=xy Min=i | equal(N1, N2) =>
+    is_in_range Small Large N2 Min Max
+
+is_in_range f f S c c
+
+is_ge Small N1=xy A=i | is_lt Large B=i N2=xy | equal(N1, N2) =>
+    is_ge_lt Small Large N1 A B
+
+is_ge_lt f f S c c
+
 is_lt f s s
 is_ge f s s
 

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1377,6 +1377,24 @@ protected:
         }
     }
 
+    void cmp(x86::Gp gp, int64_t val, const x86::Gp &spill) {
+        if (Support::isInt32(val)) {
+            a.cmp(gp, imm(val));
+        } else {
+            mov_imm(spill, val);
+            a.cmp(gp, spill);
+        }
+    }
+
+    void sub(x86::Gp gp, int64_t val, const x86::Gp &spill) {
+        if (Support::isInt32(val)) {
+            a.sub(gp, imm(val));
+        } else {
+            mov_imm(spill, val);
+            a.sub(gp, spill);
+        }
+    }
+
     /* Note: May clear flags. */
     void mov_arg(x86::Gp to, const ArgVal &from, const x86::Gp &spill) {
         if (from.isBytePtr()) {

--- a/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
@@ -79,6 +79,8 @@ my @beam_global_funcs = qw(
     increment_body_shared
     int_div_rem_body_shared
     int_div_rem_guard_shared
+    is_in_range_shared
+    is_ge_lt_shared
     internal_hash_helper
     minus_body_shared
     minus_guard_shared

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -443,6 +443,36 @@ is_eq_exact f s s
 
 is_ne_exact f s s
 
+is_integer NotInt N0 | is_ge Small N1=xy Min=i | is_ge Large Max=i N2=xy |
+  equal(N0, N1) | equal(N1, N2) |
+  equal(NotInt, Small) | equal(Small, Large) =>
+    is_int_in_range NotInt N0 Min Max
+
+is_integer NotInt N0 | is_ge Large Max=i N2=xy | is_ge Small N1=xy Min=i |
+  equal(N0, N1) | equal(N1, N2) |
+  equal(NotInt, Small) | equal(Small, Large) =>
+    is_int_in_range NotInt N0 Min Max
+
+is_integer NotInt N0 | is_ge Fail N1=xy Min=i |
+  equal(N0, N1) | equal(NotInt, Fail) =>
+    is_int_ge NotInt N0 Min
+
+is_int_in_range f S c c
+is_int_ge f S c
+
+is_ge Small N1=xy Min=i | is_ge Large Max=i N2=xy | equal(N1, N2) =>
+    is_in_range Small Large N1 Min Max
+
+is_ge Large Max=i N2=xy | is_ge Small N1=xy Min=i | equal(N1, N2) =>
+    is_in_range Small Large N2 Min Max
+
+is_in_range f f S c c
+
+is_ge Small N1=xy A=i | is_lt Large B=i N2=xy | equal(N1, N2) =>
+    is_ge_lt Small Large N1 A B
+
+is_ge_lt f f S c c
+
 is_lt f s s
 is_ge f s s
 

--- a/erts/emulator/test/op_SUITE.erl
+++ b/erts/emulator/test/op_SUITE.erl
@@ -25,7 +25,7 @@
 -export([all/0, suite/0,
          bsl_bsr/1,logical/1,t_not/1,relop_simple/1,relop/1,
          complex_relop/1,unsafe_fusing/1,
-         range_tests/1]).
+         range_tests/1, combined_relops/1]).
 
 -import(lists, [foldl/3,flatmap/2]).
 
@@ -35,7 +35,8 @@ suite() ->
 
 all() ->
     [bsl_bsr, logical, t_not, relop_simple, relop,
-     complex_relop, unsafe_fusing, range_tests].
+     complex_relop, unsafe_fusing, range_tests,
+     combined_relops].
 
 %% Test the bsl and bsr operators.
 bsl_bsr(Config) when is_list(Config) ->
@@ -523,13 +524,46 @@ range_tests(_Config) ->
     inside = range_big(MinSmall),
     inside = range_big(-1 bsl 58),
     inside = range_big(0),
-    inside = range_barely_small(17.75),
+    inside = range_big(17.75),
     inside = range_big(1 bsl 58),
     inside = range_big(MaxSmall),
 
     greater = range_big(MaxSmall + 2),
     greater = range_big(1 bsl 64),
     greater = range_big(float(1 bsl 64)),
+
+    inside = int_range_1(id(-100_000)),
+    inside = int_range_1(id(-10)),
+    inside = int_range_1(id(100)),
+    inside = int_range_1(id(100_000)),
+
+    outside = int_range_1(id(atom)),
+    outside = int_range_1(id(-1 bsl 60)),
+    outside = int_range_1(id(-100_001)),
+    outside = int_range_1(id(100_001)),
+    outside = int_range_1(id(1 bsl 60)),
+
+    inside = int_range_2(id(1)),
+    inside = int_range_2(id(42)),
+    inside = int_range_2(id(16#f000_0000)),
+
+    outside = int_range_2(id([a,list])),
+    outside = int_range_2(id(0)),
+    outside = int_range_1(id(-1 bsl 60)),
+    outside = int_range_1(id(1 bsl 60)),
+
+    inside = int_range_3(id(1 bsl 28)),
+    inside = int_range_3(id((1 bsl 28) + 1)),
+    inside = int_range_3(id((1 bsl 33) + 555)),
+    inside = int_range_3(id((1 bsl 58) - 1)),
+    inside = int_range_3(id(1 bsl 58)),
+
+    outside = int_range_3(id({a,tuple})),
+    outside = int_range_3(id(-1 bsl 60)),
+    outside = int_range_3(id(-1000)),
+    outside = int_range_3(id(100)),
+    outside = int_range_3(id((1 bsl 58) + 1)),
+    outside = int_range_3(id(1 bsl 60)),
 
     ok.
 
@@ -682,6 +716,83 @@ range_big_2(X) when (-1 bsl 59) - 1 =< X, X =< 1 bsl 59 ->
     inside;
 range_big_2(_) ->
     outside.
+
+int_range_1(X) when is_integer(X), -100_000 =< X, X =< 100_000 ->
+    inside;
+int_range_1(_) ->
+    outside.
+
+int_range_2(X) when is_integer(X), 1 =< X, X =< 16#f000_0000 ->
+    inside;
+int_range_2(_) ->
+    outside.
+
+int_range_3(X) when is_integer(X), 1 bsl 28 =< X, X =< 1 bsl 58 ->
+    inside;
+int_range_3(_) ->
+    outside.
+
+combined_relops(_Config) ->
+    other = test_tok_char(-1 bsl 64),
+    other = test_tok_char($A - 1),
+
+    var = test_tok_char($A),
+    var = test_tok_char($B),
+    var = test_tok_char($P),
+    var = test_tok_char($Y),
+    var = test_tok_char($Z),
+
+    other = test_tok_char($Z + 1),
+
+    var = tok_char($_),
+    other = tok_char(float($_)),
+
+    other = test_tok_char(1 bsl 64),
+
+    other = test_tok_char(atom),
+    other = test_tok_char(self()),
+
+    ok.
+
+test_tok_char(C) ->
+    Result = tok_char(C),
+    if
+        is_integer(C) ->
+            Result = tok_char(float(C)),
+            Result = tok_char_int(C),
+            if
+                C band 16#FFFF =:= C ->
+                    Result = tok_char_int_range(C);
+                true ->
+                    Result
+            end;
+        true ->
+            Result
+    end.
+
+%% is_ge + is_lt
+tok_char(C) when $A =< C, C =< $Z ->
+    var;
+tok_char($_) ->
+    var;
+tok_char(_) ->
+    other.
+
+%% is_ge + is_ge
+tok_char_int(C) when $A =< C, C =< $Z ->
+    var;
+tok_char_int($_) ->
+    var;
+tok_char_int(_) ->
+    other.
+
+%% is_ge + is_ge
+tok_char_int_range(C) when $A =< C, C =< $Z ->
+    var;
+tok_char_int_range($_) ->
+    var;
+tok_char_int_range(_) ->
+    other.
 
 %%%
 %%% Utilities.

--- a/lib/compiler/src/beam_jump.erl
+++ b/lib/compiler/src/beam_jump.erl
@@ -605,20 +605,23 @@ find_fixpoint(OptFun, Is0) ->
 opt([{test,is_eq_exact,{f,L},_}|[{jump,{f,L}}|_]=Is], Acc, St) ->
     %% The is_eq_exact test is not needed.
     opt(Is, Acc, St);
-opt([{test,Test0,{f,L}=Lbl,Ops}=I|[{jump,To}|Is]=Is0], Acc, St) ->
+opt([{test,Test0,{f,L}=Lbl,Ops}=I0|[{jump,To}|Is]=Is0], Acc, St) ->
     case is_label_defined(Is, L) of
 	false ->
+            I = is_lt_to_is_ge(I0),
 	    opt(Is0, [I|Acc], label_used(Lbl, St));
 	true ->
 	    case invert_test(Test0) of
 		not_possible ->
+                    I = is_lt_to_is_ge(I0),
 		    opt(Is0, [I|Acc], label_used(Lbl, St));
 		Test ->
 		    %% Invert the test and remove the jump.
 		    opt([{test,Test,To,Ops}|Is], Acc, St)
 	    end
     end;
-opt([{test,_,{f,_}=Lbl,_}=I|Is], Acc, St) ->
+opt([{test,_,{f,_}=Lbl,_}=I0|Is], Acc, St) ->
+    I = is_lt_to_is_ge(I0),
     opt(Is, [I|Acc], label_used(Lbl, St));
 opt([{test,_,{f,_}=Lbl,_,_,_}=I|Is], Acc, St) ->
     opt(Is, [I|Acc], label_used(Lbl, St));
@@ -678,6 +681,17 @@ opt([], Acc, #st{replace=Replace0}) when Replace0 =/= #{} ->
     beam_utils:replace_labels(Acc, [], Replace, fun(Old) -> Old end);
 opt([], Acc, #st{replace=Replace}) when Replace =:= #{} ->
     reverse(Acc).
+
+is_lt_to_is_ge({test,is_lt,Lbl,Args}=I) ->
+    case Args of
+        [{integer,N},{tr,_,#t_integer{}}=Src] ->
+            {test,is_ge,Lbl,[Src,{integer,N+1}]};
+        [{tr,_,#t_integer{}}=Src,{integer,N}] ->
+            {test,is_ge,Lbl,[{integer,N-1},Src]};
+        [_,_] ->
+            I
+    end;
+is_lt_to_is_ge(I) -> I.
 
 prune_redundant_values([_Val,F|Vls], F) ->
     prune_redundant_values(Vls, F);


### PR DESCRIPTION
Optimise the generated code for common combinations of relational operators such as in the following examples:

```
f(A) when is_integer(A), 0 =< A, A =< 1000 ->
    A + 1.

g(A) when 0 =< A, A =< 1000 ->
    A + 1.
```