### PR TITLE
Fix race receiving fragmented messages on terminating connection

### DIFF
--- a/lib/kernel/doc/src/logger_formatter.xml
+++ b/lib/kernel/doc/src/logger_formatter.xml
@@ -154,7 +154,7 @@
 	    <p>The value of this parameter is used as
 	      the <c>time_designator</c> option
 	      to <seemfa marker="stdlib:calendar#system_time_to_rfc3339/2">
-		<c>calendar:system_time_to_rcf3339/2</c></seemfa>.</p>
+		<c>calendar:system_time_to_rfc3339/2</c></seemfa>.</p>
 	  </item>
 	  <tag><c>time_offset = integer() | [byte()]</c></tag>
 	  <item>
@@ -179,7 +179,7 @@
 	    <p>The value of this parameter is used as
 	      the <c>offset</c> option
 	      to <seemfa marker="stdlib:calendar#system_time_to_rfc3339/2">
-		<c>calendar:system_time_to_rcf3339/2</c></seemfa>.</p>
+		<c>calendar:system_time_to_rfc3339/2</c></seemfa>.</p>
 	  </item>
 	</taglist>
       </desc>


### PR DESCRIPTION
Could potentially cause memory leaks as well as double free crashes.

Have not been seen to cause problem other then `ASSERT(... (dep->dflags & DFLAG_SEND_SENDER) ...)` failing on debug built beam.

