### PR TITLE
os_mon: allow check intervals smaller than 1 minute

### DIFF
--- a/lib/os_mon/doc/src/disksup.xml
+++ b/lib/os_mon/doc/src/disksup.xml
@@ -57,15 +57,42 @@
       longer valid.</p>
   </description>
 
+  <datatypes>
+    <datatype>
+      <name>time()</name>
+      <desc>
+        <p>Supported units:</p>
+        <taglist>
+          <tag><c>integer() >= 1</c></tag>
+          <item>
+            <p>The time interval in minutes.</p>
+          </item>
+          <tag><c>{TimeUnit, Time}</c></tag>
+          <item>
+            <p>
+              The time interval <c>Time</c> in a time unit specified by <c>TimeUnit</c> where
+              <c>TimeUnit</c> is of the type
+              <seetype marker="erts:erlang#time_unit"><c>erlang:time_unit()</c></seetype>
+              and <c>Time</c> is a positive integer. The time interval needs to be at least one
+              millisecond long.
+            </p>
+          </item>
+        </taglist>
+      </desc>
+    </datatype>
+  </datatypes>
+
   <section>
     <marker id="config"></marker>
     <title>Configuration</title>
     <p>The following configuration parameters can be used to change
       the default values for time interval and threshold:</p>
     <taglist>
-      <tag><c>disk_space_check_interval = int()>0</c></tag>
+      <tag>
+        <c>disk_space_check_interval = </c><seetype marker="#time"><c>time()</c></seetype>
+      </tag>
       <item>
-        <p>The time interval, in minutes, for the periodic disk space
+        <p>The time interval for the periodic disk space
           check. The default is 30 minutes.</p>
       </item>
       <tag><c>disk_almost_full_threshold = float()</c></tag>
@@ -123,13 +150,13 @@
       </desc>
     </func>
     <func>
-      <name since="">set_check_interval(Minutes) -> ok</name>
-      <fsummary>Set time interval, in minutes, for the periodic disk space check</fsummary>
+      <name since="">set_check_interval(Time) -> ok</name>
+      <fsummary>Set time interval for the periodic disk space check</fsummary>
       <type>
-        <v>Minutes = int()>=1</v>
+        <v>Time = <seetype marker="#time">time()</seetype></v>
       </type>
       <desc>
-        <p>Changes the time interval, given in minutes, for the periodic
+        <p>Changes the time interval for the periodic
           disk space check.</p>
         <p>The change will take effect after the next disk space check
           and is non-persist. That is, in case of a process restart,

--- a/lib/os_mon/test/disksup_SUITE.erl
+++ b/lib/os_mon/test/disksup_SUITE.erl
@@ -83,6 +83,15 @@ api(Config) when is_list(Config) ->
     1200000 = disksup:get_check_interval(),
     ok = disksup:set_check_interval(30),
 
+    %% set_check_interval({TimeUnit, Time})
+    ok = disksup:set_check_interval({second, 1}),
+    1000 = disksup:get_check_interval(),
+    {'EXIT',{badarg,_}} = (catch disksup:set_check_interval({second, 0.5})),
+    {'EXIT',{badarg,_}} = (catch disksup:set_check_interval({badarg, 1})),
+    {'EXIT',{badarg,_}} = (catch disksup:set_check_interval({nanosecond, 1})),
+    1000 = disksup:get_check_interval(),
+    ok = disksup:set_check_interval(30),
+
     %% get_almost_full_threshold()
     80 = disksup:get_almost_full_threshold(),
 
@@ -110,6 +119,13 @@ config(Config) when is_list(Config) ->
     1740000 = disksup:get_check_interval(),
     81 = disksup:get_almost_full_threshold(),
 
+    ok = application:set_env(os_mon, disk_space_check_interval, {second, 2}),
+
+    ok = supervisor:terminate_child(os_mon_sup, disksup),
+    {ok, _Child2} = supervisor:restart_child(os_mon_sup, disksup),
+
+    2000 = disksup:get_check_interval(),
+
     %% Also try this with bad parameter values, should be ignored
     ok =
 	application:set_env(os_mon, disk_space_check_interval, 0.5),
@@ -117,10 +133,31 @@ config(Config) when is_list(Config) ->
 	application:set_env(os_mon, disk_almost_full_threshold, -0.81),
 
     ok = supervisor:terminate_child(os_mon_sup, disksup),
-    {ok, _Child2} = supervisor:restart_child(os_mon_sup, disksup),
+    {ok, _Child3} = supervisor:restart_child(os_mon_sup, disksup),
 
     1800000 = disksup:get_check_interval(),
     80 = disksup:get_almost_full_threshold(),
+
+    ok = application:set_env(os_mon, disk_space_check_interval, {second, 0.5}),
+
+    ok = supervisor:terminate_child(os_mon_sup, disksup),
+    {ok, _Child4} = supervisor:restart_child(os_mon_sup, disksup),
+
+    1800000 = disksup:get_check_interval(),
+
+    ok = application:set_env(os_mon, disk_space_check_interval, {badarg, 1}),
+
+    ok = supervisor:terminate_child(os_mon_sup, disksup),
+    {ok, _Child5} = supervisor:restart_child(os_mon_sup, disksup),
+
+    1800000 = disksup:get_check_interval(),
+
+    ok = application:set_env(os_mon, disk_space_check_interval, {nanosecond, 1}),
+
+    ok = supervisor:terminate_child(os_mon_sup, disksup),
+    {ok, _Child6} = supervisor:restart_child(os_mon_sup, disksup),
+
+    1800000 = disksup:get_check_interval(),
 
     %% Reset configuration parameters
     ok = application:set_env(os_mon, disk_space_check_interval, 30),


### PR DESCRIPTION
- Expanded type of `disk_space_check_interval` to `number()`

```
1> disksup:set_check_interval(0.5).
```

Fix #6283 