### PR TITLE
beam_ssa_codegen: Don't break bs_match sequences by mixing registers

### DIFF
--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -485,6 +485,13 @@ prefer_xregs_is([#cg_set{op=call,dst=Dst}=I0|Is], St, Copies, Acc) ->
 prefer_xregs_is([#cg_set{op=old_make_fun,dst=Dst}=I0|Is], St, Copies, Acc) ->
     I = prefer_xregs_call(I0, Copies, St),
     prefer_xregs_is(Is, St, #{Dst=>{x,0}}, [I|Acc]);
+prefer_xregs_is([#cg_set{op=Op}=I|Is], St, Copies0, Acc)
+  when Op =:= bs_checked_get;
+       Op =:= bs_checked_skip;
+       Op =:= bs_checked_get_tail;
+       Op =:= bs_ensure ->
+    Copies = prefer_xregs_prune(I, Copies0, St),
+    prefer_xregs_is(Is, St, Copies, [I|Acc]);
 prefer_xregs_is([#cg_set{args=Args0}=I0|Is], St, Copies0, Acc) ->
     Args = [do_prefer_xreg(A, Copies0, St) || A <- Args0],
     I = I0#cg_set{args=Args},

--- a/lib/compiler/test/bs_match_SUITE.erl
+++ b/lib/compiler/test/bs_match_SUITE.erl
@@ -2682,6 +2682,9 @@ bs_match(_Config) ->
     {0,0} = do_bs_match_gh_6551b(0),
     {<<42>>,<<42>>} = do_bs_match_gh_6551b(<<42>>),
 
+    ok = do_bs_match_gh_6613(<<0>>),
+    <<0,0>> = do_bs_match_gh_6613(<<0,0>>),
+
     ok.
 
 do_bs_match_1(_, X) ->
@@ -2710,6 +2713,24 @@ do_bs_match_gh_6551b(X) ->
             <<_>> ->
                 X
         end}.
+
+do_bs_match_gh_6613(<<_>>) ->
+    ok;
+do_bs_match_gh_6613(X) ->
+    try
+        try X of
+            #{(not ok) := _} ->
+                ok;
+            <<Z, Z>> ->
+                ok
+        after
+            ok
+        end
+    catch
+        _ ->
+            ok
+    end,
+    X.
 
 %% GH-6348/OTP-18297: Allow aliases for binaries.
 -record(ba_foo, {a,b,c}).


### PR DESCRIPTION
The `prefer_xregs` subpass sometimes mixed which registers were used for `bs_checked_xyz` psuedo-instructions, making the `bs_translate` subpass generate bogus code.

There's nothing wrong with mixing _per se_ though, so we probably want to teach the `bs_translate` pass how to handle this in the future.

```
    {bs_match,{f,42},{y,1},{commands,[{ensure_at_least,16,1}]}}.
    {bs_match,{f,0},{x,0},{commands,[{skip,8}]}}.
    {bs_match,{f,42},{x,0},{commands,[{'=:=',nil,8,0},{ensure_exactly,0}]}}.
```

Fixes #6613 