### PR TITLE
Lift restrictions for matching of binaries and maps

### DIFF
--- a/lib/compiler/test/match_SUITE.erl
+++ b/lib/compiler/test/match_SUITE.erl
@@ -26,7 +26,8 @@
 	 selectify/1,deselectify/1,underscore/1,match_map/1,map_vars_used/1,
 	 coverage/1,grab_bag/1,literal_binary/1,
          unary_op/1,eq_types/1,match_after_return/1,match_right_tuple/1,
-         tuple_size_in_try/1,match_boolean_list/1]).
+         tuple_size_in_try/1,match_boolean_list/1,
+         heisen_variables/1]).
 	 
 -include_lib("common_test/include/ct.hrl").
 
@@ -43,7 +44,8 @@ groups() ->
        underscore,match_map,map_vars_used,coverage,
        grab_bag,literal_binary,unary_op,eq_types,
        match_after_return,match_right_tuple,
-       tuple_size_in_try,match_boolean_list]}].
+       tuple_size_in_try,match_boolean_list,
+       heisen_variables]}].
 
 
 init_per_suite(Config) ->
@@ -151,14 +153,19 @@ aliases(Config) when is_list(Config) ->
     6 = tup_lit_alias({1,2,3}),
     6 = tup_lit_alias_rev({1,2,3}),
 
-    {42,42,42,42} = multiple_aliases_1(42),
-    {7,7,7} = multiple_aliases_2(7),
-    {{a,b},{a,b},{a,b}} = multiple_aliases_3({a,b}),
+    {1,2,3,4} = list_in_tuple({container, [1,2,3], 4}),
+    {a,b,c,d} = list_in_tuple({container, [a,b,c], d}),
+
+    {13,y,13,17,x,{y,13},17} = tuple_in_tuple({x, {y,13}, 17}),
+    {a,y,a,b,x,{y,a},b} = tuple_in_tuple({x, {y,a}, b}),
+
+    {42,42,42,42} = multiple_aliases_1(id(42)),
+    {7,7,7} = multiple_aliases_2(id(7)),
+    {{a,b},{a,b},{a,b}} = multiple_aliases_3(id({a,b})),
+    {[x,y,z],[x,y,z],[x,y,z]} = multiple_aliases_4(id([x,y,z])),
 
     %% Lists/literals.
-    {a,b} = list_alias1([a,b]),
-    {a,b} = list_alias2([a,b]),
-    {a,b} = list_alias3([a,b]),
+    {a,b} = list_alias(id([a,b])),
 
     %% Multiple matches.
     {'EXIT',{{badmatch,home},_}} =
@@ -259,9 +266,20 @@ three_2(A=
 	C) ->
     {A,B,C}.
 
-tuple_alias({A,B,C}={X,Y,Z}) ->
+tuple_alias(Expr) ->
+    Res = tuple_alias_a(Expr),
+    Res = tuple_alias_b(Expr).
+
+tuple_alias_a({A,B,C} = {X,Y,Z}) ->
     {A,B,C,X,Y,Z};
-tuple_alias({A,B}={C,D}={E,F}) ->
+tuple_alias_a({A,B} = {C,D} = {E,F}) ->
+    {A,B,C,D,E,F}.
+
+tuple_alias_b({_,_,_}=Expr) ->
+    {A,B,C} = {X,Y,Z} = Expr,
+    {A,B,C,X,Y,Z};
+tuple_alias_b({_,_}=Expr) ->
+    {A,B} = {C,D} = {E,F} = Expr,
     {A,B,C,D,E,F}.
 
 tup_lit_alias({A,B,C}={1,2,3}) ->
@@ -270,22 +288,91 @@ tup_lit_alias({A,B,C}={1,2,3}) ->
 tup_lit_alias_rev({1,2,3}={A,B,C}) ->
     A+B+C.
 
-multiple_aliases_1((A=B)=(C=D)) ->
+list_in_tuple(E) ->
+    Res = list_in_tuple_a(E),
+    Res = list_in_tuple_b(E).
+
+list_in_tuple_a({container, [_,_,_] = [A,B,C], D}) ->
     {A,B,C,D}.
 
