### PR TITLE
Option to skip SSH authentication for some niche cases

### DIFF
--- a/lib/ssh/doc/src/ssh.xml
+++ b/lib/ssh/doc/src/ssh.xml
@@ -648,6 +648,19 @@
 	    </p>
 	    <p>This variant is kept for compatibility.</p>
 	  </item>
+
+	  <tag><marker id="option-no_auth_needed"/><c>no_auth_needed</c></tag>
+	  <item>
+            <p>If <c>true</c>, a client is authenticated without any need of
+	    providing any password or key.
+	    </p>
+	    <p>This option is only intended for very special applications due
+	    to the high risk of accepting any connecting client.
+	    </p>
+	    <p>The default value is <c>false</c>.
+	    </p>
+          </item>
+
 	</taglist>
       </desc>
     </datatype>

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -362,7 +362,9 @@
       | {user_passwords, [{UserName::string(),Pwd::string()}]}
       | {pk_check_user, boolean()}  
       | {password, string()}
-      | {pwdfun, pwdfun_2() | pwdfun_4()} .
+      | {pwdfun, pwdfun_2() | pwdfun_4()}
+      | {no_auth_needed, boolean()}
+        .
 
 -type prompt_texts() ::
         kb_int_tuple()

--- a/lib/ssh/src/ssh_auth.erl
+++ b/lib/ssh/src/ssh_auth.erl
@@ -272,11 +272,21 @@ handle_userauth_request(#ssh_msg_userauth_request{user = User,
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",
 						  method = "none"}, _,
-			#ssh{userauth_supported_methods = Methods} = Ssh) ->
-    {not_authorized, {User, undefined},
-     {#ssh_msg_userauth_failure{authentications = Methods,
-                                partial_success = false}, Ssh}
-    };
+			#ssh{userauth_supported_methods = Methods,
+                             opts = Opts} = Ssh) ->
+    case ?GET_OPT(no_auth_needed, Opts) of
+        false ->
+            %% The normal case
+            {not_authorized, {User, undefined},
+             {#ssh_msg_userauth_failure{authentications = Methods,
+                                        partial_success = false}, Ssh}
+            };
+        true ->
+            %% RFC 4252  5.2
+	    {authorized, User,
+             {#ssh_msg_userauth_success{}, Ssh}
+            }
+    end;
 
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -477,6 +477,12 @@ default(server) ->
             class => user_option
            },
 
+      no_auth_needed =>
+          #{default => false,
+            chk => fun(V) -> erlang:is_boolean(V) end,
+            class => user_option
+           },
+
       pk_check_user =>
           #{default => false,
             chk => fun(V) -> erlang:is_boolean(V) end,


### PR DESCRIPTION
Proposed fix #6021 

Introduces the boolean server option `no_auth_needed` which makes the server always accept a login request.