### PR TITLE
dialyzer: Fix crash when adding multiple PLTs

### DIFF
--- a/lib/dialyzer/test/dialyzer_cl_SUITE.erl
+++ b/lib/dialyzer/test/dialyzer_cl_SUITE.erl
@@ -9,14 +9,16 @@
 
 %% Test cases must be exported.
 -export([
+    can_add_multiple_plts_to_another_plt/1,
     unknown_function_warning_includes_callsite/1,
     call_to_missing_warning_includes_callsite/1
 ]).
 
-suite() -> [{timetrap, {minutes, 1}}].
+suite() -> [{timetrap, {minutes, 3}}].
 
 all() ->
     [
+        can_add_multiple_plts_to_another_plt,
         unknown_function_warning_includes_callsite,
         call_to_missing_warning_includes_callsite
     ].
@@ -116,6 +118,30 @@ unknown_function_warning_includes_callsite(Config) when is_list(Config) ->
             }
         ]},
         Res),
+
+    ok.
+
+% See GitHub issue erlang/OTP #6850
+can_add_multiple_plts_to_another_plt(Config) when is_list(Config) ->
+
+    PrivDir = proplists:get_value(priv_dir,Config),
+
+    StdlibPlt = filename:join(PrivDir, "stdlib.plt"),
+    ErtsPlt = filename:join(PrivDir, "erts.plt"),
+    OutputPlt = filename:join(PrivDir, "merged.plt"),
+
+    _ = dialyzer:run([{analysis_type, plt_build},
+                      {apps, [stdlib]},
+                      {output_plt, StdlibPlt}]),
+    _ = dialyzer:run([{analysis_type, plt_build},
+                      {apps, [erts]},
+                      {output_plt, ErtsPlt}]),
+    ?assertEqual(
+       [],
+       dialyzer:run([{analysis_type, plt_add},
+                     {apps, [erts, stdlib]},
+                     {plts, [ErtsPlt, StdlibPlt]},
+                     {output_plt, OutputPlt}])),
 
     ok.
 


### PR DESCRIPTION
The code previously assumed that multiple PLTs would only be used in combination with an analysis, but adding multiple PLTs to another without analysis was not considered.

The existing logic for merging PLTs was used in the context of an analysis, with different data to hand, so here we just validate the merge, then sequentially add each PLT.

Resolves #6850