### PR TITLE
erts: Fix large read/writes on macOS 

### DIFF
--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -3736,7 +3736,7 @@ static int examine_iovec_term(Eterm list, UWord max_length, iovec_slice_t *resul
                 result->referenced_size += byte_size;
             }
 
-            result->iovec_len += 1 + byte_size / MAX_SYSIOVEC_IOVLEN;
+            result->iovec_len += (MAX_SYSIOVEC_IOVLEN - 1 + byte_size) / MAX_SYSIOVEC_IOVLEN;
         }
 
         result->sublist_length += 1;

--- a/erts/emulator/nifs/unix/unix_prim_file.c
+++ b/erts/emulator/nifs/unix/unix_prim_file.c
@@ -42,6 +42,8 @@
 
 #include <utime.h>
 
+#define FALLBACK_RW_LENGTH ((1ull << 31) - 1)
+
 /* Macros for testing file types. */
 #ifdef NO_UMASK
 #define FILE_MODE 0644
@@ -284,6 +286,11 @@ Sint64 efile_readv(efile_data_t *d, SysIOVec *iov, int iovlen) {
 
         if(use_fallback) {
             result = read(u->fd, iov->iov_base, iov->iov_len);
+
+            /* Some OSs (e.g. macOS) does not allow reads greater than 2 GB,
+               so if we get EINVAL in the fallback, we try with a smaller length */
+            if (result < 0 && errno == EINVAL && iov->iov_len > FALLBACK_RW_LENGTH)
+                result = read(u->fd, iov->iov_base, FALLBACK_RW_LENGTH);
         }
 
         if(result > 0) {
@@ -329,6 +336,11 @@ Sint64 efile_writev(efile_data_t *d, SysIOVec *iov, int iovlen) {
 
         if(use_fallback) {
             result = write(u->fd, iov->iov_base, iov->iov_len);
+
+            /* Some OSs (e.g. macOS) does not allow writes greater than 2 GB,
+               so if we get EINVAL in the fallback, we try with a smaller length */
+            if (result < 0 && errno == EINVAL && iov->iov_len > FALLBACK_RW_LENGTH)
+                result = write(u->fd, iov->iov_base, FALLBACK_RW_LENGTH);
         }
 
         if(result > 0) {

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -4130,6 +4130,10 @@ do_large_write(Name) ->
 	    Bin = <<0:Size/unit:8>>,
 	    ok = file:write_file(Name, Bin),
 	    {ok,#file_info{size=Size}} = file:read_file_info(Name),
+
+            %% Even multiples of MAX_SYSIOVEC_IOVLEN would cause a crash
+            ok = file:write_file(Name, binary:part(Bin, 0, 1 bsl 31)),
+	    {ok,#file_info{size=1 bsl 31}} = file:read_file_info(Name),
 	    ok
     end.
 


### PR DESCRIPTION
On macOS there is an (as far as I can tell) undocumented limitation
for read and write that the size is not allowed to be greater than
2GB. So if we get an EINVAL from read/write and the size is > 2GB
we try again with a smaller size.

Closes https://github.com/erlang/otp/issues/6242