### PR TITLE
binary: Polish the hex encoding and decoding functions

### DIFF
--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -77,8 +77,13 @@ format_binary_error(encode_hex, [Subject, Case], _) ->
     [must_be_binary(Subject), must_be_hex_case(Case)];
 format_binary_error(decode_hex, [Subject], _) ->
     if
-        is_binary(Subject), byte_size(Subject) rem 2 == 1 ->
-            ["must contain an even number of bytes"];
+        is_binary(Subject) ->
+            if
+                byte_size(Subject) rem 2 =:= 1 ->
+                    [<<"must contain an even number of bytes">>];
+                true ->
+                    [<<"must only contain hex digits 0-9, A-F, and a-f">>]
+            end;
         true ->
             [must_be_binary(Subject)]
     end;
@@ -1088,7 +1093,7 @@ expand_error(not_atom) ->
 expand_error(not_binary) ->
     <<"not a binary">>;
 expand_error(bad_hex_case) ->
-    <<"not uppercase or lowercase">>;
+    <<"not 'uppercase' or 'lowercase'">>;
 expand_error(not_compiled_regexp) ->
     <<"not a compiled regular expression">>;
 expand_error(not_iodata) ->


### PR DESCRIPTION
The code for the `binary:encode_hex/1` and `binary:encode_hex/2` functions has been simplified. The simplified implementation has a more consistent runtime compared to the old implementation. To test the performance, I made a new `hex_bench` benchmark based on the `base64` benchmark:

https://gist.github.com/bjorng/522470f313ac01d16156a597657f97bb

For the old implementation, on my M1 Mac the results for the best case and worst case are as follows:

    Size: 1024*1024 (divisible by 8)
    fun binary:encode_hex/1: 1000 iterations in 1899 ms: 526 it/sec

    Size: 1024*1024 + 1 (not divisible by 2 through 7)
    fun binary:encode_hex/1: 1000 iterations in 5984 ms: 167 it/sec

That is, the worst case is about three times slower than the best case.

The simplifed encode function shows much less variation:

    Size: 1024*1024 (divisible by 8)
    fun binary:encode_hex/1: 1000 iterations in 1899 ms: 526 it/sec

    Size: 1024*1024 + 1 (not divisible by 8)
    fun binary:encode_hex/1: 1000 iterations in 2100 ms: 476 it/sec

For the old implementation of `decode_hex/1`, the benchmark results are:

    fun binary:decode_hex/1: 1000 iterations in 28823 ms: 34 it/sec

The results for the simplified implementation are:

    Size: 1024*1024 (divisible by 8)
    fun binary:decode_hex/1: 1000 iterations in 3041 ms: 328 it/sec

    Size: 1024*1024+1 (not divisible by 8)
    fun binary:decode_hex/1: 1000 iterations in 3144 ms: 318 it/sec

That is, the simplified implementation is almost 10 times faster.

All hex functions now raise exceptions with correct stack traces (with the function being called at the top of the stack trace) and error information.