### PR TITLE
dialyzer: Fix missing incremental analysis type option

### DIFF
--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -150,7 +150,8 @@
                                            'plt_add' |
                                            'plt_build' |
                                            'plt_check' |
-                                           'plt_remove'}
+                                           'plt_remove' |
+                                           'incremental'}
                        | {'warnings', [warn_option()]}
                        | {'get_warnings', boolean()}
                        | {'error_location', error_location()}.

--- a/lib/dialyzer/test/opaque_SUITE_data/src/recrec/dialyzer.hrl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/recrec/dialyzer.hrl
@@ -99,7 +99,7 @@
 %%--------------------------------------------------------------------
 
 -type anal_type()     :: 'succ_typings' | 'plt_build'.
--type anal_type1()    :: anal_type() | 'plt_add' | 'plt_check' | 'plt_remove'.
+-type anal_type1()    :: anal_type() | 'plt_add' | 'plt_check' | 'plt_remove' | 'incremental'.
 -type contr_constr()  :: {'subtype', erl_types:erl_type(), erl_types:erl_type()}.
 -type contract_pair() :: {erl_types:erl_type(), [contr_constr()]}.
 -type dial_define()   :: {atom(), term()}.


### PR DESCRIPTION
Adds the `incremental` analysis mode into the appropriate option types.

This was causing Dialyzer warnings for users that consumed the
incremental API to Dialyzer itself (e.g. erlang/rebar3#2736), since the `incremental`
option was available at runtime, but not declared in `dial_option()`.