### PR TITLE
erts: Add `+JPperf no_fp` option to suppress frame pointers

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -1016,10 +1016,33 @@ $ <input>erl \
           descriptor input events.
         </p>
       </item>
-      <tag><marker id="+JPperf"/><c>+JPperf true|false</c></tag>
+      <tag><marker id="+JPperf"/><c>+JPperf true|false|dump|map|fp|no_fp</c></tag>
       <item>
-        <p>Enables or disables support for the `perf` profiler when running
-          with the JIT on Linux. Defaults to false.</p>
+        <p>Enables or disables support for the <c>perf</c> profiler when
+          running with the JIT on Linux. Defaults to false.</p>
+        <p>This option can be combined multiple times to enable several
+          options:</p>
+        <taglist>
+          <tag><c>dump</c></tag>
+          <item>Gives <c>perf</c> detailed line information, so that the
+            <c>perf annotate</c> feature works.</item>
+          <tag><c>map</c></tag>
+          <item>Gives <c>perf</c> a map over all module code, letting it
+            translate machine code addresses to Erlang source code
+            locations. This also enables frame pointers for Erlang code so that
+            <c>perf</c> can walk the call stacks of Erlang processes, which
+            costs one extra word per stack frame.</item>
+          <tag><c>fp</c></tag>
+          <item>Enables frame pointers independently of the <c>map</c>
+            option.</item>
+          <tag><c>no_fp</c></tag>
+          <item>Disables the frame pointers added by the <c>map</c>
+            option.</item>
+          <tag><c>true</c></tag>
+          <item>Enables <c>map</c> and <c>dump</c>.</item>
+          <tag><c>false</c></tag>
+          <item>Disables all other options.</item>
+        </taglist>
         <p>For more details about how to run perf see the
           <seeguide marker="erts:BeamAsm#linux-perf-support">perf support</seeguide>
           section in the BeamAsm internal documentation.

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -651,7 +651,7 @@ void erts_usage(void)
 
 #ifdef BEAMASM
     erts_fprintf(stderr, "-JDdump bool   enable or disable dumping of generated assembly code for each module loaded\n");
-    erts_fprintf(stderr, "-JPperf bool   enable or disable support for perf on Linux\n");
+    erts_fprintf(stderr, "-JPperf true|false|dump|map|fp|no_fp   enable or disable support for perf on Linux\n");
     erts_fprintf(stderr, "\n");
 #endif
 
@@ -1731,13 +1731,18 @@ erl_start(int argc, char **argv)
 
 #ifdef HAVE_LINUX_PERF_SUPPORT
                     if (sys_strcmp(arg, "true") == 0) {
-                        erts_jit_perf_support = BEAMASM_PERF_DUMP|BEAMASM_PERF_MAP;
+                        erts_jit_perf_support |= BEAMASM_PERF_ENABLED;
                     } else if (sys_strcmp(arg, "false") == 0) {
-                        erts_jit_perf_support = 0;
+                        erts_jit_perf_support &= ~BEAMASM_PERF_ENABLED;
                     } else if (sys_strcmp(arg, "dump") == 0) {
-                        erts_jit_perf_support = BEAMASM_PERF_DUMP;
+                        erts_jit_perf_support |= BEAMASM_PERF_DUMP;
                     } else if (sys_strcmp(arg, "map") == 0) {
-                        erts_jit_perf_support = BEAMASM_PERF_MAP;
+                        erts_jit_perf_support |= BEAMASM_PERF_MAP |
+                                                 BEAMASM_PERF_FP;
+                    } else if (sys_strcmp(arg, "fp") == 0) {
+                        erts_jit_perf_support |= BEAMASM_PERF_FP;
+                    } else if (sys_strcmp(arg, "no_fp") == 0) {
+                        erts_jit_perf_support &= ~BEAMASM_PERF_FP;
                     } else {
                         erts_fprintf(stderr, "bad +JPperf support flag %s\n", arg);
                         erts_usage();

--- a/erts/emulator/beam/jit/beam_asm.h
+++ b/erts/emulator/beam/jit/beam_asm.h
@@ -33,9 +33,16 @@
 
 /* Global configuration variables */
 #    ifdef HAVE_LINUX_PERF_SUPPORT
-#        define BEAMASM_PERF_DUMP (1 << 0)
-#        define BEAMASM_PERF_MAP (1 << 1)
-extern int erts_jit_perf_support;
+enum beamasm_perf_flags {
+    BEAMASM_PERF_DUMP = (1 << 0),
+    BEAMASM_PERF_MAP = (1 << 1),
+    BEAMASM_PERF_FP = (1 << 2),
+
+    BEAMASM_PERF_ENABLED =
+            BEAMASM_PERF_DUMP | BEAMASM_PERF_MAP | BEAMASM_PERF_FP,
+    BEAMASM_PERF_DISABLED = 0,
+};
+extern enum beamasm_perf_flags erts_jit_perf_support;
 #    endif
 
 void beamasm_init(void);

--- a/erts/emulator/beam/jit/beam_jit_main.cpp
+++ b/erts/emulator/beam/jit/beam_jit_main.cpp
@@ -40,7 +40,7 @@ ErtsFrameLayout ERTS_WRITE_UNLIKELY(erts_frame_layout);
 
 /* Global configuration variables (under the `+J` prefix) */
 #ifdef HAVE_LINUX_PERF_SUPPORT
-int erts_jit_perf_support;
+enum beamasm_perf_flags erts_jit_perf_support;
 #endif
 
 /*
@@ -140,7 +140,7 @@ static JitAllocator *pick_allocator() {
 #if defined(HAVE_LINUX_PERF_SUPPORT)
     /* `perf` has a hard time showing symbols for dual-mapped memory, so we'll
      * use single-mapped memory when enabled. */
-    if (erts_jit_perf_support & (BEAMASM_PERF_DUMP | BEAMASM_PERF_MAP)) {
+    if (erts_jit_perf_support & BEAMASM_PERF_ENABLED) {
         if (auto *alloc = create_allocator(&single_params)) {
             return alloc;
         }
@@ -220,7 +220,7 @@ void beamasm_init() {
      * frame pointers are disabled or unsupported. */
 #if defined(ERLANG_FRAME_POINTERS)
 #    ifdef HAVE_LINUX_PERF_SUPPORT
-    if (erts_jit_perf_support & BEAMASM_PERF_MAP) {
+    if (erts_jit_perf_support & BEAMASM_PERF_FP) {
         erts_frame_layout = ERTS_FRAME_LAYOUT_FP_RA;
     } else {
         erts_frame_layout = ERTS_FRAME_LAYOUT_RA;


### PR DESCRIPTION
Supporting `perf record --call-graph=fp` is nice but it does come at a slight cost. This PR adds an option to suppress frame pointers for those who would like to use `--call-graph=lbr` instead.