### PR TITLE
Slightly improve the compiler's type analysis and optimisations

### DIFF
--- a/lib/compiler/src/beam_bounds.erl
+++ b/lib/compiler/src/beam_bounds.erl
@@ -43,6 +43,14 @@
 
 -spec bounds(op(), range()) -> range_result().
 
+bounds('bnot', R0) ->
+    case R0 of
+        {A,B} ->
+            R = {inf_add(inf_neg(B), -1), inf_add(inf_neg(A), -1)},
+            normalize(R);
+        _ ->
+            any
+    end;
 bounds(abs, R) ->
     case R of
         {A,B} when is_integer(A), is_integer(B) ->

--- a/lib/compiler/src/beam_bounds.erl
+++ b/lib/compiler/src/beam_bounds.erl
@@ -26,7 +26,8 @@
 %%
 %%
 -module(beam_bounds).
--export([bounds/2, bounds/3, relop/3, infer_relop_types/3]).
+-export([bounds/2, bounds/3, relop/3, infer_relop_types/3,
+         is_masking_redundant/2]).
 -export_type([range/0]).
 
 -type range() :: {integer(), integer()} |
@@ -260,6 +261,19 @@ infer_relop_types('>', any, {C,_}=R2) ->
     {normalize({inf_add(C, 1), '+inf'}), R2};
 infer_relop_types(_Op, _R1, _R2) ->
     any.
