### PR TITLE
erts: support unicode cmdline in compilation server

### DIFF
--- a/erts/etc/common/erlc.c
+++ b/erts/etc/common/erlc.c
@@ -742,14 +742,14 @@ call_compile_server(char** argv)
     ei_x_encode_atom(&args, "encoding");
     ei_x_encode_atom(&args, get_encoding());
     ei_x_encode_atom(&args, "cwd");
-    ei_x_encode_string(&args, cwd);
+    ei_x_encode_binary(&args, cwd, strlen(cwd));
     ei_x_encode_atom(&args, "env");
     encode_env(&args);
     ei_x_encode_atom(&args, "command_line");
     argc = 0;
     while (argv[argc]) {
         ei_x_encode_list_header(&args, 1);
-        ei_x_encode_string(&args, possibly_unquote(argv[argc]));
+        ei_x_encode_binary(&args, possibly_unquote(argv[argc]), strlen(argv[argc]));
         argc++;
     }
     ei_x_encode_empty_list(&args); /* End of command_line */
@@ -773,7 +773,6 @@ call_compile_server(char** argv)
     /*
      * Decode the answer.
      */
-
     dec_index = 0;
     if (ei_decode_atom(reply.buff, &dec_index, atom) == 0 &&
         strcmp(atom, "wrong_config") == 0) {

--- a/erts/test/erlc_SUITE_data/src/😀/erl_test_unicode.erl
+++ b/erts/test/erlc_SUITE_data/src/😀/erl_test_unicode.erl
@@ -1,0 +1,25 @@
+%% 
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1997-2016. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+-module(erl_test_unicode).
+-export(['😀'/1]).
+
+'😀'(0) ->
+    '😀'.

--- a/lib/stdlib/test/edlin_expand_SUITE.erl
+++ b/lib/stdlib/test/edlin_expand_SUITE.erl
@@ -157,7 +157,7 @@ filename_completion(Config) ->
     {yes,"/", [{"../",_}]} = do_expand("\".."),
     {yes,"ta/", _} = do_expand("\"../edlin_expand_SUITE_da"),
     {yes,"erl\"",[{"complete_function_parameter.erl",_}]} = do_expand("\"complete_function_parameter."),
-    R = case {os:type(), filename:native_name_encoding()} of
+    R = case {os:type(), file:native_name_encoding()} of
         {{win32,_}, _} -> {skip, "Unicode on filenames in windows are tricky"};
         {_,latin1} -> {skip, "Cannot interpret unicode filenames when native_name_encoding is latin1"};
         _ ->


### PR DESCRIPTION
Updates compilation server so that it supports input arguments in binary format, and converting them to unicode lists.

More information in https://github.com/erlang/otp/issues/6255