### PR TITLE
[public_key] Use string:casefold when comparing dirs

### DIFF
--- a/lib/public_key/src/pubkey_cert.erl
+++ b/lib/public_key/src/pubkey_cert.erl
@@ -670,8 +670,8 @@ is_dir_name(_,_,_) ->
 
 is_dir_name2(Value, Value) -> true;
 is_dir_name2({printableString, Value1}, {printableString, Value2}) ->
-    string:to_lower(strip_spaces(Value1)) =:= 
-	string:to_lower(strip_spaces(Value2));
+    string:casefold(strip_spaces(Value1)) =:=
+	string:casefold(strip_spaces(Value2));
 is_dir_name2({utf8String, Value1}, String) ->
     is_dir_name2({printableString, unicode:characters_to_list(Value1)}, String);
 is_dir_name2(String, {utf8String, Value1}) ->


### PR DESCRIPTION
to_lower doesn't work correctly in the case when utf8String is in the list of dirs:

1> string:to_lower("Юникод").
"Юникод"
2> string:casefold("Юникод").
"юникод"

Unfortunately I could not find any unittests for this function, but since to_lower is obsolete anyway I hope this will be fine

UPDATE:
> Which public_key function / functionality is it that misbehaves?

If we talk about public_key, then it affects public_key:pkix_is_issuer/2.
But it also affects certs validation in ssl.

Say we have a cert chain: "Leaf Cert" <- "Root Cert"
where "LeafCert" contains AuthKeyIdentifier extension with {utf8String, <<"Юникод"/utf8>>}
while "RootCert" uses {utf8String, <<"юникод"/utf8>>} in the subject (the only difference is the case of the first char).

If we try to call pkix_is_issuer in this situation it will return false, because to_lower will not actually lower the case for  "Юникод" when we do the comparison in is_dir_name2.
More specifically,
is_dir_name2({utf8String, _}, {utf8String, _}) will be transformed to
is_dir_name2({printableString, _}, {printableString, _}) by the 3rd and 4th clause first,
and then the 2nd clause of is_dir_name2 will fail to lower the case, so the comparison will return false, while the expected result is true in this case.