### PR TITLE
kernel: Fix Logger filter removal if message format is atom or binary

### DIFF
--- a/lib/kernel/src/logger_internal.hrl
+++ b/lib/kernel/src/logger_internal.hrl
@@ -96,7 +96,7 @@
 -define(IS_MSG(Msg),
         ((is_tuple(Msg) andalso tuple_size(Msg)==2)
          andalso
-           (is_list(element(1,Msg)) andalso is_list(element(2,Msg)))
+           (?IS_FORMAT(element(1,Msg)) andalso is_list(element(2,Msg)))
          orelse
            (element(1,Msg)==report andalso ?IS_REPORT(element(2,Msg)))
          orelse


### PR DESCRIPTION
Log event check performed in `logger_backend:do_apply_filters/4` doesn't tolerate atoms and binaries as message format strings.  This may cause a filter to be removed

    > logger:notice(<<"hello">>, []).
    Logger - error: {removed_failing_filter,no_domain}

For atom format strings it was partially fixed in OTP 25 by forcing atoms to strings before filters are applied (17c8fcf).