### PR TITLE
diameter: replace size/1 by xxx_size/1

### DIFF
--- a/lib/diameter/src/info/diameter_dbg.erl
+++ b/lib/diameter/src/info/diameter_dbg.erl
@@ -214,7 +214,7 @@ pp(<<Version:8, MsgLength:24,
     N;
 
 pp(<<_Version:8, MsgLength:24, _/binary>> = Bin) ->
-    {bad_message_length, MsgLength, size(Bin)};
+    {bad_message_length, MsgLength, byte_size(Bin)};
 
 pp(Bin)
   when is_binary(Bin) ->


### PR DESCRIPTION
The <c>size/1</c> BIF is not optimized by the JIT, and its use can result in worse types for Dialyzer.

When one knows that the value being tested must be a tuple, <c>tuple_size/1</c> should always be preferred.

When one knows that the value being tested must be a binary, <c>byte_size/1</c> should be preferred. However, <c>byte_size/1</c> also accepts a bitstring (rounding up size to a whole number of bytes), so one must make sure that the call to <c>byte_size/</c> is preceded by a call to <c>is_binary/1</c> to ensure that bitstrings are rejected. Note that the compiler removes redundant calls to <c>is_binary/1</c>, so if one is not sure whether previous code had made sure that the argument is a binary, it does not harm to add an <c>is_binary/1</c> test immediately before the call to <c>byte_size/1</c>.

This commit also updates the appup file forgotten in PR-6702 and PR-6769.