### PR TITLE
Remove the file_io_servers ETS table

### DIFF
--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -173,16 +173,9 @@ format_error(ErrorId) ->
       Pid :: pid().
 
 pid2name(Pid) when is_pid(Pid) ->
-    case whereis(?FILE_SERVER) of
-	undefined ->
-	    undefined;
-	_ ->
-	    case ets:lookup(?FILE_IO_SERVER_TABLE, Pid) of
-		[{_, Name} | _] ->
-		    {ok, Name};
-		_ ->
-		    undefined
-	    end
+    case file_request(Pid, pid2name) of
+        {ok, _} = Ok -> Ok;
+        _ -> undefined
     end.
 
 %%%-----------------------------------------------------------------

--- a/lib/kernel/src/file_io_server.erl
+++ b/lib/kernel/src/file_io_server.erl
@@ -26,7 +26,7 @@
 
 -export([count_and_find/3]).
 
--record(state, {handle,owner,mref,buf,read_mode,unic}).
+-record(state, {handle,owner,mref,name,buf,read_mode,unic}).
 
 -include("file_int.hrl").
 
@@ -80,8 +80,9 @@ do_start(Spawn, Owner, FileName, ModeList) ->
 				  Self ! {Ref, ok},
 				  server_loop(
 				    #state{handle    = Handle,
-					   owner     = Owner, 
-					   mref      = M, 
+					   owner     = Owner,
+					   mref      = M,
+					   name      = FileName,
 					   buf       = <<>>,
 					   read_mode = ReadMode,
 					   unic = UnicodeMode})
@@ -322,7 +323,10 @@ file_request({read_handle_info, Opts},
         Reply ->
             {reply,Reply,State}
     end;
-file_request(Unknown, 
+file_request(pid2name,
+             #state{name=Name}=State) ->
+    {reply,{ok,Name},State};
+file_request(Unknown,
 	     #state{}=State) ->
     Reason = {request, Unknown},
     {error,{error,Reason},State}.

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -3451,9 +3451,9 @@ pid2name(Config) when is_list(Config) ->
     %%
     {ok, Pid} = file:open(Name1, [write]),
     {ok, Name2} = file:pid2name(Pid),
-    undefined = file:pid2name(self()),
+    Dead = spawn(fun() -> ok end),
+    undefined = file:pid2name(Dead),
     ok = file:close(Pid),
-    ct:sleep(1000),
     false = is_process_alive(Pid),
     undefined = file:pid2name(Pid),
     ok.

--- a/lib/stdlib/test/error_logger_h_SUITE.erl
+++ b/lib/stdlib/test/error_logger_h_SUITE.erl
@@ -66,17 +66,17 @@ logfile(Config) ->
     analyse_events(Log, Ev, [AtNode], unlimited),
 
     %% Make sure that the file_io_server process has been stopped
-    [] = lists:filtermap(
-           fun(X) ->
-                   case {process_info(X, [current_function]),
-                         file:pid2name(X)} of
-                       {[{current_function, {file_io_server, _, _}}],
-                        {ok,P2N = Log}} ->
-                           {true, {X, P2N}};
-                       _ ->
-                           false
-                   end
-           end, processes()),
+    [] = lists:filtermap(fun(X) ->
+        case process_info(X, [current_function]) of
+            [{current_function, {file_io_server, _, _}}] ->
+                case file:pid2name(X) of
+                    {ok, Log} -> {true, {X, Log}};
+                    _ -> false
+                end;
+            _ ->
+                false
+        end
+    end, processes()),
 
     peer:stop(Peer),
 


### PR DESCRIPTION
~~Accessing a table by reference is [around 10% faster][1] on a quiet system with a lot of named tables since looking up the table name is relatively expensive. It's even worse in a system with a lot of ETS operations, since looking up a table involves locking, which can have high contention.~~

~~This doesn't seem to impact performance of file:open/2 in a measurable way on a quiet system, but it doesn't look detrimental either and logically should be saving some CPU.~~

This table was used to store Pids of files opened through the file server, however this data was never used by OTP itself. We can skip the overhead of storing this information.

[1]: https://gist.github.com/michalmuskala/5e7fc0031048f89f64b6cc4468d124a3