### PR TITLE
kernel: Fix expand below for long lines

### DIFF
--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -684,6 +684,8 @@ cols([SkipSeq | T], Unicode) when is_binary(SkipSeq) ->
     %% so we skip that
     cols(T, Unicode).
 
+cols(ColsPerLine, CurrCols, Chars, Unicode) when CurrCols > ColsPerLine ->
+    ColsPerLine + cols(ColsPerLine, CurrCols - ColsPerLine, Chars, Unicode);
 cols(_ColsPerLine, CurrCols, [], _Unicode) ->
     CurrCols;
 cols(ColsPerLine, CurrCols, ["\r\n" | T], Unicode) ->

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -924,6 +924,14 @@ shell_expand_location_below(Config) ->
         send_stdin(Term, "\t"),
         check_location(Term, {-3, width("[escript:s")}),
         check_content(Term, "script_name\\([ ]+start\\($"),
+        send_tty(Term, "C-K"),
+
+        %% Check that completion works when in the middle of a long term
+        send_tty(Term, ", "++ lists:duplicate(80*2, $a)++"]"),
+        [send_tty(Term, "Left") || _ <- ", "++ lists:duplicate(80*2, $a)++"]"],
+        send_stdin(Term, "\t"),
+        check_location(Term, {-4, width("[escript:s")}),
+        check_content(Term, "script_name\\([ ]+start\\($"),
         send_tty(Term, "End"),
         send_stdin(Term, ".\n"),
 


### PR DESCRIPTION
The column calculation was incorrect when the line where we want the completion was longer that the current screen size.

Fixes bug in #6260 