### PR TITLE
ssl: replace size/1 by xxx_size/1

### DIFF
--- a/lib/ssl/src/ssl_trace.erl
+++ b/lib/ssl/src/ssl_trace.erl
@@ -358,7 +358,7 @@ trace_pid(T) when element(1,T)==trace
 
 %% Pick last element, the Time Stamp, and format it
 trace_ts(T) when  element(1,T)==trace_ts ->
-    ts( element(size(T), T) ).
+    ts( element(tuple_size(T), T) ).
 
 ts({_,_,Usec}=Now) when is_integer(Usec) ->
     {_Date,{HH,MM,SS}} = calendar:now_to_local_time(Now),

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -359,7 +359,7 @@ handle_info({CloseTag, Socket}, StateName,
 handle_info({ssl_tls, Port, Type, {Major, Minor}, Data}, StateName,
             #state{static_env = #static_env{data_tag = Protocol},
                    ssl_options = #{ktls := true}} = State0) ->
-    Len = size(Data),
+    Len = byte_size(Data),
     handle_info({Protocol, Port, <<Type, Major, Minor, Len:16, Data/binary>>}, StateName, State0);
 handle_info(Msg, StateName, State) ->
     ssl_gen_statem:handle_info(Msg, StateName, State).


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.