### PR TITLE
kernel: os_SUITE: fix close_stdin test

### DIFF
--- a/lib/kernel/test/os_SUITE.erl
+++ b/lib/kernel/test/os_SUITE.erl
@@ -337,7 +337,7 @@ close_stdin(Config) ->
     DataDir = proplists:get_value(data_dir, Config),
     Fds = filename:join(DataDir, "my_fds"),
 
-    "-1" = os:cmd(Fds).
+    "0" = os:cmd(Fds).
 
 max_size_command(_Config) ->
     WSL = case os:getenv("WSLENV") of

--- a/lib/kernel/test/os_SUITE_data/my_fds.c
+++ b/lib/kernel/test/os_SUITE_data/my_fds.c
@@ -8,6 +8,6 @@ int
 main(int argc, char** argv)
 {
     char buff[1];
-    int res = read(stdin, buff, 1);
+    int res = read(STDIN_FILENO, buff, 1);
     printf("%d", res);
 }


### PR DESCRIPTION
* os_SUITE_data/my_fds.c: `read(stdin, buff, 1)` is invalid because stdin is a FILE* and not an fd, will become an error by default in clang 16.
* os_SUITE.erl: my_fds program now returns 0 bytes read instead of -1 for error, update assertion.

***

```
my_fds.c:11:20: error: incompatible pointer to integer conversion passing 'FILE *' (aka 'struct _IO_FILE *') to parameter of type 'int' [-Wint-conversion]
    int res = read(stdin, buff, 1);
                   ^~~~~
```