### PR TITLE
inets: replace calls `size/1` to `XXX_size/1`

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -1337,7 +1337,7 @@ validate_ipfamily(BadValue) ->
     bad_option(ipfamily, BadValue).
 
 validate_ip(Value) 
-  when is_tuple(Value) andalso ((size(Value) =:= 4) orelse (size(Value) =:= 8)) ->
+  when tuple_size(Value) =:= 4; tuple_size(Value) =:= 8 ->
     Value;
 validate_ip(BadValue) ->
     bad_option(ip, BadValue).

--- a/lib/inets/src/http_client/httpc_handler.erl
+++ b/lib/inets/src/http_client/httpc_handler.erl
@@ -50,12 +50,12 @@
 
 -record(state, 
         {
-          request                   :: request() | 'undefined',
-          session                   :: session() | 'undefined',
-          status_line,               % {Version, StatusCode, ReasonPharse}
-          headers                   :: http_response_h() | 'undefined',
-          body                      :: binary() | 'undefined',
-          mfa,                       % {Module, Function, Args}
+          request                   :: request() | undefined,
+          session                   :: session() | undefined,
+          status_line               :: tuple()   | undefined,     % {Version, StatusCode, ReasonPharse}
+          headers                   :: http_response_h() | undefined,
+          body                      :: binary() | undefined,
+          mfa                       :: {atom(), atom(), term()} | undefined, % {Module, Function, Args}
           pipeline = queue:new()    :: queue:queue(),
           keep_alive = queue:new()  :: queue:queue(),
           status                    :: undefined | new | pipeline | keep_alive | close | {ssl_tunnel, request()},
@@ -65,7 +65,7 @@
           options                   :: options(),
           timers = #timers{}        :: #timers{},
           profile_name              :: atom(), % id of httpc_manager process.
-          once = inactive           :: 'inactive' | 'once'
+          once = inactive           :: inactive | once
          }).
 
 
