### PR TITLE
 Add missing type specs in http library and replace `essl` option by `ssl`

### DIFF
--- a/lib/inets/doc/specs/.gitignore
+++ b/lib/inets/doc/specs/.gitignore
@@ -1,0 +1,1 @@
+specs_*.xml

--- a/lib/inets/doc/src/Makefile
+++ b/lib/inets/doc/src/Makefile
@@ -62,12 +62,27 @@ XML_FILES = \
 	$(BOOK_FILES)        \
 	$(XML_CHAPTER_FILES) \
 	$(XML_PART_FILES)    \
-	$(XML_REF6_FILES)    \
 	$(XML_REF3_FILES)    \
 	$(XML_APPLICATION_FILES)
 
+SPEC_FILES = $(XML_REF3_FILES:%.xml=$(SPECDIR)/specs_%.xml)
+TOP_SPECS_FILE = specs.xml
+
 NO_CHUNKS = httpd_custom_api.xml
+
+# Generate file specs for files with type specs.
+# These are needed because the standard script
+# (otp/make/otp.mk.in) does not traverse folders
+$(SPECDIR)/specs_%.xml: $(SPECS_ESRC)/http_client/%.erl $(TOP_SPECS_FILE)
+	$(gen_verbose)escript $(SPECS_EXTRACTOR) $(SPECS_FLAGS) -o$(dir $@) $<
+$(SPECDIR)/specs_%.xml: $(SPECS_ESRC)/inets_app/%.erl $(TOP_SPECS_FILE)
+	$(gen_verbose)escript $(SPECS_EXTRACTOR) $(SPECS_FLAGS) -o$(dir $@) $<
+$(SPECDIR)/specs_%.xml: $(SPECS_ESRC)/http_server/%.erl $(TOP_SPECS_FILE)
+	$(gen_verbose)escript $(SPECS_EXTRACTOR) $(SPECS_FLAGS) -o$(dir $@) $<
+$(SPECDIR)/specs_%.xml: $(SPECS_ESRC)/http_lib/%.erl $(TOP_SPECS_FILE)
+	$(gen_verbose)escript $(SPECS_EXTRACTOR) $(SPECS_FLAGS) -o$(dir $@) $<
 
 # ----------------------------------------------------
 
 include $(ERL_TOP)/make/doc.mk
+SPECS_FLAGS += -I../../src/inets_app -I../../include -I../../../kernel/include

--- a/lib/inets/doc/src/httpc.xml
+++ b/lib/inets/doc/src/httpc.xml
@@ -60,77 +60,6 @@
     <p>Some examples are provided in the <seeguide
     marker="http_client">Inets User's Guide</seeguide>.</p>
   </description>
-  
-  <section>
-    <title>DATA TYPES</title>
-    <marker id="DATA_TYPES"></marker>
-    <p>Type definitions that are used more than once in
-      this module:</p>
-    <p><c>boolean() = true | false</c></p>
-    <p><c>http_string()</c> = list of ASCII characters</p>
-    <p><c>request_id() = reference()</c></p>
-    <p><c>profile() = atom()</c></p>
-    <p><c>path() = string()</c> representing a file path or directory path</p>
-    <p><c>ip_address()</c> = See the
-    <seeerl marker="kernel:inet">inet(3)</seeerl> manual page in Kernel.</p>
-    <p><c>socket_opt()</c> = See the options used by
-    <seeerl marker="kernel:gen_tcp">gen_tcp(3)</seeerl> <c>gen_tcp(3)</c> and 
-    <seeerl marker="ssl:ssl">ssl(3)</seeerl> connect(s)</p>
-  
-  </section>
-  
-  <section>
-    <title>HTTP DATA TYPES</title>
-    <p>Type definitions related to HTTP:</p>
-
-    <p><c>method() = head | get | put | post | trace | options | delete | patch</c></p>
-    <taglist>
-      <tag><c>request()</c></tag>
-      <item><p>= <c>{url(), headers()}</c></p>
-      <p>| <c>{url(), headers(), content_type(), body()}</c></p>
-      </item>
-    </taglist>
-    <p><c>url() = http_string()</c> syntax according to the URI definition in
-    <url href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</url>,
-    for example <c>"http://www.erlang.org"</c></p>
-    <warning><p>Please note that httpc normalizes input URIs before internal processing
-    and special care shall be taken when the URI has percent ("%") characters. A percent
-    serves as the indicator for percent-encoded octets and it must be percent-encoded
-    as "%25" for that octet to be used as data within the URI.</p>
-    <p>For example, in order to send an HTTP GET request with the URI
-    <c>http://localhost/foo%25bar</c>, the percent character must be percent-encoded when
-    creating the request: <c>httpc:request("http://localhost/foo%2525bar").</c>
-    </p></warning>
-    <p><c>status_line() = {http_version(), status_code(), reason_phrase()}</c></p>
-    <p><c>http_version() = http_string()</c>, for example, <c>"HTTP/1.1"</c></p>
-    <p><c>status_code() = integer()</c></p>
-    <p><c>reason_phrase() = string()</c></p>
-    <p><c>content_type() = http_string()</c></p>
-    <p><c>headers() = [header()]</c></p>
-    <p><c>header() = {field(), value()}</c></p>
-    <p><c>field() = [byte()]</c></p>
-    <p><c>value() = binary() | iolist()</c></p>
-    <taglist>
-      <tag><c>body()</c></tag>
-      <item><p>= <c>http_string() | binary()</c></p>
-      <p>| <c>{fun(accumulator())</c></p>
-      <p><c> -> body_processing_result(), accumulator()}</c></p>
-      <p>| <c>{chunkify, fun(accumulator())</c></p>
-      <p><c> -> body_processing_result(), accumulator()}</c></p>
-      </item>
-    </taglist>
-    <p><c>body_processing_result() = eof | {ok, iolist(), accumulator()}</c></p>
-    <p><c>accumulator() = term()</c></p>
-    <p><c>filename() = string()</c></p>
- <p>For more information about HTTP, see
- <url href="http://www.ietf.org/rfc/rfc2616.txt">RFC 2616</url>.</p> 
-</section>
-  
-  <section>
-    <title>SSL DATA TYPES</title>
-    <p>See <seeerl marker="ssl:ssl">ssl(3)</seeerl> for information
-    about <c>SSL</c> options (<c>ssloptions()</c>). </p>
-  </section>
 
   <section>
     <title>HTTP CLIENT SERVICE START/STOP</title>
@@ -142,522 +71,491 @@
       see <seeerl marker="inets">inets(3)</seeerl>.
       The configuration options are as follows:</p>
     <taglist>
-      <tag>{profile, profile()}</tag>
-      <item><p>Name of the profile, see
-	<seeerl marker="#DATA_TYPES">DATA TYPES</seeerl>.
-      This option is mandatory.</p></item>
-      <tag>{data_dir, path()}</tag>
-      <item><p>Directory where the profile
+      <tag>{profile, Profile :: atom() | pid()}</tag>
+      <item>Name of the profile.
+      This option is mandatory.</item>
+      <tag>{data_dir, Path :: string()}</tag>
+      <item>Directory where the profile
 	can save persistent data. If omitted, all cookies are treated
-	as session cookies.</p></item>
+	as session cookies. <c>Path</c> represents a file path or directory path.</item>
     </taglist>
 
-    <p>The client can be stopped using <c>inets:stop(httpc, Pid)</c> or
-    <c>inets:stop(httpc, Profile)</c>.</p>
+    <p>The client can be stopped using <seemfa marker="inets#stop/2"><c>inets:stop(httpc, Pid)</c></seemfa> or
+    <seemfa marker="inets#stop/2"><c>inets:stop(httpc, Profile)</c></seemfa>.</p>
+
+    <warning><p>Please note that <c>httpc</c> normalizes input URIs before internal
+    processing and special care shall be taken when the URI has percent ("%")
+    characters. A percent serves as the indicator for percent-encoded octets and
+    it must be percent-encoded as "%25" for that octet to be used as data within
+    the URI.</p>
+    <p>For example, in order to send an <c>HTTP GET</c> request with the
+    URI <c>http://localhost/foo%25bar</c>, the percent character must be
+    percent-encoded when creating the request:
+    <c>httpc:request("http://localhost/foo%2525bar").</c> </p></warning>
   </section>
-  
+
   <funcs>
-   
     <func>
-      <name since="OTP R13B04">cancel_request(RequestId) -></name>
-      <name since="OTP R13B04">cancel_request(RequestId, Profile) -> ok</name>
+      <name since="OTP R13B04" name="cancel_request" arity="1" />
+      <name since="OTP R13B04" name="cancel_request" arity="2" />
       <fsummary>Cancels an asynchronous HTTP request.</fsummary>
-      <type>
-        <v>RequestId = request_id() - A unique identifier as returned
-        by request/4</v>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-      </type>
+      <type variable="RequestId" />
+      <type_desc variable="RequestId">
+        A unique identifier as returned by
+        <seemfa marker="#request/4"><c>request/4</c></seemfa>
+      </type_desc>
+      <type variable="Profile" />
+	    <type_desc variable="Profile">
+        When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
-        <p>Cancels an asynchronous HTTP request. Notice that this does not guarantee
-	that the request response is not delivered. Because it is asynchronous,
-	the request can already have been completed when the cancellation arrives.
-	</p>
+        <p>Cancels an asynchronous HTTP request. Notice that this does not
+        guarantee that the request response is not delivered. Because it is
+        asynchronous, the request can already have been completed when the
+        cancellation arrives.
+	      </p>
       </desc>
     </func>
 
     <func>
-      <name since="OTP R13B04">cookie_header(Url) -> </name>
-      <name since="OTP R13B04">cookie_header(Url, Profile | Opts) -> header() | {error, Reason}</name>
-      <name since="OTP R15B">cookie_header(Url, Opts, Profile) -> header() | {error, Reason}</name>
-      <fsummary>Returns the cookie header that would have been sent when
-      making a request to URL using the profile <c>Profile</c>.</fsummary>
-      <type>
-        <v>Url = url()</v>
-        <v>Opts = [cookie_header_opt()]</v>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c>.</d>
-        <v>cookie_header_opt() = {ipv6_host_with_brackets, boolean()}</v>
-      </type>
+      <name since="OTP R13B04" name="cookie_header" arity="1"/>
+      <name since="OTP R13B04" name="cookie_header" arity="2"/>
+      <fsummary>Returns the cookie header that would have been sent when making
+      a request to <c><anno>URL</anno></c>, using the profile
+      <c><anno>Profile</anno></c>.</fsummary>
+      <type_desc variable="Profile">
+		    When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
-        <p>Returns the cookie header that would have been sent
-	when making a request to <c>Url</c> using profile <c>Profile</c>.
-	If no profile is specified, the default profile is used.</p>
-	<p>Option <c>ipv6_host_with_bracket</c> deals with how to 
-	parse IPv6 addresses. For details,
-	see argument <c>Options</c> of
-	<seemfa marker="#request/4">request/[4,5]</seemfa>.</p>
+        <p>Returns the cookie header that would have been sent when making a
+        request to <c><anno>Url</anno></c> using profile
+        <c><anno>Profile</anno></c>. If no profile is specified, the default
+        profile is used.</p>
+	     <p>Option <c>ipv6_host_with_bracket</c> deals with how to parse IPv6
+	     addresses. For details, see argument <c>Options</c> of <seemfa
+	     marker="#request/4">request/[4,5]</seemfa>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name since="OTP R15B"   name="cookie_header" arity="3"/>
+      <fsummary>Returns the cookie header that would have been sent when making
+      a request to <c><anno>URL</anno></c> using the profile
+      <c><anno>Profile</anno></c>.</fsummary>
+      <type_desc variable="Profile">
+		    When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
+      <desc>
+        <p>Returns the cookie header that would have been sent when making a
+        request to <c><anno>Url</anno></c> using profile
+        <c><anno>Profile</anno></c>. If no profile is specified, the default
+        profile is used.</p>
+	     <p>Option <c>ipv6_host_with_bracket</c> deals with how to parse IPv6
+	     addresses. For details, see argument <c>Options</c> of <seemfa
+	     marker="#request/4">request/[4,5]</seemfa>.</p>
       </desc>
     </func>
 
      <func>
-      <name since="OTP R15B01">get_options(OptionItems) -> {ok, Values} | {error, Reason}</name>
-      <name since="OTP R15B01">get_options(OptionItems, Profile) -> {ok, Values} | {error, Reason}</name>
+      <name since="OTP R15B01" name="get_options" arity="1"/>
+      <name since="OTP R15B01" name="get_options" arity="2"/>
       <fsummary>Gets the currently used options.</fsummary>
-      <type>
-        <v>OptionItems = all | [option_item()]</v>
-	<v>option_item() = proxy |
-	                   https_proxy |
-                           max_sessions | 
-			   keep_alive_timeout | 
-	                   max_keep_alive_length | 
-			   pipeline_timeout | 
-			   max_pipeline_length | 
-			   cookies | 
-			   ipfamily | 
-			   ip | 
-			   port | 
-			   socket_opts | 
-	                   verbose |
-	                   unix_socket</v>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can used.</d>
-        <v>Values = [{option_item(), term()}]</v>
-        <v>Reason = term()</v>
-      </type>
+      <type_desc variable="Profile">
+		    When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
         <p>Retrieves the options currently used by the client.</p>
       </desc>
     </func>
 
     <func>
-      <name since="OTP R15B02">info() -> list()</name>
-      <name since="OTP R15B02">info(Profile) -> list()</name>
+      <name since="OTP R15B02" name="info" arity="0"/>
+      <name since="OTP R15B02" name="info" arity="1"/>
       <fsummary>Produces a list of miscellaneous information.</fsummary>
-      <type>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-      </type>
+      <type_desc variable="Profile">
+		    When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
-        <p>Produces a list of miscellaneous information. 
-	Intended for debugging. 
-	If no profile is specified, the default profile is used.</p>
+        <p>Produces a list of miscellaneous information. Intended for debugging.
+        If no profile is specified, the default profile is used.</p>
       </desc>
     </func>
 
     
     <func>
-      <name since="OTP R13B04">reset_cookies() -> void()</name>
-      <name since="OTP R13B04">reset_cookies(Profile) -> void()</name>
+      <name since="OTP R13B04" name="reset_cookies" arity="0"/>
+      <name since="OTP R13B04" name="reset_cookies" arity="1"/>
       <fsummary>Resets the cookie database.</fsummary>
-      <type>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-      </type>
+      <type_desc variable="Profile">
+		    When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
-        <p>Resets (clears) the cookie database for the specified 
-	<c>Profile</c>. If no profile is specified the default profile 
-	is used.</p>
+        <p>Resets (clears) the cookie database for the specified
+        <c><anno>Profile</anno></c>. If no profile is specified the default
+        profile is used.</p>
       </desc>
     </func>
     
     <func>
-      <name since="OTP R13B04">request(Url) -> </name>
-      <name since="OTP R13B04">request(Url, Profile) -> {ok, Result} | {error, Reason}</name>
+      <name since="OTP R13B04" name="request" arity="1"/>
+      <name since="OTP R13B04" name="request" arity="2"/>
       <fsummary>Sends a get HTTP request.</fsummary>
-      <type>
-        <v>Url = url()</v> 
-	<v>Result = {status_line(), headers(), Body} | 
-                    {status_code(), Body} | request_id()</v>
-	<v>Body = http_string() | binary()</v>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-	<v>Reason = term()</v>
-      </type>
+      <type_desc variable="Profile">
+		    When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
-        <p>Equivalent to <c>httpc:request(get, {Url, []}, [], [])</c>.</p>
+        <p>Equivalent to <seemfa marker="httpc#request/4"><c>httpc:request(get, {Url, []}, [], [])</c></seemfa>.</p>
       </desc>
     </func>
 
     <func>
-      <name since="OTP R13B04">request(Method, Request, HTTPOptions, Options) -></name>
-      <name since="OTP R13B04">request(Method, Request, HTTPOptions, Options, Profile) -> {ok, Result} | {ok, saved_to_file} | {error, Reason}</name>
-      
+      <name since="OTP R13B04" name="request" arity="4"/>
+      <name since="OTP R13B04" name="request" arity="5"/>
       <fsummary>Sends an HTTP request.</fsummary>
