### PR TITLE
Add maps:iterator/2 with ~k and ~K format options for printing ordered maps.

### DIFF
--- a/erts/preloaded/src/erts_internal.erl
+++ b/erts/preloaded/src/erts_internal.erl
@@ -430,7 +430,7 @@ map_hashmap_children(_M) ->
 
 %% return the next assoc in the iterator and a new iterator
 -spec map_next(I, M, A) -> {K,V,NI} | list() when
-      I :: non_neg_integer(),
+      I :: non_neg_integer() | list(),
       M :: map(),
       K :: term(),
       V :: term(),

--- a/lib/stdlib/doc/src/io.xml
+++ b/lib/stdlib/doc/src/io.xml
@@ -177,9 +177,43 @@ ok</pre>
         <item>
           <p><c>Mod</c> is the control sequence modifier. This is
             one or more characters that change the interpretation of
-            <c>Data</c>. The current modifiers are <c>t</c>, for Unicode
-            translation, and <c>l</c>, for stopping <c>p</c> and <c>P</c>
-            from detecting printable characters.</p>
+            <c>Data</c>.</p>
+            <p>The current modifiers are:</p>
+            <taglist>
+              <tag><c>t</c></tag>
+              <item>
+                <p>For Unicode translation.</p>
+              </item>
+              <tag><c>l</c></tag>
+              <item>
+                <p>For stopping <c>p</c> and <c>P</c> from detecting
+                  printable characters.</p>
+              </item>
+              <tag><c>k</c></tag>
+              <item>
+                <p>For use with <c>p</c>, <c>P</c>, <c>w</c>, and <c>W</c>
+                  to format maps in map-key <c>ordered</c> order (see
+                  <seetype marker="maps#iterator_order">maps:iterator_order()</seetype>).</p>
+              </item>
+              <tag><c>K</c></tag>
+              <item>
+                <p>Similar to <c>k</c>, for formatting maps in map-key order,
+                  but takes an extra argument that specifies the
+                  <seetype marker="maps#iterator_order">maps:iterator_order()</seetype>.</p>
+                <p>For example:</p>
+                <pre>
+> <input>M = #{ a => 1, b => 2 }.</input>
+#{a => 1,b => 2}
+> <input><![CDATA[io:format("~Kp~n", [fun(A, B) -> B =< A end, M]).]]></input>
+#{b => 2,a => 1}
+ok</pre>
+              </item>
+            </taglist>
+            <!-- <list type="bulleted">
+              <item><p><c>t</c>, for Unicode translation.</p></item>
+              <item><p><c>l</c>, for stopping <c>p</c> and <c>P</c>
+                from detecting printable characters.</p></item>
+            </list> -->
         </item>
       </list>
         <p>If <c>F</c>, <c>P</c>, or <c>Pad</c> is a <c>*</c> character,

--- a/lib/stdlib/doc/src/io_lib.xml
+++ b/lib/stdlib/doc/src/io_lib.xml
@@ -92,6 +92,10 @@
         <item><p><c>strings</c> is set to <c>false</c> if modifier
           <c>l</c> is present.</p>
         </item>
+        <item><p><c>maps_order</c> is set to <c>undefined</c> by default,
+          <c>ordered</c> if modifier <c>k</c> is present, or <c>CmpFun</c>
+          if modifier <c>K</c> is present.</p>
+        </item>
       </list>
       </desc>
     </datatype>

--- a/lib/stdlib/doc/src/maps.xml
+++ b/lib/stdlib/doc/src/maps.xml
@@ -582,10 +582,12 @@ error</code>
       <fsummary></fsummary>
       <desc>
         <p>Returns a list of pairs representing the key-value associations of
-          <c><anno>Map</anno></c>, where the pairs
+          <c><anno>MapOrIterator</anno></c>, where the pairs
           <c>[{K1,V1}, ..., {Kn,Vn}]</c> are returned in arbitrary order.</p>
         <p>The call fails with a <c>{badmap,Map}</c> exception if
-          <c><anno>Map</anno></c> is not a map.</p>
+        <c><anno>MapOrIterator</anno></c> is not a map or an iterator obtained
+        by a call to <seemfa marker="#iterator/1">iterator/1</seemfa> or
+        <seemfa marker="#iterator/2">iterator/2</seemfa>.</p>
         <p><em>Example:</em></p>
         <code type="none">
 > Map = #{42 => value_three,1337 => "value two","a" => 1},

--- a/lib/stdlib/doc/src/maps.xml
+++ b/lib/stdlib/doc/src/maps.xml
@@ -42,16 +42,36 @@
       <desc>
         <p>An iterator representing the associations in a map with keys of type
           <c><anno>Key</anno></c> and values of type <c><anno>Value</anno></c>.</p>
-        <p>Created using <seemfa marker="#iterator/1"><c>maps:iterator/1</c></seemfa>.</p>
+        <p>Created using <seemfa marker="#iterator/1"><c>maps:iterator/1</c></seemfa> or
+          <seemfa marker="#iterator/2"><c>maps:iterator/2</c></seemfa>.</p>
         <p>Consumed by <seemfa marker="#next/1"><c>maps:next/1</c></seemfa>,
           <seemfa marker="#filter/2"><c>maps:filter/2</c></seemfa>,
-          <seemfa marker="#fold/3"><c>maps:fold/3</c></seemfa> and
-          <seemfa marker="#map/2"><c>maps:map/2</c></seemfa>.</p>
+          <seemfa marker="#fold/3"><c>maps:fold/3</c></seemfa>,
+          <seemfa marker="#map/2"><c>maps:map/2</c></seemfa>, and
+          <seemfa marker="#to_list/1"><c>maps:to_list/1</c></seemfa>.</p>
       </desc>
     </datatype>
 
     <datatype>
       <name name="iterator" n_vars="0"/>
+    </datatype>
+
+    <datatype>
+      <name name="iterator_order" n_vars="1"/>
+      <desc>
+        <p>Key-based iterator order option that can be one of <c>undefined</c>
+          (default for <seemfa marker="#iterator/1"><c>maps:iterator/1</c></seemfa>),
+          <c>ordered</c> (sorted in map-key order), or a custom sorting function.</p>
+        <p>Used by <seemfa marker="#iterator/2"><c>maps:iterator/2</c></seemfa>.</p>
+        <p>The
+        <seeguide
+            marker="system/reference_manual:expressions#term-comparisons">
+          Expressions section</seeguide> contains descriptions of how terms are ordered.</p>
+      </desc>
+    </datatype>
+
+    <datatype>
+      <name name="iterator_order" n_vars="0"/>
     </datatype>
   </datatypes>
 
