### PR TITLE
Add Tau constant to math module

### DIFF
--- a/lib/stdlib/doc/src/math.xml
+++ b/lib/stdlib/doc/src/math.xml
@@ -102,9 +102,10 @@ erf(X) = 2/sqrt(pi)*integral from 0 to X of exp(-t*t) dt.</pre>
 
     <func>
       <name name="pi" arity="0" since=""/>
-      <fsummary>A useful number.</fsummary>
+      <fsummary>Ratio of the circumference of a circle to its diameter.</fsummary>
       <desc>
-        <p>A useful number.</p>
+          <p>Ratio of the circumference of a circle to its diameter.</p>
+          <p>Floating point approximation of mathematical constant pi.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/math.xml
+++ b/lib/stdlib/doc/src/math.xml
@@ -109,6 +109,16 @@ erf(X) = 2/sqrt(pi)*integral from 0 to X of exp(-t*t) dt.</pre>
       </desc>
     </func>
 
+    <func>
+      <name name="tau" arity="0" since="OTP @OTP-18361@"/>
+      <fsummary>Ratio of the circumference of a circle to its radius.</fsummary>
+      <desc>
+        <p>Ratio of the circumference of a circle to its radius.</p>
+        <p>This constant is equivalent to a full turn when described in radians.</p>
+        <p>The same as <c>2 * pi()</c>.</p>
+      </desc>
+    </func>
+
   </funcs>
 
   <section>

--- a/lib/stdlib/src/math.erl
+++ b/lib/stdlib/src/math.erl
@@ -19,7 +19,7 @@
 %%
 -module(math).
 
--export([pi/0]).
+-export([pi/0,tau/0]).
 
 %%% BIFs
 
@@ -154,5 +154,7 @@ tanh(_) ->
 %%% End of BIFs
 
 -spec pi() -> float().
-
 pi() -> 3.1415926535897932.
+
+-spec tau() -> float().
+tau() -> 6.2831853071795864.

--- a/lib/stdlib/test/math_SUITE.erl
+++ b/lib/stdlib/test/math_SUITE.erl
@@ -28,7 +28,7 @@
 	 init_per_testcase/2, end_per_testcase/2]).
 
 %% Test cases
--export([floor_ceil/1, error_info/1]).
+-export([floor_ceil/1, error_info/1, constants/1]).
 
 
 suite() ->
@@ -36,7 +36,7 @@ suite() ->
      {timetrap,{minutes,1}}].
 
 all() ->
-    [floor_ceil, error_info].
+    [floor_ceil, error_info, constants].
 
 groups() ->
     [].
@@ -58,6 +58,11 @@ init_per_testcase(_Case, Config) ->
     Config.
 
 end_per_testcase(_Case, _Config) ->
+    ok.
+
+constants(_Config) ->
+    3.1415926535897932 = math:pi(),
+    6.2831853071795864 = math:tau(),
     ok.
 
 floor_ceil(_Config) ->


### PR DESCRIPTION
https://tauday.com/tau-manifesto

Tau constant is already present and available in some prominent languages and libraries

- [.NET](https://learn.microsoft.com/en-us/dotnet/api/system.math.tau?view=net-7.0)
- [Rust](https://doc.rust-lang.org/std/f64/consts/constant.TAU.html)
- [Java](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/lang/Math.html#TAU)
- [Python](https://docs.python.org/3/library/math.html#math.tau)
- [Boost](https://www.boost.org/doc/libs/1_38_0/boost/units/systems/si/codata/tau_constants.hpp)