### PR TITLE
Fix release_docs for GNU make 4.3

### DIFF
--- a/system/doc/top/Makefile
+++ b/system/doc/top/Makefile
@@ -102,9 +102,7 @@ PDFREFDIR= pdf
 TOP_PDF_FILE = $(PDFDIR)/$(APPLICATION)-$(VSN).pdf
 TOPDOC=true
 
-sp :=
-
-sp +=
+sp := $(subst ,, )
 
 ## qs translates ' ' to '\ ', sq translates '\ ' to ' '
 ## These function are used when the make target is a path that can


### PR DESCRIPTION
Currently release_man_spec for system/doc/top fails on GNU make 4.3

    make[3]: Entering directory '/home/dav/.kerl/builds/26.0-rc1-master/otp_src_git/system/doc/top'
    make[3]: *** No rule to make target '/home/dav/erlang/26.0-rc1-master/doc/docbuild\', needed by 'release_man_spec'.  Stop.

Due to breaking change done in GNU make sp variable is empty in qs and sq calls (note a `\` after `docbuild`).

Previously appending using `+=` to an empty variable would result in a value starting with a space.  Since 4.3 the initial space is only added if the variable already contains some value.

<https://lists.gnu.org/archive/html/info-gnu/2020-01/msg00004.html>