### PR TITLE
Avoid redundant checks of the key returned by ets:lookup in pg.erl

### DIFF
--- a/lib/kernel/src/pg.erl
+++ b/lib/kernel/src/pg.erl
@@ -492,7 +492,7 @@ sync_groups(Scope, ScopeMon, MG, RemoteGroups, [{Group, Pids} | Tail]) ->
         {Pids, NewRemoteGroups} ->
             sync_groups(Scope, ScopeMon, MG, NewRemoteGroups, Tail);
         {OldPids, NewRemoteGroups} ->
-            [{Group, AllOldPids, LocalPids}] = ets:lookup(Scope, Group),
+            [{_Group, AllOldPids, LocalPids}] = ets:lookup(Scope, Group),
             %% should be really rare...
             AllNewPids = Pids ++ AllOldPids -- OldPids,
             true = ets:insert(Scope, {Group, AllNewPids, LocalPids}),
@@ -517,7 +517,7 @@ join_local([Pid | Tail], Group, Local) ->
 
 join_local_update_ets(Scope, ScopeMon, MG, Group, Pid) when is_pid(Pid) ->
     case ets:lookup(Scope, Group) of
-        [{Group, All, Local}] ->
+        [{_Group, All, Local}] ->
             ets:insert(Scope, {Group, [Pid | All], [Pid | Local]});
         [] ->
             ets:insert(Scope, {Group, [Pid], [Pid]})
@@ -525,7 +525,7 @@ join_local_update_ets(Scope, ScopeMon, MG, Group, Pid) when is_pid(Pid) ->
     notify_group(ScopeMon, MG, join, Group, [Pid]);
 join_local_update_ets(Scope, ScopeMon, MG, Group, Pids) ->
     case ets:lookup(Scope, Group) of
-        [{Group, All, Local}] ->
+        [{_Group, All, Local}] ->
             ets:insert(Scope, {Group, Pids ++ All, Pids ++ Local});
         [] ->
             ets:insert(Scope, {Group, Pids, Pids})
@@ -534,7 +534,7 @@ join_local_update_ets(Scope, ScopeMon, MG, Group, Pids) ->
 
 join_remote_update_ets(Scope, ScopeMon, MG, Group, Pid) when is_pid(Pid) ->
     case ets:lookup(Scope, Group) of
-        [{Group, All, Local}] ->
+        [{_Group, All, Local}] ->
             ets:insert(Scope, {Group, [Pid | All], Local});
         [] ->
             ets:insert(Scope, {Group, [Pid], []})
@@ -542,7 +542,7 @@ join_remote_update_ets(Scope, ScopeMon, MG, Group, Pid) when is_pid(Pid) ->
     notify_group(ScopeMon, MG, join, Group, [Pid]);
 join_remote_update_ets(Scope, ScopeMon, MG, Group, Pids) ->
     case ets:lookup(Scope, Group) of
-        [{Group, All, Local}] ->
+        [{_Group, All, Local}] ->
             ets:insert(Scope, {Group, Pids ++ All, Local});
         [] ->
             ets:insert(Scope, {Group, Pids, []})
@@ -576,10 +576,10 @@ leave_local([Pid | Tail], Group, Local) ->
 
 leave_local_update_ets(Scope, ScopeMon, MG, Group, Pid) when is_pid(Pid) ->
     case ets:lookup(Scope, Group) of
-        [{Group, [Pid], [Pid]}] ->
+        [{_Group, [Pid], [Pid]}] ->
             ets:delete(Scope, Group),
             notify_group(ScopeMon, MG, leave, Group, [Pid]);
-        [{Group, All, Local}] ->
+        [{_Group, All, Local}] ->
             ets:insert(Scope, {Group, lists:delete(Pid, All), lists:delete(Pid, Local)}),
             notify_group(ScopeMon, MG, leave, Group, [Pid]);
         [] ->
@@ -588,7 +588,7 @@ leave_local_update_ets(Scope, ScopeMon, MG, Group, Pid) when is_pid(Pid) ->
     end;
 leave_local_update_ets(Scope, ScopeMon, MG, Group, Pids) ->
     case ets:lookup(Scope, Group) of
-        [{Group, All, Local}] ->
+        [{_Group, All, Local}] ->
             case All -- Pids of
                 [] ->
                     ets:delete(Scope, Group);
@@ -603,10 +603,10 @@ leave_local_update_ets(Scope, ScopeMon, MG, Group, Pids) ->
 leave_remote_update_ets(Scope, ScopeMon, MG, Pid, Groups) when is_pid(Pid) ->
     _ = [
         case ets:lookup(Scope, Group) of
-            [{Group, [Pid], []}] ->
+            [{_Group, [Pid], []}] ->
                 ets:delete(Scope, Group),
                 notify_group(ScopeMon, MG, leave, Group, [Pid]);
-            [{Group, All, Local}] ->
+            [{_Group, All, Local}] ->
                 ets:insert(Scope, {Group, lists:delete(Pid, All), Local}),
                 notify_group(ScopeMon, MG, leave, Group, [Pid]);
             [] ->
@@ -616,7 +616,7 @@ leave_remote_update_ets(Scope, ScopeMon, MG, Pid, Groups) when is_pid(Pid) ->
 leave_remote_update_ets(Scope, ScopeMon, MG, Pids, Groups) ->
     _ = [
         case ets:lookup(Scope, Group) of
-            [{Group, All, Local}] ->
+            [{_Group, All, Local}] ->
                 case All -- Pids of
                     [] when Local =:= [] ->
                         ets:delete(Scope, Group);


### PR DESCRIPTION
Part of pg.erl in the stdlib has the following pattern: 
```
[{Key, Value1, Value2}] = ets:lookup(Table, Key)
```

Because Key appears on the left side, and is already bound, it results in an equality check between the Key
that is returned by lookup and the one that was passed to lookup. This is pointless since they are guaranteed to match.

I verified on a small example, and this results in 3 bytecode instructions and 19 (!) x86 instructions, all unnecessary.
It can be trivially avoided by using an unbound variable such as _Key:
```
[{_Key, Value1, Value2}] = ets:lookup(Table, Key)
```

I don't expect the performance win to be significant, but it is so simple that I think it worthwhile to land.