### PR TITLE
Port: spawn_control: Close the Write File Descriptor (Implying EOF)

### DIFF
--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -570,7 +570,7 @@ static ErlDrvData spawn_start(ErlDrvPort port_num, char* name,
 	memcpy((void *) (cmd_line + CMD_LINE_PREFIX_STR_SZ), (void *) name, len);
 	cmd_line[CMD_LINE_PREFIX_STR_SZ + len] = '\0';
 	len = CMD_LINE_PREFIX_STR_SZ + len + 1;
-}
+    }
 
     if ((cwd = getcwd(wd_buff, MAXPATHLEN+1)) == NULL) {
         /* on some OSs this call opens a fd in the

--- a/erts/emulator/test/port_bif_SUITE.erl
+++ b/erts/emulator/test/port_bif_SUITE.erl
@@ -390,6 +390,14 @@ test_op(P, Op) ->
 
 %% Test closing write file descriptor (EOF) with port_control/3
 control_eof(Config) when is_list(Config) ->
+    case os:type() of
+	{unix,_} ->
+	    do_control_eof();
+	_ ->
+	    {skip,"Only on Unix."}
+    end.
+
+do_control_eof() ->
     InputText = "5\n3\n1\n4\n2\n",
     ExpectedText = "1\n2\n3\n4\n5\n",
 
@@ -401,6 +409,8 @@ control_eof(Config) when is_list(Config) ->
     erlang:port_control(P, 16#0112c000, []), %% Magic number to close fildes.
 
     receive {P, X} -> {data, ExpectedText} = X end,
+
+    P ! {self(), {command, "To the bit bucket!"}}, %% Further writes are ignored.
 
     true = erlang:port_close(myport),
     ok.


### PR DESCRIPTION
This implements a means to close the stdin of a port (implying EOF). This is necessary for piping data to programs which read from standard input and wait for the input stream to be closed, such as `wc`.

It works by closing the write descriptor when the magic code *0x0112c000* (`SPAWN_CTRL_OP_EOF`) is passed to `port_control/3` for the `spawn_driver` [driver entry](https://www.erlang.org/doc/man/driver_entry.html). The write descriptor is replaced by `/dev/null`, with further writes being discarded to the bit bucket. Replacing the write file descriptor with `/dev/null` avoids complexities when dealing with "half-open" ports.

Only implemented for Unix systems.  See `erts/emulator/sys/unix/sys_drivers.c`.

Includes a test case. See `erts/emulator/test/port_bif_SUITE.erl`.

Resolves:

  - https://github.com/erlang/otp/issues/4326

Users having this issue:

  * [Issues with stdin on ports](https://erlang.org/pipermail/erlang-questions/2013-July/074916.html)
  * [EOF to external program](http://erlang.org/pipermail/erlang-questions/2010-November/054330.html)
  * [struggling with port_command()](http://erlang.org/pipermail/erlang-questions/2010-October/053944.html)
  * [open_pipe({spawn, "cat"}) --- how to close stdin of cat?](http://erlang.org/pipermail/erlang-questions/2009-March/042123.html)
  * [Erlang Ports: Interfacing with a "wc"-like program?](https://stackoverflow.com/questions/8792376/erlang-ports-interfacing-with-a-wc-like-program)
  * [erlang ports bewlider me](https://gist.github.com/timruffles/77e9b69cdecdd7b3ef08)
  * [Use an OS process like a bash pipe: Send it STDIN and get its STDOUT](https://stackoverflow.com/questions/74833431/use-an-os-process-like-a-bash-pipe-send-it-stdin-and-get-its-stdout)
  * [Rambo - Run your command. Send EOF. Get output](https://elixirforum.com/t/rambo-run-your-command-send-eof-get-output/25052)

Users solving this issue with middleware:

  * [mattsta/erlang-stdinout-pool](https://github.com/mattsta/erlang-stdinout-pool#why-is-this-special)
  * [saleyn/erlexec](https://github.com/saleyn/erlexec#communicating-with-an-os-process-via-stdin-and-sending-end-of-file)
  * [petrkozorezov/estdinout](https://github.com/petrkozorezov/estdinout#estdinout)
  * [jayjun/rambo](https://github.com/jayjun/rambo#why)
  * [alco/porcelain](https://github.com/alco/porcelain#overview)

Example usage of the *0x0112c000* control code with `wc`:

```
-module(test).
-export([wc/1]).

wc(InputText) ->
    P = open_port({spawn, "wc"}, [stream, use_stdio]),
    P ! {self(), {command, InputText}},
    port_control(P, 16#0112c000, []),
    receive {P, X} -> X end.
```

Running the example:

```
Erlang/OTP 26 [DEVELOPMENT] [erts-13.1.4] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [jit:ns]

Eshell V13.1.4 (press Ctrl+G to abort, type help(). for help)
1> test:wc("Hello, world!\n").
{data,"      1       2      14\n"}
2>
```