### PR TITLE
Add del_paths/1, clear_cache/0, and cache arg 

### DIFF
--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -102,12 +102,17 @@
 /usr/local/jungerl:/home/some_user/my_erlang_lib</code>
     <p>On Windows, use semi-colon as separator.</p>
     <p>The code paths specified by <c>$OTP_ROOT</c>, <c>ERL_LIBS</c>,
-      and boot scripts have their listings cached by default (except for ".").
+      and boot scripts have their listings cached by default (except for ".")
+      since OTP @OTP-18466@.
       The code server will lookup the contents in their directories once
       and avoid future file system traversals. Therefore modules added
       to such directories after the Erlang VM boots won't be picked up.
       You can disable this behaviour by setting <c>-cache_boot_paths false</c>
       or by calling <c>code:set_path(code:get_path())</c>.</p>
+    <p>The functions in this module and the command line options <c>-pa</c>
+      and <c>-pz</c> are not cached by default. However, many of the functions
+      that manipulate the code path accept the <c>cache</c> atom as an optional
+      argument, which will enable caching on selected paths.</p>
   </section>
 
   <section>
@@ -289,6 +294,12 @@ zip:create("mnesia-4.4.7.ez",
     </section>
   <datatypes>
     <datatype>
+      <name name="add_path_ret"/>
+    </datatype>
+    <datatype>
+      <name name="cache"/>
+    </datatype>
+    <datatype>
       <name name="load_ret"/>
     </datatype>
     <datatype>
@@ -301,14 +312,24 @@ zip:create("mnesia-4.4.7.ez",
       <name name="prepared_code"/>
       <desc><p>An opaque term holding prepared code.</p></desc>
     </datatype>
+    <datatype>
+      <name name="replace_path_ret"/>
+    </datatype>
+    <datatype>
+      <name name="set_path_ret"/>
+    </datatype>
   </datatypes>
 
   <funcs>
     <func>
       <name name="set_path" arity="1" since=""/>
+      <name name="set_path" arity="2" since="OTP @OTP-18466@"/>
       <fsummary>Set the code server search path.</fsummary>
       <desc>
         <p>Sets the code path to the list of directories <c><anno>Path</anno></c>.</p>
+        <p>An optional second argument may be set to the atom <c>cache</c> to
+          control if the contents of the directory must be cached on first traversal.
+          Defaults to <c>nocache</c>.</p>
         <p>Returns:</p>
 	<taglist>
 	<tag><c>true</c></tag>
@@ -327,13 +348,18 @@ zip:create("mnesia-4.4.7.ez",
     </func>
     <func>
       <name name="add_path" arity="1" since=""/>
+      <name name="add_path" arity="2" since="OTP @OTP-18466@"/>
       <name name="add_pathz" arity="1" since=""/>
+      <name name="add_pathz" arity="2" since="OTP @OTP-18466@"/>
       <fsummary>Add a directory to the end of the code path.</fsummary>
       <type name="add_path_ret"/>
       <desc>
         <p>Adds <c><anno>Dir</anno></c> to the code path. The directory is added as
           the last directory in the new path. If <c><anno>Dir</anno></c> already
           exists in the path, it is not added.</p>
+        <p>An optional second argument may be set to the atom <c>cache</c> to
+          control if the contents of the directory must be cached on first traversal.
+          Defaults to <c>nocache</c>.</p>
         <p>Returns <c>true</c> if successful, or
           <c>{error, bad_directory}</c> if <c><anno>Dir</anno></c> is not the name
           of a directory.</p>
@@ -341,12 +367,16 @@ zip:create("mnesia-4.4.7.ez",
     </func>
     <func>
       <name name="add_patha" arity="1" since=""/>
+      <name name="add_patha" arity="2" since="OTP @OTP-18466@"/>
       <fsummary>Add a directory to the beginning of the code path.</fsummary>
       <type name="add_path_ret"/>
       <desc>
         <p>Adds <c><anno>Dir</anno></c> to the beginning of the code path. If
           <c><anno>Dir</anno></c> exists, it is removed from the old
           position in the code path.</p>
+        <p>An optional second argument may be set to the atom <c>cache</c> to
+          control if the contents of the directory must be cached on first traversal.
+          Defaults to <c>nocache</c>.</p>
         <p>Returns <c>true</c> if successful, or
           <c>{error, bad_directory}</c> if <c><anno>Dir</anno></c> is not the name
           of a directory.</p>
@@ -354,17 +384,23 @@ zip:create("mnesia-4.4.7.ez",
     </func>
     <func>
       <name name="add_paths" arity="1" since=""/>
+      <name name="add_paths" arity="2" since="OTP @OTP-18466@"/>
       <name name="add_pathsz" arity="1" since=""/>
+      <name name="add_pathsz" arity="2" since="OTP @OTP-18466@"/>
       <fsummary>Add directories to the end of the code path.</fsummary>
       <desc>
         <p>Adds the directories in <c><anno>Dirs</anno></c> to the end of the code
           path. If a <c><anno>Dir</anno></c> exists, it is not added.</p>
+        <p>An optional second argument may be set to the atom <c>cache</c> to
+          control if the contents of the directory must be cached on first traversal.
+          Defaults to <c>nocache</c>.</p>
 	<p>Always returns <c>ok</c>, regardless of the validity
           of each individual <c><anno>Dir</anno></c>.</p>
       </desc>
     </func>
     <func>
       <name name="add_pathsa" arity="1" since=""/>
+      <name name="add_pathsa" arity="2" since=""/>
       <fsummary>Add directories to the beginning of the code path.</fsummary>
       <desc>
 	<p>Traverses <c><anno>Dirs</anno></c> and adds
@@ -375,6 +411,9 @@ zip:create("mnesia-4.4.7.ez",
 	  be <c>[Dir2,Dir1|OldCodePath]</c>.</p>
 	<p>If a <c><anno>Dir</anno></c> already exists in the code
 	  path, it is removed from the old position.</p>
+        <p>An optional second argument may be set to the atom <c>cache</c> to
+          control if the contents of the directory must be cached on first traversal.
+          Defaults to <c>nocache</c>.</p>
 	<p>Always returns <c>ok</c>, regardless of the validity of each
           individual <c><anno>Dir</anno></c>.</p>
       </desc>
@@ -400,7 +439,35 @@ zip:create("mnesia-4.4.7.ez",
       </desc>
     </func>
     <func>
+      <name name="del_paths" arity="1" since="OTP @OTP-18466@"/>
+      <fsummary>Deletes directories from the code path.</fsummary>
+      <desc>
+        <p>Deletes directories from the code path. The argument is a list of either
+          atoms or complete directory names. If an atom <c><anno>Name</anno></c>,
+          the directory with the name <c>.../<anno>Name</anno>[-Vsn][/ebin]</c> is
+          deleted from the code path.</p>
+        <p>Always returns <c>ok</c>, regardless of the validity
+          of each individual <c><anno>NamesOrDirs</anno></c>.</p>
+      </desc>
+    </func>
+    <func>
+      <name name="clear_cache" arity="0" since="OTP @OTP-18466@"/>
+      <fsummary>Clears the code path cache.</fsummary>
+      <desc>
+        <p>Clear the code path cache. If a directory is cached, its cache is
+          cleared once and then it will be recalculated and cached once more
+          in a future traversal.</p>
+        <p>If you want to clear the cache for a single path, you might re-add it
+          to the code path (with <c>add_path/2</c>) or
+          replace it (with <c>replace_path/3</c>).
+          If you want to disable all cache, you can reset the code path
+          with <c>code:set_path(code:get_path())</c>.</p>
+        <p>Always returns <c>ok</c>.</p>
+      </desc>
+    </func>
+    <func>
       <name name="replace_path" arity="2" since=""/>
+      <name name="replace_path" arity="3" since="OTP @OTP-18466@"/>
       <fsummary>Replace a directory with another in the code path.</fsummary>
       <desc>
         <p>Replaces an old occurrence of a directory
@@ -410,6 +477,9 @@ zip:create("mnesia-4.4.7.ez",
 	  directory must also be named <c>.../<anno>Name</anno>[-Vsn][/ebin]</c>.
 	  This function is to be used if a new version of the directory (library) is
           added to a running system.</p>
+        <p>An optional third argument may be set to the atom <c>cache</c> to
+          control if the contents of the directory must be cached on first traversal.
+          Defaults to <c>nocache</c>.</p>
         <p>Returns:</p>
 	<taglist>
 	  <tag><c>true</c></tag>

--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -41,8 +41,6 @@
 -type on_load_item() :: {{pid(),reference()},module(),
 			 [{pid(),on_load_action()}]}.
 
--define(CACHE_DEFAULT, nocache).
-
 -record(state, {supervisor :: pid(),
 		root :: file:name_all(),
 		path :: [{file:name_all(), cache | nocache}],
@@ -263,19 +261,19 @@ handle_call({dir,Dir}, _From, S) ->
     Resp = do_dir(Root,Dir,S#state.namedb),
     {reply,Resp,S};
 
-handle_call({add_path,Where,Dir0}, _From,
+handle_call({add_path,Where,Dir0,Cache}, _From,
 	    #state{namedb=Namedb,path=Path0}=S) ->
-    {Resp,Path} = add_path(Where, Dir0, Path0, ?CACHE_DEFAULT, Namedb),
+    {Resp,Path} = add_path(Where, Dir0, Path0, Cache, Namedb),
     {reply,Resp,S#state{path=Path}};
 
-handle_call({add_paths,Where,Dirs0}, _From,
+handle_call({add_paths,Where,Dirs0,Cache}, _From,
 	    #state{namedb=Namedb,path=Path0}=S) ->
-    {Resp,Path} = add_paths(Where, Dirs0, Path0, ?CACHE_DEFAULT, Namedb),
+    {Resp,Path} = add_paths(Where, Dirs0, Path0, Cache, Namedb),
     {reply,Resp,S#state{path=Path}};
 
-handle_call({set_path,PathList}, _From,
+handle_call({set_path,PathList,Cache}, _From,
 	    #state{root=Root,path=Path0,namedb=Namedb}=S) ->
-    {Resp,Path,NewDb} = set_path(PathList, Path0, ?CACHE_DEFAULT, Namedb, Root),
+    {Resp,Path,NewDb} = set_path(PathList, Path0, Cache, Namedb, Root),
     {reply,Resp,S#state{path=Path,namedb=NewDb}};
 
 handle_call({del_path,Name}, _From,
@@ -283,13 +281,23 @@ handle_call({del_path,Name}, _From,
     {Resp,Path} = del_path(Name, Path0, Namedb),
     {reply,Resp,S#state{path=Path}};
 
-handle_call({replace_path,Name,Dir}, _From,
+handle_call({del_paths,Names}, _From,
+            #state{path=Path0,namedb=Namedb}=S) ->
+    {Resp,Path} = del_paths(Names, Path0, Namedb),
+    {reply,Resp,S#state{path=Path}};
+
+handle_call({replace_path,Name,Dir,Cache}, _From,
 	    #state{path=Path0,namedb=Namedb}=S) ->
-    {Resp,Path} = replace_path(Name, Dir, Path0, ?CACHE_DEFAULT, Namedb),
+    {Resp,Path} = replace_path(Name, Dir, Path0, Cache, Namedb),
     {reply,Resp,S#state{path=Path}};
 
 handle_call(get_path, _From, S) ->
     {reply,[P || {P, _Cache} <- S#state.path],S};
+
+handle_call(clear_cache, _From, S) ->
+    Path = [{P, if is_atom(Cache) -> Cache; true -> cache end} ||
+            {P, Cache} <- S#state.path],
+    {reply,ok,S#state{path=Path}};
 
 handle_call({load_module,PC,Mod,File,Purge,EnsureLoaded}, From, S)
   when is_atom(Mod) ->
@@ -499,13 +507,12 @@ try_ebin_dirs([]) ->
 %%
 add_loader_path(IPath0,Mode) ->
     {ok,PrimP0} = erl_prim_loader:get_path(),
-    CacheBootPaths = cache_boot_paths(),
 
     %% All boot paths except for "." are cached by default but this can be disabled.
     %% -pa and -pz are never cached by default.
-    BootPaths = case Mode of
+    case Mode of
         embedded ->
-            [{P, CacheBootPaths} || P <- strip_path(PrimP0, Mode)];  % i.e. only normalize
+            cache_path(strip_path(PrimP0, Mode));  % i.e. only normalize
         _ ->
             Pa0 = get_arg(pa),
             Pz0 = get_arg(pz),
@@ -518,11 +525,16 @@ add_loader_path(IPath0,Mode) ->
             Path0 = exclude_pa_pz(PrimP,Pa,Pz),
             Path1 = strip_path(Path0, Mode),
             Path2 = merge_path(Path1, IPath, []),
-            Path3 = [{P, CacheBootPaths} || P <- Path2],
+            Path3 = cache_path(Path2),
             add_pa_pz(Path3,Pa,Pz)
-    end,
-    lists:keyreplace(".", 1, BootPaths, {".", nocache}).
+    end.
 
+cache_path(Path) ->
+    Default = cache_boot_paths(),
+    [{P, do_cache_path(P, Default)} || P <- Path].
+
+do_cache_path(".", _) -> nocache;
+do_cache_path(_, Default) -> Default.
 
 cache_boot_paths() ->
     case init:get_argument(cache_boot_paths) of
@@ -538,15 +550,10 @@ patch_path(Path) ->
 
 %% As the erl_prim_loader path includes the -pa and -pz
 %% directories they have to be removed first !!
+exclude_pa_pz(P0,Pa,[]) ->
+    P0 -- Pa;
 exclude_pa_pz(P0,Pa,Pz) ->
-    P1 = excl(Pa, P0),
-    P = excl(Pz, lists:reverse(P1)),
-    lists:reverse(P).
-
-excl([], P) -> 
-    P;
-excl([D|Ds], P) ->
-    excl(Ds, lists:delete(D, P)).
+    lists:reverse(lists:reverse(P0 -- Pa) -- Pz).
 
 %%
 %% Keep only 'valid' paths in code server.
@@ -591,9 +598,14 @@ merge_path1(_,IPath,Acc) ->
     lists:reverse(Acc) ++ IPath.
 
 add_pa_pz(Path0, Patha, Pathz) ->
-    {_,Path1} = add_paths(first,Patha,Path0,?CACHE_DEFAULT,false),
-    {_,Path2} = add_paths(first,Pathz,lists:reverse(Path1),?CACHE_DEFAULT,false),
-    lists:reverse(Path2).
+    {_,Path1} = add_paths(first,Patha,Path0,nocache,false),
+    case Pathz of
+        [] ->
+            Path1;
+        _ ->
+            {_,Path2} = add_paths(first,Pathz,lists:reverse(Path1),nocache,false),
+            lists:reverse(Path2)
+    end.
 
 get_arg(Arg) ->
     case init:get_argument(Arg) of
@@ -1047,6 +1059,12 @@ add_paths(Where,[Dir|Tail],Path,Cache,NameDb) ->
     {_,NPath} = add_path(Where,Dir,Path,Cache,NameDb),
     add_paths(Where,Tail,NPath,Cache,NameDb);
 add_paths(_,_,Path,_,_) ->
+    {ok,Path}.
+
+del_paths([Name | Names],Path,NameDb) ->
+    {_,NPath} = del_path(Name, Path, NameDb),
+    del_paths(Names,NPath,NameDb);
+del_paths(_,Path,_) ->
     {ok,Path}.
 
 try_finish_module(File, Mod, PC, true, From, St) ->


### PR DESCRIPTION
This pull request adds an optional cache/nocache
argument to all `add_path*` functions, `set_path`,
and `replace_path`.

It also adds `del_paths/1` to make it easier to
clear multiple paths and `clear_cache/0` for
clearing the whole code path caching without
disabling it.

To be merged after #6729.