### PR TITLE
[#6748] Unknown posix errors should include the error reason

### DIFF
--- a/lib/kernel/src/erl_erts_errors.erl
+++ b/lib/kernel/src/erl_erts_errors.erl
@@ -1443,7 +1443,7 @@ is_flat_char_list(_) -> false.
 
 maybe_posix_message(Cause, HasDevice) ->
     case erl_posix_msg:message(Cause) of
-        "unknown POSIX error" ->
+        "unknown POSIX error" ++ _ ->
             unknown;
         PosixStr when HasDevice ->
             [unicode:characters_to_binary(

--- a/lib/kernel/src/erl_kernel_errors.erl
+++ b/lib/kernel/src/erl_kernel_errors.erl
@@ -75,7 +75,7 @@ format_os_error(_, _, _) ->
 
 maybe_posix_message(Reason) ->
     case erl_posix_msg:message(Reason) of
-        "unknown POSIX error" ->
+        "unknown POSIX error" ++ _ ->
             io_lib:format("open_port failed with reason: ~tp",[Reason]);
         PosixStr ->
             io_lib:format("~ts (~tp)",[PosixStr, Reason])

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2665,7 +2665,7 @@ unexpected_format(Error) ->
 
 file_error_format({error, Error})->
     case file:format_error(Error) of
-	"unknown POSIX error" ->
+	"unknown POSIX error" ++ _ ->
 	    "decoding error";
 	Str ->
 	    Str

--- a/lib/stdlib/src/erl_posix_msg.erl
+++ b/lib/stdlib/src/erl_posix_msg.erl
@@ -172,4 +172,4 @@ message_1(exfull) -> <<"message tables full">>;
 message_1(nxdomain) -> <<"non-existing domain">>;
 message_1(exbadport) -> <<"inet_drv bad port state">>;
 message_1(exbadseq) -> <<"inet_drv bad request sequence">>;
-message_1(_) -> <<"unknown POSIX error">>.
+message_1(Other) -> <<"unknown POSIX error: ", (atom_to_binary(Other))/binary>>.

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -508,7 +508,7 @@ format_io_error_cause(_, _, _, _HasDevice) ->
 
 maybe_posix_message(Cause, HasDevice) ->
     case erl_posix_msg:message(Cause) of
-        "unknown POSIX error" ->
+        "unknown POSIX error" ++ _ ->
             unknown;
         PosixStr when HasDevice ->
             [io_lib:format("~ts (~tp)",[PosixStr, Cause])];


### PR DESCRIPTION
Fixes https://github.com/erlang/otp/issues/6748 

I updated the PR in `hex_core` to not leak the `too_big` error down into `erl_posix_msg.erl` but I believe the PR still stands. Someone else may end up in a similar scenario and end up requiring to patch OTP in order to figure out where the error is originating from. 