### PR TITLE
Improvements to get_until in I/O protocol

### DIFF
--- a/lib/stdlib/doc/src/io_protocol.xml
+++ b/lib/stdlib/doc/src/io_protocol.xml
@@ -210,10 +210,10 @@ ok
         <pre>
 {done, Result, RestChars}
 {more, Continuation}</pre>
-        <p><c>Result</c> can be any Erlang term, but if it is a <c>list()</c>,
-          the I/O server can convert it to a <c>binary()</c> of appropriate
-          format before returning it to the client, if the I/O server is set in
-          binary mode (see below).</p>
+        <p><c>Result</c> can be any Erlang term. In Erlang/OTP 26 and earlier,
+          the I/O server might convert a <c>list()</c> <c>Result</c> to a
+          <c>binary()</c> if the I/O server is set in binary mode (see below),
+          but this behaviour is no longer encouraged.</p>
         <p>The function is called with the data the I/O server finds on its I/O
           device, returning one of:</p>
         <list type="bulleted">
@@ -225,6 +225,12 @@ ok
           <item>
             <p><c>{more, Continuation}</c>, which indicates that more
               characters are needed to complete the request.</p>
+          </item>
+          <item>
+            <p><c>{more, Continuation, Prompt}</c>, which indicates that more
+              characters are needed to complete the request and the <c>Prompt</c>,
+              if any is shown, must be modified. This entry is new from
+              Erlang/OTP 27.</p>
           </item>
         </list>
         <p><c>Continuation</c> is sent as the state in later calls to the


### PR DESCRIPTION
This pull request adds support for returning `{more,Cont,Prompt}` from `get_until`, allowing the prompt to be changed while incomplete.

This change requires new functions in the io_lib backend. We use this opportunity to fix the following bugs:

1. The previous io_lib functions had ambiguous return types. If a get_until function returned `{stop,_,_}` as its continuation, it would be misinterpreted by I/O servers. The same for `{'EXIT', _}`.

2. The previous io_lib:get_until/4 would convert list results into binaries, but it would not do so consistently (see #4992). We now discourage converting lists to binaries in the protocol.

---

Additional notes:

1. `collect_line`, `collect_chars`, and `get_until` from `io_lib` are not documented and therefore we could remove them. Let me know if you prefer them to be first deprecated or just plain removed.

2. I am considering this feature is scheduled for Erlang/OTP 27. We will effectively need it only when multi-line editing lands in the shell, so there is no rush.

3. Tests to be coming soon if the features are agreed.