### PR TITLE
Fix bug introduced in PR 6359

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -579,7 +579,12 @@ res_update(Option, TagTm) ->
     end.
 
 db_get(Name) ->
-    ets:lookup_element(inet_db, Name, 2, undefined).
+    try
+        ets:lookup_element(inet_db, Name, 2, undefined)
+    catch
+        %% Case where the table does not exist yet.
+        error:badarg -> undefined
+    end.
 
 add_rr(RR) ->
     %% Questionable if we need to support this;

--- a/lib/kernel/src/pg.erl
+++ b/lib/kernel/src/pg.erl
@@ -203,7 +203,12 @@ get_members(Group) ->
 
 -spec get_members(Scope :: atom(), Group :: group()) -> [pid()].
 get_members(Scope, Group) ->
-    ets:lookup_element(Scope, Group, 2, []).
+    try
+        ets:lookup_element(Scope, Group, 2, [])
+    catch
+        %% Case where the table does not exist yet.
+        error:badarg -> []
+    end.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -214,7 +219,12 @@ get_local_members(Group) ->
 
 -spec get_local_members(Scope :: atom(), Group :: group()) -> [pid()].
 get_local_members(Scope, Group) ->
-    ets:lookup_element(Scope, Group, 3, []).
+    try
+        ets:lookup_element(Scope, Group, 3, [])
+    catch
+        %% Case where the table does not exist yet.
+        error:badarg -> []
+    end.
 
 %%--------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
In https://github.com/erlang/otp/pull/6359, I used the new ets:lookup_element/4 in various places in the standard library.

In particular, I replaced a try/catch wrapping a call to lookup_element/3 in 3 places. Unfortunately, this catch was also catching the case where the table does not exist at all, and this breaks some applications.

This patch just restores the 3 try/catches.