### PR TITLE
Fix crash in binary construction

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1229,6 +1229,8 @@ protected:
                 arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
 
         ASSERT(typeIndex < beam->types.count);
+        ASSERT(beam->types.entries[typeIndex].type_union ==
+               BEAM_TYPE_BITSTRING);
         return beam->types.entries[typeIndex].size_unit;
     }
 

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -2289,12 +2289,14 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
          */
         switch (seg.type) {
         case am_append:
-            if (std::gcd(seg.unit, getSizeUnit(seg.src)) != seg.unit) {
+            if (!(exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+                  std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit)) {
                 need_error_handler = true;
             }
             break;
         case am_binary:
             if (!(seg.size.isAtom() && seg.size.as<ArgAtom>().get() == am_all &&
+                  exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
                   std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit)) {
                 need_error_handler = true;
             }
@@ -2656,7 +2658,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
                            Update::eReductions>(Live.get() + 1);
 
-        if (std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
+        if (exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+            std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
             /* There is no way the call can fail with a system_limit
              * exception on a 64-bit architecture. */
             comment("skipped test for success because units are compatible");
@@ -2842,7 +2845,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                                              BSC_REASON_BADARG,
                                                              BSC_INFO_UNIT,
                                                              BSC_VALUE_FVALUE);
-                if (std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
+                if (exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+                    std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
                     comment("skipped test for success because units are "
                             "compatible");
                     can_fail = false;
@@ -3264,7 +3268,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         /* Try to keep track whether the next segment is byte
          * aligned. */
         if (seg.type == am_append || seg.type == am_private_append) {
-            if (std::gcd(getSizeUnit(seg.src), 8) != 8) {
+            if (!exact_type(seg.src, BEAM_TYPE_BITSTRING) ||
+                std::gcd(getSizeUnit(seg.src), 8) != 8) {
                 is_byte_aligned = false;
             }
         } else if (bit_offset % 8 == 0) {

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1290,6 +1290,8 @@ protected:
                 arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
 
         ASSERT(typeIndex < beam->types.count);
+        ASSERT(beam->types.entries[typeIndex].type_union ==
+               BEAM_TYPE_BITSTRING);
         return beam->types.entries[typeIndex].size_unit;
     }
 

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -2396,12 +2396,14 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
          */
         switch (seg.type) {
         case am_append:
-            if (std::gcd(seg.unit, getSizeUnit(seg.src)) != seg.unit) {
+            if (!(exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+                  std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit)) {
                 need_error_handler = true;
             }
             break;
         case am_binary:
             if (!(seg.size.isAtom() && seg.size.as<ArgAtom>().get() == am_all &&
+                  exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
                   std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit)) {
                 need_error_handler = true;
             }
@@ -2798,7 +2800,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         load_x_reg_array(ARG2);
         runtime_call<6>(erts_bs_append_checked);
 
-        if (std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
+        if (exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+            std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
             /* There is no way the call can fail with a system_limit
              * exception on a 64-bit architecture. */
             comment("skipped test for success because units are compatible");
@@ -2900,7 +2903,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                                              BSC_REASON_BADARG,
                                                              BSC_INFO_UNIT,
                                                              BSC_VALUE_FVALUE);
-                if (std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
+                if (exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+                    std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
                     comment("skipped test for success because units are "
                             "compatible");
                     can_fail = false;
@@ -3317,7 +3321,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         /* Try to keep track whether the next segment is byte
          * aligned. */
         if (seg.type == am_append || seg.type == am_private_append) {
-            if (std::gcd(getSizeUnit(seg.src), 8) != 8) {
+            if (!exact_type(seg.src, BEAM_TYPE_BITSTRING) ||
+                std::gcd(getSizeUnit(seg.src), 8) != 8) {
                 is_byte_aligned = false;
             }
         } else if (bit_offset % 8 == 0) {

--- a/erts/emulator/test/bs_construct_SUITE.erl
+++ b/erts/emulator/test/bs_construct_SUITE.erl
@@ -472,6 +472,20 @@ testf(Config) when is_list(Config) ->
     ?FAIL(<<<<7,8,9,3:7>>/binary-unit:16>>),
     ?FAIL(<<<<7,8,9,3:7>>/binary-unit:17>>),
 
+    %% Failures not deteced by v3_core. Those must be detected at
+    %% runtime.
+    Atom = id(ok),
+    Float = id(2.71),
+    List = id([-1,0,1]),
+    NonBinaries = [{'Atom',Atom}, {'Float',Float}, {'List',List}],
+    ?FAIL_VARS(<<Atom/bits>>, NonBinaries),
+    ?FAIL_VARS(<<Atom/bits,0>>, NonBinaries),
+    ?FAIL_VARS(<<0,Atom/bits>>, NonBinaries),
+    ?FAIL_VARS(<<Float/bits>>, NonBinaries),
+    ?FAIL_VARS(<<Float/bits,0>>, NonBinaries),
+    ?FAIL_VARS(<<List/bits>>, NonBinaries),
+    ?FAIL_VARS(<<List/bits,0>>, NonBinaries),
+
     ok.
 
 testf_1(W, B) ->


### PR DESCRIPTION
The JIT did not properly check the type of `Something` in code similar to:

    b(Something) ->
        <<Something/bits>>.

Calling `b/1` with a non-binary argument would most of the time crash the runtime system immediately instead of raising an exception.

This bug was introduced in 976b2a61c86f4d (#6086).

Closes #6655