### PR TITLE
gh: Update GitHub actions setup

### DIFF
--- a/.github/dockerfiles/Dockerfile.32-bit
+++ b/.github/dockerfiles/Dockerfile.32-bit
@@ -1,4 +1,4 @@
-ARG BASE=docker.pkg.github.com/erlang/otp/i386-debian-base
+ARG BASE=ghcr.io/erlang/otp/i386-debian-base
 FROM $BASE
 
 ARG MAKEFLAGS=-j4

--- a/.github/dockerfiles/Dockerfile.64-bit
+++ b/.github/dockerfiles/Dockerfile.64-bit
@@ -1,4 +1,4 @@
-ARG BASE=docker.pkg.github.com/erlang/otp/ubuntu-base
+ARG BASE=ghcr.io/erlang/otp/ubuntu-base
 FROM $BASE
 
 ARG MAKEFLAGS=$MAKEFLAGS

--- a/.github/dockerfiles/Dockerfile.clang
+++ b/.github/dockerfiles/Dockerfile.clang
@@ -1,4 +1,4 @@
-ARG BASE=docker.pkg.github.com/erlang/otp/ubuntu-base
+ARG BASE=ghcr.io/erlang/otp/ubuntu-base
 FROM $BASE
 ## We do a SSA lint check here
 ENV ERL_COMPILER_OPTIONS=ssalint

--- a/.github/dockerfiles/Dockerfile.cross-compile
+++ b/.github/dockerfiles/Dockerfile.cross-compile
@@ -1,7 +1,7 @@
 ##
 ## This docker file will build Erlang on 32-bit to 64-bit x86
 ##
-ARG BASE=docker.pkg.github.com/erlang/otp/i386-debian-base
+ARG BASE=ghcr.io/erlang/otp/i386-debian-base
 FROM $BASE as build
 
 ARG MAKEFLAGS=-j4

--- a/.github/workflows/actions-updater.yaml
+++ b/.github/workflows/actions-updater.yaml
@@ -1,0 +1,22 @@
+name: GitHub Actions Updater
+
+on:
+  schedule:
+    # Automatically run on the 1st of every month
+    - cron:  '0 0 1 * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.7.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit_message: "Updating GitHub actions to their latest versions"
+          pull_request_labels: "team:IS"

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1.5.2
+        uses: tibdex/github-app-token@v1.8.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PEM }}
-      - uses: actions/add-to-project@v0.0.3
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/erlang/projects/13
           github-token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache BASE image
@@ -328,7 +328,7 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build BASE image
@@ -381,7 +381,7 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache BASE image
@@ -408,7 +408,7 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache BASE image
@@ -478,7 +478,7 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache BASE image
@@ -540,7 +540,7 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build BASE image
@@ -615,7 +615,7 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build BASE image

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,11 +7,10 @@
 ## not possible so we need to rebuild all of Erlang/OTP multiple
 ## times.
 ##
-## When ghcr.io support using the GITHUB_TOKEN we should migrate
-## over to use it instead as that should allow us to use the
+## Now that we have migrated to ghcr.io we use the
 ## built-in caching mechanisms of docker/build-push-action@v2.
 ## However as things are now we use docker directly to make things
-## work.
+## work due to historical reasons.
 ##
 
 name: Build and check Erlang/OTP

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       ## We create an initial comment with some useful help to the user
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v5.1.1
         with:
           script: |
             const script = require('./.github/scripts/pr-comment.js');
@@ -107,7 +107,7 @@ jobs:
              "${{ needs.pr-number.outputs.result }}"
 
       - name: Deploy to github pages 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           token: ${{ secrets.ERLANG_TOKEN }}
           branch: master # The branch the action should deploy to.
@@ -117,7 +117,7 @@ jobs:
 
         ## Append some usefull links and tips to the test results posted by
         ## Publish CT Test Results
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v5.1.1
         if: always()
         with:
           script: |

--- a/.github/workflows/sync-github-releases.yaml
+++ b/.github/workflows/sync-github-releases.yaml
@@ -15,11 +15,11 @@ jobs:
     concurrency: sync-github-releases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       ## We need to login to the package registry in order to pull
       ## the base debian image.
       - name: Docker login
-        run: docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+        run: docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
       - name: Sync releases
         env:
           ERLANG_ORG_TOKEN: ${{ secrets.TRIGGER_ERLANG_ORG_BUILD }}
@@ -32,12 +32,12 @@ jobs:
     concurrency: erlang.github.io-deploy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.ERLANG_TOKEN }}
           repository: 'erlang/erlang.github.io'
           path: erlang.github.io
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update PRs
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -50,7 +50,7 @@ jobs:
             .github/scripts/sync-github-prs.es erlang/otp "${GITHUB_WORKSPACE}/erlang.github.io/prs/"
 
       - name: Deploy to github pages 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           token: ${{ secrets.ERLANG_TOKEN }}
           branch: master # The branch the action should deploy to.

--- a/.github/workflows/update-base.yaml
+++ b/.github/workflows/update-base.yaml
@@ -27,13 +27,13 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build base image
         id: base
         run: >-
-            BASE_TAG=docker.pkg.github.com/${{ github.repository_owner }}/otp/${{ matrix.type }}
+            BASE_TAG=ghcr.io/${{ github.repository_owner }}/otp/${{ matrix.type }}
             BASE_USE_CACHE=false
             .github/scripts/build-base-image.sh "${{ matrix.branch }}"
       - name: Push master image

--- a/HOWTO/DEVELOPMENT.md
+++ b/HOWTO/DEVELOPMENT.md
@@ -539,7 +539,7 @@ build it locally if you want to.
 Using the pre-built base you build an image like this:
 
 ```bash
-docker login docker.pkg.github.com
+docker login ghcr.io
 git archive --prefix otp/ -o .github/otp.tar.gz HEAD
 docker build -t my_otp_image -f .github/dockerfiles/Dockerfile.64-bit .github/
 ```
@@ -550,7 +550,7 @@ in order to fetch the base image. If you want to build the base image locally
 you can do that like this:
 
 ```bash
-docker build -t docker.pkg.github.com/erlang/otp/ubuntu-base \
+docker build -t ghcr.io/erlang/otp/ubuntu-base \
   --build-arg BASE=ubuntu:20.04 --build-arg USER=otptest --build-arg uid=$(id -u) \
   --build-arg GROUP=uucp --build-arg gid=$(id -g) \
   -f .github/dockerfiles/Dockerfile.ubuntu-base .github/


### PR DESCRIPTION
- Switch to new Docker container namespace
- Update actions dependencies, and keep them updated with a new action updater action

The new container namespace (`ghcr.io`) now supports `GITHUB_TOKEN` (see https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry), allowing us to migrate. When debugging locally, I found the new namespace was more reliable.

To see more about the migration process in general, visit: https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry