### PR TITLE
Allow the timezone part of the string to contain only an hour

### DIFF
--- a/lib/stdlib/doc/src/calendar.xml
+++ b/lib/stdlib/doc/src/calendar.xml
@@ -331,7 +331,8 @@
       <desc>
         <p>Converts an RFC 3339 timestamp into system time. The data format
           of RFC 3339 timestamps is described by
-          <url href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</url>.</p>
+          <url href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</url>.
+        Starting from OTP 25.1, the minutes part of the time zone is optional.</p>
 	<p>Valid option:</p>
 	<taglist>
 	  <tag><c>{unit, Unit}</c></tag>

--- a/lib/stdlib/src/calendar.erl
+++ b/lib/stdlib/src/calendar.erl
@@ -718,9 +718,14 @@ offset_string_adjustment(_Time, _Unit, "Z") ->
 offset_string_adjustment(_Time, _Unit, "z") ->
     0;
 offset_string_adjustment(_Time, _Unit, Tz) ->
-    [Sign, H1, H2, $:, M1, M2] = Tz,
+    [Sign, H1, H2 | MinutesDiff] = Tz,
     Hour = list_to_integer([H1, H2]),
-    Min = list_to_integer([M1, M2]),
+    Min = case MinutesDiff of
+              [$:, M1, M2] ->
+                  list_to_integer([M1, M2]);
+              [] ->
+                  0
+          end,
     Adjustment = 3600 * Hour + 60 * Min,
     case Sign of
         $- -> -Adjustment;

--- a/lib/stdlib/test/calendar_SUITE.erl
+++ b/lib/stdlib/test/calendar_SUITE.erl
@@ -281,6 +281,9 @@ rfc3339(Config) when is_list(Config) ->
     "2000-01-01T10:02:00.000+00:02" =
         do_format(TO * NaPerSec, [{offset, 120 * NaPerSec}]++Na),
 
+    1656147840 = do_parse("2022-06-25 11:04:00+02", []),
+    1656155040 = do_parse("2022-06-25 11:04:00-00", []),
+
 
     NStr = "2000-01-01T09:58:00-00:02",
     NStr = do_format(TO, [{offset, -120}]),


### PR DESCRIPTION
RFC3339 declares the minutes part of the timezone diff as optional,
which is now enabled with this commit.
E.g.: 2022-06-25 11:04:00+02 is now possible.