### PR TITLE
Optimize the `node/1` BIF in the JIT

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -2625,6 +2625,7 @@ done:
    and is only here to keep Robert happy (Even more, since it's OP as well) */
 BIF_RETTYPE hd_1(BIF_ALIST_1)
 {
+    /* NOTE: The JIT has its own implementation of this BIF. */
      if (is_not_list(BIF_ARG_1)) {
 	 BIF_ERROR(BIF_P, BADARG);
      }
@@ -2637,6 +2638,7 @@ BIF_RETTYPE hd_1(BIF_ALIST_1)
 
 BIF_RETTYPE tl_1(BIF_ALIST_1)
 {
+    /* NOTE: The JIT has its own implementation of this BIF. */
     if (is_not_list(BIF_ARG_1)) {
 	BIF_ERROR(BIF_P, BADARG);
     }
@@ -2913,6 +2915,7 @@ BIF_RETTYPE element_2(BIF_ALIST_2)
 
 BIF_RETTYPE tuple_size_1(BIF_ALIST_1)
 {
+    /* NOTE: The JIT has its own implementation of this BIF. */
     if (is_tuple(BIF_ARG_1)) {
 	return make_small(arityval(*tuple_val(BIF_ARG_1)));
     }

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -5860,7 +5860,8 @@ send_error:
 /* node(Object) -> Node */
 
 BIF_RETTYPE node_1(BIF_ALIST_1)
-{ 
+{
+    /* NOTE: The JIT has its own implementation of this BIF. */
     if (is_not_node_container(BIF_ARG_1))
       BIF_ERROR(BIF_P, BADARG);
     BIF_RET(node_container_node_name(BIF_ARG_1));

--- a/erts/emulator/beam/erl_bif_guard.c
+++ b/erts/emulator/beam/erl_bif_guard.c
@@ -338,6 +338,8 @@ BIF_RETTYPE bit_size_1(BIF_ALIST_1)
     Uint low_bits;
     Uint bytesize;
     Uint high_bits;
+
+    /* NOTE: The JIT has its own implementation of this BIF. */
     if (is_binary(BIF_ARG_1)) {
 	bytesize = binary_size(BIF_ARG_1);
 	high_bits = bytesize >>  ((sizeof(Uint) * 8)-3);
@@ -367,6 +369,7 @@ BIF_RETTYPE bit_size_1(BIF_ALIST_1)
 
 BIF_RETTYPE byte_size_1(BIF_ALIST_1)
 {
+    /* NOTE: The JIT has its own implementation of this BIF. */
     if (is_binary(BIF_ARG_1)) {
 	Uint bytesize = binary_size(BIF_ARG_1);
 	if (binary_bitsize(BIF_ARG_1) > 0) {

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -153,6 +153,9 @@ void erts_init_map(void) {
 
 BIF_RETTYPE map_size_1(BIF_ALIST_1) {
     Sint size = erts_map_size(BIF_ARG_1);
+
+    /* NOTE: The JIT has its own implementation of this BIF. */
+
     if (size < 0) {
         BIF_P->fvalue = BIF_ARG_1;
         BIF_ERROR(BIF_P, BADMAP);
@@ -269,6 +272,7 @@ BIF_RETTYPE maps_get_2(BIF_ALIST_2) {
 }
 
 BIF_RETTYPE map_get_2(BIF_ALIST_2) {
+    /* NOTE: The JIT has its own implementation of this BIF. */
     BIF_RET(maps_get_2(BIF_CALL_ARGS));
 }
 
@@ -1251,6 +1255,7 @@ BIF_RETTYPE maps_is_key_2(BIF_ALIST_2) {
 }
 
 BIF_RETTYPE is_map_key_2(BIF_ALIST_2) {
+    /* NOTE: The JIT has its own implementation of this BIF. */
     BIF_RET(maps_is_key_2(BIF_CALL_ARGS));
 }
 

--- a/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
@@ -66,6 +66,7 @@ my @beam_global_funcs = qw(
     handle_map_get_badkey
     handle_map_get_badmap
     handle_map_size_error
+    handle_node_error
     handle_not_error
     handle_or_error
     handle_tl_error

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -734,6 +734,9 @@ bif_or j s s d
 bif1 Fail Bif=u$bif:erlang:not/1 Src=d Dst=d => bif_not Fail Src Dst
 bif_not j S d
 
+bif1 Fail Bif=u$bif:erlang:node/1 Src=d Dst=d => bif_node Fail Src Dst
+bif_node j S d
+
 gc_bif1 Fail Live Bif=u$bif:erlang:bit_size/1 Src Dst=d =>
     bif_bit_size Fail Src Dst
 bif_bit_size j s d

--- a/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
@@ -58,6 +58,7 @@ my @beam_global_funcs = qw(
     handle_map_get_badkey
     handle_map_get_badmap
     handle_map_size_error
+    handle_node_error
     i_band_body_shared
     i_band_guard_shared
     i_bif_body_shared

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -706,6 +706,9 @@ bif1 Fail Bif=u$bif:erlang:get/1 Src=s Dst=d => get(Src, Dst)
 bif2 Fail u$bif:erlang:element/2 S1=ixy S2 Dst => bif_element Fail S1 S2 Dst
 bif_element j s s d
 
+bif1 Fail Bif=u$bif:erlang:node/1 Src=d Dst=d => bif_node Fail Src Dst
+bif_node j S d
+
 gc_bif1 Fail Live Bif=u$bif:erlang:bit_size/1 Src Dst=d =>
     bif_bit_size Bif Fail Src Dst
 bif_bit_size b j s d

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -546,6 +546,8 @@ types(erlang, 'node', [_]) ->
     sub_unsafe(#t_atom{}, [any]);
 types(erlang, 'node', []) ->
     sub_unsafe(#t_atom{}, []);
+types(erlang, self, []) ->
+    sub_unsafe(pid, []);
 types(erlang, 'size', [_]) ->
     ArgType = join(#t_tuple{}, #t_bitstring{}),
     sub_unsafe(#t_integer{}, [ArgType]);

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -139,6 +139,8 @@ will_succeed(erlang, length, [Arg]) ->
     succeeds_if_type(Arg, proper_list());
 will_succeed(erlang, map_size, [Arg]) ->
     succeeds_if_type(Arg, #t_map{});
+will_succeed(erlang, node, [Arg]) ->
+    succeeds_if_type(Arg, identifier);
 will_succeed(erlang, 'and', [_, _]=Args) ->
     succeeds_if_types(Args, beam_types:make_boolean());
 will_succeed(erlang, 'not', [Arg]) ->
@@ -543,7 +545,7 @@ types(erlang, 'map_get', [Key, Map]) ->
     RetType = erlang_map_get_type(Key, Map),
     sub_unsafe(RetType, [any, #t_map{}]);
 types(erlang, 'node', [_]) ->
-    sub_unsafe(#t_atom{}, [any]);
+    sub_unsafe(#t_atom{}, [identifier]);
 types(erlang, 'node', []) ->
     sub_unsafe(#t_atom{}, []);
 types(erlang, self, []) ->

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -39,9 +39,10 @@
 %%    - other                Other types.
 %%       -- #t_fun{}          Fun.
 %%       -- #t_map{}          Map.
-%%       -- pid
-%%       -- port
-%%       -- reference
+%%       -- identifier
+%%         -- pid
+%%         -- port
+%%         -- reference
 %%       -- #t_bs_matchable{} Binary-matchable types.
 %%         -- #t_bitstring{}    Bitstring.
 %%         -- #t_bs_context{}   Match context.
@@ -147,13 +148,14 @@
                        #t_list{} | #t_cons{} | 'nil' |
                        'other' |
                        #t_map{} |
+                       'identifier' |
                        'pid' |
                        'port' |
                        'reference' |
                        #t_tuple{}.
 
 -type other_type() :: 'none' | #t_fun{} | #t_map{} |
-                      'pid' | 'port' | 'reference' |
+                      'pid' | 'port' | 'reference' | 'identifier' |
                       #t_bitstring{} | #t_bs_context{} |
                       #t_bs_matchable{}.
 

--- a/lib/compiler/test/property_test/beam_types_prop.erl
+++ b/lib/compiler/test/property_test/beam_types_prop.erl
@@ -185,7 +185,7 @@ term_types(Depth) ->
     nested_generators(Depth) ++
         numerical_generators() ++
         [gen_atom(), gen_bs_matchable(),
-         pid, port, reference, other].
+         pid, port, reference, identifier, other].
 
 numerical_generators() ->
     [gen_integer(), gen_float(), gen_number()].


### PR DESCRIPTION
The `node/1` BIF is frequently called by code in `gen_server`, `gen_statem`, `proc_lib`, and other standard library functions. This pull request optimizes it by producing inlined native code instead of calling the BIF code. There also some improvements in the compiler of the type analysis for `node/1` and `self/0`.