### PR TITLE
snmp: replace size/1 by xxx_size/1

### DIFF
--- a/lib/snmp/src/agent/snmp_generic_mnesia.erl
+++ b/lib/snmp/src/agent/snmp_generic_mnesia.erl
@@ -185,8 +185,8 @@ make_row2(RowList, 1) -> RowList;
 make_row2([_OtherIndex | RowList], N) ->
     make_row2(RowList, N-1).
 
-make_row_list(Row) ->
-    make_row_list(size(Row), Row, []).
+make_row_list(Row) when is_tuple(Row) ->
+    make_row_list(tuple_size(Row), Row, []).
 make_row_list(N, Row, Acc) when N > 2 ->
     make_row_list(N-1, Row, [element(N, Row) | Acc]);
 make_row_list(2, Row, Acc) ->

--- a/lib/snmp/src/agent/snmp_index.erl
+++ b/lib/snmp/src/agent/snmp_index.erl
@@ -155,7 +155,7 @@ is_snmp_type(_) -> false.
 key_to_oid_i(Key, _Type) when is_integer(Key) -> [Key];
 key_to_oid_i(Key, fix_string) -> Key;
 key_to_oid_i(Key, _Type) when is_list(Key) -> [length(Key) | Key];
-key_to_oid_i(Key, Types) -> keys_to_oid(size(Key), Key, [], Types).
+key_to_oid_i(Key, Types) when is_tuple(Key) -> keys_to_oid(tuple_size(Key), Key, [], Types).
 
 keys_to_oid(0, _Key, Oid, _Types) -> Oid;
 keys_to_oid(N, Key, Oid, Types) ->

--- a/lib/snmp/src/agent/snmpa_local_db.erl
+++ b/lib/snmp/src/agent/snmpa_local_db.erl
@@ -1031,7 +1031,7 @@ table_get_elements(NameDb, RowIndex, Cols, _FirstOwnIndex) ->
 
 get_elements(_Cols, undefined) -> 
     undefined;
-get_elements([Col | Cols], Row) when is_tuple(Row) and (size(Row) >= Col) ->
+get_elements([Col | Cols], Row) when tuple_size(Row) >= Col ->
     [element(Col, Row) | get_elements(Cols, Row)];
 get_elements([], _Row) -> 
     [];

--- a/lib/snmp/src/agent/snmpa_mib_data_ttln.erl
+++ b/lib/snmp/src/agent/snmpa_mib_data_ttln.erl
@@ -777,10 +777,10 @@ next_node(_D, undefined_node, _Oid, _RevOidSoFar, _MibView) ->
 
 next_node(_D, {tree, Tree, {table_entry, _Id}}, [Int | _Oid], 
 	  _RevOidSoFar, _MibView)
-  when Int+1 > size(Tree) ->
+  when Int+1 > tuple_size(Tree) ->
     ?vtrace("next_node(tree,table_entry) -> entry when not found within"
 	"~n   Int:        ~p"
-	"~n   size(Tree): ~p", [Int, size(Tree)]),
+	"~n   size(Tree): ~p", [Int, tuple_size(Tree)]),
     false;
 next_node(D, {tree, Tree, {table_entry, _MibName}},
 	  Oid, RevOidSoFar, MibView) ->
@@ -788,7 +788,7 @@ next_node(D, {tree, Tree, {table_entry, _MibName}},
 	"~n   size(Tree):  ~p"
 	"~n   Oid:         ~p"
 	"~n   RevOidSoFar: ~p"
-	"~n   MibView:     ~p", [size(Tree), Oid, RevOidSoFar, MibView]),
+	"~n   MibView:     ~p", [tuple_size(Tree), Oid, RevOidSoFar, MibView]),
     OidSoFar = lists:reverse(RevOidSoFar),
     case snmpa_acm:is_definitely_not_in_mib_view(OidSoFar, MibView) of
 	true -> 
@@ -809,14 +809,14 @@ next_node(D, {tree, Tree, {table_entry, _MibName}},
     end;
 
 next_node(D, {tree, Tree, _Info}, [Int | RestOfOid], RevOidSoFar, MibView) 
-  when (Int < size(Tree)) andalso (Int >= 0) ->
+  when (Int < tuple_size(Tree)) andalso (Int >= 0) ->
     ?vtrace("next_node(tree) -> entry when"
 	"~n   size(Tree):  ~p"
 	"~n   Int:         ~p"
 	"~n   RestOfOid:   ~p"
 	"~n   RevOidSoFar: ~p"
 	"~n   MibView:     ~p", 
-	[size(Tree), Int, RestOfOid, RevOidSoFar, MibView]),
+	[tuple_size(Tree), Int, RestOfOid, RevOidSoFar, MibView]),
     case next_node(D, element(Int+1,Tree), 
 		   RestOfOid, [Int|RevOidSoFar], MibView) of
 	false -> 
