### PR TITLE
Silent init error for gen_server and gen_statem / otp-18423

### DIFF
--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -1967,7 +1967,7 @@ format_status(Status) ->
           <item>
             <p>
               Initialization failed.
-	      An exit signal with</p>
+	      An exit signal with exit reason</p>
 	      <taglist>
 		<tag>stop:</tag>
 		<item><c>Reason</c></item>

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -1916,6 +1916,7 @@ format_status(Status) ->
         <v>&nbsp;&nbsp;| {ok,State,hibernate}</v>
         <v>&nbsp;&nbsp;| {ok,State,{continue,Continue}}</v>
         <v>&nbsp;&nbsp;| {stop,Reason}</v>
+        <v>&nbsp;&nbsp;| {shutdown,Reason}</v>
         <v>&nbsp;&nbsp;| ignore</v>
         <v>&nbsp;State = term()</v>
         <v>
@@ -1960,14 +1961,22 @@ format_status(Status) ->
           </item>
           <tag>
             <c>{stop,Reason}</c><br/>
+            <c>{shutdown,Reason}</c><br/>
             <c>ignore</c>
           </tag>
           <item>
             <p>
               Initialization failed.
-              An exit signal with this <c>Reason</c>
-              (or with reason <c>normal</c> if <c>ignore</c> is returned)
-              is sent to linked processes and ports,
+	      An exit signal with</p>
+	      <taglist>
+		<tag>stop:</tag>
+		<item><c>Reason</c></item>
+		<tag>shutdown:</tag>
+		<item><c>{shutdown, Reason}</c></item>
+		<tag>ignore:</tag>
+		<item><c>normal</c></item>
+	      </taglist>
+              <p>is sent to linked processes and ports,
               notably to the process starting the gen_server when
               <seemfa marker="#start_link/3">
                 <c>start_link/3,4</c>

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -2514,7 +2514,7 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>The difference between returning <c>{stop, Reason}</c> and
 	<c>{shutdown, Reason}</c> (from <c>Module:init/1</c>) is that
-	'shutdown' results in a "silent" termination. </p>
+	<c>shutdown</c> results in a "silent" termination. </p>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -4,7 +4,7 @@
 <erlref>
   <header>
     <copyright>
-      <year>2016</year><year>2022</year>
+      <year>2016</year><year>2023</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
     <legalnotice>
@@ -1494,7 +1494,8 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>
 	  For an unsuccesful initialization,
-          <c>{stop,<anno>Reason</anno>}</c>
+	  <c>{stop,<anno>Reason</anno>}</c>,
+	  <c>{shutdown,<anno>Reason</anno>}</c>
 	  or <c>ignore</c> should be used; see
           <seemfa marker="#start_link/3"><c>start_link/3,4</c></seemfa>.
 	</p>
@@ -2495,9 +2496,10 @@ handle_event(_, _, State, Data) ->
 	<p>
 	  If <c>Module:init/1</c> fails with <c>Reason</c>,
 	  this function returns
-	  <seetype marker="#start_ret"><c>{error,Reason}</c></seetype>.
+	  <seetype marker="#start_ret"><c>{error, Reason}</c></seetype>.
 	  If <c>Module:init/1</c> returns
-	  <seetype marker="#start_ret"><c>{stop,Reason}</c></seetype>
+	  <seetype marker="#start_ret"><c>{stop, Reason}</c></seetype>,
+	  <seetype marker="#start_ret"><c>{shutdown, Reason}</c></seetype>
 	  or
 	  <seetype marker="#start_ret"><c>ignore</c></seetype>,
 	  the process is terminated and this function
@@ -2510,6 +2512,9 @@ handle_event(_, _, State, Data) ->
           <c>Module:init/1</c> returns <c>ignore</c>) is set to linked processes
           and ports, including the process calling <c>start_link/3,4</c>.
 	</p>
+	<p>The difference between returning <c>{stop, Reason}</c> and
+	<c>{shutdown, Reason}</c> (from <c>Module:init/1</c>) is that
+	'shutdown' results in a "silent" termination. </p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -851,6 +851,19 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 	    gen:unregister_name(Name0),
 	    proc_lib:init_ack(Starter, {error, Reason}),
 	    exit(Reason);
