### PR TITLE
add send/2 override for multiple pids

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -460,6 +460,7 @@ atom monotonic_timestamp
 atom more
 atom multi_scheduling
 atom multiline
+atom multisend
 atom nano_seconds
 atom nanosecond
 atom name
@@ -491,6 +492,7 @@ atom nodedown
 atom nodedown_reason
 atom nodeup
 atom noeol
+atom nomultisend
 atom noproc
 atom normal
 atom normal_exit

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -60,6 +60,7 @@ static Export await_exit_trap;
 static Export* flush_monitor_messages_trap = NULL;
 static Export* set_cpu_topology_trap = NULL;
 static Export* await_port_send_result_trap = NULL;
+static Export* multisend_trap = NULL;
 Export* erts_format_cpu_topology_trap = NULL;
 #ifndef DEBUG
 static
@@ -2123,6 +2124,8 @@ ebif_bang_2(BIF_ALIST_2)
 #define SEND_AWAIT_RESULT	(-7)
 #define SEND_YIELD_CONTINUE     (-8)
 #define SEND_SYSTEM_LIMIT	(-9)
+#define SEND_MULTISEND          (-10)
+#define SEND_NOMULTISEND        (-11)
 
 
 static Sint remote_send(Process *p, DistEntry *dep,
@@ -2133,7 +2136,7 @@ static Sint remote_send(Process *p, DistEntry *dep,
     Sint res;
     int code;
     ErtsDSigSendContext ctx;
-    ASSERT(is_atom(to) || is_external_pid(to) || is_external_ref(to));
+    ASSERT(is_atom(to) || is_external_pid(to) || is_external_ref(to) || is_list(to));
 
     code = erts_dsig_prepare(&ctx, dep, p, ERTS_PROC_LOCK_MAIN,
 			     ERTS_DSP_NO_LOCK,
@@ -2161,6 +2164,10 @@ static Sint remote_send(Process *p, DistEntry *dep,
         }
         /* Fall through... */
     case ERTS_DSIG_PREP_PENDING: {
+        if (!(ctx.dflags & DFLAG_MULTISEND) && is_list(to)) {
+            res = SEND_NOMULTISEND;
+            break;
+        }
 
 	if (is_atom(to))
 	    code = erts_dsig_send_reg_msg(&ctx, to, full_to, msg);
@@ -2216,7 +2223,10 @@ do_send(Process *p, Eterm to, Eterm msg, Eterm return_term, Eterm *refp,
     DistEntry *dep;
     Eterm* tp;
 
-    if (is_internal_pid(to)) {
+    if (is_list(to)) {
+        return SEND_MULTISEND;
+    }
+    else if (is_internal_pid(to)) {
 	if (IS_TRACED_FL(p, F_TRACE_SEND))
 	    trace_send(p, to, msg);
 	if (ERTS_PROC_GET_SAVED_CALLS_BUF(p))
@@ -2514,6 +2524,9 @@ BIF_RETTYPE send_3(BIF_ALIST_3)
 	BUMP_ALL_REDS(p);
 	ERTS_BIF_PREP_TRAP1(retval, &dsend_continue_trap_export, p, ctx);
 	break;
+    case SEND_MULTISEND:
+	ERTS_BIF_PREP_TRAP2(retval, multisend_trap, p, to, msg);
+        break;
     default:
 	erts_exit(ERTS_ABORT_EXIT, "send_3 invalid result %d\n", (int)result);
 	break;
@@ -2526,6 +2539,81 @@ done:
 BIF_RETTYPE send_2(BIF_ALIST_2)
 {
     return erl_send(BIF_P, BIF_ARG_1, BIF_ARG_2);
+}
+
+BIF_RETTYPE erts_internal_multisend_bif_2(BIF_ALIST_2)
+{
+
+    Eterm retval;
+    Eterm ref;
+    Sint result;
+    Eterm ctx;
+    Process *p;
+    Eterm pids;
+    Eterm msg;
+    DistEntry *dep;
+
+    ERTS_MSACC_PUSH_AND_SET_STATE_M_X(ERTS_MSACC_STATE_SEND);
+
+    p = BIF_P;
+    pids = BIF_ARG_1;
+    msg = BIF_ARG_2;
+    ref = NIL;
+
+    dep = external_dist_entry(CAR(list_val(pids)));
+    result = remote_send(p, dep, pids, dep->sysname, pids, msg, msg, &ctx, 1, 1);
+
+    ERTS_MSACC_POP_STATE_M_X();
+
+    if (result >= 0) {
+        ERTS_VBUMP_REDS(p, 4);
+        if (ERTS_IS_PROC_OUT_OF_REDS(p))
+            goto yield_return;
+        ERTS_BIF_PREP_RET(retval, msg);
+        goto done;
+    }
+
+    switch (result) {
+    case SEND_NOCONNECT:
+        ERTS_BIF_PREP_RET(retval, msg);
+        break;
+    case SEND_YIELD:
+        ERTS_BIF_PREP_YIELD2(retval, BIF_TRAP_EXPORT(BIF_erts_internal_multisend_bif_2), p, pids, msg);
+        break;
+    case SEND_YIELD_RETURN:
+    yield_return:
+        ERTS_BIF_PREP_YIELD_RETURN(retval, p, msg);
+        break;
+    case SEND_AWAIT_RESULT:
+        ASSERT(is_internal_ordinary_ref(ref));
+        ERTS_BIF_PREP_TRAP3(retval, await_port_send_result_trap, p, ref, msg, msg);
+        break;
+    case SEND_BADARG:
+        ERTS_BIF_PREP_ERROR(retval, p, BADARG);
+        break;
+    case SEND_SYSTEM_LIMIT:
+        ERTS_BIF_PREP_ERROR(retval, p, SYSTEM_LIMIT);
+        break;
+    case SEND_USER_ERROR:
+        ERTS_BIF_PREP_ERROR(retval, p, EXC_ERROR);
+        break;
+    case SEND_INTERNAL_ERROR:
+        ERTS_BIF_PREP_ERROR(retval, p, EXC_INTERNAL_ERROR);
+        break;
+    case SEND_YIELD_CONTINUE:
+        BUMP_ALL_REDS(p);
+        ERTS_BIF_PREP_TRAP1(retval, &dsend_continue_trap_export, p, ctx);
+        break;
+    case SEND_NOMULTISEND:
+        ERTS_BIF_PREP_RET(retval, am_nomultisend);
+        break;
+    default:
+        erts_exit(ERTS_ABORT_EXIT, "invalid send result %d\n", (int)result);
+        break;
+    }
+
+done:
+    return retval;
 }
 
 static BIF_RETTYPE dsend_continue_trap_1(BIF_ALIST_1)
@@ -2623,6 +2711,9 @@ Eterm erl_send(Process *p, Eterm to, Eterm msg)
 	BUMP_ALL_REDS(p);
 	ERTS_BIF_PREP_TRAP1(retval, &dsend_continue_trap_export, p, ctx);
 	break;
+    case SEND_MULTISEND:
+	ERTS_BIF_PREP_TRAP2(retval, multisend_trap, p, to, msg);
+        break;
     default:
 	erts_exit(ERTS_ABORT_EXIT, "invalid send result %d\n", (int)result);
 	break;
@@ -5510,6 +5601,8 @@ void erts_init_bif(void)
     flush_monitor_messages_trap = erts_export_put(am_erts_internal,
 						  am_flush_monitor_messages,
 						  3);
+
+    multisend_trap = erts_export_put(am_erts_internal, am_multisend, 2);
 
     erts_convert_time_unit_trap = erts_export_put(am_erlang,
 						  am_convert_time_unit,

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -325,6 +325,7 @@ ubif erlang:'+'/1			splus_1
 bif erlang:'!'/2		ebif_bang_2
 bif erlang:send/2
 bif erlang:send/3
+bif erts_internal:multisend_bif/2
 bif erlang:'++'/2		ebif_plusplus_2
 bif erlang:append/2
 bif erlang:'--'/2		ebif_minusminus_2

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -2516,6 +2516,25 @@ int erts_net_message(Port *prt,
 #endif
         from = tuple[2];
         to = tuple[3];
+        if (is_list(to)) {
+            Eterm pid;
+            while (is_list(to)) {
+                pid = CAR(list_val(to));
+                if (is_not_pid(pid)) {
+                    goto invalid_message;
+                }
+                rp = erts_proc_lookup(pid);
+                if (rp) {
+                    erts_queue_dist_message(rp, 0, edep, ede_hfrag, token, from);
+                }
+                to = CDR(list_val(to));
+            }
+            if (ede_hfrag != NULL) {
+                erts_free_dist_ext_copy(erts_get_dist_ext(ede_hfrag));
+                free_message_buffer(ede_hfrag);
+            }
+            break;
+        }
         if (is_not_pid(to))
             goto invalid_message;
         rp = erts_proc_lookup(to);

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -52,6 +52,7 @@
 #define DFLAG_HANDSHAKE_23        ((Uint64)0x1000000)
 #define DFLAG_UNLINK_ID           ((Uint64)0x2000000)
 #define DFLAG_MANDATORY_25_DIGEST ((Uint64)0x4000000)
+#define DFLAG_MULTISEND           ((Uint64)0x8000000)
 #define DFLAG_RESERVED           ((Uint64)0xf8000000)
 
 /*
@@ -114,7 +115,8 @@
                             | DFLAG_FRAGMENTS                 \
                             | DFLAG_SPAWN                     \
                             | DFLAG_ALIAS		      \
-                            | DFLAG_MANDATORY_25_DIGEST)
+                            | DFLAG_MANDATORY_25_DIGEST       \
+                            | DFLAG_MULTISEND)
 
 /* Flags addable by local distr implementations */
 #define DFLAG_DIST_ADDABLE    DFLAG_DIST_DEFAULT

--- a/erts/preloaded/src/erts_internal.erl
+++ b/erts/preloaded/src/erts_internal.erl
@@ -55,6 +55,8 @@
 -export([flush_monitor_messages/3,
          '@flush_monitor_messages_refopt'/0]).
 
+-export([multisend/2, multisend_bif/2]).
+
 -export([await_result/1, gather_io_bytes/2]).
 
 -export([time_unit/0, perf_counter_unit/0]).
@@ -532,6 +534,24 @@ flush_monitor_messages(Ref, Multi, Res) when is_reference(Ref) ->
     Ref = make_ref(),
     flush_monitor_messages(Ref, true, ok),
     flush_monitor_messages(Ref, true, ok).
+
+-spec multisend(Dest, Msg) -> Msg when
+      Dest :: [pid()],
+      Msg :: term().
+multisend(Dest, Msg) ->
+    Groups = maps:groups_from_list(fun erlang:node/1, Dest),
+    maps:foreach(fun(N, Ps) when N =:= erlang:node() -> lists:foreach(fun(P) -> P ! Msg end, Ps);
+                    (_N, Ps) -> case erts_internal:multisend_bif(Ps, Msg) of
+                                    nomultisend ->
+                                        lists:foreach(fun(P) -> P ! Msg end, Ps);
+                                    _ -> nil
+                                end
+                 end,
+                 Groups),
+    Msg.
+
+multisend_bif(_Pids, _Msg) ->
+    erlang:nif_error(undefined).
 
 -spec erts_internal:time_unit() -> pos_integer().
 


### PR DESCRIPTION
From discussion in https://erlangforums.com/t/send-optimization-for-sending-to-many-processes/2200

TL;DR: sending a single message to many many pids by looping over the pids is not great because the pids are almost certainly guaranteed to be grouped into a much smaller number of nodes. By passing a list of the pids to send/2, we can group them by node, and only send one message to each node, which then distributes the message to its processes.

I poorly benchmarked this on my home network with a few laptops and found that it significantly reduces the time spent in `send`, with the list variant being around 10x faster. (testing script: https://gist.github.com/devsnek/d5d1b55eade3a3d5aad07fd3675f3a22)

TODO:
- [ ] does this make sense?
- [ ] tests
- [ ] docs