### PR TITLE
base64: allow skipping padding = characters

### DIFF
--- a/lib/stdlib/doc/src/base64.xml
+++ b/lib/stdlib/doc/src/base64.xml
@@ -47,10 +47,20 @@
     <datatype>
       <name name="base64_mode"/>
       <desc>
-        <p>Selector for the Base 64 Encoding alphabet used for encoding and decoding,
-         see <url href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</url>
+        <p>Selector for the Base 64 Encoding alphabet used for
+	<seemfa marker="#encode/2">encoding</seemfa> and
+	<seemfa marker="#decode/2">decoding</seemfa>.
+         See <url href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</url>
          Sections <url href="https://datatracker.ietf.org/doc/html/rfc4648#section-4">4</url>
          and <url href="https://datatracker.ietf.org/doc/html/rfc4648#section-5">5</url>.</p>
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="options" />
+      <desc>
+        <p>Customises the behaviour of the encode and decode functions.
+	Default value if omitted entirely or partially is
+        <c>#{mode => standard, padding => true}</c>.</p>
       </desc>
     </datatype>
     <datatype>
@@ -87,6 +97,8 @@
         <p><c>mime_decode/1</c> and <c>mime_decode_to_string/1</c> strip away
           illegal characters, while <c>decode/1</c> and
           <c>decode_to_string/1</c> only strip away whitespace characters.</p>
+        <p>Checks the correct number of <c>=</c> padding characters
+          at the end of the encoded string.</p>
       </desc>
     </func>
 
@@ -97,19 +109,19 @@
       <name name="mime_decode_to_string" arity="2" since="OTP @OTP-18247@"/>
       <fsummary>Decode a base64 encoded string to data.</fsummary>
       <type variable="Base64"/>
-      <type variable="Mode" name_i="1"/>
+      <type variable="Options" name_i="1"/>
       <type variable="Data" name_i="1"/>
       <type variable="DataString" name_i="2"/>
       <desc>
         <p>Decodes a base64 string encoded using the alphabet indicated by the
-          <c><anno>Mode</anno></c> parameter to plain ASCII.</p>
+          <c>mode</c> option to plain ASCII.</p>
         <p><c>mime_decode/2</c> and <c>mime_decode_to_string/2</c> strip away
           illegal characters, while <c>decode/2</c> and
           <c>decode_to_string/2</c> only strip away whitespace characters.</p>
-        <p>The <c><anno>Mode</anno></c> parameter can be one of the following:</p>
+        <p>The <c>mode</c> option can be one of the following:</p>
         <taglist>
           <tag><c>standard</c></tag>
-          <item>Decode the given string using the standard base64 alphabet according
+          <item>Default. Decode the given string using the standard base64 alphabet according
             to <url href="https://datatracker.ietf.org/doc/html/rfc4648#section-4">RFC 4648
             Section 4</url>, that is <c>"+"</c> and <c>"/"</c> are representing bytes <c>62</c>
             and <c>63</c> respectively, while <c>"-"</c> and <c>"_"</c> are illegal
@@ -121,6 +133,15 @@
             Section 5</url>, that is <c>"-"</c> and <c>"_"</c> are representing bytes <c>62</c>
             and <c>63</c> respectively, while <c>"+"</c> and <c>"/"</c> are illegal
             characters.</item>
+        </taglist>
+        <p>The <c>padding</c> option can be one of the following:</p>
+        <taglist>
+          <tag><c>true</c></tag>
+          <item>Default. Checks the correct number of <c>=</c> padding characters
+            at the end of the encoded string.</item>
+          <tag><c>false</c></tag>
+          <item>Accepts an encoded string with missing <c>=</c> padding characters
+            at the end.</item>
         </taglist>
       </desc>
     </func>
@@ -136,6 +157,8 @@
         <p>Encodes a plain ASCII string into base64 using the standard alphabet
           according to <url href="https://datatracker.ietf.org/doc/html/rfc4648#section-4">RFC 4648
           Section 4</url>. The result is 33% larger than the data.</p>