-      <type>
-        <v>Method = method()</v>
-        <v>Request = request()</v>
-        <v>HTTPOptions = http_options()</v>
-        <v>http_options() = [http_option()]</v>
-        <v>http_option() = {timeout,         timeout()} | 
-                           {connect_timeout, timeout()} | 
-                           {ssl,             ssloptions()} | 
-                           {essl,            ssloptions()} | 
-                           {autoredirect,    boolean()} | 
-                           {proxy_auth, {userstring(), passwordstring()}} | 
-                           {version,         http_version()} | 
-                           {relaxed,         boolean()}</v>
-        <v>timeout() = integer() >= 0 | infinity</v>
-        <v>Options = options()</v>
-        <v>options() = [option()]</v>
-        <v>option() = {sync,                    boolean()} | 
-                      {stream,                  stream_to()} | 
-                      {body_format,             body_format()} | 
-                      {full_result,             boolean()} | 
-                      {headers_as_is,           boolean()} |
-                      {socket_opts,             socket_opts()} | 
-                      {receiver,                receiver()} |
-	              {ipv6_host_with_brackets, boolean()}</v>
-        <v>stream_to() = none | self | {self, once} | filename()</v>
-        <v>socket_opts() = [socket_opt()]</v>
-        <v>receiver() = pid() | function()/1 | {Module, Function, Args}</v>
-        <v>Module = atom()</v>
-        <v>Function = atom()</v>
-        <v>Args = list()</v>
-	<v>body_format() = string | binary</v>
-        <v>Result = {status_line(), headers(), Body} | 
-                    {status_code(), Body} | request_id()</v>
-        <v>Body = http_string() | binary()</v>
-        <v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-        <v>Reason = term()</v>
-      </type>
-
+      <type_desc variable="Profile">
+        When <c><anno>Profile</anno></c> is <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
-        <p>Sends an HTTP request. The function can be both synchronous
-	and asynchronous. In the latter case, the function returns
-	<c>{ok, RequestId}</c> and then the information is delivered
-	to the <c>receiver</c> depending on that value.</p>
+        <p>Sends an HTTP request. The function can be both synchronous and
+        asynchronous. In the latter case, the function returns <c>{ok,
+        RequestId}</c> and then the information is delivered to the
+        <c>receiver</c> depending on that value.</p>
+	      <p>When  <c><anno>Profile</anno></c> is <c>stand_alone</c> only the pid can be used.</p>
+        <p>HTTP options:</p>
 
-        <p>HTTP option (<c>http_option()</c>) details:</p>
-        <marker id="request2_http_options"></marker>
         <taglist>
-          <tag><c><![CDATA[timeout]]></c></tag>
+          <tag><c>timeout</c></tag>
           <item>
             <p>Time-out time for the request.</p>
             <p>The clock starts ticking when the request is sent.</p>
             <p>Time is in milliseconds.</p>
             <p>Default is <c>infinity</c>.</p>
-	  </item>
+          </item>
 
-          <tag><c><![CDATA[connect_timeout]]></c></tag>
+          <tag><c>connect_timeout</c></tag>
           <item>
-            <p>Connection time-out time, used during the initial request, 
-	    when the client is <em>connecting</em> to the server.</p>
+            <p>Connection time-out time, used during the initial request,
+	          when the client is <em>connecting</em> to the server.</p>
             <p>Time is in milliseconds.</p>
             <p>Default is the value of option <c>timeout</c>.</p>
-	  </item>
+	        </item>
 
-          <tag><c><![CDATA[ssl]]></c></tag>
+          <tag><c>ssl</c></tag>
           <item>
             <p>This is the <c>SSL/TLS</c> connecting configuration option.</p>
             <p>Defaults to <c>[]</c>. See <seeerl marker="ssl:ssl">ssl:connect/[2,3,4]</seeerl>  for available options.</p>
-	  </item>
+	        </item>
 
-          <tag><c><![CDATA[autoredirect]]></c></tag>
+          <tag><c>autoredirect</c></tag>
           <item>
-	    <p>The client automatically retrieves the information
-	    from the new URI and returns that as the result, instead 
-	    of a 30X-result code.</p>
-	    <p>For some 30X-result codes, automatic redirect 
-	    is not allowed. In these cases the 30X-result is always
-	    returned.</p>
-	    <p>Default is <c>true</c>.</p>
-	  </item>
+	          <p>The client automatically retrieves the information from the new
+	          URI and returns that as the result, instead of a 30X-result
+	          code.</p>
+	          <p>For some 30X-result codes, automatic redirect is not allowed. In
+	          these cases the 30X-result is always returned.</p>
+	          <p>Default is <c>true</c>.</p>
+	        </item>
 
-          <tag><c><![CDATA[proxy_auth]]></c></tag>
+          <tag><c>proxy_auth</c></tag>
           <item>
-            <p>A proxy-authorization header using the provided username and 
-	    password is added to the request.</p>
-	  </item>
+            <p>A proxy-authorization header using a tuple where the first element is the <c>username</c> and
+	          the second element of the tuple is the <c>password</c> added to the request.</p>
+	        </item>
 
-          <tag><c><![CDATA[version]]></c></tag>
+          <tag><c>version</c></tag>
           <item>
             <p>Can be used to make the client act as an <c>HTTP/1.0</c>
             client. By default this is an <c>HTTP/1.1</c>
             client. When using <c>HTTP/1.0</c> persistent connections are
             not used.</p>
 	          <p>Default is the string <c>"HTTP/1.1"</c>.</p>
-	  </item>
+	        </item>
 
-          <tag><c><![CDATA[relaxed]]></c></tag>
+          <tag><c>relaxed</c></tag>
           <item>
-            <p>If set to <c>true</c>, workarounds for known server deviations 
-	    from the HTTP-standard are enabled.</p>
+            <p>If set to <c>true</c>, workarounds for known server deviations
+	          from the HTTP-standard are enabled.</p>
             <p>Default is <c>false</c>.</p>
-	  </item>
+	        </item>
         </taglist>
 
-        <p>Option (<c>option()</c>) details:</p>
+        <p>Options details:</p>
         <taglist>
-          <tag><c><![CDATA[sync]]></c></tag>
+          <tag><c>sync</c></tag>
           <item>
             <p>Option for the request to be synchronous or asynchronous.</p>
             <p>Default is <c>true</c>.</p>
-	  </item>
+	        </item>
 
-          <tag><c><![CDATA[stream]]></c></tag>
+          <tag><c>stream</c></tag>
           <item>
-            <p>Streams the body of a 200 or 206 response to the calling 
-	    process or to a file. When streaming to the calling process 
-	    using option <c>self</c>, the following stream messages
-	    are sent to that process: <c>{http, {RequestId,
-	    stream_start, Headers}}, {http, {RequestId, stream,
-	    BinBodyPart}}, and {http, {RequestId, stream_end, Headers}}</c>.</p>
-	    <p>When streaming to the calling processes using option
-	    <c>{self, once}</c>, the first message has an extra
-	    element, that is, <c>{http, {RequestId, stream_start, Headers, Pid}}</c>.
-	    This is the process id to be used as an argument to
-	    <c>httpc:stream_next/1</c> to trigger the next message to be sent to
-	    the calling process.</p>
-	    <p>Notice that chunked encoding can add
-	    headers so that there are more headers in the <c>stream_end</c>
-	    message than in <c>stream_start</c>.
-	    When streaming to a file and the request is asynchronous, the
-	    message <c>{http, {RequestId, saved_to_file}}</c> is sent.</p>
+            <p>Streams the body of a 200 or 206 response to the calling process
+            or to a file. When streaming to the calling process using option
+            <c>self</c>, the following stream messages are sent to that process:
+            <c>{http, {RequestId, stream_start, Headers}}, {http, {RequestId,
+            stream, BinBodyPart}}, and {http, {RequestId, stream_end,
+            Headers}}</c>.</p>
+
+	          <p>When streaming to the calling processes using option <c>{self,
+	          once}</c>, the first message has an extra element, that is,
+	          <c>{http, {RequestId, stream_start, Headers, Pid}}</c>. This is the
+	          process id to be used as an argument to <c>httpc:stream_next/1</c>
+	          to trigger the next message to be sent to the calling process.</p>
+
+            <p>Notice that chunked encoding can add headers so that there are
+	          more headers in the <c>stream_end</c> message than in
+	          <c>stream_start</c>. When streaming to a file and the request is
+	          asynchronous, the message <c>{http, {RequestId, saved_to_file}}</c>
+	          is sent.</p>
             <p>Default is <c>none</c>.</p>
-	  </item>
+	        </item>
 
-          <tag><c><![CDATA[body_format]]></c></tag>
+          <tag><c>body_format</c></tag>
           <item>
-            <p>Defines if the body is to be delivered as a string or 
-	    binary. This option is only valid for the synchronous 
-	    request.</p>
+            <p>Defines if the body is to be delivered as a string or
+	          binary. This option is only valid for the synchronous
+	          request.</p>
             <p>Default is <c>string</c>.</p>
-	  </item>
+	        </item>
 
-          <tag><c><![CDATA[full_result]]></c></tag>
+          <tag><c>full_result</c></tag>
           <item>
-            <p>Defines if a "full result" is to be returned to the caller (that is,
-	    the body, the headers, and the entire status line) or not 
-	    (the body and the status code).</p>
+            <p>Defines if a "full result" is to be returned to the caller (that
+            is, the body, the headers, and the entire status line) or not (the
+            body and the status code).</p>
             <p>Default is <c>true</c>.</p>
-	  </item>
+	        </item>
 
-          <tag><c><![CDATA[headers_as_is]]></c></tag>
+          <tag><c>headers_as_is</c></tag>
           <item>
-            <p>Defines if the headers provided by the user are to be made 
-	    lower case or to be regarded as case sensitive.</p>
-            <p>The HTTP standard requires them to be 
-	    case insensitive. Use this feature only if there is 
-	    no other way to communicate with the server or for testing 
-	    purpose. When this option is used, no headers 
-	    are automatically added. All necessary headers must be
-	    provided by the user.</p>
-	    <p>Default is <c>false</c>.</p>
-	  </item>
+            <p>Defines if the headers provided by the user are to be made lower
+            case or to be regarded as case sensitive.</p>
 
-          <tag><c><![CDATA[socket_opts]]></c></tag>
+            <p>The HTTP standard requires them to be case insensitive. Use this
+            feature only if there is no other way to communicate with the server
+            or for testing purpose. When this option is used, no headers are
+            automatically added. All necessary headers must be provided by the
+            user.</p>
+	          <p>Default is <c>false</c>.</p>
+	        </item>
+
+          <tag><c>socket_opts</c></tag>
           <item>
             <p>Socket options to be used for this request.</p>
-	    <p>Overrides any value set by function
-	    <seemfa marker="#set_options/1">set_options</seemfa>.</p>
+            <p>See the options used by
+            <seeerl marker="kernel:gen_tcp">gen_tcp(3)</seeerl> and
+            <seeerl marker="ssl:ssl">ssl(3)</seeerl>
+            </p>
+	          <p>Overrides any value set by function
+	          <seemfa marker="#set_options/1">set_options</seemfa>.</p>
             <p>The validity of the options is <em>not</em> checked by
             the HTTP client they are assumed to be correct and passed
             on to ssl application and inet driver, which may reject
             them if they are not correct.
-	    </p>
-	    <note>
-	      <p>
-		Persistent connections are not supported when setting the
-		<c>socket_opts</c> option. When <c>socket_opts</c> is not
-		set the current implementation assumes the requests to the
-		same host, port combination will use the same socket options.
-	      </p>
-	    </note>
-	    
-            <p>By default the socket options set by function
-	    <seemfa marker="#set_options/1">set_options/[1,2]</seemfa> 
-	     are used when establishing a connection.</p>
-	  </item>
+	          </p>
+	          <note>
+	            <p>
+		            Persistent connections are not supported when setting the
+		            <c>socket_opts</c> option. When <c>socket_opts</c> is not set
+		            the current implementation assumes the requests to the same
+		            host, port combination will use the same socket options.
+	            </p>
+	          </note>
 
-          <tag><c><![CDATA[receiver]]></c></tag>
+            <p>By default the socket options set by function <seemfa
+            marker="#set_options/1">set_options/[1,2]</seemfa> are used when
+            establishing a connection.</p>
+	        </item>
+
+          <tag><c>receiver</c></tag>
           <item>
-            <p>Defines how the client delivers the result of an
-	    asynchronous request (<c>sync</c> has the value 
-	    <c>false</c>).</p>
+            <p>Defines how the client delivers the result of an asynchronous
+            request (<c>sync</c> has the value <c>false</c>).</p>
 
             <taglist>
-              <tag><c><![CDATA[pid()]]></c></tag>
+              <tag><c>pid()</c></tag>
               <item>
-	        <p>Messages are sent to this process in the format 
-		<c>{http, ReplyInfo}</c>.</p>
-	      </item>
+	              <p>Messages are sent to this process in the format <c>{http,
+	              ReplyInfo}</c>.</p>
+	            </item>
 
-              <tag><c><![CDATA[function/1]]></c></tag>
+              <tag><c>function/1</c></tag>
               <item>
-	        <p>Information is delivered to the receiver through calls 
-		to the provided fun <c>Receiver(ReplyInfo)</c>.</p>
-  	      </item>
+	              <p>Information is delivered to the receiver through calls to the
+	              provided fun <c>Receiver(ReplyInfo)</c>.</p>
+  	          </item>
 
-              <tag><c><![CDATA[{Module, Function, Args}]]></c></tag>
+              <tag><c>{Module, Function, Args}</c></tag>
               <item>
-	        <p>Information is delivered to the receiver through calls 
-		to the callback function 
-		<c>apply(Module, Function, [ReplyInfo | Args])</c>.</p>
-	      </item>
+	              <p>Information is delivered to the receiver through calls to the
+	              callback function <c>apply(Module, Function, [ReplyInfo |
+	              Args])</c>.</p>
+	            </item>
             </taglist>
             <p>In all of these cases, <c>ReplyInfo</c> has the following
-              structure:</p>
+            structure:</p>
 
-<pre>
-{RequestId, saved_to_file}
-{RequestId, {error, Reason}}
-{RequestId, Result}
-{RequestId, stream_start, Headers}
-{RequestId, stream_start, Headers, HandlerPid}
-{RequestId, stream, BinBodyPart}
-{RequestId, stream_end, Headers}</pre>
-
-            <p>Default is the <c>pid</c> of the process calling the request 
+            <pre>
+ {RequestId, saved_to_file}
+ {RequestId, {error, Reason}}
+ {RequestId, Result}
+ {RequestId, stream_start, Headers}
+ {RequestId, stream_start, Headers, HandlerPid}
+ {RequestId, stream, BinBodyPart}
+ {RequestId, stream_end, Headers}</pre>
+            <p>Default is the <c>pid</c> of the process calling the request
 	    function (<c>self()</c>). </p>
-
-	    <marker id="ipv6_host_with_brackets"></marker>
-	  </item>
-
-          <tag><c><![CDATA[ipv6_host_with_brackets]]></c></tag>
+	        <marker id="ipv6_host_with_brackets"></marker>
+	        </item>
+          <tag><c>ipv6_host_with_brackets</c></tag>
           <item>
-            <p>Defines when parsing the Host-Port part of an URI with an IPv6 address 
-	    with brackets, if those brackets are to be retained (<c>true</c>) 
-	    or stripped (<c>false</c>).</p>
+            <p>Defines when parsing the Host-Port part of an URI with an IPv6
+            address with brackets, if those brackets are to be retained
+            (<c>true</c>) or stripped (<c>false</c>).</p>
             <p>Default is <c>false</c>.</p>
-	  </item>
-
+	        </item>
         </taglist>
       </desc>
     </func>
 
   
     <func>
-      <name since="OTP R13B04">set_options(Options) -> </name>
-      <name since="OTP R13B04">set_options(Options, Profile) -> ok | {error, Reason}</name>
+      <name since="OTP R13B04" name="set_options" arity="1"/>
+      <name since="OTP R13B04" name="set_options" arity="2"/>
       <fsummary>Sets options to be used for subsequent requests.</fsummary>
-      <type>
-        <v>Options = [Option]</v>
-        <v>Option = {proxy, {Proxy, NoProxy}}</v>
-	<v>| {https_proxy, {Proxy, NoProxy}}</v>
-	<v>| {max_sessions, MaxSessions}</v>
-	<v>| {max_keep_alive_length, MaxKeepAlive}</v>
-	<v>| {keep_alive_timeout, KeepAliveTimeout}</v>
-	<v>| {max_pipeline_length, MaxPipeline}</v>
-	<v>| {pipeline_timeout, PipelineTimeout}</v>
-	<v>| {cookies, CookieMode}</v>
-	<v>| {ipfamily, IpFamily}</v>
-	<v>| {ip, IpAddress}</v>
-	<v>| {port, Port}</v>
-	<v>| {socket_opts, socket_opts()}</v>
-	<v>| {verbose, VerboseMode}</v>
-	<v>| {unix_socket, UnixSocket}</v>
-        <v>Proxy = {Hostname, Port}</v>
-        <v>Hostname = http_string()</v>
-        <d>Example: "localhost" or "foo.bar.se"</d>
-        <v>Port = integer()</v>
-        <d>Example: 8080</d>
-        <v>NoProxy = [NoProxyDesc]</v>
-        <v>NoProxyDesc = DomainDesc | HostName | IPDesc</v>
-        <v>DomainDesc = "*.Domain"</v>
-        <d>Example: "*.ericsson.se"</d>
-        <v>IpDesc = http_string()</v>
-        <d>Example: "134.138" or "[FEDC:BA98" 
-	(all IP addresses starting with 134.138 or FEDC:BA98), 
-	"66.35.250.150" or "[2010:836B:4179::836B:4179]" (a complete IP address). 
-	<c>proxy</c> defaults to <c>{undefined, []}</c>, 
-	that is, no proxy is configured and 
-	<c>https_proxy</c> defaults to the value of <c>proxy</c>.</d>	
-	<v>MaxSessions = integer()</v>
-        <d>Maximum number of persistent connections to a host.
-	Default is <c>2</c>.</d>
-	<v>MaxKeepAlive = integer()</v>
-	<d>Maximum number of outstanding requests on the same connection to 
-	a host. Default is <c>5</c>.</d>
-	<v>KeepAliveTimeout = integer()</v>
-	<d>If a persistent connection is idle longer than the 
-	<c>keep_alive_timeout</c> in milliseconds, 
-	the client closes the connection.
-	The server can also have such a time-out but do not take that for granted.
-	Default is <c>120000</c> (= 2 min).</d>
-	<v>MaxPipeline = integer()</v>
-	<d>Maximum number of outstanding requests on a pipelined connection 
-	to a host. Default is <c>2</c>.</d>
-	<v>PipelineTimeout = integer()</v>
-	<d>If a persistent connection is idle longer than the 
-	<c>pipeline_timeout</c> in milliseconds, 
-	the client closes the connection. Default is <c>0</c>,
-	which results in pipelining not being used.</d>
-        <v>CookieMode = enabled | disabled | verify</v>
-        <d>If cookies are enabled, all valid cookies are automatically 
-	saved in the cookie database of the client manager.
-	If option <c>verify</c> is used, function <c>store_cookies/2</c>
-	has to be called for the cookies to be saved. 
-	Default is <c>disabled</c>.</d>
-	<v>IpFamily = inet | inet6 | local | inet6fb4</v>
-	<d>Default is <c>inet</c>. With <c>inet6fb4</c> option, IPv6
-        will be preferred but if connection fails, an IPv4 fallback connection
-        attempt will be made.</d>
-	<v>IpAddress = ip_address()</v>
-	<d>If the host has several network interfaces, this option specifies 
-	which one to use. 
-	See <seeerl marker="kernel:gen_tcp#connect">gen_tcp:connect/3,4</seeerl> 
-	for details.</d>
-	<v>Port = integer()</v>
-	<d>Local port number to use. 
-	See <seeerl marker="kernel:gen_tcp#connect">gen_tcp:connect/3,4</seeerl> 
-	for details.</d>
-	<v>socket_opts() = [socket_opt()]</v>
-	<d>The options are appended to the socket options used by the 
-	client. 
-	These are the default values when a new request handler
-	is started (for the initial connect). They are passed directly 
-        to the underlying transport (<c>gen_tcp</c> or <c>SSL</c>) 
-	<em>without</em> verification.</d>
-	<v>VerboseMode = false | verbose | debug | trace</v>
-	<d>Default is <c>false</c>.
-        This option is used to switch on (or off)
-	different levels of Erlang trace on the client. 
-	It is a debug feature.</d>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-	<v>UnixSocket = path()</v>
-	<d>
-	  Experimental option for sending HTTP requests over a unix domain socket. The value
-	  of <c>unix_socket</c> shall be the full path to a unix domain socket file with read/write
-	  permissions for the erlang process. Default is <c>undefined</c>.
-	</d>
-      </type>
       <desc>
