### PR TITLE
pg: Note for local-only use cases

### DIFF
--- a/lib/kernel/doc/src/pg.xml
+++ b/lib/kernel/doc/src/pg.xml
@@ -89,8 +89,15 @@
       If there is another process registered under this name, or another ETS table
       exists, scope fails to start.</p>
       <p>Local membership is not preserved if scope process exits and
-        restarts.
-    </p></note>
+        restarts.</p>
+      <p>A scope can be kept local-only by using a scope name that is unique
+        cluster-wide, e.g. the node name:</p>
+      <taglist>
+	<!-- NOTE THAT THE EMPTY TAG IS INTENTIONAL -->
+	<tag></tag>
+	<item><c>pg:start_link(node()).</c></item>
+      </taglist>
+    </note>
 
   </description>
 


### PR DESCRIPTION
A tiny note to point how it can be used without the distributed features.