### PR TITLE
Fix public_key removed version

### DIFF
--- a/lib/stdlib/scripts/update_deprecations
+++ b/lib/stdlib/scripts/update_deprecations
@@ -237,6 +237,27 @@ make_xml(Top, Type, OutFile, InfoText0) ->
     InfoTextMap = maps:from_list(make_xml_info(InfoText0, AttrTag)),
     Collected = make_xml_collect(Depr, RelKey, InfoTextMap, []),
 
+    case Type of
+        "removed" ->
+            {ok, Vsn} = file:read_file(filename:join(Top,"OTP_VERSION")),
+            [Release|_] = string:split(Vsn,"."),
+            lists:foreach(
+              fun({Rel, Functions}) ->
+                      case Rel > binary_to_integer(Release) of
+                          true ->
+                              io:format(standard_error,
+                                        "Some functions have been marked "
+                                        "as removed in the future: ~n~p~n",
+                                        [Functions]),
+                              halt(1);
+                          false ->
+                              ok
+                      end
+              end, Collected);
+        _ ->
+            ok
+    end,
+
     All = make_xml_gen(lists:reverse(Collected), Type, OutDir),
     ok = file:write_file(OutFile, All).
 

--- a/system/doc/general_info/DEPRECATIONS
+++ b/system/doc/general_info/DEPRECATIONS
@@ -33,10 +33,10 @@ erts_alloc_config:_/_ since=25 remove=26
 # Added in OTP 24.
 #
 
-public_key:ssh_hostkey_fingerprint/1 since=24 remove=26
-public_key:ssh_hostkey_fingerprint/2 since=24 remove=26
-public_key:ssh_decode/2 since=24 remove=26
-public_key:ssh_encode/2 since=24 remove=26
+public_key:ssh_hostkey_fingerprint/1 since=24 remove=25
+public_key:ssh_hostkey_fingerprint/2 since=24 remove=25
+public_key:ssh_decode/2 since=24 remove=25
+public_key:ssh_encode/2 since=24 remove=25
 ftp:start_service/1 since=24 remove=26
 ftp:stop_service/1 since=24 remove=26
 httpd_util:flatlength/1 since=24 remove=26


### PR DESCRIPTION
The `public_key:ssh_*` functions were removed in Erlang/OTP 25, but were not labeled with the correct version in the DEPRECATIONS file.