### PR TITLE
Optimize comparison of equal terms

### DIFF
--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -2174,7 +2174,7 @@ erts_gc_update_map_assoc(Process* p, Eterm* reg, Uint live,
 
 	ASSERT(kp < (Eterm *)mp);
 	key = *old_keys;
-	if ((c = CMP_TERM(key, new_key)) < 0) {
+	if ((c = (key == new_key) ? 0 : CMP_TERM(key, new_key)) < 0) {
 	    /* Copy old key and value */
 	    *kp++ = key;
 	    *hp++ = *old_vals;

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -1378,7 +1378,7 @@ static Eterm flatmap_merge(Process *p, Eterm nodeA, Eterm nodeB) {
     vs2 = flatmap_get_values(mp2);
 
     while(i1 < n1 && i2 < n2) {
-	c = CMP_TERM(ks1[i1],ks2[i2]);
+	c = (ks1[i1] == ks2[i2]) ? 0 : CMP_TERM(ks1[i1],ks2[i2]);
 	if (c == 0) {
 	    /* use righthand side arguments map value,
 	     * but advance both maps */

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -1583,6 +1583,10 @@ void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,
         } else if (LHS.isSmall()) {
             a.and_(TMP1, rhs.reg, imm(_TAG_IMMED1_MASK));
         } else {
+            /* Avoid the expensive generic comparison for equal terms. */
+            a.cmp(lhs.reg, rhs.reg);
+            a.b_eq(next);
+
             ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
             a.and_(TMP1, lhs.reg, rhs.reg);
             a.and_(TMP1, TMP1, imm(_TAG_IMMED1_MASK));
@@ -1687,6 +1691,10 @@ void BeamModuleAssembler::emit_is_ge(const ArgLabel &Fail,
         } else if (LHS.isSmall()) {
             a.and_(TMP1, rhs.reg, imm(_TAG_IMMED1_MASK));
         } else {
+            /* Avoid the expensive generic comparison for equal terms. */
+            a.cmp(lhs.reg, rhs.reg);
+            a.b_eq(next);
+
             ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
             a.and_(TMP1, lhs.reg, rhs.reg);
             a.and_(TMP1, TMP1, imm(_TAG_IMMED1_MASK));

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -1700,6 +1700,10 @@ void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,
         } else if (LHS.isSmall()) {
             a.mov(RETd, ARG2d);
         } else {
+            /* Avoid the expensive generic comparison for equal terms. */
+            a.cmp(ARG1, ARG2);
+            a.short_().je(do_jge);
+
             a.mov(RETd, ARG1d);
             a.and_(RETd, ARG2d);
         }
@@ -1795,6 +1799,10 @@ void BeamModuleAssembler::emit_is_ge(const ArgLabel &Fail,
         } else if (LHS.isSmall()) {
             a.mov(RETd, ARG2d);
         } else {
+            /* Avoid the expensive generic comparison for equal terms. */
+            a.cmp(ARG1, ARG2);
+            a.short_().je(do_jl);
+
             a.mov(RETd, ARG1d);
             a.and_(RETd, ARG2d);
         }


### PR DESCRIPTION
When doing comparisons, be sure to avoid calling the quite expensive
generic comparison routine for equal tagged values.  In particular,
the generic comparison function for atoms, `erts_cmp_atoms()`, will
always call `memcmp()` for equal atoms longer than 4 characters, so we
want to avoid that.