### PR TITLE
JIT: Correct code generation for huge match in binary tail

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -706,6 +706,8 @@ protected:
     void sub(arm::Gp to, arm::Gp src, int64_t val) {
         if (val < 0) {
             add(to, src, -val);
+        } else if (val == 0 && to != src) {
+            a.mov(to, src);
         } else if (val < (1 << 24)) {
             if (val & 0xFFF) {
                 a.sub(to, src, imm(val & 0xFFF));
@@ -724,6 +726,8 @@ protected:
     void add(arm::Gp to, arm::Gp src, int64_t val) {
         if (val < 0) {
             sub(to, src, -val);
+        } else if (val == 0 && to != src) {
+            a.mov(to, src);
         } else if (val < (1 << 24)) {
             if (val & 0xFFF) {
                 a.add(to, src, imm(val & 0xFFF));
@@ -736,6 +740,17 @@ protected:
         } else {
             mov_imm(SUPER_TMP, val);
             a.add(to, src, SUPER_TMP);
+        }
+    }
+
+    void cmp(arm::Gp src, int64_t val) {
+        if (Support::isUInt12(val)) {
+            a.cmp(src, imm(val));
+        } else if (Support::isUInt12(-val)) {
+            a.cmn(src, imm(-val));
+        } else {
+            mov_imm(SUPER_TMP, val);
+            a.cmp(src, SUPER_TMP);
         }
     }
 

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -713,7 +713,7 @@ void BeamModuleAssembler::emit_bs_test_tail2(const ArgLabel &Fail,
     a.sub(TMP2, TMP2, TMP3);
 
     if (Offset.get() != 0) {
-        a.cmp(TMP2, imm(Offset.get()));
+        cmp(TMP2, Offset.get());
         a.b_ne(resolve_beam_label(Fail, disp1MB));
     } else {
         a.cbnz(TMP2, resolve_beam_label(Fail, disp1MB));

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -933,7 +933,12 @@ void BeamModuleAssembler::emit_bs_test_tail2(const ArgLabel &Fail,
     a.sub(ARG2, emit_boxed_val(ARG1, offsetof(ErlBinMatchState, mb.offset)));
 
     if (Offset.get() != 0) {
-        a.cmp(ARG2, imm(Offset.get()));
+        if (Support::isInt32(Offset.get())) {
+            a.cmp(ARG2, imm(Offset.get()));
+        } else {
+            mov_imm(RET, Offset.get());
+            a.cmp(ARG2, RET);
+        }
     }
 
     a.jne(resolve_beam_label(Fail));

--- a/erts/emulator/test/bs_match_tail_SUITE.erl
+++ b/erts/emulator/test/bs_match_tail_SUITE.erl
@@ -22,14 +22,14 @@
 
 -author('bjorn@erix.ericsson.se').
 -export([all/0, suite/0,
-	 aligned/1,unaligned/1,zero_tail/1]).
+	 aligned/1,unaligned/1,zero_tail/1,huge_tail/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
-    [aligned, unaligned, zero_tail].
+    [aligned, unaligned, zero_tail, huge_tail].
 
 
 %% Test aligned tails.
@@ -86,4 +86,34 @@ test_zero_tail(<<A:8>>) -> A.
 
 test_zero_tail2(<<_A:4,_B:4>>) -> ok.
 
-mkbin(L) when is_list(L) -> list_to_binary(L).
+huge_tail(_Config) ->
+    42 = huge_tail_1(id(<<42,0:16#1001>>)),
+    {'EXIT',{function_clause,_}} = catch huge_tail_1(id(<<0:8,0:10>>)),
+
+    {'EXIT',{function_clause,_}} = catch huge_tail_2(id(<<0:8,0:100>>)),
+
+    %% The following code is commented out by default because it
+    %% constructs a 2Gb binary.
+
+    %% try huge_tail_2(id(<<100, 0:16#8000_0000>>)) of
+    %%     100 ->
+    %%         ok
+    %% catch
+    %%     error:function_clause ->
+    %%         ct:fail(not_supposed_to_fail)
+    %% end,
+
+    ok.
+
+%% On AArch64, the immediate for the `cmp` instruction is 12 bits (unsigned).
+huge_tail_1(<<B:8,_:16#1001>>) -> B.
+
+%% On x86_64, the immediate for the `cmp` instruction is 32 bits (signed).
+huge_tail_2(<<B:8, _:16#8000_0000>>) -> B.
+
+%%%
+%%% Common utilities.
+%%%
+mkbin(L) when is_list(L) -> list_to_binary(id(L)).
+
+id(I) -> I.


### PR DESCRIPTION
On AArch64 (ARM64), the JIT would generate incorrect code for the
following binary match:

    huge_tail_1(<<B:8,_:16#1001>>) -> B.

On x86_64, the JIT would generate incorrect code for the
following binary match:

    huge_tail_2(<<B:8, _:16#8000_0000>>) -> B.

While at it, fix a potential problem in two helper functions
used on AArch64.