### PR TITLE
ssl: Store PeerCertificate for session resumption

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1461,15 +1461,34 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       <datatype>
 	<name name="server_session_tickets"/>
 	<desc>
-	  <p>Configures the session ticket functionality. Allowed values are <c>disabled</c>,
-	  <c>stateful</c> and <c>stateless</c>.</p>
-	  <p>If it is set to <c>stateful</c> or
-	  <c>stateless</c>, session resumption with pre-shared keys is enabled and the server will
-	  send stateful or stateless session tickets to the client after successful connections.</p>
+          <p>Configures the session ticket functionality. Allowed values are <c>disabled</c>,
+          <c>stateful</c>, <c>stateless</c>, <c>stateful_with_cert</c>, <c>stateless_with_cert</c>.</p>
+          <p>If it is not set to <c>disabled</c>,
+          session resumption with pre-shared keys is enabled and the server will
+          send stateful or stateless session tickets to the client after successful connections.</p>
+          
+          <note><p>
+          Pre-shared key session ticket resumption does not include any certificate exchange, 
+          hence the function <seemfa marker="ssl:ssl#peercert/1">ssl:peercert/1</seemfa> will not 
+          be able to return the peer certificate as it is only communicated in the initial handshake.
+          The server options <c>stateful_with_cert</c> or <c>stateless_with_cert</c> may be used 
+          to make a server associate the client certificate from the original handshake 
+          with the tickets it issues.
+          </p></note>
+
 	  <p>A stateful session ticket is a database reference to internal state information.
 	  A stateless session ticket is a self-encrypted binary that contains both cryptographic keying
 	  material and state data.
 	  </p>
+          
+          <warning><p>
+          If it is set to <c>stateful_with_cert</c> the client certificate
+          is stored with the internal state information, increasing memory consumption.
+          If it is set to <c>stateless_with_cert</c> the client certificate is
+          encoded in the self-encrypted binary that is sent to the client,
+          increasing the payload size.
+          </p></warning>
+
 	  <note><p>This option is supported by TLS 1.3 and above. See also
 	  <seeguide marker="ssl:using_ssl#session-tickets-and-session-resumption-in-tls-1.3">
 	  SSL's Users Guide, Session Tickets and Session Resumption in TLS 1.3</seeguide>

--- a/lib/ssl/src/ssl_cipher.hrl
+++ b/lib/ssl/src/ssl_cipher.hrl
@@ -34,7 +34,8 @@
          pre_shared_key,
          ticket_age_add,
          lifetime,
-         timestamp
+         timestamp,
+         certificate
         }).
 
 %%% SSL cipher protocol  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -2382,6 +2382,12 @@ options_anti_replay(_Config) ->
     ?OK(#{anti_replay := {_,_,_}},
         [{anti_replay, {42,4711,21}}, {session_tickets, stateless}],
         server),
+    ?OK(#{anti_replay := {_,_,_}},
+        [{anti_replay, '10k'}, {session_tickets, stateless_with_cert}],
+        server),
+    ?OK(#{anti_replay := {_,_,_}},
+        [{anti_replay, {42,4711,21}}, {session_tickets, stateless_with_cert}],
+        server),
 
 
     %% Errors
@@ -2399,6 +2405,15 @@ options_anti_replay(_Config) ->
          server),
     ?ERR({anti_replay, _},
          [{anti_replay, {1,1,1,1}}, {session_tickets, stateless}],
+         server),
+    ?ERR({options,incompatible, [session_tickets,{versions,['tlsv1']}]},
+         [{anti_replay, '10k'}, {session_tickets, stateless_with_cert}, {versions, ['tlsv1']}],
+         server),
+    ?ERR({anti_replay, '1k'},
+         [{anti_replay, '1k'}, {session_tickets, stateless_with_cert}],
+         server),
+    ?ERR({anti_replay, _},
+         [{anti_replay, {1,1,1,1}}, {session_tickets, stateless_with_cert}],
          server),
     ok.
 
