### PR TITLE
kernel: `gen_tcp:connect/3` should not accept empty strings

### DIFF
--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -161,7 +161,7 @@ connect(SockAddr, Opts) ->
     connect(SockAddr, Opts, infinity).
 
 -spec connect(Address, Port, Opts) -> {ok, Socket} | {error, Reason} when
-      Address  :: inet:socket_address() | inet:hostname(),
+      Address  :: inet:socket_address() | nonempty_string() | atom(),
       Port     :: inet:port_number(),
       Opts     :: [inet:inet_backend() | connect_option()],
       Socket   :: socket(),
@@ -202,7 +202,7 @@ connect(#{family := Fam} = SockAddr, Opts, Timeout)
 
 -spec connect(Address, Port, Opts, Timeout) ->
                      {ok, Socket} | {error, Reason} when
-      Address :: inet:socket_address() | inet:hostname(),
+      Address :: inet:socket_address() | nonempty_string() | atom(),
       Port    :: inet:port_number(),
       Opts    :: [inet:inet_backend() | connect_option()],
       Timeout :: timeout(),

--- a/lib/kernel/test/gen_tcp_api_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_api_SUITE.erl
@@ -362,6 +362,9 @@ t_connect_bad(Config) when is_list(Config) ->
                                        ?INET_BACKEND_OPTS(Config)),
     io:format("Error for connection attempt to non-existing host: ~p",
 	      [Reason2]),
+
+    {'EXIT', badarg} = catch gen_tcp:connect("", 80,
+                                             ?INET_BACKEND_OPTS(Config)),
     ok.
 
 


### PR DESCRIPTION
- This PR changes the type spec of the `gen_tcp:connect/3` to specify that its first argument cannot contain an empty string. In this case, that means replacing `inet:hostname()` which is equivalent to `atom() | string()` by `atom() | nonempty_string()`.
- The PR also adds a test case that checks that calling the `gen_tcp:connect/3` with an empty string as first argument throws a `badarg` error and this is the expected behaviour.
- Closes #6353 