### PR TITLE
emulator: scale limit in mtx_SUTIE for machines with many cores

### DIFF
--- a/erts/emulator/test/mtx_SUITE.erl
+++ b/erts/emulator/test/mtx_SUITE.erl
@@ -275,7 +275,7 @@ hammer_sched_rwlock_test(FreqRead, LockCheck, Blocking, WaitLocked, WaitUnlocked
                 _ ->
                     {_, RunTime} = statistics(runtime),
                     io:format("RunTime=~p~n", [RunTime]),
-                    true = RunTime < 700,
+                    true = RunTime < max(700, Onln*12),
                     {comment,
                      "Run-time during test was "
                      ++ integer_to_list(RunTime)


### PR DESCRIPTION
mtx_SUITE runtime limit is to low on machines with 100+ cores. This commit makes the runtime limit scale based on online schedulers.