### PR TITLE
Fix a doc link to flamegraphs on the BeamAsm page

### DIFF
--- a/erts/emulator/internal_doc/BeamAsm.md
+++ b/erts/emulator/internal_doc/BeamAsm.md
@@ -362,7 +362,7 @@ your needs. For instance, if we run dialyzer with all schedulers:
       syntax_tools asn1 edoc et ftp inets mnesia observer public_key \
       sasl runtime_tools snmp ssl tftp wx xmerl tools --statistics
 
-And then use the scripts found at Brendan Gregg's [CPU Flame Graphs](http://www.brendangregg.com/FlameGraphs/cpuflamegraphs)
+And then use the scripts found at Brendan Gregg's [CPU Flame Graphs](https://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html)
 web page as follows:
 
     ## Collect the results


### PR DESCRIPTION
The [current link](http://www.brendangregg.com/FlameGraphs/cpuflamegraphs) to Brendan Gregg's CPU Flame Graphs results in a 404. Update it to [the new url](https://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html). The rest of the links on this page seem good.