### PR TITLE
beam_validator: Fix logic bug in '=/=' inference

### DIFF
--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -1941,9 +1941,9 @@ infer_types_1(#value{op={bif,'=:='},args=[LHS,RHS]}, Val, Op, Vst) ->
     end;
 infer_types_1(#value{op={bif,'=/='},args=[LHS,RHS]}, Val, Op, Vst) ->
     case Val of
-        {atom, Bool} when Op =:= ne_exact, Bool; Op =:= eq_exact, not Bool ->
-            update_ne_types(LHS, RHS, Vst);
         {atom, Bool} when Op =:= eq_exact, Bool; Op =:= ne_exact, not Bool ->
+            update_ne_types(LHS, RHS, Vst);
+        {atom, Bool} when Op =:= ne_exact, Bool; Op =:= eq_exact, not Bool ->
             update_eq_types(LHS, RHS, Vst);
         _ ->
             Vst

--- a/lib/compiler/test/beam_validator_SUITE.erl
+++ b/lib/compiler/test/beam_validator_SUITE.erl
@@ -39,7 +39,8 @@
          branch_to_try_handler/1,call_without_stack/1,
          receive_marker/1,safe_instructions/1,
          missing_return_type/1,will_bif_succeed/1,
-         bs_saved_position_units/1,parent_container/1]).
+         bs_saved_position_units/1,parent_container/1,
+         not_equal_inference/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -73,7 +74,8 @@ groups() ->
        branch_to_try_handler,call_without_stack,
        receive_marker,safe_instructions,
        missing_return_type,will_bif_succeed,
-       bs_saved_position_units,parent_container]}].
+       bs_saved_position_units,parent_container,
+       not_equal_inference]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -959,6 +961,14 @@ pc_1(#pc{a=A}=R) ->
 
 pc_2(_R) ->
     ok.
+
+%% OTP-18365: A brainfart in inference for '=/=' inverted the results.
+not_equal_inference(_Config) ->
+    {'EXIT', {function_clause, _}} = (catch not_equal_inference_1(id([0]))),
+    ok.
+
+not_equal_inference_1(X) when (X /= []) /= is_port(0 div 0) ->
+    [X || _ <- []].
 
 id(I) ->
     I.


### PR DESCRIPTION
Fixes https://github.com/erlang/otp/issues/6552#issuecomment-1353135450