### PR TITLE
Fix typo in lib/observer crashdump_viewer

### DIFF
--- a/lib/observer/src/crashdump_viewer.erl
+++ b/lib/observer/src/crashdump_viewer.erl
@@ -1399,7 +1399,7 @@ get_pid_from_name(Name,Node) ->
 		[{_,Pid}] when is_pid(Pid) ->
 		    pid_to_list(Pid);
 		_ ->
-		    "<unkonwn_pid>"
+		    "<unknown_pid>"
 	    end;
 	_ ->
 	    "<unknown_pid_other_node>"


### PR DESCRIPTION
Fix typo: `unkonwn` -> `unknown`