### PR TITLE
Call erlang:error/2 with the actual args in erl_anno:anno_info/2,3

### DIFF
--- a/lib/stdlib/src/erl_anno.erl
+++ b/lib/stdlib/src/erl_anno.erl
@@ -361,7 +361,7 @@ anno_info(Anno, Item, Default) ->
             Value
     catch
         _:_ ->
-            erlang:error(badarg, [Anno])
+            erlang:error(badarg, [Anno, Item, Default])
     end.
 
 anno_info(Anno, Item) ->
@@ -372,7 +372,7 @@ anno_info(Anno, Item) ->
             undefined
     catch
         _:_ ->
-            erlang:error(badarg, [Anno])
+            erlang:error(badarg, [Anno, Item])
     end.
 
 end_location("", Line, Column) ->


### PR DESCRIPTION
I've been playing around with Gradualizer on random community projects and spotted this. It's present as early as `maint-21` and then further up until the current master. I haven't checked branches older than `maint-21`. Most likely it only manifests when not-an-annotation is passed to this function, hence it's gone unnoticed for a while.