### PR TITLE
ssl: implement use_srtp hello extension with options

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1231,6 +1231,36 @@ fun(srp, Username :: binary(), UserState :: term()) ->
 	</desc>
       </datatype>
 
+      <datatype>
+        <name name="use_srtp_protection_profiles"/>
+        <desc>
+          <p>Configures the list of the client's acceptable SRTP Protection Profiles.</p>
+          <p>In order to negotiate the use of SRTP data protection, clients
+          include an extension of type "use_srtp" in the DTLS extended client
+          hello.  This extension MUST only be used when the data being
+          transported is RTP or RTCP.</p>
+          <p>This extension MUST only be used with DTLS, and not with TLS</p>
+          <p>OTP does not handle SRTP, so an external implementation of SRTP
+          encoder/decoder and a packet demultiplexer are needed to make use
+          of the use_srtp extension. See also <c>cb_info</c> option</p>
+        </desc>
+      </datatype>
+
+      <datatype>
+        <name name="use_srtp_mki"/>
+        <desc>
+          <p>Configures the SRTP Master Key Identifier chosen by the client.</p>
+          <p>This options only has effect only when <c>use_srtp_protection_profiles</c>
+          option is specified.</p>
+          <p>The srtp_mki field contains the value of the SRTP MKI which is associated
+          with the SRTP master keys derived from this handshake.  Each SRTP
+          session MUST have exactly one master key that is used to protect
+          packets at any given time.  The client MUST choose the MKI value so
+          that it is distinct from the last MKI value that was used, and it
+          SHOULD make these values unique for the duration of the TLS session.</p>
+        </desc>
+      </datatype>
+
     <!--   <datatype> -->
   <!-- 	<name name="ocsp_stapling"/> -->
   <!-- 	<desc><p>If true, OCSP stapling will be enabled, an extension of type "status_request" will be -->
@@ -1579,6 +1609,31 @@ fun(srp, Username :: binary(), UserState :: term()) ->
           </p>
 	  <warning><p>This option is a placeholder, early data is not yet implemented on the server side.
           </p></warning>
+        </desc>
+      </datatype>
+
+      <datatype>
+        <name name="use_srtp_protection_profiles"/>
+        <desc>
+          <p>Configures the server's chosen SRTP Protection Profile (as a list of a single profile).</p>
+          <p>Servers that receive an extended hello containing a "use_srtp"
+          extension can agree to use SRTP by including an extension of type
+          "use_srtp", with the chosen protection profile in the extended server
+          hello.</p>
+        </desc>
+      </datatype>
+
+      <datatype>
+        <name name="use_srtp_mki"/>
+        <desc>
+          <p>Configures the server's SRTP Master Key Identifier.</p>
+          <p>Upon receipt of a "use_srtp" extension containing a "srtp_mki" field,
+          the server MUST either (assuming it accepts the extension at all):</p>
+	  <list type="bulleted">
+	    <item><p>include a matching "srtp_mki" value in its "use_srtp" extension
+            to indicate that it will make use of the MKI, or</p></item>
+	    <item><p>return an empty "srtp_mki" value to indicate that it cannot make use of the MKI.</p></item>
+	  </list>
         </desc>
       </datatype>
 

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -1232,32 +1232,30 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       </datatype>
 
       <datatype>
-        <name name="use_srtp_protection_profiles"/>
+        <name name="use_srtp"/>
         <desc>
-          <p>Configures the list of the client's acceptable SRTP Protection Profiles.</p>
+          <p>Configures the <c>use_srtp</c> DTLS hello extension.</p>
           <p>In order to negotiate the use of SRTP data protection, clients
           include an extension of type "use_srtp" in the DTLS extended client
           hello.  This extension MUST only be used when the data being
           transported is RTP or RTCP.</p>
-          <p>This extension MUST only be used with DTLS, and not with TLS</p>
-          <p>OTP does not handle SRTP, so an external implementation of SRTP
-          encoder/decoder and a packet demultiplexer are needed to make use
-          of the use_srtp extension. See also <c>cb_info</c> option</p>
-        </desc>
-      </datatype>
-
-      <datatype>
-        <name name="use_srtp_mki"/>
-        <desc>
-          <p>Configures the SRTP Master Key Identifier chosen by the client.</p>
-          <p>This options only has effect only when <c>use_srtp_protection_profiles</c>
-          option is specified.</p>
+          <p>The value is a map with a mandatory <c>protection_profiles</c> and
+          an optional <c>mki</c> parameters.</p>
+          <p><c>protection_profiles</c> configures the list of the client's acceptable
+          SRTP Protection Profiles. Each profile is a 2-byte binary. Example:
+          <c>#{protection_profiles =&gt; [&lt;&lt;0,2&gt;&gt;, &lt;&lt;0,5&gt;&gt;]}</c></p>
+          <p><c>mki</c> configures the SRTP Master Key Identifier chosen by the client.</p>
           <p>The srtp_mki field contains the value of the SRTP MKI which is associated
           with the SRTP master keys derived from this handshake.  Each SRTP
           session MUST have exactly one master key that is used to protect
           packets at any given time.  The client MUST choose the MKI value so
           that it is distinct from the last MKI value that was used, and it
           SHOULD make these values unique for the duration of the TLS session.</p>
