### PR TITLE
Do not emit "unexpected" message on shutdown

### DIFF
--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -232,7 +232,7 @@ gen_accept(Driver, Listen) ->
 %%  smaller than MaxPending
 accept_loop(DLK, undefined, MaxPending, Pending) when map_size(Pending) < MaxPending ->
     accept_loop(DLK, spawn_accept(DLK), MaxPending, Pending);
-accept_loop(DLK, HandshakePid, MaxPending, Pending) ->
+accept_loop({_, _, NetKernelPid} = DLK, HandshakePid, MaxPending, Pending) ->
     receive
         {continue, HandshakePid} when is_pid(HandshakePid) ->
             accept_loop(DLK, undefined, MaxPending, Pending#{HandshakePid => true});
@@ -243,6 +243,9 @@ accept_loop(DLK, HandshakePid, MaxPending, Pending) ->
         {'EXIT', HandshakePid, Reason} when is_pid(HandshakePid) ->
             %% HandshakePid crashed before turning into Pending, which means
             %%  error happened in accept. Need to restart the listener.
+            exit(Reason);
+        {'EXIT', NetKernelPid, Reason} ->
+            %% Since we're trapping exits, need to manually propagate this signal
             exit(Reason);
         Unexpected ->
             ?LOG_WARNING("TLS distribution: unexpected message: ~p~n" ,[Unexpected]),


### PR DESCRIPTION
During shutdown, net_kernel process that is linked to an acceptor, gracefully terminates, triggering
`{EXIT, net_kernel, shutdown}` message sent to the acceptor.

However acceptor does not expect it, and instead of a graceful shutdown logs a confusing warning.