### PR TITLE
ssh: replace size/1 by xxx_size/1

### DIFF
--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -50,7 +50,7 @@
 -define(UINT16(X),   (X):16/unsigned-big-integer).
 -define(UINT32(X),   (X):32/unsigned-big-integer).
 -define(UINT64(X),   (X):64/unsigned-big-integer).
--define(STRING(X),   ?UINT32((size(X))), (X)/binary).
+-define(STRING(X),   ?UINT32((byte_size(X))), (X)/binary).
 
 -define(DEC_BIN(X,Len),   ?UINT32(Len), X:Len/binary ).
 -define(DEC_INT(I,Len),   ?UINT32(Len), I:Len/big-signed-integer-unit:8 ).

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -173,7 +173,7 @@ send(Request, Opts) ->
 %% Message packing
 
 pack(Data) ->
-    <<(size(Data)):32/unsigned-big-integer, Data/binary>>.
+    <<(byte_size(Data)):32/unsigned-big-integer, Data/binary>>.
 
 %% SSH Agent message encoding
 

--- a/lib/ssh/src/ssh_bits.erl
+++ b/lib/ssh/src/ssh_bits.erl
@@ -40,20 +40,20 @@ mpint(I) when I>0 ->
     <<B1,V/binary>> = binary:encode_unsigned(I),
     case B1 band 16#80 of
 	16#80 ->
-	    <<(size(V)+2):32/unsigned-big-integer, 0,B1,V/binary >>;
+	    <<(byte_size(V)+2):32/unsigned-big-integer, 0,B1,V/binary >>;
 	_ ->
-	    <<(size(V)+1):32/unsigned-big-integer, B1,V/binary >>
+	    <<(byte_size(V)+1):32/unsigned-big-integer, B1,V/binary >>
     end;
 mpint(N) when N<0 -> 
-    Sxn =  8*size(binary:encode_unsigned(-N)),
+    Sxn =  bit_size(binary:encode_unsigned(-N)),
     Sxn1 = Sxn+8,
     <<W:Sxn1>> = <<1, 0:Sxn>>,
     <<B1,V/binary>> = binary:encode_unsigned(W+N),
     case B1 band 16#80 of
 	16#80 ->
-	    <<(size(V)+1):32/unsigned-big-integer, B1,V/binary >>;
+	    <<(byte_size(V)+1):32/unsigned-big-integer, B1,V/binary >>;
 	_ ->
-	    <<(size(V)+2):32/unsigned-big-integer, 255,B1,V/binary >>
+	    <<(byte_size(V)+2):32/unsigned-big-integer, 255,B1,V/binary >>
     end.
 
 %%%----------------------------------------------------------------