-	<p>Sets options to be used for subsequent requests.</p>
-	<note>
-	  <p>If possible, the client keeps its connections
-	  alive and uses persistent connections
-	  with or without pipeline depending on configuration
-	  and current circumstances. The HTTP/1.1 specification does not
-	  provide a guideline for how many requests that are
-	  ideal to be sent on a persistent connection.
-	  This depends much on the application.</p>
-	  <p>A long queue of requests can cause a
-	  user-perceived delay, as earlier requests can take a long time
-	  to complete. The HTTP/1.1 specification suggests a
-	  limit of two persistent connections per server, which is the
-	  default value of option <c>max_sessions</c>.</p>
-	  <p>
-            The current implementation assumes the requests to the same host, port
-            combination will use the same socket options.
-	  </p>
-	</note>
+	      <p>Sets options to be used for subsequent requests.</p>
+        <taglist>
+        <tag><c>HostName</c></tag>
+        <item>
+          Example: "localhost" or "foo.bar.se"
+        </item>
+        <tag><c>DomainDesc</c></tag>
+        <item>
+          Example <c>"*.Domain"</c> or <c>"*.ericsson.se"</c>
+        </item>
+        <tag><c>IpAddressDesc</c></tag>
+        <item>
+        Example: "134.138" or "[FEDC:BA98" (all IP addresses starting with
+        134.138 or FEDC:BA98), "66.35.250.150" or "[2010:836B:4179::836B:4179]"
+        (a complete IP address). <c>proxy</c> defaults to <c>{undefined,
+        []}</c>, that is, no proxy is configured and <c>https_proxy</c> defaults
+        to the value of <c>proxy</c>.
+        </item>
+        <tag><c>MaxSessions</c></tag>
+        <item>
+          <c><anno>MaxSessions</anno></c> Maximum number of persistent connections to a host. Default is <c>2</c>.
+        </item>
+
+      <tag><c>MaxKeepAlive</c></tag>
+      <item>
+        <c><anno>MaxKeepAlive</anno></c> Maximum number of outstanding requests
+        on the same connection to a host. Default is <c>5</c>.
+      </item>
+      <tag><c>KeepAliveTimeout</c></tag>
+      <item>
+       <c><anno>KeepAliveTimeout</anno></c> If a persistent connection is idle longer than the
+       <c>keep_alive_timeout</c> in milliseconds, the client closes the
+       connection. The server can also have such a time-out but do not take that
+       for granted. Default is <c>120000</c> (= 2 min).
+      </item>
+      <tag><c>MaxPipeline</c></tag>
+      <item>
+       <c><anno>MaxPipeline</anno></c> Maximum number of outstanding requests on a pipelined connection to a
+       host. Default is <c>2</c>.
+      </item>
+      <tag><c>PipelineTimeout</c></tag>
+      <item>
+       <c><anno>PipelineTimeout</anno></c> If a persistent connection is idle longer than the
+       <c>pipeline_timeout</c> in milliseconds, the client closes the
+       connection. Default is <c>0</c>, which results in pipelining not being
+       used.
+      </item>
+      <tag><c>CookieMode</c></tag>
+      <item>
+        If cookies are enabled, all valid cookies are automatically saved in
+        the cookie database of the client manager. If option <c>verify</c> is
+        used, function <c>store_cookies/2</c> has to be called for the cookies
+        to be saved. Default is <c>disabled</c>.
+      </item>
+      <tag><c>IpFamily</c></tag>
+      <item>
+       Default is <c>inet</c>. With <c>inet6fb4</c> option, IPv6
+        will be preferred but if connection fails, an IPv4 fallback connection
+        attempt will be made.
+      </item>
+      <tag><c>IpAddress</c></tag>
+      <item>
+        If the host has several network interfaces, this option specifies
+        which one to use. See
+        <seeerl marker="kernel:gen_tcp#connect">gen_tcp:connect/3,4</seeerl> for
+        details.
+      </item>
+      <tag><c>Port</c></tag>
+      <item>
+        Example: <c>8080</c>.
+        Local port number to use. See <seeerl
+        marker="kernel:gen_tcp#connect">gen_tcp:connect/3,4</seeerl> for
+        details.
+      </item>
+      <tag><c>SocketOpts</c></tag>
+      <item>
+        The options are appended to the socket options used by the client.
+        These are the default values when a new request handler is started (for
+        the initial connect). They are passed directly to the underlying
+        transport (<c>gen_tcp</c> or <c>SSL</c>) without
+        verification.
+        <p>See the options used by
+        <seeerl marker="kernel:gen_tcp">gen_tcp(3)</seeerl> and
+        <seeerl marker="ssl:ssl">ssl(3)</seeerl>
+        </p>
+      </item>
+      <tag><c>VerboseMode</c></tag>
+      <item>
+        Default is <c>false</c>. This option is used to switch on (or off)
+        different levels of Erlang trace on the client. It is a debug
+        feature.
+      </item>
+      <tag><c>Profile</c></tag>
+      <item>
+        When started <c>stand_alone</c> only the pid can be used.
+      </item>
+      <tag><c>UnixSocket</c></tag>
+      <item>
+        Experimental option for sending HTTP requests over a unix domain
+        socket. The value of <c>unix_socket</c> shall be the full path to a unix
+        domain socket file with read/write permissions for the erlang process.
+        Default is <c>undefined</c>.
+      </item>
+
+        </taglist>
+
+	      <note>
+	        <p>If possible, the client keeps its connections alive and uses
+	        persistent connections with or without pipeline depending on
+	        configuration and current circumstances. The HTTP/1.1 specification
+	        does not provide a guideline for how many requests that are ideal to
+	        be sent on a persistent connection. This depends much on the
+	        application.</p>
+	       <p>A long queue of requests can cause a user-perceived delay, as
+	       earlier requests can take a long time to complete. The HTTP/1.1
+	       specification suggests a limit of two persistent connections per
+	       server, which is the default value of option <c>max_sessions</c>.</p>
+	       <p>The current implementation assumes the requests to the same host,
+	       port combination will use the same socket options.
+	       </p>
+	      </note>
         <marker id="get_options"></marker>
       </desc>
     </func>
 
     <func>
-      <name since="OTP 25.1">ssl_verify_host_options(WildcardHostName) -> list() </name>
+      <name since="OTP 25.1" name="ssl_verify_host_options" arity="1"/>
       <fsummary>Returns ssl options for host verification.</fsummary>
-      <type>
-        <v>WildcardHostName = boolean()</v>
-      </type>
       <desc>
         <p>Returns ssl options which can be used to verify the host, uses
         <seemfa marker="public_key:public_key#cacerts_get/0"><c>public_key:cacerts_get()</c></seemfa>
-        to read CA certicates and if <c>WildcardHostName</c> is true adds the hostname check from
+        to read CA certicates and if <c><anno>WildcardHostName</anno></c> is true adds the hostname check from
         <seemfa marker="public_key:public_key#pkix_verify_hostname_match_fun/1">
           <c> public_key:public_key:pkix_verify_hostname_match_fun(https)</c></seemfa> to the options.
         </p>
@@ -665,71 +563,64 @@
     </func>
 
     <func>
-      <name since="OTP R14B02">store_cookies(SetCookieHeaders, Url) -> </name>
-      <name since="OTP R14B02">store_cookies(SetCookieHeaders, Url, Profile) -> ok | {error, Reason}</name>
+      <name since="OTP R14B02" name="store_cookies" arity="2"/>
+      <name since="OTP R14B02" name="store_cookies" arity="3"/>
       <fsummary>Saves the cookies defined in <c>SetCookieHeaders</c> in the 
       client profile cookie database.</fsummary>
-      <type>
-        <v>SetCookieHeaders = headers() - where field = "set-cookie"</v>
-        <v>Url = url()</v>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-      </type>
+      <type_desc variable="SetCookieHeaders">
+        Where field = "set-cookie"
+      </type_desc>
+      <type_desc variable="Profile">
+        When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
-        <p>Saves the cookies defined in <c>SetCookieHeaders</c>
-	in the client profile cookie database.
-	Call this function if option <c>cookies</c> is set to <c>verify</c>.
-	If no profile is specified, the default profile is used.</p>
+        <p>Saves the cookies defined in <c>SetCookieHeaders</c> in the client
+        profile cookie database. Call this function if option <c>cookies</c> is
+        set to <c>verify</c>. If no profile is specified, the default profile is
+        used.</p>
       </desc>
     </func>
 
     <func>
-      <name since="OTP R13B04">stream_next(Pid) -> ok</name>
+      <name since="OTP R13B04" name="stream_next" arity="1"/>
       <fsummary>Triggers the next message to be streamed, that is,
 	the same behavior as active one for sockets.
       </fsummary>
-      <type>
-        <v>Pid = pid()</v>
-	<d>As received in the <c>stream_start message</c></d>
-      </type>
+      <type_desc variable="Pid">
+        As received in the <c>stream_start message</c>
+      </type_desc>
       <desc>
-        <p>Triggers the next message to be streamed, that is,
-	the same behavior as active ones for sockets.</p>
-
+        <p>Triggers the next message to be streamed, that is, the same behavior
+        as active ones for sockets.</p>
         <marker id="verify_cookies"></marker>
         <marker id="store_cookies"></marker>
       </desc>
     </func>
     
     <func>
-      <name since="OTP R13B04">which_cookies() -> cookies()</name>
-      <name since="OTP R13B04">which_cookies(Profile) -> cookies()</name>
+      <name since="OTP R13B04" name="which_cookies" arity="0"/>
+      <name since="OTP R13B04" name="which_cookies" arity="1"/>
       <fsummary>Dumps the entire cookie database.</fsummary>
-      <type>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-	<v>cookies() = [cookie_stores()]</v>
-	<v>cookie_stores() = {cookies, cookies()} | {session_cookies, cookies()}</v>
-	<v>cookies() = [cookie()]</v>
-	<v>cookie() = term()</v>
-      </type>
+      <type_desc variable="Profile">
+		    When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
       <desc>
-        <p>Produces a list of the entire cookie database.
-	Intended for debugging/testing purposes. 
-	If no profile is specified, the default profile is used.</p>
+        <p>Produces a list of the entire cookie database. Intended for
+        debugging/testing purposes. If no profile is specified, the default
+        profile is used.</p>
       </desc>
     </func>
 
     <func>
-      <name since="OTP R15B02">which_sessions() -> session_info()</name>
-      <name since="OTP R15B02">which_sessions(Profile) -> session_info()</name>
+      <name since="OTP R15B02" name="which_sessions" arity="0"/>
+      <name since="OTP R15B02" name="which_sessions" arity="1"/>
       <fsummary>Produces a slightly processed dump of the sessions database.</fsummary>
-      <type>
-	<v>Profile = profile() | pid()</v>
-	<d>When started <c>stand_alone</c> only the pid can be used.</d>
-	<v>session_info() = {[session()], [term()],  [term()]}</v>
-	<v>session() = term() - Internal representation of a session</v>
-      </type>
+      <type_desc variable="Profile">
+		    When started <c>stand_alone</c> only the pid can be used.
+      </type_desc>
+      <type_desc variable="Session">
+		    Internal representation of a session.
+      </type_desc>
       <desc>
         <p> This function is intended for debugging only. It produces
         a slightly processed dump of the session database. The first
@@ -740,8 +631,6 @@
         profile is used.</p>
       </desc>
     </func>
-
-  
   </funcs>
 
   <section>

--- a/lib/inets/doc/src/httpd.xml
+++ b/lib/inets/doc/src/httpd.xml
@@ -39,7 +39,7 @@
     Provides web server start options, administrative functions, and 
     an Erlang callback API.</p>
   </description>
-  
+
   <section>
     <title>DATA TYPES</title>
     <p>Type definitions that are used more than once in
@@ -49,10 +49,10 @@
     <p><c>path() = string()</c> representing a file or a directory path</p>
     <p><c> ip_address() = {N1,N2,N3,N4} % IPv4
        | {K1,K2,K3,K4,K5,K6,K7,K8}  % IPv6</c></p>
-    <p><c>hostname() = string()</c> representing a host, for example, 
+    <p><c>hostname() = string()</c> representing a host, for example,
     "foo.bar.com"</p>
     <p><c>property() = atom()</c></p>
-    
+
   </section>
 
   <section>
@@ -75,7 +75,7 @@
     term()</c>, followed by a full stop. If the web server is started
     dynamically at runtime, a file can still be specified but also the
     complete property list.</p>
-    
+
     <taglist>
       <tag><marker id="prop_proplist_file"></marker>{proplist_file, path()}</tag>
       <item>
@@ -94,7 +94,7 @@
     <p><em>Mandatory Properties</em></p>
     <taglist>
       <tag><marker id="prop_port"></marker>{port, integer()} </tag>
-      <item> 
+      <item>
 	<p>The port that the HTTP server listen to.
 	If zero is specified as port, an arbitrary available port
 	is picked and function <c>httpd:info/2</c> can be used to
@@ -107,8 +107,8 @@
       </item>
 
       <tag><marker id="prop_server_root"></marker>{server_root, path()}</tag>
-      <item> 
-	<p>Defines the home directory of the server, where log files, and so on, 
+      <item>
+	<p>Defines the home directory of the server, where log files, and so on,
 	can be stored. Relative paths specified in other properties refer
 	to this directory.</p>
       </item>
@@ -141,14 +141,19 @@
 	</p>
       </item>
 
-      <tag><marker id="prop_socket_type"></marker>{socket_type, ip_comm | {ip_comm,  Config::proplist()} | {essl, Config::proplist()}}</tag>
+      <tag><marker id="prop_socket_type"></marker>{socket_type, ip_comm | {ip_comm,  Config::proplist()} | {ssl, Config::proplist()}}</tag>
       <item>
-	<p>For <c>ip_comm</c> configuration options, see 
+	<p>For <c>ip_comm</c> configuration options, see
 	<seemfa marker="kernel:gen_tcp#listen/2">gen_tcp:listen/2</seemfa>, some options
 	that are used internally by httpd cannot be set.</p>
-	<p>For <c>SSL</c> configuration options, see 
+	<p>For <c>SSL</c> configuration options, see
 	<seemfa marker="ssl:ssl#listen/2">ssl:listen/2</seemfa>.</p>
-	<p>Default is <c>ip_comm</c>.</p> 
+	<p>Default is <c>ip_comm</c>.</p>
+  <note>
+    <p>OTP-25 deprecates the communication properties <c>{socket_type, ip_comm | {ip_comm, Config::proplist()} | {essl, Config::proplist()}}</c>
+    replacing it by <c>{socket_type, ip_comm | {ip_comm, Config::proplist()} | {ssl, Config::proplist()}}</c>.
+    </p>
+  </note>
       </item>
 
       <tag><marker id="prop_ipfamily"></marker>{ipfamily, inet | inet6}</tag>
@@ -156,7 +161,7 @@
 	<p>Default is <c>inet</c>, legacy option <c>inet6fb4</c> no longer makes sense and will be translated
 	to inet.</p>
       </item>
