### PR TITLE
Optimize encoding of utf8 segments in the binary syntax

### DIFF
--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -884,7 +884,7 @@ erts_new_bs_put_integer(ERL_BITS_PROTO_3(Eterm arg, Uint num_bits, unsigned flag
 	if (fmt_int(iptr, NBYTES(num_bits), arg, num_bits, flags) < 0) {
 	    return 0;
 	}
-	erts_copy_bits_restricted(iptr, erts_current_bin, bin_offset, num_bits);
+	erts_copy_bits(iptr, 0, 1, erts_current_bin, bin_offset, 1, num_bits);
     }
     erts_bin_offset = bin_offset + num_bits;
     return 1;
@@ -2148,25 +2148,6 @@ erts_cmp_bits(byte* a_ptr, size_t a_offs, byte* b_ptr, size_t b_offs, size_t siz
     }
 
     return 0;
-}
-
-/*
- * Restricted version of copy_bits() for copying from a buffer into
- * a binary. Direction is always forward and the source offset is always
- * zero.
- */
-void
-erts_copy_bits_restricted(byte* src,	/* Base pointer to source. */
-                          byte* dst,	/* Base pointer to destination. */
-                          size_t doffs, /* Bit offset for destination relative to dst. */
-                          size_t n)     /* Number of bits to copy. */
-{
-    if (doffs == 0) {
-        abort();
-    }
-    ASSERT(n != 0);
-    ASSERT(doffs != 0);
-    erts_copy_bits(src, 0, 1, dst, doffs, 1, n);
 }
 
 /*

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -194,7 +194,6 @@ Eterm erts_bs_init_writable(Process* p, Eterm sz);
  */
 void erts_copy_bits(byte* src, size_t soffs, int sdir,
 		    byte* dst, size_t doffs,int ddir, size_t n);
-void erts_copy_bits_restricted(byte* src, byte* dst, size_t doffs, size_t n);
 int erts_cmp_bits(byte* a_ptr, size_t a_offs, byte* b_ptr, size_t b_offs, size_t size); 
 
 

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1445,12 +1445,14 @@ protected:
     void emit_bs_get_utf16(const ArgRegister &Ctx,
                            const ArgLabel &Fail,
                            const ArgWord &Flags);
-    void update_bin_state(arm::Gp bin_base,
-                          arm::Gp bin_offset,
+    void update_bin_state(arm::Gp bin_offset,
                           Sint bit_offset,
                           Sint size,
                           arm::Gp size_reg);
     void set_zero(Sint effectiveSize);
+    void emit_construct_utf8(const ArgVal &Src,
+                             Sint bit_offset,
+                             bool is_byte_aligned);
 
     void emit_read_bits(Uint bits,
                         const arm::Gp bin_offset,

--- a/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
@@ -49,6 +49,7 @@ my @beam_global_funcs = qw(
     call_nif_early
     call_nif_shared
     check_float_error
+    construct_utf8_shared
     debug_bp
     dispatch_bif
     dispatch_nif
@@ -101,6 +102,7 @@ my @beam_global_funcs = qw(
     process_main
     raise_exception
     raise_exception_shared
+    store_unaligned
     times_body_shared
     times_guard_shared
     unary_minus_body_shared

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1496,8 +1496,8 @@ protected:
     void emit_bs_get_utf16(const ArgRegister &Ctx,
                            const ArgLabel &Fail,
                            const ArgWord &Flags);
-    void update_bin_state(x86::Gp bin_base,
-                          x86::Gp bin_offset,
+    void update_bin_state(x86::Gp bin_offset,
+                          x86::Gp current_byte,
                           Sint bit_offset,
                           Sint size,
                           x86::Gp size_reg);
@@ -1505,6 +1505,10 @@ protected:
     void set_zero(Sint effectiveSize);
     bool bs_maybe_enter_runtime(bool entered);
     void bs_maybe_leave_runtime(bool entered);
+    void emit_construct_utf8_shared();
+    void emit_construct_utf8(const ArgVal &Src,
+                             Sint bit_offset,
+                             bool is_byte_aligned);
 
     void emit_read_bits(Uint bits,
                         const x86::Gp bin_base,

--- a/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
@@ -39,6 +39,7 @@ my @beam_global_funcs = qw(
     call_nif_yield_helper
     catch_end_shared
     check_float_error
+    construct_utf8_shared
     dispatch_bif
     dispatch_nif
     dispatch_return
@@ -93,6 +94,7 @@ my @beam_global_funcs = qw(
     process_main
     raise_exception
     raise_exception_shared
+    store_unaligned
     times_body_shared
     times_guard_shared
     unary_minus_body_shared


### PR DESCRIPTION
Currently, encoding a Unicode code point as UTF-8 in the binary syntax is done by calling a helper function written in C.

Optimize this by inlining all code for handling the ASCII subset of Unicode (code points less than 128). Handle other code points by calling a helper fragment implemented in native code. Calling a fragment has less overhead than calling a function implemented in C.