### PR TITLE
Fix more buggy assertions

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -417,12 +417,28 @@ protected:
         return arm::Mem(ARG1, CodeIndex, arm::lsl(3));
     }
 
+    /* Prefer `eHeapAlloc` over `eStack | eHeap` when calling
+     * functions in the runtime system that allocate heap
+     * memory (`HAlloc`, heap factories, etc).
+     *
+     * Prefer `eHeapOnlyAlloc` over `eHeapAlloc` for functions
+     * that assume there's already a certain amount of free
+     * space on the heap, such as those using `HeapOnlyAlloc`
+     * or similar. It's slightly cheaper in release builds,
+     * and in debug builds it updates `eStack` to ensure that
+     * we can make heap size assertions. */
     enum Update : int {
         eStack = (1 << 0),
         eHeap = (1 << 1),
         eReductions = (1 << 2),
         eCodeIndex = (1 << 3),
-        eXRegs = (1 << 4)
+        eXRegs = (1 << 4),
+        eHeapAlloc = Update::eHeap | Update::eStack,
+#ifndef DEBUG
+        eHeapOnlyAlloc = Update::eHeap,
+#else
+        eHeapOnlyAlloc = Update::eHeapAlloc
+#endif
     };
 
     void emit_enter_erlang_frame() {

--- a/erts/emulator/beam/jit/arm/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.cpp
@@ -204,8 +204,8 @@ void BeamGlobalAssembler::emit_export_trampoline() {
     a.bind(error_handler);
     {
         emit_enter_runtime_frame();
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap | Update::eXRegs>();
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc |
+                           Update::eXRegs>();
 
         lea(ARG2, arm::Mem(ARG1, offsetof(Export, info.mfa)));
         a.mov(ARG1, c_p);
@@ -215,8 +215,8 @@ void BeamGlobalAssembler::emit_export_trampoline() {
 
         /* If there is no error_handler, any number of X registers
          * can be live. */
-        emit_leave_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap | Update::eXRegs>();
+        emit_leave_runtime<Update::eReductions | Update::eHeapAlloc |
+                           Update::eXRegs>();
         emit_leave_runtime_frame();
 
         a.cbz(ARG1, labels[process_exit]);
@@ -292,7 +292,7 @@ void BeamGlobalAssembler::emit_raise_exception_shared() {
      * traces because it's equal to the error address. */
     a.str(ARG2, arm::Mem(E, -8).pre());
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs>();
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs>();
 
     /* The error address must be a valid CP or NULL. */
     a.tst(ARG2, imm(_CPMASK));
@@ -303,7 +303,7 @@ void BeamGlobalAssembler::emit_raise_exception_shared() {
     load_x_reg_array(ARG3);
     runtime_call<4>(handle_error);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs>();
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs>();
 
     a.cbz(ARG1, labels[do_schedule]);
 

--- a/erts/emulator/beam/jit/arm/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bif.cpp
@@ -993,14 +993,14 @@ void BeamModuleAssembler::emit_i_load_nif() {
 
     a.bind(entry);
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs>(2);
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs>(2);
 
     a.mov(ARG1, c_p);
     a.adr(ARG2, currLabel);
     load_x_reg_array(ARG3);
     runtime_call<3>(beam_jit_load_nif);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs>(2);
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs>(2);
 
     a.cmp(ARG1, imm(RET_NIF_yield));
     a.b_eq(schedule);

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -125,7 +125,7 @@ void BeamModuleAssembler::emit_i_bs_init_heap(const ArgWord &Size,
     mov_arg(ARG5, Heap);
     mov_arg(ARG6, Live);
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(Live.get());
 
     a.mov(ARG1, c_p);
@@ -133,7 +133,7 @@ void BeamModuleAssembler::emit_i_bs_init_heap(const ArgWord &Size,
     load_erl_bits_state(ARG3);
     runtime_call<6>(beam_jit_bs_init);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(Live.get());
 
     mov_arg(Dst, ARG1);
@@ -171,7 +171,7 @@ void BeamModuleAssembler::emit_i_bs_init_fail_heap(const ArgSource &Size,
         mov_arg(ARG5, Heap);
         mov_arg(ARG6, Live);
 
-        emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+        emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                            Update::eReductions>(Live.get());
 
         a.mov(ARG1, c_p);
@@ -179,7 +179,7 @@ void BeamModuleAssembler::emit_i_bs_init_fail_heap(const ArgSource &Size,
         load_erl_bits_state(ARG3);
         runtime_call<6>(beam_jit_bs_init);
 
-        emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+        emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                            Update::eReductions>(Live.get());
 
         mov_arg(Dst, ARG1);
@@ -230,7 +230,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_heap(const ArgWord &NumBits,
     mov_arg(ARG5, Alloc);
     mov_arg(ARG6, Live);
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(Live.get());
 
     a.mov(ARG1, c_p);
@@ -238,7 +238,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_heap(const ArgWord &NumBits,
     load_erl_bits_state(ARG3);
     runtime_call<6>(beam_jit_bs_init_bits);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(Live.get());
 
     mov_arg(Dst, ARG1);
@@ -271,7 +271,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_fail_heap(
         mov_arg(ARG5, Alloc);
         mov_arg(ARG6, Live);
 
-        emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+        emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                            Update::eReductions>(Live.get());
 
         a.mov(ARG1, c_p);
@@ -279,7 +279,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_fail_heap(
         load_erl_bits_state(ARG3);
         runtime_call<6>(beam_jit_bs_init_bits);
 
-        emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+        emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                            Update::eReductions>(Live.get());
 
         mov_arg(Dst, ARG1);
@@ -698,9 +698,8 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
             }
 
             if (potentially_expensive) {
-                emit_enter_runtime<Update::eStack | Update::eHeap |
-                                   Update::eXRegs | Update::eReductions>(
-                        Live.get());
+                emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
+                                   Update::eReductions>(Live.get());
             } else {
                 comment("simplified entering runtime because result is always "
                         "small");
@@ -719,9 +718,8 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
             runtime_call<6>(beam_jit_bs_get_integer);
 
             if (potentially_expensive) {
-                emit_leave_runtime<Update::eStack | Update::eHeap |
-                                   Update::eXRegs | Update::eReductions>(
-                        Live.get());
+                emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
+                                   Update::eReductions>(Live.get());
             } else {
                 emit_leave_runtime(Live.get());
             }
@@ -1601,14 +1599,14 @@ void BeamModuleAssembler::emit_i_bs_append(const ArgLabel &Fail,
 
     mov_arg(ArgXRegister(Live.get()), Bin);
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(Live.get() + 1);
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<6>(erts_bs_append);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(Live.get() + 1);
 
     if (Fail.get() != 0) {
@@ -1665,11 +1663,11 @@ void BeamModuleAssembler::emit_bs_init_writable() {
 
     /* We have an implicit liveness of 0, so we don't need to stash X
      * registers. */
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>(0);
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>(0);
 
     runtime_call<2>(erts_bs_init_writable);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>(0);
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>(0);
 
     a.mov(XREG0, ARG1);
 }
@@ -1677,7 +1675,7 @@ void BeamModuleAssembler::emit_bs_init_writable() {
 void BeamGlobalAssembler::emit_bs_create_bin_error_shared() {
     a.mov(XREG0, a64::x30);
 
-    emit_enter_runtime<Update::eStack | Update::eHeap>(0);
+    emit_enter_runtime<Update::eHeapAlloc>(0);
 
     /* ARG3 is already set by the caller */
     a.mov(ARG2, ARG4);
@@ -1685,7 +1683,7 @@ void BeamGlobalAssembler::emit_bs_create_bin_error_shared() {
     a.mov(ARG1, c_p);
     runtime_call<4>(beam_jit_bs_construct_fail_info);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>(0);
+    emit_leave_runtime<Update::eHeapAlloc>(0);
 
     a.mov(ARG4, ZERO);
     a.mov(ARG2, XREG0);
@@ -2639,10 +2637,10 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         a.mov(ARG1, c_p);
         load_x_reg_array(ARG2);
 
-        emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+        emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                            Update::eReductions>(Live.get() + 1);
         runtime_call<6>(erts_bs_append_checked);
-        emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+        emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                            Update::eReductions>(Live.get() + 1);
 
         if (std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
@@ -2760,8 +2758,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         load_erl_bits_state(ARG3);
         load_x_reg_array(ARG2);
         a.mov(ARG1, c_p);
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap | Update::eXRegs>(Live.get());
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc |
+                           Update::eXRegs>(Live.get());
         if (sizeReg.isValid()) {
             comment("(size in bits)");
             a.mov(ARG4, sizeReg);
@@ -2774,8 +2772,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             mov_imm(ARG4, num_bits);
             runtime_call<6>(beam_jit_bs_init_bits);
         }
-        emit_leave_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap | Update::eXRegs>(Live.get());
+        emit_leave_runtime<Update::eReductions | Update::eHeapAlloc |
+                           Update::eXRegs>(Live.get());
     }
     a.str(ARG1, TMP_MEM1q);
 

--- a/erts/emulator/beam/jit/arm/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/instr_call.cpp
@@ -119,7 +119,7 @@ arm::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
 
     a.bind(entry);
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap |
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc |
                        Update::eXRegs>(3);
 
     a.mov(ARG1, c_p);
@@ -137,7 +137,7 @@ arm::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
     runtime_call<4>(apply);
 
     /* Any number of X registers can be live at this point. */
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap |
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc |
                        Update::eXRegs>();
 
     a.cbnz(ARG1, dispatch);
@@ -172,7 +172,7 @@ arm::Mem BeamModuleAssembler::emit_fixed_apply(const ArgWord &Arity,
 
     mov_arg(ARG3, Arity);
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap |
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc |
                        Update::eXRegs>(Arity.get() + 2);
 
     a.mov(ARG1, c_p);
@@ -190,7 +190,7 @@ arm::Mem BeamModuleAssembler::emit_fixed_apply(const ArgWord &Arity,
 
     /* We will need to reload all X registers in case there has been
      * an error. */
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap |
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc |
                        Update::eXRegs>();
 
     a.cbnz(ARG1, dispatch);

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -225,7 +225,7 @@ void BeamModuleAssembler::emit_normal_exit() {
     /* This is implicitly global; it does not normally appear in modules and
      * doesn't require size optimization. */
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
     emit_proc_lc_unrequire();
 
@@ -237,7 +237,7 @@ void BeamModuleAssembler::emit_normal_exit() {
     runtime_call<2>(erts_do_exit_process);
 
     emit_proc_lc_require();
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.b(resolve_fragment(ga->get_do_schedule(), disp128MB));
@@ -247,14 +247,14 @@ void BeamModuleAssembler::emit_continue_exit() {
     /* This is implicitly global; it does not normally appear in modules and
      * doesn't require size optimization. */
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>(0);
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>(0);
     emit_proc_lc_unrequire();
 
     a.mov(ARG1, c_p);
     runtime_call<1>(erts_continue_exit_process);
 
     emit_proc_lc_require();
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>(0);
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>(0);
 
     a.b(resolve_fragment(ga->get_do_schedule(), disp128MB));
 }
@@ -2248,12 +2248,12 @@ void BeamGlobalAssembler::emit_catch_end_shared() {
 
         /* This is an error, attach a stacktrace to the reason. */
         ERTS_CT_ASSERT(ERTS_HIGHEST_CALLEE_SAVE_XREG >= 2);
-        emit_enter_runtime<Update::eStack | Update::eHeap>(2);
+        emit_enter_runtime<Update::eHeapAlloc>(2);
 
         a.mov(ARG1, c_p);
         runtime_call<3>(add_stacktrace);
 
-        emit_leave_runtime<Update::eStack | Update::eHeap>(2);
+        emit_leave_runtime<Update::eHeapAlloc>(2);
 
         /* Fall through! */
     }
@@ -2369,12 +2369,12 @@ void BeamModuleAssembler::emit_raise(const ArgSource &Trace,
 void BeamModuleAssembler::emit_build_stacktrace() {
     a.mov(ARG2, XREG0);
 
-    emit_enter_runtime<Update::eStack | Update::eHeap>(0);
+    emit_enter_runtime<Update::eHeapAlloc>(0);
 
     a.mov(ARG1, c_p);
     runtime_call<2>(build_stacktrace);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>(0);
+    emit_leave_runtime<Update::eHeapAlloc>(0);
 
     a.mov(XREG0, ARG1);
 }

--- a/erts/emulator/beam/jit/arm/instr_fun.cpp
+++ b/erts/emulator/beam/jit/arm/instr_fun.cpp
@@ -213,11 +213,11 @@ void BeamModuleAssembler::emit_i_make_fun3(const ArgLambda &Lambda,
     mov_arg(ARG3, Arity);
     mov_arg(ARG4, NumFree);
 
-    emit_enter_runtime<Update::eHeap>();
+    emit_enter_runtime<Update::eHeapOnlyAlloc>();
 
     runtime_call<4>(erts_new_local_fun_thing);
 
-    emit_leave_runtime<Update::eHeap>();
+    emit_leave_runtime<Update::eHeapOnlyAlloc>();
 
     if (num_free) {
         comment("Move fun environment");

--- a/erts/emulator/beam/jit/arm/instr_fun.cpp
+++ b/erts/emulator/beam/jit/arm/instr_fun.cpp
@@ -35,7 +35,7 @@ void BeamGlobalAssembler::emit_unloaded_fun() {
     a.str(ARG5, TMP_MEM1q);
 
     emit_enter_runtime_frame();
-    emit_enter_runtime<Update::eHeap | Update::eStack | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.mov(ARG1, c_p);
@@ -43,7 +43,7 @@ void BeamGlobalAssembler::emit_unloaded_fun() {
     /* ARG3 and ARG4 have already been set. */
     runtime_call<4>(beam_jit_handle_unloaded_fun);
 
-    emit_leave_runtime<Update::eHeap | Update::eStack | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions | Update::eCodeIndex>();
     emit_leave_runtime_frame();
 
@@ -92,14 +92,14 @@ void BeamGlobalAssembler::emit_handle_call_fun_error() {
     {
         a.stp(ARG4, ARG5, TMP_MEM1q);
 
-        emit_enter_runtime<Update::eHeap | Update::eStack | Update::eXRegs>();
+        emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs>();
 
         a.mov(ARG1, c_p);
         load_x_reg_array(ARG2);
         /* ARG3 is already set */
         runtime_call<3>(beam_jit_build_argument_list);
 
-        emit_leave_runtime<Update::eHeap | Update::eStack | Update::eXRegs>();
+        emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs>();
 
         a.ldr(XREG0, TMP_MEM1q);
         a.mov(XREG1, ARG1);

--- a/erts/emulator/beam/jit/arm/instr_map.cpp
+++ b/erts/emulator/beam/jit/arm/instr_map.cpp
@@ -236,14 +236,14 @@ void BeamGlobalAssembler::emit_flatmap_get_element() {
 
 void BeamGlobalAssembler::emit_new_map_shared() {
     emit_enter_runtime_frame();
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<5>(erts_gc_new_map);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
     emit_leave_runtime_frame();
 
@@ -552,14 +552,14 @@ void BeamModuleAssembler::emit_i_get_map_element_hash(const ArgLabel &Fail,
 /* ARG3 = live registers, ARG4 = update vector size, ARG5 = update vector. */
 void BeamGlobalAssembler::emit_update_map_assoc_shared() {
     emit_enter_runtime_frame();
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<5>(erts_gc_update_map_assoc);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
     emit_leave_runtime_frame();
 
@@ -591,14 +591,14 @@ void BeamModuleAssembler::emit_update_map_assoc(const ArgSource &Src,
  * Result is returned in RET, error is indicated by ZF. */
 void BeamGlobalAssembler::emit_update_map_exact_guard_shared() {
     emit_enter_runtime_frame();
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<5>(erts_gc_update_map_exact);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
     emit_leave_runtime_frame();
 
@@ -612,14 +612,14 @@ void BeamGlobalAssembler::emit_update_map_exact_body_shared() {
     Label error = a.newLabel();
 
     emit_enter_runtime_frame();
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<5>(erts_gc_update_map_exact);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
     emit_leave_runtime_frame();
 

--- a/erts/emulator/beam/jit/arm/instr_msg.cpp
+++ b/erts/emulator/beam/jit/arm/instr_msg.cpp
@@ -75,12 +75,12 @@ void BeamModuleAssembler::emit_i_recv_set() {
 #endif /* ERTS_SUPPORT_OLD_RECV_MARK_INSTRS */
 
 void BeamModuleAssembler::emit_recv_marker_reserve(const ArgRegister &Dst) {
-    emit_enter_runtime<Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     runtime_call<1>(erts_msgq_recv_marker_insert);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eHeapAlloc>();
 
     mov_arg(Dst, ARG1);
 }
@@ -175,7 +175,7 @@ void BeamGlobalAssembler::emit_i_loop_rec_shared() {
         a.cbnz(ARG1, check_is_distributed);
         comment("Inner queue empty, fetch more from outer/middle queues");
 
-        emit_enter_runtime<Update::eReductions | Update::eStack |
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc |
                            Update::eHeap>(0);
 
         a.str(ZERO, message_ptr);
@@ -196,8 +196,7 @@ void BeamGlobalAssembler::emit_i_loop_rec_shared() {
          * Also note that another process may have loaded new code and sent us
          * a message to notify us about it, so we must update the active code
          * index. */
-        emit_leave_runtime<Update::eStack | Update::eHeap | Update::eCodeIndex>(
-                0);
+        emit_leave_runtime<Update::eHeapAlloc | Update::eCodeIndex>(0);
 
         a.sub(FCALLS, FCALLS, ARG1);
 

--- a/erts/emulator/beam/jit/arm/instr_trace.cpp
+++ b/erts/emulator/beam/jit/arm/instr_trace.cpp
@@ -37,7 +37,7 @@ void BeamGlobalAssembler::emit_generic_bp_global() {
 
     lea(ARG2, arm::Mem(ARG1, offsetof(Export, info)));
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.mov(ARG1, c_p);
@@ -45,7 +45,7 @@ void BeamGlobalAssembler::emit_generic_bp_global() {
     load_x_reg_array(ARG3);
     runtime_call<3>(erts_generic_breakpoint);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     /* This is technically a tail call so we must leave the current frame
@@ -72,7 +72,7 @@ void BeamGlobalAssembler::emit_generic_bp_local() {
     a.sub(ARG2, ARG2, imm(BEAM_ASM_BP_RETURN_OFFSET + sizeof(ErtsCodeInfo)));
 
     emit_enter_runtime_frame();
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.mov(ARG1, c_p);
@@ -80,7 +80,7 @@ void BeamGlobalAssembler::emit_generic_bp_local() {
     load_x_reg_array(ARG3);
     runtime_call<3>(erts_generic_breakpoint);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.cmp(ARG1, imm(BeamOpCodeAddr(op_i_debug_breakpoint)));
@@ -101,7 +101,7 @@ void BeamGlobalAssembler::emit_debug_bp() {
     a.ldr(ARG2, TMP_MEM1q);
     a.sub(ARG2, ARG2, imm(BEAM_ASM_BP_RETURN_OFFSET + sizeof(ErtsCodeMFA)));
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     a.mov(ARG1, c_p);
@@ -109,7 +109,7 @@ void BeamGlobalAssembler::emit_debug_bp() {
     a.mov(ARG4, imm(am_breakpoint));
     runtime_call<4>(call_error_handler);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
 
     /* We skip two runtime frames (ours and the one entered in the module
@@ -147,12 +147,12 @@ void BeamModuleAssembler::emit_return_trace() {
     lea(ARG4, getYRef(1));
 
     ERTS_CT_ASSERT(ERTS_HIGHEST_CALLEE_SAVE_XREG >= 1);
-    emit_enter_runtime<Update::eStack | Update::eHeap>(1);
+    emit_enter_runtime<Update::eHeapAlloc>(1);
 
     a.mov(ARG1, c_p);
     runtime_call<4>(return_trace);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>(1);
+    emit_leave_runtime<Update::eHeapAlloc>(1);
 
     emit_deallocate(ArgVal(ArgVal::Word, 2));
     emit_return();
@@ -168,12 +168,12 @@ void BeamModuleAssembler::emit_i_return_time_trace() {
     a.csel(ARG2, ARG2, ARG3, arm::CondCode::kEQ);
 
     ERTS_CT_ASSERT(ERTS_HIGHEST_CALLEE_SAVE_XREG >= 1);
-    emit_enter_runtime<Update::eStack | Update::eHeap>(1);
+    emit_enter_runtime<Update::eHeapAlloc>(1);
 
     a.mov(ARG1, c_p);
     runtime_call<2>(erts_trace_time_return);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>(1);
+    emit_leave_runtime<Update::eHeapAlloc>(1);
 
     emit_deallocate(ArgVal(ArgVal::Word, 1));
     emit_return();
@@ -181,12 +181,12 @@ void BeamModuleAssembler::emit_i_return_time_trace() {
 
 void BeamModuleAssembler::emit_i_return_to_trace() {
     ERTS_CT_ASSERT(ERTS_HIGHEST_CALLEE_SAVE_XREG >= 1);
-    emit_enter_runtime<Update::eStack | Update::eHeap>(1);
+    emit_enter_runtime<Update::eHeapAlloc>(1);
 
     a.mov(ARG1, c_p);
     runtime_call<1>(beam_jit_return_to_trace);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>(1);
+    emit_leave_runtime<Update::eHeapAlloc>(1);
 
     emit_deallocate(ArgVal(ArgVal::Word, 0));
     emit_return();
@@ -195,14 +195,14 @@ void BeamModuleAssembler::emit_i_return_to_trace() {
 void BeamModuleAssembler::emit_i_hibernate() {
     Label error = a.newLabel();
 
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(3);
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<2>(erts_hibernate);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(3);
 
     a.cbz(ARG1, error);

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -577,11 +577,27 @@ protected:
 #endif
     }
 
+    /* Prefer `eHeapAlloc` over `eStack | eHeap` when calling
+     * functions in the runtime system that allocate heap
+     * memory (`HAlloc`, heap factories, etc).
+     *
+     * Prefer `eHeapOnlyAlloc` over `eHeapAlloc` for functions
+     * that assume there's already a certain amount of free
+     * space on the heap, such as those using `HeapOnlyAlloc`
+     * or similar. It's slightly cheaper in release builds,
+     * and in debug builds it updates `eStack` to ensure that
+     * we can make heap size assertions. */
     enum Update : int {
         eStack = (1 << 0),
         eHeap = (1 << 1),
         eReductions = (1 << 2),
-        eCodeIndex = (1 << 3)
+        eCodeIndex = (1 << 3),
+        eHeapAlloc = Update::eHeap | Update::eStack,
+#ifndef DEBUG
+        eHeapOnlyAlloc = Update::eHeap,
+#else
+        eHeapOnlyAlloc = Update::eHeapAlloc
+#endif
     };
 
     void emit_enter_frame() {

--- a/erts/emulator/beam/jit/x86/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.cpp
@@ -195,8 +195,7 @@ void BeamGlobalAssembler::emit_export_trampoline() {
     a.bind(error_handler);
     {
         emit_enter_frame();
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
         a.mov(ARG1, c_p);
         a.lea(ARG2, x86::qword_ptr(RET, offsetof(Export, info.mfa)));
@@ -204,8 +203,7 @@ void BeamGlobalAssembler::emit_export_trampoline() {
         mov_imm(ARG4, am_undefined_function);
         runtime_call<4>(call_error_handler);
 
-        emit_leave_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
         a.test(RET, RET);
         a.je(labels[process_exit]);
@@ -309,7 +307,7 @@ void BeamGlobalAssembler::emit_raise_exception() {
 void BeamGlobalAssembler::emit_raise_exception_shared() {
     Label crash = a.newLabel();
 
-    emit_enter_runtime<Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eHeapAlloc>();
 
     /* The error address must be a valid CP or NULL. */
     a.test(ARG2d, imm(_CPMASK));
@@ -320,7 +318,7 @@ void BeamGlobalAssembler::emit_raise_exception_shared() {
     load_x_reg_array(ARG3);
     runtime_call<4>(handle_error);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eHeapAlloc>();
 
     a.test(RET, RET);
     a.je(labels[do_schedule]);

--- a/erts/emulator/beam/jit/x86/instr_bif.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bif.cpp
@@ -1027,14 +1027,14 @@ void BeamGlobalAssembler::emit_i_load_nif_shared() {
 
     a.mov(TMP_MEM1q, ARG2);
 
-    emit_enter_runtime<Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     /* ARG2 has already been set by caller */
     load_x_reg_array(ARG3);
     runtime_call<3>(beam_jit_load_nif);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eHeapAlloc>();
 
     a.cmp(RET, RET_NIF_yield);
     a.short_().je(yield);
@@ -1134,14 +1134,14 @@ void BeamModuleAssembler::emit_i_load_nif() {
     align_erlang_cp();
     a.bind(entry);
 
-    emit_enter_runtime<Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     a.lea(ARG2, x86::qword_ptr(currLabel));
     load_x_reg_array(ARG3);
     runtime_call<3>(beam_jit_load_nif);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eHeapAlloc>();
 
     a.cmp(RET, imm(RET_NIF_yield));
     a.je(schedule);

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -130,7 +130,7 @@ void BeamModuleAssembler::emit_i_bs_init_heap(const ArgWord &Size,
     mov_arg(ARG5, Heap);
     mov_arg(ARG6, Live);
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     /* Must be last since mov_arg() may clobber ARG1 */
     a.mov(ARG1, c_p);
@@ -138,7 +138,7 @@ void BeamModuleAssembler::emit_i_bs_init_heap(const ArgWord &Size,
     load_erl_bits_state(ARG3);
     runtime_call<6>(beam_jit_bs_init);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     mov_arg(Dst, RET);
 }
@@ -170,16 +170,14 @@ void BeamModuleAssembler::emit_i_bs_init_fail_heap(const ArgSource &Size,
         mov_arg(ARG5, Heap);
         mov_arg(ARG6, Live);
 
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
         a.mov(ARG1, c_p);
         load_x_reg_array(ARG2);
         load_erl_bits_state(ARG3);
         runtime_call<6>(beam_jit_bs_init);
 
-        emit_leave_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
         mov_arg(Dst, RET);
     }
@@ -231,7 +229,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_heap(const ArgWord &NumBits,
     mov_arg(ARG5, Alloc);
     mov_arg(ARG6, Live);
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     /* Must be last since mov_arg() may clobber ARG1 */
     a.mov(ARG1, c_p);
@@ -239,7 +237,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_heap(const ArgWord &NumBits,
     load_erl_bits_state(ARG3);
     runtime_call<6>(beam_jit_bs_init_bits);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     mov_arg(Dst, RET);
 }
@@ -272,8 +270,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_fail_heap(
         mov_arg(ARG5, Alloc);
         mov_arg(ARG6, Live);
 
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
         /* Must be last since mov_arg() may clobber ARG1 */
         a.mov(ARG1, c_p);
@@ -281,8 +278,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_fail_heap(
         load_erl_bits_state(ARG3);
         runtime_call<6>(beam_jit_bs_init_bits);
 
-        emit_leave_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
         mov_arg(Dst, RET);
     }
@@ -733,8 +729,7 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
             }
 
             if (potentially_expensive) {
-                emit_enter_runtime<Update::eReductions | Update::eStack |
-                                   Update::eHeap>();
+                emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
             } else {
                 comment("simplified entering runtime because result is always "
                         "small");
@@ -753,8 +748,7 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
             runtime_call<6>(beam_jit_bs_get_integer);
 
             if (potentially_expensive) {
-                emit_leave_runtime<Update::eReductions | Update::eStack |
-                                   Update::eHeap>();
+                emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
             } else {
                 emit_leave_runtime();
             }
@@ -1686,13 +1680,13 @@ void BeamModuleAssembler::emit_i_bs_append(const ArgLabel &Fail,
 
     mov_arg(ArgXRegister(Live.get()), Bin);
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<6>(erts_bs_append);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     emit_test_the_non_value(RET);
 
@@ -1745,18 +1739,18 @@ void BeamModuleAssembler::emit_i_bs_private_append(const ArgLabel &Fail,
 }
 
 void BeamModuleAssembler::emit_bs_init_writable() {
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     a.mov(ARG2, getXRef(0));
     runtime_call<2>(erts_bs_init_writable);
     a.mov(getXRef(0), RET);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 }
 
 void BeamGlobalAssembler::emit_bs_create_bin_error_shared() {
-    emit_enter_runtime<Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eHeapAlloc>();
 
     /* ARG3 is already set by the caller */
     a.mov(ARG2, ARG4);
@@ -1764,7 +1758,7 @@ void BeamGlobalAssembler::emit_bs_create_bin_error_shared() {
     a.mov(ARG1, c_p);
     runtime_call<4>(beam_jit_bs_construct_fail_info);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eHeapAlloc>();
 
     /* We must align the return address to make it a proper tagged CP, in case
      * we were called with `safe_fragment_call`. This is safe because we will
@@ -2308,8 +2302,7 @@ void BeamGlobalAssembler::emit_store_unaligned() {
 bool BeamModuleAssembler::bs_maybe_enter_runtime(bool entered) {
     if (!entered) {
         comment("enter runtime");
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
     }
     return true;
 }
@@ -2317,8 +2310,7 @@ bool BeamModuleAssembler::bs_maybe_enter_runtime(bool entered) {
 void BeamModuleAssembler::bs_maybe_leave_runtime(bool entered) {
     if (entered) {
         comment("leave runtime");
-        emit_leave_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     }
 }
 

--- a/erts/emulator/beam/jit/x86/instr_call.cpp
+++ b/erts/emulator/beam/jit/x86/instr_call.cpp
@@ -147,7 +147,7 @@ x86::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
     align_erlang_cp();
     a.bind(entry);
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
@@ -162,7 +162,7 @@ x86::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
 
     runtime_call<4>(apply);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.test(RET, RET);
     a.short_().jne(dispatch);
@@ -198,7 +198,7 @@ x86::Mem BeamModuleAssembler::emit_fixed_apply(const ArgWord &Arity,
 
     mov_arg(ARG3, Arity);
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
@@ -213,7 +213,7 @@ x86::Mem BeamModuleAssembler::emit_fixed_apply(const ArgWord &Arity,
 
     runtime_call<5>(fixed_apply);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.test(RET, RET);
     a.short_().jne(dispatch);

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -266,7 +266,7 @@ void BeamModuleAssembler::emit_normal_exit() {
     /* This is implicitly global; it does not normally appear in modules and
      * doesn't require size optimization. */
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_proc_lc_unrequire();
 
     a.mov(x86::qword_ptr(c_p, offsetof(Process, freason)), imm(EXC_NORMAL));
@@ -276,7 +276,7 @@ void BeamModuleAssembler::emit_normal_exit() {
     runtime_call<2>(erts_do_exit_process);
 
     emit_proc_lc_require();
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     abs_jmp(ga->get_do_schedule());
 }
@@ -285,14 +285,14 @@ void BeamModuleAssembler::emit_continue_exit() {
     /* This is implicitly global; it does not normally appear in modules and
      * doesn't require size optimization. */
 
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_proc_lc_unrequire();
 
     a.mov(ARG1, c_p);
     runtime_call<1>(erts_continue_exit_process);
 
     emit_proc_lc_require();
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     abs_jmp(ga->get_do_schedule());
 }
@@ -2311,14 +2311,14 @@ void BeamGlobalAssembler::emit_catch_end_shared() {
         a.jne(not_error);
 
         /* This is an error, attach a stacktrace to the reason. */
-        emit_enter_runtime<Update::eStack | Update::eHeap>();
+        emit_enter_runtime<Update::eHeapAlloc>();
 
         a.mov(ARG1, c_p);
         /* ARG2 set above. */
         a.mov(ARG3, getXRef(2));
         runtime_call<3>(add_stacktrace);
 
-        emit_leave_runtime<Update::eStack | Update::eHeap>();
+        emit_leave_runtime<Update::eHeapAlloc>();
 
         /* not_error assumes stacktrace/reason is in ARG2 */
         a.mov(ARG2, RET);
@@ -2418,13 +2418,13 @@ void BeamModuleAssembler::emit_raise(const ArgSource &Trace,
 }
 
 void BeamModuleAssembler::emit_build_stacktrace() {
-    emit_enter_runtime<Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     a.mov(ARG2, getXRef(0));
     runtime_call<2>(build_stacktrace);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eHeapAlloc>();
 
     a.mov(getXRef(0), RET);
 }

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -206,12 +206,12 @@ void BeamModuleAssembler::emit_i_make_fun3(const ArgLambda &Lambda,
     mov_arg(ARG3, Arity);
     mov_arg(ARG4, NumFree);
 
-    emit_enter_runtime<Update::eHeap>();
+    emit_enter_runtime<Update::eHeapOnlyAlloc>();
 
     a.mov(ARG1, c_p);
     runtime_call<4>(erts_new_local_fun_thing);
 
-    emit_leave_runtime<Update::eHeap>();
+    emit_leave_runtime<Update::eHeapOnlyAlloc>();
 
     comment("Move fun environment");
     for (unsigned i = 0; i < num_free; i++) {

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -32,14 +32,14 @@ void BeamGlobalAssembler::emit_unloaded_fun() {
 
     a.mov(TMP_MEM1q, ARG5);
 
-    emit_enter_runtime<Update::eHeap | Update::eStack | Update::eReductions>();
+    emit_enter_runtime<Update::eHeapAlloc | Update::eReductions>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     /* ARG3 and ARG4 have already been set. */
     runtime_call<4>(beam_jit_handle_unloaded_fun);
 
-    emit_leave_runtime<Update::eHeap | Update::eStack | Update::eReductions |
+    emit_leave_runtime<Update::eHeapAlloc | Update::eReductions |
                        Update::eCodeIndex>();
 
     a.test(RET, RET);
@@ -93,14 +93,14 @@ void BeamGlobalAssembler::emit_handle_call_fun_error() {
         a.mov(TMP_MEM1q, ARG4);
         a.mov(TMP_MEM2q, ARG5);
 
-        emit_enter_runtime<Update::eHeap | Update::eStack>();
+        emit_enter_runtime<Update::eHeapAlloc>();
 
         a.mov(ARG1, c_p);
         load_x_reg_array(ARG2);
         /* ARG3 is already set. */
         runtime_call<3>(beam_jit_build_argument_list);
 
-        emit_leave_runtime<Update::eHeap | Update::eStack>();
+        emit_leave_runtime<Update::eHeapAlloc>();
 
         a.mov(ARG1, TMP_MEM1q);
         a.mov(getXRef(0), ARG1);

--- a/erts/emulator/beam/jit/x86/instr_map.cpp
+++ b/erts/emulator/beam/jit/x86/instr_map.cpp
@@ -232,13 +232,13 @@ void BeamGlobalAssembler::emit_flatmap_get_element() {
 
 void BeamGlobalAssembler::emit_new_map_shared() {
     emit_enter_frame();
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<5>(erts_gc_new_map);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
 
     a.ret();
@@ -562,13 +562,13 @@ void BeamModuleAssembler::emit_i_get_map_element_hash(const ArgLabel &Fail,
 /* ARG3 = live registers, ARG4 = update vector size, ARG5 = update vector. */
 void BeamGlobalAssembler::emit_update_map_assoc_shared() {
     emit_enter_frame();
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<5>(erts_gc_update_map_assoc);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
 
     a.ret();
@@ -598,13 +598,13 @@ void BeamModuleAssembler::emit_update_map_assoc(const ArgSource &Src,
  * Result is returned in RET, error is indicated by ZF. */
 void BeamGlobalAssembler::emit_update_map_exact_guard_shared() {
     emit_enter_frame();
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<5>(erts_gc_update_map_exact);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
 
     emit_test_the_non_value(RET);
@@ -618,13 +618,13 @@ void BeamGlobalAssembler::emit_update_map_exact_body_shared() {
     Label error = a.newLabel();
 
     emit_enter_frame();
-    emit_enter_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
     runtime_call<5>(erts_gc_update_map_exact);
 
-    emit_leave_runtime<Update::eReductions | Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
 
     emit_test_the_non_value(RET);

--- a/erts/emulator/beam/jit/x86/instr_msg.cpp
+++ b/erts/emulator/beam/jit/x86/instr_msg.cpp
@@ -75,12 +75,12 @@ void BeamModuleAssembler::emit_i_recv_set() {
 #endif /* ERTS_SUPPORT_OLD_RECV_MARK_INSTRS */
 
 void BeamModuleAssembler::emit_recv_marker_reserve(const ArgRegister &Dst) {
-    emit_enter_runtime<Update::eStack | Update::eHeap>();
+    emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
     runtime_call<1>(erts_msgq_recv_marker_insert);
 
-    emit_leave_runtime<Update::eStack | Update::eHeap>();
+    emit_leave_runtime<Update::eHeapAlloc>();
 
     mov_arg(Dst, RET);
 }
@@ -183,8 +183,7 @@ void BeamGlobalAssembler::emit_i_loop_rec_shared() {
 
         comment("Inner queue empty, fetch more from outer/middle queues");
 
-        emit_enter_runtime<Update::eReductions | Update::eStack |
-                           Update::eHeap>();
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
         a.mov(message_ptr, imm(0));
         a.mov(ARG1, c_p);
@@ -204,8 +203,7 @@ void BeamGlobalAssembler::emit_i_loop_rec_shared() {
          * Also note that another process may have loaded new code and sent us
          * a message to notify us about it, so we must update the active code
          * index. */
-        emit_leave_runtime<Update::eStack | Update::eHeap |
-                           Update::eCodeIndex>();
+        emit_leave_runtime<Update::eHeapAlloc | Update::eCodeIndex>();
 
         a.sub(FCALLS, RET);
 


### PR DESCRIPTION
Fix a few more buggy assertions similar to the one in #6646.

To make it easier to do the right thing, introduce new members to enum `Update`. If we are about to call a function that allocates heap space without using the stack pointer, we can now write:

```
emit_enter_runtime<Update::eHeapOnlyAlloc>();
```

which will make sure that both the heap pointer and stack pointer are saved in a debug build, but only the heap pointer in a release build.

For convenience, also introduce a shorthand for saving both the heap and stack pointer (as when doing a normal alloc using `HAlloc()`). We can now write:

```
emit_enter_runtime<Update::eHeapAlloc>();
```

instead of:

```
emit_enter_runtime<Update::eStack | Update::eHeap>();
```