### PR TITLE
dialyzer: Fix literal value being used instead of type

### DIFF
--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -1551,8 +1551,9 @@ bind_tuple(Pat, Type, Map, State, Opaques, Rev) ->
           true ->
             Any = t_any(),
             [_Head|AnyTail] = [Any || _ <- Es],
-            UntypedRecord = t_tuple([Tag|AnyTail]),
-            case state__lookup_record(cerl:atom_val(Tag), length(Tags), State) of
+            TagAtomVal = cerl:atom_val(Tag),
+            UntypedRecord = t_tuple([t_atom(TagAtomVal)|AnyTail]),
+            case state__lookup_record(TagAtomVal, length(Tags), State) of
               error ->
                 {false, UntypedRecord};
               {ok, Record, _FieldNames} ->


### PR DESCRIPTION
A missing translation of a literal atom from a record name to the corresponding atom type meant Dialyzer/TypEr would crash due to trying to pattern match on a `c_literal` value, where a type was expected.

I suspect this hasn't been noticed yet because it requires specs to be set explicitly to be ignored (which results in the table of records being empty, activating this codepath where the first literal atom in a tuple corresponding to the record name is not converted into a type, and is instead erroneously left as a value-level literal).