### PR TITLE
Eliminate another crash when optimization passes are disabled

### DIFF
--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -263,6 +263,9 @@ simplify_get_map_elements(Fail, Src, {list,[Key,Dst]},
                     {ok,[{get_map_elements,Fail,Src,{list,List}}|Acc]}
             end;
         false ->
+            %% A destination is used more than once. That should only
+            %% happen if some optimizations are disabled, so we
+            %% will not attempt do anything smart here.
             error
     end;
 simplify_get_map_elements(_, _, _, _) -> error.
@@ -283,5 +286,9 @@ are_keys_literals([{x,_}|_]) -> false;
 are_keys_literals([{y,_}|_]) -> false;
 are_keys_literals([_|_]) -> true.
 
-is_reg_overwritten(Src, [_Key,Src]) -> true;
-is_reg_overwritten(_, _) -> false.
+is_reg_overwritten(Src, [_Key,Src|_]) ->
+    true;
+is_reg_overwritten(Src, [_Key,_Src|T]) ->
+    is_reg_overwritten(Src, T);
+is_reg_overwritten(_, []) ->
+    false.

--- a/lib/compiler/test/map_SUITE.erl
+++ b/lib/compiler/test/map_SUITE.erl
@@ -83,7 +83,10 @@
          t_bif_map_find/1,
          t_fold_3/1, t_from_keys/1, t_map_2/1, t_maps_take_2/1,
          t_update_with_3/1, t_update_with_4/1,
-         t_with_2/1
+         t_with_2/1,
+
+         %% miscellaneous
+         t_conflicting_destinations/1
         ]).
 
 -define(badmap(V, F, Args), {'EXIT', {{badmap,V}, [{maps,F,Args,_}|_]}}).
@@ -153,7 +156,10 @@ all() ->
      %% cover more code
      t_bif_map_find,
      t_fold_3, t_from_keys, t_map_2, t_maps_take_2,
-     t_update_with_3, t_update_with_4, t_with_2
+     t_update_with_3, t_update_with_4, t_with_2,
+
+     %% miscellaneous
+     t_conflicting_destinations
     ].
 
 groups() -> [].
@@ -2498,6 +2504,23 @@ t_bif_map_find(Config) when is_list(Config) ->
 			  catch maps:find(a, T)
 	      end),
     ok.
+
+t_conflicting_destinations(_Config) ->
+    {'EXIT',{function_clause,_}} =
+        catch do_conflicts(#{{tag,whatever} => true}),
+    {'EXIT',{function_clause,_}} =
+        catch do_conflicts(#{[something] => 42}),
+    {'EXIT',{function_clause,_}} =
+        catch do_conflicts(#{{tag,whatever} => true,
+                             #{} => <<0>>,
+                             [something] => 42}),
+    ok.
+
+do_conflicts(#{{tag,whatever} := true,
+               #{} := <<bad_integer,0:(is_integer(a))>>} =
+                 #{[something] := 42}) ->
+    ok.
+
 
 %% aux
 


### PR DESCRIPTION
When compiling the following code with the SSA-based optimization
passes disabled:

    foo(#{{tag,whatever} := true,
          #{} := <<bad_integer,0:(is_integer(a))>>} =
            #{[something] := 42}) ->
        ok.

The `beam_validator` pass rejects the code with the following message:

    t:1: function foo/1+6:
      Internal consistency check failed - please report this bug.
      Instruction: {get_map_elements,
                       {f,1},
                       {x,0},
                       {list,
                           [{literal,[something]},
                            {x,2},
                            {literal,#{}},
                            {x,2},
                            {literal,{tag,whatever}},
                            {x,1}]}}
      Error:       conflicting_destinations:

All optimization passes are supposed to be optional, so this crash is
not acceptable even though the code is nonsensical.