### PR TITLE
lib/crypto: autoconf: Add missing ',' in an AC_IF

### DIFF
--- a/lib/crypto/configure.ac
+++ b/lib/crypto/configure.ac
@@ -821,7 +821,7 @@ AS_CASE(["$with_ssl_rpath"],
                       AS_IF([test "$with_ssl_rpath" = yes],
                             [AC_MSG_ERROR([runtime library path requested by user, but cannot be set on this platform])])
                       AC_MSG_RESULT([])
-                  ]
+                  ],
                   [test "$SSL_DYNAMIC_ONLY" != "yes"],
                   [
                       AS_IF([test "$with_ssl_rpath" = yes],


### PR DESCRIPTION
This commit fixes an issue wherein old versions of autoconf will misgenerate the configure script due to a missing comma an in AS_IF macro.