### PR TITLE
kernel: Accept ver5 distribution connection setup

### DIFF
--- a/erts/doc/src/erl_dist_protocol.xml
+++ b/erts/doc/src/erl_dist_protocol.xml
@@ -161,7 +161,8 @@
         <tag><c>LowestVersion</c></tag>
         <item>
           <p>The lowest distribution version that this node can handle.
-            Should be 5 to support connections to nodes older than OTP 23.</p>
+            The value in OTP 25 and later is 6 as support for connections to
+	    nodes older than OTP 23 has been dropped.</p>
         </item>
         <tag><c>Nlen</c></tag>
         <item>
@@ -550,10 +551,18 @@ io:format("old/unused name ~ts at port ~p, fd = ~p ~n",
       This section describes the distribution handshake protocol used between
       nodes to establishing a connection. The protocol was introduced in
       Erlang/OTP R6 and amended in OTP 23. From OTP 25 support for the older
-      protocol was dropped. Therefor an OTP 25 node can not connect to nodes
-      older than OTP 23. This documentation only decribes the new amended
-      protocol.
+      protocol was dropped. Therefore an OTP 25 node can not connect to nodes
+      older than OTP 23. This documentation only decribes the part of the
+      protocol used by OTP 25.
     </p>
+    <note>
+      <p>
+	A bug introduced in OTP 25.0 may cause OTP 25 nodes to reject connection
+	attempts from OTP 23 and 24 nodes that are not using <c>epmd</c> to gain
+	version information about the remote node.
+	This is fixed in OTP @OTP-18404@.
+      </p>
+    </note>
     <section>
       <title>General</title>
       <p>The TCP/IP distribution uses a handshake that expects a
@@ -618,9 +627,26 @@ io:format("old/unused name ~ts at port ~p, fd = ~p ~n",
         </item>
         <tag>2) <c>send_name</c>/<c>receive_name</c></tag>
         <item>
-          <p><c>A</c> sends an initial identification to <c>B</c>. The message
-            looks as follows (the packet headers are removed):
+          <p><c>A</c> sends an initial identification to <c>B</c>, which
+            receives the message. The message can have two different formats
+	    which looks as follows (the packet headers are removed):
 	  </p>
+	  <table align="left">
+            <row>
+              <cell align="center">1</cell>
+              <cell align="center">2</cell>
+              <cell align="center">4</cell>
+	      <cell align="center">Nlen</cell>
+            </row>
+            <row>
+              <cell align="center"><c>'n'</c></cell>
+              <cell align="center"><c>Version=5</c></cell>
+              <cell align="center"><c>Flags</c></cell>
+	      <cell align="center"><c>Name</c></cell>
+            </row>
+            <tcaption>Old send_name ('n') for protocol version 5</tcaption>
+	  </table>
+
 	  <table align="left">
             <row>
               <cell align="center">1</cell>
@@ -640,9 +666,25 @@ io:format("old/unused name ~ts at port ~p, fd = ~p ~n",
 	  </table>
 
 	  <p>
-	    <c>Flags</c> are the
+	    The old <c>send_name</c> format is only sent from OTP 23 and 24
+	    nodes that are not using <c>epmd</c> and therefore do not know if
+	    the remote node only supports protocol version 5. The <c>Version</c> is
+	    a 16-bit big endian integer and <em>must</em> always have the value
+	    5 (even though node <c>A</c> supports version 6). <c>Flags</c> are the
+	    <seeguide marker="#dflags">capability flags</seeguide>
+	    of node <c>A</c> in 32-bit big endian. The flag bit
+	    <seeguide marker="#DFLAG_HANDSHAKE_23"><c>DFLAG_HANDSHAKE_23</c></seeguide>
+	    must be set (as node <c>A</c> must supports version 6).
+	    <c>Name</c> is the full node name of <c>A</c>, as a string of bytes
+	    (the packet length denotes how long it is).
+	  </p>
+	  <p>
+	    The new <c>send_name</c> is sent to
+	    nodes known to support version 6. <c>Flags</c> are the
 	    <seeguide marker="#dflags">capability flags</seeguide> of node
-	    <c>A</c> in 64-bit big endian. <c>Creation</c> is the node incarnation
+	    <c>A</c> in 64-bit big endian. The flag bit
+	    <seeguide marker="#DFLAG_HANDSHAKE_23"><c>DFLAG_HANDSHAKE_23</c></seeguide>
+            must always be set. <c>Creation</c> is the node incarnation
 	    identifier used by node <c>A</c> to create its pids, ports and
 	    references. <c>Name</c> is the full node name of <c>A</c>, as a
 	    string of bytes. <c>Nlen</c> is the byte length of the node name in
@@ -784,6 +826,32 @@ io:format("old/unused name ~ts at port ~p, fd = ~p ~n",
 	    the <c>send_name</c> message. Any extra data after the node
             <c>Name</c> must be accepted and ignored.
 	  </p>
+	</item>
+        <tag>4B) <c>send_complement</c>/<c>recv_complement</c></tag>
+        <item>
+          <p>
+	    The complement message, from <c>A</c> to <c>B</c>, is only sent if
+	    node <c>A</c> initially sent an old name message. It contains complementary
+	    information missing in the initial old name message from node <c>A</c>.
+	  </p>
+	  <table align="left">
+            <row>
+              <cell align="center">1</cell>
+	      <cell align="center">4</cell>
+	      <cell align="center">4</cell>
+            </row>
+            <row>
+              <cell align="center"><c>'c'</c></cell>
+	      <cell align="center"><c>FlagsHigh</c></cell>
+	      <cell align="center"><c>Creation</c></cell>
+            </row>
+            <tcaption>The complement message</tcaption>
+	  </table>
+	  <p>
+	    <c>FlagsHigh</c> are the high capability flags (bit 33-64) of node
+	    <c>A</c> as a 32-bit big endian integer. <c>Creation</c> is the
+	    incarnation identifier of node <c>A</c>.
+	  </p>
         </item>
 
         <tag>5) <c>send_challenge_reply</c>/<c>recv_challenge_reply</c></tag>
@@ -858,6 +926,10 @@ recv_status
                           (ChB)                      ChB = gen_challenge()
   &lt;---------------------------------------------- send_challenge
 recv_challenge
+
+(if old send_name
+ send_complement - - - - - - - - - - - - - - - -&gt;
+                                                   recv_complement)
 
 ChA = gen_challenge(),
 OCA = out_cookie(B),

--- a/lib/erl_interface/src/connect/ei_connect.c
+++ b/lib/erl_interface/src/connect/ei_connect.c
@@ -103,6 +103,8 @@ static int recv_challenge(ei_socket_callbacks *cbs, void *ctx, int pkt_sz,
 static int send_challenge_reply(ei_socket_callbacks *cbs, void *ctx,
                                 int pkt_sz, unsigned char digest[16], 
 				unsigned challenge, unsigned ms);
+static int recv_complement(ei_socket_callbacks *cbs, void *ctx,
+                           int pkt_sz, DistFlags *flags, unsigned ms);
 static int recv_challenge_reply(ei_socket_callbacks *cbs, void *ctx,
                                 int pkt_sz, unsigned our_challenge,
 				char cookie[], 
@@ -115,7 +117,7 @@ static int recv_challenge_ack(ei_socket_callbacks *cbs, void *ctx,
 			      char cookie[], unsigned ms);
 static int send_name(ei_cnode *ec, void *ctx, int pkt_sz, unsigned ms);
 static int recv_name(ei_socket_callbacks *cbs, void *ctx, int pkt_sz,
-                     DistFlags *flags,
+                     char* send_name_tag, DistFlags *flags,
                      char *namebuf, unsigned ms);
 static int ei_connect_helper(ei_cnode* ec,
                              Erl_IpAddr ip_addr,
@@ -1531,6 +1533,7 @@ int ei_accept_tmo(ei_cnode* ec, int lfd, ErlConnect *conp, unsigned ms)
     int fd;
     DistFlags her_flags;
     char tmp_nodename[MAXNODELEN+1];
+    char send_name_tag;
     char *her_name;
     int pkt_sz, err;
     struct sockaddr_in addr;
@@ -1605,7 +1608,8 @@ int ei_accept_tmo(ei_cnode* ec, int lfd, ErlConnect *conp, unsigned ms)
     
     EI_TRACE_CONN0("ei_accept","<- ACCEPT connected to remote");
     
-    if (recv_name(cbs, ctx, pkt_sz, &her_flags, her_name, tmo)) {
+    if (recv_name(cbs, ctx, pkt_sz, &send_name_tag, &her_flags,
+                  her_name, tmo)) {
 	EI_TRACE_ERR0("ei_accept","<- ACCEPT initial ident failed");
 	goto error;
     }
@@ -1620,6 +1624,10 @@ int ei_accept_tmo(ei_cnode* ec, int lfd, ErlConnect *conp, unsigned ms)
 	our_challenge = gen_challenge();
 	if (send_challenge(ec, ctx, pkt_sz, our_challenge, her_flags, tmo))
 	    goto error;
+        if (send_name_tag == 'n') {
+            if (recv_complement(cbs, ctx, pkt_sz, &her_flags, tmo))
+                goto error;
+        }
 	if (recv_challenge_reply(cbs, ctx, pkt_sz, our_challenge, 
                                  ec->ei_connect_cookie, &her_challenge, tmo))
 	    goto error;
@@ -2517,6 +2525,63 @@ static int send_challenge_reply(ei_socket_callbacks *cbs, void *ctx,
     return 0;
 }
 
+static int recv_complement(ei_socket_callbacks *cbs,
+                           void *ctx,
+                           int pkt_sz,
+                           DistFlags *flags,
+                           unsigned ms)
+{
+    char dbuf[DEFBUF_SIZ];
+    char *buf = dbuf;
+    int is_static = 1;
+    int buflen = DEFBUF_SIZ;
+    int rlen;
+    char *s;
+    char tag;
+    unsigned int creation;
+
+    erl_errno = EIO;		/* Default */
+
+    if ((rlen = read_hs_package(cbs, ctx, pkt_sz, &buf, &buflen, &is_static, ms)) != 21) {
+	EI_TRACE_ERR1("recv_complement",
+		      "<- RECV_COMPLEMENT socket read failed (%d)",rlen);
+	goto error;
+    }
+
+    s = buf;
+    if ((tag = get8(s)) != 'c') {
+	EI_TRACE_ERR2("recv_complement",
+		      "<- RECV_COMPLEMENT incorrect tag, "
+		      "expected 'c' got '%c' (%u)",tag,tag);
+	goto error;
+    }
+    *flags |= (DistFlags)get32be(s) << 32;
+
+    if ((~*flags) & (DFLAG_DIST_MANDATORY | DFLAG_HANDSHAKE_23)) {
+	EI_TRACE_ERR0("recv_complement","<- RECV_COMPLEMENT peer cannot "
+		      "handle all mandatory capabilities");
+	goto error;
+    }
+
+    creation = get32be(s);
+    if (!is_static)
+	free(buf);
+
+    if (ei_tracelevel >= 3) {
+        EI_TRACE_CONN1("recv_complement",
+                       "<- RECV_COMPLEMENT (ok) creation = %u",
+                       creation);
+    }
+    /* We don't have any use for 'creation' of other node, so we drop it */
+    erl_errno = 0;
+    return 0;
+
+error:
+    if (!is_static)
+	free(buf);
+    return -1;
+}
+
 static int recv_challenge_reply(ei_socket_callbacks *cbs,
                                 void *ctx,
                                 int pkt_sz,
@@ -2673,7 +2738,7 @@ error:
 }
 
 static int recv_name(ei_socket_callbacks *cbs, void *ctx,
-                     int pkt_sz,
+                     int pkt_sz, char *send_name_tag,
                      DistFlags *flags, char *namebuf, unsigned ms)
 {
     char dbuf[DEFBUF_SIZ];
@@ -2685,6 +2750,7 @@ static int recv_name(ei_socket_callbacks *cbs, void *ctx,
     char *s;
     char tmp_nodename[MAXNODELEN+1];
     char tag;
+    DistFlags flag_mask;
     
     erl_errno = EIO;		/* Default */
 
@@ -2695,25 +2761,46 @@ static int recv_name(ei_socket_callbacks *cbs, void *ctx,
     }
     s = buf;
     tag = get8(s);
-    if (tag != 'N') {
+    *send_name_tag = tag;
+    if (tag != 'n' && tag != 'N') {
 	EI_TRACE_ERR2("recv_name","<- RECV_NAME incorrect tag, "
-		      "expected 'N', got '%c' (%u)",tag,tag);
+		      "expected 'n' or 'N', got '%c' (%u)",tag,tag);
 	goto error;
     }
-    if (rlen < 1+8+4+2) {
-        EI_TRACE_ERR1("recv_name","<- RECV_NAME 'N' packet too short (%d)",
-                      rlen)
-        goto error;
+    if (tag == 'n') {
+        unsigned int version;
+        if (rlen < 1+2+4) {
+            EI_TRACE_ERR1("recv_name","<- RECV_NAME 'n' packet too short (%d)",
+                          rlen)
+            goto error;
+        }
+        version = get16be(s);
+        if (version < EI_DIST_5) {
+            EI_TRACE_ERR1("recv_name","<- RECV_NAME 'n' invalid version=%d",
+                          version)
+            goto error;
+        }
+        *flags = get32be(s);
+        flag_mask = ((DistFlags)1 << 32) - 1;
+        namelen = rlen - (1+2+4);
     }
-    *flags = get64be(s);
-    s += 4; /* ignore peer 'creation' */
-    namelen = get16be(s);
+    else { /* tag == 'N' */
+        if (rlen < 1+8+4+2) {
+            EI_TRACE_ERR1("recv_name","<- RECV_NAME 'N' packet too short (%d)",
+                          rlen)
+            goto error;
+        }
+        *flags = get64be(s);
+        flag_mask = ~(DistFlags)0;
+        s += 4; /* ignore peer 'creation' */
+        namelen = get16be(s);
+    }
 
     if (*flags & DFLAG_MANDATORY_25_DIGEST) {
         *flags |= DFLAG_DIST_MANDATORY_25;
     }
 
-    if ((*flags & DFLAG_DIST_MANDATORY) != DFLAG_DIST_MANDATORY) {
+    if ((~*flags) & flag_mask & (DFLAG_DIST_MANDATORY | DFLAG_HANDSHAKE_23)) {
 	EI_TRACE_ERR0("recv_name","<- RECV_NAME peer cannot "
 		      "handle all mandatory capabilities");
 	erl_errno = EIO;
@@ -2724,8 +2811,8 @@ static int recv_name(ei_socket_callbacks *cbs, void *ctx,
         namebuf = &tmp_nodename[0];
     
     if (namelen > MAXNODELEN || s+namelen > buf+rlen) {
-        EI_TRACE_ERR1("recv_name","<- RECV_NAME nodename too long (%d)",
-                      namelen);
+        EI_TRACE_ERR2("recv_name","<- RECV_NAME '%c' nodename too long (%d)",
+                      tag, namelen);
         goto error;
     }
 
@@ -2734,9 +2821,9 @@ static int recv_name(ei_socket_callbacks *cbs, void *ctx,
 
     if (!is_static)
 	free(buf);
-    EI_TRACE_CONN2("recv_name",
-		   "<- RECV_NAME (ok) node = %s, flags = %u",
-		   namebuf, *flags);
+    EI_TRACE_CONN3("recv_name",
+		   "<- RECV_NAME (ok) node = %s, tag = %c, flags = %u",
+		   namebuf,tag,*flags);
     erl_errno = 0;
     return 0;
     

--- a/lib/erl_interface/src/epmd/ei_epmd.h
+++ b/lib/erl_interface/src/epmd/ei_epmd.h
@@ -24,6 +24,7 @@
 #define INADDR_LOOPBACK ((u_long) 0x7F000001)
 #endif
 
+#define EI_DIST_5 5 /* OTP R4 - 22 */
 #define EI_DIST_6 6 /* OTP 23 and later */
 
 #ifndef EI_DIST_HIGH

--- a/lib/erl_interface/test/ei_tmo_SUITE.erl
+++ b/lib/erl_interface/test/ei_tmo_SUITE.erl
@@ -146,6 +146,10 @@ do_one_recv_failure(Config,CNode) ->
 -define(EI_DIST_LOW, 6).
 -define(EI_DIST_HIGH, 6).
 
+%% An OTP-23 or 24 node may connect assuming 5 or higher.
+-define(EI_DIST_LOWEST_ASSUMED, 5).
+
+
 %% Check send with timeouts.
 ei_send_tmo(Config) when is_list(Config) ->
     register(ei_send_tmo_1,self()),
@@ -303,6 +307,15 @@ ei_connect_tmo(Config) when is_list(Config) ->
 
 %% Check accept with timeouts.
 ei_accept_tmo(Config) when is_list(Config) ->
+    [begin
+         io:format("Test assumed ver=~p\n",
+                   [AssumedVer]),
+         do_ei_accept_tmo(Config, AssumedVer)
+     end
+     || AssumedVer <- lists:seq(?EI_DIST_LOWEST_ASSUMED, ?EI_DIST_HIGH)],
+    ok.
+
+do_ei_accept_tmo(Config, AssumedVer) ->
     Flags = ?COMPULSORY_DFLAGS bor ?DFLAG_MANDATORY_25_DIGEST,
 
     P = runner:start(Config, ?accept_tmo),
@@ -323,11 +336,11 @@ ei_accept_tmo(Config) when is_list(Config) ->
     runner:recv_eot(P2),
     true = is_integer(X),
 
-    normal_accept(Config, Flags),
+    normal_accept(Config, AssumedVer, Flags),
 
     ok.
 
-normal_accept(Config, Flags) ->
+normal_accept(Config, AssumedVer, Flags) ->
     P = runner:start(Config, ?accept_tmo),
     runner:send_term(P,{c_nod_som_vi_kontaktar_2,
                          erlang:get_cookie(),
@@ -341,7 +354,7 @@ normal_accept(Config, Flags) ->
     {ok, SocketA} = gen_tcp:connect(atom_to_list(NB),PortNo,
                                     [{active,false},
                                      {packet,2}]),
-    send_name(SocketA, OurName, Flags),
+    send_name(SocketA, OurName, AssumedVer, Flags),
     ok = recv_status(SocketA),
     {hidden,_Node,HisChallengeA} = recv_challenge(SocketA), % See 1)
     _OurChallengeA = gen_challenge(),
@@ -401,13 +414,18 @@ make_and_check_dummy() ->
 
 %% Test that erl_interface sets the appropriate distributions flags.
 ei_dflags(Config) ->
+    AssumedVer = 5,
+    OurVer = 6,
+
     %% Test compatibility with OTP 24 and earlier.
     normal_connect(Config, ?COMPULSORY_DFLAGS),
-    normal_accept(Config, ?COMPULSORY_DFLAGS),
+    normal_accept(Config, AssumedVer, ?COMPULSORY_DFLAGS),
+    normal_accept(Config, OurVer, ?COMPULSORY_DFLAGS),
 
     %% Test compatibility with future versions.
     normal_connect(Config, ?DFLAG_MANDATORY_25_DIGEST),
-    normal_accept(Config, ?DFLAG_MANDATORY_25_DIGEST),
+    normal_accept(Config, AssumedVer, ?DFLAG_MANDATORY_25_DIGEST),
+    normal_accept(Config, OurVer, ?DFLAG_MANDATORY_25_DIGEST),
 
     ok.
 
@@ -558,14 +576,19 @@ send_challenge_ack(Socket, Digest) ->
 %            ?shutdown(bad_challenge_ack)
 %    end.
 
-send_name(Socket, MyNode, Flags) ->
+send_name(Socket, MyNode, AssumedVer, Flags0) ->
+    Flags = Flags0 bor?DFLAG_HANDSHAKE_23,
     NodeName = atom_to_binary(MyNode, latin1),
-    Creation = erts_internal:get_creation(),
-    ?to_port(Socket, [$N,
-                      <<Flags:64,
-                        Creation:32,
-                        (byte_size(NodeName)):16>>,
-                      NodeName]).
+    if AssumedVer =:= 5 ->
+            ?to_port(Socket, [$n,?int16(?EI_DIST_HIGH),?int32(Flags),NodeName]);
+       AssumedVer >= 6 ->
+            Creation = erts_internal:get_creation(),
+            ?to_port(Socket, [$N,
+                              <<Flags:64,
+                                Creation:32,
+                                (byte_size(NodeName)):16>>,
+                              NodeName])
+    end.
 
 recv_name(Socket) ->
     case gen_tcp:recv(Socket, 0) of

--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/AbstractConnection.java
@@ -1033,6 +1033,7 @@ public abstract class AbstractConnection extends Thread {
             sendStatus("ok");
             final int our_challenge = genChallenge();
             sendChallenge(peer.flags, localNode.flags, our_challenge);
+            recvComplement(send_name_tag);
             final int her_challenge = recvChallengeReply(our_challenge);
             final byte[] our_digest = genDigest(her_challenge,
                     localNode.cookie());
@@ -1245,11 +1246,26 @@ public abstract class AbstractConnection extends Thread {
             final OtpInputStream ibuf = new OtpInputStream(tmpbuf, 0);
             byte[] tmpname;
             final int len = tmpbuf.length;
+            long flag_mask;
+
             send_name_tag = ibuf.read1();
             switch (send_name_tag) {
+            case 'n':
+                if (ibuf.read2BE() != 5)
+                    throw new IOException("Invalid handshake version");
+                apeer.flags = ibuf.read4BE();
+                flag_mask = (1L << 32) - 1;
+                if ((apeer.flags & AbstractNode.dFlagHandshake23) == 0)
+                    throw new IOException("Missing DFLAG_HANDSHAKE_23");
+                apeer.distLow = apeer.distHigh = 6;
+                tmpname = new byte[len - 7];
+                ibuf.readN(tmpname);
+                hisname = OtpErlangString.newString(tmpname);
+                break;
             case 'N':
                 apeer.distLow = apeer.distHigh = 6;
                 apeer.flags = ibuf.read8BE();
+                flag_mask = ~0L;
                 if ((apeer.flags & AbstractNode.dFlagMandatory25Digest) != 0) {
                     apeer.flags |= AbstractNode.mandatoryFlags25;
                 }
@@ -1265,7 +1281,7 @@ public abstract class AbstractConnection extends Thread {
                 throw new IOException("Unknown remote node type");
             }
 
-            if ((apeer.flags & AbstractNode.mandatoryFlags) != AbstractNode.mandatoryFlags) {
+            if ((~apeer.flags & flag_mask & AbstractNode.mandatoryFlags) != 0) {
                 throw new IOException(
                         "Handshake failed - peer cannot handle all mandatory capabilities");
             }
@@ -1334,6 +1350,29 @@ public abstract class AbstractConnection extends Thread {
         }
 
         return challenge;
+    }
+
+    protected void recvComplement(int send_name_tag) throws IOException {
+
+        if (send_name_tag == 'n') {
+            try {
+                final byte[] tmpbuf = read2BytePackage();
+                @SuppressWarnings("resource")
+                final OtpInputStream ibuf = new OtpInputStream(tmpbuf, 0);
+                if (ibuf.read1() != 'c')
+                    throw new IOException("Not a complement tag");
+
+                final long flagsHigh = ibuf.read4BE();
+                peer.flags |= flagsHigh << 32;
+                if ((~peer.flags & AbstractNode.mandatoryFlags) != 0) {
+                    throw new IOException("Handshake failed - peer missing" +
+                                          " mandatory capabilities");
+                }
+                peer.setCreation(ibuf.read4BE());
+            } catch (final OtpErlangDecodeException e) {
+                throw new IOException("Handshake failed - not enough data");
+            }
+        }
     }
 
     protected void sendChallengeReply(final int challenge, final byte[] digest)

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -71,8 +71,6 @@
 -define(u32(X3,X2,X1,X0),
         (((X3) bsl 24) bor ((X2) bsl 16) bor ((X1) bsl 8) bor (X0))).
 
--define(CREATION_UNKNOWN,0).
-
 -record(tick, {read = 0,
 	       write = 0,
 	       tick = 0,
@@ -226,7 +224,7 @@ handshake_other_started(#hs_data{request_type=ReqType,
     ChallengeA = gen_challenge(),
     send_challenge(HSData2, ChallengeA),
     reset_timer(HSData2#hs_data.timer),
-    HSData3 = HSData2,
+    HSData3 = recv_complement(HSData2),
     check_dflags(HSData3, EDF),
     ChosenFlags = adjust_flags(HSData3#hs_data.this_flags,
                                HSData3#hs_data.other_flags),
@@ -260,10 +258,19 @@ expand_mandatory_25_flag(Flags) ->
 check_dflags(#hs_data{other_node = Node,
                       other_flags = OtherFlags,
                       other_started = OtherStarted,
-                      require_flags = RequiredFlags} = HSData,
+                      require_flags = RequiredFlags,
+                      other_creation = OtherCreation} = HSData,
              #erts_dflags{}=EDF) ->
 
-    Mandatory = (EDF#erts_dflags.mandatory bor RequiredFlags),
+    Mask = case OtherCreation of
+               undefined ->
+                   %% Old 'send_name' without creation and high flag bits
+                   %% Only check low 32 flag bits for now
+                   (1 bsl 32) - 1;
+               _ ->
+                   bnot 0
+           end,
+    Mandatory = Mask band (EDF#erts_dflags.mandatory bor RequiredFlags),
     Missing = check_mandatory(Mandatory, OtherFlags, []),
     case Missing of
         [] ->
@@ -726,10 +733,34 @@ send_challenge_ack(#hs_data{socket = Socket, f_send = FSend},
 %%
 recv_name(#hs_data{socket = Socket, f_recv = Recv} = HSData) ->
     case Recv(Socket, 0, infinity) of
+        {ok, [$n | _] = Data} ->
+            recv_name_old(HSData, Data);
         {ok, [$N | _] = Data} ->
             recv_name_new(HSData, Data);
 	_ ->
 	    ?shutdown(no_node)
+    end.
+
+%% OTP 25.3:
+%% We accept old 'send_name' messages ($n) used by OTP-22 and older.
+%% OTP-23 or OTP-24 nodes, not using epmd, may send the old message
+%% to us if they do not know our OTP version.
+%% Hence, we accept the old 'send_name' and the accompanying
+%% 'send_complement', but we do not send them ourself.
+%% This was removed prematurely in OTP-25.0,
+%% therefore versions 25.0 to 25.2.* are broken in this regard.
+%% Can be safely removed in OTP-27.0.
+recv_name_old(HSData,
+             [$n, V1, V0, F3, F2, F1, F0 | Node] = Data) ->
+    <<_Version:16>> = <<V1,V0>>,
+    <<Flags:32>> = <<F3,F2,F1,F0>>,
+    ?trace("recv_name: 'n' node=~p version=~w\n", [Node, _Version]),
+    case is_node_name(Node) of
+        true ->
+            check_allowed(HSData, Node),
+            {Flags, list_to_atom(Node), undefined};
+        false ->
+            ?shutdown(Data)
     end.
 
 recv_name_new(HSData,
@@ -922,6 +953,25 @@ recv_challenge_new(#hs_data{other_node=Node},
     end;
 recv_challenge_new(_, Other) ->
     ?shutdown2(no_node, {recv_challenge_failed, Other}).
+
+
+%% See comment for recv_name_old
+recv_complement(#hs_data{socket = Socket,
+                         f_recv = Recv,
+                         other_flags = Flags,
+                         other_creation = undefined} = HSData) ->
+    case Recv(Socket, 0, infinity) of
+        {ok, [$c, F7,F6,F5,F4, Cr3,Cr2,Cr1,Cr0]} ->
+            <<FlagsHigh:32>> = <<F7,F6,F5,F4>>,
+            <<Creation:32>> = <<Cr3,Cr2,Cr1,Cr0>>,
+            ?trace("recv_complement: creation=~w\n", [Creation]),
+            HSData#hs_data{other_creation = Creation,
+                           other_flags = Flags bor (FlagsHigh bsl 32)};
+        Other ->
+            ?shutdown2(no_node, {recv_complement_failed, Other})
+    end;
+recv_complement(HSData) ->
+    HSData.
 
 
 %%

--- a/lib/kernel/test/erl_distribution_wb_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_wb_SUITE.erl
@@ -40,7 +40,7 @@
         end).
 
 -define(DIST_VER_HIGH, 6).
--define(DIST_VER_LOW, 6).
+-define(DIST_VER_LOW, 5).
 
 -define(DFLAG_PUBLISHED,                16#01).
 -define(DFLAG_ATOM_CACHE,               16#02).
@@ -63,7 +63,7 @@
 %% From OTP 20 UTF8 atoms are compulsory.
 %% From OTP 21 NEW_FUN_TAGS is compulsory (no more tuple fallback {fun, ...}).
 %% From OTP 23 BIG_CREATION is compulsory.
-%% From OTP 25 NEW_FLOATS, MAP_TAG, EXPORT_PTR_TAG, and BIT_BINARIES are compulsory.
+%% From OTP 25 HANDSHAKE_23, NEW_FLOATS, MAP_TAG, EXPORT_PTR_TAG, and BIT_BINARIES are compulsory.
 -define(COMPULSORY_DFLAGS,
         (?DFLAG_EXTENDED_REFERENCES bor
              ?DFLAG_FUN_TAGS bor
@@ -71,6 +71,7 @@
              ?DFLAG_UTF8_ATOMS bor
              ?DFLAG_NEW_FUN_TAGS bor
              ?DFLAG_BIG_CREATION bor
+             ?DFLAG_HANDSHAKE_23 bor
              ?DFLAG_NEW_FLOATS bor
              ?DFLAG_MAP_TAG bor
              ?DFLAG_EXPORT_PTR_TAG bor
@@ -140,9 +141,13 @@ whitebox(Config) when is_list(Config) ->
     {ok, Peer, Node} = ?CT_PEER(),
     Cookie = erlang:get_cookie(),
     {_,Host} = split(node()),
-    ok = pending_up_md5(Node, join(ccc,Host), Cookie),
-    ok = simultaneous_md5(Node, join('A',Host), Cookie),
-    ok = simultaneous_md5(Node, join(zzzzzzzzzzzzzz,Host), Cookie),
+    [begin
+         io:format("Test TrustEpmd=~p\n", [TrustEpmd]),
+         ok = pending_up_md5(Node, join(ccc,Host), TrustEpmd, Cookie),
+         ok = simultaneous_md5(Node, join('A',Host), TrustEpmd, Cookie),
+         ok = simultaneous_md5(Node, join(zzzzzzzzzz,Host), TrustEpmd, Cookie)
+     end
+     || TrustEpmd <- [true, false]],
     peer:stop(Peer),
     ok.
 
@@ -211,17 +216,22 @@ test_switch_active_and_packet() ->
 %%
 %% Handshake tests
 %%
-pending_up_md5(Node, OurName, Cookie) ->
+pending_up_md5(Node,OurName,TrustEpmd,Cookie) ->
     {NA,NB} = split(Node),
-    {port,PortNo,?DIST_VER_HIGH} = erl_epmd:port_please(NA,NB),
+    {port,PortNo,EpmdSaysVersion} = erl_epmd:port_please(NA,NB),
     {ok, SocketA} = gen_tcp:connect(atom_to_list(NB),PortNo,
 				    [{active,false},
 				     {packet,2}]),
-    send_name(SocketA,OurName),
+    AssumedVersion = case TrustEpmd of
+                         true -> EpmdSaysVersion;
+                         false -> ?DIST_VER_LOW
+                     end,
+    SentNameMsg = send_name(SocketA,OurName,AssumedVersion),
     ok = recv_status(SocketA),
     {Node,HisChallengeA} = recv_challenge(SocketA),
     OurChallengeA = gen_challenge(),
     OurDigestA = gen_digest(HisChallengeA, Cookie),
+    send_complement(SocketA, SentNameMsg),
     send_challenge_reply(SocketA, OurChallengeA, OurDigestA),
     ok = recv_challenge_ack(SocketA, OurChallengeA, Cookie),
 %%%
@@ -233,13 +243,14 @@ pending_up_md5(Node, OurName, Cookie) ->
     {ok, SocketB} = gen_tcp:connect(atom_to_list(NB),PortNo,
 				    [{active,false},
 				     {packet,2}]),
-    send_name(SocketB,OurName),
+    SentNameMsg = send_name(SocketB,OurName,AssumedVersion),
     alive = recv_status(SocketB),
     send_status(SocketB, true),
     gen_tcp:close(SocketA),
     {Node,HisChallengeB} = recv_challenge(SocketB),
     OurChallengeB = gen_challenge(),
     OurDigestB = gen_digest(HisChallengeB, Cookie),
+    send_complement(SocketB, SentNameMsg),
     send_challenge_reply(SocketB, OurChallengeB, OurDigestB),
     ok = recv_challenge_ack(SocketB, OurChallengeB, Cookie),
 %%%
@@ -255,7 +266,7 @@ pending_up_md5(Node, OurName, Cookie) ->
     gen_tcp:close(SocketB),
     ok.
 
-simultaneous_md5(Node, OurName, Cookie) when OurName < Node ->
+simultaneous_md5(Node, OurName, TrustEpmd, Cookie) when OurName < Node ->
     pong = net_adm:ping(Node),
     LSocket = case gen_tcp:listen(0, [{active, false}, {packet,2}]) of
 		  {ok, Socket} ->
@@ -267,11 +278,15 @@ simultaneous_md5(Node, OurName, Cookie) when OurName < Node ->
     {NA, NB} = split(Node),
     rpc:cast(Node, net_adm, ping, [OurName]),
     receive after 1000 -> ok end,
-    {port, PortNo, ?DIST_VER_HIGH} = erl_epmd:port_please(NA,NB),
+    {port, PortNo, EpmdSaysVersion} = erl_epmd:port_please(NA,NB),
     {ok, SocketA} = gen_tcp:connect(atom_to_list(NB),PortNo,
 				    [{active,false},
 				     {packet,2}]),
-    send_name(SocketA,OurName),
+    AssumedVersion = case TrustEpmd of
+                         true -> EpmdSaysVersion;
+                         false -> ?DIST_VER_LOW
+                     end,
+    send_name(SocketA, OurName, AssumedVersion),
     %% We are still not marked up on the other side, as our first message 
     %% is not sent.
     SocketB = case gen_tcp:accept(LSocket) of
@@ -303,7 +318,7 @@ simultaneous_md5(Node, OurName, Cookie) when OurName < Node ->
     gen_tcp:close(EpmdSocket),
     ok;
 
-simultaneous_md5(Node, OurName, Cookie) when OurName > Node ->
+simultaneous_md5(Node, OurName, TrustEpmd, Cookie) when OurName > Node ->
     pong = net_adm:ping(Node),
     LSocket = case gen_tcp:listen(0, [{active, false}, {packet,2}]) of
 		  {ok, Socket} ->
@@ -315,7 +330,7 @@ simultaneous_md5(Node, OurName, Cookie) when OurName > Node ->
     {NA, NB} = split(Node),
     rpc:cast(Node, net_adm, ping, [OurName]),
     receive after 1000 -> ok end,
-    {port, PortNo, ?DIST_VER_HIGH} = erl_epmd:port_please(NA,NB),
+    {port, PortNo, EpmdSaysVersion} = erl_epmd:port_please(NA,NB),
     {ok, SocketA} = gen_tcp:connect(atom_to_list(NB),PortNo,
 				    [{active,false},
 				     {packet,2}]),
@@ -325,11 +340,15 @@ simultaneous_md5(Node, OurName, Cookie) when OurName > Node ->
 		  Else2 ->
 		      exit(Else2)
 	      end,
-    send_name(SocketA,OurName),
+    AssumedVersion = case TrustEpmd of
+                         true -> EpmdSaysVersion;
+                         false -> ?DIST_VER_LOW
+                     end,
+    SentNameMsg = send_name(SocketA,OurName, AssumedVersion),
     ok_simultaneous = recv_status(SocketA),
     %% Socket B should die during this
     case catch begin
-		   {Node,GotFlagsB} = recv_name(SocketB),
+		   {Node, GotFlagsB} = recv_name(SocketB),
                    true = (GotFlagsB band ?DFLAG_HANDSHAKE_23) =/= 0,
 		   send_status(SocketB, ok_simultaneous),
 		   MyChallengeB = gen_challenge(),
@@ -359,6 +378,7 @@ simultaneous_md5(Node, OurName, Cookie) when OurName > Node ->
     {Node,HisChallengeA} = recv_challenge(SocketA),
     OurChallengeA = gen_challenge(),
     OurDigestA = gen_digest(HisChallengeA, Cookie),
+    send_complement(SocketA, SentNameMsg),
     send_challenge_reply(SocketA, OurChallengeA, OurDigestA),
     ok = recv_challenge_ack(SocketA, OurChallengeA, Cookie),
 
@@ -374,16 +394,43 @@ simultaneous_md5(Node, OurName, Cookie) when OurName > Node ->
     ok.
 
 missing_compulsory_dflags(Config) when is_list(Config) ->
+    Cookie = erlang:get_cookie(),
     {ok, Peer, Node} = ?CT_PEER(),
     {NA,NB} = split(Node),
     {port,PortNo,_} = erl_epmd:port_please(NA,NB),
-    {ok, SocketA} = gen_tcp:connect(atom_to_list(NB),PortNo,
-                                    [{active,false},
-                                     {packet,2}]),
-    BadNode = list_to_atom(?CT_PEER_NAME()++"@"++atom_to_list(NB)),
-    send_name(SocketA,BadNode, 0),
-    not_allowed = recv_status(SocketA),
-    gen_tcp:close(SocketA),
+    [begin
+         io:format("Assumed version ~p, Missing flags ~.16B\n",
+                   [Version, MissingFlags]),
+         {ok, SocketA} = gen_tcp:connect(atom_to_list(NB),PortNo,
+                                         [{active,false},
+                                          {packet,2}]),
+         BadNode = list_to_atom(?CT_PEER_NAME()++"@"++atom_to_list(NB)),
+         Flags = ?COMPULSORY_DFLAGS band (bnot MissingFlags),
+         SentNameMsg = send_name(SocketA, BadNode, Version, Flags),
+         case {Version, MissingFlags bsr 32} of
+             {?DIST_VER_LOW, HighFlags} when HighFlags =/= 0 ->
+                 %% Missing flag in high word, peer will not detect that
+                 %% until we send complement.
+                 ok = recv_status(SocketA),
+                 {Node,HisChallengeA} = recv_challenge(SocketA),
+                 OurChallengeA = gen_challenge(),
+                 OurDigestA = gen_digest(HisChallengeA, Cookie),
+                 send_complement(SocketA, SentNameMsg, Flags),
+                 send_challenge_reply(SocketA, OurChallengeA, OurDigestA),
+
+                 %% Would normally expect recv_challenge_ack but dist_util
+                 %% reacts to missing flags with a status message instead.
+                 not_allowed = recv_status(SocketA);
+
+             _ ->
+                 not_allowed = recv_status(SocketA)
+         end,
+         gen_tcp:close(SocketA)
+     end
+     || Version <- lists:seq(?DIST_VER_LOW, ?DIST_VER_HIGH),
+        MissingFlags <- [?DFLAG_BIT_BINARIES,
+                         ?DFLAG_HANDSHAKE_23]],
+
     peer:stop(Peer),
     ok.
 
@@ -398,7 +445,7 @@ dflag_mandatory_25(_Config) ->
                                     PortNo,
                                     [{active,false},{packet,2}]),
     OtherNode = list_to_atom(?CT_PEER_NAME()++"@"++atom_to_list(NB)),
-    send_name(SocketA, OtherNode, ?DFLAG_MANDATORY_25_DIGEST),
+    send_name(SocketA, OtherNode, ?DIST_VER_HIGH, ?DFLAG_MANDATORY_25_DIGEST),
     ok = recv_status(SocketA),
     gen_tcp:close(SocketA),
     peer:stop(Peer),
@@ -558,6 +605,20 @@ verify_flags(Flags) ->
             ct:fail(missing_dflags)
     end.
 
+send_complement(Socket, SentNameMsg) ->
+    send_complement(Socket, SentNameMsg, ?COMPULSORY_DFLAGS).
+
+send_complement(Socket, SentNameMsg, Flags) ->
+    case SentNameMsg of
+        $n ->
+            FlagsHigh = Flags bsr 32,
+            ?to_port(Socket, [$c,
+                              <<FlagsHigh:32>>,
+                              ?int32(erts_internal:get_creation())]);
+        $N ->
+            ok
+    end.
+
 send_challenge_reply(Socket, Challenge, Digest) ->
     ?to_port(Socket, [$r,?int32(Challenge),Digest]).
 
@@ -589,16 +650,23 @@ recv_challenge_ack(Socket, ChallengeB, CookieA) ->
 	    end
     end.
 
-send_name(Socket, MyNode0) ->
+send_name(Socket, MyNode0, AssumedVersion) ->
     Flags = ?COMPULSORY_DFLAGS bor ?DFLAG_MANDATORY_25_DIGEST,
-    send_name(Socket, MyNode0, Flags).
+    send_name(Socket, MyNode0, AssumedVersion, Flags).
 
-send_name(Socket, MyNode0, Flags) ->
+send_name(Socket, MyNode0, AssumedVersion, Flags) ->
     MyNode = atom_to_list(MyNode0),
-    Creation = erts_internal:get_creation(),
-    NameLen = length(MyNode),
-    ok = ?to_port(Socket, [<<$N, (Flags bor ?DFLAG_HANDSHAKE_23):64,
-                             Creation:32,NameLen:16>>|MyNode]).
+    if (AssumedVersion =:= ?DIST_VER_LOW) ->
+            ok = ?to_port(Socket, [<<$n,?DIST_VER_HIGH:16,Flags:32>>|MyNode]),
+            $n;
+
+       (AssumedVersion > ?DIST_VER_LOW) ->
+            Creation = erts_internal:get_creation(),
+            NameLen = length(MyNode),
+            ok = ?to_port(Socket, [<<$N, Flags:64,
+                                     Creation:32,NameLen:16>>|MyNode]),
+            $N
+    end.
 
 recv_name(Socket) ->
     case gen_tcp:recv(Socket, 0) of


### PR DESCRIPTION
Fixes #6595.

Make OTP-25 accept old `send_name` handshake messages used by OTP-22 and older. OTP-23 or OTP-24 nodes, **not using epmd**, may send the old message to us if they do not know our OTP version.
Hence, we accept the old `send_name` and the accompanying `send_complement`, but we do not send them ourself.

This was removed prematurely in OTP-25.0 by commit 722219f211092e0c4b919f3ba4f91df42191c0e7.
Therefore versions 25.0 to 25.2.* are broken in this regard and may reject connection setup from OTP-23 and 24 not using epmd.