### PR TITLE
Removed unnecessary <em> tags

### DIFF
--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -1268,7 +1268,7 @@ analyze_form(Node) ->
 %% @doc Analyzes an attribute node. If `Node' represents a
 %% preprocessor directive, the atom `preprocessor' is
 %% returned. Otherwise, if `Node' represents a module
-%% attribute "`-<em>Name</em>...'", a tuple `{Name,
+%% attribute "`-Name...'", a tuple `{Name,
 %% Info}' is returned, where `Info' depends on
 %% `Name', as follows:
 %% <dl>
@@ -1647,8 +1647,8 @@ analyze_wild_attribute(Node) ->
 %% `Node' represents "`-record(Name, {...}).'",
 %% where `Fields' is a list of pairs `{Label,
 %% {Default, Type}}' for each field "`Label'", "`Label =
-%% <em>Default</em>'", "`Label :: <em>Type</em>'", or
-%% "`Label = <em>Default</em> :: <em>Type</em>'" in the declaration,
+%% Default'", "`Label :: Type'", or
+%% "`Label = Default :: Type'" in the declaration,
 %% listed in left-to-right
 %% order. If the field has no default-value declaration, the value for
 %% `Default' will be the atom `none'. If the field has no type declaration,
@@ -1723,7 +1723,7 @@ analyze_record_attribute_tuple(Node) ->
 %% For a `record_expr' node, `Info' represents
 %% the record name and the list of descriptors for the involved fields,
 %% listed in the order they appear. A field descriptor is a pair
-%% `{Label, Value}', if `Node' represents "`Label = <em>Value</em>'".
+%% `{Label, Value}', if `Node' represents "`Label = Value'".
 %% For a `record_access' node,
 %% `Info' represents the record name and the field name. For a
 %% `record_index_expr' node, `Info' represents the
@@ -1798,9 +1798,8 @@ analyze_record_expr(Node) ->
 %%
 %% @doc Returns the label, value-expression, and type of a record field
 %% specifier. The result is a pair `{Label, {Default, Type}}', if
-%% `Node' represents "`Label'", "`Label = <em>Default</em>'",
-%% "`Label :: <em>Type</em>'", or
-%%  "`Label = <em>Default</em> :: <em>Type</em>'".
+%% `Node' represents "`Label'", "`Label = Default'",
+%% "`Label :: Type'", or "`Label = Default :: Type'".
 %% If the field has no value-expression, the value for
 %% `Default' will be the atom `none'. If the field has no type,
 %% the value for `Type' will be the atom `none'. 
@@ -1877,7 +1876,7 @@ analyze_file_attribute(Node) ->
 %%
 %% @doc Returns the name and arity of a function definition. The result
 %% is a pair `{Name, A}' if `Node' represents a
-%% function definition "`Name(<em>P_1</em>, ..., <em>P_A</em>) ->
+%% function definition "`Name(P_1, ..., P_A) ->
 %% ...'".
 %%
 %% The evaluation throws `syntax_error' if
@@ -1910,7 +1909,7 @@ analyze_function(Node) ->
 %%          ModuleName = atom()
 %%      
 %% @doc Returns the name of an implicit fun expression "`fun
-%% <em>F</em>'". The result is a representation of the function
+%% F'". The result is a representation of the function
 %% name `F'. (Cf. `analyze_function_name/1'.)
 %%
 %% The evaluation throws `syntax_error' if
@@ -1940,7 +1939,7 @@ analyze_implicit_fun(Node) ->
 %% @doc Returns the name of a called function. The result is a
 %% representation of the name of the applied function `F/A',
 %% if `Node' represents a function application
-%% "`<em>F</em>(<em>X_1</em>, ..., <em>X_A</em>)'". If the
+%% "`F(X_1, ..., X_A)'". If the
 %% function is not explicitly named (i.e., `F' is given by
 %% some expression), only the arity `A' is returned.
 %%
@@ -1981,10 +1980,10 @@ analyze_application(Node) ->
 %% @doc Returns the name of a used type. The result is a
 %% representation of the name of the used pre-defined or local type `N/A',
 %% if `Node' represents a local (user) type application
-%% "`<em>N</em>(<em>T_1</em>, ..., <em>T_A</em>)'", or
+%% "`N(T_1, ..., T_A)'", or
 %% a representation of the name of the used remote type `M:N/A'
 %% if `Node' represents a remote user type application
-%% "`<em>M</em>:<em>N</em>(<em>T_1</em>, ..., <em>T_A</em>)'".
+%% "`M:N(T_1, ..., T_A)'".
 %%
 %% The evaluation throws `syntax_error' if `Node' does not represent a
 %% well-formed (user) type application expression.


### PR DESCRIPTION
The docs ([example](https://www.erlang.org/doc/man/erl_syntax_lib.html#analyze_function-1)) contain some emphasis tags (within code snippets) which end up visible in the documentation. I fixed these by removing the unwanted tags.
