### PR TITLE
maps: always raise a `badmap` error if an iterator fails

### DIFF
--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -982,11 +982,9 @@ must_be_map_iterator_order(_) ->
 must_be_map_or_iter(Map) when is_map(Map) ->
     [];
 must_be_map_or_iter(Iter) ->
-    try maps:next(Iter) of
-        _ -> []
-    catch
-        error:_ ->
-            not_map_or_iterator
+    case maps:is_iterator_valid(Iter) of
+        true -> [];
+        false -> not_map_or_iterator
     end.
 
 must_be_number(N) ->


### PR DESCRIPTION
Follow-up of #6762 (Thanks @bjorng for suggestions made there :smiley:)

The current implementations of `maps` functions that accept iterators (namely, `filter/2`, `filtermap/2`, `fold/3`, `foreach/2` and `map/2`) test if the input is really an iterator by calling `next/1` on it once in a `try`. If this call fails by `next` raising a **`badarg`** error, the calling function catches it and raises a **`badmap`** error instead. However, if the iterator fails later on (eg giving a tuple like `{a, b, c}` as input passes the first call to `next`, but calling it again on the follow-up "iterator" `c` fails), the **`badarg`** error is bubbled up instead of the **`badmap`** error.

Running the entire algorithm (eg. the actual mapping) in a `try` (vs only the first call to `next`) is not feasible, as this may steal errors caused by the given function (vs the iterator), and cloak them as a `badmap` error.

The proposed implementation (for `map`) tries calls to `next` (if they _could_ fail) and raises an unique error that can be identified by the calling code to reliably distinguish it from other errors caused by the given mapping function, which must be bubbled up.

Unfortunately, for basically the same reason, the function `must_be_map_or_iter` in `erl_stdlib_errors`, which decides if a given $thing is (a map or) an iterator, had to be augmented to traverse the entire iterator to produce accurate error reports.

~This PR is currently a proof of concept and only implements the proposed changes for `map`, for illustration purposes and discussion. The concept can be easily adapted to the other functions named above once this has been accepted.~