### PR TITLE
megaco: replace size/1 by xxx_size/1

### DIFF
--- a/lib/megaco/src/engine/megaco_filter.erl
+++ b/lib/megaco/src/engine/megaco_filter.erl
@@ -300,10 +300,10 @@ do_filter_contents([H | T], E, ConnData, Contents) ->
             E2 = 
 		case E#event.label of
 		    [$s, $e, $n, $d, $ , $b, $y, $t, $e, $s | Tail] ->
-			L = lists:concat(["send ", size(Bin), " bytes", Tail]),
+			L = lists:concat(["send ", byte_size(Bin), " bytes", Tail]),
 			E#event{label = L};
 		    [$r, $e, $c, $e, $i, $v, $e, $ , $b, $y, $t, $e, $s | Tail] ->
-			L = lists:concat(["receive ", size(Bin), " bytes", Tail]),
+			L = lists:concat(["receive ", byte_size(Bin), " bytes", Tail]),
 			E#event{label = L};
 		    _ ->
 			E

--- a/lib/megaco/src/engine/megaco_messenger_misc.erl
+++ b/lib/megaco/src/engine/megaco_messenger_misc.erl
@@ -217,7 +217,7 @@ encode_action_replies(#conn_data{protocol_version = V,
 		      [AR|ARs], Size, Acc) ->
     case (catch Mod:encode_action_reply(Conf, V, AR)) of
 	{ok, Bin} when is_binary(Bin) ->
-	    encode_action_replies(CD, ARs, Size + size(Bin), [Bin|Acc]);
+	    encode_action_replies(CD, ARs, Size + byte_size(Bin), [Bin|Acc]);
         {'EXIT', {undef, _}} ->
             throw({error, not_implemented});
 	{error, not_implemented} = Error1 ->

--- a/lib/megaco/src/flex/megaco_flex_scanner.erl
+++ b/lib/megaco/src/flex/megaco_flex_scanner.erl
@@ -48,8 +48,8 @@ is_scanner_port(Port, Ports) when is_tuple(Ports) ->
 is_scanner_port(_, _) ->
     false.
 
-is_own_port(Port, Ports) ->
-    is_own_port(Port, size(Ports), Ports).
+is_own_port(Port, Ports) when is_tuple(Ports)->
+    is_own_port(Port, tuple_size(Ports), Ports).
 
 is_own_port(_Port, 0, _Ports) ->
     false;

--- a/lib/megaco/src/tcp/megaco_tcp.erl
+++ b/lib/megaco/src/tcp/megaco_tcp.erl
@@ -260,7 +260,7 @@ send_message(Socket, Data) ->
 	    
 -ifdef(megaco_debug).
 sz(Bin) when is_binary(Bin) ->
-    size(Bin);
+    byte_size(Bin);
 sz(List) when is_list(List) ->
     length(List).
 -endif.
@@ -633,11 +633,11 @@ create_acceptor(Pid, Rec, TopSup, Listen) ->
 %% Description: Function is used to add the TPKT header
 %%-----------------------------------------------------------------
 add_tpkt_header(Data) when is_binary(Data) ->
