### PR TITLE
compiler: Infer types through 'and' BIF

### DIFF
--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -2692,6 +2692,21 @@ infer_type({bif,is_reference}, [#b_var{}=Arg], _Ts, _Ds) ->
 infer_type({bif,is_tuple}, [#b_var{}=Arg], _Ts, _Ds) ->
     T = {Arg, #t_tuple{}},
     {[T], [T]};
+infer_type({bif,'and'}, [#b_var{}=LHS,#b_var{}=RHS], Ts, Ds) ->
+    %% When this BIF yields true, we know that both `LHS` and `RHS` are 'true'
+    %% and should infer accordingly, lest we break later optimizations that
+    %% rewrite this BIF to plain control flow.
+    %%
+    %% Note that we can't do anything for the 'false' case as either (or both)
+    %% of the arguments could be false.
+    #{ LHS := #b_set{op=LHSOp,args=LHSArgs},
+       RHS := #b_set{op=RHSOp,args=RHSArgs} } = Ds,
+
+    LHSTypes = infer_and_type(LHSOp, LHSArgs, Ts, Ds),
+    RHSTypes = infer_and_type(RHSOp, RHSArgs, Ts, Ds),
+
+    True = beam_types:make_atom(true),
+    {[{LHS, True}, {RHS, True}] ++ LHSTypes ++ RHSTypes, []};
 infer_type(_Op, _Args, _Ts, _Ds) ->
     {[], []}.
 
@@ -2739,6 +2754,16 @@ infer_eq_type(#b_set{op=get_tuple_element,
     end;
 infer_eq_type(_, _) ->
     [].
+
+infer_and_type(Op, Args, Ts, Ds) ->
+    case inv_relop(Op) of
+        none ->
+            {LHSTypes0, _} = infer_type(Op, Args, Ts, Ds),
+            LHSTypes0;
+        _InvOp ->
+            {bif,RelOp} = Op,
+            infer_relop(RelOp, Args, concrete_types(Args, Ts), Ds)
+    end.
 
 join_types(Ts, Ts) ->
     Ts;

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -414,6 +414,9 @@ booleans(_Config) ->
     {'EXIT',{{case_clause,true},_}} = catch do_booleans_4(false),
     {'EXIT',{{badmatch,true},_}} = catch do_booleans_4(true),
 
+    true = do_booleans_5(id(0), id(<<0>>), id(0)),
+    {'EXIT',{function_clause,_}} = catch do_booleans_6(id(0), id(0), id(0)),
+
     ok.
 
 do_booleans_1(B) ->
@@ -448,6 +451,12 @@ do_booleans_4(X) ->
             false = Y,
             0
     end.
+
+do_booleans_5(X, <<X>>, X) when true; (0 rem 0) ->
+    (-2147483648 < X) orelse [0 || _ <- X].
+
+do_booleans_6(X, X, (X = [_ | X])) when true; self() ->
+    [0 || _ <- {X}].
 
 -record(update_tuple_a, {a,b}).
 -record(update_tuple_b, {a,b,c}).


### PR DESCRIPTION
Fixes #6552. The corresponding change for `'or'` requires a bit of refactoring and will be done in a later PR.