### PR TITLE
BEAM SSA checker

### DIFF
--- a/lib/compiler/doc/src/Makefile
+++ b/lib/compiler/doc/src/Makefile
@@ -36,7 +36,7 @@ EDOC_REF3_FILES =  cerl.xml cerl_trees.xml cerl_clauses.xml
 
 XML_PART_FILES = internal.xml
 XML_NOTES_FILES = notes.xml
-XML_INTERNAL_FILES = beam_ssa.xml
+XML_INTERNAL_FILES = beam_ssa.xml ssa_checks.xml
 
 XML_GEN_FILES = $(XML_INTERNAL_FILES:%=$(XMLDIR)/%)
 

--- a/lib/compiler/doc/src/compile.xml
+++ b/lib/compiler/doc/src/compile.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>1996</year><year>2022</year>
+      <year>1996</year><year>2023</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -589,7 +589,17 @@ module.beam: module.erl \
               more information.
 	    </p>
           </item>
-        </taglist>
+
+          <tag><c>{check_ssa, Tag :: atom()}</c></tag>
+          <item>
+            <p>Parse and check assertions on the structure and content
+            of the BEAM SSA code produced by the compiler. The
+            <c>Tag</c> indicates the set of assertions to check and
+            after which compiler pass the check is performed. This
+            option is internal to the compiler and can be changed or
+            removed at any time without prior warning.</p>
+          </item>
+	</taglist>
 
         <p>If warnings are turned on (option <c>report_warnings</c>
           described earlier), the following options control what type of

--- a/lib/compiler/doc/src/internal.xml
+++ b/lib/compiler/doc/src/internal.xml
@@ -4,7 +4,7 @@
 <internal xmlns:xi="http://www.w3.org/2001/XInclude">
   <header>
     <copyright>
-      <year>2018</year><year>2021</year>
+      <year>2018</year><year>2023</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -35,5 +35,6 @@
   <xi:include href="cerl_trees.xml"/>
   <xi:include href="cerl_clauses.xml"/>
   <xi:include href="beam_ssa.xml"/>
+  <xi:include href="ssa_checks.xml"/>
 </internal>
 

--- a/lib/compiler/internal_doc/ssa_checks.md
+++ b/lib/compiler/internal_doc/ssa_checks.md
@@ -1,0 +1,124 @@
+BEAM SSA Checks
+===============
+
+While developing optimizations operating on the BEAM SSA it is often
+hard to check that various transforms have the intended effect. For
+example, unless a transform produces crashing code, it is hard to
+detect that the transform is broken. Likewise missing an optimization
+opportunity is also hard to detect.
+
+To simplify the creation of tests on BEAM SSA the compiler has an
+internal mode in which it parses and checks assertions on the
+structure and content of the produced BEAM SSA code. This is a short
+introduction to the syntax and semantics of the SSA checker
+functionality.
+
+Syntax
+------
+
+SSA checks are embedded in the source code as comments starting with
+with one of `%ssa%`, `%%ssa%` or `%%%ssa%`. This is a short
+introduction the syntax, for the full syntax please refer to the
+`ssa_check_when_clause` production in `erl_parse.yrl`.
+
+SSA checks can be placed inside any Erlang function, for example:
+
+    t0() ->
+    %ssa% () when post_ssa_opt ->
+    %ssa%   ret(#{}).
+      #{}.
+
+will check that `t0/0` returns the literal `#{}`. If we want to check
+that a function returns its first formal parameter, we can write:
+
+    t1(A, _B) ->
+    %ssa% (X, _) when post_ssa_opt ->
+    %ssa%   ret(X).
+      A.
+
+Note how we match the first formal parameter using `X`. The reason for
+having our own formal parameters for the SSA check, is that we don't
+want to introduce new identifiers at the Erlang level to support
+SSA-level checks. Consider if `t1/2` had been defined as `t1([A|As],
+B)` we would have had to introduce a new identifier for the aggregate
+value `[A|As]`.
+
+The full syntax for a SSA check clause is:
+
+    <expected-result>? (<formals>) when <pipeline-location> -> <checks> '.'
+
+where `<expected-result>` can be one of `pass` (the check must
+succeed), `fail` and `xfail` (the check must fail). Omitting
+`<expected-result>` is parsed as an implicit `pass`.
+
+`<formals>` is a comma-separated list of variables.
+
+`<pipeline-location>` specifies when in the compiler pipeline to run
+the checks. For now the only supported value for `<pipeline-location>`
+is `post_ssa_opt` which runs the checks after the `ssa_opt` pass.
+
+`<checks>` is a comma-separated list of matches against the BEAM SSA
+code. For non-flow-control operations the syntax is:
+
+    <variable> = <operation> ( <arguments> ) <annotation>?
+
+where `<operation>` is the `#b_set.op` field from the internal SSA
+representation. BIFs are written as `bif:<atom>`.
+
+`<arguments>` is a comma-separated list of variables or literals.
+
+For flow control operations and labels, the syntax is as follows:
+
+    br(<bool>, <true-label>, <false-label>)
+
+    switch(<value>, <fail-label>, [{<label>,<value>},...])
+
+	ret(<value>)
+
+	label <value>
+
+where `<value>` is a literal or a variable.
+
+A check can also include an assertion on operation annotations. The
+assertion is written as a map-like pattern following the argument
+list, for example:
+
+    t0() ->
+    %ssa% () when post_ssa_opt ->
+    %ssa% _ = call(fun return_int/0) { result_type => {t_integer,{17,17}},
+    %ssa%                              location => {_,32} },
+    %ssa% _ = call(fun return_tuple/0) {
+    %ssa%    result_type => {t_tuple,2,true,#{1 => {t_integer,{1,1}},
+    %ssa%                                     2 => {t_integer,{2,2}}}}
+    %ssa% }.
+        X = return_int(),
+        Y = return_tuple(),
+        {X, Y}.
+
+Semantics
+---------
+
+When an SSA assertion is matched against the BEAM SSA for a function,
+patterns are applied sequentially. If the current pattern doesn't
+match, the checker tries with the next instruction. If the checker
+reaches the end of the SSA representation without having matched all
+patterns, the check is considered failed otherwise the assertion is
+considered successful. When a pattern is matched against an SSA
+operation, the values of variables already bound are considered and if
+the patterns matches, free variables introduced in the successfully
+matched pattern are bound to the values they have in the matched
+operation.
+
+Compiler integration
+--------------------
+
+The BEAM SSA checker is enabled by the compiler option
+`{check_ssa,post_ssa_opt}`. When enabled, a failed SSA assertion will
+be reported using the same mechanisms as an ordinary compilation
+error.
+
+Limitations
+-----------
+
+* Unbound variables are not allowed in the key-part of map literals nor
+in annotation assertions.

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -63,6 +63,7 @@ MODULES =  \
 	beam_ssa_bc_size \
 	beam_ssa_bool \
 	beam_ssa_bsm \
+	beam_ssa_check \
 	beam_ssa_codegen \
 	beam_ssa_dead \
 	beam_ssa_lint \
@@ -213,6 +214,7 @@ $(EBIN)/beam_listing.beam: core_parse.hrl v3_kernel.hrl beam_ssa.hrl \
 $(EBIN)/beam_ssa.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_bsm.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_bool.beam: beam_ssa.hrl
+$(EBIN)/beam_ssa_check.beam: beam_ssa.hrl beam_types.hrl
 $(EBIN)/beam_ssa_codegen.beam: beam_ssa.hrl beam_asm.hrl
 $(EBIN)/beam_ssa_dead.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_lint.beam: beam_ssa.hrl

