### PR TITLE
beam_validator: Eliminate type mismatch

### DIFF
--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -622,6 +622,11 @@ tuple(_Config) ->
     {0,0,-1} = decrement_element(3, Counters10),
     {'EXIT',{badarg,_}} = catch decrement_element(4, Counters10),
 
+    [] = gh_6458(id({true})),
+    {'EXIT',{function_clause,_}} = catch gh_6458(id({false})),
+    {'EXIT',{function_clause,_}} = catch gh_6458(id({42})),
+    {'EXIT',{function_clause,_}} = catch gh_6458(id(a)),
+
     ok.
 
 do_tuple() ->
@@ -640,6 +645,18 @@ increment_element(Pos, Cs) ->
 decrement_element(Pos, Cs) ->
     Ns = element(Pos, Cs),
     setelement(Pos, Cs, Ns - 1).
+
+gh_6458({X}) when X; (X orelse false) ->
+    (X orelse {}),
+    [
+     {X}#{
+          gh_6458() orelse X => []
+         }
+     || _ <- []
+    ].
+
+gh_6458() ->
+    true.
 
 -record(x, {a}).
 


### PR DESCRIPTION
When compiling the following code:

    f1({X}) when X; (X orelse false) ->
        (X orelse {}),
        [
            {X}#{
                f2() orelse X => []
            }
         || _ <- []
        ].

    f2() ->
        0.

the `beam_validator` pass rejects it:

    call_only:1: function f1/1+27:
      Internal consistency check failed - please report this bug.
      Instruction: {call_only,3,{f,16}}
      Error:       {bad_arg_type,
                       {x,1},
                       {t_tuple,1,true,#{1 => {t_atom,[false,true]}}},
                       {t_union,none,none,none,
                           [{{1,{t_atom,[false]}},
                             {t_tuple,1,true,#{1 => {t_atom,[false]}}}},
                            {{1,{t_atom,[true]}},
                             {t_tuple,1,true,#{1 => {t_atom,[true]}}}}],
                           none}}:

What happens here is that when types are updated in different ways, the result will be different. That is not supposed to happen; there should be one canonical type representation regardless how it's reached.

This pull request resolves the bug for this particular example, but a more general solution might be needed.

Closes #6458