-      
+
       <tag><marker id="prop_minimum_bytes_per_second"></marker>{minimum_bytes_per_second, integer()}</tag>
       <item>
 	<p>If given, sets a minimum of bytes per second value for connections.</p>
@@ -173,53 +178,53 @@
 	<p>Defines which modules the HTTP server uses when handling
 	requests. Default is <c>[mod_alias, mod_auth, mod_esi,
 	mod_actions, mod_cgi, mod_dir, mod_get, mod_head, mod_log,
-	mod_disk_log]</c>. 
+	mod_disk_log]</c>.
 	Notice that some <c>mod</c>-modules are dependent on
 	others, so the order cannot be entirely arbitrary. See the
 	<seeguide marker="http_server">Inets Web Server Modules</seeguide> in the
 	User's Guide for details.</p>
       </item>
     </taglist>
-    
+
     <marker id="props_limit"></marker>
     <p><em>Limit properties</em> </p>
     <taglist>
 
       <tag><marker id="prop_customize"></marker>{customize, atom()}</tag>
-      <item> 
+      <item>
 	<p>A callback module to customize the inets HTTP servers behaviour
 	see <seeerl marker="httpd_custom_api"> httpd_custom_api</seeerl> </p>
       </item>
-      
+
       <tag><marker id="prop_disable_chunked_encoding"></marker>{disable_chunked_transfer_encoding_send, boolean()}</tag>
-      <item> 
+      <item>
 	<p>Allows you to disable chunked
 	transfer-encoding when sending a response to an HTTP/1.1
 	client. Default is <c>false</c>.</p>
       </item>
-      
+
       <tag><marker id="prop_keep_alive"></marker>{keep_alive, boolean()}</tag>
       <item>
 	<p>Instructs the server whether to use persistent
 	connections when the client claims to be HTTP/1.1
 	compliant. Default is <c>true</c>.</p>
       </item>
-      
+
       <tag><marker id="prop_keep_alive_timeout"></marker>{keep_alive_timeout, integer()}</tag>
       <item>
 	<p>The number of seconds the server waits for a
 	subsequent request from the client before closing the
 	connection. Default is <c>150</c>.</p>
       </item>
-      
+
       <tag><marker id="prop_max_body_size"></marker>{max_body_size, integer()}</tag>
       <item>
 	<p>Limits the size of the message body of an HTTP request.
 	Default is no limit.</p>
       </item>
-      
+
       <tag><marker id="prop_max_clients"></marker>{max_clients, integer()}</tag>
-      <item> 
+      <item>
 	<p>Limits the number of simultaneous requests that can be
 	supported. Default is <c>150</c>.</p>
       </item>
@@ -243,31 +248,31 @@
 	<p>Limits the size of the HTTP request URI.
 	Default is no limit.</p>
       </item>
-      
+
       <tag><marker id="prop_max_keep_alive_req"></marker>{max_keep_alive_request, integer()}</tag>
       <item>
 	<p>The number of requests that a client can do on one
 	connection. When the server has responded to the number of
-	requests defined by <c>max_keep_alive_requests</c>, the server 
-	closes the connection. The server closes it even if there are 
+	requests defined by <c>max_keep_alive_requests</c>, the server
+	closes the connection. The server closes it even if there are
 	queued request. Default is no limit.</p>
       </item>
 
-      
+
       <tag><marker id="max_client_body_chunk"></marker>{max_client_body_chunk, integer()}</tag>
       <item>
 	<p>Enforces chunking of a HTTP PUT or POST body data to be delivered
-	to the mod_esi callback. Note this is not supported for mod_cgi. 
+	to the mod_esi callback. Note this is not supported for mod_cgi.
 	Default is no limit e.i the whole body is delivered as one entity, which could
 	be very memory consuming. <seeerl marker="mod_esi">mod_esi(3)</seeerl>.
 	</p>
       </item>
-      
+
     </taglist>
-    
+
     <marker id="props_admin"></marker>
     <p><em>Administrative Properties</em></p>
-    <taglist> 
+    <taglist>
       <tag><marker id="prop_mime_types"></marker>{mime_types, [{MimeType, Extension}] | path()}</tag>
       <item>
 	<p><c>MimeType = string()</c> and <c>Extension = string()</c>.
@@ -284,7 +289,7 @@
 	cannot be determined by the MIME Type Settings, the server
 	uses this default type.</p>
       </item>
-  
+
       <tag><marker id="prop_server_admin"></marker>{server_admin, string()}</tag>
       <item>
 	<p>Defines the email-address of the server
@@ -295,7 +300,7 @@
       <tag><marker id="prop_server_tokens"></marker>{server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}</tag>
       <item>
 	<p>Defines the look of the value of the server header.</p>
-	<p>Example: Assuming the version of <c>Inets</c> is 5.8.1, 
+	<p>Example: Assuming the version of <c>Inets</c> is 5.8.1,
 	the server header string can look as follows for
 	the different values of server-tokens:</p>
 	<taglist>
@@ -319,22 +324,22 @@
 	<p>By default, the value is as before, that is, <c>minimal</c>.</p>
       </item>
 
-      
+
       <tag><marker id="prop_logger"></marker>{logger, Options::list()}</tag>
       <item>
 
 	<p>Currently only one option is supported: </p>
-	
+
 	<taglist>
 	  <tag><c>{error, ServerID::atom()}</c></tag>
-	  <item>	    <p>Produces  
+	  <item>	    <p>Produces
 	    <seetype marker="kernel:logger#log_event">logger events</seetype>
 	    on logger <seetype marker="kernel:logger#level">level error</seetype>
 	    under the hierarchical logger <seetype marker="kernel:logger#log_event">domain:</seetype> <c>[otp, inets, httpd, ServerID, error]</c>
-	    The built in logger formatting 
+	    The built in logger formatting
 	    function produces log entries from the
 	    error reports:</p>
-	    
+
 	    <code>
 #{server_name => string()
   protocol => internal | 'TCP' | 'TLS' | 'HTTP',
@@ -360,12 +365,12 @@ Transport: TLS
 </code>
 
 <p>Using this option makes mod_log and mod_disk_log error logs redundant.</p>
-	
+
 	<p>Add the filter</p>
 	<code>
 {fun logger_filters:domain/2,
 	{log,equal,[otp,inets, httpd, ServerID, error]}</code>
-	
+
         to appropriate logger handler to handle the events. For
         example to write the error log from an httpd server with a
         <c>ServerID</c> of <c>my_server</c> to a file you can use the following
@@ -383,24 +388,24 @@ Transport: TLS
 	</code>
 
 	<p>or if you want to add it to the default logger via an API:</p>
-	
+
 	<code>logger:add_handler_filter(default,
                           inets_httpd,
                           {fun logger_filters:domain/2,
                            {log, equal,
                             [otp, inets, httpd, my_server, error]}}).</code>
-			    
-	  </item>      
-	</taglist> 
-	
-      </item>      
-      
+
+	  </item>
+	</taglist>
+
+      </item>
+
       <tag><marker id="prop_log_format"></marker>{log_format, common | combined}</tag>
       <item>
 	<p>Defines if access logs are to be written according to the <c>common</c>
 	log format or the extended common log format.
 	The <c>common</c> format is one line looking like this:
-        <c>remotehost rfc931 authuser [date] "request" status bytes</c>.</p> 
+        <c>remotehost rfc931 authuser [date] "request" status bytes</c>.</p>
 	<p>Here:</p>
 	<taglist>
 	  <tag><c>remotehost</c></tag>
@@ -425,90 +430,90 @@ Transport: TLS
 	<taglist>
 	  <tag><c>"referer"</c></tag>
 	  <item>The URL the client was on before
-	requesting the URL (if it could not be determined, 
+	requesting the URL (if it could not be determined,
 	a minus sign is placed in this field).</item>
 	  <tag><c>"user_agent"</c></tag>
 	  <item>The software the client claims to be using (if it
 	could not be determined, a minus sign is placed in
 	this field).</item>
 	</taglist>
-	
-	<p>This affects the access logs written by <c>mod_log</c> and 
+
+	<p>This affects the access logs written by <c>mod_log</c> and
 	<c>mod_disk_log</c>.
-	</p>	
-      </item>      
+	</p>
+      </item>
 
       <tag><marker id="prop_elog_format"></marker>{error_log_format, pretty | compact}</tag>
       <item>
 	<p>Default is <c>pretty</c>. If the error log is meant to be read
 	directly by a human, <c>pretty</c> is the best option.</p>
 	<p><c>pretty</c> has a format corresponding to:</p>
-	
+
 	<code>io:format("[~s] ~s, reason: ~n ~p ~n~n", [Date, Msg, Reason]).</code>
 
 	<p><c>compact</c> has a format corresponding to:</p>
-	
+
 	<code>io:format("[~s] ~s, reason: ~w ~n", [Date, Msg, Reason]).</code>
 
-	<p>This affects the error logs written by <c>mod_log</c> and 
+	<p>This affects the error logs written by <c>mod_log</c> and
 	<c>mod_disk_log</c>.
 	</p>
       </item>
-      
+
     </taglist>
-   
+
     <marker id="props_alias"></marker>
     <p><em>URL Aliasing Properties - Requires mod_alias</em></p>
     <taglist>
       <tag><marker id="prop_alias"></marker>{alias, {Alias, RealName}}</tag>
       <item>
-	<p><c>Alias = string()</c> and <c>RealName = string()</c>. 
+	<p><c>Alias = string()</c> and <c>RealName = string()</c>.
 	<c>alias</c> allows documents to be stored in the local file
 	system instead of the <c>document_root</c> location. URLs with a path
 	beginning with url-path is mapped to local files beginning with
 	directory-filename, for example:</p>
-	
+
 	<code>{alias, {"/image", "/ftp/pub/image"}}</code>
-	
+
 	<p>Access to http://your.server.org/image/foo.gif would refer to
 	the file /ftp/pub/image/foo.gif.</p>
       </item>
 
-      <tag><marker id="prop_re_write"></marker>{re_write, {Re, Replacement}}</tag>      
+      <tag><marker id="prop_re_write"></marker>{re_write, {Re, Replacement}}</tag>
       <item>
-	<p><c>Re = string()</c> and <c>Replacement = string()</c>. 
+	<p><c>Re = string()</c> and <c>Replacement = string()</c>.
 	<c>re_write</c> allows documents to be stored in the local file
 	system instead of the <c>document_root</c> location. URLs are rewritten
         by <c>re:replace/3</c> to produce a path in the local file-system,
         for example:</p>
-	
+
 	<code>{re_write, {"^/[~]([^/]+)(.*)$", "/home/\\1/public\\2"}}</code>
-	
+
 	<p>Access to http://your.server.org/~bob/foo.gif would refer to
 	the file /home/bob/public/foo.gif. </p>
 
       </item>
 
-      <tag><marker id="prop_dir_idx"></marker>{directory_index, [string()]}</tag>      
-      <item> 
+      <tag><marker id="prop_dir_idx"></marker>{directory_index, [string()]}</tag>
+      <item>
 	<p><c>directory_index</c> specifies a list of resources to look for
 	if a client requests a directory using a <c>/</c> at the end of the
 	directory name. <c>file</c> depicts the name of a file in the
 	directory. Several files can be given, in which case the server
 	returns the first it finds, for example:</p>
-	
+
 	<code>{directory_index, ["index.html", "welcome.html"]}</code>
-	
+
 	<p>Access to http://your.server.org/docs/ would return
 	http://your.server.org/docs/index.html or
 	http://your.server.org/docs/welcome.html if index.html does not
 	exist.</p>
-      </item> 
+      </item>
     </taglist>
 
     <marker id="props_cgi"></marker>
     <p><em>CGI Properties - Requires mod_cgi</em></p>
-    <taglist> 
+    <taglist>
       <tag><marker id="prop_script_alias"></marker>{script_alias, {Alias, RealName}}</tag>
       <item>
 	<p><c>Alias = string()</c> and <c>RealName = string()</c>.
@@ -516,13 +521,13 @@ Transport: TLS
 	they also mark the target directory as containing CGI
 	scripts. URLs with a path beginning with url-path are mapped to
 	scripts beginning with directory-filename, for example:</p>
-	
+
 	<code>{script_alias, {"/cgi-bin/", "/web/cgi-bin/"}}</code>
-	
+
 	<p>Access to http://your.server.org/cgi-bin/foo would cause
 	the server to run the script /web/cgi-bin/foo.</p>
       </item>
-      
+
       <tag><marker id="prop_script_re_write"></marker>{script_re_write, {Re, Replacement}}</tag>
       <item>
 	<p><c>Re = string()</c> and <c>Replacement = string()</c>.
@@ -530,21 +535,21 @@ Transport: TLS
 	they also mark the target directory as containing CGI
 	scripts. URLs with a path beginning with url-path are mapped to
 	scripts beginning with directory-filename, for example:</p>
-	
+
 	<code>{script_re_write, {"^/cgi-bin/(\\d+)/", "/web/\\1/cgi-bin/"}}</code>
-	
+
 	<p>Access to http://your.server.org/cgi-bin/17/foo would cause
 	the server to run the script /web/17/cgi-bin/foo.</p>
       </item>
-      
+
       <tag><marker id="prop_script_nocache"></marker>{script_nocache, boolean()}</tag>
-      <item> 
+      <item>
 	<p>If <c>script_nocache</c> is set to <c>true</c>, the HTTP server by
 	default adds the header fields necessary to prevent proxies from
-	caching the page. Generally this is preferred. 
+	caching the page. Generally this is preferred.
 	Default to <c>false</c>.</p>
       </item>
-      
+
       <tag><marker id="prop_script_timeout"></marker>{script_timeout, integer()}</tag>
       <item>
 	<p>The time in seconds the web server waits between each
@@ -552,7 +557,7 @@ Transport: TLS
 	any data before the timeout, the connection to the client is
 	closed. Default is <c>15</c>.</p>
       </item>
-      
+
       <tag><marker id="prop_action"></marker>{action, {MimeType, CgiScript}} - requires mod_action</tag>
       <item>
 	<p><c>MimeType = string()</c> and <c>CgiScript = string()</c>.
@@ -576,24 +581,24 @@ Transport: TLS
 	the standard CGI PATH_INFO and PATH_TRANSLATED environment
 	variables.</p>
 	<p>Example:</p>
-	
+
 	<code>{script, {"PUT", "/cgi-bin/put"}}</code>
-	
+
       </item>
     </taglist>
-    
+
     <marker id="props_esi"></marker>
     <p><em>ESI Properties - Requires mod_esi</em></p>
     <taglist>
-      <tag><marker id="prop_esi_alias"></marker>{erl_script_alias, {URLPath, [AllowedModule]}}</tag>      
+      <tag><marker id="prop_esi_alias"></marker>{erl_script_alias, {URLPath, [AllowedModule]}}</tag>
       <item>
 	<p><c>URLPath = string()</c> and <c>AllowedModule = atom()</c>.
 	<c>erl_script_alias</c> marks all URLs matching url-path as erl
 	scheme scripts. A matching URL is mapped into a specific module
 	and function, for example:</p>
-	
+
 	<code>{erl_script_alias, {"/cgi-bin/example", [httpd_example]}}</code>
-	
+
 	<p>A request to
 	http://your.server.org/cgi-bin/example/httpd_example:yahoo
 	would refer to httpd_example:yahoo/3 or, if that does not exist,
@@ -607,7 +612,7 @@ Transport: TLS
 	<p>If <c>erl_script_nocache</c> is set to <c>true</c>, the server adds
 	HTTP header fields preventing proxies from caching the
 	page. This is generally a good idea for dynamic content, as
-	the content often varies between each request. 
+	the content often varies between each request.
 	Default is <c>false</c>.</p>
       </item>
 
@@ -619,7 +624,7 @@ Transport: TLS
 	for scripts that use the erl scheme.</p>
       </item>
     </taglist>
-    
+
     <marker id="props_log"></marker>
     <p><em>Log Properties - Requires mod_log</em></p>
     <taglist>
@@ -638,7 +643,7 @@ Transport: TLS
       </item>
 
       <tag><marker id="prop_tlog"></marker>{transfer_log, path()}</tag>
-      <item> 
+      <item>
 	<p>Defines the filename of the access log file to be used to
 	log incoming requests. If the filename does not begin with a
 	slash (/), it is assumed to be relative to the <c>server_root</c>.</p>
@@ -684,24 +689,24 @@ Transport: TLS
 
       <tag><marker id="prop_sdlog_size"></marker>{security_disk_log_size, {MaxBytes, MaxFiles}}</tag>
       <item>
-	<p><c>MaxBytes = integer()</c> and <c>MaxFiles = integer()</c>. 
+	<p><c>MaxBytes = integer()</c> and <c>MaxFiles = integer()</c>.
 	Defines the properties of the <c>disk_log(3)</c> access log
 	file. This file is of type wrap log and
 	max bytes is written to each file and max files is
 	used before the first file is truncated and reused.</p>
       </item>
 
-      <tag><marker id="prop_tdlog"></marker>{transfer_disk_log, path()}</tag> 
+      <tag><marker id="prop_tdlog"></marker>{transfer_disk_log, path()}</tag>
       <item>
 	<p>Defines the filename of the (<c>disk_log(3)</c>) access log file
 	logging incoming requests. If the filename does not begin
 	with a slash (/), it is assumed to be relative to the
 	<c>server_root</c>.</p>
       </item>
-      
+
       <tag><marker id="prop_tdlog_size"></marker>{transfer_disk_log_size, {MaxBytes, MaxFiles}}</tag>
       <item>
-	<p><c>MaxBytes = integer()</c> and <c>MaxFiles = integer()</c>.  
+	<p><c>MaxBytes = integer()</c> and <c>MaxFiles = integer()</c>.
 	Defines the properties of the <c>disk_log(3)</c> access log
 	file. This file is of type wrap log and
 	max bytes is written to each file and max files is
@@ -717,26 +722,26 @@ Transport: TLS
 
     <marker id="props_dir"></marker>
     <p>The properties for directories are as follows:</p>
-    
+
     <taglist>
       <tag><marker id="prop_allow_from"></marker>{allow_from, all | [RegxpHostString]}</tag>
       <item>
 	<p>Defines a set of hosts to be granted access to a
 	given directory, for example:</p>
-	
+
 	<code>{allow_from, ["123.34.56.11", "150.100.23"]}</code>
-          
+
 	<p>The host <c>123.34.56.11</c> and all machines on the <c>150.100.23</c>
 	subnet are allowed access.</p>
       </item>
-      
+
       <tag><marker id="prop_deny_from"></marker>{deny_from, all | [RegxpHostString]}</tag>
       <item>
 	<p>Defines a set of hosts
 	to be denied access to a given directory, for example:</p>
-	
+
 	<code>{deny_from, ["123.34.56.11", "150.100.23"]}</code>
-          
+
 	<p>The host <c>123.34.56.11</c> and all machines on the <c>150.100.23</c>
 	subnet are not allowed access.</p>
       </item>
@@ -759,9 +764,9 @@ Transport: TLS
 	by the non-encrypted password. If usernames are duplicated,
 	the behavior is undefined.</p>
 	<p>Example:</p>
-	
+
 	<code> ragnar:s7Xxv7
- edward:wwjau8 </code> 
+ edward:wwjau8 </code>
 
 	<p>If the Dets storage method is used, the user database is
 	maintained by Dets and must not be edited by hand. Use the
@@ -772,7 +777,7 @@ Transport: TLS
 	server. If it is placed in the directory that it protects,
 	clients can download it.</p>
       </item>
-      
+
       <tag><marker id="prop_auth_group_file"></marker>{auth_group_file, path()}</tag>
       <item>
 	<p>Sets the name of a file containing the list of user
@@ -782,9 +787,9 @@ Transport: TLS
 	each line contains a group name followed by a colon, followed
 	by the members usernames separated by spaces.</p>
 	<p>Example:</p>
-	
+
 	<code>group1: bob joe ante</code>
-          
+
 	<p>If the Dets storage method is used, the group database is
 	maintained by Dets and must not be edited by hand. Use the
 	API for module <c>mod_auth</c> to create/edit the group database.
@@ -796,9 +801,9 @@ Transport: TLS
       </item>
 
       <tag><marker id="prop_auth_name"></marker>{auth_name, string()}</tag>
-      <item> 
+      <item>
 	<p>Sets the name of the authorization realm (auth-domain) for
-	a directory. This string informs the client about which 
+	a directory. This string informs the client about which
 	username and password to use.</p>
       </item>
 
@@ -811,9 +816,9 @@ Transport: TLS
 	web server is started. Otherwise it is written in clear
 	text in the configuration file.</p>
       </item>
-      
+
       <tag><marker id="prop_req_user"></marker>{require_user, [string()]}</tag>
-      <item> 
+      <item>
 	<p>Defines users to grant access to a given
 	directory using a secret password.</p>
       </item>
@@ -823,26 +828,26 @@ Transport: TLS
 	<p>Defines users to grant access to a given
 	directory using a secret password.</p>
       </item>
-      
+
     </taglist>
 
     <marker id="props_sec"></marker>
     <p><em>Security Properties - Requires mod_security</em></p>
- 
+
     <marker id="prop_sec_dir"></marker>
     <p><em>{security_directory, {path(), [{property(), term()}]}}</em></p>
-       
+
     <marker id="props_sdir"></marker>
     <p>The properties for the security directories are as follows:</p>
     <taglist>
-      <tag><marker id="prop_data_file"></marker>{data_file, path()}</tag>      
+      <tag><marker id="prop_data_file"></marker>{data_file, path()}</tag>
       <item>
 	<p>Name of the security data file. The filename can either be
 	absolute or relative to the <c>server_root</c>. This file is used to
 	store persistent data for module <c>mod_security</c>.</p>
       </item>
-	  
-      <tag><marker id="prop_max_retries"></marker>{max_retries, integer()}</tag>	  
+
+      <tag><marker id="prop_max_retries"></marker>{max_retries, integer()}</tag>
       <item>
 	<p>Specifies the maximum number of attempts to authenticate a
 	user before the user is blocked out. If a user
@@ -850,45 +855,41 @@ Transport: TLS
 	user receives a 403 (Forbidden) response from the
 	server. If the user makes a failed attempt while blocked, the
 	server returns 401 (Unauthorized), for security
-	reasons. 
+	reasons.
 	Default is <c>3</c>. Can be set to infinity.</p>
       </item>
-	
+
       <tag><marker id="prop_block_time"></marker>{block_time, integer()}</tag>
       <item>
 	<p>Specifies the number of minutes a user is blocked. After
 	this time has passed, the user automatically regains access.
 	Default is <c>60</c>.</p>
       </item>
-      
+
       <tag><marker id="prop_fail_exp_time"></marker>{fail_expire_time, integer()}</tag>
       <item>
 	<p>Specifies the number of minutes a failed user authentication
 	is remembered. If a user authenticates after this
 	time has passed, the previous failed authentications are
-	forgotten. 
+	forgotten.
 	Default is <c>30</c>.</p>
       </item>
-      
+
       <tag><marker id="prop_auth_timeout"></marker>{auth_timeout, integer()}</tag>
       <item>
 	Specifies the number of seconds a successful user
 	authentication is remembered. After this time has passed, the
 	authentication is no longer reported. Default is <c>30</c>.
       </item>
-    </taglist>    
+    </taglist>
   </section>
+
 
   <funcs>
     <func>
-      <name since="">info(Pid) -></name>
-      <name since="">info(Pid, Properties) -> [{Option, Value}]</name>
+      <name since="" name="info" arity="1" />
+      <name since="" name="info" arity="2" clause_i="1"/>
       <fsummary>Fetches information about the HTTP server.</fsummary>
-      <type>
-        <v>Properties = [property()]</v>
-	<v>Option = property()</v>
-	<v>Value = term()</v>
-      </type>
       <desc>
         <p>Fetches information about the HTTP server. When called
 	with only the pid, all properties are fetched. When called
@@ -906,43 +907,28 @@ Transport: TLS
     </func>
 
     <func>
-      <name since="">info(Address, Port) ->  </name>
-      <name since="">info(Address, Port, Profile) ->  </name>
-      <name since="OTP 18.0">info(Address, Port, Profile, Properties) -> [{Option, Value}] </name>
-      <name since="">info(Address, Port, Properties) -> [{Option, Value}] </name>
+      <name since=""          name="info" arity="2" clause_i="2"/>
+      <name since=""          name="info" arity="3" clause_i="1"/>
+      <name since=""          name="info" arity="3" clause_i="2"/>
+      <name since="OTP 18.0"  name="info" arity="4" />
       <fsummary>Fetches information about the HTTP server.</fsummary>
-      <type>
-	<v>Address = ip_address()</v>
-	<v>Port = integer()</v>
-	<v>Profile = atom()</v>
-	<v>Properties = [property()]</v>
-        <v>Option = property()</v>
-	<v>Value = term()</v>
-      </type>
       <desc>
-        <p>Fetches information about the HTTP server. When called with
-        only <c>Address</c> and <c>Port</c>, all properties are
-        fetched.  When called with a list of specific properties, they
-        are fetched.  The available properties are the same as the
-        start options of the server.
-	</p>
+        <p>Fetches information about the HTTP server. When called with only
+        <c><anno>Address</anno></c> and <c><anno>Port</anno></c>, all properties
+        are fetched. When called with a list of specific properties, they are
+        fetched. The available properties are the same as the start options of
+        the server.
+	      </p>
 
-	<note><p>The address must be the IP address and cannot be
-	    the hostname.
-	  </p></note>	
+	      <note><p>The <c>Address</c> must be the IP address and
+	      cannot be the hostname. </p></note>
       </desc>
     </func>
     
     <func>
-      <name since="">reload_config(Config, Mode) -> ok | {error, Reason}</name>
+      <name since="" name="reload_config" arity="2"/>
       <fsummary>Reloads the HTTP server configuration without
 	restarting the server.</fsummary>
-      <type>
-        <v>Config = path() | [{Option, Value}]</v>
-	<v>Option = property()</v>
-	<v>Value = term()</v>
-	<v>Mode = non_disturbing | disturbing</v>
-      </type>
       <desc>
 	<p>Reloads the HTTP server configuration without restarting the
 	  server. Incoming requests are answered with a temporary
@@ -1157,19 +1143,13 @@ Transport: TLS
       <title>ERLANG WEB SERVER API HELP FUNCTIONS</title>
     </fsdescription>
     <func>
-      <name since="">parse_query(QueryString) -> [{Key,Value}]</name>
+      <name since="" name="parse_query" arity="1"/>
       <fsummary>Parses incoming data to <c>erl</c> and <c>eval</c> scripts.</fsummary>
-      <type>
-        <v>QueryString = string()</v>
-	<v>Key = string()</v>
-	<v>Value = string()</v>
-      </type>
       <desc>
         <p><c>parse_query/1</c> parses incoming data to <c>erl</c> and
-          <c>eval</c> scripts (see <seeerl marker="mod_esi">mod_esi(3)</seeerl>) 
-	  as defined in the standard
-          URL format, that is, '+' becomes 'space' and decoding of
-          hexadecimal characters (<c>%xx</c>).</p>
+        <c>eval</c> scripts (see <seeerl marker="mod_esi">mod_esi(3)</seeerl>)
+        as defined in the standard URL format, that is, '+' becomes 'space' and
+        decoding of hexadecimal characters (<c>%xx</c>).</p>
       </desc>
     </func>
   </funcs>

--- a/lib/inets/doc/src/specs.xml
+++ b/lib/inets/doc/src/specs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<specs xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="../specs/specs_inets.xml"/>
+  <xi:include href="../specs/specs_http_uri.xml"/>
+  <xi:include href="../specs/specs_httpc.xml"/>
+  <xi:include href="../specs/specs_httpd.xml"/>
+  <xi:include href="../specs/specs_httpd_custom_api.xml"/>
+  <xi:include href="../specs/specs_httpd_socket.xml"/>
+  <xi:include href="../specs/specs_httpd_util.xml"/>
+  <xi:include href="../specs/specs_mod_alias.xml"/>
+  <xi:include href="../specs/specs_mod_auth.xml"/>
+  <xi:include href="../specs/specs_mod_esi.xml"/>
+  <xi:include href="../specs/specs_mod_security.xml"/>
+</specs>

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -53,11 +53,11 @@
 	 stop_service/1, 
 	 services/0, service_info/1]).
 
