### PR TITLE
Fix internal consistency failure

### DIFF
--- a/lib/compiler/src/beam_ssa_pre_codegen.erl
+++ b/lib/compiler/src/beam_ssa_pre_codegen.erl
@@ -2587,6 +2587,7 @@ reserve_zreg([#b_set{op=Op,dst=Dst} | Is], Last, ShortLived, A) ->
 reserve_zreg([], _, _, A) -> A.
 
 use_zreg(bs_checked_skip) -> yes;
+use_zreg(bs_ensure) -> yes;
 use_zreg(bs_match_string) -> yes;
 use_zreg(bs_set_position) -> yes;
 use_zreg(kill_try_tag) -> yes;

--- a/lib/compiler/test/bs_match_SUITE.erl
+++ b/lib/compiler/test/bs_match_SUITE.erl
@@ -50,7 +50,7 @@
          combine_empty_segments/1,hangs_forever/1,
          bs_saved_position_units/1,empty_matches/1,
          trim_bs_start_match_resume/1,
-         gh_6410/1]).
+         gh_6410/1,bs_match/1]).
 
 -export([coverage_id/1,coverage_external_ignore/2]).
 
@@ -91,7 +91,7 @@ groups() ->
        many_clauses,combine_empty_segments,hangs_forever,
        bs_saved_position_units,empty_matches,
        trim_bs_start_match_resume,
-       gh_6410]}].
+       gh_6410,bs_match]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -2669,6 +2669,21 @@ do_gh_6410(X) ->
         [] ->
             X
     end).
+
+bs_match(_Config) ->
+    <<1,0>> = do_bs_match_1(whatever, <<1,0>>),
+    <<1,1>> = do_bs_match_1(whatever, <<1,1>>),
+    {a,b,c} = do_bs_match_1(whatever, {a,b,c}),
+    ok.
+
+do_bs_match_1(_, X) ->
+    case X of
+        <<_, 0>> ->
+            id(42);
+        _ ->
+            true
+    end,
+    X.
 
 %%% Utilities.
 id(I) -> I.


### PR DESCRIPTION
The following code:

    f(_, X) ->
        (case X of
            <<_, 0>> ->
                f();
            _ ->
                true
        end),
        X.

    f() ->
        ok.

would be rejected with this message:

    consistency:1: function f/2+12:
      Internal consistency check failed - please report this bug.
      Instruction: {bs_match,{f,0},{y,1},{commands,[{skip,8}]}}
      Error:       throws_exception:

Reported by Robin Morisset in #6458.