### PR TITLE
Correct the type spec for format_status/1

### DIFF
--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -202,6 +202,31 @@ gen_event:stop             ----->  Module:terminate/2
       </desc>
     </datatype>
 
+    <datatype>
+      <name name="format_status"/>
+      <desc>
+        <p>
+          A map that describes the <c>gen_event</c> process status.
+          The keys are:
+        </p>
+        <taglist>
+          <tag><c>state</c></tag>
+          <item>The internal state of the event handler.</item>
+          <tag><c>message</c></tag>
+          <item>The message that caused the event handler to terminate.</item>
+          <tag><c>reason</c></tag>
+          <item>The reason that caused the event handler to terminate.</item>
+          <tag><c>log</c></tag>
+          <item>
+            The <seemfa marker="sys#log/2">sys log</seemfa> of the server.
+          </item>
+        </taglist>
+        <p>
+          New associations may be added into the status map
+          without prior notice.
+        </p>
+      </desc>
+    </datatype>
   </datatypes>
 
   <funcs>
@@ -1243,16 +1268,8 @@ gen_event:stop             ----->  Module:terminate/2
       <fsummary>Optional function for providing a term describing the
         current event handler state.</fsummary>
       <type>
-        <v>Status = #{ state => State,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        message => Message,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        reason => Reason,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        log => Log }</v>
-        <v>NewStatus = Status</v>
-        <v>State = Message = Reason = term()</v>
-        <v>Log = [<seetype marker="sys#system_event">sys:system_event()</seetype>]</v>
+        <v>Status = <seetype marker="#format_status">format_status()</seetype></v>
+        <v>NewStatus = <seetype marker="#format_status">format_status()</seetype></v>
       </type>
       <desc>
         <note>
@@ -1274,27 +1291,25 @@ gen_event:stop             ----->  Module:terminate/2
           <item>The event handler terminates abnormally and <c>gen_event</c>
             logs an error.</item>
         </list>
-        <p>This callback is to be used to limit the status of the event handler before
-          returned by <seemfa marker="sys#get_status/1"><c>sys:get_status/1,2</c></seemfa> or
-          sent to <seeerl marker="kernel:logger"><c>logger</c></seeerl>. The status
-          of the event handler is passed as a map with the following associations:
+        <p>
+          This callback is used to limit the status of the event handler
+          returned by
+          <seemfa marker="sys#get_status/1"><c>sys:get_status/1,2</c></seemfa>
+          or sent to <seeerl marker="kernel:logger"><c>logger</c></seeerl>.
         </p>
