### PR TITLE
crypto: replace size/1 by byte_size/1

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -1282,7 +1282,7 @@ rand_plugin_aes_next(Key, GenWords, F, Count) ->
     {V,Cache}.
 
 block_encrypt(Key, Data) ->
-    Cipher = case size(Key) of
+    Cipher = case byte_size(Key) of
                  16 -> aes_128_ecb;
                  24 -> aes_192_ecb;
                  32 -> aes_256_ecb;
@@ -2276,7 +2276,7 @@ srp_pad_length(Width, Length) ->
     (Width - Length rem Width) rem Width.
 
 srp_pad_to(Width, Binary) ->
-    case srp_pad_length(Width, size(Binary)) of
+    case srp_pad_length(Width, byte_size(Binary)) of
         0 -> Binary;
         N -> << 0:(N*8), Binary/binary>>
     end.

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -2276,9 +2276,9 @@ srp_pad_length(Width, Length) ->
     (Width - Length rem Width) rem Width.
 
 srp_pad_to(Width, Binary) ->
-    case srp_pad_length(Width, byte_size(Binary)) of
+    case srp_pad_length(Width, bit_size(Binary)) of
         0 -> Binary;
-        N -> << 0:(N*8), Binary/binary>>
+        N -> << 0:N, Binary/binary>>
     end.
 
 srp_host_secret_nif(_Verifier, _B, _U, _A, _Prime) -> ?nif_stub.


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred.

Links to #6672 