### PR TITLE
Update inet_res et.al. for RFC6891; EDNS with DNSSEC OK bit

### DIFF
--- a/lib/kernel/src/inet_dns.hrl
+++ b/lib/kernel/src/inet_dns.hrl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %% 
-%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@
 -define(T_SRV,          33).            %% services
 %% NAPTR (RFC 2915)
 -define(T_NAPTR,        35).            %% naming authority pointer
--define(T_OPT,          41).            %% EDNS pseudo-rr RFC2671(7)
+-define(T_OPT,          41).            %% EDNS pseudo-rr RFC6891(7)
 %% SPF (RFC 4408)
 -define(T_SPF,          99).            %% server policy framework
 %%      non standard
@@ -118,7 +118,7 @@
 -define(S_SRV,          srv).           %% services
 %% NAPTR (RFC 2915)
 -define(S_NAPTR,        naptr).         %% naming authority pointer
--define(S_OPT,          opt).           %% EDNS pseudo-rr RFC2671(7)
+-define(S_OPT,          opt).           %% EDNS pseudo-rr RFC6891(7)
 %% SPF (RFC 4408)
 -define(S_SPF,          spf).           %% server policy framework
 %%      non standard
@@ -201,15 +201,16 @@
 
 -define(DNS_UDP_PAYLOAD_SIZE, 1280).
 
--record(dns_rr_opt,           %% EDNS RR OPT (RFC2671), dns_rr{type=opt}
+-record(dns_rr_opt,           %% EDNS RR OPT (RFC6891), dns_rr{type=opt}
 	{
 	  domain = "",        %% should be the root domain
 	  type = opt,
-	  udp_payload_size = ?DNS_UDP_PAYLOAD_SIZE, %% RFC2671(4.5 CLASS)
-	  ext_rcode = 0,      %% RFC2671(4.6 EXTENDED-RCODE)
-	  version = 0,        %% RFC2671(4.6 VERSION)
-	  z = 0,              %% RFC2671(4.6 Z)
-	  data = []           %% RFC2671(4.4)
+	  udp_payload_size = ?DNS_UDP_PAYLOAD_SIZE, %% RFC6891(6.2.3 CLASS)
+	  ext_rcode = 0,      %% RFC6891(6.1.3 EXTENDED-RCODE)
+	  version = 0,        %% RFC6891(6.1.3 VERSION)
+	  z = 0,              %% RFC6891(6.1.3 Z)
+	  data = [],          %% RFC6891(6.1.2 RDATA)
+          do = false          %% RFC6891(6.1.3 DO)
 	 }).
 
 -record(dns_query,

--- a/lib/kernel/src/inet_dns_record_adts.pl
+++ b/lib/kernel/src/inet_dns_record_adts.pl
@@ -2,7 +2,7 @@
 #
 # %CopyrightBegin%
 # 
-# Copyright Ericsson AB 2009-2016. All Rights Reserved.
+# Copyright Ericsson AB 2009-2023. All Rights Reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ my %Names = ('msg' => ['dns_rec', 'header', 'qdlist',
 	     'dns_rr' => ['dns_rr', 'domain', 'type', 'class', 'ttl', 'data'],
 	     'dns_rr_opt' => ['dns_rr_opt', 'domain', 'type',
 			      'udp_payload_size', 'ext_rcode', 'version',
-			      'z', 'data'],
+			      'z', 'data', 'do'],
 	     'dns_query' => ['dns_query', 'domain', 'type', 'class'],
 	     'header' => ['dns_header', 'id', 'qr', 'opcode', 'aa', 'tc',
 			  'rd', 'ra', 'pr', 'rcode']);

--- a/lib/kernel/src/inet_res.erl
+++ b/lib/kernel/src/inet_res.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 %%
 %% %CopyrightEnd%
 %%
-%% RFC 1035, 2671, 2782, 2915.
+%% RFC 1035, 2782, 2915, 6891.
 %%
 -module(inet_res).
 
@@ -61,6 +61,7 @@
       | {retry, integer()}
       | {timeout, integer()}
       | {udp_payload_size, integer()}
+      | {dnssec_ok, boolean()}
       | {usevc, boolean()}
       | {nxdomain_reply, boolean()}.
 
@@ -263,7 +264,7 @@ do_nslookup(Name, Class, Type, Opts, Timeout) ->
 %% options record
 %%
 -record(options, { % These must be sorted!
-	  alt_nameservers,edns,inet6,nameservers,
+	  alt_nameservers,dnssec_ok,edns,inet6,nameservers,
           nxdomain_reply, % this is a local option, not in inet_db
           recurse,retry,servfail_retry_timeout,timeout,
           udp_payload_size,usevc,
@@ -672,9 +673,12 @@ make_query(Dname, Class, Type, Options, Edns) ->
     ARList = case Edns of
 		 false -> [];
 		 _ ->
-		     PSz = Options#options.udp_payload_size,
+                     #options{
+                        udp_payload_size = PSz,
+                        dnssec_ok = DnssecOk } = Options,
 		     [#dns_rr_opt{udp_payload_size=PSz,
-				  version=Edns}]
+				  version=Edns,
+                                  do=DnssecOk}]
 	     end,
     Msg = #dns_rec{header=#dns_header{id=Id,
                                       qr=false,


### PR DESCRIPTION
Resolves #6606.

This implements the only bit I noticed was missing for RFC6891 from the original EDNS RFC2671, that is the DNSSEC OK bit (DO) in the OPT RR.  By this we should be able to claim supporting RFC6891.

Still, we do not have any other DNSSEC records implemented, so they will be a possible future improvement.

Has anyone tried to use `inet_res` for DNSSEC records?  I try to set this bit to see if I can get records, but has not succeeded.

`inet_res:resolve("google.com", in, 30, [verbose, {edns, 0}, {dnssec_ok, true}])` does not return any "30" record, which should be NXT RR.  Any pointers?