### PR TITLE
Eliminate internal error in beam_validator

### DIFF
--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -1363,8 +1363,8 @@ resolve_bs_match_commands([{atom,'=:='},nil,Bits,Value|Rest]) ->
     [{'=:=',nil,Bits,Value} | resolve_bs_match_commands(Rest)];
 resolve_bs_match_commands([{atom,skip},Stride|Rest]) ->
     [{skip,Stride} | resolve_bs_match_commands(Rest)];
-resolve_bs_match_commands([{atom,get_tail},Live,Src,Dst]) ->
-    [{get_tail,Live,Src,Dst}];
+resolve_bs_match_commands([{atom,get_tail},Live,Src,Dst|Rest]) ->
+    [{get_tail,Live,Src,Dst} | resolve_bs_match_commands(Rest)];
 resolve_bs_match_commands([]) ->
     [].
 

--- a/lib/compiler/test/bs_match_SUITE.erl
+++ b/lib/compiler/test/bs_match_SUITE.erl
@@ -2675,6 +2675,13 @@ bs_match(_Config) ->
     <<1,0>> = do_bs_match_1(whatever, <<1,0>>),
     <<1,1>> = do_bs_match_1(whatever, <<1,1>>),
     {a,b,c} = do_bs_match_1(whatever, {a,b,c}),
+
+    {'EXIT',{badarg,_}} = catch do_bs_match_gh_6551a(<<>>),
+    false = do_bs_match_gh_6551a(<<42>>),
+
+    {0,0} = do_bs_match_gh_6551b(0),
+    {<<42>>,<<42>>} = do_bs_match_gh_6551b(<<42>>),
+
     ok.
 
 do_bs_match_1(_, X) ->
@@ -2685,6 +2692,24 @@ do_bs_match_1(_, X) ->
             true
     end,
     X.
+
+do_bs_match_gh_6551a(X) ->
+    case X of
+        <<>> ->
+            true -- [];
+        <<_>> ->
+            X
+    end /= X.
+
+
+do_bs_match_gh_6551b(X) ->
+    {X,
+        case X of
+            0 ->
+                0;
+            <<_>> ->
+                X
+        end}.
 
 %% GH-6348/OTP-18297: Allow aliases for binaries.
 -record(ba_foo, {a,b,c}).


### PR DESCRIPTION
`beam_validator` and `beam_disasm` assumed that there could only be one `get_tail` command in a `bs_match` instruction. That assumption is wrong. In rare circumstances, there can be more than one.

Closes #6551