### PR TITLE
[erts] report writable binaries as off-heap binaries

### DIFF
--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -1998,12 +1998,15 @@ process_info_aux(Process *c_p,
 
     case ERTS_PI_IX_BINARY: {
         ErlHeapFragment *hfrag;
+        ErlOffHeap wrt_bins;
         Uint sz;
 
         res = NIL;
         sz = 0;
+        wrt_bins.first = rp->wrt_bins;
 
         (void)erts_bld_bin_list(NULL, &sz, &MSO(rp), NIL);
+        (void)erts_bld_bin_list(NULL, &sz, &wrt_bins, NIL);
         for (hfrag = rp->mbuf; hfrag != NULL; hfrag = hfrag->next) {
             (void)erts_bld_bin_list(NULL, &sz, &hfrag->off_heap, NIL);
         }
@@ -2011,6 +2014,7 @@ process_info_aux(Process *c_p,
         hp = erts_produce_heap(hfact, sz, reserve_size);
 
         res = erts_bld_bin_list(&hp, NULL, &MSO(rp), NIL);
+        res = erts_bld_bin_list(&hp, NULL, &wrt_bins, res);
         for (hfrag = rp->mbuf; hfrag != NULL; hfrag = hfrag->next) {
             res = erts_bld_bin_list(&hp, NULL, &hfrag->off_heap, res);
         }

--- a/erts/emulator/test/bs_construct_SUITE.erl
+++ b/erts/emulator/test/bs_construct_SUITE.erl
@@ -28,6 +28,7 @@
 	 huge_float_field/1, system_limit/1, badarg/1,
 	 copy_writable_binary/1, kostis/1, dynamic/1, bs_add/1,
 	 otp_7422/1, zero_width/1, bad_append/1, bs_append_overflow/1,
+         bs_append_offheap/1,
          reductions/1, fp16/1, error_info/1]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -41,7 +42,8 @@ all() ->
      in_guard, mem_leak, coerce_to_float, bjorn, append_empty_is_same,
      huge_float_field, system_limit, badarg,
      copy_writable_binary, kostis, dynamic, bs_add, otp_7422, zero_width,
-     bad_append, bs_append_overflow, reductions, fp16, error_info].
+     bad_append, bs_append_overflow, bs_append_offheap,
+     reductions, fp16, error_info].
 
 init_per_suite(Config) ->
     Config.
@@ -926,6 +928,29 @@ bs_append_overflow_unsigned() ->
     B = <<2, 3>>,
     C = <<A/binary,1,B/binary>>,
     true = byte_size(B) < byte_size(C).
+
+bs_append_offheap(Config) when is_list(Config) ->
+    %% test that erts_bs_private_append is reflected correctly in
+    %%  process_info(Pid, binary()) report for off-heap binaries.
+    {Pid, MRef} = erlang:spawn_monitor(fun bs_append_offheap_proc/0),
+    receive
+        {'DOWN', MRef, process, Pid, normal} ->
+            ok;
+        {'DOWN', MRef, process, Pid, {{badmatch,[{binary,[]}]}, _}} ->
+            {fail, "missing binary in erts_bs_private_append"}
+    end.
+
+bs_append_offheap_proc() ->
+    Self = self(),
+    Len = 128,
+    OffHeapBin = list_to_binary(lists:duplicate(Len, $b)),
+    erlang:garbage_collect(Self),
+    [{binary, [{_, Len, 1}]}] = erlang:process_info(Self, [binary]),
+    Bin = <<OffHeapBin/binary, "a">>,
+    erlang:garbage_collect(Self),
+    %% expect a single binary (2 bytes longer than the original)
+    [{binary, [{_, _, 1}]}] = erlang:process_info(Self, [binary]),
+    Bin.
 
 reductions(_Config) ->
     TwoMeg = <<0:(2_000*1024)/unit:8>>,


### PR DESCRIPTION
When writable binaries were moved to a separate list `proc->wrt_bins`, they weren't added to the output of `process_info(Pid, binary)`. It led to interesting effects of binaries suddenly disappearing after running implicit GC caused by BIF calls, including `process_info` itself. Effectively, running `process_info(self(), binary)` twice in a row resulted in different lists, because first call triggers GC clearing out original binary from the off-heap list:

    start() ->
        OffHeapBin = crypto:strong_rand_bytes(1024 * 1024),
        Bin = <<OffHeapBin/binary, "a">>,
        Before = erlang:process_info(self(), [binary]),
        After = erlang:process_info(self(), [binary]),
        Before =/= After andalso erlang:display({wtf, Before, After}),
        Bin.

Fixes #6573