### PR TITLE
documentation: fix XML linter error

### DIFF
--- a/system/doc/reference_manual/typespec.xml
+++ b/system/doc/reference_manual/typespec.xml
@@ -610,11 +610,10 @@
 
   <note>
     <p>Erlang uses the shorthand version <c>_</c> as an anonymous type variable
-    equivalent to <c>term()</c> or <c>any()</c>. For example, the following function
+    equivalent to <c>term()</c> or <c>any()</c>. For example, the following function</p>
     <pre>  -spec Function(string(), _) -> string().</pre>
-    is equivalent to:
+    <p>is equivalent to:</p>
     <pre>  -spec Function(string(), any()) -> string().</pre>
-    </p>
   </note>
   </section>
 </chapter>


### PR DESCRIPTION
Fix an error in the documentation from `make xmllint`