### PR TITLE
Support including off-heap binaries in max_heap_size

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -949,6 +949,14 @@ $ <input>erl \
           <seeerl marker="erlang#process_flag_max_heap_size">
           <c>process_flag(max_heap_size, MaxHeapSize)</c></seeerl>.</p>
       </item>
+      <tag><marker id="+hmaxib"/><c><![CDATA[+hmaxib true|false]]></c></tag>
+      <item>
+        <p>Sets whether to include the size of shared off-heap binaries
+          in the sum compared against the maximum heap size. Defaults to
+	  <c>false</c>. For more information, see
+          <seeerl marker="erlang#process_flag_max_heap_size">
+          <c>process_flag(max_heap_size, MaxHeapSize)</c></seeerl>.</p>
+      </item>
       <tag><marker id="+hmaxk"/><c><![CDATA[+hmaxk true|false]]></c></tag>
       <item>
         <p>Sets whether to kill processes reaching the maximum heap size or not.

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -6468,6 +6468,26 @@ receive_replies(ReqId, N, Acc) ->
               or <seeerl marker="#system_flag_max_heap_size">
               <c>erlang:system_flag(max_heap_size, MaxHeapSize)</c></seeerl>.</p>
           </item>
+          <tag><c>include_shared_binaries</c></tag>
+          <item>
+            <p>
+	      When set to <c>true</c>, off-heap binaries are included in the
+	      total sum compared against the <c>size</c> limit. Off-heap binaries
+	      are typically larger binaries that may be shared between
+	      processes. The size of a shared binary is included by all
+	      processes that are referring it. Also, the entire size of a large
+	      binary may be included even if only a smaller part of it is
+	      referred by the process.
+            </p>
+	    <p>
+	      If <c>include_shared_binaries</c> is not defined in the map, the
+	      system default is used. The default system default is <c>false</c>.
+              It can be changed by either the option
+              <seecom marker="erl#+hmaxib">+hmaxib</seecom> in <c>erl(1)</c>,
+              or <seeerl marker="#system_flag_max_heap_size">
+              <c>erlang:system_flag(max_heap_size, MaxHeapSize)</c></seeerl>.
+            </p>
+          </item>
         </taglist>
         <p>The heap size of a process is quite hard to predict, especially the
           amount of memory that is used during the garbage collection. When
@@ -10415,8 +10435,10 @@ Metadata = #{ pid => pid(),
               system-wide maximum heap size settings for spawned processes.
               This setting can be set using the command-line flags
               <seecom marker="erl#+hmax"><c>+hmax</c></seecom>,
-              <seecom marker="erl#+hmaxk"><c>+hmaxk</c></seecom> and
-              <seecom marker="erl#+hmaxel"><c>+hmaxel</c></seecom> in
+              <seecom marker="erl#+hmaxk"><c>+hmaxk</c></seecom>,
+              <seecom marker="erl#+hmaxel"><c>+hmaxel</c></seecom> and
+	      <seecom marker="erl#+hmaxib"><c>+hmaxibl</c></seecom> in
+
               <c>erl(1)</c>. It can also be changed at runtime using
               <seeerl marker="#system_flag_max_heap_size">
               <c>erlang:system_flag(max_heap_size, MaxHeapSize)</c></seeerl>.

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -363,6 +363,7 @@ atom ignore
 atom in
 atom in_exiting
 atom inactive
