### PR TITLE
Sets overloaded domains/contracts as an opt-in flag

### DIFF
--- a/lib/dialyzer/src/dialyzer.erl
+++ b/lib/dialyzer/src/dialyzer.erl
@@ -542,7 +542,7 @@ message_to_string({missing_range, [M, F, A, ExtraRanges, ContrRange]}, I, _E) ->
 		[M, F, A, t(ExtraRanges, I), t(ContrRange, I)]);
 message_to_string({overlapping_contract, [M, F, A]}, _I, _E) ->
   io_lib:format("Overloaded contract for ~w:~tw/~w has overlapping domains;"
-		" such contracts are currently unsupported and are simply ignored\n",
+		" such contracts cannot establish a dependency between the overloaded input and output types\n",
 		[M, F, A]);
 message_to_string({spec_missing_fun, [M, F, A]}, _I, _E) ->
   io_lib:format("Contract for function that does not exist: ~w:~tw/~w\n",

--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -33,29 +33,30 @@
 %% Warning classification
 %%--------------------------------------------------------------------
 
+-define(WARN_BEHAVIOUR, warn_behaviour).
+-define(WARN_BIN_CONSTRUCTION, warn_bin_construction).
+-define(WARN_CALLGRAPH, warn_callgraph).
+-define(WARN_CONTRACT_EXTRA_RETURN, warn_contract_extra_return).
+-define(WARN_CONTRACT_MISSING_RETURN, warn_contract_missing_return).
+-define(WARN_CONTRACT_NOT_EQUAL, warn_contract_not_equal).
+-define(WARN_CONTRACT_RANGE, warn_contract_range).
+-define(WARN_CONTRACT_SUBTYPE, warn_contract_subtype).
+-define(WARN_CONTRACT_SUPERTYPE, warn_contract_supertype).
+-define(WARN_CONTRACT_SYNTAX, warn_contract_syntax).
+-define(WARN_CONTRACT_TYPES, warn_contract_types).
+-define(WARN_FAILING_CALL, warn_failing_call).
+-define(WARN_FUN_APP, warn_fun_app).
+-define(WARN_MAP_CONSTRUCTION, warn_map_construction).
+-define(WARN_MATCHING, warn_matching).
+-define(WARN_NON_PROPER_LIST, warn_non_proper_list).
+-define(WARN_NOT_CALLED, warn_not_called).
+-define(WARN_OPAQUE, warn_opaque).
+-define(WARN_OVERLAPPING_CONTRACT, warn_overlapping_contract).
 -define(WARN_RETURN_NO_RETURN, warn_return_no_exit).
 -define(WARN_RETURN_ONLY_EXIT, warn_return_only_exit).
--define(WARN_NOT_CALLED, warn_not_called).
--define(WARN_NON_PROPER_LIST, warn_non_proper_list).
--define(WARN_FUN_APP, warn_fun_app).
--define(WARN_MATCHING, warn_matching).
--define(WARN_OPAQUE, warn_opaque).
--define(WARN_FAILING_CALL, warn_failing_call).
--define(WARN_BIN_CONSTRUCTION, warn_bin_construction).
--define(WARN_CONTRACT_TYPES, warn_contract_types).
--define(WARN_CONTRACT_SYNTAX, warn_contract_syntax).
--define(WARN_CONTRACT_NOT_EQUAL, warn_contract_not_equal).
--define(WARN_CONTRACT_SUBTYPE, warn_contract_subtype).
--define(WARN_CONTRACT_MISSING_RETURN, warn_contract_missing_return).
--define(WARN_CONTRACT_SUPERTYPE, warn_contract_supertype).
--define(WARN_CONTRACT_EXTRA_RETURN, warn_contract_extra_return).
--define(WARN_CONTRACT_RANGE, warn_contract_range).
--define(WARN_CALLGRAPH, warn_callgraph).
--define(WARN_UNMATCHED_RETURN, warn_umatched_return).
--define(WARN_BEHAVIOUR, warn_behaviour).
 -define(WARN_UNDEFINED_CALLBACK, warn_undefined_callbacks).
 -define(WARN_UNKNOWN, warn_unknown).
--define(WARN_MAP_CONSTRUCTION, warn_map_construction).
+-define(WARN_UNMATCHED_RETURN, warn_umatched_return).
 
 %%
 %% The following type has double role:

--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -64,14 +64,15 @@
 %%   2. It is also the set of tags for warnings that will be returned.
 %%
 -type dial_warn_tag() :: ?WARN_BEHAVIOUR | ?WARN_BIN_CONSTRUCTION
-                       | ?WARN_CALLGRAPH | ?WARN_CONTRACT_NOT_EQUAL
+                       | ?WARN_CALLGRAPH | ?WARN_CONTRACT_EXTRA_RETURN
+                       | ?WARN_CONTRACT_MISSING_RETURN | ?WARN_CONTRACT_NOT_EQUAL
                        | ?WARN_CONTRACT_RANGE | ?WARN_CONTRACT_SUBTYPE
                        | ?WARN_CONTRACT_SUPERTYPE | ?WARN_CONTRACT_SYNTAX
                        | ?WARN_CONTRACT_TYPES | ?WARN_FAILING_CALL
                        | ?WARN_FUN_APP | ?WARN_MAP_CONSTRUCTION
                        | ?WARN_MATCHING | ?WARN_NON_PROPER_LIST
                        | ?WARN_NOT_CALLED | ?WARN_OPAQUE
-                       | ?WARN_RETURN_NO_RETURN
+                       | ?WARN_OVERLAPPING_CONTRACT | ?WARN_RETURN_NO_RETURN
                        | ?WARN_RETURN_ONLY_EXIT | ?WARN_UNDEFINED_CALLBACK
                        | ?WARN_UNKNOWN | ?WARN_UNMATCHED_RETURN.
 

--- a/lib/dialyzer/src/dialyzer_cl.erl
+++ b/lib/dialyzer/src/dialyzer_cl.erl
@@ -420,15 +420,10 @@ do_analysis(Files, Options, Plt, PltInfo) ->
   report_elapsed_time(T1, T2, Options),
   {RetAndWarns, lists:usort([path_to_mod(F) || F <- Files])}.
 
-convert_analysis_type(plt_check, true)   -> succ_typings;
-convert_analysis_type(plt_check, false)  -> plt_build;
-convert_analysis_type(plt_add, true)     -> succ_typings;
-convert_analysis_type(plt_add, false)    -> plt_build;
-convert_analysis_type(plt_build, true)   -> succ_typings;
-convert_analysis_type(plt_build, false)  -> plt_build;
-convert_analysis_type(plt_remove, true)  -> succ_typings;
-convert_analysis_type(plt_remove, false) -> plt_build;
-convert_analysis_type(succ_typings, _)   -> succ_typings.
+-spec convert_analysis_type(anal_type1(), boolean()) -> succ_typings | plt_build.
+convert_analysis_type(succ_typings, _) -> succ_typings;
+convert_analysis_type(_, true) -> succ_typings;
+convert_analysis_type(_, false) -> plt_build.
 
 %%--------------------------------------------------------------------
 

--- a/lib/dialyzer/src/dialyzer_cl_parse.erl
+++ b/lib/dialyzer/src/dialyzer_cl_parse.erl
@@ -608,6 +608,8 @@ warning_options_msg() ->
   -Wmissing_return ***
      Warn about functions that return values that are not part
      of the specification.
+  -Woverlapping_contract ***
+     Warn about overloaded functions whose specification include types that overlap.
   -Wunknown ***
      Let warnings about unknown functions and types affect the
      exit status of the command line version. The default is to ignore

--- a/lib/dialyzer/src/dialyzer_contracts.erl
+++ b/lib/dialyzer/src/dialyzer_contracts.erl
@@ -918,7 +918,7 @@ contract_opaque_warning({M, F, A}, WarningInfo, OpType, SuccType, RecDict) ->
    {contract_with_opaque, [M, F, A, OpaqueStr, SuccTypeStr]}}.
 
 overlapping_contract_warning({M, F, A}, WarningInfo) ->