@@ -2594,6 +2609,8 @@ options_early_data(_Config) -> %% early_data, session_tickets and use_ticket
 
     ?OK(#{early_data := enabled, stateless_tickets_seed := <<"foo">>},
         [{early_data, enabled}, {session_tickets, stateless}, {stateless_tickets_seed, <<"foo">>}], server),
+    ?OK(#{early_data := enabled, stateless_tickets_seed := <<"foo">>},
+        [{early_data, enabled}, {session_tickets, stateless_with_cert}, {stateless_tickets_seed, <<"foo">>}], server),
 
     ?OK(#{early_data := disabled}, [{early_data, disabled}], server),
 
@@ -2606,6 +2623,8 @@ options_early_data(_Config) -> %% early_data, session_tickets and use_ticket
     ?ERR({options, {session_tickets, stateful}}, [{session_tickets, stateful}], client),
     ?ERR({options, incompatible, [session_tickets, {versions, _}]},
          [{session_tickets, stateful}, {versions, ['tlsv1.2']}], server),
+    ?ERR({options, incompatible, [session_tickets, {versions, _}]},
+         [{session_tickets, stateful_with_cert}, {versions, ['tlsv1.2']}], server),
 
     ?ERR({use_ticket, foo},
          [{use_ticket, foo}, {session_tickets, manual}], client),
@@ -2622,12 +2641,20 @@ options_early_data(_Config) -> %% early_data, session_tickets and use_ticket
          [{early_data, enabled}], server),
     ?ERR({options, {early_data, <<>>}},
          [{early_data, <<>>}, {session_tickets, stateless}], server),
+    ?ERR({options, {early_data, <<>>}},
+         [{early_data, <<>>}, {session_tickets, stateless_with_cert}], server),
 
     ?ERR({options, incompatible, [stateless_tickets_seed, {session_tickets, stateful}]},
          [{stateless_tickets_seed, <<"foo">>}, {session_tickets, stateful}],
          server),
+    ?ERR({options, incompatible, [stateless_tickets_seed, {session_tickets, stateful_with_cert}]},
+         [{stateless_tickets_seed, <<"foo">>}, {session_tickets, stateful_with_cert}],
+         server),
     ?ERR({stateless_tickets_seed, foo},
          [{stateless_tickets_seed, foo}, {session_tickets, stateless}],
+         server),
+    ?ERR({stateless_tickets_seed, foo},
+         [{stateless_tickets_seed, foo}, {session_tickets, stateless_with_cert}],
          server),
     ?ERR({option, server_only, stateless_tickets_seed},
          [{stateless_tickets_seed, <<"foo">>}], client),

--- a/lib/ssl/test/tls_server_session_ticket_SUITE.erl
+++ b/lib/ssl/test/tls_server_session_ticket_SUITE.erl
@@ -45,7 +45,9 @@
          misc_test/0,
          misc_test/1,
          valid_ticket_older_than_windowsize_test/0,
-         valid_ticket_older_than_windowsize_test/1]).
+         valid_ticket_older_than_windowsize_test/1,
+         certificate_encoding_test/0,
+         certificate_encoding_test/1]).
 
 -define(LIFETIME, 3). % tickets expire after 3s
 -define(TICKET_STORE_SIZE, 1).
@@ -54,17 +56,25 @@
 -define(VERSION, {3,4}).
 -define(PSK, <<15,168,18,43,216,33,227,142,114,190,70,183,137,57,64,64,66,152,115,94>>).
 -define(WINDOW_SIZE, 1).
+-define(SEED, <<1,2,3,4,5>>).
 
 %%--------------------------------------------------------------------
 %% Common Test interface functions -----------------------------------
 %%--------------------------------------------------------------------
 all() ->
