### PR TITLE
diameter: replace size/1 by xxx_size/1

### DIFF
--- a/lib/diameter/src/base/diameter_peer_fsm.erl
+++ b/lib/diameter/src/base/diameter_peer_fsm.erl
@@ -696,16 +696,16 @@ recv(#diameter_header{length = Len} = H, Bin, Msg, #state{length_errors = E,
                                                           dictionary = Dict0}
                                                    = S)
   when E == handle;
-       0 == Len rem 4, bit_size(Bin) == 8*Len, size(Bin) =< M ->
+       is_binary(Bin), 0 == Len rem 4, bit_size(Bin) == 8*Len, byte_size(Bin) =< M ->
     recv1(diameter_codec:msg_name(Dict0, H), H, Msg, S);
 
 recv(H, Bin, _, #state{incoming_maxlen = M})
-  when M < size(Bin) ->
-    invalid(false, incoming_maxlen_exceeded, {size(Bin), H}),
+  when is_binary(Bin), M < byte_size(Bin) ->
+    invalid(false, incoming_maxlen_exceeded, {byte_size(Bin), H}),
     H;
 
-recv(H, Bin, _, #state{length_errors = E}) ->
-    T = {size(Bin), bit_size(Bin) rem 8, H},
+recv(H, Bin, _, #state{length_errors = E}) when is_binary(Bin) ->
+    T = {byte_size(Bin), bit_size(Bin) rem 8, H},
     invalid(E, message_length_mismatch, T),
     H.
 

--- a/lib/diameter/src/info/diameter_dbg.erl
+++ b/lib/diameter/src/info/diameter_dbg.erl
@@ -203,7 +203,7 @@ pp(<<Version:8, MsgLength:24,
          "Application id",
          "Hop by hop id",
          "End to end id"],
-        [Version, MsgLength, size(AVPs) + 20,
+        [Version, MsgLength, byte_size(AVPs) + 20,
          Rbit, Pbit, Ebit, Tbit, Reserved,
          CmdCode,
          ApplId,
@@ -273,7 +273,7 @@ avp(0, Data, Length, Size) ->
     data(Data, Length, Size).
 
 data(Bin, Length, Size)
-  when size(Bin) >= Length ->
+  when is_binary(Bin), byte_size(Bin) >= Length ->
     <<AVP:Length/binary, Rest/binary>> = Bin,
     ppp({"Data", AVP}),
     unpad(Rest, Size - Length, Length rem 4);
@@ -288,7 +288,7 @@ unpad(Bin, Size, N) ->
     un(Bin, Size, 4 - N).
 
 un(Bin, Size, N)
-  when size(Bin) >= N ->
+  when is_binary(Bin), byte_size(Bin) >= N ->
     ppp({"Padding bytes", N}),
     <<Pad:N/binary, Rest/binary>> = Bin,
     Bits = N*8,


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.

Links to #6672 