### PR TITLE
Add transaction_log_dir option to Mnesia

### DIFF
--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -2551,6 +2551,7 @@ system_info2(transaction_commits) -> mnesia_lib:read_counter(trans_commits);
 system_info2(transaction_restarts) -> mnesia_lib:read_counter(trans_restarts);
 system_info2(transaction_log_writes) -> mnesia_dumper:get_log_writes();
 system_info2(core_dir) ->  mnesia_monitor:get_env(core_dir);
+system_info2(transaction_log_dir) -> mnesia_monitor:get_env(transaction_log_dir);
 system_info2(no_table_loaders) ->  mnesia_monitor:get_env(no_table_loaders);
 system_info2(dc_dump_limit) ->  mnesia_monitor:get_env(dc_dump_limit);
 system_info2(send_compressed) -> mnesia_monitor:get_env(send_compressed);
@@ -2597,6 +2598,7 @@ system_info_items(yes) ->
      transactions,
      use_dir,
      core_dir,
+     transaction_log_dir,
      no_table_loaders,
      dc_dump_limit,
      send_compressed,
@@ -2627,6 +2629,7 @@ system_info_items(no) ->
      schema_version,
      use_dir,
      core_dir,
+     transaction_log_dir,
      version
     ].
 

--- a/lib/mnesia/src/mnesia_lib.erl
+++ b/lib/mnesia/src/mnesia_lib.erl
@@ -306,6 +306,12 @@ exists(Fname) -> filelib:is_regular(Fname).
 
 dir() -> mnesia_monitor:get_env(dir).
 
+dir("LATEST.LOG" = Fname) ->
+    TLogDir = mnesia_monitor:get_env(transaction_log_dir),
+    filename:join(TLogDir, Fname);
+dir("PREVIOUS.LOG" = Fname) ->
+    TLogDir = mnesia_monitor:get_env(transaction_log_dir),
+    filename:join(TLogDir, Fname);
 dir(Fname) ->
     filename:join([dir(), to_list(Fname)]).
 

--- a/lib/mnesia/src/mnesia_monitor.erl
+++ b/lib/mnesia/src/mnesia_monitor.erl
@@ -674,6 +674,7 @@ env() ->
      backup_module,
      debug,
      dir,
+     transaction_log_dir,
      dump_disc_copies_at_startup,
      dump_log_load_regulation,
      dump_log_time_threshold,
@@ -708,6 +709,8 @@ default_env(debug) ->
 default_env(dir) ->
     Name = lists:concat(["Mnesia.", node()]),
     filename:absname(Name);
+default_env(transaction_log_dir) ->
+    get_env(dir);
 default_env(dump_disc_copies_at_startup) ->
     true;
 default_env(dump_log_load_regulation) ->
@@ -763,6 +766,7 @@ do_check_type(debug, trace) -> trace;
 do_check_type(debug, true) -> debug;
 do_check_type(debug, verbose) -> verbose;
 do_check_type(dir, V) -> filename:absname(V);
+do_check_type(transaction_log_dir, V) -> filename:absname(V);
 do_check_type(dump_disc_copies_at_startup, B) -> bool(B);
 do_check_type(dump_log_load_regulation, B) -> bool(B);
 do_check_type(dump_log_time_threshold, I) when is_integer(I), I > 0 -> I;


### PR DESCRIPTION
Hi!
We've noticed `mnesia overloaded` warnings in one system, and wanted to address this somehow. Since the warnings are happening when the transaction log files are to be dumped before the previous dumping has finished, the issue seems to be with disc performance. Changing `dump_log_write_treshold​` or `dc_dump_limit​` did not help, from what I understand. So the proposed solution was to put the transaction log files on a different filesystem, possibly on a different, faster drive then the Mnesia directory. This would require adding a configuration parameter with a path specifying where to put the log files, something like proposed in this PR - `transaction_log_dir`.

I've tried to write testcases for this option, and from what I checked locally, the proposal seems to work. I did not write the documentation yet, because it maybe better to get some feedback before that.