### PR TITLE
[erts] Display large maps similarly to small maps

### DIFF
--- a/erts/emulator/beam/erl_printf_term.c
+++ b/erts/emulator/beam/erl_printf_term.c
@@ -726,40 +726,66 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
                 switch (MAP_HEADER_TYPE(*head)) {
                 case MAP_HEADER_TAG_HAMT_HEAD_ARRAY:
                 case MAP_HEADER_TAG_HAMT_HEAD_BITMAP:
-                    PRINT_STRING(res, fn, arg, "#<");
-                    PRINT_UWORD(res, fn, arg, 'x', 0, 1, mapval);
-                    PRINT_STRING(res, fn, arg, ">{");
-                    WSTACK_PUSH(s,PRT_CLOSE_TUPLE);
+                    PRINT_STRING(res, fn, arg, "#{");
+                    WSTACK_PUSH(s, PRT_CLOSE_TUPLE);
                     n = hashmap_bitcount(mapval);
                     ASSERT(n < 17);
                     head += 2;
                     if (n > 0) {
+			Eterm* assoc;
+			Eterm key, val;
                         n--;
-                        WSTACK_PUSH(s, head[n]);
-                        WSTACK_PUSH(s, PRT_TERM);
-                        while (n--) {
-                            WSTACK_PUSH(s, PRT_COMMA);
+                        if (is_list(head[n])) {
+                            assoc = list_val(head[n]);
+                            key = CAR(assoc);
+                            val = CDR(assoc);
+                            WSTACK_PUSH5(s, val, PRT_TERM, PRT_ASSOC, key, PRT_TERM);
+                        } else {
                             WSTACK_PUSH(s, head[n]);
                             WSTACK_PUSH(s, PRT_TERM);
+			}
+                        while (n--) {
+                            if (is_list(head[n])) {
+                                assoc = list_val(head[n]);
+                                key = CAR(assoc);
+                                val = CDR(assoc);
+                                WSTACK_PUSH6(s, PRT_COMMA, val, PRT_TERM, PRT_ASSOC, key, PRT_TERM);
+                            } else {
+                                WSTACK_PUSH(s, PRT_COMMA);
+                                WSTACK_PUSH(s, head[n]);
+                                WSTACK_PUSH(s, PRT_TERM);
+                            }
                         }
                     }
                     break;
                 case MAP_HEADER_TAG_HAMT_NODE_BITMAP:
                     n = hashmap_bitcount(mapval);
                     head++;
-                    PRINT_CHAR(res, fn, arg, '<');
-                    PRINT_UWORD(res, fn, arg, 'x', 0, 1, mapval);
-                    PRINT_STRING(res, fn, arg, ">{");
-                    WSTACK_PUSH(s,PRT_CLOSE_TUPLE);
                     ASSERT(n < 17);
                     if (n > 0) {
+			Eterm* assoc;
+			Eterm key, val;
                         n--;
-                        WSTACK_PUSH(s, head[n]);
-                        WSTACK_PUSH(s, PRT_TERM);
-                        while (n--) {
-                            WSTACK_PUSH(s, PRT_COMMA);
+                        if (is_list(head[n])) {
+                            assoc = list_val(head[n]);
+                            key = CAR(assoc);
+                            val = CDR(assoc);
+                            WSTACK_PUSH5(s, val, PRT_TERM, PRT_ASSOC, key, PRT_TERM);
+                        } else {
                             WSTACK_PUSH(s, head[n]);
                             WSTACK_PUSH(s, PRT_TERM);
+                        }
+                        while (n--) {
+                            if (is_list(head[n])) {
+                                assoc = list_val(head[n]);
+                                key = CAR(assoc);
+                                val = CDR(assoc);
+                                WSTACK_PUSH6(s, PRT_COMMA, val, PRT_TERM, PRT_ASSOC, key, PRT_TERM);
+                            } else {
+                                WSTACK_PUSH(s, PRT_COMMA);
+                                WSTACK_PUSH(s, head[n]);
+                                WSTACK_PUSH(s, PRT_TERM);
+                            }
                         }
                     }
                     break;


### PR DESCRIPTION
The formatting of large maps done by erlang:display/1 used to reveal interesting information about the map internals, but was difficult to read, compared to the formatting of small maps. This commit aims at a similar (but still not sorted) display of large maps as for small maps.

This is important to those of us who regularly try to understand the state of our system from erlang:process_info(...,backtrace) or erlang:system_info(procs).

Pull request submitted based on issue #5585 discussion.