### PR TITLE
AArch64 JIT: Fix crash in bxor/2

### DIFF
--- a/erts/emulator/beam/jit/arm/instr_arith.cpp
+++ b/erts/emulator/beam/jit/arm/instr_arith.cpp
@@ -993,6 +993,7 @@ void BeamModuleAssembler::emit_i_bxor(const ArgLabel &Fail,
 
     if (Fail.get() != 0) {
         emit_enter_runtime(Live.get());
+        a.mov(ARG1, c_p);
         runtime_call<3>(erts_bxor);
         emit_leave_runtime(Live.get());
         emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));

--- a/erts/emulator/test/small_SUITE.erl
+++ b/erts/emulator/test/small_SUITE.erl
@@ -449,6 +449,29 @@ test_bitwise(_Config) ->
     merl:print(Tree),
     {ok,_Bin} = merl:compile_and_load(Tree, []),
     test_bitwise(Fs0, Mod),
+
+    %% Test invalid operands.
+    expect_badarith(fun(X) -> 42 band X end),
+    expect_badarith(fun(X) -> 42 bor X end),
+    expect_badarith(fun(X) -> 42 bxor X end),
+    expect_badarith(fun(X) -> X band 42 end),
+    expect_badarith(fun(X) -> X bor 42 end),
+    expect_badarith(fun(X) -> X bxor 42 end),
+    expect_fc(fun(X) when is_integer(42 band X) -> ok end),
+    expect_fc(fun(X) when is_integer(42 bor X) -> ok end),
+    expect_fc(fun(X) when is_integer(42 bxor X) -> ok end),
+    expect_fc(fun(X) when is_integer(X band 42) -> ok end),
+    expect_fc(fun(X) when is_integer(X bor 42) -> ok end),
+    expect_fc(fun(X) when is_integer(X bxor 42) -> ok end),
+
+    ok.
+
+expect_fc(Fun) ->
+    {'EXIT',{function_clause,_}} = catch Fun(id(bad)),
+    ok.
+
+expect_badarith(Fun) ->
+    {'EXIT',{badarith,_}} = catch Fun(id(bad)),
     ok.
 
 bitwise_gen_pairs() ->


### PR DESCRIPTION
With the AArch64 (AMD64) JIT, calling `bxor` with non-integer operands in a guard would crash the runtime system.