### PR TITLE
Fix a bug that `file:read(standard_io, ..)` unexpectedly returns `eof`

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -518,8 +518,10 @@ get_chars_apply(Pbs, M, F, Xa, Drv, Shell, Buf, State0, Line, Encoding) ->
 
 get_chars_n_loop(Pbs, M, F, Xa, Drv, Shell, Buf0, State, Encoding) ->
     try M:F(State, cast(Buf0, get(read_mode), Encoding), Encoding, Xa) of
+        {stop,Result,eof} ->
+            {ok,Result,eof};
         {stop,Result,Rest} ->
-            {ok, Result, Rest};
+            {ok,Result,append(Rest, [], Encoding)};
         State1 ->
             case get_chars_echo_off(Pbs, Drv, Shell) of
                 interrupted ->

--- a/lib/stdlib/src/io_lib.erl
+++ b/lib/stdlib/src/io_lib.erl
@@ -808,23 +808,19 @@ collect_chars(Tag, Data, N) ->
 %% Now we are aware of encoding...    
 collect_chars(start, Data, unicode, N) when is_binary(Data), is_integer(N) ->
     {Size,Npos} = count_and_find_utf8(Data,N),
-    if Size > N ->
+    if Size >= N ->
 	    {B1,B2} = split_binary(Data, Npos),
 	    {stop,B1,B2};
        Size < N ->
-	    {binary,[Data],N-Size};
-       true ->
-	    {stop,Data,eof}
+	    {binary,[Data],N-Size}
     end;
 collect_chars(start, Data, latin1, N) when is_binary(Data), is_integer(N) ->
     Size = byte_size(Data),
-    if Size > N ->
+    if Size >= N ->
 	    {B1,B2} = split_binary(Data, N),
 	    {stop,B1,B2};
        Size < N ->
-	    {binary,[Data],N-Size};
-       true ->
-	    {stop,Data,eof}
+	    {binary,[Data],N-Size}
     end;
 collect_chars(start,Data,_,N) when is_list(Data), is_integer(N) ->
     collect_chars_list([], N, Data);
@@ -834,23 +830,19 @@ collect_chars({binary,Stack,_N}, eof, _,_) ->
     {stop,binrev(Stack),eof};
 collect_chars({binary,Stack,N}, Data,unicode, _) when is_integer(N) ->
     {Size,Npos} = count_and_find_utf8(Data,N),
-    if Size > N ->
+    if Size >= N ->
 	    {B1,B2} = split_binary(Data, Npos),
 	    {stop,binrev(Stack, [B1]),B2};
        Size < N ->
-	    {binary,[Data|Stack],N-Size};
-       true ->
-	    {stop,binrev(Stack, [Data]),eof}
+	    {binary,[Data|Stack],N-Size}
     end;
 collect_chars({binary,Stack,N}, Data,latin1, _) when is_integer(N) ->
     Size = byte_size(Data),
-    if Size > N ->
+    if Size >= N ->
 	    {B1,B2} = split_binary(Data, N),
 	    {stop,binrev(Stack, [B1]),B2};
        Size < N ->
-	    {binary,[Data|Stack],N-Size};
-       true ->
-	    {stop,binrev(Stack, [Data]),eof}
+	    {binary,[Data|Stack],N-Size}
     end;
 collect_chars({list,Stack,N}, Data, _,_) when is_integer(N) ->
     collect_chars_list(Stack, N, Data);


### PR DESCRIPTION
This PR fixes a bug that `file:read(standard_io, ..)` call in escript could unexpectedly return `eof` if `io:setopts(standard_io, [binary])` is set.
This bug seems introduced by https://github.com/erlang/otp/commit/72a5fc13ffa3370d96844c3cef3268546e8fe7cb that replaced `user` module by `group` module.

## Bug reproduce code

Creates an escript file that calls `file:read/2` twice.
```erlang
#!/usr/bin/env escript
%% filename: foo.erl

main([]) ->
    ok = io:setopts(standard_io, [binary]),
    io:format("1st: ~p", [file:read(standard_io, 3)]),
    io:format("2nd: ~p", [file:read(standard_io, 3)]).
```

Starts Erlang shell and invokes the above escript via `open_port/2`.
After `erlang:port_command(P, ["foo"]).` is called, the second `file:read/2` call in the escript file will return falsey `eof`.
```erlang
$ chmod +x foo.erl
$ erl
Erlang/OTP 26 [RELEASE CANDIDATE 1] [erts-13.1.4] [source-ea903ec2bb] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [jit]

Eshell V13.1.4 (press Ctrl+G to abort, type help(). for help)
1> P = open_port({spawn, "./foo.erl"}, []).                                 
#Port<0.3>
2> erlang:port_command(P, ["foo"]).        
true
3> flush().
Shell got {#Port<0.3>,{data,"1st: {ok,<<\"foo\">>}"}}
Shell got {#Port<0.3>,{data,"2nd: eof"}}   % Unexpected falsey eof
ok
4> erlang:port_command(P, ["bar"]).
** exception error: bad argument
     in function  port_command/2
        called as port_command(#Port<0.3>,["bar"])
```

By applying the change in this PR, the escript behaves as follows:
```erlang
$ erl
Erlang/OTP 26 [RELEASE CANDIDATE 1] [erts-13.1.4] [source-ea903ec2bb] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [jit]

Eshell V13.1.4 (press Ctrl+G to abort, type help(). for help)
1> P = open_port({spawn, "./foo.erl"}, []).
#Port<0.3>
2> erlang:port_command(P, ["foo"]).        
true
3> flush().
Shell got {#Port<0.3>,{data,"1st: {ok,<<\"foo\">>}"}}
ok
4> erlang:port_command(P, ["bar"]).
true
5> flush().
Shell got {#Port<0.3>,{data,"2nd: {ok,<<\"bar\">>}"}}
ok
```