### PR TITLE
Change SSH options in a running server

### DIFF
--- a/lib/ssh/doc/src/ssh.xml
+++ b/lib/ssh/doc/src/ssh.xml
@@ -1408,6 +1408,31 @@
        </desc>
    </func>
 
+<!-- DAEMON_REPLACE_OPTIONS/2 -->
+   <func>
+     <name name="daemon_replace_options" arity="2" since="OTP 25.1"/>
+     <fsummary>Change options in a running daemon</fsummary>
+     <desc>
+       <p>
+	 Replaces the options in a running daemon with the options in
+	 <c>NewUserOptions</c>. Only connections established after this call
+	 are affected, already established connections are not.
+       </p>
+       <note>
+	 <p>In the final phase of this function, the listening process is restarted.
+	 Therfore a connection attempt to the daemon in this final phase could fail.
+	 </p>
+       </note>
+       <p>
+	 The handling of Erlang configurations is described in the User's Guide;
+	 see chapters
+	 <seeguide marker="configurations">Configuration in SSH</seeguide>
+	 and
+	 <seeguide marker="configure_algos">Configuring algorithms in SSH</seeguide>.
+       </p>
+     </desc>
+   </func>
+
 <!-- DAEMON_INFO/1 -->   
    <func>
      <name name="daemon_info" arity="1" since="OTP 19.0"/>
@@ -1423,7 +1448,6 @@
        </p>
      </desc>
    </func>
-
 
 <!-- DEFAULT_ALGORITHMS/0 -->
     <func>

--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -35,6 +35,7 @@
 	 channel_info/3,
 	 daemon/1, daemon/2, daemon/3,
 	 daemon_info/1, daemon_info/2,
+         daemon_replace_options/2,
          set_sock_opts/2, get_sock_opts/2,
 	 default_algorithms/0,
          chk_algos_opts/1,
@@ -441,6 +442,17 @@ daemon(Host0, Port0, UserOptions0) when 0 =< Port0, Port0 =< 65535,
 
 daemon(_, _, _) ->
     {error, badarg}.
+
+%%--------------------------------------------------------------------
+-spec daemon_replace_options(DaemonRef, NewUserOptions) -> {ok,daemon_ref()}
+                                                         | {error,term()} when
+      DaemonRef :: daemon_ref(),
+      NewUserOptions :: daemon_options().
+
+daemon_replace_options(DaemonRef, NewUserOptions) ->
+    {ok,Os0} = ssh_system_sup:get_acceptor_options(DaemonRef),
+    Os1 = ssh_options:merge_options(server, NewUserOptions, Os0),
+    ssh_system_sup:replace_acceptor_options(DaemonRef, Os1).
 
 %%--------------------------------------------------------------------
 -type daemon_info_tuple() ::

--- a/lib/ssh/src/ssh_system_sup.erl
+++ b/lib/ssh/src/ssh_system_sup.erl
@@ -39,7 +39,9 @@
 	 get_daemon_listen_address/1,
          addresses/1,
          addresses/2,
-         get_options/2
+         get_options/2,
+         get_acceptor_options/1,
+         replace_acceptor_options/2
         ]).
 
 %% Supervisor callback
@@ -150,6 +152,32 @@ addresses(Role,  #address{address=Address, port=Port, profile=Profile}) ->
                  Address == any orelse A#address.address == Address,
                  Port == any    orelse A#address.port == Port,
                  Profile == any orelse A#address.profile == Profile].
+
+%%%----------------------------------------------------------------
+%% SysPid is the DaemonRef
+
+get_acceptor_options(SysPid) ->
+    case get_daemon_listen_address(SysPid) of
+        {ok,Address} ->
+            get_options(SysPid, Address);
+        {error,Error} ->
+            {error,Error}
+    end.
+
+replace_acceptor_options(SysPid, NewOpts) ->
+    case get_daemon_listen_address(SysPid) of
+        {ok,Address} ->
+            try stop_listener(SysPid)
+            of
+                ok ->
+                    restart_acceptor(SysPid, Address, NewOpts)
+            catch
+                error:_ ->
+                    restart_acceptor(SysPid, Address, NewOpts)
+            end;
+        {error,Error} ->
+            {error,Error}
+    end.
 
 %%%=========================================================================
 %%%  Supervisor callback

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -84,7 +84,11 @@
          save_accepted_host_option/1,
          raw_option/1,
          config_file/1,
-         config_file_modify_algorithms_order/1
+         config_file_modify_algorithms_order/1,
+         daemon_replace_options_simple/1,
+         daemon_replace_options_algs/1,
+         daemon_replace_options_algs_connect/1,
+         daemon_replace_options_algs_conf_file/1
 	]).
 
 %%% Common test callbacks