+          <note><p>This extension MUST only be used with DTLS, and not with TLS.</p></note>
+          <note><p>OTP does not handle SRTP, so an external implementations of SRTP
+          encoder/decoder and a packet demultiplexer are needed to make use
+          of the <c>use_srtp</c> extension. See also
+          <seetype marker="#transport_option">cb_info</seetype> option.</p></note>
         </desc>
       </datatype>
 
@@ -1613,27 +1611,36 @@ fun(srp, Username :: binary(), UserState :: term()) ->
       </datatype>
 
       <datatype>
-        <name name="use_srtp_protection_profiles"/>
+        <name name="use_srtp"/>
         <desc>
-          <p>Configures the server's chosen SRTP Protection Profile (as a list of a single profile).</p>
+          <p>Configures the <c>use_srtp</c> DTLS hello extension.</p>
           <p>Servers that receive an extended hello containing a "use_srtp"
           extension can agree to use SRTP by including an extension of type
           "use_srtp", with the chosen protection profile in the extended server
-          hello.</p>
-        </desc>
-      </datatype>
-
-      <datatype>
-        <name name="use_srtp_mki"/>
-        <desc>
-          <p>Configures the server's SRTP Master Key Identifier.</p>
-          <p>Upon receipt of a "use_srtp" extension containing a "srtp_mki" field,
-          the server MUST either (assuming it accepts the extension at all):</p>
+          hello. This extension MUST only be used when the data being
+          transported is RTP or RTCP.</p>
+          <p>The value is a map with a mandatory <c>protection_profiles</c> and
+          an optional <c>mki</c> parameters.</p>
 	  <list type="bulleted">
-	    <item><p>include a matching "srtp_mki" value in its "use_srtp" extension
-            to indicate that it will make use of the MKI, or</p></item>
-	    <item><p>return an empty "srtp_mki" value to indicate that it cannot make use of the MKI.</p></item>
-	  </list>
+            <item><p><c>protection_profiles</c> configures the list of the server's chosen
+            SRTP Protection Profile as a list of a single 2-byte binary. Example:
+            <c>#{protection_profiles =&gt; [&lt;&lt;0,5&gt;&gt;]}</c></p></item>
+            <item><p><c>mki</c> configures the server's SRTP Master Key Identifier.</p>
+            <p>Upon receipt of a "use_srtp" extension containing a "srtp_mki" field,
+            the server MUST either (assuming it accepts the extension at all):</p>
+	    <list type="bulleted">
+	      <item><p>include a matching "srtp_mki" value in its "use_srtp" extension
+              to indicate that it will make use of the MKI, or</p></item>
+              <item><p>return an empty "srtp_mki" value to indicate that it cannot
+              make use of the MKI (default).</p></item>
+	    </list>
+            </item>
+          </list>
+          <note><p>This extension MUST only be used with DTLS, and not with TLS.</p></note>
+          <note><p>OTP does not handle SRTP, so an external implementations of SRTP
+          encoder/decoder and a packet demultiplexer are needed to make use
+          of the <c>use_srtp</c> extension. See also
+          <seetype marker="#transport_option">cb_info</seetype> option.</p></note>
         </desc>
       </datatype>
 

--- a/lib/ssl/doc/src/standards_compliance.xml
+++ b/lib/ssl/doc/src/standards_compliance.xml
@@ -327,8 +327,8 @@
       <row>
         <cell align="left" valign="middle"></cell>
         <cell align="left" valign="middle">use_srtp (RFC5764)</cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+        <cell align="left" valign="middle"><em>C</em></cell>
+        <cell align="left" valign="middle">26.0</cell>
       </row>
       <row>
         <cell align="left" valign="middle"></cell>
@@ -466,8 +466,8 @@
       <row>
         <cell align="left" valign="middle"></cell>
         <cell align="left" valign="middle">use_srtp (RFC5764)</cell>