@@ -830,11 +830,11 @@ next_node(D, {tree, Tree, _Info}, [], RevOidSoFar, MibView) ->
 	"~n   size(Tree):  ~p"
 	"~n   RevOidSoFar: ~p"
 	"~n   MibView:     ~p", 
-	[size(Tree), RevOidSoFar, MibView]),
+	[tuple_size(Tree), RevOidSoFar, MibView]),
     find_next(D, {tree, Tree, _Info}, 0, RevOidSoFar, MibView);
 next_node(_D, {tree, Tree, _Info}, _RestOfOid, _RevOidSoFar, _MibView) ->
     ?vtrace("next_node(tree) -> entry when"
-	"~n   size(Tree):  ~p", [size(Tree)]),
+	"~n   size(Tree):  ~p", [tuple_size(Tree)]),
     false;
 
 next_node(D, {node, subagent}, Oid, RevOidSoFar, MibView) ->
@@ -896,7 +896,7 @@ next_node(_D, {node, {variable, _MibName}}, _Oid, _RevOidSoFar, _MibView) ->
 %%      node.
 %%-----------------------------------------------------------------
 find_next(D, {tree, Tree, internal}, Idx, RevOidSoFar, MibView) 
-  when Idx < size(Tree) ->
+  when Idx < tuple_size(Tree) ->
     case find_next(D, element(Idx+1, Tree), 0, [Idx| RevOidSoFar], MibView) of
 	false -> 
 	    find_next(D, {tree, Tree, internal}, Idx+1, RevOidSoFar, MibView);

--- a/lib/snmp/src/agent/snmpa_mib_data_tttn.erl
+++ b/lib/snmp/src/agent/snmpa_mib_data_tttn.erl
@@ -804,10 +804,10 @@ next_node(_D, undefined_node, _Oid, _RevOidSoFar, _MibView) ->
 
 next_node(_D, {tree, Tree, {table_entry, _Id}}, [Int | _Oid], 
 	  _RevOidSoFar, _MibView)
-  when Int+1 > size(Tree) ->
+  when Int+1 > tuple_size(Tree) ->
     ?vtrace("next_node(tree,table_entry) -> entry when not found within"
 	"~n   Int:        ~p"
-	"~n   size(Tree): ~p", [Int, size(Tree)]),
+	"~n   size(Tree): ~p", [Int, tuple_size(Tree)]),
     false;
 next_node(D, {tree, Tree, {table_entry, _MibName}},
 	  Oid, RevOidSoFar, MibView) ->
@@ -815,7 +815,7 @@ next_node(D, {tree, Tree, {table_entry, _MibName}},
 	"~n   size(Tree):  ~p"
 	"~n   Oid:         ~p"
 	"~n   RevOidSoFar: ~p"
-	"~n   MibView:     ~p", [size(Tree), Oid, RevOidSoFar, MibView]),
+	"~n   MibView:     ~p", [tuple_size(Tree), Oid, RevOidSoFar, MibView]),
     OidSoFar = lists:reverse(RevOidSoFar),
     case snmpa_acm:is_definitely_not_in_mib_view(OidSoFar, MibView) of
 	true -> 
@@ -836,14 +836,14 @@ next_node(D, {tree, Tree, {table_entry, _MibName}},
     end;
 
 next_node(D, {tree, Tree, _Info}, [Int | RestOfOid], RevOidSoFar, MibView) 
-  when (Int < size(Tree)) andalso (Int >= 0) ->
+  when (Int < tuple_size(Tree)) andalso (Int >= 0) ->
     ?vtrace("next_node(tree) -> entry when"
 	"~n   size(Tree):  ~p"
 	"~n   Int:         ~p"
 	"~n   RestOfOid:   ~p"
 	"~n   RevOidSoFar: ~p"
 	"~n   MibView:     ~p", 
-	[size(Tree), Int, RestOfOid, RevOidSoFar, MibView]),
+	[tuple_size(Tree), Int, RestOfOid, RevOidSoFar, MibView]),
     case next_node(D, element(Int+1,Tree), 
 		   RestOfOid, [Int|RevOidSoFar], MibView) of
 	false -> 
@@ -857,11 +857,11 @@ next_node(D, {tree, Tree, _Info}, [], RevOidSoFar, MibView) ->
 	"~n   size(Tree):  ~p"
 	"~n   RevOidSoFar: ~p"
 	"~n   MibView:     ~p", 
