### PR TITLE
Add support for sm3 hash algorithm

### DIFF
--- a/lib/crypto/c_src/algorithms.c
+++ b/lib/crypto/c_src/algorithms.c
@@ -29,7 +29,7 @@
 #ifdef HAS_3_0_API
 #else
 static unsigned int algo_hash_cnt, algo_hash_fips_cnt;
-static ERL_NIF_TERM algo_hash[16];   /* increase when extending the list */
+static ERL_NIF_TERM algo_hash[17];   /* increase when extending the list */
 void init_hash_types(ErlNifEnv* env);
 #endif
 
@@ -129,6 +129,9 @@ void init_hash_types(ErlNifEnv* env) {
 #endif
 #ifdef HAVE_SHAKE256
     algo_hash[algo_hash_cnt++] = enif_make_atom(env, "shake256");
+#endif
+#ifdef HAVE_SM3
+    algo_hash[algo_hash_cnt++] = enif_make_atom(env, "sm3");
 #endif
 #ifdef HAVE_BLAKE2
     algo_hash[algo_hash_cnt++] = enif_make_atom(env, "blake2b");

--- a/lib/crypto/c_src/check_openssl.cocci
+++ b/lib/crypto/c_src/check_openssl.cocci
@@ -88,6 +88,7 @@
 // EVP_shake128
 // EVP_shake256
 // EVP_sha512
+// EVP_sm3
 // OpenSSL_version
 // OpenSSL_version_num
 // PEM_read_PrivateKey

--- a/lib/crypto/c_src/digest.c
+++ b/lib/crypto/c_src/digest.c
@@ -130,6 +130,14 @@ static struct digest_type_t digest_types[] =
 #endif
     },
 
+    {"sm3", "SM3", 0, 0,
+#ifdef HAVE_SM3
+    {&EVP_sm3, NULL}
+#else
+    {NULL,NULL}
+#endif
+    },
+
     {"blake2b", "BLAKE2b512", 0, 0,
 #ifdef HAVE_BLAKE2
      {&EVP_blake2b512,NULL}

--- a/lib/crypto/c_src/openssl_config.h
+++ b/lib/crypto/c_src/openssl_config.h
@@ -180,6 +180,10 @@
     && !defined(OPENSSL_NO_SHA512) && defined(NID_sha512)
 # define HAVE_SHA512
 #endif
+#if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION_PLAIN(1,1,1)	\
+    && !defined(OPENSSL_NO_SM3) && defined(NID_sm3)
+# define HAVE_SM3
+#endif
 
 // SHA3:
 #if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION_PLAIN(1,1,1)

--- a/lib/crypto/doc/guides/algorithm_details.md
+++ b/lib/crypto/doc/guides/algorithm_details.md
@@ -204,6 +204,7 @@ column is present in the list returned by
 | SHA1     | sha                                                        |                                     |
 | SHA2     | sha224, sha256, sha384, sha512                             |                                     |
 | SHA3     | sha3_224, sha3_256, sha3_384, sha3_512, shake128, shake256 | ≥1.1.1                              |
+| SM3      | sm3                                                        | ≥1.1.1                              |
 | MD4      | md4                                                        |                                     |
 | MD5      | md5                                                        |                                     |
 | RIPEMD   | ripemd160                                                  |                                     |

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -33,7 +33,10 @@ This module provides a set of cryptographic functions.
 
   - **BLAKE2** - [BLAKE2 — fast secure hashing](https://blake2.net/)
 
-  - **MD5** - [The MD5 Message Digest Algorithm \[RFC 1321\]](http://www.ietf.org/rfc/rfc1321.txt)
+  - **SM3** - [The SM3 Hash Function (GM/T 0004-2012)](https://datatracker.ietf.org/doc/html/draft-sca-cfrg-sm3-02)
+
+  - **MD5** - [The MD5 Message Digest Algorithm \[RFC
+    1321]](http://www.ietf.org/rfc/rfc1321.txt)
 
   - **MD4** - [The MD4 Message Digest Algorithm \[RFC 1320\]](http://www.ietf.org/rfc/rfc1320.txt)
 
@@ -797,7 +800,7 @@ stop() ->
                                       | {macs,    Macs}
                                       | {curves,  Curves}
                                       | {rsa_opts, RSAopts},
-                             Hashs :: [sha1() | sha2() | sha3() | sha3_xof() | blake2() | ripemd160 | compatibility_only_hash()],
+                             Hashs :: [sha1() | sha2() | sha3() | sha3_xof() | blake2() | ripemd160 | sm3 | compatibility_only_hash()],
                              Ciphers :: [cipher()],
                              PKs :: [rsa | dss | ecdsa | dh | ecdh | eddh | ec_gf2m],
                              Macs :: [hmac | cmac | poly1305],
@@ -968,7 +971,7 @@ pbkdf2_hmac_nif(_, _, _, _, _) -> ?nif_stub.
 %%%================================================================
 
 -doc(#{title => <<"Digests and hash">>}).
--type hash_algorithm() :: sha1() | sha2() | sha3() | sha3_xof() | blake2() | ripemd160 | compatibility_only_hash() .
+-type hash_algorithm() :: sha1() | sha2() | sha3() | sha3_xof() | blake2() | ripemd160 | sm3 | compatibility_only_hash() .
 -doc(#{title => <<"Digests and hash">>}).
 -type hash_xof_algorithm() :: sha3_xof() .
 
@@ -1080,7 +1083,7 @@ hash_final_xof(Context, Length) ->
 %%%================================================================
 
 -doc(#{title => <<"Digests and hash">>}).
--type hmac_hash_algorithm() ::  sha1() | sha2() | sha3() | compatibility_only_hash().
+-type hmac_hash_algorithm() ::  sha1() | sha2() | sha3() | sm3 | compatibility_only_hash().
 
 -doc(#{title => <<"Digests and hash">>}).
 -type cmac_cipher_algorithm() :: aes_128_cbc    | aes_192_cbc    | aes_256_cbc    | aes_cbc


### PR DESCRIPTION
This PR add support for [sm3](https://en.wikipedia.org/wiki/SM3_(hash_function)) hash algo in crypto app.
OpenSSL has supported sm3 since version 1.1.1, released almost 4 years ago.
I would like to get some guidance if the OTP Team would be interested in merging this, and i would like to implement 
**sm4** block cipher and 
**sm2** public key algo also.