### PR TITLE
Update Android cross compilation

### DIFF
--- a/xcomp/erl-xcomp-arm-android.conf
+++ b/xcomp/erl-xcomp-arm-android.conf
@@ -62,7 +62,7 @@ erl_xcomp_host=arm-linux-androideabi
 #   `configure' script.
 # Set --enable-builtin-zlib to avoid a inflateGetDictionary missing symbol
 erl_xcomp_configure_flags="--without-termcap --without-wx \
-                           --enable-builtin-zlib"
+                           --enable-builtin-zlib --enable-deterministic-build"
 
 
 ## -- Cross Compiler and Other Tools -------------------------------------------

--- a/xcomp/erl-xcomp-arm-android.conf
+++ b/xcomp/erl-xcomp-arm-android.conf
@@ -2,7 +2,7 @@
 ##
 ## %CopyrightBegin%
 ##
-## Copyright Ericsson AB 2009-2021. All Rights Reserved.
+## Copyright Ericsson AB 2009-2022. All Rights Reserved.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ erl_xcomp_host=arm-linux-androideabi
 #   `configure' script.
 # Set --enable-builtin-zlib to avoid a inflateGetDictionary missing symbol
 erl_xcomp_configure_flags="--without-termcap --without-wx \
-                                          --enable-builtin-zlib"
+                           --enable-builtin-zlib"
 
 
 ## -- Cross Compiler and Other Tools -------------------------------------------
@@ -72,9 +72,13 @@ erl_xcomp_configure_flags="--without-termcap --without-wx \
 #   Previously with older Android NDK versions before NDK r14, each Android
 #   API level had a different set of headers, each in its own directory.
 #NDK_SYSROOT=$NDK_ROOT/platforms/$NDK_PLAT/arch-arm
-#   Starting with Android NDK r14, a single set of headers (called Unified Headers)
-#   is provided in one location for every Android API level.
-NDK_SYSROOT=$NDK_ROOT/sysroot
+#   Starting with Android NDK r14, a single set of headers (called Unified
+#   Headers) is provided in one location for every Android API level.
+#NDK_SYSROOT=$NDK_ROOT/sysroot
+#   Starting with Android NDK r19, the actual sysroot path is not needed
+#   anymore as the NDK toolchain handles it implicitly.
+#   For reference: https://github.com/android/ndk/issues/1407
+#NDK_SYSROOT=$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot
 
 ## If the cross compilation tools are prefixed by `<HOST>-' you probably do
 ## not need to set these variables (where `<HOST>' is what has been passed as
@@ -187,7 +191,13 @@ LDFLAGS="-march=armv7-a -mfloat-abi=softfp -mthumb"
 #   skipped if the system root has not been set. The system root might be
 #   needed for other things too. If this is the case and the system root
 #   has not been set, `configure' will fail and request you to set it.
-erl_xcomp_sysroot="$NDK_SYSROOT"
+#
+#   Previously for older Android NDK versions before NDK r19.
+#erl_xcomp_sysroot="$NDK_SYSROOT"
+#   Starting with Android NDK r19, this path does not matter anymore
+#   as the NDK toolchain handles the sysroot directory implicitly.
+#   Set a value anyway to enable all applications as described above.
+erl_xcomp_sysroot=/sysroot/path/handled/by/the/Android/NDK
 
 
 # * `erl_xcomp_isysroot' - The absolute path to the system root for includes

--- a/xcomp/erl-xcomp-arm64-android.conf
+++ b/xcomp/erl-xcomp-arm64-android.conf
@@ -2,7 +2,7 @@
 ##
 ## %CopyrightBegin%
 ##
-## Copyright Ericsson AB 2019-2021. All Rights Reserved.
+## Copyright Ericsson AB 2019-2022. All Rights Reserved.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ erl_xcomp_host=aarch64-linux-android
 #   `configure' script.
 # Set --enable-builtin-zlib to avoid a inflateGetDictionary missing symbol
 erl_xcomp_configure_flags="--without-termcap --without-wx \
-                                          --enable-builtin-zlib"
+                           --enable-builtin-zlib"
 
 
 ## -- Cross Compiler and Other Tools -------------------------------------------
@@ -72,9 +72,13 @@ erl_xcomp_configure_flags="--without-termcap --without-wx \
 #   Previously with older Android NDK versions before NDK r14, each Android
 #   API level had a different set of headers, each in its own directory.
 #NDK_SYSROOT=$NDK_ROOT/platforms/$NDK_PLAT/arch-arm
-#   Starting with Android NDK r14, a single set of headers (called Unified Headers)
-#   is provided in one location for every Android API level.
-NDK_SYSROOT=$NDK_ROOT/sysroot
+#   Starting with Android NDK r14, a single set of headers (called Unified
+#   Headers) is provided in one location for every Android API level.
+#NDK_SYSROOT=$NDK_ROOT/sysroot
+#   Starting with Android NDK r19, the actual sysroot path is not needed
+#   anymore as the NDK toolchain handles it implicitly.
+#   For reference: https://github.com/android/ndk/issues/1407
+#NDK_SYSROOT=$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot
 
 ## If the cross compilation tools are prefixed by `<HOST>-' you probably do
 ## not need to set these variables (where `<HOST>' is what has been passed as