-multiple_aliases_2((A=B)=(A=C)) ->
+list_in_tuple_b(E) ->
+    {container, [_,_,_] = [A,B,C], D} = E,
+    {A,B,C,D}.
+
+tuple_in_tuple(Expr) ->
+    Res = tuple_in_tuple_a(Expr),
+    Res = tuple_in_tuple_b(Expr).
+
+tuple_in_tuple_a({x, {y,A} = {B,C}, D} = {E, F, G}) ->
+    {A,B,C,D,E,F,G}.
+
+tuple_in_tuple_b(Expr) ->
+    {x, {y,A} = {B,C}, D} = {E, F, G} = Expr,
+    {A,B,C,D,E,F,G}.
+
+multiple_aliases_1(Expr) ->
+    Res = multiple_aliases_1a(Expr),
+    Res = multiple_aliases_1b(Expr).
+
+multiple_aliases_1a((A=B) = (C=D)) ->
+    {A,B,C,D}.
+
+multiple_aliases_1b(Expr) ->
+    (A=B) = (C=D) = Expr,
+    {A,B,C,D}.
+
+multiple_aliases_2((A=B) = (A=C)) ->
     {A,B,C}.
 
-multiple_aliases_3((A={_,_}=B)={_,_}=C) ->
+multiple_aliases_3(Expr) ->
+    Res = multiple_aliases_3a(Expr),
+    Res = multiple_aliases_3b(Expr).
+
+multiple_aliases_3a((A={_,_}=B)={_,_}=C) ->
     {A,B,C}.
 
-list_alias1([a,b]=[X,Y]) ->
+multiple_aliases_3b(Expr) ->
+    (A={_,_}=B) = {_,_} = C = Expr,
+    {A,B,C}.
+
+multiple_aliases_4(Expr) ->
+    Res = multiple_aliases_4a(Expr),
+    Res = multiple_aliases_4b(Expr).
+
+multiple_aliases_4a((A=[_,_,_]=B) = [_,_,_] = C) ->
+    {A,B,C}.
+
+multiple_aliases_4b(Expr) ->
+    (A=[_,_,_]=B) = [_,_,_] = C = Expr,
+    {A,B,C}.
+
+list_alias(Expr) ->
+    Res = list_alias1a(Expr),
+    Res = list_alias1b(Expr),
+    Res = list_alias2a(Expr),
+    Res = list_alias2b(Expr),
+    Res = list_alias3a(Expr),
+    Res = list_alias3b(Expr).
+
+list_alias1a([a,b]=[X,Y]) ->
     {X,Y}.
 
-list_alias2([X,Y]=[a,b]) ->
+list_alias1b(Expr) ->
+    [a,b] = [X,Y] = Expr,
     {X,Y}.
 
-list_alias3([X,b]=[a,Y]) ->
+list_alias2a([X,Y]=[a,b]) ->
+    {X,Y}.
+
+list_alias2b(Expr) ->
+    [X,Y] = [a,b] = Expr,
+    {X,Y}.
+
+list_alias3a([X,b]=[a,Y]) ->
+    {X,Y}.
+
+list_alias3b(Expr) ->
+    [X,b] = [a,Y]= Expr,
     {X,Y}.
 
 non_matching_aliases(_Config) ->
@@ -319,6 +406,9 @@ non_matching_aliases(_Config) ->
 
     {'EXIT',{{case_clause,whatever},_}} = (catch pike1(whatever)),
     {'EXIT',{{case_clause,whatever},_}} = (catch pike2(whatever)),
+
+    {'EXIT',{badarith,_}} = catch squid(a),
+    {'EXIT',{{badmatch,43},_}} = catch squid(42),
 
     ok.
 
@@ -401,6 +491,11 @@ pike2(X) ->
             end
     end,
     Var.
+
+squid(E) ->
+    ([X] = {Y}) = V = E + 1,
+    {V,X + Y}.
+
 
 %% OTP-7018.
 
