### PR TITLE
Don't allow local calls from record init in guards

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2847,9 +2847,8 @@ ginit_fields(Ifs, Anno, Name, Dfs, Vt0, St0) ->
     Defs = init_fields(Ifs, Anno, Dfs),
     St2 = St1#lint{errors = []},
     {_,St3} = check_fields(Defs, Name, Dfs, Vt1, St2, fun gexpr/3),
-    #lint{usage = Usage, errors = Errors} = St3,
-    IllErrs = [E || {_File,{_Anno,erl_lint,illegal_guard_expr}}=E <- Errors],
-    St4 = St1#lint{usage = Usage, errors = IllErrs ++ St1#lint.errors},
+    #lint{usage = Usage, errors = IllErrors} = St3,
+    St4 = St1#lint{usage = Usage, errors = IllErrors ++ St1#lint.errors},
     {Vt1,St4}.
 
 %% Default initializations to be carried out

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -1645,8 +1645,20 @@ guard(Config) when is_list(Config) ->
             [],
             {error,
 	     [{{2,26},erl_lint,{obsolete_guard_overridden,port}}],
-	     [{{2,26},erl_lint,{obsolete_guard,{port,1}}}]}}
-	  ],
+	     [{{2,26},erl_lint,{obsolete_guard,{port,1}}}]}},
+           {guard11,
+            <<"-record(bar, {a = mk_a()}).
+               mk_a() -> 1.
+
+               test_rec(Rec) when Rec =:= #bar{} -> true.
+               map_pattern(#{#bar{} := _}) -> ok.
+              ">>,
+            [],
+            {errors,
+             [{{4,43},erl_lint,{illegal_guard_local_call,{mk_a,0}}},
+              {{5,30},erl_lint,{illegal_guard_local_call,{mk_a,0}}}],
+             []}}
+          ],
     [] = run(Config, Ts1),
     ok.
 


### PR DESCRIPTION
Calling functions in guards is forbidden, but the compiler would fail to reject a function call from a default record initializer used in a guard. For example:

    -record(test, {a = mk_a()}).
    mk_a() -> 1.

    test_rec(Rec) when Rec =:= #test{} ->
        true.

Before this pull request, the compiler would fail to reject the illegal call to `mk_a/0`, and crash in a later pass. The compiler will now give the following error message:

    t.erl:7:36: call to local/imported function mk_a/0 is illegal in guard
    %    7|         test_rec(Rec) when Rec =:= #test{} ->
    %     |                                    ^

Closes #6465
Closes #6466