--- a/lib/compiler/src/beam_ssa_check.erl
+++ b/lib/compiler/src/beam_ssa_check.erl
@@ -1,0 +1,360 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+
+-module(beam_ssa_check).
+
+-export([module/2, format_error/1]).
+
+-import(lists, [reverse/1, flatten/1]).
+
+-include("beam_ssa.hrl").
+
+%%-define(DEBUG, true).
+
+-ifdef(DEBUG).
+-define(DP(FMT, ARGS), io:format(FMT, ARGS)).
+-define(DP(FMT), io:format(FMT)).
+-else.
+-define(DP(FMT, ARGS), skip).
+-define(DP(FMT), skip).
+-endif.
+
+-spec module(beam_ssa:b_module(), atom()) -> 'ok' | {'error',list()}.
+
+module(#b_module{body=Body}, Tag) ->
+    Errors = functions(Tag, Body),
+    case Errors of
+        [] ->
+            ok;
+        _ ->
+            {error, reverse(Errors)}
+    end.
+
+functions(Tag, [F|Rest]) ->
+    function(Tag, F) ++ functions(Tag, Rest);
+functions(_Tag, []) ->
+    [].
+
+function(Tag, F) ->
+    run_checks(beam_ssa:get_anno(ssa_checks, F, []), F, Tag).
+
+run_checks([{ssa_check_when,WantedResult,{atom,_,Tag},Args,Exprs}|Checks],
+           F, Tag) ->
+    check_function(Args, Exprs, WantedResult, F) ++ run_checks(Checks, F, Tag);
+run_checks([_|Checks], F, Tag) ->
+    run_checks(Checks, F, Tag);
+run_checks([], _, _) ->
+    [].
+
+check_function(CheckArgs, Exprs, {atom,Loc,pass}, #b_function{args=_Args}=F) ->
+    run_check(CheckArgs, Exprs, Loc, F);
+check_function(CheckArgs, Exprs, {atom,Loc,Key}, #b_function{args=_Args}=F)
+  when Key =:= fail ; Key =:= xfail ->
+    case run_check(CheckArgs, Exprs, Loc, F) of
+        [] ->
+            %% This succeeded but should have failed
+            {File,_} = beam_ssa:get_anno(location, F),
+            [{File,[{Loc,?MODULE,xfail_passed}]}];
+        _ ->
+            []
+    end;
+check_function(_, _, {atom,Loc,Result}, F) ->
+    {File,_} = beam_ssa:get_anno(location, F),
+    [{File,[{Loc,?MODULE,{unknown_result_kind,Result}}]}].
+
+run_check(CheckArgs, Exprs, Loc, #b_function{args=FunArgs}=F) ->
+    init_and_run_check(CheckArgs, FunArgs, #{}, Loc, Exprs, F).
+
+
+%% Create a mapping from each argument in the check pattern to the
+%% actual arguments of the SSA function.
+init_and_run_check([{var,Loc,'_'}|CheckArgs],
+                   [#b_var{}|FunArgs],
+                   Env, _, Exprs, F) ->
+    init_and_run_check(CheckArgs, FunArgs, Env, Loc, Exprs, F);
+init_and_run_check([{var,Loc,CheckV}|CheckArgs],
+                   [V=#b_var{}|FunArgs],
+                   Env, _, Exprs, F) ->
+    init_and_run_check(CheckArgs, FunArgs, Env#{CheckV=>V}, Loc, Exprs, F);
+init_and_run_check([{'...',_}], [_|_], Env, _Loc, Exprs, F) ->
+    check_exprs(Exprs, Env, F);
+init_and_run_check([], [], Env, _Loc,  Exprs, F) ->
+    check_exprs(Exprs, Env, F);
+init_and_run_check([], _, _Env, Loc, _Exprs, F) ->
+    {File,_} = beam_ssa:get_anno(location, F),
+    [{File,[{Loc,?MODULE,too_few_pattern_args}]}];
+init_and_run_check(_, [], _Env, Loc, _Exprs, F) ->
+    {File,_} = beam_ssa:get_anno(location, F),
+    [{File,[{Loc,?MODULE,too_many_pattern_args}]}].
+
+check_exprs(Exprs, Env, #b_function{bs=Blocks}=F) ->
+    %% A function check executes sequentially on the blocks as if they
+    %% were in a beam ssa listing, so arrange the blocks in RPO and
+    %% insert a label for each new block.
+    Code =
+        lists:foldr(fun(Lbl, Acc) ->
+                            #b_blk{is=Is,last=Last} = map_get(Lbl, Blocks),
+                            [{label,Lbl}|Is] ++ [Last] ++ Acc
+                    end, [], beam_ssa:rpo(Blocks)),
+    ?DP("  Env ~p~n", [Env]),
+    ?DP("  Code~n   ~p~n", [Code]),
+    ?DP("  Checks~n   ~p~n", [Exprs]),
+    {File,_} = beam_ssa:get_anno(location, F),
+    check_expr_seq(Exprs, Code, Env, never, File).
+
+check_expr_seq([{check_expr,Loc,Args}|Rest]=Checks,
+               [First|Code], Env0, LastMatchedLoc, File) ->
+    Env = try
+              ?DP("trying:~n  pat: ~p~n  i: ~p~n", [Args, First]),
+              op_check(Args, First, Env0)
+          catch
+              throw:no_match ->
+                  ?DP("op_check did not match~n"),
+                  false;
+              error:_E ->
+                  ?DP("op_check failed ~p~n", [_E]),
+                  false
+          end,
+    case Env of
+        false ->
+            %% Continue with the next op in the code
+            check_expr_seq(Checks, Code, Env0, LastMatchedLoc, File);
+        Env ->
+            %% The code matched
+            check_expr_seq(Rest, Code, Env, Loc, File)
+     end;
+check_expr_seq([], _Blocks, _Env, _LastMatchedLoc, _File) ->
+    %% Done and all expressions matched.
+    [];
+check_expr_seq([{check_expr,Loc,Args}|_], [], Env, LastMatchedLoc, File) ->
+    %% We didn't find a match and we have no more code to look at
+    [{File,[{Loc,?MODULE,{no_match,Args,LastMatchedLoc,Env}}]}].
+
+
+op_check([set,Result,{atom,_,Op}|PArgs],
+         #b_set{dst=Dst,args=AArgs,op=Op}=_I, Env) ->
+    ?DP("trying set ~p:~n  res: ~p <-> ~p~n  args: ~p <-> ~p~n  i: ~p~n",
+        [Op, Result, Dst, PArgs, AArgs, _I]),
+    op_check_call(Op, Result, Dst, PArgs, AArgs, Env);
+op_check([set,Result,{{atom,_,bif},{atom,_,Op}}|PArgs],
+         #b_set{dst=Dst,args=AArgs,op={bif,Op}}=_I, Env) ->
+    ?DP("trying bif ~p:~n  res: ~p <-> ~p~n  args: ~p <-> ~p~n  i: ~p~n",
+        [Op, Result, Dst, PArgs, AArgs, _I]),
+    op_check_call(Op, Result, Dst, PArgs, AArgs, Env);
+op_check([none,{atom,_,ret}|PArgs], #b_ret{arg=AArg}=_I, Env) ->
+    ?DP("trying return:, arg: ~p <-> ~p~n  i: ~p~n",
+        [PArgs, [AArg], _I]),
+    post_args(PArgs, [AArg], Env);
+op_check([none,{atom,_,br}|PArgs],
+         #b_br{bool=ABool,succ=ASucc,fail=AFail}=_I, Env) ->
+    ?DP("trying br: arg: ~p <-> ~p~n  i: ~p~n",
+        [PArgs, [ABool,ASucc,AFail], _I]),
+    post_args(PArgs, [ABool,#b_literal{val=ASucc},#b_literal{val=AFail}], Env);
+op_check([none,{atom,_,switch},PArg,PFail,{list,_,PArgs}],
+         #b_switch{arg=AArg,fail=AFail,list=AList}=_I, Env0) ->
+    ?DP("trying switch: arg: ~p <-> ~p~n  i: ~p~n",
+        [PArgs, [AArg,AFail,AList], _I]),
+    Env = env_post(PArg, AArg, env_post(PFail, #b_literal{val=AFail}, Env0)),
+    post_switch_args(PArgs, AList, Env);
+op_check([label,PLbl], {label,ALbl}, Env) when is_integer(ALbl) ->
+    env_post(PLbl, #b_literal{val=ALbl}, Env).
+
+op_check_call(Op, PResult, AResult, PArgs, AArgs, Env0) ->
+    Env = env_post(PResult, AResult, Env0),
+    case Op of
+        phi ->
+            post_phi_args(PArgs, AArgs, Env);
+        _ ->
+            post_args(PArgs, AArgs, Env)
+    end.
+
+post_args([{'...',_}], _, Env) ->
+    Env;
+post_args([PA|PArgs], [AA|AArgs], Env) ->
+    post_args(PArgs, AArgs, env_post(PA, AA, Env));
+post_args([], [], Env) ->
+    Env;
+post_args(Pattern, Args, _Env) ->
+    io:format("Failed to match ~p <-> ~p~n", [Pattern, Args]),
+    error({internal_pattern_match_error,post_args}).
+
+post_phi_args([{'...',_}], _, Env) ->
+    Env;
+post_phi_args([{tuple,_,[PVar,PLbl]}|PArgs], [{AVar,ALbl}|AArgs], Env0) ->
+    Env = env_post(PVar, AVar, env_post(PLbl, ALbl, Env0)),
+    post_phi_args(PArgs, AArgs, Env);
+post_phi_args([], [], Env) ->
+    Env.
+
+post_switch_args([{'...',_}], _, Env) ->
+    Env;
+post_switch_args([{tuple,_,[PVal,PLbl]}|PArgs], [{AVal,ALbl}|AArgs], Env0) ->
+    Env = env_post(PVal, AVal, env_post(PLbl, #b_literal{val=ALbl}, Env0)),
+    post_switch_args(PArgs, AArgs, Env);
+post_switch_args([], [], Env) ->
+    Env.
+
+env_post({var,_,PV}, Actual, Env) ->
+    env_post1(PV, Actual, Env);
+env_post({atom,_,Atom}, #b_literal{val=Atom}, Env) ->
+    Env;
+env_post({atom,_,Atom}, Atom, Env) when is_atom(Atom) ->
+    Env;
+env_post({local_fun,{atom,_,N},{integer,_,A}},
+         #b_local{name=#b_literal{val=N},arity=A}, Env) ->
+    Env;
+env_post({external_fun,{atom,_,M},{atom,_,N},{integer,_,A}},
+         #b_remote{mod=#b_literal{val=M},name=#b_literal{val=N},arity=A},
+         Env) ->
+    Env;
+env_post({external_fun,{atom,_,M},{atom,_,N},{integer,_,A}},
+         #b_literal{val=F}, Env) ->
+    {M,N,A} = erlang:fun_info_mfa(F),
+    Env;
+env_post({integer,_,V}, #b_literal{val=V}, Env) ->
+    Env;
+env_post({integer,_,V}, V, Env) when is_integer(V) ->
+    Env;
+env_post({float,_,V}, #b_literal{val=V}, Env) ->
+    Env;
+env_post({float,_,V}, V, Env) when is_float(V) ->
+    Env;
+env_post({float_epsilon,{float,_,V},{float,_,Epsilon}},
+         #b_literal{val=Actual}, Env) ->
+    true = abs(V - Actual) < Epsilon,
+    Env;
+env_post({float_epsilon,{float,_,V},{float,_,Epsilon}}, Actual, Env)
+  when is_float(Actual) ->
+    true = abs(V - Actual) < Epsilon,
+    Env;
+env_post({binary,_,Bits}, #b_literal{val=V}, Env) ->
+    post_bitstring(Bits, V, Env);
+env_post({binary,_,Bits}, Bin, Env) when is_bitstring(Bin)->
+    post_bitstring(Bits, Bin, Env);
+env_post({list,_,Elems}, #b_literal{val=Ls}, Env) ->
+    post_list(Elems, Ls, Env);
+env_post({list,_,Elems}, Ls, Env) when is_list(Ls) ->
+    post_list(Elems, Ls, Env);
+env_post({tuple,_,Es}, #b_literal{val=Ls}, Env) ->
+    post_tuple(Es, tuple_to_list(Ls), Env);
+env_post({tuple,_,Es}, Tuple, Env) when is_tuple(Tuple) ->
+    post_tuple(Es, tuple_to_list(Tuple), Env);
+env_post({map,_,Elems}, #b_literal{val=Map}, Env) when is_map(Map) ->
+    post_map(Elems, Map, Env);
+env_post({map,_,Elems}, Map, Env) when is_map(Map) ->
+    post_map(Elems, Map, Env);
+env_post(_Pattern, _Args, _Env) ->
+    ?DP("Failed to match ~p <-> ~p~n", [_Pattern, _Args]),
+    error({internal_pattern_match_error,env_post}).
+
+env_post1('_', _Actual, Env) ->
+    ?DP("Ignored posting _ => ~p~n", [_Actual]),
+    Env;
+env_post1(PV, Actual, Env) when is_map_key(PV, Env) ->
+    ?DP("Attempting post ~p => ~p in ~p~n", [PV, Actual, Env]),
+    Actual = map_get(PV, Env),
+    Env;
+env_post1(PV, #b_var{}=Actual, Env) ->
+    ?DP("Posting ~p => ~p~n", [PV, Actual]),
+    Env#{PV => Actual};
+env_post1(PV, #b_literal{}=Actual, Env) ->
+    ?DP("Posting ~p => ~p~n", [PV, Actual]),
+    Env#{PV => Actual};
+env_post1(_Pattern, _Actual, _Env) ->
+    ?DP("Failed to match ~p <-> ~p~n", [_Pattern, _Actual]),
+    error({internal_pattern_match_error,env_post1}).
+
+post_bitstring(Bytes, Actual, _Env) ->
+    Actual = build_bitstring(Bytes, <<>>).
+
+%% Convert the parsed literal binary to an actual bitstring.
+build_bitstring([{integer,_,V}|Bytes], Acc) ->
+    build_bitstring(Bytes, <<Acc/bits, V:8>>);
+build_bitstring([{{integer,_,V},{integer,_,N}}|Bytes], Acc) ->
+    build_bitstring(Bytes, <<Acc/bits, V:N>>);
+build_bitstring([], Acc) ->
+    Acc.
+
+post_list([{'...',_}], _, Env) ->
+    Env;
+post_list([Elem|Elements], [A|Actual], Env0) ->
+    Env = env_post(Elem, A, Env0),
+    post_list(Elements, Actual, Env);
+post_list([], [], Env) ->
+    Env;
+post_list(Elem, Actual, Env) ->
+    env_post(Elem, Actual, Env).
+
+post_tuple([{'...',_}], _, Env) ->
+    Env;
+post_tuple([Elem|Elements], [A|Actual], Env0) ->
+    Env = env_post(Elem, A, Env0),
+    post_tuple(Elements, Actual, Env);
+post_tuple([], [], Env) ->
+    Env.
+
+post_map([{Key,Val}|Items], Map, Env) ->
+    K = build_map_key(Key),
+    V = build_map_key(Val),
+    #{K := V} = Map,
+
+    post_map(Items, maps:remove(K, Map), Env);
+post_map([], Map, Env) ->
+    0 = maps:size(Map),
+    Env.
+
+build_map_key({atom,_,A}) ->
+    A;
+build_map_key({local_fun,{atom,_,N},{integer,_,A}}) ->
+    #b_local{name=#b_literal{val=N},arity=A};
+build_map_key({integer,_,V}) ->
+    V;
+build_map_key({float,_,V}) ->
+    V;
+build_map_key({binary,_,Bits}) ->
+    build_bitstring(Bits, <<>>);
+build_map_key({list,_,Elems}) ->
+    build_map_key_list(Elems);
+build_map_key({tuple,_,Elems}) ->
+    list_to_tuple([build_map_key(E) || E <- Elems]);
+build_map_key({map,_,Elems}) ->
+    maps:from_list([{build_map_key(K),build_map_key(V)} || {K,V} <- Elems]);
+build_map_key(_Key) ->
+    ?DP("Failed to match ~p~n", [_Key]),
+    error({internal_pattern_match_error,build_map_key}).
+
+build_map_key_list([E|Elems]) ->
+    [build_map_key(E)|build_map_key_list(Elems)];
+build_map_key_list([]) ->
+    [];
+build_map_key_list(E) ->
+    build_map_key(E).
+
+-spec format_error(term()) -> nonempty_string().
+
+format_error(xfail_passed) ->
+    "test which was expected to fail passed";
+format_error({unknown_result_kind,Result}) ->
+    "unknown expected result: " ++ atom_to_list(Result);
+format_error(too_many_pattern_args) ->
+    "pattern has more arguments than the function";
+format_error(too_few_pattern_args) ->
+    "pattern has fewer arguments than the function";
+format_error({no_match,_Args,_LastMatchedLoc,Env}) ->
+    flatten(io_lib:format("no match found for pattern, env: ~p~n", [Env])).
+

--- a/lib/compiler/src/beam_ssa_check.erl
+++ b/lib/compiler/src/beam_ssa_check.erl
@@ -117,7 +117,7 @@ check_exprs(Exprs, Env, #b_function{bs=Blocks}=F) ->
     {File,_} = beam_ssa:get_anno(location, F),
     check_expr_seq(Exprs, Code, Env, never, File).
 
-check_expr_seq([{check_expr,Loc,Args}|Rest]=Checks,
+check_expr_seq([{check_expr,Loc,Args,_}|Rest]=Checks,
                [First|Code], Env0, LastMatchedLoc, File) ->
     Env = try
               ?DP("trying:~n  pat: ~p~n  i: ~p~n", [Args, First]),
@@ -141,7 +141,7 @@ check_expr_seq([{check_expr,Loc,Args}|Rest]=Checks,
 check_expr_seq([], _Blocks, _Env, _LastMatchedLoc, _File) ->
     %% Done and all expressions matched.
     [];
-check_expr_seq([{check_expr,Loc,Args}|_], [], Env, LastMatchedLoc, File) ->
+check_expr_seq([{check_expr,Loc,Args,_}|_], [], Env, LastMatchedLoc, File) ->
     %% We didn't find a match and we have no more code to look at
     [{File,[{Loc,?MODULE,{no_match,Args,LastMatchedLoc,Env}}]}].
 

--- a/lib/compiler/src/cerl.erl
+++ b/lib/compiler/src/cerl.erl
@@ -156,6 +156,7 @@
 -type c_map()     :: #c_map{}.
 -type c_map_pair() :: #c_map_pair{}.
 -type c_module()  :: #c_module{}.
+-type c_opaque()  :: #c_opaque{}.
 -type c_primop()  :: #c_primop{}.
 -type c_receive() :: #c_receive{}.
 -type c_seq()     :: #c_seq{}.
@@ -168,7 +169,8 @@
               | c_call()   | c_case()   | c_catch()   | c_clause()  | c_cons()
               | c_fun()    | c_let()    | c_letrec()  | c_literal()
 	      | c_map()    | c_map_pair()
-	      | c_module() | c_primop() | c_receive() | c_seq()
+	      | c_module() | c_opaque()
+              | c_primop() | c_receive() | c_seq()
               | c_try()    | c_tuple()  | c_values()  | c_var().
 
 -type var_name() :: integer() | atom() | {atom(), integer()}.
@@ -292,7 +294,8 @@ type(#c_seq{}) -> seq;
 type(#c_try{}) -> 'try';
 type(#c_tuple{}) -> tuple;
 type(#c_values{}) -> values;
-type(#c_var{}) -> var.
+type(#c_var{}) -> var;
+type(#c_opaque{}) -> opaque.
 
 
 %% @spec is_leaf(Node::cerl()) -> boolean()

--- a/lib/compiler/src/cerl_trees.erl
+++ b/lib/compiler/src/cerl_trees.erl
@@ -198,7 +198,9 @@ map_1(F, T) ->
 	    update_c_module(T, map(F, module_name(T)),
 			    map_list(F, module_exports(T)),
 			    map_pairs(F, module_attrs(T)),
-			    map_pairs(F, module_defs(T)))
+			    map_pairs(F, module_defs(T)));
+        opaque ->
+            T
     end.
 
 map_list(F, [T | Ts]) ->
@@ -312,7 +314,9 @@ fold_1(F, S, T) ->
 					    fold(F, S, module_name(T)),
 					    module_exports(T)),
 				  module_attrs(T)),
-		       module_defs(T))
+		       module_defs(T));
+        opaque ->
+            S
     end.
 
 fold_list(F, S, [T | Ts]) ->
@@ -483,7 +487,9 @@ mapfold(Pre, Post, S00, T0) ->
 		    {Es, S2} = mapfold_list(Pre, Post, S1, module_exports(T)),
 		    {As, S3} = mapfold_pairs(Pre, Post, S2, module_attrs(T)),
 		    {Ds, S4} = mapfold_pairs(Pre, Post, S3, module_defs(T)),
-		    Post(update_c_module(T, N, Es, As, Ds), S4)
+		    Post(update_c_module(T, N, Es, As, Ds), S4);
+                opaque ->
+                    Post(T, S0)
 	    end;
 	skip ->
 	    {T0, S00}
@@ -657,7 +663,9 @@ variables(T, S) ->
 		    ordsets:subtract(Vs1, Vs2);
 		false ->
 		    ordsets:union(Vs1, Vs2)
-	    end
+	    end;
+        opaque ->
+            []
     end.
 
 vars_in_list(Ts, S) ->
@@ -782,7 +790,9 @@ next_free(T, Max) ->
             Max2 = next_free(letrec_body(T), Max1),
             next_free_in_list(letrec_vars(T), Max2);
         module ->
-            next_free_in_defs(module_defs(T), Max)
+            next_free_in_defs(module_defs(T), Max);
+        opaque ->
+            Max
     end.
 
 next_free_in_list([H | T], Max) ->
@@ -974,7 +984,10 @@ label(T, N, Env) ->
 	    {Ds, N3} = label_defs(module_defs(T), N2, Env1),
 	    {Es, N4} = label_list(module_exports(T), N3, Env1),
 	    {As, N5} = label_ann(T, N4),
-	    {ann_c_module(As, module_name(T), Es, Ts, Ds), N5}
+	    {ann_c_module(As, module_name(T), Es, Ts, Ds), N5};
+        opaque ->
+	    %% Not labeled.
+	    {T, N}
     end.
 
 label_list([T | Ts], N, Env) ->

--- a/lib/compiler/src/compiler.app.src
+++ b/lib/compiler/src/compiler.app.src
@@ -39,6 +39,7 @@
              beam_ssa_bc_size,
              beam_ssa_bool,
              beam_ssa_bsm,
+             beam_ssa_check,
              beam_ssa_codegen,
              beam_ssa_dead,
              beam_ssa_lint,

--- a/lib/compiler/src/core_parse.hrl
+++ b/lib/compiler/src/core_parse.hrl
@@ -87,6 +87,8 @@
 		   attrs :: [{cerl:cerl(), cerl:cerl()}],
 		   defs :: [{cerl:cerl(), cerl:cerl()}]}).
 
+-record(c_opaque, {anno=[] :: list(), val :: any()}).
+
 -record(c_primop, {anno=[] :: list(), name :: cerl:cerl(),
 		   args :: [cerl:cerl()]}).
 

--- a/lib/compiler/src/core_pp.erl
+++ b/lib/compiler/src/core_pp.erl
@@ -359,7 +359,9 @@ format_1(#c_module{name=N,exports=Es,attrs=As,defs=Ds}, Ctxt) ->
      format_funcs(Ds, Ctxt),
      nl_indent(Ctxt)
      | "end"
-    ].
+    ];
+format_1(#c_opaque{val=V}, Ctxt) ->
+    ["%% Opaque: ", format_1(#c_literal{val=V}, Ctxt)].
 
 format_funcs(Fs, Ctxt) ->
     format_vseq(Fs,

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -403,7 +403,9 @@ expr(#c_try{anno=A,arg=E0,vars=Vs0,body=B0,evars=Evs0,handler=H0}=Try, _, Sub0) 
 	    {Evs1,Sub2} = var_list(Evs0, Sub0),
 	    H1 = body(H0, value, Sub2),
 	    Try#c_try{arg=E1,vars=Vs1,body=B1,evars=Evs1,handler=H1}
-    end.
+    end;
+expr(#c_opaque{}=O, effect, _Sub) ->
+    O.
 
 %% If a fun or its application is used as an argument, then it's unsafe to
 %% handle it in effect context as the side-effects may rely on its return

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -975,7 +975,9 @@ expr({op,L,Op,L0,R0}, St0) ->
     LineAnno = full_anno(L, St1),
     {#icall{anno=#a{anno=LineAnno},		%Must have an #a{}
 	    module=#c_literal{anno=LineAnno,val=erlang},
-	    name=#c_literal{anno=LineAnno,val=Op},args=As},Aps,St1}.
+	    name=#c_literal{anno=LineAnno,val=Op},args=As},Aps,St1};
+expr({ssa_check_when,L,WantedResult,Args,Tag,Clauses}, St) ->
+    {#c_opaque{anno=full_anno(L, St),val={ssa_check_when,WantedResult,Tag,Args,Clauses}}, [], St}.
 
 blockify(L0, {sequential_match,_L1,First,Then}, E) ->
     [{single_match,L0,First,E}|blockify(L0, Then, E)];
@@ -2837,6 +2839,8 @@ uexpr(#ibinary{anno=A,segments=Ss}, _, St) ->
 uexpr(#c_literal{}=Lit, _, St) ->
     Anno = get_anno(Lit),
     {set_anno(Lit, #a{us=[],anno=Anno}),St};
+uexpr(#c_opaque{}=Opaque, _, St) ->
+    {set_anno(Opaque, #a{us=[],anno=get_anno(Opaque)}),St};
 uexpr(Simple, _, St) ->
     true = is_simple(Simple),			%Sanity check!
     Vs = lit_vars(Simple),
@@ -3317,6 +3321,8 @@ cexpr(#icall{anno=A,module=Mod,name=Name,args=Args}, _As, St0) ->
 	false ->
 	    {#c_call{anno=Anno,module=Mod,name=Name,args=Args},[],A#a.us,St0}
     end;
+cexpr(O=#c_opaque{}, _As, St) ->
+    {O,[],[],St};
 cexpr(#iprimop{anno=A,name=Name,args=Args}, _As, St) ->
     {#c_primop{anno=A#a.anno,name=Name,args=Args},[],A#a.us,St};
 cexpr(#iprotect{anno=A,body=Es}, _As, St0) ->
@@ -3418,6 +3424,7 @@ skip_lowering(#c_call{}, _A) -> skip;
 skip_lowering(#c_cons{}, _A) -> skip;
 skip_lowering(#c_literal{}, _A) -> skip;
 skip_lowering(#c_map{}, _A) -> skip;
+skip_lowering(#c_opaque{}, _A) -> skip;
 skip_lowering(#c_primop{}, _A) -> skip;
 skip_lowering(#c_tuple{}, _A) -> skip;
 skip_lowering(T, A) -> {T, A}.

--- a/lib/compiler/src/v3_kernel.hrl
+++ b/lib/compiler/src/v3_kernel.hrl
@@ -70,5 +70,7 @@
 -record(k_break, {anno=[],args=[]}).
 -record(k_return, {anno=[],args=[]}).
 
+-record(k_opaque, {anno=[],val}).
+
 %%k_get_anno(Thing) -> element(2, Thing).
 %%k_set_anno(Thing, Anno) -> setelement(2, Thing, Anno).

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -356,6 +356,8 @@ format_1(#ifun{vars=Vs,body=B}, Ctxt) ->
      nl_indent(Ctxt1)
      | format(B, Ctxt1)
     ];
+format_1(#k_opaque{val=V}, _Ctxt) ->
+    ["** Opaque: ", io_lib:write(V), " **\n"];
 format_1(Type, _Ctxt) ->
     ["** Unsupported type: ",
      io_lib:write(Type)

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -16,6 +16,7 @@ MODULES= \
 	beam_jump_SUITE \
 	beam_reorder_SUITE \
 	beam_ssa_SUITE \
+	beam_ssa_check_SUITE \
 	beam_type_SUITE \
 	beam_types_SUITE \
 	beam_utils_SUITE \

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -28,6 +28,7 @@
          init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
 
+         annotation_checks/1,
          sanity_checks/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
@@ -36,7 +37,7 @@ all() ->
     [{group,post_ssa_opt_static}].
 
 groups() ->
-    [{post_ssa_opt_static,test_lib:parallel(),[sanity_checks]}].
+    [{post_ssa_opt_static,test_lib:parallel(),[annotation_checks, sanity_checks]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -50,6 +51,9 @@ init_per_group(_GroupName, Config) ->
 
 end_per_group(_GroupName, Config) ->
     Config.
+
+annotation_checks(Config) when is_list(Config) ->
+    run_post_ssa_opt(annotations, Config).
 
 sanity_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(sanity_checks, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/annotations.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/annotations.erl
@@ -1,0 +1,40 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-module(annotations).
+
+-export([t0/0]).
+
+%% Check annotations, do not add lines before this function without
+%% changing the location annotation.
+t0() ->
+%ssa% () when post_ssa_opt ->
+%ssa% _ = call(fun return_int/0) { result_type => {t_integer,{17,17}},
+%ssa%                              location => {_,32} },
+%ssa% _ = call(fun return_tuple/0) {
+%ssa%    result_type => {t_tuple,2,true,#{1 => {t_integer,{1,1}},
+%ssa%                                     2 => {t_integer,{2,2}}}}
+%ssa% }.
+    X = return_int(),
+    Y = return_tuple(),
+    {X, Y}.
+
+return_int() ->
+    17.
+
+return_tuple() ->
+    {1,2}.

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/gen_bs_size_unit_checks.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/gen_bs_size_unit_checks.erl
@@ -1,0 +1,229 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(gen_bs_size_unit_checks).
+
+-export([generate/2]).
+
+-import(lists, [reverse/1, seq/2, uniq/1, unzip/1, zip/2]).
+-import(string, [join/2]).
+
+generate(File, _Config) ->
+    InitialSizes = seq(0, 4) ++ [15, 16, 17, 31, 32, 33, 63, 64, 65,
+				 127, 128, 129, 255, 256, 257],
+    AddedSizes = seq(0, 4) ++ [15, 16 ,17, 31, 32, 33, 63, 64, 65,
+			       127, 128, 129, 255, 256, 257],
+    NoofElements = seq(1, 5),
+
+    _ = rand:seed(exro928ss, {123, 123534, 345345}),
+
+    Cases1 = [{Initial,Increment,Elements,FixedSize} ||
+		 Initial <- InitialSizes,
+		 Increment <- AddedSizes,
+		 Elements <- NoofElements,
+		 FixedSize <- [fixed, variable, mixed],
+		 Elements =< Increment,
+		 Increment > 0],
+    Cases2 = uniq(Cases1),
+    Cases = zip(seq(1, length(Cases2)), Cases2),
+
+    Out = [format_case(["bsu_test_", integer_to_list(Id)],
+                       Initial, Increment, Elements, FixedSize)
+	   || {Id, {Initial,Increment,Elements,FixedSize}} <- Cases],
+
+    Exports = [["-export([", Export, "]).\n"] || {Export, _} <- Out],
+    Bodies = [Body || {_, Body} <- Out],
+    Module = ["-module(bsu_tests).\n",
+	      "\n",
+	      Exports,
+	      "\n",
+	      Bodies
+	     ],
+    ok = file:write_file(File, Module).
+
+
+format_case(Name, InitialSize, AddedSize, NoofElements, fixed) ->
+    Expected = gcd(gcd(InitialSize, 256), AddedSize),
+    Es = make_elements(AddedSize, NoofElements, 0),
+    {Vars, Elements} = unzip(Es),
+    Comment = [io_lib:format("%% Adding ~p bits to initial accumulator"
+                             " of ~p bits using ~p elements.~n",
+                             [AddedSize, InitialSize, NoofElements]),
+               io_lib:format("%% Expected unit size is ~p~n", [Expected])],
+    {[Name, "/1"], body(Comment, Name, Vars, Expected, InitialSize, Elements)};
+format_case(Name, InitialSize, _, NoofElements, variable) ->
+    InitialUnit = gcd(InitialSize, 256),
+    {Vars, Elements, Unit} =
+	make_varsize_elements(NoofElements, 0, InitialUnit),
+    Comment = [io_lib:format("%% Adding a variable number of bits to initial"
+                             " accumulator of ~p bits using~n%% both fixed size"
+                             " and variable sized elements.~n",
+                             [InitialSize]),
+               io_lib:format("%% Expected unit size is ~p~n", [Unit])],
+    {[Name, "/1"], body(Comment, Name, Vars, Unit, InitialSize, Elements)};
+format_case(Name, InitialSize, AddedSize, NoofElements, mixed) ->
+    InitialUnit = gcd(InitialSize, 256),
+    Es = make_elements(AddedSize, NoofElements, 0),
+    {FixedVars, FixedElements} = unzip(Es),
+    {VaribleVars, VariableElements, Unit1} =
+	make_varsize_elements(NoofElements, NoofElements, InitialUnit),
+    Unit = gcd(gcd(InitialUnit, AddedSize), Unit1),
+    Elements = shuffle(FixedElements ++ VariableElements),
+    Vars = VaribleVars ++ FixedVars,
+    Comment = [io_lib:format("%% Adding a variable number of bits to initial"
+                             " accumulator of ~p bits~n%% using ~p elements.~n",
+                             [InitialSize, NoofElements]),
+               io_lib:format("%% Expected unit size is ~p~n", [Unit])],
+    {[Name, "/1"], body(Comment, Name, Vars, Unit, InitialSize, Elements)}.
+
+body(Comment, Name, Vars, Unit, InitialSize, Elements) ->
+    [Comment,
+     Name, "(Xs) ->\n",
+     "%%ssa% (_) when post_ssa_opt ->\n",
+     "%%ssa% _ = call(fun ", Name, "/2, _, A)"
+     " { result_type => {t_bitstring,", integer_to_list(Unit), "} }.\n",
+     "    ", Name, "(Xs, ", "<<0:", integer_to_list(InitialSize), ">>", ").\n\n",
+     Name, "([_", Vars, "|Xs], Acc) ->\n",
+     "    ", Name, "(Xs, ", "<<Acc/bitstring", Elements, ">>", ");\n",
+     Name, "([], Acc) ->\n",
+     "    Acc.\n\n"].
+
+make_elements(0, 0, _) ->
+    [];
+make_elements(Size, 1, Id) ->
+    [format_element_of_size(Size, Id)];
+make_elements(Size, NoofElements, Id) when Size =:= NoofElements ->
+    [format_element_of_size(1, Id)|
+     make_elements(Size - 1, NoofElements - 1, Id + 1)];
+make_elements(Size, NoofElements, Id) when Size > NoofElements ->
+    MaxSize = Size - NoofElements,
+    ElemSize = rand:uniform(MaxSize),
+    [format_element_of_size(ElemSize, Id)
+    |make_elements(Size - ElemSize, NoofElements - 1, Id + 1)].
+
+format_element_of_size(Size, Id) ->
+    case rand:uniform(2) of
+	1 ->
+	    format_bitstring_element(Size, Id);
+	2 ->
+	    format_integer_element(Size, Id)
+    end.
+
+format_integer_element(Size, Id) ->
+    case rand:uniform(2) of
+	1 ->
+	    literal_integer_element(Size);
+	2 ->
+	    variable_integer_element(Size, Id)
+    end.
+
+variable_integer_element(Size=32, Id) ->
+    Unit = make_unit(Size),
+    E = case rand:uniform(2) of
+	    1 ->
+		io_lib:format(", V~p:~p~s", [Id, Size, Unit]);
+	    2 ->
+		io_lib:format(", V~p/utf32", [Id])
+	end,
+    V = io_lib:format(", V~p", [Id]),
+    {V, E};
+variable_integer_element(Size, Id) ->
+    Unit = make_unit(Size),
+    E = io_lib:format(", V~p:~p~s", [Id, Size, Unit]),
+    V = io_lib:format(", V~p", [Id]),
+    {V, E}.
+
+literal_integer_element(Size) ->
+    %% We're not doing utf32 here as it is too hard to generate a
+    %% valid code point.
+    V = rand:uniform(1 bsl Size) - 1,
+    Unit = make_unit(Size),
+    E = io_lib:format(", ~p:~p~s", [V, Size, Unit]),
+    {[], E}.
+
+format_bitstring_element(Size, Id) ->
+    case rand:uniform(2) of
+	1 ->
+	    literal_bitstring_element(Size);
+	2 ->
+	    variable_bitstring_element(Size, Id)
+    end.
+
+variable_bitstring_element(Size, Id) ->
+    Unit = make_unit(Size),
+    E = io_lib:format(", V~p:~p/bitstring~s", [Id, Size, Unit]),
+    V = io_lib:format(", V~p", [Id]),
+    {V, E}.
+
+literal_bitstring_element(Size) ->
+    V = rand:uniform(1 bsl Size) - 1,
+    Unit = make_unit(Size),
+    E = io_lib:format(", <<~p:~p>>/bitstring~s", [V, Size, Unit]),
+    {[], E}.
+
+
+make_unit(Size) ->
+    case rand:uniform(1) of
+	1 ->
+	    [];
+	2 ->
+	    io_lib:format("-unit:~p", [Size])
+    end.
+
+make_varsize_elements(NoofElements, Id, Unit0) ->
+    make_varsize_elements(NoofElements, Id, Unit0, [], []).
+
+make_varsize_elements(0, _, Unit, Vars, Elements) ->
+    {reverse(Vars), reverse(Elements), Unit};
+make_varsize_elements(NoofElements, Id, Unit0, Vars, Elements) ->
+    Var = io_lib:format(", V~p", [Id]),
+    Es = #{ 1 => {binary, 8},
+	    2 => {bitstring, 1},
+	    3 => {utf8, 8},
+	    4 => {utf16, 16} },
+
+    {T,U} = map_get(rand:uniform(4), Es),
+    Unit = gcd(U, Unit0),
+    Element = io_lib:format(", V~p/~p", [Id, T]),
+    make_varsize_elements(NoofElements - 1, Id + 1, Unit,
+			  [Var|Vars], [Element|Elements]).
+
+gcd(0, Other) -> Other;
+gcd(Other, 0) -> Other;
+gcd(A, B) ->
+    case A rem B of
+        0 -> B;
+        X -> gcd(B, X)
+    end.
+
+shuffle(Ls) ->
+    %% à la Knuth
+    A = array:from_list(Ls),
+    shuffle(A, array:size(A)).
+
+shuffle(A, 0) ->
+    array:to_list(A);
+shuffle(A0, Size) ->
+    A = swap(rand:uniform(Size) - 1, Size - 1, A0),
+    shuffle(A, Size - 1).
+
+swap(X, Y, A) ->
+    Xv = array:get(X, A),
+    Yv = array:get(Y, A),
+    array:set(X, Yv, array:set(Y, Xv, A)).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/sanity_checks.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/sanity_checks.erl
@@ -1,0 +1,327 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+
+-module(sanity_checks).
+
+-export([check_fail/0,
+         check_wrong_pass/0,
+         check_xfail/0,
+         check_prefix1/0,
+         check_prefix2/0,
+         check_prefix3/0,
+
+         t0/0, t1/0, t2/0, t3/0, t4/0,
+         t5/0, t6/0, t7/0, t8/0, t9/0,
+         t10/0, t11/0, t12/0, t13/0, t14/0,
+         t15/0, t16/0, t17/0, t18/0, t19/0,
+         t20/0, t21/0, t22/0, t23/0, t24/0,
+         t25/0, t26/0, t27/0, t28/0, t29/0,
+         t30/0, t31/0, t32/1, t33/1, t34/1,
+         t35/1, t36/0, t37/0, t38/0, t39/1,
+         t40/0, t41/0, t42/0, t43/0, t44/0]).
+
+%% Check that we do not trigger on the wrong pass
+check_wrong_pass() ->
+%ssa% (_) when this_pass_does_not_exist ->
+%ssa% _ = this_instruction_does_not_exist().
+    ok.
+
+%% Check that failures work
+check_fail() ->
+%ssa% fail (_) when post_ssa_opt ->
+%ssa% _ = this_instruction_does_not_exist().
+    ok.
+
+check_xfail() ->
+%ssa% xfail (_) when post_ssa_opt ->
+%ssa% _ = this_instruction_does_not_exist().
+    ok.
+
+check_prefix1() ->
+%ssa% fail (_) when post_ssa_opt ->
+%ssa% _ = this_instruction_does_not_exist().
+    ok.
+
+check_prefix2() ->
+%%ssa% fail (_) when post_ssa_opt ->
+%ssa% _ = this_instruction_does_not_exist().
+    ok.
+
+check_prefix3() ->
+%%%ssa% fail (_) when post_ssa_opt ->
+%ssa% _ = this_instruction_does_not_exist().
+    ok.
+
+%% Check map literals with any type which can be a key
+t0() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{}).
+    #{}.
+
+t1() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{a=>b}).
+    #{a=>b}.
+
+t2() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{a=>b,c=>d}).
+    #{a=>b,c=>d}.
+
+t3() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{1=>1}).
+    #{1=>1}.
+
+t4() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{3.14=>3.14}).
+    #{3.14=>3.14}.
+
+t5() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{#{}=>1}).
+    #{#{}=>1}.
+
+t6() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{<<17,15>> => 1}).
+    #{<<17,15>> => 1}.
+
+t7() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{{} => 1}).
+    #{{} => 1}.
+
+t8() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{{1,2} => 1}).
+    #{{1,2} => 1}.
+
+t9() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{[] => 1}).
+    #{[] => 1}.
+
+t10() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(#{[1,2] => 1}).
+    #{[1,2] => 1}.
+
+
+%% Check literals
+t11() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(atom).
+    atom.
+
+t12() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(17).
+    17.
+
+t13() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(3.14).
+    3.14.
+
+t14() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(3.141(1.0e-3)).
+    3.1415.
+
+t15() ->
+%ssa% () when post_ssa_opt ->
+%ssa% _ = make_fun(fun t15/0).
+    fun t15/0.
+
+t16() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(fun sanity_checks:t16/0).
+    fun sanity_checks:t16/0.
+
+t17() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret({}).
+    {}.
+
+t18() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret({1}).
+    {1}.
+
+t19() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret({1,2}).
+    {1,2}.
+
+t20() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret({1,2,3}).
+    {1,2,3}.
+
+t21() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret({1,...}).
+    {1,2,3}.
+
+t22() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(<<>>).
+    <<>>.
+
+t23() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(<<1>>).
+    <<1>>.
+
+t24() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(<<1,2>>).
+    <<1,2>>.
+
+t25() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(<<1,2,3>>).
+    <<1,2,3>>.
+
+t26() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret([]).
+    [].
+
+t27() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret([1]).
+    [1].
+
+t28() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret([1,2]).
+    [1,2].
+
+t29() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret([1,2,3]).
+    [1,2,3].
+
+t30() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret([1,2|3]).
+    [1,2|3].
+
+t31() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret([1,2,...]).
+    [1,2,3].
+
+%% Check that we handle a bif
+t32(X) ->
+%ssa% (X) when post_ssa_opt ->
+%ssa% A = bif:'=='(X, 1).
+    true = X == 1.
+
+%% Check that we handle a br
+t33(X) ->
+%ssa% (X) when post_ssa_opt ->
+%ssa% A = bif:'=='(X, 1),
+%ssa% br(A, 5, 4).
+    true = X == 1.
+
+%% Check that we handle a branch and variable labels
+t34(X) ->
+%ssa% (X) when post_ssa_opt ->
+%ssa% A = bif:'=='(X, 1),
+%ssa% br(A, Succ, Fail),
+%ssa% label Succ,
+%ssa% ret(true),
+%ssa% label Fail,
+%ssa% _ = match_fail(badmatch, ...).
+    true = X == 1.
+
+%% Check that we handle a switch
+t35(X) ->
+%ssa% (X) when post_ssa_opt ->
+%ssa% switch(X, Fail, [{1,One},{2,Two},...]),
+%ssa% label Two,
+%ssa% ret(b),
+%ssa% label One,
+%ssa% ret(a),
+%ssa% label Fail,
+%ssa% _ = match_fail(case_clause, ...).
+    case X of
+	1 ->
+	    a;
+	2 ->
+	    b;
+	3 ->
+	    c
+    end.
+
+%% Check a complex pattern
+t36() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret({{}, 4,a,{[45|a], 17.0, 3.141(1.0e-3), #{a=>b}}, [1,2,...], ...}).
+    {{}, 4,a,{[45|a], 17.0, 3.14,#{a=>b}}, [1,2,3,4], 3.1415, 5, 7}.
+
+%% Check '...' when used for instruction arguments.
+t37() ->
+%ssa% () when post_ssa_opt ->
+%ssa% _ = call(fun e:f0/4, _, _, ...),
+%ssa% _ = call(fun e:f1/4, ...).
+    e:f0(1, 2, 3, 4),
+    e:f1(1, 2, 3, 4).
+
+%% Check that we fail if we specify too many arguments.
+t38() ->
+%ssa% xfail (_) when post_ssa_opt ->
+%ssa% _ = call(fun e:f0/4, ...).
+    e:f0(1, 2, 3, 4).
+
+%% Check that we fail if we specify too few arguments.
+t39(_) ->
+%ssa% xfail () when post_ssa_opt ->
+%ssa% _ = call(fun e:f0/4, ...).
+    e:f0(1, 2, 3, 4).
+
+
+%% Check ... when used to match part of a tuple.
+t40() ->
+%ssa% () when post_ssa_opt ->
+%ssa% _ = call(fun e:f0/1, {...}).
+    e:f0({1, 2, 3, 4}).
+
+t41() ->
+%ssa% () when post_ssa_opt ->
+%ssa% _ = call(fun e:f0/1, {1, ...}).
+    e:f0({1, 2, 3, 4}).
+
+t42() ->
+%ssa% () when post_ssa_opt ->
+%ssa% _ = call(fun e:f0/1, {1, 2, ...}).
+    e:f0({1, 2, 3, 4}).
+
+t43() ->
+%ssa% fail () when post_ssa_opt ->
+%ssa% _ = call(fun e:f0/1, {1, 2, ...}).
+    e:f0({1}).
+
+t44() ->
+%ssa% () when post_ssa_opt ->
+%ssa% _ = call(fun e:f0/1, {...}).
+    e:f0({}).

--- a/lib/stdlib/doc/src/epp.xml
+++ b/lib/stdlib/doc/src/epp.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>1996</year><year>2022</year>
+      <year>1996</year><year>2023</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -142,6 +142,10 @@
        <p>The option <c>location</c> is forwarded
          to the Erlang token scanner, see
          <seemfa marker="erl_scan#tokens/3"><c>erl_scan:tokens/3,4</c></seemfa>.</p>
+       <p>The <c>{compiler_internal,term()}</c> option is forwarded
+       to the Erlang token scanner, see
+       <seeerl marker="erl_scan#compiler_interal">
+       <c>{compiler_internal,term()}</c></seeerl>.</p>
       </desc>
     </func>
 
@@ -193,6 +197,10 @@
        <p>The option <c>location</c> is forwarded
          to the Erlang token scanner, see
          <seemfa marker="erl_scan#tokens/3"><c>erl_scan:tokens/3,4</c></seemfa>.</p>
+       <p>The <c>{compiler_internal,term()}</c> option is forwarded
+       to the Erlang token scanner, see
+       <seeerl marker="erl_scan#compiler_interal">
+       <c>{compiler_internal,term()}</c></seeerl>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/erl_scan.xml
+++ b/lib/stdlib/doc/src/erl_scan.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>1996</year><year>2022</year>
+      <year>1996</year><year>2023</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -236,6 +236,22 @@
           <seeerl marker="#text"><c>text</c></seeerl> is not present.
           If neither are present the text will not be saved in the
           token annotation.</p>
+          </item>
+          <tag><marker id="compiler_interal"/>
+	  <c>{compiler_internal, term()}</c>
+	  </tag>
+          <item><p>Pass compiler-internal options to the scanner. The
+          set of internal options understood by the scanner should
+          be considered experimental and can thus be changed at any time
+          without prior warning.</p>
+	  <p>The following options are currently understood:</p>
+	  <taglist>
+            <tag><c>ssa_checks</c></tag>
+            <item>
+              <p>Tokenizes source code annotations used for encoding
+              tests on the BEAM SSA code produced by the compiler.</p>
+            </item>
+          </taglist>
           </item>
         </taglist>
       </desc>

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -442,7 +442,9 @@ expr({op,Anno,Op,L0,R0}, St0) when Op =:= 'andalso';
 expr({op,Anno,Op,L0,R0}, St0) ->
     {L,St1} = expr(L0, St0),
     {R,St2} = expr(R0, St1),
-    {{op,Anno,Op,L,R},St2}.
+    {{op,Anno,Op,L,R},St2};
+expr(E={ssa_check_when,_,_,_,_,_}, St) ->
+    {E, St}.
 
 expr_list([E0 | Es0], St0) ->
     {E,St1} = expr(E0, St0),

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2567,7 +2567,10 @@ expr({op,_Anno,_Op,L,R}, Vt, St) ->
     expr_list([L,R], Vt, St);                   %They see the same variables
 %% The following are not allowed to occur anywhere!
 expr({remote,_Anno,M,_F}, _Vt, St) ->
-    {[],add_error(erl_parse:first_anno(M), illegal_expr, St)}.
+    {[],add_error(erl_parse:first_anno(M), illegal_expr, St)};
+expr({ssa_check_when,_Anno,_WantedResult,_Args,_Tag,_Exprs}, _Vt, St) ->
+    {[], St}.
+
 
 %% expr_list(Expressions, Variables, State) ->
 %%      {UsedVarTable,State}

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -49,7 +49,28 @@ type_sig type_sigs type_guard type_guards fun_type binary_type
 type_spec spec_fun typed_exprs typed_record_fields field_types field_type
 map_pair_types map_pair_type
 bin_base_type bin_unit_type
-maybe_expr maybe_match_exprs maybe_match.
+maybe_expr maybe_match_exprs maybe_match
+clause_body_exprs
+ssa_check_args
+ssa_check_binary_lit
+ssa_check_binary_lit_bytes_ls
+ssa_check_binary_lit_rest
+ssa_check_clause_args
+ssa_check_clause_args_ls
+ssa_check_expr
+ssa_check_exprs
+ssa_check_fun_ref
+ssa_check_list_lit
+ssa_check_list_lit_ls
+ssa_check_map_key
+ssa_check_map_key_element
+ssa_check_map_key_elements
+ssa_check_map_key_list
+ssa_check_map_key_tuple_elements
+ssa_check_pat
+ssa_check_pats
+ssa_check_when_clause
+ssa_check_when_clauses.
 
 Terminals
 char integer float atom string var
@@ -67,7 +88,8 @@ char integer float atom string var
 '!' '=' '::' '..' '...'
 '?='
 'spec' 'callback' % helper
-dot.
+dot
+'%ssa%'.
 
 Expect 0.
 
@@ -86,6 +108,7 @@ Left 500 mult_op.
 Unary 600 prefix_op.
 Nonassoc 700 '#'.
 Nonassoc 800 ':'.
+Nonassoc 900 clause_body_exprs.
 
 %% Types
 
@@ -225,8 +248,7 @@ clause_args -> pat_argument_list : element(1, '$1').
 clause_guard -> 'when' guard : '$2'.
 clause_guard -> '$empty' : [].
 
-clause_body -> '->' exprs: '$2'.
-
+clause_body -> '->' clause_body_exprs: '$2'.
 
 expr -> 'catch' expr : {'catch',?anno('$1'),'$2'}.
 expr -> expr '=' expr : {match,first_anno('$1'),'$1','$3'}.
@@ -500,6 +522,9 @@ pat_argument_list -> '(' pat_exprs ')' : {'$2',?anno('$1')}.
 exprs -> expr : ['$1'].
 exprs -> expr ',' exprs : ['$1' | '$3'].
 
+clause_body_exprs -> ssa_check_when_clauses exprs : '$1' ++ '$2'.
+clause_body_exprs -> exprs : '$1'.
+
 pat_exprs -> pat_expr : ['$1'].
 pat_exprs -> pat_expr ',' pat_exprs : ['$1' | '$3'].
 
@@ -548,6 +573,118 @@ comp_op -> '>=' : '$1'.
 comp_op -> '>' : '$1'.
 comp_op -> '=:=' : '$1'.
 comp_op -> '=/=' : '$1'.
+
+ssa_check_when_clauses -> ssa_check_when_clause : ['$1'].
+ssa_check_when_clauses -> ssa_check_when_clause ssa_check_when_clauses :
+    ['$1'|'$2'].
+
+ssa_check_when_clause -> '%ssa%' atom ssa_check_clause_args_ls 'when' atom '->'
+                             ssa_check_exprs '.' :
+   {ssa_check_when, ?anno('$1'), '$2', '$3', '$5', '$7'}.
+
+ssa_check_when_clause -> '%ssa%' ssa_check_clause_args_ls 'when' atom '->'
+                             ssa_check_exprs '.' :
+   {ssa_check_when, ?anno('$1'), {atom,?anno('$1'),pass}, '$2', '$4', '$6'}.
+
+ssa_check_exprs -> ssa_check_expr : ['$1'].
+ssa_check_exprs -> ssa_check_expr ',' ssa_check_exprs : ['$1'|'$3'].
+
+ssa_check_expr -> var '=' atom ssa_check_args :
+   {check_expr, ?anno('$1'), [set, '$1', '$3'|'$4']}.
+ssa_check_expr -> atom ssa_check_args :
+    {check_expr, ?anno('$1'), [none, '$1'|'$2']}.
+ssa_check_expr -> var '=' atom ':' atom ssa_check_args :
+   {check_expr, ?anno('$1'), [set, '$1', {'$3', '$5'}|'$6']}.
+ssa_check_expr -> atom integer :
+   {check_expr, ?anno('$1'), build_ssa_check_label('$1', '$2')}.
+ssa_check_expr -> atom var :
+   {check_expr, ?anno('$1'), build_ssa_check_label('$1', '$2')}.
+
+ssa_check_clause_args_ls -> '(' ')' : [].
+ssa_check_clause_args_ls -> '(' ssa_check_clause_args ')' : '$2'.
+ssa_check_clause_args_ls -> '(' '...' ')' : ['$2'].
+
+ssa_check_clause_args -> var : ['$1'].
+ssa_check_clause_args -> var ',' ssa_check_clause_args : ['$1'|'$3'].
+ssa_check_clause_args -> var ',' '...' : ['$1', '$3'].
+
+ssa_check_args -> '(' ')' : {[], ?anno('$1')}.
+ssa_check_args -> '(' ssa_check_pats ')' : '$2'.
+ssa_check_args -> '(' '...' ')' : ['$2'].
+
+ssa_check_pats -> ssa_check_pat : ['$1'].
+ssa_check_pats -> ssa_check_pat ',' ssa_check_pats : ['$1'|'$3'].
+ssa_check_pats -> ssa_check_pat ',' '...' : ['$1', '$3'].
+
+ssa_check_pat -> var : '$1'.
+ssa_check_pat -> atom : '$1'.
+ssa_check_pat -> integer : '$1'.
+ssa_check_pat -> float : '$1'.
+ssa_check_pat -> float '(' float ')': {float_epsilon, '$1', '$3'}.
+ssa_check_pat -> ssa_check_fun_ref : '$1'.
+ssa_check_pat -> '{' '}' : {tuple, ?anno('$1'), []}.
+ssa_check_pat -> '{' ssa_check_pats '}' : {tuple, ?anno('$1'), '$2'}.
+ssa_check_pat -> '{' '...' '}' : {tuple, ?anno('$1'), ['$2']}.
+ssa_check_pat -> ssa_check_binary_lit : '$1'.
+ssa_check_pat -> ssa_check_list_lit : '$1'.
+ssa_check_pat -> '#' '{' '}' : {map, ?anno('$1'), []}.
+ssa_check_pat -> '#' '{' ssa_check_map_key_elements '}' : {map, ?anno('$1'), '$3'}.
+
+ssa_check_fun_ref -> 'fun' atom '/' integer : {local_fun, '$2', '$4'}.
+ssa_check_fun_ref -> 'fun' atom ':' atom '/' integer : {external_fun, '$2', '$4', '$6'}.
+
+ssa_check_binary_lit -> '<<' '>>' : {binary, ?anno('$1'), []}.
+ssa_check_binary_lit -> '<<' ssa_check_binary_lit_bytes_ls '>>' :
+    {binary, ?anno('$1'), '$2'}.
+ssa_check_binary_lit -> '<<' ssa_check_binary_lit_rest '>>' :
+    {binary, ?anno('$1'), ['$2']}.
+
+ssa_check_binary_lit_bytes_ls -> integer : ['$1'].
+ssa_check_binary_lit_bytes_ls -> integer ',' ssa_check_binary_lit_bytes_ls :
+    ['$1'|'$3'].
+ssa_check_binary_lit_bytes_ls -> integer ',' ssa_check_binary_lit_rest :
+    ['$1', '$3'].
+
+ssa_check_binary_lit_rest -> integer ':' integer : {'$1', '$3'}.
+
+ssa_check_list_lit -> '[' ']' : {list, ?anno('$1'), []}.
+ssa_check_list_lit -> '[' ssa_check_list_lit_ls ']' :
+    {list, ?anno('$1'), '$2'}.
+
+ssa_check_list_lit_ls -> ssa_check_pat : ['$1'].
+ssa_check_list_lit_ls -> ssa_check_pat ',' ssa_check_list_lit_ls : ['$1'|'$3'].
+ssa_check_list_lit_ls -> ssa_check_pat ',' '...' : ['$1', '$3'].
+ssa_check_list_lit_ls -> ssa_check_pat '|' ssa_check_pat : ['$1'|'$3'].
+
+ssa_check_map_key -> atom : '$1'.
+ssa_check_map_key -> integer : '$1'.
+ssa_check_map_key -> float : '$1'.
+ssa_check_map_key -> '{' ssa_check_map_key_tuple_elements '}' :
+    {tuple, ?anno('$1'), '$2'}.
+ssa_check_map_key -> '{' '}' : {tuple, ?anno('$1'), []}.
+ssa_check_map_key -> ssa_check_binary_lit : '$1'.
+ssa_check_map_key -> '[' ssa_check_map_key_list ']' :
+    {list, ?anno('$1'), '$2'}.
+ssa_check_map_key -> '[' ']' : {list, ?anno('$1'), []}.
+ssa_check_map_key -> '#' '{' '}' : {map, ?anno('$1'), []}.
+ssa_check_map_key -> '#' '{' ssa_check_map_key_elements '}' : '$3'.
+
+ssa_check_map_key_list -> ssa_check_map_key : ['$1'].
+ssa_check_map_key_list -> ssa_check_map_key ',' ssa_check_map_key_list :
+    ['$1'|'$3'].
+ssa_check_map_key_list -> ssa_check_map_key '|' ssa_check_map_key :
+    ['$1'|'$3'].
+
+ssa_check_map_key_elements -> ssa_check_map_key_element : ['$1'].
+ssa_check_map_key_elements -> ssa_check_map_key_element ',' ssa_check_map_key_elements :
+    ['$1'|'$3'].
+
+ssa_check_map_key_element -> ssa_check_map_key '=>' ssa_check_map_key:
+    {'$1', '$3'}.
+
+ssa_check_map_key_tuple_elements -> ssa_check_map_key : ['$1'].
+ssa_check_map_key_tuple_elements -> ssa_check_map_key ',' ssa_check_map_key_tuple_elements:
+    ['$1'|'$3'].
 
 Header
 "%% This file was automatically generated from the file \"erl_parse.yrl\"."
@@ -1832,5 +1969,10 @@ modify_anno1([H|T], Ac, Mf) ->
     {[H1|T1],Ac2};
 modify_anno1([], Ac, _Mf) -> {[],Ac};
 modify_anno1(E, Ac, _Mf) when not is_tuple(E), not is_list(E) -> {E,Ac}.
+
+build_ssa_check_label({atom,_,label}, Lbl) ->
+    [label, Lbl];
+build_ssa_check_label({atom,L,_}, _) ->
+    return_error(L, "expected 'label'").
 
 %% vim: ft=erlang


### PR DESCRIPTION
[@bjorng and @jhogberg this is the SSA Checker i have been talking about]

This is a series of patches which adds a mechanism to check the emitted
BEAM SSA against patterns embedded in comments in the source code.
This greatly simplifies writing tests for compiler optimizations as it becomes
possible to directly check properties of the emitted code instead of having to create a test which exhibit different behavior depending on the triggering of the optimization.

For examples on how the patterns look like, check [sanity_checks.erl](https://github.com/erlang/otp/blob/f08007ac250712ee3463607bd2f8fd76b9f2ff70/lib/compiler/test/beam_ssa_check_SUITE_data/sanity_checks.erl). As a non-synthetic example, this PR includes [an improvement to ](https://github.com/erlang/otp/commit/7cca58fe31c9f7fd046c41ac097e0341ce7f79a9) `beam_ssa_type:bs_size_unit/2` where it is tested using the new pattern language.

What this PR is missing is internal documentation of the pattern language. As I think that the examples given above are enough to form an opinion about the syntax and provide feedback, I will wait for review comments and finalization of the syntax before creating the documentation.

A work-In-Progress branch using the SSA checking framework for an additional optimization is also [available](https://github.com/frej/otp/tree/frej/private_append).