@@ -515,7 +515,7 @@ do_handle_info({Proto, _Socket, Data},
 	    handle_http_msg(Result, State); 
 	{_, whole_body, _} when Method =:= head ->
 	    handle_response(State#state{body = <<>>}); 
-	{Module, whole_body, [Body, Length]} ->
+	{Module, whole_body, [Body, Length]} when is_binary(Body)->
 	    {_, Code, _} = StatusLine,
 	    {Streamed, NewBody, NewRequest} = stream(Body, Request, Code),
 	    %% When we stream we will not keep the already
@@ -525,7 +525,7 @@ do_handle_info({Proto, _Socket, Data},
 		    false ->
 			Length;
 		    true ->
-			Length - size(Body)                     
+			Length - byte_size(Body)
 		end,
 	    
 	    NewState = next_body_chunk(State, Code),

--- a/lib/inets/src/http_client/httpc_request.erl
+++ b/lib/inets/src/http_client/httpc_request.erl
@@ -241,7 +241,7 @@ handle_transfer_encoding(Headers) ->
     Headers#http_request_h{'content-length' = undefined}.
 
 body_length(Body) when is_binary(Body) ->
-   integer_to_list(size(Body));
+   integer_to_list(byte_size(Body));
 
 body_length(Body) when is_list(Body) ->
   integer_to_list(iolist_size(Body)).

--- a/lib/inets/src/http_lib/http_chunk.erl
+++ b/lib/inets/src/http_lib/http_chunk.erl
@@ -71,8 +71,8 @@ decode(ChunkedBody, MaxBodySize, MaxHeaderSize) ->
 %%              input format. When sending the data on the both formats 
 %%              are accepted.
 %%-------------------------------------------------------------------------
-encode(Chunk) when is_binary(Chunk)->
-    HEXSize = list_to_binary(http_util:integer_to_hexlist(size(Chunk))),
+encode(Chunk) when is_binary(Chunk) ->
+    HEXSize = list_to_binary(http_util:integer_to_hexlist(byte_size(Chunk))),
     <<HEXSize/binary, ?CR, ?LF, Chunk/binary, ?CR, ?LF>>;
 
 encode([<<>>]) ->
@@ -202,7 +202,7 @@ ignore_extensions(<<_Octet, Rest/binary>>, RemainingSize, TotalMaxHeaderSize, Ne
 
 decode_data(ChunkSize, TotalChunk,
 	    Info = {MaxBodySize, BodySoFar, AccLength, MaxHeaderSize}) 
-  when ChunkSize =< size(TotalChunk) ->
+  when is_binary(TotalChunk), ChunkSize =< byte_size(TotalChunk) ->
     case TotalChunk of
 	%% Last chunk
 	<<Data:ChunkSize/binary, ?CR, ?LF, "0", ";">> ->

--- a/lib/inets/src/http_lib/http_transport.erl
+++ b/lib/inets/src/http_lib/http_transport.erl
@@ -403,11 +403,11 @@ peername({essl, _}, Socket) ->
     do_peername(ssl:peername(Socket)).
 
 do_peername({ok, {Addr, Port}}) 
-  when is_tuple(Addr) andalso (size(Addr) =:= 4) ->
+  when tuple_size(Addr) =:= 4 ->
     PeerName = ipv4_name(Addr), 
     {Port, PeerName};
 do_peername({ok, {Addr, Port}}) 
-  when is_tuple(Addr) andalso (size(Addr) =:= 8) ->
+  when tuple_size(Addr) =:= 8 ->
     PeerName = ipv6_name(Addr), 
     {Port, PeerName};
 do_peername({error, _}) ->
@@ -436,11 +436,11 @@ sockname({essl, _}, Socket) ->
     do_sockname(ssl:sockname(Socket)).
 
 do_sockname({ok, {Addr, Port}}) 
-  when is_tuple(Addr) andalso (size(Addr) =:= 4) ->
+  when tuple_size(Addr) =:= 4 ->
     SockName = ipv4_name(Addr), 
     {Port, SockName};
 do_sockname({ok, {Addr, Port}}) 
-  when is_tuple(Addr) andalso (size(Addr) =:= 8) ->
+  when tuple_size(Addr) =:= 8 ->
     SockName = ipv6_name(Addr), 
     {Port, SockName};
 do_sockname({error, _}) ->

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -2352,7 +2352,7 @@ handle_http_msg({Method, RelUri, _, {_, Headers}, Body}, Socket, _) ->
 		stop;
 	    _ ->
 		ContentLength = content_length(Headers),    
-		case size(Body) - ContentLength of
+		case byte_size(Body) - ContentLength of
 		    0 ->
 			<<>>;
 		    _ ->

--- a/lib/inets/test/httpd_bench_SUITE.erl
+++ b/lib/inets/test/httpd_bench_SUITE.erl
@@ -634,7 +634,7 @@ do_handle_request(CB, S, Name, Opts, KeepAlive) when is_list(Name) ->
     send_file(CB, S, Fdesc);
 do_handle_request(CB, S, {gen, Data}, Opts, KeepAlive) ->
     Version = proplists:get_value(http_version, Opts),
-    Length = size(Data),
+    Length = byte_size(Data),
     Response = response_status_line_and_headers(Version, "Content-Length:" 
 						++ integer_to_list(Length) ++ ?CRLF, keep_alive(KeepAlive)), 
     CB:send(S, Response),
@@ -643,7 +643,7 @@ do_handle_request(CB, S, {gen, Data}, Opts, KeepAlive) ->
 send_file(CB, S, {gen, Data})  ->
     CB:send(S, Data);
     %% ChunkSize = 64*1024,
-    %% case size(Data) of
+    %% case byte_size(Data) of
     %% 	N when N > ChunkSize ->
     %% 	    <<Chunk:N/binary, Rest/binary>> = Data,
     %% 	    %%{Chunk, Rest} = lists:split(N, Data),

--- a/lib/inets/test/httpd_poll.erl
+++ b/lib/inets/test/httpd_poll.erl
@@ -299,7 +299,7 @@ add(_N1, N2) when is_integer(N2) ->
 sz(L) when is_list(L) ->
     length(lists:flatten(L));
 sz(B) when is_binary(B) ->
-    size(B);
+    byte_size(B);
 sz(O) ->
     {unknown_size,O}.
 

--- a/lib/inets/test/httpd_test_lib.erl
+++ b/lib/inets/test/httpd_test_lib.erl
@@ -407,7 +407,7 @@ check_body("GET /cgi-bin/erl/httpd_example:get_bin HTTP/1.1\r\n\r\n", 200, "text
     ct:fail({content_length_error, Length});
 check_body("GET /cgi-bin/cgi_echo HTTP/1.0\r\n\r\n", 200, "text/plain", 
 	   _, Body) ->
-    case size(Body) of
+    case byte_size(Body) of
 	100 ->
 	    ok;
 	_ ->

--- a/lib/inets/test/httpd_time_test.erl
+++ b/lib/inets/test/httpd_time_test.erl
@@ -417,7 +417,7 @@ validate(ExpStatusCode, _SocketType, _Socket, Response) ->
 sz(L) when is_list(L) ->
     length(lists:flatten(L));
 sz(B) when is_binary(B) ->
-    size(B);
+    byte_size(B);
 sz(O) ->
     {unknown_size,O}.
 


### PR DESCRIPTION
Replace calls in the `inets` module from `size/1` to `tuple_size/1` or `byte_size/1`.
This PR is part of issue (PR) #6669 