@@ -1017,5 +1112,17 @@ match_boolean_list(Config) when is_list(Config) ->
              [true | _] -> error;
              [false | _] -> ok
          end.
+
+heisen_variables(_Config) ->
+    {'EXIT',{{badmatch,3},_}} = catch gh_6516_scope1(),
+    {'EXIT',{{badmatch,3},_}} = catch gh_6516_scope2(),
+
+    ok.
+
+gh_6516_scope1() ->
+    {X = 4, X = 3}.
+
+gh_6516_scope2() ->
+  {X = 4, _ = X = 3}.
 
 id(I) -> I.

--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -102,8 +102,7 @@ pattern(Config) when is_list(Config) ->
            [warn_unused_vars],
            {warnings,
             [{{2,15},v3_core,{nomatch,pattern}},
-             {{6,20},v3_core,{nomatch,pattern}},
-             {{11,18},v3_core,{nomatch,pattern}}
+             {{6,20},v3_core,{nomatch,pattern}}
             ]}}],
     [] = run(Config, Ts),
     ok.

--- a/lib/stdlib/test/erl_eval_SUITE.erl
+++ b/lib/stdlib/test/erl_eval_SUITE.erl
@@ -55,7 +55,8 @@
          otp_14708/1,
          otp_16545/1,
          otp_16865/1,
-         eep49/1]).
+         eep49/1,
+         binary_and_map_aliases/1]).
 
 %%
 %% Define to run outside of test server
@@ -96,7 +97,7 @@ all() ->
      otp_8133, otp_10622, otp_13228, otp_14826,
      funs, custom_stacktrace, try_catch, eval_expr_5, zero_width,
      eep37, eep43, otp_15035, otp_16439, otp_14708, otp_16545, otp_16865,
-     eep49].
+     eep49, binary_and_map_aliases].
 
 groups() -> 
     [].
@@ -1969,6 +1970,36 @@ eep49(Config) when is_list(Config) ->
           error),
     error_check("maybe ok ?= simply_wrong else {error,_} -> error end.",
                 {else_clause,simply_wrong}),
