### PR TITLE
kernel: Add support for expand after current line

### DIFF
--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -574,6 +574,7 @@ do_break(void)
 {
     const char *helpstring = "BREAK: (a)bort (A)bort with dump (c)ontinue (p)roc info (i)nfo\n"
         "       (l)oaded (v)ersion (k)ill (D)b-tables (d)istribution\n";
+    char *clearscreen = "\E[J";
     int i;
 #ifdef __WIN32__
     char *mode; /* enough for storing "window" */
@@ -588,7 +589,14 @@ do_break(void)
 
     ASSERT(erts_thr_progress_is_blocking());
 
-    erts_printf("\n%s", helpstring);
+    /* If we are writing to something known to be a tty we clear the screen
+       after doing newline as the shell tab completion may have written
+       things there. */
+    if (!isatty(fileno(stdin)) || !isatty(fileno(stdout))) {
+        clearscreen = "";
+    }
+
+    erts_printf("\n%s%s", clearscreen, helpstring);
 
     while (1) {
 	if ((i = sys_get_key(0)) <= 0)

--- a/lib/kernel/src/kernel.app.src
+++ b/lib/kernel/src/kernel.app.src
@@ -158,6 +158,7 @@
          {shell_docs_ansi,auto}
         ]},
   {mod, {kernel, []}},
-  {runtime_dependencies, ["erts-13.1", "stdlib-@OTP-17932@", "sasl-3.0", "crypto-5.0"]}
+  {runtime_dependencies, ["erts-@OTP-18248@", "stdlib-@OTP-17932@",
+                          "sasl-3.0", "crypto-5.0"]}
   ]
 }.

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -1068,7 +1068,7 @@ external_editor_visual(Config) ->
                 check_content(Term, "4>"),
                 send_tty(Term,"\"hello"),
                 send_tty(Term, "C-O"), %% Open vim
-                check_content(Term, "\"hello"),
+                check_content(Term, "^\"hello"),
                 send_tty(Term, "$"), %% Set cursor at end
                 send_tty(Term, "a"), %% Enter insert mode at end
                 check_content(Term, "-- INSERT --"),

--- a/lib/kernel/test/rtnode.erl
+++ b/lib/kernel/test/rtnode.erl
@@ -124,7 +124,7 @@ timeout(long) ->
 timeout(short) ->
     timeout(normal) div 10;
 timeout(normal) ->
-    1000 * test_server:timetrap_scale_factor().
+    10000 * test_server:timetrap_scale_factor().
 
 send_commands(Node, CPid, [{sleep, X}|T], N) ->
     ?dbg({sleep, X}),

--- a/lib/ssh/src/ssh_cli.erl
+++ b/lib/ssh/src/ssh_cli.erl
@@ -670,7 +670,9 @@ start_shell(ConnectionHandler, State) ->
             {_,_,_} = Shell ->
                 Shell
         end,
-    State#state{group = group:start(self(), ShellSpawner, [{echo, get_echo(State#state.pty)}]),
+    State#state{group = group:start(self(), ShellSpawner,
+                                    [{expand_below, false},
+                                     {echo, get_echo(State#state.pty)}]),
                 buf = empty_buf()}.
 
 %%--------------------------------------------------------------------
@@ -691,7 +693,8 @@ start_exec_shell(ConnectionHandler, Cmd, State) ->
             {M,F,A} ->
                 {M, F, A++[Cmd]}
         end,
-    State#state{group = group:start(self(), ExecShellSpawner, [{echo,false}]),
+    State#state{group = group:start(self(), ExecShellSpawner, [{expand_below, false},
+                                                               {echo,false}]),
                 buf = empty_buf()}.
 
 %%--------------------------------------------------------------------
@@ -775,7 +778,8 @@ exec_in_self_group(ConnectionHandler, ChannelId, WantReply, State, Fun) ->
                           end
                   end)
         end,
-    {ok, State#state{group = group:start(self(), Exec, [{echo,false}]),
+    {ok, State#state{group = group:start(self(), Exec, [{expand_below, false},
+                                                        {echo,false}]),
                      buf = empty_buf()}}.
     
 