@@ -369,6 +389,45 @@ none</code>
     </func>
 
     <func>
+      <name name="iterator" arity="2" since="OTP 26.0"/>
+      <fsummary>Create a map iterator.</fsummary>
+      <desc>
+        <p>Returns a map iterator <c><anno>Iterator</anno></c> that can
+          be used by <seemfa marker="#next/1"><c>maps:next/1</c></seemfa>
+          to traverse the key-value associations in a map sorted by key using
+          the given <c><anno>Order</anno></c>.</p>
+        <p>The call fails with a <c>{badmap,Map}</c> exception if
+          <c><anno>Map</anno></c> is not a map or if <c><anno>Order</anno></c>
+          is invalid.</p>
+        <p><em>Example (when </em><c><anno>Order</anno></c><em> is </em><c>ordered</c><em>):</em></p>
+        <code type="none">
+> M = #{ a => 1, b => 2 }.
+#{a => 1,b => 2}
+> OrdI = maps:iterator(M, ordered), ok.
+ok
+> {K1, V1, OrdI2} = maps:next(OrdI), {K1, V1}.
+{a,1}
+> {K2, V2, OrdI3} = maps:next(OrdI2),{K2, V2}.
+{b,2}
+> maps:next(OrdI3).
+none</code>
+        <p><em>Example (when </em><c><anno>Order</anno></c><em> is a custom sorting function):</em></p>
+        <code type="none"><![CDATA[
+> M = #{ a => 1, b => 2 }.
+#{a => 1,b => 2}
+> RevI = maps:iterator(M, fun(A, B) -> B =< A end), ok.
+ok
+> {K2, V2, RevI2} = maps:next(RevI), {K2, V2}.
+{b,2}
+> {K1, V1, RevI3} = maps:next(RevI2),{K1, V1}.
+{a,1}
+> maps:next(RevI3).
+none
+     ]]></code>
+      </desc>
+    </func>
+
+    <func>
       <name name="keys" arity="1" since="OTP 17.0"/>
       <fsummary></fsummary>
       <desc>
@@ -593,6 +652,13 @@ error</code>
 > Map = #{42 => value_three,1337 => "value two","a" => 1},
   maps:to_list(Map).
 [{42,value_three},{1337,"value two"},{"a",1}]</code>
+        <p><em>Example (using </em><seemfa marker="#iterator/2">iterator/2</seemfa><em>):</em></p>
+<code type="none"><![CDATA[
+> Map = #{ z => 1, y => 2, x => 3 }.
+#{x => 3,y => 2,z => 1}
+> maps:to_list(maps:iterator(Map, ordered)).
+[{x,3},{y,2},{z,1}]
+     ]]></code>
       </desc>
     </func>
 

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -239,8 +239,10 @@ format_maps_error(intersect_with, [Combiner, Map1, Map2]) ->
     [must_be_fun(Combiner, 3), must_be_map(Map1), must_be_map(Map2)];
 format_maps_error(is_key, _Args) ->
     [[], not_map];
-format_maps_error(iterator, _Args) ->
-    [not_map];
+format_maps_error(iterator, [Map]) ->
+    [must_be_map(Map)];
+format_maps_error(iterator, [Map, Order]) ->
+    [must_be_map(Map), must_be_map_iterator_order(Order)];
 format_maps_error(keys, _Args) ->
     [not_map];
 format_maps_error(map, [Pred, Map]) ->
@@ -249,10 +251,10 @@ format_maps_error(merge, [Map1, Map2]) ->
     [must_be_map(Map1), must_be_map(Map2)];
 format_maps_error(merge_with, [Combiner, Map1, Map2]) ->
     [must_be_fun(Combiner, 3), must_be_map(Map1), must_be_map(Map2)];
-format_maps_error(put, _Args) ->
-    [[], [], not_map];
 format_maps_error(next, _Args) ->
     [bad_iterator];
+format_maps_error(put, _Args) ->
+    [[], [], not_map];
 format_maps_error(remove, _Args) ->
     [[], not_map];
 format_maps_error(size, _Args) ->
@@ -260,7 +262,7 @@ format_maps_error(size, _Args) ->
 format_maps_error(take, _Args) ->
     [[], not_map];
 format_maps_error(to_list, _Args) ->
-    [not_map];
+    [not_map_or_iterator];
 format_maps_error(update, _Args) ->
     [[], [], not_map];
 format_maps_error(update_with, [_Key, Fun, Map]) ->
@@ -968,6 +970,15 @@ must_be_list(_) ->
 must_be_map(#{}) -> [];
 must_be_map(_) -> not_map.
 
+must_be_map_iterator_order(undefined) ->
+    [];
+must_be_map_iterator_order(ordered) ->
+    [];
+must_be_map_iterator_order(CmpFun) when is_function(CmpFun, 2) ->
+    [];
+must_be_map_iterator_order(_) ->
+    not_map_iterator_order.
+
 must_be_map_or_iter(Map) when is_map(Map) ->
     [];
 must_be_map_or_iter(Iter) ->
@@ -1094,6 +1105,8 @@ expand_error(not_integer) ->
     <<"not an integer">>;
 expand_error(not_list) ->
     <<"not a list">>;
+expand_error(not_map_iterator_order) ->
+    <<"not 'undefined', 'ordered', or a fun that takes two arguments">>;
 expand_error(not_map_or_iterator) ->
     <<"not a map or an iterator">>;
 expand_error(not_number) ->

--- a/lib/stdlib/src/io_lib_pretty.erl
+++ b/lib/stdlib/src/io_lib_pretty.erl
@@ -27,7 +27,7 @@
 -export([print/1,print/2,print/3,print/4,print/5,print/6]).
 
 %% To be used by io_lib only.
--export([intermediate/6, write/1]).
+-export([intermediate/7, write/1]).
 
 %%%
 %%% Exported functions
@@ -64,7 +64,8 @@ print(Term) ->
                 | {'line_length', line_length()}
                 | {'line_max_chars', line_max_chars()}
                 | {'record_print_fun', rec_print_fun()}
-                | {'strings', boolean()}.
+                | {'strings', boolean()}
+                | {'maps_order', maps:iterator_order()}.
 -type options() :: [option()].
 
 -spec print(term(), rec_print_fun()) -> chars();
@@ -79,7 +80,8 @@ print(Term, Options) when is_list(Options) ->
     RecDefFun = get_option(record_print_fun, Options, no_fun),
     Encoding = get_option(encoding, Options, epp:default_encoding()),
     Strings = get_option(strings, Options, true),
-    print(Term, Col, Ll, D, M, T, RecDefFun, Encoding, Strings);
+    MapsOrder = get_option(maps_order, Options, undefined),
+    print(Term, Col, Ll, D, M, T, RecDefFun, Encoding, Strings, MapsOrder);
 print(Term, RecDefFun) ->
     print(Term, -1, RecDefFun).
 
@@ -91,7 +93,7 @@ print(Term, Depth, RecDefFun) ->
 -spec print(term(), column(), line_length(), depth()) -> chars().
 
 print(Term, Col, Ll, D) ->
-    print(Term, Col, Ll, D, _M=-1, _T=-1, no_fun, latin1, true).
+    print(Term, Col, Ll, D, _M=-1, _T=-1, no_fun, latin1, true, undefined).
 
 -spec print(term(), column(), line_length(), depth(), rec_print_fun()) ->
                    chars().
@@ -102,7 +104,7 @@ print(Term, Col, Ll, D, RecDefFun) ->
             rec_print_fun()) -> chars().
 
 print(Term, Col, Ll, D, M, RecDefFun) ->
