### PR TITLE
Fix distributed spawn_request() bug

### DIFF
--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -289,6 +289,15 @@ static int monitor_connection_down(ErtsMonitor *mon, void *unused, Sint reds)
 
 static int dist_pend_spawn_exit_connection_down(ErtsMonitor *mon, void *unused, Sint reds)
 {
+    Process *proc = mon->other.ptr;
+    ASSERT(!erts_monitor_is_origin(mon));
+    if (proc) {
+        ErtsMonitorData *mdp = erts_monitor_to_data(mon);
+        if (mdp->origin.other.item == am_pending) {
+            /* Resume the parent process waiting for a result... */
+            erts_resume(proc, 0);
+        }
+    }
     erts_monitor_release(mon);
     return 1;
 }

--- a/erts/emulator/beam/erl_node_tables.c
+++ b/erts/emulator/beam/erl_node_tables.c
@@ -1641,6 +1641,9 @@ insert_dist_monitors(DistEntry *dep)
         erts_monitor_tree_foreach(dep->mld->orig_name_monitors,
                                   insert_monitor,
                                   (void *) &dep->sysname);
+        erts_monitor_tree_foreach(dep->mld->dist_pend_spawn_exit,
+                                  insert_monitor,
+                                  (void *) &dep->sysname);
     }
 }
 

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -4924,8 +4924,7 @@ handle_dist_spawn_reply(Process *c_p, ErtsSigRecvTracing *tracing,
 static int
 handle_dist_spawn_reply_exiting(Process *c_p,
                                 ErtsMessage *sig,
-                                ErtsMonitor **pend_spawn_mon_pp,
-                                Eterm reason)
+                                ErtsProcExitContext *pe_ctxt_p)
 {
     ErtsDistSpawnReplySigData *datap = get_dist_spawn_reply_data(sig);
     Eterm result = datap->result;
@@ -4937,7 +4936,7 @@ handle_dist_spawn_reply_exiting(Process *c_p,
     ASSERT(is_atom(result) || is_external_pid(result));
     ASSERT(is_atom(result) || size_object(result) == EXTERNAL_PID_HEAP_SIZE);
 
-    omon = erts_monitor_tree_lookup(*pend_spawn_mon_pp, datap->ref);
+    omon = erts_monitor_tree_lookup(pe_ctxt_p->pend_spawn_monitors, datap->ref);
     if (!omon) {
         /* May happen when connection concurrently close... */
         ErtsLink *lnk = datap->link;
@@ -4955,7 +4954,7 @@ handle_dist_spawn_reply_exiting(Process *c_p,
         ASSERT(omon->flags & ERTS_ML_FLG_SPAWN_PENDING);
         ASSERT(!datap->link || is_external_pid(result));
 
-        erts_monitor_tree_delete(pend_spawn_mon_pp, omon);
+        erts_monitor_tree_delete(&pe_ctxt_p->pend_spawn_monitors, omon);
         mdp = erts_monitor_to_data(omon);
 
         if (!erts_dist_pend_spawn_exit_delete(&mdp->u.target))
@@ -4976,12 +4975,17 @@ handle_dist_spawn_reply_exiting(Process *c_p,
             ASSERT(!(omon->flags & ERTS_ML_FLG_SPAWN_LINK) || datap->link);
 
             if (datap->link) {
-                /* This link exit *should* have actual reason... */
-                ErtsProcExitContext pectxt = {c_p, reason};
                 /* unless operation has been abandoned... */
-                if (omon->flags & ERTS_ML_FLG_SPAWN_ABANDONED)
-                    pectxt.reason = am_abandoned;
-                erts_proc_exit_handle_link(datap->link, (void *) &pectxt, -1);
+                if (omon->flags & ERTS_ML_FLG_SPAWN_ABANDONED) {
+                    ErtsProcExitContext pectxt = {c_p, am_abandoned};
+                    erts_proc_exit_handle_link(datap->link, (void *) &pectxt, -1);
+                }
+                else {
+                    /* This link exit *should* have actual reason... */
+                    erts_proc_exit_handle_link(datap->link,
+                                               (void *) pe_ctxt_p,
+                                               -1);
+                }
                 cnt++;
             }
         }
@@ -6007,8 +6011,7 @@ stretch_limit(Process *c_p, ErtsSigRecvTracing *tp,
 
 int
 erts_proc_sig_handle_exit(Process *c_p, Sint *redsp,
-                          ErtsMonitor **pend_spawn_mon_pp,
-                          Eterm reason)
+                          ErtsProcExitContext *pe_ctxt_p)
 {
     int cnt;
     Sint limit;
@@ -6158,9 +6161,8 @@ erts_proc_sig_handle_exit(Process *c_p, Sint *redsp,
         }
 
         case ERTS_SIG_Q_OP_DIST_SPAWN_REPLY: {
-            cnt += handle_dist_spawn_reply_exiting(c_p, sig,
-                                                   pend_spawn_mon_pp,
-                                                   reason);
+            cnt += handle_dist_spawn_reply_exiting(c_p, sig, pe_ctxt_p);
+
             break;
         }
 

--- a/erts/emulator/beam/erl_proc_sig_queue.h
+++ b/erts/emulator/beam/erl_proc_sig_queue.h
@@ -1185,6 +1185,8 @@ erts_proc_sig_handle_incoming(Process *c_p, erts_aint32_t *statep,
  *                              used by the call. On output, the
  *                              amount of reductions consumed.
  *
+ * @param[in,out] pe_ctxtp      Process exit context pointer.
+ *
  * @return                      Returns a non-zero value, when
  *                              no more signals to handle in the
  *                              middle queue remain. A zero
@@ -1194,8 +1196,7 @@ erts_proc_sig_handle_incoming(Process *c_p, erts_aint32_t *statep,
  */
 int
 erts_proc_sig_handle_exit(Process *c_p, Sint *redsp,
-                          ErtsMonitor **pend_spawn_mon_pp,
-                          Eterm reason);
+                          ErtsProcExitContext *pe_ctxt_p);
 
 /**
  *

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -14056,9 +14056,7 @@ restart:
     case ERTS_CONTINUE_EXIT_HANDLE_PROC_SIG: {
         Sint r = reds;
 
-        if (!erts_proc_sig_handle_exit(p, &r,
-                                       &trap_state->pectxt.pend_spawn_monitors,
-                                       trap_state->reason)) {
+        if (!erts_proc_sig_handle_exit(p, &r, &trap_state->pectxt)) {
             goto yield;
         }
 


### PR DESCRIPTION
Distributed exit signals could be lost under the following conditions:
*   An exit signal from a parent process to a child process was lost if:
    * the parent process terminated before the spawn request that created the child had completed,
    * the spawn request set up a link between parent and child
    * the spawn request was distributed, and
    * the exit reason was larger than one machine word.
* Loss of a connection over which a not yet completed spawn request was ongoing could cause loss of exit signals. Such loss of exit signals was very rare. Besides the above described connection loss also the following
conditions had to be satisfied:
    * The spawn request that was interrupted by the connection loss also had to set up a link between the parent process and the child process.
    * The parent process that issued the spawn request also had to be terminating while the spawn request was interrupted by the connection loss.
    * The same parent process also had to have made other spawn requests to other nodes than to the node to which the connection was lost.
    * These spawn requests to the other nodes also had to set up links.
    * These spawn requests to the other nodes also had to be not yet completed at the time of the connection loss. That is, the spawn reply from the child process had not yet reached the parent process.

    If all the conditions above were met, exit signals to the children spawned due to the above described spawn requests to other nodes *could* be lost.

    The above bug also caused a significant memory leak when it was triggered
since the destruction of the parent process never completed.