### PR TITLE
fix typo in :eprof docs: prifile --> profile

### DIFF
--- a/lib/tools/doc/src/eprof.xml
+++ b/lib/tools/doc/src/eprof.xml
@@ -74,7 +74,7 @@
         <p>Stops profiling started with
           <seemfa marker="#start_profiling/1"><c>start_profiling/1</c></seemfa>
           or
-          <seemfa marker="#profile/1"><c>prifile/1</c></seemfa>.</p>
+          <seemfa marker="#profile/1"><c>profile/1</c></seemfa>.</p>
       </desc>
     </func>
     <func>


### PR DESCRIPTION
Just a small typo I noticed reading the docs.

Thanks for all the work y'all are doing!

![IMG_20220605_130628](https://user-images.githubusercontent.com/606517/179744947-23141b97-ab9b-458e-aaff-6aa1b27654db.jpg)

