### PR TITLE
Include timing on -init_debug to further aid debugging

### DIFF
--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -1024,10 +1024,13 @@ eval_script([{preLoaded,_}|T], #es{}=Es) ->
     eval_script(T, Es);
 eval_script([{path,Path}|T], #es{path=false,pa=Pa,pz=Pz,
 				 path_choice=PathChoice,
-				 vars=Vars}=Es) ->
-    RealPath0 = make_path(Pa, Pz, Path, Vars),
-    RealPath = patch_path(RealPath0, PathChoice),
-    erl_prim_loader:set_path(RealPath),
+				 vars=Vars,debug=Deb}=Es) ->
+    debug(Deb, {path,Path},
+          fun() ->
+                  RealPath0 = make_path(Pa, Pz, Path, Vars),
+                  RealPath = patch_path(RealPath0, PathChoice),
+                  erl_prim_loader:set_path(RealPath)
+          end),
     eval_script(T, Es);
 eval_script([{path,_}|T], #es{}=Es) ->
     %% Ignore, use the command line -path flag.

--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -98,6 +98,17 @@
 debug(false, _) -> ok;
 debug(_, T)     -> erlang:display(T).
 
+debug(false, _, Fun) ->
+    Fun();
+debug(_, T, Fun) ->
+    erlang:display(T),
+    T1 = erlang:monotonic_time(),
+    Val = Fun(),
+    T2 = erlang:monotonic_time(),
+    Time = erlang:convert_time_unit(T2 - T1, native, microsecond),
+    erlang:display({'done_in_μs', Time}),
+    Val.
+
 -spec get_configfd(integer()) -> none | term().
 get_configfd(ConfigFdId) ->
     request({get_configfd, ConfigFdId}).
@@ -1039,12 +1050,10 @@ eval_script([{primLoad,Mods}|T], #es{init=Init,prim_load=PrimLoad}=Es)
     eval_script(T, Es);
 eval_script([{kernelProcess,Server,{Mod,Fun,Args}}|T],
 	    #es{init=Init,debug=Deb}=Es) ->
-    debug(Deb, {start,Server}),
-    start_in_kernel(Server, Mod, Fun, Args, Init),
+    debug(Deb, {start,Server}, fun() -> start_in_kernel(Server, Mod, Fun, Args, Init) end),
     eval_script(T, Es);
 eval_script([{apply,{Mod,Fun,Args}}=Apply|T], #es{debug=Deb}=Es) ->
-    debug(Deb, Apply),
-    apply(Mod, Fun, Args),
+    debug(Deb, Apply, fun() -> apply(Mod, Fun, Args) end),
     eval_script(T, Es);
 eval_script([], #es{}) ->
     ok;
@@ -1536,28 +1545,31 @@ on_load_loop(Mods, Debug0) ->
     end.
 
 run_on_load_handlers([M|Ms], Debug) ->
-    debug(Debug, {running_on_load_handler,M}),
-    Fun = fun() ->
-		  Res = erlang:call_on_load_function(M),
-		  exit(Res)
-	  end,
-    {Pid,Ref} = spawn_monitor(Fun),
-    receive
-	{'DOWN',Ref,process,Pid,OnLoadRes} ->
-	    Keep = OnLoadRes =:= ok,
-	    erlang:finish_after_on_load(M, Keep),
-	    case Keep of
-		false ->
-		    Error = {on_load_function_failed,M,OnLoadRes},
-		    debug(Debug, Error),
-		    exit(Error);
-		true ->
-		    debug(Debug, {on_load_handler_returned_ok,M}),
-		    run_on_load_handlers(Ms, Debug)
-	    end
-    end;
+    debug(Debug,
+          {running_on_load_handler,M},
+          fun() -> run_on_load_handler(M, Debug) end),
+    run_on_load_handlers(Ms, Debug);
 run_on_load_handlers([], _) -> ok.
 
+run_on_load_handler(M, Debug) ->
+    Fun = fun() ->
+                  Res = erlang:call_on_load_function(M),
+                  exit(Res)
+          end,
+    {Pid,Ref} = spawn_monitor(Fun),
+    receive
+        {'DOWN',Ref,process,Pid,OnLoadRes} ->
+            Keep = OnLoadRes =:= ok,
+            erlang:finish_after_on_load(M, Keep),
+            case Keep of
+                false ->
+                    Error = {on_load_function_failed,M,OnLoadRes},
+                    debug(Debug, Error),
+                    exit(Error);
+                true ->
+                    debug(Debug, {on_load_handler_returned_ok,M})
+            end
+    end.
 
 %% debug profile (light variant of eprof)
 debug_profile_start() ->


### PR DESCRIPTION
This is a snippet of how it looks like:

```erlang
{progress,preloaded}
{progress,kernel_load_completed}
{progress,modules_loaded}
{start,heart}
{'done_in_µs',17}
{start,logger}
{'done_in_µs',1473}
{start,application_controller}
{'done_in_µs',19451}
{progress,init_kernel_started}
{apply,{application,load,[{application,stdlib,[{description,"ERTS  CXC 138 10"},{vsn,"4.2"},{id,[]},{modules,[array,base64,beam_lib,binary,c,calendar,dets,dets_server,dets_sup,dets_utils,dets_v9,dict,digraph,digraph_utils,edlin,edlin_context,edlin_expand,edlin_type_suggestion,epp,eval_bits,erl_abstract_code,erl_anno,erl_bits,erl_compile,erl_error,erl_eval,erl_expand_records,erl_features,erl_internal,erl_lint,erl_parse,erl_posix_msg,erl_pp,erl_scan,erl_stdlib_errors,erl_tar,error_logger_file_h,error_logger_tty_h,escript,ets,file_sorter,filelib,filename,gb_trees,gb_sets,gen,gen_event,gen_fsm,gen_server,gen_statem,io,io_lib,io_lib_format,io_lib_fread,io_lib_pretty,lists,log_mf_h,maps,math,ms_transform,orddict,ordsets,otp_internal,peer,pool,proc_lib,proplists,qlc,qlc_pt,queue,rand,random,re,sets,shell,shell_default,shell_docs,slave,sofs,string,supervisor,supervisor_bridge,sys,timer,unicode,unicode_util,uri_string,win32reg,zip]},{registered,[timer_server,rsh_starter,take_over_monitor,pool_master,dets]},{applications,[kernel]},{optional_applications,[]},{included_applications,[]},{env,[]},{maxT,infinity},{maxP,infinity}]}]}}
{'done_in_µs',13}
{apply,{application,load,[{application,compiler,[{description,"ERTS  CXC 138 10"},{vsn,"8.2.2"},{id,[]},{modules,[beam_a,beam_asm,beam_bounds,beam_block,beam_call_types,beam_clean,beam_dict,beam_digraph,beam_disasm,beam_flatten,beam_jump,beam_kernel_to_ssa,beam_listing,beam_opcodes,beam_ssa,beam_ssa_bc_size,beam_ssa_bool,beam_ssa_bsm,beam_ssa_codegen,beam_ssa_dead,beam_ssa_lint,beam_ssa_opt,beam_ssa_pp,beam_ssa_pre_codegen,beam_ssa_recv,beam_ssa_share,beam_ssa_throw,beam_ssa_type,beam_trim,beam_types,beam_utils,beam_validator,beam_z,cerl,cerl_clauses,cerl_inline,cerl_trees,compile,core_scan,core_lint,core_parse,core_pp,core_lib,erl_bifs,rec_env,sys_core_alias,sys_core_bsm,sys_core_fold,sys_core_fold_lists,sys_core_inline,sys_core_prepare,sys_messages,sys_pre_attributes,v3_core,v3_kernel,v3_kernel_pp]},{registered,[]},{applications,[kernel,stdlib]},{optional_applications,[]},{included_applications,[]},{env,[]},{maxT,infinity},{maxP,infinity}]}]}}
{'done_in_µs',3}
{apply,{application,load,[{application,elixir,[{description,"elixir"},{vsn,"1.15.0-dev"},{id,[]},{modules,['Elixir.Access','Elixir.Agent.Server','Elixir.Agent','Elixir.Application','Elixir.ArgumentError','Elixir.ArithmeticError','Elixir.Atom','Elixir.BadArityError','Elixir.BadBooleanError','Elixir.BadFunctionError','Elixir.BadMapError','Elixir.BadStructError','Elixir.Base','Elixir.Behaviour','Elixir.Bitwise','Elixir.Calendar.ISO','Elixir.Calendar.TimeZoneDatabase','Elixir.Calendar.UTCOnlyTimeZoneDatabase','Elixir.Calendar','Elixir.CaseClauseError','Elixir.Code.Formatter','Elixir.Code.Fragment','Elixir.Code.Identifier','Elixir.Code.LoadError','Elixir.Code.Normalizer','Elixir.Code.Typespec','Elixir.Code','Elixir.Collectable.BitString','Elixir.Collectable.File.Stream','Elixir.Collectable.HashDict','Elixir.Collectable.HashSet','Elixir.Collectable.IO.Stream','Elixir.Collectable.List','Elixir.Collectable.Map','Elixir.Collectable.MapSet','Elixir.Collectable','Elixir.CompileError','Elixir.CondClauseError','Elixir.Config.Provider','Elixir.Config.Reader','Elixir.Config','Elixir.Date.Range','Elixir.Date','Elixir.DateTime','Elixir.Dict','Elixir.DynamicSupervisor','Elixir.Enum.EmptyError','Elixir.Enum.OutOfBoundsError','Elixir.Enum','Elixir.Enumerable.Date.Range','Elixir.Enumerable.File.Stream','Elixir.Enumerable.Function','Elixir.Enumerable.GenEvent.Stream','Elixir.Enumerable.HashDict','Elixir.Enumerable.HashSet','Elixir.Enumerable.IO.Stream','Elixir.Enumerable.List','Elixir.Enumerable.Map','Elixir.Enumerable.MapSet','Elixir.Enumerable.Range','Elixir.Enumerable.Stream','Elixir.Enumerable','Elixir.ErlangError','Elixir.Exception','Elixir.File.CopyError','Elixir.File.Error','Elixir.File.LinkError','Elixir.File.RenameError','Elixir.File.Stat','Elixir.File.Stream','Elixir.File','Elixir.Float','Elixir.Function','Elixir.FunctionClauseError','Elixir.GenEvent.Stream','Elixir.GenEvent','Elixir.GenServer','Elixir.HashDict','Elixir.HashSet','Elixir.IO.ANSI.Docs','Elixir.IO.ANSI.Sequence','Elixir.IO.ANSI','Elixir.IO.Stream','Elixir.IO.StreamError','Elixir.IO','Elixir.Inspect.Algebra','Elixir.Inspect.Any','Elixir.Inspect.Atom','Elixir.Inspect.BitString','Elixir.Inspect.Date.Range','Elixir.Inspect.Date','Elixir.Inspect.DateTime','Elixir.Inspect.Error','Elixir.Inspect.Float','Elixir.Inspect.Function','Elixir.Inspect.HashDict','Elixir.Inspect.HashSet','Elixir.Inspect.Inspect.Error','Elixir.Inspect.Integer','Elixir.Inspect.List','Elixir.Inspect.Macro.Env','Elixir.Inspect.Map','Elixir.Inspect.MapSet','Elixir.Inspect.NaiveDateTime','Elixir.Inspect.Opts','Elixir.Inspect.PID','Elixir.Inspect.Port','Elixir.Inspect.Range','Elixir.Inspect.Reference','Elixir.Inspect.Regex','Elixir.Inspect.Stream','Elixir.Inspect.Time','Elixir.Inspect.Tuple','Elixir.Inspect.URI','Elixir.Inspect.Version.Requirement','Elixir.Inspect.Version','Elixir.Inspect','Elixir.Integer','Elixir.Kernel.CLI','Elixir.Kernel.ErrorHandler','Elixir.Kernel.LexicalTracker','Elixir.Kernel.ParallelCompiler','Elixir.Kernel.ParallelRequire','Elixir.Kernel.SpecialForms','Elixir.Kernel.Typespec','Elixir.Kernel.TypespecError','Elixir.Kernel.Utils','Elixir.Kernel','Elixir.KeyError','Elixir.Keyword','Elixir.List.Chars.Atom','Elixir.List.Chars.BitString','Elixir.List.Chars.Float','Elixir.List.Chars.Integer','Elixir.List.Chars.List','Elixir.List.Chars','Elixir.List','Elixir.Macro.Env','Elixir.Macro','Elixir.Map','Elixir.MapSet','Elixir.MatchError','Elixir.Module.LocalsTracker','Elixir.Module.ParallelChecker','Elixir.Module.Types.Behaviour','Elixir.Module.Types.Error','Elixir.Module.Types.Expr','Elixir.Module.Types.Helpers','Elixir.Module.Types.Of','Elixir.Module.Types.Pattern','Elixir.Module.Types.Unify','Elixir.Module.Types','Elixir.Module','Elixir.NaiveDateTime','Elixir.Node','Elixir.OptionParser.ParseError','Elixir.OptionParser','Elixir.PartitionSupervisor','Elixir.Path.Wildcard','Elixir.Path','Elixir.Port','Elixir.Process','Elixir.Protocol.UndefinedError','Elixir.Protocol','Elixir.Range','Elixir.Record.Extractor','Elixir.Record','Elixir.Regex.CompileError','Elixir.Regex','Elixir.Registry.Partition','Elixir.Registry.Supervisor','Elixir.Registry','Elixir.RuntimeError','Elixir.Set','Elixir.Stream.Reducers','Elixir.Stream','Elixir.String.Break','Elixir.String.Chars.Atom','Elixir.String.Chars.BitString','Elixir.String.Chars.Date','Elixir.String.Chars.DateTime','Elixir.String.Chars.Float','Elixir.String.Chars.Integer','Elixir.String.Chars.List','Elixir.String.Chars.NaiveDateTime','Elixir.String.Chars.Time','Elixir.String.Chars.URI','Elixir.String.Chars.Version.Requirement','Elixir.String.Chars.Version','Elixir.String.Chars','Elixir.String.Tokenizer.ScriptSet','Elixir.String.Tokenizer.Security','Elixir.String.Tokenizer','Elixir.String.Unicode','Elixir.String','Elixir.StringIO','Elixir.Supervisor.Default','Elixir.Supervisor.Spec','Elixir.Supervisor','Elixir.SyntaxError','Elixir.System.EnvError','Elixir.System.SignalHandler','Elixir.System','Elixir.SystemLimitError','Elixir.Task.Supervised','Elixir.Task.Supervisor','Elixir.Task','Elixir.Time','Elixir.TokenMissingError','Elixir.TryClauseError','Elixir.Tuple','Elixir.URI.Error','Elixir.URI','Elixir.UndefinedFunctionError','Elixir.UnicodeConversionError','Elixir.Version.InvalidRequirementError','Elixir.Version.InvalidVersionError','Elixir.Version.Parser','Elixir.Version.Requirement','Elixir.Version','Elixir.WithClauseError',elixir,elixir_aliases,elixir_bitstring,elixir_bootstrap,elixir_clauses,elixir_code_server,elixir_compiler,elixir_config,elixir_def,elixir_dispatch,elixir_env,elixir_erl,elixir_erl_clauses,elixir_erl_compiler,elixir_erl_for,elixir_erl_pass,elixir_erl_try,elixir_erl_var,elixir_errors,elixir_expand,elixir_fn,elixir_import,elixir_interpolation,elixir_lexical,elixir_locals,elixir_map,elixir_module,elixir_overridable,elixir_parser,elixir_quote,elixir_rewrite,elixir_sup,elixir_tokenizer,elixir_utils]},{registered,[elixir_sup,elixir_config,elixir_code_server]},{applications,[kernel,stdlib,compiler]},{optional_applications,[]},{included_applications,[]},{env,[{ansi_enabled,false},{ansi_syntax_colors,[{atom,cyan},{binary,default_color},{boolean,magenta},{charlist,yellow},{list,default_color},{map,default_color},{nil,magenta},{number,yellow},{string,green},{tuple,default_color},{variable,light_cyan},{call,light_white},{operator,light_white}]},{check_endianness,true},{dbg_callback,{'Elixir.Macro',dbg,[]}},{time_zone_database,'Elixir.Calendar.UTCOnlyTimeZoneDatabase'}]},{maxT,infinity},{maxP,infinity},{mod,{elixir,[]}}]}]}}
{'done_in_µs',15}
{apply,{application,load,[{application,sasl,[{description,"SASL  CXC 138 11"},{vsn,"4.2"},{id,[]},{modules,[sasl,alarm_handler,format_lib_supp,misc_supp,rb,rb_format_supp,release_handler,release_handler_1,erlsrv,sasl_report,sasl_report_tty_h,sasl_report_file_h,systools,systools_make,systools_rc,systools_relup,systools_lib]},{registered,[sasl_sup,alarm_handler,release_handler]},{applications,[kernel,stdlib]},{optional_applications,[]},{included_applications,[]},{env,[]},{maxT,infinity},{maxP,infinity},{mod,{sasl,[]}}]}]}}
{'done_in_µs',3}
{apply,{application,load,[{application,aws_signature,[{description,"Request signature implementation for authorizing AWS API calls"},{vsn,"0.3.1"},{id,[]},{modules,[aws_signature,aws_signature_utils]},{registered,[]},{applications,[kernel,stdlib]},{optional_applications,[]},{included_applications,[]},{env,[]},{maxT,infinity},{maxP,infinity}]}]}}
{'done_in_µs',3}
{apply,{application,load,[{application,logger,[{description,"logger"},{vsn,"1.15.0-dev"},{id,[]},{modules,['Elixir.Logger','Elixir.Logger.App','Elixir.Logger.BackendSupervisor','Elixir.Logger.Backends.Console','Elixir.Logger.Config','Elixir.Logger.Filter','Elixir.Logger.Formatter','Elixir.Logger.Handler','Elixir.Logger.Translator','Elixir.Logger.Utils','Elixir.Logger.Watcher']},{registered,['Elixir.Logger','Elixir.Logger.BackendSupervisor','Elixir.Logger.Supervisor','Elixir.Logger.Watcher']},{applications,[kernel,stdlib,elixir]},{optional_applications,[]},{included_applications,[]},{env,[{utc_log,false},{truncate,8096},{backends,[console]},{translators,[{'Elixir.Logger.Translator',translate}]},{sync_threshold,20},{discard_threshold,500},{handle_otp_reports,true},{handle_sasl_reports,false},{discard_threshold_periodic_check,30000},{discard_threshold_for_error_logger,500},{compile_time_purge_matching,[]},{compile_time_application,nil},{translator_inspect_opts,[]},{console,[]},{start_options,[]}]},{maxT,infinity},{maxP,infinity},{mod,{'Elixir.Logger.App',[]}}]}]}}
{'done_in_µs',8}
{apply,{application,load,[{application,castore,[{description,"Up-to-date CA certificate store."},{vsn,"0.1.18"},{id,[]},{modules,['Elixir.CAStore']},{registered,[]},{applications,[kernel,stdlib,elixir,logger]},{optional_applications,[]},{included_applications,[]},{env,[]},{maxT,infinity},{maxP,infinity}]}]}}
{'done_in_µs',2}
...
{apply,{application,start_boot,[cowboy_telemetry,permanent]}}
{'done_in_µs',31}
{apply,{application,start_boot,[plug_cowboy,permanent]}}
[notice]     :alarm_handler: {:set, {:system_memory_high_watermark, []}}
{'done_in_µs',1143}
{apply,{application,start_boot,[phoenix,permanent]}}
{'done_in_µs',5332}
{apply,{application,start_boot,[phoenix_ecto,permanent]}}
{'done_in_µs',839}
{apply,{application,start_boot,[phoenix_live_view,permanent]}}
{'done_in_µs',1536}
{apply,{application,start_boot,[telemetry_metrics,permanent]}}
{'done_in_µs',22}
{apply,{application,start_boot,[phoenix_live_dashboard,permanent]}}
{'done_in_µs',2696}
{apply,{application,start_boot,[file_system,permanent]}}
{'done_in_µs',24}
{apply,{application,start_boot,[phoenix_live_reload,permanent]}}
{'done_in_µs',4448}
{apply,{application,start_boot,[protobuf,permanent]}}
{'done_in_µs',22}
{apply,{application,start_boot,[runtime_tools,permanent]}}
{'done_in_µs',3647}
{apply,{application,start_boot,[telemetry_poller,permanent]}}
{'done_in_µs',2122}
{apply,{application,start_boot,[xmerl,permanent]}}
{'done_in_µs',27}
{apply,{application,start_boot,[livebook,permanent]}}
{'done_in_µs',49209}
{progress,started}
```