### PR TITLE
erts: Apply -fno-omit-frame-pointer to erts/lib_src when JIT is enabled

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -270,6 +270,45 @@ jobs:
           name: otp_win32_installer
           path: otp/release/win32/otp*.exe
 
+  build-flavors:
+    name: Build Erlang/OTP (Types and Flavors)
+    runs-on: ubuntu-latest
+    needs: [pack, changed-apps]
+    if: contains(needs.changed-apps.outputs.changes, 'emulator')
+
+    steps:
+      - uses: actions/checkout@v2
+      ## Download docker images
+      - name: Cache BASE image
+        id: cache-base-image
+        uses: actions/cache@v3
+        with:
+            path: otp_docker_base.tar
+            key: ${{ runner.os }}-${{ hashFiles('.github/dockerfiles/Dockerfile.ubuntu-base', '.github/scripts/build-base-image.sh') }}
+      - name: Download otp build
+        uses: actions/download-artifact@v2
+        with:
+          name: otp-ubuntu-20.04
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Restore docker image
+        run: .github/scripts/restore-otp-image.sh
+      - name: Build Erlang/OTP flavors and types
+        run: |
+            TYPES="opt debug lcnt"
+            FLAVORS="emu jit"
+            for TYPE in ${TYPES}; do
+              for FLAVOR in ${FLAVORS}; do
+                echo "::group::{TYPE=$TYPE FLAVOR=$FLAVOR}"
+                docker run otp "make TYPE=$TYPE FLAVOR=$FLAVOR"
+                echo "::endgroup::"
+              done
+            done
+
   build:
     name: Build Erlang/OTP
     runs-on: ubuntu-latest

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -1433,8 +1433,9 @@ depend:
 else
 depend: $(TTF_DIR)/depend.mk
 $(TTF_DIR)/depend.mk: $(foreach dep, $(DEPEND_DEPS), $(TTF_DIR)/$(dep).depend.mk)
-	$(V_at)if [ -f "$@" ]; then rm "$@"; fi
-	$(V_at)for dep in $^; do cat $$dep >> $@; done
+	$(gen_verbose)
+	$(V_at)echo "" > "$@"
+	$(V_at)for dep in "$^"; do cat $$dep >> "$@"; done
 	$(V_at)cd $(ERTS_LIB_DIR) && $(MAKE) depend
 endif
 

--- a/erts/emulator/beam/erl_lock_count.h
+++ b/erts/emulator/beam/erl_lock_count.h
@@ -261,12 +261,14 @@ int erts_lcnt_check_ref_installed(erts_lcnt_ref_t *ref);
 
 /** @brief Convenience macro to re/enable counting on an already initialized
  * reference. Don't forget to specify the lock type in \c flags! */
-#define erts_lcnt_install_new_lock_info(ref, name, id, flags) \
-    if(!erts_lcnt_check_ref_installed(ref)) { \
-        erts_lcnt_lock_info_carrier_t *__carrier; \
-        __carrier = erts_lcnt_create_lock_info_carrier(1);\
-        erts_lcnt_init_lock_info_idx(__carrier, 0, name, id, flags); \
-        erts_lcnt_install(ref, __carrier);\
+#define erts_lcnt_install_new_lock_info(ref, name, id, flags)           \
+    do {                                                                \
+        if(!erts_lcnt_check_ref_installed(ref)) {                       \
+            erts_lcnt_lock_info_carrier_t *__carrier;                   \
+            __carrier = erts_lcnt_create_lock_info_carrier(1);          \
+            erts_lcnt_init_lock_info_idx(__carrier, 0, name, id, flags); \
+            erts_lcnt_install(ref, __carrier);                          \
+        }                                                               \
     } while(0)
 
 erts_lcnt_lock_info_carrier_t *erts_lcnt_create_lock_info_carrier(int count);

--- a/erts/lib_src/Makefile.in
+++ b/erts/lib_src/Makefile.in
@@ -94,7 +94,11 @@ CFLAGS += -DERTS_OPCODE_COUNTER_SUPPORT
 PRE_LD=
 else
 override TYPE=opt
+ifeq (@JIT_ENABLED@, yes)
+OMIT_OMIT_FP=yes
+else
 OMIT_FP=true
+endif
 TYPE_SUFFIX=
 PRE_LD=
 endif
@@ -311,15 +315,6 @@ include $(YCF_SOURCE_DIR)/main_target.mk
 
 $(OBJ_DIR)/MADE: $(YCF_EXECUTABLE) $(ETHREAD_LIB) $(ERTS_INTERNAL_LIBS)
 	$(gen_verbose)
-ifeq ($(OMIT_OMIT_FP),yes)
-	@echo '* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *'
-	@echo '* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *'
-	@echo '* *                                                         * *'
-	@echo '* * NOTE: Omit frame pointer optimization has been omitted  * *'
-	@echo '* *                                                         * *'
-	@echo '* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *'
-	@echo '* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *'
-endif
 	$(V_at)echo $? > $(OBJ_DIR)/MADE
 
 #

--- a/lib/public_key/c_src/Makefile
+++ b/lib/public_key/c_src/Makefile
@@ -91,7 +91,7 @@ endif
 
 _create_dirs := $(shell mkdir -p $(OBJDIR) $(LIBDIR))
 
-debug opt valgrind: $(DIRS) $(PUBKEY_LIB)
+debug opt valgrind lcnt asan: $(DIRS) $(PUBKEY_LIB)
 
 $(OBJDIR):
 	-@mkdir -p $(OBJDIR)


### PR DESCRIPTION
Currently OMIT_OMIT_FP is set to true in erts/emulator/Makefile.in
when JIT is enabled, but not necessarily in erts/lib_src/Makefile.in.

This change factors out OMIT_OMIT_FP computation to be shared between
those two builds to apply this flag consistently to them.

Note that this bug was confirmed by @garazdawi in an Erlang forum post: https://erlangforums.com/t/unify-builds-for-otp-erts-targets/1419/3