+atom include_shared_binaries
 atom incomplete
 atom inconsistent
 atom index

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -1898,8 +1898,8 @@ BIF_RETTYPE process_flag_2(BIF_ALIST_2)
        BIF_RET(old_value);
    }
    else if (BIF_ARG_1 == am_max_heap_size) {
-       Eterm *hp;
-       Uint sz = 0, max_heap_size, max_heap_flags;
+       ErtsHeapFactory factory;
+       Uint max_heap_size, max_heap_flags;
 
        if (!erts_max_heap_size(BIF_ARG_2, &max_heap_size, &max_heap_flags))
            goto error;
@@ -1907,9 +1907,11 @@ BIF_RETTYPE process_flag_2(BIF_ALIST_2)
        if ((max_heap_size < MIN_HEAP_SIZE(BIF_P) && max_heap_size != 0))
 	   goto error;
 
-       erts_max_heap_size_map(MAX_HEAP_SIZE_GET(BIF_P), MAX_HEAP_SIZE_FLAGS_GET(BIF_P), NULL, &sz);
-       hp = HAlloc(BIF_P, sz);
-       old_value = erts_max_heap_size_map(MAX_HEAP_SIZE_GET(BIF_P), MAX_HEAP_SIZE_FLAGS_GET(BIF_P), &hp, NULL);
+       erts_factory_proc_init(&factory, BIF_P);
+       old_value = erts_max_heap_size_map(&factory,
+                                          MAX_HEAP_SIZE_GET(BIF_P),
+                                          MAX_HEAP_SIZE_FLAGS_GET(BIF_P));
+       erts_factory_close(&factory);
        MAX_HEAP_SIZE_SET(BIF_P, max_heap_size);
        MAX_HEAP_SIZE_FLAGS_SET(BIF_P, max_heap_flags);
        BIF_RET(old_value);
@@ -5080,9 +5082,9 @@ BIF_RETTYPE system_flag_2(BIF_ALIST_2)
 
 	BIF_RET(make_small(oval));
     } else if (BIF_ARG_1 == am_max_heap_size) {
-
-        Eterm *hp, old_value;
-        Uint sz = 0, max_heap_size, max_heap_flags;
+        ErtsHeapFactory factory;
+        Eterm old_value;
+        Uint max_heap_size, max_heap_flags;
 
         if (!erts_max_heap_size(BIF_ARG_2, &max_heap_size, &max_heap_flags))
             goto error;
@@ -5090,9 +5092,9 @@ BIF_RETTYPE system_flag_2(BIF_ALIST_2)
         if (max_heap_size < H_MIN_SIZE && max_heap_size != 0)
             goto error;
 
-        erts_max_heap_size_map(H_MAX_SIZE, H_MAX_FLAGS, NULL, &sz);
-        hp = HAlloc(BIF_P, sz);
-        old_value = erts_max_heap_size_map(H_MAX_SIZE, H_MAX_FLAGS, &hp, NULL);
+        erts_factory_proc_init(&factory, BIF_P);
+        old_value = erts_max_heap_size_map(&factory, H_MAX_SIZE, H_MAX_FLAGS);
+        erts_factory_close(&factory);
 
         erts_proc_unlock(BIF_P, ERTS_PROC_LOCK_MAIN);
         erts_thr_progress_block();

--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -401,12 +401,12 @@ print_process_info(fmtfn_t to, void *to_arg, Process *p, ErtsProcLocks orig_lock
     erts_print(to, to_arg, "OldHeap unused: %bpu\n",
 	       (OLD_HEAP(p) == NULL) ? 0 : (OLD_HEND(p) - OLD_HTOP(p)) );
     erts_print(to, to_arg, "BinVHeap: %b64u\n", p->off_heap.overhead);
-    erts_print(to, to_arg, "OldBinVHeap: %b64u\n", BIN_OLD_VHEAP(p));
+    erts_print(to, to_arg, "OldBinVHeap: %b64u\n", p->bin_old_vheap);
     erts_print(to, to_arg, "BinVHeap unused: %b64u\n",
-               BIN_VHEAP_SZ(p) - p->off_heap.overhead);
-    if (BIN_OLD_VHEAP_SZ(p) >= BIN_OLD_VHEAP(p)) {
+               p->bin_vheap_sz - p->off_heap.overhead);
+    if (p->bin_old_vheap_sz >= p->bin_old_vheap) {
         erts_print(to, to_arg, "OldBinVHeap unused: %b64u\n",
-                   BIN_OLD_VHEAP_SZ(p) - BIN_OLD_VHEAP(p));
+                   p->bin_old_vheap_sz - p->bin_old_vheap);
     } else {
         erts_print(to, to_arg, "OldBinVHeap unused: overflow\n");
     }

--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -125,7 +125,7 @@ BS_GET_UNCHECKED_FIELD_SIZE(Bits, Unit, Fail, Dst) {
 TEST_BIN_VHEAP(VNh, Nh, Live) {
     Uint need = $Nh;
     if ((E - HTOP < (need + S_RESERVED)) ||
-         (MSO(c_p).overhead + $VNh >= BIN_VHEAP_SZ(c_p))) {
+        (MSO(c_p).overhead + $VNh >= c_p->bin_vheap_sz)) {
         $GC_SWAPOUT();
         PROCESS_MAIN_CHK_LOCKS(c_p);
         FCALLS -= erts_garbage_collect_nobump(c_p, need, reg, $Live, FCALLS);

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -1866,9 +1866,9 @@ process_info_aux(Process *c_p,
 
     case ERTS_PI_IX_MIN_BIN_VHEAP_SIZE: {
 	Uint hsz = 0;
-	(void) erts_bld_uint(NULL, &hsz, MIN_VHEAP_SIZE(rp));
+	(void) erts_bld_uint(NULL, &hsz, rp->min_vheap_size);
         hp = erts_produce_heap(hfact, hsz, reserve_size);
-	res = erts_bld_uint(&hp, NULL, MIN_VHEAP_SIZE(rp));
+	res = erts_bld_uint(&hp, NULL, rp->min_vheap_size);
 	break;
     }
 
@@ -1951,7 +1951,7 @@ process_info_aux(Process *c_p,
 
 	t = TUPLE2(hp, am_min_heap_size, make_small(MIN_HEAP_SIZE(rp))); hp += 3;
 	res = CONS(hp, t, res); hp += 2;
-	t = TUPLE2(hp, am_min_bin_vheap_size, make_small(MIN_VHEAP_SIZE(rp))); hp += 3;
+	t = TUPLE2(hp, am_min_bin_vheap_size, make_small(rp->min_vheap_size)); hp += 3;
 	res = CONS(hp, t, res); hp += 2;
 
         t = erts_max_heap_size_map(MAX_HEAP_SIZE_GET(rp), MAX_HEAP_SIZE_FLAGS_GET(rp), &hp, NULL);

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -1873,14 +1873,9 @@ process_info_aux(Process *c_p,
     }
 
     case ERTS_PI_IX_MAX_HEAP_SIZE: {
-	Uint hsz = 0;
-	(void) erts_max_heap_size_map(MAX_HEAP_SIZE_GET(rp),
-                                      MAX_HEAP_SIZE_FLAGS_GET(rp),
-                                      NULL, &hsz);
-        hp = erts_produce_heap(hfact, hsz, reserve_size);
-	res = erts_max_heap_size_map(MAX_HEAP_SIZE_GET(rp),
-                                     MAX_HEAP_SIZE_FLAGS_GET(rp),
-                                     &hp, NULL);
+	res = erts_max_heap_size_map(hfact,
+                                     MAX_HEAP_SIZE_GET(rp),
+                                     MAX_HEAP_SIZE_FLAGS_GET(rp));
 	break;
     }
 
@@ -1937,12 +1932,12 @@ process_info_aux(Process *c_p,
 
     case ERTS_PI_IX_GARBAGE_COLLECTION: {
         DECL_AM(minor_gcs);
-        Eterm t;
-        Uint map_sz = 0;
+        Eterm t, mhs_map;
 
-        erts_max_heap_size_map(MAX_HEAP_SIZE_GET(rp), MAX_HEAP_SIZE_FLAGS_GET(rp), NULL, &map_sz);
+        mhs_map = erts_max_heap_size_map(hfact, MAX_HEAP_SIZE_GET(rp),
+                                         MAX_HEAP_SIZE_FLAGS_GET(rp));
 
-        hp = erts_produce_heap(hfact, 3+2 + 3+2 + 3+2 + 3+2 + 3+2 + map_sz, reserve_size);
+        hp = erts_produce_heap(hfact, 5*(3+2), reserve_size);
 
 	t = TUPLE2(hp, AM_minor_gcs, make_small(GEN_GCS(rp))); hp += 3;
 	res = CONS(hp, t, NIL); hp += 2;
@@ -1954,10 +1949,8 @@ process_info_aux(Process *c_p,
 	t = TUPLE2(hp, am_min_bin_vheap_size, make_small(rp->min_vheap_size)); hp += 3;
 	res = CONS(hp, t, res); hp += 2;
 
-        t = erts_max_heap_size_map(MAX_HEAP_SIZE_GET(rp), MAX_HEAP_SIZE_FLAGS_GET(rp), &hp, NULL);
-
 	t = TUPLE2(hp, am_max_heap_size, t); hp += 3;
-	res = CONS(hp, t, res); hp += 2;
+	res = CONS(hp, mhs_map, res); hp += 2;
 	break;
     }
 
@@ -2748,10 +2741,10 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 	res = TUPLE2(hp, am_min_heap_size,make_small(H_MIN_SIZE));
 	BIF_RET(res);
     } else if (BIF_ARG_1 == am_max_heap_size) {
-        Uint sz = 0;
-        erts_max_heap_size_map(H_MAX_SIZE, H_MAX_FLAGS, NULL, &sz);
-	hp = HAlloc(BIF_P, sz);
-	res = erts_max_heap_size_map(H_MAX_SIZE, H_MAX_FLAGS, &hp, NULL);
+        ErtsHeapFactory factory;
+        erts_factory_proc_init(&factory, BIF_P);
+	res = erts_max_heap_size_map(&factory, H_MAX_SIZE, H_MAX_FLAGS);
+        erts_factory_close(&factory);
 	BIF_RET(res);
     } else if (BIF_ARG_1 == am_min_bin_vheap_size) {
 	hp = HAlloc(BIF_P, 3);

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -1381,7 +1381,7 @@ void increase_proc_bin_sz(Process* p, ProcBin* pb, Uint new_size)
 {
     if (new_size > pb->size) {
         if (ErtsInBetween(pb, OLD_HEAP(p), OLD_HTOP(p))) {
-            BIN_OLD_VHEAP(p) += (new_size / sizeof(Eterm) -
+            p->bin_old_vheap += (new_size / sizeof(Eterm) -
                                  pb->size / sizeof(Eterm));
         }
         pb->size = new_size;

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -3739,28 +3739,20 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
 }
 
 Eterm
-erts_max_heap_size_map(Sint max_heap_size, Uint max_heap_flags,
-                       Eterm **hpp, Uint *sz)
+erts_max_heap_size_map(ErtsHeapFactory *factory,
+                       Sint max_heap_size, Uint max_heap_flags)
 {
-    if (!hpp) {
-        *sz += ERTS_MAX_HEAP_SIZE_MAP_SZ;
-        return THE_NON_VALUE;
-    } else {
-        Eterm *hp = *hpp;
-        Eterm keys = TUPLE3(hp, am_error_logger, am_kill, am_size);
-        flatmap_t *mp;
-        hp += 4;
-        mp = (flatmap_t*) hp;
-        mp->thing_word = MAP_HEADER_FLATMAP;
-        mp->size = 3;
-        mp->keys = keys;
-        hp += MAP_HEADER_FLATMAP_SZ;
-        *hp++ = max_heap_flags & MAX_HEAP_SIZE_LOG ? am_true : am_false;
-        *hp++ = max_heap_flags & MAX_HEAP_SIZE_KILL ? am_true : am_false;
-        *hp++ = make_small(max_heap_size);
-        *hpp = hp;
-        return make_flatmap(mp);
-    }
+    Eterm keys[] = {
+        am_error_logger, am_kill, am_size
+    };
+    Eterm values[] = {
+        max_heap_flags & MAX_HEAP_SIZE_LOG ? am_true : am_false,
+        max_heap_flags & MAX_HEAP_SIZE_KILL ? am_true : am_false,
+        make_small(max_heap_size)
+    };
+    ERTS_CT_ASSERT(sizeof(keys) == sizeof(values));
+    return erts_map_from_ks_and_vs(factory, keys, values,
+                                   sizeof(keys) / sizeof(keys[0]));
 }
 
 int

--- a/erts/emulator/beam/erl_gc.h
+++ b/erts/emulator/beam/erl_gc.h
@@ -160,7 +160,7 @@ typedef struct {
   Uint64 garbage_cols;
 } ErtsGCInfo;
 
-#define ERTS_MAX_HEAP_SIZE_MAP_SZ (2*3 + 1 + MAP_HEADER_FLATMAP_SZ)
+#define ERTS_MAX_HEAP_SIZE_MAP_SZ (2*4 + 1 + MAP_HEADER_FLATMAP_SZ)
 
 #define ERTS_PROCESS_GC_INFO_MAX_TERMS (11)  /* number of elements in process_gc_info*/
 #define ERTS_PROCESS_GC_INFO_MAX_SIZE                                   \

--- a/erts/emulator/beam/erl_gc.h
+++ b/erts/emulator/beam/erl_gc.h
@@ -186,7 +186,7 @@ void erts_offset_off_heap(struct erl_off_heap*, Sint, Eterm*, Eterm*);
 void erts_offset_heap_ptr(Eterm*, Uint, Sint, Eterm*, Eterm*);
 void erts_offset_heap(Eterm*, Uint, Sint, Eterm*, Eterm*);
 void erts_free_heap_frags(struct process* p);
-Eterm erts_max_heap_size_map(Sint, Uint, Eterm **, Uint *);
+Eterm erts_max_heap_size_map(ErtsHeapFactory *factory, Sint, Uint);
 int erts_max_heap_size(Eterm, Uint *, Uint *);
 void erts_deallocate_young_generation(Process *c_p);
 void erts_copy_one_frag(Eterm** hpp, ErlOffHeap* off_heap,

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -631,6 +631,7 @@ void erts_usage(void)
 	       H_DEFAULT_MAX_SIZE);
     erts_fprintf(stderr, "-hmaxk bool    enable or disable kill at max heap size (default true)\n");
     erts_fprintf(stderr, "-hmaxel bool   enable or disable error_logger report at max heap size (default true)\n");
+    erts_fprintf(stderr, "-hmaxib bool   enable or disable including off-heap binaries into max heap size (default false)\n");
     erts_fprintf(stderr, "-hpds size     set initial process dictionary size (default %d)\n",
 	       erts_pd_initial_size);
     erts_fprintf(stderr, "-hmqd  val     set default message queue data flag for processes;\n");
@@ -1580,6 +1581,8 @@ erl_start(int argc, char **argv)
              * h|max   - max_heap_size
              * h|maxk  - max_heap_kill
              * h|maxel - max_heap_error_logger
+             * h|maxib - map_heap_include_shared_binaries
+             *
 	     *
 	     */
 	    if (has_prefix("mbs", sub_param)) {
@@ -1642,6 +1645,17 @@ erl_start(int argc, char **argv)
 		    erts_usage();
 		}
 		VERBOSE(DEBUG_SYSTEM, ("using max heap log %d\n", H_MAX_FLAGS));
+            } else if (has_prefix("maxib", sub_param)) {
+                arg = get_arg(sub_param+5, argv[i+1], &i);
+                if (sys_strcmp(arg,"true") == 0) {
+                    H_MAX_FLAGS |= MAX_HEAP_SIZE_INCLUDE_OH_BINS;
+                } else if (sys_strcmp(arg,"false") == 0) {
+                    H_MAX_FLAGS &= ~MAX_HEAP_SIZE_INCLUDE_OH_BINS;
+                } else {
+                    erts_fprintf(stderr, "bad max heap include bins %s\n", arg);
+                    erts_usage();
+                }
+                VERBOSE(DEBUG_SYSTEM, ("using max heap log %d\n", H_MAX_FLAGS));
 	    } else if (has_prefix("max", sub_param)) {
                 Sint hMaxSize;
                 char *rest;

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -993,14 +993,15 @@ typedef struct ErtsProcSysTaskQs_ ErtsProcSysTaskQs;
 #  define MSO(p)            (p)->off_heap
 #  define MIN_HEAP_SIZE(p)  (p)->min_heap_size
 
-#  define MAX_HEAP_SIZE_GET(p)     ((p)->max_heap_size >> 2)
-#  define MAX_HEAP_SIZE_SET(p, sz) ((p)->max_heap_size = ((sz) << 2) |  \
+#  define MAX_HEAP_SIZE_GET(p)     ((p)->max_heap_size >> 3)
+#  define MAX_HEAP_SIZE_SET(p, sz) ((p)->max_heap_size = ((sz) << 3) |  \
                                     MAX_HEAP_SIZE_FLAGS_GET(p))
-#  define MAX_HEAP_SIZE_FLAGS_GET(p)          ((p)->max_heap_size & 0x3)
+#  define MAX_HEAP_SIZE_FLAGS_GET(p)          ((p)->max_heap_size & 0x7)
 #  define MAX_HEAP_SIZE_FLAGS_SET(p, flags)   ((p)->max_heap_size = flags | \
-                                               ((p)->max_heap_size & ~0x3))
+                                               ((p)->max_heap_size & ~0x7))
 #  define MAX_HEAP_SIZE_KILL 1
 #  define MAX_HEAP_SIZE_LOG  2
+#  define MAX_HEAP_SIZE_INCLUDE_OH_BINS 4
 
 struct process {
     ErtsPTabElementCommon common; /* *Need* to be first in struct */

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -993,11 +993,6 @@ typedef struct ErtsProcSysTaskQs_ ErtsProcSysTaskQs;
 #  define MSO(p)            (p)->off_heap
 #  define MIN_HEAP_SIZE(p)  (p)->min_heap_size
 
-#  define MIN_VHEAP_SIZE(p)   (p)->min_vheap_size
-#  define BIN_VHEAP_SZ(p)     (p)->bin_vheap_sz
-#  define BIN_OLD_VHEAP_SZ(p) (p)->bin_old_vheap_sz
-#  define BIN_OLD_VHEAP(p)    (p)->bin_old_vheap
-
 #  define MAX_HEAP_SIZE_GET(p)     ((p)->max_heap_size >> 2)
 #  define MAX_HEAP_SIZE_SET(p, sz) ((p)->max_heap_size = ((sz) << 2) |  \
                                     MAX_HEAP_SIZE_FLAGS_GET(p))

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -1339,7 +1339,7 @@ static BIF_RETTYPE term_to_binary_trap_1(BIF_ALIST_1)
                                         0, 0,bin, 0, ~((Uint) 0));
     if (is_non_value(res)) {
         if (erts_set_gc_state(BIF_P, 1)
-            || MSO(BIF_P).overhead > BIN_VHEAP_SZ(BIF_P)) {
+            || MSO(BIF_P).overhead > BIF_P->bin_vheap_sz) {
             ERTS_VBUMP_ALL_REDS(BIF_P);
         }
         if (Opts == am_undefined)
@@ -1354,7 +1354,7 @@ static BIF_RETTYPE term_to_binary_trap_1(BIF_ALIST_1)
 	BIF_TRAP1(&term_to_binary_trap_export,BIF_P,res);
     } else {
         if (erts_set_gc_state(BIF_P, 1)
-            || MSO(BIF_P).overhead > BIN_VHEAP_SZ(BIF_P))
+            || MSO(BIF_P).overhead > BIF_P->bin_vheap_sz)
             ERTS_BIF_YIELD_RETURN(BIF_P, res);
         else
             BIF_RET(res);

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -690,7 +690,7 @@ static void test_bin_vheap(Process *c_p,
     int need = Nh;
 
     if (c_p->stop - c_p->htop < (need + S_RESERVED) ||
-        MSO(c_p).overhead + VNh >= BIN_VHEAP_SZ(c_p)) {
+        MSO(c_p).overhead + VNh >= c_p->bin_vheap_sz) {
         c_p->fcalls -=
                 erts_garbage_collect_nobump(c_p, need, reg, Live, c_p->fcalls);
     }

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -152,6 +152,7 @@ static char *plush_val_switches[] = {
     "max",
     "maxk",
     "maxel",
+    "maxib",
     "mqd",
     "",
     NULL

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -3093,7 +3093,8 @@ spawn_monitor(M, F, A) ->
         %% TODO change size => to := when -type maps support is finalized
       | #{ size => non_neg_integer(),
            kill => boolean(),
-           error_logger => boolean() }.
+           error_logger => boolean(),
+           include_shared_binaries => boolean() }.
 
 -type spawn_opt_option() ::
 	link


### PR DESCRIPTION
Fixes #5889.

Instead of adding a new limit "max_vheap_size", this PR proposes an option to the existing max_heap_size map:

`#{include_shared_bins => true | false}
`

If set to `true` off-heap binaries ("vheap") is included in the total heap size compared against the `max_heap_size` limit.
Default is false to keep existing semantics.