### PR TITLE
Fix typos in doc

### DIFF
--- a/erts/doc/src/crash_dump.xml
+++ b/erts/doc/src/crash_dump.xml
@@ -536,7 +536,7 @@ Slogan: &lt;reason&gt;</pre>
       <tag><em>Type</em></tag>
       <item>
         <p>The table type, that is, <c>set</c>, <c>bag</c>,
-          <c>dublicate_bag</c>, or <c>ordered_set</c>.</p>
+          <c>duplicate_bag</c>, or <c>ordered_set</c>.</p>
       </item>
       <tag><em>Compressed</em></tag>
       <item>

--- a/lib/ssh/doc/src/configurations.xml
+++ b/lib/ssh/doc/src/configurations.xml
@@ -246,7 +246,7 @@ ok
                         ]).
 {ok,&gt;0.118.0>}
 	</code>
-	<p>We check which algoritms are negotiated by the client and the server, and note that
+	<p>We check which algorithms are negotiated by the client and the server, and note that
 	the (only) <c>kex</c> algorithm <c>'curve25519-sha256@libssh.org'</c> was selected:
 	</p>
 	<code>

--- a/lib/ssh/doc/src/configure_algos.xml
+++ b/lib/ssh/doc/src/configure_algos.xml
@@ -110,7 +110,7 @@
 
     <section>
       <title>The SSH app's mechanism</title>
-      <p>The set of algorithms that the SSH app uses by default depends on the algoritms supported by the:</p>
+      <p>The set of algorithms that the SSH app uses by default depends on the algorithms supported by the:</p>
       <list>
 	<item><p><seeerl marker="crypto:crypto">crypto</seeerl> app,</p>
 	</item>
@@ -322,7 +322,7 @@
     <section>
       <title>Example 5</title>
       <p>As an example let's add the Diffie-Hellman Group1 first in the kex list. It is supported according to 
-      <seeapp marker="SSH_app#supported_algos">Supported algoritms</seeapp>.</p>
+      <seeapp marker="SSH_app#supported_algos">Supported algorithms</seeapp>.</p>
       <code type="erl">
 5> ssh:chk_algos_opts(
          [{modify_algorithms,

--- a/lib/ssh/test/ssh_compat_SUITE.erl
+++ b/lib/ssh/test/ssh_compat_SUITE.erl
@@ -847,7 +847,7 @@ new_dir(Config) ->
 
 %%--------------------------------------------------------------------
 %%
-%% Find the intersection of algoritms for otp ssh and the docker ssh.
+%% Find the intersection of algorithms for otp ssh and the docker ssh.
 %% Returns {ok, ServerHello, Server, ClientHello, Client} where Server are the algorithms common
 %% with the docker server and analogous for Client.
 %%

--- a/lib/stdlib/doc/src/rand.xml
+++ b/lib/stdlib/doc/src/rand.xml
@@ -540,7 +540,7 @@ end.</pre>
 	    <seemfa marker="#uniform/0"><c>uniform/0</c></seemfa>
 	    because all bits in the mantissa are random.
 	    This property, in combination with the fact that exactly zero
-	    is never returned is useful for algoritms doing for example
+	    is never returned is useful for algorithms doing for example
 	    <c>1.0 / <anno>X</anno></c> or <c>math:log(<anno>X</anno>)</c>.
 	  </p>
 	</note>
@@ -623,7 +623,7 @@ end.</pre>
 	    <seemfa marker="#uniform_s/1"><c>uniform_s/1</c></seemfa>
 	    because all bits in the mantissa are random.
 	    This property, in combination with the fact that exactly zero
-	    is never returned is useful for algoritms doing for example
+	    is never returned is useful for algorithms doing for example
 	    <c>1.0 / <anno>X</anno></c> or <c>math:log(<anno>X</anno>)</c>.
 	  </p>
 	</note>


### PR DESCRIPTION
This fix some typos in the documentation