### PR TITLE
Make list_to_atom reject all negative code points

### DIFF
--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -3648,7 +3648,7 @@ erts_unicode_list_to_buf(Eterm list, byte *buf, Sint len, Sint* written)
 {
     Eterm* listptr;
     Sint sz = 0;
-    Sint val;
+    Uint val;
     int res;
 
     while (1) {
@@ -3671,8 +3671,8 @@ erts_unicode_list_to_buf(Eterm list, byte *buf, Sint len, Sint* written)
 	    res = -1;
             break;
 	}
-	val = signed_val(CAR(listptr));
-	if (0 <= val && val < 0x80) {
+        val = (Uint) signed_val(CAR(listptr));
+	if (val < 0x80) {
 	    buf[sz] = val;
 	    sz++;
 	} else if (val < 0x800) {
@@ -3721,13 +3721,13 @@ erts_unicode_list_to_buf_len(Eterm list)
     listptr = list_val(list);
 
     while (1) {
-	Sint val;
+	Uint val;
 
 	if (is_not_small(CAR(listptr))) {
 	    return -1;
 	}
-	val = signed_val(CAR(listptr));
-	if (0 <= val && val < 0x80) {
+	val = (Uint) signed_val(CAR(listptr));
+	if (val < 0x80) {
 	    sz++;
 	} else if (val < 0x800) {
 	    sz += 2;

--- a/erts/emulator/test/bif_SUITE.erl
+++ b/erts/emulator/test/bif_SUITE.erl
@@ -380,6 +380,9 @@ list_to_utf8_atom(Config) when is_list(Config) ->
     _ = atom_roundtrip([16#1000]),
     _ = atom_roundtrip([16#10FFFF]),
     atom_badarg([16#110000]),
+
+    atom_badarg([-1]),
+    [atom_badarg([(-1 bsl N) + $A]) || N <- lists:seq(8,16)],
     ok.
 
 atom_roundtrip(String) ->


### PR DESCRIPTION
Negative values could either be accepted as some code point
```
1> list_to_atom([-3900]).
'Ä'
```
or cause an exception with an incorrect reason
```
2> catch list_to_atom([-1]).
{'EXIT',{[],[]}}
```