### PR TITLE
Unlink issues

### DIFF
--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -6129,7 +6129,10 @@ erts_proc_sig_handle_exit(Process *c_p, Sint *redsp,
             break;
 
         case ERTS_SIG_Q_OP_UNLINK_ACK:
-            erts_proc_sig_destroy_unlink_op((ErtsSigUnlinkOp *) sig);
+            if (type == ERTS_SIG_Q_TYPE_DIST_LINK)
+                destroy_sig_dist_unlink_op((ErtsSigDistUnlinkOp *) sig);
+            else
+                erts_proc_sig_destroy_unlink_op((ErtsSigUnlinkOp *) sig);
             break;
 
         case ERTS_SIG_Q_OP_GROUP_LEADER: {

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -3794,8 +3794,11 @@ static int link_port_exit(ErtsLink *lnk, void *vpectxt, Sint reds)
     ErtsPortExitContext *pectxt = vpectxt;
     Port *port = pectxt->port;
 
-    erts_proc_sig_send_link_exit(&port->common, port->common.id,
-                                 lnk, pectxt->reason, NIL);
+    if (((ErtsILink *) lnk)->unlinking)
+        erts_link_release(lnk);
+    else
+        erts_proc_sig_send_link_exit(&port->common, port->common.id,
+                                     lnk, pectxt->reason, NIL);
     return 1;
 }
 

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -49,7 +49,8 @@
          process_info_status_handled_signal/1,
          process_info_reductions/1,
 	 bump_reductions/1, low_prio/1, binary_owner/1, yield/1, yield2/1,
-	 otp_4725/1, bad_register/1, garbage_collect/1, otp_6237/1,
+	 otp_4725/1, dist_unlink_ack_exit_leak/1, bad_register/1,
+         garbage_collect/1, otp_6237/1,
 	 process_info_messages/1, process_flag_badarg/1,
          process_flag_fullsweep_after/1, process_flag_heap_size/1,
 	 spawn_opt_heap_size/1, spawn_opt_max_heap_size/1,
@@ -112,6 +113,7 @@ all() ->
      process_info_status_handled_signal,
      process_info_reductions,
      bump_reductions, low_prio, yield, yield2, otp_4725,
+     dist_unlink_ack_exit_leak,
      bad_register, garbage_collect, process_info_messages,
      process_flag_badarg,
      process_flag_fullsweep_after, process_flag_heap_size,
@@ -1531,6 +1533,43 @@ next_tmsg(Pid) ->
     after 100 ->
 	    none
     end.
+
+dist_unlink_ack_exit_leak(Config) when is_list(Config) ->
+    %% Verification of nc reference counts when stopping node
+    %% will find the bug if it exists...
+    {ok, Peer, Node} = ?CT_PEER(),
+    ParentFun =
+        fun () ->
+                %% Give parent some work to do when
+                %% exiting to increase the likelyhood
+                %% of the bug triggereing...
+                T = ets:new(x,[]),
+                ets:insert(T, lists:map(fun (I) ->
+                                                {I,I}
+                                        end,
+                                        lists:seq(1,10000))),
+                Chld = spawn_link(Node,
+                                  fun () ->
+                                          receive
+                                          after infinity ->
+                                                  ok
+                                          end
+                                  end),
+                erlang:yield(),
+                unlink(Chld),
+                exit(bye)
+        end,
+    PMs = lists:map(fun (_) ->
+                            spawn_monitor(ParentFun)
+                    end, lists:seq(1, 10)),
+    lists:foreach(fun ({P, M}) ->
+                          receive
+                              {'DOWN', M, process, P, bye} ->
+                                  ok
+                          end
+                  end, PMs),
+    stop_node(Peer, Node),
+    ok.
 
 %% Test that bad arguments to register/2 cause an exception.
 bad_register(Config) when is_list(Config) ->

--- a/erts/emulator/test/signal_SUITE.erl
+++ b/erts/emulator/test/signal_SUITE.erl
@@ -42,6 +42,7 @@
          busy_dist_down_signal/1,
          busy_dist_spawn_reply_signal/1,
          busy_dist_unlink_ack_signal/1,
+         unlink_exit/1,
          monitor_order/1]).
 
 init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
@@ -69,6 +70,7 @@ all() ->
      busy_dist_down_signal,
      busy_dist_spawn_reply_signal,
      busy_dist_unlink_ack_signal,
+     unlink_exit,
      monitor_order].
 
 %% Test that exit signals and messages are received in correct order
@@ -79,7 +81,6 @@ xm_sig_order(Config) when is_list(Config) ->
     repeat(fun () -> xm_sig_order_test(RNode) end, 1000),
     peer:stop(Peer),
     ok.
-    
 
 xm_sig_order_test(Node) ->
     P = spawn(Node, fun () -> xm_sig_order_proc() end),
@@ -459,6 +460,102 @@ busy_dist_unlink_ack_signal(Config) when is_list(Config) ->
     peer:stop(OtherPeer),
     ok.
 
