### PR TITLE
Fix crash when matching out empty binaries

### DIFF
--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -3674,7 +3674,9 @@ void BeamModuleAssembler::emit_extract_binary(const arm::Gp bitdata,
     mov_imm(TMP3, num_bytes);
     a.rev64(TMP4, bitdata);
     a.stp(TMP2, TMP3, arm::Mem(HTOP).post(sizeof(Eterm[2])));
-    a.str(TMP4, arm::Mem(HTOP).post(sizeof(Eterm[1])));
+    if (num_bytes != 0) {
+        a.str(TMP4, arm::Mem(HTOP).post(sizeof(Eterm[1])));
+    }
     flush_var(dst);
 }
 

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -3781,8 +3781,12 @@ void BeamModuleAssembler::emit_extract_binary(const x86::Gp bitdata,
     a.mov(x86::qword_ptr(HTOP, sizeof(Eterm)), imm(num_bytes));
     a.mov(RET, bitdata);
     a.bswap(RET);
-    a.mov(x86::qword_ptr(HTOP, 2 * sizeof(Eterm)), RET);
-    a.add(HTOP, imm(sizeof(Eterm[3])));
+    if (num_bytes == 0) {
+        a.add(HTOP, imm(sizeof(Eterm[2])));
+    } else {
+        a.mov(x86::qword_ptr(HTOP, 2 * sizeof(Eterm)), RET);
+        a.add(HTOP, imm(sizeof(Eterm[3])));
+    }
 }
 
 static std::vector<BsmSegment> opt_bsm_segments(

--- a/erts/emulator/test/bs_match_bin_SUITE.erl
+++ b/erts/emulator/test/bs_match_bin_SUITE.erl
@@ -23,7 +23,8 @@
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
          init_per_group/2,end_per_group/2,
          byte_split_binary/1,bit_split_binary/1,match_huge_bin/1,
-         bs_match_string_edge_case/1,contexts/1]).
+         bs_match_string_edge_case/1,contexts/1,
+         empty_binary/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -31,7 +32,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
     [byte_split_binary, bit_split_binary, match_huge_bin,
-     bs_match_string_edge_case, contexts].
+     bs_match_string_edge_case, contexts, empty_binary].
 
 groups() ->
     [].
@@ -269,4 +270,16 @@ get_binary_memory_ctx(A, B, C, D, E, F, Bin) ->
               <<Res0:12/binary>> -> Res0
           end,
     {Res,{A,B,C,D,E,F}}.
+
+empty_binary(_Config) ->
+    _ = do_empty_binary(1_000_000),
+    ok.
+
+do_empty_binary(0) ->
+    ok;
+do_empty_binary(N) ->
+    %% The new bs_match instruction would use more heap space
+    %% than reserved when matching out an empty binary.
+    <<V1:0/bits, V1:0/bitstring, V2:0/bytes, V2:0/bits>> = <<>>,
+    [0|do_empty_binary(N-1)].
 


### PR DESCRIPTION
Code matching out empty binaries such as in the following example:

    start() ->
        [0 || <<V1:0/bits, V1:0/bitstring, V2:0/bytes, V2:0/bits>> <= <<>>].

could crash the runtime system. (This bug is not present in OTP 25 or earlier.)

Thanks to Robin Morisset for noticing this bug.