### PR TITLE
Allow local redefinition of built-in types

### DIFF
--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -826,7 +826,23 @@ module.beam: module.erl \
                 (or contract) for an exported or unexported function is not
                 given. Use this option to turn on this kind of warning.</p>
           </item>
-        </taglist>
+
+          <tag><c>nowarn_redefined_builtin_type</c></tag>
+          <item>
+            <p>By default, a warning is emitted when a built-in type
+            is locally redefined. Use this option to turn off this
+            kind of warning.</p>
+          </item>
+
+          <tag><c>{nowarn_redefined_builtin_type, Types}</c></tag>
+          <item>
+            <p>By default, a warning is emitted when a built-in type
+            is locally redefined. Use this option to turn off this
+            kind of warning for the types in <c>Types</c>, where
+            <c>Types</c> is a tuple <c>{TypeName,Arity}</c> or a list
+            of such tuples.</p>
+          </item>
+</taglist>
 
 	<p>Other kinds of warnings are <em>opportunistic
 	warnings</em>. They are generated when the compiler happens to

--- a/lib/dialyzer/test/small_SUITE_data/results/redefine_builtins
+++ b/lib/dialyzer/test/small_SUITE_data/results/redefine_builtins
@@ -1,0 +1,5 @@
+
+a.erl:4:2: Invalid type specification for function a:vi/1.
+ The success typing is a:vi(integer()) -> 'ok'
+ But the spec is a:vi(b:integer()) -> 'ok'
+ They do not overlap in the 1st argument

--- a/lib/dialyzer/test/small_SUITE_data/src/redefine_builtin_type.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/redefine_builtin_type.erl
@@ -1,0 +1,24 @@
+-module(redefine_builtin_type).
+-export([lookup/2, verify_mfa/1, verify_pid/1]).
+
+-type map() :: {atom(), erlang:map()}.
+
+-spec lookup(atom(), map()) -> {'ok', term()} | 'error'.
+
+lookup(Key, {Key, Map}) when is_atom(Key), is_map(Map) ->
+    {ok, Map};
+lookup(Key1, {Key2, Map}) when is_atom(Key1), is_atom(Key2), is_map(Map) ->
+    error.
+
+%% Type `mfa()` depends on `erlang::module()`. Make sure that `mfa()`
+%% does not attempt to use our local definition of `module()`.
+
+-type module() :: pid().
+
+-spec verify_mfa(mfa()) -> 'ok'.
+verify_mfa({M, F, A}) when is_atom(M), is_atom(F), is_integer(A) ->
+    ok.
+
+-spec verify_pid(module()) -> 'ok'.
+verify_pid(Pid) when is_pid(Pid) ->
+    ok.

--- a/lib/dialyzer/test/small_SUITE_data/src/redefine_builtins/a.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/redefine_builtins/a.erl
@@ -1,0 +1,14 @@
+-module(a).
+-export([vi/1, sum/2, vc/1]).
+
+-spec vi(b:integer()) -> 'ok'.
+vi(I) when is_integer(I) ->
+    ok.
+
+-spec sum(b:integer(), integer()) -> integer().
+sum([A], B) ->
+    A + B.
+
+-spec vc(b:collection()) -> 'ok'.
+vc({Int, List}) when length(List) =:= Int ->
+    ok.

--- a/lib/dialyzer/test/small_SUITE_data/src/redefine_builtins/b.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/redefine_builtins/b.erl
@@ -1,0 +1,6 @@
+-module(b).
+-export_type([integer/0, collection/0]).
+
+-type integer() :: [integer()].
+
+-type collection() :: {erlang:integer(), integer()}.

--- a/system/doc/reference_manual/typespec.xml
+++ b/system/doc/reference_manual/typespec.xml
@@ -314,11 +314,6 @@
     <tcaption>Additional built-in types</tcaption>
   </table>
 
-  <p>
-    Users are not allowed to define types with the same names as the
-    predefined or built-in ones. This is checked by the compiler and
-    its violation results in a compilation error.
-  </p>
   <note>
     <p>
       The following built-in list types also exist,
@@ -345,7 +340,34 @@
     This is described in <seeguide marker="#typeinrecords">
     Type Information in Record Declarations</seeguide>.
   </p>
+
+  <section>
+    <title>Redefining built-in types</title>
+    <p>
+      Starting from Erlang/OTP 26, is is permitted to define a type
+      having the same name as a built-in type. It is recommended to
+      avoid deliberately reusing built-in names because it can be
+      confusing. However, when an Erlang/OTP release introduces a new
+      type, code that happened to define its own type having the same
+      name will continue to work.
+    </p>
+
+    <p>As an example, imagine that the Erlang/OTP 42 release introduces
+    a new type <c>gadget()</c> defined like this:</p>
+
+    <pre>
+  -type gadget() :: {'gadget', reference()}.</pre>
+
+    <p>Further imagine that some code has its own (different)
+    definition of <c>gadget()</c>, for example:</p>
+
+    <pre>
+  -type gadget() :: #{}.</pre>
+
+    <p>Since redefinitions are allowed, the code will still compile (but
+    with a warning), and Dialyzer will not emit any additional warnings.</p>
   </section>
+</section>
 
   <section>
     <title>Type Declarations of User-Defined Types</title>


### PR DESCRIPTION
If a module defines a type and a new built-in type is added with the same name, Dialyzer will allow the redefinition of that particular release for one release only. That makes it difficult to write code that is supposed to work for multiple releases of OTP.

For example, the OTP 24 release introduced the `nonempty_binary` type. Modules that had their own definition would continue to work in OTP 24 but not in OTP 25.

Always allow the name of a built-in type to be reused locally, in the same way that a definition of a function with the same name as a BIF will take precedence over the BIF. Starting from OTP 25, the built-in types belong to the erlang module, so it will always be possible to get the built-in definition if needed by prefixing the name with `erlang:`.

Closes #6132