### PR TITLE
`private_append` optimization for binaries

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -60,6 +60,7 @@ MODULES =  \
 	beam_listing \
 	beam_opcodes \
 	beam_ssa \
+	beam_ssa_alias \
 	beam_ssa_bc_size \
 	beam_ssa_bool \
 	beam_ssa_bsm \
@@ -212,6 +213,7 @@ $(EBIN)/beam_kernel_to_ssa.beam: v3_kernel.hrl beam_ssa.hrl
 $(EBIN)/beam_listing.beam: core_parse.hrl v3_kernel.hrl beam_ssa.hrl \
      beam_asm.hrl beam_types.hrl
 $(EBIN)/beam_ssa.beam: beam_ssa.hrl
+$(EBIN)/beam_ssa_alias_opt.beam: beam_ssa_opt.hrl beam_types.hrl
 $(EBIN)/beam_ssa_bsm.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_bool.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_check.beam: beam_ssa.hrl beam_types.hrl

--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -71,6 +71,7 @@ MODULES =  \
 	beam_ssa_opt \
 	beam_ssa_pp \
 	beam_ssa_pre_codegen \
+	beam_ssa_private_append \
 	beam_ssa_recv \
 	beam_ssa_share \
 	beam_ssa_throw \

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -23,7 +23,11 @@
 
 -export([opt/2]).
 
--import(lists, [foldl/3, reverse/1]).
+-import(lists, [foldl/3, reverse/1, zip/2]).
+
+%% The maximum number of iterations when calculating alias
+%% information.
+-define(MAX_REPETITIONS, 16).
 
 -include("beam_ssa_opt.hrl").
 -include("beam_types.hrl").
@@ -37,6 +41,19 @@
 -define(DP(FMT, ARGS), skip).
 -define(DP(FMT), skip).
 -endif.
+
+-type call_args_status_map() :: #{ #b_local{} => ['aliased' | 'unique'] }.
+
+%% Alias analysis state
+-record(aas, {
+              caller :: func_id() | 'undefined',
+              call_args = #{} :: call_args_status_map(),
+              alias_map = #{},
+              func_db :: func_info_db(),
+              kills :: kills_map(),
+              st_map :: st_map(),
+              orig_st_map :: st_map()
+             }).
 
 %% A code location refering to either the #b_set{} defining a variable
 %% or the terminator of a block.
@@ -66,8 +83,9 @@ opt(StMap0, FuncDb0) ->
     Funs = [ F || F <- maps:keys(StMap0),
                   is_map_key(F, FuncDb0), not is_nif(F, StMap0)],
     Liveness = liveness(Funs, StMap0),
-    _KillsMap = killsets(Liveness, StMap0),
-    {StMap0, FuncDb0}.
+    KillsMap = killsets(Liveness, StMap0),
+
+    aa(Funs, KillsMap, StMap0, FuncDb0).
 
 %%%
 %%% Calculate liveness for each function using the standard iterative
@@ -200,3 +218,634 @@ kills_is([I|Is], Live0, KillsMap0, Blk) ->
     kills_is(Is, sets:union(Live, Killed), KillsMap, Blk);
 kills_is([], _, KillsMap, _) ->
     KillsMap.
