### PR TITLE
handle DB2 32Bit null values on data encoding

### DIFF
--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -1215,7 +1215,9 @@ static db_result_msg encode_out_params(db_state *state,
             }
             column = params[i];
             if (column.type.len == 0 ||
-                column.type.strlen_or_indptr == SQL_NULL_DATA) {
+                column.type.strlen_or_indptr == SQL_NULL_DATA ||
+                // DB2 64Bit Driver uses 32Bit null
+                column.type.strlen_or_indptr == 0xffffffff) {
                 ei_x_encode_atom(&dynamic_buffer(state), "null");
             } else {
                 void* values = retrive_param_values(&column);
@@ -1502,7 +1504,9 @@ static void encode_column_dyn(db_column column, int column_nr,
 {
     TIMESTAMP_STRUCT* ts;
     if (column.type.len == 0 ||
-	column.type.strlen_or_indptr == SQL_NULL_DATA) {
+	column.type.strlen_or_indptr == SQL_NULL_DATA ||
+	// DB2 64Bit Driver uses 32Bit null
+	column.type.strlen_or_indptr == 0xffffffff) {
 	ei_x_encode_atom(&dynamic_buffer(state), "null");
     } else {
 	switch(column.type.c) {


### PR DESCRIPTION
The 64Bit DB2 ODBC driver reports null values in 32Bit fashion instead of 64 Bit.

This is a minimal change to always check for 32Bit null value as well as the configured null value in `SQL_NULL_DATA` when receiving data in ODBC.

Tested with DB2 `v10.5` and DB2 ODBC driver `v10.5fp11_linuxx64_odbc_cli` and OTP `v24.3.4.6`.

If you consider merging this, I would also be happy to get it into master.