### PR TITLE
Don't break bs_match sequences by mixing registers (again)

### DIFF
--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -489,7 +489,8 @@ prefer_xregs_is([#cg_set{op=Op}=I|Is], St, Copies0, Acc)
   when Op =:= bs_checked_get;
        Op =:= bs_checked_skip;
        Op =:= bs_checked_get_tail;
-       Op =:= bs_ensure ->
+       Op =:= bs_ensure;
+       Op =:= bs_match_string ->
     Copies = prefer_xregs_prune(I, Copies0, St),
     prefer_xregs_is(Is, St, Copies, [I|Acc]);
 prefer_xregs_is([#cg_set{args=Args0}=I0|Is], St, Copies0, Acc) ->

--- a/lib/compiler/test/bs_match_SUITE.erl
+++ b/lib/compiler/test/bs_match_SUITE.erl
@@ -2690,6 +2690,8 @@ bs_match(_Config) ->
     <<"abc">> = do_bs_match_gh_6660(id(<<"abc">>)),
     {'EXIT', {{try_clause,abc},_}} = catch do_bs_match_gh_6660(id(abc)),
 
+    {'EXIT',{{case_clause,_},_}} = catch do_bs_match_gh_6755(id(<<"1000">>)),
+
     ok.
 
 do_bs_match_1(_, X) ->
@@ -2747,6 +2749,18 @@ do_bs_match_gh_6660(X) ->
             Y
     after
         ok
+    end.
+
+do_bs_match_gh_6755(B) ->
+    C = case B of
+            <<"1000">> -> test;
+            <<"1001">> -> test2
+        end,
+
+    _ = atom_to_list(C),
+
+    case B of
+        <<"b">> -> b
     end.
 
 %% GH-6348/OTP-18297: Allow aliases for binaries.


### PR DESCRIPTION
See #6623 for a fix to a similar bug reported in #6613.

Closes #6755