### PR TITLE
Fix erts/test/erlc_SUITE.erl testcase warnings

### DIFF
--- a/erts/test/erlc_SUITE.erl
+++ b/erts/test/erlc_SUITE.erl
@@ -508,9 +508,9 @@ unicode_paths(Config) ->
             run(Config, Cmd, FileName, "", DepRE),
             true = exists(BeamFileName),
             file:delete(BeamFileName),
-            file:delete(OutDir)
-    end,
-    ok.
+            file:delete(OutDir),
+            ok
+    end.
 
 %%% Tests related to the features mechanism
 %% Support macros and functions


### PR DESCRIPTION
erlc_SUITE.erl:494:27: Warning: a term is constructed, but never used
%  494|         {{win32,\_}, _} -> {skip, "Unicode paths not supported on windows"};
%     |                           ^
erlc_SUITE.erl:495:23: Warning: a term is constructed, but never used
%  495|         {\_,latin1} -> {skip, "Cannot interpret unicode filenames when native_name_encoding is latin1"};
%     |