### PR TITLE
Introduce file:flock/2

### DIFF
--- a/erts/emulator/nifs/common/prim_file_nif.c
+++ b/erts/emulator/nifs/common/prim_file_nif.c
@@ -59,6 +59,12 @@ static ERL_NIF_TERM am_skip_type_check;
 static ERL_NIF_TERM am_read_write;
 static ERL_NIF_TERM am_none;
 
+/* Lock modes */
+static ERL_NIF_TERM am_shared;
+// static ERL_NIF_TERM am_exclusive;
+static ERL_NIF_TERM am_non_blocking;
+static ERL_NIF_TERM am_unlock;
+
 /* enum efile_advise_t */
 static ERL_NIF_TERM am_normal;
 static ERL_NIF_TERM am_random;
@@ -101,6 +107,8 @@ static ERL_NIF_TERM read_file_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
 
 static ERL_NIF_TERM open_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM close_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
+static ERL_NIF_TERM flock_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
 static ERL_NIF_TERM file_desc_to_ref_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
@@ -158,6 +166,7 @@ static ERL_NIF_TERM file_handle_wrapper(file_op_impl_t operation, ErlNifEnv *env
         return file_handle_wrapper( name ## _impl , env, argc, argv); \
     }
 
+WRAP_FILE_HANDLE_EXPORT(flock_nif)
 WRAP_FILE_HANDLE_EXPORT(read_nif)
 WRAP_FILE_HANDLE_EXPORT(write_nif)
 WRAP_FILE_HANDLE_EXPORT(pread_nif)
@@ -175,6 +184,7 @@ static ErlNifFunc nif_funcs[] = {
     /* File handle ops */
     {"open_nif", 2, open_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"close_nif", 1, close_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"flock_nif", 2, flock_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"read_nif", 2, read_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"write_nif", 2, write_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"pread_nif", 3, pread_nif, ERL_NIF_DIRTY_JOB_IO_BOUND},
@@ -247,6 +257,10 @@ static int load(ErlNifEnv *env, void** priv_data, ERL_NIF_TERM prim_file_pid)
 
     am_read_write = enif_make_atom(env, "read_write");
     am_none = enif_make_atom(env, "none");
+
+    am_shared = enif_make_atom(env, "shared");
+    am_non_blocking = enif_make_atom(env, "non_blocking");
+    am_unlock = enif_make_atom(env, "unlock");
 
     am_normal = enif_make_atom(env, "normal");
     am_random = enif_make_atom(env, "random");
@@ -535,6 +549,29 @@ static enum efile_modes_t efile_translate_modelist(ErlNifEnv *env, ERL_NIF_TERM 
     return modes;
 }
 
+static enum efile_lock_t efile_translate_locklist(ErlNifEnv *env, ERL_NIF_TERM list) {
+    enum efile_lock_t modes;
+    ERL_NIF_TERM head, tail;
+
+    modes = 0;
+
+    while(enif_get_list_cell(env, list, &head, &tail)) {
+        if(enif_is_identical(head, am_shared)) {
+            modes |= EFILE_LOCK_SH;
+        } else if(enif_is_identical(head, am_exclusive)) {
+            modes |= EFILE_LOCK_EX;
+        } else if(enif_is_identical(head, am_non_blocking)) {
+            modes |= EFILE_LOCK_NB;
+        } else if(enif_is_identical(head, am_unlock)) {
+            modes |= EFILE_LOCK_UN;
+        }
+
+        list = tail;
+    }
+
+    return modes;
+}
+
 static ERL_NIF_TERM create_ref_or_error_tuple(ErlNifEnv *env, efile_data_t *d) {
     ErlNifPid controlling_process;
     ERL_NIF_TERM result;
@@ -641,6 +678,21 @@ static ERL_NIF_TERM close_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
 
         return posix_error_to_tuple(env, EINVAL);
     }
+}
+
+static ERL_NIF_TERM flock_nif_impl(efile_data_t *d, ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    posix_errno_t error;
+    enum efile_lock_t modes;
+
+    ASSERT(argc == 1);
+
+    modes = efile_translate_locklist(env, argv[0]);
+
+    if(!efile_flock(d, modes, &error)) {
+        return posix_error_to_tuple(env, error);
+    }
+
+    return am_ok;
 }
 
 static ERL_NIF_TERM read_nif_impl(efile_data_t *d, ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {

--- a/erts/emulator/nifs/common/prim_file_nif.h
+++ b/erts/emulator/nifs/common/prim_file_nif.h
@@ -58,6 +58,13 @@ enum efile_filetype_t {
     EFILE_FILETYPE_OTHER
 };
 
+enum efile_lock_t {
+    EFILE_LOCK_SH = (1 << 0),
+    EFILE_LOCK_EX = (1 << 1),
+    EFILE_LOCK_NB = (1 << 2),
+    EFILE_LOCK_UN = (1 << 3)
+};
+
 enum efile_advise_t {
     EFILE_ADVISE_NORMAL,
     EFILE_ADVISE_RANDOM,
@@ -178,6 +185,16 @@ posix_errno_t efile_from_fd(int fd,
  * Note that the file is completely invalid after this point, so the error code
  * is provided in \c error rather than d->posix_errno. */
 int efile_close(efile_data_t *d, posix_errno_t *error);
+
+/** @brief Locks a file for shared or exclusive access. On Unix flock(2)
+ * system call is used. On Windows LockFileEx and UnlockFileEx win32 API calls
+ * are used respectively over the entire range of file.
+ * 
+ * Note that on Windows it is possible to hold both shared and exclusive locks over
+ * the same file region. In such case two unlock operations are necessary.
+ * Note that on Unix upgrading a shared to an exclusive lock is not atomic.
+ * */
+int efile_flock(efile_data_t *d, enum efile_lock_t modes, posix_errno_t *error);
 
 /* **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** */
 

--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -267,6 +267,25 @@
       </desc>
     </func>
     <func>
+      <name name="flock" arity="2" since="OTP 26"/>
+      <fsummary>Locks or unlocks a file for shared or exclusive access.</fsummary>
+      <desc>
+        <p>Locks the file referenced by <c><anno>IoDevice</anno></c>. Returns <c>ok</c>
+          if the operation succedes or <c>{error, atom()}</c> otherwise.</p>
+        <p>If the flag <c>unlock</c> is set then the function unlocks the file.</p>
+        <p>On Unix shared locks can be upgraded to exclusive and vice versa.
+          Note however, that it is not atomic.</p>
+        <p>On Unix this function uses <c>flock(2)</c> syscall</p>
+        <p>On Windows one process can hold both shared and exclusive locks
+          over the same file range. This situation needs two unlock operations.</p>
+        <p>On Windows this function uses <c>LockFileEx</c> and <c>UnlokcFileEx</c>
+          win32 API calls</p>
+        <p>Notice that unless option <c>non_blocking</c> was
+          set, <c>flock/2</c> may block if the file is already locked by
+          some other operating system process with an incompatible lock type.</p>
+      </desc>
+    </func>
+    <func>
       <name name="consult" arity="1" since=""/>
       <fsummary>Read Erlang terms from a file.</fsummary>
       <desc>

--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -39,7 +39,7 @@
 %% Specialized
 -export([ipread_s32bu_p32bu/3]).
 %% Generic file contents.
--export([open/2, close/1, advise/4, allocate/3,
+-export([open/2, close/1, flock/2, advise/4, allocate/3,
 	 read/2, write/2, 
 	 pread/2, pread/3, pwrite/2, pwrite/3,
 	 read_line/1,
@@ -560,6 +560,24 @@ close(File) when is_pid(File) ->
 close(#file_descriptor{module = Module} = Handle) ->
     Module:close(Handle);
 close(_) ->
+    {error, badarg}.
+
+-spec flock(IoDevice, Flags) -> ok | {error, Reason} when
+      IoDevice :: io_device(),
+      Flags :: list(Flag),
+      Flag :: shared | exclusive | non_blocking | unlock,
+      Reason :: posix() | badarg | terminated.
+
+flock(File, Flags) when is_pid(File) ->
+    case file_request(File, {flock, Flags}) of
+	{error, terminated} ->
+	    ok;
+	Other ->
+	    Other
+    end;
+flock(#file_descriptor{module = Module} = Handle, Flags) ->
+    Module:flock(Handle, Flags);
+flock(_, _) ->
     {error, badarg}.
 
 -spec advise(IoDevice, Offset, Length, Advise) -> ok | {error, Reason} when

--- a/lib/kernel/src/file_io_server.erl
+++ b/lib/kernel/src/file_io_server.erl
@@ -235,6 +235,10 @@ file_request({allocate, Offset, Length},
          #state{handle = Handle} = State) ->
     Reply = ?CALL_FD(Handle, allocate, [Offset, Length]),
     {reply, Reply, State};
+file_request({flock, Flags},
+         #state{handle = Handle} = State) ->
+    Reply = ?CALL_FD(Handle, flock, [Flags]),
+    {reply, Reply, State};
 file_request({pread,At,Sz}, State)
   when At =:= cur;
        At =:= {cur,0} ->

--- a/lib/kernel/src/raw_file_io_list.erl
+++ b/lib/kernel/src/raw_file_io_list.erl
@@ -19,7 +19,7 @@
 %%
 -module(raw_file_io_list).
 
--export([close/1, sync/1, datasync/1, truncate/1, advise/4, allocate/3,
+-export([close/1, flock/2, sync/1, datasync/1, truncate/1, advise/4, allocate/3,
          position/2, write/2, pwrite/2, pwrite/3,
          read_line/1, read/2, pread/2, pread/3,
          read_handle_info/2]).
@@ -49,6 +49,10 @@ make_public_fd(PrivateFd, Modes) ->
 close(Fd) ->
     PrivateFd = Fd#file_descriptor.data,
     ?CALL_FD(PrivateFd, close, []).
+
+flock(Fd, Opts) ->
+    PrivateFd = Fd#file_descriptor.data,
+    ?CALL_FD(PrivateFd, flock, [Opts]).
 
 sync(Fd) ->
     PrivateFd = Fd#file_descriptor.data,


### PR DESCRIPTION
This PR extends `file` module with new function `flock/2`. It allows locking files for shared or exclusive access on Unix and Windows.

Rationale: Currently the OTP lacks suitable APIs allowing fine grained control over access to filesystem. Those can be especially useful for applications like language tools, compilers (e.g. elixir compiler), IDEs (like language servers) that share access to the same filesystem directories.

Please note that this is a first draft that received only a little testing on macOS platform. I would like to get some guidance if the direction I took is acceptable and if the OTP Team would be interested in merging this. The documentation will also need further improvements.

Related manpages and documentation:
1. https://linux.die.net/man/2/flock
2. https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/flock.2.html
3. http://www.polarhome.com/service/man/?qf=flock&tf=2&of=Solaris&sf=3UCB
4. https://www.freebsd.org/cgi/man.cgi?query=flock&sektion=2
5. https://man.openbsd.org/flock.2
6. https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
7. https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-unlockfileex
8. https://docs.microsoft.com/en-us/windows/win32/fileio/locking-and-unlocking-byte-ranges-in-files

CC @josevalim 