### PR TITLE
Improve `public_key:pkix_path_validation` to allow certificates that expire after 2050 

### DIFF
--- a/lib/public_key/src/pubkey_cert.erl
+++ b/lib/public_key/src/pubkey_cert.erl
@@ -134,7 +134,7 @@ prepare_for_next_cert(OtpCert, ValidationState = #path_validation_state{
      }.
 
  %%--------------------------------------------------------------------
--spec validate_time(#'OTPCertificate'{}, term(), fun()) -> term().
+-spec validate_time(#'OTPCertificate'{}, term(), fun()) -> term() | no_return().
 %%
 %% Description: Check that the certificate validity period includes the 
 %% current time.
@@ -144,8 +144,8 @@ validate_time(OtpCert, UserState, VerifyFun) ->
     {'Validity', NotBeforeStr, NotAfterStr} 
 	= TBSCert#'OTPTBSCertificate'.validity,
     Now = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
-    NotBefore = time_str_2_gregorian_sec(NotBeforeStr),
-    NotAfter = time_str_2_gregorian_sec(NotAfterStr),
+    NotBefore = time_str_2_gregorian_sec(notBefore, NotBeforeStr),
+    NotAfter = time_str_2_gregorian_sec(notAfter, NotAfterStr),
 
     case ((NotBefore =< Now) and (Now =< NotAfter)) of
 	true ->
@@ -633,19 +633,44 @@ public_key_info(PublicKeyInfo,
 	end,
     {Algorithm, PublicKey, NewPublicKeyParams}.
 
-time_str_2_gregorian_sec({utcTime, [Y1,Y2,M1,M2,D1,D2,H1,H2,M3,M4,S1,S2,Z]}) ->
-    case list_to_integer([Y1,Y2]) of
-	N when N >= 50 ->
-	    time_str_2_gregorian_sec({generalTime, 
-				      [$1,$9,Y1,Y2,M1,M2,D1,D2,
-				       H1,H2,M3,M4,S1,S2,Z]});
-	_ ->
-	    time_str_2_gregorian_sec({generalTime, 
-				      [$2,$0,Y1,Y2,M1,M2,D1,D2,
-				       H1,H2,M3,M4,S1,S2,Z]}) 
-    end;
+%% time_str_2_gregorian_sec/2 is a wrapper (decorator pattern) over
+%% time_str_2_gregorian_sec/1. the decorator deals with notBefore and notAfter
+%% property differently when we pass utcTime because the data format is
+%% ambiguous YYMMDD. on generalTime the year ambiguity cannot happen because
+%% years are expressed in a 4-digit format, i.e., YYYYMMDD.
+-spec time_str_2_gregorian_sec(PeriodOfTime, Time) -> Seconds :: non_neg_integer() when
+      PeriodOfTime :: notBefore | notAfter,
+      Time :: {utcTime | generalTime, [non_neg_integer() | char()]}.
+time_str_2_gregorian_sec(notBefore, {utcTime, [FirstDigitYear | _]=UtcTime}) ->
+    %% To be compliant with PKITS Certification Path Validation,
+    %% we must accept certificates with notBefore = 50, meaning 1950.
+    %% Once the PKITS certification path validation is updated,
+    %% we must update this function body and test case
+    %% {"4.2.3", "Valid pre2000 UTC notBefore Date Test3 EE"}
+    %% in pkits_SUITE.erl
+    Y1 = erlang:list_to_integer([FirstDigitYear]),
+    YearPrefix = case (Y1 > 4 andalso Y1 =< 9) of
+                     true -> [$1, $9];
+                     false  ->
+                         {Y, _M, _D} = erlang:date(),
+                         integer_to_list(Y div 100)
+                 end,
+    time_str_2_gregorian_sec({generalTime, YearPrefix ++ UtcTime});
 
-time_str_2_gregorian_sec({_,[Y1,Y2,Y3,Y4,M1,M2,D1,D2,H1,H2,M3,M4,S1,S2,$Z]}) ->
+time_str_2_gregorian_sec(notAfter, {utcTime, UtcTime}) ->
+    SlidingDate = sliding_year_window(UtcTime),
+    time_str_2_gregorian_sec({generalTime, SlidingDate});
+
+time_str_2_gregorian_sec(_, {generalTime, _Time}=GeneralTime) ->
+    time_str_2_gregorian_sec(GeneralTime).
+
+%% converts 'Time' as a string into gregorian time in seconds.
+-spec time_str_2_gregorian_sec(Time) -> Seconds :: non_neg_integer() when
+      Time :: {generalTime | utcTime, string()}.
+time_str_2_gregorian_sec({utcTime, UtcTime}) ->
+    time_str_2_gregorian_sec(notAfter, {utcTime, UtcTime});
+
+time_str_2_gregorian_sec({generalTime,[Y1,Y2,Y3,Y4,M1,M2,D1,D2,H1,H2,M3,M4,S1,S2,$Z]}) ->
     Year  = list_to_integer([Y1, Y2, Y3, Y4]),
     Month = list_to_integer([M1, M2]),
     Day   = list_to_integer([D1, D2]),
@@ -654,6 +679,28 @@ time_str_2_gregorian_sec({_,[Y1,Y2,Y3,Y4,M1,M2,D1,D2,H1,H2,M3,M4,S1,S2,$Z]}) ->
     Sec   = list_to_integer([S1, S2]),
     calendar:datetime_to_gregorian_seconds({{Year, Month, Day},
 					    {Hour, Min, Sec}}).
+
+%% Sliding window algorithm to calculate the time.
+%% The value is set as taking {Y1, Y2} from the first two digits of
+%% current_date - 50 or current_date - 49.
+sliding_year_window([Y1,Y2,M1,M2,D1,D2,H1,H2,M3,M4,S1,S2,Z]) ->
+    {{CurrentYear,_, _}, _} = calendar:universal_time(),
+    LastTwoDigitYear = CurrentYear rem 100,
+    MinYear = mod(LastTwoDigitYear - 50, 100),
+    YearWindow = case list_to_integer([Y1,Y2]) of
+                     N when N < MinYear -> CurrentYear + 50;
+                     N when N >= MinYear -> CurrentYear - 49
+                 end,
+    [Year1, Year2] = integer_to_list(YearWindow div 100),
+    [Year1,Year2,Y1,Y2,M1,M2,D1,D2,H1,H2,M3,M4,S1,S2,Z].
+
+
+%% Helper function to perform modulo calculation for integer
+-spec mod(A :: integer(), B :: non_neg_integer()) -> non_neg_integer().
+mod(A, B) when A > 0 -> A rem B;
+mod(A, B) when A < 0 -> mod(A+B, B);
+mod(0, _) -> 0.
+
 
 is_dir_name([], [], _Exact) ->    true;
 is_dir_name([H|R1],[H|R2], Exact) -> is_dir_name(R1,R2, Exact);

--- a/lib/public_key/src/pubkey_cert.erl
+++ b/lib/public_key/src/pubkey_cert.erl
@@ -154,7 +154,7 @@ validate_time(OtpCert, UserState, VerifyFun) ->
 	    verify_fun(OtpCert, {bad_cert, cert_expired}, UserState, VerifyFun)
     end.
 %%--------------------------------------------------------------------
--spec validate_issuer(#'OTPCertificate'{}, term(), term(), fun()) -> term().
+-spec validate_issuer(#'OTPCertificate'{}, term(), term(), fun()) -> term() | no_return().
 %%
 %% Description: Check that the certificate issuer name is the working_issuer_name
 %% in path_validation_state.
@@ -169,7 +169,7 @@ validate_issuer(OtpCert, Issuer, UserState, VerifyFun) ->
     end. 
 %%--------------------------------------------------------------------
 -spec validate_signature(#'OTPCertificate'{}, DER::binary(),
-			 term(),term(), term(), fun()) -> term().
+			 term(),term(), term(), fun()) -> term() | no_return().
 				
 %%
 %% Description: Check that the signature on the certificate can be verified using
@@ -187,7 +187,7 @@ validate_signature(OtpCert, DerCert, Key, KeyParams,
     end.
 %%--------------------------------------------------------------------
 -spec validate_names(#'OTPCertificate'{}, no_constraints | list(), list(),
-		     term(), term(), fun())-> term().
+		     term(), term(), fun())-> term() | no_return().
 %%
 %% Description: Validate Subject Alternative Name.
 %%--------------------------------------------------------------------	
@@ -333,7 +333,7 @@ is_fixed_dh_cert(#'OTPCertificate'{tbsCertificate =
 
 %%--------------------------------------------------------------------
 -spec verify_fun(#'OTPCertificate'{}, {bad_cert, atom()} | {extension, #'Extension'{}}|
-		 valid | valid_peer, term(), fun()) -> term().
+		 valid | valid_peer, term(), fun()) -> term() | no_return().
 %%
 %% Description: Gives the user application the opportunity handle path
 %% validation errors and unknown extensions and optional do other

--- a/lib/public_key/test/Makefile
+++ b/lib/public_key/test/Makefile
@@ -32,7 +32,8 @@ MODULES= \
 	erl_make_certs \
 	public_key_SUITE \
 	pbe_SUITE \
-	pkits_SUITE
+	pkits_SUITE \
+	pubkey_cert_SUITE
 
 ERL_FILES= $(MODULES:%=%.erl)
 

--- a/lib/public_key/test/pubkey_cert_SUITE.erl
+++ b/lib/public_key/test/pubkey_cert_SUITE.erl
@@ -1,0 +1,128 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2011-2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(pubkey_cert_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+%% -include_lib("public_key/include/public_key.hrl").
+
+%% Note: This directive should only be used in test suites.
+-compile(export_all).
+
+%%--------------------------------------------------------------------
+%% Common Test interface functions -----------------------------------
+%%--------------------------------------------------------------------
+
+all() ->
+    [{group, time_str_2_gregorian_sec}].
+
+groups() ->
+    [{time_str_2_gregorian_sec, [], time_str_two_gregorian()}].
+
+time_str_two_gregorian() ->
+    [ time_str_2_gregorian_utc_post2000
+    , time_str_2_gregorian_utc_limit_pre2000
+    , time_str_2_gregorian_utc_limit_post2000
+    , time_str_2_gregorian_generaltime_pre2000
+    , time_str_2_gregorian_generaltime_post2000
+    ].
+
+%%--------------------------------------------------------------------
+%% Test Cases --------------------------------------------------------
+%%--------------------------------------------------------------------
+time_str_2_gregorian_utc_post2000() ->
+    [{doc, "Tests a valid gregorian Utc time"}].
+time_str_2_gregorian_utc_post2000(_) ->
+    YYMMDD = "450101",
+    HHMMSSZ = "000000Z",
+    ExpectedYear = 2045,
+    UtcTime = {utcTime, YYMMDD ++ HHMMSSZ},
+    {ExpectedDate, _} = convert_to_datetime_format(UtcTime, ExpectedYear),
+
+    Result = pubkey_cert:time_str_2_gregorian_sec(UtcTime),
+    {ExpectedDate, _} = calendar:gregorian_seconds_to_datetime(Result).
+
+
+time_str_2_gregorian_utc_limit_pre2000() ->
+    [{doc, "Tests a valid gregorian Utc time"}].
+time_str_2_gregorian_utc_limit_pre2000(_) ->
+    YYMMDD = "720101",
+    HHMMSSZ = "000000Z",
+    ExpectedYear = 1972,
+    UtcTime = {utcTime, YYMMDD ++ HHMMSSZ},
+    {ExpectedDate, _} = convert_to_datetime_format(UtcTime, ExpectedYear),
+
+    Result = pubkey_cert:time_str_2_gregorian_sec(UtcTime),
+    {ExpectedDate, _} = calendar:gregorian_seconds_to_datetime(Result).
+
+
+time_str_2_gregorian_utc_limit_post2000() ->
+    [{doc, "Tests a valid gregorian Utc time"}].
+time_str_2_gregorian_utc_limit_post2000(_) ->
+    YYMMDD = "710101",
+    HHMMSSZ = "000000Z",
+    ExpectedYear = 2071,
+    UtcTime = {utcTime, YYMMDD ++ HHMMSSZ},
+    {ExpectedDate, _} = convert_to_datetime_format(UtcTime, ExpectedYear),
+
+    Result = pubkey_cert:time_str_2_gregorian_sec(UtcTime),
+    {ExpectedDate, _} = calendar:gregorian_seconds_to_datetime(Result).
+
+
+time_str_2_gregorian_generaltime_pre2000() ->
+    [{doc, "Tests a valid gregorian Utc time"}].
+time_str_2_gregorian_generaltime_pre2000(_) ->
+    [Year | _]=YYMMDD = ["1972", "01", "01"],
+    HHMMSSZ = "000000Z",
+    GeneralTime = {generalTime, lists:flatten(YYMMDD) ++ HHMMSSZ},
+    {ExpectedYear, _} = convert_to_datetime_format(GeneralTime
+                                                  , erlang:list_to_integer(Year)),
+
+    Result = pubkey_cert:time_str_2_gregorian_sec(GeneralTime),
+    {ExpectedYear, _} = calendar:gregorian_seconds_to_datetime(Result).
+
+
+time_str_2_gregorian_generaltime_post2000() ->
+    [{doc, "Tests a valid gregorian Utc time"}].
+time_str_2_gregorian_generaltime_post2000(_) ->
+    [Year | _]=YYMMDD = ["2045", "01", "01"],
+    HHMMSSZ = "000000Z",
+    GeneralTime = {generalTime, lists:flatten(YYMMDD) ++ HHMMSSZ},
+    {ExpectedYear, _} = convert_to_datetime_format(GeneralTime
+                                                  , erlang:list_to_integer(Year)),
+
+    Result = pubkey_cert:time_str_2_gregorian_sec(GeneralTime),
+    {ExpectedYear, _} = calendar:gregorian_seconds_to_datetime(Result).
+
+
+convert_to_datetime_format({utcTime, [Y1, Y2, M1, M2, D1, D2 | _]}, ExpectedYear) ->
+    YYMMDD = [[Y1, Y2], [M1, M2], [D1, D2]],
+    [Y, M, D] = lists:map(fun (Str) -> erlang:list_to_integer(Str) end
+                         , YYMMDD),
+    case (ExpectedYear rem 100) =:= Y of
+        true -> {{ExpectedYear, M, D}, {0, 0, 0}};
+        false -> error
+    end;
+
+convert_to_datetime_format({generalTime, [Y1, Y2, Y3, Y4, M1, M2, D1, D2 | _]}, ExpectedYear) ->
+    YYMMDD = [[Y1, Y2, Y3, Y4], [M1, M2], [D1, D2]],
+    [ExpectedYear, M, D] = lists:map(fun (Str) -> erlang:list_to_integer(Str) end
+                                    , YYMMDD),
+    {{ExpectedYear, M, D}, {0, 0, 0}}.


### PR DESCRIPTION
This PR re-writes the validity algorithm to use the sliding window algorithm (see #6403 ), allowing certificates with the property `notAfter` to be accepted from the current date + 49 years in advanced. Certificates with `notBefore` date will work from current date - 50 years.
For example, certificates with `notBefore` and `notAfter` dates between [1972, 2071] (included both years) are valid. 
The sliding window works on old format certificates where the `notBefore` and `notAfter` values use the old format `YYMMDDHHMMSSZ`. New certificates should remove the `YY` (two digit year) ambiguity and use instead `YYYY`.

Closes #6403 