### PR TITLE
inets: add type specifications

### DIFF
--- a/lib/inets/src/http_client/httpc_internal.hrl
+++ b/lib/inets/src/http_client/httpc_internal.hrl
@@ -127,7 +127,7 @@
 	  %% {{Host, Port}, HandlerPid}
 	  id, 
 
-	  client_close :: 'undefined' | boolean(),
+	  client_close = false :: boolean(),
 
 	  %% http (HTTP/TCP) | https (HTTP/SSL/TCP)
 	  scheme, 


### PR DESCRIPTION
This PR adds some type specifications to the `inets` module.

These have been checked by Dialyzer and eqWAlizer. 

Note: Not all types have been added because that would require bigger changes in `stdlib`, but the ones that were possible have been added and are type checked by eqWalizer. The ones that are not possible usually refer to prop lists, because the return type in the spec is always `term()`, which makes eqWAlizer to think that `term()` is the input type to another function. When this other function expects (e.g.,) `integer()`, it reports a mismatch between `term()` and `integer()`.