--- a/lib/stdlib/doc/src/stdlib_app.xml
+++ b/lib/stdlib/doc/src/stdlib_app.xml
@@ -57,6 +57,11 @@
         <p>Can be used to set the exception handling of the evaluator process of
           Erlang shell.</p>
       </item>
+      <tag><marker id="shell_expand_location"/><c>shell_expand_location = above | below</c></tag>
+      <item>
+          <p>Sets where the tab expansion text should appear in the shell.
+            The default is <c>below</c>.</p>
+      </item>
       <tag><marker id="shell_history_length"/><c>shell_history_length = integer() >= 0</c></tag>
       <item>
         <p>Can be used to determine how many commands are saved by the Erlang

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -116,10 +116,14 @@ edit([C|Cs], P, {Bef,Aft}, Prefix, Rs0) ->
             Rs1 = erase(P, Bef, Aft, Rs0),
             Rs = redraw(P, Bef, Aft, Rs1),
             edit(Cs, P, {Bef,Aft}, none, Rs);
-        tab_expand ->
-            {expand, Bef, Cs,
-            {line, P, {Bef, Aft}, none},
-            reverse(Rs0)};
+	tab_expand ->
+	    {expand, Bef, Cs,
+	     {line, P, {Bef, Aft}, tab_expand},
+	     reverse(Rs0)};
+        tab_expand_full ->
+            {expand_full, Bef, Cs,
+	     {line, P, {Bef, Aft}, tab_expand},
+	     reverse(Rs0)};
         {undefined,C} ->
             {undefined,{none,Prefix,C},Cs,{line,P,{Bef,Aft},none},
             reverse(Rs0)};
@@ -172,6 +176,8 @@ key_map($\^E, none) -> end_of_line;
 key_map($\^F, none) -> forward_char;
 key_map($\^H, none) -> backward_delete_char;
 key_map($\t, none) -> tab_expand;
+key_map($\t, tab_expand) -> tab_expand_full;
+key_map(C, tab_expand) -> key_map(C, none);
 key_map($\^K, none) -> kill_line;
 key_map($\^L, none) -> redraw_line;
 key_map($\n, none) -> new_line;

--- a/lib/stdlib/src/edlin_expand.erl
+++ b/lib/stdlib/src/edlin_expand.erl
@@ -22,7 +22,7 @@
 %% filepaths, variable binding, record names, function parameter values,
 %% record fields and map keys and record field values.
 -include_lib("kernel/include/eep48.hrl").
--export([expand/1, expand/2, expand/3, format_matches/2, get_exports/1,
+-export([expand/1, expand/2, expand/3, format_matches/2, number_matches/1, get_exports/1,
          shell_default_or_bif/1, bif/1, over_word/1]).
 -export([is_type/3, match_arguments1/3]).
 -record(shell_state,{
@@ -1130,6 +1130,13 @@ field_width([], W, LL) when W < LL ->
     W + 4;
 field_width([], _, LL) ->
     LL.
+
+number_matches([#{ elems := Matches }|T]) ->
+    number_matches(Matches) + number_matches(T);
+number_matches([_|T]) ->
+    1 + number_matches(T);
+number_matches([]) ->
+    0.
 
 %% Strings are handled naively, but it should be OK here.
 longest_common_head([]) ->

--- a/lib/stdlib/test/shell_SUITE.erl
+++ b/lib/stdlib/test/shell_SUITE.erl
@@ -3107,9 +3107,9 @@ start_interactive_shell(ExtraArgs) ->
        {eval, fun() -> shell:start_interactive(noshell) end},
        {eval, fun() -> io:format(user,"~ts",[io:get_line(user, "")]) end},
        {expect, "test\\."},
-       {putline, "test."},
        {eval, fun() -> shell:start_interactive() end},
        {expect, "1>"},
+       {putline, "test."},
        {expect, "2>"}
       ],[],"",["-noinput","-eval","io:format(\"eval_test~n\")"] ++ ExtraArgs),
 


### PR DESCRIPTION
This PR changes the tab-completion location to be after the current cursor instead of before. It is possible to configure the behaviour to work as it did before by setting the `stdlib` application parameter `shell_expand_location` to either `above` or `below`.

[![asciicast](https://asciinema.org/a/4tDMbPksWndZ6vApbsOUl1viL.svg)](https://asciinema.org/a/4tDMbPksWndZ6vApbsOUl1viL)