### PR TITLE
compiler: Avoid unsafe rewrite to bs_create_bin private_append

### DIFF
--- a/lib/compiler/src/beam_ssa_private_append.erl
+++ b/lib/compiler/src/beam_ssa_private_append.erl
@@ -87,8 +87,10 @@ find_appends_blk([], _, Found) ->
 
 find_appends_is([#b_set{dst=Dst, op=bs_create_bin,
                         args=[#b_literal{val=append},SegmentInfo,Var|_],
-                        anno=Anno}|Is], Fun, Found0) ->
-    case is_unique(Var, Anno) andalso is_appendable(Anno, SegmentInfo) of
+                        anno=#{first_fragment_dies:=Dies}=Anno}|Is],
+                Fun, Found0) ->
+    case Dies andalso is_unique(Var, Anno)
+        andalso is_appendable(Anno, SegmentInfo) of
         true ->
             AlreadyFound = maps:get(Fun, Found0, []),
             Found = Found0#{Fun => [{append,Dst,Var}|AlreadyFound]},

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
@@ -71,7 +71,8 @@
 	 not_transformable10/1,
          not_transformable11/0,
          not_transformable12/1,
-         not_transformable13/1]).
+         not_transformable13/1,
+         not_transformable14/0]).
 
 %% Trivial smoke test
 transformable0(L) ->
@@ -934,3 +935,14 @@ not_transformable13([H|T], [N|Acc]) ->
     not_transformable13(T, [N+1|<<Acc/binary, H:8>>]);
 not_transformable13([], Acc) ->
     Acc.
+
+%% Check that we don't try to transform appends into private_appends
+%% when the first fragment doesn't die with the
+%% bs_create_bin. GH-6925.
+not_transformable14() ->
+%ssa% () when post_ssa_opt ->
+%ssa% A = bs_create_bin(private_append, ...),
+%ssa% B = bs_create_bin(append, ...).
+    A = << <<"x">> || true >>,
+    B = <<A/binary, "z">>,
+    {A, B}.


### PR DESCRIPTION
Nick Vatamaniuc reported that the following Erlang snippet:

```
B1 = << <<"x">> || true >>,
B2 = <<B1/binary, "z">>,
```

created identical `B1` and `B2` binaries. The error occurs because the private-append pass was missing the condition that for a transform from `bs_create_bin append, ...` to `bs_create_bin private_append, ...` to be safe, the first fragment must die with the `bs_create_bin` instruction, it is not enough that the fragment is unique and appendable.

The error is avoided by having the alias analysis, which has access to liveness information, annotate `bs_create_bin` instructions with a boolean annotation indicating whether the first fragment dies with the instruction. The later private-append pass can then consult the annotation to determine if the transform is safe. The use of an annotation is more efficient than trying to reconstruct the information in the alias analysis kill map during the private-append pass.

Fixes #6925