@@ -177,7 +181,13 @@ LD="aarch64-linux-android-ld"
 #   skipped if the system root has not been set. The system root might be
 #   needed for other things too. If this is the case and the system root
 #   has not been set, `configure' will fail and request you to set it.
-erl_xcomp_sysroot="$NDK_SYSROOT"
+#
+#   Previously for older Android NDK versions before NDK r19.
+#erl_xcomp_sysroot="$NDK_SYSROOT"
+#   Starting with Android NDK r19, this path does not matter anymore
+#   as the NDK toolchain handles the sysroot directory implicitly.
+#   Set a value anyway to enable all applications as described above.
+erl_xcomp_sysroot=/sysroot/path/handled/by/the/Android/NDK
 
 
 # * `erl_xcomp_isysroot' - The absolute path to the system root for includes

--- a/xcomp/erl-xcomp-arm64-android.conf
+++ b/xcomp/erl-xcomp-arm64-android.conf
@@ -127,7 +127,9 @@ CXX="aarch64-linux-$NDK_ABI_PLAT-clang++"
 LD="aarch64-linux-android-ld"
 
 # * `LDFLAGS' - Linker flags.
-#LDFLAGS=
+# Use the static version of libc++ provided by the Android NDK
+# when compiling the JIT flavor of the beam.smp executable.
+LDFLAGS="-static-libstdc++"
 
 # * `LIBS' - Libraries.
 #LIBS=

--- a/xcomp/erl-xcomp-arm64-android.conf
+++ b/xcomp/erl-xcomp-arm64-android.conf
@@ -62,7 +62,7 @@ erl_xcomp_host=aarch64-linux-android
 #   `configure' script.
 # Set --enable-builtin-zlib to avoid a inflateGetDictionary missing symbol
 erl_xcomp_configure_flags="--without-termcap --without-wx \
-                           --enable-builtin-zlib"
+                           --enable-builtin-zlib --enable-deterministic-build"
 
 
 ## -- Cross Compiler and Other Tools -------------------------------------------

--- a/xcomp/erl-xcomp-x86_64-android.conf
+++ b/xcomp/erl-xcomp-x86_64-android.conf
@@ -61,7 +61,7 @@ erl_xcomp_host=x86_64-linux-android
 # * `erl_xcomp_configure_flags' - Extra configure flags to pass to the
 #   `configure' script.
 erl_xcomp_configure_flags="--without-termcap --without-wx \
-                           --enable-builtin-zlib"
+                           --enable-builtin-zlib --enable-deterministic-build"
 
 ## -- Cross Compiler and Other Tools -------------------------------------------
 

--- a/xcomp/erl-xcomp-x86_64-android.conf
+++ b/xcomp/erl-xcomp-x86_64-android.conf
@@ -2,7 +2,7 @@
 ##
 ## %CopyrightBegin%
 ##
-## Copyright Ericsson AB 2021. All Rights Reserved.
+## Copyright Ericsson AB 2021-2022. All Rights Reserved.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -60,8 +60,8 @@ erl_xcomp_host=x86_64-linux-android
 
 # * `erl_xcomp_configure_flags' - Extra configure flags to pass to the
 #   `configure' script.
-erl_xcomp_configure_flags="--disable-hipe --without-termcap --without-wx \
-                                          --enable-builtin-zlib"
+erl_xcomp_configure_flags="--without-termcap --without-wx \
+                           --enable-builtin-zlib"
 
 ## -- Cross Compiler and Other Tools -------------------------------------------
 
@@ -155,7 +155,11 @@ LD=x86_64-linux-android-ld.gold
 #   skipped if the system root has not been set. The system root might be
 #   needed for other things too. If this is the case and the system root
 #   has not been set, `configure' will fail and request you to set it.
-erl_xcomp_sysroot="$NDK_ROOT/sys_root"
+#
+#   Starting with Android NDK r19, this path does not matter anymore
+#   as the NDK toolchain handles the sysroot directory implicitly.
+#   Set a value anyway to enable all applications as described above.
+erl_xcomp_sysroot=/sysroot/path/handled/by/the/Android/NDK
 
 # * `erl_xcomp_isysroot' - The absolute path to the system root for includes
 #   of the cross compilation environment. If not set, this value defaults

--- a/xcomp/erl-xcomp-x86_64-android.conf
+++ b/xcomp/erl-xcomp-x86_64-android.conf
@@ -101,7 +101,9 @@ CXX=x86_64-linux-$NDK_ABI_PLAT-clang++
 LD=x86_64-linux-android-ld.gold
 
 # * `LDFLAGS' - Linker flags.
-#LDFLAGS=
+# Use the static version of libc++ provided by the Android NDK
+# when compiling the JIT flavor of the beam.smp executable.
+LDFLAGS="-static-libstdc++"
 
 # * `LIBS' - Libraries.
 #LIBS=


### PR DESCRIPTION
* Update the cross compilation for newer versions of the Android NDK

* Use the static version of libc++ on Android

Remove the runtime dependency on libc++_shared.so for the JIT flavor of beam.smp. This simplifies Erlang deployment on Android as libc++ is not provided as a system library. See https://developer.android.com/ndk/guides/cpp-support

* Switch to deterministic builds for Android