-    print(Term, Col, Ll, D, M, _T=-1, RecDefFun, latin1, true).
+    print(Term, Col, Ll, D, M, _T=-1, RecDefFun, latin1, true, undefined).
 
 %% D = Depth, default -1 (infinite), or LINEMAX=30 when printing from shell
 %% T = chars_limit, that is, maximal number of characters, default -1
@@ -111,22 +113,22 @@ print(Term, Col, Ll, D, M, RecDefFun) ->
 %% Col = current column, default 1
 %% Ll = line length/~p field width, default 80
 %% M = CHAR_MAX (-1 if no max, 60 when printing from shell)
-print(_, _, _, 0, _M, _T, _RF, _Enc, _Str) -> "...";
-print(_, _, _, _D, _M, 0, _RF, _Enc, _Str) -> "...";
-print(Term, Col, Ll, D, M, T, RecDefFun, Enc, Str) when Col =< 0 ->
+print(_, _, _, 0, _M, _T, _RF, _Enc, _Str, _Ord) -> "...";
+print(_, _, _, _D, _M, 0, _RF, _Enc, _Str, _Ord) -> "...";
+print(Term, Col, Ll, D, M, T, RecDefFun, Enc, Str, Ord) when Col =< 0 ->
     %% ensure Col is at least 1
-    print(Term, 1, Ll, D, M, T, RecDefFun, Enc, Str);
-print(Atom, _Col, _Ll, _D, _M, _T, _RF, Enc, _Str) when is_atom(Atom) ->
+    print(Term, 1, Ll, D, M, T, RecDefFun, Enc, Str, Ord);
+print(Atom, _Col, _Ll, _D, _M, _T, _RF, Enc, _Str, _Ord) when is_atom(Atom) ->
     write_atom(Atom, Enc);
-print(Term, Col, Ll, D, M0, T, RecDefFun, Enc, Str) when is_tuple(Term);
+print(Term, Col, Ll, D, M0, T, RecDefFun, Enc, Str, Ord) when is_tuple(Term);
                                                          is_list(Term);
                                                          is_map(Term);
                                                          is_bitstring(Term) ->
     %% preprocess and compute total number of chars
     {_, Len, _Dots, _} = If =
         case T < 0 of
-            true -> print_length(Term, D, T, RecDefFun, Enc, Str);
-            false -> intermediate(Term, D, T, RecDefFun, Enc, Str)
+            true -> print_length(Term, D, T, RecDefFun, Enc, Str, Ord);
+            false -> intermediate(Term, D, T, RecDefFun, Enc, Str, Ord)
         end,
     %% use Len as CHAR_MAX if M0 = -1
     M = max_cs(M0, Len),
@@ -143,7 +145,7 @@ print(Term, Col, Ll, D, M0, T, RecDefFun, Enc, Str) when is_tuple(Term);
                               1),
             pp(If, Col, Ll, M, TInd, indent(Col), 0, 0)
     end;
-print(Term, _Col, _Ll, _D, _M, _T, _RF, _Enc, _Str) ->
+print(Term, _Col, _Ll, _D, _M, _T, _RF, _Enc, _Str, _Ord) ->
     %% atomic data types (bignums, atoms, ...) are never truncated
     io_lib:write(Term).
 
@@ -442,19 +444,19 @@ write_tail(E, S) ->
         }.
 
 -spec intermediate(term(), depth(), pos_integer(), rec_print_fun(),
-                   encoding(), boolean()) -> intermediate_format().
+                   encoding(), boolean(), boolean()) -> intermediate_format().
 
-intermediate(Term, D, T, RF, Enc, Str) when T > 0 ->
+intermediate(Term, D, T, RF, Enc, Str, Ord) when T > 0 ->
     D0 = 1,
-    If = print_length(Term, D0, T, RF, Enc, Str),
+    If = print_length(Term, D0, T, RF, Enc, Str, Ord),
     case If of
         {_, Len, Dots, _} when Dots =:= 0; Len > T; D =:= 1 ->
             If;
         {_, Len, _, _} ->
-            find_upper(If, Term, T, D0, 2, D, RF, Enc, Str, Len)
+            find_upper(If, Term, T, D0, 2, D, RF, Enc, Str, Ord, Len)
     end.
 
-find_upper(Lower, Term, T, Dl, Dd, D, RF, Enc, Str, LastLen) ->
+find_upper(Lower, Term, T, Dl, Dd, D, RF, Enc, Str, Ord, LastLen) ->
     Dd2 = Dd * 2,
     D1 = case D < 0 of
              true -> Dl + Dd2;
@@ -468,14 +470,14 @@ find_upper(Lower, Term, T, Dl, Dd, D, RF, Enc, Str, LastLen) ->
             %% Cannot happen if print_length() is free of bugs.
             If;
         {_, Len, _, _} when Len =< T, D1 < D orelse D < 0 ->
-	    find_upper(If, Term, T, D1, Dd2, D, RF, Enc, Str, Len);
+	    find_upper(If, Term, T, D1, Dd2, D, RF, Enc, Str, Ord, Len);
         _ ->
