### PR TITLE
dialyzer: Add warning_options `missing_return` and `extra_return`

### DIFF
--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -130,7 +130,9 @@
                        | 'unmatched_returns'
                        | 'overspecs'
                        | 'specdiffs'
+                       | 'extra_return'
                        | 'no_extra_return'
+                       | 'missing_return'
                        | 'no_missing_return'.
 -type dial_option()   :: {'files', [FileName :: file:filename()]}
                        | {'files_rec', [DirName :: file:filename()]}

--- a/lib/dialyzer/src/dialyzer_cl_parse.erl
+++ b/lib/dialyzer/src/dialyzer_cl_parse.erl
@@ -547,6 +547,12 @@ warning_options_msg() ->
   -Wunderspecs ***
      Warn about underspecified functions
      (those whose -spec is strictly more allowing than the success typing).
+  -Wextra_return ***
+     Warn about functions whose specification includes types that the
+     function cannot return.
+  -Wmissing_return ***
+     Warn about functions that return values that are not part
+     of the specification.
   -Wunknown ***
      Let warnings about unknown functions and types affect the
      exit status of the command line version. The default is to ignore

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -3473,7 +3473,8 @@ is_module_dialyzer_option(Option) ->
                   no_behaviours,no_undefined_callbacks,unmatched_returns,
                   error_handling,race_conditions,no_missing_calls,
                   specdiffs,overspecs,underspecs,unknown,
-                  no_underspecs, no_extra_return, no_missing_return
+                  no_underspecs,extra_return,no_extra_return,
+                  missing_return,no_missing_return
                  ]).
 
 %% try_catch_clauses(Scs, Ccs, In, ImportVarTable, State) ->


### PR DESCRIPTION
The options are documented in [docs](https://www.erlang.org/doc/man/dialyzer.html#using-dialyzer-from-the-command-line) 
But they are not in the `warn_option() type` and not in the `dialyzer -Whelp`.
This commit add the options in dialyzer docs and cli help.