### PR TITLE
fix 6074 (mod_alias failed to handle re_write config)

### DIFF
--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -1149,11 +1149,19 @@ alias() ->
     [{doc, "Test mod_alias"}].
 
 alias(Config) when is_list(Config) ->
+    Cgi = case os:type() of
+        {win32, _} ->
+            "printenv.bat";
+        _ ->
+            "printenv.sh"
+    end,
     TestURIs200 = [
                    {"GET /pics/icon.sheet.gif ", 200, "image/gif"},
                    {"GET /pictures/icon.sheet.gif ", 200, "image/gif"},
                    {"GET / ", 200, "text/html"},
-                   {"GET /misc/ ", 200, "text/html"}
+                   {"GET /misc/ ", 200, "text/html"},
+                   {"GET /cgi-bin/" ++ Cgi ++ " ", 200, "text/html"},
+                   {"GET /cgi-UNWANTED-bin/" ++ Cgi ++ " ", 200, "text/html"}
                   ],
     Test200 =
         fun({Request, ResultCode, ContentType}) ->
@@ -2162,8 +2170,9 @@ config_template(Config, ServerRoot, ScriptPath, Modules) ->
 		   {"gif", "image/gif"}]},
      {alias, {"/icons/", filename:join(ServerRoot,"icons") ++ "/"}},
      {re_write, {"/pic(ture)?s/",  filename:join(ServerRoot,"icons") ++ "/"}},
-     {script_alias, {"/cgi-bin/", ScriptPath}},
      {script_alias, {"/htbin/", ScriptPath}},
+     {script_alias, {"/cgi-bin/", ScriptPath}},
+     {script_re_write, {"/cgi-([a-zA-Z-]*)bin/", ScriptPath}},
      {erl_script_alias, {"/cgi-bin/erl", Modules}}
     ].
 

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -1151,6 +1151,7 @@ alias() ->
 alias(Config) when is_list(Config) ->
     TestURIs200 = [
                    {"GET /pics/icon.sheet.gif ", 200, "image/gif"},
+                   {"GET /pictures/icon.sheet.gif ", 200, "image/gif"},
                    {"GET / ", 200, "text/html"},
                    {"GET /misc/ ", 200, "text/html"}
                   ],
@@ -2160,7 +2161,7 @@ config_template(Config, ServerRoot, ScriptPath, Modules) ->
      {mime_types, [{"html","text/html"},{"htm","text/html"}, {"shtml","text/html"},
 		   {"gif", "image/gif"}]},
      {alias, {"/icons/", filename:join(ServerRoot,"icons") ++ "/"}},
-     {alias, {"/pics/",  filename:join(ServerRoot,"icons") ++ "/"}},
+     {re_write, {"/pic(ture)?s/",  filename:join(ServerRoot,"icons") ++ "/"}},
      {script_alias, {"/cgi-bin/", ScriptPath}},
      {script_alias, {"/htbin/", ScriptPath}},
      {erl_script_alias, {"/cgi-bin/erl", Modules}}


### PR DESCRIPTION
Fixed functionallity of re_write property (Issue #6074).
Previous code coudn't work because there was "^"++FakeName line,
   but FakeName could be MatchPattern so this would fail.
I changed the behaviour to append "^" while storeing the re_write, alias or script_alias proplist.

Also, I included one simple re_write property into test, to make sure everything works correcty.