### PR TITLE
sys_core_fold: Remove problematic optimization

### DIFF
--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -18,6 +18,7 @@
 %% %CopyrightEnd%
 %%
 -module(core_fold_SUITE).
+-feature(maybe_expr, enable).
 
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
 	 init_per_group/2,end_per_group/2,
@@ -705,6 +706,8 @@ nested_lets(_Config) ->
     {'EXIT',{badarith,_}} = catch nested_lets_2(id(0), id(0)),
     {'EXIT',{badarith,_}} = catch nested_lets_3(),
     {'EXIT',{undef,_}} = catch nested_lets_4(),
+    {'EXIT',{{case_clause,_},_}} = catch nested_lets_5(),
+    {'EXIT',{badarith,_}} = catch nested_lets_6(),
 
     ok.
 
@@ -817,6 +820,31 @@ nested_lets_4() ->
     of
         _ ->
             Y
+    after
+        ok
+    end.
+
+%% GH-6633.
+nested_lets_5() ->
+    case self() of
+        [_ | X] ->
+            ok;
+        false ->
+            {ok#{
+                (X = ok) :=
+                    ((ok /=
+                        maybe
+                            ok
+                        end) =/= ok)
+            }}
+    end,
+    X.
+
+%% GH-6635.
+nested_lets_6() ->
+    try {not (false orelse (ok#{(1 / 0) := ok})), X = ok} of
+        X ->
+            ok
     after
         ok
     end.


### PR DESCRIPTION
The optimization of nested lets was unsafe if the number of iterations for `sys_core_fold` ran out. There have been several attempts to fix that problem:

5076069ff1278ba7a511f8cdd449d2718abfa278 (#6624)
30d4c453ed6522b95faf771ff54530a513d70a44 (#6631)
ff05beecae2e002914515e94ab59930026dc9a75 (#6575)

It's time to cut the Gordian knot by removing the optimization. While at it, remove all optimizations of nested lets, not only the offending part of the optimization.

Running `scripts/diffable` before and after and diffing, shows changes in 40 modules. Most of them are neutral (the same instructions in a different order). There are few changes where an extra `test_heap` instruction has been introduced, for example in the `compile` module:

    -    {test_heap,19,1}.
    +    {test_heap,15,1}.
         {update_record,{atom,reuse},14,{y,0},{x,0},{list,[7,{x,0}]}}.
    -    {put_tuple2,{x,0},{list,[{atom,ok},{y,1},{x,0}]}}.
         {try_end,{y,2}}.
    +    {test_heap,4,1}.
    +    {put_tuple2,{x,0},{list,[{atom,ok},{y,1},{x,0}]}}.
         {deallocate,3}.
         return.

which was compiled from this source code:

    try
        Mod = cerl:concrete(cerl:module_name(Core)),
        {ok,Core,St#compile{module=Mod}}
    catch
        _:_ ->
            {ok,Core,St}
    end.

In the `ct_run` module, the following code:

    case proplists:get_value(step, Misc) of
        undefined ->
            #opts{};
        StepOpts ->
            #opts{step = StepOpts}
    end

is no longer optimized to:

    StepOpts = proplists:get_value(step, Misc)
    #opts{step = StepOpts}

There are also improvements in a few modules.

Closes #6633
Closes #6635