### PR TITLE
Enhance creation of maps with literal keys

### DIFF
--- a/lib/compiler/test/map_SUITE.erl
+++ b/lib/compiler/test/map_SUITE.erl
@@ -87,7 +87,8 @@
 
          %% miscellaneous
          t_conflicting_destinations/1,
-         t_cse_assoc/1
+         t_cse_assoc/1,
+         shared_key_tuples/1
         ]).
 
 -define(badmap(V, F, Args), {'EXIT', {{badmap,V}, [{maps,F,Args,_}|_]}}).
@@ -161,7 +162,8 @@ all() ->
 
      %% miscellaneous
      t_conflicting_destinations,
-     t_cse_assoc
+     t_cse_assoc,
+     shared_key_tuples
     ].
 
 groups() -> [].
@@ -2545,6 +2547,25 @@ do_cse_assoc(M, V) ->
         #{assoc := Assoc} ->
             Assoc
     end.
+
+shared_key_tuples(_Config) ->
+    A = decimal(0),
+    B = decimal(1),
+
+    case ?MODULE of
+        map_inline_SUITE ->
+            %% With inlining, two separate map literals will be created. They
+            %% will not share keys.
+            ok;
+        _ ->
+            %% The two instances should share the key tuple.
+            true = erts_debug:same(erts_internal:map_to_tuple_keys(A),
+                                   erts_internal:map_to_tuple_keys(B))
+    end,
+    ok.
+
+decimal(Int) ->
+    #{type => decimal, int => Int, exp => 0}.
 
 %% aux
 


### PR DESCRIPTION
An optimization in the loader was added in: https://github.com/erlang/otp/pull/1498

When a small map is created where all keys are literals, the key tuple
is created as a literal. That means that the key tuple can be shared
for all instances of the map created by the same code.

However, that does not always work, for example for code such
as:

    decimal(Int) ->
        #{type => decimal, int => Int, exp => 0}.

The compiler would try to be smart and rewrite the code to:

    decimal(Int) ->
        (#{type => decimal, exp => 0})#{int => Int}.

Expressed in that way, the loader optimization cannot be applied and
a new key tuple will be created every time `decimal/1` is called.

This pull request removes that problematic transformation. The implementation
is based on José Valim's suggested implementation.

Fixes #6139