-	<cell align="left" valign="middle"><em>NC</em></cell>
-	<cell align="left" valign="middle"></cell>
+        <cell align="left" valign="middle"><em>C</em></cell>
+        <cell align="left" valign="middle">26.0</cell>
       </row>
       <row>
         <cell align="left" valign="middle"></cell>
@@ -594,6 +594,12 @@
 	<cell align="left" valign="middle"><em>C</em></cell>
 	<cell align="left" valign="middle"><em>22.1</em></cell>
       </row>
+      <row>
+        <cell align="left" valign="middle"></cell>
+        <cell align="left" valign="middle">use_srtp (RFC5764)</cell>
+        <cell align="left" valign="middle"><em>C</em></cell>
+        <cell align="left" valign="middle">26.0</cell>
+      </row>
 
       <row>
         <cell align="left" valign="middle"></cell>
@@ -624,6 +630,12 @@
         <cell align="left" valign="middle">supported_versions (RFC8446)</cell>
 	<cell align="left" valign="middle"><em>C</em></cell>
 	<cell align="left" valign="middle"><em>22</em></cell>
+      </row>
+      <row>
+        <cell align="left" valign="middle"></cell>
+        <cell align="left" valign="middle">use_srtp (RFC5764)</cell>
+        <cell align="left" valign="middle"><em>C</em></cell>
+        <cell align="left" valign="middle">26.0</cell>
       </row>
 
       <row>

--- a/lib/ssl/src/dtls_handshake.hrl
+++ b/lib/ssl/src/dtls_handshake.hrl
@@ -48,10 +48,9 @@
 	 }).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% RFC 7764  Datagram Transport Layer Security (DTLS) Extension to Establish Keys
+%% RFC 5764  Datagram Transport Layer Security (DTLS) Extension to Establish Keys
 %% for the Secure Real-time Transport Protocol (SRTP)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Not supported
