### PR TITLE
Use in-memory atom ordering for map ordering

### DIFF
--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -2174,7 +2174,7 @@ erts_gc_update_map_assoc(Process* p, Eterm* reg, Uint live,
 
 	ASSERT(kp < (Eterm *)mp);
 	key = *old_keys;
-	if ((c = (key == new_key) ? 0 : CMP_TERM(key, new_key)) < 0) {
+	if ((c = (key == new_key) ? 0 : erts_cmp_flatmap_keys(key, new_key)) < 0) {
 	    /* Copy old key and value */
 	    *kp++ = key;
 	    *hp++ = *old_vals;

--- a/erts/emulator/beam/beam_transform_helpers.c
+++ b/erts/emulator/beam/beam_transform_helpers.c
@@ -150,7 +150,7 @@ oparg_compare(BeamOpArg* a, BeamOpArg* b)
 static int
 oparg_term_compare(SortBeamOpArg* a, SortBeamOpArg* b)
 {
-    Sint res = CMP_TERM(a->term, b->term);
+    Sint res = erts_cmp_flatmap_keys(a->term, b->term);
 
     if (res < 0) {
         return -1;

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -6054,7 +6054,7 @@ nodes(Process *c_p, Eterm node_types, Eterm options)
         }
     }
     else {
-        Eterm ks[2], *hp, keys_tuple = THE_NON_VALUE;
+        Eterm ks[2], *hp;
         Uint map_size = 0, el_xtra, xtra;
         ErtsHeapFactory hfact;
 
@@ -6089,8 +6089,8 @@ nodes(Process *c_p, Eterm node_types, Eterm options)
                 vs[map_size++] = eni->type;
             }
 
-            info_map = erts_map_from_sorted_ks_and_vs(&hfact, ks, vs,
-                                                      map_size, &keys_tuple);
+            info_map = erts_map_from_ks_and_vs(&hfact, ks, vs, map_size);
+            ASSERT(is_value(info_map));
 
             hp = erts_produce_heap(&hfact, 3+2, xtra);
 
@@ -6676,8 +6676,7 @@ send_nodes_mon_msgs(Process *c_p, Eterm what, Eterm node,
                     map_size++;
                 }
 
-                info = erts_map_from_sorted_ks_and_vs(&hfact, ks, vs,
-                                                      map_size, NULL);
+                info = erts_map_from_ks_and_vs(&hfact, ks, vs, map_size);
                 ASSERT(is_value(info));
             }
             else { /* Info list */

--- a/erts/emulator/beam/erl_map.h
+++ b/erts/emulator/beam/erl_map.h
@@ -106,8 +106,6 @@ Eterm  erts_hashmap_from_array(ErtsHeapFactory*, Eterm *leafs, Uint n, int rejec
     erts_hashmap_from_ks_and_vs_extra((F), (KS), (VS), (N), THE_NON_VALUE, THE_NON_VALUE);
 
 Eterm erts_map_from_ks_and_vs(ErtsHeapFactory *factory, Eterm *ks, Eterm *vs, Uint n);
-Eterm erts_map_from_sorted_ks_and_vs(ErtsHeapFactory *factory, Eterm *ks0, Eterm *vs0,
-                                     Uint n, Eterm *key_tuple);
 Eterm  erts_hashmap_from_ks_and_vs_extra(ErtsHeapFactory *factory,
                                          Eterm *ks, Eterm *vs, Uint n,
 					 Eterm k, Eterm v);

--- a/erts/emulator/beam/erl_utils.h
+++ b/erts/emulator/beam/erl_utils.h
@@ -112,6 +112,7 @@ int eq(Eterm, Eterm);
 
 ERTS_GLB_INLINE Sint erts_cmp(Eterm, Eterm, int, int);
 ERTS_GLB_INLINE int erts_cmp_atoms(Eterm a, Eterm b);
+ERTS_GLB_INLINE Sint erts_cmp_flatmap_keys(Eterm, Eterm);
 
 Sint erts_cmp_compound(Eterm, Eterm, int, int);
 
@@ -230,6 +231,17 @@ ERTS_GLB_INLINE Sint erts_cmp(Eterm a, Eterm b, int exact, int eq_only) {
 
     return erts_cmp_compound(a,b,exact,eq_only);
 }
+
+/*
+ * Only to be used for the *internal* sort order of flatmap keys.
+ */
+ERTS_GLB_INLINE Sint erts_cmp_flatmap_keys(Eterm key_a, Eterm key_b) {
+    if (is_atom(key_a) && is_atom(key_b)) {
+        return key_a - key_b;
+    }
+    return erts_cmp(key_a, key_b, 1, 0);
+}
+
 
 #endif /* ERTS_GLB_INLINE_INCL_FUNC_DEF */
 

--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -2923,6 +2923,10 @@ t_erts_internal_order(_Config) when is_list(_Config) ->
     0  = erts_internal:cmp_term(2147483648,2147483648),
     1  = erts_internal:cmp_term(2147483648,0),
 
+    %% Make sure it's not the internal flatmap order
+    %% where low indexed 'true' < 'a'.
+    -1  = erts_internal:cmp_term(a,true),
+
     M = #{0 => 0,2147483648 => 0},
     true = M =:= binary_to_term(term_to_binary(M)),
     true = M =:= binary_to_term(term_to_binary(M, [deterministic])),

--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -183,7 +183,7 @@ single_line(_Config) ->
     ct:log(String3),
     match = re:run(String3,"\\[1,2,3,4,5,6,7,8,9,10\\]",[{capture,none}]),
     match = re:run(String3,
-                   "#{a => map,few => accociations,with => a}",
+                   "#{((a => map|with => a|few => accociations)[,}]){3}",
                    [{capture,none}]),
 
     %% This part is added to make sure that the previous test made

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -2271,20 +2271,15 @@ format_string(_Config) ->
     ok.
 
 maps(_Config) ->
-    %% Note that order in which a map is printed is arbitrary.  In
-    %% practice, small maps (non-HAMT) are printed in key order, but
-    %% the breakpoint for creating big maps (HAMT) is lower in the
-    %% debug-compiled run-time system than in the optimized run-time
-    %% system.
-    %%
+    %% Note that order in which a map is printed is arbitrary.
     %% Therefore, play it completely safe by not assuming any order
     %% in a map with more than one element.
 
     "#{}" = fmt("~w", [#{}]),
     "#{a => b}" = fmt("~w", [#{a=>b}]),
-    re_fmt(<<"#\\{(a => b),[.][.][.]\\}">>,
+    re_fmt(<<"#\\{(a => b|c => d),[.][.][.]\\}">>,
 	     "~W", [#{a => b,c => d},2]),
-    re_fmt(<<"#\\{(a => b),[.][.][.]\\}">>,
+    re_fmt(<<"#\\{(a => b|c => d|e => f),[.][.][.]\\}">>,
 	   "~W", [#{a => b,c => d,e => f},2]),
 
     "#{}" = fmt("~p", [#{}]),


### PR DESCRIPTION
This should optimize all operations on small maps
that rely on ordering. As an example, creating a
map with 32 keys named 'atom-INDEX', where INDEX
is an integer, is an order of magnitude faster
with this patch.

Before:

    from_list      624.32 K        1.60 μs   ±723.44%        1.54 μs        1.71 μs

After:

    from_list        6.23 M      160.47 ns ±15898.23%         125 ns         167 ns

It has been verified that the distribution and
ETS will respect the atom ordering of the system
and therefore are backwards compatible.

A potential downside is that the order of atom
fields in maps is no longer deterministic, but
that's already the case for large maps, and having
non-deterministic atom ordering may help avoid
code that accidentally relies on order.

This patch also opens up the possibility for
more efficient map lookups in the future.