### PR TITLE
[kernel|pg] Add tagged processes feature

### DIFF
--- a/lib/kernel/doc/src/pg.xml
+++ b/lib/kernel/doc/src/pg.xml
@@ -55,6 +55,12 @@
       <seemfa marker="#get_local_members/1"><c>get_local_members/1</c></seemfa>
       to determine which processes are members of the group.
       Then the message can be sent to one or more group members.</p>
+    <p>To help identifying particular processes within a group, processes can be
+       associated with a tag. These tagged processes are returned along with
+       untagged processes by <c>pg</c> functions. There are no special functions
+       for handling tagged or untagged processes only.
+    </p>
+
     <p>If a member terminates, it is automatically removed from the group.</p>
 
     <p>A process may join multiple groups. It may join the same group multiple times.
@@ -98,6 +104,14 @@
     <datatype>
       <name name="group"/>
       <desc><p>The identifier of a process group.</p></desc>
+    </datatype>
+    <datatype>
+      <name name="tag"/>
+      <desc><p>The tag associated with a process.</p></desc>
+    </datatype>
+    <datatype>
+      <name name="pid_or_tagged_pid"/>
+      <desc><p>An untagged or tagged process.</p></desc>
     </datatype>
   </datatypes>
 


### PR DESCRIPTION
Added possibility to associate a process with a tag when joining pg
groups. This tag can be useful to identify particular processes within a
given group.

For example, suppose some resource is controlled by three processes -
each one controls one aspect of this resource. Let's name these aspects
top, middle and bottom.
These processes are added to a pg group. In this way, it's easy to get
the processes associated to a resource, but it's hard to identify the
process related to a specific aspect among the returned ones.
With tagged processes, these processes could be associated with some tag
in order to be easily identified within that group.

This use case may be executed as follow:
  %%%%
  %% The resource instance 42 is controlled by three processes (local or
  %% remote).
  %% Each process manages one aspect (top, middle and bottom) of that
  %% resource.
  %%%%

  %% Set up group
  Scope = some_scope,
  GroupId = 42,
  Top = new_pid(top, GroupId), % returns pid()
  Middle = new_pid(middle, GroupId), % returns pid()
  Bottom = new_pid(bottom, GroupId), % returns pid()
  Processes = [{top, Top}, {middle, Middle}, {bottom, Bottom}].
  pg:join(Scope, GroupId, Processes).

  %% Getting members
  Members = pg:get_members(Scope, GroupId).
  % something like [{top, Pid1}, {middle, Pid2}, {bottom, Pid3}]

  %% it's easy to get the process which controls the aspect "middle" in
  %% this group
  {middle, MiddlePid} = lists:keyfind(middle, 1, Members).