### PR TITLE
jit: Fix erts_beamasm symbols

### DIFF
--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -378,8 +378,13 @@ void BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
         start = getCode(functions[i]);
         ci = (const ErtsCodeInfo *)start;
 
-        stop = ((const char *)erts_codeinfo_to_code(ci)) +
-               BEAM_ASM_FUNC_PROLOGUE_SIZE;
+        stop = ((const char *)erts_codeinfo_to_code(ci));
+
+        if (ci->mfa.module != AM_erts_beamasm) {
+            /* All modules (except erts_beamasm, which is a JIT internal module)
+               have a prologue that should be counted as part of the CodeInfo */
+            stop = ((const char *)stop) + BEAM_ASM_FUNC_PROLOGUE_SIZE;
+        }
 
         n = erts_snprintf(name_buffer,
                           1024,


### PR DESCRIPTION
The symbols for erts_beamasm did not take into consideration that there was not prologue for functions in that jit internal module. This causes perf to show `$erts_beamasm:normal_exit/0-CodeInfoPrologue` instead of `$erts_beamasm:normal_exit/0` for the top frame of all processes, which is incorrect and possibly confusing.