### PR TITLE
[erts] Implement call_memory tracing

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -12819,6 +12819,21 @@ improper_end</pre>
               <seemfa marker="#trace_pattern/3">
               <c>erlang:trace_pattern/3</c></seemfa>.</p>
           </item>
+          <tag><c>call_memory</c></tag>
+          <item>
+            <p>Returns the accumulated number of words allocated by this function.
+              Accumulation stops at the next memory traced function: if there
+              are <c>outer</c>, <c>middle</c> and <c>inner</c> functions each
+              allocating 3 words, but only <c>outer</c> is traced, it will report
+              9 allocated words. If <c>outer</c> and <c>inner</c> are traced,
+              6 words are reported for <c>outer</c> and 3 for <c>inner</c>.
+              When function is not traced, <c>false</c> is returned.
+              Returned tuple is <c>[{Pid, Count, Words}]</c>,
+              for each process that executed the function.</p>
+            <p>See also
+              <seemfa marker="#trace_pattern/3">
+              <c>erlang:trace_pattern/3</c></seemfa>.</p>
+          </item>
           <tag><c>all</c></tag>
           <item>
             <p>Returns a list containing the
@@ -13121,15 +13136,15 @@ improper_end</pre>
           </item>
           <tag><c>restart</c></tag>
           <item>
-            <p>For the <c><anno>FlagList</anno></c> options <c>call_count</c>
-              and <c>call_time</c>: restarts
+            <p>For the <c><anno>FlagList</anno></c> options <c>call_count</c>,
+              <c>call_time</c> and <c>call_memory</c>: restarts
               the existing counters. The behavior is undefined
               for other <c><anno>FlagList</anno></c> options.</p>
           </item>
           <tag><c>pause</c></tag>
           <item>
             <p>For the <c><anno>FlagList</anno></c> options
-              <c>call_count</c> and <c>call_time</c>: pauses
+              <c>call_count</c>, <c>call_time</c> and <c>call_memory</c>: pauses
               the existing counters. The behavior is undefined for
               other <c><anno>FlagList</anno></c> options.</p>
           </item>
@@ -13198,6 +13213,20 @@ improper_end</pre>
               The counters are stored for each call traced process.</p>
             <p>If call time tracing is started while already running,
               the count and time restart from zero. To pause
+              running counters, use <c><anno>MatchSpec</anno> == pause</c>.
+              Paused and running counters can be restarted from zero with
+              <c><anno>MatchSpec</anno> == restart</c>.</p>
+            <p>To read the counter value, use
+              <seemfa marker="#trace_info/2">
+              <c>erlang:trace_info/2</c></seemfa>.</p>
+          </item>
+          <tag><c>call_memory</c></tag>
+          <item>
+            <p>Starts (<c><anno>MatchSpec</anno> == true</c>) or stops
+              (<c><anno>MatchSpec</anno> == false</c>) call memory
+              tracing for all types of function calls.</p>
+            <p>If call memory tracing is started while already running,
+              counters and allocations restart from zero. To pause
               running counters, use <c><anno>MatchSpec</anno> == pause</c>.
               Paused and running counters can be restarted from zero with
               <c><anno>MatchSpec</anno> == restart</c>.</p>

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -164,7 +164,9 @@ atom busy_port
 atom call
 atom call_count
 atom call_error_handler
+atom call_memory
 atom call_time
+atom call_trace_return
 atom caller
 atom caller_line
 atom capture
@@ -606,7 +608,6 @@ atom reset_seq_trace
 atom restart
 atom resume
 atom return_from
-atom return_time_trace
 atom return_to
 atom return_to_trace
 atom return_trace

