### PR TITLE
Improve observer nodes list menu

### DIFF
--- a/lib/observer/src/observer_wx.erl
+++ b/lib/observer/src/observer_wx.erl
@@ -747,17 +747,20 @@ get_nodes() ->
     Nodes0 = case erlang:is_alive() of
 		false -> [];
 		true  ->
-		    case net_adm:names() of
-			{error, _} -> nodes();
-			{ok, Names} ->
-			    epmd_nodes(Names) ++ nodes()
-		    end
+                    case net_adm:names() of
+                        {error, _} -> [];
+                        {ok, Names} -> epmd_nodes(Names)
+                    end
+                    ++
+                    nodes(connected)
 	     end,
     Nodes = lists:usort(Nodes0),
+    WarningText = "WARNING: connecting to non-erlang nodes may crash them",
     {_, Menues} =
 	lists:foldl(fun(Node, {Id, Acc}) when Id < ?LAST_NODES_MENU_ID ->
 			    {Id + 1, [#create_menu{id=Id + ?FIRST_NODES_MENU_ID,
-						   text=atom_to_list(Node)} | Acc]}
+						   text=atom_to_list(Node),
+						   help=WarningText} | Acc]}
 		    end, {1, []}, Nodes),
     {Nodes, lists:reverse(Menues)}.
 


### PR DESCRIPTION
- Also include connected, hidden nodes ([Observer User Guide](https://www.erlang.org/doc/apps/observer/observer_ug.html#getting-started) uses a hidden node as example)
- Always include current node. If dist_listen is false it won't show up
in epdm names
- If the default epmd module `erl_epmd` is used and `erl_epmd_port` is set
to `DistPort` then it is only possible to connect to the node listening
on `DistPort` (if any), so exclude other nodes registered in EPMD

The last change is controversial, maybe it should be implemented elsewhere (in net_adm or erl_epmd?) and it's not the responsibility of observer to know about this detail. Or the exclusion should not happen at all (Observer shows a nice error dialogue when connection fails and maybe that's good enough)