### PR TITLE
Reference to split/3 function corrected

### DIFF
--- a/lib/stdlib/doc/src/string.xml
+++ b/lib/stdlib/doc/src/string.xml
@@ -69,7 +69,7 @@
       <seemfa marker="#find/3"><c>find/3</c></seemfa>,
       <seemfa marker="#replace/3"><c>replace/3</c></seemfa>,
       <seemfa marker="#split/2"><c>split/2</c></seemfa>,
-      <seemfa marker="#lexemes/2"><c>split/2</c></seemfa> and
+      <seemfa marker="#split/3"><c>split/3</c></seemfa> and
       <seemfa marker="#trim/3"><c>trim/3</c></seemfa>.
     </p>
     <p>


### PR DESCRIPTION
There is minor mistake in documentation of the string module. After docs generation it is visible as follows (split/2 is repeated twice and links to incorrect function):

'''
Grapheme clusters for codepoints of class prepend and non-modern (or decomposed) Hangul is not handled for performance reasons in find/3, replace/3, split/2, split/2 and trim/3.
'''