### PR TITLE
kernel: Fix standard_error config race

### DIFF
--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -216,8 +216,9 @@ init_term(State = #state{ tty = TTY, options = Options }) ->
         case maps:get(tty, Options) of
             true ->
                 ok = tty_init(TTY, stdout, Options),
+                NewTTYState = init(State, os:type()),
                 ok = tty_set(TTY),
-                init(State, os:type());
+                NewTTYState;
             false ->
                 State
         end,


### PR DESCRIPTION
When starting a shell using start:interactive_shell, standard_error
would not be correctly configured to use the correct newline sequence
when the shell was started causing staggering printouts.

    erl -noshell -eval 'shell:start_interactive(), io:put_chars(standard_error, "oops\noops").'
    oops
        oopsErlang/OTP 26

Closes #6263