### PR TITLE
os_mon: Close cpu_sup and memsup port on terminate

### DIFF
--- a/lib/os_mon/c_src/memsup.c
+++ b/lib/os_mon/c_src/memsup.c
@@ -609,6 +609,8 @@ message_loop(int erlin_fd)
 		    case SHOW_SYSTEM_MEM:
 			extended_show_mem();
 			break;
+		    case EXIT:
+			return;
 		    default:	/* ignore all other messages */
 			break;
 		    }

--- a/lib/os_mon/c_src/memsup.h
+++ b/lib/os_mon/c_src/memsup.h
@@ -30,6 +30,8 @@
 /* Extended memory statistics */
 /*IG*/ #define SHOW_SYSTEM_MEM 2
 
+#define EXIT 3
+
 /* Tags for the extended statistics */
 /*IG*/ #define SHOW_SYSTEM_MEM_END 0
 /*IG*/ #define MEM_SYSTEM_TOTAL 1

--- a/lib/os_mon/include/memsup.hrl
+++ b/lib/os_mon/include/memsup.hrl
@@ -26,6 +26,7 @@
 
 -define( SHOW_MEM , 1 ).
 -define( SHOW_SYSTEM_MEM , 2 ).
+-define( EXIT , 3 ).
 -define( SHOW_SYSTEM_MEM_END , 8#0 ).
 %% tags for extended statistics
 -define( MEM_SYSTEM_TOTAL , 1 ).


### PR DESCRIPTION
Closes #4221

There seems to be a similar issue with memsup. Should I include it here?