### PR TITLE
xmerl: replace size/1 by xxx_size/1

### DIFF
--- a/lib/xmerl/src/xmerl_eventp.erl
+++ b/lib/xmerl/src/xmerl_eventp.erl
@@ -295,8 +295,8 @@ read_chunk(Fd, _Fname, _Sofar) ->
 
 -ifndef(no_bitsyntax).
 
-find_good_split(Bin, F, Exception, Fd, Fname, T, S) ->
-    find_good_split(size(Bin)-1, Bin, F, Exception, Fd, Fname, T, S).
+find_good_split(Bin, F, Exception, Fd, Fname, T, S) when is_binary(Bin) ->
+    find_good_split(byte_size(Bin)-1, Bin, F, Exception, Fd, Fname, T, S).
 
 find_good_split(0, B, F, Exception, Fd, Fname, T, S) ->
     cont2(F, Exception, B, Fd, Fname, T, S);
@@ -312,8 +312,8 @@ find_good_split(Size, B, F, Exception, Fd, Fname, T, S) ->
 
 -else.
 
-find_good_split(Bin, F, Exception, Fd, Fname, T, S) ->
-    find_good_split(size(Bin), Bin, F, Exception, Fd, Fname, T, S).
+find_good_split(Bin, F, Exception, Fd, Fname, T, S) when is_binary(Size) ->
+    find_good_split(byte_size(Bin), Bin, F, Exception, Fd, Fname, T, S).
 
 find_good_split(0, B, F, Exception, Fd, Fname, T, S) ->
     cont2(F, Exception, B, Fd, Fname, T, S);


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.