### PR TITLE
Ensure that is_binary(BigNum) does not return true

### DIFF
--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -689,7 +689,7 @@ arm::Gp BeamModuleAssembler::emit_is_binary(const ArgLabel &Fail,
     a.cmp(TMP1, imm(_TAG_HEADER_SUB_BIN));
     a.b_eq(subbin);
 
-    if (masked_types(Src, BEAM_TYPE_MASK_ALWAYS_BOXED) == BEAM_TYPE_BITSTRING) {
+    if (masked_types(Src, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_BITSTRING) {
         comment("simplified binary test since source is always a bitstring "
                 "when boxed");
     } else {

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -825,7 +825,7 @@ x86::Gp BeamModuleAssembler::emit_is_binary(const ArgLabel &Fail,
     a.cmp(RETb, imm(_TAG_HEADER_SUB_BIN));
     a.short_().je(subbin);
 
-    if (masked_types(Src, BEAM_TYPE_MASK_ALWAYS_BOXED) == BEAM_TYPE_BITSTRING) {
+    if (masked_types(Src, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_BITSTRING) {
         comment("simplified binary test since source is always a bitstring "
                 "when boxed");
     } else {


### PR DESCRIPTION
An unsafe type-based optimization in the JIT could cause the
`is_binary/1` guard test to succeed when its argument was a bignum.

Closes #6239