### PR TITLE
Add reversed iterators for maps

### DIFF
--- a/lib/stdlib/doc/src/io.xml
+++ b/lib/stdlib/doc/src/io.xml
@@ -204,16 +204,11 @@ ok</pre>
                 <pre>
 > <input>M = #{ a => 1, b => 2 }.</input>
 #{a => 1,b => 2}
-> <input><![CDATA[io:format("~Kp~n", [fun(A, B) -> B =< A end, M]).]]></input>
+> <input><![CDATA[io:format("~Kp~n", [reversed, M]).]]></input>
 #{b => 2,a => 1}
 ok</pre>
               </item>
             </taglist>
-            <!-- <list type="bulleted">
-              <item><p><c>t</c>, for Unicode translation.</p></item>
-              <item><p><c>l</c>, for stopping <c>p</c> and <c>P</c>
-                from detecting printable characters.</p></item>
-            </list> -->
         </item>
       </list>
         <p>If <c>F</c>, <c>P</c>, or <c>Pad</c> is a <c>*</c> character,

--- a/lib/stdlib/doc/src/io_lib.xml
+++ b/lib/stdlib/doc/src/io_lib.xml
@@ -93,8 +93,8 @@
           <c>l</c> is present.</p>
         </item>
         <item><p><c>maps_order</c> is set to <c>undefined</c> by default,
-          <c>ordered</c> if modifier <c>k</c> is present, or <c>CmpFun</c>
-          if modifier <c>K</c> is present.</p>
+          <c>ordered</c> if modifier <c>k</c> is present, or <c>reversed</c>
+          or <c>CmpFun</c> if modifier <c>K</c> is present.</p>
         </item>
       </list>
       </desc>

--- a/lib/stdlib/doc/src/maps.xml
+++ b/lib/stdlib/doc/src/maps.xml
@@ -61,7 +61,8 @@
       <desc>
         <p>Key-based iterator order option that can be one of <c>undefined</c>
           (default for <seemfa marker="#iterator/1"><c>maps:iterator/1</c></seemfa>),
-          <c>ordered</c> (sorted in map-key order), or a custom sorting function.</p>
+          <c>ordered</c> (sorted in map-key order), <c>reversed</c>,
+          or a custom sorting function.</p>
         <p>Used by <seemfa marker="#iterator/2"><c>maps:iterator/2</c></seemfa>.</p>
         <p>The
         <seeguide
@@ -400,7 +401,7 @@ none</code>
           <c><anno>Map</anno></c> is not a map or if <c><anno>Order</anno></c>
           is invalid.</p>
         <p><em>Example (when </em><c><anno>Order</anno></c><em> is </em><c>ordered</c><em>):</em></p>
-        <code type="none">
+        <code type="none"><![CDATA[
 > M = #{ a => 1, b => 2 }.
 #{a => 1,b => 2}
 > OrdI = maps:iterator(M, ordered), ok.
@@ -410,12 +411,13 @@ ok
 > {K2, V2, OrdI3} = maps:next(OrdI2),{K2, V2}.
 {b,2}
 > maps:next(OrdI3).
-none</code>
-        <p><em>Example (when </em><c><anno>Order</anno></c><em> is a custom sorting function):</em></p>
+none
+     ]]></code>
+        <p><em>Example (when </em><c><anno>Order</anno></c><em> is </em><c>reversed</c><em>):</em></p>
         <code type="none"><![CDATA[
 > M = #{ a => 1, b => 2 }.
 #{a => 1,b => 2}
-> RevI = maps:iterator(M, fun(A, B) -> B =< A end), ok.
+> RevI = maps:iterator(M, reversed), ok.
 ok
 > {K2, V2, RevI2} = maps:next(RevI), {K2, V2}.
 {b,2}
@@ -423,6 +425,19 @@ ok
 {a,1}
 > maps:next(RevI3).
 none
+     ]]></code>
+        <p><em>Example (when </em><c><anno>Order</anno></c><em> is an arithmetic sorting function):</em></p>
+        <code type="none"><![CDATA[
+> M = #{ -1 => a, -1.0 => b, 0 => c, 0.0 => d }.
+#{-1 => a,0 => c,-1.0 => b,0.0 => d}
+> ArithOrdI = maps:iterator(M, fun(A, B) -> A =< B end), ok.
+ok
+> maps:to_list(ArithOrdI).
+[{-1,a},{-1.0,b},{0,c},{0.0,d}]
+> ArithRevI = maps:iterator(M, fun(A, B) -> B < A end), ok.
+ok
+> maps:to_list(ArithRevI).
+[{0.0,d},{0,c},{-1.0,b},{-1,a}]
      ]]></code>
       </desc>
     </func>

