### PR TITLE
erts: Decouple use of single-mapped memory from `perf` support

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -1025,6 +1025,18 @@ $ <input>erl \
           section in the BeamAsm internal documentation.
         </p>
       </item>
+      <tag><marker id="+JMsingle"/><c>+JMsingle true|false</c></tag>
+      <item>
+        <p>Enables or disables the use of single-mapped RWX memory for JIT
+          code. The default is to map JIT:ed machine code into two
+          regions sharing the same physical pages, where one region is
+          executable but not writable, and the other writable but not
+          executable. As some tools, such as QEMU user mode emulation,
+          cannot deal with the dual mapping, this flags allows it to be
+          disabled. This flag is automatically enabled by the
+          <seecom marker="#+JPperf"><c>+JPperf</c></seecom> flag.
+        </p>
+      </item>
       <tag><c><![CDATA[+L]]></c></tag>
       <item>
         <p>Prevents loading information about source filenames and line

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -652,6 +652,7 @@ void erts_usage(void)
 #ifdef BEAMASM
     erts_fprintf(stderr, "-JDdump bool   enable or disable dumping of generated assembly code for each module loaded\n");
     erts_fprintf(stderr, "-JPperf bool   enable or disable support for perf on Linux\n");
+    erts_fprintf(stderr, "-JMsingle bool enable the use of single-mapped RWX memory for JIT:ed code\n");
     erts_fprintf(stderr, "\n");
 #endif
 
@@ -1728,6 +1729,23 @@ erl_start(int argc, char **argv)
                 erts_fprintf(stderr, "+JPperf is not supported on this platform\n");
                 erts_usage();
 #endif
+                }
+                break;
+            case 'M':
+                sub_param++;
+                if (has_prefix("single", sub_param)) {
+                    arg = get_arg(sub_param+6, argv[i + 1], &i);
+                    if (sys_strcmp(arg, "true") == 0) {
+                        erts_jit_single_map = 1;
+                    } else if (sys_strcmp(arg, "false") == 0) {
+                        erts_jit_single_map = 0;
+                    } else {
+                        erts_fprintf(stderr, "bad +JMsingle support flag %s\n", arg);
+                        erts_usage();
+                    }
+                } else {
+                    erts_fprintf(stderr, "bad +JM sub-option %s\n", arg);
+                    erts_usage();
                 }
                 break;
             default:

--- a/erts/emulator/beam/jit/beam_asm.h
+++ b/erts/emulator/beam/jit/beam_asm.h
@@ -37,6 +37,7 @@
 #        define BEAMASM_PERF_MAP (1 << 1)
 extern int erts_jit_perf_support;
 #    endif
+extern int erts_jit_single_map;
 
 void beamasm_init(void);
 void *beamasm_new_assembler(Eterm mod,

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -1220,7 +1220,7 @@ usage_aux(void)
           "[-emu_type TYPE] [-emu_flavor FLAVOR] "
 	  "[-args_file FILENAME] [+A THREADS] [+a SIZE] [+B[c|d|i]] [+c [BOOLEAN]] "
 	  "[+C MODE] [+dcg DECENTRALIZED_COUNTER_GROUPS_LIMIT] [+h HEAP_SIZE_OPTION] "
-          "[+J[Pperf] JIT_OPTION] "
+          "[+J[Pperf|Msingle] JIT_OPTION] "
 	  "[+M<SUBSWITCH> <ARGUMENT>] [+P MAX_PROCS] [+Q MAX_PORTS] "
 	  "[+R COMPAT_REL] "
 	  "[+r] [+rg READER_GROUPS_LIMIT] [+s<SUBSWITCH> SCHEDULER_OPTION] "


### PR DESCRIPTION
Running the JIT with single-mapped RWX memory for JIT:ed machine code is needed for `perf` support. But as it is also useful for running under QEMU user mode emulation [1] this patch adds a new flag `+JMsingle bool` which controls the use of single-mapped RWX memory without triggering the output of perf-related metadata.

The naming of the flag is intended to follow the (perceived) pattern introduced by the `+JPperf`-flag, that is, `J` is a JIT-related option and `M` stands for memory related things.

Personally I use the additional patch below in order to use the same file system image for development on an amd64 build host and for deployment to an aarch64-target board. The patch detects when the VM is running using QEMU and if so, enables single-mapped memory. As the patch only works on Linux and doesn't try to identify the version of QEMU (if the bug gets fixed), I don't think it belongs to OTP master. But as it is nevertheless useful, I include it here:

```
diff --git a/erts/emulator/beam/erl_init.c b/erts/emulator/beam/erl_init.c
index 42216da0b2..6f11c7586b 100644
--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -2408,6 +2408,40 @@ erl_start(int argc, char **argv)
 	erts_usage();
     }

+
+#if defined(HAVE_LINUX_PERF_SUPPORT)
+    /* We want to detect if we are running under QEMU user mode
+       emulation in order to activate single-mapped RWX memory for the
+       JIT:ed code. This only works on Linux, so we use
+       HAVE_LINUX_PERF_SUPPORT to conditionally compile this piece of
+       detection code.
+
+       To detect QEMU user mode we make use of the fact that our
+       parent process will always be QEMU, we detect that by looking
+       up our parent process and then checking if the final path
+       component of the symlink /proc/<parent>/exe starts with
+       "qemu-".
+    */
+    {
+        char symlink_buf[21 + 11]; /* space for any 64 bit integer
+                                      + /proc/%d/exe and terminator */
+        char target_buf[MAXPATHLEN];
+        ssize_t l;
+        erts_snprintf(symlink_buf, sizeof(symlink_buf),
+                      "/proc/%d/exe", getppid());
+        l = readlink(symlink_buf, target_buf, sizeof(target_buf));
+        if (l > 0 && l != sizeof(target_buf)) {
+            char *last_path_separator;
+
+            target_buf[l] = 0;
+            last_path_separator = memrchr(target_buf, '/', l);
+            if (last_path_separator && strncmp(last_path_separator + 1,
+                                               "qemu-", 5) == 0)
+                erts_jit_single_map = 1;
+        }
+    }
+#endif
+
 /* Output format on windows for sprintf defaults to three exponents.
  * We use two-exponent to mimic normal sprintf behaviour.
  */
```

[1] There is a bug in QEMU,
    see https://gitlab.com/qemu-project/qemu/-/issues/1034