### PR TITLE
gh: temporarily use 20.04 for some jobs

### DIFF
--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -14,7 +14,7 @@ concurrency: pr-comment
 
 jobs:
   pr-number:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'erlang/otp'
     outputs:
       result: ${{ steps.pr-number.outputs.result }}
@@ -45,7 +45,7 @@ jobs:
                    pr_number: ${{ needs.pr-number.outputs.result }} });
 
   finished-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: pr-number
     ## Limit concurrency so that only one job deploys to erlang.github.io
     concurrency: erlang.github.io-deploy

--- a/.github/workflows/sync-github-releases.yaml
+++ b/.github/workflows/sync-github-releases.yaml
@@ -30,7 +30,7 @@ jobs:
   sync-prs:
     if: github.repository == 'erlang/otp'
     concurrency: erlang.github.io-deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
- https://github.com/actions/runner-images/issues/6673
- some jobs failed with ubuntu-22.04 which does not have rebar3