+unlink_exit(Config) when is_list(Config) ->
+    %% OTP-18177
+    %%
+    %% This bug is theoretically possible, at least in the
+    %% node local scenario, but more or less undetectable and
+    %% quite harmless when it hits. A process A (the child in
+    %% the testcase) could get actual exit reason of another
+    %% process B (the parent in the testcase) when it should
+    %% have gotten 'noproc' as exit reason. This can happen if
+    %% 1. B unlinks A
+    %% 2. B begin terminating before it has received an unlink
+    %%    ack from A
+    %% 3. A links to B after it has received the unlink signal
+    %%
+    %% This testcase hammers on the above scenario, but I have
+    %% not seen it fail yet though when the bug is present...
+    repeat(fun unlink_exit_test/0, 1000).
+
+unlink_exit_test() ->
+    Tester = self(),
+    ChildFun =
+        fun () ->
+                process_flag(trap_exit, true),
+                Tester ! {child, self()},
+                Parent = receive {tester_parent, Tester, Pid} -> Pid end,
+                Parent ! {go, self()},
+                busy_wait_until(fun () ->
+                                        receive {go, Parent} -> true
+                                        after 0 -> false
+                                        end
+                                end),
+                IsAlive = erlang:is_process_alive(Parent),
+                try
+                    link(Parent),
+                    case IsAlive of
+                        false ->
+                            receive
+                                {'EXIT', Parent, noproc} ->
+                                    exit(ok);
+                                {'EXIT', Parent, R1} ->
+                                    exit({not_alive_unexpected_exit_reason, R1})
+                            after 1000 ->
+                                    exit(not_alive_missing_exit)
+                            end;
+                        true ->
+                            receive
+                                {'EXIT', Parent, R2} when R2 == noproc;
+                                                          R2 == bye ->
+                                    exit(ok);
+                                {'EXIT', Parent, R2} ->
+                                    exit({alive_unexpected_exit_reason, R2})
+                            after 1000 ->
+                                    exit(alive_missing_exit)
+                            end
+                    end
+                catch error:noproc ->
+                        receive
+                            {'EXIT', Parent, _} = X0 ->
+                                exit({unexpected_exit, X0})
+                        after 1000 ->
+                                exit(ok)
+                        end
+                end
+        end,
+    {Parent, PMon} = spawn_opt(fun () ->
+                                       %% Work to do when terminating in order
+                                       %% to increase the likelyhood of the
+                                       %% bug triggering (if present)...
+                                       T = ets:new(x,[]),
+                                       ets:insert(T, lists:map(fun (I) ->
+                                                                       {I,I}
+                                                               end,
+                                                               lists:seq(1,10000))),
+
+                                       Child = spawn_opt(ChildFun,
+                                                         [{priority, high},
+                                                          link]),
+                                       receive {go, Child} -> ok end,
+                                       unlink(Child),
+                                       Child ! {go, self()},
+                                       exit(bye)
+                               end, [{priority, high}, monitor]),
+    Child = receive {child, Chld} -> Chld end,
+    CMon = erlang:monitor(process, Child),
+    Child ! {tester_parent, Tester, Parent},
+    receive
+        {'DOWN', PMon, process, Parent, bye} ->
+            ok
+    end,
+    receive
+        {'DOWN', CMon, process, Child, ok} ->
+            ok;
+        {'DOWN', CMon, process, Child, ChildReason} ->
+            ct:fail(ChildReason)
+    end.
+
 %% Monitors could be reordered relative to message signals when the parallel
 %% signal sending optimization was active.
 monitor_order(_Config) ->
@@ -609,6 +706,15 @@ spam(To, Data) ->
 
 repeat(_Fun, N) when is_integer(N), N =< 0 ->
     ok;
-repeat(Fun, N) when is_integer(N)  ->
+repeat(Fun, N) when is_function(Fun, 0), is_integer(N)  ->
     Fun(),
+    repeat(Fun, N-1);
+repeat(Fun, N) when is_function(Fun, 1), is_integer(N)  ->
+    Fun(N),
     repeat(Fun, N-1).
+
+busy_wait_until(Fun) ->
+    case catch Fun() of
+        true -> ok;
+        _ -> busy_wait_until(Fun)
+    end.


### PR DESCRIPTION
 An unlink operation made by a process that terminated before the unlink operation completed, i.e., before it had received an unlink-ack signal from the linked process, caused an exit signal to erroneously be sent from the terminating process to the process being unlinked. This exit signal would most often be ignored by the receiver, but if the receiver of the exit signal concurrently set up a new link, it could receive the exit signal with the actual exit reason of the terminating process instead of a noproc exit reason. It is however very hard to detect that this has happened and has no obvious negative consequences, so it should be considered harmless.

A distributed unlink-ack signal received by a terminating process was also not properly removed which could cause a minor memory leak.