### PR TITLE
Add Ubuntu 22.04 to GHA testing

### DIFF
--- a/.github/scripts/build-base-image.sh
+++ b/.github/scripts/build-base-image.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
-BASE_BRANCH="$1"
+readonly arg_base_branch="$1"
+readonly arg_dockerfile_suffix="$2"
 
-case "${BASE_BRANCH}" in
+case "${arg_base_branch}" in
     master|maint|maint-*)
-    ;;
+        readonly BASE_BRANCH="$arg_base_branch"
+        ;;
     *)
-        BASE_BRANCH="master"
+        readonly BASE_BRANCH="master"
         ;;
 esac
 
 if [ -z "${BASE_TAG}" ]; then
-    BASE_TAG=$(grep "ARG BASE=" ".github/dockerfiles/Dockerfile.${2}" | head -1 | tr '=' ' ' | awk '{print $3}')
+    BASE_TAG="$(awk -F= '/^ARG BASE=/ { print $2; exit }' ".github/dockerfiles/Dockerfile.${arg_dockerfile_suffix}")"
 fi
 
 case "${BASE_TAG}" in
@@ -25,6 +27,10 @@ case "${BASE_TAG}" in
         ;;
     *ubuntu-base)
         BASE="ubuntu:20.04"
+        BASE_TYPE=ubuntu-base
+        ;;
+    *ubuntu-latest-base)
+        BASE="ubuntu:22.04"
         BASE_TYPE=ubuntu-base
         ;;
 esac

--- a/.github/workflows/update-base.yaml
+++ b/.github/workflows/update-base.yaml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        type: [debian-base,ubuntu-base,i386-debian-base]
+        type: [debian-base,ubuntu-base,i386-debian-base,ubuntu-latest-base]
         branch: [master, maint, maint-25]
 
     steps:


### PR DESCRIPTION
Related to https://github.com/erlang/otp/issues/6406

Note: work-in-progress. I realize this isn't the "right" way to accomplish this, but I have the following question -

Does it make more sense to just update the base Ubuntu image to 22.04? The goal of this work is to get GHA to use a linux image with OpenSSL 3.0 available. Ubuntu Jammy is the first version to ship with this updated OpenSSL library.

cc @garazdawi since he assisted me the last time I modified this file. Thanks!