### PR TITLE
named_fun_expr annotate bindings fix

### DIFF
--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -538,6 +538,8 @@ vann(Tree, Env) ->
             vann_function(Tree, Env);
         fun_expr ->
             vann_fun_expr(Tree, Env);
+        named_fun_expr ->
+            vann_named_fun_expr(Tree, Env);
         list_comp ->
             vann_list_comp(Tree, Env);
         binary_comp ->
@@ -580,6 +582,18 @@ vann_fun_expr(Tree, Env) ->
     Cs = erl_syntax:fun_expr_clauses(Tree),
     {Cs1, {_, Free}} = vann_clauses(Cs, Env),
     Tree1 = rewrite(Tree, erl_syntax:fun_expr(Cs1)),
+    Bound = [],
+    {ann_bindings(Tree1, Env, Bound, Free), Bound, Free}.
+
+vann_named_fun_expr(Tree, Env) ->
+    N = erl_syntax:named_fun_expr_name(Tree),
+    NBound = [erl_syntax:variable_name(N)],
+    NFree = [],
+    N1 = ann_bindings(N, Env, NBound, NFree),
+    Env1 = ordsets:union(Env, NBound),
+    Cs = erl_syntax:named_fun_expr_clauses(Tree),
+    {Cs1, {_, Free}} = vann_clauses(Cs, Env1),
+    Tree1 = rewrite(Tree, erl_syntax:named_fun_expr(N1,Cs1)),
     Bound = [],
     {ann_bindings(Tree1, Env, Bound, Free), Bound, Free}.
 


### PR DESCRIPTION
Attempt to fix the behavior of `erl_syntax_lib:annotate_bindings/1-2` described in #4733 (labeled with "help wanted").
Issue is also mentioned in `erlang_ls` repo, so potential fix may also allow better UX while using it.

Description:
My plan was to include a case in `vann/2` function to handle `named_fun_expr`nodes correctly. Annotation process is almost identical to the one of `fun_expr`, obviously with the difference of handling `named_fun_expr`'s name. Name of the function is set into the environment for each of the clause patterns, because patterns can shadow the function name.

I included one concrete example for the testing purpose.
GitHub actions passed successfully on the fork repo.