### PR TITLE
5719 - Adding Stacktrace to thrown

### DIFF
--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -1789,7 +1789,7 @@ ts_tc(M, F, A) ->
 		     set_loc(Stk),
 		     case Type of
 			 throw ->
-			     {failed,{thrown,Reason}};
+			     {failed,{thrown,{Reason,Stk}}};
 			 error ->
 			     {'EXIT',{Reason,Stk}};
 			 exit ->

--- a/lib/common_test/test/ct_error_SUITE.erl
+++ b/lib/common_test/test/ct_error_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2009-2021. All Rights Reserved.
+%% Copyright Ericsson AB 2009-2022. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -729,9 +729,8 @@ test_events(lib_error) ->
       {lib_error_1_SUITE,lines_hang,{failed,{timetrap_timeout,3000}}}},
      {?eh,test_stats,{0,3,{0,0}}},
      {?eh,tc_start,{lib_error_1_SUITE,lines_throw}},
-     {?eh,tc_done,
-      {lib_error_1_SUITE,lines_throw,
-       {failed,{error,{thrown,catch_me_if_u_can}}}}},
+     {?eh,tc_done,{lib_error_1_SUITE,lines_throw,{failed,
+        {error,{thrown,{catch_me_if_u_can,'_'}}}}}},
      {?eh,test_stats,{0,4,{0,0}}},
      {?eh,tc_start,{lib_error_1_SUITE,no_lines_error}},
      {?eh,tc_done,
@@ -748,8 +747,8 @@ test_events(lib_error) ->
       {lib_error_1_SUITE,no_lines_hang,{failed,{timetrap_timeout,3000}}}},
      {?eh,test_stats,{0,7,{0,0}}},
      {?eh,tc_start,{lib_error_1_SUITE,no_lines_throw}},
-     {?eh,tc_done,
-      {lib_error_1_SUITE,no_lines_throw,{failed,{error,{thrown,catch_me_if_u_can}}}}},
+     {?eh,tc_done,{lib_error_1_SUITE,no_lines_throw,{failed,
+        {error,{thrown,{catch_me_if_u_can,'_'}}}}}},
      {?eh,test_stats,{0,8,{0,0}}},
      {?eh,tc_start,{lib_error_1_SUITE,init_tc_error}},
      {?eh,tc_done,{lib_error_1_SUITE,init_tc_error,

--- a/lib/common_test/test/ct_test_support.erl
+++ b/lib/common_test/test/ct_test_support.erl
@@ -1217,6 +1217,9 @@ result_match({failed,{timetrap_timeout,{'$approx',Num}}},
 result_match({user_timetrap_error,{Why,'_'}},
 	     {user_timetrap_error,{Why,_Stack}}) ->
     true;
+result_match({SkipOrFail,{ErrorInd,{thrown,{Why,'_'}}}},
+         {SkipOrFail,{ErrorInd,{thrown,{Why,_Stack}}}}) ->
+    true;
 result_match(Result, Result) ->
     true;
 result_match(_, _) ->


### PR DESCRIPTION
this commit fixes #5719 
New Stacktrace with thrown is:
```
===> Running Common Test suites...
%%% db_data_type_SUITE: 
%%% db_data_type_SUITE ==> init_per_suite: FAILED
%%% db_data_type_SUITE ==> {thrown,
    {foo,
        [{db_data_type_SUITE,init_per_suite,1,
             [{file,
                  "/home/adamsbd/src/infratracks/common_tests/db_data_type_SUITE.erl"},
              {line,44}]},
         {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1782}]},
         {test_server,run_test_case_eval1,6,
             [{file,"test_server.erl"},{line,1379}]},
         {test_server,run_test_case_eval,9,
             [{file,"test_server.erl"},{line,1223}]}]}}
```

no change to without Thrown and Normal Error:
```
===> Running Common Test suites...                                                                                                          
%%% db_data_type_SUITE:                                               
%%% db_data_type_SUITE ==> init_per_suite: FAILED
%%% db_data_type_SUITE ==> {undef,[{db,connect,["DSN=sqlserver;UID=alladin;PWD=sesame",[]],[]},
        {db_data_type_SUITE,init_per_suite,1,
                            [{file,"/home/adamsbd/src/infratracks/common_tests/db_data_type_SUITE.erl"},
                             {line,43}]},
        {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1782}]},
        {test_server,run_test_case_eval1,6,
                     [{file,"test_server.erl"},{line,1379}]},
        {test_server,run_test_case_eval,9,
                     [{file,"test_server.erl"},{line,1223}]}]}