+        <p>Always appends correct number of <c>=</c> padding characters
+          to the encoded string.</p>
       </desc>
     </func>
 
@@ -144,16 +167,16 @@
       <name name="encode_to_string" arity="2" since="OTP @OTP-18247@"/>
       <fsummary>Encode data into base64.</fsummary>
       <type variable="Data"/>
-      <type variable="Mode"/>
+      <type variable="Options"/>
       <type variable="Base64" name_i="1"/>
       <type variable="Base64String"/>
       <desc>
         <p>Encodes a plain ASCII string into base64 using the alphabet indicated by
-          the <c><anno>Mode</anno></c> parameter. The result is 33% larger than the data.</p>
-        <p>The <c><anno>Mode</anno></c> parameter can be one of the following:</p>
+          the <c>mode</c> option. The result is 33% larger than the data.</p>
+        <p>The <c>mode</c> option can be one of the following:</p>
         <taglist>
           <tag><c>standard</c></tag>
-          <item>Encode the given string using the standard base64 alphabet according
+          <item>Default. Encode the given string using the standard base64 alphabet according
             to <url href="https://datatracker.ietf.org/doc/html/rfc4648#section-4">RFC 4648
             Section 4</url>.</item>
           <tag><c>urlsafe</c></tag>
@@ -162,8 +185,15 @@
             <url href="https://datatracker.ietf.org/doc/html/rfc4648#section-5">RFC 4648
             Section 5</url>.</item>
         </taglist>
+        <p>The <c>padding</c> option can be one of the following:</p>
+        <taglist>
+          <tag><c>true</c></tag>
+          <item>Default. Appends correct number of <c>=</c> padding characters
+            to the encoded string.</item>
+          <tag><c>false</c></tag>
+          <item>Skips appending <c>=</c> padding characters to the encoded string.</item>
+        </taglist>
       </desc>
     </func>
   </funcs>
 </erlref>
-

--- a/lib/stdlib/test/base64_SUITE.erl
+++ b/lib/stdlib/test/base64_SUITE.erl
@@ -26,8 +26,8 @@
 -export([all/0, suite/0, groups/0, group/1]).
 
 %% Test cases must be exported.
