### PR TITLE
JIT: Minor optimizations

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1353,6 +1353,8 @@ protected:
 
     void emit_validate_unicode(Label next, Label fail, arm::Gp value);
 
+    void ubif_comment(const ArgWord &Bif);
+
     void emit_bif_is_eq_ne_exact_immed(const ArgSource &LHS,
                                        const ArgSource &RHS,
                                        const ArgRegister &Dst,

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1003,6 +1003,12 @@ class BeamModuleAssembler : public BeamAssembler {
      * fragments as if they were local. */
     std::unordered_map<void (*)(), Label> _dispatchTable;
 
+    /* Skip unnecessary moves in load_source(), load_sources(), and
+     * mov_arg(). */
+    size_t last_destination_offset = 0;
+    arm::Gp last_destination_from;
+    arm::Mem last_destination_to;
+
 public:
     BeamModuleAssembler(BeamGlobalAssembler *ga,
                         Eterm mod,
@@ -1524,11 +1530,32 @@ protected:
         } else if (arg.isRegister()) {
             if (isRegisterBacked(arg)) {
                 auto index = arg.as<ArgXRegister>().get();
-                return Variable(register_backed_xregs[index]);
+                arm::Gp reg = register_backed_xregs[index];
+                if (reg == last_destination_from) {
+                    last_destination_offset = ~0;
+                }
+                return Variable(reg);
             }
 
             auto ref = getArgRef(arg);
-            a.ldr(tmp, ref);
+
+            if (a.offset() == last_destination_offset &&
+                ref == last_destination_to) {
+                if (last_destination_from != tmp) {
+                    comment("simplified fetching of BEAM register");
+                    a.mov(tmp, last_destination_from);
+                } else {
+                    comment("skipped fetching of BEAM register");
+                }
+                last_destination_offset = ~0;
+            } else if (a.offset() == last_destination_offset) {
+                a.ldr(tmp, ref);
+                if (last_destination_from != tmp) {
+                    last_destination_offset = a.offset();
+                }
+            } else {
+                a.ldr(tmp, ref);
+            }
             return Variable(tmp, ref);
         } else {
             if (arg.isImmed() || arg.isWord()) {
@@ -1597,8 +1624,16 @@ protected:
         }
     }
 
-    template<typename Reg>
-    void flush_var(const Variable<Reg> &to) {
+    void flush_var(const Variable<arm::Gp> &to) {
+        if (to.mem.hasBase()) {
+            a.str(to.reg, to.mem);
+            last_destination_offset = a.offset();
+            last_destination_to = to.mem;
+            last_destination_from = to.reg;
+        }
+    }
+
+    void flush_var(const Variable<arm::VecD> &to) {
         if (to.mem.hasBase()) {
             a.str(to.reg, to.mem);
         }

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -350,6 +350,8 @@ void BeamModuleAssembler::emit_label(const ArgLabel &Label) {
 
     currLabel = rawLabels[Label.get()];
     bind_veneer_target(currLabel);
+
+    last_destination_offset = ~0;
 }
 
 void BeamModuleAssembler::emit_aligned_label(const ArgLabel &Label,

--- a/erts/emulator/beam/jit/arm/generators.tab
+++ b/erts/emulator/beam/jit/arm/generators.tab
@@ -19,47 +19,6 @@
 // %CopyrightEnd%
 //
 
-// Generate the fastest instruction to fetch an integer from a binary.
-gen.get_integer2(Fail, Ms, Live, Size, Unit, Flags, Dst) {
-    BeamOp* op;
-    UWord bits;
-
-    $NewBeamOp(S, op);
-    $NativeEndian(Flags);
-
-    if (Size.type == TAG_i) {
-        if (!beam_load_safe_mul(Size.val, Unit.val, &bits)) {
-            $BeamOpNameArity(op, jump, 1);
-            op->a[0] = Fail;
-
-            return op;
-        } else if (bits <= 1023) {
-            $BeamOpNameArity(op, i_bs_get_fixed_integer, 6);
-            op->a[0] = Ms;
-            op->a[1] = Fail;
-            op->a[2] = Live;
-            op->a[3].type = TAG_u;
-            op->a[3].val = Flags.val;
-            op->a[4].type = TAG_u;
-            op->a[4].val = bits;
-            op->a[5] = Dst;
-
-            return op;
-        }
-    }
-
-    $BeamOpNameArity(op, i_bs_get_integer, 6);
-    op->a[0] = Ms;
-    op->a[1] = Fail;
-    op->a[2] = Live;
-    op->a[3].type = TAG_u;
-    op->a[3].val = (Unit.val << 3) | Flags.val;
-    op->a[4] = Size;
-    op->a[5] = Dst;
-
-    return op;
-}
-
 gen.select_tuple_arity(Src, Fail, Size, Rest) {
     BeamOp* op;
     BeamOpArg *tmp;

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -899,17 +899,13 @@ i_bs_match_test_heap f S I t *
 
 %warm
 
-# Matching integers
+# Matching integers.
 bs_match_string Fail Ms Bits Val => i_bs_match_string Ms Fail Bits Val
 
 i_bs_match_string S f W M
 
 # Fetching integers from binaries.
-bs_get_integer2 Fail=f Ms=xy Live=u Sz=sq Unit=u Flags=u Dst=d =>
-    get_integer2(Fail, Ms, Live, Sz, Unit, Flags, Dst)
-
-i_bs_get_integer S f t t s d
-i_bs_get_fixed_integer S f t t t d
+bs_get_integer2 f S t s t t d
 
 # Fetching binaries from binaries.
 bs_get_binary2 Fail=f Ms=xy Live=u Sz=sq Unit=u Flags=u Dst=d =>

--- a/erts/emulator/beam/jit/x86/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_module.cpp
@@ -326,6 +326,8 @@ void BeamModuleAssembler::emit_label(const ArgLabel &Label) {
 
     currLabel = rawLabels[Label.get()];
     a.bind(currLabel);
+
+    last_movarg_offset = ~0;
 }
 
 void BeamModuleAssembler::emit_aligned_label(const ArgLabel &Label,

--- a/erts/emulator/beam/jit/x86/generators.tab
+++ b/erts/emulator/beam/jit/x86/generators.tab
@@ -19,60 +19,6 @@
 // %CopyrightEnd%
 //
 
-// Generate the fastest instruction to fetch an integer from a binary.
-gen.get_integer2(Fail, Ms, Live, Size, Unit, Flags, Dst) {
-    BeamOp* op;
-    UWord bits;
-
-    $NewBeamOp(S, op);
-    $NativeEndian(Flags);
-    if (Size.type == TAG_i) {
-        if (!beam_load_safe_mul(Size.val, Unit.val, &bits)) {
-            $BeamOpNameArity(op, jump, 1);
-            op->a[0] = Fail;
-        } else if (bits == 8) {
-            $BeamOpNameArity(op, i_bs_get_integer_8, 4);
-            op->a[0] = Ms;
-            op->a[1] = Flags;
-            op->a[2] = Fail;
-            op->a[3] = Dst;
-        } else if (bits == 16) {
-            $BeamOpNameArity(op, i_bs_get_integer_16, 4);
-            op->a[0] = Ms;
-            op->a[1] = Flags;
-            op->a[2] = Fail;
-            op->a[3] = Dst;
-        } else if (bits == 32) {
-            $BeamOpNameArity(op, i_bs_get_integer_32, 4);
-            op->a[0] = Ms;
-            op->a[1] = Flags;
-            op->a[2] = Fail;
-            op->a[3] = Dst;
-        } else if (bits == 64) {
-            $BeamOpNameArity(op, i_bs_get_integer_64, 5);
-            op->a[0] = Ms;
-            op->a[1] = Flags;
-            op->a[2] = Fail;
-            op->a[3] = Live;
-            op->a[4] = Dst;
-        } else {
-            goto generic;
-        }
-    } else {
-    generic:
-        $BeamOpNameArity(op, i_bs_get_integer, 6);
-        op->a[0] = Ms;
-        op->a[1] = Fail;
-        op->a[2] = Live;
-        op->a[3].type = TAG_u;
-        op->a[3].val = (Unit.val << 3) | Flags.val;
-        op->a[4] = Size;
-        op->a[5] = Dst;
-        return op;
-    }
-    return op;
-}
-
 gen.select_tuple_arity(Src, Fail, Size, Rest) {
     BeamOp* op;
     BeamOpArg *tmp;

--- a/erts/emulator/beam/jit/x86/instr_arith.cpp
+++ b/erts/emulator/beam/jit/x86/instr_arith.cpp
@@ -711,8 +711,7 @@ void BeamModuleAssembler::emit_div_rem(const ArgLabel &Fail,
         } else if (always_one_of(LHS, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
             comment("simplified test for small dividend since it is an "
                     "integer");
-            a.mov(ARG2d, x86::eax);
-            a.test(ARG2d, imm(TAG_PRIMARY_LIST));
+            a.test(x86::al, imm(TAG_PRIMARY_LIST));
             a.short_().je(generic_div);
         } else {
             comment("testing for a small dividend");

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -652,114 +652,62 @@ void BeamModuleAssembler::emit_i_bs_get_position(const ArgRegister &Ctx,
     mov_arg(Dst, ARG1);
 }
 
-void BeamModuleAssembler::emit_bs_get_integer(const ArgRegister &Ctx,
-                                              const ArgLabel &Fail,
-                                              const ArgWord &Live,
-                                              const ArgWord Flags,
-                                              int bits,
-                                              const ArgRegister &Dst) {
-    const int base_offset = offsetof(ErlBinMatchState, mb.base);
-    const int position_offset = offsetof(ErlBinMatchState, mb.offset);
-    const int size_offset = offsetof(ErlBinMatchState, mb.size);
+void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
+                                               const ArgRegister &Ctx,
+                                               const ArgWord &Live,
+                                               const ArgSource &Sz,
+                                               const ArgWord &Unit,
+                                               const ArgWord &Flags,
+                                               const ArgRegister &Dst) {
+    Uint size;
+    Uint flags = Flags.get();
 
-#ifdef WIN32
-    const x86::Gp bin_position = ARG1;
-    const x86::Gp bitdata = ARG4;
-#else
-    const x86::Gp bin_position = ARG4;
-    const x86::Gp bitdata = ARG1;
-#endif
-    ASSERT(bin_position == x86::rcx);
-    const x86::Gp bin_base = ARG2;
-    const x86::Gp ctx = ARG3;
-    const x86::Gp tmp = ARG5;
-
-    mov_arg(ctx, Ctx);
-
-    if (bits == 64) {
-        a.mov(ARG1, ctx);
-        emit_gc_test_preserve(ArgWord(BIG_UINT_HEAP_SIZE), Live, Ctx, ARG1);
-        a.mov(ARG3, ARG1);
+    if (flags & BSF_NATIVE) {
+        flags &= ~BSF_NATIVE;
+        flags |= BSF_LITTLE;
     }
 
-    a.mov(bin_position, emit_boxed_val(ctx, position_offset));
-    a.lea(RET, qword_ptr(bin_position, bits));
-    a.cmp(RET, emit_boxed_val(ctx, size_offset));
-    a.ja(resolve_beam_label(Fail));
+    if (Sz.isSmall() &&
+        (size = Sz.as<ArgSmall>().getUnsigned()) < 8 * sizeof(Uint)) {
+        /* Segment of a fixed size supported by bs_match. */
+        const ArgVal match[] = {ArgAtom(am_ensure_at_least),
+                                ArgWord(size),
+                                Unit,
+                                ArgAtom(am_integer),
+                                Live,
+                                ArgWord(flags),
+                                ArgWord(size),
+                                Unit,
+                                Dst};
 
-    a.mov(bin_base, emit_boxed_val(ctx, base_offset));
-    a.mov(emit_boxed_val(ctx, position_offset), RET);
-
-    if (bits == 64) {
-        emit_read_bits(bits, bin_base, bin_position, bitdata);
-        emit_extract_integer(bitdata, tmp, Flags.get(), bits, Dst);
+        const Span<ArgVal> args(match, sizeof(match) / sizeof(match[0]));
+        emit_i_bs_match(Fail, Ctx, args);
     } else {
-        emit_read_integer(bin_base, bin_position, tmp, Flags.get(), bits, Dst);
-    }
-}
+        Label fail = resolve_beam_label(Fail);
+        int unit = Unit.get();
 
-void BeamModuleAssembler::emit_i_bs_get_integer_8(const ArgRegister &Ctx,
-                                                  const ArgWord &Flags,
-                                                  const ArgLabel &Fail,
-                                                  const ArgRegister &Dst) {
-    emit_bs_get_integer(Ctx, Fail, ArgWord(0), Flags, 8, Dst);
-}
+        /* Clobbers RET + ARG3, returns a negative result if we always
+         * fail and further work is redundant. */
+        if (emit_bs_get_field_size(Sz, unit, fail, ARG5) >= 0) {
+            mov_arg(ARG3, Ctx);
+            mov_imm(ARG4, flags);
+            mov_arg(ARG6, Live);
 
-void BeamModuleAssembler::emit_i_bs_get_integer_16(const ArgRegister &Ctx,
-                                                   const ArgWord &Flags,
-                                                   const ArgLabel &Fail,
-                                                   const ArgRegister &Dst) {
-    emit_bs_get_integer(Ctx, Fail, ArgWord(0), Flags, 16, Dst);
-}
+            emit_enter_runtime<Update::eReductions | Update::eStack |
+                               Update::eHeap>();
 
-void BeamModuleAssembler::emit_i_bs_get_integer_32(const ArgRegister &Ctx,
-                                                   const ArgWord &Flags,
-                                                   const ArgLabel &Fail,
-                                                   const ArgRegister &Dst) {
-    emit_bs_get_integer(Ctx, Fail, ArgWord(0), Flags, 32, Dst);
-}
+            a.mov(ARG1, c_p);
+            load_x_reg_array(ARG2);
+            runtime_call<6>(beam_jit_bs_get_integer);
 
-void BeamModuleAssembler::emit_i_bs_get_integer_64(const ArgRegister &Ctx,
-                                                   const ArgWord &Flags,
-                                                   const ArgLabel &Fail,
-                                                   const ArgWord &Live,
-                                                   const ArgRegister &Dst) {
-    emit_bs_get_integer(Ctx, Fail, Live, Flags, 64, Dst);
-}
+            emit_leave_runtime<Update::eReductions | Update::eStack |
+                               Update::eHeap>();
 
-void BeamModuleAssembler::emit_i_bs_get_integer(const ArgRegister &Ctx,
-                                                const ArgLabel &Fail,
-                                                const ArgWord &Live,
-                                                const ArgWord &FlagsAndUnit,
-                                                const ArgSource &Sz,
-                                                const ArgRegister &Dst) {
-    Label fail;
-    int unit;
+            emit_test_the_non_value(RET);
+            a.je(fail);
 
-    fail = resolve_beam_label(Fail);
-    unit = FlagsAndUnit.get() >> 3;
-
-    /* Clobbers RET + ARG3, returns a negative result if we always fail and
-     * further work is redundant. */
-    if (emit_bs_get_field_size(Sz, unit, fail, ARG5) >= 0) {
-        mov_arg(ARG3, Ctx);
-        mov_arg(ARG4, FlagsAndUnit);
-        mov_arg(ARG6, Live);
-
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
-
-        a.mov(ARG1, c_p);
-        load_x_reg_array(ARG2);
-        runtime_call<6>(beam_jit_bs_get_integer);
-
-        emit_leave_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
-
-        emit_test_the_non_value(RET);
-        a.je(fail);
-
-        mov_arg(Dst, RET);
+            mov_arg(Dst, RET);
+        }
     }
 }
 
@@ -1119,8 +1067,8 @@ void BeamModuleAssembler::emit_validate_unicode(Label next,
                                                 Label fail,
                                                 x86::Gp value) {
     a.mov(ARG3d, value.r32());
-    a.and_(ARG3d, imm(_TAG_IMMED1_MASK));
-    a.cmp(ARG3d, imm(_TAG_IMMED1_SMALL));
+    a.and_(ARG3d.r8(), imm(_TAG_IMMED1_MASK));
+    a.cmp(ARG3d.r8(), imm(_TAG_IMMED1_SMALL));
     a.jne(fail);
 
     a.cmp(value, imm(make_small(0xD800UL)));
@@ -2672,21 +2620,69 @@ void BeamModuleAssembler::emit_read_bits(Uint bits,
                                          const x86::Gp bin_base,
                                          const x86::Gp bin_offset,
                                          const x86::Gp bitdata) {
-    Label handle_partial = a.newLabel();
-    Label shift = a.newLabel();
     Label read_done = a.newLabel();
     auto num_partial = bits % 8;
     auto num_bytes_to_read = (bits + 7) / 8;
 
+    ASSERT(bin_offset == x86::rcx);
+
     a.mov(RET, bin_offset);
     a.shr(RET, imm(3));
+    if (num_bytes_to_read != 1) {
+        a.add(bin_base, RET);
+    }
     a.and_(bin_offset.r32(), imm(7));
+
+    /*
+     * Special-case handling of reading 8 or 9 bytes.
+     */
+    if (num_bytes_to_read == 8) {
+        if (hasCpuFeature(CpuFeatures::X86::kMOVBE)) {
+            a.movbe(bitdata, x86::qword_ptr(bin_base, num_bytes_to_read - 8));
+        } else {
+            a.mov(bitdata, x86::qword_ptr(bin_base, num_bytes_to_read - 8));
+            a.bswap(bitdata);
+        }
+
+        a.shl(bitdata, bin_offset.r8());
+
+        a.test(x86::cl, imm(7));
+        if (num_partial == 0) {
+            /* Byte-sized segment. If bit_offset is not byte-aligned, this
+             * segment always needs an additional byte. */
+            a.jz(read_done);
+        } else if (num_partial > 1) {
+            /* Non-byte-sized segment. Test whether we will need an
+             * additional byte. */
+            a.cmp(bin_offset.r32(), imm(8 - num_partial));
+            a.jle(read_done);
+        }
+
+        if (num_partial != 1) {
+            /* Read an extra byte. */
+            a.movzx(RETd, x86::byte_ptr(bin_base, 8));
+            a.shl(RETd, bin_offset.r8());
+            a.shr(RETd, imm(8));
+            a.or_(bitdata, RET);
+        }
+
+        a.bind(read_done);
+
+        return;
+    }
+
+    /*
+     * Handle reading of up to 7 bytes.
+     */
+    Label handle_partial = a.newLabel();
+    Label swap = a.newLabel();
+    Label shift = a.newLabel();
 
     if (num_partial == 0) {
         /* Byte-sized segment. If bit_offset is not byte-aligned, this
          * segment always needs an additional byte. */
         a.jnz(handle_partial);
-    } else {
+    } else if (num_partial > 1) {
         /* Non-byte-sized segment. Test whether we will need an
          * additional byte. */
         a.cmp(bin_offset.r32(), imm(8 - num_partial));
@@ -2699,12 +2695,10 @@ void BeamModuleAssembler::emit_read_bits(Uint bits,
         if (num_partial == 0) {
             a.bswap(bitdata);
             a.short_().jmp(read_done);
-        } else {
-            a.add(bin_offset.r32(), imm(56));
-            a.short_().jmp(shift);
+        } else if (num_partial > 1) {
+            a.short_().jmp(swap);
         }
     } else if (num_bytes_to_read <= 4) {
-        a.add(bin_base, RET);
         if (hasCpuFeature(CpuFeatures::X86::kMOVBE)) {
             a.movbe(bitdata.r32(),
                     x86::dword_ptr(bin_base, num_bytes_to_read - 4));
@@ -2716,59 +2710,36 @@ void BeamModuleAssembler::emit_read_bits(Uint bits,
         a.add(bin_offset.r32(), imm(64 - 8 * num_bytes_to_read));
         a.short_().jmp(shift);
     } else {
-        a.add(bin_base, RET);
         if (hasCpuFeature(CpuFeatures::X86::kMOVBE)) {
             a.movbe(bitdata, x86::qword_ptr(bin_base, num_bytes_to_read - 8));
         } else {
             a.mov(bitdata, x86::qword_ptr(bin_base, num_bytes_to_read - 8));
             a.bswap(bitdata);
         }
-        if (num_bytes_to_read < 8) {
-            a.add(bin_offset.r32(), imm(64 - 8 * num_bytes_to_read));
-        }
+        ASSERT(num_bytes_to_read < 8);
+        a.add(bin_offset.r32(), imm(64 - 8 * num_bytes_to_read));
         a.short_().jmp(shift);
     }
 
     /* We'll need an extra byte and we will need to shift. */
     a.bind(handle_partial);
-
-    if (num_bytes_to_read == 1) {
-        a.mov(bitdata.r16(), x86::word_ptr(bin_base, RET));
-        a.bswap(bitdata);
-    } else if (num_bytes_to_read < 8) {
-        a.add(bin_base, RET);
-        a.mov(bitdata, x86::qword_ptr(bin_base, num_bytes_to_read - 7));
-        a.shr(bitdata, imm(64 - 8 * (num_bytes_to_read + 1)));
-        a.bswap(bitdata);
-    } else {
-        a.add(bin_base, RET);
-        if (hasCpuFeature(CpuFeatures::X86::kMOVBE)) {
-            a.movbe(bitdata, x86::qword_ptr(bin_base));
+    if (num_partial != 1) {
+        if (num_bytes_to_read == 1) {
+            a.mov(bitdata.r16(), x86::word_ptr(bin_base, RET));
         } else {
-            a.mov(bitdata, x86::qword_ptr(bin_base));
-            a.bswap(bitdata);
+            ASSERT(num_bytes_to_read < 8);
+            a.mov(bitdata, x86::qword_ptr(bin_base, num_bytes_to_read - 7));
+            a.shr(bitdata, imm(64 - 8 * (num_bytes_to_read + 1)));
         }
-        ASSERT(bitdata != x86::rcx);
-        if (bin_offset != x86::rcx) {
-            a.mov(x86::cl, bin_offset.r8());
-        }
-        a.shl(bitdata, x86::cl);
-        a.mov(RET.r8(), x86::byte_ptr(bin_base, 8));
-        a.movzx(RET.r32(), RET.r8());
-        a.shl(RET.r32(), x86::cl);
-        a.shr(RET.r32(), imm(8));
-        a.or_(bitdata, RET);
-        a.short_().jmp(read_done);
     }
+
+    a.bind(swap);
+    a.bswap(bitdata);
 
     /* Shift the read data into the most significant bits of the
      * word. */
     a.bind(shift);
-    ASSERT(bitdata != x86::rcx);
-    if (bin_offset != x86::rcx) {
-        a.mov(x86::cl, bin_offset.r8());
-    }
-    a.shl(bitdata, x86::cl);
+    a.shl(bitdata, bin_offset.r8());
 
     a.bind(read_done);
 }
@@ -2817,7 +2788,7 @@ void BeamModuleAssembler::emit_read_integer(const x86::Gp bin_base,
         }
         ASSERT(bin_offset == x86::rcx);
         a.shl(RETd, bin_offset.r8());
-        a.shr(RETd, imm(8));
+        a.mov(x86::al, x86::ah);
         if ((flags & BSF_SIGNED) == 0) {
             a.movzx(RETd, RETb);
         } else {
@@ -3296,16 +3267,23 @@ void BeamModuleAssembler::emit_i_bs_match_test_heap(ArgLabel const &Fail,
 
     segments = opt_bsm_segments(segments, Need, Live);
 
+    /* Constraints:
+     *
+     * bin_position must be RCX because only CL can be used for
+     * a variable shift without using the SHLX instruction from BMI2.
+     */
 #ifdef WIN32
     const x86::Gp bin_position = ARG1;
-    const x86::Gp bitdata = ARG4;
+    const x86::Gp bitdata = ARG2;
+    const x86::Gp bin_base = ARG3;
+    const x86::Gp ctx = ARG4;
 #else
     const x86::Gp bin_position = ARG4;
-    const x86::Gp bitdata = ARG1;
+    const x86::Gp bitdata = ARG3;
+    const x86::Gp bin_base = ARG1;
+    const x86::Gp ctx = ARG2;
 #endif
     ASSERT(bin_position == x86::rcx);
-    const x86::Gp bin_base = ARG2;
-    const x86::Gp ctx = ARG3;
     const x86::Gp tmp = ARG5;
 
     bool is_ctx_valid = false;
@@ -3341,7 +3319,7 @@ void BeamModuleAssembler::emit_i_bs_match_test_heap(ArgLabel const &Fail,
 
             if (unit != 1) {
                 if (size % unit != 0) {
-                    sub(RET, size, ARG1);
+                    sub(RET, size, tmp);
                 }
 
                 if ((unit & (unit - 1))) {

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -1914,7 +1914,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             } else if (always_one_of(seg.size,
                                      BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
                 comment("simplified test for small size since it is a number");
-                a.test(ARG1d, imm(TAG_PRIMARY_LIST));
+                a.test(ARG1.r8(), imm(TAG_PRIMARY_LIST));
                 a.je(error);
             } else {
                 a.mov(RETd, ARG1d);

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -242,7 +242,7 @@ void BeamGlobalAssembler::emit_apply_fun_shared() {
             a.cmp(ARG1d, imm(NIL));
             a.short_().je(finished);
 
-            a.test(ARG1d, imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_LIST));
+            a.test(ARG1.r8(), imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_LIST));
             a.short_().jne(malformed_list);
 
             emit_ptr_val(ARG1, ARG1);

--- a/erts/emulator/beam/jit/x86/instr_map.cpp
+++ b/erts/emulator/beam/jit/x86/instr_map.cpp
@@ -148,7 +148,7 @@ void BeamGlobalAssembler::emit_hashmap_get_element() {
         emit_ptr_val(node, node);
 
         /* Have we found our leaf? */
-        a.test(node.r32(), imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_LIST));
+        a.test(node.r8(), imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_LIST));
         a.short_().je(leaf_node);
 
         /* Nope, we have to search another node. */

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -866,21 +866,13 @@ i_bs_match_test_heap f S I t *
 
 %warm
 
-# Matching integers
+# Matching integers.
 bs_match_string Fail Ms Bits Val => i_bs_match_string Ms Fail Bits Val
 
 i_bs_match_string S f W M
 
 # Fetching integers from binaries.
-bs_get_integer2 Fail=f Ms=xy Live=u Sz=sq Unit=u Flags=u Dst=d =>
-    get_integer2(Fail, Ms, Live, Sz, Unit, Flags, Dst)
-
-i_bs_get_integer S f t t s d
-
-i_bs_get_integer_8 S t f d
-i_bs_get_integer_16 S t f d
-i_bs_get_integer_32 S t f d
-i_bs_get_integer_64 S t f t d
+bs_get_integer2 f S t s t t d
 
 # Fetching binaries from binaries.
 bs_get_binary2 Fail=f Ms=xy Live=u Sz=sq Unit=u Flags=u Dst=d =>


### PR DESCRIPTION
This PR improves the code generation of the JIT in several ways.

The most important is eliminating reading from a BEAM register written by the previous BEAM instructions if the contents is already available in a CPU register.

For example, consider:

```
foo(<<X:16>>) ->
    (X band 7) bor 1.
```

The BEAM code for the expression body looks like this:

```
    {gc_bif,'band',
            {f,0},
            3,
            [{tr,{x,2},{t_integer,{0,65535}}},{integer,7}],
            {x,0}}.
    {gc_bif,'bor',{f,0},1,[{tr,{x,0},{t_integer,{0,7}}},{integer,1}],{x,0}}.
```

The result of the `band` operand is written X-register 0 (`{x,0}`). The `bor` operation then reads X-register 0.

The JIT in Erlang/OTP 25 generates the following code:

```
# i_band_ssjd
    mov rsi, qword ptr [rbx+16]
    mov eax, 127
    and rax, rsi
    mov qword ptr [rbx], rax
# i_bor_jssd
    mov rsi, qword ptr [rbx]
    mov eax, 31
    or rax, rsi
    mov qword ptr [rbx], rax
```

Here we can see that the last instruction of `band` stores the result to memory (`mov qword ptr [rbx], rax`). The very first thing `bor` does is to read back the value (albeit to another CPU register).

The new optimization will rewrite the first instruction of `bor` to get the value from the `rax` register:

```
# i_bor_jssd
    mov rsi, rax
    mov eax, 31
    or rax, rsi
    mov qword ptr [rbx], rax
```

But that is not actually the code that will be emitted because there is another optimization in this pull request that avoids loading a small integer operand into a register for logical operations. Here is the actual code for the two BEAM instructions:

```
# i_band_ssjd
    and eax, 127
    mov qword ptr [rbx], rax
# i_bor_jssd
    or rax, 31
    mov qword ptr [rbx], rax
```

As it happened, the result of the instruction before `band` (not shown) was available in the `rax` register. Since one operand for `band` is the integer 127, it can be used as an immediate operand for the `and` instruction. Similarly, the `bor` can also be reduced to two instructions because the result from `band` happened to be available in exactly the register it needed to be.


