### PR TITLE
[diameter] no_result_code in diameter stats ets table when experimental result is a list

### DIFF
--- a/lib/diameter/src/base/diameter_traffic.erl
+++ b/lib/diameter/src/base/diameter_traffic.erl
@@ -1989,6 +1989,9 @@ get_avp(Dict, Name, Rec) ->
             undefined
     end.
 
+value('Experimental-Result' = N, [#{'Vendor-Id' := Vid,
+                                    'Experimental-Result-Code' := RC}]) ->
+    {N, Vid, RC};
 value('Experimental-Result' = N, #{'Vendor-Id' := Vid,
                                    'Experimental-Result-Code' := RC}) ->
     {N, Vid, RC};


### PR DESCRIPTION
Some diameter specifications contain both `Result-Code` and `Experimental-Result` AVPs in some command answers. Since only one can be present in the answer they are both marked as optional and thus represented as a list (empty or with a single element). See for instance this fragment taken from [this spec, sec 7.2.20](https://www.etsi.org/deliver/etsi_ts/129200_129299/129272/16.07.00_60/ts_129272v160700p.pdf)
![image](https://user-images.githubusercontent.com/5650488/198138496-a5a77347-16ea-4263-959b-1e6bd0796431.png)

This allows a server to send the `Experimental-Result~ AVP value wrapped in a list but when this is done the diameter stats fails to get the correct code and the corresponding row in the ETS table becomes something like
```erlang
{{{{16777252,324,0},send,no_result_code},<0.772.0>},2}
```
instead of the correct one:
```erlang
{{{{16777252,324,0},send,{'Experimental-Result',10415,5422}},<0.772.0>},2}
```

This happens because the code that searches for that AVP does not consider that it can be wrapped in a list, this PR solves this problem.
