### PR TITLE
wx: fix build issue when GL/glu.h is not present

### DIFF
--- a/lib/wx/c_src/egl_impl.h
+++ b/lib/wx/c_src/egl_impl.h
@@ -29,10 +29,10 @@
 #include <windows.h>  
 #include <gl/gl.h>
 #include <gl/glu.h>
-#elif defined(HAVE_GL_GL_H)
+#elif defined(HAVE_GL_GL_H) && defined(HAVE_GL_GLU_H)
 #include <GL/gl.h>
 # include <GL/glu.h>	
-#elif defined(HAVE_OPENGL_GL_H)
+#elif defined(HAVE_OPENGL_GL_H) && defined(HAVE_OPENGL_GLU_H)
 #include <OpenGL/gl.h> 
 #include <OpenGL/glu.h> 
 #endif


### PR DESCRIPTION
Currently the build of wx fails if `GL/gl.h` is present but `GL/glu.h` is not. This may happen, for example, in macOS if the homebrew `mesa` package is installed.

This change ensures that both `GL/gl.h` and `GL/glu.h` are present before including them.