-	    search_depth(Lower, If, Term, T, Dl, D1, RF, Enc, Str)
+	    search_depth(Lower, If, Term, T, Dl, D1, RF, Enc, Str, Ord)
     end.
 
 %% Lower has NumOfDots > 0 and Len =< T.
 %% Upper has NumOfDots > 0 and Len > T.
-search_depth(Lower, Upper, _Term, T, Dl, Du, _RF, _Enc, _Str)
+search_depth(Lower, Upper, _Term, T, Dl, Du, _RF, _Enc, _Str, _Ord)
         when Du - Dl =:= 1 ->
     %% The returned intermediate format has Len >= T.
     case Lower of
@@ -484,7 +486,7 @@ search_depth(Lower, Upper, _Term, T, Dl, Du, _RF, _Enc, _Str)
         _ ->
             Upper
     end;
-search_depth(Lower, Upper, Term, T, Dl, Du, RF, Enc, Str) ->
+search_depth(Lower, Upper, Term, T, Dl, Du, RF, Enc, Str, Ord) ->
     D1 = (Dl  + Du) div 2,
     If = expand(Lower, T, D1 - Dl),
     case If of
@@ -493,9 +495,9 @@ search_depth(Lower, Upper, Term, T, Dl, Du, RF, Enc, Str) ->
             %% This is a bit expensive since the work to
             %% crate Upper is wasted. It is the price
             %% to pay to get a more balanced output.
-            search_depth(Lower, If, Term, T, Dl, D1, RF, Enc, Str);
+            search_depth(Lower, If, Term, T, Dl, D1, RF, Enc, Str, Ord);
         _ ->
-            search_depth(If, Upper, Term, T, D1, Du, RF, Enc, Str)
+            search_depth(If, Upper, Term, T, D1, Du, RF, Enc, Str, Ord)
     end.
 
 %% The depth (D) is used for extracting and counting the characters to
@@ -504,16 +506,16 @@ search_depth(Lower, Upper, Term, T, Dl, Du, RF, Enc, Str) ->
 %% counted but need to be added later.
 
 %% D =/= 0
-print_length([], _D, _T, _RF, _Enc, _Str) ->
+print_length([], _D, _T, _RF, _Enc, _Str, _Ord) ->
     {"[]", 2, 0, no_more};
-print_length({}, _D, _T, _RF, _Enc, _Str) ->
+print_length({}, _D, _T, _RF, _Enc, _Str, _Ord) ->
     {"{}", 2, 0, no_more};
