### PR TITLE
crypto: adjust list of nifs

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -156,7 +156,7 @@
        engine_unregister_nif/2, engine_add_nif/1, engine_remove_nif/1,
        engine_get_first_nif/0, engine_get_next_nif/1, engine_get_id_nif/1,
        engine_get_name_nif/1, engine_get_all_methods_nif/0,
-       ensure_engine_loaded_nif/3, ensure_engine_unloaded_nif/2
+       ensure_engine_loaded_nif/2
       ]).
 
 -export_type([ %% A minimum exported: only what public_key needs.


### PR DESCRIPTION
Since 6ca05d934 two crypto related NIFs were updated:

  * ensure_engine_loaded_nif - arity was changed from 3 to 2
  * ensure_engine_unloaded_nif - was removed

this commit adjusts NIFs list in crypto.erl to avoid errors:

```
crypto.erl:138:2: nif ensure_engine_loaded_nif/3 undefined
%  138| -nifs([info_nif/0, info_lib/0, info_fips/0, enable_fips_mode_nif/1,
%     |  ^

crypto.erl:138:2: nif ensure_engine_unloaded_nif/2 undefined
%  138| -nifs([info_nif/0, info_lib/0, info_fips/0, enable_fips_mode_nif/1,
%     |  ^
```