### PR TITLE
ets:lookup_element badarg for Pos

### DIFF
--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -944,6 +944,8 @@ Error: fun containing local Erlang function calls
           element of every object with key <c><anno>Key</anno></c>.</p>
         <p>If no object with key <c><anno>Key</anno></c> exists, the
           function exits with reason <c>badarg</c>.</p>
+        <p>If <c><anno>Pos</anno></c> is larger than the size of the tuple,
+          the function exits with reason <c>badarg</c>.</p>
         <p>The difference between <c>set</c>, <c>bag</c>, and
           <c>duplicate_bag</c> on one hand, and <c>ordered_set</c> on
           the other, regarding the fact that <c>ordered_set</c>


### PR DESCRIPTION
Document badarg when Pos is larger than the tuple the element it to be extracted from.

This came up when testing cases in the discussion on adding support for ets:lookup_element/4

https://erlangforums.com/t/proposal-adding-ets-lookup-element-as-list-3/1743/11