### PR TITLE
Correct default for dump_log_write_threshold in Mnesia docs

### DIFF
--- a/lib/mnesia/doc/src/mnesia.xml
+++ b/lib/mnesia/doc/src/mnesia.xml
@@ -2955,7 +2955,7 @@ raise(Name, Amount) ->
         <p><c>-mnesia dump_log_write_threshold Max</c>.
           <c>Max</c> is an integer that specifies the maximum
           number of writes allowed to the transaction log before
-          a new dump of the log is performed. Default is <c>100</c>
+          a new dump of the log is performed. Default is <c>1000</c>
           log writes.</p>
       </item>
       <item>


### PR DESCRIPTION
From what I understand, the default value is 1000, not 100: https://github.com/erlang/otp/blob/master/lib/mnesia/src/mnesia_monitor.erl#L719.
This is in line with what's written in the Mnesia User's Guide: https://github.com/erlang/otp/blob/maint/lib/mnesia/doc/src/Mnesia_chap7.xmlsrc#L298.