### PR TITLE
dialyzer: Correct interpretation of [none()]

### DIFF
--- a/lib/dialyzer/src/erl_types.erl
+++ b/lib/dialyzer/src/erl_types.erl
@@ -1468,10 +1468,8 @@ t_list() ->
 
 -spec t_list(erl_type()) -> erl_type().
 
-t_list(?none) -> ?none;
-t_list(?unit) -> ?none;
 t_list(Contents) ->
-  ?list(Contents, ?nil, ?unknown_qual).
+  t_sup(t_nonempty_list(Contents), t_nil()).
 
 -spec t_list_elements(erl_type()) -> erl_type().
 

--- a/lib/dialyzer/test/small_SUITE_data/src/list_none.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/list_none.erl
@@ -1,0 +1,5 @@
+-module(list_none).
+-export([new/0]).
+
+-spec new() -> list(none()).
+new() -> [].

--- a/lib/dialyzer/test/small_SUITE_data/src/stack.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/stack.erl
@@ -1,0 +1,15 @@
+-module(stack).
+
+-export([new/0, push/2, pop/1]).
+-export_type([stack/1]).
+
+-opaque stack(A) :: [A].
+
+-spec new() -> stack(none()).
+new() -> [].
+
+-spec push(stack(A), A) -> stack(A).
+push(T, H) -> [H | T].
+
+-spec pop(stack(A)) -> {A, stack(A)}.
+pop([H | T]) -> {H, T}.


### PR DESCRIPTION
Given the following module:

    -module(list_none).
    -export([new/0]).

    -spec new() -> list(none()).
    new() -> [].

dialyzer emits the following warning:

    list_none.erl:4:2: Invalid type specification for function list_none:new/0. The success typing is
              () -> []

No warning is expected, since `list(Type)` means a list containing zero or more elements. Even if `Type` is impossible, the empty list is still possible. Therefore, the success typing and the spec are consistent with each other.

Closes #6333