-        <taglist>
-          <tag><c>state => term()</c></tag>
-          <item>The internal state of the event handler.</item>
-          <tag><c>message => term()</c></tag>
-          <item>The message that caused the event handler to terminate.</item>
-          <tag><c>reason => term()</c></tag>
-          <item>The reason that caused the event handler to terminate.</item>
-          <tag><c>log => [</c><seetype marker="sys#system_event"><c>sys:system_event/0</c></seetype><c>]</c></tag>
-          <item>The <seemfa marker="sys#log/2">sys log</seemfa> of the server.</item>
-        </taglist>
-        <p>New associations may be added into the status map without prior notice.</p>
-        <p>The function is to return <c>NewStatus</c>, a map containing the same
-          associations as the input map.</p>
-        <p>Two possible use cases for this callback is to either remove
-          sensitive information from the state so that it not printed in log files,
-          or to remove large irrelevant terms of state that clutter the logs.</p>
+        <p>
+          The callback gets a map <c>Status</c>
+          describing the current status and shall return a map
+          <c>NewStatus</c> with the same keys,
+          but it may transform some values.
+        </p>
+        <p>
+          Two possible use cases for this callback is to
+          remove sensitive information from the state
+          to prevent it from being printed in log files,
+          or to compact large irrelevant status items
+          that would only clutter the logs.
+        </p>
         <code type="erl"><![CDATA[
 format_status(Status) ->
   maps:map(

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -473,6 +473,32 @@ gen_server:abcast     -----> Module:handle_cast/2
         </taglist>
       </desc>
     </datatype>
+
+    <datatype>
+      <name name="format_status"/>
+      <desc>
+        <p>
+          A map that describes the <c>gen_server</c> status.
+          The keys are:
+        </p>
+        <taglist>
+          <tag><c>state</c></tag>
+          <item>The internal state of the <c>gen_server</c> process.</item>
+          <tag><c>message</c></tag>
+          <item>The message that caused the server to terminate.</item>
+          <tag><c>reason</c></tag>
+          <item>The reason that caused the server to terminate.</item>
+          <tag><c>log</c></tag>
+          <item>
+            The <seemfa marker="sys#log/2">sys log</seemfa> of the server.
+          </item>
+        </taglist>
+        <p>
+          New associations may be added to the status map
+          without prior notice.
+        </p>
+      </desc>
+    </datatype>
   </datatypes>
 
 
@@ -1513,16 +1539,8 @@ gen_server:abcast     -----> Module:handle_cast/2
       <fsummary>Optional function for providing a term describing the
         current <c>gen_server</c> status.</fsummary>
       <type>
-        <v>Status = #{ state => State,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        message => Message,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        reason => Reason,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        log => Log }</v>
-        <v>NewStatus = Status</v>
-        <v>State = Message = Reason = term()</v>
-        <v>Log = [<seetype marker="sys#system_event">sys:system_event()</seetype>]</v>
+        <v>Status = <seetype marker="#format_status">format_status()</seetype></v>
+        <v>NewStatus = <seetype marker="#format_status">format_status()</seetype></v>
       </type>
       <desc>
         <note>
@@ -1545,27 +1563,25 @@ gen_server:abcast     -----> Module:handle_cast/2
             <p>The <c>gen_server</c> process terminates abnormally and logs an error.</p>
           </item>
         </list>
-        <p>This callback is to be used to limit the status of the process before
-          returned by <seemfa marker="sys#get_status/1"><c>sys:get_status/1,2</c></seemfa> or
-          sent to <seeerl marker="kernel:logger"><c>logger</c></seeerl>. The status
-          of the server is passed as a map with the following associations:
+        <p>
+          This callback is used to limit the status of the process
+          returned by
+          <seemfa marker="sys#get_status/1"><c>sys:get_status/1,2</c></seemfa>
+          or sent to <seeerl marker="kernel:logger"><c>logger</c></seeerl>.
         </p>
-        <taglist>
-          <tag><c>state => term()</c></tag>
-          <item>The internal state of the <c>gen_server</c> process.</item>
-          <tag><c>message => term()</c></tag>
-          <item>The message that caused the server to terminate.</item>
-          <tag><c>reason => term()</c></tag>
-          <item>The reason that caused the server to terminate.</item>
-          <tag><c>log => [</c><seetype marker="sys#system_event"><c>sys:system_event/0</c></seetype><c>]</c></tag>
-          <item>The <seemfa marker="sys#log/2">sys log</seemfa> of the server.</item>
-        </taglist>
-        <p>New associations may be added into the status map without prior notice.</p>
-        <p>The function is to return <c>NewStatus</c>, a map containing the same
-          associations as the input map.</p>
-        <p>Two possible use cases for this callback is to either remove
-          sensitive information from the state so that it not printed in log files,
-          or to remove large irrelevant terms of state that do clutter the logs.</p>
+        <p>
+          The callback gets a map <c>Status</c>
+          describing the current status and shall return a map
+          <c>NewStatus</c> with the same keys,
+          but it may transform some values.
+        </p>
+        <p>
+          Two possible use cases for this callback is to
+          remove sensitive information from the state
+          to prevent it from being printed in log files,
+          or to compact large irrelevant status items
+          that would only clutter the logs.
+        </p>
         <p>Example:</p>
         <code type="erl"><![CDATA[
 format_status(Status) ->

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -734,6 +734,19 @@ handle_event(_, _, State, Data) ->
       </desc>
     </datatype>
     <datatype>
+      <name name="event_content"/>
+      <desc>
+	<p>
+          Any event's content can be any term.
+        </p>
+        <p>
+          See <seetype marker="#event_type"><c>event_type</c></seetype>
+          that describes the origins of the different event types,
+          which is also where the event content comes from.
+        </p>
+      </desc>
+    </datatype>
+    <datatype>
       <name name="callback_mode_result"/>
       <desc>
 	<p>
@@ -1683,6 +1696,45 @@ handle_event(_, _, State, Data) ->
             over and over again.
 	  </p></item>
         </taglist>
+      </desc>
+    </datatype>
+
+    <datatype>
+      <name name="format_status"/>
+      <desc>
+        <p>
+          A map that describes the <c>gen_statem</c> status.
+          The keys are:
+	</p>
+        <taglist>
+          <tag><c>state</c></tag>
+          <item>The current state of the <c>gen_statem</c> process.</item>
+          <tag><c>data</c></tag>
+          <item>The state data of the the <c>gen_statem</c> process.</item>
+          <tag><c>reason</c></tag>
+          <item>The reason that caused the state machine to terminate.</item>
+          <tag><c>queue</c></tag>
+          <item>The event queue of the <c>gen_statem</c> process.</item>
+          <tag><c>postponed</c></tag>
+          <item>
+            The <seetype marker="#postpone">postponed</seetype>
+            events queue of the <c>gen_statem</c> process.
+          </item>
+          <tag><c>timeouts</c></tag>
+          <item>
+            The active
+            <seetype marker="#timeout_action">time-outs</seetype>
+            of the <c>gen_statem</c> process.
+          </item>
+          <tag><c>log</c></tag>
+          <item>
+            The <seemfa marker="sys#log/2">sys log</seemfa> of the server.
+          </item>
+        </taglist>
+        <p>
+          New associations may be added to the status map
+          without prior notice.
+        </p>
       </desc>
     </datatype>
   </datatypes>
@@ -2918,25 +2970,8 @@ init(Args) -> erlang:error(not_implemented, [Args]).</pre>
       <fsummary>Optional function for providing a term describing the
         current <c>gen_statem</c> status.</fsummary>
       <type>
-        <v>Status = #{ state => <seetype marker="#state">state()</seetype>,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        reason => term(),</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        data => <seetype marker="#data">data()</seetype>,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        queue => Queue,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        postponed => Postponed,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        timeouts => Timeouts,</v>
-        <v>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        log => Log }</v>
-        <v>NewStatus = Status</v>
-        <v>Queue = Postponed = [{EventType,EventContent}]</v>
-        <v>EventType = <seetype marker="#event_type">event_type()</seetype></v>
-        <v>Timeouts = [{<seetype marker="#timeout_event_type">timeout_event_type()</seetype>,EventContent}]</v>
-        <v>EventContent = term()</v>
-        <v>Log = [<seetype marker="sys#system_event">sys:system_event()</seetype>]</v>
+        <v>Status = <seetype marker="#format_status">format_status()</seetype></v>
+        <v>NewStatus = <seetype marker="#format_status">format_status()</seetype></v>
       </type>
       <desc>
         <note>
@@ -2971,31 +3006,18 @@ init(Args) -> erlang:error(not_implemented, [Args]).</pre>
           callback module wishing to change the
           <seemfa marker="sys#get_status/1"><c>sys:get_status/1,2</c></seemfa>
 	  return value and how
-          its status appears in termination error logs exports an
-          instance of <c>format_status/1</c>, which returns a map
-          describing the current status of the <c>gen_statem</c>.
+          its status appears in termination error logs exports
+          an instance of <c>format_status/1</c>,
+          which will get a map <c>Status</c> that describes
+          the current states of the <c>gen_statem</c>,
+          and shall return a map <c>NewStatus</c>
+          containing the same keys as the input map,
+          but it may transform some values.
 	</p>
-        <taglist>
-          <tag><c>state => </c><seetype marker="#state"><c>state()</c></seetype></tag>
-          <item>The current state of the <c>gen_statem</c> process.</item>
-          <tag><c>data => </c><seetype marker="#data"><c>data()</c></seetype></tag>
-          <item>The state data of the the <c>gen_statem</c> process.</item>
-          <tag><c>reason => term()</c></tag>
-          <item>The reason that caused the state machine to terminate.</item>
-          <tag><c>queue => [{</c><seetype marker="#event_type"><c>event_type()</c></seetype><c>,term()}]</c></tag>
-          <item>The event queue of the <c>gen_statem</c> process.</item>
-          <tag><c>postponed => [{</c><seetype marker="#event_type"><c>event_type()</c></seetype><c>,term()}]</c></tag>
-          <item>The <seetype marker="#postpone">postponed</seetype> events queue of the <c>gen_statem</c> process.</item>
-          <tag><c>log => [</c><seetype marker="sys#system_event"><c>sys:system_event/0</c></seetype><c>]</c></tag>
-          <item>The <seemfa marker="sys#log/2">sys log</seemfa> of the server.</item>
-        </taglist>
-        <p>New associations may be added into the status map without prior notice.</p>
-        <p>The function is to return <c>NewStatus</c>, a map containing the same
-          associations as the input map.</p>
-	<p>
+        <p>
 	  One use case for this function is to return compact alternative
           state representations to avoid having large state terms
-          printed in log files. Another use is to hide sensitive data from
+          printed in log files. Another is to hide sensitive data from
 	  being written to the error log.
 	</p>
         <p>Example:</p>

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -62,7 +62,8 @@
 -export([format_log/1, format_log/2]).
 
 -export_type([handler/0, handler_args/0, add_handler_ret/0,
-              del_handler_ret/0, request_id/0, request_id_collection/0]).
+              del_handler_ret/0, request_id/0, request_id_collection/0,
+              format_status/0]).
 
 -record(handler, {module             :: atom(),
 		  id = false,
@@ -122,12 +123,14 @@
       PDict :: [{Key :: term(), Value :: term()}],
       State :: term(),
       Status :: term().
+-type format_status() ::
+        #{ state => term(),
+           message => term(),
+           reason => term(),
+           log => [sys:system_event()] }.
 -callback format_status(Status) -> NewStatus when
-      Status :: #{ state => term(),
-                   message => term(),
-                   reason => term(),
-                   log => [sys:system_event()] },
-      NewStatus :: Status.
+      Status    :: format_status(),
+      NewStatus :: format_status().
 
 -optional_callbacks(
     [handle_info/2, terminate/2, code_change/3, format_status/1, format_status/2]).

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -127,7 +127,8 @@
    [from/0,
     reply_tag/0,
     request_id/0,
-    request_id_collection/0]).
+    request_id_collection/0,
+    format_status/0]).
 
 -export_type(
    [server_name/0,
@@ -180,18 +181,20 @@
 -callback code_change(OldVsn :: (term() | {down, term()}), State :: term(),
                       Extra :: term()) ->
     {ok, NewState :: term()} | {error, Reason :: term()}.
--callback format_status(Status) -> NewStatus when
-      Status :: #{ state => term(),
-                   message => term(),
-                   reason => term(),
-                   log => [sys:system_event()] },
-      NewStatus :: Status.
 -callback format_status(Opt, StatusData) -> Status when
       Opt :: 'normal' | 'terminate',
       StatusData :: [PDict | State],
       PDict :: [{Key :: term(), Value :: term()}],
       State :: term(),
       Status :: term().
+-type format_status() ::
+        #{ state => term(),
+           message => term(),
+           reason => term(),
+           log => [sys:system_event()] }.
+-callback format_status(Status) -> NewStatus when
+      Status    :: format_status(),
+      NewStatus :: format_status().
 
 -optional_callbacks(
     [handle_info/2, handle_continue/2, terminate/2, code_change/3,


### PR DESCRIPTION
The bad type spec in gen_statem, gen_server and gen_event
stated that the return value of format_status/1
is exactly the input argument value, which is incorrect.

To fix this, a type format_status() was needed in each module
to be used both for the argument and the return value.  This type
is exported since it is essential for the format_status/1 function.

Also, for gen_statem, a type event_content() :: term()
was needed to facilitate documentation and to not lure any future
code update into incorrectly using a type value EventContent
multiple times in a bad way.