### PR TITLE
Regular expression replacement with a function

### DIFF
--- a/lib/stdlib/doc/src/re.xml
+++ b/lib/stdlib/doc/src/re.xml
@@ -75,6 +75,9 @@
     <datatype>
       <name name="compile_option"/>
     </datatype>
+    <datatype>
+      <name name="replace_fun"/>
+    </datatype>
   </datatypes>
 
   <funcs>
@@ -363,7 +366,7 @@
         elements with Replacement.</fsummary>
       <desc>
         <p>Replaces the matched part of the <c><anno>Subject</anno></c> string
-          with the contents of <c><anno>Replacement</anno></c>.</p>
+          with <c><anno>Replacement</anno></c>.</p>
         <p>The permissible options are the same as for
           <seemfa marker="#run/3"><c>run/3</c></seemfa>, except that option<c>
           capture</c> is not allowed. Instead a <c>{return,
@@ -378,8 +381,8 @@
           <c>unicode</c> compilation option is specified to this function, both
           the regular expression and <c><anno>Subject</anno></c> are to
           specified as valid Unicode <c>charlist()</c>s.</p>
-        <p>The replacement string can contain the special character
-          <c>&amp;</c>, which inserts the whole matching expression in the
+        <p>If the replacement is given as a string, it  can contain the special
+          character <c>&amp;</c>, which inserts the whole matching expression in the
           result, and the special sequence <c>\</c>N (where N is an integer &gt;
           0), <c>\g</c>N, or <c>\g{</c>N<c>}</c>, resulting in the subexpression
           number N, is inserted in the result. If no subexpression with that
@@ -401,6 +404,35 @@ re:replace("abcd","c","[\\&amp;]",[{return,list}]).</code>
         <p>gives</p>
         <code>
 "ab[&amp;]d"</code>
+        <p>If the replacement is given as a fun, it will be called with the
+          whole matching expression as the first argument and a list of subexpression
+          matches in the order in which they appear in the regular expression.
+          The returned value will be inserted in the result.</p>
+        <p><em>Example:</em></p>
+        <code>
+re:replace("abcd", ".(.)", fun(Whole, [&lt;&lt;C&gt;&gt;]) -> &lt;&lt;$#, Whole/binary, $-, (C - $a + $A), $#&gt;&gt; end, [{return, list}]).</code>
+        <p>gives</p>
+        <code>
+"#ab-B#cd"</code>
+        <note>
+          <p>Non-matching optional subexpressions will not be included in the list
+            of subexpression matches if they are the last subexpressions in the
+            regular expression.</p>
+          <p><em>Example:</em></p>
+          <p>The regular expression <c>"(a)(b)?(c)?"</c> ("a", optionally followed
+            by "b", optionally followed by "c") will create the following subexpression
+            lists:</p>
+          <list>
+            <item><c>[&lt;&lt;"a"&gt;&gt;, &lt;&lt;"b"&gt;&gt;, &lt;&lt;"c"&gt;&gt;]</c>
+              when applied to the string <c>"abc"</c></item>
+            <item><c>[&lt;&lt;"a"&gt;&gt;, &lt;&lt;&gt;&gt;, &lt;&lt;"c"&gt;&gt;]</c>
+              when applied to the string <c>"acx"</c></item>
+            <item><c>[&lt;&lt;"a"&gt;&gt;, &lt;&lt;"b"&gt;&gt;]</c>
+              when applied to the string <c>"abx"</c></item>
+            <item><c>[&lt;&lt;"a"&gt;&gt;]</c>
+              when applied to the string <c>"axx"</c></item>
+          </list>
+        </note>
         <p>As with <c>run/3</c>, compilation errors raise the <c>badarg</c>
           exception. <seemfa marker="#compile/2"><c>compile/2</c></seemfa>
           can be used to get more information about the error.</p>
@@ -972,7 +1004,7 @@ re:run("ABCabcdABC",".*(?&lt;FOO&gt;abcd).*",[{capture,['FOO']}]).</code>
             <p>Here the empty binary (<c>&lt;&lt;&gt;&gt;</c>) represents the
               unassigned subpattern. In the <c>binary</c> case, some information
               about the matching is therefore lost, as
-	      <c>&lt;&lt;&gt;&gt;</c> can
+              <c>&lt;&lt;&gt;&gt;</c> can
               also be an empty string captured.</p>
             <p>If differentiation between empty matches and non-existing
               subpatterns is necessary, use the <c>type</c> <c>index</c> and do

--- a/lib/stdlib/test/re_SUITE.erl
+++ b/lib/stdlib/test/re_SUITE.erl
@@ -22,7 +22,7 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
 	 init_per_group/2,end_per_group/2, pcre/1,compile_options/1,
 	 run_options/1,combined_options/1,replace_autogen/1,
-	 global_capture/1,replace_input_types/1,replace_return/1,
+	 global_capture/1,replace_input_types/1,replace_with_fun/1,replace_return/1,
 	 split_autogen/1,split_options/1,split_specials/1,
 	 error_handling/1,pcre_cve_2008_2371/1,re_version/1,
 	 pcre_compile_workspace_overflow/1,re_infinite_loop/1, 
@@ -42,7 +42,7 @@ suite() ->
 all() -> 
     [pcre, compile_options, run_options, combined_options,
      replace_autogen, global_capture, replace_input_types,
-     replace_return, split_autogen, split_options,
+     replace_with_fun, replace_return, split_autogen, split_options,
      split_specials, error_handling, pcre_cve_2008_2371,
      pcre_compile_workspace_overflow, re_infinite_loop, 
      re_backwards_accented, opt_dupnames, opt_all_names, 
@@ -363,6 +363,16 @@ replace_input_types(Config) when is_list(Config) ->
     <<"abcd">> = re:replace("abcd","Z","X",[{return,binary},unicode]),
     <<"abcd">> = re:replace("abcd","\x{400}","X",[{return,binary},unicode]),
     <<"a",208,128,"cd">> = re:replace(<<"abcd">>,"b","\x{400}",[{return,binary},unicode]),
+    ok.
+
+%% Test replace with a replacement function.
+replace_with_fun(Config) when is_list(Config) ->
+    <<"ABCD">> = re:replace("abcd", ".", fun(<<C>>, []) -> <<(C - $a + $A)>> end, [global, {return, binary}]),
+    <<"AbCd">> = re:replace("abcd", ".", fun(<<C>>, []) when (C - $a) rem 2 =:= 0 -> <<(C - $a + $A)>>; (C, []) -> C end, [global, {return, binary}]),
+    <<"b-ad-c">> = re:replace("abcd", "(.)(.)", fun(_, [A, B]) -> <<B/binary, $-, A/binary>> end, [global, {return, binary}]),
+    <<"#ab-B#cd">> = re:replace("abcd", ".(.)", fun(Whole, [<<C>>]) -> <<$#, Whole/binary, $-, (C - $a + $A), $#>> end, [{return, binary}]),
+    <<"#ab#cd">> = re:replace("abcd", ".(x)?(.)", fun(Whole, [<<>>, _]) -> <<$#, Whole/binary, $#>> end, [{return, binary}]),
+    <<"#ab#cd">> = re:replace("abcd", ".(.)(x)?", fun(Whole, [_]) -> <<$#, Whole/binary, $#>> end, [{return, binary}]),
     ok.
 
 %% Test return options of replace together with global searching.


### PR DESCRIPTION
I rarely use regular expressions with Erlang. But when I do, I often would need a function to process matches and create replacements.

This PR extends `re:replace/3,4` to accept a 2-ary function for the replacement. This function will be called with the entire match as the first and a list of subexpression matches as second argument. The value returned from the function will be inserted into the result.

A problem exists in case of regular expressions like this:
```
".(x)?(y)?"
```
When applied to a string like `"axy"`, the function will be called with arguments `<<"axy">>` and `[<<"x">>, <<"y">>]`.
When applied to `"ax"`, the arguments will be `<<"ax">>` and `[<<"x">>]`, ie the subexpression match list _does not_ contain the optional-ish match related to `(y)`.
When applied to `"ay"`, the arguments will be `<<"ay">>` and `[<<>>, <<"y">>]`, ie the subexpression match list _does_ contain the optional-ish match related to `(x)` as an empty binary.

I'm not sure how to handle this (and that is why it is not documented yet). The implementation for replacements using strings with back references inserts empty binaries if the match index does not exist in the actual match. For creating the subexpression match list for replacement via a function however, something like this is not possible. The easiest way out may be to recommend a catch-all clause that will return an empty binary, in the documentation.