### PR TITLE
Fix: Export all types used by specs of functions exported by beam_lib

### DIFF
--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -52,6 +52,8 @@
 
 -export_type([attrib_entry/0, compinfo_entry/0, labeled_entry/0, label/0]).
 -export_type([chnk_rsn/0]).
+-export_type([info_rsn/0, chunkid/0, cmp_rsn/0, beam/0, chunkdata/0, chunkref/0, dataB/0, crypto_fun/0, mode/0]).
+-export_type([abst_code/0, debug_info/0, index/0, chunkname/0, crypto_fun_arg/0, forms/0]).
 
 -import(lists, [append/1, delete/2, foreach/2, keysort/2, 
 		member/2, reverse/1, sort/1, splitwith/2]).


### PR DESCRIPTION
## Problem
Specs of some functions exported by beam_lib module use types that are not exported. As a result, Dialyzer checks fail in user code that e.g. accepts data returned by those functions.

## Solution
Export all types which are used in function signatures and types which are referred to inside the types above.

## Checks performed
```
export ERL_TOP=`pwd`
./otp_build setup -a
(cd $ERL_TOP/lib/stdlib && make test ARGS="-suite beam_lib_SUITE")
```