### PR TITLE
Simplify some calls to application:get_env/2

### DIFF
--- a/lib/kernel/src/error_logger.erl
+++ b/lib/kernel/src/error_logger.erl
@@ -578,11 +578,9 @@ limit_term(Term) ->
 -spec get_format_depth() -> 'unlimited' | pos_integer().
 
 get_format_depth() ->
-    case application:get_env(kernel, error_logger_format_depth) of
-	{ok, Depth} when is_integer(Depth) ->
+    case application:get_env(kernel, error_logger_format_depth, unlimited) of
+	Depth when is_integer(Depth) ->
 	    max(10, Depth);
-        {ok, unlimited} ->
-            unlimited;
-	undefined ->
-	    unlimited
+        unlimited ->
+            unlimited
     end.

--- a/lib/kernel/src/group_history.erl
+++ b/lib/kernel/src/group_history.erl
@@ -310,10 +310,7 @@ disk_log_info(Tag) ->
     Value.
 
 find_wrap_values() ->
-    ConfSize = case application:get_env(kernel, shell_history_file_bytes) of
-        undefined -> ?DEFAULT_SIZE;
-        {ok, S} -> S
-    end,
+    ConfSize = application:get_env(kernel, shell_history_file_bytes, ?DEFAULT_SIZE),
     SizePerFile = max(?MIN_HISTORY_SIZE, ConfSize div ?MAX_HISTORY_FILES),
     FileCount = if SizePerFile > ?MIN_HISTORY_SIZE ->
                        ?MAX_HISTORY_FILES


### PR DESCRIPTION
Replace some calls to `application:get_env/2` with `application:get_env/3`. This simplifies the code at the call site, and as an additional benefit, `application:get_env/3` is slightly more efficient than `application:get_env/2`.