--- a/lib/ssh/src/ssh_client_channel.erl
+++ b/lib/ssh/src/ssh_client_channel.erl
@@ -288,7 +288,7 @@ handle_info(Msg, #state{channel_cb = Module,
 	{stop, ChannelId, ChannelState} ->
             do_the_close(Msg, ChannelId, State#state{channel_state = ChannelState})
     catch
-        error:function_clause when size(Msg) == 3,
+        error:function_clause when tuple_size(Msg) == 3,
                                    element(1,Msg) == 'EXIT' ->
             do_the_close(Msg, State#state.channel_id, State)
     end.
@@ -390,7 +390,7 @@ handle_cb_result({stop, Reason, ChannelState}, State) ->
 
 adjust_window({ssh_cm, ConnectionManager,
 	       {data, ChannelId, _, Data}}) ->
-    ssh_connection:adjust_window(ConnectionManager, ChannelId, size(Data));
+    ssh_connection:adjust_window(ConnectionManager, ChannelId, byte_size(Data));
 adjust_window(_) ->
     ok.
     

--- a/lib/ssh/src/ssh_connection.erl
+++ b/lib/ssh/src/ssh_connection.erl
@@ -1200,7 +1200,7 @@ get_window(#channel{send_buf = Buffer,
 		   } = Channel, Acc0) ->
     case queue:out(Buffer) of
 	{{value, {_, Data} = Msg}, NewBuffer} ->
-	    case handle_send_window(Msg, size(Data), PacketSize, WindowSize0, Acc0) of		
+	    case handle_send_window(Msg, byte_size(Data), PacketSize, WindowSize0, Acc0) of
 		{WindowSize, Acc, {_, <<>>}} ->
 		    {lists:reverse(Acc), Channel#channel{send_window_size = WindowSize,
 							 send_buf = NewBuffer}};
@@ -1520,7 +1520,7 @@ handle_cli_msg(C0, ChId, Reply0) ->
 channel_data_reply_msg(ChannelId, Connection, DataType, Data) ->
     case ssh_client_channel:cache_lookup(Connection#connection.channel_cache, ChannelId) of
 	#channel{recv_window_size = Size} = Channel ->
-	    WantedSize = Size - size(Data),
+	    WantedSize = Size - byte_size(Data),
 	    ssh_client_channel:cache_update(Connection#connection.channel_cache, 
                                      Channel#channel{recv_window_size = WantedSize}),
             reply_msg(Channel, Connection, {data, ChannelId, DataType, Data});

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1189,7 +1189,7 @@ handle_event(info, {Proto, Sock, NewData}, StateName,
 %%%==== 
 handle_event(internal, prepare_next_packet, _StateName, D) ->
     Enough =  erlang:max(8, D#data.ssh_params#ssh.decrypt_block_size),
-    case size(D#data.encrypted_data_buffer) of
+    case byte_size(D#data.encrypted_data_buffer) of
 	Sz when Sz >= Enough ->
 	    self() ! {D#data.transport_protocol, D#data.socket, <<>>};
 	_ ->

--- a/lib/ssh/src/ssh_file.erl
+++ b/lib/ssh/src/ssh_file.erl
@@ -289,7 +289,7 @@ decode(Bin, auth_keys) when is_binary(Bin) ->
                     [ [[] | binary:split(L,<<" ">>,[global,trim_all])] ];
                 {Pos,Len} when is_integer(Pos), is_integer(Len) ->
                     [ [binary:split(binary:part(L,0,Pos-1), <<",">>,[global,trim_all]) |
-                       binary:split(binary:part(L,Pos,size(L)-Pos), <<" ">>, [global,trim_all])]
+                       binary:split(binary:part(L,Pos,byte_size(L)-Pos), <<" ">>, [global,trim_all])]
                     ]
             end
     ];
@@ -730,12 +730,12 @@ pos_match(H, P) ->
 
         {[Hh], [Ph,<<"*">>]} ->
             %% host [host]:*
-            Sz = size(Hh),
+            Sz = byte_size(Hh),
             Ph == <<"[", Hh:Sz/binary, "]">>;
 
         {[Hh], [Ph,<<"22">>]} ->
             %% host [host]:22
-            Sz = size(Hh),
+            Sz = byte_size(Hh),
             Ph == <<"[", Hh:Sz/binary, "]">>;
 
         _ ->
@@ -1145,7 +1145,7 @@ openssh_key_v1_encode(KeyPairs) ->
                      CheckInt/binary,
                      (openssh_key_v1_encode_priv_keys_cmnts(KeyPairs))/binary>>,
     UnEncrypted = <<UnEncrypted0/binary,
-                    (pad(size(UnEncrypted0), BlockSize))/binary>>,
+                    (pad(byte_size(UnEncrypted0), BlockSize))/binary>>,
     Encrypted = encrypt_openssh_key_v1(UnEncrypted,  KdfName, KdfOptions, CipherName, ignore),
     <<"openssh-key-v1",0,
       ?STRING(CipherName),

--- a/lib/ssh/src/ssh_xfer.erl
+++ b/lib/ssh/src/ssh_xfer.erl
@@ -242,7 +242,7 @@ xf_request(XF, Op, Arg) ->
 	       is_list(Arg) ->
 		   ?to_binary(Arg)
 	   end,
-    Size = 1+size(Data),
+    Size = 1+byte_size(Data),
     ssh_connection:send(CM, Channel, [<<?UINT32(Size), Op, Data/binary>>]).
 
 xf_send_reply(#ssh_xfer{cm = CM, channel = Channel}, Op, Arg) ->    
@@ -252,7 +252,7 @@ xf_send_reply(#ssh_xfer{cm = CM, channel = Channel}, Op, Arg) ->
 	       is_list(Arg) ->
 		   ?to_binary(Arg)
 	   end,
-    Size = 1 + size(Data),
+    Size = 1 + byte_size(Data),
     ssh_connection:send(CM, Channel, [<<?UINT32(Size), Op, Data/binary>>]).
 
 xf_send_name(XF, ReqId, Name, Attr) ->
@@ -290,7 +290,7 @@ xf_send_status(#ssh_xfer{cm = CM, channel = Channel},
     LangTag = "en",
     ELen = length(ErrorMsg),
     TLen = 2, %% length(LangTag),
-    Size = 1 + 4 + 4 + 4+ELen + 4+TLen + size(Data),
+    Size = 1 + 4 + 4 + 4+ELen + 4+TLen + byte_size(Data),
     ToSend = [<<?UINT32(Size), ?SSH_FXP_STATUS, ?UINT32(ReqId),
 	       ?UINT32(ErrorCode)>>,
 	      <<?UINT32(ELen)>>, ErrorMsg,
@@ -300,13 +300,13 @@ xf_send_status(#ssh_xfer{cm = CM, channel = Channel},
 
 xf_send_attr(#ssh_xfer{cm = CM, channel = Channel, vsn = Vsn}, ReqId, Attr) ->
     EncAttr = encode_ATTR(Vsn, Attr),
-    ALen = size(EncAttr),
+    ALen = byte_size(EncAttr),
     Size = 1 + 4 + ALen,
     ToSend = [<<?UINT32(Size), ?SSH_FXP_ATTRS, ?UINT32(ReqId)>>, EncAttr],
     ssh_connection:send(CM, Channel, ToSend).
 
 xf_send_data(#ssh_xfer{cm = CM, channel = Channel}, ReqId, Data) ->
-    DLen = size(Data),
+    DLen = byte_size(Data),
     Size = 1 + 4 + 4+DLen,
     ToSend = [<<?UINT32(Size), ?SSH_FXP_DATA, ?UINT32(ReqId), ?UINT32(DLen)>>,
 	      Data],
@@ -815,21 +815,21 @@ encode_name(Vsn, {{NameUC,LongNameUC},Attr}, Len) when Vsn =< 3 ->
 	LongName = binary_to_list(unicode:characters_to_binary(LongNameUC)),
     LNLen = length(LongName),
 	EncAttr = encode_ATTR(Vsn, Attr),
-    ALen = size(EncAttr),
+    ALen = byte_size(EncAttr),
     NewLen = Len + NLen + LNLen + 4 + 4 + ALen,
     {[<<?UINT32(NLen)>>, Name, <<?UINT32(LNLen)>>, LongName, EncAttr], NewLen};
 encode_name(Vsn, {NameUC,Attr}, Len) when Vsn =< 3 ->
     Name = binary_to_list(unicode:characters_to_binary(NameUC)),
     NLen = length(Name),
     EncAttr = encode_ATTR(Vsn, Attr),
-    ALen = size(EncAttr),
+    ALen = byte_size(EncAttr),
     NewLen = Len + NLen*2 + 4 + 4 + ALen,
     {[<<?UINT32(NLen)>>, Name, <<?UINT32(NLen)>>, Name, EncAttr], NewLen};
 encode_name(Vsn, {NameUC,Attr}, Len) when Vsn >= 4 ->
     Name = binary_to_list(unicode:characters_to_binary(NameUC)),
     NLen = length(Name),
     EncAttr = encode_ATTR(Vsn, Attr),
-    ALen = size(EncAttr),
+    ALen = byte_size(EncAttr),
     {[<<?UINT32(NLen)>>, Name, EncAttr],
      Len + 4 + NLen + ALen}.
 


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.

This PR replaces #6778 in its branch naming convention. The content is the same