### PR TITLE
ets: improve ets:new/2 already_exists named_table error

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -90,6 +90,7 @@ atom allocator
 atom allocator_sizes
 atom alloc_util_allocators
 atom allow_passive_connect
+atom already_exists
 atom already_loaded
 atom amd64
 atom anchored

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -57,6 +57,7 @@
 #define EXI_POSITION am_position /* The position is out of range. */
 #define EXI_OWNER    am_owner	 /* The receiving process is already the owner. */
 #define EXI_NOT_OWNER am_not_owner /* The current process is not the owner. */
+#define EXI_ALREADY_EXISTS am_already_exists /* The table identifier already exists. */
 
 #define DB_WRITE_CONCURRENCY_MIN_LOCKS 1
 #define DB_WRITE_CONCURRENCY_MAX_LOCKS 32768
@@ -2532,7 +2533,8 @@ BIF_RETTYPE ets_new_2(BIF_ALIST_2)
 	tb->common.meth->db_free_empty_table(tb);
 	db_unlock(tb,LCK_WRITE);
         table_dec_refc(tb, 0);
-	BIF_ERROR(BIF_P, BADARG);
+        BIF_P->fvalue = EXI_ALREADY_EXISTS;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
     }
 
     BIF_P->flags |= F_USING_DB; /* So we can remove tb if p dies */

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -653,17 +653,19 @@ format_ets_error(match_spec_compile, [_], _Cause) ->
     [bad_matchspec];
 format_ets_error(next, Args, Cause) ->
     format_default(bad_key, Args, Cause);
-format_ets_error(new, [Name,Options], _Cause) ->
+format_ets_error(new, [Name,Options], Cause) ->
     NameError = if
                     is_atom(Name) -> [];
                     true -> not_atom
                 end,
     OptsError = must_be_list(Options),
-    case {NameError,OptsError} of
-        {[],[]} ->
-            [[],bad_options];
-        {_,_} ->
-            [NameError,OptsError]
+    case {NameError, OptsError, Cause} of
+        {[], [], already_exists} ->
+            [name_already_exists, []];
+        {[], [], _} ->
+            [[], bad_options];
+        {_, _, _} ->
+            [NameError, OptsError]
     end;
 format_ets_error(prev, Args, Cause) ->
     format_default(bad_key, Args, Cause);


### PR DESCRIPTION
Adds extra information in `erl_db.c` before returning the error for already used table name. The error is only returned if the option `named_table` is give and the name is already in use.

The extra information is used later to format the error message.

Closes #6252