### PR TITLE
inets: Add a helper function for client ssl connections

### DIFF
--- a/lib/inets/doc/src/http_client.xml
+++ b/lib/inets/doc/src/http_client.xml
@@ -81,27 +81,31 @@
     <code type="erl">
       4 > {ok, {{Version, 200, ReasonPhrase}, Headers, Body}} =
       httpc:request("http://www.erlang.org").</code>
+    <p>The following is a https request and with verification of the host:</p>
+    <code type="erl">
+      5 > {ok, {{Version, 200, ReasonPhrase}, Headers, Body}} =
+      httpc:request(get, {"https://www.erlang.org", []}, [{ssl, httpc:ssl_verify_host_options(true)}], []).</code>
     <p>The following is an ordinary asynchronous request:</p>
     <code type="erl">
-      5 > {ok, RequestId} =
+      6 > {ok, RequestId} =
       httpc:request(get, {"http://www.erlang.org", []}, [], [{sync, false}]).</code>
       <p>The result is sent to the calling process as
       <c>{http, {ReqestId, Result}}</c>.</p>
     <p>In this case, the calling process is the shell, so the following
       result is received:</p>
     <code type="erl">
-      6 > receive {http, {RequestId, Result}} -> ok after 500 -> error end.
+      7 > receive {http, {RequestId, Result}} -> ok after 500 -> error end.
       ok</code>
     <p>This sends a request with a specified connection header:</p>
     <code type="erl">
-      7 > {ok, {{NewVersion, 200, NewReasonPhrase}, NewHeaders, NewBody}} =
+      8 > {ok, {{NewVersion, 200, NewReasonPhrase}, NewHeaders, NewBody}} =
       httpc:request(get, {"http://www.erlang.org", [{"connection", "close"}]},
       [], []).</code>
     <p>This sends an HTTP request over a unix domain socket (experimental):</p>
     <code type="erl">
-      8 > httpc:set_options([{ipfamily, local},
+      9 > httpc:set_options([{ipfamily, local},
       {unix_socket,"/tmp/unix_socket/consul_http.sock"}]).
-      9 > {ok, {{NewVersion, 200, NewReasonPhrase}, NewHeaders, NewBody}} =
+      10 > {ok, {{NewVersion, 200, NewReasonPhrase}, NewHeaders, NewBody}} =
       httpc:request(put, {"http:///v1/kv/foo", [], [], "hello"}, [], []).</code>
     <p>Start an HTTP client profile:</p>
    

--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -647,7 +647,23 @@
         <marker id="get_options"></marker>
       </desc>
     </func>
-     
+
+    <func>
+      <name since="OTP @OTP-18118@">ssl_verify_host_options(WildcardHostName) -> list() </name>
+      <fsummary>Returns ssl options for host verification.</fsummary>
+      <type>
+        <v>WildcardHostName = boolean()</v>
+      </type>
+      <desc>
+        <p>Returns ssl options which can be used to verify the host, uses
+        <seemfa marker="public_key:public_key#cacerts_get/0"><c>public_key:cacerts_get()</c></seemfa>
+        to read CA certicates and if <c>WildcardHostName</c> is true adds the hostname check from
+        <seemfa marker="public_key:public_key#pkix_verify_hostname_match_fun/1">
+          <c> public_key:public_key:pkix_verify_hostname_match_fun(https)</c></seemfa> to the options.
+        </p>
+      </desc>
+    </func>
+
     <func>
       <name since="OTP R14B02">store_cookies(SetCookieHeaders, Url) -> </name>
       <name since="OTP R14B02">store_cookies(SetCookieHeaders, Url, Profile) -> ok | {error, Reason}</name>

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -44,6 +44,7 @@
 	 stream_next/1,
 	 default_profile/0, 
 	 profile_name/1, profile_name/2,
+         ssl_verify_host_options/1,
 	 info/0, info/1
 	]).
 
@@ -296,6 +297,21 @@ get_option(Key, Profile) ->
 	    Error
     end.
 
+%%--------------------------------------------------------------------------
+%% Default client ssl options to verify server
+%%
+%%  UseWildcard=true  does wildcard matching on the hostname check
+%%--------------------------------------------------------------------------
+-spec ssl_verify_host_options(UseWildCard::boolean()) -> list().
+ssl_verify_host_options(UseWildCard) ->
+    WildCard = case UseWildCard of
+                   true ->
+                       Fun = public_key:pkix_verify_hostname_match_fun(https),
+                       [{customize_hostname_check,[{match_fun, Fun}]}];
+                   false ->
+                       []
+               end,
+    [{verify, verify_peer}, {cacerts, public_key:cacerts_get()} | WildCard].
 
 %%--------------------------------------------------------------------------
 %% store_cookies(SetCookieHeaders, Url [, Profile]) -> ok | {error, reason} 

--- a/lib/inets/src/inets_app/inets.app.src
+++ b/lib/inets/src/inets_app/inets.app.src
@@ -98,4 +98,4 @@
   {applications,[kernel,stdlib]},
   {mod,{inets_app,[]}},
   {runtime_dependencies, ["stdlib-4.0","ssl-9.0","runtime_tools-1.8.14",
-			  "mnesia-4.12","kernel-6.0","erts-6.0"]}]}.
+			  "mnesia-4.12","kernel-6.0","erts-6.0", "public_key-1.13"]}]}.


### PR DESCRIPTION
httpc:ssl_verify_host_options/1 returns ssl client options
to verify the host.

Added as a helper function to 25.1 to be added as the default option
in 26.