-  {?WARN_CONTRACT_TYPES, WarningInfo, {overlapping_contract, [M, F, A]}}.
+  {?WARN_OVERLAPPING_CONTRACT, WarningInfo, {overlapping_contract, [M, F, A]}}.
 
 extra_range_warning({M, F, A}, WarningInfo, ExtraRanges, STRange) ->
   ERangesStr = erl_types:t_to_string(ExtraRanges),

--- a/lib/dialyzer/src/dialyzer_options.erl
+++ b/lib/dialyzer/src/dialyzer_options.erl
@@ -479,6 +479,8 @@ build_warnings([Opt|Opts], Warnings) ->
         ordsets:del_element(?WARN_CONTRACT_MISSING_RETURN, Warnings);
       unknown ->
         ordsets:add_element(?WARN_UNKNOWN, Warnings);
+      overlapping_contract ->
+        ordsets:add_element(?WARN_OVERLAPPING_CONTRACT, Warnings);
       OtherAtom ->
         bad_option("Unknown dialyzer warning option", OtherAtom)
     end,

--- a/lib/dialyzer/test/default_ignore_overlapping_contract_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/default_ignore_overlapping_contract_SUITE_data/dialyzer_options
@@ -1,0 +1,1 @@
+{dialyzer_options, [{indent_opt, false}]}.

--- a/lib/dialyzer/test/default_ignore_overlapping_contract_SUITE_data/src/default_ignore_overlapping_contract.erl
+++ b/lib/dialyzer/test/default_ignore_overlapping_contract_SUITE_data/src/default_ignore_overlapping_contract.erl
@@ -1,0 +1,13 @@
+-module(default_ignore_overlapping_contract).
+
+-export([t1/0]).
+
+%% Should not result in a overlapping_contract warning,
+%% as dialyzer_options does not set it to active
+-spec t1() -> list();
+        () -> [atom].
+t1() ->
+    case rand:uniform(2) of
+        1 -> [test];
+        2 -> [2]
+    end.

