### PR TITLE
supervisor: export sup_ref type

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -56,9 +56,10 @@
 
 %%--------------------------------------------------------------------------
 
--export_type([sup_flags/0, child_spec/0, strategy/0,
-              startchild_ret/0, startchild_err/0,
-              startlink_ret/0, startlink_err/0]).
+-export_type([sup_flags/0, sup_ref/0, child_spec/0,
+              strategy/0, startchild_ret/0,
+              startchild_err/0, startlink_ret/0,
+              startlink_err/0]).
 
 %%--------------------------------------------------------------------------
 


### PR DESCRIPTION
dialyzer in OTP-26 caught that I was using this unexported type `supervisor:sup_ref/0`, https://github.com/open-telemetry/opentelemetry-erlang/blob/6a29857f39ebf027bb77bc9a59d752d4a52eef11/apps/opentelemetry_experimental/src/otel_meter_server_sup.erl#L32

