### PR TITLE
[stdlib] Fix unicode:characters_to_binary/3

### DIFF
--- a/lib/stdlib/src/unicode.erl
+++ b/lib/stdlib/src/unicode.erl
@@ -445,10 +445,12 @@ characters_to_binary_int(ML, InEncoding, OutEncoding) ->
 		       {error, Accum, [Part]}
 	       end,<<>>),
     case Res of
+        Bin when is_binary(Bin) ->
+            Bin;
 	{incomplete,A,B,_} ->
 	    {incomplete,A,B};
-	_ ->
-	    Res
+        {error, _Converted, _Rest} = Error ->
+            Error
     end.
 
 
@@ -528,14 +530,7 @@ ml_map([Part|_] = Whole,_,{{Incomplete, _}, Accum}) when is_integer(Part) ->
 ml_map([Part|T],Fun,Accum) when is_integer(Part) ->
     case Fun(Part,Accum) of
 	Bin when is_binary(Bin) ->
-	    case ml_map(T,Fun,Bin) of
-		Bin2 when is_binary(Bin2) ->
-		    Bin2;
-		{error, Converted, Rest} ->
-		    {error, Converted, Rest};
-		{incomplete, Converted, Rest,X} ->
-		    {incomplete, Converted, Rest,X}
-	    end;
+	    ml_map(T,Fun,Bin);
 	% Can not be incomplete - it's an integer
 	{error, Converted, Rest} ->
 	    {error, Converted, [Rest|T]}


### PR DESCRIPTION
Avoid unnecessary body recursive calls in `unicode:characters_to_binary()` which can produce unnecessary large call stacks.