-print_length(#{}=M, _D, _T, _RF, _Enc, _Str) when map_size(M) =:= 0 ->
+print_length(#{}=M, _D, _T, _RF, _Enc, _Str, _Ord) when map_size(M) =:= 0 ->
     {"#{}", 3, 0, no_more};
-print_length(Atom, _D, _T, _RF, Enc, _Str) when is_atom(Atom) ->
+print_length(Atom, _D, _T, _RF, Enc, _Str, _Ord) when is_atom(Atom) ->
     S = write_atom(Atom, Enc),
     {S, io_lib:chars_length(S), 0, no_more};
-print_length(List, D, T, RF, Enc, Str) when is_list(List) ->
+print_length(List, D, T, RF, Enc, Str, Ord) when is_list(List) ->
     %% only flat lists are "printable"
     case Str andalso printable_list(List, D, T, Enc) of
         true ->
@@ -527,37 +529,37 @@ print_length(List, D, T, RF, Enc, Str) when is_list(List) ->
             %% does not make Prefix longer.
             {[S | "..."], 3 + io_lib:chars_length(S), 0, no_more};
         false ->
-            case print_length_list(List, D, T, RF, Enc, Str) of
+            case print_length_list(List, D, T, RF, Enc, Str, Ord) of
                 {What, Len, Dots, _More} when Dots > 0 ->
                     More = fun(T1, Dd) ->
-                                   ?FUNCTION_NAME(List, D+Dd, T1, RF, Enc, Str)
+                                   ?FUNCTION_NAME(List, D+Dd, T1, RF, Enc, Str, Ord)
                            end,
                     {What, Len, Dots, More};
                 If ->
                     If
             end
     end;
-print_length(Fun, _D, _T, _RF, _Enc, _Str) when is_function(Fun) ->
+print_length(Fun, _D, _T, _RF, _Enc, _Str, _Ord) when is_function(Fun) ->
     S = io_lib:write(Fun),
     {S, iolist_size(S), 0, no_more};
-print_length(R, D, T, RF, Enc, Str) when is_atom(element(1, R)),
-                                         is_function(RF) ->
+print_length(R, D, T, RF, Enc, Str, Ord) when is_atom(element(1, R)),
+                                              is_function(RF) ->
     case RF(element(1, R), tuple_size(R) - 1) of
         no -> 
-            print_length_tuple(R, D, T, RF, Enc, Str);
+            print_length_tuple(R, D, T, RF, Enc, Str, Ord);
         RDefs ->
-            print_length_record(R, D, T, RF, RDefs, Enc, Str)
+            print_length_record(R, D, T, RF, RDefs, Enc, Str, Ord)
     end;
-print_length(Tuple, D, T, RF, Enc, Str) when is_tuple(Tuple) ->
-    print_length_tuple(Tuple, D, T, RF, Enc, Str);
-print_length(Map, D, T, RF, Enc, Str) when is_map(Map) ->
-    print_length_map(Map, D, T, RF, Enc, Str);
-print_length(<<>>, _D, _T, _RF, _Enc, _Str) ->
+print_length(Tuple, D, T, RF, Enc, Str, Ord) when is_tuple(Tuple) ->
+    print_length_tuple(Tuple, D, T, RF, Enc, Str, Ord);
+print_length(Map, D, T, RF, Enc, Str, Ord) when is_map(Map) ->
+    print_length_map(Map, D, T, RF, Enc, Str, Ord);
+print_length(<<>>, _D, _T, _RF, _Enc, _Str, _Ord) ->
     {"<<>>", 4, 0, no_more};
-print_length(<<_/bitstring>> = Bin, 1, _T, RF, Enc, Str) ->
-    More = fun(T1, Dd) -> ?FUNCTION_NAME(Bin, 1+Dd, T1, RF, Enc, Str) end,
+print_length(<<_/bitstring>> = Bin, 1, _T, RF, Enc, Str, Ord) ->
+    More = fun(T1, Dd) -> ?FUNCTION_NAME(Bin, 1+Dd, T1, RF, Enc, Str, Ord) end,
     {"<<...>>", 7, 3, More};
-print_length(<<_/bitstring>> = Bin, D, T, RF, Enc, Str) ->
+print_length(<<_/bitstring>> = Bin, D, T, RF, Enc, Str, Ord) ->
     D1 = D - 1,
     case
         Str andalso
@@ -573,13 +575,13 @@ print_length(<<_/bitstring>> = Bin, D, T, RF, Enc, Str) ->
         {true, true, Prefix} ->
             S = io_lib:write_string(Prefix, $"), %"
             More = fun(T1, Dd) ->
-                           ?FUNCTION_NAME(Bin, D+Dd, T1, RF, Enc, Str)
+                           ?FUNCTION_NAME(Bin, D+Dd, T1, RF, Enc, Str, Ord)
                    end,
             {[$<,$<,S|"...>>"], 7 + length(S), 3, More};
         {false, true, Prefix} ->
             S = io_lib:write_string(Prefix, $"), %"
             More = fun(T1, Dd) ->
-                           ?FUNCTION_NAME(Bin, D+Dd, T1, RF, Enc, Str)
+                           ?FUNCTION_NAME(Bin, D+Dd, T1, RF, Enc, Str, Ord)
                    end,
             {[$<,$<,S|"/utf8...>>"], 12 + io_lib:chars_length(S), 3, More};
         false ->
@@ -588,135 +590,135 @@ print_length(<<_/bitstring>> = Bin, D, T, RF, Enc, Str) ->
                     {{bin, S}, iolist_size(S), 0, no_more};
                 {S, _Rest} ->
                     More = fun(T1, Dd) ->
-                                   ?FUNCTION_NAME(Bin, D+Dd, T1, RF, Enc, Str)
+                                   ?FUNCTION_NAME(Bin, D+Dd, T1, RF, Enc, Str, Ord)
                            end,
                     {{bin, S}, iolist_size(S), 3, More}
             end
     end;    
-print_length(Term, _D, _T, _RF, _Enc, _Str) ->
+print_length(Term, _D, _T, _RF, _Enc, _Str, _Ord) ->
     S = io_lib:write(Term),
     %% S can contain unicode, so iolist_size(S) cannot be used here
     {S, io_lib:chars_length(S), 0, no_more}.
 
-print_length_map(Map, 1, _T, RF, Enc, Str) ->
-    More = fun(T1, Dd) -> ?FUNCTION_NAME(Map, 1+Dd, T1, RF, Enc, Str) end,
+print_length_map(Map, 1, _T, RF, Enc, Str, Ord) ->
+    More = fun(T1, Dd) -> ?FUNCTION_NAME(Map, 1+Dd, T1, RF, Enc, Str, Ord) end,
     {"#{...}", 6, 3, More};
-print_length_map(Map, D, T, RF, Enc, Str) when is_map(Map) ->
-    Next = maps:next(maps:iterator(Map)),
-    PairsS = print_length_map_pairs(Next, D, D - 1, tsub(T, 3), RF, Enc, Str),
+print_length_map(Map, D, T, RF, Enc, Str, Ord) when is_map(Map) ->
+    Next = maps:next(maps:iterator(Map, Ord)),
+    PairsS = print_length_map_pairs(Next, D, D - 1, tsub(T, 3), RF, Enc, Str, Ord),
     {Len, Dots} = list_length(PairsS, 3, 0),
     {{map, PairsS}, Len, Dots, no_more}.
 
-print_length_map_pairs(none, _D, _D0, _T, _RF, _Enc, _Str) ->
+print_length_map_pairs(none, _D, _D0, _T, _RF, _Enc, _Str, _Ord) ->
     [];
-print_length_map_pairs(Term, D, D0, T, RF, Enc, Str) when D =:= 1; T =:= 0->
+print_length_map_pairs(Term, D, D0, T, RF, Enc, Str, Ord) when D =:= 1; T =:= 0->
     More = fun(T1, Dd) ->
-                   ?FUNCTION_NAME(Term, D+Dd, D0, T1, RF, Enc, Str)
+                   ?FUNCTION_NAME(Term, D+Dd, D0, T1, RF, Enc, Str, Ord)
            end,
     {dots, 3, 3, More};
-print_length_map_pairs({K, V, Iter}, D, D0, T, RF, Enc, Str) ->
+print_length_map_pairs({K, V, Iter}, D, D0, T, RF, Enc, Str, Ord) ->
     Next = maps:next(Iter),
     T1 = case Next =:= none of
              false -> tsub(T, 1);
              true -> T
          end,
-    Pair1 = print_length_map_pair(K, V, D0, T1, RF, Enc, Str),
+    Pair1 = print_length_map_pair(K, V, D0, T1, RF, Enc, Str, Ord),
     {_, Len1, _, _} = Pair1,
     [Pair1 |
-     print_length_map_pairs(Next, D - 1, D0, tsub(T1, Len1), RF, Enc, Str)].
+     print_length_map_pairs(Next, D - 1, D0, tsub(T1, Len1), RF, Enc, Str, Ord)].
 
-print_length_map_pair(K, V, D, T, RF, Enc, Str) ->
-    {_, KL, KD, _} = P1 = print_length(K, D, T, RF, Enc, Str),
+print_length_map_pair(K, V, D, T, RF, Enc, Str, Ord) ->
+    {_, KL, KD, _} = P1 = print_length(K, D, T, RF, Enc, Str, Ord),
     KL1 = KL + 4,
-    {_, VL, VD, _} = P2 = print_length(V, D, tsub(T, KL1), RF, Enc, Str),
+    {_, VL, VD, _} = P2 = print_length(V, D, tsub(T, KL1), RF, Enc, Str, Ord),
     {{map_pair, P1, P2}, KL1 + VL, KD + VD, no_more}.
 
-print_length_tuple(Tuple, 1, _T, RF, Enc, Str) ->
-    More = fun(T1, Dd) -> ?FUNCTION_NAME(Tuple, 1+Dd, T1, RF, Enc, Str) end,
+print_length_tuple(Tuple, 1, _T, RF, Enc, Str, Ord) ->
+    More = fun(T1, Dd) -> ?FUNCTION_NAME(Tuple, 1+Dd, T1, RF, Enc, Str, Ord) end,
     {"{...}", 5, 3, More};
-print_length_tuple(Tuple, D, T, RF, Enc, Str) ->
-    L = print_length_tuple1(Tuple, 1, D, tsub(T, 2), RF, Enc, Str),
+print_length_tuple(Tuple, D, T, RF, Enc, Str, Ord) ->
+    L = print_length_tuple1(Tuple, 1, D, tsub(T, 2), RF, Enc, Str, Ord),
     IsTagged = is_atom(element(1, Tuple)) and (tuple_size(Tuple) > 1),
     {Len, Dots} = list_length(L, 2, 0),
     {{tuple,IsTagged,L}, Len, Dots, no_more}.
 
-print_length_tuple1(Tuple, I, _D, _T, _RF, _Enc, _Str)
+print_length_tuple1(Tuple, I, _D, _T, _RF, _Enc, _Str, _Ord)
              when I > tuple_size(Tuple) ->
     [];
-print_length_tuple1(Tuple, I, D, T, RF, Enc, Str) when D =:= 1; T =:= 0->
-    More = fun(T1, Dd) -> ?FUNCTION_NAME(Tuple, I, D+Dd, T1, RF, Enc, Str) end,
+print_length_tuple1(Tuple, I, D, T, RF, Enc, Str, Ord) when D =:= 1; T =:= 0->
+    More = fun(T1, Dd) -> ?FUNCTION_NAME(Tuple, I, D+Dd, T1, RF, Enc, Str, Ord) end,
     {dots, 3, 3, More};
-print_length_tuple1(Tuple, I, D, T, RF, Enc, Str) ->
+print_length_tuple1(Tuple, I, D, T, RF, Enc, Str, Ord) ->
     E = element(I, Tuple),
     T1 = case I =:= tuple_size(Tuple) of
              false -> tsub(T, 1);
              true -> T
          end,
-    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T1, RF, Enc, Str),
+    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T1, RF, Enc, Str, Ord),
     T2 = tsub(T1, Len1),
-    [Elem1 | print_length_tuple1(Tuple, I + 1, D - 1, T2, RF, Enc, Str)].
+    [Elem1 | print_length_tuple1(Tuple, I + 1, D - 1, T2, RF, Enc, Str, Ord)].
 
-print_length_record(Tuple, 1, _T, RF, RDefs, Enc, Str) ->
+print_length_record(Tuple, 1, _T, RF, RDefs, Enc, Str, Ord) ->
     More = fun(T1, Dd) ->
-                   ?FUNCTION_NAME(Tuple, 1+Dd, T1, RF, RDefs, Enc, Str)
+                   ?FUNCTION_NAME(Tuple, 1+Dd, T1, RF, RDefs, Enc, Str, Ord)
            end,
     {"{...}", 5, 3, More};
-print_length_record(Tuple, D, T, RF, RDefs, Enc, Str) ->
+print_length_record(Tuple, D, T, RF, RDefs, Enc, Str, Ord) ->
     Name = [$# | write_atom(element(1, Tuple), Enc)],
     NameL = io_lib:chars_length(Name),
     T1 = tsub(T, NameL+2),
-    L = print_length_fields(RDefs, D - 1, T1, Tuple, 2, RF, Enc, Str),
+    L = print_length_fields(RDefs, D - 1, T1, Tuple, 2, RF, Enc, Str, Ord),
     {Len, Dots} = list_length(L, NameL + 2, 0),
     {{record, [{Name,NameL} | L]}, Len, Dots, no_more}.
 
-print_length_fields([], _D, _T, Tuple, I, _RF, _Enc, _Str)
+print_length_fields([], _D, _T, Tuple, I, _RF, _Enc, _Str, _Ord)
                 when I > tuple_size(Tuple) ->
     [];
-print_length_fields(Term, D, T, Tuple, I, RF, Enc, Str)
+print_length_fields(Term, D, T, Tuple, I, RF, Enc, Str, Ord)
                 when D =:= 1; T =:= 0 ->
     More = fun(T1, Dd) ->
-                   ?FUNCTION_NAME(Term, D+Dd, T1, Tuple, I, RF, Enc, Str)
+                   ?FUNCTION_NAME(Term, D+Dd, T1, Tuple, I, RF, Enc, Str, Ord)
            end,
     {dots, 3, 3, More};
-print_length_fields([Def | Defs], D, T, Tuple, I, RF, Enc, Str) ->
+print_length_fields([Def | Defs], D, T, Tuple, I, RF, Enc, Str, Ord) ->
     E = element(I, Tuple),
     T1 = case I =:= tuple_size(Tuple) of
              false -> tsub(T, 1);
              true -> T
          end,
-    Field1 = print_length_field(Def, D - 1, T1, E, RF, Enc, Str),
+    Field1 = print_length_field(Def, D - 1, T1, E, RF, Enc, Str, Ord),
     {_, Len1, _, _} = Field1,
     T2 = tsub(T1, Len1),
     [Field1 |
-     print_length_fields(Defs, D - 1, T2, Tuple, I + 1, RF, Enc, Str)].
+     print_length_fields(Defs, D - 1, T2, Tuple, I + 1, RF, Enc, Str, Ord)].
 
-print_length_field(Def, D, T, E, RF, Enc, Str) ->
+print_length_field(Def, D, T, E, RF, Enc, Str, Ord) ->
     Name = write_atom(Def, Enc),
     NameL = io_lib:chars_length(Name) + 3,
     {_, Len, Dots, _} =
-        Field = print_length(E, D, tsub(T, NameL), RF, Enc, Str),
+        Field = print_length(E, D, tsub(T, NameL), RF, Enc, Str, Ord),
     {{field, Name, NameL, Field}, NameL + Len, Dots, no_more}.
 
-print_length_list(List, D, T, RF, Enc, Str) ->
-    L = print_length_list1(List, D, tsub(T, 2), RF, Enc, Str),
+print_length_list(List, D, T, RF, Enc, Str, Ord) ->
+    L = print_length_list1(List, D, tsub(T, 2), RF, Enc, Str, Ord),
     {Len, Dots} = list_length(L, 2, 0),
     {{list, L}, Len, Dots, no_more}.
 
-print_length_list1([], _D, _T, _RF, _Enc, _Str) ->
+print_length_list1([], _D, _T, _RF, _Enc, _Str, _Ord) ->
     [];
-print_length_list1(Term, D, T, RF, Enc, Str) when D =:= 1; T =:= 0->
-    More = fun(T1, Dd) -> ?FUNCTION_NAME(Term, D+Dd, T1, RF, Enc, Str) end,
+print_length_list1(Term, D, T, RF, Enc, Str, Ord) when D =:= 1; T =:= 0->
+    More = fun(T1, Dd) -> ?FUNCTION_NAME(Term, D+Dd, T1, RF, Enc, Str, Ord) end,
     {dots, 3, 3, More};
-print_length_list1([E | Es], D, T, RF, Enc, Str) ->
+print_length_list1([E | Es], D, T, RF, Enc, Str, Ord) ->
     %% If E is the last element in list, don't account length for a comma.
     T1 = case Es =:= [] of
              false -> tsub(T, 1);
              true -> T
          end,
-    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T1, RF, Enc, Str),
-    [Elem1 | print_length_list1(Es, D - 1, tsub(T1, Len1), RF, Enc, Str)];
-print_length_list1(E, D, T, RF, Enc, Str) ->
-    print_length(E, D - 1, T, RF, Enc, Str).
+    {_, Len1, _, _} = Elem1 = print_length(E, D - 1, T1, RF, Enc, Str, Ord),
+    [Elem1 | print_length_list1(Es, D - 1, tsub(T1, Len1), RF, Enc, Str, Ord)];
+print_length_list1(E, D, T, RF, Enc, Str, Ord) ->
+    print_length(E, D - 1, T, RF, Enc, Str, Ord).
 
 list_length([], Acc, DotsAcc) ->
     {Acc, DotsAcc};