+	{ok, {shutdown, Reason} = SHUTDOWN} ->
+            %% The point of this clause is that we shall have a *silent*
+            %% termination. The error reason will be returned to the
+            %% 'Starter' ({error, Reason}), but *no* crash report.
+	    %% For consistency, we must make sure that the
+	    %% registered name (if any) is unregistered before
+	    %% the parent process is notified about the failure.
+	    %% (Otherwise, the parent process could get
+	    %% an 'already_started' error if it immediately
+	    %% tried starting the process again.)
+	    gen:unregister_name(Name0),
+	    proc_lib:init_ack(Starter, {error, Reason}),
+	    exit(SHUTDOWN);
 	{ok, ignore} ->
 	    gen:unregister_name(Name0),
 	    proc_lib:init_ack(Starter, ignore),

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2016-2022. All Rights Reserved.
+%% Copyright Ericsson AB 2016-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -96,6 +96,9 @@
     enter_loop_opt/0,
     start_ret/0,
     start_mon_ret/0]).
+
+%% -define(DBG(T), erlang:display({{self(), ?MODULE, ?LINE, ?FUNCTION_NAME}, T})).
+
 
 %%%==========================================================================
 %%% Interface functions.
@@ -225,8 +228,9 @@
     {ok, State :: StateType, Data :: DataType} |
     {ok, State :: StateType, Data :: DataType,
      Actions :: [action()] | action()} |
-    'ignore' |
-    {'stop', Reason :: term()}.
+        'ignore' |
+        {'stop', Reason :: term()} |
+        {'shutdown', Reason :: term()}.
 
 %% Old, not advertised
 -type state_function_result() ::
@@ -1056,6 +1060,13 @@ init_result(
 	    gen:unregister_name(ServerRef),
 	    proc_lib:init_ack(Starter, {error,Reason}),
 	    exit(Reason);
+	{shutdown, Reason} = SHUTDOWN ->
+            %% The point of this clause is that we shall have a *silent*
+            %% termination. The error reason will be returned to the
+            %% 'Starter' ({error, Reason}), but *no* crash report.
+	    gen:unregister_name(ServerRef),
+	    proc_lib:init_ack(Starter, {error, Reason}),
+	    exit(SHUTDOWN);
 	ignore ->
 	    gen:unregister_name(ServerRef),
 	    proc_lib:init_ack(Starter, ignore),

--- a/lib/stdlib/test/gen_server_SUITE.erl
+++ b/lib/stdlib/test/gen_server_SUITE.erl
@@ -148,6 +148,7 @@ start(Config) when is_list(Config) ->
     OldFl = process_flag(trap_exit, true),
 
     %% anonymous
+    io:format("anonymous~n", []),
     {ok, Pid0} = gen_server:start(gen_server_SUITE, [], []),
     ok = gen_server:call(Pid0, started_p),
     ok = gen_server:call(Pid0, stop),
@@ -155,6 +156,7 @@ start(Config) when is_list(Config) ->
     {'EXIT', {noproc,_}} = (catch gen_server:call(Pid0, started_p, 1)),
 
     %% anonymous with timeout
+    io:format("try init timeout~n", []),
     {ok, Pid00} = gen_server:start(gen_server_SUITE, [],
 				   [{timeout,1000}]),
     ok = gen_server:call(Pid00, started_p),
@@ -163,9 +165,16 @@ start(Config) when is_list(Config) ->
 					[{timeout,100}]),
 
     %% anonymous with ignore
+    io:format("try init ignore~n", []),
     ignore = gen_server:start(gen_server_SUITE, ignore, []),
 
+    %% anonymous with shutdown
+    io:format("try init shutdown~n", []),
+    {error, foobar} =
+        gen_server:start(gen_server_SUITE, {shutdown, foobar}, []),
+
     %% anonymous with stop
+    io:format("try init stop~n", []),
     {error, stopped} = gen_server:start(gen_server_SUITE, stop, []),
 
     %% anonymous linked
@@ -2483,18 +2492,27 @@ spec_init_not_proc_lib(Options) ->
 init([]) ->
     {ok, []};
 init(ignore) ->
+    io:format("init(ignore)~n"),
     ignore;
 init(stop) ->
+    io:format("init(stop)~n"),
     {stop, stopped};
+init({shutdown, Reason}) ->
+    io:format("init(shutdown) -> ~w~n", [Reason]),
+    {shutdown, Reason};
 init(hibernate) ->
+    io:format("init(hibernate)~n"),
     {ok,[],hibernate};
 init(sleep) ->
