### PR TITLE
beam_lib: Fix spec for all_chunks/1

### DIFF
--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -156,7 +156,7 @@ chunks(File, Chunks, Options) ->
     catch Error -> Error end.
 
 -spec all_chunks(beam()) ->
-           {'ok', 'beam_lib', [{chunkid(), dataB()}]} | {'error', 'beam_lib', info_rsn()}.
+           {'ok', module(), [{chunkid(), dataB()}]} | {'error', 'beam_lib', info_rsn()}.
 
 all_chunks(File) ->
     read_all_chunks(File).


### PR DESCRIPTION
`beam_lib:all_chunks/1` returns the module contained in the given beam file/binary rather than the `beam_lib` atom if successful. Also see [`beam_lib:scan_beam/2`](https://github.com/erlang/otp/blob/54e4353c70fc4eb6ddc8fefd1475ca60366ffeeb/lib/stdlib/src/beam_lib.erl#L579-L581) which originally returns the module.