--- a/lib/dialyzer/test/indent_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/indent_SUITE_data/dialyzer_options
@@ -1,1 +1,1 @@
-{dialyzer_options, [{warnings, [no_unused, no_return]}]}.
+{dialyzer_options, [{warnings, [no_unused, no_return, overlapping_contract]}]}.

--- a/lib/dialyzer/test/indent_SUITE_data/results/contract3
+++ b/lib/dialyzer/test/indent_SUITE_data/results/contract3
@@ -1,3 +1,3 @@
 
-contract3.erl:17:2: Overloaded contract for contract3:t1/1 has overlapping domains; such contracts are currently unsupported and are simply ignored
-contract3.erl:29:2: Overloaded contract for contract3:t3/3 has overlapping domains; such contracts are currently unsupported and are simply ignored
+contract3.erl:17:2: Overloaded contract for contract3:t1/1 has overlapping domains; such contracts cannot establish a dependency between the overloaded input and output types
+contract3.erl:29:2: Overloaded contract for contract3:t3/3 has overlapping domains; such contracts cannot establish a dependency between the overloaded input and output types

--- a/lib/dialyzer/test/overlapping_contract_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/overlapping_contract_SUITE_data/dialyzer_options
@@ -1,0 +1,1 @@
+{dialyzer_options, [{indent_opt, false}, {warnings, [overlapping_contract]}]}.

--- a/lib/dialyzer/test/overlapping_contract_SUITE_data/results/overlapping_contract
+++ b/lib/dialyzer/test/overlapping_contract_SUITE_data/results/overlapping_contract
@@ -1,2 +1,2 @@
 
-overlapping_contract.erl:6:2: Overloaded contract for overlapping_contract:t1/0 has overlapping domains; such contracts are currently unsupported and are simply ignored
+overlapping_contract.erl:6:2: Overloaded contract for overlapping_contract:t1/0 has overlapping domains; such contracts cannot establish a dependency between the overloaded input and output types

--- a/lib/dialyzer/test/overlapping_contract_SUITE_data/results/overlapping_contract
+++ b/lib/dialyzer/test/overlapping_contract_SUITE_data/results/overlapping_contract
@@ -1,0 +1,2 @@
+
+overlapping_contract.erl:6:2: Overloaded contract for overlapping_contract:t1/0 has overlapping domains; such contracts are currently unsupported and are simply ignored

--- a/lib/dialyzer/test/overlapping_contract_SUITE_data/src/overlapping_contract.erl
+++ b/lib/dialyzer/test/overlapping_contract_SUITE_data/src/overlapping_contract.erl
@@ -1,0 +1,12 @@
+-module(overlapping_contract).
+
+-export([t1/0]).
+
+%% Should result in a overlapping_contract warning
+-spec t1() -> list();
+        () -> [atom].
+t1() ->
+    case rand:uniform(2) of
+        1 -> [test];
+        2 -> [2]
+    end.

--- a/lib/dialyzer/test/small_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/small_SUITE_data/dialyzer_options
@@ -1,1 +1,1 @@
-{dialyzer_options, [{indent_opt, false}, {error_location, column}]}.
+{dialyzer_options, [{indent_opt, false}, {error_location, column}, {warnings, [overlapping_contract]}]}.

--- a/lib/dialyzer/test/small_SUITE_data/results/contract3
+++ b/lib/dialyzer/test/small_SUITE_data/results/contract3
@@ -1,3 +1,3 @@
 
-contract3.erl:17:2: Overloaded contract for contract3:t1/1 has overlapping domains; such contracts are currently unsupported and are simply ignored
-contract3.erl:29:2: Overloaded contract for contract3:t3/3 has overlapping domains; such contracts are currently unsupported and are simply ignored
+contract3.erl:17:2: Overloaded contract for contract3:t1/1 has overlapping domains; such contracts cannot establish a dependency between the overloaded input and output types
+contract3.erl:29:2: Overloaded contract for contract3:t3/3 has overlapping domains; such contracts cannot establish a dependency between the overloaded input and output types

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -3414,7 +3414,7 @@ is_module_dialyzer_option(Option) ->
                   error_handling,race_conditions,no_missing_calls,
                   specdiffs,overspecs,underspecs,unknown,
                   no_underspecs,extra_return,no_extra_return,
-                  missing_return,no_missing_return
+                  missing_return,no_missing_return,overlapping_contract
                  ]).
 
 %% try_catch_clauses(Scs, Ccs, In, ImportVarTable, State) ->


### PR DESCRIPTION
- This PR makes the overlapping contracts warning of Dialyzer an opt-in flag, instead of considering them active by default.
- The PR also updates the message `"such contracts are currently unsupported and are simply ignored"` to `"such contracts cannot establish a dependency between the overloaded input and output types"`. The types are not really ignored and Dialyzer performs the union of them but it cannot establish a dependency between the input and output types
- Closes #6597 
- Closes #6117 

(Same as #6600 to see if the build system does not break)