### PR TITLE
inets: fix dialyzer warnings for inets/httd examples

### DIFF
--- a/lib/inets/examples/httpd_load_test/hdlt_ctrl.erl
+++ b/lib/inets/examples/httpd_load_test/hdlt_ctrl.erl
@@ -27,7 +27,7 @@
 %%----------------------------------------------------------------------
 
 -module(hdlt_ctrl).
-
+-dialyzer({no_fail_call, proxy_loop/1}).
 -export([start/1, stop/0, help/0]).
 
 -export([init/1, proxy/7]).

--- a/lib/inets/examples/httpd_load_test/hdlt_slave.erl
+++ b/lib/inets/examples/httpd_load_test/hdlt_slave.erl
@@ -108,7 +108,7 @@ wait_for_slave(Parent, Host, Name, Node, Paths, Args,
     ?SET_LEVEL(DebugLevel),
     ?DEBUG("begin", []),
     Waiter = register_unique_name(0),
-    case mk_cmd(Host, Name, Paths, Args, Waiter, Prog) of
+    case (catch mk_cmd(Host, Name, Paths, Args, Waiter, Prog)) of
 	{ok, Cmd} ->
   	    ?DEBUG("command generated: ~n~s", [Cmd]),
 	    case (catch ssh_slave_start(Host, Cmd)) of

--- a/lib/ssh/src/ssh_sftp.erl
+++ b/lib/ssh/src/ssh_sftp.erl
@@ -121,7 +121,7 @@ start_channel(Dest) ->
 %%% function clauses.
 
 -spec start_channel(ssh:open_socket(),
-                    [ssh:client_options() | sftp_option()]
+                    [ssh:client_option() | sftp_option()]
                    )
                    -> {ok,pid(),ssh:connection_ref()} | {error,reason()};
 
@@ -131,7 +131,7 @@ start_channel(Dest) ->
                    -> {ok,pid()}  | {ok,pid(),ssh:connection_ref()} | {error,reason()};
 
                    (ssh:host(),
-                    [ssh:client_options() | sftp_option()]
+                    [ssh:client_option() | sftp_option()]
                    )
                    -> {ok,pid(),ssh:connection_ref()} | {error,reason()} .
 


### PR DESCRIPTION
- fix dialyzer warnings in inets/httpd examples folder
- fix related spec in ssh_sftp module