--export([base64_encode/1, base64_encode_modes/1,
-	 base64_decode/1, base64_decode_modes/1,
+-export([base64_encode/1, base64_encode_to_string/1, base64_encode_modes/1,
+	 base64_decode/1, base64_decode_to_string/1, base64_decode_modes/1,
 	 base64_otp_5635/1, base64_otp_6279/1, big/1, illegal/1,
 	 mime_decode/1, mime_decode_modes/1,
 	 mime_decode_to_string/1, mime_decode_to_string_modes/1,
@@ -42,8 +42,8 @@ suite() ->
      {timetrap,{minutes,4}}].
 
 all() ->
-    [base64_encode, base64_encode_modes,
-     base64_decode, base64_decode_modes,
+    [base64_encode, base64_encode_to_string, base64_encode_modes,
+     base64_decode, base64_decode_to_string, base64_decode_modes,
      base64_otp_5635, base64_otp_6279, big, illegal,
      mime_decode, mime_decode_modes,
      mime_decode_to_string, mime_decode_to_string_modes,
@@ -58,76 +58,176 @@ group(roundtrip) ->
     [{timetrap,{minutes,10}}].
 
 %%-------------------------------------------------------------------------
-%% Test base64:encode/1.
+%% Test base64:encode/1,2.
 base64_encode(Config) when is_list(Config) ->
     %% Two pads
     <<"QWxhZGRpbjpvcGVuIHNlc2FtZQ==">> =
 	base64:encode("Aladdin:open sesame"),
+    <<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">> =
+        base64:encode("Aladdin:open sesame", #{padding => false}),
     %% One pad
     <<"SGVsbG8gV29ybGQ=">> = base64:encode(<<"Hello World">>),
+    <<"SGVsbG8gV29ybGQ">> = base64:encode(<<"Hello World">>, #{padding => false}),
+    %% No pad
+    <<"QWxhZGRpbjpvcGVuIHNlc2Ft">> = base64:encode("Aladdin:open sesam"),
+    <<"QWxhZGRpbjpvcGVuIHNlc2Ft">> =
+        base64:encode("Aladdin:open sesam", #{padding => false}),
+
+    <<"MDEyMzQ1Njc4OSFAIzBeJiooKTs6PD4sLiBbXXt9">> =
+	base64:encode(<<"0123456789!@#0^&*();:<>,. []{}">>),
+    ok.
+
+%%-------------------------------------------------------------------------
+%% Test base64:encode_to_string/1,2.
+base64_encode_to_string(Config) when is_list(Config) ->
+    %% Two pads
+    "QWxhZGRpbjpvcGVuIHNlc2FtZQ==" =
+        base64:encode_to_string("Aladdin:open sesame"),
+    "QWxhZGRpbjpvcGVuIHNlc2FtZQ" =
+        base64:encode_to_string("Aladdin:open sesame", #{padding => false}),
+    %% One pad
+    "SGVsbG8gV29ybGQ=" = base64:encode_to_string(<<"Hello World">>),
+    "SGVsbG8gV29ybGQ" =
+        base64:encode_to_string(<<"Hello World">>, #{padding => false}),
     %% No pad
     "QWxhZGRpbjpvcGVuIHNlc2Ft" =
 	base64:encode_to_string("Aladdin:open sesam"),
+    "QWxhZGRpbjpvcGVuIHNlc2Ft" =
+        base64:encode_to_string("Aladdin:open sesam", #{padding => false}),
 
     "MDEyMzQ1Njc4OSFAIzBeJiooKTs6PD4sLiBbXXt9" =
 	base64:encode_to_string(<<"0123456789!@#0^&*();:<>,. []{}">>),
     ok.
 
 %%-------------------------------------------------------------------------
-%% Test base64:encode/2.
+%% Test base64:encode/2 and base64:encode_to_string/2.
 base64_encode_modes(Config) when is_list(Config) ->
     Data = <<23, 234, 63, 163, 239, 129, 253, 175, 171>>,
 
-    <<"F+o/o++B/a+r">> = base64:encode(Data, standard),
-    <<"F-o_o--B_a-r">> = base64:encode(Data, urlsafe),
+    <<"F+o/o++B/a+r">> = base64:encode(Data, #{mode => standard}),
+    <<"F-o_o--B_a-r">> = base64:encode(Data, #{mode => urlsafe}),
 
-    "F+o/o++B/a+r" = base64:encode_to_string(Data, standard),
-    "F-o_o--B_a-r" = base64:encode_to_string(Data, urlsafe),
+    "F+o/o++B/a+r" = base64:encode_to_string(Data, #{mode => standard}),
+    "F-o_o--B_a-r" = base64:encode_to_string(Data, #{mode => urlsafe}),
 
     ok.
 
 %%-------------------------------------------------------------------------
-%% Test base64:decode/1.
+%% Test base64:decode/1,2.
 base64_decode(Config) when is_list(Config) ->
     %% Two pads
     <<"Aladdin:open sesame">> =
-	base64:decode("QWxhZGRpbjpvcGVuIHNlc2FtZQ=="),
+        base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ==">>),
+    <<"Aladdin:open sesame">> =
+        base64:decode("QWxhZGRpbjpvcGVuIHNlc2FtZQ=="),
+    <<"Aladdin:open sesame">> =
+        base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>, #{padding => false}),
+    <<"Aladdin:open sesame">> =
+        base64:decode("QWxhZGRpbjpvcGVuIHNlc2FtZQ", #{padding => false}),
+    {'EXIT', {'missing_padding', _}} =
+        catch base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>),
+    {'EXIT', {'missing_padding', _}} =
+        catch base64:decode("QWxhZGRpbjpvcGVuIHNlc2FtZQ"),
     %% One pad
     <<"Hello World">> = base64:decode(<<"SGVsbG8gV29ybGQ=">>),
+    <<"Hello World">> = base64:decode("SGVsbG8gV29ybGQ="),
+    <<"Hello World">> = base64:decode(<<"SGVsbG8gV29ybGQ">>, #{padding => false}),
+    <<"Hello World">> = base64:decode("SGVsbG8gV29ybGQ", #{padding => false}),
+    {'EXIT', {'missing_padding', _}} =
+        catch base64:decode_to_string(<<"SGVsbG8gV29ybGQ">>),
+    {'EXIT', {'missing_padding', _}} =
+        catch base64:decode_to_string("SGVsbG8gV29ybGQ"),
     %% No pad
     <<"Aladdin:open sesam">> =
-	base64:decode("QWxhZGRpbjpvcGVuIHNlc2Ft"),
+        base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2Ft">>),
+    <<"Aladdin:open sesam">> =
+        base64:decode("QWxhZGRpbjpvcGVuIHNlc2Ft"),
+    <<"Aladdin:open sesam">> =
+        base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2Ft">>, #{padding => false}),
+    <<"Aladdin:open sesam">> =
+        base64:decode("QWxhZGRpbjpvcGVuIHNlc2Ft", #{padding => false}),
 
     Alphabet = list_to_binary(lists:seq(0, 255)),
     Alphabet = base64:decode(base64:encode(Alphabet)),
+    Alphabet = base64:decode(base64:encode_to_string(Alphabet)),
+
+    %% Encoded base 64 strings may be divided by non base 64 chars.
+    %% In this cases whitespaces.
+    <<"0123456789!@#0^&*();:<>,. []{}">> =
+        base64:decode(
+            "MDEy MzQ1Njc4 \tOSFAIzBeJ \niooKTs6 PD4sLi \r\nBbXXt9"),
+    <<"0123456789!@#0^&*();:<>,. []{}">> =
+        base64:decode(
+            <<"MDEy MzQ1Njc4 \tOSFAIzBeJ \niooKTs6 PD4sLi \r\nBbXXt9">>),
+    ok.
+
+%%-------------------------------------------------------------------------
+%% Test base64:decode_to_string/1,2.
+base64_decode_to_string(Config) when is_list(Config) ->
+    %% Two pads
+    "Aladdin:open sesame" =
+        base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ==">>),
+    "Aladdin:open sesame" =
+        base64:decode_to_string("QWxhZGRpbjpvcGVuIHNlc2FtZQ=="),
+    "Aladdin:open sesame" =
+        base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>, #{padding => false}),
+    "Aladdin:open sesame" =
+        base64:decode_to_string("QWxhZGRpbjpvcGVuIHNlc2FtZQ", #{padding => false}),
+    {'EXIT', {'missing_padding', _}} =
+        catch base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>),
+    {'EXIT', {'missing_padding', _}} =
+        catch base64:decode_to_string("QWxhZGRpbjpvcGVuIHNlc2FtZQ"),
+    %% One pad
+    "Hello World" = base64:decode_to_string(<<"SGVsbG8gV29ybGQ=">>),
+    "Hello World" = base64:decode_to_string("SGVsbG8gV29ybGQ="),
+    "Hello World" = base64:decode_to_string(<<"SGVsbG8gV29ybGQ">>, #{padding => false}),
+    "Hello World" = base64:decode_to_string("SGVsbG8gV29ybGQ", #{padding => false}),
+    {'EXIT', {'missing_padding', _}} =
+        catch base64:decode_to_string(<<"SGVsbG8gV29ybGQ">>),
+    {'EXIT', {'missing_padding', _}} =
+        catch base64:decode_to_string("SGVsbG8gV29ybGQ"),
+    %% No pad
+    "Aladdin:open sesam" =
+        base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2Ft">>),
+    "Aladdin:open sesam" =
+        base64:decode_to_string("QWxhZGRpbjpvcGVuIHNlc2Ft"),
+    "Aladdin:open sesam" =
+        base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2Ft">>, #{padding => false}),
+    "Aladdin:open sesam" =
+        base64:decode_to_string("QWxhZGRpbjpvcGVuIHNlc2Ft", #{padding => false}),
+
+    Alphabet = lists:seq(0, 255),
+    Alphabet = base64:decode_to_string(base64:encode(Alphabet)),
+    Alphabet = base64:decode_to_string(base64:encode_to_string(Alphabet)),
 
     %% Encoded base 64 strings may be divided by non base 64 chars.
     %% In this cases whitespaces.
     "0123456789!@#0^&*();:<>,. []{}" =
-	base64:decode_to_string(
-	  "MDEy MzQ1Njc4 \tOSFAIzBeJ \niooKTs6 PD4sLi \r\nBbXXt9"),
+        base64:decode_to_string(
+            "MDEy MzQ1Njc4 \tOSFAIzBeJ \niooKTs6 PD4sLi \r\nBbXXt9"),
     "0123456789!@#0^&*();:<>,. []{}" =
-	base64:decode_to_string(
-	  <<"MDEy MzQ1Njc4 \tOSFAIzBeJ \niooKTs6 PD4sLi \r\nBbXXt9">>),
+        base64:decode_to_string(
+            <<"MDEy MzQ1Njc4 \tOSFAIzBeJ \niooKTs6 PD4sLi \r\nBbXXt9">>),
     ok.
 
 %%-------------------------------------------------------------------------
-%% Test base64:decode/2.
+%% Test base64:decode/2 and base64:decode_to_string/2
 base64_decode_modes(Config) when is_list(Config) ->
     DataBin = <<23, 234, 63, 163, 239, 129, 253, 175, 171>>,
     DataStr = [23, 234, 63, 163, 239, 129, 253, 175, 171],
 
-    DataBin = base64:decode("F+o/o++B/a+r", standard),
-    DataBin = base64:decode("F-o_o--B_a-r", urlsafe),
-    {'EXIT', _} = catch base64:decode("F-o_o--B_a-r", standard),
-    {'EXIT', _} = catch base64:decode("F+o/o++B/a+r", urlsafe),
+    DataBin = base64:decode("F+o/o++B/a+r", #{mode => standard}),
+    DataBin = base64:decode("F-o_o--B_a-r", #{mode => urlsafe}),
+    {'EXIT', _} = catch base64:decode("F-o_o--B_a-r", #{mode => standard}),
+    {'EXIT', _} = catch base64:decode("F+o/o++B/a+r", #{mode => urlsafe}),
 
-    DataStr = base64:decode_to_string("F+o/o++B/a+r", standard),
-    DataStr = base64:decode_to_string("F-o_o--B_a-r", urlsafe),
-    {'EXIT', _} = catch base64:decode_to_string("F-o_o--B_a-r", standard),
-    {'EXIT', _} = catch base64:decode_to_string("F+o/o++B/a+r", urlsafe),
+    DataStr = base64:decode_to_string("F+o/o++B/a+r", #{mode => standard}),
+    DataStr = base64:decode_to_string("F-o_o--B_a-r", #{mode => urlsafe}),
+    {'EXIT', _} = catch base64:decode_to_string("F-o_o--B_a-r", #{mode => standard}),
+    {'EXIT', _} = catch base64:decode_to_string("F+o/o++B/a+r", #{mode => urlsafe}),
 
     ok.
+
 %%-------------------------------------------------------------------------
 %% OTP-5635: Some data doesn't pass through base64:decode/1 correctly.
 base64_otp_5635(Config) when is_list(Config) ->
@@ -210,26 +310,26 @@ mime_decode(Config) when is_list(Config) ->
 
 %% Test base64:mime_decode/2.
 mime_decode_modes(Config) when is_list(Config) ->
-    MimeDecode = fun (In, Mode) ->
-                                Out = base64:mime_decode(In, Mode),
-                                Out = base64:mime_decode(binary_to_list(In), Mode)
+    MimeDecode = fun (In, Options) ->
+                                Out = base64:mime_decode(In, Options),
+                                Out = base64:mime_decode(binary_to_list(In), Options)
                  end,
 
     %% The following all decode to the same data.
     Data = <<23, 234, 63, 163, 239, 129, 253, 175, 171>>,
-    Data = MimeDecode(<<"F+o/o++B/a+r">>, standard),
-    Data = MimeDecode(<<"F-o_o--B_a-r">>, urlsafe),
+    Data = MimeDecode(<<"F+o/o++B/a+r">>, #{mode => standard}),
+    Data = MimeDecode(<<"F-o_o--B_a-r">>, #{mode => urlsafe}),
 
     %% The following decodes to different data depending on mode.
     Base64 = <<"AB+C+D/E/FG-H-I_J_KL">>,
     %% In standard mode, "-" and "_" are invalid and thus ignored.
     %% The base64 string to be decoded is equivalent to "AB+C+D/E/FGHIJKL".
     <<0, 31, 130, 248, 63, 196, 252, 81, 135, 32, 146, 139>> =
-        MimeDecode(Base64, standard),
+        MimeDecode(Base64, #{mode => standard}),
     %% In urlsafe mode, "+" and "/" are invalid and thus ignored.
     %% The base64 string to be decoded is equivalent to "ABCDEFG-H-I_J_KL".
     <<0, 16, 131, 16, 81, 190, 31, 226, 63, 39, 242, 139>> =
-        MimeDecode(Base64, urlsafe),
+        MimeDecode(Base64, #{mode => urlsafe}),
 
     ok.
 
@@ -286,26 +386,26 @@ mime_decode_to_string(Config) when is_list(Config) ->
 
 %% Test base64:mime_decode_to_string/2.
 mime_decode_to_string_modes(Config) when is_list(Config) ->
-    MimeDecode = fun (In, Mode) ->
-                                Out = base64:mime_decode_to_string(In, Mode),
-                                Out = base64:mime_decode_to_string(binary_to_list(In), Mode)
+    MimeDecode = fun (In, Options) ->
+                                Out = base64:mime_decode_to_string(In, Options),
+                                Out = base64:mime_decode_to_string(binary_to_list(In), Options)
                  end,
 
     %% The following all decode to the same data.
     Data = [23, 234, 63, 163, 239, 129, 253, 175, 171],
-    Data = MimeDecode(<<"F+o/o++B/a+r">>, standard),
-    Data = MimeDecode(<<"F-o_o--B_a-r">>, urlsafe),
+    Data = MimeDecode(<<"F+o/o++B/a+r">>, #{mode => standard}),
+    Data = MimeDecode(<<"F-o_o--B_a-r">>, #{mode => urlsafe}),
 
     %% The following decodes to different data depending on mode.
     Base64 = <<"AB+C+D/E/FG-H-I_J_KL">>,
     %% In standard mode, "-" and "_" are invalid and thus ignored.
     %% The base64 string to be decoded is equivalent to "AB+C+D/E/FGHIJKL".
     [0, 31, 130, 248, 63, 196, 252, 81, 135, 32, 146, 139] =
-        MimeDecode(Base64, standard),
+        MimeDecode(Base64, #{mode => standard}),
     %% In urlsafe mode, "+" and "/" are invalid and thus ignored.
     %% The base64 string to be decoded is equivalent to "ABCDEFG-H-I_J_KL".
     [0, 16, 131, 16, 81, 190, 31, 226, 63, 39, 242, 139] =
-        MimeDecode(Base64, urlsafe),
+        MimeDecode(Base64, #{mode => urlsafe}),
 
     ok.
 

--- a/lib/stdlib/test/property_test/base64_prop.erl
+++ b/lib/stdlib/test/property_test/base64_prop.erl
@@ -70,8 +70,8 @@ prop_encode_2() ->
         {Str, Mode},
         {oneof([list(byte()), binary()]), mode()},
         begin
-            Enc = base64:encode(Str, Mode),
-            Dec = base64:decode(Enc, Mode),
+            Enc = base64:encode(Str, #{mode => Mode}),
+            Dec = base64:decode(Enc, #{mode => Mode}),
             is_b64_binary(Mode, Enc) andalso str_equals(Str, Dec)
         end
     ).
@@ -92,8 +92,8 @@ prop_encode_to_string_2() ->
         {Str, Mode},
         {oneof([list(byte()), binary()]), mode()},
         begin
-            Enc = base64:encode_to_string(Str, Mode),
-            Dec = base64:decode_to_string(Enc, Mode),
+            Enc = base64:encode_to_string(Str, #{mode => Mode}),
+            Dec = base64:decode_to_string(Enc, #{mode => Mode}),
             is_b64_string(Mode, Enc) andalso str_equals(Str, Dec)
         end
     ).
@@ -118,8 +118,8 @@ prop_decode_2() ->
             {wsped_b64(Mode), Mode}
         ),
         begin
-            Dec = base64:decode(WspedB64, Mode),
-            Enc = base64:encode(Dec, Mode),
+            Dec = base64:decode(WspedB64, #{mode => Mode}),
+            Enc = base64:encode(Dec, #{mode => Mode}),
             is_binary(Dec) andalso b64_equals(Mode, NormalizedB64, Enc)
         end
     ).
@@ -156,8 +156,8 @@ prop_decode_to_string_2() ->
             {wsped_b64(Mode), Mode}
         ),
         begin
-            Dec = base64:decode_to_string(WspedB64, Mode),
-            Enc = base64:encode(Dec, Mode),
+            Dec = base64:decode_to_string(WspedB64, #{mode => Mode}),
+            Enc = base64:encode(Dec, #{mode => Mode}),
             is_bytelist(Dec) andalso b64_equals(Mode, NormalizedB64, Enc)
         end
     ).
@@ -194,8 +194,8 @@ prop_mime_decode_2() ->
             {wsped_b64(Mode), Mode}
         ),
         begin
-            Dec = base64:mime_decode(NoisyB64, Mode),
-            Enc = base64:encode(Dec, Mode),
+            Dec = base64:mime_decode(NoisyB64, #{mode => Mode}),
+            Enc = base64:encode(Dec, #{mode => Mode}),
             is_binary(Dec) andalso b64_equals(Mode, NormalizedB64, Enc)
         end
     ).
@@ -226,8 +226,8 @@ prop_mime_decode_to_string_2() ->
             {wsped_b64(Mode), Mode}
         ),
         begin
-            Dec = base64:mime_decode_to_string(NoisyB64, Mode),
-            Enc = base64:encode(Dec, Mode),
+            Dec = base64:mime_decode_to_string(NoisyB64, #{mode => Mode}),
+            Enc = base64:encode(Dec, #{mode => Mode}),
             is_bytelist(Dec) andalso b64_equals(Mode, NormalizedB64, Enc)
         end
     ).
@@ -247,7 +247,7 @@ common_decode_noisy(ModeGen, Fn) ->
             {?SUCHTHAT({NormalizedB64, NoisyB64}, noisy_b64(Mode), NormalizedB64 =/= NoisyB64), Mode}
         ),
         try
-            Fn(NoisyB64, Mode)
+            Fn(NoisyB64, #{mode => Mode})
         of
             _ ->
                 false
@@ -280,7 +280,7 @@ common_decode_malformed(DataGen, ModeGen, Fn) ->
             )
         ),
         try
-            Fn(MalformedB64, Mode)
+            Fn(MalformedB64, #{mode => Mode})
         of
             _ ->
                 false


### PR DESCRIPTION
This extends base64 encoding and decoding routines to allow skipping emitting final = characters, or to accept encoded data with final = characters skipped. This format is common for some use-cases. Today, parsing it requires appending the missing = characters, which incurs an unnecessary copy of the input data, or re-implementing the entire routine.

This amends the interface in a backwards-incompatible way, since the last change wasn't released yet, so should have no expectation of backwards-compatibility.

Additionally, tests are slightly enhanced to cover more cases directly with simple examples.

If this change is accepted, I will provide documentation.