### PR TITLE
Simplify implementation of maps:to_list/1 for iterators

### DIFF
--- a/lib/stdlib/test/maps_SUITE.erl
+++ b/lib/stdlib/test/maps_SUITE.erl
@@ -882,6 +882,7 @@ t_groups_from_list(_Config) ->
 
 error_info(_Config) ->
     BadIterator = [-1|#{}],
+    BadIterator2 = {x, y, z},
     GoodIterator = maps:iterator(#{}),
     BadOrder = fun(_) -> true end,
     GoodOrder = fun(A, B) -> A =< B end,
@@ -973,6 +974,7 @@ error_info(_Config) ->
 
          {to_list,[xyz]},
          {to_list,[BadIterator]},
+         {to_list,[BadIterator2]},
 
          {update,[key, value, no_map]},
 


### PR DESCRIPTION
`maps:to_list` for iterators can be written in a much simpler fashion by simply _trying_ the given iterator with `next` (see https://github.com/erlang/otp/pull/6718#discussion_r1091660046).