+
+%%%
+%%% Perform an alias analysis of the given functions, alias
+%%% information is added as annotations on the SSA code.
+%%%
+%%% Alias analysis is done by an algorithm inspired by Kotzmann and
+%%% Mössenböck's 2005 algorithm for Escape Analysis
+%%% (https://www.usenix.org/events/vee05/full_papers/p111-kotzmann.pdf),
+%%% particularly their escape equivalent sets. But in contrast to
+%%% Kotzmann and Mössenböck, instead of just tracking escaping values
+%%% we track if a value in a variable is unique and/or aliased.
+%%%
+%%% A variable is said to be unique if it currently is the only live
+%%% variable pointing to a particular term on the heap. Literals and
+%%% non-boxed terms are considered unique.
+%%%
+%%% A variable is said to be aliased if it points to a heap term which
+%%% can be reached by other means than the boxed pointer in the
+%%% variable.
+%%%
+%%% The alias analysis is performed by traversing the functions in the
+%%% module and their code. For each operation the uniqueness and alias
+%%% status are updated. The unique/aliased status is maintained in a
+%%% map which maps a variable to a either a status or another
+%%% variable. Thus constructing equivalent sets in the same way a
+%%% Kotzmann and Mössenböck.
+%%%
+%%% When the analysis finishes each instruction is annotated with
+%%% information about which of its arguments are unique or aliased.
+%%%
+-spec aa([func_id()], kills_map(), st_map(), func_info_db()) ->
+          {st_map(), func_info_db()}.
+
+aa(Funs, KillsMap, StMap, FuncDb) ->
+    %% Set up the argument info to make all incoming arguments to
+    %% exported functions aliased and all non-exported functions
+    %% unique.
+    ArgsInfo =
+        foldl(
+          fun(F=#b_local{}, Acc) ->
+                  #func_info{exported=E,arg_types=AT} = map_get(F, FuncDb),
+                  S = case E of
+                          true -> aliased;
+                          false -> unique
+                      end,
+                  Acc#{F=>[S || _ <- AT]}
+          end, #{}, Funs),
+    AAS = #aas{call_args=ArgsInfo,func_db=FuncDb,kills=KillsMap,
+               st_map=StMap, orig_st_map=StMap},
+    aa_fixpoint(Funs, AAS).
+
+%%%
+%%% Alias analysis works on the whole module and uses its own fixpoint
+%%% loop instead of the fixpoint abstraction in beam_ssa_opt. The
+%%% reason for this is three-fold:
+%%%
+%%% * The termination condition is simpler: the alias map hasn't
+%%%   changed.
+%%%
+%%% * Adapting the alias analysis to fit into the beam_ssa_opt
+%%%   fixpoint framework would require it to be expressed as three
+%%%   passes in the style of ssa_opt_type_start,
+%%%   ssa_opt_type_continue, and ssa_opt_type_finish in order to
+%%%   create and maintain the state which is now kept in #aas{}.
+%%%
+%%% * As the beam_ssa_opt fixpoint framework doesn't provide a way for
+%%%   an optimization to be informed that the fixpoint calculation
+%%%   didn't converge within the interation limit and it is unsafe to
+%%%   do optimizations on incomplete unique/aliased information it is
+%%%   much simpler to explicitly handle it locally instead of trying
+%%%   to detect incomplete information in a hypothetical
+%%%   ssa_opt_alias_finish pass.
+%%%
+aa_fixpoint(Order, AAS) ->
+    ?DP("**** Starting fixpoint iteration ****~n"),
+    aa_fixpoint(Order, Order, AAS#aas.alias_map, AAS, ?MAX_REPETITIONS).
+
+aa_fixpoint([F|Fs], Order, OldAliasMap, AAS0=#aas{st_map=StMap}, Limit) ->
+    #b_local{name=#b_literal{val=_N},arity=_A} = F,
+    AAS1 = AAS0#aas{caller=F},
+    ?DP("-= ~p/~p =-~n", [_N, _A]),
+    {OptSt,AAS2} = aa_fun(F, map_get(F, StMap), AAS1),
+    AAS = AAS2#aas{st_map=StMap#{F => OptSt}},
+    aa_fixpoint(Fs, Order, OldAliasMap, AAS, Limit);
+aa_fixpoint([], _Order, OldAliasMap,
+            #aas{alias_map=OldAliasMap,func_db=FuncDb,st_map=StMap}, _) ->
+    ?DP("**** End of iteration ****~n"),
+    {StMap, FuncDb};
+aa_fixpoint([], _, _, #aas{func_db=FuncDb,orig_st_map=StMap}, 0) ->
+    ?DP("**** End of iteration, too many iterations ****~n"),
+    {StMap, FuncDb};
+aa_fixpoint([], Order, _OldAliasMap, AAS=#aas{alias_map=AliasMap}, Limit) ->
+    ?DP("**** Things have changed, starting next iteration ****~n"),
+    aa_fixpoint(Order, Order, AliasMap, AAS, Limit - 1).
+
+aa_fun(F, #opt_st{ssa=Linear0,anno=_Anno,args=Args}=St,
+       AAS0=#aas{alias_map=AliasMap0}) ->
+    %% Initially assume all formal parameters are unique for a
+    %% non-exported function, if we have call argument info in the
+    %% AAS, we use it. For an exported function, all arguments are
+    %% assumed to be aliased.
+    ArgsStatus = aa_get_call_args_status(Args, F, AAS0),
+    SS0 = foldl(fun({Var, Status}, Acc) ->
+                        aa_new_ssa_var(Var, Status, Acc)
+                end, #{}, ArgsStatus),
+    ?DP("@@ Args: ~p~n", [ArgsStatus]),
+    {Linear1,SS} = aa_blocks(Linear0, SS0, AAS0),
+    ?DP("SS:~n~s~n~n", [aa_format(SS)]),
+    AAS = aa_merge_call_args_status(SS, AAS0),
+
+    AliasMap = AliasMap0#{ F => SS },
+    {St#opt_st{ssa=Linear1}, AAS#aas{alias_map=AliasMap}}.
+
+%% Main entry point for the alias analysis
+aa_blocks([{L,#b_blk{is=Is0,last=T0}=Blk}|Bs0], SS0, AAS) ->
+    {Is,SS1} = aa_is(Is0, SS0, [], AAS),
+    {T,SS2} = aa_terminator(T0, SS1),
+    {Bs,SS} = aa_blocks(Bs0, SS2, AAS),
+    {[{L,Blk#b_blk{is=Is,last=T}}|Bs],SS};
+aa_blocks([], SS, _) ->
+    {[],SS}.
+
+aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0, Acc, AAS) ->
+    SS1 = aa_new_ssa_var(Dst, unique, SS0),
+    SS = case Op of
+             %% Instructions changing the alias status.
+             {bif,Bif} ->
+                 aa_bif(Dst, Bif, Args, SS1, AAS);
+             bs_create_bin ->
+                 case Args of
+                     [#b_literal{val=Flag},_,Arg|_] when
+                           Flag =:= private_append ; Flag =:= append ->
+                         case aa_all_dies([Arg], Dst, AAS) of
+                             true ->
+                                 %% Inherit the status of the argument
+                                 aa_join(Dst, Arg, SS1);
+                             false ->
+                                 %% We alias with the surviving arg
+                                 aa_set_aliased([Dst|Args], SS1)
+                         end;
+                     _ ->
+                         %% TODO: Too conservative?
+                         aa_set_aliased([Dst|Args], SS1)
+                 end;
+             bs_extract ->
+                 aa_set_aliased([Dst|Args], SS1);
+             bs_get_tail ->
+                 aa_set_aliased([Dst|Args], SS1);
+             bs_match ->
+                 aa_set_aliased([Dst|Args], SS1);
+             bs_start_match ->
+                 [_,Bin] = Args,
+                 aa_set_aliased([Dst,Bin], SS1);
+             build_stacktrace ->
+                 %% build_stacktrace can potentially alias anything
+                 %% live at this point in the code. We handle it by
+                 %% aliasing everything known to us. Touching
+                 %% variables which are dead is harmless.
+                 aa_alias_all(SS1);
+             call ->
+                 aa_call(Dst, Args, Anno0, SS1, AAS);
+             'catch_end' ->
+                 [_Tag,Arg] = Args,
+                 aa_join(Dst, Arg, SS1);
+             extract ->
+                 [Arg,_] = Args,
+                 aa_join(Dst, Arg, SS1);
+             get_hd ->
+                 [Arg] = Args,
+                 aa_pair_extraction(Dst, Arg, hd, SS1);
+             get_map_element ->
+                 [Map,_Key] = Args,
+                 aa_join(Dst, Map, SS1);
+             get_tl ->
+                 [Arg] = Args,
+                 aa_pair_extraction(Dst, Arg, tl, SS1);
+             get_tuple_element ->
+                 [Arg,Idx] = Args,
+                 aa_tuple_extraction(Dst, Arg, Idx, SS1);
+             landingpad ->
+                 aa_set_aliased(Dst, SS1);
+             make_fun ->
+                 [_|Env] = Args,
+                 aa_join([Dst|Env], SS1);
+             old_make_fun ->
+                 [_|Env] = Args,
+                 aa_join([Dst|Env], SS1);
+             peek_message ->
+                 aa_set_aliased(Dst, SS1);
+             phi ->
+                 aa_phi(Dst, Args, SS1);
+             put_list ->
+                 aa_construct_term(Dst, Args, SS1, AAS);
+             put_map ->
+                 aa_construct_term(Dst, Args, SS1, AAS);
+             put_tuple ->
+                 aa_construct_term(Dst, Args, SS1, AAS);
+             update_tuple ->
+                 aa_construct_term(Dst, Args, SS1, AAS);
+             update_record ->
+                 [_Hint,_Size,Src|Updates] = Args,
+                 Values = [Src|aa_update_record_get_vars(Updates)],
+                 aa_construct_term(Dst, Values, SS1, AAS);
+
+             %% Instructions which don't change the alias status
+             {float,_} ->
+                 SS1;
+             {succeeded,_} ->
+                 SS1;
+             bs_init_writable ->
+                 SS1;
+             bs_test_tail ->
+                 SS1;
+             has_map_field ->
+                 SS1;
+             is_nonempty_list ->
+                 SS1;
+             is_tagged_tuple ->
+                 SS1;
+             kill_try_tag ->
+                 SS1;
+             match_fail ->
+                 SS1;
+             new_try_tag ->
+                 SS1;
+             nif_start ->
+                 SS1;
+             raw_raise ->
+                 SS1;
+             recv_marker_bind ->
+                 SS1;
+             recv_marker_clear ->
+                 SS1;
+             recv_marker_reserve ->
+                 SS1;
+             recv_next ->
+                 SS1;
+             remove_message ->
+                 SS1;
+             resume ->
+                 SS1;
+             wait_timeout ->
+                 SS1;
+             _ ->
+                 exit({unknown_instruction, I})
+         end,
+    aa_is(Is, SS, [aa_update_annotation(I, SS1)|Acc],
+          AAS);
+aa_is([], SS, Acc, _AAS) ->
+    {reverse(Acc), SS}.
+
+aa_terminator(T=#b_br{anno=Anno0}, SS0) ->
+    Anno = aa_update_annotation(Anno0, SS0),
+    {T#b_br{anno=Anno}, SS0};
+aa_terminator(T=#b_ret{arg=Arg,anno=Anno0}, SS0) ->
+    Type = maps:get(result_type, Anno0, any),
+    Status0 = aa_get_status(Arg, SS0),
+    ?DP("Returned ~p:~p:~p~n", [Arg, Status0, Type]),
+    Type2Status0 = maps:get(returns, SS0, #{}),
+    Status = case Type2Status0 of
+                 #{ Type := OtherStatus } ->
+                     aa_meet(Status0, OtherStatus);
+                 #{ } ->
+                     Status0
+             end,
+    Type2Status = Type2Status0#{ Type => Status },
+    ?DP("new status map: ~p~n", [Type2Status]),
+    SS = SS0#{ returns => Type2Status},
+    {aa_update_annotation(T, SS), SS};
+aa_terminator(T=#b_switch{anno=Anno0}, SS0) ->
+    Anno = aa_update_annotation(Anno0, SS0),
+    {T#b_switch{anno=Anno}, SS0}.
+
+%% Add a new ssa variable to the alias state and set its status.
+aa_new_ssa_var(Var, Status, State) ->
+    false = maps:get(Var, State, false), % Assertion
+    State#{Var => {status, Status}}.
+
+aa_get_representative(Var, State) ->
+    %% TODO: Consider path compression
+    case State of
+        #{ Var := {status, _} } ->
+            Var;
+        #{ Var := Parent } ->
+            aa_get_representative(Parent, State);
+        #{} ->
+            Var
+    end.
+
+aa_get_status(V=#b_var{}, State) ->
+    Repr = aa_get_representative(V, State),
+    {status, S} = map_get(Repr, State),
+    S;
+aa_get_status(#b_literal{}, _State) ->
+    unique.
+
+%% As aa_get_status/2 but return false if nothing is known about the
+%% variable.
+aa_check_status(V=#b_var{}, State) ->
+    Repr = aa_get_representative(V, State),
+    case State of
+        #{ Repr := {status, S}} -> S;
+        #{} -> false
+    end.
+
+aa_set_status(V=#b_var{}, Status, State) ->
+    Repr = aa_get_representative(V, State),
+    State#{ Repr => {status, Status} };
+aa_set_status(#b_literal{}, _Status, State) ->
+    State;
+aa_set_status([X|T], Status, State) ->
+    aa_set_status(X, Status, aa_set_status(T, Status, State));
+aa_set_status([], _, State) ->
+    State.
+
+aa_update_annotation(I=#b_set{anno=Anno0,args=Args}, SS) ->
+    {Aliased,Unique} =
+        foldl(fun(#b_var{}=V, {As,Us}) ->
+                      case aa_check_status(V, SS) of
+                          aliased ->
+                              {ordsets:add_element(V, As), Us};
+                          unique ->
+                              {As, ordsets:add_element(V, Us)};
+                          false ->
+                              {As, Us}
+                      end;
+                 (_, A) ->
+                      A
+              end, {ordsets:new(),ordsets:new()}, Args),
+    Anno1 = case Aliased of
+                [] -> maps:remove(aliased, Anno0);
+                _ -> Anno0#{aliased => Aliased}
+            end,
+    Anno = case Unique of
+               [] -> maps:remove(unique, Anno1);
+               _ -> Anno1#{unique => Unique}
+           end,
+    I#b_set{anno=Anno};
+aa_update_annotation(I=#b_ret{arg=#b_var{}=V,anno=Anno0}, SS) ->
+    Anno = case aa_check_status(V, SS) of
+               aliased ->
+                   maps:remove(unique, Anno0#{aliased=>[V]});
+               unique ->
+                   maps:remove(aliased, Anno0#{unique=>[V]});
+               false ->
+                   maps:remove(aliased, maps:remove(unique, Anno0))
+           end,
+    I#b_ret{anno=Anno};
+aa_update_annotation(I, _SS) ->
+    %% For now we don't care about the other terminators.
+    I.
+
+aa_set_aliased(Args, SS) ->
+    aa_set_status(Args, aliased, SS).
+
+aa_alias_all(SS0) ->
+    maps:map(fun(#b_var{}, _) ->
+                     {status,aliased};
+                (returns, Types) ->
+                     #{ T => aliased || T := _ <- Types};
+                (_, V) ->
+                     V
+             end, SS0).
+
+aa_join([#b_var{}=Var|Vars], State) ->
+    aa_join_1(Vars, Var, State);
+aa_join([_|Vars], State) ->
+    aa_join(Vars, State);
+aa_join([], State) ->
+    State.
+
+aa_join_1([#b_var{}=VarB|Vars], VarA, State) ->
+    aa_join_1(Vars, VarB, aa_join(VarA, VarB, State));
+aa_join_1([_|Vars], VarA, State) ->
+    aa_join_1(Vars, VarA, State);
+aa_join_1([], _, State) ->
+    State.
+
+aa_join(#b_var{}=VarA, #b_var{}=VarB, State) ->
+    ARepr = aa_get_representative(VarA, State),
+    BRepr = aa_get_representative(VarB, State),
+    case {ARepr, BRepr} of
+        {Repr, Repr} ->
+            State;
+        _ ->
+            {status, A} = map_get(ARepr, State),
+            {status, B} = map_get(BRepr, State),
+            State#{ ARepr => {status, aa_meet(A, B)}, BRepr => ARepr }
+    end;
+aa_join(_, _, State) ->
+    State.
+
+aa_meet(#b_var{}=Var, SetStatus, State) ->
+    Repr = aa_get_representative(Var, State),
+    {status, Status} = map_get(Repr, State),
+    State#{ Repr => {status, aa_meet(SetStatus, Status)} };
+aa_meet(#b_literal{}, _SetStatus, State) ->
+    State;
+aa_meet([Var|Vars], [Status|Statuses], State) ->
+    aa_meet(Vars, Statuses, aa_meet(Var, Status, State));
+aa_meet([], [], State) ->
+    State.
+
+aa_meet(StatusA, StatusB) ->
+    case {StatusA, StatusB} of
+        {_,aliased} -> aliased;
+        {aliased, _} -> aliased;
+        {unique, unique} -> unique
+    end.
+
+aa_meet([H|T]) ->
+    aa_meet(H, aa_meet(T));
+aa_meet([]) ->
+    unique.
+
+%%
+%% Type is always less specific or exactly the same as one of the
+%% types in StatusByType, so we need to meet all possible statuses for
+%% the call site.
+%%
+aa_get_status_by_type(Type, StatusByType) ->
+    Statuses = [Status || Candidate := Status <- StatusByType,
+                          beam_types:meet(Type, Candidate) =/= none],
+    aa_meet(Statuses).
+
+%% Predicate to check if all variables in `Vars` dies at `Where`.
+-spec aa_all_dies([#b_var{}], kill_loc(), #aas{}) -> boolean().
+aa_all_dies(Vars, Where, #aas{caller=Caller,kills=Kills}) ->
+    KillMap = map_get(Caller, Kills),
+    KillSet = map_get(Where, KillMap),
+    aa_all_dies(Vars, KillSet).
+
+aa_all_dies([#b_literal{}|Vars], KillSet) ->
+    aa_all_dies(Vars, KillSet);
+aa_all_dies([#b_var{}=V|Vars], KillSet) ->
+    case sets:is_element(V, KillSet) of
+        true ->
+            aa_all_dies(Vars, KillSet);
+        false ->
+            false
+    end;
+aa_all_dies([], _) ->
+    true.
+
+aa_alias_if_args_dont_die(Args, Where, SS, AAS) ->
+    case aa_all_dies(Args, Where, AAS) of
+        true ->
+            SS;
+        false ->
+            aa_set_aliased([Where|Args], SS)
+    end.
+
+%% Check that a variable in Args only occurs once, literals are
+%% ignored.
+aa_all_vars_unique(Args) ->
+    aa_all_vars_unique(Args, #{}).
+
+aa_all_vars_unique([#b_literal{}|Args], Seen) ->
+    aa_all_vars_unique(Args, Seen);
+aa_all_vars_unique([#b_var{}=V|Args], Seen) ->
+    case Seen of
+        #{ V := _ } ->
+            false;
+        #{} ->
+            aa_all_vars_unique(Args, Seen#{V => true })
+    end;
+aa_all_vars_unique([], _) ->
+    true.
+
+aa_construct_term(Dst, Values, SS, AAS) ->
+    case aa_all_vars_unique(Values)
+        andalso aa_all_dies(Values, Dst, AAS) of
+        true ->
+            aa_join([Dst|Values], SS);
+        false ->
+            aa_set_aliased([Dst|Values], SS)
+    end.
+
+aa_update_record_get_vars([#b_literal{}, Value|Updates]) ->
+    [Value|aa_update_record_get_vars(Updates)];
+aa_update_record_get_vars([]) ->
+    [].
+
+aa_bif(Dst, element, [_Idx,Tuple], SS, AAS) ->
+    %% If we extract a value and the aggregate dies and wasn't aliased,
+    %% we should not consider this an aliasing operation.
+    aa_alias_if_args_dont_die([Tuple], Dst, SS, AAS);
+aa_bif(Dst, hd, Args, SS, AAS) ->
+    %% If we extract a value and the aggregate dies and wasn't aliased,
+    %% we should not consider this an aliasing operation.
+    aa_alias_if_args_dont_die(Args, Dst, SS, AAS);
+aa_bif(Dst, tl, Args, SS, AAS) ->
+    %% If we extract a value and the aggregate dies and wasn't aliased,
+    %% we should not consider this an aliasing operation.
+    aa_alias_if_args_dont_die(Args, Dst, SS, AAS);
+%% TODO: Ignored for now, as we don't track what's inside maps.
+%% aa_bif(_Dst, map_get, _Args, SS, _AAS) ->
+%%     SS;
+aa_bif(Dst, Bif, Args, SS, _AAS) ->
+    Arity = length(Args),
+    case erl_internal:guard_bif(Bif, Arity)
+        orelse erl_internal:bool_op(Bif, Arity)
+        orelse erl_internal:comp_op(Bif, Arity)
+        orelse erl_internal:arith_op(Bif, Arity)
+        orelse erl_internal:new_type_test(Bif, Arity) of
+        true ->
+            SS;
+        false ->
+            %% Assume anything else shares the arguments and returns an
+            %% aliased result.
+            aa_set_aliased([Dst|Args], SS)
+    end.
+
+aa_phi(Dst, Args0, SS) ->
+    Args = [V || {V,_} <- Args0],
+    aa_join([Dst|Args], SS).
+
+aa_call(Dst, [#b_local{}=Callee|Args], Anno, SS0,
+        #aas{alias_map=AliasMap,st_map=StMap}) ->
+    #b_local{name=#b_literal{val=_N},arity=_A} = Callee,
+    ?DP("A Call~n  callee: ~p/~p~n  args: ~p~n", [_N, _A, Args]),
+    IsNif = is_nif(Callee, StMap),
+    case AliasMap of
+        #{ Callee := CalleeSS } when not IsNif ->
+            ?DP("  The callee is known~n"),
+            #opt_st{args=CalleeArgs} = map_get(Callee, StMap),
+            ?DP("  args in caller: ~p~n",
+                [[{Arg, aa_get_status(Arg, SS0)} || Arg <- Args]]),
+            ArgStates = [ aa_get_status(Arg, CalleeSS) || Arg <- CalleeArgs],
+            ?DP("  callee arg states: ~p~n", [ArgStates]),
+            SS1 = aa_add_call_info(Callee, Args, SS0),
+            SS = aa_meet(Args, ArgStates, SS1),
+            ?DP("  meet: ~p~n",
+                [[{Arg, aa_get_status(Arg, SS1)} || Arg <- Args]]),
+            ReturnStatusByType = maps:get(returns, CalleeSS, #{}),
+            ?DP("  status by type: ~p~n", [ReturnStatusByType]),
+            ReturnedType = case Anno of
+                               #{ result_type := ResultType } ->
+                                   ResultType;
+                               #{} ->
+                                   any
+                           end,
+            %% ReturnedType is always less specific or exactly the
+            %% same as one of the types in ReturnStatusByType.
+            ?DP("  returned type: ~s~n",
+                [beam_ssa_pp:format_type(ReturnedType)]),
+            ResultStatus = aa_get_status_by_type(ReturnedType,
+                                                 ReturnStatusByType),
+            ?DP("  result status: ~p~n", [ResultStatus]),
+            aa_set_status(Dst, ResultStatus, SS);
+        _ when IsNif ->
+            %% This is a nif, assume that all arguments will be
+            %% aliased and that the result is aliased.
+            aa_set_aliased([Dst|Args], SS0);
+        #{} ->
+            %% We don't know anything about the function, don't change
+            %% the status of any variables
+            SS0
+    end;
+aa_call(Dst, [_Callee|Args], _Anno, SS, _AAS) ->
+    %% This is either a call to a fun or to an external function,
+    %% assume that all arguments and the result escape.
+    aa_set_aliased([Dst|Args], SS).
+
+%% Add info about the aliasing status of the arguments to the call
+aa_add_call_info(Callee, Args, SS0) ->
+    ArgStats = [aa_get_status(Arg, SS0) || Arg <- Args],
+    NewStats = case SS0 of
+                   #{{call_info, Callee} := Stats} ->
+                       [aa_meet(A, B) || {A,B} <- zip(Stats, ArgStats)];
+                   #{} ->
+                       ArgStats
+               end,
+    SS0#{{call_info, Callee} => NewStats}.
+
+%% Incorporate aliasing information derived when analysing the body of
+%% a function into the module-global state.
+aa_merge_call_args_status(SS, AAS=#aas{call_args=Info0}) ->
+    Info =
+        maps:fold(fun({call_info,Callee}, NewArgs, Acc) ->
+                          case Acc of
+                              #{ Callee := OldArgs } ->
+                                  Args = [aa_meet(A, B)
+                                          || {A,B} <- zip(NewArgs, OldArgs)],
+                                  Acc#{Callee => Args};
+                              #{} ->
+                                  Acc#{Callee => NewArgs}
+                          end;
+                     (_, _, Acc) ->
+                          Acc
+                  end, Info0, SS),
+    AAS#aas{call_args=Info}.
+
+aa_get_call_args_status(Args, Callee, #aas{call_args=Info}) ->
+    case Info of
+        #{ Callee := Status } ->
+            zip(Args, Status);
+        #{} ->
+            [{V, unique} || V <- Args]
+    end.
+
+aa_pair_extraction(Dst, Pair, Element, SS0) ->
+    case SS0 of
+        #{{pair,Pair}:=both} ->
+            %% Both elements have already been extracted
+            aa_set_aliased([Dst,Pair], SS0);
+        #{{pair,Pair}:=Element} ->
+            %% This element has already been extracted
+            aa_set_aliased([Dst,Pair], SS0);
+        #{{pair,Pair}:=_Other} ->
+            %% Both elements have now been extracted
+            aa_join(Dst, Pair, SS0#{{pair,Pair}=>both});
+        _ ->
+            %% Nothing has been extracted from this pair
+            aa_join(Dst, Pair, SS0#{{pair,Pair}=>Element})
+    end.
+
+aa_tuple_extraction(Dst, Tuple, #b_literal{val=I}, SS1) ->
+    case SS1 of
+        #{{tuple_element,Tuple}:=OrdSet0} ->
+            case ordsets:is_element(I, OrdSet0) of
+                true ->
+                    aa_set_aliased([Dst,Tuple], SS1);
+                false ->
+                    OrdSet = ordsets:add_element(I, OrdSet0),
+                    aa_join(Dst, Tuple, SS1#{{tuple_element,Tuple}=>OrdSet})
+            end;
+        _ ->
+            %% There are no aliases yet.
+            aa_join(Dst, Tuple, SS1#{{tuple_element,Tuple}=>[I]})
+    end.

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -23,7 +23,10 @@
 
 -export([opt/2]).
 
+-import(lists, [foldl/3, reverse/1]).
+
 -include("beam_ssa_opt.hrl").
+-include("beam_types.hrl").
 
 %% -define(DEBUG, true).
 
@@ -35,6 +38,12 @@
 -define(DP(FMT), skip).
 -endif.
 
+%% Record holding the liveness information for a code location.
+-record(liveness_st, {
+                      in = sets:new([{version,2}]) :: sets:set(#b_var{}),
+                      out = sets:new([{version,2}]) :: sets:set(#b_var{})
+                     }).
+
 %%%
 %%% Optimization pass which calculates the alias status of values and
 %%% uses the results to transform the code.
@@ -42,4 +51,99 @@
 -spec opt(st_map(), func_info_db()) -> {st_map(), func_info_db()}.
 
 opt(StMap0, FuncDb0) ->
+    %% Ignore functions which are not in the function db (never
+    %% called) or are stubs for nifs.
+    Funs = [ F || F <- maps:keys(StMap0),
+                  is_map_key(F, FuncDb0), not is_nif(F, StMap0)],
+    _Liveness = liveness(Funs, StMap0),
     {StMap0, FuncDb0}.
+
+%%%
+%%% Calculate liveness for each function using the standard iterative
+%%% fixpoint method.
+%%%
+
+-spec liveness([func_id()], st_map()) ->
+          [{func_id(), #{func_id() => {beam_ssa:label(), #liveness_st{}}}}].
+
+liveness([F|Funs], StMap) ->
+    Liveness = liveness_fun(F, StMap),
+    [{F,Liveness}|liveness(Funs, StMap)];
+liveness([], _StMap) ->
+    [].
+
+liveness_fun(F, StMap0) ->
+    #opt_st{ssa=SSA} = map_get(F, StMap0),
+    State0 = maps:from_list([ {Lbl, #liveness_st{}} || {Lbl,_} <- SSA]),
+    liveness_blks_fixp(reverse(SSA), State0, false).
+
+liveness_blks_fixp(_SSA, State0, State0) ->
+    State0;
+liveness_blks_fixp(SSA, State0, _Old) ->
+    State = liveness_blks(SSA, State0),
+    liveness_blks_fixp(SSA, State, State0).
+
+liveness_blks([{Lbl,Blk}|Blocks], State0) ->
+    OutOld = get_live_out(Lbl, State0),
+    Defs = blk_defs(Blk),
+    Uses = blk_effective_uses(Blk),
+    In = sets:union(Uses, sets:subtract(OutOld, Defs)),
+    Out = successor_live_ins(Blk, State0),
+    liveness_blks(Blocks, set_block_liveness(Lbl, In, Out, State0));
+liveness_blks([], State0) ->
+    State0.
+
+get_live_in(Lbl, State) ->
+    #liveness_st{in=In} = map_get(Lbl, State),
+    In.
+
+get_live_out(Lbl, State) ->
+    #liveness_st{out=Out} = map_get(Lbl, State),
+    Out.
+
+set_block_liveness(Lbl, In, Out, State) ->
+    L = map_get(Lbl, State),
+    State#{Lbl => L#liveness_st{in=In,out=Out}}.
+
+successor_live_ins(Blk, State) ->
+    foldl(fun(Lbl, Acc) ->
+                  sets:union(Acc, get_live_in(Lbl, State))
+          end, sets:new([{version,2}]), beam_ssa:successors(Blk)).
+
+blk_defs(#b_blk{is=Is}) ->
+    foldl(fun(#b_set{dst=Dst}, Acc) ->
+                  sets:add_element(Dst, Acc)
+          end, sets:new([{version,2}]), Is).
+
+blk_effective_uses(#b_blk{is=Is,last=Last}) ->
+    %% We can't use beam_ssa:used/1 on the whole block as it considers
+    %% a use after a def a use and that will derail the liveness
+    %% calculation.
+    blk_effective_uses([Last|reverse(Is)], sets:new([{version,2}])).
+
+blk_effective_uses([I|Is], Uses0) ->
+    Uses = case I of
+               #b_set{dst=Dst} ->
+                   %% The uses after the def do not count
+                   sets:del_element(Dst, Uses0);
+               _ -> % A terminator, no defs
+                   Uses0
+           end,
+    LocalUses = sets:from_list(beam_ssa:used(I), [{version,2}]),
+    blk_effective_uses(Is, sets:union(Uses, LocalUses));
+blk_effective_uses([], Uses) ->
+    Uses.
+
+%%%
+%%% Predicate to check if a function is the stub for a nif.
+%%%
+-spec is_nif(func_id(), st_map()) -> boolean().
+
+is_nif(F, StMap) ->
+    #opt_st{ssa=[{0,#b_blk{is=Is}}|_]} = map_get(F, StMap),
+    case Is of
+        [#b_set{op=nif_start}|_] ->
+            true;
+        _ -> false
+    end.
+

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -1,0 +1,45 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%%
+
+-module(beam_ssa_alias).
+
+-export([opt/2]).
+
+-include("beam_ssa_opt.hrl").
+
+%% -define(DEBUG, true).
+
+-ifdef(DEBUG).
+-define(DP(FMT, ARGS), io:format(FMT, ARGS)).
+-define(DP(FMT), io:format(FMT)).
+-else.
+-define(DP(FMT, ARGS), skip).
+-define(DP(FMT), skip).
+-endif.
+
+%%%
+%%% Optimization pass which calculates the alias status of values and
+%%% uses the results to transform the code.
+%%%
+-spec opt(st_map(), func_info_db()) -> {st_map(), func_info_db()}.
+
+opt(StMap0, FuncDb0) ->
+    {StMap0, FuncDb0}.

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -1176,8 +1176,14 @@ cg_block([#cg_set{op=bs_create_bin,dst=Dst0,args=Args0,anno=Anno}=I,
                _ ->
                    Unit0
            end,
+    TypeInfo = case Anno of
+                   #{result_type := #t_bitstring{appendable=true}=Type} ->
+                       [{'%',{var_info,Dst,[{type,Type}]}}];
+                   _ ->
+                       []
+               end,
     Is = [Line,{bs_create_bin,Fail,Alloc,Live,Unit,Dst,{list,Args}}],
-    {Is,St};
+    {Is++TypeInfo,St};
 cg_block([#cg_set{op=bs_start_match,
                   dst=Ctx0,
                   args=[#b_literal{val=new},Bin0]}=I,

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -282,6 +282,10 @@ epilogue_module_passes(Opts) ->
     Ps0 = [{ssa_opt_alias,
             fun({StMap, FuncDb}) ->
                     beam_ssa_alias:opt(StMap, FuncDb)
+            end},
+           {ssa_opt_private_append,
+            fun({StMap, FuncDb}) ->
+                    beam_ssa_private_append:opt(StMap, FuncDb)
             end}],
     passes_1(Ps0, Opts).
 

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -302,6 +302,8 @@ format_type(#t_atom{elements=Es}) ->
                  || E <- ordsets:to_list(Es)], " | ");
 format_type(#t_bs_matchable{tail_unit=U}) ->
     io_lib:format("bs_matchable(~p)", [U]);
+format_type(#t_bitstring{size_unit=S,appendable=true}) ->
+    io_lib:format("bitstring(~p,appendable)", [S]);
 format_type(#t_bitstring{size_unit=S}) ->
     io_lib:format("bitstring(~p)", [S]);
 format_type(#t_bs_context{tail_unit=U}) ->

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -280,6 +280,16 @@ format_instr_anno(#{arg_types:=Ts}=Anno0, FuncAnno, Args) ->
     [io_lib:format("  %% Argument types:~s~ts\n",
                    [Break, unicode:characters_to_list(Formatted)]) |
      format_instr_anno(Anno, FuncAnno, Args)];
+format_instr_anno(#{aliased:=As}=Anno, FuncAnno, Args) ->
+    Break = "\n  %%    ",
+    ["  %% Aliased:",
+     string:join([[Break, format_var(V)] || V <- As], ", "), "\n",
+     format_instr_anno(maps:remove(aliased, Anno), FuncAnno, Args)];
+format_instr_anno(#{unique:=Us}=Anno, FuncAnno, Args) ->
+    Break = "\n  %%    ",
+    ["  %% Unique:",
+     string:join([[Break, format_var(V)] || V <- Us], ", "), "\n",
+     format_instr_anno(maps:remove(unique, Anno), FuncAnno, Args)];
 format_instr_anno(Anno, _FuncAnno, _Args) ->
     format_instr_anno_1(Anno).
 

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -171,21 +171,31 @@ format_i_number(#{}) -> [].
 
 format_terminator(#b_br{anno=A,bool=#b_literal{val=true},
                         succ=Same,fail=Same}, _) ->
-    io_lib:format("  ~sbr ~ts\n", [format_i_number(A),format_label(Same)]);
+    io_lib:format("~s  ~sbr ~ts\n",
+                  [format_terminator_anno(A),
+                   format_i_number(A),
+                   format_label(Same)]);
 format_terminator(#b_br{anno=A,bool=Bool,succ=Succ,fail=Fail}, FuncAnno) ->
-    io_lib:format("  ~sbr ~ts, ~ts, ~ts\n",
-                  [format_i_number(A),
+    io_lib:format("~s  ~sbr ~ts, ~ts, ~ts\n",
+                  [format_terminator_anno(A),
+                   format_i_number(A),
                    format_arg(Bool, FuncAnno),
                    format_label(Succ),
                    format_label(Fail)]);
 format_terminator(#b_switch{anno=A,arg=Arg,fail=Fail,list=List}, FuncAnno) ->
-    [format_instr_anno(A, FuncAnno, [Arg]),
-    io_lib:format("  ~sswitch ~ts, ~ts, ~ts\n",
-                  [format_i_number(A),format_arg(Arg, FuncAnno),
+    io_lib:format("~s  ~sswitch ~ts, ~ts, ~ts\n",
+                  [format_terminator_anno(A),
+                   format_i_number(A),format_arg(Arg, FuncAnno),
                    format_label(Fail),
-                   format_switch_list(List, FuncAnno)])];
+                   format_switch_list(List, FuncAnno)]);
 format_terminator(#b_ret{anno=A,arg=Arg}, FuncAnno) ->
-    io_lib:format("  ~sret ~ts\n", [format_i_number(A),format_arg(Arg, FuncAnno)]).
+    io_lib:format("~s  ~sret ~ts\n",
+                  [format_terminator_anno(A),
+                   format_i_number(A),
+                   format_arg(Arg, FuncAnno)]).
+
+format_terminator_anno(Anno) ->
+    format_instr_anno(Anno, #{}, []).
 
 format_op({Prefix,Name}) ->
     io_lib:format("~p:~p", [Prefix,Name]);

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -19,7 +19,7 @@
 %%
 -module(beam_ssa_pp).
 
--export([format_function/1,format_instr/1,format_var/1]).
+-export([format_function/1,format_instr/1,format_var/1,format_type/1]).
 
 -include("beam_ssa.hrl").
 -include("beam_types.hrl").
@@ -302,6 +302,8 @@ format_live_interval(#b_var{}=Dst, #{live_intervals:=Intervals}) ->
             []
     end;
 format_live_interval(_, _) -> [].
+
+-spec format_type(type()) -> iolist().
 
 format_type(any) ->
     "any()";

--- a/lib/compiler/src/beam_ssa_private_append.erl
+++ b/lib/compiler/src/beam_ssa_private_append.erl
@@ -1,0 +1,623 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%%
+
+%% When a binary is grown by appending data to it using
+%% `bs_create_bin`, a considerable performance improvement can be
+%% achieved if the append can be done using the destructive
+%% `private_append` instead of `append`. Using `private_append` flavor
+%% of `bs_create_bin` is only possible when the binary being extended
+%% has been created by `bs_writable_binary` or by another
+%% `bs_create_bin` using `private_append`. As `private_append` is
+%% destructive, an additional requirement is that there is only one
+%% live reference to the binary being being extended.
+
+%% This optimization implements a new SSA optimization pass which
+%% finds suitable code sequences which iteratively grow a binaries
+%% starting with `<<>>` and rewrites them to start with an initial
+%% value created by `bs_writable_binary` and use `private_append` for
+%% `bs_create_bin`.
+
+-module(beam_ssa_private_append).
+
+-export([opt/2]).
+
+-import(lists, [foldl/3, foldr/3, keysort/2, map/2, reverse/1]).
+
+-include("beam_ssa_opt.hrl").
+-include("beam_types.hrl").
+
+%% -define(DEBUG, true).
+
+-ifdef(DEBUG).
+-define(DP(FMT, ARGS), io:format(FMT, ARGS)).
+-define(DP(FMT), io:format(FMT)).
+-else.
+-define(DP(FMT, ARGS), skip).
+-define(DP(FMT), skip).
+-endif.
+
+-spec opt(st_map(), func_info_db()) -> {st_map(), func_info_db()}.
+opt(StMap, FuncDb) ->
+    %% Ignore functions which are not in the function db (never
+    %% called) or are stubs for nifs.
+    Funs = [ F || F <- maps:keys(StMap),
+                  is_map_key(F, FuncDb), not is_nif(F, StMap)],
+    private_append(Funs, StMap, FuncDb).
+
+private_append(Funs, StMap0, FuncDb) ->
+    Appends = maps:fold(fun(Fun, As, Acc) ->
+                                [{Fun,A} || A <- As] ++ Acc
+                        end, [], find_appends(Funs, StMap0, #{})),
+    %% We now have to find where we create the binaries in order to
+    %% patch them.
+    Defs = find_defs(Appends, StMap0, FuncDb),
+    StMap = patch_appends(Defs, Appends, StMap0),
+    {StMap, FuncDb}.
+
+find_appends([F|Funs], StMap, Found0) ->
+    #opt_st{ssa=Linear} = map_get(F, StMap),
+    Found = find_appends_blk(Linear, F, Found0),
+    find_appends(Funs, StMap, Found);
+find_appends([], _, Found) ->
+    Found.
+
+find_appends_blk([{_Lbl,#b_blk{is=Is}}|Linear], Fun, Found0) ->
+    Found = find_appends_is(Is, Fun, Found0),
+    find_appends_blk(Linear, Fun, Found);
+find_appends_blk([], _, Found) ->
+    Found.
+
+find_appends_is([#b_set{dst=Dst, op=bs_create_bin,
+                        args=[#b_literal{val=append},SegmentInfo,Var|_],
+                        anno=Anno}|Is], Fun, Found0) ->
+    case is_unique(Var, Anno) andalso is_appendable(Anno, SegmentInfo) of
+        true ->
+            AlreadyFound = maps:get(Fun, Found0, []),
+            Found = Found0#{Fun => [{append,Dst,Var}|AlreadyFound]},
+            find_appends_is(Is, Fun, Found);
+        false ->
+            find_appends_is(Is, Fun, Found0)
+    end;
+find_appends_is([_|Is], Fun, Found) ->
+    find_appends_is(Is, Fun, Found);
+find_appends_is([], _, Found) ->
+    Found.
+
+is_unique(Var, Anno) ->
+    ordsets:is_element(Var, maps:get(unique, Anno, [])).
+
+is_appendable(Anno, #b_literal{val=[SegmentUnit|_]})
+  when is_integer(SegmentUnit) ->
+    case Anno of
+        #{arg_types:=#{2:=#t_bitstring{appendable=true,size_unit=SizeUnit}}} ->
+            SizeUnit rem SegmentUnit == 0;
+        #{arg_types:=#{2:=#t_union{other=#t_bitstring{appendable=true,
+                                                      size_unit=SizeUnit}}}} ->
+            SizeUnit rem SegmentUnit == 0;
+        _ ->
+            false
+    end.
+
+-record(def_st,
+        {
+         funcdb,
+         stmap,
+         defsdb = #{},
+         literals = #{},
+         valuesdb = #{}
+        }).
+
+find_defs(As, StMap, FuncDb) ->
+    find_defs_1(As, #def_st{funcdb=FuncDb,stmap=StMap}).
+
+find_defs_1([{Fun,{append,Dst,_Arg}}|Work], DefSt0=#def_st{stmap=StMap}) ->
+    #{Fun:=#opt_st{ssa=SSA,args=Args}} = StMap,
+    {DefsInFun,DefSt} = defs_in_fun(Fun, Args, SSA, DefSt0),
+    ValuesInFun = values_in_fun(Fun, DefSt),
+    ?DP("*** append in: ~p ***~n", [Fun]),
+    track_value_in_fun([{Dst,self}], Fun, Work,
+                       DefsInFun, ValuesInFun, DefSt);
+find_defs_1([{Fun,{track_call_argument,Callee,Element,Idx}}|Work],
+            DefSt0=#def_st{stmap=StMap}) ->
+    #{Fun:=#opt_st{ssa=SSA,args=Args}} = StMap,
+    ?DP("*** Tracking ~p of the ~p:th argument in call to ~p"
+        " in the function ~p ***~n", [Element, Idx, Callee, Fun]),
+
+    {DefsInFun,DefSt1} = defs_in_fun(Fun, Args, SSA, DefSt0),
+    ValuesInFun = values_in_fun(Fun, DefSt1),
+    {Vars,DefSt} =
+        get_call_arguments(Callee, Element, Idx, DefsInFun, Fun, DefSt1),
+    ?DP("  Vars to track: ~p~n", [Vars]),
+    track_value_in_fun(Vars, Fun, Work, DefsInFun, ValuesInFun, DefSt);
+find_defs_1([{Fun,{track_result,Element}}|Work],
+            DefSt0=#def_st{stmap=StMap}) ->
+    #{Fun:=#opt_st{ssa=SSA,args=Args}} = StMap,
+    {DefsInFun,DefSt1} = defs_in_fun(Fun, Args, SSA, DefSt0),
+    ValuesInFun = values_in_fun(Fun, DefSt0),
+    ?DP("*** Tracking ~p of the result of ~p ***~n",
+        [Fun, Element]),
+    {Results,DefSt} = get_results(SSA, Element, Fun, DefSt1),
+    ?DP("values to track inside the function: ~p~n", [Results]),
+    track_value_in_fun(Results, Fun, Work, DefsInFun, ValuesInFun, DefSt);
+
+find_defs_1([], DefSt) ->
+    DefSt#def_st.literals.
+
+%% Find all variables which are returned and return them in a worklist
+get_results(SSA, Element, Fun, DefSt) ->
+    get_results(SSA, [], Element, Fun, DefSt).
+
+get_results([{_,#b_blk{last=#b_ret{arg=#b_var{}=V}}}|Rest],
+            Acc, Element, Fun, DefSt) ->
+    get_results(Rest, [{V,Element}|Acc], Element, Fun, DefSt);
+get_results([{Lbl,#b_blk{last=#b_ret{arg=#b_literal{}}}}|Rest],
+            Acc, Element, Fun, DefSt0) ->
+    DefSt = add_literal(Fun, {ret,Lbl,Element}, DefSt0),
+    get_results(Rest, Acc, Element, Fun, DefSt);
+get_results([_|Rest], Acc, Element, Fun, DefSt) ->
+    get_results(Rest, Acc, Element, Fun, DefSt);
+get_results([], Acc, _, _Fun, DefSt) ->
+    {Acc, DefSt}.
+
+track_value_in_fun([{#b_var{}=V,Element}|Rest], Fun, Work,
+                   Defs, ValuesInFun, DefSt0)
+  when is_map_key({V,Element}, ValuesInFun) ->
+    %% We have already explored this value.
+    ?DP("We have already explored ~p of ~p in ~p~n", [Element, V, Fun]),
+    track_value_in_fun(Rest, Fun, Work, Defs, ValuesInFun, DefSt0);
+track_value_in_fun([{#b_var{}=V,Element}|Rest], Fun, Work0, Defs,
+                   ValuesInFun0, DefSt0=#def_st{}) ->
+    ?DP("Tracking  ~p of ~p in fun ~p~n", [Element, V, Fun]),
+    ValuesInFun = ValuesInFun0#{{V,Element}=>visited},
+    case Defs of
+        #{V:=#b_set{dst=V,op=Op,args=Args}} ->
+            case {Op,Args,Element} of
+                {bs_create_bin,[#b_literal{val=append},_,Arg|_],self} ->
+                    track_value_in_fun([{Arg,self}|Rest], Fun, Work0,
+                                       Defs, ValuesInFun, DefSt0);
+                {bs_create_bin,[#b_literal{val=private_append},_,_|_],self} ->
+                    %% If the code has already been rewritten to use
+                    %% private_append, tracking the accumulator to
+                    %% ensure that it is is writable has already
+                    %% been seen to, so no need to track it.
+                    track_value_in_fun(Rest, Fun, Work0,
+                                       Defs, ValuesInFun, DefSt0);
+                {bs_init_writable,_,self} ->
+                    %% bs_init_writable creates a writable binary, so
+                    %% we are done.
+                    track_value_in_fun(Rest, Fun, Work0,
+                                       Defs, ValuesInFun, DefSt0);
+                {call,[#b_local{}=Callee|_Args],_} ->
+                    track_value_into_call(Callee, Element, Fun, Rest, Work0,
+                                          Defs, ValuesInFun, DefSt0);
+                {call,[#b_remote{mod=#b_literal{val=erlang},
+                                 name=#b_literal{val=error},
+                                 arity=1}|_Args],_} ->
+                    %% As erlang:error/1 never returns, we shouldn't
+                    %% try to track this value.
+                    track_value_in_fun(Rest, Fun, Work0,
+                                       Defs, ValuesInFun, DefSt0);
+                {get_hd,[List],_} ->
+                    track_value_in_fun(
+                      [{List,{hd,Element}}|Rest], Fun, Work0,
+                      Defs, ValuesInFun, DefSt0);
+                {get_tl,[List],_} ->
+                    track_value_in_fun(
+                      [{List,{tl,Element}}|Rest], Fun, Work0,
+                      Defs, ValuesInFun, DefSt0);
+                {get_tuple_element,[#b_var{}=Tuple,#b_literal{val=Idx}],_} ->
+                    track_value_in_fun(
+                      [{Tuple,{tuple_element,Idx,Element}}|Rest], Fun, Work0,
+                      Defs, ValuesInFun, DefSt0);
+                {phi,_,_} ->
+                    {ToExplore,DefSt} = handle_phi(Fun, V, Args,
+                                                   Element, DefSt0),
+                    track_value_in_fun(ToExplore ++ Rest, Fun, Work0,
+                                       Defs, ValuesInFun, DefSt);
+                {put_tuple,_,_} ->
+                    track_put_tuple(Args, Element, Rest, Fun, V, Work0,
+                                    Defs, ValuesInFun, DefSt0);
+                {put_list,_,_} ->
+                    track_put_list(Args, Element, Rest, Fun, V, Work0,
+                                   Defs, ValuesInFun, DefSt0)
+            end;
+        #{V:={arg,Idx}} ->
+            track_value_into_caller(Element, Idx, Rest, Fun, Work0, Defs,
+                                    ValuesInFun, DefSt0)
+    end;
+track_value_in_fun([{#b_literal{},_}|Rest], Fun, Work,
+                   Defs, ValuesInFun, DefSt) ->
+    track_value_in_fun(Rest, Fun, Work, Defs, ValuesInFun, DefSt);
+track_value_in_fun([], Fun, Work, _Defs, ValuesInFun,
+                   DefSt0=#def_st{valuesdb=ValuesDb0}) ->
+    %% We are done with this function. Store the result in the
+    %% valuesdb and continue with the work list.
+    DefSt = DefSt0#def_st{valuesdb=ValuesDb0#{Fun=>ValuesInFun}},
+    find_defs_1(Work, DefSt).
+
+track_value_into_call(Callee, Element, CallerFun, CallerWork, GlobalWork0,
+                      CallerDefs, CallerValuesInFun, DefSt0) ->
+    GlobalWork = [{Callee, {track_result, Element}}|GlobalWork0],
+    track_value_in_fun(CallerWork, CallerFun, GlobalWork,
+                       CallerDefs, CallerValuesInFun, DefSt0).
+
+track_value_into_caller(Element, ArgIdx,
+                        CalledFunWorklist, CalledFun,
+                        GlobalWorklist0,
+                        CalledFunDefs, CalledFunValues,
+                        DefSt0=#def_st{funcdb=FuncDb,stmap=StMap}) ->
+    #func_info{in=Callers} = map_get(CalledFun, FuncDb),
+    ?DP("Track into callers of ~p, tracking arg-idx:~p, ~p~n  callers:~p~n",
+        [CalledFun, ArgIdx, Element, Callers]),
+    %% The caller information in func_info does not remove a caller
+    %% when it is inlined into another function (although the new
+    %% caller is added), so we have to filter out functions which lack
+    %% entries in the st_map (as they are dead, they have been removed
+    %% from the stmap).
+    Work = [ {Caller,{track_call_argument,CalledFun,Element,ArgIdx}}
+             || Caller <- Callers, is_map_key(Caller, StMap)],
+    GlobalWorklist = Work ++ GlobalWorklist0,
+    track_value_in_fun(CalledFunWorklist, CalledFun, GlobalWorklist,
+                       CalledFunDefs, CalledFunValues, DefSt0).
+
+track_put_tuple(FieldVars, {tuple_element,Idx,Element},
+                Work, Fun, Dst, GlobalWork,
+                Defs, ValuesInFun, DefSt0) ->
+    %% The value we are tracking was constructed by a put tuple and we
+    %% are interested in continuing the tracking of the field
+    case lists:nth(Idx + 1, FieldVars) of
+        ToTrack = #b_var{} ->
+            track_value_in_fun([{ToTrack,Element}|Work], Fun, GlobalWork,
+                               Defs, ValuesInFun, DefSt0);
+        #b_literal{val=Lit} ->
+            DefSt = add_literal(Fun, {opargs,Dst,Idx,Lit,Element}, DefSt0),
+            track_value_in_fun(Work, Fun, GlobalWork,
+                               Defs, ValuesInFun, DefSt)
+    end.
+
+track_put_list([Hd,Tl], {What,Element},
+               Work, Fun, Dst, GlobalWork,
+               Defs, ValuesInFun, DefSt0) ->
+    %% The value we are tracking was constructed by a put list and we
+    %% are interested in continuing the tracking of the field
+    {ToTrack, Idx} = case What of
+                         hd -> {Hd, 0};
+                         tl -> {Tl, 1}
+                     end,
+    case ToTrack of
+        #b_var{} ->
+            track_value_in_fun([{ToTrack,Element}|Work], Fun, GlobalWork,
+                               Defs, ValuesInFun, DefSt0);
+        #b_literal{val=Lit} ->
+            DefSt = add_literal(Fun, {opargs,Dst,Idx,Lit,Element}, DefSt0),
+            track_value_in_fun(Work, Fun, GlobalWork, Defs, ValuesInFun, DefSt)
+    end.
+
+%% Find all calls to Callee and produce a work-list containing all
+%% values which are used as the Idx:th argument.
+get_call_arguments(Callee, Element, Idx, Defs, Fun, DefSt0) ->
+    %% We traverse all defs inside the caller to find the calls.
+    maps:fold(fun(_, #b_set{dst=Dst,op=call,args=[Target|Args]}, {Acc,DefSt})
+                    when Callee =:= Target ->
+                      {Values,DefSt1} =
+                          gca(Args, Element, Idx, Fun, Dst, DefSt),
+                      {Values ++ Acc, DefSt1};
+                 (_, _, Acc) ->
+                      Acc
+              end, {[], DefSt0}, Defs).
+
+gca(Args, Element, Idx, Fun, Dst, DefSt) ->
+    gca(Args, 0, Element, Idx, Fun, Dst, DefSt).
+
+gca([#b_var{}=V|_], I, Element, I, _Fun, _Dst, DefSt) ->
+    %% This is the argument we are tracking.
+    {[{V,Element}], DefSt};
+gca([#b_literal{val=Lit}|_], I, self, I, _Fun, _Dst, DefSt)
+  when not is_bitstring(Lit)->
+    %% As value tracking is done without type information, we can
+    %% follow def chains which don't terminate in a bitstring. This is
+    %% harmless, but we should ignore them and not, later on, try to
+    %% patch them to a bs_writable_binary.
+    {[], DefSt};
+gca([#b_literal{val=Lit}|_], I, Element, I, Fun, Dst, DefSt) ->
+    {[], add_literal(Fun, {opargs,Dst,I+1,Lit,Element}, DefSt)};
+gca([_|Args], I, Element, Idx, Fun, Dst, DefSt) ->
+    gca(Args, I + 1, Element, Idx, Fun, Dst, DefSt).
+
+handle_phi(Fun, Dst, Args, Element, DefSt0) ->
+    foldl(fun({#b_literal{val=Lit},Lbl}, {Acc,DefStAcc0}) ->
+                  DefStAcc =
+                      add_literal(Fun, {phi,Dst,Lbl,Lit,Element}, DefStAcc0),
+                  {Acc, DefStAcc};
+             ({V=#b_var{},_Lbl}, {Acc,DefStAcc}) ->
+                  {[{V,Element}|Acc],DefStAcc}
+          end, {[],DefSt0}, Args).
+
+%% Cache calculation of the defs for a function so we only do it once.
+defs_in_fun(Fun, Args, SSA, DefSt=#def_st{defsdb=DefsDb}) ->
+    case DefsDb of
+        #{Fun:=Defs} ->
+            {Defs, DefSt};
+        #{} ->
+            BlockMap = maps:from_list(SSA),
+            Labels = maps:keys(BlockMap),
+            Defs0 = beam_ssa:definitions(Labels, BlockMap),
+            {Defs,_} = foldl(fun(Arg, {Acc,Idx}) ->
+                                     {Acc#{Arg => {arg,Idx}}, Idx + 1}
+                             end, {Defs0,0}, Args),
+            {Defs, DefSt#def_st{defsdb=DefsDb#{Fun=>Defs}}}
+    end.
+
+
+%% Look up what we know about the values in Fun.
+values_in_fun(Fun, #def_st{valuesdb=ValuesDb}) ->
+    maps:get(Fun, ValuesDb, #{}).
+
+add_literal(Fun, LitInfo, DefSt=#def_st{literals=Ls}) ->
+    Old = maps:get(Fun, Ls, []),
+    DefSt#def_st{literals=Ls#{Fun => [LitInfo|Old]}}.
+
+patch_appends(Bins, Appends, StMap0) ->
+    ?DP("Appends:~n~p~n", [Appends]),
+    ?DP("Bins:~n~p~n", [Bins]),
+
+    %% Group by function
+    Patches = foldl(fun({Fun,Append}, Acc) ->
+                            Acc#{Fun => [Append|maps:get(Fun, Acc, [])] }
+                    end, Bins, Appends),
+    ?DP("Patches:~n~p~n", [Patches]),
+    maps:fold(fun(Fun, Ps, StMapAcc) ->
+                      OptSt=#opt_st{ssa=SSA0,cnt=Cnt0} =
+                          map_get(Fun, StMapAcc),
+                      {SSA,Cnt} = patch_appends_f(SSA0, Cnt0, Ps),
+                      StMapAcc#{Fun => OptSt#opt_st{ssa=SSA,cnt=Cnt}}
+              end, StMap0, Patches).
+
+patch_appends_f(SSA0, Cnt0, Patches) ->
+    ?DP("Will patch ~p~n", [Patches]),
+    ?DP("SSA: ~p~n", [SSA0]),
+    %% Group by PD
+    PD = foldl(fun(P, Acc) ->
+                       case P of
+                           {opargs,Dst,_,_,_} -> ok;
+                           {append,Dst,_} -> ok;
+                           {phi,Dst,_,_,_} -> ok;
+                           {ret,Dst,_} -> ok
+                       end,
+                       Set = ordsets:add_element(P, maps:get(Dst, Acc, [])),
+                       Acc#{Dst => Set}
+               end, #{}, Patches),
+    ?DP("PD: ~p~n", [PD]),
+    patch_appends_f(SSA0, Cnt0, PD, [], []).
+
+patch_appends_f([{Lbl,Blk=#b_blk{is=Is0,last=Last0}}|Rest],
+                Cnt0, PD0, Acc0, BlockAdditions0) ->
+    {Last,Extra,Cnt2,PD} =
+        case PD0 of
+            #{ Lbl := Patches } ->
+                {Last1,Extra0,Cnt1} = patch_appends_ret(Last0, Patches, Cnt0),
+                {Last1, reverse(Extra0), Cnt1, maps:remove(Lbl, PD0)};
+            #{} ->
+                {Last0, [], Cnt0, PD0}
+        end,
+    {Is, Cnt, BlockAdditions} = patch_appends_is(Is0, PD, Cnt2, [], []),
+    Acc = [{Lbl,Blk#b_blk{is=Is ++ Extra, last=Last}}|Acc0],
+    patch_appends_f(Rest, Cnt, PD, Acc, BlockAdditions ++ BlockAdditions0 );
+patch_appends_f([], Cnt, _PD, Acc, BlockAdditions) ->
+    ?DP("BlockAdditions: ~p~n", [BlockAdditions]),
+    Linear = insert_block_additions(Acc, maps:from_list(BlockAdditions), []),
+    ?DP("SSA-result:~n~p~n", [Linear]),
+    {Linear, Cnt}.
+
+patch_appends_is([I0=#b_set{dst=Dst}|Rest], PD0, Cnt0, Acc, BlockAdditions0)
+  when is_map_key(Dst, PD0) ->
+    #{ Dst := Patches } = PD0,
+    PD = maps:remove(Dst, PD0),
+    ExtractOpargs = fun({opargs,D,Idx,Lit,Element}) when Dst =:= D ->
+                            {Idx, Lit, Element}
+                    end,
+    case Patches of
+        [{opargs,Dst,_,_,_}|_] ->
+            Ps = keysort(1, map(ExtractOpargs, Patches)),
+            {Is, Cnt} = patch_opargs(I0, Ps, Cnt0),
+            patch_appends_is(Rest, PD, Cnt, Is++Acc, BlockAdditions0);
+        [{append,Dst,_}] ->
+            #b_set{op=bs_create_bin,dst=Dst,args=Args0}=I0,
+            [#b_literal{val=append}|OtherArgs] = Args0,
+            I = I0#b_set{args=[#b_literal{val=private_append}|OtherArgs]},
+            patch_appends_is(Rest, PD, Cnt0, [I|Acc], BlockAdditions0);
+        [{phi,Dst,_,_,_}|_] ->
+            {I, Extra, Cnt} = patch_phi(I0, Patches, Cnt0),
+            patch_appends_is(Rest, PD, Cnt, [I|Acc], Extra ++ BlockAdditions0)
+    end;
+patch_appends_is([I|Rest], PD, Cnt, Acc, BlockAdditions) ->
+    patch_appends_is(Rest, PD, Cnt, [I|Acc], BlockAdditions);
+patch_appends_is([], _, Cnt, Acc, BlockAdditions) ->
+    {reverse(Acc), Cnt, BlockAdditions}.
+
+%% The only time when we patch a return is when it returns a
+%% literal.
+patch_appends_ret(Last=#b_ret{arg=#b_literal{val=Lit}}, Patches, Cnt0)
+  when is_list(Lit); is_tuple(Lit) ->
+    Ps = keysort(1, [E || {ret,_,E} <- Patches]),
+    ?DP("patch_appends_ret tuple or list :~n  lit: ~p~n  patches: ~p~n", [Lit, Ps]),
+    {V,Extra,Cnt} = patch_literal_term(Lit, Ps, Cnt0),
+    {Last#b_ret{arg=V}, Extra, Cnt};
+patch_appends_ret(Last=#b_ret{arg=#b_literal{val=Lit}},
+                  [{ret,_,Element}],
+                  Cnt0) ->
+    ?DP("patch_appends_ret other:~n  lit: ~p~n  element: ~p~n", [Lit, Element]),
+    {V,Extra,Cnt} = patch_literal_term(Lit, Element, Cnt0),
+    {Last#b_ret{arg=V}, Extra, Cnt}.
+
+%% Should return the instructions in reversed order
+patch_opargs(I0=#b_set{args=Args}, Patches0, Cnt0) ->
+    ?DP("Patching args in ~p~nArgs: ~p~n Patches: ~p~n",
+        [I0,Args,Patches0]),
+    Patches = merge_arg_patches(Patches0),
+    {PatchedArgs, Is, Cnt} = patch_opargs(Args, Patches, 0, [], [], Cnt0),
+    {[I0#b_set{args=reverse(PatchedArgs)}|Is], Cnt}.
+
+patch_opargs([#b_literal{val=Lit}|Args], [{Idx,Lit,Element}|Patches],
+             Idx, PatchedArgs, Is, Cnt0) ->
+    ?DP("Patching arg idx ~p~n  lit: ~p~n  elem: ~p~n", [Idx, Lit, Element]),
+    {Arg,Extra,Cnt} = patch_literal_term(Lit, Element, Cnt0),
+    patch_opargs(Args, Patches, Idx + 1, [Arg|PatchedArgs], Extra ++ Is, Cnt);
+patch_opargs([Arg|Args], Patches, Idx, PatchedArgs, Is, Cnt) ->
+    ?DP("Skipping arg idx ~p~n  arg: ~p~n  patches: ~p~n",
+              [Idx,Arg,Patches]),
+    patch_opargs(Args, Patches, Idx + 1, [Arg|PatchedArgs], Is, Cnt);
+patch_opargs([], [], _, PatchedArgs, Is, Cnt) ->
+    {PatchedArgs, Is, Cnt}.
+
+%% The way find_defs and find_appends work, we can end up with
+%% multiple patches patching different parts of a tuple or pair. We
+%% merge them here.
+merge_arg_patches([{Idx,Lit,P0},{Idx,Lit,P1}|Patches]) ->
+    P = case {P0, P1} of
+            %% As patches are stored in the PD as an orddict we will
+            %% never see {{tl,T},{hd,H}}.
+            {{hd,H},{tl,T}} ->
+                {pair,H,T};
+            {{tuple_element,I0,E0},{tuple_element,I1,E1}} ->
+                {tuple_elements,[{I0,E0},{I1,E1}]};
+            {{tuple_elements,Es},{tuple_element,I,E}} ->
+                {tuple_elements,[{I,E}|Es]}
+        end,
+    merge_arg_patches([{Idx,Lit,P}|Patches]);
+merge_arg_patches([P|Patches]) ->
+    [P|merge_arg_patches(Patches)];
+merge_arg_patches([]) ->
+    [].
+
+patch_phi(I0=#b_set{op=phi,args=Args0}, Patches, Cnt0) ->
+    L2P = foldl(fun(Phi={phi,_,Lbl,_,_}, Acc) ->
+                        Acc#{Lbl => Phi}
+                end, #{}, Patches),
+    {Args, Extra, Cnt} =
+        foldr(fun(Arg0={_, Lbl}, {ArgsAcc, ExtraAcc, CntAcc}) ->
+                      case L2P of
+                          #{Lbl := {phi,_,Lbl,Lit,Element}} ->
+                              {Arg,Extra,Cnt1} =
+                                  patch_literal_term(Lit, Element, CntAcc),
+                              {[{Arg,Lbl}|ArgsAcc],
+                               [{Lbl, Extra}|ExtraAcc], Cnt1};
+                          _ ->
+                              {[Arg0|ArgsAcc], ExtraAcc, CntAcc}
+                      end
+              end, {[], [], Cnt0}, Args0),
+    I = I0#b_set{op=phi,args=Args},
+    {I, Extra, Cnt}.
+
+%% Should return the instructions in reversed order
+patch_literal_term(Tuple, {tuple_elements,Elems}, Cnt) ->
+    Es = [{tuple_element,I,E} || {I,E} <- keysort(1, Elems)],
+    patch_literal_tuple(Tuple, Es, Cnt);
+patch_literal_term(Tuple, Elements0, Cnt) when is_tuple(Tuple) ->
+    Elements = if is_list(Elements0) -> Elements0;
+                  true -> [Elements0]
+               end,
+    patch_literal_tuple(Tuple, Elements, Cnt);
+patch_literal_term(<<>>, self, Cnt0) ->
+    {V,Cnt} = new_var(Cnt0),
+    I = #b_set{op=bs_init_writable,dst=V,args=[#b_literal{val=256}]},
+    {V, [I], Cnt};
+patch_literal_term(X, self, Cnt) when not is_binary(X) ->
+    %% When we track where a literal comes from and we pass PHI
+    %% instructions where the value produced is a non-binary
+    %% literal. Instead of trying to detect that when tracking the
+    %% provenance, we just ignore them here.
+    {#b_literal{val=X}, [], Cnt};
+patch_literal_term([H0|T0], {hd,Element}, Cnt0) ->
+    {H,Extra,Cnt1} = patch_literal_term(H0, Element, Cnt0),
+    {T,[],Cnt1} = patch_literal_term(T0, [], Cnt1),
+    {Dst,Cnt} = new_var(Cnt1),
+    I = #b_set{op=put_list,dst=Dst,args=[H,T]},
+    {Dst, [I|Extra], Cnt};
+patch_literal_term([H0|T0], {tl,Element}, Cnt0) ->
+    {H,[],Cnt0} = patch_literal_term(H0, [], Cnt0),
+    {T,Extra,Cnt1} = patch_literal_term(T0, Element, Cnt0),
+    {Dst,Cnt} = new_var(Cnt1),
+    I = #b_set{op=put_list,dst=Dst,args=[H,T]},
+    {Dst, [I|Extra], Cnt};
+patch_literal_term([H0|T0], {pair,E0,E1}, Cnt0) ->
+    {H,Extra1,Cnt1} = patch_literal_term(H0, E0, Cnt0),
+    {T,Extra2,Cnt2} = patch_literal_term(T0, E1, Cnt1),
+    Extra = Extra2 ++ Extra1,
+    {Dst,Cnt} = new_var(Cnt2),
+    I = #b_set{op=put_list,dst=Dst,args=[H,T]},
+    {Dst, [I|Extra], Cnt};
+patch_literal_term(Lit, [], Cnt) ->
+    {#b_literal{val=Lit}, [], Cnt}.
+
+patch_literal_tuple(Tuple, Elements, Cnt) ->
+    ?DP("Will patch literal tuple~n  tuple:~p~n  elements: ~p~n",
+              [Tuple,Elements]),
+    patch_literal_tuple(erlang:tuple_to_list(Tuple), Elements, [], [], 0, Cnt).
+
+patch_literal_tuple([Lit|LitElements], [{tuple_element,Idx,Element}|Elements],
+                    Patched, Extra, Idx, Cnt0) ->
+    ?DP("patch_literal_tuple: idx:~p~n  Lit: ~p~n  patch: ~p~n",
+              [Idx, Lit, Element]),
+    {V,Exs,Cnt} = patch_literal_term(Lit, Element, Cnt0),
+    patch_literal_tuple(LitElements, Elements, [V|Patched],
+                        Exs ++ Extra, Idx + 1, Cnt);
+patch_literal_tuple([Lit|LitElements], Patches, Patched, Extra, Idx, Cnt) ->
+    ?DP("patch_literal_tuple: skipping idx:~p~n  Lit: ~p~n  patches: ~p~n", [Idx, Lit, Patches]),
+    {T,[],Cnt} = patch_literal_term(Lit, [], Cnt),
+    patch_literal_tuple(LitElements, Patches, [T|Patched],
+                        Extra, Idx + 1, Cnt);
+patch_literal_tuple([], [], Patched, Extra, _, Cnt0) ->
+    {V,Cnt} = new_var(Cnt0),
+    I = #b_set{op=put_tuple,dst=V,args=reverse(Patched)},
+    {V, [I|Extra], Cnt}.
+
+%% As beam_ssa_opt:new_var/2, but with a hard-coded base
+new_var(Count) ->
+    {#b_var{name={alias_opt,Count}},Count+1}.
+
+%% Done with an accumulator to reverse the reversed block order from
+%% patch_appends_f/5.
+insert_block_additions([Blk0={L,B=#b_blk{is=Is0}}|RevLinear],
+                       Lbl2Addition, Acc) ->
+    Blk = case Lbl2Addition of
+            #{ L := Additions} ->
+                  Is = Is0 ++ reverse(Additions),
+                  {L,B#b_blk{is=Is}};
+              _ ->
+                  Blk0
+          end,
+    insert_block_additions(RevLinear, Lbl2Addition, [Blk|Acc]);
+insert_block_additions([], _, Acc) ->
+    Acc.
+
+%%%
+%%% Predicate to check if a function is the stub for a nif.
+%%%
+-spec is_nif(func_id(), st_map()) -> boolean().
+
+is_nif(F, StMap) ->
+    #opt_st{ssa=[{0,#b_blk{is=Is}}|_]} = map_get(F, StMap),
+    case Is of
+        [#b_set{op=nif_start}|_] ->
+            true;
+        _ -> false
+    end.

--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -958,12 +958,27 @@ simplify_terminator(#b_switch{arg=Arg0,fail=Fail,list=List0}=Sw0,
         #b_br{}=Br ->
             simplify_terminator(Br, Ts, Ds, Sub)
     end;
-simplify_terminator(#b_ret{arg=Arg}=Ret, Ts, Ds, Sub) ->
+simplify_terminator(#b_ret{arg=Arg,anno=Anno0}=Ret0, Ts, Ds, Sub) ->
     %% Reducing the result of a call to a literal (fairly common for 'ok')
     %% breaks tail call optimization.
-    case Ds of
-        #{ Arg := #b_set{op=call}} -> Ret;
-        #{} -> Ret#b_ret{arg=simplify_arg(Arg, Ts, Sub)}
+    Ret = case Ds of
+              #{ Arg := #b_set{op=call}} -> Ret0;
+              #{} -> Ret0#b_ret{arg=simplify_arg(Arg, Ts, Sub)}
+          end,
+    %% Annotate the terminator with the type it returns, skip the
+    %% annotation if nothing is yet known about the variable. The
+    %% annotation is used by the alias analysis pass.
+    Type = case {Arg, Ts} of
+               {#b_literal{},_} -> concrete_type(Arg, Ts);
+               {_,#{Arg:=_}} -> concrete_type(Arg, Ts);
+               _ -> any
+           end,
+    case Type of
+        any ->
+            Ret;
+        _ ->
+            Anno = Anno0#{ result_type => Type },
+            Ret#b_ret{anno=Anno}
     end.
 
 %%

--- a/lib/compiler/src/beam_types.hrl
+++ b/lib/compiler/src/beam_types.hrl
@@ -91,7 +91,12 @@
 -type float_range() :: 'any' | {'-inf',float()} | {float(),'+inf'}.
 
 -record(t_atom, {elements=any :: 'any' | ordsets:ordset(atom())}).
--record(t_bitstring, {size_unit=1 :: pos_integer()}).
+-record(t_bitstring, {size_unit=1 :: pos_integer(),
+                      %% The appendable flag indicates whether the bitstring
+                      %% originated as <<>> and has only been appended to by
+                      %% `bs_create_bin` with the bitstring as the leftmost
+                      %% fragment.
+                      appendable=false :: boolean()}).
 -record(t_bs_context, {tail_unit=1 :: pos_integer()}).
 -record(t_bs_matchable, {tail_unit=1 :: pos_integer()}).
 -record(t_float, {elements=any :: float_range()}).

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -2109,6 +2109,7 @@ pre_load() ->
 	 beam_ssa_dead,
 	 beam_ssa_opt,
 	 beam_ssa_pre_codegen,
+	 beam_ssa_private_append,
 	 beam_ssa_recv,
 	 beam_ssa_share,
 	 beam_ssa_throw,

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -2101,6 +2101,7 @@ pre_load() ->
 	 beam_kernel_to_ssa,
 	 beam_opcodes,
 	 beam_ssa,
+	 beam_ssa_alias,
 	 beam_ssa_bc_size,
 	 beam_ssa_bool,
 	 beam_ssa_bsm,

--- a/lib/compiler/src/compiler.app.src
+++ b/lib/compiler/src/compiler.app.src
@@ -47,6 +47,7 @@
              beam_ssa_opt,
              beam_ssa_pp,
              beam_ssa_pre_codegen,
+             beam_ssa_private_append,
              beam_ssa_recv,
              beam_ssa_share,
              beam_ssa_throw,

--- a/lib/compiler/src/compiler.app.src
+++ b/lib/compiler/src/compiler.app.src
@@ -36,6 +36,7 @@
 	     beam_listing,
 	     beam_opcodes,
              beam_ssa,
+             beam_ssa_alias,
              beam_ssa_bc_size,
              beam_ssa_bool,
              beam_ssa_bsm,

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -26,9 +26,10 @@
 
 -export([all/0, suite/0, groups/0,
          init_per_suite/1, end_per_suite/1,
-	 init_per_group/2,end_per_group/2,
+	 init_per_group/2, end_per_group/2,
 
          annotation_checks/1,
+         appendable_checks/1,
          bs_size_unit_checks/1,
          sanity_checks/1]).
 
@@ -40,6 +41,7 @@ all() ->
 groups() ->
     [{post_ssa_opt_static,test_lib:parallel(),
       [annotation_checks,
+       appendable_checks,
        sanity_checks]},
      {post_ssa_opt_dynamic,test_lib:parallel(),
       [bs_size_unit_checks]}].
@@ -76,6 +78,9 @@ end_per_group(_GroupName, Config) ->
 
 annotation_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(annotations, Config).
+
+appendable_checks(Config) when is_list(Config) ->
+    run_post_ssa_opt(appendable, Config).
 
 bs_size_unit_checks(Config) when is_list(Config) ->
     gen_and_run_post_ssa_opt(bs_size_unit_checks, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -28,6 +28,7 @@
          init_per_suite/1, end_per_suite/1,
 	 init_per_group/2, end_per_group/2,
 
+         alias_checks/1,
          annotation_checks/1,
          appendable_checks/1,
          bs_size_unit_checks/1,
@@ -41,7 +42,8 @@ all() ->
 
 groups() ->
     [{post_ssa_opt_static,test_lib:parallel(),
-      [annotation_checks,
+      [alias_checks,
+       annotation_checks,
        appendable_checks,
        ret_annotation_checks,
        sanity_checks]},
@@ -77,6 +79,9 @@ end_per_group(post_ssa_opt_dynamic, Config) ->
     end;
 end_per_group(_GroupName, Config) ->
     Config.
+
+alias_checks(Config) when is_list(Config) ->
+    run_post_ssa_opt(alias, Config).
 
 annotation_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(annotations, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -32,6 +32,7 @@
          annotation_checks/1,
          appendable_checks/1,
          bs_size_unit_checks/1,
+         private_append_checks/1,
          ret_annotation_checks/1,
          sanity_checks/1]).
 
@@ -45,6 +46,7 @@ groups() ->
       [alias_checks,
        annotation_checks,
        appendable_checks,
+       private_append_checks,
        ret_annotation_checks,
        sanity_checks]},
      {post_ssa_opt_dynamic,test_lib:parallel(),
@@ -91,6 +93,9 @@ appendable_checks(Config) when is_list(Config) ->
 
 bs_size_unit_checks(Config) when is_list(Config) ->
     gen_and_run_post_ssa_opt(bs_size_unit_checks, Config).
+
+private_append_checks(Config) when is_list(Config) ->
+    run_post_ssa_opt(private_append, Config).
 
 ret_annotation_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(ret_annotation, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -31,6 +31,7 @@
          annotation_checks/1,
          appendable_checks/1,
          bs_size_unit_checks/1,
+         ret_annotation_checks/1,
          sanity_checks/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
@@ -42,6 +43,7 @@ groups() ->
     [{post_ssa_opt_static,test_lib:parallel(),
       [annotation_checks,
        appendable_checks,
+       ret_annotation_checks,
        sanity_checks]},
      {post_ssa_opt_dynamic,test_lib:parallel(),
       [bs_size_unit_checks]}].
@@ -84,6 +86,9 @@ appendable_checks(Config) when is_list(Config) ->
 
 bs_size_unit_checks(Config) when is_list(Config) ->
     gen_and_run_post_ssa_opt(bs_size_unit_checks, Config).
+
+ret_annotation_checks(Config) when is_list(Config) ->
+    run_post_ssa_opt(ret_annotation, Config).
 
 sanity_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(sanity_checks, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -1,0 +1,647 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% This module tests that beam_ssa_alias_opt:opt/2 correctly annotates
+%% instructions with information about unique and aliased operands.
+%%
+
+-compile(no_ssa_opt_private_append).
+
+-module(alias).
+
+-export([transformable0/1,
+	 transformable1/1,
+	 transformable1b/1,
+	 transformable2/1,
+	 transformable3/1,
+	 transformable4/1,
+	 transformable5/1,
+	 %% transformable6/1,
+	 transformable7/1,
+	 transformable8/1,
+	 transformable9/1,
+	 transformable10/1,
+	 transformable11/1,
+	 transformable12a/1,
+	 transformable12b/1,
+	 transformable13/1,
+	 transformable14/1,
+	 transformable15/1,
+	 transformable16/1,
+	 transformable17/1,
+	 transformable18/2,
+	 transformable19/1,
+	 transformable20/1,
+	 transformable21/1,
+	 transformable22/1,
+	 transformable23/1,
+	 transformable24/1,
+	 transformable25/1,
+	 transformable26/1,
+
+	 not_transformable1/2,
+	 not_transformable2/1,
+	 not_transformable3/1,
+	 not_transformable4/1,
+	 not_transformable5/1,
+
+         bad_get_status_by_type/0,
+         stacktrace0/0,
+         stacktrace1/0,
+         in_cons/0]).
+
+%% Trivial smoke test
+transformable0(L) ->
+%ssa% (A) when post_ssa_opt ->
+%ssa% _ = call(fun transformable0/2, A, _) { aliased => [A] }.
+    transformable0(L, <<>>).
+
+transformable0([H|T], Acc) ->
+%ssa% (_, A) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, A, _, _, _, B, ...) { aliased => [B], unique => [A] }.
+    transformable0(T, <<Acc/binary, H:8>>);
+transformable0([], Acc) ->
+    Acc.
+
+transformable1(L) ->
+    transformable1(L, start).
+
+transformable1(L, start) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [X], unique => [Arg1] }.
+    transformable1(L, <<>>);
+transformable1([H|T], Acc) ->
+    transformable1(T, <<Acc/binary, H:8>>);
+transformable1([], Acc) ->
+    Acc.
+
+transformable1b(L) ->
+    transformable1b(L, start).
+
+transformable1b([H|T], X) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% Phi = phi({Arg1, _}, {_, _}, ...),
+%ssa% _ = bs_create_bin(append, _, Phi, _, _, _, X, _) { aliased => [X], unique => [Phi] }.
+    Acc = case X of
+	      start ->
+		  <<>>;
+	      _ ->
+		  X
+	  end,
+    N = <<Acc/binary, H:8>>,
+    transformable1b(T, N);
+transformable1b([], Acc) ->
+    Acc.
+
+transformable2(L) ->
+    transformable2(L, <<>>).
+
+transformable2([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [X], unique => [Arg1] },
+%ssa% _ = call(fun transformable2/2, _, A).
+    case ex:f() of
+	true ->
+	    transformable2(T, <<Acc/binary, H:8>>);
+	false ->
+	    transformable2(T, <<>>)
+    end;
+transformable2([], Acc) ->
+    Acc.
+
+transformable3(L) ->
+    transformable3(L, <<>>).
+
+transformable3([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [X], unique => [Arg1] }.
+    R = case ex:f() of
+	    true ->
+		<<Acc/binary, H:8>>;
+	    false ->
+		<<>>
+	end,
+    transformable3(T, R);
+transformable3([], Acc) ->
+    Acc.
+
+transformable4(L) ->
+    transformable4(L, <<>>).
+
+transformable4([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% Phi = phi({_, _}, {Arg1, _}, ...),
+%ssa% _ = bs_create_bin(append, _, Phi, _, _, _, X, _) { aliased => [X], unique => [Phi] }.
+    R = case ex:f() of
+	    true ->
+		Acc;
+	    false ->
+		<<>>
+	end,
+    transformable4(T, <<R/binary, H:8>>);
+transformable4([], Acc) ->
+    Acc.
+
+%% Check that the alias analysis handles local functions.
+transformable5(L) ->
+    transformable5(L, <<>>).
+
+transformable5([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [X], unique => [Arg1] }.
+    does_not_escape(Acc),
+    transformable5(T, <<Acc/binary, H:8>>);
+transformable5([], Acc) ->
+    Acc.
+
+does_not_escape(_) ->
+    ok.
+
+%% Check that the analysis works when we have an appendable binary in
+%% the head of a cons.
+transformable7(L) ->
+    transformable7(L, [<<>>|0]).
+
+transformable7([H|T], [Acc|N]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_hd(Arg1),
+%ssa% _ = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [X], unique => [A] }.
+    transformable7(T, [<<Acc/binary, H:8>>|N+1]);
+transformable7([], Acc) ->
+    Acc.
+
+%% Check that the analysis works when we have an appendable binary in
+%% just one of the clauses.
+transformable8(L) ->
+    transformable8(L, start).
+
+transformable8(L, start) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [X], unique => [Arg1] }.
+    transformable8(L, <<>>);
+transformable8([H|T], Acc) ->
+    transformable8b(T, <<Acc/binary, H:8>>);
+transformable8([], Acc) ->
+    Acc.
+
+transformable8b(T, Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...) { unique => [Arg1] }.
+    transformable8(T, <<Acc/binary, 16#ff:8>>).
+
+%% Check that the analysis works across mutually recursive functions.
+transformable9(L) ->
+    transformable9a(L, <<>>).
+
+transformable9a([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, _, _, _, _, X, _) { aliased => [X], unique => [Arg1] }.
+    transformable9b(T, <<Acc/binary, 0:8, H:8>>);
+transformable9a([], Acc) ->
+    Acc.
+
+transformable9b([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, _, _, _, _, X, _) { aliased => [X], unique => [Arg1] }.
+    transformable9a(T, <<Acc/binary, 1:8, H:8>>);
+transformable9b([], Acc) ->
+    Acc.
+
+%% Check that the analysis works for binaries embedded in a literal.
+transformable10(L) ->
+    transformable10(L, {<<>>,0}).
+
+transformable10([H|T], {Acc,N}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% _ = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [X], unique => [A] }.
+    transformable10(T, {<<Acc/binary, H:8>>,N+1});
+transformable10([], Acc) ->
+    Acc.
+
+%% Check that the analysis works across clauses
+transformable11(L) ->
+    transformable11(L, <<>>).
+
+transformable11([H|T], Acc) when H =:= 0 ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(append, _, Arg1, ...) { unique => [Arg1] },
+%ssa% _ = call(fun transformable11/2, _, A),
+%ssa% B = bs_create_bin(append, _, Arg1, ...) { unique => [Arg1] },
+%ssa% _ = call(fun transformable11/2, _, B).
+    transformable11(T, <<Acc/binary, 0:8>>);
+transformable11([_|T], Acc)->
+    transformable11(T, <<Acc/binary, 1:8>>);
+transformable11([], Acc) ->
+    Acc.
+
+% Broken, type analysis can't handle the list
+transformable12a(L) ->
+    transformable12(L, {<<>>}).
+
+transformable12b(L) ->
+    transformable12(L, [<<>>]).
+
+%% The type analysis can't handle the list yet
+transformable12([H|T], {Acc}) ->
+%ssa% (_, _) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, A, _, _, _, B, _) { aliased => [B, A] },
+%ssa% _ = bs_create_bin(append, _, C, _, _, _, D, _) { aliased => [D, C] }.
+    transformable12([H|T], {<<Acc/binary,H:8>>});
+transformable12([H|T], [Acc]) ->
+    transformable12([H|T], [<<Acc/binary,H:8>>]);
+transformable12([], {Acc}) ->
+    Acc;
+transformable12([], [Acc]) ->
+    Acc.
+
+%% Check binaries coming from another function.
+transformable13(L) ->
+    transformable13(L, make_empty_binary()).
+
+transformable13([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [X], unique => [Arg1] }.
+    transformable13(T, <<Acc/binary, H:8>>);
+transformable13([], Acc) ->
+    Acc.
+
+make_empty_binary() ->
+    <<>>.
+
+%% Check binaries coming from other functions, with various levels of
+%% nesting in the literals and how they are picked apart using
+%% matching.
+transformable14(L) ->
+    {X} = make_wrapped_empty_binary(),
+    transformable14(L, X).
+
+transformable14([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [X], unique => [Arg1] }.
+    transformable14(T, <<Acc/binary, H:8>>);
+transformable14([], Acc) ->
+    Acc.
+
+make_wrapped_empty_binary() ->
+    {<<>>}.
+
+transformable15(L) ->
+    {X} = make_wrapped_empty_binary(),
+    Y = make_empty_binary(),
+    transformable15(L, X, Y).
+
+transformable15([A,B|T], Acc0, Acc1) ->
+%ssa% (_, Arg1, Arg2) when post_ssa_opt ->
+%ssa% A = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [X], unique => [Arg1] },
+%ssa% B = bs_create_bin(append, _, Arg2, _, _, _, Y, _) { aliased => [Y], unique => [Arg2] },
+%ssa% _ = call(fun transformable15/3, _, A, B).
+
+    transformable15(T, <<Acc0/binary, A:8>>, <<Acc1/binary, B:8>>);
+transformable15([], Acc0, Acc1) ->
+    {Acc0,Acc1}.
+
+transformable16(L) ->
+    X = make_wrapped_empty_binary(),
+    Y = make_empty_binary(),
+    transformable16(L, {X, Y}).
+
+transformable16([A,B|T], {{Acc0}, Acc1}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = get_tuple_element(A, 0),
+%ssa% C = bs_create_bin(append, _, B, _, _, _, X, _) { aliased => [X], unique => [B] },
+%ssa% D = get_tuple_element(Arg1, 1),
+%ssa% E = bs_create_bin(append, _, D, _, _, _, Y, _) { aliased => [Y], unique => [D] },
+%ssa% F = put_tuple(C),
+%ssa% G = put_tuple(F, E),
+%ssa% _ = call(fun transformable16/2, _, G).
+    transformable16(T, {{<<Acc0/binary, A:8>>}, <<Acc1/binary, B:8>>});
+transformable16([], {{Acc0}, Acc1}) ->
+    {Acc0,Acc1}.
+
+transformable17(L) ->
+    transformable17(L, [0|<<>>]).
+
+transformable17([H|T], [N|Acc]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tl(Arg1),
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [X], unique => [A]  },
+%ssa% C = put_list(_, B),
+%ssa% _ = call(fun transformable17/2, _, C).
+    transformable17(T, [N+1|<<Acc/binary, H:8>>]);
+transformable17([], Acc) ->
+    Acc.
+
+%% We should use type information to figure out that {<<>>, X} is not
+%% aliased, but as of now we don't have the information at this pass,
+%% nor do we track alias status at the sub-term level.
+transformable18(L, X) when is_integer(X), X < 256 ->
+    transformable18b(L, {<<>>, X}).
+
+transformable18b([H|T], {Acc,X}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [A], unique => [X] },
+%ssa% C = put_tuple(B, _),
+%ssa% _ = call(fun transformable18b/2, _, C).
+    transformable18b(T, {<<Acc/binary, (H+X):8>>, X});
+transformable18b([], {Acc,_}) ->
+    Acc.
+
+%% Check that the analysis works when the binary isn't embedded in a
+%% tuple literal.
+transformable19(L) ->
+    X = case ex:foo() of
+	    true ->
+		4711;
+	    false ->
+		17
+	end,
+    transformable19b(L, {<<>>, X}).
+
+transformable19b([H|T], {Acc,X}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { unique => [X, A] },
+%ssa% C = put_tuple(B, _),
+%ssa% _ = call(fun transformable19b/2, _, C).
+    transformable19b(T, {<<Acc/binary, (H+X):8>>, X});
+transformable19b([], {Acc,_}) ->
+    Acc.
+
+%% Check that the analysis works when the binary isn't embedded in a
+%% list literal.
+transformable20(L) ->
+    X = case ex:foo() of
+	    true ->
+		4711;
+	    false ->
+		17
+	end,
+    transformable20b(L, [<<>>|X]).
+
+transformable20b([H|T], [Acc|X]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_hd(Arg1),
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { unique => [X, A] },
+%ssa% C = put_list(B, _),
+%ssa% _ = call(fun transformable20b/2, _, C).
+    transformable20b(T, [<<Acc/binary, (H+X):8>>|X+1]);
+transformable20b([], [Acc|_]) ->
+    Acc.
+
+%% Check that the analysis works when the binary is embedded in a
+%% tuple literal returned from another function.
+transformable21(L) ->
+    transformable21(L, make_empty_binary_tuple()).
+
+transformable21([H|T], {AccA,AccB}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [X], unique => [A] },
+%ssa% C = get_tuple_element(Arg1, 1),
+%ssa% D = bs_create_bin(append, _, C, _, _, _, _, _) { unique => [C] },
+%ssa% E = put_tuple(B, D),
+%ssa% _ = call(fun transformable21/2, _, E).
+    transformable21(T, {<<AccA/binary, H:8>>,<<AccB/binary, 17:8>>});
+transformable21([], {AccA, AccB}) ->
+    {AccA, AccB}.
+
+make_empty_binary_tuple() ->
+    {<<>>, <<>>}.
+
+transformable22(L) ->
+    transformable22(L, [<<>>|<<>>]).
+
+transformable22([H|T], [AccA|AccB]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_hd(Arg1),
+%ssa% B = get_tl(Arg1),
+%ssa% C = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [X], unique => [A] },
+%ssa% D = bs_create_bin(append, _, B, _, _, _, _, _) { unique => [B] },
+%ssa% E = put_list(C, D),
+%ssa% _ = call(fun transformable22/2, _, E).
+    transformable22(T, [<<AccA/binary, H:8>>|<<AccB/binary, 17:8>>]);
+transformable22([], Acc) ->
+    Acc.
+
+%% As transformable21 but with a more complex embedded tuple
+transformable23(L) ->
+    transformable23(L, make_empty_binary_tuple_nested()).
+
+transformable23([H|T], {AccA,{AccB},X}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [X], unique => [A] },
+%ssa% C = get_tuple_element(Arg1, 1),
+%ssa% D = get_tuple_element(C, 0),
+%ssa% E = bs_create_bin(append, _, D, _, _, _, _, _) { unique => [D] },
+%ssa% F = put_tuple(E),
+%ssa% G = put_tuple(B, F, _),
+%ssa% _ = call(fun transformable23/2, _, G).
+    transformable23(T, {<<AccA/binary, H:8>>,{<<AccB/binary, 17:8>>}, X});
+transformable23([], {AccA, AccB, X}) ->
+    {AccA, AccB, X}.
+
+make_empty_binary_tuple_nested() ->
+    {<<>>, {<<>>}, 47}.
+
+transformable24(L) ->
+    transformable24(L, {<<>>, ex:foo()}).
+
+transformable24([H|T], {Acc,X}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [A], unique => [X] },
+%ssa% C = put_tuple(B, _),
+%ssa% _ = call(fun transformable24/2, _, C).
+    transformable24(T, {<<Acc/binary, (H+X):8>>, X});
+transformable24([], {Acc,_}) ->
+    Acc.
+
+%% Check that the update of more than one element of a tuple is
+%% handled.
+transformable25(L) ->
+    transformable25(L, {<<>>,<<>>}).
+
+transformable25([H|T], {AccA,AccB}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [X], unique => [A] },
+%ssa% C = get_tuple_element(Arg1, 1),
+%ssa% D = bs_create_bin(append, _, C, _) { unique => [C] },
+%ssa% E = put_tuple(B, D),
+%ssa% _ = call(fun transformable25/2, _, E).
+    transformable25(T, {<<AccA/binary, H:8>>,<<AccB/binary>>});
+transformable25([], Acc) ->
+    Acc.
+
+%% Check that the update of more than two elements of a tuple is
+%% handled (check the that inductive step of
+%% beam_ssa_alias_opt:merge_arg_patches/1 works).
+transformable26(L) ->
+    transformable26(L, {<<>>,<<>>,<<>>}).
+
+transformable26([H|T], {AccA,AccB,AccC}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(append, _, A, _, _, _, X, _) { aliased => [X], unique => [A] },
+%ssa% C = get_tuple_element(Arg1, 1),
+%ssa% D = bs_create_bin(append, _, C, _, _, _, Y, _) { aliased => [Y], unique => [C] },
+%ssa% E = get_tuple_element(Arg1, 2),
+%ssa% F = bs_create_bin(append, _, E, _, _, _, Z, _) { aliased => [Z], unique => [E] },
+%ssa% G = put_tuple(B, D, F),
+%ssa% _ = call(fun transformable26/2, _, G).
+    transformable26(T, {<<AccA/binary, H:8>>,
+			<<AccB/binary, H:8>>,
+			<<AccC/binary, H:8>>});
+transformable26([], Acc) ->
+    Acc.
+
+%%
+%% Check that we detect aliasing
+%%
+
+not_transformable1([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [Arg1, X] }.
+    not_transformable1(T, <<Acc/binary, H:8>>);
+not_transformable1([], Acc) ->
+    Acc.
+
+not_transformable2(L) ->
+    not_transformable2(L, <<>>).
+
+not_transformable2([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [Arg1, X] }.
+    ex:escape(Acc),
+    not_transformable2(T, <<Acc/binary, H:8>>);
+not_transformable2([], Acc) ->
+    Acc.
+
+not_transformable3(L) ->
+    not_transformable3(L, <<>>, []).
+
+not_transformable3([H|T], Acc, Ls) ->
+%ssa% (_, Arg1, _) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, X, _) { aliased => [Arg1, X] }.
+    not_transformable3(T, <<Acc/binary, H:8>>, [Acc|Ls]);
+not_transformable3([], Acc, Ls) ->
+    {Acc, Ls}.
+
+%% We randomly keep multiple references to the binary, so we should
+%% detect aliasing.
+not_transformable4(L) ->
+    not_transformable4(L, [<<>>|[]]).
+
+not_transformable4([H|T], X=[Acc|Ls]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, X, _, _, _, Y, _) { aliased => [Y, X] }.
+    Tmp = case ex:f() of
+	      true ->
+		  [Q|_] = X,
+		  Q;
+	      false ->
+		  ok
+	  end,
+    T1 = [Tmp|Ls],
+    not_transformable4(T, [<<Acc/binary, H:8>>|T1]);
+not_transformable4([], Acc) ->
+    Acc.
+
+%% Check that the leak in the external call is detected despite the
+%% mutual recursion.
+not_transformable5(L) ->
+    not_transformable5a(L, <<>>).
+
+not_transformable5a([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, _, _, _, _, X, _) { aliased => [Arg1, X] }.
+    not_transformable5b(T, <<Acc/binary, 0:8, H:8>>);
+not_transformable5a([], Acc) ->
+    Acc.
+
+not_transformable5b([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, _, _, _, _, _, _, _, X, _) { aliased => [Arg1, X] }.
+    ex:alias(Acc),
+    not_transformable5a(T, <<Acc/binary, 1:8, H:8>>);
+not_transformable5b([], Acc) ->
+    Acc.
+
+%% Reproducer for a bug in beam_ssa_alias:aa_get_status_by_type/2
+%% where it would return the wrong alias/uniqe status for certain
+%% combinations of returned types.
+bad_get_status_by_type() ->
+%ssa% () when post_ssa_opt ->
+%ssa% A = call(fun bad_get_status_by_type_1/0),
+%ssa% ret(A) { aliased => [A] }.
+    bad_get_status_by_type_1().
+
+bad_get_status_by_type_1() ->
+    case e:foo() of
+	a -> <<0:1>>;
+	b -> X = e:bar(),
+	     true = is_binary(X),
+	     X
+    end.
+
+stacktrace0() ->
+%ssa% () when post_ssa_opt ->
+%ssa% X = call(fun transformable0/2, ...),
+%ssa% ret(A) { unique => [A] },
+%ssa% ret(A) { aliased => [A] },
+%ssa% ret(_) { result_type => none }.
+    X = transformable0(e:foo(), <<>>),
+    try
+	e:code_that_fails(),
+	X
+    catch
+	_:_:Stacktrace ->
+	    e:foo(Stacktrace),
+	    X
+    end.
+
+stacktrace1() ->
+%ssa% () when post_ssa_opt ->
+%ssa% X = call(fun transformable0/2, ...),
+%ssa% ret(A) { unique => [A] },
+%ssa% ret('bad'),
+%ssa% ret(_) { result_type => none }.
+    try
+	X = transformable0(e:foo(), <<>>),
+	e:code_that_fails(),
+	X
+    catch
+	_:_:Stacktrace ->
+	    e:foo(Stacktrace),
+	    bad
+    end.
+
+in_cons() ->
+%ssa% () when post_ssa_opt ->
+%ssa% A = call(fun in_cons_inner/1, ...),
+%ssa% ret(A) { unique => [A] },
+%ssa% ret(_) { result_type => none }.
+    in_cons_inner([x|<<>>]).
+
+in_cons_inner([x|B]) ->
+    [x|<<B/binary,1:8>>].

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/appendable.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/appendable.erl
@@ -1,0 +1,162 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-module(appendable).
+-export([make_empty/0, t0/0, t1/0, t2/0, t3/0, t4/0,
+	 t5/0, t6/0, t7/0, t8/1, t9/1, t10/1, t11/1, t12/0]).
+
+%% Check that just returning an empty bitstring is considered
+%% appendable.
+t0() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(<<>>) { result_type => {t_bitstring,_,true} }.
+    A = <<>>,
+    A.
+
+%% Check that appending an unknown bitstring to a literal <<>> results
+%% in an appendable bitstring.
+t1() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,true} }.
+    A = <<>>,
+    B = ex:f(),
+    <<A/binary, B/binary>>.
+
+%% Check that appending an integer to a literal <<>> results in an
+%% appendable bitstring.
+t2() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,true} }.
+    A = <<>>,
+    B = ex:f(),
+    <<A/binary, B:32>>.
+
+%% Check that just returning an empty bitstring is considered
+%% appendable.
+t3() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,true} }.
+    A = make_empty(),
+    A.
+
+%% Check that appending an unknown bitstring to a value known to be
+%% <<>> results in an appendable bitstring.
+t4() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,true} }.
+    A = make_empty(),
+    B = ex:f(),
+    <<A/binary, B/binary>>.
+
+%% Check that appending an integer to a value known results in an
+%% appendable bitstring.
+t5() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,true} }.
+    A = make_empty(),
+    B = ex:f(),
+    <<A/binary, B:32>>.
+
+%% Check that the appendable flag is cleared when we don't append
+%% things to the bitstring accumulator.
+t6() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,false} }.
+    A = <<>>,
+    B = ex:f(),
+    <<B/binary, A/binary>>.
+
+%% Check that the appendable flag is cleared when we don't append
+%% things to the bitstring accumulator.
+t7() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,false} }.
+    A = ex:f(),
+    <<17:8, A/binary>>.
+
+%% More complicated recursive check for setting the appendable flag
+t8(Ls) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,true} }.
+    t8(<<>>, Ls).
+
+t8(Acc, [H|T]) ->
+    t8(<<Acc/binary, H:32>>, T);
+t8(Acc, []) ->
+    Acc.
+
+%% More complicated recursive check for when the appendable flag
+%% should not be set.
+t9(Ls) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,false} }.
+    t9(<<>>, Ls).
+
+t9(Acc, [H|T]) ->
+    t9(<<H:32, Acc/binary>>, T);
+t9(Acc, []) ->
+    Acc.
+
+%% More complicated recursive check for when the appendable flag
+%% should be set.
+t10(Ls) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,true} }.
+    t10(<<>>, Ls).
+
+t10(Acc, [H|T]) ->
+    case H rem 2 of
+	0 ->
+	    t10(<<Acc/binary, H:16>>, T);
+	1 ->
+	    t10(<<Acc/binary, H:32>>, T)
+    end;
+t10(Acc, []) ->
+    Acc.
+
+%% More complicated recursive check for when the appendable flag
+%% should not be set.
+t11(Ls) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_bitstring,_,false} }.
+    t11(<<>>, Ls).
+
+t11(Acc, [H|T]) ->
+    case H rem 2 of
+	0 ->
+	    t11(<<H:32, Acc/binary>>, T);
+	1 ->
+	    t11(<<Acc/binary, H:32>>, T)
+    end;
+t11(Acc, []) ->
+    Acc.
+
+make_empty() ->
+    <<>>.
+
+%% beam_ssa_type:type/5 had problems handling bs_create_bin when the
+%% first fragment was typed as a #t_union{} containing an appendable
+%% bit string. Check that we don't lose append=true.
+t12() ->
+%ssa% () when post_ssa_opt ->
+%ssa% A = call(fun t12_inner/1, ...),
+%ssa% ret(A) { result_type => {t_cons,_,{t_bitstring,8,true}} },
+%ssa% ret(_) { result_type => none }.
+    t12_inner([x|<<>>]).
+
+t12_inner([x|B]) ->
+    [x|<<B/binary,1:8>>].

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
@@ -1,0 +1,891 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% This module tests that beam_ssa_alias_opt:to_private_append/3
+%% rewrites plain appends in bs_create_bin to private_append when
+%% appropriate.
+%%
+-module(private_append).
+
+-export([transformable0/1,
+	 transformable1/1,
+	 transformable1b/1,
+	 transformable2/1,
+	 transformable3/1,
+	 transformable4/1,
+	 transformable5/1,
+	 %% transformable6/1,
+	 transformable7/1,
+	 transformable8/1,
+	 transformable9/1,
+	 transformable10/1,
+	 transformable11/1,
+	 transformable12a/1,
+	 transformable12b/1,
+	 transformable13/1,
+	 transformable14/1,
+	 transformable15/1,
+	 transformable16/1,
+	 transformable17/1,
+	 transformable18/2,
+	 transformable19/1,
+	 transformable20/1,
+	 transformable21/1,
+	 transformable22/1,
+	 transformable23/1,
+	 transformable24/1,
+	 transformable25/1,
+	 transformable26/1,
+	 transformable27/1,
+	 transformable28/1,
+	 transformable29/1,
+	 transformable30/1,
+	 transformable31a/1,
+	 transformable31b/1,
+
+	 not_transformable1/2,
+	 not_transformable2/1,
+	 not_transformable3/1,
+	 not_transformable4/1,
+	 not_transformable5/1,
+	 not_transformable6/1,
+	 not_transformable7/1,
+	 not_transformable8/1,
+	 not_transformable9/1,
+	 not_transformable10/1]).
+
+%% Trivial smoke test
+transformable0(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable0/2, _, A).
+    transformable0(L, <<>>).
+
+transformable0([H|T], Acc) ->
+%ssa% (_, Acc) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(private_append, _, Acc, ...).
+    transformable0(T, <<Acc/binary, H:8>>);
+transformable0([], Acc) ->
+    Acc.
+
+%% Check that the transform works when the binary is produced by a
+%% non-trivial constructions. (transformable{1,2,3,4})
+transformable1(L) ->
+    transformable1(L, start).
+
+transformable1(L, start) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable1/2, _, A),
+%ssa% _ = bs_create_bin(private_append, _, Arg1, ...).
+    transformable1(L, <<>>);
+transformable1([H|T], Acc) ->
+    transformable1(T, <<Acc/binary, H:8>>);
+transformable1([], Acc) ->
+    Acc.
+
+transformable1b(L) ->
+    transformable1b(L, start).
+
+transformable1b([H|T], X) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% Phi = phi({Arg1, _}, {A, _}, ...),
+%ssa% _ = bs_create_bin(private_append, _, Phi, ...).
+    Acc = case X of
+	      start ->
+		  <<>>;
+	      _ ->
+		  X
+	  end,
+    N = <<Acc/binary, H:8>>,
+    transformable1b(T, N);
+transformable1b([], Acc) ->
+    Acc.
+
+transformable2(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable2/2, _, A).
+    transformable2(L, <<>>).
+
+transformable2([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable2/2, _, A),
+%ssa% B = bs_init_writable(_),
+%ssa% _ = call(fun transformable2/2, _, B).
+    case ex:f() of
+	true ->
+	    transformable2(T, <<Acc/binary, H:8>>);
+	false ->
+	    transformable2(T, <<>>)
+    end;
+transformable2([], Acc) ->
+    Acc.
+
+transformable3(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable3/2, _, A).
+    transformable3(L, <<>>).
+
+transformable3([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% B = bs_init_writable(_),
+%ssa% Phi = phi({A, _}, {B, _}, ...),
+%ssa% _ = call(fun transformable3/2, _, Phi).
+    R = case ex:f() of
+	    true ->
+		<<Acc/binary, H:8>>;
+	    false ->
+		<<>>
+	end,
+    transformable3(T, R);
+transformable3([], Acc) ->
+    Acc.
+
+transformable4(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable4/2, _, A).
+    transformable4(L, <<>>).
+
+transformable4([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% Phi = phi({A, _}, {Arg1, _}, ...),
+%ssa% B = bs_create_bin(private_append, _, Phi, ...),
+%ssa% _ = call(fun transformable4/2, _, B).
+    R = case ex:f() of
+	    true ->
+		Acc;
+	    false ->
+		<<>>
+	end,
+    transformable4(T, <<R/binary, H:8>>);
+transformable4([], Acc) ->
+    Acc.
+
+%% Check that the alias analysis handles local functions.
+transformable5(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable5/2, _, A).
+    transformable5(L, <<>>).
+
+transformable5([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable5/2, _, A).
+    does_not_escape(Acc),
+    transformable5(T, <<Acc/binary, H:8>>);
+transformable5([], Acc) ->
+    Acc.
+
+does_not_escape(_) ->
+    ok.
+
+%% Check that the transform works when we have an appendable binary in
+%% the head of a cons.
+transformable7(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_list(A, _),
+%ssa% _ = call(fun transformable7/2, _, B).
+    transformable7(L, [<<>>|0]).
+
+transformable7([H|T], [Acc|N]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_hd(Arg1),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = put_list(B, _),
+%ssa% _ = call(fun transformable7/2, _, C).
+    transformable7(T, [<<Acc/binary, H:8>>|N+1]);
+transformable7([], Acc) ->
+    Acc.
+
+%% Check that the transform works when we have an appendable binary in
+%% just one of the clauses.
+transformable8(L) ->
+    transformable8(L, start).
+
+transformable8(L, start) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% B = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable8b/2, _, B).
+    transformable8(L, <<>>);
+transformable8([H|T], Acc) ->
+    transformable8b(T, <<Acc/binary, H:8>>);
+transformable8([], Acc) ->
+    Acc.
+
+transformable8b(T, Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable8/2, _, B).
+    transformable8(T, <<Acc/binary, 16#ff:8>>).
+
+%% Check that the transform works across mutually recursive functions.
+transformable9(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable9a/2, _, A).
+    transformable9a(L, <<>>).
+
+transformable9a([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable9b/2, _, B).
+    transformable9b(T, <<Acc/binary, 0:8, H:8>>);
+transformable9a([], Acc) ->
+    Acc.
+
+transformable9b([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable9a/2, _, B).
+    transformable9a(T, <<Acc/binary, 1:8, H:8>>);
+transformable9b([], Acc) ->
+    Acc.
+
+%% Check that the transform works for binaries embedded in a literal.
+transformable10(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_tuple(A, ...),
+%ssa% _ = call(fun transformable10/2, _, B).
+    transformable10(L, {<<>>,0}).
+
+transformable10([H|T], {Acc,N}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = put_tuple(B, _),
+%ssa% _ = call(fun transformable10/2, _, C).
+    transformable10(T, {<<Acc/binary, H:8>>,N+1});
+transformable10([], Acc) ->
+    Acc.
+
+%% Check that the transform works across clauses
+transformable11(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable11/2, _, A).
+    transformable11(L, <<>>).
+
+transformable11([H|T], Acc) when H =:= 0 ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable11/2, _, A),
+%ssa% B = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable11/2, _, B).
+    transformable11(T, <<Acc/binary, 0:8>>);
+transformable11([_|T], Acc)->
+    transformable11(T, <<Acc/binary, 1:8>>);
+transformable11([], Acc) ->
+    Acc.
+
+% Broken, type analysis can't handle the list
+transformable12a(L) ->
+%ssa% xfail (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_tuple(A),
+%ssa% _ = call(fun transformable12/2, _, B).
+    transformable12(L, {<<>>}).
+
+transformable12b(L) ->
+%ssa% xfail (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_list(A, '_'),
+%ssa% _ = call(fun transformable12/2, _, B).
+    transformable12(L, [<<>>]).
+
+%% The type analysis can't handle the list yet
+transformable12([H|T], {Acc}) ->
+%ssa% xfail (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_hd(Arg1),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = put_list(B, _),
+%ssa% _ = call(fun transformable12/2, _, C),
+%ssa% D = get_tuple_element(Arg1, 0),
+%ssa% E = bs_create_bin(private_append, _, D, ...),
+%ssa% F = put_tuple('E'),
+%ssa% _ = call(fun transformable12/2, _, F).
+    transformable12([H|T], {<<Acc/binary,H:8>>});
+transformable12([H|T], [Acc]) ->
+    transformable12([H|T], [<<Acc/binary,H:8>>]);
+transformable12([], {Acc}) ->
+    Acc;
+transformable12([], [Acc]) ->
+    Acc.
+
+%% Check binaries coming from another function.
+transformable13(L) ->
+%ssa% (Arg0) when post_ssa_opt ->
+%ssa% A = call(fun make_empty_binary/0),
+%ssa% _ = call(fun transformable13/2, _, A).
+    transformable13(L, make_empty_binary()).
+
+transformable13([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable13/2, _, A).
+    transformable13(T, <<Acc/binary, H:8>>);
+transformable13([], Acc) ->
+    Acc.
+
+make_empty_binary() ->
+%ssa% () when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% ret(A).
+    <<>>.
+
+%% Check binaries coming from other functions, with various levels of
+%% nesting in the literals and how they are picked apart using
+%% matching.
+transformable14(L) ->
+%ssa% (Arg0) when post_ssa_opt ->
+%ssa% A = call(fun make_wrapped_empty_binary/0),
+%ssa% B = get_tuple_element(A, 0),
+%ssa% _ = call(fun transformable14/2, _, B).
+    {X} = make_wrapped_empty_binary(),
+    transformable14(L, X).
+
+transformable14([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% _ = call(fun transformable14/2, _, A).
+    transformable14(T, <<Acc/binary, H:8>>);
+transformable14([], Acc) ->
+    Acc.
+
+make_wrapped_empty_binary() ->
+%ssa% () when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_tuple(A),
+%ssa% ret(B).
+    {<<>>}.
+
+transformable15(L) ->
+%ssa% (Arg0) when post_ssa_opt ->
+%ssa% A = call(fun make_wrapped_empty_binary/0),
+%ssa% B = call(fun make_empty_binary/0),
+%ssa% C = get_tuple_element(A, 0),
+%ssa% _ = call(fun transformable15/3, Arg0, C, B).
+    {X} = make_wrapped_empty_binary(),
+    Y = make_empty_binary(),
+    transformable15(L, X, Y).
+
+transformable15([A,B|T], Acc0, Acc1) ->
+%ssa% (_, Arg1, Arg2) when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, _, Arg1, ...),
+%ssa% B = bs_create_bin(private_append, _, Arg2, ...),
+%ssa% _ = call(fun transformable15/3, _, A, B).
+
+    transformable15(T, <<Acc0/binary, A:8>>, <<Acc1/binary, B:8>>);
+transformable15([], Acc0, Acc1) ->
+    {Acc0,Acc1}.
+
+transformable16(L) ->
+%ssa% (Arg0) when post_ssa_opt ->
+%ssa% A = call(fun make_wrapped_empty_binary/0),
+%ssa% B = call(fun make_empty_binary/0),
+%ssa% C = put_tuple(A, B),
+%ssa% _ = call(fun transformable16/2, Arg0, C).
+    X = make_wrapped_empty_binary(),
+    Y = make_empty_binary(),
+    transformable16(L, {X, Y}).
+
+transformable16([A,B|T], {{Acc0}, Acc1}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = get_tuple_element(A, 0),
+%ssa% C = bs_create_bin(private_append, _, B, ...),
+%ssa% D = get_tuple_element(Arg1, 1),
+%ssa% E = bs_create_bin(private_append, _, D, ...),
+%ssa% F = put_tuple(C),
+%ssa% G = put_tuple(F, E),
+%ssa% _ = call(fun transformable16/2, _, G).
+    transformable16(T, {{<<Acc0/binary, A:8>>}, <<Acc1/binary, B:8>>});
+transformable16([], {{Acc0}, Acc1}) ->
+    {Acc0,Acc1}.
+
+%% The order of fields in the accumulator is swapped compared to
+%% transformable7.
+transformable17(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_list(_, A),
+%ssa% _ = call(fun transformable17/2, _, B).
+    transformable17(L, [0|<<>>]).
+
+transformable17([H|T], [N|Acc]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tl(Arg1),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = put_list(_, B),
+%ssa% _ = call(fun transformable17/2, _, C).
+    transformable17(T, [N+1|<<Acc/binary, H:8>>]);
+transformable17([], Acc) ->
+    Acc.
+
+%% We should use type information to figure out that {<<>>, X} is not
+%% aliased, but as of now we don't have the information at this pass,
+%% nor do we track alias status at the sub-term level.
+transformable18(L, X) when is_integer(X), X < 256 ->
+%ssa% xfail (_, _) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_tuple(_, A),
+%ssa% _ = call(fun transformable18b/2, _, B).
+    transformable18b(L, {<<>>, X}).
+
+transformable18b([H|T], {Acc,X}) ->
+%ssa% xfail (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = put_tuple(B, _),
+%ssa% _ = call(fun transformable18b/2, _, C).
+    transformable18b(T, {<<Acc/binary, (H+X):8>>, X});
+transformable18b([], {Acc,_}) ->
+    Acc.
+
+%% Check that the conversion works when the binary isn't embedded in a
+%% tuple literal.
+transformable19(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_tuple(A, _),
+%ssa% _ = call(fun transformable19b/2, _, B).
+    X = case ex:foo() of
+	    true ->
+		4711;
+	    false ->
+		17
+	end,
+    transformable19b(L, {<<>>, X}).
+
+transformable19b([H|T], {Acc,X}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = put_tuple(B, _),
+%ssa% _ = call(fun transformable19b/2, _, C).
+    transformable19b(T, {<<Acc/binary, (H+X):8>>, X});
+transformable19b([], {Acc,_}) ->
+    Acc.
+
+%% Check that the conversion works when the binary isn't embedded in a
+%% list literal.
+transformable20(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_list(A, _),
+%ssa% _ = call(fun transformable20b/2, _, B).
+    X = case ex:foo() of
+	    true ->
+		4711;
+	    false ->
+		17
+	end,
+    transformable20b(L, [<<>>|X]). % XXXX
+
+transformable20b([H|T], [Acc|X]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_hd(Arg1),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = put_list(B, _),
+%ssa% _ = call(fun transformable20b/2, _, C).
+    transformable20b(T, [<<Acc/binary, (H+X):8>>|X+1]);
+transformable20b([], [Acc|_]) ->
+    Acc.
+
+%% Check that the conversion works when the binary is embedded in a
+%% tuple literal returned from another function.
+transformable21(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = call(fun make_empty_binary_tuple/0),
+%ssa% _ = call(fun transformable21/2, _, A).
+    transformable21(L, make_empty_binary_tuple()).
+
+transformable21([H|T], {AccA,AccB}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = get_tuple_element(Arg1, 1),
+%ssa% D = bs_create_bin(private_append, _, C, ...),
+%ssa% E = put_tuple(B, D),
+%ssa% _ = call(fun transformable21/2, _, E).
+    transformable21(T, {<<AccA/binary, H:8>>,<<AccB/binary, 17:8>>});
+transformable21([], {AccA, AccB}) ->
+    {AccA, AccB}.
+
+make_empty_binary_tuple() ->
+%ssa% () when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = bs_init_writable(_),
+%ssa% C = put_tuple(A, B),
+%ssa% ret(C).
+    {<<>>, <<>>}.
+
+%% Check that the conversion works for both elements of the list.
+%%
+transformable22(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = bs_init_writable(_),
+%ssa% C = put_list(A, B),
+%ssa% _ = call(fun transformable22/2, _, C).
+    transformable22(L, [<<>>|<<>>]).
+
+transformable22([H|T], [AccA|AccB]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_hd(Arg1),
+%ssa% B = get_tl(Arg1),
+%ssa% C = bs_create_bin(private_append, _, A, ...),
+%ssa% D = bs_create_bin(private_append, _, B, ...),
+%ssa% E = put_list(C, D),
+%ssa% _ = call(fun transformable22/2, _, E).
+    transformable22(T, [<<AccA/binary, H:8>>|<<AccB/binary, 17:8>>]);
+transformable22([], Acc) ->
+    Acc.
+
+%% As transformable21 but with a more complex embedded tuple
+transformable23(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = call(fun make_empty_binary_tuple_nested/0),
+%ssa% _ = call(fun transformable23/2, _, A).
+    transformable23(L, make_empty_binary_tuple_nested()).
+
+transformable23([H|T], {AccA,{AccB},X}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = get_tuple_element(Arg1, 1),
+%ssa% D = get_tuple_element(C, 0),
+%ssa% E = bs_create_bin(private_append, _, D, ...),
+%ssa% F = put_tuple(E),
+%ssa% G = put_tuple(B, F, _),
+%ssa% _ = call(fun transformable23/2, _, G).
+    transformable23(T, {<<AccA/binary, H:8>>,{<<AccB/binary, 17:8>>}, X});
+transformable23([], {AccA, AccB, X}) ->
+    {AccA, AccB, X}.
+
+make_empty_binary_tuple_nested() ->
+%ssa% () when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = bs_init_writable(_),
+%ssa% C = put_tuple(B),
+%ssa% D = put_tuple(A, C, _),
+%ssa% ret(D).
+    {<<>>, {<<>>}, 47}.
+
+%% We can't handle this as we do not track alias status at the sub-term level.
+transformable24(L) ->
+%ssa% xfail (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = put_tuple(A, _),
+%ssa% _ = call(fun transformable24/2, _, B).
+    transformable24(L, {<<>>, ex:foo()}).
+
+transformable24([H|T], {Acc,X}) ->
+%ssa% xfail (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = put_tuple(B, _),
+%ssa% _ = call(fun transformable24/2, _, C).
+    transformable24(T, {<<Acc/binary, (H+X):8>>, X});
+transformable24([], {Acc,_}) ->
+    Acc.
+
+%% Check that the update of more than one element of a tuple is
+%% handled.
+transformable25(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = bs_init_writable(_),
+%ssa% C = put_tuple(A, B),
+%ssa% _ = call(fun transformable25/2, _, C).
+    transformable25(L, {<<>>,<<>>}).
+
+transformable25([H|T], {AccA,AccB}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = get_tuple_element(Arg1, 1),
+%ssa% D = bs_create_bin(private_append, _, C, ...),
+%ssa% E = put_tuple(B, D),
+%ssa% _ = call(fun transformable25/2, _, E).
+    transformable25(T, {<<AccA/binary, H:8>>,<<AccB/binary>>});
+transformable25([], Acc) ->
+    Acc.
+
+%% Check that the update of more than two elements of a tuple is
+%% handled (check the inductive step of
+%% beam_ssa_alias_opt:merge_arg_patches/1 works).
+transformable26(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = bs_init_writable(_),
+%ssa% C = bs_init_writable(_),
+%ssa% D = put_tuple(A, B, C),
+%ssa% _ = call(fun transformable26/2, _, D).
+    transformable26(L, {<<>>,<<>>,<<>>}).
+
+transformable26([H|T], {AccA,AccB,AccC}) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% A = get_tuple_element(Arg1, 0),
+%ssa% B = bs_create_bin(private_append, _, A, ...),
+%ssa% C = get_tuple_element(Arg1, 1),
+%ssa% D = bs_create_bin(private_append, _, C, ...),
+%ssa% E = get_tuple_element(Arg1, 2),
+%ssa% F = bs_create_bin(private_append, _, E, ...),
+%ssa% G = put_tuple(B, D, F),
+%ssa% _ = call(fun transformable26/2, _, G).
+    transformable26(T, {<<AccA/binary, H:8>>,
+			<<AccB/binary, H:8>>,
+			<<AccC/binary, H:8>>});
+transformable26([], Acc) ->
+    Acc.
+
+%% Check that we allow the transform when we append a multiple of 8
+%% bits.
+transformable27(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable27/2, _, A).
+    transformable27(L, <<>>).
+
+transformable27([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(private_append, _, Arg1, ...).
+    transformable27(T, <<Acc/binary, H:7, 1:1>>);
+transformable27([], Acc) ->
+    Acc.
+
+transformable28(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable28/2, _, A).
+    transformable28(L, <<>>).
+
+transformable28([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(private_append, _, Arg1, ...).
+    transformable28(T, <<Acc/binary, H:23/bitstring, 1:1>>);
+transformable28([], Acc) ->
+    Acc.
+
+transformable29(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% _ = call(fun transformable29/2, _, A).
+    transformable29(L, <<>>).
+
+transformable29([A,B|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(private_append, _, Arg1, ...).
+    transformable29(T, <<Acc/binary, A:23/bitstring, B/float, 1:9>>);
+transformable29([], Acc) ->
+    Acc.
+
+%% As transformable22, but the accumulator is deconstructed in the
+%% reverse order, tail-head instead of head-tail.
+transformable30(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = bs_init_writable(_),
+%ssa% C = put_list(A, B),
+%ssa% _ = call(fun transformable30/2, _, C).
+    transformable30(L, [<<>>|<<>>]).
+
+transformable30([H|T], X) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% B = get_tl(Arg1),
+%ssa% A = get_hd(Arg1),
+%ssa% C = bs_create_bin(private_append, _, A, ...),
+%ssa% D = bs_create_bin(private_append, _, B, ...),
+%ssa% E = put_list(C, D),
+%ssa% _ = call(fun transformable30/2, _, E).
+    AccB = tl(X),
+    AccA = hd(X),
+    transformable30(T, [<<AccA/binary, H:8>>|<<AccB/binary, 17:8>>]);
+transformable30([], Acc) ->
+    Acc.
+
+%% The private-append transform detects that the accumulator can be
+%% transformed when the third argument to transformable31/3 is
+%% 'b'. This test case checks that the transform doesn't try to
+%% rewrite the {a,b} tuple (which lead to a compiler crash).
+transformable31a(L) ->
+    transformable31(L, <<>>, a).
+
+transformable31b(L) ->
+    transformable31(L, <<>>, b).
+
+transformable31([H|T], Acc, a) when is_binary(Acc) ->
+    transformable31(T, <<Acc/binary, H:8>>, a);
+transformable31([_|T], _Acc, b) ->
+    transformable31(T, {a,b}, b);
+transformable31([], Acc, a) when is_binary(Acc) ->
+    Acc;
+transformable31([], Acc, b) when is_tuple(Acc) ->
+    <<>>.
+
+% Should not be transformed as we can't know the alias status of Acc
+not_transformable1([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    not_transformable1(T, <<Acc/binary, H:8>>);
+not_transformable1([], Acc) ->
+    Acc.
+
+% Should not be transformed as references to the binary can escape in
+% ex:escape/1.
+not_transformable2(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable2/2, _, <<>>).
+    not_transformable2(L, <<>>).
+
+not_transformable2([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    ex:escape(Acc),
+    not_transformable2(T, <<Acc/binary, H:8>>);
+not_transformable2([], Acc) ->
+    Acc.
+
+% Should not be transformed as we create and preserve multiple
+% references to the binary.
+not_transformable3(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable3/3, _, <<>>, _).
+    not_transformable3(L, <<>>, []).
+
+not_transformable3([H|T], Acc, Ls) ->
+%ssa% (_, Arg1, _) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    not_transformable3(T, <<Acc/binary, H:8>>, [Acc|Ls]);
+not_transformable3([], Acc, Ls) ->
+    {Acc, Ls}.
+
+%% We randomly keep multiple references to the binary.
+not_transformable4(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable4/2, _, [<<>>]).
+    not_transformable4(L, [<<>>|[]]).
+
+not_transformable4([H|T], X=[Acc|Ls]) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, ...).
+    Tmp = case ex:f() of
+	      true ->
+		  [Q|_] = X,
+		  Q;
+	      false ->
+		  ok
+	  end,
+    T1 = [Tmp|Ls],
+    not_transformable4(T, [<<Acc/binary, H:8>>|T1]);
+not_transformable4([], Acc) ->
+    Acc.
+
+%% Check that the leak in the external call is detected despite the
+%% mutual recursion.
+not_transformable5(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable5a/2, _, <<>>).
+    not_transformable5a(L, <<>>).
+
+not_transformable5a([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    not_transformable5b(T, <<Acc/binary, 0:8, H:8>>);
+not_transformable5a([], Acc) ->
+    Acc.
+
+not_transformable5b([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    ex:alias(Acc),
+    not_transformable5a(T, <<Acc/binary, 1:8, H:8>>);
+not_transformable5b([], Acc) ->
+    Acc.
+
+%% Check that we're not trying to build binaries which are not a
+%% multiple of 8 bits.
+not_transformable6(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable6/2, _, <<>>).
+    not_transformable6(L, <<>>).
+
+not_transformable6([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    not_transformable6(T, <<Acc/binary, H:1>>);
+not_transformable6([], Acc) ->
+    Acc.
+
+not_transformable7(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable7/2, _, <<>>).
+    not_transformable7(L, <<>>).
+
+not_transformable7([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    not_transformable7(T, <<Acc/binary, H:H>>);
+not_transformable7([], Acc) ->
+    Acc.
+
+not_transformable8(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable8/2, _, <<>>).
+    not_transformable8(L, <<>>).
+
+not_transformable8([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    not_transformable8(T, <<Acc/binary, H/float, 15:4>>);
+not_transformable8([], Acc) ->
+    Acc.
+
+not_transformable9(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable9/2, _, <<>>).
+    not_transformable9(L, <<>>).
+
+not_transformable9([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    not_transformable9(T, <<Acc/binary, H:15/binary, 15:4>>);
+not_transformable9([], Acc) ->
+    Acc.
+
+not_transformable10(L) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = call(fun not_transformable10/2, _, <<>>).
+    not_transformable10(L, <<>>).
+
+not_transformable10([H|T], Acc) ->
+%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(append, _, Arg1, ...).
+    not_transformable10(T, <<Acc/binary, H:15/bitstring>>);
+not_transformable10([], Acc) ->
+    Acc.

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/ret_annotation.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/ret_annotation.erl
@@ -1,0 +1,46 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-module(ret_annotation).
+
+-export([return_atom/0, return_int/0, return_tuple/0, return_unknown/0]).
+
+%%%
+%%% Check that a type annotation is added to return instructions when
+%%% the type is known.
+%%%
+
+return_atom() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_atom,_} }.
+    foo.
+
+return_int() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_integer,_} }.
+    17.
+
+return_tuple() ->
+%ssa% () when post_ssa_opt ->
+%ssa% ret(_) { result_type => {t_tuple,2,true,_} }.
+    {1,2}.
+
+return_unknown() ->
+%ssa% fail () when post_ssa_opt ->
+%ssa% ret(_) { result_type => _ },
+%ssa% label 1.
+    e:f().

--- a/lib/compiler/test/beam_types_SUITE.erl
+++ b/lib/compiler/test/beam_types_SUITE.erl
@@ -101,6 +101,16 @@ binary_absorption(Config) when is_list(Config) ->
     A = beam_types:meet(A, beam_types:join(A, B)),
     A = beam_types:join(A, beam_types:meet(A, B)),
 
+    %% Tests that the appendable flag behaves as intended.
+    C = #t_bitstring{size_unit=4,appendable=true},
+    D = #t_bitstring{size_unit=6},
+
+    #t_bitstring{size_unit=12,appendable=true} = beam_types:meet(C, D),
+    #t_bitstring{size_unit=2,appendable=false} = beam_types:join(C, D),
+
+    C = beam_types:meet(C, beam_types:join(C, D)),
+    C = beam_types:join(C, beam_types:meet(C, D)),
+
     ok.
 
 integer_absorption(Config) when is_list(Config) ->

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -2133,8 +2133,16 @@ annotations_pp(Config) when is_list(Config) ->
     {ok,_} = compile:file(File, [dssaopt, {outdir, TargetDir}]),
     {ok, Data} = file:read_file(Listing),
     Lines = string:split(binary_to_list(Data), "\n", all),
+
     ResultTypes = get_annotations("  %% Result type:", Lines),
     10 = length(ResultTypes),
+
+    Uniques = get_annotations("  %% Unique:", Lines),
+    10 = length(Uniques),
+
+    Aliased = get_annotations("  %% Aliased:", Lines),
+    17 = length(Aliased),
+
     ok = file:del_dir_r(TargetDir),
     ok.
 

--- a/lib/compiler/test/compile_SUITE_data/annotations_pp.erl
+++ b/lib/compiler/test/compile_SUITE_data/annotations_pp.erl
@@ -1,0 +1,31 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-module(annotations_pp).
+
+-export([a/1]).
+
+%% The annotations_pp test will check that these functions and
+%% module_info/[01] have "Result type:" annotations.
+
+a(L) ->
+    b(L, <<>>).
+
+b([H|T], Acc) ->
+    b(T, <<Acc/binary, H:8>>);
+b([], Acc) ->
+    Acc.

--- a/lib/compiler/test/property_test/beam_types_prop.erl
+++ b/lib/compiler/test/property_test/beam_types_prop.erl
@@ -217,7 +217,8 @@ gen_atom() ->
 gen_bs_matchable() ->
     oneof([?LET(Unit, range(1, 16), #t_bs_matchable{tail_unit=Unit}),
            ?LET(Unit, range(1, 16), #t_bs_context{tail_unit=Unit}),
-           ?LET(Unit, range(1, 16), #t_bitstring{size_unit=Unit})]).
+           ?LET({Unit, Appendable}, {range(1, 16), boolean()},
+                #t_bitstring{size_unit=Unit,appendable=Appendable})]).
 
 gen_float() ->
     oneof([?LET({A, B}, {integer(), integer()},


### PR DESCRIPTION
When a binary is grown by appending data to it using `bs_create_bin`,
a considerable performance improvement can be achieved if the append
can be done using the destructive `private_append` instead of
`append`. Using `private_append` flavor of `bs_create_bin` is only
possible when the binary being extended has been created by
`bs_writable_binary` or by another `bs_create_bin` using
`private_append`. As `private_append` is destructive, an additional
requirement is that there is only one live reference to the binary
being being extended.


This set of patches implements the compiler optimization described above together with its dependencies.