### PR TITLE
ftp: replace size/1 by XXX_size/1

### DIFF
--- a/lib/ftp/src/ftp.erl
+++ b/lib/ftp/src/ftp.erl
@@ -2338,8 +2338,8 @@ file_close(Fd) ->
 
 file_read(Fd) ->
     case file:read(Fd, ?FILE_BUFSIZE) of
-        {ok, Bytes} ->
-            {ok, size(Bytes), Bytes};
+        {ok, Bytes} when is_binary(Bytes) ->
+            {ok, byte_size(Bytes), Bytes};
         eof ->
             {ok, 0, []};
         Other ->
@@ -2426,8 +2426,8 @@ progress_report(_, #state{progress = ignore}) ->
     ok;
 progress_report(stop, #state{progress = ProgressPid}) ->
     ftp_progress:stop(ProgressPid);
-progress_report({binary, Data}, #state{progress = ProgressPid}) ->
-    ftp_progress:report(ProgressPid, {transfer_size, size(Data)});
+progress_report({binary, Data}, #state{progress = ProgressPid}) when is_binary(Data) ->
+    ftp_progress:report(ProgressPid, {transfer_size, byte_size(Data)});
 progress_report(Report, #state{progress = ProgressPid}) ->
     ftp_progress:report(ProgressPid, Report).
 
@@ -2519,7 +2519,7 @@ open_options(Options) ->
         fun(Host) when is_list(Host) ->
                 true;
            (Host) when is_tuple(Host) andalso
-                       ((size(Host) =:= 4) orelse (size(Host) =:= 8)) ->
+                       ((tuple_size(Host) =:= 4) orelse (tuple_size(Host) =:= 8)) ->
                 true;
            (_) ->
                 false

--- a/lib/ftp/src/ftp.erl
+++ b/lib/ftp/src/ftp.erl
@@ -2338,7 +2338,7 @@ file_close(Fd) ->
 
 file_read(Fd) ->
     case file:read(Fd, ?FILE_BUFSIZE) of
-        {ok, Bytes} when is_binary(Bytes) ->
+        {ok, Bytes} ->
             {ok, byte_size(Bytes), Bytes};
         eof ->
             {ok, 0, []};
@@ -2518,8 +2518,7 @@ open_options(Options) ->
     ValidateHost =
         fun(Host) when is_list(Host) ->
                 true;
-           (Host) when is_tuple(Host) andalso
-                       ((tuple_size(Host) =:= 4) orelse (tuple_size(Host) =:= 8)) ->
+           (Host) when tuple_size(Host) =:= 4; tuple_size(Host) =:= 8 ->
                 true;
            (_) ->
                 false

--- a/lib/ftp/src/ftp_response.erl
+++ b/lib/ftp/src/ftp_response.erl
@@ -80,7 +80,7 @@
 %% Make sure we received the first 4 bytes so we know how to parse
 %% the FTP server response e.i. is the response composed of one
 %% or multiple lines.
-parse_lines(Bin, Lines, start) when size(Bin) < 4 ->
+parse_lines(Bin, Lines, start) when is_binary(Bin), byte_size(Bin) < 4 ->
     {continue, {Bin, Lines, start}};
 %% Multiple lines exist
 parse_lines(<<C1, C2, C3, $-, Rest/binary>>, Lines, start) ->


### PR DESCRIPTION


The size/1 BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, tuple_size/1 should always be preferred.

When one knows that the value being tested must be a binary, byte_size/1 should be preferred. However, byte_size/1 also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to byte_size/ is preceded by a call to is_binary/1 to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to is_binary/1, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an is_binary/1 test immediately before the call to byte_size/1.

This PR extends #6770 simply in the branch naming convention. No changes in the implementation
