### PR TITLE
Remove archives fallback in code path

### DIFF
--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -162,34 +162,6 @@ zip:create("mnesia-4.4.7.ez",
      would list the contents of a directory inside an archive.
      See <seeerl marker="erts:erl_prim_loader"><c>erl_prim_loader(3)</c></seeerl>.</p>
 
-    <p>An application archive file and a regular application directory
-     can coexist. This can be useful when it is needed to have
-     parts of the application as regular files. A typical case is the
-     <c>priv</c> directory, which must reside as a regular directory
-     to link in drivers dynamically and start port programs.
-     For other applications that do not need this, directory
-     <c>priv</c> can reside in the archive and the files
-     under the directory <c>priv</c> can be read through
-     <c>erl_prim_loader</c>.</p>
-
-    <p>When a directory is added to the code path and
-     when the entire code path is (re)set, the code server
-     decides which subdirectories in an application that are to be
-     read from the archive and which that are to be read as regular
-     files. If directories are added or removed afterwards, the file
-     access can fail if the code path is not updated (possibly to the
-     same path as before, to trigger the directory resolution
-     update).</p>
-
-     <p>For each directory on the second level in the application archive
-     (<c>ebin</c>, <c>priv</c>, <c>src</c>, and so on), the code server first
-     chooses the regular directory if it exists and second from the
-     archive. Function <c>code:lib_dir/2</c> returns the path to the
-     subdirectory. For example, <c>code:lib_dir(megaco,ebin)</c> can return
-     <c>/otp/root/lib/megaco-3.9.1.1.ez/megaco-3.9.1.1/ebin</c> while
-     <c>code:lib_dir(megaco,priv)</c> can return
-     <c>/otp/root/lib/megaco-3.9.1.1/priv</c>.</p>
-
     <p>When an <c>escript</c> file contains an archive, there are
      no restrictions on the name of the <c>escript</c> and no restrictions
      on how many applications that can be stored in the embedded

--- a/system/doc/general_info/scheduled_for_removal_26.inc
+++ b/system/doc/general_info/scheduled_for_removal_26.inc
@@ -28,3 +28,16 @@
 	inconsistent state.
       </p>
     </section>
+
+    <section>
+      <title>Archive fallback directory</title>
+      <p>
+	This feature makes archives more unpredictable, since you might
+	have a application folder that contains files that overrides the files in the archive.
+	It also makes packaging archives not as straight forward as you would have
+	to bundle files in an additional archive layer. We will change this
+	so that all files related to an App can be packaged in the .ez archive.
+	Additionally dynamically linked libraries such as NIFs will also be loaded
+	from the archive.
+      </p>
+    </section>


### PR DESCRIPTION
Archives have a feature where both the archive directory and the application directory can co-exist and the contents of the archive will be read as a fallback. This pull request removes this feature as it is implicit behaviour and has a direct impact on each code path added to the code server with two additional file system lookups per code path.

Furthermore, I struggle to see the benefit of this feature:

1. This could be used to provide a fallback `ebin` directory for a given application, but this requires an application without `ebin` to be added to the code path, which is slightly contradictory as the `ebin` directory is the one typically added to the code path in the first place

2. You most likely cannot  add `priv` from an archive because the functions in the `file` module cannot read contents from archives. Therefore, if you do `file:read_info(code:priv_dir(megaco))`, it will return `error` if the path points to an archive (and we most likely don't want to make that support archives as it will make all error paths from the `file` module more expensive)

Finally, reading any content from an archive is actually considerably slower than reading from an unpacked archive. Therefore we should promote users to unpack archives and use them directly whenever possible. Still, Erlang/OTP should still support archives, especially for cases like escripts, and this pull request removes only one specific implicit feature from them.

---

Apologies for sending another pull request which is removing existing behaviour. But I believe there is merit on this proposal, similar to the one in #6683. Both are implicit behaviours that have an impact in all users while they are likely rarely used. And I keep running into those scenarios while looking into #5811 and #6692.

Given archives are still tagged as experimental, perhaps this is a good opportunity to clean up those implicit behaviours and streamline code loading, with the goal of eventually marking archives as stable. 