### PR TITLE
Optimize gen:send_request/3 + gen:wait_response/2 sequences

### DIFF
--- a/lib/compiler/test/receive_SUITE.erl
+++ b/lib/compiler/test/receive_SUITE.erl
@@ -200,7 +200,7 @@ coverage(Config) when is_list(Config) ->
 
 receive_in_called_function() ->
     RefA = make_ref(),
-    RefB = make_ref(),
+    RefB = returns_reference(),
 
     self() ! hello,
     self() ! RefA,
@@ -221,6 +221,9 @@ receive_in_called_function() ->
     ricf_1(Foo, Bar),
 
     ok.
+
+returns_reference() ->
+    make_ref().
 
 ricf_1(A, B) ->
     %% Both A and B are fed a reference at least once, so both of these loops

--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -40,6 +40,8 @@
 
 -export([format_status_header/2, format_status/4]).
 
+-export(['@wait_response_recv_opt'/3]).
+
 -define(MAX_INT_TIMEOUT, 4294967295).
 -define(default_timeout, 5000).
 
@@ -312,6 +314,17 @@ do_send_request(Process, Tag, Request) ->
     ReqId = erlang:monitor(process, Process, [{alias, demonitor}]),
     _ = erlang:send(Process, {Tag, {self(), [alias|ReqId]}, Request}, [noconnect]),
     ReqId.
+
+-spec '@wait_response_recv_opt'(term(), term(), term()) -> ok.
+'@wait_response_recv_opt'(Process, Tag, Request) ->
+    %% Enables reference optimization in wait_response/2 and
+    %% receive_response/2
+    %%
+    %% This never actually runs and is only used to trigger the optimization,
+    %% see the module comment in beam_ssa_recv for details.
+    _ = wait_response(send_request(Process, Tag, Request), infinity),
+    _ = receive_response(send_request(Process, Tag, Request), infinity),
+    ok.
 
 %%
 %% Wait for a reply to the client.


### PR DESCRIPTION
`gen_server:call/2,3` uses an optimization where only the messages received after sending the request are searched for the response, greatly speeding up calls inside processes that have very large message queues.

Unfortunately, this optimization doesn't kick in if you split it up into the largely equivalent `gen_server:send_request/2` and `gen_server:receive_response/2` functions. This PR fixes that.