--define(USE_SRTP, 14).
+%% Defined in ssl_handshake.hrl because extension parsing code is in ssl_handshake.erl
 
 -endif. % -ifdef(dtls_handshake).

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -696,6 +696,15 @@ encode_extensions([#sni{hostname = Hostname} | Rest], Acc) ->
                               ?BYTE(?SNI_NAMETYPE_HOST_NAME),
                               ?UINT16(HostLen), HostnameBin/binary,
                               Acc/binary>>);
+encode_extensions([#use_srtp{protection_profiles = Profiles, mki = MKI} | Rest], Acc) ->
+    ProfilesBin = iolist_to_binary(Profiles),
+    ProfilesLength = byte_size(ProfilesBin),
+    MKILength = byte_size(MKI),
+    ExtLength = ProfilesLength + 2 + MKILength + 1,
+    encode_extensions(Rest, <<?UINT16(?USE_SRTP_EXT), ?UINT16(ExtLength),
+                              ?UINT16(ProfilesLength), ProfilesBin/binary,
+                              ?BYTE(MKILength), MKI/binary,
+                              Acc/binary>>);
 encode_extensions([#max_frag_enum{enum = MaxFragEnum} | Rest], Acc) ->
     ExtLength = 1,
     encode_extensions(Rest, <<?UINT16(?MAX_FRAGMENT_LENGTH_EXT), ?UINT16(ExtLength), ?BYTE(MaxFragEnum),
@@ -1256,6 +1265,7 @@ add_tls12_extensions(_Version,
           encode_client_protocol_negotiation(NextProtocolSelector,
                                              Renegotiation),
       sni => sni(SslOpts),
+      use_srtp => use_srtp_ext(SslOpts),
       max_frag_enum => max_frag_enum(MaxFragmentLength)
      }.
 
@@ -1472,6 +1482,14 @@ signature_algs_cert(undefined) ->
 signature_algs_cert(SignatureSchemes) ->
     #signature_algorithms_cert{signature_scheme_list = SignatureSchemes}.
 
+
+use_srtp_ext(#{use_srtp_protection_profiles := [_|_] = Profiles} = Opts) ->
+    MKI = maps:get(use_srtp_mki, Opts, <<>>),
+    #use_srtp{protection_profiles = Profiles, mki = MKI};
+use_srtp_ext(#{}) ->
+    undefined.
+
+
 handle_client_hello_extensions(RecordCB, Random, ClientCipherSuites,
                                Exts, Version,
 			       #{secure_renegotiate := SecureRenegotation,
@@ -1498,6 +1516,7 @@ handle_client_hello_extensions(RecordCB, Random, ClientCipherSuites,
                                                                             ConnectionStates, Renegotiation),
                                    ec_point_formats => server_ecc_extension(Version, 
                                                                             maps:get(ec_point_formats, Exts, undefined)),
+                                   use_srtp => use_srtp_ext(Opts),
                                    max_frag_enum => ServerMaxFragEnum
                                   },
     
@@ -1897,6 +1916,8 @@ extension_value(undefined) ->
     undefined;
 extension_value(#sni{hostname = HostName}) ->
     HostName;
+extension_value(#use_srtp{protection_profiles = ProtectionProfiles, mki = MKI}) ->
+    #{protection_profiles => ProtectionProfiles, mki => MKI};
 extension_value(#ec_point_formats{ec_point_format_list = List}) ->
     List;
 extension_value(#elliptic_curves{elliptic_curve_list = List}) ->
@@ -2918,6 +2939,16 @@ decode_extensions(<<?UINT16(?SIGNATURE_ALGORITHMS_CERT_EXT), ?UINT16(Len),
                                #signature_algorithms_cert{
                                   signature_scheme_list = SignSchemes}});
 
+decode_extensions(<<?UINT16(?USE_SRTP_EXT), ?UINT16(Len),
+		       ExtData:Len/binary, Rest/binary>>, Version, MessageType, Acc) ->
+    <<?UINT16(ProfilesLen), ProfilesBin:ProfilesLen/binary, ?BYTE(MKILen), MKI:MKILen/binary>> = ExtData,
+    Profiles = [P || <<P:2/binary>> <= ProfilesBin],
+    decode_extensions(Rest, Version, MessageType,
+                      Acc#{use_srtp =>
+                              #use_srtp{
+                                 protection_profiles = Profiles,
+                                 mki=MKI}});
+
 decode_extensions(<<?UINT16(?ELLIPTIC_CURVES_EXT), ?UINT16(Len),
 		       ExtData:Len/binary, Rest/binary>>, Version, MessageType, Acc)
   when Version < {3,4} ->
@@ -3768,7 +3799,7 @@ empty_extensions({3,4}, client_hello) ->
       %% status_request => undefined,
       elliptic_curves => undefined,
       signature_algs => undefined,
-      %% use_srtp => undefined,
+      use_srtp => undefined,
       %% heartbeat => undefined,
       alpn => undefined,
       %% signed_cert_timestamp => undefined,

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1483,8 +1483,7 @@ signature_algs_cert(SignatureSchemes) ->
     #signature_algorithms_cert{signature_scheme_list = SignatureSchemes}.
 
 
-use_srtp_ext(#{use_srtp_protection_profiles := [_|_] = Profiles} = Opts) ->
-    MKI = maps:get(use_srtp_mki, Opts, <<>>),
+use_srtp_ext(#{use_srtp := #{protection_profiles := Profiles, mki := MKI}}) ->
     #use_srtp{protection_profiles = Profiles, mki = MKI};
 use_srtp_ext(#{}) ->
     undefined.
@@ -2947,7 +2946,7 @@ decode_extensions(<<?UINT16(?USE_SRTP_EXT), ?UINT16(Len),
                       Acc#{use_srtp =>
                               #use_srtp{
                                  protection_profiles = Profiles,
-                                 mki=MKI}});
+                                 mki = MKI}});
 
 decode_extensions(<<?UINT16(?ELLIPTIC_CURVES_EXT), ?UINT16(Len),
 		       ExtData:Len/binary, Rest/binary>>, Version, MessageType, Acc)

--- a/lib/ssl/src/ssl_handshake.hrl
+++ b/lib/ssl/src/ssl_handshake.hrl
@@ -371,6 +371,17 @@
 -define(ECPOINT_ANSIX962_COMPRESSED_CHAR2, 2).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% RFC 5764 section 4 Datagram Transport Layer Security (DTLS) Extensions
+%% for SRTP (Secure Real-time Transport Protocol) Key Establishment
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-define(USE_SRTP_EXT, 14).
+
+-record(use_srtp, {
+    protection_profiles,
+    mki
+   }).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% ECC RFC 4492 Handshake Messages, Section 5
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/lib/ssl/test/Makefile
+++ b/lib/ssl/test/Makefile
@@ -56,6 +56,7 @@ MODULES = \
 	openssl_sni_SUITE\
 	ssl_mfl_SUITE\
 	openssl_mfl_SUITE\
+	ssl_use_srtp_SUITE\
 	ssl_reject_SUITE\
         ssl_renegotiate_SUITE\
 	openssl_renegotiate_SUITE\

--- a/lib/ssl/test/property_test/ssl_eqc_handshake.erl
+++ b/lib/ssl/test/property_test/ssl_eqc_handshake.erl
@@ -297,7 +297,7 @@ extensions(?'TLS_v1.3' = Version, MsgType = client_hello) ->
            %% StatusRequest,
            SupportedGroups,
            SignatureAlgorithms,
-           %% UseSrtp,
+           UseSrtp,
            %% Heartbeat,
            ALPN,
            %% SignedCertTimestamp,
@@ -320,7 +320,7 @@ extensions(?'TLS_v1.3' = Version, MsgType = client_hello) ->
            %% oneof([status_request(), undefined]),
            oneof([supported_groups(Version), undefined]),
            oneof([signature_algs(Version), undefined]),
-           %% oneof([use_srtp(), undefined]),
+           oneof([use_srtp(), undefined]),
            %% oneof([heartbeat(), undefined]),
            oneof([alpn(), undefined]),
            %% oneof([signed_cert_timestamp(), undefined]),
@@ -348,7 +348,7 @@ extensions(?'TLS_v1.3' = Version, MsgType = client_hello) ->
                         %% status_request => StatusRequest,
                         elliptic_curves => SupportedGroups,
                         signature_algs => SignatureAlgorithms,
-                        %% use_srtp => UseSrtp,
+                        use_srtp => UseSrtp,
                         %% heartbeat => Heartbeat,
                         alpn => ALPN,
                         %% signed_cert_timestamp => SignedCertTimestamp,
@@ -681,6 +681,12 @@ sign_algorithm(?'TLS_v1.3') ->
     oneof([rsa, ecdsa]);
 sign_algorithm(_) ->
     oneof([rsa, dsa, ecdsa]).
+
+
+use_srtp() ->
+    FullProfiles = [<<0,1>>, <<0,2>>, <<0,5>>],
+    NullProfiles = [<<0,5>>],
+    ?LET(PP, oneof([FullProfiles, NullProfiles]), #use_srtp{protection_profiles = PP, mki = <<>>}).
 
 certificate_authorities(?'TLS_v1.3') ->
     Auths = certificate_authorities(?'TLS_v1.2'),

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -2295,6 +2295,7 @@ options_whitebox(Config) when is_list(Config) ->
     options_sni(Config),
     options_sign_alg(Config),
     options_supported_groups(Config),
+    options_use_srtp(Config),
     ok.
 
 options_protocol(_Config) ->
@@ -2986,6 +2987,23 @@ options_supported_groups(_Config) ->
     ?ERR({supported_groups, not_a_list}, [{supported_groups, not_a_list}], client),
     ?ERR({supported_groups, none_valid},  [{supported_groups, []}], client),
     ?ERR({supported_groups, none_valid},  [{supported_groups, [foo]}], client),
+    ok.
+
+options_use_srtp(_Config) ->
+    ?OK(#{use_srtp_protection_profiles := [<<0,2>>, <<0,5>>], use_srtp_mki := <<>>},
+        [{protocol, dtls}, {use_srtp_protection_profiles, [<<0,2>>, <<0,5>>]}], client),
+    ?OK(#{use_srtp_protection_profiles := [<<0,2>>], use_srtp_mki := <<>>},
+        [{protocol, dtls}, {use_srtp_protection_profiles, [<<0,2>>]}], server),
+    ?OK(#{use_srtp_protection_profiles := [<<0,2>>, <<0,5>>], use_srtp_mki := <<"123">>},
+        [{protocol, dtls}, {use_srtp_protection_profiles, [<<0,2>>, <<0,5>>]},
+         {use_srtp_mki, <<"123">>}], client),
+    ?OK(#{use_srtp_protection_profiles := [<<0,2>>], use_srtp_mki := <<"123">>},
+        [{protocol, dtls}, {use_srtp_protection_profiles, [<<0,2>>]},
+         {use_srtp_mki, <<"123">>}], server),
+
+    % use_srtp is DTLS-only extension, by default setting its options should raise an error
+    ?ERR({options, incompatible, _}, [{use_srtp_protection_profiles, [<<0,2>>, <<0,5>>]}], client),
+    ?ERR({options, incompatible, _}, [{use_srtp_protection_profiles, [<<0,2>>]}], server),
     ok.
 
 %%-------------------------------------------------------------------

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -2990,20 +2990,38 @@ options_supported_groups(_Config) ->
     ok.
 
 options_use_srtp(_Config) ->
-    ?OK(#{use_srtp_protection_profiles := [<<0,2>>, <<0,5>>], use_srtp_mki := <<>>},
-        [{protocol, dtls}, {use_srtp_protection_profiles, [<<0,2>>, <<0,5>>]}], client),
-    ?OK(#{use_srtp_protection_profiles := [<<0,2>>], use_srtp_mki := <<>>},
-        [{protocol, dtls}, {use_srtp_protection_profiles, [<<0,2>>]}], server),
-    ?OK(#{use_srtp_protection_profiles := [<<0,2>>, <<0,5>>], use_srtp_mki := <<"123">>},
-        [{protocol, dtls}, {use_srtp_protection_profiles, [<<0,2>>, <<0,5>>]},
-         {use_srtp_mki, <<"123">>}], client),
-    ?OK(#{use_srtp_protection_profiles := [<<0,2>>], use_srtp_mki := <<"123">>},
-        [{protocol, dtls}, {use_srtp_protection_profiles, [<<0,2>>]},
-         {use_srtp_mki, <<"123">>}], server),
+    ?OK(#{use_srtp := #{protection_profiles := [<<0,2>>, <<0,5>>], mki := <<>>}},
+        [{protocol, dtls},
+         {use_srtp, #{protection_profiles => [<<0,2>>, <<0,5>>]}}], client),
+    ?OK(#{use_srtp := #{protection_profiles := [<<0,2>>], mki := <<>>}},
+        [{protocol, dtls},
+         {use_srtp, #{protection_profiles => [<<0,2>>]}}], server),
+    ?OK(#{use_srtp := #{protection_profiles := [<<0,2>>, <<0,5>>], mki := <<"123">>}},
+        [{protocol, dtls},
+         {use_srtp, #{protection_profiles => [<<0,2>>, <<0,5>>], mki => <<"123">>}}], client),
+    ?OK(#{use_srtp := #{protection_profiles := [<<0,2>>], mki := <<"123">>}},
+        [{protocol, dtls},
+         {use_srtp, #{protection_profiles => [<<0,2>>], mki => <<"123">>}}], server),
 
-    % use_srtp is DTLS-only extension, by default setting its options should raise an error
-    ?ERR({options, incompatible, _}, [{use_srtp_protection_profiles, [<<0,2>>, <<0,5>>]}], client),
-    ?ERR({options, incompatible, _}, [{use_srtp_protection_profiles, [<<0,2>>]}], server),
+    %% invalid parameters
+    ?ERR({options, {use_srtp, {no_protection_profiles, _}}},
+         [{protocol, dtls},
+          {use_srtp, #{}}], client),
+    ?ERR({options, {use_srtp, {no_protection_profiles, _}}},
+         [{protocol, dtls},
+          {use_srtp, #{protection_profiles => []}}], client),
+    ?ERR({options, {use_srtp, {invalid_protection_profiles, _}}},
+         [{protocol, dtls},
+          {use_srtp, #{protection_profiles => [<<"bad">>]}}], client),
+    ?ERR({options, {use_srtp, {unknown_parameters,[whatever]}}},
+         [{protocol, dtls},
+          {use_srtp, #{protection_profiles => [<<0,2>>], whatever => xxx}}], client),
+
+    %% use_srtp is DTLS-only extension, by default setting its options should raise an error
+    ?ERR({options, incompatible, _},
+         [{use_srtp, #{protection_profiles => [<<0,2>>, <<0,5>>]}}], client),
+    ?ERR({options, incompatible, _},
+         [{use_srtp, #{protection_profiles => [<<0,2>>]}}], server),
     ok.
 
 %%-------------------------------------------------------------------

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -1152,10 +1152,8 @@ client_cont_loop(_Node, Host, Port, Pid, Transport, Options, ContOpts0, Opts) ->
             case Transport:handshake_continue(Socket0, ContOpts) of
                 {ok, Socket} ->
                     Pid ! {connected, Socket},
-                    {Module, Function, Args} = proplists:get_value(mfa, Opts),
-                    ?LOG("~nClient: apply(~p,~p,~p)~n",
-                           [Module, Function, [Socket | Args]]),
-                    case apply(Module, Function, [Socket | Args]) of
+                    MFA = proplists:get_value(mfa, Opts),
+                    case client_apply_mfa(Socket, MFA) of
                         no_result_msg ->
                             ok;
                         Msg ->

--- a/lib/ssl/test/ssl_use_srtp_SUITE.erl
+++ b/lib/ssl/test/ssl_use_srtp_SUITE.erl
@@ -1,0 +1,176 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2015-2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%%
+
+-module(ssl_use_srtp_SUITE).
+
+-behaviour(ct_suite).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("public_key/include/public_key.hrl").
+-include_lib("kernel/include/inet.hrl").
+
+%% Callback functions
+-export([all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2]).
+
+%% Testcases
+-export([srtp_profiles/1,
+         srtp_mki/1
+        ]).
+
+-define(TIMEOUT, {seconds, 6}).
+
+%%--------------------------------------------------------------------
+%% Common Test interface functions -----------------------------------
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+     {group, 'dtlsv1.2'},
+     {group, 'dtlsv1'}
+    ].
+
+groups() ->
+    [
+     {'dtlsv1.2', [], use_srtp_tests()},
+     {'dtlsv1', [], use_srtp_tests()}
+    ].
+
+use_srtp_tests() ->
+    [
+     srtp_profiles,
+     srtp_mki
+    ].
+
+init_per_suite(Config0) ->
+    catch crypto:stop(),
+    try crypto:start() of
+        ok ->
+            ssl_test_lib:clean_start(),
+            {#{server_config := _ServerConf,
+               client_config := ClientConf},
+             #{server_config := _LServerConf,
+               client_config := LClientConf}} = ssl_test_lib:make_rsa_sni_configs(),
+            %% RSA certs files needed by *dot cases
+            ssl_test_lib:make_rsa_cert([{client_opts, ClientConf},
+                                        {client_local_opts, LClientConf}
+                                       | Config0])
+    catch _:_  ->
+            {skip, "Crypto did not start"}
+    end.
+init_per_group(GroupName, Config) ->
+    ssl_test_lib:init_per_group(GroupName, Config).
+
+end_per_group(GroupName, Config) ->
+   ssl_test_lib:end_per_group(GroupName, Config).
+
+end_per_suite(_) ->
+    ssl:stop(),
+    application:stop(crypto).
+
+init_per_testcase(_TestCase, Config) ->
+    ssl_test_lib:ct_log_supported_protocol_versions(Config),
+    ct:timetrap(?TIMEOUT),
+    Config.
+
+end_per_testcase(_TestCase, Config) ->     
+    Config.
+
+%%--------------------------------------------------------------------
+%% Test Cases --------------------------------------------------------
+%%--------------------------------------------------------------------
+
+srtp_profiles(Config) ->
+    % Client sends a list of SRTP profiles it supports in client_hello
+    ClientOpts0 = ssl_test_lib:ssl_options(client_rsa_verify_opts, Config),
+    ClentSrtpOpts = [{use_srtp_protection_profiles, [<<0,1>>,<<0,2>>,<<0,5>>]}],
+    ClientOpts = ClentSrtpOpts ++ [{handshake, hello}] ++ ClientOpts0,
+    ClientContOpts = [{continue_options, [{want_ext, self()}]}],
+    % Server responds with a single chosen profile in server_hello
+    ServerOpts0 = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    ServerOpts = [{handshake, hello}] ++ ServerOpts0,
+    ServerSrtpOts = [{use_srtp_protection_profiles, [<<0,2>>]}],
+    ServerContOpts = [{continue_options, [{want_ext, self()}|ServerSrtpOts]}],
+
+    Server = ssl_test_lib:start_server(ServerContOpts,
+                                       [{server_opts, ServerOpts} | Config]),
+
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_client([{port, Port} | ClientContOpts],
+                                       [{client_opts, ClientOpts} | Config]),
+
+    receive
+        {Server, {ext, C2SExt}} ->
+            C2SSRTP = maps:get(use_srtp, C2SExt),
+            #{protection_profiles := [<<0,1>>,<<0,2>>,<<0,5>>]} = C2SSRTP,
+            #{mki := <<>>} = C2SSRTP,
+            ssl_test_lib:close(Server)
+    end,
+    receive
+        {Client, {ext, S2CExt}} ->
+            S2CSRTP = maps:get(use_srtp, S2CExt),
+            #{protection_profiles := [<<0,2>>]} = S2CSRTP,
+            #{mki := <<>>} = S2CSRTP,
+            ssl_test_lib:close(Client)
+    end,
+    ok.
+
+
+srtp_mki(Config) ->
+    % Client sends some MKI in a client_hello
+    ClientOpts0 = ssl_test_lib:ssl_options(client_rsa_verify_opts, Config),
+    ClientSrtpOpts = [{use_srtp_protection_profiles, [<<0,1>>,<<0,2>>,<<0,5>>]},
+                      {use_srtp_mki, <<"client_mki">>}],
+    ClientOpts = ClientSrtpOpts ++ [{handshake, hello}] ++ ClientOpts0,
+    ClientContOpts = [{continue_options, [{want_ext, self()}]}],
+    % Server responds with its own MKI just to ensure it is delivered to the client
+    ServerOpts0 = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    ServerOpts = [{handshake, hello}] ++ ServerOpts0,
+    ServerSrtpOpts = [{use_srtp_protection_profiles, [<<0,2>>]},
+                      {use_srtp_mki, <<"server_mki">>}],
+    ServerContOpts = [{continue_options, [{want_ext, self()}|ServerSrtpOpts]}],
+
+    Server = ssl_test_lib:start_server(ServerContOpts,
+                                       [{server_opts, ServerOpts} | Config]),
+
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_client(
+               [{port, Port}, {options, ClientOpts} | ClientContOpts], Config),
+
+    receive
+        {Server, {ext, C2SExt}} ->
+            C2SSRTP = maps:get(use_srtp, C2SExt),
+            #{mki := <<"client_mki">>} = C2SSRTP,
+            ssl_test_lib:close(Server)
+    end,
+    receive
+        {Client, {ext, S2CExt}} ->
+            S2CSRTP = maps:get(use_srtp, S2CExt),
+            #{mki := <<"server_mki">>} = S2CSRTP,
+            ssl_test_lib:close(Client)
+    end,
+    ok.

--- a/lib/ssl/test/ssl_use_srtp_SUITE.erl
+++ b/lib/ssl/test/ssl_use_srtp_SUITE.erl
@@ -107,13 +107,13 @@ end_per_testcase(_TestCase, Config) ->
 srtp_profiles(Config) ->
     % Client sends a list of SRTP profiles it supports in client_hello
     ClientOpts0 = ssl_test_lib:ssl_options(client_rsa_verify_opts, Config),
-    ClentSrtpOpts = [{use_srtp_protection_profiles, [<<0,1>>,<<0,2>>,<<0,5>>]}],
+    ClentSrtpOpts = [{use_srtp, #{protection_profiles => [<<0,1>>,<<0,2>>,<<0,5>>]}}],
     ClientOpts = ClentSrtpOpts ++ [{handshake, hello}] ++ ClientOpts0,
     ClientContOpts = [{continue_options, [{want_ext, self()}]}],
     % Server responds with a single chosen profile in server_hello
     ServerOpts0 = ssl_test_lib:ssl_options(server_rsa_opts, Config),
     ServerOpts = [{handshake, hello}] ++ ServerOpts0,
-    ServerSrtpOts = [{use_srtp_protection_profiles, [<<0,2>>]}],
+    ServerSrtpOts = [{use_srtp, #{protection_profiles => [<<0,2>>]}}],
     ServerContOpts = [{continue_options, [{want_ext, self()}|ServerSrtpOts]}],
 
     Server = ssl_test_lib:start_server(ServerContOpts,
@@ -143,15 +143,15 @@ srtp_profiles(Config) ->
 srtp_mki(Config) ->
     % Client sends some MKI in a client_hello
     ClientOpts0 = ssl_test_lib:ssl_options(client_rsa_verify_opts, Config),
-    ClientSrtpOpts = [{use_srtp_protection_profiles, [<<0,1>>,<<0,2>>,<<0,5>>]},
-                      {use_srtp_mki, <<"client_mki">>}],
+    ClientSrtpOpts = [{use_srtp, #{protection_profiles => [<<0,1>>,<<0,2>>,<<0,5>>],
+                                   mki => <<"client_mki">>}}],
     ClientOpts = ClientSrtpOpts ++ [{handshake, hello}] ++ ClientOpts0,
     ClientContOpts = [{continue_options, [{want_ext, self()}]}],
     % Server responds with its own MKI just to ensure it is delivered to the client
     ServerOpts0 = ssl_test_lib:ssl_options(server_rsa_opts, Config),
     ServerOpts = [{handshake, hello}] ++ ServerOpts0,
-    ServerSrtpOpts = [{use_srtp_protection_profiles, [<<0,2>>]},
-                      {use_srtp_mki, <<"server_mki">>}],
+    ServerSrtpOpts = [{use_srtp, #{protection_profiles => [<<0,2>>],
+                                   mki => <<"server_mki">>}}],
     ServerContOpts = [{continue_options, [{want_ext, self()}|ServerSrtpOpts]}],
 
     Server = ssl_test_lib:start_server(ServerContOpts,


### PR DESCRIPTION
This PR implements encoding and decoding of use_srtp hello extension (RFC 5764) which is necessary for setting up an SRTP channel. SRTP is used in WebRTC.

This feature was requested in #3771

To add use_srtp to hello extensions, you need to pass 'use_srtp_protection_profiles' option, e.g.
  `ssl:connect("localhost", 17423, [{protocol, dtls},
    {use_srtp_protection_profiles, [<<0,1>>, <<0,5>>]}, {handshake, hello}]).`
Proper value for use_srtp_protection_profiles option is a list of 2-byte binary profile ids (see section 4.1.2 of RFC 5764)

Optionally you may specify use_srtp_mki option to set srtp_mki field (I don't need it now but someone may need it later).