### PR TITLE
Add code path caching

### DIFF
--- a/erts/preloaded/src/erl_prim_loader.erl
+++ b/erts/preloaded/src/erl_prim_loader.erl
@@ -53,10 +53,10 @@
 -export([set_primary_archive/4]).
 
 %% Used by test suites
--export([purge_archive_cache/0]).
+-export([purge_archive_cache/0, get_modules/3]).
 
-%% Used by init and the code server.
--export([get_modules/2,get_modules/3, is_basename/1]).
+%% Used by init and the code server
+-export([get_modules/2, is_basename/1]).
 
 -include_lib("kernel/include/file.hrl").
 

--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -102,7 +102,7 @@
 /usr/local/jungerl:/home/some_user/my_erlang_lib</code>
     <p>On Windows, use semi-colon as separator.</p>
     <p>The code paths specified by <c>$OTP_ROOT</c>, <c>ERL_LIBS</c>,
-      and boot scripts have their listings cached by default.
+      and boot scripts have their listings cached by default (except for ".").
       The code server will lookup the contents in their directories once
       and avoid future file system traversals. Therefore modules added
       to such directories after the Erlang VM boots won't be picked up.

--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -101,6 +101,13 @@
       <code>
 /usr/local/jungerl:/home/some_user/my_erlang_lib</code>
     <p>On Windows, use semi-colon as separator.</p>
+    <p>The code paths specified by <c>$OTP_ROOT</c>, <c>ERL_LIBS</c>,
+      and boot scripts have their listings cached by default.
+      The code server will lookup the contents in their directories once
+      and avoid future file system traversals. Therefore modules added
+      to such directories after the Erlang VM boots won't be picked up.
+      You can disable this behaviour by setting <c>-cache_boot_paths false</c>
+      or by calling <c>code:set_path(code:get_path())</c>.</p>
   </section>
 
   <section>

--- a/lib/kernel/test/code_SUITE.erl
+++ b/lib/kernel/test/code_SUITE.erl
@@ -997,8 +997,12 @@ purge_stacktrace_test(Config) when is_list(Config) ->
 mult_lib_roots(Config) when is_list(Config) ->
     DataDir = filename:join(proplists:get_value(data_dir, Config), "mult_lib_roots"),
     mult_lib_compile(DataDir, "my_dummy_app-b/ebin/lists"),
-    mult_lib_compile(DataDir,
-			   "my_dummy_app-c/ebin/code_SUITE_mult_root_module"),
+
+    %% We will use this module to test both code path loading and
+    %% code path caching. So we ensure its beam file does not exist.
+    CodeSuiteMultRootBeam =
+	filename:join(DataDir, "first_root/my_dummy_app-c/ebin/code_SUITE_mult_root_module.beam"),
+    file:delete(CodeSuiteMultRootBeam),
 
     %% Set up ERL_LIBS and start a peer node.
     ErlLibs = filename:join(DataDir, "first_root") ++ mult_lib_sep() ++
@@ -1026,9 +1030,26 @@ mult_lib_roots(Config) when is_list(Config) ->
 	    E <- lists:sort([Lib1,Lib2,Lib3,Lib4,Lib5])],
     io:format("~p\n", [Path]),
 
-    true = rpc:call(Node, code_SUITE_mult_root_module, works_fine, []),
+    %% Now let's attempt to dynamically add a module,
+    %% this will fail due to the boot paths cache.
+    error = rpc:call(Node, code, get_object_code, [code_SUITE_mult_root_module]),
+    mult_lib_compile(DataDir, "my_dummy_app-c/ebin/code_SUITE_mult_root_module"),
+    error = rpc:call(Node, code, get_object_code, [code_SUITE_mult_root_module]),
+
+    %% Clean up so we can start again
+    file:delete(CodeSuiteMultRootBeam),
     peer:stop(Peer),
 
+    NoCacheArgs = ["-env", "ERL_LIBS", ErlLibs, "-cache_boot_paths", "false"],
+    {ok, NoCachePeer, NoCacheNode} = ?CT_PEER(NoCacheArgs),
+
+    %% Now the same code should work
+    error = rpc:call(NoCacheNode, code, get_object_code, [code_SUITE_mult_root_module]),
+    mult_lib_compile(DataDir, "my_dummy_app-c/ebin/code_SUITE_mult_root_module"),
+    {_,_,_} = rpc:call(NoCacheNode, code, get_object_code, [code_SUITE_mult_root_module]),
+    true = rpc:call(NoCacheNode, code_SUITE_mult_root_module, works_fine, []),
+
+    peer:stop(NoCachePeer),
     ok.
 
 mult_lib_compile(Root, Last) ->

