### PR TITLE
beam_types: Increment `#t_bitstring.size_unit` in decode

### DIFF
--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -1420,7 +1420,7 @@ decode_fix(#t_integer{}, Range, _Unit) ->
 decode_fix(#t_number{}, Range, _Unit) ->
     #t_number{elements=Range};
 decode_fix(#t_bitstring{}, _Range, Unit) ->
-    #t_bitstring{size_unit=Unit};
+    #t_bitstring{size_unit=Unit+1};
 decode_fix(#t_union{}=Type0, Range, Unit) ->
     Type1 = case meet(Type0, #t_integer{}) of
                 #t_integer{} ->


### PR DESCRIPTION
This change increments the unit in the `#t_bitstring` type while decoding the type in `beam_types:decode_fix/2`. The unit is decremented while being encoded in `beam_types:encode_unit/1`.

This fixes a discrepancy between the types created when compiling to asm and the type decoded by `beam_disasm`.

For example, with the following snippet:

```erl
-module(enc).
-export([encode/1]).
encode(Bool) when is_boolean(Bool) ->
    <<(encode_bool(Bool))/bitstring>>.
encode_bool(true)  -> <<1:1>>;
encode_bool(false) -> <<0:1>>.
```

Prior to this change, when `enc.erl` is compiled with `erlc -S enc.erl`, within the `bs_create_bin/6` the register is tagged as `#t_bitstring{size_unit=1}`. When compiled to beam and read with `beam_disasm:file/1` though, the register is tagged as `#t_bitstring{size_unit=0}`. If you attempt to re-compile this function from the asm returned by beam_disasm, the assertion that `0 < Unit` within `beam_types:encode_unit/1` will fail.