+
+-spec is_masking_redundant(range(), integer()) -> boolean().
+
+is_masking_redundant(_, -1) ->
+    true;
+is_masking_redundant({A,B}, M)
+  when M band (M + 1) =:= 0,            %Is M + 1 a power of two?
+       M > 0,
+       is_integer(A), A >= 0,
+       B band M =:= B ->
+    true;
+is_masking_redundant(_, _) ->
+    false.
 
 %%%
 %%% Internal functions.

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -993,6 +993,13 @@ types(_, _, Args) ->
 arith_type({bif,'-'}, [Arg]) ->
     ArgTypes = [#t_integer{elements={0,0}},Arg],
     beam_bounds_type('-', #t_number{}, ArgTypes);
+arith_type({bif,'bnot'}, [Arg0]) ->
+    case meet(Arg0, #t_integer{}) of
+        none ->
+            none;
+        #t_integer{elements=R} ->
+            #t_integer{elements=beam_bounds:bounds('bnot', R)}
+    end;
 arith_type({bif,Op}, [_,_]=ArgTypes) when Op =:= '+';
                                           Op =:= '-';
                                           Op =:= '*' ->

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -414,8 +414,15 @@ types(erlang, 'rem', Args) ->
 %% Some mixed-type arithmetic.
 types(erlang, Op, [LHS, RHS]) when Op =:= '+'; Op =:= '-' ->
     case get_range(LHS, RHS, #t_number{}) of
-        {Type, {A,B}, {C,_D}} when is_integer(C), C > 0 ->
+        {Type, {A,B}, {C,_D}} when is_integer(C), C >= 0 ->
             R = beam_bounds:bounds(Op, {A,B}, {C,'+inf'}),
+            RetType = case Type of
+                          integer -> #t_integer{elements=R};
+                          number -> #t_number{elements=R}
+                      end,
+            sub_unsafe(RetType, [#t_number{}, #t_number{}]);
+        {Type, {A,_B}, {C,D}} when Op =:= '+', is_integer(A), A >= 0 ->
+            R = beam_bounds:bounds(Op, {A,'+inf'}, {C,D}),
             RetType = case Type of
                           integer -> #t_integer{elements=R};
                           number -> #t_number{elements=R}

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -35,6 +35,8 @@
 %%
 -define(SIZE_UPPER_LIMIT, ((1 bsl 58) - 1)).
 
+-define(UNICODE_TYPE, #t_integer{elements={0,16#10FFFF}}).
+
 %%
 %% Returns whether a call will succeed or not.
 %%
@@ -459,6 +461,8 @@ types(erlang, '--', [LHS, _]) ->
     RetType = copy_list(LHS, new_length, proper),
     sub_unsafe(RetType, [proper_list(), proper_list()]);
 
+types(erlang, atom_to_list, [_]) ->
+    sub_unsafe(proper_list(?UNICODE_TYPE), [#t_atom{}]);
 types(erlang, 'iolist_to_binary', [_]) ->
     %% Arg is an iodata(), despite its name.
     ArgType = join(#t_list{}, #t_bitstring{size_unit=8}),
@@ -474,6 +478,10 @@ types(erlang, 'list_to_binary', [_]) ->
 types(erlang, 'list_to_bitstring', [_]) ->
     %% As list_to_binary but with bitstrings rather than binaries.
     sub_unsafe(#t_bitstring{}, [proper_list()]);
+types(erlang, list_to_integer, [_]) ->
+    sub_unsafe(#t_integer{}, [proper_cons()]);
+types(erlang, list_to_integer, [_, _]) ->
+    sub_unsafe(#t_integer{}, [proper_cons(), #t_integer{}]);
 
 %% Process operations
 types(erlang, alias, []) ->

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -1016,7 +1016,7 @@ arith_type(_Op, _Args) ->
 %%
 
 mixed_arith_types(Args0) ->
-    [FirstType|_] = Args = [normalize(A) || A <- Args0],
+    [FirstType|_] = Args = [meet(A, #t_number{}) || A <- Args0],
     RetType = foldl(fun(#t_integer{}, #t_integer{}) -> #t_integer{};
                        (#t_integer{}, #t_number{}) -> #t_number{};
                        (#t_integer{}, #t_float{}) -> #t_float{};
@@ -1026,7 +1026,6 @@ mixed_arith_types(Args0) ->
                        (#t_number{}, #t_integer{}) -> #t_number{};
                        (#t_number{}, #t_float{}) -> #t_float{};
                        (#t_number{}, #t_number{}) -> #t_number{};
-                       (any, _) -> #t_number{};
                        (_, _) -> none
                     end, FirstType, Args),
     sub_unsafe(RetType, [#t_number{} || _ <- Args]).

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -986,6 +986,9 @@ types(_, _, Args) ->
       ArgTypes :: [type()],
       RetType :: type().
 
+arith_type({bif,'-'}, [Arg]) ->
+    ArgTypes = [#t_integer{elements={0,0}},Arg],
+    beam_bounds_type('-', #t_number{}, ArgTypes);
 arith_type({bif,Op}, [_,_]=ArgTypes) when Op =:= '+';
                                           Op =:= '-';
                                           Op =:= '*' ->

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -584,15 +584,12 @@ types(erlang, Op, [LHS,RHS]) when Op =:= min; Op =:= max ->
     %%
     %%   1235.0 = 1 + 1234.0
     %%   1 = erlang:min(1, 1234.0)
-    RetType = case {normalize(LHS), normalize(RHS)} of
-                  {#t_float{}, #t_float{}} -> #t_float{elements=R};
-                  {#t_float{}, #t_integer{}} -> #t_number{elements=R};
-                  {#t_float{}, #t_number{}} -> #t_number{elements=R};
+    RetType = case {LHS, RHS} of
                   {#t_integer{}, #t_integer{}} -> #t_integer{elements=R};
-                  {#t_integer{}, #t_float{}} -> #t_number{elements=R};
                   {#t_integer{}, #t_number{}} -> #t_number{elements=R};
+                  {#t_number{}, #t_integer{}} -> #t_number{elements=R};
                   {#t_number{}, #t_number{}} -> #t_number{elements=R};
-                  {_, _} -> any
+                  {_, _} -> join(LHS, RHS)
               end,
 
     sub_unsafe(RetType, [any, any]);

--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -1024,7 +1024,7 @@ simplify(#b_set{op=bs_create_bin=Op,dst=Dst,args=Args0,anno=Anno}=I0,
 simplify(#b_set{dst=Dst,args=Args0}=I0, Ts0, Ds0, _Ls, Sub) ->
     Args = simplify_args(Args0, Ts0, Sub),
     I1 = beam_ssa:normalize(I0#b_set{args=Args}),
-    case simplify(I1, Ts0) of
+    case simplify(I1, Ts0, Ds0) of
         #b_set{}=I ->
             Ts = update_types(I, Ts0, Ds0),
             Ds = Ds0#{ Dst => I },
@@ -1035,54 +1035,54 @@ simplify(#b_set{dst=Dst,args=Args0}=I0, Ts0, Ds0, _Ls, Sub) ->
             Sub#{ Dst => Var }
     end.
 
-simplify(#b_set{op={bif,'and'},args=Args}=I, Ts) ->
+simplify(#b_set{op={bif,'and'},args=Args}=I, Ts, Ds) ->
     case is_safe_bool_op(Args, Ts) of
         true ->
             case Args of
                 [_,#b_literal{val=false}=Res] -> Res;
                 [Res,#b_literal{val=true}] -> Res;
-                _ -> eval_bif(I, Ts)
+                _ -> eval_bif(I, Ts, Ds)
             end;
         false ->
             I
     end;
-simplify(#b_set{op={bif,'or'},args=Args}=I, Ts) ->
+simplify(#b_set{op={bif,'or'},args=Args}=I, Ts, Ds) ->
     case is_safe_bool_op(Args, Ts) of
         true ->
             case Args of
                 [Res,#b_literal{val=false}] -> Res;
                 [_,#b_literal{val=true}=Res] -> Res;
-                _ -> eval_bif(I, Ts)
+                _ -> eval_bif(I, Ts, Ds)
             end;
         false ->
             I
     end;
-simplify(#b_set{op={bif,element},args=[#b_literal{val=Index},Tuple]}=I0, Ts) ->
+simplify(#b_set{op={bif,element},args=[#b_literal{val=Index},Tuple]}=I0, Ts, Ds) ->
     case normalized_type(Tuple, Ts) of
         #t_tuple{size=Size} when is_integer(Index),
                                  1 =< Index,
                                  Index =< Size ->
             I = I0#b_set{op=get_tuple_element,
                          args=[Tuple,#b_literal{val=Index-1}]},
-            simplify(I, Ts);
+            simplify(I, Ts, Ds);
         _ ->
-            eval_bif(I0, Ts)
+            eval_bif(I0, Ts, Ds)
     end;
-simplify(#b_set{op={bif,hd},args=[List]}=I, Ts) ->
+simplify(#b_set{op={bif,hd},args=[List]}=I, Ts, Ds) ->
     case normalized_type(List, Ts) of
         #t_cons{} ->
             I#b_set{op=get_hd};
         _ ->
-            eval_bif(I, Ts)
+            eval_bif(I, Ts, Ds)
     end;
-simplify(#b_set{op={bif,tl},args=[List]}=I, Ts) ->
+simplify(#b_set{op={bif,tl},args=[List]}=I, Ts, Ds) ->
     case normalized_type(List, Ts) of
         #t_cons{} ->
             I#b_set{op=get_tl};
         _ ->
-            eval_bif(I, Ts)
+            eval_bif(I, Ts, Ds)
     end;
-simplify(#b_set{op={bif,size},args=[Term]}=I, Ts) ->
+simplify(#b_set{op={bif,size},args=[Term]}=I, Ts, Ds) ->
     case normalized_type(Term, Ts) of
         #t_tuple{} ->
             simplify(I#b_set{op={bif,tuple_size}}, Ts);
@@ -1090,26 +1090,26 @@ simplify(#b_set{op={bif,size},args=[Term]}=I, Ts) ->
             %% If the bitstring is a binary (the size in bits is
             %% evenly divisibly by 8), byte_size/1 gives
             %% the same result as size/1.
-            simplify(I#b_set{op={bif,byte_size}}, Ts);
+            simplify(I#b_set{op={bif,byte_size}}, Ts, Ds);
         _ ->
-            eval_bif(I, Ts)
+            eval_bif(I, Ts, Ds)
     end;
-simplify(#b_set{op={bif,tuple_size},args=[Term]}=I, Ts) ->
+simplify(#b_set{op={bif,tuple_size},args=[Term]}=I, Ts, _Ds) ->
     case normalized_type(Term, Ts) of
         #t_tuple{size=Size,exact=true} ->
             #b_literal{val=Size};
         _ ->
             I
     end;
-simplify(#b_set{op={bif,is_map_key},args=[Key,Map]}=I, Ts) ->
+simplify(#b_set{op={bif,is_map_key},args=[Key,Map]}=I, Ts, _Ds) ->
     case normalized_type(Map, Ts) of
         #t_map{} ->
             I#b_set{op=has_map_field,args=[Map,Key]};
         _ ->
             I
     end;
-simplify(#b_set{op={bif,Op0},args=Args}=I, Ts) when Op0 =:= '==';
-                                                    Op0 =:= '/=' ->
+simplify(#b_set{op={bif,Op0},args=Args}=I, Ts, Ds) when Op0 =:= '==';
+                                                        Op0 =:= '/=' ->
     Types = normalized_types(Args, Ts),
     EqEq0 = case {beam_types:meet(Types),beam_types:join(Types)} of
                 {none,any} -> true;
@@ -1126,13 +1126,13 @@ simplify(#b_set{op={bif,Op0},args=Args}=I, Ts) when Op0 =:= '==';
                      '==' -> '=:=';
                      '/=' -> '=/='
                  end,
-            simplify(I#b_set{op={bif,Op}}, Ts);
+            simplify(I#b_set{op={bif,Op}}, Ts, Ds);
         false ->
-            eval_bif(I, Ts)
+            eval_bif(I, Ts, Ds)
     end;
-simplify(#b_set{op={bif,'=:='},args=[Same,Same]}, _Ts) ->
+simplify(#b_set{op={bif,'=:='},args=[Same,Same]}, _Ts, _Ds) ->
     #b_literal{val=true};
-simplify(#b_set{op={bif,'=:='},args=[LHS,RHS]}=I, Ts) ->
+simplify(#b_set{op={bif,'=:='},args=[LHS,RHS]}=I, Ts, Ds) ->
     LType = concrete_type(LHS, Ts),
     RType = concrete_type(RHS, Ts),
     case beam_types:meet(LType, RType) of
@@ -1154,12 +1154,12 @@ simplify(#b_set{op={bif,'=:='},args=[LHS,RHS]}=I, Ts) ->
                     %% comparison operator (such as >=) that can be
                     %% translated to test instruction, this
                     %% optimization will eliminate one instruction.
-                    simplify(I#b_set{op={bif,'not'},args=[LHS]}, Ts);
+                    simplify(I#b_set{op={bif,'not'},args=[LHS]}, Ts, Ds);
                 {_,_} ->
-                    eval_bif(I, Ts)
+                    eval_bif(I, Ts, Ds)
             end
     end;
-simplify(#b_set{op={bif,is_list},args=[Src]}=I0, Ts) ->
+simplify(#b_set{op={bif,is_list},args=[Src]}=I0, Ts, Ds) ->
     case concrete_type(Src, Ts) of
         #t_union{list=#t_cons{}} ->
             I = I0#b_set{op=is_nonempty_list,args=[Src]},
@@ -1170,17 +1170,20 @@ simplify(#b_set{op={bif,is_list},args=[Src]}=I0, Ts) ->
         #t_union{list=nil} ->
             I0#b_set{op={bif,'=:='},args=[Src,#b_literal{val=[]}]};
         _ ->
-            eval_bif(I0, Ts)
+            eval_bif(I0, Ts, Ds)
     end;
-simplify(#b_set{op={bif,Op},args=Args}=I, Ts) ->
+simplify(#b_set{op={bif,Op},args=Args}=I, Ts, Ds) ->
     Types = normalized_types(Args, Ts),
     case is_float_op(Op, Types) of
         false ->
-            eval_bif(I, Ts);
+            eval_bif(I, Ts, Ds);
         true ->
             AnnoArgs = [anno_float_arg(A) || A <- Types],
-            eval_bif(beam_ssa:add_anno(float_op, AnnoArgs, I), Ts)
+            eval_bif(beam_ssa:add_anno(float_op, AnnoArgs, I), Ts, Ds)
     end;
+simplify(I, Ts, _Ds) ->
+    simplify(I, Ts).
+
 simplify(#b_set{op=bs_extract,args=[Ctx]}=I, Ts) ->
     case concrete_type(Ctx, Ts) of
         #t_bitstring{} ->
@@ -1659,7 +1662,7 @@ is_safe_bool_op([LHS, RHS], Ts) ->
     beam_types:is_boolean_type(LType) andalso
         beam_types:is_boolean_type(RType).
 
-eval_bif(#b_set{op={bif,Bif},args=Args}=I, Ts) ->
+eval_bif(#b_set{op={bif,Bif},args=Args}=I, Ts, Ds) ->
     Arity = length(Args),
     case erl_bifs:is_pure(erlang, Bif, Arity) of
         false ->
@@ -1667,7 +1670,7 @@ eval_bif(#b_set{op={bif,Bif},args=Args}=I, Ts) ->
         true ->
             case make_literal_list(Args) of
                 none ->
-                    eval_bif_1(I, Bif, concrete_types(Args, Ts));
+                    eval_bif_1(I, Bif, Ts, Ds);
                 LitArgs ->
                     try apply(erlang, Bif, LitArgs) of
                         Val -> #b_literal{val=Val}
@@ -1678,8 +1681,8 @@ eval_bif(#b_set{op={bif,Bif},args=Args}=I, Ts) ->
             end
     end.
 
-eval_bif_1(I, Op, Types) ->
-    case Types of
+eval_bif_1(#b_set{args=Args}=I, Op, Ts, Ds) ->
+    case concrete_types(Args, Ts) of
         [#t_integer{},#t_integer{elements={0,0}}] when Op =:= 'bor'; Op =:= 'bxor' ->
             #b_set{args=[Result,_]} = I,
             Result;
@@ -1701,9 +1704,29 @@ eval_bif_1(I, Op, Types) ->
                 false ->
                     I
             end;
+        [#t_integer{},#t_integer{}] ->
+            reassociate(I, Ts, Ds);
         _ ->
             I
     end.
+
+reassociate(#b_set{op={bif,OpB},args=[#b_var{}=V0,#b_literal{val=B0}]}=I, _Ts, Ds)
+  when OpB =:= '+'; OpB =:= '-' ->
+    case map_get(V0, Ds) of
+        #b_set{op={bif,OpA},args=[#b_var{}=V,#b_literal{val=A0}]}
+          when OpA =:= '+'; OpA =:= '-' ->
+            A = erlang:OpA(A0),
+            B = erlang:OpB(B0),
+            case A + B of
+                Combined when Combined < 0 ->
+                    I#b_set{op={bif,'-'},args=[V,#b_literal{val=-Combined}]};
+                Combined when Combined >= 0 ->
+                    I#b_set{op={bif,'+'},args=[V,#b_literal{val=Combined}]}
+            end;
+        #b_set{} ->
+            I
+    end;
+reassociate(I, _Ts, _Ds) -> I.
 
 simplify_args(Args, Ts, Sub) ->
     [simplify_arg(Arg, Ts, Sub) || Arg <- Args].

--- a/lib/compiler/test/beam_bounds_SUITE.erl
+++ b/lib/compiler/test/beam_bounds_SUITE.erl
@@ -25,6 +25,7 @@
          multiplication_bounds/1, division_bounds/1, rem_bounds/1,
          band_bounds/1, bor_bounds/1, bxor_bounds/1,
          bsr_bounds/1, bsl_bounds/1,
+         bnot_bounds/1,
          lt_bounds/1, le_bounds/1, gt_bounds/1, ge_bounds/1,
          min_bounds/1, max_bounds/1,
          abs_bounds/1,
@@ -45,6 +46,7 @@ groups() ->
        band_bounds,
        bor_bounds,
        bxor_bounds,
+       bnot_bounds,
        bsr_bounds,
        bsl_bounds,
        lt_bounds,
@@ -170,6 +172,33 @@ bxor_bounds(_Config) ->
     any = beam_bounds:bounds('bxor', {-20,-10}, {-1,10}),
 
     ok.
+
+bnot_bounds(_Config) ->
+    Min = -7,
+    Max = 7,
+    Seq = lists:seq(Min, Max),
+    _ = [bnot_bounds_1({A,B}) ||
+            A <- Seq,
+            B <- lists:nthtail(A-Min, Seq)],
+
+    {-43,'+inf'} = beam_bounds:bounds('bnot', {'-inf',42}),
+    {99,'+inf'} = beam_bounds:bounds('bnot', {'-inf',-100}),
+    {'-inf',-8} = beam_bounds:bounds('bnot', {7,'+inf'}),
+    {'-inf',9} = beam_bounds:bounds('bnot', {-10,'+inf'}),
+
+    ok.
+
+bnot_bounds_1(R) ->
+    {HighestMin,LowestMax} = min_max_unary_op('bnot', R),
+    {Min,Max} = beam_bounds:bounds('bnot', R),
+    if
+        Min =< HighestMin, LowestMax =< Max ->
+            ok;
+        true ->
+            io:format("bnot(~p) evaluates to ~p; should be ~p\n",
+                      [R,{Min,Max},{HighestMin,LowestMax}]),
+            ct:fail(bad_min_or_max)
+        end.
 
 bsr_bounds(_Config) ->
     test_noncommutative('bsr', {-12,12}, {0,7}),

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -306,6 +306,15 @@ coverage(Config) ->
     {'EXIT',{function_clause,_}} = catch coverage_3("a"),
     {'EXIT',{function_clause,_}} = catch coverage_3("b"),
 
+    Number = id(1),
+    if
+        0 =< Number, Number < 10 ->
+            0 = coverage_4(-1, Number),
+            10 = coverage_4(0, Number),
+            20 = coverage_4(1, Number),
+            30 = coverage_4(2, Number)
+    end,
+
     ok.
 
 coverage_1() ->
@@ -324,6 +333,9 @@ coverage_2() ->
 %% Cover beam_ssa_type:infer_br_value(V, Bool, none).
 coverage_3("a" = V) when is_function(V, false) ->
     0.
+
+coverage_4(X, Y) ->
+    10 * (X + Y).
 
 booleans(_Config) ->
     {'EXIT',{{case_clause,_},_}} = (catch do_booleans_1(42)),

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -1104,11 +1104,17 @@ cover_maps_functions(_Config) ->
 %% The types for erlang:min/2 and erlang:max/2 were wrong, assuming that the
 %% result was a float if either argument was a float.
 min_max_mixed_types(_Config) ->
-    NotFloatA = erlang:min(id(12), 100.0),
+    NotFloatA = min(id(12), 100.0),
     id(NotFloatA * 0.5),
 
-    NotFloatB = erlang:max(id(12.0), 100),
+    NotFloatB = max(id(12.0), 100),
     id(NotFloatB * 0.5),
+
+    %% Cover more of the type analysis code.
+    1 = id(min(id(0)+1, 42)),
+    -10 = id(min(id(0)+1, -10)),
+    43 = id(max(3, id(42)+1)),
+    42 = id(max(-99, id(41)+1)),
 
     ok.
 

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -315,6 +315,9 @@ coverage(Config) ->
             30 = coverage_4(2, Number)
     end,
 
+    {'EXIT',{badarg,_}} = catch false ++ true,
+    {'EXIT',{badarg,_}} = catch false -- true,
+
     ok.
 
 coverage_1() ->


### PR DESCRIPTION
* Do range analysis for the unary `-` operator and the `bnot` operator
* Improve range analysis for `min/2`, `max/2`, `+/2`, and `-/2`
* Derive types from a few more BIFs
* Improve combination of literals in integer expressions such as `H - $A + $a`
* Eliminate `band` operations without effect
