### PR TITLE
logger: Print to stderr if printing to stdout failed

### DIFF
--- a/lib/kernel/src/logger_std_h.erl
+++ b/lib/kernel/src/logger_std_h.erl
@@ -507,6 +507,15 @@ ensure_open(Filename, Modes) ->
             exit({could_not_create_dir_for_file,Error})
     end.
 
+write_to_dev(Bin,#{dev:=standard_io}=State) ->
+    try
+        io:put_chars(user, Bin)
+    catch _E:_R ->
+            io:put_chars(
+              standard_error, "Failed to write log message to stdout, trying stderr\n"),
+            io:put_chars(standard_error, Bin)
+    end,
+    State;
 write_to_dev(Bin,#{dev:=DevName}=State) ->
     io:put_chars(DevName, Bin),
     State;


### PR DESCRIPTION
If we cannot print to standard_io we try to instead print
to standard_error just to make sure that the error log message
is printed.

We know that group_leader will always point to the kernel application
master and thus we will be forwarded to 'user' eventutally, so we
can short circuit there. As a bonus we also now get to know if
user or user_drv has crashed and the io:put_chars call can fail.