### PR TITLE
Fix SEGV while crash dumping ETS ordered_set

### DIFF
--- a/erts/emulator/beam/erl_db_catree.c
+++ b/erts/emulator/beam/erl_db_catree.c
@@ -1196,7 +1196,7 @@ static void join_catree(DbTableCATree *tb,
     DbTableCATreeNode *neighbor_parent;
 
     ASSERT(thiz->is_base_node);
-    if (parent == NULL) {
+    if (parent == NULL || ERTS_IS_CRASH_DUMPING) {
         BASE_NODE_STAT_SET(thiz, 0);
         wunlock_base_node(thiz);
         return;
@@ -1342,7 +1342,7 @@ static void split_catree(DbTableCATree *tb,
     DbTableCATreeNode* ERTS_RESTRICT new_right;
     DbTableCATreeNode* ERTS_RESTRICT new_route;
 
-    if (less_than_two_elements(base->u.base.root)) {
+    if (less_than_two_elements(base->u.base.root) || ERTS_IS_CRASH_DUMPING) {
         if (!(tb->common.status & DB_CATREE_FORCE_SPLIT))
             BASE_NODE_STAT_SET(base, 0);
         wunlock_base_node(base);

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -5873,6 +5873,7 @@ init_scheduler_data(ErtsSchedulerData* esdp, int num,
     }
 
     esdp->reductions = 0;
+    esdp->rand_state = (Uint64)(UWord)esdp + ((Uint64)(UWord)esdp << 32);
 
     init_sched_wall_time(esdp, time_stamp);
     erts_port_task_handle_init(&esdp->nosuspend_port_task_handle);

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -673,6 +673,7 @@ struct ErtsSchedulerData_ {
     } pending_signal;
 
     Uint64 reductions;
+    Uint64 rand_state;
     ErtsSchedWallTime sched_wall_time;
     ErtsGCInfo gc_info;
     ErtsPortTaskHandle nosuspend_port_task_handle;
@@ -2798,19 +2799,15 @@ Uint32 erts_sched_local_random_hash_64_to_32_shift(Uint64 key)
 
 /*
  * This function attempts to return a random number based on the state
- * of the scheduler, the current process and the additional_seed
- * parameter.
+ * of the scheduler and the additional_seed parameter.
  */
 ERTS_GLB_INLINE
 Uint32 erts_sched_local_random(Uint additional_seed)
 {
     ErtsSchedulerData *esdp = erts_get_scheduler_data();
-    Uint64 seed =
-        additional_seed +
-        esdp->reductions +
-        esdp->current_process->fcalls +
-        (((Uint64)esdp->no) << 32);
-    return erts_sched_local_random_hash_64_to_32_shift(seed);
+    esdp->rand_state++;
+    return erts_sched_local_random_hash_64_to_32_shift(esdp->rand_state
+                                                       + additional_seed);
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
Fixes #5981.

Crash dump of ETS table with options `ordered_set` and `{write_concurrency,true}` could lead the segmentation violation crash if the crash dumping happens to not be done on behalf of an Erlang process running thread (current_process==NULL).
