### PR TITLE
observer: correct the units shown for memory data

### DIFF
--- a/lib/observer/src/observer_lib.erl
+++ b/lib/observer/src/observer_lib.erl
@@ -299,13 +299,13 @@ to_str({Unit, X}) when (Unit==bytes orelse Unit==time_ms) andalso is_list(X) ->
     catch error:badarg -> X
     end;
 to_str({bytes, B}) ->
-    KB = B div 1024,
-    MB = KB div 1024,
-    GB = MB div 1024,
+    KiB = B div 1024,
+    MiB = KiB div 1024,
+    GiB = MiB div 1024,
     if
-	GB > 10 -> integer_to_list(GB) ++ " GB";
-	MB > 10 -> integer_to_list(MB) ++ " MB";
-	KB >  0 -> integer_to_list(KB) ++ " kB";
+	GiB > 10 -> integer_to_list(GiB) ++ " GiB";
+	MiB > 10 -> integer_to_list(MiB) ++ " MiB";
+	KiB >  0 -> integer_to_list(KiB) ++ " KiB";
 	true -> integer_to_list(B) ++ " B"
     end;
 to_str({{words,WSz}, Sz}) ->


### PR DESCRIPTION
The current code does the conversion from bytes to kibibyte (KiB), mebibyte(MiB) and gibibyte(GiB), that is dividing by 1024.

However, when the units are printed, the units are in kilobytes (KB), megabytes (MB) and gigabytes (GB), so the bytes should be divided by 1000 instead of 1024.

We realised about the error when we were discussing in [erlang forum](https://erlangforums.com/t/ets-memory-occupy-the-erl-shell-query-occupies-more-than-2m-memory-but-the-observer-query-occupies-more-than-18m-memory/1525/5), and I couldn't explain why it was a difference between calculating the ets memory footprint in the shell and looking in `observer` (I must say that I wasn't very awake so I didn't think it could be in KiB).

The change is not a big deal but I think it will show more precise values.