-    [{group, stateful}, {group, stateless}, {group, stateless_antireplay}].
+    [{group, stateful},
+     {group, stateful_with_cert},
+     {group, stateless},
+     {group, stateless_with_cert},
+     {group, stateless_antireplay}
+    ].
 
 groups() ->
     [{stateful, [], [main_test, expired_ticket_test, invalid_ticket_test]},
-     {stateless, [], [expired_ticket_test, invalid_ticket_test, main_test]},
-     {stateless_antireplay, [], [main_test, misc_test, valid_ticket_older_than_windowsize_test]}
+     {stateful_with_cert, [], [main_test, expired_ticket_test, invalid_ticket_test]},
+     {stateless, [], [expired_ticket_test, invalid_ticket_test, main_test, certificate_encoding_test]},
+     {stateless_with_cert, [], [expired_ticket_test, invalid_ticket_test, main_test, certificate_encoding_test]},
+     {stateless_antireplay, [], [main_test, misc_test, valid_ticket_older_than_windowsize_test, certificate_encoding_test]}
     ].
 
 init_per_suite(Config0) ->
@@ -85,9 +95,11 @@ init_per_group(stateless_antireplay, Config) ->
     check_environment([{server_session_tickets, stateless},
                        {anti_replay, {?WINDOW_SIZE, 20, 30}}]
                       ++ Config);
-init_per_group(Group = stateless, Config) ->
+init_per_group(Group, Config)
+    when Group == stateless orelse Group == stateless_with_cert ->
     check_environment([{server_session_tickets, Group} | Config]);
-init_per_group(Group = stateful, Config) ->
+init_per_group(Group, Config)
+    when Group == stateful orelse Group == stateful_with_cert ->
     [{server_session_tickets, Group} | Config].
 
 end_per_group(_GroupName, Config) ->
@@ -95,10 +107,17 @@ end_per_group(_GroupName, Config) ->
 
 init_per_testcase(_TestCase, Config)  ->
     {ok, ListenSocket} = gen_tcp:listen(0, [{active, false}]),
+    AntiReplay = ?config(anti_replay, Config),
     {ok, Pid} = tls_server_session_ticket:start_link(
                   ListenSocket, ?config(server_session_tickets, Config),
                   ?LIFETIME, ?TICKET_STORE_SIZE, _MaxEarlyDataSize = 100,
-                  ?config(anti_replay, Config)),
+                  AntiReplay, ?SEED),
+    % For all anti-replay test-cases we will sleep longer than the warmup period
+    case AntiReplay of
+        undefined -> undefined;
+        _ ->
+            ct:sleep({seconds, 2 * ?LIFETIME})
+    end,
     [{server_pid, Pid}, {listen_socket, ListenSocket} | Config].
 
 end_per_testcase(_TestCase, Config) ->
@@ -116,17 +135,17 @@ main_test() ->
 main_test(Config) when is_list(Config) ->
     Pid = ?config(server_pid, Config),
     % Fill in GB tree store for stateful setup
-    tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET),
+    tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET, undefined),
     % Reach ticket store size limit - force GB tree pruning
     SessionTicket = #new_session_ticket{} =
-        tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET),
+        tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET, undefined),
     TicketRecvTime = erlang:system_time(millisecond),
     %% Sleep more than the ticket lifetime (which is in seconds) in
     %% milliseconds, to confirm that the client reported age (which is in
     %% milliseconds) is compared correctly with the lifetime
     ct:sleep(5 * ?LIFETIME),
     {HandshakeHist, OferredPsks} = get_handshake_hist(SessionTicket, TicketRecvTime, ?PSK),
-    AcceptResponse = {ok, {0, ?PSK}},
+    AcceptResponse = {ok, {0, ?PSK, undefined}},
     AcceptResponse = tls_server_session_ticket:use(Pid, OferredPsks, ?PRF,
                                       [iolist_to_binary(HandshakeHist)]),
     % check replay attempt result
@@ -140,7 +159,7 @@ invalid_ticket_test() ->
 invalid_ticket_test(Config) when is_list(Config) ->
     Pid = ?config(server_pid, Config),
     #new_session_ticket{ticket=Ticket} =
-        tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET),
+        tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET, undefined),
     Ids = [#psk_identity{identity = <<"wrongidentity">>,
                          obfuscated_ticket_age = 0},
            #psk_identity{identity = Ticket,