+
 -include_lib("inets/src/http_lib/http_internal.hrl").
 -include("httpc_internal.hrl").
 
 -define(DEFAULT_PROFILE, default).
-
 
 %%%=========================================================================
 %%%  API
@@ -66,7 +66,8 @@
 default_profile() ->
     ?DEFAULT_PROFILE.
 
-
+-spec profile_name(pid()) -> pid();
+                  (atom()) -> pid() | atom().
 profile_name(?DEFAULT_PROFILE) ->
     httpc_manager;
 profile_name(Profile) when is_pid(Profile) -> 
@@ -75,85 +76,169 @@ profile_name(Profile) ->
     Prefix = lists:flatten(io_lib:format("~w_", [?MODULE])),
     profile_name(Prefix, Profile).
 
+
 profile_name(Prefix, Profile) when is_atom(Profile) ->
     list_to_atom(Prefix ++ atom_to_list(Profile));
 profile_name(_Prefix, Profile) when is_pid(Profile) ->
     Profile.
 
 
-%%--------------------------------------------------------------------------
-%% request(Url) -> {ok, {StatusLine, Headers, Body}} | {error,Reason} 
-%% request(Url Profile) ->
-%%           {ok, {StatusLine, Headers, Body}} | {error,Reason} 
-%%
-%%	Url - string() 
-%% Description: Calls request/4 with default values.
-%%--------------------------------------------------------------------------
-
+-spec request(uri_string:uri_string()) -> {ok, Result} | {error, term()} when
+      Result :: {StatusLine :: { HttpVersion, StatusCode, string()}
+                , [HttpHeader]
+                , HttpBodyResult}
+              | { StatusCode
+                , HttpBodyResult}
+              | RequestId
+              | saved_to_file,
+      HttpBodyResult :: uri_string:uri_string() | binary(),
+      HttpVersion :: uri_string:uri_string(),
+      StatusCode :: non_neg_integer(),
+      HttpHeader :: { Field :: [byte()]
+                    , Value :: binary() | iolist()},
+      RequestId :: any().
 request(Url) ->
     request(Url, default_profile()).
 
+-spec request(Url, Profile) -> {ok, Result} | {error, term()} when
+      Url :: uri_string:uri_string(),
+      Profile :: atom() | pid(),
+      Result ::{ StatusLine, [HttpHeader], HttpBodyResult}
+              | { StatusCode, HttpBodyResult}
+              | RequestId
+              | saved_to_file,
+      HttpHeader :: { Field :: [byte()]
+                    , Value :: binary() | iolist()},
+      HttpBodyResult :: uri_string:uri_string() | binary(),
+      StatusLine :: { HttpVersion
+                    , StatusCode
+                    , string()},
+      HttpVersion :: uri_string:uri_string(),
+      StatusCode  :: non_neg_integer(),
+      RequestId :: any().
 request(Url, Profile) ->
     request(get, {Url, []}, [], [], Profile).
 
