### PR TITLE
Fix case clause errors in erl_erts_errors

### DIFF
--- a/lib/kernel/src/erl_erts_errors.erl
+++ b/lib/kernel/src/erl_erts_errors.erl
@@ -595,7 +595,7 @@ format_erlang_error(monitor_node, [Node,Flag], _) ->
 format_erlang_error(monitor_node, [Node,Flag,Options], Cause) ->
     Arg3 = case Cause of
                badopt -> bad_option;
-               true -> []
+               _ -> []
            end,
     case format_erlang_error(monitor_node, [Node,Flag], Cause) of
         [[],[]] ->
@@ -754,7 +754,7 @@ format_erlang_error(send, [_,_,Options], Cause) ->
     case Cause of
         badopt ->
             [[],[],must_be_list(Options, bad_option)];
-        true ->
+        _ ->
             [bad_destination]
     end;
 format_erlang_error(send_after, Args, Cause) ->


### PR DESCRIPTION
`Cause` defaults to `none`, not `true`.
A catch-all was used for consistency with
the remaining of the file.