### PR TITLE
Eliminate a valgrind warning

### DIFF
--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -1137,8 +1137,10 @@ void BeamGlobalAssembler::emit_bs_get_utf8_short_shared() {
         a.pop(x86::rcx);
     }
 
-    a.test(RET, RET);
-    a.short_().jns(ascii);
+    /* `test rax, rax` is a shorter instruction but can cause a warning
+     * in valgrind if there are any uninitialized bits in rax. */
+    a.bt(RET, imm(63));
+    a.short_().jnc(ascii);
 
     /* The bs_get_utf8_shared fragment expects the contents in RETd. */
     a.shr(RET, imm(32));


### PR DESCRIPTION
When matching an `utf8` segment, valgrind could generate a warning stating that a jump or conditional move was based on an uninitialized value. The following instructions were the culprit:

    test rax, rax
    short jns L107

Those instructions test the most significant bit of the `rax` register and jumps if it is zero. The most significant bit is always initialized when the `test` instruction is executed, but it is possible that some of the lower bits in the register are uninitialized. It seems that valgrind will emit the warning if any part of the register is uninitialized when executing the `test` instruction (presumably because the values of the flags `ZF` and `PF` depend on all bits in the register including the uninitialized bits).

~~We can avoid this warning by making sure that there are no uninitialized bits in `rax` when executing the `test` instruction.~~

We can avoid this warning by using the `bt` instruction:

        bt rax, 63
        short jnc L107
