### PR TITLE
Specify encoding when running javadoc

### DIFF
--- a/lib/jinterface/doc/src/Makefile
+++ b/lib/jinterface/doc/src/Makefile
@@ -74,7 +74,7 @@ JAVA_SRC_FILES = $(JAVA_FILES:%=$(JAVA_SRC_PATH)/%.java)
 
 
 ../html/java/index.html: $(JAVA_SRC_FILES)
-	(cd ../../java_src;$(JAVADOC) -sourcepath . -d $(JAVADOC_DEST) \
+	(cd ../../java_src;$(JAVADOC) -encoding UTF-8 -sourcepath . -d $(JAVADOC_DEST) \
 		-windowtitle $(JAVADOC_TITLE) $(JAVADOC_PKGS))
 
 html: ../html/java/index.html


### PR DESCRIPTION
This fixes the following issues during javadoc file processing stage:

```
(cd ../../java_src;javadoc -sourcepath . -d ../doc/html/java \
	-windowtitle 'Java-Erlang Interface Library' com.ericsson.otp.erlang)
Loading source files for package com.ericsson.otp.erlang...
./com/ericsson/otp/erlang/OtpGenericTransportFactory.java:2: error: unmappable character (0xC3) for encoding US-ASCII
 * Copyright 2022 J??r??me de Bretagne
                   ^
./com/ericsson/otp/erlang/OtpGenericTransportFactory.java:2: error: unmappable character (0xA9) for encoding US-ASCII
 * Copyright 2022 J??r??me de Bretagne
                    ^
./com/ericsson/otp/erlang/OtpGenericTransportFactory.java:2: error: unmappable character (0xC3) for encoding US-ASCII
 * Copyright 2022 J??r??me de Bretagne
                      ^
./com/ericsson/otp/erlang/OtpGenericTransportFactory.java:2: error: unmappable character (0xB4) for encoding US-ASCII
 * Copyright 2022 J??r??me de Bretagne
                       ^
4 errors
```

Followup to commit 6bcfd5aaa66c208251357db3d5e8a2927a7af4d1.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>