### PR TITLE
Improve optimization of binary matching

### DIFF
--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -159,10 +159,15 @@ pattern3(Config) when is_list(Config) ->
             f({A,_}) -> {ok,A};
             f([_|_]=B) -> {ok,B};
             f({urk,nisse}) -> urka_glurka.
+            word(<<\"AND\">>) -> <<\"and\">>;
+            word(<<\"AS\">>) -> <<\"as\">>;
+            word(<<\"A\">>) -> <<\"a\">>;
+            word(<<\"AS\">>) -> <<\"as\">>.
            ">>,
 	   [nowarn_unused_vars],
 	   {warnings,
-            [{{4,13},v3_kernel,{nomatch,{shadow,2}}}]}}],
+            [{{4,13},v3_kernel,{nomatch,{shadow,2}}},
+             {{8,13},v3_kernel,{nomatch,{shadow,6}}}]}}],
     [] = run(Config, Ts),
 
     ok.


### PR DESCRIPTION
The pattern matching compiler conservatively assumed that binary patterns can never be re-ordered. Actually it is safe to re-order clauses that match binaries if the first segment in each clause match the same number of bits. Re-ordering clauses can help generating better code and also help detect redundant clauses.

For the following code:

    word(<<"AND">>) -> <<"and">>;
    word(<<"AS">>) -> <<"as">>;
    word(<<"A">>) -> <<"a">>;
    word(<<"AS">>) -> <<"as">>.

the compiler will now generate the following warning:

    t.erl:6:1: Warning: this clause cannot match because a previous clause at line 5 always matches
    %    6| word(<<"AS">>) -> <<"as">>;
    %     | ^

The compiler will also generate slightly better code for the same example without the redundant clause:

    word(<<"AND">>) -> <<"and">>;
    word(<<"AS">>) -> <<"as">>;
    word(<<"A">>) -> <<"a">>.

Closes #6535