### PR TITLE
inets: Remove documentation of no longer supported callback

### DIFF
--- a/lib/inets/doc/src/mod_esi.xml
+++ b/lib/inets/doc/src/mod_esi.xml
@@ -177,24 +177,7 @@
 	any data that it needs to keep track of when handling the chunks.
 	</p>
       </desc>
-   </func>
-
-   <func>
-     <name since="">Module:Function(Env, Input)-> Response </name>
-     <fsummary>Creates a dynamic web page and returns it as a list. 
-     This function is deprecated and is only kept for backwards compatibility.</fsummary>
-     <type>
-       <v>Env = env()</v>
-       <v>Input = string() </v>
-       <v>Response = string()</v>
-     </type>
-      <desc>
-        <p>This callback format consumes much memory, as the
-        whole response must be generated before it is sent to the
-        user. This callback format is deprecated. 
-        For new development, use <c>Module:Function/3</c>.</p>
-      </desc>
-   </func>
+   </func>  
  </funcs>
  
 </erlref>


### PR DESCRIPTION
Was removed in OTP-23 and also in 22.3.1

Closes #6122