### PR TITLE
Fix `logger_formatter` about `msg` by making templates linear before split

### DIFF
--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -272,7 +272,7 @@ template(_Config) ->
                                [[nested,subkey]]),
     String8 = format(info,{"~p",[term]},Meta8,#{template=>Template8,
                                                 single_line=>true}),
-    ct:log(String6),
+    ct:log(String8),
     SelfStr = pid_to_list(self()),
     RefStr8 = ref_to_list(Ref8),
     ListStr = "[list,\"string\",4321,#{},{tuple}]",
@@ -344,6 +344,18 @@ template(_Config) ->
         "exist:#{key1 => #{subkey1 => value1},key2 => value2}" -> ok;
         _ -> ct:fail({full_nested_map_unexpected,MultipleKeysStr10})
     end,
+
+    Meta11A = #{time=>Time,be_short=>ok},
+    Meta11B = #{time=>Time},
+    Template11 =
+        [{be_short,
+          ["short:",msg],
+          ["long:[",level,"]",msg]}],
+    String11A = format(info,{"~p",[term]},Meta11A,#{template=>Template11,single_line=>true}),
+    String11B = format(info,{"~p",[term]},Meta11B,#{template=>Template11,single_line=>true}),
+    ct:log(String11A),
+    ct:log(String11B),
+    {"short:term","long:[info]term"} = {String11A,String11B},
 
     ok.
 


### PR DESCRIPTION
I have encountered a somewhat strange behavior of [`logger_formatter`](https://www.erlang.org/doc/man/logger_formatter.html) about `msg` in templates. This pull request attempts to remedy it.

The behavior is exemplified by the following application:

- https://github.com/gfngfn/a_strange_behavior_of_logger_formatter

In summary, `msg`s occurring at conditional branching `{metakey(), template(), template()}` in templates will not be formatted as intended.

Looking into the implementation of `logger_formatter:format`, I have found that the implementation presumably assumes that given templates are of the form `[Elem_1, …, Elem_{i - 1}, msg, Elem_{i + 1}, …, Elem_n]` or do not contain `msg`. According to [the definition of `logger_formatter:template()`](https://www.erlang.org/doc/man/logger_formatter.html#type-template), this assumption is not documented. Therefore, one of the following amendments seems to be needed:

1. State in the manual that `msg` must occur as a top level element of templates and at most once;
2. Fix the implementation of `logger_formatter:format` so that `msg`s can occur under conditional branching but at most once for every “path”; or
3. Fix the implementation of `logger_formatter:format` so that `msg`s can occur everywhere in templates possibly more than once.

The present pull request suggests an amendment based on the second approach. This is because using `msg` more than once in a “path” does not seem so usual and also its support will require a bit complicated implementation due to [the `chars_limit` option](https://www.erlang.org/doc/man/logger_formatter.html#type-config).

I would appreciate it if you could give any comments or suggestions (especially since this is my first pull request to this repository).