@@ -93,6 +97,10 @@
 	 init_per_group/2, end_per_group/2, 
 	 init_per_testcase/2, end_per_testcase/2
 	]).
+
+%%% For test nodes
+-export([get_preferred_algorithms/2
+        ]).
 
 -define(NEWLINE, <<"\r\n">>).
 
@@ -147,6 +155,10 @@ all() ->
      raw_option,
      config_file,
      config_file_modify_algorithms_order,
+     daemon_replace_options_simple,
+     daemon_replace_options_algs,
+     daemon_replace_options_algs_connect,
+     daemon_replace_options_algs_conf_file,
      {group, hardening_tests}
     ].
 
@@ -1700,27 +1712,21 @@ config_file(Config) ->
             [{_,[Ch1|_]}|_] = proplists:get_value(cipher, CommonAlgs),
 
             %% Make config file:
-            Contents = 
-                [{ssh, [{preferred_algorithms,
-                         [{cipher, [Ch1]},
-                          {kex,    [K1a]}
-                         ] ++ AdjustClient},
-                        {client_options,
-                         [{modify_algorithms,
-                           [{rm,     [{kex, [K1a]}]},
-                            {append, [{kex, [K1b]}]}
+            {ok,ConfFile} = 
+                make_config_file_in_privdir(
+                  "c2.config", Config,
+                  [{ssh, [{preferred_algorithms,
+                           [{cipher, [Ch1]},
+                            {kex,    [K1a]}
+                           ] ++ AdjustClient},
+                          {client_options,
+                           [{modify_algorithms,
+                             [{rm,     [{kex, [K1a]}]},
+                              {append, [{kex, [K1b]}]}
+                             ]}
                            ]}
                          ]}
-                       ]}
-                ],          
-            %% write the file:
-            PrivDir = proplists:get_value(priv_dir, Config),
-            ConfFile = filename:join(PrivDir,"c2.config"),
-            {ok,D} = file:open(ConfFile, [write]),
-            io:format(D, "~p.~n", [Contents]),
-            file:close(D),
-            {ok,Cnfs} = file:read_file(ConfFile),
-            ct:log("c2.config:~n~s", [Cnfs]),
+                  ]),
 
             %% Start the slave node with the configuration just made:
             {ok, Peer, Node} = ?CT_PEER(["-config", ConfFile]),
@@ -1792,33 +1798,27 @@ config_file_modify_algorithms_order(Config) ->
             [{_,[Ch1|_]}|_] = proplists:get_value(cipher, CommonAlgs),
 
             %% Make config file:
-            Contents = 
-                [{ssh, [{preferred_algorithms,
-                         [{cipher, [Ch1]},
-                          {kex,    [K1]}
-                         ]},
-                        {server_options,
-                         [{modify_algorithms,
-                           [{rm,     [{kex, [K1]}]},
-                            {append, [{kex, [K2]}]}
-                           ]}
-                         ]},
-                        {client_options,
-                         [{modify_algorithms,
-                           [{rm,     [{kex, [K1]}]},
-                            {append, [{kex, [K3]}]}
+            {ok, ConfFile} =
+                make_config_file_in_privdir(
+                  "c3.config", Config,
+                  [{ssh, [{preferred_algorithms,
+                           [{cipher, [Ch1]},
+                            {kex,    [K1]}
+                           ]},
+                          {server_options,
+                           [{modify_algorithms,
+                             [{rm,     [{kex, [K1]}]},
+                              {append, [{kex, [K2]}]}
+                             ]}
+                           ]},
+                          {client_options,
+                           [{modify_algorithms,
+                             [{rm,     [{kex, [K1]}]},
+                              {append, [{kex, [K3]}]}
+                             ]}
                            ]}
                          ]}
-                       ]}
-                ],          
-            %% write the file:
-            PrivDir = proplists:get_value(priv_dir, Config),
-            ConfFile = filename:join(PrivDir,"c3.config"),
-            {ok,D} = file:open(ConfFile, [write]),
-            io:format(D, "~p.~n", [Contents]),
-            file:close(D),
-            {ok,Cnfs} = file:read_file(ConfFile),
-            ct:log("c3.config:~n~s", [Cnfs]),
+                  ]),
 
             %% Start the slave node with the configuration just made:
             {ok, Peer, Node} = ?CT_PEER(["-config", ConfFile]),
@@ -1866,6 +1866,173 @@ config_file_modify_algorithms_order(Config) ->
 
     
 %%--------------------------------------------------------------------
+daemon_replace_options_simple(Config) ->
+    SysDir = proplists:get_value(data_dir, Config),
+
+    UserDir1 = proplists:get_value(user_dir, Config),
+    UserDir2 = filename:join(UserDir1, "foo"),
+    file:make_dir(UserDir2),
+
+    {Pid, _Host, _Port} = ssh_test_lib:daemon([{system_dir, SysDir},
+                                               {user_dir, UserDir1}
+                                              ]),
+    {ok,Opts1} = ssh:daemon_info(Pid),
+    UserDir1 = proplists:get_value(user_dir, proplists:get_value(options,Opts1,[])),
+
+    {ok, Pid} = ssh:daemon_replace_options(Pid, [{user_dir,UserDir2}]),
+    {ok,Opts2} = ssh:daemon_info(Pid),
+    case proplists:get_value(user_dir, proplists:get_value(options,Opts2,[])) of
+        UserDir2 ->
+            ok;
+        UserDir1 ->
+            ct:log("~p:~p Got old value ~p~nExpected ~p", [?MODULE,?LINE,UserDir1,UserDir2]),
+            {fail, "Not changed"};
+        Other ->
+            ct:log("~p:~p Got ~p~nExpected ~p", [?MODULE,?LINE,Other,UserDir2]),
+            {fail, "Strange value"}
+    end.
+
+%%--------------------------------------------------------------------
+daemon_replace_options_algs(Config) ->
+    SysDir = proplists:get_value(data_dir, Config),
+    UserDir = proplists:get_value(user_dir, Config),
+
+    DefaultKex =
+        ssh_transport:default_algorithms(kex),
+    NonDefaultKex =
+        ssh_transport:supported_algorithms(kex) -- DefaultKex,
+
+    case NonDefaultKex of
+        [A1|_] ->
+            [A2,A3|_] = DefaultKex,
+            {Pid, _Host, _Port} = ssh_test_lib:daemon([{system_dir, SysDir},
+                                                       {user_dir, UserDir},
+                                                       {preferred_algorithms,[{kex,[A1]}]}
+                                                      ]),
+            [A1] = get_preferred_algorithms(Pid, kex),
+            {ok, Pid} =
+                ssh:daemon_replace_options(Pid, [{modify_algorithms,
+                                                  [{prepend,[{kex,[A2]}]}]
+                                                 }
+                                                ]),
+            [A2,A1] = get_preferred_algorithms(Pid, kex),
+
+            {ok, Pid} =
+                ssh:daemon_replace_options(Pid, [{preferred_algorithms,[{kex,[A3]}]
+                                                 }
+                                                ]),
+            [A2,A3] = get_preferred_algorithms(Pid, kex)
+            ;
+        [] ->
+            {skip, "No non-default kex"}
+    end.
+
+%%--------------------------------------------------------------------
+daemon_replace_options_algs_connect(Config) ->
+    [A1,A2|_] =
+        ssh_transport:default_algorithms(kex),
+
+    {Pid, Host, Port} =
+        ssh_test_lib:std_daemon(Config,
+                                [{preferred_algorithms,[{kex,[A1]}]}
+                                ]),
+    [A1] = get_preferred_algorithms(Pid, kex),
+
+    %% Open a connection with A1 as kex and test it
+    C1 =
+        ssh_test_lib:std_connect(Config, Host, Port,
+                                 [{preferred_algorithms,[{kex,[A1]}]}
+                                 ]),
+    ok = test_connection(C1),
+    ok = test_not_connect(Config, Host, Port,
+                          [{preferred_algorithms,[{kex,[A2]}]}
+                          ]),
+
+    %% Change kex to A2
+    {ok, Pid} =
+        ssh:daemon_replace_options(Pid,
+                                   [{preferred_algorithms,[{kex,[A2]}]}]),
+    [A2] = get_preferred_algorithms(Pid, kex),
+
+    %% and open the second connection with this kex, and test it
+    C2 =
+        ssh_test_lib:std_connect(Config, Host, Port,
+                                 [{preferred_algorithms,[{kex,[A2]}]}
+                                 ]),
+    ok = test_connection(C2),
+    ok = test_not_connect(Config, Host, Port,
+                          [{preferred_algorithms,[{kex,[A1]}]}
+                          ]),
+
+    %% Test that the first connection is still alive:
+    ok = test_connection(C1),
+
+    ssh:close(C1),
+    ssh:close(C2),
+    ssh:stop_daemon(Pid).
+
+%%--------------------------------------------------------------------
+daemon_replace_options_algs_conf_file(Config) ->
+    SysDir = proplists:get_value(data_dir, Config),
+    UserDir = proplists:get_value(user_dir, Config),
+
+    DefaultKex =
+        ssh_transport:default_algorithms(kex),
+    NonDefaultKex =
+        ssh_transport:supported_algorithms(kex) -- DefaultKex,
+
+    case NonDefaultKex of
+        [A0,A1|_] ->
+            %% Make config file:
+            {ok,ConfFile} =
+                make_config_file_in_privdir(
+                  "c4.config", Config,
+                  [{ssh, [{modify_algorithms,
+                           %% Whatever happens, always put A0 first in the kex list:
+                           [{prepend, [{kex, [A0]}]}
+                           ]}
+                         ]}
+                  ]),
+
+            [A2|_] = DefaultKex,
+            ct:log("[A0, A1, A2] = ~p", [[A0, A1, A2]]),
+
+            %% Start the slave node with the configuration just made:
+            {ok, Peer, Node} = ?CT_PEER(["-config", ConfFile]),
+
+            %% Start ssh on the slave. This should apply the ConfFile:
+            rpc:call(Node, ssh, start, []),
+
+            {Pid, _Host, _Port} =
+                rpc:call(Node, ssh_test_lib, daemon,
+                         [
+                          [{system_dir, SysDir},
+                           {user_dir, UserDir},
+                           {preferred_algorithms,[{kex,[A1]}]}
+                          ]
+                         ]),
+
+            [A0,A1] =
+                rpc:call(Node, ?MODULE, get_preferred_algorithms, [Pid, kex]),
+            {ok, Pid} =
+                rpc:call(Node, ssh, daemon_replace_options,
+                         [Pid,
+                          [{modify_algorithms,
+                            [{prepend,[{kex,[A2]}]}]
+                           }
+                          ]
+                         ]),
+
+            %% Check that the precedens order is fulfilled:
+            [A2,A0,A1] =
+                rpc:call(Node, ?MODULE, get_preferred_algorithms, [Pid, kex]),
+
+            peer:stop(Peer);
+        [] ->
+            {skip, "No non-default kex"}
+    end.
+
+%%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------
 %%--------------------------------------------------------------------
 
@@ -1905,3 +2072,42 @@ fake_daemon(_Config) ->
     after 
 	10000 -> ct:fail("timeout ~p:~p",[?MODULE,?LINE])
     end.
+
+
+make_config_file_in_privdir(FileName, Config, Contents) ->
+    %% write the file:
+    PrivDir = proplists:get_value(priv_dir, Config),
+    ConfFile = filename:join(PrivDir, FileName),
+    {ok,D} = file:open(ConfFile, [write]),
+    io:format(D, "~p.~n", [Contents]),
+    file:close(D),
+    {ok,Cnfs} = file:read_file(ConfFile),
+    ct:log("Config file ~p :~n~s", [ConfFile,Cnfs]),
+    {ok,ConfFile}.
+
+
+get_preferred_algorithms(Pid, Type) ->
+    {ok,#{preferred_algorithms:=As}} = ssh_system_sup:get_acceptor_options(Pid),
+    proplists:get_value(Type, As).
+
+test_connection(C) ->
+    {ok, Ch} = ssh_connection:session_channel(C, infinity),
+    A = rand:uniform(100),
+    B = rand:uniform(100),
+    A_plus_B = lists:concat([A,"+",B,"."]),
+    Sum = integer_to_binary(A+B),
+    success = ssh_connection:exec(C, Ch, A_plus_B, infinity),
+    expected = ssh_test_lib:receive_exec_result(
+                 {ssh_cm, C, {data, Ch, 0, Sum}} ),
+    ssh_test_lib:receive_exec_end(C, Ch),
+    ok.
+
+test_not_connect(Config, Host, Port, Opts) ->
+    try
+        ssh_test_lib:std_connect(Config, Host, Port, Opts)
+    of
+        Cx when is_pid(Cx) -> {error, connected}
+    catch
+        error:{badmatch, {error,_}} -> ok
+    end.
+


### PR DESCRIPTION
This PR makes it possible to change the Options in a running SSH server.  Established connections are not affected, only those created after the call to `ssh:daemon_replace_options/2`.

Example usage:

```
{ok,Dref} = ssh:daemon(1234, [{system_dir,"..."}]).

ssh:daemon_replace_options(Dref, [{preferred_algorithms,[{kex,['diffie-hellman-group1-sha1']}]}]).
```