### PR TITLE
ct: Don't use compile server for peer compilation

### DIFF
--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -2867,7 +2867,8 @@ peer_compile(Erl, ModPath, OutDir) ->
 %% This should really be implemented as os:cmd.
 cmd(Exec, Args) ->
     %% remove all ERL_AFLAGS to drop "-emu_type debug" and similar
-    Env = [{"ERL_AFLAGS", false}],
+    %% remote ERLC_COMPILE_SERVER because of a bug in pre 25.2 Erlang/OTP
+    Env = [{"ERL_AFLAGS", false},{"ERLC_COMPILE_SERVER",false}],
     Port = open_port({spawn_executable, Exec}, [{args, Args}, {env, Env},
         stream, binary, exit_status, stderr_to_stdout]),
     read_std(Port, lists:join(" ", [Exec|Args]), <<>>).


### PR DESCRIPTION
A bug when using the compile server together with a unicode path causes compilation of peer to fail for old nodes. So we don't allow the compile server for peer compilation.