### PR TITLE
dialyzer: fix singleton type var in union types

### DIFF
--- a/lib/common_test/src/ct_release_test.erl
+++ b/lib/common_test/src/ct_release_test.erl
@@ -142,7 +142,7 @@
 -spec init(Config) -> Result when
       Config :: config(),
       Result :: config() | SkipOrFail,
-      SkipOrFail :: {skip,Reason} | {fail,Reason}.
+      SkipOrFail :: {skip,Reason::term()} | {fail,Reason :: term()}.
 %% Initialize ct_release_test.
 %%
 %% This function can be called from any of the

--- a/lib/kernel/src/wrap_log_reader.erl
+++ b/lib/kernel/src/wrap_log_reader.erl
@@ -116,11 +116,11 @@ open(File, FileNo) when is_list(File), is_integer(FileNo) ->
 close(#wrap_reader{fd = FD}) ->
     file:close(FD).
 
--type chunk_ret() :: {Continuation2, Terms :: [term()]}
-                   | {Continuation2,
+-type chunk_ret() :: {Continuation2 :: term(), Terms :: [term()]}
+                   | {Continuation2 :: term(),
                       Terms :: [term()],
                       Badbytes :: non_neg_integer()}
-                   | {Continuation2, 'eof'}
+                   | {Continuation2 :: term(), 'eof'}
                    | {'error', Reason :: term()}.
 
 -spec chunk(Continuation) -> chunk_ret() when

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2683,9 +2683,10 @@ handle_supported_groups_option(Value, Version) when is_list(Value) ->
                      | InetError
                      | OtherReason) -> string()
               when
-      FileType   :: cacertfile | certfile | keyfile | dhfile,
-      OtherReason     :: term(),
-      InetError :: inet:posix() | system_limit.
+      FileType    :: cacertfile | certfile | keyfile | dhfile,
+      OtherReason :: term(),
+      Error       :: term(),
+      InetError   :: inet:posix() | system_limit.
 
 do_format_error(Reason) when is_list(Reason) ->
     Reason;

--- a/lib/tools/src/xref.erl
+++ b/lib/tools/src/xref.erl
@@ -83,11 +83,11 @@
                        | {'unused', [mfa()]},
       NoDebugInfoResult :: {'deprecated', [xmfa()]}
                          | {'undefined', [xmfa()]},
-      Reason :: {'cover_compiled', Module}
+      Reason :: {'cover_compiled', Module :: module()}
               | {'file_error', file(), file_error()}
-              | {'interpreted', Module}
+              | {'interpreted', Module :: module()}
               | {'invalid_filename', term()}
-              | {'no_such_module', Module}
+              | {'no_such_module', Module :: module()}
               | beam_lib:chnk_rsn().
 
 %% No user variables have been assigned digraphs, so there is no


### PR DESCRIPTION
Dialyzer (or `erl_lint.erl`) was accepting code of the following form:

```erlang
-spec run_test(Opts) -> term()
      when Opts :: {join_specs, Bool} | {test, Bool}.
run_test(Opts) ->    {error, fail}.
```

But this cannot be ever checked by Dialyzer as the type variable `Bool` is in an union, which means that `Bool` happened only once and thus, `Bool` is an unbound type variable. Essentially, the example above should be rejected by Dialyzer as is the one below:

```erlang
-spec run_test_error(Opts) -> term()
      when Opts :: {join_specs, Bool}.
run_test_error(Opts) ->
    {error, fail}.
```

This commit fixes GH-6508 and adds a bunch of tests to `erl_lint.erl` so that we can keep track of which singleton type variables should throw an error and which ones are ok.