### PR TITLE
Convert from `::set-output` to `GITHUB_OUTPUT`

### DIFF
--- a/.github/scripts/build-base-image.sh
+++ b/.github/scripts/build-base-image.sh
@@ -29,16 +29,16 @@ case "${BASE_TAG}" in
         ;;
 esac
 
-echo "::set-output name=BASE::${BASE}"
-echo "::set-output name=BASE_TAG::${BASE_TAG}"
-echo "::set-output name=BASE_TYPE::${BASE_TYPE}"
+echo "BASE=${BASE}" >> $GITHUB_OUTPUT
+echo "BASE_TAG=${BASE_TAG}" >> $GITHUB_OUTPUT
+echo "BASE_TYPE=${BASE_TYPE}" >> $GITHUB_OUTPUT
 
 if [ -f "otp_docker_base.tar" ]; then
     docker load -i "otp_docker_base.tar"
-    echo "::set-output name=BASE_BUILD::loaded"
+    echo "BASE_BUILD=loaded" >> $GITHUB_OUTPUT
 elif [ -f "otp_docker_base/otp_docker_base.tar" ]; then
     docker load -i "otp_docker_base/otp_docker_base.tar"
-    echo "::set-output name=BASE_BUILD::loaded"
+    echo "BASE_BUILD=loaded" >> $GITHUB_OUTPUT
 else
     if [ "${BASE_USE_CACHE}" != "false" ]; then
         docker pull "${BASE_TAG}:${BASE_BRANCH}"
@@ -58,9 +58,9 @@ else
 
     NEW_BASE_IMAGE_ID=$(docker images -q "${BASE_TAG}:latest")
     if [ "${BASE_IMAGE_ID}" = "${NEW_BASE_IMAGE_ID}" ]; then
-        echo "::set-output name=BASE_BUILD::cached"
+        echo "BASE_BUILD=cached" >> $GITHUB_OUTPUT
     else
-        echo "::set-output name=BASE_BUILD::re-built"
+        echo "BASE_BUILD=re-built" >> $GITHUB_OUTPUT
         docker save "${BASE_TAG}:latest" > "otp_docker_base.tar"
     fi
 fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,7 @@ jobs:
           .github/scripts/path-filters.sh > .github/scripts/path-filters.yaml
           ALL_APPS=$(grep '^[a-z_]*:' .github/scripts/path-filters.yaml | sed 's/:.*$//')
           ALL_APPS=$(jq -n --arg inarr "${ALL_APPS}" '$inarr | split("\n")' | tr '\n' ' ')
-          echo "::set-output name=all::${ALL_APPS}"
+          echo "all=${ALL_APPS}" >> $GITHUB_OUTPUT
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -250,11 +250,13 @@ jobs:
       # actions/cache on Windows sometimes does not set cache-hit even though there was one. Setting it manually.
       - name: Set wxWidgets cache
         id: wxwidgets-cache
+        env:
+          WSLENV: GITHUB_OUTPUT/p
         run: |
           if [ -d wxWidgets ]; then
-            echo "::set-output name=cache-hit::true"
+            echo "cache-hit=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=cache-hit::false"
+            echo "cache-hit=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Download wxWidgets
@@ -695,8 +697,8 @@ jobs:
         run: |
           TAG=${GITHUB_REF#refs/tags/}
           VSN=${TAG#OTP-}
-          echo "::set-output name=tag::${TAG}"
-          echo "::set-output name=vsn::${VSN}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "vsn=${VSN}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -74,9 +74,9 @@ jobs:
            done
 
            if [ -d "Unit Test Results" ]; then
-             echo "::set-output name=HAS_TEST_ARTIFACTS::true"
+             echo "HAS_TEST_ARTIFACTS=true" >> $GITHUB_OUTPUT
            else
-             echo "::set-output name=HAS_TEST_ARTIFACTS::false"
+             echo "HAS_TEST_ARTIFACTS=false" >> $GITHUB_OUTPUT
            fi
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I noticed this in the following build:

https://github.com/erlang/otp/actions/runs/3304563740/jobs/5454076885

"Build BASE image" step