+    io:format("init(sleep)~n"),
     ct:sleep(1000),
     {ok, []};
 init({continue, Pid}) ->
+    io:format("init(continue) -> ~p~n", [Pid]),
     self() ! {after_continue, Pid},
     {ok, [], {continue, {message, Pid}}};
 init({state,State}) ->
+    io:format("init(state) -> ~p~n", [State]),
     {ok,State}.
 
 handle_call(started_p, _From, State) ->
@@ -2507,6 +2525,7 @@ handle_call({call_within, T}, _From, _) ->
 handle_call(next_call, _From, call_within) ->
     {reply,ok,[]};
 handle_call(next_call, _From, State) ->
+    io:format("handle_call(next_call) -> State: ~p~n", [State]),
     {reply,false,State};
 handle_call(badreturn, _From, _State) ->
     badreturn;

--- a/lib/stdlib/test/gen_statem_SUITE.erl
+++ b/lib/stdlib/test/gen_statem_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2016-2022. All Rights Reserved.
+%% Copyright Ericsson AB 2016-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ groups() ->
      {format_log, [], tcs(format_log)}].
 
 tcs(start) ->
-    [start1, start2, start3, start4, start5, start6, start7,
+    [start1, start2, start3, start4, start5a, start5b, start6, start7,
      start8, start9, start10, start11, start12, next_events];
 tcs(stop) ->
     [stop1, stop2, stop3, stop4, stop5, stop6, stop7, stop8, stop9, stop10];
@@ -210,10 +210,20 @@ start4(Config) ->
     ok = verify_empty_msgq().
 
 %% anonymous with stop
-start5(Config) ->
+start5a(Config) ->
     OldFl = process_flag(trap_exit, true),
 
     {error,stopped} = gen_statem:start(?MODULE, start_arg(Config, stop), []),
+
+    process_flag(trap_exit, OldFl),
+    ok = verify_empty_msgq().
+
+%% anonymous with shutdown
+start5b(Config) ->
+    OldFl = process_flag(trap_exit, true),
+
+    {error, foobar} =
+        gen_statem:start(?MODULE, start_arg(Config, {shutdown, foobar}), []),
 
     process_flag(trap_exit, OldFl),
     ok = verify_empty_msgq().
@@ -2753,25 +2763,37 @@ start_arg(Config, Arg) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 init(ignore) ->
+    io:format("init(ignore)~n", []),
     ignore;
 init(stop) ->
+    io:format("init(stop)~n", []),
     {stop,stopped};
+init({shutdown, Reason}) ->
+    io:format("init(shutdown) -> Reason: ~p~n", [Reason]),
+    {shutdown, Reason};
 init(stop_shutdown) ->
+    io:format("init(stop_shutdown)~n", []),
     {stop,shutdown};
 init(sleep) ->
+    io:format("init(sleep)~n", []),
     ct:sleep(1000),
     init_sup({ok,idle,data});
 init(hiber) ->
+    io:format("init(hiber)~n", []),
     init_sup({ok,hiber_idle,[]});
 init(hiber_now) ->
+    io:format("init(hiber_now)~n", []),
     init_sup({ok,hiber_idle,[],[hibernate]});
 init({data, Data}) ->
+    io:format("init(data)~n", []),
     init_sup({ok,idle,Data});
 init({callback_mode,CallbackMode,Arg}) ->
+    io:format("init(callback_mode)~n", []),
     ets:new(?MODULE, [named_table,private]),
     ets:insert(?MODULE, {callback_mode,CallbackMode}),
     init(Arg);
 init({map_statem,#{init := Init}=Machine,Modes}) ->
+    io:format("init(map_statem)~n", []),
     ets:new(?MODULE, [named_table,private]),
     ets:insert(?MODULE, {callback_mode,[handle_event_function|Modes]}),
     case Init() of
@@ -2783,6 +2805,7 @@ init({map_statem,#{init := Init}=Machine,Modes}) ->
 	    init_sup(Other)
     end;
 init([]) ->
+    io:format("init~n", []),
     init_sup({ok,idle,data}).
 
 %% Supervise state machine parent i.e the test case, and if it dies


### PR DESCRIPTION
The point of this extension is to provide a way for a user of gen_server | gen_statem to "silently"
(*no* automatic error reports) return an error during *init* (new return value from Module:init/1).
In essence, behave as 'ignore'  but provide a way to return an '{error, Reason}' (from the 
[gen_server|gen_statem]:start_link functions).