### PR TITLE
Allow disabling `certificate_authorities` extension on server with `verify_peer`

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1033,7 +1033,7 @@ fun(srp, Username :: binary(), UserState :: term()) ->
     </datatype>
 
     <datatype>
-      <name name="certificate_authorities"/>
+      <name name="client_certificate_authorities"/>
       <desc>
 	<p>If set to true, sends the certificate authorities extension in TLS-1.3 client hello.
 	The default is false. Note that setting it to true may result in a big overhead if you
@@ -1248,6 +1248,15 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       is supplied it overrides option <c>cacertfile</c>.</p>
 	</desc>
       </datatype>
+
+  <datatype>
+    <name since="OTP 25.2" name="server_certificate_authorities"/>
+      <desc>
+      <p>When used with <c>{verify, verify_peer}</c> on the server with TLS-1.3, the certificate
+      authorities extension will be included or excluded from the certificate request. The Default
+      is true.</p>
+      </desc>
+  </datatype>
             
       <datatype>
 	<name name="server_cafile"/>
@@ -1287,8 +1296,9 @@ fun(srp, Username :: binary(), UserState :: term()) ->
 	A server only does x509-certificate path validation in mode
 	<c>verify_peer</c>. By default the server is in <c>verify_none</c> mode
 	an hence will not send an certificate request to the client.
-	When using <c>verify_peer</c> you may also want to specify the option
-	<seetype marker="#fail_if_no_peer_cert">fail_if_no_peer_cert</seetype>.</p>
+	When using <c>verify_peer</c> you may also want to specify the options
+	<seetype marker="#fail_if_no_peer_cert">fail_if_no_peer_cert</seetype> and
+  <seetype marker="#server_certificate_authorities">certificate_authorities</seetype>.</p>
       </desc>
       </datatype>
 

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -418,7 +418,7 @@
                                 {customize_hostname_check, customize_hostname_check()} |
                                 {fallback, fallback()} |
                                 {middlebox_comp_mode, middlebox_comp_mode()} |
-                                {certificate_authorities, certificate_authorities()} |
+                                {certificate_authorities, client_certificate_authorities()} |
                                 {session_tickets, client_session_tickets()} |
                                 {use_ticket, use_ticket()} |
                                 {early_data, client_early_data()}.
@@ -429,7 +429,7 @@
 -type client_verify_type()       :: verify_type().
 -type client_reuse_session()     :: session_id() | {session_id(), SessionData::binary()}.
 -type client_reuse_sessions()    :: boolean() | save.
--type certificate_authorities()  :: boolean().
+-type client_certificate_authorities()  :: boolean().
 -type client_cacerts()           :: [public_key:der_encoded()] | [public_key:combined_cert()].
 -type client_cafile()            :: file:filename().
 -type app_level_protocol()       :: binary().
@@ -458,6 +458,7 @@
                                 {dhfile, dh_file()} |
                                 {verify, server_verify_type()} |
                                 {fail_if_no_peer_cert, fail_if_no_peer_cert()} |
+                                {certificate_authorities, server_certificate_authorities()} |
                                 {reuse_sessions, server_reuse_sessions()} |
                                 {reuse_session, server_reuse_session()} |
                                 {alpn_preferred_protocols, server_alpn()} |
@@ -490,6 +491,7 @@
 -type honor_ecc_order()          :: boolean().
 -type client_renegotiation()     :: boolean().
 -type cookie()                   :: boolean().
+-type server_certificate_authorities() :: boolean().
 %% -------------------------------------------------------------------------------------------------------
 -type prf_random() :: client_random | server_random. % exported
 -type protocol_extensions()  :: #{renegotiation_info => binary(),
@@ -1684,11 +1686,11 @@ handle_option(fallback = Option, Value0, OptionsMap, #{role := Role}) ->
     assert_role(client_only, Role, Option, Value0),
     Value = validate_option(Option, Value0),
     OptionsMap#{Option => Value};
-handle_option(certificate_authorities = Option, unbound, OptionsMap, #{role := Role}) ->
-    Value = default_option_role(client, false, Role),
-    OptionsMap#{Option => Value};
-handle_option(certificate_authorities = Option, Value0, #{versions := Versions} = OptionsMap, #{role := Role}) ->
-    assert_role(client_only, Role, Option, Value0),
+handle_option(certificate_authorities = Option, unbound, OptionsMap, #{role := server}) ->
+    OptionsMap#{Option => true};
+handle_option(certificate_authorities = Option, unbound, OptionsMap, #{role := client}) ->
+    OptionsMap#{Option => false};
+handle_option(certificate_authorities = Option, Value0, #{versions := Versions} = OptionsMap, _Env) ->
     assert_option_dependency(Option, versions, Versions, ['tlsv1.3']),
     Value = validate_option(Option, Value0),
     OptionsMap#{Option => Value};


### PR DESCRIPTION
Fixes #6106

/cc @IngelaAndin 

Based on the discussion from the issue (and #6204), it was decided that adding the
ability to disable the `certificate_authorities` extension on the server would be
the fitting resolution for situations where you do not want that extension forced
in TLS 1.3.

This adds that ability to specify as a server option and defaults to `true` to keep
with existing expected functionality.