### PR TITLE
Improve interval timer handling

### DIFF
--- a/lib/stdlib/doc/src/timer.xml
+++ b/lib/stdlib/doc/src/timer.xml
@@ -122,7 +122,15 @@
           finish before starting the next.</p>
         <p>If the execution time of the spawned process is greater than the
           given <c><anno>Time</anno></c>, the next process is spawned immediately
-          after the one currently running has finished.</p>
+          after the one currently running has finished. Assuming that execution
+          times of the spawned processes performing the applies on average
+          are smaller than <c><anno>Time</anno></c>, the amount of applies
+          made over a large amount of time will be the same even if some
+          individual execution times are larger than
+          <c><anno>Time</anno></c>. The system will try to catch up as soon
+          as possible. For example, if one apply takes
+          <c>2.5*<anno>Time</anno></c>, the following two applies will be
+          made immediately one after the other in sequence.</p>
         <p>Returns <c>{ok, <anno>TRef</anno>}</c> or
           <c>{error, <anno>Reason</anno>}</c>.</p>
       </desc>

--- a/lib/stdlib/doc/src/timer.xml
+++ b/lib/stdlib/doc/src/timer.xml
@@ -71,10 +71,10 @@
   <funcs>
     <func>
       <name name="apply_after" arity="4" since=""/>
-      <fsummary>Apply <c>Module:Function(Arguments)</c> after a specified
-        <c>Time</c>.</fsummary>
+      <fsummary>Spawn a process evaluating <c>Module:Function(Arguments)</c>
+        after a specified <c>Time</c>.</fsummary>
       <desc>
-        <p>Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
+        <p>Evaluates <c>spawn(<anno>Module</anno>, <anno>Function</anno>,
           <anno>Arguments</anno>)</c> after <c><anno>Time</anno></c>
           milliseconds.</p>
         <p>Returns <c>{ok, <anno>TRef</anno>}</c> or
@@ -84,12 +84,45 @@
 
     <func>
       <name name="apply_interval" arity="4" since=""/>
-      <fsummary>Evaluate <c>Module:Function(Arguments)</c> repeatedly at
-        intervals of <c>Time</c>.</fsummary>
+      <fsummary>Spawn a process evaluating <c>Module:Function(Arguments)</c>
+        repeatedly at intervals of <c>Time</c>.</fsummary>
       <desc>
