### PR TITLE
doc: add missing syntax case to Test Case Groups

### DIFF
--- a/lib/common_test/doc/src/write_test_chapter.xml
+++ b/lib/common_test/doc/src/write_test_chapter.xml
@@ -551,6 +551,21 @@
       [{tests2, default,
         [{tests3, [parallel,{repeat,100}]}]}]}].</pre>
 
+    <p>For ease of readibility, all syntax definitions can be replaced by a function
+    call whose return value should match the expected syntax case.</p>
+    <p>Example</p>
+    <pre>
+ all() ->
+    [{group, tests1, default, test_cases()},
+     {group, tests1, default, [shuffle_test(),
+                               {tests3, default}]}].
+ test_cases() ->
+    [{tests2, [parallel]}, {tests3, default}].
+
+ shuffle_test() ->
+    {tests2, [shuffle,{repeat,10}]}.
+    </pre>
+
     <p>The described syntax can also be used in test specifications
       to change group properties at the time of execution,
       without having to edit the test suite. For more information, see

--- a/lib/common_test/doc/src/write_test_chapter.xml
+++ b/lib/common_test/doc/src/write_test_chapter.xml
@@ -449,7 +449,7 @@
     functions and execution properties. Test case groups are defined by
     function
     <seemfa marker="ct_suite#Module:groups/0"><c>groups/0</c></seemfa>
-    according to the following syntax:</p>
+    that should return a term having the following syntax:</p>
     <pre>
  groups() -> GroupDefs
 
@@ -551,9 +551,9 @@
       [{tests2, default,
         [{tests3, [parallel,{repeat,100}]}]}]}].</pre>
 
-    <p>For ease of readibility, all syntax definitions can be replaced by a function
+    <p>For ease of readability, all syntax definitions can be replaced by a function
     call whose return value should match the expected syntax case.</p>
-    <p>Example</p>
+    <p><em>Example:</em></p>
     <pre>
  all() ->
     [{group, tests1, default, test_cases()},
@@ -563,8 +563,7 @@
     [{tests2, [parallel]}, {tests3, default}].
 
  shuffle_test() ->
-    {tests2, [shuffle,{repeat,10}]}.
-    </pre>
+    {tests2, [shuffle,{repeat,10}]}.</pre>
 
     <p>The described syntax can also be used in test specifications
       to change group properties at the time of execution,


### PR DESCRIPTION
This` PR adds a missing case on how to write test case groups.
The missing case is that one can perform function calls at any point of the test case group as long as the result of the function call returns a `GroupsAndTestCases` ([Syntax for the Erlang TestCaseGroup docs](https://www.erlang.org/docs/23/apps/common_test/write_test_chapter.html#test-case-groups)).
The following example follows, which is also used in the OTP code:

```erlang
groups() ->
    [
     {http, [], real_requests()}
   ]
```
Closes #6342 