### PR TITLE
Fix typo in the name of the system_time_to_rfc3339 function.

### DIFF
--- a/lib/kernel/doc/src/logger_formatter.xml
+++ b/lib/kernel/doc/src/logger_formatter.xml
@@ -154,7 +154,7 @@
 	    <p>The value of this parameter is used as
 	      the <c>time_designator</c> option
 	      to <seemfa marker="stdlib:calendar#system_time_to_rfc3339/2">
-		<c>calendar:system_time_to_rcf3339/2</c></seemfa>.</p>
+		<c>calendar:system_time_to_rfc3339/2</c></seemfa>.</p>
 	  </item>
 	  <tag><c>time_offset = integer() | [byte()]</c></tag>
 	  <item>
@@ -179,7 +179,7 @@
 	    <p>The value of this parameter is used as
 	      the <c>offset</c> option
 	      to <seemfa marker="stdlib:calendar#system_time_to_rfc3339/2">
-		<c>calendar:system_time_to_rcf3339/2</c></seemfa>.</p>
+		<c>calendar:system_time_to_rfc3339/2</c></seemfa>.</p>
 	  </item>
 	</taglist>
       </desc>


### PR DESCRIPTION
In the docs: [https://erlang.org/doc/man/logger_formatter.html](https://erlang.org/doc/man/logger_formatter.html) it needs to fix a typo in the name of the `calendar:system_time_to_rfc3339/2` function (two entries).