### PR TITLE
pg: Do not send redundant sync 'messages'

### DIFF
--- a/lib/kernel/src/pg.erl
+++ b/lib/kernel/src/pg.erl
@@ -438,12 +438,12 @@ terminate(_Reason, #state{scope = Scope}) ->
 %% Internal implementation
 
 handle_discover(Peer, #state{remote = Remote, local = Local} = State) ->
-    gen_server:cast(Peer, {sync, self(), all_local_pids(Local)}),
     %% do we know who is looking for us?
     case maps:is_key(Peer, Remote) of
         true ->
             {noreply, State};
         false ->
+            gen_server:cast(Peer, {sync, self(), all_local_pids(Local)}),
             MRef = erlang:monitor(process, Peer),
             erlang:send(Peer, {discover, self()}, [noconnect]),
             {noreply, State#state{remote = Remote#{Peer => {MRef, #{}}}}}

--- a/lib/kernel/test/pg_SUITE.erl
+++ b/lib/kernel/test/pg_SUITE.erl
@@ -551,12 +551,12 @@ forced_sync(Config) when is_list(Config) ->
     {?FUNCTION_NAME, Node} ! {discover, whereis(?FUNCTION_NAME)},
     sync({?FUNCTION_NAME, Node}),
     sync(?FUNCTION_NAME),
-    ?assertEqual(Expected, lists:sort(pg:get_members(?FUNCTION_NAME, one))),
-    ?assertEqual([], lists:sort(pg:get_members(?FUNCTION_NAME, ?FUNCTION_NAME))),
+    ?assertEqual(lists:sort([Pid,RemotePid, RemotePid]), lists:sort(pg:get_members(?FUNCTION_NAME, one))),
+    ?assertEqual(lists:sort([RemotePid, RemotePid]), lists:sort(pg:get_members(?FUNCTION_NAME, ?FUNCTION_NAME))),
     %% and simulate extra sync
     sync({?FUNCTION_NAME, Node}),
     sync(?FUNCTION_NAME),
-    ?assertEqual(Expected, lists:sort(pg:get_members(?FUNCTION_NAME, one))),
+    ?assertEqual(lists:sort([Pid,RemotePid, RemotePid]), lists:sort(pg:get_members(?FUNCTION_NAME, one))),
 
     peer:stop(Peer),
     ok.


### PR DESCRIPTION
When working on fixing `pg_SUITE:forced_sync` sporadic failures, I found out there are quite common for redundant `discover` and `sync` messages to be sent. So this PR is me wondering...

@max-au: Why would a second `sync` message toward the same `pg` process be necessary at all?

When we receive a `discover` we monitor the sender and send a `sync` with all our local groups as reply. That's the only way a `sync` is sent. If we then get a second `discover` from the same process, why would that need a second `sync` reply? Any updates to our local groups are sent anyway as `join` and `leave` messages as I understand it.


All `pg_SUITE` tests passed unchanged on my 8-core machine, except white-box test `pg_SUITE:forced_sync` that needed to be tweaked to not expect sending of redundant `sync`. With that change one would question its purpose, or am I missing something?