### PR TITLE
Add integer guard tests to some modules in STDLIB

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2084,7 +2084,8 @@ bit_size_check(Anno, all, #bittype{type=Type}, St) ->
         binary -> {all,St};
         _ -> {unknown,add_error(Anno, illegal_bitsize, St)}
     end;
-bit_size_check(Anno, Size, #bittype{type=Type,unit=Unit}, St) ->
+bit_size_check(Anno, Size, #bittype{type=Type,unit=Unit}, St)
+  when is_integer(Size), is_integer(Unit) ->
     Sz = Unit * Size,                           %Total number of bits!
     St2 = elemtype_check(Anno, Type, Sz, St),
     {Sz,St2}.
@@ -4370,9 +4371,11 @@ extract_sequences(Fmt, Need0) ->
             end
     end.
 
-extract_sequence(1, [$-,C|Fmt], Need) when C >= $0, C =< $9 ->
+extract_sequence(1, [$-,C|Fmt], Need)
+  when is_integer(C), C >= $0, C =< $9 ->
     extract_sequence_digits(1, Fmt, Need);
-extract_sequence(1, [C|Fmt], Need) when C >= $0, C =< $9 ->
+extract_sequence(1, [C|Fmt], Need)
+  when is_integer(C), C >= $0, C =< $9 ->
     extract_sequence_digits(1, Fmt, Need);
 extract_sequence(1, [$-,$*|Fmt], Need) ->
     extract_sequence(2, Fmt, [int|Need]);
@@ -4381,7 +4384,8 @@ extract_sequence(1, [$*|Fmt], Need) ->
 extract_sequence(1, Fmt, Need) ->
     extract_sequence(2, Fmt, Need);
 
-extract_sequence(2, [$.,C|Fmt], Need) when C >= $0, C =< $9 ->
+extract_sequence(2, [$.,C|Fmt], Need)
+  when is_integer(C), C >= $0, C =< $9 ->
     extract_sequence_digits(2, Fmt, Need);
 extract_sequence(2, [$.,$*|Fmt], Need) ->
     extract_sequence(3, Fmt, [int|Need]);
@@ -4435,7 +4439,8 @@ extract_sequence(5, [C|Fmt], Need0) ->
     end;
 extract_sequence(_, [], _Need) -> {error,"truncated"}.
 
-extract_sequence_digits(Fld, [C|Fmt], Need) when C >= $0, C =< $9 ->
+extract_sequence_digits(Fld, [C|Fmt], Need)
+  when is_integer(C), C >= $0, C =< $9 ->
     extract_sequence_digits(Fld, Fmt, Need);
 extract_sequence_digits(Fld, Fmt, Need) ->
     extract_sequence(Fld+1, Fmt, Need).

--- a/lib/stdlib/src/filename.erl
+++ b/lib/stdlib/src/filename.erl
@@ -78,8 +78,10 @@
 
 -include_lib("kernel/include/file.hrl").
 
--define(IS_DRIVELETTER(Letter),(((Letter >= $A) andalso (Letter =< $Z)) orelse
-				((Letter >= $a) andalso (Letter =< $z)))). 
+-define(IS_DRIVELETTER(Letter),
+        (is_integer(Letter)
+         andalso (($A =< Letter andalso Letter =< $Z)
+                  orelse ($a =< Letter andalso Letter =< $z)))).
 
 %% Converts a relative filename to an absolute filename
 %% or the filename itself if it already is an absolute filename
@@ -333,8 +335,7 @@ dirname([$/|Rest], Dir, File, Seps) ->
 dirname([DirSep|Rest], Dir, File, {DirSep,_}=Seps) when is_integer(DirSep) ->
     dirname(Rest, File++Dir, [$/], Seps);
 dirname([Dl,DrvSep|Rest], [], [], {_,DrvSep}=Seps)
-  when is_integer(DrvSep), ((($a =< Dl) and (Dl =< $z)) or
-			    (($A =< Dl) and (Dl =< $Z))) ->
+  when is_integer(DrvSep), ?IS_DRIVELETTER(Dl) ->
     dirname(Rest, [DrvSep,Dl], [], Seps);
 dirname([Char|Rest], Dir, File, Seps) when is_integer(Char) ->
     dirname(Rest, Dir, [Char|File], Seps);
@@ -757,7 +758,8 @@ win32_split([X, $\\|Rest]) when is_integer(X) ->
     win32_split([X, $/|Rest]);
 win32_split([X, Y, $\\|Rest]) when is_integer(X), is_integer(Y) ->
     win32_split([X, Y, $/|Rest]);
-win32_split([UcLetter, $:|Rest]) when UcLetter >= $A, UcLetter =< $Z ->
+win32_split([UcLetter, $:|Rest])
+  when is_integer(UcLetter), $A =< UcLetter, UcLetter =< $Z ->
     win32_split([UcLetter+$a-$A, $:|Rest]);
 win32_split([Letter, $:, $/|Rest]) ->
     split(Rest, [], [[Letter, $:, $/]], win32);

--- a/lib/stdlib/src/gb_sets.erl
+++ b/lib/stdlib/src/gb_sets.erl
@@ -259,13 +259,13 @@ is_member_1(_, nil) ->
       Set1 :: set(Element),
       Set2 :: set(Element).
 
-insert(Key, {S, T}) ->
+insert(Key, {S, T}) when is_integer(S), S >= 0 ->
     S1 = S + 1,
     {S1, insert_1(Key, T, ?pow(S1, ?p))}.
 
 insert_1(Key, {Key1, Smaller, Bigger}, S) when Key < Key1 -> 
     case insert_1(Key, Smaller, ?div2(S)) of
-	{T1, H1, S1} when is_integer(H1) ->
+	{T1, H1, S1} when is_integer(H1), is_integer(S1) ->
 	    T = {Key1, T1, Bigger},
 	    {H2, S2} = count(Bigger),
 	    H = ?mul2(erlang:max(H1, H2)),
@@ -282,7 +282,7 @@ insert_1(Key, {Key1, Smaller, Bigger}, S) when Key < Key1 ->
     end;
 insert_1(Key, {Key1, Smaller, Bigger}, S) when Key > Key1 -> 
     case insert_1(Key, Bigger, ?div2(S)) of
-	{T1, H1, S1} when is_integer(H1) ->
+	{T1, H1, S1} when is_integer(H1), is_integer(S1) ->
 	    T = {Key1, Smaller, T1},
 	    {H2, S2} = count(Smaller),
 	    H = ?mul2(erlang:max(H1, H2)),
@@ -317,7 +317,7 @@ count(nil) ->
       Set1 :: set(Element),
       Set2 :: set(Element).
 
-balance({S, T}) ->
+balance({S, T}) when is_integer(S), S >= 0 ->
     {S, balance(T, S)}.
 
 balance(T, S) ->
@@ -550,9 +550,9 @@ next([]) ->
       Set2 :: set(Element),
       Set3 :: set(Element).
 
-union({N1, T1}, {N2, T2}) when N2 < N1 ->
+union({N1, T1}, {N2, T2}) when is_integer(N1), is_integer(N2), N2 < N1 ->
     union(to_list_1(T2), N2, T1, N1);
-union({N1, T1}, {N2, T2}) ->
+union({N1, T1}, {N2, T2}) when is_integer(N1), is_integer(N2) ->
     union(to_list_1(T1), N1, T2, N2).
 
 %% We avoid the expensive mathematical computations if there is little
@@ -633,7 +633,7 @@ push([X | Xs], As) ->
 push([], As) ->
     As.
 
-balance_revlist(L, S) ->
+balance_revlist(L, S) when is_integer(S) ->
     {T, _} = balance_revlist_1(L, S),
     T.
 
@@ -670,9 +670,9 @@ union_list(S, []) -> S.
       Set2 :: set(Element),
       Set3 :: set(Element).
 
-intersection({N1, T1}, {N2, T2}) when N2 < N1 ->
+intersection({N1, T1}, {N2, T2}) when is_integer(N1), is_integer(N2), N2 < N1 ->
     intersection(to_list_1(T2), N2, T1, N1);
-intersection({N1, T1}, {N2, T2}) ->
+intersection({N1, T1}, {N2, T2}) when is_integer(N1), is_integer(N2) ->
     intersection(to_list_1(T1), N1, T2, N2).
 
 intersection(L, _N1, T2, N2) when N2 < 10 ->
@@ -770,7 +770,8 @@ subtract(S1, S2) ->
       Set2 :: set(Element),
       Set3 :: set(Element).
 
-difference({N1, T1}, {N2, T2}) ->
+difference({N1, T1}, {N2, T2}) when is_integer(N1), N1 >= 0,
+                                    is_integer(N2), N2 >= 0 ->
     difference(to_list_1(T1), N1, T2, N2).
 
 difference(L, N1, T2, N2) when N2 < 10 ->
@@ -820,7 +821,8 @@ difference_2(Xs, [], As, S) ->
       Set1 :: set(Element),
       Set2 :: set(Element).
 
-is_subset({N1, T1}, {N2, T2}) ->
+is_subset({N1, T1}, {N2, T2}) when is_integer(N1), N1 >= 0,
+                                   is_integer(N2), N2 >= 0 ->
     is_subset(to_list_1(T1), N1, T2, N2).
 
 is_subset(L, _N1, T2, N2) when N2 < 10 ->

--- a/lib/stdlib/src/gb_trees.erl
+++ b/lib/stdlib/src/gb_trees.erl
@@ -279,7 +279,7 @@ insert(Key, Val, {S, T}) when is_integer(S) ->
 
 insert_1(Key, Value, {Key1, V, Smaller, Bigger}, S) when Key < Key1 -> 
     case insert_1(Key, Value, Smaller, ?div2(S)) of
-	{T1, H1, S1} ->
+        {T1, H1, S1} when is_integer(H1), is_integer(S1) ->
 	    T = {Key1, V, T1, Bigger},
 	    {H2, S2} = count(Bigger),
 	    H = ?mul2(erlang:max(H1, H2)),
@@ -296,7 +296,7 @@ insert_1(Key, Value, {Key1, V, Smaller, Bigger}, S) when Key < Key1 ->
     end;
 insert_1(Key, Value, {Key1, V, Smaller, Bigger}, S) when Key > Key1 -> 
     case insert_1(Key, Value, Bigger, ?div2(S)) of
-	{T1, H1, S1} ->
+        {T1, H1, S1} when is_integer(H1), is_integer(S1) ->
 	    T = {Key1, V, Smaller, T1},
 	    {H2, S2} = count(Smaller),
 	    H = ?mul2(erlang:max(H1, H2)),
@@ -349,7 +349,7 @@ count(nil) ->
       Tree1 :: tree(Key, Value),
       Tree2 :: tree(Key, Value).
 
-balance({S, T}) ->
+balance({S, T}) when is_integer(S), S >= 0 ->
     {S, balance(T, S)}.
 
 balance(T, S) ->

--- a/lib/stdlib/test/erl_scan_SUITE.erl
+++ b/lib/stdlib/test/erl_scan_SUITE.erl
@@ -676,6 +676,8 @@ illegal() ->
 
 crashes() ->
     {'EXIT',_} = (catch {foo, erl_scan:string([-1])}), % type error
+    {'EXIT',_} = (catch erl_scan:string("'a" ++ [999999999] ++ "c'")),
+
     {'EXIT',_} = (catch {foo, erl_scan:string("$"++[-1])}),
     {'EXIT',_} = (catch {foo, erl_scan:string("$\\"++[-1])}),
     {'EXIT',_} = (catch {foo, erl_scan:string("$\\^"++[-1])}),
@@ -698,6 +700,7 @@ crashes() ->
          (catch {foo, erl_scan:string("% foo"++[a],{1,1})}),
 
     {'EXIT',_} = (catch {foo, erl_scan:string([3.0])}), % type error
+    {'EXIT',_} = (catch {foo, erl_scan:string("A" ++ [999999999])}),
 
     ok.
 
@@ -867,8 +870,8 @@ unicode() ->
         erl_scan:string([1089]),
     {error,{{1,1},erl_scan,{illegal,character}},{1,2}} =
         erl_scan:string([1089], {1,1}),
-    {error,{{1,3},erl_scan,{illegal,character}},{1,4}} =
-        erl_scan:string("'a" ++ [999999999] ++ "c'", {1,1}),
+    {error,{{1,1},erl_scan,{illegal,character}},{1,2}} =
+        erl_scan:string([16#D800], {1,1}),
 
     test("\"a"++[1089]++"b\""),
     {ok,[{char,1,1}],1} =

--- a/lib/stdlib/uc_spec/gen_unicode_mod.escript
+++ b/lib/stdlib/uc_spec/gen_unicode_mod.escript
@@ -335,7 +335,7 @@ gen_norm(Fd) ->
                  "-spec nfd(unicode:chardata()) -> maybe_improper_list(gc(),unicode:chardata()) | {error, unicode:chardata()}.\n"
                  "nfd(Str0) ->\n"
                  "    case gc(Str0) of\n"
-                 "        [GC|R] when GC < 128 -> [GC|R];\n"
+                 "        [GC|R] when is_integer(GC), 0 =< GC, GC < 128 -> [GC|R];\n"
                  "        [GC|Str] -> [decompose(GC)|Str];\n"
                  "        [] -> [];\n"
                  "        {error,_}=Error -> Error\n    end.\n\n"
@@ -345,7 +345,7 @@ gen_norm(Fd) ->
                  "-spec nfkd(unicode:chardata()) -> maybe_improper_list(gc(),unicode:chardata()) | {error, unicode:chardata()}.\n"
                  "nfkd(Str0) ->\n"
                  "    case gc(Str0) of\n"
-                 "        [GC|R] when GC < 128 -> [GC|R];\n"
+                 "        [GC|R] when is_integer(GC), 0 =< GC, GC < 128 -> [GC|R];\n"
                  "        [GC|Str] -> [decompose_compat(GC)|Str];\n"
                  "        [] -> [];\n"
                  "        {error,_}=Error -> Error\n    end.\n\n"
@@ -355,7 +355,7 @@ gen_norm(Fd) ->
                  "-spec nfc(unicode:chardata()) -> maybe_improper_list(gc(),unicode:chardata()) | {error, unicode:chardata()}.\n"
                  "nfc(Str0) ->\n"
                  "    case gc(Str0) of\n"
-                 "        [GC|R] when GC < 256 -> [GC|R];\n"
+                 "        [GC|R] when is_integer(GC), 0 =< GC, GC < 256 -> [GC|R];\n"
                  "        [GC|Str] -> [compose(decompose(GC))|Str];\n"
                  "        [] -> [];\n"
                  "        {error,_}=Error -> Error\n    end.\n\n"
@@ -365,7 +365,7 @@ gen_norm(Fd) ->
                  "-spec nfkc(unicode:chardata()) -> maybe_improper_list(gc(),unicode:chardata()) | {error, unicode:chardata()}.\n"
                  "nfkc(Str0) ->\n"
                  "    case gc(Str0) of\n"
-                 "        [GC|R] when GC < 128 -> [GC|R];\n"
+                 "        [GC|R] when is_integer(GC), 0 =< GC, GC < 128 -> [GC|R];\n"
                  "        [GC|Str] -> [compose_compat_0(decompose_compat(GC))|Str];\n"
                  "        [] -> [];\n"
                  "        {error,_}=Error -> Error\n    end.\n\n"
@@ -380,7 +380,7 @@ gen_norm(Fd) ->
                  "decompose(CP) ->\n"
                  "   canonical_order(decompose_1(CP)).\n"
                  "\n"
-                 "decompose_1(CP) when 16#AC00 =< CP, CP =< 16#D7A3 ->\n"
+                 "decompose_1(CP) when is_integer(CP), 16#AC00 =< CP, CP =< 16#D7A3 ->\n"
                  "    Syll = CP-16#AC00,\n"
                  "    T = 28,\n"
                  "    N = 588,\n"
@@ -424,7 +424,7 @@ gen_norm(Fd) ->
                  "decompose_compat(CP) ->\n"
                  "   canonical_order(decompose_compat_1(CP)).\n"
                  "\n"
-                 "decompose_compat_1(CP) when 16#AC00 =< CP, CP =< 16#D7A3 ->\n"
+                 "decompose_compat_1(CP) when is_integer(CP), 16#AC00 =< CP, CP =< 16#D7A3 ->\n"
                  "    Syll = CP-16#AC00,\n"
                  "    T = 28,\n"
                  "    N = 588,\n"
@@ -442,17 +442,18 @@ gen_norm(Fd) ->
                  "    end;\n"
                  "decompose_compat_1([CP|CPs]) ->\n"
                  "    decompose_compat_1(CP) ++ decompose_compat_1(CPs);\n"
-                 "decompose_compat_1([]) -> [].\n"),
+                 "decompose_compat_1([]) -> [].\n\n"),
 
 
     io:put_chars(Fd,
                  "compose(CP) when is_integer(CP) -> CP;\n"
                  "compose([Lead,Vowel|Trail]) %% Hangul\n"
-                 "  when 16#1100 =< Lead, Lead =< 16#1112 ->\n"
+                 "  when is_integer(Lead), 16#1100 =< Lead, Lead =< 16#1112, is_integer(Vowel) ->\n"
                  "    if 16#1161 =< Vowel, Vowel =< 16#1175 ->\n"
                  "            CP = 16#AC00 + ((Lead - 16#1100) * 588) + ((Vowel - 16#1161) * 28),\n"
                  "            case Trail of\n"
-                 "                [T|Acc] when 16#11A7 =< T, T =< 16#11C2 -> nolist(CP+T-16#11A7,Acc);\n"
+                 "                [T|Acc] when is_integer(T), 16#11A7 =< T, T =< 16#11C2 ->"
+                 "                     nolist(CP+T-16#11A7,Acc);\n"
                  "                Acc -> nolist(CP,Acc)\n"
                  "            end;\n"
                  "       true ->\n"
@@ -494,11 +495,12 @@ gen_norm(Fd) ->
                  "    end.\n\n"
                  "compose_compat(CP) when is_integer(CP) -> CP;\n"
                  "compose_compat([Lead,Vowel|Trail]) %% Hangul\n"
-                 "  when 16#1100 =< Lead, Lead =< 16#1112 ->\n"
+                 "  when is_integer(Lead), 16#1100 =< Lead, Lead =< 16#1112, is_integer(Vowel) ->\n"
                  "    if 16#1161 =< Vowel, Vowel =< 16#1175 ->\n"
                  "            CP = 16#AC00 + ((Lead - 16#1100) * 588) + ((Vowel - 16#1161) * 28),\n"
                  "            case Trail of\n"
-                 "                [T|Acc] when 16#11A7 =< T, T =< 16#11C2 -> nolist(CP+T-16#11A7,Acc);\n"
+                 "                [T|Acc] when is_integer(T), 16#11A7 =< T, T =< 16#11C2 ->"
+                 "                    nolist(CP+T-16#11A7,Acc);\n"
                  "                Acc -> nolist(CP,Acc)\n"
                  "            end;\n"
                  "       true ->\n"
@@ -634,12 +636,12 @@ gen_gc(Fd, GBP) ->
                  "        [$\\n|R1] -> [[$\\r,$\\n]|R1];\n"
                  "        T -> [CP|T]\n"
                  "    end;\n"
-                 "gc([CP1|T1]=T) when CP1 < 256 andalso ?IS_CP(CP1) ->\n"
+                 "gc([CP1|T1]=T) when ?IS_CP(CP1), CP1 < 256 ->\n"
                  "    case T1 of\n"
-                 "        [CP2|_] when CP2 < 256 -> T; %% Ascii Fast path\n"
+                 "        [CP2|_] when is_integer(CP2), 0 =< CP2, CP2 < 256 -> T; %% Ascii Fast path\n"
                  "        _ -> %% Keep the tail binary.\n"
                  "            case cp_no_bin(T1) of\n"
-                 "                [CP2|_]=T3 when CP2 < 256 -> [CP1|T3]; %% Asciii Fast path\n"
+                 "                [CP2|_]=T3 when is_integer(CP2), 0 =< CP2, CP2 < 256 -> [CP1|T3]; %% Asciii Fast path\n"
                  "                binary_found -> gc_1(T);\n"
                  "                T4 -> gc_1([CP1|T4])\n"
                  "            end\n"
@@ -682,13 +684,14 @@ gen_gc(Fd, GBP) ->
     io:put_chars(Fd, "\n%% Optimize Latin-1\n"),
     [GenExtP(CP) || CP <- merge_ranges(ExtendedPictographicLow)],
 
-    io:format(Fd,
-              "gc_1([CP|R]=R0) when CP < 256 ->\n"
-              "    case R of\n"
-              "        [CP2|_] when CP2 < 256 -> R0;\n"
-              "        _ -> gc_extend(cp(R), R, CP)\n"
-              "    end;\n",
-              []),
+    io:put_chars(Fd,
+                 "gc_1([CP|R]=R0) when is_integer(CP), 0 =< CP, CP < 256 ->\n"
+                 "    case R of\n"
+                 "        [CP2|_] when is_integer(CP2), 0 =< CP2, CP2 < 256 -> R0;\n"
+                 "        _ -> gc_extend(cp(R), R, CP)\n"
+                 "    end;\n"
+                 "gc_1([CP|_]) when not ?IS_CP(CP) ->\n"
+                 "    error({badarg,CP});\n"),
     io:put_chars(Fd, "\n%% Continue control\n"),
     [GenControl(CP) || CP <- Crs],
     %% One clause per CP
@@ -709,7 +712,7 @@ gen_gc(Fd, GBP) ->
     GenHangulT = fun(Range) -> io:format(Fd, "gc_1~s gc_h_T(R1,[CP]);\n", [gen_clause(Range)]) end,
     [GenHangulT(CP) || CP <- merge_ranges(maps:get(t,GBP))],
     io:put_chars(Fd, "%% Handle Hangul LV and LVT special, since they are large\n"),
-    io:put_chars(Fd, "gc_1([CP|_]=R0) when 44000 < CP, CP < 56000 -> gc_h_lv_lvt(R0, R0, []);\n"),
+    io:put_chars(Fd, "gc_1([CP|_]=R0) when is_integer(CP), 44000 < CP, CP < 56000 -> gc_h_lv_lvt(R0, R0, []);\n"),
 
     io:put_chars(Fd, "\n%% Handle Regional\n"),
     GenRegional = fun(Range) -> io:format(Fd, "gc_1~s gc_regional(R1,CP);\n", [gen_clause(Range)]) end,
@@ -825,7 +828,9 @@ gen_gc(Fd, GBP) ->
     [{RLess,RLarge}] = merge_ranges(maps:get(regional_indicator,GBP)),
     io:put_chars(Fd,"gc_regional(R0, CP0) ->\n"
                  "    case cp(R0) of\n"),
-    io:format(Fd,   "        [CP|R1] when ~w =< CP,CP =< ~w-> gc_extend2(cp(R1),R1,[CP,CP0]);~n",[RLess, RLarge]),
+    io:format(Fd,   "        [CP|R1] when is_integer(CP), ~w =< CP, CP =< ~w ->\n"
+              "             gc_extend2(cp(R1),R1,[CP,CP0]);~n",
+              [RLess, RLarge]),
     io:put_chars(Fd,"        R1 -> gc_extend(R1, R0, CP0)\n"
                  "    end.\n\n"),
 
@@ -893,7 +898,8 @@ gen_compose_pairs(Fd, ExclData, Data) ->
     [io:format(Fd, "compose_pair(~w,~w) -> ~w;~n", [A,B,CP]) || {[A,B],CP} <- lists:sort(DeCmp2)],
     io:put_chars(Fd, "compose_pair(_,_) -> false.\n\n"),
 
-    io:put_chars(Fd, "nolist(CP, []) -> CP;\nnolist(CP,L) -> [CP|L].\n\n"),
+    io:put_chars(Fd, "nolist(CP, []) when ?IS_CP(CP) -> CP;\n"
+                 "nolist(CP, L) when ?IS_CP(CP) -> [CP|L].\n\n"),
     ok.
 
 gen_case_table(Fd, Data) ->
@@ -1164,23 +1170,23 @@ gen_width_table(Fd, WideChars) ->
 gen_clause({R0, undefined}) ->
     io_lib:format("([~w=CP|R1]=R0) ->", [R0]);
 gen_clause({R0, R1}) ->
-    io_lib:format("([CP|R1]=R0) when ~w =< CP, CP =< ~w ->", [R0,R1]).
+    io_lib:format("([CP|R1]=R0) when is_integer(CP), ~w =< CP, CP =< ~w ->", [R0,R1]).
 
 gen_clause2({R0, undefined}) ->
     io_lib:format("([~w=CP|R1], R0, Acc) ->", [R0]);
 gen_clause2({R0, R1}) ->
-    io_lib:format("([CP|R1], R0, Acc) when ~w =< CP, CP =< ~w ->", [R0,R1]).
+    io_lib:format("([CP|R1], R0, Acc) when is_integer(CP), ~w =< CP, CP =< ~w ->", [R0,R1]).
 
 gen_case_clause({R0, undefined}) ->
     io_lib:format("[~w=CP|R1] ->", [R0]);
 gen_case_clause({R0, R1}) ->
-    io_lib:format("[CP|R1] when ~w =< CP, CP =< ~w ->", [R0,R1]).
+    io_lib:format("[CP|R1] when is_integer(CP), ~w =< CP, CP =< ~w ->", [R0,R1]).
 
 
 gen_single_clause({R0, undefined}) ->
     io_lib:format("(~w) ->", [R0]);
 gen_single_clause({R0, R1}) ->
-    io_lib:format("(CP) when ~w =< CP, CP =< ~w ->", [R0,R1]).
+    io_lib:format("(CP) when is_integer(CP), ~w =< CP, CP =< ~w ->", [R0,R1]).
 
 
 merge_ranges(List) ->


### PR DESCRIPTION
Add `is_integer/1` guard tests (and some range tests) to a few of the important modules in STDLIB.

This change will make sure that floats are rejected for functions that should only accept integers. It will also enable the JIT to generate more compact code.