### PR TITLE
Mention that os.cmd/1 captures stderr as well.

### DIFF
--- a/lib/kernel/doc/src/os.xml
+++ b/lib/kernel/doc/src/os.xml
@@ -115,8 +115,8 @@
       <fsummary>Execute a command in a shell of the target OS.</fsummary>
       <desc>
         <p>Executes <c><anno>Command</anno></c> in a command shell of the
-	  target OS, captures the standard output of the command,
-          and returns this result as a string.</p>
+          target OS, captures the standard output and standard error of the
+          command, and returns this result as a string.</p>
         <p><em>Examples:</em></p>
         <code type="none">
 LsOut = os:cmd("ls"), % on unix platform


### PR DESCRIPTION
This patch adds a `and standard error` piece of (important?) information to the `os.cmd/1` docs.

See also http://erlang.org/pipermail/erlang-questions/2016-June/089640.html

```
Eshell V12.2.1  (abort with ^G)
1> os:cmd('echo foo >&2').
"foo\n"
```