### PR TITLE
beam_jump: Be more careful when sharing function calls

### DIFF
--- a/lib/compiler/src/beam_jump.erl
+++ b/lib/compiler/src/beam_jump.erl
@@ -353,7 +353,7 @@ share_1([{label,L}=Lbl|Is], Safe, Dict0, Lbls0, [_|_]=Seq0, Acc) ->
             %% Find out whether it is safe to share the sequence.
             case (map_size(Safe) =:= 0 orelse
                   is_shareable(Seq)) andalso
-                unambigous_exit_call(Seq)
+                unambigous_deallocation(Seq)
             of
                 true ->
                     %% Either this function does not contain any try/catch
@@ -402,36 +402,30 @@ share_1([I|Is], Safe, Dict, Lbls, Seq, Acc) ->
 	    share_1(Is, Safe, Dict, Lbls, [I], Acc)
     end.
 
-unambigous_exit_call([{call_ext,A,{extfunc,M,F,A}}|Is]) ->
-    case erl_bifs:is_exit_bif(M, F, A) of
-        true ->
-            %% beam_validator requires that the size of the stack
-            %% frame is unambigously known when a function is called.
-            %%
-            %% That means that we must be careful when sharing function
-            %% calls.
-            %%
-            %% In practice, it seems that only exit BIFs can
-            %% potentially be shared in an unsafe way, and only in
-            %% rare circumstances. (See the undecided_allocation_1/1
-            %% function in beam_jump_SUITE.)
-            %%
-            %% To ensure that the frame size is unambigous, only allow
-            %% sharing of a call to exit BIFs if the call is followed
-            %% by an instruction that indicates the size of the stack
-            %% frame (that is almost always the case in real-world
-            %% code).
-            case Is of
-                [{deallocate,_}|_] -> true;
-                [return] -> true;
-                _ -> false
-            end;
-        false ->
-            true
-    end;
-unambigous_exit_call([_|Is]) ->
-    unambigous_exit_call(Is);
-unambigous_exit_call([]) -> true.
+unambigous_deallocation([{call_ext,_,_}|Is]) ->
+    %% beam_validator requires that the size of the stack frame is
+    %% unambigously known when a function is called.
+    %%
+    %% That means that we must be careful when sharing function calls.
+    %%
+    %% To ensure that the frame size is unambigous, only allow sharing
+    %% of calls if the call is followed by instructions that
+    %% indicates the size of the stack frame.
+    find_deallocation(Is);
+unambigous_deallocation([{call,_,_}|Is]) ->
+    find_deallocation(Is);
+unambigous_deallocation([_|Is]) ->
+    unambigous_deallocation(Is);
+unambigous_deallocation([]) -> true.
+
+find_deallocation([{line,_}|Is]) -> find_deallocation(Is);
+find_deallocation([{call,_,_}|Is]) -> find_deallocation(Is);
+find_deallocation([{call_ext,_,_}|Is]) -> find_deallocation(Is);
+find_deallocation([{init_yregs,_}|Is]) -> find_deallocation(Is);
+find_deallocation([{block,_}|Is]) -> find_deallocation(Is);
+find_deallocation([{deallocate,_}|_]) -> true;
+find_deallocation([return]) -> true;
+find_deallocation(_) -> false.
 
 %% If the label has a scope set, assign it to any line instruction
 %% in the sequence.

--- a/lib/compiler/test/beam_jump_SUITE.erl
+++ b/lib/compiler/test/beam_jump_SUITE.erl
@@ -320,6 +320,14 @@ cs_2(I) -> I.
 undecided_allocation(_Config) ->
     ok = catch undecided_allocation_1(<<10:(3*7)>>),
     {'EXIT',{{badrecord,rec},_}} = catch undecided_allocation_1(8),
+
+    {bar,1} = undecided_allocation_2(id(<<"bar">>)),
+    {foo,2} = undecided_allocation_2(id(<<"foo">>)),
+    {'EXIT',_} = catch undecided_allocation_2(id(<<"foobar">>)),
+    {'EXIT',{{badmatch,error},_}} = catch undecided_allocation_2(id("foo,bar")),
+    {'EXIT',_} = catch undecided_allocation_2(id(foobar)),
+    {'EXIT',_} = catch undecided_allocation_2(id(make_ref())),
+
     ok.
 
 -record(rec, {}).
@@ -339,6 +347,38 @@ undecided_allocation_1(V) ->
       <<0>> || <<0:V>> <= <<0>>
     >>#rec{},
     if whatever -> [] end.
+
+undecided_allocation_2(Order) ->
+    {_, _} =
+        case Order of
+            <<"bar">> ->
+                {bar, 1};
+            <<"foo">> ->
+                {foo, 2};
+            S ->
+                case string:split("foo", "o") of
+                    [] ->
+                        ok;
+                    _ ->
+                        %% The beam_ssa_bsm pass will duplicate this code,
+                        %% and beam_jump would undo the duplication by sharing
+                        %% the code that calls lists:flatten/1. The problem was
+                        %% that the stack frames had different sizes for the
+                        %% two calls to lists:flatten/1. The diagnostic would be:
+                        %%
+                        %%  Internal consistency check failed - please report this bug.
+                        %%  Instruction: {call_ext,1,{extfunc,lists,flatten,1}}
+                        %%  Error:       {allocated,undecided}:
+
+                        lists:flatten(
+                            case S of
+                                Y when is_binary(Y) -> Y;
+                                Y -> string:split(Y, ",")
+                            end
+                        )
+                end,
+                error
+        end.
 
 
 id(I) ->


### PR DESCRIPTION
The code in #6222 would fail to compile like this:

    t:1: function from/1+58:
      Internal consistency check failed - please report this bug.
      Instruction: {call_ext,1,{extfunc,lists,flatten,1}}
      Error:       {allocated,undecided}:

The reason was an unsafe optimization made by the `beam_jump`
pass. Avoid the problem by only sharing function calls if it
can be seen that the stack frames at the time of the calls
have the same size.

Closes #6222