### PR TITLE
jit: Turn various type hint bugs into compile-time errors

### DIFF
--- a/erts/emulator/beam/beam_types.c
+++ b/erts/emulator/beam/beam_types.c
@@ -38,7 +38,9 @@ int beam_types_decode_type_otp_26(const byte *data, BeamType *out) {
     if (types == BEAM_TYPE_NONE) {
         return -1;
     }
-    out->type_union = types;
+
+    /* The "extra data" aren't part of the type union proper. */
+    out->type_union = types & BEAM_TYPE_ANY;
 
     if (types & BEAM_TYPE_HAS_LOWER_BOUND) {
         extra += 8;

--- a/erts/emulator/beam/beam_types.h
+++ b/erts/emulator/beam/beam_types.h
@@ -57,38 +57,11 @@
 
 #define BEAM_TYPE_ANY                ((1 << 13) - 1)
 
+/* This is not a part of the type union proper, but is present in the format
+ * to signal the presence of metadata. */
 #define BEAM_TYPE_HAS_LOWER_BOUND    (1 << 13)
 #define BEAM_TYPE_HAS_UPPER_BOUND    (1 << 14)
 #define BEAM_TYPE_HAS_UNIT           (1 << 15)
-
-#define BEAM_TYPE_MASK_BOXED        \
-    (BEAM_TYPE_BITSTRING |          \
-     BEAM_TYPE_BS_MATCHSTATE |      \
-     BEAM_TYPE_FLOAT |              \
-     BEAM_TYPE_FUN |                \
-     BEAM_TYPE_INTEGER |            \
-     BEAM_TYPE_MAP |                \
-     BEAM_TYPE_PID |                \
-     BEAM_TYPE_PORT |               \
-     BEAM_TYPE_REFERENCE |          \
-     BEAM_TYPE_TUPLE)
-
-#define BEAM_TYPE_MASK_IMMEDIATE    \
-    (BEAM_TYPE_ATOM |               \
-     BEAM_TYPE_INTEGER |            \
-     BEAM_TYPE_NIL |                \
-     BEAM_TYPE_PID |                \
-     BEAM_TYPE_PORT)
-
-#define BEAM_TYPE_MASK_CELL         \
-    (BEAM_TYPE_CONS)
-
-#define BEAM_TYPE_MASK_ALWAYS_IMMEDIATE  \
-    (BEAM_TYPE_MASK_IMMEDIATE & ~(BEAM_TYPE_MASK_BOXED | BEAM_TYPE_MASK_CELL))
-#define BEAM_TYPE_MASK_ALWAYS_BOXED      \
-    (BEAM_TYPE_MASK_BOXED & ~(BEAM_TYPE_MASK_CELL | BEAM_TYPE_MASK_IMMEDIATE))
-#define BEAM_TYPE_MASK_ALWAYS_CELL       \
-    (BEAM_TYPE_MASK_CELL & ~(BEAM_TYPE_MASK_BOXED | BEAM_TYPE_MASK_IMMEDIATE))
 
 typedef struct {
     /** @brief A set of the possible types (atom, tuple, etc) this term may

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1190,31 +1190,55 @@ public:
     void patchStrings(char *rw_base, const byte *string);
 
 protected:
-    int getTypeUnion(const ArgSource &arg) const {
+    const auto &getTypeEntry(const ArgSource &arg) const {
         auto typeIndex =
                 arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-
         ASSERT(typeIndex < beam->types.count);
-        return beam->types.entries[typeIndex].type_union;
+        return beam->types.entries[typeIndex];
     }
 
-    int getExtendedTypeUnion(const ArgSource &arg) const {
-        if (arg.isLiteral()) {
-            Eterm literal =
-                    beamfile_get_literal(beam, arg.as<ArgLiteral>().get());
-            if (is_binary(literal)) {
-                return BEAM_TYPE_BITSTRING;
-            } else if (is_list(literal)) {
-                return BEAM_TYPE_CONS;
-            } else if (is_tuple(literal)) {
-                return BEAM_TYPE_TUPLE;
-            } else if (is_map(literal)) {
-                return BEAM_TYPE_MAP;
-            } else {
-                return BEAM_TYPE_ANY;
-            }
-        } else {
-            return getTypeUnion(arg);
+    auto getTypeUnion(const ArgSource &arg) const {
+        if (arg.isRegister()) {
+            return static_cast<BeamTypeId>(getTypeEntry(arg).type_union);
+        }
+
+        Eterm constant =
+                arg.isImmed()
+                        ? arg.as<ArgImmed>().get()
+                        : beamfile_get_literal(beam,
+                                               arg.as<ArgLiteral>().get());
+
+        switch (tag_val_def(constant)) {
+        case ATOM_DEF:
+            return BeamTypeId::Atom;
+        case BINARY_DEF:
+            return BeamTypeId::Bitstring;
+        case FLOAT_DEF:
+            return BeamTypeId::Float;
+        case FUN_DEF:
+            return BeamTypeId::Fun;
+        case BIG_DEF:
+        case SMALL_DEF:
+            return BeamTypeId::Integer;
+        case LIST_DEF:
+            return BeamTypeId::Cons;
+        case MAP_DEF:
+            return BeamTypeId::Map;
+        case NIL_DEF:
+            return BeamTypeId::Nil;
+        case EXTERNAL_PID_DEF:
+        case PID_DEF:
+            return BeamTypeId::Pid;
+        case EXTERNAL_PORT_DEF:
+        case PORT_DEF:
+            return BeamTypeId::Port;
+        case EXTERNAL_REF_DEF:
+        case REF_DEF:
+            return BeamTypeId::Reference;
+        case TUPLE_DEF:
+            return BeamTypeId::Tuple;
+        default:
+            ERTS_ASSERT(!"tag_val_def error");
         }
     }
 
@@ -1223,11 +1247,8 @@ protected:
             Sint value = arg.as<ArgSmall>().getSigned();
             return std::make_pair(value, value);
         } else {
-            auto typeIndex =
-                    arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+            const auto &entry = getTypeEntry(arg);
 
-            ASSERT(typeIndex < beam->types.count);
-            const auto &entry = beam->types.entries[typeIndex];
             if (entry.min <= entry.max) {
                 return std::make_pair(entry.min, entry.max);
             } else if (IS_SSMALL(entry.min) && !IS_SSMALL(entry.max)) {
@@ -1241,55 +1262,41 @@ protected:
     }
 
     int getSizeUnit(const ArgSource &arg) const {
-        auto typeIndex =
-                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-
-        ASSERT(typeIndex < beam->types.count);
-        ASSERT(beam->types.entries[typeIndex].type_union ==
-               BEAM_TYPE_BITSTRING);
-        return beam->types.entries[typeIndex].size_unit;
+        const auto &entry = getTypeEntry(arg);
+        ASSERT(maybe_one_of<BeamTypeId::Bitstring>(arg));
+        return entry.size_unit;
     }
 
     bool hasLowerBound(const ArgSource &arg) const {
-        auto typeIndex =
-                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-        ASSERT(typeIndex < beam->types.count);
-        const auto &entry = beam->types.entries[typeIndex];
+        const auto &entry = getTypeEntry(arg);
         return IS_SSMALL(entry.min) && !IS_SSMALL(entry.max);
     }
 
     bool hasUpperBound(const ArgSource &arg) const {
-        auto typeIndex =
-                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-        ASSERT(typeIndex < beam->types.count);
-        const auto &entry = beam->types.entries[typeIndex];
+        const auto &entry = getTypeEntry(arg);
         return !IS_SSMALL(entry.min) && IS_SSMALL(entry.max);
     }
 
     bool always_small(const ArgSource &arg) const {
         if (arg.isSmall()) {
             return true;
+        } else if (!exact_type<BeamTypeId::Integer>(arg)) {
+            return false;
         }
 
-        auto typeIndex =
-                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-        ASSERT(typeIndex < beam->types.count);
-        const auto &entry = beam->types.entries[typeIndex];
-        return entry.type_union == BEAM_TYPE_INTEGER && entry.min <= entry.max;
+        const auto &entry = getTypeEntry(arg);
+        return entry.min <= entry.max;
     }
 
     bool always_immediate(const ArgSource &arg) const {
-        if (arg.isImmed() || always_small(arg)) {
-            return true;
-        }
-
-        int type_union = getTypeUnion(arg);
-        return (type_union & BEAM_TYPE_MASK_ALWAYS_IMMEDIATE) == type_union;
+        return always_one_of<BeamTypeId::AlwaysImmediate>(arg) ||
+               always_small(arg);
     }
 
     bool always_same_types(const ArgSource &lhs, const ArgSource &rhs) const {
-        int lhs_types = getExtendedTypeUnion(lhs);
-        int rhs_types = getExtendedTypeUnion(rhs);
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto lhs_types = static_cast<integral>(getTypeUnion(lhs));
+        auto rhs_types = static_cast<integral>(getTypeUnion(rhs));
 
         /* We can only be certain that the types are the same when there's
          * one possible type. For example, if one is a number and the other
@@ -1301,41 +1308,69 @@ protected:
         return false;
     }
 
-    bool always_one_of(const ArgSource &arg, int types) const {
-        if (arg.isImmed()) {
-            if (arg.isSmall()) {
-                return !!(types & BEAM_TYPE_INTEGER);
-            } else if (arg.isAtom()) {
-                return !!(types & BEAM_TYPE_ATOM);
-            } else if (arg.isNil()) {
-                return !!(types & BEAM_TYPE_NIL);
-            }
-
-            return false;
-        } else {
-            int type_union = getTypeUnion(arg);
-            return type_union == (type_union & types);
-        }
+    template<BeamTypeId... Types>
+    bool never_one_of(const ArgSource &arg) const {
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto types = static_cast<integral>(BeamTypeIdUnion<Types...>::value());
+        auto type_union = static_cast<integral>(getTypeUnion(arg));
+        return static_cast<BeamTypeId>(type_union & types) == BeamTypeId::None;
     }
 
-    int masked_types(const ArgSource &arg, int mask) const {
-        if (arg.isImmed()) {
-            if (arg.isSmall()) {
-                return mask & BEAM_TYPE_INTEGER;
-            } else if (arg.isAtom()) {
-                return mask & BEAM_TYPE_ATOM;
-            } else if (arg.isNil()) {
-                return mask & BEAM_TYPE_NIL;
-            }
-
-            return BEAM_TYPE_NONE;
-        } else {
-            return getTypeUnion(arg) & mask;
-        }
+    template<BeamTypeId... Types>
+    bool maybe_one_of(const ArgSource &arg) const {
+        return !never_one_of<Types...>(arg);
     }
 
-    bool exact_type(const ArgSource &arg, int type_id) const {
-        return always_one_of(arg, type_id);
+    template<BeamTypeId... Types>
+    bool always_one_of(const ArgSource &arg) const {
+        /* Providing a single type to this function is not an error per se, but
+         * `exact_type` provides a bit more error checking for that use-case,
+         * so we want to encourage its use. */
+        static_assert(!BeamTypeIdUnion<Types...>::is_single_typed(),
+                      "always_one_of expects a union of several primitive "
+                      "types, use exact_type instead");
+
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto types = static_cast<integral>(BeamTypeIdUnion<Types...>::value());
+        auto type_union = static_cast<integral>(getTypeUnion(arg));
+        return type_union == (type_union & types);
+    }
+
+    template<BeamTypeId Type>
+    bool exact_type(const ArgSource &arg) const {
+        /* Rejects `exact_type<BeamTypeId::List>(...)` and similar, as it's
+         * almost always an error to exactly match a union of several types.
+         *
+         * On the off chance that you _do_ need to match a union exactly, use
+         * `masked_types<T>(arg) == T` instead. */
+        static_assert(BeamTypeIdUnion<Type>::is_single_typed(),
+                      "exact_type expects exactly one primitive type, use "
+                      "always_one_of instead");
+
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto type_union = static_cast<integral>(getTypeUnion(arg));
+        return type_union == (type_union & static_cast<integral>(Type));
+    }
+
+    template<BeamTypeId Mask>
+    BeamTypeId masked_types(const ArgSource &arg) const {
+        static_assert((Mask != BeamTypeId::AlwaysBoxed &&
+                       Mask != BeamTypeId::AlwaysImmediate),
+                      "using masked_types with AlwaysBoxed or AlwaysImmediate "
+                      "is almost always an error, use exact_type, "
+                      "maybe_one_of, or never_one_of instead");
+        static_assert((Mask == BeamTypeId::MaybeBoxed ||
+                       Mask == BeamTypeId::MaybeImmediate ||
+                       Mask == BeamTypeId::AlwaysBoxed ||
+                       Mask == BeamTypeId::AlwaysImmediate),
+                      "masked_types expects a mask type like MaybeBoxed or "
+                      "MaybeImmediate, use exact_type, maybe_one_of, or"
+                      "never_one_of instead");
+
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto mask = static_cast<integral>(Mask);
+        auto type_union = static_cast<integral>(getTypeUnion(arg));
+        return static_cast<BeamTypeId>(type_union & mask);
     }
 
     bool is_sum_small_if_args_are_small(const ArgSource &LHS,
@@ -1409,7 +1444,7 @@ protected:
     }
 
     void emit_is_boxed(Label Fail, const ArgVal &Arg, arm::Gp Src) {
-        if (always_one_of(Arg, BEAM_TYPE_MASK_ALWAYS_BOXED)) {
+        if (always_one_of<BeamTypeId::AlwaysBoxed>(Arg)) {
             comment("skipped box test since argument is always boxed");
             return;
         }

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1883,14 +1883,14 @@ protected:
     }
 
     void safe_stp(arm::Gp gp1, arm::Gp gp2, arm::Mem mem) {
+        size_t abs_offset = std::abs(mem.offset());
         auto offset = mem.offset();
 
         ASSERT(gp1.isGpX() && gp2.isGpX());
 
-        if (std::abs(offset) <= sizeof(Eterm) * MAX_LDP_STP_DISPLACEMENT) {
+        if (abs_offset <= sizeof(Eterm) * MAX_LDP_STP_DISPLACEMENT) {
             a.stp(gp1, gp2, mem);
-        } else if (std::abs(offset) <
-                   sizeof(Eterm) * MAX_LDR_STR_DISPLACEMENT) {
+        } else if (abs_offset < sizeof(Eterm) * MAX_LDR_STR_DISPLACEMENT) {
             /* Note that we used `<` instead of `<=`, as we're loading two
              * elements rather than one. */
             a.str(gp1, mem);
@@ -1902,12 +1902,13 @@ protected:
     }
 
     void safe_ldr(arm::Gp gp, arm::Mem mem) {
+        size_t abs_offset = std::abs(mem.offset());
         auto offset = mem.offset();
 
         ASSERT(mem.hasBaseReg() && !mem.hasIndex());
         ASSERT(gp.isGpX());
 
-        if (std::abs(offset) <= sizeof(Eterm) * MAX_LDR_STR_DISPLACEMENT) {
+        if (abs_offset <= sizeof(Eterm) * MAX_LDR_STR_DISPLACEMENT) {
             a.ldr(gp, mem);
         } else {
             add(SUPER_TMP, arm::GpX(mem.baseId()), offset);
@@ -1916,12 +1917,13 @@ protected:
     }
 
     void safe_ldur(arm::Gp gp, arm::Mem mem) {
+        size_t abs_offset = std::abs(mem.offset());
         auto offset = mem.offset();
 
         ASSERT(mem.hasBaseReg() && !mem.hasIndex());
         ASSERT(gp.isGpX());
 
-        if (std::abs(offset) <= MAX_LDUR_STUR_DISPLACEMENT) {
+        if (abs_offset <= MAX_LDUR_STUR_DISPLACEMENT) {
             a.ldur(gp, mem);
         } else {
             add(SUPER_TMP, arm::GpX(mem.baseId()), offset);
@@ -1940,15 +1942,15 @@ protected:
     }
 
     void safe_ldp(arm::Gp gp1, arm::Gp gp2, arm::Mem mem) {
+        size_t abs_offset = std::abs(mem.offset());
         auto offset = mem.offset();
 
         ASSERT(gp1.isGpX() && gp2.isGpX());
         ASSERT(gp1 != gp2);
 
-        if (std::abs(offset) <= sizeof(Eterm) * MAX_LDP_STP_DISPLACEMENT) {
+        if (abs_offset <= sizeof(Eterm) * MAX_LDP_STP_DISPLACEMENT) {
             a.ldp(gp1, gp2, mem);
-        } else if (std::abs(offset) <
-                   sizeof(Eterm) * MAX_LDR_STR_DISPLACEMENT) {
+        } else if (abs_offset < sizeof(Eterm) * MAX_LDR_STR_DISPLACEMENT) {
             /* Note that we used `<` instead of `<=`, as we're loading two
              * elements rather than one. */
             a.ldr(gp1, mem);

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -674,10 +674,8 @@ void BeamModuleAssembler::check_pending_stubs() {
 }
 
 void BeamModuleAssembler::flush_pending_stubs(size_t range) {
-    size_t effective_offset;
+    ssize_t effective_offset = a.offset() + range;
     Label next;
-
-    effective_offset = a.offset() + range;
 
     while (!_pending_veneers.empty()) {
         const Veneer &veneer = _pending_veneers.top();

--- a/erts/emulator/beam/jit/arm/instr_float.cpp
+++ b/erts/emulator/beam/jit/arm/instr_float.cpp
@@ -159,12 +159,12 @@ void BeamModuleAssembler::emit_fconv(const ArgSource &Src,
 
     a.bind(not_small);
     {
-        if (masked_types(Src, BEAM_TYPE_FLOAT) == BEAM_TYPE_NONE) {
+        if (never_one_of<BeamTypeId::Float>(Src)) {
             comment("skipped float path since source cannot be a float");
         } else {
             /* If the source is always a number, we can skip the box test when
              * it's not a small. */
-            if (always_one_of(Src, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+            if (always_one_of<BeamTypeId::Number>(Src)) {
                 comment("skipped box test since source is always a number");
             } else {
                 emit_is_boxed(fallback, Src, src.reg);

--- a/erts/emulator/beam/jit/arm/instr_fun.cpp
+++ b/erts/emulator/beam/jit/arm/instr_fun.cpp
@@ -407,8 +407,8 @@ void BeamModuleAssembler::emit_i_call_fun2(const ArgVal &Tag,
         mov_imm(ARG3, Arity.get());
 
         auto target = emit_call_fun(
-                always_one_of(Func, BEAM_TYPE_MASK_ALWAYS_BOXED),
-                masked_types(Func, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_FUN,
+                always_one_of<BeamTypeId::AlwaysBoxed>(Func),
+                masked_types<BeamTypeId::MaybeBoxed>(Func) == BeamTypeId::Fun,
                 Tag.as<ArgAtom>().get() == am_safe);
 
         erlang_call(target);
@@ -428,8 +428,8 @@ void BeamModuleAssembler::emit_i_call_fun2_last(const ArgVal &Tag,
         mov_imm(ARG3, Arity.get());
 
         auto target = emit_call_fun(
-                always_one_of(Func, BEAM_TYPE_MASK_ALWAYS_BOXED),
-                masked_types(Func, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_FUN,
+                always_one_of<BeamTypeId::AlwaysBoxed>(Func),
+                masked_types<BeamTypeId::MaybeBoxed>(Func) == BeamTypeId::Fun,
                 Tag.as<ArgAtom>().get() == am_safe);
 
         emit_deallocate(Deallocate);

--- a/erts/emulator/beam/jit/arm/instr_map.cpp
+++ b/erts/emulator/beam/jit/arm/instr_map.cpp
@@ -95,7 +95,7 @@ void BeamGlobalAssembler::emit_hashmap_get_element() {
     Label node_loop = a.newLabel();
 
     arm::Gp node = ARG1, key = ARG2, key_hash = ARG3, header_val = ARG4,
-            depth = TMP4, index = TMP5, one = TMP6;
+            depth = TMP4, index = TMP5;
 
     const int header_shift =
             (_HEADER_ARITY_OFFS + MAP_HEADER_TAG_SZ + MAP_HEADER_ARITY_SZ);

--- a/erts/emulator/beam/jit/arm/instr_map.cpp
+++ b/erts/emulator/beam/jit/arm/instr_map.cpp
@@ -381,7 +381,7 @@ void BeamModuleAssembler::emit_i_get_map_element(const ArgLabel &Fail,
     mov_arg(ARG1, Src);
     mov_arg(ARG2, Key);
 
-    if (masked_types(Key, BEAM_TYPE_MASK_IMMEDIATE) != BEAM_TYPE_NONE) {
+    if (maybe_one_of<BeamTypeId::MaybeImmediate>(Key)) {
         fragment_call(ga->get_i_get_map_element_shared());
         a.b_ne(resolve_beam_label(Fail, disp1MB));
     } else {

--- a/erts/emulator/beam/jit/arm/instr_select.cpp
+++ b/erts/emulator/beam/jit/arm/instr_select.cpp
@@ -114,7 +114,7 @@ const std::vector<ArgVal> BeamModuleAssembler::emit_select_untag(
      * untag it. */
     comment("(comparing untagged+rebased values)");
     if ((args.front().isSmall() && always_small(Src)) ||
-        (args.front().isAtom() && exact_type(Src, BEAM_TYPE_ATOM))) {
+        (args.front().isAtom() && exact_type<BeamTypeId::Atom>(Src))) {
         comment("(skipped type test)");
     } else {
         if (args.front().isSmall()) {
@@ -228,7 +228,7 @@ void BeamModuleAssembler::emit_i_select_tuple_arity(const ArgRegister &Src,
     arm::Gp boxed_ptr = emit_ptr_val(TMP1, src.reg);
     a.ldur(TMP1, emit_boxed_val(boxed_ptr, 0));
 
-    if (masked_types(Src, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_TUPLE) {
+    if (masked_types<BeamTypeId::MaybeBoxed>(Src) == BeamTypeId::Tuple) {
         comment("simplified tuple test since the source is always a tuple "
                 "when boxed");
     } else {

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1251,31 +1251,55 @@ public:
     void patchStrings(char *rw_base, const byte *string);
 
 protected:
-    int getTypeUnion(const ArgSource &arg) const {
+    const auto &getTypeEntry(const ArgSource &arg) const {
         auto typeIndex =
                 arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-
         ASSERT(typeIndex < beam->types.count);
-        return beam->types.entries[typeIndex].type_union;
+        return beam->types.entries[typeIndex];
     }
 
-    int getExtendedTypeUnion(const ArgSource &arg) const {
-        if (arg.isLiteral()) {
-            Eterm literal =
-                    beamfile_get_literal(beam, arg.as<ArgLiteral>().get());
-            if (is_binary(literal)) {
-                return BEAM_TYPE_BITSTRING;
-            } else if (is_list(literal)) {
-                return BEAM_TYPE_CONS;
-            } else if (is_tuple(literal)) {
-                return BEAM_TYPE_TUPLE;
-            } else if (is_map(literal)) {
-                return BEAM_TYPE_MAP;
-            } else {
-                return BEAM_TYPE_ANY;
-            }
-        } else {
-            return getTypeUnion(arg);
+    auto getTypeUnion(const ArgSource &arg) const {
+        if (arg.isRegister()) {
+            return static_cast<BeamTypeId>(getTypeEntry(arg).type_union);
+        }
+
+        Eterm constant =
+                arg.isImmed()
+                        ? arg.as<ArgImmed>().get()
+                        : beamfile_get_literal(beam,
+                                               arg.as<ArgLiteral>().get());
+
+        switch (tag_val_def(constant)) {
+        case ATOM_DEF:
+            return BeamTypeId::Atom;
+        case BINARY_DEF:
+            return BeamTypeId::Bitstring;
+        case FLOAT_DEF:
+            return BeamTypeId::Float;
+        case FUN_DEF:
+            return BeamTypeId::Fun;
+        case BIG_DEF:
+        case SMALL_DEF:
+            return BeamTypeId::Integer;
+        case LIST_DEF:
+            return BeamTypeId::Cons;
+        case MAP_DEF:
+            return BeamTypeId::Map;
+        case NIL_DEF:
+            return BeamTypeId::Nil;
+        case EXTERNAL_PID_DEF:
+        case PID_DEF:
+            return BeamTypeId::Pid;
+        case EXTERNAL_PORT_DEF:
+        case PORT_DEF:
+            return BeamTypeId::Port;
+        case EXTERNAL_REF_DEF:
+        case REF_DEF:
+            return BeamTypeId::Reference;
+        case TUPLE_DEF:
+            return BeamTypeId::Tuple;
+        default:
+            ERTS_ASSERT(!"tag_val_def error");
         }
     }
 
@@ -1284,11 +1308,8 @@ protected:
             Sint value = arg.as<ArgSmall>().getSigned();
             return std::make_pair(value, value);
         } else {
-            auto typeIndex =
-                    arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
+            const auto &entry = getTypeEntry(arg);
 
-            ASSERT(typeIndex < beam->types.count);
-            const auto &entry = beam->types.entries[typeIndex];
             if (entry.min <= entry.max) {
                 return std::make_pair(entry.min, entry.max);
             } else if (IS_SSMALL(entry.min) && !IS_SSMALL(entry.max)) {
@@ -1302,55 +1323,41 @@ protected:
     }
 
     int getSizeUnit(const ArgSource &arg) const {
-        auto typeIndex =
-                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-
-        ASSERT(typeIndex < beam->types.count);
-        ASSERT(beam->types.entries[typeIndex].type_union ==
-               BEAM_TYPE_BITSTRING);
-        return beam->types.entries[typeIndex].size_unit;
+        const auto &entry = getTypeEntry(arg);
+        ASSERT(maybe_one_of<BeamTypeId::Bitstring>(arg));
+        return entry.size_unit;
     }
 
     bool hasLowerBound(const ArgSource &arg) const {
-        auto typeIndex =
-                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-        ASSERT(typeIndex < beam->types.count);
-        const auto &entry = beam->types.entries[typeIndex];
+        const auto &entry = getTypeEntry(arg);
         return IS_SSMALL(entry.min) && !IS_SSMALL(entry.max);
     }
 
     bool hasUpperBound(const ArgSource &arg) const {
-        auto typeIndex =
-                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-        ASSERT(typeIndex < beam->types.count);
-        const auto &entry = beam->types.entries[typeIndex];
+        const auto &entry = getTypeEntry(arg);
         return !IS_SSMALL(entry.min) && IS_SSMALL(entry.max);
     }
 
     bool always_small(const ArgSource &arg) const {
         if (arg.isSmall()) {
             return true;
+        } else if (!exact_type<BeamTypeId::Integer>(arg)) {
+            return false;
         }
 
-        auto typeIndex =
-                arg.isRegister() ? arg.as<ArgRegister>().typeIndex() : 0;
-        ASSERT(typeIndex < beam->types.count);
-        const auto &entry = beam->types.entries[typeIndex];
-        return entry.type_union == BEAM_TYPE_INTEGER && entry.min <= entry.max;
+        const auto &entry = getTypeEntry(arg);
+        return entry.min <= entry.max;
     }
 
     bool always_immediate(const ArgSource &arg) const {
-        if (arg.isImmed() || always_small(arg)) {
-            return true;
-        }
-
-        int type_union = getTypeUnion(arg);
-        return (type_union & BEAM_TYPE_MASK_ALWAYS_IMMEDIATE) == type_union;
+        return always_one_of<BeamTypeId::AlwaysImmediate>(arg) ||
+               always_small(arg);
     }
 
     bool always_same_types(const ArgSource &lhs, const ArgSource &rhs) const {
-        int lhs_types = getExtendedTypeUnion(lhs);
-        int rhs_types = getExtendedTypeUnion(rhs);
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto lhs_types = static_cast<integral>(getTypeUnion(lhs));
+        auto rhs_types = static_cast<integral>(getTypeUnion(rhs));
 
         /* We can only be certain that the types are the same when there's
          * one possible type. For example, if one is a number and the other
@@ -1362,41 +1369,69 @@ protected:
         return false;
     }
 
-    bool always_one_of(const ArgSource &arg, int types) const {
-        if (arg.isImmed()) {
-            if (arg.isSmall()) {
-                return !!(types & BEAM_TYPE_INTEGER);
-            } else if (arg.isAtom()) {
-                return !!(types & BEAM_TYPE_ATOM);
-            } else if (arg.isNil()) {
-                return !!(types & BEAM_TYPE_NIL);
-            }
-
-            return false;
-        } else {
-            int type_union = getTypeUnion(arg);
-            return type_union == (type_union & types);
-        }
+    template<BeamTypeId... Types>
+    bool never_one_of(const ArgSource &arg) const {
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto types = static_cast<integral>(BeamTypeIdUnion<Types...>::value());
+        auto type_union = static_cast<integral>(getTypeUnion(arg));
+        return static_cast<BeamTypeId>(type_union & types) == BeamTypeId::None;
     }
 
-    int masked_types(const ArgSource &arg, int mask) const {
-        if (arg.isImmed()) {
-            if (arg.isSmall()) {
-                return mask & BEAM_TYPE_INTEGER;
-            } else if (arg.isAtom()) {
-                return mask & BEAM_TYPE_ATOM;
-            } else if (arg.isNil()) {
-                return mask & BEAM_TYPE_NIL;
-            }
-
-            return BEAM_TYPE_NONE;
-        } else {
-            return getTypeUnion(arg) & mask;
-        }
+    template<BeamTypeId... Types>
+    bool maybe_one_of(const ArgSource &arg) const {
+        return !never_one_of<Types...>(arg);
     }
 
-    bool exact_type(const ArgSource &arg, int type_id) const {
-        return always_one_of(arg, type_id);
+    template<BeamTypeId... Types>
+    bool always_one_of(const ArgSource &arg) const {
+        /* Providing a single type to this function is not an error per se, but
+         * `exact_type` provides a bit more error checking for that use-case,
+         * so we want to encourage its use. */
+        static_assert(!BeamTypeIdUnion<Types...>::is_single_typed(),
+                      "always_one_of expects a union of several primitive "
+                      "types, use exact_type instead");
+
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto types = static_cast<integral>(BeamTypeIdUnion<Types...>::value());
+        auto type_union = static_cast<integral>(getTypeUnion(arg));
+        return type_union == (type_union & types);
+    }
+
+    template<BeamTypeId Type>
+    bool exact_type(const ArgSource &arg) const {
+        /* Rejects `exact_type<BeamTypeId::List>(...)` and similar, as it's
+         * almost always an error to exactly match a union of several types.
+         *
+         * On the off chance that you _do_ need to match a union exactly, use
+         * `masked_types<T>(arg) == T` instead. */
+        static_assert(BeamTypeIdUnion<Type>::is_single_typed(),
+                      "exact_type expects exactly one primitive type, use "
+                      "always_one_of instead");
+
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto type_union = static_cast<integral>(getTypeUnion(arg));
+        return type_union == (type_union & static_cast<integral>(Type));
+    }
+
+    template<BeamTypeId Mask>
+    BeamTypeId masked_types(const ArgSource &arg) const {
+        static_assert((Mask != BeamTypeId::AlwaysBoxed &&
+                       Mask != BeamTypeId::AlwaysImmediate),
+                      "using masked_types with AlwaysBoxed or AlwaysImmediate "
+                      "is almost always an error, use exact_type, "
+                      "maybe_one_of, or never_one_of instead");
+        static_assert((Mask == BeamTypeId::MaybeBoxed ||
+                       Mask == BeamTypeId::MaybeImmediate ||
+                       Mask == BeamTypeId::AlwaysBoxed ||
+                       Mask == BeamTypeId::AlwaysImmediate),
+                      "masked_types expects a mask type like MaybeBoxed or "
+                      "MaybeImmediate, use exact_type, maybe_one_of, or"
+                      "never_one_of instead");
+
+        using integral = std::underlying_type_t<BeamTypeId>;
+        auto mask = static_cast<integral>(Mask);
+        auto type_union = static_cast<integral>(getTypeUnion(arg));
+        return static_cast<BeamTypeId>(type_union & mask);
     }
 
     bool is_sum_small_if_args_are_small(const ArgSource &LHS,
@@ -1473,7 +1508,7 @@ protected:
                        const ArgVal &Arg,
                        x86::Gp Src,
                        Distance dist = dLong) {
-        if (always_one_of(Arg, BEAM_TYPE_MASK_ALWAYS_BOXED)) {
+        if (always_one_of<BeamTypeId::AlwaysBoxed>(Arg)) {
             comment("skipped box test since argument is always boxed");
             return;
         }

--- a/erts/emulator/beam/jit/x86/instr_arith.cpp
+++ b/erts/emulator/beam/jit/x86/instr_arith.cpp
@@ -41,7 +41,7 @@ void BeamModuleAssembler::emit_is_small(Label fail,
 
     if (always_small(Arg)) {
         comment("skipped test for small operand since it is always small");
-    } else if (always_one_of(Arg, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+    } else if (always_one_of<BeamTypeId::Number>(Arg)) {
         comment("simplified test for small operand since it is a number");
         a.test(Reg.r8(), imm(TAG_PRIMARY_LIST));
         a.short_().je(fail);
@@ -65,8 +65,8 @@ void BeamModuleAssembler::emit_are_both_small(Label fail,
     ASSERT(ARG1 != A && ARG1 != B);
     if (always_small(LHS) && always_small(RHS)) {
         comment("skipped test for small operands since they are always small");
-    } else if (always_one_of(LHS, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER) &&
-               always_one_of(RHS, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+    } else if (always_one_of<BeamTypeId::Number>(LHS) &&
+               always_one_of<BeamTypeId::Number>(RHS)) {
         comment("simplified test for small operands since both are numbers");
         if (always_small(RHS)) {
             a.test(A.r8(), imm(TAG_PRIMARY_LIST));
@@ -659,7 +659,7 @@ void BeamModuleAssembler::emit_div_rem(const ArgLabel &Fail,
         if (always_small(LHS)) {
             comment("skipped test for small dividend since it is always small");
             need_generic = false;
-        } else if (always_one_of(LHS, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+        } else if (always_one_of<BeamTypeId::Number>(LHS)) {
             comment("simplified test for small dividend since it is an "
                     "integer");
             a.test(x86::al, imm(TAG_PRIMARY_LIST));
@@ -1262,7 +1262,7 @@ void BeamModuleAssembler::emit_i_bnot(const ArgLabel &Fail,
 
     /* Fall through to the generic path if the result is not a small, where the
      * above operation will be reverted. */
-    if (always_one_of(Src, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+    if (always_one_of<BeamTypeId::Number>(Src)) {
         comment("simplified test for small operand since it is a number");
         a.test(RETb, imm(TAG_PRIMARY_LIST));
         a.short_().jne(next);

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -2377,20 +2377,20 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
          */
         switch (seg.type) {
         case am_append:
-            if (!(exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+            if (!(exact_type<BeamTypeId::Bitstring>(seg.src) &&
                   std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit)) {
                 need_error_handler = true;
             }
             break;
         case am_binary:
             if (!(seg.size.isAtom() && seg.size.as<ArgAtom>().get() == am_all &&
-                  exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+                  exact_type<BeamTypeId::Bitstring>(seg.src) &&
                   std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit)) {
                 need_error_handler = true;
             }
             break;
         case am_integer:
-            if (!always_one_of(seg.src, BEAM_TYPE_INTEGER)) {
+            if (!exact_type<BeamTypeId::Integer>(seg.src)) {
                 need_error_handler = true;
             }
             break;
@@ -2548,7 +2548,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             runtime_entered = bs_maybe_enter_runtime(runtime_entered);
             mov_arg(ARG1, seg.src);
 
-            if (exact_type(seg.src, BEAM_TYPE_BITSTRING)) {
+            if (exact_type<BeamTypeId::Bitstring>(seg.src)) {
                 auto unit = getSizeUnit(seg.src);
                 bool is_bitstring = unit == 0 || std::gcd(unit, 8) != 8;
                 x86::Gp boxed_ptr = emit_ptr_val(ARG1, ARG1);
@@ -2622,8 +2622,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
 
             if (always_small(seg.size)) {
                 comment("skipped test for small size since it is always small");
-            } else if (always_one_of(seg.size,
-                                     BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+            } else if (always_one_of<BeamTypeId::Number>(seg.size)) {
                 comment("simplified test for small size since it is a number");
                 a.test(ARG1.r8(), imm(TAG_PRIMARY_LIST));
                 a.je(error);
@@ -2671,9 +2670,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                 if (always_small(seg.src)) {
                     comment("skipped test for small value since it is always "
                             "small");
-                } else if (always_one_of(seg.src,
-                                         BEAM_TYPE_INTEGER |
-                                                 BEAM_TYPE_MASK_BOXED)) {
+                } else if (always_one_of<BeamTypeId::Integer,
+                                         BeamTypeId::AlwaysBoxed>(seg.src)) {
                     comment("simplified test for small operand since other "
                             "types are boxed");
                     emit_is_not_boxed(error, ARG1);
@@ -2781,7 +2779,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         load_x_reg_array(ARG2);
         runtime_call<6>(erts_bs_append_checked);
 
-        if (exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+        if (exact_type<BeamTypeId::Bitstring>(seg.src) &&
             std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
             /* There is no way the call can fail with a system_limit
              * exception on a 64-bit architecture. */
@@ -2884,7 +2882,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                                              BSC_REASON_BADARG,
                                                              BSC_INFO_UNIT,
                                                              BSC_VALUE_FVALUE);
-                if (exact_type(seg.src, BEAM_TYPE_BITSTRING) &&
+                if (exact_type<BeamTypeId::Bitstring>(seg.src) &&
                     std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
                     comment("skipped test for success because units are "
                             "compatible");
@@ -2969,9 +2967,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                 mov_arg(ARG1, seg.src);
 
                 if (!always_small(seg.src)) {
-                    if (always_one_of(seg.src,
-                                      BEAM_TYPE_INTEGER |
-                                              BEAM_TYPE_MASK_ALWAYS_BOXED)) {
+                    if (always_one_of<BeamTypeId::Integer,
+                                      BeamTypeId::AlwaysBoxed>(seg.src)) {
                         comment("simplified small test since all other types "
                                 "are boxed");
                         emit_is_boxed(value_is_small, seg.src, ARG1);
@@ -2985,7 +2982,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                     /* The value is boxed. If it is a bignum, extract the
                      * least significant 64 bits. */
                     safe_fragment_call(ga->get_get_sint64_shared());
-                    if (always_one_of(seg.src, BEAM_TYPE_INTEGER)) {
+                    if (exact_type<BeamTypeId::Integer>(seg.src)) {
                         a.short_().jmp(accumulate);
                     } else {
                         a.short_().jne(accumulate);
@@ -3212,7 +3209,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                     mov_imm(ARG4, seg.flags);
                     load_erl_bits_state(ARG1);
                     runtime_call<4>(erts_new_bs_put_integer);
-                    if (exact_type(seg.src, BEAM_TYPE_INTEGER)) {
+                    if (exact_type<BeamTypeId::Integer>(seg.src)) {
                         comment("skipped test for success because construction "
                                 "can't fail");
                     } else {
@@ -3302,7 +3299,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         /* Try to keep track whether the next segment is byte
          * aligned. */
         if (seg.type == am_append || seg.type == am_private_append) {
-            if (!exact_type(seg.src, BEAM_TYPE_BITSTRING) ||
+            if (!exact_type<BeamTypeId::Bitstring>(seg.src) ||
                 std::gcd(getSizeUnit(seg.src), 8) != 8) {
                 is_byte_aligned = false;
             }

--- a/erts/emulator/beam/jit/x86/instr_float.cpp
+++ b/erts/emulator/beam/jit/x86/instr_float.cpp
@@ -158,12 +158,12 @@ void BeamModuleAssembler::emit_fconv(const ArgSource &Src,
 
     a.bind(not_small);
     {
-        if (masked_types(Src, BEAM_TYPE_FLOAT) == BEAM_TYPE_NONE) {
+        if (never_one_of<BeamTypeId::Float>(Src)) {
             comment("skipped float path since source cannot be a float");
         } else {
             /* If the source is always a number, we can skip the box test when
              * it's not a small. */
-            if (always_one_of(Src, BEAM_TYPE_FLOAT | BEAM_TYPE_INTEGER)) {
+            if (always_one_of<BeamTypeId::Number>(Src)) {
                 comment("skipped box test since source is always a number");
             } else {
                 emit_is_boxed(fallback, Src, ARG2, dShort);

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -389,8 +389,8 @@ void BeamModuleAssembler::emit_i_call_fun2(const ArgVal &Tag,
         mov_imm(ARG3, Arity.get());
 
         auto target = emit_call_fun(
-                always_one_of(Func, BEAM_TYPE_MASK_ALWAYS_BOXED),
-                masked_types(Func, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_FUN,
+                always_one_of<BeamTypeId::AlwaysBoxed>(Func),
+                masked_types<BeamTypeId::MaybeBoxed>(Func) == BeamTypeId::Fun,
                 Tag.as<ArgImmed>().get() == am_safe);
 
         erlang_call(target, ARG6);
@@ -410,8 +410,8 @@ void BeamModuleAssembler::emit_i_call_fun2_last(const ArgVal &Tag,
         mov_imm(ARG3, Arity.get());
 
         auto target = emit_call_fun(
-                always_one_of(Func, BEAM_TYPE_MASK_ALWAYS_BOXED),
-                masked_types(Func, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_FUN,
+                always_one_of<BeamTypeId::AlwaysBoxed>(Func),
+                masked_types<BeamTypeId::MaybeBoxed>(Func) == BeamTypeId::Fun,
                 Tag.as<ArgImmed>().get() == am_safe);
 
         emit_deallocate(Deallocate);

--- a/erts/emulator/beam/jit/x86/instr_map.cpp
+++ b/erts/emulator/beam/jit/x86/instr_map.cpp
@@ -396,7 +396,7 @@ void BeamModuleAssembler::emit_i_get_map_element(const ArgLabel &Fail,
     mov_arg(ARG1, Src);
     mov_arg(ARG2, Key);
 
-    if (masked_types(Key, BEAM_TYPE_MASK_IMMEDIATE) != BEAM_TYPE_NONE &&
+    if (maybe_one_of<BeamTypeId::MaybeImmediate>(Key) &&
         hasCpuFeature(CpuFeatures::X86::kBMI2)) {
         safe_fragment_call(ga->get_i_get_map_element_shared());
         a.jne(resolve_beam_label(Fail));

--- a/erts/emulator/beam/jit/x86/instr_select.cpp
+++ b/erts/emulator/beam/jit/x86/instr_select.cpp
@@ -55,7 +55,7 @@ void BeamModuleAssembler::emit_i_select_tuple_arity(const ArgRegister &Src,
     ERTS_CT_ASSERT(Support::isInt32(make_arityval(MAX_ARITYVAL)));
     a.mov(ARG2d, emit_boxed_val(boxed_ptr, 0, sizeof(Uint32)));
 
-    if (masked_types(Src, BEAM_TYPE_MASK_BOXED) == BEAM_TYPE_TUPLE) {
+    if (masked_types<BeamTypeId::MaybeBoxed>(Src) == BeamTypeId::Tuple) {
         comment("simplified tuple test since the source is always a tuple "
                 "when boxed");
     } else {


### PR DESCRIPTION
We've had a few too many bugs where we used `BEAM_TYPE_INTEGER | BEAM_TYPE_MASK_BOXED` instead of  `BEAM_TYPE_INTEGER | BEAM_TYPE_ALWAYS_BOXED`.

This PR turns that kind of error, and a few other misuses, into compile-time errors.