--- a/lib/kernel/test/code_SUITE.erl
+++ b/lib/kernel/test/code_SUITE.erl
@@ -1035,7 +1035,12 @@ mult_lib_roots(Config) when is_list(Config) ->
     error = rpc:call(Node, code, get_object_code, [code_SUITE_mult_root_module]),
     mult_lib_compile(DataDir, "my_dummy_app-c/ebin/code_SUITE_mult_root_module"),
     error = rpc:call(Node, code, get_object_code, [code_SUITE_mult_root_module]),
-
+    %% Test that the CWD is not cached
+    File = filename:join([DataDir, "first_root/my_dummy_app-c/ebin/code_SUITE_mult_root_module"]),
+    {ok, _} = compile:file(File, [{outdir, "."}]),
+    {_,_,_} = rpc:call(Node, code, get_object_code, [code_SUITE_mult_root_module]),
+    true = rpc:call(Node, code_SUITE_mult_root_module, works_fine, []),
+    file:delete("code_SUITE_mult_root_module.beam"),
     %% Clean up so we can start again
     file:delete(CodeSuiteMultRootBeam),
     peer:stop(Peer),


### PR DESCRIPTION
When an application has several entries in its code path, loading modules in interactive mode becomes more expensive because of code path misses.

This commit introduces code path caching, where we can opt-in into caching each directory individually.

This won’t be applied to all paths but a project has several paths that are unlikely to change while a system is running in development or test:

  * the paths from Erlang/OTP won’t be written to by most projects
  * paths from build tools and other languages
  * non-local dependencies, such as the ones from Hex/Git

Loading of the cache happens lazily, as to avoid introducing rehashes, or any upfront cost.

## Benchmarks

This change brought the boot time of Livebook (the time to start all apps in interactive mode for dev+test) on my machine (MacStudio M1 Max) from 1.095s to 0.940, which is roughly a ~15% win.

If you want to try it out, compile Erlang/OTP from this branch and measure the time to boot a project (in Elixir, for example, this is `mix run -e 1`). Run the command at least 5 times.

Then open up `code_server.erl` and change this `-define(CACHE_DEFAULT, cache).` to `-define(CACHE_DEFAULT, nocache).`, run `erlc -o lib/kernel/ebin lib/kernel/srccode_server.erl` to recompile it without cache, and run the command again.

## Decisions to be taken

Assuming we want to move forward with this, we need to take some decisions. Currently this commit enables caching by default, but I assume we don't want this in practice. I propose we add the following features for low-level control:

  * `add_path*` now accept `cache`/`nocache` as second argument
  * `-pac` and `-pzc` to be added to the command line

However, Erlang also loads code paths from three other locations:

  * Erlang/OTP lib directory
  * `ERL_LIBS`
  * `{path, ...}` instruction in the init script

We need to decide if we want one option for caching all three, such as `-cache_init_paths`, or one option for each, such as `-cache_otp_lib`, `-cache_erl_libs`, and `-cache_init_path`.

## TODO

  * [x] `code:ensure_modules_loaded/1` does not benefit from this patch as it uses another code for loading. We should unify those code paths (which will also help address bugs)
  * [x] Add `cache`/`nocache` argument to `add_path*`
  * [x] Add `cache`/`nocache` argument to `set_path*`
  * [x] Add `cache`/`nocache` argument to `replace_path*`
  * [ ] Support `-pac` and `-pzc`
  * [x] Add `code:del_paths/1`
  * [x] Add `code:clear_caches/1`
  * [x] Docs

## Future work

A future optimization is to remove parts of the linear lookup. This patch simply changes the code path to be `{Path, #{Beam := Path}}`. Therefore, if we have two cached paths in a row inside the `code_server`, we could merge their maps. This would be useful for Erlang/OTP, for instance, as its directories are typically stored sequentially in the code path.

Also note that `where_is_file/1` and `which/1` are not optimized by this pull request, as they traverse code paths on the caller. Maybe with the cache is worth moving to the server, but I would consider those changes as future work.