### PR TITLE
compiler: Add type info for bs_init_writable

### DIFF
--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -2148,6 +2148,8 @@ type(update_tuple, [Src | Updates], _Anno, Ts, _Ds) ->
 type(wait_timeout, [#b_literal{val=infinity}], _Anno, _Ts, _Ds) ->
     %% Waits forever, never reaching the 'after' block.
     beam_types:make_atom(false);
+type(bs_init_writable, [_Size], _, _, _) ->
+    beam_types:make_type_from_value(<<>>);
 type(_, _, _, _, _) ->
     any.
 

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -3279,6 +3279,9 @@ join_tuple_elements(I, Tuple, Type0) ->
 call_types({extfunc,M,F,A}, A, Vst) ->
     Args = get_call_args(A, Vst),
     beam_call_types:types(M, F, Args);
+call_types(bs_init_writable, A, Vst) ->
+    T = beam_types:make_type_from_value(<<>>),
+    {T, get_call_args(A, Vst), false};
 call_types(_, A, Vst) ->
     {any, get_call_args(A, Vst), false}.
 

--- a/lib/compiler/test/compile_SUITE_data/bs_init_writable.erl
+++ b/lib/compiler/test/compile_SUITE_data/bs_init_writable.erl
@@ -1,0 +1,45 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(bs_init_writable).
+
+-export([do/0]).
+
+do() ->
+    Val = ex:foo(),
+    X = << <<B:1>> || B <- Val >>,
+    should_not_have_bitstring_test(X),
+    Y = << <<B:8>> || B <- Val >>,
+    should_not_have_binary_test(Y).
+
+
+%% If the beam_ssa_type pass does its job,
+%% should_not_have_bitstring_test/1 should not contain a is_bitstr test.
+should_not_have_bitstring_test(X) when is_bitstring(X) ->
+    bitstring;
+should_not_have_bitstring_test(_) ->
+    something_else.
+
+%% If the beam_ssa_type pass does its job,
+%% should_not_have_binary_test/1 should not contain a is_binary test.
+should_not_have_binary_test(X) when is_binary(X) ->
+    binary;
+should_not_have_binary_test(_) ->
+    something_else.


### PR DESCRIPTION
The SSA instruction bs_init_writable is not known to the SSA type
analysis pass, nor is its result type known to the BEAM
validator. This patch adds type information for bs_init_writable and
as it allows the SSA type pass to elide is_bitstring tests, it also
extends the BEAM validator to consider the result of bs_init_writable
to be a bitstring.