### PR TITLE
compiler: Add missing bs_create_bin prim_op() to type definition

### DIFF
--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -105,7 +105,8 @@
 %% To avoid the collapsing, change the value of SET_LIMIT to 50 in the
 %% file erl_types.erl in the dialyzer application.
 
--type prim_op() :: 'bs_extract' | 'bs_get_tail' | 'bs_init_writable' |
+-type prim_op() :: 'bs_create_bin' |
+                   'bs_extract' | 'bs_get_tail' | 'bs_init_writable' |
                    'bs_match' | 'bs_start_match' | 'bs_test_tail' |
                    'build_stacktrace' |
                    'call' | 'catch_end' |


### PR DESCRIPTION
The missing bs_create_bin operation has probably remained undiscovered
as the Dialyzer limit mentioned in the comment preceding the prim_op()
type definition collapses the effective type to atom().