--- a/erts/emulator/beam/beam_bp.c
+++ b/erts/emulator/beam/beam_bp.c
@@ -719,12 +719,12 @@ static void fixup_cp_before_trace(Process *c_p,
         erts_inspect_frame(cpp, &w);
 
         if (BeamIsReturnTrace(w)) {
-            cpp += CP_SIZE + 2;
+            cpp += CP_SIZE + BEAM_RETURN_TRACE_FRAME_SZ;
         } else if (BeamIsReturnCallAccTrace(w)) {
-            cpp += CP_SIZE + 2;
+            cpp += CP_SIZE + BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
         } else if (BeamIsReturnToTrace(w)) {
             *return_to_trace = 1;
-            cpp += CP_SIZE;
+            cpp += CP_SIZE + BEAM_RETURN_TO_TRACE_FRAME_SZ;
         } else {
             if (frame_layout == ERTS_FRAME_LAYOUT_FP_RA) {
                 ASSERT(is_CP(cpp[1]));
@@ -845,7 +845,7 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
         if (!(BeamIsReturnTrace(w) ||
               BeamIsReturnToTrace(w) ||
               BeamIsReturnCallAccTrace(w))) {
-            int need = CP_SIZE + 2;
+            int need = CP_SIZE + BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
 
             ASSERT(c_p->htop <= E && E <= c_p->hend);
 
@@ -858,7 +858,7 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
             E = c_p->stop;
 
             ASSERT(c_p->htop <= E && E <= c_p->hend);
-
+            ERTS_CT_ASSERT(BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ == 2);
             E -= 3;
             E[2] = make_small(bp_flags);
             E[1] = prev_info ? make_cp(erts_codeinfo_to_code(prev_info)) : NIL;

--- a/erts/emulator/beam/beam_bp.c
+++ b/erts/emulator/beam/beam_bp.c
@@ -58,8 +58,10 @@
 #define ERTS_BPF_TIME_TRACE        0x20
 #define ERTS_BPF_TIME_TRACE_ACTIVE 0x40
 #define ERTS_BPF_GLOBAL_TRACE      0x80
+#define ERTS_BPF_MEM_TRACE        0x100
+#define ERTS_BPF_MEM_TRACE_ACTIVE 0x200
 
-#define ERTS_BPF_ALL               0xFF
+#define ERTS_BPF_ALL              0x3FF
 
 erts_atomic32_t erts_active_bp_index;
 erts_atomic32_t erts_staging_bp_index;
@@ -103,6 +105,12 @@ release_bp_sched_ix(Uint32 ix)
 /*
 ** Helpers
 */
+const ErtsCodeInfo* erts_trace_call(Process* c_p,
+                                    const ErtsCodeInfo *ci,
+                                    BpDataAccumulator accum,
+                                    int psd_ix,
+                                    BpDataCallTrace* bdt);
+
 static ErtsTracer do_call_trace(Process* c_p, ErtsCodeInfo *info, Eterm* reg,
                                 int local, Binary* ms, ErtsTracer tracer);
 static void set_break(BpFunctions* f, Binary *match_spec, Uint break_flags,
@@ -116,28 +124,29 @@ static void set_function_break(ErtsCodeInfo *ci,
 static void clear_break(BpFunctions* f, Uint break_flags);
 static int clear_function_break(const ErtsCodeInfo *ci, Uint break_flags);
 
-static BpDataTime* get_time_break(const ErtsCodeInfo *ci);
+static BpDataCallTrace* get_time_break(const ErtsCodeInfo *ci);
+static BpDataCallTrace* get_memory_break(const ErtsCodeInfo *ci);
 static GenericBpData* check_break(const ErtsCodeInfo *ci, Uint break_flags);
 
 static void bp_meta_unref(BpMetaTracer *bmt);
 static void bp_count_unref(BpCount *bcp);
-static void bp_time_unref(BpDataTime *bdt);
+static void bp_calltrace_unref(BpDataCallTrace *bdt);
 static void consolidate_bp_data(Module *modp, ErtsCodeInfo *ci, int local);
 static void uninstall_breakpoint(ErtsCodeInfo *ci_rw,
                                  const ErtsCodeInfo *ci_exec);
 
 /* bp_hash */
-#define BP_TIME_ADD(pi0, pi1)                       \
-    do {                                            \
-	(pi0)->count   += (pi1)->count;             \
-	(pi0)->time    += (pi1)->time;              \
+#define BP_ACCUMULATE(pi0, pi1)                         \
+    do {                                                \
+	(pi0)->count   += (pi1)->count;                 \
+	(pi0)->accumulator  += (pi1)->accumulator;      \
     } while(0)
 
-static void bp_hash_init(bp_time_hash_t *hash, Uint n);
-static void bp_hash_rehash(bp_time_hash_t *hash, Uint n);
-static ERTS_INLINE bp_data_time_item_t * bp_hash_get(bp_time_hash_t *hash, bp_data_time_item_t *sitem);
-static ERTS_INLINE bp_data_time_item_t * bp_hash_put(bp_time_hash_t *hash, bp_data_time_item_t *sitem);
-static void bp_hash_delete(bp_time_hash_t *hash);
+static void bp_hash_init(bp_trace_hash_t *hash, Uint n);
+static void bp_hash_rehash(bp_trace_hash_t *hash, Uint n);
+static ERTS_INLINE bp_data_trace_item_t * bp_hash_get(bp_trace_hash_t *hash, bp_data_trace_item_t *sitem);
+static ERTS_INLINE bp_data_trace_item_t * bp_hash_put(bp_trace_hash_t *hash, bp_data_trace_item_t *sitem);
+static void bp_hash_delete(bp_trace_hash_t *hash);
 
 /* *************************************************************************
 ** External interfaces
@@ -328,7 +337,10 @@ consolidate_bp_data(Module* modp, ErtsCodeInfo *ci_rw, int local)
 	bp_count_unref(dst->count);
     }
     if (flags & ERTS_BPF_TIME_TRACE) {
-	bp_time_unref(dst->time);
+	bp_calltrace_unref(dst->time);
+    }
+    if (flags & ERTS_BPF_MEM_TRACE) {
+	bp_calltrace_unref(dst->memory);
     }
 
     /*
@@ -381,6 +393,11 @@ consolidate_bp_data(Module* modp, ErtsCodeInfo *ci_rw, int local)
 	dst->time = src->time;
 	erts_refc_inc(&dst->time->refc, 1);
 	ASSERT(dst->time->hash);
+    }
+    if (flags & ERTS_BPF_MEM_TRACE) {
+	dst->memory = src->memory;
+	erts_refc_inc(&dst->memory->refc, 1);
+	ASSERT(dst->memory->hash);
     }
 }
 
@@ -544,6 +561,13 @@ erts_set_time_break(BpFunctions* f, enum erts_break_op count_op)
 }
 
 void
+erts_set_memory_break(BpFunctions* f, enum erts_break_op count_op)
+{
+    set_break(f, 0, ERTS_BPF_MEM_TRACE|ERTS_BPF_MEM_TRACE_ACTIVE,
+	      count_op, erts_tracer_nil);
+}
+
+void
 erts_clear_trace_break(BpFunctions* f)
 {
     clear_break(f, ERTS_BPF_LOCAL_TRACE);
@@ -586,6 +610,12 @@ void
 erts_clear_time_break(BpFunctions* f)
 {
     clear_break(f, ERTS_BPF_TIME_TRACE|ERTS_BPF_TIME_TRACE_ACTIVE);
+}
+
+void
+erts_clear_memory_break(BpFunctions* f)
+{
+    clear_break(f, ERTS_BPF_MEM_TRACE|ERTS_BPF_MEM_TRACE_ACTIVE);
 }
  
 void
@@ -690,8 +720,8 @@ static void fixup_cp_before_trace(Process *c_p,
 
         if (BeamIsReturnTrace(w)) {
             cpp += CP_SIZE + 2;
-        } else if (BeamIsReturnTimeTrace(w)) {
-            cpp += CP_SIZE + 1;
+        } else if (BeamIsReturnCallAccTrace(w)) {
+            cpp += CP_SIZE + 2;
         } else if (BeamIsReturnToTrace(w)) {
             *return_to_trace = 1;
             cpp += CP_SIZE;
@@ -717,6 +747,12 @@ static void restore_cp_after_trace(Process *c_p, const Eterm cp_save[2]) {
     c_p->stop[0] = cp_save[0];
 }
 
+static ERTS_INLINE Uint get_allocated_words(Process *c_p, Sint allocated) {
+    if (c_p->abandoned_heap)
+        return allocated + c_p->htop - c_p->heap + c_p->mbuf_sz;
+    return allocated + c_p->htop - c_p->high_water + c_p->mbuf_sz;
+}
+
 BeamInstr
 erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
 {
@@ -735,12 +771,15 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
     ASSERT((bp_flags & ~ERTS_BPF_ALL) == 0);
     if (bp_flags & (ERTS_BPF_LOCAL_TRACE|
 		    ERTS_BPF_GLOBAL_TRACE|
-		    ERTS_BPF_TIME_TRACE_ACTIVE) &&
+		    ERTS_BPF_TIME_TRACE_ACTIVE|
+                    ERTS_BPF_MEM_TRACE_ACTIVE) &&
 	!IS_TRACED_FL(c_p, F_TRACE_CALLS)) {
 	bp_flags &= ~(ERTS_BPF_LOCAL_TRACE|
 		      ERTS_BPF_GLOBAL_TRACE|
 		      ERTS_BPF_TIME_TRACE|
-		      ERTS_BPF_TIME_TRACE_ACTIVE);
+		      ERTS_BPF_TIME_TRACE_ACTIVE|
+                      ERTS_BPF_MEM_TRACE|
+                      ERTS_BPF_MEM_TRACE_ACTIVE);
 	if (bp_flags == 0) {	/* Quick exit */
 	    return g->orig_instr;
 	}
@@ -776,12 +815,28 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
 	erts_atomic_inc_nob(&bp->count->acount);
     }
 
-    if (bp_flags & ERTS_BPF_TIME_TRACE_ACTIVE) {
-        const ErtsCodeInfo* prev_info;
+    if (bp_flags & (ERTS_BPF_TIME_TRACE_ACTIVE | ERTS_BPF_MEM_TRACE_ACTIVE)) {
+        const ErtsCodeInfo* prev_info = 0;
         ErtsCodePtr w;
         Eterm* E;
 
-        prev_info = erts_trace_time_call(c_p, info, bp->time);
+        if (bp_flags & ERTS_BPF_TIME_TRACE_ACTIVE) {
+            BpDataAccumulator time = get_mtime(c_p);
+            prev_info = erts_trace_call(c_p, info, time, ERTS_PSD_CALL_TIME_BP, bp->time);
+        }
+
+        if (bp_flags & ERTS_BPF_MEM_TRACE_ACTIVE) {
+            BpDataAccumulator allocated;
+            /* if this is initial call, ignore 'allocated' */
+            if (c_p->u.initial.function == info->mfa.function && c_p->u.initial.module == info->mfa.module &&
+                c_p->u.initial.arity == info->mfa.arity)
+                allocated = 0;
+            else {
+                process_breakpoint_trace_t * pbt = ERTS_PROC_GET_CALL_MEMORY(c_p);
+                allocated = get_allocated_words(c_p, pbt ? pbt->allocated : 0);
+            }
+            prev_info = erts_trace_call(c_p, info, allocated, ERTS_PSD_CALL_MEMORY_BP, bp->memory);
+        }
 
         E = c_p->stop;
 
@@ -789,8 +844,8 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
 
         if (!(BeamIsReturnTrace(w) ||
               BeamIsReturnToTrace(w) ||
-              BeamIsReturnTimeTrace(w))) {
-            int need = CP_SIZE + 1;
+              BeamIsReturnCallAccTrace(w))) {
+            int need = CP_SIZE + 2;
 
             ASSERT(c_p->htop <= E && E <= c_p->hend);
 
@@ -804,9 +859,10 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
 
             ASSERT(c_p->htop <= E && E <= c_p->hend);
 
-            E -= 2;
+            E -= 3;
+            E[2] = make_small(bp_flags);
             E[1] = prev_info ? make_cp(erts_codeinfo_to_code(prev_info)) : NIL;
-            E[0] = make_cp(beam_return_time_trace);
+            E[0] = make_cp(beam_call_trace_return);
 
             if (erts_frame_layout == ERTS_FRAME_LAYOUT_FP_RA) {
                 E -= 1;
@@ -821,7 +877,7 @@ erts_generic_breakpoint(Process* c_p, ErtsCodeInfo *info, Eterm* reg)
     if (bp_flags & ERTS_BPF_DEBUG) {
         return BeamOpCodeAddr(op_i_debug_breakpoint);
     } else {
-	return g->orig_instr;
+        return g->orig_instr;
     }
 }
 
@@ -918,13 +974,13 @@ do_call_trace(Process* c_p, ErtsCodeInfo* info, Eterm* reg,
 }
 
 const ErtsCodeInfo*
-erts_trace_time_call(Process* c_p, const ErtsCodeInfo *info, BpDataTime* bdt)
+erts_trace_call(Process* c_p, const ErtsCodeInfo *info, BpDataAccumulator accum,
+                int psd_ix, BpDataCallTrace* bdt)
 {
-    ErtsMonotonicTime time;
-    process_breakpoint_time_t *pbt = NULL;
-    bp_data_time_item_t sitem, *item = NULL;
-    bp_time_hash_t *h = NULL;
-    BpDataTime *pbdt = NULL;
+    process_breakpoint_trace_t *pbt = NULL;
+    bp_data_trace_item_t sitem, *item = NULL;
+    bp_trace_hash_t *h = NULL;
+    BpDataCallTrace *pbdt = NULL;
     Uint32 six = acquire_bp_sched_ix(c_p);
     const ErtsCodeInfo* prev_info;
 
@@ -932,32 +988,33 @@ erts_trace_time_call(Process* c_p, const ErtsCodeInfo *info, BpDataTime* bdt)
     ASSERT(erts_atomic32_read_acqb(&c_p->state) & (ERTS_PSFLG_RUNNING
 						       | ERTS_PSFLG_DIRTY_RUNNING));
 
-    /* get previous timestamp and breakpoint
+    /* get previous (timestamp or allocated memory size) and breakpoint
      * from the process psd  */
     
-    pbt = ERTS_PROC_GET_CALL_TIME(c_p);
-    time = get_mtime(c_p);
+    pbt = (process_breakpoint_trace_t *) erts_psd_get(c_p, psd_ix);
 
     /* get pbt
-     * timestamp = t0
+     * timestamp/allocated = ta0
      * lookup bdt from code
-     * set ts0 to pbt
+     * set ts0/alloc0 to pbt
      * add call count here?
      */
     if (pbt == 0) {
 	/* First call of process to instrumented function */
-	pbt = Alloc(sizeof(process_breakpoint_time_t));
-	(void) ERTS_PROC_SET_CALL_TIME(c_p, pbt);
+	pbt = Alloc(sizeof(process_breakpoint_trace_t));
+        erts_psd_set(c_p, psd_ix, pbt);
+        pbt->allocated = 0;
         pbt->ci = NULL;
     }
     else if (pbt->ci) {
-	/* add time to previous code */
-	sitem.time = time - pbt->time;
+	/* add time/allocation to previous code */
+	sitem.accumulator = accum - pbt->accumulator;
 	sitem.pid = c_p->common.id;
 	sitem.count = 0;
 
 	/* previous breakpoint */
-	pbdt = get_time_break(pbt->ci);
+	pbdt = (psd_ix == ERTS_PSD_CALL_TIME_BP) ?
+                get_time_break(pbt->ci) : get_memory_break(pbt->ci);
 
 	/* if null then the breakpoint was removed */
 	if (pbdt) {
@@ -970,7 +1027,7 @@ erts_trace_time_call(Process* c_p, const ErtsCodeInfo *info, BpDataTime* bdt)
 	    if (!item) {
 		item = bp_hash_put(h, &sitem);
 	    } else {
-		BP_TIME_ADD(item, &sitem);
+		BP_ACCUMULATE(item, &sitem);
 	    }
 	}
     }
@@ -979,7 +1036,7 @@ erts_trace_time_call(Process* c_p, const ErtsCodeInfo *info, BpDataTime* bdt)
     /* Add count to this code */
     sitem.pid     = c_p->common.id;
     sitem.count   = 1;
-    sitem.time    = 0;
+    sitem.accumulator = 0;
 
     /* this breakpoint */
     ASSERT(bdt);
@@ -992,79 +1049,96 @@ erts_trace_time_call(Process* c_p, const ErtsCodeInfo *info, BpDataTime* bdt)
     if (!item) {
 	item = bp_hash_put(h, &sitem);
     } else {
-	BP_TIME_ADD(item, &sitem);
+	BP_ACCUMULATE(item, &sitem);
     }
 
     prev_info = pbt->ci;
     pbt->ci = info;
-    pbt->time = time;
+    pbt->accumulator = accum;
 
     release_bp_sched_ix(six);
     return prev_info;
 }
 
-void
-erts_trace_time_return(Process *p, const ErtsCodeInfo *prev_info)
+
+static void
+call_trace_add(Process *p, BpDataCallTrace *pbdt, Uint32 six,
+               BpDataAccumulator accum, BpDataAccumulator prev_accum)
 {
-    ErtsMonotonicTime time;
-    process_breakpoint_time_t *pbt = NULL;
-    bp_data_time_item_t sitem, *item = NULL;
-    bp_time_hash_t *h = NULL;
-    BpDataTime *pbdt = NULL;
+    bp_data_trace_item_t sitem, *item = NULL;
+    bp_trace_hash_t *h = NULL;
+
+    sitem.accumulator = accum - prev_accum;
+    sitem.pid   = p->common.id;
+    sitem.count = 0;
+
+    /* beware, the trace_pattern might have been removed */
+    if (pbdt) {
+
+        h = &(pbdt->hash[six]);
+
+        ASSERT(h);
+        ASSERT(h->item);
+
+        item = bp_hash_get(h, &sitem);
+        if (!item) {
+            item = bp_hash_put(h, &sitem);
+        } else {
+            BP_ACCUMULATE(item, &sitem);
+        }
+    }
+}
+
+void
+erts_call_trace_return(Process *p, const ErtsCodeInfo *prev_info,
+                       Eterm bp_flags_term)
+{
+    process_breakpoint_trace_t *pbt = NULL;
+    BpDataCallTrace *pbdt;
     Uint32 six = acquire_bp_sched_ix(p);
+    const Uint bp_flags = unsigned_val(bp_flags_term);
 
     ASSERT(p);
     ASSERT(erts_atomic32_read_acqb(&p->state) & (ERTS_PSFLG_RUNNING
 						     | ERTS_PSFLG_DIRTY_RUNNING));
 
-    /* get previous timestamp and breakpoint
-     * from the process psd  */
-
-    pbt = ERTS_PROC_GET_CALL_TIME(p);
-    time = get_mtime(p);
-
     /* get pbt
-     * lookup bdt from code
-     * timestamp = t1
-     * get ts0 from pbt
-     * get item from bdt->hash[bp_hash(p->id)]
-     * ack diff (t1, t0) to item
-     */
+    * lookup bdt from code
+    * timestamp/alloc = t1
+    * get ts0/alloc from pbt
+    * get item from bdt->hash[bp_hash(p->id)]
+    * add diff (t1, t0) to item
+    */
+    if (bp_flags & ERTS_BPF_TIME_TRACE_ACTIVE) {
+        /* get previous timestamp and breakpoint
+        * from the process psd  */
+        pbt = ERTS_PROC_GET_CALL_TIME(p);
+        if (pbt) {
+            ErtsMonotonicTime time = get_mtime(p);
 
-    if (pbt) {
+            /* might have been removed due to
+            * trace_pattern(false)
+            */
+            ASSERT(pbt->ci);
+            /* previous breakpoint */
+            pbdt = get_time_break(pbt->ci);
+            call_trace_add(p, pbdt, six, time, pbt->accumulator);
+            pbt->ci = prev_info;
+            pbt->accumulator = time;
+        }
+    }
 
-	/* might have been removed due to
-	 * trace_pattern(false)
-	 */
-	ASSERT(pbt->ci);
-
-	sitem.time = time - pbt->time;
-	sitem.pid   = p->common.id;
-	sitem.count = 0;
-
-	/* previous breakpoint */
-	pbdt = get_time_break(pbt->ci);
-
-	/* beware, the trace_pattern might have been removed */
-	if (pbdt) {
-
-	    h = &(pbdt->hash[six]);
-
-	    ASSERT(h);
-	    ASSERT(h->item);
-
-	    item = bp_hash_get(h, &sitem);
-	    if (!item) {
-		item = bp_hash_put(h, &sitem);
-	    } else {
-		BP_TIME_ADD(item, &sitem);
-	    }
-
-	}
-
-	pbt->ci = prev_info;
-	pbt->time = time;
-
+    if (bp_flags & ERTS_BPF_MEM_TRACE_ACTIVE) {
+        pbt = (process_breakpoint_trace_t *) erts_psd_get(p, ERTS_PSD_CALL_MEMORY_BP);
+        if (pbt) {
+            Sint allocated = get_allocated_words(p, pbt->allocated);
+            /* previous breakpoint */
+            ASSERT(pbt->ci);
+            pbdt = get_memory_break(pbt->ci);
+            call_trace_add(p, pbdt, six, allocated, pbt->accumulator);
+            pbt->ci = prev_info;
+            pbt->accumulator = allocated;
+        }
     }
 
     release_bp_sched_ix(six);
@@ -1117,65 +1191,76 @@ erts_is_count_break(const ErtsCodeInfo *ci, Uint *count_ret)
     return 0;
 }
 
-int erts_is_time_break(Process *p, const ErtsCodeInfo *ci, Eterm *retval) {
+int erts_is_call_break(Process *p, int is_time, const ErtsCodeInfo *ci,
+                       Eterm *retval) {
     Uint i, ix;
-    bp_time_hash_t hash;
-    Uint size;
-    Eterm *hp, t;
-    bp_data_time_item_t *item = NULL;
-    BpDataTime *bdt = get_time_break(ci);
+    bp_trace_hash_t hash;
+    bp_data_trace_item_t *item = NULL;
+    BpDataCallTrace *bdt = is_time ? get_time_break(ci) : get_memory_break(ci);
 
-    if (bdt) {
-	if (retval) {
-	    /* collect all hashes to one hash */
-	    bp_hash_init(&hash, 64);
-	    /* foreach threadspecific hash */
-	    for (i = 0; i < bdt->n; i++) {
-		bp_data_time_item_t *sitem;
+    if (!bdt)
+        return 0;
 
-	        /* foreach hash bucket not NIL*/
-		for(ix = 0; ix < bdt->hash[i].n; ix++) {
-		    item = &(bdt->hash[i].item[ix]);
-		    if (item->pid != NIL) {
-			sitem = bp_hash_get(&hash, item);
-			if (sitem) {
-			    BP_TIME_ADD(sitem, item);
-			} else {
-			    bp_hash_put(&hash, item);
-			}
-		    }
-		}
-	    }
-	    /* *retval should be NIL or term from previous bif in export entry */
+    ASSERT(retval);
+    /* collect all hashes to one hash */
+    bp_hash_init(&hash, 64);
+    /* foreach threadspecific hash */
+    for (i = 0; i < bdt->n; i++) {
+        bp_data_trace_item_t *sitem;
 
-	    if (hash.used > 0) {
-		size = (5 + 2)*hash.used;
-		hp   = HAlloc(p, size);
-
-		for(ix = 0; ix < hash.n; ix++) {
-		    item = &(hash.item[ix]);
-		    if (item->pid != NIL) {
-			ErtsMonotonicTime sec, usec;
-			usec = ERTS_MONOTONIC_TO_USEC(item->time);
-			sec = usec / 1000000;
-			usec = usec - sec*1000000;
-			t = TUPLE4(hp, item->pid,
-				make_small(item->count),
-				   make_small((Uint) sec),
-				   make_small((Uint) usec));
-			hp += 5;
-			*retval = CONS(hp, t, *retval); hp += 2;
-		    }
-		}
-	    }
-	    bp_hash_delete(&hash);
-	}
-	return 1;
+        /* foreach hash bucket not NIL*/
+        for(ix = 0; ix < bdt->hash[i].n; ix++) {
+            item = &(bdt->hash[i].item[ix]);
+            if (item->pid != NIL) {
+                sitem = bp_hash_get(&hash, item);
+                if (sitem) {
+                    BP_ACCUMULATE(sitem, item);
+                } else {
+                    bp_hash_put(&hash, item);
+                }
+            }
+        }
     }
+    /* *retval should be NIL or term from previous bif in export entry */
 
-    return 0;
+    if (hash.used > 0) {
+        Uint size;
+        Eterm *hp, *hp_end, t;
+
+        size = hash.used * (is_time ? (2+5) : (2+4+ERTS_MAX_SINT64_HEAP_SIZE));
+        hp   = HAlloc(p, size);
+        hp_end = hp + size;
+
+        for(ix = 0; ix < hash.n; ix++) {
+            item = &(hash.item[ix]);
+            if (item->pid != NIL) {
+                if (is_time) {
+                    BpDataAccumulator sec, usec;
+                    usec = ERTS_MONOTONIC_TO_USEC(item->accumulator);
+                    sec = usec / 1000000;
+                    usec = usec - sec*1000000;
+                    t = TUPLE4(hp, item->pid,
+                               make_small(item->count),
+                               make_small((Uint) sec),
+                               make_small((Uint) usec));
+                    hp += 5;
+                }
+                else {
+                    Eterm words = erts_bld_sint64(&hp, NULL, item->accumulator);
+                    t = TUPLE3(hp, item->pid,
+                               make_small(item->count),
+                               words);
+                    hp += 4;
+                }
+                *retval = CONS(hp, t, *retval); hp += 2;
+            }
+        }
+        ASSERT(hp <= hp_end);
+        HRelease(p, hp_end, hp);
+    }
+    bp_hash_delete(&hash);
+    return 1;
 }
-
 
 const ErtsCodeInfo *
 erts_find_local_func(const ErtsCodeMFA *mfa) {
@@ -1203,14 +1288,14 @@ erts_find_local_func(const ErtsCodeMFA *mfa) {
     return NULL;
 }
 
-static void bp_hash_init(bp_time_hash_t *hash, Uint n) {
-    Uint size = sizeof(bp_data_time_item_t)*n;
+static void bp_hash_init(bp_trace_hash_t *hash, Uint n) {
+    Uint size = sizeof(bp_data_trace_item_t)*n;
     Uint i;
 
     hash->n    = n;
     hash->used = 0;
 
-    hash->item = (bp_data_time_item_t *)Alloc(size);
+    hash->item = (bp_data_trace_item_t *)Alloc(size);
     sys_memzero(hash->item, size);
 
     for(i = 0; i < n; ++i) {
@@ -1218,15 +1303,15 @@ static void bp_hash_init(bp_time_hash_t *hash, Uint n) {
     }
 }
 
-static void bp_hash_rehash(bp_time_hash_t *hash, Uint n) {
-    bp_data_time_item_t *item = NULL;
-    Uint size = sizeof(bp_data_time_item_t)*n;
+static void bp_hash_rehash(bp_trace_hash_t *hash, Uint n) {
+    bp_data_trace_item_t *item = NULL;
+    Uint size = sizeof(bp_data_trace_item_t)*n;
     Uint ix;
     Uint hval;
 
     ASSERT(n > 0);
 
-    item = (bp_data_time_item_t *)Alloc(size);
+    item = (bp_data_trace_item_t *)Alloc(size);
     sys_memzero(item, size);
 
     for( ix = 0; ix < n; ++ix) {
@@ -1246,7 +1331,7 @@ static void bp_hash_rehash(bp_time_hash_t *hash, Uint n) {
 	    }
 	    item[hval].pid     = hash->item[ix].pid;
 	    item[hval].count   = hash->item[ix].count;
-	    item[hval].time    = hash->item[ix].time;
+	    item[hval].accumulator = hash->item[ix].accumulator;
 	}
     }
 
@@ -1254,10 +1339,10 @@ static void bp_hash_rehash(bp_time_hash_t *hash, Uint n) {
     hash->n = n;
     hash->item = item;
 }
-static ERTS_INLINE bp_data_time_item_t * bp_hash_get(bp_time_hash_t *hash, bp_data_time_item_t *sitem) {
+static ERTS_INLINE bp_data_trace_item_t * bp_hash_get(bp_trace_hash_t *hash, bp_data_trace_item_t *sitem) {
     Eterm pid = sitem->pid;
     Uint hval = (pid >> 4) % hash->n;
-    bp_data_time_item_t *item = NULL;
+    bp_data_trace_item_t *item = NULL;
 
     item = hash->item;
 
@@ -1269,10 +1354,10 @@ static ERTS_INLINE bp_data_time_item_t * bp_hash_get(bp_time_hash_t *hash, bp_da
     return &(item[hval]);
 }
 
-static ERTS_INLINE bp_data_time_item_t * bp_hash_put(bp_time_hash_t *hash, bp_data_time_item_t* sitem) {
+static ERTS_INLINE bp_data_trace_item_t * bp_hash_put(bp_trace_hash_t *hash, bp_data_trace_item_t* sitem) {
     Uint hval;
     float r = 0.0;
-    bp_data_time_item_t *item;
+    bp_data_trace_item_t *item;
 
     /* make sure that the hash is not saturated */
     /* if saturated, rehash it */
@@ -1294,25 +1379,33 @@ static ERTS_INLINE bp_data_time_item_t * bp_hash_put(bp_time_hash_t *hash, bp_da
     item = &(hash->item[hval]);
 
     item->pid     = sitem->pid;
-    item->time    = sitem->time;
+    item->accumulator = sitem->accumulator;
     item->count   = sitem->count;
     hash->used++;
 
     return item;
 }
 
-static void bp_hash_delete(bp_time_hash_t *hash) {
+static void bp_hash_delete(bp_trace_hash_t *hash) {
     hash->n = 0;
     hash->used = 0;
     Free(hash->item);
     hash->item = NULL;
 }
 
+static void bp_hash_reset(BpDataCallTrace* bdt) {
+    Uint i;
+    for (i = 0; i < bdt->n; i++) {
+        bp_hash_delete(&(bdt->hash[i]));
+        bp_hash_init(&(bdt->hash[i]), 32);
+    }
+}
+
 void erts_schedule_time_break(Process *p, Uint schedule) {
-    process_breakpoint_time_t *pbt = NULL;
-    bp_data_time_item_t sitem, *item = NULL;
-    bp_time_hash_t *h = NULL;
-    BpDataTime *pbdt = NULL;
+    process_breakpoint_trace_t *pbt = NULL;
+    bp_data_trace_item_t sitem, *item = NULL;
+    bp_trace_hash_t *h = NULL;
+    BpDataCallTrace *pbdt = NULL;
     Uint32 six = acquire_bp_sched_ix(p);
 
     ASSERT(p);
@@ -1333,7 +1426,7 @@ void erts_schedule_time_break(Process *p, Uint schedule) {
             if (pbt->ci) {
                 pbdt = get_time_break(pbt->ci);
                 if (pbdt) {
-                    sitem.time = get_mtime(p) - pbt->time;
+                    sitem.accumulator = get_mtime(p) - pbt->accumulator;
                     sitem.pid   = p->common.id;
                     sitem.count = 0;
 
@@ -1346,7 +1439,7 @@ void erts_schedule_time_break(Process *p, Uint schedule) {
                     if (!item) {
                         item = bp_hash_put(h, &sitem);
                     } else {
-                        BP_TIME_ADD(item, &sitem);
+                        BP_ACCUMULATE(item, &sitem);
                     }
                 }
             }
@@ -1356,7 +1449,7 @@ void erts_schedule_time_break(Process *p, Uint schedule) {
 	     * timestamp it and remove the previous
 	     * timestamp in the psd.
 	     */
-	    pbt->time = get_mtime(p);
+	    pbt->accumulator = get_mtime(p);
 	    break;
 	default :
 	    ASSERT(0);
@@ -1450,17 +1543,20 @@ set_function_break(ErtsCodeInfo *ci, Binary *match_spec, Uint break_flags,
 	ASSERT((bp->flags & ~ERTS_BPF_ALL) == 0);
 	return;
     } else if (common & ERTS_BPF_TIME_TRACE) {
-	BpDataTime* bdt = bp->time;
-	Uint i = 0;
-
 	if (count_op == ERTS_BREAK_PAUSE) {
 	    bp->flags &= ~ERTS_BPF_TIME_TRACE_ACTIVE;
 	} else {
 	    bp->flags |= ERTS_BPF_TIME_TRACE_ACTIVE;
-	    for (i = 0; i < bdt->n; i++) {
-		bp_hash_delete(&(bdt->hash[i]));
-		bp_hash_init(&(bdt->hash[i]), 32);
-	    }
+	    bp_hash_reset(bp->time);
+	}
+	ASSERT((bp->flags & ~ERTS_BPF_ALL) == 0);
+	return;
+    } else if (common & ERTS_BPF_MEM_TRACE) {
+	if (count_op == ERTS_BREAK_PAUSE) {
+	    bp->flags &= ~ERTS_BPF_MEM_TRACE_ACTIVE;
+	} else {
+	    bp->flags |= ERTS_BPF_MEM_TRACE_ACTIVE;
+	    bp_hash_reset(bp->memory);
 	}
 	ASSERT((bp->flags & ~ERTS_BPF_ALL) == 0);
 	return;
@@ -1491,19 +1587,23 @@ set_function_break(ErtsCodeInfo *ci, Binary *match_spec, Uint break_flags,
 	erts_refc_init(&bcp->refc, 1);
 	erts_atomic_init_nob(&bcp->acount, 0);
 	bp->count = bcp;
-    } else if (break_flags & ERTS_BPF_TIME_TRACE) {
-	BpDataTime* bdt;
+    } else if (break_flags & (ERTS_BPF_TIME_TRACE | ERTS_BPF_MEM_TRACE)) {
+	BpDataCallTrace* bdt;
 	Uint i;
 
-	ASSERT((bp->flags & ERTS_BPF_TIME_TRACE) == 0);
-	bdt = Alloc(sizeof(BpDataTime));
+	ASSERT((break_flags & bp->flags & ERTS_BPF_TIME_TRACE) == 0);
+        ASSERT((break_flags & bp->flags & ERTS_BPF_MEM_TRACE) == 0);
+	bdt = Alloc(sizeof(BpDataCallTrace));
 	erts_refc_init(&bdt->refc, 1);
 	bdt->n = erts_no_schedulers + 1;
-	bdt->hash = Alloc(sizeof(bp_time_hash_t)*(bdt->n));
+	bdt->hash = Alloc(sizeof(bp_trace_hash_t)*(bdt->n));
 	for (i = 0; i < bdt->n; i++) {
 	    bp_hash_init(&(bdt->hash[i]), 32);
 	}
-	bp->time = bdt;
+        if (break_flags & ERTS_BPF_TIME_TRACE)
+            bp->time = bdt;
+        else
+            bp->memory = bdt;
     }
 
     bp->flags |= break_flags;
@@ -1553,7 +1653,11 @@ clear_function_break(const ErtsCodeInfo *ci, Uint break_flags)
     }
     if (common & ERTS_BPF_TIME_TRACE) {
 	ASSERT((bp->flags & ERTS_BPF_TIME_TRACE_ACTIVE) == 0);
-	bp_time_unref(bp->time);
+	bp_calltrace_unref(bp->time);
+    }
+    if (common & ERTS_BPF_MEM_TRACE) {
+        ASSERT((bp->flags & ERTS_BPF_MEM_TRACE_ACTIVE) == 0);
+	bp_calltrace_unref(bp->memory);
     }
 
     ASSERT((bp->flags & ~ERTS_BPF_ALL) == 0);
@@ -1579,7 +1683,7 @@ bp_count_unref(BpCount* bcp)
 }
 
 static void
-bp_time_unref(BpDataTime* bdt)
+bp_calltrace_unref(BpDataCallTrace* bdt)
 {
     if (erts_refc_dectest(&bdt->refc, 0) <= 0) {
 	Uint i = 0;
@@ -1592,11 +1696,18 @@ bp_time_unref(BpDataTime* bdt)
     }
 }
 
-static BpDataTime*
+static BpDataCallTrace*
 get_time_break(const ErtsCodeInfo *ci)
 {
     GenericBpData* bp = check_break(ci, ERTS_BPF_TIME_TRACE);
     return bp ? bp->time : 0;
+}
+
+static BpDataCallTrace*
+get_memory_break(const ErtsCodeInfo *ci)
+{
+    GenericBpData* bp = check_break(ci, ERTS_BPF_MEM_TRACE);
+    return bp ? bp->memory : 0;
 }
 
 static GenericBpData*

--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -416,8 +416,8 @@ ErtsCodePtr erts_printable_return_address(Process* p, Eterm *E) {
 
         if (BeamIsReturnTrace(return_address)) {
             scanner += CP_SIZE + 2;
-        } else if (BeamIsReturnTimeTrace(return_address)) {
-            scanner += CP_SIZE + 1;
+        } else if (BeamIsReturnCallAccTrace(return_address)) {
+            scanner += CP_SIZE + 2;
         } else if (BeamIsReturnToTrace(return_address)) {
             scanner += CP_SIZE;
         } else {
@@ -624,8 +624,8 @@ next_catch(Process* c_p, Eterm *reg) {
                 }
 
                 ptr += CP_SIZE + 2;
-            } else if (BeamIsReturnTimeTrace(return_address)) {
-                ptr += CP_SIZE + 1;
+            } else if (BeamIsReturnCallAccTrace(return_address)) {
+                ptr += CP_SIZE + 2;
             } else if (BeamIsReturnToTrace(return_address)) {
                 have_return_to_trace = 1; /* Record next cp */
                 return_to_trace_address = NULL;
@@ -802,8 +802,8 @@ gather_stacktrace(Process* p, struct StackTrace* s, int depth)
 
             if (BeamIsReturnTrace(return_address)) {
                 ptr += CP_SIZE + 2;
-            } else if (BeamIsReturnTimeTrace(return_address)) {
-                ptr += CP_SIZE + 1;
+            } else if (BeamIsReturnCallAccTrace(return_address)) {
+                ptr += CP_SIZE + 2;
             } else if (BeamIsReturnToTrace(return_address)) {
                 ptr += CP_SIZE;
             } else {

--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -415,11 +415,11 @@ ErtsCodePtr erts_printable_return_address(Process* p, Eterm *E) {
         erts_inspect_frame(scanner, &return_address);
 
         if (BeamIsReturnTrace(return_address)) {
-            scanner += CP_SIZE + 2;
+            scanner += CP_SIZE + BEAM_RETURN_TRACE_FRAME_SZ;
         } else if (BeamIsReturnCallAccTrace(return_address)) {
-            scanner += CP_SIZE + 2;
+            scanner += CP_SIZE + BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
         } else if (BeamIsReturnToTrace(return_address)) {
-            scanner += CP_SIZE;
+            scanner += CP_SIZE + BEAM_RETURN_TO_TRACE_FRAME_SZ;
         } else {
             return return_address;
         }
@@ -622,15 +622,14 @@ next_catch(Process* c_p, Eterm *reg) {
                     ASSERT_MFA(mfa);
                     erts_trace_exception(c_p, mfa, reg[3], reg[1], tracer);
                 }
-
-                ptr += CP_SIZE + 2;
+                ptr += CP_SIZE + BEAM_RETURN_TRACE_FRAME_SZ;
             } else if (BeamIsReturnCallAccTrace(return_address)) {
-                ptr += CP_SIZE + 2;
+                ptr += CP_SIZE + BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
             } else if (BeamIsReturnToTrace(return_address)) {
                 have_return_to_trace = 1; /* Record next cp */
                 return_to_trace_address = NULL;
 
-                ptr += CP_SIZE;
+                ptr += CP_SIZE + BEAM_RETURN_TO_TRACE_FRAME_SZ;
             } else {
                 /* This is an ordinary call frame: if the previous frame was a
                  * return_to trace we should record this CP as a return_to
@@ -801,11 +800,11 @@ gather_stacktrace(Process* p, struct StackTrace* s, int depth)
             erts_inspect_frame(ptr, &return_address);
 
             if (BeamIsReturnTrace(return_address)) {
-                ptr += CP_SIZE + 2;
+                ptr += CP_SIZE + BEAM_RETURN_TRACE_FRAME_SZ;
             } else if (BeamIsReturnCallAccTrace(return_address)) {
-                ptr += CP_SIZE + 2;
+                ptr += CP_SIZE + BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
             } else if (BeamIsReturnToTrace(return_address)) {
-                ptr += CP_SIZE;
+                ptr += CP_SIZE + BEAM_RETURN_TO_TRACE_FRAME_SZ;
             } else {
                 if (return_address != prev) {
                     ErtsCodePtr adjusted_address;

--- a/erts/emulator/beam/beam_common.h
+++ b/erts/emulator/beam/beam_common.h
@@ -290,7 +290,7 @@ extern ErtsCodePtr beam_unloaded_fun;
 extern ErtsCodePtr beam_return_to_trace;   /* OpCode(i_return_to_trace) */
 extern ErtsCodePtr beam_return_trace;      /* OpCode(i_return_trace) */
 extern ErtsCodePtr beam_exception_trace;   /* OpCode(i_exception_trace) */
-extern ErtsCodePtr beam_return_time_trace; /* OpCode(i_return_time_trace) */
+extern ErtsCodePtr beam_call_trace_return; /* OpCode(i_call_trace_return) */
 
 /** @brief Inspects an Erlang stack frame, returning the base of the data
  *         (first Y register).

--- a/erts/emulator/beam/emu/beam_emu.c
+++ b/erts/emulator/beam/emu/beam_emu.c
@@ -138,9 +138,9 @@ ErtsCodePtr beam_return_trace;
 static BeamInstr beam_exception_trace_[1];
 ErtsCodePtr beam_exception_trace;
 
-/* OpCode(i_return_time_trace) */
-static BeamInstr beam_return_time_trace_[1];
-ErtsCodePtr beam_return_time_trace;
+/* OpCode(i_call_trace_return) */
+static BeamInstr beam_call_trace_return_[1];
+ErtsCodePtr beam_call_trace_return;
 
 /* The address field of every fun that has no loaded code will point to
  * beam_unloaded_fun[]. The -1 in beam_unloaded_fun[0] will be interpreted
@@ -696,8 +696,8 @@ init_emulator_finish(void)
     beam_exception_trace_[0]   = BeamOpCodeAddr(op_return_trace); /* UGLY */
     beam_exception_trace = (ErtsCodePtr)&beam_exception_trace_[0];
 
-    beam_return_time_trace_[0] = BeamOpCodeAddr(op_i_return_time_trace);
-    beam_return_time_trace = (ErtsCodePtr)&beam_return_time_trace_[0];
+    beam_call_trace_return_[0] = BeamOpCodeAddr(op_i_call_trace_return);
+    beam_call_trace_return = (ErtsCodePtr)&beam_call_trace_return_[0];
 
     install_bifs();
 }

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -69,7 +69,7 @@ nif_start
 
 i_generic_breakpoint
 i_debug_breakpoint
-i_return_time_trace
+i_call_trace_return
 i_return_to_trace
 i_yield
 trace_jump W

--- a/erts/emulator/beam/emu/trace_instrs.tab
+++ b/erts/emulator/beam/emu/trace_instrs.tab
@@ -27,7 +27,7 @@ return_trace() {
     erts_trace_return(c_p, mfa, r(0), ERTS_TRACER_FROM_ETERM(E+2)/* tracer */);
     ERTS_REQ_PROC_MAIN_LOCK(c_p);
     SWAPIN;
-    E += 3;
+    E += 1 + BEAM_RETURN_TRACE_FRAME_SZ;
     $RETURN();
     Goto(*I);
     //| -no_next
@@ -62,7 +62,7 @@ i_call_trace_return() {
     erts_call_trace_return(c_p, cinfo, E[2]);
     SWAPIN;
 
-    E += 3;
+    E += 1 + BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
     $RETURN();
     Goto(*I);
     //| -no_next
@@ -94,7 +94,7 @@ i_return_to_trace() {
         ERTS_REQ_PROC_MAIN_LOCK(c_p);
         SWAPIN;
     }
-    E += 1;
+    E += 1 + BEAM_RETURN_TO_TRACE_FRAME_SZ;
     $RETURN();
     Goto(*I);
     //| -no_next

--- a/erts/emulator/beam/emu/trace_instrs.tab
+++ b/erts/emulator/beam/emu/trace_instrs.tab
@@ -49,7 +49,7 @@ i_generic_breakpoint() {
     //| -no_next
 }
 
-i_return_time_trace() {
+i_call_trace_return() {
     const ErtsCodeInfo *cinfo;
 
     if (is_CP(E[1])) {
@@ -59,10 +59,10 @@ i_return_time_trace() {
     }
 
     SWAPOUT;
-    erts_trace_time_return(c_p, cinfo);
+    erts_call_trace_return(c_p, cinfo, E[2]);
     SWAPIN;
 
-    E += 2;
+    E += 3;
     $RETURN();
     Goto(*I);
     //| -no_next

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -41,6 +41,7 @@
 #include "erl_nfunc_sched.h"
 #include "erl_proc_sig_queue.h"
 #include "beam_common.h"
+#include "beam_bp.h"
 
 #define ERTS_INACT_WR_PB_LEAVE_MUCH_LIMIT 1
 #define ERTS_INACT_WR_PB_LEAVE_MUCH_PERCENTAGE 20
@@ -551,6 +552,7 @@ delay_garbage_collection(Process *p, ErlHeapFragment *live_hf_end, int need, int
 	    }
 	}
 	p->abandoned_heap = orig_heap;
+        erts_adjust_memory_break(p, orig_htop - p->high_water);
     }
 
 #ifdef CHECK_FOR_HOLES
@@ -736,6 +738,12 @@ garbage_collect(Process* p, ErlHeapFragment *live_hf_end,
         dtrace_proc_str(p, pidbuf);
     }
 #endif
+
+    if (p->abandoned_heap)
+        erts_adjust_memory_break(p, p->htop - p->heap + p->mbuf_sz);
+    else
+        erts_adjust_memory_break(p, p->htop - p->high_water + p->mbuf_sz);
+
     /*
      * Test which type of GC to do.
      */
@@ -3824,9 +3832,9 @@ void erts_validate_stack(Process *p, Eterm *frame_ptr, Eterm *stack_top) {
         ASSERT_MFA((ErtsCodeMFA*)cp_val(scanner[0]));
         ASSERT(IS_TRACER_VALID(scanner[1]));
         scanner += 2;
-    } else if (BeamIsReturnTimeTrace(p->i)) {
+    } else if (BeamIsReturnCallAccTrace(p->i)) {
         /* Skip prev_info. */
-        scanner += 1;
+        scanner += 2;
     }
 
     while (next_fp) {
@@ -3849,9 +3857,9 @@ void erts_validate_stack(Process *p, Eterm *frame_ptr, Eterm *stack_top) {
             ASSERT_MFA((ErtsCodeMFA*)cp_val(scanner[2]));
             ASSERT(IS_TRACER_VALID(scanner[3]));
             scanner += 2;
-        } else if (BeamIsReturnTimeTrace((ErtsCodePtr)scanner[1])) {
+        } else if (BeamIsReturnCallAccTrace((ErtsCodePtr)scanner[1])) {
             /* Skip prev_info. */
-            scanner += 1;
+            scanner += 2;
         }
 
         scanner += CP_SIZE;

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -3831,11 +3831,12 @@ void erts_validate_stack(Process *p, Eterm *frame_ptr, Eterm *stack_top) {
         /* Skip MFA and tracer. */
         ASSERT_MFA((ErtsCodeMFA*)cp_val(scanner[0]));
         ASSERT(IS_TRACER_VALID(scanner[1]));
-        scanner += 2;
+        scanner += BEAM_RETURN_TRACE_FRAME_SZ;
     } else if (BeamIsReturnCallAccTrace(p->i)) {
         /* Skip prev_info. */
-        scanner += 2;
+        scanner += BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
     }
+    ERTS_CT_ASSERT(BEAM_RETURN_TO_TRACE_FRAME_SZ == 0);
 
     while (next_fp) {
         ASSERT(next_fp >= stack_top && next_fp <= stack_bottom);
@@ -3856,10 +3857,10 @@ void erts_validate_stack(Process *p, Eterm *frame_ptr, Eterm *stack_top) {
             /* Skip MFA and tracer. */
             ASSERT_MFA((ErtsCodeMFA*)cp_val(scanner[2]));
             ASSERT(IS_TRACER_VALID(scanner[3]));
-            scanner += 2;
+            scanner += BEAM_RETURN_TRACE_FRAME_SZ;
         } else if (BeamIsReturnCallAccTrace((ErtsCodePtr)scanner[1])) {
             /* Skip prev_info. */
-            scanner += 2;
+            scanner += BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
         }
 
         scanner += CP_SIZE;

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -660,6 +660,7 @@ erts_try_alloc_message_on_heap(Process *pp,
 	mp = erts_alloc_message(0, NULL);
 	mp->data.attached = NULL;
 	*on_heap_p = !0;
+        erts_adjust_memory_break(pp, -sz);
     }
     else if (pp && erts_proc_trylock(pp, ERTS_PROC_LOCK_MAIN) == 0) {
 	locked_main = 1;
@@ -975,6 +976,7 @@ void erts_save_message_in_proc(Process *p, ErtsMessage *msgp)
 	hfp = msgp->data.heap_frag;
     }
     else {
+        erts_adjust_message_break(p, ERL_MESSAGE_TERM(msgp));
 	erts_free_message(msgp);
 	return; /* Nothing to save */
     }

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -13043,7 +13043,7 @@ delete_process(Process* p)
 {
     ErtsPSD *psd;
     struct saved_calls *scb;
-    process_breakpoint_time_t *pbt;
+    process_breakpoint_trace_t *pbt;
     Uint32 block_rla_ref = (Uint32) (Uint) p->u.terminate;
 
     VERBOSE(DEBUG_PROCESSES, ("Removing process: %T\n",p->common.id));
@@ -13064,6 +13064,9 @@ delete_process(Process* p)
     }
 
     pbt = ERTS_PROC_SET_CALL_TIME(p, NULL);
+    if (pbt)
+        erts_free(ERTS_ALC_T_BPD, (void *) pbt);
+    pbt = ERTS_PROC_SET_CALL_MEMORY(p, NULL);
     if (pbt)
         erts_free(ERTS_ALC_T_BPD, (void *) pbt);
 

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -871,9 +871,10 @@ erts_reset_max_len(ErtsRunQueue *rq, ErtsRunQueueInfo *rqi)
 #define ERTS_PSD_ETS_OWNED_TABLES               6
 #define ERTS_PSD_ETS_FIXED_TABLES               7
 #define ERTS_PSD_DIST_ENTRY	                8
-#define ERTS_PSD_PENDING_SUSPEND                9 /* keep last... */
+#define ERTS_PSD_PENDING_SUSPEND                9
+#define ERTS_PSD_CALL_MEMORY_BP	               10
 
-#define ERTS_PSD_SIZE				10
+#define ERTS_PSD_SIZE				11
 
 typedef struct {
     void *data[ERTS_PSD_SIZE];
@@ -2234,9 +2235,9 @@ erts_psd_set(Process *p, int ix, void *data)
   ((struct saved_calls *) erts_psd_set((P), ERTS_PSD_SAVED_CALLS_BUF, (void *) (SCB)))
 
 #define ERTS_PROC_GET_CALL_TIME(P) \
-  ((process_breakpoint_time_t *) erts_psd_get((P), ERTS_PSD_CALL_TIME_BP))
+  ((process_breakpoint_trace_t *) erts_psd_get((P), ERTS_PSD_CALL_TIME_BP))
 #define ERTS_PROC_SET_CALL_TIME(P, PBT) \
-  ((process_breakpoint_time_t *) erts_psd_set((P), ERTS_PSD_CALL_TIME_BP, (void *) (PBT)))
+  ((process_breakpoint_trace_t *) erts_psd_set((P), ERTS_PSD_CALL_TIME_BP, (void *) (PBT)))
 
 #define ERTS_PROC_GET_DELAYED_GC_TASK_QS(P) \
     ((ErtsProcSysTaskQs *) erts_psd_get((P), ERTS_PSD_DELAYED_GC_TASK_QS))
@@ -2257,6 +2258,11 @@ erts_psd_set(Process *p, int ix, void *data)
     ((void *) erts_psd_get((P), ERTS_PSD_PENDING_SUSPEND))
 #define ERTS_PROC_SET_PENDING_SUSPEND(P, PS) \
     ((void *) erts_psd_set((P), ERTS_PSD_PENDING_SUSPEND, (void *) (PS)))
+
+#define ERTS_PROC_GET_CALL_MEMORY(P) \
+    ((process_breakpoint_trace_t *) erts_psd_get((P), ERTS_PSD_CALL_MEMORY_BP))
+#define ERTS_PROC_SET_CALL_MEMORY(P, PBT) \
+    ((process_breakpoint_trace_t *) erts_psd_set((P), ERTS_PSD_CALL_MEMORY_BP, (void *) (PBT)))
 
 ERTS_GLB_INLINE Eterm erts_proc_get_error_handler(Process *p);
 ERTS_GLB_INLINE Eterm erts_proc_set_error_handler(Process *p, Eterm handler);

--- a/erts/emulator/beam/erl_trace.h
+++ b/erts/emulator/beam/erl_trace.h
@@ -172,6 +172,7 @@ struct trace_pattern_flags {
     unsigned int meta       : 1; /* Metadata trace breakpoint */
     unsigned int call_count : 1; /* Fast call count breakpoint */
     unsigned int call_time  : 1; /* Fast call time breakpoint */
+    unsigned int call_memory: 1; /* Fast memory tracing breakpoint */
 };
 extern const struct trace_pattern_flags erts_trace_pattern_flags_off;
 extern int erts_call_time_breakpoint_tracing;

--- a/erts/emulator/beam/erl_vm.h
+++ b/erts/emulator/beam/erl_vm.h
@@ -298,8 +298,8 @@ extern void** beam_ops;
 
 #ifndef BEAMASM
 
-#define BeamIsReturnTimeTrace(w) \
-    BeamIsOpCode(*(const BeamInstr*)(w), op_i_return_time_trace)
+#define BeamIsReturnCallAccTrace(w) \
+    BeamIsOpCode(*(const BeamInstr*)(w), op_i_call_trace_return)
 #define BeamIsReturnToTrace(w) \
     BeamIsOpCode(*(const BeamInstr*)(w), op_i_return_to_trace)
 #define BeamIsReturnTrace(w) \
@@ -307,8 +307,8 @@ extern void** beam_ops;
 
 #else /* BEAMASM */
 
-#define BeamIsReturnTimeTrace(w) \
-    ((w) == beam_return_time_trace)
+#define BeamIsReturnCallAccTrace(w) \
+    ((w) == beam_call_trace_return)
 #define BeamIsReturnToTrace(w) \
     ((w) == beam_return_to_trace)
 #define BeamIsReturnTrace(w) \

--- a/erts/emulator/beam/erl_vm.h
+++ b/erts/emulator/beam/erl_vm.h
@@ -316,6 +316,11 @@ extern void** beam_ops;
 
 #endif /* BEAMASM */
 
+/* Stack frame sizes (not including CP_SIZE) */
+#define BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ 2
+#define BEAM_RETURN_TO_TRACE_FRAME_SZ   0
+#define BEAM_RETURN_TRACE_FRAME_SZ      2
+
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 ERTS_GLB_INLINE
 int erts_cp_size()

--- a/erts/emulator/beam/jit/arm/instr_trace.cpp
+++ b/erts/emulator/beam/jit/arm/instr_trace.cpp
@@ -158,24 +158,25 @@ void BeamModuleAssembler::emit_return_trace() {
     emit_return();
 }
 
-void BeamModuleAssembler::emit_i_return_time_trace() {
+void BeamModuleAssembler::emit_i_call_trace_return() {
     /* Pass prev_info if present (is a CP), otherwise null. */
     a.ldr(ARG2, getYRef(0));
-    mov_imm(ARG3, 0);
+    mov_imm(ARG4, 0);
 
     a.tst(ARG2, imm(_CPMASK));
     a.sub(ARG2, ARG2, imm(sizeof(ErtsCodeInfo)));
-    a.csel(ARG2, ARG2, ARG3, arm::CondCode::kEQ);
+    a.csel(ARG2, ARG2, ARG4, arm::CondCode::kEQ);
+    a.ldr(ARG3, getYRef(1));
 
     ERTS_CT_ASSERT(ERTS_HIGHEST_CALLEE_SAVE_XREG >= 1);
     emit_enter_runtime<Update::eStack | Update::eHeap>(1);
 
     a.mov(ARG1, c_p);
-    runtime_call<2>(erts_trace_time_return);
+    runtime_call<3>(erts_call_trace_return);
 
     emit_leave_runtime<Update::eStack | Update::eHeap>(1);
 
-    emit_deallocate(ArgVal(ArgVal::Word, 1));
+    emit_deallocate(ArgVal(ArgVal::Word, 2));
     emit_return();
 }
 

--- a/erts/emulator/beam/jit/arm/instr_trace.cpp
+++ b/erts/emulator/beam/jit/arm/instr_trace.cpp
@@ -154,7 +154,7 @@ void BeamModuleAssembler::emit_return_trace() {
 
     emit_leave_runtime<Update::eStack | Update::eHeap>(1);
 
-    emit_deallocate(ArgVal(ArgVal::Word, 2));
+    emit_deallocate(ArgVal(ArgVal::Word, BEAM_RETURN_TRACE_FRAME_SZ));
     emit_return();
 }
 
@@ -176,7 +176,7 @@ void BeamModuleAssembler::emit_i_call_trace_return() {
 
     emit_leave_runtime<Update::eStack | Update::eHeap>(1);
 
-    emit_deallocate(ArgVal(ArgVal::Word, 2));
+    emit_deallocate(ArgVal(ArgVal::Word, BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ));
     emit_return();
 }
 
@@ -189,7 +189,7 @@ void BeamModuleAssembler::emit_i_return_to_trace() {
 
     emit_leave_runtime<Update::eStack | Update::eHeap>(1);
 
-    emit_deallocate(ArgVal(ArgVal::Word, 0));
+    emit_deallocate(ArgVal(ArgVal::Word, BEAM_RETURN_TO_TRACE_FRAME_SZ));
     emit_return();
 }
 

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -79,7 +79,7 @@ nif_start
 
 i_generic_breakpoint
 i_debug_breakpoint
-i_return_time_trace
+i_call_trace_return
 i_return_to_trace
 trace_jump W
 i_yield

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -1220,8 +1220,8 @@ void beam_jit_return_to_trace(Process *c_p) {
 
             if (BeamIsReturnTrace(return_to_address)) {
                 cpp += CP_SIZE + 2;
-            } else if (BeamIsReturnTimeTrace(return_to_address)) {
-                cpp += CP_SIZE + 1;
+            } else if (BeamIsReturnCallAccTrace(return_to_address)) {
+                cpp += CP_SIZE + 2;
             } else if (BeamIsReturnToTrace(return_to_address)) {
                 cpp += CP_SIZE;
             } else {

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -1219,11 +1219,11 @@ void beam_jit_return_to_trace(Process *c_p) {
             erts_inspect_frame(cpp, &return_to_address);
 
             if (BeamIsReturnTrace(return_to_address)) {
-                cpp += CP_SIZE + 2;
+                cpp += CP_SIZE + BEAM_RETURN_TRACE_FRAME_SZ;
             } else if (BeamIsReturnCallAccTrace(return_to_address)) {
-                cpp += CP_SIZE + 2;
+                cpp += CP_SIZE + BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ;
             } else if (BeamIsReturnToTrace(return_to_address)) {
-                cpp += CP_SIZE;
+                cpp += CP_SIZE + BEAM_RETURN_TO_TRACE_FRAME_SZ;
             } else {
                 break;
             }

--- a/erts/emulator/beam/jit/beam_jit_main.cpp
+++ b/erts/emulator/beam/jit/beam_jit_main.cpp
@@ -67,7 +67,7 @@ ErtsCodePtr beam_unloaded_fun;
 ErtsCodePtr beam_return_to_trace;   /* OpCode(i_return_to_trace) */
 ErtsCodePtr beam_return_trace;      /* OpCode(i_return_trace) */
 ErtsCodePtr beam_exception_trace;   /* UGLY also OpCode(i_return_trace) */
-ErtsCodePtr beam_return_time_trace; /* OpCode(i_return_time_trace) */
+ErtsCodePtr beam_call_trace_return; /* OpCode(i_call_trace_return) */
 
 static JitAllocator *jit_allocator;
 
@@ -220,10 +220,10 @@ void beamasm_init() {
              0,
              op_i_return_to_trace,
              &beam_return_to_trace},
-            {am_return_time_trace,
+            {am_call_trace_return,
              0,
-             op_i_return_time_trace,
-             &beam_return_time_trace}};
+             op_i_call_trace_return,
+             &beam_call_trace_return}};
 
     Eterm mod_name;
     ERTS_DECL_AM(erts_beamasm);

--- a/erts/emulator/beam/jit/x86/instr_trace.cpp
+++ b/erts/emulator/beam/jit/x86/instr_trace.cpp
@@ -182,23 +182,24 @@ void BeamModuleAssembler::emit_return_trace() {
     emit_return();
 }
 
-void BeamModuleAssembler::emit_i_return_time_trace() {
+void BeamModuleAssembler::emit_i_call_trace_return() {
     /* Pass prev_info if present (is a CP), otherwise null. */
     a.mov(ARG2, getYRef(0));
-    mov_imm(ARG3, 0);
+    mov_imm(ARG4, 0);
 
     a.test(ARG2, imm(_CPMASK));
     a.lea(ARG2, x86::qword_ptr(ARG2, -(Sint)sizeof(ErtsCodeInfo)));
-    a.cmovnz(ARG2, ARG3);
+    a.cmovnz(ARG2, ARG4);
+    a.mov(ARG3, getYRef(1));
 
     emit_enter_runtime<Update::eStack | Update::eHeap>();
 
     a.mov(ARG1, c_p);
-    runtime_call<2>(erts_trace_time_return);
+    runtime_call<3>(erts_call_trace_return);
 
     emit_leave_runtime<Update::eStack | Update::eHeap>();
 
-    emit_deallocate(ArgWord(1));
+    emit_deallocate(ArgWord(2));
     emit_return();
 }
 

--- a/erts/emulator/beam/jit/x86/instr_trace.cpp
+++ b/erts/emulator/beam/jit/x86/instr_trace.cpp
@@ -178,7 +178,7 @@ void BeamModuleAssembler::emit_return_trace() {
 
     emit_leave_runtime<Update::eStack | Update::eHeap>();
 
-    emit_deallocate(ArgWord(2));
+    emit_deallocate(ArgWord(BEAM_RETURN_TRACE_FRAME_SZ));
     emit_return();
 }
 
@@ -199,7 +199,7 @@ void BeamModuleAssembler::emit_i_call_trace_return() {
 
     emit_leave_runtime<Update::eStack | Update::eHeap>();
 
-    emit_deallocate(ArgWord(2));
+    emit_deallocate(ArgWord(BEAM_RETURN_CALL_ACC_TRACE_FRAME_SZ));
     emit_return();
 }
 
@@ -213,7 +213,7 @@ void BeamModuleAssembler::emit_i_return_to_trace() {
 
     /* Remove the zero-sized stack frame. (Will actually do nothing if
      * the native stack is used.) */
-    emit_deallocate(ArgWord(0));
+    emit_deallocate(ArgWord(BEAM_RETURN_TO_TRACE_FRAME_SZ));
     emit_return();
 }
 

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -81,7 +81,7 @@ nif_start
 
 i_generic_breakpoint
 i_debug_breakpoint
-i_return_time_trace
+i_call_trace_return
 i_return_to_trace
 trace_jump W
 i_yield

--- a/erts/emulator/internal_doc/Tracing.md
+++ b/erts/emulator/internal_doc/Tracing.md
@@ -148,7 +148,7 @@ through when adding a new breakpoint.
 
 7. Wait for thread progress.
 
-8. Commit the breadpoint by switching `erts_active_bp_index`.
+8. Commit the breakpoint by switching `erts_active_bp_index`.
 
 9. Wait for thread progress.
 
@@ -203,7 +203,7 @@ and removing breakpoints.
 
 6. Wait for thread progress.
 
-7. Commit all staged breadpoints by switching `erts_active_bp_index`.
+7. Commit all staged breakpoints by switching `erts_active_bp_index`.
 
 8. Wait for thread progress.
 

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -123,6 +123,7 @@ MODULES= \
 	trace_meta_SUITE \
 	trace_call_count_SUITE \
 	trace_call_time_SUITE \
+	trace_call_memory_SUITE \
 	tracer_SUITE \
 	tracer_test \
 	scheduler_SUITE \

--- a/erts/emulator/test/trace_call_memory_SUITE.erl
+++ b/erts/emulator/test/trace_call_memory_SUITE.erl
@@ -1,0 +1,366 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2011-2021. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(trace_call_memory_SUITE).
+-author("maximfca@gmail.com").
+
+
+%% Test server callbacks
+-export([
+    suite/0,
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+%% Test cases exports
+-export([
+    basic/0, basic/1,
+    late_trace/0, late_trace/1,
+    skip/0, skip/1,
+    message/0, message/1,
+    parallel_map/0, parallel_map/1,
+    trace_all/0, trace_all/1,
+    spawn_memory/0, spawn_memory/1, spawn_memory_internal/1,
+    spawn_memory_lambda/1,
+    conflict_traces/0, conflict_traces/1,
+    big_words/0, big_words/1
+]).
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(basic, _Config) ->
+    erlang:trace_pattern({?MODULE, alloc_2tup, 0}, false, [call_memory]),
+    erlang:trace(self(), false, [call]);
+end_per_testcase(late_trace, _Config) ->
+    erlang:trace_pattern({?MODULE, '_', '_'}, false, [call_memory]);
+end_per_testcase(skip, _Config) ->
+    erlang:trace_pattern({?MODULE, '_', '_'}, false, [call_memory]),
+    erlang:trace(self(), false, [call]);
+end_per_testcase(message, _Config) ->
+    erlang:trace_pattern({?MODULE, receive_message, 0}, false, [call_memory]),
+    erlang:trace(all, false, [call]);
+end_per_testcase(parallel_map, _Config) ->
+    erlang:trace_pattern({?MODULE, '_', '_'}, false, [call_memory]),
+    erlang:trace(all, false, [call]);
+end_per_testcase(trace_all, _Config) ->
+    erlang:trace_pattern({'_', '_', '_'}, false, [call_memory]),
+    erlang:trace(all, false, [call]);
+end_per_testcase(spawn_memory, _Config) ->
+    erlang:trace_pattern({?MODULE, spawn_memory_internal, '_'}, false, [call_memory]),
+    erlang:trace(self(), false, [call]);
+end_per_testcase(spawn_memory_lambda, _Config) ->
+    erlang:trace_pattern({erlang, apply, 2}, false, [call_memory]),
+    erlang:trace(self(), false, [call]);
+end_per_testcase(conflict_traces, _Config) ->
+    erlang:trace_pattern({?MODULE, '_', '_'}, false, [call_memory]),
+    erlang:trace(self(), false, [call]);
+end_per_testcase(big_words, _Config) ->
+    erlang:trace_pattern({?MODULE,alloc_tuples,2}, false, [call_memory]),
+    erlang:trace(self(), false, [call]).
+
+
+suite() ->
+    [{timetrap, {seconds, 60}}].
+
+all() ->
+    [basic, late_trace, skip, message, parallel_map, trace_all, spawn_memory,
+    spawn_memory_lambda, conflict_traces, big_words].
+
+%% allocation functions
+alloc_2tup() ->
+    {self(),self()}. %% a non literal
+
+receive_message() ->
+    receive
+        Msg -> Msg
+    end.
+
+basic() ->
+    [{doc, "Assert that two-tuple allocated 3-word structure on the heap"}].
+
+basic(Config) when is_list(Config) ->
+    Self = self(),
+    Traced = {?MODULE, alloc_2tup, 0},
+    1 = erlang:trace_pattern(Traced, true, [call_memory]),
+    1 = erlang:trace(Self, true, [call]),
+    alloc_2tup(),
+    {call_memory, [{Self, 1, 3}]} = erlang:trace_info(Traced, call_memory),
+    alloc_2tup(),
+    {call_memory, [{Self, 2, 6}]} = erlang:trace_info(Traced, call_memory),
+    %% test that GC works correctly
+    erlang:garbage_collect(),
+    alloc_2tup(),
+    {call_memory, [{Self, 3, 9}]} = erlang:trace_info(Traced, call_memory),
+    1 = erlang:trace(Self, false, [call]),
+    1 = erlang:trace_pattern(Traced, false, [call_memory]).
+
+late_trace() ->
+    [{doc, "Tests that garbage_collect call done before tracing is enabled works as expected"}].
+
+late_trace(Config) when is_list(Config) ->
+    Control = self(),
+    Pid = spawn_link(
+        fun () ->
+            _ = late_trace_inner(),
+            1 = erlang:trace_pattern({?MODULE, late_trace_inner, 0}, true, [call_memory]),
+            1 = erlang:trace(self(), true, [call]),
+            _ = late_trace_inner(),
+            Control ! continue,
+            receive
+                stop ->
+                    1 = erlang:trace_pattern({?MODULE, late_trace_inner, 0}, false, [call_memory])
+            end
+        end),
+    NonLiteral = non_literal_9(),
+    MRef = monitor(process, Pid),
+    Pid ! NonLiteral,
+    Pid ! NonLiteral,
+    receive continue -> ok end,
+    {call_memory, [{Pid, 1, 12}]} = erlang:trace_info({?MODULE, late_trace_inner, 0}, call_memory),
+    Pid ! stop,
+    receive {'DOWN', MRef, process, Pid, _} -> ok end.
+
+late_trace_inner() ->
+    Ref = alloc_2tup(), %% 3 words
+    receive _Msg -> Ref end. %% 9 more words
+
+non_literal_9() ->
+    %% 9 words in total: 6 words for the list, 3 for the tuple
+    erlang:insert_element(2, erlang:insert_element(1, {}, atom), lists:seq(1, 3)).
+
+skip() ->
+    [{doc, "Tests that skipped trace for a function accumulates in an upper level caller"}].
+
+skip(Config) when is_list(Config) ->
+    Self = self(),
+    1 = erlang:trace_pattern({?MODULE, upper, 0}, true, [call_memory]),
+    1 = erlang:trace_pattern({?MODULE, lower, 1}, true, [call_memory]),
+    1 = erlang:trace(Self, true, [call]),
+    upper(),
+    {call_memory, [{Self, 1, 8 * 2}]} = erlang:trace_info({?MODULE, lower, 1}, call_memory),
+    {call_memory, [{Self, 1, 3 + 3 + 6}]} = erlang:trace_info({?MODULE, upper, 0}, call_memory).
+
+upper() ->
+    Ref = alloc_2tup(),          %% 3
+    X = middle(Ref),            %% 3 in middle, and 8 in lower (but lower has its own accounting)
+    {1, 2, 3, X, Ref}.          %% extra 6 words (5 elements and 1 tuple size)
+
+middle(_Ref) ->
+    Ref2 = alloc_2tup(),         %% 3 - but accounted in 'upper/0' instead
+    lower(8),
+    Ref2.
+
+lower(Max) ->
+    lists:seq(1, Max).
+
+message() ->
+    [{doc, "Assert that receiving a message results in memory trace"}].
+
+message(Config) when is_list(Config) ->
+    Control = self(),
+    Traced = {?MODULE, receive_message, 0},
+    NonLiteral = non_literal_9(),
+    1 = erlang:trace_pattern(Traced, true, [call_memory]),
+    1 = erlang:trace(self(), true, [call, set_on_first_spawn]),
+    Pid = spawn_link(
+        fun Wrap() ->
+            receive
+                pre ->
+                    receive_message(),
+                    Control ! done,
+                    Wrap();
+                stop ->
+                    ok
+            end
+        end),
+    1 = erlang:trace(self(), false, [call, set_on_first_spawn]),
+    %% first, check that sending a (non-matched) message does not result in a negative allocation
+    Pid ! NonLiteral,
+    timer:sleep(500),
+    {call_memory, []} = erlang:trace_info(Traced, call_memory),
+    %% enter the receive_message/0
+    Pid ! pre,
+    %% wait for 'done' response
+    receive done -> ok end,
+    {call_memory, [{Pid, 1, 9}]} = erlang:trace_info(Traced, call_memory),
+    %% once again, just in case, to verify that decrementing "allocated" worked
+    Pid ! pre,
+    Pid ! NonLiteral,
+    receive done -> ok end,
+    {call_memory, [{Pid, 2, 18}]} = erlang:trace_info(Traced, call_memory),
+    1 = erlang:trace_pattern(Traced, false, [call_memory]).
+
+parallel_map() ->
+    [{doc, "Test memory profiling with spawned processes"}].
+
+parallel_map(Config) when is_list(Config) ->
+    _ = erlang:trace_pattern({?MODULE, '_', '_'}, true, [call_memory]),
+    1 = erlang:trace(self(), true, [call, set_on_spawn]),
+    Pid = spawn_link(fun do_parallel/0),
+    MRef = monitor(process, Pid),
+    Pid ! pre_stop,
+    Pid ! {stop, 1},
+    receive
+        {'DOWN', MRef, process, Pid, _} ->
+            %% alloc_2tup called 3 times (once per process)
+            {call_memory, [{_, 1, 3}, {_, 1, 3}, {_, 1, 3}]} =
+                erlang:trace_info({?MODULE, alloc_2tup, 0}, call_memory),
+            %% receive_message called 8 times (3 from "Allocs", 3 from "Grand", and 2 from the runner)
+            %%  from 7 processes, but only 3*6 Grand processes and 3 words for the runner are on the heap
+            {call_memory, RecvMsg} = erlang:trace_info({?MODULE, receive_message, 0}, call_memory),
+            {7, 8, 21} = collapse_procs(RecvMsg)
+    end.
+
+do_parallel() ->
+    Allocs = [spawn_link(fun() -> alloc_2tup(), receive_message() end) || _ <- lists:seq(1, 3)],
+    Grand = [spawn_link(fun() -> receive_message() end) || _ <- lists:seq(1, 3)],
+    pre_stop = receive_message(),
+    [P ! {atom, <<"1234">>} || P <- Grand], %% 6 words on the heap: 3 for binary, 3 for tuple
+    {stop, 1} = receive_message(),
+    [exit(P, normal) || P <- Allocs].
+
+trace_all() ->
+    [{doc, "Enables memory tracing for all processes, mainly ensuring there are no core dumps"}].
+
+trace_all(Config) when is_list(Config) ->
+    _ = erlang:trace_pattern({'_', '_', '_'}, true, [call_memory]),
+    _ = erlang:trace(all, true, [call]),
+    do_heavy_lifting(),
+    _ = erlang:trace(all, false, [call]),
+    Profile = profile_memory(),
+    %% it'd be better to introduce more checks, but for now see that
+    %%  at least some action happened
+    true = is_map_key(application_controller, Profile).
+
+do_heavy_lifting() ->
+    {ok, []} = application:ensure_all_started(kernel).
+
+profile_memory() ->
+    profile_modules(code:all_loaded(), #{}).
+
+profile_modules([], Acc) ->
+    Acc;
+profile_modules([{Module, _} | Tail], Acc) ->
+    Funcs = try Module:module_info(functions)
+            catch error:undef -> [] % ignore homebrewed without module_info
+            end,
+    case profile_functions(Module, Funcs, #{}) of
+        Empty when Empty =:= #{} ->
+            profile_modules(Tail, Acc);
+        NonEmpty ->
+            profile_modules(Tail, Acc#{Module => NonEmpty})
+    end.
+
+profile_functions(_Module, [], Acc) ->
+    Acc;
+profile_functions(Module, [{Fun, Arity} | Tail], Acc) ->
+    case erlang:trace_info({Module, Fun, Arity}, call_memory) of
+        {call_memory, Skip} when Skip =:= []; Skip =:= false ->
+            profile_functions(Module, Tail, Acc);
+        {call_memory, Mem} ->
+            profile_functions(Module, Tail, Acc#{{Fun, Arity} => collapse_procs(Mem)})
+    end.
+
+collapse_procs(Processes) ->
+    lists:foldl(
+        fun ({_Pid, Calls, Words}, {Procs, TotCalls, TotWords}) ->
+            {Procs + 1, TotCalls + Calls, TotWords + Words}
+        end, {0, 0, 0}, Processes).
+
+spawn_memory() ->
+    [{doc, "Tests that when a process is spawned, initial memory correctly attributed to the initial call"}].
+
+spawn_memory(Config) when is_list(Config) ->
+    LostSharing = lists:seq(1, 16),
+    _ = erlang:trace_pattern({?MODULE, spawn_memory_internal, 1}, true, [call_memory]),
+    1 = erlang:trace(self(), true, [call, set_on_first_spawn]),
+    Pid = erlang:spawn_link(?MODULE, spawn_memory_internal, [LostSharing]),
+    MRef = monitor(process, Pid),
+    receive {'DOWN', MRef, process, Pid, _} -> ok end,
+    1 = erlang:trace(self(), false, [all]),
+    %% 16-elements list translates into 34-words for spawn
+    {call_memory, [{Pid, 1, 34}]} = erlang:trace_info({?MODULE, spawn_memory_internal, 1}, call_memory).
+
+spawn_memory_lambda(Config) when is_list(Config) ->
+    %% check that tracing with context captured through lambda also works - but reports erlang:apply
+    LostSharing = lists:seq(1, 16),
+    _ = erlang:trace_pattern({erlang, apply, 2}, true, [call_memory]),
+    1 = erlang:trace(self(), true, [call, set_on_first_spawn]),
+    Pid = erlang:spawn_link(fun () -> spawn_memory_internal(LostSharing) end),
+    MRef = monitor(process, Pid),
+    receive {'DOWN', MRef, process, Pid, _} -> ok end,
+    1 = erlang:trace(self(), false, [all]),
+    %% 16-elements list translates into 34-words for spawn, and 6 more words for apply itself
+    {call_memory, [{Pid, 1, 40}]} = erlang:trace_info({erlang, apply, 2}, call_memory).
+
+spawn_memory_internal(Array) ->
+    Array.
+
+conflict_traces() ->
+    [{doc, "Verify that call_time and call_memory don't break each other"}].
+
+conflict_traces(Config) when is_list(Config) ->
+    Self = self(),
+    Traced = {?MODULE, alloc_2tup, 0},
+    %% start call_memory trace
+    1 = erlang:trace_pattern(Traced, true, [call_memory]),
+    1 = erlang:trace(Self, true, [call]),
+    alloc_2tup(),
+    {call_memory, [{Self, 1, 3}]} = erlang:trace_info(Traced, call_memory),
+    %% start/stop call_time trace
+    1 = erlang:trace_pattern(Traced, true, [call_time]),
+    alloc_2tup(), %% this goes to both time and memory
+    {call_time, [{Self, 1, _, _}]} = erlang:trace_info(Traced, call_time),
+    1 = erlang:trace_pattern(Traced, false, [call_time]),
+    %% memory is unaffected
+    alloc_2tup(),
+    {call_memory, [{Self, 3, 9}]} = erlang:trace_info(Traced, call_memory),
+    %%
+    1 = erlang:trace(Self, false, [call]),
+    1 = erlang:trace_pattern(Traced, false, [call_memory]).
+
+big_words() ->
+    [{doc, "Test that Words counter can be a bignum on 32-bit"}].
+
+big_words(Config) when is_list(Config) ->
+    Self = self(),
+    Traced = {?MODULE, alloc_tuples, 2},
+    1 = erlang:trace_pattern(Traced, true, [call_memory]),
+    1 = erlang:trace(Self, true, [call]),
+    Words = (1 bsl 27),
+    case {erts_debug:size(Words), 8*erlang:system_info(wordsize)} of
+        {2, 32} -> ok;
+        {0, 64} -> ok
+    end,
+    TupleSz = 1023,
+    TupleCnt = Words div (TupleSz + 1),
+    alloc_tuples(TupleCnt, TupleSz),
+    CallCnt = TupleCnt + 1,
+    {call_memory, [{Self, CallCnt, Words}]} = erlang:trace_info(Traced, call_memory),
+    1 = erlang:trace(Self, false, [call]),
+    1 = erlang:trace_pattern(Traced, false, [call_memory]).
+
+
+alloc_tuples(0, _) ->
+    ok;
+alloc_tuples(N, TupleSz) ->
+    erlang:make_tuple(TupleSz, []),
+    alloc_tuples(N-1, TupleSz).

--- a/erts/emulator/test/trace_call_time_SUITE.erl
+++ b/erts/emulator/test/trace_call_time_SUITE.erl
@@ -96,7 +96,7 @@ all() ->
 %% Tests basic call time trace
 basic(Config) when is_list(Config) ->
     P = erlang:trace_pattern({'_','_','_'}, false, [call_time]),
-    M = 1000,
+    M = 900,
     %%
     1 = erlang:trace_pattern({?MODULE,seq,  '_'}, true, [call_time]),
     2 = erlang:trace_pattern({?MODULE,seq_r,'_'}, true, [call_time]),
@@ -298,12 +298,14 @@ combo(Config) when is_list(Config) ->
     2 = erlang:trace_pattern({?MODULE,seq_r,'_'}, true, [call_time]),
     2 = erlang:trace_pattern({?MODULE,seq_r,'_'}, MetaMs, [{meta,MetaTracer}]),
     2 = erlang:trace_pattern({?MODULE,seq_r,'_'}, true, [call_count]),
+    2 = erlang:trace_pattern({?MODULE,seq_r,'_'}, true, [call_memory]),
 
     % bifs
     2 = erlang:trace_pattern({erlang, term_to_binary, '_'}, [], [local]),
     2 = erlang:trace_pattern({erlang, term_to_binary, '_'}, true, [call_time]),
     2 = erlang:trace_pattern({erlang, term_to_binary, '_'}, MetaMs, [{meta,MetaTracer}]),
     2 = erlang:trace_pattern({erlang, term_to_binary, '_'}, true, [call_count]),
+    2 = erlang:trace_pattern({erlang, term_to_binary, '_'}, true, [call_memory]),
 
     1 = erlang:trace(Self, true, [{tracer,LocalTracer} | Flags]),
     %%
@@ -319,12 +321,14 @@ combo(Config) when is_list(Config) ->
 
     %% check empty trace_info for ?MODULE:seq_r/3
     {all,[_|_]=TraceInfo}     = erlang:trace_info({?MODULE,seq_r,3}, all),
+    io:format("TraceInfo=~p\n",[TraceInfo]),
     {value,{traced,local}}    = lists:keysearch(traced, 1, TraceInfo),
     {value,{match_spec,[]}}   = lists:keysearch(match_spec, 1, TraceInfo),
     {value,{meta,MetaTracer}} = lists:keysearch(meta, 1, TraceInfo),
     {value,{meta_match_spec,MetaMs}} = lists:keysearch(meta_match_spec, 1, TraceInfo),
     {value,{call_count,0}} = lists:keysearch(call_count, 1, TraceInfo),
     {value,{call_time,[]}} = lists:keysearch(call_time, 1, TraceInfo),
+    {value,{call_memory,[]}} = lists:keysearch(call_memory, 1, TraceInfo),
 
     %% check empty trace_info for erlang:term_to_binary/1
     {all, [_|_] = TraceInfoBif} = erlang:trace_info({erlang, term_to_binary, 1}, all),
@@ -334,6 +338,7 @@ combo(Config) when is_list(Config) ->
     {value,{meta_match_spec,MetaMs}} = lists:keysearch(meta_match_spec, 1, TraceInfoBif),
     {value,{call_count,0}} = lists:keysearch(call_count, 1, TraceInfoBif),
     {value,{call_time,[]}} = lists:keysearch(call_time, 1, TraceInfoBif),
+    {value,{call_memory,[]}} = lists:keysearch(call_memory, 1, TraceInfoBif),
 
     %%
     [3,2,1] = seq_r(1, 3, fun(X) -> X+1 end),

--- a/erts/etc/unix/etp.py
+++ b/erts/etc/unix/etp.py
@@ -689,7 +689,7 @@ def init(target):
     names = ['beam_run_process', 'beam_normal_exit', 'beam_exit', 'beam_save_calls_export',
              'beam_save_calls_fun', 'beam_bif_export_trap', 'beam_export_trampoline',
              'beam_continue_exit', 'beam_return_to_trace', 'beam_return_trace',
-             'beam_exception_trace', 'beam_return_time_trace']
+             'beam_exception_trace', 'beam_call_trace_return']
     for name in names:
         code_pointers[global_var(name, target).unsigned] = name
 

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -389,7 +389,7 @@
        {meta, module(), term() } |
        {meta_match_spec, trace_match_spec() | false | undefined} |
        {call_count, non_neg_integer() | boolean() | undefined} |
-       {call_time, [{pid(), non_neg_integer(),
+       {call_time | call_memory, [{pid(), non_neg_integer(),
 		     non_neg_integer(), non_neg_integer()}] | boolean() | undefined}.
 
 -type trace_info_flag() ::
@@ -2124,7 +2124,7 @@ trace_delivered(_Tracee) ->
       Function :: atom(),
       Arity :: arity(),
       Item :: flags | tracer | traced | match_spec
-            | meta | meta_match_spec | call_count | call_time | all,
+            | meta | meta_match_spec | call_count | call_time | call_memory | all,
       Res :: trace_info_return().
 trace_info(_PidPortFuncEvent, _Item) ->
     erlang:nif_error(undefined).
@@ -2823,7 +2823,8 @@ trace_pattern(MFA, MatchSpec) ->
       meta | {meta, Pid :: pid()} |
       {meta, TracerModule :: module(), TracerState :: term()} |
       call_count |
-      call_time.
+      call_time |
+      call_memory.
 
 -spec erlang:trace_pattern(send, MatchSpec, []) -> non_neg_integer() when
       MatchSpec :: (MatchSpecList :: trace_match_spec())


### PR DESCRIPTION
Similar to call_time, erlang:trace_pattern(..., [call_memory]) accumulates memory allocations, allowing for basic heap profiling.

Inspired by @garazdawi's prototype discussed on Erlang Forums. This PR implements only the underlying mechanism. Heap profiler itself (`hprof`) is in works here: https://github.com/erlang/otp/commit/62b184611779a84fa66d43af3971938e67e80be0