### PR TITLE
logger_common_h: remove extraneous space in mode_change msg

### DIFF
--- a/lib/kernel/src/logger_h_common.erl
+++ b/lib/kernel/src/logger_h_common.erl
@@ -350,7 +350,7 @@ call(_, Name, Op) ->
     {error,{badarg,{Op,[Name]}}}.
 
 notify({mode_change,Mode0,Mode1},#{id:=Name}=State) ->
-    log_handler_info(Name,"Handler ~p switched from  ~p to ~p mode",
+    log_handler_info(Name,"Handler ~p switched from ~p to ~p mode",
                      [Name,Mode0,Mode1], State);
 notify({flushed,Flushed},#{id:=Name}=State) ->
     log_handler_info(Name, "Handler ~p flushed ~w log events",


### PR DESCRIPTION
Noticed this in a log entry today. It's harmless but looks untidy.