### PR TITLE
kernel: invoke init:run_on_load_handlers/0 after code_server start

### DIFF
--- a/lib/ssl/Makefile
+++ b/lib/ssl/Makefile
@@ -40,4 +40,6 @@ include $(ERL_TOP)/make/otp_subdir.mk
 
 DIA_PLT_APPS=crypto runtime_tools inets public_key
 
+TEST_NEEDS_RELEASE=true
+
 include $(ERL_TOP)/make/app_targets.mk

--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -421,6 +421,7 @@ wait_for_code_server() ->
 	    timer:sleep(10),
 	    wait_for_code_server();
 	Pid when is_pid(Pid) ->
+            init:run_on_load_handlers([crypto,asn1rt_nif]),
 	    ok
     end.
 
@@ -552,6 +553,8 @@ setup_fun(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
 
 -spec do_setup(_,_,_,_,_,_,_) -> no_return().
 do_setup(Driver, Kernel, Node, Type, MyNode, LongOrShortNames, SetupTime) ->
+    wait_for_code_server(),
+
     {Name, Address} = split_node(Driver, Node, LongOrShortNames),
     ErlEpmd = net_kernel:epmd_module(),
     {ARMod, ARFun} = get_address_resolver(ErlEpmd, Driver),


### PR DESCRIPTION
Moving the invocation of init:on_load_handlers/0 from kernel:init(safe) to code:do_start/0.

init:on_load_handlers/0 has been added as part of https://github.com/erlang/otp/commit/7f82edd and it was implemented in such a way that it will be invoked, quoting, "after having started most servers in the kernel application", problem is that some of those servers, under specific configurations (see #6085), need the on load handlers in order for them to properly start.

As mentioned, this should fix #6085.