### PR TITLE
Update docker build to work on non-Ubuntu hosts

### DIFF
--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -71,6 +71,7 @@ RUN apt-get install -y \
     xvfb libgl1-mesa-dri && \
     for lib in ${EXTRA_LIBS}; do apt-get install -y ${lib}; done && \
     if [ ! -f /etc/apache2/apache2.conf ]; then apt-get install -y apache2; fi
+RUN apt-get install -y linux-tools-$(uname -r) || true
 
 ## We use tmux to test terminals
 RUN apt-get install -y libevent-dev libutf8proc-dev && \

--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -67,7 +67,7 @@ ARG EXTRA_LIBS="erlang erlang-doc"
 RUN apt-get install -y \
     unixodbc odbc-postgresql postgresql ssh openssh-server groff-base gdb \
     tinyproxy bind9 nsd expect vsftpd python emacs nano vim \
-    linux-tools-common linux-tools-generic linux-tools-`uname -r` jq \
+    linux-tools-common linux-tools-generic jq \
     xvfb libgl1-mesa-dri && \
     for lib in ${EXTRA_LIBS}; do apt-get install -y ${lib}; done && \
     if [ ! -f /etc/apache2/apache2.conf ]; then apt-get install -y apache2; fi

--- a/.github/dockerfiles/init.sh
+++ b/.github/dockerfiles/init.sh
@@ -11,6 +11,7 @@ sudo /usr/sbin/sshd
 sudo service postgresql start
 
 sudo -E bash -c "apt-get update && apt-get install -y linux-tools-common linux-tools-generic"
+sudo -E bash -c "apt-get install -y linux-tools-$(uname-r)" || true
 
 sudo bash -c "Xvfb :99 -ac -screen 0 1920x1080x24 -nolisten tcp" &
 export DISPLAY=:99

--- a/.github/dockerfiles/init.sh
+++ b/.github/dockerfiles/init.sh
@@ -10,7 +10,7 @@ sudo /usr/sbin/sshd
 
 sudo service postgresql start
 
-sudo -E bash -c "apt-get update && apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`"
+sudo -E bash -c "apt-get update && apt-get install -y linux-tools-common linux-tools-generic"
 
 sudo bash -c "Xvfb :99 -ac -screen 0 1920x1080x24 -nolisten tcp" &
 export DISPLAY=:99

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -172,7 +172,7 @@ then
     echo "The tests will start in a few seconds..."
     sleep 45
     cd "$ERL_TOP/release/tests/test_server"
-    erl -eval "ts:install(),erlang:halt()"
+    erl -noinput -eval "ts:install(),erlang:halt()"
     erl -noinput -eval "ts:run([all_tests,batch]),erlang:halt()"
     exit $?
 fi


### PR DESCRIPTION
While following [these instructions](https://github.com/erlang/otp/blob/master/HOWTO/DEVELOPMENT.md#using-docker) on my up-to-date Arch Linux host system, I ran into a couple issues while building the Erlang docker images for testing.

* Linux kernel version issues

My host system is currently using the `5.15.91-4-lts` kernel. The docker build process tries to install the `linux-tools-$(uname -r)` package, which does not exist for Ubuntu 20.04 (obviously). I removed this package from the docker build because it does not seem necessary. All you need to do is install `linux-tools-common` and `linux-tools-generic`, as can be seen in this output from a fresh Ubuntu 20.04 container:

```
root@9eae609bf272:/# apt install linux-tools-common linux-tools-generic
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  distro-info-data file libcap2 libdw1 libelf1 libexpat1 libmagic-mgc libmagic1 libmpdec2 libnuma1 libpci3 libpython3-stdlib libpython3.8-minimal libpython3.8-stdlib libreadline8 libslang2 libsqlite3-0 libssl1.1 libunwind8 linux-tools-5.4.0-137
  linux-tools-5.4.0-137-generic lsb-release mime-support pci.ids python3 python3-minimal python3.8 python3.8-minimal readline-common xz-utils
Suggested packages:
  python3-doc python3-tk python3-venv python3.8-venv python3.8-doc binutils binfmt-support readline-doc
The following NEW packages will be installed:
  distro-info-data file libcap2 libdw1 libelf1 libexpat1 libmagic-mgc libmagic1 libmpdec2 libnuma1 libpci3 libpython3-stdlib libpython3.8-minimal libpython3.8-stdlib libreadline8 libslang2 libsqlite3-0 libssl1.1 libunwind8 linux-tools-5.4.0-137
  linux-tools-5.4.0-137-generic linux-tools-common linux-tools-generic lsb-release mime-support pci.ids python3 python3-minimal python3.8 python3.8-minimal readline-common xz-utils
0 upgraded, 32 newly installed, 0 to remove and 4 not upgraded.
Need to get 14.3 MB of archives.
After this operation, 64.4 MB of additional disk space will be used.
Do you want to continue? [Y/n] n
```

* `broken pipe` when running `docker run my_otp_image 'make test'`

I would consistently get `broken pipe` errors when running via a non-interactive, non-tty docker container. If I added `--tty` to the `docker run` arguments, the command would succeed. Turns out that `-noinput` must be passed to all Erlang VMs that are started.