### PR TITLE
[MnesiaTM] Lightweight method for obtaining an active mnesia transactions counters

### DIFF
--- a/lib/mnesia/src/mnesia_tm.erl
+++ b/lib/mnesia/src/mnesia_tm.erl
@@ -32,6 +32,7 @@
 	 do_update_op/3,
 	 get_info/1,
 	 get_transactions/0,
+         get_transactions_count/0,
 	 info/1,
 	 mnesia_down/1,
 	 prepare_checkpoint/2,
@@ -405,6 +406,10 @@ doit_loop(#state{coordinators=Coordinators,participants=Participants,supervisor=
 	{From, info} ->
 	    reply(From, {info, gb_trees:values(Participants),
 			 gb_trees:to_list(Coordinators)}, State);
+
+	{From, transactions_count} ->
+	    reply(From, {transactions_count, gb_trees:size(Participants),
+                         gb_trees:size(Coordinators)}, State);
 
 	{mnesia_down, N} ->
 	    verbose("Got mnesia_down from ~p, reconfiguring...~n", [N]),
@@ -2119,6 +2124,14 @@ tr_status(Tid,Participant) ->
     case lists:keymember(Tid, 1, Participant) of
 	true -> participant;
 	false  -> coordinator
+    end.
+
+get_transactions_count() ->
+    case req(transactions_count) of
+        {transactions_count, ParticipantsCount, CoordinatorsCount} ->
+            {ParticipantsCount, CoordinatorsCount};
+        Error ->
+            Error
     end.
 
 get_info(Timeout) ->

--- a/lib/mnesia/test/mnesia_trans_access_test.erl
+++ b/lib/mnesia/test/mnesia_trans_access_test.erl
@@ -28,7 +28,7 @@
 
 -export([write/1, read/1, wread/1, delete/1,
          delete_object_bag/1, delete_object_set/1,
-         match_object/1, select/1, select14/1, all_keys/1, transaction/1,
+         match_object/1, select/1, select14/1, all_keys/1, transaction/1, transaction_counters/1,
          basic_nested/1, mix_of_nested_activities/1,
          nested_trans_both_ok/1, nested_trans_child_dies/1,
          nested_trans_parent_dies/1, nested_trans_both_dies/1,
@@ -65,7 +65,7 @@ end_per_testcase(Func, Conf) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 all() ->
     [write, read, wread, delete, delete_object_bag, delete_object_set,
-     match_object, select, select14, all_keys, transaction,
+     match_object, select, select14, all_keys, transaction, transaction_counters,
      {group, nested_activities}, {group, index_tabs},
      {group, index_lifecycle}].
 
@@ -546,6 +546,28 @@ transaction(Config) when is_list(Config) ->
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+transaction_counters(suite) -> [];
+transaction_counters(Config) ->
+    Nodes = ?acquire_nodes(1, Config),
+
+    {atomic, {{Participants1, Coordinators1}, {Participants2, Coordinators2}}} =
+        mnesia:transaction(fun get_transactions_counters/0),
+
+    ?match(Coordinators1, Coordinators2),
+    ?match(Coordinators1, 1),
+    ?match(Participants1, Participants2),
+    ?match(Participants1, 0),
+
+    ?verify_mnesia(Nodes, []).
+
+get_transactions_counters() ->
+    {count_sides(mnesia_tm:get_transactions()), mnesia_tm:get_transactions_count()}.
+
+count_sides(TransactionsList) ->
+    lists:foldl(
+        fun({_Tid, _Pid, participant}, {Participants, Coordinators}) -> {Participants + 1, Coordinators};
+            ({_Tid, _Pid, coordinator}, {Participants, Coordinators}) -> {Participants, Coordinators + 1}
+        end, {0, 0}, TransactionsList).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This is a pull request for idea #6376. A simple and light way for obtaining the active mnesia transactions counters for monitoring purposes