### PR TITLE
Improve the type-based optimizations

### DIFF
--- a/erts/emulator/beam/beam_file.c
+++ b/erts/emulator/beam/beam_file.c
@@ -595,30 +595,20 @@ static void init_fallback_type_table(BeamFile *beam) {
     types->fallback = 1;
 
     types->entries[0].type_union = BEAM_TYPE_ANY;
-    types->entries[0].min = 0;
-    types->entries[0].max = -1;
+    types->entries[0].min = MAX_SMALL + 1;
+    types->entries[0].max = MIN_SMALL - 1;
 }
 
-static int parse_type_chunk(BeamFile *beam, IFF_Chunk *chunk) {
+static int parse_type_chunk_otp_25(BeamFile *beam, BeamReader *p_reader) {
     BeamFile_TypeTable *types;
-    BeamReader reader;
 
-    Sint32 version, count;
+    Sint32 count;
     int i;
-
-    beamreader_init(chunk->data, chunk->size, &reader);
-
-    LoadAssert(beamreader_read_i32(&reader, &version));
-    if (version != BEAM_TYPES_VERSION) {
-        /* Incompatible type format. */
-        init_fallback_type_table(beam);
-        return 1;
-    }
 
     types = &beam->types;
     ASSERT(types->entries == NULL);
 
-    LoadAssert(beamreader_read_i32(&reader, &count));
+    LoadAssert(beamreader_read_i32(p_reader, &count));
     LoadAssert(CHECK_ITEM_COUNT(count, 0, sizeof(types->entries[0])));
     LoadAssert(count >= 1);
 
@@ -630,8 +620,8 @@ static int parse_type_chunk(BeamFile *beam, IFF_Chunk *chunk) {
     for (i = 0; i < count; i++) {
         const byte *type_data;
 
-        LoadAssert(beamreader_read_bytes(&reader, 18, &type_data));
-        LoadAssert(beam_types_decode(type_data, 18, &types->entries[i]));
+        LoadAssert(beamreader_read_bytes(p_reader, 18, &type_data));
+        LoadAssert(beam_types_decode_otp_25(type_data, 18, &types->entries[i]));
     }
 
     /* The first entry MUST be the "any type." */
@@ -639,6 +629,61 @@ static int parse_type_chunk(BeamFile *beam, IFF_Chunk *chunk) {
     LoadAssert(types->entries[0].min > types->entries[0].max);
 
     return 1;
+}
+
+static int parse_type_chunk_otp_26(BeamFile *beam, BeamReader *p_reader) {
+    BeamFile_TypeTable *types;
+
+    Sint32 count;
+    int i;
+
+    types = &beam->types;
+    ASSERT(types->entries == NULL);
+
+    LoadAssert(beamreader_read_i32(p_reader, &count));
+    LoadAssert(CHECK_ITEM_COUNT(count, 0, sizeof(types->entries[0])));
+    LoadAssert(count >= 1);
+
+    types->entries = erts_alloc(ERTS_ALC_T_PREPARED_CODE,
+                                count * sizeof(types->entries[0]));
+    types->count = count;
+    types->fallback = 0;
+
+    for (i = 0; i < count; i++) {
+        const byte *type_data;
+        int extra;
+
+        LoadAssert(beamreader_read_bytes(p_reader, 2, &type_data));
+        extra = beam_types_decode_type_otp_26(type_data, &types->entries[i]);
+        LoadAssert(extra >= 0);
+        LoadAssert(beamreader_read_bytes(p_reader, extra, &type_data));
+        beam_types_decode_extra_otp_26(type_data, &types->entries[i]);
+    }
+
+    /* The first entry MUST be the "any type." */
+    LoadAssert(types->entries[0].type_union == BEAM_TYPE_ANY);
+    LoadAssert(types->entries[0].min > types->entries[0].max);
+
+    return 1;
+}
+
+static int parse_type_chunk(BeamFile *beam, IFF_Chunk *chunk) {
+    BeamReader reader;
+    Sint32 version;
+
+    beamreader_init(chunk->data, chunk->size, &reader);
+
+    LoadAssert(beamreader_read_i32(&reader, &version));
+    switch (version) {
+    case 1:                     /* OTP 25 */
+        return parse_type_chunk_otp_25(beam, &reader);
+    case BEAM_TYPES_VERSION:    /* OTP 26 */
+        return parse_type_chunk_otp_26(beam, &reader);
+    default:
+        /* Incompatible type format. */
+        init_fallback_type_table(beam);
+        return 1;
+    }
 }
 
 static ErlHeapFragment *new_literal_fragment(Uint size)

--- a/erts/emulator/beam/beam_types.c
+++ b/erts/emulator/beam/beam_types.c
@@ -30,7 +30,55 @@
 
 static Sint64 get_sint64(const byte *data);
 
-int beam_types_decode(const byte *data, Uint size, BeamType *out) {
+int beam_types_decode_type_otp_26(const byte *data, BeamType *out) {
+    int types;
+    int extra = 0;
+
+    types = (Uint16)data[0] << 8 | (Uint16)data[1];
+    if (types == BEAM_TYPE_NONE) {
+        return -1;
+    }
+    out->type_union = types;
+
+    if (types & BEAM_TYPE_HAS_LOWER_BOUND) {
+        extra += 8;
+    }
+
+    if (types & BEAM_TYPE_HAS_UPPER_BOUND) {
+        extra += 8;
+    }
+
+    if (types & BEAM_TYPE_HAS_UNIT) {
+        extra += 1;
+    }
+
+    return extra;
+}
+
+void beam_types_decode_extra_otp_26(const byte *data, BeamType *out) {
+    int types = out->type_union;
+    out->type_union = types & BEAM_TYPE_ANY;
+
+    out->min = MAX_SMALL + 1;
+    out->max = MIN_SMALL - 1;
+    out->size_unit = 1;
+
+    if (types & BEAM_TYPE_HAS_LOWER_BOUND) {
+        out->min = get_sint64(data);
+        data += 8;
+    }
+
+    if (types & BEAM_TYPE_HAS_UPPER_BOUND) {
+        out->max = get_sint64(data);
+        data += 8;
+    }
+
+    if (types & BEAM_TYPE_HAS_UNIT) {
+        out->size_unit = data[0] + 1;
+    }
+}
+
+int beam_types_decode_otp_25(const byte *data, Uint size, BeamType *out) {
     int types;
 
     if (size != 18) {
@@ -49,6 +97,13 @@ int beam_types_decode(const byte *data, Uint size, BeamType *out) {
     data += 8;
     out->max = get_sint64(data);
 
+    if (out->min > out->max) {
+        out->min = MAX_SMALL + 1;
+        out->max = MIN_SMALL - 1;
+    }
+
+    out->size_unit = 1;
+
     return 1;
 }
 
@@ -57,7 +112,7 @@ static Sint64 get_sint64(const byte *data) {
     int i;
 
     for (i = 0; i < 8; i++) {
-        value = value << 8 | (Sint16)data[i];
+        value = value << 8 | (Sint64)data[i];
     }
     return value;
 }

--- a/erts/emulator/beam/beam_types.h
+++ b/erts/emulator/beam/beam_types.h
@@ -37,7 +37,7 @@
 
 #include "sys.h"
 
-#define BEAM_TYPES_VERSION 1
+#define BEAM_TYPES_VERSION 2
 
 #define BEAM_TYPE_NONE               (0)
 
@@ -56,6 +56,10 @@
 #define BEAM_TYPE_TUPLE              (1 << 12)
 
 #define BEAM_TYPE_ANY                ((1 << 13) - 1)
+
+#define BEAM_TYPE_HAS_LOWER_BOUND    (1 << 13)
+#define BEAM_TYPE_HAS_UPPER_BOUND    (1 << 14)
+#define BEAM_TYPE_HAS_UNIT           (1 << 15)
 
 #define BEAM_TYPE_MASK_BOXED        \
     (BEAM_TYPE_BITSTRING |          \
@@ -91,11 +95,27 @@ typedef struct {
      * be. When a single bit is set, the term will always be of that type. */
     int type_union;
 
-    /** @brief Minimum and maximum values. Only valid if min <= max. */
+    /** @brief Minimum and maximum values. Valid if at least one of
+     * IS_SSMALL(min) and IS_SSMALL(max) is true; otherwise the range is
+     * unknown.
+     *
+     * If and only if min < max, then the value is always a small within
+     * the range min trough max (including the endpoints).
+     *
+     * If and only if IS_SSMALL(min) && !IS_SSMALL(max) is true, then
+     * the value is greater than or equal to min.
+     *
+     * If and only if !IS_SSMALL(min) && IS_SSMALL(max), then the
+     * value is less than or equal to min. */
     Sint64 min;
     Sint64 max;
+
+    /** @brief Unit for bitstring size. */
+    byte size_unit;
 } BeamType;
 
-int beam_types_decode(const byte *data, Uint size, BeamType *out);
+int beam_types_decode_type_otp_26(const byte *data, BeamType *out);
+void beam_types_decode_extra_otp_26(const byte *data, BeamType *out);
 
+int beam_types_decode_otp_25(const byte *data, Uint size, BeamType *out);
 #endif

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1053,7 +1053,7 @@ protected:
         return beam->types.entries[typeIndex].type_union;
     }
 
-    auto getIntRange(const ArgSource &arg) const {
+    auto getClampedRange(const ArgSource &arg) const {
         if (arg.isSmall()) {
             Sint value = arg.as<ArgSmall>().getSigned();
             return std::make_pair(value, value);
@@ -1063,9 +1063,40 @@ protected:
 
             ASSERT(typeIndex < beam->types.count);
             const auto &entry = beam->types.entries[typeIndex];
-            ASSERT(entry.type_union & BEAM_TYPE_INTEGER);
-            return std::make_pair(entry.min, entry.max);
+            if (entry.min <= entry.max) {
+                return std::make_pair(entry.min, entry.max);
+            } else if (IS_SSMALL(entry.min) && !IS_SSMALL(entry.max)) {
+                return std::make_pair(entry.min, MAX_SMALL);
+            } else if (!IS_SSMALL(entry.min) && IS_SSMALL(entry.max)) {
+                return std::make_pair(MIN_SMALL, entry.max);
+            } else {
+                return std::make_pair(MIN_SMALL, MAX_SMALL);
+            }
         }
+    }
+
+    int getSizeUnit(const ArgSource &arg) const {
+        auto typeIndex =
+                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+
+        ASSERT(typeIndex < beam->types.count);
+        return beam->types.entries[typeIndex].size_unit;
+    }
+
+    bool hasLowerBound(const ArgSource &arg) const {
+        auto typeIndex =
+                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+        ASSERT(typeIndex < beam->types.count);
+        const auto &entry = beam->types.entries[typeIndex];
+        return IS_SSMALL(entry.min) && !IS_SSMALL(entry.max);
+    }
+
+    bool hasUpperBound(const ArgSource &arg) const {
+        auto typeIndex =
+                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+        ASSERT(typeIndex < beam->types.count);
+        const auto &entry = beam->types.entries[typeIndex];
+        return !IS_SSMALL(entry.min) && IS_SSMALL(entry.max);
     }
 
     bool always_small(const ArgSource &arg) const {
@@ -1073,13 +1104,11 @@ protected:
             return true;
         }
 
-        int type_union = getTypeUnion(arg);
-        if (type_union == BEAM_TYPE_INTEGER) {
-            auto [min, max] = getIntRange(arg);
-            return min <= max;
-        } else {
-            return false;
-        }
+        auto typeIndex =
+                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+        ASSERT(typeIndex < beam->types.count);
+        const auto &entry = beam->types.entries[typeIndex];
+        return entry.type_union == BEAM_TYPE_INTEGER && entry.min <= entry.max;
     }
 
     bool always_immediate(const ArgSource &arg) const {
@@ -1142,67 +1171,53 @@ protected:
         return always_one_of(arg, type_id);
     }
 
-    bool is_sum_small(const ArgSource &LHS, const ArgSource &RHS) {
-        if (!(always_small(LHS) && always_small(RHS))) {
-            return false;
-        } else {
-            Sint min, max;
-            auto [min1, max1] = getIntRange(LHS);
-            auto [min2, max2] = getIntRange(RHS);
-            min = min1 + min2;
-            max = max1 + max2;
-            return IS_SSMALL(min) && IS_SSMALL(max);
-        }
+    bool is_sum_small_if_args_are_small(const ArgSource &LHS,
+                                        const ArgSource &RHS) {
+        Sint min, max;
+        auto [min1, max1] = getClampedRange(LHS);
+        auto [min2, max2] = getClampedRange(RHS);
+        min = min1 + min2;
+        max = max1 + max2;
+        return IS_SSMALL(min) && IS_SSMALL(max);
     }
 
-    bool is_difference_small(const ArgSource &LHS, const ArgSource &RHS) {
-        if (!(always_small(LHS) && always_small(RHS))) {
-            return false;
-        } else {
-            Sint min, max;
-            auto [min1, max1] = getIntRange(LHS);
-            auto [min2, max2] = getIntRange(RHS);
-            min = min1 - max2;
-            max = max1 - min2;
-            return IS_SSMALL(min) && IS_SSMALL(max);
-        }
+    bool is_diff_small_if_args_are_small(const ArgSource &LHS,
+                                         const ArgSource &RHS) {
+        Sint min, max;
+        auto [min1, max1] = getClampedRange(LHS);
+        auto [min2, max2] = getClampedRange(RHS);
+        min = min1 - max2;
+        max = max1 - min2;
+        return IS_SSMALL(min) && IS_SSMALL(max);
     }
 
-    bool is_product_small(const ArgSource &LHS, const ArgSource &RHS) {
-        if (!(always_small(LHS) && always_small(RHS))) {
-            return false;
-        } else {
-            auto [min1, max1] = getIntRange(LHS);
-            auto [min2, max2] = getIntRange(RHS);
-            auto mag1 = std::max(std::abs(min1), std::abs(max1));
-            auto mag2 = std::max(std::abs(min2), std::abs(max2));
+    bool is_product_small_if_args_are_small(const ArgSource &LHS,
+                                            const ArgSource &RHS) {
+        auto [min1, max1] = getClampedRange(LHS);
+        auto [min2, max2] = getClampedRange(RHS);
+        auto mag1 = std::max(std::abs(min1), std::abs(max1));
+        auto mag2 = std::max(std::abs(min2), std::abs(max2));
 
-            /*
-             * mag1 * mag2 <= MAX_SMALL
-             * mag1 <= MAX_SMALL / mag2   (when mag2 != 0)
-             */
-            ERTS_CT_ASSERT(MAX_SMALL < -MIN_SMALL);
-            return mag2 == 0 || mag1 <= MAX_SMALL / mag2;
-        }
+        /*
+         * mag1 * mag2 <= MAX_SMALL
+         * mag1 <= MAX_SMALL / mag2   (when mag2 != 0)
+         */
+        ERTS_CT_ASSERT(MAX_SMALL < -MIN_SMALL);
+        return mag2 == 0 || mag1 <= MAX_SMALL / mag2;
     }
 
     bool is_bsl_small(const ArgSource &LHS, const ArgSource &RHS) {
-        /*
-         * In the code compiled by scripts/diffable, there never
-         * seems to be any range information for the RHS. Therefore,
-         * don't bother unless RHS is an immediate small.
-         */
-        if (!(always_small(LHS) && RHS.isSmall())) {
+        if (!(always_small(LHS) && always_small(RHS))) {
             return false;
         } else {
-            auto [min1, max1] = getIntRange(LHS);
-            auto rhs_val = RHS.as<ArgSmall>().getSigned();
+            auto [min1, max1] = getClampedRange(LHS);
+            auto [min2, max2] = getClampedRange(RHS);
 
-            if (min1 < 0 || max1 == 0 || rhs_val < 0) {
+            if (min1 < 0 || max1 == 0 || min2 < 0) {
                 return false;
             }
 
-            return rhs_val < Support::clz(max1) - _TAG_IMMED1_SIZE;
+            return max2 < Support::clz(max1) - _TAG_IMMED1_SIZE;
         }
     }
 
@@ -1248,6 +1263,19 @@ protected:
     void emit_get_list(const arm::Gp boxed_ptr,
                        const ArgRegister &Hd,
                        const ArgRegister &Tl);
+
+    void emit_add_sub_types(bool is_small_result,
+                            const ArgSource &LHS,
+                            const a64::Gp lhs_reg,
+                            const ArgSource &RHS,
+                            const a64::Gp rhs_reg,
+                            const Label next);
+
+    void emit_are_both_small(const ArgSource &LHS,
+                             const a64::Gp lhs_reg,
+                             const ArgSource &RHS,
+                             const a64::Gp rhs_reg,
+                             const Label next);
 
     void emit_div_rem(const ArgLabel &Fail,
                       const ArgSource &LHS,

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "beam_asm.hpp"
+#include <numeric>
 
 extern "C"
 {
@@ -1735,6 +1736,17 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
          * Test whether we can omit the code for the error handler.
          */
         switch (seg.type) {
+        case am_append:
+            if (std::gcd(seg.unit, getSizeUnit(seg.src)) != seg.unit) {
+                need_error_handler = true;
+            }
+            break;
+        case am_binary:
+            if (!(seg.size.isAtom() && seg.size.as<ArgAtom>().get() == am_all &&
+                  std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit)) {
+                need_error_handler = true;
+            }
+            break;
         case am_integer:
             if (!always_one_of(seg.src, BEAM_TYPE_INTEGER)) {
                 need_error_handler = true;
@@ -1848,7 +1860,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             comment("size binary/integer/float/string");
 
             if (always_small(seg.size)) {
-                auto [min, _] = getIntRange(seg.size);
+                auto [min, _] = getClampedRange(seg.size);
                 if (min >= 0) {
                     can_fail = false;
                 }
@@ -1999,15 +2011,21 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
                            Update::eReductions>(Live.get() + 1);
 
-        if (Fail.get() == 0) {
-            mov_arg(ARG3, ArgXRegister(Live.get()));
-            mov_imm(ARG4,
-                    beam_jit_update_bsc_reason_info(seg.error_info,
-                                                    BSC_REASON_BADARG,
-                                                    BSC_INFO_FVALUE,
-                                                    BSC_VALUE_ARG3));
+        if (std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
+            /* There is no way the call can fail with a system_limit
+             * exception on a 64-bit architecture. */
+            comment("skipped test for success because units are compatible");
+        } else {
+            if (Fail.get() == 0) {
+                mov_arg(ARG3, ArgXRegister(Live.get()));
+                mov_imm(ARG4,
+                        beam_jit_update_bsc_reason_info(seg.error_info,
+                                                        BSC_REASON_BADARG,
+                                                        BSC_INFO_FVALUE,
+                                                        BSC_VALUE_ARG3));
+            }
+            emit_branch_if_not_value(ARG1, resolve_label(error, dispUnknown));
         }
-        emit_branch_if_not_value(ARG1, resolve_label(error, dispUnknown));
     } else if (segments[0].type == am_private_append) {
         BscSegment seg = segments[0];
         comment("private append to binary");
@@ -2084,7 +2102,15 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
 
     segments = bs_combine_segments(segments);
 
+    /* Keep track of the bit offset from the being of the binary.
+     * Set to -1 if offset is not known (when a segment of unknown
+     * size has been seen). */
     Sint bit_offset = 0;
+
+    /* Keep track of whether the current segment is byte-aligned.  (A
+     * segment can be known to be byte-aligned even if the bit offset
+     * is unknown.) */
+    bool is_byte_aligned = true;
 
     /* Build each segment of the binary. */
     for (auto seg : segments) {
@@ -2126,8 +2152,9 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                                              BSC_REASON_BADARG,
                                                              BSC_INFO_UNIT,
                                                              BSC_VALUE_FVALUE);
-                if (seg.unit == 1) {
-                    comment("skipped test for success because unit =:= 1");
+                if (std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
+                    comment("skipped test for success because units are "
+                            "compatible");
                     can_fail = false;
                 }
             } else {
@@ -2318,13 +2345,14 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                  seg.effectiveSize,
                                  arm::Gp());
 
-                if (bit_offset < 0) {
-                    /* Bit offset is unknown. Must test alignment. */
+                if (bit_offset < 0 && !is_byte_aligned) {
+                    /* Bit offset is unknown and is not known to be
+                     * byte aligned. Must test alignment. */
                     a.tst(bin_offset, imm(7));
                     a.b_eq(store);
                 }
 
-                if (bit_offset % 8 != 0) {
+                if (!is_byte_aligned) {
                     /* Bit offset is tested or known to be unaligned. */
                     a.str(bin_data, TMP_MEM2q); /* MEM1q is already in use. */
                     lea(ARG1, TMP_MEM2q);
@@ -2335,14 +2363,16 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                     emit_leave_runtime(Live.get());
 
                     if (bit_offset < 0) {
-                        /* Need to jump around the store code. */
+                        /* The bit offset is unknown, which implies that
+                         * there exists store code that we will need to
+                         * branch past. */
                         a.b(done);
                     }
                 }
 
                 a.bind(store);
 
-                if (bit_offset < 0 || bit_offset % 8 == 0) {
+                if (bit_offset < 0 || is_byte_aligned) {
                     /* Bit offset is tested or known to be
                      * byte-aligned. Emit inline code to store the
                      * value of the accumulator into the binary. */
@@ -2427,7 +2457,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                     }
                 }
 
-                if (bit_offset % 8 == 0 && seg.src.isSmall() &&
+                if (is_byte_aligned && seg.src.isSmall() &&
                     seg.src.as<ArgSmall>().getSigned() == 0) {
                     /* Optimize the special case of setting a known
                      * byte-aligned segment to zero. */
@@ -2541,6 +2571,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             break;
         }
 
+        /* Try to keep track of the bit offset. */
         if (bit_offset >= 0 && (seg.action == BscSegment::action::DIRECT ||
                                 seg.action == BscSegment::action::STORE)) {
             if (seg.effectiveSize >= 0) {
@@ -2548,6 +2579,22 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             } else {
                 bit_offset = -1;
             }
+        }
+
+        /* Try to keep track whether the next segment is byte
+         * aligned. */
+        if (seg.type == am_append || seg.type == am_private_append) {
+            if (std::gcd(getSizeUnit(seg.src), 8) != 8) {
+                is_byte_aligned = false;
+            }
+        } else if (bit_offset % 8 == 0) {
+            is_byte_aligned = true;
+        } else if (seg.effectiveSize >= 0) {
+            if (seg.effectiveSize % 8 != 0) {
+                is_byte_aligned = false;
+            }
+        } else if (std::gcd(seg.unit, 8) != 8) {
+            is_byte_aligned = false;
         }
     }
 

--- a/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
@@ -477,9 +477,8 @@ void BeamModuleAssembler::emit_bif_element(const ArgLabel &Fail,
         if (is_tuple(tuple_literal)) {
             Label next = a.newLabel(), fail = a.newLabel();
             Sint size = Sint(arityval(*tuple_val(tuple_literal)));
-            auto [min, max] = getIntRange(Pos);
-            bool is_bounded = min <= max;
-            bool can_fail = !is_bounded || min < 1 || size < max;
+            auto [min, max] = getClampedRange(Pos);
+            bool can_fail = min < 1 || size < max;
             auto [pos, tuple] = load_sources(Pos, ARG3, Tuple, ARG4);
             auto dst = init_destination(Dst, ARG1);
 
@@ -499,14 +498,14 @@ void BeamModuleAssembler::emit_bif_element(const ArgLabel &Fail,
 
             a.asr(TMP3, pos.reg, imm(_TAG_IMMED1_SIZE));
 
-            if (is_bounded && min >= 1) {
+            if (min >= 1) {
                 comment("skipped check for position >= 1");
             } else {
                 a.cmp(TMP3, imm(1));
                 a.b_mi(fail);
             }
 
-            if (is_bounded && size >= max) {
+            if (size >= max) {
                 comment("skipped check for position beyond tuple");
             } else {
                 mov_imm(TMP2, size);

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -747,7 +747,7 @@ protected:
 #endif
     }
 
-    void emit_is_boxed(Label Fail, x86::Gp Src, Distance dist = dLong) {
+    void emit_test_boxed(x86::Gp Src) {
         /* Use the shortest possible instruction depending on the source
          * register. */
         if (Src == x86::rax || Src == x86::rdi || Src == x86::rsi ||
@@ -756,10 +756,23 @@ protected:
         } else {
             a.test(Src.r32(), imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_BOXED));
         }
+    }
+
+    void emit_is_boxed(Label Fail, x86::Gp Src, Distance dist = dLong) {
+        emit_test_boxed(Src);
         if (dist == dShort) {
             a.short_().jne(Fail);
         } else {
             a.jne(Fail);
+        }
+    }
+
+    void emit_is_not_boxed(Label Fail, x86::Gp Src, Distance dist = dLong) {
+        emit_test_boxed(Src);
+        if (dist == dShort) {
+            a.short_().je(Fail);
+        } else {
+            a.je(Fail);
         }
     }
 
@@ -1137,7 +1150,7 @@ protected:
         return beam->types.entries[typeIndex].type_union;
     }
 
-    auto getIntRange(const ArgSource &arg) const {
+    auto getClampedRange(const ArgSource &arg) const {
         if (arg.isSmall()) {
             Sint value = arg.as<ArgSmall>().getSigned();
             return std::make_pair(value, value);
@@ -1147,9 +1160,40 @@ protected:
 
             ASSERT(typeIndex < beam->types.count);
             const auto &entry = beam->types.entries[typeIndex];
-            ASSERT(entry.type_union & BEAM_TYPE_INTEGER);
-            return std::make_pair(entry.min, entry.max);
+            if (entry.min <= entry.max) {
+                return std::make_pair(entry.min, entry.max);
+            } else if (IS_SSMALL(entry.min) && !IS_SSMALL(entry.max)) {
+                return std::make_pair(entry.min, MAX_SMALL);
+            } else if (!IS_SSMALL(entry.min) && IS_SSMALL(entry.max)) {
+                return std::make_pair(MIN_SMALL, entry.max);
+            } else {
+                return std::make_pair(MIN_SMALL, MAX_SMALL);
+            }
         }
+    }
+
+    int getSizeUnit(const ArgSource &arg) const {
+        auto typeIndex =
+                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+
+        ASSERT(typeIndex < beam->types.count);
+        return beam->types.entries[typeIndex].size_unit;
+    }
+
+    bool hasLowerBound(const ArgSource &arg) const {
+        auto typeIndex =
+                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+        ASSERT(typeIndex < beam->types.count);
+        const auto &entry = beam->types.entries[typeIndex];
+        return IS_SSMALL(entry.min) && !IS_SSMALL(entry.max);
+    }
+
+    bool hasUpperBound(const ArgSource &arg) const {
+        auto typeIndex =
+                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+        ASSERT(typeIndex < beam->types.count);
+        const auto &entry = beam->types.entries[typeIndex];
+        return !IS_SSMALL(entry.min) && IS_SSMALL(entry.max);
     }
 
     bool always_small(const ArgSource &arg) const {
@@ -1157,13 +1201,11 @@ protected:
             return true;
         }
 
-        int type_union = getTypeUnion(arg);
-        if (type_union == BEAM_TYPE_INTEGER) {
-            auto [min, max] = getIntRange(arg);
-            return min <= max;
-        } else {
-            return false;
-        }
+        auto typeIndex =
+                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+        ASSERT(typeIndex < beam->types.count);
+        const auto &entry = beam->types.entries[typeIndex];
+        return entry.type_union == BEAM_TYPE_INTEGER && entry.min <= entry.max;
     }
 
     bool always_immediate(const ArgSource &arg) const {
@@ -1226,67 +1268,53 @@ protected:
         return always_one_of(arg, type_id);
     }
 
-    bool is_sum_small(const ArgSource &LHS, const ArgSource &RHS) {
-        if (!(always_small(LHS) && always_small(RHS))) {
-            return false;
-        } else {
-            Sint min, max;
-            auto [min1, max1] = getIntRange(LHS);
-            auto [min2, max2] = getIntRange(RHS);
-            min = min1 + min2;
-            max = max1 + max2;
-            return IS_SSMALL(min) && IS_SSMALL(max);
-        }
+    bool is_sum_small_if_args_are_small(const ArgSource &LHS,
+                                        const ArgSource &RHS) {
+        Sint min, max;
+        auto [min1, max1] = getClampedRange(LHS);
+        auto [min2, max2] = getClampedRange(RHS);
+        min = min1 + min2;
+        max = max1 + max2;
+        return IS_SSMALL(min) && IS_SSMALL(max);
     }
 
-    bool is_difference_small(const ArgSource &LHS, const ArgSource &RHS) {
-        if (!(always_small(LHS) && always_small(RHS))) {
-            return false;
-        } else {
-            Sint min, max;
-            auto [min1, max1] = getIntRange(LHS);
-            auto [min2, max2] = getIntRange(RHS);
-            min = min1 - max2;
-            max = max1 - min2;
-            return IS_SSMALL(min) && IS_SSMALL(max);
-        }
+    bool is_diff_small_if_args_are_small(const ArgSource &LHS,
+                                         const ArgSource &RHS) {
+        Sint min, max;
+        auto [min1, max1] = getClampedRange(LHS);
+        auto [min2, max2] = getClampedRange(RHS);
+        min = min1 - max2;
+        max = max1 - min2;
+        return IS_SSMALL(min) && IS_SSMALL(max);
     }
 
-    bool is_product_small(const ArgSource &LHS, const ArgSource &RHS) {
-        if (!(always_small(LHS) && always_small(RHS))) {
-            return false;
-        } else {
-            auto [min1, max1] = getIntRange(LHS);
-            auto [min2, max2] = getIntRange(RHS);
-            auto mag1 = std::max(std::abs(min1), std::abs(max1));
-            auto mag2 = std::max(std::abs(min2), std::abs(max2));
+    bool is_product_small_if_args_are_small(const ArgSource &LHS,
+                                            const ArgSource &RHS) {
+        auto [min1, max1] = getClampedRange(LHS);
+        auto [min2, max2] = getClampedRange(RHS);
+        auto mag1 = std::max(std::abs(min1), std::abs(max1));
+        auto mag2 = std::max(std::abs(min2), std::abs(max2));
 
-            /*
-             * mag1 * mag2 <= MAX_SMALL
-             * mag1 <= MAX_SMALL / mag2   (when mag2 != 0)
-             */
-            ERTS_CT_ASSERT(MAX_SMALL < -MIN_SMALL);
-            return mag2 == 0 || mag1 <= MAX_SMALL / mag2;
-        }
+        /*
+         * mag1 * mag2 <= MAX_SMALL
+         * mag1 <= MAX_SMALL / mag2   (when mag2 != 0)
+         */
+        ERTS_CT_ASSERT(MAX_SMALL < -MIN_SMALL);
+        return mag2 == 0 || mag1 <= MAX_SMALL / mag2;
     }
 
     bool is_bsl_small(const ArgSource &LHS, const ArgSource &RHS) {
-        /*
-         * In the code compiled by scripts/diffable, there never
-         * seems to be any range information for the RHS. Therefore,
-         * don't bother unless RHS is an immediate small.
-         */
-        if (!(always_small(LHS) && RHS.isSmall())) {
+        if (!(always_small(LHS) && always_small(RHS))) {
             return false;
         } else {
-            auto [min1, max1] = getIntRange(LHS);
-            auto rhs_val = RHS.as<ArgSmall>().getSigned();
+            auto [min1, max1] = getClampedRange(LHS);
+            auto [min2, max2] = getClampedRange(RHS);
 
-            if (min1 < 0 || max1 == 0 || rhs_val < 0) {
+            if (min1 < 0 || max1 == 0 || min2 < 0) {
                 return false;
             }
 
-            return rhs_val < Support::clz(max1) - _TAG_IMMED1_SIZE;
+            return max2 < Support::clz(max1) - _TAG_IMMED1_SIZE;
         }
     }
 

--- a/erts/emulator/beam/jit/x86/instr_arith.cpp
+++ b/erts/emulator/beam/jit/x86/instr_arith.cpp
@@ -121,8 +121,9 @@ void BeamModuleAssembler::emit_i_increment(const ArgRegister &Src,
                                            const ArgWord &Val,
                                            const ArgRegister &Dst) {
     ArgVal tagged_val = ArgVal(ArgVal::Immediate, make_small(Val.get()));
+    bool small_result = is_sum_small_if_args_are_small(Src, tagged_val);
 
-    if (is_sum_small(Src, tagged_val)) {
+    if (always_small(Src) && small_result) {
         Uint shifted_val = Val.get() << _TAG_IMMED1_SIZE;
 
         comment("skipped operand and overflow checks");
@@ -145,13 +146,11 @@ void BeamModuleAssembler::emit_i_increment(const ArgRegister &Src,
     mov_arg(ARG2, Src);
     mov_imm(ARG3, Val.get() << _TAG_IMMED1_SIZE);
 
-    if (always_one_of(Src, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+    if (always_one_of(Src, BEAM_TYPE_INTEGER | BEAM_TYPE_MASK_BOXED)) {
         comment("simplified test for small operand since it is a number");
         a.mov(RET, ARG2);
-        a.test(RETb, imm(TAG_PRIMARY_LIST));
-        a.short_().je(mixed);
+        emit_is_not_boxed(mixed, RET, dShort);
         a.add(RET, ARG3);
-        a.short_().jno(next);
     } else {
         a.mov(RETd, ARG2d);
         a.and_(RETb, imm(_TAG_IMMED1_MASK));
@@ -159,6 +158,12 @@ void BeamModuleAssembler::emit_i_increment(const ArgRegister &Src,
         a.short_().jne(mixed);
         a.mov(RET, ARG2);
         a.add(RET, ARG3);
+    }
+
+    if (small_result) {
+        comment("skipped overflow test because the result is always small");
+        a.short_().jmp(next);
+    } else {
         a.short_().jno(next);
     }
 
@@ -225,7 +230,9 @@ void BeamModuleAssembler::emit_i_plus(const ArgSource &LHS,
                                       const ArgSource &RHS,
                                       const ArgLabel &Fail,
                                       const ArgRegister &Dst) {
-    if (is_sum_small(LHS, RHS)) {
+    bool small_result = is_sum_small_if_args_are_small(LHS, RHS);
+
+    if (always_small(LHS) && always_small(RHS) && small_result) {
         comment("add without overflow check");
         mov_arg(RET, LHS);
         mov_arg(ARG2, RHS);
@@ -242,12 +249,16 @@ void BeamModuleAssembler::emit_i_plus(const ArgSource &LHS,
     mov_arg(ARG3, RHS); /* Used by erts_mixed_plus in this slot */
     emit_are_both_small(mixed, LHS, ARG2, RHS, ARG3);
 
-    comment("add with overflow check");
     a.mov(RET, ARG2);
     a.mov(ARG4, ARG3);
     a.and_(ARG4, imm(~_TAG_IMMED1_MASK));
     a.add(RET, ARG4);
-    a.short_().jno(next);
+    if (small_result) {
+        comment("skipped overflow test because the result is always small");
+        a.short_().jmp(next);
+    } else {
+        a.short_().jno(next);
+    }
 
     /* Call mixed addition. */
     a.bind(mixed);
@@ -319,7 +330,9 @@ void BeamModuleAssembler::emit_i_minus(const ArgSource &LHS,
                                        const ArgSource &RHS,
                                        const ArgLabel &Fail,
                                        const ArgRegister &Dst) {
-    if (is_difference_small(LHS, RHS)) {
+    bool small_result = is_diff_small_if_args_are_small(LHS, RHS);
+
+    if (always_small(LHS) && always_small(RHS) && small_result) {
         comment("subtract without overflow check");
         mov_arg(RET, LHS);
         mov_arg(ARG2, RHS);
@@ -337,12 +350,16 @@ void BeamModuleAssembler::emit_i_minus(const ArgSource &LHS,
 
     emit_are_both_small(mixed, LHS, ARG2, RHS, ARG3);
 
-    comment("sub with overflow check");
     a.mov(RET, ARG2);
     a.mov(ARG4, ARG3);
     a.and_(ARG4, imm(~_TAG_IMMED1_MASK));
     a.sub(RET, ARG4);
-    a.short_().jno(next);
+    if (small_result) {
+        comment("skipped overflow test because the result is always small");
+        a.short_().jmp(next);
+    } else {
+        a.short_().jno(next);
+    }
 
     a.bind(mixed);
     if (Fail.get() != 0) {
@@ -408,8 +425,9 @@ void BeamModuleAssembler::emit_i_unary_minus(const ArgSource &Src,
                                              const ArgLabel &Fail,
                                              const ArgRegister &Dst) {
     ArgVal zero = ArgVal(ArgVal::Immediate, make_small(0));
+    bool small_result = is_diff_small_if_args_are_small(zero, Src);
 
-    if (is_difference_small(zero, Src)) {
+    if (always_small(Src) && small_result) {
         comment("negation without overflow test");
         mov_arg(ARG2, Src);
         a.mov(RETd, imm(_TAG_IMMED1_SMALL));
@@ -428,13 +446,18 @@ void BeamModuleAssembler::emit_i_unary_minus(const ArgSource &Src,
     a.cmp(RETb, imm(_TAG_IMMED1_SMALL));
     a.short_().jne(mixed);
 
-    comment("negation with overflow test");
     /* RETb is now equal to _TAG_IMMED1_SMALL. */
     a.movzx(RET, RETb); /* Set RET to make_small(0). */
     a.mov(ARG3, ARG2);
     a.and_(ARG3, imm(~_TAG_IMMED1_MASK));
     a.sub(RET, ARG3);
-    a.short_().jno(next);
+
+    if (small_result) {
+        comment("skipped overflow test because the result is always small");
+        a.short_().jmp(next);
+    } else {
+        a.short_().jno(next);
+    }
 
     a.bind(mixed);
     if (Fail.get() != 0) {
@@ -673,25 +696,45 @@ void BeamModuleAssembler::emit_div_rem(const ArgLabel &Fail,
 
         /* Sign-extend and divide. The result is implicitly placed in
          * RAX and the remainder in RDX (ARG3). */
-        comment("divide with inlined code");
-        a.sar(x86::rax, imm(_TAG_IMMED1_SIZE));
-        a.cqo();
-        a.idiv(ARG6);
+        if (Support::isPowerOf2(divisor) &&
+            std::get<0>(getClampedRange(LHS)) >= 0) {
+            int trailing_bits = Support::ctz<Eterm>(divisor);
 
-        if (need_div) {
-            a.sal(x86::rax, imm(_TAG_IMMED1_SIZE));
-        }
+            if (need_rem) {
+                Uint mask = Support::lsbMask<Uint>(trailing_bits +
+                                                   _TAG_IMMED1_SIZE);
+                mask = (1ULL << (trailing_bits + _TAG_IMMED1_SIZE)) - 1;
+                comment("optimized rem by replacing with masking");
+                mov_imm(x86::rdx, mask);
+                a.and_(x86::rdx, x86::rax);
+            }
+            if (need_div) {
+                comment("optimized div by replacing with right shift");
+                ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
+                a.shr(x86::rax, imm(trailing_bits));
+                a.or_(x86::rax, imm(_TAG_IMMED1_SMALL));
+            }
+        } else {
+            comment("divide with inlined code");
+            a.sar(x86::rax, imm(_TAG_IMMED1_SIZE));
+            a.cqo();
+            a.idiv(ARG6);
 
-        if (need_rem) {
-            a.sal(x86::rdx, imm(_TAG_IMMED1_SIZE));
-        }
+            if (need_div) {
+                a.sal(x86::rax, imm(_TAG_IMMED1_SIZE));
+            }
 
-        if (need_div) {
-            a.or_(x86::rax, imm(_TAG_IMMED1_SMALL));
-        }
+            if (need_rem) {
+                a.sal(x86::rdx, imm(_TAG_IMMED1_SIZE));
+            }
 
-        if (need_rem) {
-            a.or_(x86::rdx, imm(_TAG_IMMED1_SMALL));
+            if (need_div) {
+                a.or_(x86::rax, imm(_TAG_IMMED1_SMALL));
+            }
+
+            if (need_rem) {
+                a.or_(x86::rdx, imm(_TAG_IMMED1_SMALL));
+            }
         }
 
         if (need_generic) {
@@ -862,15 +905,35 @@ void BeamModuleAssembler::emit_i_times(const ArgLabel &Fail,
                                        const ArgSource &LHS,
                                        const ArgSource &RHS,
                                        const ArgRegister &Dst) {
-    if (is_product_small(LHS, RHS)) {
+    bool small_result = is_product_small_if_args_are_small(LHS, RHS);
+
+    if (always_small(LHS) && always_small(RHS) && small_result) {
         comment("multiplication without overflow check");
-        mov_arg(RET, LHS);
-        mov_arg(ARG2, RHS);
-        a.and_(RET, imm(~_TAG_IMMED1_MASK));
-        a.sar(ARG2, imm(_TAG_IMMED1_SIZE));
-        a.imul(RET, ARG2);
+        if (RHS.isSmall()) {
+            Sint factor = RHS.as<ArgSmall>().getSigned();
+
+            mov_arg(RET, LHS);
+            a.and_(RET, imm(~_TAG_IMMED1_MASK));
+            if (Support::isPowerOf2(factor)) {
+                int trailing_bits = Support::ctz<Eterm>(factor);
+                comment("optimized multiplication by replacing with left "
+                        "shift");
+                a.shl(RET, imm(trailing_bits));
+            } else {
+                mov_imm(ARG2, factor);
+                a.imul(RET, ARG2);
+            }
+        } else {
+            mov_arg(RET, LHS);
+            mov_arg(ARG2, RHS);
+            a.and_(RET, imm(~_TAG_IMMED1_MASK));
+            a.sar(ARG2, imm(_TAG_IMMED1_SIZE));
+            a.imul(RET, ARG2);
+        }
+
         a.or_(RET, imm(_TAG_IMMED1_SMALL));
         mov_arg(Dst, RET);
+
         return;
     }
 
@@ -882,18 +945,10 @@ void BeamModuleAssembler::emit_i_times(const ArgLabel &Fail,
     if (RHS.isSmall()) {
         Sint val = RHS.as<ArgSmall>().getSigned();
         emit_is_small(mixed, LHS, ARG2);
-        comment("mul with overflow check, imm RHS");
         a.mov(RET, ARG2);
-        a.mov(ARG4, imm(val));
-    } else if (LHS.isSmall()) {
-        Sint val = LHS.as<ArgSmall>().getSigned();
-        emit_is_small(mixed, RHS, ARG3);
-        comment("mul with overflow check, imm LHS");
-        a.mov(RET, ARG3);
         a.mov(ARG4, imm(val));
     } else {
         emit_are_both_small(mixed, LHS, ARG2, RHS, ARG3);
-        comment("mul with overflow check");
         a.mov(RET, ARG2);
         a.mov(ARG4, ARG3);
         a.sar(ARG4, imm(_TAG_IMMED1_SIZE));
@@ -901,7 +956,11 @@ void BeamModuleAssembler::emit_i_times(const ArgLabel &Fail,
 
     a.and_(RET, imm(~_TAG_IMMED1_MASK));
     a.imul(RET, ARG4);
-    a.short_().jo(mixed);
+    if (small_result) {
+        comment("skipped overflow check because the result is always small");
+    } else {
+        a.short_().jo(mixed);
+    }
     a.or_(RET, imm(_TAG_IMMED1_SMALL));
     a.short_().jmp(next);
 
@@ -1341,7 +1400,13 @@ void BeamModuleAssembler::emit_i_bsl(const ArgSource &LHS,
         mov_arg(RET, LHS);
         ERTS_CT_ASSERT(_TAG_IMMED1_MASK == _TAG_IMMED1_SMALL);
         a.xor_(RET, imm(_TAG_IMMED1_MASK));
-        a.sal(RET, imm(RHS.as<ArgSmall>().getSigned()));
+        if (RHS.isSmall()) {
+            a.shl(RET, imm(RHS.as<ArgSmall>().getSigned()));
+        } else {
+            mov_arg(x86::rcx, RHS);
+            a.shr(x86::rcx, imm(_TAG_IMMED1_SIZE));
+            a.shl(RET, x86::rcx);
+        }
         a.or_(RET, imm(_TAG_IMMED1_SMALL));
         mov_arg(Dst, RET);
         return;

--- a/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
@@ -169,9 +169,8 @@ void BeamModuleAssembler::emit_bif_element(const ArgLabel &Fail,
         if (is_tuple(tuple)) {
             Label error = a.newLabel(), next = a.newLabel();
             Sint size = Sint(arityval(*tuple_val(tuple)));
-            auto [min, max] = getIntRange(Pos);
-            bool is_bounded = min <= max;
-            bool can_fail = !is_bounded || min < 1 || size < max;
+            auto [min, max] = getClampedRange(Pos);
+            bool can_fail = min < 1 || size < max;
 
             comment("skipped tuple test since source is always a literal "
                     "tuple");
@@ -191,13 +190,13 @@ void BeamModuleAssembler::emit_bif_element(const ArgLabel &Fail,
 
             a.mov(RET, ARG1);
             a.sar(RET, imm(_TAG_IMMED1_SIZE));
-            if (is_bounded && min >= 1) {
+            if (min >= 1) {
                 comment("skipped check for position =:= 0 since it is always "
                         ">= 1");
             } else {
                 a.short_().jz(error);
             }
-            if (is_bounded && min >= 0 && size >= max) {
+            if (min >= 0 && size >= max) {
                 comment("skipped check for negative position and position "
                         "beyond tuple");
             } else {

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -193,13 +193,16 @@ release_docs_spec:
 # Dependencies -- alphabetically, please
 # ---------------------------------------------------- 
 
-$(EBIN)/beam_asm.beam: beam_asm.hrl
+$(EBIN)/beam_asm.beam: beam_asm.hrl beam_opcodes.hrl beam_types.hrl
 $(EBIN)/beam_call_types.beam: beam_types.hrl
 $(EBIN)/beam_block.beam: beam_asm.hrl
-$(EBIN)/beam_disasm.beam: $(EGEN)/beam_opcodes.hrl beam_disasm.hrl beam_asm.hrl
+$(EBIN)/beam_dict.beam: beam_types.hrl
+$(EBIN)/beam_disasm.beam: $(EGEN)/beam_opcodes.hrl beam_disasm.hrl \
+     beam_asm.hrl beam_types.hrl
 $(EBIN)/beam_jump.beam: beam_asm.hrl
 $(EBIN)/beam_kernel_to_ssa.beam: v3_kernel.hrl beam_ssa.hrl
-$(EBIN)/beam_listing.beam: core_parse.hrl v3_kernel.hrl beam_ssa.hrl beam_asm.hrl
+$(EBIN)/beam_listing.beam: core_parse.hrl v3_kernel.hrl beam_ssa.hrl \
+     beam_asm.hrl beam_types.hrl
 $(EBIN)/beam_ssa.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_bsm.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_bool.beam: beam_ssa.hrl
@@ -207,11 +210,11 @@ $(EBIN)/beam_ssa_codegen.beam: beam_ssa.hrl beam_asm.hrl
 $(EBIN)/beam_ssa_dead.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_lint.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_opt.beam: beam_ssa.hrl
-$(EBIN)/beam_ssa_pp.beam: beam_ssa.hrl
+$(EBIN)/beam_ssa_pp.beam: beam_ssa.hrl beam_types.hrl
 $(EBIN)/beam_ssa_pre_codegen.beam: beam_ssa.hrl beam_asm.hrl
 $(EBIN)/beam_ssa_recv.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_share.beam: beam_ssa.hrl
-$(EBIN)/beam_ssa_throw.beam: beam_ssa.hrl
+$(EBIN)/beam_ssa_throw.beam: beam_ssa.hrl beam_types.hrl
 $(EBIN)/beam_ssa_type.beam: beam_ssa.hrl beam_types.hrl
 $(EBIN)/beam_trim.beam: beam_asm.hrl
 $(EBIN)/beam_types.beam: beam_types.hrl

--- a/lib/compiler/src/beam_bounds.erl
+++ b/lib/compiler/src/beam_bounds.erl
@@ -62,6 +62,12 @@ bounds('+', R1, R2) ->
                             abs(C) bsr ?NUM_BITS =:= 0,
                             abs(D) bsr ?NUM_BITS =:= 0 ->
             normalize({A+C,B+D});
+        {{'-inf',B}, {_C,D}} when abs(B) bsr ?NUM_BITS =:= 0,
+                                  abs(D) bsr ?NUM_BITS =:= 0 ->
+            normalize({'-inf',B+D});
+        {{_A,B}, {'-inf',D}} when abs(B) bsr ?NUM_BITS =:= 0,
+                                  abs(D) bsr ?NUM_BITS =:= 0 ->
+            normalize({'-inf',B+D});
         {{A,'+inf'}, {C,_D}} when abs(A) bsr ?NUM_BITS =:= 0,
                                   abs(C) bsr ?NUM_BITS =:= 0 ->
             normalize({A+C,'+inf'});
@@ -78,9 +84,18 @@ bounds('-', R1, R2) ->
                             abs(C) bsr ?NUM_BITS =:= 0,
                             abs(D) bsr ?NUM_BITS =:= 0 ->
             normalize({A-D,B-C});
+        {{A,'+inf'}, {_C,D}} when abs(A) bsr ?NUM_BITS =:= 0,
+                                  abs(D) bsr ?NUM_BITS =:= 0 ->
+            normalize({A-D,'+inf'});
         {{_A,B}, {C,'+inf'}} when abs(B) bsr ?NUM_BITS =:= 0,
                                   abs(C) bsr ?NUM_BITS =:= 0 ->
             normalize({'-inf',B-C});
+        {{'-inf',B}, {C,_D}} when abs(B) bsr ?NUM_BITS =:= 0,
+                                  abs(C) bsr ?NUM_BITS =:= 0 ->
+            normalize({'-inf',B-C});
+        {{A,_B}, {'-inf',D}} when abs(A) bsr ?NUM_BITS =:= 0,
+                                  abs(D) bsr ?NUM_BITS =:= 0 ->
+            normalize({A-D,'+inf'});
         {_, _} ->
             any
     end;

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -269,12 +269,17 @@ beam_disasm_types(none) ->
 beam_disasm_types(<<?BEAM_TYPES_VERSION:32,Count:32,Table/binary>>) ->
     Res = gb_trees:from_orddict(disasm_types(Table, 0)),
     Count = gb_trees:size(Res),                 %Assertion.
-    Res.
+    Res;
+beam_disasm_types(<<_/binary>>) ->
+    none.
 
-disasm_types(<<Type:18/binary,Rest/binary>>, Index) ->
-    [{Index,beam_types:decode_ext(Type)}|disasm_types(Rest, Index+1)];
-disasm_types(<<>>, _) ->
-    [].
+disasm_types(Types0, Index) ->
+    case beam_types:decode_ext(Types0) of
+        done ->
+            [];
+        {Types,Rest} ->
+            [{Index,Types}|disasm_types(Rest, Index+1)]
+    end.
 
 %%-----------------------------------------------------------------------
 %% Disassembles the code chunk of a BEAM file:

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -1116,10 +1116,14 @@ cg_block([#cg_set{op=bs_create_bin,dst=Dst0,args=Args0,anno=Anno}=I,
     Live = get_live(I),
     Dst = beam_arg(Dst0, St),
     Args = bs_args(Args1),
+    Unit0 = maps:get(unit, Anno, 1),
     Unit = case Args of
-               [{atom,append},_Seg,U|_] -> U;
-               [{atom,private_append},_Seg,U|_] -> U;
-               _ -> 1
+               [{atom,append},_Seg,U|_] ->
+                   max(U, Unit0);
+               [{atom,private_append},_Seg,U|_] ->
+                   max(U, Unit0);
+               _ ->
+                   Unit0
            end,
     Is = [Line,{bs_create_bin,Fail,Alloc,Live,Unit,Dst,{list,Args}}],
     {Is,St};

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -23,7 +23,7 @@
 -define(BEAM_TYPES_INTERNAL, true).
 -include("beam_types.hrl").
 
--import(lists, [foldl/3, reverse/1, usort/1]).
+-import(lists, [foldl/3, mapfoldl/3, reverse/1, usort/1]).
 
 -export([meet/1, meet/2, join/1, join/2, subtract/2]).
 
@@ -1329,6 +1329,10 @@ verified_normal_type(#t_tuple{size=Size,elements=Es}=T) ->
 -define(BEAM_TYPE_REFERENCE,     (1 bsl 11)).
 -define(BEAM_TYPE_TUPLE,         (1 bsl 12)).
 
+-define(BEAM_TYPE_HAS_LOWER_BOUND, (1 bsl 13)).
+-define(BEAM_TYPE_HAS_UPPER_BOUND, (1 bsl 14)).
+-define(BEAM_TYPE_HAS_UNIT,        (1 bsl 15)).
+
 ext_type_mapping() ->
     [{?BEAM_TYPE_ATOM,          #t_atom{}},
      {?BEAM_TYPE_BITSTRING,     #t_bitstring{}},
@@ -1344,12 +1348,19 @@ ext_type_mapping() ->
      {?BEAM_TYPE_REFERENCE,     reference},
      {?BEAM_TYPE_TUPLE,         #t_tuple{}}].
 
--spec decode_ext(binary()) -> type().
-decode_ext(<<TypeBits:16/big,Min:64,Max:64>>) ->
+-spec decode_ext(binary()) -> {type(),binary()} | 'done'.
+decode_ext(<<TypeBits:16/big,More/binary>>) ->
     Res = foldl(fun({Id, Type}, Acc) ->
                         decode_ext_bits(TypeBits, Id, Type, Acc)
                 end, none, ext_type_mapping()),
-    {Res,Min,Max}.
+    {[Min,Max,Unit],Extra} = decode_extra(TypeBits, More),
+    R = case {Min,Max} of
+            {'-inf','+inf'} -> any;
+            R0 -> R0
+        end,
+    {decode_fix(Res, R, Unit),Extra};
+decode_ext(<<>>) ->
+    done.
 
 decode_ext_bits(Input, TypeBit, Type, Acc) ->
     case Input band TypeBit of
@@ -1357,17 +1368,50 @@ decode_ext_bits(Input, TypeBit, Type, Acc) ->
         _ -> join(Type, Acc)
     end.
 
+decode_extra(TypeBits, Extra) ->
+    L = [{?BEAM_TYPE_HAS_LOWER_BOUND, 64, '-inf'},
+         {?BEAM_TYPE_HAS_UPPER_BOUND, 64, '+inf'},
+         {?BEAM_TYPE_HAS_UNIT, 8, 1}],
+    mapfoldl(fun({Bit,Size,Default}, Acc0) ->
+                     if
+                         TypeBits band Bit =:= Bit ->
+                             <<Value:Size,Acc/binary>> = Acc0,
+                             {Value,Acc};
+                         true ->
+                             {Default,Acc0}
+                     end
+             end, Extra, L).
+
+decode_fix(#t_integer{}, Range, _Unit) ->
+    #t_integer{elements=Range};
+decode_fix(#t_number{}, Range, _Unit) ->
+    #t_number{elements=Range};
+decode_fix(#t_bitstring{}, _Range, Unit) ->
+    #t_bitstring{size_unit=Unit};
+decode_fix(#t_union{}=Type0, Range, Unit) ->
+    Type1 = case meet(Type0, #t_integer{}) of
+                #t_integer{} ->
+                    Type0#t_union{number=#t_integer{elements=Range}};
+                _ ->
+                    Type0
+            end,
+    case meet(Type1, #t_bitstring{}) of
+        #t_bitstring{} ->
+            Type1#t_union{other=#t_bitstring{size_unit=Unit}};
+        _ ->
+            Type1
+    end;
+decode_fix(Type, _, _) ->
+    Type.
+
 -spec encode_ext(type()) -> binary().
 encode_ext(Input) ->
-    TypeBits = foldl(fun({Id, Type}, Acc) ->
-                             encode_ext_bits(Input, Id, Type, Acc)
-                     end, 0, ext_type_mapping()),
-    case get_integer_range(Input) of
-        none ->
-            <<TypeBits:16/big,0:64,-1:64>>;
-        {Min,Max} ->
-            <<TypeBits:16/big,Min:64,Max:64>>
-    end.
+    TypeBits0 = foldl(fun({Id, Type}, Acc) ->
+                              encode_ext_bits(Input, Id, Type, Acc)
+                      end, 0, ext_type_mapping()),
+    {TypeBits1,Extra} = encode_extra(Input),
+    TypeBits = TypeBits0 bor TypeBits1,
+    <<TypeBits:16,Extra/binary>>.
 
 encode_ext_bits(Input, TypeBit, Type, Acc) ->
     case meet(Input, Type) of
@@ -1375,21 +1419,49 @@ encode_ext_bits(Input, TypeBit, Type, Acc) ->
         _ -> Acc bor TypeBit
     end.
 
-get_integer_range(#t_integer{elements={Min,Max}}) ->
-    case is_small(Min) andalso is_small(Max) of
+encode_extra(Input) ->
+    {TypeBits0,Extra0} = encode_range(Input),
+    {TypeBits1,Extra1} = encode_unit(Input),
+    {TypeBits0 bor TypeBits1,<<Extra0/binary,Extra1/binary>>}.
+
+encode_range(#t_integer{elements={Min,Max}}) ->
+    encode_range(Min, Max);
+encode_range(#t_number{elements={Min,Max}}) ->
+    encode_range(Min, Max);
+encode_range(#t_union{number=N}) ->
+    encode_range(N);
+encode_range(_) ->
+    {0,<<>>}.
+
+encode_range(Min, Max) ->
+    case is_small(Min) of
         true ->
-            {Min,Max};
+            encode_range(Max, ?BEAM_TYPE_HAS_LOWER_BOUND, <<Min:64>>);
         false ->
-            %% Not an integer with range, or at least one of the
-            %% endpoints is a bignum.
-            none
-    end;
-get_integer_range(#t_union{number=N}) ->
-    get_integer_range(N);
-get_integer_range(_) -> none.
+            encode_range(Max, 0, <<>>)
+    end.
+
+encode_range(Max, TypeBits, Extra) ->
+    case is_small(Max) of
+        true ->
+            {TypeBits bor ?BEAM_TYPE_HAS_UPPER_BOUND,
+             <<Extra/binary,Max:64>>};
+        false ->
+            {TypeBits,Extra}
+    end.
+
+encode_unit(#t_bitstring{size_unit=Unit}) ->
+    true = 0 < Unit andalso Unit =< 256,        %Assertion.
+    {?BEAM_TYPE_HAS_UNIT,<<(Unit-1):8>>};
+encode_unit(#t_union{other=Other}) ->
+    encode_unit(Other);
+encode_unit(_) ->
+    {0,<<>>}.
 
 %% Test whether the number is a small on a 64-bit machine.
 %% (Normally the compiler doesn't know/doesn't care whether something is
 %% bignum, but because the type representation is versioned this is safe.)
-is_small(N) ->
-    -(1 bsl 59) =< N andalso N =< (1 bsl 59) - 1.
+is_small(N) when -(1 bsl 59) =< N andalso N =< (1 bsl 59) - 1 ->
+    true;
+is_small(_) ->
+    false.

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -592,11 +592,9 @@ mtfv_1(A) when is_atom(A) ->
 mtfv_1(B) when is_bitstring(B) ->
     case bit_size(B) of
         0 ->
-            %% This is a bit of a hack, but saying that empty binaries have a
-            %% unit of 8 helps us get rid of is_binary/1 checks.
-            #t_bitstring{size_unit=8};
+            #t_bitstring{size_unit=256};
         Size ->
-            #t_bitstring{size_unit=Size}
+            #t_bitstring{size_unit=gcd(Size, 256)}
     end;
 mtfv_1(F) when is_float(F) ->
     make_float(F);

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -19,7 +19,7 @@
 %%
 
 %% Type version, must be bumped whenever the external type format changes.
--define(BEAM_TYPES_VERSION, 1).
+-define(BEAM_TYPES_VERSION, 2).
 
 %% Common term types for passes operating on beam SSA and assembly. Helper
 %% functions for wrangling these can be found in beam_types.erl

--- a/lib/compiler/test/beam_bounds_SUITE.erl
+++ b/lib/compiler/test/beam_bounds_SUITE.erl
@@ -70,10 +70,32 @@ end_per_group(_GroupName, Config) ->
     Config.
 
 addition_bounds(_Config) ->
-    test_commutative('+', {-12,12}).
+    test_commutative('+', {-12,12}),
+
+    {'-inf',-15} = beam_bounds:bounds('+', {'-inf',-20}, {2,5}),
+    {'-inf',55} = beam_bounds:bounds('+', {'-inf',50}, {'-inf',5}),
+    {'-inf',110} = beam_bounds:bounds('+', {1,10}, {'-inf',100}),
+    any = beam_bounds:bounds('+', {1,'+inf'}, {'-inf',100}),
+
+    {-8,'+inf'} = beam_bounds:bounds('+', {2,'+inf'}, {-10,20}),
+    {6,'+inf'} = beam_bounds:bounds('+', {1,10}, {5,'+inf'}),
+    {9,'+inf'} = beam_bounds:bounds('+', {2,'+inf'}, {7,'+inf'}),
+
+    ok.
 
 subtraction_bounds(_Config) ->
-    test_noncommutative('-', {-12,12}).
+    test_noncommutative('-', {-12,12}),
+
+    {'-inf',18} = beam_bounds:bounds('-', {'-inf',20}, {2,9}),
+    any = beam_bounds:bounds('-', {'-inf',20}, {'-inf',17}),
+    {-99,'+inf'} = beam_bounds:bounds('-', {1,10}, {'-inf',100}),
+    {-93,'+inf'} = beam_bounds:bounds('-', {7,'+inf'}, {'-inf',100}),
+
+    {-18,'+inf'} = beam_bounds:bounds('-', {2,'+inf'}, {-10,20}),
+    {'-inf',6} = beam_bounds:bounds('-', {1,11}, {5,'+inf'}),
+    any = beam_bounds:bounds('-', {2,'+inf'}, {7,'+inf'}),
+
+    ok.
 
 multiplication_bounds(_Config) ->
     test_commutative('*', {-12,12}),

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -2028,8 +2028,8 @@ types_pp(Config) when is_list(Config) ->
                     {make_inexact_tuple, "{any(), any(), any(), ...}"},
                     {make_union,
                      "'foo' | nonempty_list(1..3) | number(3, 7) |"
-                     " {'tag0', 1, 2} | {'tag1', 3, 4} | bitstring(24)"},
-                    {make_bitstring, "bitstring(24)"},
+                     " {'tag0', 1, 2} | {'tag1', 3, 4} | bitstring(8)"},
+                    {make_bitstring, "bitstring(8)"},
                     {make_none, "none()"}],
     lists:foreach(fun({FunName, Expected}) ->
                           Actual = map_get(atom_to_list(FunName), ResultTypes),


### PR DESCRIPTION
Introduce a new version of the type information store in BEAM files. (The loader can still load and take advantage of type information in BEAM files produced by the compiler in OTP 25.) The new format differs from the previous format in the following ways:

* Ranges are included for numbers as well as for integers.
    
* Ranges can go from minus infinity to an integer value that fits in a small, or from a small value to positive infinity.
    
* The size unit are included for bitstrings.
    
* The size of the type information as stored in BEAM files varies from 2 to 19 bytes depending on the types (instead of having a fixed size of 18 bytes).

Using the new type information, do the following new optimizations in the JIT:

* Eliminate redundant tests when appending to binaries by using the new information about size unit for binaries.
    
* Eliminate redundant overflow checks for the `+` and `-` operators.
    
* While we are at it, optimize multiplication and division by a power of two.
    
* Optimize `<`, `=<`, `>`, and `>=` tests using the better information about ranges.

