### PR TITLE
Replace some uses of ets:lookup by ets:lookup_element in the stdlib

### DIFF
--- a/lib/asn1/src/asn1_db.erl
+++ b/lib/asn1/src/asn1_db.erl
@@ -82,11 +82,11 @@ loop(#state{parent = Parent, monitor = MRef, table = Table,
             includes = Includes} = State) ->
     receive
         {set, Mod, K2, V} ->
-            [{_, Modtab}] = ets:lookup(Table, Mod),
+            Modtab = ets:lookup_element(Table, Mod, 2),
             ets:insert(Modtab, {K2, V}),
             loop(State);
         {set, Mod, Kvs} ->
-            [{_, Modtab}] = ets:lookup(Table, Mod),
+            Modtab = ets:lookup_element(Table, Mod, 2),
             ets:insert(Modtab, Kvs),
             loop(State);
         {From, {get, Mod, K2}} ->
@@ -105,7 +105,7 @@ loop(#state{parent = Parent, monitor = MRef, table = Table,
             end,
             loop(State);
         {save, OutFile, Mod} ->
-            [{_,Mtab}] = ets:lookup(Table, Mod),
+            Mtab = ets:lookup_element(Table, Mod, 2),
 	    TempFile = OutFile ++ ".#temp",
             ok = ets:tab2file(Mtab, TempFile),
 	    ok = file:rename(TempFile, OutFile),
@@ -146,10 +146,7 @@ get_table(Table, Mod, Includes) ->
     end.
 
 lookup(Tab, K) ->
-    case ets:lookup(Tab, K) of
-        []      -> undefined;
-        [{K,V}] -> V
-    end.
+	ets:lookup_element(Tab, K, 2, undefined).
 
 info(EruleMaps) ->
     {asn1ct:vsn(),EruleMaps}.

--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -397,13 +397,8 @@ get_env(Application, Key) ->
       Def :: term(),
       Val :: term().
 
-get_env(Application, Key, Def) ->
-    case get_env(Application, Key) of
-    {ok, Val} ->
-        Val;
-    undefined ->
-        Def
-    end.
+get_env(Application, Key, Default) ->
+    application_controller:get_env(Application, Key, Default).
 
 -spec get_all_env() -> Env when
       Env :: [{Par :: atom(), Val :: term()}].

--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -579,9 +579,7 @@ res_update(Option, TagTm) ->
     end.
 
 db_get(Name) ->
-    try ets:lookup_element(inet_db, Name, 2)
-    catch error:badarg -> undefined
-    end.
+    ets:lookup_element(inet_db, Name, 2, undefined).
 
 add_rr(RR) ->
     %% Questionable if we need to support this;

--- a/lib/kernel/src/pg.erl
+++ b/lib/kernel/src/pg.erl
@@ -203,12 +203,7 @@ get_members(Group) ->
 
 -spec get_members(Scope :: atom(), Group :: group()) -> [pid()].
 get_members(Scope, Group) ->
-    try
-        ets:lookup_element(Scope, Group, 2)
-    catch
-        error:badarg ->
-            []
-    end.
+    ets:lookup_element(Scope, Group, 2, []).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -219,12 +214,7 @@ get_local_members(Group) ->
 
 -spec get_local_members(Scope :: atom(), Group :: group()) -> [pid()].
 get_local_members(Scope, Group) ->
-    try
-        ets:lookup_element(Scope, Group, 3)
-    catch
-        error:badarg ->
-            []
-    end.
+    ets:lookup_element(Scope, Group, 3, []).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -832,8 +832,7 @@ symbol(_, AT, I1, I2, _I3, _Cnt) ->
     {atm(AT, I1), I2}.
 
 atm(AT, N) ->
-    [{_N, S}] = ets:lookup(AT, N),
-    S.
+    ets:lookup_element(AT, N, 2).
 
 %% AT is updated.
 ensure_atoms({empty, AT}, Cs) ->


### PR DESCRIPTION
When only one field of an ETS record is needed, using ets:lookup_element is usually faster than ets:lookup. This patch makes sure that we do so when possible in various erlang files in OTP, taking advantage of the recently landed ets:lookup_element/4 (https://github.com/erlang/otp/pull/6234) in places.