### PR TITLE
ct: Replace size/1 with either tuple_size/1 or byte_size/1

### DIFF
--- a/lib/common_test/src/ct_framework.erl
+++ b/lib/common_test/src/ct_framework.erl
@@ -443,7 +443,7 @@ get_suite_name(Mod, _) ->
 %% Check that alias names are not already in use
 check_for_clashes(TCInfo, [CurrGrInfo|Path], SuiteInfo) ->
     ReqNames = fun(Info) -> [element(2,R) || R <- Info,
-					     size(R) == 3,
+                                             tuple_size(R) == 3,
 					     require == element(1,R)]
 	       end,
     ExistingNames = lists:flatten([ReqNames(L)  || L <- [SuiteInfo|Path]]),

--- a/lib/common_test/src/ct_groups.erl
+++ b/lib/common_test/src/ct_groups.erl
@@ -191,8 +191,8 @@ find(Mod, GrNames, all, [{testcase,TC,[Prop]} | Gs], Known,
 %% Check if test case should be saved
 find(Mod, GrNames, TCs, [TC | Gs], Known, Defs, FindAll)
   when is_atom(TC) orelse
-       ((size(TC) == 3) andalso (element(1,TC) == testcase)) orelse
-       ((size(TC) == 2) and (element(1,TC) /= group)) ->
+       ((tuple_size(TC) == 3) andalso (element(1,TC) == testcase)) orelse
+       ((tuple_size(TC) == 2) andalso (element(1,TC) /= group)) ->
     Case =
         case TC of
             _ when is_atom(TC) ->
@@ -333,8 +333,7 @@ modify_tc_list1(GrSpecTs, TSCs) ->
 					  false -> []
 				      end
 			      end;
-                         (Test) when is_tuple(Test),
-				     (size(Test) > 2) ->
+                         (Test) when tuple_size(Test) > 2 ->
 			      [Test];
 			 (Test={group,_}) ->
 			      [Test];

--- a/lib/common_test/src/ct_ssh.erl
+++ b/lib/common_test/src/ct_ssh.erl
@@ -738,8 +738,8 @@ do_recv_response(SSH, Chn, Data, End, Timeout) ->
 	    debug("CLSD~n~p ~p", [SSH,Chn]),
 	    {ok,Data};
 
-	{ssh_cm, SSH, {data,Chn,_,NewData}} ->
-	    ssh_connection:adjust_window(SSH, Chn, size(NewData)),
+	{ssh_cm, SSH, {data,Chn,_,NewData}} when is_binary(NewData) ->
+	    ssh_connection:adjust_window(SSH, Chn, byte_size(NewData)),
 	    debug("RECVD~n~tp", [binary_to_list(NewData)]),
 	    DataAcc = Data ++ binary_to_list(NewData),
 	    if is_function(End) ->

--- a/lib/common_test/src/ct_testspec.erl
+++ b/lib/common_test/src/ct_testspec.erl
@@ -1079,7 +1079,7 @@ add_tests([],Spec) ->				% done
 %% have added something of his/her own, which we'll let pass if relaxed
 %% mode is enabled.
 check_term(Term) when is_tuple(Term) ->
-    Size = size(Term),
+    Size = tuple_size(Term),
     [Name|_] = tuple_to_list(Term),
     Valid = valid_terms(),
     case lists:member({Name,Size},Valid) of
@@ -1093,7 +1093,7 @@ check_term(Term) when is_tuple(Term) ->
 		    case get(relaxed) of
 			true ->
 			    %% warn if name resembles a CT term
-			    case resembles_ct_term(Name,size(Term)) of
+                            case resembles_ct_term(Name,tuple_size(Term)) of
 				true ->
 				    io:format("~nSuspicious term, "
 					      "please check:~n"

--- a/lib/common_test/src/ct_util.erl
+++ b/lib/common_test/src/ct_util.erl
@@ -786,7 +786,7 @@ listenv(Telnet) ->
 %%% Equivalent to ct:parse_table/1
 parse_table(Data) ->
     {Heading, Rest} = get_headings(Data),
-    Lines = parse_row(Rest,[],size(Heading)),
+    Lines = parse_row(Rest,[],tuple_size(Heading)),
     {Heading,Lines}.
 
 get_headings(["|" ++ Headings | Rest]) ->

--- a/lib/common_test/test/test_server_SUITE.erl
+++ b/lib/common_test/test/test_server_SUITE.erl
@@ -283,7 +283,7 @@ get_latest_run_dir(Dir) ->
 	    Dir
     end.
 
-l(X) when is_binary(X) -> size(X);
+l(X) when is_binary(X) -> byte_size(X);
 l(X) when is_list(X) -> length(X).
 
 get_latest_dir([H|T],Latest) when H>Latest ->


### PR DESCRIPTION
The `size/1` BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, `tuple_size/1` should always be preferred.

When one knows that the value being tested must be a binary, `byte_size/1` should be preferred. However, `byte_size/1` also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to `byte_size/1` is preceded by a call to `is_binary/1` to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to `is_binary/1`, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an `is_binary/1` test immediately before the call to `byte_size/1`.