### PR TITLE
ssl: replace size/1 by xxx_size/1

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -183,10 +183,10 @@ cipher(?AES_CBC, CipherState, Mac, Fragment, Version) ->
 		 end, block_size(aes_128_cbc), CipherState, Mac, Fragment, Version).
 
 aead_encrypt(Type, Key, Nonce, Fragment, AdditionalData, TagLen) ->
-    crypto:crypto_one_time_aead(aead_type(Type,size(Key)), Key, Nonce, Fragment, AdditionalData, TagLen, true).
+    crypto:crypto_one_time_aead(aead_type(Type,byte_size(Key)), Key, Nonce, Fragment, AdditionalData, TagLen, true).
 
 aead_decrypt(Type, Key, Nonce, CipherText, CipherTag, AdditionalData) ->
-    crypto:crypto_one_time_aead(aead_type(Type,size(Key)), Key, Nonce, CipherText, AdditionalData, CipherTag, false).
+    crypto:crypto_one_time_aead(aead_type(Type,byte_size(Key)), Key, Nonce, CipherText, AdditionalData, CipherTag, false).
 
 aead_type(?AES_GCM, 16) ->
     aes_128_gcm;


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.