### PR TITLE
Adjust language around the usage of receive in a gen_statem.

### DIFF
--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -1918,7 +1918,7 @@ do_unlock() ->
       Using a receive with a catch all match may result in system messages
       being discarded which in turn may lead to unexpected behaviour.
       If a selective receive must be used then great care should be taken to
-      ensure messages only messages pertitnent to the operation are caught.
+      ensure messages only messages pertinent to the operation are caught.
       Likewise, long running operations may result in timeouts and the
       deferment of system messages, which in turn can lead to undesirable behaviour;
       thus a reasonable timeout for any blocking operation should be used.

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -1918,7 +1918,7 @@ do_unlock() ->
       Using such a receive may result in system messages
       being discarded which in turn may lead to unexpected behaviour.
       If a selective receive must be used then great care should be taken to
-      ensure messages only messages pertinent to the operation are caught.
+      ensure only messages pertinent to the operation are caught.
       Likewise, long running operations may result in timeouts and the
       deferment of system messages, which in turn can lead to undesirable behaviour;
       thus a reasonable timeout for any blocking operation should be used.

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -1915,7 +1915,7 @@ do_unlock() ->
       A catch-all receive should never be used from a <c>gen_statem</c>
       behaviour (or from any <c>gen_*</c> behaviour),
       as the receive statement is within the <c>gen_*</c> engine itself.
-      Using a receive with a catch all match may result in system messages
+      Using such a receive may result in system messages
       being discarded which in turn may lead to unexpected behaviour.
       If a selective receive must be used then great care should be taken to
       ensure messages only messages pertinent to the operation are caught.

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -1912,15 +1912,16 @@ do_unlock() ->
       to implicitly postpone any events to the <c>locked</c> state.
     </p>
     <p>
-      A receive should not be used from a <c>gen_statem</c>
+      A receive all should never be used from a <c>gen_statem</c>
       behaviour (or from any <c>gen_*</c> behaviour),
       as the receive statement is within the <c>gen_*</c> engine itself.
-      Doing so without taking all cases into consideration could result
-      in system messages being discarded leading to unexpected behaviour.
-      Even if all cases are taken into consideration the recvieve would
-      still block system messages from arriving in a timely manor or
-      indefinitely if a timeout is not provided.
-      It must be there because all
+      Using a receive with a catch all match may result in system messages
+      being discarded which in turn may lead to unexpected behaviour.
+      If a selective receive must be used then great care should be taken to
+      ensure messages only messages pertitnent to the operation are caught.
+      Likewise, long running operations may result in timeouts and the
+      deferment of system messages, which in turn can lead to undesirable behaviour;
+      thus a reasonable timeout for any blocking operation should be used.
       <seeerl marker="stdlib:sys"><c>sys</c></seeerl>
       compatible behaviours must respond to system messages and therefore
       do that in their engine receive loop,

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -1922,10 +1922,10 @@ do_unlock() ->
       Using a catch-all receive may result in system messages
       being discarded which in turn may lead to unexpected behaviour.
       If a selective receive must be used then great care should be taken to
-      ensure that only non-system messages which are pertinent to the operation
-      are caught. Likewise, long-running operations may result in timeouts and the
-      deferment of system messages, which in turn can lead to undesirable behaviour;
-      thus, a reasonable timeout for any blocking operation should be used.
+      ensure that only messages pertinent to the operation are received.
+      Likewise, a callback must return in due time to let the engine
+      receive loop handle system messages, or they might time out also
+      leading to unexpected behaviour.
     </p>
     <p>
       The

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -1915,17 +1915,17 @@ do_unlock() ->
       A catch-all receive should never be used from a <c>gen_statem</c>
       behaviour (or from any <c>gen_*</c> behaviour),
       as the receive statement is within the <c>gen_*</c> engine itself.
-      Using such a receive may result in system messages
-      being discarded which in turn may lead to unexpected behaviour.
-      If a selective receive must be used then great care should be taken to
-      ensure only messages pertinent to the operation are caught.
-      Likewise, long running operations may result in timeouts and the
-      deferment of system messages, which in turn can lead to undesirable behaviour;
-      thus a reasonable timeout for any blocking operation should be used.
       <seeerl marker="stdlib:sys"><c>sys</c></seeerl>
       compatible behaviours must respond to system messages and therefore
       do that in their engine receive loop,
       passing non-system messages to the <em>callback module</em>.
+      Using a catch-all receive may result in system messages
+      being discarded which in turn may lead to unexpected behaviour.
+      If a selective receive must be used then great care should be taken to
+      ensure that only non-system messages which are pertinent to the operation
+      are caught. Likewise, long-running operations may result in timeouts and the
+      deferment of system messages, which in turn can lead to undesirable behaviour;
+      thus, a reasonable timeout for any blocking operation should be used.
     </p>
     <p>
       The

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -1912,7 +1912,7 @@ do_unlock() ->
       to implicitly postpone any events to the <c>locked</c> state.
     </p>
     <p>
-      A receive all should never be used from a <c>gen_statem</c>
+      A catch-all receive should never be used from a <c>gen_statem</c>
       behaviour (or from any <c>gen_*</c> behaviour),
       as the receive statement is within the <c>gen_*</c> engine itself.
       Using a receive with a catch all match may result in system messages

--- a/system/doc/design_principles/statem.xml
+++ b/system/doc/design_principles/statem.xml
@@ -1912,9 +1912,14 @@ do_unlock() ->
       to implicitly postpone any events to the <c>locked</c> state.
     </p>
     <p>
-      A selective receive cannot be used from a <c>gen_statem</c>
+      A receive should not be used from a <c>gen_statem</c>
       behaviour (or from any <c>gen_*</c> behaviour),
       as the receive statement is within the <c>gen_*</c> engine itself.
+      Doing so without taking all cases into consideration could result
+      in system messages being discarded leading to unexpected behaviour.
+      Even if all cases are taken into consideration the recvieve would
+      still block system messages from arriving in a timely manor or
+      indefinitely if a timeout is not provided.
       It must be there because all
       <seeerl marker="stdlib:sys"><c>sys</c></seeerl>
       compatible behaviours must respond to system messages and therefore


### PR DESCRIPTION
- Change can not to should not and give a brief explanation of why one should not use a receive in a gen_* process.

I suspect this will go through a few revisions. We may want to provide examples or simply expand on all this in another chapter (the dos and donts of gen_*) and link to that. However, I didn't think letting perfect be the enemy of good here was ideal. 