### PR TITLE
Fix map compare bug

### DIFF
--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -1643,10 +1643,8 @@ Sint erts_cmp_compound(Eterm a, Eterm b, int exact, int eq_only)
 #define FLATMAP_ATOM_KEYS_OP          8
 #define FLATMAP_ATOM_VALUES_OP        9
 
-#define OP_WORD(OP)  (((OP)  << _TAG_PRIMARY_SIZE) | TAG_PRIMARY_HEADER)
-#define TERM_ARRAY_OP_WORD(SZ)    OP_WORD(((SZ) << OP_BITS) | TERM_ARRAY_OP)
-#define FLATMAP_ATOM_KEYS_OP_WORD(SZ) OP_WORD(((SZ) << OP_BITS) | FLATMAP_ATOM_KEYS_OP)
-#define FLATMAP_ATOM_VALUES_OP_WORD(SZ) OP_WORD(((SZ) << OP_BITS) | FLATMAP_ATOM_VALUES_OP)
+#define OP_WORD(OP)         (((OP)  << _TAG_PRIMARY_SIZE) | TAG_PRIMARY_HEADER)
+#define OP_ARG_WORD(OP, SZ) OP_WORD(((SZ) << OP_BITS) | OP)
 
 #define GET_OP(WORD) (ASSERT(is_header(WORD)), ((WORD) >> _TAG_PRIMARY_SIZE) & OP_MASK)
 #define GET_OP_ARG(WORD) (ASSERT(is_header(WORD)), ((WORD) >> (OP_BITS + _TAG_PRIMARY_SIZE)))
@@ -1875,18 +1873,18 @@ tailrecur_ne:
                                 WSTACK_PUSH3(stack,
                                              (UWord)&b_vals[n_numbers+n_atoms],
                                              (UWord)&a_vals[n_numbers+n_atoms],
-                                             TERM_ARRAY_OP_WORD(n_rest));
+                                             OP_ARG_WORD(TERM_ARRAY_OP,n_rest));
                             }
                             if (n_atoms) {
                                 WSTACK_PUSH4(stack,
                                              (UWord)&b_vals[n_numbers],
                                              (UWord)&a_vals[n_numbers],
                                              (UWord)&a_keys[n_numbers],
-                                             FLATMAP_ATOM_VALUES_OP_WORD(n_atoms));
+                                             OP_ARG_WORD(FLATMAP_ATOM_VALUES_OP,n_atoms));
                             }
                             if (n_numbers) {
                                 WSTACK_PUSH3(stack, (UWord)b_vals, (UWord)a_vals,
-                                             TERM_ARRAY_OP_WORD(n_numbers));
+                                             OP_ARG_WORD(TERM_ARRAY_OP,n_numbers));
                             }
                             if (!exact) {
                                 WSTACK_PUSH(stack, OP_WORD(SWITCH_EXACT_OFF_OP));
@@ -1896,17 +1894,17 @@ tailrecur_ne:
                                 WSTACK_PUSH3(stack,
                                              (UWord)&b_keys[n_numbers+n_atoms],
                                              (UWord)&a_keys[n_numbers+n_atoms],
-                                             TERM_ARRAY_OP_WORD(n_rest));
+                                             OP_ARG_WORD(TERM_ARRAY_OP,n_rest));
                             }
                             if (n_atoms) {
                                 WSTACK_PUSH3(stack,
                                              (UWord)&b_keys[n_numbers],
                                              (UWord)&a_keys[n_numbers],
-                                             FLATMAP_ATOM_KEYS_OP_WORD(n_atoms));
+                                             OP_ARG_WORD(FLATMAP_ATOM_KEYS_OP,n_atoms));
                             }
                             if (n_numbers) {
                                 WSTACK_PUSH3(stack, (UWord)b_keys, (UWord)a_keys,
-                                             TERM_ARRAY_OP_WORD(n_numbers));
+                                             OP_ARG_WORD(TERM_ARRAY_OP,n_numbers));
                             }
                         }
                         goto pop_next;
@@ -2317,7 +2315,8 @@ term_array: /* arrays in 'aa' and 'bb', length in 'i' */
 		    goto not_equal;
 		}
 	    } else {
-		WSTACK_PUSH3(stack, (UWord)bb, (UWord)aa, TERM_ARRAY_OP_WORD(i));
+		WSTACK_PUSH3(stack, (UWord)bb, (UWord)aa,
+                             OP_ARG_WORD(TERM_ARRAY_OP,i));
 		goto tailrecur_ne;
 	    }
 	}

--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -1699,6 +1699,7 @@ t_map_compare(Config) when is_list(Config) ->
     repeat(100, fun(_) -> float_int_compare() end, []),
     repeat(100, fun(_) -> recursive_compare() end, []),
     repeat(10, fun(_) -> atoms_compare() end, []),
+    repeat(10, fun(_) -> atoms_plus_compare() end, []),
     ok.
 
 float_int_compare() ->
@@ -1721,6 +1722,31 @@ atoms_compare() ->
               M1 = map_gen(Pairs, Size),
               M2 = map_gen(Pairs, Size),
               %%io:format("Atom maps to compare: ~p AND ~p\n", [M1, M2]),
+              do_cmp(M1, M2)
+      end,
+      lists:seq(1,length(Atoms))),
+    ok.
+
+atoms_plus_compare() ->
+    Atoms = [true, false, ok, '', ?MODULE, list_to_atom(id("a new atom"))],
+    Pairs = lists:map(fun(K) -> list_to_tuple([{K,V} || V <- Atoms]) end,
+                      Atoms),
+    Small = 17,
+    Big1 = 1 bsl 64,
+    Big2 = erts_debug:copy_shared(Big1),
+    Float1 = float(Big1),
+    Float2 = float(Big2),
+    Others = {Small, -Small, Big1, -Big1, Big2, Float1, Float2,
+              [], {}, #{}, self(), make_ref(),
+              ok, yes, no, lists, maps, seq},
+    RandOther = fun() -> element(rand:uniform(size(Others)), Others) end,
+
+    lists:foreach(
+      fun(Size) ->
+              M = map_gen(Pairs, Size),
+              M1 = M#{RandOther() => RandOther()},
+              M2 = M#{RandOther() => RandOther()},
+              %%io:format("Maps to compare:\nM1 = ~p\nM2 = ~p\n", [M1, M2]),
               do_cmp(M1, M2)
       end,
       lists:seq(1,length(Atoms))),


### PR DESCRIPTION
This fix did not make it into 26.0-rc1, where the bug was introduced by #6151.

_Don't let this bug deter you from trying 26.0-rc1. Even though easy to reproduce with the right maps we judge it row risk to actually cause any problems._ 

```
1> #{aaa => v, true => v} < #{bbb => v, [] => v}.
false
```
should be `true` as `aaa` < `bbb`.
    
Necessary bug conditions:
* Small map (<= 32 keys)
* Identical number of keys
* Zero or identical numeric keys (integers and floats)
* Different number of atom keys

The bug compares consistent on a node, but can differ on different node instances if the atoms get different internal index (caused by module load order for example).