-
-%%--------------------------------------------------------------------------
-%% request(Method, Request, HTTPOptions, Options [, Profile]) ->
-%%           {ok, {StatusLine, Headers, Body}}
-%%         | {ok, {Status, Body}}
-%%         | {ok, RequestId}
-%%         | {ok, {saved_as, FilePath}
-%%         | {error, Reason}
 %%
-%%	Method - atom() = head | get | put | patch | post | trace |
-%%	                  options | delete 
-%%	Request - {Url, Headers} | {Url, Headers, ContentType, Body} 
-%%	Url - string() 
-%%	HTTPOptions - [HttpOption]
-%%	HTTPOption - {timeout, Time} | {connect_timeout, Time} | 
-%%                   {ssl, SSLOptions} | {proxy_auth, {User, Password}}
-%%	Ssloptions = ssl_options() | 
-%%                   {ssl,  ssl_options()} | 
-%%                   {essl, ssl_options()}
-%%      ssl_options() = [ssl_option()]
-%%	ssl_option() =  {verify, code()} | 
-%%                      {depth, depth()} | 
-%%                      {certfile, path()} |
-%%	{keyfile, path()} | {password, string()} | {cacertfile, path()} |
-%%	{ciphers, string()} 
-%%	Options - [Option]
-%%	Option -  {sync, Boolean}           | 
-%%                {body_format, BodyFormat} | 
-%%	          {full_result, Boolean}    | 
-%%                {stream, To}              |
-%%                {headers_as_is, Boolean}  
-%%	StatusLine = {HTTPVersion, StatusCode, ReasonPhrase}</v>
-%%	HTTPVersion = string()
-%%	StatusCode = integer()
-%%	ReasonPhrase = string()
-%%	Headers = [Header]
-%%      Header = {Field, Value}
-%%	Field = [byte()]
-%%	Value = binary() | iolist()
-%%	Body = iolist() | binary() | {fun(SendAcc) -> SendFunResult, SendAcc} |
-%%              {chunkify, fun(SendAcc) -> SendFunResult, SendAcc} - HTML-code
-%%      SendFunResult = eof | {ok, iolist(), NewSendAcc}
-%%      SendAcc = NewSendAcc = term()
-%%
-%% Description: Sends a HTTP-request. The function can be both
-%% synchronous and asynchronous in the later case the function will
-%% return {ok, RequestId} and later on a message will be sent to the
-%% calling process on the format {http, {RequestId, {StatusLine,
-%% Headers, Body}}} or {http, {RequestId, {error, Reason}}}.
-%% Only octects are accepted in header fields and values.
-%%--------------------------------------------------------------------------
-
+%% @doc Sends a HTTP-request. The function can be both synchronous and
+%% asynchronous in the later case the function will return `{ok, RequestId}' and
+%% and then the information is delivered to the receiver depending on that
+%% value.
+-spec request(Method, Request, HttpOptions, Options) -> {ok, Result} | {error, term()} when
+      Method :: head | get | put | patch | post | trace | options | delete,
+      Request :: { uri_string:uri_string()
+                 , [HttpHeader] }
+               | { uri_string:uri_string()
+                 , [ HttpHeader ]
+                 , ContentType::uri_string:uri_string()
+                 , HttpBody},
+      HttpBody :: iolist()
+                | binary()
+                | { fun((Accumulator::term()) ->
+                      eof | {ok, iolist(), Accumulator::term()}), Accumulator::term()}
+                | { chunkify
+                  , fun((Accumulator::term()) ->
+                      eof | {ok, iolist(), Accumulator::term()})
+                  , Accumulator::term() },
+      HttpOptions :: [HttpOption],
+      HttpOption :: {timeout, timeout()}
+                  | {connect_timeout, timeout()}
+                  | {ssl, [ssl:tls_option()]}
+                  | {autoredirect, boolean()}
+                  | {proxy_auth, {string(), string()}}
+                  | {version, HttpVersion} | {relaxed, boolean()},
+      Options :: [OptionRequest],
+      OptionRequest :: {sync, boolean()}
+                        | {stream, StreamTo}
+                        | {body_format, BodyFormat}
+                        | {full_result, boolean()}
+                        | {headers_as_is, boolean()}
+                        | {socket_opts, [SocketOpt]}
+                        | {receiver, Receiver}
+                        | {ipv6_host_with_brackets, boolean()},
+      StreamTo :: none | self | {self, once} | file:name_all(),
+      SocketOpt :: term(),
+      BodyFormat  :: string() | binary() | atom(),
+      Receiver :: pid()
+                  | fun((term()) -> term())
+                  | { ReceiverModule::atom()
+                    , ReceiverFunction::atom()
+                    , ReceiverArgs::list()},
+      Result :: { StatusLine , [HttpHeader], HttpBodyResult}
+              | { StatusCode, HttpBodyResult}
+              | RequestId
+              | saved_to_file,
+      StatusCode::non_neg_integer(),
+      StatusLine :: { HttpVersion
+                    , StatusCode
+                    , string()},
+      HttpVersion :: uri_string:uri_string(),
+      HttpHeader :: { Field :: [byte()]
+                    , Value :: binary() | iolist()},
+      HttpBodyResult :: uri_string:uri_string() | binary(),
+      RequestId :: any().
 request(Method, Request, HttpOptions, Options) ->
     request(Method, Request, HttpOptions, Options, default_profile()).
+
 
 -define(WITH_BODY, [post, put, patch, delete]).
 -define(WITHOUT_BODY, [get, head, options, trace, put, delete]).
 
+-spec request(Method, Request, HttpOptions, Options, Profile) -> {ok, Result} | {error, term()} when
+      Method :: head | get | put | patch | post | trace | options | delete,
+      Request :: { uri_string:uri_string()
+                 , [HttpHeader] }
+               | { uri_string:uri_string()
+                 , [ HttpHeader ]
+                 , ContentType::uri_string:uri_string()
+                 , HttpBody},
+      HttpBody :: iolist()
+                | binary()
+                | { fun((Accumulator::term()) ->
+                      eof | {ok, iolist(), Accumulator::term()}), Accumulator::term()}
+                | { chunkify
+                  , fun((Accumulator::term()) ->
+                      eof | {ok, iolist(), Accumulator::term()})
+                  , Accumulator::term() },
+      HttpHeader :: { Field :: [byte()]
+                    , Value :: binary() | iolist()},
+      HttpOptions :: [HttpOption],
+      HttpOption :: {timeout, timeout()}
+                  | {connect_timeout, timeout()}
+                  | {ssl, [ssl:tls_option()]}
+                  | {autoredirect, boolean()}
+                  | {proxy_auth, {string(), string()}}
+                  | {version, HttpVersion} | {relaxed, boolean()},
+      Options :: [OptionRequest],
+      OptionRequest :: {sync, boolean()}
+                     | {stream, StreamTo}
+                     | {body_format, BodyFormat}
+                     | {full_result, boolean()}
+                     | {headers_as_is, boolean()}
+                     | {socket_opts, [SocketOpt]}
+                     | {receiver, Receiver}
+                     | {ipv6_host_with_brackets, boolean()},
+      StreamTo :: none | self | {self, once} | file:name_all(),
+      BodyFormat  :: string() | binary() | atom(),
+      SocketOpt :: term(),
+      Receiver :: pid()
+                  | fun((term()) -> term())
+                  | { ReceiverModule::atom()
+                    , ReceiverFunction::atom()
+                    , ReceiverArgs::list()},
+      Profile :: atom() | pid(),
+      HttpVersion :: uri_string:uri_string(),
+      Result :: {StatusLine
+                , [HttpHeader]
+                , HttpBodyResult}
+              | { StatusCode
+                , HttpBodyResult}
+              | RequestId
+              | saved_to_file,
+      StatusLine :: { HttpVersion, StatusCode, string()},
+      StatusCode  :: non_neg_integer(),
+      HttpBodyResult :: uri_string:uri_string() | binary(),
+      RequestId :: any().
 request(Method, Request, HTTPOptions, Options, Profile)
   when is_atom(Profile) orelse is_pid(Profile) ->
     WithBody = lists:member(Method, ?WITH_BODY),
@@ -174,12 +259,12 @@ do_request(Method, {Url, Headers, ContentType, Body}, HTTPOptions, Options, Prof
 	    {error, Reason};
 	ParsedUrl ->
 	    case header_parse(Headers) of
-		{error, Reason} ->
-		    {error, Reason};
-                ok ->
-                    handle_request(Method, Url,
-                                   ParsedUrl, Headers, ContentType, Body,
-                                   HTTPOptions, Options, Profile)
+            {error, Reason} ->
+                {error, Reason};
+            ok ->
+                handle_request(Method, Url,
+                               ParsedUrl, Headers, ContentType, Body,
+                               HTTPOptions, Options, Profile)
             end
     end.
 
@@ -198,39 +283,104 @@ check_request(true, _, {_URL, _Headers, ContentType, Body})
 check_request(_, _, _Request) ->
     {error, invalid_request}.
 
-%%--------------------------------------------------------------------------
-%% cancel_request(RequestId) -> ok
-%% cancel_request(RequestId, Profile) -> ok
-%%   RequestId - As returned by request/4  
-%%                                 
-%% Description: Cancels a HTTP-request.
-%%-------------------------------------------------------------------------
+%%
+%% @doc Description: Cancels a HTTP-request.
+%%
+-spec cancel_request(RequestId) -> ok when
+      RequestId :: any().
 cancel_request(RequestId) ->
     cancel_request(RequestId, default_profile()).
 
-cancel_request(RequestId, Profile) 
+%%
+%% @doc Cancels an asynchronous HTTP request. Notice that this does not
+%% guarantee that the request response is not delivered. Because it is
+%% asynchronous, the request can already have been completed when the
+%% cancellation arrives.
+%%
+-spec cancel_request(RequestId, Profile) -> ok when
+      RequestId :: any(),
+      Profile :: atom() | pid().
+cancel_request(RequestId, Profile)
   when is_atom(Profile) orelse is_pid(Profile) ->
     httpc_manager:cancel_request(RequestId, profile_name(Profile)).
    
 
-%%--------------------------------------------------------------------------
-%% set_options(Options) -> ok | {error, Reason}
-%% set_options(Options, Profile) -> ok | {error, Reason}
-%%   Options - [Option]
-%%   Profile - atom()
-%%   Option - {proxy, {Proxy, NoProxy}} | {max_sessions, MaxSessions} | 
-%%            {max_pipeline_length, MaxPipeline} | 
-%%            {pipeline_timeout, PipelineTimeout} | {cookies, CookieMode} | 
-%%            {ipfamily, IpFamily}
-%%   Proxy - {Host, Port}
-%%   NoProxy - [Domain | HostName | IPAddress]   
-%%   MaxSessions, MaxPipeline, PipelineTimeout = integer()   
-%%   CookieMode - enabled | disabled | verify
-%%   IpFamily - inet | inet6 | inet6fb4
-%% Description: Informs the httpc_manager of the new settings. 
-%%-------------------------------------------------------------------------
+%% @doc Sets options to be used for subsequent requests.
+%% @see set_options/2. Informs the httpc_manager of the new settings.
+-spec set_options(Options) -> ok | {error, Reason} when
+      Options :: [Option],
+      Option :: {proxy, {Proxy, NoProxy}}
+              | {https_proxy, {Proxy, NoProxy}}
+              | {max_sessions, MaxSessions}
+              | {max_keep_alive_length, MaxKeepAlive}
+              | {keep_alive_timeout, KeepAliveTimeout}
+              | {max_pipeline_length, MaxPipeline}
+              | {pipeline_timeout, PipelineTimeout}
+              | {cookies, CookieMode}
+              | {ipfamily, IpFamily}
+              | {ip, IpAddress}
+              | {port, Port}
+              | {socket_opts, SocketOpts}
+              | {verbose, VerboseMode}
+              | {unix_socket, UnixSocket},
+      Proxy :: {HostName, Port},
+      Port :: non_neg_integer(),
+      NoProxy :: [DomainDesc | HostName | IpAddressDesc],
+      MaxSessions :: integer(),
+      MaxKeepAlive :: integer(),
+      KeepAliveTimeout :: integer(),
+      MaxPipeline :: integer(),
+      PipelineTimeout :: integer(),
+      CookieMode :: enabled | disabled | verify,
+      IpFamily :: inet | inet6 | local | inet6fb4,
+      IpAddressDesc :: uri_string:uri_string(),
+      IpAddress :: inet:ip_address(),
+      VerboseMode :: false | verbose | debug | trace,
+      SocketOpts :: [SocketOpt],
+      SocketOpt :: term(),
+      UnixSocket :: file:name_all(),
+      Reason :: term(),
+      DomainDesc :: string(),
+      HostName :: uri_string:uri_string().
 set_options(Options) ->
     set_options(Options, default_profile()).
+
+%% @doc Sets options to be used for subsequent requests.
+-spec set_options(Options, Profile) -> ok | {error, Reason} when
+      Options :: [Option],
+      Option :: {proxy, {Proxy, NoProxy}}
+              | {https_proxy, {Proxy, NoProxy}}
+              | {max_sessions, MaxSessions}
+              | {max_keep_alive_length, MaxKeepAlive}
+              | {keep_alive_timeout, KeepAliveTimeout}
+              | {max_pipeline_length, MaxPipeline}
+              | {pipeline_timeout, PipelineTimeout}
+              | {cookies, CookieMode}
+              | {ipfamily, IpFamily}
+              | {ip, IpAddress}
+              | {port, Port}
+              | {socket_opts, [SocketOpt]}
+              | {verbose, VerboseMode}
+              | {unix_socket, UnixSocket},
+      Profile :: atom() | pid(),
+      SocketOpt :: term(),
+      Proxy :: {HostName, Port},
+      Port :: non_neg_integer(),
+      NoProxy :: [DomainDesc | HostName | IpAddressDesc],
+      MaxSessions :: integer(),
+      MaxKeepAlive :: integer(),
+      KeepAliveTimeout :: integer(),
+      MaxPipeline :: integer(),
+      PipelineTimeout :: integer(),
+      CookieMode :: enabled | disabled | verify,
+      IpFamily :: inet | inet6 | local | inet6fb4,
+      IpAddressDesc :: uri_string:uri_string(),
+      IpAddress :: inet:ip_address(),
+      VerboseMode :: false | verbose | debug | trace,
+      UnixSocket :: string(),
+      Reason :: term(),
+      DomainDesc :: string(),
+      HostName :: uri_string:uri_string().
 set_options(Options, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
     case validate_options(Options) of
 	{ok, Opts} ->
@@ -239,33 +389,43 @@ set_options(Options, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
 	    {error, Reason}
     end.
 
+-spec set_option(atom(), term()) -> ok | {error, term()}.
 set_option(Key, Value) ->
     set_option(Key, Value, default_profile()).
 
+-spec set_option(atom(), term(), atom()) -> ok | {error, term()}.
 set_option(Key, Value, Profile) ->
     set_options([{Key, Value}], Profile).
 
 
-%%--------------------------------------------------------------------------
-%% get_options(OptionItems) -> {ok, Values} | {error, Reason}
-%% get_options(OptionItems, Profile) -> {ok, Values} | {error, Reason}
-%%   OptionItems   - all | [option_item()]
-%%   option_item() - proxy | pipeline_timeout | max_pipeline_length | 
-%%                   keep_alive_timeout | max_keep_alive_length | 
-%%                   max_sessions | verbose | 
-%%                   cookies | ipfamily | ip | port | socket_opts
-%%   Profile       - atom()
-%%   Values - [{option_item(), term()}]
-%%   Reason - term()
-%% Description: Retrieves the current options. 
-%%-------------------------------------------------------------------------
-
+-spec get_options() -> term().
 get_options() ->
     record_info(fields, options).
 
+%%
+%% @doc Retrieves the options currently used by the client.
+%%
+-spec get_options(OptionItems) -> {ok, Values} | {error, Reason} when
+      OptionItems :: all | [OptionItem],
+      OptionItem :: proxy | https_proxy | max_sessions | keep_alive_timeout
+                  | max_keep_alive_length | pipeline_timeout | max_pipeline_length | cookies
+                  | ipfamily | ip | port | socket_opts | verbose | unix_socket,
+      Values :: [{OptionItem, term()}],
+      Reason :: term().
 get_options(Options) ->
     get_options(Options, default_profile()).
 
+%%
+%% @doc Retrieves the options currently used by the client.
+%%
+-spec get_options(OptionItems, Profile) -> {ok, Values} | {error, Reason} when
+      OptionItems :: all | [OptionItem],
+      OptionItem :: proxy | https_proxy | max_sessions | keep_alive_timeout
+                  | max_keep_alive_length | pipeline_timeout | max_pipeline_length | cookies
+                  | ipfamily | ip | port | socket_opts | verbose | unix_socket,
+      Values :: [{OptionItem, term()}],
+      Profile :: atom() | pid(),
+      Reason :: term().
 get_options(all = _Options, Profile) ->
     get_options(get_options(), Profile);
 get_options(Options, Profile) 
@@ -300,11 +460,12 @@ get_option(Key, Profile) ->
 %%--------------------------------------------------------------------------
 %% Default client ssl options to verify server
 %%
-%%  UseWildcard=true  does wildcard matching on the hostname check
+%%  WildcardHostName=true  does wildcard matching on the hostname check
 %%--------------------------------------------------------------------------
--spec ssl_verify_host_options(UseWildCard::boolean()) -> list().
-ssl_verify_host_options(UseWildCard) ->
-    WildCard = case UseWildCard of
+-spec ssl_verify_host_options(WildcardHostName) -> list() when
+      WildcardHostName :: boolean().
+ssl_verify_host_options(WildcardHostName) ->
+    WildCard = case WildcardHostName of
                    true ->
                        Fun = public_key:pkix_verify_hostname_match_fun(https),
                        [{customize_hostname_check,[{match_fun, Fun}]}];
@@ -313,18 +474,25 @@ ssl_verify_host_options(UseWildCard) ->
                end,
     [{verify, verify_peer}, {cacerts, public_key:cacerts_get()} | WildCard].
 
-%%--------------------------------------------------------------------------
-%% store_cookies(SetCookieHeaders, Url [, Profile]) -> ok | {error, reason} 
-%%   
-%%                                 
-%% Description: Store the cookies from <SetCookieHeaders> 
-%%              in the cookie database
-%% for the profile <Profile>. This function shall be used when the option
-%% cookies is set to verify.
-%%-------------------------------------------------------------------------
+
+-spec store_cookies(SetCookieHeaders, Url) -> ok | {error, Reason} when
+      SetCookieHeaders :: [HttpHeader],
+      HttpHeader       :: { Field :: [byte()], Value :: binary() | iolist()},
+      Url              :: term(),
+      Reason           :: term().
 store_cookies(SetCookieHeaders, Url) ->
     store_cookies(SetCookieHeaders, Url, default_profile()).
 
+%%
+%% @doc Saves the cookies defined in `SetCookieHeaders; in the client profile
+%% cookie database. Call this function if option `cookies' is set to `verify'. If no
+%% profile is specified, the default profile is used.
+-spec store_cookies(SetCookieHeaders, Url, Profile) -> ok | {error, Reason} when
+      SetCookieHeaders :: [HttpHeader],
+      HttpHeader       :: { Field :: [byte()], Value :: binary() | iolist()},
+      Url              :: term(),
+      Profile          :: atom() | pid(),
+      Reason           :: term().
 store_cookies(SetCookieHeaders, Url, Profile) 
   when is_atom(Profile) orelse is_pid(Profile) ->
     case normalize_and_parse_url(Url) of
@@ -350,23 +518,40 @@ default_port(http) ->
 default_port(https) ->
     443.
 
-%%--------------------------------------------------------------------------
-%% cookie_header(Url) -> Header | {error, Reason}
-%% cookie_header(Url, Profile) -> Header | {error, Reason}
-%% cookie_header(Url, Opts,  Profile) -> Header | {error, Reason}
-%% 
-%% Description: Returns the cookie header that would be sent when making
-%% a request to <Url>.
-%%-------------------------------------------------------------------------
+
+-spec cookie_header(Url) -> [HttpHeader] | {error, Reason} when
+      Url        :: uri_string:uri_string(),
+      HttpHeader :: { Field :: [byte()], Value :: binary() | iolist()},
+      Reason     :: term().
 cookie_header(Url) ->
     cookie_header(Url, default_profile()).
 
+-spec cookie_header(Url, ProfileOrOpts) -> [HttpHeader] | {error, Reason} when
+      Url        :: uri_string:uri_string(),
+      HttpHeader :: { Field :: [byte()], Value :: binary() | iolist()},
+      ProfileOrOpts :: Profile | Opts,
+      Profile    :: atom() | pid(),
+      Opts       :: [CookieHeaderOpt],
+      CookieHeaderOpt :: {ipv6_host_with_brackets, boolean()},
+      Reason     :: term().
 cookie_header(Url, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
     cookie_header(Url, [], Profile);
 cookie_header(Url, Opts) when is_list(Opts) ->
     cookie_header(Url, Opts, default_profile()).
 
-cookie_header(Url, Opts, Profile) 
+%%
+%% @doc Returns the cookie header that would have been sent when making a
+%% request to Url using profile Profile. If no profile is specified, the default
+%% profile is used.
+%%
+-spec cookie_header(Url, Opts, Profile) -> [HttpHeader] | {error, Reason} when
+      Url        :: uri_string:uri_string(),
+      HttpHeader :: { Field :: [byte()], Value :: binary() | iolist()},
+      Profile    :: atom() | pid(),
+      Opts       :: [CookieHeaderOpt],
+      CookieHeaderOpt :: {ipv6_host_with_brackets, boolean()},
+      Reason     :: term().
+cookie_header(Url, Opts, Profile)
   when (is_list(Opts) andalso (is_atom(Profile) orelse is_pid(Profile))) ->
     try 
 	begin
@@ -378,15 +563,21 @@ cookie_header(Url, Opts, Profile)
     end.
     
 
-%%--------------------------------------------------------------------------
-%% which_cookies() -> [cookie()]
-%% which_cookies(Profile) -> [cookie()]
-%%               
-%% Description: Debug function, dumping the cookie database
-%%-------------------------------------------------------------------------
+-spec which_cookies() -> [CookieStores] when
+      CookieStores :: {cookies, Cookies} | {session_cookies, Cookies},
+      Cookies :: [term()].
 which_cookies() ->
     which_cookies(default_profile()).
 
+%%
+%% @doc Produces a list of the entire cookie database. Intended for
+%% debugging/testing purposes. If no profile is specified, the default profile
+%% is used.
+%%
+-spec which_cookies(Profile) -> [CookieStores] when
+      Profile :: atom() | pid(),
+      CookieStores :: {cookies, Cookies} | {session_cookies, Cookies},
+      Cookies :: [term()].
 which_cookies(Profile) ->
     ?hcrt("which cookies", [{profile, Profile}]),
     try 
@@ -399,16 +590,31 @@ which_cookies(Profile) ->
     end.
 
 
-%%--------------------------------------------------------------------------
-%% which_sessions() -> {GoodSession, BadSessions, NonSessions}
-%% which_sessions(Profile) -> {GoodSession, BadSessions, NonSessions}
-%%               
-%% Description: Debug function, dumping the sessions database, sorted 
-%%              into three groups (Good-, Bad- and Non-sessions).
-%%-------------------------------------------------------------------------
+-spec which_sessions() -> SessionInfo when
+      SessionInfo :: {GoodSession, BadSessions, NonSessions},
+      GoodSession :: [Session],
+      BadSessions :: [term()],
+      NonSessions :: [term()],
+      Session :: term().
 which_sessions() ->
     which_sessions(default_profile()).
 
+%%
+%% @doc This function is intended for debugging only. It produces a slightly
+%% processed dump of the session database. The first list of the session
+%% information tuple will contain session information on an internal format. The
+%% last two lists of the session information tuple should always be empty if the
+%% code is working as intended. If no profile is specified, the default profile
+%% is used. The dumped sessions database is sorted into three groups
+%% (Good-, Bad- and Non-sessions).
+%%
+-spec which_sessions(Profile) -> SessionInfo when
+      Profile :: atom() | pid(),
+      SessionInfo :: {GoodSession, BadSessions, NonSessions},
+      GoodSession :: [Session],
+      BadSessions :: [term()],
+      NonSessions :: [term()],
+      Session :: term().
 which_sessions(Profile) ->
     try 
 	begin
@@ -420,15 +626,23 @@ which_sessions(Profile) ->
     end.
 
 
-%%--------------------------------------------------------------------------
-%% info() -> list()
-%% info(Profile) -> list()
-%%               
-%% Description: Debug function, retrieve info about the profile
-%%-------------------------------------------------------------------------
+
+%%
+%% @doc Produces a list of miscellaneous information. Intended for debugging. If
+%% no profile is specified, the default profile is used.
+%%
+-spec info() -> list() | {error, Reason} when
+      Reason :: term().
 info() ->
     info(default_profile()).
 
+%%
+%% @doc Produces a list of miscellaneous information. Intended for debugging. If
+%% no profile is specified, the default profile is used.
+%%
+-spec info(Profile) -> list() | {error, Reason} when
+      Reason :: term(),
+      Profile :: atom() | pid().
 info(Profile) ->
     try 
 	begin
@@ -440,15 +654,21 @@ info(Profile) ->
     end.
 
 
-%%--------------------------------------------------------------------------
-%% reset_cookies() -> void()
-%% reset_cookies(Profile) -> void()
-%%               
-%% Description: Debug function, reset the cookie database
-%%-------------------------------------------------------------------------
+%%
+%% @doc Debug function. Resets (clears) the cookie database for the default profile
+%%
+-spec reset_cookies() -> Void when
+      Void :: term().
 reset_cookies() ->
     reset_cookies(default_profile()).
 
+%%
+%% @doc Debug function. Resets (clears) the cookie database for the specified
+%% `Profile'. If no profile is specified the default profile is used.
+%%
+-spec reset_cookies(Profile) -> Void when
+      Profile :: atom() | pid(),
+      Void :: term().
 reset_cookies(Profile) ->
     try 
 	begin
@@ -460,12 +680,12 @@ reset_cookies(Profile) ->
     end.
 
 
-%%--------------------------------------------------------------------------
-%% stream_next(Pid) -> Header | {error, Reason}
-%%               
-%% Description: Triggers the next message to be streamed, e.i. 
-%%              same behavior as active once for sockets.
-%%-------------------------------------------------------------------------
+%%
+%% @doc Triggers the next message to be streamed, that is, the same behavior as
+%% active ones for sockets.
+%%
+-spec stream_next(Pid) -> ok when
+      Pid :: pid().
 stream_next(Pid) ->
     httpc_handler:stream_next(Pid).
 
@@ -514,6 +734,10 @@ service_info(Pid) ->
 %%%========================================================================
 %%% Internal functions
 %%%========================================================================
+-spec normalize_and_parse_url(Characters) -> NormalizedURI when
+      Characters    :: uri_string:uri_string(),
+      NormalizedURI :: uri_string:uri_string() | uri_string:uri_map()
+                     | uri_string:error().
 normalize_and_parse_url(Url) ->
     uri_string:normalize(unicode:characters_to_list(Url), [return_map]).
 
@@ -667,6 +891,25 @@ maybe_format_body(BinBody, Options) ->
 	    BinBody
     end.
 
+-spec headers_as_is(HeaderRequest, OptionsRequest) -> HeaderRequest when
+      HeaderRequest :: [{list(), list() | binary()}] | [tuple()],
+      OptionsRequest :: [OptionRequest],
+      OptionRequest :: {sync, boolean()}
+                        | {stream, StreamTo}
+                        | {body_format, BodyFormat}
+                        | {full_result, boolean()}
+                        | {headers_as_is, boolean()}
+                        | {socket_opts, [SocketOpt]}
+                        | {receiver, Receiver}
+                        | {ipv6_host_with_brackets, boolean()},
+      BodyFormat  :: string() | binary() | atom(),
+      StreamTo :: none | self | {self, once} | file:name_all(),
+      SocketOpt :: term(),
+      Receiver :: pid()
+                  | fun((term()) -> term())
+                  | { ReceiverModule::atom()
+                    , ReceiverFunction::atom()
+                    , ReceiverArgs::list()}.
 %% This options is a workaround for http servers that do not follow the 
 %% http standard and have case sensitive header parsing. Should only be
 %% used if there is no other way to communicate with the server or for
@@ -678,7 +921,6 @@ headers_as_is(Headers, Options) ->
 	 true  ->
 	     Headers
      end.
-
 
 http_options(HttpOptions) ->
     HttpOptionsDefault = http_options_default(),
@@ -720,7 +962,7 @@ http_options([{Tag, Default, Idx, Post} | Defaults], HttpOptions, Acc) ->
 	    Acc2 = setelement(Idx, Acc, DefaultVal),
 	    http_options(Defaults, HttpOptions, Acc2)
     end.
-		    
+
 http_options_default() ->
     VersionPost = 
 	fun(Value) when is_atom(Value) ->
@@ -778,6 +1020,7 @@ http_options_default() ->
      {connect_timeout, {field, #http_options.timeout}, #http_options.connect_timeout, ConnTimeoutPost}
     ].
 
+-spec boolfun() -> fun(((true | false)) -> {ok, true | false}) | fun((term()) -> error).
 boolfun() ->
     fun(Value) when (Value =:= true) orelse
 		    (Value =:= false) ->
@@ -888,6 +1131,23 @@ request_options([{Key, DefaultVal, Verify} | Defaults], Options, Acc) ->
 	    request_options(Defaults, Options, [{Key, DefaultVal} | Acc])
     end.
 
+-spec request_options_sanity_check([OptionRequest]) -> ok | no_return() when
+      OptionRequest :: {sync, boolean()}
+                     | {stream, StreamTo}
+                     | {body_format, BodyFormat}
+                     | {full_result, boolean()}
+                     | {headers_as_is, boolean()}
+                     | {socket_opts, [SocketOpt]}
+                     | {receiver, Receiver}
+                     | {ipv6_host_with_brackets, boolean()},
+      StreamTo :: none | self | {self, once} | file:name_all(),
+      BodyFormat  :: string() | binary() | atom(),
+      SocketOpt :: term(),
+      Receiver :: pid()
+                  | fun((term()) -> term())
+                  | { ReceiverModule::atom()
+                    , ReceiverFunction::atom()
+                    , ReceiverArgs::list()}.
 request_options_sanity_check(Opts) ->
     case proplists:get_value(sync, Opts) of
 	Sync when (Sync =:= true) ->
@@ -927,7 +1187,6 @@ validate_ipfamily_unix_socket(IpFamily, UnixSocket, Options, Acc) ->
     validate_ipfamily(IpFamily),
     validate_unix_socket(UnixSocket),
     {Options, Acc}.
-
 
 validate_options(Options0) ->
     try
@@ -1007,7 +1266,7 @@ validate_options([{_, _} = Opt| _], _Acc) ->
     {error, {not_an_option, Opt}}.
 
 
-validate_proxy({{ProxyHost, ProxyPort}, NoProxy} = Proxy) 
+validate_proxy({{ProxyHost, ProxyPort}, NoProxy} = Proxy)
   when is_list(ProxyHost) andalso 
        is_integer(ProxyPort) andalso 
        is_list(NoProxy) ->
@@ -1265,11 +1524,13 @@ validate_headers(RequestHeaders = #http_request_h{host = undefined},
 validate_headers(RequestHeaders, _, _) ->
     RequestHeaders.
 
-
 %%--------------------------------------------------------------------------
 %% These functions are just simple wrappers to parse specifically HTTP URIs
 %%--------------------------------------------------------------------------
 
+-spec header_parse(HeaderRequest) -> ok | InvalidHeaderParsed when
+      HeaderRequest       :: [{list(), list() | binary()}] | [tuple()],
+      InvalidHeaderParsed :: {error, {headers_error, invalid_field | invalid_value}}.
 header_parse([]) ->
     ok;
 header_parse([{Field, Value}|T])

--- a/lib/inets/src/http_lib/http_transport.erl
+++ b/lib/inets/src/http_lib/http_transport.erl
@@ -199,9 +199,22 @@ get_socket_info(Addr, Port, Fd, BaseOpts) ->
 %% Description: Accepts an incoming connection request on a listen socket,
 %% using either gen_tcp or ssl.
 %%-------------------------------------------------------------------------
+-spec accept(SocketType, ListenSocket) -> {ok, Socket} | {error, Reason} when
+      SocketType   :: ip_comm | {ssl, SSLConfig},
+      SSLConfig    :: term(),
+      ListenSocket :: gen_tcp:socket(),
+      Socket       :: gen_tcp:socket(),
+      Reason       :: term().
 accept(SocketType, ListenSocket) ->
     accept(SocketType, ListenSocket, infinity).
 
+-spec accept(SocketType, ListenSocket, Timeout) -> {ok, Socket} | {error, Reason} when
+      SocketType   :: ip_comm | {ssl | essl, SSLConfig},
+      SSLConfig    :: term(),
+      Timeout      :: timeout(),
+      ListenSocket :: gen_tcp:socket(),
+      Socket       :: gen_tcp:socket(),
+      Reason       :: term().
 accept(ip_comm, ListenSocket, Timeout) ->
     gen_tcp:accept(ListenSocket, Timeout);
 accept({ip_comm, _}, ListenSocket, Timeout) ->
@@ -216,13 +229,14 @@ accept({essl, _SSLConfig}, ListenSocket, Timeout) ->
 
 
 %%-------------------------------------------------------------------------
-%% controlling_process(SocketType, Socket, NewOwner) -> ok | {error, Reason}
-%%   SocketType = ip_comm | {ssl, _}  
-%%   Socket = socket()        
-%%   NewOwner = pid()
-%%                                
-%% Description: Assigns a new controlling process to Socket. 
+%% Description: Assigns a new controlling process to Socket.
 %%-------------------------------------------------------------------------
+-spec controlling_process(SocketType, Socket, NewOwner) -> Object when
+      SocketType :: ip_comm | {ip_comm | ssl | essl, _SSLConfig},
+      Socket     :: gen_tcp:socket(),
+      NewOwner   :: pid(),
+      Object     :: ok | {error, Reason},
+      Reason     :: closed | not_owner | badarg | inet:posix().
 controlling_process(ip_comm, Socket, NewOwner) ->
     gen_tcp:controlling_process(Socket, NewOwner);
 controlling_process({ip_comm, _}, Socket, NewOwner) ->
@@ -237,13 +251,13 @@ controlling_process({essl, _}, Socket, NewOwner) ->
 
 
 %%-------------------------------------------------------------------------
-%% setopts(SocketType, Socket, Options) -> ok | {error, Reason}
-%%     SocketType = ip_comm | {ssl, _}
-%%     Socket = socket()
-%%     Options = list()                              
 %% Description: Sets one or more options for a socket, using either
 %% gen_tcp or ssl.
 %%-------------------------------------------------------------------------
+-spec setopts(SocketType, Socket, Options) -> ok | {error, inet:posix()} when
+      SocketType :: ip_comm | {ip_comm | ssl | essl, _SSLConfig},
+      Socket     :: inet:socket() | ssl:sslsocket(),
+      Options    :: [inet:socket_setopt()] |  [gen_tcp:option()].
 setopts(ip_comm, Socket, Options) ->
     inet:setopts(Socket, Options);
 setopts({ip_comm, _}, Socket, Options) ->
@@ -258,16 +272,21 @@ setopts({essl, _}, Socket, Options) ->
 
 
 %%-------------------------------------------------------------------------
-%% getopts(SocketType, Socket [, Opts]) -> ok | {error, Reason}
-%%     SocketType = ip_comm | {ssl, _}
-%%     Socket = socket()
-%%     Opts   = socket_options()
-%% Description: Gets the values for some options. 
+%% Description: Gets the values for some options.
 %%-------------------------------------------------------------------------
+-spec getopts(SocketType, Socket) -> Object when
+      SocketType :: ip_comm | {ip_comm | ssl | essl, _SSLConfig},
+      Socket     :: ssl:sslsocket() | inet:socket(),
+      Object     :: [gen_tcp:option()] | [inet:socket_setopt() | gen_tcp:pktoptions_value()] | [].
 getopts(SocketType, Socket) ->
     Opts = [packet, packet_size, recbuf, sndbuf, priority, tos, send_timeout], 
     getopts(SocketType, Socket, Opts).
 
+-spec getopts(SocketType, Socket, Options) -> Object when
+      SocketType :: ip_comm | {ip_comm | ssl | essl, _SSLConfig},
+      Socket     :: ssl:sslsocket() | inet:socket(),
+      Options    :: [gen_tcp:option_name()],
+      Object     :: [gen_tcp:option()] | [inet:socket_setopt() | gen_tcp:pktoptions_value()] | [].
 getopts({ip_comm, _}, Socket, Options) ->
     getopts(ip_comm, Socket, Options);
 
@@ -286,6 +305,10 @@ getopts({ssl, SSLConfig}, Socket, Options) ->
 getopts({essl, _}, Socket, Options) ->
     getopts_ssl(Socket, Options).
 
+-spec getopts_ssl(SslSocket, Options) ->
+		     [gen_tcp:option()] | [] when
+      SslSocket :: ssl:sslsocket(),
+      Options :: [gen_tcp:option_name()].
 getopts_ssl(Socket, Options) ->
     case ssl:getopts(Socket, Options) of
 	{ok, SocketOpts} ->

--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -23,7 +23,6 @@
 
 -behaviour(inets_service).
 
--include("httpd.hrl").
 -include("httpd_internal.hrl").
 
 %% Behavior callbacks
@@ -52,9 +51,18 @@
 %%% API
 %%%========================================================================
 
+-spec parse_query(QueryString) -> QueryList | uri_string:error() when
+      QueryString :: string(),
+      QueryList :: [{unicode:chardata(), unicode:chardata() | true}].
 parse_query(String) ->
     uri_string:dissect_query(String).
 
+-spec reload_config(Config, Mode) -> ok | {error, Reason} | no_return() when
+      Config :: file:name_all() | [{Option, Value}],
+      Mode   :: non_disturbing | disturbing | blocked,
+      Option :: atom(),
+      Value  :: term(),
+      Reason :: term().
 reload_config(Config = [Value| _], Mode) when is_tuple(Value) ->
     do_reload_config(Config, Mode);
 reload_config(ConfigFile, Mode) ->
@@ -67,10 +75,121 @@ reload_config(ConfigFile, Mode) ->
             throw({error, {could_not_consult_proplist_file, ConfigFile}})
     end.
 
-
+-spec info(Pid) -> HttpInformation when
+      Pid :: pid(),
+      Path :: file:name_all(),
+      HttpInformation :: [CommonOption]
+                       | [CommunicationOption]
+                       | [ModOption]
+                       | [LimitOption]
+                       | [AdminOption],
+      CommonOption :: {port, non_neg_integer()}
+                | {server_name, string()}
+                | {server_root, Path}
+                | {document_root, Path},
+      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
+        | {profile, atom()}
+        | { socket_type,
+            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
+        | {ipfamily, inet | inet6}
+        | {minimum_bytes_per_second, integer()},
+      ModOption :: {modules, atom()},
+      LimitOption :: {customize, atom()}
+                   | {disable_chunked_transfer_encoding_send, boolean()}
+                   | {keep_alive, boolean()}
+                   | {keep_alive_timeout, integer()}
+                   | {max_body_size, integer()}
+                   | {max_clients, integer()}
+                   | {max_header_size, integer()}
+                   | {max_content_length, integer()}
+                   | {max_uri_size, integer()}
+                   | {max_keep_alive_request, integer()}
+                   | {max_client_body_chunk, integer()},
+      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
+                   | {mime_type, string()}
+                   | {server_admin, string()}
+                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
+                   | {logger, Options::list()}
+                   | {log_format, common | combined}
+                   | {error_log_format, pretty | compact}.
 info(Pid) when is_pid(Pid) ->
     info(Pid, []).
 
+-spec info(Pid, HttpInformation) -> HttpInformation  when
+      Pid     :: pid(),
+      Path :: file:name_all(),
+      HttpInformation :: [CommonOption]
+                       | [CommunicationOption]
+                       | [ModOption]
+                       | [LimitOption]
+                       | [AdminOption],
+      CommonOption :: {port, non_neg_integer()}
+                | {server_name, string()}
+                | {server_root, Path}
+                | {document_root, Path},
+      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
+        | {profile, atom()}
+        | { socket_type,
+            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
+        | {ipfamily, inet | inet6}
+        | {minimum_bytes_per_second, integer()},
+      ModOption :: {modules, atom()},
+      LimitOption :: {customize, atom()}
+                   | {disable_chunked_transfer_encoding_send, boolean()}
+                   | {keep_alive, boolean()}
+                   | {keep_alive_timeout, integer()}
+                   | {max_body_size, integer()}
+                   | {max_clients, integer()}
+                   | {max_header_size, integer()}
+                   | {max_content_length, integer()}
+                   | {max_uri_size, integer()}
+                   | {max_keep_alive_request, integer()}
+                   | {max_client_body_chunk, integer()},
+      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
+                   | {mime_type, string()}
+                   | {server_admin, string()}
+                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
+                   | {logger, Options::list()}
+                   | {log_format, common | combined}
+                   | {error_log_format, pretty | compact};
+          (Address, Port) -> HttpInformation when
+      Address :: inet:ip_address(),
+      Port    :: integer(),
+      Path :: file:name_all(),
+      HttpInformation :: [CommonOption]
+                       | [CommunicationOption]
+                       | [ModOption]
+                       | [LimitOption]
+                       | [AdminOption],
+      CommonOption :: {port, non_neg_integer()}
+                | {server_name, string()}
+                | {server_root, Path}
+                | {document_root, Path},
+      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
+        | {profile, atom()}
+        | { socket_type,
+            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
+        | {ipfamily, inet | inet6}
+        | {minimum_bytes_per_second, integer()},
+      ModOption :: {modules, atom()},
+      LimitOption :: {customize, atom()}
+                   | {disable_chunked_transfer_encoding_send, boolean()}
+                   | {keep_alive, boolean()}
+                   | {keep_alive_timeout, integer()}
+                   | {max_body_size, integer()}
+                   | {max_clients, integer()}
+                   | {max_header_size, integer()}
+                   | {max_content_length, integer()}
+                   | {max_uri_size, integer()}
+                   | {max_keep_alive_request, integer()}
+                   | {max_client_body_chunk, integer()},
+      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
+                   | {mime_type, string()}
+                   | {server_admin, string()}
+                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
+                   | {logger, Options::list()}
+                   | {log_format, common | combined}
+                   | {error_log_format, pretty | compact}.
 info(Pid, Properties) when is_pid(Pid) andalso is_list(Properties) ->
     {ok, ServiceInfo} = service_info(Pid), 
     Address = proplists:get_value(bind_address, ServiceInfo),
@@ -83,17 +202,135 @@ info(Pid, Properties) when is_pid(Pid) andalso is_list(Properties) ->
 	    info(Address, Port, Profile, Properties)
     end; 
 
-info(Address, Port) when is_integer(Port) ->    
+info(Address, Port) when is_integer(Port) ->
     info(Address, Port, default).
 
-info(Address, Port, Profile) when is_integer(Port), is_atom(Profile) ->    
+-spec info(Address, Port, Profile) -> HttpInformation when
+      Address :: inet:ip_address() | any,
+      Port    :: integer(),
+      Profile :: atom(),
+      Path :: file:name_all(),
+      HttpInformation :: [CommonOption]
+                       | [CommunicationOption]
+                       | [ModOption]
+                       | [LimitOption]
+                       | [AdminOption],
+      CommonOption :: {port, non_neg_integer()}
+                | {server_name, string()}
+                | {server_root, Path}
+                | {document_root, Path},
+      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
+        | {profile, atom()}
+        | { socket_type,
+            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
+        | {ipfamily, inet | inet6}
+        | {minimum_bytes_per_second, integer()},
+      ModOption :: {modules, atom()},
+      LimitOption :: {customize, atom()}
+                   | {disable_chunked_transfer_encoding_send, boolean()}
+                   | {keep_alive, boolean()}
+                   | {keep_alive_timeout, integer()}
+                   | {max_body_size, integer()}
+                   | {max_clients, integer()}
+                   | {max_header_size, integer()}
+                   | {max_content_length, integer()}
+                   | {max_uri_size, integer()}
+                   | {max_keep_alive_request, integer()}
+                   | {max_client_body_chunk, integer()},
+      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
+                   | {mime_type, string()}
+                   | {server_admin, string()}
+                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
+                   | {logger, Options::list()}
+                   | {log_format, common | combined}
+                   | {error_log_format, pretty | compact};
+          (Address, Port, Properties) -> HttpInformation when
+      Address :: inet:ip_address() | any,
+      Port    :: integer(),
+      Properties :: [atom()],
+      Path :: file:name_all(),
+      HttpInformation :: [CommonOption]
+                       | [CommunicationOption]
+                       | [ModOption]
+                       | [LimitOption]
+                       | [AdminOption],
+      CommonOption :: {port, non_neg_integer()}
+                | {server_name, string()}
+                | {server_root, Path}
+                | {document_root, Path},
+      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
+        | {profile, atom()}
+        | { socket_type,
+            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
+        | {ipfamily, inet | inet6}
+        | {minimum_bytes_per_second, integer()},
+      ModOption :: {modules, atom()},
+      LimitOption :: {customize, atom()}
+                   | {disable_chunked_transfer_encoding_send, boolean()}
+                   | {keep_alive, boolean()}
+                   | {keep_alive_timeout, integer()}
+                   | {max_body_size, integer()}
+                   | {max_clients, integer()}
+                   | {max_header_size, integer()}
+                   | {max_content_length, integer()}
+                   | {max_uri_size, integer()}
+                   | {max_keep_alive_request, integer()}
+                   | {max_client_body_chunk, integer()},
+      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
+                   | {mime_type, string()}
+                   | {server_admin, string()}
+                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
+                   | {logger, Options::list()}
+                   | {log_format, common | combined}
+                   | {error_log_format, pretty | compact}.
+info(Address, Port, Profile) when is_integer(Port), is_atom(Profile) ->
     httpd_conf:get_config(Address, Port, Profile);
 
 info(Address, Port, Properties) when is_integer(Port) andalso 
 				     is_list(Properties) ->    
     httpd_conf:get_config(Address, Port, default, Properties).
 
-info(Address, Port, Profile, Properties) when is_integer(Port) andalso 
+-spec info(Address, Port, Profile, Properties) -> HttpInformation when
+      Address :: inet:ip_address() | any,
+      Port    :: integer(),
+      Profile :: atom(),
+      Properties :: [atom()],
+      Path :: file:name_all(),
+      HttpInformation :: [CommonOption]
+                       | [CommunicationOption]
+                       | [ModOption]
+                       | [LimitOption]
+                       | [AdminOption],
+      CommonOption :: {port, non_neg_integer()}
+                | {server_name, string()}
+                | {server_root, Path}
+                | {document_root, Path},
+      CommunicationOption :: {bind_address, inet:ip_address() | inet:hostname() | any}
+        | {profile, atom()}
+        | { socket_type,
+            ip_comm | {ip_comm, ssl:tls_option() | gen_tcp:option()} | {ssl, ssl:tls_option() | gen_tcp:option()}}
+        | {ipfamily, inet | inet6}
+        | {minimum_bytes_per_second, integer()},
+      ModOption :: {modules, atom()},
+      LimitOption :: {customize, atom()}
+                   | {disable_chunked_transfer_encoding_send, boolean()}
+                   | {keep_alive, boolean()}
+                   | {keep_alive_timeout, integer()}
+                   | {max_body_size, integer()}
+                   | {max_clients, integer()}
+                   | {max_header_size, integer()}
+                   | {max_content_length, integer()}
+                   | {max_uri_size, integer()}
+                   | {max_keep_alive_request, integer()}
+                   | {max_client_body_chunk, integer()},
+      AdminOption :: {mime_types, [{MimeType :: string(), Extension :: string()}] | Path}
+                   | {mime_type, string()}
+                   | {server_admin, string()}
+                   | {server_tokens, none|prod|major|minor|minimal|os|full|{private, string()}}
+                   | {logger, Options::list()}
+                   | {log_format, common | combined}
+                   | {error_log_format, pretty | compact}.
+info(Address, Port, Profile, Properties) when is_integer(Port) andalso
 					      is_atom(Profile) andalso is_list(Properties) ->    
     httpd_conf:get_config(Address, Port, Profile, Properties).
 
@@ -102,11 +339,23 @@ info(Address, Port, Profile, Properties) when is_integer(Port) andalso
 %%% Behavior callbacks
 %%%========================================================================
 
-start_standalone(Config) ->
+start_standalone(Config0) ->
+    Config = httpd_ssl_wrapper(Config0),
     httpd_sup:start_link([{httpd, Config}], stand_alone).
 
-start_service(Conf) ->
-    httpd_sup:start_child(Conf).
+start_service(Config0) ->
+    Config = httpd_ssl_wrapper(Config0),
+    httpd_sup:start_child(Config).
+
+httpd_ssl_wrapper(Config0) ->
+    case proplists:get_value(socket_type, Config0) of
+        {essl, Value} ->
+            lists:keyreplace(socket_type, 1, Config0, {socket_type, {ssl, Value}});
+        {ssl, Value} ->
+            lists:keyreplace(socket_type, 1, Config0, {socket_type, {essl, Value}});
+        _ -> Config0
+    end.
+
 
 stop_service({Address, Port}) ->
     stop_service({Address, Port, ?DEFAULT_PROFILE});
@@ -156,6 +405,13 @@ child_name(Pid, [{Name, Pid} | _]) ->
 child_name(Pid, [_ | Children]) ->
     child_name(Pid, Children).
 
+-spec child_name2info(undefined | HTTPSup) -> Object when
+      HTTPSup :: {httpd_instance_sup, any, Port, Profile}
+               | {httpd_instance_sup, Address, Port, Profile},
+      Port    :: integer(),
+      Address :: inet:ip_address() | any,
+      Profile :: atom(),
+      Object  :: {error, no_such_service} | {ok, [tuple()]}.
 child_name2info(undefined) ->
     {error, no_such_service};
 child_name2info({httpd_instance_sup, any, Port, Profile}) ->

--- a/lib/inets/src/http_server/httpd_conf.erl
+++ b/lib/inets/src/http_server/httpd_conf.erl
@@ -506,25 +506,46 @@ remove(ConfigDB) ->
     ets:delete(ConfigDB),
     ok.
 
-
+-spec get_config(Address, Port, Profile) -> [tuple()] when
+      Address :: inet:ip_address() | any,
+      Port    :: integer(),
+      Profile :: atom().
 get_config(Address, Port, Profile) ->    
     Tab = httpd_util:make_name("httpd_conf", Address, Port, Profile),
     Properties =  ets:tab2list(Tab),
     MimeTab = proplists:get_value(mime_types, Properties),
     NewProperties = proplists:delete(mime_types, Properties),
     [{mime_types, ets:tab2list(MimeTab)} | NewProperties].
-     
+
+-spec get_config(Address, Port, Profile, Properties) -> [tuple()] when
+      Address :: inet:ip_address() | any,
+      Port    :: integer(),
+      Profile :: atom(),
+      Properties :: [tuple() | atom()].
 get_config(Address, Port, Profile, Properties) ->    
     Tab = httpd_util:make_name("httpd_conf", Address, Port, Profile),
     Config = 
 	lists:map(fun(Prop) -> {Prop, httpd_util:lookup(Tab, Prop)} end,
 		  Properties),
-    [{Proporty, Value} || {Proporty, Value} <- Config, Value =/= undefined].  
+    [{Property, Value} || {Property, Value} <- Config, Value =/= undefined].
 	
-		   
+-spec lookup(Tab, Key) -> Result when
+      Tab :: ets:tab(),
+      Key :: term(),
+      Result :: [tuple()] | atom().
 lookup(Tab, Key) ->
     httpd_util:lookup(Tab, Key).
 
+-spec lookup(Tab, Key, Default) -> Object when
+      Tab :: ets:tab(),
+      Key :: atom(),
+      Default :: atom(),
+      Object :: [tuple()] | atom();
+            (Address, Port, Key) -> Object when
+      Address :: inet:ip_address() | any,
+      Port    :: integer(),
+      Key     :: atom(),
+      Object  :: [tuple()] | atom().
 lookup(Tab, Key, Default) when is_atom(Key) ->
     httpd_util:lookup(Tab, Key, Default);
 
@@ -532,6 +553,12 @@ lookup(Address, Port, Key) when is_integer(Port) ->
     Tab = table(Address, Port),
     lookup(Tab, Key).
 
+-spec lookup(Address, Port, Key, Default) -> Object when
+      Address :: inet:ip_address() | any,
+      Port    :: integer(),
+      Key     :: atom(),
+      Default :: atom(),
+      Object  :: [tuple()] | atom().
 lookup(Address, Port, Key, Default) when is_integer(Port) ->
     Tab = table(Address, Port),
     lookup(Tab, Key, Default).

--- a/lib/inets/src/http_server/httpd_sup.erl
+++ b/lib/inets/src/http_server/httpd_sup.erl
@@ -252,11 +252,14 @@ listen_loop() ->
 	{'EXIT', _, _} ->
 	    ok
     end.
-	    
+
 socket_type(Config) ->
     SocketType = proplists:get_value(socket_type, Config, ip_comm), 
     socket_type(SocketType, Config).
 
+-spec socket_type(SocketType | Term) -> SocketType when
+      Term       :: term(),
+      SocketType :: ip_comm | {ip_comm, _Value} | {ssl, _Value}.
 socket_type(ip_comm = SocketType, _) ->
     SocketType;
 socket_type({ip_comm, _} = SocketType, _) ->
@@ -335,6 +338,9 @@ ssl_ca_certificate_file(Config) ->
 	    [{cacertfile, File}]
     end.
 
+-spec get_fd(Port) -> Object when
+      Port :: integer(),
+      Object :: {ok, integer() | undefined} | {error, {bad_descriptor, term()}}.
 get_fd(0) ->
     {ok, undefined};
 get_fd(Port) ->

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -2097,7 +2097,7 @@ server_config(http_internal, Config) ->
      {erl_script_alias, {"", [httpc_SUITE]}}
     ];
 server_config(https, Config) ->
-    [{socket_type, {essl, ssl_config(Config)}} | server_config(http, Config)];
+    [{socket_type, {ssl, ssl_config(Config)}} | server_config(http, Config)];
 server_config(sim_https, Config) ->
     ssl_config(Config);
 server_config(http_unix_socket, _Config) ->

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -2125,7 +2125,7 @@ server_config(http_rel_path_script_alias, Config) ->
 server_config(https, Config) ->
     SSLConf = proplists:get_value(ssl_conf, Config),
     ServerConf = proplists:get_value(server_config, SSLConf),
-    [{socket_type, {essl,
+    [{socket_type, {ssl,
 		    [{nodelay, true} | ServerConf]}}]
         ++ proplists:delete(socket_type, server_config(http, Config)).
 


### PR DESCRIPTION
This PR adds type specs to the API of the http_client app, file httpc.erl.
I have updated the XML documentation to use the type specs from httpc.erland this fixes https://github.com/erlang/otp/issues/6245

For some addressed comments, see #6300
Closes #6245