-        <p>Evaluates <c>apply(<anno>Module</anno>, <anno>Function</anno>,
+        <p>Evaluates <c>spawn(<anno>Module</anno>, <anno>Function</anno>,
           <anno>Arguments</anno>)</c> repeatedly at intervals of
-          <c><anno>Time</anno></c>.</p>
+          <c><anno>Time</anno></c>, irrespective of whether a previously
+          spawned process has finished or not.</p>
+        <warning>
+          <p>If the execution time of the spawned process is, on average,
+            greater than the given <c><anno>Time</anno></c>, multiple such
+            processes will run at the same time. With long execution times,
+            short intervals, and many interval timers running, this may even
+            lead to exceeding the number of allowed processes. As an extreme
+            example, consider
+            <c>[timer:apply_interval(1, timer, sleep, [1000]) || _ &lt;- lists:seq(1, 1000)]</c>,
+            that is, 1,000 interval timers executing a process that takes 1s
+            to complete, started in intervals of 1ms, which would result in
+            1,000,000 processes running at the same time, far more than a node
+            started with default settings allows (see the
+            <seeguide marker="system/efficiency_guide:advanced#system-limits">System
+            Limits section in the Effiency Guide</seeguide>).</p>
+        </warning>
+        <p>Returns <c>{ok, <anno>TRef</anno>}</c> or
+          <c>{error, <anno>Reason</anno>}</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="apply_repeatedly" arity="4" since="OTP @OTP-18236@"/>
+      <fsummary>Spawn a process evaluating <c>Module:Function(Arguments)</c>
+        repeatedly at intervals of <c>Time</c>.</fsummary>
+      <desc>
+        <p>Evaluates <c>spawn(<anno>Module</anno>, <anno>Function</anno>,
+          <anno>Arguments</anno>)</c> repeatedly at intervals of
+          <c><anno>Time</anno></c>, waiting for the spawned process to
+          finish before starting the next.</p>
+        <p>If the execution time of the spawned process is greater than the
+          given <c><anno>Time</anno></c>, the next process is spawned immediately
+          after the one currently running has finished.</p>
         <p>Returns <c>{ok, <anno>TRef</anno>}</c> or
           <c>{error, <anno>Reason</anno>}</c>.</p>
       </desc>

--- a/lib/stdlib/test/timer_simple_SUITE.erl
+++ b/lib/stdlib/test/timer_simple_SUITE.erl
@@ -51,7 +51,11 @@
          kill_after2/1,
          kill_after3/1,
          apply_interval1/1,
+         apply_interval2/1,
          apply_interval_invalid_args/1,
+         apply_repeatedly1/1,
+         apply_repeatedly2/1,
+         apply_repeatedly_invalid_args/1,
          send_interval1/1,
          send_interval2/1,
          send_interval3/1,
@@ -95,6 +99,7 @@ all() ->
         {group, exit_after},
         {group, kill_after},
         {group, apply_interval},
+        {group, apply_repeatedly},
         {group, send_interval},
         {group, cancel},
         {group, sleep},
@@ -152,7 +157,17 @@ groups() ->
             [],
             [
                 apply_interval1,
+                apply_interval2,
                 apply_interval_invalid_args
+            ]
+        },
+        {
+            apply_repeatedly,
+            [],
+            [
+                apply_repeatedly1,
+                apply_repeatedly2,
+                apply_repeatedly_invalid_args
             ]
         },
         {
@@ -406,12 +421,67 @@ apply_interval1(Config) when is_list(Config) ->
     {ok, cancel} = timer:cancel(Ref),
     nor = get_mess(1000, Msg).
 
+%% Test apply_interval with the execution time of the action
+%% longer than the timer interval. The timer should not wait for
+%% the action to complete, ie start another action while the
+%% previously started action is still running.
+apply_interval2(Config) when is_list(Config) ->
+    Msg = make_ref(),
+    Self = self(),
+    {ok, Ref} = timer:apply_interval(500, erlang, apply,
+                                     [fun() ->
+                                          Self ! Msg,
+                                          receive after 1000 -> ok end
+                                      end, []]),
+    receive after 1800 -> ok end,
+    {ok, cancel} = timer:cancel(Ref),
+    ok = get_mess(1000, Msg, 3),
+    nor = get_mess(1000, Msg).
+
 %% Test that apply_interval rejects invalid arguments.
 apply_interval_invalid_args(Config) when is_list(Config) ->
     {error, badarg} = timer:apply_interval(-1, foo, bar, []),
     {error, badarg} = timer:apply_interval(0, "foo", bar, []),
     {error, badarg} = timer:apply_interval(0, foo, "bar", []),
     {error, badarg} = timer:apply_interval(0, foo, bar, baz),
+    ok.
+
+%% Test of apply_repeatedly by sending messages. Receive
+%% 3 messages, cancel the timer, and check that we do
+%% not get any more messages. In a case like this, ie where
+%% the execution time of the action is shorter than the timer
+%% interval, this should behave the same as apply_interval.
+apply_repeatedly1(Config) when is_list(Config) ->
+    Msg = make_ref(),
+    {ok, Ref} = timer:apply_repeatedly(1000, ?MODULE, send,
+                                       [self(), Msg]),
+    ok = get_mess(1500, Msg, 3),
+    {ok, cancel} = timer:cancel(Ref),
+    nor = get_mess(1000, Msg).
+
+%% Test apply_repeatedly with the execution time of the action
+%% longer than the timer interval. The timer should wait for
+%% the action to complete, ie not start another action until it
+%% has completed.
+apply_repeatedly2(Config) when is_list(Config) ->
+    Msg = make_ref(),
+    Self = self(),
+    {ok, Ref} = timer:apply_repeatedly(1, erlang, apply,
+                                       [fun() ->
+                                            Self ! Msg,
+                                            receive after 1000 -> ok end
+                                        end, []]),
+    receive after 2500 -> ok end,
+    {ok, cancel} = timer:cancel(Ref),
+    ok = get_mess(1000, Msg, 3),
+    nor = get_mess(1000, Msg).
+
+%% Test that apply_repeatedly rejects invalid arguments.
+apply_repeatedly_invalid_args(Config) when is_list(Config) ->
+    {error, badarg} = timer:apply_repeatedly(-1, foo, bar, []),
+    {error, badarg} = timer:apply_repeatedly(0, "foo", bar, []),
+    {error, badarg} = timer:apply_repeatedly(0, foo, "bar", []),
+    {error, badarg} = timer:apply_repeatedly(0, foo, bar, baz),
     ok.
 
 %% Test of send_interval/2. Receive 5 messages, cancel the timer, and


### PR DESCRIPTION
This PR was inspired and is competing (to a degree) with #6145.

With the current (old) implementation, the apply messages resultingh from interval timers were handled by the timer server process itself, which may lead to its congestion. Specifically, it has been noticed that, with many short-interval timers running, starting as cancelling of timers takes longer and longer, stalling the calling process.

The changes in this PR run each interval timer in a separate process, so their apply messages don't compete with other (start/cancel/etc) messages. This reduces the load of the timer server, and at the same time reduces the tendency of interval timers to lag.