### PR TITLE
Call `mach_clock_getres` only on initialized clocks

### DIFF
--- a/erts/emulator/sys/unix/sys_time.c
+++ b/erts/emulator/sys/unix/sys_time.c
@@ -219,7 +219,7 @@ sys_init_time(ErtsSysInitTimeResult *init_resp)
 #endif
 
     init_resp->os_monotonic_time_info.resolution = (Uint64) 1000*1000*1000;
-#if defined(ERTS_HAVE_MACH_CLOCK_GETRES) && defined(MONOTONIC_CLOCK_ID)
+#if defined(ERTS_HAVE_MACH_CLOCK_GETRES) && defined(OS_MONOTONIC_TIME_USING_MACH_CLOCK_GET_TIME)
     init_resp->os_monotonic_time_info.resolution
 	= mach_clock_getres(&internal_state.r.o.mach.clock.monotonic);
 #elif defined(HAVE_CLOCK_GETRES) && defined(MONOTONIC_CLOCK_ID)
@@ -379,7 +379,7 @@ sys_init_time(ErtsSysInitTimeResult *init_resp)
 
     init_resp->os_system_time_info.locked_use = 0;
     init_resp->os_system_time_info.resolution = (Uint64) 1000*1000*1000;
-#if defined(ERTS_HAVE_MACH_CLOCK_GETRES) && defined(WALL_CLOCK_ID)
+#if defined(ERTS_HAVE_MACH_CLOCK_GETRES) && defined(OS_SYSTEM_TIME_USING_MACH_CLOCK_GET_TIME)
     init_resp->os_system_time_info.resolution
 	= mach_clock_getres(&internal_state.r.o.mach.clock.wall);
 #elif defined(HAVE_CLOCK_GETRES) && defined(WALL_CLOCK_ID)


### PR DESCRIPTION
Mac OS X 10.6 and earlier produce a segmentation fault due to a condition mismatch between calls to `host_get_clock_service` and `mach_clock_getres`. This change brings consistency to the conditionals and fixes the segfault.