--- a/lib/stdlib/src/maps.erl
+++ b/lib/stdlib/src/maps.erl
@@ -24,7 +24,8 @@
          map/2, size/1, new/0,
          update_with/3, update_with/4,
          without/2, with/2,
-         iterator/1, next/1,
+         iterator/1, iterator/2,
+         next/1,
          intersect/2, intersect_with/3,
          merge_with/3,
          groups_from_list/2, groups_from_list/3]).
@@ -36,13 +37,17 @@
          to_list/1, update/3, values/1]).
 
 -opaque iterator(Key, Value) :: {Key, Value, iterator(Key, Value)} | none
-                              | nonempty_improper_list(integer(), #{Key => Value}).
+                              | nonempty_improper_list(integer(), #{Key => Value})
+                              | nonempty_improper_list(list(Key), #{Key => Value}).
 
 -type iterator() :: iterator(term(), term()).
 
--export_type([iterator/2, iterator/0]).
+-type iterator_order(Key) :: undefined | ordered | fun((A :: Key, B :: Key) -> boolean()).
+-type iterator_order() :: iterator_order(term()).
 
--dialyzer({no_improper_lists, iterator/1}).
+-export_type([iterator/2, iterator/0, iterator_order/1, iterator_order/0]).
+
+-dialyzer({no_improper_lists, [iterator/1, iterator/2]}).
 
 %% We must inline these functions so that the stacktrace points to
 %% the correct function.
@@ -220,13 +225,36 @@ remove(_,_) -> erlang:nif_error(undef).
 
 take(_,_) -> erlang:nif_error(undef).
 
--spec to_list(Map) -> [{Key,Value}] when
-    Map :: #{Key => Value}.
+-spec to_list(MapOrIterator) -> [{Key, Value}] when
+    MapOrIterator :: #{Key => Value} | iterator(Key, Value).
 
 to_list(Map) when is_map(Map) ->
     to_list_internal(erts_internal:map_next(0, Map, []));
+to_list({_K, _V, _NextIterator} = Iterator) ->
+    try to_list_from_iterator(Iterator) of
+        Result -> Result
+    catch
+        error:badarg ->
+            error_with_info({badmap, Iterator}, [Iterator])
+    end;
+to_list([PathOrKeys | Map] = Iterator)
+  when (is_integer(PathOrKeys) orelse is_list(PathOrKeys)), is_map(Map) ->
+    try to_list_from_iterator(Iterator) of
+        Result -> Result
+    catch
+        error:badarg ->
+            error_with_info({badmap, Iterator}, [Iterator])
+    end;
 to_list(Map) ->
-    error_with_info({badmap,Map}, [Map]).
+    error_with_info({badmap, Map}, [Map]).
+
+to_list_from_iterator(Iterator) ->
+    case maps:next(Iterator) of
+        {Key, Value, NextIterator} ->
+            [{Key, Value} | to_list_from_iterator(NextIterator)];
+        none ->
+            []
+    end.
 
 to_list_internal([Iter, Map | Acc]) when is_integer(Iter) ->
     to_list_internal(erts_internal:map_next(Iter, Map, Acc));
@@ -455,16 +483,39 @@ size(Map) ->
       Map :: #{Key => Value},
       Iterator :: iterator(Key, Value).
 
-iterator(M) when is_map(M) -> [0 | M];
+iterator(M) when is_map(M) -> iterator(M, undefined);
 iterator(M) -> error_with_info({badmap, M}, [M]).
+
+-spec iterator(Map, Order) -> Iterator when
+      Map :: #{Key => Value},
+      Order :: iterator_order(Key),
+      Iterator :: iterator(Key, Value).
+
+iterator(M, undefined) when is_map(M) ->
+    [0 | M];
+iterator(M, ordered) when is_map(M) ->
+    CmpFun = fun(A, B) -> erts_internal:cmp_term(A, B) =< 0 end,
+    Keys = lists:sort(CmpFun, maps:keys(M)),
+    [Keys | M];
+iterator(M, CmpFun) when is_map(M), is_function(CmpFun, 2) ->
+    Keys = lists:sort(CmpFun, maps:keys(M)),
+    [Keys | M];
+iterator(M, Order) ->
+    badarg_with_info([M, Order]).
 
 -spec next(Iterator) -> {Key, Value, NextIterator} | 'none' when
       Iterator :: iterator(Key, Value),
       NextIterator :: iterator(Key, Value).
 next({K, V, I}) ->
     {K, V, I};
-next([Path | Map]) when is_integer(Path), is_map(Map) ->
-    erts_internal:map_next(Path, Map, iterator);
+next([Path | Map] = Iterator)
+  when (is_integer(Path) orelse is_list(Path)), is_map(Map) ->
+    try erts_internal:map_next(Path, Map, iterator) of
+        Result -> Result
+    catch
+        error:badarg ->
+            badarg_with_info([Iterator])
+    end;
 next(none) ->
     none;
 next(Iter) ->

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -2275,25 +2275,44 @@ maps(_Config) ->
     %% Therefore, play it completely safe by not assuming any order
     %% in a map with more than one element.
 
+    RevCmpFun = fun(A, B) -> B =< A end,
+
+    AtomMap1 = #{a => b},
+    AtomMap2 = #{a => b, c => d},
+    AtomMap3 = #{a => b, c => d, e => f},
+
     "#{}" = fmt("~w", [#{}]),
-    "#{a => b}" = fmt("~w", [#{a=>b}]),
+    "#{a => b}" = fmt("~w", [AtomMap1]),
     re_fmt(<<"#\\{(a => b|c => d),[.][.][.]\\}">>,
-	     "~W", [#{a => b,c => d},2]),
+	     "~W", [AtomMap2, 2]),
     re_fmt(<<"#\\{(a => b|c => d|e => f),[.][.][.]\\}">>,
-	   "~W", [#{a => b,c => d,e => f},2]),
+	   "~W", [AtomMap3, 2]),
+    "#{a => b,c => d,e => f}" = fmt("~kw", [AtomMap3]),
+    re_fmt(<<"#\\{(a => b|c => d|e => f),[.][.][.]\\}">>,
+           "~KW", [undefined, AtomMap3, 2]),
+    "#{a => b,c => d,e => f}" = fmt("~Kw", [ordered, AtomMap3]),
+    "#{e => f,c => d,a => b}" = fmt("~Kw", [RevCmpFun, AtomMap3]),
 
     "#{}" = fmt("~p", [#{}]),
-    "#{a => b}" = fmt("~p", [#{a => b}]),
-    "#{...}" = fmt("~P", [#{a => b},1]),
+    "#{a => b}" = fmt("~p", [AtomMap1]),
+    "#{...}" = fmt("~P", [AtomMap1, 1]),
     re_fmt(<<"#\\{(a => b|c => d),[.][.][.]\\}">>,
-	   "~P", [#{a => b,c => d},2]),
+	   "~P", [AtomMap2, 2]),
     re_fmt(<<"#\\{(a => b|c => d|e => f),[.][.][.]\\}">>,
-	   "~P", [#{a => b,c => d,e => f},2]),
+	   "~P", [AtomMap3, 2]),
+    "#{a => b,c => d,e => f}" = fmt("~kp", [AtomMap3]),
+    re_fmt(<<"#\\{(a => b|c => d|e => f),[.][.][.]\\}">>,
+           "~KP", [undefined, AtomMap3, 2]),
+    "#{a => b,c => d,e => f}" = fmt("~Kp", [ordered, AtomMap3]),
+    "#{e => f,c => d,a => b}" = fmt("~Kp", [RevCmpFun, AtomMap3]),
 
-    List = [{I,I*I} || I <- lists:seq(1, 20)],
+    List = [{I, I * I} || I <- lists:seq(1, 64)],
     Map = maps:from_list(List),
 
-    "#{...}" = fmt("~P", [Map,1]),
+    "#{...}" = fmt("~P", [Map, 1]),
+    "#{1 => 1,...}" = fmt("~kP", [Map, 2]),
+    "#{1 => 1,...}" = fmt("~KP", [ordered, Map, 2]),
+    "#{64 => 4096,...}" = fmt("~KP", [RevCmpFun, Map, 2]),
 
     %% Print a map and parse it back to a map.
     S = fmt("~p\n", [Map]),


### PR DESCRIPTION
This PR add support for both term-ordered and custom order of keys for map iterators.  It also includes support for specifying the ordering of maps when printing or formatting.

Summary of changes:

1. New function: `maps:iterator/2`
    > Accepts a `map()` as the first argument and `undefined` (the default for `maps:iterator/1`), `ordered`, or a 2-arity comparison function `fun((A :: Key, B :: Key) -> boolean())`.
    > 
    > For example:
    > ```erlang
    > %% Ordered
    > Iter = maps:iterator(#{a => b, c => d}, ordered),
    > {a, b, NextIter} = maps:next(Iter).
    > 
    > %% Reversed
    > Iter = maps:iterator(#{a => b, c => d}, fun(A, B) -> B =< A end),
    > {c, d, NextIter} = maps:next(NextIter).
    > ```
2. <del>New function: `maps:next_key/1`
    > Accepts a `maps:iterator()` and returns `{Key, NextIter}`.  This is the same as `maps:next/1`, but does not return the `Value`.
    </del>
3. New type: `maps:iterator_order/0` and `maps:iterator_order/1`
    > ```erlang
    > -type iterator_order(Key) :: undefined | ordered | fun((A :: Key, B :: Key) -> boolean()).
    > -type iterator_order() :: iterator_order(term()).
    > ```
4. Changed type: `maps:iterator/2`
    > Now accepts type `nonempty_improper_list(list(Key), #{Key => Value})` which is used for ordering of keys during iteration.
5. Changed function: `maps:to_list/1`
    > Now accepts `map() | maps:iterator()`.
    > 
    > For example:
    > ```erlang
    > %% Ordered
    > [{a, b}, {c, d}] = maps:to_list(maps:iterator(#{a => b, c => d}, ordered)).
    > 
    > %% Reversed
    > [{c, d}, {a, b}] = maps:to_list(maps:iterator(#{a => b, c => d}, fun(A, B) -> B =< A end)).
    > ```
6. New `io` modifier: `~k` for ordered map formatting
    > ```erlang
    > Map = #{a => b, c => d},
    > FormatList = io_lib:scan_format("~kp", [Map]),
    > {"~kp", [Map]} = io_lib:unscan_format(FormatList).
    > 
    > "#{a => b,c => d}" = lists:flatten(io_lib:format("~kp", [Map])).
    > ```
7. New `io` modifier: `~K` for custom order map formatting
    > ```erlang
    > Map = #{a => b, c => d},
    > RevCmpFun = fun(A, B) -> B =< A end,
    > FormatList = io_lib:scan_format("~Kp", [RevCmpFun, Map]),
    > {"~Kp", [RevCmpFun, Map]} = io_lib:unscan_format(FormatList).
    > 
    > "#{c => d,a => b}" = lists:flatten(io_lib:format("~Kp", [RevCmpFun, Map])).
    > ```
8. Tests for all of the above in `io_SUITE` and `maps_SUITE`
    > ```bash
    > make stdlib_test ARGS="-suite io_SUITE"
    > make stdlib_test ARGS="-suite maps_SUITE"
    > ```
9. Updated `maps.xml`, `io.xml`, and `io_lib.xml` documentation.