### PR TITLE
diameter: update appup files

### DIFF
--- a/lib/diameter/src/diameter.appup.src
+++ b/lib/diameter/src/diameter.appup.src
@@ -63,24 +63,13 @@
   {"2.1.5",   [{restart_application, diameter}]},  %% 21.0
   {"2.1.6",   [{restart_application, diameter}]},  %% 21.1
   {"2.2",     [{restart_application, diameter}]},  %% 21.3
-  {"2.2.1",   [{load_module, diameter},            %% 21.3.5
-               {load_module, diameter_codec},
-               {update, diameter_config},
-               {update, diameter_dist},
-               {update, diameter_peer_fsm},
-               {update, diameter_service},
-               {load_module, diameter_traffic},
-               {load_module, diameter_types},
-               {update, diameter_tcp},
-               {update, diameter_sctp}]},
- {"2.2.2",    [{load_module, diameter},            %% 22.2.8
-               {load_module, diameter_types},
-               {update, diameter_sctp}]},
- {"2.2.3",    [{load_module, diameter_types},
-               {update, diameter_sctp}]},          %% 22.3
- {"2.2.4",    [{load_module, diameter_types}]},    %% 23.3.4
- {"2.2.5",    [{load_module, diameter_types}]},     %% 24.3
- {"2.2.6",   [{restart_application, diameter}]}
+  {"2.2.1",   [{restart_application, diameter}]},
+  {"2.2.2",   [{restart_application, diameter}]},  %% 22.2.8
+  {"2.2.3",   [{restart_application, diameter}]},  %% 22.3
+  {"2.2.4",   [{restart_application, diameter}]},  %% 23.3.4
+  {"2.2.5",   [{restart_application, diameter}]},  %% 24.3
+  {"2.2.6",   [{restart_application, diameter}]},  %% 25.0
+  {"2.2.7",   [{restart_application, diameter}]}   %% 25.1
  ],
  [
   {"0.9",     [{restart_application, diameter}]},
@@ -125,23 +114,20 @@
   {"2.1.5",   [{restart_application, diameter}]},
   {"2.1.6",   [{restart_application, diameter}]},
   {"2.2",     [{restart_application, diameter}]},
-  {"2.2.1",   [{load_module, diameter},
-               {load_module, diameter_codec},
-               {update, diameter_config},
-               {update, diameter_dist},
-               {update, diameter_peer_fsm},
-               {update, diameter_service},
-               {load_module, diameter_traffic},
-               {load_module, diameter_types},
-               {update, diameter_tcp},
-               {update, diameter_sctp}]},
-  {"2.2.2",   [{load_module, diameter},
-               {load_module, diameter_types},
-               {update, diameter_sctp}]},
-  {"2.2.3",   [{load_module, diameter_types},
-               {update, diameter_sctp}]},
-  {"2.2.4",   [{load_module, diameter_types}]},
-  {"2.2.5",   [{load_module, diameter_types}]},
-  {"2.2.6",   [{restart_application, diameter}]}
+  {"2.1.1",   [{restart_application, diameter}]},
+  {"2.1.2",   [{restart_application, diameter}]},
+  {"2.1.3",   [{restart_application, diameter}]},
+  {"2.1.4",   [{restart_application, diameter}]},
+  {"2.1.4.1", [{restart_application, diameter}]},
+  {"2.1.5",   [{restart_application, diameter}]},
+  {"2.1.6",   [{restart_application, diameter}]},
+  {"2.2",     [{restart_application, diameter}]},
+  {"2.2.1",   [{restart_application, diameter}]},
+  {"2.2.2",   [{restart_application, diameter}]},
+  {"2.2.3",   [{restart_application, diameter}]},
+  {"2.2.4",   [{restart_application, diameter}]},
+  {"2.2.5",   [{restart_application, diameter}]},
+  {"2.2.6",   [{restart_application, diameter}]},
+  {"2.2.7",   [{restart_application, diameter}]}
  ]
 }.


### PR DESCRIPTION
This commit updates the appup file forgotten in PR-6702 and PR-6769 as well as other calls from `size/1` to `byte_size/1`