### PR TITLE
compiler: Print map entries in deterministic order

### DIFF
--- a/lib/compiler/src/beam_listing.erl
+++ b/lib/compiler/src/beam_listing.erl
@@ -41,19 +41,18 @@ module(File, #c_module{}=Core) ->
 module(File, #k_mdef{}=Kern) ->
     %% This is a kernel module.
     io:put_chars(File, v3_kernel_pp:format(Kern));
-    %%io:put_chars(File, io_lib:format("~p~n", [Kern]));
 module(File, #b_module{name=Mod,exports=Exp,attributes=Attr,body=Fs}) ->
     io:format(File, "module ~p.\n", [Mod]),
     io:format(File, "exports ~p.\n", [Exp]),
-    io:format(File, "attributes ~p.\n\n", [Attr]),
+    io:format(File, "attributes ~kp.\n\n", [Attr]),
     PP = [beam_ssa_pp:format_function(F) || F <- Fs],
     io:put_chars(File, lists:join($\n, PP));
 module(Stream, {Mod,Exp,Attr,Code,NumLabels}) ->
     %% This is output from v3_codegen.
-    io:format(Stream, "{module, ~p}.  %% version = ~w\n",
+    io:format(Stream, "{module, ~kp}.  %% version = ~w\n",
 	      [Mod, beam_opcodes:format_number()]),
     io:format(Stream, "\n{exports, ~p}.\n", [Exp]),
-    io:format(Stream, "\n{attributes, ~p}.\n", [Attr]),
+    io:format(Stream, "\n{attributes, ~kp}.\n", [Attr]),
     io:format(Stream, "\n{labels, ~p}.\n", [NumLabels]),
     Lbl2Fun = foldl(fun({function,Name,Arity,Entry,_}, Map) ->
                             Map#{ Entry => {Name,Arity} }
@@ -66,7 +65,7 @@ module(Stream, {Mod,Exp,Attr,Code,NumLabels}) ->
       end, Code);
 module(Stream, [_|_]=Fs) ->
     %% Form-based abstract format.
-    foreach(fun (F) -> io:format(Stream, "~p.\n", [F]) end, Fs).
+    foreach(fun (F) -> io:format(Stream, "~kp.\n", [F]) end, Fs).
 
 format_asm([{label,L}|Is], Lbl2Fun) ->
     [io_lib:format("  {label,~p}.\n", [L])|format_asm(Is, Lbl2Fun)];
@@ -75,7 +74,7 @@ format_asm([I={Call,_,L}|Is], Lbl2Fun) when Call =:= call; Call =:= call_only ->
 format_asm([I={call_last,_,L,_}|Is], Lbl2Fun) ->
     format_asm_call(L, I, Is, Lbl2Fun);
 format_asm([I|Is], Lbl2Fun) ->
-    [io_lib:format("    ~p", [I]),".\n"|format_asm(Is, Lbl2Fun)];
+    [io_lib:format("    ~kp", [I]),".\n"|format_asm(Is, Lbl2Fun)];
 format_asm([], _) -> [].
 
 format_asm_call({f,L}, I, Is, Lbl2Fun) ->

--- a/lib/compiler/src/beam_ssa_check.erl
+++ b/lib/compiler/src/beam_ssa_check.erl
@@ -196,7 +196,7 @@ post_args([PA|PArgs], [AA|AArgs], Env) ->
 post_args([], [], Env) ->
     Env;
 post_args(Pattern, Args, _Env) ->
-    io:format("Failed to match ~p <-> ~p~n", [Pattern, Args]),
+    io:format("Failed to match ~kp <-> ~kp~n", [Pattern, Args]),
     error({internal_pattern_match_error,post_args}).
 
 post_phi_args([{'...',_}], _, Env) ->

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -99,17 +99,17 @@ format_anno(parameter_info, Map) when is_map(Map) ->
                  {V,I} <- Params]]
     end;
 format_anno(Key, Map) when is_map(Map) ->
-    Sorted = lists:sort(maps:to_list(Map)),
+    Sorted = maps:to_list(maps:iterator(Map, ordered)),
     [io_lib:format("%% ~s:\n", [Key]),
-     [io_lib:format("%%    ~w => ~w\n", [K,V]) || {K,V} <- Sorted]];
+     [io_lib:format("%%    ~kw => ~kw\n", [K,V]) || {K,V} <- Sorted]];
 format_anno(Key, Value) ->
-    io_lib:format("%% ~s: ~p\n", [Key,Value]).
+    io_lib:format("%% ~s: ~kp\n", [Key,Value]).
 
 format_param_info([{type, T} | Infos], Break) ->
     [format_type(T, Break) |
      format_param_info(Infos, Break)];
 format_param_info([Info | Infos], Break) ->
-    [io_lib:format("~s~p", [Break, Info]) |
+    [io_lib:format("~s~kp", [Break, Info]) |
      format_param_info(Infos, Break)];
 format_param_info([], _Break) ->
     [].
@@ -127,9 +127,9 @@ format_block(L, Blocks, FuncAnno) ->
     #b_blk{anno=Anno,is=Is,last=Last} = maps:get(L, Blocks),
     [case map_size(Anno) of
          0 -> [];
-         _ -> io_lib:format("%% ~p\n", [Anno])
+         _ -> io_lib:format("%% ~kp\n", [Anno])
      end,
-     io_lib:format("~p:", [L]),
+     io_lib:format("~kp:", [L]),
      format_instrs(Is, FuncAnno, true),
      $\n,
      format_terminator(Last, FuncAnno)].
@@ -223,7 +223,7 @@ format_args(Args, FuncAnno) ->
 format_arg(#b_var{}=Arg, FuncAnno) ->
     format_var(Arg, FuncAnno);
 format_arg(#b_literal{val=Val}, _FuncAnno) ->
-    io_lib:format("`~p`", [Val]);
+    io_lib:format("`~kp`", [Val]);
 format_arg(#b_remote{mod=Mod,name=Name,arity=Arity}, FuncAnno) ->
     io_lib:format("(~ts:~ts/~p)",
                   [format_arg(Mod, FuncAnno),format_arg(Name, FuncAnno),Arity]);
@@ -233,7 +233,7 @@ format_arg({Value,Label}, FuncAnno) when is_integer(Label) ->
     io_lib:format("{ ~ts, ~ts }", [format_arg(Value, FuncAnno),
                                    format_label(Label)]);
 format_arg(Other, _) ->
-    io_lib:format("*** ~p ***", [Other]).
+    io_lib:format("*** ~kp ***", [Other]).
 
 format_switch_list(List, FuncAnno) ->
     Ss = [io_lib:format("{ ~ts, ~ts }", [format_arg(Val, FuncAnno),
@@ -278,7 +278,7 @@ format_instr_anno_1(Anno) ->
         0 ->
             [];
         _ ->
-            [io_lib:format("  %% Anno: ~p\n", [Anno])]
+            [io_lib:format("  %% Anno: ~kp\n", [Anno])]
     end.
 
 format_live_interval(#b_var{}=Dst, #{live_intervals:=Intervals}) ->

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -362,6 +362,8 @@ format_type(port) ->
     "pid()";
 format_type(reference) ->
     "reference()";
+format_type(identifier) ->
+    "identifier()";
 format_type(none) ->
     "none()";
 format_type(#t_union{atom=A,list=L,number=N,tuple_set=Ts,other=O}) ->

--- a/lib/compiler/src/compiler.app.src
+++ b/lib/compiler/src/compiler.app.src
@@ -82,5 +82,5 @@
   {registered, []},
   {applications, [kernel, stdlib]},
   {env, []},
-  {runtime_dependencies, ["stdlib-4.0","kernel-8.4","erts-13.0",
+  {runtime_dependencies, ["stdlib-@OTP-18414@","kernel-8.4","erts-13.0",
 			  "crypto-5.1"]}]}.

--- a/lib/compiler/src/v3_kernel_pp.erl
+++ b/lib/compiler/src/v3_kernel_pp.erl
@@ -139,7 +139,7 @@ format_1(#k_bin_end{}, _Ctxt) -> "#<>#";
 format_1(#k_literal{val=A}, _Ctxt) when is_atom(A) ->
     core_atom(A);
 format_1(#k_literal{val=Term}, _Ctxt) ->
-    io_lib:format("~p", [Term]);
+    io_lib:format("~kp", [Term]);
 format_1(#k_local{name=N,arity=A}, Ctxt) ->
     "local " ++ format_fa_pair({N,A}, Ctxt);
 format_1(#k_remote{mod=M,name=N,arity=A}, _Ctxt) ->


### PR DESCRIPTION
This is most important for *.S files because they are often diffed using the [scripts/diffable](https://github.com/erlang/otp/blob/master/scripts/diffable) script.