### PR TITLE
Default -code_path_choice to strict 

### DIFF
--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -292,7 +292,7 @@ code_path_choice() ->
 	{ok,[["relaxed"]]} ->
 	    relaxed;
 	_Else ->
-	    relaxed
+	    strict
     end.
 
 boot(Start,Flags,Args) ->


### PR DESCRIPTION
This PR may be a bit controversial but I would say it is worth it.

The `init` process has a feature where it tries to preemptively
fix code paths. To do so, it has to traverse all paths and perform
(most commonly) two additional file system lookups.

https://github.com/erlang/otp/blob/bdf564f8ee2ef847a33dded0f30bb9073779ace7/erts/preloaded/src/init.erl#L1125-L1161

While trying to optimize the boot process, I have noticed this
does show up when profiling. 1-2ms on my (fast) local machine
for `erl` and 3-4ms with Elixir (it uses -pa and -pz with increases
the cost for every loaded application).

When trying this on an actual application, such as Livebook which
has 50 dependencies, I got up to 10ms spent on patching paths
on a Linux-like machine typically used for deployment (emulated
with VirtualBox).

The times may be higher for embedded devices and those where
filesystem lookups are more expensive.

Luckily, this can be disabled by setting `-code_path_choice strict`,
which I argue should be the default. We could also try to optimize
this code but I would argue that, unless there are very good reasons,
it should not be the job of the `init` system to fix invalid paths.
The faster booter times can be seen as an additional positive side-effect
from removing this behaviour.

Therefore my suggestion is to change the default for this release and
completely remove the relaxed behaviour in future releases.

PS: This PR will most likely break the build. I am waiting for the desired
outcome to fix tests.