-    L = size(Data) + 4,
+    L = byte_size(Data) + 4,
     {L, [3, 0, ((L) bsr 8) band 16#ff, (L) band 16#ff ,Data]};
 add_tpkt_header(IOList) when is_list(IOList) ->
     Binary = list_to_binary(IOList),
-    L = size(Binary) + 4,
+    L = byte_size(Binary) + 4,
     {L, [3, 0, ((L) bsr 8) band 16#ff, (L) band 16#ff , Binary]}.
 
 %%-----------------------------------------------------------------

--- a/lib/megaco/src/tcp/megaco_tcp_connection.erl
+++ b/lib/megaco/src/tcp/megaco_tcp_connection.erl
@@ -141,26 +141,26 @@ handle_info({tcp_error, _Socket}, TcpRec) ->
     {stop, shutdown, TcpRec};
 handle_info({tcp, Socket, <<3:8, _X:8, Length:16, Msg/binary>>}, 
 	    #megaco_tcp{socket = Socket, serialize = false} = TcpRec) 
-  when Length < ?GC_MSG_LIMIT ->
+  when is_binary(Msg), Length < ?GC_MSG_LIMIT ->
     #megaco_tcp{module = Mod, receive_handle = RH} = TcpRec,
     incNumInMessages(Socket),
-    incNumInOctets(Socket, 4+size(Msg)),
+    incNumInOctets(Socket, 4+byte_size(Msg)),
     apply(Mod, receive_message, [RH, self(), Socket, Msg]),
     _ = inet:setopts(Socket, [{active, once}]),
     {noreply, TcpRec};
 handle_info({tcp, Socket, <<3:8, _X:8, Length:16, Msg/binary>>}, 
-	    #megaco_tcp{socket = Socket, serialize = false} = TcpRec) ->
+	    #megaco_tcp{socket = Socket, serialize = false} = TcpRec) when is_binary(Msg)->
     #megaco_tcp{module = Mod, receive_handle = RH} = TcpRec,
     incNumInMessages(Socket),
-    incNumInOctets(Socket, 4+size(Msg)),
+    incNumInOctets(Socket, 4+byte_size(Msg)),
     receive_message(Mod, RH, Socket, Length, Msg),
     _ = inet:setopts(Socket, [{active, once}]),
     {noreply, TcpRec};
 handle_info({tcp, Socket, <<3:8, _X:8, _Length:16, Msg/binary>>},
-            #megaco_tcp{socket = Socket, serialize = true} = TcpRec) ->
+            #megaco_tcp{socket = Socket, serialize = true} = TcpRec) when is_binary(Msg) ->
     #megaco_tcp{module = Mod, receive_handle = RH} = TcpRec,
     incNumInMessages(Socket),
-    incNumInOctets(Socket, 4+size(Msg)),
+    incNumInOctets(Socket, 4+byte_size(Msg)),
     process_received_message(Mod, RH, Socket, Msg),
     _ = inet:setopts(Socket, [{active, once}]),
     {noreply, TcpRec};

--- a/lib/megaco/src/udp/megaco_udp.erl
+++ b/lib/megaco/src/udp/megaco_udp.erl
@@ -223,7 +223,7 @@ send_message(SH, Data) when is_record(SH, send_handle) ->
     _ = case Res of
             ok ->
                 incNumOutMessages(SH),
-                incNumOutOctets(SH, size(Data));
+                incNumOutOctets(SH, byte_size(Data));
             _ ->
                 ok
         end,

--- a/lib/megaco/src/udp/megaco_udp_server.erl
+++ b/lib/megaco/src/udp/megaco_udp_server.erl
@@ -150,10 +150,10 @@ handle_cast(Msg, UdpRec) ->
 %%              from the socket and exit codes.
 %%-----------------------------------------------------------------
 handle_info({udp, _Socket, Ip, Port, Msg}, 
-	    #megaco_udp{serialize = false} = UdpRec) ->
+	    #megaco_udp{serialize = false} = UdpRec) when is_binary(Msg) ->
     #megaco_udp{socket = Socket, module = Mod, receive_handle = RH} = UdpRec,
     SH = megaco_udp:create_send_handle(Socket, Ip, Port), 
-    MsgSize = size(Msg),
+    MsgSize = byte_size(Msg),
     incNumInMessages(SH),
     incNumInOctets(SH, MsgSize),
     case MsgSize of
@@ -165,10 +165,10 @@ handle_info({udp, _Socket, Ip, Port, Msg},
     _ = activate(Socket),
     {noreply, UdpRec};
 handle_info({udp, _Socket, Ip, Port, Msg}, 
-	    #megaco_udp{serialize = true} = UdpRec) ->
+	    #megaco_udp{serialize = true} = UdpRec) when is_binary(Msg) ->
     #megaco_udp{socket = Socket, module = Mod, receive_handle = RH} = UdpRec,
     SH = megaco_udp:create_send_handle(Socket, Ip, Port), 
-    MsgSize = size(Msg),
+    MsgSize = byte_size(Msg),
     incNumInMessages(SH),
     incNumInOctets(SH, MsgSize),
     process_received_message(Mod, RH, SH, Msg),


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.

Super-seeds #6773 where they only change is in how the branch is named.