### PR TITLE
Fix `ssh_connection_handler` logging of atoms

### DIFF
--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1903,7 +1903,7 @@ do_log(F, Reason0, #data{ssh_params=S}) ->
 
 assure_string(S) ->
     try io_lib:format("~s",[S])
-    of _ -> S
+    of Formatted -> Formatted
     catch
         _:_ -> io_lib:format("~p",[S])
     end.

--- a/lib/ssh/src/ssh_transport.erl
+++ b/lib/ssh/src/ssh_transport.erl
@@ -433,7 +433,12 @@ kexinit_error(Class, Error, Role, Own, CounterPart) ->
             _ ->
                 {"Kexinit failed in ~p: ~p:~p", [Role,Class,Error]}
         end,
-    io_lib:format(Fmt, Args).
+    try io_lib:format(Fmt, Args) of
+        R -> R
+    catch
+        _:_ ->
+            io_lib:format("Kexinit failed in ~p: ~p:~p", [Role, Class, Error])
+    end.
 
 alg_info(client, Alg) ->
     alg_info(Alg);


### PR DESCRIPTION
Attempting to log reasons `ssh_connection_handler` may fail if the reason is an atom. This is because the `assure_string/1` function will return the original `Reason0` instead of the formatted result and `io_lib.format` can successfully format atoms, returning the original atom reason which then fails in `string:chomp/1`

```erlang
1> io_lib:format("~s", [undef]).
"undef"
2> string:chomp(undef).
** exception error: no function clause matching string:trim_t(undef,0,{["\r\n",10],"\r\n",undefined}) (string.erl, line 885)
3>
```

This changes to return the formatted result rather than the original when attempting to use `assure_string/1`

<details>
<summary>Discovery details</summary>

For reference, this was discovered while trying to implement [`ssh_client_key_api`](https://www.erlang.org/doc/man/ssh_client_key_api.html) behavior but some required functions were missing. This produced an error for the failed formatting rather than what the _actual_ problem was.

```elixir
iex> :ssh.connect(host, 22, [key_cb: {NervesSSH.Client.Keys, []}])
{:error,
 {:function_clause,
  [
    {:string, :trim_t, [:undef, 0, {['\r\n', 10], '\r\n', :undefined}],
     [file: 'string.erl', line: 885]},
    {:ssh_connection_handler, :do_log, 3,
     [file: 'ssh_connection_handler.erl', line: 1877]},
    {:ssh_connection_handler, :terminate, 3,
     [file: 'ssh_connection_handler.erl', line: 1379]},
    {:gen_statem, :terminate, 7, [file: 'gen_statem.erl', line: 2602]},
    {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}
  ]}}
```

Once the formatting error was fixed, I was able to actually see useful output towards the root cause

```elixir
iex(3)> :ssh.connect host, 22, opts
 
14:20:24.929 [error] Erlang SSH :client version: 4.15.1 (OpenSSL 1.1.1s  1 Nov 2022).
Address: 10.0.1.90:52146
Peer server version: 'SSH-2.0-tufl'
Peer address: 10.0.1.10:22
undef
 
14:20:24.934 [notice] Erlang SSH :client version: 4.15.1 (OpenSSL 1.1.1s  1 Nov 2022).
Address: 10.0.1.90:52146
Peer server version: 'SSH-2.0-tufl'
Peer address: 10.0.1.10:22
Disconnects with code = 11 [RFC4253 11.1]: Internal error
State = {key_exchange,client,init}
Module = ssh_connection_handler, Line = 1382.
Details:
  Reason: undef

{:error,
 {:undef,
  [
    {NervesSSH.Client.Keys, :is_host_key,
     [
       {:RSAPublicKey, 1234, 65537},
       '10.0.1.10',
       :"ssh-rsa",
       [
         key_cb_private: [],
         silently_accept_hosts: true,
         auth_methods: 'publickey',
         key_cb: {NervesSSH.Client.Keys, []},
         save_accepted_host: false
       ]
     ], []},
    {:ssh_transport, :known_host_key, 3,
     [file: 'ssh_transport.erl', line: 1018]},
    {:ssh_transport, :handle_kexdh_reply, 2,
     [file: 'ssh_transport.erl', line: 592]},
    {:ssh_fsm_kexinit, :handle_event, 4,
     [file: 'ssh_fsm_kexinit.erl', line: 84]},
    {:gen_statem, :loop_state_callback, 11,
     [file: 'gen_statem.erl', line: 1428]},
    {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}
```
</details>