-	[size(Tree), RevOidSoFar, MibView]),
+	[tuple_size(Tree), RevOidSoFar, MibView]),
     find_next(D, {tree, Tree, _Info}, 0, RevOidSoFar, MibView);
 next_node(_D, {tree, Tree, _Info}, _RestOfOid, _RevOidSoFar, _MibView) ->
     ?vtrace("next_node(tree) -> entry when"
-	"~n   size(Tree):  ~p", [size(Tree)]),
+	"~n   size(Tree):  ~p", [tuple_size(Tree)]),
     false;
 
 next_node(D, {node, subagent}, Oid, RevOidSoFar, MibView) ->
@@ -924,7 +924,7 @@ next_node(_D, {node, {variable, _MibName}}, _Oid, _RevOidSoFar, _MibView) ->
 %%      node.
 %%-----------------------------------------------------------------
 find_next(D, {tree, Tree, internal}, Idx, RevOidSoFar, MibView) 
-  when Idx < size(Tree) ->
+  when Idx < tuple_size(Tree) ->
     case find_next(D, element(Idx+1, Tree), 0, [Idx| RevOidSoFar], MibView) of
 	false -> 
 	    find_next(D, {tree, Tree, internal}, Idx+1, RevOidSoFar, MibView);

--- a/lib/snmp/src/agent/snmpa_mpd.erl
+++ b/lib/snmp/src/agent/snmpa_mpd.erl
@@ -673,7 +673,7 @@ generate_response_msg(Vsn, RePdu, Type,
 			{discarded, Reason};
 		    Packet ->
 			MMS = get_engine_max_message_size(LocalEngineID),
-			case size(Packet) of
+			case byte_size(Packet) of
 			    Len when Len =< MMS ->
 				Log(Type, Packet),
 				inc_snmp_cnt_vars(Type, RePdu),
@@ -742,7 +742,7 @@ generate_response_msg(Vsn, RePdu, Type,
 		    %% because of the calculation we do when we
 		    %% receive the bulk-request.
 		    Packet = list_to_binary(OutMsg),
-		    case size(Packet) of
+		    case byte_size(Packet) of
 			Len when Len =< AgentMS ->
 			    if
 				SecLevel =:= 3 -> 
@@ -932,7 +932,7 @@ generate_msg(Vsn, _NoteStore, Pdu, {community, Community}, LocalEngineID, To) ->
 	    {discarded, Reason};
 	Packet ->
 	    AgentMax = get_engine_max_message_size(LocalEngineID),
-	    case size(Packet) of
+	    case byte_size(Packet) of
 		Len when Len =< AgentMax ->
 		    {ok, mk_v1_v2_packet_list(To, Packet, Len, Pdu)};
 		Len ->
@@ -1321,7 +1321,7 @@ mk_v3_packet_entry(NoteStore, Domain, Addr,
 	    %% Store in cache for 150 sec.
 	    Packet = list_to_binary(OutMsg),
 	    ?vdebug("mk_v3_packet_entry -> generated: ~w bytes", 
-		    [size(Packet)]),
+		    [byte_size(Packet)]),
 	    Data = 
 		if
 		    SecLevel =:= 3 -> 
@@ -1560,3 +1560,4 @@ user_err(F, A) ->
 
 config_err(F, A) ->
     snmpa_error:config_err(F, A).
+

--- a/lib/snmp/src/manager/snmpm_net_if.erl
+++ b/lib/snmp/src/manager/snmpm_net_if.erl
@@ -814,7 +814,7 @@ maybe_handle_recv_msg_mt(
     
 
 handle_recv_msg(Domain, Addr, Bytes, #state{server = Pid})
-  when is_binary(Bytes) andalso (size(Bytes) =:= 0) ->
+  when is_binary(Bytes) andalso (byte_size(Bytes) =:= 0) ->
     Pid ! {snmp_error, {empty_message, Domain, Addr}, Domain, Addr};
 %%
 handle_recv_msg(

--- a/lib/snmp/src/misc/snmp_pdus.erl
+++ b/lib/snmp/src/misc/snmp_pdus.erl
@@ -828,8 +828,8 @@ enint(N, Acc) ->
  
 enc_oct_str_tag(OStr) when is_list(OStr) ->
     lists:append([4|elength(length(OStr))],OStr);
-enc_oct_str_tag(OBin) ->
-    [4 | elength(size(OBin))] ++ binary_to_list(OBin).
+enc_oct_str_tag(OBin) when is_binary(OBin) ->
+    [4 | elength(byte_size(OBin))] ++ binary_to_list(OBin).
 
 
 enc_oct_str_notag(OStr) -> OStr.


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.

Replaces #6776 due to the naming convention.