### PR TITLE
Fix typo in code snippet for supervisor example

### DIFF
--- a/system/doc/design_principles/sup_princ.xml
+++ b/system/doc/design_principles/sup_princ.xml
@@ -69,7 +69,7 @@ init(_Args) ->
                     restart => permanent,
                     shutdown => brutal_kill,
                     type => worker,
-                    modules => [cg3]}],
+                    modules => [ch3]}],
     {ok, {SupFlags, ChildSpecs}}.</code>
     <p>The <c>SupFlags</c> variable in the return value
       from <c>init/1</c> represents


### PR DESCRIPTION
`cg3` should be `ch3`