### PR TITLE
Eliminate crash when optimization passes are disabled

### DIFF
--- a/lib/compiler/test/beam_ssa_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_SUITE.erl
@@ -886,6 +886,8 @@ grab_bag(_Config) ->
 
     {'EXIT',{{try_clause,[]},[_|_]}} = catch grab_bag_18(),
 
+    {'EXIT',{{badmatch,[whatever]},[_|_]}} = catch grab_bag_19(),
+
     ok.
 
 grab_bag_1() ->
@@ -1112,6 +1114,18 @@ grab_bag_18() ->
         end
     end.
 
+grab_bag_19() ->
+    ([<<bad/utf8>>] =
+         %% beam_ssa_pre_codegen would produce single-valued phi
+         %% nodes, which in turn would cause the constant propagation
+         %% in beam_ssa_codegen:prefer_xregs/2 to produce get_hd and
+         %% get_tl instructions with literal operands.
+         try
+             [whatever]
+         catch
+             _:_ when false ->
+                 ok
+         end) ! (some_atom ++ <<>>).
 
 redundant_br(_Config) ->
     {false,{x,y,z}} = redundant_br_1(id({x,y,z})),


### PR DESCRIPTION
When compiling the following code with optimization passes disabled:

    foo() ->
        ([<<bad/utf8>>] =
             try
                 [whatever]
             catch
                 _:_ when false ->
                     ok
             end) ! (some_atom ++ <<>>).

`beam_validator` rejects the code with the following message:

    some_module:1: function foo/0+11:
      Internal consistency check failed - please report this bug.
      Instruction: {get_hd,{literal,[whatever]},{x,0}}
      Error:       {literal_not_allowed,{literal,[whatever]}}:

All optimization passes are supposed to be optional, so this crash is
not acceptable even though the code is nonsensical. Eliminate the
crash by having `beam_ssa_pre_codegen` re-run its code cleaning
pass until there are no more unreachable blocks.