+    ok.
+
+%% GH-6348/OTP-18297: Lift restrictions for matching of binaries and maps.
+binary_and_map_aliases(Config) when is_list(Config) ->
+    check(fun() ->
+                  <<A:16>> = <<B:8,C:8>> = <<16#cafe:16>>,
+                  {A,B,C}
+          end,
+          "begin <<A:16>> = <<B:8,C:8>> = <<16#cafe:16>>, {A,B,C} end.",
+          {16#cafe,16#ca,16#fe}),
+    check(fun() ->
+                  <<A:8/bits,B:24/bits>> =
+                      <<C:16,D:16>> =
+                      <<E:8,F:8,G:8,H:8>> =
+                      <<16#abcdef57:32>>,
+                  {A,B,C,D,E,F,G,H}
+          end,
+          "begin <<A:8/bits,B:24/bits>> =
+                 <<C:16,D:16>> =
+                 <<E:8,F:8,G:8,H:8>> =
+                 <<16#abcdef57:32>>,
+                 {A,B,C,D,E,F,G,H}
+           end.",
+          {<<16#ab>>,<<16#cdef57:24>>, 16#abcd,16#ef57, 16#ab,16#cd,16#ef,16#57}),
+    check(fun() ->
+                  #{K := V} = #{k := K} = #{k => my_key, my_key => 42},
+                  V
+          end,
+          "begin #{K := V} = #{k := K} = #{k => my_key, my_key => 42}, V end.",
+          42),
     ok.
 
 %% Check the string in different contexts: as is; in fun; from compiled code.

--- a/lib/stdlib/test/qlc_SUITE.erl
+++ b/lib/stdlib/test/qlc_SUITE.erl
@@ -401,6 +401,7 @@ nomatch(Config) when is_list(Config) ->
         %% {warnings,[{{3,52},qlc,nomatch_pattern}]}},
         {warnings,[{{3,37},v3_core,{nomatch,pattern}}]}},
 
+       %% No longer illegal in OTP 26.
        {nomatch4,
         <<"nomatch() ->
               etsc(fun(E) ->
@@ -411,7 +412,7 @@ nomatch(Config) when is_list(Config) ->
                     end, [{<<34>>},{<<40>>}]).
         ">>,
         [],
-        {errors,[{{3,48},erl_lint,illegal_bin_pattern}],[]}},
+        []},
 
        {nomatch5,
         <<"nomatch() ->

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -138,18 +138,22 @@ member(_Elem, []) ->
 Name1
 [H|T]
 {error,Reason}</pre>
-    <p>Patterns are allowed in clause heads, <c>case</c> and
-      <c>receive</c> expressions, and match expressions.</p>
+     <p>Patterns are allowed in clause heads,
+     <seeguide marker="#case">case expressions</seeguide>,
+     <seeguide marker="#receive">receive expressions</seeguide>,
+     and
+     <seeguide marker="#match_operator">match expressions</seeguide>.</p>
 
     <section>
-      <title>Match Operator = in Patterns</title>
+      <marker id="compound_pattern_operator"></marker>
+      <title>The Compound Pattern Operator</title>
       <p>If <c>Pattern1</c> and <c>Pattern2</c> are valid patterns,
         the following is also a valid pattern:</p>
       <pre>
 Pattern1 = Pattern2</pre>
       <p>When matched against a term, both <c>Pattern1</c> and
-        <c>Pattern2</c> are  matched against the term. The idea
-        behind this feature is to avoid reconstruction of terms.</p>
+      <c>Pattern2</c> are matched against the term. The idea behind
+      this feature is to avoid reconstruction of terms.</p>
        <p><em>Example:</em></p>
       <pre>
 f({connect,From,To,Number,Options}, To) ->
@@ -163,6 +167,11 @@ f({connect,_,To,_,_} = Signal, To) ->
     ...;
 f(Signal, To) ->
     ignore.</pre>
+
+    <p>The compound pattern operator does not imply that its operands
+    are matched in any particular order. That means that it is not
+    legal to bind a variable in <c>Pattern1</c> and use it in <c>Pattern2</c>,
+    or vice versa.</p>
     </section>
 
     <section>
@@ -192,22 +201,121 @@ case {Value, Result} of
   </section>
 
   <section>
-    <title>Match</title>
-    <p>The following matches <c>Expr1</c>, a pattern, against
-      <c>Expr2</c>:</p>
+    <marker id="match_operator"></marker>
+    <title>The Match Operator</title>
+    <p>The following matches <c>Pattern</c> against
+      <c>Expr</c>:</p>
     <pre>
-Expr1 = Expr2</pre>
+Pattern = Expr</pre>
     <p>If the matching succeeds, any unbound variable in the pattern
-      becomes bound and the value of <c>Expr2</c> is returned.</p>
+    becomes bound and the value of <c>Expr</c> is returned.</p>
+    <p>If multiple match operators are applied in sequence, they will be
+    evaluated from right to left.</p>
     <p>If the matching fails, a <c>badmatch</c> run-time error occurs.</p>
     <p><em>Examples:</em></p>
     <pre>
-1> <input>{A, B} = {answer, 42}.</input>
+1> <input>{A, B} = T = {answer, 42}.</input>
 {answer,42}
 2> <input>A.</input>
 answer
-3> <input>{C, D} = [1, 2].</input>
+3> <input>B.</input>
+42
+4> <input>T.</input>
+{answer,42}
+5> <input>{C, D} = [1, 2].</input>
 ** exception error: no match of right-hand side value [1,2]</pre>
+
+    <p>Because multiple match operators are evaluated from right to left,
+    it means that:</p>
+
+    <pre>
+Pattern1 = Pattern2 = . . . = PatternN = Expression</pre>
+
+    <p>is equivalent to:</p>
+    <pre>
+Temporary = Expression,
+PatternN = Temporary,
+   .
+   .
+   .,
+Pattern2 = Temporary,
+Pattern = Temporary</pre>
+  </section>
+
+  <section>
+    <title>The Match Operator and the Compound Pattern Operator</title>
+    <note><p>This is an advanced section, which references to topics not
+    yet introduced. It can safely be skipped on a first
+    reading.</p></note>
+
+    <p>The <c>=</c> character is used to denote two similar but
+    distinct operators: the match operator and the compound pattern
+    operator. Which one is meant is determined by context.</p>
+
+    <p>The <em>compound pattern operator</em> is used to construct a
+    compound pattern from two patterns. Compound patterns are accepted
+    everywhere a pattern is accepted. A compound pattern matches if
+    all of its constituent patterns match. It is not legal for a
+    pattern that is part of a compound pattern to use variables (as
+    keys in map patterns or sizes in binary patterns) bound in other
+    sub patterns of the same compound pattern.</p>
+    <p><em>Examples:</em></p>
+
+    <pre>
+1> <input>fun(#{Key := Value} = #{key := Key}) -> Value end.</input>
+* 1:7: variable 'Key' is unbound
+2> <input>F = fun({A, B} = E) -> {E, A + B} end, F({1,2}).</input>
+{{1,2},3}
+3> <input>G = fun(&lt;&lt;A:8,B:8>> = &lt;&lt;C:16>>) -> {A, B, C} end, G(&lt;&lt;42,43>>).</input>
+{42,43,10795}</pre>
+
+    <p>The <em>match operator</em> is allowed everywhere an expression
+    is allowed. It is used to match the value of an expression to a pattern.
+    If multiple match operators are applied in sequence, they will be
+    evaluated from right to left.</p>
+
+    <p><em>Examples:</em></p>
+    <pre>
+1> <input>M = #{key => key2, key2 => value}.</input>
+#{key => key2,key2 => value}
+2> <input>f(Key), #{Key := Value} = #{key := Key} = M, Value.</input>
+value
+3> <input>f(Key), #{Key := Value} = (#{key := Key} = M), Value.</input>
+value
+4> <input>f(Key), (#{Key := Value} = #{key := Key}) = M, Value.</input>
+* 1:12: variable 'Key' is unbound
+5> <input>&lt;&lt;X:Y&gt;&gt; = begin Y = 8, &lt;&lt;42:8&gt;&gt; end, X.</input>
+42</pre>
+
+    <p>The expression at prompt <em>2&gt;</em> first matches the value of
+    variable <c>M</c> against pattern <c>#{key := Key}</c>, binding
+    variable <c>Key</c>. It then matches the value of <c>M</c> against
+    pattern <c>#{Key := Value}</c> using variable <c>Key</c> as the
+    key, binding variable <c>Value</c>.</p>
+
+    <p>The expression at prompt <em>3&gt;</em> matches expression
+    <c>(#{key := Key} = M)</c> against pattern <c>#{Key :=
+    Value}</c>. The expression inside the parentheses is evaluated
+    first. That is, <c>M</c> is matched against <c>#{key := Key}</c>,
+    and then the value of <c>M</c> is matched against pattern <c>#{Key
+    := Value}</c>. That is the same evaluation order as in <em>2</em>;
+    therefore, the parentheses are redundant.</p>
+
+    <p>In the expression at prompt <em>4&gt;</em> the expression <c>M</c>
+    is matched against a pattern inside parentheses. Since the
+    construct inside the parentheses is a pattern, the <c>=</c> that
+    separates the two patterns is the compound pattern operator
+    (<em>not</em> the match operator). The match fails because the two
+    sub patterns are matched at the same time, and the variable
+    <c>Key</c> is therefore not bound when matching against pattern
+    <c>#{Key := Value}</c>.</p>
+
+    <p>In the expression at prompt <em>5&gt;</em> the expressions
+    inside the <seeguide marker="#block_expressions">block
+    expression</seeguide> are evaluated first, binding variable
+    <c>Y</c> and creating a binary.  The binary is then matched
+    against pattern <c>&lt;&lt;X:Y&gt;&gt;</c> using the value of
+    <c>Y</c> as the size of the segment.</p>
   </section>
 
   <section>
@@ -1668,6 +1776,7 @@ end</code>
   </section>
 
   <section>
+    <marker id="block_expressions"></marker>
     <title>Block Expressions</title>
     <pre>
 begin
@@ -2003,6 +2112,11 @@ end</pre>
       </row>
       <tcaption>Operator Precedence</tcaption>
     </table>
+    <note><p>The <c>=</c> operator in the table is the
+    <seeguide marker="#match_operator">match operator</seeguide>.
+    The character <c>=</c> can also denote the
+    <seeguide marker="#compound_pattern_operator">compound pattern operator</seeguide>,
+    which can only be used in patterns.</p></note>
     <p>When evaluating an expression, the operator with the highest
       priority is evaluated first. Operators with the same priority
       are evaluated according to their associativity.</p>


### PR DESCRIPTION
Lift restrictions for matching of binaries and maps

There has always been an implementation limitation for matching
of binaries (for technical reasons). For example:

    foo(Bin) ->
        <<A:8>> = <<X:4,Y:4>> = Bin,
        {A,X,Y}.

This would fail to compile with the following message:

    t.erl:5:5: binary patterns cannot be matched in parallel using '='
    %    5|     <<A:8>> = <<X:4,Y:4>> = Bin,
    %     |     ^

This commit lifts this restriction, making the example legal.

A restriction for map matching is also lifted, but before we can
describe that, we'll need a digression to talk about the `=` operator.

The `=` operator can be used for two similar but slightly differently
purposes.

When used in a pattern in a clause, for example in a function head,
both the left-hand and right-hand side operands must be patterns:

    Pattern1 = Pattern2

For example:

    bar(#{a := A} = #{b := B}) -> {A, B}.

The following example will not compile because the right-hand side
is not a pattern but an expression:

    wrong(#{a := A} = #{b => B}) -> {A, B}.

    t.erl:4:23: illegal pattern
    %    4| wrong(#{a := A} = #{b => B}) -> {A, B}.
    %     |                       ^

Used in this context, the `=` operator does not imply that the two
patterns are matched in any particular order. Attempting to use a
variable matched out on the left-hand side on the right-hand side, or
vice versa, will fail:

    also_wrong1(#{B := A} = #{b := B}) -> {A,B}.
    also_wrong2(#{a := A} = #{A := B}) -> {A,B}.

    t.erl:6:15: variable 'B' is unbound
    %    6| also_wrong1(#{B := A} = #{b := B}) -> {A,B}.
    %     |               ^

    t.erl:7:27: variable 'A' is unbound
    %    7| also_wrong2(#{a := A} = #{A := B}) -> {A,B}.
    %     |                           ^

The other way to use `=` is in a function body. Used in this way,
the right-hand side must be an expression:

    Pattern = Expression

For example:

    foobar(Value) ->
        #{a := A} = #{a => Value},
        A.

Used in this context, the right-hand side of `=` must **not** be a pattern:

    illegal_foobar(Value) ->
        #{a := A} = #{a := Value},
        A.

    t.erl:18:21: only association operators '=>' are allowed in map construction
    %   18|     #{a := A} = #{a := Value},
    %     |                     ^

When used in a body context, the value of the `=` operator is the
value of its right-hand side operand. When multiple `=` operators are
combined, they are evaluted from right to left. That means that any
number of patterns can be matched at once:

    Pattern1 = Pattern2 = ... = PatternN = Expr

which is equivalent to:

    Var = Expr
    PatternN = Var
       .
       .
       .
    Pattern2 = Var
    Pattern1 = Var

Given that there is a well-defined evaluation order from right to
left, one would expect that the following example would be legal:

    baz(M) ->
        #{K := V} = #{k := K} = M,
        V.

It is not. In Erlang/OTP 25 or earlier, the compilation fails with the
following message:

    t.erl:28:7: variable 'K' is unbound
    %   28|     #{K := V} = #{k := K} = M,
    %     |       ^

That restriction is now lifted, making the example legal.

Closes #6348
Closes #6444
Closes #6467
