### PR TITLE
inets: replace size/1 by xxx_size/1

### DIFF
--- a/lib/inets/src/http_server/httpd_request_handler.erl
+++ b/lib/inets/src/http_server/httpd_request_handler.erl
@@ -369,8 +369,8 @@ handle_msg({{continue, Chunk}, Module, Function, Args}, #state{chunk = {_, CbSta
 handle_msg({continue, Module, Function, Args}, 	#state{mod = ModData} = State) ->
     setopts(ModData#mod.socket, ModData#mod.socket_type, [{active, once}]),
     {noreply, State#state{mfa = {Module, Function, Args}}};
-handle_msg({last, Body}, #state{headers = Headers, chunk = {_, CbState}} = State) -> 
-    NewHeaders = Headers#http_request_h{'content-length' = integer_to_list(size(Body))},
+handle_msg({last, Body}, #state{headers = Headers, chunk = {_, CbState}} = State) when is_binary(Body) ->
+    NewHeaders = Headers#http_request_h{'content-length' = integer_to_list(byte_size(Body))},
     handle_response(State#state{chunk = {last, CbState},
                                 headers = NewHeaders,
                                 body = Body});

--- a/lib/inets/src/http_server/httpd_util.erl
+++ b/lib/inets/src/http_server/httpd_util.erl
@@ -412,7 +412,7 @@ flatlength(List) ->
 flatlength([H|T],L) when is_list(H) ->
     flatlength(H,flatlength(T,L));
 flatlength([H|T],L) when is_binary(H) ->
-    flatlength(T,L+size(H));
+    flatlength(T,L+byte_size(H));
 flatlength([_H|T],L) ->
     flatlength(T,L+1);
 flatlength([],L) ->


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.

Replaces #6771 due to renaming of the branch. The content stays the same