### PR TITLE
Compiler: alias analysis speedup

### DIFF
--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -318,7 +318,7 @@ aa_fixpoint([], Order, _OldAliasMap,
     aa_fixpoint(NewOrder, Order, AliasMap,
                 AAS#aas{repeats=sets:new([{version,2}])}, Limit - 1).
 
-aa_fun(F, #opt_st{ssa=Linear0,anno=_Anno,args=Args}=St,
+aa_fun(F, #opt_st{ssa=Linear0,args=Args}=St,
        AAS0=#aas{alias_map=AliasMap0,func_db=FuncDb,repeats=Repeats0}) ->
     %% Initially assume all formal parameters are unique for a
     %% non-exported function, if we have call argument info in the
@@ -330,7 +330,7 @@ aa_fun(F, #opt_st{ssa=Linear0,anno=_Anno,args=Args}=St,
                 end, #{}, ArgsStatus),
     ?DP("@@ Args: ~p~n", [ArgsStatus]),
     {Linear1,SS,AAS1} = aa_blocks(Linear0, SS0, AAS0),
-    ?DP("SS:~n~s~n~n", [aa_format(SS)]),
+    ?DP("SS:~n~s~n~n", [SS]),
     AAS = aa_merge_call_args_status(SS, AAS1),
 
     AliasMap = AliasMap0#{ F => SS },
@@ -838,8 +838,7 @@ aa_tuple_extraction(Dst, Tuple, #b_literal{val=I}, SS1) ->
 
 aa_make_fun(Dst, Callee=#b_local{name=#b_literal{}},
             Env0, SS0,
-            AAS0=#aas{alias_map=_AliasMap,call_args=Info0,
-                      repeats=Repeats0,st_map=_StMap}) ->
+            AAS0=#aas{call_args=Info0,repeats=Repeats0}) ->
     %% When a value is copied into the environment of a fun we assume
     %% that it has been aliased as there is no obvious way to track
     %% and ensure that the value is only used once, even if the

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -52,7 +52,8 @@
               func_db :: func_info_db(),
               kills :: kills_map(),
               st_map :: st_map(),
-              orig_st_map :: st_map()
+              orig_st_map :: st_map(),
+              repeats = sets:new([{version,2}]) :: sets:set(func_id())
              }).
 
 %% A code location refering to either the #b_set{} defining a variable
@@ -309,13 +310,16 @@ aa_fixpoint([], _Order, OldAliasMap,
 aa_fixpoint([], _, _, #aas{func_db=FuncDb,orig_st_map=StMap}, 0) ->
     ?DP("**** End of iteration, too many iterations ****~n"),
     {StMap, FuncDb};
-aa_fixpoint([], Order, _OldAliasMap, AAS=#aas{alias_map=AliasMap}, Limit) ->
+aa_fixpoint([], Order, _OldAliasMap,
+            AAS=#aas{alias_map=AliasMap,repeats=Repeats}, Limit) ->
     ?DP("**** Things have changed, starting next iteration ****~n"),
     %% Following the depth first order, select those in Repeats.
-    aa_fixpoint(Order, Order, AliasMap, AAS, Limit - 1).
+    NewOrder = [Id || Id <- Order, sets:is_element(Id, Repeats)],
+    aa_fixpoint(NewOrder, Order, AliasMap,
+                AAS#aas{repeats=sets:new([{version,2}])}, Limit - 1).
 
 aa_fun(F, #opt_st{ssa=Linear0,anno=_Anno,args=Args}=St,
-       AAS0=#aas{alias_map=AliasMap0}) ->
+       AAS0=#aas{alias_map=AliasMap0,func_db=FuncDb,repeats=Repeats0}) ->
     %% Initially assume all formal parameters are unique for a
     %% non-exported function, if we have call argument info in the
     %% AAS, we use it. For an exported function, all arguments are
@@ -330,7 +334,18 @@ aa_fun(F, #opt_st{ssa=Linear0,anno=_Anno,args=Args}=St,
     AAS = aa_merge_call_args_status(SS, AAS1),
 
     AliasMap = AliasMap0#{ F => SS },
-    {St#opt_st{ssa=Linear1}, AAS#aas{alias_map=AliasMap}}.
+    PrevSS = maps:get(F, AliasMap0, #{}),
+    Repeats = case PrevSS =/= SS of
+                  true ->
+                      %% Alias status has changed, so schedule both
+                      %% our callers and callees for renewed analysis.
+                      #{ F := #func_info{in=In,out=Out} } = FuncDb,
+                      foldl(fun sets:add_element/2,
+                            foldl(fun sets:add_element/2, Repeats0, Out), In);
+                  false ->
+                      Repeats0
+              end,
+    {St#opt_st{ssa=Linear1}, AAS#aas{alias_map=AliasMap,repeats=Repeats}}.
 
 %% Main entry point for the alias analysis
 aa_blocks([{L,#b_blk{is=Is0,last=T0}=Blk}|Bs0], SS0, AAS0) ->
@@ -821,9 +836,10 @@ aa_tuple_extraction(Dst, Tuple, #b_literal{val=I}, SS1) ->
             aa_join(Dst, Tuple, SS1#{{tuple_element,Tuple}=>[I]})
     end.
 
-aa_make_fun(Dst, #b_local{name=#b_literal{}} = Callee,
+aa_make_fun(Dst, Callee=#b_local{name=#b_literal{}},
             Env0, SS0,
-            AAS0=#aas{alias_map=_AliasMap,call_args=Info0,st_map=_StMap}) ->
+            AAS0=#aas{alias_map=_AliasMap,call_args=Info0,
+                      repeats=Repeats0,st_map=_StMap}) ->
     %% When a value is copied into the environment of a fun we assume
     %% that it has been aliased as there is no obvious way to track
     %% and ensure that the value is only used once, even if the
@@ -835,8 +851,17 @@ aa_make_fun(Dst, #b_local{name=#b_literal{}} = Callee,
     SS = aa_set_aliased([Dst|Env0], SS0),
     #{ Callee := Status0 } = Info0,
     Status = aa_merge_env(reverse(Status0), [aliased || _ <- Env0], []),
+    #{ Callee := PrevStatus } = Info0,
     Info = Info0#{ Callee := Status },
-    AAS = AAS0#aas{call_args=Info},
+    Repeats = case PrevStatus =/= Status of
+                  true ->
+                      %% We have new information for the callee, we
+                      %% have to revisit it.
+                      sets:add_element(Callee, Repeats0);
+                  false ->
+                      Repeats0
+              end,
+    AAS = AAS0#aas{call_args=Info,repeats=Repeats},
     {SS, AAS}.
 
 aa_merge_env([_|Args], [E|Env], Acc) ->

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -84,7 +84,8 @@ end_per_group(_GroupName, Config) ->
 
 alias_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(alias, Config),
-    run_post_ssa_opt(alias_non_convergence, Config).
+    run_post_ssa_opt(alias_non_convergence, Config),
+    run_post_ssa_opt(alias_chain, Config).
 
 annotation_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(annotations, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias_chain.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias_chain.erl
@@ -1,0 +1,117 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% This module tests that beam_ssa_alias_opt:opt/2 does not annotate
+%% instructions with information about aliased operands when more than
+%% MAX_REPETITIONS are required for the analysis to converge.
+%%
+%% A specially crafted module which is designed to hit the alias
+%% analysis iteration limit if functions are visited naïvely in the
+%% order they occur in the module.
+%%
+-compile(no_ssa_opt_private_append).
+
+-module(alias_chain).
+
+-export([top/1]).
+
+top(L) ->
+%ssa% (A) when post_ssa_opt ->
+%ssa% _ = call(...) { aliased => [A] }.
+    fF(L, <<>>).
+
+fF([H|T], AccA) ->
+    fE(T, <<AccA/binary, H:8>>);
+fF([], Acc) ->
+    Acc.
+
+fE([H|T], AccA) ->
+    fD(T, <<AccA/binary, H:8>>);
+fE([], Acc) ->
+    Acc.
+
+fD([H|T], AccA) ->
+    fC(T, <<AccA/binary, H:8>>);
+fD([], Acc) ->
+    Acc.
+
+fC([H|T], AccA) ->
+    fB(T, <<AccA/binary, H:8>>);
+fC([], Acc) ->
+    Acc.
+
+fB([H|T], AccA) ->
+    fA(T, <<AccA/binary, H:8>>);
+fB([], Acc) ->
+    Acc.
+
+fA([H|T], AccA) ->
+    f9(T, <<AccA/binary, H:8>>);
+fA([], Acc) ->
+    Acc.
+
+f9([H|T], AccA) ->
+    f8(T, <<AccA/binary, H:8>>);
+f9([], Acc) ->
+    Acc.
+
+f8([H|T], AccA) ->
+    f7(T, <<AccA/binary, H:8>>);
+f8([], Acc) ->
+    Acc.
+
+f7([H|T], AccA) ->
+    f6(T, <<AccA/binary, H:8>>);
+f7([], Acc) ->
+    Acc.
+
+f6([H|T], AccA) ->
+    f5(T, <<AccA/binary, H:8>>);
+f6([], Acc) ->
+    Acc.
+
+f5([H|T], AccA) ->
+    f4(T, <<AccA/binary, H:8>>);
+f5([], Acc) ->
+    Acc.
+
+f4([H|T], AccA) ->
+    f3(T, <<AccA/binary, H:8>>);
+f4([], Acc) ->
+    Acc.
+
+f3([H|T], AccA) ->
+    f2(T, <<AccA/binary, H:8>>);
+f3([], Acc) ->
+    Acc.
+
+f2([H|T], AccA) ->
+    f1(T, <<AccA/binary, H:8>>);
+f2([], Acc) ->
+    Acc.
+
+f1([H|T], AccA) ->
+    f0(T, <<AccA/binary, H:8>>);
+f1([], Acc) ->
+    Acc.
+
+f0([H|T], AccA) ->
+    f3(T, <<AccA/binary, H:8>>);
+f0([], Acc) ->
+    Acc.
+


### PR DESCRIPTION
This is a set of patches which speeds up the alias analysis pass by reducing the number of iterations required to find a fix point and reduces the amount of work in each iteration.