@@ -162,7 +181,7 @@ expired_ticket_test() ->
     [{doc, "Expired ticket scenario"}].
 expired_ticket_test(Config) when is_list(Config) ->
     Pid = ?config(server_pid, Config),
-    SessionTicket = tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET),
+    SessionTicket = tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET, undefined),
     TicketRecvTime = erlang:system_time(millisecond),
     ct:sleep({seconds, 2 * ?LIFETIME}),
     {HandshakeHist, OFPSKs} = get_handshake_hist(SessionTicket, TicketRecvTime, ?PSK),
@@ -176,15 +195,15 @@ valid_ticket_older_than_windowsize_test() ->
 valid_ticket_older_than_windowsize_test(Config) when is_list(Config) ->
     Pid = ?config(server_pid, Config),
     % Fill in GB tree store for stateful setup (Stateless tests also fail without this)
-    tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET),
+    tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET, undefined),
     % Reach ticket store size limit - force GB tree pruning
     SessionTicket = #new_session_ticket{} =
-        tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET),
+        tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET, undefined),
     TicketRecvTime = erlang:system_time(millisecond),
     %% Sleep more than the window length (which is in seconds)
     ct:sleep({seconds, 2 * ?WINDOW_SIZE}),
     {HandshakeHist, OferredPsks} = get_handshake_hist(SessionTicket, TicketRecvTime, ?PSK),
-    AcceptResponse = {ok, {0, ?PSK}},
+    AcceptResponse = {ok, {0, ?PSK, undefined}},
     AcceptResponse = tls_server_session_ticket:use(Pid, OferredPsks, ?PRF,
                                       [iolist_to_binary(HandshakeHist)]),
     % check replay attempt result
@@ -202,6 +221,22 @@ misc_test(Config) when is_list(Config) ->
     Pid ! general_handle_info,
     {ok, state} = tls_server_session_ticket:code_change(old_version, state, extra),
     Pid = tls_server_session_ticket:format_status(not_relevant, Pid),
+    true = is_process_alive(Pid).
+
+certificate_encoding_test() ->
+    [{doc, "Verify certifcate encoding/decoding in ticket"}].
+
+certificate_encoding_test(Config) when is_list(Config) ->
+    Pid = ?config(server_pid, Config),
+    tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET, undefined),
+    Certificate = crypto:strong_rand_bytes(100),
+    SessionTicket = #new_session_ticket{} =
+        tls_server_session_ticket:new(Pid, ?PRF, ?MASTER_SECRET, Certificate),
+    TicketRecvTime = erlang:system_time(millisecond),
+    {HandshakeHist, OferredPsks} = get_handshake_hist(SessionTicket, TicketRecvTime, ?PSK),
+    AcceptResponse = {ok, {0, ?PSK, Certificate}},
+    AcceptResponse = tls_server_session_ticket:use(Pid, OferredPsks, ?PRF,
+                                      [iolist_to_binary(HandshakeHist)]),
     true = is_process_alive(Pid).
 
 %%--------------------------------------------------------------------
@@ -240,6 +275,9 @@ get_replay_expected_result(Config, AcceptResponse) ->
         stateless ->
             % no protection - replayed ticket is accepted
             AcceptResponse;
+        stateless_with_cert ->
+            % no protection - replayed ticket is accepted
+            AcceptResponse;
         _ ->
             {ok, undefined}
     end.
@@ -247,6 +285,8 @@ get_replay_expected_result(Config, AcceptResponse) ->
 get_alert_reason(Config) ->
     case get_group(Config) of
         stateful ->
+            stateful;
+        stateful_with_cert ->
             stateful;
         _ ->
             stateless


### PR DESCRIPTION
This PR subsumes PR: #5957 and closes issue: #5870 

Calling `ssl:peercert/1` after a client connects with session resumption returns `{error, no_peercert}`. This PR adds the new options `stateful_with_cert` and `stateless_with_cert` to the `server_session_tickets` option that allow `ssl:peercert/1` to return the client certificate even after session resumption.

