### PR TITLE
Update io_protocol.xml

### DIFF
--- a/lib/stdlib/doc/src/io_protocol.xml
+++ b/lib/stdlib/doc/src/io_protocol.xml
@@ -449,10 +449,10 @@ ok
         <c>columns</c>.</item>
     </list>
 
-    <p>The I/O server is to send the <c>Reply</c> as:</p>
+      <p>The I/O server is to send the <c>Reply</c> (successful dimension integer value <pre>N</pre>) as:</p>
 
     <pre>
-{ok, N}
+N
 {error, Error}</pre>
 
    <list type="bulleted">

--- a/lib/stdlib/doc/src/io_protocol.xml
+++ b/lib/stdlib/doc/src/io_protocol.xml
@@ -449,7 +449,7 @@ ok
         <c>columns</c>.</item>
     </list>
 
-      <p>The I/O server is to send the <c>Reply</c> (successful dimension integer value <pre>N</pre>) as:</p>
+      <p>The I/O server is to send as the <c>Reply</c> one of:</p>
 
     <pre>
 N


### PR DESCRIPTION
The documentation appears to be incorrect, judging from the following LOC:

https://github.com/erlang/otp/blob/a213a9a9541731f1f68a85d9cc14af9535d9be14/lib/stdlib/src/io.erl#L148-L154