### PR TITLE
gh: Bump Vampire/setup-wsl version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,7 +46,7 @@ jobs:
     runs-on: windows-2022
     needs: pack
     steps:
-      - uses: Vampire/setup-wsl@v1
+      - uses: Vampire/setup-wsl@v1.2.1
         with:
           distribution: Ubuntu-18.04
 


### PR DESCRIPTION
This fixes issue with
The process 'C:\hostedtoolcache\windows\Ubuntu\18.4.0\x64\ubuntu1804.exe' failed with exit code 1