### PR TITLE
ms_transform: allow caller_line and current_stacktrace action functions

### DIFF
--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -1017,6 +1017,9 @@ action_function(set_tcw,1) -> true;
 action_function(silent,1) -> true;
 action_function(trace,2) -> true;
 action_function(trace,3) -> true;
+action_function(caller_line,0) -> true;
+action_function(current_stacktrace,0) -> true;
+action_function(current_stacktrace,1) -> true;
 action_function(_,_) -> false.
 
 bool_operator('and',2) ->

--- a/lib/stdlib/test/ms_transform_SUITE.erl
+++ b/lib/stdlib/test/ms_transform_SUITE.erl
@@ -859,6 +859,16 @@ action_function(Config) when is_list(Config) ->
 	    "silent(true), "
 	    "trace([send], [procs]), "
 	    "trace(Y, [procs], [send])  end)">>),
+    [{['$1','$2'],
+             [],
+             [{caller_line},
+              {current_stacktrace},
+              {current_stacktrace,3}]}] =
+        compile_and_run
+          (<<"dbg:fun2ms(fun([X,Y]) -> "
+             "caller_line(),"
+             "current_stacktrace(),"
+             "current_stacktrace(3) end)">>),
     ok.
 
 


### PR DESCRIPTION
caller_line/0 was added in https://github.com/erlang/otp/pull/5305, while current_stacktrace/0,/1 were added in
https://github.com/erlang/otp/pull/6628