### PR TITLE
eunit: Fix `$ rebar3 eunit` error on OTP 25.1

### DIFF
--- a/lib/eunit/src/eunit_data.erl
+++ b/lib/eunit/src/eunit_data.erl
@@ -289,7 +289,7 @@ parse({setup, P, S, C, I} = T, Options)
 		{spawn, N} when is_atom(N) -> ok;
 		_ -> bad_test(T)
 	    end,
-	    group(#group{tests = I,
+	    group(#group{tests = I, options = Options,
 			 context = #context{setup = S, cleanup = C,
 					    process = P}})
     end;
@@ -395,15 +395,15 @@ parse({with, X, As}=T, _Options) when is_list(As) ->
 	[] ->
 	    {data, []}
     end;
-parse({S, T1} = T, _Options) when is_list(S) ->
+parse({S, T1} = T, Options) when is_list(S) ->
     case eunit_lib:is_string(S) of
 	true ->
-	    group(#group{tests = T1, desc = unicode:characters_to_binary(S)});
+	    group(#group{tests = T1, options = Options, desc = unicode:characters_to_binary(S)});
 	false ->
 	    bad_test(T)
     end;
-parse({S, T1}, _Options) when is_binary(S) ->
-    group(#group{tests = T1, desc = S});
+parse({S, T1}, Options) when is_binary(S) ->
+    group(#group{tests = T1, options = Options, desc = S});
 parse(T, Options) when is_tuple(T), size(T) > 2, is_list(element(1, T)) ->
     [S | Es] = tuple_to_list(T),
     parse({S, list_to_tuple(Es)}, Options);


### PR DESCRIPTION
Hi,

After updating to OTP 25.1, `$ rebar3 eunit` became failed as follows:
```console
// Erlang/OTP version
$ erl
Erlang/OTP 25 [erts-13.1] [source] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [jit]
Eshell V13.1  (abort with ^G)
1> q().

//  rebar3 version
$ rebar3 version
rebar 3.19.0 on Erlang/OTP 25 Erts 13.1

// Create an empty project
$ rebar3 new app foo
$ cd foo/

// Execute eunit
$ rebar3 eunit
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling foo
===> Performing EUnit tests...

=ERROR REPORT==== 22-Sep-2022::12:02:30.980278 ===
Error in process <0.182.0> with exit value:
{function_clause,[{proplists,get_bool,
                             [exact_execution,undefined],
                             [{file,"proplists.erl"},{line,307}]},
                  {eunit_data,extract_module_tests,3,
                              [{file,"eunit_data.erl"},{line,581}]},
                  {eunit_data,get_module_tests,2,
                              [{file,"eunit_data.erl"},{line,564}]},
                  {eunit_data,parse,2,[{file,"eunit_data.erl"},{line,343}]},
                  {eunit_data,next,2,[{file,"eunit_data.erl"},{line,174}]},
                  {eunit_data,lookahead,2,
                              [{file,"eunit_data.erl"},{line,532}]},
                  {eunit_data,group,1,[{file,"eunit_data.erl"},{line,485}]},
                  {eunit_data,next,2,[{file,"eunit_data.erl"},{line,174}]}]}
...
1 tests, 0 failures, 1 cancelled                                                                                                                                                                                                                       
===> Error running tests       
```

With some investigation, it turned out that the `#group.options` field introduced in https://github.com/erlang/otp/commit/c194380712236c301188f0b401352f14c608c145 are omitted in some code when creating the record instances. Thus, the value of the field would become `undefined` and the above error could occur.

This PR fixes this problem by making sure to pass `Options` to `#record.options`.
Besides, I have confirmed that this fix can resolve https://github.com/erlang/otp/issues/6320.
