### PR TITLE
STDLIB tests: Fix falling map iterator tests in debug build

### DIFF
--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -2331,8 +2331,6 @@ maps(_Config) ->
            "~KP", [undefined, FloatIntegerMap, 2]),
     "#{-1 => c,0 => d,-1.0 => a,0.0 => b}" = fmt("~Kp", [ordered, FloatIntegerMap]),
     "#{0.0 => b,-1.0 => a,0 => d,-1 => c}" = fmt("~Kp", [reversed, FloatIntegerMap]),
-    "#{-1 => c,-1.0 => a,0 => d,0.0 => b}" = fmt("~Kp", [AOrdCmpFun, FloatIntegerMap]),
-    "#{0.0 => b,0 => d,-1.0 => a,-1 => c}" = fmt("~Kp", [ARevCmpFun, FloatIntegerMap]),
 
     %% Print a map and parse it back to a map.
     S = fmt("~p\n", [Map]),

--- a/lib/stdlib/test/maps_SUITE.erl
+++ b/lib/stdlib/test/maps_SUITE.erl
@@ -503,7 +503,7 @@ t_iterator_1(Config) when is_list(Config) ->
 t_iterator_2(Config) when is_list(Config) ->
 
     AOrdCmpFun = fun(A, B) -> A =< B end,
-    ARevCmpFun = fun(A, B) -> B < A end,
+    ARevCmpFun = fun(A, B) -> B =< A end,
 
     %% Small map test
     M0 = #{ a => 1, b => 2 },
@@ -557,7 +557,6 @@ t_iterator_2(Config) when is_list(Config) ->
     OrdIter4 = maps:iterator(M4, ordered),
     [{-1, c}, {0, d}, {-1.0, a}, {0.0, b}] = maps:to_list(OrdIter4),
     ok = iterator_2_check_order(M4, ordered, reversed),
-    ok = iterator_2_check_order(M4, AOrdCmpFun, ARevCmpFun),
 
     ok.
 


### PR DESCRIPTION
The `>=/2` sort function is not appropriate for sorting maps with mixed integer and float keys. It happens to work with small maps because `maps:to_list/1` returns a list already correctly sorted. In a debug build, the four-elements maps are large maps and the test case fails.

While at it, also correct `ARevCmpFun`.