### PR TITLE
fix typo

### DIFF
--- a/system/doc/system_principles/system_principles.xml
+++ b/system/doc/system_principles/system_principles.xml
@@ -107,7 +107,7 @@ init:stop()</pre>
 	the applications Kernel and STDLIB.</item>
 	<item><c>start_sasl.boot</c> - Loads the code for and starts
 	the applications Kernel, STDLIB, and
-	SASL).</item>
+	SASL.</item>
 	<item><c>no_dot_erlang.boot</c> - Loads the code for and
 	starts the applications Kernel and STDLIB.
 	Skips loading the file <c>.erlang</c>. Useful for scripts and


### PR DESCRIPTION
Hello,
Small typo fix to remove an orphan `)`.