### PR TITLE
Refuse usage of SO_REUSEADDR on non-UDP sockets on Windows

### DIFF
--- a/lib/kernel/doc/src/inet.xml
+++ b/lib/kernel/doc/src/inet.xml
@@ -1569,17 +1569,14 @@ setcap cap_sys_admin,cap_sys_ptrace,cap_dac_read_search+epi beam.smp</code>
           <tag><c>{reuseaddr, Boolean}</c></tag>
           <item>
             <p>
-              Allows or disallows local reuse of port numbers. By
+              Allows or disallows local reuse of address. By
               default, reuse is disallowed.
             </p>
             <note><p>
               On Windows this option will be ignored unless
               <c><anno>Socket</anno></c> is an UDP socket. This since the
               behavior of <c>reuseaddr</c> is very different on Windows
-              compared to other system. The Windows behavior makes its use
-              dangerous, and there probably are no useful use-cases in the
-              non-UDP cases either. However, in the UDP case on Windows there
-              are useful use-cases.
+              compared to other system.
             </p></note>
           </item>
           <tag><c>{send_timeout, Integer}</c></tag>


### PR DESCRIPTION
The following will be changed on Windows by this change:

We refuse usage of `SO_REUSEADDR` on non-UDP sockets since it mostly (perhaps only) opens up for socket collisions and probably hasn't got any useful use-cases. There are useful use-cases for multicast sockets, though. For more information see: https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse

Prior to OTP 25 we also refused to use `SO_REUSEADDR` on any sockets on Windows. See 2a6ac6f3f027fcab6d607599e82714e930d9fde2

We certainly do not want to use it for the Erlang distribution TCP sockets since we can end up reusing our own active sockets as demonstrated in the issue: #6461 

We probably want to expose the Windows specific `SO_EXCLUSIVEADDRUSE` in the API as well...

-----

Issue #4819 is releated (triggered the change made in OTP 25.0)

Closes: #6461 