### PR TITLE
[peer] Link peer node lifecycle to control connection

### DIFF
--- a/lib/stdlib/src/peer.erl
+++ b/lib/stdlib/src/peer.erl
@@ -890,6 +890,17 @@ notify_started(Kind, Port) ->
 %% I/O redirection: peer side
 -spec start() -> pid().
 start() ->
+    %% watchdog: a process that has the only purpose of halting the node
+    %%  if controlling process terminates for whatever reason
+    Self = self(),
+    spawn_link(
+        fun () ->
+            false = process_flag(trap_exit, true),
+            receive
+                {'EXIT', Self, _Reason} ->
+                    erlang:halt(0)
+            end
+        end),
     case init:get_argument(origin) of
         {ok, [[IpStr, PortString]]} ->
             %% enter this clause when -origin IpList Port is specified in the command line.


### PR DESCRIPTION
Crashing controller process should always lead to halting the entire node. Before this change it was possible for controlling process to crash itself and user_sup, but not the node.