### PR TITLE
stdlib: Hibernate static supervisors

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -349,7 +349,10 @@ init_children(State, StartSpec) ->
         {ok, Children} ->
             case start_children(Children, SupName) of
                 {ok, NChildren} ->
-                    {ok, State#state{children = NChildren}};
+                    %% Static supervisor are not expected to
+                    %% have much work to do so hibernate them
+                    %% to improve memory handling.
+                    {ok, State#state{children = NChildren}, hibernate};
                 {error, NChildren, Reason} ->
                     _ = terminate_children(NChildren, SupName),
                     {stop, {shutdown, Reason}}
@@ -361,6 +364,9 @@ init_children(State, StartSpec) ->
 init_dynamic(State, [StartSpec]) ->
     case check_startspec([StartSpec], State#state.auto_shutdown) of
         {ok, Children} ->
+            %% Simple one for one supervisors are expected to
+            %% have many children coming and going so do not
+            %% hibernate.
 	    {ok, dyn_init(State#state{children = Children})};
         Error ->
             {stop, {start_spec, Error}}


### PR DESCRIPTION
Static supervisors are very idle processes after they have started so they will now be hibernated after start to improve resource management.