### PR TITLE
emulator: statistics_SUITE timetraps on nenya, increase timetrap

### DIFF
--- a/erts/emulator/test/statistics_SUITE.erl
+++ b/erts/emulator/test/statistics_SUITE.erl
@@ -43,8 +43,10 @@
 -include_lib("common_test/include/ct.hrl").
 
 suite() ->
+    Onln = erlang:system_info(schedulers_online),
+    Mins = max(4,Onln*2/60),
     [{ct_hooks,[ts_install_cth]},
-     {timetrap, {minutes, 4}}].
+     {timetrap, {minutes, Mins}}].
 
 all() -> 
     [{group, wall_clock}, {group, runtime}, reductions,


### PR DESCRIPTION
Make timetrap scale based on number of schedulers, but set a lower limit to 4 minutes