--- a/lib/stdlib/src/io_lib_format.erl
+++ b/lib/stdlib/src/io_lib_format.erl
@@ -106,7 +106,7 @@ scan(Format, Args) ->
 unscan(Cs) ->
     {print(Cs), args(Cs)}.
 
-args([#{args := As, maps_order := O} | Cs]) when is_function(O, 2) ->
+args([#{args := As, maps_order := O} | Cs]) when is_function(O, 2); O =:= reversed ->
     [O | As] ++ args(Cs);
 args([#{args := As} | Cs]) ->
     As ++ args(Cs);
@@ -149,6 +149,7 @@ print_strings(true) -> "".
 
 print_maps_order(undefined) -> "";
 print_maps_order(ordered) -> "k";
+print_maps_order(reversed) -> "K";
 print_maps_order(CmpFun) when is_function(CmpFun, 2) -> "K".
 
 collect([$~|Fmt0], Args0) ->

--- a/lib/stdlib/src/maps.erl
+++ b/lib/stdlib/src/maps.erl
@@ -42,7 +42,8 @@
 
 -type iterator() :: iterator(term(), term()).
 
--type iterator_order(Key) :: undefined | ordered | fun((A :: Key, B :: Key) -> boolean()).
+-type iterator_order(Key) :: undefined | ordered | reversed
+                           | fun((A :: Key, B :: Key) -> boolean()).
 -type iterator_order() :: iterator_order(term()).
 
 -export_type([iterator/2, iterator/0, iterator_order/1, iterator_order/0]).
@@ -495,6 +496,10 @@ iterator(M, undefined) when is_map(M) ->
     [0 | M];
 iterator(M, ordered) when is_map(M) ->
     CmpFun = fun(A, B) -> erts_internal:cmp_term(A, B) =< 0 end,
+    Keys = lists:sort(CmpFun, maps:keys(M)),
+    [Keys | M];
+iterator(M, reversed) when is_map(M) ->
+    CmpFun = fun(A, B) -> erts_internal:cmp_term(B, A) =< 0 end,
     Keys = lists:sort(CmpFun, maps:keys(M)),
     [Keys | M];
 iterator(M, CmpFun) when is_map(M), is_function(CmpFun, 2) ->

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -2275,7 +2275,8 @@ maps(_Config) ->
     %% Therefore, play it completely safe by not assuming any order
     %% in a map with more than one element.
 
-    RevCmpFun = fun(A, B) -> B =< A end,
+    AOrdCmpFun = fun(A, B) -> A =< B end,
+    ARevCmpFun = fun(A, B) -> B < A end,
 
     AtomMap1 = #{a => b},
     AtomMap2 = #{a => b, c => d},
@@ -2291,7 +2292,9 @@ maps(_Config) ->
     re_fmt(<<"#\\{(a => b|c => d|e => f),[.][.][.]\\}">>,
            "~KW", [undefined, AtomMap3, 2]),
     "#{a => b,c => d,e => f}" = fmt("~Kw", [ordered, AtomMap3]),
-    "#{e => f,c => d,a => b}" = fmt("~Kw", [RevCmpFun, AtomMap3]),
+    "#{e => f,c => d,a => b}" = fmt("~Kw", [reversed, AtomMap3]),
+    "#{a => b,c => d,e => f}" = fmt("~Kw", [AOrdCmpFun, AtomMap3]),
+    "#{e => f,c => d,a => b}" = fmt("~Kw", [ARevCmpFun, AtomMap3]),
 
     "#{}" = fmt("~p", [#{}]),
     "#{a => b}" = fmt("~p", [AtomMap1]),
@@ -2304,7 +2307,9 @@ maps(_Config) ->
     re_fmt(<<"#\\{(a => b|c => d|e => f),[.][.][.]\\}">>,
            "~KP", [undefined, AtomMap3, 2]),
     "#{a => b,c => d,e => f}" = fmt("~Kp", [ordered, AtomMap3]),
-    "#{e => f,c => d,a => b}" = fmt("~Kp", [RevCmpFun, AtomMap3]),
+    "#{e => f,c => d,a => b}" = fmt("~Kp", [reversed, AtomMap3]),
+    "#{a => b,c => d,e => f}" = fmt("~Kp", [AOrdCmpFun, AtomMap3]),
+    "#{e => f,c => d,a => b}" = fmt("~Kp", [ARevCmpFun, AtomMap3]),
 
     List = [{I, I * I} || I <- lists:seq(1, 64)],
     Map = maps:from_list(List),
@@ -2312,7 +2317,20 @@ maps(_Config) ->
     "#{...}" = fmt("~P", [Map, 1]),
     "#{1 => 1,...}" = fmt("~kP", [Map, 2]),
     "#{1 => 1,...}" = fmt("~KP", [ordered, Map, 2]),
-    "#{64 => 4096,...}" = fmt("~KP", [RevCmpFun, Map, 2]),
+    "#{64 => 4096,...}" = fmt("~KP", [reversed, Map, 2]),
+    "#{1 => 1,...}" = fmt("~KP", [AOrdCmpFun, Map, 2]),
+    "#{64 => 4096,...}" = fmt("~KP", [ARevCmpFun, Map, 2]),
+
+    FloatIntegerMap = #{-1.0 => a, 0.0 => b, -1 => c, 0 => d},
+    re_fmt(<<"#\\{(-1.0 => a|0.0 => b|-1 => c|0 => d),[.][.][.]\\}">>,
+           "~P", [FloatIntegerMap, 2]),
+    "#{-1 => c,0 => d,-1.0 => a,0.0 => b}" = fmt("~kp", [FloatIntegerMap]),
+    re_fmt(<<"#\\{(-1.0 => a|0.0 => b|-1 => c|0 => d),[.][.][.]\\}">>,
+           "~KP", [undefined, FloatIntegerMap, 2]),
+    "#{-1 => c,0 => d,-1.0 => a,0.0 => b}" = fmt("~Kp", [ordered, FloatIntegerMap]),
+    "#{0.0 => b,-1.0 => a,0 => d,-1 => c}" = fmt("~Kp", [reversed, FloatIntegerMap]),
+    "#{-1 => c,-1.0 => a,0 => d,0.0 => b}" = fmt("~Kp", [AOrdCmpFun, FloatIntegerMap]),
+    "#{0.0 => b,0 => d,-1.0 => a,-1 => c}" = fmt("~Kp", [ARevCmpFun, FloatIntegerMap]),
 
     %% Print a map and parse it back to a map.
     S = fmt("~p\n", [Map]),


### PR DESCRIPTION
This PR is a continuation of #6718 which adds support for `reversed` key order for maps iterators.

Summary:

1. Changed type: `maps:iterator_order/0,1` now supports `reversed`
2. Changed function: `maps:iterator/2` now accepts `reversed`
3. Tests for all of the above in `io_SUITE` and `maps_SUITE`
    > ```bash
    > make stdlib_test ARGS="-suite io_SUITE"
    > make stdlib_test ARGS="-suite maps_SUITE"
    > ```
4. Updated `maps.xml`, `io.xml`, and `io_lib.xml` documentation.