### PR TITLE
dialyzer: Add no_extra_return and no_missing_return to warn_options type

### DIFF
--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -129,7 +129,9 @@
                        | 'unknown'
                        | 'unmatched_returns'
                        | 'overspecs'
-                       | 'specdiffs'.
+                       | 'specdiffs'
+                       | 'no_extra_return'
+                       | 'no_missing_return'.
 -type dial_option()   :: {'files', [FileName :: file:filename()]}
                        | {'files_rec', [DirName :: file:filename()]}
                        | {'defines', [{Macro :: atom(), Value :: term()}]}

--- a/lib/dialyzer/src/dialyzer_cl_parse.erl
+++ b/lib/dialyzer/src/dialyzer_cl_parse.erl
@@ -570,4 +570,8 @@ They are primarily intended to be used with the -dialyzer attribute:
   -Wno_underspecs
      Suppress warnings about underspecified functions (those whose -spec
      is strictly more allowing than the success typing).
+  -Wno_extra_return
+     Suppress warnings about functions whose specification includes types that the function cannot return.
+  -Wno_missing_return
+     Suppress warnings about functions that return values that are not part of the specification.
 ".

--- a/lib/dialyzer/test/extra_return_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/extra_return_SUITE_data/dialyzer_options
@@ -1,0 +1,1 @@
+{dialyzer_options, [{indent_opt, false}, {warnings, [extra_return]}]}.

--- a/lib/dialyzer/test/extra_return_SUITE_data/results/extra_return
+++ b/lib/dialyzer/test/extra_return_SUITE_data/results/extra_return
@@ -1,0 +1,2 @@
+
+extra_return.erl:7:2: The specification for extra_return:t1/0 states that the function might also return 'other' but the inferred return is boolean()

--- a/lib/dialyzer/test/extra_return_SUITE_data/src/extra_return.erl
+++ b/lib/dialyzer/test/extra_return_SUITE_data/src/extra_return.erl
@@ -1,0 +1,12 @@
+-module(extra_return).
+
+-export([t1/0]).
+
+
+% Should warn about having `undefined` as return value when it is not returned by the function
+-spec t1() -> true | false | 'other'.
+t1() ->
+    case rand:uniform(2) of
+        1 -> true;
+        2 -> false
+    end.

--- a/lib/dialyzer/test/extra_return_SUITE_data/src/extra_return.erl
+++ b/lib/dialyzer/test/extra_return_SUITE_data/src/extra_return.erl
@@ -1,11 +1,20 @@
 -module(extra_return).
 
--export([t1/0]).
+-export([t1/0, t2/0]).
 
 
 % Should warn about having `undefined` as return value when it is not returned by the function
 -spec t1() -> true | false | 'other'.
 t1() ->
+    case rand:uniform(2) of
+        1 -> true;
+        2 -> false
+    end.
+
+% Should not warn about extra return
+-dialyzer({no_extra_return, t2/0}).
+-spec t2() -> true | false | 'other'.
+t2() ->
     case rand:uniform(2) of
         1 -> true;
         2 -> false

--- a/lib/dialyzer/test/missing_return_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/missing_return_SUITE_data/dialyzer_options
@@ -1,0 +1,1 @@
+{dialyzer_options, [{indent_opt, false}, {warnings, [missing_return]}]}.

--- a/lib/dialyzer/test/missing_return_SUITE_data/results/missing_return
+++ b/lib/dialyzer/test/missing_return_SUITE_data/results/missing_return
@@ -1,0 +1,2 @@
+
+missing_return.erl:7:2: The success typing for missing_return:t1/0 implies that the function might also return 'false' but the specification return is 'true'

--- a/lib/dialyzer/test/missing_return_SUITE_data/src/missing_return.erl
+++ b/lib/dialyzer/test/missing_return_SUITE_data/src/missing_return.erl
@@ -1,11 +1,20 @@
 -module(missing_return).
 
--export([t1/0]).
+-export([t1/0, t2/0]).
 
 
 % Should warn about only having true when also false is returned
 -spec t1() -> true.
 t1() ->
+    case rand:uniform(2) of
+        1 -> true;
+        2 -> false
+    end.
+
+% Should not warn about missing return
+-dialyzer({no_missing_return, t2/0}).
+-spec t2() -> true.
+t2() ->
     case rand:uniform(2) of
         1 -> true;
         2 -> false

--- a/lib/dialyzer/test/missing_return_SUITE_data/src/missing_return.erl
+++ b/lib/dialyzer/test/missing_return_SUITE_data/src/missing_return.erl
@@ -1,0 +1,12 @@
+-module(missing_return).
+
+-export([t1/0]).
+
+
+% Should warn about only having true when also false is returned
+-spec t1() -> true.
+t1() ->
+    case rand:uniform(2) of
+        1 -> true;
+        2 -> false
+    end.

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -3439,7 +3439,7 @@ is_module_dialyzer_option(Option) ->
                   no_behaviours,no_undefined_callbacks,unmatched_returns,
                   error_handling,race_conditions,no_missing_calls,
                   specdiffs,overspecs,underspecs,unknown,
-                  no_underspecs
+                  no_underspecs, no_extra_return, no_missing_return
                  ]).
 
 %% try_catch_clauses(Scs, Ccs, In, ImportVarTable, State) ->


### PR DESCRIPTION
When `extra_return` and `missing_return` were added in https://github.com/erlang/otp/pull/5214, the values weren't added to warn_options. This caused the following error when I try to skip any of the errors with `-dialyzer()`.

I used the same code as https://github.com/erlang/otp/pull/5214.
```erlang
-module(t).
-export([t/1, q/1]).

-dialyzer({no_missing_return, t/1}).
-spec t(integer()) -> odd.
t(N) when N rem 2 =/= 0 ->
    odd;
t(_) ->
    even.

-dialyzer({no_extra_return, q/1}).
-spec q(integer()) -> positive | negative | zero.
q(N) when N > 0 ->
    positive;
q(N) when N < 0 ->
    negative.
```

```
$ dialyzer t.erl -Wextra_return -Wmissing_return                                                                                                
  Checking whether the PLT /home/gonzalo/.cache/erlang/.dialyzer_plt is up-to-date... yes
  Proceeding with analysis...
dialyzer: Analysis failed with error:
Could not scan the following file(s):
/tmp/t.erl:4:2: unknown dialyzer warning option: no_extra_return
/tmp/t.erl:11:2: unknown dialyzer warning option: no_missing_return
```

`-Wno_extra_return` and `-Wno_missing_return` are defined at the end of the section in this  documentation page https://www.erlang.org/doc/man/dialyzer.html#using-dialyzer-from-the-command-line so I think they are wanted as warning option too.

I realised about the missing options when I was trying to add new dialyzer options  `-Wextra_return` and `Wmissing_return`, and I just wanted to fix a few warnings and skip a few others.