### PR TITLE
peer: Add detached and post_process_args

### DIFF
--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -650,13 +650,12 @@ int main(int argc, char **argv)
 		    break;
 
 		  case 'd':
-		    if (strcmp(argv[i], "-detached") != 0) {
-			add_arg(argv[i]);
-		    } else {
-			start_detached = 1;
-			add_args("-noshell", "-noinput", NULL);
-		    }
-		    break;
+                    add_arg(argv[i]);
+                    if (strcmp(argv[i], "-detached") == 0) {
+                        start_detached = 1;
+                        add_args("-noshell", "-noinput", NULL);
+                    }
+                    break;
 
 		  case 'e':
 		    if (strcmp(argv[i], "-extra") == 0) {

--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -2844,7 +2844,6 @@ start_peer(#{name := Name} = Opts, Module) ->
             Shutdown = binary_to_term(term_to_binary({10000, CoverMain})),
             case peer:start_link(Opts#{args => FullArgs, shutdown => Shutdown}) of
                 {ok, Peer, Node} ->
-                    do_cover_for_node(Node, start),
                     {ok, Peer, Node};
                 Other ->
                     Other

--- a/lib/kernel/src/user_sup.erl
+++ b/lib/kernel/src/user_sup.erl
@@ -39,7 +39,9 @@ start() ->
 -spec init([]) -> 'ignore' | {'error', 'nouser'} | {'ok', pid(), pid()}.
 
 init([]) ->
-    case get_user() of
+    init(init:get_arguments());
+init(Flags) ->
+    case get_user(Flags) of
 	nouser ->
 	    ignore;
 	{master, Master} ->
@@ -112,8 +114,7 @@ wait_for_user_p(N) ->
 	    wait_for_user_p(N-1)
     end.
 
-get_user() ->
-    Flags = init:get_arguments(),
+get_user(Flags) ->
     check_flags(Flags, {user_drv, start, []}).
 
 %% These flags depend upon what arguments the erl script passes on

--- a/lib/stdlib/doc/src/peer.xml
+++ b/lib/stdlib/doc/src/peer.xml
@@ -313,6 +313,20 @@ build_image(Dir) ->
             <p>Extra command line arguments to append to the "erl" command. Arguments are
               passed as is, no escaping or quoting is needed or accepted.</p>
           </item>
+          <tag><c>post_process_args</c></tag>
+          <item>
+            <p>Allows the user to change the arguments passed to <c>exec</c> before the
+              peer is started. This can for example be useful when the <c>exec</c> program
+              wants the arguments to "erl" as a single argument. Example:
+            </p>
+            <code type="erl">
+peer:start(#{ name => peer:random_name(),
+  exec => {os:find_executable("bash"),["-c","erl"]},
+  post_process_args =>
+     fun(["-c"|Args]) -> ["-c", lists:flatten(lists:join($\s, Args))] end
+  }).
+            </code>
+          </item>
           <tag><c>env</c></tag>
           <item>
             <p>

--- a/lib/stdlib/doc/src/peer.xml
+++ b/lib/stdlib/doc/src/peer.xml
@@ -308,6 +308,13 @@ build_image(Dir) ->
               default bash.
             </p>
           </item>
+          <tag><c>detached</c></tag>
+          <item>
+            <p>Defines whether to pass the <c>-detached</c> flag to the started peer.
+              This option cannot be set to <c>false</c> using the standard_io alternative
+              connection type. Default is <c>true</c>.
+            </p>
+          </item>
           <tag><c>args</c></tag>
           <item>
             <p>Extra command line arguments to append to the "erl" command. Arguments are

--- a/lib/stdlib/doc/src/peer.xml
+++ b/lib/stdlib/doc/src/peer.xml
@@ -99,60 +99,60 @@
       of the same test suite running in parallel</item>
     </list>
     <code type="erl">
-      -module(my_SUITE).
-      -behaviour(ct_suite).
-      -export([all/0, groups/0]).
-      -export([basic/1, args/1, named/1, restart_node/1, multi_node/1]).
+-module(my_SUITE).
+-behaviour(ct_suite).
+-export([all/0, groups/0]).
+-export([basic/1, args/1, named/1, restart_node/1, multi_node/1]).
 
-      -include_lib("common_test/include/ct.hrl").
+-include_lib("common_test/include/ct.hrl").
 
-      groups() ->
-          [{quick, [parallel],
-              [basic, args, named, restart_node, multi_node]}].
+groups() ->
+    [{quick, [parallel],
+        [basic, args, named, restart_node, multi_node]}].
 
-      all() ->
-          [{group, quick}].
+all() ->
+    [{group, quick}].
 
-      basic(Config) when is_list(Config) ->
-          {ok, Peer, _Node} = ?CT_PEER(),
-          peer:stop(Peer).
+basic(Config) when is_list(Config) ->
+    {ok, Peer, _Node} = ?CT_PEER(),
+    peer:stop(Peer).
 
-      args(Config) when is_list(Config) ->
-          %% specify additional arguments to the new node
-          {ok, Peer, _Node} = ?CT_PEER(["-emu_flavor", "smp"]),
-          peer:stop(Peer).
+args(Config) when is_list(Config) ->
+    %% specify additional arguments to the new node
+    {ok, Peer, _Node} = ?CT_PEER(["-emu_flavor", "smp"]),
+    peer:stop(Peer).
 
-      named(Config) when is_list(Config) ->
-          %% pass test case name down to function starting nodes
-          Peer = start_node_impl(named_test),
-          peer:stop(Peer).
+named(Config) when is_list(Config) ->
+    %% pass test case name down to function starting nodes
+    Peer = start_node_impl(named_test),
+    peer:stop(Peer).
 
-      start_node_impl(ActualTestCase) ->
-          {ok, Peer, Node} = ?CT_PEER(#{name => ?CT_PEER_NAME(ActualTestCase)}),
-          %% extra setup needed for multiple test cases
-          ok = rpc:call(Node, application, set_env, [kernel, key, value]),
-          Peer.
+start_node_impl(ActualTestCase) ->
+    {ok, Peer, Node} = ?CT_PEER(#{name => ?CT_PEER_NAME(ActualTestCase)}),
+    %% extra setup needed for multiple test cases
+    ok = rpc:call(Node, application, set_env, [kernel, key, value]),
+    Peer.
 
-      restart_node(Config) when is_list(Config) ->
-          Name = ?CT_PEER_NAME(),
-          {ok, Peer, Node} = ?CT_PEER(#{name => Name}),
-          peer:stop(Peer),
-          %% restart the node with the same name as before
-          {ok, Peer2, Node} = ?CT_PEER(#{name => Name, args => ["+fnl"]}),
-          peer:stop(Peer2).
+restart_node(Config) when is_list(Config) ->
+    Name = ?CT_PEER_NAME(),
+    {ok, Peer, Node} = ?CT_PEER(#{name => Name}),
+    peer:stop(Peer),
+    %% restart the node with the same name as before
+    {ok, Peer2, Node} = ?CT_PEER(#{name => Name, args => ["+fnl"]}),
+    peer:stop(Peer2).
     </code>
 
     <p>
       The next example demonstrates how to start multiple nodes concurrently:
     </p>
     <code type="erl">
-      multi_node(Config) when is_list(Config) ->
-          Peers = [?CT_PEER(#{wait_boot => {self(), tag}})
-              || _ &lt;- lists:seq(1, 4)],
-          %% wait for all nodes to complete boot process, get their names:
-          _Nodes = [receive {tag, {started, Node, Peer}} -> Node end
-              || {ok, Peer} &lt;- Peers],
-          [peer:stop(Peer) || {ok, Peer} &lt;- Peers].
+multi_node(Config) when is_list(Config) ->
+    Peers = [?CT_PEER(#{wait_boot => {self(), tag}})
+        || _ &lt;- lists:seq(1, 4)],
+    %% wait for all nodes to complete boot process, get their names:
+    _Nodes = [receive {tag, {started, Node, Peer}} -> Node end
+        || {ok, Peer} &lt;- Peers],
+    [peer:stop(Peer) || {ok, Peer} &lt;- Peers].
     </code>
 
     <p>
@@ -161,9 +161,9 @@
       prompt.
     </p>
     <code type="erl">
-      Ssh = os:find_executable("ssh"),
-      peer:start_link(#{exec => {Ssh, ["another_host", "erl"]},
-          connection => standard_io}),
+Ssh = os:find_executable("ssh"),
+peer:start_link(#{exec => {Ssh, ["another_host", "erl"]},
+    connection => standard_io}),
     </code>
 
     <p>
@@ -172,76 +172,76 @@
       running inside containers form an Erlang cluster.
     </p>
     <code type="erl">
-      docker(Config) when is_list(Config) ->
-          Docker = os:find_executable("docker"),
-          PrivDir = proplists:get_value(priv_dir, Config),
-          build_release(PrivDir),
-          build_image(PrivDir),
+docker(Config) when is_list(Config) ->
+    Docker = os:find_executable("docker"),
+    PrivDir = proplists:get_value(priv_dir, Config),
+    build_release(PrivDir),
+    build_image(PrivDir),
 
-          %% start two Docker containers
-          {ok, Peer, Node} = peer:start_link(#{name => lambda,
-              connection => standard_io,
-              exec => {Docker, ["run", "-h", "one", "-i", "lambda"]}}),
-          {ok, Peer2, Node2} = peer:start_link(#{name => lambda,
-              connection => standard_io,
-              exec => {Docker, ["run", "-h", "two", "-i", "lambda"]}}),
+    %% start two Docker containers
+    {ok, Peer, Node} = peer:start_link(#{name => lambda,
+        connection => standard_io,
+        exec => {Docker, ["run", "-h", "one", "-i", "lambda"]}}),
+    {ok, Peer2, Node2} = peer:start_link(#{name => lambda,
+        connection => standard_io,
+        exec => {Docker, ["run", "-h", "two", "-i", "lambda"]}}),
 
-          %% find IP address of the second node using alternative connection RPC
-          {ok, Ips} = peer:call(Peer2, inet, getifaddrs, []),
-          {"eth0", Eth0} = lists:keyfind("eth0", 1, Ips),
-          {addr, Ip} = lists:keyfind(addr, 1, Eth0),
+    %% find IP address of the second node using alternative connection RPC
+    {ok, Ips} = peer:call(Peer2, inet, getifaddrs, []),
+    {"eth0", Eth0} = lists:keyfind("eth0", 1, Ips),
+    {addr, Ip} = lists:keyfind(addr, 1, Eth0),
 
-          %% make first node to discover second one
-          ok = peer:call(Peer, inet_db, set_lookup, [[file]]),
-          ok = peer:call(Peer, inet_db, add_host, [Ip, ["two"]]),
+    %% make first node to discover second one
+    ok = peer:call(Peer, inet_db, set_lookup, [[file]]),
+    ok = peer:call(Peer, inet_db, add_host, [Ip, ["two"]]),
 
-          %% join a cluster
-          true = peer:call(Peer, net_kernel, connect_node, [Node2]),
-          %% verify that second peer node has only the first node visible
-          [Node] = peer:call(Peer2, erlang, nodes, []),
+    %% join a cluster
+    true = peer:call(Peer, net_kernel, connect_node, [Node2]),
+    %% verify that second peer node has only the first node visible
+    [Node] = peer:call(Peer2, erlang, nodes, []),
 
-          %% stop peers, causing containers to also stop
-          peer:stop(Peer2),
-          peer:stop(Peer).
+    %% stop peers, causing containers to also stop
+    peer:stop(Peer2),
+    peer:stop(Peer).
 
-      build_release(Dir) ->
-          %% load sasl.app file, otherwise application:get_key will fail
-          application:load(sasl),
-          %% create *.rel - release file
-          RelFile = filename:join(Dir, "lambda.rel"),
-          Release = {release, {"lambda", "1.0.0"},
-              {erts, erlang:system_info(version)},
-              [{App, begin {ok, Vsn} = application:get_key(App, vsn), Vsn end}
-                  || App &lt;- [kernel, stdlib, sasl]]},
-          ok = file:write_file(RelFile, list_to_binary(lists:flatten(
-              io_lib:format("~tp.", [Release])))),
-          RelFileNoExt = filename:join(Dir, "lambda"),
+build_release(Dir) ->
+    %% load sasl.app file, otherwise application:get_key will fail
+    application:load(sasl),
+    %% create *.rel - release file
+    RelFile = filename:join(Dir, "lambda.rel"),
+    Release = {release, {"lambda", "1.0.0"},
+        {erts, erlang:system_info(version)},
+        [{App, begin {ok, Vsn} = application:get_key(App, vsn), Vsn end}
+            || App &lt;- [kernel, stdlib, sasl]]},
+    ok = file:write_file(RelFile, list_to_binary(lists:flatten(
+        io_lib:format("~tp.", [Release])))),
+    RelFileNoExt = filename:join(Dir, "lambda"),
 
-          %% create boot script
-          {ok, systools_make, []} = systools:make_script(RelFileNoExt,
-              [silent, {outdir, Dir}]),
-          %% package release into *.tar.gz
-          ok = systools:make_tar(RelFileNoExt, [{erts, code:root_dir()}]).
+    %% create boot script
+    {ok, systools_make, []} = systools:make_script(RelFileNoExt,
+        [silent, {outdir, Dir}]),
+    %% package release into *.tar.gz
+    ok = systools:make_tar(RelFileNoExt, [{erts, code:root_dir()}]).
 
-      build_image(Dir) ->
-          %% Create Dockerfile example, working only for Ubuntu 20.04
-          %% Expose port 4445, and make Erlang distribution to listen
-          %%  on this port, and connect to it without EPMD
-          %% Set cookie on both nodes to be the same.
-          BuildScript = filename:join(Dir, "Dockerfile"),
-          Dockerfile =
-            "FROM ubuntu:20.04 as runner\n"
-            "EXPOSE 4445\n"
-            "WORKDIR /opt/lambda\n"
-            "COPY lambda.tar.gz /tmp\n"
-            "RUN tar -zxvf /tmp/lambda.tar.gz -C /opt/lambda\n"
-            "ENTRYPOINT [\"/opt/lambda/erts-" ++ erlang:system_info(version) ++
-            "/bin/dyn_erl\", \"-boot\", \"/opt/lambda/releases/1.0.0/start\","
-            " \"-kernel\", \"inet_dist_listen_min\", \"4445\","
-            " \"-erl_epmd_port\", \"4445\","
-            " \"-setcookie\", \"secret\"]\n",
-          ok = file:write_file(BuildScript, Dockerfile),
-          os:cmd("docker build -t lambda " ++ Dir).
+build_image(Dir) ->
+    %% Create Dockerfile example, working only for Ubuntu 20.04
+    %% Expose port 4445, and make Erlang distribution to listen
+    %%  on this port, and connect to it without EPMD
+    %% Set cookie on both nodes to be the same.
+    BuildScript = filename:join(Dir, "Dockerfile"),
+    Dockerfile =
+      "FROM ubuntu:20.04 as runner\n"
+      "EXPOSE 4445\n"
+      "WORKDIR /opt/lambda\n"
+      "COPY lambda.tar.gz /tmp\n"
+      "RUN tar -zxvf /tmp/lambda.tar.gz -C /opt/lambda\n"
+      "ENTRYPOINT [\"/opt/lambda/erts-" ++ erlang:system_info(version) ++
+      "/bin/dyn_erl\", \"-boot\", \"/opt/lambda/releases/1.0.0/start\","
+      " \"-kernel\", \"inet_dist_listen_min\", \"4445\","
+      " \"-erl_epmd_port\", \"4445\","
+      " \"-setcookie\", \"secret\"]\n",
+    ok = file:write_file(BuildScript, Dockerfile),
+    os:cmd("docker build -t lambda " ++ Dir).
     </code>
   </section>
 
@@ -270,19 +270,19 @@
               is, <c>peer</c> follows compatibility behaviour and uses the origin node name.
             </p>
           </item>
-          <tag><c>host</c></tag>
-          <item>
-            <p>
-              Enforces a specific host name. Can be used to override the default
-              behaviour and start "node@localhost" instead of "node@realhostname".
-            </p>
-          </item>
           <tag><c>longnames</c></tag>
           <item>
             <p>
               Use long names to start a node. Default is taken from the origin
               using <c>net_kernel:longnames()</c>. If the origin is not distributed,
               short names is the default.
+            </p>
+          </item>
+          <tag><c>host</c></tag>
+          <item>
+            <p>
+              Enforces a specific host name. Can be used to override the default
+              behaviour and start "node@localhost" instead of "node@realhostname".
             </p>
           </item>
           <tag><c>peer_down</c></tag>
@@ -296,17 +296,17 @@
               the controlling process to exit abnormally.
             </p>
           </item>
+          <tag><c>connection</c></tag>
+          <item>
+            <p>Alternative connection specification. See the
+              <seetype marker="#connection"><c>connection</c> datatype</seetype>.</p>
+          </item>
           <tag><c>exec</c></tag>
           <item>
             <p>
               Alternative mechanism to start peer nodes with, for example, ssh instead of the
               default bash.
             </p>
-          </item>
-          <tag><c>connection</c></tag>
-          <item>
-            <p>Alternative connection specification. See the
-              <seetype marker="#connection"><c>connection</c> datatype</seetype>.</p>
           </item>
           <tag><c>args</c></tag>
           <item>

--- a/lib/stdlib/src/peer.erl
+++ b/lib/stdlib/src/peer.erl
@@ -113,8 +113,8 @@
           %%  saving exit reason in the state
           %% crash: when peer terminates, origin process
           %%  terminates with underlying reason
-          exec => exec(),                     %% path to executable, or SSH/Docker support
           connection => connection(),         %% alternative connection specification
+          exec => exec(),                     %% path to executable, or SSH/Docker support
           args => [string()],                 %% additional command line parameters to append
           env => [{string(), string()}],      %% additional environment variables
           wait_boot => wait_boot(),           %% default is synchronous start with 15 sec timeout

--- a/lib/stdlib/src/peer.erl
+++ b/lib/stdlib/src/peer.erl
@@ -332,6 +332,25 @@ handle_call({call, M, F, A}, From,
     origin_to_peer(tcp, Socket, {call, Seq, M, F, A}),
     {noreply, State#peer_state{outstanding = Out#{Seq => From}, seq = Seq + 1}};
 
+handle_call({starting, Node}, _From, #peer_state{ options = Options } = State) ->
+    case maps:find(shutdown, Options) of
+        {ok, {Timeout, MainCoverNode}} when is_integer(Timeout),
+                                            is_atom(MainCoverNode) ->
+
+            %% The node was started using test_server:start_peer/2 with cover enabled
+            %% so we should start cover on the starting node.
+            Modules = erpc:call(MainCoverNode,cover,modules,[]),
+            erpc:call(
+              Node, fun() ->
+                            Sticky = [ begin code:unstick_mod(M), M end
+                                       || M <- Modules, code:is_sticky(M)],
+                            erpc:call(MainCoverNode, cover, start, [Node]),
+                            [code:stick_mod(M) || M <- Sticky]
+                    end);
+        _ ->
+            ok
+    end,
+    {reply, ok, State};
 handle_call(get_node, _From, #peer_state{node = Node} = State) ->
     {reply, Node, State};
 
@@ -531,8 +550,9 @@ verify_args(Options) ->
     [error({invalid_arg, Arg}) || Arg <- Args, not io_lib:char_list(Arg)],
     %% alternative connection must be requested for non-distributed node,
     %%  or a distributed node when origin is not alive
-    is_map_key(connection, Options) orelse
-                                      (is_map_key(name, Options) andalso erlang:is_alive()) orelse error(not_alive),
+    is_map_key(connection, Options)
+        orelse
+          (is_map_key(name, Options) andalso erlang:is_alive()) orelse error(not_alive),
     %% exec must be a string, or a tuple of string(), [string()]
     case maps:find(exec, Options) of
         {ok, {Exec, Strs}} ->
@@ -933,6 +953,7 @@ start() ->
                       notify_when_started(dist, OriginProcess),
                       origin_link(MRef, OriginProcess)
               end),
+            ok = gen_server:call(OriginProcess, {starting, node()}),
             case init:get_argument(peer_detached) of
                 {ok, _} ->
                     %% We are detached, so setup 'user' process, I/O redirection:

--- a/lib/stdlib/test/peer_SUITE.erl
+++ b/lib/stdlib/test/peer_SUITE.erl
@@ -46,7 +46,8 @@
     old_release/0, old_release/1,
     ssh/0, ssh/1,
     docker/0, docker/1,
-    post_process_args/0, post_process_args/1
+    post_process_args/0, post_process_args/1,
+    attached/0, attached/1
 ]).
 
 suite() ->
@@ -57,12 +58,12 @@ shutdown_alternatives() ->
 
 alternative() ->
     [basic, peer_states, cast, detached, dyn_peer, stop_peer,
-     io_redirect, multi_node, duplicate_name] ++ shutdown_alternatives().
+     io_redirect, multi_node, duplicate_name, attached] ++ shutdown_alternatives().
 
 groups() ->
     [
         {dist, [parallel], [errors, dist, peer_down_crash, peer_down_continue, peer_down_boot,
-                            dist_up_down, dist_localhost, post_process_args] ++ shutdown_alternatives()},
+                            dist_up_down, dist_localhost, post_process_args, attached] ++ shutdown_alternatives()},
         {dist_seq, [], [dist_io_redirect,      %% Cannot be run in parallel in dist group
                         peer_down_crash_tcp]},
         {tcp, [parallel], alternative()},
@@ -586,4 +587,33 @@ docker(Config) when is_list(Config) ->
                 exec => {Docker, ["run", "-i", "lambda"]}, connection => standard_io}),
             ?assertEqual(Node, peer:call(Peer, erlang, node, [])),
             peer:stop(Peer)
+    end.
+
+attached() ->
+    [{doc, "Test that it is possible to start a peer node using run_erl aka attached"}].
+
+attached(Config) ->
+    RunErl = os:find_executable("run_erl"),
+    [throw({skip, "Could not find run_erl"}) || RunErl =:= false],
+    Erl = string:split(ct:get_progname()," ",all),
+    RunErlDir = filename:join(proplists:get_value(priv_dir, Config),?FUNCTION_NAME),
+    filelib:ensure_path(RunErlDir),
+    Connection = proplists:get_value(connection, Config),
+    Conn = if Connection =:= undefined -> #{ name => ?CT_PEER_NAME() };
+              true -> #{ connection => Connection }
+           end,
+    try peer:start(
+           Conn#{
+                 exec => {RunErl, Erl},
+                 detached => false,
+                 post_process_args =>
+                     fun(Args) ->
+                             [RunErlDir ++ "/", RunErlDir,
+                              lists:flatten(lists:join(" ",[[$',A,$'] || A <- Args]))]
+                     end
+                }) of
+        {ok, Peer, _Node} when Connection =:= undefined; Connection =:= 0 ->
+            peer:stop(Peer)
+    catch error:{detached,_} when Connection =:= standard_io ->
+            ok
     end.


### PR DESCRIPTION
In order to test interactive shells, peer nodes sometimes need to be started without detaching the shell. This PR adds two mechanism that help when testing such systems:

1. The `detached` option can be set to false which causes the peer when running using distributed or tcp connection to not close its terminal.
2. The `post_process_args` option can be set to a fun which allows the peer to process all arguments before the peer node is started, this notably includes any arguments that `peer` itself has added.

These two changes in combination allows a peer node to be started in a screen/tmux session, or using run_erl/to_erl.

This PR also contains some changes to how cover is started when peer is running in CT so that cover is started earlier in the boot sequence allowing for better code coverage reports.